### PR TITLE
Fix recompile of all sources after commit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,6 @@ execute_process(COMMAND git
                 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                 OUTPUT_VARIABLE GIT_COMMIT_HASH
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
-add_definitions(-DDUCKDB_SOURCE_ID="\""${GIT_COMMIT_HASH}"\"")
 
 option(AMALGAMATION_BUILD
        "Build from the amalgamation files, rather than from the normal sources."

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -60,7 +60,7 @@ void DataTable::InitializeScan(TableScanState &state, vector<column_t> column_id
 	state.max_persistent_row = persistent_manager.max_row;
 	state.current_transient_row = 0;
 	state.max_transient_row = transient_manager.max_row;
-	if (table_filters) {
+	if (table_filters && table_filters->size() > 0) {
 		state.adaptive_filter = make_unique<AdaptiveFilter>(*table_filters);
 	}
 }

--- a/tools/shell/CMakeLists.txt
+++ b/tools/shell/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_definitions(-DSQLITE_OMIT_LOAD_EXTENSION=1)
 
+add_definitions(-DDUCKDB_SOURCE_ID="\""${GIT_COMMIT_HASH}"\"")
+
 set(SHELL_SOURCES shell.c)
 if(NOT WIN32)
   add_definitions(-DHAVE_LINENOISE=1)

--- a/tools/sqlite3_api_wrapper/CMakeLists.txt
+++ b/tools/sqlite3_api_wrapper/CMakeLists.txt
@@ -1,8 +1,9 @@
 include_directories(include)
 
+add_definitions(-DDUCKDB_SOURCE_ID="\""${GIT_COMMIT_HASH}"\"")
+
 add_library(sqlite3_api_wrapper SHARED sqlite3_api_wrapper.cpp printf.c)
 target_link_libraries(sqlite3_api_wrapper duckdb)
-
 
 add_library(sqlite3_api_wrapper_static STATIC sqlite3_api_wrapper.cpp printf.c)
 target_link_libraries(sqlite3_api_wrapper_static duckdb_static)


### PR DESCRIPTION
Only include the DUCKDB_SOURCE_ID definition in source files where this is required. This fixes the issue with a complete recompilation being triggered on every commit.