### PR TITLE
Rid of redundant copies in getters

### DIFF
--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -127,9 +127,7 @@ ColumnDefinition &TableCatalogEntry::GetColumn(const string &name) {
 
 vector<TypeId> TableCatalogEntry::GetTypes() {
 	vector<TypeId> types;
-	for (auto &it : columns) {
-		types.push_back(GetInternalType(it.type));
-	}
+	transform(columns.begin(), columns.end(), std::back_inserter(types), [](const ColumnDefinition& column){ return GetInternalType(column.type); });
 	return types;
 }
 

--- a/src/catalog/catalog_entry/table_function_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_function_catalog_entry.cpp
@@ -30,8 +30,6 @@ bool TableFunctionCatalogEntry::ColumnExists(const string &name) {
 
 vector<TypeId> TableFunctionCatalogEntry::GetTypes() {
 	vector<TypeId> types;
-	for (auto &type : function.types) {
-		types.push_back(GetInternalType(type));
-	}
+	transform(function.types.begin(), function.types.end(), std::back_inserter(types), [](const SQLType& type) { return GetInternalType(type); });
 	return types;
 }

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -184,7 +184,7 @@ string SQLTypeIdToString(SQLTypeId id) {
 	}
 }
 
-string SQLTypeToString(SQLType type) {
+string SQLTypeToString(const SQLType& type) {
 	// FIXME: display width/scale
 	return SQLTypeIdToString(type.id);
 }
@@ -204,7 +204,7 @@ bool IsNumericType(SQLTypeId type) {
 	}
 }
 
-TypeId GetInternalType(SQLType type) {
+TypeId GetInternalType(const SQLType& type) {
 	switch (type.id) {
 	case SQLTypeId::BOOLEAN:
 		return TypeId::BOOLEAN;

--- a/src/include/common/types.hpp
+++ b/src/include/common/types.hpp
@@ -112,12 +112,12 @@ public:
 bool IsNumericType(SQLTypeId type);
 
 string SQLTypeIdToString(SQLTypeId type);
-string SQLTypeToString(SQLType type);
+string SQLTypeToString(const SQLType& type);
 
 SQLType MaxSQLType(SQLType left, SQLType right);
 
 //! Gets the internal type associated with the given SQL type
-TypeId GetInternalType(SQLType type);
+TypeId GetInternalType(const SQLType& type);
 //! Returns the "simplest" SQL type corresponding to the given type id (e.g. TypeId::INTEGER -> SQLTypeId::INTEGER)
 SQLType SQLTypeFromInternalType(TypeId type);
 


### PR DESCRIPTION
I have found two functions `SQLTypeToString` and `GetInternalType` that when they are called cause redundant copy of their arguments.