### PR TITLE
Implement random() function

### DIFF
--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -92,6 +92,7 @@ void BuiltinFunctions::Initialize(Transaction &transaction, Catalog &catalog) {
 	AddScalarFunction<CeilingFunction>(transaction, catalog);
 	AddScalarFunction<FloorFunction>(transaction, catalog);
 	AddScalarFunction<PiFunction>(transaction, catalog);
+	AddScalarFunction<RandomFunction>(transaction, catalog);
 	AddScalarFunction<SqrtFunction>(transaction, catalog);
 	AddScalarFunction<LnFunction>(transaction, catalog);
 	AddScalarFunction<LogFunction>(transaction, catalog);

--- a/src/include/function/scalar_function/math.hpp
+++ b/src/include/function/scalar_function/math.hpp
@@ -286,8 +286,9 @@ public:
 
 void random_function(ExpressionExecutor &exec, Vector inputs[], index_t input_count, BoundFunctionExpression &expr,
                      Vector &result);
+unique_ptr<FunctionData> random_bind(BoundFunctionExpression &expr, ClientContext &context);
 
-class RandomFunction : public ScalarFunction {
+class RandomFunction {
 public:
 	static const char *GetName() {
 		return "random";
@@ -303,6 +304,18 @@ public:
 
 	static get_return_type_function_t GetReturnTypeFunction() {
 		return double_return_type;
+	}
+
+	static bind_scalar_function_t GetBindFunction() {
+		return random_bind;
+	}
+
+	static dependency_function_t GetDependencyFunction() {
+		return nullptr;
+	}
+
+	static bool HasSideEffects() {
+		return true;
 	}
 };
 

--- a/test/sql/function/test_math.cpp
+++ b/test/sql/function/test_math.cpp
@@ -70,6 +70,48 @@ TEST_CASE("Rounding test", "[function]") {
 	REQUIRE(CHECK_COLUMN(result, 0, {42.123}));
 }
 
+TEST_CASE("Test random() function", "[function]") {
+	unique_ptr<QueryResult> result, result1, result2;
+	DuckDB db(nullptr);
+	Connection con(db), con1(db), con2(db);
+	con.EnableQueryVerification();
+	vector<string> splits1, splits2;
+
+	// random() is evaluated twice here
+	result = con.Query("select case when random() between 0 and 0.99999 then 1 else 0 end");
+	REQUIRE(CHECK_COLUMN(result, 0, {1}));
+
+	result1 = con1.Query("select random()");
+	result2 = con2.Query("select random()");
+	REQUIRE(!result1->Equals(*result2));
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE numbers(a INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO numbers VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10)"));
+
+	result = con.Query("select case when min(random()) >= 0  then 1 else 0 end from numbers;");
+	REQUIRE(CHECK_COLUMN(result, 0, {1}));
+	result = con.Query("select case when max(random()) < 1  then 1 else 0 end from numbers;");
+	REQUIRE(CHECK_COLUMN(result, 0, {1}));
+
+	result1 = con1.Query("select * from numbers order by random()");
+	result2 = con2.Query("select * from numbers order by random()");
+	splits1 = StringUtil::Split(result1->ToString(), '\n');
+	splits2 = StringUtil::Split(result2->ToString(), '\n');
+	REQUIRE(splits1 != splits2);
+	sort(begin(splits1), end(splits1));
+	sort(begin(splits2), end(splits2));
+	REQUIRE(splits1 == splits2);
+
+	result1 = con1.Query("select random() from numbers");
+	result2 = con2.Query("select random() from numbers");
+	splits1 = StringUtil::Split(result1->ToString(), '\n');
+	splits2 = StringUtil::Split(result2->ToString(), '\n');
+	REQUIRE(splits1 != splits2);
+	sort(begin(splits1), end(splits1));
+	sort(begin(splits2), end(splits2));
+	REQUIRE(splits1 != splits2);
+}
+
 // see https://www.postgresql.org/docs/10/functions-math.html
 
 TEST_CASE("Function test cases from PG docs", "[function]") {

--- a/test/sql/simple/test_default.cpp
+++ b/test/sql/simple/test_default.cpp
@@ -80,4 +80,15 @@ TEST_CASE("Test DEFAULT in tables", "[default]") {
 	REQUIRE_FAIL(con.Query("CREATE TABLE test (a INTEGER DEFAULT row_number() OVER (), b INTEGER);"));
 	// default value must be scalar expression
 	REQUIRE_FAIL(con.Query("CREATE TABLE test (a INTEGER DEFAULT b+1, b INTEGER);"));
+
+	// test default with random
+	unique_ptr<MaterializedQueryResult> result_tmp;
+	REQUIRE_NO_FAIL(con.Query("DROP TABLE test"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE test (a DOUBLE DEFAULT random(), b INTEGER);"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO test (b) VALUES (1);"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO test (b) VALUES (2);"));
+	result = con.Query("SELECT a FROM test WHERE b = 1;");
+	result_tmp = move(result);
+	result = con.Query("SELECT a FROM test WHERE b = 2;");
+	REQUIRE(!result->Equals(*result_tmp));
 }


### PR DESCRIPTION
- Textual comparison in `test_math.cpp` is ugly but I found it quite handy. Please
let me know if there is a better way to accomplish the same kind of comparisons.
- Some earlier `random()` tests in `test_math.cpp` were failing with
`TransactionContext: Transaction is already running!`. Not sure about the root
cause but I can reproduce it with just two
`result = con.Query("select random()");` in a row. Please let me know if something is
wrong with my implementation.
- As a next step, we should add the ability to set a seed (e.g. similar to
postgres' `setseed` function)
