### PR TITLE
Fix dbtransfer and add unittests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,7 @@ include_directories(../third_party/catch)
 include_directories(../third_party/dbgen/include)
 include_directories(../third_party/tpce-tool/include)
 include_directories(../third_party/sqlite/include)
+include_directories(../tools/dbtransfer/include)
 include_directories(include)
 
 add_subdirectory(api)
@@ -20,6 +21,7 @@ if(NOT WIN32)
   add_subdirectory(sqlsmith)
   add_subdirectory(tpce)
   add_subdirectory(persistence)
+  add_subdirectory(dbtransfer)
 endif()
 
 add_executable(unittest unittest.cpp ${ALL_OBJECT_FILES})
@@ -30,7 +32,8 @@ if(NOT WIN32)
                         dbgen
                         dsdgen
                         test_helpers
-                        tpce)
+                        tpce
+                        sqlite_transfer)
 else()
   target_link_libraries(unittest duckdb_static test_helpers)
 endif()

--- a/test/dbtransfer/CMakeLists.txt
+++ b/test/dbtransfer/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library_unity(test_dbtransfer OBJECT test_dbtransfer.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:test_dbtransfer>
+    PARENT_SCOPE)

--- a/test/dbtransfer/test_dbtransfer.cpp
+++ b/test/dbtransfer/test_dbtransfer.cpp
@@ -112,6 +112,8 @@ TEST_CASE("Check getting query from sqlite database", "[dbtransfer]") {
     int interrupt = 0;
     auto result = sqlite::QueryDatabase(result_types, source_db, std::move(query), interrupt);
 
+    sqlite3_close(source_db);
+
     REQUIRE(result->success);
     REQUIRE(CHECK_COLUMN(result, 0, {"a", "b", "c", "d", "e"}));
     REQUIRE(CHECK_COLUMN(result, 1, {1, 2, 3, 4, 5}));

--- a/test/dbtransfer/test_dbtransfer.cpp
+++ b/test/dbtransfer/test_dbtransfer.cpp
@@ -20,13 +20,13 @@ TEST_CASE("Check transfer from DuckDB to sqlite database", "[dbtransfer]") {
 	duckdb::Connection con(source_db);
 
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE items(field1 VARCHAR, field2 INTEGER)"));
-	con.Query("INSERT INTO items VALUES ('a', 1)");
-	con.Query("INSERT INTO items VALUES ('b', 2)");
-	con.Query("INSERT INTO items VALUES ('c', 3)");
-	con.Query("INSERT INTO items VALUES ('d', 4)");
-    con.Query("INSERT INTO items VALUES ('e', 5)");
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO items VALUES ('a', 1)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO items VALUES ('b', 2)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO items VALUES ('c', 3)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO items VALUES ('d', 4)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO items VALUES ('e', 5)"));
 
-    sqlite3 *destination_db = nullptr;
+	sqlite3 *destination_db = nullptr;
 	if (sqlite3_open(":memory:", &destination_db) != SQLITE_OK) {
         REQUIRE(false);
 		return;

--- a/test/dbtransfer/test_dbtransfer.cpp
+++ b/test/dbtransfer/test_dbtransfer.cpp
@@ -9,28 +9,28 @@
 #include <sstream>
 
 TEST_CASE("Pass nullptr to transfer function", "[dbtransfer]") {
-	duckdb::DuckDB source_db(nullptr);
-	duckdb::Connection con(source_db);
+    duckdb::DuckDB source_db(nullptr);
+    duckdb::Connection con(source_db);
 
     REQUIRE_FALSE(sqlite::TransferDatabase(con, nullptr));
 }
 
 TEST_CASE("Check transfer from DuckDB to sqlite database", "[dbtransfer]") {
-	duckdb::DuckDB source_db(nullptr);
-	duckdb::Connection con(source_db);
+    duckdb::DuckDB source_db(nullptr);
+    duckdb::Connection con(source_db);
 
-	REQUIRE_NO_FAIL(con.Query("CREATE TABLE items(field1 VARCHAR, field2 INTEGER)"));
-	REQUIRE_NO_FAIL(con.Query("INSERT INTO items VALUES ('a', 1)"));
-	REQUIRE_NO_FAIL(con.Query("INSERT INTO items VALUES ('b', 2)"));
-	REQUIRE_NO_FAIL(con.Query("INSERT INTO items VALUES ('c', 3)"));
-	REQUIRE_NO_FAIL(con.Query("INSERT INTO items VALUES ('d', 4)"));
-	REQUIRE_NO_FAIL(con.Query("INSERT INTO items VALUES ('e', 5)"));
+    REQUIRE_NO_FAIL(con.Query("CREATE TABLE items(field1 VARCHAR, field2 INTEGER)"));
+    REQUIRE_NO_FAIL(con.Query("INSERT INTO items VALUES ('a', 1)"));
+    REQUIRE_NO_FAIL(con.Query("INSERT INTO items VALUES ('b', 2)"));
+    REQUIRE_NO_FAIL(con.Query("INSERT INTO items VALUES ('c', 3)"));
+    REQUIRE_NO_FAIL(con.Query("INSERT INTO items VALUES ('d', 4)"));
+    REQUIRE_NO_FAIL(con.Query("INSERT INTO items VALUES ('e', 5)"));
 
-	sqlite3 *destination_db = nullptr;
-	if (sqlite3_open(":memory:", &destination_db) != SQLITE_OK) {
+    sqlite3 *destination_db = nullptr;
+    if (sqlite3_open(":memory:", &destination_db) != SQLITE_OK) {
         REQUIRE(false);
-		return;
-	}
+        return;
+    }
     
     REQUIRE(sqlite::TransferDatabase(con, destination_db));
 
@@ -59,7 +59,7 @@ TEST_CASE("Check transfer from DuckDB to sqlite database", "[dbtransfer]") {
         sqlite3_close(destination_db);
         
         REQUIRE(false);
-		return;
+        return;
     } 
     
     sqlite3_close(destination_db);
@@ -76,10 +76,10 @@ TEST_CASE("Pass pointer to sqlite3 as nullptr to QueryDatabase", "[dbtransfer]")
 }
 
 TEST_CASE("Check getting query from sqlite database", "[dbtransfer]") {
-    sqlite3 *source_db = nullptr;
-	if (sqlite3_open(":memory:", &source_db) != SQLITE_OK) {
+     sqlite3 *source_db = nullptr;
+     if (sqlite3_open(":memory:", &source_db) != SQLITE_OK) {
         REQUIRE(false);
-		return;
+        return;
     }
 
     const char *sql_create_table = "CREATE TABLE items (field1 VARCHAR, field2 INTEGER)";
@@ -90,7 +90,7 @@ TEST_CASE("Check getting query from sqlite database", "[dbtransfer]") {
         sqlite3_close(source_db);
 
         REQUIRE(false);
-		return;
+        return;
     }
 
     // Inserting 5 rows in sqlite db

--- a/test/dbtransfer/test_dbtransfer.cpp
+++ b/test/dbtransfer/test_dbtransfer.cpp
@@ -1,0 +1,120 @@
+#include "sqlite_transfer.hpp"
+#include "common/types.hpp"
+#include "duckdb.hpp"
+#include "sqlite3.h"
+#include "catch.hpp"
+#include "test_helpers.hpp"
+
+#include <string>
+#include <sstream>
+
+TEST_CASE("Pass nullptr to transfer function", "[dbtransfer]") {
+	duckdb::DuckDB source_db(nullptr);
+	duckdb::Connection con(source_db);
+
+    REQUIRE_FALSE(sqlite::TransferDatabase(con, nullptr));
+}
+
+TEST_CASE("Check transfer from DuckDB to sqlite database", "[dbtransfer]") {
+	duckdb::DuckDB source_db(nullptr);
+	duckdb::Connection con(source_db);
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE items(field1 VARCHAR, field2 INTEGER)"));
+	con.Query("INSERT INTO items VALUES ('a', 1)");
+	con.Query("INSERT INTO items VALUES ('b', 2)");
+	con.Query("INSERT INTO items VALUES ('c', 3)");
+	con.Query("INSERT INTO items VALUES ('d', 4)");
+    con.Query("INSERT INTO items VALUES ('e', 5)");
+
+    sqlite3 *destination_db = nullptr;
+	if (sqlite3_open(":memory:", &destination_db) != SQLITE_OK) {
+        REQUIRE(false);
+		return;
+	}
+    
+    REQUIRE(sqlite::TransferDatabase(con, destination_db));
+
+    const char *sql = "SELECT field1, field2 FROM items";
+    auto check_callback = [](void *unused, int argc, char **values, char **columns) {
+        static char field1 = 'a';
+        static char field2 = '1';
+        unused = 0;
+
+        REQUIRE(strcmp(columns[0], "field1") == 0);
+        REQUIRE(strcmp(columns[1], "field2") == 0);
+        char f1[2] = {field1, '\0'};
+        REQUIRE(strcmp(values[0], f1) == 0);
+        char f2[2] = {field2, '\0'};
+        REQUIRE(strcmp(values[1], f2) == 0);
+
+        ++field1;
+        ++field2;
+
+        return 0;
+    };
+    char *err = 0;
+
+    if (sqlite3_exec(destination_db, sql, check_callback, 0, &err) != SQLITE_OK) {
+        sqlite3_free(err);
+        sqlite3_close(destination_db);
+        
+        REQUIRE(false);
+		return;
+    } 
+    
+    sqlite3_close(destination_db);
+}
+
+TEST_CASE("Pass pointer to sqlite3 as nullptr to QueryDatabase", "[dbtransfer]") {
+    duckdb::vector<duckdb::SQLType> result_types = { duckdb::SQLTypeId::VARCHAR,
+                                                     duckdb::SQLTypeId::INTEGER };
+    std::string query = "SELECT * from items";
+    int interrupt = 0;
+    auto result = sqlite::QueryDatabase(result_types, nullptr, std::move(query), interrupt);
+
+    REQUIRE_FALSE(result);
+}
+
+TEST_CASE("Check getting query from sqlite database", "[dbtransfer]") {
+    sqlite3 *source_db = nullptr;
+	if (sqlite3_open(":memory:", &source_db) != SQLITE_OK) {
+        REQUIRE(false);
+		return;
+    }
+
+    const char *sql_create_table = "CREATE TABLE items (field1 VARCHAR, field2 INTEGER)";
+    auto empty_callback = [](void*, int, char**, char**){ return 0; };
+    char *err = 0;
+    if (sqlite3_exec(source_db, sql_create_table, empty_callback, 0, &err) != SQLITE_OK) {
+        sqlite3_free(err);
+        sqlite3_close(source_db);
+
+        REQUIRE(false);
+		return;
+    }
+
+    // Inserting 5 rows in sqlite db
+    char field1 = 'a';
+    char field2 = '1';
+    for (int i = 0; i < 5; ++i, ++field1, ++field2) {
+        std::ostringstream sql_insert;
+        sql_insert << "INSERT INTO items VALUES ('" << field1 << "', " << field2 << ")";
+        if (sqlite3_exec(source_db, sql_insert.str().c_str(), empty_callback, 0, &err) != SQLITE_OK) {
+            sqlite3_free(err);
+            sqlite3_close(source_db);
+
+            REQUIRE(false);
+            return;
+        }
+    }
+
+    duckdb::vector<duckdb::SQLType> result_types = { duckdb::SQLTypeId::VARCHAR,
+                                                     duckdb::SQLTypeId::INTEGER };
+    std::string query = "SELECT * from items";
+    int interrupt = 0;
+    auto result = sqlite::QueryDatabase(result_types, source_db, std::move(query), interrupt);
+
+    REQUIRE(result->success);
+    REQUIRE(CHECK_COLUMN(result, 0, {"a", "b", "c", "d", "e"}));
+    REQUIRE(CHECK_COLUMN(result, 1, {1, 2, 3, 4, 5}));
+}

--- a/test/dbtransfer/test_dbtransfer.cpp
+++ b/test/dbtransfer/test_dbtransfer.cpp
@@ -70,9 +70,7 @@ TEST_CASE("Pass pointer to sqlite3 as nullptr to QueryDatabase", "[dbtransfer]")
                                                      duckdb::SQLTypeId::INTEGER };
     std::string query = "SELECT * from items";
     int interrupt = 0;
-    auto result = sqlite::QueryDatabase(result_types, nullptr, std::move(query), interrupt);
-
-    REQUIRE_FALSE(result);
+    REQUIRE_FALSE(sqlite::QueryDatabase(result_types, nullptr, std::move(query), interrupt));
 }
 
 TEST_CASE("Check getting query from sqlite database", "[dbtransfer]") {

--- a/tools/dbtransfer/sqlite_transfer.cpp
+++ b/tools/dbtransfer/sqlite_transfer.cpp
@@ -119,18 +119,20 @@ unique_ptr<QueryResult> QueryDatabase(vector<SQLType> result_types, sqlite3 *sql
 	if (sqlite3_prepare_v2(sqlite, query.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
 		return nullptr;
 	}
-	// construct the result
-	auto result = make_unique<MaterializedQueryResult>(StatementType::SELECT);
+	int col_count = sqlite3_column_count(stmt);
+	vector<string> names;
+	for (int i = 0; i < col_count; i++) {
+		names.push_back(sqlite3_column_name(stmt, i));
+	}
 	// figure out the types of the columns
 	// construct the types of the result
-	int col_count = sqlite3_column_count(stmt);
-	for (int i = 0; i < col_count; i++) {
-		result->names.push_back(sqlite3_column_name(stmt, i));
-	}
 	vector<TypeId> typeids;
 	for (auto &tp : result_types) {
 		typeids.push_back(GetInternalType(tp));
 	}
+
+	// construct the result
+	auto result = make_unique<MaterializedQueryResult>(StatementType::SELECT, result_types, typeids, std::move(names));
 	DataChunk result_chunk;
 	result_chunk.Initialize(typeids);
 	int rc = SQLITE_ERROR;


### PR DESCRIPTION
I have implemented several tests for `dbtransfer` tool and made several fixes in `QueryDatabase`: add passing `result_types` and `typeids` to `result` object of `MaterializedQueryResult` type.