### PR TITLE
Renaming index_t to idx_t because - drumroll - Solaris!

### DIFF
--- a/benchmark/benchmark_runner.cpp
+++ b/benchmark/benchmark_runner.cpp
@@ -285,7 +285,7 @@ ConfigurationError run_benchmarks(const BenchmarkConfiguration &configuration) {
 		// passed name pattern.
 		std::vector<int> benchmark_indices{};
 		benchmark_indices.reserve(benchmarks.size());
-		for (index_t index = 0; index < benchmarks.size(); ++index) {
+		for (idx_t index = 0; index < benchmarks.size(); ++index) {
 			if (RE2::FullMatch(benchmarks[index]->name, configuration.name_pattern)) {
 				benchmark_indices.emplace_back(index);
 			}
@@ -307,7 +307,7 @@ ConfigurationError run_benchmarks(const BenchmarkConfiguration &configuration) {
 			}
 		} else if (configuration.meta == BenchmarkMetaType::QUERY) {
 			for (const auto &benchmark_index : benchmark_indices) {
-				auto duckdb_benchmark = dynamic_cast<DuckDBBenchmark*>(benchmarks[benchmark_index]);
+				auto duckdb_benchmark = dynamic_cast<DuckDBBenchmark *>(benchmarks[benchmark_index]);
 				if (!duckdb_benchmark) {
 					continue;
 				}

--- a/examples/programmatic-querying/main.cpp
+++ b/examples/programmatic-querying/main.cpp
@@ -58,7 +58,7 @@ unique_ptr<BoundFunctionExpression> resolve_function(Connection &con, string nam
 	assert(catalog_entry->type == CatalogType::SCALAR_FUNCTION);
 	auto scalar_fun = (ScalarFunctionCatalogEntry *)catalog_entry;
 
-	index_t best_function = Function::BindFunction(scalar_fun->name, scalar_fun->functions, function_args);
+	idx_t best_function = Function::BindFunction(scalar_fun->name, scalar_fun->functions, function_args);
 	auto fun = scalar_fun->functions[best_function];
 
 	return make_unique<BoundFunctionExpression>(GetInternalType(fun.return_type), fun, is_operator);
@@ -70,7 +70,7 @@ unique_ptr<BoundAggregateExpression> resolve_aggregate(Connection &con, string n
 	assert(catalog_entry->type == CatalogType::AGGREGATE_FUNCTION);
 	auto aggr_fun = (AggregateFunctionCatalogEntry *)catalog_entry;
 
-	index_t best_function = Function::BindFunction(aggr_fun->name, aggr_fun->functions, function_args);
+	idx_t best_function = Function::BindFunction(aggr_fun->name, aggr_fun->functions, function_args);
 	auto fun = aggr_fun->functions[best_function];
 	return make_unique<BoundAggregateExpression>(GetInternalType(fun.return_type), fun, false);
 }

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -37,7 +37,7 @@ TableCatalogEntry::TableCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schem
 		storage = make_shared<DataTable>(catalog->storage, schema->name, name, GetTypes(), move(info->data));
 
 		// create the unique indexes for the UNIQUE and PRIMARY KEY constraints
-		for (index_t i = 0; i < bound_constraints.size(); i++) {
+		for (idx_t i = 0; i < bound_constraints.size(); i++) {
 			auto &constraint = bound_constraints[i];
 			if (constraint->type == ConstraintType::UNIQUE) {
 				// unique constraint: create a unique index
@@ -46,7 +46,7 @@ TableCatalogEntry::TableCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schem
 				vector<column_t> column_ids;
 				vector<unique_ptr<Expression>> unbound_expressions;
 				vector<unique_ptr<Expression>> bound_expressions;
-				index_t key_nr = 0;
+				idx_t key_nr = 0;
 				for (auto &key : unique.keys) {
 					TypeId column_type = GetInternalType(columns[key].type);
 					assert(key < columns.size());
@@ -88,7 +88,7 @@ unique_ptr<CatalogEntry> TableCatalogEntry::AlterEntry(ClientContext &context, A
 		auto rename_info = (RenameColumnInfo *)table_info;
 		auto create_info = make_unique<CreateTableInfo>(schema->name, name);
 		bool found = false;
-		for (index_t i = 0; i < columns.size(); i++) {
+		for (idx_t i = 0; i < columns.size(); i++) {
 			ColumnDefinition copy(columns[i].name, columns[i].type);
 			copy.oid = columns[i].oid;
 			copy.default_value = columns[i].default_value ? columns[i].default_value->Copy() : nullptr;
@@ -105,7 +105,7 @@ unique_ptr<CatalogEntry> TableCatalogEntry::AlterEntry(ClientContext &context, A
 		}
 		assert(constraints.size() == 0);
 		// create_info->constraints.resize(constraints.size());
-		// for (index_t i = 0; i < constraints.size(); i++) {
+		// for (idx_t i = 0; i < constraints.size(); i++) {
 		// 	create_info->constraints[i] = constraints[i]->Copy();
 		// }
 		Binder binder(context);

--- a/src/common/constants.cpp
+++ b/src/common/constants.cpp
@@ -7,7 +7,7 @@ using namespace std;
 
 namespace duckdb {
 
-const index_t INVALID_INDEX = (index_t)-1;
+const idx_t INVALID_INDEX = (idx_t)-1;
 const row_t MAX_ROW_ID = 4611686018427388000ULL; // 2^62
 const column_t COLUMN_IDENTIFIER_ROW_ID = (column_t)-1;
 const sel_t ZERO_VECTOR[STANDARD_VECTOR_SIZE] = {0};

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -113,7 +113,7 @@ ValueOutOfRangeException::ValueOutOfRangeException(const double value, const Typ
                                                TypeIdToString(newType)) {
 }
 
-ValueOutOfRangeException::ValueOutOfRangeException(const TypeId varType, const index_t length)
+ValueOutOfRangeException::ValueOutOfRangeException(const TypeId varType, const idx_t length)
     : Exception(ExceptionType::OUT_OF_RANGE, "The value is too long to fit into type " + TypeIdToString(varType) + "(" +
                                                  std::to_string(length) + ")"){};
 

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -106,7 +106,7 @@ unique_ptr<FileHandle> FileSystem::OpenFile(const char *path, uint8_t flags, Fil
 	return make_unique<UnixFileHandle>(*this, path, fd);
 }
 
-void FileSystem::SetFilePointer(FileHandle &handle, index_t location) {
+void FileSystem::SetFilePointer(FileHandle &handle, idx_t location) {
 	int fd = ((UnixFileHandle &)handle).fd;
 	off_t offset = lseek(fd, location, SEEK_SET);
 	if (offset == (off_t)-1) {
@@ -190,7 +190,7 @@ void FileSystem::CreateDirectory(const string &directory) {
 
 int remove_directory_recursively(const char *path) {
 	DIR *d = opendir(path);
-	index_t path_len = (index_t)strlen(path);
+	idx_t path_len = (idx_t)strlen(path);
 	int r = -1;
 
 	if (d) {
@@ -199,12 +199,12 @@ int remove_directory_recursively(const char *path) {
 		while (!r && (p = readdir(d))) {
 			int r2 = -1;
 			char *buf;
-			index_t len;
+			idx_t len;
 			/* Skip the names "." and ".." as we don't want to recurse on them. */
 			if (!strcmp(p->d_name, ".") || !strcmp(p->d_name, "..")) {
 				continue;
 			}
-			len = path_len + (index_t)strlen(p->d_name) + 2;
+			len = path_len + (idx_t)strlen(p->d_name) + 2;
 			buf = new char[len];
 			if (buf) {
 				struct stat statbuf;
@@ -297,7 +297,7 @@ std::string GetLastErrorAsString() {
 		return std::string(); // No error message has been recorded
 
 	LPSTR messageBuffer = nullptr;
-	index_t size =
+	idx_t size =
 	    FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
 	                   NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
 
@@ -364,7 +364,7 @@ unique_ptr<FileHandle> FileSystem::OpenFile(const char *path, uint8_t flags, Fil
 	return move(handle);
 }
 
-void FileSystem::SetFilePointer(FileHandle &handle, index_t location) {
+void FileSystem::SetFilePointer(FileHandle &handle, idx_t location) {
 	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
 	LARGE_INTEGER loc;
 	loc.QuadPart = location;
@@ -535,7 +535,7 @@ void FileSystem::MoveFile(const string &source, const string &target) {
 }
 #endif
 
-void FileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, index_t location) {
+void FileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
 	// seek to the location
 	SetFilePointer(handle, location);
 	// now read from the location
@@ -545,7 +545,7 @@ void FileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, index_
 	}
 }
 
-void FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, index_t location) {
+void FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
 	// seek to the location
 	SetFilePointer(handle, location);
 	// now write to the location
@@ -560,11 +560,11 @@ string FileSystem::JoinPath(const string &a, const string &b) {
 	return a + PathSeparator() + b;
 }
 
-void FileHandle::Read(void *buffer, index_t nr_bytes, index_t location) {
+void FileHandle::Read(void *buffer, idx_t nr_bytes, idx_t location) {
 	file_system.Read(*this, buffer, nr_bytes, location);
 }
 
-void FileHandle::Write(void *buffer, index_t nr_bytes, index_t location) {
+void FileHandle::Write(void *buffer, idx_t nr_bytes, idx_t location) {
 	file_system.Write(*this, buffer, nr_bytes, location);
 }
 

--- a/src/common/fstream_util.cpp
+++ b/src/common/fstream_util.cpp
@@ -18,7 +18,7 @@ void FstreamUtil::CloseFile(fstream &file) {
 	}
 }
 
-index_t FstreamUtil::GetFileSize(fstream &file) {
+idx_t FstreamUtil::GetFileSize(fstream &file) {
 	file.seekg(0, ios::end);
 	return file.tellg();
 }

--- a/src/common/gzip_stream.cpp
+++ b/src/common/gzip_stream.cpp
@@ -54,8 +54,8 @@ using namespace duckdb;
 
  */
 
-static index_t consume_string(fstream &input) {
-	index_t size = 1; // terminator
+static idx_t consume_string(fstream &input) {
+	idx_t size = 1; // terminator
 	while (input.get() != '\0') {
 		size++;
 	}

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -144,7 +144,7 @@ template <class T> static T try_cast_string(const char *input) {
 }
 
 template <class T, bool NEGATIVE, bool ALLOW_EXPONENT> static bool IntegerCastLoop(const char *buf, T &result) {
-	index_t pos = NEGATIVE ? 1 : 0;
+	idx_t pos = NEGATIVE ? 1 : 0;
 	while (buf[pos]) {
 		if (!std::isdigit(buf[pos])) {
 			// not a digit!
@@ -250,7 +250,7 @@ template <> bool TryCast::Operation(const char *input, int64_t &result) {
 	return TryIntegerCast<int64_t>(input, result);
 }
 
-template <class T, bool NEGATIVE> static void ComputeDoubleResult(T &result, index_t decimal, index_t decimal_factor) {
+template <class T, bool NEGATIVE> static void ComputeDoubleResult(T &result, idx_t decimal, idx_t decimal_factor) {
 	if (decimal_factor > 1) {
 		if (NEGATIVE) {
 			result -= (T)decimal / (T)decimal_factor;
@@ -261,9 +261,9 @@ template <class T, bool NEGATIVE> static void ComputeDoubleResult(T &result, ind
 }
 
 template <class T, bool NEGATIVE> static bool DoubleCastLoop(const char *buf, T &result) {
-	index_t pos = NEGATIVE ? 1 : 0;
-	index_t decimal = 0;
-	index_t decimal_factor = 0;
+	idx_t pos = NEGATIVE ? 1 : 0;
+	idx_t decimal = 0;
+	idx_t decimal_factor = 0;
 	while (buf[pos]) {
 		if (!std::isdigit(buf[pos])) {
 			// not a digit!

--- a/src/common/serializer/buffered_deserializer.cpp
+++ b/src/common/serializer/buffered_deserializer.cpp
@@ -5,14 +5,14 @@
 using namespace duckdb;
 using namespace std;
 
-BufferedDeserializer::BufferedDeserializer(data_ptr_t ptr, index_t data_size) : ptr(ptr), endptr(ptr + data_size) {
+BufferedDeserializer::BufferedDeserializer(data_ptr_t ptr, idx_t data_size) : ptr(ptr), endptr(ptr + data_size) {
 }
 
 BufferedDeserializer::BufferedDeserializer(BufferedSerializer &serializer)
     : BufferedDeserializer(serializer.data, serializer.maximum_size) {
 }
 
-void BufferedDeserializer::ReadData(data_ptr_t buffer, index_t read_size) {
+void BufferedDeserializer::ReadData(data_ptr_t buffer, idx_t read_size) {
 	if (ptr + read_size > endptr) {
 		throw SerializationException("Failed to deserialize: not enough data in buffer to fulfill read request");
 	}

--- a/src/common/serializer/buffered_file_reader.cpp
+++ b/src/common/serializer/buffered_file_reader.cpp
@@ -17,7 +17,7 @@ void BufferedFileReader::ReadData(data_ptr_t target_buffer, uint64_t read_size) 
 	// first copy anything we can from the buffer
 	data_ptr_t end_ptr = target_buffer + read_size;
 	while (true) {
-		index_t to_read = std::min((index_t)(end_ptr - target_buffer), read_data - offset);
+		idx_t to_read = std::min((idx_t)(end_ptr - target_buffer), read_data - offset);
 		if (to_read > 0) {
 			memcpy(target_buffer, data.get() + offset, to_read);
 			offset += to_read;

--- a/src/common/serializer/buffered_file_writer.cpp
+++ b/src/common/serializer/buffered_file_writer.cpp
@@ -23,7 +23,7 @@ void BufferedFileWriter::WriteData(const_data_ptr_t buffer, uint64_t write_size)
 	// first copy anything we can from the buffer
 	const_data_ptr_t end_ptr = buffer + write_size;
 	while (buffer < end_ptr) {
-		index_t to_write = std::min((index_t)(end_ptr - buffer), FILE_BUFFER_SIZE - offset);
+		idx_t to_write = std::min((idx_t)(end_ptr - buffer), FILE_BUFFER_SIZE - offset);
 		assert(to_write > 0);
 		memcpy(data.get() + offset, buffer, to_write);
 		offset += to_write;

--- a/src/common/serializer/buffered_serializer.cpp
+++ b/src/common/serializer/buffered_serializer.cpp
@@ -5,16 +5,16 @@
 using namespace duckdb;
 using namespace std;
 
-BufferedSerializer::BufferedSerializer(index_t maximum_size)
+BufferedSerializer::BufferedSerializer(idx_t maximum_size)
     : BufferedSerializer(unique_ptr<data_t[]>(new data_t[maximum_size]), maximum_size) {
 }
 
-BufferedSerializer::BufferedSerializer(unique_ptr<data_t[]> data, index_t size) : maximum_size(size), data(data.get()) {
+BufferedSerializer::BufferedSerializer(unique_ptr<data_t[]> data, idx_t size) : maximum_size(size), data(data.get()) {
 	blob.size = 0;
 	blob.data = move(data);
 }
 
-void BufferedSerializer::WriteData(const_data_ptr_t buffer, index_t write_size) {
+void BufferedSerializer::WriteData(const_data_ptr_t buffer, idx_t write_size) {
 	if (blob.size + write_size >= maximum_size) {
 		do {
 			maximum_size *= 2;

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -47,7 +47,7 @@ bool StringUtil::EndsWith(const string &str, const string &suffix) {
 	return equal(suffix.rbegin(), suffix.rend(), str.rbegin());
 }
 
-string StringUtil::Repeat(const string &str, index_t n) {
+string StringUtil::Repeat(const string &str, idx_t n) {
 	ostringstream os;
 	if (n == 0 || str.empty()) {
 		return (os.str());
@@ -78,7 +78,7 @@ string StringUtil::Prefix(const string &str, const string &prefix) {
 		return ("");
 
 	ostringstream os;
-	for (index_t i = 0, cnt = lines.size(); i < cnt; i++) {
+	for (idx_t i = 0, cnt = lines.size(); i < cnt; i++) {
 		if (i > 0)
 			os << endl;
 		os << prefix << lines[i];
@@ -87,7 +87,7 @@ string StringUtil::Prefix(const string &str, const string &prefix) {
 }
 
 // http://ubuntuforums.org/showpost.php?p=10215516&postcount=5
-string StringUtil::FormatSize(index_t bytes) {
+string StringUtil::FormatSize(idx_t bytes) {
 	double BASE = 1024;
 	double KB = BASE;
 	double MB = KB * BASE;
@@ -161,11 +161,11 @@ string StringUtil::VFormat(const string fmt_str, va_list args) {
 vector<string> StringUtil::Split(const string &input, const string &split) {
 	vector<string> splits;
 
-	index_t last = 0;
-	index_t input_len = input.size();
-	index_t split_len = split.size();
+	idx_t last = 0;
+	idx_t input_len = input.size();
+	idx_t split_len = split.size();
 	while (last <= input_len) {
-		index_t next = input.find(split, last);
+		idx_t next = input.find(split, last);
 		if (next == string::npos) {
 			next = input_len;
 		}
@@ -184,7 +184,7 @@ string StringUtil::Replace(string source, const string &from, const string &to) 
 	if (from.empty())
 		return source;
 	;
-	index_t start_pos = 0;
+	idx_t start_pos = 0;
 	while ((start_pos = source.find(from, start_pos)) != string::npos) {
 		source.replace(start_pos, from.length(), to);
 		start_pos += to.length(); // In case 'to' contains 'from', like

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -76,7 +76,7 @@ string TypeIdToString(TypeId type) {
 	}
 }
 
-index_t GetTypeIdSize(TypeId type) {
+idx_t GetTypeIdSize(TypeId type) {
 	switch (type) {
 	case TypeId::BOOL:
 		return sizeof(bool);

--- a/src/common/types/chunk_collection.cpp
+++ b/src/common/types/chunk_collection.cpp
@@ -21,8 +21,8 @@ void ChunkCollection::Append(DataChunk &new_chunk) {
 	// first fill the latest chunk, if it exists
 	count += new_chunk.size();
 
-	index_t remaining_data = new_chunk.size();
-	index_t offset = 0;
+	idx_t remaining_data = new_chunk.size();
+	idx_t offset = 0;
 	if (chunks.size() == 0) {
 		// first chunk
 		types = new_chunk.GetTypes();
@@ -31,24 +31,24 @@ void ChunkCollection::Append(DataChunk &new_chunk) {
 		// the types of the new chunk should match the types of the previous one
 		assert(types.size() == new_chunk.column_count);
 		auto new_types = new_chunk.GetTypes();
-		for (index_t i = 0; i < types.size(); i++) {
+		for (idx_t i = 0; i < types.size(); i++) {
 			assert(new_types[i] == types[i]);
 		}
 #endif
 
 		// first append data to the current chunk
 		DataChunk &last_chunk = *chunks.back();
-		index_t added_data = std::min(remaining_data, (index_t)(STANDARD_VECTOR_SIZE - last_chunk.size()));
+		idx_t added_data = std::min(remaining_data, (idx_t)(STANDARD_VECTOR_SIZE - last_chunk.size()));
 		if (added_data > 0) {
 			// copy <added_data> elements to the last chunk
-			index_t old_count = new_chunk.size();
-			for (index_t c = 0; c < new_chunk.column_count; c++) {
+			idx_t old_count = new_chunk.size();
+			for (idx_t c = 0; c < new_chunk.column_count; c++) {
 				new_chunk.data[c].count = added_data;
 			}
 			last_chunk.Append(new_chunk);
 			remaining_data -= added_data;
 			// reset the chunk to the old data
-			for (index_t c = 0; c < new_chunk.column_count; c++) {
+			for (idx_t c = 0; c < new_chunk.column_count; c++) {
 				new_chunk.data[c].count = old_count;
 			}
 			offset = added_data;
@@ -70,7 +70,7 @@ void ChunkCollection::Append(DataChunk &new_chunk) {
 // 1 if left > right
 
 template <class TYPE>
-static int8_t templated_compare_value(Vector &left_vec, Vector &right_vec, index_t left_idx, index_t right_idx) {
+static int8_t templated_compare_value(Vector &left_vec, Vector &right_vec, idx_t left_idx, idx_t right_idx) {
 	assert(left_vec.type == right_vec.type);
 	TYPE left_val = ((TYPE *)left_vec.GetData())[left_idx];
 	TYPE right_val = ((TYPE *)right_vec.GetData())[right_idx];
@@ -84,7 +84,7 @@ static int8_t templated_compare_value(Vector &left_vec, Vector &right_vec, index
 }
 
 // return type here is int32 because strcmp() on some platforms returns rather large values
-static int32_t compare_value(Vector &left_vec, Vector &right_vec, index_t vector_idx_left, index_t vector_idx_right) {
+static int32_t compare_value(Vector &left_vec, Vector &right_vec, idx_t vector_idx_left, idx_t vector_idx_right) {
 
 	auto left_null = left_vec.nullmask[vector_idx_left];
 	auto right_null = right_vec.nullmask[vector_idx_right];
@@ -119,18 +119,18 @@ static int32_t compare_value(Vector &left_vec, Vector &right_vec, index_t vector
 	return false;
 }
 
-static int compare_tuple(ChunkCollection *sort_by, vector<OrderType> &desc, index_t left, index_t right) {
+static int compare_tuple(ChunkCollection *sort_by, vector<OrderType> &desc, idx_t left, idx_t right) {
 	assert(sort_by);
 
-	index_t chunk_idx_left = left / STANDARD_VECTOR_SIZE;
-	index_t chunk_idx_right = right / STANDARD_VECTOR_SIZE;
-	index_t vector_idx_left = left % STANDARD_VECTOR_SIZE;
-	index_t vector_idx_right = right % STANDARD_VECTOR_SIZE;
+	idx_t chunk_idx_left = left / STANDARD_VECTOR_SIZE;
+	idx_t chunk_idx_right = right / STANDARD_VECTOR_SIZE;
+	idx_t vector_idx_left = left % STANDARD_VECTOR_SIZE;
+	idx_t vector_idx_right = right % STANDARD_VECTOR_SIZE;
 
 	auto &left_chunk = sort_by->chunks[chunk_idx_left];
 	auto &right_chunk = sort_by->chunks[chunk_idx_right];
 
-	for (index_t col_idx = 0; col_idx < desc.size(); col_idx++) {
+	for (idx_t col_idx = 0; col_idx < desc.size(); col_idx++) {
 		auto order_type = desc[col_idx];
 
 		Vector &left_vec = left_chunk->data[col_idx];
@@ -151,12 +151,12 @@ static int compare_tuple(ChunkCollection *sort_by, vector<OrderType> &desc, inde
 	return 0;
 }
 
-static int64_t _quicksort_initial(ChunkCollection *sort_by, vector<OrderType> &desc, index_t *result) {
+static int64_t _quicksort_initial(ChunkCollection *sort_by, vector<OrderType> &desc, idx_t *result) {
 	// select pivot
 	int64_t pivot = 0;
 	int64_t low = 0, high = sort_by->count - 1;
 	// now insert elements
-	for (index_t i = 1; i < sort_by->count; i++) {
+	for (idx_t i = 1; i < sort_by->count; i++) {
 		if (compare_tuple(sort_by, desc, i, pivot) <= 0) {
 			result[low++] = i;
 		} else {
@@ -168,7 +168,7 @@ static int64_t _quicksort_initial(ChunkCollection *sort_by, vector<OrderType> &d
 	return low;
 }
 
-static void _quicksort_inplace(ChunkCollection *sort_by, vector<OrderType> &desc, index_t *result, int64_t left,
+static void _quicksort_inplace(ChunkCollection *sort_by, vector<OrderType> &desc, idx_t *result, int64_t left,
                                int64_t right) {
 	if (left >= right) {
 		return;
@@ -201,7 +201,7 @@ static void _quicksort_inplace(ChunkCollection *sort_by, vector<OrderType> &desc
 	_quicksort_inplace(sort_by, desc, result, part + 1, right);
 }
 
-void ChunkCollection::Sort(vector<OrderType> &desc, index_t result[]) {
+void ChunkCollection::Sort(vector<OrderType> &desc, idx_t result[]) {
 	assert(result);
 	if (count == 0)
 		return;
@@ -214,18 +214,18 @@ void ChunkCollection::Sort(vector<OrderType> &desc, index_t result[]) {
 // FIXME make this more efficient by not using the Value API
 // just use memcpy in the vectors
 // assert that there is no selection list
-void ChunkCollection::Reorder(index_t order_org[]) {
-	auto order = unique_ptr<index_t[]>(new index_t[count]);
-	memcpy(order.get(), order_org, sizeof(index_t) * count);
+void ChunkCollection::Reorder(idx_t order_org[]) {
+	auto order = unique_ptr<idx_t[]>(new idx_t[count]);
+	memcpy(order.get(), order_org, sizeof(idx_t) * count);
 
 	// adapted from https://stackoverflow.com/a/7366196/2652376
 
 	auto val_buf = vector<Value>();
 	val_buf.resize(column_count());
 
-	index_t j, k;
-	for (index_t i = 0; i < count; i++) {
-		for (index_t col_idx = 0; col_idx < column_count(); col_idx++) {
+	idx_t j, k;
+	for (idx_t i = 0; i < count; i++) {
+		for (idx_t col_idx = 0; col_idx < column_count(); col_idx++) {
 			val_buf[col_idx] = GetValue(col_idx, i);
 		}
 		j = i;
@@ -235,25 +235,25 @@ void ChunkCollection::Reorder(index_t order_org[]) {
 			if (k == i) {
 				break;
 			}
-			for (index_t col_idx = 0; col_idx < column_count(); col_idx++) {
+			for (idx_t col_idx = 0; col_idx < column_count(); col_idx++) {
 				SetValue(col_idx, j, GetValue(col_idx, k));
 			}
 			j = k;
 		}
-		for (index_t col_idx = 0; col_idx < column_count(); col_idx++) {
+		for (idx_t col_idx = 0; col_idx < column_count(); col_idx++) {
 			SetValue(col_idx, j, val_buf[col_idx]);
 		}
 	}
 }
 
 template <class TYPE>
-static void templated_set_values(ChunkCollection *src_coll, Vector &tgt_vec, index_t order[], index_t col_idx,
-                                 index_t start_offset, index_t remaining_data) {
+static void templated_set_values(ChunkCollection *src_coll, Vector &tgt_vec, idx_t order[], idx_t col_idx,
+                                 idx_t start_offset, idx_t remaining_data) {
 	assert(src_coll);
 
-	for (index_t row_idx = 0; row_idx < remaining_data; row_idx++) {
-		index_t chunk_idx_src = order[start_offset + row_idx] / STANDARD_VECTOR_SIZE;
-		index_t vector_idx_src = order[start_offset + row_idx] % STANDARD_VECTOR_SIZE;
+	for (idx_t row_idx = 0; row_idx < remaining_data; row_idx++) {
+		idx_t chunk_idx_src = order[start_offset + row_idx] / STANDARD_VECTOR_SIZE;
+		idx_t vector_idx_src = order[start_offset + row_idx] % STANDARD_VECTOR_SIZE;
 
 		auto &src_chunk = src_coll->chunks[chunk_idx_src];
 		Vector &src_vec = src_chunk->data[col_idx];
@@ -269,11 +269,11 @@ static void templated_set_values(ChunkCollection *src_coll, Vector &tgt_vec, ind
 }
 
 // TODO: reorder functionality is similar, perhaps merge
-void ChunkCollection::MaterializeSortedChunk(DataChunk &target, index_t order[], index_t start_offset) {
-	index_t remaining_data = min((index_t)STANDARD_VECTOR_SIZE, count - start_offset);
+void ChunkCollection::MaterializeSortedChunk(DataChunk &target, idx_t order[], idx_t start_offset) {
+	idx_t remaining_data = min((idx_t)STANDARD_VECTOR_SIZE, count - start_offset);
 	assert(target.GetTypes() == types);
 
-	for (index_t col_idx = 0; col_idx < column_count(); col_idx++) {
+	for (idx_t col_idx = 0; col_idx < column_count(); col_idx++) {
 		target.data[col_idx].count = remaining_data;
 
 		switch (types[col_idx]) {
@@ -300,9 +300,9 @@ void ChunkCollection::MaterializeSortedChunk(DataChunk &target, index_t order[],
 			templated_set_values<char *>(this, target.data[col_idx], order, col_idx, start_offset, remaining_data);
 			break;
 		case TypeId::STRUCT: {
-			for (index_t row_idx = 0; row_idx < remaining_data; row_idx++) {
-				index_t chunk_idx_src = order[start_offset + row_idx] / STANDARD_VECTOR_SIZE;
-				index_t vector_idx_src = order[start_offset + row_idx] % STANDARD_VECTOR_SIZE;
+			for (idx_t row_idx = 0; row_idx < remaining_data; row_idx++) {
+				idx_t chunk_idx_src = order[start_offset + row_idx] / STANDARD_VECTOR_SIZE;
+				idx_t vector_idx_src = order[start_offset + row_idx] % STANDARD_VECTOR_SIZE;
 
 				auto &src_chunk = chunks[chunk_idx_src];
 				Vector &src_vec = src_chunk->data[col_idx];
@@ -322,21 +322,21 @@ void ChunkCollection::MaterializeSortedChunk(DataChunk &target, index_t order[],
 	target.Verify();
 }
 
-Value ChunkCollection::GetValue(index_t column, index_t index) {
+Value ChunkCollection::GetValue(idx_t column, idx_t index) {
 	return chunks[LocateChunk(index)]->data[column].GetValue(index % STANDARD_VECTOR_SIZE);
 }
 
-vector<Value> ChunkCollection::GetRow(index_t index) {
+vector<Value> ChunkCollection::GetRow(idx_t index) {
 	vector<Value> values;
 	values.resize(column_count());
 
-	for (index_t p_idx = 0; p_idx < column_count(); p_idx++) {
+	for (idx_t p_idx = 0; p_idx < column_count(); p_idx++) {
 		values[p_idx] = GetValue(p_idx, index);
 	}
 	return values;
 }
 
-void ChunkCollection::SetValue(index_t column, index_t index, Value value) {
+void ChunkCollection::SetValue(idx_t column, idx_t index, Value value) {
 	chunks[LocateChunk(index)]->data[column].SetValue(index % STANDARD_VECTOR_SIZE, value);
 }
 
@@ -355,8 +355,8 @@ bool ChunkCollection::Equals(ChunkCollection &other) {
 		return false;
 	}
 	// if count is equal amount of chunks should be equal
-	for (index_t row_idx = 0; row_idx < count; row_idx++) {
-		for (index_t col_idx = 0; col_idx < column_count(); col_idx++) {
+	for (idx_t row_idx = 0; row_idx < count; row_idx++) {
+		for (idx_t col_idx = 0; col_idx < column_count(); col_idx++) {
 			auto lvalue = GetValue(col_idx, row_idx);
 			auto rvalue = other.GetValue(col_idx, row_idx);
 			if (!Value::ValuesAreEqual(lvalue, rvalue)) {
@@ -366,14 +366,14 @@ bool ChunkCollection::Equals(ChunkCollection &other) {
 	}
 	return true;
 }
-static void _heapify(ChunkCollection *input, vector<OrderType> &desc, index_t *heap, index_t heap_size,
-                     index_t current_index) {
+static void _heapify(ChunkCollection *input, vector<OrderType> &desc, idx_t *heap, idx_t heap_size,
+                     idx_t current_index) {
 	if (current_index >= heap_size) {
 		return;
 	}
-	index_t left_child_index = current_index * 2 + 1;
-	index_t right_child_index = current_index * 2 + 2;
-	index_t swap_index = current_index;
+	idx_t left_child_index = current_index * 2 + 1;
+	idx_t right_child_index = current_index * 2 + 2;
+	idx_t swap_index = current_index;
 
 	if (left_child_index < heap_size) {
 		swap_index =
@@ -391,8 +391,8 @@ static void _heapify(ChunkCollection *input, vector<OrderType> &desc, index_t *h
 	}
 }
 
-static void _heap_create(ChunkCollection *input, vector<OrderType> &desc, index_t *heap, index_t heap_size) {
-	for (index_t i = 0; i < heap_size; i++) {
+static void _heap_create(ChunkCollection *input, vector<OrderType> &desc, idx_t *heap, idx_t heap_size) {
+	for (idx_t i = 0; i < heap_size; i++) {
 		heap[i] = i;
 	}
 
@@ -402,7 +402,7 @@ static void _heap_create(ChunkCollection *input, vector<OrderType> &desc, index_
 	}
 
 	// Run through all the rows.
-	for (index_t i = heap_size; i < input->count; i++) {
+	for (idx_t i = heap_size; i < input->count; i++) {
 		if (compare_tuple(input, desc, i, heap[0]) <= 0) {
 			heap[0] = i;
 			_heapify(input, desc, heap, heap_size, 0);
@@ -410,7 +410,7 @@ static void _heap_create(ChunkCollection *input, vector<OrderType> &desc, index_
 	}
 }
 
-void ChunkCollection::Heap(vector<OrderType> &desc, index_t heap[], index_t heap_size) {
+void ChunkCollection::Heap(vector<OrderType> &desc, idx_t heap[], idx_t heap_size) {
 	assert(heap);
 	if (count == 0)
 		return;
@@ -424,12 +424,11 @@ void ChunkCollection::Heap(vector<OrderType> &desc, index_t heap[], index_t heap
 	}
 }
 
-index_t ChunkCollection::MaterializeHeapChunk(DataChunk &target, index_t order[], index_t start_offset,
-                                              index_t heap_size) {
-	index_t remaining_data = min((index_t)STANDARD_VECTOR_SIZE, heap_size - start_offset);
+idx_t ChunkCollection::MaterializeHeapChunk(DataChunk &target, idx_t order[], idx_t start_offset, idx_t heap_size) {
+	idx_t remaining_data = min((idx_t)STANDARD_VECTOR_SIZE, heap_size - start_offset);
 	assert(target.GetTypes() == types);
 
-	for (index_t col_idx = 0; col_idx < column_count(); col_idx++) {
+	for (idx_t col_idx = 0; col_idx < column_count(); col_idx++) {
 		target.data[col_idx].count = remaining_data;
 
 		switch (types[col_idx]) {
@@ -458,9 +457,9 @@ index_t ChunkCollection::MaterializeHeapChunk(DataChunk &target, index_t order[]
 			// TODO this is ugly and sloooow!
 		case TypeId::STRUCT:
 		case TypeId::LIST: {
-			for (index_t row_idx = 0; row_idx < remaining_data; row_idx++) {
-				index_t chunk_idx_src = order[start_offset + row_idx] / STANDARD_VECTOR_SIZE;
-				index_t vector_idx_src = order[start_offset + row_idx] % STANDARD_VECTOR_SIZE;
+			for (idx_t row_idx = 0; row_idx < remaining_data; row_idx++) {
+				idx_t chunk_idx_src = order[start_offset + row_idx] / STANDARD_VECTOR_SIZE;
+				idx_t vector_idx_src = order[start_offset + row_idx] % STANDARD_VECTOR_SIZE;
 
 				auto &src_chunk = chunks[chunk_idx_src];
 				Vector &src_vec = src_chunk->data[col_idx];

--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -17,7 +17,7 @@ void DataChunk::InitializeEmpty(vector<TypeId> &types) {
 	assert(types.size() > 0);
 	column_count = types.size();
 	data = unique_ptr<Vector[]>(new Vector[types.size()]);
-	for (index_t i = 0; i < types.size(); i++) {
+	for (idx_t i = 0; i < types.size(); i++) {
 		data[i].type = types[i];
 		data[i].data = nullptr;
 		data[i].count = 0;
@@ -28,7 +28,7 @@ void DataChunk::InitializeEmpty(vector<TypeId> &types) {
 void DataChunk::Initialize(vector<TypeId> &types) {
 	assert(types.size() > 0);
 	InitializeEmpty(types);
-	index_t size = 0;
+	idx_t size = 0;
 	for (auto &type : types) {
 		size += GetTypeIdSize(type) * STANDARD_VECTOR_SIZE;
 	}
@@ -38,7 +38,7 @@ void DataChunk::Initialize(vector<TypeId> &types) {
 	}
 
 	auto ptr = owned_data.get();
-	for (index_t i = 0; i < types.size(); i++) {
+	for (idx_t i = 0; i < types.size(); i++) {
 		data[i].data = ptr;
 		ptr += GetTypeIdSize(types[i]) * STANDARD_VECTOR_SIZE;
 	}
@@ -46,7 +46,7 @@ void DataChunk::Initialize(vector<TypeId> &types) {
 
 void DataChunk::Reset() {
 	auto ptr = owned_data.get();
-	for (index_t i = 0; i < column_count; i++) {
+	for (idx_t i = 0; i < column_count; i++) {
 		data[i].data = ptr;
 		data[i].count = 0;
 		data[i].sel_vector = nullptr;
@@ -65,11 +65,11 @@ void DataChunk::Destroy() {
 	column_count = 0;
 }
 
-void DataChunk::Copy(DataChunk &other, index_t offset) {
+void DataChunk::Copy(DataChunk &other, idx_t offset) {
 	assert(column_count == other.column_count);
 	other.sel_vector = nullptr;
 
-	for (index_t i = 0; i < column_count; i++) {
+	for (idx_t i = 0; i < column_count; i++) {
 		data[i].Copy(other.data[i], offset);
 	}
 }
@@ -94,14 +94,14 @@ void DataChunk::Flatten() {
 		return;
 	}
 
-	for (index_t i = 0; i < column_count; i++) {
+	for (idx_t i = 0; i < column_count; i++) {
 		data[i].Flatten();
 	}
 	sel_vector = nullptr;
 }
 
 void DataChunk::Normalify() {
-	for (index_t i = 0; i < column_count; i++) {
+	for (idx_t i = 0; i < column_count; i++) {
 		data[i].Normalify();
 	}
 }
@@ -113,14 +113,14 @@ void DataChunk::Append(DataChunk &other) {
 	if (column_count != other.column_count) {
 		throw OutOfRangeException("Column counts of appending chunk doesn't match!");
 	}
-	for (index_t i = 0; i < column_count; i++) {
+	for (idx_t i = 0; i < column_count; i++) {
 		data[i].Append(other.data[i]);
 	}
 }
 
 vector<TypeId> DataChunk::GetTypes() {
 	vector<TypeId> types;
-	for (index_t i = 0; i < column_count; i++) {
+	for (idx_t i = 0; i < column_count; i++) {
 		types.push_back(data[i].type);
 	}
 	return types;
@@ -128,7 +128,7 @@ vector<TypeId> DataChunk::GetTypes() {
 
 string DataChunk::ToString() const {
 	string retval = "Chunk - [" + to_string(column_count) + " Columns]\n";
-	for (index_t i = 0; i < column_count; i++) {
+	for (idx_t i = 0; i < column_count; i++) {
 		retval += "- " + data[i].ToString() + "\n";
 	}
 	return retval;
@@ -137,16 +137,16 @@ string DataChunk::ToString() const {
 void DataChunk::Serialize(Serializer &serializer) {
 	// write the count
 	serializer.Write<sel_t>(size());
-	serializer.Write<index_t>(column_count);
-	for (index_t i = 0; i < column_count; i++) {
+	serializer.Write<idx_t>(column_count);
+	for (idx_t i = 0; i < column_count; i++) {
 		// write the types
 		serializer.Write<int>((int)data[i].type);
 	}
 	// write the data
-	for (index_t i = 0; i < column_count; i++) {
+	for (idx_t i = 0; i < column_count; i++) {
 		auto type = data[i].type;
 		if (TypeIsConstantSize(type)) {
-			index_t write_size = GetTypeIdSize(type) * size();
+			idx_t write_size = GetTypeIdSize(type) * size();
 			auto ptr = unique_ptr<data_t[]>(new data_t[write_size]);
 			// constant size type: simple memcpy
 			VectorOperations::CopyToStorage(data[i], ptr.get());
@@ -156,7 +156,7 @@ void DataChunk::Serialize(Serializer &serializer) {
 			// strings are inlined into the blob
 			// we use null-padding to store them
 			auto strings = (const char **)data[i].data;
-			VectorOperations::Exec(sel_vector, size(), [&](index_t j, index_t k) {
+			VectorOperations::Exec(sel_vector, size(), [&](idx_t j, idx_t k) {
 				auto source = strings[j] ? strings[j] : NullValue<const char *>();
 				serializer.WriteString(source);
 			});
@@ -166,15 +166,15 @@ void DataChunk::Serialize(Serializer &serializer) {
 
 void DataChunk::Deserialize(Deserializer &source) {
 	auto rows = source.Read<sel_t>();
-	column_count = source.Read<index_t>();
+	column_count = source.Read<idx_t>();
 
 	vector<TypeId> types;
-	for (index_t i = 0; i < column_count; i++) {
+	for (idx_t i = 0; i < column_count; i++) {
 		types.push_back((TypeId)source.Read<int>());
 	}
 	Initialize(types);
 	// now load the column data
-	for (index_t i = 0; i < column_count; i++) {
+	for (idx_t i = 0; i < column_count; i++) {
 		auto type = data[i].type;
 		if (TypeIsConstantSize(type)) {
 			// constant size type: simple memcpy
@@ -186,7 +186,7 @@ void DataChunk::Deserialize(Deserializer &source) {
 			VectorOperations::AppendFromStorage(v, data[i]);
 		} else {
 			auto strings = (const char **)data[i].data;
-			for (index_t j = 0; j < rows; j++) {
+			for (idx_t j = 0; j < rows; j++) {
 				// read the strings
 				auto str = source.Read<string>();
 				// now add the string to the StringHeap of the vector
@@ -205,7 +205,7 @@ void DataChunk::Deserialize(Deserializer &source) {
 }
 
 void DataChunk::MoveStringsToHeap(StringHeap &heap) {
-	for (index_t c = 0; c < column_count; c++) {
+	for (idx_t c = 0; c < column_count; c++) {
 		if (data[c].type == TypeId::VARCHAR) {
 			// move strings of this chunk to the specified heap
 			auto source_strings = (const char **)data[c].GetData();
@@ -221,7 +221,7 @@ void DataChunk::MoveStringsToHeap(StringHeap &heap) {
 				data[c].buffer = VectorBuffer::CreateStandardVector(TypeId::VARCHAR);
 				data[c].data = data[c].buffer->GetData();
 				auto target_strings = (const char **)data[c].GetData();
-				VectorOperations::ExecType<const char *>(data[c], [&](const char *str, index_t i, index_t k) {
+				VectorOperations::ExecType<const char *>(data[c], [&](const char *str, idx_t i, idx_t k) {
 					if (!data[c].nullmask[i]) {
 						target_strings[i] = heap.AddString(source_strings[i]);
 					}
@@ -234,7 +234,7 @@ void DataChunk::MoveStringsToHeap(StringHeap &heap) {
 void DataChunk::Hash(Vector &result) {
 	assert(result.type == TypeId::HASH);
 	VectorOperations::Hash(data[0], result);
-	for (index_t i = 1; i < column_count; i++) {
+	for (idx_t i = 1; i < column_count; i++) {
 		VectorOperations::CombineHash(result, data[i]);
 	}
 }
@@ -243,12 +243,12 @@ void DataChunk::Verify() {
 #ifdef DEBUG
 	// verify that all vectors in this chunk have the chunk selection vector
 	sel_t *v = sel_vector;
-	for (index_t i = 0; i < column_count; i++) {
+	for (idx_t i = 0; i < column_count; i++) {
 		assert(data[i].sel_vector == v);
 		data[i].Verify();
 	}
 	// verify that all vectors in the chunk have the same count
-	for (index_t i = 0; i < column_count; i++) {
+	for (idx_t i = 0; i < column_count; i++) {
 		assert(size() == data[i].count);
 	}
 #endif

--- a/src/common/types/date.cpp
+++ b/src/common/types/date.cpp
@@ -99,7 +99,7 @@ static inline int32_t date_to_number(int32_t year, int32_t month, int32_t day) {
 	return n;
 }
 
-static bool ParseDoubleDigit(const char *buf, index_t &pos, int32_t &result) {
+static bool ParseDoubleDigit(const char *buf, idx_t &pos, int32_t &result) {
 	if (std::isdigit(buf[pos])) {
 		result = buf[pos++] - '0';
 		if (std::isdigit(buf[pos])) {
@@ -113,7 +113,7 @@ static bool ParseDoubleDigit(const char *buf, index_t &pos, int32_t &result) {
 static bool TryConvertDate(const char *buf, date_t &result) {
 	int32_t day = 0, month = -1;
 	int32_t year = 0, yearneg = (buf[0] == '-');
-	index_t pos = 0;
+	idx_t pos = 0;
 	int sep;
 
 	if (yearneg == 0 && !std::isdigit(buf[0])) {

--- a/src/common/types/hyperloglog.cpp
+++ b/src/common/types/hyperloglog.cpp
@@ -17,13 +17,13 @@ HyperLogLog::~HyperLogLog() {
 	hll_destroy((robj *)hll);
 }
 
-void HyperLogLog::Add(data_ptr_t element, index_t size) {
+void HyperLogLog::Add(data_ptr_t element, idx_t size) {
 	if (hll_add((robj *)hll, element, size) == C_ERR) {
 		throw Exception("Could not add to HLL?");
 	}
 }
 
-index_t HyperLogLog::Count() {
+idx_t HyperLogLog::Count() {
 	size_t result; // exception from size_t ban
 	if (hll_count((robj *)hll, &result) != C_OK) {
 		throw Exception("Could not count HLL?");
@@ -42,10 +42,10 @@ unique_ptr<HyperLogLog> HyperLogLog::Merge(HyperLogLog &other) {
 	return unique_ptr<HyperLogLog>(new HyperLogLog((void *)new_hll));
 }
 
-unique_ptr<HyperLogLog> HyperLogLog::Merge(HyperLogLog logs[], index_t count) {
+unique_ptr<HyperLogLog> HyperLogLog::Merge(HyperLogLog logs[], idx_t count) {
 	auto hlls_uptr = unique_ptr<robj *[]> { new robj *[count] };
 	auto hlls = hlls_uptr.get();
-	for (index_t i = 0; i < count; i++) {
+	for (idx_t i = 0; i < count; i++) {
 		hlls[i] = (robj *)logs[i].hll;
 	}
 	auto new_hll = hll_merge(hlls, count);

--- a/src/common/types/string_heap.cpp
+++ b/src/common/types/string_heap.cpp
@@ -11,7 +11,7 @@ using namespace std;
 StringHeap::StringHeap() : tail(nullptr) {
 }
 
-const char *StringHeap::AddString(const char *data, index_t len) {
+const char *StringHeap::AddString(const char *data, idx_t len) {
 #ifdef DEBUG
 	if (!Value::IsUTF8String(data)) {
 		throw Exception("String value is not valid UTF8");
@@ -19,7 +19,7 @@ const char *StringHeap::AddString(const char *data, index_t len) {
 #endif
 	if (!chunk || chunk->current_position + len >= chunk->maximum_size) {
 		// have to make a new entry
-		auto new_chunk = make_unique<StringChunk>(std::max(len + 1, (index_t)MINIMUM_HEAP_SIZE));
+		auto new_chunk = make_unique<StringChunk>(std::max(len + 1, (idx_t)MINIMUM_HEAP_SIZE));
 		new_chunk->prev = move(chunk);
 		chunk = move(new_chunk);
 		if (!tail) {

--- a/src/common/types/time.cpp
+++ b/src/common/types/time.cpp
@@ -46,7 +46,7 @@ static void number_to_time(dtime_t n, int32_t &hour, int32_t &min, int32_t &sec,
 }
 
 // TODO this is duplicated in date.cpp
-static bool ParseDoubleDigit2(const char *buf, index_t &pos, int32_t &result) {
+static bool ParseDoubleDigit2(const char *buf, idx_t &pos, int32_t &result) {
 	if (std::isdigit(buf[pos])) {
 		result = buf[pos++] - '0';
 		if (std::isdigit(buf[pos])) {
@@ -59,7 +59,7 @@ static bool ParseDoubleDigit2(const char *buf, index_t &pos, int32_t &result) {
 
 static bool TryConvertTime(const char *buf, dtime_t &result) {
 	int32_t hour = -1, min = -1, sec = -1, msec = -1;
-	index_t pos = 0;
+	idx_t pos = 0;
 	int sep;
 
 	// skip leading spaces

--- a/src/common/types/vector_buffer.cpp
+++ b/src/common/types/vector_buffer.cpp
@@ -5,13 +5,13 @@
 using namespace duckdb;
 using namespace std;
 
-VectorBuffer::VectorBuffer(index_t data_size) : type(VectorBufferType::STANDARD_BUFFER) {
+VectorBuffer::VectorBuffer(idx_t data_size) : type(VectorBufferType::STANDARD_BUFFER) {
 	if (data_size > 0) {
 		data = unique_ptr<data_t[]>(new data_t[data_size]);
 	}
 }
 
-buffer_ptr<VectorBuffer> VectorBuffer::CreateStandardVector(TypeId type, index_t count) {
+buffer_ptr<VectorBuffer> VectorBuffer::CreateStandardVector(TypeId type, idx_t count) {
 	return make_buffer<VectorBuffer>(count * GetTypeIdSize(type));
 }
 

--- a/src/common/value_operations/comparison_operations.cpp
+++ b/src/common/value_operations/comparison_operations.cpp
@@ -51,11 +51,11 @@ template <class OP> static bool templated_boolean_operation(const Value &left, c
 	case TypeId::VARCHAR:
 		return OP::Operation(left.str_value, right.str_value);
 	case TypeId::STRUCT: {
-		for (index_t i = 0; i < left.struct_value.size(); i++) {
+		for (idx_t i = 0; i < left.struct_value.size(); i++) {
 			if (i >= right.struct_value.size() || left.struct_value[i].first != right.struct_value[i].first ||
-				left.struct_value[i].second != left.struct_value[i].second) {
-					return false;
-				}
+			    left.struct_value[i].second != left.struct_value[i].second) {
+				return false;
+			}
 		}
 		return true;
 		break;

--- a/src/common/vector_operations/append.cpp
+++ b/src/common/vector_operations/append.cpp
@@ -11,10 +11,10 @@ using namespace duckdb;
 using namespace std;
 
 template <class T, bool HAS_NULL>
-static void vector_append_function(T *__restrict source, T *__restrict target, index_t count,
-                                   sel_t *__restrict sel_vector, nullmask_t &nullmask, index_t right_offset) {
+static void vector_append_function(T *__restrict source, T *__restrict target, idx_t count,
+                                   sel_t *__restrict sel_vector, nullmask_t &nullmask, idx_t right_offset) {
 	target += right_offset;
-	VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
+	VectorOperations::Exec(sel_vector, count, [&](idx_t i, idx_t k) {
 		target[k] = source[i];
 		if (HAS_NULL && IsNullValue<T>(target[k])) {
 			nullmask[right_offset + k] = true;

--- a/src/common/vector_operations/boolean_operators.cpp
+++ b/src/common/vector_operations/boolean_operators.cpp
@@ -18,19 +18,19 @@ using namespace std;
 //===--------------------------------------------------------------------===//
 template <class OP, class NULLOP, bool LEFT_CONSTANT, bool RIGHT_CONSTANT>
 static void templated_boolean_function_loop(bool *__restrict ldata, bool *__restrict rdata,
-                                            bool *__restrict result_data, index_t count, sel_t *__restrict sel_vector,
+                                            bool *__restrict result_data, idx_t count, sel_t *__restrict sel_vector,
                                             nullmask_t &left_nullmask, nullmask_t &right_nullmask,
                                             nullmask_t &result_nullmask) {
 	if (left_nullmask.any() || right_nullmask.any()) {
-		VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
-			index_t left_idx = LEFT_CONSTANT ? 0 : i;
-			index_t right_idx = RIGHT_CONSTANT ? 0 : i;
+		VectorOperations::Exec(sel_vector, count, [&](idx_t i, idx_t k) {
+			idx_t left_idx = LEFT_CONSTANT ? 0 : i;
+			idx_t right_idx = RIGHT_CONSTANT ? 0 : i;
 			result_data[i] = OP::Operation(ldata[left_idx], rdata[right_idx]);
 			result_nullmask[i] = NULLOP::Operation(ldata[left_idx], rdata[right_idx], left_nullmask[left_idx],
 			                                       right_nullmask[right_idx]);
 		});
 	} else {
-		VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
+		VectorOperations::Exec(sel_vector, count, [&](idx_t i, idx_t k) {
 			result_data[i] = OP::Operation(ldata[LEFT_CONSTANT ? 0 : i], rdata[RIGHT_CONSTANT ? 0 : i]);
 		});
 	}

--- a/src/common/vector_operations/comparison_select_operators.cpp
+++ b/src/common/vector_operations/comparison_select_operators.cpp
@@ -12,7 +12,7 @@
 using namespace duckdb;
 using namespace std;
 
-template <class OP> static index_t templated_select_operation(Vector &left, Vector &right, sel_t result[]) {
+template <class OP> static idx_t templated_select_operation(Vector &left, Vector &right, sel_t result[]) {
 	// the inplace loops take the result as the last parameter
 	switch (left.type) {
 	case TypeId::BOOL:
@@ -37,26 +37,26 @@ template <class OP> static index_t templated_select_operation(Vector &left, Vect
 	}
 }
 
-index_t VectorOperations::SelectEquals(Vector &left, Vector &right, sel_t result[]) {
+idx_t VectorOperations::SelectEquals(Vector &left, Vector &right, sel_t result[]) {
 	return templated_select_operation<duckdb::Equals>(left, right, result);
 }
 
-index_t VectorOperations::SelectNotEquals(Vector &left, Vector &right, sel_t result[]) {
+idx_t VectorOperations::SelectNotEquals(Vector &left, Vector &right, sel_t result[]) {
 	return templated_select_operation<duckdb::NotEquals>(left, right, result);
 }
 
-index_t VectorOperations::SelectGreaterThanEquals(Vector &left, Vector &right, sel_t result[]) {
+idx_t VectorOperations::SelectGreaterThanEquals(Vector &left, Vector &right, sel_t result[]) {
 	return templated_select_operation<duckdb::GreaterThanEquals>(left, right, result);
 }
 
-index_t VectorOperations::SelectLessThanEquals(Vector &left, Vector &right, sel_t result[]) {
+idx_t VectorOperations::SelectLessThanEquals(Vector &left, Vector &right, sel_t result[]) {
 	return templated_select_operation<duckdb::LessThanEquals>(left, right, result);
 }
 
-index_t VectorOperations::SelectGreaterThan(Vector &left, Vector &right, sel_t result[]) {
+idx_t VectorOperations::SelectGreaterThan(Vector &left, Vector &right, sel_t result[]) {
 	return templated_select_operation<duckdb::GreaterThan>(left, right, result);
 }
 
-index_t VectorOperations::SelectLessThan(Vector &left, Vector &right, sel_t result[]) {
+idx_t VectorOperations::SelectLessThan(Vector &left, Vector &right, sel_t result[]) {
 	return templated_select_operation<duckdb::LessThan>(left, right, result);
 }

--- a/src/common/vector_operations/copy.cpp
+++ b/src/common/vector_operations/copy.cpp
@@ -12,20 +12,20 @@ using namespace duckdb;
 using namespace std;
 
 template <class T>
-static void copy_function(T *__restrict source, T *__restrict target, index_t offset, index_t count,
+static void copy_function(T *__restrict source, T *__restrict target, idx_t offset, idx_t count,
                           sel_t *__restrict sel_vector) {
 	VectorOperations::Exec(
-	    sel_vector, count + offset, [&](index_t i, index_t k) { target[k - offset] = source[i]; }, offset);
+	    sel_vector, count + offset, [&](idx_t i, idx_t k) { target[k - offset] = source[i]; }, offset);
 }
 
 template <class T>
-static void copy_function_set_null(T *__restrict source, T *__restrict target, index_t offset, index_t count,
+static void copy_function_set_null(T *__restrict source, T *__restrict target, idx_t offset, idx_t count,
                                    sel_t *__restrict sel_vector, nullmask_t &nullmask) {
 	if (nullmask.any()) {
 		// null values, have to check the NULL values in the mask
 		VectorOperations::Exec(
 		    sel_vector, count + offset,
-		    [&](index_t i, index_t k) {
+		    [&](idx_t i, idx_t k) {
 			    if (nullmask[i]) {
 				    target[k - offset] = NullValue<T>();
 			    } else {
@@ -40,7 +40,7 @@ static void copy_function_set_null(T *__restrict source, T *__restrict target, i
 }
 
 template <class T, bool SET_NULL>
-static void copy_loop(Vector &input, void *target, index_t offset, index_t element_count) {
+static void copy_loop(Vector &input, void *target, idx_t offset, idx_t element_count) {
 	auto ldata = (T *)input.GetData();
 	auto result_data = (T *)target;
 	if (SET_NULL) {
@@ -50,7 +50,7 @@ static void copy_loop(Vector &input, void *target, index_t offset, index_t eleme
 	}
 }
 
-template <bool SET_NULL> void generic_copy_loop(Vector &source, void *target, index_t offset, index_t element_count) {
+template <bool SET_NULL> void generic_copy_loop(Vector &source, void *target, idx_t offset, idx_t element_count) {
 	if (source.count == 0)
 		return;
 	if (element_count == 0) {
@@ -95,24 +95,24 @@ template <bool SET_NULL> void generic_copy_loop(Vector &source, void *target, in
 //===--------------------------------------------------------------------===//
 // Copy data from vector
 //===--------------------------------------------------------------------===//
-void VectorOperations::Copy(Vector &source, void *target, index_t offset, index_t element_count) {
+void VectorOperations::Copy(Vector &source, void *target, idx_t offset, idx_t element_count) {
 	if (!TypeIsConstantSize(source.type)) {
 		throw InvalidTypeException(source.type, "Cannot copy non-constant size types using this method!");
 	}
 	generic_copy_loop<false>(source, target, offset, element_count);
 }
 
-void VectorOperations::CopyToStorage(Vector &source, void *target, index_t offset, index_t element_count) {
+void VectorOperations::CopyToStorage(Vector &source, void *target, idx_t offset, idx_t element_count) {
 	generic_copy_loop<true>(source, target, offset, element_count);
 }
 
-void VectorOperations::Copy(Vector &source, Vector &target, index_t offset) {
+void VectorOperations::Copy(Vector &source, Vector &target, idx_t offset) {
 	if (source.type != target.type) {
 		throw TypeMismatchException(source.type, target.type, "Copy types don't match!");
 	}
 	assert(offset <= source.count);
 	target.count = source.count - offset;
 	VectorOperations::Exec(
-	    source, [&](index_t i, index_t k) { target.nullmask[k - offset] = source.nullmask[i]; }, offset);
+	    source, [&](idx_t i, idx_t k) { target.nullmask[k - offset] = source.nullmask[i]; }, offset);
 	VectorOperations::Copy(source, target.GetData(), offset, target.count);
 }

--- a/src/common/vector_operations/generators.cpp
+++ b/src/common/vector_operations/generators.cpp
@@ -10,21 +10,21 @@ using namespace duckdb;
 using namespace std;
 
 template <class T>
-void generate_sequence_function(T *__restrict result_data, T value, T increment, index_t count,
+void generate_sequence_function(T *__restrict result_data, T value, T increment, idx_t count,
                                 sel_t *__restrict sel_vector, bool ignore_sel_vector) {
 	if (ignore_sel_vector) {
-		VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
+		VectorOperations::Exec(sel_vector, count, [&](idx_t i, idx_t k) {
 			result_data[i] = value;
 			value += increment;
 		});
 	} else {
 		if (sel_vector) {
-			for (index_t i = 0; i < count; i++) {
+			for (idx_t i = 0; i < count; i++) {
 				auto idx = sel_vector[i];
 				result_data[idx] = value + increment * idx;
 			}
 		} else {
-			for (index_t i = 0; i < count; i++) {
+			for (idx_t i = 0; i < count; i++) {
 				result_data[i] = value;
 				value += increment;
 			}

--- a/src/common/vector_operations/hash.cpp
+++ b/src/common/vector_operations/hash.cpp
@@ -17,16 +17,15 @@ struct HashOp {
 };
 
 template <class T>
-static inline void tight_loop_hash(T *__restrict ldata, uint64_t *__restrict result_data, index_t count,
+static inline void tight_loop_hash(T *__restrict ldata, uint64_t *__restrict result_data, idx_t count,
                                    sel_t *__restrict sel_vector, nullmask_t &nullmask) {
 	ASSERT_RESTRICT(ldata, ldata + count, result_data, result_data + count);
 	if (nullmask.any()) {
-		VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
-			result_data[i] = HashOp::Operation(ldata[i], nullmask[i]);
-		});
+		VectorOperations::Exec(sel_vector, count,
+		                       [&](idx_t i, idx_t k) { result_data[i] = HashOp::Operation(ldata[i], nullmask[i]); });
 	} else {
 		VectorOperations::Exec(sel_vector, count,
-		                       [&](index_t i, index_t k) { result_data[i] = HashOp::Operation(ldata[i], false); });
+		                       [&](idx_t i, idx_t k) { result_data[i] = HashOp::Operation(ldata[i], false); });
 	}
 }
 
@@ -83,16 +82,16 @@ static inline uint64_t combine_hash(uint64_t a, uint64_t b) {
 }
 
 template <class T>
-static inline void tight_loop_combine_hash(T *__restrict ldata, uint64_t *__restrict hash_data, index_t count,
+static inline void tight_loop_combine_hash(T *__restrict ldata, uint64_t *__restrict hash_data, idx_t count,
                                            sel_t *__restrict sel_vector, nullmask_t &nullmask) {
 	ASSERT_RESTRICT(ldata, ldata + count, hash_data, hash_data + count);
 	if (nullmask.any()) {
-		VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
+		VectorOperations::Exec(sel_vector, count, [&](idx_t i, idx_t k) {
 			auto other_hash = HashOp::Operation(ldata[i], nullmask[i]);
 			hash_data[i] = combine_hash(hash_data[i], other_hash);
 		});
 	} else {
-		VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
+		VectorOperations::Exec(sel_vector, count, [&](idx_t i, idx_t k) {
 			auto other_hash = HashOp::Operation(ldata[i], false);
 			hash_data[i] = combine_hash(hash_data[i], other_hash);
 		});

--- a/src/common/vector_operations/null_operations.cpp
+++ b/src/common/vector_operations/null_operations.cpp
@@ -17,7 +17,7 @@ template <bool INVERSE> void is_null_loop(Vector &input, Vector &result) {
 	result.nullmask.reset();
 
 	auto result_data = (bool *)result.GetData();
-	VectorOperations::Exec(input.sel_vector, input.count, [&](index_t i, index_t k) {
+	VectorOperations::Exec(input.sel_vector, input.count, [&](idx_t i, idx_t k) {
 		result_data[i] = INVERSE ? !input.nullmask[i] : input.nullmask[i];
 	});
 	result.sel_vector = input.sel_vector;
@@ -41,7 +41,7 @@ bool VectorOperations::HasNull(Vector &input) {
 			return false;
 		}
 		bool has_null = false;
-		VectorOperations::Exec(input, [&](index_t i, index_t k) {
+		VectorOperations::Exec(input, [&](idx_t i, idx_t k) {
 			if (input.nullmask[i]) {
 				has_null = true;
 			}
@@ -50,8 +50,8 @@ bool VectorOperations::HasNull(Vector &input) {
 	}
 }
 
-index_t VectorOperations::NotNullSelVector(Vector &vector, sel_t *not_null_vector, sel_t *&result_assignment,
-                                  sel_t *null_vector) {
+idx_t VectorOperations::NotNullSelVector(Vector &vector, sel_t *not_null_vector, sel_t *&result_assignment,
+                                         sel_t *null_vector) {
 	vector.Normalify();
 	if (vector.nullmask.any()) {
 		uint64_t result_count = 0, null_count = 0;

--- a/src/common/vector_operations/numeric_binary_operators.cpp
+++ b/src/common/vector_operations/numeric_binary_operators.cpp
@@ -77,7 +77,7 @@ void VectorOperations::Multiply(Vector &left, Vector &right, Vector &result) {
 //===--------------------------------------------------------------------===//
 struct BinaryZeroIsNullWrapper {
 	template <class FUNC, class OP, class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE>
-	static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, nullmask_t &nullmask, index_t idx) {
+	static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, nullmask_t &nullmask, idx_t idx) {
 		if (right == 0) {
 			nullmask[idx] = true;
 			return 0;

--- a/src/common/vector_operations/scatter.cpp
+++ b/src/common/vector_operations/scatter.cpp
@@ -88,10 +88,10 @@ void VectorOperations::Scatter::AddOne(Vector &source, Vector &dest) {
 			// constant NULL, ignore value
 			return;
 		}
-		VectorOperations::Exec(dest, [&](index_t i, index_t k) { (*destinations[i])++; });
+		VectorOperations::Exec(dest, [&](idx_t i, idx_t k) { (*destinations[i])++; });
 
 	} else if (source.vector_type == VectorType::SEQUENCE_VECTOR) {
-		VectorOperations::Exec(source.sel_vector, source.count, [&](index_t i, index_t k) {
+		VectorOperations::Exec(source.sel_vector, source.count, [&](idx_t i, idx_t k) {
 			if (!source.nullmask[i]) {
 				(*destinations[i])++;
 			}
@@ -99,7 +99,7 @@ void VectorOperations::Scatter::AddOne(Vector &source, Vector &dest) {
 	} else {
 		source.Normalify();
 		assert(source.vector_type == VectorType::FLAT_VECTOR);
-		VectorOperations::Exec(source, [&](index_t i, index_t k) {
+		VectorOperations::Exec(source, [&](idx_t i, idx_t k) {
 			if (!source.nullmask[i]) {
 				(*destinations[i])++;
 			}
@@ -107,16 +107,16 @@ void VectorOperations::Scatter::AddOne(Vector &source, Vector &dest) {
 	}
 }
 
-template <class T, bool IGNORE_NULL> static void scatter_set_loop(Vector &source, data_ptr_t dest[], index_t offset) {
+template <class T, bool IGNORE_NULL> static void scatter_set_loop(Vector &source, data_ptr_t dest[], idx_t offset) {
 	auto data = (T *)source.GetData();
 	if (source.vector_type == VectorType::CONSTANT_VECTOR) {
 		if (!source.nullmask[0]) {
-			VectorOperations::Exec(source.sel_vector, source.count, [&](index_t i, index_t k) {
+			VectorOperations::Exec(source.sel_vector, source.count, [&](idx_t i, idx_t k) {
 				auto destination = (T *)(dest[i] + offset);
 				*destination = data[0];
 			});
 		} else {
-			VectorOperations::Exec(source.sel_vector, source.count, [&](index_t i, index_t k) {
+			VectorOperations::Exec(source.sel_vector, source.count, [&](idx_t i, idx_t k) {
 				auto destination = (T *)(dest[i] + offset);
 				*destination = NullValue<T>();
 			});
@@ -124,12 +124,12 @@ template <class T, bool IGNORE_NULL> static void scatter_set_loop(Vector &source
 	} else {
 		assert(source.vector_type == VectorType::FLAT_VECTOR);
 		if (IGNORE_NULL || !source.nullmask.any()) {
-			VectorOperations::Exec(source, [&](index_t i, index_t k) {
+			VectorOperations::Exec(source, [&](idx_t i, idx_t k) {
 				auto destination = (T *)(dest[i] + offset);
 				*destination = data[i];
 			});
 		} else {
-			VectorOperations::Exec(source, [&](index_t i, index_t k) {
+			VectorOperations::Exec(source, [&](idx_t i, idx_t k) {
 				auto destination = (T *)(dest[i] + offset);
 				if (source.nullmask[i]) {
 					*destination = NullValue<T>();
@@ -141,8 +141,7 @@ template <class T, bool IGNORE_NULL> static void scatter_set_loop(Vector &source
 	}
 }
 
-template <bool IGNORE_NULL = false>
-static void scatter_set_all_loop(Vector &source, data_ptr_t dest[], index_t offset) {
+template <bool IGNORE_NULL = false> static void scatter_set_all_loop(Vector &source, data_ptr_t dest[], idx_t offset) {
 	switch (source.type) {
 	case TypeId::BOOL:
 	case TypeId::INT8:
@@ -174,7 +173,7 @@ static void scatter_set_all_loop(Vector &source, data_ptr_t dest[], index_t offs
 	}
 }
 
-void VectorOperations::Scatter::SetAll(Vector &source, Vector &dest, bool set_null, index_t offset) {
+void VectorOperations::Scatter::SetAll(Vector &source, Vector &dest, bool set_null, idx_t offset) {
 	if (dest.type != TypeId::POINTER) {
 		throw InvalidTypeException(dest.type, "Cannot scatter to non-pointer type!");
 	}

--- a/src/common/vector_operations/set.cpp
+++ b/src/common/vector_operations/set.cpp
@@ -13,8 +13,8 @@ using namespace duckdb;
 using namespace std;
 
 template <class T>
-static inline void set_loop(T *__restrict result_data, T value, index_t count, sel_t *__restrict sel_vector) {
-	VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) { result_data[i] = value; });
+static inline void set_loop(T *__restrict result_data, T value, idx_t count, sel_t *__restrict sel_vector) {
+	VectorOperations::Exec(sel_vector, count, [&](idx_t i, idx_t k) { result_data[i] = value; });
 }
 
 template <class T> void templated_set_loop(Vector &result, T value) {
@@ -66,7 +66,7 @@ void VectorOperations::Set(Vector &result, Value value) {
 		case TypeId::VARCHAR: {
 			auto str = result.AddString(value.str_value);
 			auto dataptr = (const char **)result.GetData();
-			VectorOperations::Exec(result.sel_vector, result.count, [&](index_t i, index_t k) { dataptr[i] = str; });
+			VectorOperations::Exec(result.sel_vector, result.count, [&](idx_t i, idx_t k) { dataptr[i] = str; });
 			break;
 		}
 		default:
@@ -90,7 +90,7 @@ template <class T> void templated_fill_nullmask(Vector &v) {
 			// no NULL values, skip
 			return;
 		}
-		VectorOperations::Exec(v, [&](index_t i, index_t k) {
+		VectorOperations::Exec(v, [&](idx_t i, idx_t k) {
 			if (v.nullmask[i]) {
 				data[i] = NullValue<T>();
 			}

--- a/src/common/vector_operations/sort.cpp
+++ b/src/common/vector_operations/sort.cpp
@@ -11,13 +11,13 @@ using namespace duckdb;
 using namespace std;
 
 template <class T, class OP>
-static sel_t templated_quicksort_initial(T *data, sel_t *sel_vector, sel_t result[], index_t count) {
+static sel_t templated_quicksort_initial(T *data, sel_t *sel_vector, sel_t result[], idx_t count) {
 	// select pivot
 	sel_t pivot = 0;
 	sel_t low = 0, high = count - 1;
 	if (sel_vector) {
 		// now insert elements
-		for (index_t i = 1; i < count; i++) {
+		for (idx_t i = 1; i < count; i++) {
 			if (OP::Operation(data[sel_vector[i]], data[pivot])) {
 				result[low++] = sel_vector[i];
 			} else {
@@ -28,7 +28,7 @@ static sel_t templated_quicksort_initial(T *data, sel_t *sel_vector, sel_t resul
 		result[low] = sel_vector[pivot];
 	} else {
 		// now insert elements
-		for (index_t i = 1; i < count; i++) {
+		for (idx_t i = 1; i < count; i++) {
 			if (OP::Operation(data[i], data[pivot])) {
 				result[low++] = i;
 			} else {
@@ -85,13 +85,13 @@ template <class T, class OP> void templated_quicksort(T *data, sel_t *sel_vector
 	templated_quicksort_inplace<T, OP>(data, result, part + 1, count - 1);
 }
 
-template <class T> static void templated_quicksort(Vector &vector, sel_t *sel_vector, index_t count, sel_t result[]) {
+template <class T> static void templated_quicksort(Vector &vector, sel_t *sel_vector, idx_t count, sel_t result[]) {
 	auto data = (T *)vector.GetData();
 	// quicksort without nulls
 	templated_quicksort<T, duckdb::LessThanEquals>(data, sel_vector, count, result);
 }
 
-void VectorOperations::Sort(Vector &vector, sel_t *sel_vector, index_t count, sel_t result[]) {
+void VectorOperations::Sort(Vector &vector, sel_t *sel_vector, idx_t count, sel_t result[]) {
 	if (count == 0) {
 		return;
 	}
@@ -134,15 +134,15 @@ void VectorOperations::Sort(Vector &vector, sel_t result[]) {
 	// first we extract NULL values
 	sel_t not_null_sel_vector[STANDARD_VECTOR_SIZE], null_sel_vector[STANDARD_VECTOR_SIZE];
 	sel_t *sel_vector;
-	index_t count = VectorOperations::NotNullSelVector(vector, not_null_sel_vector, sel_vector, null_sel_vector);
+	idx_t count = VectorOperations::NotNullSelVector(vector, not_null_sel_vector, sel_vector, null_sel_vector);
 	if (count == vector.count) {
 		// no NULL values
 		// we don't need to use the selection vector at all
 		VectorOperations::Sort(vector, nullptr, vector.count, result);
 	} else {
 		// first fill in the NULL values
-		index_t null_count = vector.count - count;
-		for (index_t i = 0; i < null_count; i++) {
+		idx_t null_count = vector.count - count;
+		for (idx_t i = 0; i < null_count; i++) {
 			result[i] = null_sel_vector[i];
 		}
 		// now sort the remainder
@@ -154,7 +154,7 @@ void VectorOperations::Sort(Vector &vector, sel_t result[]) {
 
 template <class T> bool is_unique(Vector &vector, sel_t sel_vector[]) {
 	auto data = (T *)vector.GetData();
-	for (index_t i = 1; i < vector.count; i++) {
+	for (idx_t i = 1; i < vector.count; i++) {
 		if (vector.nullmask[sel_vector[i]]) {
 			continue;
 		}

--- a/src/execution/column_binding_resolver.cpp
+++ b/src/execution/column_binding_resolver.cpp
@@ -68,7 +68,7 @@ unique_ptr<Expression> ColumnBindingResolver::VisitReplace(BoundColumnRefExpress
                                                            unique_ptr<Expression> *expr_ptr) {
 	assert(expr.depth == 0);
 	// check the current set of column bindings to see which index corresponds to the column reference
-	for (index_t i = 0; i < bindings.size(); i++) {
+	for (idx_t i = 0; i < bindings.size(); i++) {
 		if (expr.binding == bindings[i]) {
 			return make_unique<BoundReferenceExpression>(expr.alias, expr.return_type, i);
 		}
@@ -76,7 +76,7 @@ unique_ptr<Expression> ColumnBindingResolver::VisitReplace(BoundColumnRefExpress
 	// could not bind the column reference, this should never happen and indicates a bug in the code
 	// generate an error message
 	string bound_columns = "[";
-	for (index_t i = 0; i < bindings.size(); i++) {
+	for (idx_t i = 0; i < bindings.size(); i++) {
 		if (i != 0) {
 			bound_columns += " ";
 		}

--- a/src/execution/expression_executor.cpp
+++ b/src/execution/expression_executor.cpp
@@ -42,7 +42,7 @@ void ExpressionExecutor::Execute(DataChunk *input, DataChunk &result) {
 	assert(expressions.size() == result.column_count);
 	assert(expressions.size() > 0);
 	result.Reset();
-	for (index_t i = 0; i < expressions.size(); i++) {
+	for (idx_t i = 0; i < expressions.size(); i++) {
 		ExecuteExpression(i, result.data[i]);
 	}
 	result.sel_vector = result.data[0].sel_vector;
@@ -54,7 +54,7 @@ void ExpressionExecutor::ExecuteExpression(DataChunk &input, Vector &result) {
 	ExecuteExpression(result);
 }
 
-index_t ExpressionExecutor::SelectExpression(DataChunk &input, sel_t result[]) {
+idx_t ExpressionExecutor::SelectExpression(DataChunk &input, sel_t result[]) {
 	assert(expressions.size() == 1);
 	SetChunk(&input);
 	return Select(*expressions[0], states[0]->root_state.get(), result);
@@ -65,7 +65,7 @@ void ExpressionExecutor::ExecuteExpression(Vector &result) {
 	ExecuteExpression(0, result);
 }
 
-void ExpressionExecutor::ExecuteExpression(index_t expr_idx, Vector &result) {
+void ExpressionExecutor::ExecuteExpression(idx_t expr_idx, Vector &result) {
 	assert(expr_idx < expressions.size());
 	assert(result.type == expressions[expr_idx]->return_type);
 	Execute(*expressions[expr_idx], states[expr_idx]->root_state.get(), result);
@@ -161,7 +161,7 @@ void ExpressionExecutor::Execute(Expression &expr, ExpressionState *state, Vecto
 	Verify(expr, result);
 }
 
-index_t ExpressionExecutor::Select(Expression &expr, ExpressionState *state, sel_t result[]) {
+idx_t ExpressionExecutor::Select(Expression &expr, ExpressionState *state, sel_t result[]) {
 	assert(expr.return_type == TypeId::BOOL);
 	switch (expr.expression_class) {
 	case ExpressionClass::BOUND_BETWEEN:
@@ -175,7 +175,7 @@ index_t ExpressionExecutor::Select(Expression &expr, ExpressionState *state, sel
 	}
 }
 
-index_t ExpressionExecutor::DefaultSelect(Expression &expr, ExpressionState *state, sel_t result[]) {
+idx_t ExpressionExecutor::DefaultSelect(Expression &expr, ExpressionState *state, sel_t result[]) {
 	// generic selection of boolean expression:
 	// resolve the true/false expression first
 	// then use that to generate the selection vector
@@ -195,8 +195,8 @@ index_t ExpressionExecutor::DefaultSelect(Expression &expr, ExpressionState *sta
 		}
 	} else {
 		// not a constant value
-		index_t result_count = 0;
-		VectorOperations::Exec(intermediate, [&](index_t i, index_t k) {
+		idx_t result_count = 0;
+		VectorOperations::Exec(intermediate, [&](idx_t i, idx_t k) {
 			if (intermediate_result[i] && !intermediate.nullmask[i]) {
 				result[result_count++] = i;
 			}

--- a/src/execution/expression_executor/execute_between.cpp
+++ b/src/execution/expression_executor/execute_between.cpp
@@ -31,8 +31,7 @@ struct ExclusiveBetweenOperator {
 	}
 };
 
-template <class OP>
-static index_t between_loop_type_switch(Vector &input, Vector &lower, Vector &upper, sel_t result[]) {
+template <class OP> static idx_t between_loop_type_switch(Vector &input, Vector &lower, Vector &upper, sel_t result[]) {
 	switch (input.type) {
 	case TypeId::BOOL:
 	case TypeId::INT8:
@@ -89,7 +88,7 @@ void ExpressionExecutor::Execute(BoundBetweenExpression &expr, ExpressionState *
 	VectorOperations::And(intermediate1, intermediate2, result);
 }
 
-index_t ExpressionExecutor::Select(BoundBetweenExpression &expr, ExpressionState *state, sel_t result[]) {
+idx_t ExpressionExecutor::Select(BoundBetweenExpression &expr, ExpressionState *state, sel_t result[]) {
 	// resolve the children
 	auto &input = state->arguments.data[0];
 	auto &lower = state->arguments.data[1];
@@ -98,7 +97,7 @@ index_t ExpressionExecutor::Select(BoundBetweenExpression &expr, ExpressionState
 	Execute(*expr.lower, state->child_states[1].get(), lower);
 	Execute(*expr.upper, state->child_states[2].get(), upper);
 
-	index_t result_count;
+	idx_t result_count;
 	if (expr.upper_inclusive && expr.lower_inclusive) {
 		result_count = between_loop_type_switch<BothInclusiveBetweenOperator>(input, lower, upper, result);
 	} else if (expr.lower_inclusive) {

--- a/src/execution/expression_executor/execute_case.cpp
+++ b/src/execution/expression_executor/execute_case.cpp
@@ -5,8 +5,8 @@
 using namespace duckdb;
 using namespace std;
 
-void Case(Vector &res_true, Vector &res_false, Vector &result, sel_t tside[], index_t tcount, sel_t fside[],
-          index_t fcount);
+void Case(Vector &res_true, Vector &res_false, Vector &result, sel_t tside[], idx_t tcount, sel_t fside[],
+          idx_t fcount);
 
 unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(BoundCaseExpression &expr,
                                                                 ExpressionExecutorState &root) {
@@ -40,8 +40,8 @@ void ExpressionExecutor::Execute(BoundCaseExpression &expr, ExpressionState *sta
 		// check is not a constant
 		// first set up the sel vectors for both sides
 		sel_t tside[STANDARD_VECTOR_SIZE], fside[STANDARD_VECTOR_SIZE];
-		index_t tcount = 0, fcount = 0;
-		VectorOperations::Exec(check, [&](index_t i, index_t k) {
+		idx_t tcount = 0, fcount = 0;
+		VectorOperations::Exec(check, [&](idx_t i, idx_t k) {
 			if (!check_data[i] || check.nullmask[i]) {
 				fside[fcount++] = i;
 			} else {
@@ -72,16 +72,16 @@ template <class T> void fill_loop(Vector &vector, Vector &result, sel_t sel[], s
 	auto res = (T *)result.GetData();
 	if (vector.vector_type == VectorType::CONSTANT_VECTOR) {
 		if (vector.nullmask[0]) {
-			for (index_t i = 0; i < count; i++) {
+			for (idx_t i = 0; i < count; i++) {
 				result.nullmask[sel[i]] = true;
 			}
 		} else {
-			for (index_t i = 0; i < count; i++) {
+			for (idx_t i = 0; i < count; i++) {
 				res[sel[i]] = data[0];
 			}
 		}
 	} else {
-		for (index_t i = 0; i < count; i++) {
+		for (idx_t i = 0; i < count; i++) {
 			res[sel[i]] = data[sel[i]];
 			result.nullmask[sel[i]] = vector.nullmask[sel[i]];
 		}
@@ -89,14 +89,14 @@ template <class T> void fill_loop(Vector &vector, Vector &result, sel_t sel[], s
 }
 
 template <class T>
-void case_loop(Vector &res_true, Vector &res_false, Vector &result, sel_t tside[], index_t tcount, sel_t fside[],
-               index_t fcount) {
+void case_loop(Vector &res_true, Vector &res_false, Vector &result, sel_t tside[], idx_t tcount, sel_t fside[],
+               idx_t fcount) {
 	fill_loop<T>(res_true, result, tside, tcount);
 	fill_loop<T>(res_false, result, fside, fcount);
 }
 
-void Case(Vector &res_true, Vector &res_false, Vector &result, sel_t tside[], index_t tcount, sel_t fside[],
-          index_t fcount) {
+void Case(Vector &res_true, Vector &res_false, Vector &result, sel_t tside[], idx_t tcount, sel_t fside[],
+          idx_t fcount) {
 	assert(res_true.type == res_false.type && res_true.type == result.type);
 
 	switch (result.type) {

--- a/src/execution/expression_executor/execute_comparison.cpp
+++ b/src/execution/expression_executor/execute_comparison.cpp
@@ -45,14 +45,14 @@ void ExpressionExecutor::Execute(BoundComparisonExpression &expr, ExpressionStat
 	}
 }
 
-index_t ExpressionExecutor::Select(BoundComparisonExpression &expr, ExpressionState *state, sel_t result[]) {
+idx_t ExpressionExecutor::Select(BoundComparisonExpression &expr, ExpressionState *state, sel_t result[]) {
 	// resolve the children
 	auto &left = state->arguments.data[0];
 	auto &right = state->arguments.data[1];
 	Execute(*expr.left, state->child_states[0].get(), left);
 	Execute(*expr.right, state->child_states[1].get(), right);
 
-	index_t result_count;
+	idx_t result_count;
 	switch (expr.type) {
 	case ExpressionType::COMPARE_EQUAL:
 		result_count = VectorOperations::SelectEquals(left, right, result);

--- a/src/execution/expression_executor/execute_conjunction.cpp
+++ b/src/execution/expression_executor/execute_conjunction.cpp
@@ -14,7 +14,7 @@ struct ConjunctionState : public ExpressionState {
 	    : ExpressionState(expr, root), iteration_count(0), observe_interval(10), execute_interval(20), warmup(true) {
 		auto &conj_expr = (BoundConjunctionExpression &)expr;
 		assert(conj_expr.children.size() > 1);
-		for (index_t idx = 0; idx < conj_expr.children.size(); idx++) {
+		for (idx_t idx = 0; idx < conj_expr.children.size(); idx++) {
 			permutation.push_back(idx);
 			if (idx != conj_expr.children.size() - 1) {
 				swap_likeliness.push_back(100);
@@ -24,17 +24,17 @@ struct ConjunctionState : public ExpressionState {
 	}
 
 	// used for adaptive expression reordering
-	index_t iteration_count;
-	index_t swap_idx;
-	index_t right_random_border;
-	index_t observe_interval;
-	index_t execute_interval;
+	idx_t iteration_count;
+	idx_t swap_idx;
+	idx_t right_random_border;
+	idx_t observe_interval;
+	idx_t execute_interval;
 	double runtime_sum;
 	double prev_mean;
 	bool observe;
 	bool warmup;
-	vector<index_t> permutation;
-	vector<index_t> swap_likeliness;
+	vector<idx_t> permutation;
+	vector<idx_t> swap_likeliness;
 	std::default_random_engine generator;
 };
 
@@ -51,7 +51,7 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(BoundConjunction
 
 void ExpressionExecutor::Execute(BoundConjunctionExpression &expr, ExpressionState *state, Vector &result) {
 	// execute the children
-	for (index_t i = 0; i < expr.children.size(); i++) {
+	for (idx_t i = 0; i < expr.children.size(); i++) {
 		Execute(*expr.children[i], state->child_states[i].get(), state->arguments.data[i]);
 		if (i == 0) {
 			// move the result
@@ -74,15 +74,15 @@ void ExpressionExecutor::Execute(BoundConjunctionExpression &expr, ExpressionSta
 	}
 }
 
-static void SetChunkSelectionVector(DataChunk &chunk, sel_t *sel_vector, index_t count) {
+static void SetChunkSelectionVector(DataChunk &chunk, sel_t *sel_vector, idx_t count) {
 	chunk.sel_vector = sel_vector;
-	for (index_t col_idx = 0; col_idx < chunk.column_count; col_idx++) {
+	for (idx_t col_idx = 0; col_idx < chunk.column_count; col_idx++) {
 		chunk.data[col_idx].count = count;
 		chunk.data[col_idx].sel_vector = sel_vector;
 	}
 }
 
-static void MergeSelectionVectorIntoResult(sel_t *result, index_t &result_count, sel_t *sel, index_t count) {
+static void MergeSelectionVectorIntoResult(sel_t *result, idx_t &result_count, sel_t *sel, idx_t count) {
 	assert(count > 0);
 	if (result_count == 0) {
 		// nothing to merge
@@ -92,8 +92,8 @@ static void MergeSelectionVectorIntoResult(sel_t *result, index_t &result_count,
 	}
 
 	sel_t temp_result[STANDARD_VECTOR_SIZE];
-	index_t res_idx = 0, sel_idx = 0;
-	index_t temp_count = 0;
+	idx_t res_idx = 0, sel_idx = 0;
+	idx_t temp_count = 0;
 	while (true) {
 		// the two sets should be disjunct
 		assert(result[res_idx] != sel[sel_idx]);
@@ -161,10 +161,10 @@ void AdaptRuntimeStatistics(BoundConjunctionExpression &expr, ConjunctionState *
 
 			// get swap index and swap likeliness
 			uniform_int_distribution<int> distribution(1, state->right_random_border); // a <= i <= b
-			index_t random_number = distribution(state->generator) - 1;
+			idx_t random_number = distribution(state->generator) - 1;
 
-			state->swap_idx = random_number / 100;                      // index to be swapped
-			index_t likeliness = random_number - 100 * state->swap_idx; // random number between [0, 100)
+			state->swap_idx = random_number / 100;                    // index to be swapped
+			idx_t likeliness = random_number - 100 * state->swap_idx; // random number between [0, 100)
 
 			// check if swap is going to happen
 			if (state->swap_likeliness[state->swap_idx] > likeliness) { // always true for the first swap of an index
@@ -192,7 +192,7 @@ void AdaptRuntimeStatistics(BoundConjunctionExpression &expr, ConjunctionState *
 	}
 }
 
-index_t ExpressionExecutor::Select(BoundConjunctionExpression &expr, ExpressionState *state_, sel_t result[]) {
+idx_t ExpressionExecutor::Select(BoundConjunctionExpression &expr, ExpressionState *state_, sel_t result[]) {
 	auto state = (ConjunctionState *)state_;
 	if (!chunk) {
 		return DefaultSelect(expr, state, result);
@@ -204,16 +204,16 @@ index_t ExpressionExecutor::Select(BoundConjunctionExpression &expr, ExpressionS
 	if (expr.type == ExpressionType::CONJUNCTION_AND) {
 		// store the initial selection vector and count
 		auto initial_sel = chunk->sel_vector;
-		index_t initial_count = chunk->size();
-		index_t current_count = chunk->size();
+		idx_t initial_count = chunk->size();
+		idx_t current_count = chunk->size();
 
 		// get runtime statistics
 		start_time = chrono::high_resolution_clock::now();
 
-		for (index_t i = 0; i < expr.children.size(); i++) {
+		for (idx_t i = 0; i < expr.children.size(); i++) {
 
 			// first resolve the current expression and get its execution time
-			index_t new_count =
+			idx_t new_count =
 			    Select(*expr.children[state->permutation[i]], state->child_states[state->permutation[i]].get(), result);
 
 			if (new_count == 0) {
@@ -237,24 +237,24 @@ index_t ExpressionExecutor::Select(BoundConjunctionExpression &expr, ExpressionS
 		return current_count;
 	} else {
 		sel_t *initial_sel = chunk->sel_vector;
-		index_t initial_count = chunk->size();
-		index_t current_count = chunk->size();
+		idx_t initial_count = chunk->size();
+		idx_t current_count = chunk->size();
 		sel_t *current_sel = initial_sel;
 
 		sel_t intermediate_result[STANDARD_VECTOR_SIZE];
 		sel_t expression_result[STANDARD_VECTOR_SIZE];
 		sel_t remaining[STANDARD_VECTOR_SIZE];
-		index_t result_count = 0;
-		index_t remaining_count = 0;
+		idx_t result_count = 0;
+		idx_t remaining_count = 0;
 		sel_t *result_vector = initial_sel == result ? intermediate_result : result;
 
 		// get runtime statistics
 		start_time = chrono::high_resolution_clock::now();
 
-		for (index_t expr_idx = 0; expr_idx < expr.children.size(); expr_idx++) {
+		for (idx_t expr_idx = 0; expr_idx < expr.children.size(); expr_idx++) {
 			// first resolve the current expression
-			index_t new_count = Select(*expr.children[state->permutation[expr_idx]],
-			                           state->child_states[state->permutation[expr_idx]].get(), expression_result);
+			idx_t new_count = Select(*expr.children[state->permutation[expr_idx]],
+			                         state->child_states[state->permutation[expr_idx]].get(), expression_result);
 			if (new_count == 0) {
 				// no new qualifying entries: continue
 				continue;
@@ -278,9 +278,9 @@ index_t ExpressionExecutor::Select(BoundConjunctionExpression &expr, ExpressionS
 			}
 			// now we only need to continue executing tuples that were not qualified
 			// we figure this out by performing a merge of the remaining tuples and the resulting selection vector
-			index_t new_idx = 0;
+			idx_t new_idx = 0;
 			remaining_count = 0;
-			for (index_t i = 0; i < current_count; i++) {
+			for (idx_t i = 0; i < current_count; i++) {
 				auto entry = current_sel ? current_sel[i] : i;
 				if (new_idx >= new_count || expression_result[new_idx] != entry) {
 					remaining[remaining_count++] = entry;

--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -16,7 +16,7 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(BoundFunctionExp
 }
 
 void ExpressionExecutor::Execute(BoundFunctionExpression &expr, ExpressionState *state, Vector &result) {
-	for (index_t i = 0; i < expr.children.size(); i++) {
+	for (idx_t i = 0; i < expr.children.size(); i++) {
 		Execute(*expr.children[i], state->child_states[i].get(), state->arguments.data[i]);
 	}
 	expr.function.function(state->arguments, *state, result);

--- a/src/execution/expression_executor/execute_operator.cpp
+++ b/src/execution/expression_executor/execute_operator.cpp
@@ -37,7 +37,7 @@ void ExpressionExecutor::Execute(BoundOperatorExpression &expr, ExpressionState 
 		// in rhs is a list of constants
 		// for every child, OR the result of the comparision with the left
 		// to get the overall result.
-		for (index_t child = 1; child < expr.children.size(); child++) {
+		for (idx_t child = 1; child < expr.children.size(); child++) {
 			Vector comp_res(TypeId::BOOL, true, false);
 
 			auto &vector_to_check = state->arguments.data[child];

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -40,7 +40,7 @@ ART::~ART() {
 bool ART::LeafMatches(Node *node, Key &key, unsigned depth) {
 	auto leaf = static_cast<Leaf *>(node);
 	Key &leaf_key = *leaf->value;
-	for (index_t i = depth; i < leaf_key.len; i++) {
+	for (idx_t i = depth; i < leaf_key.len; i++) {
 		if (leaf_key[i] != key[i]) {
 			return false;
 		}
@@ -73,7 +73,7 @@ unique_ptr<IndexScanState> ART::InitializeScanTwoPredicates(Transaction &transac
 //===--------------------------------------------------------------------===//
 template <class T> static void generate_keys(Vector &input, vector<unique_ptr<Key>> &keys, bool is_little_endian) {
 	auto input_data = (T *)input.GetData();
-	VectorOperations::Exec(input, [&](index_t i, index_t k) {
+	VectorOperations::Exec(input, [&](idx_t i, idx_t k) {
 		if (input.nullmask[i]) {
 			keys.push_back(nullptr);
 		} else {
@@ -84,7 +84,7 @@ template <class T> static void generate_keys(Vector &input, vector<unique_ptr<Ke
 
 template <class T> static void concatenate_keys(Vector &input, vector<unique_ptr<Key>> &keys, bool is_little_endian) {
 	auto input_data = (T *)input.GetData();
-	VectorOperations::Exec(input, [&](index_t i, index_t k) {
+	VectorOperations::Exec(input, [&](idx_t i, idx_t k) {
 		if (input.nullmask[i] || !keys[k]) {
 			// either this column is NULL, or the previous column is NULL!
 			keys[k] = nullptr;
@@ -129,7 +129,7 @@ void ART::GenerateKeys(DataChunk &input, vector<unique_ptr<Key>> &keys) {
 	default:
 		throw InvalidTypeException(input.data[0].type, "Invalid type for index");
 	}
-	for (index_t i = 1; i < input.column_count; i++) {
+	for (idx_t i = 1; i < input.column_count; i++) {
 		// for each fo the remaining columns, concatenate
 		switch (input.data[i].type) {
 		case TypeId::INT8:
@@ -171,8 +171,8 @@ bool ART::Insert(IndexLock &lock, DataChunk &input, Vector &row_ids) {
 	// now insert the elements into the index
 	row_ids.Normalify();
 	auto row_identifiers = (row_t *)row_ids.GetData();
-	index_t failed_index = INVALID_INDEX;
-	for (index_t i = 0; i < row_ids.count; i++) {
+	idx_t failed_index = INVALID_INDEX;
+	for (idx_t i = 0; i < row_ids.count; i++) {
 		if (!keys[i]) {
 			continue;
 		}
@@ -192,11 +192,11 @@ bool ART::Insert(IndexLock &lock, DataChunk &input, Vector &row_ids) {
 		unique_ptr<Key> key;
 
 		// now erase the entries
-		for (index_t i = 0; i < failed_index; i++) {
+		for (idx_t i = 0; i < failed_index; i++) {
 			if (!keys[i]) {
 				continue;
 			}
-			index_t k = row_ids.sel_vector ? row_ids.sel_vector[i] : i;
+			idx_t k = row_ids.sel_vector ? row_ids.sel_vector[i] : i;
 			row_t row_id = row_identifiers[k];
 			Erase(tree, *keys[i], 0, row_id);
 		}
@@ -226,7 +226,7 @@ void ART::VerifyAppend(DataChunk &chunk) {
 	vector<unique_ptr<Key>> keys;
 	GenerateKeys(expression_result, keys);
 
-	for (index_t i = 0; i < chunk.size(); i++) {
+	for (idx_t i = 0; i < chunk.size(); i++) {
 		if (!keys[i]) {
 			continue;
 		}
@@ -303,7 +303,7 @@ bool ART::Insert(unique_ptr<Node> &node, unique_ptr<Key> value, unsigned depth, 
 	}
 
 	// Recurse
-	index_t pos = node->GetChildPos(key[depth]);
+	idx_t pos = node->GetChildPos(key[depth]);
 	if (pos != INVALID_INDEX) {
 		auto child = node->GetChild(pos);
 		return Insert(*child, move(value), depth + 1, row_id);
@@ -328,7 +328,7 @@ void ART::Delete(IndexLock &state, DataChunk &input, Vector &row_ids) {
 	row_ids.Normalify();
 	auto row_identifiers = (int64_t *)row_ids.GetData();
 
-	for (index_t i = 0; i < row_ids.count; i++) {
+	for (idx_t i = 0; i < row_ids.count; i++) {
 		if (!keys[i]) {
 			continue;
 		}
@@ -358,7 +358,7 @@ void ART::Erase(unique_ptr<Node> &node, Key &key, unsigned depth, row_t row_id) 
 		}
 		depth += node->prefix_length;
 	}
-	index_t pos = node->GetChildPos(key[depth]);
+	idx_t pos = node->GetChildPos(key[depth]);
 	if (pos != INVALID_INDEX) {
 		auto child = node->GetChild(pos);
 		assert(child);
@@ -412,7 +412,7 @@ void ART::SearchEqual(vector<row_t> &result_ids, ARTIndexScanState *state) {
 	if (!leaf) {
 		return;
 	}
-	for (index_t i = 0; i < leaf->num_elements; i++) {
+	for (idx_t i = 0; i < leaf->num_elements; i++) {
 		row_t row_id = leaf->GetRowId(i);
 		result_ids.push_back(row_id);
 	}
@@ -426,7 +426,7 @@ Node *ART::Lookup(unique_ptr<Node> &node, Key &key, unsigned depth) {
 			auto leaf = static_cast<Leaf *>(node_val);
 			Key &leafKey = *leaf->value;
 			//! Check leaf
-			for (index_t i = depth; i < leafKey.len; i++) {
+			for (idx_t i = depth; i < leafKey.len; i++) {
 				if (leafKey[i] != key[i]) {
 					return nullptr;
 				}
@@ -434,14 +434,14 @@ Node *ART::Lookup(unique_ptr<Node> &node, Key &key, unsigned depth) {
 			return node_val;
 		}
 		if (node_val->prefix_length) {
-			for (index_t pos = 0; pos < node_val->prefix_length; pos++) {
+			for (idx_t pos = 0; pos < node_val->prefix_length; pos++) {
 				if (key[depth + pos] != node_val->prefix[pos]) {
 					return nullptr;
 				}
 			}
 			depth += node_val->prefix_length;
 		}
-		index_t pos = node_val->GetChildPos(key[depth]);
+		idx_t pos = node_val->GetChildPos(key[depth]);
 		if (pos == INVALID_INDEX) {
 			return nullptr;
 		}
@@ -473,7 +473,7 @@ void ART::IteratorScan(ARTIndexScanState *state, Iterator *it, vector<row_t> &re
 				}
 			}
 		}
-		for (index_t i = 0; i < it->node->num_elements; i++) {
+		for (idx_t i = 0; i < it->node->num_elements; i++) {
 			row_t row_id = it->node->GetRowId(i);
 			result_ids.push_back(row_id);
 		}
@@ -525,7 +525,7 @@ bool ART::Bound(unique_ptr<Node> &n, Key &key, Iterator &it, bool inclusive) {
 	}
 	Node *node = n.get();
 
-	index_t depth = 0;
+	idx_t depth = 0;
 	while (true) {
 		auto &top = it.stack[it.depth];
 		top.node = node;
@@ -615,7 +615,7 @@ void ART::SearchGreater(vector<row_t> &result_ids, ARTIndexScanState *state, boo
 //===--------------------------------------------------------------------===//
 static Leaf &FindMinimum(Iterator &it, Node &node) {
 	Node *next = nullptr;
-	index_t pos = 0;
+	idx_t pos = 0;
 	switch (node.type) {
 	case NodeType::NLeaf:
 		it.node = (Leaf *)&node;
@@ -748,7 +748,7 @@ void ART::Scan(Transaction &transaction, TableIndexScanState &table_state, DataC
 		state->result_ids.reserve(result_ids.size());
 
 		state->result_ids.push_back(result_ids[0]);
-		for (index_t i = 1; i < result_ids.size(); i++) {
+		for (idx_t i = 1; i < result_ids.size(); i++) {
 			if (result_ids[i] != result_ids[i - 1]) {
 				state->result_ids.push_back(result_ids[i]);
 			}
@@ -763,7 +763,7 @@ void ART::Scan(Transaction &transaction, TableIndexScanState &table_state, DataC
 	// create a vector pointing to the current set of row ids
 	Vector row_identifiers(ROW_TYPE, (data_ptr_t)&state->result_ids[state->result_index]);
 	row_identifiers.count =
-	    std::min((index_t)STANDARD_VECTOR_SIZE, (index_t)state->result_ids.size() - state->result_index);
+	    std::min((idx_t)STANDARD_VECTOR_SIZE, (idx_t)state->result_ids.size() - state->result_index);
 
 	// fetch the actual values from the base table
 	table.Fetch(transaction, result, state->column_ids, row_identifiers, table_state);

--- a/src/execution/index/art/art_key.cpp
+++ b/src/execution/index/art/art_key.cpp
@@ -74,7 +74,7 @@ uint64_t Key::EncodeDouble(double x) {
 	return buff;
 }
 
-Key::Key(unique_ptr<data_t[]> data, index_t len) : len(len), data(move(data)) {
+Key::Key(unique_ptr<data_t[]> data, idx_t len) : len(len), data(move(data)) {
 }
 
 template <> unique_ptr<data_t[]> Key::CreateData(int8_t value, bool is_little_endian) {
@@ -119,21 +119,21 @@ template <> unique_ptr<data_t[]> Key::CreateData(double value, bool is_little_en
 }
 
 template <> unique_ptr<Key> Key::CreateKey(string value, bool is_little_endian) {
-	index_t len = value.size() + 1;
+	idx_t len = value.size() + 1;
 	auto data = unique_ptr<data_t[]>(new data_t[len]);
 	memcpy(data.get(), value.c_str(), len);
 	return make_unique<Key>(move(data), len);
 }
 
 template <> unique_ptr<Key> Key::CreateKey(char *value, bool is_little_endian) {
-	index_t len = strlen(value) + 1;
+	idx_t len = strlen(value) + 1;
 	auto data = unique_ptr<data_t[]>(new data_t[len]);
 	memcpy(data.get(), value, len);
 	return make_unique<Key>(move(data), len);
 }
 
 bool Key::operator>(const Key &k) const {
-	for (index_t i = 0; i < std::min(len, k.len); i++) {
+	for (idx_t i = 0; i < std::min(len, k.len); i++) {
 		if (data[i] > k.data[i]) {
 			return true;
 		} else if (data[i] < k.data[i]) {
@@ -144,7 +144,7 @@ bool Key::operator>(const Key &k) const {
 }
 
 bool Key::operator<(const Key &k) const {
-	for (index_t i = 0; i < std::min(len, k.len); i++) {
+	for (idx_t i = 0; i < std::min(len, k.len); i++) {
 		if (data[i] < k.data[i]) {
 			return true;
 		} else if (data[i] > k.data[i]) {
@@ -155,7 +155,7 @@ bool Key::operator<(const Key &k) const {
 }
 
 bool Key::operator>=(const Key &k) const {
-	for (index_t i = 0; i < std::min(len, k.len); i++) {
+	for (idx_t i = 0; i < std::min(len, k.len); i++) {
 		if (data[i] > k.data[i]) {
 			return true;
 		} else if (data[i] < k.data[i]) {
@@ -169,7 +169,7 @@ bool Key::operator==(const Key &k) const {
 	if (len != k.len) {
 		return false;
 	}
-	for (index_t i = 0; i < len; i++) {
+	for (idx_t i = 0; i < len; i++) {
 		if (data[i] != k.data[i]) {
 			return false;
 		}

--- a/src/execution/index/art/leaf.cpp
+++ b/src/execution/index/art/leaf.cpp
@@ -27,15 +27,15 @@ void Leaf::Insert(row_t row_id) {
 
 //! TODO: Maybe shrink array dynamically?
 void Leaf::Remove(row_t row_id) {
-	index_t entry_offset = -1;
-	for (index_t i = 0; i < num_elements; i++) {
+	idx_t entry_offset = -1;
+	for (idx_t i = 0; i < num_elements; i++) {
 		if (row_ids[i] == row_id) {
 			entry_offset = i;
 			break;
 		}
 	}
 	num_elements--;
-	for (index_t j = entry_offset; j < num_elements; j++) {
+	for (idx_t j = entry_offset; j < num_elements; j++) {
 		row_ids[j] = row_ids[j + 1];
 	}
 }

--- a/src/execution/index/art/node.cpp
+++ b/src/execution/index/art/node.cpp
@@ -13,12 +13,12 @@ void Node::CopyPrefix(ART &art, Node *src, Node *dst) {
 	memcpy(dst->prefix.get(), src->prefix.get(), src->prefix_length);
 }
 
-unique_ptr<Node> *Node::GetChild(index_t pos) {
+unique_ptr<Node> *Node::GetChild(idx_t pos) {
 	assert(0);
 	return nullptr;
 }
 
-index_t Node::GetMin() {
+idx_t Node::GetMin() {
 	assert(0);
 	return 0;
 }
@@ -52,7 +52,7 @@ void Node::InsertLeaf(ART &art, unique_ptr<Node> &node, uint8_t key, unique_ptr<
 	}
 }
 
-void Node::Erase(ART &art, unique_ptr<Node> &node, index_t pos) {
+void Node::Erase(ART &art, unique_ptr<Node> &node, idx_t pos) {
 	switch (node->type) {
 	case NodeType::N4: {
 		Node4::erase(art, node, pos);

--- a/src/execution/index/art/node16.cpp
+++ b/src/execution/index/art/node16.cpp
@@ -11,8 +11,8 @@ Node16::Node16(ART &art, size_t compressionLength) : Node(art, NodeType::N16, co
 }
 
 // TODO : In the future this can be performed using SIMD (#include <emmintrin.h>  x86 SSE intrinsics)
-index_t Node16::GetChildPos(uint8_t k) {
-	for (index_t pos = 0; pos < count; pos++) {
+idx_t Node16::GetChildPos(uint8_t k) {
+	for (idx_t pos = 0; pos < count; pos++) {
 		if (key[pos] == k) {
 			return pos;
 		}
@@ -20,8 +20,8 @@ index_t Node16::GetChildPos(uint8_t k) {
 	return Node::GetChildPos(k);
 }
 
-index_t Node16::GetChildGreaterEqual(uint8_t k) {
-	for (index_t pos = 0; pos < count; pos++) {
+idx_t Node16::GetChildGreaterEqual(uint8_t k) {
+	for (idx_t pos = 0; pos < count; pos++) {
 		if (key[pos] >= k) {
 			return pos;
 		}
@@ -29,7 +29,7 @@ index_t Node16::GetChildGreaterEqual(uint8_t k) {
 	return Node::GetChildGreaterEqual(k);
 }
 
-index_t Node16::GetNextPos(index_t pos) {
+idx_t Node16::GetNextPos(idx_t pos) {
 	if (pos == INVALID_INDEX) {
 		return 0;
 	}
@@ -37,12 +37,12 @@ index_t Node16::GetNextPos(index_t pos) {
 	return pos < count ? pos : INVALID_INDEX;
 }
 
-unique_ptr<Node> *Node16::GetChild(index_t pos) {
+unique_ptr<Node> *Node16::GetChild(idx_t pos) {
 	assert(pos < count);
 	return &child[pos];
 }
 
-index_t Node16::GetMin() {
+idx_t Node16::GetMin() {
 	return 0;
 }
 

--- a/src/execution/index/art/node256.cpp
+++ b/src/execution/index/art/node256.cpp
@@ -6,7 +6,7 @@ using namespace duckdb;
 Node256::Node256(ART &art, size_t compressionLength) : Node(art, NodeType::N256, compressionLength) {
 }
 
-index_t Node256::GetChildPos(uint8_t k) {
+idx_t Node256::GetChildPos(uint8_t k) {
 	if (child[k]) {
 		return k;
 	} else {
@@ -14,8 +14,8 @@ index_t Node256::GetChildPos(uint8_t k) {
 	}
 }
 
-index_t Node256::GetChildGreaterEqual(uint8_t k) {
-	for (index_t pos = k; pos < 256; pos++) {
+idx_t Node256::GetChildGreaterEqual(uint8_t k) {
+	for (idx_t pos = k; pos < 256; pos++) {
 		if (child[pos]) {
 			return pos;
 		}
@@ -23,8 +23,8 @@ index_t Node256::GetChildGreaterEqual(uint8_t k) {
 	return INVALID_INDEX;
 }
 
-index_t Node256::GetMin() {
-	for (index_t i = 0; i < 256; i++) {
+idx_t Node256::GetMin() {
+	for (idx_t i = 0; i < 256; i++) {
 		if (child[i]) {
 			return i;
 		}
@@ -32,7 +32,7 @@ index_t Node256::GetMin() {
 	return INVALID_INDEX;
 }
 
-index_t Node256::GetNextPos(index_t pos) {
+idx_t Node256::GetNextPos(idx_t pos) {
 	for (pos == INVALID_INDEX ? pos = 0 : pos++; pos < 256; pos++) {
 		if (child[pos]) {
 			return pos;
@@ -41,7 +41,7 @@ index_t Node256::GetNextPos(index_t pos) {
 	return Node::GetNextPos(pos);
 }
 
-unique_ptr<Node> *Node256::GetChild(index_t pos) {
+unique_ptr<Node> *Node256::GetChild(idx_t pos) {
 	assert(child[pos]);
 	return &child[pos];
 }
@@ -61,7 +61,7 @@ void Node256::erase(ART &art, unique_ptr<Node> &node, int pos) {
 	if (node->count <= 36) {
 		auto newNode = make_unique<Node48>(art, n->prefix_length);
 		CopyPrefix(art, n, newNode.get());
-		for (index_t i = 0; i < 256; i++) {
+		for (idx_t i = 0; i < 256; i++) {
 			if (n->child[i]) {
 				newNode->childIndex[i] = newNode->count;
 				newNode->child[newNode->count] = move(n->child[i]);

--- a/src/execution/index/art/node4.cpp
+++ b/src/execution/index/art/node4.cpp
@@ -8,8 +8,8 @@ Node4::Node4(ART &art, size_t compressionLength) : Node(art, NodeType::N4, compr
 	memset(key, 0, sizeof(key));
 }
 
-index_t Node4::GetChildPos(uint8_t k) {
-	for (index_t pos = 0; pos < count; pos++) {
+idx_t Node4::GetChildPos(uint8_t k) {
+	for (idx_t pos = 0; pos < count; pos++) {
 		if (key[pos] == k) {
 			return pos;
 		}
@@ -17,8 +17,8 @@ index_t Node4::GetChildPos(uint8_t k) {
 	return Node::GetChildPos(k);
 }
 
-index_t Node4::GetChildGreaterEqual(uint8_t k) {
-	for (index_t pos = 0; pos < count; pos++) {
+idx_t Node4::GetChildGreaterEqual(uint8_t k) {
+	for (idx_t pos = 0; pos < count; pos++) {
 		if (key[pos] >= k) {
 			return pos;
 		}
@@ -26,11 +26,11 @@ index_t Node4::GetChildGreaterEqual(uint8_t k) {
 	return Node::GetChildGreaterEqual(k);
 }
 
-index_t Node4::GetMin() {
+idx_t Node4::GetMin() {
 	return 0;
 }
 
-index_t Node4::GetNextPos(index_t pos) {
+idx_t Node4::GetNextPos(idx_t pos) {
 	if (pos == INVALID_INDEX) {
 		return 0;
 	}
@@ -38,7 +38,7 @@ index_t Node4::GetNextPos(index_t pos) {
 	return pos < count ? pos : INVALID_INDEX;
 }
 
-unique_ptr<Node> *Node4::GetChild(index_t pos) {
+unique_ptr<Node> *Node4::GetChild(idx_t pos) {
 	assert(pos < count);
 	return &child[pos];
 }

--- a/src/execution/index/art/node48.cpp
+++ b/src/execution/index/art/node48.cpp
@@ -10,7 +10,7 @@ Node48::Node48(ART &art, size_t compressionLength) : Node(art, NodeType::N48, co
 	}
 }
 
-index_t Node48::GetChildPos(uint8_t k) {
+idx_t Node48::GetChildPos(uint8_t k) {
 	if (childIndex[k] == Node::EMPTY_MARKER) {
 		return INVALID_INDEX;
 	} else {
@@ -18,8 +18,8 @@ index_t Node48::GetChildPos(uint8_t k) {
 	}
 }
 
-index_t Node48::GetChildGreaterEqual(uint8_t k) {
-	for (index_t pos = k; pos < 256; pos++) {
+idx_t Node48::GetChildGreaterEqual(uint8_t k) {
+	for (idx_t pos = k; pos < 256; pos++) {
 		if (childIndex[pos] != Node::EMPTY_MARKER) {
 			return pos;
 		}
@@ -27,7 +27,7 @@ index_t Node48::GetChildGreaterEqual(uint8_t k) {
 	return Node::GetChildGreaterEqual(k);
 }
 
-index_t Node48::GetNextPos(index_t pos) {
+idx_t Node48::GetNextPos(idx_t pos) {
 	for (pos == INVALID_INDEX ? pos = 0 : pos++; pos < 256; pos++) {
 		if (childIndex[pos] != Node::EMPTY_MARKER) {
 			return pos;
@@ -36,13 +36,13 @@ index_t Node48::GetNextPos(index_t pos) {
 	return Node::GetNextPos(pos);
 }
 
-unique_ptr<Node> *Node48::GetChild(index_t pos) {
+unique_ptr<Node> *Node48::GetChild(idx_t pos) {
 	assert(childIndex[pos] != Node::EMPTY_MARKER);
 	return &child[childIndex[pos]];
 }
 
-index_t Node48::GetMin() {
-	for (index_t i = 0; i < 256; i++) {
+idx_t Node48::GetMin() {
+	for (idx_t i = 0; i < 256; i++) {
 		if (childIndex[i] != Node::EMPTY_MARKER) {
 			return i;
 		}
@@ -56,7 +56,7 @@ void Node48::insert(ART &art, unique_ptr<Node> &node, uint8_t keyByte, unique_pt
 	// Insert leaf into inner node
 	if (node->count < 48) {
 		// Insert element
-		index_t pos = n->count;
+		idx_t pos = n->count;
 		if (n->child[pos]) {
 			// find an empty position in the node list if the current position is occupied
 			pos = 0;
@@ -70,7 +70,7 @@ void Node48::insert(ART &art, unique_ptr<Node> &node, uint8_t keyByte, unique_pt
 	} else {
 		// Grow to Node256
 		auto newNode = make_unique<Node256>(art, n->prefix_length);
-		for (index_t i = 0; i < 256; i++) {
+		for (idx_t i = 0; i < 256; i++) {
 			if (n->childIndex[i] != Node::EMPTY_MARKER) {
 				newNode->child[i] = move(n->child[n->childIndex[i]]);
 			}
@@ -91,7 +91,7 @@ void Node48::erase(ART &art, unique_ptr<Node> &node, int pos) {
 	if (node->count <= 12) {
 		auto newNode = make_unique<Node16>(art, n->prefix_length);
 		CopyPrefix(art, n, newNode.get());
-		for (index_t i = 0; i < 256; i++) {
+		for (idx_t i = 0; i < 256; i++) {
 			if (n->childIndex[i] != Node::EMPTY_MARKER) {
 				newNode->key[newNode->count] = i;
 				newNode->child[newNode->count++] = move(n->child[n->childIndex[i]]);

--- a/src/execution/merge_join/merge_join.cpp
+++ b/src/execution/merge_join/merge_join.cpp
@@ -5,7 +5,7 @@
 using namespace duckdb;
 using namespace std;
 
-template <class MJ, class L_ARG, class R_ARG> static index_t merge_join(L_ARG &l, R_ARG &r) {
+template <class MJ, class L_ARG, class R_ARG> static idx_t merge_join(L_ARG &l, R_ARG &r) {
 	switch (l.type) {
 	case TypeId::INT8:
 		return MJ::template Operation<int8_t>(l, r);
@@ -27,7 +27,7 @@ template <class MJ, class L_ARG, class R_ARG> static index_t merge_join(L_ARG &l
 }
 
 template <class T, class L_ARG, class R_ARG>
-static index_t perform_merge_join(L_ARG &l, R_ARG &r, ExpressionType comparison_type) {
+static idx_t perform_merge_join(L_ARG &l, R_ARG &r, ExpressionType comparison_type) {
 	switch (comparison_type) {
 	case ExpressionType::COMPARE_EQUAL:
 		return merge_join<typename T::Equality, L_ARG, R_ARG>(l, r);
@@ -44,7 +44,7 @@ static index_t perform_merge_join(L_ARG &l, R_ARG &r, ExpressionType comparison_
 	}
 }
 
-index_t MergeJoinInner::Perform(MergeInfo &l, MergeInfo &r, ExpressionType comparison_type) {
+idx_t MergeJoinInner::Perform(MergeInfo &l, MergeInfo &r, ExpressionType comparison_type) {
 	assert(l.info_type == MergeInfoType::SCALAR_MERGE_INFO && r.info_type == MergeInfoType::SCALAR_MERGE_INFO);
 	auto &left = (ScalarMergeInfo &)l;
 	auto &right = (ScalarMergeInfo &)r;
@@ -55,7 +55,7 @@ index_t MergeJoinInner::Perform(MergeInfo &l, MergeInfo &r, ExpressionType compa
 	return perform_merge_join<MergeJoinInner, ScalarMergeInfo, ScalarMergeInfo>(left, right, comparison_type);
 }
 
-index_t MergeJoinMark::Perform(MergeInfo &l, MergeInfo &r, ExpressionType comparison_type) {
+idx_t MergeJoinMark::Perform(MergeInfo &l, MergeInfo &r, ExpressionType comparison_type) {
 	assert(l.info_type == MergeInfoType::SCALAR_MERGE_INFO && r.info_type == MergeInfoType::CHUNK_MERGE_INFO);
 	auto &left = (ScalarMergeInfo &)l;
 	auto &right = (ChunkMergeInfo &)r;

--- a/src/execution/merge_join/merge_join_inner.cpp
+++ b/src/execution/merge_join/merge_join_inner.cpp
@@ -6,7 +6,7 @@
 using namespace duckdb;
 using namespace std;
 
-template <class T> index_t MergeJoinInner::Equality::Operation(ScalarMergeInfo &l, ScalarMergeInfo &r) {
+template <class T> idx_t MergeJoinInner::Equality::Operation(ScalarMergeInfo &l, ScalarMergeInfo &r) {
 	throw NotImplementedException("Merge Join with Equality not implemented");
 	// if (l.pos >= l.count) {
 	// 	return 0;
@@ -14,7 +14,7 @@ template <class T> index_t MergeJoinInner::Equality::Operation(ScalarMergeInfo &
 	// assert(l.sel_vector && r.sel_vector);
 	// auto ldata = (T *)l.v.data;
 	// auto rdata = (T *)r.v.data;
-	// index_t result_count = 0;
+	// idx_t result_count = 0;
 	// while (true) {
 	// 	if (r.pos == r.count || duckdb::LessThan::Operation(ldata[l.sel_vector[l.pos]], rdata[r.sel_vector[r.pos]])) {
 	// 		// left side smaller: move left pointer forward
@@ -49,14 +49,14 @@ template <class T> index_t MergeJoinInner::Equality::Operation(ScalarMergeInfo &
 	// return result_count;
 }
 
-template <class T> index_t MergeJoinInner::LessThan::Operation(ScalarMergeInfo &l, ScalarMergeInfo &r) {
+template <class T> idx_t MergeJoinInner::LessThan::Operation(ScalarMergeInfo &l, ScalarMergeInfo &r) {
 	if (r.pos >= r.count) {
 		return 0;
 	}
 	assert(l.sel_vector && r.sel_vector);
 	auto ldata = (T *)l.v.GetData();
 	auto rdata = (T *)r.v.GetData();
-	index_t result_count = 0;
+	idx_t result_count = 0;
 	while (true) {
 		if (l.pos < l.count && duckdb::LessThan::Operation(ldata[l.sel_vector[l.pos]], rdata[r.sel_vector[r.pos]])) {
 			// left side smaller: found match
@@ -82,14 +82,14 @@ template <class T> index_t MergeJoinInner::LessThan::Operation(ScalarMergeInfo &
 	return result_count;
 }
 
-template <class T> index_t MergeJoinInner::LessThanEquals::Operation(ScalarMergeInfo &l, ScalarMergeInfo &r) {
+template <class T> idx_t MergeJoinInner::LessThanEquals::Operation(ScalarMergeInfo &l, ScalarMergeInfo &r) {
 	if (r.pos >= r.count) {
 		return 0;
 	}
 	assert(l.sel_vector && r.sel_vector);
 	auto ldata = (T *)l.v.GetData();
 	auto rdata = (T *)r.v.GetData();
-	index_t result_count = 0;
+	idx_t result_count = 0;
 	while (true) {
 		if (l.pos < l.count &&
 		    duckdb::LessThanEquals::Operation(ldata[l.sel_vector[l.pos]], rdata[r.sel_vector[r.pos]])) {

--- a/src/execution/merge_join/merge_join_mark.cpp
+++ b/src/execution/merge_join/merge_join_mark.cpp
@@ -6,15 +6,15 @@
 using namespace duckdb;
 using namespace std;
 
-template <class T> index_t MergeJoinMark::Equality::Operation(ScalarMergeInfo &l, ChunkMergeInfo &r) {
+template <class T> idx_t MergeJoinMark::Equality::Operation(ScalarMergeInfo &l, ChunkMergeInfo &r) {
 	throw NotImplementedException("Merge Join with Equality not implemented");
 }
 
-template <class T, class OP> static index_t merge_join_mark_gt(ScalarMergeInfo &l, ChunkMergeInfo &r) {
+template <class T, class OP> static idx_t merge_join_mark_gt(ScalarMergeInfo &l, ChunkMergeInfo &r) {
 	assert(l.sel_vector);
 	auto ldata = (T *)l.v.GetData();
 	l.pos = l.count;
-	for (index_t chunk_idx = 0; chunk_idx < r.order_info.size(); chunk_idx++) {
+	for (idx_t chunk_idx = 0; chunk_idx < r.order_info.size(); chunk_idx++) {
 		// we only care about the SMALLEST value in each of the RHS
 		// because we want to figure out if they are greater than [or equal] to ANY value
 		// get the smallest value from the RHS
@@ -41,19 +41,19 @@ template <class T, class OP> static index_t merge_join_mark_gt(ScalarMergeInfo &
 	}
 	return 0;
 }
-template <class T> index_t MergeJoinMark::GreaterThan::Operation(ScalarMergeInfo &l, ChunkMergeInfo &r) {
+template <class T> idx_t MergeJoinMark::GreaterThan::Operation(ScalarMergeInfo &l, ChunkMergeInfo &r) {
 	return merge_join_mark_gt<T, duckdb::GreaterThan>(l, r);
 }
 
-template <class T> index_t MergeJoinMark::GreaterThanEquals::Operation(ScalarMergeInfo &l, ChunkMergeInfo &r) {
+template <class T> idx_t MergeJoinMark::GreaterThanEquals::Operation(ScalarMergeInfo &l, ChunkMergeInfo &r) {
 	return merge_join_mark_gt<T, duckdb::GreaterThanEquals>(l, r);
 }
 
-template <class T, class OP> static index_t merge_join_mark_lt(ScalarMergeInfo &l, ChunkMergeInfo &r) {
+template <class T, class OP> static idx_t merge_join_mark_lt(ScalarMergeInfo &l, ChunkMergeInfo &r) {
 	assert(l.sel_vector);
 	auto ldata = (T *)l.v.GetData();
 	l.pos = 0;
-	for (index_t chunk_idx = 0; chunk_idx < r.order_info.size(); chunk_idx++) {
+	for (idx_t chunk_idx = 0; chunk_idx < r.order_info.size(); chunk_idx++) {
 		// we only care about the BIGGEST value in each of the RHS
 		// because we want to figure out if they are less than [or equal] to ANY value
 		// get the biggest value from the RHS
@@ -81,11 +81,11 @@ template <class T, class OP> static index_t merge_join_mark_lt(ScalarMergeInfo &
 	return 0;
 }
 
-template <class T> index_t MergeJoinMark::LessThan::Operation(ScalarMergeInfo &l, ChunkMergeInfo &r) {
+template <class T> idx_t MergeJoinMark::LessThan::Operation(ScalarMergeInfo &l, ChunkMergeInfo &r) {
 	return merge_join_mark_lt<T, duckdb::LessThan>(l, r);
 }
 
-template <class T> index_t MergeJoinMark::LessThanEquals::Operation(ScalarMergeInfo &l, ChunkMergeInfo &r) {
+template <class T> idx_t MergeJoinMark::LessThanEquals::Operation(ScalarMergeInfo &l, ChunkMergeInfo &r) {
 	return merge_join_mark_lt<T, duckdb::LessThanEquals>(l, r);
 }
 

--- a/src/execution/nested_loop_join/nested_loop_join_inner.cpp
+++ b/src/execution/nested_loop_join/nested_loop_join_inner.cpp
@@ -6,22 +6,22 @@ using namespace std;
 
 struct InitialNestedLoopJoin {
 	template <class T, class OP>
-	static index_t Operation(Vector &left, Vector &right, index_t &lpos, index_t &rpos, sel_t lvector[],
-	                         sel_t rvector[], index_t current_match_count) {
+	static idx_t Operation(Vector &left, Vector &right, idx_t &lpos, idx_t &rpos, sel_t lvector[], sel_t rvector[],
+	                       idx_t current_match_count) {
 		// initialize phase of nested loop join
 		// fill lvector and rvector with matches from the base vectors
 		auto ldata = (T *)left.GetData();
 		auto rdata = (T *)right.GetData();
-		index_t result_count = 0;
+		idx_t result_count = 0;
 		for (; rpos < right.count; rpos++) {
-			index_t right_position = right.sel_vector ? right.sel_vector[rpos] : rpos;
+			idx_t right_position = right.sel_vector ? right.sel_vector[rpos] : rpos;
 			assert(!right.nullmask[right_position]);
 			for (; lpos < left.count; lpos++) {
 				if (result_count == STANDARD_VECTOR_SIZE) {
 					// out of space!
 					return result_count;
 				}
-				index_t left_position = left.sel_vector ? left.sel_vector[lpos] : lpos;
+				idx_t left_position = left.sel_vector ? left.sel_vector[lpos] : lpos;
 				assert(!left.nullmask[left_position]);
 				if (OP::Operation(ldata[left_position], rdata[right_position])) {
 					// emit tuple
@@ -38,16 +38,16 @@ struct InitialNestedLoopJoin {
 
 struct RefineNestedLoopJoin {
 	template <class T, class OP>
-	static index_t Operation(Vector &left, Vector &right, index_t &lpos, index_t &rpos, sel_t lvector[],
-	                         sel_t rvector[], index_t current_match_count) {
+	static idx_t Operation(Vector &left, Vector &right, idx_t &lpos, idx_t &rpos, sel_t lvector[], sel_t rvector[],
+	                       idx_t current_match_count) {
 		// refine phase of the nested loop join
 		// refine lvector and rvector based on matches of subsequent conditions (in case there are multiple conditions
 		// in the join)
 		assert(current_match_count > 0);
 		auto ldata = (T *)left.GetData();
 		auto rdata = (T *)right.GetData();
-		index_t result_count = 0;
-		for (index_t i = 0; i < current_match_count; i++) {
+		idx_t result_count = 0;
+		for (idx_t i = 0; i < current_match_count; i++) {
 			// null values should be filtered out before
 			assert(!left.nullmask[lvector[i]] && !right.nullmask[rvector[i]]);
 			if (OP::Operation(ldata[lvector[i]], rdata[rvector[i]])) {
@@ -61,8 +61,8 @@ struct RefineNestedLoopJoin {
 };
 
 template <class NLTYPE, class OP>
-static index_t nested_loop_join_inner_operator(Vector &left, Vector &right, index_t &lpos, index_t &rpos,
-                                               sel_t lvector[], sel_t rvector[], index_t current_match_count) {
+static idx_t nested_loop_join_inner_operator(Vector &left, Vector &right, idx_t &lpos, idx_t &rpos, sel_t lvector[],
+                                             sel_t rvector[], idx_t current_match_count) {
 	switch (left.type) {
 	case TypeId::BOOL:
 	case TypeId::INT8:
@@ -86,8 +86,8 @@ static index_t nested_loop_join_inner_operator(Vector &left, Vector &right, inde
 }
 
 template <class NLTYPE>
-index_t nested_loop_join_inner(Vector &left, Vector &right, index_t &lpos, index_t &rpos, sel_t lvector[],
-                               sel_t rvector[], index_t current_match_count, ExpressionType comparison_type) {
+idx_t nested_loop_join_inner(Vector &left, Vector &right, idx_t &lpos, idx_t &rpos, sel_t lvector[], sel_t rvector[],
+                             idx_t current_match_count, ExpressionType comparison_type) {
 	assert(left.type == right.type);
 	switch (comparison_type) {
 	case ExpressionType::COMPARE_EQUAL:
@@ -113,19 +113,18 @@ index_t nested_loop_join_inner(Vector &left, Vector &right, index_t &lpos, index
 	}
 }
 
-index_t NestedLoopJoinInner::Perform(index_t &lpos, index_t &rpos, DataChunk &left_conditions,
-                                     DataChunk &right_conditions, sel_t lvector[], sel_t rvector[],
-                                     vector<JoinCondition> &conditions) {
+idx_t NestedLoopJoinInner::Perform(idx_t &lpos, idx_t &rpos, DataChunk &left_conditions, DataChunk &right_conditions,
+                                   sel_t lvector[], sel_t rvector[], vector<JoinCondition> &conditions) {
 	assert(left_conditions.column_count == right_conditions.column_count);
 	if (lpos >= left_conditions.size() || rpos >= right_conditions.size()) {
 		return 0;
 	}
 	// for the first condition, lvector and rvector are not set yet
 	// we initialize them using the InitialNestedLoopJoin
-	index_t match_count = nested_loop_join_inner<InitialNestedLoopJoin>(
+	idx_t match_count = nested_loop_join_inner<InitialNestedLoopJoin>(
 	    left_conditions.data[0], right_conditions.data[0], lpos, rpos, lvector, rvector, 0, conditions[0].comparison);
 	// now resolve the rest of the conditions
-	for (index_t i = 1; i < conditions.size(); i++) {
+	for (idx_t i = 1; i < conditions.size(); i++) {
 		// check if we have run out of tuples to compare
 		if (match_count == 0) {
 			return 0;

--- a/src/execution/nested_loop_join/nested_loop_join_mark.cpp
+++ b/src/execution/nested_loop_join/nested_loop_join_mark.cpp
@@ -8,8 +8,8 @@ using namespace std;
 template <class T, class OP> static void mark_join_templated(Vector &left, Vector &right, bool found_match[]) {
 	auto ldata = (T *)left.GetData();
 	auto rdata = (T *)right.GetData();
-	VectorOperations::Exec(left, [&](index_t left_position, index_t k) {
-		VectorOperations::Exec(right, [&](index_t right_position, index_t k) {
+	VectorOperations::Exec(left, [&](idx_t left_position, idx_t k) {
+		VectorOperations::Exec(right, [&](idx_t right_position, idx_t k) {
 			if (OP::Operation(ldata[left_position], rdata[right_position])) {
 				found_match[left_position] = true;
 			}
@@ -63,9 +63,9 @@ void NestedLoopJoinMark::Perform(DataChunk &left, ChunkCollection &right, bool f
                                  vector<JoinCondition> &conditions) {
 	// initialize a new temporary selection vector for the left chunk
 	// loop over all chunks in the RHS
-	for (index_t chunk_idx = 0; chunk_idx < right.chunks.size(); chunk_idx++) {
+	for (idx_t chunk_idx = 0; chunk_idx < right.chunks.size(); chunk_idx++) {
 		DataChunk &right_chunk = *right.chunks[chunk_idx];
-		for (index_t i = 0; i < conditions.size(); i++) {
+		for (idx_t i = 0; i < conditions.size(); i++) {
 			mark_join(left.data[i], right_chunk.data[i], found_match, conditions[i].comparison);
 		}
 	}

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -18,8 +18,8 @@ public:
 	//! Materialized aggregates
 	DataChunk aggregate_chunk;
 	//! The current position to scan the HT for output tuples
-	index_t ht_scan_position;
-	index_t tuples_scanned;
+	idx_t ht_scan_position;
+	idx_t tuples_scanned;
 	//! The HT
 	unique_ptr<SuperLargeHashTable> ht;
 	//! The payload chunk, only used while filling the HT
@@ -69,11 +69,11 @@ void PhysicalHashAggregate::GetChunkInternal(ClientContext &context, DataChunk &
 		state->payload_executor.SetChunk(state->child_chunk);
 
 		payload_chunk.Reset();
-		index_t payload_idx = 0, payload_expr_idx = 0;
-		for (index_t i = 0; i < aggregates.size(); i++) {
+		idx_t payload_idx = 0, payload_expr_idx = 0;
+		for (idx_t i = 0; i < aggregates.size(); i++) {
 			auto &aggr = (BoundAggregateExpression &)*aggregates[i];
 			if (aggr.children.size()) {
-				for (index_t j = 0; j < aggr.children.size(); ++j) {
+				for (idx_t j = 0; j < aggr.children.size(); ++j) {
 					state->payload_executor.ExecuteExpression(payload_expr_idx, payload_chunk.data[payload_idx]);
 					++payload_idx;
 					++payload_expr_idx;
@@ -100,14 +100,14 @@ void PhysicalHashAggregate::GetChunkInternal(ClientContext &context, DataChunk &
 
 	state->group_chunk.Reset();
 	state->aggregate_chunk.Reset();
-	index_t elements_found = state->ht->Scan(state->ht_scan_position, state->group_chunk, state->aggregate_chunk);
+	idx_t elements_found = state->ht->Scan(state->ht_scan_position, state->group_chunk, state->aggregate_chunk);
 
 	// special case hack to sort out aggregating from empty intermediates
 	// for aggregations without groups
 	if (elements_found == 0 && state->tuples_scanned == 0 && is_implicit_aggr) {
 		assert(state->aggregate_chunk.column_count == aggregates.size());
 		// for each column in the aggregates, set to initial state
-		for (index_t i = 0; i < state->aggregate_chunk.column_count; i++) {
+		for (idx_t i = 0; i < state->aggregate_chunk.column_count; i++) {
 			assert(aggregates[i]->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
 			auto &aggr = (BoundAggregateExpression &)*aggregates[i];
 			auto aggr_state = unique_ptr<data_t[]>(new data_t[aggr.function.state_size(aggr.return_type)]);
@@ -125,16 +125,16 @@ void PhysicalHashAggregate::GetChunkInternal(ClientContext &context, DataChunk &
 	}
 	// we finished the child chunk
 	// actually compute the final projection list now
-	index_t chunk_index = 0;
+	idx_t chunk_index = 0;
 	if (state->group_chunk.column_count + state->aggregate_chunk.column_count == chunk.column_count) {
-		for (index_t col_idx = 0; col_idx < state->group_chunk.column_count; col_idx++) {
+		for (idx_t col_idx = 0; col_idx < state->group_chunk.column_count; col_idx++) {
 			chunk.data[chunk_index++].Reference(state->group_chunk.data[col_idx]);
 		}
 	} else {
 		assert(state->aggregate_chunk.column_count == chunk.column_count);
 	}
 
-	for (index_t col_idx = 0; col_idx < state->aggregate_chunk.column_count; col_idx++) {
+	for (idx_t col_idx = 0; col_idx < state->aggregate_chunk.column_count; col_idx++) {
 		chunk.data[chunk_index++].Reference(state->aggregate_chunk.data[col_idx]);
 	}
 }
@@ -153,7 +153,7 @@ unique_ptr<PhysicalOperatorState> PhysicalHashAggregate::GetOperatorState() {
 		auto &aggr = (BoundAggregateExpression &)*expr;
 		aggregate_kind.push_back(&aggr);
 		if (aggr.children.size()) {
-			for (index_t i = 0; i < aggr.children.size(); ++i) {
+			for (idx_t i = 0; i < aggr.children.size(); ++i) {
 				payload_types.push_back(aggr.children[i]->return_type);
 				state->payload_executor.AddExpression(*aggr.children[i]);
 			}

--- a/src/execution/operator/aggregate/physical_simple_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_simple_aggregate.cpp
@@ -35,16 +35,16 @@ void PhysicalSimpleAggregate::GetChunkInternal(ClientContext &context, DataChunk
 		}
 
 		// now resolve the aggregates for each of the children
-		index_t payload_idx = 0, payload_expr_idx = 0;
+		idx_t payload_idx = 0, payload_expr_idx = 0;
 		DataChunk &payload_chunk = state->payload_chunk;
 		payload_chunk.Reset();
 		state->child_executor.SetChunk(state->child_chunk);
-		for (index_t aggr_idx = 0; aggr_idx < aggregates.size(); aggr_idx++) {
+		for (idx_t aggr_idx = 0; aggr_idx < aggregates.size(); aggr_idx++) {
 			auto &aggregate = (BoundAggregateExpression &)*aggregates[aggr_idx];
-			index_t payload_cnt = 0;
+			idx_t payload_cnt = 0;
 			// resolve the child expression of the aggregate (if any)
 			if (aggregate.children.size() > 0) {
-				for (index_t i = 0; i < aggregate.children.size(); ++i) {
+				for (idx_t i = 0; i < aggregate.children.size(); ++i) {
 					state->child_executor.ExecuteExpression(payload_expr_idx,
 					                                        payload_chunk.data[payload_idx + payload_cnt]);
 					payload_expr_idx++;
@@ -61,7 +61,7 @@ void PhysicalSimpleAggregate::GetChunkInternal(ClientContext &context, DataChunk
 		}
 	}
 	// initialize the result chunk with the aggregate values
-	for (index_t aggr_idx = 0; aggr_idx < aggregates.size(); aggr_idx++) {
+	for (idx_t aggr_idx = 0; aggr_idx < aggregates.size(); aggr_idx++) {
 		auto &aggregate = (BoundAggregateExpression &)*aggregates[aggr_idx];
 
 		Vector state_vector(Value::POINTER((uintptr_t)state->aggregates[aggr_idx].get()));
@@ -83,7 +83,7 @@ PhysicalSimpleAggregateOperatorState::PhysicalSimpleAggregateOperatorState(Physi
 		auto &aggr = (BoundAggregateExpression &)*aggregate;
 		// initialize the payload chunk
 		if (aggr.children.size()) {
-			for (index_t i = 0; i < aggr.children.size(); ++i) {
+			for (idx_t i = 0; i < aggr.children.size(); ++i) {
 				payload_types.push_back(aggr.children[i]->return_type);
 				child_executor.AddExpression(*aggr.children[i]);
 			}

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -18,7 +18,7 @@ public:
 	PhysicalWindowOperatorState(PhysicalOperator *child) : PhysicalOperatorState(child), position(0) {
 	}
 
-	index_t position;
+	idx_t position;
 	ChunkCollection tuples;
 	ChunkCollection window_results;
 };
@@ -29,9 +29,9 @@ PhysicalWindow::PhysicalWindow(LogicalOperator &op, vector<unique_ptr<Expression
     : PhysicalOperator(type, op.types), select_list(std::move(select_list)) {
 }
 
-static bool EqualsSubset(vector<Value> &a, vector<Value> &b, index_t start, index_t end) {
+static bool EqualsSubset(vector<Value> &a, vector<Value> &b, idx_t start, idx_t end) {
 	assert(start <= end);
-	for (index_t i = start; i < end; i++) {
+	for (idx_t i = start; i < end; i++) {
 		if (a[i] != b[i]) {
 			return false;
 		}
@@ -39,15 +39,14 @@ static bool EqualsSubset(vector<Value> &a, vector<Value> &b, index_t start, inde
 	return true;
 }
 
-static index_t BinarySearchRightmost(ChunkCollection &input, vector<Value> row, index_t l, index_t r,
-                                     index_t comp_cols) {
+static idx_t BinarySearchRightmost(ChunkCollection &input, vector<Value> row, idx_t l, idx_t r, idx_t comp_cols) {
 	if (comp_cols == 0) {
 		return r - 1;
 	}
 	while (l < r) {
-		index_t m = floor((l + r) / 2);
+		idx_t m = floor((l + r) / 2);
 		bool less_than_equals = true;
-		for (index_t i = 0; i < comp_cols; i++) {
+		for (idx_t i = 0; i < comp_cols; i++) {
 			if (input.GetRow(m)[i] > row[i]) {
 				less_than_equals = false;
 				break;
@@ -62,20 +61,20 @@ static index_t BinarySearchRightmost(ChunkCollection &input, vector<Value> row, 
 	return l - 1;
 }
 
-static void MaterializeExpressions(ClientContext &context, Expression **exprs, index_t expr_count,
-                                   ChunkCollection &input, ChunkCollection &output, bool scalar = false) {
+static void MaterializeExpressions(ClientContext &context, Expression **exprs, idx_t expr_count, ChunkCollection &input,
+                                   ChunkCollection &output, bool scalar = false) {
 	if (expr_count == 0) {
 		return;
 	}
 
 	vector<TypeId> types;
 	ExpressionExecutor executor;
-	for (index_t expr_idx = 0; expr_idx < expr_count; ++expr_idx) {
+	for (idx_t expr_idx = 0; expr_idx < expr_count; ++expr_idx) {
 		types.push_back(exprs[expr_idx]->return_type);
 		executor.AddExpression(*exprs[expr_idx]);
 	}
 
-	for (index_t i = 0; i < input.chunks.size(); i++) {
+	for (idx_t i = 0; i < input.chunks.size(); i++) {
 		DataChunk chunk;
 		chunk.Initialize(types);
 
@@ -102,14 +101,14 @@ static void SortCollectionForWindow(ClientContext &context, BoundWindowExpressio
 	ExpressionExecutor executor;
 
 	// we sort by both 1) partition by expression list and 2) order by expressions
-	for (index_t prt_idx = 0; prt_idx < wexpr->partitions.size(); prt_idx++) {
+	for (idx_t prt_idx = 0; prt_idx < wexpr->partitions.size(); prt_idx++) {
 		auto &pexpr = wexpr->partitions[prt_idx];
 		sort_types.push_back(pexpr->return_type);
 		orders.push_back(OrderType::ASCENDING);
 		executor.AddExpression(*pexpr);
 	}
 
-	for (index_t ord_idx = 0; ord_idx < wexpr->orders.size(); ord_idx++) {
+	for (idx_t ord_idx = 0; ord_idx < wexpr->orders.size(); ord_idx++) {
 		auto &oexpr = wexpr->orders[ord_idx].expression;
 		sort_types.push_back(oexpr->return_type);
 		orders.push_back(wexpr->orders[ord_idx].type);
@@ -119,7 +118,7 @@ static void SortCollectionForWindow(ClientContext &context, BoundWindowExpressio
 	assert(sort_types.size() > 0);
 
 	// create a chunkcollection for the results of the expressions in the window definitions
-	for (index_t i = 0; i < input.chunks.size(); i++) {
+	for (idx_t i = 0; i < input.chunks.size(); i++) {
 		DataChunk sort_chunk;
 		sort_chunk.Initialize(sort_types);
 
@@ -131,7 +130,7 @@ static void SortCollectionForWindow(ClientContext &context, BoundWindowExpressio
 
 	assert(input.count == sort_collection.count);
 
-	auto sorted_vector = unique_ptr<index_t[]>(new index_t[input.count]);
+	auto sorted_vector = unique_ptr<idx_t[]>(new idx_t[input.count]);
 	sort_collection.Sort(orders, sorted_vector.get());
 
 	input.Reorder(sorted_vector.get());
@@ -140,10 +139,10 @@ static void SortCollectionForWindow(ClientContext &context, BoundWindowExpressio
 }
 
 struct WindowBoundariesState {
-	index_t partition_start = 0;
-	index_t partition_end = 0;
-	index_t peer_start = 0;
-	index_t peer_end = 0;
+	idx_t partition_start = 0;
+	idx_t partition_end = 0;
+	idx_t peer_start = 0;
+	idx_t peer_end = 0;
 	int64_t window_start = -1;
 	int64_t window_end = -1;
 	bool is_same_partition = false;
@@ -156,13 +155,13 @@ static bool WindowNeedsRank(BoundWindowExpression *wexpr) {
 	       wexpr->type == ExpressionType::WINDOW_RANK_DENSE || wexpr->type == ExpressionType::WINDOW_CUME_DIST;
 }
 
-static void UpdateWindowBoundaries(BoundWindowExpression *wexpr, ChunkCollection &input, index_t input_size,
-                                   index_t row_idx, ChunkCollection &boundary_start_collection,
+static void UpdateWindowBoundaries(BoundWindowExpression *wexpr, ChunkCollection &input, idx_t input_size,
+                                   idx_t row_idx, ChunkCollection &boundary_start_collection,
                                    ChunkCollection &boundary_end_collection, WindowBoundariesState &bounds) {
 
 	if (input.column_count() > 0) {
 		vector<Value> row_cur = input.GetRow(row_idx);
-		index_t sort_col_count = wexpr->partitions.size() + wexpr->orders.size();
+		idx_t sort_col_count = wexpr->partitions.size() + wexpr->orders.size();
 
 		// determine partition and peer group boundaries to ultimately figure out window size
 		bounds.is_same_partition = EqualsSubset(bounds.row_prev, row_cur, 0, wexpr->partitions.size());
@@ -264,7 +263,7 @@ static void UpdateWindowBoundaries(BoundWindowExpression *wexpr, ChunkCollection
 	if (bounds.window_start < (int64_t)bounds.partition_start) {
 		bounds.window_start = bounds.partition_start;
 	}
-	if ((index_t)bounds.window_end > bounds.partition_end) {
+	if ((idx_t)bounds.window_end > bounds.partition_end) {
 		bounds.window_end = bounds.partition_end;
 	}
 
@@ -274,7 +273,7 @@ static void UpdateWindowBoundaries(BoundWindowExpression *wexpr, ChunkCollection
 }
 
 static void ComputeWindowExpression(ClientContext &context, BoundWindowExpression *wexpr, ChunkCollection &input,
-                                    ChunkCollection &output, index_t output_idx) {
+                                    ChunkCollection &output, idx_t output_idx) {
 
 	ChunkCollection sort_collection;
 	bool needs_sorting = wexpr->partitions.size() + wexpr->orders.size() > 0;
@@ -334,7 +333,7 @@ static void ComputeWindowExpression(ClientContext &context, BoundWindowExpressio
 	}
 
 	// this is the main loop, go through all sorted rows and compute window function result
-	for (index_t row_idx = 0; row_idx < input.count; row_idx++) {
+	for (idx_t row_idx = 0; row_idx < input.count; row_idx++) {
 		// special case, OVER (), aggregate over everything
 		UpdateWindowBoundaries(wexpr, sort_collection, input.count, row_idx, boundary_start_collection,
 		                       boundary_end_collection, bounds);
@@ -402,7 +401,7 @@ static void ComputeWindowExpression(ClientContext &context, BoundWindowExpressio
 
 				assert((n_large * (n_size + 1) + (n_param - n_large) * n_size) == n_total);
 
-				if (row_idx < (index_t)i_small) {
+				if (row_idx < (idx_t)i_small) {
 					res = Value::Numeric(wexpr->return_type, 1 + row_idx / (n_size + 1));
 				} else {
 					res = Value::Numeric(wexpr->return_type, 1 + n_large + (row_idx - i_small) / n_size);
@@ -413,7 +412,7 @@ static void ComputeWindowExpression(ClientContext &context, BoundWindowExpressio
 		case ExpressionType::WINDOW_LEAD:
 		case ExpressionType::WINDOW_LAG: {
 			Value def_val = Value(wexpr->return_type);
-			index_t offset = 1;
+			idx_t offset = 1;
 			if (wexpr->offset_expr) {
 				offset = leadlag_offset_collection.GetValue(0, wexpr->offset_expr->IsScalar() ? 0 : row_idx)
 				             .GetValue<int64_t>();
@@ -430,7 +429,7 @@ static void ComputeWindowExpression(ClientContext &context, BoundWindowExpressio
 				}
 			} else {
 				int64_t lag_idx = (int64_t)row_idx - offset;
-				if (lag_idx >= 0 && (index_t)lag_idx >= bounds.partition_start) {
+				if (lag_idx >= 0 && (idx_t)lag_idx >= bounds.partition_start) {
 					res = payload_collection.GetValue(0, lag_idx);
 				} else {
 					res = def_val;
@@ -472,14 +471,14 @@ void PhysicalWindow::GetChunkInternal(ClientContext &context, DataChunk &chunk, 
 		}
 
 		vector<TypeId> window_types;
-		for (index_t expr_idx = 0; expr_idx < select_list.size(); expr_idx++) {
+		for (idx_t expr_idx = 0; expr_idx < select_list.size(); expr_idx++) {
 			window_types.push_back(select_list[expr_idx]->return_type);
 		}
 
-		for (index_t i = 0; i < big_data.chunks.size(); i++) {
+		for (idx_t i = 0; i < big_data.chunks.size(); i++) {
 			DataChunk window_chunk;
 			window_chunk.Initialize(window_types);
-			for (index_t col_idx = 0; col_idx < window_chunk.column_count; col_idx++) {
+			for (idx_t col_idx = 0; col_idx < window_chunk.column_count; col_idx++) {
 				window_chunk.data[col_idx].count = big_data.chunks[i]->size();
 				VectorOperations::Set(window_chunk.data[col_idx], Value());
 			}
@@ -488,9 +487,9 @@ void PhysicalWindow::GetChunkInternal(ClientContext &context, DataChunk &chunk, 
 		}
 
 		assert(window_results.column_count() == select_list.size());
-		index_t window_output_idx = 0;
+		idx_t window_output_idx = 0;
 		// we can have multiple window functions
-		for (index_t expr_idx = 0; expr_idx < select_list.size(); expr_idx++) {
+		for (idx_t expr_idx = 0; expr_idx < select_list.size(); expr_idx++) {
 			assert(select_list[expr_idx]->GetExpressionClass() == ExpressionClass::BOUND_WINDOW);
 			// sort by partition and order clause in window def
 			auto wexpr = reinterpret_cast<BoundWindowExpression *>(select_list[expr_idx].get());
@@ -506,11 +505,11 @@ void PhysicalWindow::GetChunkInternal(ClientContext &context, DataChunk &chunk, 
 	auto &proj_ch = big_data.GetChunk(state->position);
 	auto &wind_ch = window_results.GetChunk(state->position);
 
-	index_t out_idx = 0;
-	for (index_t col_idx = 0; col_idx < proj_ch.column_count; col_idx++) {
+	idx_t out_idx = 0;
+	for (idx_t col_idx = 0; col_idx < proj_ch.column_count; col_idx++) {
 		chunk.data[out_idx++].Reference(proj_ch.data[col_idx]);
 	}
-	for (index_t col_idx = 0; col_idx < wind_ch.column_count; col_idx++) {
+	for (idx_t col_idx = 0; col_idx < wind_ch.column_count; col_idx++) {
 		chunk.data[out_idx++].Reference(wind_ch.data[col_idx]);
 	}
 	state->position += STANDARD_VECTOR_SIZE;

--- a/src/execution/operator/filter/physical_filter.cpp
+++ b/src/execution/operator/filter/physical_filter.cpp
@@ -30,8 +30,8 @@ PhysicalFilter::PhysicalFilter(vector<TypeId> types, vector<unique_ptr<Expressio
 
 void PhysicalFilter::GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state_) {
 	auto state = reinterpret_cast<PhysicalFilterState *>(state_);
-	index_t initial_count;
-	index_t result_count;
+	idx_t initial_count;
+	idx_t result_count;
 	do {
 		// fetch a chunk from the child and run the filter
 		// we repeat this process until either (1) passing tuples are found, or (2) the child is completely exhausted
@@ -47,7 +47,7 @@ void PhysicalFilter::GetChunkInternal(ClientContext &context, DataChunk &chunk, 
 		// nothing was filtered: skip adding any selection vectors
 		return;
 	}
-	for (index_t i = 0; i < chunk.column_count; i++) {
+	for (idx_t i = 0; i < chunk.column_count; i++) {
 		chunk.data[i].count = result_count;
 		chunk.data[i].sel_vector = chunk.owned_sel_vector;
 	}

--- a/src/execution/operator/helper/physical_limit.cpp
+++ b/src/execution/operator/helper/physical_limit.cpp
@@ -5,17 +5,17 @@ using namespace std;
 
 class PhysicalLimitOperatorState : public PhysicalOperatorState {
 public:
-	PhysicalLimitOperatorState(PhysicalOperator *child, index_t current_offset = 0)
+	PhysicalLimitOperatorState(PhysicalOperator *child, idx_t current_offset = 0)
 	    : PhysicalOperatorState(child), current_offset(current_offset) {
 	}
 
-	index_t current_offset;
+	idx_t current_offset;
 };
 
 void PhysicalLimit::GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state_) {
 	auto state = reinterpret_cast<PhysicalLimitOperatorState *>(state_);
 
-	index_t max_element = limit + offset;
+	idx_t max_element = limit + offset;
 	if (state->current_offset >= max_element) {
 		return;
 	}
@@ -31,17 +31,17 @@ void PhysicalLimit::GetChunkInternal(ClientContext &context, DataChunk &chunk, P
 		if (state->current_offset + state->child_chunk.size() >= offset) {
 			// however we will reach it in this chunk
 			// we have to copy part of the chunk with an offset
-			index_t start_position = offset - state->current_offset;
-			index_t chunk_count = min(limit, state->child_chunk.size() - start_position);
+			idx_t start_position = offset - state->current_offset;
+			idx_t chunk_count = min(limit, state->child_chunk.size() - start_position);
 
 			// first reference all the columns and set up the counts
-			for (index_t i = 0; i < chunk.column_count; i++) {
+			for (idx_t i = 0; i < chunk.column_count; i++) {
 				chunk.data[i].Reference(state->child_chunk.data[i]);
 				chunk.data[i].sel_vector = chunk.owned_sel_vector;
 				chunk.data[i].count = chunk_count;
 			}
 			// now set up the selection vector of the chunk
-			for (index_t idx = 0; idx < chunk_count; idx++) {
+			for (idx_t idx = 0; idx < chunk_count; idx++) {
 				chunk.owned_sel_vector[idx] = state->child_chunk.sel_vector
 				                                  ? state->child_chunk.sel_vector[start_position + idx]
 				                                  : start_position + idx;
@@ -50,7 +50,7 @@ void PhysicalLimit::GetChunkInternal(ClientContext &context, DataChunk &chunk, P
 		}
 	} else {
 		// have to copy either the entire chunk or part of it
-		index_t chunk_count;
+		idx_t chunk_count;
 		if (state->current_offset + state->child_chunk.size() >= max_element) {
 			// have to limit the count of the chunk
 			chunk_count = max_element - state->current_offset;
@@ -59,7 +59,7 @@ void PhysicalLimit::GetChunkInternal(ClientContext &context, DataChunk &chunk, P
 			chunk_count = state->child_chunk.size();
 		}
 		// instead of copying we just change the pointer in the current chunk
-		for (index_t i = 0; i < chunk.column_count; i++) {
+		for (idx_t i = 0; i < chunk.column_count; i++) {
 			chunk.data[i].Reference(state->child_chunk.data[i]);
 			chunk.data[i].count = chunk_count;
 		}

--- a/src/execution/operator/helper/physical_pragma.cpp
+++ b/src/execution/operator/helper/physical_pragma.cpp
@@ -11,7 +11,7 @@
 using namespace duckdb;
 using namespace std;
 
-static index_t ParseMemoryLimit(string arg);
+static idx_t ParseMemoryLimit(string arg);
 
 void PhysicalPragma::GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state) {
 	auto &pragma = *info;
@@ -55,7 +55,7 @@ void PhysicalPragma::GetChunkInternal(ClientContext &context, DataChunk &chunk, 
 			throw ParserException("Memory limit must be an assignment (e.g. PRAGMA memory_limit='1GB')");
 		}
 		if (pragma.parameters[0].type == TypeId::VARCHAR) {
-			index_t new_limit = ParseMemoryLimit(pragma.parameters[0].str_value);
+			idx_t new_limit = ParseMemoryLimit(pragma.parameters[0].str_value);
 			// set the new limit in the buffer manager
 			context.db.storage->buffer_manager->SetLimit(new_limit);
 		} else {
@@ -73,13 +73,13 @@ void PhysicalPragma::GetChunkInternal(ClientContext &context, DataChunk &chunk, 
 	}
 }
 
-index_t ParseMemoryLimit(string arg) {
+idx_t ParseMemoryLimit(string arg) {
 	// split based on the number/non-number
-	index_t idx = 0;
+	idx_t idx = 0;
 	while (std::isspace(arg[idx])) {
 		idx++;
 	}
-	index_t num_start = idx;
+	idx_t num_start = idx;
 	while ((arg[idx] >= '0' && arg[idx] <= '9') || arg[idx] == '.' || arg[idx] == 'e' || arg[idx] == 'E' ||
 	       arg[idx] == '-') {
 		idx++;
@@ -96,16 +96,16 @@ index_t ParseMemoryLimit(string arg) {
 	while (std::isspace(arg[idx])) {
 		idx++;
 	}
-	index_t start = idx;
+	idx_t start = idx;
 	while (idx < arg.size() && !std::isspace(arg[idx])) {
 		idx++;
 	}
 	if (limit < 0) {
 		// limit < 0, set limit to infinite
-		return (index_t)-1;
+		return (idx_t)-1;
 	}
 	string unit = StringUtil::Lower(arg.substr(start, idx - start));
-	index_t multiplier;
+	idx_t multiplier;
 	if (unit == "byte" || unit == "bytes" || unit == "b") {
 		multiplier = 1;
 	} else if (unit == "kilobyte" || unit == "kilobytes" || unit == "kb" || unit == "k") {
@@ -119,5 +119,5 @@ index_t ParseMemoryLimit(string arg) {
 	} else {
 		throw ParserException("Unknown unit for memory_limit: %s (expected: b, mb, gb or tb)", unit.c_str());
 	}
-	return (index_t)multiplier * limit;
+	return (idx_t)multiplier * limit;
 }

--- a/src/execution/operator/helper/physical_prune_columns.cpp
+++ b/src/execution/operator/helper/physical_prune_columns.cpp
@@ -13,7 +13,7 @@ void PhysicalPruneColumns::GetChunkInternal(ClientContext &context, DataChunk &c
 		return;
 	}
 	assert(column_limit <= state->child_chunk.column_count);
-	for (index_t i = 0; i < column_limit; i++) {
+	for (idx_t i = 0; i < column_limit; i++) {
 		chunk.data[i].Reference(state->child_chunk.data[i]);
 	}
 	chunk.sel_vector = state->child_chunk.sel_vector;

--- a/src/execution/operator/join/physical_blockwise_nl_join.cpp
+++ b/src/execution/operator/join/physical_blockwise_nl_join.cpp
@@ -19,8 +19,8 @@ public:
 	//! Whether or not a tuple on the RHS has found a match, only used for FULL OUTER joins
 	unique_ptr<bool[]> rhs_found_match;
 	ChunkCollection right_chunks;
-	index_t left_position;
-	index_t right_position;
+	idx_t left_position;
+	idx_t right_position;
 	bool fill_in_rhs;
 	bool checked_found_match;
 	ExpressionExecutor executor;
@@ -83,14 +83,14 @@ void PhysicalBlockwiseNLJoin::GetChunkInternal(ClientContext &context, DataChunk
 			return;
 		}
 		// fill in the data from the chunk
-		for (index_t i = 0; i < state->child_chunk.column_count; i++) {
+		for (idx_t i = 0; i < state->child_chunk.column_count; i++) {
 			chunk.data[i].Reference(state->child_chunk.data[i]);
 		}
 		if (type == JoinType::LEFT || type == JoinType::OUTER) {
 			// LEFT OUTER or FULL OUTER join with empty RHS
 			// fill any columns from the RHS with NULLs
 			chunk.sel_vector = chunk.data[0].sel_vector;
-			for (index_t i = state->child_chunk.column_count; i < chunk.column_count; i++) {
+			for (idx_t i = state->child_chunk.column_count; i < chunk.column_count; i++) {
 				chunk.data[i].count = chunk.size();
 				chunk.data[i].sel_vector = chunk.sel_vector;
 				VectorOperations::Set(chunk.data[i], Value());
@@ -104,7 +104,7 @@ void PhysicalBlockwiseNLJoin::GetChunkInternal(ClientContext &context, DataChunk
 	// every step that we do not have output results we shift the vectors of the RHS one up or down
 	// this creates a new "alignment" between the tuples, exhausting all possible O(n^2) combinations
 	// while allowing us to use vectorized execution for every step
-	index_t result_count = 0;
+	idx_t result_count = 0;
 	do {
 		if (state->fill_in_rhs) {
 			throw NotImplementedException("FIXME: full outer join");
@@ -114,7 +114,7 @@ void PhysicalBlockwiseNLJoin::GetChunkInternal(ClientContext &context, DataChunk
 			if (!state->checked_found_match && state->lhs_found_match) {
 				// LEFT OUTER JOIN or FULL OUTER JOIN, first check if we need to create extra results because of
 				// non-matching tuples
-				for (index_t i = 0; i < state->child_chunk.size(); i++) {
+				for (idx_t i = 0; i < state->child_chunk.size(); i++) {
 					if (!state->lhs_found_match[i]) {
 						chunk.owned_sel_vector[result_count++] = i;
 					}
@@ -123,13 +123,13 @@ void PhysicalBlockwiseNLJoin::GetChunkInternal(ClientContext &context, DataChunk
 					// have to create the chunk, set the selection vector and count
 					chunk.sel_vector = chunk.owned_sel_vector;
 					// for the LHS, reference the child_chunk and set the sel_vector and count
-					for (index_t i = 0; i < state->child_chunk.column_count; i++) {
+					for (idx_t i = 0; i < state->child_chunk.column_count; i++) {
 						chunk.data[i].Reference(state->child_chunk.data[i]);
 						chunk.data[i].sel_vector = chunk.sel_vector;
 						chunk.data[i].count = result_count;
 					}
 					// for the RHS, set the mask to NULL and set the sel_vector and count
-					for (index_t i = state->child_chunk.column_count; i < chunk.column_count; i++) {
+					for (idx_t i = state->child_chunk.column_count; i < chunk.column_count; i++) {
 						chunk.data[i].nullmask.set();
 						chunk.data[i].sel_vector = chunk.sel_vector;
 						chunk.data[i].count = result_count;
@@ -161,13 +161,13 @@ void PhysicalBlockwiseNLJoin::GetChunkInternal(ClientContext &context, DataChunk
 
 		// fill in the current element of the LHS into the chunk
 		assert(chunk.column_count == lchunk.column_count + rchunk.column_count);
-		for (index_t i = 0; i < lchunk.column_count; i++) {
+		for (idx_t i = 0; i < lchunk.column_count; i++) {
 			auto lvalue = lchunk.data[i].GetValue(state->left_position);
 			chunk.data[i].Reference(lvalue);
 			chunk.data[i].count = rchunk.size();
 		}
 		// for the RHS we just reference the entire vector
-		for (index_t i = 0; i < rchunk.column_count; i++) {
+		for (idx_t i = 0; i < rchunk.column_count; i++) {
 			chunk.data[lchunk.column_count + i].Reference(rchunk.data[i]);
 		}
 		// now perform the computation
@@ -185,13 +185,13 @@ void PhysicalBlockwiseNLJoin::GetChunkInternal(ClientContext &context, DataChunk
 				// partial match
 				chunk.sel_vector = chunk.owned_sel_vector;
 			}
-			for (index_t i = 0; i < chunk.column_count; i++) {
+			for (idx_t i = 0; i < chunk.column_count; i++) {
 				chunk.data[i].sel_vector = chunk.sel_vector;
 				chunk.data[i].count = result_count;
 			}
 			// set the match flags in the RHS
 			if (state->rhs_found_match) {
-				for (index_t i = 0; i < result_count; i++) {
+				for (idx_t i = 0; i < result_count; i++) {
 					state->rhs_found_match[state->right_position * STANDARD_VECTOR_SIZE +
 					                       (chunk.sel_vector ? chunk.sel_vector[i] : i)] = true;
 				}

--- a/src/execution/operator/join/physical_comparison_join.cpp
+++ b/src/execution/operator/join/physical_comparison_join.cpp
@@ -8,9 +8,9 @@ PhysicalComparisonJoin::PhysicalComparisonJoin(LogicalOperator &op, PhysicalOper
     : PhysicalJoin(op, type, join_type) {
 	conditions.resize(conditions_.size());
 	// we reorder conditions so the ones with COMPARE_EQUAL occur first
-	index_t equal_position = 0;
-	index_t other_position = conditions_.size() - 1;
-	for (index_t i = 0; i < conditions_.size(); i++) {
+	idx_t equal_position = 0;
+	idx_t other_position = conditions_.size() - 1;
+	for (idx_t i = 0; i < conditions_.size(); i++) {
 		if (conditions_[i].comparison == ExpressionType::COMPARE_EQUAL) {
 			// COMPARE_EQUAL, move to the start
 			conditions[equal_position++] = std::move(conditions_[i]);

--- a/src/execution/operator/join/physical_cross_product.cpp
+++ b/src/execution/operator/join/physical_cross_product.cpp
@@ -12,8 +12,8 @@ public:
 		assert(left && right);
 	}
 
-	index_t left_position;
-	index_t right_position;
+	idx_t left_position;
+	idx_t right_position;
 	ChunkCollection right_data;
 };
 
@@ -57,13 +57,13 @@ void PhysicalCrossProduct::GetChunkInternal(ClientContext &context, DataChunk &c
 	auto &right_chunk = *state->right_data.chunks[state->right_position];
 	// now match the current row of the left relation with the current chunk
 	// from the right relation
-	for (index_t i = 0; i < left_chunk.column_count; i++) {
+	for (idx_t i = 0; i < left_chunk.column_count; i++) {
 		// first duplicate the values of the left side
 		auto lvalue = left_chunk.data[i].GetValue(state->left_position);
 		chunk.data[i].Reference(lvalue);
 		chunk.data[i].count = right_chunk.size();
 	}
-	for (index_t i = 0; i < right_chunk.column_count; i++) {
+	for (idx_t i = 0; i < right_chunk.column_count; i++) {
 		// now create a reference to the vectors of the right chunk
 		chunk.data[left_chunk.column_count + i].Reference(right_chunk.data[i]);
 	}

--- a/src/execution/operator/join/physical_piecewise_merge_join.cpp
+++ b/src/execution/operator/join/physical_piecewise_merge_join.cpp
@@ -15,9 +15,9 @@ public:
 	}
 
 	bool initialized;
-	index_t left_position;
-	index_t right_position;
-	index_t right_chunk_index;
+	idx_t left_position;
+	idx_t right_position;
+	idx_t right_chunk_index;
 	DataChunk left_chunk;
 	DataChunk join_keys;
 	MergeOrder left_orders;
@@ -79,13 +79,13 @@ void PhysicalPiecewiseMergeJoin::GetChunkInternal(ClientContext &context, DataCh
 		}
 		// now order all the chunks
 		state->right_orders.resize(state->right_chunks.chunks.size());
-		for (index_t i = 0; i < state->right_chunks.chunks.size(); i++) {
+		for (idx_t i = 0; i < state->right_chunks.chunks.size(); i++) {
 			auto &chunk_to_order = *state->right_chunks.chunks[i];
 			// create a new selection vector
 			// resolve the join keys for the right chunk
 			state->join_keys.Reset();
 			state->rhs_executor.SetChunk(chunk_to_order);
-			for (index_t k = 0; k < conditions.size(); k++) {
+			for (idx_t k = 0; k < conditions.size(); k++) {
 				// resolve the join key
 				state->rhs_executor.ExecuteExpression(k, state->join_keys.data[k]);
 				OrderVector(state->join_keys.data[k], state->right_orders[i]);
@@ -115,7 +115,7 @@ void PhysicalPiecewiseMergeJoin::GetChunkInternal(ClientContext &context, DataCh
 			// resolve the join keys for the left chunk
 			state->join_keys.Reset();
 			state->lhs_executor.SetChunk(state->child_chunk);
-			for (index_t k = 0; k < conditions.size(); k++) {
+			for (idx_t k = 0; k < conditions.size(); k++) {
 				state->lhs_executor.ExecuteExpression(k, state->join_keys.data[k]);
 				// sort by join key
 				OrderVector(state->join_keys.data[k], state->left_orders);
@@ -168,7 +168,7 @@ void PhysicalPiecewiseMergeJoin::GetChunkInternal(ClientContext &context, DataCh
 		// perform the merge join
 		switch (type) {
 		case JoinType::INNER: {
-			index_t result_count = MergeJoinInner::Perform(left_info, right, conditions[0].comparison);
+			idx_t result_count = MergeJoinInner::Perform(left_info, right, conditions[0].comparison);
 			if (result_count == 0) {
 				// exhausted this chunk on the right side
 				// move to the next
@@ -176,15 +176,15 @@ void PhysicalPiecewiseMergeJoin::GetChunkInternal(ClientContext &context, DataCh
 				state->left_position = 0;
 				state->right_position = 0;
 			} else {
-				for (index_t i = 0; i < state->child_chunk.column_count; i++) {
+				for (idx_t i = 0; i < state->child_chunk.column_count; i++) {
 					chunk.data[i].Reference(state->child_chunk.data[i]);
 					chunk.data[i].count = result_count;
 					chunk.data[i].sel_vector = left_info.result;
 					chunk.data[i].Flatten();
 				}
 				// now create a reference to the chunk on the right side
-				for (index_t i = 0; i < right_chunk.column_count; i++) {
-					index_t chunk_entry = state->child_chunk.column_count + i;
+				for (idx_t i = 0; i < right_chunk.column_count; i++) {
+					idx_t chunk_entry = state->child_chunk.column_count + i;
 					chunk.data[chunk_entry].Reference(right_chunk.data[i]);
 					chunk.data[chunk_entry].count = result_count;
 					chunk.data[chunk_entry].sel_vector = right.result;

--- a/src/execution/operator/order/physical_order.cpp
+++ b/src/execution/operator/order/physical_order.cpp
@@ -14,9 +14,9 @@ public:
 	PhysicalOrderOperatorState(PhysicalOperator *child) : PhysicalOperatorState(child), position(0) {
 	}
 
-	index_t position;
+	idx_t position;
 	ChunkCollection sorted_data;
-	unique_ptr<index_t[]> sorted_vector;
+	unique_ptr<idx_t[]> sorted_vector;
 };
 
 void PhysicalOrder::GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state_) {
@@ -34,7 +34,7 @@ void PhysicalOrder::GetChunkInternal(ClientContext &context, DataChunk &chunk, P
 		ExpressionExecutor executor;
 		vector<TypeId> sort_types;
 		vector<OrderType> order_types;
-		for (index_t i = 0; i < orders.size(); i++) {
+		for (idx_t i = 0; i < orders.size(); i++) {
 			auto &expr = orders[i].expression;
 			sort_types.push_back(expr->return_type);
 			order_types.push_back(orders[i].type);
@@ -42,7 +42,7 @@ void PhysicalOrder::GetChunkInternal(ClientContext &context, DataChunk &chunk, P
 		}
 
 		ChunkCollection sort_collection;
-		for (index_t i = 0; i < big_data.chunks.size(); i++) {
+		for (idx_t i = 0; i < big_data.chunks.size(); i++) {
 			DataChunk sort_chunk;
 			sort_chunk.Initialize(sort_types);
 
@@ -53,7 +53,7 @@ void PhysicalOrder::GetChunkInternal(ClientContext &context, DataChunk &chunk, P
 		assert(sort_collection.count == big_data.count);
 
 		// now perform the actual sort
-		state->sorted_vector = unique_ptr<index_t[]>(new index_t[sort_collection.count]);
+		state->sorted_vector = unique_ptr<idx_t[]>(new idx_t[sort_collection.count]);
 		sort_collection.Sort(order_types, state->sorted_vector.get());
 	}
 

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -14,10 +14,10 @@ public:
 	PhysicalTopNOperatorState(PhysicalOperator *child) : PhysicalOperatorState(child), position(0) {
 	}
 
-	index_t position;
-	index_t current_offset;
+	idx_t position;
+	idx_t current_offset;
 	ChunkCollection sorted_data;
-	unique_ptr<index_t[]> heap;
+	unique_ptr<idx_t[]> heap;
 };
 
 void PhysicalTopN::GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state_) {
@@ -36,7 +36,7 @@ void PhysicalTopN::GetChunkInternal(ClientContext &context, DataChunk &chunk, Ph
 		ExpressionExecutor executor;
 		vector<TypeId> sort_types;
 		vector<OrderType> order_types;
-		for (index_t i = 0; i < orders.size(); i++) {
+		for (idx_t i = 0; i < orders.size(); i++) {
 			auto &expr = orders[i].expression;
 			sort_types.push_back(expr->return_type);
 			order_types.push_back(orders[i].type);
@@ -49,7 +49,7 @@ void PhysicalTopN::GetChunkInternal(ClientContext &context, DataChunk &chunk, Ph
 		}
 
 		ChunkCollection heap_collection;
-		for (index_t i = 0; i < big_data.chunks.size(); i++) {
+		for (idx_t i = 0; i < big_data.chunks.size(); i++) {
 			DataChunk heap_chunk;
 			heap_chunk.Initialize(sort_types);
 
@@ -60,7 +60,7 @@ void PhysicalTopN::GetChunkInternal(ClientContext &context, DataChunk &chunk, Ph
 		assert(heap_collection.count == big_data.count);
 
 		// create and use the heap
-		state->heap = unique_ptr<index_t[]>(new index_t[heap_size]);
+		state->heap = unique_ptr<idx_t[]>(new idx_t[heap_size]);
 		heap_collection.Heap(order_types, state->heap.get(), heap_size);
 	}
 
@@ -77,6 +77,6 @@ unique_ptr<PhysicalOperatorState> PhysicalTopN::GetOperatorState() {
 	return make_unique<PhysicalTopNOperatorState>(children[0].get());
 }
 
-void PhysicalTopN::CalculateHeapSize(index_t rows) {
+void PhysicalTopN::CalculateHeapSize(idx_t rows) {
 	heap_size = (rows > offset) ? min(limit + offset, rows) : 0;
 }

--- a/src/execution/operator/persistent/buffered_csv_reader.cpp
+++ b/src/execution/operator/persistent/buffered_csv_reader.cpp
@@ -27,14 +27,14 @@ TextSearchShiftArray::TextSearchShiftArray(string search_term) : length(search_t
 	shifts = unique_ptr<uint8_t[]>(new uint8_t[length * 255]);
 	memset(shifts.get(), 0, length * 255 * sizeof(uint8_t));
 	// iterate over each of the characters in the array
-	for (index_t main_idx = 0; main_idx < length; main_idx++) {
+	for (idx_t main_idx = 0; main_idx < length; main_idx++) {
 		uint8_t current_char = (uint8_t)search_term[main_idx];
 		// now move over all the remaining positions
-		for (index_t i = main_idx; i < length; i++) {
+		for (idx_t i = main_idx; i < length; i++) {
 			bool is_match = true;
 			// check if the prefix matches at this position
 			// if it does, we move to this position after encountering the current character
-			for (index_t j = 0; j < main_idx; j++) {
+			for (idx_t j = 0; j < main_idx; j++) {
 				if (search_term[i - main_idx + j] != search_term[j]) {
 					is_match = false;
 				}
@@ -56,7 +56,7 @@ BufferedCSVReader::BufferedCSVReader(CopyInfo &info, vector<SQLType> sql_types, 
 	assert(info.force_not_null.size() == sql_types.size());
 	// initialize the parse_chunk with a set of VARCHAR types
 	vector<TypeId> varchar_types;
-	for (index_t i = 0; i < sql_types.size(); i++) {
+	for (idx_t i = 0; i < sql_types.size(); i++) {
 		varchar_types.push_back(TypeId::VARCHAR);
 	}
 	parse_chunk.Initialize(varchar_types);
@@ -72,10 +72,10 @@ BufferedCSVReader::BufferedCSVReader(CopyInfo &info, vector<SQLType> sql_types, 
 void BufferedCSVReader::ParseComplexCSV(DataChunk &insert_chunk) {
 	// used for parsing algorithm
 	bool finished_chunk = false;
-	index_t column = 0;
-	vector<index_t> escape_positions;
+	idx_t column = 0;
+	vector<idx_t> escape_positions;
 	uint8_t delimiter_pos = 0, escape_pos = 0, quote_pos = 0;
-	index_t offset = 0;
+	idx_t offset = 0;
 
 	// read values into the buffer (if any)
 	if (position >= buffer_size) {
@@ -93,7 +93,7 @@ value_start:
 	delimiter_pos = 0;
 	quote_pos = 0;
 	do {
-		index_t count = 0;
+		idx_t count = 0;
 		for (; position < buffer_size; position++) {
 			quote_search.Match(quote_pos, buffer[position]);
 			delimiter_search.Match(delimiter_pos, buffer[position]);
@@ -207,7 +207,7 @@ unquote:
 		goto add_row;
 	}
 	do {
-		index_t count = 0;
+		idx_t count = 0;
 		for (; position < buffer_size; position++) {
 			quote_search.Match(quote_pos, buffer[position]);
 			delimiter_search.Match(delimiter_pos, buffer[position]);
@@ -235,7 +235,7 @@ handle_escape:
 	quote_pos = 0;
 	position++;
 	do {
-		index_t count = 0;
+		idx_t count = 0;
 		for (; position < buffer_size; position++) {
 			quote_search.Match(quote_pos, buffer[position]);
 			escape_search.Match(escape_pos, buffer[position]);
@@ -282,9 +282,9 @@ final_state:
 void BufferedCSVReader::ParseSimpleCSV(DataChunk &insert_chunk) {
 	// used for parsing algorithm
 	bool finished_chunk = false;
-	index_t column = 0;
-	index_t offset = 0;
-	vector<index_t> escape_positions;
+	idx_t column = 0;
+	idx_t offset = 0;
+	vector<idx_t> escape_positions;
 
 	// read values into the buffer (if any)
 	if (position >= buffer_size) {
@@ -443,12 +443,12 @@ final_state:
 	Flush(insert_chunk);
 }
 
-bool BufferedCSVReader::ReadBuffer(index_t &start) {
+bool BufferedCSVReader::ReadBuffer(idx_t &start) {
 	auto old_buffer = move(buffer);
 
 	// the remaining part of the last buffer
-	index_t remaining = buffer_size - start;
-	index_t buffer_read_size = INITIAL_BUFFER_SIZE;
+	idx_t remaining = buffer_size - start;
+	idx_t buffer_read_size = INITIAL_BUFFER_SIZE;
 	while (remaining > buffer_read_size) {
 		buffer_read_size *= 2;
 	}
@@ -462,7 +462,7 @@ bool BufferedCSVReader::ReadBuffer(index_t &start) {
 		memcpy(buffer.get(), old_buffer.get() + start, remaining);
 	}
 	source.read(buffer.get() + remaining, buffer_read_size);
-	index_t read_count = source.eof() ? source.gcount() : buffer_read_size;
+	idx_t read_count = source.eof() ? source.gcount() : buffer_read_size;
 	buffer_size = remaining + read_count;
 	buffer[buffer_size] = '\0';
 	if (old_buffer) {
@@ -484,7 +484,7 @@ void BufferedCSVReader::ParseCSV(DataChunk &insert_chunk) {
 	}
 }
 
-void BufferedCSVReader::AddValue(char *str_val, index_t length, index_t &column, vector<index_t> &escape_positions) {
+void BufferedCSVReader::AddValue(char *str_val, idx_t length, idx_t &column, vector<idx_t> &escape_positions) {
 	if (column == sql_types.size() && length == 0) {
 		// skip a single trailing delimiter
 		column++;
@@ -495,7 +495,7 @@ void BufferedCSVReader::AddValue(char *str_val, index_t length, index_t &column,
 		                      column + 1);
 	}
 	// insert the line number into the chunk
-	index_t row_entry = parse_chunk.data[column].count++;
+	idx_t row_entry = parse_chunk.data[column].count++;
 
 	str_val[length] = '\0';
 	// test against null string
@@ -508,9 +508,9 @@ void BufferedCSVReader::AddValue(char *str_val, index_t length, index_t &column,
 			// remove escape characters (if any)
 			string old_val = str_val;
 			string new_val = "";
-			index_t prev_pos = 0;
-			for (index_t i = 0; i < escape_positions.size(); i++) {
-				index_t next_pos = escape_positions[i];
+			idx_t prev_pos = 0;
+			for (idx_t i = 0; i < escape_positions.size(); i++) {
+				idx_t next_pos = escape_positions[i];
 				new_val += old_val.substr(prev_pos, next_pos - prev_pos);
 				prev_pos = next_pos + info.escape.size();
 			}
@@ -526,7 +526,7 @@ void BufferedCSVReader::AddValue(char *str_val, index_t length, index_t &column,
 	column++;
 }
 
-bool BufferedCSVReader::AddRow(DataChunk &insert_chunk, index_t &column) {
+bool BufferedCSVReader::AddRow(DataChunk &insert_chunk, idx_t &column) {
 	if (column < sql_types.size()) {
 		throw ParserException("Error on line %lld: expected %lld values but got %d", linenr, sql_types.size(), column);
 	}
@@ -545,12 +545,12 @@ void BufferedCSVReader::Flush(DataChunk &insert_chunk) {
 		return;
 	}
 	// convert the columns in the parsed chunk to the types of the table
-	for (index_t col_idx = 0; col_idx < sql_types.size(); col_idx++) {
+	for (idx_t col_idx = 0; col_idx < sql_types.size(); col_idx++) {
 		if (sql_types[col_idx].id == SQLTypeId::VARCHAR) {
 			// target type is varchar: no need to convert
 			// just test that all strings are valid utf-8 strings
 			auto parse_data = (const char **)parse_chunk.data[col_idx].GetData();
-			VectorOperations::Exec(parse_chunk.data[col_idx], [&](index_t i, index_t k) {
+			VectorOperations::Exec(parse_chunk.data[col_idx], [&](idx_t i, idx_t k) {
 				if (!parse_chunk.data[col_idx].nullmask[i]) {
 					if (!Value::IsUTF8String(parse_data[i])) {
 						throw ParserException("Error on line %lld: file is not valid UTF8", linenr);

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -8,7 +8,7 @@ using namespace duckdb;
 using namespace std;
 
 class BufferedWriter {
-	constexpr static index_t BUFFER_SIZE = 4096 * 4;
+	constexpr static idx_t BUFFER_SIZE = 4096 * 4;
 
 public:
 	BufferedWriter(string &path) : pos(0) {
@@ -30,7 +30,7 @@ public:
 		to_csv.close();
 	}
 
-	void Write(const char *buf, index_t len) {
+	void Write(const char *buf, idx_t len) {
 		if (len >= BUFFER_SIZE) {
 			Flush();
 			to_csv.write(buf, len);
@@ -49,15 +49,15 @@ public:
 
 private:
 	char buffer[BUFFER_SIZE];
-	index_t pos = 0;
+	idx_t pos = 0;
 
 	ofstream to_csv;
 };
 
 string AddEscapes(string &to_be_escaped, string escape, string val) {
-	index_t i = 0;
+	idx_t i = 0;
 	string new_val = "";
-	index_t found = val.find(to_be_escaped);
+	idx_t found = val.find(to_be_escaped);
 
 	while (found != string::npos) {
 		while (i < found) {
@@ -136,13 +136,13 @@ static void WriteQuotedString(BufferedWriter &writer, const char *str_value, str
 
 void PhysicalCopyToFile::GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state) {
 	auto &info = *this->info;
-	index_t total = 0;
+	idx_t total = 0;
 
 	string newline = "\n";
 	BufferedWriter writer(info.file_path);
 	if (info.header) {
 		// write the header line
-		for (index_t i = 0; i < names.size(); i++) {
+		for (idx_t i = 0; i < names.size(); i++) {
 			if (i != 0) {
 				writer.Write(info.delimiter);
 			}
@@ -152,7 +152,7 @@ void PhysicalCopyToFile::GetChunkInternal(ClientContext &context, DataChunk &chu
 	}
 	// create a chunk with VARCHAR columns
 	vector<TypeId> types;
-	for (index_t col_idx = 0; col_idx < state->child_chunk.column_count; col_idx++) {
+	for (idx_t col_idx = 0; col_idx < state->child_chunk.column_count; col_idx++) {
 		types.push_back(TypeId::VARCHAR);
 	}
 	DataChunk cast_chunk;
@@ -164,7 +164,7 @@ void PhysicalCopyToFile::GetChunkInternal(ClientContext &context, DataChunk &chu
 			break;
 		}
 		// cast the columns of the chunk to varchar
-		for (index_t col_idx = 0; col_idx < state->child_chunk.column_count; col_idx++) {
+		for (idx_t col_idx = 0; col_idx < state->child_chunk.column_count; col_idx++) {
 			if (sql_types[col_idx].id == SQLTypeId::VARCHAR) {
 				// VARCHAR, just create a reference
 				cast_chunk.data[col_idx].Reference(state->child_chunk.data[col_idx]);
@@ -175,9 +175,9 @@ void PhysicalCopyToFile::GetChunkInternal(ClientContext &context, DataChunk &chu
 			}
 		}
 		// now loop over the vectors and output the values
-		VectorOperations::Exec(cast_chunk.data[0], [&](index_t i, index_t k) {
+		VectorOperations::Exec(cast_chunk.data[0], [&](idx_t i, idx_t k) {
 			// write values
-			for (index_t col_idx = 0; col_idx < state->child_chunk.column_count; col_idx++) {
+			for (idx_t col_idx = 0; col_idx < state->child_chunk.column_count; col_idx++) {
 				if (col_idx != 0) {
 					writer.Write(info.delimiter);
 				}

--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -35,20 +35,20 @@ void PhysicalInsert::GetChunkInternal(ClientContext &context, DataChunk &chunk, 
 		insert_chunk.Reset();
 		if (column_index_map.size() > 0) {
 			// columns specified by the user, use column_index_map
-			for (index_t i = 0; i < table->columns.size(); i++) {
+			for (idx_t i = 0; i < table->columns.size(); i++) {
 				if (column_index_map[i] == INVALID_INDEX) {
 					// insert default value
 					default_executor.ExecuteExpression(i, insert_chunk.data[i]);
 				} else {
 					// get value from child chunk
-					assert((index_t)column_index_map[i] < chunk.column_count);
+					assert((idx_t)column_index_map[i] < chunk.column_count);
 					assert(insert_chunk.data[i].type == chunk.data[column_index_map[i]].type);
 					insert_chunk.data[i].Reference(chunk.data[column_index_map[i]]);
 				}
 			}
 		} else {
 			// no columns specified, just append directly
-			for (index_t i = 0; i < insert_chunk.column_count; i++) {
+			for (idx_t i = 0; i < insert_chunk.column_count; i++) {
 				assert(insert_chunk.data[i].type == chunk.data[i].type);
 				insert_chunk.data[i].Reference(chunk.data[i]);
 			}

--- a/src/execution/operator/persistent/physical_update.cpp
+++ b/src/execution/operator/persistent/physical_update.cpp
@@ -39,7 +39,7 @@ void PhysicalUpdate::GetChunkInternal(ClientContext &context, DataChunk &chunk, 
 		// update data in the base table
 		// the row ids are given to us as the last column of the child chunk
 		auto &row_ids = state->child_chunk.data[state->child_chunk.column_count - 1];
-		for (index_t i = 0; i < expressions.size(); i++) {
+		for (idx_t i = 0; i < expressions.size(); i++) {
 			if (expressions[i]->type == ExpressionType::VALUE_DEFAULT) {
 				// default expression, set to the default value of the column
 				default_executor.ExecuteExpression(columns[i], update_chunk.data[i]);
@@ -55,7 +55,7 @@ void PhysicalUpdate::GetChunkInternal(ClientContext &context, DataChunk &chunk, 
 		if (is_index_update) {
 			// index update, perform a delete and an append instead
 			table.Delete(tableref, context, row_ids);
-			for (index_t i = 0; i < columns.size(); i++) {
+			for (idx_t i = 0; i < columns.size(); i++) {
 				mock_chunk.data[columns[i]].Reference(update_chunk.data[i]);
 			}
 			table.Append(tableref, context, mock_chunk);

--- a/src/execution/operator/scan/physical_chunk_scan.cpp
+++ b/src/execution/operator/scan/physical_chunk_scan.cpp
@@ -9,7 +9,7 @@ public:
 	}
 
 	//! The current position in the scan
-	index_t chunk_index;
+	idx_t chunk_index;
 };
 
 void PhysicalChunkScan::GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state_) {
@@ -23,7 +23,7 @@ void PhysicalChunkScan::GetChunkInternal(ClientContext &context, DataChunk &chun
 		return;
 	}
 	auto &collection_chunk = *collection->chunks[state->chunk_index];
-	for (index_t i = 0; i < chunk.column_count; i++) {
+	for (idx_t i = 0; i < chunk.column_count; i++) {
 		chunk.data[i].Reference(collection_chunk.data[i]);
 	}
 	state->chunk_index++;

--- a/src/execution/operator/scan/physical_expression_scan.cpp
+++ b/src/execution/operator/scan/physical_expression_scan.cpp
@@ -11,7 +11,7 @@ public:
 	}
 
 	//! The current position in the scan
-	index_t expression_index;
+	idx_t expression_index;
 
 	unique_ptr<ExpressionExecutor> executor;
 };

--- a/src/execution/operator/schema/physical_create_index.cpp
+++ b/src/execution/operator/schema/physical_create_index.cpp
@@ -28,7 +28,7 @@ void PhysicalCreateIndex::GetChunkInternal(ClientContext &context, DataChunk &ch
 
 	// create the chunk to hold intermediate expression results
 
-	switch (info->index_type) {
+	switch (info->idx_type) {
 	case IndexType::ART: {
 		CreateARTIndex();
 		break;

--- a/src/execution/operator/set/physical_recursive_cte.cpp
+++ b/src/execution/operator/set/physical_recursive_cte.cpp
@@ -37,7 +37,7 @@ void PhysicalRecursiveCTE::GetChunkInternal(ClientContext &context, DataChunk &c
 		do {
 			children[0]->GetChunk(context, chunk, state->top_state.get());
 			if (!union_all) {
-				index_t match_count = ProbeHT(chunk, state);
+				idx_t match_count = ProbeHT(chunk, state);
 				if (match_count > 0) {
 					working_table->Append(chunk);
 				}
@@ -79,7 +79,7 @@ void PhysicalRecursiveCTE::GetChunkInternal(ClientContext &context, DataChunk &c
 		if (!union_all) {
 			// If we evaluate using UNION semantics, we have to eliminate duplicates before appending them to
 			// intermediate tables.
-			index_t match_count = ProbeHT(chunk, state);
+			idx_t match_count = ProbeHT(chunk, state);
 			if (match_count > 0) {
 				intermediate_table.Append(chunk);
 				state->intermediate_empty = false;
@@ -93,7 +93,7 @@ void PhysicalRecursiveCTE::GetChunkInternal(ClientContext &context, DataChunk &c
 	}
 }
 
-index_t PhysicalRecursiveCTE::ProbeHT(DataChunk &chunk, PhysicalOperatorState *state_) {
+idx_t PhysicalRecursiveCTE::ProbeHT(DataChunk &chunk, PhysicalOperatorState *state_) {
 	auto state = reinterpret_cast<PhysicalRecursiveCTEState *>(state_);
 
 	Vector dummy_addresses(TypeId::POINTER);
@@ -106,15 +106,15 @@ index_t PhysicalRecursiveCTE::ProbeHT(DataChunk &chunk, PhysicalOperatorState *s
 	state->ht->FindOrCreateGroups(chunk, dummy_addresses, probe_result);
 
 	// Update the sel_vector of the DataChunk
-	index_t match_count = 0;
-	for (index_t probe_idx = 0; probe_idx < probe_result.count; probe_idx++) {
-		index_t sel_idx = probe_idx;
+	idx_t match_count = 0;
+	for (idx_t probe_idx = 0; probe_idx < probe_result.count; probe_idx++) {
+		idx_t sel_idx = probe_idx;
 		if (probe_data[sel_idx]) {
 			chunk.owned_sel_vector[match_count++] = sel_idx;
 		}
 	}
 
-	for (index_t i = 0; i < chunk.column_count; i++) {
+	for (idx_t i = 0; i < chunk.column_count; i++) {
 		chunk.data[i].count = match_count;
 		chunk.data[i].sel_vector = chunk.owned_sel_vector;
 	}

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -6,7 +6,7 @@
 using namespace duckdb;
 using namespace std;
 
-string PhysicalOperator::ToString(index_t depth) const {
+string PhysicalOperator::ToString(idx_t depth) const {
 	string extra_info = StringUtil::Replace(ExtraRenderInformation(), "\n", " ");
 	StringUtil::RTrim(extra_info);
 	if (!extra_info.empty()) {
@@ -14,7 +14,7 @@ string PhysicalOperator::ToString(index_t depth) const {
 	}
 	string result = PhysicalOperatorToString(type) + extra_info;
 	if (children.size() > 0) {
-		for (index_t i = 0; i < children.size(); i++) {
+		for (idx_t i = 0; i < children.size(); i++) {
 			result += "\n" + string(depth * 4, ' ');
 			auto &child = children[i];
 			result += child->ToString(depth + 1);

--- a/src/execution/physical_plan/plan_aggregate.cpp
+++ b/src/execution/physical_plan/plan_aggregate.cpp
@@ -16,7 +16,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAggregate 
 		// no groups, check if we can use a simple aggregation
 		// special case: aggregate entire columns together
 		bool use_simple_aggregation = true;
-		for (index_t i = 0; i < op.expressions.size(); i++) {
+		for (idx_t i = 0; i < op.expressions.size(); i++) {
 			auto &aggregate = (BoundAggregateExpression &)*op.expressions[i];
 			if (!aggregate.function.simple_update || aggregate.distinct) {
 				// unsupported aggregate for simple aggregation: use hash aggregation

--- a/src/execution/physical_plan/plan_delim_join.cpp
+++ b/src/execution/physical_plan/plan_delim_join.cpp
@@ -59,7 +59,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelimJoin 
 			vector<TypeId> payload_types = {TypeId::INT64, TypeId::INT64}; // COUNT types
 			vector<AggregateFunction> aggregate_functions = {CountStarFun::GetFunction(), CountFun::GetFunction()};
 			vector<BoundAggregateExpression *> correlated_aggregates;
-			for (index_t i = 0; i < aggregate_functions.size(); ++i) {
+			for (idx_t i = 0; i < aggregate_functions.size(); ++i) {
 				auto aggr = make_unique<BoundAggregateExpression>(payload_types[i], aggregate_functions[i], false);
 				correlated_aggregates.push_back(&*aggr);
 				info.correlated_aggregates.push_back(move(aggr));

--- a/src/execution/physical_plan/plan_distinct.cpp
+++ b/src/execution/physical_plan/plan_distinct.cpp
@@ -16,7 +16,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreateDistinct(unique_ptr<Ph
 	// create a PhysicalHashAggregate that groups by the input columns
 	auto &types = child->GetTypes();
 	vector<unique_ptr<Expression>> groups, expressions;
-	for (index_t i = 0; i < types.size(); i++) {
+	for (idx_t i = 0; i < types.size(); i++) {
 		groups.push_back(make_unique<BoundReferenceExpression>(types[i], i));
 	}
 
@@ -40,7 +40,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreateDistinctOn(unique_ptr<
 	// we need the projection to fetch the select_list
 	auto &child_projection = (PhysicalProjection &)*child;
 	// we need to create one aggregate per column in the select_list
-	for (index_t i = 0; i < child_projection.select_list.size(); ++i) {
+	for (idx_t i = 0; i < child_projection.select_list.size(); ++i) {
 		// first we create an aggregate that returns the FIRST element
 		auto bound = make_unique<BoundReferenceExpression>(types[i], i);
 		auto first_aggregate = make_unique<BoundAggregateExpression>(

--- a/src/execution/physical_plan/plan_explain.cpp
+++ b/src/execution/physical_plan/plan_explain.cpp
@@ -20,7 +20,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExplain &o
 	DataChunk chunk;
 	chunk.Initialize(op.types);
 	chunk.data[0].count = chunk.data[1].count = keys.size();
-	for (index_t i = 0; i < keys.size(); i++) {
+	for (idx_t i = 0; i < keys.size(); i++) {
 		chunk.data[0].SetValue(i, Value(keys[i]));
 		chunk.data[1].SetValue(i, Value(values[i]));
 	}

--- a/src/execution/physical_plan/plan_filter.cpp
+++ b/src/execution/physical_plan/plan_filter.cpp
@@ -21,7 +21,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalFilter &op
 		if (op.projection_map.size() > 0) {
 			// there is a projection map, generate a physical projection
 			vector<unique_ptr<Expression>> select_list;
-			for (index_t i = 0; i < op.projection_map.size(); i++) {
+			for (idx_t i = 0; i < op.projection_map.size(); i++) {
 				select_list.push_back(make_unique<BoundReferenceExpression>(op.types[i], op.projection_map[i]));
 			}
 			auto proj = make_unique<PhysicalProjection>(op.types, move(select_list));

--- a/src/execution/physical_plan/plan_set_operation.cpp
+++ b/src/execution/physical_plan/plan_set_operation.cpp
@@ -27,7 +27,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSetOperati
 		auto &types = left->GetTypes();
 		vector<JoinCondition> conditions;
 		// create equality condition for all columns
-		for (index_t i = 0; i < types.size(); i++) {
+		for (idx_t i = 0; i < types.size(); i++) {
 			JoinCondition cond;
 			cond.comparison = ExpressionType::COMPARE_EQUAL;
 			cond.left = make_unique<BoundReferenceExpression>(types[i], i);

--- a/src/function/aggregate/algebraic/avg.cpp
+++ b/src/function/aggregate/algebraic/avg.cpp
@@ -11,7 +11,7 @@ struct avg_state_t {
 	double sum;
 };
 
-static index_t avg_payload_size(TypeId return_type) {
+static idx_t avg_payload_size(TypeId return_type) {
 	return sizeof(avg_state_t);
 }
 
@@ -19,13 +19,13 @@ static void avg_initialize(data_ptr_t payload, TypeId return_type) {
 	memset(payload, 0, avg_payload_size(return_type));
 }
 
-static void avg_update(Vector inputs[], index_t input_count, Vector &state) {
+static void avg_update(Vector inputs[], idx_t input_count, Vector &state) {
 	assert(input_count == 1);
 	inputs[0].Normalify();
 
 	auto states = (avg_state_t **)state.GetData();
 	auto input_data = (double *)inputs[0].GetData();
-	VectorOperations::Exec(state, [&](index_t i, index_t k) {
+	VectorOperations::Exec(state, [&](idx_t i, idx_t k) {
 		if (inputs[0].nullmask[i]) {
 			return;
 		}

--- a/src/function/aggregate/algebraic/covar.cpp
+++ b/src/function/aggregate/algebraic/covar.cpp
@@ -14,7 +14,7 @@ struct covar_state_t {
 	double co_moment;
 };
 
-static index_t covar_state_size(TypeId return_type) {
+static idx_t covar_state_size(TypeId return_type) {
 	return sizeof(covar_state_t);
 }
 
@@ -22,7 +22,7 @@ static void covar_initialize(data_ptr_t payload, TypeId return_type) {
 	memset(payload, 0, covar_state_size(return_type));
 }
 
-static void covar_update(Vector inputs[], index_t input_count, Vector &state) {
+static void covar_update(Vector inputs[], idx_t input_count, Vector &state) {
 	// Streaming approximate covariance
 	assert(input_count == 2);
 	inputs[0].Normalify();
@@ -31,7 +31,7 @@ static void covar_update(Vector inputs[], index_t input_count, Vector &state) {
 	auto states = (covar_state_t **)state.GetData();
 	auto xdata = (double *)inputs[0].GetData();
 	auto ydata = (double *)inputs[1].GetData();
-	VectorOperations::Exec(state, [&](index_t i, index_t k) {
+	VectorOperations::Exec(state, [&](idx_t i, idx_t k) {
 		if (inputs[0].nullmask[i] || inputs[1].nullmask[i]) {
 			return;
 		}

--- a/src/function/aggregate/algebraic/stddev.cpp
+++ b/src/function/aggregate/algebraic/stddev.cpp
@@ -13,7 +13,7 @@ struct stddev_state_t {
 	double dsquared; //  M2
 };
 
-static index_t stddev_state_size(TypeId return_type) {
+static idx_t stddev_state_size(TypeId return_type) {
 	return sizeof(stddev_state_t);
 }
 
@@ -21,14 +21,14 @@ static void stddev_initialize(data_ptr_t payload, TypeId return_type) {
 	memset(payload, 0, stddev_state_size(return_type));
 }
 
-static void stddev_update(Vector inputs[], index_t input_count, Vector &state) {
+static void stddev_update(Vector inputs[], idx_t input_count, Vector &state) {
 	assert(input_count == 1);
 	// Streaming approximate standard deviation using Welford's
 	// method, DOI: 10.2307/1266577
 
 	auto states = (stddev_state_t **)state.GetData();
 	auto input_data = (double *)inputs[0].GetData();
-	VectorOperations::Exec(state, [&](index_t i, index_t k) {
+	VectorOperations::Exec(state, [&](idx_t i, idx_t k) {
 		if (inputs[0].nullmask[i]) {
 			return;
 		}

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -13,19 +13,19 @@ struct CountOperator {
 	}
 };
 
-static void countstar_update(Vector inputs[], index_t input_count, Vector &addresses) {
+static void countstar_update(Vector inputs[], idx_t input_count, Vector &addresses) {
 	// add one to each address
 	auto states = (int64_t **)addresses.GetData();
-	VectorOperations::Exec(addresses, [&](index_t i, index_t k) { states[i][0]++; });
+	VectorOperations::Exec(addresses, [&](idx_t i, idx_t k) { states[i][0]++; });
 }
 
-static void countstar_simple_update(Vector inputs[], index_t input_count, data_ptr_t state_) {
+static void countstar_simple_update(Vector inputs[], idx_t input_count, data_ptr_t state_) {
 	// count star: just add the count
 	auto state = (int64_t *)state_;
 	*state += inputs[0].count;
 }
 
-static void count_update(Vector inputs[], index_t input_count, Vector &addresses) {
+static void count_update(Vector inputs[], idx_t input_count, Vector &addresses) {
 	auto &input = inputs[0];
 	if (input.vector_type == VectorType::CONSTANT_VECTOR) {
 		// constant input
@@ -44,7 +44,7 @@ static void count_update(Vector inputs[], index_t input_count, Vector &addresses
 		return;
 	}
 	auto states = (int64_t **)addresses.GetData();
-	VectorOperations::Exec(input, [&](index_t i, index_t k) {
+	VectorOperations::Exec(input, [&](idx_t i, idx_t k) {
 		if (!input.nullmask[i]) {
 			states[i][0]++;
 		}
@@ -55,7 +55,7 @@ static void count_combine(Vector &state, Vector &combined) {
 	VectorOperations::Scatter::Add(state, combined);
 }
 
-static void count_simple_update(Vector inputs[], index_t input_count, data_ptr_t state_) {
+static void count_simple_update(Vector inputs[], idx_t input_count, data_ptr_t state_) {
 	auto state = (int64_t *)state_;
 	auto &input = inputs[0];
 	if (input.vector_type == VectorType::CONSTANT_VECTOR) {
@@ -69,7 +69,7 @@ static void count_simple_update(Vector inputs[], index_t input_count, data_ptr_t
 		input.Normalify();
 		if (input.nullmask.any()) {
 			// NULL values, count the amount of NULL entries
-			VectorOperations::Exec(input, [&](index_t i, index_t k) {
+			VectorOperations::Exec(input, [&](idx_t i, idx_t k) {
 				if (!input.nullmask[i]) {
 					(*state)++;
 				}

--- a/src/function/aggregate/distributive/first.cpp
+++ b/src/function/aggregate/distributive/first.cpp
@@ -7,7 +7,7 @@ using namespace std;
 
 namespace duckdb {
 
-static void first_update(Vector inputs[], index_t input_count, Vector &result) {
+static void first_update(Vector inputs[], idx_t input_count, Vector &result) {
 	assert(input_count == 1);
 	VectorOperations::Scatter::SetFirst(inputs[0], result);
 }

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -10,7 +10,7 @@ using namespace std;
 
 namespace duckdb {
 
-static void min_update(Vector inputs[], index_t input_count, Vector &result) {
+static void min_update(Vector inputs[], idx_t input_count, Vector &result) {
 	assert(input_count == 1);
 	VectorOperations::Scatter::Min(inputs[0], result);
 }
@@ -19,7 +19,7 @@ static void min_combine(Vector &state, Vector &combined) {
 	VectorOperations::Scatter::Min(state, combined);
 }
 
-static void max_update(Vector inputs[], index_t input_count, Vector &result) {
+static void max_update(Vector inputs[], idx_t input_count, Vector &result) {
 	assert(input_count == 1);
 	VectorOperations::Scatter::Max(inputs[0], result);
 }
@@ -28,7 +28,7 @@ static void max_combine(Vector &state, Vector &combined) {
 	VectorOperations::Scatter::Max(state, combined);
 }
 
-template <class T, class OP> static void minmax_simple_update(Vector inputs[], index_t input_count, data_ptr_t state_) {
+template <class T, class OP> static void minmax_simple_update(Vector inputs[], idx_t input_count, data_ptr_t state_) {
 	auto state = (T *)state_;
 	T result;
 	if (!AggregateExecutor::Execute<T, T, OP>(inputs[0], &result)) {

--- a/src/function/aggregate/distributive/string_agg.cpp
+++ b/src/function/aggregate/distributive/string_agg.cpp
@@ -10,7 +10,7 @@ namespace duckdb {
 
 typedef const char *string_agg_state_t;
 
-void string_agg_update(Vector inputs[], index_t input_count, Vector &state) {
+void string_agg_update(Vector inputs[], idx_t input_count, Vector &state) {
 	assert(input_count == 2 && inputs[0].type == TypeId::VARCHAR && inputs[1].type == TypeId::VARCHAR);
 	inputs[0].Normalify();
 	inputs[1].Normalify();
@@ -25,7 +25,7 @@ void string_agg_update(Vector inputs[], index_t input_count, Vector &state) {
 	//  Share a reusable buffer for the block
 	std::string buffer;
 
-	VectorOperations::Exec(state, [&](index_t i, index_t k) {
+	VectorOperations::Exec(state, [&](idx_t i, idx_t k) {
 		if (strs.nullmask[i] || seps.nullmask[i]) {
 			return;
 		}

--- a/src/function/aggregate/distributive/sum.cpp
+++ b/src/function/aggregate/distributive/sum.cpp
@@ -9,7 +9,7 @@ using namespace std;
 
 namespace duckdb {
 
-static void sum_update(Vector inputs[], index_t input_count, Vector &result) {
+static void sum_update(Vector inputs[], idx_t input_count, Vector &result) {
 	assert(input_count == 1);
 	VectorOperations::Scatter::Add(inputs[0], result);
 }
@@ -18,7 +18,7 @@ static void sum_combine(Vector &state, Vector &combined) {
 	VectorOperations::Scatter::Add(state, combined);
 }
 
-template <class T> static void sum_simple_update(Vector inputs[], index_t input_count, data_ptr_t state_) {
+template <class T> static void sum_simple_update(Vector inputs[], idx_t input_count, data_ptr_t state_) {
 	auto state = (T *)state_;
 	T result;
 	if (!AggregateExecutor::Execute<T, T, duckdb::Add>(inputs[0], &result)) {

--- a/src/function/aggregate/distributive_functions.cpp
+++ b/src/function/aggregate/distributive_functions.cpp
@@ -16,7 +16,7 @@ void null_state_initialize(data_ptr_t state, TypeId return_type) {
 	SetNullValue(state, return_type);
 }
 
-index_t get_bigint_type_size(TypeId return_type) {
+idx_t get_bigint_type_size(TypeId return_type) {
 	return GetTypeIdSize(TypeId::INT64);
 }
 
@@ -27,7 +27,7 @@ void bigint_payload_initialize(data_ptr_t payload, TypeId return_type) {
 Value bigint_simple_initialize() {
 	return Value::BIGINT(0);
 }
-index_t get_return_type_size(TypeId return_type) {
+idx_t get_return_type_size(TypeId return_type) {
 	return GetTypeIdSize(return_type);
 }
 

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -80,7 +80,7 @@ static int64_t BindVarArgsFunctionCost(SimpleFunction &func, vector<SQLType> &ar
 		return -1;
 	}
 	int64_t cost = 0;
-	for (index_t i = 0; i < arguments.size(); i++) {
+	for (idx_t i = 0; i < arguments.size(); i++) {
 		SQLType arg_type = i < func.arguments.size() ? func.arguments[i] : func.varargs;
 		if (arguments[i] == arg_type) {
 			// arguments match: do nothing
@@ -108,7 +108,7 @@ static int64_t BindFunctionCost(SimpleFunction &func, vector<SQLType> &arguments
 		return -1;
 	}
 	int64_t cost = 0;
-	for (index_t i = 0; i < arguments.size(); i++) {
+	for (idx_t i = 0; i < arguments.size(); i++) {
 		if (arguments[i] == func.arguments[i]) {
 			// arguments match: do nothing
 			continue;
@@ -126,11 +126,11 @@ static int64_t BindFunctionCost(SimpleFunction &func, vector<SQLType> &arguments
 }
 
 template <class T>
-static index_t BindFunctionFromArguments(string name, vector<T> &functions, vector<SQLType> &arguments) {
-	index_t best_function = INVALID_INDEX;
+static idx_t BindFunctionFromArguments(string name, vector<T> &functions, vector<SQLType> &arguments) {
+	idx_t best_function = INVALID_INDEX;
 	int64_t lowest_cost = numeric_limits<int64_t>::max();
-	vector<index_t> conflicting_functions;
-	for (index_t f_idx = 0; f_idx < functions.size(); f_idx++) {
+	vector<idx_t> conflicting_functions;
+	for (idx_t f_idx = 0; f_idx < functions.size(); f_idx++) {
 		auto &func = functions[f_idx];
 		// check the arguments of the function
 		int64_t cost = BindFunctionCost(func, arguments);
@@ -177,16 +177,16 @@ static index_t BindFunctionFromArguments(string name, vector<T> &functions, vect
 	return best_function;
 }
 
-index_t Function::BindFunction(string name, vector<ScalarFunction> &functions, vector<SQLType> &arguments) {
+idx_t Function::BindFunction(string name, vector<ScalarFunction> &functions, vector<SQLType> &arguments) {
 	return BindFunctionFromArguments(name, functions, arguments);
 }
 
-index_t Function::BindFunction(string name, vector<AggregateFunction> &functions, vector<SQLType> &arguments) {
+idx_t Function::BindFunction(string name, vector<AggregateFunction> &functions, vector<SQLType> &arguments) {
 	return BindFunctionFromArguments(name, functions, arguments);
 }
 
 void SimpleFunction::CastToFunctionArguments(vector<unique_ptr<Expression>> &children, vector<SQLType> &types) {
-	for (index_t i = 0; i < types.size(); i++) {
+	for (idx_t i = 0; i < types.size(); i++) {
 		auto target_type = i < this->arguments.size() ? this->arguments[i] : this->varargs;
 		if (target_type.id != SQLTypeId::ANY && types[i] != target_type) {
 			// type of child does not match type of function argument: add a cast
@@ -210,7 +210,7 @@ unique_ptr<BoundFunctionExpression>
 ScalarFunction::BindScalarFunction(ClientContext &context, ScalarFunctionCatalogEntry &func, vector<SQLType> &arguments,
                                    vector<unique_ptr<Expression>> children, bool is_operator) {
 	// bind the function
-	index_t best_function = Function::BindFunction(func.name, func.functions, arguments);
+	idx_t best_function = Function::BindFunction(func.name, func.functions, arguments);
 	// found a matching function!
 	auto &bound_function = func.functions[best_function];
 	// check if we need to add casts to the children

--- a/src/function/scalar/math/random.cpp
+++ b/src/function/scalar/math/random.cpp
@@ -32,8 +32,7 @@ static void random_function(DataChunk &args, ExpressionState &state, Vector &res
 	}
 
 	auto result_data = (double *)result.GetData();
-	VectorOperations::Exec(result,
-	                       [&](index_t i, index_t k) { result_data[i] = info.dist(info.context.random_engine); });
+	VectorOperations::Exec(result, [&](idx_t i, idx_t k) { result_data[i] = info.dist(info.context.random_engine); });
 }
 
 unique_ptr<FunctionData> random_bind(BoundFunctionExpression &expr, ClientContext &context) {

--- a/src/function/scalar/math/setseed.cpp
+++ b/src/function/scalar/math/setseed.cpp
@@ -30,7 +30,7 @@ static void setseed_function(DataChunk &args, ExpressionState &state, Vector &re
 
 	auto input_seeds = (double *)input.GetData();
 	uint32_t half_max = numeric_limits<uint32_t>::max() / 2;
-	VectorOperations::Exec(result, [&](index_t i, index_t k) {
+	VectorOperations::Exec(result, [&](idx_t i, idx_t k) {
 		if (input_seeds[i] < -1.0 || input_seeds[i] > 1.0) {
 			throw Exception("SETSEED accepts seed values between -1.0 and 1.0, inclusive");
 		}

--- a/src/function/scalar/sequence/nextval.cpp
+++ b/src/function/scalar/sequence/nextval.cpp
@@ -29,11 +29,11 @@ struct NextvalBindData : public FunctionData {
 };
 
 static void parse_schema_and_sequence(string input, string &schema, string &name) {
-	index_t start = 0;
+	idx_t start = 0;
 	for (const char *istr = input.c_str(); *istr; istr++) {
 		if (*istr == '.') {
 			// separator
-			index_t len = istr - input.c_str();
+			idx_t len = istr - input.c_str();
 			if (len == 0) {
 				throw ParserException("invalid name syntax");
 			}
@@ -100,7 +100,7 @@ static void nextval_function(DataChunk &args, ExpressionState &state, Vector &re
 		// sequence to use is hard coded
 		// increment the sequence
 		auto result_data = (int64_t *)result.GetData();
-		VectorOperations::Exec(result, [&](index_t i, index_t k) {
+		VectorOperations::Exec(result, [&](idx_t i, idx_t k) {
 			// get the next value from the sequence
 			result_data[i] = next_sequence_value(transaction, info.sequence);
 		});
@@ -108,7 +108,7 @@ static void nextval_function(DataChunk &args, ExpressionState &state, Vector &re
 		// sequence to use comes from the input
 		assert(result.count == input.count && result.sel_vector == input.sel_vector);
 		auto result_data = (int64_t *)result.GetData();
-		VectorOperations::ExecType<const char *>(input, [&](const char *value, index_t i, index_t k) {
+		VectorOperations::ExecType<const char *>(input, [&](const char *value, idx_t i, idx_t k) {
 			// first get the sequence schema/name
 			string schema, seq;
 			string seqname = string(value);

--- a/src/function/scalar/string/caseconvert.cpp
+++ b/src/function/scalar/string/caseconvert.cpp
@@ -40,15 +40,15 @@ template <str_function CASE_FUNCTION> static void caseconvert_function(Vector &i
 	auto result_data = (const char **)result.GetData();
 	auto input_data = (const char **)input.GetData();
 
-	index_t current_len = 0;
+	idx_t current_len = 0;
 	unique_ptr<char[]> output;
-	VectorOperations::Exec(input, [&](index_t i, index_t k) {
+	VectorOperations::Exec(input, [&](idx_t i, idx_t k) {
 		if (input.nullmask[i]) {
 			return;
 		}
 		// if (!has_stats) {
 		// no stats available, might need to reallocate
-		index_t required_len = strlen(input_data[i]) + 1;
+		idx_t required_len = strlen(input_data[i]) + 1;
 		if (required_len > current_len) {
 			current_len = required_len + 1;
 			output = unique_ptr<char[]>{new char[current_len]};

--- a/src/function/scalar/string/concat.cpp
+++ b/src/function/scalar/string/concat.cpp
@@ -17,7 +17,7 @@ static void concat_function(DataChunk &args, ExpressionState &state, Vector &res
 	result.sel_vector = args.data[0].sel_vector;
 	result.count = args.data[0].count;
 	// iterate over the vectors to check if the result is a constant vector or not
-	for (index_t col_idx = 0; col_idx < args.column_count; col_idx++) {
+	for (idx_t col_idx = 0; col_idx < args.column_count; col_idx++) {
 		auto &input = args.data[col_idx];
 		assert(input.type == TypeId::VARCHAR);
 		if (input.vector_type != VectorType::CONSTANT_VECTOR) {
@@ -30,7 +30,7 @@ static void concat_function(DataChunk &args, ExpressionState &state, Vector &res
 
 	// now perform the actual concatenation
 	vector<string> results(result.count);
-	for (index_t col_idx = 0; col_idx < args.column_count; col_idx++) {
+	for (idx_t col_idx = 0; col_idx < args.column_count; col_idx++) {
 		auto &input = args.data[col_idx];
 		auto input_data = (const char **)input.GetData();
 		assert(input.vector_type == VectorType::FLAT_VECTOR || input.vector_type == VectorType::CONSTANT_VECTOR);
@@ -41,10 +41,10 @@ static void concat_function(DataChunk &args, ExpressionState &state, Vector &res
 				// constant null, skip
 				continue;
 			}
-			VectorOperations::Exec(result, [&](index_t i, index_t k) { results[k] += input_data[0]; });
+			VectorOperations::Exec(result, [&](idx_t i, idx_t k) { results[k] += input_data[0]; });
 		} else {
 			// standard vector
-			VectorOperations::Exec(result, [&](index_t i, index_t k) {
+			VectorOperations::Exec(result, [&](idx_t i, idx_t k) {
 				// ignore null entries
 				if (input.nullmask[i]) {
 					return;
@@ -55,7 +55,7 @@ static void concat_function(DataChunk &args, ExpressionState &state, Vector &res
 	}
 	// now write the final result to the result vector and add the strings to the heap
 	auto result_data = (const char **)result.GetData();
-	VectorOperations::Exec(result, [&](index_t i, index_t k) { result_data[i] = result.AddString(results[k]); });
+	VectorOperations::Exec(result, [&](idx_t i, idx_t k) { result_data[i] = result.AddString(results[k]); });
 }
 
 static void concat_operator(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -69,7 +69,7 @@ static void concat_operator(DataChunk &args, ExpressionState &state, Vector &res
 static void concat_ws_constant_sep(DataChunk &args, Vector &result, vector<string> &results, string sep) {
 	// now perform the actual concatenation
 	vector<bool> has_results(result.count, false);
-	for (index_t col_idx = 1; col_idx < args.column_count; col_idx++) {
+	for (idx_t col_idx = 1; col_idx < args.column_count; col_idx++) {
 		auto &input = args.data[col_idx];
 		auto input_data = (const char **)input.GetData();
 		assert(input.vector_type == VectorType::FLAT_VECTOR || input.vector_type == VectorType::CONSTANT_VECTOR);
@@ -80,7 +80,7 @@ static void concat_ws_constant_sep(DataChunk &args, Vector &result, vector<strin
 				// constant null, skip
 				continue;
 			}
-			VectorOperations::Exec(result, [&](index_t i, index_t k) {
+			VectorOperations::Exec(result, [&](idx_t i, idx_t k) {
 				if (has_results[k]) {
 					results[k] += sep;
 				}
@@ -89,7 +89,7 @@ static void concat_ws_constant_sep(DataChunk &args, Vector &result, vector<strin
 			});
 		} else {
 			// standard vector
-			VectorOperations::Exec(result, [&](index_t i, index_t k) {
+			VectorOperations::Exec(result, [&](idx_t i, idx_t k) {
 				// ignore null entries
 				if (input.nullmask[i]) {
 					return;
@@ -108,7 +108,7 @@ static void concat_ws_variable_sep(DataChunk &args, Vector &result, vector<strin
 	auto sep_data = (const char **)separator.GetData();
 	// now perform the actual concatenation
 	vector<bool> has_results(result.count, false);
-	for (index_t col_idx = 1; col_idx < args.column_count; col_idx++) {
+	for (idx_t col_idx = 1; col_idx < args.column_count; col_idx++) {
 		auto &input = args.data[col_idx];
 		auto input_data = (const char **)input.GetData();
 		assert(input.vector_type == VectorType::FLAT_VECTOR || input.vector_type == VectorType::CONSTANT_VECTOR);
@@ -119,7 +119,7 @@ static void concat_ws_variable_sep(DataChunk &args, Vector &result, vector<strin
 				// constant null, skip
 				continue;
 			}
-			VectorOperations::Exec(result, [&](index_t i, index_t k) {
+			VectorOperations::Exec(result, [&](idx_t i, idx_t k) {
 				if (separator.nullmask[i]) {
 					return;
 				}
@@ -131,7 +131,7 @@ static void concat_ws_variable_sep(DataChunk &args, Vector &result, vector<strin
 			});
 		} else {
 			// standard vector
-			VectorOperations::Exec(result, [&](index_t i, index_t k) {
+			VectorOperations::Exec(result, [&](idx_t i, idx_t k) {
 				// ignore null entries
 				if (input.nullmask[i] || separator.nullmask[i]) {
 					return;
@@ -154,7 +154,7 @@ static void concat_ws_function(DataChunk &args, ExpressionState &state, Vector &
 	result.sel_vector = args.data[0].sel_vector;
 	result.count = args.data[0].count;
 	// iterate over the vectors to check the result vector type
-	for (index_t col_idx = 0; col_idx < args.column_count; col_idx++) {
+	for (idx_t col_idx = 0; col_idx < args.column_count; col_idx++) {
 		auto &input = args.data[col_idx];
 		assert(input.type == TypeId::VARCHAR);
 		if (input.vector_type != VectorType::CONSTANT_VECTOR) {
@@ -186,7 +186,7 @@ static void concat_ws_function(DataChunk &args, ExpressionState &state, Vector &
 
 	// now write the final result to the result vector and add the strings to the heap
 	auto result_data = (const char **)result.GetData();
-	VectorOperations::Exec(result, [&](index_t i, index_t k) { result_data[i] = result.AddString(results[k]); });
+	VectorOperations::Exec(result, [&](idx_t i, idx_t k) { result_data[i] = result.AddString(results[k]); });
 }
 
 void ConcatFun::RegisterFunction(BuiltinFunctions &set) {

--- a/src/function/scalar/string/length.cpp
+++ b/src/function/scalar/string/length.cpp
@@ -10,7 +10,7 @@ namespace duckdb {
 struct StringLengthOperator {
 	template <class TA, class TR> static inline TR Operation(TA input) {
 		int64_t length = 0;
-		for (index_t str_idx = 0; input[str_idx]; str_idx++) {
+		for (idx_t str_idx = 0; input[str_idx]; str_idx++) {
 			length += (input[str_idx] & 0xC0) != 0x80;
 		}
 		return length;

--- a/src/function/scalar/string/substring.cpp
+++ b/src/function/scalar/string/substring.cpp
@@ -9,7 +9,7 @@ using namespace std;
 namespace duckdb {
 
 static const char *substring_scalar_function(const char *input_string, int offset, int length,
-                                             unique_ptr<char[]> &output, index_t &current_len) {
+                                             unique_ptr<char[]> &output, idx_t &current_len) {
 	// reduce offset by one because SQL starts counting at 1
 	offset--;
 
@@ -17,7 +17,7 @@ static const char *substring_scalar_function(const char *input_string, int offse
 		throw Exception("SUBSTRING cannot handle negative offsets");
 	}
 
-	index_t required_len = strlen(input_string) + 1;
+	idx_t required_len = strlen(input_string) + 1;
 	if (required_len > current_len) {
 		// need a resize
 		current_len = required_len;
@@ -25,17 +25,17 @@ static const char *substring_scalar_function(const char *input_string, int offse
 	}
 
 	// UTF8 chars can use more than one byte
-	index_t input_char_offset = 0;
-	index_t input_byte_offset = 0;
-	index_t output_byte_offset = 0;
+	idx_t input_char_offset = 0;
+	idx_t input_byte_offset = 0;
+	idx_t output_byte_offset = 0;
 
 	while (input_string[input_byte_offset]) {
 		char b = input_string[input_byte_offset++];
 		input_char_offset += (b & 0xC0) != 0x80;
-		if (input_char_offset > (index_t)(offset + length)) {
+		if (input_char_offset > (idx_t)(offset + length)) {
 			break;
 		}
-		if (input_char_offset > (index_t)offset) {
+		if (input_char_offset > (idx_t)offset) {
 			output[output_byte_offset++] = b;
 		}
 	}
@@ -51,7 +51,7 @@ static void substring_function(DataChunk &args, ExpressionState &state, Vector &
 	auto &offset_vector = args.data[1];
 	auto &length_vector = args.data[2];
 
-	index_t current_len = 0;
+	idx_t current_len = 0;
 	unique_ptr<char[]> output;
 	TernaryExecutor::Execute<const char *, int, int, const char *, true>(
 	    input_vector, offset_vector, length_vector, result, [&](const char *input_string, int offset, int length) {

--- a/src/function/scalar/struct/extract.cpp
+++ b/src/function/scalar/struct/extract.cpp
@@ -11,13 +11,13 @@ static void struct_extract_fun(DataChunk &input, ExpressionState &state, Vector 
 
 	// this should be guaranteed by the binder
 	assert(input.column_count == 1);
-	auto& vec = input.data[0];
+	auto &vec = input.data[0];
 
 	if (info.index >= vec.GetChildren().size()) {
 		throw Exception("Not enough struct entries for struct_extract");
 	}
 
-	auto& child = vec.GetChildren()[info.index];
+	auto &child = vec.GetChildren()[info.index];
 	if (child.first != info.key || child.second->type != info.type) {
 		throw Exception("Struct key or type mismatch");
 	}
@@ -25,13 +25,12 @@ static void struct_extract_fun(DataChunk &input, ExpressionState &state, Vector 
 	assert(result.count == vec.count);
 }
 
-
 static unique_ptr<FunctionData> struct_extract_bind(BoundFunctionExpression &expr, ClientContext &context) {
 	// the binder should fix this for us.
 	assert(expr.children.size() == 2);
 	assert(expr.arguments.size() == expr.children.size());
 
-	auto& struct_child = expr.children[0];
+	auto &struct_child = expr.children[0];
 
 	assert(expr.arguments[0].id == SQLTypeId::STRUCT);
 	assert(struct_child->return_type == TypeId::STRUCT);
@@ -39,11 +38,10 @@ static unique_ptr<FunctionData> struct_extract_bind(BoundFunctionExpression &exp
 		throw Exception("Can't extract something from an empty struct");
 	}
 
-	auto& key_child = expr.children[1];
+	auto &key_child = expr.children[1];
 
-
-	if (expr.arguments[1].id != SQLTypeId::VARCHAR ||
-			key_child->return_type != TypeId::VARCHAR || !key_child->IsScalar()) {
+	if (expr.arguments[1].id != SQLTypeId::VARCHAR || key_child->return_type != TypeId::VARCHAR ||
+	    !key_child->IsScalar()) {
 		throw Exception("Key name for struct_extract needs to be a constant string");
 	}
 	Value key_val = ExpressionExecutor::EvaluateScalar(*key_child.get());
@@ -54,11 +52,11 @@ static unique_ptr<FunctionData> struct_extract_bind(BoundFunctionExpression &exp
 	string key = StringUtil::Lower(key_val.str_value);
 
 	SQLType return_type;
-	index_t key_index = 0;
+	idx_t key_index = 0;
 	bool found_key = false;
 
 	for (size_t i = 0; i < expr.arguments[0].child_type.size(); i++) {
-		auto& child = expr.arguments[0].child_type[i];
+		auto &child = expr.arguments[0].child_type[i];
 		if (child.first == key) {
 			found_key = true;
 			key_index = i;
@@ -78,7 +76,8 @@ static unique_ptr<FunctionData> struct_extract_bind(BoundFunctionExpression &exp
 
 void StructExtractFun::RegisterFunction(BuiltinFunctions &set) {
 	// the arguments and return types are actually set in the binder function
-	ScalarFunction fun("struct_extract", {SQLType::STRUCT, SQLType::VARCHAR}, SQLType::ANY, struct_extract_fun, false, struct_extract_bind);
+	ScalarFunction fun("struct_extract", {SQLType::STRUCT, SQLType::VARCHAR}, SQLType::ANY, struct_extract_fun, false,
+	                   struct_extract_bind);
 	set.AddFunction(fun);
 }
 

--- a/src/function/scalar/struct/pack.cpp
+++ b/src/function/scalar/struct/pack.cpp
@@ -33,16 +33,16 @@ static void struct_pack_fun(DataChunk &input, ExpressionState &state, Vector &re
 }
 
 static unique_ptr<FunctionData> struct_pack_bind(BoundFunctionExpression &expr, ClientContext &context) {
-	SQLType stype (SQLTypeId::STRUCT);
+	SQLType stype(SQLTypeId::STRUCT);
 	set<string> name_collision_set;
 
 	// collect names and deconflict, construct return type
 	assert(expr.arguments.size() == expr.children.size());
 
-	if (expr.arguments.size()  == 0) {
+	if (expr.arguments.size() == 0) {
 		throw Exception("Can't pack nothing into a struct");
 	}
-	for (index_t i = 0; i < expr.children.size(); i++) {
+	for (idx_t i = 0; i < expr.children.size(); i++) {
 		auto &child = expr.children[i];
 		if (child->alias.size() == 0) {
 			throw Exception("Need named argument for struct pack, e.g. STRUCT_PACK(a := b)");
@@ -58,7 +58,6 @@ static unique_ptr<FunctionData> struct_pack_bind(BoundFunctionExpression &expr, 
 	expr.sql_return_type = stype;
 	return make_unique<StructPackBindData>(stype);
 }
-
 
 void StructPackFun::RegisterFunction(BuiltinFunctions &set) {
 	// the arguments and return types are actually set in the binder function

--- a/src/function/table/sqlite/pragma_table_info.cpp
+++ b/src/function/table/sqlite/pragma_table_info.cpp
@@ -17,7 +17,7 @@ struct PragmaTableFunctionData : public TableFunctionData {
 	}
 
 	TableCatalogEntry *entry;
-	index_t offset;
+	idx_t offset;
 };
 
 FunctionData *pragma_table_info_init(ClientContext &context) {
@@ -47,18 +47,18 @@ void pragma_table_info(ClientContext &context, DataChunk &input, DataChunk &outp
 	}
 	// start returning values
 	// either fill up the chunk or return all the remaining columns
-	index_t next = min(data.offset + STANDARD_VECTOR_SIZE, (index_t)data.entry->columns.size());
-	index_t output_count = next - data.offset;
-	for (index_t j = 0; j < output.column_count; j++) {
+	idx_t next = min(data.offset + STANDARD_VECTOR_SIZE, (idx_t)data.entry->columns.size());
+	idx_t output_count = next - data.offset;
+	for (idx_t j = 0; j < output.column_count; j++) {
 		output.data[j].count = output_count;
 	}
 
-	for (index_t i = data.offset; i < next; i++) {
+	for (idx_t i = data.offset; i < next; i++) {
 		auto index = i - data.offset;
 		auto &column = data.entry->columns[i];
 		// return values:
 		// "cid", TypeId::INT32
-		assert(column.oid < (index_t)std::numeric_limits<int32_t>::max());
+		assert(column.oid < (idx_t)std::numeric_limits<int32_t>::max());
 
 		output.data[0].SetValue(index, Value::INTEGER((int32_t)column.oid));
 		// "name", TypeId::VARCHAR

--- a/src/function/table/sqlite/sqlite_master.cpp
+++ b/src/function/table/sqlite/sqlite_master.cpp
@@ -19,7 +19,7 @@ struct SQLiteMasterData : public TableFunctionData {
 
 	bool initialized;
 	vector<CatalogEntry *> entries;
-	index_t offset;
+	idx_t offset;
 };
 
 FunctionData *sqlite_master_init(ClientContext &context) {
@@ -35,7 +35,7 @@ string GenerateQuery(CatalogEntry *entry) {
 		auto table = (TableCatalogEntry *)entry;
 		ss << "CREATE TABLE " << table->name << "(";
 
-		for (index_t i = 0; i < table->columns.size(); i++) {
+		for (idx_t i = 0; i < table->columns.size(); i++) {
 			auto &column = table->columns[i];
 			ss << column.name << " " << SQLTypeToString(column.type);
 			if (i + 1 < table->columns.size()) {
@@ -66,15 +66,15 @@ void sqlite_master(ClientContext &context, DataChunk &input, DataChunk &output, 
 		// finished returning values
 		return;
 	}
-	index_t next = min(data.offset + STANDARD_VECTOR_SIZE, (index_t)data.entries.size());
+	idx_t next = min(data.offset + STANDARD_VECTOR_SIZE, (idx_t)data.entries.size());
 
-	index_t output_count = next - data.offset;
-	for (index_t j = 0; j < output.column_count; j++) {
+	idx_t output_count = next - data.offset;
+	for (idx_t j = 0; j < output.column_count; j++) {
 		output.data[j].count = output_count;
 	}
 	// start returning values
 	// either fill up the chunk or return all the remaining columns
-	for (index_t i = data.offset; i < next; i++) {
+	for (idx_t i = data.offset; i < next; i++) {
 		auto index = i - data.offset;
 		auto &entry = data.entries[i];
 

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-typedef uint64_t index_t;
+typedef uint64_t idx_t;
 
 typedef enum DUCKDB_TYPE {
 	DUCKDB_TYPE_INVALID = 0,
@@ -72,8 +72,8 @@ typedef struct {
 } duckdb_column;
 
 typedef struct {
-	index_t column_count;
-	index_t row_count;
+	idx_t column_count;
+	idx_t row_count;
 	duckdb_column *columns;
 	char *error_message;
 } duckdb_result;
@@ -116,21 +116,21 @@ void duckdb_destroy_result(duckdb_result *result);
 // value is returned.
 
 //! Converts the specified value to a bool. Returns false on failure or NULL.
-bool duckdb_value_boolean(duckdb_result *result, index_t col, index_t row);
+bool duckdb_value_boolean(duckdb_result *result, idx_t col, idx_t row);
 //! Converts the specified value to an int8_t. Returns 0 on failure or NULL.
-int8_t duckdb_value_int8(duckdb_result *result, index_t col, index_t row);
+int8_t duckdb_value_int8(duckdb_result *result, idx_t col, idx_t row);
 //! Converts the specified value to an int16_t. Returns 0 on failure or NULL.
-int16_t duckdb_value_int16(duckdb_result *result, index_t col, index_t row);
+int16_t duckdb_value_int16(duckdb_result *result, idx_t col, idx_t row);
 //! Converts the specified value to an int64_t. Returns 0 on failure or NULL.
-int32_t duckdb_value_int32(duckdb_result *result, index_t col, index_t row);
+int32_t duckdb_value_int32(duckdb_result *result, idx_t col, idx_t row);
 //! Converts the specified value to an int64_t. Returns 0 on failure or NULL.
-int64_t duckdb_value_int64(duckdb_result *result, index_t col, index_t row);
+int64_t duckdb_value_int64(duckdb_result *result, idx_t col, idx_t row);
 //! Converts the specified value to a float. Returns 0.0 on failure or NULL.
-float duckdb_value_float(duckdb_result *result, index_t col, index_t row);
+float duckdb_value_float(duckdb_result *result, idx_t col, idx_t row);
 //! Converts the specified value to a double. Returns 0.0 on failure or NULL.
-double duckdb_value_double(duckdb_result *result, index_t col, index_t row);
+double duckdb_value_double(duckdb_result *result, idx_t col, idx_t row);
 //! Converts the specified value to a string. Returns nullptr on failure or NULL. The result must be freed with free.
-char *duckdb_value_varchar(duckdb_result *result, index_t col, index_t row);
+char *duckdb_value_varchar(duckdb_result *result, idx_t col, idx_t row);
 
 // Prepared Statements
 
@@ -138,18 +138,18 @@ char *duckdb_value_varchar(duckdb_result *result, index_t col, index_t row);
 duckdb_state duckdb_prepare(duckdb_connection connection, const char *query,
                             duckdb_prepared_statement *out_prepared_statement);
 
-duckdb_state duckdb_nparams(duckdb_prepared_statement prepared_statement, index_t *nparams_out);
+duckdb_state duckdb_nparams(duckdb_prepared_statement prepared_statement, idx_t *nparams_out);
 
 //! binds parameters to prepared statement
-duckdb_state duckdb_bind_boolean(duckdb_prepared_statement prepared_statement, index_t param_idx, bool val);
-duckdb_state duckdb_bind_int8(duckdb_prepared_statement prepared_statement, index_t param_idx, int8_t val);
-duckdb_state duckdb_bind_int16(duckdb_prepared_statement prepared_statement, index_t param_idx, int16_t val);
-duckdb_state duckdb_bind_int32(duckdb_prepared_statement prepared_statement, index_t param_idx, int32_t val);
-duckdb_state duckdb_bind_int64(duckdb_prepared_statement prepared_statement, index_t param_idx, int64_t val);
-duckdb_state duckdb_bind_float(duckdb_prepared_statement prepared_statement, index_t param_idx, float val);
-duckdb_state duckdb_bind_double(duckdb_prepared_statement prepared_statement, index_t param_idx, double val);
-duckdb_state duckdb_bind_varchar(duckdb_prepared_statement prepared_statement, index_t param_idx, const char *val);
-duckdb_state duckdb_bind_null(duckdb_prepared_statement prepared_statement, index_t param_idx);
+duckdb_state duckdb_bind_boolean(duckdb_prepared_statement prepared_statement, idx_t param_idx, bool val);
+duckdb_state duckdb_bind_int8(duckdb_prepared_statement prepared_statement, idx_t param_idx, int8_t val);
+duckdb_state duckdb_bind_int16(duckdb_prepared_statement prepared_statement, idx_t param_idx, int16_t val);
+duckdb_state duckdb_bind_int32(duckdb_prepared_statement prepared_statement, idx_t param_idx, int32_t val);
+duckdb_state duckdb_bind_int64(duckdb_prepared_statement prepared_statement, idx_t param_idx, int64_t val);
+duckdb_state duckdb_bind_float(duckdb_prepared_statement prepared_statement, idx_t param_idx, float val);
+duckdb_state duckdb_bind_double(duckdb_prepared_statement prepared_statement, idx_t param_idx, double val);
+duckdb_state duckdb_bind_varchar(duckdb_prepared_statement prepared_statement, idx_t param_idx, const char *val);
+duckdb_state duckdb_bind_null(duckdb_prepared_statement prepared_statement, idx_t param_idx);
 
 //! Executes the prepared statements with currently bound parameters
 duckdb_state duckdb_execute_prepared(duckdb_prepared_statement prepared_statement, duckdb_result *out_result);

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -37,7 +37,7 @@ public:
 		return new (ptr) T(std::forward<Args>(args)...);
 	}
 
-	char *allocate(index_t size) {
+	char *allocate(idx_t size) {
 		if (chunk && chunk->current_position + size < chunk->maximum_size) {
 			auto ptr = chunk->data.get() + chunk->current_position;
 			chunk->current_position += size;
@@ -69,12 +69,12 @@ public:
 
 private:
 	struct AllocatorRegion {
-		AllocatorRegion(index_t size) : current_position(0), maximum_size(size) {
+		AllocatorRegion(idx_t size) : current_position(0), maximum_size(size) {
 			data = unique_ptr<char[]>(new char[maximum_size]);
 		}
 		unique_ptr<char[]> data;
-		index_t current_position;
-		index_t maximum_size;
+		idx_t current_position;
+		idx_t maximum_size;
 		unique_ptr<AllocatorRegion> prev;
 	};
 	unique_ptr<AllocatorRegion> chunk;

--- a/src/include/duckdb/common/constants.hpp
+++ b/src/include/duckdb/common/constants.hpp
@@ -36,13 +36,13 @@ using std::vector;
 #define STORAGE_CHUNK_SIZE (STANDARD_VECTOR_SIZE * STORAGE_CHUNK_VECTORS)
 
 //! a saner size_t for loop indices etc
-typedef uint64_t index_t;
+typedef uint64_t idx_t;
 
 //! The type used for row identifiers
 typedef int64_t row_t;
 
 //! The value used to signify an invalid index entry
-extern const index_t INVALID_INDEX;
+extern const idx_t INVALID_INDEX;
 
 //! data pointers
 typedef uint8_t data_t;
@@ -58,10 +58,10 @@ typedef int64_t timestamp_t;
 //! Type used for the selection vector
 typedef uint16_t sel_t;
 //! Type used for transaction timestamps
-typedef index_t transaction_t;
+typedef idx_t transaction_t;
 
 //! Type used for column identifiers
-typedef index_t column_t;
+typedef idx_t column_t;
 //! Special value used to signify the ROW ID of a table
 extern const column_t COLUMN_IDENTIFIER_ROW_ID;
 

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -114,7 +114,7 @@ class ValueOutOfRangeException : public Exception {
 public:
 	ValueOutOfRangeException(const int64_t value, const TypeId origType, const TypeId newType);
 	ValueOutOfRangeException(const double value, const TypeId origType, const TypeId newType);
-	ValueOutOfRangeException(const TypeId varType, const index_t length);
+	ValueOutOfRangeException(const TypeId varType, const idx_t length);
 };
 
 class ConversionException : public Exception {

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -24,8 +24,8 @@ public:
 	virtual ~FileHandle() {
 	}
 
-	void Read(void *buffer, index_t nr_bytes, index_t location);
-	void Write(void *buffer, index_t nr_bytes, index_t location);
+	void Read(void *buffer, idx_t nr_bytes, idx_t location);
+	void Write(void *buffer, idx_t nr_bytes, idx_t location);
 	void Sync();
 	void Truncate(int64_t new_size);
 
@@ -65,10 +65,10 @@ public:
 	}
 	//! Read exactly nr_bytes from the specified location in the file. Fails if nr_bytes could not be read. This is
 	//! equivalent to calling SetFilePointer(location) followed by calling Read().
-	virtual void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, index_t location);
+	virtual void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location);
 	//! Write exactly nr_bytes to the specified location in the file. Fails if nr_bytes could not be read. This is
 	//! equivalent to calling SetFilePointer(location) followed by calling Write().
-	virtual void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, index_t location);
+	virtual void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location);
 	//! Read nr_bytes from the specified file into the buffer, moving the file pointer forward by nr_bytes. Returns the
 	//! amount of bytes read.
 	virtual int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes);
@@ -105,7 +105,7 @@ public:
 
 private:
 	//! Set the file pointer of a file handle to a specified location. Reads and writes will happen from this location
-	void SetFilePointer(FileHandle &handle, index_t location);
+	void SetFilePointer(FileHandle &handle, idx_t location);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/fstream_util.hpp
+++ b/src/include/duckdb/common/fstream_util.hpp
@@ -32,7 +32,7 @@ public:
 	/**
 	 * Returns the size in bytes of the given file
 	 */
-	static index_t GetFileSize(fstream &);
+	static idx_t GetFileSize(fstream &);
 
 	/**
 	 * Reads the given file as a binary

--- a/src/include/duckdb/common/gzip_stream.hpp
+++ b/src/include/duckdb/common/gzip_stream.hpp
@@ -32,12 +32,12 @@ public:
 private:
 	void initialize();
 	std::fstream input;
-	index_t data_start = 0;
+	idx_t data_start = 0;
 	void *mz_stream_ptr = nullptr; // void* so we don't have to include the header
 	data_ptr_t in_buff = nullptr, in_buff_start, in_buff_end, out_buff = nullptr; // various buffers & pointers
 	bool is_initialized = false;
 	std::string filename;
-	index_t BUFFER_SIZE = 1024;
+	idx_t BUFFER_SIZE = 1024;
 };
 
 class GzipStream : public std::istream {

--- a/src/include/duckdb/common/serializer.hpp
+++ b/src/include/duckdb/common/serializer.hpp
@@ -19,7 +19,7 @@ public:
 	virtual ~Serializer() {
 	}
 
-	virtual void WriteData(const_data_ptr_t buffer, index_t write_size) = 0;
+	virtual void WriteData(const_data_ptr_t buffer, idx_t write_size) = 0;
 
 	template <class T> void Write(T element) {
 		WriteData((const_data_ptr_t)&element, sizeof(T));
@@ -57,7 +57,7 @@ public:
 	}
 
 	//! Reads [read_size] bytes into the buffer
-	virtual void ReadData(data_ptr_t buffer, index_t read_size) = 0;
+	virtual void ReadData(data_ptr_t buffer, idx_t read_size) = 0;
 
 	template <class T> T Read() {
 		T value;

--- a/src/include/duckdb/common/serializer/buffered_deserializer.hpp
+++ b/src/include/duckdb/common/serializer/buffered_deserializer.hpp
@@ -15,7 +15,7 @@ namespace duckdb {
 
 class BufferedDeserializer : public Deserializer {
 public:
-	BufferedDeserializer(data_ptr_t ptr, index_t data_size);
+	BufferedDeserializer(data_ptr_t ptr, idx_t data_size);
 	BufferedDeserializer(BufferedSerializer &serializer);
 
 	data_ptr_t ptr;

--- a/src/include/duckdb/common/serializer/buffered_file_reader.hpp
+++ b/src/include/duckdb/common/serializer/buffered_file_reader.hpp
@@ -18,8 +18,8 @@ public:
 
 	FileSystem &fs;
 	unique_ptr<data_t[]> data;
-	index_t offset;
-	index_t read_data;
+	idx_t offset;
+	idx_t read_data;
 	unique_ptr<FileHandle> handle;
 
 public:
@@ -27,13 +27,13 @@ public:
 	//! Returns true if the reader has finished reading the entire file
 	bool Finished();
 
-	index_t FileSize() {
+	idx_t FileSize() {
 		return file_size;
 	}
 
 private:
-	index_t file_size;
-	index_t total_read;
+	idx_t file_size;
+	idx_t total_read;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/serializer/buffered_file_writer.hpp
+++ b/src/include/duckdb/common/serializer/buffered_file_writer.hpp
@@ -23,7 +23,7 @@ public:
 
 	FileSystem &fs;
 	unique_ptr<data_t[]> data;
-	index_t offset;
+	idx_t offset;
 	unique_ptr<FileHandle> handle;
 
 public:

--- a/src/include/duckdb/common/serializer/buffered_serializer.hpp
+++ b/src/include/duckdb/common/serializer/buffered_serializer.hpp
@@ -16,18 +16,18 @@ namespace duckdb {
 
 struct BinaryData {
 	unique_ptr<data_t[]> data;
-	index_t size;
+	idx_t size;
 };
 
 class BufferedSerializer : public Serializer {
 public:
 	//! Serializes to a buffer allocated by the serializer, will expand when
 	//! writing past the initial threshold
-	BufferedSerializer(index_t maximum_size = SERIALIZER_DEFAULT_SIZE);
+	BufferedSerializer(idx_t maximum_size = SERIALIZER_DEFAULT_SIZE);
 	//! Serializes to a provided (owned) data pointer
-	BufferedSerializer(unique_ptr<data_t[]> data, index_t size);
+	BufferedSerializer(unique_ptr<data_t[]> data, idx_t size);
 
-	index_t maximum_size;
+	idx_t maximum_size;
 	data_ptr_t data;
 
 	BinaryData blob;

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -30,7 +30,7 @@ public:
 	static bool EndsWith(const string &str, const string &suffix);
 
 	//! Repeat a string multiple times
-	static string Repeat(const string &str, const index_t n);
+	static string Repeat(const string &str, const idx_t n);
 
 	//! Split the input string based on newline char
 	static vector<string> Split(const string &str, char delimiter);
@@ -63,7 +63,7 @@ public:
 	static string Prefix(const string &str, const string &prefix);
 
 	//! Return a string that formats the give number of bytes
-	static string FormatSize(index_t bytes);
+	static string FormatSize(idx_t bytes);
 
 	//! Convert a string to uppercase
 	static string Upper(const string &str);

--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -20,7 +20,7 @@ class Deserializer;
 
 struct blob_t {
 	data_ptr_t data;
-	index_t size;
+	idx_t size;
 };
 
 struct string_t {
@@ -32,8 +32,7 @@ struct string_t {
 	uint32_t length;
 };
 
-template <class T>
-using child_list_t = std::vector<std::pair<std::string, T>>;
+template <class T> using child_list_t = std::vector<std::pair<std::string, T>>;
 
 struct list_entry_t {
 	list_entry_t() = default;
@@ -241,7 +240,6 @@ public:
 	static const SQLType LIST;
 	static const SQLType ANY;
 
-
 	//! A list of all NUMERIC types (integral and floating point types)
 	static const vector<SQLType> NUMERIC;
 	//! A list of all INTEGRAL types
@@ -293,7 +291,7 @@ template <class T> bool IsValidType() {
 extern const TypeId ROW_TYPE;
 
 string TypeIdToString(TypeId type);
-index_t GetTypeIdSize(TypeId type);
+idx_t GetTypeIdSize(TypeId type);
 bool TypeIsConstantSize(TypeId type);
 bool TypeIsIntegral(TypeId type);
 bool TypeIsNumeric(TypeId type);

--- a/src/include/duckdb/common/types/chunk_collection.hpp
+++ b/src/include/duckdb/common/types/chunk_collection.hpp
@@ -27,14 +27,14 @@ public:
 	}
 
 	//! The total amount of elements in the collection
-	index_t count;
+	idx_t count;
 	//! The set of data chunks in the collection
 	vector<unique_ptr<DataChunk>> chunks;
 	//! The types of the ChunkCollection
 	vector<TypeId> types;
 
 	//! The amount of columns in the ChunkCollection
-	index_t column_count() {
+	idx_t column_count() {
 		return types.size();
 	}
 
@@ -42,11 +42,11 @@ public:
 	void Append(DataChunk &new_chunk);
 
 	//! Gets the value of the column at the specified index
-	Value GetValue(index_t column, index_t index);
+	Value GetValue(idx_t column, idx_t index);
 	//! Sets the value of the column at the specified index
-	void SetValue(index_t column, index_t index, Value value);
+	void SetValue(idx_t column, idx_t index, Value value);
 
-	vector<Value> GetRow(index_t index);
+	vector<Value> GetRow(idx_t index);
 
 	string ToString() const {
 		return chunks.size() == 0 ? "ChunkCollection [ 0 ]"
@@ -55,27 +55,27 @@ public:
 	void Print();
 
 	//! Gets a reference to the chunk at the given index
-	DataChunk &GetChunk(index_t index) {
+	DataChunk &GetChunk(idx_t index) {
 		return *chunks[LocateChunk(index)];
 	}
 
-	void Sort(vector<OrderType> &desc, index_t result[]);
+	void Sort(vector<OrderType> &desc, idx_t result[]);
 	//! Reorders the rows in the collection according to the given indices. NB: order is changed!
-	void Reorder(index_t order[]);
+	void Reorder(idx_t order[]);
 
-	void MaterializeSortedChunk(DataChunk &target, index_t order[], index_t start_offset);
+	void MaterializeSortedChunk(DataChunk &target, idx_t order[], idx_t start_offset);
 
 	//! Returns true if the ChunkCollections are equivalent
 	bool Equals(ChunkCollection &other);
 
 	//! Locates the chunk that belongs to the specific index
-	index_t LocateChunk(index_t index) {
-		index_t result = index / STANDARD_VECTOR_SIZE;
+	idx_t LocateChunk(idx_t index) {
+		idx_t result = index / STANDARD_VECTOR_SIZE;
 		assert(result < chunks.size());
 		return result;
 	}
 
-	void Heap(vector<OrderType> &desc, index_t heap[], index_t heap_size);
-	index_t MaterializeHeapChunk(DataChunk &target, index_t order[], index_t start_offset, index_t heap_size);
+	void Heap(vector<OrderType> &desc, idx_t heap[], idx_t heap_size);
+	idx_t MaterializeHeapChunk(DataChunk &target, idx_t order[], idx_t start_offset, idx_t heap_size);
 };
 } // namespace duckdb

--- a/src/include/duckdb/common/types/data_chunk.hpp
+++ b/src/include/duckdb/common/types/data_chunk.hpp
@@ -39,7 +39,7 @@ public:
 	DataChunk();
 
 	//! The amount of vectors that are part of this DataChunk.
-	index_t column_count;
+	idx_t column_count;
 	//! The vectors owned by the DataChunk.
 	unique_ptr<Vector[]> data;
 	//! The (optional) selection vector of the DataChunk. Each of the member
@@ -49,7 +49,7 @@ public:
 	sel_t owned_sel_vector[STANDARD_VECTOR_SIZE];
 
 public:
-	index_t size() {
+	idx_t size() {
 		if (column_count == 0) {
 			return 0;
 		}
@@ -73,7 +73,7 @@ public:
 	void Move(DataChunk &other);
 
 	//! Copies the data from this vector to another vector.
-	void Copy(DataChunk &other, index_t offset = 0);
+	void Copy(DataChunk &other, idx_t offset = 0);
 
 	//! Removes the selection vector from the chunk
 	void Flatten();
@@ -105,7 +105,7 @@ public:
 	string ToString() const;
 	void Print();
 
-	Vector &GetVector(index_t index) {
+	Vector &GetVector(idx_t index) {
 		assert(index < column_count);
 		return data[index];
 	}

--- a/src/include/duckdb/common/types/hyperloglog.hpp
+++ b/src/include/duckdb/common/types/hyperloglog.hpp
@@ -21,13 +21,13 @@ public:
 	HyperLogLog(const HyperLogLog &) = delete;
 
 	//! Adds an element of the specified size to the HyperLogLog counter
-	void Add(data_ptr_t element, index_t size);
+	void Add(data_ptr_t element, idx_t size);
 	//! Return the count of this HyperLogLog counter
-	index_t Count();
+	idx_t Count();
 	//! Merge this HyperLogLog counter with another counter to create a new one
 	unique_ptr<HyperLogLog> Merge(HyperLogLog &other);
 	//! Merge a set of HyperLogLogs to create one big one
-	static unique_ptr<HyperLogLog> Merge(HyperLogLog logs[], index_t count);
+	static unique_ptr<HyperLogLog> Merge(HyperLogLog logs[], idx_t count);
 
 private:
 	HyperLogLog(void *hll);

--- a/src/include/duckdb/common/types/string_heap.hpp
+++ b/src/include/duckdb/common/types/string_heap.hpp
@@ -32,7 +32,7 @@ public:
 	}
 
 	//! Add a string to the string heap, returns a pointer to the string
-	const char *AddString(const char *data, index_t len);
+	const char *AddString(const char *data, idx_t len);
 	//! Add a string to the string heap, returns a pointer to the string
 	const char *AddString(const char *data);
 	//! Add a string to the string heap, returns a pointer to the string
@@ -42,7 +42,7 @@ public:
 
 private:
 	struct StringChunk {
-		StringChunk(index_t size) : current_position(0), maximum_size(size) {
+		StringChunk(idx_t size) : current_position(0), maximum_size(size) {
 			data = unique_ptr<char[]>(new char[maximum_size]);
 		}
 		~StringChunk() {
@@ -55,8 +55,8 @@ private:
 		}
 
 		unique_ptr<char[]> data;
-		index_t current_position;
-		index_t maximum_size;
+		idx_t current_position;
+		idx_t maximum_size;
 		unique_ptr<StringChunk> prev;
 	};
 	StringChunk *tail;

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -75,31 +75,30 @@ public:
 	//! The type of the elements stored in the vector (e.g. integer, float)
 	TypeId type;
 	//! The amount of elements in the vector.
-	index_t count;
+	idx_t count;
 	//! The selection vector of the vector.
 	sel_t *sel_vector;
 	//! The null mask of the vector, if the Vector has any NULL values
 	nullmask_t nullmask;
-
 
 public:
 	//! Create a vector that references the specified value.
 	void Reference(Value &value);
 
 	//! Returns the [index] element of the Vector as a Value.
-	Value GetValue(index_t index) const;
+	Value GetValue(idx_t index) const;
 	//! Sets the [index] element of the Vector to the specified Value
-	void SetValue(index_t index, Value val);
+	void SetValue(idx_t index, Value val);
 
 	//! Creates the data of this vector with the specified type. Any data that
 	//! is currently in the vector is destroyed.
-	void Initialize(TypeId new_type, bool zero_data = false, index_t count = STANDARD_VECTOR_SIZE);
+	void Initialize(TypeId new_type, bool zero_data = false, idx_t count = STANDARD_VECTOR_SIZE);
 	//! Casts the vector to the specified type
 	void Cast(TypeId new_type = TypeId::INVALID);
 	//! Appends the other vector to this vector.
 	void Append(Vector &other);
 	//! Copies the data from this vector to another vector.
-	void Copy(Vector &other, index_t offset = 0);
+	void Copy(Vector &other, idx_t offset = 0);
 	//! Flattens the vector, removing any selection vector
 	void Flatten();
 	//! Causes this vector to reference the data held by the other vector.
@@ -113,7 +112,7 @@ public:
 	void Normalify();
 
 	//! Turn the vector into a sequence vector
-	void Sequence(int64_t start, int64_t increment, index_t count);
+	void Sequence(int64_t start, int64_t increment, idx_t count);
 	//! Get the sequence attributes of a sequence vector
 	void GetSequence(int64_t &start, int64_t &increment) const;
 
@@ -126,7 +125,7 @@ public:
 	}
 
 	//! Add a string to the string heap of the vector (auxiliary data)
-	const char *AddString(const char *data, index_t len);
+	const char *AddString(const char *data, idx_t len);
 	//! Add a string to the string heap of the vector (auxiliary data)
 	const char *AddString(const char *data);
 	//! Add a string to the string heap of the vector (auxiliary data)
@@ -135,9 +134,8 @@ public:
 	//! Add a reference from this vector to the string heap of the provided vector
 	void AddHeapReference(Vector &other);
 
-	child_list_t<unique_ptr<Vector>>& GetChildren();
-	void AddChild(unique_ptr<Vector> vector, string name="");
-
+	child_list_t<unique_ptr<Vector>> &GetChildren();
+	void AddChild(unique_ptr<Vector> vector, string name = "");
 
 protected:
 	//! A pointer to the data.

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -27,7 +27,7 @@ class VectorBuffer {
 public:
 	VectorBuffer(VectorBufferType type) : type(type) {
 	}
-	VectorBuffer(index_t data_size);
+	VectorBuffer(idx_t data_size);
 	virtual ~VectorBuffer() {
 	}
 
@@ -38,7 +38,7 @@ public:
 		return data.get();
 	}
 
-	static buffer_ptr<VectorBuffer> CreateStandardVector(TypeId type, index_t count = STANDARD_VECTOR_SIZE);
+	static buffer_ptr<VectorBuffer> CreateStandardVector(TypeId type, idx_t count = STANDARD_VECTOR_SIZE);
 	static buffer_ptr<VectorBuffer> CreateConstantVector(TypeId type);
 
 private:
@@ -51,7 +51,7 @@ public:
 	VectorStringBuffer();
 
 public:
-	const char *AddString(const char *data, index_t len) {
+	const char *AddString(const char *data, idx_t len) {
 		return heap.AddString(data, len);
 	}
 

--- a/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
@@ -17,15 +17,15 @@ namespace duckdb {
 class AggregateExecutor {
 private:
 	template <class INPUT_TYPE, class RESULT_TYPE, class OP, bool HAS_SEL_VECTOR>
-	static inline bool ExecuteLoop(INPUT_TYPE *__restrict ldata, RESULT_TYPE *__restrict result, index_t count,
+	static inline bool ExecuteLoop(INPUT_TYPE *__restrict ldata, RESULT_TYPE *__restrict result, idx_t count,
 	                               sel_t *__restrict sel_vector, nullmask_t &nullmask) {
 		ASSERT_RESTRICT(ldata, ldata + count, result, result + 1);
 		if (nullmask.any()) {
 			// skip null values in the operation
-			index_t i = 0;
+			idx_t i = 0;
 			// find the first null value
 			for (; i < count; i++) {
-				index_t index = HAS_SEL_VECTOR ? sel_vector[i] : i;
+				idx_t index = HAS_SEL_VECTOR ? sel_vector[i] : i;
 				if (!nullmask[index]) {
 					*result = ldata[index];
 					break;
@@ -36,7 +36,7 @@ private:
 			}
 			// now perform the rest of the iteration
 			for (i++; i < count; i++) {
-				index_t index = HAS_SEL_VECTOR ? sel_vector[i] : i;
+				idx_t index = HAS_SEL_VECTOR ? sel_vector[i] : i;
 				if (!nullmask[index]) {
 					*result = OP::Operation(ldata[index], *result);
 				}
@@ -47,7 +47,7 @@ private:
 				return false;
 			}
 			*result = ldata[HAS_SEL_VECTOR ? sel_vector[0] : 0];
-			for (index_t i = 1; i < count; i++) {
+			for (idx_t i = 1; i < count; i++) {
 				*result = OP::Operation(ldata[HAS_SEL_VECTOR ? sel_vector[i] : i], *result);
 			}
 		}

--- a/src/include/duckdb/common/vector_operations/binary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/binary_executor.hpp
@@ -23,21 +23,21 @@ struct DefaultNullCheckOperator {
 
 struct BinaryStandardOperatorWrapper {
 	template <class FUNC, class OP, class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE>
-	static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, nullmask_t &nullmask, index_t idx) {
+	static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, nullmask_t &nullmask, idx_t idx) {
 		return OP::template Operation<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE>(left, right);
 	}
 };
 
 struct BinarySingleArgumentOperatorWrapper {
 	template <class FUNC, class OP, class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE>
-	static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, nullmask_t &nullmask, index_t idx) {
+	static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, nullmask_t &nullmask, idx_t idx) {
 		return OP::template Operation<LEFT_TYPE>(left, right);
 	}
 };
 
 struct BinaryLambdaWrapper {
 	template <class FUNC, class OP, class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE>
-	static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, nullmask_t &nullmask, index_t idx) {
+	static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, nullmask_t &nullmask, idx_t idx) {
 		return fun(left, right);
 	}
 };
@@ -47,7 +47,7 @@ private:
 	template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP, class FUNC,
 	          bool IGNORE_NULL, bool LEFT_CONSTANT, bool RIGHT_CONSTANT>
 	static void ExecuteLoop(LEFT_TYPE *__restrict ldata, RIGHT_TYPE *__restrict rdata,
-	                        RESULT_TYPE *__restrict result_data, index_t count, sel_t *__restrict sel_vector,
+	                        RESULT_TYPE *__restrict result_data, idx_t count, sel_t *__restrict sel_vector,
 	                        nullmask_t &nullmask, FUNC fun) {
 		if (!LEFT_CONSTANT) {
 			ASSERT_RESTRICT(ldata, ldata + count, result_data, result_data + count);
@@ -56,7 +56,7 @@ private:
 			ASSERT_RESTRICT(ldata, ldata + count, result_data, result_data + count);
 		}
 		if (IGNORE_NULL && nullmask.any()) {
-			VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
+			VectorOperations::Exec(sel_vector, count, [&](idx_t i, idx_t k) {
 				auto lentry = ldata[LEFT_CONSTANT ? 0 : i];
 				auto rentry = rdata[RIGHT_CONSTANT ? 0 : i];
 				if (!nullmask[i]) {
@@ -65,7 +65,7 @@ private:
 				}
 			});
 		} else {
-			VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
+			VectorOperations::Exec(sel_vector, count, [&](idx_t i, idx_t k) {
 				auto lentry = ldata[LEFT_CONSTANT ? 0 : i];
 				auto rentry = rdata[RIGHT_CONSTANT ? 0 : i];
 				result_data[i] = OPWRAPPER::template Operation<FUNC, OP, LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE>(
@@ -159,18 +159,17 @@ public:
 
 private:
 	template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool LEFT_CONSTANT, bool RIGHT_CONSTANT>
-	static inline index_t SelectLoop(LEFT_TYPE *__restrict ldata, RIGHT_TYPE *__restrict rdata,
-	                                 sel_t *__restrict result, index_t count, sel_t *__restrict sel_vector,
-	                                 nullmask_t &nullmask) {
-		index_t result_count = 0;
+	static inline idx_t SelectLoop(LEFT_TYPE *__restrict ldata, RIGHT_TYPE *__restrict rdata, sel_t *__restrict result,
+	                               idx_t count, sel_t *__restrict sel_vector, nullmask_t &nullmask) {
+		idx_t result_count = 0;
 		if (nullmask.any()) {
-			VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
+			VectorOperations::Exec(sel_vector, count, [&](idx_t i, idx_t k) {
 				if (!nullmask[i] && OP::Operation(ldata[LEFT_CONSTANT ? 0 : i], rdata[RIGHT_CONSTANT ? 0 : i])) {
 					result[result_count++] = i;
 				}
 			});
 		} else {
-			VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
+			VectorOperations::Exec(sel_vector, count, [&](idx_t i, idx_t k) {
 				if (OP::Operation(ldata[LEFT_CONSTANT ? 0 : i], rdata[RIGHT_CONSTANT ? 0 : i])) {
 					result[result_count++] = i;
 				}
@@ -181,7 +180,7 @@ private:
 
 public:
 	template <class LEFT_TYPE, class RIGHT_TYPE, class OP>
-	static index_t Select(Vector &left, Vector &right, sel_t result[]) {
+	static idx_t Select(Vector &left, Vector &right, sel_t result[]) {
 
 		assert(left.count == right.count && left.sel_vector == right.sel_vector);
 		if (left.vector_type == VectorType::CONSTANT_VECTOR && right.vector_type == VectorType::CONSTANT_VECTOR) {

--- a/src/include/duckdb/common/vector_operations/inplace_loops.hpp
+++ b/src/include/duckdb/common/vector_operations/inplace_loops.hpp
@@ -16,12 +16,12 @@ namespace duckdb {
 
 template <class LEFT_TYPE, class RESULT_TYPE, class OP, bool INPUT_CONSTANT>
 static inline void templated_inplace_loop_function(LEFT_TYPE *__restrict ldata, RESULT_TYPE *__restrict result_data,
-                                                   index_t count, sel_t *__restrict sel_vector) {
+                                                   idx_t count, sel_t *__restrict sel_vector) {
 	if (!INPUT_CONSTANT) {
 		ASSERT_RESTRICT(ldata, ldata + count, result_data, result_data + count);
 	}
 	VectorOperations::Exec(sel_vector, count,
-	                       [&](index_t i, index_t k) { OP::Operation(result_data[i], ldata[INPUT_CONSTANT ? 0 : i]); });
+	                       [&](idx_t i, idx_t k) { OP::Operation(result_data[i], ldata[INPUT_CONSTANT ? 0 : i]); });
 }
 
 template <class LEFT_TYPE, class RESULT_TYPE, class OP> void templated_inplace_loop(Vector &input, Vector &result) {

--- a/src/include/duckdb/common/vector_operations/scatter_loops.hpp
+++ b/src/include/duckdb/common/vector_operations/scatter_loops.hpp
@@ -16,9 +16,9 @@
 namespace duckdb {
 
 template <class T, class OP>
-static inline void scatter_loop_constant(T constant, T **__restrict destination, index_t count,
+static inline void scatter_loop_constant(T constant, T **__restrict destination, idx_t count,
                                          sel_t *__restrict sel_vector) {
-	VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
+	VectorOperations::Exec(sel_vector, count, [&](idx_t i, idx_t k) {
 		if (!IsNullValue<T>(*destination[i])) {
 			*destination[i] = OP::Operation(constant, *destination[i]);
 		} else {
@@ -28,10 +28,10 @@ static inline void scatter_loop_constant(T constant, T **__restrict destination,
 }
 
 template <class T, class OP>
-static inline void scatter_loop(T *__restrict ldata, T **__restrict destination, index_t count,
+static inline void scatter_loop(T *__restrict ldata, T **__restrict destination, idx_t count,
                                 sel_t *__restrict sel_vector, nullmask_t &nullmask) {
 	ASSERT_RESTRICT(ldata, ldata + count, destination, destination + count);
-	VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
+	VectorOperations::Exec(sel_vector, count, [&](idx_t i, idx_t k) {
 		if (!nullmask[i]) {
 			if (!IsNullValue<T>(*destination[i])) {
 				*destination[i] = OP::Operation(ldata[i], *destination[i]);

--- a/src/include/duckdb/common/vector_operations/ternary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/ternary_executor.hpp
@@ -20,7 +20,7 @@ private:
 	template <class A_TYPE, class B_TYPE, class C_TYPE, class RESULT_TYPE, class FUN, bool IGNORE_NULL, bool A_CONSTANT,
 	          bool B_CONSTANT, bool C_CONSTANT>
 	static inline void ExecuteLoop(A_TYPE *__restrict adata, B_TYPE *__restrict bdata, C_TYPE *__restrict cdata,
-	                               RESULT_TYPE *__restrict result_data, index_t count, sel_t *__restrict sel_vector,
+	                               RESULT_TYPE *__restrict result_data, idx_t count, sel_t *__restrict sel_vector,
 	                               nullmask_t &nullmask, FUN fun) {
 		if (!A_CONSTANT) {
 			ASSERT_RESTRICT(adata, adata + count, result_data, result_data + count);
@@ -32,14 +32,14 @@ private:
 			ASSERT_RESTRICT(cdata, cdata + count, result_data, result_data + count);
 		}
 		if (IGNORE_NULL && nullmask.any()) {
-			VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
+			VectorOperations::Exec(sel_vector, count, [&](idx_t i, idx_t k) {
 				if (!nullmask[i]) {
 					result_data[i] =
 					    fun(adata[A_CONSTANT ? 0 : i], bdata[B_CONSTANT ? 0 : i], cdata[C_CONSTANT ? 0 : i]);
 				}
 			});
 		} else {
-			VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
+			VectorOperations::Exec(sel_vector, count, [&](idx_t i, idx_t k) {
 				result_data[i] = fun(adata[A_CONSTANT ? 0 : i], bdata[B_CONSTANT ? 0 : i], cdata[C_CONSTANT ? 0 : i]);
 			});
 		}
@@ -153,19 +153,19 @@ public:
 
 private:
 	template <class A_TYPE, class B_TYPE, class C_TYPE, class OP, bool A_CONSTANT, bool B_CONSTANT, bool C_CONSTANT>
-	static inline index_t SelectLoop(A_TYPE *__restrict adata, B_TYPE *__restrict bdata, C_TYPE *__restrict cdata,
-	                                 sel_t *__restrict result, index_t count, sel_t *__restrict sel_vector,
-	                                 nullmask_t &nullmask) {
-		index_t result_count = 0;
+	static inline idx_t SelectLoop(A_TYPE *__restrict adata, B_TYPE *__restrict bdata, C_TYPE *__restrict cdata,
+	                               sel_t *__restrict result, idx_t count, sel_t *__restrict sel_vector,
+	                               nullmask_t &nullmask) {
+		idx_t result_count = 0;
 		if (nullmask.any()) {
-			VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
+			VectorOperations::Exec(sel_vector, count, [&](idx_t i, idx_t k) {
 				if (!nullmask[i] &&
 				    OP::Operation(adata[A_CONSTANT ? 0 : i], bdata[B_CONSTANT ? 0 : i], cdata[C_CONSTANT ? 0 : i])) {
 					result[result_count++] = i;
 				}
 			});
 		} else {
-			VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
+			VectorOperations::Exec(sel_vector, count, [&](idx_t i, idx_t k) {
 				if (OP::Operation(adata[A_CONSTANT ? 0 : i], bdata[B_CONSTANT ? 0 : i], cdata[C_CONSTANT ? 0 : i])) {
 					result[result_count++] = i;
 				}
@@ -175,7 +175,7 @@ private:
 	}
 
 	template <class A_TYPE, class B_TYPE, class C_TYPE, class OP, bool A_CONSTANT>
-	static inline index_t SelectA(Vector &a, Vector &b, Vector &c, sel_t result[]) {
+	static inline idx_t SelectA(Vector &a, Vector &b, Vector &c, sel_t result[]) {
 		if (b.vector_type == VectorType::CONSTANT_VECTOR) {
 			if (b.nullmask[0]) {
 				return 0;
@@ -188,7 +188,7 @@ private:
 	}
 
 	template <class A_TYPE, class B_TYPE, class C_TYPE, class OP, bool A_CONSTANT, bool B_CONSTANT>
-	static inline index_t SelectAB(Vector &a, Vector &b, Vector &c, sel_t result[]) {
+	static inline idx_t SelectAB(Vector &a, Vector &b, Vector &c, sel_t result[]) {
 		if (c.vector_type == VectorType::CONSTANT_VECTOR) {
 			if (c.nullmask[0]) {
 				return 0;
@@ -201,7 +201,7 @@ private:
 	}
 
 	template <class A_TYPE, class B_TYPE, class C_TYPE, class OP, bool A_CONSTANT, bool B_CONSTANT, bool C_CONSTANT>
-	static inline index_t SelectABC(Vector &a, Vector &b, Vector &c, sel_t result[]) {
+	static inline idx_t SelectABC(Vector &a, Vector &b, Vector &c, sel_t result[]) {
 		auto adata = (A_TYPE *)a.GetData();
 		auto bdata = (B_TYPE *)b.GetData();
 		auto cdata = (C_TYPE *)c.GetData();
@@ -228,7 +228,7 @@ private:
 
 public:
 	template <class A_TYPE, class B_TYPE, class C_TYPE, class OP>
-	static index_t Select(Vector &a, Vector &b, Vector &c, sel_t result[]) {
+	static idx_t Select(Vector &a, Vector &b, Vector &c, sel_t result[]) {
 		assert(a.count == b.count && a.count == c.count && a.sel_vector == b.sel_vector &&
 		       a.sel_vector == c.sel_vector);
 		if (a.vector_type == VectorType::CONSTANT_VECTOR) {

--- a/src/include/duckdb/common/vector_operations/unary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/unary_executor.hpp
@@ -33,18 +33,18 @@ struct UnaryLambdaWrapper {
 struct UnaryExecutor {
 private:
 	template <class INPUT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP, class FUNC, bool IGNORE_NULL>
-	static inline void ExecuteLoop(INPUT_TYPE *__restrict ldata, RESULT_TYPE *__restrict result_data, index_t count,
+	static inline void ExecuteLoop(INPUT_TYPE *__restrict ldata, RESULT_TYPE *__restrict result_data, idx_t count,
 	                               sel_t *__restrict sel_vector, nullmask_t nullmask, FUNC fun) {
 		ASSERT_RESTRICT(ldata, ldata + count, result_data, result_data + count);
 
 		if (IGNORE_NULL && nullmask.any()) {
-			VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
+			VectorOperations::Exec(sel_vector, count, [&](idx_t i, idx_t k) {
 				if (!nullmask[i]) {
 					result_data[i] = OPWRAPPER::template Operation<FUNC, OP, INPUT_TYPE, RESULT_TYPE>(fun, ldata[i]);
 				}
 			});
 		} else {
-			VectorOperations::Exec(sel_vector, count, [&](index_t i, index_t k) {
+			VectorOperations::Exec(sel_vector, count, [&](idx_t i, idx_t k) {
 				result_data[i] = OPWRAPPER::template Operation<FUNC, OP, INPUT_TYPE, RESULT_TYPE>(fun, ldata[i]);
 			});
 		}

--- a/src/include/duckdb/common/vector_operations/vector_operations.hpp
+++ b/src/include/duckdb/common/vector_operations/vector_operations.hpp
@@ -58,8 +58,8 @@ struct VectorOperations {
 	//! given null mask. Returns the amount of not-null values.
 	//! result_assignment will be set to either result_vector (if there are null
 	//! values) or to nullptr (if there are no null values)
-	static index_t NotNullSelVector(Vector &vector, sel_t *not_null_vector, sel_t *&result_assignment,
-	                                sel_t *null_vector = nullptr);
+	static idx_t NotNullSelVector(Vector &vector, sel_t *not_null_vector, sel_t *&result_assignment,
+	                              sel_t *null_vector = nullptr);
 
 	//===--------------------------------------------------------------------===//
 	// Boolean Operations
@@ -91,17 +91,17 @@ struct VectorOperations {
 	// Select Comparison Operations
 	//===--------------------------------------------------------------------===//
 	// result = A == B
-	static index_t SelectEquals(Vector &A, Vector &B, sel_t result[]);
+	static idx_t SelectEquals(Vector &A, Vector &B, sel_t result[]);
 	// result = A != B
-	static index_t SelectNotEquals(Vector &A, Vector &B, sel_t result[]);
+	static idx_t SelectNotEquals(Vector &A, Vector &B, sel_t result[]);
 	// result = A > B
-	static index_t SelectGreaterThan(Vector &A, Vector &B, sel_t result[]);
+	static idx_t SelectGreaterThan(Vector &A, Vector &B, sel_t result[]);
 	// result = A >= B
-	static index_t SelectGreaterThanEquals(Vector &A, Vector &B, sel_t result[]);
+	static idx_t SelectGreaterThanEquals(Vector &A, Vector &B, sel_t result[]);
 	// result = A < B
-	static index_t SelectLessThan(Vector &A, Vector &B, sel_t result[]);
+	static idx_t SelectLessThan(Vector &A, Vector &B, sel_t result[]);
 	// result = A <= B
-	static index_t SelectLessThanEquals(Vector &A, Vector &B, sel_t result[]);
+	static idx_t SelectLessThanEquals(Vector &A, Vector &B, sel_t result[]);
 
 	//===--------------------------------------------------------------------===//
 	// Scatter methods
@@ -122,20 +122,20 @@ struct VectorOperations {
 		//! dest[i] = dest[i]
 		static void SetFirst(Vector &source, Vector &dest);
 		// dest[i] = dest[i] + source
-		static void Add(int64_t source, void **dest, index_t length);
+		static void Add(int64_t source, void **dest, idx_t length);
 		//! Similar to Set, but also write NullValue<T> if set_null = true, or ignore null values entirely if set_null =
 		//! false
-		static void SetAll(Vector &source, Vector &dest, bool set_null = false, index_t offset = 0);
+		static void SetAll(Vector &source, Vector &dest, bool set_null = false, idx_t offset = 0);
 	};
 	// make sure dest.count is set for gather methods!
 	struct Gather {
 		//! dest.data[i] = ptr[i]. If set_null is true, NullValue<T> is checked for and converted to the nullmask in
 		//! dest. If set_null is false, NullValue<T> is ignored.
-		static void Set(Vector &source, Vector &dest, bool set_null = true, index_t offset = 0);
+		static void Set(Vector &source, Vector &dest, bool set_null = true, idx_t offset = 0);
 		//! Append the values from source to the dest vector. If set_null is true, NullValue<T> is checked for and
 		//! converted to the nullmask in dest. If set_null is false, NullValue<T> is ignored. If offset is set, it is
 		//! added to
-		static void Append(Vector &source, Vector &dest, index_t offset = 0, bool set_null = true);
+		static void Append(Vector &source, Vector &dest, idx_t offset = 0, bool set_null = true);
 	};
 
 	//===--------------------------------------------------------------------===//
@@ -145,7 +145,7 @@ struct VectorOperations {
 	static void Sort(Vector &vector, sel_t result[]);
 	// Sort the vector, setting the given selection vector to a sorted state
 	// while ignoring NULL values.
-	static void Sort(Vector &vector, sel_t *result_vector, index_t count, sel_t result[]);
+	static void Sort(Vector &vector, sel_t *result_vector, idx_t count, sel_t result[]);
 	// Checks whether or not the vector contains only unique values
 	static bool Unique(Vector &vector);
 	//===--------------------------------------------------------------------===//
@@ -169,12 +169,12 @@ struct VectorOperations {
 	// Cast the data from the source type to the target type
 	static void Cast(Vector &source, Vector &result);
 	// Copy the data of <source> to the target location
-	static void Copy(Vector &source, void *target, index_t offset = 0, index_t element_count = 0);
+	static void Copy(Vector &source, void *target, idx_t offset = 0, idx_t element_count = 0);
 	// Copy the data of <source> to the target vector
-	static void Copy(Vector &source, Vector &target, index_t offset = 0);
+	static void Copy(Vector &source, Vector &target, idx_t offset = 0);
 	// Copy the data of <source> to the target location, setting null values to
 	// NullValue<T>. Used to store data without separate NULL mask.
-	static void CopyToStorage(Vector &source, void *target, index_t offset = 0, index_t element_count = 0);
+	static void CopyToStorage(Vector &source, void *target, idx_t offset = 0, idx_t element_count = 0);
 	// Appends the data of <source> to the target vector, setting the nullmask
 	// for any NullValue<T> of source. Used to go back from storage to a
 	// nullmask.
@@ -187,8 +187,8 @@ struct VectorOperations {
 	//===--------------------------------------------------------------------===//
 	// Exec
 	//===--------------------------------------------------------------------===//
-	template <class T> static void Exec(sel_t *sel_vector, index_t count, T &&fun, index_t offset = 0) {
-		index_t i = offset;
+	template <class T> static void Exec(sel_t *sel_vector, idx_t count, T &&fun, idx_t offset = 0) {
+		idx_t i = offset;
 		if (sel_vector) {
 			//#pragma GCC ivdep
 			for (; i < count; i++) {
@@ -203,7 +203,7 @@ struct VectorOperations {
 	}
 	//! Exec over the set of indexes, calls the callback function with (i) =
 	//! index, dependent on selection vector and (k) = count
-	template <class T> static void Exec(const Vector &vector, T &&fun, index_t offset = 0, index_t count = 0) {
+	template <class T> static void Exec(const Vector &vector, T &&fun, idx_t offset = 0, idx_t count = 0) {
 		if (vector.vector_type == VectorType::CONSTANT_VECTOR) {
 			assert(count == 0 && offset == 0);
 			Exec(nullptr, 1, fun, offset);
@@ -223,18 +223,18 @@ struct VectorOperations {
 	//! is equivalent to calling ::Exec() and performing data[i] for
 	//! every entry
 	template <typename T, class FUNC>
-	static void ExecType(Vector &vector, FUNC &&fun, index_t offset = 0, index_t limit = 0) {
+	static void ExecType(Vector &vector, FUNC &&fun, idx_t offset = 0, idx_t limit = 0) {
 		auto data = (T *)vector.GetData();
 		VectorOperations::Exec(
-		    vector, [&](index_t i, index_t k) { fun(data[i], i, k); }, offset, limit);
+		    vector, [&](idx_t i, idx_t k) { fun(data[i], i, k); }, offset, limit);
 	}
 
 	template <typename T, class FUNC> static void ExecNumeric(Vector &vector, FUNC &&fun) {
 		if (vector.vector_type == VectorType::SEQUENCE_VECTOR) {
 			int64_t start, increment;
 			vector.GetSequence(start, increment);
-			for (index_t i = 0; i < vector.count; i++) {
-				index_t idx = vector.sel_vector ? vector.sel_vector[i] : i;
+			for (idx_t i = 0; i < vector.count; i++) {
+				idx_t idx = vector.sel_vector ? vector.sel_vector[i] : i;
 				fun((T)(start + increment * idx), idx, i);
 			}
 		} else if (vector.vector_type == VectorType::CONSTANT_VECTOR) {
@@ -243,7 +243,7 @@ struct VectorOperations {
 		} else {
 			assert(vector.vector_type == VectorType::FLAT_VECTOR);
 			auto data = (T *)vector.GetData();
-			VectorOperations::Exec(vector, [&](index_t i, index_t k) { fun(data[i], i, k); });
+			VectorOperations::Exec(vector, [&](idx_t i, idx_t k) { fun(data[i], i, k); });
 		}
 	}
 };

--- a/src/include/duckdb/execution/aggregate_hashtable.hpp
+++ b/src/include/duckdb/execution/aggregate_hashtable.hpp
@@ -26,13 +26,13 @@ class BoundAggregateExpression;
 */
 class SuperLargeHashTable {
 public:
-	SuperLargeHashTable(index_t initial_capacity, vector<TypeId> group_types, vector<TypeId> payload_types,
+	SuperLargeHashTable(idx_t initial_capacity, vector<TypeId> group_types, vector<TypeId> payload_types,
 	                    vector<BoundAggregateExpression *> aggregates, bool parallel = false);
 	~SuperLargeHashTable();
 
 	//! Resize the HT to the specified size. Must be larger than the current
 	//! size.
-	void Resize(index_t size);
+	void Resize(idx_t size);
 	//! Add the given data to the HT, computing the aggregates grouped by the
 	//! data in the group chunk. When resize = true, aggregates will not be
 	//! computed but instead just assigned.
@@ -40,7 +40,7 @@ public:
 	//! Scan the HT starting from the scan_position until the result and group
 	//! chunks are filled. scan_position will be updated by this function.
 	//! Returns the amount of elements found.
-	index_t Scan(index_t &scan_position, DataChunk &group, DataChunk &result);
+	idx_t Scan(idx_t &scan_position, DataChunk &group, DataChunk &result);
 
 	//! Fetch the aggregates for specific groups from the HT and place them in the result
 	void FetchAggregates(DataChunk &groups, DataChunk &result);
@@ -60,16 +60,16 @@ private:
 	//! The types of the payload columns stored in the hashtable
 	vector<TypeId> payload_types;
 	//! The size of the groups in bytes
-	index_t group_width;
+	idx_t group_width;
 	//! The size of the payload (aggregations) in bytes
-	index_t payload_width;
+	idx_t payload_width;
 	//! The total tuple size
-	index_t tuple_size;
+	idx_t tuple_size;
 	//! The capacity of the HT. This can be increased using
 	//! SuperLargeHashTable::Resize
-	index_t capacity;
+	idx_t capacity;
 	//! The amount of entries stored in the HT currently
-	index_t entries;
+	idx_t entries;
 	//! The data of the HT
 	data_ptr_t data;
 	//! The endptr of the hashtable

--- a/src/include/duckdb/execution/expression_executor.hpp
+++ b/src/include/duckdb/execution/expression_executor.hpp
@@ -43,10 +43,10 @@ public:
 	void ExecuteExpression(Vector &result);
 	//! Execute the ExpressionExecutor and generate a selection vector from all true values in the result; this should
 	//! only be used with a single boolean expression
-	index_t SelectExpression(DataChunk &input, sel_t result[]);
+	idx_t SelectExpression(DataChunk &input, sel_t result[]);
 
 	//! Execute the expression with index `expr_idx` and store the result in the result vector
-	void ExecuteExpression(index_t expr_idx, Vector &result);
+	void ExecuteExpression(idx_t expr_idx, Vector &result);
 	//! Evaluate a scalar expression and fold it into a single value
 	static Value EvaluateScalar(Expression &expr);
 
@@ -98,12 +98,12 @@ protected:
 
 	//! Execute the (boolean-returning) expression and generate a selection vector with all entries that are "true" in
 	//! the result
-	index_t Select(Expression &expr, ExpressionState *state, sel_t result[]);
-	index_t DefaultSelect(Expression &expr, ExpressionState *state, sel_t result[]);
+	idx_t Select(Expression &expr, ExpressionState *state, sel_t result[]);
+	idx_t DefaultSelect(Expression &expr, ExpressionState *state, sel_t result[]);
 
-	index_t Select(BoundBetweenExpression &expr, ExpressionState *state, sel_t result[]);
-	index_t Select(BoundComparisonExpression &expr, ExpressionState *state, sel_t result[]);
-	index_t Select(BoundConjunctionExpression &expr, ExpressionState *state, sel_t result[]);
+	idx_t Select(BoundBetweenExpression &expr, ExpressionState *state, sel_t result[]);
+	idx_t Select(BoundComparisonExpression &expr, ExpressionState *state, sel_t result[]);
+	idx_t Select(BoundConjunctionExpression &expr, ExpressionState *state, sel_t result[]);
 
 	//! Verify that the output of a step in the ExpressionExecutor is correct
 	void Verify(Expression &expr, Vector &result);

--- a/src/include/duckdb/execution/index/art/art.hpp
+++ b/src/include/duckdb/execution/index/art/art.hpp
@@ -26,7 +26,7 @@
 namespace duckdb {
 struct IteratorEntry {
 	Node *node = nullptr;
-	index_t pos = 0;
+	idx_t pos = 0;
 };
 
 struct Iterator {
@@ -47,7 +47,7 @@ struct ARTIndexScanState : public IndexScanState {
 	Value values[2];
 	ExpressionType expressions[2];
 	bool checked;
-	index_t result_index = 0;
+	idx_t result_index = 0;
 	vector<row_t> result_ids;
 	Iterator iterator;
 };

--- a/src/include/duckdb/execution/index/art/art_key.hpp
+++ b/src/include/duckdb/execution/index/art/art_key.hpp
@@ -15,9 +15,9 @@ namespace duckdb {
 
 class Key {
 public:
-	Key(unique_ptr<data_t[]> data, index_t len);
+	Key(unique_ptr<data_t[]> data, idx_t len);
 
-	index_t len;
+	idx_t len;
 	unique_ptr<data_t[]> data;
 
 public:

--- a/src/include/duckdb/execution/index/art/leaf.hpp
+++ b/src/include/duckdb/execution/index/art/leaf.hpp
@@ -17,10 +17,10 @@ public:
 	Leaf(ART &art, unique_ptr<Key> value, row_t row_id);
 
 	unique_ptr<Key> value;
-	index_t capacity;
-	index_t num_elements;
+	idx_t capacity;
+	idx_t num_elements;
 
-	row_t GetRowId(index_t index) {
+	row_t GetRowId(idx_t index) {
 		return row_ids[index];
 	}
 

--- a/src/include/duckdb/execution/index/art/node.hpp
+++ b/src/include/duckdb/execution/index/art/node.hpp
@@ -36,31 +36,31 @@ public:
 
 public:
 	//! Get the position of a child corresponding exactly to the specific byte, returns INVALID_INDEX if not exists
-	virtual index_t GetChildPos(uint8_t k) {
+	virtual idx_t GetChildPos(uint8_t k) {
 		return INVALID_INDEX;
 	}
 	//! Get the position of the first child that is greater or equal to the specific byte, or INVALID_INDEX if there are
 	//! no children matching the criteria
-	virtual index_t GetChildGreaterEqual(uint8_t k) {
+	virtual idx_t GetChildGreaterEqual(uint8_t k) {
 		return INVALID_INDEX;
 	}
 	//! Get the position of the biggest element in node
-	virtual index_t GetMin();
+	virtual idx_t GetMin();
 	//! Get the next position in the node, or INVALID_INDEX if there is no next position. if pos == INVALID_INDEX, then
 	//! the first valid position in the node will be returned.
-	virtual index_t GetNextPos(index_t pos) {
+	virtual idx_t GetNextPos(idx_t pos) {
 		return INVALID_INDEX;
 	}
 	//! Get the child at the specified position in the node. pos should be between [0, count). Throws an assertion if
 	//! the element is not found.
-	virtual unique_ptr<Node> *GetChild(index_t pos);
+	virtual unique_ptr<Node> *GetChild(idx_t pos);
 
 	//! Compare the key with the prefix of the node, return the number matching bytes
 	static uint32_t PrefixMismatch(ART &art, Node *node, Key &key, uint64_t depth);
 	//! Insert leaf into inner node
 	static void InsertLeaf(ART &art, unique_ptr<Node> &node, uint8_t key, unique_ptr<Node> &newNode);
 	//! Erase entry from node
-	static void Erase(ART &art, unique_ptr<Node> &node, index_t pos);
+	static void Erase(ART &art, unique_ptr<Node> &node, idx_t pos);
 
 protected:
 	//! Copies the prefix from the source to the destination node

--- a/src/include/duckdb/execution/index/art/node16.hpp
+++ b/src/include/duckdb/execution/index/art/node16.hpp
@@ -20,16 +20,16 @@ public:
 
 public:
 	//! Get position of a byte, returns -1 if not exists
-	index_t GetChildPos(uint8_t k) override;
+	idx_t GetChildPos(uint8_t k) override;
 	//! Get the position of the first child that is greater or equal to the specific byte, or INVALID_INDEX if there are
 	//! no children matching the criteria
-	index_t GetChildGreaterEqual(uint8_t k) override;
+	idx_t GetChildGreaterEqual(uint8_t k) override;
 	//! Get the next position in the node, or INVALID_INDEX if there is no next position
-	index_t GetNextPos(index_t pos) override;
+	idx_t GetNextPos(idx_t pos) override;
 	//! Get Node16 Child
-	unique_ptr<Node> *GetChild(index_t pos) override;
+	unique_ptr<Node> *GetChild(idx_t pos) override;
 
-	index_t GetMin() override;
+	idx_t GetMin() override;
 
 	//! Insert node into Node16
 	static void insert(ART &art, unique_ptr<Node> &node, uint8_t keyByte, unique_ptr<Node> &child);

--- a/src/include/duckdb/execution/index/art/node256.hpp
+++ b/src/include/duckdb/execution/index/art/node256.hpp
@@ -19,16 +19,16 @@ public:
 
 public:
 	//! Get position of a specific byte, returns INVALID_INDEX if not exists
-	index_t GetChildPos(uint8_t k) override;
+	idx_t GetChildPos(uint8_t k) override;
 	//! Get the position of the first child that is greater or equal to the specific byte, or INVALID_INDEX if there are
 	//! no children matching the criteria
-	index_t GetChildGreaterEqual(uint8_t k) override;
+	idx_t GetChildGreaterEqual(uint8_t k) override;
 	//! Get the next position in the node, or INVALID_INDEX if there is no next position
-	index_t GetNextPos(index_t pos) override;
+	idx_t GetNextPos(idx_t pos) override;
 	//! Get Node256 Child
-	unique_ptr<Node> *GetChild(index_t pos) override;
+	unique_ptr<Node> *GetChild(idx_t pos) override;
 
-	index_t GetMin() override;
+	idx_t GetMin() override;
 
 	//! Insert node From Node256
 	static void insert(ART &art, unique_ptr<Node> &node, uint8_t keyByte, unique_ptr<Node> &child);

--- a/src/include/duckdb/execution/index/art/node4.hpp
+++ b/src/include/duckdb/execution/index/art/node4.hpp
@@ -20,16 +20,16 @@ public:
 
 public:
 	//! Get position of a byte, returns -1 if not exists
-	index_t GetChildPos(uint8_t k) override;
+	idx_t GetChildPos(uint8_t k) override;
 	//! Get the position of the first child that is greater or equal to the specific byte, or INVALID_INDEX if there are
 	//! no children matching the criteria
-	index_t GetChildGreaterEqual(uint8_t k) override;
+	idx_t GetChildGreaterEqual(uint8_t k) override;
 	//! Get the next position in the node, or INVALID_INDEX if there is no next position
-	index_t GetNextPos(index_t pos) override;
+	idx_t GetNextPos(idx_t pos) override;
 	//! Get Node4 Child
-	unique_ptr<Node> *GetChild(index_t pos) override;
+	unique_ptr<Node> *GetChild(idx_t pos) override;
 
-	index_t GetMin() override;
+	idx_t GetMin() override;
 
 	//! Insert Leaf to the Node4
 	static void insert(ART &art, unique_ptr<Node> &node, uint8_t keyByte, unique_ptr<Node> &child);

--- a/src/include/duckdb/execution/index/art/node48.hpp
+++ b/src/include/duckdb/execution/index/art/node48.hpp
@@ -20,16 +20,16 @@ public:
 
 public:
 	//! Get position of a byte, returns -1 if not exists
-	index_t GetChildPos(uint8_t k) override;
+	idx_t GetChildPos(uint8_t k) override;
 	//! Get the position of the first child that is greater or equal to the specific byte, or INVALID_INDEX if there are
 	//! no children matching the criteria
-	index_t GetChildGreaterEqual(uint8_t k) override;
+	idx_t GetChildGreaterEqual(uint8_t k) override;
 	//! Get the next position in the node, or INVALID_INDEX if there is no next position
-	index_t GetNextPos(index_t pos) override;
+	idx_t GetNextPos(idx_t pos) override;
 	//! Get Node48 Child
-	unique_ptr<Node> *GetChild(index_t pos) override;
+	unique_ptr<Node> *GetChild(idx_t pos) override;
 
-	index_t GetMin() override;
+	idx_t GetMin() override;
 
 	//! Insert node in Node48
 	static void insert(ART &art, unique_ptr<Node> &node, uint8_t keyByte, unique_ptr<Node> &child);

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -72,22 +72,22 @@ public:
 		void ScanKeyMatches(DataChunk &keys);
 		template <bool MATCH> void NextSemiOrAntiJoin(DataChunk &keys, DataChunk &left, DataChunk &result);
 
-		index_t ScanInnerJoin(DataChunk &keys, DataChunk &left, DataChunk &result);
+		idx_t ScanInnerJoin(DataChunk &keys, DataChunk &left, DataChunk &result);
 
 		void ResolvePredicates(DataChunk &keys, Vector &comparison_result);
-		index_t ResolvePredicates(DataChunk &keys, sel_t comparison_result[]);
+		idx_t ResolvePredicates(DataChunk &keys, sel_t comparison_result[]);
 	};
 
 private:
 	//! Nodes store the actual data of the tuples inside the HT as a linked list
 	struct HTDataBlock {
-		index_t count;
-		index_t capacity;
+		idx_t count;
+		idx_t capacity;
 		block_id_t block_id;
 	};
 
-	index_t AppendToBlock(HTDataBlock &block, BufferHandle &handle, Vector &key_data, data_ptr_t key_locations[],
-	                      data_ptr_t tuple_locations[], data_ptr_t hash_locations[], index_t remaining);
+	idx_t AppendToBlock(HTDataBlock &block, BufferHandle &handle, Vector &key_data, data_ptr_t key_locations[],
+	                    data_ptr_t tuple_locations[], data_ptr_t hash_locations[], idx_t remaining);
 
 	void Hash(DataChunk &keys, Vector &hashes);
 
@@ -107,7 +107,7 @@ public:
 	//! The stringheap of the JoinHashTable
 	StringHeap string_heap;
 
-	index_t size() {
+	idx_t size() {
 		return count;
 	}
 
@@ -121,15 +121,15 @@ public:
 	//! The comparison predicates
 	vector<ExpressionType> predicates;
 	//! Size of condition keys
-	index_t equality_size;
+	idx_t equality_size;
 	//! Size of condition keys
-	index_t condition_size;
+	idx_t condition_size;
 	//! Size of build tuple
-	index_t build_size;
+	idx_t build_size;
 	//! The size of an entry as stored in the HashTable
-	index_t entry_size;
+	idx_t entry_size;
 	//! The total tuple size
-	index_t tuple_size;
+	idx_t tuple_size;
 	//! The join type of the HT
 	JoinType join_type;
 	//! Whether or not the HT has been finalized
@@ -139,7 +139,7 @@ public:
 	//! Bitmask for getting relevant bits from the hashes to determine the position
 	uint64_t bitmask;
 	//! The amount of entries stored per block
-	index_t block_capacity;
+	idx_t block_capacity;
 
 	struct {
 		//! The types of the duplicate eliminated columns, only used in correlated MARK JOIN for flattening ANY()/ALL()
@@ -165,7 +165,7 @@ private:
 	void InsertHashes(Vector &hashes, data_ptr_t key_locations[]);
 
 	//! The amount of entries stored in the HT currently
-	index_t count;
+	idx_t count;
 	//! The blocks holding the main data of the hash table
 	vector<HTDataBlock> blocks;
 	//! Pinned handles, these are pinned during finalization only

--- a/src/include/duckdb/execution/merge_join.hpp
+++ b/src/include/duckdb/execution/merge_join.hpp
@@ -17,7 +17,7 @@ namespace duckdb {
 
 struct MergeOrder {
 	sel_t order[STANDARD_VECTOR_SIZE];
-	index_t count;
+	idx_t count;
 };
 
 enum MergeInfoType : uint8_t { SCALAR_MERGE_INFO = 1, CHUNK_MERGE_INFO = 2 };
@@ -31,12 +31,12 @@ struct MergeInfo {
 
 struct ScalarMergeInfo : public MergeInfo {
 	Vector &v;
-	index_t count;
+	idx_t count;
 	sel_t *sel_vector;
-	index_t &pos;
+	idx_t &pos;
 	sel_t result[STANDARD_VECTOR_SIZE];
 
-	ScalarMergeInfo(Vector &v, index_t count, sel_t *sel_vector, index_t &pos)
+	ScalarMergeInfo(Vector &v, idx_t count, sel_t *sel_vector, idx_t &pos)
 	    : MergeInfo(MergeInfoType::SCALAR_MERGE_INFO, v.type), v(v), count(count), sel_vector(sel_vector), pos(pos) {
 	}
 };
@@ -55,55 +55,55 @@ struct ChunkMergeInfo : public MergeInfo {
 
 struct MergeJoinInner {
 	struct Equality {
-		template <class T> static index_t Operation(ScalarMergeInfo &l, ScalarMergeInfo &r);
+		template <class T> static idx_t Operation(ScalarMergeInfo &l, ScalarMergeInfo &r);
 	};
 	struct LessThan {
-		template <class T> static index_t Operation(ScalarMergeInfo &l, ScalarMergeInfo &r);
+		template <class T> static idx_t Operation(ScalarMergeInfo &l, ScalarMergeInfo &r);
 	};
 	struct LessThanEquals {
-		template <class T> static index_t Operation(ScalarMergeInfo &l, ScalarMergeInfo &r);
+		template <class T> static idx_t Operation(ScalarMergeInfo &l, ScalarMergeInfo &r);
 	};
 	struct GreaterThan {
-		template <class T> static index_t Operation(ScalarMergeInfo &l, ScalarMergeInfo &r) {
+		template <class T> static idx_t Operation(ScalarMergeInfo &l, ScalarMergeInfo &r) {
 			return LessThan::Operation<T>(r, l);
 		}
 	};
 	struct GreaterThanEquals {
-		template <class T> static index_t Operation(ScalarMergeInfo &l, ScalarMergeInfo &r) {
+		template <class T> static idx_t Operation(ScalarMergeInfo &l, ScalarMergeInfo &r) {
 			return LessThanEquals::Operation<T>(r, l);
 		}
 	};
 
-	static index_t Perform(MergeInfo &l, MergeInfo &r, ExpressionType comparison_type);
+	static idx_t Perform(MergeInfo &l, MergeInfo &r, ExpressionType comparison_type);
 };
 
 struct MergeJoinMark {
 	struct Equality {
-		template <class T> static index_t Operation(ScalarMergeInfo &l, ChunkMergeInfo &r);
+		template <class T> static idx_t Operation(ScalarMergeInfo &l, ChunkMergeInfo &r);
 	};
 	struct LessThan {
-		template <class T> static index_t Operation(ScalarMergeInfo &l, ChunkMergeInfo &r);
+		template <class T> static idx_t Operation(ScalarMergeInfo &l, ChunkMergeInfo &r);
 	};
 	struct LessThanEquals {
-		template <class T> static index_t Operation(ScalarMergeInfo &l, ChunkMergeInfo &r);
+		template <class T> static idx_t Operation(ScalarMergeInfo &l, ChunkMergeInfo &r);
 	};
 	struct GreaterThan {
-		template <class T> static index_t Operation(ScalarMergeInfo &l, ChunkMergeInfo &r);
+		template <class T> static idx_t Operation(ScalarMergeInfo &l, ChunkMergeInfo &r);
 	};
 	struct GreaterThanEquals {
-		template <class T> static index_t Operation(ScalarMergeInfo &l, ChunkMergeInfo &r);
+		template <class T> static idx_t Operation(ScalarMergeInfo &l, ChunkMergeInfo &r);
 	};
 
-	static index_t Perform(MergeInfo &l, MergeInfo &r, ExpressionType comparison);
+	static idx_t Perform(MergeInfo &l, MergeInfo &r, ExpressionType comparison);
 };
 
 #define INSTANTIATE_MERGEJOIN_TEMPLATES(MJCLASS, OPNAME, L, R)                                                         \
-	template index_t MJCLASS::OPNAME::Operation<int8_t>(L & l, R & r);                                                 \
-	template index_t MJCLASS::OPNAME::Operation<int16_t>(L & l, R & r);                                                \
-	template index_t MJCLASS::OPNAME::Operation<int32_t>(L & l, R & r);                                                \
-	template index_t MJCLASS::OPNAME::Operation<int64_t>(L & l, R & r);                                                \
-	template index_t MJCLASS::OPNAME::Operation<float>(L & l, R & r);                                                 \
-	template index_t MJCLASS::OPNAME::Operation<double>(L & l, R & r);                                                 \
-	template index_t MJCLASS::OPNAME::Operation<const char *>(L & l, R & r);
+	template idx_t MJCLASS::OPNAME::Operation<int8_t>(L & l, R & r);                                                   \
+	template idx_t MJCLASS::OPNAME::Operation<int16_t>(L & l, R & r);                                                  \
+	template idx_t MJCLASS::OPNAME::Operation<int32_t>(L & l, R & r);                                                  \
+	template idx_t MJCLASS::OPNAME::Operation<int64_t>(L & l, R & r);                                                  \
+	template idx_t MJCLASS::OPNAME::Operation<float>(L & l, R & r);                                                    \
+	template idx_t MJCLASS::OPNAME::Operation<double>(L & l, R & r);                                                   \
+	template idx_t MJCLASS::OPNAME::Operation<const char *>(L & l, R & r);
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/nested_loop_join.hpp
+++ b/src/include/duckdb/execution/nested_loop_join.hpp
@@ -16,8 +16,8 @@
 namespace duckdb {
 
 struct NestedLoopJoinInner {
-	static index_t Perform(index_t &ltuple, index_t &rtuple, DataChunk &left_conditions, DataChunk &right_conditions,
-	                       sel_t lvector[], sel_t rvector[], vector<JoinCondition> &conditions);
+	static idx_t Perform(idx_t &ltuple, idx_t &rtuple, DataChunk &left_conditions, DataChunk &right_conditions,
+	                     sel_t lvector[], sel_t rvector[], vector<JoinCondition> &conditions);
 };
 
 struct NestedLoopJoinMark {

--- a/src/include/duckdb/execution/operator/helper/physical_limit.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_limit.hpp
@@ -15,12 +15,12 @@ namespace duckdb {
 //! PhyisicalLimit represents the LIMIT operator
 class PhysicalLimit : public PhysicalOperator {
 public:
-	PhysicalLimit(LogicalOperator &op, index_t limit, index_t offset)
+	PhysicalLimit(LogicalOperator &op, idx_t limit, idx_t offset)
 	    : PhysicalOperator(PhysicalOperatorType::LIMIT, op.types), limit(limit), offset(offset) {
 	}
 
-	index_t limit;
-	index_t offset;
+	idx_t limit;
+	idx_t offset;
 
 public:
 	void GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;

--- a/src/include/duckdb/execution/operator/helper/physical_prune_columns.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_prune_columns.hpp
@@ -15,11 +15,11 @@ namespace duckdb {
 //! PhysicalPruneColumns prunes (removes) columns from its input
 class PhysicalPruneColumns : public PhysicalOperator {
 public:
-	PhysicalPruneColumns(LogicalOperator &op, index_t column_limit)
+	PhysicalPruneColumns(LogicalOperator &op, idx_t column_limit)
 	    : PhysicalOperator(PhysicalOperatorType::PRUNE_COLUMNS, op.types), column_limit(column_limit) {
 	}
 
-	index_t column_limit;
+	idx_t column_limit;
 
 public:
 	void GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;

--- a/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
@@ -21,12 +21,12 @@ class PhysicalHashJoin : public PhysicalComparisonJoin {
 public:
 	PhysicalHashJoin(ClientContext &context, LogicalOperator &op, unique_ptr<PhysicalOperator> left,
 	                 unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type,
-	                 vector<index_t> left_projection_map, vector<index_t> right_projection_map);
+	                 vector<idx_t> left_projection_map, vector<idx_t> right_projection_map);
 	PhysicalHashJoin(ClientContext &context, LogicalOperator &op, unique_ptr<PhysicalOperator> left,
 	                 unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type);
 
 	unique_ptr<JoinHashTable> hash_table;
-	vector<index_t> right_projection_map;
+	vector<idx_t> right_projection_map;
 
 public:
 	void GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;

--- a/src/include/duckdb/execution/operator/join/physical_nested_loop_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_nested_loop_join.hpp
@@ -13,10 +13,10 @@
 
 namespace duckdb {
 
-index_t nested_loop_join(ExpressionType op, Vector &left, Vector &right, index_t &lpos, index_t &rpos, sel_t lvector[],
-                         sel_t rvector[]);
-index_t nested_loop_comparison(ExpressionType op, Vector &left, Vector &right, sel_t lvector[], sel_t rvector[],
-                               index_t count);
+idx_t nested_loop_join(ExpressionType op, Vector &left, Vector &right, idx_t &lpos, idx_t &rpos, sel_t lvector[],
+                       sel_t rvector[]);
+idx_t nested_loop_comparison(ExpressionType op, Vector &left, Vector &right, sel_t lvector[], sel_t rvector[],
+                             idx_t count);
 
 //! PhysicalNestedLoopJoin represents a nested loop join between two tables
 class PhysicalNestedLoopJoin : public PhysicalComparisonJoin {

--- a/src/include/duckdb/execution/operator/order/physical_top_n.hpp
+++ b/src/include/duckdb/execution/operator/order/physical_top_n.hpp
@@ -18,20 +18,20 @@ namespace duckdb {
 //! the data but only add a selection vector.
 class PhysicalTopN : public PhysicalOperator {
 public:
-	PhysicalTopN(LogicalOperator &op, vector<BoundOrderByNode> orders, index_t limit, index_t offset)
+	PhysicalTopN(LogicalOperator &op, vector<BoundOrderByNode> orders, idx_t limit, idx_t offset)
 	    : PhysicalOperator(PhysicalOperatorType::TOP_N, op.types), orders(move(orders)), limit(limit), offset(offset),
 	      heap_size(0) {
 	}
 
 	vector<BoundOrderByNode> orders;
-	index_t limit;
-	index_t offset;
-	index_t heap_size;
+	idx_t limit;
+	idx_t offset;
+	idx_t heap_size;
 
 public:
 	void GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;
 	unique_ptr<PhysicalOperatorState> GetOperatorState() override;
-	void CalculateHeapSize(index_t rows);
+	void CalculateHeapSize(idx_t rows);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
@@ -32,14 +32,14 @@ struct TextSearchShiftArray {
 		return position == length;
 	}
 
-	index_t length;
+	idx_t length;
 	unique_ptr<uint8_t[]> shifts;
 };
 
 //! Buffered CSV reader is a class that reads values from a stream and parses them as a CSV file
 class BufferedCSVReader {
-	static constexpr index_t INITIAL_BUFFER_SIZE = 16384;
-	static constexpr index_t MAXIMUM_CSV_LINE_SIZE = 1048576;
+	static constexpr idx_t INITIAL_BUFFER_SIZE = 16384;
+	static constexpr idx_t MAXIMUM_CSV_LINE_SIZE = 1048576;
 
 public:
 	BufferedCSVReader(CopyInfo &info, vector<SQLType> sql_types, std::istream &source);
@@ -49,12 +49,12 @@ public:
 	std::istream &source;
 
 	unique_ptr<char[]> buffer;
-	index_t buffer_size;
-	index_t position;
-	index_t start = 0;
+	idx_t buffer_size;
+	idx_t position;
+	idx_t start = 0;
 
-	index_t linenr = 0;
-	index_t nr_elements = 0;
+	idx_t linenr = 0;
+	idx_t nr_elements = 0;
 
 	TextSearchShiftArray delimiter_search, escape_search, quote_search;
 
@@ -73,13 +73,13 @@ private:
 	void ParseComplexCSV(DataChunk &insert_chunk);
 
 	//! Adds a value to the current row
-	void AddValue(char *str_val, index_t length, index_t &column, vector<index_t> &escape_positions);
+	void AddValue(char *str_val, idx_t length, idx_t &column, vector<idx_t> &escape_positions);
 	//! Adds a row to the insert_chunk, returns true if the chunk is filled as a result of this row being added
-	bool AddRow(DataChunk &insert_chunk, index_t &column);
+	bool AddRow(DataChunk &insert_chunk, idx_t &column);
 	//! Finalizes a chunk, parsing all values that have been added so far and adding them to the insert_chunk
 	void Flush(DataChunk &insert_chunk);
 	//! Reads a new buffer from the CSV file if the current one has been exhausted
-	bool ReadBuffer(index_t &start);
+	bool ReadBuffer(idx_t &start);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/persistent/physical_delete.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_delete.hpp
@@ -16,14 +16,14 @@ class DataTable;
 //! Physically delete data from a table
 class PhysicalDelete : public PhysicalOperator {
 public:
-	PhysicalDelete(LogicalOperator &op, TableCatalogEntry &tableref, DataTable &table, index_t row_id_index)
+	PhysicalDelete(LogicalOperator &op, TableCatalogEntry &tableref, DataTable &table, idx_t row_id_index)
 	    : PhysicalOperator(PhysicalOperatorType::DELETE, op.types), tableref(tableref), table(table),
 	      row_id_index(row_id_index) {
 	}
 
 	TableCatalogEntry &tableref;
 	DataTable &table;
-	index_t row_id_index;
+	idx_t row_id_index;
 
 public:
 	void GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;

--- a/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
@@ -15,13 +15,13 @@ namespace duckdb {
 //! Physically insert a set of data into a table
 class PhysicalInsert : public PhysicalOperator {
 public:
-	PhysicalInsert(LogicalOperator &op, TableCatalogEntry *table, vector<index_t> column_index_map,
+	PhysicalInsert(LogicalOperator &op, TableCatalogEntry *table, vector<idx_t> column_index_map,
 	               vector<unique_ptr<Expression>> bound_defaults)
 	    : PhysicalOperator(PhysicalOperatorType::INSERT, op.types), column_index_map(column_index_map), table(table),
 	      bound_defaults(move(bound_defaults)) {
 	}
 
-	vector<index_t> column_index_map;
+	vector<idx_t> column_index_map;
 	TableCatalogEntry *table;
 	vector<unique_ptr<Expression>> bound_defaults;
 

--- a/src/include/duckdb/execution/operator/set/physical_recursive_cte.hpp
+++ b/src/include/duckdb/execution/operator/set/physical_recursive_cte.hpp
@@ -12,20 +12,22 @@
 #include "duckdb/common/types/chunk_collection.hpp"
 
 namespace duckdb {
-    class PhysicalRecursiveCTE : public PhysicalOperator {
-    public:
-        PhysicalRecursiveCTE(LogicalOperator &op, bool union_all, unique_ptr<PhysicalOperator> top, unique_ptr<PhysicalOperator> bottom);
+class PhysicalRecursiveCTE : public PhysicalOperator {
+public:
+	PhysicalRecursiveCTE(LogicalOperator &op, bool union_all, unique_ptr<PhysicalOperator> top,
+	                     unique_ptr<PhysicalOperator> bottom);
 
-        bool union_all;
-        std::shared_ptr<ChunkCollection> working_table;
-        ChunkCollection intermediate_table;
-    public:
-        void GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;
-        unique_ptr<PhysicalOperatorState> GetOperatorState() override;
+	bool union_all;
+	std::shared_ptr<ChunkCollection> working_table;
+	ChunkCollection intermediate_table;
 
-    private:
-        //! Probe Hash Table and eliminate duplicate rows
-        index_t ProbeHT(DataChunk &chunk, PhysicalOperatorState *state);
-    };
+public:
+	void GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;
+	unique_ptr<PhysicalOperatorState> GetOperatorState() override;
+
+private:
+	//! Probe Hash Table and eliminate duplicate rows
+	idx_t ProbeHT(DataChunk &chunk, PhysicalOperatorState *state);
+};
 
 }; // namespace duckdb

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -63,7 +63,7 @@ public:
 	vector<TypeId> types;
 
 public:
-	string ToString(index_t depth = 0) const;
+	string ToString(idx_t depth = 0) const;
 	void Print();
 
 	//! Return a vector of the types that will be returned by this operator

--- a/src/include/duckdb/execution/physical_plan_generator.hpp
+++ b/src/include/duckdb/execution/physical_plan_generator.hpp
@@ -27,7 +27,7 @@ public:
 	unordered_set<CatalogEntry *> dependencies;
 	//! Recursive CTEs require at least one ChunkScan, referencing the working_table.
 	//! This data structure is used to establish it.
-    unordered_map<index_t, std::shared_ptr<ChunkCollection>> rec_ctes;
+	unordered_map<idx_t, std::shared_ptr<ChunkCollection>> rec_ctes;
 
 public:
 	//! Creates a plan from the logical operator. This involves resolving column bindings and generating physical

--- a/src/include/duckdb/execution/window_segment_tree.hpp
+++ b/src/include/duckdb/execution/window_segment_tree.hpp
@@ -17,11 +17,11 @@ namespace duckdb {
 class WindowSegmentTree {
 public:
 	WindowSegmentTree(AggregateFunction &aggregate, TypeId result_type, ChunkCollection *input);
-	Value Compute(index_t start, index_t end);
+	Value Compute(idx_t start, idx_t end);
 
 private:
 	void ConstructTree();
-	void WindowSegmentValue(index_t l_idx, index_t begin, index_t end);
+	void WindowSegmentValue(idx_t l_idx, idx_t begin, idx_t end);
 	void AggregateInit();
 	Value AggegateFinal();
 
@@ -30,12 +30,12 @@ private:
 	Vector statep;
 	TypeId result_type;
 	unique_ptr<data_t[]> levels_flat_native;
-	vector<index_t> levels_flat_start;
+	vector<idx_t> levels_flat_start;
 	unique_ptr<Vector[]> inputs;
 
 	ChunkCollection *input_ref;
 
-	static constexpr index_t TREE_FANOUT = 64; // this should cleanly divide STANDARD_VECTOR_SIZE
+	static constexpr idx_t TREE_FANOUT = 64; // this should cleanly divide STANDARD_VECTOR_SIZE
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/function/aggregate/distributive_functions.hpp
+++ b/src/include/duckdb/function/aggregate/distributive_functions.hpp
@@ -15,11 +15,11 @@ namespace duckdb {
 
 void gather_finalize(Vector &payloads, Vector &result);
 
-index_t get_bigint_type_size(TypeId return_type);
+idx_t get_bigint_type_size(TypeId return_type);
 void bigint_payload_initialize(data_ptr_t payload, TypeId return_type);
 Value bigint_simple_initialize();
 
-index_t get_return_type_size(TypeId return_type);
+idx_t get_return_type_size(TypeId return_type);
 
 void null_state_initialize(data_ptr_t state, TypeId return_type);
 Value null_simple_initialize();

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -13,18 +13,18 @@
 namespace duckdb {
 
 //! The type used for sizing hashed aggregate function states
-typedef index_t (*aggregate_size_t)(TypeId return_type);
+typedef idx_t (*aggregate_size_t)(TypeId return_type);
 //! The type used for initializing hashed aggregate function states
 typedef void (*aggregate_initialize_t)(data_ptr_t state, TypeId return_type);
 //! The type used for updating hashed aggregate functions
-typedef void (*aggregate_update_t)(Vector inputs[], index_t input_count, Vector &state);
+typedef void (*aggregate_update_t)(Vector inputs[], idx_t input_count, Vector &state);
 //! The type used for combining hashed aggregate states (optional)
 typedef void (*aggregate_combine_t)(Vector &state, Vector &combined);
 //! The type used for finalizing hashed aggregate function payloads
 typedef void (*aggregate_finalize_t)(Vector &state, Vector &result);
 
 //! The type used for updating simple (non-grouped) aggregate functions
-typedef void (*aggregate_simple_update_t)(Vector inputs[], index_t input_count, data_ptr_t state);
+typedef void (*aggregate_simple_update_t)(Vector inputs[], idx_t input_count, data_ptr_t state);
 
 class AggregateFunction : public SimpleFunction {
 public:

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -58,10 +58,10 @@ public:
 
 	//! Bind a scalar function from the set of functions and input arguments. Returns the index of the chosen function,
 	//! or throws an exception if none could be found.
-	static index_t BindFunction(string name, vector<ScalarFunction> &functions, vector<SQLType> &arguments);
+	static idx_t BindFunction(string name, vector<ScalarFunction> &functions, vector<SQLType> &arguments);
 	//! Bind an aggregate function from the set of functions and input arguments. Returns the index of the chosen
 	//! function, or throws an exception if none could be found.
-	static index_t BindFunction(string name, vector<AggregateFunction> &functions, vector<SQLType> &arguments);
+	static idx_t BindFunction(string name, vector<AggregateFunction> &functions, vector<SQLType> &arguments);
 };
 
 class SimpleFunction : public Function {

--- a/src/include/duckdb/function/scalar/struct_functions.hpp
+++ b/src/include/duckdb/function/scalar/struct_functions.hpp
@@ -13,7 +13,6 @@
 
 namespace duckdb {
 
-
 struct StructPackBindData : public FunctionData {
 	SQLType stype;
 
@@ -25,24 +24,22 @@ struct StructPackBindData : public FunctionData {
 	}
 };
 
-
 struct StructPackFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
 struct StructExtractBindData : public FunctionData {
 	string key;
-	index_t index;
+	idx_t index;
 	TypeId type;
 
-	StructExtractBindData(string key, index_t index, TypeId type) : key(key), index(index), type(type) {
+	StructExtractBindData(string key, idx_t index, TypeId type) : key(key), index(index), type(type) {
 	}
 
 	unique_ptr<FunctionData> Copy() override {
 		return make_unique<StructExtractBindData>(key, index, type);
 	}
 };
-
 
 struct StructExtractFun {
 	static void RegisterFunction(BuiltinFunctions &set);

--- a/src/include/duckdb/main/appender.hpp
+++ b/src/include/duckdb/main/appender.hpp
@@ -27,7 +27,7 @@ class Appender {
 	//! Internal chunk used for appends
 	DataChunk chunk;
 	//! The current column to append to
-	index_t column = 0;
+	idx_t column = 0;
 	//! Message explaining why the Appender is invalidated (if any)
 	string invalidated_msg;
 
@@ -60,9 +60,9 @@ public:
 	void Close();
 
 	//! Obtain a reference to the internal vector that is used to append to the table
-	Vector &GetAppendVector(index_t col_idx);
+	Vector &GetAppendVector(idx_t col_idx);
 
-	index_t CurrentColumn() {
+	idx_t CurrentColumn() {
 		return column;
 	}
 

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -125,7 +125,7 @@ private:
 	                                             bool allow_stream_result);
 
 private:
-	index_t prepare_count = 0;
+	idx_t prepare_count = 0;
 	//! The currently opened StreamQueryResult (if any)
 	StreamQueryResult *open_result = nullptr;
 	//! Prepared statement objects that were created using the ClientContext::Prepare method

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -31,14 +31,14 @@ public:
 	//! Access mode of the database (AUTOMATIC, READ_ONLY or READ_WRITE)
 	AccessMode access_mode = AccessMode::AUTOMATIC;
 	// Checkpoint when WAL reaches this size
-	index_t checkpoint_wal_size = 1 << 20;
+	idx_t checkpoint_wal_size = 1 << 20;
 	//! Whether or not to use Direct IO, bypassing operating system buffers
 	bool use_direct_io = false;
 	//! The FileSystem to use, can be overwritten to allow for injecting custom file systems for testing purposes (e.g.
 	//! RamFS or something similar)
 	unique_ptr<FileSystem> file_system;
 	//! The maximum memory used by the database system (in bytes). Default: Infinite
-	index_t maximum_memory = (index_t)-1;
+	idx_t maximum_memory = (idx_t)-1;
 	//! Whether or not to create and use a temporary directory to store intermediates that do not fit in memory
 	bool use_temporary_directory = true;
 	//! Directory to store temporary structures that do not fit in memory
@@ -68,8 +68,8 @@ public:
 	AccessMode access_mode;
 	bool use_direct_io;
 	bool checkpoint_only;
-	index_t checkpoint_wal_size;
-	index_t maximum_memory;
+	idx_t checkpoint_wal_size;
+	idx_t maximum_memory;
 	string temporary_directory;
 
 private:

--- a/src/include/duckdb/main/materialized_query_result.hpp
+++ b/src/include/duckdb/main/materialized_query_result.hpp
@@ -30,9 +30,9 @@ public:
 	string ToString() override;
 
 	//! Gets the (index) value of the (column index) column
-	Value GetValue(index_t column, index_t index);
+	Value GetValue(idx_t column, idx_t index);
 
-	template <class T> T GetValue(index_t column, index_t index) {
+	template <class T> T GetValue(idx_t column, idx_t index) {
 		auto value = GetValue(column, index);
 		return (T)value.GetValue<int64_t>();
 	}

--- a/src/include/duckdb/main/prepared_statement.hpp
+++ b/src/include/duckdb/main/prepared_statement.hpp
@@ -18,7 +18,7 @@ class PreparedStatementData;
 class PreparedStatement {
 public:
 	//! Create a successfully prepared prepared statement object with the given name
-	PreparedStatement(ClientContext *context, string name, PreparedStatementData &data, index_t n_param = 0);
+	PreparedStatement(ClientContext *context, string name, PreparedStatementData &data, idx_t n_param = 0);
 	//! Create a prepared statement that was not successfully prepared
 	PreparedStatement(string error);
 
@@ -37,7 +37,7 @@ public:
 	//! Whether or not the prepared statement has been invalidated because the underlying connection has been destroyed
 	bool is_invalidated;
 	//! The amount of bound parameters
-	index_t n_param;
+	idx_t n_param;
 	//! The result SQL types of the prepared statement
 	vector<SQLType> types;
 	//! The result names of the prepared statement

--- a/src/include/duckdb/main/prepared_statement_data.hpp
+++ b/src/include/duckdb/main/prepared_statement_data.hpp
@@ -31,7 +31,7 @@ public:
 	//! The fully prepared physical plan of the prepared statement
 	unique_ptr<PhysicalOperator> plan;
 	//! The map of parameter index to the actual value entry
-	unordered_map<index_t, PreparedValueEntry> value_map;
+	unordered_map<idx_t, PreparedValueEntry> value_map;
 	//! Any internal catalog dependencies of the prepared statement
 	unordered_set<CatalogEntry *> dependencies;
 
@@ -44,13 +44,15 @@ public:
 
 	//! Whether or not the statement is a read-only statement, or whether it can result in changes to the database
 	bool read_only;
-	//! Whether or not the statement requires a valid transaction. Almost all statements require this, with the exception of
+	//! Whether or not the statement requires a valid transaction. Almost all statements require this, with the
+	//! exception of
 	bool requires_valid_transaction;
+
 public:
 	//! Bind a set of values to the prepared statement data
 	void Bind(vector<Value> values);
 	//! Get the expected SQL Type of the bound parameter
-	SQLType GetType(index_t param_index);
+	SQLType GetType(idx_t param_index);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -26,7 +26,7 @@ class QueryProfiler {
 public:
 	struct TimingInformation {
 		double time = 0;
-		index_t elements = 0;
+		idx_t elements = 0;
 
 		TimingInformation() : time(0), elements(0) {
 		}
@@ -37,15 +37,15 @@ public:
 		vector<string> split_extra_info;
 		TimingInformation info;
 		vector<unique_ptr<TreeNode>> children;
-		index_t depth = 0;
+		idx_t depth = 0;
 	};
 
 private:
-	static index_t GetDepth(QueryProfiler::TreeNode &node);
-	unique_ptr<TreeNode> CreateTree(PhysicalOperator *root, index_t depth = 0);
+	static idx_t GetDepth(QueryProfiler::TreeNode &node);
+	unique_ptr<TreeNode> CreateTree(PhysicalOperator *root, idx_t depth = 0);
 
-	static index_t RenderTreeRecursive(TreeNode &node, vector<string> &render, vector<index_t> &render_heights,
-	                                   index_t base_render_x = 0, index_t start_depth = 0, index_t depth = 0);
+	static idx_t RenderTreeRecursive(TreeNode &node, vector<string> &render, vector<idx_t> &render_heights,
+	                                 idx_t base_render_x = 0, idx_t start_depth = 0, idx_t depth = 0);
 	static string RenderTree(TreeNode &node);
 
 public:

--- a/src/include/duckdb/main/query_result.hpp
+++ b/src/include/duckdb/main/query_result.hpp
@@ -70,9 +70,9 @@ private:
 		}
 
 		QueryResultIterator &iterator;
-		index_t row;
+		idx_t row;
 
-		template <class T> T GetValue(index_t col_idx) const {
+		template <class T> T GetValue(idx_t col_idx) const {
 			return iterator.result->iterator_chunk->data[col_idx].GetValue(iterator.row_idx).GetValue<T>();
 		}
 	};
@@ -87,7 +87,7 @@ private:
 
 		QueryResultRow current_row;
 		QueryResult *result;
-		index_t row_idx;
+		idx_t row_idx;
 
 	public:
 		void Next() {

--- a/src/include/duckdb/optimizer/column_lifetime_optimizer.hpp
+++ b/src/include/duckdb/optimizer/column_lifetime_optimizer.hpp
@@ -39,6 +39,6 @@ private:
 
 	void ExtractUnusedColumnBindings(vector<ColumnBinding> bindings, column_binding_set_t &unused_bindings);
 	void GenerateProjectionMap(vector<ColumnBinding> bindings, column_binding_set_t &unused_bindings,
-	                           vector<index_t> &map);
+	                           vector<idx_t> &map);
 };
 } // namespace duckdb

--- a/src/include/duckdb/optimizer/cse_optimizer.hpp
+++ b/src/include/duckdb/optimizer/cse_optimizer.hpp
@@ -18,10 +18,10 @@ namespace duckdb {
 class CommonSubExpressionOptimizer : public LogicalOperatorVisitor {
 private:
 	struct CSENode {
-		index_t count;
+		idx_t count;
 		Expression *expr;
 
-		CSENode(index_t count = 1, Expression *expr = nullptr) : count(count), expr(expr) {
+		CSENode(idx_t count = 1, Expression *expr = nullptr) : count(count), expr(expr) {
 		}
 	};
 

--- a/src/include/duckdb/optimizer/expression_heuristics.hpp
+++ b/src/include/duckdb/optimizer/expression_heuristics.hpp
@@ -26,27 +26,27 @@ public:
 	//! Reorder the expressions of a filter
 	void ReorderExpressions(vector<unique_ptr<Expression>> &expressions);
 	//! Return the cost of an expression
-	index_t Cost(Expression &expr);
+	idx_t Cost(Expression &expr);
 
 	unique_ptr<Expression> VisitReplace(BoundConjunctionExpression &expr, unique_ptr<Expression> *expr_ptr) override;
 	//! Override this function to search for filter operators
 	void VisitOperator(LogicalOperator &op) override;
 
 private:
-	std::unordered_map<std::string, index_t> function_costs = {
+	std::unordered_map<std::string, idx_t> function_costs = {
 	    {"+", 5},       {"-", 5},    {"&", 5},          {"#", 5},
 	    {">>", 5},      {"<<", 5},   {"abs", 5},        {"*", 10},
 	    {"%", 10},      {"/", 15},   {"date_part", 20}, {"year", 20},
 	    {"round", 100}, {"~~", 200}, {"!~~", 200},      {"regexp_matches", 200},
 	    {"||", 200}};
 
-	index_t ExpressionCost(BoundBetweenExpression &expr);
-	index_t ExpressionCost(BoundCaseExpression &expr);
-	index_t ExpressionCost(BoundCastExpression &expr);
-	index_t ExpressionCost(BoundComparisonExpression &expr);
-	index_t ExpressionCost(BoundConjunctionExpression &expr);
-	index_t ExpressionCost(BoundFunctionExpression &expr);
-	index_t ExpressionCost(BoundOperatorExpression &expr, ExpressionType &expr_type);
-	index_t ExpressionCost(TypeId &return_type, index_t multiplier);
+	idx_t ExpressionCost(BoundBetweenExpression &expr);
+	idx_t ExpressionCost(BoundCaseExpression &expr);
+	idx_t ExpressionCost(BoundCastExpression &expr);
+	idx_t ExpressionCost(BoundComparisonExpression &expr);
+	idx_t ExpressionCost(BoundConjunctionExpression &expr);
+	idx_t ExpressionCost(BoundFunctionExpression &expr);
+	idx_t ExpressionCost(BoundOperatorExpression &expr, ExpressionType &expr_type);
+	idx_t ExpressionCost(TypeId &return_type, idx_t multiplier);
 };
 } // namespace duckdb

--- a/src/include/duckdb/optimizer/filter_combiner.hpp
+++ b/src/include/duckdb/optimizer/filter_combiner.hpp
@@ -41,16 +41,16 @@ private:
 	FilterResult AddFilter(Expression *expr);
 
 	Expression *GetNode(Expression *expr);
-	index_t GetEquivalenceSet(Expression *expr);
+	idx_t GetEquivalenceSet(Expression *expr);
 	FilterResult AddConstantComparison(vector<ExpressionValueInformation> &info_list, ExpressionValueInformation info);
 
 	vector<unique_ptr<Expression>> remaining_filters;
 
 	expression_map_t<unique_ptr<Expression>> stored_expressions;
-	unordered_map<Expression *, index_t> equivalence_set_map;
-	unordered_map<index_t, vector<ExpressionValueInformation>> constant_values;
-	unordered_map<index_t, vector<Expression *>> equivalence_map;
-	index_t set_index = 0;
+	unordered_map<Expression *, idx_t> equivalence_set_map;
+	unordered_map<idx_t, vector<ExpressionValueInformation>> constant_values;
+	unordered_map<idx_t, vector<Expression *>> equivalence_map;
+	idx_t set_index = 0;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/optimizer/filter_pushdown.hpp
+++ b/src/include/duckdb/optimizer/filter_pushdown.hpp
@@ -24,7 +24,7 @@ public:
 	unique_ptr<LogicalOperator> Rewrite(unique_ptr<LogicalOperator> node);
 
 	struct Filter {
-		unordered_set<index_t> bindings;
+		unordered_set<idx_t> bindings;
 		unique_ptr<Expression> filter;
 
 		Filter() {
@@ -53,18 +53,17 @@ private:
 	unique_ptr<LogicalOperator> PushdownSetOperation(unique_ptr<LogicalOperator> op);
 
 	// Pushdown an inner join
-	unique_ptr<LogicalOperator> PushdownInnerJoin(unique_ptr<LogicalOperator> op, unordered_set<index_t> &left_bindings,
-	                                              unordered_set<index_t> &right_bindings);
+	unique_ptr<LogicalOperator> PushdownInnerJoin(unique_ptr<LogicalOperator> op, unordered_set<idx_t> &left_bindings,
+	                                              unordered_set<idx_t> &right_bindings);
 	// Pushdown a left join
-	unique_ptr<LogicalOperator> PushdownLeftJoin(unique_ptr<LogicalOperator> op, unordered_set<index_t> &left_bindings,
-	                                             unordered_set<index_t> &right_bindings);
+	unique_ptr<LogicalOperator> PushdownLeftJoin(unique_ptr<LogicalOperator> op, unordered_set<idx_t> &left_bindings,
+	                                             unordered_set<idx_t> &right_bindings);
 	// Pushdown a mark join
-	unique_ptr<LogicalOperator> PushdownMarkJoin(unique_ptr<LogicalOperator> op, unordered_set<index_t> &left_bindings,
-	                                             unordered_set<index_t> &right_bindings);
+	unique_ptr<LogicalOperator> PushdownMarkJoin(unique_ptr<LogicalOperator> op, unordered_set<idx_t> &left_bindings,
+	                                             unordered_set<idx_t> &right_bindings);
 	// Pushdown a single join
-	unique_ptr<LogicalOperator> PushdownSingleJoin(unique_ptr<LogicalOperator> op,
-	                                               unordered_set<index_t> &left_bindings,
-	                                               unordered_set<index_t> &right_bindings);
+	unique_ptr<LogicalOperator> PushdownSingleJoin(unique_ptr<LogicalOperator> op, unordered_set<idx_t> &left_bindings,
+	                                               unordered_set<idx_t> &right_bindings);
 
 	// Finish pushing down at this operator, creating a LogicalFilter to store any of the stored filters and recursively
 	// pushing down into its children (if any)

--- a/src/include/duckdb/optimizer/join_order/query_graph.hpp
+++ b/src/include/duckdb/optimizer/join_order/query_graph.hpp
@@ -20,7 +20,7 @@ class Expression;
 class LogicalOperator;
 
 struct FilterInfo {
-	index_t filter_index;
+	idx_t filter_index;
 	RelationSet *left_set = nullptr;
 	RelationSet *right_set = nullptr;
 	RelationSet *set = nullptr;
@@ -28,7 +28,7 @@ struct FilterInfo {
 
 struct FilterNode {
 	vector<FilterInfo *> filters;
-	unordered_map<index_t, unique_ptr<FilterNode>> children;
+	unordered_map<idx_t, unique_ptr<FilterNode>> children;
 };
 
 struct NeighborInfo {
@@ -42,7 +42,7 @@ public:
 	//! Contains a node with info about neighboring relations and child edge infos
 	struct QueryEdge {
 		vector<unique_ptr<NeighborInfo>> neighbors;
-		unordered_map<index_t, unique_ptr<QueryEdge>> children;
+		unordered_map<idx_t, unique_ptr<QueryEdge>> children;
 	};
 
 public:
@@ -55,7 +55,7 @@ public:
 	NeighborInfo *GetConnection(RelationSet *node, RelationSet *other);
 	//! Enumerate the neighbors of a specific node that do not belong to any of the exclusion_set. Note that if a
 	//! neighbor has multiple nodes, this function will return the lowest entry in that set.
-	vector<index_t> GetNeighbors(RelationSet *node, unordered_set<index_t> &exclusion_set);
+	vector<idx_t> GetNeighbors(RelationSet *node, unordered_set<idx_t> &exclusion_set);
 	//! Enumerate all neighbors of a given RelationSet node
 	void EnumerateNeighbors(RelationSet *node, std::function<bool(NeighborInfo *)> callback);
 

--- a/src/include/duckdb/optimizer/join_order/relation.hpp
+++ b/src/include/duckdb/optimizer/join_order/relation.hpp
@@ -28,13 +28,13 @@ struct Relation {
 
 //! Set of relations, used in the join graph.
 struct RelationSet {
-	RelationSet(unique_ptr<index_t[]> relations, index_t count) : relations(move(relations)), count(count) {
+	RelationSet(unique_ptr<idx_t[]> relations, idx_t count) : relations(move(relations)), count(count) {
 	}
 
 	string ToString() const;
 
-	unique_ptr<index_t[]> relations;
-	index_t count;
+	unique_ptr<idx_t[]> relations;
+	idx_t count;
 
 	static bool IsSubset(RelationSet *super, RelationSet *sub);
 };
@@ -46,16 +46,16 @@ public:
 	// FIXME: this structure is inefficient, could use a bitmap for lookup instead (todo: profile)
 	struct RelationTreeNode {
 		unique_ptr<RelationSet> relation;
-		unordered_map<index_t, unique_ptr<RelationTreeNode>> children;
+		unordered_map<idx_t, unique_ptr<RelationTreeNode>> children;
 	};
 
 public:
 	//! Create or get a RelationSet from a single node with the given index
-	RelationSet *GetRelation(index_t index);
+	RelationSet *GetRelation(idx_t index);
 	//! Create or get a RelationSet from a set of relation bindings
-	RelationSet *GetRelation(unordered_set<index_t> &bindings);
+	RelationSet *GetRelation(unordered_set<idx_t> &bindings);
 	//! Create or get a RelationSet from a (sorted, duplicate-free!) list of relations
-	RelationSet *GetRelation(unique_ptr<index_t[]> relations, index_t count);
+	RelationSet *GetRelation(unique_ptr<idx_t[]> relations, idx_t count);
 	//! Union two sets of relations together and create a new relation set
 	RelationSet *Union(RelationSet *left, RelationSet *right);
 	//! Create the set difference of left \ right (i.e. all elements in left that are not in right)

--- a/src/include/duckdb/optimizer/join_order_optimizer.hpp
+++ b/src/include/duckdb/optimizer/join_order_optimizer.hpp
@@ -26,18 +26,17 @@ public:
 	struct JoinNode {
 		RelationSet *set;
 		NeighborInfo *info;
-		index_t cardinality;
-		index_t cost;
+		idx_t cardinality;
+		idx_t cost;
 		JoinNode *left;
 		JoinNode *right;
 
 		//! Create a leaf node in the join tree
-		JoinNode(RelationSet *set, index_t cardinality)
+		JoinNode(RelationSet *set, idx_t cardinality)
 		    : set(set), info(nullptr), cardinality(cardinality), cost(cardinality), left(nullptr), right(nullptr) {
 		}
 		//! Create an intermediate node in the join tree
-		JoinNode(RelationSet *set, NeighborInfo *info, JoinNode *left, JoinNode *right, index_t cardinality,
-		         index_t cost)
+		JoinNode(RelationSet *set, NeighborInfo *info, JoinNode *left, JoinNode *right, idx_t cardinality, idx_t cost)
 		    : set(set), info(info), cardinality(cardinality), cost(cost), left(left), right(right) {
 		}
 	};
@@ -48,11 +47,11 @@ public:
 
 private:
 	//! The total amount of join pairs that have been considered
-	index_t pairs = 0;
+	idx_t pairs = 0;
 	//! Set of all relations considered in the join optimizer
 	vector<unique_ptr<Relation>> relations;
 	//! A mapping of base table index -> index into relations array (relation number)
-	unordered_map<index_t, index_t> relation_mapping;
+	unordered_map<idx_t, idx_t> relation_mapping;
 	//! A structure holding all the created RelationSet objects
 	RelationSetManager set_manager;
 	//! The set of edges used in the join optimizer
@@ -69,7 +68,7 @@ private:
 	expression_map_t<vector<FilterInfo *>> equivalence_sets;
 
 	//! Extract the bindings referred to by an Expression
-	bool ExtractBindings(Expression &expression, unordered_set<index_t> &bindings);
+	bool ExtractBindings(Expression &expression, unordered_set<idx_t> &bindings);
 	//! Traverse the query tree to find (1) base relations, (2) existing join conditions and (3) filters that can be
 	//! rewritten into joins. Returns true if there are joins in the tree that can be reordered, false otherwise.
 	bool ExtractJoinRelations(LogicalOperator &input_op, vector<LogicalOperator *> &filter_operators,
@@ -81,11 +80,11 @@ private:
 	//! cancelling the dynamic programming step.
 	bool TryEmitPair(RelationSet *left, RelationSet *right, NeighborInfo *info);
 
-	bool EnumerateCmpRecursive(RelationSet *left, RelationSet *right, unordered_set<index_t> exclusion_set);
+	bool EnumerateCmpRecursive(RelationSet *left, RelationSet *right, unordered_set<idx_t> exclusion_set);
 	//! Emit a relation set node
 	bool EmitCSG(RelationSet *node);
 	//! Enumerate the possible connected subgraphs that can be joined together in the join graph
-	bool EnumerateCSGRecursive(RelationSet *node, unordered_set<index_t> &exclusion_set);
+	bool EnumerateCSGRecursive(RelationSet *node, unordered_set<idx_t> &exclusion_set);
 	//! Rewrite a logical query plan given the join plan
 	unique_ptr<LogicalOperator> RewritePlan(unique_ptr<LogicalOperator> plan, JoinNode *node);
 	//! Generate cross product edges inside the side

--- a/src/include/duckdb/optimizer/matcher/set_matcher.hpp
+++ b/src/include/duckdb/optimizer/matcher/set_matcher.hpp
@@ -28,14 +28,14 @@ public:
 	/* The double {{}} in the intializer for excluded_entries is intentional, workaround for bug in gcc-4.9 */
 	template <class T, class MATCHER>
 	static bool MatchRecursive(vector<unique_ptr<MATCHER>> &matchers, vector<T *> &entries, vector<T *> &bindings,
-	                           unordered_set<index_t> excluded_entries, index_t m_idx = 0) {
+	                           unordered_set<idx_t> excluded_entries, idx_t m_idx = 0) {
 		if (m_idx == matchers.size()) {
 			// matched all matchers!
 			return true;
 		}
 		// try to find a match for the current matcher (m_idx)
-		index_t previous_binding_count = bindings.size();
-		for (index_t e_idx = 0; e_idx < entries.size(); e_idx++) {
+		idx_t previous_binding_count = bindings.size();
+		for (idx_t e_idx = 0; e_idx < entries.size(); e_idx++) {
 			// first check if this entry has already been matched
 			if (excluded_entries.find(e_idx) != excluded_entries.end()) {
 				// it has been matched: skip this entry
@@ -46,7 +46,7 @@ public:
 				// m_idx matches e_idx!
 				// check if we can find a complete match for this path
 				// first add e_idx to the new set of excluded entries
-				unordered_set<index_t> new_excluded_entries;
+				unordered_set<idx_t> new_excluded_entries;
 				new_excluded_entries = excluded_entries;
 				new_excluded_entries.insert(e_idx);
 				// then match the next matcher in the set
@@ -71,7 +71,7 @@ public:
 				return false;
 			}
 			// now entries have to match in order
-			for (index_t i = 0; i < matchers.size(); i++) {
+			for (idx_t i = 0; i < matchers.size(); i++) {
 				if (!matchers[i]->Match(entries[i], bindings)) {
 					return false;
 				}
@@ -89,7 +89,7 @@ public:
 			// now perform the actual matching
 			// every matcher has to match a UNIQUE entry
 			// we perform this matching in a recursive way
-			unordered_set<index_t> excluded_entries;
+			unordered_set<idx_t> excluded_entries;
 			if (!MatchRecursive(matchers, entries, bindings, excluded_entries)) {
 				return false;
 			}

--- a/src/include/duckdb/optimizer/remove_unused_columns.hpp
+++ b/src/include/duckdb/optimizer/remove_unused_columns.hpp
@@ -34,7 +34,7 @@ private:
 	column_binding_map_t<vector<BoundColumnRefExpression *>> column_references;
 
 private:
-	template <class T> void ClearUnusedExpressions(vector<T> &list, index_t table_idx);
+	template <class T> void ClearUnusedExpressions(vector<T> &list, idx_t table_idx);
 
 	//! Perform a replacement of the ColumnBinding, iterating over all the currently found column references and
 	//! replacing the bindings

--- a/src/include/duckdb/optimizer/rule/distributivity.hpp
+++ b/src/include/duckdb/optimizer/rule/distributivity.hpp
@@ -22,7 +22,7 @@ public:
 
 private:
 	void AddExpressionSet(Expression &expr, expression_set_t &set);
-	unique_ptr<Expression> ExtractExpression(BoundConjunctionExpression &conj, index_t idx, Expression &expr);
+	unique_ptr<Expression> ExtractExpression(BoundConjunctionExpression &conj, idx_t idx, Expression &expr);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/column_definition.hpp
+++ b/src/include/duckdb/parser/column_definition.hpp
@@ -26,7 +26,7 @@ public:
 	//! The name of the entry
 	string name;
 	//! The index of the column in the table
-	index_t oid;
+	idx_t oid;
 	//! The type of the column
 	SQLType type;
 	//! The default value of the column (if any)

--- a/src/include/duckdb/parser/expression/parameter_expression.hpp
+++ b/src/include/duckdb/parser/expression/parameter_expression.hpp
@@ -15,7 +15,7 @@ class ParameterExpression : public ParsedExpression {
 public:
 	ParameterExpression();
 
-	index_t parameter_nr;
+	idx_t parameter_nr;
 
 public:
 	bool IsScalar() const override {

--- a/src/include/duckdb/parser/parsed_data/create_index_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_index_info.hpp
@@ -18,7 +18,7 @@ struct CreateIndexInfo : public ParseInfo {
 	}
 
 	////! Index Type (e.g., B+-tree, Skip-List, ...)
-	IndexType index_type;
+	IndexType idx_type;
 	////! Name of the Index
 	string index_name;
 	////! If it is an unique index

--- a/src/include/duckdb/parser/parser.hpp
+++ b/src/include/duckdb/parser/parser.hpp
@@ -32,7 +32,7 @@ public:
 	//! The parsed SQL statements from an invocation to ParseQuery.
 	vector<unique_ptr<SQLStatement>> statements;
 
-	index_t n_prepared_parameters = 0;
+	idx_t n_prepared_parameters = 0;
 
 private:
 	//! Transform a Postgres parse tree into a set of SQL Statements

--- a/src/include/duckdb/parser/sql_statement.hpp
+++ b/src/include/duckdb/parser/sql_statement.hpp
@@ -22,7 +22,7 @@ public:
 	}
 
 	StatementType type;
-	index_t stmt_location;
-	index_t stmt_length;
+	idx_t stmt_location;
+	idx_t stmt_length;
 };
 } // namespace duckdb

--- a/src/include/duckdb/parser/transformer.hpp
+++ b/src/include/duckdb/parser/transformer.hpp
@@ -30,7 +30,7 @@ public:
 	bool TransformParseTree(PGList *tree, vector<unique_ptr<SQLStatement>> &statements);
 	string NodetypeToString(PGNodeTag type);
 
-	index_t prepared_statement_parameter_index = 0;
+	idx_t prepared_statement_parameter_index = 0;
 
 private:
 	//! Transforms a Postgres statement into a single SQL statement
@@ -119,14 +119,14 @@ private:
 	//===--------------------------------------------------------------------===//
 	unique_ptr<Constraint> TransformConstraint(PGListCell *cell);
 
-	unique_ptr<Constraint> TransformConstraint(PGListCell *cell, ColumnDefinition &column, index_t index);
+	unique_ptr<Constraint> TransformConstraint(PGListCell *cell, ColumnDefinition &column, idx_t index);
 
 	//===--------------------------------------------------------------------===//
 	// Helpers
 	//===--------------------------------------------------------------------===//
 	string TransformAlias(PGAlias *root);
 	void TransformCTE(PGWithClause *de_with_clause, SelectStatement &select);
-    unique_ptr<QueryNode> TransformRecursiveCTE(PGCommonTableExpr *node);
+	unique_ptr<QueryNode> TransformRecursiveCTE(PGCommonTableExpr *node);
 	// Operator String to ExpressionType (e.g. + => OPERATOR_ADD)
 	ExpressionType OperatorToExpressionType(string &op);
 

--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -33,7 +33,7 @@ public:
 	Binding *GetCTEBinding(const string &ctename);
 	//! Binds a column expression to the base table. Returns the bound expression
 	//! or throws an exception if the column could not be bound.
-	BindResult BindColumn(ColumnRefExpression &colref, index_t depth);
+	BindResult BindColumn(ColumnRefExpression &colref, idx_t depth);
 
 	//! Generate column expressions for all columns that are present in the
 	//! referenced tables. This is used to resolve the * expression in a
@@ -43,20 +43,20 @@ public:
 	//! Adds a base table with the given alias to the BindContext.
 	void AddBaseTable(BoundBaseTableRef *bound, const string &alias);
 	//! Adds a subquery with a given alias to the BindContext.
-	void AddSubquery(index_t index, const string &alias, SubqueryRef &ref, BoundQueryNode &subquery);
+	void AddSubquery(idx_t index, const string &alias, SubqueryRef &ref, BoundQueryNode &subquery);
 	//! Adds a table function with a given alias to the BindContext
-	void AddTableFunction(index_t index, const string &alias, TableFunctionCatalogEntry *function_entry);
+	void AddTableFunction(idx_t index, const string &alias, TableFunctionCatalogEntry *function_entry);
 	//! Adds a base table with the given alias to the BindContext.
-	void AddGenericBinding(index_t index, const string &alias, vector<string> names, vector<SQLType> types);
+	void AddGenericBinding(idx_t index, const string &alias, vector<string> names, vector<SQLType> types);
 
 	//! Adds a base table with the given alias to the CTE BindContext.
 	//! We need this to correctly bind recursive CTEs with multiple references.
-	void AddCTEBinding(index_t index, const string &alias, vector<string> names, vector<SQLType> types);
+	void AddCTEBinding(idx_t index, const string &alias, vector<string> names, vector<SQLType> types);
 
 	unordered_set<string> hidden_columns;
 
 	//! Keep track of recursive CTE references
-	unordered_map<string, std::shared_ptr<index_t>> cte_references;
+	unordered_map<string, std::shared_ptr<idx_t>> cte_references;
 
 	unordered_map<string, std::shared_ptr<Binding>> GetCTEBindings() {
 		return cte_bindings;

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -25,7 +25,7 @@ struct CorrelatedColumnInfo {
 	ColumnBinding binding;
 	TypeId type;
 	string name;
-	index_t depth;
+	idx_t depth;
 
 	CorrelatedColumnInfo(BoundColumnRefExpression &expr)
 	    : binding(expr.binding), type(expr.return_type), name(expr.GetName()), depth(expr.depth) {
@@ -65,7 +65,7 @@ public:
 	unique_ptr<BoundCreateTableInfo> BindCreateTableInfo(unique_ptr<CreateTableInfo> info);
 
 	//! Generates an unused index for a table
-	index_t GenerateTableIndex();
+	idx_t GenerateTableIndex();
 
 	//! Add a common table expression to the binder
 	void AddCTE(const string &name, QueryNode *cte);
@@ -90,7 +90,7 @@ private:
 	//! The vector of active binders
 	vector<ExpressionBinder *> active_binders;
 	//! The count of bound_tables
-	index_t bound_tables;
+	idx_t bound_tables;
 
 private:
 	//! Bind the default values of the columns of a table
@@ -118,7 +118,7 @@ private:
 
 	unique_ptr<BoundQueryNode> Bind(SelectNode &node);
 	unique_ptr<BoundQueryNode> Bind(SetOperationNode &node);
-    unique_ptr<BoundQueryNode> Bind(RecursiveCTENode &node);
+	unique_ptr<BoundQueryNode> Bind(RecursiveCTENode &node);
 
 	unique_ptr<BoundTableRef> Bind(TableRef &ref);
 	unique_ptr<BoundTableRef> Bind(BaseTableRef &ref);

--- a/src/include/duckdb/planner/bound_query_node.hpp
+++ b/src/include/duckdb/planner/bound_query_node.hpp
@@ -51,7 +51,7 @@ public:
 	vector<SQLType> types;
 
 public:
-	virtual index_t GetRootIndex() = 0;
+	virtual idx_t GetRootIndex() = 0;
 };
 
 }; // namespace duckdb

--- a/src/include/duckdb/planner/column_binding.hpp
+++ b/src/include/duckdb/planner/column_binding.hpp
@@ -13,12 +13,12 @@
 namespace duckdb {
 
 struct ColumnBinding {
-	index_t table_index;
-	index_t column_index;
+	idx_t table_index;
+	idx_t column_index;
 
 	ColumnBinding() : table_index(INVALID_INDEX), column_index(INVALID_INDEX) {
 	}
-	ColumnBinding(index_t table, index_t column) : table_index(table), column_index(column) {
+	ColumnBinding(idx_t table, idx_t column) : table_index(table), column_index(column) {
 	}
 
 	bool operator==(const ColumnBinding &rhs) const {

--- a/src/include/duckdb/planner/column_binding_map.hpp
+++ b/src/include/duckdb/planner/column_binding_map.hpp
@@ -17,7 +17,7 @@ namespace duckdb {
 
 struct ColumnBindingHashFunction {
 	uint64_t operator()(const ColumnBinding &a) const {
-		return CombineHash(Hash<index_t>(a.table_index), Hash<index_t>(a.column_index));
+		return CombineHash(Hash<idx_t>(a.table_index), Hash<idx_t>(a.column_index));
 	}
 };
 

--- a/src/include/duckdb/planner/constraints/bound_unique_constraint.hpp
+++ b/src/include/duckdb/planner/constraints/bound_unique_constraint.hpp
@@ -15,12 +15,12 @@ namespace duckdb {
 
 class BoundUniqueConstraint : public BoundConstraint {
 public:
-	BoundUniqueConstraint(unordered_set<index_t> keys, bool is_primary_key)
+	BoundUniqueConstraint(unordered_set<idx_t> keys, bool is_primary_key)
 	    : BoundConstraint(ConstraintType::UNIQUE), keys(keys), is_primary_key(is_primary_key) {
 	}
 
 	//! The same keys but represented as an unordered set
-	unordered_set<index_t> keys;
+	unordered_set<idx_t> keys;
 	//! Whether or not the unique constraint is a primary key
 	bool is_primary_key;
 };

--- a/src/include/duckdb/planner/expression/bound_columnref_expression.hpp
+++ b/src/include/duckdb/planner/expression/bound_columnref_expression.hpp
@@ -18,14 +18,14 @@ namespace duckdb {
 //! BoundExpressions, which refer to indexes into the physical chunks that pass through the executor.
 class BoundColumnRefExpression : public Expression {
 public:
-	BoundColumnRefExpression(TypeId type, ColumnBinding binding, index_t depth = 0);
-	BoundColumnRefExpression(string alias, TypeId type, ColumnBinding binding, index_t depth = 0);
+	BoundColumnRefExpression(TypeId type, ColumnBinding binding, idx_t depth = 0);
+	BoundColumnRefExpression(string alias, TypeId type, ColumnBinding binding, idx_t depth = 0);
 
 	//! Column index set by the binder, used to generate the final BoundExpression
 	ColumnBinding binding;
 	//! The subquery depth (i.e. depth 0 = current query, depth 1 = parent query, depth 2 = parent of parent, etc...).
 	//! This is only non-zero for correlated expressions inside subqueries.
-	index_t depth;
+	idx_t depth;
 
 public:
 	bool IsScalar() const override {

--- a/src/include/duckdb/planner/expression/bound_parameter_expression.hpp
+++ b/src/include/duckdb/planner/expression/bound_parameter_expression.hpp
@@ -15,10 +15,10 @@ namespace duckdb {
 
 class BoundParameterExpression : public Expression {
 public:
-	BoundParameterExpression(index_t parameter_nr);
+	BoundParameterExpression(idx_t parameter_nr);
 
 	SQLType sql_type;
-	index_t parameter_nr;
+	idx_t parameter_nr;
 	Value *value;
 
 public:

--- a/src/include/duckdb/planner/expression/bound_reference_expression.hpp
+++ b/src/include/duckdb/planner/expression/bound_reference_expression.hpp
@@ -15,11 +15,11 @@ namespace duckdb {
 //! A BoundReferenceExpression represents a physical index into a DataChunk
 class BoundReferenceExpression : public Expression {
 public:
-	BoundReferenceExpression(string alias, TypeId type, index_t index);
-	BoundReferenceExpression(TypeId type, index_t index);
+	BoundReferenceExpression(string alias, TypeId type, idx_t index);
+	BoundReferenceExpression(TypeId type, idx_t index);
 
 	//! Index used to access data in the chunks
-	index_t index;
+	idx_t index;
 
 public:
 	bool IsScalar() const override {

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -52,7 +52,7 @@ public:
 		return bound_columns;
 	}
 
-	string Bind(unique_ptr<ParsedExpression> *expr, index_t depth, bool root_expression = false);
+	string Bind(unique_ptr<ParsedExpression> *expr, idx_t depth, bool root_expression = false);
 
 	// Bind table names to ColumnRefExpressions
 	void BindTableNames(ParsedExpression &expr);
@@ -64,27 +64,27 @@ public:
 	SQLType target_type;
 
 protected:
-	virtual BindResult BindExpression(ParsedExpression &expr, index_t depth, bool root_expression = false);
+	virtual BindResult BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression = false);
 
-	BindResult BindExpression(CaseExpression &expr, index_t depth);
-	BindResult BindExpression(CastExpression &expr, index_t depth);
-	BindResult BindExpression(ColumnRefExpression &expr, index_t depth);
-	BindResult BindExpression(ComparisonExpression &expr, index_t depth);
-	BindResult BindExpression(ConjunctionExpression &expr, index_t depth);
-	BindResult BindExpression(ConstantExpression &expr, index_t depth);
-	BindResult BindExpression(FunctionExpression &expr, index_t depth);
-	BindResult BindExpression(OperatorExpression &expr, index_t depth);
-	BindResult BindExpression(ParameterExpression &expr, index_t depth);
-	BindResult BindExpression(StarExpression &expr, index_t depth);
-	BindResult BindExpression(SubqueryExpression &expr, index_t depth);
+	BindResult BindExpression(CaseExpression &expr, idx_t depth);
+	BindResult BindExpression(CastExpression &expr, idx_t depth);
+	BindResult BindExpression(ColumnRefExpression &expr, idx_t depth);
+	BindResult BindExpression(ComparisonExpression &expr, idx_t depth);
+	BindResult BindExpression(ConjunctionExpression &expr, idx_t depth);
+	BindResult BindExpression(ConstantExpression &expr, idx_t depth);
+	BindResult BindExpression(FunctionExpression &expr, idx_t depth);
+	BindResult BindExpression(OperatorExpression &expr, idx_t depth);
+	BindResult BindExpression(ParameterExpression &expr, idx_t depth);
+	BindResult BindExpression(StarExpression &expr, idx_t depth);
+	BindResult BindExpression(SubqueryExpression &expr, idx_t depth);
 
-	void BindChild(unique_ptr<ParsedExpression> &expr, index_t depth, string &error);
+	void BindChild(unique_ptr<ParsedExpression> &expr, idx_t depth, string &error);
 
 protected:
 	static void ExtractCorrelatedExpressions(Binder &binder, Expression &expr);
 
-	virtual BindResult BindFunction(FunctionExpression &expr, ScalarFunctionCatalogEntry *function, index_t depth);
-	virtual BindResult BindAggregate(FunctionExpression &expr, AggregateFunctionCatalogEntry *function, index_t depth);
+	virtual BindResult BindFunction(FunctionExpression &expr, ScalarFunctionCatalogEntry *function, idx_t depth);
+	virtual BindResult BindAggregate(FunctionExpression &expr, AggregateFunctionCatalogEntry *function, idx_t depth);
 
 	virtual string UnsupportedAggregateMessage();
 

--- a/src/include/duckdb/planner/expression_binder/aggregate_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/aggregate_binder.hpp
@@ -21,7 +21,7 @@ public:
 	AggregateBinder(Binder &binder, ClientContext &context);
 
 protected:
-	BindResult BindExpression(ParsedExpression &expr, index_t depth, bool root_expression = false) override;
+	BindResult BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression = false) override;
 
 	string UnsupportedAggregateMessage() override;
 };

--- a/src/include/duckdb/planner/expression_binder/check_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/check_binder.hpp
@@ -24,7 +24,7 @@ public:
 	unordered_set<column_t> &bound_columns;
 
 protected:
-	BindResult BindExpression(ParsedExpression &expr, index_t depth, bool root_expression = false) override;
+	BindResult BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression = false) override;
 
 	BindResult BindCheckColumn(ColumnRefExpression &expr);
 

--- a/src/include/duckdb/planner/expression_binder/constant_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/constant_binder.hpp
@@ -21,7 +21,7 @@ public:
 	string clause;
 
 protected:
-	BindResult BindExpression(ParsedExpression &expr, index_t depth, bool root_expression = false) override;
+	BindResult BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression = false) override;
 
 	string UnsupportedAggregateMessage() override;
 };

--- a/src/include/duckdb/planner/expression_binder/group_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/group_binder.hpp
@@ -19,29 +19,29 @@ class ColumnRefExpression;
 //! The GROUP binder is responsible for binding expressions in the GROUP BY clause
 class GroupBinder : public ExpressionBinder {
 public:
-	GroupBinder(Binder &binder, ClientContext &context, SelectNode &node, index_t group_index,
-	            unordered_map<string, index_t> &alias_map, unordered_map<string, index_t> &group_alias_map);
+	GroupBinder(Binder &binder, ClientContext &context, SelectNode &node, idx_t group_index,
+	            unordered_map<string, idx_t> &alias_map, unordered_map<string, idx_t> &group_alias_map);
 
 	//! The unbound root expression
 	unique_ptr<ParsedExpression> unbound_expression;
 	//! The group index currently being bound
-	index_t bind_index;
+	idx_t bind_index;
 
 protected:
-	BindResult BindExpression(ParsedExpression &expr, index_t depth, bool root_expression) override;
+	BindResult BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression) override;
 
 	string UnsupportedAggregateMessage() override;
 
-	BindResult BindSelectRef(index_t entry);
+	BindResult BindSelectRef(idx_t entry);
 	BindResult BindColumnRef(ColumnRefExpression &expr);
 	BindResult BindConstant(ConstantExpression &expr);
 
 	SelectNode &node;
-	unordered_map<string, index_t> &alias_map;
-	unordered_map<string, index_t> &group_alias_map;
-	unordered_set<index_t> used_aliases;
+	unordered_map<string, idx_t> &alias_map;
+	unordered_map<string, idx_t> &group_alias_map;
+	unordered_set<idx_t> used_aliases;
 
-	index_t group_index;
+	idx_t group_index;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder/having_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/having_binder.hpp
@@ -18,7 +18,7 @@ public:
 	HavingBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info);
 
 protected:
-	BindResult BindExpression(ParsedExpression &expr, index_t depth, bool root_expression = false) override;
+	BindResult BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression = false) override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder/index_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/index_binder.hpp
@@ -20,7 +20,7 @@ public:
 	IndexBinder(Binder &binder, ClientContext &context);
 
 protected:
-	BindResult BindExpression(ParsedExpression &expr, index_t depth, bool root_expression = false) override;
+	BindResult BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression = false) override;
 
 	string UnsupportedAggregateMessage() override;
 };

--- a/src/include/duckdb/planner/expression_binder/insert_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/insert_binder.hpp
@@ -18,7 +18,7 @@ public:
 	InsertBinder(Binder &binder, ClientContext &context);
 
 protected:
-	BindResult BindExpression(ParsedExpression &expr, index_t depth, bool root_expression = false) override;
+	BindResult BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression = false) override;
 
 	string UnsupportedAggregateMessage() override;
 };

--- a/src/include/duckdb/planner/expression_binder/order_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/order_binder.hpp
@@ -20,19 +20,19 @@ class SelectNode;
 //! The ORDER binder is responsible for binding an expression within the ORDER BY clause of a SQL statement
 class OrderBinder {
 public:
-	OrderBinder(index_t projection_index, SelectNode &node, unordered_map<string, index_t> &alias_map,
-	            expression_map_t<index_t> &projection_map, vector<unique_ptr<ParsedExpression>> &extra_select_list);
+	OrderBinder(idx_t projection_index, SelectNode &node, unordered_map<string, idx_t> &alias_map,
+	            expression_map_t<idx_t> &projection_map, vector<unique_ptr<ParsedExpression>> &extra_select_list);
 
 	unique_ptr<Expression> Bind(unique_ptr<ParsedExpression> expr);
-	void RemapIndex(BoundColumnRefExpression &expr, index_t index);
+	void RemapIndex(BoundColumnRefExpression &expr, idx_t index);
 
 private:
-	unique_ptr<Expression> CreateProjectionReference(ParsedExpression &expr, index_t index);
+	unique_ptr<Expression> CreateProjectionReference(ParsedExpression &expr, idx_t index);
 
-	index_t projection_index;
+	idx_t projection_index;
 	SelectNode &node;
-	unordered_map<string, index_t> &alias_map;
-	expression_map_t<index_t> &projection_map;
+	unordered_map<string, idx_t> &alias_map;
+	expression_map_t<idx_t> &projection_map;
 	vector<unique_ptr<ParsedExpression>> &extra_select_list;
 };
 

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -19,8 +19,8 @@ class WindowExpression;
 class BoundSelectNode;
 
 struct BoundGroupInformation {
-	expression_map_t<index_t> map;
-	unordered_map<string, index_t> alias_map;
+	expression_map_t<idx_t> map;
+	unordered_map<string, idx_t> alias_map;
 	vector<SQLType> group_types;
 };
 
@@ -30,9 +30,9 @@ public:
 	SelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info);
 
 protected:
-	BindResult BindExpression(ParsedExpression &expr, index_t depth, bool root_expression = false) override;
+	BindResult BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression = false) override;
 
-	BindResult BindAggregate(FunctionExpression &expr, AggregateFunctionCatalogEntry *function, index_t depth) override;
+	BindResult BindAggregate(FunctionExpression &expr, AggregateFunctionCatalogEntry *function, idx_t depth) override;
 
 	bool inside_window;
 
@@ -40,10 +40,10 @@ protected:
 	BoundGroupInformation &info;
 
 protected:
-	BindResult BindWindow(WindowExpression &expr, index_t depth);
+	BindResult BindWindow(WindowExpression &expr, idx_t depth);
 
-	index_t TryBindGroup(ParsedExpression &expr, index_t depth);
-	BindResult BindGroup(ParsedExpression &expr, index_t depth, index_t group_index);
+	idx_t TryBindGroup(ParsedExpression &expr, idx_t depth);
+	BindResult BindGroup(ParsedExpression &expr, idx_t depth, idx_t group_index);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder/update_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/update_binder.hpp
@@ -18,7 +18,7 @@ public:
 	UpdateBinder(Binder &binder, ClientContext &context);
 
 protected:
-	BindResult BindExpression(ParsedExpression &expr, index_t depth, bool root_expression = false) override;
+	BindResult BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression = false) override;
 
 	string UnsupportedAggregateMessage() override;
 };

--- a/src/include/duckdb/planner/expression_binder/where_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/where_binder.hpp
@@ -18,7 +18,7 @@ public:
 	WhereBinder(Binder &binder, ClientContext &context);
 
 protected:
-	BindResult BindExpression(ParsedExpression &expr, index_t depth, bool root_expression = false) override;
+	BindResult BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression = false) override;
 
 	string UnsupportedAggregateMessage() override;
 };

--- a/src/include/duckdb/planner/joinside.hpp
+++ b/src/include/duckdb/planner/joinside.hpp
@@ -52,12 +52,12 @@ public:
 	}
 
 	static JoinSide CombineJoinSide(JoinSide left, JoinSide right);
-	static JoinSide GetJoinSide(index_t table_binding, unordered_set<index_t> &left_bindings,
+	static JoinSide GetJoinSide(idx_t table_binding, unordered_set<idx_t> &left_bindings,
 	                            unordered_set<uint64_t> &right_bindings);
-	static JoinSide GetJoinSide(Expression &expression, unordered_set<index_t> &left_bindings,
-	                            unordered_set<index_t> &right_bindings);
-	static JoinSide GetJoinSide(unordered_set<index_t> bindings, unordered_set<index_t> &left_bindings,
-	                            unordered_set<index_t> &right_bindings);
+	static JoinSide GetJoinSide(Expression &expression, unordered_set<idx_t> &left_bindings,
+	                            unordered_set<idx_t> &right_bindings);
+	static JoinSide GetJoinSide(unordered_set<idx_t> bindings, unordered_set<idx_t> &left_bindings,
+	                            unordered_set<idx_t> &right_bindings);
 
 private:
 	join_value value;

--- a/src/include/duckdb/planner/logical_operator.hpp
+++ b/src/include/duckdb/planner/logical_operator.hpp
@@ -44,24 +44,24 @@ public:
 	virtual vector<ColumnBinding> GetColumnBindings() {
 		return {};
 	}
-	static vector<ColumnBinding> GenerateColumnBindings(index_t table_idx, index_t column_count);
-	static vector<TypeId> MapTypes(vector<TypeId> types, vector<index_t> projection_map);
-	static vector<ColumnBinding> MapBindings(vector<ColumnBinding> types, vector<index_t> projection_map);
+	static vector<ColumnBinding> GenerateColumnBindings(idx_t table_idx, idx_t column_count);
+	static vector<TypeId> MapTypes(vector<TypeId> types, vector<idx_t> projection_map);
+	static vector<ColumnBinding> MapBindings(vector<ColumnBinding> types, vector<idx_t> projection_map);
 
 	//! Resolve the types of the logical operator and its children
 	void ResolveOperatorTypes();
 
 	virtual string ParamsToString() const;
-	virtual string ToString(index_t depth = 0) const;
+	virtual string ToString(idx_t depth = 0) const;
 	void Print();
 
 	void AddChild(unique_ptr<LogicalOperator> child) {
 		children.push_back(move(child));
 	}
 
-	virtual index_t EstimateCardinality() {
+	virtual idx_t EstimateCardinality() {
 		// simple estimator, just take the max of the children
-		index_t max_cardinality = 0;
+		idx_t max_cardinality = 0;
 		for (auto &child : children) {
 			max_cardinality = std::max(child->EstimateCardinality(), max_cardinality);
 		}

--- a/src/include/duckdb/planner/operator/logical_aggregate.hpp
+++ b/src/include/duckdb/planner/operator/logical_aggregate.hpp
@@ -17,12 +17,12 @@ namespace duckdb {
 //! operator.
 class LogicalAggregate : public LogicalOperator {
 public:
-	LogicalAggregate(index_t group_index, index_t aggregate_index, vector<unique_ptr<Expression>> select_list);
+	LogicalAggregate(idx_t group_index, idx_t aggregate_index, vector<unique_ptr<Expression>> select_list);
 
 	//! The table index for the groups of the LogicalAggregate
-	index_t group_index;
+	idx_t group_index;
 	//! The table index for the aggregates of the LogicalAggregate
-	index_t aggregate_index;
+	idx_t aggregate_index;
 	//! The set of groups (optional).
 	vector<unique_ptr<Expression>> groups;
 

--- a/src/include/duckdb/planner/operator/logical_chunk_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_chunk_get.hpp
@@ -16,14 +16,14 @@ namespace duckdb {
 //! LogicalChunkGet represents a scan operation from a ChunkCollection
 class LogicalChunkGet : public LogicalOperator {
 public:
-	LogicalChunkGet(index_t table_index, vector<TypeId> types, unique_ptr<ChunkCollection> collection)
+	LogicalChunkGet(idx_t table_index, vector<TypeId> types, unique_ptr<ChunkCollection> collection)
 	    : LogicalOperator(LogicalOperatorType::CHUNK_GET), table_index(table_index), collection(move(collection)) {
 		assert(types.size() > 0);
 		chunk_types = types;
 	}
 
 	//! The table index in the current bind context
-	index_t table_index;
+	idx_t table_index;
 	//! The types of the chunk
 	vector<TypeId> chunk_types;
 	//! The chunk collection to scan

--- a/src/include/duckdb/planner/operator/logical_comparison_join.hpp
+++ b/src/include/duckdb/planner/operator/logical_comparison_join.hpp
@@ -29,8 +29,8 @@ public:
 public:
 	static unique_ptr<LogicalOperator> CreateJoin(JoinType type, unique_ptr<LogicalOperator> left_child,
 	                                              unique_ptr<LogicalOperator> right_child,
-	                                              unordered_set<index_t> &left_bindings,
-	                                              unordered_set<index_t> &right_bindings,
+	                                              unordered_set<idx_t> &left_bindings,
+	                                              unordered_set<idx_t> &right_bindings,
 	                                              vector<unique_ptr<Expression>> &expressions);
 };
 

--- a/src/include/duckdb/planner/operator/logical_copy_from_file.hpp
+++ b/src/include/duckdb/planner/operator/logical_copy_from_file.hpp
@@ -15,12 +15,12 @@ namespace duckdb {
 
 class LogicalCopyFromFile : public LogicalOperator {
 public:
-	LogicalCopyFromFile(index_t table_index, unique_ptr<CopyInfo> info, vector<SQLType> sql_types)
+	LogicalCopyFromFile(idx_t table_index, unique_ptr<CopyInfo> info, vector<SQLType> sql_types)
 	    : LogicalOperator(LogicalOperatorType::COPY_FROM_FILE), table_index(table_index), info(move(info)),
 	      sql_types(sql_types) {
 	}
 
-	index_t table_index;
+	idx_t table_index;
 	unique_ptr<CopyInfo> info;
 	vector<SQLType> sql_types;
 

--- a/src/include/duckdb/planner/operator/logical_cteref.hpp
+++ b/src/include/duckdb/planner/operator/logical_cteref.hpp
@@ -14,32 +14,32 @@
 namespace duckdb {
 
 //! LogicalChunkGet represents a scan operation from a ChunkCollection
-    class LogicalCTERef : public LogicalOperator {
-    public:
-        LogicalCTERef(index_t table_index, index_t cte_index, vector<TypeId> types, vector<string> colnames)
-                : LogicalOperator(LogicalOperatorType::CTE_REF), table_index(table_index), cte_index(cte_index) {
-            assert(types.size() > 0);
-            chunk_types = types;
-            bound_columns = colnames;
-        }
+class LogicalCTERef : public LogicalOperator {
+public:
+	LogicalCTERef(idx_t table_index, idx_t cte_index, vector<TypeId> types, vector<string> colnames)
+	    : LogicalOperator(LogicalOperatorType::CTE_REF), table_index(table_index), cte_index(cte_index) {
+		assert(types.size() > 0);
+		chunk_types = types;
+		bound_columns = colnames;
+	}
 
-        vector<string> bound_columns;
-        //! The table index in the current bind context
-        index_t table_index;
-        //! CTE index
-        index_t cte_index;
-        //! The types of the chunk
-        vector<TypeId> chunk_types;
+	vector<string> bound_columns;
+	//! The table index in the current bind context
+	idx_t table_index;
+	//! CTE index
+	idx_t cte_index;
+	//! The types of the chunk
+	vector<TypeId> chunk_types;
 
-    public:
-        vector<ColumnBinding> GetColumnBindings() override {
-            return GenerateColumnBindings(table_index, chunk_types.size());
-        }
+public:
+	vector<ColumnBinding> GetColumnBindings() override {
+		return GenerateColumnBindings(table_index, chunk_types.size());
+	}
 
-    protected:
-        void ResolveTypes() override {
-            // types are resolved in the constructor
-            this->types = chunk_types;
-        }
-    };
+protected:
+	void ResolveTypes() override {
+		// types are resolved in the constructor
+		this->types = chunk_types;
+	}
+};
 } // namespace duckdb

--- a/src/include/duckdb/planner/operator/logical_delim_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_delim_get.hpp
@@ -15,14 +15,14 @@ namespace duckdb {
 //! LogicalDelimGet represents a duplicate eliminated scan belonging to a DelimJoin
 class LogicalDelimGet : public LogicalOperator {
 public:
-	LogicalDelimGet(index_t table_index, vector<TypeId> types)
+	LogicalDelimGet(idx_t table_index, vector<TypeId> types)
 	    : LogicalOperator(LogicalOperatorType::DELIM_GET), table_index(table_index) {
 		assert(types.size() > 0);
 		chunk_types = types;
 	}
 
 	//! The table index in the current bind context
-	index_t table_index;
+	idx_t table_index;
 	//! The types of the chunk
 	vector<TypeId> chunk_types;
 

--- a/src/include/duckdb/planner/operator/logical_expression_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_expression_get.hpp
@@ -15,13 +15,13 @@ namespace duckdb {
 //! LogicalExpressionGet represents a scan operation over a set of to-be-executed expressions
 class LogicalExpressionGet : public LogicalOperator {
 public:
-	LogicalExpressionGet(index_t table_index, vector<TypeId> types, vector<vector<unique_ptr<Expression>>> expressions)
+	LogicalExpressionGet(idx_t table_index, vector<TypeId> types, vector<vector<unique_ptr<Expression>>> expressions)
 	    : LogicalOperator(LogicalOperatorType::EXPRESSION_GET), table_index(table_index), expr_types(types),
 	      expressions(move(expressions)) {
 	}
 
 	//! The table index in the current bind context
-	index_t table_index;
+	idx_t table_index;
 	//! The types of the expressions
 	vector<TypeId> expr_types;
 	//! The set of expressions

--- a/src/include/duckdb/planner/operator/logical_filter.hpp
+++ b/src/include/duckdb/planner/operator/logical_filter.hpp
@@ -18,7 +18,7 @@ public:
 	LogicalFilter(unique_ptr<Expression> expression);
 	LogicalFilter();
 
-	vector<index_t> projection_map;
+	vector<idx_t> projection_map;
 
 public:
 	vector<ColumnBinding> GetColumnBindings() override;

--- a/src/include/duckdb/planner/operator/logical_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_get.hpp
@@ -16,15 +16,15 @@ namespace duckdb {
 //! LogicalGet represents a scan operation from a data source
 class LogicalGet : public LogicalOperator {
 public:
-	LogicalGet(index_t table_index);
-	LogicalGet(TableCatalogEntry *table, index_t table_index, vector<column_t> column_ids);
+	LogicalGet(idx_t table_index);
+	LogicalGet(TableCatalogEntry *table, idx_t table_index, vector<column_t> column_ids);
 
-	index_t EstimateCardinality() override;
+	idx_t EstimateCardinality() override;
 
 	//! The base table to retrieve data from
 	TableCatalogEntry *table;
 	//! The table index in the current bind context
-	index_t table_index;
+	idx_t table_index;
 	//! Bound column IDs
 	vector<column_t> column_ids;
 

--- a/src/include/duckdb/planner/operator/logical_index_scan.hpp
+++ b/src/include/duckdb/planner/operator/logical_index_scan.hpp
@@ -18,7 +18,7 @@ namespace duckdb {
 class LogicalIndexScan : public LogicalOperator {
 public:
 	LogicalIndexScan(TableCatalogEntry &tableref, DataTable &table, Index &index, vector<column_t> column_ids,
-	                 index_t table_index)
+	                 idx_t table_index)
 	    : LogicalOperator(LogicalOperatorType::INDEX_SCAN), tableref(tableref), table(table), index(index),
 	      column_ids(column_ids), table_index(table_index) {
 	}
@@ -47,7 +47,7 @@ public:
 	ExpressionType high_expression_type;
 
 	//! The table index in the current bind context
-	index_t table_index;
+	idx_t table_index;
 
 public:
 	vector<ColumnBinding> GetColumnBindings() override {

--- a/src/include/duckdb/planner/operator/logical_insert.hpp
+++ b/src/include/duckdb/planner/operator/logical_insert.hpp
@@ -20,7 +20,7 @@ public:
 	}
 
 	vector<vector<unique_ptr<Expression>>> insert_values;
-	vector<index_t> column_index_map;
+	vector<idx_t> column_index_map;
 
 	//! The base table to insert into
 	TableCatalogEntry *table;

--- a/src/include/duckdb/planner/operator/logical_join.hpp
+++ b/src/include/duckdb/planner/operator/logical_join.hpp
@@ -20,17 +20,17 @@ public:
 	LogicalJoin(JoinType type, LogicalOperatorType logical_type = LogicalOperatorType::JOIN);
 
 	// Gets the set of table references that are reachable from this node
-	static void GetTableReferences(LogicalOperator &op, unordered_set<index_t> &bindings);
-	static void GetExpressionBindings(Expression &expr, unordered_set<index_t> &bindings);
+	static void GetTableReferences(LogicalOperator &op, unordered_set<idx_t> &bindings);
+	static void GetExpressionBindings(Expression &expr, unordered_set<idx_t> &bindings);
 
 	//! The type of the join (INNER, OUTER, etc...)
 	JoinType join_type;
 	//! Table index used to refer to the MARK column (in case of a MARK join)
-	index_t mark_index;
+	idx_t mark_index;
 	//! The columns of the LHS that are output by the join
-	vector<index_t> left_projection_map;
+	vector<idx_t> left_projection_map;
 	//! The columns of the RHS that are output by the join
-	vector<index_t> right_projection_map;
+	vector<idx_t> right_projection_map;
 
 public:
 	vector<ColumnBinding> GetColumnBindings() override;

--- a/src/include/duckdb/planner/operator/logical_projection.hpp
+++ b/src/include/duckdb/planner/operator/logical_projection.hpp
@@ -15,9 +15,9 @@ namespace duckdb {
 //! LogicalProjection represents the projection list in a SELECT clause
 class LogicalProjection : public LogicalOperator {
 public:
-	LogicalProjection(index_t table_index, vector<unique_ptr<Expression>> select_list);
+	LogicalProjection(idx_t table_index, vector<unique_ptr<Expression>> select_list);
 
-	index_t table_index;
+	idx_t table_index;
 
 public:
 	vector<ColumnBinding> GetColumnBindings() override;

--- a/src/include/duckdb/planner/operator/logical_prune_columns.hpp
+++ b/src/include/duckdb/planner/operator/logical_prune_columns.hpp
@@ -16,11 +16,11 @@ namespace duckdb {
 //! children
 class LogicalPruneColumns : public LogicalOperator {
 public:
-	LogicalPruneColumns(index_t column_limit)
+	LogicalPruneColumns(idx_t column_limit)
 	    : LogicalOperator(LogicalOperatorType::PRUNE_COLUMNS), column_limit(column_limit) {
 	}
 
-	index_t column_limit;
+	idx_t column_limit;
 
 public:
 	vector<ColumnBinding> GetColumnBindings() override;

--- a/src/include/duckdb/planner/operator/logical_recursive_cte.hpp
+++ b/src/include/duckdb/planner/operator/logical_recursive_cte.hpp
@@ -12,28 +12,28 @@
 
 namespace duckdb {
 
-    class LogicalRecursiveCTE : public LogicalOperator {
-    public:
-        LogicalRecursiveCTE(index_t table_index, index_t column_count, bool union_all, unique_ptr<LogicalOperator> top,
-                            unique_ptr<LogicalOperator> bottom, LogicalOperatorType type)
-                : LogicalOperator(type), union_all(union_all), table_index(table_index), column_count(column_count) {
-            assert(type == LogicalOperatorType::RECURSIVE_CTE);
-            children.push_back(move(top));
-            children.push_back(move(bottom));
-        }
+class LogicalRecursiveCTE : public LogicalOperator {
+public:
+	LogicalRecursiveCTE(idx_t table_index, idx_t column_count, bool union_all, unique_ptr<LogicalOperator> top,
+	                    unique_ptr<LogicalOperator> bottom, LogicalOperatorType type)
+	    : LogicalOperator(type), union_all(union_all), table_index(table_index), column_count(column_count) {
+		assert(type == LogicalOperatorType::RECURSIVE_CTE);
+		children.push_back(move(top));
+		children.push_back(move(bottom));
+	}
 
-        bool union_all;
-        index_t table_index;
-        index_t column_count;
+	bool union_all;
+	idx_t table_index;
+	idx_t column_count;
 
-    public:
-        vector<ColumnBinding> GetColumnBindings() override {
-            return GenerateColumnBindings(table_index, column_count);
-        }
+public:
+	vector<ColumnBinding> GetColumnBindings() override {
+		return GenerateColumnBindings(table_index, column_count);
+	}
 
-    protected:
-        void ResolveTypes() override {
-            types = children[0]->types;
-        }
-    };
+protected:
+	void ResolveTypes() override {
+		types = children[0]->types;
+	}
+};
 } // namespace duckdb

--- a/src/include/duckdb/planner/operator/logical_set_operation.hpp
+++ b/src/include/duckdb/planner/operator/logical_set_operation.hpp
@@ -14,7 +14,7 @@ namespace duckdb {
 
 class LogicalSetOperation : public LogicalOperator {
 public:
-	LogicalSetOperation(index_t table_index, index_t column_count, unique_ptr<LogicalOperator> top,
+	LogicalSetOperation(idx_t table_index, idx_t column_count, unique_ptr<LogicalOperator> top,
 	                    unique_ptr<LogicalOperator> bottom, LogicalOperatorType type)
 	    : LogicalOperator(type), table_index(table_index), column_count(column_count) {
 		assert(type == LogicalOperatorType::UNION || type == LogicalOperatorType::EXCEPT ||
@@ -23,8 +23,8 @@ public:
 		children.push_back(move(bottom));
 	}
 
-	index_t table_index;
-	index_t column_count;
+	idx_t table_index;
+	idx_t column_count;
 
 public:
 	vector<ColumnBinding> GetColumnBindings() override {

--- a/src/include/duckdb/planner/operator/logical_table_function.hpp
+++ b/src/include/duckdb/planner/operator/logical_table_function.hpp
@@ -15,7 +15,7 @@ namespace duckdb {
 //! LogicalTableFunction represents a call to a table-producing function
 class LogicalTableFunction : public LogicalOperator {
 public:
-	LogicalTableFunction(TableFunctionCatalogEntry *function, index_t table_index,
+	LogicalTableFunction(TableFunctionCatalogEntry *function, idx_t table_index,
 	                     vector<unique_ptr<Expression>> parameters)
 	    : LogicalOperator(LogicalOperatorType::TABLE_FUNCTION), function(function), table_index(table_index) {
 		expressions = move(parameters);
@@ -24,7 +24,7 @@ public:
 	//! The function
 	TableFunctionCatalogEntry *function;
 	//! The table index of the table-producing function
-	index_t table_index;
+	idx_t table_index;
 
 public:
 	vector<ColumnBinding> GetColumnBindings() override;

--- a/src/include/duckdb/planner/operator/logical_window.hpp
+++ b/src/include/duckdb/planner/operator/logical_window.hpp
@@ -16,10 +16,10 @@ namespace duckdb {
 //! operator.
 class LogicalWindow : public LogicalOperator {
 public:
-	LogicalWindow(index_t window_index) : LogicalOperator(LogicalOperatorType::WINDOW), window_index(window_index) {
+	LogicalWindow(idx_t window_index) : LogicalOperator(LogicalOperatorType::WINDOW), window_index(window_index) {
 	}
 
-	index_t window_index;
+	idx_t window_index;
 
 public:
 	vector<ColumnBinding> GetColumnBindings() override;

--- a/src/include/duckdb/planner/planner.hpp
+++ b/src/include/duckdb/planner/planner.hpp
@@ -27,13 +27,14 @@ public:
 	unique_ptr<LogicalOperator> plan;
 	vector<string> names;
 	vector<SQLType> sql_types;
-	unordered_map<index_t, PreparedValueEntry> value_map;
+	unordered_map<idx_t, PreparedValueEntry> value_map;
 
 	Binder binder;
 	ClientContext &context;
 
 	bool read_only;
 	bool requires_valid_transaction;
+
 private:
 	void CreatePlan(SQLStatement &statement);
 

--- a/src/include/duckdb/planner/query_node/bound_recursive_cte_node.hpp
+++ b/src/include/duckdb/planner/query_node/bound_recursive_cte_node.hpp
@@ -14,31 +14,31 @@
 namespace duckdb {
 
 //! Bound equivalent of SetOperationNode
-    class BoundRecursiveCTENode : public BoundQueryNode {
-    public:
-        BoundRecursiveCTENode() : BoundQueryNode(QueryNodeType::RECURSIVE_CTE_NODE) {
-        }
+class BoundRecursiveCTENode : public BoundQueryNode {
+public:
+	BoundRecursiveCTENode() : BoundQueryNode(QueryNodeType::RECURSIVE_CTE_NODE) {
+	}
 
-        //! Keep track of the CTE name this node represents
-        string ctename;
+	//! Keep track of the CTE name this node represents
+	string ctename;
 
-        bool union_all;
-        //! The left side of the set operation
-        unique_ptr<BoundQueryNode> left;
-        //! The right side of the set operation
-        unique_ptr<BoundQueryNode> right;
+	bool union_all;
+	//! The left side of the set operation
+	unique_ptr<BoundQueryNode> left;
+	//! The right side of the set operation
+	unique_ptr<BoundQueryNode> right;
 
-        //! Index used by the set operation
-        index_t setop_index;
-        //! The binder used by the left side of the set operation
-        unique_ptr<Binder> left_binder;
-        //! The binder used by the right side of the set operation
-        unique_ptr<Binder> right_binder;
+	//! Index used by the set operation
+	idx_t setop_index;
+	//! The binder used by the left side of the set operation
+	unique_ptr<Binder> left_binder;
+	//! The binder used by the right side of the set operation
+	unique_ptr<Binder> right_binder;
 
-    public:
-        index_t GetRootIndex() override {
-            return setop_index;
-        }
-    };
+public:
+	idx_t GetRootIndex() override {
+		return setop_index;
+	}
+};
 
 }; // namespace duckdb

--- a/src/include/duckdb/planner/query_node/bound_select_node.hpp
+++ b/src/include/duckdb/planner/query_node/bound_select_node.hpp
@@ -32,27 +32,27 @@ public:
 	unique_ptr<Expression> having;
 
 	//! The amount of columns in the final result
-	index_t column_count;
+	idx_t column_count;
 
 	//! Index used by the LogicalProjection
-	index_t projection_index;
+	idx_t projection_index;
 
 	//! Group index used by the LogicalAggregate (only used if HasAggregation is true)
-	index_t group_index;
+	idx_t group_index;
 	//! Aggregate index used by the LogicalAggregate (only used if HasAggregation is true)
-	index_t aggregate_index;
+	idx_t aggregate_index;
 	//! Aggregate functions to compute (only used if HasAggregation is true)
 	vector<unique_ptr<Expression>> aggregates;
 	//! Map from aggregate function to aggregate index (used to eliminate duplicate aggregates)
-	expression_map_t<index_t> aggregate_map;
+	expression_map_t<idx_t> aggregate_map;
 
 	//! Window index used by the LogicalWindow (only used if HasWindow is true)
-	index_t window_index;
+	idx_t window_index;
 	//! Window functions to compute (only used if HasWindow is true)
 	vector<unique_ptr<Expression>> windows;
 
 public:
-	index_t GetRootIndex() override {
+	idx_t GetRootIndex() override {
 		return projection_index;
 	}
 };

--- a/src/include/duckdb/planner/query_node/bound_set_operation_node.hpp
+++ b/src/include/duckdb/planner/query_node/bound_set_operation_node.hpp
@@ -28,14 +28,14 @@ public:
 	unique_ptr<BoundQueryNode> right;
 
 	//! Index used by the set operation
-	index_t setop_index;
+	idx_t setop_index;
 	//! The binder used by the left side of the set operation
 	unique_ptr<Binder> left_binder;
 	//! The binder used by the right side of the set operation
 	unique_ptr<Binder> right_binder;
 
 public:
-	index_t GetRootIndex() override {
+	idx_t GetRootIndex() override {
 		return setop_index;
 	}
 };

--- a/src/include/duckdb/planner/statement/bound_copy_statement.hpp
+++ b/src/include/duckdb/planner/statement/bound_copy_statement.hpp
@@ -29,7 +29,7 @@ public:
 	//! The bound SQL statement (only for COPY TO)
 	unique_ptr<BoundQueryNode> select_statement;
 
-	index_t table_index;
+	idx_t table_index;
 	vector<string> names;
 	vector<SQLType> sql_types;
 

--- a/src/include/duckdb/planner/statement/bound_insert_statement.hpp
+++ b/src/include/duckdb/planner/statement/bound_insert_statement.hpp
@@ -25,7 +25,7 @@ public:
 	//! The bound select statement (if any)
 	unique_ptr<BoundSelectStatement> select_statement;
 	//! The insertion map ([table_index -> index in result, or INVALID_INDEX if not specified])
-	vector<index_t> column_index_map;
+	vector<idx_t> column_index_map;
 	//! The expected types for the INSERT statement (obtained from the column types)
 	vector<SQLType> expected_types;
 	//! The default statements used by the table

--- a/src/include/duckdb/planner/statement/bound_update_statement.hpp
+++ b/src/include/duckdb/planner/statement/bound_update_statement.hpp
@@ -31,7 +31,7 @@ public:
 	//! The default statements used by the table
 	vector<unique_ptr<Expression>> bound_defaults;
 	//! The projection index
-	index_t proj_index;
+	idx_t proj_index;
 	//! Whether or not the update is an index update. Index updates are translated into insert + deletes, instead of
 	//! performing an in-place update.
 	bool is_index_update;

--- a/src/include/duckdb/planner/subquery/flatten_dependent_join.hpp
+++ b/src/include/duckdb/planner/subquery/flatten_dependent_join.hpp
@@ -29,11 +29,11 @@ struct FlattenDependentJoins {
 
 	Binder &binder;
 	ColumnBinding base_binding;
-	index_t delim_offset;
-	index_t data_offset;
+	idx_t delim_offset;
+	idx_t data_offset;
 	unordered_map<LogicalOperator *, bool> has_correlated_expressions;
-	column_binding_map_t<index_t> correlated_map;
-	column_binding_map_t<index_t> replacement_map;
+	column_binding_map_t<idx_t> correlated_map;
+	column_binding_map_t<idx_t> replacement_map;
 	const vector<CorrelatedColumnInfo> &correlated_columns;
 	vector<TypeId> delim_types;
 

--- a/src/include/duckdb/planner/subquery/rewrite_correlated_expressions.hpp
+++ b/src/include/duckdb/planner/subquery/rewrite_correlated_expressions.hpp
@@ -17,7 +17,7 @@ namespace duckdb {
 //! Helper class to rewrite correlated expressions within a single LogicalOperator
 class RewriteCorrelatedExpressions : public LogicalOperatorVisitor {
 public:
-	RewriteCorrelatedExpressions(ColumnBinding base_binding, column_binding_map_t<index_t> &correlated_map);
+	RewriteCorrelatedExpressions(ColumnBinding base_binding, column_binding_map_t<idx_t> &correlated_map);
 
 	void VisitOperator(LogicalOperator &op) override;
 
@@ -30,29 +30,29 @@ private:
 	class RewriteCorrelatedRecursive {
 	public:
 		RewriteCorrelatedRecursive(BoundSubqueryExpression &parent, ColumnBinding base_binding,
-		                           column_binding_map_t<index_t> &correlated_map);
+		                           column_binding_map_t<idx_t> &correlated_map);
 
 		void RewriteCorrelatedSubquery(BoundSubqueryExpression &expr);
 		void RewriteCorrelatedExpressions(Expression &child);
 
 		BoundSubqueryExpression &parent;
 		ColumnBinding base_binding;
-		column_binding_map_t<index_t> &correlated_map;
+		column_binding_map_t<idx_t> &correlated_map;
 	};
 
 private:
 	ColumnBinding base_binding;
-	column_binding_map_t<index_t> &correlated_map;
+	column_binding_map_t<idx_t> &correlated_map;
 };
 
 //! Helper class that rewrites COUNT aggregates into a CASE expression turning NULL into 0 after a LEFT OUTER JOIN
 class RewriteCountAggregates : public LogicalOperatorVisitor {
 public:
-	RewriteCountAggregates(column_binding_map_t<index_t> &replacement_map);
+	RewriteCountAggregates(column_binding_map_t<idx_t> &replacement_map);
 
 	unique_ptr<Expression> VisitReplace(BoundColumnRefExpression &expr, unique_ptr<Expression> *expr_ptr) override;
 
-	column_binding_map_t<index_t> &replacement_map;
+	column_binding_map_t<idx_t> &replacement_map;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/table_binding.hpp
+++ b/src/include/duckdb/planner/table_binding.hpp
@@ -28,17 +28,17 @@ enum class BindingType : uint8_t { TABLE = 0, SUBQUERY = 1, TABLE_FUNCTION = 2, 
 //! A Binding represents a binding to a table, table-producing function or subquery with a specified table index. Used
 //! in the binder.
 struct Binding {
-	Binding(BindingType type, const string &alias, index_t index) : type(type), alias(alias), index(index) {
+	Binding(BindingType type, const string &alias, idx_t index) : type(type), alias(alias), index(index) {
 	}
 	virtual ~Binding() = default;
 
 	BindingType type;
 	string alias;
-	index_t index;
+	idx_t index;
 
 public:
 	virtual bool HasMatchingBinding(const string &column_name) = 0;
-	virtual BindResult Bind(ColumnRefExpression &colref, index_t depth) = 0;
+	virtual BindResult Bind(ColumnRefExpression &colref, idx_t depth) = 0;
 	virtual void GenerateAllColumnExpressions(BindContext &context,
 	                                          vector<unique_ptr<ParsedExpression>> &select_list) = 0;
 };
@@ -51,13 +51,13 @@ struct TableBinding : public Binding {
 
 public:
 	bool HasMatchingBinding(const string &column_name) override;
-	BindResult Bind(ColumnRefExpression &colref, index_t depth) override;
+	BindResult Bind(ColumnRefExpression &colref, idx_t depth) override;
 	void GenerateAllColumnExpressions(BindContext &context, vector<unique_ptr<ParsedExpression>> &select_list) override;
 };
 
 //! Represents a binding to a subquery
 struct SubqueryBinding : public Binding {
-	SubqueryBinding(const string &alias, SubqueryRef &ref, BoundQueryNode &subquery, index_t index);
+	SubqueryBinding(const string &alias, SubqueryRef &ref, BoundQueryNode &subquery, idx_t index);
 
 	BoundQueryNode &subquery;
 	//! Column names of the subquery
@@ -67,7 +67,7 @@ struct SubqueryBinding : public Binding {
 
 public:
 	bool HasMatchingBinding(const string &column_name) override;
-	BindResult Bind(ColumnRefExpression &colref, index_t depth) override;
+	BindResult Bind(ColumnRefExpression &colref, idx_t depth) override;
 	void GenerateAllColumnExpressions(BindContext &context, vector<unique_ptr<ParsedExpression>> &select_list) override;
 
 private:
@@ -76,10 +76,10 @@ private:
 
 //! Represents a binding to a table-producing function
 struct TableFunctionBinding : public Binding {
-	TableFunctionBinding(const string &alias, TableFunctionCatalogEntry *function, index_t index);
+	TableFunctionBinding(const string &alias, TableFunctionCatalogEntry *function, idx_t index);
 
 	bool HasMatchingBinding(const string &column_name) override;
-	BindResult Bind(ColumnRefExpression &colref, index_t depth) override;
+	BindResult Bind(ColumnRefExpression &colref, idx_t depth) override;
 	void GenerateAllColumnExpressions(BindContext &context, vector<unique_ptr<ParsedExpression>> &select_list) override;
 
 	TableFunctionCatalogEntry *function;
@@ -87,7 +87,7 @@ struct TableFunctionBinding : public Binding {
 
 //! Represents a generic binding with types and names
 struct GenericBinding : public Binding {
-	GenericBinding(const string &alias, vector<SQLType> types, vector<string> names, index_t index);
+	GenericBinding(const string &alias, vector<SQLType> types, vector<string> names, idx_t index);
 
 	vector<SQLType> types;
 	//! Column names of the subquery
@@ -97,7 +97,7 @@ struct GenericBinding : public Binding {
 
 public:
 	bool HasMatchingBinding(const string &column_name) override;
-	BindResult Bind(ColumnRefExpression &colref, index_t depth) override;
+	BindResult Bind(ColumnRefExpression &colref, idx_t depth) override;
 	void GenerateAllColumnExpressions(BindContext &context, vector<unique_ptr<ParsedExpression>> &select_list) override;
 };
 

--- a/src/include/duckdb/planner/tableref/bound_basetableref.hpp
+++ b/src/include/duckdb/planner/tableref/bound_basetableref.hpp
@@ -16,7 +16,7 @@ class TableCatalogEntry;
 //! Represents a TableReference to a base table in the schema
 class BoundBaseTableRef : public BoundTableRef {
 public:
-	BoundBaseTableRef(TableCatalogEntry *table, index_t bind_index)
+	BoundBaseTableRef(TableCatalogEntry *table, idx_t bind_index)
 	    : BoundTableRef(TableReferenceType::BASE_TABLE), table(table), bind_index(bind_index) {
 	}
 
@@ -25,6 +25,6 @@ public:
 	//! The set of columns bound to this base table reference
 	vector<string> bound_columns;
 	//! The index in the bind context
-	index_t bind_index;
+	idx_t bind_index;
 };
 } // namespace duckdb

--- a/src/include/duckdb/planner/tableref/bound_cteref.hpp
+++ b/src/include/duckdb/planner/tableref/bound_cteref.hpp
@@ -1,7 +1,7 @@
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// duckdb/planner/tableref/bound_basetableref.hpp
+// duckdb/planner/tableref/bound_cteref.hpp
 //
 //
 //===----------------------------------------------------------------------===//
@@ -12,19 +12,19 @@
 
 namespace duckdb {
 
-    class BoundCTERef : public BoundTableRef {
-    public:
-        BoundCTERef(index_t bind_index, index_t cte_index)
-                : BoundTableRef(TableReferenceType::CTE), bind_index(bind_index), cte_index(cte_index) {
-        }
+class BoundCTERef : public BoundTableRef {
+public:
+	BoundCTERef(idx_t bind_index, idx_t cte_index)
+	    : BoundTableRef(TableReferenceType::CTE), bind_index(bind_index), cte_index(cte_index) {
+	}
 
-        //! The set of columns bound to this base table reference
-        vector<string> bound_columns;
-        //! The types of the values list
-        vector<SQLType> types;
-        //! The index in the bind context
-        index_t bind_index;
-        //! The index of the cte
-        index_t cte_index;
-    };
+	//! The set of columns bound to this base table reference
+	vector<string> bound_columns;
+	//! The types of the values list
+	vector<SQLType> types;
+	//! The index in the bind context
+	idx_t bind_index;
+	//! The index of the cte
+	idx_t cte_index;
+};
 } // namespace duckdb

--- a/src/include/duckdb/planner/tableref/bound_dummytableref.hpp
+++ b/src/include/duckdb/planner/tableref/bound_dummytableref.hpp
@@ -15,8 +15,8 @@ namespace duckdb {
 //! Represents a cross product
 class BoundEmptyTableRef : public BoundTableRef {
 public:
-	BoundEmptyTableRef(index_t bind_index) : BoundTableRef(TableReferenceType::EMPTY), bind_index(bind_index) {
+	BoundEmptyTableRef(idx_t bind_index) : BoundTableRef(TableReferenceType::EMPTY), bind_index(bind_index) {
 	}
-	index_t bind_index;
+	idx_t bind_index;
 };
 } // namespace duckdb

--- a/src/include/duckdb/planner/tableref/bound_expressionlistref.hpp
+++ b/src/include/duckdb/planner/tableref/bound_expressionlistref.hpp
@@ -25,6 +25,6 @@ public:
 	//! The types of the values list
 	vector<SQLType> types;
 	//! The index in the bind context
-	index_t bind_index;
+	idx_t bind_index;
 };
 } // namespace duckdb

--- a/src/include/duckdb/planner/tableref/bound_table_function.hpp
+++ b/src/include/duckdb/planner/tableref/bound_table_function.hpp
@@ -18,7 +18,7 @@ class TableFunctionCatalogEntry;
 //! Represents a reference to a table-producing function call
 class BoundTableFunction : public BoundTableRef {
 public:
-	BoundTableFunction(TableFunctionCatalogEntry *function, index_t bind_index)
+	BoundTableFunction(TableFunctionCatalogEntry *function, idx_t bind_index)
 	    : BoundTableRef(TableReferenceType::TABLE_FUNCTION), function(function), bind_index(bind_index) {
 	}
 
@@ -27,6 +27,6 @@ public:
 	//! The set of parameters to use as input to the table-producing function
 	vector<unique_ptr<Expression>> parameters;
 	//! The index in the bind context
-	index_t bind_index;
+	idx_t bind_index;
 };
 } // namespace duckdb

--- a/src/include/duckdb/storage/buffer/buffer_list.hpp
+++ b/src/include/duckdb/storage/buffer/buffer_list.hpp
@@ -24,7 +24,7 @@ struct BufferEntry {
 	//! The actual buffer
 	unique_ptr<FileBuffer> buffer;
 	//! The amount of references to this entry
-	index_t ref_count;
+	idx_t ref_count;
 	//! Next node
 	unique_ptr<BufferEntry> next;
 	//! Prev entry
@@ -50,7 +50,7 @@ private:
 	//! Pointer to last element in list
 	BufferEntry *last;
 	//! The amount of entries in the list
-	index_t count;
+	idx_t count;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/buffer/managed_buffer.hpp
+++ b/src/include/duckdb/storage/buffer/managed_buffer.hpp
@@ -18,7 +18,7 @@ class BufferManager;
 //! Managed buffer is an arbitrarily-sized buffer that is at least of size >= BLOCK_SIZE
 class ManagedBuffer : public FileBuffer {
 public:
-	ManagedBuffer(BufferManager &manager, index_t size, bool can_destroy, block_id_t id);
+	ManagedBuffer(BufferManager &manager, idx_t size, bool can_destroy, block_id_t id);
 
 	//! The buffer manager this buffer belongs to
 	BufferManager &manager;

--- a/src/include/duckdb/storage/buffer_manager.hpp
+++ b/src/include/duckdb/storage/buffer_manager.hpp
@@ -25,7 +25,7 @@ class BufferManager {
 	friend class BufferHandle;
 
 public:
-	BufferManager(FileSystem &fs, BlockManager &manager, string temp_directory, index_t maximum_memory);
+	BufferManager(FileSystem &fs, BlockManager &manager, string temp_directory, idx_t maximum_memory);
 	~BufferManager();
 
 	//! Pin a block id, returning a block handle holding a pointer to the block
@@ -34,13 +34,13 @@ public:
 	//! Allocate a buffer of arbitrary size, as long as it is >= BLOCK_SIZE. can_destroy signifies whether or not the
 	//! buffer can be destroyed when unpinned, or whether or not it needs to be written to a temporary file so it can be
 	//! reloaded.
-	unique_ptr<BufferHandle> Allocate(index_t alloc_size, bool can_destroy = false);
+	unique_ptr<BufferHandle> Allocate(idx_t alloc_size, bool can_destroy = false);
 	//! Destroy the managed buffer with the specified buffer_id, freeing its memory
 	void DestroyBuffer(block_id_t buffer_id, bool can_destroy = false);
 
 	//! Set a new memory limit to the buffer manager, throws an exception if the new limit is too low and not enough
 	//! blocks can be evicted
-	void SetLimit(index_t limit = (index_t)-1);
+	void SetLimit(idx_t limit = (idx_t)-1);
 
 private:
 	unique_ptr<BufferHandle> PinBlock(block_id_t block_id);
@@ -70,9 +70,9 @@ private:
 	//! The block manager
 	BlockManager &manager;
 	//! The current amount of memory that is occupied by the buffer manager (in bytes)
-	index_t current_memory;
+	idx_t current_memory;
 	//! The maximum amount of memory that the buffer manager can keep (in bytes)
-	index_t maximum_memory;
+	idx_t maximum_memory;
 	//! The directory name where temporary files are stored
 	string temp_directory;
 	//! The lock for the set of blocks

--- a/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
@@ -24,10 +24,10 @@ public:
 	void WriteTableData(Transaction &transaction);
 
 private:
-	void AppendData(index_t col_idx, Vector &data);
+	void AppendData(idx_t col_idx, Vector &data);
 
-	void CreateSegment(index_t col_idx);
-	void FlushSegment(index_t col_idx);
+	void CreateSegment(idx_t col_idx);
+	void FlushSegment(idx_t col_idx);
 
 	void WriteDataPointers();
 

--- a/src/include/duckdb/storage/column_data.hpp
+++ b/src/include/duckdb/storage/column_data.hpp
@@ -29,11 +29,11 @@ public:
 	//! The table of the column
 	DataTable *table;
 	//! The column index of the column
-	index_t column_idx;
+	idx_t column_idx;
 	//! The segments holding the data of the column
 	SegmentTree data;
 	//! The amount of persistent rows
-	index_t persistent_rows;
+	idx_t persistent_rows;
 
 public:
 	//! Initialize a scan of the column
@@ -60,7 +60,7 @@ public:
 
 private:
 	//! Append a transient segment
-	void AppendTransientSegment(index_t start_row);
+	void AppendTransientSegment(idx_t start_row);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -39,7 +39,7 @@ public:
 
 	//! The amount of elements in the table. Note that this number signifies the amount of COMMITTED entries in the
 	//! table. It can be inaccurate inside of transactions. More work is needed to properly support that.
-	std::atomic<index_t> cardinality;
+	std::atomic<idx_t> cardinality;
 	// schema of the table
 	string schema;
 	// name of the table
@@ -113,14 +113,14 @@ private:
 	void InitializeIndexScan(Transaction &transaction, TableIndexScanState &state, Index &index,
 	                         vector<column_t> column_ids);
 
-	bool ScanBaseTable(Transaction &transaction, DataChunk &result, TableScanState &state, index_t &current_row,
-	                   index_t max_row, index_t base_row, VersionManager &manager);
-	bool ScanCreateIndex(CreateIndexScanState &state, DataChunk &result, index_t &current_row, index_t max_row,
-	                     index_t base_row);
+	bool ScanBaseTable(Transaction &transaction, DataChunk &result, TableScanState &state, idx_t &current_row,
+	                   idx_t max_row, idx_t base_row, VersionManager &manager);
+	bool ScanCreateIndex(CreateIndexScanState &state, DataChunk &result, idx_t &current_row, idx_t max_row,
+	                     idx_t base_row);
 
 	//! Figure out which of the row ids to use for the given transaction by looking at inserted/deleted data. Returns
 	//! the amount of rows to use and places the row_ids in the result_rows array.
-	index_t FetchRows(Transaction &transaction, Vector &row_identifiers, row_t result_rows[]);
+	idx_t FetchRows(Transaction &transaction, Vector &row_identifiers, row_t result_rows[]);
 
 	//! The CreateIndexScan is a special scan that is used to create an index on the table, it keeps locks on the table
 	void InitializeCreateIndexScan(CreateIndexScanState &state, vector<column_t> column_ids);

--- a/src/include/duckdb/storage/meta_block_reader.hpp
+++ b/src/include/duckdb/storage/meta_block_reader.hpp
@@ -21,12 +21,12 @@ public:
 
 	BufferManager &manager;
 	unique_ptr<BufferHandle> handle;
-	index_t offset;
+	idx_t offset;
 	block_id_t next_block;
 
 public:
 	//! Read content of size read_size into the buffer
-	void ReadData(data_ptr_t buffer, index_t read_size) override;
+	void ReadData(data_ptr_t buffer, idx_t read_size) override;
 
 private:
 	void ReadNewBlock(block_id_t id);

--- a/src/include/duckdb/storage/meta_block_writer.hpp
+++ b/src/include/duckdb/storage/meta_block_writer.hpp
@@ -23,12 +23,12 @@ public:
 
 	BlockManager &manager;
 	unique_ptr<Block> block;
-	index_t offset;
+	idx_t offset;
 
 public:
 	void Flush();
 
-	void WriteData(const_data_ptr_t buffer, index_t write_size) override;
+	void WriteData(const_data_ptr_t buffer, idx_t write_size) override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/numeric_segment.hpp
+++ b/src/include/duckdb/storage/numeric_segment.hpp
@@ -14,10 +14,10 @@ namespace duckdb {
 
 class NumericSegment : public UncompressedSegment {
 public:
-	NumericSegment(BufferManager &manager, TypeId type, index_t row_start, block_id_t block_id = INVALID_BLOCK);
+	NumericSegment(BufferManager &manager, TypeId type, idx_t row_start, block_id_t block_id = INVALID_BLOCK);
 
 	//! The size of this type
-	index_t type_size;
+	idx_t type_size;
 
 public:
 	//! Fetch a single value and append it to the vector
@@ -26,29 +26,29 @@ public:
 	//! Append a part of a vector to the uncompressed segment with the given append state, updating the provided stats
 	//! in the process. Returns the amount of tuples appended. If this is less than `count`, the uncompressed segment is
 	//! full.
-	index_t Append(SegmentStatistics &stats, Vector &data, index_t offset, index_t count) override;
+	idx_t Append(SegmentStatistics &stats, Vector &data, idx_t offset, idx_t count) override;
 
 	//! Rollback a previous update
 	void RollbackUpdate(UpdateInfo *info) override;
 
 protected:
 	void Update(ColumnData &data, SegmentStatistics &stats, Transaction &transaction, Vector &update, row_t *ids,
-	            index_t vector_index, index_t vector_offset, UpdateInfo *node) override;
+	            idx_t vector_index, idx_t vector_offset, UpdateInfo *node) override;
 
-	void FetchBaseData(ColumnScanState &state, index_t vector_index, Vector &result) override;
+	void FetchBaseData(ColumnScanState &state, idx_t vector_index, Vector &result) override;
 	void FetchUpdateData(ColumnScanState &state, Transaction &transaction, UpdateInfo *versions,
 	                     Vector &result) override;
 
 public:
-	typedef void (*append_function_t)(SegmentStatistics &stats, data_ptr_t target, index_t target_offset,
-	                                  Vector &source, index_t offset, index_t count);
+	typedef void (*append_function_t)(SegmentStatistics &stats, data_ptr_t target, idx_t target_offset, Vector &source,
+	                                  idx_t offset, idx_t count);
 	typedef void (*update_function_t)(SegmentStatistics &stats, UpdateInfo *info, data_ptr_t base_data, Vector &update);
 	typedef void (*update_info_fetch_function_t)(Transaction &transaction, UpdateInfo *info, Vector &result);
-	typedef void (*update_info_append_function_t)(Transaction &transaction, UpdateInfo *info, index_t idx,
+	typedef void (*update_info_append_function_t)(Transaction &transaction, UpdateInfo *info, idx_t idx,
 	                                              Vector &result);
 	typedef void (*rollback_update_function_t)(UpdateInfo *info, data_ptr_t base_data);
 	typedef void (*merge_update_function_t)(SegmentStatistics &stats, UpdateInfo *node, data_ptr_t target,
-	                                        Vector &update, row_t *ids, index_t vector_offset);
+	                                        Vector &update, row_t *ids, idx_t vector_offset);
 
 private:
 	append_function_t append_function;
@@ -60,10 +60,10 @@ private:
 };
 
 template <class F1, class F2, class F3>
-static index_t merge_loop(row_t a[], sel_t b[], index_t acount, index_t bcount, index_t aoffset, F1 merge, F2 pick_a,
-                          F3 pick_b) {
-	index_t aidx = 0, bidx = 0;
-	index_t count = 0;
+static idx_t merge_loop(row_t a[], sel_t b[], idx_t acount, idx_t bcount, idx_t aoffset, F1 merge, F2 pick_a,
+                        F3 pick_b) {
+	idx_t aidx = 0, bidx = 0;
+	idx_t count = 0;
 	while (aidx < acount && bidx < bcount) {
 		auto a_id = a[aidx] - aoffset;
 		auto b_id = b[bidx];

--- a/src/include/duckdb/storage/storage_lock.hpp
+++ b/src/include/duckdb/storage/storage_lock.hpp
@@ -40,7 +40,7 @@ public:
 
 private:
 	std::mutex exclusive_lock;
-	std::atomic<index_t> read_count;
+	std::atomic<idx_t> read_count;
 
 private:
 	//! Release an exclusive lock

--- a/src/include/duckdb/storage/string_segment.hpp
+++ b/src/include/duckdb/storage/string_segment.hpp
@@ -21,8 +21,8 @@ public:
 
 struct StringBlock {
 	block_id_t block_id;
-	index_t offset;
-	index_t size;
+	idx_t offset;
+	idx_t size;
 	unique_ptr<StringBlock> next;
 };
 
@@ -49,11 +49,11 @@ typedef unique_ptr<StringUpdateInfo> string_update_info_t;
 
 class StringSegment : public UncompressedSegment {
 public:
-	StringSegment(BufferManager &manager, index_t row_start, block_id_t block_id = INVALID_BLOCK);
+	StringSegment(BufferManager &manager, idx_t row_start, block_id_t block_id = INVALID_BLOCK);
 	~StringSegment() override;
 
 	//! The current dictionary offset
-	index_t dictionary_offset;
+	idx_t dictionary_offset;
 	//! The string block holding strings that do not fit in the main block
 	//! FIXME: this should be replaced by a heap that also allows freeing of unused strings
 	unique_ptr<StringBlock> head;
@@ -71,26 +71,25 @@ public:
 	//! Append a part of a vector to the uncompressed segment with the given append state, updating the provided stats
 	//! in the process. Returns the amount of tuples appended. If this is less than `count`, the uncompressed segment is
 	//! full.
-	index_t Append(SegmentStatistics &stats, Vector &data, index_t offset, index_t count) override;
+	idx_t Append(SegmentStatistics &stats, Vector &data, idx_t offset, idx_t count) override;
 
 	//! Rollback a previous update
 	void RollbackUpdate(UpdateInfo *info) override;
 
 protected:
 	void Update(ColumnData &column_data, SegmentStatistics &stats, Transaction &transaction, Vector &update, row_t *ids,
-	            index_t vector_index, index_t vector_offset, UpdateInfo *node) override;
+	            idx_t vector_index, idx_t vector_offset, UpdateInfo *node) override;
 
-	void FetchBaseData(ColumnScanState &state, index_t vector_index, Vector &result) override;
+	void FetchBaseData(ColumnScanState &state, idx_t vector_index, Vector &result) override;
 	void FetchUpdateData(ColumnScanState &state, Transaction &transaction, UpdateInfo *versions,
 	                     Vector &result) override;
 
 private:
-	void AppendData(SegmentStatistics &stats, data_ptr_t target, data_ptr_t end, index_t target_offset, Vector &source,
-	                index_t offset, index_t count);
+	void AppendData(SegmentStatistics &stats, data_ptr_t target, data_ptr_t end, idx_t target_offset, Vector &source,
+	                idx_t offset, idx_t count);
 
 	//! Fetch all the strings of a vector from the base table and place their locations in the result vector
-	void FetchBaseData(ColumnScanState &state, data_ptr_t base_data, index_t vector_index, Vector &result,
-	                   index_t count);
+	void FetchBaseData(ColumnScanState &state, data_ptr_t base_data, idx_t vector_index, Vector &result, idx_t count);
 
 	string_location_t FetchStringLocation(data_ptr_t baseptr, int32_t dict_offset);
 	string_t FetchString(buffer_handle_set_t &handles, data_ptr_t baseptr, string_location_t location);
@@ -99,8 +98,8 @@ private:
 	string_t FetchStringFromDict(buffer_handle_set_t &handles, data_ptr_t baseptr, int32_t dict_offset);
 
 	//! Fetch string locations for a subset of the strings
-	void FetchStringLocations(data_ptr_t baseptr, row_t *ids, index_t vector_index, index_t vector_offset,
-	                          index_t count, string_location_t result[]);
+	void FetchStringLocations(data_ptr_t baseptr, row_t *ids, idx_t vector_index, idx_t vector_offset, idx_t count,
+	                          string_location_t result[]);
 
 	void WriteString(string_t string, block_id_t &result_block, int32_t &result_offset);
 	string_t ReadString(buffer_handle_set_t &handles, block_id_t block, int32_t offset);
@@ -114,16 +113,15 @@ private:
 	//! Expand the string segment, adding an additional maximum vector to the segment
 	void ExpandStringSegment(data_ptr_t baseptr);
 
-	string_update_info_t CreateStringUpdate(SegmentStatistics &stats, Vector &update, row_t *ids,
-	                                        index_t vector_offset);
-	string_update_info_t MergeStringUpdate(SegmentStatistics &stats, Vector &update, row_t *ids, index_t vector_offset,
+	string_update_info_t CreateStringUpdate(SegmentStatistics &stats, Vector &update, row_t *ids, idx_t vector_offset);
+	string_update_info_t MergeStringUpdate(SegmentStatistics &stats, Vector &update, row_t *ids, idx_t vector_offset,
 	                                       StringUpdateInfo &update_info);
 
-	void MergeUpdateInfo(UpdateInfo *node, Vector &update, row_t *ids, index_t vector_offset,
+	void MergeUpdateInfo(UpdateInfo *node, Vector &update, row_t *ids, idx_t vector_offset,
 	                     string_location_t string_locations[], nullmask_t original_nullmask);
 
 	//! The amount of bytes remaining to store in the block
-	index_t RemainingSpace() {
+	idx_t RemainingSpace() {
 		return Storage::BLOCK_SIZE - dictionary_offset - max_vector_count * vector_size;
 	}
 
@@ -134,9 +132,9 @@ private:
 	//! Marker used in length field to indicate the presence of a big string
 	static constexpr uint16_t BIG_STRING_MARKER = (uint16_t)-1;
 	//! Base size of big string marker (block id + offset)
-	static constexpr index_t BIG_STRING_MARKER_BASE_SIZE = sizeof(block_id_t) + sizeof(int32_t);
+	static constexpr idx_t BIG_STRING_MARKER_BASE_SIZE = sizeof(block_id_t) + sizeof(int32_t);
 	//! The marker size of the big string
-	static constexpr index_t BIG_STRING_MARKER_SIZE = BIG_STRING_MARKER_BASE_SIZE + sizeof(uint16_t);
+	static constexpr idx_t BIG_STRING_MARKER_SIZE = BIG_STRING_MARKER_BASE_SIZE + sizeof(uint16_t);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -18,7 +18,7 @@ enum class ChunkInfoType : uint8_t { DELETE_INFO, INSERT_INFO };
 
 class ChunkInfo {
 public:
-	ChunkInfo(VersionManager &manager, index_t start_row, ChunkInfoType type)
+	ChunkInfo(VersionManager &manager, idx_t start_row, ChunkInfoType type)
 	    : manager(manager), start(start_row), type(type) {
 	}
 	virtual ~ChunkInfo() {
@@ -27,46 +27,46 @@ public:
 	//! The version manager
 	VersionManager &manager;
 	//! The start row of the chunk
-	index_t start;
+	idx_t start;
 	//! The ChunkInfo type
 	ChunkInfoType type;
 
 public:
-	virtual index_t GetSelVector(Transaction &transaction, sel_t sel_vector[], index_t max_count) = 0;
+	virtual idx_t GetSelVector(Transaction &transaction, sel_t sel_vector[], idx_t max_count) = 0;
 	//! Returns whether or not a single row in the ChunkInfo should be used or not for the given transaction
 	virtual bool Fetch(Transaction &transaction, row_t row) = 0;
 	//! Marks the set of tuples inside the chunk as deleted
-	virtual void Delete(Transaction &transaction, row_t rows[], index_t count) = 0;
+	virtual void Delete(Transaction &transaction, row_t rows[], idx_t count) = 0;
 	//! Mark the rows as committed
-	virtual void CommitDelete(transaction_t commit_id, row_t rows[], index_t count) = 0;
+	virtual void CommitDelete(transaction_t commit_id, row_t rows[], idx_t count) = 0;
 };
 
 class ChunkDeleteInfo : public ChunkInfo {
 public:
-	ChunkDeleteInfo(VersionManager &manager, index_t start_row, ChunkInfoType type = ChunkInfoType::DELETE_INFO);
+	ChunkDeleteInfo(VersionManager &manager, idx_t start_row, ChunkInfoType type = ChunkInfoType::DELETE_INFO);
 	ChunkDeleteInfo(ChunkDeleteInfo &info, ChunkInfoType type);
 
 	//! The transaction ids of the transactions that deleted the tuples (if any)
 	transaction_t deleted[STANDARD_VECTOR_SIZE];
 
 public:
-	index_t GetSelVector(Transaction &transaction, sel_t sel_vector[], index_t max_count) override;
+	idx_t GetSelVector(Transaction &transaction, sel_t sel_vector[], idx_t max_count) override;
 	bool Fetch(Transaction &transaction, row_t row) override;
 
-	void Delete(Transaction &transaction, row_t rows[], index_t count) override;
-	void CommitDelete(transaction_t commit_id, row_t rows[], index_t count) override;
+	void Delete(Transaction &transaction, row_t rows[], idx_t count) override;
+	void CommitDelete(transaction_t commit_id, row_t rows[], idx_t count) override;
 };
 
 class ChunkInsertInfo : public ChunkDeleteInfo {
 public:
-	ChunkInsertInfo(VersionManager &manager, index_t start_row);
+	ChunkInsertInfo(VersionManager &manager, idx_t start_row);
 	ChunkInsertInfo(ChunkDeleteInfo &info);
 
 	//! The transaction ids of the transactions that inserted the tuples (if any)
 	transaction_t inserted[STANDARD_VECTOR_SIZE];
 
 public:
-	index_t GetSelVector(Transaction &transaction, sel_t sel_vector[], index_t max_count) override;
+	idx_t GetSelVector(Transaction &transaction, sel_t sel_vector[], idx_t max_count) override;
 	bool Fetch(Transaction &transaction, row_t row) override;
 };
 

--- a/src/include/duckdb/storage/table/column_segment.hpp
+++ b/src/include/duckdb/storage/table/column_segment.hpp
@@ -27,10 +27,10 @@ enum class ColumnSegmentType : uint8_t { TRANSIENT, PERSISTENT };
 
 class SegmentStatistics {
 public:
-	SegmentStatistics(TypeId type, index_t type_size);
+	SegmentStatistics(TypeId type, idx_t type_size);
 
 	TypeId type;
-	index_t type_size;
+	idx_t type_size;
 	//! The minimum value of the segment
 	unique_ptr<data_t[]> minimum;
 	//! The maximum value of the segment
@@ -38,7 +38,7 @@ public:
 	//! Whether or not the segment has NULL values
 	bool has_null;
 	//! The maximum string length, only used for string columns
-	index_t max_string_length;
+	idx_t max_string_length;
 	//! Whether or not the segment contains any big strings in overflow blocks, only used for string columns
 	bool has_overflow_strings;
 
@@ -49,13 +49,13 @@ public:
 class ColumnSegment : public SegmentBase {
 public:
 	//! Initialize an empty column segment of the specified type
-	ColumnSegment(TypeId type, ColumnSegmentType segment_type, index_t start, index_t count = 0);
+	ColumnSegment(TypeId type, ColumnSegmentType segment_type, idx_t start, idx_t count = 0);
 	virtual ~ColumnSegment() = default;
 
 	//! The type stored in the column
 	TypeId type;
 	//! The size of the type
-	index_t type_size;
+	idx_t type_size;
 	//! The column segment type (transient or persistent)
 	ColumnSegmentType segment_type;
 	//! The statistics for the segment
@@ -64,12 +64,12 @@ public:
 public:
 	virtual void InitializeScan(ColumnScanState &state) = 0;
 	//! Scan one vector from this segment
-	virtual void Scan(Transaction &transaction, ColumnScanState &state, index_t vector_index, Vector &result) = 0;
+	virtual void Scan(Transaction &transaction, ColumnScanState &state, idx_t vector_index, Vector &result) = 0;
 	//! Scan one vector from this segment, throwing an exception if there are any outstanding updates
 	virtual void IndexScan(ColumnScanState &state, Vector &result) = 0;
 
 	//! Fetch the base table vector index that belongs to this row
-	virtual void Fetch(ColumnScanState &state, index_t vector_index, Vector &result) = 0;
+	virtual void Fetch(ColumnScanState &state, idx_t vector_index, Vector &result) = 0;
 	//! Fetch a value of the specific row id and append it to the result
 	virtual void FetchRow(ColumnFetchState &state, Transaction &transaction, row_t row_id, Vector &result) = 0;
 

--- a/src/include/duckdb/storage/table/persistent_segment.hpp
+++ b/src/include/duckdb/storage/table/persistent_segment.hpp
@@ -17,26 +17,26 @@ namespace duckdb {
 
 class PersistentSegment : public ColumnSegment {
 public:
-	PersistentSegment(BufferManager &manager, block_id_t id, index_t offset, TypeId type, index_t start, index_t count);
+	PersistentSegment(BufferManager &manager, block_id_t id, idx_t offset, TypeId type, idx_t start, idx_t count);
 
 	//! The buffer manager
 	BufferManager &manager;
 	//! The block id that this segment relates to
 	block_id_t block_id;
 	//! The offset into the block
-	index_t offset;
+	idx_t offset;
 	//! The uncompressed segment that the data of the persistent segment is loaded into
 	unique_ptr<UncompressedSegment> data;
 
 public:
 	void InitializeScan(ColumnScanState &state) override;
 	//! Scan one vector from this transient segment
-	void Scan(Transaction &transaction, ColumnScanState &state, index_t vector_index, Vector &result) override;
+	void Scan(Transaction &transaction, ColumnScanState &state, idx_t vector_index, Vector &result) override;
 	//! Scan one vector from this transient segment, throwing an exception if there are any outstanding updates
 	void IndexScan(ColumnScanState &state, Vector &result) override;
 
 	//! Fetch the base table vector index that belongs to this row
-	void Fetch(ColumnScanState &state, index_t vector_index, Vector &result) override;
+	void Fetch(ColumnScanState &state, idx_t vector_index, Vector &result) override;
 	//! Fetch a value of the specific row id and append it to the result
 	void FetchRow(ColumnFetchState &state, Transaction &transaction, row_t row_id, Vector &result) override;
 

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -34,7 +34,7 @@ struct ColumnScanState {
 	//! The column segment that is currently being scanned
 	ColumnSegment *current;
 	//! The vector index of the transient segment
-	index_t vector_index;
+	idx_t vector_index;
 	//! The primary buffer handle
 	unique_ptr<BufferHandle> primary_handle;
 	//! The set of pinned block handles for this scan
@@ -57,9 +57,9 @@ struct ColumnFetchState {
 struct LocalScanState {
 	LocalTableStorage *storage = nullptr;
 
-	index_t chunk_index;
-	index_t max_index;
-	index_t last_chunk_count;
+	idx_t chunk_index;
+	idx_t max_index;
+	idx_t last_chunk_count;
 
 	sel_t sel_vector_data[STANDARD_VECTOR_SIZE];
 };
@@ -67,10 +67,10 @@ struct LocalScanState {
 struct TableScanState {
 	virtual ~TableScanState() = default;
 
-	index_t current_persistent_row, max_persistent_row;
-	index_t current_transient_row, max_transient_row;
+	idx_t current_persistent_row, max_persistent_row;
+	idx_t current_transient_row, max_transient_row;
 	unique_ptr<ColumnScanState[]> column_scans;
-	index_t offset;
+	idx_t offset;
 	sel_t sel_vector[STANDARD_VECTOR_SIZE];
 	vector<column_t> column_ids;
 	LocalScanState local_state;

--- a/src/include/duckdb/storage/table/segment_base.hpp
+++ b/src/include/duckdb/storage/table/segment_base.hpp
@@ -14,15 +14,15 @@ namespace duckdb {
 
 class SegmentBase {
 public:
-	SegmentBase(index_t start, index_t count) : start(start), count(count) {
+	SegmentBase(idx_t start, idx_t count) : start(start), count(count) {
 	}
 	virtual ~SegmentBase() {
 	}
 
 	//! The start row id of this chunk
-	index_t start;
+	idx_t start;
 	//! The amount of entries in this storage chunk
-	index_t count;
+	idx_t count;
 	//! The next segment after this one
 	unique_ptr<SegmentBase> next;
 };

--- a/src/include/duckdb/storage/table/segment_tree.hpp
+++ b/src/include/duckdb/storage/table/segment_tree.hpp
@@ -17,7 +17,7 @@
 namespace duckdb {
 
 struct SegmentNode {
-	index_t row_start;
+	idx_t row_start;
 	SegmentBase *node;
 };
 
@@ -38,12 +38,12 @@ public:
 	//! Gets a pointer to the last segment. Useful for appends.
 	SegmentBase *GetLastSegment();
 	//! Gets a pointer to a specific column segment for the given row
-	SegmentBase *GetSegment(index_t row_number);
+	SegmentBase *GetSegment(idx_t row_number);
 	//! Append a column segment to the tree
 	void AppendSegment(unique_ptr<SegmentBase> segment);
 
 	//! Get the segment index of the column segment for the given row (does not lock the segment tree!)
-	index_t GetSegmentIndex(index_t row_number);
+	idx_t GetSegmentIndex(idx_t row_number);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/transient_segment.hpp
+++ b/src/include/duckdb/storage/table/transient_segment.hpp
@@ -18,7 +18,7 @@ struct ColumnAppendState;
 
 class TransientSegment : public ColumnSegment {
 public:
-	TransientSegment(BufferManager &manager, TypeId type, index_t start);
+	TransientSegment(BufferManager &manager, TypeId type, idx_t start);
 
 	//! The buffer manager
 	BufferManager &manager;
@@ -28,12 +28,12 @@ public:
 public:
 	void InitializeScan(ColumnScanState &state) override;
 	//! Scan one vector from this transient segment
-	void Scan(Transaction &transaction, ColumnScanState &state, index_t vector_index, Vector &result) override;
+	void Scan(Transaction &transaction, ColumnScanState &state, idx_t vector_index, Vector &result) override;
 	//! Scan one vector from this transient segment, throwing an exception if there are any outstanding updates
 	void IndexScan(ColumnScanState &state, Vector &result) override;
 
 	//! Fetch the base table vector index that belongs to this row
-	void Fetch(ColumnScanState &state, index_t vector_index, Vector &result) override;
+	void Fetch(ColumnScanState &state, idx_t vector_index, Vector &result) override;
 	//! Fetch a value of the specific row id and append it to the result
 	void FetchRow(ColumnFetchState &state, Transaction &transaction, row_t row_id, Vector &result) override;
 
@@ -43,9 +43,9 @@ public:
 	//! Initialize an append of this transient segment
 	void InitializeAppend(ColumnAppendState &state);
 	//! Appends a (part of) vector to the transient segment, returns the amount of entries successfully appended
-	index_t Append(ColumnAppendState &state, Vector &data, index_t offset, index_t count);
+	idx_t Append(ColumnAppendState &state, Vector &data, idx_t offset, idx_t count);
 	//! Revert an append made to this transient segment
-	void RevertAppend(index_t start_row);
+	void RevertAppend(idx_t start_row);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/version_manager.hpp
+++ b/src/include/duckdb/storage/table/version_manager.hpp
@@ -30,30 +30,30 @@ public:
 	//! The read/write lock for the delete info and insert info
 	StorageLock lock;
 	//! The info for each of the chunks
-	unordered_map<index_t, unique_ptr<ChunkInfo>> info;
+	unordered_map<idx_t, unique_ptr<ChunkInfo>> info;
 	//! The maximum amount of rows managed by the version manager
-	index_t max_row;
+	idx_t max_row;
 	//! The base row of the version manager, i.e. when passing row = base_row, it will be treated as row = 0
-	index_t base_row;
+	idx_t base_row;
 
 public:
 	//! For a given chunk index, fills the selection vector with the relevant tuples for a given transaction. If count
 	//! == max_count, all tuples are relevant and the selection vector is not set
-	index_t GetSelVector(Transaction &transaction, index_t index, sel_t sel_vector[], index_t max_count);
+	idx_t GetSelVector(Transaction &transaction, idx_t index, sel_t sel_vector[], idx_t max_count);
 
 	//! Fetch a specific row from the VersionManager, returns true if the row should be used for the transaction and
 	//! false otherwise.
-	bool Fetch(Transaction &transaction, index_t row);
+	bool Fetch(Transaction &transaction, idx_t row);
 
 	//! Delete the given set of rows in the version manager
 	void Delete(Transaction &transaction, Vector &row_ids);
 	//! Append a set of rows to the version manager, setting their inserted id to the given commit_id
-	void Append(Transaction &transaction, row_t row_start, index_t count, transaction_t commit_id);
+	void Append(Transaction &transaction, row_t row_start, idx_t count, transaction_t commit_id);
 	//! Revert a set of appends made to the version manager from the rows [row_start] until [row_end]
 	void RevertAppend(row_t row_start, row_t row_end);
 
 private:
-	ChunkInsertInfo *GetInsertInfo(index_t chunk_idx);
+	ChunkInsertInfo *GetInsertInfo(idx_t chunk_idx);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table_statistics.hpp
+++ b/src/include/duckdb/storage/table_statistics.hpp
@@ -14,7 +14,7 @@
 namespace duckdb {
 
 struct TableStatistics {
-	index_t estimated_cardinality;
+	idx_t estimated_cardinality;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/uncompressed_segment.hpp
+++ b/src/include/duckdb/storage/uncompressed_segment.hpp
@@ -24,7 +24,7 @@ struct UpdateInfo;
 //! An uncompressed segment represents an uncompressed segment of a column residing in a block
 class UncompressedSegment {
 public:
-	UncompressedSegment(BufferManager &manager, TypeId type, index_t row_start);
+	UncompressedSegment(BufferManager &manager, TypeId type, idx_t row_start);
 	virtual ~UncompressedSegment();
 
 	//! The buffer manager
@@ -34,13 +34,13 @@ public:
 	//! The block id that this segment relates to
 	block_id_t block_id;
 	//! The size of a vector of this type
-	index_t vector_size;
+	idx_t vector_size;
 	//! The maximum amount of vectors that can be stored in this segment
-	index_t max_vector_count;
+	idx_t max_vector_count;
 	//! The current amount of tuples that are stored in this segment
-	index_t tuple_count;
+	idx_t tuple_count;
 	//! The starting row of this segment
-	index_t row_start;
+	idx_t row_start;
 	//! Version chains for each of the vectors
 	unique_ptr<UpdateInfo *[]> versions;
 	//! The lock for the uncompressed segment
@@ -50,20 +50,20 @@ public:
 	virtual void InitializeScan(ColumnScanState &state) {
 	}
 	//! Fetch the vector at index "vector_index" from the uncompressed segment, storing it in the result vector
-	void Scan(Transaction &transaction, ColumnScanState &state, index_t vector_index, Vector &result);
+	void Scan(Transaction &transaction, ColumnScanState &state, idx_t vector_index, Vector &result);
 	//! Fetch the vector at index "vector_index" from the uncompressed segment, throwing an exception if there are any
 	//! outstanding updates
-	void IndexScan(ColumnScanState &state, index_t vector_index, Vector &result);
+	void IndexScan(ColumnScanState &state, idx_t vector_index, Vector &result);
 
 	//! Fetch a single vector from the base table
-	void Fetch(ColumnScanState &state, index_t vector_index, Vector &result);
+	void Fetch(ColumnScanState &state, idx_t vector_index, Vector &result);
 	//! Fetch a single value and append it to the vector
 	virtual void FetchRow(ColumnFetchState &state, Transaction &transaction, row_t row_id, Vector &result) = 0;
 
 	//! Append a part of a vector to the uncompressed segment with the given append state, updating the provided stats
 	//! in the process. Returns the amount of tuples appended. If this is less than `count`, the uncompressed segment is
 	//! full.
-	virtual index_t Append(SegmentStatistics &stats, Vector &data, index_t offset, index_t count) = 0;
+	virtual idx_t Append(SegmentStatistics &stats, Vector &data, idx_t offset, idx_t count) = 0;
 
 	//! Update a set of row identifiers to the specified set of updated values
 	void Update(ColumnData &data, SegmentStatistics &stats, Transaction &transaction, Vector &update, row_t *ids,
@@ -80,24 +80,24 @@ public:
 	void ToTemporary();
 
 	//! Get the amount of tuples in a vector
-	index_t GetVectorCount(index_t vector_index) {
+	idx_t GetVectorCount(idx_t vector_index) {
 		assert(vector_index < max_vector_count);
 		assert(vector_index * STANDARD_VECTOR_SIZE <= tuple_count);
-		return std::min((index_t)STANDARD_VECTOR_SIZE, tuple_count - vector_index * STANDARD_VECTOR_SIZE);
+		return std::min((idx_t)STANDARD_VECTOR_SIZE, tuple_count - vector_index * STANDARD_VECTOR_SIZE);
 	}
 
 protected:
 	virtual void Update(ColumnData &data, SegmentStatistics &stats, Transaction &transaction, Vector &update,
-	                    row_t *ids, index_t vector_index, index_t vector_offset, UpdateInfo *node) = 0;
+	                    row_t *ids, idx_t vector_index, idx_t vector_offset, UpdateInfo *node) = 0;
 	//! Fetch base table data
-	virtual void FetchBaseData(ColumnScanState &state, index_t vector_index, Vector &result) = 0;
+	virtual void FetchBaseData(ColumnScanState &state, idx_t vector_index, Vector &result) = 0;
 	//! Fetch update data from an UpdateInfo version
 	virtual void FetchUpdateData(ColumnScanState &state, Transaction &transaction, UpdateInfo *version,
 	                             Vector &result) = 0;
 
 	//! Create a new update info for the specified transaction reflecting an update of the specified rows
-	UpdateInfo *CreateUpdateInfo(ColumnData &data, Transaction &transaction, row_t *ids, index_t count,
-	                             index_t vector_index, index_t vector_offset, index_t type_size);
+	UpdateInfo *CreateUpdateInfo(ColumnData &data, Transaction &transaction, row_t *ids, idx_t count,
+	                             idx_t vector_index, idx_t vector_offset, idx_t type_size);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/transaction/cleanup_state.hpp
+++ b/src/include/duckdb/transaction/cleanup_state.hpp
@@ -30,7 +30,7 @@ private:
 	DataTable *current_table;
 	DataChunk chunk;
 	row_t row_numbers[STANDARD_VECTOR_SIZE];
-	index_t count;
+	idx_t count;
 
 private:
 	void CleanupDelete(DeleteInfo *info);

--- a/src/include/duckdb/transaction/commit_state.hpp
+++ b/src/include/duckdb/transaction/commit_state.hpp
@@ -28,7 +28,7 @@ public:
 	UndoFlags current_op;
 
 	DataTable *current_table;
-	index_t row_identifiers[STANDARD_VECTOR_SIZE];
+	idx_t row_identifiers[STANDARD_VECTOR_SIZE];
 
 	unique_ptr<DataChunk> delete_chunk;
 	unique_ptr<DataChunk> update_chunk;

--- a/src/include/duckdb/transaction/delete_info.hpp
+++ b/src/include/duckdb/transaction/delete_info.hpp
@@ -16,8 +16,8 @@ class DataTable;
 
 struct DeleteInfo {
 	ChunkInfo *vinfo;
-	index_t count;
-	index_t base_row;
+	idx_t count;
+	idx_t base_row;
 	row_t rows[1];
 
 	DataTable &GetTable();

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -27,7 +27,7 @@ public:
 	//! The set of unique indexes
 	vector<unique_ptr<Index>> indexes;
 	//! The set of deleted entries
-	unordered_map<index_t, unique_ptr<bool[]>> deleted_entries;
+	unordered_map<idx_t, unique_ptr<bool[]>> deleted_entries;
 	//! The max row
 	row_t max_row;
 

--- a/src/include/duckdb/transaction/transaction.hpp
+++ b/src/include/duckdb/transaction/transaction.hpp
@@ -57,9 +57,10 @@ public:
 	bool is_invalidated;
 
 public:
-	void PushCatalogEntry(CatalogEntry *entry, data_ptr_t extra_data = nullptr, index_t extra_data_size = 0);
+	void PushCatalogEntry(CatalogEntry *entry, data_ptr_t extra_data = nullptr, idx_t extra_data_size = 0);
 
-	//! Commit the current transaction with the given commit identifier. Returns an error message if the transaction commit failed, or an empty string if the commit was sucessful
+	//! Commit the current transaction with the given commit identifier. Returns an error message if the transaction
+	//! commit failed, or an empty string if the commit was sucessful
 	string Commit(WriteAheadLog *log, transaction_t commit_id) noexcept;
 	//! Rollback
 	void Rollback() noexcept {
@@ -74,9 +75,10 @@ public:
 		return start_timestamp;
 	}
 
-	void PushDelete(ChunkInfo *vinfo, row_t rows[], index_t count, index_t base_row);
+	void PushDelete(ChunkInfo *vinfo, row_t rows[], idx_t count, idx_t base_row);
 
-	UpdateInfo *CreateUpdateInfo(index_t type_size, index_t entries);
+	UpdateInfo *CreateUpdateInfo(idx_t type_size, idx_t entries);
+
 private:
 	//! The undo buffer is used to store old versions of rows that are updated
 	//! or deleted

--- a/src/include/duckdb/transaction/undo_buffer.hpp
+++ b/src/include/duckdb/transaction/undo_buffer.hpp
@@ -19,14 +19,14 @@ namespace duckdb {
 class WriteAheadLog;
 
 struct UndoChunk {
-	UndoChunk(index_t size);
+	UndoChunk(idx_t size);
 	~UndoChunk();
 
 	data_ptr_t WriteEntry(UndoFlags type, uint32_t len);
 
 	unique_ptr<data_t[]> data;
-	index_t current_position;
-	index_t maximum_size;
+	idx_t current_position;
+	idx_t maximum_size;
 	unique_ptr<UndoChunk> next;
 	UndoChunk *prev;
 };
@@ -47,7 +47,7 @@ public:
 
 	//! Reserve space for an entry of the specified type and length in the undo
 	//! buffer
-	data_ptr_t CreateEntry(UndoFlags type, index_t len);
+	data_ptr_t CreateEntry(UndoFlags type, idx_t len);
 
 	bool ChangesMade();
 

--- a/src/include/duckdb/transaction/update_info.hpp
+++ b/src/include/duckdb/transaction/update_info.hpp
@@ -23,7 +23,7 @@ struct UpdateInfo {
 	//! The version number
 	transaction_t version_number;
 	//! The vector index within the uncompressed segment
-	index_t vector_index;
+	idx_t vector_index;
 	//! The amount of updated tuples
 	sel_t N;
 	//! The maximum amount of tuples that can fit into this UpdateInfo

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -146,7 +146,7 @@ void Appender::AppendValue(Value value) {
 	column++;
 }
 
-Vector &Appender::GetAppendVector(index_t col_idx) {
+Vector &Appender::GetAppendVector(idx_t col_idx) {
 	if (col_idx >= chunk.column_count) {
 		throw Exception("Column index out of range!");
 	}
@@ -160,8 +160,8 @@ void Appender::Flush() {
 	CheckInvalidated();
 	try {
 		// check that all vectors have the same length before appending
-		index_t chunk_size = chunk.size();
-		for (index_t i = 1; i < chunk.column_count; i++) {
+		idx_t chunk_size = chunk.size();
+		for (idx_t i = 1; i < chunk.column_count; i++) {
 			if (chunk.data[i].count != chunk_size) {
 				throw Exception("Failed to Flush appender: vectors have different number of rows");
 			}

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -200,7 +200,8 @@ unique_ptr<QueryResult> ClientContext::ExecutePreparedStatement(const string &qu
 		throw Exception("Current transaction is aborted (please ROLLBACK)");
 	}
 	if (db.access_mode == AccessMode::READ_ONLY && !statement.read_only) {
-		throw Exception(StringUtil::Format("Cannot execute statement of type \"%s\" in read-only mode!", StatementTypeToString(statement.statement_type).c_str()));
+		throw Exception(StringUtil::Format("Cannot execute statement of type \"%s\" in read-only mode!",
+		                                   StatementTypeToString(statement.statement_type).c_str()));
 	}
 
 	// bind the bound values before execution
@@ -391,7 +392,7 @@ unique_ptr<QueryResult> ClientContext::RunStatements(const string &query, vector
 	// iterate over them and execute them one by one
 	unique_ptr<QueryResult> result;
 	QueryResult *last_result = nullptr;
-	for (index_t i = 0; i < statements.size(); i++) {
+	for (idx_t i = 0; i < statements.size(); i++) {
 		auto &statement = statements[i];
 		bool is_last_statement = i + 1 == statements.size();
 		auto current_result = RunStatement(query, move(statement), allow_stream_result && is_last_statement);
@@ -494,7 +495,7 @@ string ClientContext::VerifyQuery(string query, unique_ptr<SQLStatement> stateme
 	auto &de_expr_list = deserialized_stmt->node->GetSelectList();
 	auto &cp_expr_list = copied_stmt->node->GetSelectList();
 	assert(orig_expr_list.size() == de_expr_list.size() && cp_expr_list.size() == de_expr_list.size());
-	for (index_t i = 0; i < orig_expr_list.size(); i++) {
+	for (idx_t i = 0; i < orig_expr_list.size(); i++) {
 		// check that the expressions are equivalent
 		assert(orig_expr_list[i]->Equals(de_expr_list[i].get()));
 		assert(orig_expr_list[i]->Equals(cp_expr_list[i].get()));
@@ -504,9 +505,9 @@ string ClientContext::VerifyQuery(string query, unique_ptr<SQLStatement> stateme
 		assert(orig_expr_list[i]->Hash() == cp_expr_list[i]->Hash());
 	}
 	// now perform additional checking within the expressions
-	for (index_t outer_idx = 0; outer_idx < orig_expr_list.size(); outer_idx++) {
+	for (idx_t outer_idx = 0; outer_idx < orig_expr_list.size(); outer_idx++) {
 		auto hash = orig_expr_list[outer_idx]->Hash();
-		for (index_t inner_idx = 0; inner_idx < orig_expr_list.size(); inner_idx++) {
+		for (idx_t inner_idx = 0; inner_idx < orig_expr_list.size(); inner_idx++) {
 			auto hash2 = orig_expr_list[inner_idx]->Hash();
 			if (hash != hash2) {
 				// if the hashes are not equivalent, the expressions should not be equivalent
@@ -650,7 +651,7 @@ void ClientContext::Append(TableDescription &description, DataChunk &chunk) {
 		if (description.columns.size() != table_entry->columns.size()) {
 			throw Exception("Failed to append: table entry has different number of columns!");
 		}
-		for (index_t i = 0; i < description.columns.size(); i++) {
+		for (idx_t i = 0; i < description.columns.size(); i++) {
 			if (description.columns[i].type != table_entry->columns[i].type) {
 				throw Exception("Failed to append: table entry has different number of columns!");
 			}

--- a/src/main/duckdb-c.cpp
+++ b/src/main/duckdb-c.cpp
@@ -15,7 +15,7 @@ using namespace duckdb;
 
 static SQLType ConvertCTypeToCPP(duckdb_type type);
 static duckdb_type ConvertCPPTypeToC(SQLType type);
-static index_t GetCTypeSize(duckdb_type type);
+static idx_t GetCTypeSize(duckdb_type type);
 
 struct DatabaseData {
 	DatabaseData() : database(nullptr) {
@@ -69,12 +69,12 @@ void duckdb_disconnect(duckdb_connection *connection) {
 	}
 }
 
-template <class T> void WriteData(duckdb_result *out, ChunkCollection &source, index_t col) {
-	index_t row = 0;
+template <class T> void WriteData(duckdb_result *out, ChunkCollection &source, idx_t col) {
+	idx_t row = 0;
 	auto target = (T *)out->columns[col].data;
 	for (auto &chunk : source.chunks) {
 		auto source = (T *)chunk->data[col].GetData();
-		for (index_t k = 0; k < chunk->data[col].count; k++) {
+		for (idx_t k = 0; k < chunk->data[col].count; k++) {
 			target[row++] = source[k];
 		}
 	}
@@ -102,7 +102,7 @@ static duckdb_state duckdb_translate_result(MaterializedQueryResult *result, duc
 	}
 	// zero initialize the columns (so we can cleanly delete it in case a malloc fails)
 	memset(out->columns, 0, sizeof(duckdb_column) * out->column_count);
-	for (index_t i = 0; i < out->column_count; i++) {
+	for (idx_t i = 0; i < out->column_count; i++) {
 		out->columns[i].type = ConvertCPPTypeToC(result->sql_types[i]);
 		out->columns[i].name = strdup(result->names[i].c_str());
 		out->columns[i].nullmask = (bool *)malloc(sizeof(bool) * out->row_count);
@@ -117,12 +117,12 @@ static duckdb_state duckdb_translate_result(MaterializedQueryResult *result, duc
 		}
 	}
 	// now write the data
-	for (index_t col = 0; col < out->column_count; col++) {
+	for (idx_t col = 0; col < out->column_count; col++) {
 		// first set the nullmask
-		index_t row = 0;
+		idx_t row = 0;
 		for (auto &chunk : result->collection.chunks) {
 			assert(!chunk->data[col].sel_vector);
-			for (index_t k = 0; k < chunk->data[col].count; k++) {
+			for (idx_t k = 0; k < chunk->data[col].count; k++) {
 				out->columns[col].nullmask[row++] = chunk->data[col].nullmask[k];
 			}
 		}
@@ -151,11 +151,11 @@ static duckdb_state duckdb_translate_result(MaterializedQueryResult *result, duc
 			WriteData<double>(out, result->collection, col);
 			break;
 		case SQLTypeId::VARCHAR: {
-			index_t row = 0;
+			idx_t row = 0;
 			auto target = (const char **)out->columns[col].data;
 			for (auto &chunk : result->collection.chunks) {
 				auto source = (const char **)chunk->data[col].GetData();
-				for (index_t k = 0; k < chunk->data[col].count; k++) {
+				for (idx_t k = 0; k < chunk->data[col].count; k++) {
 					if (!chunk->data[col].nullmask[k]) {
 						target[row] = strdup(source[k]);
 					}
@@ -165,11 +165,11 @@ static duckdb_state duckdb_translate_result(MaterializedQueryResult *result, duc
 			break;
 		}
 		case SQLTypeId::DATE: {
-			index_t row = 0;
+			idx_t row = 0;
 			auto target = (duckdb_date *)out->columns[col].data;
 			for (auto &chunk : result->collection.chunks) {
 				auto source = (date_t *)chunk->data[col].GetData();
-				for (index_t k = 0; k < chunk->data[col].count; k++) {
+				for (idx_t k = 0; k < chunk->data[col].count; k++) {
 					if (!chunk->data[col].nullmask[k]) {
 						int32_t year, month, day;
 						Date::Convert(source[k], year, month, day);
@@ -183,11 +183,11 @@ static duckdb_state duckdb_translate_result(MaterializedQueryResult *result, duc
 			break;
 		}
 		case SQLTypeId::TIME: {
-			index_t row = 0;
+			idx_t row = 0;
 			auto target = (duckdb_time *)out->columns[col].data;
 			for (auto &chunk : result->collection.chunks) {
 				auto source = (dtime_t *)chunk->data[col].GetData();
-				for (index_t k = 0; k < chunk->data[col].count; k++) {
+				for (idx_t k = 0; k < chunk->data[col].count; k++) {
 					if (!chunk->data[col].nullmask[k]) {
 						int32_t hour, min, sec, msec;
 						Time::Convert(source[k], hour, min, sec, msec);
@@ -202,11 +202,11 @@ static duckdb_state duckdb_translate_result(MaterializedQueryResult *result, duc
 			break;
 		}
 		case SQLTypeId::TIMESTAMP: {
-			index_t row = 0;
+			idx_t row = 0;
 			auto target = (duckdb_timestamp *)out->columns[col].data;
 			for (auto &chunk : result->collection.chunks) {
 				auto source = (timestamp_t *)chunk->data[col].GetData();
-				for (index_t k = 0; k < chunk->data[col].count; k++) {
+				for (idx_t k = 0; k < chunk->data[col].count; k++) {
 					if (!chunk->data[col].nullmask[k]) {
 						date_t date;
 						dtime_t time;
@@ -246,12 +246,12 @@ duckdb_state duckdb_query(duckdb_connection connection, const char *query, duckd
 	return duckdb_translate_result(result.get(), out);
 }
 
-static void duckdb_destroy_column(duckdb_column column, index_t count) {
+static void duckdb_destroy_column(duckdb_column column, idx_t count) {
 	if (column.data) {
 		if (column.type == DUCKDB_TYPE_VARCHAR) {
 			// varchar, delete individual strings
 			auto data = (char **)column.data;
-			for (index_t i = 0; i < count; i++) {
+			for (idx_t i = 0; i < count; i++) {
 				if (data[i]) {
 					free(data[i]);
 				}
@@ -272,7 +272,7 @@ void duckdb_destroy_result(duckdb_result *result) {
 		free(result->error_message);
 	}
 	if (result->columns) {
-		for (index_t i = 0; i < result->column_count; i++) {
+		for (idx_t i = 0; i < result->column_count; i++) {
 			duckdb_destroy_column(result->columns[i], result->row_count);
 		}
 		free(result->columns);
@@ -301,7 +301,7 @@ duckdb_state duckdb_prepare(duckdb_connection connection, const char *query,
 	return wrapper->statement->success ? DuckDBSuccess : DuckDBError;
 }
 
-duckdb_state duckdb_nparams(duckdb_prepared_statement prepared_statement, index_t *nparams_out) {
+duckdb_state duckdb_nparams(duckdb_prepared_statement prepared_statement, idx_t *nparams_out) {
 	auto wrapper = (PreparedStatementWrapper *)prepared_statement;
 	if (!wrapper || !wrapper->statement || !wrapper->statement->success || wrapper->statement->is_invalidated) {
 		return DuckDBError;
@@ -310,7 +310,7 @@ duckdb_state duckdb_nparams(duckdb_prepared_statement prepared_statement, index_
 	return DuckDBSuccess;
 }
 
-static duckdb_state duckdb_bind_value(duckdb_prepared_statement prepared_statement, index_t param_idx, Value val) {
+static duckdb_state duckdb_bind_value(duckdb_prepared_statement prepared_statement, idx_t param_idx, Value val) {
 	auto wrapper = (PreparedStatementWrapper *)prepared_statement;
 	if (!wrapper || !wrapper->statement || !wrapper->statement->success || wrapper->statement->is_invalidated) {
 		return DuckDBError;
@@ -325,39 +325,39 @@ static duckdb_state duckdb_bind_value(duckdb_prepared_statement prepared_stateme
 	return DuckDBSuccess;
 }
 
-duckdb_state duckdb_bind_boolean(duckdb_prepared_statement prepared_statement, index_t param_idx, bool val) {
+duckdb_state duckdb_bind_boolean(duckdb_prepared_statement prepared_statement, idx_t param_idx, bool val) {
 	return duckdb_bind_value(prepared_statement, param_idx, Value::BOOLEAN(val));
 }
 
-duckdb_state duckdb_bind_int8(duckdb_prepared_statement prepared_statement, index_t param_idx, int8_t val) {
+duckdb_state duckdb_bind_int8(duckdb_prepared_statement prepared_statement, idx_t param_idx, int8_t val) {
 	return duckdb_bind_value(prepared_statement, param_idx, Value::TINYINT(val));
 }
 
-duckdb_state duckdb_bind_int16(duckdb_prepared_statement prepared_statement, index_t param_idx, int16_t val) {
+duckdb_state duckdb_bind_int16(duckdb_prepared_statement prepared_statement, idx_t param_idx, int16_t val) {
 	return duckdb_bind_value(prepared_statement, param_idx, Value::SMALLINT(val));
 }
 
-duckdb_state duckdb_bind_int32(duckdb_prepared_statement prepared_statement, index_t param_idx, int32_t val) {
+duckdb_state duckdb_bind_int32(duckdb_prepared_statement prepared_statement, idx_t param_idx, int32_t val) {
 	return duckdb_bind_value(prepared_statement, param_idx, Value::INTEGER(val));
 }
 
-duckdb_state duckdb_bind_int64(duckdb_prepared_statement prepared_statement, index_t param_idx, int64_t val) {
+duckdb_state duckdb_bind_int64(duckdb_prepared_statement prepared_statement, idx_t param_idx, int64_t val) {
 	return duckdb_bind_value(prepared_statement, param_idx, Value::BIGINT(val));
 }
 
-duckdb_state duckdb_bind_float(duckdb_prepared_statement prepared_statement, index_t param_idx, float val) {
+duckdb_state duckdb_bind_float(duckdb_prepared_statement prepared_statement, idx_t param_idx, float val) {
 	return duckdb_bind_value(prepared_statement, param_idx, Value(val));
 }
 
-duckdb_state duckdb_bind_double(duckdb_prepared_statement prepared_statement, index_t param_idx, double val) {
+duckdb_state duckdb_bind_double(duckdb_prepared_statement prepared_statement, idx_t param_idx, double val) {
 	return duckdb_bind_value(prepared_statement, param_idx, Value(val));
 }
 
-duckdb_state duckdb_bind_varchar(duckdb_prepared_statement prepared_statement, index_t param_idx, const char *val) {
+duckdb_state duckdb_bind_varchar(duckdb_prepared_statement prepared_statement, idx_t param_idx, const char *val) {
 	return duckdb_bind_value(prepared_statement, param_idx, Value(val));
 }
 
-duckdb_state duckdb_bind_null(duckdb_prepared_statement prepared_statement, index_t param_idx) {
+duckdb_state duckdb_bind_null(duckdb_prepared_statement prepared_statement, idx_t param_idx) {
 	return duckdb_bind_value(prepared_statement, param_idx, Value());
 }
 
@@ -442,7 +442,7 @@ SQLType ConvertCTypeToCPP(duckdb_type type) {
 	}
 }
 
-index_t GetCTypeSize(duckdb_type type) {
+idx_t GetCTypeSize(duckdb_type type) {
 	switch (type) {
 	case DUCKDB_TYPE_BOOLEAN:
 		return sizeof(bool);
@@ -473,12 +473,12 @@ index_t GetCTypeSize(duckdb_type type) {
 	}
 }
 
-template <class T> T UnsafeFetch(duckdb_result *result, index_t col, index_t row) {
+template <class T> T UnsafeFetch(duckdb_result *result, idx_t col, idx_t row) {
 	assert(row < result->row_count);
 	return ((T *)result->columns[col].data)[row];
 }
 
-static Value GetCValue(duckdb_result *result, index_t col, index_t row) {
+static Value GetCValue(duckdb_result *result, idx_t col, idx_t row) {
 	if (col >= result->column_count) {
 		return Value();
 	}
@@ -525,7 +525,7 @@ static Value GetCValue(duckdb_result *result, index_t col, index_t row) {
 	}
 }
 
-bool duckdb_value_boolean(duckdb_result *result, index_t col, index_t row) {
+bool duckdb_value_boolean(duckdb_result *result, idx_t col, idx_t row) {
 	Value val = GetCValue(result, col, row);
 	if (val.is_null) {
 		return false;
@@ -534,7 +534,7 @@ bool duckdb_value_boolean(duckdb_result *result, index_t col, index_t row) {
 	}
 }
 
-int8_t duckdb_value_int8(duckdb_result *result, index_t col, index_t row) {
+int8_t duckdb_value_int8(duckdb_result *result, idx_t col, idx_t row) {
 	Value val = GetCValue(result, col, row);
 	if (val.is_null) {
 		return 0;
@@ -543,7 +543,7 @@ int8_t duckdb_value_int8(duckdb_result *result, index_t col, index_t row) {
 	}
 }
 
-int16_t duckdb_value_int16(duckdb_result *result, index_t col, index_t row) {
+int16_t duckdb_value_int16(duckdb_result *result, idx_t col, idx_t row) {
 	Value val = GetCValue(result, col, row);
 	if (val.is_null) {
 		return 0;
@@ -552,7 +552,7 @@ int16_t duckdb_value_int16(duckdb_result *result, index_t col, index_t row) {
 	}
 }
 
-int32_t duckdb_value_int32(duckdb_result *result, index_t col, index_t row) {
+int32_t duckdb_value_int32(duckdb_result *result, idx_t col, idx_t row) {
 	Value val = GetCValue(result, col, row);
 	if (val.is_null) {
 		return 0;
@@ -561,7 +561,7 @@ int32_t duckdb_value_int32(duckdb_result *result, index_t col, index_t row) {
 	}
 }
 
-int64_t duckdb_value_int64(duckdb_result *result, index_t col, index_t row) {
+int64_t duckdb_value_int64(duckdb_result *result, idx_t col, idx_t row) {
 	Value val = GetCValue(result, col, row);
 	if (val.is_null) {
 		return 0;
@@ -570,7 +570,7 @@ int64_t duckdb_value_int64(duckdb_result *result, index_t col, index_t row) {
 	}
 }
 
-float duckdb_value_float(duckdb_result *result, index_t col, index_t row) {
+float duckdb_value_float(duckdb_result *result, idx_t col, idx_t row) {
 	Value val = GetCValue(result, col, row);
 	if (val.is_null) {
 		return 0.0;
@@ -579,7 +579,7 @@ float duckdb_value_float(duckdb_result *result, index_t col, index_t row) {
 	}
 }
 
-double duckdb_value_double(duckdb_result *result, index_t col, index_t row) {
+double duckdb_value_double(duckdb_result *result, idx_t col, idx_t row) {
 	Value val = GetCValue(result, col, row);
 	if (val.is_null) {
 		return 0.0;
@@ -588,7 +588,7 @@ double duckdb_value_double(duckdb_result *result, index_t col, index_t row) {
 	}
 }
 
-char *duckdb_value_varchar(duckdb_result *result, index_t col, index_t row) {
+char *duckdb_value_varchar(duckdb_result *result, idx_t col, idx_t row) {
 	Value val = GetCValue(result, col, row);
 	return strdup(val.ToString(ConvertCTypeToCPP(result->columns[col].type)).c_str());
 }

--- a/src/main/materialized_query_result.cpp
+++ b/src/main/materialized_query_result.cpp
@@ -16,7 +16,7 @@ MaterializedQueryResult::MaterializedQueryResult(string error)
     : QueryResult(QueryResultType::MATERIALIZED_RESULT, error) {
 }
 
-Value MaterializedQueryResult::GetValue(index_t column, index_t index) {
+Value MaterializedQueryResult::GetValue(idx_t column, idx_t index) {
 	auto &data = collection.GetChunk(index).data[column];
 	auto offset_in_chunk = index % STANDARD_VECTOR_SIZE;
 	return data.GetValue(offset_in_chunk);
@@ -27,8 +27,8 @@ string MaterializedQueryResult::ToString() {
 	if (success) {
 		result = HeaderToString();
 		result += "[ Rows: " + to_string(collection.count) + "]\n";
-		for (index_t j = 0; j < collection.count; j++) {
-			for (index_t i = 0; i < collection.column_count(); i++) {
+		for (idx_t j = 0; j < collection.count; j++) {
+			for (idx_t i = 0; i < collection.column_count(); i++) {
 				auto val = collection.GetValue(i, j);
 				result += val.is_null ? "NULL" : val.ToString(sql_types[i]);
 				result += "\t";

--- a/src/main/prepared_statement.cpp
+++ b/src/main/prepared_statement.cpp
@@ -6,7 +6,7 @@
 using namespace duckdb;
 using namespace std;
 
-PreparedStatement::PreparedStatement(ClientContext *context, string name, PreparedStatementData &data, index_t n_param)
+PreparedStatement::PreparedStatement(ClientContext *context, string name, PreparedStatementData &data, idx_t n_param)
     : context(context), name(name), success(true), is_invalidated(false), n_param(n_param) {
 	this->type = data.statement_type;
 	this->types = data.sql_types;

--- a/src/main/prepared_statement_data.cpp
+++ b/src/main/prepared_statement_data.cpp
@@ -4,8 +4,8 @@
 using namespace duckdb;
 using namespace std;
 
-PreparedStatementData::PreparedStatementData(StatementType type) : statement_type(type), read_only(true), requires_valid_transaction(true) {
-
+PreparedStatementData::PreparedStatementData(StatementType type)
+    : statement_type(type), read_only(true), requires_valid_transaction(true) {
 }
 
 PreparedStatementData::~PreparedStatementData() {
@@ -17,7 +17,7 @@ void PreparedStatementData::Bind(vector<Value> values) {
 		throw BinderException("Parameter/argument count mismatch for prepared statement");
 	}
 	// bind the values
-	for (index_t i = 0; i < values.size(); i++) {
+	for (idx_t i = 0; i < values.size(); i++) {
 		auto it = value_map.find(i + 1);
 		if (it == value_map.end()) {
 			throw BinderException("Could not find parameter with index %llu", i + 1);
@@ -33,7 +33,7 @@ void PreparedStatementData::Bind(vector<Value> values) {
 	}
 }
 
-SQLType PreparedStatementData::GetType(index_t param_idx) {
+SQLType PreparedStatementData::GetType(idx_t param_idx) {
 	auto it = value_map.find(param_idx);
 	if (it == value_map.end()) {
 		throw BinderException("Could not find parameter with index %llu", param_idx);

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -11,9 +11,9 @@
 using namespace duckdb;
 using namespace std;
 
-constexpr index_t TREE_RENDER_WIDTH = 20;
-constexpr index_t REMAINING_RENDER_WIDTH = TREE_RENDER_WIDTH - 2;
-constexpr index_t MAX_EXTRA_LINES = 10;
+constexpr idx_t TREE_RENDER_WIDTH = 20;
+constexpr idx_t REMAINING_RENDER_WIDTH = TREE_RENDER_WIDTH - 2;
+constexpr idx_t MAX_EXTRA_LINES = 10;
 
 void QueryProfiler::StartQuery(string query) {
 	if (!enabled)
@@ -223,7 +223,7 @@ static bool is_padding(char l) {
 }
 
 static string remove_padding(string l) {
-	index_t start = 0, end = l.size();
+	idx_t start = 0, end = l.size();
 	while (start < l.size() && is_padding(l[start])) {
 		start++;
 	}
@@ -233,7 +233,7 @@ static string remove_padding(string l) {
 	return l.substr(start, end - start);
 }
 
-unique_ptr<QueryProfiler::TreeNode> QueryProfiler::CreateTree(PhysicalOperator *root, index_t depth) {
+unique_ptr<QueryProfiler::TreeNode> QueryProfiler::CreateTree(PhysicalOperator *root, idx_t depth) {
 	auto node = make_unique<QueryProfiler::TreeNode>();
 	node->name = PhysicalOperatorToString(root->type);
 	node->extra_info = root->ExtraRenderInformation();
@@ -241,13 +241,13 @@ unique_ptr<QueryProfiler::TreeNode> QueryProfiler::CreateTree(PhysicalOperator *
 		auto splits = StringUtil::Split(node->extra_info, '\n');
 		for (auto &split : splits) {
 			string str = remove_padding(split);
-			constexpr index_t max_segment_size = REMAINING_RENDER_WIDTH - 2;
-			index_t location = 0;
+			constexpr idx_t max_segment_size = REMAINING_RENDER_WIDTH - 2;
+			idx_t location = 0;
 			while (location < str.size() && node->split_extra_info.size() < MAX_EXTRA_LINES) {
 				bool has_to_split = (str.size() - location) > max_segment_size;
 				if (has_to_split) {
 					// look for a split character
-					index_t i;
+					idx_t i;
 					for (i = 8; i < max_segment_size; i++) {
 						if (!is_non_split_char(str[location + i])) {
 							// split here
@@ -277,22 +277,22 @@ static string DrawPadded(string text, char padding_character = ' ') {
 	if (text.size() > remaining_width) {
 		text = text.substr(0, remaining_width);
 	}
-	assert(text.size() <= (index_t)numeric_limits<int32_t>::max());
+	assert(text.size() <= (idx_t)numeric_limits<int32_t>::max());
 
 	auto right_padding = (remaining_width - text.size()) / 2;
 	auto left_padding = remaining_width - text.size() - right_padding;
 	return "|" + string(left_padding, padding_character) + text + string(right_padding, padding_character) + "|";
 }
 
-index_t QueryProfiler::RenderTreeRecursive(QueryProfiler::TreeNode &node, vector<string> &render,
-                                           vector<index_t> &render_heights, index_t base_render_x, index_t start_depth,
-                                           index_t depth) {
+idx_t QueryProfiler::RenderTreeRecursive(QueryProfiler::TreeNode &node, vector<string> &render,
+                                         vector<idx_t> &render_heights, idx_t base_render_x, idx_t start_depth,
+                                         idx_t depth) {
 	auto render_height = render_heights[depth];
 	auto width = base_render_x;
 	// render this node
 	// first add any padding to render at this location
 	auto start_position = width * TREE_RENDER_WIDTH;
-	for (index_t i = 0; i < render_height; i++) {
+	for (idx_t i = 0; i < render_height; i++) {
 		if (render[start_depth + i].size() > start_position) {
 			// something has already been rendered here!
 			throw Exception("Tree rendering error, overlapping nodes!");
@@ -310,7 +310,7 @@ index_t QueryProfiler::RenderTreeRecursive(QueryProfiler::TreeNode &node, vector
 	string name = node.name;
 	render[start_depth + 1] += DrawPadded(name);
 	// draw extra information
-	for (index_t i = 2; i < render_height - 3; i++) {
+	for (idx_t i = 2; i < render_height - 3; i++) {
 		auto split_index = i - 2;
 		string string = split_index < node.split_extra_info.size() ? node.split_extra_info[split_index] : "";
 		render[start_depth + i] += DrawPadded(string);
@@ -333,23 +333,23 @@ index_t QueryProfiler::RenderTreeRecursive(QueryProfiler::TreeNode &node, vector
 	return width;
 }
 
-index_t QueryProfiler::GetDepth(QueryProfiler::TreeNode &node) {
-	index_t depth = 0;
+idx_t QueryProfiler::GetDepth(QueryProfiler::TreeNode &node) {
+	idx_t depth = 0;
 	for (auto &child : node.children) {
 		depth = max(depth, GetDepth(*child));
 	}
 	return depth + 1;
 }
 
-static void GetRenderHeight(QueryProfiler::TreeNode &node, vector<index_t> &render_heights, int depth = 0) {
-	render_heights[depth] = max(render_heights[depth], (5 + (index_t)node.split_extra_info.size()));
+static void GetRenderHeight(QueryProfiler::TreeNode &node, vector<idx_t> &render_heights, int depth = 0) {
+	render_heights[depth] = max(render_heights[depth], (5 + (idx_t)node.split_extra_info.size()));
 	for (auto &child : node.children) {
 		GetRenderHeight(*child, render_heights, depth + 1);
 	}
 }
 
 string QueryProfiler::RenderTree(QueryProfiler::TreeNode &node) {
-	vector<index_t> render_heights;
+	vector<idx_t> render_heights;
 	// compute the height of each level
 	auto depth = GetDepth(node);
 

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -46,8 +46,8 @@ bool QueryResult::Equals(QueryResult &other) {
 			return false;
 		}
 		assert(lchunk->column_count == rchunk->column_count);
-		for (index_t col = 0; col < rchunk->column_count; col++) {
-			for (index_t row = 0; row < rchunk->size(); row++) {
+		for (idx_t col = 0; col < rchunk->column_count; col++) {
+			for (idx_t row = 0; row < rchunk->size(); row++) {
 				auto lvalue = lchunk->data[col].GetValue(row);
 				auto rvalue = rchunk->data[col].GetValue(row);
 				if (lvalue != rvalue) {

--- a/src/optimizer/column_lifetime_analyzer.cpp
+++ b/src/optimizer/column_lifetime_analyzer.cpp
@@ -11,7 +11,7 @@ using namespace std;
 
 void ColumnLifetimeAnalyzer::ExtractUnusedColumnBindings(vector<ColumnBinding> bindings,
                                                          column_binding_set_t &unused_bindings) {
-	for (index_t i = 0; i < bindings.size(); i++) {
+	for (idx_t i = 0; i < bindings.size(); i++) {
 		if (column_references.find(bindings[i]) == column_references.end()) {
 			unused_bindings.insert(bindings[i]);
 		}
@@ -20,12 +20,12 @@ void ColumnLifetimeAnalyzer::ExtractUnusedColumnBindings(vector<ColumnBinding> b
 
 void ColumnLifetimeAnalyzer::GenerateProjectionMap(vector<ColumnBinding> bindings,
                                                    column_binding_set_t &unused_bindings,
-                                                   vector<index_t> &projection_map) {
+                                                   vector<idx_t> &projection_map) {
 	if (unused_bindings.size() == 0) {
 		return;
 	}
 	// now iterate over the result bindings of the child
-	for (index_t i = 0; i < bindings.size(); i++) {
+	for (idx_t i = 0; i < bindings.size(); i++) {
 		// if this binding does not belong to the unused bindings, add it to the projection map
 		if (unused_bindings.find(bindings[i]) == unused_bindings.end()) {
 			projection_map.push_back(i);

--- a/src/optimizer/cse_optimizer.cpp
+++ b/src/optimizer/cse_optimizer.cpp
@@ -90,7 +90,7 @@ void CommonSubExpressionOptimizer::ExtractCommonSubExpresions(LogicalOperator &o
 		CountExpressions(*expr, expression_count);
 	}
 	// now we iterate over all the expressions and perform the actual CSE elimination
-	for (index_t i = 0; i < op.expressions.size(); i++) {
+	for (idx_t i = 0; i < op.expressions.size(); i++) {
 		PerformCSEReplacement(&op.expressions[i], expression_count);
 	}
 }

--- a/src/optimizer/expression_heuristics.cpp
+++ b/src/optimizer/expression_heuristics.cpp
@@ -32,7 +32,7 @@ void ExpressionHeuristics::ReorderExpressions(vector<unique_ptr<Expression>> &ex
 
 	struct ExpressionCosts {
 		unique_ptr<Expression> expr;
-		index_t cost;
+		idx_t cost;
 
 		bool operator==(const ExpressionCosts &p) const {
 			return cost == p.cost;
@@ -44,31 +44,31 @@ void ExpressionHeuristics::ReorderExpressions(vector<unique_ptr<Expression>> &ex
 
 	vector<ExpressionCosts> expression_costs;
 	// iterate expressions, get cost for each one
-	for (index_t i = 0; i < expressions.size(); i++) {
-		index_t cost = Cost(*expressions[i]);
+	for (idx_t i = 0; i < expressions.size(); i++) {
+		idx_t cost = Cost(*expressions[i]);
 		expression_costs.push_back({move(expressions[i]), cost});
 	}
 
 	// sort by cost and put back in place
 	sort(expression_costs.begin(), expression_costs.end());
-	for (index_t i = 0; i < expression_costs.size(); i++) {
+	for (idx_t i = 0; i < expression_costs.size(); i++) {
 		expressions[i] = move(expression_costs[i].expr);
 	}
 }
 
-index_t ExpressionHeuristics::ExpressionCost(BoundBetweenExpression &expr) {
+idx_t ExpressionHeuristics::ExpressionCost(BoundBetweenExpression &expr) {
 	return Cost(*expr.input) + Cost(*expr.lower) + Cost(*expr.upper) + 10;
 }
 
-index_t ExpressionHeuristics::ExpressionCost(BoundCaseExpression &expr) {
+idx_t ExpressionHeuristics::ExpressionCost(BoundCaseExpression &expr) {
 	// CASE WHEN check THEN result_if_true ELSE result_if_false END
 	return Cost(*expr.check) + Cost(*expr.result_if_true) + Cost(*expr.result_if_false) + 5;
 }
 
-index_t ExpressionHeuristics::ExpressionCost(BoundCastExpression &expr) {
+idx_t ExpressionHeuristics::ExpressionCost(BoundCastExpression &expr) {
 	// OPERATOR_CAST
 	// determine cast cost by comparing cast_expr.source_type and cast_expr_target_type
-	index_t cast_cost = 0;
+	idx_t cast_cost = 0;
 	if (expr.target_type != expr.source_type) {
 		// if cast from or to varchar
 		// TODO: we might want to add more cases
@@ -81,23 +81,23 @@ index_t ExpressionHeuristics::ExpressionCost(BoundCastExpression &expr) {
 	return Cost(*expr.child) + cast_cost;
 }
 
-index_t ExpressionHeuristics::ExpressionCost(BoundComparisonExpression &expr) {
+idx_t ExpressionHeuristics::ExpressionCost(BoundComparisonExpression &expr) {
 	// COMPARE_EQUAL, COMPARE_NOTEQUAL, COMPARE_GREATERTHAN, COMPARE_GREATERTHANOREQUALTO, COMPARE_LESSTHAN,
 	// COMPARE_LESSTHANOREQUALTO
 	return Cost(*expr.left) + 5 + Cost(*expr.right);
 }
 
-index_t ExpressionHeuristics::ExpressionCost(BoundConjunctionExpression &expr) {
+idx_t ExpressionHeuristics::ExpressionCost(BoundConjunctionExpression &expr) {
 	// CONJUNCTION_AND, CONJUNCTION_OR
-	index_t cost = 5;
+	idx_t cost = 5;
 	for (auto &child : expr.children) {
 		cost += Cost(*child);
 	}
 	return cost;
 }
 
-index_t ExpressionHeuristics::ExpressionCost(BoundFunctionExpression &expr) {
-	index_t cost_children = 0;
+idx_t ExpressionHeuristics::ExpressionCost(BoundFunctionExpression &expr) {
+	idx_t cost_children = 0;
 	for (auto &child : expr.children) {
 		cost_children += Cost(*child);
 	}
@@ -110,8 +110,8 @@ index_t ExpressionHeuristics::ExpressionCost(BoundFunctionExpression &expr) {
 	}
 }
 
-index_t ExpressionHeuristics::ExpressionCost(BoundOperatorExpression &expr, ExpressionType &expr_type) {
-	index_t sum = 0;
+idx_t ExpressionHeuristics::ExpressionCost(BoundOperatorExpression &expr, ExpressionType &expr_type) {
+	idx_t sum = 0;
 	for (auto &child : expr.children) {
 		sum += Cost(*child);
 	}
@@ -130,7 +130,7 @@ index_t ExpressionHeuristics::ExpressionCost(BoundOperatorExpression &expr, Expr
 	}
 }
 
-index_t ExpressionHeuristics::ExpressionCost(TypeId &return_type, index_t multiplier) {
+idx_t ExpressionHeuristics::ExpressionCost(TypeId &return_type, idx_t multiplier) {
 	// TODO: ajust values according to benchmark results
 	switch (return_type) {
 	case TypeId::VARCHAR:
@@ -144,7 +144,7 @@ index_t ExpressionHeuristics::ExpressionCost(TypeId &return_type, index_t multip
 	}
 }
 
-index_t ExpressionHeuristics::Cost(Expression &expr) {
+idx_t ExpressionHeuristics::Cost(Expression &expr) {
 	switch (expr.expression_class) {
 	case ExpressionClass::BOUND_CASE: {
 		auto &case_expr = (BoundCaseExpression &)expr;

--- a/src/optimizer/expression_rewriter.cpp
+++ b/src/optimizer/expression_rewriter.cpp
@@ -59,7 +59,7 @@ void ExpressionRewriter::Apply(LogicalOperator &root) {
 		// no rules to apply on this node
 		return;
 	}
-	for (index_t i = 0; i < root.expressions.size(); i++) {
+	for (idx_t i = 0; i < root.expressions.size(); i++) {
 		bool changes_made;
 		do {
 			changes_made = false;

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -27,13 +27,13 @@ Expression *FilterCombiner::GetNode(Expression *expr) {
 	return pointer_copy;
 }
 
-index_t FilterCombiner::GetEquivalenceSet(Expression *expr) {
+idx_t FilterCombiner::GetEquivalenceSet(Expression *expr) {
 	assert(stored_expressions.find(expr) != stored_expressions.end());
 	assert(stored_expressions.find(expr)->second.get() == expr);
 
 	auto entry = equivalence_set_map.find(expr);
 	if (entry == equivalence_set_map.end()) {
-		index_t index = set_index++;
+		idx_t index = set_index++;
 		equivalence_set_map[expr] = index;
 		equivalence_map[index].push_back(expr);
 		constant_values.insert(make_pair(index, vector<ExpressionValueInformation>()));
@@ -45,7 +45,7 @@ index_t FilterCombiner::GetEquivalenceSet(Expression *expr) {
 
 FilterResult FilterCombiner::AddConstantComparison(vector<ExpressionValueInformation> &info_list,
                                                    ExpressionValueInformation info) {
-	for (index_t i = 0; i < info_list.size(); i++) {
+	for (idx_t i = 0; i < info_list.size(); i++) {
 		auto comparison = CompareValueInformation(info_list[i], info);
 		switch (comparison) {
 		case ValueComparisonResult::PRUNE_LEFT:
@@ -92,8 +92,8 @@ void FilterCombiner::GenerateFilters(std::function<void(unique_ptr<Expression> f
 		auto &entries = entry.second;
 		auto &constant_list = constant_values.find(equivalence_set)->second;
 		// for each entry generate an equality expression comparing to each other
-		for (index_t i = 0; i < entries.size(); i++) {
-			for (index_t k = i + 1; k < entries.size(); k++) {
+		for (idx_t i = 0; i < entries.size(); i++) {
+			for (idx_t k = i + 1; k < entries.size(); k++) {
 				auto comparison = make_unique<BoundComparisonExpression>(ExpressionType::COMPARE_EQUAL,
 				                                                         entries[i]->Copy(), entries[k]->Copy());
 				callback(move(comparison));
@@ -101,7 +101,7 @@ void FilterCombiner::GenerateFilters(std::function<void(unique_ptr<Expression> f
 			// for each entry also create a comparison with each constant
 			int lower_index = -1, upper_index = -1;
 			bool lower_inclusive, upper_inclusive;
-			for (index_t k = 0; k < constant_list.size(); k++) {
+			for (idx_t k = 0; k < constant_list.size(); k++) {
 				auto &info = constant_list[k];
 				if (info.comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
 				    info.comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO) {
@@ -188,7 +188,7 @@ FilterResult FilterCombiner::AddFilter(Expression *expr) {
 	if (left_is_scalar || right_is_scalar) {
 		// comparison with scalar
 		auto node = GetNode(left_is_scalar ? comparison.right.get() : comparison.left.get());
-		index_t equivalence_set = GetEquivalenceSet(node);
+		idx_t equivalence_set = GetEquivalenceSet(node);
 		auto scalar = left_is_scalar ? comparison.left.get() : comparison.right.get();
 		auto constant_value = ExpressionExecutor::EvaluateScalar(*scalar);
 
@@ -224,7 +224,7 @@ FilterResult FilterCombiner::AddFilter(Expression *expr) {
 
 		auto &left_bucket = equivalence_map.find(left_equivalence_set)->second;
 		auto &right_bucket = equivalence_map.find(right_equivalence_set)->second;
-		for (index_t i = 0; i < right_bucket.size(); i++) {
+		for (idx_t i = 0; i < right_bucket.size(); i++) {
 			// rewrite the equivalence set mapping for this node
 			equivalence_set_map[right_bucket[i]] = left_equivalence_set;
 			// add the node to the left bucket
@@ -235,7 +235,7 @@ FilterResult FilterCombiner::AddFilter(Expression *expr) {
 		assert(constant_values.find(right_equivalence_set) != constant_values.end());
 		auto &left_constant_bucket = constant_values.find(left_equivalence_set)->second;
 		auto &right_constant_bucket = constant_values.find(right_equivalence_set)->second;
-		for (index_t i = 0; i < right_constant_bucket.size(); i++) {
+		for (idx_t i = 0; i < right_constant_bucket.size(); i++) {
 			if (AddConstantComparison(left_constant_bucket, right_constant_bucket[i]) == FilterResult::UNSATISFIABLE) {
 				return FilterResult::UNSATISFIABLE;
 			}

--- a/src/optimizer/filter_pushdown.cpp
+++ b/src/optimizer/filter_pushdown.cpp
@@ -44,7 +44,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownJoin(unique_ptr<LogicalOpera
 	assert(op->type == LogicalOperatorType::COMPARISON_JOIN || op->type == LogicalOperatorType::ANY_JOIN ||
 	       op->type == LogicalOperatorType::DELIM_JOIN);
 	auto &join = (LogicalJoin &)*op;
-	unordered_set<index_t> left_bindings, right_bindings;
+	unordered_set<idx_t> left_bindings, right_bindings;
 	LogicalJoin::GetTableReferences(*op->children[0], left_bindings);
 	LogicalJoin::GetTableReferences(*op->children[1], right_bindings);
 
@@ -98,7 +98,7 @@ void FilterPushdown::GenerateFilters() {
 
 unique_ptr<LogicalOperator> FilterPushdown::FinishPushdown(unique_ptr<LogicalOperator> op) {
 	// unhandled type, first perform filter pushdown in its children
-	for (index_t i = 0; i < op->children.size(); i++) {
+	for (idx_t i = 0; i < op->children.size(); i++) {
 		FilterPushdown pushdown(optimizer);
 		op->children[i] = pushdown.Rewrite(move(op->children[i]));
 	}

--- a/src/optimizer/index_scan.cpp
+++ b/src/optimizer/index_scan.cpp
@@ -32,7 +32,7 @@ static void RewriteIndexExpression(Index &index, LogicalGet &get, Expression &ex
 		bound_colref.binding.table_index = get.table_index;
 		column_t referenced_column = index.column_ids[bound_colref.binding.column_index];
 		// search for the referenced column in the set of column_ids
-		for (index_t i = 0; i < get.column_ids.size(); i++) {
+		for (idx_t i = 0; i < get.column_ids.size(); i++) {
 			if (get.column_ids[i] == referenced_column) {
 				bound_colref.binding.column_index = i;
 				return;
@@ -82,7 +82,7 @@ unique_ptr<LogicalOperator> IndexScan::TransformFilterToIndexScan(unique_ptr<Log
 		auto expr = filter.expressions[0].get();
 		auto low_comparison_type = expr->type;
 		auto high_comparison_type = expr->type;
-		for (index_t i = 0; i < filter.expressions.size(); i++) {
+		for (idx_t i = 0; i < filter.expressions.size(); i++) {
 			expr = filter.expressions[i].get();
 			// create a matcher for a comparison with a constant
 			ComparisonExpressionMatcher matcher;

--- a/src/optimizer/join_order/query_graph.cpp
+++ b/src/optimizer/join_order/query_graph.cpp
@@ -8,10 +8,10 @@ using namespace std;
 
 using QueryEdge = QueryGraph::QueryEdge;
 
-static string QueryEdgeToString(const QueryEdge *info, vector<index_t> prefix) {
+static string QueryEdgeToString(const QueryEdge *info, vector<idx_t> prefix) {
 	string result = "";
 	string source = "[";
-	for (index_t i = 0; i < prefix.size(); i++) {
+	for (idx_t i = 0; i < prefix.size(); i++) {
 		source += to_string(prefix[i]) + (i < prefix.size() - 1 ? ", " : "");
 	}
 	source += "]";
@@ -19,7 +19,7 @@ static string QueryEdgeToString(const QueryEdge *info, vector<index_t> prefix) {
 		result += StringUtil::Format("%s -> %s\n", source.c_str(), entry->neighbor->ToString().c_str());
 	}
 	for (auto &entry : info->children) {
-		vector<index_t> new_prefix = prefix;
+		vector<idx_t> new_prefix = prefix;
 		new_prefix.push_back(entry.first);
 		result += QueryEdgeToString(entry.second.get(), new_prefix);
 	}
@@ -34,7 +34,7 @@ QueryEdge *QueryGraph::GetQueryEdge(RelationSet *left) {
 	assert(left && left->count > 0);
 	// find the EdgeInfo corresponding to the left set
 	QueryEdge *info = &root;
-	for (index_t i = 0; i < left->count; i++) {
+	for (idx_t i = 0; i < left->count; i++) {
 		auto entry = info->children.find(left->relations[i]);
 		if (entry == info->children.end()) {
 			// node not found, create it
@@ -52,7 +52,7 @@ void QueryGraph::CreateEdge(RelationSet *left, RelationSet *right, FilterInfo *f
 	// find the EdgeInfo corresponding to the left set
 	auto info = GetQueryEdge(left);
 	// now insert the edge to the right relation, if it does not exist
-	for (index_t i = 0; i < info->neighbors.size(); i++) {
+	for (idx_t i = 0; i < info->neighbors.size(); i++) {
 		if (info->neighbors[i]->neighbor == right) {
 			if (filter_info) {
 				// neighbor already exists just add the filter, if we have any
@@ -71,9 +71,9 @@ void QueryGraph::CreateEdge(RelationSet *left, RelationSet *right, FilterInfo *f
 }
 
 void QueryGraph::EnumerateNeighbors(RelationSet *node, function<bool(NeighborInfo *)> callback) {
-	for (index_t j = 0; j < node->count; j++) {
+	for (idx_t j = 0; j < node->count; j++) {
 		QueryEdge *info = &root;
-		for (index_t i = j; i < node->count; i++) {
+		for (idx_t i = j; i < node->count; i++) {
 			auto entry = info->children.find(node->relations[i]);
 			if (entry == info->children.end()) {
 				// node not found
@@ -91,12 +91,12 @@ void QueryGraph::EnumerateNeighbors(RelationSet *node, function<bool(NeighborInf
 }
 
 //! Returns true if a RelationSet is banned by the list of exclusion_set, false otherwise
-static bool RelationSetIsExcluded(RelationSet *node, unordered_set<index_t> &exclusion_set) {
+static bool RelationSetIsExcluded(RelationSet *node, unordered_set<idx_t> &exclusion_set) {
 	return exclusion_set.find(node->relations[0]) != exclusion_set.end();
 }
 
-vector<index_t> QueryGraph::GetNeighbors(RelationSet *node, unordered_set<index_t> &exclusion_set) {
-	unordered_set<index_t> result;
+vector<idx_t> QueryGraph::GetNeighbors(RelationSet *node, unordered_set<idx_t> &exclusion_set) {
+	unordered_set<idx_t> result;
 	EnumerateNeighbors(node, [&](NeighborInfo *info) -> bool {
 		if (!RelationSetIsExcluded(info->neighbor, exclusion_set)) {
 			// add the smallest node of the neighbor to the set
@@ -104,7 +104,7 @@ vector<index_t> QueryGraph::GetNeighbors(RelationSet *node, unordered_set<index_
 		}
 		return false;
 	});
-	vector<index_t> neighbors;
+	vector<idx_t> neighbors;
 	neighbors.insert(neighbors.end(), result.begin(), result.end());
 	return neighbors;
 }

--- a/src/optimizer/join_order/relation.cpp
+++ b/src/optimizer/join_order/relation.cpp
@@ -11,7 +11,7 @@ using RelationTreeNode = RelationSetManager::RelationTreeNode;
 
 string RelationSet::ToString() const {
 	string result = "[";
-	result += StringUtil::Join(relations, count, ", ", [](const index_t &relation) { return to_string(relation); });
+	result += StringUtil::Join(relations, count, ", ", [](const idx_t &relation) { return to_string(relation); });
 	result += "]";
 	return result;
 }
@@ -24,8 +24,8 @@ bool RelationSet::IsSubset(RelationSet *super, RelationSet *sub) {
 	if (sub->count > super->count) {
 		return false;
 	}
-	index_t j = 0;
-	for (index_t i = 0; i < super->count; i++) {
+	idx_t j = 0;
+	for (idx_t i = 0; i < super->count; i++) {
 		if (sub->relations[j] == super->relations[i]) {
 			j++;
 			if (j == sub->count) {
@@ -36,10 +36,10 @@ bool RelationSet::IsSubset(RelationSet *super, RelationSet *sub) {
 	return false;
 }
 
-RelationSet *RelationSetManager::GetRelation(unique_ptr<index_t[]> relations, index_t count) {
+RelationSet *RelationSetManager::GetRelation(unique_ptr<idx_t[]> relations, idx_t count) {
 	// now look it up in the tree
 	RelationTreeNode *info = &root;
-	for (index_t i = 0; i < count; i++) {
+	for (idx_t i = 0; i < count; i++) {
 		auto entry = info->children.find(relations[i]);
 		if (entry == info->children.end()) {
 			// node not found, create it
@@ -58,19 +58,18 @@ RelationSet *RelationSetManager::GetRelation(unique_ptr<index_t[]> relations, in
 }
 
 //! Create or get a RelationSet from a single node with the given index
-RelationSet *RelationSetManager::GetRelation(index_t index) {
+RelationSet *RelationSetManager::GetRelation(idx_t index) {
 	// create a sorted vector of the relations
-	auto relations = unique_ptr<index_t[]>(new index_t[1]);
+	auto relations = unique_ptr<idx_t[]>(new idx_t[1]);
 	relations[0] = index;
-	index_t count = 1;
+	idx_t count = 1;
 	return GetRelation(move(relations), count);
 }
 
-RelationSet *RelationSetManager::GetRelation(unordered_set<index_t> &bindings) {
+RelationSet *RelationSetManager::GetRelation(unordered_set<idx_t> &bindings) {
 	// create a sorted vector of the relations
-	unique_ptr<index_t[]> relations =
-	    bindings.size() == 0 ? nullptr : unique_ptr<index_t[]>(new index_t[bindings.size()]);
-	index_t count = 0;
+	unique_ptr<idx_t[]> relations = bindings.size() == 0 ? nullptr : unique_ptr<idx_t[]>(new idx_t[bindings.size()]);
+	idx_t count = 0;
 	for (auto &entry : bindings) {
 		relations[count++] = entry;
 	}
@@ -79,10 +78,10 @@ RelationSet *RelationSetManager::GetRelation(unordered_set<index_t> &bindings) {
 }
 
 RelationSet *RelationSetManager::Union(RelationSet *left, RelationSet *right) {
-	auto relations = unique_ptr<index_t[]>(new index_t[left->count + right->count]);
-	index_t count = 0;
+	auto relations = unique_ptr<idx_t[]>(new idx_t[left->count + right->count]);
+	idx_t count = 0;
 	// move through the left and right relations, eliminating duplicates
-	index_t i = 0, j = 0;
+	idx_t i = 0, j = 0;
 	while (true) {
 		if (i == left->count) {
 			// exhausted left relation, add remaining of right relation
@@ -115,10 +114,10 @@ RelationSet *RelationSetManager::Union(RelationSet *left, RelationSet *right) {
 }
 
 RelationSet *RelationSetManager::Difference(RelationSet *left, RelationSet *right) {
-	auto relations = unique_ptr<index_t[]>(new index_t[left->count]);
-	index_t count = 0;
+	auto relations = unique_ptr<idx_t[]>(new idx_t[left->count]);
+	idx_t count = 0;
 	// move through the left and right relations
-	index_t i = 0, j = 0;
+	idx_t i = 0, j = 0;
 	while (true) {
 		if (i == left->count) {
 			// exhausted left relation, we are done

--- a/src/optimizer/join_order_optimizer.cpp
+++ b/src/optimizer/join_order_optimizer.cpp
@@ -20,7 +20,7 @@ template <class T> static bool Disjoint(unordered_set<T> &a, unordered_set<T> &b
 }
 
 //! Extract the set of relations referred to inside an expression
-bool JoinOrderOptimizer::ExtractBindings(Expression &expression, unordered_set<index_t> &bindings) {
+bool JoinOrderOptimizer::ExtractBindings(Expression &expression, unordered_set<idx_t> &bindings) {
 	if (expression.type == ExpressionType::BOUND_COLUMN_REF) {
 		auto &colref = (BoundColumnRefExpression &)expression;
 		assert(colref.depth == 0);
@@ -102,7 +102,7 @@ bool JoinOrderOptimizer::ExtractJoinRelations(LogicalOperator &input_op, vector<
 		// e.g. suppose we have (left LEFT OUTER JOIN right WHERE right IS NOT NULL), the join can generate
 		// new NULL values in the right side, so pushing this condition through the join leads to incorrect results
 		// for this reason, we just start a new JoinOptimizer pass in each of the children of the join
-		for (index_t i = 0; i < op->children.size(); i++) {
+		for (idx_t i = 0; i < op->children.size(); i++) {
 			JoinOrderOptimizer optimizer;
 			op->children[i] = optimizer.Optimize(move(op->children[i]));
 		}
@@ -111,11 +111,11 @@ bool JoinOrderOptimizer::ExtractJoinRelations(LogicalOperator &input_op, vector<
 		// enumerate all base relations obtained from this join and add them to the relation mapping
 		// also, we have to resolve the join conditions for the joins here
 		// get the left and right bindings
-		unordered_set<index_t> bindings;
+		unordered_set<idx_t> bindings;
 		LogicalJoin::GetTableReferences(*op, bindings);
 		// now create the relation that refers to all these bindings
 		auto relation = make_unique<Relation>(&input_op, parent);
-		for (index_t it : bindings) {
+		for (idx_t it : bindings) {
 			relation_mapping[it] = relations.size();
 		}
 		relations.push_back(move(relation));
@@ -155,8 +155,8 @@ bool JoinOrderOptimizer::ExtractJoinRelations(LogicalOperator &input_op, vector<
 }
 
 //! Update the exclusion set with all entries in the subgraph
-static void UpdateExclusionSet(RelationSet *node, unordered_set<index_t> &exclusion_set) {
-	for (index_t i = 0; i < node->count; i++) {
+static void UpdateExclusionSet(RelationSet *node, unordered_set<idx_t> &exclusion_set) {
+	for (idx_t i = 0; i < node->count; i++) {
 		exclusion_set.insert(node->relations[i]);
 	}
 }
@@ -173,7 +173,7 @@ static unique_ptr<JoinNode> CreateJoinTree(RelationSet *set, NeighborInfo *info,
 	// the expected cardinality is the max of the child cardinalities
 	// FIXME: we should obviously use better cardinality estimation here
 	// but for now we just assume foreign key joins only
-	index_t expected_cardinality;
+	idx_t expected_cardinality;
 	if (info->filters.size() == 0) {
 		// cross product
 		expected_cardinality = left->cardinality * right->cardinality;
@@ -182,7 +182,7 @@ static unique_ptr<JoinNode> CreateJoinTree(RelationSet *set, NeighborInfo *info,
 		expected_cardinality = std::max(left->cardinality, right->cardinality);
 	}
 	// cost is expected_cardinality plus the cost of the previous plans
-	index_t cost = expected_cardinality;
+	idx_t cost = expected_cardinality;
 	return make_unique<JoinNode>(set, info, left, right, expected_cardinality, cost);
 }
 
@@ -218,8 +218,8 @@ bool JoinOrderOptimizer::TryEmitPair(RelationSet *left, RelationSet *right, Neig
 
 bool JoinOrderOptimizer::EmitCSG(RelationSet *node) {
 	// create the exclusion set as everything inside the subgraph AND anything with members BELOW it
-	unordered_set<index_t> exclusion_set;
-	for (index_t i = 0; i < node->relations[0]; i++) {
+	unordered_set<idx_t> exclusion_set;
+	for (idx_t i = 0; i < node->relations[0]; i++) {
 		exclusion_set.insert(i);
 	}
 	UpdateExclusionSet(node, exclusion_set);
@@ -248,7 +248,7 @@ bool JoinOrderOptimizer::EmitCSG(RelationSet *node) {
 }
 
 bool JoinOrderOptimizer::EnumerateCmpRecursive(RelationSet *left, RelationSet *right,
-                                               unordered_set<index_t> exclusion_set) {
+                                               unordered_set<idx_t> exclusion_set) {
 	// get the neighbors of the second relation under the exclusion set
 	auto neighbors = query_graph.GetNeighbors(right, exclusion_set);
 	if (neighbors.size() == 0) {
@@ -256,7 +256,7 @@ bool JoinOrderOptimizer::EnumerateCmpRecursive(RelationSet *left, RelationSet *r
 	}
 	vector<RelationSet *> union_sets;
 	union_sets.resize(neighbors.size());
-	for (index_t i = 0; i < neighbors.size(); i++) {
+	for (idx_t i = 0; i < neighbors.size(); i++) {
 		auto neighbor = set_manager.GetRelation(neighbors[i]);
 		// emit the combinations of this node and its neighbors
 		auto combined_set = set_manager.Union(right, neighbor);
@@ -271,9 +271,9 @@ bool JoinOrderOptimizer::EnumerateCmpRecursive(RelationSet *left, RelationSet *r
 		union_sets[i] = combined_set;
 	}
 	// recursively enumerate the sets
-	for (index_t i = 0; i < neighbors.size(); i++) {
+	for (idx_t i = 0; i < neighbors.size(); i++) {
 		// updated the set of excluded entries with this neighbor
-		unordered_set<index_t> new_exclusion_set = exclusion_set;
+		unordered_set<idx_t> new_exclusion_set = exclusion_set;
 		new_exclusion_set.insert(neighbors[i]);
 		if (!EnumerateCmpRecursive(left, union_sets[i], new_exclusion_set)) {
 			return false;
@@ -282,7 +282,7 @@ bool JoinOrderOptimizer::EnumerateCmpRecursive(RelationSet *left, RelationSet *r
 	return true;
 }
 
-bool JoinOrderOptimizer::EnumerateCSGRecursive(RelationSet *node, unordered_set<index_t> &exclusion_set) {
+bool JoinOrderOptimizer::EnumerateCSGRecursive(RelationSet *node, unordered_set<idx_t> &exclusion_set) {
 	// find neighbors of S under the exlusion set
 	auto neighbors = query_graph.GetNeighbors(node, exclusion_set);
 	if (neighbors.size() == 0) {
@@ -291,7 +291,7 @@ bool JoinOrderOptimizer::EnumerateCSGRecursive(RelationSet *node, unordered_set<
 	// now first emit the connected subgraphs of the neighbors
 	vector<RelationSet *> union_sets;
 	union_sets.resize(neighbors.size());
-	for (index_t i = 0; i < neighbors.size(); i++) {
+	for (idx_t i = 0; i < neighbors.size(); i++) {
 		auto neighbor = set_manager.GetRelation(neighbors[i]);
 		// emit the combinations of this node and its neighbors
 		auto new_set = set_manager.Union(node, neighbor);
@@ -303,9 +303,9 @@ bool JoinOrderOptimizer::EnumerateCSGRecursive(RelationSet *node, unordered_set<
 		union_sets[i] = new_set;
 	}
 	// recursively enumerate the sets
-	for (index_t i = 0; i < neighbors.size(); i++) {
+	for (idx_t i = 0; i < neighbors.size(); i++) {
 		// updated the set of excluded entries with this neighbor
-		unordered_set<index_t> new_exclusion_set = exclusion_set;
+		unordered_set<idx_t> new_exclusion_set = exclusion_set;
 		new_exclusion_set.insert(neighbors[i]);
 		if (!EnumerateCSGRecursive(union_sets[i], new_exclusion_set)) {
 			return false;
@@ -317,7 +317,7 @@ bool JoinOrderOptimizer::EnumerateCSGRecursive(RelationSet *node, unordered_set<
 bool JoinOrderOptimizer::SolveJoinOrderExactly() {
 	// now we perform the actual dynamic programming to compute the final result
 	// we enumerate over all the possible pairs in the neighborhood
-	for (index_t i = relations.size(); i > 0; i--) {
+	for (idx_t i = relations.size(); i > 0; i--) {
 		// for every node in the set, we consider it as the start node once
 		auto start_node = set_manager.GetRelation(i - 1);
 		// emit the start node
@@ -325,8 +325,8 @@ bool JoinOrderOptimizer::SolveJoinOrderExactly() {
 			return false;
 		}
 		// initialize the set of exclusion_set as all the nodes with a number below this
-		unordered_set<index_t> exclusion_set;
-		for (index_t j = 0; j < i - 1; j++) {
+		unordered_set<idx_t> exclusion_set;
+		for (idx_t j = 0; j < i - 1; j++) {
 			exclusion_set.insert(j);
 		}
 		// then we recursively search for neighbors that do not belong to the banned entries
@@ -342,18 +342,18 @@ void JoinOrderOptimizer::SolveJoinOrderApproximately() {
 	// long instead, we use a greedy heuristic to obtain a join ordering now we use Greedy Operator Ordering to
 	// construct the result tree first we start out with all the base relations (the to-be-joined relations)
 	vector<RelationSet *> T;
-	for (index_t i = 0; i < relations.size(); i++) {
+	for (idx_t i = 0; i < relations.size(); i++) {
 		T.push_back(set_manager.GetRelation(i));
 	}
 	while (T.size() > 1) {
 		// now in every step of the algorithm, we greedily pick the join between the to-be-joined relations that has the
 		// smallest cost. This is O(r^2) per step, and every step will reduce the total amount of relations to-be-joined
 		// by 1, so the total cost is O(r^3) in the amount of relations
-		index_t best_left = 0, best_right = 0;
+		idx_t best_left = 0, best_right = 0;
 		JoinNode *best_connection = nullptr;
-		for (index_t i = 0; i < T.size(); i++) {
+		for (idx_t i = 0; i < T.size(); i++) {
 			auto left = T[i];
-			for (index_t j = i + 1; j < T.size(); j++) {
+			for (idx_t j = i + 1; j < T.size(); j++) {
 				auto right = T[j];
 				// check if we can connect these two relations
 				auto connection = query_graph.GetConnection(left, right);
@@ -373,12 +373,12 @@ void JoinOrderOptimizer::SolveJoinOrderApproximately() {
 			// could not find a connection, but we were not done with finding a completed plan
 			// we have to add a cross product; we add it between the two smallest relations
 			JoinNode *smallest_plans[2] = {nullptr};
-			index_t smallest_index[2];
-			for (index_t i = 0; i < T.size(); i++) {
+			idx_t smallest_index[2];
+			for (idx_t i = 0; i < T.size(); i++) {
 				// get the plan for this relation
 				auto current_plan = plans[T[i]].get();
 				// check if the cardinality is smaller than the smallest two found so far
-				for (index_t j = 0; j < 2; j++) {
+				for (idx_t j = 0; j < 2; j++) {
 					if (!smallest_plans[j] || smallest_plans[j]->cardinality > current_plan->cardinality) {
 						smallest_plans[j] = current_plan;
 						smallest_index[j] = i;
@@ -426,9 +426,9 @@ void JoinOrderOptimizer::SolveJoinOrder() {
 void JoinOrderOptimizer::GenerateCrossProducts() {
 	// generate a set of cross products to combine the currently available plans into a full join plan
 	// we create edges between every relation with a high cost
-	for (index_t i = 0; i < relations.size(); i++) {
+	for (idx_t i = 0; i < relations.size(); i++) {
 		auto left = set_manager.GetRelation(i);
-		for (index_t j = 0; j < relations.size(); j++) {
+		for (idx_t j = 0; j < relations.size(); j++) {
 			if (i != j) {
 				auto right = set_manager.GetRelation(j);
 				query_graph.CreateEdge(left, right, nullptr);
@@ -440,7 +440,7 @@ void JoinOrderOptimizer::GenerateCrossProducts() {
 
 static unique_ptr<LogicalOperator> ExtractRelation(Relation &rel) {
 	auto &children = rel.parent->children;
-	for (index_t i = 0; i < children.size(); i++) {
+	for (idx_t i = 0; i < children.size(); i++) {
 		if (children[i].get() == rel.op) {
 			// found it! take ownership of it from the parent
 			auto result = move(children[i]);
@@ -512,7 +512,7 @@ JoinOrderOptimizer::GenerateJoins(vector<unique_ptr<LogicalOperator>> &extracted
 	// check if we should do a pushdown on this node
 	// basically, any remaining filter that is a subset of the current relation will no longer be used in joins
 	// hence we should push it here
-	for (index_t i = 0; i < filter_infos.size(); i++) {
+	for (idx_t i = 0; i < filter_infos.size(); i++) {
 		// check if the filter has already been extracted
 		auto info = filter_infos[i].get();
 		if (filters[info->filter_index]) {
@@ -577,13 +577,13 @@ unique_ptr<LogicalOperator> JoinOrderOptimizer::RewritePlan(unique_ptr<LogicalOp
 
 	// first we will extract all relations from the main plan
 	vector<unique_ptr<LogicalOperator>> extracted_relations;
-	for (index_t i = 0; i < relations.size(); i++) {
+	for (idx_t i = 0; i < relations.size(); i++) {
 		extracted_relations.push_back(ExtractRelation(*relations[i]));
 	}
 	// now we generate the actual joins
 	auto join_tree = GenerateJoins(extracted_relations, node);
 	// perform the final pushdown of remaining filters
-	for (index_t i = 0; i < filters.size(); i++) {
+	for (idx_t i = 0; i < filters.size(); i++) {
 		// check if the filter has already been extracted
 		if (filters[i]) {
 			// if not we need to push it
@@ -649,7 +649,7 @@ unique_ptr<LogicalOperator> JoinOrderOptimizer::Optimize(unique_ptr<LogicalOpera
 			}
 			join.conditions.clear();
 		} else {
-			for (index_t i = 0; i < op->expressions.size(); i++) {
+			for (idx_t i = 0; i < op->expressions.size(); i++) {
 				if (filter_set.find(op->expressions[i].get()) == filter_set.end()) {
 					filter_set.insert(op->expressions[i].get());
 					filters.push_back(move(op->expressions[i]));
@@ -659,13 +659,13 @@ unique_ptr<LogicalOperator> JoinOrderOptimizer::Optimize(unique_ptr<LogicalOpera
 		}
 	}
 	// create potential edges from the comparisons
-	for (index_t i = 0; i < filters.size(); i++) {
+	for (idx_t i = 0; i < filters.size(); i++) {
 		auto &filter = filters[i];
 		auto info = make_unique<FilterInfo>();
 		auto filter_info = info.get();
 		filter_infos.push_back(move(info));
 		// first extract the relation set for the entire filter
-		unordered_set<index_t> bindings;
+		unordered_set<idx_t> bindings;
 		ExtractBindings(*filter, bindings);
 		filter_info->set = set_manager.GetRelation(bindings);
 		filter_info->filter_index = i;
@@ -673,7 +673,7 @@ unique_ptr<LogicalOperator> JoinOrderOptimizer::Optimize(unique_ptr<LogicalOpera
 		if (filter->GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
 			auto comparison = (BoundComparisonExpression *)filter.get();
 			// extract the bindings that are required for the left and right side of the comparison
-			unordered_set<index_t> left_bindings, right_bindings;
+			unordered_set<idx_t> left_bindings, right_bindings;
 			ExtractBindings(*comparison->left, left_bindings);
 			ExtractBindings(*comparison->right, right_bindings);
 			if (left_bindings.size() > 0 && right_bindings.size() > 0) {
@@ -708,7 +708,7 @@ unique_ptr<LogicalOperator> JoinOrderOptimizer::Optimize(unique_ptr<LogicalOpera
 	// First we initialize each of the single-node plans with themselves and with their cardinalities these are the leaf
 	// nodes of the join tree NOTE: we can just use pointers to RelationSet* here because the GetRelation function
 	// ensures that a unique combination of relations will have a unique RelationSet object.
-	for (index_t i = 0; i < relations.size(); i++) {
+	for (idx_t i = 0; i < relations.size(); i++) {
 		auto &rel = *relations[i];
 		auto node = set_manager.GetRelation(i);
 		plans[node] = make_unique<JoinNode>(node, rel.op->EstimateCardinality());
@@ -717,8 +717,8 @@ unique_ptr<LogicalOperator> JoinOrderOptimizer::Optimize(unique_ptr<LogicalOpera
 	SolveJoinOrder();
 	// now the optimal join path should have been found
 	// get it from the node
-	unordered_set<index_t> bindings;
-	for (index_t i = 0; i < relations.size(); i++) {
+	unordered_set<idx_t> bindings;
+	for (idx_t i = 0; i < relations.size(); i++) {
 		bindings.insert(i);
 	}
 	auto total_relation = set_manager.GetRelation(bindings);

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -144,7 +144,7 @@ unique_ptr<Expression> InClauseRewriter::VisitReplace(BoundOperatorExpression &e
 	bool all_scalar = true;
 	// IN clause with many children: try to generate a mark join that replaces this IN expression
 	// we can only do this if the expressions in the expression list are scalar
-	for (index_t i = 1; i < expr.children.size(); i++) {
+	for (idx_t i = 1; i < expr.children.size(); i++) {
 		assert(expr.children[i]->return_type == in_type);
 		if (!expr.children[i]->IsFoldable()) {
 			// non-scalar expression
@@ -165,7 +165,7 @@ unique_ptr<Expression> InClauseRewriter::VisitReplace(BoundOperatorExpression &e
 		// NOT IN: turn into (X <> 1 AND X <> 2 AND X <> 3 ...)
 		auto conjunction = make_unique<BoundConjunctionExpression>(is_regular_in ? ExpressionType::CONJUNCTION_OR
 		                                                                         : ExpressionType::CONJUNCTION_AND);
-		for (index_t i = 1; i < expr.children.size(); i++) {
+		for (idx_t i = 1; i < expr.children.size(); i++) {
 			conjunction->children.push_back(make_unique<BoundComparisonExpression>(
 			    is_regular_in ? ExpressionType::COMPARE_EQUAL : ExpressionType::COMPARE_NOTEQUAL,
 			    expr.children[0]->Copy(), move(expr.children[i])));
@@ -179,10 +179,10 @@ unique_ptr<Expression> InClauseRewriter::VisitReplace(BoundOperatorExpression &e
 	auto collection = make_unique<ChunkCollection>();
 	DataChunk chunk;
 	chunk.Initialize(types);
-	for (index_t i = 1; i < expr.children.size(); i++) {
+	for (idx_t i = 1; i < expr.children.size(); i++) {
 		// reoslve this expression to a constant
 		auto value = ExpressionExecutor::EvaluateScalar(*expr.children[i]);
-		index_t index = chunk.data[0].count++;
+		idx_t index = chunk.data[0].count++;
 		chunk.data[0].SetValue(index, value);
 		if (chunk.data[0].count == STANDARD_VECTOR_SIZE || i + 1 == expr.children.size()) {
 			// chunk full: append to chunk collection

--- a/src/optimizer/pushdown/pushdown_aggregate.cpp
+++ b/src/optimizer/pushdown/pushdown_aggregate.cpp
@@ -32,7 +32,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownAggregate(unique_ptr<Logical
 	// pushdown into AGGREGATE and GROUP BY
 	// we cannot push expressions that refer to the aggregate
 	FilterPushdown child_pushdown(optimizer);
-	for (index_t i = 0; i < filters.size(); i++) {
+	for (idx_t i = 0; i < filters.size(); i++) {
 		auto &f = *filters[i];
 		// check if the aggregate is in the set
 		if (f.bindings.find(aggr.aggregate_index) == f.bindings.end()) {

--- a/src/optimizer/pushdown/pushdown_cross_product.cpp
+++ b/src/optimizer/pushdown/pushdown_cross_product.cpp
@@ -11,7 +11,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownCrossProduct(unique_ptr<Logi
 	assert(op->type == LogicalOperatorType::CROSS_PRODUCT);
 	FilterPushdown left_pushdown(optimizer), right_pushdown(optimizer);
 	vector<unique_ptr<Expression>> join_conditions;
-	unordered_set<index_t> left_bindings, right_bindings;
+	unordered_set<idx_t> left_bindings, right_bindings;
 	if (filters.size() > 0) {
 		// check to see into which side we should push the filters
 		// first get the LHS and RHS bindings

--- a/src/optimizer/pushdown/pushdown_filter.cpp
+++ b/src/optimizer/pushdown/pushdown_filter.cpp
@@ -11,7 +11,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownFilter(unique_ptr<LogicalOpe
 	assert(op->type == LogicalOperatorType::FILTER);
 	auto &filter = (LogicalFilter &)*op;
 	// filter: gather the filters and remove the filter from the set of operations
-	for (index_t i = 0; i < filter.expressions.size(); i++) {
+	for (idx_t i = 0; i < filter.expressions.size(); i++) {
 		if (AddFilter(move(filter.expressions[i])) == FilterResult::UNSATISFIABLE) {
 			// filter statically evaluates to false, strip tree
 			return make_unique<LogicalEmptyResult>(move(op));

--- a/src/optimizer/pushdown/pushdown_inner_join.cpp
+++ b/src/optimizer/pushdown/pushdown_inner_join.cpp
@@ -10,8 +10,8 @@ using namespace std;
 using Filter = FilterPushdown::Filter;
 
 unique_ptr<LogicalOperator> FilterPushdown::PushdownInnerJoin(unique_ptr<LogicalOperator> op,
-                                                              unordered_set<index_t> &left_bindings,
-                                                              unordered_set<index_t> &right_bindings) {
+                                                              unordered_set<idx_t> &left_bindings,
+                                                              unordered_set<idx_t> &right_bindings) {
 	auto &join = (LogicalJoin &)*op;
 	assert(join.join_type == JoinType::INNER);
 	assert(op->type != LogicalOperatorType::DELIM_JOIN);
@@ -28,7 +28,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownInnerJoin(unique_ptr<Logical
 		assert(op->type == LogicalOperatorType::COMPARISON_JOIN);
 		auto &comp_join = (LogicalComparisonJoin &)join;
 		// turn the conditions into filters
-		for (index_t i = 0; i < comp_join.conditions.size(); i++) {
+		for (idx_t i = 0; i < comp_join.conditions.size(); i++) {
 			auto condition = JoinCondition::CreateExpression(move(comp_join.conditions[i]));
 			if (AddFilter(move(condition)) == FilterResult::UNSATISFIABLE) {
 				// filter statically evaluates to false, strip tree

--- a/src/optimizer/pushdown/pushdown_left_join.cpp
+++ b/src/optimizer/pushdown/pushdown_left_join.cpp
@@ -13,8 +13,7 @@ using namespace std;
 
 using Filter = FilterPushdown::Filter;
 
-static unique_ptr<Expression> ReplaceColRefWithNull(unique_ptr<Expression> expr,
-                                                    unordered_set<index_t> &right_bindings) {
+static unique_ptr<Expression> ReplaceColRefWithNull(unique_ptr<Expression> expr, unordered_set<idx_t> &right_bindings) {
 	if (expr->type == ExpressionType::BOUND_COLUMN_REF) {
 		auto &bound_colref = (BoundColumnRefExpression &)*expr;
 		if (right_bindings.find(bound_colref.binding.table_index) != right_bindings.end()) {
@@ -30,7 +29,7 @@ static unique_ptr<Expression> ReplaceColRefWithNull(unique_ptr<Expression> expr,
 	return expr;
 }
 
-static bool FilterRemovesNull(ExpressionRewriter &rewriter, Expression *expr, unordered_set<index_t> &right_bindings) {
+static bool FilterRemovesNull(ExpressionRewriter &rewriter, Expression *expr, unordered_set<idx_t> &right_bindings) {
 	// make a copy of the expression
 	auto copy = expr->Copy();
 	// replace all BoundColumnRef expressions frmo the RHS with NULL constants in the copied expression
@@ -56,8 +55,8 @@ static bool FilterRemovesNull(ExpressionRewriter &rewriter, Expression *expr, un
 }
 
 unique_ptr<LogicalOperator> FilterPushdown::PushdownLeftJoin(unique_ptr<LogicalOperator> op,
-                                                             unordered_set<index_t> &left_bindings,
-                                                             unordered_set<index_t> &right_bindings) {
+                                                             unordered_set<idx_t> &left_bindings,
+                                                             unordered_set<idx_t> &right_bindings) {
 	auto &join = (LogicalJoin &)*op;
 	assert(join.join_type == JoinType::LEFT);
 	assert(op->type != LogicalOperatorType::DELIM_JOIN);
@@ -74,7 +73,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownLeftJoin(unique_ptr<LogicalO
 		}
 	}
 	// now check the set of filters
-	for (index_t i = 0; i < filters.size(); i++) {
+	for (idx_t i = 0; i < filters.size(); i++) {
 		auto side = JoinSide::GetJoinSide(filters[i]->bindings, left_bindings, right_bindings);
 		if (side == JoinSide::LEFT) {
 			// bindings match left side

--- a/src/optimizer/pushdown/pushdown_mark_join.cpp
+++ b/src/optimizer/pushdown/pushdown_mark_join.cpp
@@ -8,8 +8,8 @@ using namespace std;
 using Filter = FilterPushdown::Filter;
 
 unique_ptr<LogicalOperator> FilterPushdown::PushdownMarkJoin(unique_ptr<LogicalOperator> op,
-                                                             unordered_set<index_t> &left_bindings,
-                                                             unordered_set<index_t> &right_bindings) {
+                                                             unordered_set<idx_t> &left_bindings,
+                                                             unordered_set<idx_t> &right_bindings) {
 	auto &join = (LogicalJoin &)*op;
 	auto &comp_join = (LogicalComparisonJoin &)*op;
 	assert(join.join_type == JoinType::MARK);
@@ -19,7 +19,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownMarkJoin(unique_ptr<LogicalO
 	FilterPushdown left_pushdown(optimizer), right_pushdown(optimizer);
 	bool found_mark_reference = false;
 	// now check the set of filters
-	for (index_t i = 0; i < filters.size(); i++) {
+	for (idx_t i = 0; i < filters.size(); i++) {
 		auto side = JoinSide::GetJoinSide(filters[i]->bindings, left_bindings, right_bindings);
 		if (side == JoinSide::LEFT) {
 			// bindings match left side: push into left

--- a/src/optimizer/pushdown/pushdown_projection.cpp
+++ b/src/optimizer/pushdown/pushdown_projection.cpp
@@ -29,7 +29,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownProjection(unique_ptr<Logica
 	// all the BoundColumnRefExpressions in the filter should refer to the LogicalProjection
 	// we can rewrite them by replacing those references with the expression of the LogicalProjection node
 	FilterPushdown child_pushdown(optimizer);
-	for (index_t i = 0; i < filters.size(); i++) {
+	for (idx_t i = 0; i < filters.size(); i++) {
 		auto &f = *filters[i];
 		assert(f.bindings.size() <= 1);
 		// rewrite the bindings within this subquery

--- a/src/optimizer/pushdown/pushdown_set_operation.cpp
+++ b/src/optimizer/pushdown/pushdown_set_operation.cpp
@@ -37,7 +37,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownSetOperation(unique_ptr<Logi
 
 	// pushdown into set operation, we can duplicate the condition and pushdown the expressions into both sides
 	FilterPushdown left_pushdown(optimizer), right_pushdown(optimizer);
-	for (index_t i = 0; i < filters.size(); i++) {
+	for (idx_t i = 0; i < filters.size(); i++) {
 		// first create a copy of the filter
 		auto right_filter = make_unique<Filter>();
 		right_filter->filter = filters[i]->filter->Copy();

--- a/src/optimizer/pushdown/pushdown_single_join.cpp
+++ b/src/optimizer/pushdown/pushdown_single_join.cpp
@@ -7,12 +7,12 @@ using namespace std;
 using Filter = FilterPushdown::Filter;
 
 unique_ptr<LogicalOperator> FilterPushdown::PushdownSingleJoin(unique_ptr<LogicalOperator> op,
-                                                               unordered_set<index_t> &left_bindings,
-                                                               unordered_set<index_t> &right_bindings) {
+                                                               unordered_set<idx_t> &left_bindings,
+                                                               unordered_set<idx_t> &right_bindings) {
 	assert(((LogicalJoin &)*op).join_type == JoinType::SINGLE);
 	FilterPushdown left_pushdown(optimizer), right_pushdown(optimizer);
 	// now check the set of filters
-	for (index_t i = 0; i < filters.size(); i++) {
+	for (idx_t i = 0; i < filters.size(); i++) {
 		auto side = JoinSide::GetJoinSide(filters[i]->bindings, left_bindings, right_bindings);
 		if (side == JoinSide::LEFT) {
 			// bindings match left side: push into left

--- a/src/optimizer/regex_range_filter.cpp
+++ b/src/optimizer/regex_range_filter.cpp
@@ -16,7 +16,7 @@ using namespace std;
 
 unique_ptr<LogicalOperator> RegexRangeFilter::Rewrite(unique_ptr<LogicalOperator> op) {
 
-	for (index_t child_idx = 0; child_idx < op->children.size(); child_idx++) {
+	for (idx_t child_idx = 0; child_idx < op->children.size(); child_idx++) {
 		op->children[child_idx] = Rewrite(move(op->children[child_idx]));
 	}
 

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -28,9 +28,9 @@ void RemoveUnusedColumns::ReplaceBinding(ColumnBinding current_binding, ColumnBi
 	}
 }
 
-template <class T> void RemoveUnusedColumns::ClearUnusedExpressions(vector<T> &list, index_t table_idx) {
-	index_t offset = 0;
-	for (index_t col_idx = 0; col_idx < list.size(); col_idx++) {
+template <class T> void RemoveUnusedColumns::ClearUnusedExpressions(vector<T> &list, idx_t table_idx) {
+	idx_t offset = 0;
+	for (idx_t col_idx = 0; col_idx < list.size(); col_idx++) {
 		auto current_binding = ColumnBinding(table_idx, col_idx + offset);
 		auto entry = column_references.find(current_binding);
 		if (entry == column_references.end()) {

--- a/src/optimizer/rule/conjunction_simplification.cpp
+++ b/src/optimizer/rule/conjunction_simplification.cpp
@@ -17,7 +17,7 @@ ConjunctionSimplificationRule::ConjunctionSimplificationRule(ExpressionRewriter 
 
 unique_ptr<Expression> ConjunctionSimplificationRule::RemoveExpression(BoundConjunctionExpression &conj,
                                                                        Expression *expr) {
-	for (index_t i = 0; i < conj.children.size(); i++) {
+	for (idx_t i = 0; i < conj.children.size(); i++) {
 		if (conj.children[i].get() == expr) {
 			// erase the expression
 			conj.children.erase(conj.children.begin() + i);

--- a/src/optimizer/rule/distributivity.cpp
+++ b/src/optimizer/rule/distributivity.cpp
@@ -26,14 +26,14 @@ void DistributivityRule::AddExpressionSet(Expression &expr, expression_set_t &se
 	}
 }
 
-unique_ptr<Expression> DistributivityRule::ExtractExpression(BoundConjunctionExpression &conj, index_t idx,
+unique_ptr<Expression> DistributivityRule::ExtractExpression(BoundConjunctionExpression &conj, idx_t idx,
                                                              Expression &expr) {
 	auto &child = conj.children[idx];
 	unique_ptr<Expression> result;
 	if (child->type == ExpressionType::CONJUNCTION_AND) {
 		// AND, remove expression from the list
 		auto &and_expr = (BoundConjunctionExpression &)*child;
-		for (index_t i = 0; i < and_expr.children.size(); i++) {
+		for (idx_t i = 0; i < and_expr.children.size(); i++) {
 			if (Expression::Equals(and_expr.children[i].get(), &expr)) {
 				result = move(and_expr.children[i]);
 				and_expr.children.erase(and_expr.children.begin() + i);
@@ -67,7 +67,7 @@ unique_ptr<Expression> DistributivityRule::Apply(LogicalOperator &op, vector<Exp
 	// now for each of the remaining children, we create a set again and intersect them
 	// in our example: the second set would be [X, B]
 	// the intersection would leave [X]
-	for (index_t i = 1; i < initial_or->children.size(); i++) {
+	for (idx_t i = 1; i < initial_or->children.size(); i++) {
 		expression_set_t next_set;
 		AddExpressionSet(*initial_or->children[i], next_set);
 		expression_set_t intersect_result;
@@ -91,13 +91,13 @@ unique_ptr<Expression> DistributivityRule::Apply(LogicalOperator &op, vector<Exp
 		// extract the expression from the first child of the OR
 		auto result = ExtractExpression(*initial_or, 0, (Expression &)*expr);
 		// now for the subsequent expressions, simply remove the expression
-		for (index_t i = 1; i < initial_or->children.size(); i++) {
+		for (idx_t i = 1; i < initial_or->children.size(); i++) {
 			ExtractExpression(*initial_or, i, *result);
 		}
 		// now we add the expression to the new root
 		new_root->children.push_back(move(result));
 		// remove any expressions that were set to nullptr
-		for (index_t i = 0; i < initial_or->children.size(); i++) {
+		for (idx_t i = 0; i < initial_or->children.size(); i++) {
 			if (!initial_or->children[i]) {
 				initial_or->children.erase(initial_or->children.begin() + i);
 				i--;

--- a/src/parser/constraints/not_null_constraint.cpp
+++ b/src/parser/constraints/not_null_constraint.cpp
@@ -15,10 +15,10 @@ unique_ptr<Constraint> NotNullConstraint::Copy() {
 
 void NotNullConstraint::Serialize(Serializer &serializer) {
 	Constraint::Serialize(serializer);
-	serializer.Write<index_t>(index);
+	serializer.Write<idx_t>(index);
 }
 
 unique_ptr<Constraint> NotNullConstraint::Deserialize(Deserializer &source) {
-	auto index = source.Read<index_t>();
+	auto index = source.Read<idx_t>();
 	return make_unique_base<Constraint, NotNullConstraint>(index);
 }

--- a/src/parser/expression/conjunction_expression.cpp
+++ b/src/parser/expression/conjunction_expression.cpp
@@ -38,7 +38,7 @@ void ConjunctionExpression::AddExpression(unique_ptr<ParsedExpression> expr) {
 
 string ConjunctionExpression::ToString() const {
 	string result = children[0]->ToString();
-	for (index_t i = 1; i < children.size(); i++) {
+	for (idx_t i = 1; i < children.size(); i++) {
 		result += " " + ExpressionTypeToOperator(type) + " " + children[i]->ToString();
 	}
 	return result;

--- a/src/parser/expression/function_expression.cpp
+++ b/src/parser/expression/function_expression.cpp
@@ -44,7 +44,7 @@ bool FunctionExpression::Equals(const FunctionExpression *a, const FunctionExpre
 	if (b->children.size() != a->children.size()) {
 		return false;
 	}
-	for (index_t i = 0; i < a->children.size(); i++) {
+	for (idx_t i = 0; i < a->children.size(); i++) {
 		if (!a->children[i]->Equals(b->children[i].get())) {
 			return false;
 		}

--- a/src/parser/expression/operator_expression.cpp
+++ b/src/parser/expression/operator_expression.cpp
@@ -40,7 +40,7 @@ bool OperatorExpression::Equals(const OperatorExpression *a, const OperatorExpre
 	if (a->children.size() != b->children.size()) {
 		return false;
 	}
-	for (index_t i = 0; i < a->children.size(); i++) {
+	for (idx_t i = 0; i < a->children.size(); i++) {
 		if (!a->children[i]->Equals(b->children[i].get())) {
 			return false;
 		}

--- a/src/parser/expression/parameter_expression.cpp
+++ b/src/parser/expression/parameter_expression.cpp
@@ -28,11 +28,11 @@ uint64_t ParameterExpression::Hash() const {
 
 void ParameterExpression::Serialize(Serializer &serializer) {
 	ParsedExpression::Serialize(serializer);
-	serializer.Write<index_t>(parameter_nr);
+	serializer.Write<idx_t>(parameter_nr);
 }
 
 unique_ptr<ParsedExpression> ParameterExpression::Deserialize(ExpressionType type, Deserializer &source) {
 	auto expression = make_unique<ParameterExpression>();
-	expression->parameter_nr = source.Read<index_t>();
+	expression->parameter_nr = source.Read<idx_t>();
 	return move(expression);
 }

--- a/src/parser/expression/window_expression.cpp
+++ b/src/parser/expression/window_expression.cpp
@@ -35,7 +35,7 @@ bool WindowExpression::Equals(const WindowExpression *a, const WindowExpression 
 	if (b->children.size() != a->children.size()) {
 		return false;
 	}
-	for (index_t i = 0; i < a->children.size(); i++) {
+	for (idx_t i = 0; i < a->children.size(); i++) {
 		if (!a->children[i]->Equals(b->children[i].get())) {
 			return false;
 		}
@@ -55,7 +55,7 @@ bool WindowExpression::Equals(const WindowExpression *a, const WindowExpression 
 	if (a->partitions.size() != b->partitions.size()) {
 		return false;
 	}
-	for (index_t i = 0; i < a->partitions.size(); i++) {
+	for (idx_t i = 0; i < a->partitions.size(); i++) {
 		if (!a->partitions[i]->Equals(b->partitions[i].get())) {
 			return false;
 		}
@@ -64,7 +64,7 @@ bool WindowExpression::Equals(const WindowExpression *a, const WindowExpression 
 	if (a->orders.size() != b->orders.size()) {
 		return false;
 	}
-	for (index_t i = 0; i < a->orders.size(); i++) {
+	for (idx_t i = 0; i < a->orders.size(); i++) {
 		if (a->orders[i].type != b->orders[i].type) {
 			return false;
 		}
@@ -133,7 +133,7 @@ unique_ptr<ParsedExpression> WindowExpression::Deserialize(ExpressionType type, 
 	source.ReadList<ParsedExpression>(expr->partitions);
 
 	auto order_count = source.Read<uint32_t>();
-	for (index_t i = 0; i < order_count; i++) {
+	for (idx_t i = 0; i < order_count; i++) {
 		auto order_type = source.Read<OrderType>();
 		auto expression = ParsedExpression::Deserialize(source);
 		expr->orders.push_back(OrderByNode(order_type, move(expression)));

--- a/src/parser/expression_util.cpp
+++ b/src/parser/expression_util.cpp
@@ -11,7 +11,7 @@ bool ExpressionUtil::ExpressionListEquals(const vector<unique_ptr<T>> &a, const 
 	if (a.size() != b.size()) {
 		return false;
 	}
-	for (index_t i = 0; i < a.size(); i++) {
+	for (idx_t i = 0; i < a.size(); i++) {
 		if (!(*a[i] == *b[i])) {
 			return false;
 		}
@@ -27,8 +27,8 @@ bool ExpressionUtil::ExpressionSetEquals(const vector<unique_ptr<T>> &a, const v
 	// we create a map of expression -> count for the left side
 	// we keep the count because the same expression can occur multiple times (e.g. "1 AND 1" is legal)
 	// in this case we track the following value: map["Constant(1)"] = 2
-	expression_map_t<index_t> map;
-	for (index_t i = 0; i < a.size(); i++) {
+	expression_map_t<idx_t> map;
+	for (idx_t i = 0; i < a.size(); i++) {
 		map[a[i].get()]++;
 	}
 	// now on the right side we reduce the counts again

--- a/src/parser/query_node.cpp
+++ b/src/parser/query_node.cpp
@@ -29,7 +29,7 @@ bool QueryNode::Equals(const QueryNode *other) const {
 	if (orders.size() != other->orders.size()) {
 		return false;
 	}
-	for (index_t i = 0; i < orders.size(); i++) {
+	for (idx_t i = 0; i < orders.size(); i++) {
 		if (orders[i].type != other->orders[i].type ||
 		    !orders[i].expression->Equals(other->orders[i].expression.get())) {
 			return false;
@@ -54,8 +54,8 @@ void QueryNode::Serialize(Serializer &serializer) {
 	serializer.Write<bool>(select_distinct);
 	serializer.WriteOptional(limit);
 	serializer.WriteOptional(offset);
-	serializer.Write<index_t>(orders.size());
-	for (index_t i = 0; i < orders.size(); i++) {
+	serializer.Write<idx_t>(orders.size());
+	for (idx_t i = 0; i < orders.size(); i++) {
 		serializer.Write<OrderType>(orders[i].type);
 		orders[i].expression->Serialize(serializer);
 	}
@@ -67,9 +67,9 @@ unique_ptr<QueryNode> QueryNode::Deserialize(Deserializer &source) {
 	auto select_distinct = source.Read<bool>();
 	auto limit = source.ReadOptional<ParsedExpression>();
 	auto offset = source.ReadOptional<ParsedExpression>();
-	index_t order_count = source.Read<index_t>();
+	idx_t order_count = source.Read<idx_t>();
 	vector<OrderByNode> orders;
-	for (index_t i = 0; i < order_count; i++) {
+	for (idx_t i = 0; i < order_count; i++) {
 		OrderByNode node;
 		node.type = source.Read<OrderType>();
 		node.expression = ParsedExpression::Deserialize(source);
@@ -82,9 +82,9 @@ unique_ptr<QueryNode> QueryNode::Deserialize(Deserializer &source) {
 	case QueryNodeType::SET_OPERATION_NODE:
 		result = SetOperationNode::Deserialize(source);
 		break;
-    case QueryNodeType::RECURSIVE_CTE_NODE:
-	    result = RecursiveCTENode::Deserialize(source);
-	    break;
+	case QueryNodeType::RECURSIVE_CTE_NODE:
+		result = RecursiveCTENode::Deserialize(source);
+		break;
 	default:
 		throw SerializationException("Could not deserialize Query Node: unknown type!");
 	}

--- a/src/parser/statement/select_statement.cpp
+++ b/src/parser/statement/select_statement.cpp
@@ -29,7 +29,7 @@ void SelectStatement::Serialize(Serializer &serializer) {
 unique_ptr<SelectStatement> SelectStatement::Deserialize(Deserializer &source) {
 	auto result = make_unique<SelectStatement>();
 	auto cte_count = source.Read<uint32_t>();
-	for (index_t i = 0; i < cte_count; i++) {
+	for (idx_t i = 0; i < cte_count; i++) {
 		auto name = source.Read<string>();
 		auto statement = QueryNode::Deserialize(source);
 		result->cte_map[name] = move(statement);

--- a/src/parser/tableref/expressionlistref.cpp
+++ b/src/parser/tableref/expressionlistref.cpp
@@ -13,11 +13,11 @@ bool ExpressionListRef::Equals(const TableRef *other_) const {
 	if (values.size() != other->values.size()) {
 		return false;
 	}
-	for (index_t i = 0; i < values.size(); i++) {
+	for (idx_t i = 0; i < values.size(); i++) {
 		if (values[i].size() != other->values[i].size()) {
 			return false;
 		}
-		for (index_t j = 0; j < values[i].size(); j++) {
+		for (idx_t j = 0; j < values[i].size(); j++) {
 			if (!values[i][j]->Equals(other->values[i][j].get())) {
 				return false;
 			}
@@ -42,8 +42,8 @@ unique_ptr<TableRef> ExpressionListRef::Copy() {
 
 void ExpressionListRef::Serialize(Serializer &serializer) {
 	TableRef::Serialize(serializer);
-	serializer.Write<index_t>(values.size());
-	for (index_t i = 0; i < values.size(); i++) {
+	serializer.Write<idx_t>(values.size());
+	for (idx_t i = 0; i < values.size(); i++) {
 		serializer.WriteList(values[i]);
 	}
 }
@@ -51,8 +51,8 @@ void ExpressionListRef::Serialize(Serializer &serializer) {
 unique_ptr<TableRef> ExpressionListRef::Deserialize(Deserializer &source) {
 	auto result = make_unique<ExpressionListRef>();
 	// value list
-	index_t value_list_size = source.Read<index_t>();
-	for (index_t i = 0; i < value_list_size; i++) {
+	idx_t value_list_size = source.Read<idx_t>();
+	for (idx_t i = 0; i < value_list_size; i++) {
 		vector<unique_ptr<ParsedExpression>> value_list;
 		source.ReadList<ParsedExpression>(value_list);
 		result->values.push_back(move(value_list));

--- a/src/parser/tableref/joinref.cpp
+++ b/src/parser/tableref/joinref.cpp
@@ -47,7 +47,7 @@ unique_ptr<TableRef> JoinRef::Deserialize(Deserializer &source) {
 	result->condition = ParsedExpression::Deserialize(source);
 	result->type = source.Read<JoinType>();
 	auto count = source.Read<uint32_t>();
-	for (index_t i = 0; i < count; i++) {
+	for (idx_t i = 0; i < count; i++) {
 		result->hidden_columns.insert(source.Read<string>());
 	}
 	return move(result);

--- a/src/parser/tableref/subqueryref.cpp
+++ b/src/parser/tableref/subqueryref.cpp
@@ -40,8 +40,8 @@ unique_ptr<TableRef> SubqueryRef::Deserialize(Deserializer &source) {
 		return nullptr;
 	}
 	auto result = make_unique<SubqueryRef>(move(subquery));
-	index_t column_count = (index_t)source.Read<uint32_t>();
-	for (index_t i = 0; i < column_count; i++) {
+	idx_t column_count = (idx_t)source.Read<uint32_t>();
+	for (idx_t i = 0; i < column_count; i++) {
 		result->column_name_alias.push_back(source.Read<string>());
 	}
 	return move(result);

--- a/src/parser/transform/constraint/transform_constraint.cpp
+++ b/src/parser/transform/constraint/transform_constraint.cpp
@@ -23,7 +23,7 @@ unique_ptr<Constraint> Transformer::TransformConstraint(PGListCell *cell) {
 	}
 }
 
-unique_ptr<Constraint> Transformer::TransformConstraint(PGListCell *cell, ColumnDefinition &column, index_t index) {
+unique_ptr<Constraint> Transformer::TransformConstraint(PGListCell *cell, ColumnDefinition &column, idx_t index) {
 	auto constraint = reinterpret_cast<PGConstraint *>(cell->data.ptr_value);
 	assert(constraint);
 	switch (constraint->contype) {

--- a/src/parser/transform/statement/transform_copy.cpp
+++ b/src/parser/transform/statement/transform_copy.cpp
@@ -196,7 +196,7 @@ unique_ptr<CopyStatement> Transformer::TransformCopy(PGNode *node) {
 			auto statement = make_unique<SelectNode>();
 			statement->from_table = move(ref);
 			if (stmt->attlist) {
-				for (index_t i = 0; i < info.select_list.size(); i++)
+				for (idx_t i = 0; i < info.select_list.size(); i++)
 					statement->select_list.push_back(make_unique<ColumnRefExpression>(info.select_list[i]));
 			} else {
 				statement->select_list.push_back(make_unique<StarExpression>());

--- a/src/parser/transform/statement/transform_create_index.cpp
+++ b/src/parser/transform/statement/transform_create_index.cpp
@@ -48,7 +48,7 @@ unique_ptr<CreateIndexStatement> Transformer::TransformCreateIndex(PGNode *node)
 		}
 	}
 
-	info.index_type = StringToIndexType(string(stmt->accessMethod));
+	info.idx_type = StringToIndexType(string(stmt->accessMethod));
 	auto tableref = make_unique<BaseTableRef>();
 	tableref->table_name = stmt->relation->relname;
 	if (stmt->relation->schemaname) {

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -37,7 +37,7 @@ Binding *BindContext::GetCTEBinding(const string &ctename) {
 	return match->second.get();
 }
 
-BindResult BindContext::BindColumn(ColumnRefExpression &colref, index_t depth) {
+BindResult BindContext::BindColumn(ColumnRefExpression &colref, idx_t depth) {
 	if (colref.table_name.empty()) {
 		return BindResult(StringUtil::Format("Could not bind alias \"%s\"!", colref.column_name.c_str()));
 	}
@@ -85,24 +85,24 @@ void BindContext::AddBaseTable(BoundBaseTableRef *bound, const string &alias) {
 	AddBinding(alias, make_unique<TableBinding>(alias, bound));
 }
 
-void BindContext::AddSubquery(index_t index, const string &alias, SubqueryRef &ref, BoundQueryNode &subquery) {
+void BindContext::AddSubquery(idx_t index, const string &alias, SubqueryRef &ref, BoundQueryNode &subquery) {
 	AddBinding(alias, make_unique<SubqueryBinding>(alias, ref, subquery, index));
 }
 
-void BindContext::AddTableFunction(index_t index, const string &alias, TableFunctionCatalogEntry *function_entry) {
+void BindContext::AddTableFunction(idx_t index, const string &alias, TableFunctionCatalogEntry *function_entry) {
 	AddBinding(alias, make_unique<TableFunctionBinding>(alias, function_entry, index));
 }
 
-void BindContext::AddGenericBinding(index_t index, const string &alias, vector<string> names, vector<SQLType> types) {
+void BindContext::AddGenericBinding(idx_t index, const string &alias, vector<string> names, vector<SQLType> types) {
 	AddBinding(alias, make_unique<GenericBinding>(alias, move(types), move(names), index));
 }
 
-void BindContext::AddCTEBinding(index_t index, const string &alias, vector<string> names, vector<SQLType> types) {
+void BindContext::AddCTEBinding(idx_t index, const string &alias, vector<string> names, vector<SQLType> types) {
 	auto binding = make_shared<GenericBinding>(alias, move(types), move(names), index);
 
 	if (cte_bindings.find(alias) != cte_bindings.end()) {
 		throw BinderException("Duplicate alias \"%s\" in query!", alias.c_str());
 	}
 	cte_bindings[alias] = move(binding);
-	cte_references[alias] = std::make_shared<index_t>(0);
+	cte_references[alias] = std::make_shared<idx_t>(0);
 }

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -13,11 +13,11 @@ using namespace std;
 
 Binder::Binder(ClientContext &context, Binder *parent_)
     : context(context), parent(!parent_ ? nullptr : (parent_->parent ? parent_->parent : parent_)), bound_tables(0) {
-    if(parent_) {
-        // We have to inherit CTE bindings from the parent bind_context, if there is a parent.
-        bind_context.SetCTEBindings(parent_->bind_context.GetCTEBindings());
-        bind_context.cte_references = parent_->bind_context.cte_references;
-    }
+	if (parent_) {
+		// We have to inherit CTE bindings from the parent bind_context, if there is a parent.
+		bind_context.SetCTEBindings(parent_->bind_context.GetCTEBindings());
+		bind_context.cte_references = parent_->bind_context.cte_references;
+	}
 	if (parent) {
 		parameters = parent->parameters;
 		CTE_bindings = parent->CTE_bindings;
@@ -84,9 +84,9 @@ unique_ptr<BoundQueryNode> Binder::Bind(QueryNode &node) {
 	case QueryNodeType::SELECT_NODE:
 		result = Bind((SelectNode &)node);
 		break;
-    case QueryNodeType::RECURSIVE_CTE_NODE:
-        result = Bind((RecursiveCTENode &)node);
-	    break;
+	case QueryNodeType::RECURSIVE_CTE_NODE:
+		result = Bind((RecursiveCTENode &)node);
+		break;
 	default:
 		assert(node.type == QueryNodeType::SET_OPERATION_NODE);
 		result = Bind((SetOperationNode &)node);
@@ -150,7 +150,7 @@ unique_ptr<QueryNode> Binder::FindCTE(const string &name) {
 	return entry->second->Copy();
 }
 
-index_t Binder::GenerateTableIndex() {
+idx_t Binder::GenerateTableIndex() {
 	if (parent) {
 		return parent->GenerateTableIndex();
 	}
@@ -192,7 +192,7 @@ void Binder::MoveCorrelatedExpressions(Binder &other) {
 }
 
 void Binder::MergeCorrelatedColumns(vector<CorrelatedColumnInfo> &other) {
-	for (index_t i = 0; i < other.size(); i++) {
+	for (idx_t i = 0; i < other.size(); i++) {
 		AddCorrelatedColumn(other[i]);
 	}
 }

--- a/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -10,18 +10,17 @@
 using namespace duckdb;
 using namespace std;
 
-
-BindResult SelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFunctionCatalogEntry *func, index_t depth) {
+BindResult SelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFunctionCatalogEntry *func, idx_t depth) {
 	// first bind the child of the aggregate expression (if any)
 	AggregateBinder aggregate_binder(binder, context);
 	string error;
-	for (index_t i = 0; i < aggr.children.size(); i++) {
+	for (idx_t i = 0; i < aggr.children.size(); i++) {
 		aggregate_binder.BindChild(aggr.children[i], 0, error);
 	}
 	if (!error.empty()) {
 		// failed to bind child
 		if (aggregate_binder.BoundColumns()) {
-			for (index_t i = 0; i < aggr.children.size(); i++) {
+			for (idx_t i = 0; i < aggr.children.size(); i++) {
 				// however, we bound columns!
 				// that means this aggregation belongs to this node
 				// check if we have to resolve any errors by binding with parent binders
@@ -42,14 +41,14 @@ BindResult SelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFuncti
 	// extract the children and types
 	vector<SQLType> types;
 	vector<unique_ptr<Expression>> children;
-	for (index_t i = 0; i < aggr.children.size(); i++) {
+	for (idx_t i = 0; i < aggr.children.size(); i++) {
 		auto &child = (BoundExpression &)*aggr.children[i];
 		types.push_back(child.sql_type);
 		children.push_back(move(child.expr));
 	}
 
 	// bind the aggregate
-	index_t best_function = Function::BindFunction(func->name, func->functions, types);
+	idx_t best_function = Function::BindFunction(func->name, func->functions, types);
 	// found a matching function!
 	auto &bound_function = func->functions[best_function];
 	// check if we need to add casts to the children
@@ -61,7 +60,7 @@ BindResult SelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFuncti
 	aggregate->children = move(children);
 
 	// check for all the aggregates if this aggregate already exists
-	index_t aggr_index;
+	idx_t aggr_index;
 	auto entry = node.aggregate_map.find(aggregate.get());
 	if (entry == node.aggregate_map.end()) {
 		// new aggregate: insert into aggregate list

--- a/src/planner/binder/expression/bind_case_expression.cpp
+++ b/src/planner/binder/expression/bind_case_expression.cpp
@@ -6,7 +6,7 @@
 using namespace duckdb;
 using namespace std;
 
-BindResult ExpressionBinder::BindExpression(CaseExpression &expr, index_t depth) {
+BindResult ExpressionBinder::BindExpression(CaseExpression &expr, idx_t depth) {
 	// first try to bind the children of the case expression
 	string error;
 	BindChild(expr.check, depth, error);

--- a/src/planner/binder/expression/bind_cast_expression.cpp
+++ b/src/planner/binder/expression/bind_cast_expression.cpp
@@ -6,7 +6,7 @@
 using namespace duckdb;
 using namespace std;
 
-BindResult ExpressionBinder::BindExpression(CastExpression &expr, index_t depth) {
+BindResult ExpressionBinder::BindExpression(CastExpression &expr, idx_t depth) {
 	// first try to bind the child of the cast expression
 	string error = Bind(&expr.child, depth);
 	if (!error.empty()) {

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -7,7 +7,7 @@
 using namespace duckdb;
 using namespace std;
 
-BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref, index_t depth) {
+BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref, idx_t depth) {
 	assert(!colref.column_name.empty());
 	// individual column reference
 	// resolve to either a base table or a subquery expression

--- a/src/planner/binder/expression/bind_comparison_expression.cpp
+++ b/src/planner/binder/expression/bind_comparison_expression.cpp
@@ -6,7 +6,7 @@
 using namespace duckdb;
 using namespace std;
 
-BindResult ExpressionBinder::BindExpression(ComparisonExpression &expr, index_t depth) {
+BindResult ExpressionBinder::BindExpression(ComparisonExpression &expr, idx_t depth) {
 	// first try to bind the children of the case expression
 	string error;
 	BindChild(expr.left, depth, error);

--- a/src/planner/binder/expression/bind_conjunction_expression.cpp
+++ b/src/planner/binder/expression/bind_conjunction_expression.cpp
@@ -6,10 +6,10 @@
 using namespace duckdb;
 using namespace std;
 
-BindResult ExpressionBinder::BindExpression(ConjunctionExpression &expr, index_t depth) {
+BindResult ExpressionBinder::BindExpression(ConjunctionExpression &expr, idx_t depth) {
 	// first try to bind the children of the case expression
 	string error;
-	for (index_t i = 0; i < expr.children.size(); i++) {
+	for (idx_t i = 0; i < expr.children.size(); i++) {
 		BindChild(expr.children[i], depth, error);
 	}
 	if (!error.empty()) {

--- a/src/planner/binder/expression/bind_constant_expression.cpp
+++ b/src/planner/binder/expression/bind_constant_expression.cpp
@@ -5,6 +5,6 @@
 using namespace duckdb;
 using namespace std;
 
-BindResult ExpressionBinder::BindExpression(ConstantExpression &expr, index_t depth) {
+BindResult ExpressionBinder::BindExpression(ConstantExpression &expr, idx_t depth) {
 	return BindResult(make_unique<BoundConstantExpression>(expr.value), expr.sql_type);
 }

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -10,7 +10,7 @@
 using namespace duckdb;
 using namespace std;
 
-BindResult ExpressionBinder::BindExpression(FunctionExpression &function, index_t depth) {
+BindResult ExpressionBinder::BindExpression(FunctionExpression &function, idx_t depth) {
 	// lookup the function in the catalog
 	auto func = context.catalog.GetFunction(context.ActiveTransaction(), function.schema, function.function_name);
 	if (func->type == CatalogType::SCALAR_FUNCTION) {
@@ -22,12 +22,10 @@ BindResult ExpressionBinder::BindExpression(FunctionExpression &function, index_
 	}
 }
 
-
-BindResult ExpressionBinder::BindFunction(FunctionExpression &function, ScalarFunctionCatalogEntry *func,
-                                          index_t depth) {
+BindResult ExpressionBinder::BindFunction(FunctionExpression &function, ScalarFunctionCatalogEntry *func, idx_t depth) {
 	// bind the children of the function expression
 	string error;
-	for (index_t i = 0; i < function.children.size(); i++) {
+	for (idx_t i = 0; i < function.children.size(); i++) {
 		BindChild(function.children[i], depth, error);
 	}
 	if (!error.empty()) {
@@ -37,7 +35,7 @@ BindResult ExpressionBinder::BindFunction(FunctionExpression &function, ScalarFu
 	// extract the children and types
 	vector<SQLType> arguments;
 	vector<unique_ptr<Expression>> children;
-	for (index_t i = 0; i < function.children.size(); i++) {
+	for (idx_t i = 0; i < function.children.size(); i++) {
 		auto &child = (BoundExpression &)*function.children[i];
 		arguments.push_back(child.sql_type);
 		children.push_back(move(child.expr));
@@ -49,7 +47,7 @@ BindResult ExpressionBinder::BindFunction(FunctionExpression &function, ScalarFu
 }
 
 BindResult ExpressionBinder::BindAggregate(FunctionExpression &expr, AggregateFunctionCatalogEntry *function,
-                                           index_t depth) {
+                                           idx_t depth) {
 	return BindResult(UnsupportedAggregateMessage());
 }
 

--- a/src/planner/binder/expression/bind_operator_expression.cpp
+++ b/src/planner/binder/expression/bind_operator_expression.cpp
@@ -17,11 +17,11 @@ static SQLType ResolveNotType(OperatorExpression &op, vector<BoundExpression *> 
 static SQLType ResolveInType(OperatorExpression &op, vector<BoundExpression *> &children) {
 	// get the maximum type from the children
 	SQLType max_type = children[0]->sql_type;
-	for (index_t i = 1; i < children.size(); i++) {
+	for (idx_t i = 1; i < children.size(); i++) {
 		max_type = MaxSQLType(max_type, children[i]->sql_type);
 	}
 	// cast all children to the same type
-	for (index_t i = 0; i < children.size(); i++) {
+	for (idx_t i = 0; i < children.size(); i++) {
 		children[i]->expr =
 		    BoundCastExpression::AddCastToType(move(children[i]->expr), children[i]->sql_type, max_type);
 	}
@@ -44,10 +44,10 @@ static SQLType ResolveOperatorType(OperatorExpression &op, vector<BoundExpressio
 	}
 }
 
-BindResult ExpressionBinder::BindExpression(OperatorExpression &op, index_t depth) {
+BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth) {
 	// bind the children of the operator expression
 	string error;
-	for (index_t i = 0; i < op.children.size(); i++) {
+	for (idx_t i = 0; i < op.children.size(); i++) {
 		BindChild(op.children[i], depth, error);
 	}
 	if (!error.empty()) {
@@ -55,7 +55,7 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, index_t dept
 	}
 	// all children bound successfully, extract them
 	vector<BoundExpression *> children;
-	for (index_t i = 0; i < op.children.size(); i++) {
+	for (idx_t i = 0; i < op.children.size(); i++) {
 		assert(op.children[i]->expression_class == ExpressionClass::BOUND_EXPRESSION);
 		children.push_back((BoundExpression *)op.children[i].get());
 	}

--- a/src/planner/binder/expression/bind_parameter_expression.cpp
+++ b/src/planner/binder/expression/bind_parameter_expression.cpp
@@ -6,7 +6,7 @@
 using namespace duckdb;
 using namespace std;
 
-BindResult ExpressionBinder::BindExpression(ParameterExpression &expr, index_t depth) {
+BindResult ExpressionBinder::BindExpression(ParameterExpression &expr, idx_t depth) {
 	auto bound_parameter = make_unique<BoundParameterExpression>(expr.parameter_nr);
 	auto sql_type = bound_parameter->sql_type;
 	binder.parameters->push_back(bound_parameter.get());

--- a/src/planner/binder/expression/bind_subquery_expression.cpp
+++ b/src/planner/binder/expression/bind_subquery_expression.cpp
@@ -28,7 +28,7 @@ public:
 	}
 };
 
-BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, index_t depth) {
+BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t depth) {
 	if (expr.subquery->type != QueryNodeType::BOUND_SUBQUERY_NODE) {
 		assert(depth == 0);
 		// first bind the actual subquery in a new binder
@@ -37,7 +37,7 @@ BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, index_t de
 		subquery_binder->CTE_bindings = binder.CTE_bindings;
 		auto bound_node = subquery_binder->Bind(*expr.subquery);
 		// check the correlated columns of the subquery for correlated columns with depth > 1
-		for (index_t i = 0; i < subquery_binder->correlated_columns.size(); i++) {
+		for (idx_t i = 0; i < subquery_binder->correlated_columns.size(); i++) {
 			CorrelatedColumnInfo corr = subquery_binder->correlated_columns[i];
 			if (corr.depth > 1) {
 				// depth > 1, the column references the query ABOVE the current one

--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -42,7 +42,7 @@ static unique_ptr<Expression> GetExpression(unique_ptr<ParsedExpression> &expr) 
 	return move(((BoundExpression &)*expr).expr);
 }
 
-BindResult SelectBinder::BindWindow(WindowExpression &window, index_t depth) {
+BindResult SelectBinder::BindWindow(WindowExpression &window, idx_t depth) {
 	if (inside_window) {
 		throw BinderException("window function calls cannot be nested");
 	}

--- a/src/planner/binder/query_node/bind_recursive_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_recursive_cte_node.cpp
@@ -9,59 +9,59 @@
 using namespace duckdb;
 using namespace std;
 
-
 unique_ptr<BoundQueryNode> Binder::Bind(RecursiveCTENode &statement) {
-    auto result = make_unique<BoundRecursiveCTENode>();
+	auto result = make_unique<BoundRecursiveCTENode>();
 
-    // first recursively visit the recursive CTE operations
-    // the left side is visited first and is added to the BindContext of the right side
-    assert(statement.left);
-    assert(statement.right);
+	// first recursively visit the recursive CTE operations
+	// the left side is visited first and is added to the BindContext of the right side
+	assert(statement.left);
+	assert(statement.right);
 
-    result->ctename = statement.ctename;
-    result->union_all = statement.union_all;
-    result->setop_index = GenerateTableIndex();
+	result->ctename = statement.ctename;
+	result->union_all = statement.union_all;
+	result->setop_index = GenerateTableIndex();
 
-    result->left_binder = make_unique<Binder>(context, this);
-    result->left = result->left_binder->Bind(*statement.left);
+	result->left_binder = make_unique<Binder>(context, this);
+	result->left = result->left_binder->Bind(*statement.left);
 
-    // This allows the right side to reference the CTE recursively
-    bind_context.AddGenericBinding(result->setop_index, statement.ctename, result->left->names, result->left->types);
+	// This allows the right side to reference the CTE recursively
+	bind_context.AddGenericBinding(result->setop_index, statement.ctename, result->left->names, result->left->types);
 
-    result->right_binder = make_unique<Binder>(context, this);
+	result->right_binder = make_unique<Binder>(context, this);
 
-    // Add bindings of left side to temporary CTE bindings context
-    result->right_binder->bind_context.AddCTEBinding(result->setop_index, statement.ctename, result->left->names, result->left->types);
-    result->right = result->right_binder->Bind(*statement.right);
+	// Add bindings of left side to temporary CTE bindings context
+	result->right_binder->bind_context.AddCTEBinding(result->setop_index, statement.ctename, result->left->names,
+	                                                 result->left->types);
+	result->right = result->right_binder->Bind(*statement.right);
 
-    // Check if there are aggregates present in the recursive term
-    switch (result->right->type) {
-        case QueryNodeType::SELECT_NODE:
-            if(!((BoundSelectNode *) result->right.get())->aggregates.empty()) {
-                throw Exception("Aggregate functions are not allowed in a recursive query's recursive term");
-            }
-            break;
-        default:
-            break;
-    }
+	// Check if there are aggregates present in the recursive term
+	switch (result->right->type) {
+	case QueryNodeType::SELECT_NODE:
+		if (!((BoundSelectNode *)result->right.get())->aggregates.empty()) {
+			throw Exception("Aggregate functions are not allowed in a recursive query's recursive term");
+		}
+		break;
+	default:
+		break;
+	}
 
-    result->names = result->left->names;
+	result->names = result->left->names;
 
-    // move the correlated expressions from the child binders to this binder
-    MoveCorrelatedExpressions(*result->left_binder);
-    MoveCorrelatedExpressions(*result->right_binder);
+	// move the correlated expressions from the child binders to this binder
+	MoveCorrelatedExpressions(*result->left_binder);
+	MoveCorrelatedExpressions(*result->right_binder);
 
-    // now both sides have been bound we can resolve types
-    if (result->left->types.size() != result->right->types.size()) {
-        throw Exception("Set operations can only apply to expressions with the "
-                        "same number of result columns");
-    }
+	// now both sides have been bound we can resolve types
+	if (result->left->types.size() != result->right->types.size()) {
+		throw Exception("Set operations can only apply to expressions with the "
+		                "same number of result columns");
+	}
 
-    // figure out the types of the recursive CTE result by picking the max of both
-    for (index_t i = 0; i < result->left->types.size(); i++) {
-        auto result_type = MaxSQLType(result->left->types[i], result->right->types[i]);
-        result->types.push_back(result_type);
-    }
+	// figure out the types of the recursive CTE result by picking the max of both
+	for (idx_t i = 0; i < result->left->types.size(); i++) {
+		auto result_type = MaxSQLType(result->left->types[i], result->right->types[i]);
+		result->types.push_back(result_type);
+	}
 
-    return move(result);
+	return move(result);
 }

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -20,7 +20,7 @@ unique_ptr<BoundSQLStatement> Binder::Bind(CopyStatement &stmt) {
 		auto quote_list = stmt.info->force_quote_list;
 
 		// set all columns to false
-		for (index_t i = 0; i < names.size(); i++) {
+		for (idx_t i = 0; i < names.size(); i++) {
 			stmt.info->force_quote.push_back(stmt.info->quote_all);
 		}
 
@@ -54,7 +54,7 @@ unique_ptr<BoundSQLStatement> Binder::Bind(CopyStatement &stmt) {
 
 		auto table = context.catalog.GetTable(context, stmt.info->schema, stmt.info->table);
 		// set all columns to false
-		index_t column_count = stmt.info->select_list.empty() ? table->columns.size() : stmt.info->select_list.size();
+		idx_t column_count = stmt.info->select_list.empty() ? table->columns.size() : stmt.info->select_list.size();
 		stmt.info->force_not_null.resize(column_count, false);
 
 		// transform column names of force_not_null_list into force_not_null booleans

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -27,7 +27,7 @@ static void CreateColumnMap(BoundCreateTableInfo &info) {
 
 static void BindConstraints(Binder &binder, BoundCreateTableInfo &info) {
 	bool has_primary_key = false;
-	for (index_t i = 0; i < info.base->constraints.size(); i++) {
+	for (idx_t i = 0; i < info.base->constraints.size(); i++) {
 		auto &cond = info.base->constraints[i];
 		switch (cond->type) {
 		case ConstraintType::CHECK: {
@@ -53,7 +53,7 @@ static void BindConstraints(Binder &binder, BoundCreateTableInfo &info) {
 		case ConstraintType::UNIQUE: {
 			auto &unique = (UniqueConstraint &)*cond;
 			// have to resolve columns of the unique constraint
-			unordered_set<index_t> keys;
+			unordered_set<idx_t> keys;
 			if (unique.index != INVALID_INDEX) {
 				assert(unique.index < info.base->columns.size());
 				// unique constraint is given by single index
@@ -93,7 +93,7 @@ static void BindConstraints(Binder &binder, BoundCreateTableInfo &info) {
 }
 
 void Binder::BindDefaultValues(vector<ColumnDefinition> &columns, vector<unique_ptr<Expression>> &bound_defaults) {
-	for (index_t i = 0; i < columns.size(); i++) {
+	for (idx_t i = 0; i < columns.size(); i++) {
 		unique_ptr<Expression> bound_default;
 		if (columns[i].default_value) {
 			// we bind a copy of the DEFAULT value because binding is destructive
@@ -148,7 +148,7 @@ unique_ptr<BoundSQLStatement> Binder::Bind(CreateTableStatement &stmt) {
 		auto &names = result->query->node->names;
 		auto &sql_types = result->query->node->types;
 		assert(names.size() == sql_types.size());
-		for (index_t i = 0; i < names.size(); i++) {
+		for (idx_t i = 0; i < names.size(); i++) {
 			result->info->base->columns.push_back(ColumnDefinition(names[i], sql_types[i]));
 		}
 		// create the name map for the statement

--- a/src/planner/binder/statement/bind_execute.cpp
+++ b/src/planner/binder/statement/bind_execute.cpp
@@ -20,7 +20,7 @@ unique_ptr<BoundSQLStatement> Binder::Bind(ExecuteStatement &stmt) {
 	result->prepared = entry->prepared.get();
 
 	vector<Value> bind_values;
-	for (index_t i = 0; i < stmt.values.size(); i++) {
+	for (idx_t i = 0; i < stmt.values.size(); i++) {
 		ConstantBinder binder(*this, context, "EXECUTE statement");
 		binder.target_type = result->prepared->GetType(i + 1);
 		auto bound_expr = binder.Bind(stmt.values[i]);

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -30,13 +30,13 @@ unique_ptr<BoundSQLStatement> Binder::Bind(InsertStatement &stmt) {
 
 	result->table = table;
 
-	vector<index_t> named_column_map;
+	vector<idx_t> named_column_map;
 	if (stmt.columns.size() > 0) {
 		// insertion statement specifies column list
 
 		// create a mapping of (list index) -> (column index)
-		unordered_map<string, index_t> column_name_map;
-		for (index_t i = 0; i < stmt.columns.size(); i++) {
+		unordered_map<string, idx_t> column_name_map;
+		for (idx_t i = 0; i < stmt.columns.size(); i++) {
 			column_name_map[stmt.columns[i]] = i;
 			auto entry = table->name_map.find(stmt.columns[i]);
 			if (entry == table->name_map.end()) {
@@ -48,7 +48,7 @@ unique_ptr<BoundSQLStatement> Binder::Bind(InsertStatement &stmt) {
 			result->expected_types.push_back(table->columns[entry->second].type);
 			named_column_map.push_back(entry->second);
 		}
-		for (index_t i = 0; i < result->table->columns.size(); i++) {
+		for (idx_t i = 0; i < result->table->columns.size(); i++) {
 			auto &col = result->table->columns[i];
 			auto entry = column_name_map.find(col.name);
 			if (entry == column_name_map.end()) {
@@ -60,7 +60,7 @@ unique_ptr<BoundSQLStatement> Binder::Bind(InsertStatement &stmt) {
 			}
 		}
 	} else {
-		for (index_t i = 0; i < result->table->columns.size(); i++) {
+		for (idx_t i = 0; i < result->table->columns.size(); i++) {
 			result->expected_types.push_back(table->columns[i].type);
 		}
 	}
@@ -71,7 +71,7 @@ unique_ptr<BoundSQLStatement> Binder::Bind(InsertStatement &stmt) {
 		return move(result);
 	}
 
-	index_t expected_columns = stmt.columns.size() == 0 ? result->table->columns.size() : stmt.columns.size();
+	idx_t expected_columns = stmt.columns.size() == 0 ? result->table->columns.size() : stmt.columns.size();
 	// special case: check if we are inserting from a VALUES statement
 	if (stmt.select_statement->node->type == QueryNodeType::SELECT_NODE) {
 		auto &node = (SelectNode &)*stmt.select_statement->node;
@@ -82,8 +82,8 @@ unique_ptr<BoundSQLStatement> Binder::Bind(InsertStatement &stmt) {
 			                               result->table->name.c_str());
 
 			// VALUES list!
-			for (index_t col_idx = 0; col_idx < expected_columns; col_idx++) {
-				index_t table_col_idx = stmt.columns.size() == 0 ? col_idx : named_column_map[col_idx];
+			for (idx_t col_idx = 0; col_idx < expected_columns; col_idx++) {
+				idx_t table_col_idx = stmt.columns.size() == 0 ? col_idx : named_column_map[col_idx];
 				assert(table_col_idx < table->columns.size());
 
 				// set the expected types as the types for the INSERT statement
@@ -92,7 +92,7 @@ unique_ptr<BoundSQLStatement> Binder::Bind(InsertStatement &stmt) {
 				expr_list.expected_names.push_back(column.name);
 
 				// now replace any DEFAULT values with the corresponding default expression
-				for (index_t list_idx = 0; list_idx < expr_list.values.size(); list_idx++) {
+				for (idx_t list_idx = 0; list_idx < expr_list.values.size(); list_idx++) {
 					if (expr_list.values[list_idx][col_idx]->type == ExpressionType::VALUE_DEFAULT) {
 						// DEFAULT value! replace the entry
 						if (column.default_value) {

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -19,9 +19,9 @@ static void BindExtraColumns(TableCatalogEntry &table, Binder &binder, ClientCon
 	if (bound_columns.size() <= 1) {
 		return;
 	}
-	index_t found_column_count = 0;
-	unordered_set<index_t> found_columns;
-	for (index_t i = 0; i < result.column_ids.size(); i++) {
+	idx_t found_column_count = 0;
+	unordered_set<idx_t> found_columns;
+	for (idx_t i = 0; i < result.column_ids.size(); i++) {
 		if (bound_columns.find(result.column_ids[i]) != bound_columns.end()) {
 			// this column is referenced in the CHECK constraint
 			found_column_count++;
@@ -74,7 +74,7 @@ static void BindUpdateConstraints(TableCatalogEntry &table, Binder &binder, Clie
 	if (result.is_index_update) {
 		// the update updates a column required by an index, push projections for all columns
 		unordered_set<column_t> all_columns;
-		for (index_t i = 0; i < table.storage->types.size(); i++) {
+		for (idx_t i = 0; i < table.storage->types.size(); i++) {
 			all_columns.insert(i);
 		}
 		BindExtraColumns(table, binder, context, result, all_columns);
@@ -96,7 +96,7 @@ unique_ptr<BoundSQLStatement> Binder::Bind(UpdateStatement &stmt) {
 		result->condition = binder.Bind(stmt.condition);
 	}
 	assert(stmt.columns.size() == stmt.expressions.size());
-	for (index_t i = 0; i < stmt.columns.size(); i++) {
+	for (idx_t i = 0; i < stmt.columns.size(); i++) {
 		auto &colname = stmt.columns[i];
 		auto &expr = stmt.expressions[i];
 		if (!table->ColumnExists(colname)) {

--- a/src/planner/binder/tableref/bind_expressionlistref.cpp
+++ b/src/planner/binder/tableref/bind_expressionlistref.cpp
@@ -15,12 +15,12 @@ unique_ptr<BoundTableRef> Binder::Bind(ExpressionListRef &expr) {
 	// bind value list
 	InsertBinder binder(*this, context);
 	binder.target_type = SQLType(SQLTypeId::INVALID);
-	for (index_t list_idx = 0; list_idx < expr.values.size(); list_idx++) {
+	for (idx_t list_idx = 0; list_idx < expr.values.size(); list_idx++) {
 		auto &expression_list = expr.values[list_idx];
 		vector<unique_ptr<Expression>> list;
 		if (result->types.size() == 0) {
 			// for the first list, we set the expected types as the types of these expressions
-			for (index_t val_idx = 0; val_idx < expression_list.size(); val_idx++) {
+			for (idx_t val_idx = 0; val_idx < expression_list.size(); val_idx++) {
 				SQLType result_type;
 				auto expr = binder.Bind(expression_list[val_idx], &result_type);
 				result->types.push_back(result_type);
@@ -29,7 +29,7 @@ unique_ptr<BoundTableRef> Binder::Bind(ExpressionListRef &expr) {
 			}
 		} else {
 			// for subsequent lists, we apply the expected types we found in the first list
-			for (index_t val_idx = 0; val_idx < expression_list.size(); val_idx++) {
+			for (idx_t val_idx = 0; val_idx < expression_list.size(); val_idx++) {
 				binder.target_type = result->types[val_idx];
 				list.push_back(binder.Bind(expression_list[val_idx]));
 			}

--- a/src/planner/binder/tableref/bind_subqueryref.cpp
+++ b/src/planner/binder/tableref/bind_subqueryref.cpp
@@ -8,7 +8,7 @@ using namespace std;
 unique_ptr<BoundTableRef> Binder::Bind(SubqueryRef &ref) {
 	auto binder = make_unique<Binder>(context, this);
 	auto subquery = binder->Bind(*ref.subquery);
-	index_t bind_index = subquery->GetRootIndex();
+	idx_t bind_index = subquery->GetRootIndex();
 	auto result = make_unique<BoundSubqueryRef>(move(binder), move(subquery));
 
 	bind_context.AddSubquery(bind_index, ref.alias, ref, *result->subquery);

--- a/src/planner/expression/bound_aggregate_expression.cpp
+++ b/src/planner/expression/bound_aggregate_expression.cpp
@@ -42,7 +42,7 @@ bool BoundAggregateExpression::Equals(const BaseExpression *other_) const {
 	if (children.size() != other->children.size()) {
 		return false;
 	}
-	for (index_t i = 0; i < children.size(); i++) {
+	for (idx_t i = 0; i < children.size(); i++) {
 		if (!Expression::Equals(children[i].get(), other->children[i].get())) {
 			return false;
 		}

--- a/src/planner/expression/bound_columnref_expression.cpp
+++ b/src/planner/expression/bound_columnref_expression.cpp
@@ -5,13 +5,13 @@
 using namespace duckdb;
 using namespace std;
 
-BoundColumnRefExpression::BoundColumnRefExpression(string alias, TypeId type, ColumnBinding binding, index_t depth)
+BoundColumnRefExpression::BoundColumnRefExpression(string alias, TypeId type, ColumnBinding binding, idx_t depth)
     : Expression(ExpressionType::BOUND_COLUMN_REF, ExpressionClass::BOUND_COLUMN_REF, type), binding(binding),
       depth(depth) {
 	this->alias = alias;
 }
 
-BoundColumnRefExpression::BoundColumnRefExpression(TypeId type, ColumnBinding binding, index_t depth)
+BoundColumnRefExpression::BoundColumnRefExpression(TypeId type, ColumnBinding binding, idx_t depth)
     : BoundColumnRefExpression(string(), type, binding, depth) {
 }
 

--- a/src/planner/expression/bound_conjunction_expression.cpp
+++ b/src/planner/expression/bound_conjunction_expression.cpp
@@ -17,7 +17,7 @@ BoundConjunctionExpression::BoundConjunctionExpression(ExpressionType type, uniq
 
 string BoundConjunctionExpression::ToString() const {
 	string result = "(" + children[0]->ToString();
-	for (index_t i = 1; i < children.size(); i++) {
+	for (idx_t i = 1; i < children.size(); i++) {
 		result += " " + ExpressionTypeToOperator(type) + " " + children[i]->ToString();
 	}
 	return result + ")";

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -41,7 +41,7 @@ bool BoundFunctionExpression::Equals(const BaseExpression *other_) const {
 	if (children.size() != other->children.size()) {
 		return false;
 	}
-	for (index_t i = 0; i < children.size(); i++) {
+	for (idx_t i = 0; i < children.size(); i++) {
 		if (!Expression::Equals(children[i].get(), other->children[i].get())) {
 			return false;
 		}

--- a/src/planner/expression/bound_operator_expression.cpp
+++ b/src/planner/expression/bound_operator_expression.cpp
@@ -34,7 +34,7 @@ bool BoundOperatorExpression::Equals(const BaseExpression *other_) const {
 	if (children.size() != other->children.size()) {
 		return false;
 	}
-	for (index_t i = 0; i < children.size(); i++) {
+	for (idx_t i = 0; i < children.size(); i++) {
 		if (!Expression::Equals(children[i].get(), other->children[i].get())) {
 			return false;
 		}

--- a/src/planner/expression/bound_parameter_expression.cpp
+++ b/src/planner/expression/bound_parameter_expression.cpp
@@ -4,7 +4,7 @@
 using namespace duckdb;
 using namespace std;
 
-BoundParameterExpression::BoundParameterExpression(index_t parameter_nr)
+BoundParameterExpression::BoundParameterExpression(idx_t parameter_nr)
     : Expression(ExpressionType::VALUE_PARAMETER, ExpressionClass::BOUND_PARAMETER, TypeId::INVALID),
       sql_type(SQLType(SQLTypeId::UNKNOWN)), parameter_nr(parameter_nr), value(nullptr) {
 }

--- a/src/planner/expression/bound_reference_expression.cpp
+++ b/src/planner/expression/bound_reference_expression.cpp
@@ -6,11 +6,11 @@
 using namespace duckdb;
 using namespace std;
 
-BoundReferenceExpression::BoundReferenceExpression(string alias, TypeId type, index_t index)
+BoundReferenceExpression::BoundReferenceExpression(string alias, TypeId type, idx_t index)
     : Expression(ExpressionType::BOUND_REF, ExpressionClass::BOUND_REF, type), index(index) {
 	this->alias = alias;
 }
-BoundReferenceExpression::BoundReferenceExpression(TypeId type, index_t index)
+BoundReferenceExpression::BoundReferenceExpression(TypeId type, idx_t index)
     : BoundReferenceExpression(string(), type, index) {
 }
 
@@ -27,7 +27,7 @@ bool BoundReferenceExpression::Equals(const BaseExpression *other_) const {
 }
 
 uint64_t BoundReferenceExpression::Hash() const {
-	return CombineHash(Expression::Hash(), duckdb::Hash<index_t>(index));
+	return CombineHash(Expression::Hash(), duckdb::Hash<idx_t>(index));
 }
 
 unique_ptr<Expression> BoundReferenceExpression::Copy() {

--- a/src/planner/expression/bound_window_expression.cpp
+++ b/src/planner/expression/bound_window_expression.cpp
@@ -26,7 +26,7 @@ bool BoundWindowExpression::Equals(const BaseExpression *other_) const {
 	if (other->children.size() != children.size()) {
 		return false;
 	}
-	for (index_t i = 0; i < children.size(); i++) {
+	for (idx_t i = 0; i < children.size(); i++) {
 		if (!Expression::Equals(children[i].get(), other->children[i].get())) {
 			return false;
 		}
@@ -43,7 +43,7 @@ bool BoundWindowExpression::Equals(const BaseExpression *other_) const {
 	if (partitions.size() != other->partitions.size()) {
 		return false;
 	}
-	for (index_t i = 0; i < partitions.size(); i++) {
+	for (idx_t i = 0; i < partitions.size(); i++) {
 		if (!Expression::Equals(partitions[i].get(), other->partitions[i].get())) {
 			return false;
 		}
@@ -52,7 +52,7 @@ bool BoundWindowExpression::Equals(const BaseExpression *other_) const {
 	if (orders.size() != other->orders.size()) {
 		return false;
 	}
-	for (index_t i = 0; i < orders.size(); i++) {
+	for (idx_t i = 0; i < orders.size(); i++) {
 		if (orders[i].type != other->orders[i].type) {
 			return false;
 		}

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -35,7 +35,7 @@ ExpressionBinder::~ExpressionBinder() {
 	}
 }
 
-BindResult ExpressionBinder::BindExpression(ParsedExpression &expr, index_t depth, bool root_expression) {
+BindResult ExpressionBinder::BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression) {
 	switch (expr.expression_class) {
 	case ExpressionClass::CASE:
 		return BindExpression((CaseExpression &)expr, depth);
@@ -68,7 +68,7 @@ bool ExpressionBinder::BindCorrelatedColumns(unique_ptr<ParsedExpression> &expr)
 	// make a copy of the set of binders, so we can restore it later
 	auto binders = active_binders;
 	active_binders.pop_back();
-	index_t depth = 1;
+	idx_t depth = 1;
 	bool success = false;
 	while (active_binders.size() > 0) {
 		auto &next_binder = active_binders.back();
@@ -85,7 +85,7 @@ bool ExpressionBinder::BindCorrelatedColumns(unique_ptr<ParsedExpression> &expr)
 	return success;
 }
 
-void ExpressionBinder::BindChild(unique_ptr<ParsedExpression> &expr, index_t depth, string &error) {
+void ExpressionBinder::BindChild(unique_ptr<ParsedExpression> &expr, idx_t depth, string &error) {
 	if (expr.get()) {
 		string bind_error = Bind(&expr, depth);
 		if (error.empty()) {
@@ -138,7 +138,7 @@ unique_ptr<Expression> ExpressionBinder::Bind(unique_ptr<ParsedExpression> &expr
 	return result;
 }
 
-string ExpressionBinder::Bind(unique_ptr<ParsedExpression> *expr, index_t depth, bool root_expression) {
+string ExpressionBinder::Bind(unique_ptr<ParsedExpression> *expr, idx_t depth, bool root_expression) {
 	// bind the node, but only if it has not been bound yet
 	auto &expression = **expr;
 	auto alias = expression.alias;
@@ -153,7 +153,7 @@ string ExpressionBinder::Bind(unique_ptr<ParsedExpression> *expr, index_t depth,
 	} else {
 		// successfully bound: replace the node with a BoundExpression
 		*expr = make_unique<BoundExpression>(move(result.expression), move(*expr), result.sql_type);
-		auto be = (BoundExpression*) expr->get();
+		auto be = (BoundExpression *)expr->get();
 		assert(be);
 		be->alias = alias;
 		if (!alias.empty()) {

--- a/src/planner/expression_binder/aggregate_binder.cpp
+++ b/src/planner/expression_binder/aggregate_binder.cpp
@@ -8,7 +8,7 @@ using namespace std;
 AggregateBinder::AggregateBinder(Binder &binder, ClientContext &context) : ExpressionBinder(binder, context, true) {
 }
 
-BindResult AggregateBinder::BindExpression(ParsedExpression &expr, index_t depth, bool root_expression) {
+BindResult AggregateBinder::BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression) {
 	switch (expr.expression_class) {
 	case ExpressionClass::WINDOW:
 		throw ParserException("aggregate function calls cannot contain window function calls");

--- a/src/planner/expression_binder/check_binder.cpp
+++ b/src/planner/expression_binder/check_binder.cpp
@@ -12,7 +12,7 @@ CheckBinder::CheckBinder(Binder &binder, ClientContext &context, string table, v
 	target_type = SQLType::INTEGER;
 }
 
-BindResult CheckBinder::BindExpression(ParsedExpression &expr, index_t depth, bool root_expression) {
+BindResult CheckBinder::BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression) {
 	switch (expr.GetExpressionClass()) {
 	case ExpressionClass::WINDOW:
 		return BindResult("window functions are not allowed in check constraints");
@@ -34,7 +34,7 @@ BindResult CheckBinder::BindCheckColumn(ColumnRefExpression &colref) {
 		throw BinderException("Cannot reference table %s from within check constraint for table %s!",
 		                      colref.table_name.c_str(), table.c_str());
 	}
-	for (index_t i = 0; i < columns.size(); i++) {
+	for (idx_t i = 0; i < columns.size(); i++) {
 		if (colref.column_name == columns[i].name) {
 			bound_columns.insert(i);
 			return BindResult(make_unique<BoundReferenceExpression>(GetInternalType(columns[i].type), i),

--- a/src/planner/expression_binder/constant_binder.cpp
+++ b/src/planner/expression_binder/constant_binder.cpp
@@ -7,7 +7,7 @@ ConstantBinder::ConstantBinder(Binder &binder, ClientContext &context, string cl
     : ExpressionBinder(binder, context), clause(clause) {
 }
 
-BindResult ConstantBinder::BindExpression(ParsedExpression &expr, index_t depth, bool root_expression) {
+BindResult ConstantBinder::BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression) {
 	switch (expr.GetExpressionClass()) {
 	case ExpressionClass::COLUMN_REF:
 		return BindResult(clause + "cannot contain column names");

--- a/src/planner/expression_binder/group_binder.cpp
+++ b/src/planner/expression_binder/group_binder.cpp
@@ -8,13 +8,13 @@
 using namespace duckdb;
 using namespace std;
 
-GroupBinder::GroupBinder(Binder &binder, ClientContext &context, SelectNode &node, index_t group_index,
-                         unordered_map<string, index_t> &alias_map, unordered_map<string, index_t> &group_alias_map)
+GroupBinder::GroupBinder(Binder &binder, ClientContext &context, SelectNode &node, idx_t group_index,
+                         unordered_map<string, idx_t> &alias_map, unordered_map<string, idx_t> &group_alias_map)
     : ExpressionBinder(binder, context), node(node), alias_map(alias_map), group_alias_map(group_alias_map),
       group_index(group_index) {
 }
 
-BindResult GroupBinder::BindExpression(ParsedExpression &expr, index_t depth, bool root_expression) {
+BindResult GroupBinder::BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression) {
 	if (root_expression && depth == 0) {
 		switch (expr.expression_class) {
 		case ExpressionClass::COLUMN_REF:
@@ -39,7 +39,7 @@ string GroupBinder::UnsupportedAggregateMessage() {
 	return "GROUP BY clause cannot contain aggregates!";
 }
 
-BindResult GroupBinder::BindSelectRef(index_t entry) {
+BindResult GroupBinder::BindSelectRef(idx_t entry) {
 	if (used_aliases.find(entry) != used_aliases.end()) {
 		// the alias has already been bound to before!
 		// this happens if we group on the same alias twice
@@ -72,7 +72,7 @@ BindResult GroupBinder::BindConstant(ConstantExpression &constant) {
 		return ExpressionBinder::BindExpression(constant, 0);
 	}
 	// INTEGER constant: we use the integer as an index into the select list (e.g. GROUP BY 1)
-	auto index = (index_t)constant.value.GetValue<int64_t>();
+	auto index = (idx_t)constant.value.GetValue<int64_t>();
 	return BindSelectRef(index - 1);
 }
 

--- a/src/planner/expression_binder/having_binder.cpp
+++ b/src/planner/expression_binder/having_binder.cpp
@@ -13,7 +13,7 @@ HavingBinder::HavingBinder(Binder &binder, ClientContext &context, BoundSelectNo
 	target_type = SQLType(SQLTypeId::BOOLEAN);
 }
 
-BindResult HavingBinder::BindExpression(ParsedExpression &expr, index_t depth, bool root_expression) {
+BindResult HavingBinder::BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression) {
 	// check if the expression binds to one of the groups
 	auto group_index = TryBindGroup(expr, depth);
 	if (group_index != INVALID_INDEX) {

--- a/src/planner/expression_binder/index_binder.cpp
+++ b/src/planner/expression_binder/index_binder.cpp
@@ -6,7 +6,7 @@ using namespace std;
 IndexBinder::IndexBinder(Binder &binder, ClientContext &context) : ExpressionBinder(binder, context) {
 }
 
-BindResult IndexBinder::BindExpression(ParsedExpression &expr, index_t depth, bool root_expression) {
+BindResult IndexBinder::BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression) {
 	switch (expr.expression_class) {
 	case ExpressionClass::WINDOW:
 		return BindResult("window functions are not allowed in index expressions");

--- a/src/planner/expression_binder/insert_binder.cpp
+++ b/src/planner/expression_binder/insert_binder.cpp
@@ -8,7 +8,7 @@ using namespace std;
 InsertBinder::InsertBinder(Binder &binder, ClientContext &context) : ExpressionBinder(binder, context) {
 }
 
-BindResult InsertBinder::BindExpression(ParsedExpression &expr, index_t depth, bool root_expression) {
+BindResult InsertBinder::BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression) {
 	switch (expr.GetExpressionClass()) {
 	case ExpressionClass::DEFAULT:
 		return BindResult("DEFAULT is not allowed here!");

--- a/src/planner/expression_binder/order_binder.cpp
+++ b/src/planner/expression_binder/order_binder.cpp
@@ -7,19 +7,19 @@
 using namespace duckdb;
 using namespace std;
 
-OrderBinder::OrderBinder(index_t projection_index, SelectNode &node, unordered_map<string, index_t> &alias_map,
-                         expression_map_t<index_t> &projection_map,
+OrderBinder::OrderBinder(idx_t projection_index, SelectNode &node, unordered_map<string, idx_t> &alias_map,
+                         expression_map_t<idx_t> &projection_map,
                          vector<unique_ptr<ParsedExpression>> &extra_select_list)
     : projection_index(projection_index), node(node), alias_map(alias_map), projection_map(projection_map),
       extra_select_list(extra_select_list) {
 }
 
-unique_ptr<Expression> OrderBinder::CreateProjectionReference(ParsedExpression &expr, index_t index) {
+unique_ptr<Expression> OrderBinder::CreateProjectionReference(ParsedExpression &expr, idx_t index) {
 	return make_unique<BoundColumnRefExpression>(expr.GetName(), TypeId::INVALID,
 	                                             ColumnBinding(projection_index, index));
 }
 
-void OrderBinder::RemapIndex(BoundColumnRefExpression &expr, index_t index) {
+void OrderBinder::RemapIndex(BoundColumnRefExpression &expr, idx_t index) {
 	expr.binding.column_index = index;
 }
 
@@ -42,10 +42,10 @@ unique_ptr<Expression> OrderBinder::Bind(unique_ptr<ParsedExpression> expr) {
 			return nullptr;
 		}
 		// INTEGER constant: we use the integer as an index into the select list (e.g. ORDER BY 1)
-		auto index = (index_t)constant.value.GetValue<int64_t>();
+		auto index = (idx_t)constant.value.GetValue<int64_t>();
 		if (index < 1 || index > node.select_list.size()) {
 			throw BinderException("ORDER term out of range - should be between 1 and %lld",
-			                      (index_t)node.select_list.size());
+			                      (idx_t)node.select_list.size());
 		}
 		return CreateProjectionReference(*expr, index - 1);
 	}

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -15,7 +15,7 @@ SelectBinder::SelectBinder(Binder &binder, ClientContext &context, BoundSelectNo
     : ExpressionBinder(binder, context), inside_window(false), node(node), info(info) {
 }
 
-BindResult SelectBinder::BindExpression(ParsedExpression &expr, index_t depth, bool root_expression) {
+BindResult SelectBinder::BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression) {
 	// check if the expression binds to one of the groups
 	auto group_index = TryBindGroup(expr, depth);
 	if (group_index != INVALID_INDEX) {
@@ -31,7 +31,7 @@ BindResult SelectBinder::BindExpression(ParsedExpression &expr, index_t depth, b
 	}
 }
 
-index_t SelectBinder::TryBindGroup(ParsedExpression &expr, index_t depth) {
+idx_t SelectBinder::TryBindGroup(ParsedExpression &expr, idx_t depth) {
 	// first check the group alias map, if expr is a ColumnRefExpression
 	if (expr.type == ExpressionType::COLUMN_REF) {
 		auto &colref = (ColumnRefExpression &)expr;
@@ -58,7 +58,7 @@ index_t SelectBinder::TryBindGroup(ParsedExpression &expr, index_t depth) {
 	return INVALID_INDEX;
 }
 
-BindResult SelectBinder::BindGroup(ParsedExpression &expr, index_t depth, index_t group_index) {
+BindResult SelectBinder::BindGroup(ParsedExpression &expr, idx_t depth, idx_t group_index) {
 	auto &group = node.groups[group_index];
 
 	return BindResult(make_unique<BoundColumnRefExpression>(expr.GetName(), group->return_type,

--- a/src/planner/expression_binder/update_binder.cpp
+++ b/src/planner/expression_binder/update_binder.cpp
@@ -6,7 +6,7 @@ using namespace std;
 UpdateBinder::UpdateBinder(Binder &binder, ClientContext &context) : ExpressionBinder(binder, context) {
 }
 
-BindResult UpdateBinder::BindExpression(ParsedExpression &expr, index_t depth, bool root_expression) {
+BindResult UpdateBinder::BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression) {
 	switch (expr.expression_class) {
 	case ExpressionClass::WINDOW:
 		return BindResult("window functions are not allowed in UPDATE");

--- a/src/planner/expression_binder/where_binder.cpp
+++ b/src/planner/expression_binder/where_binder.cpp
@@ -7,7 +7,7 @@ WhereBinder::WhereBinder(Binder &binder, ClientContext &context) : ExpressionBin
 	target_type = SQLType(SQLTypeId::BOOLEAN);
 }
 
-BindResult WhereBinder::BindExpression(ParsedExpression &expr, index_t depth, bool root_expression) {
+BindResult WhereBinder::BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression) {
 	switch (expr.GetExpressionClass()) {
 	case ExpressionClass::DEFAULT:
 		return BindResult("WHERE clause cannot contain DEFAULT clause");

--- a/src/planner/expression_iterator.cpp
+++ b/src/planner/expression_iterator.cpp
@@ -178,18 +178,18 @@ void ExpressionIterator::EnumerateQueryNodeChildren(BoundQueryNode &node,
 	default:
 		assert(node.type == QueryNodeType::SELECT_NODE);
 		auto &bound_select = (BoundSelectNode &)node;
-		for (index_t i = 0; i < bound_select.select_list.size(); i++) {
+		for (idx_t i = 0; i < bound_select.select_list.size(); i++) {
 			EnumerateExpression(bound_select.select_list[i], callback);
 		}
 		EnumerateExpression(bound_select.where_clause, callback);
-		for (index_t i = 0; i < bound_select.groups.size(); i++) {
+		for (idx_t i = 0; i < bound_select.groups.size(); i++) {
 			EnumerateExpression(bound_select.groups[i], callback);
 		}
 		EnumerateExpression(bound_select.having, callback);
-		for (index_t i = 0; i < bound_select.aggregates.size(); i++) {
+		for (idx_t i = 0; i < bound_select.aggregates.size(); i++) {
 			EnumerateExpression(bound_select.aggregates[i], callback);
 		}
-		for (index_t i = 0; i < bound_select.windows.size(); i++) {
+		for (idx_t i = 0; i < bound_select.windows.size(); i++) {
 			EnumerateExpression(bound_select.windows[i], callback);
 		}
 		if (bound_select.from_table) {
@@ -197,7 +197,7 @@ void ExpressionIterator::EnumerateQueryNodeChildren(BoundQueryNode &node,
 		}
 		break;
 	}
-	for (index_t i = 0; i < node.orders.size(); i++) {
+	for (idx_t i = 0; i < node.orders.size(); i++) {
 		EnumerateExpression(node.orders[i].expression, callback);
 	}
 }

--- a/src/planner/joinside.cpp
+++ b/src/planner/joinside.cpp
@@ -25,8 +25,8 @@ JoinSide JoinSide::CombineJoinSide(JoinSide left, JoinSide right) {
 	return left;
 }
 
-JoinSide JoinSide::GetJoinSide(index_t table_binding, unordered_set<index_t> &left_bindings,
-                               unordered_set<index_t> &right_bindings) {
+JoinSide JoinSide::GetJoinSide(idx_t table_binding, unordered_set<idx_t> &left_bindings,
+                               unordered_set<idx_t> &right_bindings) {
 	if (left_bindings.find(table_binding) != left_bindings.end()) {
 		// column references table on left side
 		assert(right_bindings.find(table_binding) == right_bindings.end());
@@ -38,8 +38,8 @@ JoinSide JoinSide::GetJoinSide(index_t table_binding, unordered_set<index_t> &le
 	}
 }
 
-JoinSide JoinSide::GetJoinSide(Expression &expression, unordered_set<index_t> &left_bindings,
-                               unordered_set<index_t> &right_bindings) {
+JoinSide JoinSide::GetJoinSide(Expression &expression, unordered_set<idx_t> &left_bindings,
+                               unordered_set<idx_t> &right_bindings) {
 	if (expression.type == ExpressionType::BOUND_COLUMN_REF) {
 		auto &colref = (BoundColumnRefExpression &)expression;
 		if (colref.depth > 0) {
@@ -72,8 +72,8 @@ JoinSide JoinSide::GetJoinSide(Expression &expression, unordered_set<index_t> &l
 	return join_side;
 }
 
-JoinSide JoinSide::GetJoinSide(unordered_set<index_t> bindings, unordered_set<index_t> &left_bindings,
-                               unordered_set<index_t> &right_bindings) {
+JoinSide JoinSide::GetJoinSide(unordered_set<idx_t> bindings, unordered_set<idx_t> &left_bindings,
+                               unordered_set<idx_t> &right_bindings) {
 	JoinSide side = JoinSide::NONE;
 	for (auto binding : bindings) {
 		side = CombineJoinSide(side, GetJoinSide(binding, left_bindings, right_bindings));

--- a/src/planner/logical_operator.cpp
+++ b/src/planner/logical_operator.cpp
@@ -32,15 +32,15 @@ void LogicalOperator::ResolveOperatorTypes() {
 	ResolveTypes();
 }
 
-vector<ColumnBinding> LogicalOperator::GenerateColumnBindings(index_t table_idx, index_t column_count) {
+vector<ColumnBinding> LogicalOperator::GenerateColumnBindings(idx_t table_idx, idx_t column_count) {
 	vector<ColumnBinding> result;
-	for (index_t i = 0; i < column_count; i++) {
+	for (idx_t i = 0; i < column_count; i++) {
 		result.push_back(ColumnBinding(table_idx, i));
 	}
 	return result;
 }
 
-vector<TypeId> LogicalOperator::MapTypes(vector<TypeId> types, vector<index_t> projection_map) {
+vector<TypeId> LogicalOperator::MapTypes(vector<TypeId> types, vector<idx_t> projection_map) {
 	if (projection_map.size() == 0) {
 		return types;
 	} else {
@@ -52,7 +52,7 @@ vector<TypeId> LogicalOperator::MapTypes(vector<TypeId> types, vector<index_t> p
 	}
 }
 
-vector<ColumnBinding> LogicalOperator::MapBindings(vector<ColumnBinding> bindings, vector<index_t> projection_map) {
+vector<ColumnBinding> LogicalOperator::MapBindings(vector<ColumnBinding> bindings, vector<idx_t> projection_map) {
 	if (projection_map.size() == 0) {
 		return bindings;
 	} else {
@@ -64,11 +64,11 @@ vector<ColumnBinding> LogicalOperator::MapBindings(vector<ColumnBinding> binding
 	}
 }
 
-string LogicalOperator::ToString(index_t depth) const {
+string LogicalOperator::ToString(idx_t depth) const {
 	string result = LogicalOperatorToString(type);
 	result += ParamsToString();
 	if (children.size() > 0) {
-		for (index_t i = 0; i < children.size(); i++) {
+		for (idx_t i = 0; i < children.size(); i++) {
 			result += "\n" + string(depth * 4, ' ');
 			auto &child = children[i];
 			result += child->ToString(depth + 1);

--- a/src/planner/logical_operator_visitor.cpp
+++ b/src/planner/logical_operator_visitor.cpp
@@ -66,7 +66,7 @@ void LogicalOperatorVisitor::VisitOperatorExpressions(LogicalOperator &op) {
 	}
 	case LogicalOperatorType::AGGREGATE_AND_GROUP_BY: {
 		auto &aggr = (LogicalAggregate &)op;
-		for (index_t i = 0; i < aggr.groups.size(); i++) {
+		for (idx_t i = 0; i < aggr.groups.size(); i++) {
 			VisitExpression(&aggr.groups[i]);
 		}
 		break;
@@ -74,7 +74,7 @@ void LogicalOperatorVisitor::VisitOperatorExpressions(LogicalOperator &op) {
 	default:
 		break;
 	}
-	for (index_t i = 0; i < op.expressions.size(); i++) {
+	for (idx_t i = 0; i < op.expressions.size(); i++) {
 		VisitExpression(&op.expressions[i]);
 	}
 }

--- a/src/planner/logical_plan/plan_subquery.cpp
+++ b/src/planner/logical_plan/plan_subquery.cpp
@@ -30,7 +30,7 @@ static unique_ptr<Expression> PlanUncorrelatedSubquery(Binder &binder, BoundSubq
 
 		// now we push a COUNT(*) aggregate onto the limit, this will be either 0 or 1 (EXISTS or NOT EXISTS)
 		auto count_star = make_unique<BoundAggregateExpression>(TypeId::INT64, CountStarFun::GetFunction(), false);
-		auto index_type = count_star->return_type;
+		auto idx_type = count_star->return_type;
 		vector<unique_ptr<Expression>> aggregate_list;
 		aggregate_list.push_back(move(count_star));
 		auto aggregate_index = binder.GenerateTableIndex();
@@ -40,8 +40,8 @@ static unique_ptr<Expression> PlanUncorrelatedSubquery(Binder &binder, BoundSubq
 		plan = move(aggregate);
 
 		// now we push a projection with a comparison to 1
-		auto left_child = make_unique<BoundColumnRefExpression>(index_type, ColumnBinding(aggregate_index, 0));
-		auto right_child = make_unique<BoundConstantExpression>(Value::Numeric(index_type, 1));
+		auto left_child = make_unique<BoundColumnRefExpression>(idx_type, ColumnBinding(aggregate_index, 0));
+		auto right_child = make_unique<BoundConstantExpression>(Value::Numeric(idx_type, 1));
 		auto comparison =
 		    make_unique<BoundComparisonExpression>(ExpressionType::COMPARE_EQUAL, move(left_child), move(right_child));
 
@@ -68,7 +68,7 @@ static unique_ptr<Expression> PlanUncorrelatedSubquery(Binder &binder, BoundSubq
 		// figure out the table index of the bound table of the entry which we want to return
 		auto bindings = plan->GetColumnBindings();
 		assert(bindings.size() == 1);
-		index_t table_idx = bindings[0].table_index;
+		idx_t table_idx = bindings[0].table_index;
 
 		// in the uncorrelated case we are only interested in the first result of the query
 		// hence we simply push a LIMIT 1 to get the first row of the subquery
@@ -110,7 +110,7 @@ static unique_ptr<Expression> PlanUncorrelatedSubquery(Binder &binder, BoundSubq
 		auto plan_columns = plan->GetColumnBindings();
 
 		// then we generate the MARK join with the subquery
-		index_t mark_index = binder.GenerateTableIndex();
+		idx_t mark_index = binder.GenerateTableIndex();
 		auto join = make_unique<LogicalComparisonJoin>(JoinType::MARK);
 		join->mark_index = mark_index;
 		join->AddChild(move(root));
@@ -134,7 +134,7 @@ static unique_ptr<Expression> PlanUncorrelatedSubquery(Binder &binder, BoundSubq
 static unique_ptr<LogicalDelimJoin> CreateDuplicateEliminatedJoin(vector<CorrelatedColumnInfo> &correlated_columns,
                                                                   JoinType join_type) {
 	auto delim_join = make_unique<LogicalDelimJoin>(join_type);
-	for (index_t i = 0; i < correlated_columns.size(); i++) {
+	for (idx_t i = 0; i < correlated_columns.size(); i++) {
 		auto &col = correlated_columns[i];
 		delim_join->duplicate_eliminated_columns.push_back(
 		    make_unique<BoundColumnRefExpression>(col.type, col.binding));
@@ -143,8 +143,8 @@ static unique_ptr<LogicalDelimJoin> CreateDuplicateEliminatedJoin(vector<Correla
 }
 
 static void CreateDelimJoinConditions(LogicalDelimJoin &delim_join, vector<CorrelatedColumnInfo> &correlated_columns,
-                                      vector<ColumnBinding> bindings, index_t base_offset) {
-	for (index_t i = 0; i < correlated_columns.size(); i++) {
+                                      vector<ColumnBinding> bindings, idx_t base_offset) {
+	for (idx_t i = 0; i < correlated_columns.size(); i++) {
 		auto &col = correlated_columns[i];
 		JoinCondition cond;
 		cond.left = make_unique<BoundColumnRefExpression>(col.name, col.type, col.binding);
@@ -206,7 +206,7 @@ static unique_ptr<Expression> PlanCorrelatedSubquery(Binder &binder, BoundSubque
 	case SubqueryType::EXISTS: {
 		// correlated EXISTS query
 		// this query is similar to the correlated SCALAR query, except we use a MARK join here
-		index_t mark_index = binder.GenerateTableIndex();
+		idx_t mark_index = binder.GenerateTableIndex();
 		auto delim_join = CreateDuplicateEliminatedJoin(correlated_columns, JoinType::MARK);
 		delim_join->mark_index = mark_index;
 		// LHS
@@ -235,7 +235,7 @@ static unique_ptr<Expression> PlanCorrelatedSubquery(Binder &binder, BoundSubque
 		// the correlated mark join handles this case by itself
 		// as the MARK join has one extra join condition (the original condition, of the ANY expression, e.g.
 		// [i=ANY(...)])
-		index_t mark_index = binder.GenerateTableIndex();
+		idx_t mark_index = binder.GenerateTableIndex();
 		auto delim_join = CreateDuplicateEliminatedJoin(correlated_columns, JoinType::MARK);
 		delim_join->mark_index = mark_index;
 		// LHS
@@ -281,7 +281,7 @@ public:
 			root = move(op.children[0]);
 			VisitOperatorExpressions(op);
 			op.children[0] = move(root);
-			for (index_t i = 0; i < op.children.size(); i++) {
+			for (idx_t i = 0; i < op.children.size(); i++) {
 				VisitOperator(*op.children[i]);
 			}
 		}

--- a/src/planner/logical_plan/query_node/plan_select_node.cpp
+++ b/src/planner/logical_plan/query_node/plan_select_node.cpp
@@ -22,7 +22,7 @@ unique_ptr<LogicalOperator> LogicalPlanGenerator::CreatePlan(BoundSelectNode &st
 	if (statement.aggregates.size() > 0 || statement.groups.size() > 0) {
 		if (statement.groups.size() > 0) {
 			// visit the groups
-			for (index_t i = 0; i < statement.groups.size(); i++) {
+			for (idx_t i = 0; i < statement.groups.size(); i++) {
 				auto &group = statement.groups[i];
 				PlanSubqueries(&group, &root);
 			}

--- a/src/planner/logical_plan/query_node/plan_setop.cpp
+++ b/src/planner/logical_plan/query_node/plan_setop.cpp
@@ -24,7 +24,7 @@ unique_ptr<LogicalOperator> LogicalPlanGenerator::CastLogicalOperatorToTypes(vec
 		// "node" is a projection; we can just do the casts in there
 		assert(node->expressions.size() == source_types.size());
 		// add the casts to the selection list
-		for (index_t i = 0; i < target_types.size(); i++) {
+		for (idx_t i = 0; i < target_types.size(); i++) {
 			if (source_types[i] != target_types[i]) {
 				// differing types, have to add a cast
 				string alias = node->expressions[i]->alias;
@@ -44,7 +44,7 @@ unique_ptr<LogicalOperator> LogicalPlanGenerator::CastLogicalOperatorToTypes(vec
 
 		// now generate the expression list
 		vector<unique_ptr<Expression>> select_list;
-		for (index_t i = 0; i < target_types.size(); i++) {
+		for (idx_t i = 0; i < target_types.size(); i++) {
 			unique_ptr<Expression> result =
 			    make_unique<BoundColumnRefExpression>(GetInternalType(source_types[i]), setop_columns[i]);
 			if (source_types[i] != target_types[i]) {

--- a/src/planner/logical_plan/statement/plan_update.cpp
+++ b/src/planner/logical_plan/statement/plan_update.cpp
@@ -27,7 +27,7 @@ unique_ptr<LogicalOperator> LogicalPlanGenerator::CreatePlan(BoundUpdateStatemen
 	// scan the table for the referenced columns in the update clause
 	auto &table = get.table;
 	vector<unique_ptr<Expression>> projection_expressions;
-	for (index_t i = 0; i < stmt.expressions.size(); i++) {
+	for (idx_t i = 0; i < stmt.expressions.size(); i++) {
 		if (stmt.expressions[i]->type != ExpressionType::VALUE_DEFAULT) {
 			// plan subqueries inside the expression
 			PlanSubqueries(&stmt.expressions[i], &root);

--- a/src/planner/logical_plan/tableref/plan_joinref.cpp
+++ b/src/planner/logical_plan/tableref/plan_joinref.cpp
@@ -16,8 +16,8 @@ using namespace duckdb;
 using namespace std;
 
 //! Create a JoinCondition from a comparison
-static bool CreateJoinCondition(Expression &expr, unordered_set<index_t> &left_bindings,
-                                unordered_set<index_t> &right_bindings, vector<JoinCondition> &conditions) {
+static bool CreateJoinCondition(Expression &expr, unordered_set<idx_t> &left_bindings,
+                                unordered_set<idx_t> &right_bindings, vector<JoinCondition> &conditions) {
 	// comparison
 	auto &comparison = (BoundComparisonExpression &)expr;
 	auto left_side = JoinSide::GetJoinSide(*comparison.left, left_bindings, right_bindings);
@@ -43,13 +43,13 @@ static bool CreateJoinCondition(Expression &expr, unordered_set<index_t> &left_b
 
 unique_ptr<LogicalOperator> LogicalComparisonJoin::CreateJoin(JoinType type, unique_ptr<LogicalOperator> left_child,
                                                               unique_ptr<LogicalOperator> right_child,
-                                                              unordered_set<index_t> &left_bindings,
-                                                              unordered_set<index_t> &right_bindings,
+                                                              unordered_set<idx_t> &left_bindings,
+                                                              unordered_set<idx_t> &right_bindings,
                                                               vector<unique_ptr<Expression>> &expressions) {
 	vector<JoinCondition> conditions;
 	vector<unique_ptr<Expression>> arbitrary_expressions;
 	// first check if we can create
-	for (index_t i = 0; i < expressions.size(); i++) {
+	for (idx_t i = 0; i < expressions.size(); i++) {
 		auto &expr = expressions[i];
 		auto total_side = JoinSide::GetJoinSide(*expr, left_bindings, right_bindings);
 		if (total_side != JoinSide::BOTH) {
@@ -132,7 +132,7 @@ unique_ptr<LogicalOperator> LogicalComparisonJoin::CreateJoin(JoinType type, uni
 		// AND all the arbitrary expressions together
 		// do the same with any remaining conditions
 		any_join->condition = move(arbitrary_expressions[0]);
-		for (index_t i = 1; i < arbitrary_expressions.size(); i++) {
+		for (idx_t i = 1; i < arbitrary_expressions.size(); i++) {
 			any_join->condition = make_unique<BoundConjunctionExpression>(
 			    ExpressionType::CONJUNCTION_AND, move(any_join->condition), move(arbitrary_expressions[i]));
 		}
@@ -156,7 +156,7 @@ unique_ptr<LogicalOperator> LogicalPlanGenerator::CreatePlan(BoundJoinRef &ref) 
 
 		auto filter = make_unique<LogicalFilter>(move(ref.condition));
 		// visit the expressions in the filter
-		for (index_t i = 0; i < filter->expressions.size(); i++) {
+		for (idx_t i = 0; i < filter->expressions.size(); i++) {
 			PlanSubqueries(&filter->expressions[i], &root);
 		}
 		filter->AddChild(move(root));
@@ -169,7 +169,7 @@ unique_ptr<LogicalOperator> LogicalPlanGenerator::CreatePlan(BoundJoinRef &ref) 
 	LogicalFilter::SplitPredicates(expressions);
 
 	// find the table bindings on the LHS and RHS of the join
-	unordered_set<index_t> left_bindings, right_bindings;
+	unordered_set<idx_t> left_bindings, right_bindings;
 	LogicalJoin::GetTableReferences(*left, left_bindings);
 	LogicalJoin::GetTableReferences(*right, right_bindings);
 	// now create the join operator from the set of join conditions
@@ -189,7 +189,7 @@ unique_ptr<LogicalOperator> LogicalPlanGenerator::CreatePlan(BoundJoinRef &ref) 
 		// in this join we visit the expressions on the LHS with the LHS as root node
 		// and the expressions on the RHS with the RHS as root node
 		auto &comp_join = (LogicalComparisonJoin &)*join;
-		for (index_t i = 0; i < comp_join.conditions.size(); i++) {
+		for (idx_t i = 0; i < comp_join.conditions.size(); i++) {
 			PlanSubqueries(&comp_join.conditions[i].left, &comp_join.children[0]);
 			PlanSubqueries(&comp_join.conditions[i].right, &comp_join.children[1]);
 		}

--- a/src/planner/operator/logical_aggregate.cpp
+++ b/src/planner/operator/logical_aggregate.cpp
@@ -4,8 +4,7 @@
 using namespace duckdb;
 using namespace std;
 
-LogicalAggregate::LogicalAggregate(index_t group_index, index_t aggregate_index,
-                                   vector<unique_ptr<Expression>> select_list)
+LogicalAggregate::LogicalAggregate(idx_t group_index, idx_t aggregate_index, vector<unique_ptr<Expression>> select_list)
     : LogicalOperator(LogicalOperatorType::AGGREGATE_AND_GROUP_BY, move(select_list)), group_index(group_index),
       aggregate_index(aggregate_index) {
 }
@@ -22,10 +21,10 @@ void LogicalAggregate::ResolveTypes() {
 
 vector<ColumnBinding> LogicalAggregate::GetColumnBindings() {
 	vector<ColumnBinding> result;
-	for (index_t i = 0; i < groups.size(); i++) {
+	for (idx_t i = 0; i < groups.size(); i++) {
 		result.push_back(ColumnBinding(group_index, i));
 	}
-	for (index_t i = 0; i < expressions.size(); i++) {
+	for (idx_t i = 0; i < expressions.size(); i++) {
 		result.push_back(ColumnBinding(aggregate_index, i));
 	}
 	return result;

--- a/src/planner/operator/logical_filter.cpp
+++ b/src/planner/operator/logical_filter.cpp
@@ -26,12 +26,12 @@ vector<ColumnBinding> LogicalFilter::GetColumnBindings() {
 // be true
 bool LogicalFilter::SplitPredicates(vector<unique_ptr<Expression>> &expressions) {
 	bool found_conjunction = false;
-	for (index_t i = 0; i < expressions.size(); i++) {
+	for (idx_t i = 0; i < expressions.size(); i++) {
 		if (expressions[i]->type == ExpressionType::CONJUNCTION_AND) {
 			auto &conjunction = (BoundConjunctionExpression &)*expressions[i];
 			found_conjunction = true;
 			// AND expression, append the other children
-			for (index_t k = 1; k < conjunction.children.size(); k++) {
+			for (idx_t k = 1; k < conjunction.children.size(); k++) {
 				expressions.push_back(move(conjunction.children[k]));
 			}
 			// replace this expression with the first child of the conjunction

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -6,10 +6,10 @@
 using namespace duckdb;
 using namespace std;
 
-LogicalGet::LogicalGet(index_t table_index)
+LogicalGet::LogicalGet(idx_t table_index)
     : LogicalOperator(LogicalOperatorType::GET), table(nullptr), table_index(table_index) {
 }
-LogicalGet::LogicalGet(TableCatalogEntry *table, index_t table_index, vector<column_t> column_ids)
+LogicalGet::LogicalGet(TableCatalogEntry *table, idx_t table_index, vector<column_t> column_ids)
     : LogicalOperator(LogicalOperatorType::GET), table(table), table_index(table_index), column_ids(column_ids) {
 }
 
@@ -25,7 +25,7 @@ vector<ColumnBinding> LogicalGet::GetColumnBindings() {
 		return {ColumnBinding(INVALID_INDEX, 0)};
 	}
 	vector<ColumnBinding> result;
-	for (index_t i = 0; i < column_ids.size(); i++) {
+	for (idx_t i = 0; i < column_ids.size(); i++) {
 		result.push_back(ColumnBinding(table_index, i));
 	}
 	return result;
@@ -39,7 +39,7 @@ void LogicalGet::ResolveTypes() {
 	}
 }
 
-index_t LogicalGet::EstimateCardinality() {
+idx_t LogicalGet::EstimateCardinality() {
 	if (table) {
 		return table->storage->cardinality;
 	} else {

--- a/src/planner/operator/logical_join.cpp
+++ b/src/planner/operator/logical_join.cpp
@@ -43,14 +43,14 @@ void LogicalJoin::ResolveTypes() {
 	types.insert(types.end(), right_types.begin(), right_types.end());
 }
 
-void LogicalJoin::GetTableReferences(LogicalOperator &op, unordered_set<index_t> &bindings) {
+void LogicalJoin::GetTableReferences(LogicalOperator &op, unordered_set<idx_t> &bindings) {
 	auto column_bindings = op.GetColumnBindings();
 	for (auto binding : column_bindings) {
 		bindings.insert(binding.table_index);
 	}
 }
 
-void LogicalJoin::GetExpressionBindings(Expression &expr, unordered_set<index_t> &bindings) {
+void LogicalJoin::GetExpressionBindings(Expression &expr, unordered_set<idx_t> &bindings) {
 	if (expr.type == ExpressionType::BOUND_COLUMN_REF) {
 		auto &colref = (BoundColumnRefExpression &)expr;
 		assert(colref.depth == 0);

--- a/src/planner/operator/logical_projection.cpp
+++ b/src/planner/operator/logical_projection.cpp
@@ -3,7 +3,7 @@
 using namespace duckdb;
 using namespace std;
 
-LogicalProjection::LogicalProjection(index_t table_index, vector<unique_ptr<Expression>> select_list)
+LogicalProjection::LogicalProjection(idx_t table_index, vector<unique_ptr<Expression>> select_list)
     : LogicalOperator(LogicalOperatorType::PROJECTION, move(select_list)), table_index(table_index) {
 }
 

--- a/src/planner/operator/logical_window.cpp
+++ b/src/planner/operator/logical_window.cpp
@@ -5,7 +5,7 @@ using namespace std;
 
 vector<ColumnBinding> LogicalWindow::GetColumnBindings() {
 	auto child_bindings = children[0]->GetColumnBindings();
-	for (index_t i = 0; i < expressions.size(); i++) {
+	for (idx_t i = 0; i < expressions.size(); i++) {
 		child_bindings.push_back(ColumnBinding(window_index, i));
 	}
 	return child_bindings;

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -25,7 +25,7 @@ Planner::Planner(ClientContext &context) : binder(context), context(context) {
 }
 
 bool Planner::StatementIsReadOnly(BoundSQLStatement &statement) {
-	switch(statement.type) {
+	switch (statement.type) {
 	case StatementType::INSERT:
 	case StatementType::COPY:
 	case StatementType::DELETE:
@@ -39,22 +39,22 @@ bool Planner::StatementIsReadOnly(BoundSQLStatement &statement) {
 		return false;
 	case StatementType::DROP: {
 		// dropping prepared statements is a read-only action
-		auto &drop_info = (DropInfo&) (*((BoundSimpleStatement&) statement).info);
+		auto &drop_info = (DropInfo &)(*((BoundSimpleStatement &)statement).info);
 		return drop_info.type == CatalogType::PREPARED_STATEMENT;
 	}
 	case StatementType::EXECUTE:
 		// execute statement: look into the to-be-executed statement
-		return ((BoundExecuteStatement&) statement).prepared->read_only;
+		return ((BoundExecuteStatement &)statement).prepared->read_only;
 	default:
 		return true;
 	}
 }
 
 bool Planner::StatementRequiresValidTransaction(BoundSQLStatement &statement) {
-	switch(statement.type) {
+	switch (statement.type) {
 	case StatementType::DROP: {
 		// dropping prepared statements also does not require a valid transaction
-		auto &drop_info = (DropInfo&) (*((BoundSimpleStatement&) statement).info);
+		auto &drop_info = (DropInfo &)(*((BoundSimpleStatement &)statement).info);
 		return drop_info.type == CatalogType::PREPARED_STATEMENT;
 	}
 	case StatementType::PREPARE:
@@ -63,7 +63,7 @@ bool Planner::StatementRequiresValidTransaction(BoundSQLStatement &statement) {
 		return false;
 	case StatementType::EXECUTE:
 		// execute statement: look into the to-be-executed statement
-		return ((BoundExecuteStatement&) statement).prepared->requires_valid_transaction;
+		return ((BoundExecuteStatement &)statement).prepared->requires_valid_transaction;
 	default:
 		return true;
 	}
@@ -206,9 +206,9 @@ void Planner::VerifyNode(BoundQueryNode &node) {
 		}
 
 		// double loop to verify that (in)equality of hashes
-		for (index_t i = 0; i < copies.size(); i++) {
+		for (idx_t i = 0; i < copies.size(); i++) {
 			auto outer_hash = copies[i]->Hash();
-			for (index_t j = 0; j < copies.size(); j++) {
+			for (idx_t j = 0; j < copies.size(); j++) {
 				auto inner_hash = copies[j]->Hash();
 				if (outer_hash != inner_hash) {
 					// if hashes are not equivalent the expressions should not be equivalent

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -16,7 +16,7 @@ using namespace std;
 
 FlattenDependentJoins::FlattenDependentJoins(Binder &binder, const vector<CorrelatedColumnInfo> &correlated)
     : binder(binder), correlated_columns(correlated) {
-	for (index_t i = 0; i < correlated_columns.size(); i++) {
+	for (idx_t i = 0; i < correlated_columns.size(); i++) {
 		auto &col = correlated_columns[i];
 		correlated_map[col.binding] = i;
 		delim_types.push_back(col.type);
@@ -88,7 +88,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 		rewriter.VisitOperator(*plan);
 		// now we add all the columns of the delim_scan to the projection list
 		auto proj = (LogicalProjection *)plan.get();
-		for (index_t i = 0; i < correlated_columns.size(); i++) {
+		for (idx_t i = 0; i < correlated_columns.size(); i++) {
 			auto colref = make_unique<BoundColumnRefExpression>(
 			    correlated_columns[i].type, ColumnBinding(base_binding.table_index, base_binding.column_index + i));
 			plan->expressions.push_back(move(colref));
@@ -108,7 +108,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 		RewriteCorrelatedExpressions rewriter(base_binding, correlated_map);
 		rewriter.VisitOperator(*plan);
 		// now we add all the columns of the delim_scan to the grouping operators AND the projection list
-		for (index_t i = 0; i < correlated_columns.size(); i++) {
+		for (idx_t i = 0; i < correlated_columns.size(); i++) {
 			auto colref = make_unique<BoundColumnRefExpression>(
 			    correlated_columns[i].type, ColumnBinding(base_binding.table_index, base_binding.column_index + i));
 			aggr.groups.push_back(move(colref));
@@ -120,7 +120,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 			auto delim_scan = make_unique<LogicalDelimGet>(left_index, delim_types);
 			left_outer_join->children.push_back(move(delim_scan));
 			left_outer_join->children.push_back(move(plan));
-			for (index_t i = 0; i < correlated_columns.size(); i++) {
+			for (idx_t i = 0; i < correlated_columns.size(); i++) {
 				JoinCondition cond;
 				cond.left =
 				    make_unique<BoundColumnRefExpression>(correlated_columns[i].type, ColumnBinding(left_index, i));
@@ -133,7 +133,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 			}
 			// for any COUNT aggregate we replace references to the column with: CASE WHEN COUNT(*) IS NULL THEN 0
 			// ELSE COUNT(*) END
-			for (index_t i = 0; i < aggr.expressions.size(); i++) {
+			for (idx_t i = 0; i < aggr.expressions.size(); i++) {
 				assert(aggr.expressions[i]->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
 				auto bound = (BoundAggregateExpression *)&*aggr.expressions[i];
 				vector<SQLType> arguments;
@@ -178,7 +178,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 		auto left_binding = this->base_binding;
 		plan->children[1] = PushDownDependentJoinInternal(move(plan->children[1]));
 		// add the correlated columns to the join conditions
-		for (index_t i = 0; i < correlated_columns.size(); i++) {
+		for (idx_t i = 0; i < correlated_columns.size(); i++) {
 			JoinCondition cond;
 			cond.left = make_unique<BoundColumnRefExpression>(
 			    correlated_columns[i].type, ColumnBinding(left_binding.table_index, left_binding.column_index + i));
@@ -244,7 +244,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 			this->base_binding = left_binding;
 		}
 		// add the correlated columns to the join conditions
-		for (index_t i = 0; i < correlated_columns.size(); i++) {
+		for (idx_t i = 0; i < correlated_columns.size(); i++) {
 			JoinCondition cond;
 
 			cond.left = make_unique<BoundColumnRefExpression>(
@@ -282,7 +282,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 		for (auto &expr : window.expressions) {
 			assert(expr->GetExpressionClass() == ExpressionClass::BOUND_WINDOW);
 			auto &w = (BoundWindowExpression &)*expr;
-			for (index_t i = 0; i < correlated_columns.size(); i++) {
+			for (idx_t i = 0; i < correlated_columns.size(); i++) {
 				w.partitions.push_back(make_unique<BoundColumnRefExpression>(
 				    correlated_columns[i].type,
 				    ColumnBinding(base_binding.table_index, base_binding.column_index + i)));

--- a/src/planner/subquery/has_correlated_expressions.cpp
+++ b/src/planner/subquery/has_correlated_expressions.cpp
@@ -32,7 +32,7 @@ unique_ptr<Expression> HasCorrelatedExpressions::VisitReplace(BoundSubqueryExpre
 		return nullptr;
 	}
 	// check if the subquery contains any of the correlated expressions that we are concerned about in this node
-	for (index_t i = 0; i < correlated_columns.size(); i++) {
+	for (idx_t i = 0; i < correlated_columns.size(); i++) {
 		if (std::find(expr.binder->correlated_columns.begin(), expr.binder->correlated_columns.end(),
 		              correlated_columns[i]) != expr.binder->correlated_columns.end()) {
 			has_correlated_expressions = true;

--- a/src/planner/subquery/rewrite_correlated_expressions.cpp
+++ b/src/planner/subquery/rewrite_correlated_expressions.cpp
@@ -11,7 +11,7 @@ using namespace duckdb;
 using namespace std;
 
 RewriteCorrelatedExpressions::RewriteCorrelatedExpressions(ColumnBinding base_binding,
-                                                           column_binding_map_t<index_t> &correlated_map)
+                                                           column_binding_map_t<idx_t> &correlated_map)
     : base_binding(base_binding), correlated_map(correlated_map) {
 }
 
@@ -48,7 +48,7 @@ unique_ptr<Expression> RewriteCorrelatedExpressions::VisitReplace(BoundSubqueryE
 }
 
 RewriteCorrelatedExpressions::RewriteCorrelatedRecursive::RewriteCorrelatedRecursive(
-    BoundSubqueryExpression &parent, ColumnBinding base_binding, column_binding_map_t<index_t> &correlated_map)
+    BoundSubqueryExpression &parent, ColumnBinding base_binding, column_binding_map_t<idx_t> &correlated_map)
     : parent(parent), base_binding(base_binding), correlated_map(correlated_map) {
 }
 
@@ -93,7 +93,7 @@ void RewriteCorrelatedExpressions::RewriteCorrelatedRecursive::RewriteCorrelated
 	}
 }
 
-RewriteCountAggregates::RewriteCountAggregates(column_binding_map_t<index_t> &replacement_map)
+RewriteCountAggregates::RewriteCountAggregates(column_binding_map_t<idx_t> &replacement_map)
     : replacement_map(replacement_map) {
 }
 

--- a/src/planner/table_binding.cpp
+++ b/src/planner/table_binding.cpp
@@ -21,7 +21,7 @@ bool TableBinding::HasMatchingBinding(const string &column_name) {
 	return bound->table->ColumnExists(column_name);
 }
 
-BindResult TableBinding::Bind(ColumnRefExpression &colref, index_t depth) {
+BindResult TableBinding::Bind(ColumnRefExpression &colref, idx_t depth) {
 	auto entry = bound->table->name_map.find(colref.column_name);
 	if (entry == bound->table->name_map.end()) {
 		return BindResult(StringUtil::Format("Table \"%s\" does not have a column named \"%s\"",
@@ -42,7 +42,7 @@ BindResult TableBinding::Bind(ColumnRefExpression &colref, index_t depth) {
 	ColumnBinding binding;
 
 	binding.column_index = column_list.size();
-	for (index_t i = 0; i < column_list.size(); i++) {
+	for (idx_t i = 0; i < column_list.size(); i++) {
 		auto &column = column_list[i];
 		if (column == colref.column_name) {
 			binding.column_index = i;
@@ -69,13 +69,13 @@ void TableBinding::GenerateAllColumnExpressions(BindContext &context,
 	}
 }
 
-SubqueryBinding::SubqueryBinding(const string &alias, SubqueryRef &ref, BoundQueryNode &subquery, index_t index)
+SubqueryBinding::SubqueryBinding(const string &alias, SubqueryRef &ref, BoundQueryNode &subquery, idx_t index)
     : Binding(BindingType::SUBQUERY, alias, index), subquery(subquery) {
 	if (ref.column_name_alias.size() > subquery.names.size()) {
 		throw BinderException("table \"%s\" has %lld columns available but %lld columns specified", alias.c_str(),
 		                      (int64_t)subquery.names.size(), (int64_t)ref.column_name_alias.size());
 	}
-	index_t i;
+	idx_t i;
 	// use any provided aliases from the subquery
 	for (i = 0; i < ref.column_name_alias.size(); i++) {
 		auto &name = ref.column_name_alias[i];
@@ -101,7 +101,7 @@ bool SubqueryBinding::HasMatchingBinding(const string &column_name) {
 	return entry != name_map.end();
 }
 
-BindResult SubqueryBinding::Bind(ColumnRefExpression &colref, index_t depth) {
+BindResult SubqueryBinding::Bind(ColumnRefExpression &colref, idx_t depth) {
 	auto column_entry = name_map.find(colref.column_name);
 	if (column_entry == name_map.end()) {
 		return BindResult(StringUtil::Format("Subquery \"%s\" does not have a column named \"%s\"", alias.c_str(),
@@ -124,7 +124,7 @@ void SubqueryBinding::GenerateAllColumnExpressions(BindContext &context,
 	}
 }
 
-TableFunctionBinding::TableFunctionBinding(const string &alias, TableFunctionCatalogEntry *function, index_t index)
+TableFunctionBinding::TableFunctionBinding(const string &alias, TableFunctionCatalogEntry *function, idx_t index)
     : Binding(BindingType::TABLE_FUNCTION, alias, index), function(function) {
 }
 
@@ -132,7 +132,7 @@ bool TableFunctionBinding::HasMatchingBinding(const string &column_name) {
 	return function->ColumnExists(column_name);
 }
 
-BindResult TableFunctionBinding::Bind(ColumnRefExpression &colref, index_t depth) {
+BindResult TableFunctionBinding::Bind(ColumnRefExpression &colref, idx_t depth) {
 	auto column_entry = function->name_map.find(colref.column_name);
 	if (column_entry == function->name_map.end()) {
 		return BindResult(StringUtil::Format("Table Function \"%s\" does not have a column named \"%s\"", alias.c_str(),
@@ -153,10 +153,10 @@ void TableFunctionBinding::GenerateAllColumnExpressions(BindContext &context,
 	}
 }
 
-GenericBinding::GenericBinding(const string &alias, vector<SQLType> coltypes, vector<string> colnames, index_t index)
+GenericBinding::GenericBinding(const string &alias, vector<SQLType> coltypes, vector<string> colnames, idx_t index)
     : Binding(BindingType::GENERIC, alias, index), types(move(coltypes)), names(move(colnames)) {
 	assert(types.size() == names.size());
-	for (index_t i = 0; i < names.size(); i++) {
+	for (idx_t i = 0; i < names.size(); i++) {
 		auto &name = names[i];
 		if (name_map.find(name) != name_map.end()) {
 			throw BinderException("table \"%s\" has duplicate column name \"%s\"", alias.c_str(), name.c_str());
@@ -170,7 +170,7 @@ bool GenericBinding::HasMatchingBinding(const string &column_name) {
 	return entry != name_map.end();
 }
 
-BindResult GenericBinding::Bind(ColumnRefExpression &colref, index_t depth) {
+BindResult GenericBinding::Bind(ColumnRefExpression &colref, idx_t depth) {
 	auto column_entry = name_map.find(colref.column_name);
 	if (column_entry == name_map.end()) {
 		return BindResult(StringUtil::Format("Values list \"%s\" does not have a column named \"%s\"", alias.c_str(),

--- a/src/storage/buffer/managed_buffer.cpp
+++ b/src/storage/buffer/managed_buffer.cpp
@@ -4,7 +4,7 @@
 using namespace duckdb;
 using namespace std;
 
-ManagedBuffer::ManagedBuffer(BufferManager &manager, index_t size, bool can_destroy, block_id_t id)
+ManagedBuffer::ManagedBuffer(BufferManager &manager, idx_t size, bool can_destroy, block_id_t id)
     : FileBuffer(FileBufferType::MANAGED_BUFFER, size), manager(manager), can_destroy(can_destroy), id(id) {
 	assert(id >= MAXIMUM_BLOCK);
 	assert(size >= Storage::BLOCK_ALLOC_SIZE);

--- a/src/storage/checkpoint/table_data_reader.cpp
+++ b/src/storage/checkpoint/table_data_reader.cpp
@@ -23,16 +23,16 @@ void TableDataReader::ReadTableData() {
 	assert(columns.size() > 0);
 
 	// load the data pointers for the table
-	for (index_t col = 0; col < columns.size(); col++) {
+	for (idx_t col = 0; col < columns.size(); col++) {
 		auto &column = columns[col];
-		index_t data_pointer_count = reader.Read<index_t>();
-		for (index_t data_ptr = 0; data_ptr < data_pointer_count; data_ptr++) {
+		idx_t data_pointer_count = reader.Read<idx_t>();
+		for (idx_t data_ptr = 0; data_ptr < data_pointer_count; data_ptr++) {
 			// read the data pointer
 			DataPointer data_pointer;
 			data_pointer.min = reader.Read<double>();
 			data_pointer.max = reader.Read<double>();
-			data_pointer.row_start = reader.Read<index_t>();
-			data_pointer.tuple_count = reader.Read<index_t>();
+			data_pointer.row_start = reader.Read<idx_t>();
+			data_pointer.tuple_count = reader.Read<idx_t>();
 			data_pointer.block_id = reader.Read<block_id_t>();
 			data_pointer.offset = reader.Read<uint32_t>();
 			// create a persistent segment

--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -25,9 +25,9 @@ public:
 	//! The current block we are writing to
 	block_id_t block_id;
 	//! The offset within the current block
-	index_t offset;
+	idx_t offset;
 
-	static constexpr index_t STRING_SPACE = Storage::BLOCK_SIZE - sizeof(block_id_t);
+	static constexpr idx_t STRING_SPACE = Storage::BLOCK_SIZE - sizeof(block_id_t);
 
 public:
 	void WriteString(string_t string, block_id_t &result_block, int32_t &result_offset) override;
@@ -47,7 +47,7 @@ void TableDataWriter::WriteTableData(Transaction &transaction) {
 	// allocate segments to write the table to
 	segments.resize(table.columns.size());
 	data_pointers.resize(table.columns.size());
-	for (index_t i = 0; i < table.columns.size(); i++) {
+	for (idx_t i = 0; i < table.columns.size(); i++) {
 		auto type_id = GetInternalType(table.columns[i].type);
 		stats.push_back(make_unique<SegmentStatistics>(type_id, GetTypeIdSize(type_id)));
 		CreateSegment(i);
@@ -74,19 +74,19 @@ void TableDataWriter::WriteTableData(Transaction &transaction) {
 			break;
 		}
 		// for each column, we append whatever we can fit into the block
-		for (index_t i = 0; i < table.columns.size(); i++) {
+		for (idx_t i = 0; i < table.columns.size(); i++) {
 			assert(chunk.data[i].type == GetInternalType(table.columns[i].type));
 			AppendData(i, chunk.data[i]);
 		}
 	}
 	// flush any remaining data and write the data pointers to disk
-	for (index_t i = 0; i < table.columns.size(); i++) {
+	for (idx_t i = 0; i < table.columns.size(); i++) {
 		FlushSegment(i);
 	}
 	WriteDataPointers();
 }
 
-void TableDataWriter::CreateSegment(index_t col_idx) {
+void TableDataWriter::CreateSegment(idx_t col_idx) {
 	auto type_id = GetInternalType(table.columns[col_idx].type);
 	if (type_id == TypeId::VARCHAR) {
 		auto string_segment = make_unique<StringSegment>(manager.buffer_manager, 0);
@@ -97,11 +97,11 @@ void TableDataWriter::CreateSegment(index_t col_idx) {
 	}
 }
 
-void TableDataWriter::AppendData(index_t col_idx, Vector &data) {
-	index_t count = data.count;
-	index_t offset = 0;
+void TableDataWriter::AppendData(idx_t col_idx, Vector &data) {
+	idx_t count = data.count;
+	idx_t offset = 0;
 	while (offset < count) {
-		index_t appended = segments[col_idx]->Append(*stats[col_idx], data, offset, count);
+		idx_t appended = segments[col_idx]->Append(*stats[col_idx], data, offset, count);
 		if (appended == count) {
 			// appended everything: finished
 			return;
@@ -116,7 +116,7 @@ void TableDataWriter::AppendData(index_t col_idx, Vector &data) {
 	}
 }
 
-void TableDataWriter::FlushSegment(index_t col_idx) {
+void TableDataWriter::FlushSegment(idx_t col_idx) {
 	auto tuple_count = segments[col_idx]->tuple_count;
 	if (tuple_count == 0) {
 		return;
@@ -144,17 +144,17 @@ void TableDataWriter::FlushSegment(index_t col_idx) {
 }
 
 void TableDataWriter::WriteDataPointers() {
-	for (index_t i = 0; i < data_pointers.size(); i++) {
+	for (idx_t i = 0; i < data_pointers.size(); i++) {
 		// get a reference to the data column
 		auto &data_pointer_list = data_pointers[i];
-		manager.tabledata_writer->Write<index_t>(data_pointer_list.size());
+		manager.tabledata_writer->Write<idx_t>(data_pointer_list.size());
 		// then write the data pointers themselves
-		for (index_t k = 0; k < data_pointer_list.size(); k++) {
+		for (idx_t k = 0; k < data_pointer_list.size(); k++) {
 			auto &data_pointer = data_pointer_list[k];
 			manager.tabledata_writer->Write<double>(data_pointer.min);
 			manager.tabledata_writer->Write<double>(data_pointer.max);
-			manager.tabledata_writer->Write<index_t>(data_pointer.row_start);
-			manager.tabledata_writer->Write<index_t>(data_pointer.tuple_count);
+			manager.tabledata_writer->Write<idx_t>(data_pointer.row_start);
+			manager.tabledata_writer->Write<idx_t>(data_pointer.tuple_count);
 			manager.tabledata_writer->Write<block_id_t>(data_pointer.block_id);
 			manager.tabledata_writer->Write<uint32_t>(data_pointer.offset);
 		}

--- a/src/storage/column_data.cpp
+++ b/src/storage/column_data.cpp
@@ -72,11 +72,11 @@ void ColumnData::InitializeAppend(ColumnAppendState &state) {
 }
 
 void ColumnData::Append(ColumnAppendState &state, Vector &vector) {
-	index_t offset = 0;
-	index_t count = vector.count;
+	idx_t offset = 0;
+	idx_t count = vector.count;
 	while (true) {
 		// append the data from the vector
-		index_t copied_elements = state.current->Append(state, vector, offset, count);
+		idx_t copied_elements = state.current->Append(state, vector, offset, count);
 		if (copied_elements == count) {
 			// finished copying everything
 			break;
@@ -97,7 +97,7 @@ void ColumnData::Append(ColumnAppendState &state, Vector &vector) {
 void ColumnData::RevertAppend(row_t start_row) {
 	lock_guard<mutex> tree_lock(data.node_lock);
 	// find the segment index that the current row belongs to
-	index_t segment_index = data.GetSegmentIndex(start_row);
+	idx_t segment_index = data.GetSegmentIndex(start_row);
 	auto segment = data.nodes[segment_index].node;
 	auto &transient = (TransientSegment &)*segment;
 	assert(transient.segment_type == ColumnSegmentType::TRANSIENT);
@@ -112,7 +112,7 @@ void ColumnData::RevertAppend(row_t start_row) {
 
 void ColumnData::Update(Transaction &transaction, Vector &updates, row_t *ids) {
 	// first find the segment that the update belongs to
-	index_t first_id = ids[updates.sel_vector ? updates.sel_vector[0] : 0];
+	idx_t first_id = ids[updates.sel_vector ? updates.sel_vector[0] : 0];
 	auto segment = (ColumnSegment *)data.GetSegment(first_id);
 	// now perform the update within the segment
 	segment->Update(*this, transaction, updates, ids);
@@ -133,7 +133,7 @@ void ColumnData::FetchRow(ColumnFetchState &state, Transaction &transaction, row
 	segment->FetchRow(state, transaction, row_id, result);
 }
 
-void ColumnData::AppendTransientSegment(index_t start_row) {
+void ColumnData::AppendTransientSegment(idx_t start_row) {
 	auto new_segment = make_unique<TransientSegment>(*table->storage.buffer_manager, type, start_row);
 	data.AppendSegment(move(new_segment));
 }

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -20,7 +20,7 @@ DataTable::DataTable(StorageManager &storage, string schema, string table, vecto
       transient_manager(*this) {
 	// set up the segment trees for the column segments
 	columns = unique_ptr<ColumnData[]>(new ColumnData[types.size()]);
-	for (index_t i = 0; i < types.size(); i++) {
+	for (idx_t i = 0; i < types.size(); i++) {
 		columns[i].type = types[i];
 		columns[i].table = this;
 		columns[i].column_idx = i;
@@ -29,7 +29,7 @@ DataTable::DataTable(StorageManager &storage, string schema, string table, vecto
 	// initialize the table with the existing data from disk, if any
 	if (data && data[0].size() > 0) {
 		// first append all the segments to the set of column segments
-		for (index_t i = 0; i < types.size(); i++) {
+		for (idx_t i = 0; i < types.size(); i++) {
 			columns[i].Initialize(data[i]);
 			if (columns[i].persistent_rows != columns[0].persistent_rows) {
 				throw Exception("Column length mismatch in table load!");
@@ -46,7 +46,7 @@ DataTable::DataTable(StorageManager &storage, string schema, string table, vecto
 void DataTable::InitializeScan(TableScanState &state, vector<column_t> column_ids) {
 	// initialize a column scan state for each column
 	state.column_scans = unique_ptr<ColumnScanState[]>(new ColumnScanState[column_ids.size()]);
-	for (index_t i = 0; i < column_ids.size(); i++) {
+	for (idx_t i = 0; i < column_ids.size(); i++) {
 		auto column = column_ids[i];
 		if (column != COLUMN_IDENTIFIER_ROW_ID) {
 			columns[column].InitializeScan(state.column_scans[i]);
@@ -86,19 +86,19 @@ void DataTable::Scan(Transaction &transaction, DataChunk &result, TableScanState
 	transaction.storage.Scan(state.local_state, state.column_ids, result);
 }
 
-bool DataTable::ScanBaseTable(Transaction &transaction, DataChunk &result, TableScanState &state, index_t &current_row,
-                              index_t max_row, index_t base_row, VersionManager &manager) {
+bool DataTable::ScanBaseTable(Transaction &transaction, DataChunk &result, TableScanState &state, idx_t &current_row,
+                              idx_t max_row, idx_t base_row, VersionManager &manager) {
 	if (current_row >= max_row) {
 		// exceeded the amount of rows to scan
 		return false;
 	}
-	index_t max_count = std::min((index_t)STANDARD_VECTOR_SIZE, max_row - current_row);
-	index_t vector_offset = current_row / STANDARD_VECTOR_SIZE;
+	idx_t max_count = std::min((idx_t)STANDARD_VECTOR_SIZE, max_row - current_row);
+	idx_t vector_offset = current_row / STANDARD_VECTOR_SIZE;
 	// first scan the version chunk manager to figure out which tuples to load for this transaction
-	index_t count = manager.GetSelVector(transaction, vector_offset, state.sel_vector, max_count);
+	idx_t count = manager.GetSelVector(transaction, vector_offset, state.sel_vector, max_count);
 	if (count == 0) {
 		// nothing to scan for this vector, skip the entire vector
-		for (index_t i = 0; i < state.column_ids.size(); i++) {
+		for (idx_t i = 0; i < state.column_ids.size(); i++) {
 			auto column = state.column_ids[i];
 			if (column != COLUMN_IDENTIFIER_ROW_ID) {
 				state.column_scans[i].Next();
@@ -110,7 +110,7 @@ bool DataTable::ScanBaseTable(Transaction &transaction, DataChunk &result, Table
 
 	sel_t *sel_vector = count == max_count ? nullptr : state.sel_vector;
 	// now scan the base columns to fetch the actual data
-	for (index_t i = 0; i < state.column_ids.size(); i++) {
+	for (idx_t i = 0; i < state.column_ids.size(); i++) {
 		auto column = state.column_ids[i];
 		if (column == COLUMN_IDENTIFIER_ROW_ID) {
 			// scan row id
@@ -172,26 +172,26 @@ void DataTable::Fetch(Transaction &transaction, DataChunk &result, vector<column
                       Vector &row_identifiers, TableIndexScanState &state) {
 	// first figure out which row identifiers we should use for this transaction by looking at the VersionManagers
 	row_t rows[STANDARD_VECTOR_SIZE];
-	index_t count = FetchRows(transaction, row_identifiers, rows);
+	idx_t count = FetchRows(transaction, row_identifiers, rows);
 
 	if (count == 0) {
 		// no rows to use
 		return;
 	}
 	// for each of the remaining rows, now fetch the data
-	for (index_t col_idx = 0; col_idx < column_ids.size(); col_idx++) {
+	for (idx_t col_idx = 0; col_idx < column_ids.size(); col_idx++) {
 		auto column = column_ids[col_idx];
 		if (column == COLUMN_IDENTIFIER_ROW_ID) {
 			// row id column: fill in the row ids
 			assert(result.data[col_idx].type == TypeId::INT64);
 			result.data[col_idx].count = count;
 			auto data = (row_t *)result.data[col_idx].GetData();
-			for (index_t i = 0; i < count; i++) {
+			for (idx_t i = 0; i < count; i++) {
 				data[i] = rows[i];
 			}
 		} else {
 			// regular column: fetch data from the base column
-			for (index_t i = 0; i < count; i++) {
+			for (idx_t i = 0; i < count; i++) {
 				auto row_id = rows[i];
 				columns[column].FetchRow(state.fetch_state, transaction, row_id, result.data[col_idx]);
 			}
@@ -199,7 +199,7 @@ void DataTable::Fetch(Transaction &transaction, DataChunk &result, vector<column
 	}
 }
 
-index_t DataTable::FetchRows(Transaction &transaction, Vector &row_identifiers, row_t result_rows[]) {
+idx_t DataTable::FetchRows(Transaction &transaction, Vector &row_identifiers, row_t result_rows[]) {
 	assert(row_identifiers.type == ROW_TYPE);
 
 	// obtain a read lock on the version managers
@@ -207,13 +207,13 @@ index_t DataTable::FetchRows(Transaction &transaction, Vector &row_identifiers, 
 	auto l2 = transient_manager.lock.GetSharedLock();
 
 	// now iterate over the row ids and figure out which rows to use
-	index_t count = 0;
+	idx_t count = 0;
 
 	auto row_ids = (row_t *)row_identifiers.GetData();
-	VectorOperations::Exec(row_identifiers, [&](index_t i, index_t k) {
+	VectorOperations::Exec(row_identifiers, [&](idx_t i, idx_t k) {
 		auto row_id = row_ids[i];
 		bool use_row;
-		if ((index_t)row_id < persistent_manager.max_row) {
+		if ((idx_t)row_id < persistent_manager.max_row) {
 			// persistent row: use persistent manager
 			use_row = persistent_manager.Fetch(transaction, row_id);
 		} else {
@@ -249,8 +249,8 @@ static void VerifyCheckConstraint(TableCatalogEntry &table, Expression &expr, Da
 	}
 
 	auto dataptr = (int *)result.GetData();
-	for (index_t i = 0; i < result.count; i++) {
-		index_t index = result.sel_vector ? result.sel_vector[i] : i;
+	for (idx_t i = 0; i < result.count; i++) {
+		idx_t index = result.sel_vector ? result.sel_vector[i] : i;
 		if (!result.nullmask[index] && dataptr[index] == 0) {
 			throw ConstraintException("CHECK constraint failed: %s", table.name.c_str());
 		}
@@ -307,12 +307,12 @@ void DataTable::InitializeAppend(TableAppendState &state) {
 	state.append_lock = unique_lock<mutex>(append_lock);
 	// obtain locks on all indexes for the table
 	state.index_locks = unique_ptr<IndexLock[]>(new IndexLock[indexes.size()]);
-	for (index_t i = 0; i < indexes.size(); i++) {
+	for (idx_t i = 0; i < indexes.size(); i++) {
 		indexes[i]->InitializeLock(state.index_locks[i]);
 	}
 	// for each column, initialize the append state
 	state.states = unique_ptr<ColumnAppendState[]>(new ColumnAppendState[types.size()]);
-	for (index_t i = 0; i < types.size(); i++) {
+	for (idx_t i = 0; i < types.size(); i++) {
 		columns[i].InitializeAppend(state.states[i]);
 	}
 	state.row_start = transient_manager.max_row;
@@ -327,7 +327,7 @@ void DataTable::Append(Transaction &transaction, transaction_t commit_id, DataCh
 	transient_manager.Append(transaction, state.current_row, chunk.size(), commit_id);
 
 	// append the physical data to each of the entries
-	for (index_t i = 0; i < types.size(); i++) {
+	for (idx_t i = 0; i < types.size(); i++) {
 		columns[i].Append(state.states[i], chunk.data[i]);
 	}
 	cardinality += chunk.size();
@@ -340,7 +340,7 @@ void DataTable::RevertAppend(TableAppendState &state) {
 		return;
 	}
 	// revert changes in the base columns
-	for (index_t i = 0; i < types.size(); i++) {
+	for (idx_t i = 0; i < types.size(); i++) {
 		columns[i].RevertAppend(state.row_start);
 	}
 	// adjust the cardinality
@@ -363,9 +363,9 @@ bool DataTable::AppendToIndexes(TableAppendState &state, DataChunk &chunk, row_t
 	row_identifiers.count = chunk.size();
 	VectorOperations::GenerateSequence(row_identifiers, row_start, 1, true);
 
-	index_t failed_index = INVALID_INDEX;
+	idx_t failed_index = INVALID_INDEX;
 	// now append the entries to the indices
-	for (index_t i = 0; i < indexes.size(); i++) {
+	for (idx_t i = 0; i < indexes.size(); i++) {
 		if (!indexes[i]->Append(state.index_locks[i], chunk, row_identifiers)) {
 			failed_index = i;
 			break;
@@ -374,7 +374,7 @@ bool DataTable::AppendToIndexes(TableAppendState &state, DataChunk &chunk, row_t
 	if (failed_index != INVALID_INDEX) {
 		// constraint violation!
 		// remove any appended entries from previous indexes (if any)
-		for (index_t i = 0; i < failed_index; i++) {
+		for (idx_t i = 0; i < failed_index; i++) {
 			indexes[i]->Delete(state.index_locks[i], chunk, row_identifiers);
 		}
 		return false;
@@ -397,7 +397,7 @@ void DataTable::RemoveFromIndexes(TableAppendState &state, DataChunk &chunk, row
 }
 
 void DataTable::RemoveFromIndexes(TableAppendState &state, DataChunk &chunk, Vector &row_identifiers) {
-	for (index_t i = 0; i < indexes.size(); i++) {
+	for (idx_t i = 0; i < indexes.size(); i++) {
 		indexes[i]->Delete(state.index_locks[i], chunk, row_identifiers);
 	}
 }
@@ -407,7 +407,7 @@ void DataTable::RemoveFromIndexes(Vector &row_identifiers) {
 	auto row_ids = (row_t *)row_identifiers.GetData();
 	// create a selection vector from the row_ids
 	sel_t sel[STANDARD_VECTOR_SIZE];
-	for (index_t i = 0; i < row_identifiers.count; i++) {
+	for (idx_t i = 0; i < row_identifiers.count; i++) {
 		sel[i] = row_ids[i] % STANDARD_VECTOR_SIZE;
 	}
 
@@ -416,13 +416,13 @@ void DataTable::RemoveFromIndexes(Vector &row_identifiers) {
 	result.Initialize(types);
 	// FIXME: we do not need to fetch all columns, only the columns required by the indices!
 	auto states = unique_ptr<ColumnScanState[]>(new ColumnScanState[types.size()]);
-	for (index_t i = 0; i < types.size(); i++) {
+	for (idx_t i = 0; i < types.size(); i++) {
 		columns[i].Fetch(states[i], row_ids[0], result.data[i]);
 		result.data[i].count = row_identifiers.count;
 		result.data[i].sel_vector = sel;
 	}
 	result.sel_vector = sel;
-	for (index_t i = 0; i < indexes.size(); i++) {
+	for (idx_t i = 0; i < indexes.size(); i++) {
 		indexes[i]->Delete(result, row_identifiers);
 	}
 }
@@ -446,7 +446,7 @@ void DataTable::Delete(TableCatalogEntry &table, ClientContext &context, Vector 
 	if (first_id >= MAX_ROW_ID) {
 		// deletion is in transaction-local storage: push delete into local chunk collection
 		transaction.storage.Delete(this, row_identifiers);
-	} else if ((index_t)first_id < persistent_manager.max_row) {
+	} else if ((idx_t)first_id < persistent_manager.max_row) {
 		// deletion is in persistent storage: delete in the persistent version manager
 		persistent_manager.Delete(transaction, row_identifiers);
 	} else {
@@ -471,7 +471,7 @@ static void CreateMockChunk(vector<TypeId> &types, vector<column_t> &column_ids,
 
 static bool CreateMockChunk(TableCatalogEntry &table, vector<column_t> &column_ids,
                             unordered_set<column_t> &desired_column_ids, DataChunk &chunk, DataChunk &mock_chunk) {
-	index_t found_columns = 0;
+	idx_t found_columns = 0;
 	// check whether the desired columns are present in the UPDATE clause
 	for (column_t i = 0; i < column_ids.size(); i++) {
 		if (desired_column_ids.find(column_ids[i]) != desired_column_ids.end()) {
@@ -500,7 +500,7 @@ void DataTable::VerifyUpdateConstraints(TableCatalogEntry &table, DataChunk &chu
 		case ConstraintType::NOT_NULL: {
 			auto &not_null = *reinterpret_cast<BoundNotNullConstraint *>(constraint.get());
 			// check if the constraint is in the list of column_ids
-			for (index_t i = 0; i < column_ids.size(); i++) {
+			for (idx_t i = 0; i < column_ids.size(); i++) {
 				if (column_ids[i] == not_null.index) {
 					// found the column id: check the data in
 					VerifyNotNullConstraint(table, chunk.data[i], table.columns[not_null.index].name);
@@ -528,7 +528,7 @@ void DataTable::VerifyUpdateConstraints(TableCatalogEntry &table, DataChunk &chu
 	// update should not be called for indexed columns!
 	// instead update should have been rewritten to delete + update on higher layer
 #ifdef DEBUG
-	for (index_t i = 0; i < indexes.size(); i++) {
+	for (idx_t i = 0; i < indexes.size(); i++) {
 		assert(!indexes[i]->IndexIsUpdated(column_ids));
 	}
 #endif
@@ -561,7 +561,7 @@ void DataTable::Update(TableCatalogEntry &table, ClientContext &context, Vector 
 		return;
 	}
 
-	for (index_t i = 0; i < column_ids.size(); i++) {
+	for (idx_t i = 0; i < column_ids.size(); i++) {
 		auto column = column_ids[i];
 		assert(column != COLUMN_IDENTIFIER_ROW_ID);
 
@@ -594,17 +594,17 @@ void DataTable::CreateIndexScan(CreateIndexScanState &state, DataChunk &result) 
 	}
 }
 
-bool DataTable::ScanCreateIndex(CreateIndexScanState &state, DataChunk &result, index_t &current_row, index_t max_row,
-                                index_t base_row) {
+bool DataTable::ScanCreateIndex(CreateIndexScanState &state, DataChunk &result, idx_t &current_row, idx_t max_row,
+                                idx_t base_row) {
 	if (current_row >= max_row) {
 		return false;
 	}
-	index_t count = std::min((index_t)STANDARD_VECTOR_SIZE, max_row - current_row);
+	idx_t count = std::min((idx_t)STANDARD_VECTOR_SIZE, max_row - current_row);
 
 	// scan the base columns to fetch the actual data
 	// note that we insert all data into the index, even if it is marked as deleted
 	// FIXME: tuples that are already "cleaned up" do not need to be inserted into the index!
-	for (index_t i = 0; i < state.column_ids.size(); i++) {
+	for (idx_t i = 0; i < state.column_ids.size(); i++) {
 		auto column = state.column_ids[i];
 		if (column == COLUMN_IDENTIFIER_ROW_ID) {
 			// scan row id

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -57,8 +57,8 @@ void LocalStorage::Scan(LocalScanState &state, const vector<column_t> &column_id
 		return;
 	}
 	auto &chunk = *state.storage->collection.chunks[state.chunk_index];
-	index_t chunk_count = state.chunk_index == state.max_index ? state.last_chunk_count : chunk.size();
-	index_t count = chunk_count;
+	idx_t chunk_count = state.chunk_index == state.max_index ? state.last_chunk_count : chunk.size();
+	idx_t count = chunk_count;
 
 	// first create a selection vector from the deleted entries (if any)
 	sel_t *sel_vector = nullptr;
@@ -67,8 +67,8 @@ void LocalStorage::Scan(LocalScanState &state, const vector<column_t> &column_id
 		// deleted entries! create a selection vector
 		auto deleted = entry->second.get();
 		sel_vector = state.sel_vector_data;
-		index_t new_count = 0;
-		for (index_t i = 0; i < count; i++) {
+		idx_t new_count = 0;
+		for (idx_t i = 0; i < count; i++) {
 			if (!deleted[i]) {
 				sel_vector[new_count++] = i;
 			}
@@ -77,7 +77,7 @@ void LocalStorage::Scan(LocalScanState &state, const vector<column_t> &column_id
 	}
 
 	// now scan the vectors of the chunk
-	for (index_t i = 0; i < column_ids.size(); i++) {
+	for (idx_t i = 0; i < column_ids.size(); i++) {
 		auto id = column_ids[i];
 		if (id == COLUMN_IDENTIFIER_ROW_ID) {
 			// row identifier: return a sequence of rowids starting from MAX_ROW_ID plus the row offset in the chunk
@@ -104,7 +104,7 @@ void LocalStorage::Append(DataTable *table, DataChunk &chunk) {
 	}
 	// append to unique indices (if any)
 	if (storage->indexes.size() > 0) {
-		index_t base_id = MAX_ROW_ID + storage->collection.count;
+		idx_t base_id = MAX_ROW_ID + storage->collection.count;
 
 		// first generate the vector of row identifiers
 		Vector row_identifiers(ROW_TYPE);
@@ -130,16 +130,16 @@ LocalTableStorage *LocalStorage::GetStorage(DataTable *table) {
 	return entry->second.get();
 }
 
-static index_t GetChunk(Vector &row_identifiers) {
+static idx_t GetChunk(Vector &row_identifiers) {
 	row_identifiers.Normalify();
 	auto ids = (row_t *)row_identifiers.GetData();
 	auto first_id = ids[row_identifiers.sel_vector ? row_identifiers.sel_vector[0] : 0] - MAX_ROW_ID;
 
-	index_t chunk_idx = first_id / STANDARD_VECTOR_SIZE;
+	idx_t chunk_idx = first_id / STANDARD_VECTOR_SIZE;
 	// verify that all row ids belong to the same chunk
 #ifdef DEBUG
-	VectorOperations::Exec(row_identifiers, [&](index_t i, index_t k) {
-		index_t idx = (ids[i] - MAX_ROW_ID) / STANDARD_VECTOR_SIZE;
+	VectorOperations::Exec(row_identifiers, [&](idx_t i, idx_t k) {
+		idx_t idx = (ids[i] - MAX_ROW_ID) / STANDARD_VECTOR_SIZE;
 		assert(idx == chunk_idx);
 	});
 #endif
@@ -149,7 +149,7 @@ static index_t GetChunk(Vector &row_identifiers) {
 void LocalStorage::Delete(DataTable *table, Vector &row_identifiers) {
 	auto storage = GetStorage(table);
 	// figure out the chunk from which these row ids came
-	index_t chunk_idx = GetChunk(row_identifiers);
+	idx_t chunk_idx = GetChunk(row_identifiers);
 	assert(chunk_idx < storage->collection.chunks.size());
 
 	// get a pointer to the deleted entries for this chunk
@@ -166,27 +166,27 @@ void LocalStorage::Delete(DataTable *table, Vector &row_identifiers) {
 	}
 
 	// now actually mark the entries as deleted in the deleted vector
-	index_t base_index = MAX_ROW_ID + chunk_idx * STANDARD_VECTOR_SIZE;
+	idx_t base_index = MAX_ROW_ID + chunk_idx * STANDARD_VECTOR_SIZE;
 
 	auto ids = (row_t *)row_identifiers.GetData();
-	VectorOperations::Exec(row_identifiers, [&](index_t i, index_t k) {
+	VectorOperations::Exec(row_identifiers, [&](idx_t i, idx_t k) {
 		auto id = ids[i] - base_index;
 		deleted[id] = true;
 	});
 }
 
 template <class T>
-static void update_data(Vector &data_vector, Vector &update_vector, Vector &row_identifiers, index_t base_index) {
+static void update_data(Vector &data_vector, Vector &update_vector, Vector &row_identifiers, idx_t base_index) {
 	auto target = (T *)data_vector.GetData();
 	auto updates = (T *)update_vector.GetData();
 	auto ids = (row_t *)row_identifiers.GetData();
-	VectorOperations::Exec(row_identifiers, [&](index_t i, index_t k) {
+	VectorOperations::Exec(row_identifiers, [&](idx_t i, idx_t k) {
 		auto id = ids[i] - base_index;
 		target[id] = updates[i];
 	});
 }
 
-static void update_chunk(Vector &data, Vector &updates, Vector &row_identifiers, index_t base_index) {
+static void update_chunk(Vector &data, Vector &updates, Vector &row_identifiers, idx_t base_index) {
 	assert(data.type == updates.type);
 	assert(row_identifiers.type == ROW_TYPE);
 	assert(updates.sel_vector == row_identifiers.sel_vector);
@@ -218,14 +218,14 @@ static void update_chunk(Vector &data, Vector &updates, Vector &row_identifiers,
 void LocalStorage::Update(DataTable *table, Vector &row_identifiers, vector<column_t> &column_ids, DataChunk &data) {
 	auto storage = GetStorage(table);
 	// figure out the chunk from which these row ids came
-	index_t chunk_idx = GetChunk(row_identifiers);
+	idx_t chunk_idx = GetChunk(row_identifiers);
 	assert(chunk_idx < storage->collection.chunks.size());
 
-	index_t base_index = MAX_ROW_ID + chunk_idx * STANDARD_VECTOR_SIZE;
+	idx_t base_index = MAX_ROW_ID + chunk_idx * STANDARD_VECTOR_SIZE;
 
 	// now perform the actual update
 	auto &chunk = *storage->collection.chunks[chunk_idx];
-	for (index_t i = 0; i < column_ids.size(); i++) {
+	for (idx_t i = 0; i < column_ids.size(); i++) {
 		auto col_idx = column_ids[i];
 		update_chunk(chunk.data[col_idx], data.data[i], row_identifiers, base_index);
 	}
@@ -233,7 +233,7 @@ void LocalStorage::Update(DataTable *table, Vector &row_identifiers, vector<colu
 
 template <class T> bool LocalStorage::ScanTableStorage(DataTable *table, LocalTableStorage *storage, T &&fun) {
 	vector<column_t> column_ids;
-	for (index_t i = 0; i < table->types.size(); i++) {
+	for (idx_t i = 0; i < table->types.size(); i++) {
 		column_ids.push_back(i);
 	}
 

--- a/src/storage/meta_block_reader.cpp
+++ b/src/storage/meta_block_reader.cpp
@@ -10,11 +10,11 @@ MetaBlockReader::MetaBlockReader(BufferManager &manager, block_id_t block_id)
 	ReadNewBlock(block_id);
 }
 
-void MetaBlockReader::ReadData(data_ptr_t buffer, index_t read_size) {
+void MetaBlockReader::ReadData(data_ptr_t buffer, idx_t read_size) {
 	while (offset + read_size > handle->node->size) {
 		// cannot read entire entry from block
 		// first read what we can from this block
-		index_t to_read = handle->node->size - offset;
+		idx_t to_read = handle->node->size - offset;
 		if (to_read > 0) {
 			memcpy(buffer, handle->node->buffer + offset, to_read);
 			read_size -= to_read;

--- a/src/storage/meta_block_writer.cpp
+++ b/src/storage/meta_block_writer.cpp
@@ -21,12 +21,12 @@ void MetaBlockWriter::Flush() {
 	}
 }
 
-void MetaBlockWriter::WriteData(const_data_ptr_t buffer, index_t write_size) {
+void MetaBlockWriter::WriteData(const_data_ptr_t buffer, idx_t write_size) {
 	while (offset + write_size > block->size) {
 		// we need to make a new block
 		// first copy what we can
 		assert(offset <= block->size);
-		index_t copy_amount = block->size - offset;
+		idx_t copy_amount = block->size - offset;
 		if (copy_amount > 0) {
 			memcpy(block->buffer + offset, buffer, copy_amount);
 			buffer += copy_amount;

--- a/src/storage/numeric_segment.cpp
+++ b/src/storage/numeric_segment.cpp
@@ -16,7 +16,7 @@ static NumericSegment::rollback_update_function_t GetRollbackUpdateFunction(Type
 static NumericSegment::merge_update_function_t GetMergeUpdateFunction(TypeId type);
 static NumericSegment::update_info_append_function_t GetUpdateInfoAppendFunction(TypeId type);
 
-NumericSegment::NumericSegment(BufferManager &manager, TypeId type, index_t row_start, block_id_t block)
+NumericSegment::NumericSegment(BufferManager &manager, TypeId type, idx_t row_start, block_id_t block)
     : UncompressedSegment(manager, type, row_start) {
 	// set up the different functions for this type of segment
 	this->append_function = GetAppendFunction(type);
@@ -37,7 +37,7 @@ NumericSegment::NumericSegment(BufferManager &manager, TypeId type, index_t row_
 		auto handle = manager.Allocate(Storage::BLOCK_ALLOC_SIZE);
 		this->block_id = handle->block_id;
 		// initialize nullmasks to 0 for all vectors
-		for (index_t i = 0; i < max_vector_count; i++) {
+		for (idx_t i = 0; i < max_vector_count; i++) {
 			auto mask = (nullmask_t *)(handle->node->buffer + (i * vector_size));
 			mask->reset();
 		}
@@ -47,7 +47,7 @@ NumericSegment::NumericSegment(BufferManager &manager, TypeId type, index_t row_
 //===--------------------------------------------------------------------===//
 // Fetch base data
 //===--------------------------------------------------------------------===//
-void NumericSegment::FetchBaseData(ColumnScanState &state, index_t vector_index, Vector &result) {
+void NumericSegment::FetchBaseData(ColumnScanState &state, idx_t vector_index, Vector &result) {
 	assert(vector_index < max_vector_count);
 	assert(vector_index * STANDARD_VECTOR_SIZE <= tuple_count);
 
@@ -57,7 +57,7 @@ void NumericSegment::FetchBaseData(ColumnScanState &state, index_t vector_index,
 
 	auto offset = vector_index * vector_size;
 
-	index_t count = GetVectorCount(vector_index);
+	idx_t count = GetVectorCount(vector_index);
 	// fetch the nullmask and copy the data from the base table
 	result.nullmask = *((nullmask_t *)(data + offset));
 	memcpy(result.GetData(), data + offset + sizeof(nullmask_t), count * type_size);
@@ -77,8 +77,8 @@ void NumericSegment::FetchRow(ColumnFetchState &state, Transaction &transaction,
 	auto handle = manager.Pin(block_id);
 
 	// get the vector index
-	index_t vector_index = row_id / STANDARD_VECTOR_SIZE;
-	index_t id_in_vector = row_id - vector_index * STANDARD_VECTOR_SIZE;
+	idx_t vector_index = row_id / STANDARD_VECTOR_SIZE;
+	idx_t id_in_vector = row_id - vector_index * STANDARD_VECTOR_SIZE;
 	assert(vector_index < max_vector_count);
 
 	// first fetch the data from the base table
@@ -99,19 +99,19 @@ void NumericSegment::FetchRow(ColumnFetchState &state, Transaction &transaction,
 //===--------------------------------------------------------------------===//
 // Append
 //===--------------------------------------------------------------------===//
-index_t NumericSegment::Append(SegmentStatistics &stats, Vector &data, index_t offset, index_t count) {
+idx_t NumericSegment::Append(SegmentStatistics &stats, Vector &data, idx_t offset, idx_t count) {
 	assert(data.type == type);
 	auto handle = manager.Pin(block_id);
 
-	index_t initial_count = tuple_count;
+	idx_t initial_count = tuple_count;
 	while (count > 0) {
 		// get the vector index of the vector to append to and see how many tuples we can append to that vector
-		index_t vector_index = tuple_count / STANDARD_VECTOR_SIZE;
+		idx_t vector_index = tuple_count / STANDARD_VECTOR_SIZE;
 		if (vector_index == max_vector_count) {
 			break;
 		}
-		index_t current_tuple_count = tuple_count - vector_index * STANDARD_VECTOR_SIZE;
-		index_t append_count = std::min(STANDARD_VECTOR_SIZE - current_tuple_count, count);
+		idx_t current_tuple_count = tuple_count - vector_index * STANDARD_VECTOR_SIZE;
+		idx_t append_count = std::min(STANDARD_VECTOR_SIZE - current_tuple_count, count);
 
 		// now perform the actual append
 		append_function(stats, handle->node->buffer + vector_size * vector_index, current_tuple_count, data, offset,
@@ -128,7 +128,7 @@ index_t NumericSegment::Append(SegmentStatistics &stats, Vector &data, index_t o
 // Update
 //===--------------------------------------------------------------------===//
 void NumericSegment::Update(ColumnData &column_data, SegmentStatistics &stats, Transaction &transaction, Vector &update,
-                            row_t *ids, index_t vector_index, index_t vector_offset, UpdateInfo *node) {
+                            row_t *ids, idx_t vector_index, idx_t vector_offset, UpdateInfo *node) {
 	if (!node) {
 		auto handle = manager.Pin(block_id);
 
@@ -170,12 +170,12 @@ template <class T> static void update_min_max(T value, T *__restrict min, T *__r
 
 template <class T>
 static void append_loop_null(T *__restrict source, nullmask_t &result_nullmask, T *__restrict target,
-                             index_t target_offset, index_t offset, index_t count, sel_t *__restrict sel_vector,
+                             idx_t target_offset, idx_t offset, idx_t count, sel_t *__restrict sel_vector,
                              nullmask_t &nullmask, T *__restrict min, T *__restrict max, bool &has_null) {
 	// null values, have to check the NULL values in the mask
 	VectorOperations::Exec(
 	    sel_vector, count + offset,
-	    [&](index_t i, index_t k) {
+	    [&](idx_t i, idx_t k) {
 		    if (nullmask[i]) {
 			    result_nullmask[k - offset + target_offset] = true;
 			    has_null = true;
@@ -188,11 +188,11 @@ static void append_loop_null(T *__restrict source, nullmask_t &result_nullmask, 
 }
 
 template <class T>
-static void append_loop_no_null(T *__restrict source, T *__restrict target, index_t target_offset, index_t offset,
-                                index_t count, sel_t *__restrict sel_vector, T *__restrict min, T *__restrict max) {
+static void append_loop_no_null(T *__restrict source, T *__restrict target, idx_t target_offset, idx_t offset,
+                                idx_t count, sel_t *__restrict sel_vector, T *__restrict min, T *__restrict max) {
 	VectorOperations::Exec(
 	    sel_vector, count + offset,
-	    [&](index_t i, index_t k) {
+	    [&](idx_t i, idx_t k) {
 		    update_min_max(source[i], min, max);
 		    target[k - offset + target_offset] = source[i];
 	    },
@@ -200,8 +200,8 @@ static void append_loop_no_null(T *__restrict source, T *__restrict target, inde
 }
 
 template <class T>
-static void append_loop(SegmentStatistics &stats, data_ptr_t target, index_t target_offset, Vector &source,
-                        index_t offset, index_t count) {
+static void append_loop(SegmentStatistics &stats, data_ptr_t target, idx_t target_offset, Vector &source, idx_t offset,
+                        idx_t count) {
 	assert(offset + count <= source.count);
 	auto ldata = (T *)source.GetData();
 	auto result_data = (T *)(target + sizeof(nullmask_t));
@@ -242,8 +242,8 @@ static NumericSegment::append_function_t GetAppendFunction(TypeId type) {
 template <class T>
 static void update_loop_null(T *__restrict undo_data, T *__restrict base_data, T *__restrict new_data,
                              nullmask_t &undo_nullmask, nullmask_t &base_nullmask, nullmask_t &new_nullmask,
-                             index_t count, sel_t *__restrict base_sel, T *__restrict min, T *__restrict max) {
-	for (index_t i = 0; i < count; i++) {
+                             idx_t count, sel_t *__restrict base_sel, T *__restrict min, T *__restrict max) {
+	for (idx_t i = 0; i < count; i++) {
 		// first move the base data into the undo buffer info
 		undo_data[i] = base_data[base_sel[i]];
 		undo_nullmask[base_sel[i]] = base_nullmask[base_sel[i]];
@@ -256,9 +256,9 @@ static void update_loop_null(T *__restrict undo_data, T *__restrict base_data, T
 }
 
 template <class T>
-static void update_loop_no_null(T *__restrict undo_data, T *__restrict base_data, T *__restrict new_data, index_t count,
+static void update_loop_no_null(T *__restrict undo_data, T *__restrict base_data, T *__restrict new_data, idx_t count,
                                 sel_t *__restrict base_sel, T *__restrict min, T *__restrict max) {
-	for (index_t i = 0; i < count; i++) {
+	for (idx_t i = 0; i < count; i++) {
 		// first move the base data into the undo buffer info
 		undo_data[i] = base_data[base_sel[i]];
 		// now move the new data in-place into the base table
@@ -310,7 +310,7 @@ static NumericSegment::update_function_t GetUpdateFunction(TypeId type) {
 //===--------------------------------------------------------------------===//
 template <class T>
 static void merge_update_loop(SegmentStatistics &stats, UpdateInfo *node, data_ptr_t base, Vector &update, row_t *ids,
-                              index_t vector_offset) {
+                              idx_t vector_offset) {
 	auto &base_nullmask = *((nullmask_t *)base);
 	auto base_data = (T *)(base + sizeof(nullmask_t));
 	auto info_data = (T *)node->tuple_data;
@@ -324,7 +324,7 @@ static void merge_update_loop(SegmentStatistics &stats, UpdateInfo *node, data_p
 	memcpy(old_data, node->tuple_data, node->N * sizeof(T));
 
 	// now we perform a merge of the new ids with the old ids
-	auto merge = [&](index_t id, index_t aidx, index_t bidx, index_t count) {
+	auto merge = [&](idx_t id, idx_t aidx, idx_t bidx, idx_t count) {
 		// new_id and old_id are the same:
 		// insert the new data into the base table
 		base_nullmask[id] = update.nullmask[aidx];
@@ -333,7 +333,7 @@ static void merge_update_loop(SegmentStatistics &stats, UpdateInfo *node, data_p
 		info_data[count] = old_data[bidx];
 		node->tuples[count] = id;
 	};
-	auto pick_new = [&](index_t id, index_t aidx, index_t count) {
+	auto pick_new = [&](idx_t id, idx_t aidx, idx_t count) {
 		// new_id comes before the old id
 		// insert the base table data into the update info
 		info_data[count] = base_data[id];
@@ -345,7 +345,7 @@ static void merge_update_loop(SegmentStatistics &stats, UpdateInfo *node, data_p
 
 		node->tuples[count] = id;
 	};
-	auto pick_old = [&](index_t id, index_t bidx, index_t count) {
+	auto pick_old = [&](idx_t id, idx_t bidx, idx_t count) {
 		// old_id comes before new_id, insert the old data
 		info_data[count] = old_data[bidx];
 		node->tuples[count] = id;
@@ -380,7 +380,7 @@ template <class T> static void update_info_fetch(Transaction &transaction, Updat
 	auto result_data = (T *)result.GetData();
 	UpdateInfo::UpdatesForTransaction(info, transaction, [&](UpdateInfo *current) {
 		auto info_data = (T *)current->tuple_data;
-		for (index_t i = 0; i < current->N; i++) {
+		for (idx_t i = 0; i < current->N; i++) {
 			result_data[current->tuples[i]] = info_data[i];
 			result.nullmask[current->tuples[i]] = current->nullmask[current->tuples[i]];
 		}
@@ -411,12 +411,12 @@ static NumericSegment::update_info_fetch_function_t GetUpdateInfoFetchFunction(T
 // Update Append
 //===--------------------------------------------------------------------===//
 template <class T>
-static void update_info_append(Transaction &transaction, UpdateInfo *info, index_t row_id, Vector &result) {
+static void update_info_append(Transaction &transaction, UpdateInfo *info, idx_t row_id, Vector &result) {
 	auto result_data = (T *)result.GetData();
 	UpdateInfo::UpdatesForTransaction(info, transaction, [&](UpdateInfo *current) {
 		auto info_data = (T *)current->tuple_data;
 		// loop over the tuples in this UpdateInfo
-		for (index_t i = 0; i < current->N; i++) {
+		for (idx_t i = 0; i < current->N; i++) {
 			if (current->tuples[i] == row_id) {
 				// found the relevant tuple
 				result_data[result.count] = info_data[i];
@@ -458,7 +458,7 @@ template <class T> static void rollback_update(UpdateInfo *info, data_ptr_t base
 	auto info_data = (T *)info->tuple_data;
 	auto base_data = (T *)(base + sizeof(nullmask_t));
 
-	for (index_t i = 0; i < info->N; i++) {
+	for (idx_t i = 0; i < info->N; i++) {
 		base_data[info->tuples[i]] = info_data[i];
 		nullmask[info->tuples[i]] = info->nullmask[info->tuples[i]];
 	}

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -106,7 +106,7 @@ void SingleFileBlockManager::LoadFreeList(BufferManager &manager) {
 	MetaBlockReader reader(manager, free_list_id);
 	auto free_list_count = reader.Read<uint64_t>();
 	free_list.reserve(free_list_count);
-	for (index_t i = 0; i < free_list_count; i++) {
+	for (idx_t i = 0; i < free_list_count; i++) {
 		free_list.push_back(reader.Read<block_id_t>());
 	}
 }

--- a/src/storage/string_segment.cpp
+++ b/src/storage/string_segment.cpp
@@ -7,7 +7,7 @@
 using namespace duckdb;
 using namespace std;
 
-StringSegment::StringSegment(BufferManager &manager, index_t row_start, block_id_t block)
+StringSegment::StringSegment(BufferManager &manager, idx_t row_start, block_id_t block)
     : UncompressedSegment(manager, TypeId::VARCHAR, row_start) {
 	this->max_vector_count = 0;
 	this->dictionary_offset = 0;
@@ -47,7 +47,7 @@ void StringSegment::ExpandStringSegment(data_ptr_t baseptr) {
 
 	if (string_updates) {
 		auto new_string_updates = unique_ptr<string_update_info_t[]>(new string_update_info_t[max_vector_count]);
-		for (index_t i = 0; i < max_vector_count - 1; i++) {
+		for (idx_t i = 0; i < max_vector_count - 1; i++) {
 			new_string_updates[i] = move(string_updates[i]);
 		}
 		new_string_updates[max_vector_count - 1] = 0;
@@ -66,7 +66,7 @@ void StringSegment::InitializeScan(ColumnScanState &state) {
 //===--------------------------------------------------------------------===//
 // Fetch base data
 //===--------------------------------------------------------------------===//
-void StringSegment::FetchBaseData(ColumnScanState &state, index_t vector_index, Vector &result) {
+void StringSegment::FetchBaseData(ColumnScanState &state, idx_t vector_index, Vector &result) {
 	// clear any previously locked buffers and get the primary buffer handle
 	auto handle = state.primary_handle.get();
 	state.handles.clear();
@@ -75,8 +75,8 @@ void StringSegment::FetchBaseData(ColumnScanState &state, index_t vector_index, 
 	FetchBaseData(state, handle->node->buffer, vector_index, result, GetVectorCount(vector_index));
 }
 
-void StringSegment::FetchBaseData(ColumnScanState &state, data_ptr_t baseptr, index_t vector_index, Vector &result,
-                                  index_t count) {
+void StringSegment::FetchBaseData(ColumnScanState &state, data_ptr_t baseptr, idx_t vector_index, Vector &result,
+                                  idx_t count) {
 	auto base = baseptr + vector_index * vector_size;
 
 	auto &base_nullmask = *((nullmask_t *)base);
@@ -86,8 +86,8 @@ void StringSegment::FetchBaseData(ColumnScanState &state, data_ptr_t baseptr, in
 	if (string_updates && string_updates[vector_index]) {
 		// there are updates: merge them in
 		auto &info = *string_updates[vector_index];
-		index_t update_idx = 0;
-		for (index_t i = 0; i < count; i++) {
+		idx_t update_idx = 0;
+		for (idx_t i = 0; i < count; i++) {
 			if (update_idx < info.count && info.ids[update_idx] == i) {
 				// use update info
 				result_data[i] = ReadString(state.handles, info.block_ids[update_idx], info.offsets[update_idx]).data;
@@ -99,7 +99,7 @@ void StringSegment::FetchBaseData(ColumnScanState &state, data_ptr_t baseptr, in
 		}
 	} else {
 		// no updates: fetch only from the string dictionary
-		for (index_t i = 0; i < count; i++) {
+		for (idx_t i = 0; i < count; i++) {
 			result_data[i] = FetchStringFromDict(state.handles, baseptr, base_data[i]).data;
 		}
 	}
@@ -118,7 +118,7 @@ void StringSegment::FetchUpdateData(ColumnScanState &state, Transaction &transac
 	auto result_data = (char **)result.GetData();
 	UpdateInfo::UpdatesForTransaction(info, transaction, [&](UpdateInfo *current) {
 		auto info_data = (string_location_t *)current->tuple_data;
-		for (index_t i = 0; i < current->N; i++) {
+		for (idx_t i = 0; i < current->N; i++) {
 			auto string = FetchString(state.handles, handle->node->buffer, info_data[i]);
 			result_data[current->tuples[i]] = string.data;
 			result.nullmask[current->tuples[i]] = current->nullmask[current->tuples[i]];
@@ -129,16 +129,16 @@ void StringSegment::FetchUpdateData(ColumnScanState &state, Transaction &transac
 //===--------------------------------------------------------------------===//
 // Fetch strings
 //===--------------------------------------------------------------------===//
-void StringSegment::FetchStringLocations(data_ptr_t baseptr, row_t *ids, index_t vector_index, index_t vector_offset,
-                                         index_t count, string_location_t result[]) {
+void StringSegment::FetchStringLocations(data_ptr_t baseptr, row_t *ids, idx_t vector_index, idx_t vector_offset,
+                                         idx_t count, string_location_t result[]) {
 	auto base = baseptr + vector_index * vector_size;
 	auto base_data = (int32_t *)(base + sizeof(nullmask_t));
 
 	if (string_updates && string_updates[vector_index]) {
 		// there are updates: merge them in
 		auto &info = *string_updates[vector_index];
-		index_t update_idx = 0;
-		for (index_t i = 0; i < count; i++) {
+		idx_t update_idx = 0;
+		for (idx_t i = 0; i < count; i++) {
 			auto id = ids[i] - vector_offset;
 			while (update_idx < info.count && info.ids[update_idx] < id) {
 				update_idx++;
@@ -155,7 +155,7 @@ void StringSegment::FetchStringLocations(data_ptr_t baseptr, row_t *ids, index_t
 		}
 	} else {
 		// no updates: fetch strings from base vector
-		for (index_t i = 0; i < count; i++) {
+		for (idx_t i = 0; i < count; i++) {
 			auto id = ids[i] - vector_offset;
 			result[i] = FetchStringLocation(baseptr, base_data[id]);
 		}
@@ -209,8 +209,8 @@ string_t StringSegment::FetchString(buffer_handle_set_t &handles, data_ptr_t bas
 void StringSegment::FetchRow(ColumnFetchState &state, Transaction &transaction, row_t row_id, Vector &result) {
 	auto read_lock = lock.GetSharedLock();
 
-	index_t vector_index = row_id / STANDARD_VECTOR_SIZE;
-	index_t id_in_vector = row_id - vector_index * STANDARD_VECTOR_SIZE;
+	idx_t vector_index = row_id / STANDARD_VECTOR_SIZE;
+	idx_t id_in_vector = row_id - vector_index * STANDARD_VECTOR_SIZE;
 	assert(vector_index < max_vector_count);
 
 	data_ptr_t baseptr;
@@ -239,7 +239,7 @@ void StringSegment::FetchRow(ColumnFetchState &state, Transaction &transaction, 
 		UpdateInfo::UpdatesForTransaction(versions[vector_index], transaction, [&](UpdateInfo *current) {
 			auto info_data = (string_location_t *)current->tuple_data;
 			// loop over the tuples in this UpdateInfo
-			for (index_t i = 0; i < current->N; i++) {
+			for (idx_t i = 0; i < current->N; i++) {
 				if (current->tuples[i] == row_id) {
 					// found the relevant tuple
 					auto string = FetchString(state.handles, baseptr, info_data[i]);
@@ -258,7 +258,7 @@ void StringSegment::FetchRow(ColumnFetchState &state, Transaction &transaction, 
 		if (string_updates && string_updates[vector_index]) {
 			// there are updates: check if we should use them
 			auto &info = *string_updates[vector_index];
-			for (index_t i = 0; i < info.count; i++) {
+			for (idx_t i = 0; i < info.count; i++) {
 				if (info.ids[i] == id_in_vector) {
 					// use the update
 					result_data[result.count] = ReadString(state.handles, info.block_ids[i], info.offsets[i]).data;
@@ -279,14 +279,14 @@ void StringSegment::FetchRow(ColumnFetchState &state, Transaction &transaction, 
 //===--------------------------------------------------------------------===//
 // Append
 //===--------------------------------------------------------------------===//
-index_t StringSegment::Append(SegmentStatistics &stats, Vector &data, index_t offset, index_t count) {
+idx_t StringSegment::Append(SegmentStatistics &stats, Vector &data, idx_t offset, idx_t count) {
 	assert(data.type == TypeId::VARCHAR);
 	auto handle = manager.Pin(block_id);
 
-	index_t initial_count = tuple_count;
+	idx_t initial_count = tuple_count;
 	while (count > 0) {
 		// get the vector index of the vector to append to and see how many tuples we can append to that vector
-		index_t vector_index = tuple_count / STANDARD_VECTOR_SIZE;
+		idx_t vector_index = tuple_count / STANDARD_VECTOR_SIZE;
 		if (vector_index == max_vector_count) {
 			// we are at the maximum vector, check if there is space to increase the maximum vector count
 			// as a heuristic, we only allow another vector to be added if we have at least 32 bytes per string
@@ -298,8 +298,8 @@ index_t StringSegment::Append(SegmentStatistics &stats, Vector &data, index_t of
 				break;
 			}
 		}
-		index_t current_tuple_count = tuple_count - vector_index * STANDARD_VECTOR_SIZE;
-		index_t append_count = std::min(STANDARD_VECTOR_SIZE - current_tuple_count, count);
+		idx_t current_tuple_count = tuple_count - vector_index * STANDARD_VECTOR_SIZE;
+		idx_t append_count = std::min(STANDARD_VECTOR_SIZE - current_tuple_count, count);
 
 		// now perform the actual append
 		AppendData(stats, handle->node->buffer + vector_size * vector_index, handle->node->buffer + Storage::BLOCK_SIZE,
@@ -312,17 +312,17 @@ index_t StringSegment::Append(SegmentStatistics &stats, Vector &data, index_t of
 	return tuple_count - initial_count;
 }
 
-void StringSegment::AppendData(SegmentStatistics &stats, data_ptr_t target, data_ptr_t end, index_t target_offset,
-                               Vector &source, index_t offset, index_t count) {
+void StringSegment::AppendData(SegmentStatistics &stats, data_ptr_t target, data_ptr_t end, idx_t target_offset,
+                               Vector &source, idx_t offset, idx_t count) {
 	assert(offset + count <= source.count);
 	auto ldata = (char **)source.GetData();
 	auto &result_nullmask = *((nullmask_t *)target);
 	auto result_data = (int32_t *)(target + sizeof(nullmask_t));
 
-	index_t remaining_strings = STANDARD_VECTOR_SIZE - (this->tuple_count % STANDARD_VECTOR_SIZE);
+	idx_t remaining_strings = STANDARD_VECTOR_SIZE - (this->tuple_count % STANDARD_VECTOR_SIZE);
 	VectorOperations::Exec(
 	    source.sel_vector, count + offset,
-	    [&](index_t i, index_t k) {
+	    [&](idx_t i, idx_t k) {
 		    if (source.nullmask[i]) {
 			    // null value is stored as -1
 			    result_data[k - offset + target_offset] = 0;
@@ -331,8 +331,8 @@ void StringSegment::AppendData(SegmentStatistics &stats, data_ptr_t target, data
 		    } else {
 			    assert(dictionary_offset < Storage::BLOCK_SIZE);
 			    // non-null value, check if we can fit it within the block
-			    index_t string_length = strlen(ldata[i]);
-			    index_t total_length = string_length + 1 + sizeof(uint16_t);
+			    idx_t string_length = strlen(ldata[i]);
+			    idx_t total_length = string_length + 1 + sizeof(uint16_t);
 
 			    if (string_length > stats.max_string_length) {
 				    stats.max_string_length = string_length;
@@ -396,7 +396,7 @@ void StringSegment::WriteStringMemory(string_t string, block_id_t &result_block,
 	if (!head || head->offset + total_length >= head->size) {
 		// string does not fit, allocate space for it
 		// create a new string block
-		index_t alloc_size = std::max((index_t)total_length, (index_t)Storage::BLOCK_ALLOC_SIZE);
+		idx_t alloc_size = std::max((idx_t)total_length, (idx_t)Storage::BLOCK_ALLOC_SIZE);
 		auto new_block = make_unique<StringBlock>();
 		new_block->offset = 0;
 		new_block->size = alloc_size;
@@ -435,7 +435,7 @@ string_t StringSegment::ReadString(buffer_handle_set_t &handles, block_id_t bloc
 		offset += sizeof(uint32_t);
 
 		// allocate a buffer to store the string
-		auto alloc_size = std::max((index_t)Storage::BLOCK_ALLOC_SIZE, (index_t)length + 1 + sizeof(uint32_t));
+		auto alloc_size = std::max((idx_t)Storage::BLOCK_ALLOC_SIZE, (idx_t)length + 1 + sizeof(uint32_t));
 		auto target_handle = manager.Allocate(alloc_size, true);
 		auto target_ptr = target_handle->node->buffer;
 		// write the length in this block as well
@@ -443,8 +443,7 @@ string_t StringSegment::ReadString(buffer_handle_set_t &handles, block_id_t bloc
 		target_ptr += sizeof(uint32_t);
 		// now append the string to the single buffer
 		while (remaining > 0) {
-			index_t to_write =
-			    std::min((index_t)remaining, (index_t)(Storage::BLOCK_SIZE - sizeof(block_id_t) - offset));
+			idx_t to_write = std::min((idx_t)remaining, (idx_t)(Storage::BLOCK_SIZE - sizeof(block_id_t) - offset));
 			memcpy(target_ptr, handle->node->buffer + offset, to_write);
 
 			remaining -= to_write;
@@ -506,11 +505,11 @@ void StringSegment::ReadStringMarker(data_ptr_t target, block_id_t &block_id, in
 // String Update
 //===--------------------------------------------------------------------===//
 string_update_info_t StringSegment::CreateStringUpdate(SegmentStatistics &stats, Vector &update, row_t *ids,
-                                                       index_t vector_offset) {
+                                                       idx_t vector_offset) {
 	auto info = make_unique<StringUpdateInfo>();
 	info->count = update.count;
 	auto strings = (char **)update.GetData();
-	for (index_t i = 0; i < update.count; i++) {
+	for (idx_t i = 0; i < update.count; i++) {
 		info->ids[i] = ids[i] - vector_offset;
 		// copy the string into the block
 		if (!update.nullmask[i]) {
@@ -524,12 +523,12 @@ string_update_info_t StringSegment::CreateStringUpdate(SegmentStatistics &stats,
 }
 
 string_update_info_t StringSegment::MergeStringUpdate(SegmentStatistics &stats, Vector &update, row_t *ids,
-                                                      index_t vector_offset, StringUpdateInfo &update_info) {
+                                                      idx_t vector_offset, StringUpdateInfo &update_info) {
 	auto info = make_unique<StringUpdateInfo>();
 
 	// perform a merge between the new and old indexes
 	auto strings = (char **)update.GetData();
-	auto pick_new = [&](index_t id, index_t idx, index_t count) {
+	auto pick_new = [&](idx_t id, idx_t idx, idx_t count) {
 		info->ids[count] = id;
 		if (!update.nullmask[idx]) {
 			WriteString(string_t(strings[idx], strlen(strings[idx])), info->block_ids[count], info->offsets[count]);
@@ -538,11 +537,11 @@ string_update_info_t StringSegment::MergeStringUpdate(SegmentStatistics &stats, 
 			info->offsets[count] = 0;
 		}
 	};
-	auto merge = [&](index_t id, index_t aidx, index_t bidx, index_t count) {
+	auto merge = [&](idx_t id, idx_t aidx, idx_t bidx, idx_t count) {
 		// merge: only pick new entry
 		pick_new(id, aidx, count);
 	};
-	auto pick_old = [&](index_t id, index_t bidx, index_t count) {
+	auto pick_old = [&](idx_t id, idx_t bidx, idx_t count) {
 		// pick old entry
 		info->ids[count] = id;
 		info->block_ids[count] = update_info.block_ids[bidx];
@@ -557,7 +556,7 @@ string_update_info_t StringSegment::MergeStringUpdate(SegmentStatistics &stats, 
 //===--------------------------------------------------------------------===//
 // Update Info
 //===--------------------------------------------------------------------===//
-void StringSegment::MergeUpdateInfo(UpdateInfo *node, Vector &update, row_t *ids, index_t vector_offset,
+void StringSegment::MergeUpdateInfo(UpdateInfo *node, Vector &update, row_t *ids, idx_t vector_offset,
                                     string_location_t base_data[], nullmask_t base_nullmask) {
 	auto info_data = (string_location_t *)node->tuple_data;
 
@@ -569,13 +568,13 @@ void StringSegment::MergeUpdateInfo(UpdateInfo *node, Vector &update, row_t *ids
 	memcpy(old_data, node->tuple_data, node->N * sizeof(string_location_t));
 
 	// now we perform a merge of the new ids with the old ids
-	auto merge = [&](index_t id, index_t aidx, index_t bidx, index_t count) {
+	auto merge = [&](idx_t id, idx_t aidx, idx_t bidx, idx_t count) {
 		// new_id and old_id are the same, insert the old data in the UpdateInfo
 		assert(old_data[bidx].IsValid());
 		info_data[count] = old_data[bidx];
 		node->tuples[count] = id;
 	};
-	auto pick_new = [&](index_t id, index_t aidx, index_t count) {
+	auto pick_new = [&](idx_t id, idx_t aidx, idx_t count) {
 		// new_id comes before the old id, insert the base table data into the update info
 		assert(base_data[aidx].IsValid());
 		info_data[count] = base_data[aidx];
@@ -583,7 +582,7 @@ void StringSegment::MergeUpdateInfo(UpdateInfo *node, Vector &update, row_t *ids
 
 		node->tuples[count] = id;
 	};
-	auto pick_old = [&](index_t id, index_t bidx, index_t count) {
+	auto pick_old = [&](idx_t id, idx_t bidx, idx_t count) {
 		// old_id comes before new_id, insert the old data
 		assert(old_data[bidx].IsValid());
 		info_data[count] = old_data[bidx];
@@ -597,7 +596,7 @@ void StringSegment::MergeUpdateInfo(UpdateInfo *node, Vector &update, row_t *ids
 // Update
 //===--------------------------------------------------------------------===//
 void StringSegment::Update(ColumnData &column_data, SegmentStatistics &stats, Transaction &transaction, Vector &update,
-                           row_t *ids, index_t vector_index, index_t vector_offset, UpdateInfo *node) {
+                           row_t *ids, idx_t vector_index, idx_t vector_offset, UpdateInfo *node) {
 	if (!string_updates) {
 		string_updates = unique_ptr<string_update_info_t[]>(new string_update_info_t[max_vector_count]);
 	}
@@ -624,7 +623,7 @@ void StringSegment::Update(ColumnData &column_data, SegmentStatistics &stats, Tr
 	}
 
 	// now update the original nullmask
-	for (index_t i = 0; i < update.count; i++) {
+	for (idx_t i = 0; i < update.count; i++) {
 		base_nullmask[ids[i] - vector_offset] = update.nullmask[i];
 	}
 
@@ -649,7 +648,7 @@ void StringSegment::Update(ColumnData &column_data, SegmentStatistics &stats, Tr
 void StringSegment::RollbackUpdate(UpdateInfo *info) {
 	auto lock_handle = lock.GetExclusiveLock();
 
-	index_t new_count = 0;
+	idx_t new_count = 0;
 	auto &update_info = *string_updates[info->vector_index];
 	auto string_locations = (string_location_t *)info->tuple_data;
 
@@ -658,13 +657,13 @@ void StringSegment::RollbackUpdate(UpdateInfo *info) {
 	auto baseptr = handle->node->buffer;
 	auto base = baseptr + info->vector_index * vector_size;
 	auto &base_nullmask = *((nullmask_t *)base);
-	for (index_t i = 0; i < info->N; i++) {
+	for (idx_t i = 0; i < info->N; i++) {
 		base_nullmask[info->tuples[i]] = info->nullmask[info->tuples[i]];
 	}
 
 	// now put the original values back into the update info
-	index_t old_idx = 0;
-	for (index_t i = 0; i < update_info.count; i++) {
+	idx_t old_idx = 0;
+	for (idx_t i = 0; i < update_info.count; i++) {
 		if (old_idx >= info->N || update_info.ids[i] != info->tuples[old_idx]) {
 			assert(old_idx >= info->N || update_info.ids[i] < info->tuples[old_idx]);
 			// this entry is not rolled back: insert entry directly

--- a/src/storage/table/chunk_info.cpp
+++ b/src/storage/table/chunk_info.cpp
@@ -11,23 +11,23 @@ static bool UseVersion(Transaction &transaction, transaction_t id) {
 //===--------------------------------------------------------------------===//
 // Delete info
 //===--------------------------------------------------------------------===//
-ChunkDeleteInfo::ChunkDeleteInfo(VersionManager &manager, index_t start_row, ChunkInfoType type)
+ChunkDeleteInfo::ChunkDeleteInfo(VersionManager &manager, idx_t start_row, ChunkInfoType type)
     : ChunkInfo(manager, start_row, type) {
-	for (index_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
 		deleted[i] = NOT_DELETED_ID;
 	}
 }
 
 ChunkDeleteInfo::ChunkDeleteInfo(ChunkDeleteInfo &info, ChunkInfoType type)
     : ChunkInfo(info.manager, info.start, type) {
-	for (index_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
 		deleted[i] = info.deleted[i];
 	}
 }
 
-index_t ChunkDeleteInfo::GetSelVector(Transaction &transaction, sel_t sel_vector[], index_t max_count) {
-	index_t count = 0;
-	for (index_t i = 0; i < max_count; i++) {
+idx_t ChunkDeleteInfo::GetSelVector(Transaction &transaction, sel_t sel_vector[], idx_t max_count) {
+	idx_t count = 0;
+	for (idx_t i = 0; i < max_count; i++) {
 		if (!UseVersion(transaction, deleted[i])) {
 			sel_vector[count++] = i;
 		}
@@ -39,22 +39,22 @@ bool ChunkDeleteInfo::Fetch(Transaction &transaction, row_t row) {
 	return !UseVersion(transaction, deleted[row]);
 }
 
-void ChunkDeleteInfo::Delete(Transaction &transaction, row_t rows[], index_t count) {
+void ChunkDeleteInfo::Delete(Transaction &transaction, row_t rows[], idx_t count) {
 	// first check the chunk for conflicts
-	for (index_t i = 0; i < count; i++) {
+	for (idx_t i = 0; i < count; i++) {
 		if (deleted[rows[i]] != NOT_DELETED_ID) {
 			// tuple was already deleted by another transaction
 			throw TransactionException("Conflict on tuple deletion!");
 		}
 	}
 	// after verifying that there are no conflicts we mark the tuples as deleted
-	for (index_t i = 0; i < count; i++) {
+	for (idx_t i = 0; i < count; i++) {
 		deleted[rows[i]] = transaction.transaction_id;
 	}
 }
 
-void ChunkDeleteInfo::CommitDelete(transaction_t commit_id, row_t rows[], index_t count) {
-	for (index_t i = 0; i < count; i++) {
+void ChunkDeleteInfo::CommitDelete(transaction_t commit_id, row_t rows[], idx_t count) {
+	for (idx_t i = 0; i < count; i++) {
 		deleted[rows[i]] = commit_id;
 	}
 }
@@ -62,22 +62,22 @@ void ChunkDeleteInfo::CommitDelete(transaction_t commit_id, row_t rows[], index_
 //===--------------------------------------------------------------------===//
 // Insert info
 //===--------------------------------------------------------------------===//
-ChunkInsertInfo::ChunkInsertInfo(VersionManager &manager, index_t start_row)
+ChunkInsertInfo::ChunkInsertInfo(VersionManager &manager, idx_t start_row)
     : ChunkDeleteInfo(manager, start_row, ChunkInfoType::INSERT_INFO) {
-	for (index_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
 		inserted[i] = NOT_DELETED_ID;
 	}
 }
 
 ChunkInsertInfo::ChunkInsertInfo(ChunkDeleteInfo &info) : ChunkDeleteInfo(info, ChunkInfoType::INSERT_INFO) {
-	for (index_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
 		inserted[i] = NOT_DELETED_ID;
 	}
 }
 
-index_t ChunkInsertInfo::GetSelVector(Transaction &transaction, sel_t sel_vector[], index_t max_count) {
-	index_t count = 0;
-	for (index_t i = 0; i < max_count; i++) {
+idx_t ChunkInsertInfo::GetSelVector(Transaction &transaction, sel_t sel_vector[], idx_t max_count) {
+	idx_t count = 0;
+	for (idx_t i = 0; i < max_count; i++) {
 		if (UseVersion(transaction, inserted[i]) && !UseVersion(transaction, deleted[i])) {
 			sel_vector[count++] = i;
 		}

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -4,12 +4,12 @@
 using namespace duckdb;
 using namespace std;
 
-ColumnSegment::ColumnSegment(TypeId type, ColumnSegmentType segment_type, index_t start, index_t count)
+ColumnSegment::ColumnSegment(TypeId type, ColumnSegmentType segment_type, idx_t start, idx_t count)
     : SegmentBase(start, count), type(type), type_size(GetTypeIdSize(type)), segment_type(segment_type),
       stats(type, type_size) {
 }
 
-SegmentStatistics::SegmentStatistics(TypeId type, index_t type_size) : type(type), type_size(type_size) {
+SegmentStatistics::SegmentStatistics(TypeId type, idx_t type_size) : type(type), type_size(type_size) {
 	Reset();
 }
 

--- a/src/storage/table/persistent_segment.cpp
+++ b/src/storage/table/persistent_segment.cpp
@@ -12,8 +12,8 @@
 using namespace duckdb;
 using namespace std;
 
-PersistentSegment::PersistentSegment(BufferManager &manager, block_id_t id, index_t offset, TypeId type, index_t start,
-                                     index_t count)
+PersistentSegment::PersistentSegment(BufferManager &manager, block_id_t id, idx_t offset, TypeId type, idx_t start,
+                                     idx_t count)
     : ColumnSegment(type, ColumnSegmentType::PERSISTENT, start, count), manager(manager), block_id(id), offset(offset) {
 	assert(offset == 0);
 	if (type == TypeId::VARCHAR) {
@@ -29,7 +29,7 @@ void PersistentSegment::InitializeScan(ColumnScanState &state) {
 	data->InitializeScan(state);
 }
 
-void PersistentSegment::Scan(Transaction &transaction, ColumnScanState &state, index_t vector_index, Vector &result) {
+void PersistentSegment::Scan(Transaction &transaction, ColumnScanState &state, idx_t vector_index, Vector &result) {
 	data->Scan(transaction, state, vector_index, result);
 }
 
@@ -37,7 +37,7 @@ void PersistentSegment::IndexScan(ColumnScanState &state, Vector &result) {
 	data->IndexScan(state, state.vector_index, result);
 }
 
-void PersistentSegment::Fetch(ColumnScanState &state, index_t vector_index, Vector &result) {
+void PersistentSegment::Fetch(ColumnScanState &state, idx_t vector_index, Vector &result) {
 	data->Fetch(state, vector_index, result);
 }
 

--- a/src/storage/table/segment_tree.cpp
+++ b/src/storage/table/segment_tree.cpp
@@ -12,17 +12,17 @@ SegmentBase *SegmentTree::GetLastSegment() {
 	return nodes.back().node;
 }
 
-SegmentBase *SegmentTree::GetSegment(index_t row_number) {
+SegmentBase *SegmentTree::GetSegment(idx_t row_number) {
 	lock_guard<mutex> tree_lock(node_lock);
 	return nodes[GetSegmentIndex(row_number)].node;
 }
 
-index_t SegmentTree::GetSegmentIndex(index_t row_number) {
-	index_t lower = 0;
-	index_t upper = nodes.size() - 1;
+idx_t SegmentTree::GetSegmentIndex(idx_t row_number) {
+	idx_t lower = 0;
+	idx_t upper = nodes.size() - 1;
 	// binary search to find the node
 	while (lower <= upper) {
-		index_t index = (lower + upper) / 2;
+		idx_t index = (lower + upper) / 2;
 		auto &entry = nodes[index];
 		if (row_number < entry.row_start) {
 			upper = index - 1;

--- a/src/storage/table/transient_segment.cpp
+++ b/src/storage/table/transient_segment.cpp
@@ -9,7 +9,7 @@
 using namespace duckdb;
 using namespace std;
 
-TransientSegment::TransientSegment(BufferManager &manager, TypeId type, index_t start)
+TransientSegment::TransientSegment(BufferManager &manager, TypeId type, idx_t start)
     : ColumnSegment(type, ColumnSegmentType::TRANSIENT, start), manager(manager) {
 	if (type == TypeId::VARCHAR) {
 		data = make_unique<StringSegment>(manager, start);
@@ -22,7 +22,7 @@ void TransientSegment::InitializeScan(ColumnScanState &state) {
 	data->InitializeScan(state);
 }
 
-void TransientSegment::Scan(Transaction &transaction, ColumnScanState &state, index_t vector_index, Vector &result) {
+void TransientSegment::Scan(Transaction &transaction, ColumnScanState &state, idx_t vector_index, Vector &result) {
 	data->Scan(transaction, state, vector_index, result);
 }
 
@@ -30,7 +30,7 @@ void TransientSegment::IndexScan(ColumnScanState &state, Vector &result) {
 	data->IndexScan(state, state.vector_index, result);
 }
 
-void TransientSegment::Fetch(ColumnScanState &state, index_t vector_index, Vector &result) {
+void TransientSegment::Fetch(ColumnScanState &state, idx_t vector_index, Vector &result) {
 	data->Fetch(state, vector_index, result);
 }
 
@@ -46,13 +46,13 @@ void TransientSegment::InitializeAppend(ColumnAppendState &state) {
 	state.lock = data->lock.GetExclusiveLock();
 }
 
-index_t TransientSegment::Append(ColumnAppendState &state, Vector &append_data, index_t offset, index_t count) {
-	index_t appended = data->Append(stats, append_data, offset, count);
+idx_t TransientSegment::Append(ColumnAppendState &state, Vector &append_data, idx_t offset, idx_t count) {
+	idx_t appended = data->Append(stats, append_data, offset, count);
 	this->count += appended;
 	return appended;
 }
 
-void TransientSegment::RevertAppend(index_t start_row) {
+void TransientSegment::RevertAppend(idx_t start_row) {
 	data->tuple_count = start_row - this->start;
 	this->count = start_row - this->start;
 }

--- a/src/storage/uncompressed_segment.cpp
+++ b/src/storage/uncompressed_segment.cpp
@@ -6,7 +6,7 @@
 using namespace duckdb;
 using namespace std;
 
-UncompressedSegment::UncompressedSegment(BufferManager &manager, TypeId type, index_t row_start)
+UncompressedSegment::UncompressedSegment(BufferManager &manager, TypeId type, idx_t row_start)
     : manager(manager), type(type), block_id(INVALID_BLOCK), max_vector_count(0), tuple_count(0), row_start(row_start),
       versions(nullptr) {
 }
@@ -26,7 +26,7 @@ static void CheckForConflicts(UpdateInfo *info, Transaction &transaction, Vector
 	} else if (info->version_number > transaction.start_time) {
 		// potential conflict, check that tuple ids do not conflict
 		// as both ids and info->tuples are sorted, this is similar to a merge join
-		index_t i = 0, j = 0;
+		idx_t i = 0, j = 0;
 		while (true) {
 			auto id = ids[i] - offset;
 			if (id == info->tuples[j]) {
@@ -62,7 +62,7 @@ void UncompressedSegment::Update(ColumnData &column_data, SegmentStatistics &sta
 	assert(!update.sel_vector);
 #ifdef DEBUG
 	// verify that the ids are sorted and there are no duplicates
-	for (index_t i = 1; i < update.count; i++) {
+	for (idx_t i = 1; i < update.count; i++) {
 		assert(ids[i] > ids[i - 1]);
 	}
 #endif
@@ -70,7 +70,7 @@ void UncompressedSegment::Update(ColumnData &column_data, SegmentStatistics &sta
 	// create the versions for this segment, if there are none yet
 	if (!versions) {
 		this->versions = unique_ptr<UpdateInfo *[]>(new UpdateInfo *[max_vector_count]);
-		for (index_t i = 0; i < max_vector_count; i++) {
+		for (idx_t i = 0; i < max_vector_count; i++) {
 			this->versions[i] = nullptr;
 		}
 	}
@@ -78,8 +78,8 @@ void UncompressedSegment::Update(ColumnData &column_data, SegmentStatistics &sta
 	// get the vector index based on the first id
 	// we assert that all updates must be part of the same vector
 	auto first_id = update.sel_vector ? ids[update.sel_vector[0]] : ids[0];
-	index_t vector_index = (first_id - offset) / STANDARD_VECTOR_SIZE;
-	index_t vector_offset = offset + vector_index * STANDARD_VECTOR_SIZE;
+	idx_t vector_index = (first_id - offset) / STANDARD_VECTOR_SIZE;
+	idx_t vector_offset = offset + vector_index * STANDARD_VECTOR_SIZE;
 
 	assert(first_id >= offset);
 	assert(vector_index < max_vector_count);
@@ -95,8 +95,8 @@ void UncompressedSegment::Update(ColumnData &column_data, SegmentStatistics &sta
 }
 
 UpdateInfo *UncompressedSegment::CreateUpdateInfo(ColumnData &column_data, Transaction &transaction, row_t *ids,
-                                                  index_t count, index_t vector_index, index_t vector_offset,
-                                                  index_t type_size) {
+                                                  idx_t count, idx_t vector_index, idx_t vector_offset,
+                                                  idx_t type_size) {
 	auto node = transaction.CreateUpdateInfo(type_size, STANDARD_VECTOR_SIZE);
 	node->column_data = &column_data;
 	node->segment = this;
@@ -110,14 +110,14 @@ UpdateInfo *UncompressedSegment::CreateUpdateInfo(ColumnData &column_data, Trans
 
 	// set up the tuple ids
 	node->N = count;
-	for (index_t i = 0; i < count; i++) {
-		assert((index_t)ids[i] >= vector_offset && (index_t)ids[i] < vector_offset + STANDARD_VECTOR_SIZE);
+	for (idx_t i = 0; i < count; i++) {
+		assert((idx_t)ids[i] >= vector_offset && (idx_t)ids[i] < vector_offset + STANDARD_VECTOR_SIZE);
 		node->tuples[i] = ids[i] - vector_offset;
 	};
 	return node;
 }
 
-void UncompressedSegment::Fetch(ColumnScanState &state, index_t vector_index, Vector &result) {
+void UncompressedSegment::Fetch(ColumnScanState &state, idx_t vector_index, Vector &result) {
 	auto read_lock = lock.GetSharedLock();
 
 	InitializeScan(state);
@@ -127,7 +127,7 @@ void UncompressedSegment::Fetch(ColumnScanState &state, index_t vector_index, Ve
 //===--------------------------------------------------------------------===//
 // Scan
 //===--------------------------------------------------------------------===//
-void UncompressedSegment::Scan(Transaction &transaction, ColumnScanState &state, index_t vector_index, Vector &result) {
+void UncompressedSegment::Scan(Transaction &transaction, ColumnScanState &state, idx_t vector_index, Vector &result) {
 	auto read_lock = lock.GetSharedLock();
 
 	// first fetch the data from the base table
@@ -138,7 +138,7 @@ void UncompressedSegment::Scan(Transaction &transaction, ColumnScanState &state,
 	}
 }
 
-void UncompressedSegment::IndexScan(ColumnScanState &state, index_t vector_index, Vector &result) {
+void UncompressedSegment::IndexScan(ColumnScanState &state, idx_t vector_index, Vector &result) {
 	if (vector_index == 0) {
 		// vector_index = 0, obtain a shared lock on the segment that we keep until the index scan is complete
 		state.locks.push_back(lock.GetSharedLock());

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -284,7 +284,7 @@ void ReplayState::ReplayDelete() {
 
 	auto source_ids = (row_t *)chunk.data[0].GetData();
 	// delete the tuples from the current table
-	for (index_t i = 0; i < chunk.size(); i++) {
+	for (idx_t i = 0; i < chunk.size(); i++) {
 		row_ids[0] = source_ids[i];
 		current_table->storage->Delete(*current_table, context, row_identifiers);
 	}
@@ -295,7 +295,7 @@ void ReplayState::ReplayUpdate() {
 		throw Exception("Corrupt WAL: update without table");
 	}
 
-	index_t column_index = source.Read<column_t>();
+	idx_t column_index = source.Read<column_t>();
 
 	DataChunk chunk;
 	chunk.Deserialize(source);

--- a/src/transaction/cleanup_state.cpp
+++ b/src/transaction/cleanup_state.cpp
@@ -66,7 +66,7 @@ void CleanupState::CleanupDelete(DeleteInfo *info) {
 		Flush();
 		current_table = version_table;
 	}
-	for (index_t i = 0; i < info->count; i++) {
+	for (idx_t i = 0; i < info->count; i++) {
 		if (count == STANDARD_VECTOR_SIZE) {
 			Flush();
 		}

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -34,8 +34,8 @@ void CommitState::WriteCatalogEntry(CatalogEntry *entry, data_ptr_t dataptr) {
 		}
 		if (entry->type == CatalogType::TABLE) {
 			// ALTER TABLE statement, read the extra data after the entry
-			auto extra_data_size = *((index_t *)dataptr);
-			auto extra_data = (data_ptr_t)(dataptr + sizeof(index_t));
+			auto extra_data_size = *((idx_t *)dataptr);
+			auto extra_data = (data_ptr_t)(dataptr + sizeof(idx_t));
 			// deserialize it
 			BufferedDeserializer source(extra_data, extra_data_size);
 			auto info = AlterInfo::Deserialize(source);
@@ -95,7 +95,7 @@ void CommitState::WriteDelete(DeleteInfo *info) {
 		delete_chunk->Initialize(delete_types);
 	}
 	auto rows = (row_t *)delete_chunk->data[0].GetData();
-	for (index_t i = 0; i < info->count; i++) {
+	for (idx_t i = 0; i < info->count; i++) {
 		rows[i] = info->base_row + info->rows[i];
 	}
 	delete_chunk->data[0].count = info->count;
@@ -122,8 +122,8 @@ void CommitState::WriteUpdate(UpdateInfo *info) {
 
 	// write the row ids into the chunk
 	auto row_ids = (row_t *)update_chunk->data[1].GetData();
-	index_t start = info->segment->row_start + info->vector_index * STANDARD_VECTOR_SIZE;
-	for (index_t i = 0; i < info->N; i++) {
+	idx_t start = info->segment->row_start + info->vector_index * STANDARD_VECTOR_SIZE;
+	for (idx_t i = 0; i < info->N; i++) {
 		row_ids[info->tuples[i]] = start + info->tuples[i];
 	}
 	update_chunk->data[1].sel_vector = info->tuples;

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -14,10 +14,10 @@
 using namespace duckdb;
 using namespace std;
 
-void Transaction::PushCatalogEntry(CatalogEntry *entry, data_ptr_t extra_data, index_t extra_data_size) {
-	index_t alloc_size = sizeof(CatalogEntry *);
+void Transaction::PushCatalogEntry(CatalogEntry *entry, data_ptr_t extra_data, idx_t extra_data_size) {
+	idx_t alloc_size = sizeof(CatalogEntry *);
 	if (extra_data_size > 0) {
-		alloc_size += extra_data_size + sizeof(index_t);
+		alloc_size += extra_data_size + sizeof(idx_t);
 	}
 	auto baseptr = undo_buffer.CreateEntry(UndoFlags::CATALOG_ENTRY, alloc_size);
 	// store the pointer to the catalog entry
@@ -26,14 +26,14 @@ void Transaction::PushCatalogEntry(CatalogEntry *entry, data_ptr_t extra_data, i
 		// copy the extra data behind the catalog entry pointer (if any)
 		baseptr += sizeof(CatalogEntry *);
 		// first store the extra data size
-		*((index_t *)baseptr) = extra_data_size;
-		baseptr += sizeof(index_t);
+		*((idx_t *)baseptr) = extra_data_size;
+		baseptr += sizeof(idx_t);
 		// then copy over the actual data
 		memcpy(baseptr, extra_data, extra_data_size);
 	}
 }
 
-void Transaction::PushDelete(ChunkInfo *vinfo, row_t rows[], index_t count, index_t base_row) {
+void Transaction::PushDelete(ChunkInfo *vinfo, row_t rows[], idx_t count, idx_t base_row) {
 	auto delete_info =
 	    (DeleteInfo *)undo_buffer.CreateEntry(UndoFlags::DELETE_TUPLE, sizeof(DeleteInfo) + sizeof(row_t) * count);
 	delete_info->vinfo = vinfo;
@@ -42,7 +42,7 @@ void Transaction::PushDelete(ChunkInfo *vinfo, row_t rows[], index_t count, inde
 	memcpy(delete_info->rows, rows, sizeof(row_t) * count);
 }
 
-UpdateInfo *Transaction::CreateUpdateInfo(index_t type_size, index_t entries) {
+UpdateInfo *Transaction::CreateUpdateInfo(idx_t type_size, idx_t entries) {
 	auto update_info = (UpdateInfo *)undo_buffer.CreateEntry(
 	    UndoFlags::UPDATE_TUPLE, sizeof(UpdateInfo) + (sizeof(sel_t) + type_size) * entries);
 	update_info->max = entries;

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -84,11 +84,11 @@ void TransactionManager::RollbackTransaction(Transaction *transaction) {
 
 void TransactionManager::RemoveTransaction(Transaction *transaction) noexcept {
 	// remove the transaction from the list of active transactions
-	index_t t_index = active_transactions.size();
+	idx_t t_index = active_transactions.size();
 	// check for the lowest and highest start time in the list of transactions
 	transaction_t lowest_start_time = TRANSACTION_ID_START;
 	transaction_t lowest_active_query = MAXIMUM_QUERY_ID;
-	for (index_t i = 0; i < active_transactions.size(); i++) {
+	for (idx_t i = 0; i < active_transactions.size(); i++) {
 		if (active_transactions[i].get() == transaction) {
 			t_index = i;
 		} else {
@@ -112,7 +112,7 @@ void TransactionManager::RemoveTransaction(Transaction *transaction) noexcept {
 	// remove the transaction from the set of currently active transactions
 	active_transactions.erase(active_transactions.begin() + t_index);
 	// traverse the recently_committed transactions to see if we can remove any
-	index_t i = 0;
+	idx_t i = 0;
 	for (; i < recently_committed_transactions.size(); i++) {
 		assert(recently_committed_transactions[i]);
 		lowest_stored_query = std::min(recently_committed_transactions[i]->start_time, lowest_stored_query);

--- a/src/transaction/undo_buffer.cpp
+++ b/src/transaction/undo_buffer.cpp
@@ -23,7 +23,7 @@ UndoBuffer::UndoBuffer() {
 	tail = head.get();
 }
 
-UndoChunk::UndoChunk(index_t size) : current_position(0), maximum_size(size), prev(nullptr) {
+UndoChunk::UndoChunk(idx_t size) : current_position(0), maximum_size(size), prev(nullptr) {
 	if (size > 0) {
 		data = unique_ptr<data_t[]>(new data_t[maximum_size]);
 	}
@@ -48,9 +48,9 @@ data_ptr_t UndoChunk::WriteEntry(UndoFlags type, uint32_t len) {
 	return result;
 }
 
-data_ptr_t UndoBuffer::CreateEntry(UndoFlags type, index_t len) {
+data_ptr_t UndoBuffer::CreateEntry(UndoFlags type, idx_t len) {
 	assert(len <= std::numeric_limits<uint32_t>::max());
-	index_t needed_space = len + UNDO_ENTRY_HEADER_SIZE;
+	idx_t needed_space = len + UNDO_ENTRY_HEADER_SIZE;
 	if (head->current_position + needed_space >= head->maximum_size) {
 		auto new_chunk =
 		    make_unique<UndoChunk>(needed_space > DEFAULT_UNDO_CHUNK_SIZE ? needed_space : DEFAULT_UNDO_CHUNK_SIZE);
@@ -120,7 +120,7 @@ template <class T> void UndoBuffer::ReverseIterateEntries(T &&callback) {
 			start += len;
 		}
 		// iterate over it in reverse order
-		for (index_t i = nodes.size(); i > 0; i--) {
+		for (idx_t i = nodes.size(); i > 0; i--) {
 			callback(nodes[i - 1].first, nodes[i - 1].second);
 		}
 		current = current->next.get();

--- a/test/api/test_appender_api.cpp
+++ b/test/api/test_appender_api.cpp
@@ -43,7 +43,7 @@ TEST_CASE("Test using appender after connection is gone", "[api]") {
 }
 
 TEST_CASE("Test appender and connection destruction order", "[api]") {
-	for (index_t i = 0; i < 6; i++) {
+	for (idx_t i = 0; i < 6; i++) {
 		auto db = make_unique<DuckDB>(nullptr);
 		auto con = make_unique<Connection>(*db);
 		REQUIRE_NO_FAIL(con->Query("CREATE TABLE integers(i INTEGER)"));

--- a/test/api/test_results.cpp
+++ b/test/api/test_results.cpp
@@ -43,7 +43,7 @@ TEST_CASE("Test iterating over results", "[api]") {
 
 	vector<int> i_values = {1, 2};
 	vector<string> j_values = {"hello", "test"};
-	index_t row_count = 0;
+	idx_t row_count = 0;
 	auto result = con.Query("SELECT * FROM data;");
 	for (auto &row : *result) {
 		REQUIRE(row.GetValue<int>(0) == i_values[row.row]);

--- a/test/common/test_cast.cpp
+++ b/test/common/test_cast.cpp
@@ -25,7 +25,7 @@ template <class DST>
 static void TestStringCast(vector<string> &working_values, vector<DST> &expected_values,
                            vector<string> &broken_values) {
 	DST result;
-	for (index_t i = 0; i < working_values.size(); i++) {
+	for (idx_t i = 0; i < working_values.size(); i++) {
 		auto &value = working_values[i];
 		auto expected_value = expected_values[i];
 		REQUIRE_NOTHROW(Cast::Operation<const char *, DST>(value.c_str()) == expected_value);
@@ -52,7 +52,7 @@ template <class T> static void TestExponent() {
 	string str;
 	double value = 1;
 	T expected_value = 1;
-	for (index_t exponent = 0; exponent < 100; exponent++) {
+	for (idx_t exponent = 0; exponent < 100; exponent++) {
 		if (value < MaximumValue<T>()) {
 			// expect success
 			str = "1e" + to_string(exponent);
@@ -79,7 +79,7 @@ TEST_CASE("Test casting to boolean", "[cast]") {
 	vector<string> broken_values = {"1", "blabla", "", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"};
 
 	bool result;
-	for (index_t i = 0; i < working_values.size(); i++) {
+	for (idx_t i = 0; i < working_values.size(); i++) {
 		auto &value = working_values[i];
 		auto expected_value = expected_values[i];
 		REQUIRE_NOTHROW(Cast::Operation<const char *, bool>(value.c_str()) == expected_value);
@@ -221,7 +221,7 @@ template <class DST>
 static void TestStringCastDouble(vector<string> &working_values, vector<DST> &expected_values,
                                  vector<string> &broken_values) {
 	DST result;
-	for (index_t i = 0; i < working_values.size(); i++) {
+	for (idx_t i = 0; i < working_values.size(); i++) {
 		auto &value = working_values[i];
 		auto expected_value = expected_values[i];
 		REQUIRE_NOTHROW(Cast::Operation<const char *, DST>(value.c_str()) == expected_value);

--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -242,8 +242,8 @@ bool compare_result(string csv, ChunkCollection &collection, vector<SQLType> sql
 	istringstream csv_stream(csv);
 
 	BufferedCSVReader reader(info, sql_types, csv_stream);
-	index_t collection_index = 0;
-	index_t tuple_count = 0;
+	idx_t collection_index = 0;
+	idx_t tuple_count = 0;
 	while (true) {
 		// parse a chunk from the CSV file
 		try {

--- a/test/sql/aggregate/test_aggregate.cpp
+++ b/test/sql/aggregate/test_aggregate.cpp
@@ -304,7 +304,7 @@ TEST_CASE("Test GROUP BY with many groups", "[aggregate][.]") {
 	Connection con(db);
 
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER, j INTEGER);"));
-	for (index_t i = 0; i < 10000; i++) {
+	for (idx_t i = 0; i < 10000; i++) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (" + to_string(i) + ", 1), (" + to_string(i) + ", 2);"));
 	}
 	result = con.Query("SELECT SUM(i), SUM(sums) FROM (SELECT i, SUM(j) AS sums FROM integers GROUP BY i) tbl1");

--- a/test/sql/append/test_big_append.cpp
+++ b/test/sql/append/test_big_append.cpp
@@ -15,8 +15,8 @@ TEST_CASE("Test big append", "[append][.]") {
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER);"));
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (1), (2), (3), (NULL)"));
 
-	index_t desired_count = (Storage::BLOCK_SIZE * 2) / sizeof(int);
-	index_t current_count = 4;
+	idx_t desired_count = (Storage::BLOCK_SIZE * 2) / sizeof(int);
+	idx_t current_count = 4;
 	while (current_count < desired_count) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers SELECT * FROM integers"));
 		current_count *= 2;

--- a/test/sql/capi/test_capi.cpp
+++ b/test/sql/capi/test_capi.cpp
@@ -15,19 +15,19 @@ public:
 		success = (duckdb_query(connection, query.c_str(), &result) == DuckDBSuccess);
 	}
 
-	index_t column_count() {
+	idx_t column_count() {
 		return result.column_count;
 	}
 
-	index_t row_count() {
+	idx_t row_count() {
 		return result.row_count;
 	}
 
-	template <class T> T Fetch(index_t col, index_t row) {
+	template <class T> T Fetch(idx_t col, idx_t row) {
 		throw NotImplementedException("Unimplemented type for fetch");
 	}
 
-	bool IsNull(index_t col, index_t row) {
+	bool IsNull(idx_t col, idx_t row) {
 		return result.columns[col].nullmask[row];
 	}
 
@@ -46,45 +46,45 @@ static bool NO_FAIL(unique_ptr<CAPIResult> result) {
 	return NO_FAIL(*result);
 }
 
-template <> bool CAPIResult::Fetch(index_t col, index_t row) {
+template <> bool CAPIResult::Fetch(idx_t col, idx_t row) {
 	return duckdb_value_boolean(&result, col, row);
 }
 
-template <> int8_t CAPIResult::Fetch(index_t col, index_t row) {
+template <> int8_t CAPIResult::Fetch(idx_t col, idx_t row) {
 	return duckdb_value_int8(&result, col, row);
 }
 
-template <> int16_t CAPIResult::Fetch(index_t col, index_t row) {
+template <> int16_t CAPIResult::Fetch(idx_t col, idx_t row) {
 	return duckdb_value_int16(&result, col, row);
 }
 
-template <> int32_t CAPIResult::Fetch(index_t col, index_t row) {
+template <> int32_t CAPIResult::Fetch(idx_t col, idx_t row) {
 	return duckdb_value_int32(&result, col, row);
 }
 
-template <> int64_t CAPIResult::Fetch(index_t col, index_t row) {
+template <> int64_t CAPIResult::Fetch(idx_t col, idx_t row) {
 	return duckdb_value_int64(&result, col, row);
 }
 
-template <> float CAPIResult::Fetch(index_t col, index_t row) {
+template <> float CAPIResult::Fetch(idx_t col, idx_t row) {
 	return duckdb_value_float(&result, col, row);
 }
 
-template <> double CAPIResult::Fetch(index_t col, index_t row) {
+template <> double CAPIResult::Fetch(idx_t col, idx_t row) {
 	return duckdb_value_double(&result, col, row);
 }
 
-template <> duckdb_date CAPIResult::Fetch(index_t col, index_t row) {
+template <> duckdb_date CAPIResult::Fetch(idx_t col, idx_t row) {
 	auto data = (duckdb_date *)result.columns[col].data;
 	return data[row];
 }
 
-template <> duckdb_timestamp CAPIResult::Fetch(index_t col, index_t row) {
+template <> duckdb_timestamp CAPIResult::Fetch(idx_t col, idx_t row) {
 	auto data = (duckdb_timestamp *)result.columns[col].data;
 	return data[row];
 }
 
-template <> string CAPIResult::Fetch(index_t col, index_t row) {
+template <> string CAPIResult::Fetch(idx_t col, idx_t row) {
 	auto value = duckdb_value_varchar(&result, col, row);
 	string strval = string(value);
 	free((void *)value);
@@ -399,7 +399,7 @@ TEST_CASE("Test prepared statements in C API", "[capi]") {
 	status = duckdb_prepare(tester.connection, "INSERT INTO a VALUES (?)", &stmt);
 	REQUIRE(status == DuckDBSuccess);
 	REQUIRE(stmt != nullptr);
-	index_t nparams;
+	idx_t nparams;
 	REQUIRE(duckdb_nparams(stmt, &nparams) == DuckDBSuccess);
 	REQUIRE(nparams == 1);
 

--- a/test/sql/constraints/test_primarykey.cpp
+++ b/test/sql/constraints/test_primarykey.cpp
@@ -195,12 +195,12 @@ TEST_CASE("PRIMARY KEY prefix stress test multiple columns", "[constraints]") {
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE test (a INTEGER, b VARCHAR, PRIMARY KEY(a, b));"));
 
 	//! Insert 300 values
-	for (index_t idx = 0; idx < 300; idx++) {
+	for (idx_t idx = 0; idx < 300; idx++) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO test VALUES (" + to_string(idx) + ", 'hello_" + to_string(idx) + "')"));
 	}
 
 	//! Inserting same values should fail
-	for (index_t idx = 0; idx < 300; idx++) {
+	for (idx_t idx = 0; idx < 300; idx++) {
 		REQUIRE_FAIL(con.Query("INSERT INTO test VALUES (" + to_string(idx) + ", 'hello_" + to_string(idx) + "')"));
 	}
 
@@ -208,7 +208,7 @@ TEST_CASE("PRIMARY KEY prefix stress test multiple columns", "[constraints]") {
 	REQUIRE_NO_FAIL(con.Query("UPDATE test SET a=a+1000;"));
 
 	//! Now inserting same 1000 values should work
-	for (index_t idx = 0; idx < 300; idx++) {
+	for (idx_t idx = 0; idx < 300; idx++) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO test VALUES (" + to_string(idx) + ", 'hello_" + to_string(idx) + "')"));
 	}
 
@@ -216,7 +216,7 @@ TEST_CASE("PRIMARY KEY prefix stress test multiple columns", "[constraints]") {
 	REQUIRE_FAIL(con.Query("UPDATE test SET a=a+1000;"));
 
 	//! Should fail for same reason as above, just checking element per element to see if no one is escaping
-	for (index_t idx = 0; idx < 300; idx++) {
+	for (idx_t idx = 0; idx < 300; idx++) {
 		REQUIRE_FAIL(
 		    con.Query("INSERT INTO test VALUES (" + to_string(idx + 1000) + ", 'hello_" + to_string(idx) + "')"));
 	}

--- a/test/sql/constraints/test_unique.cpp
+++ b/test/sql/constraints/test_unique.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Single UNIQUE constraint", "[constraints]") {
 	REQUIRE(CHECK_COLUMN(result, 0, {Value(), 2, 3, 77}));
 	REQUIRE(CHECK_COLUMN(result, 1, {7, 5, 4, 6}));
 
-	for (index_t i = 0; i < 10; i++) {
+	for (idx_t i = 0; i < 10; i++) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (NULL, 6), (NULL, 7)"));
 	}
 	REQUIRE_FAIL(con.Query("INSERT INTO integers VALUES (NULL, 6), (3, 7)"));
@@ -81,7 +81,7 @@ TEST_CASE("UNIQUE constraint on temporary tables", "[constraints]") {
 	REQUIRE(CHECK_COLUMN(result, 0, {Value(), 2, 3, 77}));
 	REQUIRE(CHECK_COLUMN(result, 1, {7, 5, 4, 6}));
 
-	for (index_t i = 0; i < 10; i++) {
+	for (idx_t i = 0; i < 10; i++) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (NULL, 6), (NULL, 7)"));
 	}
 	REQUIRE_FAIL(con.Query("INSERT INTO integers VALUES  (3, 4)"));
@@ -124,7 +124,7 @@ TEST_CASE("NULL values and a multi-column UNIQUE constraint", "[constraints]") {
 	REQUIRE(CHECK_COLUMN(result, 0, {Value(), Value(), 2, 3, 77}));
 	REQUIRE(CHECK_COLUMN(result, 1, {6, 6, 5, 4, 7}));
 
-	for (index_t i = 0; i < 10; i++) {
+	for (idx_t i = 0; i < 10; i++) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (NULL, 6), (NULL, 7)"));
 	}
 	REQUIRE_FAIL(con.Query("INSERT INTO integers VALUES  (3, 4)"));
@@ -160,7 +160,7 @@ TEST_CASE("UNIQUE constraint on temporary tables with Strings", "[constraints]")
 
 	// we can replace them like this though
 	REQUIRE_NO_FAIL(con.Query("UPDATE integers SET j='7777777777777777777777777777' WHERE j IS NULL AND i=6"));
-	for (index_t i = 0; i < 10; i++) {
+	for (idx_t i = 0; i < 10; i++) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (6,NULL), (7,NULL)"));
 	}
 	REQUIRE_FAIL(con.Query("INSERT INTO integers VALUES  (3, '4')"));

--- a/test/sql/copy/test_copy.cpp
+++ b/test/sql/copy/test_copy.cpp
@@ -1159,7 +1159,7 @@ TEST_CASE("Test copy statement with many empty lines", "[copy]") {
 	// generate CSV file with a very long string
 	ofstream from_csv_file(fs.JoinPath(csv_path, "test.csv"));
 	from_csv_file << "1\n";
-	for (index_t i = 0; i < 19999; i++) {
+	for (idx_t i = 0; i < 19999; i++) {
 		from_csv_file << "\n";
 	}
 	from_csv_file.close();
@@ -1213,12 +1213,12 @@ TEST_CASE("Test Windows Newlines with a long file", "[copy]") {
 
 	auto csv_path = GetCSVPath();
 
-	index_t line_count = 20000;
+	idx_t line_count = 20000;
 	int64_t sum_a = 0, sum_c = 0;
 
 	// generate a CSV file with many strings
 	ofstream from_csv_file(fs.JoinPath(csv_path, "test.csv"));
-	for (index_t i = 0; i < line_count; i++) {
+	for (idx_t i = 0; i < line_count; i++) {
 		from_csv_file << i << ","
 		              << "hello"
 		              << "," << i + 2 << "\r\n";
@@ -1257,7 +1257,7 @@ TEST_CASE("Test Windows Newlines with a long file", "[copy]") {
 	// generate a csv file with one value and many empty values
 	ofstream from_csv_file_empty(fs.JoinPath(csv_path, "test2.csv"));
 	from_csv_file_empty << 1 << "\r\n";
-	for (index_t i = 0; i < line_count - 1; i++) {
+	for (idx_t i = 0; i < line_count - 1; i++) {
 		from_csv_file_empty << "\r\n";
 	}
 	from_csv_file_empty.close();

--- a/test/sql/date/test_timestamp.cpp
+++ b/test/sql/date/test_timestamp.cpp
@@ -124,7 +124,7 @@ TEST_CASE("Test storage for timestamp type", "[timestamp]") {
 		    "('2008-01-02 00:00:01'), ('2008-01-01 10:00:00'), ('2008-01-01 00:10:00'), ('2008-01-01 00:00:10')"));
 	}
 	// reload the database from disk
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database);
 		Connection con(db);
 		result = con.Query("SELECT t FROM timestamp ORDER BY t;");

--- a/test/sql/delete/test_delete.cpp
+++ b/test/sql/delete/test_delete.cpp
@@ -50,7 +50,7 @@ TEST_CASE("Test scan with large deletions", "[delete][.]") {
 
 	REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION;"));
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE a(i INTEGER);"));
-	for (index_t i = 0; i < 10000; i++) {
+	for (idx_t i = 0; i < 10000; i++) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO a VALUES (" + to_string(i) + ")"));
 	}
 	REQUIRE_NO_FAIL(con.Query("COMMIT;"));
@@ -67,21 +67,21 @@ TEST_CASE("Test scan with many segmented deletions", "[delete][.]") {
 	DuckDB db(nullptr);
 	Connection con(db);
 
-	index_t n = 20;
-	index_t val_count = 1024;
-	vector<index_t> tested_values = {0, 1, val_count - 2, val_count - 1};
+	idx_t n = 20;
+	idx_t val_count = 1024;
+	vector<idx_t> tested_values = {0, 1, val_count - 2, val_count - 1};
 
 	REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION;"));
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE a(i INTEGER);"));
-	for (index_t k = 0; k < n; k++) {
-		for (index_t i = 0; i < val_count; i++) {
+	for (idx_t k = 0; k < n; k++) {
+		for (idx_t i = 0; i < val_count; i++) {
 			REQUIRE_NO_FAIL(con.Query("INSERT INTO a VALUES (" + to_string(i) + ")"));
 		}
 	}
 	REQUIRE_NO_FAIL(con.Query("COMMIT;"));
 
 	// verify the initial count
-	for (index_t j = 0; j < 2; j++) {
+	for (idx_t j = 0; j < 2; j++) {
 		// verify the initial count again twice
 		result = con.Query("SELECT COUNT(*) FROM a");
 		REQUIRE(CHECK_COLUMN(result, 0, {Value::BIGINT(n * val_count)}));
@@ -98,7 +98,7 @@ TEST_CASE("Test scan with many segmented deletions", "[delete][.]") {
 		// rollback
 		REQUIRE_NO_FAIL(con.Query("ROLLBACK"));
 
-		for (index_t j = 0; j < 2; j++) {
+		for (idx_t j = 0; j < 2; j++) {
 			// verify the initial count again twice
 			result = con.Query("SELECT COUNT(*) FROM a");
 			REQUIRE(CHECK_COLUMN(result, 0, {Value::BIGINT(n * val_count)}));

--- a/test/sql/index/test_art_index.cpp
+++ b/test/sql/index/test_art_index.cpp
@@ -439,9 +439,9 @@ TEST_CASE("Test ART index with prefixes", "[art]") {
 	                          -598538523852390853,
 	                          4298422,
 	                          -498261};
-	index_t gt_count = 0, lt_count = 0;
-	index_t count = 0;
-	for (index_t val_index = 0; val_index < values.size(); val_index++) {
+	idx_t gt_count = 0, lt_count = 0;
+	idx_t count = 0;
+	for (idx_t val_index = 0; val_index < values.size(); val_index++) {
 		auto &value = values[val_index];
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES ($1)", value));
 		if (value >= 0) {
@@ -450,7 +450,7 @@ TEST_CASE("Test ART index with prefixes", "[art]") {
 			lt_count++;
 		}
 		count++;
-		for (index_t i = 0; i <= val_index; i++) {
+		for (idx_t i = 0; i <= val_index; i++) {
 			result = con.Query("SELECT COUNT(*) FROM integers WHERE i = " + to_string(values[i]));
 			REQUIRE(CHECK_COLUMN(result, 0, {Value::BIGINT(1)}));
 		}
@@ -470,15 +470,15 @@ TEST_CASE("Test ART index with linear insertions and deletes", "[art][.]") {
 	DuckDB db(nullptr);
 	Connection con(db);
 
-	vector<index_t> insertion_count = {4, 16, 48, 256, 1024};
+	vector<idx_t> insertion_count = {4, 16, 48, 256, 1024};
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
 	REQUIRE_NO_FAIL(con.Query("CREATE INDEX i_index ON integers using art(i)"));
 	for (auto &insert_count : insertion_count) {
 		// insert the data
-		vector<index_t> elements;
-		index_t table_count = 0;
-		for (index_t i = 0; i < insert_count; i++) {
-			index_t element = i;
+		vector<idx_t> elements;
+		idx_t table_count = 0;
+		for (idx_t i = 0; i < insert_count; i++) {
+			idx_t element = i;
 			REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES ($1)", (int32_t)element));
 			elements.push_back(element);
 			table_count++;
@@ -513,15 +513,15 @@ TEST_CASE("Test ART index with random insertions and deletes", "[art][.]") {
 	DuckDB db(nullptr);
 	Connection con(db);
 
-	vector<index_t> insertion_count = {1024, 2048};
+	vector<idx_t> insertion_count = {1024, 2048};
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
 	REQUIRE_NO_FAIL(con.Query("CREATE INDEX i_index ON integers using art(i)"));
 	for (auto &insert_count : insertion_count) {
 		// insert the data
-		vector<index_t> elements;
-		index_t table_count = 0;
-		for (index_t i = 0; i < insert_count; i++) {
-			index_t element = i * i;
+		vector<idx_t> elements;
+		idx_t table_count = 0;
+		for (idx_t i = 0; i < insert_count; i++) {
+			idx_t element = i * i;
 			REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES ($1)", (int32_t)element));
 			elements.push_back(element);
 			table_count++;
@@ -554,7 +554,7 @@ TEST_CASE("Test ART index creation with many versions", "[art][.]") {
 
 	// insert the values [0...20000]
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
-	for (index_t i = 0; i < 20000; i++) {
+	for (idx_t i = 0; i < 20000; i++) {
 		int32_t val = i + 1;
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES ($1)", val));
 		expected_sum_r1 += val;
@@ -606,8 +606,8 @@ TEST_CASE("Test ART index with many matches", "[art][.]") {
 
 	REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION"));
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
-	for (index_t i = 0; i < 1024; i++) {
-		for (index_t val = 0; val < 2; val++) {
+	for (idx_t i = 0; i < 1024; i++) {
+		for (idx_t val = 0; val < 2; val++) {
 			REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES ($1)", (int32_t)val));
 		}
 	}
@@ -632,8 +632,8 @@ TEST_CASE("Test ART index with many matches", "[art][.]") {
 
 	REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION"));
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
-	for (index_t i = 0; i < 2048; i++) {
-		for (index_t val = 0; val < 2; val++) {
+	for (idx_t i = 0; i < 2048; i++) {
+		for (idx_t val = 0; val < 2; val++) {
 			REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES ($1)", (int32_t)val));
 		}
 	}
@@ -665,7 +665,7 @@ TEST_CASE("Test ART index with non-linear insertion", "[art][.]") {
 
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
 	REQUIRE_NO_FAIL(con.Query("CREATE INDEX i_index ON integers using art(i)"));
-	index_t count = 0;
+	idx_t count = 0;
 	for (int32_t it = 0; it < 10; it++) {
 		for (int32_t val = 0; val < 1000; val++) {
 			if (it + val % 2) {
@@ -687,7 +687,7 @@ TEST_CASE("Test ART index with rollbacks", "[art][.]") {
 
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
 	REQUIRE_NO_FAIL(con.Query("CREATE INDEX i_index ON integers using art(i)"));
-	index_t count = 0;
+	idx_t count = 0;
 	for (int32_t it = 0; it < 10; it++) {
 		for (int32_t val = 0; val < 1000; val++) {
 			REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION"));
@@ -850,20 +850,20 @@ TEST_CASE("ART Integer Types", "[art][.]") {
 	Connection con(db);
 
 	string int_types[4] = {"tinyint", "smallint", "integer", "bigint"};
-	index_t n_sizes[4] = {100, 1000, 1000, 1000};
-	for (index_t idx = 0; idx < 4; idx++) {
+	idx_t n_sizes[4] = {100, 1000, 1000, 1000};
+	for (idx_t idx = 0; idx < 4; idx++) {
 		REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i " + int_types[idx] + ")"));
 		REQUIRE_NO_FAIL(con.Query("CREATE INDEX i_index ON integers(i)"));
 
-		index_t n = n_sizes[idx];
+		idx_t n = n_sizes[idx];
 		auto keys = unique_ptr<int32_t[]>(new int32_t[n]);
 		auto key_pointer = keys.get();
-		for (index_t i = 0; i < n; i++) {
+		for (idx_t i = 0; i < n; i++) {
 			keys[i] = i + 1;
 		}
 		std::random_shuffle(key_pointer, key_pointer + n);
 
-		for (index_t i = 0; i < n; i++) {
+		for (idx_t i = 0; i < n; i++) {
 			REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES ($1)", keys[i]));
 			result =
 			    con.Query("SELECT i FROM integers WHERE i=CAST(" + to_string(keys[i]) + " AS " + int_types[idx] + ")");
@@ -877,7 +877,7 @@ TEST_CASE("ART Integer Types", "[art][.]") {
 		REQUIRE(CHECK_COLUMN(result, 0, {}));
 
 		//! Checking if all elements are still there
-		for (index_t i = 0; i < n; i++) {
+		for (idx_t i = 0; i < n; i++) {
 			result =
 			    con.Query("SELECT i FROM integers WHERE i=CAST(" + to_string(keys[i]) + " AS " + int_types[idx] + ")");
 			REQUIRE(CHECK_COLUMN(result, 0, {Value(keys[i])}));
@@ -951,7 +951,7 @@ TEST_CASE("ART Integer Types", "[art][.]") {
 		// Delete non-existing element
 		REQUIRE_NO_FAIL(con.Query("DELETE FROM integers WHERE i=0"));
 		// Now Deleting all elements
-		for (index_t i = 0; i < n; i++) {
+		for (idx_t i = 0; i < n; i++) {
 			REQUIRE_NO_FAIL(
 			    con.Query("DELETE FROM integers WHERE i=CAST(" + to_string(keys[i]) + " AS " + int_types[idx] + ")"));
 			// check the value does not exist
@@ -973,15 +973,15 @@ TEST_CASE("ART Simple Big Range", "[art][.]") {
 	Connection con(db);
 
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i integer)"));
-	index_t n = 4;
+	idx_t n = 4;
 	auto keys = unique_ptr<int32_t[]>(new int32_t[n + 1]);
-	for (index_t i = 0; i < n + 1; i++) {
+	for (idx_t i = 0; i < n + 1; i++) {
 		keys[i] = i + 1;
 	}
 
 	REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION"));
-	for (index_t i = 0; i < n; i++) {
-		for (index_t j = 0; j < 1500; j++) {
+	for (idx_t i = 0; i < n; i++) {
+		for (idx_t j = 0; j < 1500; j++) {
 			REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES ($1)", keys[i]));
 		}
 	}
@@ -1007,17 +1007,17 @@ TEST_CASE("ART Big Range with deletions", "[art][.]") {
 	DuckDB db(nullptr);
 	Connection con(db);
 
-	index_t n = 4;
+	idx_t n = 4;
 	auto keys = unique_ptr<int32_t[]>(new int32_t[n + 1]);
-	for (index_t i = 0; i < n + 1; i++) {
+	for (idx_t i = 0; i < n + 1; i++) {
 		keys[i] = i + 1;
 	}
 
 	// now perform a an index creation and scan with deletions with a second transaction
 	REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION"));
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i integer)"));
-	for (index_t j = 0; j < 1500; j++) {
-		for (index_t i = 0; i < n + 1; i++) {
+	for (idx_t j = 0; j < 1500; j++) {
+		for (idx_t i = 0; i < n + 1; i++) {
 			REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES ($1)", keys[i]));
 		}
 	}
@@ -1026,7 +1026,7 @@ TEST_CASE("ART Big Range with deletions", "[art][.]") {
 	// second transaction: begin and verify counts
 	Connection con2(db);
 	REQUIRE_NO_FAIL(con2.Query("BEGIN TRANSACTION"));
-	for (index_t i = 0; i < n + 1; i++) {
+	for (idx_t i = 0; i < n + 1; i++) {
 		result = con2.Query("SELECT FIRST(i), COUNT(i) FROM integers WHERE i=" + to_string(keys[i]));
 		REQUIRE(CHECK_COLUMN(result, 0, {Value(keys[i])}));
 		REQUIRE(CHECK_COLUMN(result, 1, {Value(1500)}));
@@ -1037,7 +1037,7 @@ TEST_CASE("ART Big Range with deletions", "[art][.]") {
 	// now delete entries in the first transaction
 	REQUIRE_NO_FAIL(con.Query("DELETE FROM integers WHERE i = 5"));
 	// verify that the counts are still correct in the second transaction
-	for (index_t i = 0; i < n + 1; i++) {
+	for (idx_t i = 0; i < n + 1; i++) {
 		result = con2.Query("SELECT FIRST(i), COUNT(i) FROM integers WHERE i=" + to_string(keys[i]));
 		REQUIRE(CHECK_COLUMN(result, 0, {Value(keys[i])}));
 		REQUIRE(CHECK_COLUMN(result, 1, {Value(1500)}));
@@ -1048,7 +1048,7 @@ TEST_CASE("ART Big Range with deletions", "[art][.]") {
 	// create an index in the first transaction now
 	REQUIRE_NO_FAIL(con.Query("CREATE INDEX i_index ON integers(i)"));
 	// verify that the counts are still correct for con2
-	for (index_t i = 0; i < n + 1; i++) {
+	for (idx_t i = 0; i < n + 1; i++) {
 		result = con2.Query("SELECT FIRST(i), COUNT(i) FROM integers WHERE i=" + to_string(keys[i]));
 		REQUIRE(CHECK_COLUMN(result, 0, {Value(keys[i])}));
 		REQUIRE(CHECK_COLUMN(result, 1, {Value(1500)}));
@@ -1082,14 +1082,14 @@ TEST_CASE("ART Negative Range", "[art-neg]") {
 	Connection con(db);
 
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i integer)"));
-	index_t n = 1000;
+	idx_t n = 1000;
 	auto keys = unique_ptr<int32_t[]>(new int32_t[n]);
-	for (index_t i = 0; i < n; i++) {
+	for (idx_t i = 0; i < n; i++) {
 		keys[i] = i - 500;
 	}
 
 	REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION"));
-	for (index_t i = 0; i < n; i++) {
+	for (idx_t i = 0; i < n; i++) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES ($1)", keys[i]));
 	}
 	REQUIRE_NO_FAIL(con.Query("COMMIT"));
@@ -1121,9 +1121,9 @@ double generate_double(double min_double, double max_double) {
 	return min_double + static_cast<double>(rand()) / (static_cast<double>(RAND_MAX / (max_double - min_double)));
 }
 
-template <class T> int full_scan(T *keys, index_t size, T low, T high) {
+template <class T> int full_scan(T *keys, idx_t size, T low, T high) {
 	int sum = 0;
-	for (index_t i = 0; i < size; i++) {
+	for (idx_t i = 0; i < size; i++) {
 		if (keys[i] >= low && keys[i] <= high) {
 			sum += 1;
 		}
@@ -1138,51 +1138,51 @@ TEST_CASE("ART Floating Point Small", "[art-float-small]") {
 	vector<int64_t> min_values, max_values;
 	Connection con(db);
 	//! Will use 100 keys
-	index_t n = 100;
+	idx_t n = 100;
 	auto keys = unique_ptr<int64_t[]>(new int64_t[n]);
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE numbers(i BIGINT)"));
 	//! Generate 10 small floats (0.0 - 1.0)
-	for (index_t i = 0; i < n / 10; i++) {
+	for (idx_t i = 0; i < n / 10; i++) {
 		keys[i] = Key::EncodeFloat(generate_small_float());
 	}
 
 	//! Generate 40 floats (-50/50)
-	for (index_t i = n / 10; i < n / 2; i++) {
+	for (idx_t i = n / 10; i < n / 2; i++) {
 		keys[i] = Key::EncodeFloat(generate_float(-50, 50));
 	}
 	//! Generate 50 floats (min/max)
-	for (index_t i = n / 2; i < n; i++) {
+	for (idx_t i = n / 2; i < n; i++) {
 		keys[i] = Key::EncodeFloat(generate_float(FLT_MIN, FLT_MAX));
 	}
 	//! Insert values and create index
 	REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION"));
-	for (index_t i = 0; i < n; i++) {
+	for (idx_t i = 0; i < n; i++) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO numbers VALUES (" + to_string(keys[i]) + ")"));
 	}
 	REQUIRE_NO_FAIL(con.Query("COMMIT"));
 	REQUIRE_NO_FAIL(con.Query("CREATE INDEX i_index ON numbers(i)"));
 	//! Generate 500 small-small range queries
-	for (index_t i = 0; i < 5; i++) {
+	for (idx_t i = 0; i < 5; i++) {
 		a = Key::EncodeFloat(generate_small_float());
 		b = Key::EncodeFloat(generate_small_float());
 		min_values.push_back(min(a, b));
 		max_values.push_back(max(a, b));
 	}
 	//! Generate 500 normal-normal range queries
-	for (index_t i = 0; i < 5; i++) {
+	for (idx_t i = 0; i < 5; i++) {
 		a = Key::EncodeFloat(generate_float(-50, 50));
 		b = Key::EncodeFloat(generate_float(-50, 50));
 		min_values.push_back(min(a, b));
 		max_values.push_back(max(a, b));
 	}
 	//! Generate 500 big-big range queries
-	for (index_t i = 0; i < 5; i++) {
+	for (idx_t i = 0; i < 5; i++) {
 		a = Key::EncodeFloat(generate_float(FLT_MIN, FLT_MAX));
 		b = Key::EncodeFloat(generate_float(FLT_MIN, FLT_MAX));
 		min_values.push_back(min(a, b));
 		max_values.push_back(max(a, b));
 	}
-	for (index_t i = 0; i < min_values.size(); i++) {
+	for (idx_t i = 0; i < min_values.size(); i++) {
 		int64_t low = Key::EncodeFloat(min_values[i]);
 		int64_t high = Key::EncodeFloat(max_values[i]);
 		int answer = full_scan<int64_t>(keys.get(), n, low, high);
@@ -1192,7 +1192,7 @@ TEST_CASE("ART Floating Point Small", "[art-float-small]") {
 		if (!CHECK_COLUMN(result, 0, {answer})) {
 			cout << "Wrong answer on floating point real-small!" << std::endl << "Queries to reproduce:" << std::endl;
 			cout << "CREATE TABLE numbers(i BIGINT);" << std::endl;
-			for (index_t k = 0; k < n; k++) {
+			for (idx_t k = 0; k < n; k++) {
 				cout << "INSERT INTO numbers VALUES (" << keys[k] << ");" << std::endl;
 			}
 			cout << query << std::endl;
@@ -1210,51 +1210,51 @@ TEST_CASE("ART Floating Point Double Small", "[art-double-small]") {
 	vector<int64_t> min_values, max_values;
 	Connection con(db);
 	//! Will use 100 keys
-	index_t n = 100;
+	idx_t n = 100;
 	auto keys = unique_ptr<int64_t[]>(new int64_t[n]);
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE numbers(i BIGINT)"));
 	//! Generate 10 small floats (0.0 - 1.0)
-	for (index_t i = 0; i < n / 10; i++) {
+	for (idx_t i = 0; i < n / 10; i++) {
 		keys[i] = Key::EncodeFloat(generate_small_float());
 	}
 
 	//! Generate 40 floats (-50/50)
-	for (index_t i = n / 10; i < n / 2; i++) {
+	for (idx_t i = n / 10; i < n / 2; i++) {
 		keys[i] = Key::EncodeFloat(generate_float(-50, 50));
 	}
 	//! Generate 50 floats (min/max)
-	for (index_t i = n / 2; i < n; i++) {
+	for (idx_t i = n / 2; i < n; i++) {
 		keys[i] = Key::EncodeFloat(generate_float(FLT_MIN, FLT_MAX));
 	}
 	//! Insert values and create index
 	REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION"));
-	for (index_t i = 0; i < n; i++) {
+	for (idx_t i = 0; i < n; i++) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO numbers VALUES (" + to_string(keys[i]) + ")"));
 	}
 	REQUIRE_NO_FAIL(con.Query("COMMIT"));
 	REQUIRE_NO_FAIL(con.Query("CREATE INDEX i_index ON numbers(i)"));
 	//! Generate 500 small-small range queries
-	for (index_t i = 0; i < 5; i++) {
+	for (idx_t i = 0; i < 5; i++) {
 		a = Key::EncodeDouble(generate_small_double());
 		b = Key::EncodeDouble(generate_small_double());
 		min_values.push_back(min(a, b));
 		max_values.push_back(max(a, b));
 	}
 	//! Generate 500 normal-normal range queries
-	for (index_t i = 0; i < 5; i++) {
+	for (idx_t i = 0; i < 5; i++) {
 		a = Key::EncodeDouble(generate_double(-50, 50));
 		b = Key::EncodeDouble(generate_double(-50, 50));
 		min_values.push_back(min(a, b));
 		max_values.push_back(max(a, b));
 	}
 	//! Generate 500 big-big range queries
-	for (index_t i = 0; i < 5; i++) {
+	for (idx_t i = 0; i < 5; i++) {
 		a = Key::EncodeDouble(generate_double(FLT_MIN, FLT_MAX));
 		b = Key::EncodeDouble(generate_double(FLT_MIN, FLT_MAX));
 		min_values.push_back(min(a, b));
 		max_values.push_back(max(a, b));
 	}
-	for (index_t i = 0; i < min_values.size(); i++) {
+	for (idx_t i = 0; i < min_values.size(); i++) {
 		int64_t low = Key::EncodeDouble(min_values[i]);
 		int64_t high = Key::EncodeDouble(max_values[i]);
 		int answer = full_scan<int64_t>(keys.get(), n, low, high);
@@ -1264,7 +1264,7 @@ TEST_CASE("ART Floating Point Double Small", "[art-double-small]") {
 		if (!CHECK_COLUMN(result, 0, {answer})) {
 			cout << "Wrong answer on double!" << std::endl << "Queries to reproduce:" << std::endl;
 			cout << "CREATE TABLE numbers(i BIGINT);" << std::endl;
-			for (index_t k = 0; k < n; k++) {
+			for (idx_t k = 0; k < n; k++) {
 				cout << "INSERT INTO numbers VALUES (" << keys[k] << ");" << std::endl;
 			}
 			cout << query << std::endl;
@@ -1327,51 +1327,51 @@ TEST_CASE("ART Floating Point", "[art-float][.]") {
 	vector<int64_t> min_values, max_values;
 	Connection con(db);
 	//! Will use 10k keys
-	index_t n = 10000;
+	idx_t n = 10000;
 	auto keys = unique_ptr<int64_t[]>(new int64_t[n]);
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE numbers(i BIGINT)"));
 	//! Generate 1000 small floats (0.0 - 1.0)
-	for (index_t i = 0; i < n / 10; i++) {
+	for (idx_t i = 0; i < n / 10; i++) {
 		keys[i] = Key::EncodeFloat(generate_small_float());
 	}
 
 	//! Generate 4000 floats (-50/50)
-	for (index_t i = n / 10; i < n / 2; i++) {
+	for (idx_t i = n / 10; i < n / 2; i++) {
 		keys[i] = Key::EncodeFloat(generate_float(-50, 50));
 	}
 	//! Generate 5000 floats (min/max)
-	for (index_t i = n / 2; i < n; i++) {
+	for (idx_t i = n / 2; i < n; i++) {
 		keys[i] = Key::EncodeFloat(generate_float(FLT_MIN, FLT_MAX));
 	}
 	//! Insert values and create index
 	REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION"));
-	for (index_t i = 0; i < n; i++) {
+	for (idx_t i = 0; i < n; i++) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO numbers VALUES (" + to_string(keys[i]) + ")"));
 	}
 	REQUIRE_NO_FAIL(con.Query("COMMIT"));
 	REQUIRE_NO_FAIL(con.Query("CREATE INDEX i_index ON numbers(i)"));
 	//! Generate 500 small-small range queries
-	for (index_t i = 0; i < 500; i++) {
+	for (idx_t i = 0; i < 500; i++) {
 		a = Key::EncodeFloat(generate_small_float());
 		b = Key::EncodeFloat(generate_small_float());
 		min_values.push_back(min(a, b));
 		max_values.push_back(max(a, b));
 	}
 	//! Generate 500 normal-normal range queries
-	for (index_t i = 0; i < 500; i++) {
+	for (idx_t i = 0; i < 500; i++) {
 		a = Key::EncodeFloat(generate_float(-50, 50));
 		b = Key::EncodeFloat(generate_float(-50, 50));
 		min_values.push_back(min(a, b));
 		max_values.push_back(max(a, b));
 	}
 	//! Generate 500 big-big range queries
-	for (index_t i = 0; i < 500; i++) {
+	for (idx_t i = 0; i < 500; i++) {
 		a = Key::EncodeFloat(generate_float(FLT_MIN, FLT_MAX));
 		b = Key::EncodeFloat(generate_float(FLT_MIN, FLT_MAX));
 		min_values.push_back(min(a, b));
 		max_values.push_back(max(a, b));
 	}
-	for (index_t i = 0; i < min_values.size(); i++) {
+	for (idx_t i = 0; i < min_values.size(); i++) {
 		int64_t low = Key::EncodeFloat(min_values[i]);
 		int64_t high = Key::EncodeFloat(max_values[i]);
 		int answer = full_scan<int64_t>(keys.get(), n, low, high);
@@ -1381,7 +1381,7 @@ TEST_CASE("ART Floating Point", "[art-float][.]") {
 		if (!CHECK_COLUMN(result, 0, {answer})) {
 			cout << "Wrong answer on floating point real-small!" << std::endl << "Queries to reproduce:" << std::endl;
 			cout << "CREATE TABLE numbers(i BIGINT);" << std::endl;
-			for (index_t k = 0; k < n; k++) {
+			for (idx_t k = 0; k < n; k++) {
 				cout << "INSERT INTO numbers VALUES (" << keys[k] << ");" << std::endl;
 			}
 			cout << query << std::endl;
@@ -1399,51 +1399,51 @@ TEST_CASE("ART Floating Point Double", "[art-double][.]") {
 	vector<int64_t> min_values, max_values;
 	Connection con(db);
 	//! Will use 10000 keys
-	index_t n = 10000;
+	idx_t n = 10000;
 	auto keys = unique_ptr<int64_t[]>(new int64_t[n]);
 	con.Query("CREATE TABLE numbers(i BIGINT)");
 	//! Generate 1000 small floats (0.0 - 1.0)
-	for (index_t i = 0; i < n / 10; i++) {
+	for (idx_t i = 0; i < n / 10; i++) {
 		keys[i] = Key::EncodeFloat(generate_small_float());
 	}
 
 	//! Generate 4000 floats (-50/50)
-	for (index_t i = n / 10; i < n / 2; i++) {
+	for (idx_t i = n / 10; i < n / 2; i++) {
 		keys[i] = Key::EncodeFloat(generate_float(-50, 50));
 	}
 	//! Generate 5000 floats (min/max)
-	for (index_t i = n / 2; i < n; i++) {
+	for (idx_t i = n / 2; i < n; i++) {
 		keys[i] = Key::EncodeFloat(generate_float(FLT_MIN, FLT_MAX));
 	}
 	//! Insert values and create index
 	REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION"));
-	for (index_t i = 0; i < n; i++) {
+	for (idx_t i = 0; i < n; i++) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO numbers VALUES (" + to_string(keys[i]) + ")"));
 	}
 	REQUIRE_NO_FAIL(con.Query("COMMIT"));
 	REQUIRE_NO_FAIL(con.Query("CREATE INDEX i_index ON numbers(i)"));
 	//! Generate 500 small-small range queries
-	for (index_t i = 0; i < 500; i++) {
+	for (idx_t i = 0; i < 500; i++) {
 		a = Key::EncodeDouble(generate_small_double());
 		b = Key::EncodeDouble(generate_small_double());
 		min_values.push_back(min(a, b));
 		max_values.push_back(max(a, b));
 	}
 	//! Generate 500 normal-normal range queries
-	for (index_t i = 0; i < 500; i++) {
+	for (idx_t i = 0; i < 500; i++) {
 		a = Key::EncodeDouble(generate_double(-50, 50));
 		b = Key::EncodeDouble(generate_double(-50, 50));
 		min_values.push_back(min(a, b));
 		max_values.push_back(max(a, b));
 	}
 	//! Generate 500 big-big range queries
-	for (index_t i = 0; i < 500; i++) {
+	for (idx_t i = 0; i < 500; i++) {
 		a = Key::EncodeDouble(generate_double(FLT_MIN, FLT_MAX));
 		b = Key::EncodeDouble(generate_double(FLT_MIN, FLT_MAX));
 		min_values.push_back(min(a, b));
 		max_values.push_back(max(a, b));
 	}
-	for (index_t i = 0; i < min_values.size(); i++) {
+	for (idx_t i = 0; i < min_values.size(); i++) {
 		int64_t low = Key::EncodeDouble(min_values[i]);
 		int64_t high = Key::EncodeDouble(max_values[i]);
 		int answer = full_scan<int64_t>(keys.get(), n, low, high);
@@ -1453,7 +1453,7 @@ TEST_CASE("ART Floating Point Double", "[art-double][.]") {
 		if (!CHECK_COLUMN(result, 0, {answer})) {
 			cout << "Wrong answer on floating point real-small!" << std::endl << "Queries to reproduce:" << std::endl;
 			cout << "CREATE TABLE numbers(i BIGINT);" << std::endl;
-			for (index_t k = 0; k < n; k++) {
+			for (idx_t k = 0; k < n; k++) {
 				cout << "INSERT INTO numbers VALUES (" << keys[k] << ");" << std::endl;
 			}
 			cout << query << std::endl;
@@ -1588,7 +1588,7 @@ TEST_CASE("Test updates resulting from big index scans", "[art][.]") {
 
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i integer)"));
 	REQUIRE_NO_FAIL(con.Query("CREATE INDEX i_index ON integers(i)"));
-	for (index_t i = 0; i < 25000; i++) {
+	for (idx_t i = 0; i < 25000; i++) {
 		int32_t value = i + 1;
 
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES ($1)", value));
@@ -1627,17 +1627,17 @@ TEST_CASE("ART Node 4", "[art]") {
 	Connection con(db);
 
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i integer)"));
-	index_t n = 4;
+	idx_t n = 4;
 	auto keys = unique_ptr<int32_t[]>(new int32_t[n]);
-	for (index_t i = 0; i < n; i++) {
+	for (idx_t i = 0; i < n; i++) {
 		keys[i] = i + 1;
 	}
 
-	for (index_t i = 0; i < n; i++) {
+	for (idx_t i = 0; i < n; i++) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES ($1)", keys[i]));
 	}
 
-	for (index_t i = 0; i < n; i++) {
+	for (idx_t i = 0; i < n; i++) {
 		result = con.Query("SELECT i FROM integers WHERE i=$1", keys[i]);
 		REQUIRE(CHECK_COLUMN(result, 0, {Value(keys[i])}));
 	}
@@ -1647,7 +1647,7 @@ TEST_CASE("ART Node 4", "[art]") {
 	result = con.Query("SELECT sum(i) FROM integers WHERE i > 1");
 	REQUIRE(CHECK_COLUMN(result, 0, {Value(2 + 3 + 4)}));
 	// Now Deleting all elements
-	for (index_t i = 0; i < n; i++) {
+	for (idx_t i = 0; i < n; i++) {
 		REQUIRE_NO_FAIL(con.Query("DELETE FROM integers WHERE i=$1", keys[i]));
 	}
 	REQUIRE_NO_FAIL(con.Query("DELETE FROM integers WHERE i = 0"));
@@ -1662,17 +1662,17 @@ TEST_CASE("ART Node 16", "[art]") {
 	Connection con(db);
 
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i integer)"));
-	index_t n = 6;
+	idx_t n = 6;
 	auto keys = unique_ptr<int32_t[]>(new int32_t[n]);
-	for (index_t i = 0; i < n; i++) {
+	for (idx_t i = 0; i < n; i++) {
 		keys[i] = i + 1;
 	}
 
-	for (index_t i = 0; i < n; i++) {
+	for (idx_t i = 0; i < n; i++) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES ($1)", keys[i]));
 	}
 	REQUIRE_NO_FAIL(con.Query("CREATE INDEX i_index ON integers(i)"));
-	for (index_t i = 0; i < n; i++) {
+	for (idx_t i = 0; i < n; i++) {
 		result = con.Query("SELECT i FROM integers WHERE i=$1", keys[i]);
 		REQUIRE(CHECK_COLUMN(result, 0, {Value(keys[i])}));
 	}
@@ -1681,7 +1681,7 @@ TEST_CASE("ART Node 16", "[art]") {
 	result = con.Query("SELECT sum(i) FROM integers WHERE i > 4");
 	REQUIRE(CHECK_COLUMN(result, 0, {Value(5 + 6)}));
 	// Now Deleting all elements
-	for (index_t i = 0; i < n; i++) {
+	for (idx_t i = 0; i < n; i++) {
 		REQUIRE_NO_FAIL(con.Query("DELETE FROM integers WHERE i=$1", keys[i]));
 	}
 	REQUIRE_NO_FAIL(con.Query("DROP INDEX i_index"));
@@ -1695,18 +1695,18 @@ TEST_CASE("ART Node 48", "[art]") {
 	Connection con(db);
 
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i integer)"));
-	index_t n = 20;
+	idx_t n = 20;
 	auto keys = unique_ptr<int32_t[]>(new int32_t[n]);
-	for (index_t i = 0; i < n; i++) {
+	for (idx_t i = 0; i < n; i++) {
 		keys[i] = i + 1;
 	}
 	int64_t expected_sum = 0;
-	for (index_t i = 0; i < n; i++) {
+	for (idx_t i = 0; i < n; i++) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES ($1)", keys[i]));
 		expected_sum += keys[i];
 	}
 	REQUIRE_NO_FAIL(con.Query("CREATE INDEX i_index ON integers(i)"));
-	for (index_t i = 0; i < n; i++) {
+	for (idx_t i = 0; i < n; i++) {
 		result = con.Query("SELECT i FROM integers WHERE i=$1", keys[i]);
 		REQUIRE(CHECK_COLUMN(result, 0, {Value(keys[i])}));
 	}
@@ -1726,7 +1726,7 @@ TEST_CASE("ART Node 48", "[art]") {
 	REQUIRE(CHECK_COLUMN(result, 0, {Value(16 + 17 + 18 + 19 + 20)}));
 
 	// Now delete all elements
-	for (index_t i = 0; i < n; i++) {
+	for (idx_t i = 0; i < n; i++) {
 		REQUIRE_NO_FAIL(con.Query("DELETE FROM integers WHERE i=$1", keys[i]));
 		expected_sum -= keys[i];
 		// verify the sum

--- a/test/sql/index/test_art_keys.cpp
+++ b/test/sql/index/test_art_keys.cpp
@@ -30,8 +30,8 @@ static void TestKeyBigger(Key &big, Key &small) {
 }
 
 static void TestKeys(vector<unique_ptr<Key>> &keys) {
-	for (index_t outer = 0; outer < keys.size(); outer++) {
-		for (index_t inner = 0; inner < keys.size(); inner++) {
+	for (idx_t outer = 0; outer < keys.size(); outer++) {
+		for (idx_t inner = 0; inner < keys.size(); inner++) {
 			if (inner == outer) {
 				TestKeyEqual(*keys[inner], *keys[outer]);
 			} else if (inner > outer) {
@@ -170,7 +170,7 @@ TEST_CASE("Test correct functioning of art EncodeFloat/EncodeDouble", "[art-enc]
 		}
 		std::sort(values.begin(), values.end());
 		uint32_t current_encoded = Key::EncodeFloat(values[0]);
-		for (index_t i = 1; i < values.size(); i++) {
+		for (idx_t i = 1; i < values.size(); i++) {
 			uint32_t next_encoded = Key::EncodeFloat(values[i]);
 			if (!(next_encoded > current_encoded)) {
 				printf("Failure in Key::EncodeFloat!\n");
@@ -199,7 +199,7 @@ TEST_CASE("Test correct functioning of art EncodeFloat/EncodeDouble", "[art-enc]
 		}
 		std::sort(values.begin(), values.end());
 		uint64_t current_encoded = Key::EncodeDouble(values[0]);
-		for (index_t i = 1; i < values.size(); i++) {
+		for (idx_t i = 1; i < values.size(); i++) {
 			uint64_t next_encoded = Key::EncodeDouble(values[i]);
 			if (!(next_encoded > current_encoded)) {
 				cout << "Failure in Key::EncodeDouble!" << std::endl;

--- a/test/sql/join/test_unequal_join.cpp
+++ b/test/sql/join/test_unequal_join.cpp
@@ -41,7 +41,7 @@ TEST_CASE("Test less than join", "[join][.]") {
 	con.EnableQueryVerification();
 
 	REQUIRE_NO_FAIL(con.Query("create table a (i integer)"));
-	for (index_t i = 0; i < 2000; i++) {
+	for (idx_t i = 0; i < 2000; i++) {
 		REQUIRE_NO_FAIL(con.Query("insert into a values ($1)", (int32_t)i + 1));
 	}
 
@@ -69,7 +69,7 @@ TEST_CASE("Test joins with different types", "[join]") {
 	for (auto &type : numeric_types) {
 		REQUIRE_NO_FAIL(con.Query("begin transaction"));
 		REQUIRE_NO_FAIL(con.Query("create table a (i " + type + ")"));
-		for (index_t i = 0; i < 100; i++) {
+		for (idx_t i = 0; i < 100; i++) {
 			REQUIRE_NO_FAIL(con.Query("insert into a values ($1)", (int32_t)i + 1));
 		}
 		// range joins
@@ -130,7 +130,7 @@ TEST_CASE("Test mark join with different types", "[join]") {
 	for (auto &type : numeric_types) {
 		REQUIRE_NO_FAIL(con.Query("begin transaction"));
 		REQUIRE_NO_FAIL(con.Query("create table a (i " + type + ")"));
-		for (index_t i = 0; i < 100; i++) {
+		for (idx_t i = 0; i < 100; i++) {
 			REQUIRE_NO_FAIL(con.Query("insert into a values ($1)", (int32_t)i + 1));
 		}
 		// range joins

--- a/test/sql/prepared/test_prepared.cpp
+++ b/test/sql/prepared/test_prepared.cpp
@@ -325,7 +325,7 @@ TEST_CASE("PREPARE and WAL", "[prepared][.]") {
 		result = con.Query("SELECT a FROM t");
 		REQUIRE(CHECK_COLUMN(result, 0, {43}));
 	}
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(prepare_database);
 		Connection con(db);
 

--- a/test/sql/storage/test_big_storage.cpp
+++ b/test/sql/storage/test_big_storage.cpp
@@ -82,7 +82,7 @@ TEST_CASE("Test storage that exceeds a single block with different types", "[sto
 		sum = result->GetValue(0, 0);
 	}
 	// reload the database from disk
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		result = con.Query("SELECT SUM(a) + SUM(b) FROM test");
@@ -122,7 +122,7 @@ TEST_CASE("Test storing strings that exceed a single block", "[storage][.]") {
 		                     {count_per_group, count_per_group, count_per_group, count_per_group, count_per_group}));
 	}
 	// reload the database from disk
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		result = con.Query("SELECT a, COUNT(*) FROM test GROUP BY a ORDER BY a");
@@ -137,7 +137,7 @@ TEST_CASE("Test storing strings that exceed a single block", "[storage][.]") {
 		REQUIRE_NO_FAIL(con.Query("UPDATE test SET a='aaa' WHERE a='a'"));
 	}
 	// reload the database from disk again
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		result = con.Query("SELECT a, COUNT(*) FROM test GROUP BY a ORDER BY a");
@@ -178,7 +178,7 @@ TEST_CASE("Test storing big strings", "[storage][.]") {
 		REQUIRE(CHECK_COLUMN(result, 0, {Value::BIGINT(string_length)}));
 	}
 	// reload the database from disk
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		result = con.Query("SELECT LENGTH(a) FROM test");

--- a/test/sql/storage/test_buffer_manager.cpp
+++ b/test/sql/storage/test_buffer_manager.cpp
@@ -39,7 +39,7 @@ TEST_CASE("Test scanning a table and computing an aggregate over a table that ex
 		result = con.Query("SELECT SUM(a) + SUM(b) FROM test");
 		REQUIRE(CHECK_COLUMN(result, 0, {sum}));
 	}
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		result = con.Query("SELECT SUM(a) + SUM(b) FROM test");
@@ -100,7 +100,7 @@ TEST_CASE("Test storing a big string that exceeds buffer manager size", "[storag
 	}
 	{
 		// reloading with a bigger limit again makes it work
-		config->maximum_memory = (index_t)-1;
+		config->maximum_memory = (idx_t)-1;
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		result = con.Query("SELECT LENGTH(a) FROM test");
@@ -147,7 +147,7 @@ TEST_CASE("Test appending and checkpointing a table that exceeds buffer manager 
 		REQUIRE(CHECK_COLUMN(result, 2, {Value::BIGINT(sum_a)}));
 		REQUIRE(CHECK_COLUMN(result, 3, {Value::BIGINT(sum_b)}));
 	}
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		// reload the table and checkpoint, still with a 10MB limit
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
@@ -173,9 +173,9 @@ TEST_CASE("Modifying the buffer manager limit at runtime for an in-memory databa
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE test (a INTEGER);"));
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO test VALUES (1), (2), (3), (NULL)"));
 
-	index_t not_null_size = 3;
-	index_t size = 4;
-	index_t sum = 6;
+	idx_t not_null_size = 3;
+	idx_t size = 4;
+	idx_t sum = 6;
 	for (; size < table_size; size *= 2) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO test SELECT * FROM test"));
 		not_null_size *= 2;

--- a/test/sql/storage/test_commit_abort.cpp
+++ b/test/sql/storage/test_commit_abort.cpp
@@ -58,7 +58,7 @@ TEST_CASE("Test abort of commit with persistent storage", "[storage]") {
 		REQUIRE(CHECK_COLUMN(result, 5, {expected_sum_strlen}));
 	}
 	// reload the database from disk
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		result = con.Query("SELECT COUNT(*), COUNT(a), COUNT(b), SUM(a), SUM(b), SUM(LENGTH(c)) FROM test");
@@ -97,7 +97,7 @@ TEST_CASE("Test abort of large commit with persistent storage", "[storage][.]") 
 		// insert the value 14 in con
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO test VALUES (14, 10, 'con')"));
 		// now insert many non-conflicting values in con2
-		index_t tpl_count = 2 * Storage::BLOCK_SIZE / sizeof(int);
+		idx_t tpl_count = 2 * Storage::BLOCK_SIZE / sizeof(int);
 		for (int i = 0; i < (int)tpl_count; i++) {
 			REQUIRE_NO_FAIL(con2.Query("INSERT INTO test VALUES (" + to_string(15 + i) + ", 10, 'con2')"));
 		}
@@ -129,7 +129,7 @@ TEST_CASE("Test abort of large commit with persistent storage", "[storage][.]") 
 		REQUIRE(CHECK_COLUMN(result, 5, {expected_sum_strlen}));
 	}
 	// reload the database from disk
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		result = con.Query("SELECT COUNT(*), COUNT(a), COUNT(b), SUM(a), SUM(b), SUM(LENGTH(c)) FROM test");

--- a/test/sql/storage/test_database_size.cpp
+++ b/test/sql/storage/test_database_size.cpp
@@ -6,8 +6,8 @@ using namespace duckdb;
 using namespace std;
 
 TEST_CASE("Test that database size does not grow after many checkpoints", "[storage][.]") {
-	constexpr index_t VALUE_COUNT = 10000;
-	index_t expected_sum = 0;
+	constexpr idx_t VALUE_COUNT = 10000;
+	idx_t expected_sum = 0;
 
 	FileSystem fs;
 	auto config = GetTestConfig();
@@ -23,7 +23,7 @@ TEST_CASE("Test that database size does not grow after many checkpoints", "[stor
 		Connection con(db);
 		REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION;"));
 		REQUIRE_NO_FAIL(con.Query("CREATE TABLE test(a INTEGER);"));
-		for (index_t i = 0; i < VALUE_COUNT; i++) {
+		for (idx_t i = 0; i < VALUE_COUNT; i++) {
 			REQUIRE_NO_FAIL(con.Query("INSERT INTO test VALUES (" + to_string(i) + ");"));
 			expected_sum += i;
 		}
@@ -45,7 +45,7 @@ TEST_CASE("Test that database size does not grow after many checkpoints", "[stor
 		REQUIRE(size >= 0);
 	}
 	// now reload the database a bunch of times, and everytime we reload update all the values
-	for (index_t i = 0; i < 20; i++) {
+	for (idx_t i = 0; i < 20; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		// verify the current count

--- a/test/sql/storage/test_shutdown.cpp
+++ b/test/sql/storage/test_shutdown.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Shutdown with running transaction", "[storage]") {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO test VALUES (22, 23);"));
 	}
 	// reload the database from disk
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		result = con.Query("SELECT * FROM test ORDER BY a");
@@ -49,7 +49,7 @@ TEST_CASE("UNIQUE INDEX after shutdown", "[storage]") {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO test VALUES (11, 22), (13, 22);"));
 	}
 	// reload the database from disk
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 
@@ -77,7 +77,7 @@ TEST_CASE("CREATE INDEX statement after shutdown", "[storage]") {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO test VALUES (11, 22), (13, 22);"));
 	}
 	// reload the database from disk
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 
@@ -104,7 +104,7 @@ TEST_CASE("CREATE INDEX statement after shutdown", "[storage]") {
 		REQUIRE(CHECK_COLUMN(result, 1, {22, 22}));
 	}
 	// now with updates
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 

--- a/test/sql/storage/test_storage.cpp
+++ b/test/sql/storage/test_storage.cpp
@@ -72,7 +72,7 @@ TEST_CASE("Test simple storage", "[storage]") {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO test2 VALUES (13), (12), (11)"));
 	}
 	// reload the database from disk a few times
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		result = con.Query("SELECT * FROM test ORDER BY a");
@@ -100,7 +100,7 @@ TEST_CASE("Test storing NULLs and strings", "[storage]") {
 		                          "(13, 'abcdefgh'), (12, NULL)"));
 	}
 	// reload the database from disk a few times
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		result = con.Query("SELECT a, b FROM test ORDER BY a");
@@ -131,7 +131,7 @@ TEST_CASE("Test updates/deletes and strings", "[storage]") {
 		REQUIRE_NO_FAIL(con.Query("UPDATE test SET a=a+1"));
 	}
 	// reload the database from disk a few times
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		result = con.Query("SELECT a, b FROM test ORDER BY a");
@@ -162,7 +162,7 @@ TEST_CASE("Test deletes with storage", "[storage]") {
 		REQUIRE_NO_FAIL(con.Query("COMMIT"));
 	}
 	// reload the database from disk
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		result = con.Query("SELECT a, b FROM test ORDER BY a");
@@ -191,7 +191,7 @@ TEST_CASE("Test updates with storage", "[storage]") {
 		REQUIRE_NO_FAIL(con.Query("COMMIT"));
 	}
 	// reload the database from disk
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		result = con.Query("SELECT a, b FROM test ORDER BY a");
@@ -222,7 +222,7 @@ TEST_CASE("Test mix of updates and deletes with storage", "[storage]") {
 		REQUIRE_NO_FAIL(con.Query("COMMIT"));
 	}
 	// reload the database from disk
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		result = con.Query("SELECT a, b FROM test ORDER BY a");
@@ -246,7 +246,7 @@ TEST_CASE("Test large inserts in a single transaction", "[storage]") {
 		Connection con(db);
 		REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION;"));
 		REQUIRE_NO_FAIL(con.Query("CREATE TABLE test (a INTEGER, b INTEGER);"));
-		for (index_t i = 0; i < 1000; i++) {
+		for (idx_t i = 0; i < 1000; i++) {
 			REQUIRE_NO_FAIL(con.Query("INSERT INTO test VALUES (11, 22), (13, 22), (12, 21)"));
 			expected_sum_a += 11 + 13;
 			expected_sum_b += 22 + 22;
@@ -261,7 +261,7 @@ TEST_CASE("Test large inserts in a single transaction", "[storage]") {
 		REQUIRE(CHECK_COLUMN(result, 2, {Value::BIGINT(expected_count)}));
 	}
 	// reload the database from disk
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		result = con.Query("SELECT SUM(a), SUM(b), COUNT(*) FROM test");
@@ -286,9 +286,9 @@ TEST_CASE("Test interleaving of insertions/updates/deletes on multiple tables", 
 		REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION;"));
 		REQUIRE_NO_FAIL(con.Query("CREATE TABLE test (a INTEGER);"));
 		REQUIRE_NO_FAIL(con.Query("CREATE TABLE test2 (a INTEGER, b INTEGER);"));
-		index_t test_insert = 0, test_insert2 = 0;
-		for (index_t i = 0; i < 1000; i++) {
-			index_t stage = i % 7;
+		idx_t test_insert = 0, test_insert2 = 0;
+		for (idx_t i = 0; i < 1000; i++) {
+			idx_t stage = i % 7;
 			switch (stage) {
 			case 0:
 				for (; test_insert < i; test_insert++) {
@@ -328,7 +328,7 @@ TEST_CASE("Test interleaving of insertions/updates/deletes on multiple tables", 
 		REQUIRE(CHECK_COLUMN(result, 1, {405513}));
 	}
 	// reload the database from disk
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		result = con.Query("SELECT SUM(a) FROM test ORDER BY 1");
@@ -377,7 +377,7 @@ TEST_CASE("Test update/deletes on big table", "[storage][.]") {
 		REQUIRE(CHECK_COLUMN(result, 0, {0}));
 	}
 	// reload the database from disk
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		result = con.Query("SELECT SUM(a), COUNT(a) FROM test");

--- a/test/sql/storage/test_storage_scan.cpp
+++ b/test/sql/storage/test_storage_scan.cpp
@@ -21,7 +21,7 @@ TEST_CASE("Test scanning of persisted storage", "[storage]") {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO test VALUES (11), (12), (13), (14), (15), (NULL)"));
 	}
 	// perform read-only scans a few times
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		result = con.Query("SELECT * FROM test ORDER BY a");

--- a/test/sql/storage/test_store_alter.cpp
+++ b/test/sql/storage/test_store_alter.cpp
@@ -18,7 +18,7 @@ TEST_CASE("Test storage of alter table", "[storage]") {
 		Connection con(db);
 		REQUIRE_NO_FAIL(con.Query("CREATE TABLE test (a INTEGER, b INTEGER);"));
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO test VALUES (11, 22), (13, 22), (12, 21)"));
-		for (index_t i = 0; i < 2; i++) {
+		for (idx_t i = 0; i < 2; i++) {
 			REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION"));
 			result = con.Query("SELECT a FROM test ORDER BY a");
 			REQUIRE(CHECK_COLUMN(result, 0, {11, 12, 13}));
@@ -31,7 +31,7 @@ TEST_CASE("Test storage of alter table", "[storage]") {
 		}
 	}
 	// reload the database from disk
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		DuckDB db(storage_database, config.get());
 		Connection con(db);
 		result = con.Query("SELECT k FROM test ORDER BY k");

--- a/test/sql/tpch/test_tpch.cpp
+++ b/test/sql/tpch/test_tpch.cpp
@@ -30,7 +30,7 @@ TEST_CASE("Test TPC-H SF0.01", "[tpch]") {
 	tpch::dbgen(sf, db);
 
 	// test all the basic queries
-	for (index_t i = 1; i <= 22; i++) {
+	for (idx_t i = 1; i <= 22; i++) {
 		result = con.Query(tpch::get_query(i));
 		COMPARE_CSV(result, tpch::get_answer(sf, i), true);
 	}
@@ -105,7 +105,7 @@ TEST_CASE("Test TPC-H SF0.1", "[tpch][.]") {
 	REQUIRE(CHECK_COLUMN(result, 0, {0}));
 
 	// test all the basic queries
-	for (index_t i = 1; i <= 22; i++) {
+	for (idx_t i = 1; i <= 22; i++) {
 		result = con.Query(tpch::get_query(i));
 		COMPARE_CSV(result, tpch::get_answer(sf, i), true);
 	}

--- a/test/sql/transactions/test_big_transaction_abort.cpp
+++ b/test/sql/transactions/test_big_transaction_abort.cpp
@@ -58,7 +58,7 @@ TEST_CASE("Test abort of big append", "[transactions][.]") {
 	// insert two blocks worth of values into the table in con2, plus the value [1]
 	// and the value [1] in con
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (1);"));
-	index_t tpl_count = 2 * Storage::BLOCK_SIZE / sizeof(int);
+	idx_t tpl_count = 2 * Storage::BLOCK_SIZE / sizeof(int);
 	auto prepared = con2.Prepare("INSERT INTO integers VALUES (?)");
 	for (int i = 2; i < (int32_t)tpl_count; i++) {
 		REQUIRE_NO_FAIL(prepared->Execute(i));

--- a/test/sql/transactions/test_multiple_versions.cpp
+++ b/test/sql/transactions/test_multiple_versions.cpp
@@ -85,7 +85,7 @@ TEST_CASE("Test multiple versions of the same data with a data set that exceeds 
 	result = con.Query("SELECT SUM(i) FROM integers");
 	REQUIRE(CHECK_COLUMN(result, 0, {Value::BIGINT(expected_sum)}));
 
-	for (index_t i = 1; i <= 4; i++) {
+	for (idx_t i = 1; i <= 4; i++) {
 		// now delete some tuples
 		REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION;"));
 		REQUIRE_NO_FAIL(con.Query("DELETE FROM integers WHERE i=" + to_string(i)));

--- a/test/sql/transactions/test_transaction_local.cpp
+++ b/test/sql/transactions/test_transaction_local.cpp
@@ -148,7 +148,7 @@ TEST_CASE("Test operations on transaction local data with unique indices", "[tra
 	con.EnableQueryVerification();
 
 	// perform different operations on the same data within one transaction
-	for (index_t i = 0; i < 3; i++) {
+	for (idx_t i = 0; i < 3; i++) {
 		REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION"));
 		REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER PRIMARY KEY, j INTEGER)"));
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (1, 3), (2, 3)"));

--- a/test/sql/update/test_string_update.cpp
+++ b/test/sql/update/test_string_update.cpp
@@ -245,7 +245,7 @@ TEST_CASE("Test string updates with many strings", "[update][.]") {
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO test VALUES ('a'), ('b'), ('c'), (NULL)"));
 
 	// insert the same strings many times
-	index_t size = 4 * sizeof(int32_t);
+	idx_t size = 4 * sizeof(int32_t);
 	while (size < Storage::BLOCK_SIZE * 2) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO test SELECT * FROM test"));
 		size *= 4;
@@ -296,7 +296,7 @@ TEST_CASE("Test update of big string", "[update][.]") {
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO test VALUES ('abcdefghijklmnopqrstuvwxyz')"));
 
 	// increase the size of the string until it is bigger than a block
-	index_t size = 26;
+	idx_t size = 26;
 	while (size < Storage::BLOCK_SIZE * 2) {
 		// concat the string 10x and insert it
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO test SELECT a||a||a||a||a||a||a||a||a||a FROM test"));

--- a/test/sql/update/test_update.cpp
+++ b/test/sql/update/test_update.cpp
@@ -139,7 +139,7 @@ TEST_CASE("Test update behavior with multiple updaters", "[update]") {
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO test VALUES (1), (2), (3)"));
 
 	// now we start updating specific values and reading different versions
-	for (index_t i = 0; i < 2; i++) {
+	for (idx_t i = 0; i < 2; i++) {
 		REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION"));
 		REQUIRE_NO_FAIL(u1.Query("UPDATE test SET a=4 WHERE a=1"));
 		REQUIRE_NO_FAIL(con2.Query("BEGIN TRANSACTION"));

--- a/test/sql/varchar/test_big_varchar.cpp
+++ b/test/sql/varchar/test_big_varchar.cpp
@@ -13,7 +13,7 @@ TEST_CASE("Insert big varchar strings", "[varchar]") {
 	// insert a big varchar
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO test VALUES ('aaaaaaaaaa')"));
 	// sizes: 10, 100, 1000, 10000
-	for (index_t i = 0; i < 3; i++) {
+	for (idx_t i = 0; i < 3; i++) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO test SELECT a||a||a||a||a||a||a||a||a||a FROM test WHERE "
 		                          "LENGTH(a)=(SELECT MAX(LENGTH(a)) FROM test)"));
 	}
@@ -37,7 +37,7 @@ TEST_CASE("Test scanning many big varchar strings with limited memory", "[varcha
 	// create a big varchar (10K characters)
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO test VALUES ('aaaaaaaaaa')"));
 	// sizes: 10, 100, 1000, 10000
-	for (index_t i = 0; i < 3; i++) {
+	for (idx_t i = 0; i < 3; i++) {
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO test SELECT a||a||a||a||a||a||a||a||a||a FROM test WHERE "
 		                          "LENGTH(a)=(SELECT MAX(LENGTH(a)) FROM test)"));
 	}
@@ -46,7 +46,7 @@ TEST_CASE("Test scanning many big varchar strings with limited memory", "[varcha
 	REQUIRE_NO_FAIL(
 	    con.Query("INSERT INTO bigtable SELECT a FROM test WHERE LENGTH(a)=(SELECT MAX(LENGTH(a)) FROM test)"));
 
-	index_t entries = 1;
+	idx_t entries = 1;
 
 	// verify that the append worked
 	result = con.Query("SELECT COUNT(*), COUNT(a), MAX(LENGTH(a)), SUM(LENGTH(a)) FROM bigtable");

--- a/tools/rest/server.cpp
+++ b/tools/rest/server.cpp
@@ -81,7 +81,7 @@ void serialize_chunk(QueryResult *res, DataChunk *chunk, json &j) {
 			// int types
 			v->Cast(TypeId::INT64);
 			auto data_ptr = (int64_t *)v->GetData();
-			VectorOperations::Exec(*v, [&](index_t i, index_t k) {
+			VectorOperations::Exec(*v, [&](idx_t i, idx_t k) {
 				if (!v->nullmask[i]) {
 					j["data"][col_idx] += data_ptr[i];
 
@@ -96,7 +96,7 @@ void serialize_chunk(QueryResult *res, DataChunk *chunk, json &j) {
 			v->Cast(TypeId::DOUBLE);
 
 			auto data_ptr = (double *)v->GetData();
-			VectorOperations::Exec(*v, [&](index_t i, index_t k) {
+			VectorOperations::Exec(*v, [&](idx_t i, idx_t k) {
 				if (!v->nullmask[i]) {
 					j["data"][col_idx] += data_ptr[i];
 
@@ -108,7 +108,7 @@ void serialize_chunk(QueryResult *res, DataChunk *chunk, json &j) {
 		}
 		case TypeId::VARCHAR: {
 			auto data_ptr = (char **)v->GetData();
-			VectorOperations::Exec(*v, [&](index_t i, index_t k) {
+			VectorOperations::Exec(*v, [&](idx_t i, idx_t k) {
 				if (!v->nullmask[i]) {
 					j["data"][col_idx] += data_ptr[i];
 

--- a/tools/rpkg/src/Makevars
+++ b/tools/rpkg/src/Makevars
@@ -1,2 +1,3 @@
+CXX_STD = CXX11
 PKG_CXXFLAGS = -I.
 OBJECTS=duckdbr.o duckdb.o

--- a/tools/rpkg/src/duckdbr.cpp
+++ b/tools/rpkg/src/duckdbr.cpp
@@ -72,9 +72,9 @@ struct RBooleanType {
 };
 
 template <class SRC, class DST, class RTYPE>
-static void AppendColumnSegment(SRC *source_data, Vector &result, index_t count) {
+static void AppendColumnSegment(SRC *source_data, Vector &result, idx_t count) {
 	auto result_data = (DST *)result.GetData();
-	for (index_t i = 0; i < count; i++) {
+	for (idx_t i = 0; i < count; i++) {
 		auto val = source_data[i];
 		if (RTYPE::IsNull(val)) {
 			result.nullmask[i] = true;
@@ -84,9 +84,9 @@ static void AppendColumnSegment(SRC *source_data, Vector &result, index_t count)
 	}
 }
 
-static void AppendStringSegment(SEXP coldata, Vector &result, index_t row_idx, index_t count) {
+static void AppendStringSegment(SEXP coldata, Vector &result, idx_t row_idx, idx_t count) {
 	auto result_data = (const char **)result.GetData();
-	for (index_t i = 0; i < count; i++) {
+	for (idx_t i = 0; i < count; i++) {
 		SEXP val = STRING_ELT(coldata, row_idx + i);
 		if (val == NA_STRING) {
 			result.nullmask[i] = true;
@@ -96,11 +96,11 @@ static void AppendStringSegment(SEXP coldata, Vector &result, index_t row_idx, i
 	}
 }
 
-static void AppendFactor(SEXP coldata, Vector &result, index_t row_idx, index_t count) {
+static void AppendFactor(SEXP coldata, Vector &result, idx_t row_idx, idx_t count) {
 	auto source_data = INTEGER_POINTER(coldata) + row_idx;
 	auto result_data = (const char **)result.GetData();
 	SEXP factor_levels = GET_LEVELS(coldata);
-	for (index_t i = 0; i < count; i++) {
+	for (idx_t i = 0; i < count; i++) {
 		int val = source_data[i];
 		if (RIntegerType::IsNull(val)) {
 			result.nullmask[i] = true;
@@ -452,9 +452,9 @@ SEXP duckdb_append_R(SEXP connsexp, SEXP namesexp, SEXP valuesexp) {
 	try {
 		Appender appender(*conn, INVALID_SCHEMA, name);
 		auto nrows = LENGTH(VECTOR_ELT(valuesexp, 0));
-		for (index_t row_idx = 0; row_idx < nrows; row_idx += STANDARD_VECTOR_SIZE) {
-			index_t current_count = std::min((index_t)nrows - row_idx, (index_t)STANDARD_VECTOR_SIZE);
-			for (index_t col_idx = 0; col_idx < LENGTH(valuesexp); col_idx++) {
+		for (idx_t row_idx = 0; row_idx < nrows; row_idx += STANDARD_VECTOR_SIZE) {
+			idx_t current_count = std::min((idx_t)nrows - row_idx, (idx_t)STANDARD_VECTOR_SIZE);
+			for (idx_t col_idx = 0; col_idx < LENGTH(valuesexp); col_idx++) {
 				auto &append_data = appender.GetAppendVector(col_idx);
 				SEXP coldata = VECTOR_ELT(valuesexp, col_idx);
 				if (TYPEOF(coldata) == REALSXP && TYPEOF(GET_CLASS(coldata)) == STRSXP &&

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -153,7 +153,7 @@ int sqlite3_prepare_v2(sqlite3 *db,           /* Database handle */
 		stmt->query_string = query;
 		stmt->prepared = move(prepared);
 		stmt->current_row = -1;
-		for (index_t i = 0; i < stmt->prepared->n_param; i++) {
+		for (idx_t i = 0; i < stmt->prepared->n_param; i++) {
 			stmt->bound_names.push_back("$" + to_string(i + 1));
 			stmt->bound_values.push_back(Value());
 		}
@@ -475,7 +475,7 @@ int sqlite3_bind_parameter_index(sqlite3_stmt *stmt, const char *zName) {
 	if (!stmt || !zName) {
 		return 0;
 	}
-	for (index_t i = 0; i < stmt->bound_names.size(); i++) {
+	for (idx_t i = 0; i < stmt->bound_names.size(); i++) {
 		if (stmt->bound_names[i] == string(zName)) {
 			return i + 1;
 		}


### PR DESCRIPTION
Solaris defines `index_t` as well. So regrettably, to comply with R's CRAN policies which require compilation on Solaris, we rename to `idx_t`.