### PR TITLE
Support TIMESTAMP in EXTRACT(…)

### DIFF
--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -224,3 +224,29 @@ Interval TimestampToInterval(timestamp_struct *timestamp) {
 
 	return interval;
 }
+
+int64_t Timestamp::GetEpoch(timestamp_t timestamp) {
+    return Date::Epoch(Timestamp::GetDate(timestamp)) + (int64_t)Timestamp::GetTime(timestamp);
+}
+
+int64_t Timestamp::GetMilliseconds(timestamp_t timestamp) {
+    int n = Timestamp::GetTime(timestamp);
+    int m = n / 60000;
+    return n - m * 60000;
+}
+
+int64_t Timestamp::GetSeconds(timestamp_t timestamp) {
+    int n = Timestamp::GetTime(timestamp);
+    int m = n / 60000;
+    return (n - m * 60000) / 1000;
+}
+
+int64_t Timestamp::GetMinutes(timestamp_t timestamp) {
+    int n = Timestamp::GetTime(timestamp);
+    int h = n / 3600000;
+    return (n - h * 3600000) / 60000;
+}
+
+int64_t Timestamp::GetHours(timestamp_t timestamp) {
+    return Timestamp::GetTime(timestamp) / 3600000;
+}

--- a/src/function/scalar/date/date_part.cpp
+++ b/src/function/scalar/date/date_part.cpp
@@ -115,34 +115,78 @@ static int64_t extract_element(SpecifierType type, date_t element) {
 	}
 }
 
+static int64_t extract_element(SpecifierType type, timestamp_t element) {
+	switch (type) {
+	case SpecifierType::YEAR:
+	case SpecifierType::MONTH:
+	case SpecifierType::DAY:
+	case SpecifierType::DECADE:
+	case SpecifierType::CENTURY:
+	case SpecifierType::MILLENIUM:
+	case SpecifierType::QUARTER:
+	case SpecifierType::DOW:
+	case SpecifierType::ISODOW:
+	case SpecifierType::DOY:
+	case SpecifierType::WEEK:
+        return extract_element(type, Timestamp::GetDate(element));
+	case SpecifierType::EPOCH:
+		return Timestamp::GetEpoch(element);
+	case SpecifierType::MILLISECONDS:
+        return Timestamp::GetMilliseconds(element);
+	case SpecifierType::SECOND:
+        return Timestamp::GetSeconds(element);
+	case SpecifierType::MINUTE:
+        return Timestamp::GetMinutes(element);
+	case SpecifierType::HOUR:
+        return Timestamp::GetHours(element);
+	default:
+		throw NotImplementedException("Specifier type not implemented");
+	}
+}
+
 static void date_part_function(ExpressionExecutor &exec, Vector inputs[], index_t input_count, BoundFunctionExpression &expr,
                         Vector &result) {
 	result.Initialize(TypeId::BIGINT);
 	result.nullmask = inputs[1].nullmask;
 	result.count = inputs[1].count;
 	result.sel_vector = inputs[1].sel_vector;
-	if (inputs[1].type != TypeId::INTEGER) {
-		throw NotImplementedException("For now only DATE is implemented in Extract");
-	}
+	if (inputs[1].type != TypeId::INTEGER && inputs[1].type != TypeId::BIGINT) {
+		throw NotImplementedException("Can only extract from dates or timestamps");
+    }
 
 	auto result_data = (int64_t *)result.data;
 	if (inputs[0].IsConstant()) {
 		// constant specifier
 		auto specifier_type = GetSpecifierType(((const char **)inputs[0].data)[0]);
-		VectorOperations::ExecType<date_t>(inputs[1], [&](date_t element, index_t i, index_t k) {
-			result_data[i] = extract_element(specifier_type, element);
-		});
+        if (inputs[1].type == TypeId::INTEGER) {
+  		    VectorOperations::ExecType<date_t>(inputs[1], [&](date_t element, index_t i, index_t k) {
+			    result_data[i] = extract_element(specifier_type, element);
+    		});
+        } else {
+  		    VectorOperations::ExecType<timestamp_t>(inputs[1], [&](timestamp_t element, index_t i, index_t k) {
+			    result_data[i] = extract_element(specifier_type, element);
+    		});
+        }
 	} else {
 		// not constant specifier
 		auto specifiers = ((const char **)inputs[0].data);
-		VectorOperations::ExecType<date_t>(inputs[1], [&](date_t element, index_t i, index_t k) {
-			result_data[i] = extract_element(GetSpecifierType(specifiers[i]), element);
-		});
+        if (inputs[1].type == TypeId::INTEGER) {
+		    VectorOperations::ExecType<date_t>(inputs[1], [&](date_t element, index_t i, index_t k) {
+			    result_data[i] = extract_element(GetSpecifierType(specifiers[i]), element);
+    		});
+        } else {
+		    VectorOperations::ExecType<timestamp_t>(inputs[1], [&](timestamp_t element, index_t i, index_t k) {
+			    result_data[i] = extract_element(GetSpecifierType(specifiers[i]), element);
+    		});
+        }
 	}
 }
 
 void DatePart::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(ScalarFunction("date_part", { SQLType::VARCHAR, SQLType::DATE }, SQLType::BIGINT, date_part_function));
