### PR TITLE
add `EPOCH_MS` function and test cases

### DIFF
--- a/src/function/scalar/date/CMakeLists.txt
+++ b/src/function/scalar/date/CMakeLists.txt
@@ -1,5 +1,11 @@
-add_library_unity(duckdb_func_date OBJECT age.cpp current.cpp date_trunc.cpp
-                  date_part.cpp)
+add_library_unity(
+  duckdb_func_date
+  OBJECT
+  age.cpp
+  current.cpp
+  epoch.cpp
+  date_trunc.cpp
+  date_part.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_date>
     PARENT_SCOPE)

--- a/src/function/scalar/date/epoch.cpp
+++ b/src/function/scalar/date/epoch.cpp
@@ -1,0 +1,41 @@
+#include "duckdb/function/scalar/date_functions.hpp"
+#include "duckdb/common/types/time.hpp"
+#include "duckdb/common/types/date.hpp"
+#include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
+#include "duckdb/common/vector_operations/unary_executor.hpp"
+
+using namespace std;
+
+namespace duckdb {
+
+static void epoch_function(DataChunk &input, ExpressionState &state, Vector &result) {
+	assert(input.column_count() == 1);
+
+	string output_buffer;
+	UnaryExecutor::Execute<int64_t, timestamp_t, true>(input.data[0], result, input.size(), [&](int64_t input) {
+		auto ms_per_day = (int64_t)60 * 60 * 24 * 1000;
+		auto date = Date::EpochToDate(input / 1000);
+		auto time = (dtime_t)(std::abs(input) % ms_per_day);
+		if (input < 0) { // for dates before 1970 time goes backwards
+			time = ms_per_day - time;
+			if (time > 0) {
+				// date needs to go one back if time is non-zero
+				date -= 1;
+			}
+			if (time == ms_per_day) {
+				time = 0;
+				date += 1;
+			}
+		}
+		return Timestamp::FromDatetime(date, time);
+	});
+}
+
+void EpochFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet epoch("epoch_ms");
+	epoch.AddFunction(ScalarFunction({SQLType::BIGINT}, SQLType::TIMESTAMP, epoch_function));
+	set.AddFunction(epoch);
+}
+
+} // namespace duckdb

--- a/src/function/scalar/date_functions.cpp
+++ b/src/function/scalar/date_functions.cpp
@@ -10,4 +10,5 @@ void BuiltinFunctions::RegisterDateFunctions() {
 	Register<CurrentTimeFun>();
 	Register<CurrentDateFun>();
 	Register<CurrentTimestampFun>();
+	Register<EpochFun>();
 }

--- a/src/include/duckdb/function/scalar/date_functions.hpp
+++ b/src/include/duckdb/function/scalar/date_functions.hpp
@@ -37,4 +37,8 @@ struct CurrentTimestampFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct EpochFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 } // namespace duckdb

--- a/test/sql/date/test_timestamp.cpp
+++ b/test/sql/date/test_timestamp.cpp
@@ -283,3 +283,20 @@ TEST_CASE("Test more timestamp functions", "[timestamp]") {
 	auto ts2 = Timestamp::FromString(ds->GetValue(3, 0).str_value);
 	REQUIRE(ts2 > 0);
 }
+
+TEST_CASE("Test epoch_ms function", "[timestamp]") {
+	unique_ptr<QueryResult> result;
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	result = con.Query(
+	    "SELECT epoch_ms(0) as epoch1, epoch_ms(1574802684123) as epoch2, epoch_ms(-291044928000) as epoch3, "
+	    "epoch_ms(-291081600000) as epoch4,  epoch_ms(-291081600001) as epoch5, epoch_ms(-290995201000) as epoch6");
+
+	REQUIRE(CHECK_COLUMN(result, 0, {Value::BIGINT(Timestamp::FromString("1970-01-01 00:00:00.000"))}));
+	REQUIRE(CHECK_COLUMN(result, 1, {Value::BIGINT(Timestamp::FromString("2019-11-26 21:11:24.123"))}));
+	REQUIRE(CHECK_COLUMN(result, 2, {Value::BIGINT(Timestamp::FromString("1960-10-11 10:11:12.000"))}));
+	REQUIRE(CHECK_COLUMN(result, 3, {Value::BIGINT(Timestamp::FromString("1960-10-11 00:00:00"))}));
+	REQUIRE(CHECK_COLUMN(result, 4, {Value::BIGINT(Timestamp::FromString("1960-10-10 23:59:59.999"))}));
+	REQUIRE(CHECK_COLUMN(result, 5, {Value::BIGINT(Timestamp::FromString("1960-10-11 23:59:59"))}));
+}


### PR DESCRIPTION
This function converts a an unix timestamp (in milliseconds since the epoch) to a duckdb-internal timestamp type