### PR TITLE
Fix UB: access uninitialized variable in TransactionContext destructor

### DIFF
--- a/src/include/transaction/transaction_context.hpp
+++ b/src/include/transaction/transaction_context.hpp
@@ -20,7 +20,7 @@ class TransactionManager;
 class TransactionContext {
 public:
 	TransactionContext(TransactionManager &transaction_manager)
-	    : transaction_manager(transaction_manager), auto_commit(true), current_transaction(nullptr) {
+	    : transaction_manager(transaction_manager) {
 	}
 	~TransactionContext();
 
@@ -51,10 +51,10 @@ public:
 
 private:
 	TransactionManager &transaction_manager;
-	bool auto_commit;
-	bool is_invalidated;
+	bool auto_commit = true;
+	bool is_invalidated = false;
 
-	Transaction *current_transaction;
+	Transaction *current_transaction = nullptr;
 
 	TransactionContext(const TransactionContext &) = delete;
 };


### PR DESCRIPTION
There is a situation in which `is_invalidated` can be uninitialized and accessed in `~TransactionContext` call. Valgrind shows the following for `duckdb/examples/embedded-c++/
` example:
```
==4616== Conditional jump or move depends on uninitialised value(s)
==4616==    at 0x50D2DA4: duckdb::TransactionContext::~TransactionContext() (transaction_context.cpp:11)
==4616==    by 0x50A79E1: ~ClientContext (client_context.hpp:26)
==4616==    by 0x50A79E1: operator() (unique_ptr.h:78)
==4616==    by 0x50A79E1: ~unique_ptr (unique_ptr.h:268)
==4616==    by 0x50A79E1: duckdb::Connection::~Connection() (connection.cpp:18)
==4616==    by 0x108F2B: main (main.cpp:7)
```
Reading an uninitialized variable results in undefined behaviour.