### PR TITLE
Implement unsorted STRING_AGG

### DIFF
--- a/src/function/aggregate_function/CMakeLists.txt
+++ b/src/function/aggregate_function/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library_unity(duckdb_aggregate_function
                   sum.cpp
                   covar.cpp
                   stddev_samp.cpp
+                  string_agg.cpp
                   distributive.cpp
                   avg.cpp)
 set(ALL_OBJECT_FILES ${ALL_OBJECT_FILES}

--- a/src/function/aggregate_function/distributive.cpp
+++ b/src/function/aggregate_function/distributive.cpp
@@ -7,12 +7,12 @@ using namespace std;
 
 namespace duckdb {
 
-void gather_finalize(Vector &payloads, Vector &result) {
-	VectorOperations::Gather::Set(payloads, result);
+void gather_finalize(Vector &states, Vector &result) {
+	VectorOperations::Gather::Set(states, result);
 }
 
-void null_payload_initialize(data_ptr_t payload, TypeId return_type) {
-	SetNullValue(payload, return_type);
+void null_state_initialize(data_ptr_t state, TypeId return_type) {
+	SetNullValue(state, return_type);
 }
 
 } // namespace duckdb

--- a/src/function/aggregate_function/string_agg.cpp
+++ b/src/function/aggregate_function/string_agg.cpp
@@ -1,0 +1,62 @@
+#include "function/aggregate_function/covar.hpp"
+#include "common/exception.hpp"
+#include "common/types/null_value.hpp"
+#include "common/vector_operations/vector_operations.hpp"
+#include <string>
+
+using namespace std;
+
+namespace duckdb {
+
+typedef const char* string_agg_state_t;
+
+SQLType string_agg_get_return_type(vector<SQLType> &arguments) {
+    if (arguments.size() != 2)
+        return SQLTypeId::INVALID;
+
+    for ( index_t i = 0; i < arguments.size(); ++i) {
+        switch (arguments[i].id) {
+        case SQLTypeId::SQLNULL:
+        case SQLTypeId::VARCHAR:
+            break;
+        default:
+        return SQLTypeId::INVALID;
+        }
+    }
+
+    return SQLTypeId::VARCHAR;
+}
+
+void string_agg_update(Vector inputs[], index_t input_count, Vector &state) {
+    assert(input_count == 2);
+    auto& strs = inputs[0];
+    auto& seps = inputs[1];
+    assert(strs.type == TypeId::VARCHAR);
+    assert(seps.type == TypeId::VARCHAR);
+
+    auto str_data = (const char **)strs.data;
+    auto sep_data = (const char **)seps.data;
+
+    //  Share a reusable buffer for the block
+    std::string buffer;
+
+    VectorOperations::Exec(state, [&](index_t i, index_t k) {
+        if (strs.nullmask[i] || seps.nullmask[i]) {
+            return;
+        }
+
+        auto state_ptr = (string_agg_state_t*) ((data_ptr_t *)state.data)[i];
+        auto str = str_data[i];
+        auto sep = sep_data[i];
+        if (IsNullValue(*state_ptr)) {
+            *state_ptr = strs.string_heap.AddString(str);
+        } else {
+            buffer = *state_ptr;
+            buffer += sep;
+            buffer += str;
+            *state_ptr = strs.string_heap.AddString(buffer.c_str());
+        }
+    });
+}
+
+} // namespace duckdb

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -74,6 +74,7 @@ void BuiltinFunctions::Initialize(Transaction &transaction, Catalog &catalog) {
 	AddAggregateFunction<MinFunction>(transaction, catalog);
 	AddAggregateFunction<StdDevPopFunction>(transaction, catalog);
 	AddAggregateFunction<StdDevSampFunction>(transaction, catalog);
+	AddAggregateFunction<StringAggFunction>(transaction, catalog);
 	AddAggregateFunction<SumFunction>(transaction, catalog);
 	AddAggregateFunction<VarPopFunction>(transaction, catalog);
 	AddAggregateFunction<VarSampFunction>(transaction, catalog);

--- a/src/include/function/aggregate_function/covar.hpp
+++ b/src/include/function/aggregate_function/covar.hpp
@@ -17,9 +17,15 @@ void covarpop_finalize(Vector &payloads, Vector &result);
 void covarsamp_finalize(Vector &payloads, Vector &result);
 SQLType covar_get_return_type(vector<SQLType> &arguments);
 
+struct covar_state_t {
+    uint64_t    count;
+    double      meanx;
+    double      meany;
+    double      co_moment;
+};
+
 static index_t covar_state_size(TypeId return_type) {
-	// count meanx meany co-moment
-	return sizeof(uint64_t) + 3 * sizeof(double);
+	return sizeof(covar_state_t);
 }
 
 static void covar_initialize(data_ptr_t payload, TypeId return_type) {

--- a/src/include/function/aggregate_function/distributive.hpp
+++ b/src/include/function/aggregate_function/distributive.hpp
@@ -71,7 +71,7 @@ static index_t get_return_type_size(TypeId return_type) {
 	return GetTypeIdSize(return_type);
 }
 
-void null_payload_initialize(data_ptr_t payload, TypeId return_type);
+void null_state_initialize(data_ptr_t state, TypeId return_type);
 
 static Value null_simple_initialize() {
 	return Value();
@@ -94,7 +94,7 @@ public:
 	}
 
 	static aggregate_initialize_t GetInitalizeFunction() {
-		return null_payload_initialize;
+		return null_state_initialize;
 	}
 
 	static aggregate_simple_initialize_t GetSimpleInitializeFunction() {

--- a/src/include/function/aggregate_function/list.hpp
+++ b/src/include/function/aggregate_function/list.hpp
@@ -7,4 +7,5 @@
 #include "function/aggregate_function/max.hpp"
 #include "function/aggregate_function/min.hpp"
 #include "function/aggregate_function/stddev_samp.hpp"
+#include "function/aggregate_function/string_agg.hpp"
 #include "function/aggregate_function/sum.hpp"

--- a/src/include/function/aggregate_function/string_agg.hpp
+++ b/src/include/function/aggregate_function/string_agg.hpp
@@ -1,7 +1,7 @@
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// function/aggregate_function/sum.hpp
+// function/aggregate_function/stringagg.hpp
 //
 //
 //===----------------------------------------------------------------------===//
@@ -12,14 +12,13 @@
 
 namespace duckdb {
 
-void sum_update(Vector inputs[], index_t input_count, Vector &result);
-void sum_simple_update(Vector inputs[], index_t input_count, Value &result);
-SQLType sum_get_return_type(vector<SQLType> &arguments);
+void string_agg_update(Vector inputs[], index_t input_count, Vector &result);
+SQLType string_agg_get_return_type(vector<SQLType> &arguments);
 
-class SumFunction : public AggregateInPlaceFunction {
+class StringAggFunction : public AggregateInPlaceFunction {
 public:
 	static const char *GetName() {
-		return "sum";
+		return "string_agg";
 	}
 
 	static aggregate_size_t GetStateSizeFunction() {
@@ -31,7 +30,7 @@ public:
 	}
 
 	static aggregate_update_t GetUpdateFunction() {
-		return sum_update;
+		return string_agg_update;
 	}
 
 	static aggregate_simple_initialize_t GetSimpleInitializeFunction() {
@@ -39,11 +38,11 @@ public:
 	}
 
 	static aggregate_simple_update_t GetSimpleUpdateFunction() {
-		return sum_simple_update;
+		return nullptr;
 	}
 
 	static get_return_type_function_t GetReturnTypeFunction() {
-		return sum_get_return_type;
+		return string_agg_get_return_type;
 	}
 
 	static matches_argument_function_t GetCastArgumentsFunction() {


### PR DESCRIPTION
The values will be concatenated in the order they are received. If the hosting operators implement the `ORDER BY` syntax, then the values will be concatenated in the correct order.