### PR TITLE
Have Travis generate the R repo metadata files `PACKAGES` and upload to DuckDB Download server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -265,6 +265,8 @@ matrix:
         - R -f ../../examples/R/dplyr.R
 
       after_success:
+        - R -e "tools::write_PACKAGES(dir = '.', type = 'source')"
+        - python ../upload-s3.py rstats/src/contrib duckdb_*.tar.gz PACKAGES*
         - python ../upload-s3.py rstats duckdb_*.tar.gz
 
 
@@ -290,6 +292,8 @@ matrix:
         - (cd tests && R -f testthat.R)
 
       after_success:
+        - R -e "tools::write_PACKAGES(dir = '.', type = 'mac.binary')"
+        - python ../upload-s3.py rstats/bin/macosx/el-capitan/contrib/3.6 duckdb_*.tgz PACKAGES*
         - python ../upload-s3.py rstats duckdb_*.tgz
 
 
@@ -318,6 +322,8 @@ matrix:
 
       after_success:
         - C:/Python37-x64/python.exe ../upload-s3.py rstats duckdb_*.zip
+        - C:/Program\ Files/R/R-3.6.0/bin/R.exe -e "tools::write_PACKAGES(dir = '.', type = 'win.binary')"
+        - C:/Python37-x64/python.exe ../upload-s3.py rstats/bin/windows/contrib/3.6 duckdb_*.zip PACKAGES*
 
 
     - os: linux


### PR DESCRIPTION
So we can do e.g.

````R
install.packages("duckdb", repos=c("http://download.duckdb.org/alias/master/rstats/", "http://cran.rstudio.com"))
````