### PR TITLE
Fix for Issue #303

### DIFF
--- a/src/include/parser/expression/bound_expression.hpp
+++ b/src/include/parser/expression/bound_expression.hpp
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// parser/expression/bound_expression.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "common/exception.hpp"
+#include "parser/parsed_expression.hpp"
+#include "planner/expression.hpp"
+
+namespace duckdb {
+
+//! BoundExpression is an intermediate dummy class used by the binder. It is a ParsedExpression but holds an Expression.
+//! It represents a successfully bound expression. It is used in the Binder to prevent re-binding of already bound parts
+//! when dealing with subqueries.
+class BoundExpression : public ParsedExpression {
+public:
+	BoundExpression(unique_ptr<Expression> expr, unique_ptr<ParsedExpression> parsed_expr, SQLType sql_type)
+	    : ParsedExpression(ExpressionType::INVALID, ExpressionClass::BOUND_EXPRESSION), expr(move(expr)), parsed_expr(move(parsed_expr)),
+	      sql_type(sql_type) {
+	}
+
+	unique_ptr<Expression> expr;
+	unique_ptr<ParsedExpression> parsed_expr;
+	SQLType sql_type;
+
+public:
+	string ToString() const override {
+		return expr->ToString();
+	}
+
+	bool Equals(const BaseExpression *other) const override {
+		return parsed_expr->Equals(other);
+	}
+	uint64_t Hash() const override {
+		return parsed_expr->Hash();
+	}
+
+	unique_ptr<ParsedExpression> Copy() const override {
+		throw SerializationException("Cannot copy or serialize bound expression");
+	}
+};
+
+}

--- a/src/include/parser/expression/case_expression.hpp
+++ b/src/include/parser/expression/case_expression.hpp
@@ -26,7 +26,7 @@ public:
 public:
 	string ToString() const override;
 
-	bool Equals(const BaseExpression *other) const override;
+	static bool Equals(const CaseExpression *a, const CaseExpression *b);
 
 	unique_ptr<ParsedExpression> Copy() const override;
 

--- a/src/include/parser/expression/cast_expression.hpp
+++ b/src/include/parser/expression/cast_expression.hpp
@@ -25,7 +25,7 @@ public:
 public:
 	string ToString() const override;
 
-	bool Equals(const BaseExpression *other) const override;
+	static bool Equals(const CastExpression *a, const CastExpression *b);
 
 	unique_ptr<ParsedExpression> Copy() const override;
 

--- a/src/include/parser/expression/columnref_expression.hpp
+++ b/src/include/parser/expression/columnref_expression.hpp
@@ -34,7 +34,7 @@ public:
 	string GetName() const override;
 	string ToString() const override;
 
-	bool Equals(const BaseExpression *other) const override;
+	static bool Equals(const ColumnRefExpression *a, const ColumnRefExpression *b);
 	uint64_t Hash() const override;
 
 	unique_ptr<ParsedExpression> Copy() const override;

--- a/src/include/parser/expression/comparison_expression.hpp
+++ b/src/include/parser/expression/comparison_expression.hpp
@@ -23,7 +23,7 @@ public:
 public:
 	string ToString() const override;
 
-	bool Equals(const BaseExpression *other) const override;
+	static bool Equals(const ComparisonExpression *a, const ComparisonExpression *b);
 
 	unique_ptr<ParsedExpression> Copy() const override;
 

--- a/src/include/parser/expression/conjunction_expression.hpp
+++ b/src/include/parser/expression/conjunction_expression.hpp
@@ -22,7 +22,7 @@ public:
 public:
 	string ToString() const override;
 
-	bool Equals(const BaseExpression *other) const override;
+	static bool Equals(const ConjunctionExpression *a, const ConjunctionExpression *b);
 
 	unique_ptr<ParsedExpression> Copy() const override;
 

