### PR TITLE
Fix cmake build error: No such file or directory

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,5 +1,6 @@
 include_directories(../third_party/catch)
 include_directories(../third_party/tpce-tool/include)
+include_directories(../third_party/sqlite/include)
 include_directories(../test/include)
 include_directories(../tools/dbtransfer/include)
 include_directories(include)


### PR DESCRIPTION
Steps to reproduce on OS Linux:
1) Go to duckdb directory
2) `$ mkdir build`
3) `$ cd build`
4) `$ cmake ..`
5) `$ cmake --build .`

```
duckdb/benchmark/include/sqlite_benchmark.hpp:14:10: fatal error: sqlite3.h: No such file or directory
 #include "sqlite3.h"
          ^~~~~~~~~~~
compilation terminated.
```