### PR TITLE
Implement setseed function

### DIFF
--- a/src/function/scalar/math/CMakeLists.txt
+++ b/src/function/scalar/math/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library_unity(duckdb_func_math
 				radians.cpp
 				random.cpp
 				round.cpp
+				setseed.cpp
 				sign.cpp
 				sqrt.cpp)
 set(ALL_OBJECT_FILES ${ALL_OBJECT_FILES}

--- a/src/function/scalar/math/setseed.cpp
+++ b/src/function/scalar/math/setseed.cpp
@@ -1,0 +1,42 @@
+#include "function/scalar/math_functions.hpp"
+#include "common/exception.hpp"
+#include "common/vector_operations/vector_operations.hpp"
+#include "execution/expression_executor.hpp"
+#include "main/client_context.hpp"
+#include "planner/expression/bound_function_expression.hpp"
+
+using namespace duckdb;
+using namespace std;
+
+struct SetseedBindData : public FunctionData {
+	//! The client context for the function call
+	ClientContext &context;
+
+	SetseedBindData(ClientContext &context) : context(context) {
+	}
+
+	unique_ptr<FunctionData> Copy() override {
+		return make_unique<SetseedBindData>(context);
+	}
+};
+
+static void setseed_function(ExpressionExecutor &exec, Vector inputs[], index_t input_count, BoundFunctionExpression &expr,
+                     Vector &result) {
+	auto &info = (SetseedBindData &) *expr.bind_info;
+	assert(input_count == 1 && inputs[0].type == TypeId::INTEGER);
+	result.Initialize(TypeId::INTEGER);
+	result.count = 1;
+
+	int32_t seed = ((int32_t *)inputs[0].data)[0];
+	info.context.random_engine.seed(seed);
+
+	VectorOperations::Set(result, Value(seed));
+}
+
+unique_ptr<FunctionData> setseed_bind(BoundFunctionExpression &expr, ClientContext &context) {
+	return make_unique<SetseedBindData>(context);
+}
+
+void Setseed::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("setseed", { SQLType::INTEGER }, SQLType::INTEGER, setseed_function, true, setseed_bind));
+}

