### PR TITLE
Add C-API helper functions to convert missing types

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -101,10 +101,20 @@ void duckdb_destroy_result(duckdb_result *result);
 // These functions will perform conversions if necessary. On failure (e.g. if conversion cannot be performed) a special
 // value is returned.
 
+//! Converts the specified value to a bool. Returns false on failure or NULL.
+bool duckdb_value_boolean(duckdb_result *result, index_t col, index_t row);
+//! Converts the specified value to an int8_t. Returns 0 on failure or NULL.
+int8_t duckdb_value_int8(duckdb_result *result, index_t col, index_t row);
+//! Converts the specified value to an int16_t. Returns 0 on failure or NULL.
+int16_t duckdb_value_int16(duckdb_result *result, index_t col, index_t row);
 //! Converts the specified value to an int64_t. Returns 0 on failure or NULL.
 int32_t duckdb_value_int32(duckdb_result *result, index_t col, index_t row);
 //! Converts the specified value to an int64_t. Returns 0 on failure or NULL.
 int64_t duckdb_value_int64(duckdb_result *result, index_t col, index_t row);
+//! Converts the specified value to a float. Returns 0.0 on failure or NULL.
+float duckdb_value_float(duckdb_result *result, index_t col, index_t row);
+//! Converts the specified value to a double. Returns 0.0 on failure or NULL.
+double duckdb_value_double(duckdb_result *result, index_t col, index_t row);
 //! Converts the specified value to a string. Returns nullptr on failure or NULL. The result must be freed with free.
 char *duckdb_value_varchar(duckdb_result *result, index_t col, index_t row);
 

--- a/src/main/duckdb-c.cpp
+++ b/src/main/duckdb-c.cpp
@@ -346,6 +346,33 @@ static Value GetCValue(duckdb_result *result, index_t col, index_t row) {
 	}
 }
 
+bool duckdb_value_boolean(duckdb_result *result, index_t col, index_t row) {
+	Value val = GetCValue(result, col, row);
+	if (val.is_null) {
+		return false;
+	} else {
+		return val.CastAs(TypeId::BOOLEAN).value_.boolean;
+	}
+}
+
+int8_t duckdb_value_int8(duckdb_result *result, index_t col, index_t row) {
+	Value val = GetCValue(result, col, row);
+	if (val.is_null) {
+		return 0;
+	} else {
+		return val.CastAs(TypeId::TINYINT).value_.tinyint;
+	}
+}
+
+int16_t duckdb_value_int16(duckdb_result *result, index_t col, index_t row) {
+	Value val = GetCValue(result, col, row);
+	if (val.is_null) {
+		return 0;
+	} else {
+		return val.CastAs(TypeId::SMALLINT).value_.smallint;
+	}
+}
+
 int32_t duckdb_value_int32(duckdb_result *result, index_t col, index_t row) {
 	Value val = GetCValue(result, col, row);
 	if (val.is_null) {
@@ -361,6 +388,24 @@ int64_t duckdb_value_int64(duckdb_result *result, index_t col, index_t row) {
 		return 0;
 	} else {
 		return val.CastAs(TypeId::BIGINT).value_.bigint;
+	}
+}
+
+float duckdb_value_float(duckdb_result *result, index_t col, index_t row) {
+	Value val = GetCValue(result, col, row);
+	if (val.is_null) {
+		return 0.0;
+	} else {
+		return val.CastAs(TypeId::FLOAT).value_.float_;
+	}
+}
+
+double duckdb_value_double(duckdb_result *result, index_t col, index_t row) {
+	Value val = GetCValue(result, col, row);
+	if (val.is_null) {
+		return 0.0;
+	} else {
+		return val.CastAs(TypeId::DOUBLE).value_.double_;
 	}
 }
 


### PR DESCRIPTION
The [DuckDB Go driver](https://github.com/marcboeker/go-duckdb) is based on the DuckDB C-API, that is currently lacking the convert functions for some integer and float types.

I've [added](https://github.com/marcboeker/go-duckdb/pull/1) them to complete the Go driver.