### PR TITLE
added strict cast support for date and time

### DIFF
--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -706,6 +706,10 @@ template <> date_t CastToDate::Operation(string_t input) {
 	return Date::FromCString(input.GetData());
 }
 
+template <> date_t StrictCastToDate::Operation(string_t input) {
+	return Date::FromCString(input.GetData(), true);
+}
+
 //===--------------------------------------------------------------------===//
 // Cast From Time
 //===--------------------------------------------------------------------===//
@@ -769,6 +773,10 @@ template <> string_t CastFromTime::Operation(dtime_t input, Vector &vector) {
 //===--------------------------------------------------------------------===//
 template <> dtime_t CastToTime::Operation(string_t input) {
 	return Time::FromCString(input.GetData());
+}
+
+template <> dtime_t StrictCastToTime::Operation(string_t input) {
+	return Time::FromCString(input.GetData(), true);
 }
 
 template <> timestamp_t CastDateToTimestamp::Operation(date_t input) {

--- a/src/common/types/date.cpp
+++ b/src/common/types/date.cpp
@@ -110,11 +110,16 @@ static bool ParseDoubleDigit(const char *buf, idx_t &pos, int32_t &result) {
 	return false;
 }
 
-static bool TryConvertDate(const char *buf, date_t &result) {
+static bool TryConvertDate(const char *buf, date_t &result, bool strict = false) {
 	int32_t day = 0, month = -1;
 	int32_t year = 0, yearneg = (buf[0] == '-');
 	idx_t pos = 0;
 	int sep;
+
+	// skip leading spaces
+	while (std::isspace((unsigned char)buf[pos])) {
+		pos++;
+	}
 
 	if (yearneg == 0 && !std::isdigit((unsigned char)buf[0])) {
 		return false;
@@ -149,6 +154,13 @@ static bool TryConvertDate(const char *buf, date_t &result) {
 		return false;
 	}
 
+	if (strict) {
+		// skip trailing spaces
+		while (std::isspace((unsigned char)buf[pos])) {
+			pos++;
+		}
+	}
+
 	if (std::isdigit((unsigned char)buf[pos])) {
 		return false;
 	}
@@ -157,9 +169,9 @@ static bool TryConvertDate(const char *buf, date_t &result) {
 	return true;
 }
 
-date_t Date::FromCString(const char *buf) {
+date_t Date::FromCString(const char *buf, bool strict) {
 	date_t result;
-	if (!TryConvertDate(buf, result)) {
+	if (!TryConvertDate(buf, result, strict)) {
 		throw ConversionException("date/time field value out of range: \"%s\", "
 		                          "expected format is (YYYY-MM-DD)",
 		                          buf);
@@ -167,8 +179,8 @@ date_t Date::FromCString(const char *buf) {
 	return result;
 }
 
-date_t Date::FromString(string str) {
-	return Date::FromCString(str.c_str());
+date_t Date::FromString(string str, bool strict) {
+	return Date::FromCString(str.c_str(), strict);
 }
 
 string Date::ToString(int32_t date) {

--- a/src/common/types/date.cpp
+++ b/src/common/types/date.cpp
@@ -121,12 +121,12 @@ static bool TryConvertDate(const char *buf, date_t &result, bool strict = false)
 		pos++;
 	}
 
-	if (yearneg == 0 && !std::isdigit((unsigned char)buf[0])) {
+	if (yearneg == 0 && !std::isdigit((unsigned char)buf[pos])) {
 		return false;
 	}
 
 	// first parse the year
-	for (pos = yearneg; std::isdigit((unsigned char)buf[pos]); pos++) {
+	for (pos = pos + yearneg; std::isdigit((unsigned char)buf[pos]); pos++) {
 		year = (buf[pos] - '0') + year * 10;
 		if (year > YEAR_MAX) {
 			break;
@@ -154,15 +154,21 @@ static bool TryConvertDate(const char *buf, date_t &result, bool strict = false)
 		return false;
 	}
 
+	// in strict mode, check remaining string for non-space characters
 	if (strict) {
 		// skip trailing spaces
 		while (std::isspace((unsigned char)buf[pos])) {
 			pos++;
 		}
-	}
-
-	if (std::isdigit((unsigned char)buf[pos])) {
-		return false;
+		// check position. if end was not reached, non-space chars remaining
+		if (pos < strlen(buf)) {
+			return false;
+		}
+	} else {
+		// in non-strict mode, check for any direct trailing digits
+		if (std::isdigit((unsigned char)buf[pos])) {
+			return false;
+		}
 	}
 
 	result = Date::FromDate(yearneg ? -year : year, month, day);

--- a/src/common/types/date.cpp
+++ b/src/common/types/date.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 
+#include <cstring>
 #include <cctype>
 #include <iomanip>
 #include <iostream>

--- a/src/common/types/time.cpp
+++ b/src/common/types/time.cpp
@@ -112,12 +112,14 @@ static bool TryConvertTime(const char *buf, dtime_t &result, bool strict = false
 		}
 	}
 
+	// in strict mode, check remaining string for non-space characters
 	if (strict) {
 		// skip trailing spaces
 		while (std::isspace((unsigned char)buf[pos])) {
 			pos++;
 		}
-		if (std::isdigit((unsigned char)buf[pos])) {
+		// check position. if end was not reached, non-space chars remaining
+		if (pos < strlen(buf)) {
 			return false;
 		}
 	}

--- a/src/include/duckdb/common/operator/cast_operators.hpp
+++ b/src/include/duckdb/common/operator/cast_operators.hpp
@@ -112,6 +112,7 @@ template <> int64_t StrictCast::Operation(string_t input);
 template <> float StrictCast::Operation(string_t input);
 template <> double StrictCast::Operation(string_t input);
 template <> string StrictCast::Operation(string_t input);
+
 //===--------------------------------------------------------------------===//
 // Numeric -> String Casts
 //===--------------------------------------------------------------------===//
@@ -154,6 +155,12 @@ struct CastToDate {
 	}
 };
 
+struct StrictCastToDate {
+	template <class SRC, class DST> static inline DST Operation(SRC input) {
+		throw duckdb::NotImplementedException("Cast to date could not be performed!");
+	}
+};
+
 struct CastDateToTimestamp {
 	template <class SRC, class DST> static inline DST Operation(SRC input) {
 		throw duckdb::NotImplementedException("Cast to timestamp could not be performed!");
@@ -161,6 +168,7 @@ struct CastDateToTimestamp {
 };
 template <> duckdb::string_t CastFromDate::Operation(duckdb::date_t input, Vector &result);
 template <> duckdb::date_t CastToDate::Operation(string_t input);
+template <> duckdb::date_t StrictCastToDate::Operation(string_t input);
 template <> duckdb::timestamp_t CastDateToTimestamp::Operation(duckdb::date_t input);
 
 struct CastFromTime {
@@ -173,8 +181,14 @@ struct CastToTime {
 		throw duckdb::NotImplementedException("Cast to time could not be performed!");
 	}
 };
+struct StrictCastToTime {
+	template <class SRC, class DST> static inline DST Operation(SRC input) {
+		throw duckdb::NotImplementedException("Cast to time could not be performed!");
+	}
+};
 template <> duckdb::string_t CastFromTime::Operation(duckdb::dtime_t input, Vector &result);
 template <> duckdb::dtime_t CastToTime::Operation(string_t input);
+template <> duckdb::dtime_t StrictCastToTime::Operation(string_t input);
 
 struct CastToTimestamp {
 	template <class SRC, class DST> static inline DST Operation(SRC input) {

--- a/src/include/duckdb/common/types/date.hpp
+++ b/src/include/duckdb/common/types/date.hpp
@@ -17,9 +17,9 @@ namespace duckdb {
 class Date {
 public:
 	//! Convert a string in the format "YYYY-MM-DD" to a date object
-	static date_t FromString(string str);
+	static date_t FromString(string str, bool strict = false);
 	//! Convert a string in the format "YYYY-MM-DD" to a date object
-	static date_t FromCString(const char *str);
+	static date_t FromCString(const char *str, bool strict = false);
 	//! Convert a date object to a string in the format "YYYY-MM-DD"
 	static string ToString(date_t date);
 

--- a/src/include/duckdb/common/types/time.hpp
+++ b/src/include/duckdb/common/types/time.hpp
@@ -17,8 +17,8 @@ namespace duckdb {
 class Time {
 public:
 	//! Convert a string in the format "hh:mm:ss" to a time object
-	static dtime_t FromString(string str);
-	static dtime_t FromCString(const char *buf);
+	static dtime_t FromString(string str, bool strict = false);
+	static dtime_t FromCString(const char *buf, bool strict = false);
 
 	//! Convert a time object to a string in the format "hh:mm:ss"
 	static string ToString(dtime_t time);

--- a/test/sql/copy/test_csv_auto.cpp
+++ b/test/sql/copy/test_csv_auto.cpp
@@ -659,7 +659,7 @@ TEST_CASE("Test csv header completion", "[copy]") {
 	REQUIRE_NO_FAIL(con.Query("DROP TABLE test;"));
 }
 
-TEST_CASE("Test csv type detection with sampling", "[copy]") {
+TEST_CASE("Test csv type detection", "[copy]") {
 	FileSystem fs;
 	unique_ptr<QueryResult> result;
 	DuckDB db(nullptr);
@@ -700,6 +700,27 @@ TEST_CASE("Test csv type detection with sampling", "[copy]") {
 	REQUIRE(CHECK_COLUMN(result, 0, {27001, 27002, 27003}));
 	REQUIRE(CHECK_COLUMN(result, 1, {"1", "2", "3"}));
 	REQUIRE(CHECK_COLUMN(result, 2, {1.0, 2.0, 3.5}));
+	REQUIRE_NO_FAIL(con.Query("DROP TABLE test;"));
+
+	// generate a CSV file containing time, date and timestamp columns
+	ofstream csv_file2(fs.JoinPath(csv_path, "test.csv"));
+	csv_file2 << "a,b,t,d,ts" << endl;
+	csv_file2 << "123,TEST2,12:12:12,2000-01-01,2000-01-01 12:12:00" << endl;
+	csv_file2 << "345,TEST2,14:15:30,2002-02-02,2002-02-02 14:15:00" << endl;
+	csv_file2 << "346,TEST2,15:16:17,2004-12-13,2004-12-13 15:16:00" << endl;
+	csv_file2.close();
+
+	REQUIRE_NO_FAIL(
+	    con.Query("CREATE TABLE test AS SELECT * FROM read_csv_auto ('" + fs.JoinPath(csv_path, "test.csv") + "');"));
+	result = con.Query("SELECT a, b, t, d, ts FROM test ORDER BY a;");
+	REQUIRE(CHECK_COLUMN(result, 0, {123, 345, 346}));
+	REQUIRE(CHECK_COLUMN(result, 1, {"TEST2", "TEST2", "TEST2"}));
+	REQUIRE(
+	    CHECK_COLUMN(result, 2, {Value::TIME(12, 12, 12, 0), Value::TIME(14, 15, 30, 0), Value::TIME(15, 16, 17, 0)}));
+	REQUIRE(CHECK_COLUMN(result, 3, {Value::DATE(2000, 01, 01), Value::DATE(2002, 02, 02), Value::DATE(2004, 12, 13)}));
+	REQUIRE(CHECK_COLUMN(result, 4,
+	                     {Value::TIMESTAMP(2000, 01, 01, 12, 12, 0, 0), Value::TIMESTAMP(2002, 02, 02, 14, 15, 0, 0),
+	                      Value::TIMESTAMP(2004, 12, 13, 15, 16, 0, 0)}));
 	REQUIRE_NO_FAIL(con.Query("DROP TABLE test;"));
 }
 


### PR DESCRIPTION
Small improvements for the date and time parsing component (to support strict casts). Now, when using the strict cast, additional trailing numerics within the date/time field are not accepted anymore. The strict cast was added to solve ambiguities in CSV data type detection.