### PR TITLE
Fixes for support of different vector sizes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -167,6 +167,23 @@ matrix:
 
 
     - os: linux
+      dist: bionic
+      name: GCC 9 (Vector Sizes)
+      python: 3.7
+
+      addons:
+        apt:
+          packages:
+            - g++-9 python3.7
+      env:
+        - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
+      before_install:
+        - eval "${MATRIX_EVAL}"
+      script:
+        - python3 scripts/test_vector_sizes.py
+
+
+    - os: linux
       dist: xenial
       name: Code Coverage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -173,6 +173,8 @@ matrix:
 
       addons:
         apt:
+          sources:
+            - ubuntu-toolchain-r-test
           packages:
             - g++-9 python3.7
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -175,12 +175,6 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-          packages:
-            - g++-9 python3.7
-      env:
-        - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
-      before_install:
-        - eval "${MATRIX_EVAL}"
       script:
         - python3 scripts/test_vector_sizes.py
 

--- a/examples/programmatic-querying/main.cpp
+++ b/examples/programmatic-querying/main.cpp
@@ -30,7 +30,7 @@ void my_scan_function(ClientContext &context, DataChunk &input, DataChunk &outpu
 	}
 
 	// generate data for two output columns
-	size_t this_rows = std::min(data.nrow, (size_t)1024);
+	size_t this_rows = std::min(data.nrow, (size_t)STANDARD_VECTOR_SIZE);
 	data.nrow -= this_rows;
 
 	auto int_data = (int32_t *)output.data[0].GetData();

--- a/scripts/test_vector_sizes.py
+++ b/scripts/test_vector_sizes.py
@@ -1,5 +1,5 @@
 import os, sys, re
-vector_sizes = [2, 4, 8, 64, 512]
+vector_sizes = [2, 512]
 
 current_dir = os.getcwd()
 build_dir = os.path.join(os.getcwd(), 'build', 'release')

--- a/scripts/test_vector_sizes.py
+++ b/scripts/test_vector_sizes.py
@@ -1,5 +1,5 @@
 import os, sys, re
-vector_sizes = [2, 4, 8, 16, 32, 64, 512]
+vector_sizes = [2, 4, 8, 64, 512]
 
 current_dir = os.getcwd()
 build_dir = os.path.join(os.getcwd(), 'build', 'release')

--- a/scripts/test_vector_sizes.py
+++ b/scripts/test_vector_sizes.py
@@ -1,0 +1,19 @@
+import os, sys
+vector_sizes = [2, 4, 8, 16, 32, 64, 128, 256, 512]
+
+current_dir = os.getcwd()
+build_dir = os.path.join(os.getcwd(), 'build', 'release')
+
+def execute_system_command(cmd):
+	if os.system != 0:
+		raise Exception
+
+for vector_size in vector_sizes:
+	print("TESTING STANDARD_VECTOR_SIZE=%d" % (vector_size,))
+	execute_system_command('rm -rf build')
+	execute_system_command('mkdir -p build/release')
+	os.chdir(build_dir)
+	execute_system_command('cmake -DCMAKE_BUILD_TYPE=Release -DSTANDARD_VECTOR_SIZE=%d ../..')
+	execute_system_command('cmake --build .')
+	os.chdir(current_dir)
+	execute_system_command('build/release/test/unittest "*"')

--- a/scripts/test_vector_sizes.py
+++ b/scripts/test_vector_sizes.py
@@ -25,6 +25,6 @@ for vector_size in vector_sizes:
 	execute_system_command('mkdir -p build/release')
 	os.chdir(build_dir)
 	execute_system_command('cmake -DCMAKE_BUILD_TYPE=Release ../..')
-	execute_system_command('cmake --build . -j')
+	execute_system_command('cmake --build .')
 	os.chdir(current_dir)
 	execute_system_command('build/release/test/unittest')

--- a/scripts/test_vector_sizes.py
+++ b/scripts/test_vector_sizes.py
@@ -1,19 +1,30 @@
-import os, sys
-vector_sizes = [2, 4, 8, 16, 32, 64, 128, 256, 512]
+import os, sys, re
+vector_sizes = [2, 4, 8, 16, 32, 64, 512]
 
 current_dir = os.getcwd()
 build_dir = os.path.join(os.getcwd(), 'build', 'release')
 
 def execute_system_command(cmd):
