### PR TITLE
Support building with -std=c++14

### DIFF
--- a/src/include/common/helper.hpp
+++ b/src/include/common/helper.hpp
@@ -19,7 +19,7 @@
 #endif
 
 namespace duckdb {
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) && (__cplusplus < 201402L)
 template <typename T, typename... Args> unique_ptr<T> make_unique(Args &&... args) {
 	return unique_ptr<T>(new T(std::forward<Args>(args)...));
 }


### PR DESCRIPTION
Fixes #224 

This enables us to build in environments where the C++ Standard is fixed from the outside via the `CXXFLAGS`.