### PR TITLE
Upload binary assets to GitHub releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ env:
     - CIBW_BEFORE_BUILD='pip install "numpy>=1.16" && pip install "pandas>=0.24" && pip install "pytest>=4.3" && pip install "cmake==3.13.3" && pip install "pybind11>=2.4"'
     - CIBW_TEST_COMMAND='python -m pytest {project}/tests'
 
+# exclude this because its a tag used for master builds
+if: NOT tag =~ /^master-builds$/
+
 
 matrix:
   include:
@@ -95,6 +98,7 @@ matrix:
 
       after_success:
         - C:/Python37-x64/python.exe tools/upload-s3.py lib-windows-amd64 src/Release/duckdb.dll Release/duckdb_cli.exe tools/jdbc/DuckDBJ.jar
+        - C:/Python37-x64/python.exe scripts/asset-upload.py libduckdb-windows-amd64.dll=src/Release/duckdb.dll duckdb_cli-windows-amd64.exe=Release/duckdb_cli.exe DuckDBJ-windows-amd64.jar=tools/jdbc/DuckDBJ.jar
 
 
 # checks: debug mode (with sanitizers), coveralls, valgrind, vector sizes
@@ -232,6 +236,7 @@ matrix:
       after_success:
         - (cd src/amalgamation; zip ../../build/duckdb.zip duckdb.*)
         - python tools/upload-s3.py src-amalgamation build/duckdb.zip
+        - python scripts/asset-upload.py duckdb_amalgamation.zip=build/duckdb.zip
 
 
     - os: osx
@@ -280,7 +285,7 @@ matrix:
         - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
       before_install:
         - eval "${MATRIX_EVAL}"
-        - pip install --user boto3
+        - pip install --user boto3 requests
       script:
         - mkdir -p build/release
         - (cd build/release && cmake -DFORCE_32_BIT=1 -DCMAKE_BUILD_TYPE=Release ../.. && cmake --build .)
@@ -288,6 +293,7 @@ matrix:
 
       after_success:
         - python tools/upload-s3.py lib-linux-i386 build/release/src/libduckdb*.so build/release/src/libduckdb*.a build/release/duckdb_cli
+        - python scripts/asset-upload.py libduckdb-linux-i386.so=build/release/src/libduckdb*.so duckdb_cli-linux-i386=build/release/duckdb_cli
 
 
     - os: windows
@@ -354,7 +360,7 @@ matrix:
       script:
         - python scripts/amalgamation.py > /dev/null
         - rsync -a -e "ssh $SSHFLAGS -p 2222" --exclude=.git --exclude=build --exclude=third_party/sqllogictest --exclude=third_party/imdb .  root@localhost:/duckdb
-        - travis_wait 30 $SCMD 'rm -rf /duckdb/build && mkdir -p /duckdb/build && cd /duckdb/build && export PATH=/opt/csw/bin/:$PATH CXX=g++ CC=gcc  && cmake -DCMAKE_AR=/opt/csw/bin/gar -DCMAKE_BUILD_TYPE=Debug -DAMALGAMATION_BUILD=1 .. && gmake -j2'
+        - travis_wait 50 $SCMD 'rm -rf /duckdb/build && mkdir -p /duckdb/build && cd /duckdb/build && export PATH=/opt/csw/bin/:$PATH CXX=g++ CC=gcc  && cmake -DCMAKE_AR=/opt/csw/bin/gar -DCMAKE_BUILD_TYPE=Debug -DAMALGAMATION_BUILD=1 .. && gmake -j2'
         - $SCMD /duckdb/build/test/unittest "~[copy]~[file_system]~[.]"
 
 
@@ -385,7 +391,7 @@ matrix:
       script:
         - python scripts/amalgamation.py > /dev/null
         - rsync -a -e "ssh $SSHFLAGS -p 2222" --exclude=.git --exclude=build --exclude=third_party/sqllogictest .  root@localhost:/home/duckdb
-        - travis_wait 30 $SCMD 'rm -rf /home/duckdb/build && mkdir -p /home/duckdb/build && cd /home/duckdb/build && cmake -DCMAKE_BUILD_TYPE=Debug -DAMALGAMATION_BUILD=1 .. && gmake -j2'
+        - travis_wait 50 $SCMD 'rm -rf /home/duckdb/build && mkdir -p /home/duckdb/build && cd /home/duckdb/build && cmake -DCMAKE_BUILD_TYPE=Debug -DAMALGAMATION_BUILD=1 .. && gmake -j2'
         - $SCMD /home/duckdb/build/test/unittest "~[copy]~[sqlitelogic]~[sqlserver]~[parquet]~[.]"
 
 
@@ -435,7 +441,7 @@ matrix:
       r: devel
 
       before_install:
-        - pip install --user boto3
+        - pip install --user boto3 requests
         - cd tools/rpkg
         - R -f dependencies.R
 
@@ -466,7 +472,7 @@ matrix:
       before_install:
         - curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
         - python3 /tmp/get-pip.py
-        - python3 -m pip install --user boto3
+        - python3 -m pip install --user boto3 requests
         - cd tools/rpkg
         - R -f dependencies.R
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
 
       after_success:
         - python tools/upload-s3.py lib-linux-amd64 build/release/src/libduckdb*.so build/release/src/libduckdb*.a build/release/duckdb_cli build/release/tools/jdbc/DuckDBJ.jar
-        - python scripts/asset-upload.py build/release/src/libduckdb*.so build/release/duckdb_cli build/release/tools/jdbc/DuckDBJ.jar
+        - python scripts/asset-upload.py libduckdb-linux-amd64.so=build/release/src/libduckdb*.so duckdb_cli-linux-amd64=build/release/duckdb_cli DuckDBJ-linux-amd64.jar=build/release/tools/jdbc/DuckDBJ.jar
 
 
     - os: osx
@@ -57,7 +57,7 @@ matrix:
       before_install:
         - curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
         - python3 /tmp/get-pip.py
-        - python3 -m pip install --user boto3
+        - python3 -m pip install --user boto3 requests
 
       script:
         - (mkdir -p build/release && cd build/release && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_ICU_EXTENSION=1 -DJDBC_DRIVER=1 ../.. && cmake --build .)
@@ -68,6 +68,7 @@ matrix:
 
       after_success:
         - python3 tools/upload-s3.py lib-osx build/release/src/libduckdb.dylib build/release/src/libduckdb_static.a build/release/duckdb_cli build/release/tools/jdbc/DuckDBJ.jar
+        - python scripts/asset-upload.py libduckdb-osx.so=build/release/src/libduckdb*.so duckdb_cli-osx=build/release/duckdb_cli DuckDBJ-osx.jar=build/release/tools/jdbc/DuckDBJ.jar
 
 
     - os: windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -465,6 +465,7 @@ matrix:
         - R -e "tools::write_PACKAGES(dir = '.', type = 'source')"
         - python ../upload-s3.py rstats/src/contrib duckdb_*.tar.gz PACKAGES*
         - python ../upload-s3.py rstats duckdb_*.tar.gz
