### PR TITLE
Efficient CSV Reader and Benchmark Data Re-Use

### DIFF
--- a/benchmark/benchmark_runner.cpp
+++ b/benchmark/benchmark_runner.cpp
@@ -2,11 +2,14 @@
 
 #include "duckdb/common/profiler.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb.hpp"
 
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
 #include "re2/re2.h"
 
+#include <fstream>
+#include <sstream>
 #include <thread>
 
 using namespace duckdb;
@@ -20,6 +23,78 @@ Benchmark::Benchmark(bool register_benchmark, string name, string group) : name(
 	if (register_benchmark) {
 		BenchmarkRunner::RegisterBenchmark(this);
 	}
+}
+
+void BenchmarkRunner::SaveDatabase(DuckDB &db, string name) {
+	auto &fs = *db.file_system;
+	// check if the database directory exists; if not create it
+	if (!fs.DirectoryExists(DUCKDB_BENCHMARK_DIRECTORY)) {
+		fs.CreateDirectory(DUCKDB_BENCHMARK_DIRECTORY);
+	}
+	// first export the schema
+	// create two files, "[name].sql" and "[name].list"
+	// [name].sql contains the SQL used to re-create the tables
+	// [name].list contains a list of the exported tables
+	ofstream sql_file(fs.JoinPath(DUCKDB_BENCHMARK_DIRECTORY, name + ".sql"));
+	ofstream list_file(fs.JoinPath(DUCKDB_BENCHMARK_DIRECTORY, name + ".list"));
+
+	vector<string> table_list;
+	Connection con(db);
+	auto result = con.Query("SELECT name, sql FROM sqlite_master()");
+	for(auto &row : *result) {
+		auto table_name = row.GetValue<string>(0);
+		auto table_sql = row.GetValue<string>(1);
+		table_list.push_back(table_name);
+
+		list_file << table_name << std::endl;
+		sql_file << table_sql << std::endl;
+	}
+	sql_file.close();
+	list_file.close();
+
+	// now for each table, write it to a separate file "[name]_[tablename].csv"
+	for(auto &table : table_list) {
+		auto target_path = fs.JoinPath(DUCKDB_BENCHMARK_DIRECTORY, name + "_" + table + ".csv");
+		result = con.Query("COPY " + table + " TO '" + target_path + "'");
+		if (!result->success) {
+			throw Exception("Failed to save database: " + result->error);
+		}
+	}
+}
+
+bool BenchmarkRunner::TryLoadDatabase(DuckDB &db, string name) {
+	auto &fs = *db.file_system;
+	if (!fs.DirectoryExists(DUCKDB_BENCHMARK_DIRECTORY)) {
+		return false;
+	}
+	auto sql_fname = fs.JoinPath(DUCKDB_BENCHMARK_DIRECTORY, name + ".sql");
+	auto list_fname = fs.JoinPath(DUCKDB_BENCHMARK_DIRECTORY, name + ".list");
+	// check if the [name].list and [name].sql files exist
+	if (!fs.FileExists(list_fname) || !fs.FileExists(sql_fname)) {
+		return false;
+	}
+	Connection con(db);
+	// the files exist, load the data into the database
+	// first load the entire SQL and execute it
+	ifstream sql_file(sql_fname);
+	std::stringstream buffer;
+	buffer << sql_file.rdbuf();
+	auto result = con.Query(buffer.str());
+	if (!result->success) {
+		throw Exception("Failed to load database: " + result->error);
+	}
+	// now read the tables line by line
+	ifstream list_file(list_fname);
+	string table_name;
+	while (getline(list_file, table_name)) {
+		// for each table, copy the files
+		auto target_path = fs.JoinPath(DUCKDB_BENCHMARK_DIRECTORY, name + "_" + table_name + ".csv");
+		result = con.Query("COPY " + table_name + " FROM '" + target_path + "'");
+		if (!result->success) {
+			throw Exception("Failed to load database: " + result->error);
+		}
+	}
+	return true;
 }
 
 volatile bool is_active = false;
