### PR TITLE
fix comment bug: drops

### DIFF
--- a/src/include/catalog/catalog_entry/schema_catalog_entry.hpp
+++ b/src/include/catalog/catalog_entry/schema_catalog_entry.hpp
@@ -59,12 +59,12 @@ public:
 
 	//! Creates a view with the given name in the schema
 	void CreateView(Transaction &transaction, CreateViewInfo *info);
-	//! Creates a view with the given name in the schema
+	//! Drops a view with the given name in the schema
 	void DropView(Transaction &transaction, DropInfo *info);
 
 	//! Creates a sequence with the given name in the schema
 	void CreateSequence(Transaction &transaction, CreateSequenceInfo *info);
-	//! Creates a sequence with the given name in the schema
+	//! Drops a sequence with the given name in the schema
 	void DropSequence(Transaction &transaction, DropInfo *info);
 
 	//! Creates an index with the given name in the schema


### PR DESCRIPTION
Comments of `DropView` and `DropSequence` should begin with 'Drops' instead of 'Creates'.