### PR TITLE
DATE type handling for Python

### DIFF
--- a/tools/pythonpkg/cursor.cpp
+++ b/tools/pythonpkg/cursor.cpp
@@ -461,6 +461,7 @@ PyObject *duckdb_cursor_fetchnumpy(duckdb_Cursor *self) {
 			dtype->meta.base = NPY_FR_ms;
 		} else if (result->sql_types[col_idx].id == duckdb::SQLTypeId::DATE) {
 			auto dtype = reinterpret_cast<PyArray_DatetimeDTypeMetaData *>(descr->c_metadata);
+			dtype->meta.base = NPY_FR_s;
 		}
 		cols[col_idx].array = PyArray_Empty(1, dims, descr, 0);
 		cols[col_idx].nullmask = PyArray_EMPTY(1, dims, NPY_BOOL, 0);
@@ -520,7 +521,7 @@ PyObject *duckdb_cursor_fetchnumpy(duckdb_Cursor *self) {
 				}    // else fall-through-to-default
 			case duckdb::TypeId::INT32:
 				if (result->sql_types[col_idx].id == duckdb::SQLTypeId::DATE) {
-					int32_t *array_data_ptr = reinterpret_cast<int32_t *>(array_data + (offset * duckdb_type_size));
+					int64_t *array_data_ptr = reinterpret_cast<int64_t *>(array_data + (offset * 2 * duckdb_type_size));
 					duckdb::date_t *chunk_data_ptr = reinterpret_cast<int32_t *>(chunk->data[col_idx].GetData());
 					for (size_t chunk_idx = 0; chunk_idx < chunk->size(); chunk_idx++) {
 						// array_data_ptr[chunk_idx] = duckdb::Timestamp::GetEpoch(chunk_data_ptr[chunk_idx]) * 1000;
@@ -630,7 +631,7 @@ PyObject *duckdb_cursor_iternext(duckdb_Cursor *self) {
 		case duckdb::TypeId::INT32:
 			if (self->result->sql_types[col_idx].id == duckdb::SQLTypeId::DATE) {
 				auto date_val = dval.value_.integer;
-				auto date_val;
+				auto date = date_val;
 				// oof
 				val = PyDate_FromDate(duckdb::Date::ExtractYear(date),
 						duckdb::Date::ExtractMonth(date),

--- a/tools/pythonpkg/tests/test_dbapi09.py
+++ b/tools/pythonpkg/tests/test_dbapi09.py
@@ -2,16 +2,20 @@
 
 import numpy 
 import datetime
+import pandas
 
 class TestNumpyDate(object):
     def test_fetchall_date(self, duckdb_cursor):
         res = duckdb_cursor.execute("SELECT DATE '2020-01-10' as test_date").fetchall()
-        assert isinstance(res[0][0], datetime.date)
+        assert res == [[datetime.date(2020, 1, 10)]]
 
     def test_fetchnumpy_date(self, duckdb_cursor):
         res = duckdb_cursor.execute("SELECT DATE '2020-01-10' as test_date").fetchnumpy()
-        assert res['test_date'].dtype == numpy.dtype('datetime64[s]')
+        arr = numpy.array(['2020-01-10'], dtype="datetime64[s]")
+        arr = numpy.ma.masked_array(arr)
+        numpy.testing.assert_array_equal(res['test_date'], arr)
 
     def test_fetchdf_date(self, duckdb_cursor):
         res = duckdb_cursor.execute("SELECT DATE '2020-01-10' as test_date").fetchdf()
-        assert res['test_date'].dtype == numpy.dtype('datetime64[ns]')
+        ser = pandas.Series(numpy.array(['2020-01-10'], dtype="datetime64[ns]"), name="test_date")
+        pandas.testing.assert_series_equal(res['test_date'], ser)

--- a/tools/pythonpkg/tests/test_dbapi09.py
+++ b/tools/pythonpkg/tests/test_dbapi09.py
@@ -1,0 +1,17 @@
+# date type
+
+import numpy 
+import datetime
+
+class TestNumpyDate(object):
+    def test_fetchall_date(self, duckdb_cursor):
+        res = duckdb_cursor.execute("SELECT DATE '2020-01-10' as test_date").fetchall()
+        assert isinstance(res[0][0], datetime.date)
+
+    def test_fetchnumpy_date(self, duckdb_cursor):
+        res = duckdb_cursor.execute("SELECT DATE '2020-01-10' as test_date").fetchnumpy()
+        assert res['test_date'].dtype == numpy.dtype('datetime64[s]')
+
+    def test_fetchdf_date(self, duckdb_cursor):
+        res = duckdb_cursor.execute("SELECT DATE '2020-01-10' as test_date").fetchdf()
+        assert res['test_date'].dtype == numpy.dtype('datetime64[ns]')


### PR DESCRIPTION
DATE is converted as datetime.date for fetchall and numpy.datetime64 with second as units for fetchnumpy and fetchdf.
Do you agree with this choice?