### PR TITLE
add C-API duckdb_bind_null

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -149,6 +149,7 @@ duckdb_state duckdb_bind_int64(duckdb_prepared_statement prepared_statement, ind
 duckdb_state duckdb_bind_float(duckdb_prepared_statement prepared_statement, index_t param_idx, float val);
 duckdb_state duckdb_bind_double(duckdb_prepared_statement prepared_statement, index_t param_idx, double val);
 duckdb_state duckdb_bind_varchar(duckdb_prepared_statement prepared_statement, index_t param_idx, const char *val);
+duckdb_state duckdb_bind_null(duckdb_prepared_statement prepared_statement, index_t param_idx);
 
 //! Executes the prepared statements with currently bound parameters
 duckdb_state duckdb_execute_prepared(duckdb_prepared_statement prepared_statement, duckdb_result *out_result);

--- a/src/main/duckdb-c.cpp
+++ b/src/main/duckdb-c.cpp
@@ -353,6 +353,10 @@ duckdb_state duckdb_bind_varchar(duckdb_prepared_statement prepared_statement, i
 	return duckdb_bind_value(prepared_statement, param_idx, Value(val));
 }
 
+duckdb_state duckdb_bind_null(duckdb_prepared_statement prepared_statement, index_t param_idx) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value());
+}
+
 duckdb_state duckdb_execute_prepared(duckdb_prepared_statement prepared_statement, duckdb_result *out_result) {
 	auto wrapper = (PreparedStatementWrapper *)prepared_statement;
 	if (!wrapper || !wrapper->statement || !wrapper->statement->success || wrapper->statement->is_invalidated) {

--- a/test/sql/capi/test_capi.cpp
+++ b/test/sql/capi/test_capi.cpp
@@ -383,6 +383,12 @@ TEST_CASE("Test prepared statements in C API", "[capi]") {
 	REQUIRE(duckdb_value_int64(&res, 0, 0) == 44);
 	duckdb_destroy_result(&res);
 
+	duckdb_bind_null(stmt, 1);
+	status = duckdb_execute_prepared(stmt, &res);
+	REQUIRE(status == DuckDBSuccess);
+	REQUIRE(res.columns[0].nullmask[0] == true);
+	duckdb_destroy_result(&res);
+
 	duckdb_destroy_prepare(&stmt);
 	// again to make sure it does not crash
 	duckdb_destroy_result(&res);


### PR DESCRIPTION
It seems to me there is no way to bind null value with prepared statement in C-API.

This PR adds duckdb_bind_null C-API to bind null value with prepaered statement.