### PR TITLE
Fast Pandas Scan

### DIFF
--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -187,6 +187,10 @@ struct FlatVector {
 	template <class T> static inline T *GetData(Vector &vector) {
 		return ConstantVector::GetData<T>(vector);
 	}
+	static inline void SetData(Vector &vector, data_ptr_t data) {
+		assert(vector.vector_type == VectorType::FLAT_VECTOR);
+		vector.data = data;
+	}
 	template <class T> static inline T GetValue(Vector &vector, idx_t idx) {
 		assert(vector.vector_type == VectorType::FLAT_VECTOR);
 		return FlatVector::GetData<T>(vector)[idx];


### PR DESCRIPTION
This PR improves the scan speed of Pandas DataFrames by using a zero copy scan for numerics, and avoiding copying ASCII strings by directly accessing the bytes for pure ASCII strings (i.e. `PyUnicode_KIND(val) = PyUnicode_1BYTE_KIND`).


### Performance
Running [this benchmark here](https://gist.github.com/Mytherin/37de933372eb608fb81b9bb64f2df44f) (Q1 on a Pandas DataFrame) this increases performance by a factor 2~ and allows us to run Q1 faster than Pandas does directly on a Pandas DataFrame.

### Old

```
Base Pandas: 2.48 seconds
Pandas Scan: 4.56 seconds
```

### New

```
Base Pandas: 2.17 seconds
Pandas Scan: 2.04 seconds
```