+        - python ../../scripts/asset-upload.py duckdb_r.tar.gz=duckdb_*.tar.gz
 
 
     - os: osx
@@ -495,6 +496,7 @@ matrix:
         - R -e "tools::write_PACKAGES(dir = '.', type = 'mac.binary')"
         - python3 ../upload-s3.py rstats/bin/macosx/el-capitan/contrib/3.6 duckdb_*.tgz PACKAGES*
         - python3 ../upload-s3.py rstats duckdb_*.tgz
+        - python ../../scripts/asset-upload.py duckdb_r_osx.tgz=duckdb_*.tgz
 
 
     - os: windows
@@ -525,6 +527,7 @@ matrix:
         - C:/Python37-x64/python.exe ../upload-s3.py rstats duckdb_*.zip
         - C:/Program\ Files/R/R-3.6.0/bin/R.exe -e "tools::write_PACKAGES(dir = '.', type = 'win.binary')"
         - C:/Python37-x64/python.exe ../upload-s3.py rstats/bin/windows/contrib/3.6 duckdb_*.zip PACKAGES*
+        - C:/Python37-x64/python.exe ../../scripts/asset-upload.py duckdb_r_windows.zip=duckdb_*.zip
 
 
     - os: linux
@@ -546,7 +549,7 @@ matrix:
         - cd ../..
       after_success:
         - python tools/upload-s3.py python tools/pythonpkg/wheelhouse/*.whl tools/pythonpkg/dist/duckdb-*.tar.gz
-        - python scripts/asset-upload.py tools/pythonpkg/dist/duckdb-*.tar.gz
+        - python scripts/asset-upload.py duckdb_python.tar.gz=tools/pythonpkg/dist/duckdb-*.tar.gz tools/pythonpkg/wheelhouse/*.whl
 
 
     - os: linux
@@ -567,8 +570,6 @@ matrix:
         - python -m pytest tests
         - python setup.py sdist
         - mkdir duckdb_tarball && tar xvf dist/duckdb-*.tar.gz --strip-components=1 -C duckdb_tarball
-      after_success:
-        - python tools/upload-s3.py python tools/pythonpkg/dist/duckdb-*.tar.gz
 
 
     - os: osx
@@ -592,7 +593,7 @@ matrix:
 
       after_success:
         - python3 tools/upload-s3.py python tools/pythonpkg/wheelhouse/*.whl
-        - python3 scripts/asset-upload.py tools/pythonpkg/dist/duckdb-*.tar.gz
+        - python3 scripts/asset-upload.py tools/pythonpkg/wheelhouse/*.whl
 
 
     - os: windows
@@ -615,15 +616,16 @@ matrix:
         - choco install curl -y --force
         - C:/Python37-x64/python.exe -m pip install --upgrade pip
         - C:/Python37-x64/python.exe -m pip install "cibuildwheel==0.10.2"
-        - C:/Python37-x64/python.exe -m pip install "numpy>=1.16" "pandas>=0.24" "pytest>=4.3" "pybind11>=2.4"
+        - C:/Python37-x64/python.exe -m pip install "numpy>=1.16" "pandas>=0.24" "pytest>=4.3" "pybind11>=2.4" "requests"
 
       script:
         - cd tools/pythonpkg
-        - C:/Python37-x64/python.exe  setup.py sdist
+        - C:/Python37-x64/python.exe setup.py sdist
         - mkdir duckdb_tarball && tar xvf dist/duckdb-*.tar.gz --strip-components=1 -C duckdb_tarball
         - C:/Python37-x64/python.exe -m cibuildwheel --platform windows --output-dir wheelhouse duckdb_tarball
         - cd ../..
 
       after_success:
-        C:/Python37-x64/python.exe tools/upload-s3.py python tools/pythonpkg/wheelhouse/*.whl
+        - C:/Python37-x64/python.exe tools/upload-s3.py python tools/pythonpkg/wheelhouse/*.whl
+        - C:/Python37-x64/python.exe scripts/asset-upload.py tools/pythonpkg/wheelhouse/*.whl
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,12 +42,12 @@ matrix:
         - (cd examples/embedded-c; make)
         - (cd examples/embedded-c++; make)
         - (cd examples/programmatic-querying; make)
-        - java -cp build/release/tools/jdbc/DuckDBJ.jar nl.cwi.da.duckdb.test.TestDuckDBJDBC
+        - java -cp build/release/tools/jdbc/duckdb_jdbc.jar nl.cwi.da.duckdb.test.TestDuckDBJDBC
         - build/release/extension/icu/test/icu_test
 
       after_success:
-        - python tools/upload-s3.py lib-linux-amd64 build/release/src/libduckdb*.so build/release/src/libduckdb*.a build/release/duckdb_cli build/release/tools/jdbc/DuckDBJ.jar
-        - python scripts/asset-upload.py libduckdb-linux-amd64.so=build/release/src/libduckdb.so duckdb_cli-linux-amd64=build/release/duckdb_cli DuckDBJ-linux-amd64.jar=build/release/tools/jdbc/DuckDBJ.jar
+        - python tools/upload-s3.py lib-linux-amd64 build/release/src/libduckdb*.so build/release/src/libduckdb*.a build/release/duckdb_cli build/release/tools/jdbc/duckdb_jdbc.jar
+        - python scripts/asset-upload.py libduckdb-linux-amd64.so=build/release/src/libduckdb*.so duckdb_cli-linux-amd64=build/release/duckdb_cli duckdb_jdbc-linux-amd64.jar=build/release/tools/jdbc/duckdb_jdbc.jar
 
 
     - os: osx
@@ -64,12 +64,12 @@ matrix:
         - (mkdir -p build/release && cd build/release && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_ICU_EXTENSION=1 -DJDBC_DRIVER=1 ../.. && cmake --build .)
         - build/release/test/unittest
         - python3 tools/shell/shell-test.py build/release/duckdb_cli
-        - java -cp build/release/tools/jdbc/DuckDBJ.jar nl.cwi.da.duckdb.test.TestDuckDBJDBC
+        - java -cp build/release/tools/jdbc/duckdb_jdbc.jar nl.cwi.da.duckdb.test.TestDuckDBJDBC
         - build/release/extension/icu/test/icu_test
 
       after_success:
-        - python3 tools/upload-s3.py lib-osx build/release/src/libduckdb.dylib build/release/src/libduckdb_static.a build/release/duckdb_cli build/release/tools/jdbc/DuckDBJ.jar
-        - python3 scripts/asset-upload.py libduckdb-osx.so=build/release/src/libduckdb*.so duckdb_cli-osx=build/release/duckdb_cli DuckDBJ-osx.jar=build/release/tools/jdbc/DuckDBJ.jar
+        - python3 tools/upload-s3.py lib-osx build/release/src/libduckdb.dylib build/release/src/libduckdb_static.a build/release/duckdb_cli build/release/tools/jdbc/duckdb_jdbc.jar
+        - python3 scripts/asset-upload.py libduckdb-osx.dylib=build/release/src/libduckdb*.dylib duckdb_cli-osx=build/release/duckdb_cli duckdb_jdbc-osx.jar=build/release/tools/jdbc/duckdb_jdbc.jar
 
 
     - os: windows
@@ -94,12 +94,12 @@ matrix:
         - cmake --build . --target icu_test --config Release
         - test/Release/unittest.exe
         - C:/Python37-x64/python.exe tools/shell/shell-test.py Release/duckdb_cli.exe
-        - C:/Program\ Files/Java/jdk1.8.0_211/bin/java -cp tools/jdbc/DuckDBJ.jar nl.cwi.da.duckdb.test.TestDuckDBJDBC
+        - C:/Program\ Files/Java/jdk1.8.0_211/bin/java -cp tools/jdbc/duckdb-jdbc.jar nl.cwi.da.duckdb.test.TestDuckDBJDBC
         - extension/icu/test/Release/icu_test.exe
 
       after_success:
-        - C:/Python37-x64/python.exe tools/upload-s3.py lib-windows-amd64 src/Release/duckdb.dll Release/duckdb_cli.exe tools/jdbc/DuckDBJ.jar
-        - C:/Python37-x64/python.exe scripts/asset-upload.py libduckdb-windows-amd64.dll=src/Release/duckdb.dll duckdb_cli-windows-amd64.exe=Release/duckdb_cli.exe DuckDBJ-windows-amd64.jar=tools/jdbc/DuckDBJ.jar
+        - C:/Python37-x64/python.exe tools/upload-s3.py lib-windows-amd64 src/Release/duckdb.dll Release/duckdb_cli.exe tools/jdbc/duckdb_jdbc.jar
+        - C:/Python37-x64/python.exe scripts/asset-upload.py libduckdb-windows-amd64.dll=src/Release/duckdb.dll duckdb_cli-windows-amd64.exe=Release/duckdb_cli.exe duckdb_jdbc-windows-amd64.jar=tools/jdbc/duckdb_jdbc.jar
 
 
 # checks: debug mode (with sanitizers), coveralls, valgrind, vector sizes
@@ -431,9 +431,9 @@ matrix:
       script:
         - mkdir -p build/release
         - (cd build/release && cmake -DCMAKE_BUILD_TYPE=Release -DJDBC_DRIVER=1 ../.. && cmake --build .)
-        - java -cp build/release/tools/jdbc/DuckDBJ.jar nl.cwi.da.duckdb.test.TestDuckDBJDBC
+        - java -cp build/release/tools/jdbc/duckdb_jdbc.jar nl.cwi.da.duckdb.test.TestDuckDBJDBC
         - git clone https://github.com/cwida/jdbccts.git
-        - (cd jdbccts && make DUCKDB_JAR=../build/release/tools/jdbc/DuckDBJ.jar test)
+        - (cd jdbccts && make DUCKDB_JAR=../build/release/tools/jdbc/duckdb_jdbc.jar test)
 
     - os: linux
       if: tag != master-builds

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
 
       after_success:
         - python tools/upload-s3.py lib-linux-amd64 build/release/src/libduckdb*.so build/release/src/libduckdb*.a build/release/duckdb_cli build/release/tools/jdbc/DuckDBJ.jar
-        - python scripts/asset-upload.py libduckdb-linux-amd64.so=build/release/src/libduckdb*.so duckdb_cli-linux-amd64=build/release/duckdb_cli DuckDBJ-linux-amd64.jar=build/release/tools/jdbc/DuckDBJ.jar
+        - python scripts/asset-upload.py libduckdb-linux-amd64.so=build/release/src/libduckdb.so duckdb_cli-linux-amd64=build/release/duckdb_cli DuckDBJ-linux-amd64.jar=build/release/tools/jdbc/DuckDBJ.jar
 
 
     - os: osx
@@ -293,7 +293,7 @@ matrix:
 
       after_success:
         - python tools/upload-s3.py lib-linux-i386 build/release/src/libduckdb*.so build/release/src/libduckdb*.a build/release/duckdb_cli
-        - python scripts/asset-upload.py libduckdb-linux-i386.so=build/release/src/libduckdb*.so duckdb_cli-linux-i386=build/release/duckdb_cli
+        - python scripts/asset-upload.py libduckdb-linux-i386.so=build/release/src/libduckdb.so duckdb_cli-linux-i386=build/release/duckdb_cli
 
 
     - os: windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
         - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
       before_install:
         - eval "${MATRIX_EVAL}"
-        - pip install --user boto3
+        - pip install --user boto3 requests
       script:
         - mkdir -p build/release
         - (cd build/release && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_ICU_EXTENSION=1 -DJDBC_DRIVER=1 ../.. && cmake --build .)
@@ -46,7 +46,7 @@ matrix:
 
       after_success:
         - python tools/upload-s3.py lib-linux-amd64 build/release/src/libduckdb*.so build/release/src/libduckdb*.a build/release/duckdb_cli build/release/tools/jdbc/DuckDBJ.jar
-        - python scripts/asset-upload.py lib-linux-amd64 build/release/src/libduckdb*.so build/release/duckdb_cli build/release/tools/jdbc/DuckDBJ.jar
+        - python scripts/asset-upload.py build/release/src/libduckdb*.so build/release/duckdb_cli build/release/tools/jdbc/DuckDBJ.jar
 
 
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ matrix:
 
       after_success:
         - python3 tools/upload-s3.py lib-osx build/release/src/libduckdb.dylib build/release/src/libduckdb_static.a build/release/duckdb_cli build/release/tools/jdbc/DuckDBJ.jar
-        - python scripts/asset-upload.py libduckdb-osx.so=build/release/src/libduckdb*.so duckdb_cli-osx=build/release/duckdb_cli DuckDBJ-osx.jar=build/release/tools/jdbc/DuckDBJ.jar
+        - python3 scripts/asset-upload.py libduckdb-osx.so=build/release/src/libduckdb*.so duckdb_cli-osx=build/release/duckdb_cli DuckDBJ-osx.jar=build/release/tools/jdbc/DuckDBJ.jar
 
 
     - os: windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
 
       after_success:
         - python tools/upload-s3.py lib-linux-amd64 build/release/src/libduckdb*.so build/release/src/libduckdb*.a build/release/duckdb_cli build/release/tools/jdbc/duckdb_jdbc.jar
-        - python scripts/asset-upload.py libduckdb-linux-amd64.so=build/release/src/libduckdb*.so duckdb_cli-linux-amd64=build/release/duckdb_cli duckdb_jdbc-linux-amd64.jar=build/release/tools/jdbc/duckdb_jdbc.jar
+        - python3 scripts/asset-upload.py libduckdb-linux-amd64.so=build/release/src/libduckdb*.so duckdb_cli-linux-amd64=build/release/duckdb_cli duckdb_jdbc-linux-amd64.jar=build/release/tools/jdbc/duckdb_jdbc.jar
 
 
     - os: osx
@@ -238,7 +238,7 @@ matrix:
       after_success:
         - (cd src/amalgamation; zip ../../build/duckdb.zip duckdb.*)
         - python tools/upload-s3.py src-amalgamation build/duckdb.zip
-        - python scripts/asset-upload.py duckdb_amalgamation.zip=build/duckdb.zip
+        - python3 scripts/asset-upload.py duckdb_amalgamation.zip=build/duckdb.zip
 
 
     - os: osx
@@ -295,7 +295,7 @@ matrix:
 
       after_success:
         - python tools/upload-s3.py lib-linux-i386 build/release/src/libduckdb*.so build/release/src/libduckdb*.a build/release/duckdb_cli
-        - python scripts/asset-upload.py libduckdb-linux-i386.so=build/release/src/libduckdb.so duckdb_cli-linux-i386=build/release/duckdb_cli
+        - python3 scripts/asset-upload.py libduckdb-linux-i386.so=build/release/src/libduckdb.so duckdb_cli-linux-i386=build/release/duckdb_cli
 
 
     - os: windows
@@ -463,7 +463,7 @@ matrix:
         - R -e "tools::write_PACKAGES(dir = '.', type = 'source')"
         - python ../upload-s3.py rstats/src/contrib duckdb_*.tar.gz PACKAGES*
         - python ../upload-s3.py rstats duckdb_*.tar.gz
-        - python ../../scripts/asset-upload.py duckdb_r.tar.gz=duckdb_*.tar.gz
+        - python3 ../../scripts/asset-upload.py duckdb_r.tar.gz=duckdb_*.tar.gz
 
 
     - os: osx
@@ -494,7 +494,7 @@ matrix:
         - R -e "tools::write_PACKAGES(dir = '.', type = 'mac.binary')"
         - python3 ../upload-s3.py rstats/bin/macosx/el-capitan/contrib/3.6 duckdb_*.tgz PACKAGES*
         - python3 ../upload-s3.py rstats duckdb_*.tgz
-        - python ../../scripts/asset-upload.py duckdb_r_osx.tgz=duckdb_*.tgz
+        - python3 ../../scripts/asset-upload.py duckdb_r_osx.tgz=duckdb_*.tgz
 
 
     - os: windows
@@ -547,7 +547,7 @@ matrix:
         - cd ../..
       after_success:
         - python tools/upload-s3.py python tools/pythonpkg/wheelhouse/*.whl tools/pythonpkg/dist/duckdb-*.tar.gz
-        - python scripts/asset-upload.py duckdb_python.tar.gz=tools/pythonpkg/dist/duckdb-*.tar.gz tools/pythonpkg/wheelhouse/*.whl
+        - python3 scripts/asset-upload.py duckdb_python.tar.gz=tools/pythonpkg/dist/duckdb-*.tar.gz tools/pythonpkg/wheelhouse/*.whl
 
 
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - CIBW_TEST_COMMAND='python -m pytest {project}/tests'
 
 # exclude this because its a tag used for master builds
-if: NOT tag =~ /^master-builds$/
+if: tag != master-builds
 
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,12 @@ env:
     - CIBW_BEFORE_BUILD='pip install "numpy>=1.16" && pip install "pandas>=0.24" && pip install "pytest>=4.3" && pip install "cmake==3.13.3" && pip install "pybind11>=2.4"'
     - CIBW_TEST_COMMAND='python -m pytest {project}/tests'
 
-# exclude this because its a tag used for master builds
-if: tag != master-builds
-
 
 matrix:
   include:
 
     - os: linux
+      if: tag != master-builds
       dist: bionic
       name: GCC 9
       python: 3.7
@@ -53,8 +51,8 @@ matrix:
 
 
     - os: osx
+      if: tag != master-builds
       name: Xcode 11.3
-
       osx_image: xcode11.3
 
       before_install:
@@ -75,6 +73,7 @@ matrix:
 
 
     - os: windows
+      if: tag != master-builds
       name: VS 2017
       filter_secrets: false
 
@@ -104,6 +103,7 @@ matrix:
 # checks: debug mode (with sanitizers), coveralls, valgrind, vector sizes
 
     - os: linux
+      if: tag != master-builds
       dist: xenial
       name: GCC 9 Debug
 
@@ -434,6 +434,7 @@ matrix:
         - (cd jdbccts && make DUCKDB_JAR=../build/release/tools/jdbc/DuckDBJ.jar test)
 
     - os: linux
+      if: tag != master-builds
       name: R Package
 
       dist: xenial
@@ -522,8 +523,8 @@ matrix:
 
 
     - os: linux
+      if: tag != master-builds
       name: Python 3 Package
-
       dist: xenial
       language: python
       cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -229,6 +229,8 @@ matrix:
         - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
       before_install:
         - eval "${MATRIX_EVAL}"
+        - pip install --user boto3 requests
+
       script:
         - python scripts/amalgamation.py
         - mkdir -p build/release
@@ -435,6 +437,7 @@ matrix:
         - git clone https://github.com/cwida/jdbccts.git
         - (cd jdbccts && make DUCKDB_JAR=../build/release/tools/jdbc/duckdb_jdbc.jar test)
 
+
     - os: linux
       if: tag != master-builds
       name: R Package
@@ -535,14 +538,16 @@ matrix:
       python: 3.7
 
       script:
-        - pip install cibuildwheel==0.10.2 boto3
+        - pip install cibuildwheel==0.10.2 boto3 requests
         - cd tools/pythonpkg
         - python setup.py sdist
         - mkdir duckdb_tarball && tar xvf dist/duckdb-*.tar.gz --strip-components=1 -C duckdb_tarball
         - cibuildwheel --output-dir wheelhouse duckdb_tarball
         - cd ../..
       after_success:
-        python tools/upload-s3.py python tools/pythonpkg/wheelhouse/*.whl tools/pythonpkg/dist/duckdb-*.tar.gz
+        - python tools/upload-s3.py python tools/pythonpkg/wheelhouse/*.whl tools/pythonpkg/dist/duckdb-*.tar.gz
+        - python scripts/asset-upload.py tools/pythonpkg/dist/duckdb-*.tar.gz
+
 
     - os: linux
       name: Python 2 Package
@@ -563,7 +568,7 @@ matrix:
         - python setup.py sdist
         - mkdir duckdb_tarball && tar xvf dist/duckdb-*.tar.gz --strip-components=1 -C duckdb_tarball
       after_success:
-        python tools/upload-s3.py python tools/pythonpkg/dist/duckdb-*.tar.gz
+        - python tools/upload-s3.py python tools/pythonpkg/dist/duckdb-*.tar.gz
 
 
     - os: osx
@@ -576,7 +581,7 @@ matrix:
       before_install:
         - curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
         - python3 /tmp/get-pip.py
-        - python3 -m pip install cibuildwheel==0.10.2 boto3
+        - python3 -m pip install cibuildwheel==0.10.2 boto3 requests
 
       script:
         - cd tools/pythonpkg
@@ -586,7 +591,8 @@ matrix:
         - cd ../..
 
       after_success:
-        python3 tools/upload-s3.py python tools/pythonpkg/wheelhouse/*.whl
+        - python3 tools/upload-s3.py python tools/pythonpkg/wheelhouse/*.whl
+        - python3 scripts/asset-upload.py tools/pythonpkg/dist/duckdb-*.tar.gz
 
 
     - os: windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ matrix:
         - cmake --build . --target icu_test --config Release
         - test/Release/unittest.exe
         - C:/Python37-x64/python.exe tools/shell/shell-test.py Release/duckdb_cli.exe
-        - C:/Program\ Files/Java/jdk1.8.0_211/bin/java -cp tools/jdbc/duckdb-jdbc.jar nl.cwi.da.duckdb.test.TestDuckDBJDBC
+        - C:/Program\ Files/Java/jdk1.8.0_211/bin/java -cp tools/jdbc/duckdb_jdbc.jar nl.cwi.da.duckdb.test.TestDuckDBJDBC
         - extension/icu/test/Release/icu_test.exe
 
       after_success:
@@ -463,7 +463,7 @@ matrix:
         - R -e "tools::write_PACKAGES(dir = '.', type = 'source')"
         - python ../upload-s3.py rstats/src/contrib duckdb_*.tar.gz PACKAGES*
         - python ../upload-s3.py rstats duckdb_*.tar.gz
-        - python3 ../../scripts/asset-upload.py duckdb_r.tar.gz=duckdb_*.tar.gz
+        - python3 ../../scripts/asset-upload.py duckdb_r_src.tar.gz=duckdb_*.tar.gz
 
 
     - os: osx
@@ -547,7 +547,7 @@ matrix:
         - cd ../..
       after_success:
         - python tools/upload-s3.py python tools/pythonpkg/wheelhouse/*.whl tools/pythonpkg/dist/duckdb-*.tar.gz
-        - python3 scripts/asset-upload.py duckdb_python.tar.gz=tools/pythonpkg/dist/duckdb-*.tar.gz tools/pythonpkg/wheelhouse/*.whl
+       # - python3 scripts/asset-upload.py duckdb_python_src.tar.gz=tools/pythonpkg/dist/duckdb-*.tar.gz tools/pythonpkg/wheelhouse/*.whl
 
 
     - os: linux
@@ -591,7 +591,7 @@ matrix:
 
       after_success:
         - python3 tools/upload-s3.py python tools/pythonpkg/wheelhouse/*.whl
-        - python3 scripts/asset-upload.py tools/pythonpkg/wheelhouse/*.whl
+       # - python3 scripts/asset-upload.py tools/pythonpkg/wheelhouse/*.whl
 
 
     - os: windows
@@ -625,5 +625,5 @@ matrix:
 
       after_success:
         - C:/Python37-x64/python.exe tools/upload-s3.py python tools/pythonpkg/wheelhouse/*.whl
-        - C:/Python37-x64/python.exe scripts/asset-upload.py tools/pythonpkg/wheelhouse/*.whl
+        # - C:/Python37-x64/python.exe scripts/asset-upload.py tools/pythonpkg/wheelhouse/*.whl
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ matrix:
 
       after_success:
         - python tools/upload-s3.py lib-linux-amd64 build/release/src/libduckdb*.so build/release/src/libduckdb*.a build/release/duckdb_cli build/release/tools/jdbc/DuckDBJ.jar
+        - python scripts/asset-upload.py lib-linux-amd64 build/release/src/libduckdb*.so build/release/duckdb_cli build/release/tools/jdbc/DuckDBJ.jar
+
 
     - os: osx
       name: Xcode 11.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ matrix:
 
       after_success:
         - python3 tools/upload-s3.py lib-osx build/release/src/libduckdb.dylib build/release/src/libduckdb_static.a build/release/duckdb_cli build/release/tools/jdbc/duckdb_jdbc.jar
-        - python3 scripts/asset-upload.py libduckdb-osx.dylib=build/release/src/libduckdb*.dylib duckdb_cli-osx=build/release/duckdb_cli duckdb_jdbc-osx.jar=build/release/tools/jdbc/duckdb_jdbc.jar
+        - python3 scripts/asset-upload.py libduckdb-osx-amd64.dylib=build/release/src/libduckdb*.dylib duckdb_cli-osx-amd64=build/release/duckdb_cli duckdb_jdbc-osx-amd64.jar=build/release/tools/jdbc/duckdb_jdbc.jar
 
 
     - os: windows
@@ -320,6 +320,7 @@ matrix:
 
       after_success:
         - C:/Python37-x64/python.exe tools/upload-s3.py lib-windows-i386 src/Release/duckdb.dll Release/duckdb_cli.exe
+        - C:/Python37-x64/python.exe scripts/asset-upload.py libduckdb-windows-i386.dll=src/Release/duckdb.dll duckdb_cli-windows-i386.exe=Release/duckdb_cli.exe duckdb_jdbc-windows-i386.jar=tools/jdbc/duckdb_jdbc.jar
 
 
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,8 @@ matrix:
       before_script:
         - choco install python3 --version 3.7.3 -y --params "/InstallDir:C:\Python37-x64"
         - choco install jdk8 --version 8.0.211 -y --force
+        - C:/Python37-x64/python.exe -m pip install --upgrade pip
+        - C:/Python37-x64/python.exe -m pip install requests
 
       script:
         - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR_PLATFORM=x64 -DJDBC_DRIVER=1 -DBUILD_ICU_EXTENSION=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
         - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
       before_install:
         - eval "${MATRIX_EVAL}"
-        - pip install --user boto3 requests
+        - pip install --user boto3
       script:
         - mkdir -p build/release
         - (cd build/release && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_ICU_EXTENSION=1 -DJDBC_DRIVER=1 ../.. && cmake --build .)
@@ -58,7 +58,7 @@ matrix:
       before_install:
         - curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
         - python3 /tmp/get-pip.py
-        - python3 -m pip install --user boto3 requests
+        - python3 -m pip install --user boto3
 
       script:
         - (mkdir -p build/release && cd build/release && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_ICU_EXTENSION=1 -DJDBC_DRIVER=1 ../.. && cmake --build .)
@@ -82,8 +82,6 @@ matrix:
       before_script:
         - choco install python3 --version 3.7.3 -y --params "/InstallDir:C:\Python37-x64"
         - choco install jdk8 --version 8.0.211 -y --force
-        - C:/Python37-x64/python.exe -m pip install --upgrade pip
-        - C:/Python37-x64/python.exe -m pip install requests
 
       script:
         - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR_PLATFORM=x64 -DJDBC_DRIVER=1 -DBUILD_ICU_EXTENSION=1
@@ -229,7 +227,7 @@ matrix:
         - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
       before_install:
         - eval "${MATRIX_EVAL}"
-        - pip install --user boto3 requests
+        - pip install --user boto3
 
       script:
         - python scripts/amalgamation.py
@@ -289,7 +287,7 @@ matrix:
         - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
       before_install:
         - eval "${MATRIX_EVAL}"
-        - pip install --user boto3 requests
+        - pip install --user boto3
       script:
         - mkdir -p build/release
         - (cd build/release && cmake -DFORCE_32_BIT=1 -DCMAKE_BUILD_TYPE=Release ../.. && cmake --build .)
@@ -447,7 +445,7 @@ matrix:
       r: devel
 
       before_install:
-        - pip install --user boto3 requests
+        - pip install --user boto3
         - cd tools/rpkg
         - R -f dependencies.R
 
@@ -479,7 +477,7 @@ matrix:
       before_install:
         - curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
         - python3 /tmp/get-pip.py
-        - python3 -m pip install --user boto3 requests
+        - python3 -m pip install --user boto3
         - cd tools/rpkg
         - R -f dependencies.R
 
@@ -541,7 +539,7 @@ matrix:
       python: 3.7
 
       script:
-        - pip install cibuildwheel==0.10.2 boto3 requests
+        - pip install cibuildwheel==0.10.2 boto3
         - cd tools/pythonpkg
         - python setup.py sdist
         - mkdir duckdb_tarball && tar xvf dist/duckdb-*.tar.gz --strip-components=1 -C duckdb_tarball
@@ -582,7 +580,7 @@ matrix:
       before_install:
         - curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
         - python3 /tmp/get-pip.py
-        - python3 -m pip install cibuildwheel==0.10.2 boto3 requests
+        - python3 -m pip install cibuildwheel==0.10.2 boto3
 
       script:
         - cd tools/pythonpkg
@@ -616,7 +614,7 @@ matrix:
         - choco install curl -y --force
         - C:/Python37-x64/python.exe -m pip install --upgrade pip
         - C:/Python37-x64/python.exe -m pip install "cibuildwheel==0.10.2"
-        - C:/Python37-x64/python.exe -m pip install "numpy>=1.16" "pandas>=0.24" "pytest>=4.3" "pybind11>=2.4" "requests"
+        - C:/Python37-x64/python.exe -m pip install "numpy>=1.16" "pandas>=0.24" "pytest>=4.3" "pybind11>=2.4"
 
       script:
         - cd tools/pythonpkg

--- a/scripts/asset-upload.py
+++ b/scripts/asset-upload.py
@@ -1,6 +1,4 @@
-import json, os, sys, mimetypes
-import urllib.request
-import json
+import json, os, sys, mimetypes, urllib.request
 
 api_url = 'https://api.github.com/repos/cwida/duckdb/'
 tag = 'master-builds'

--- a/scripts/asset-upload.py
+++ b/scripts/asset-upload.py
@@ -1,0 +1,75 @@
+import requests, json, os, sys, mimetypes
+
+if (len(sys.argv) < 2):
+    print("Usage: [filename1] [filename2] ... ")
+    exit(1)
+
+api_url = 'https://api.github.com/repos/cwida/duckdb/'
+
+tag = 'master-builds'
+
+# this essentially should run on release tag builds to fill up release assets and master
+# so check travis tag?
+
+# TODO check TRAVIS_TAG
+
+token = os.getenv("GH_TOKEN", "")
+if token == "":
+	raise ValueError('need a GitHub token in GH_TOKEN')
+header = {'Authorization': 'token ' + token}
+
+
+branch = os.getenv("TRAVIS_BRANCH", "")
+if branch != "ghassets":
+	print("Only running on ghassets branch for now. Exiting.")
+	exit(0)
+
+sha = os.getenv("TRAVIS_COMMIT", "")
+if sha == "":
+	raise ValueError('need a commit ID in TRAVIS_COMMIT')
+
+# find out if commit exists in the first place
+resp = requests.get(api_url +'commits/%s' % sha, headers=header).json()
+if 'sha' not in resp:
+	raise ValueError('commit %s not found' % sha)
+
+# check if tag exists with the correct hash already, if not, recreate tag & release
+resp = requests.get(api_url +'git/ref/tags/%s' % tag, headers=header).json()
+if 'object' not in resp or 'sha' not in resp['object'] or resp['object']['sha'] != sha:
+	print("re-creating tag & release")
+	# clean up, delete release if exists and tag
+	# this creates a potential race condition, use travis stages?
+	response_json = requests.get(api_url +'releases/tags/%s' % tag, headers=header).json()
+	if "id" in response_json:
+		requests.delete(api_url +'releases/%s' % response_json["id"], headers=header)
+	requests.delete(api_url +'git/refs/tags/%s' % tag, headers=header)
+
+	payload = {
+	  "tag_name": tag,
+	  "target_commitish": sha, # what a wonderful key name
+	  "name": "Development builds from `master`",
+	  "body": "This release contains builds for the latest commit to the master branch. They are meant for testing.",
+	  "draft": False,
+	  "prerelease": True
+	}
+	response_json = requests.post(api_url +'releases', json=payload, headers=header).json()
+
+# double-check that release exists and has correct sha
+resp = requests.get(api_url +'releases/tags/%s' % tag, headers=header).json()
+if 'id' not in resp or 'upload_url' not in resp or 'target_commitish' not in resp or resp['target_commitish'] != sha:
+	raise ValueError('release does not point to requested commit %s' % sha)
+
+upload_url = resp['upload_url'].split('{')[0] # gah
+
+files = sys.argv[1:]
+for filename in files:
+	mime_type = mimetypes.guess_type(filename)[0]
+	if mime_type is None:
+		mime_type = "application/octet-stream"
+
+	header["Content-Type"] = mime_type
+	with open(filename, 'rb') as f:
+	    resp = requests.post(upload_url + '?name=%s' % os.path.basename(filename), data=f, headers=header).json()
+	    if 'id' not in resp:
+	    	raise ValueError('upload failed :/ ' + str(resp))
+	    print(resp['browser_download_url'])

--- a/scripts/asset-upload.py
+++ b/scripts/asset-upload.py
@@ -17,6 +17,11 @@ if branch != "master":
 	print("Only running on master branch for now. Exiting.")
 	exit(0)
 
+pr = os.getenv("TRAVIS_PULL_REQUEST", "")
+if pr != "false":
+	print("Not running on PRs. Exiting.")
+	exit(0)
+
 # sha = os.getenv("TRAVIS_COMMIT", "")
 # if sha == "":
 # 	raise ValueError('need a commit ID in TRAVIS_COMMIT')

--- a/scripts/asset-upload.py
+++ b/scripts/asset-upload.py
@@ -6,8 +6,8 @@ api_url = 'https://api.github.com/repos/cwida/duckdb/'
 tag = 'master-builds'
 
 if (len(sys.argv) < 2):
-    print("Usage: [filename1] [filename2] ... ")
-    exit(1)
+	print("Usage: [filename1] [filename2] ... ")
+	exit(1)
 
 # this essentially should run on release tag builds to fill up release assets and master
 # so check travis tag?
@@ -121,7 +121,7 @@ for filename in files:
 		if asset['name'] == asset_filename:
 			gh_api('releases/assets/%s' % asset['id'], method='DELETE')
 
-    resp = gh_api(upload_url + '?name=%s' % asset_filename, filename=local_filename)
-    if 'id' not in resp:
-    	raise ValueError('upload failed :/ ' + str(resp))
-    print(resp['browser_download_url'])
+	resp = gh_api(upload_url + '?name=%s' % asset_filename, filename=local_filename)
+	if 'id' not in resp:
+		raise ValueError('upload failed :/ ' + str(resp))
+	print(resp['browser_download_url'])

--- a/scripts/asset-upload.py
+++ b/scripts/asset-upload.py
@@ -13,8 +13,8 @@ if (len(sys.argv) < 2):
 # TODO check TRAVIS_TAG
 
 branch = os.getenv("TRAVIS_BRANCH", "")
-if branch != "ghassets":
-	print("Only running on ghassets branch for now. Exiting.")
+if branch != "master":
+	print("Only running on master branch for now. Exiting.")
 	exit(0)
 
 # sha = os.getenv("TRAVIS_COMMIT", "")

--- a/scripts/asset-upload.py
+++ b/scripts/asset-upload.py
@@ -63,9 +63,14 @@ upload_url = resp['upload_url'].split('{')[0] # gah
 
 files = sys.argv[1:]
 for filename in files:
-	parts = filename.split("=")
-	local_filename = parts[1]
-	asset_filename = parts[0]
+	if '=' in filename:
+		parts = filename.split("=")
+		local_filename = parts[1]
+		asset_filename = parts[0]
+	else :
+		local_filename = filename
+		asset_filename = os.path.basename(filename)
+
 	mime_type = mimetypes.guess_type(local_filename)[0]
 	if mime_type is None:
 		mime_type = "application/octet-stream"

--- a/scripts/asset-upload.py
+++ b/scripts/asset-upload.py
@@ -1,48 +1,86 @@
-import requests, json, os, sys, mimetypes
+import json, os, sys, mimetypes
+import urllib.request
+import json
+
+api_url = 'https://api.github.com/repos/cwida/duckdb/'
+tag = 'master-builds'
 
 if (len(sys.argv) < 2):
     print("Usage: [filename1] [filename2] ... ")
     exit(1)
-
-api_url = 'https://api.github.com/repos/cwida/duckdb/'
-
-tag = 'master-builds'
 
 # this essentially should run on release tag builds to fill up release assets and master
 # so check travis tag?
 
 # TODO check TRAVIS_TAG
 
-token = os.getenv("GH_TOKEN", "")
-if token == "":
-	raise ValueError('need a GitHub token in GH_TOKEN')
-header = {'Authorization': 'token ' + token}
-
-
 branch = os.getenv("TRAVIS_BRANCH", "")
 if branch != "ghassets":
 	print("Only running on ghassets branch for now. Exiting.")
 	exit(0)
 
-sha = os.getenv("TRAVIS_COMMIT", "")
-if sha == "":
-	raise ValueError('need a commit ID in TRAVIS_COMMIT')
+# sha = os.getenv("TRAVIS_COMMIT", "")
+# if sha == "":
+# 	raise ValueError('need a commit ID in TRAVIS_COMMIT')
+sha = 'ba75d81601913782d28a3878707d135319f38bdd'
+
+token = os.getenv("GH_TOKEN", "")
+if token == "":
+	raise ValueError('need a GitHub token in GH_TOKEN')
+
+def gh_api(suburl, payload={}, filename='', method='GET'):
+	url = api_url + suburl
+	headers = {
+		"Content-Type": "application/json",
+		'Authorization': 'token ' + token
+	}
+
+	body_data = b''
+	if len(payload) > 0:
+		method = 'POST'
+		body_data = json.dumps(payload).encode("utf-8")
+		headers["Content-Length"] = len(body_data)
+
+	if len(filename) > 0:
+		method = 'POST'
+		body_data = open(filename, 'rb')
+
+		mime_type = mimetypes.guess_type(local_filename)[0]
+		if mime_type is None:
+			mime_type = "application/octet-stream"
+		headers["Content-Type"] = mime_type
+		headers["Content-Length"] = os.path.getsize(local_filename)
+
+		url = suburl # cough
+
+	req = urllib.request.Request(url, body_data, headers)
+	req.get_method = lambda: method
+	try:
+		raw_resp = urllib.request.urlopen(req).read().decode()
+	except urllib.error.HTTPError as e:
+		raw_resp = e.read().decode() # gah
+
+	if (method != 'DELETE'):
+		return json.loads(raw_resp)
+	else:
+		return {}
+
 
 # find out if commit exists in the first place
-resp = requests.get(api_url +'commits/%s' % sha, headers=header).json()
-if 'sha' not in resp:
+if 'sha' not in gh_api('commits/%s' % sha):
 	raise ValueError('commit %s not found' % sha)
 
 # check if tag exists with the correct hash already, if not, recreate tag & release
-resp = requests.get(api_url +'git/ref/tags/%s' % tag, headers=header).json()
-if 'object' not in resp or 'sha' not in resp['object'] or resp['object']['sha'] != sha:
+resp = gh_api('git/ref/tags/%s' % tag)
+if 'object' not in resp or 'sha' not in resp['object'] : # or resp['object']['sha'] != sha
 	print("re-creating tag & release")
 	# clean up, delete release if exists and tag
 	# this creates a potential race condition, use travis stages?
-	response_json = requests.get(api_url +'releases/tags/%s' % tag, headers=header).json()
-	if "id" in response_json:
-		requests.delete(api_url +'releases/%s' % response_json["id"], headers=header)
-	requests.delete(api_url +'git/refs/tags/%s' % tag, headers=header)
+	resp = gh_api('releases/tags/%s' % tag)
+	if "id" in resp:
+		gh_api('releases/%s' % resp["id"], method='DELETE')
+
+	gh_api('git/refs/tags/%s' % tag, method='DELETE')
 
 	payload = {
 	  "tag_name": tag,
@@ -52,15 +90,22 @@ if 'object' not in resp or 'sha' not in resp['object'] or resp['object']['sha'] 
 	  "draft": False,
 	  "prerelease": True
 	}
-	response_json = requests.post(api_url +'releases', json=payload, headers=header).json()
+	resp = gh_api('releases', payload=payload)
+	print(resp)
+
+resp = gh_api('releases/tags/%s' % tag)
+if 'id' not in resp or 'upload_url' not in resp:
+	raise ValueError('release does not exist for tag ' % tag)
 
 # double-check that release exists and has correct sha
-resp = requests.get(api_url +'releases/tags/%s' % tag, headers=header).json()
-if 'id' not in resp or 'upload_url' not in resp or 'target_commitish' not in resp or resp['target_commitish'] != sha:
-	raise ValueError('release does not point to requested commit %s' % sha)
+# disabled to not spam people watching releases
+# if 'id' not in resp or 'upload_url' not in resp or 'target_commitish' not in resp or resp['target_commitish'] != sha:
+# 	raise ValueError('release does not point to requested commit %s' % sha)
+
+# TODO this could be a paged response!
+assets = gh_api('releases/%s/assets' % resp['id'])
 
 upload_url = resp['upload_url'].split('{')[0] # gah
-
 files = sys.argv[1:]
 for filename in files:
 	if '=' in filename:
@@ -71,13 +116,12 @@ for filename in files:
 		local_filename = filename
 		asset_filename = os.path.basename(filename)
 
-	mime_type = mimetypes.guess_type(local_filename)[0]
-	if mime_type is None:
-		mime_type = "application/octet-stream"
+	# delete if present
+	for asset in assets:
+		if asset['name'] == asset_filename:
+			gh_api('releases/assets/%s' % asset['id'], method='DELETE')
 
-	header["Content-Type"] = mime_type
-	with open(local_filename, 'rb') as f:
-	    resp = requests.post(upload_url + '?name=%s' % asset_filename, data=f, headers=header).json()
-	    if 'id' not in resp:
-	    	raise ValueError('upload failed :/ ' + str(resp))
-	    print(resp['browser_download_url'])
+    resp = gh_api(upload_url + '?name=%s' % asset_filename, filename=local_filename)
+    if 'id' not in resp:
+    	raise ValueError('upload failed :/ ' + str(resp))
+    print(resp['browser_download_url'])

--- a/scripts/asset-upload.py
+++ b/scripts/asset-upload.py
@@ -1,4 +1,4 @@
-import json, os, sys, mimetypes, urllib.request
+import json, os, sys, glob, mimetypes, urllib.request
 
 api_url = 'https://api.github.com/repos/cwida/duckdb/'
 tag = 'master-builds'
@@ -108,11 +108,14 @@ files = sys.argv[1:]
 for filename in files:
 	if '=' in filename:
 		parts = filename.split("=")
-		local_filename = parts[1]
 		asset_filename = parts[0]
+		paths = glob.glob(parts[1])
+		if len(paths) != 1:
+			raise ValueError("Could not find file for pattern %s" % local_filename)
+		local_filename = paths[0]
 	else :
-		local_filename = filename
 		asset_filename = os.path.basename(filename)
+		local_filename = filename
 
 	# delete if present
 	for asset in assets:
@@ -122,4 +125,4 @@ for filename in files:
 	resp = gh_api(upload_url + '?name=%s' % asset_filename, filename=local_filename)
 	if 'id' not in resp:
 		raise ValueError('upload failed :/ ' + str(resp))
-	print(resp['browser_download_url'])
+	print("%s -> %s" % (local_filename, resp['browser_download_url']))

--- a/scripts/asset-upload.py
+++ b/scripts/asset-upload.py
@@ -63,13 +63,16 @@ upload_url = resp['upload_url'].split('{')[0] # gah
 
 files = sys.argv[1:]
 for filename in files:
-	mime_type = mimetypes.guess_type(filename)[0]
+	parts = filename.split("=")
+	local_filename = parts[1]
+	asset_filename = parts[0]
+	mime_type = mimetypes.guess_type(local_filename)[0]
 	if mime_type is None:
 		mime_type = "application/octet-stream"
 
 	header["Content-Type"] = mime_type
-	with open(filename, 'rb') as f:
-	    resp = requests.post(upload_url + '?name=%s' % os.path.basename(filename), data=f, headers=header).json()
+	with open(local_filename, 'rb') as f:
+	    resp = requests.post(upload_url + '?name=%s' % asset_filename, data=f, headers=header).json()
 	    if 'id' not in resp:
 	    	raise ValueError('upload failed :/ ' + str(resp))
 	    print(resp['browser_download_url'])

--- a/tools/jdbc/CMakeLists.txt
+++ b/tools/jdbc/CMakeLists.txt
@@ -1,6 +1,9 @@
 find_package(Java 1.8)
 find_package(JNI)
 
+cmake_minimum_required(VERSION 3.11.0)
+
+
 if(NOT JNI_FOUND OR NOT Java_FOUND)
   message(FATAL_ERROR No
                       compatible
@@ -14,7 +17,7 @@ project(DuckDBJDummy NONE)
 file(GLOB JAVA_SRC_FILES src/main/java/nl/cwi/da/duckdb/*.java)
 file(GLOB JAVA_TEST_FILES src/test/java/nl/cwi/da/duckdb/test/*.java)
 
-add_jar(DuckDBJ
+add_jar(duckdb_jdbc
         ${JAVA_SRC_FILES}
         ${JAVA_TEST_FILES}
         GENERATE_NATIVE_HEADERS
@@ -27,10 +30,10 @@ set_target_properties(duckdb_java PROPERTIES SUFFIX ".so")
 set_target_properties(duckdb_java PROPERTIES PREFIX "lib")
 
 add_custom_command(OUTPUT dummy_jdbc_target
-                   DEPENDS duckdb_java DuckDBJ
+                   DEPENDS duckdb_java duckdb_jdbc
                    COMMAND ${Java_JAR_EXECUTABLE}
                            uf
-                           DuckDBJ.jar
+                           duckdb_jdbc.jar
                            -C
                            $<TARGET_FILE_DIR:duckdb_java>
                            $<TARGET_FILE_NAME:duckdb_java>)

--- a/tools/jdbc/CMakeLists.txt
+++ b/tools/jdbc/CMakeLists.txt
@@ -9,6 +9,7 @@ if(NOT JNI_FOUND OR NOT Java_FOUND)
 endif()
 
 include(UseJava)
+include(JNI)
 project(DuckDBJDummy NONE)
 
 file(GLOB JAVA_SRC_FILES src/main/java/nl/cwi/da/duckdb/*.java)

--- a/tools/jdbc/CMakeLists.txt
+++ b/tools/jdbc/CMakeLists.txt
@@ -9,7 +9,6 @@ if(NOT JNI_FOUND OR NOT Java_FOUND)
 endif()
 
 include(UseJava)
-include(JNI)
 project(DuckDBJDummy NONE)
 
 file(GLOB JAVA_SRC_FILES src/main/java/nl/cwi/da/duckdb/*.java)


### PR DESCRIPTION
We don't really want to maintain our own download server. GitHub has support for binary artefacts to be hosted in the "releases" section of a repo. This PR adds a script that - for now - uploads binary artefacts for each change to the `master` branch to a special release: https://github.com/cwida/duckdb/releases/tag/master-builds