--- a/src/include/parser/expression/constant_expression.hpp
+++ b/src/include/parser/expression/constant_expression.hpp
@@ -25,7 +25,7 @@ public:
 public:
 	string ToString() const override;
 
-	bool Equals(const BaseExpression *other_) const override;
+	static bool Equals(const ConstantExpression *a, const ConstantExpression *b);
 	uint64_t Hash() const override;
 
 	unique_ptr<ParsedExpression> Copy() const override;

--- a/src/include/parser/expression/function_expression.hpp
+++ b/src/include/parser/expression/function_expression.hpp
@@ -34,7 +34,7 @@ public:
 
 	unique_ptr<ParsedExpression> Copy() const override;
 
-	bool Equals(const BaseExpression *other) const override;
+	static bool Equals(const FunctionExpression *a, const FunctionExpression *b);
 	uint64_t Hash() const override;
 
 	//! Serializes a FunctionExpression to a stand-alone binary blob

--- a/src/include/parser/expression/list.hpp
+++ b/src/include/parser/expression/list.hpp
@@ -1,3 +1,4 @@
+#include "parser/expression/bound_expression.hpp"
 #include "parser/expression/case_expression.hpp"
 #include "parser/expression/cast_expression.hpp"
 #include "parser/expression/columnref_expression.hpp"

--- a/src/include/parser/expression/operator_expression.hpp
+++ b/src/include/parser/expression/operator_expression.hpp
@@ -22,7 +22,7 @@ public:
 public:
 	string ToString() const override;
 
-	bool Equals(const BaseExpression *other) const override;
+	static bool Equals(const OperatorExpression *a, const OperatorExpression *b);
 
 	unique_ptr<ParsedExpression> Copy() const override;
 

--- a/src/include/parser/expression/subquery_expression.hpp
+++ b/src/include/parser/expression/subquery_expression.hpp
@@ -39,7 +39,7 @@ public:
 
 	string ToString() const override;
 
-	bool Equals(const BaseExpression *other) const override;
+	static bool Equals(const SubqueryExpression *a, const SubqueryExpression *b);
 
 	unique_ptr<ParsedExpression> Copy() const override;
 

--- a/src/include/parser/expression/window_expression.hpp
+++ b/src/include/parser/expression/window_expression.hpp
@@ -56,7 +56,7 @@ public:
 
 	string ToString() const override;
 
-	bool Equals(const BaseExpression *other) const override;
+	static bool Equals(const WindowExpression *a, const WindowExpression *b);
 
 	unique_ptr<ParsedExpression> Copy() const override;
 

--- a/src/include/parser/parsed_expression.hpp
+++ b/src/include/parser/parsed_expression.hpp
@@ -36,6 +36,7 @@ public:
 	bool IsScalar() const override;
 	bool HasParameter() const override;
 
+	bool Equals(const BaseExpression *other) const override;
 	uint64_t Hash() const override;
 
 	//! Create a copy of this expression

--- a/src/include/planner/expression_binder.hpp
+++ b/src/include/planner/expression_binder.hpp
@@ -10,6 +10,7 @@
 
 #include "common/exception.hpp"
 #include "parser/parsed_expression.hpp"
+#include "parser/expression/bound_expression.hpp"
 #include "parser/tokens.hpp"
 #include "planner/expression.hpp"
 
