### PR TITLE
pybind11 is a build-time-only dependency

### DIFF
--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -65,9 +65,6 @@ setup(
     keywords = 'DuckDB Database SQL OLAP',
     url="https://www.duckdb.org",
     long_description = '',
-    setup_requires=[
-          'pybind11>=2.4'
-    ],
     install_requires=[ # these versions are still available for Python 2, newer ones aren't
          'numpy>=1.14', 
          'pandas>=0.23',

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -65,10 +65,12 @@ setup(
     keywords = 'DuckDB Database SQL OLAP',
     url="https://www.duckdb.org",
     long_description = '',
+    setup_requires=[
+          'pybind11>=2.4'
+    ],
     install_requires=[ # these versions are still available for Python 2, newer ones aren't
          'numpy>=1.14', 
          'pandas>=0.23',
-         'pybind11>=2.4'
     ],
     packages=['duckdb_query_graph'],
     include_package_data=True,


### PR DESCRIPTION
Once the package is built, `pybind11` is no longer needed.