### PR TITLE
Return datetime64 in Python

### DIFF
--- a/tools/pythonpkg/tests/conftest.py
+++ b/tools/pythonpkg/tests/conftest.py
@@ -21,6 +21,8 @@ def duckdb_cursor(request):
    # cursor.create('integers', {'i': numpy.arange(10)})
     cursor.execute('CREATE TABLE integers (i integer)')
     cursor.execute('INSERT INTO integers VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(NULL)')
+    cursor.execute('CREATE TABLE timestamps (t timestamp)')
+    cursor.execute("INSERT INTO timestamps VALUES ('1992-10-03 18:34:45'), ('2010-01-01 00:00:01'), (NULL)")
     return cursor
 
 

--- a/tools/pythonpkg/tests/test_dbapi00.py
+++ b/tools/pythonpkg/tests/test_dbapi00.py
@@ -17,6 +17,13 @@ class TestSimpleDBAPI(object):
         arr.mask = [False] * 10 + [True]
         numpy.testing.assert_array_equal(result['i'], arr, "Incorrect result returned")
 
+        duckdb_cursor.execute('SELECT * FROM timestamps')
+        result = duckdb_cursor.fetchnumpy()
+        arr = numpy.array(['1992-10-03 18:34:45', '2010-01-01 00:00:01', None], dtype="datetime64[ms]")
+        arr = numpy.ma.masked_array(arr)
+        arr.mask = [False, False, True]
+        numpy.testing.assert_array_equal(result['t'], arr, "Incorrect result returned")
+
     def test_pandas_selection(self, duckdb_cursor):
         duckdb_cursor.execute('SELECT * FROM integers')
         result = duckdb_cursor.fetchdf()
@@ -26,6 +33,13 @@ class TestSimpleDBAPI(object):
         arr = pandas.DataFrame.from_dict(arr)
         # assert str(result) == str(arr), "Incorrect result returned"
         pandas.testing.assert_frame_equal(result, arr)
+
+        duckdb_cursor.execute('SELECT * FROM timestamps')
+        result = duckdb_cursor.fetchdf()
+        df = pandas.DataFrame({
+            't': pandas.to_datetime(['1992-10-03 18:34:45', '2010-01-01 00:00:01', None])
+        })
+        pandas.testing.assert_frame_equal(result, df)
 
     # def test_numpy_creation(self, duckdb_cursor):
     #     # numpyarray = {'i': numpy.arange(10), 'v': numpy.random.randint(100, size=(1, 10))}  # segfaults


### PR DESCRIPTION
This adds support for correctly returning `TIMESTAMP` columns as `numpy.datetime64` in the Python client.

Sadly the tests fail with 

```
E   AssertionError: DataFrame.iloc[:, 0] are different
E
E   DataFrame.iloc[:, 0] values are different (66.66667 %)
E   [left]:  [1994-11-16T03:10:00.000000000, 2010-01-01T00:16:40.000000000, NaT]
E   [right]: [1992-10-03T18:34:45.000000000, 2010-01-01T00:00:01.000000000, NaT]
```

Any idea where this timeshift may be introduced?