### PR TITLE
Add CONCAT_WS function and modify CONCAT to accept multiary inputs

### DIFF
--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -119,6 +119,7 @@ void BuiltinFunctions::Initialize(Transaction &transaction, Catalog &catalog) {
 	AddScalarFunction<SubstringFunction>(transaction, catalog);
 	AddScalarFunction<UpperFunction>(transaction, catalog);
 	AddScalarFunction<LowerFunction>(transaction, catalog);
+	AddScalarFunction<ConcatWSFunction>(transaction, catalog);
 
 	// regex
 	AddScalarFunction<RegexpMatchesFunction>(transaction, catalog);

--- a/src/function/scalar_function/CMakeLists.txt
+++ b/src/function/scalar_function/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library_unity(duckdb_scalar_function
                   trigonometrics.cpp
                   age.cpp
                   mod.cpp
-                  pow.cpp)
+                  pow.cpp
+                  concat_ws.cpp)
 set(ALL_OBJECT_FILES ${ALL_OBJECT_FILES}
                      $<TARGET_OBJECTS:duckdb_scalar_function> PARENT_SCOPE)

--- a/src/function/scalar_function/concat.cpp
+++ b/src/function/scalar_function/concat.cpp
@@ -12,46 +12,69 @@ namespace duckdb {
 
 void concat_function(ExpressionExecutor &exec, Vector inputs[], index_t input_count, BoundFunctionExpression &expr,
                      Vector &result) {
-	assert(input_count == 2);
-	auto &input1 = inputs[0];
-	auto &input2 = inputs[1];
-	assert(input1.type == TypeId::VARCHAR);
-	assert(input2.type == TypeId::VARCHAR);
+	assert(input_count >= 2 && input_count <= 64);
 
 	result.Initialize(TypeId::VARCHAR);
-	result.nullmask = input1.nullmask | input2.nullmask;
-
-	auto result_data = (const char **)result.data;
-	auto input1_data = (const char **)input1.data;
-	auto input2_data = (const char **)input2.data;
+	result.nullmask = 0;
+	for (index_t i = 0; i < input_count; i++) {
+		auto &input = inputs[i];
+		assert(input.type == TypeId::VARCHAR);
+		if (!input.IsConstant()) {
+			result.sel_vector = input.sel_vector;
+			result.count = input.count;
+		}
+		// Any null input makes concat's result null.
+		result.nullmask |= input.nullmask;
+	}
 
 	// bool has_stats = expr.function->children[0]->stats.has_stats && expr.function->children[1]->stats.has_stats;
+	auto result_data = (const char **)result.data;
 	index_t current_len = 0;
 	unique_ptr<char[]> output;
 
-	VectorOperations::BinaryExec(input1, input2, result,
-	                             [&](index_t input1_index, index_t input2_index, index_t result_index) {
-		                             if (result.nullmask[result_index]) {
-			                             return;
-		                             }
-		                             auto input1 = input1_data[input1_index];
-		                             auto input2 = input2_data[input2_index];
-		                             index_t len1 = strlen(input1), len2 = strlen(input2);
-		                             index_t required_len = len1 + len2 + 1;
-		                             if (required_len > current_len) {
-			                             current_len = required_len;
-			                             output = unique_ptr<char[]>{new char[required_len]};
-		                             }
-		                             strncpy(output.get(), input1, len1);
-		                             strncpy(output.get() + len1, input2, len2);
-		                             output[len1 + len2] = '\0';
-		                             result_data[result_index] = result.string_heap.AddString(output.get());
-	                             });
+	VectorOperations::MultiaryExec(inputs, input_count, result, [&](vector<index_t> mul, index_t result_index) {
+		if (result.nullmask[result_index]) {
+			return;
+		}
+
+		// calculate length of result string
+		vector<const char *> input_chars(input_count);
+		index_t required_len = 0;
+		for (index_t i = 0; i < input_count; i++) {
+			int current_index = mul[i] * result_index;
+			input_chars[i] = ((const char **)inputs[i].data)[current_index];
+			required_len += strlen(input_chars[i]);
+		}
+		required_len++;
+
+		// allocate length of result string
+		if (required_len > current_len) {
+			current_len = required_len;
+			output = unique_ptr<char[]>{new char[required_len]};
+		}
+
+		// actual concatenation
+		int length_so_far = 0;
+		for (index_t i = 0; i < input_count; i++) {
+			int len = strlen(input_chars[i]);
+			strncpy(output.get() + length_so_far, input_chars[i], len);
+			length_so_far += len;
+		}
+		output[length_so_far] = '\0';
+		result_data[result_index] = result.string_heap.AddString(output.get());
+	});
 }
 
-// TODO: extend to support arbitrary number of arguments, not only two
+bool concat_match_input_types(vector<SQLType> &arguments) {
+	for (index_t i = 0; i < arguments.size(); i++) {
+		if (arguments[i].id != SQLTypeId::VARCHAR)
+			return false;
+	}
+	return true;
+}
+
 bool concat_matches_arguments(vector<SQLType> &arguments) {
-	return arguments.size() == 2 && arguments[0].id == SQLTypeId::VARCHAR && arguments[1].id == SQLTypeId::VARCHAR;
+	return arguments.size() >= 2 && arguments.size() <= 64 && concat_match_input_types(arguments);
 }
 
 SQLType concat_get_return_type(vector<SQLType> &arguments) {

--- a/src/function/scalar_function/concat_ws.cpp
+++ b/src/function/scalar_function/concat_ws.cpp
@@ -1,0 +1,111 @@
+#include "function/scalar_function/concat_ws.hpp"
+
+#include "common/exception.hpp"
+#include "common/types/date.hpp"
+#include "common/vector_operations/vector_operations.hpp"
+
+#include <string.h>
+
+using namespace std;
+
+namespace duckdb {
+
+void concat_ws_function(ExpressionExecutor &exec, Vector inputs[], index_t input_count, BoundFunctionExpression &expr,
+                        Vector &result) {
+	assert(input_count >= 2 && input_count <= 64);
+
+	// The first input parameter is the seperator
+	auto &input_separator = inputs[0];
+	auto input_separator_data = (const char **)input_separator.data;
+
+	result.Initialize(TypeId::VARCHAR);
+
+	// concat_ws becomes null only when the separator is null.
+	result.nullmask = input_separator.nullmask;
+	for (index_t i = 1; i < input_count; i++) {
+		auto &input = inputs[i];
+		assert(input.type == TypeId::VARCHAR);
+		if (!input.IsConstant()) {
+			result.sel_vector = input.sel_vector;
+			result.count = input.count;
+		}
+	}
+
+	// bool has_stats = expr.function->children[0]->stats.has_stats && expr.function->children[1]->stats.has_stats;
+	auto result_data = (const char **)result.data;
+	index_t current_len = 0;
+	unique_ptr<char[]> output;
+
+	VectorOperations::MultiaryExec(inputs, input_count, result, [&](vector<index_t> mul, index_t result_index) {
+		if (result.nullmask[result_index]) {
+			return;
+		}
+
+		// calculate length of separator string
+		auto separator = input_separator_data[mul[0] * result_index];
+		index_t separator_length = strlen(separator);
+
+		// calculate length of result string using the rest of the input parameters
+		vector<const char *> input_chars(input_count);
+		index_t required_len = 0;
+		for (index_t i = 1; i < input_count; i++) {
+			auto &input = inputs[i];
+			int current_index = mul[i] * result_index;
+
+			// Add the first non-separator string to the result string
+			if (!input.nullmask[current_index]) {
+				input_chars[i] = ((const char **)input.data)[current_index];
+				// append the separator only when there is something preceding it
+				if (i > 1 && required_len > 0)
+					required_len += separator_length;
+				required_len += strlen(input_chars[i]);
+			}
+		}
+		required_len++;
+
+		// allocate length of result string
+		if (required_len > current_len) {
+			current_len = required_len;
+			output = unique_ptr<char[]>{new char[required_len]};
+		}
+
+		int length_so_far = 0;
+		for (index_t i = 1; i < input_count; i++) {
+			auto &input = inputs[i];
+			int current_index = mul[i] * result_index;
+
+			// Add the first non-separator string to the result string
+			if (!input.nullmask[current_index]) {
+				// append the separator only when there is something preceding it
+				if (i > 1 && length_so_far > 0) {
+					strncpy(output.get() + length_so_far, separator, separator_length);
+					length_so_far += separator_length;
+				}
+
+				// append the next input string
+				int input_length = strlen(input_chars[i]);
+				strncpy(output.get() + length_so_far, input_chars[i], input_length);
+				length_so_far += input_length;
+			}
+		}
+		output[length_so_far] = '\0';
+		result_data[result_index] = result.string_heap.AddString(output.get());
+	});
+}
+
+bool concat_ws_match_input_types(vector<SQLType> &arguments) {
+	for (index_t i = 0; i < arguments.size(); i++) {
+		if (arguments[i].id != SQLTypeId::VARCHAR)
+			return false;
+	}
+	return true;
+}
+
+bool concat_ws_matches_arguments(vector<SQLType> &arguments) {
+	return arguments.size() >= 2 && arguments.size() <= 64 && concat_ws_match_input_types(arguments);
+}
+
+SQLType concat_ws_get_return_type(vector<SQLType> &arguments) {
+	return SQLType(SQLTypeId::VARCHAR);
+}
+} // namespace duckdb

--- a/src/include/common/vector_operations/vector_operations.hpp
+++ b/src/include/common/vector_operations/vector_operations.hpp
@@ -340,5 +340,21 @@ struct VectorOperations {
 
 		VectorOperations::Exec(result, [&](index_t i, index_t k) { fun(a_mul * i, b_mul * i, c_mul * i, i); });
 	}
+
+	template <class FUNC> static void MultiaryExec(Vector inputs[], int input_count, Vector &result, FUNC &&fun) {
+		result.sel_vector = nullptr;
+		result.count = 1;
+		vector<index_t> mul(input_count, 0);
+
+		for (int i = 0; i < input_count; i++) {
+			auto &input = inputs[i];
+			if (!input.IsConstant()) {
+				result.sel_vector = input.sel_vector;
+				result.count = input.count;
+			}
+			mul[i] = input.IsConstant() ? 0 : 1;
+		}
+		VectorOperations::Exec(result, [&](index_t i, index_t k) { fun(mul, i); });
+	}
 };
 } // namespace duckdb

