### PR TITLE
Fix Minor Bugs

### DIFF
--- a/benchmark/dbwrapper/sqlite_benchmark.cpp
+++ b/benchmark/dbwrapper/sqlite_benchmark.cpp
@@ -39,6 +39,9 @@ void SQLiteBenchmark::Cleanup(BenchmarkState *state_) {
 
 string SQLiteBenchmark::Verify(BenchmarkState *state_) {
 	auto state = (SQLiteBenchmarkState *)state_;
+	if (!state->result) {
+		return "No result!";
+	}
 	return duckdb_benchmark->VerifyResult(state->result.get());
 }
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -458,7 +458,10 @@ void ClientContext::Invalidate() {
 	if (open_result) {
 		open_result->is_open = false;
 	}
-	// and close any open appenders
+	// and close any open appenders and prepared statements
+	for (auto &statement : prepared_statement_objects) {
+		statement->is_invalidated = true;
+	}
 	for (auto &appender : appenders) {
 		appender->Invalidate("Database that this appender belongs to has been closed!", false);
 	}

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -95,6 +95,19 @@ TEST_CASE("Test closing result after database is gone", "[api]") {
 	streaming_result.reset();
 }
 
+TEST_CASE("Test closing database with open prepared statements", "[api]") {
+	auto db = make_unique<DuckDB>(nullptr);
+	auto conn = make_unique<Connection>(*db);
+
+	auto p1 = conn->Prepare("CREATE TABLE a (i INTEGER)");
+	p1->Execute();
+	auto p2 = conn->Prepare("INSERT INTO a VALUES (42)");
+	p2->Execute();
+
+	db.reset();
+	conn.reset();
+}
+
 static void parallel_query(Connection *conn, bool *correct, size_t threadnr) {
 	correct[threadnr] = true;
 	for (size_t i = 0; i < 100; i++) {

--- a/tools/dbtransfer/sqlite_transfer.cpp
+++ b/tools/dbtransfer/sqlite_transfer.cpp
@@ -117,7 +117,7 @@ unique_ptr<QueryResult> QueryDatabase(vector<SQLType> result_types, sqlite3 *sql
 	// prepare the SQL statement
 	sqlite3_stmt *stmt;
 	if (sqlite3_prepare_v2(sqlite, query.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
-		return nullptr;
+		return make_unique<MaterializedQueryResult>(sqlite3_errmsg(sqlite));
 	}
 	int col_count = sqlite3_column_count(stmt);
 	vector<string> names;

--- a/tools/dbtransfer/sqlite_transfer.cpp
+++ b/tools/dbtransfer/sqlite_transfer.cpp
@@ -114,6 +114,9 @@ bool TransferDatabase(Connection &con, sqlite3 *sqlite) {
 
 unique_ptr<QueryResult> QueryDatabase(vector<SQLType> result_types, sqlite3 *sqlite, std::string query,
                                       volatile int &interrupt) {
+	if (!sqlite) {
+		return nullptr;
+	}
 	// prepare the SQL statement
 	sqlite3_stmt *stmt;
 	if (sqlite3_prepare_v2(sqlite, query.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {


### PR DESCRIPTION
This PR fixes three minor bugs, bundled into one PR to minimize testing time:

### Properly allocate for FIRST(VARCHAR)
In the new aggregate HT the payload columns are not automatically added to the string heap of the hash table. This is generally a good thing, because before many strings were unnecessarily added there (e.g. if we do STRING_AGG(x, ' ') we don't need every single version of 'x' there but only the accumulated aggregate). However, this also means we now need to copy the string in FIRST() if it is not inlined to avoid storing a pointer to a string that might be freed in the hash table.

### Fix for destroying database with open prepared statements
### Fix for sqlite::QueryDatabase: properly report the error

