### PR TITLE
Join Hash Table Rework

### DIFF
--- a/src/common/symbols.cpp
+++ b/src/common/symbols.cpp
@@ -137,7 +137,6 @@ template class std::unique_ptr<Vector[]>;
 template class std::unique_ptr<DataChunk>;
 template class std::unique_ptr<JoinHashTable>;
 template class std::unique_ptr<JoinHashTable::ScanStructure>;
-template class std::unique_ptr<JoinHashTable::Node>;
 template class std::unique_ptr<data_ptr_t[]>;
 template class std::unique_ptr<Rule>;
 template class std::unique_ptr<LogicalFilter>;

--- a/src/common/vector_operations/hash.cpp
+++ b/src/common/vector_operations/hash.cpp
@@ -9,26 +9,28 @@
 using namespace duckdb;
 using namespace std;
 
-template <class LEFT_TYPE, class RESULT_TYPE, class OP>
-static inline void unary_loop_process_null_function(LEFT_TYPE *__restrict ldata, RESULT_TYPE *__restrict result_data,
+template <class T>
+static inline void tight_loop_hash(T *__restrict ldata, uint64_t *__restrict result_data,
                                                     index_t count, sel_t *__restrict sel_vector, nullmask_t &nullmask) {
 	ASSERT_RESTRICT(ldata, ldata + count, result_data, result_data + count);
 	if (nullmask.any()) {
-		VectorOperations::Exec(sel_vector, count,
-		                       [&](index_t i, index_t k) { result_data[i] = OP::Operation(ldata[i], nullmask[i]); });
+		VectorOperations::Exec(sel_vector, count,[&](index_t i, index_t k) {
+			result_data[i] = duckdb::HashOp::Operation(ldata[i], nullmask[i]);
+		});
 	} else {
-		VectorOperations::Exec(sel_vector, count,
-		                       [&](index_t i, index_t k) { result_data[i] = OP::Operation(ldata[i], false); });
+		VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
+			result_data[i] = duckdb::HashOp::Operation(ldata[i], false);
+		});
 	}
 }
 
-template <class LEFT_TYPE, class RESULT_TYPE, class OP>
-void templated_unary_loop_process_null(Vector &input, Vector &result) {
-	auto ldata = (LEFT_TYPE *)input.data;
-	auto result_data = (RESULT_TYPE *)result.data;
+template <class T>
+void templated_loop_hash(Vector &input, Vector &result) {
+	auto ldata = (T *)input.data;
+	auto result_data = (uint64_t *)result.data;
 
 	result.nullmask.reset();
-	unary_loop_process_null_function<LEFT_TYPE, RESULT_TYPE, OP>(ldata, result_data, input.count, input.sel_vector,
+	tight_loop_hash<T>(ldata, result_data, input.count, input.sel_vector,
 	                                                             input.nullmask);
 	result.sel_vector = input.sel_vector;
 	result.count = input.count;
@@ -41,38 +43,89 @@ void VectorOperations::Hash(Vector &input, Vector &result) {
 	switch (input.type) {
 	case TypeId::BOOLEAN:
 	case TypeId::TINYINT:
-		templated_unary_loop_process_null<int8_t, uint64_t, duckdb::HashOp>(input, result);
+		templated_loop_hash<int8_t>(input, result);
 		break;
 	case TypeId::SMALLINT:
-		templated_unary_loop_process_null<int16_t, uint64_t, duckdb::HashOp>(input, result);
+		templated_loop_hash<int16_t>(input, result);
 		break;
 	case TypeId::INTEGER:
-		templated_unary_loop_process_null<int32_t, uint64_t, duckdb::HashOp>(input, result);
+		templated_loop_hash<int32_t>(input, result);
 		break;
 	case TypeId::BIGINT:
-		templated_unary_loop_process_null<int64_t, uint64_t, duckdb::HashOp>(input, result);
+		templated_loop_hash<int64_t>(input, result);
 		break;
 	case TypeId::FLOAT:
-		templated_unary_loop_process_null<float, uint64_t, duckdb::HashOp>(input, result);
+		templated_loop_hash<float>(input, result);
 		break;
 	case TypeId::DOUBLE:
-		templated_unary_loop_process_null<double, uint64_t, duckdb::HashOp>(input, result);
+		templated_loop_hash<double>(input, result);
 		break;
 	case TypeId::VARCHAR:
-		templated_unary_loop_process_null<const char *, uint64_t, duckdb::HashOp>(input, result);
+		templated_loop_hash<const char *>(input, result);
 		break;
 	default:
 		throw InvalidTypeException(input.type, "Invalid type for hash");
 	}
 }
 
+static inline uint64_t combine_hash(uint64_t a, uint64_t b) {
+	return (a * UINT64_C(0xbf58476d1ce4e5b9)) ^ b;
+}
+
+template <class T>
+static inline void tight_loop_combine_hash(T *__restrict ldata, uint64_t *__restrict hash_data,
+                                                    index_t count, sel_t *__restrict sel_vector, nullmask_t &nullmask) {
+	ASSERT_RESTRICT(ldata, ldata + count, hash_data, hash_data + count);
+	if (nullmask.any()) {
+		VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
+			auto other_hash = duckdb::HashOp::Operation(ldata[i], nullmask[i]);
+			hash_data[i] = combine_hash(hash_data[i], other_hash);
+		});
+	} else {
+		VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
+			auto other_hash = duckdb::HashOp::Operation(ldata[i], false);
+			hash_data[i] = combine_hash(hash_data[i], other_hash);
+		});
+	}
+}
+
+template <class T>
+void templated_loop_combine_hash(Vector &input, Vector &hashes) {
+	auto ldata = (T *)input.data;
+	auto hash_data = (uint64_t *)hashes.data;
+
+	tight_loop_combine_hash<T>(ldata, hash_data, input.count, input.sel_vector, input.nullmask);
+}
+
 void VectorOperations::CombineHash(Vector &hashes, Vector &input) {
 	if (hashes.type != TypeId::HASH) {
 		throw NotImplementedException("Hashes must be 64-bit unsigned integer hash vector");
 	}
-	// first hash the input to an intermediate vector
-	Vector intermediate(TypeId::HASH, true, false);
-	VectorOperations::Hash(input, intermediate);
-	// then XOR it together with the input
-	VectorOperations::BitwiseXORInPlace(hashes, intermediate);
+	assert(input.sel_vector == hashes.sel_vector && input.count == hashes.count);
+	switch (input.type) {
+	case TypeId::BOOLEAN:
+	case TypeId::TINYINT:
+		templated_loop_combine_hash<int8_t>(input, hashes);
+		break;
+	case TypeId::SMALLINT:
+		templated_loop_combine_hash<int16_t>(input, hashes);
+		break;
+	case TypeId::INTEGER:
+		templated_loop_combine_hash<int32_t>(input, hashes);
+		break;
+	case TypeId::BIGINT:
+		templated_loop_combine_hash<int64_t>(input, hashes);
+		break;
+	case TypeId::FLOAT:
+		templated_loop_combine_hash<float>(input, hashes);
+		break;
+	case TypeId::DOUBLE:
+		templated_loop_combine_hash<double>(input, hashes);
+		break;
+	case TypeId::VARCHAR:
+		templated_loop_combine_hash<const char *>(input, hashes);
+		break;
+	default:
+		throw InvalidTypeException(input.type, "Invalid type for hash");
+	}
 }

