### PR TITLE
Fix 293: ORDER BY pushes unnecessary projections

### DIFF
--- a/src/include/planner/expression_binder/order_binder.hpp
+++ b/src/include/planner/expression_binder/order_binder.hpp
@@ -11,6 +11,7 @@
 #include "common/unordered_map.hpp"
 #include "parser/expression_map.hpp"
 #include "parser/parsed_expression.hpp"
+#include "planner/expression/bound_columnref_expression.hpp"
 
 namespace duckdb {
 class Expression;
@@ -20,9 +21,10 @@ class SelectNode;
 class OrderBinder {
 public:
 	OrderBinder(index_t projection_index, SelectNode &node, unordered_map<string, index_t> &alias_map,
-	            expression_map_t<index_t> &projection_map);
+	            expression_map_t<index_t> &projection_map, vector<unique_ptr<ParsedExpression>> &extra_select_list);
 
 	unique_ptr<Expression> Bind(unique_ptr<ParsedExpression> expr);
+	void RemapIndex(BoundColumnRefExpression &expr, index_t index);
 
 private:
 	unique_ptr<Expression> CreateProjectionReference(ParsedExpression &expr, index_t index);
@@ -31,6 +33,7 @@ private:
 	SelectNode &node;
 	unordered_map<string, index_t> &alias_map;
 	expression_map_t<index_t> &projection_map;
+	vector<unique_ptr<ParsedExpression>> &extra_select_list;
 };
 
 } // namespace duckdb

--- a/src/planner/expression_binder/order_binder.cpp
+++ b/src/planner/expression_binder/order_binder.cpp
@@ -3,19 +3,24 @@
 #include "parser/expression/columnref_expression.hpp"
 #include "parser/expression/constant_expression.hpp"
 #include "parser/query_node/select_node.hpp"
-#include "planner/expression/bound_columnref_expression.hpp"
 
 using namespace duckdb;
 using namespace std;
 
 OrderBinder::OrderBinder(index_t projection_index, SelectNode &node, unordered_map<string, index_t> &alias_map,
-                         expression_map_t<index_t> &projection_map)
-    : projection_index(projection_index), node(node), alias_map(alias_map), projection_map(projection_map) {
+                         expression_map_t<index_t> &projection_map,
+                         vector<unique_ptr<ParsedExpression>> &extra_select_list)
+    : projection_index(projection_index), node(node), alias_map(alias_map), projection_map(projection_map),
+      extra_select_list(extra_select_list) {
 }
 
 unique_ptr<Expression> OrderBinder::CreateProjectionReference(ParsedExpression &expr, index_t index) {
 	return make_unique<BoundColumnRefExpression>(expr.GetName(), TypeId::INVALID,
 	                                             ColumnBinding(projection_index, index));
+}
+
+void OrderBinder::RemapIndex(BoundColumnRefExpression &expr, index_t index) {
+	expr.binding.column_index = index;
 }
 
 unique_ptr<Expression> OrderBinder::Bind(unique_ptr<ParsedExpression> expr) {
@@ -75,7 +80,7 @@ unique_ptr<Expression> OrderBinder::Bind(unique_ptr<ParsedExpression> expr) {
 		throw BinderException("for SELECT DISTINCT, ORDER BY expressions must appear in select list!");
 	}
 	// otherwise we need to push the ORDER BY entry into the select list
-	auto result = CreateProjectionReference(*expr, node.select_list.size());
-	node.select_list.push_back(move(expr));
+	auto result = CreateProjectionReference(*expr, node.select_list.size() + extra_select_list.size());
+	extra_select_list.push_back(move(expr));
 	return result;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,7 @@ add_subdirectory(common)
 add_subdirectory(helpers)
 add_subdirectory(monetdb)
 add_subdirectory(sql)
+add_subdirectory(planner)
 add_subdirectory(optimizer)
 
 if(NOT WIN32)

--- a/test/planner/CMakeLists.txt
+++ b/test/planner/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(test_planner OBJECT
+            test_projection_binding.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:test_planner>
+    PARENT_SCOPE)

--- a/test/planner/test_projection_binding.cpp
+++ b/test/planner/test_projection_binding.cpp
@@ -1,0 +1,34 @@
+#include "catch.hpp"
+#include "expression_helper.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb;
+using namespace std;
+
+TEST_CASE("Test projection bindings for ORDER BY", "[projection-binding-order-by]") {
+	ExpressionHelper helper;
+  using Op = LogicalOperatorType;
+
+	auto projection_matches = [&](string query, vector<LogicalOperatorType> path, size_t count) -> bool {
+		auto plan = helper.ParseLogicalTree(query);
+		for (auto type : path) {
+			if (plan->type != type)
+				return false;
+			if (plan->children.size() == 0)
+				return false;
+			plan = move(plan->children[0]);
+		}
+		return (plan->type == Op::PROJECTION && plan->expressions.size() == count);
+	};
+
+	auto &con = helper.con;
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE a (i INTEGER, j INTEGER)"));
+
+	REQUIRE(projection_matches("SELECT i FROM a ORDER BY j", {Op::PRUNE_COLUMNS, Op::ORDER_BY}, 2));
+	REQUIRE(projection_matches("SELECT i FROM a ORDER BY i", {Op::ORDER_BY}, 1));
+	REQUIRE(projection_matches("SELECT a.i FROM a ORDER BY i", {Op::ORDER_BY}, 1));
+	REQUIRE(projection_matches("SELECT i FROM a ORDER BY a.i", {Op::ORDER_BY}, 1));
+	REQUIRE(projection_matches("SELECT i AS k FROM a ORDER BY i", {Op::ORDER_BY}, 1));
+
+	con.Query("DROP TABLE a");
+}


### PR DESCRIPTION
As #293 says, ORDER BY does not recognise matching columns already in the projection if they are qualified differently. This is because `OrderBinder` does not have the `BindContext` and thus cannot resolve unbound expressions via table bindings. But `OrderBinder`'s client does have the `BindContext`, and thus _can_.

This PR uses that fact to solve the problem. With this change:
1. `OrderBinder` no longer pushes any new projections directly into the `SelectNode`, but into a separate vector for further processing; and
2. `Bind(SelectNode&)` then resolves the table bindings of these potential new projections and matches them against the existing ones; if matched, they're reused, avoiding duplication.

A (positive, IMO) side-effect of this change is that these extra projections show up in the `select_list` only at the very end, after all of the other binders (i.e., `WhereBinder`, `HavingBinder`, `GroupBinder`) have been called. This was not intentional, though I think it is better this way.