@@ -36,29 +37,6 @@ struct BindResult {
 	unique_ptr<Expression> expression;
 	SQLType sql_type;
 	string error;
-};
-
-//! BoundExpression is an intermediate dummy class used by the binder. It is a ParsedExpression but holds an Expression.
-//! It represents a successfully bound expression. It is used in the Binder to prevent re-binding of already bound parts
-//! when dealing with subqueries.
-class BoundExpression : public ParsedExpression {
-public:
-	BoundExpression(unique_ptr<Expression> expr, SQLType sql_type)
-	    : ParsedExpression(ExpressionType::INVALID, ExpressionClass::BOUND_EXPRESSION), expr(move(expr)),
-	      sql_type(sql_type) {
-	}
-
-	unique_ptr<Expression> expr;
-	SQLType sql_type;
-
-public:
-	string ToString() const override {
-		return expr->ToString();
-	}
-
-	unique_ptr<ParsedExpression> Copy() const override {
-		throw SerializationException("Cannot copy or serialize bound expression");
-	}
 };
 
 class ExpressionBinder {

--- a/src/parser/expression/case_expression.cpp
+++ b/src/parser/expression/case_expression.cpp
@@ -13,18 +13,15 @@ string CaseExpression::ToString() const {
 	       result_if_false->ToString() + ")";
 }
 
-bool CaseExpression::Equals(const BaseExpression *other_) const {
-	if (!BaseExpression::Equals(other_)) {
+
+bool CaseExpression::Equals(const CaseExpression *a, const CaseExpression *b) {
+	if (!a->check->Equals(b->check.get())) {
 		return false;
 	}
-	auto other = (CaseExpression *)other_;
-	if (!check->Equals(other->check.get())) {
+	if (!a->result_if_true->Equals(b->result_if_true.get())) {
 		return false;
 	}
-	if (!result_if_true->Equals(other->result_if_true.get())) {
-		return false;
-	}
-	if (!result_if_false->Equals(other->result_if_false.get())) {
+	if (!a->result_if_false->Equals(b->result_if_false.get())) {
 		return false;
 	}
 	return true;

--- a/src/parser/expression/cast_expression.cpp
+++ b/src/parser/expression/cast_expression.cpp
@@ -15,15 +15,11 @@ string CastExpression::ToString() const {
 	return "CAST[" + SQLTypeToString(cast_type) + "](" + child->ToString() + ")";
 }
 
-bool CastExpression::Equals(const BaseExpression *other_) const {
-	if (!BaseExpression::Equals(other_)) {
+bool CastExpression::Equals(const CastExpression *a, const CastExpression *b) {
+	if (!a->child->Equals(b->child.get())) {
 		return false;
 	}
-	auto other = (CastExpression *)other_;
-	if (!child->Equals(other->child.get())) {
-		return false;
-	}
-	if (cast_type != other->cast_type) {
+	if (a->cast_type != b->cast_type) {
 		return false;
 	}
 	return true;

--- a/src/parser/expression/columnref_expression.cpp
+++ b/src/parser/expression/columnref_expression.cpp
@@ -28,12 +28,8 @@ string ColumnRefExpression::ToString() const {
 	}
 }
 
-bool ColumnRefExpression::Equals(const BaseExpression *other_) const {
-	if (!BaseExpression::Equals(other_)) {
-		return false;
-	}
-	auto other = (ColumnRefExpression *)other_;
-	return column_name == other->column_name && table_name == other->table_name;
+bool ColumnRefExpression::Equals(const ColumnRefExpression *a, const ColumnRefExpression *b) {
+	return a->column_name == b->column_name && a->table_name == b->table_name;
 }
 
 uint64_t ColumnRefExpression::Hash() const {

--- a/src/parser/expression/comparison_expression.cpp
+++ b/src/parser/expression/comparison_expression.cpp
@@ -18,15 +18,11 @@ string ComparisonExpression::ToString() const {
 	return left->ToString() + ExpressionTypeToOperator(type) + right->ToString();
 }
 
-bool ComparisonExpression::Equals(const BaseExpression *other_) const {
-	if (!BaseExpression::Equals(other_)) {
+bool ComparisonExpression::Equals(const ComparisonExpression *a, const ComparisonExpression *b) {
+	if (!a->left->Equals(b->left.get())) {
 		return false;
 	}
-	auto other = (ComparisonExpression *)other_;
-	if (!left->Equals(other->left.get())) {
-		return false;
-	}
-	if (!right->Equals(other->right.get())) {
+	if (!a->right->Equals(b->right.get())) {
 		return false;
 	}
 	return true;

--- a/src/parser/expression/conjunction_expression.cpp
+++ b/src/parser/expression/conjunction_expression.cpp
@@ -15,16 +15,12 @@ string ConjunctionExpression::ToString() const {
 	return left->ToString() + " " + ExpressionTypeToOperator(type) + " " + right->ToString();
 }
 
-bool ConjunctionExpression::Equals(const BaseExpression *other_) const {
-	if (!BaseExpression::Equals(other_)) {
-		return false;
-	}
-	auto other = (ConjunctionExpression *)other_;
+bool ConjunctionExpression::Equals(const ConjunctionExpression *a, const ConjunctionExpression *b) {
 	// conjunctions are Commutative
-	if (left->Equals(other->left.get()) && right->Equals(other->right.get())) {
+	if (a->left->Equals(b->left.get()) && a->right->Equals(b->right.get())) {
 		return true;
 	}
-	if (right->Equals(other->left.get()) && left->Equals(other->right.get())) {
+	if (a->right->Equals(b->left.get()) && a->left->Equals(b->right.get())) {
 		return true;
 	}
 	return false;

--- a/src/parser/expression/constant_expression.cpp
+++ b/src/parser/expression/constant_expression.cpp
@@ -15,12 +15,8 @@ string ConstantExpression::ToString() const {
 	return value.ToString();
 }
 
-bool ConstantExpression::Equals(const BaseExpression *other_) const {
-	if (!BaseExpression::Equals(other_)) {
-		return false;
-	}
-	auto other = (ConstantExpression *)other_;
-	return value == other->value;
+bool ConstantExpression::Equals(const ConstantExpression *a, const ConstantExpression *b) {
+	return a->value == b->value;
 }
 
 uint64_t ConstantExpression::Hash() const {

--- a/src/parser/expression/function_expression.cpp
+++ b/src/parser/expression/function_expression.cpp
@@ -41,19 +41,15 @@ string FunctionExpression::ToString() const {
 	return result + ")";
 }
 
-bool FunctionExpression::Equals(const BaseExpression *other_) const {
-	if (!BaseExpression::Equals(other_)) {
+bool FunctionExpression::Equals(const FunctionExpression *a, const FunctionExpression *b) {
+	if (a->schema != b->schema || a->function_name != b->function_name || b->distinct != a->distinct) {
 		return false;
 	}
-	auto other = (FunctionExpression *)other_;
-	if (schema != other->schema || function_name != other->function_name || other->distinct != distinct) {
+	if (b->children.size() != a->children.size()) {
 		return false;
 	}
-	if (other->children.size() != children.size()) {
-		return false;
-	}
-	for (index_t i = 0; i < children.size(); i++) {
-		if (!children[i]->Equals(other->children[i].get())) {
+	for (index_t i = 0; i < a->children.size(); i++) {
+		if (!a->children[i]->Equals(b->children[i].get())) {
 			return false;
 		}
 	}

--- a/src/parser/expression/operator_expression.cpp
+++ b/src/parser/expression/operator_expression.cpp
@@ -40,16 +40,12 @@ string OperatorExpression::ToString() const {
 	return result;
 }
 
-bool OperatorExpression::Equals(const BaseExpression *other_) const {
-	if (!BaseExpression::Equals(other_)) {
+bool OperatorExpression::Equals(const OperatorExpression *a, const OperatorExpression *b) {
+	if (a->children.size() != b->children.size()) {
 		return false;
 	}
-	auto other = (OperatorExpression *)other_;
-	if (children.size() != other->children.size()) {
-		return false;
-	}
-	for (index_t i = 0; i < children.size(); i++) {
-		if (!children[i]->Equals(other->children[i].get())) {
+	for (index_t i = 0; i < a->children.size(); i++) {
+		if (!a->children[i]->Equals(b->children[i].get())) {
 			return false;
 		}
 	}

--- a/src/parser/expression/subquery_expression.cpp
+++ b/src/parser/expression/subquery_expression.cpp
@@ -15,18 +15,11 @@ string SubqueryExpression::ToString() const {
 	return "SUBQUERY";
 }
 
-bool SubqueryExpression::Equals(const BaseExpression *other_) const {
-	if (!BaseExpression::Equals(other_)) {
+bool SubqueryExpression::Equals(const SubqueryExpression *a, const SubqueryExpression *b) {
+	if (!a->subquery || !b->subquery) {
 		return false;
 	}
-	auto other = reinterpret_cast<const SubqueryExpression *>(other_);
-	if (!other) {
-		return false;
-	}
-	if (!subquery || !other->subquery) {
-		return false;
-	}
-	return subquery_type == other->subquery_type && subquery->Equals(other->subquery.get());
+	return a->subquery_type == b->subquery_type && a->subquery->Equals(b->subquery.get());
 }
 
 unique_ptr<ParsedExpression> SubqueryExpression::Copy() const {

--- a/src/parser/expression/window_expression.cpp
+++ b/src/parser/expression/window_expression.cpp
@@ -31,50 +31,45 @@ string WindowExpression::ToString() const {
 	return "WINDOW";
 }
 
-bool WindowExpression::Equals(const BaseExpression *other_) const {
-	if (!BaseExpression::Equals(other_)) {
-		return false;
-	}
-	auto other = (WindowExpression *)other_;
-
+bool WindowExpression::Equals(const WindowExpression *a, const WindowExpression *b) {
 	// check if the child expressions are equivalent
-	if (other->children.size() != children.size()) {
+	if (b->children.size() != a->children.size()) {
 		return false;
 	}
-	for (index_t i = 0; i < children.size(); i++) {
-		if (!children[i]->Equals(other->children[i].get())) {
+	for (index_t i = 0; i < a->children.size(); i++) {
+		if (!a->children[i]->Equals(b->children[i].get())) {
 			return false;
 		}
 	}
-	if (start != other->start || end != other->end) {
+	if (a->start != b->start || a->end != b->end) {
 		return false;
 	}
 	// check if the framing expressions are equivalent
-	if (!BaseExpression::Equals(start_expr.get(), other->start_expr.get()) ||
-	    !BaseExpression::Equals(end_expr.get(), other->end_expr.get()) ||
-	    !BaseExpression::Equals(offset_expr.get(), other->offset_expr.get()) ||
-	    !BaseExpression::Equals(default_expr.get(), other->default_expr.get())) {
+	if (!BaseExpression::Equals(a->start_expr.get(), b->start_expr.get()) ||
+	    !BaseExpression::Equals(a->end_expr.get(), b->end_expr.get()) ||
+	    !BaseExpression::Equals(a->offset_expr.get(), b->offset_expr.get()) ||
+	    !BaseExpression::Equals(a->default_expr.get(), b->default_expr.get())) {
 		return false;
 	}
 
 	// check if the partitions are equivalent
-	if (partitions.size() != other->partitions.size()) {
+	if (a->partitions.size() != b->partitions.size()) {
 		return false;
 	}
-	for (index_t i = 0; i < partitions.size(); i++) {
-		if (!partitions[i]->Equals(other->partitions[i].get())) {
+	for (index_t i = 0; i < a->partitions.size(); i++) {
+		if (!a->partitions[i]->Equals(b->partitions[i].get())) {
 			return false;
 		}
 	}
 	// check if the orderings are equivalent
-	if (orders.size() != other->orders.size()) {
+	if (a->orders.size() != b->orders.size()) {
 		return false;
 	}
-	for (index_t i = 0; i < orders.size(); i++) {
-		if (orders[i].type != other->orders[i].type) {
+	for (index_t i = 0; i < a->orders.size(); i++) {
+		if (a->orders[i].type != b->orders[i].type) {
 			return false;
 		}
-		if (!orders[i].expression->Equals(other->orders[i].expression.get())) {
+		if (!a->orders[i].expression->Equals(b->orders[i].expression.get())) {
 			return false;
 		}
 	}

--- a/src/parser/parsed_expression.cpp
+++ b/src/parser/parsed_expression.cpp
@@ -46,6 +46,46 @@ bool ParsedExpression::HasSubquery() const {
 	return has_subquery;
 }
 
+bool ParsedExpression::Equals(const BaseExpression *other) const {
+	if (other->expression_class == ExpressionClass::BOUND_EXPRESSION) {
+		auto bound_expr = (BoundExpression*) other;
+		other = bound_expr->parsed_expr.get();
+	}
+	if (!BaseExpression::Equals(other)) {
+		return false;
+	}
+	switch (expression_class) {
+	case ExpressionClass::CASE:
+		return CaseExpression::Equals((CaseExpression*) this, (CaseExpression*)other);
+	case ExpressionClass::CAST:
+		return CastExpression::Equals((CastExpression*) this, (CastExpression*)other);
+	case ExpressionClass::COLUMN_REF:
+		return ColumnRefExpression::Equals((ColumnRefExpression*) this, (ColumnRefExpression*)other);
+	case ExpressionClass::COMPARISON:
+		return ComparisonExpression::Equals((ComparisonExpression*) this, (ComparisonExpression*)other);
+	case ExpressionClass::CONJUNCTION:
+		return ConjunctionExpression::Equals((ConjunctionExpression*) this, (ConjunctionExpression*)other);
+	case ExpressionClass::CONSTANT:
+		return ConstantExpression::Equals((ConstantExpression*) this, (ConstantExpression*)other);
+	case ExpressionClass::DEFAULT:
+		return true;
+	case ExpressionClass::FUNCTION:
+		return FunctionExpression::Equals((FunctionExpression*) this, (FunctionExpression*)other);
+	case ExpressionClass::OPERATOR:
+		return OperatorExpression::Equals((OperatorExpression*) this, (OperatorExpression*)other);
+	case ExpressionClass::PARAMETER:
+		return true;
+	case ExpressionClass::STAR:
+		return true;
+	case ExpressionClass::SUBQUERY:
+		return SubqueryExpression::Equals((SubqueryExpression*) this, (SubqueryExpression*)other);
+	case ExpressionClass::WINDOW:
+		return WindowExpression::Equals((WindowExpression*) this, (WindowExpression*)other);
+	default:
+		throw SerializationException("Unsupported type for expression deserialization!");
+	}
+}
+
 uint64_t ParsedExpression::Hash() const {
 	uint64_t hash = duckdb::Hash<uint32_t>((uint32_t)type);
 	ParsedExpressionIterator::EnumerateChildren(

--- a/src/parser/query_node.cpp
+++ b/src/parser/query_node.cpp
@@ -19,10 +19,10 @@ bool QueryNode::Equals(const QueryNode *other) const {
 	if (select_distinct != other->select_distinct) {
 		return false;
 	}
-	if (!ParsedExpression::Equals(limit.get(), other->limit.get())) {
+	if (!BaseExpression::Equals(limit.get(), other->limit.get())) {
 		return false;
 	}
-	if (!ParsedExpression::Equals(offset.get(), other->offset.get())) {
+	if (!BaseExpression::Equals(offset.get(), other->offset.get())) {
 		return false;
 	}
 	if (orders.size() != other->orders.size()) {

--- a/src/parser/query_node/select_node.cpp
+++ b/src/parser/query_node/select_node.cpp
@@ -52,7 +52,7 @@ bool SelectNode::Equals(const QueryNode *other_) const {
 		return false;
 	}
 	// WHERE
-	if (!ParsedExpression::Equals(where_clause.get(), other->where_clause.get())) {
+	if (!BaseExpression::Equals(where_clause.get(), other->where_clause.get())) {
 		return false;
 	}
 	// GROUP BY
@@ -63,7 +63,7 @@ bool SelectNode::Equals(const QueryNode *other_) const {
 	}
 
 	// HAVING
-	if (!ParsedExpression::Equals(having.get(), other->having.get())) {
+	if (!BaseExpression::Equals(having.get(), other->having.get())) {
 		return false;
 	}
 	return true;

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -172,7 +172,7 @@ unique_ptr<BoundQueryNode> Binder::Bind(SelectNode &statement) {
 	// i.e. in the query [SELECT i, SUM(i) FROM integers;] the "i" will be bound as a normal column
 	// since we have an aggregation, we need to either (1) throw an error, or (2) wrap the column in a FIRST() aggregate
 	// we choose the former one [CONTROVERSIAL: this is the PostgreSQL behavior]
-	if (result->aggregates.size() > 0) {
+	if (result->groups.size() > 0 || result->aggregates.size() > 0) {
 		if (select_binder.BoundColumns()) {
 			throw BinderException("column must appear in the GROUP BY clause or be used in an aggregate function");
 		}

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -71,6 +71,7 @@ bool ExpressionBinder::BindCorrelatedColumns(unique_ptr<ParsedExpression> &expr)
 	bool success = false;
 	while (active_binders.size() > 0) {
 		auto &next_binder = active_binders.back();
+		next_binder->BindTableNames(*expr);
 		auto bind_result = next_binder->Bind(&expr, depth);
 		if (bind_result.empty()) {
 			success = true;
@@ -149,7 +150,7 @@ string ExpressionBinder::Bind(unique_ptr<ParsedExpression> *expr, index_t depth,
 		return result.error;
 	} else {
 		// successfully bound: replace the node with a BoundExpression
-		*expr = make_unique<BoundExpression>(move(result.expression), result.sql_type);
+		*expr = make_unique<BoundExpression>(move(result.expression), move(*expr), result.sql_type);
 		return string();
 	}
 }

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -51,8 +51,6 @@ index_t SelectBinder::TryBindGroup(ParsedExpression &expr, index_t depth) {
 	}
 #ifdef DEBUG
 	for(auto entry : info.map) {
-		auto hash2 = entry.first->Hash();
-		auto hash = expr.Hash();
 		assert(!entry.first->Equals(&expr));
 		assert(!expr.Equals(entry.first));
 	}

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -49,6 +49,14 @@ index_t SelectBinder::TryBindGroup(ParsedExpression &expr, index_t depth) {
 	if (entry != info.map.end()) {
 		return entry->second;
 	}
+#ifdef DEBUG
+	for(auto entry : info.map) {
+		auto hash2 = entry.first->Hash();
+		auto hash = expr.Hash();
+		assert(!entry.first->Equals(&expr));
+		assert(!expr.Equals(entry.first));
+	}
+#endif
 	return INVALID_INDEX;
 }
 


### PR DESCRIPTION
This was basically a combination of two problems:

(1) If a query had no aggregations but only groups, no error would be thrown if there were column references bound outside of the original grouping columns and the subsequent column resolution would fail.

(2) Binding to the group inside the subquery would not work because BindTableNames() was not called prior to performing the group lookup, leading to `col1` being not equal to `another_T.col1`.

There was also an additional problem found relating to the BoundExpression that would make a composite grouping column not bind properly in subqueries, e.g. the following query would fail to bind:

```sql
SELECT (col1 + 1) IN (SELECT ColID + (col1 + 1) FROM tbl_ProductSales) FROM another_T GROUP BY (col1 + 1);
```

Note that this query actually also fails to bind in PostgreSQL, but SQLite correctly binds it. This I resolved by making the BoundExpression use the underlying ParsedExpression, so now this query also works correctly.