-	if os.system != 0:
+	print(cmd)
+	retcode = os.system(cmd)
+	print(retcode)
+	if retcode != 0:
 		raise Exception
+
+def replace_in_file(fname, regex, replace):
+	with open(fname, 'r') as f:
+		contents = f.read()
+	contents = re.sub(regex, replace, contents)
+	with open(fname, 'w+') as f:
+		f.write(contents)
 
 for vector_size in vector_sizes:
 	print("TESTING STANDARD_VECTOR_SIZE=%d" % (vector_size,))
+	replace_in_file('src/include/duckdb/common/constants.hpp', '#define STANDARD_VECTOR_SIZE \d+', '#define STANDARD_VECTOR_SIZE %d' % (vector_size,))
 	execute_system_command('rm -rf build')
 	execute_system_command('mkdir -p build/release')
 	os.chdir(build_dir)
-	execute_system_command('cmake -DCMAKE_BUILD_TYPE=Release -DSTANDARD_VECTOR_SIZE=%d ../..')
-	execute_system_command('cmake --build .')
+	execute_system_command('cmake -DCMAKE_BUILD_TYPE=Release ../..')
+	execute_system_command('cmake --build . -j')
 	os.chdir(current_dir)
-	execute_system_command('build/release/test/unittest "*"')
+	execute_system_command('build/release/test/unittest')

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,10 @@ if(NOT MSVC)
     )
 endif()
 
+if (STANDARD_VECTOR_SIZE)
+  add_definitions("-DSTANDARD_VECTOR_SIZE=${STANDARD_VECTOR_SIZE}")
+endif()
+
 if(AMALGAMATION_BUILD)
 
   if(WIN32)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,10 +7,6 @@ if(NOT MSVC)
     )
 endif()
 
-if (STANDARD_VECTOR_SIZE)
-  add_definitions("-DSTANDARD_VECTOR_SIZE=${STANDARD_VECTOR_SIZE}")
-endif()
-
 if(AMALGAMATION_BUILD)
 
   if(WIN32)

--- a/src/common/constants.cpp
+++ b/src/common/constants.cpp
@@ -17,4 +17,16 @@ const transaction_t TRANSACTION_ID_START = 4611686018427388000ULL;              
 const transaction_t NOT_DELETED_ID = std::numeric_limits<transaction_t>::max() - 1; // 2^64 - 1
 const transaction_t MAXIMUM_QUERY_ID = std::numeric_limits<transaction_t>::max();   // 2^64
 
+uint64_t NextPowerOfTwo(uint64_t v) {
+	v--;
+	v |= v >> 1;
+	v |= v >> 2;
+	v |= v >> 4;
+	v |= v >> 8;
+	v |= v >> 16;
+	v |= v >> 32;
+	v++;
+	return v;
+}
+
 } // namespace duckdb

--- a/src/common/symbols.cpp
+++ b/src/common/symbols.cpp
@@ -182,7 +182,6 @@ template class std::vector<SQLType>;
 
 template struct std::atomic<uint64_t>;
 template class std::bitset<STANDARD_VECTOR_SIZE>;
-template class std::bitset<STORAGE_CHUNK_SIZE>;
 template class std::unordered_map<PhysicalOperator *, QueryProfiler::TreeNode *>;
 template class std::stack<PhysicalOperator *>;
 

