### PR TITLE
Variable Return Types for Table-Producing Functions

### DIFF
--- a/examples/programmatic-querying/main.cpp
+++ b/examples/programmatic-querying/main.cpp
@@ -23,17 +23,14 @@ struct MyScanFunctionData : public TableFunctionData {
 	size_t nrow;
 };
 
-unique_ptr<FunctionData> my_scan_function_init(ClientContext &context) {
-	// initialize the function data structure
-	return make_unique<MyScanFunctionData>();
-}
-
-static void my_scan_bind(vector<Value> inputs, vector<SQLType> &return_types, vector<string> &names) {
+static unique_ptr<FunctionData> my_scan_bind(ClientContext &context, vector<Value> inputs, vector<SQLType> &return_types, vector<string> &names) {
 	names.push_back("some_int");
 	return_types.push_back(SQLType::INTEGER);
 
 	names.push_back("some_string");
 	return_types.push_back(SQLType::VARCHAR);
+
+	return make_unique<MyScanFunctionData>();
 }
 
 void my_scan_function(ClientContext &context, vector<Value> &input, DataChunk &output, FunctionData *dataptr) {
@@ -61,7 +58,7 @@ void my_scan_function(ClientContext &context, vector<Value> &input, DataChunk &o
 class MyScanFunction : public TableFunction {
 public:
 	MyScanFunction()
-	    : TableFunction("my_scan", {}, my_scan_bind, my_scan_function_init, my_scan_function, nullptr){};
+	    : TableFunction("my_scan", {}, my_scan_bind, my_scan_function, nullptr){};
 };
 
 unique_ptr<BoundFunctionExpression> resolve_function(Connection &con, string name, vector<SQLType> function_args,

--- a/examples/programmatic-querying/main.cpp
+++ b/examples/programmatic-querying/main.cpp
@@ -123,12 +123,14 @@ int main() {
 
 	vector<TypeId> types{TypeId::INT32, TypeId::VARCHAR};
 
+	auto bind_data = make_unique<MyScanFunctionData>();
+
 	// TABLE_FUNCTION my_scan
 	vector<unique_ptr<ParsedExpression>> children; // empty
 	auto scan_function_catalog_entry =
 	    con.context->catalog.GetEntry<TableFunctionCatalogEntry>(*con.context, DEFAULT_SCHEMA, "my_scan");
 	vector<Value> parameters; // empty
-	auto scan_function = make_unique<PhysicalTableFunction>(types, scan_function_catalog_entry, move(parameters));
+	auto scan_function = make_unique<PhysicalTableFunction>(types, scan_function_catalog_entry, move(bind_data), move(parameters));
 
 	//  FILTER[some_int<=7 some_int>=3]
 	vector<unique_ptr<Expression>> filter_expressions;

--- a/examples/programmatic-querying/main.cpp
+++ b/examples/programmatic-querying/main.cpp
@@ -8,6 +8,12 @@
 #include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/main/client_context.hpp"
 
+/**
+This file contains an example on how a query tree can be programmatically constructed. This is essentially hand-rolling the binding+planning phase for one specific query.
+
+Note that this API is currently very unstable, and is subject to change at any moment. In general, this API should not be used currently outside of internal use cases.
+**/
+
 using namespace duckdb;
 
 struct MyScanFunctionData : public TableFunctionData {
@@ -17,13 +23,22 @@ struct MyScanFunctionData : public TableFunctionData {
 	size_t nrow;
 };
 
-FunctionData *my_scan_function_init(ClientContext &context) {
+unique_ptr<FunctionData> my_scan_function_init(ClientContext &context) {
 	// initialize the function data structure
-	return new MyScanFunctionData();
+	return make_unique<MyScanFunctionData>();
 }
 
-void my_scan_function(ClientContext &context, DataChunk &input, DataChunk &output, FunctionData *dataptr) {
+static void my_scan_bind(vector<Value> inputs, vector<SQLType> &return_types, vector<string> &names) {
+	names.push_back("some_int");
+	return_types.push_back(SQLType::INTEGER);
+
+	names.push_back("some_string");
+	return_types.push_back(SQLType::VARCHAR);
+}
+
+void my_scan_function(ClientContext &context, vector<Value> &input, DataChunk &output, FunctionData *dataptr) {
 	auto &data = *((MyScanFunctionData *)dataptr);
+	assert(input.size() == 0);
 
 	if (data.nrow < 1) {
 		return;
@@ -46,8 +61,7 @@ void my_scan_function(ClientContext &context, DataChunk &input, DataChunk &outpu
 class MyScanFunction : public TableFunction {
 public:
 	MyScanFunction()
-	    : TableFunction("my_scan", {}, {SQLType::INTEGER, SQLType::VARCHAR}, {"some_int", "some_string"},
-	                    my_scan_function_init, my_scan_function, nullptr){};
+	    : TableFunction("my_scan", {}, my_scan_bind, my_scan_function_init, my_scan_function, nullptr){};
 };
 
 unique_ptr<BoundFunctionExpression> resolve_function(Connection &con, string name, vector<SQLType> function_args,
@@ -114,7 +128,7 @@ int main() {
 	vector<unique_ptr<ParsedExpression>> children; // empty
 	auto scan_function_catalog_entry =
 	    con.context->catalog.GetEntry<TableFunctionCatalogEntry>(*con.context, DEFAULT_SCHEMA, "my_scan");
-	vector<unique_ptr<Expression>> parameters; // empty
+	vector<Value> parameters; // empty
 	auto scan_function = make_unique<PhysicalTableFunction>(types, scan_function_catalog_entry, move(parameters));
 
 	//  FILTER[some_int<=7 some_int>=3]

--- a/examples/programmatic-querying/main.cpp
+++ b/examples/programmatic-querying/main.cpp
@@ -9,9 +9,11 @@
 #include "duckdb/main/client_context.hpp"
 
 /**
-This file contains an example on how a query tree can be programmatically constructed. This is essentially hand-rolling the binding+planning phase for one specific query.
+This file contains an example on how a query tree can be programmatically constructed. This is essentially hand-rolling
+the binding+planning phase for one specific query.
 
-Note that this API is currently very unstable, and is subject to change at any moment. In general, this API should not be used currently outside of internal use cases.
+Note that this API is currently very unstable, and is subject to change at any moment. In general, this API should not
+be used currently outside of internal use cases.
 **/
 
 using namespace duckdb;
@@ -23,7 +25,8 @@ struct MyScanFunctionData : public TableFunctionData {
 	size_t nrow;
 };
 
-static unique_ptr<FunctionData> my_scan_bind(ClientContext &context, vector<Value> inputs, vector<SQLType> &return_types, vector<string> &names) {
+static unique_ptr<FunctionData> my_scan_bind(ClientContext &context, vector<Value> inputs,
+                                             vector<SQLType> &return_types, vector<string> &names) {
 	names.push_back("some_int");
 	return_types.push_back(SQLType::INTEGER);
 
@@ -57,8 +60,7 @@ void my_scan_function(ClientContext &context, vector<Value> &input, DataChunk &o
 
 class MyScanFunction : public TableFunction {
 public:
-	MyScanFunction()
-	    : TableFunction("my_scan", {}, my_scan_bind, my_scan_function, nullptr){};
+	MyScanFunction() : TableFunction("my_scan", {}, my_scan_bind, my_scan_function, nullptr){};
 };
 
 unique_ptr<BoundFunctionExpression> resolve_function(Connection &con, string name, vector<SQLType> function_args,

--- a/src/catalog/catalog_entry/table_function_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_function_catalog_entry.cpp
@@ -13,25 +13,4 @@ using namespace std;
 TableFunctionCatalogEntry::TableFunctionCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema,
                                                      CreateTableFunctionInfo *info)
     : StandardEntry(CatalogType::TABLE_FUNCTION, schema, catalog, info->name), function(info->function) {
-	column_t oid = 0;
-	for (auto &name : function.names) {
-		if (name_map.find(name) != name_map.end()) {
-			throw CatalogException("Column with name %s already exists!", name.c_str());
-		}
-
-		name_map[name] = oid;
-		oid++;
-	}
-}
-
-bool TableFunctionCatalogEntry::ColumnExists(const string &name) {
-	return name_map.find(name) != name_map.end();
-}
-
-vector<TypeId> TableFunctionCatalogEntry::GetTypes() {
-	vector<TypeId> types;
-	for (auto &type : function.types) {
-		types.push_back(GetInternalType(type));
-	}
-	return types;
 }

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -237,9 +237,11 @@ string SQLTypeToString(SQLType type) {
 SQLType TransformStringToSQLType(string str) {
 	auto lower_str = StringUtil::Lower(str);
 	// Transform column type
-	if (lower_str == "int" || lower_str == "int4" || lower_str == "signed" || lower_str == "integer" || lower_str == "integral" || lower_str == "int32") {
+	if (lower_str == "int" || lower_str == "int4" || lower_str == "signed" || lower_str == "integer" ||
+	    lower_str == "integral" || lower_str == "int32") {
 		return SQLType::INTEGER;
-	} else if (lower_str == "varchar" || lower_str == "bpchar" || lower_str == "text" || lower_str == "string" || lower_str == "char") {
+	} else if (lower_str == "varchar" || lower_str == "bpchar" || lower_str == "text" || lower_str == "string" ||
+	           lower_str == "char") {
 		return SQLType::VARCHAR;
 	} else if (lower_str == "int8" || lower_str == "bigint" || lower_str == "int64" || lower_str == "long") {
 		return SQLType::BIGINT;

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/serializer.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/string_type.hpp"
 
 #include <cmath>
@@ -230,6 +231,38 @@ string SQLTypeToString(SQLType type) {
 	}
 	default:
 		return SQLTypeIdToString(type.id);
+	}
+}
+
+SQLType TransformStringToSQLType(string str) {
+	auto lower_str = StringUtil::Lower(str);
+	// Transform column type
+	if (lower_str == "int" || lower_str == "int4" || lower_str == "signed" || lower_str == "integer" || lower_str == "integral" || lower_str == "int32") {
+		return SQLType::INTEGER;
+	} else if (lower_str == "varchar" || lower_str == "bpchar" || lower_str == "text" || lower_str == "string" || lower_str == "char") {
+		return SQLType::VARCHAR;
+	} else if (lower_str == "int8" || lower_str == "bigint" || lower_str == "int64" || lower_str == "long") {
+		return SQLType::BIGINT;
+	} else if (lower_str == "int2" || lower_str == "smallint" || lower_str == "short" || lower_str == "int16") {
+		return SQLType::SMALLINT;
+	} else if (lower_str == "timestamp" || lower_str == "datetime") {
+		return SQLType::TIMESTAMP;
+	} else if (lower_str == "bool" || lower_str == "boolean" || lower_str == "logical") {
+		return SQLType(SQLTypeId::BOOLEAN);
+	} else if (lower_str == "real" || lower_str == "float4" || lower_str == "float") {
+		return SQLType::FLOAT;
+	} else if (lower_str == "double" || lower_str == "numeric" || lower_str == "float8") {
+		return SQLType::DOUBLE;
+	} else if (lower_str == "tinyint" || lower_str == "int1") {
+		return SQLType::TINYINT;
+	} else if (lower_str == "varbinary") {
+		return SQLType(SQLTypeId::VARBINARY);
+	} else if (lower_str == "date") {
+		return SQLType::DATE;
+	} else if (lower_str == "time") {
+		return SQLType::TIME;
+	} else {
+		throw NotImplementedException("DataType %s not supported yet...\n", str.c_str());
 	}
 }
 

--- a/src/execution/operator/persistent/buffered_csv_reader.cpp
+++ b/src/execution/operator/persistent/buffered_csv_reader.cpp
@@ -7,6 +7,10 @@
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/parser/column_definition.hpp"
 
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/gzip_stream.hpp"
+#include "duckdb/common/string_util.hpp"
+
 #include <algorithm>
 #include <fstream>
 #include <queue>
@@ -47,12 +51,18 @@ TextSearchShiftArray::TextSearchShiftArray(string search_term) : length(search_t
 	}
 }
 
-BufferedCSVReader::BufferedCSVReader(CopyInfo &info, vector<SQLType> sql_types, istream &source)
-    : info(info), sql_types(sql_types), source(source), buffer_size(0), position(0), start(0),
+BufferedCSVReader::BufferedCSVReader(ClientContext &context, CopyInfo &info, vector<SQLType> sql_types) :
+	BufferedCSVReader(info, sql_types, OpenCSV(context, info)) {
+
+}
+
+BufferedCSVReader::BufferedCSVReader(CopyInfo &info, vector<SQLType> sql_types, unique_ptr<istream> ssource)
+    : info(info), sql_types(sql_types), source(move(ssource)), buffer_size(0), position(0), start(0),
       delimiter_search(info.delimiter), escape_search(info.escape), quote_search(info.quote) {
 	if (info.force_not_null.size() == 0) {
 		info.force_not_null.resize(sql_types.size(), false);
 	}
+
 	assert(info.force_not_null.size() == sql_types.size());
 	// initialize the parse_chunk with a set of VARCHAR types
 	vector<TypeId> varchar_types;
@@ -64,9 +74,25 @@ BufferedCSVReader::BufferedCSVReader(CopyInfo &info, vector<SQLType> sql_types, 
 	if (info.header) {
 		// ignore the first line as a header line
 		string read_line;
-		getline(source, read_line);
+		getline(*source, read_line);
 		linenr++;
 	}
+}
+
+unique_ptr<istream> BufferedCSVReader::OpenCSV(ClientContext &context, CopyInfo &info) {
+	if (!FileSystem::GetFileSystem(context).FileExists(info.file_path)) {
+		throw IOException("File \"%s\" not found", info.file_path.c_str());
+	}
+	unique_ptr<istream> result;
+	// decide based on the extension which stream to use
+	if (StringUtil::EndsWith(StringUtil::Lower(info.file_path), ".gz")) {
+		result = make_unique<GzipStream>(info.file_path);
+	} else {
+		auto csv_local = make_unique<ifstream>();
+		csv_local->open(info.file_path);
+		result = move(csv_local);
+	}
+	return result;
 }
 
 void BufferedCSVReader::ParseComplexCSV(DataChunk &insert_chunk) {
@@ -461,8 +487,8 @@ bool BufferedCSVReader::ReadBuffer(idx_t &start) {
 		// remaining from last buffer: copy it here
 		memcpy(buffer.get(), old_buffer.get() + start, remaining);
 	}
-	source.read(buffer.get() + remaining, buffer_read_size);
-	idx_t read_count = source.eof() ? source.gcount() : buffer_read_size;
+	source->read(buffer.get() + remaining, buffer_read_size);
+	idx_t read_count = source->eof() ? source->gcount() : buffer_read_size;
 	buffer_size = remaining + read_count;
 	buffer[buffer_size] = '\0';
 	if (old_buffer) {

--- a/src/execution/operator/persistent/buffered_csv_reader.cpp
+++ b/src/execution/operator/persistent/buffered_csv_reader.cpp
@@ -51,9 +51,8 @@ TextSearchShiftArray::TextSearchShiftArray(string search_term) : length(search_t
 	}
 }
 
-BufferedCSVReader::BufferedCSVReader(ClientContext &context, CopyInfo &info, vector<SQLType> sql_types) :
-	BufferedCSVReader(info, sql_types, OpenCSV(context, info)) {
-
+BufferedCSVReader::BufferedCSVReader(ClientContext &context, CopyInfo &info, vector<SQLType> sql_types)
+    : BufferedCSVReader(info, sql_types, OpenCSV(context, info)) {
 }
 
 BufferedCSVReader::BufferedCSVReader(CopyInfo &info, vector<SQLType> sql_types, unique_ptr<istream> ssource)

--- a/src/execution/operator/scan/physical_table_function.cpp
+++ b/src/execution/operator/scan/physical_table_function.cpp
@@ -8,14 +8,7 @@
 using namespace duckdb;
 using namespace std;
 
-class PhysicalTableFunctionOperatorState : public PhysicalOperatorState {
-public:
-	PhysicalTableFunctionOperatorState() : PhysicalOperatorState(nullptr) {
-	}
-};
-
-void PhysicalTableFunction::GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state_) {
-	auto state = (PhysicalTableFunctionOperatorState *)state_;
+void PhysicalTableFunction::GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state) {
 	// run main code
 	function->function.function(context, parameters, chunk, bind_data.get());
 	if (chunk.size() == 0) {
@@ -24,8 +17,4 @@ void PhysicalTableFunction::GetChunkInternal(ClientContext &context, DataChunk &
 			function->function.final(context, bind_data.get());
 		}
 	}
-}
-
-unique_ptr<PhysicalOperatorState> PhysicalTableFunction::GetOperatorState() {
-	return make_unique<PhysicalTableFunctionOperatorState>();
 }

--- a/src/execution/operator/scan/physical_table_function.cpp
+++ b/src/execution/operator/scan/physical_table_function.cpp
@@ -22,10 +22,7 @@ void PhysicalTableFunction::GetChunkInternal(ClientContext &context, DataChunk &
 	if (!state->initialized) {
 		// run initialization code
 		if (function->function.init) {
-			auto function_data = function->function.init(context);
-			if (function_data) {
-				state->function_data = unique_ptr<FunctionData>(function_data);
-			}
+			state->function_data = function->function.init(context);
 		}
 		state->initialized = true;
 	}

--- a/src/execution/operator/scan/physical_table_function.cpp
+++ b/src/execution/operator/scan/physical_table_function.cpp
@@ -26,25 +26,8 @@ void PhysicalTableFunction::GetChunkInternal(ClientContext &context, DataChunk &
 		}
 		state->initialized = true;
 	}
-	// create the input arguments
-	vector<TypeId> input_types;
-	for (auto &argument_type : function->function.arguments) {
-		input_types.push_back(GetInternalType(argument_type));
-	}
-
-	DataChunk input;
-	if (parameters.size() > 0) {
-		assert(parameters.size() == input_types.size());
-		input.Initialize(input_types);
-
-		for (auto &expr : parameters) {
-			ExpressionExecutor executor(*expr);
-			executor.Execute(input);
-		}
-	}
-
 	// run main code
-	function->function.function(context, input, chunk, state->function_data.get());
+	function->function.function(context, parameters, chunk, state->function_data.get());
 	if (chunk.size() == 0) {
 		// finished, call clean up
 		if (function->function.final) {

--- a/src/execution/operator/scan/physical_table_function.cpp
+++ b/src/execution/operator/scan/physical_table_function.cpp
@@ -10,28 +10,18 @@ using namespace std;
 
 class PhysicalTableFunctionOperatorState : public PhysicalOperatorState {
 public:
-	PhysicalTableFunctionOperatorState() : PhysicalOperatorState(nullptr), initialized(false) {
+	PhysicalTableFunctionOperatorState() : PhysicalOperatorState(nullptr) {
 	}
-
-	unique_ptr<FunctionData> function_data;
-	bool initialized;
 };
 
 void PhysicalTableFunction::GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state_) {
 	auto state = (PhysicalTableFunctionOperatorState *)state_;
-	if (!state->initialized) {
-		// run initialization code
-		if (function->function.init) {
-			state->function_data = function->function.init(context);
-		}
-		state->initialized = true;
-	}
 	// run main code
-	function->function.function(context, parameters, chunk, state->function_data.get());
+	function->function.function(context, parameters, chunk, bind_data.get());
 	if (chunk.size() == 0) {
 		// finished, call clean up
 		if (function->function.final) {
-			function->function.final(context, state->function_data.get());
+			function->function.final(context, bind_data.get());
 		}
 	}
 }

--- a/src/execution/physical_plan/plan_table_function.cpp
+++ b/src/execution/physical_plan/plan_table_function.cpp
@@ -8,5 +8,5 @@ using namespace std;
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalTableFunction &op) {
 	assert(op.children.size() == 0);
 
-	return make_unique<PhysicalTableFunction>(op.types, op.function, move(op.expressions));
+	return make_unique<PhysicalTableFunction>(op.types, op.function, move(op.parameters));
 }

--- a/src/execution/physical_plan/plan_table_function.cpp
+++ b/src/execution/physical_plan/plan_table_function.cpp
@@ -8,5 +8,5 @@ using namespace std;
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalTableFunction &op) {
 	assert(op.children.size() == 0);
 
-	return make_unique<PhysicalTableFunction>(op.types, op.function, move(op.parameters));
+	return make_unique<PhysicalTableFunction>(op.types, op.function, move(op.bind_data), move(op.parameters));
 }

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -46,6 +46,7 @@ void BuiltinFunctions::AddFunction(TableFunction function) {
 
 void BuiltinFunctions::Initialize() {
 	RegisterSQLiteFunctions();
+	RegisterReadFunctions();
 
 	RegisterAlgebraicAggregates();
 	RegisterDistributiveAggregates();

--- a/src/function/table/CMakeLists.txt
+++ b/src/function/table/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_subdirectory(sqlite)
-add_library_unity(duckdb_func_table OBJECT sqlite_functions.cpp)
+add_library_unity(duckdb_func_table OBJECT read_csv.cpp sqlite_functions.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_table>
     PARENT_SCOPE)

--- a/src/function/table/CMakeLists.txt
+++ b/src/function/table/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_subdirectory(sqlite)
-add_library_unity(duckdb_func_table OBJECT read_csv.cpp sqlite_functions.cpp)
+add_library_unity(duckdb_func_table
+                  OBJECT
+                  read_csv.cpp
+                  sqlite_functions.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_table>
     PARENT_SCOPE)

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -1,0 +1,51 @@
+#include "duckdb/function/table/read_csv.hpp"
+#include "duckdb/execution/operator/persistent/buffered_csv_reader.hpp"
+
+using namespace std;
+
+namespace duckdb {
+
+struct ReadCSVData : public TableFunctionData {
+	ReadCSVData() {
+	}
+
+	CopyInfo info;
+	//! The CSV reader
+	unique_ptr<BufferedCSVReader> csv_reader;
+};
+
+static unique_ptr<FunctionData> read_csv_bind(ClientContext &context, vector<Value> inputs, vector<SQLType> &return_types, vector<string> &names) {
+	for(auto &val : inputs[2].struct_value) {
+		names.push_back(val.first);
+		if (val.second.type != TypeId::VARCHAR) {
+			throw BinderException("read_csv requires a type specification as string");
+		}
+		return_types.push_back(TransformStringToSQLType(val.second.str_value.c_str()));
+	}
+	if (names.size() == 0) {
+		throw BinderException("read_csv requires at least a single column as input!");
+	}
+	auto result = make_unique<ReadCSVData>();
+
+	result->info.file_path = inputs[0].str_value;
+	result->info.header = false;
+	result->info.delimiter = inputs[1].str_value;
+
+	result->csv_reader = make_unique<BufferedCSVReader>(context, result->info, return_types);
+	return move(result);
+}
+
+static void read_csv_info(ClientContext &context, vector<Value> &input, DataChunk &output, FunctionData *dataptr) {
+	auto &data = ((ReadCSVData &)*dataptr);
+	data.csv_reader->ParseCSV(output);
+}
+
+void ReadCSVTableFunction::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("read_csv", {SQLType::VARCHAR, SQLType::VARCHAR, SQLType::STRUCT}, read_csv_bind, read_csv_info, nullptr));
+}
+
+void BuiltinFunctions::RegisterReadFunctions() {
+	ReadCSVTableFunction::RegisterFunction(*this);
+}
+
+} // namespace duckdb

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -14,8 +14,9 @@ struct ReadCSVData : public TableFunctionData {
 	unique_ptr<BufferedCSVReader> csv_reader;
 };
 
-static unique_ptr<FunctionData> read_csv_bind(ClientContext &context, vector<Value> inputs, vector<SQLType> &return_types, vector<string> &names) {
-	for(auto &val : inputs[2].struct_value) {
+static unique_ptr<FunctionData> read_csv_bind(ClientContext &context, vector<Value> inputs,
+                                              vector<SQLType> &return_types, vector<string> &names) {
+	for (auto &val : inputs[2].struct_value) {
 		names.push_back(val.first);
 		if (val.second.type != TypeId::VARCHAR) {
 			throw BinderException("read_csv requires a type specification as string");
@@ -41,7 +42,8 @@ static void read_csv_info(ClientContext &context, vector<Value> &input, DataChun
 }
 
 void ReadCSVTableFunction::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("read_csv", {SQLType::VARCHAR, SQLType::VARCHAR, SQLType::STRUCT}, read_csv_bind, read_csv_info, nullptr));
+	set.AddFunction(TableFunction("read_csv", {SQLType::VARCHAR, SQLType::VARCHAR, SQLType::STRUCT}, read_csv_bind,
+	                              read_csv_info, nullptr));
 }
 
 void BuiltinFunctions::RegisterReadFunctions() {

--- a/src/function/table/sqlite/pragma_table_info.cpp
+++ b/src/function/table/sqlite/pragma_table_info.cpp
@@ -19,12 +19,7 @@ struct PragmaTableFunctionData : public TableFunctionData {
 	idx_t offset;
 };
 
-static unique_ptr<FunctionData> pragma_table_info_init(ClientContext &context) {
-	// initialize the function data structure
-	return make_unique<PragmaTableFunctionData>();
-}
-
-static void pragma_table_info_bind(vector<Value> inputs, vector<SQLType> &return_types, vector<string> &names) {
+static unique_ptr<FunctionData> pragma_table_info_bind(ClientContext &context, vector<Value> inputs, vector<SQLType> &return_types, vector<string> &names) {
 	names.push_back("cid");
 	return_types.push_back(SQLType::INTEGER);
 
@@ -42,6 +37,8 @@ static void pragma_table_info_bind(vector<Value> inputs, vector<SQLType> &return
 
 	names.push_back("pk");
 	return_types.push_back(SQLType::BOOLEAN);
+
+	return make_unique<PragmaTableFunctionData>();
 }
 
 static void pragma_table_info(ClientContext &context, vector<Value> &input, DataChunk &output, FunctionData *dataptr) {
@@ -91,8 +88,7 @@ static void pragma_table_info(ClientContext &context, vector<Value> &input, Data
 }
 
 void PragmaTableInfo::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("pragma_table_info", {SQLType::VARCHAR}, pragma_table_info_bind,
-	                              pragma_table_info_init, pragma_table_info, nullptr));
+	set.AddFunction(TableFunction("pragma_table_info", {SQLType::VARCHAR}, pragma_table_info_bind, pragma_table_info, nullptr));
 }
 
 } // namespace duckdb

--- a/src/function/table/sqlite/pragma_table_info.cpp
+++ b/src/function/table/sqlite/pragma_table_info.cpp
@@ -44,17 +44,13 @@ static void pragma_table_info_bind(vector<Value> inputs, vector<SQLType> &return
 	return_types.push_back(SQLType::BOOLEAN);
 }
 
-static void pragma_table_info(ClientContext &context, DataChunk &input, DataChunk &output, FunctionData *dataptr) {
+static void pragma_table_info(ClientContext &context, vector<Value> &input, DataChunk &output, FunctionData *dataptr) {
 	auto &data = *((PragmaTableFunctionData *)dataptr);
 	if (!data.entry) {
 		// first call: load the entry from the catalog
-		if (input.size() != 1) {
-			throw Exception("Expected a single table name as input");
-		}
-		if (input.column_count() != 1 || input.data[0].type != TypeId::VARCHAR) {
-			throw Exception("Expected a single table name as input");
-		}
-		auto table_name = input.GetValue(0, 0).str_value;
+		assert(input.size() == 1);
+
+		auto table_name = input[0].GetValue<string>();
 		// look up the table name in the catalog
 		auto &catalog = Catalog::GetCatalog(context);
 		data.entry = catalog.GetEntry<TableCatalogEntry>(context, DEFAULT_SCHEMA, table_name);

--- a/src/function/table/sqlite/pragma_table_info.cpp
+++ b/src/function/table/sqlite/pragma_table_info.cpp
@@ -19,7 +19,8 @@ struct PragmaTableFunctionData : public TableFunctionData {
 	idx_t offset;
 };
 
-static unique_ptr<FunctionData> pragma_table_info_bind(ClientContext &context, vector<Value> inputs, vector<SQLType> &return_types, vector<string> &names) {
+static unique_ptr<FunctionData> pragma_table_info_bind(ClientContext &context, vector<Value> inputs,
+                                                       vector<SQLType> &return_types, vector<string> &names) {
 	names.push_back("cid");
 	return_types.push_back(SQLType::INTEGER);
 
@@ -88,7 +89,8 @@ static void pragma_table_info(ClientContext &context, vector<Value> &input, Data
 }
 
 void PragmaTableInfo::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("pragma_table_info", {SQLType::VARCHAR}, pragma_table_info_bind, pragma_table_info, nullptr));
+	set.AddFunction(
+	    TableFunction("pragma_table_info", {SQLType::VARCHAR}, pragma_table_info_bind, pragma_table_info, nullptr));
 }
 
 } // namespace duckdb

--- a/src/function/table/sqlite/sqlite_master.cpp
+++ b/src/function/table/sqlite/sqlite_master.cpp
@@ -21,11 +21,6 @@ struct SQLiteMasterData : public TableFunctionData {
 	idx_t offset;
 };
 
-unique_ptr<FunctionData> sqlite_master_init(ClientContext &context) {
-	// initialize the function data structure
-	return make_unique<SQLiteMasterData>();
-}
-
 string GenerateQuery(CatalogEntry *entry) {
 	// generate a query from a catalog entry
 	if (entry->type == CatalogType::TABLE) {
@@ -49,7 +44,7 @@ string GenerateQuery(CatalogEntry *entry) {
 	}
 }
 
-static void sqlite_master_bind(vector<Value> inputs, vector<SQLType> &return_types, vector<string> &names) {
+static unique_ptr<FunctionData> sqlite_master_bind(ClientContext &context, vector<Value> inputs, vector<SQLType> &return_types, vector<string> &names) {
 	names.push_back("type");
 	return_types.push_back(SQLType::VARCHAR);
 
@@ -64,6 +59,9 @@ static void sqlite_master_bind(vector<Value> inputs, vector<SQLType> &return_typ
 
 	names.push_back("sql");
 	return_types.push_back(SQLType::VARCHAR);
+
+	// initialize the function data structure
+	return make_unique<SQLiteMasterData>();
 }
 
 void sqlite_master(ClientContext &context, vector<Value> &input, DataChunk &output, FunctionData *dataptr) {
@@ -125,7 +123,7 @@ void sqlite_master(ClientContext &context, vector<Value> &input, DataChunk &outp
 }
 
 void SQLiteMaster::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("sqlite_master", {}, sqlite_master_bind, sqlite_master_init, sqlite_master, nullptr));
+	set.AddFunction(TableFunction("sqlite_master", {}, sqlite_master_bind, sqlite_master, nullptr));
 }
 
 } // namespace duckdb

--- a/src/function/table/sqlite/sqlite_master.cpp
+++ b/src/function/table/sqlite/sqlite_master.cpp
@@ -66,8 +66,9 @@ static void sqlite_master_bind(vector<Value> inputs, vector<SQLType> &return_typ
 	return_types.push_back(SQLType::VARCHAR);
 }
 
-void sqlite_master(ClientContext &context, DataChunk &input, DataChunk &output, FunctionData *dataptr) {
+void sqlite_master(ClientContext &context, vector<Value> &input, DataChunk &output, FunctionData *dataptr) {
 	auto &data = *((SQLiteMasterData *)dataptr);
+	assert(input.size() == 0);
 	if (!data.initialized) {
 		// scan all the schemas
 		auto &transaction = Transaction::GetTransaction(context);

--- a/src/function/table/sqlite/sqlite_master.cpp
+++ b/src/function/table/sqlite/sqlite_master.cpp
@@ -21,9 +21,9 @@ struct SQLiteMasterData : public TableFunctionData {
 	idx_t offset;
 };
 
-FunctionData *sqlite_master_init(ClientContext &context) {
+unique_ptr<FunctionData> sqlite_master_init(ClientContext &context) {
 	// initialize the function data structure
-	return new SQLiteMasterData();
+	return make_unique<SQLiteMasterData>();
 }
 
 string GenerateQuery(CatalogEntry *entry) {
@@ -47,6 +47,23 @@ string GenerateQuery(CatalogEntry *entry) {
 	} else {
 		return "[Unknown]";
 	}
+}
+
+static void sqlite_master_bind(vector<Value> inputs, vector<SQLType> &return_types, vector<string> &names) {
+	names.push_back("type");
+	return_types.push_back(SQLType::VARCHAR);
+
+	names.push_back("name");
+	return_types.push_back(SQLType::VARCHAR);
+
+	names.push_back("tbl_name");
+	return_types.push_back(SQLType::VARCHAR);
+
+	names.push_back("rootpage");
+	return_types.push_back(SQLType::INTEGER);
+
+	names.push_back("sql");
+	return_types.push_back(SQLType::VARCHAR);
 }
 
 void sqlite_master(ClientContext &context, DataChunk &input, DataChunk &output, FunctionData *dataptr) {
@@ -104,6 +121,10 @@ void sqlite_master(ClientContext &context, DataChunk &input, DataChunk &output, 
 		output.SetValue(4, index, Value(GenerateQuery(entry)));
 	}
 	data.offset = next;
+}
+
+void SQLiteMaster::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("sqlite_master", {}, sqlite_master_bind, sqlite_master_init, sqlite_master, nullptr));
 }
 
 } // namespace duckdb

--- a/src/function/table/sqlite/sqlite_master.cpp
+++ b/src/function/table/sqlite/sqlite_master.cpp
@@ -44,7 +44,8 @@ string GenerateQuery(CatalogEntry *entry) {
 	}
 }
 
-static unique_ptr<FunctionData> sqlite_master_bind(ClientContext &context, vector<Value> inputs, vector<SQLType> &return_types, vector<string> &names) {
+static unique_ptr<FunctionData> sqlite_master_bind(ClientContext &context, vector<Value> inputs,
+                                                   vector<SQLType> &return_types, vector<string> &names) {
 	names.push_back("type");
 	return_types.push_back(SQLType::VARCHAR);
 

--- a/src/function/table/sqlite_functions.cpp
+++ b/src/function/table/sqlite_functions.cpp
@@ -11,15 +11,8 @@ using namespace std;
 namespace duckdb {
 
 void BuiltinFunctions::RegisterSQLiteFunctions() {
-	AddFunction(TableFunction(
-	    "sqlite_master", {}, {SQLType::VARCHAR, SQLType::VARCHAR, SQLType::VARCHAR, SQLType::INTEGER, SQLType::VARCHAR},
-	    {"type", "name", "tbl_name", "rootpage", "sql"}, sqlite_master_init, sqlite_master, nullptr));
-
-	AddFunction(TableFunction("pragma_table_info", {SQLType::VARCHAR},
-	                          {SQLType::INTEGER, SQLType::VARCHAR, SQLType::VARCHAR, SQLType(SQLTypeId::BOOLEAN),
-	                           SQLType::VARCHAR, SQLType(SQLTypeId::BOOLEAN)},
-	                          {"cid", "name", "type", "notnull", "dflt_value", "pk"}, pragma_table_info_init,
-	                          pragma_table_info, nullptr));
+	PragmaTableInfo::RegisterFunction(*this);
+	SQLiteMaster::RegisterFunction(*this);
 
 	CreateViewInfo info;
 	info.schema = DEFAULT_SCHEMA;

--- a/src/include/duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp
@@ -26,14 +26,5 @@ public:
 
 	//! The table function
 	TableFunction function;
-	//! A map of return-column name to column index
-	unordered_map<string, column_t> name_map;
-
-public:
-	//! Returns whether or not a column with the given name is returned by the
-	//! function
-	bool ColumnExists(const string &name);
-	//! Returns a list of return-types of the function
-	vector<TypeId> GetTypes();
 };
 } // namespace duckdb

--- a/src/include/duckdb/common/storage_util.hpp
+++ b/src/include/duckdb/common/storage_util.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "constants.hpp"
+#include <cassert>
 
 namespace duckdb {
 constexpr const size_t FULL_MASK = 0xFF;

--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -245,6 +245,7 @@ string SQLTypeIdToString(SQLTypeId type);
 string SQLTypeToString(SQLType type);
 
 SQLType MaxSQLType(SQLType left, SQLType right);
+SQLType TransformStringToSQLType(string str);
 
 //! Gets the internal type associated with the given SQL type
 TypeId GetInternalType(SQLType type);

--- a/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
@@ -42,11 +42,12 @@ class BufferedCSVReader {
 	static constexpr idx_t MAXIMUM_CSV_LINE_SIZE = 1048576;
 
 public:
-	BufferedCSVReader(CopyInfo &info, vector<SQLType> sql_types, std::istream &source);
+	BufferedCSVReader(ClientContext &context, CopyInfo &info, vector<SQLType> sql_types);
+	BufferedCSVReader(CopyInfo &info, vector<SQLType> sql_types, unique_ptr<std::istream> source);
 
 	CopyInfo &info;
 	vector<SQLType> sql_types;
-	std::istream &source;
+	unique_ptr<std::istream> source;
 
 	unique_ptr<char[]> buffer;
 	idx_t buffer_size;
@@ -79,6 +80,8 @@ private:
 	void Flush(DataChunk &insert_chunk);
 	//! Reads a new buffer from the CSV file if the current one has been exhausted
 	bool ReadBuffer(idx_t &start);
+
+	unique_ptr<std::istream> OpenCSV(ClientContext &context, CopyInfo &info);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/scan/physical_table_function.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_function.hpp
@@ -18,13 +18,15 @@ namespace duckdb {
 class PhysicalTableFunction : public PhysicalOperator {
 public:
 	PhysicalTableFunction(vector<TypeId> types, TableFunctionCatalogEntry *function,
-	                      vector<Value> parameters)
+	                      unique_ptr<FunctionData> bind_data, vector<Value> parameters)
 	    : PhysicalOperator(PhysicalOperatorType::TABLE_FUNCTION, types), function(function),
-	      parameters(move(parameters)) {
+	      bind_data(move(bind_data)), parameters(move(parameters)) {
 	}
 
 	//! Function to call
 	TableFunctionCatalogEntry *function;
+	//! The bind data
+	unique_ptr<FunctionData> bind_data;
 	//! Parameters
 	vector<Value> parameters;
 

--- a/src/include/duckdb/execution/operator/scan/physical_table_function.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_function.hpp
@@ -32,7 +32,6 @@ public:
 
 public:
 	void GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;
-	unique_ptr<PhysicalOperatorState> GetOperatorState() override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/scan/physical_table_function.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_function.hpp
@@ -18,15 +18,15 @@ namespace duckdb {
 class PhysicalTableFunction : public PhysicalOperator {
 public:
 	PhysicalTableFunction(vector<TypeId> types, TableFunctionCatalogEntry *function,
-	                      vector<unique_ptr<Expression>> parameters)
+	                      vector<Value> parameters)
 	    : PhysicalOperator(PhysicalOperatorType::TABLE_FUNCTION, types), function(function),
 	      parameters(move(parameters)) {
 	}
 
 	//! Function to call
 	TableFunctionCatalogEntry *function;
-	//! Expressions
-	vector<unique_ptr<Expression>> parameters;
+	//! Parameters
+	vector<Value> parameters;
 
 public:
 	void GetChunkInternal(ClientContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;

--- a/src/include/duckdb/execution/operator/scan/physical_table_function.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_function.hpp
@@ -17,10 +17,10 @@ namespace duckdb {
 //! Represents a scan of a base table
 class PhysicalTableFunction : public PhysicalOperator {
 public:
-	PhysicalTableFunction(vector<TypeId> types, TableFunctionCatalogEntry *function,
-	                      unique_ptr<FunctionData> bind_data, vector<Value> parameters)
-	    : PhysicalOperator(PhysicalOperatorType::TABLE_FUNCTION, types), function(function),
-	      bind_data(move(bind_data)), parameters(move(parameters)) {
+	PhysicalTableFunction(vector<TypeId> types, TableFunctionCatalogEntry *function, unique_ptr<FunctionData> bind_data,
+	                      vector<Value> parameters)
+	    : PhysicalOperator(PhysicalOperatorType::TABLE_FUNCTION, types), function(function), bind_data(move(bind_data)),
+	      parameters(move(parameters)) {
 	}
 
 	//! Function to call

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -121,6 +121,7 @@ private:
 
 	// table-producing functions
 	void RegisterSQLiteFunctions();
+	void RegisterReadFunctions();
 
 	// aggregates
 	void RegisterAlgebraicAggregates();

--- a/src/include/duckdb/function/table/read_csv.hpp
+++ b/src/include/duckdb/function/table/read_csv.hpp
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/function/table/read_csv.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/function/table_function.hpp"
+
+namespace duckdb {
+
+struct ReadCSVTableFunction {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/function/table/sqlite_functions.hpp
+++ b/src/include/duckdb/function/table/sqlite_functions.hpp
@@ -12,10 +12,12 @@
 
 namespace duckdb {
 
-FunctionData *pragma_table_info_init(ClientContext &);
-void pragma_table_info(ClientContext &, DataChunk &input, DataChunk &output, FunctionData *dataptr);
+struct PragmaTableInfo {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
 
-FunctionData *sqlite_master_init(ClientContext &);
-void sqlite_master(ClientContext &, DataChunk &input, DataChunk &output, FunctionData *dataptr);
+struct SQLiteMaster {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
 
 } // namespace duckdb

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -15,9 +15,9 @@ namespace duckdb {
 //! Type used for initialization function
 typedef unique_ptr<FunctionData> (*table_function_init_t)(ClientContext &);
 //! Type used for table-returning function
-typedef void (*table_function_t)(ClientContext &, DataChunk &input, DataChunk &output, FunctionData *dataptr);
+typedef void (*table_function_t)(ClientContext &context, vector<Value> &input, DataChunk &output, FunctionData *dataptr);
 //! Type used for final (cleanup) function
-typedef void (*table_function_final_t)(ClientContext &, FunctionData *dataptr);
+typedef void (*table_function_final_t)(ClientContext &context, FunctionData *dataptr);
 //! Function used for determining the return type of a table producing function
 typedef void (*table_function_bind_t)(vector<Value> inputs, vector<SQLType> &return_types, vector<string> &names);
 

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -13,16 +13,18 @@
 namespace duckdb {
 
 //! Function used for determining the return type of a table producing function
-typedef unique_ptr<FunctionData> (*table_function_bind_t)(ClientContext &context, vector<Value> inputs, vector<SQLType> &return_types, vector<string> &names);
+typedef unique_ptr<FunctionData> (*table_function_bind_t)(ClientContext &context, vector<Value> inputs,
+                                                          vector<SQLType> &return_types, vector<string> &names);
 //! Type used for table-returning function
-typedef void (*table_function_t)(ClientContext &context, vector<Value> &input, DataChunk &output, FunctionData *dataptr);
+typedef void (*table_function_t)(ClientContext &context, vector<Value> &input, DataChunk &output,
+                                 FunctionData *dataptr);
 //! Type used for final (cleanup) function
 typedef void (*table_function_final_t)(ClientContext &context, FunctionData *dataptr);
 
 class TableFunction : public Function {
 public:
-	TableFunction(string name, vector<SQLType> arguments, table_function_bind_t bind,
-	              table_function_t function, table_function_final_t final)
+	TableFunction(string name, vector<SQLType> arguments, table_function_bind_t bind, table_function_t function,
+	              table_function_final_t final)
 	    : Function(name), arguments(move(arguments)), bind(bind), function(function), final(final) {
 	}
 

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -12,28 +12,24 @@
 
 namespace duckdb {
 
-//! Type used for initialization function
-typedef unique_ptr<FunctionData> (*table_function_init_t)(ClientContext &);
+//! Function used for determining the return type of a table producing function
+typedef unique_ptr<FunctionData> (*table_function_bind_t)(ClientContext &context, vector<Value> inputs, vector<SQLType> &return_types, vector<string> &names);
 //! Type used for table-returning function
 typedef void (*table_function_t)(ClientContext &context, vector<Value> &input, DataChunk &output, FunctionData *dataptr);
 //! Type used for final (cleanup) function
 typedef void (*table_function_final_t)(ClientContext &context, FunctionData *dataptr);
-//! Function used for determining the return type of a table producing function
-typedef void (*table_function_bind_t)(vector<Value> inputs, vector<SQLType> &return_types, vector<string> &names);
 
 class TableFunction : public Function {
 public:
-	TableFunction(string name, vector<SQLType> arguments, table_function_bind_t bind, table_function_init_t init,
+	TableFunction(string name, vector<SQLType> arguments, table_function_bind_t bind,
 	              table_function_t function, table_function_final_t final)
-	    : Function(name), arguments(move(arguments)), bind(bind), init(init), function(function), final(final) {
+	    : Function(name), arguments(move(arguments)), bind(bind), function(function), final(final) {
 	}
 
 	//! Input arguments
 	vector<SQLType> arguments;
 	//! The bind function
 	table_function_bind_t bind;
-	//! Initialize function pointer
-	table_function_init_t init;
 	//! The function pointer
 	table_function_t function;
 	//! Final function pointer

--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -44,8 +44,6 @@ public:
 	void AddBaseTable(BoundBaseTableRef *bound, const string &alias);
 	//! Adds a subquery with a given alias to the BindContext.
 	void AddSubquery(idx_t index, const string &alias, SubqueryRef &ref, BoundQueryNode &subquery);
-	//! Adds a table function with a given alias to the BindContext
-	void AddTableFunction(idx_t index, const string &alias, TableFunctionCatalogEntry *function_entry);
 	//! Adds a base table with the given alias to the BindContext.
 	void AddGenericBinding(idx_t index, const string &alias, vector<string> names, vector<SQLType> types);
 

--- a/src/include/duckdb/planner/operator/logical_table_function.hpp
+++ b/src/include/duckdb/planner/operator/logical_table_function.hpp
@@ -16,8 +16,9 @@ namespace duckdb {
 class LogicalTableFunction : public LogicalOperator {
 public:
 	LogicalTableFunction(TableFunctionCatalogEntry *function, idx_t table_index,
-	                     vector<unique_ptr<Expression>> parameters)
-	    : LogicalOperator(LogicalOperatorType::TABLE_FUNCTION), function(function), table_index(table_index) {
+	                     vector<unique_ptr<Expression>> parameters, vector<SQLType> return_types, vector<string> names)
+	    : LogicalOperator(LogicalOperatorType::TABLE_FUNCTION), function(function), table_index(table_index),
+	      return_types(move(return_types)), names(move(names)) {
 		expressions = move(parameters);
 	}
 
@@ -25,6 +26,10 @@ public:
 	TableFunctionCatalogEntry *function;
 	//! The table index of the table-producing function
 	idx_t table_index;
+	//! The set of returned sql types
+	vector<SQLType> return_types;
+	//! The set of returned column names
+	vector<string> names;
 
 public:
 	vector<ColumnBinding> GetColumnBindings() override;

--- a/src/include/duckdb/planner/operator/logical_table_function.hpp
+++ b/src/include/duckdb/planner/operator/logical_table_function.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/function/function.hpp"
+#include "duckdb/common/types/value.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/planner/operator/logical_table_function.hpp
+++ b/src/include/duckdb/planner/operator/logical_table_function.hpp
@@ -16,10 +16,11 @@ namespace duckdb {
 //! LogicalTableFunction represents a call to a table-producing function
 class LogicalTableFunction : public LogicalOperator {
 public:
-	LogicalTableFunction(TableFunctionCatalogEntry *function, idx_t table_index,
-	                     unique_ptr<FunctionData> bind_data, vector<Value> parameters, vector<SQLType> return_types, vector<string> names)
+	LogicalTableFunction(TableFunctionCatalogEntry *function, idx_t table_index, unique_ptr<FunctionData> bind_data,
+	                     vector<Value> parameters, vector<SQLType> return_types, vector<string> names)
 	    : LogicalOperator(LogicalOperatorType::TABLE_FUNCTION), function(function), table_index(table_index),
-	      bind_data(move(bind_data)), parameters(move(parameters)), return_types(move(return_types)), names(move(names)) {
+	      bind_data(move(bind_data)), parameters(move(parameters)), return_types(move(return_types)),
+	      names(move(names)) {
 	}
 
 	//! The function

--- a/src/include/duckdb/planner/operator/logical_table_function.hpp
+++ b/src/include/duckdb/planner/operator/logical_table_function.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/planner/logical_operator.hpp"
+#include "duckdb/function/function.hpp"
 
 namespace duckdb {
 
@@ -16,15 +17,17 @@ namespace duckdb {
 class LogicalTableFunction : public LogicalOperator {
 public:
 	LogicalTableFunction(TableFunctionCatalogEntry *function, idx_t table_index,
-	                     vector<Value> parameters, vector<SQLType> return_types, vector<string> names)
+	                     unique_ptr<FunctionData> bind_data, vector<Value> parameters, vector<SQLType> return_types, vector<string> names)
 	    : LogicalOperator(LogicalOperatorType::TABLE_FUNCTION), function(function), table_index(table_index),
-	      parameters(move(parameters)), return_types(move(return_types)), names(move(names)) {
+	      bind_data(move(bind_data)), parameters(move(parameters)), return_types(move(return_types)), names(move(names)) {
 	}
 
 	//! The function
 	TableFunctionCatalogEntry *function;
 	//! The table index of the table-producing function
 	idx_t table_index;
+	//! The bind data of the function
+	unique_ptr<FunctionData> bind_data;
 	//! The input parameters
 	vector<Value> parameters;
 	//! The set of returned sql types

--- a/src/include/duckdb/planner/operator/logical_table_function.hpp
+++ b/src/include/duckdb/planner/operator/logical_table_function.hpp
@@ -16,16 +16,17 @@ namespace duckdb {
 class LogicalTableFunction : public LogicalOperator {
 public:
 	LogicalTableFunction(TableFunctionCatalogEntry *function, idx_t table_index,
-	                     vector<unique_ptr<Expression>> parameters, vector<SQLType> return_types, vector<string> names)
+	                     vector<Value> parameters, vector<SQLType> return_types, vector<string> names)
 	    : LogicalOperator(LogicalOperatorType::TABLE_FUNCTION), function(function), table_index(table_index),
-	      return_types(move(return_types)), names(move(names)) {
-		expressions = move(parameters);
+	      parameters(move(parameters)), return_types(move(return_types)), names(move(names)) {
 	}
 
 	//! The function
 	TableFunctionCatalogEntry *function;
 	//! The table index of the table-producing function
 	idx_t table_index;
+	//! The input parameters
+	vector<Value> parameters;
 	//! The set of returned sql types
 	vector<SQLType> return_types;
 	//! The set of returned column names

--- a/src/include/duckdb/planner/table_binding.hpp
+++ b/src/include/duckdb/planner/table_binding.hpp
@@ -74,17 +74,6 @@ private:
 	void AddName(string &name);
 };
 
-//! Represents a binding to a table-producing function
-struct TableFunctionBinding : public Binding {
-	TableFunctionBinding(const string &alias, TableFunctionCatalogEntry *function, idx_t index);
-
-	bool HasMatchingBinding(const string &column_name) override;
-	BindResult Bind(ColumnRefExpression &colref, idx_t depth) override;
-	void GenerateAllColumnExpressions(BindContext &context, vector<unique_ptr<ParsedExpression>> &select_list) override;
-
-	TableFunctionCatalogEntry *function;
-};
-
 //! Represents a generic binding with types and names
 struct GenericBinding : public Binding {
 	GenericBinding(const string &alias, vector<SQLType> types, vector<string> names, idx_t index);

--- a/src/include/duckdb/planner/tableref/bound_table_function.hpp
+++ b/src/include/duckdb/planner/tableref/bound_table_function.hpp
@@ -26,6 +26,10 @@ public:
 	TableFunctionCatalogEntry *function;
 	//! The set of parameters to use as input to the table-producing function
 	vector<unique_ptr<Expression>> parameters;
+	//! The set of returned sql types
+	vector<SQLType> return_types;
+	//! The set of returned column names
+	vector<string> names;
 	//! The index in the bind context
 	idx_t bind_index;
 };

--- a/src/include/duckdb/planner/tableref/bound_table_function.hpp
+++ b/src/include/duckdb/planner/tableref/bound_table_function.hpp
@@ -24,6 +24,8 @@ public:
 
 	//! The function that is called
 	TableFunctionCatalogEntry *function;
+	//! The bind data of the function
+	unique_ptr<FunctionData> bind_data;
 	//! The set of parameters to use as input to the table-producing function
 	vector<Value> parameters;
 	//! The set of returned sql types

--- a/src/include/duckdb/planner/tableref/bound_table_function.hpp
+++ b/src/include/duckdb/planner/tableref/bound_table_function.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/planner/bound_tableref.hpp"
+#include "duckdb/function/function.hpp"
 
 namespace duckdb {
 class TableFunctionCatalogEntry;

--- a/src/include/duckdb/planner/tableref/bound_table_function.hpp
+++ b/src/include/duckdb/planner/tableref/bound_table_function.hpp
@@ -25,7 +25,7 @@ public:
 	//! The function that is called
 	TableFunctionCatalogEntry *function;
 	//! The set of parameters to use as input to the table-producing function
-	vector<unique_ptr<Expression>> parameters;
+	vector<Value> parameters;
 	//! The set of returned sql types
 	vector<SQLType> return_types;
 	//! The set of returned column names

--- a/src/parser/transform/helpers/transform_typename.cpp
+++ b/src/parser/transform/helpers/transform_typename.cpp
@@ -5,38 +5,6 @@
 using namespace duckdb;
 using namespace std;
 
-static SQLType TransformStringToSQLType(char *str) {
-	auto lower_str = StringUtil::Lower(string(str));
-	// Transform column type
-	if (lower_str == "int" || lower_str == "int4" || lower_str == "signed") {
-		return SQLType::INTEGER;
-	} else if (lower_str == "varchar" || lower_str == "bpchar" || lower_str == "text" || lower_str == "string") {
-		return SQLType::VARCHAR;
-	} else if (lower_str == "int8") {
-		return SQLType::BIGINT;
-	} else if (lower_str == "int2") {
-		return SQLType::SMALLINT;
-	} else if (lower_str == "timestamp" || lower_str == "datetime") {
-		return SQLType::TIMESTAMP;
-	} else if (lower_str == "bool") {
-		return SQLType(SQLTypeId::BOOLEAN);
-	} else if (lower_str == "real" || lower_str == "float4") {
-		return SQLType::FLOAT;
-	} else if (lower_str == "double" || lower_str == "numeric" || lower_str == "float8") {
-		return SQLType::DOUBLE;
-	} else if (lower_str == "tinyint") {
-		return SQLType::TINYINT;
-	} else if (lower_str == "varbinary") {
-		return SQLType(SQLTypeId::VARBINARY);
-	} else if (lower_str == "date") {
-		return SQLType::DATE;
-	} else if (lower_str == "time") {
-		return SQLType::TIME;
-	} else {
-		throw NotImplementedException("DataType %s not supported yet...\n", str);
-	}
-}
-
 SQLType Transformer::TransformTypeName(PGTypeName *type_name) {
 	auto name = (reinterpret_cast<PGValue *>(type_name->names->tail->data.ptr_value)->val.str);
 	// transform it to the SQL type

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -89,10 +89,6 @@ void BindContext::AddSubquery(idx_t index, const string &alias, SubqueryRef &ref
 	AddBinding(alias, make_unique<SubqueryBinding>(alias, ref, subquery, index));
 }
 
-void BindContext::AddTableFunction(idx_t index, const string &alias, TableFunctionCatalogEntry *function_entry) {
-	AddBinding(alias, make_unique<TableFunctionBinding>(alias, function_entry, index));
-}
-
 void BindContext::AddGenericBinding(idx_t index, const string &alias, vector<string> names, vector<SQLType> types) {
 	AddBinding(alias, make_unique<GenericBinding>(alias, move(types), move(names), index));
 }

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -34,8 +34,9 @@ unique_ptr<BoundTableRef> Binder::Bind(TableFunctionRef &ref) {
 		result->parameters.push_back(constant);
 	}
 	// perform the binding
-	function->function.bind(result->parameters, result->return_types, result->names);
+	result->bind_data = function->function.bind(context, result->parameters, result->return_types, result->names);
 	assert(result->return_types.size() == result->names.size());
+	assert(result->return_types.size() > 0);
 	// now add the table function to the bind context so its columns can be bound
 	bind_context.AddGenericBinding(bind_index, ref.alias.empty() ? fexpr->function_name : ref.alias, result->names,
 	                               result->return_types);

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression_binder/constant_binder.hpp"
 #include "duckdb/planner/tableref/bound_table_function.hpp"
+#include "duckdb/execution/expression_executor.hpp"
 
 using namespace duckdb;
 using namespace std;
@@ -25,10 +26,20 @@ unique_ptr<BoundTableRef> Binder::Bind(TableFunctionRef &ref) {
 		                       (int)fexpr->children.size());
 	}
 	auto result = make_unique<BoundTableFunction>(function, bind_index);
+	// evalate the input parameters to the function
+	vector<Value> inputs;
 	for (auto &child : fexpr->children) {
 		ConstantBinder binder(*this, context, "TABLE FUNCTION parameter");
-		result->parameters.push_back(binder.Bind(child));
+		auto expr = binder.Bind(child);
+		auto constant = ExpressionExecutor::EvaluateScalar(*expr);
+		result->parameters.push_back(move(expr));
+		inputs.push_back(constant);
 	}
-	bind_context.AddTableFunction(bind_index, ref.alias.empty() ? fexpr->function_name : ref.alias, function);
+	// perform the binding
+	function->function.bind(inputs, result->return_types, result->names);
+	assert(result->return_types.size() == result->names.size());
+	// now add the table function to the bind context so its columns can be bound
+	bind_context.AddGenericBinding(bind_index, ref.alias.empty() ? fexpr->function_name : ref.alias, result->names,
+	                               result->return_types);
 	return move(result);
 }

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -27,16 +27,14 @@ unique_ptr<BoundTableRef> Binder::Bind(TableFunctionRef &ref) {
 	}
 	auto result = make_unique<BoundTableFunction>(function, bind_index);
 	// evalate the input parameters to the function
-	vector<Value> inputs;
 	for (auto &child : fexpr->children) {
 		ConstantBinder binder(*this, context, "TABLE FUNCTION parameter");
 		auto expr = binder.Bind(child);
 		auto constant = ExpressionExecutor::EvaluateScalar(*expr);
-		result->parameters.push_back(move(expr));
-		inputs.push_back(constant);
+		result->parameters.push_back(constant);
 	}
 	// perform the binding
-	function->function.bind(inputs, result->return_types, result->names);
+	function->function.bind(result->parameters, result->return_types, result->names);
 	assert(result->return_types.size() == result->names.size());
 	// now add the table function to the bind context so its columns can be bound
 	bind_context.AddGenericBinding(bind_index, ref.alias.empty() ? fexpr->function_name : ref.alias, result->names,

--- a/src/planner/expression_binder/constant_binder.cpp
+++ b/src/planner/expression_binder/constant_binder.cpp
@@ -10,13 +10,13 @@ ConstantBinder::ConstantBinder(Binder &binder, ClientContext &context, string cl
 BindResult ConstantBinder::BindExpression(ParsedExpression &expr, idx_t depth, bool root_expression) {
 	switch (expr.GetExpressionClass()) {
 	case ExpressionClass::COLUMN_REF:
-		return BindResult(clause + "cannot contain column names");
+		return BindResult(clause + " cannot contain column names");
 	case ExpressionClass::SUBQUERY:
-		return BindResult(clause + "cannot contain subqueries");
+		return BindResult(clause + " cannot contain subqueries");
 	case ExpressionClass::DEFAULT:
-		return BindResult(clause + "cannot contain DEFAULT clause");
+		return BindResult(clause + " cannot contain DEFAULT clause");
 	case ExpressionClass::WINDOW:
-		return BindResult(clause + "cannot contain window functions!");
+		return BindResult(clause + " cannot contain window functions!");
 	default:
 		return ExpressionBinder::BindExpression(expr, depth);
 	}

--- a/src/planner/logical_plan/tableref/plan_table_function.cpp
+++ b/src/planner/logical_plan/tableref/plan_table_function.cpp
@@ -6,6 +6,6 @@ using namespace duckdb;
 using namespace std;
 
 unique_ptr<LogicalOperator> LogicalPlanGenerator::CreatePlan(BoundTableFunction &ref) {
-	return make_unique<LogicalTableFunction>(ref.function, ref.bind_index, move(ref.bind_data), move(ref.parameters), ref.return_types,
-	                                         ref.names);
+	return make_unique<LogicalTableFunction>(ref.function, ref.bind_index, move(ref.bind_data), move(ref.parameters),
+	                                         ref.return_types, ref.names);
 }

--- a/src/planner/logical_plan/tableref/plan_table_function.cpp
+++ b/src/planner/logical_plan/tableref/plan_table_function.cpp
@@ -6,5 +6,6 @@ using namespace duckdb;
 using namespace std;
 
 unique_ptr<LogicalOperator> LogicalPlanGenerator::CreatePlan(BoundTableFunction &ref) {
-	return make_unique<LogicalTableFunction>(ref.function, ref.bind_index, move(ref.parameters));
+	return make_unique<LogicalTableFunction>(ref.function, ref.bind_index, move(ref.parameters), ref.return_types,
+	                                         ref.names);
 }

--- a/src/planner/logical_plan/tableref/plan_table_function.cpp
+++ b/src/planner/logical_plan/tableref/plan_table_function.cpp
@@ -6,6 +6,6 @@ using namespace duckdb;
 using namespace std;
 
 unique_ptr<LogicalOperator> LogicalPlanGenerator::CreatePlan(BoundTableFunction &ref) {
-	return make_unique<LogicalTableFunction>(ref.function, ref.bind_index, move(ref.parameters), ref.return_types,
+	return make_unique<LogicalTableFunction>(ref.function, ref.bind_index, move(ref.bind_data), move(ref.parameters), ref.return_types,
 	                                         ref.names);
 }

--- a/src/planner/operator/logical_table_function.cpp
+++ b/src/planner/operator/logical_table_function.cpp
@@ -6,11 +6,11 @@ using namespace duckdb;
 using namespace std;
 
 vector<ColumnBinding> LogicalTableFunction::GetColumnBindings() {
-	return GenerateColumnBindings(table_index, function->function.types.size());
+	return GenerateColumnBindings(table_index, return_types.size());
 }
 
 void LogicalTableFunction::ResolveTypes() {
-	for (auto &type : function->function.types) {
+	for (auto &type : return_types) {
 		types.push_back(GetInternalType(type));
 	}
 }

--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -240,9 +240,9 @@ bool compare_result(string csv, ChunkCollection &collection, vector<SQLType> sql
 	parsed_result.Initialize(internal_types);
 
 	// convert the CSV string into a stringstream
-	istringstream csv_stream(csv);
+	auto source = make_unique<istringstream>(csv);
 
-	BufferedCSVReader reader(info, sql_types, csv_stream);
+	BufferedCSVReader reader(info, sql_types, move(source));
 	idx_t collection_index = 0;
 	idx_t tuple_count = 0;
 	while (true) {

--- a/test/sql/copy/test_copy.cpp
+++ b/test/sql/copy/test_copy.cpp
@@ -1556,3 +1556,31 @@ TEST_CASE("Test imdb escapes", "[copy]") {
 	// TODO: actually check results
 	result = con.Query("SELECT * FROM movie_info;");
 }
+
+TEST_CASE("Test read CSV function with lineitem", "[copy]") {
+	unique_ptr<QueryResult> result;
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	auto csv_path = GetCSVPath();
+	auto lineitem_csv = fs.JoinPath(csv_path, "lineitem.csv");
+	WriteBinary(lineitem_csv, lineitem_sample, sizeof(lineitem_sample));
+
+	// create a view using the read_csv function
+	REQUIRE_NO_FAIL(con.Query("CREATE VIEW lineitem AS SELECT * FROM read_csv('" + lineitem_csv + "', '|', STRUCT_PACK(l_orderkey := 'INT', l_partkey := 'INT', l_suppkey := 'INT', l_linenumber := 'INT', l_quantity := 'INTEGER', l_extendedprice := 'DOUBLE', l_discount := 'DOUBLE', l_tax := 'DOUBLE', l_returnflag := 'VARCHAR', l_linestatus := 'VARCHAR', l_shipdate := 'DATE', l_commitdate := 'DATE', l_receiptdate := 'DATE', l_shipinstruct := 'VARCHAR', l_shipmode := 'VARCHAR', l_comment := 'VARCHAR'));"));
+
+	// each of these will read the CSV again through the view
+	result = con.Query("SELECT COUNT(*) FROM lineitem");
+	REQUIRE(CHECK_COLUMN(result, 0, {10}));
+
+	result = con.Query("SELECT l_partkey, l_comment FROM lineitem WHERE l_orderkey=1 ORDER BY l_linenumber;");
+	REQUIRE(CHECK_COLUMN(result, 0, {15519, 6731, 6370, 214, 2403, 1564}));
+	REQUIRE(
+	    CHECK_COLUMN(result, 1,
+	                 {"egular courts above the", "ly final dependencies: slyly bold ", "riously. regular, express dep",
+	                  "lites. fluffily even de", " pending foxes. slyly re", "arefully slyly ex"}));
+
+	// test incorrect usage of read_csv function
+	// wrong argument type
+	REQUIRE_FAIL(con.Query("SELECT * FROM read_csv('" + lineitem_csv + "', '|', STRUCT_PACK(l_orderkey := 5))"));
+}

--- a/test/sql/copy/test_copy.cpp
+++ b/test/sql/copy/test_copy.cpp
@@ -1567,7 +1567,12 @@ TEST_CASE("Test read CSV function with lineitem", "[copy]") {
 	WriteBinary(lineitem_csv, lineitem_sample, sizeof(lineitem_sample));
 
 	// create a view using the read_csv function
-	REQUIRE_NO_FAIL(con.Query("CREATE VIEW lineitem AS SELECT * FROM read_csv('" + lineitem_csv + "', '|', STRUCT_PACK(l_orderkey := 'INT', l_partkey := 'INT', l_suppkey := 'INT', l_linenumber := 'INT', l_quantity := 'INTEGER', l_extendedprice := 'DOUBLE', l_discount := 'DOUBLE', l_tax := 'DOUBLE', l_returnflag := 'VARCHAR', l_linestatus := 'VARCHAR', l_shipdate := 'DATE', l_commitdate := 'DATE', l_receiptdate := 'DATE', l_shipinstruct := 'VARCHAR', l_shipmode := 'VARCHAR', l_comment := 'VARCHAR'));"));
+	REQUIRE_NO_FAIL(con.Query(
+	    "CREATE VIEW lineitem AS SELECT * FROM read_csv('" + lineitem_csv +
+	    "', '|', STRUCT_PACK(l_orderkey := 'INT', l_partkey := 'INT', l_suppkey := 'INT', l_linenumber := 'INT', "
+	    "l_quantity := 'INTEGER', l_extendedprice := 'DOUBLE', l_discount := 'DOUBLE', l_tax := 'DOUBLE', l_returnflag "
+	    ":= 'VARCHAR', l_linestatus := 'VARCHAR', l_shipdate := 'DATE', l_commitdate := 'DATE', l_receiptdate := "
+	    "'DATE', l_shipinstruct := 'VARCHAR', l_shipmode := 'VARCHAR', l_comment := 'VARCHAR'));"));
 
 	// each of these will read the CSV again through the view
 	result = con.Query("SELECT COUNT(*) FROM lineitem");


### PR DESCRIPTION
This PR adds a bind function to table producing functions, this allows table-producing functions to provide different return values depending on their input arguments. This is useful for e.g. implementing file readers, as they can take as parameter the file to read, then inspect the file during the `bind` step and figure out what the return types will be.

The signature of the bind function is as follows, where `inputs` is the set of input arguments, and `return_types` and `names` are the result of the bind step:

```cpp
typedef unique_ptr<FunctionData> (*table_function_bind_t)(ClientContext &context, vector<Value> inputs, vector<SQLType> &return_types, vector<string> &names);
```

This PR also includes a new `read_csv` method, that takes a struct as input describing the schema, e.g.:

```sql
SELECT * FROM read_csv('lineitem.tbl', '|',
	STRUCT_PACK(l_orderkey := 'INT',
	l_partkey := 'INT',
	l_suppkey := 'INT',
	l_linenumber := 'INT',
	l_quantity := 'INTEGER',
	l_extendedprice := 'DOUBLE',
	l_discount := 'DOUBLE',
	l_tax := 'DOUBLE',
	l_returnflag := 'VARCHAR',
	l_linestatus := 'VARCHAR',
	l_shipdate := 'DATE',
	l_commitdate := 'DATE',
	l_receiptdate := 'DATE',
	l_shipinstruct := 'VARCHAR',
	l_shipmode := 'VARCHAR',
	l_comment := 'VARCHAR'));
```

The idea is that this function can later be extended to automatically recognize column names and types similar to how `data.table` does it. From their documentation:

```
     A sample of 10,000 rows is used for a very good estimate of column
     types. 100 contiguous rows are read from 100 equally spaced points
     throughout the file including the beginning, middle and the very
     end. This results in a better guess when a column changes type
     later in the file (e.g. blank at the beginning/only populated near
     the end, or 001 at the start but 0A0 later on). This very good
     type guess enables a single allocation of the correct type up
     front once for speed, memory efficiency and convenience of
     avoiding the need to set ‘colClasses’ after an error. Even though
     the sample is large and jumping over the file, it is almost
     instant regardless of the size of the file because a lazy
     on-demand memory map is used. If a jump lands inside a quoted
     field containing newlines, each newline is tested until 5 lines
     are found following it with the expected number of fields. The
     lowest type for each column is chosen from the ordered list:
     ‘logical’, ‘integer’, ‘integer64’, ‘double’, ‘character’. Rarely,
     the file may contain data of a higher type in rows outside the
     sample (referred to as an out-of-sample type exception). In this
     event ‘fread’ will _automatically_ reread just those columns from
     the beginning so that you don't have the inconvenience of having
     to set ‘colClasses’ yourself; particularly helpful if you have a
     lot of columns. Such columns must be read from the beginning to
     correctly distinguish "00" from "000" when those have both been
     interpreted as integer 0 due to the sample but 00A occurs out of
     sample. Set ‘verbose=TRUE’ to see a detailed report of the logic
     deployed to read your file.
```