--- a/src/function/scalar/math_functions.cpp
+++ b/src/function/scalar/math_functions.cpp
@@ -22,6 +22,7 @@ void BuiltinFunctions::RegisterMathFunctions() {
 	Register<Ln>();
 	Register<Pow>();
 	Register<Random>();
+	Register<Setseed>();
 	Register<Sqrt>();
 
 	Register<Pi>();

--- a/src/include/function/scalar/math_functions.hpp
+++ b/src/include/function/scalar/math_functions.hpp
@@ -46,6 +46,10 @@ struct Random {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct Setseed {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct Cbrt {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/src/include/main/client_context.hpp
+++ b/src/include/main/client_context.hpp
@@ -15,6 +15,7 @@
 #include "transaction/transaction_context.hpp"
 #include "common/unordered_set.hpp"
 #include "main/prepared_statement.hpp"
+#include <random>
 
 namespace duckdb {
 class Catalog;
@@ -49,6 +50,9 @@ public:
 	bool query_verification_enabled = false;
 	//! Enable the running of optimizers
 	bool enable_optimizer = true;
+
+	//! The random generator used by random(). Its seed value can be set by setseed().
+	std::mt19937 random_engine;
 
 public:
 	Transaction &ActiveTransaction() {

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -24,6 +24,8 @@ using namespace std;
 ClientContext::ClientContext(DuckDB &database)
     : db(database), transaction(*database.transaction_manager), interrupted(false), catalog(*database.catalog),
       prepared_statements(make_unique<CatalogSet>(*db.catalog)), open_result(nullptr) {
+	random_device rd;
+	random_engine.seed(rd());
 }
 
 void ClientContext::Cleanup() {

--- a/test/sql/function/test_math.cpp
+++ b/test/sql/function/test_math.cpp
@@ -85,15 +85,26 @@ TEST_CASE("Test random & setseed functions", "[function]") {
 
 	REQUIRE_NO_FAIL(con.Query("select setseed(0.1)"));
 	result1 = con.Query("select random(), random(), random()");
-	REQUIRE(CHECK_COLUMN(result1, 0, {0.171597}));
-	REQUIRE(CHECK_COLUMN(result1, 1, {0.384717}));
-	REQUIRE(CHECK_COLUMN(result1, 2, {0.072175}));
+	REQUIRE(CHECK_COLUMN(result1, 0, {0.612055}));
+	REQUIRE(CHECK_COLUMN(result1, 1, {0.384141}));
+	REQUIRE(CHECK_COLUMN(result1, 2, {0.288025}));
 	REQUIRE_NO_FAIL(con.Query("select setseed(0.1)"));
 	result2 = con.Query("select random(), random(), random()");
 	REQUIRE(result1->Equals(*result2));
 
 	REQUIRE_FAIL(con.Query("select setseed(1.1)"));
 	REQUIRE_FAIL(con.Query("select setseed(-1.1)"));
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE seeds(a DOUBLE)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO seeds VALUES (-0.1), (0.0), (0.1)"));
+	result2 = con.Query("select setseed(a), a from seeds;");
+	REQUIRE(CHECK_COLUMN(result2, 0, {Value(), Value(), Value()}));
+	REQUIRE(CHECK_COLUMN(result2, 1, {-0.1, 0.0, 0.1}));
+	// Make sure last seed (0.1) is in effect
+	result1 = con.Query("select random(), random(), random()");
+	REQUIRE_NO_FAIL(con.Query("select setseed(0.1)"));
+	result2 = con.Query("select random(), random(), random()");
+	REQUIRE(result1->Equals(*result2));
 
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE numbers(a INTEGER)"));
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO numbers VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10)"));

--- a/test/sql/function/test_math.cpp
+++ b/test/sql/function/test_math.cpp
@@ -70,11 +70,10 @@ TEST_CASE("Rounding test", "[function]") {
 	REQUIRE(CHECK_COLUMN(result, 0, {42.123}));
 }
 
-TEST_CASE("Test random() function", "[function]") {
+TEST_CASE("Test random & setseed functions", "[function]") {
 	unique_ptr<QueryResult> result, result1, result2;
 	DuckDB db(nullptr);
 	Connection con(db);
-	vector<string> splits1, splits2;
 
 	// random() is evaluated twice here
 	result = con.Query("select case when random() between 0 and 0.99999 then 1 else 0 end");
@@ -83,6 +82,15 @@ TEST_CASE("Test random() function", "[function]") {
 	result1 = con.Query("select random()");
 	result2 = con.Query("select random()");
 	REQUIRE(!result1->Equals(*result2));
+
+	REQUIRE_NO_FAIL(con.Query("select setseed(42)"));
+	result1 = con.Query("select random(), random(), random()");
+	REQUIRE(CHECK_COLUMN(result1, 0, {0.796543}));
+	REQUIRE(CHECK_COLUMN(result1, 1, {0.183435}));
+	REQUIRE(CHECK_COLUMN(result1, 2, {0.779691}));
+	REQUIRE_NO_FAIL(con.Query("select setseed(42)"));
+	result2 = con.Query("select random(), random(), random()");
+	REQUIRE(result1->Equals(*result2));
 
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE numbers(a INTEGER)"));
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO numbers VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10)"));

--- a/test/sql/function/test_math.cpp
+++ b/test/sql/function/test_math.cpp
@@ -83,14 +83,17 @@ TEST_CASE("Test random & setseed functions", "[function]") {
 	result2 = con.Query("select random()");
 	REQUIRE(!result1->Equals(*result2));
 
-	REQUIRE_NO_FAIL(con.Query("select setseed(42)"));
+	REQUIRE_NO_FAIL(con.Query("select setseed(0.1)"));
 	result1 = con.Query("select random(), random(), random()");
-	REQUIRE(CHECK_COLUMN(result1, 0, {0.796543}));
-	REQUIRE(CHECK_COLUMN(result1, 1, {0.183435}));
-	REQUIRE(CHECK_COLUMN(result1, 2, {0.779691}));
-	REQUIRE_NO_FAIL(con.Query("select setseed(42)"));
+	REQUIRE(CHECK_COLUMN(result1, 0, {0.171597}));
+	REQUIRE(CHECK_COLUMN(result1, 1, {0.384717}));
+	REQUIRE(CHECK_COLUMN(result1, 2, {0.072175}));
+	REQUIRE_NO_FAIL(con.Query("select setseed(0.1)"));
 	result2 = con.Query("select random(), random(), random()");
 	REQUIRE(result1->Equals(*result2));
+
+	REQUIRE_FAIL(con.Query("select setseed(1.1)"));
+	REQUIRE_FAIL(con.Query("select setseed(-1.1)"));
 
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE numbers(a INTEGER)"));
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO numbers VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10)"));


### PR DESCRIPTION
From what I understand, all std's predefined random number generators generate unsigned integer values and their seed methods also expect values of unsigned integral type. In some local experiments with the current PR I see that e.g. all seed values between 0.1-0.9 generate the same sequence of "random" numbers, making the random() function a bit useless if used with that range of inputs. Instead, it's working fine if we provide different unsigned integers as seeds.

I'm mentioning the above because Postgres' setseed function supports only seed values between -1.0 and 1.0, inclusive. I'd like your input about how DuckDB should handle random/setseed:

- Leave it as it is in this PR and expect integers as seeds
- Follow Postgres (-1.0 <= seed value <= 1.0) + use a std predefined random generator (e.g. the one in this PR) + manipulate the seed value so that we end-up with a large int. For example, we could multiply the seed with a large number so that seeds 0.123 & 0.124 become 123000 & 124000 respectively and generate different sequences (in the current PR 0.123 & 0.124 produce the same sequences).
- Follow Postgres (-1.0 <= seed value <= 1.0) + use whatever random engine is used by Postgres (erand48 from stdlib?)

Something else I'm not sure how to handle is the return type of setseed. In Postgres, its return type is void. I'm not sure how to achieve that in DuckDB. Whatever I tried was failing with conversion errors. For the time being, updated it to just return the seed value itself. Any thoughts on how to implement that in DuckDB or if we even care about it?
