### PR TITLE
Fix todo: use unique_lock in Appender to hold mutex lock

### DIFF
--- a/src/include/main/appender.hpp
+++ b/src/include/main/appender.hpp
@@ -11,6 +11,8 @@
 #include "common/types/data_chunk.hpp"
 #include "main/client_context.hpp"
 
+#include <mutex>
+
 namespace duckdb {
 
 class ClientContext;
@@ -28,9 +30,10 @@ class Appender {
 	DataChunk chunk;
 	//! The current column to append to
 	index_t column = 0;
-
+	//! Internal lock for appends
+	std::unique_lock<std::mutex> lock;
 public:
-	Appender(Connection &con, string schema_name, string table_name);
+	Appender(Connection &con, string schema_name, string table_name, std::unique_lock<std::mutex> lock);
 
 	~Appender();
 

--- a/src/include/main/appender.hpp
+++ b/src/include/main/appender.hpp
@@ -30,7 +30,7 @@ class Appender {
 	DataChunk chunk;
 	//! The current column to append to
 	index_t column = 0;
-	//! Internal lock for appends
+	//! Lock holder for appends
 	std::unique_lock<std::mutex> lock;
 
 public:

--- a/src/include/main/appender.hpp
+++ b/src/include/main/appender.hpp
@@ -32,6 +32,7 @@ class Appender {
 	index_t column = 0;
 	//! Internal lock for appends
 	std::unique_lock<std::mutex> lock;
+
 public:
 	Appender(Connection &con, string schema_name, string table_name, std::unique_lock<std::mutex> lock);
 

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -9,7 +9,7 @@
 using namespace duckdb;
 using namespace std;
 
-Appender::Appender(Connection &con, string schema_name, string table_name) : con(con), table_entry(nullptr), column(0) {
+Appender::Appender(Connection &con, string schema_name, string table_name, unique_lock<mutex> lock) : con(con), table_entry(nullptr), column(0), lock(std::move(lock)) {
 
 	table_entry = con.db.catalog->GetTable(con.context->transaction.ActiveTransaction(), schema_name, table_name);
 


### PR DESCRIPTION
My proposal is to use unique_lock to hold mutex lock inside object of `Appender` class. Unlock will be done in `Appender` destructor. Please review this Pull Request.