### PR TITLE
Named Window Fix & Rigger Fix

### DIFF
--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -87,11 +87,18 @@ static unique_ptr<FunctionData> regexp_matches_get_bind_function(BoundFunctionEx
 
 			string range_min, range_max;
 			auto range_success = re->PossibleMatchRange(&range_min, &range_max, 1000);
-			// range_min and range_max might produce non-valid UTF8 strings, e.g. in the case of 'a.*'
-			// in this case we don't push a range filter
-			if (range_success && (Utf8Proc::Analyze(range_min) == UnicodeType::INVALID ||
-			                      Utf8Proc::Analyze(range_max) == UnicodeType::INVALID)) {
-				range_success = false;
+			if (range_success) {
+				// there can be null terminators in the produced range value: remove them
+				range_min = string(range_min.c_str());
+				range_max = string(range_max.c_str());
+				if (range_min.size() == 0 || range_max.size() == 0) {
+					range_success = false;
+				}
+				// range_min and range_max might produce non-valid UTF8 strings, e.g. in the case of 'a.*'
+				// in this case we don't push a range filter
+				if (Utf8Proc::Analyze(range_min) == UnicodeType::INVALID || Utf8Proc::Analyze(range_max) == UnicodeType::INVALID) {
+					range_success = false;
+				}
 			}
 
 			return make_unique<RegexpMatchesBindData>(move(re), range_min, range_max, range_success);

--- a/src/include/duckdb/parser/transformer.hpp
+++ b/src/include/duckdb/parser/transformer.hpp
@@ -35,6 +35,7 @@ public:
 	idx_t ParamCount() {
 		return parent ? parent->ParamCount() : prepared_statement_parameter_index;
 	}
+
 private:
 	Transformer *parent;
 	//! The current prepared statement parameter index
@@ -49,6 +50,7 @@ private:
 			this->prepared_statement_parameter_index = new_count;
 		}
 	}
+
 private:
 	//! Transforms a Postgres statement into a single SQL statement
 	unique_ptr<SQLStatement> TransformStatement(PGNode *stmt);