@@ -133,7 +208,7 @@ void print_help() {
 	fprintf(stderr, "              --info         Prints info about the benchmark\n");
 	fprintf(stderr, "              --group        Prints group name of the benchmark\n");
 	fprintf(stderr, "              [name_pattern] Run only the benchmark which names match the specified name pattern, "
-	                "e.g., DS.* for TPC-DS benchmarks\n");
+					"e.g., DS.* for TPC-DS benchmarks\n");
 }
 
 enum class BenchmarkMetaType {

--- a/benchmark/benchmark_runner.cpp
+++ b/benchmark/benchmark_runner.cpp
@@ -41,7 +41,7 @@ void BenchmarkRunner::SaveDatabase(DuckDB &db, string name) {
 	vector<string> table_list;
 	Connection con(db);
 	auto result = con.Query("SELECT name, sql FROM sqlite_master()");
-	for(auto &row : *result) {
+	for (auto &row : *result) {
 		auto table_name = row.GetValue<string>(0);
 		auto table_sql = row.GetValue<string>(1);
 		table_list.push_back(table_name);
@@ -53,7 +53,7 @@ void BenchmarkRunner::SaveDatabase(DuckDB &db, string name) {
 	list_file.close();
 
 	// now for each table, write it to a separate file "[name]_[tablename].csv"
-	for(auto &table : table_list) {
+	for (auto &table : table_list) {
 		auto target_path = fs.JoinPath(DUCKDB_BENCHMARK_DIRECTORY, name + "_" + table + ".csv");
 		result = con.Query("COPY " + table + " TO '" + target_path + "'");
 		if (!result->success) {
@@ -208,14 +208,10 @@ void print_help() {
 	fprintf(stderr, "              --info         Prints info about the benchmark\n");
 	fprintf(stderr, "              --group        Prints group name of the benchmark\n");
 	fprintf(stderr, "              [name_pattern] Run only the benchmark which names match the specified name pattern, "
-					"e.g., DS.* for TPC-DS benchmarks\n");
+	                "e.g., DS.* for TPC-DS benchmarks\n");
 }
 
-enum class BenchmarkMetaType {
-	NONE,
-	INFO,
-	GROUP
-};
+enum class BenchmarkMetaType { NONE, INFO, GROUP };
 
 struct BenchmarkConfiguration {
 	std::string name_pattern{};

--- a/benchmark/include/benchmark_runner.hpp
+++ b/benchmark/include/benchmark_runner.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/fstream.hpp"
 
 namespace duckdb {
+class DuckDB;
 
 //! The benchmark runner class is responsible for running benchmarks
 class BenchmarkRunner {
@@ -22,10 +23,17 @@ class BenchmarkRunner {
 	}
 
 public:
+	static constexpr const char* DUCKDB_BENCHMARK_DIRECTORY = "duckdb_benchmark_data";
+
 	static BenchmarkRunner &GetInstance() {
 		static BenchmarkRunner instance;
 		return instance;
 	}
+
+	//! Save the current database state, exporting it to a set of CSVs in the DUCKDB_BENCHMARK_DIRECTORY directory
+	static void SaveDatabase(DuckDB &db, string name);
+	//! Try to initialize the database from the DUCKDB_BENCHMARK_DIRECTORY
+	static bool TryLoadDatabase(DuckDB &db, string name);
 
 	//! Register a benchmark in the Benchmark Runner, this is done automatically
 	//! as long as the proper macro's are used

--- a/benchmark/include/benchmark_runner.hpp
+++ b/benchmark/include/benchmark_runner.hpp
@@ -23,7 +23,7 @@ class BenchmarkRunner {
 	}
 
 public:
-	static constexpr const char* DUCKDB_BENCHMARK_DIRECTORY = "duckdb_benchmark_data";
+	static constexpr const char *DUCKDB_BENCHMARK_DIRECTORY = "duckdb_benchmark_data";
 
 	static BenchmarkRunner &GetInstance() {
 		static BenchmarkRunner instance;

--- a/benchmark/tpcds/sf1.cpp
+++ b/benchmark/tpcds/sf1.cpp
@@ -10,7 +10,10 @@ using namespace std;
 
 #define TPCDS_QUERY_BODY(QNR)                                                                                          \
 	virtual void Load(DuckDBBenchmarkState *state) {                                                                   \
-		tpcds::dbgen(SF, state->db);                                                                                   \
+		if (!BenchmarkRunner::TryLoadDatabase(state->db, "tpcds")) {                                                   \
+			tpcds::dbgen(SF, state->db);                                                                               \
+			BenchmarkRunner::SaveDatabase(state->db, "tpcds");                                                         \
+		}                                                                                                              \
 	}                                                                                                                  \
 	virtual string GetQuery() {                                                                                        \
 		return tpcds::get_query(QNR);                                                                                  \

--- a/benchmark/tpch/read_lineitem.cpp
+++ b/benchmark/tpch/read_lineitem.cpp
@@ -46,6 +46,44 @@ string BenchmarkInfo() override {
 }
 FINISH_BENCHMARK(ReadLineitemCSV)
 
+DUCKDB_BENCHMARK(ReadLineitemCSVUnicode, "[csv]")
+int64_t count = 0;
+void Load(DuckDBBenchmarkState *state) override {
+	// load the data into the tpch schema
+	state->conn.Query("CREATE SCHEMA tpch");
+	tpch::dbgen(SF, state->db, "tpch");
+	// create the CSV file
+	auto result = state->conn.Query("COPY tpch.lineitem TO 'lineitem_unicode.csv' DELIMITER '🦆' HEADER");
+	assert(result->success);
+	count = result->collection.chunks[0]->data[0].GetValue(0).GetNumericValue();
+	// delete the database
+	state->conn.Query("DROP SCHEMA tpch CASCADE");
+	// create the empty schema to load into
+	tpch::dbgen(0, state->db);
+}
+string GetQuery() override {
+	return "COPY lineitem FROM 'lineitem_unicode.csv' DELIMITER '🦆' HEADER";
+}
+void Cleanup(DuckDBBenchmarkState *state) override {
+	state->conn.Query("DROP TABLE lineitem");
+	tpch::dbgen(0, state->db);
+}
+string VerifyResult(QueryResult *result) override {
+	if (!result->success) {
+		return result->error;
+	}
+	auto &materialized = (MaterializedQueryResult &)*result;
+	auto expected_count = materialized.collection.chunks[0]->data[0].GetValue(0).GetNumericValue();
+	if (expected_count != count) {
+		return StringUtil::Format("Count mismatch, expected %lld elements but got %lld", count, expected_count);
+	}
+	return string();
+}
+string BenchmarkInfo() override {
+	return "Read the lineitem table from SF 0.1 from CSV format";
+}
+FINISH_BENCHMARK(ReadLineitemCSVUnicode)
+
 DUCKDB_BENCHMARK(WriteLineitemCSV, "[csv]")
 void Load(DuckDBBenchmarkState *state) override {
 	// load the data into the tpch schema

--- a/benchmark/tpch/sf1.cpp
+++ b/benchmark/tpch/sf1.cpp
@@ -10,7 +10,10 @@ using namespace std;
 
 #define TPCH_QUERY_BODY(QNR)                                                                                           \
 	virtual void Load(DuckDBBenchmarkState *state) {                                                                   \
-		tpch::dbgen(SF, state->db);                                                                                    \
+		if (!BenchmarkRunner::TryLoadDatabase(state->db, "tpch")) {                                                    \
+			tpch::dbgen(SF, state->db);                                                                                \
+			BenchmarkRunner::SaveDatabase(state->db, "tpch");                                                          \
+		}                                                                                                              \
 	}                                                                                                                  \
 	virtual string GetQuery() {                                                                                        \
 		return tpch::get_query(QNR);                                                                                   \

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -215,7 +215,7 @@ template <> Value Value::CreateValue(double value) {
 //===--------------------------------------------------------------------===//
 // GetValue
 //===--------------------------------------------------------------------===//
-template<class T> T Value::GetValueInternal() {
+template <class T> T Value::GetValueInternal() {
 	if (is_null) {
 		return NullValue<T>();
 	}
@@ -235,7 +235,7 @@ template<class T> T Value::GetValueInternal() {
 	case TypeId::DOUBLE:
 		return Cast::Operation<double, T>(value_.double_);
 	case TypeId::VARCHAR:
-		return Cast::Operation<const char*, T>(str_value.c_str());
+		return Cast::Operation<const char *, T>(str_value.c_str());
 	default:
 		throw NotImplementedException("Unimplemented type for GetValue()");
 	}
@@ -265,7 +265,6 @@ template <> float Value::GetValue() {
 template <> double Value::GetValue() {
 	return GetValueInternal<double>();
 }
-
 
 Value Value::Numeric(TypeId type, int64_t value) {
 	assert(!TypeIsIntegral(type) ||

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/serializer.hpp"
 #include "duckdb/common/types/date.hpp"
+#include "duckdb/common/types/null_value.hpp"
 #include "duckdb/common/types/time.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/types/vector.hpp"
@@ -172,6 +173,9 @@ Value Value::TIMESTAMP(int32_t year, int32_t month, int32_t day, int32_t hour, i
 	return Value::TIMESTAMP(Date::FromDate(year, month, day), Time::FromTime(hour, min, sec, msec));
 }
 
+//===--------------------------------------------------------------------===//
+// CreateValue
+//===--------------------------------------------------------------------===//
 template <> Value Value::CreateValue(bool value) {
 	return Value::BOOLEAN(value);
 }
@@ -207,6 +211,61 @@ template <> Value Value::CreateValue(float value) {
 template <> Value Value::CreateValue(double value) {
 	return Value::DOUBLE(value);
 }
+
+//===--------------------------------------------------------------------===//
+// GetValue
+//===--------------------------------------------------------------------===//
+template<class T> T Value::GetValueInternal() {
+	if (is_null) {
+		return NullValue<T>();
+	}
+	switch (type) {
+	case TypeId::BOOLEAN:
+		return Cast::Operation<bool, T>(value_.boolean);
+	case TypeId::TINYINT:
+		return Cast::Operation<int8_t, T>(value_.tinyint);
+	case TypeId::SMALLINT:
+		return Cast::Operation<int16_t, T>(value_.smallint);
+	case TypeId::INTEGER:
+		return Cast::Operation<int32_t, T>(value_.integer);
+	case TypeId::BIGINT:
+		return Cast::Operation<int64_t, T>(value_.bigint);
+	case TypeId::FLOAT:
+		return Cast::Operation<float, T>(value_.float_);
+	case TypeId::DOUBLE:
+		return Cast::Operation<double, T>(value_.double_);
+	case TypeId::VARCHAR:
+		return Cast::Operation<const char*, T>(str_value.c_str());
+	default:
+		throw NotImplementedException("Unimplemented type for GetValue()");
+	}
+}
+
+template <> bool Value::GetValue() {
+	return GetValueInternal<bool>();
+}
+template <> int8_t Value::GetValue() {
+	return GetValueInternal<int8_t>();
+}
+template <> int16_t Value::GetValue() {
+	return GetValueInternal<int16_t>();
+}
+template <> int32_t Value::GetValue() {
+	return GetValueInternal<int32_t>();
+}
+template <> int64_t Value::GetValue() {
+	return GetValueInternal<int64_t>();
+}
+template <> string Value::GetValue() {
+	return GetValueInternal<string>();
+}
+template <> float Value::GetValue() {
+	return GetValueInternal<float>();
+}
+template <> double Value::GetValue() {
+	return GetValueInternal<double>();
+}
+
 
 Value Value::Numeric(TypeId type, int64_t value) {
 	assert(!TypeIsIntegral(type) ||

--- a/src/execution/operator/persistent/buffered_csv_reader.cpp
+++ b/src/execution/operator/persistent/buffered_csv_reader.cpp
@@ -24,14 +24,14 @@ TextSearchShiftArray::TextSearchShiftArray(string search_term) : length(search_t
 	shifts = unique_ptr<uint8_t[]>(new uint8_t[length * 255]);
 	memset(shifts.get(), 0, length * 255 * sizeof(uint8_t));
 	// iterate over each of the characters in the array
-	for(index_t main_idx = 0; main_idx < length; main_idx++) {
-		uint8_t current_char = (uint8_t) search_term[main_idx];
+	for (index_t main_idx = 0; main_idx < length; main_idx++) {
+		uint8_t current_char = (uint8_t)search_term[main_idx];
 		// now move over all the remaining positions
-		for(index_t i = main_idx; i < length; i++) {
+		for (index_t i = main_idx; i < length; i++) {
 			bool is_match = true;
 			// check if the prefix matches at this position
 			// if it does, we move to this position after encountering the current character
-			for(index_t j = 0; j < main_idx; j++) {
+			for (index_t j = 0; j < main_idx; j++) {
 				if (search_term[i - main_idx + j] != search_term[j]) {
 					is_match = false;
 				}
@@ -46,7 +46,7 @@ TextSearchShiftArray::TextSearchShiftArray(string search_term) : length(search_t
 
 BufferedCSVReader::BufferedCSVReader(CopyInfo &info, vector<SQLType> sql_types, istream &source)
     : info(info), sql_types(sql_types), source(source), buffer_size(0), position(0), start(0),
-	  delimiter_search(info.delimiter), escape_search(info.escape), quote_search(info.quote) {
+      delimiter_search(info.delimiter), escape_search(info.escape), quote_search(info.quote) {
 	if (info.force_not_null.size() == 0) {
 		info.force_not_null.resize(sql_types.size(), false);
 	}
@@ -94,7 +94,7 @@ value_start:
 	quote_pos = 0;
 	do {
 		index_t count = 0;
-		for(; position < buffer_size; position++) {
+		for (; position < buffer_size; position++) {
 			quote_search.Match(quote_pos, buffer[position]);
 			delimiter_search.Match(delimiter_pos, buffer[position]);
 			count++;
@@ -124,7 +124,7 @@ normal:
 	// this state parses the remainder of a non-quoted value until we reach a delimiter or newline
 	position++;
 	do {
-		for(; position < buffer_size; position++) {
+		for (; position < buffer_size; position++) {
 			delimiter_search.Match(delimiter_pos, buffer[position]);
 			if (delimiter_pos == info.delimiter.size()) {
 				offset = info.delimiter.size() - 1;
@@ -144,7 +144,7 @@ add_value:
 		goto final_state;
 	}
 	goto value_start;
-add_row: {
+add_row : {
 	// check type of newline (\r or \n)
 	bool carriage_return = buffer[position] == '\r';
 	AddValue(buffer.get() + start, position - start - offset, column, escape_positions);
@@ -173,7 +173,7 @@ in_quotes:
 	escape_pos = 0;
 	position++;
 	do {
-		for(; position < buffer_size; position++) {
+		for (; position < buffer_size; position++) {
 			quote_search.Match(quote_pos, buffer[position]);
 			escape_search.Match(escape_pos, buffer[position]);
 			if (quote_pos == info.quote.size()) {
@@ -205,12 +205,14 @@ unquote:
 	}
 	do {
 		index_t count = 0;
-		for(; position < buffer_size; position++) {
+		for (; position < buffer_size; position++) {
 			quote_search.Match(quote_pos, buffer[position]);
 			delimiter_search.Match(delimiter_pos, buffer[position]);
 			count++;
 			if (count > delimiter_pos && count > quote_pos) {
-				throw ParserException("Error on line %lld: quote should be followed by end of value, end of row or another quote", linenr);
+				throw ParserException(
+				    "Error on line %lld: quote should be followed by end of value, end of row or another quote",
+				    linenr);
 			}
 			if (delimiter_pos == info.delimiter.size()) {
 				// quote followed by delimiter, add value
@@ -223,20 +225,20 @@ unquote:
 			}
 		}
 	} while (ReadBuffer(start));
-	throw ParserException("Error on line %lld: quote should be followed by end of value, end of row or another quote", linenr);
+	throw ParserException("Error on line %lld: quote should be followed by end of value, end of row or another quote",
+	                      linenr);
 handle_escape:
 	escape_pos = 0;
 	quote_pos = 0;
 	position++;
 	do {
 		index_t count = 0;
-		for(; position < buffer_size; position++) {
+		for (; position < buffer_size; position++) {
 			quote_search.Match(quote_pos, buffer[position]);
 			escape_search.Match(escape_pos, buffer[position]);
 			count++;
 			if (count > escape_pos && count > quote_pos) {
-				throw ParserException("Error on line %lld: neither QUOTE nor ESCAPE is proceeded by ESCAPE",
-										linenr);
+				throw ParserException("Error on line %lld: neither QUOTE nor ESCAPE is proceeded by ESCAPE", linenr);
 			}
 			if (quote_pos == info.quote.size() || escape_pos == info.escape.size()) {
 				// found quote or escape: move back to quoted state
@@ -244,8 +246,7 @@ handle_escape:
 			}
 		}
 	} while (ReadBuffer(start));
-	throw ParserException("Error on line %lld: neither QUOTE nor ESCAPE is proceeded by ESCAPE",
-							linenr);
+	throw ParserException("Error on line %lld: neither QUOTE nor ESCAPE is proceeded by ESCAPE", linenr);
 carriage_return:
 	/* state: carriage_return */
 	// this stage optionally skips a newline (\n) character, which allows \r\n to be interpreted as a single line
@@ -308,7 +309,7 @@ normal:
 	/* state: normal parsing state */
 	// this state parses the remainder of a non-quoted value until we reach a delimiter or newline
 	do {
-		for(; position < buffer_size; position++) {
+		for (; position < buffer_size; position++) {
 			if (buffer[position] == info.delimiter[0]) {
 				// delimiter: end the value and add it to the chunk
 				goto add_value;
@@ -329,7 +330,7 @@ add_value:
 		goto final_state;
 	}
 	goto value_start;
-add_row: {
+add_row : {
 	// check type of newline (\r or \n)
 	bool carriage_return = buffer[position] == '\r';
 	AddValue(buffer.get() + start, position - start - offset, column, escape_positions);
@@ -356,7 +357,7 @@ in_quotes:
 	// this state parses the remainder of a quoted value
 	position++;
 	do {
-		for(; position < buffer_size; position++) {
+		for (; position < buffer_size; position++) {
 			if (buffer[position] == info.quote[0]) {
 				// quote: move to unquoted state
 				goto unquote;
@@ -391,19 +392,18 @@ unquote:
 		offset = 1;
 		goto add_row;
 	} else {
-		throw ParserException("Error on line %lld: quote should be followed by end of value, end of row or another quote", linenr);
+		throw ParserException(
+		    "Error on line %lld: quote should be followed by end of value, end of row or another quote", linenr);
 	}
 handle_escape:
 	/* state: handle_escape */
 	// escape should be followed by a quote or another escape character
 	position++;
 	if (position >= buffer_size && !ReadBuffer(start)) {
-		throw ParserException("Error on line %lld: neither QUOTE nor ESCAPE is proceeded by ESCAPE",
-								linenr);
+		throw ParserException("Error on line %lld: neither QUOTE nor ESCAPE is proceeded by ESCAPE", linenr);
 	}
 	if (buffer[position] != info.quote[0] && buffer[position] != info.escape[0]) {
-		throw ParserException("Error on line %lld: neither QUOTE nor ESCAPE is proceeded by ESCAPE",
-								linenr);
+		throw ParserException("Error on line %lld: neither QUOTE nor ESCAPE is proceeded by ESCAPE", linenr);
 	}
 	// escape was followed by quote or escape, go back to quoted state
 	goto in_quotes;
@@ -412,12 +412,12 @@ carriage_return:
 	// this stage optionally skips a newline (\n) character, which allows \r\n to be interpreted as a single line
 	if (buffer[position] == '\n') {
 		// newline after carriage return: skip
-	// increase position by 1 and move start to the new position
-	start = ++position;
-	if (position >= buffer_size && !ReadBuffer(start)) {
-		// file ends right after delimiter, go to final state
-		goto final_state;
-	}
+		// increase position by 1 and move start to the new position
+		start = ++position;
+		if (position >= buffer_size && !ReadBuffer(start)) {
+			// file ends right after delimiter, go to final state
+			goto final_state;
+		}
 	}
 	if (finished_chunk) {
 		return;
@@ -478,8 +478,7 @@ void BufferedCSVReader::ParseCSV(DataChunk &insert_chunk) {
 	}
 }
 
-void BufferedCSVReader::AddValue(char *str_val, index_t length, index_t &column,
-                                 vector<index_t> &escape_positions) {
+void BufferedCSVReader::AddValue(char *str_val, index_t length, index_t &column, vector<index_t> &escape_positions) {
 	if (column == sql_types.size() && length == 0) {
 		// skip a single trailing delimiter
 		column++;
@@ -504,7 +503,7 @@ void BufferedCSVReader::AddValue(char *str_val, index_t length, index_t &column,
 			string old_val = str_val;
 			string new_val = "";
 			index_t prev_pos = 0;
-			for(index_t i = 0; i < escape_positions.size(); i++) {
+			for (index_t i = 0; i < escape_positions.size(); i++) {
 				index_t next_pos = escape_positions[i];
 				new_val += old_val.substr(prev_pos, next_pos - prev_pos);
 				prev_pos = next_pos + info.escape.size();
@@ -544,7 +543,7 @@ void BufferedCSVReader::Flush(DataChunk &insert_chunk) {
 		if (sql_types[col_idx].id == SQLTypeId::VARCHAR) {
 			// target type is varchar: no need to convert
 			// just test that all strings are valid utf-8 strings
-			auto parse_data = (const char**) parse_chunk.data[col_idx].data;
+			auto parse_data = (const char **)parse_chunk.data[col_idx].data;
 			VectorOperations::Exec(parse_chunk.data[col_idx], [&](index_t i, index_t k) {
 				if (!parse_chunk.data[col_idx].nullmask[i]) {
 					if (!Value::IsUTF8String(parse_data[i])) {

--- a/src/execution/operator/persistent/buffered_csv_reader.cpp
+++ b/src/execution/operator/persistent/buffered_csv_reader.cpp
@@ -387,6 +387,14 @@ carriage_return:
 	}
 	goto value_start;
 final:
+	if (finished_chunk) {
+		return;
+	}
+	if (column > 0) {
+		// remaining values to be added to the chunk
+		AddValue(buffer.get() + start, position - start, column, escape_positions);
+		finished_chunk = AddRow(insert_chunk, column);
+	}
 	// final stage, only reached after parsing the file is finished
 	// flush the parsed chunk and finalize parsing
 	Flush(insert_chunk);

--- a/src/execution/operator/persistent/buffered_csv_reader.cpp
+++ b/src/execution/operator/persistent/buffered_csv_reader.cpp
@@ -19,8 +19,34 @@ static char is_newline(char c) {
 	return c == '\n' || c == '\r';
 }
 
+TextSearchShiftArray::TextSearchShiftArray(string search_term) : length(search_term.size()) {
+	// initialize the shifts array
+	shifts = unique_ptr<uint8_t[]>(new uint8_t[length * 255]);
+	memset(shifts.get(), 0, length * 255 * sizeof(uint8_t));
+	// iterate over each of the characters in the array
+	for(index_t main_idx = 0; main_idx < length; main_idx++) {
+		uint8_t current_char = (uint8_t) search_term[main_idx];
+		// now move over all the remaining positions
+		for(index_t i = main_idx; i < length; i++) {
+			bool is_match = true;
+			// check if the prefix matches at this position
+			// if it does, we move to this position after encountering the current character
+			for(index_t j = 0; j < main_idx; j++) {
+				if (search_term[i - main_idx + j] != search_term[j]) {
+					is_match = false;
+				}
+			}
+			if (!is_match) {
+				continue;
+			}
+			shifts[i * 255 + current_char] = main_idx + 1;
+		}
+	}
+}
+
 BufferedCSVReader::BufferedCSVReader(CopyInfo &info, vector<SQLType> sql_types, istream &source)
-    : info(info), sql_types(sql_types), source(source), buffer_size(0), position(0), start(0) {
+    : info(info), sql_types(sql_types), source(source), buffer_size(0), position(0), start(0),
+	  delimiter_search(info.delimiter), escape_search(info.escape), quote_search(info.quote) {
 	if (info.force_not_null.size() == 0) {
 		info.force_not_null.resize(sql_types.size(), false);
 	}
@@ -38,226 +64,216 @@ BufferedCSVReader::BufferedCSVReader(CopyInfo &info, vector<SQLType> sql_types, 
 		getline(source, read_line);
 		linenr++;
 	}
-}
-
-void BufferedCSVReader::MatchBufferPosition(bool &prev_pos_matches, index_t &control_str_offset, index_t &tmp_position,
-                                            bool &match, string &control_str) {
-	if (prev_pos_matches && control_str_offset < control_str.length()) {
-		if (buffer[tmp_position] != control_str[control_str_offset]) {
-			prev_pos_matches = false;
-		} else {
-			if (control_str_offset == control_str.length() - 1) {
-				prev_pos_matches = false;
-				match = true;
-			}
-		}
-	}
-}
-
-bool BufferedCSVReader::MatchControlString(bool &delim_match, bool &quote_match, bool &escape_match) {
-	index_t tmp_position = position;
-	index_t control_str_offset = 0;
-
-	bool delim = true;
-	bool quote = true;
-	bool escape = true;
-
-	while (true) {
-		// check if the delimiter string matches
-		MatchBufferPosition(delim, control_str_offset, tmp_position, delim_match, info.delimiter);
-		// check if the quote string matches
-		MatchBufferPosition(quote, control_str_offset, tmp_position, quote_match, info.quote);
-		// check if the escape string matches
-		MatchBufferPosition(escape, control_str_offset, tmp_position, escape_match, info.escape);
-
-		// return if matching is not possible any longer
-		if (!delim && !quote && !escape) {
-			return false;
-		}
-
-		tmp_position++;
-		control_str_offset++;
-
-		// make sure not to exceed buffer size, and return if there cannot be any further control strings
-		if (tmp_position >= buffer_size) {
-			return true;
-		}
+	if (info.delimiter.size() > 255 || info.quote.size() > 255 || info.escape.size() > 255) {
+		throw Exception("Size of delimiter/quote/escape in CSV reader is limited to 255 bytes");
 	}
 }
 
 void BufferedCSVReader::ParseComplexCSV(DataChunk &insert_chunk) {
 	// used for parsing algorithm
-	bool in_quotes = false;
 	bool finished_chunk = false;
-	bool seen_escape = false;
-	bool reset_quotes = false;
-	bool quote_or_escape = false;
-	bool exhausted_buffer = false;
 	index_t column = 0;
-	index_t offset = 0;
 	vector<index_t> escape_positions;
+	uint8_t delimiter_pos = 0, escape_pos = 0, quote_pos = 0;
+	index_t offset = 0;
 
-	// used for fast control sequence detection
-	bool delimiter = false;
-	bool quote = false;
-	bool escape = false;
-
+	// read values into the buffer (if any)
 	if (position >= buffer_size) {
 		if (!ReadBuffer(start)) {
 			return;
 		}
 	}
-
-	// read until we exhaust the stream
-	while (true) {
+	// start parsing the first value
+	start = position;
+	goto value_start;
+value_start:
+	/* state: value_start */
+	// this state parses the first characters of a value
+	offset = 0;
+	delimiter_pos = 0;
+	quote_pos = 0;
+	do {
+		index_t count = 0;
+		for(; position < buffer_size; position++) {
+			quote_search.Match(quote_pos, buffer[position]);
+			delimiter_search.Match(delimiter_pos, buffer[position]);
+			count++;
+			if (delimiter_pos == info.delimiter.size()) {
+				// found a delimiter, add the value
+				offset = info.delimiter.size() - 1;
+				goto add_value;
+			} else if (is_newline(buffer[position])) {
+				// found a newline, add the row
+				goto add_row;
+			}
+			if (count > quote_pos) {
+				// did not find a quote directly at the start of the value, stop looking for the quote now
+				goto normal;
+			}
+			if (quote_pos == info.quote.size()) {
+				// found a quote, go to quoted loop and skip the initial quote
+				start += info.quote.size();
+				goto in_quotes;
+			}
+		}
+	} while (ReadBuffer(start));
+	// file ends while scanning for quote/delimiter, go to final state
+	goto final_state;
+normal:
+	/* state: normal parsing state */
+	// this state parses the remainder of a non-quoted value until we reach a delimiter or newline
+	position++;
+	do {
+		for(; position < buffer_size; position++) {
+			delimiter_search.Match(delimiter_pos, buffer[position]);
+			if (delimiter_pos == info.delimiter.size()) {
+				offset = info.delimiter.size() - 1;
+				goto add_value;
+			} else if (is_newline(buffer[position])) {
+				goto add_row;
+			}
+		}
+	} while (ReadBuffer(start));
+	goto final_state;
+add_value:
+	AddValue(buffer.get() + start, position - start - offset, column, escape_positions);
+	// increase position by 1 and move start to the new position
+	start = ++position;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		// file ends right after delimiter, go to final state
+		goto final_state;
+	}
+	goto value_start;
+add_row: {
+	// check type of newline (\r or \n)
+	bool carriage_return = buffer[position] == '\r';
+	AddValue(buffer.get() + start, position - start - offset, column, escape_positions);
+	finished_chunk = AddRow(insert_chunk, column);
+	// increase position by 1 and move start to the new position
+	start = ++position;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		// file ends right after newline, go to final state
+		goto final_state;
+	}
+	if (carriage_return) {
+		// \r newline, go to special state that parses an optional \n afterwards
+		goto carriage_return;
+	} else {
+		// \n newline, move to value start
 		if (finished_chunk) {
 			return;
 		}
-
-		// detect control strings
-		exhausted_buffer = MatchControlString(delimiter, quote, escape);
-
-		if (!exhausted_buffer) {
-			// if QUOTE equals ESCAPE we might need to determine which one we detected in the previous loop
-			if (quote_or_escape) {
-				if (delimiter || is_newline(buffer[position]) || (source.eof() && position + 1 == buffer_size)) {
-					// found quote without escape, end quote
-					offset = info.quote.length();
-					in_quotes = false;
-				} else {
-					// found escape
-					seen_escape = true;
-				}
-				quote_or_escape = false;
-			}
-
-			if (in_quotes) {
-				if (!quote && !escape && !seen_escape) {
-					// plain value character
-					seen_escape = false;
-				} else if (!quote && !escape && seen_escape) {
-					throw ParserException("Error on line %lld: neither QUOTE nor ESCAPE is proceeded by ESCAPE",
-					                      linenr);
-				} else if (!quote && escape && !seen_escape) {
-					// escape
-					seen_escape = true;
-					position += info.escape.length() - 1;
-				} else if (!quote && escape && seen_escape) {
-					// escaped escape
-					// we store the position of the escape so we can skip it when adding the value
-					escape_positions.push_back(position - start);
-					position += info.escape.length() - 1;
-					seen_escape = false;
-				} else if (quote && !escape && !seen_escape) {
-					// found quote without escape, end quote
-					offset = info.quote.length();
-					position += info.quote.length() - 1;
-					in_quotes = false;
-				} else if (quote && !escape && seen_escape) {
-					// escaped quote
-					// we store the position of the escape so we can skip it when adding the value
-					escape_positions.push_back(position - start);
-					position += info.quote.length() - 1;
-					seen_escape = false;
-				} else if (quote && escape && !seen_escape) {
-					// either escape or end of quote, decide depending on next character
-					// NOTE: QUOTE and ESCAPE cannot be subsets of each other
-					position += info.escape.length() - 1;
-					quote_or_escape = true;
-				} else if (quote && escape && seen_escape) {
-					// we store the position of the escape so we can skip it when adding the value
-					escape_positions.push_back(position - start);
-					position += info.escape.length() - 1;
-					seen_escape = false;
-				}
-			} else {
-				if (quote) {
-					// start quotes can only occur at the start of a field
-					if (position == start) {
-						in_quotes = true;
-						// increment start by quote length
-						start += info.quote.length();
-						reset_quotes = in_quotes;
-						position += info.quote.length() - 1;
-					} else {
-						throw ParserException("Error on line %lld: unterminated quotes", linenr);
-					}
-				} else if (delimiter) {
-					// encountered delimiter
-					AddValue(buffer.get() + start, position - start - offset, column, escape_positions);
-					start = position + info.delimiter.length();
-					reset_quotes = in_quotes;
-					position += info.delimiter.length() - 1;
-					offset = 0;
-				}
-
-				if (is_newline(buffer[position]) || (source.eof() && position + 1 == buffer_size)) {
-					char newline = buffer[position];
-					// encountered a newline, add the current value and push the row
-					AddValue(buffer.get() + start, position - start - offset, column, escape_positions);
-					finished_chunk = AddRow(insert_chunk, column);
-
-					// move to the next character
-					start = position + 1;
-					reset_quotes = in_quotes;
-					offset = 0;
-					if (newline == '\r') {
-						// \r, skip subsequent \n
-						if (position + 1 >= buffer_size) {
-							if (!ReadBuffer(start)) {
-								break;
-							}
-							if (buffer[position] == '\n') {
-								start++;
-								position++;
-							}
-							continue;
-						}
-						if (buffer[position + 1] == '\n') {
-							start++;
-							position++;
-						}
-					}
-				}
-				if (offset != 0) {
-					in_quotes = true;
-				}
+		goto value_start;
+	}
+}
+in_quotes:
+	/* state: in_quotes */
+	// this state parses the remainder of a quoted value
+	quote_pos = 0;
+	escape_pos = 0;
+	position++;
+	do {
+		for(; position < buffer_size; position++) {
+			quote_search.Match(quote_pos, buffer[position]);
+			escape_search.Match(escape_pos, buffer[position]);
+			if (quote_pos == info.quote.size()) {
+				goto unquote;
+			} else if (escape_pos == info.escape.size()) {
+				escape_positions.push_back(position - start - (info.escape.size() - 1));
+				goto handle_escape;
 			}
 		}
-
-		position++;
-		if (position >= buffer_size) {
-			// exhausted the buffer
-			if (!ReadBuffer(start)) {
-				break;
+	} while (ReadBuffer(start));
+	// still in quoted state at the end of the file, error:
+	throw ParserException("Error on line %lld: unterminated quotes", linenr);
+unquote:
+	/* state: unquote */
+	// this state handles the state directly after we unquote
+	// in this state we expect either another quote (entering the quoted state again, and escaping the quote)
+	// or a delimiter/newline, ending the current value and moving on to the next value
+	delimiter_pos = 0;
+	quote_pos = 0;
+	position++;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		// file ends right after unquote, go to final state
+		goto final_state;
+	}
+	if (is_newline(buffer[position])) {
+		// quote followed by newline, add row
+		offset = info.quote.size();
+		goto add_row;
+	}
+	do {
+		index_t count = 0;
+		for(; position < buffer_size; position++) {
+			quote_search.Match(quote_pos, buffer[position]);
+			delimiter_search.Match(delimiter_pos, buffer[position]);
+			count++;
+			if (count > delimiter_pos && count > quote_pos) {
+				throw ParserException("Error on line %lld: quote should be followed by end of value, end of row or another quote", linenr);
 			}
-			// restore the current state after reading from the buffer
-			in_quotes = reset_quotes;
-			seen_escape = false;
-			position = start;
-			quote_or_escape = false;
-			escape_positions.clear();
+			if (delimiter_pos == info.delimiter.size()) {
+				// quote followed by delimiter, add value
+				offset = info.quote.size() + info.delimiter.size() - 1;
+				goto add_value;
+			} else if (quote_pos == info.quote.size()) {
+				// quote followed by quote, go back to quoted state and add to escape
+				escape_positions.push_back(position - start - (info.quote.size() - 1));
+				goto in_quotes;
+			}
 		}
-
-		// reset values for control string matching
-		delimiter = false;
-		quote = false;
-		escape = false;
+	} while (ReadBuffer(start));
+	throw ParserException("Error on line %lld: quote should be followed by end of value, end of row or another quote", linenr);
+handle_escape:
+	escape_pos = 0;
+	quote_pos = 0;
+	position++;
+	do {
+		index_t count = 0;
+		for(; position < buffer_size; position++) {
+			quote_search.Match(quote_pos, buffer[position]);
+			escape_search.Match(escape_pos, buffer[position]);
+			count++;
+			if (count > escape_pos && count > quote_pos) {
+				throw ParserException("Error on line %lld: neither QUOTE nor ESCAPE is proceeded by ESCAPE",
+										linenr);
+			}
+			if (quote_pos == info.quote.size() || escape_pos == info.escape.size()) {
+				// found quote or escape: move back to quoted state
+				goto in_quotes;
+			}
+		}
+	} while (ReadBuffer(start));
+	throw ParserException("Error on line %lld: neither QUOTE nor ESCAPE is proceeded by ESCAPE",
+							linenr);
+carriage_return:
+	/* state: carriage_return */
+	// this stage optionally skips a newline (\n) character, which allows \r\n to be interpreted as a single line
+	if (buffer[position] == '\n') {
+		// newline after carriage return: skip
+		start = ++position;
+		if (position >= buffer_size && !ReadBuffer(start)) {
+			// file ends right after newline, go to final state
+			goto final_state;
+		}
 	}
-
-	if (in_quotes) {
-		throw ParserException("Error on line %lld: unterminated quotes", linenr);
+	if (finished_chunk) {
+		return;
 	}
+	goto value_start;
+final_state:
+	if (finished_chunk) {
+		return;
+	}
+	if (column > 0 || position > start) {
+		// remaining values to be added to the chunk
+		AddValue(buffer.get() + start, position - start, column, escape_positions);
+		finished_chunk = AddRow(insert_chunk, column);
+	}
+	// final stage, only reached after parsing the file is finished
+	// flush the parsed chunk and finalize parsing
 	Flush(insert_chunk);
 }
-
-#define NextPosition() \
-	position++; \
-	if (position >= buffer_size) { \
-		if (!ReadBuffer(start)) { \
-			goto final; \
-		} \
-	} \
 
 void BufferedCSVReader::ParseSimpleCSV(DataChunk &insert_chunk) {
 	// used for parsing algorithm
@@ -282,7 +298,6 @@ value_start:
 		// quote: actual value starts in the next position
 		// move to in_quotes state
 		start = position + 1;
-		NextPosition();
 		goto in_quotes;
 	} else {
 		// no quote, move to normal parsing state
@@ -303,17 +318,28 @@ normal:
 			}
 		}
 	} while (ReadBuffer(start));
-	goto final;
+	// file ends during normal scan: go to end state
+	goto final_state;
 add_value:
 	AddValue(buffer.get() + start, position - start - offset, column, escape_positions);
-	NextPosition();
+	// increase position by 1 and move start to the new position
+	start = ++position;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		// file ends right after delimiter, go to final state
+		goto final_state;
+	}
 	goto value_start;
 add_row: {
 	// check type of newline (\r or \n)
 	bool carriage_return = buffer[position] == '\r';
 	AddValue(buffer.get() + start, position - start - offset, column, escape_positions);
 	finished_chunk = AddRow(insert_chunk, column);
-	NextPosition();
+	// increase position by 1 and move start to the new position
+	start = ++position;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		// file ends right after delimiter, go to final state
+		goto final_state;
+	}
 	if (carriage_return) {
 		// \r newline, go to special state that parses an optional \n afterwards
 		goto carriage_return;
@@ -328,16 +354,15 @@ add_row: {
 in_quotes:
 	/* state: in_quotes */
 	// this state parses the remainder of a quoted value
+	position++;
 	do {
 		for(; position < buffer_size; position++) {
 			if (buffer[position] == info.quote[0]) {
 				// quote: move to unquoted state
-				NextPosition();
 				goto unquote;
 			} else if (buffer[position] == info.escape[0]) {
 				// escape: store the escaped position and move to handle_escape state
 				escape_positions.push_back(position - start);
-				NextPosition();
 				goto handle_escape;
 			}
 		}
@@ -349,10 +374,14 @@ unquote:
 	// this state handles the state directly after we unquote
 	// in this state we expect either another quote (entering the quoted state again, and escaping the quote)
 	// or a delimiter/newline, ending the current value and moving on to the next value
+	position++;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		// file ends right after unquote, go to final state
+		goto final_state;
+	}
 	if (buffer[position] == info.quote[0]) {
 		// escaped quote, return to quoted state and store escape position
 		escape_positions.push_back(position - start);
-		NextPosition();
 		goto in_quotes;
 	} else if (buffer[position] == info.delimiter[0]) {
 		// delimiter, add value
@@ -362,33 +391,43 @@ unquote:
 		offset = 1;
 		goto add_row;
 	} else {
-		throw Exception("Quote should be followed by end of value, end of row or another quote");
+		throw ParserException("Error on line %lld: quote should be followed by end of value, end of row or another quote", linenr);
 	}
 handle_escape:
 	/* state: handle_escape */
 	// escape should be followed by a quote or another escape character
+	position++;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		throw ParserException("Error on line %lld: neither QUOTE nor ESCAPE is proceeded by ESCAPE",
+								linenr);
+	}
 	if (buffer[position] != info.quote[0] && buffer[position] != info.escape[0]) {
 		throw ParserException("Error on line %lld: neither QUOTE nor ESCAPE is proceeded by ESCAPE",
 								linenr);
 	}
-	NextPosition();
+	// escape was followed by quote or escape, go back to quoted state
 	goto in_quotes;
 carriage_return:
 	/* state: carriage_return */
 	// this stage optionally skips a newline (\n) character, which allows \r\n to be interpreted as a single line
 	if (buffer[position] == '\n') {
 		// newline after carriage return: skip
-		NextPosition();
+	// increase position by 1 and move start to the new position
+	start = ++position;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		// file ends right after delimiter, go to final state
+		goto final_state;
+	}
 	}
 	if (finished_chunk) {
 		return;
 	}
 	goto value_start;
-final:
+final_state:
 	if (finished_chunk) {
 		return;
 	}
-	if (column > 0) {
+	if (column > 0 || position > start) {
 		// remaining values to be added to the chunk
 		AddValue(buffer.get() + start, position - start, column, escape_positions);
 		finished_chunk = AddRow(insert_chunk, column);

--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -90,8 +90,11 @@ public:
 	//! Create a double Value from a specified value
 	static Value DOUBLE(double value);
 
+	template<class T> T GetValue() {
+		throw NotImplementedException("Unimplemented template type for Value::GetValue");
+	}
 	template <class T> static Value CreateValue(T value) {
-		throw NotImplementedException("Unimplemented template type for value creation");
+		throw NotImplementedException("Unimplemented template type for Value::CreateValue");
 	}
 
 	int64_t GetNumericValue();
@@ -175,6 +178,8 @@ public:
 	void Print();
 
 private:
+	template<class T>
+	T GetValueInternal();
 	//! Templated helper function for casting
 	template <class DST, class OP> static DST _cast(const Value &v);
 
@@ -195,5 +200,14 @@ template <> Value Value::CreateValue(const char *value);
 template <> Value Value::CreateValue(string value);
 template <> Value Value::CreateValue(float value);
 template <> Value Value::CreateValue(double value);
+
+template <> bool        Value::GetValue();
+template <> int8_t      Value::GetValue();
+template <> int16_t     Value::GetValue();
+template <> int32_t     Value::GetValue();
+template <> int64_t     Value::GetValue();
+template <> string      Value::GetValue();
+template <> float       Value::GetValue();
+template <> double      Value::GetValue();
 
 } // namespace duckdb

--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -90,7 +90,7 @@ public:
 	//! Create a double Value from a specified value
 	static Value DOUBLE(double value);
 
-	template<class T> T GetValue() {
+	template <class T> T GetValue() {
 		throw NotImplementedException("Unimplemented template type for Value::GetValue");
 	}
 	template <class T> static Value CreateValue(T value) {
@@ -178,8 +178,7 @@ public:
 	void Print();
 
 private:
-	template<class T>
-	T GetValueInternal();
+	template <class T> T GetValueInternal();
 	//! Templated helper function for casting
 	template <class DST, class OP> static DST _cast(const Value &v);
 
@@ -201,13 +200,13 @@ template <> Value Value::CreateValue(string value);
 template <> Value Value::CreateValue(float value);
 template <> Value Value::CreateValue(double value);
 
-template <> bool        Value::GetValue();
-template <> int8_t      Value::GetValue();
-template <> int16_t     Value::GetValue();
-template <> int32_t     Value::GetValue();
-template <> int64_t     Value::GetValue();
-template <> string      Value::GetValue();
-template <> float       Value::GetValue();
-template <> double      Value::GetValue();
+template <> bool Value::GetValue();
+template <> int8_t Value::GetValue();
+template <> int16_t Value::GetValue();
+template <> int32_t Value::GetValue();
+template <> int64_t Value::GetValue();
+template <> string Value::GetValue();
+template <> float Value::GetValue();
+template <> double Value::GetValue();
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
@@ -14,15 +14,16 @@
 namespace duckdb {
 struct CopyInfo;
 
-//! The shifts array allows for linear searching of multi-byte values. For each position, it determines the next position given that we encounter a byte with the given value.
+//! The shifts array allows for linear searching of multi-byte values. For each position, it determines the next
+//! position given that we encounter a byte with the given value.
 /*! For example, if we have a string "ABAC", the shifts array will have the following values:
-	*  [0] --> ['A'] = 1, all others = 0
-	*  [1] --> ['B'] = 2, ['A'] = 1, all others = 0
-	*  [2] --> ['A'] = 3, all others = 0
-	*  [3] --> ['C'] = 4 (match), 'B' = 2, 'A' = 1, all others = 0
-	* Suppose we then search in the following string "ABABAC", our progression will be as follows:
-	* 'A' -> [1], 'B' -> [2], 'A' -> [3], 'B' -> [2], 'A' -> [3], 'C' -> [4] (match!)
-	*/
+ *  [0] --> ['A'] = 1, all others = 0
+ *  [1] --> ['B'] = 2, ['A'] = 1, all others = 0
+ *  [2] --> ['A'] = 3, all others = 0
+ *  [3] --> ['C'] = 4 (match), 'B' = 2, 'A' = 1, all others = 0
+ * Suppose we then search in the following string "ABABAC", our progression will be as follows:
+ * 'A' -> [1], 'B' -> [2], 'A' -> [3], 'B' -> [2], 'A' -> [3], 'C' -> [4] (match!)
+ */
 struct TextSearchShiftArray {
 	TextSearchShiftArray(string search_term);
 
@@ -30,7 +31,6 @@ struct TextSearchShiftArray {
 		position = shifts[position * 255 + byte_value];
 		return position == length;
 	}
-
 
 	index_t length;
 	unique_ptr<uint8_t[]> shifts;

--- a/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
@@ -45,6 +45,11 @@ public:
 	void ParseCSV(DataChunk &insert_chunk);
 
 private:
+	//! Parses a CSV file with a one-byte delimiter, escape and quote character
+	void ParseSimpleCSV(DataChunk &insert_chunk);
+	//! Parses more complex CSV files with multi-byte delimiters, escapes or quotes
+	void ParseComplexCSV(DataChunk &insert_chunk);
+
 	//! Adds a value to the current row
 	void AddValue(char *str_val, index_t length, index_t &column, std::queue<index_t> &escape_positions);
 	//! Adds a row to the insert_chunk, returns true if the chunk is filled as a result of this row being added

--- a/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
@@ -11,8 +11,6 @@
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/parser/parsed_data/copy_info.hpp"
 
-#include <queue>
-
 namespace duckdb {
 struct CopyInfo;
 
@@ -51,7 +49,7 @@ private:
 	void ParseComplexCSV(DataChunk &insert_chunk);
 
 	//! Adds a value to the current row
-	void AddValue(char *str_val, index_t length, index_t &column, std::queue<index_t> &escape_positions);
+	void AddValue(char *str_val, index_t length, index_t &column, vector<index_t> &escape_positions);
 	//! Adds a row to the insert_chunk, returns true if the chunk is filled as a result of this row being added
 	bool AddRow(DataChunk &insert_chunk, index_t &column);
 	//! Finalizes a chunk, parsing all values that have been added so far and adding them to the insert_chunk

--- a/src/include/duckdb/main/query_result.hpp
+++ b/src/include/duckdb/main/query_result.hpp
@@ -24,7 +24,7 @@ public:
 	QueryResult(QueryResultType type, StatementType statement_type);
 	//! Creates a successful query result with the specified names and types
 	QueryResult(QueryResultType type, StatementType statement_type, vector<SQLType> sql_types, vector<TypeId> types,
-	            vector<string> names);
+				vector<string> names);
 	//! Creates an unsuccessful query result with error condition
 	QueryResult(QueryResultType type, string error);
 	virtual ~QueryResult() {
@@ -57,7 +57,59 @@ public:
 	//! Returns true if the two results are identical; false otherwise. Note that this method is destructive; it calls
 	//! Fetch() until both results are exhausted. The data in the results will be lost.
 	bool Equals(QueryResult &other);
+private:
+	//! The current chunk used by the iterator
+	unique_ptr<DataChunk> iterator_chunk;
 
+	class QueryResultIterator;
+
+	class QueryResultRow {
+	public:
+		QueryResultRow(QueryResultIterator &iterator) :
+			iterator(iterator), row(0) {
+		}
+
+		QueryResultIterator &iterator;
+		index_t row;
+
+		template<class T>
+		T GetValue(index_t col_idx) const {
+			return iterator.result->iterator_chunk->data[col_idx].GetValue(iterator.row_idx).GetValue<T>();
+		}
+	};
+	//! The row-based query result iterator. Invoking the
+	class QueryResultIterator {
+	public:
+		QueryResultIterator(QueryResult *result) :
+			current_row(*this), result(result), row_idx(0){
+			if (result) {
+				result->iterator_chunk = result->Fetch();
+			}
+		}
+
+		QueryResultRow current_row;
+		QueryResult *result;
+		index_t row_idx;
+public:
+		void Next() {
+			if (!result->iterator_chunk) {
+				return;
+			}
+			current_row.row++;
+			row_idx++;
+			if (row_idx >= result->iterator_chunk->size()) {
+				result->iterator_chunk = result->Fetch();
+				row_idx = 0;
+			}
+		}
+
+		QueryResultIterator& operator++() { Next(); return *this; }
+		bool operator!=(const QueryResultIterator &other) const { return !result->iterator_chunk; }
+		const QueryResultRow& operator*() const { return current_row; }
+	};
+public:
+	QueryResultIterator begin() { return QueryResultIterator(this); }
+	QueryResultIterator end() { return QueryResultIterator(nullptr); }
 protected:
 	string HeaderToString();
 

--- a/src/include/duckdb/main/query_result.hpp
+++ b/src/include/duckdb/main/query_result.hpp
@@ -104,7 +104,7 @@ public:
 		}
 
 		QueryResultIterator& operator++() { Next(); return *this; }
-		bool operator!=(const QueryResultIterator &other) const { return !result->iterator_chunk; }
+		bool operator!=(const QueryResultIterator &other) const { return result->iterator_chunk && result->iterator_chunk->column_count > 0; }
 		const QueryResultRow& operator*() const { return current_row; }
 	};
 public:

--- a/src/include/duckdb/main/query_result.hpp
+++ b/src/include/duckdb/main/query_result.hpp
@@ -24,7 +24,7 @@ public:
 	QueryResult(QueryResultType type, StatementType statement_type);
 	//! Creates a successful query result with the specified names and types
 	QueryResult(QueryResultType type, StatementType statement_type, vector<SQLType> sql_types, vector<TypeId> types,
-				vector<string> names);
+	            vector<string> names);
 	//! Creates an unsuccessful query result with error condition
 	QueryResult(QueryResultType type, string error);
 	virtual ~QueryResult() {
@@ -57,6 +57,7 @@ public:
 	//! Returns true if the two results are identical; false otherwise. Note that this method is destructive; it calls
 	//! Fetch() until both results are exhausted. The data in the results will be lost.
 	bool Equals(QueryResult &other);
+
 private:
 	//! The current chunk used by the iterator
 	unique_ptr<DataChunk> iterator_chunk;
@@ -65,23 +66,20 @@ private:
 
 	class QueryResultRow {
 	public:
-		QueryResultRow(QueryResultIterator &iterator) :
-			iterator(iterator), row(0) {
+		QueryResultRow(QueryResultIterator &iterator) : iterator(iterator), row(0) {
 		}
 
 		QueryResultIterator &iterator;
 		index_t row;
 
-		template<class T>
-		T GetValue(index_t col_idx) const {
+		template <class T> T GetValue(index_t col_idx) const {
 			return iterator.result->iterator_chunk->data[col_idx].GetValue(iterator.row_idx).GetValue<T>();
 		}
 	};
 	//! The row-based query result iterator. Invoking the
 	class QueryResultIterator {
 	public:
-		QueryResultIterator(QueryResult *result) :
-			current_row(*this), result(result), row_idx(0){
+		QueryResultIterator(QueryResult *result) : current_row(*this), result(result), row_idx(0) {
 			if (result) {
 				result->iterator_chunk = result->Fetch();
 			}
@@ -90,7 +88,8 @@ private:
 		QueryResultRow current_row;
 		QueryResult *result;
 		index_t row_idx;
-public:
+
+	public:
 		void Next() {
 			if (!result->iterator_chunk) {
 				return;
@@ -103,13 +102,26 @@ public:
 			}
 		}
 
-		QueryResultIterator& operator++() { Next(); return *this; }
-		bool operator!=(const QueryResultIterator &other) const { return result->iterator_chunk && result->iterator_chunk->column_count > 0; }
-		const QueryResultRow& operator*() const { return current_row; }
+		QueryResultIterator &operator++() {
+			Next();
+			return *this;
+		}
+		bool operator!=(const QueryResultIterator &other) const {
+			return result->iterator_chunk && result->iterator_chunk->column_count > 0;
+		}
+		const QueryResultRow &operator*() const {
+			return current_row;
+		}
 	};
+
 public:
-	QueryResultIterator begin() { return QueryResultIterator(this); }
-	QueryResultIterator end() { return QueryResultIterator(nullptr); }
+	QueryResultIterator begin() {
+		return QueryResultIterator(this);
+	}
+	QueryResultIterator end() {
+		return QueryResultIterator(nullptr);
+	}
+
 protected:
 	string HeaderToString();
 

--- a/test/api/test_results.cpp
+++ b/test/api/test_results.cpp
@@ -34,6 +34,23 @@ TEST_CASE("Test results API", "[api]") {
 	REQUIRE(!str.empty());
 }
 
+TEST_CASE("Test iterating over results", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE data(i INTEGER, j VARCHAR)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO data VALUES (1, 'hello'), (2, 'test')"));
+
+	vector<int> i_values = {1, 2};
+	vector<string> j_values = {"hello", "test"};
+
+	auto result = con.Query("SELECT * FROM data;");
+	for(auto &row : *result) {
+		REQUIRE(row.GetValue<int>(0) == i_values[row.row]);
+		REQUIRE(row.GetValue<string>(1) == j_values[row.row]);
+	}
+}
+
 TEST_CASE("Error in streaming result after initial query", "[api]") {
 	DuckDB db(nullptr);
 	Connection con(db);

--- a/test/api/test_results.cpp
+++ b/test/api/test_results.cpp
@@ -43,12 +43,14 @@ TEST_CASE("Test iterating over results", "[api]") {
 
 	vector<int> i_values = {1, 2};
 	vector<string> j_values = {"hello", "test"};
-
+	index_t row_count = 0;
 	auto result = con.Query("SELECT * FROM data;");
 	for(auto &row : *result) {
 		REQUIRE(row.GetValue<int>(0) == i_values[row.row]);
 		REQUIRE(row.GetValue<string>(1) == j_values[row.row]);
+		row_count++;
 	}
+	REQUIRE(row_count == 2);
 }
 
 TEST_CASE("Error in streaming result after initial query", "[api]") {

--- a/test/api/test_results.cpp
+++ b/test/api/test_results.cpp
@@ -45,7 +45,7 @@ TEST_CASE("Test iterating over results", "[api]") {
 	vector<string> j_values = {"hello", "test"};
 	index_t row_count = 0;
 	auto result = con.Query("SELECT * FROM data;");
-	for(auto &row : *result) {
+	for (auto &row : *result) {
 		REQUIRE(row.GetValue<int>(0) == i_values[row.row]);
 		REQUIRE(row.GetValue<string>(1) == j_values[row.row]);
 		row_count++;

--- a/test/sql/copy/test_copy.cpp
+++ b/test/sql/copy/test_copy.cpp
@@ -367,6 +367,15 @@ TEST_CASE("Test CSVs with repeating patterns in delimiter/escape/quote", "[copy]
 		REQUIRE_NO_FAIL(con.Query("CREATE TABLE abac_tbl (a VARCHAR);"));
 		REQUIRE_FAIL(con.Query("COPY abac_tbl FROM '" + csv_path + "' QUOTE 'ABABAC';"));
 	}
+	SECTION("Quote followed by incomplete multi-byte delimiter") {
+		ofstream csv_stream(csv_path);
+		csv_stream << "\"\"AB";
+		csv_stream.close();
+
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE abac_tbl (a VARCHAR);"));
+		REQUIRE_FAIL(con.Query("COPY abac_tbl FROM '" + csv_path + "' DELIMITER 'ABAC';"));
+		REQUIRE_NO_FAIL(con.Query("COPY abac_tbl FROM '" + csv_path + "' DELIMITER 'AB';"));
+	}
 	SECTION("Multi-byte quote terminates after escape results in error") {
 		ofstream csv_stream(csv_path);
 		csv_stream << "ABACABABABAC";

--- a/test/sql/copy/test_copy.cpp
+++ b/test/sql/copy/test_copy.cpp
@@ -221,7 +221,8 @@ TEST_CASE("Test CSV file without trailing newline", "[copy]") {
 
 	// load CSV file into a table
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE no_newline_unicode (a INTEGER, b INTEGER, c VARCHAR(10));"));
-	result = con.Query("COPY no_newline_unicode FROM '" + fs.JoinPath(csv_path, "no_newline_unicode.csv") + "' DELIMITER '🦆';");
+	result = con.Query("COPY no_newline_unicode FROM '" + fs.JoinPath(csv_path, "no_newline_unicode.csv") +
+	                   "' DELIMITER '🦆';");
 	REQUIRE(CHECK_COLUMN(result, 0, {1024}));
 }
 
@@ -380,12 +381,14 @@ TEST_CASE("Test long value with escapes", "[copy]") {
 
 	// long value with escape and simple delimiter
 	ofstream long_escaped_value(fs.JoinPath(csv_path, "long_escaped_value.csv"));
-	long_escaped_value << 1 << "🦆" << 2 << "🦆" << "\"" << value << "\"" << endl;
+	long_escaped_value << 1 << "🦆" << 2 << "🦆"
+	                   << "\"" << value << "\"" << endl;
 	long_escaped_value.close();
 
 	// load CSV file into a table
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE long_escaped_value (a INTEGER, b INTEGER, c VARCHAR);"));
-	result = con.Query("COPY long_escaped_value FROM '" + fs.JoinPath(csv_path, "long_escaped_value.csv") + "' DELIMITER '🦆';");
+	result = con.Query("COPY long_escaped_value FROM '" + fs.JoinPath(csv_path, "long_escaped_value.csv") +
+	                   "' DELIMITER '🦆';");
 	REQUIRE(CHECK_COLUMN(result, 0, {1}));
 
 	result = con.Query("SELECT * FROM long_escaped_value");
@@ -395,12 +398,14 @@ TEST_CASE("Test long value with escapes", "[copy]") {
 
 	// long value with escape and complex delimiter
 	ofstream long_escaped_value_unicode(fs.JoinPath(csv_path, "long_escaped_value_unicode.csv"));
-	long_escaped_value_unicode << 1 << "," << 2 << "," << "\"" << value << "\"" << endl;
+	long_escaped_value_unicode << 1 << "," << 2 << ","
+	                           << "\"" << value << "\"" << endl;
 	long_escaped_value_unicode.close();
 
 	// load CSV file into a table
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE long_escaped_value_unicode (a INTEGER, b INTEGER, c VARCHAR);"));
-	result = con.Query("COPY long_escaped_value_unicode FROM '" + fs.JoinPath(csv_path, "long_escaped_value_unicode.csv") + "';");
+	result = con.Query("COPY long_escaped_value_unicode FROM '" +
+	                   fs.JoinPath(csv_path, "long_escaped_value_unicode.csv") + "';");
 	REQUIRE(CHECK_COLUMN(result, 0, {1}));
 
 	result = con.Query("SELECT * FROM long_escaped_value_unicode");


### PR DESCRIPTION
This PR allows the TPC-H and TPC-DS to write the generated data to disk in CSV format, and reload it from there when available. This significantly decreases loading times for these benchmarks (by more than a factor 10, from some simple measurements).

### CSV Reader Optimization
In the process I noticed the performance of the CSV reader had degraded somewhat, and decided to create an optimized version that is around 50-100% faster than the old one. There are two separate optimized CSV reader implementations, one for the common simple case of 1-byte delimiter/escape/quote, and one for the more complex case of multi-byte delimiter/escape/quote. The performance difference between these is not that significant (~20%) but it seems worthwhile to have the distinction since in my experience by far the most common case is 1-byte delimiter/escape/quote. PostgreSQL does not even support anything except 1-byte delimiter/escape/quote.

The CSV reader code works with a set of tight loops within various states (`value_start`, `normal`, `in_quotes`, etc). Transitions between states are made with a `goto` statement. Initially this was done with a loop and a switch statement but this was around 10% slower and (in my opinion) less readable. In both versions, we perform a single character-by-character iteration over the CSV file. 

The single character-by-character iteration makes the multi-byte case a bit more difficult to understand, in this case we preprocess the delimiter/quote/escape and generate a simple finite state machine parser for each of them. The FSM parser works as follows:

* The state is the position within the string to match (starts at 0)
* The state transition is the next character to match
* By performing a single array lookup, the state is updated based on the state transition (this is very efficient)

As an example of how it would work, if we have the match string "ABAC" we generate the following transitions:

*Position 0*
'A' -> 1
else -> 0

*Position 1*
'B' -> 2
'A' -> 1
else -> 0

*Position 2*
'A' -> 3
else -> 0

*Position 3*
'C' -> 4 (match)
'B' -> 2
'A' -> 1
else -> 0

Now if we match for example on the string ABABAC, the state transitions look as follows:
*'A'* -> move to position 1
*'B'* -> move to position 2
*'A'* -> move to position 3
*'B'* -> move to position 2
*'A'* -> move to position 3
*'C'* -> move to position 4, match found!

### Query Result Iteration
The PR in addition also enables the following syntax on QueryResults:
```cpp
for(auto &row : result) {
    // get first value of row as int32
    row.GetValue<int32_t>(0);
    // get second value of row as string
    row.GetValue<string>(1);
}
```