### PR TITLE
Use setuptools_scm for Python versioning

### DIFF
--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -125,7 +125,6 @@ else:
 
 setup(
     name = "duckdb",
-    version = '0.1.0',
     description = 'DuckDB embedded database',
     keywords = 'DuckDB Database SQL OLAP',
     url="https://github.com/cwida/duckdb",
@@ -136,7 +135,8 @@ setup(
     ],
     packages=['duckdb_query_graph'],
     include_package_data=True,
-    setup_requires=setup_requires,
+    setup_requires=setup_requires + ["setuptools_scm"],
+    use_scm_version = {"root": "../..", "relative_to": __file__},
     tests_require=['pytest'],
     classifiers = [
         'Topic :: Database :: Database Engines/Servers',


### PR DESCRIPTION
This uses git tags for versioning the Python package. The version tags are baked into the package on `python setup.py bdist_wheel` or `python setup.py sdist` and do not require the git information to be present for end-users.

Its main benefit is during development where you get versions like `duckdb-0.1.1.dev191+g9b57b5ad.d20190821-cp37-cp37m-macosx_10_9_x86_64.whl` and thus can identify from which commit your local build stems from.