--- a/src/common/vector_operations/hash.cpp
+++ b/src/common/vector_operations/hash.cpp
@@ -10,11 +10,11 @@ using namespace duckdb;
 using namespace std;
 
 template <class T>
-static inline void tight_loop_hash(T *__restrict ldata, uint64_t *__restrict result_data,
-                                                    index_t count, sel_t *__restrict sel_vector, nullmask_t &nullmask) {
+static inline void tight_loop_hash(T *__restrict ldata, uint64_t *__restrict result_data, index_t count,
+                                   sel_t *__restrict sel_vector, nullmask_t &nullmask) {
 	ASSERT_RESTRICT(ldata, ldata + count, result_data, result_data + count);
 	if (nullmask.any()) {
-		VectorOperations::Exec(sel_vector, count,[&](index_t i, index_t k) {
+		VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
 			result_data[i] = duckdb::HashOp::Operation(ldata[i], nullmask[i]);
 		});
 	} else {
@@ -24,14 +24,12 @@ static inline void tight_loop_hash(T *__restrict ldata, uint64_t *__restrict res
 	}
 }
 
-template <class T>
-void templated_loop_hash(Vector &input, Vector &result) {
+template <class T> void templated_loop_hash(Vector &input, Vector &result) {
 	auto ldata = (T *)input.data;
 	auto result_data = (uint64_t *)result.data;
 
 	result.nullmask.reset();
-	tight_loop_hash<T>(ldata, result_data, input.count, input.sel_vector,
-	                                                             input.nullmask);
+	tight_loop_hash<T>(ldata, result_data, input.count, input.sel_vector, input.nullmask);
 	result.sel_vector = input.sel_vector;
 	result.count = input.count;
 }
@@ -73,8 +71,8 @@ static inline uint64_t combine_hash(uint64_t a, uint64_t b) {
 }
 
 template <class T>
-static inline void tight_loop_combine_hash(T *__restrict ldata, uint64_t *__restrict hash_data,
-                                                    index_t count, sel_t *__restrict sel_vector, nullmask_t &nullmask) {
+static inline void tight_loop_combine_hash(T *__restrict ldata, uint64_t *__restrict hash_data, index_t count,
+                                           sel_t *__restrict sel_vector, nullmask_t &nullmask) {
 	ASSERT_RESTRICT(ldata, ldata + count, hash_data, hash_data + count);
 	if (nullmask.any()) {
 		VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
@@ -89,8 +87,7 @@ static inline void tight_loop_combine_hash(T *__restrict ldata, uint64_t *__rest
 	}
 }
 
-template <class T>
-void templated_loop_combine_hash(Vector &input, Vector &hashes) {
+template <class T> void templated_loop_combine_hash(Vector &input, Vector &hashes) {
 	auto ldata = (T *)input.data;
 	auto hash_data = (uint64_t *)hashes.data;
 

--- a/src/common/vector_operations/hash.cpp
+++ b/src/common/vector_operations/hash.cpp
@@ -4,11 +4,35 @@
 //===--------------------------------------------------------------------===//
 
 #include "duckdb/common/operator/hash_operators.hpp"
-#include "duckdb/common/vector_operations/binary_loops.hpp"
-#include "duckdb/common/vector_operations/unary_loops.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
 
 using namespace duckdb;
 using namespace std;
+
+template <class LEFT_TYPE, class RESULT_TYPE, class OP>
+static inline void unary_loop_process_null_function(LEFT_TYPE *__restrict ldata, RESULT_TYPE *__restrict result_data,
+                                                    index_t count, sel_t *__restrict sel_vector, nullmask_t &nullmask) {
+	ASSERT_RESTRICT(ldata, ldata + count, result_data, result_data + count);
+	if (nullmask.any()) {
+		VectorOperations::Exec(sel_vector, count,
+		                       [&](index_t i, index_t k) { result_data[i] = OP::Operation(ldata[i], nullmask[i]); });
+	} else {
+		VectorOperations::Exec(sel_vector, count,
+		                       [&](index_t i, index_t k) { result_data[i] = OP::Operation(ldata[i], false); });
+	}
+}
+
+template <class LEFT_TYPE, class RESULT_TYPE, class OP>
+void templated_unary_loop_process_null(Vector &input, Vector &result) {
+	auto ldata = (LEFT_TYPE *)input.data;
+	auto result_data = (RESULT_TYPE *)result.data;
+
+	result.nullmask.reset();
+	unary_loop_process_null_function<LEFT_TYPE, RESULT_TYPE, OP>(ldata, result_data, input.count, input.sel_vector,
+	                                                             input.nullmask);
+	result.sel_vector = input.sel_vector;
+	result.count = input.count;
+}
 
 void VectorOperations::Hash(Vector &input, Vector &result) {
 	if (result.type != TypeId::HASH) {

--- a/src/common/vector_operations/scatter.cpp
+++ b/src/common/vector_operations/scatter.cpp
@@ -125,6 +125,9 @@ static void scatter_set_all_loop(Vector &source, data_ptr_t dest[], index_t offs
 	case TypeId::BIGINT:
 		scatter_set_loop<int64_t, IGNORE_NULL>(source, dest, offset);
 		break;
+	case TypeId::HASH:
+		scatter_set_loop<uint64_t, IGNORE_NULL>(source, dest, offset);
+		break;
 	case TypeId::FLOAT:
 		scatter_set_loop<float, IGNORE_NULL>(source, dest, offset);
 		break;

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -415,11 +415,15 @@ void ScanStructure::Next(DataChunk &keys, DataChunk &left, DataChunk &result) {
 	}
 }
 
-index_t ScanStructure::ResolvePredicates(DataChunk &keys, sel_t result[]) {
+void ScanStructure::ResolvePredicates(DataChunk &keys, Vector &final_result) {
 	Vector current_pointers;
 	current_pointers.Reference(pointers);
 
-	index_t match_count = 0;
+	sel_t temporary_selection_vector[STANDARD_VECTOR_SIZE];
+
+	auto old_sel_vector = current_pointers.sel_vector;
+	auto old_count = current_pointers.count;
+
 	for (index_t i = 0; i < ht.predicates.size(); i++) {
 		// gather the data from the pointers
 		Vector ht_data(keys.data[i].type, true, false);
@@ -439,22 +443,22 @@ index_t ScanStructure::ResolvePredicates(DataChunk &keys, sel_t result[]) {
 		// perform the comparison expression
 		switch (ht.predicates[i]) {
 		case ExpressionType::COMPARE_EQUAL:
-			match_count = VectorOperations::SelectEquals(keys.data[i], ht_data, result);
+			VectorOperations::Equals(keys.data[i], ht_data, final_result);
 			break;
 		case ExpressionType::COMPARE_GREATERTHAN:
-			match_count = VectorOperations::SelectGreaterThan(keys.data[i], ht_data, result);
+			VectorOperations::GreaterThan(keys.data[i], ht_data, final_result);
 			break;
 		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
-			match_count = VectorOperations::SelectGreaterThanEquals(keys.data[i], ht_data, result);
+			VectorOperations::GreaterThanEquals(keys.data[i], ht_data, final_result);
 			break;
 		case ExpressionType::COMPARE_LESSTHAN:
-			match_count = VectorOperations::SelectLessThan(keys.data[i], ht_data, result);
+			VectorOperations::LessThan(keys.data[i], ht_data, final_result);
 			break;
 		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
-			match_count = VectorOperations::SelectLessThanEquals(keys.data[i], ht_data, result);
+			VectorOperations::LessThanEquals(keys.data[i], ht_data, final_result);
 			break;
 		case ExpressionType::COMPARE_NOTEQUAL:
-			match_count = VectorOperations::SelectNotEquals(keys.data[i], ht_data, result);
+			VectorOperations::NotEquals(keys.data[i], ht_data, final_result);
 			break;
 		default:
 			throw NotImplementedException("Unimplemented comparison type for join");
@@ -465,31 +469,43 @@ index_t ScanStructure::ResolvePredicates(DataChunk &keys, sel_t result[]) {
 
 		// now based on the result recreate the selection vector for the next
 		// step so we can skip unnecessary comparisons in the next phase
-		current_pointers.sel_vector = result;
-		current_pointers.count = match_count;
-
+		if (i != ht.predicates.size() - 1) {
+			index_t new_count = 0;
+			VectorOperations::ExecType<bool>(final_result, [&](bool match, index_t index, index_t k) {
+				if (match && !final_result.nullmask[index]) {
+					temporary_selection_vector[new_count++] = index;
+				}
+			});
+			current_pointers.sel_vector = temporary_selection_vector;
+			current_pointers.count = new_count;
+		}
 		// move all the pointers to the next element
 		VectorOperations::AddInPlace(pointers, GetTypeIdSize(keys.data[i].type));
 	}
-	return match_count;
+	final_result.sel_vector = old_sel_vector;
+	final_result.count = old_count;
 }
 
 index_t ScanStructure::ScanInnerJoin(DataChunk &keys, DataChunk &left, DataChunk &result) {
-	sel_t result_indices[STANDARD_VECTOR_SIZE];
+	StaticVector<bool> comparison_result;
 	index_t result_count = 0;
 	do {
 		auto build_pointers = (data_ptr_t *)build_pointer_vector.data;
 
 		// resolve the predicates for all the pointers
-		result_count = ResolvePredicates(keys, result_indices);
+		ResolvePredicates(keys, comparison_result);
 
 		auto ptrs = (data_ptr_t *)pointers.data;
 		// after doing all the comparisons we loop to find all the actual matches
-		for(index_t i = 0; i < result_count; i++) {
-			found_match[result_indices[i]] = true;
-			result.owned_sel_vector[i] = result_indices[i];
-			build_pointers[i] = ptrs[result_indices[i]];
-		}
+		result_count = 0;
+		VectorOperations::ExecType<bool>(comparison_result, [&](bool match, index_t index, index_t k) {
+			if (match && !comparison_result.nullmask[index]) {
+				found_match[index] = true;
+				result.owned_sel_vector[result_count] = index;
+				build_pointers[result_count] = ptrs[index];
+				result_count++;
+			}
+		});
 
 		// finally we chase the pointers for the next iteration
 		index_t new_count = 0;
@@ -545,22 +561,19 @@ void ScanStructure::ScanKeyMatches(DataChunk &keys) {
 	// we handle the entire chunk in one call to Next().
 	// for every pointer, we keep chasing pointers and doing comparisons.
 	// this results in a boolean array indicating whether or not the tuple has a match
-	sel_t result_indices[STANDARD_VECTOR_SIZE];
+	StaticVector<bool> comparison_result;
 	while (pointers.count > 0) {
 		// resolve the predicates for the current set of pointers
-		index_t result_count = ResolvePredicates(keys, result_indices);
+		ResolvePredicates(keys, comparison_result);
 
 		// after doing all the comparisons we loop to find all the matches
 		auto ptrs = (data_ptr_t *)pointers.data;
 		index_t new_count = 0;
-		index_t result_idx = 0;
-		for(index_t i = 0; i < pointers.count; i++) {
-			auto index = pointers.sel_vector ? pointers.sel_vector[i] : i;
-			if (result_idx < result_count && index == result_indices[result_idx]) {
+		VectorOperations::ExecType<bool>(comparison_result, [&](bool match, index_t index, index_t k) {
+			if (match) {
 				// found a match, set the entry to true
 				// after this we no longer need to check this entry
 				found_match[index] = true;
-				result_idx++;
 			} else {
 				// did not find a match, keep on looking for this entry
 				// first check if there is a next entry
@@ -571,7 +584,7 @@ void ScanStructure::ScanKeyMatches(DataChunk &keys) {
 					sel_vector[new_count++] = index;
 				}
 			}
-		}
+		});
 		pointers.count = new_count;
 	}
 }
@@ -755,14 +768,20 @@ void ScanStructure::NextSingleJoin(DataChunk &keys, DataChunk &left, DataChunk &
 	sel_t result_sel_vector[STANDARD_VECTOR_SIZE];
 	while (pointers.count > 0) {
 		// resolve the predicates for all the pointers
-		result_count = ResolvePredicates(keys, result_sel_vector);
+		ResolvePredicates(keys, comparison_result);
 
 		auto ptrs = (data_ptr_t *)pointers.data;
-		for(index_t i = 0; i < result_count; i++) {
-			found_match[result_sel_vector[i]] = true;
-			build_pointers[i] = ptrs[result_sel_vector[i]];
-			result_sel_vector[i] = result_sel_vector[i];
-		}
+		// after doing all the comparisons we loop to find all the actual matches
+		VectorOperations::ExecType<bool>(comparison_result, [&](bool match, index_t index, index_t k) {
+			if (match) {
+				// found a match for this index
+				// set the build_pointers to this position
+				found_match[index] = true;
+				build_pointers[result_count] = ptrs[index];
+				result_sel_vector[result_count] = index;
+				result_count++;
+			}
+		});
 
 		// finally we chase the pointers for the next iteration
 		index_t new_count = 0;

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -22,21 +22,9 @@ static void SerializeChunk(DataChunk &source, data_ptr_t targets[]) {
 	}
 }
 
-static void DeserializeChunk(DataChunk &result, data_ptr_t source[], index_t count) {
-	Vector source_vector(TypeId::POINTER, (data_ptr_t)source);
-	source_vector.count = count;
-
-	index_t offset = 0;
-	for (index_t i = 0; i < result.column_count; i++) {
-		VectorOperations::Gather::Set(source_vector, result.data[i], false, offset);
-		offset += GetTypeIdSize(result.data[i].type);
-	}
-}
-
-JoinHashTable::JoinHashTable(vector<JoinCondition> &conditions, vector<TypeId> build_types, JoinType type,
-							 index_t initial_capacity, bool parallel)
+JoinHashTable::JoinHashTable(vector<JoinCondition> &conditions, vector<TypeId> build_types, JoinType type, bool parallel)
 	: build_types(build_types), equality_size(0), condition_size(0), build_size(0), entry_size(0), tuple_size(0),
-	  join_type(type), finalized(false), has_null(false), capacity(0), count(0), parallel(parallel) {
+	  join_type(type), finalized(false), has_null(false), count(0), parallel(parallel) {
 	for (auto &condition : conditions) {
 		assert(condition.left->return_type == condition.right->return_type);
 		auto type = condition.left->return_type;

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -27,7 +27,8 @@ PhysicalHashJoin::PhysicalHashJoin(ClientContext &context, LogicalOperator &op, 
 	children.push_back(move(left));
 	children.push_back(move(right));
 
-	hash_table = make_unique<JoinHashTable>(*context.db.storage->buffer_manager, conditions, children[1]->GetTypes(), type);
+	hash_table =
+	    make_unique<JoinHashTable>(*context.db.storage->buffer_manager, conditions, children[1]->GetTypes(), type);
 }
 
 void PhysicalHashJoin::BuildHashTable(ClientContext &context, PhysicalOperatorState *state_) {
@@ -111,14 +112,15 @@ void PhysicalHashJoin::ProbeHashTable(ClientContext &context, DataChunk &chunk, 
 					result_vector.nullmask.set();
 				}
 				return;
-			} else if (hash_table->join_type == JoinType::LEFT || hash_table->join_type == JoinType::OUTER || hash_table->join_type == JoinType::SINGLE) {
+			} else if (hash_table->join_type == JoinType::LEFT || hash_table->join_type == JoinType::OUTER ||
+			           hash_table->join_type == JoinType::SINGLE) {
 				// LEFT/FULL OUTER/SINGLE join and build side is empty
 				// for the LHS we reference the data
 				for (index_t i = 0; i < state->child_chunk.column_count; i++) {
 					chunk.data[i].Reference(state->child_chunk.data[i]);
 				}
 				// for the RHS
-				for(index_t k = state->child_chunk.column_count; k < chunk.column_count; k++) {
+				for (index_t k = state->child_chunk.column_count; k < chunk.column_count; k++) {
 					chunk.data[k].count = state->child_chunk.size();
 					chunk.data[k].nullmask.set();
 				}
@@ -146,7 +148,7 @@ void PhysicalHashJoin::GetChunkInternal(ClientContext &context, DataChunk &chunk
 		state->initialized = true;
 
 		if (hash_table->size() == 0 &&
-			(hash_table->join_type == JoinType::INNER || hash_table->join_type == JoinType::SEMI)) {
+		    (hash_table->join_type == JoinType::INNER || hash_table->join_type == JoinType::SEMI)) {
 			// empty hash table with INNER or SEMI join means empty result set
 			return;
 		}
@@ -156,7 +158,7 @@ void PhysicalHashJoin::GetChunkInternal(ClientContext &context, DataChunk &chunk
 		if (chunk.size() == 0) {
 			if (state->cached_chunk.size() > 0) {
 				// finished probing but cached data remains, return cached chunk
-				for(index_t col_idx = 0; col_idx < chunk.column_count; col_idx++) {
+				for (index_t col_idx = 0; col_idx < chunk.column_count; col_idx++) {
 					state->cached_chunk.data[col_idx].Move(chunk.data[col_idx]);
 				}
 				chunk.sel_vector = state->cached_chunk.sel_vector;
@@ -168,7 +170,7 @@ void PhysicalHashJoin::GetChunkInternal(ClientContext &context, DataChunk &chunk
 			state->cached_chunk.Append(chunk);
 			if (state->cached_chunk.size() >= (1024 - 64)) {
 				// chunk cache full: return it
-				for(index_t col_idx = 0; col_idx < chunk.column_count; col_idx++) {
+				for (index_t col_idx = 0; col_idx < chunk.column_count; col_idx++) {
 					state->cached_chunk.data[col_idx].Move(chunk.data[col_idx]);
 				}
 				chunk.sel_vector = state->cached_chunk.sel_vector;
@@ -181,5 +183,5 @@ void PhysicalHashJoin::GetChunkInternal(ClientContext &context, DataChunk &chunk
 		} else {
 			return;
 		}
-	} while(true);
+	} while (true);
 }

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -108,6 +108,18 @@ void PhysicalHashJoin::ProbeHashTable(ClientContext &context, DataChunk &chunk, 
 					result_vector.nullmask.set();
 				}
 				return;
+			} else if (hash_table->join_type == JoinType::LEFT || hash_table->join_type == JoinType::OUTER || hash_table->join_type == JoinType::SINGLE) {
+				// LEFT/FULL OUTER/SINGLE join and build side is empty
+				// for the LHS we reference the data
+				for (index_t i = 0; i < state->child_chunk.column_count; i++) {
+					chunk.data[i].Reference(state->child_chunk.data[i]);
+				}
+				// for the RHS
+				for(index_t k = state->child_chunk.column_count; k < chunk.column_count; k++) {
+					chunk.data[k].count = state->child_chunk.size();
+					chunk.data[k].nullmask.set();
+				}
+				return;
 			}
 		}
 		// resolve the join keys for the left chunk

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -13,6 +13,7 @@ public:
 	}
 
 	bool initialized;
+	DataChunk cached_chunk;
 	DataChunk join_keys;
 	unique_ptr<JoinHashTable::ScanStructure> scan_structure;
 };
@@ -26,38 +27,39 @@ PhysicalHashJoin::PhysicalHashJoin(LogicalOperator &op, unique_ptr<PhysicalOpera
 	children.push_back(move(right));
 }
 
-void PhysicalHashJoin::GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state_) {
+void PhysicalHashJoin::BuildHashTable(ClientContext &context, PhysicalOperatorState *state_) {
 	auto state = reinterpret_cast<PhysicalHashJoinState *>(state_);
-	if (!state->initialized) {
+
+	// build the HT
+	auto right_state = children[1]->GetOperatorState();
+	auto types = children[1]->GetTypes();
+
+	DataChunk right_chunk;
+	right_chunk.Initialize(types);
+
+	state->join_keys.Initialize(hash_table->condition_types);
+	while (true) {
+		// get the child chunk
+		children[1]->GetChunk(context, right_chunk, right_state.get());
+		if (right_chunk.size() == 0) {
+			break;
+		}
+		// resolve the join keys for the right chunk
+		state->rhs_executor.Execute(right_chunk, state->join_keys);
+
 		// build the HT
-		auto right_state = children[1]->GetOperatorState();
-		auto types = children[1]->GetTypes();
-
-		DataChunk right_chunk;
-		right_chunk.Initialize(types);
-
-		state->join_keys.Initialize(hash_table->condition_types);
-		while (true) {
-			// get the child chunk
-			children[1]->GetChunk(context, right_chunk, right_state.get());
-			if (right_chunk.size() == 0) {
-				break;
-			}
-			// resolve the join keys for the right chunk
-			state->rhs_executor.Execute(right_chunk, state->join_keys);
-
-			// build the HT
-			hash_table->Build(state->join_keys, right_chunk);
-		}
-
-		if (hash_table->size() == 0 &&
-		    (hash_table->join_type == JoinType::INNER || hash_table->join_type == JoinType::SEMI)) {
-			// empty hash table with INNER or SEMI join means empty result set
-			return;
-		}
-
-		state->initialized = true;
+		hash_table->Build(state->join_keys, right_chunk);
 	}
+
+	if (hash_table->size() == 0 &&
+		(hash_table->join_type == JoinType::INNER || hash_table->join_type == JoinType::SEMI)) {
+		// empty hash table with INNER or SEMI join means empty result set
+		return;
+	}
+}
+
+void PhysicalHashJoin::ProbeHashTable(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state_) {
+	auto state = reinterpret_cast<PhysicalHashJoinState *>(state_);
 	if (state->child_chunk.size() > 0 && state->scan_structure) {
 		// still have elements remaining from the previous probe (i.e. we got
 		// >1024 elements in the previous probe)
@@ -124,4 +126,44 @@ void PhysicalHashJoin::GetChunkInternal(ClientContext &context, DataChunk &chunk
 
 unique_ptr<PhysicalOperatorState> PhysicalHashJoin::GetOperatorState() {
 	return make_unique<PhysicalHashJoinState>(children[0].get(), children[1].get(), conditions);
+}
+
+void PhysicalHashJoin::GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state_) {
+	auto state = reinterpret_cast<PhysicalHashJoinState *>(state_);
+	if (!state->initialized) {
+		state->cached_chunk.Initialize(types);
+		BuildHashTable(context, state_);
+		state->initialized = true;
+	}
+	do {
+		ProbeHashTable(context, chunk, state);
+		if (chunk.size() == 0) {
+			if (state->cached_chunk.size() > 0) {
+				// finished probing but cached data remains, return cached chunk
+				for(index_t col_idx = 0; col_idx < chunk.column_count; col_idx++) {
+					state->cached_chunk.data[col_idx].Move(chunk.data[col_idx]);
+				}
+				chunk.sel_vector = state->cached_chunk.sel_vector;
+				state->cached_chunk.Reset();
+			}
+			return;
+		} else if (chunk.size() < 64) {
+			// small chunk: add it to chunk cache and continue
+			state->cached_chunk.Append(chunk);
+			if (state->cached_chunk.size() >= (1024 - 64)) {
+				// chunk cache full: return it
+				for(index_t col_idx = 0; col_idx < chunk.column_count; col_idx++) {
+					state->cached_chunk.data[col_idx].Move(chunk.data[col_idx]);
+				}
+				chunk.sel_vector = state->cached_chunk.sel_vector;
+				state->cached_chunk.Reset();
+				return;
+			} else {
+				// chunk cache not full: probe again
+				chunk.Reset();
+			}
+		} else {
+			return;
+		}
+	} while(true);
 }

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -35,7 +35,7 @@ void PhysicalOperator::GetChunk(ClientContext &context, DataChunk &chunk, Physic
 	if (context.interrupted) {
 		throw InterruptException();
 	}
-	// finished with this operator
+
 	chunk.Reset();
 	if (state->finished) {
 		return;

--- a/src/execution/physical_plan/plan_comparison_join.cpp
+++ b/src/execution/physical_plan/plan_comparison_join.cpp
@@ -39,7 +39,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalComparison
 	unique_ptr<PhysicalOperator> plan;
 	if (has_equality) {
 		// equality join: use hash join
-		plan = make_unique<PhysicalHashJoin>(op, move(left), move(right), move(op.conditions), op.type);
+		plan = make_unique<PhysicalHashJoin>(context, op, move(left), move(right), move(op.conditions), op.type);
 	} else {
 		assert(!has_null_equal_conditions); // don't support this for anything but hash joins for now
 		if (op.conditions.size() == 1 && (op.type == JoinType::MARK || op.type == JoinType::INNER) && !has_inequality) {

--- a/src/execution/physical_plan/plan_set_operation.cpp
+++ b/src/execution/physical_plan/plan_set_operation.cpp
@@ -38,7 +38,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSetOperati
 		// EXCEPT is ANTI join
 		// INTERSECT is SEMI join
 		JoinType join_type = op.type == LogicalOperatorType::EXCEPT ? JoinType::ANTI : JoinType::SEMI;
-		return make_unique<PhysicalHashJoin>(op, move(left), move(right), move(conditions), join_type);
+		return make_unique<PhysicalHashJoin>(context, op, move(left), move(right), move(conditions), join_type);
 	}
 	}
 }

--- a/src/include/duckdb/common/types/hash.hpp
+++ b/src/include/duckdb/common/types/hash.hpp
@@ -18,21 +18,11 @@ namespace duckdb {
 // bias
 // see: https://nullprogram.com/blog/2018/07/31/
 inline uint64_t murmurhash32(uint32_t x) {
-	x ^= x >> 16;
-	x *= UINT32_C(0x85ebca6b);
-	x ^= x >> 13;
-	x *= UINT32_C(0xc2b2ae35);
-	x ^= x >> 16;
-	return (uint64_t)x;
+	return x * UINT32_C(0x85ebca6b);
 }
 
 inline uint64_t murmurhash64(uint64_t x) {
-	x ^= x >> 30;
-	x *= UINT64_C(0xbf58476d1ce4e5b9);
-	x ^= x >> 27;
-	x *= UINT64_C(0x94d049bb133111eb);
-	x ^= x >> 31;
-	return x;
+	return x * UINT64_C(0xbf58476d1ce4e5b9);
 }
 
 template <class T> uint64_t Hash(T value) {

--- a/src/include/duckdb/common/vector_operations/unary_loops.hpp
+++ b/src/include/duckdb/common/vector_operations/unary_loops.hpp
@@ -49,28 +49,4 @@ void templated_unary_loop(Vector &input, Vector &result) {
 	result.count = input.count;
 }
 
-template <class LEFT_TYPE, class RESULT_TYPE, class OP>
-static inline void unary_loop_process_null_function(LEFT_TYPE *__restrict ldata, RESULT_TYPE *__restrict result_data,
-                                                    index_t count, sel_t *__restrict sel_vector, nullmask_t &nullmask) {
-	ASSERT_RESTRICT(ldata, ldata + count, result_data, result_data + count);
-	if (nullmask.any()) {
-		VectorOperations::Exec(sel_vector, count,
-		                       [&](index_t i, index_t k) { result_data[i] = OP::Operation(ldata[i], nullmask[i]); });
-	} else {
-		VectorOperations::Exec(sel_vector, count,
-		                       [&](index_t i, index_t k) { result_data[i] = OP::Operation(ldata[i], false); });
-	}
-}
-
-template <class LEFT_TYPE, class RESULT_TYPE, class OP>
-void templated_unary_loop_process_null(Vector &input, Vector &result) {
-	auto ldata = (LEFT_TYPE *)input.data;
-	auto result_data = (RESULT_TYPE *)result.data;
-
-	result.nullmask.reset();
-	unary_loop_process_null_function<LEFT_TYPE, RESULT_TYPE, OP>(ldata, result_data, input.count, input.sel_vector,
-	                                                             input.nullmask);
-	result.sel_vector = input.sel_vector;
-	result.count = input.count;
-}
 } // namespace duckdb

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -101,11 +101,10 @@ private:
 public:
 	JoinHashTable(vector<JoinCondition> &conditions, vector<TypeId> build_types, JoinType type,
 	              index_t initial_capacity = 32768, bool parallel = false);
-	//! Resize the HT to the specified size. Must be larger than the current
-	//! size.
-	void Resize(index_t size);
 	//! Add the given data to the HT
 	void Build(DataChunk &keys, DataChunk &input);
+	//! Finalize the build of the HT, constructing the actual hash table and making the HT ready for probing. Finalize must be called before any call to Probe, and after Finalize is called Build should no longer be ever called.
+	void Finalize();
 	//! Probe the HT with the given input chunk, resulting in the given result
 	unique_ptr<ScanStructure> Probe(DataChunk &keys);
 
@@ -136,6 +135,8 @@ public:
 	index_t tuple_size;
 	//! The join type of the HT
 	JoinType join_type;
+	//! Whether or not the HT has been finalized
+	bool finalized;
 	//! Whether or not any of the key elements contain NULL
 	bool has_null;
 	//! Bitmask for getting relevant bits from the hashes to determine the position

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -99,8 +99,7 @@ private:
 	void Hash(DataChunk &keys, Vector &hashes);
 
 public:
-	JoinHashTable(vector<JoinCondition> &conditions, vector<TypeId> build_types, JoinType type,
-	              index_t initial_capacity = 32768, bool parallel = false);
+	JoinHashTable(vector<JoinCondition> &conditions, vector<TypeId> build_types, JoinType type, bool parallel = false);
 	//! Add the given data to the HT
 	void Build(DataChunk &keys, DataChunk &input);
 	//! Finalize the build of the HT, constructing the actual hash table and making the HT ready for probing. Finalize must be called before any call to Probe, and after Finalize is called Build should no longer be ever called.
@@ -164,9 +163,7 @@ private:
 	//! Insert the given set of locations into the HT with the given set of
 	//! hashes. Caller should hold lock in parallel HT.
 	void InsertHashes(Vector &hashes, data_ptr_t key_locations[]);
-	//! The capacity of the HT. This can be increased using
-	//! JoinHashTable::Resize
-	index_t capacity;
+
 	//! The amount of entries stored in the HT currently
 	index_t count;
 	//! The data of the HT

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -86,17 +86,20 @@ private:
 		block_id_t block_id;
 	};
 
-	index_t AppendToBlock(HTDataBlock &block, BufferHandle &handle, Vector &key_data, data_ptr_t key_locations[], data_ptr_t tuple_locations[], data_ptr_t hash_locations[], index_t remaining);
+	index_t AppendToBlock(HTDataBlock &block, BufferHandle &handle, Vector &key_data, data_ptr_t key_locations[],
+	                      data_ptr_t tuple_locations[], data_ptr_t hash_locations[], index_t remaining);
 
 	void Hash(DataChunk &keys, Vector &hashes);
 
 public:
-	JoinHashTable(BufferManager &buffer_manager, vector<JoinCondition> &conditions, vector<TypeId> build_types, JoinType type);
+	JoinHashTable(BufferManager &buffer_manager, vector<JoinCondition> &conditions, vector<TypeId> build_types,
+	              JoinType type);
 	~JoinHashTable();
 
 	//! Add the given data to the HT
 	void Build(DataChunk &keys, DataChunk &input);
-	//! Finalize the build of the HT, constructing the actual hash table and making the HT ready for probing. Finalize must be called before any call to Probe, and after Finalize is called Build should no longer be ever called.
+	//! Finalize the build of the HT, constructing the actual hash table and making the HT ready for probing. Finalize
+	//! must be called before any call to Probe, and after Finalize is called Build should no longer be ever called.
 	void Finalize();
 	//! Probe the HT with the given input chunk, resulting in the given result
 	unique_ptr<ScanStructure> Probe(DataChunk &keys);

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -74,7 +74,8 @@ public:
 
 		index_t ScanInnerJoin(DataChunk &keys, DataChunk &left, DataChunk &result);
 
-		void ResolvePredicates(DataChunk &keys, Vector &comparison_result);
+		//! Check the given set of keys against the data stored in the set of pointers; returns the amount of matches found
+		index_t ResolvePredicates(DataChunk &keys, sel_t result[]);
 	};
 
 private:

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -75,6 +75,7 @@ public:
 		index_t ScanInnerJoin(DataChunk &keys, DataChunk &left, DataChunk &result);
 
 		void ResolvePredicates(DataChunk &keys, Vector &comparison_result);
+		index_t ResolvePredicates(DataChunk &keys, sel_t comparison_result[]);
 	};
 
 private:

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -74,8 +74,7 @@ public:
 
 		index_t ScanInnerJoin(DataChunk &keys, DataChunk &left, DataChunk &result);
 
-		//! Check the given set of keys against the data stored in the set of pointers; returns the amount of matches found
-		index_t ResolvePredicates(DataChunk &keys, sel_t result[]);
+		void ResolvePredicates(DataChunk &keys, Vector &comparison_result);
 	};
 
 private:

--- a/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
@@ -27,6 +27,10 @@ public:
 public:
 	void GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;
 	unique_ptr<PhysicalOperatorState> GetOperatorState() override;
+private:
+	void BuildHashTable(ClientContext &context, PhysicalOperatorState *state_);
+	void ProbeHashTable(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state_);
+
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
@@ -19,18 +19,18 @@ namespace duckdb {
 //! PhysicalHashJoin represents a hash loop join between two tables
 class PhysicalHashJoin : public PhysicalComparisonJoin {
 public:
-	PhysicalHashJoin(ClientContext &context, LogicalOperator &op, unique_ptr<PhysicalOperator> left, unique_ptr<PhysicalOperator> right,
-	                 vector<JoinCondition> cond, JoinType join_type);
+	PhysicalHashJoin(ClientContext &context, LogicalOperator &op, unique_ptr<PhysicalOperator> left,
+	                 unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type);
 
 	unique_ptr<JoinHashTable> hash_table;
 
 public:
 	void GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;
 	unique_ptr<PhysicalOperatorState> GetOperatorState() override;
+
 private:
 	void BuildHashTable(ClientContext &context, PhysicalOperatorState *state_);
 	void ProbeHashTable(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state_);
-
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
@@ -19,7 +19,7 @@ namespace duckdb {
 //! PhysicalHashJoin represents a hash loop join between two tables
 class PhysicalHashJoin : public PhysicalComparisonJoin {
 public:
-	PhysicalHashJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left, unique_ptr<PhysicalOperator> right,
+	PhysicalHashJoin(ClientContext &context, LogicalOperator &op, unique_ptr<PhysicalOperator> left, unique_ptr<PhysicalOperator> right,
 	                 vector<JoinCondition> cond, JoinType join_type);
 
 	unique_ptr<JoinHashTable> hash_table;

--- a/src/optimizer/join_order_optimizer.cpp
+++ b/src/optimizer/join_order_optimizer.cpp
@@ -45,13 +45,6 @@ bool JoinOrderOptimizer::ExtractBindings(Expression &expression, unordered_set<i
 	return can_reorder;
 }
 
-static void ExtractFilters(LogicalOperator *op, vector<unique_ptr<Expression>> &filters) {
-	for (index_t i = 0; i < op->expressions.size(); i++) {
-		filters.push_back(move(op->expressions[i]));
-	}
-	op->expressions.clear();
-}
-
 static unique_ptr<LogicalOperator> PushFilter(unique_ptr<LogicalOperator> node, unique_ptr<Expression> expr) {
 	// push an expression into a filter
 	// first check if we have any filter to push it into
@@ -201,7 +194,7 @@ static unique_ptr<JoinNode> CreateJoinTree(RelationSet *set, NeighborInfo *info,
 		expected_cardinality = std::max(left->cardinality, right->cardinality);
 	}
 	// cost is expected_cardinality plus the cost of the previous plans
-	index_t cost = expected_cardinality;
+	index_t cost = left->cost + right->cost + expected_cardinality;
 	return make_unique<JoinNode>(set, info, left, right, expected_cardinality, cost);
 }
 
@@ -650,19 +643,29 @@ unique_ptr<LogicalOperator> JoinOrderOptimizer::Optimize(unique_ptr<LogicalOpera
 		// at most one relation, nothing to reorder
 		return plan;
 	}
-	// now that we know we are going to perform join ordering we actually extract the filters
+	// now that we know we are going to perform join ordering we actually extract the filters, eliminating duplicate filters in the process
+	expression_set_t filter_set;
 	for (auto &op : filter_operators) {
 		if (op->type == LogicalOperatorType::COMPARISON_JOIN) {
 			auto &join = (LogicalComparisonJoin &)*op;
 			assert(join.type == JoinType::INNER);
 			assert(join.expressions.size() == 0);
 			for (auto &cond : join.conditions) {
-				filters.push_back(
-				    make_unique<BoundComparisonExpression>(cond.comparison, move(cond.left), move(cond.right)));
+				auto comparison = make_unique<BoundComparisonExpression>(cond.comparison, move(cond.left), move(cond.right));
+				if (filter_set.find(comparison.get()) == filter_set.end()) {
+					filter_set.insert(comparison.get());
+					filters.push_back(move(comparison));
+				}
 			}
 			join.conditions.clear();
 		} else {
-			ExtractFilters(op, filters);
+			for (index_t i = 0; i < op->expressions.size(); i++) {
+				if (filter_set.find(op->expressions[i].get()) == filter_set.end()) {
+					filter_set.insert(op->expressions[i].get());
+					filters.push_back(move(op->expressions[i]));
+				}
+			}
+			op->expressions.clear();
 		}
 	}
 	// create potential edges from the comparisons

--- a/src/optimizer/join_order_optimizer.cpp
+++ b/src/optimizer/join_order_optimizer.cpp
@@ -643,7 +643,8 @@ unique_ptr<LogicalOperator> JoinOrderOptimizer::Optimize(unique_ptr<LogicalOpera
 		// at most one relation, nothing to reorder
 		return plan;
 	}
-	// now that we know we are going to perform join ordering we actually extract the filters, eliminating duplicate filters in the process
+	// now that we know we are going to perform join ordering we actually extract the filters, eliminating duplicate
+	// filters in the process
 	expression_set_t filter_set;
 	for (auto &op : filter_operators) {
 		if (op->type == LogicalOperatorType::COMPARISON_JOIN) {
@@ -651,7 +652,8 @@ unique_ptr<LogicalOperator> JoinOrderOptimizer::Optimize(unique_ptr<LogicalOpera
 			assert(join.type == JoinType::INNER);
 			assert(join.expressions.size() == 0);
 			for (auto &cond : join.conditions) {
-				auto comparison = make_unique<BoundComparisonExpression>(cond.comparison, move(cond.left), move(cond.right));
+				auto comparison =
+				    make_unique<BoundComparisonExpression>(cond.comparison, move(cond.left), move(cond.right));
 				if (filter_set.find(comparison.get()) == filter_set.end()) {
 					filter_set.insert(comparison.get());
 					filters.push_back(move(comparison));

--- a/src/optimizer/join_order_optimizer.cpp
+++ b/src/optimizer/join_order_optimizer.cpp
@@ -194,7 +194,7 @@ static unique_ptr<JoinNode> CreateJoinTree(RelationSet *set, NeighborInfo *info,
 		expected_cardinality = std::max(left->cardinality, right->cardinality);
 	}
 	// cost is expected_cardinality plus the cost of the previous plans
-	index_t cost = left->cost + right->cost + expected_cardinality;
+	index_t cost = expected_cardinality;
 	return make_unique<JoinNode>(set, info, left, right, expected_cardinality, cost);
 }
 

--- a/test/monetdb/test_leftjoin_bug.cpp
+++ b/test/monetdb/test_leftjoin_bug.cpp
@@ -14,7 +14,8 @@ TEST_CASE("MonetDB Test: leftjoin.Bug-3981.sql", "[monetdb]") {
 
 	result = con.Query(
 	    "SELECT * FROM ( SELECT 'apple' as fruit UNION ALL SELECT 'banana' ) a JOIN ( SELECT 'apple' as fruit UNION "
-	    "ALL SELECT 'banana' ) b ON a.fruit=b.fruit LEFT JOIN ( SELECT 1 as isyellow ) c ON b.fruit='banana' ORDER BY 1, 2, 3;");
+	    "ALL SELECT 'banana' ) b ON a.fruit=b.fruit LEFT JOIN ( SELECT 1 as isyellow ) c ON b.fruit='banana' ORDER BY "
+	    "1, 2, 3;");
 	REQUIRE(CHECK_COLUMN(result, 0, {"apple", "banana"}));
 	REQUIRE(CHECK_COLUMN(result, 1, {"apple", "banana"}));
 	REQUIRE(CHECK_COLUMN(result, 2, {Value(), 1}));

--- a/test/monetdb/test_leftjoin_bug.cpp
+++ b/test/monetdb/test_leftjoin_bug.cpp
@@ -14,7 +14,7 @@ TEST_CASE("MonetDB Test: leftjoin.Bug-3981.sql", "[monetdb]") {
 
 	result = con.Query(
 	    "SELECT * FROM ( SELECT 'apple' as fruit UNION ALL SELECT 'banana' ) a JOIN ( SELECT 'apple' as fruit UNION "
-	    "ALL SELECT 'banana' ) b ON a.fruit=b.fruit LEFT JOIN ( SELECT 1 as isyellow ) c ON b.fruit='banana';");
+	    "ALL SELECT 'banana' ) b ON a.fruit=b.fruit LEFT JOIN ( SELECT 1 as isyellow ) c ON b.fruit='banana' ORDER BY 1, 2, 3;");
 	REQUIRE(CHECK_COLUMN(result, 0, {"apple", "banana"}));
 	REQUIRE(CHECK_COLUMN(result, 1, {"apple", "banana"}));
 	REQUIRE(CHECK_COLUMN(result, 2, {Value(), 1}));

--- a/test/sakila/test_sakila.cpp
+++ b/test/sakila/test_sakila.cpp
@@ -95,9 +95,9 @@ TEST_CASE("Run Sakila test queries", "[sakila][.]") {
 	REQUIRE(CHECK_COLUMN(result, 0, {"HUNCHBACK IMPOSSIBLE"}));
 	REQUIRE(CHECK_COLUMN(result, 1, {6}));
 
-	result = con.Query(
-	    "SELECT first_name, last_name, SUM(amount) as total_paid FROM payment INNER JOIN customer ON "
-	    "payment.customer_id = customer.customer_id GROUP BY first_name, last_name ORDER BY total_paid desc, first_name limit 10");
+	result = con.Query("SELECT first_name, last_name, SUM(amount) as total_paid FROM payment INNER JOIN customer ON "
+	                   "payment.customer_id = customer.customer_id GROUP BY first_name, last_name ORDER BY total_paid "
+	                   "desc, first_name limit 10");
 	REQUIRE_NO_FAIL(*result);
 	REQUIRE(CHECK_COLUMN(result, 0,
 	                     {"KARL", "ELEANOR", "CLARA", "MARION", "RHONDA", "TOMMY", "WESLEY", "TIM", "MARCIA", "ANA"}));

--- a/test/sakila/test_sakila.cpp
+++ b/test/sakila/test_sakila.cpp
@@ -97,7 +97,7 @@ TEST_CASE("Run Sakila test queries", "[sakila][.]") {
 
 	result = con.Query(
 	    "SELECT first_name, last_name, SUM(amount) as total_paid FROM payment INNER JOIN customer ON "
-	    "payment.customer_id = customer.customer_id GROUP BY first_name, last_name ORDER BY total_paid desc limit 10");
+	    "payment.customer_id = customer.customer_id GROUP BY first_name, last_name ORDER BY total_paid desc, first_name limit 10");
 	REQUIRE_NO_FAIL(*result);
 	REQUIRE(CHECK_COLUMN(result, 0,
 	                     {"KARL", "ELEANOR", "CLARA", "MARION", "RHONDA", "TOMMY", "WESLEY", "TIM", "MARCIA", "ANA"}));

--- a/test/sql/aggregate/test_aggregate.cpp
+++ b/test/sql/aggregate/test_aggregate.cpp
@@ -126,9 +126,10 @@ TEST_CASE("Test STRING_AGG operator", "[aggregate]") {
 	REQUIRE(CHECK_COLUMN(result, 0, {"a,b,i,j,p,x,y,z"}));
 	REQUIRE(CHECK_COLUMN(result, 1, {"a-b/i+j/p/x-y+z"}));
 
-	result = con.Query("SELECT STRING_AGG(x,','), STRING_AGG(x,y) FROM strings GROUP BY g");
-	REQUIRE(CHECK_COLUMN(result, 0, {"a,b", "x,y,z", "i,j", "p"}));
-	REQUIRE(CHECK_COLUMN(result, 1, {"a-b", "x-y+z", "i+j", "p"}));
+	result = con.Query("SELECT g, STRING_AGG(x,','), STRING_AGG(x,y) FROM strings GROUP BY g ORDER BY g");
+	REQUIRE(CHECK_COLUMN(result, 0, {1, 2, 3, 4}));
+	REQUIRE(CHECK_COLUMN(result, 1, {"a,b", "i,j", "p", "x,y,z"}));
+	REQUIRE(CHECK_COLUMN(result, 2, {"a-b", "i+j", "p", "x-y+z"}));
 
 	// test average on empty set
 	result = con.Query("SELECT STRING_AGG(x,','), STRING_AGG(x,y) FROM strings WHERE g > 100");

--- a/test/sql/simple/test_groupby.cpp
+++ b/test/sql/simple/test_groupby.cpp
@@ -238,7 +238,7 @@ TEST_CASE("Group by multiple columns", "[aggregations]") {
 	REQUIRE_NO_FAIL(
 	    con.Query("INSERT INTO integers VALUES (1, 1, 2), (1, 2, 2), (1, 1, 2), (2, 1, 2), (1, 2, 4), (1, 2, NULL);"));
 
-	result = con.Query("SELECT i, j, SUM(k), COUNT(*), COUNT(k) FROM integers GROUP BY i, j ORDER BY 1");
+	result = con.Query("SELECT i, j, SUM(k), COUNT(*), COUNT(k) FROM integers GROUP BY i, j ORDER BY 1, 2");
 	REQUIRE(CHECK_COLUMN(result, 0, {1, 1, 2}));
 	REQUIRE(CHECK_COLUMN(result, 1, {1, 2, 1}));
 	REQUIRE(CHECK_COLUMN(result, 2, {4, 6, 2}));

--- a/test/sql/simple/test_join.cpp
+++ b/test/sql/simple/test_join.cpp
@@ -24,6 +24,12 @@ TEST_CASE("Test basic joins of tables", "[joins]") {
 		REQUIRE(CHECK_COLUMN(result, 1, {1, 1, 2}));
 		REQUIRE(CHECK_COLUMN(result, 2, {10, 20, 30}));
 	}
+	SECTION("simple cross product + multiple join conditions") {
+		result = con.Query("SELECT a, test.b, c FROM test, test2 WHERE test.b=test2.b AND test.a-1=test2.c");
+		REQUIRE(CHECK_COLUMN(result, 0, {11}));
+		REQUIRE(CHECK_COLUMN(result, 1, {1}));
+		REQUIRE(CHECK_COLUMN(result, 2, {10}));
+	}
 	SECTION("use join columns in subquery") {
 		result = con.Query("SELECT a, (SELECT test.a), c FROM test, test2 WHERE "
 		                   "test.b = test2.b ORDER BY c;");

--- a/test/sql/simple/test_table_subquery.cpp
+++ b/test/sql/simple/test_table_subquery.cpp
@@ -23,7 +23,7 @@ TEST_CASE("Table subquery", "[subquery]") {
 
 	// join with subqueries
 	result = con.Query("SELECT a.i,a.j,b.r,b.j FROM (SELECT i, j FROM test) AS a "
-	                   "INNER JOIN (SELECT i+1 AS r,j FROM test) AS b ON a.i=b.r;");
+	                   "INNER JOIN (SELECT i+1 AS r,j FROM test) AS b ON a.i=b.r ORDER BY 1;");
 	REQUIRE(CHECK_COLUMN(result, 0, {4, 5}));
 	REQUIRE(CHECK_COLUMN(result, 1, {5, 6}));
 	REQUIRE(CHECK_COLUMN(result, 2, {4, 5}));


### PR DESCRIPTION
(Ignore the name of the branch, I was going to work on the scan but then got sidetracked)

This PR implements several modifications to the hash table used in the hash join. First, the join hash table is modified to use the buffer manager for storage instead of allocating its own memory. While constructing the hash table blocks are allocated from the buffer manager and data is written into these blocks. In the Finalize method, the blocks are pinned again and the actual hash table is constructed. The blocks are kept pinned in memory during the probing phase, and only released when the hash table is destroyed and no longer required.

The advantages of this approach are that (1) the hash table never needs to be resized, and (2) the entire hash table contents are written out incrementally without requiring it to fit in memory in its entirety. In the future, this could be used by transparently switching to an out-of-core merge join when the hash table does not fit in memory in its entirety.

In addition to this, there are several smaller changes to the join hash table. The new `Select` comparison operators are used instead of the normal comparison operators for more efficient probing. The hash table also caches entries after probing now, to avoid propagating chunks with a low amount of entries through the plan (which negates the advantages of vectorization further on in the plan). The hash and combine hash functions were also changed to more faster variants involving only multiplication.