--- a/src/common/vector_operations/gather.cpp
+++ b/src/common/vector_operations/gather.cpp
@@ -65,6 +65,7 @@ template <class LOOP, class OP> static void generic_gather_loop(Vector &source, 
 	if (source.type != TypeId::POINTER) {
 		throw InvalidTypeException(source.type, "Cannot gather from non-pointer type!");
 	}
+	dest.vector_type = VectorType::FLAT_VECTOR;
 	switch (dest.type) {
 	case TypeId::BOOL:
 	case TypeId::INT8:

--- a/src/common/vector_operations/sort.cpp
+++ b/src/common/vector_operations/sort.cpp
@@ -18,7 +18,7 @@ static sel_t templated_quicksort_initial(T *data, sel_t *sel_vector, sel_t resul
 	if (sel_vector) {
 		// now insert elements
 		for (index_t i = 1; i < count; i++) {
-			if (OP::Operation(data[sel_vector[i]], data[pivot])) {
+			if (OP::Operation(data[sel_vector[i]], data[sel_vector[pivot]])) {
 				result[low++] = sel_vector[i];
 			} else {
 				result[high--] = sel_vector[i];

--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -85,7 +85,7 @@ SuperLargeHashTable::~SuperLargeHashTable() {
 }
 
 void SuperLargeHashTable::CallDestructors(Vector &state_vector) {
-	if (state_vector.size() < 0) {
+	if (state_vector.size() == 0) {
 		return;
 	}
 	for(index_t i = 0; i < aggregates.size(); i++) {

--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -74,6 +74,9 @@ void SuperLargeHashTable::Resize(index_t size) {
 	if (size <= capacity) {
 		throw Exception("Cannot downsize a hash table!");
 	}
+	if (size < STANDARD_VECTOR_SIZE) {
+		size = STANDARD_VECTOR_SIZE;
+	}
 	// size needs to be a power of 2
 	assert((size & (size - 1)) == 0);
 	bitmask = size - 1;

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -243,18 +243,6 @@ void JoinHashTable::Build(DataChunk &keys, DataChunk &payload) {
 	SerializeChunk(hash_chunk, hash_locations);
 }
 
-uint64_t NextPowerOfTwo(uint64_t v) {
-	v--;
-	v |= v >> 1;
-	v |= v >> 2;
-	v |= v >> 4;
-	v |= v >> 8;
-	v |= v >> 16;
-	v |= v >> 32;
-	v++;
-	return v;
-}
-
 void JoinHashTable::InsertHashes(Vector &hashes, data_ptr_t key_locations[]) {
 	assert(hashes.type == TypeId::HASH);
 

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -201,6 +201,8 @@ void PhysicalHashJoin::GetChunkInternal(ClientContext &context, DataChunk &chunk
 		} else {
 			return;
 		}
+#else
+		return;
 #endif
 	} while (true);
 }

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -178,6 +178,7 @@ void PhysicalHashJoin::GetChunkInternal(ClientContext &context, DataChunk &chunk
 	}
 	do {
 		ProbeHashTable(context, chunk, state);
+#if STANDARD_VECTOR_SIZE >= 128
 		if (chunk.size() == 0) {
 			if (state->cached_chunk.size() > 0) {
 				// finished probing but cached data remains, return cached chunk
@@ -200,5 +201,6 @@ void PhysicalHashJoin::GetChunkInternal(ClientContext &context, DataChunk &chunk
 		} else {
 			return;
 		}
+#endif
 	} while (true);
 }

--- a/src/execution/operator/join/physical_nested_loop_join.cpp
+++ b/src/execution/operator/join/physical_nested_loop_join.cpp
@@ -85,7 +85,7 @@ static void ConstructSemiOrAntiJoinResult(DataChunk &left, DataChunk &result, bo
 		}
 		result.SetCardinality(result_count, result.owned_sel_vector);
 	} else {
-		assert(result.size() == 0);
+		result.SetCardinality(0);
 	}
 }
 
@@ -147,13 +147,30 @@ void PhysicalNestedLoopJoin::GetChunkInternal(ClientContext &context, DataChunk 
 			bool found_match[STANDARD_VECTOR_SIZE] = {false};
 			ConstructMarkJoinResult(state->left_join_condition, state->child_chunk, chunk, found_match,
 			                        state->has_null);
+		} else if (type == JoinType::ANTI) {
+			// ANTI join, just pull chunk from RHS
+			children[0]->GetChunk(context, chunk, state->child_state.get());
+		} else if (type == JoinType::LEFT) {
+			children[0]->GetChunk(context, state->child_chunk, state->child_state.get());
+			if (state->child_chunk.size() == 0) {
+				return;
+			}
+			chunk.SetCardinality(state->child_chunk);
+			index_t idx = 0;
+			for(; idx < state->child_chunk.column_count(); idx++) {
+				chunk.data[idx].Reference(state->child_chunk.data[idx]);
+			}
+			for(; idx < chunk.column_count(); idx++) {
+				chunk.data[idx].vector_type = VectorType::CONSTANT_VECTOR;
+				chunk.data[idx].nullmask[0] = true;
+			}
 		} else {
 			throw Exception("Unhandled type for empty NL join");
 		}
 		return;
 	}
 
-	if (state->right_chunk >= state->right_chunks.chunks.size()) {
+	if ((type == JoinType::INNER || type == JoinType::LEFT) && state->right_chunk >= state->right_chunks.chunks.size()) {
 		return;
 	}
 	// now that we have fully materialized the right child
@@ -209,7 +226,8 @@ void PhysicalNestedLoopJoin::GetChunkInternal(ClientContext &context, DataChunk 
 				ConstructSemiOrAntiJoinResult<false>(state->child_chunk, chunk, found_match);
 			}
 			// move to the next LHS chunk in the next iteration
-			state->right_chunk = state->right_chunks.chunks.size();
+			state->right_tuple = state->right_chunks.chunks[state->right_chunk]->size();
+			state->right_chunk = state->right_chunks.chunks.size() - 1;
 			return;
 		}
 		default:

--- a/src/execution/operator/join/physical_nested_loop_join.cpp
+++ b/src/execution/operator/join/physical_nested_loop_join.cpp
@@ -126,7 +126,9 @@ void PhysicalNestedLoopJoin::GetChunkInternal(ClientContext &context, DataChunk 
 		} else {
 			// disqualify tuples from the RHS that have NULL values
 			for (index_t i = 0; i < state->right_chunks.chunks.size(); i++) {
-				state->has_null = state->has_null || RemoveNullValues(*state->right_chunks.chunks[i]);
+				if (RemoveNullValues(*state->right_chunks.chunks[i])) {
+					state->has_null = true;
+				}
 			}
 			// initialize the chunks for the join conditions
 			state->left_join_condition.Initialize(condition_types);

--- a/src/execution/physical_plan/plan_explain.cpp
+++ b/src/execution/physical_plan/plan_explain.cpp
@@ -17,12 +17,17 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExplain &o
 	vector<string> values = {op.logical_plan_unopt, logical_plan_opt, op.physical_plan};
 	// create a ChunkCollection from the output
 	auto collection = make_unique<ChunkCollection>();
+
 	DataChunk chunk;
 	chunk.Initialize(op.types);
-	chunk.SetCardinality(keys.size());
 	for (index_t i = 0; i < keys.size(); i++) {
-		chunk.SetValue(0, i, Value(keys[i]));
-		chunk.SetValue(1, i, Value(values[i]));
+		chunk.SetValue(0, chunk.size(), Value(keys[i]));
+		chunk.SetValue(1, chunk.size(), Value(values[i]));
+		chunk.SetCardinality(chunk.size() + 1);
+		if (chunk.size() == STANDARD_VECTOR_SIZE) {
+			collection->Append(chunk);
+			chunk.Reset();
+		}
 	}
 	collection->Append(chunk);
 

--- a/src/execution/window_segment_tree.cpp
+++ b/src/execution/window_segment_tree.cpp
@@ -56,7 +56,7 @@ void WindowSegmentTree::WindowSegmentValue(index_t l_idx, index_t begin, index_t
 		}
 		aggregate.update(&inputs.data[0], input_count, s);
 	} else {
-		assert(end - begin < STANDARD_VECTOR_SIZE);
+		assert(end - begin <= STANDARD_VECTOR_SIZE);
 		data_ptr_t ptr = levels_flat_native.get() + state.size() * (begin + levels_flat_start[l_idx - 1]);
 		Vector v(inputs, result_type, ptr);
 		v.Verify();

--- a/src/include/duckdb/common/constants.hpp
+++ b/src/include/duckdb/common/constants.hpp
@@ -33,7 +33,7 @@ using std::vector;
 #define STANDARD_VECTOR_SIZE 1024
 #endif
 
-#if (STANDARD_VECTOR_SIZE < 128) || ((STANDARD_VECTOR_SIZE & (STANDARD_VECTOR_SIZE - 1)) != 0)
+#if (STANDARD_VECTOR_SIZE < 64) || ((STANDARD_VECTOR_SIZE & (STANDARD_VECTOR_SIZE - 1)) != 0)
 #error Vector size should be a power of two and bigger than or equal to 128
 #endif
 

--- a/src/include/duckdb/common/constants.hpp
+++ b/src/include/duckdb/common/constants.hpp
@@ -33,8 +33,8 @@ using std::vector;
 #define STANDARD_VECTOR_SIZE 1024
 #endif
 
-#if (STANDARD_VECTOR_SIZE < 16) || ((STANDARD_VECTOR_SIZE & (STANDARD_VECTOR_SIZE - 1)) != 0)
-#error Vector size should be a power of two and bigger than or equal to 16
+#if (STANDARD_VECTOR_SIZE < 8) || ((STANDARD_VECTOR_SIZE & (STANDARD_VECTOR_SIZE - 1)) != 0)
+#error Vector size should be a power of two and bigger than or equal to 8
 #endif
 
 //! a saner size_t for loop indices etc

--- a/src/include/duckdb/common/constants.hpp
+++ b/src/include/duckdb/common/constants.hpp
@@ -33,8 +33,8 @@ using std::vector;
 #define STANDARD_VECTOR_SIZE 1024
 #endif
 
-#if (STANDARD_VECTOR_SIZE < 32) || ((STANDARD_VECTOR_SIZE & (STANDARD_VECTOR_SIZE - 1)) != 0)
-#error Vector size should be a power of two and bigger than or equal to 32
+#if (STANDARD_VECTOR_SIZE < 16) || ((STANDARD_VECTOR_SIZE & (STANDARD_VECTOR_SIZE - 1)) != 0)
+#error Vector size should be a power of two and bigger than or equal to 16
 #endif
 
 //! a saner size_t for loop indices etc

--- a/src/include/duckdb/common/constants.hpp
+++ b/src/include/duckdb/common/constants.hpp
@@ -29,11 +29,9 @@ using std::vector;
 #define INVALID_SCHEMA ""
 
 //! The vector size used in the execution engine
+#ifndef STANDARD_VECTOR_SIZE
 #define STANDARD_VECTOR_SIZE 1024
-//! The amount of vectors per storage chunk
-#define STORAGE_CHUNK_VECTORS 10
-//! The storage chunk size
-#define STORAGE_CHUNK_SIZE (STANDARD_VECTOR_SIZE * STORAGE_CHUNK_VECTORS)
+#endif
 
 //! a saner size_t for loop indices etc
 typedef uint64_t index_t;

--- a/src/include/duckdb/common/constants.hpp
+++ b/src/include/duckdb/common/constants.hpp
@@ -33,8 +33,8 @@ using std::vector;
 #define STANDARD_VECTOR_SIZE 1024
 #endif
 
-#if (STANDARD_VECTOR_SIZE < 8) || ((STANDARD_VECTOR_SIZE & (STANDARD_VECTOR_SIZE - 1)) != 0)
-#error Vector size should be a power of two and bigger than or equal to 8
+#if ((STANDARD_VECTOR_SIZE & (STANDARD_VECTOR_SIZE - 1)) != 0)
+#error Vector size should be a power of two
 #endif
 
 //! a saner size_t for loop indices etc

--- a/src/include/duckdb/common/constants.hpp
+++ b/src/include/duckdb/common/constants.hpp
@@ -33,8 +33,8 @@ using std::vector;
 #define STANDARD_VECTOR_SIZE 1024
 #endif
 
-#if (STANDARD_VECTOR_SIZE < 64) || ((STANDARD_VECTOR_SIZE & (STANDARD_VECTOR_SIZE - 1)) != 0)
-#error Vector size should be a power of two and bigger than or equal to 128
+#if (STANDARD_VECTOR_SIZE < 32) || ((STANDARD_VECTOR_SIZE & (STANDARD_VECTOR_SIZE - 1)) != 0)
+#error Vector size should be a power of two and bigger than or equal to 32
 #endif
 
 //! a saner size_t for loop indices etc

--- a/src/include/duckdb/common/constants.hpp
+++ b/src/include/duckdb/common/constants.hpp
@@ -33,6 +33,10 @@ using std::vector;
 #define STANDARD_VECTOR_SIZE 1024
 #endif
 
+#if (STANDARD_VECTOR_SIZE < 128) || ((STANDARD_VECTOR_SIZE & (STANDARD_VECTOR_SIZE - 1)) != 0)
+#error Vector size should be a power of two and bigger than or equal to 128
+#endif
+
 //! a saner size_t for loop indices etc
 typedef uint64_t index_t;
 

--- a/src/include/duckdb/common/constants.hpp
+++ b/src/include/duckdb/common/constants.hpp
@@ -94,4 +94,6 @@ struct Storage {
 	constexpr static int FILE_HEADER_SIZE = 4096;
 };
 
+uint64_t NextPowerOfTwo(uint64_t v);
+
 } // namespace duckdb

--- a/src/include/duckdb/common/types/data_chunk.hpp
+++ b/src/include/duckdb/common/types/data_chunk.hpp
@@ -51,6 +51,7 @@ public:
 		return data.size();
 	}
 	void SetCardinality(index_t count, sel_t *sel_vector = nullptr) {
+		assert(count <= STANDARD_VECTOR_SIZE);
 		this->count = count;
 		this->sel_vector = sel_vector;
 	}

--- a/src/include/duckdb/execution/operator/join/physical_nested_loop_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_nested_loop_join.hpp
@@ -12,7 +12,6 @@
 #include "duckdb/execution/operator/join/physical_comparison_join.hpp"
 
 namespace duckdb {
-
 index_t nested_loop_join(ExpressionType op, Vector &left, Vector &right, index_t &lpos, index_t &rpos, sel_t lvector[],
                          sel_t rvector[]);
 index_t nested_loop_comparison(ExpressionType op, Vector &left, Vector &right, sel_t lvector[], sel_t rvector[],

--- a/src/include/duckdb/execution/window_segment_tree.hpp
+++ b/src/include/duckdb/execution/window_segment_tree.hpp
@@ -35,7 +35,12 @@ private:
 
 	ChunkCollection *input_ref;
 
-	static constexpr index_t TREE_FANOUT = 64; // this should cleanly divide STANDARD_VECTOR_SIZE
+	// TREE_FANOUT needs to cleanly divide STANDARD_VECTOR_SIZE
+#if STANDARD_VECTOR_SIZE < 64
+	static constexpr index_t TREE_FANOUT = STANDARD_VECTOR_SIZE;
+#else
+	static constexpr index_t TREE_FANOUT = 64;
+#endif
 };
 
 } // namespace duckdb

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -73,6 +73,12 @@ void LocalStorage::Scan(LocalScanState &state, const vector<column_t> &column_id
 				sel_vector[new_count++] = i;
 			}
 		}
+		if (new_count == 0 && count > 0) {
+			// all entries in this chunk were deleted: continue to next chunk
+			state.chunk_index++;
+			Scan(state, column_ids, result);
+			return;
+		}
 		count = new_count;
 	}
 

--- a/test/api/test_results.cpp
+++ b/test/api/test_results.cpp
@@ -59,7 +59,7 @@ TEST_CASE("Error in streaming result after initial query", "[api]") {
 
 	// create a big table with strings that are numbers
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE strings(v VARCHAR)"));
-	for (size_t i = 0; i < STANDARD_VECTOR_SIZE + 10; i++) {
+	for (size_t i = 0; i < STANDARD_VECTOR_SIZE * 2 - 1; i++) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO strings VALUES ('" + to_string(i) + "')"));
 	}
 	// now insert one non-numeric value

--- a/test/common/test_ops.cpp
+++ b/test/common/test_ops.cpp
@@ -14,6 +14,7 @@ using namespace std;
 // TODO add boolean ops
 // TODO add null checks
 
+#if STANDARD_VECTOR_SIZE >= 8
 TEST_CASE("Casting vectors", "[vector_ops]") {
 	vector<TypeId> types{TypeId::BOOL,  TypeId::INT8,  TypeId::INT16,  TypeId::INT32,
 	                     TypeId::INT64, TypeId::FLOAT, TypeId::DOUBLE, TypeId::VARCHAR};
@@ -162,7 +163,7 @@ TEST_CASE("Scatter/gather numeric vectors", "[vector_ops]") {
 }
 
 static void require_generate(TypeId t) {
-	VectorCardinality cardinality(8);
+	VectorCardinality cardinality(7);
 	Vector v(cardinality, t);
 	VectorOperations::GenerateSequence(v, 42, 1);
 	for (size_t i = 0; i < v.size(); i++) {
@@ -324,3 +325,4 @@ TEST_CASE("Arithmetic operations on vectors", "[vector_ops]") {
 	require_mod(TypeId::INT64);
 	require_mod_double();
 }
+#endif

--- a/test/common/test_ops.cpp
+++ b/test/common/test_ops.cpp
@@ -162,7 +162,7 @@ TEST_CASE("Scatter/gather numeric vectors", "[vector_ops]") {
 }
 
 static void require_generate(TypeId t) {
-	VectorCardinality cardinality(100);
+	VectorCardinality cardinality(8);
 	Vector v(cardinality, t);
 	VectorOperations::GenerateSequence(v, 42, 1);
 	for (size_t i = 0; i < v.size(); i++) {

--- a/test/sql/aggregate/test_aggregate.cpp
+++ b/test/sql/aggregate/test_aggregate.cpp
@@ -228,6 +228,40 @@ TEST_CASE("Test STRING_AGG operator with many groups", "[aggregate][.]") {
 	REQUIRE_FAIL(con.Query("SELECT STRING_AGG(k, ','), SUM(CAST(k AS BIGINT)) FROM (SELECT CAST(g AS VARCHAR) FROM strings UNION ALL SELECT CAST(x AS VARCHAR) FROM strings) tbl1(k)"));
 }
 
+TEST_CASE("STRING_AGG big", "[aggregate]") {
+	unique_ptr<QueryResult> result;
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	// test string aggregation on a set of values
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE strings(g VARCHAR, x VARCHAR);"));
+
+	std::stringstream query_string;
+	query_string << "INSERT INTO strings VALUES ";
+	for(int c = 0; c < 100; ++c) {
+		for(int e = 0; e < 100; ++e) {
+			query_string << "(";
+
+			query_string << c;
+
+			query_string << ",";
+
+			query_string << "'";
+			query_string << c * 10 + e;
+			query_string << "'";
+
+			query_string << "),";
+		}
+	}
+	std::string query_string_str = query_string.str();
+	query_string_str.pop_back();
+
+	REQUIRE_NO_FAIL(con.Query(query_string_str));
+
+	result = con.Query("SELECT g, STRING_AGG(x,',') FROM strings GROUP BY g");
+	REQUIRE_NO_FAIL(std::move(result));
+}
+
 TEST_CASE("Test AVG operator", "[aggregate]") {
 	unique_ptr<QueryResult> result;
 	DuckDB db(nullptr);

--- a/test/sql/aggregate/test_aggregate.cpp
+++ b/test/sql/aggregate/test_aggregate.cpp
@@ -223,6 +223,9 @@ TEST_CASE("Test STRING_AGG operator with many groups", "[aggregate][.]") {
 	result = con.Query("SELECT 1, STRING_AGG(x, ',') FROM strings GROUP BY 1 ORDER BY 1");
 	REQUIRE(CHECK_COLUMN(result, 0, {1}));
 	REQUIRE(CHECK_COLUMN(result, 1, {Value(expected_large_value)}));
+
+	// now test exception in the middle of an aggregate
+	REQUIRE_FAIL(con.Query("SELECT STRING_AGG(k, ','), SUM(CAST(k AS BIGINT)) FROM (SELECT CAST(g AS VARCHAR) FROM strings UNION ALL SELECT CAST(x AS VARCHAR) FROM strings) tbl1(k)"));
 }
 
 TEST_CASE("Test AVG operator", "[aggregate]") {

--- a/test/sql/copy/test_copy.cpp
+++ b/test/sql/copy/test_copy.cpp
@@ -182,7 +182,7 @@ TEST_CASE("Test copy statement", "[copy]") {
 
 	// 1024 rows (vector size)
 	ofstream csv_vector_size(fs.JoinPath(csv_path, "vsize.csv"));
-	for (int i = 0; i < 1024; i++) {
+	for (int i = 0; i < STANDARD_VECTOR_SIZE; i++) {
 		csv_vector_size << i << "," << i << ", test" << endl;
 	}
 	csv_vector_size.close();
@@ -190,7 +190,7 @@ TEST_CASE("Test copy statement", "[copy]") {
 	// load CSV file into a table
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE vsize (a INTEGER, b INTEGER, c VARCHAR(10));"));
 	result = con.Query("COPY vsize FROM '" + fs.JoinPath(csv_path, "vsize.csv") + "';");
-	REQUIRE(CHECK_COLUMN(result, 0, {1024}));
+	REQUIRE(CHECK_COLUMN(result, 0, {STANDARD_VECTOR_SIZE}));
 }
 
 TEST_CASE("Test CSV file without trailing newline", "[copy]") {

--- a/test/sql/simple/test_groupby.cpp
+++ b/test/sql/simple/test_groupby.cpp
@@ -179,13 +179,13 @@ TEST_CASE("Test aliases in group by/aggregation", "[aggregations]") {
 	// ...BUT the alias in ORDER BY should refer to the alias from the select list
 	// note that both Postgres and MonetDB reject this query because of ambiguity. SQLite accepts it though so we do
 	// too.
-	result = con.Query("SELECT i, i % 2 AS i, SUM(i) FROM integers GROUP BY i ORDER BY i;");
+	result = con.Query("SELECT i, i % 2 AS i, SUM(i) FROM integers GROUP BY i ORDER BY i, 3;");
 	REQUIRE(CHECK_COLUMN(result, 0, {Value(), 2, 1, 3}));
 	REQUIRE(CHECK_COLUMN(result, 1, {Value(), 0, 1, 1}));
 	REQUIRE(CHECK_COLUMN(result, 2, {Value(), 2, 1, 3}));
 
 	// changing the name of the alias makes it more explicit what should happen
-	result = con.Query("SELECT i, i % 2 AS k, SUM(i) FROM integers GROUP BY i ORDER BY k;");
+	result = con.Query("SELECT i, i % 2 AS k, SUM(i) FROM integers GROUP BY i ORDER BY k, 3;");
 	REQUIRE(CHECK_COLUMN(result, 0, {Value(), 2, 1, 3}));
 	REQUIRE(CHECK_COLUMN(result, 1, {Value(), 0, 1, 1}));
 	REQUIRE(CHECK_COLUMN(result, 2, {Value(), 2, 1, 3}));

--- a/test/sql/simple/test_setops.cpp
+++ b/test/sql/simple/test_setops.cpp
@@ -65,7 +65,7 @@ TEST_CASE("Test UNION/EXCEPT/INTERSECT", "[setop]") {
 	REQUIRE(CHECK_COLUMN(result, 1, {"a", "b", "c"}));
 
 	result = con.Query("SELECT b FROM test WHERE a < 13 UNION  SELECT b FROM "
-	                   "test WHERE a > 11");
+	                   "test WHERE a > 11 ORDER BY 1");
 	REQUIRE(CHECK_COLUMN(result, 0, {1, 2}));
 
 	// mixed fun
@@ -106,7 +106,7 @@ TEST_CASE("Test EXCEPT / INTERSECT", "[setop]") {
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE b(i INTEGER)"));
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO b VALUES (40), (43), (43)"));
 
-	result = con.Query("select * from a except select * from b");
+	result = con.Query("select * from a except select * from b order by 1");
 	REQUIRE(CHECK_COLUMN(result, 0, {41, 42}));
 
 	result = con.Query("select * from a intersect select * from b");


### PR DESCRIPTION
This PR implements correct support for changing the standard vector size, as well as a travis test case that verifies that various vector sizes work correctly on our test suite. In the process of getting this to work, several bugs have been fixed. As part of a bugfix relating to STRING_AGG, the STRING_AGG aggregate is reworked: it no longer uses string heaps to store strings, and instead memory is allocated within the hash table. Aggregates now also can have an optional destructor that is called when the hash table is destroyed (also when an exception causes the query to be terminated early). This is used by the STRING_AGG to free the allocated strings.