--- a/src/include/function/scalar_function/concat_ws.hpp
+++ b/src/include/function/scalar_function/concat_ws.hpp
@@ -1,7 +1,7 @@
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// function/scalar_function/concat.hpp
+// function/scalar_function/concat_ws.hpp
 //
 //
 //===----------------------------------------------------------------------===//
@@ -14,28 +14,28 @@
 
 namespace duckdb {
 
-void concat_function(ExpressionExecutor &exec, Vector inputs[], index_t input_count, BoundFunctionExpression &expr,
-                     Vector &result);
-bool concat_match_input_types(vector<SQLType> &arguments);
-bool concat_matches_arguments(vector<SQLType> &arguments);
-SQLType concat_get_return_type(vector<SQLType> &arguments);
+void concat_ws_function(ExpressionExecutor &exec, Vector inputs[], index_t input_count, BoundFunctionExpression &expr,
+                        Vector &result);
+bool concat_ws_match_input_types(vector<SQLType> &arguments);
+bool concat_ws_matches_arguments(vector<SQLType> &arguments);
+SQLType concat_ws_get_return_type(vector<SQLType> &arguments);
 
-class ConcatFunction {
+class ConcatWSFunction {
 public:
 	static const char *GetName() {
-		return "concat";
+		return "concat_ws";
 	}
 
 	static scalar_function_t GetFunction() {
-		return concat_function;
+		return concat_ws_function;
 	}
 
 	static matches_argument_function_t GetMatchesArgumentFunction() {
-		return concat_matches_arguments;
+		return concat_ws_matches_arguments;
 	}
 
 	static get_return_type_function_t GetReturnTypeFunction() {
-		return concat_get_return_type;
+		return concat_ws_get_return_type;
 	}
 
 	static bind_scalar_function_t GetBindFunction() {

--- a/src/include/function/scalar_function/list.hpp
+++ b/src/include/function/scalar_function/list.hpp
@@ -1,6 +1,7 @@
 #include "function/scalar_function/age.hpp"
 #include "function/scalar_function/caseconvert.hpp"
 #include "function/scalar_function/concat.hpp"
+#include "function/scalar_function/concat_ws.hpp"
 #include "function/scalar_function/date_part.hpp"
 #include "function/scalar_function/length.hpp"
 #include "function/scalar_function/math.hpp"

--- a/test/sql/function/test_stringfunctions.cpp
+++ b/test/sql/function/test_stringfunctions.cpp
@@ -22,6 +22,44 @@ TEST_CASE("CONCAT test", "[function]") {
 
 	result = con.Query("select CONCAT(a, b) FROM strings");
 	REQUIRE(CHECK_COLUMN(result, 0, {"HelloWorld", Value(), "MotörHeadRÄcks"}));
+
+	result = con.Query("select CONCAT(a, b, 'SUFFIX') FROM strings");
+	REQUIRE(CHECK_COLUMN(result, 0, {"HelloWorldSUFFIX", Value(), "MotörHeadRÄcksSUFFIX"}));
+
+	result = con.Query("select CONCAT(a, b, a) FROM strings");
+	REQUIRE(CHECK_COLUMN(result, 0, {"HelloWorldHello", Value(), "MotörHeadRÄcksMotörHead"}));
+
+	result = con.Query("select CONCAT('1', '2', '3', '4', '5', '6', '7', '8', '9', '0')");
+	REQUIRE(CHECK_COLUMN(result, 0, {"1234567890"}));
+}
+
+TEST_CASE("CONCAT_WS test", "[function]") {
+	unique_ptr<QueryResult> result;
+	DuckDB db(nullptr);
+	Connection con(db);
+	con.EnableQueryVerification();
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE strings(a STRING, b STRING)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO strings VALUES ('Hello', 'World'), "
+	                          "('HuLlD', NULL), ('MotörHead','RÄcks')"));
+
+	result = con.Query("select CONCAT_WS(',',a, 'SUFFIX') FROM strings");
+	REQUIRE(CHECK_COLUMN(result, 0, {"Hello,SUFFIX", "HuLlD,SUFFIX", "MotörHead,SUFFIX"}));
+
+	result = con.Query("select CONCAT_WS('@','PREFIX', b) FROM strings");
+	REQUIRE(CHECK_COLUMN(result, 0, {"PREFIX@World", "PREFIX", "PREFIX@RÄcks"}));
+
+	result = con.Query("select CONCAT_WS('$',a, b) FROM strings");
+	REQUIRE(CHECK_COLUMN(result, 0, {"Hello$World", "HuLlD", "MotörHead$RÄcks"}));
+
+	result = con.Query("select CONCAT_WS(a, b, 'SUFFIX') FROM strings");
+	REQUIRE(CHECK_COLUMN(result, 0, {"WorldHelloSUFFIX", "SUFFIX", "RÄcksMotörHeadSUFFIX"}));
+
+	result = con.Query("select CONCAT_WS(a, b, b) FROM strings");
+	REQUIRE(CHECK_COLUMN(result, 0, {"WorldHelloWorld", "", "RÄcksMotörHeadRÄcks"}));
+
+	result = con.Query("select CONCAT_WS('@','1', '2', '3', '4', '5', '6', '7', '8', '9')");
+	REQUIRE(CHECK_COLUMN(result, 0, {"1@2@3@4@5@6@7@8@9"}));
 }
 
 TEST_CASE("UPPER/LOWER test", "[function]") {


### PR DESCRIPTION
Changes required to make CONCAT accept multiary inputs:
1) Implement MultiaryExec function which is similar to BinaryExec and TernaryExec, but accepts more than 3 inputs.
2) Change concat_function to use MultiaryExec and add loops to deal with multiple inputs.
3) Make relevant changes to input parameter validation, i.e. count, type etc.

Changes to add a new function CONCAT_WS:
1) CONCAT_WS is present in Mysql:
https://dev.mysql.com/doc/refman/8.0/en/string-functions.html#function_concat-ws
2) Like concat_function, concat_ws_function also uses MultiaryExec.
3) The first input parameter is always the separator. The separator should be a string / character, as can the rest of the arguments. If the separator is NULL, the result is NULL.
4) A NULL input parameter is skipped.