+    ScalarFunctionSet date_part("date_part");
+	date_part.AddFunction(ScalarFunction({ SQLType::VARCHAR, SQLType::DATE }, SQLType::BIGINT, date_part_function));
+	date_part.AddFunction(ScalarFunction({ SQLType::VARCHAR, SQLType::TIMESTAMP }, SQLType::BIGINT, date_part_function));
+    set.AddFunction(date_part);
 }
 
 } // namespace duckdb

--- a/src/include/common/types/timestamp.hpp
+++ b/src/include/common/types/timestamp.hpp
@@ -55,5 +55,13 @@ public:
 	static Interval GetDifference(timestamp_t timestamp_a, timestamp_t timestamp_b);
 
 	static timestamp_struct IntervalToTimestamp(Interval &interval);
+
+    // Unix epoch: milliseconds since 1970
+    static int64_t GetEpoch(timestamp_t timestamp);
+    // Seconds including fractional part multiplied by 1000
+    static int64_t GetMilliseconds(timestamp_t timestamp);
+    static int64_t GetSeconds(timestamp_t timestamp);
+    static int64_t GetMinutes(timestamp_t timestamp);
+    static int64_t GetHours(timestamp_t timestamp);
 };
 } // namespace duckdb

--- a/test/sql/date/test_extract.cpp
+++ b/test/sql/date/test_extract.cpp
@@ -107,3 +107,54 @@ TEST_CASE("Extract function edge cases", "[date]") {
 		expected_week++;
 	}
 }
+
+TEST_CASE("Extract timestamp function", "[timestamp]") {
+	unique_ptr<QueryResult> result;
+	DuckDB db(nullptr);
+	Connection con(db);
+	con.EnableQueryVerification();
+
+	// create and insert into table
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE timestamps(i TIMESTAMP)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO timestamps VALUES ('1993-08-14 08:22:33'), (NULL)"));
+
+	// extract various parts of the date
+	// year
+	result = con.Query("SELECT EXTRACT(year FROM i) FROM timestamps");
+	REQUIRE(CHECK_COLUMN(result, 0, {Value::INTEGER(1993), Value()}));
+	// month
+	result = con.Query("SELECT EXTRACT(month FROM i) FROM timestamps");
+	REQUIRE(CHECK_COLUMN(result, 0, {Value::INTEGER(8), Value()}));
+	// day
+	result = con.Query("SELECT EXTRACT(day FROM i) FROM timestamps");
+	REQUIRE(CHECK_COLUMN(result, 0, {Value::INTEGER(14), Value()}));
+	// decade
+	result = con.Query("SELECT EXTRACT(decade FROM i) FROM timestamps");
+	REQUIRE(CHECK_COLUMN(result, 0, {Value::INTEGER(199), Value()}));
+	// century
+	result = con.Query("SELECT EXTRACT(century FROM i) FROM timestamps");
+	REQUIRE(CHECK_COLUMN(result, 0, {Value::INTEGER(20), Value()}));
+	// day of the week (Sunday = 0, Saturday = 6)
+	result = con.Query("SELECT EXTRACT(DOW FROM i) FROM timestamps");
+	REQUIRE(CHECK_COLUMN(result, 0, {Value::INTEGER(6), Value()}));
+	// day of the year (1 - 365/366)
+	result = con.Query("SELECT EXTRACT(DOY FROM i) FROM timestamps");
+	REQUIRE(CHECK_COLUMN(result, 0, {Value::INTEGER(226), Value()}));
+	// epoch
+	result = con.Query("SELECT EXTRACT(epoch FROM i) FROM timestamps");
+	REQUIRE(CHECK_COLUMN(result, 0, {Value::BIGINT(775439400), Value()}));
+	// isodow (Monday = 1, Sunday = 7)
+	result = con.Query("SELECT EXTRACT(ISODOW FROM i) FROM timestamps");
+	REQUIRE(CHECK_COLUMN(result, 0, {Value::INTEGER(6), Value()}));
+	// millenium (change of millenium is January 1, X001)
+	result = con.Query("SELECT EXTRACT(millennium FROM i) FROM timestamps");
+	REQUIRE(CHECK_COLUMN(result, 0, {Value::INTEGER(2), Value()}));
+	result = con.Query("SELECT EXTRACT(second FROM i) FROM timestamps");
+	REQUIRE(CHECK_COLUMN(result, 0, {Value::INTEGER(33), Value()}));
+	result = con.Query("SELECT EXTRACT(minute FROM i) FROM timestamps");
+	REQUIRE(CHECK_COLUMN(result, 0, {Value::INTEGER(22), Value()}));
+	result = con.Query("SELECT EXTRACT(hour FROM i) FROM timestamps");
+	REQUIRE(CHECK_COLUMN(result, 0, {Value::INTEGER(8), Value()}));
+	result = con.Query("SELECT EXTRACT(milliseconds FROM i) FROM timestamps");
+	REQUIRE(CHECK_COLUMN(result, 0, {Value::INTEGER(33000), Value()}));
+}


### PR DESCRIPTION
I tried to run `format.py` but it seems that my local version of `clang-format` produces different results than the one used for the codebase (This is a known problem).