--- a/src/include/duckdb/parser/transformer.hpp
+++ b/src/include/duckdb/parser/transformer.hpp
@@ -26,12 +26,29 @@ struct OrderByNode;
 //! parser representation into the DuckDB representation
 class Transformer {
 public:
+	Transformer(Transformer *parent = nullptr) : parent(parent) {}
+
 	//! Transforms a Postgres parse tree into a set of SQL Statements
 	bool TransformParseTree(PGList *tree, vector<unique_ptr<SQLStatement>> &statements);
 	string NodetypeToString(PGNodeTag type);
 
+	idx_t ParamCount() {
+		return parent ? parent->ParamCount() : prepared_statement_parameter_index;
+	}
+private:
+	Transformer *parent;
+	//! The current prepared statement parameter index
 	idx_t prepared_statement_parameter_index = 0;
+	//! Holds window expressions defined by name. We need those when transforming the expressions referring to them.
+	unordered_map<string, PGWindowDef *> window_clauses;
 
+	void SetParamCount(idx_t new_count) {
+		if (parent) {
+			parent->SetParamCount(new_count);
+		} else {
+			this->prepared_statement_parameter_index = new_count;
+		}
+	}
 private:
 	//! Transforms a Postgres statement into a single SQL statement
 	unique_ptr<SQLStatement> TransformStatement(PGNode *stmt);
@@ -166,9 +183,6 @@ private:
 	bool TransformExpressionList(PGList *list, vector<unique_ptr<ParsedExpression>> &result);
 
 	void TransformWindowDef(PGWindowDef *window_spec, WindowExpression *expr);
-
-	//! Holds window expressions defined by name. We need those when transforming the expressions referring to them.
-	unordered_map<string, PGWindowDef *> window_clauses;
 };
 
 } // namespace duckdb

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -34,7 +34,7 @@ void Parser::ParseQuery(string query) {
 	// SQLStatements
 	Transformer transformer;
 	transformer.TransformParseTree(parser.parse_tree, statements);
-	n_prepared_parameters = transformer.prepared_statement_parameter_index;
+	n_prepared_parameters = transformer.ParamCount();
 
 	if (statements.size() > 0) {
 		auto &last_statement = statements.back();

--- a/src/parser/transform/expression/transform_function.cpp
+++ b/src/parser/transform/expression/transform_function.cpp
@@ -153,7 +153,7 @@ unique_ptr<ParsedExpression> Transformer::TransformFuncCall(PGFuncCall *root) {
 		if (window_spec->name) {
 			auto it = window_clauses.find(StringUtil::Lower(string(window_spec->name)));
 			if (it == window_clauses.end()) {
-				throw Exception("Could not find named window specification");
+				throw ParserException("window \"%s\" does not exist", window_spec->name);
 			}
 			window_spec = it->second;
 			assert(window_spec);

--- a/src/parser/transform/expression/transform_param_ref.cpp
+++ b/src/parser/transform/expression/transform_param_ref.cpp
@@ -10,10 +10,10 @@ unique_ptr<ParsedExpression> Transformer::TransformParamRef(PGParamRef *node) {
 	}
 	auto expr = make_unique<ParameterExpression>();
 	if (node->number == 0) {
-		expr->parameter_nr = prepared_statement_parameter_index + 1;
+		expr->parameter_nr = ParamCount() + 1;
 	} else {
 		expr->parameter_nr = node->number;
 	}
-	prepared_statement_parameter_index = max(prepared_statement_parameter_index, expr->parameter_nr);
+	SetParamCount(max(ParamCount(), expr->parameter_nr));
 	return move(expr);
 }

--- a/src/parser/transform/statement/transform_prepare.cpp
+++ b/src/parser/transform/statement/transform_prepare.cpp
@@ -17,7 +17,7 @@ unique_ptr<PrepareStatement> Transformer::TransformPrepare(PGNode *node) {
 	auto result = make_unique<PrepareStatement>();
 	result->name = string(stmt->name);
 	result->statement = TransformStatement(stmt->query);
-	prepared_statement_parameter_index = 0;
+	SetParamCount(0);
 
 	return result;
 }

--- a/src/parser/transform/statement/transform_select.cpp
+++ b/src/parser/transform/statement/transform_select.cpp
@@ -9,21 +9,6 @@ unique_ptr<SelectStatement> Transformer::TransformSelect(PGNode *node) {
 	auto stmt = reinterpret_cast<PGSelectStmt *>(node);
 	auto result = make_unique<SelectStatement>();
 
-	if (stmt->windowClause) {
-		for (auto window_ele = stmt->windowClause->head; window_ele != NULL; window_ele = window_ele->next) {
-			auto window_def = reinterpret_cast<PGWindowDef *>(window_ele->data.ptr_value);
-			assert(window_def);
-			assert(window_def->name);
-			auto window_name = StringUtil::Lower(string(window_def->name));
-
-			auto it = window_clauses.find(window_name);
-			if (it != window_clauses.end()) {
-				throw Exception("A window specification needs an unique name");
-			}
-			window_clauses[window_name] = window_def;
-		}
-	}
-
 	// may contain windows so second
 	if (stmt->withClause) {
 		TransformCTE(reinterpret_cast<PGWithClause *>(stmt->withClause), *result);

--- a/src/parser/transform/statement/transform_select_node.cpp
+++ b/src/parser/transform/statement/transform_select_node.cpp
@@ -4,16 +4,34 @@
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/transformer.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
+#include "duckdb/common/string_util.hpp"
 
 using namespace duckdb;
 using namespace std;
 
 unique_ptr<QueryNode> Transformer::TransformSelectNode(PGSelectStmt *stmt) {
 	unique_ptr<QueryNode> node;
+
 	switch (stmt->op) {
 	case PG_SETOP_NONE: {
 		node = make_unique<SelectNode>();
 		auto result = (SelectNode *)node.get();
+
+		if (stmt->windowClause) {
+			for (auto window_ele = stmt->windowClause->head; window_ele != NULL; window_ele = window_ele->next) {
+				auto window_def = reinterpret_cast<PGWindowDef *>(window_ele->data.ptr_value);
+				assert(window_def);
+				assert(window_def->name);
+				auto window_name = StringUtil::Lower(string(window_def->name));
+
+				auto it = window_clauses.find(window_name);
+				if (it != window_clauses.end()) {
+					throw Exception("A window specification needs an unique name");
+				}
+				window_clauses[window_name] = window_def;
+			}
+		}
+
 		// do this early so the value lists also have a `FROM`
 		if (stmt->valuesLists) {
 			// VALUES list, create an ExpressionList

--- a/src/parser/transform/statement/transform_select_node.cpp
+++ b/src/parser/transform/statement/transform_select_node.cpp
@@ -26,7 +26,7 @@ unique_ptr<QueryNode> Transformer::TransformSelectNode(PGSelectStmt *stmt) {
 
 				auto it = window_clauses.find(window_name);
 				if (it != window_clauses.end()) {
-					throw Exception("A window specification needs an unique name");
+					throw ParserException("window \"%s\" is already defined", window_name.c_str());
 				}
 				window_clauses[window_name] = window_def;
 			}

--- a/src/parser/transform/tableref/transform_subquery.cpp
+++ b/src/parser/transform/tableref/transform_subquery.cpp
@@ -5,7 +5,8 @@ using namespace duckdb;
 using namespace std;
 
 unique_ptr<TableRef> Transformer::TransformRangeSubselect(PGRangeSubselect *root) {
-	auto subquery = TransformSelectNode((PGSelectStmt *)root->subquery);
+	Transformer subquery_transformer(this);
+	auto subquery = subquery_transformer.TransformSelectNode((PGSelectStmt *)root->subquery);
 	if (!subquery) {
 		return nullptr;
 	}

--- a/test/rigger/test_rigger.cpp
+++ b/test/rigger/test_rigger.cpp
@@ -478,4 +478,11 @@ TEST_CASE("Tests found by Rigger", "[rigger]") {
 		result = con.Query("SELECT * FROM v0 ORDER BY 'a';");
 		REQUIRE(CHECK_COLUMN(result, 0, {1}));
 	}
+	SECTION("547") {
+		// Query with SIMILAR TO results in "Assertion `strlen(dataptr) == length' failed"
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE t0(c0 INT);"));
+		REQUIRE_NO_FAIL(con.Query("INSERT INTO t0 VALUES (0);"));
+		result = con.Query("SELECT * FROM t0 WHERE t0.c0 SIMILAR TO '.';");
+		REQUIRE(CHECK_COLUMN(result, 0, {"0"}));
+	}
 }

--- a/test/sql/simple/test_window.cpp
+++ b/test/sql/simple/test_window.cpp
@@ -592,4 +592,6 @@ TEST_CASE("Test binding of named window functions in CTEs", "[window]") {
 
 	// we cannot use named window specifications of the main query inside CTEs
 	REQUIRE_FAIL(con.Query("WITH subquery AS (SELECT i, lag(i) OVER named_window FROM ( VALUES (1), (2), (3)) AS t (i)) SELECT * FROM subquery window named_window AS ( ORDER BY i);"));
+	// duplicate window clause name
+	REQUIRE_FAIL(con.Query("select i, lag(i) over named_window from (values (1), (2), (3)) as t (i) window named_window as (order by i), named_window as (order by j);"));
 }


### PR DESCRIPTION
Fixes #546 and #547

For #546: the transformer used to store named window clauses globally and did not parse them for CTEs. This lead to several weird behaviors: window clauses in the top level select clause could be used throughout the query, and window clauses in CTEs were entirely ignored. This is fixed now by properly scoping window clauses to select nodes in a similar way to how scoping is performed in the binder.

For #547: The regex range filter would produce strings with a null terminator ('\0') for a regex with a '.'. This would cause this assertion to trigger, as the string length would not match the actual string length. 