### PR TITLE
Adding Parquet and ICU support to shell

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,18 @@ function(disable_target_warnings NAME)
   endif()
 endfunction()
 
+
+option(BUILD_ICU_EXTENSION "Build the ICU extension." FALSE)
+if(${BUILD_ICU_EXTENSION})
+	add_definitions( -DBUILD_ICU_EXTENSION=${BUILD_ICU_EXTENSION} )
+endif()
+
+option(BUILD_PARQUET_EXTENSION "Build the Parquet extension." FALSE)
+if(${BUILD_PARQUET_EXTENSION})
+	add_definitions( -DBUILD_PARQUET_EXTENSION=${BUILD_PARQUET_EXTENSION} )
+endif()
+
+
 add_subdirectory(extension)
 add_subdirectory(src)
 add_subdirectory(third_party)

--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -1,10 +1,6 @@
-option(BUILD_ICU_EXTENSION "Build the ICU extension." FALSE)
-
 if(${BUILD_ICU_EXTENSION})
   add_subdirectory(icu)
 endif()
-
-option(BUILD_PARQUET_EXTENSION "Build the Parquet extension." FALSE)
 
 if(${BUILD_PARQUET_EXTENSION})
   add_subdirectory(parquet)

--- a/extension/parquet/parquet-extension.cpp
+++ b/extension/parquet/parquet-extension.cpp
@@ -874,5 +874,8 @@ void ParquetExtension::Load(DuckDB &db) {
 	Connection conn(db);
 	conn.context->transaction.BeginTransaction();
 	conn.context->catalog.CreateTableFunction(*conn.context, &info);
+	info.name = "read_parquet"; // ok we will have this alias
+	conn.context->catalog.CreateTableFunction(*conn.context, &info);
+
 	conn.context->transaction.Commit();
 }

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -80,6 +80,7 @@ void CommitState::WriteCatalogEntry(CatalogEntry *entry, data_ptr_t dataptr) {
 	case CatalogType::AGGREGATE_FUNCTION:
 	case CatalogType::SCALAR_FUNCTION:
 	case CatalogType::TABLE_FUNCTION:
+	case CatalogType::COLLATION:
 
 		// do nothing, we log the query to recreate this
 		break;

--- a/tools/shell/CMakeLists.txt
+++ b/tools/shell/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(shell sqlite3_api_wrapper_static)
 if(NOT AMALGAMATION_BUILD AND NOT WIN32)
   target_link_libraries(shell utf8proc)
 endif()
+
 set_target_properties(shell PROPERTIES OUTPUT_NAME duckdb)
 set_target_properties(shell
                       PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tools/sqlite3_api_wrapper/CMakeLists.txt
+++ b/tools/sqlite3_api_wrapper/CMakeLists.txt
@@ -14,6 +14,12 @@ if(${BUILD_PARQUET_EXTENSION})
     target_link_libraries(sqlite3_api_wrapper_static parquet_extension)
 endif()
 
+if(${BUILD_ICU_EXTENSION})
+	include_directories(../../extension/icu/include)
+    target_link_libraries(sqlite3_api_wrapper icu_extension)
+    target_link_libraries(sqlite3_api_wrapper_static icu_extension)
+endif()
+
 include_directories(../../third_party/catch)
 
 add_executable(test_sqlite3_api_wrapper test_sqlite3_api_wrapper.cpp)

--- a/tools/sqlite3_api_wrapper/CMakeLists.txt
+++ b/tools/sqlite3_api_wrapper/CMakeLists.txt
@@ -8,6 +8,11 @@ target_link_libraries(sqlite3_api_wrapper duckdb)
 add_library(sqlite3_api_wrapper_static STATIC sqlite3_api_wrapper.cpp printf.c)
 target_link_libraries(sqlite3_api_wrapper_static duckdb_static)
 
+if(${BUILD_PARQUET_EXTENSION})
+	include_directories(../../extension/parquet/include)
+    target_link_libraries(sqlite3_api_wrapper parquet_extension)
+    target_link_libraries(sqlite3_api_wrapper_static parquet_extension)
+endif()
 
 include_directories(../../third_party/catch)
 
@@ -16,6 +21,8 @@ target_link_libraries(test_sqlite3_api_wrapper
                       sqlite3_api_wrapper
                       duckdb
                       Threads::Threads)
+                      
+
 
 # For testing only: compile a version of test_sqlite3_api_wrapper that is bound
 # to SQLite: this should have the same behavior as binding to DuckDB

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -68,6 +68,10 @@ int sqlite3_open(const char *filename, /* Database filename (UTF-8) */
 	return sqlite3_open_v2(filename, ppDb, 0, NULL);
 }
 
+#ifdef BUILD_ICU_EXTENSION
+#include "icu-extension.hpp"
+#endif
+
 #ifdef BUILD_PARQUET_EXTENSION
 #include "parquet-extension.hpp"
 #endif
@@ -95,6 +99,9 @@ int sqlite3_open_v2(const char *filename, /* Database filename (UTF-8) */
 			pDb->db = make_unique<DuckDB>(filename, &config);
 			pDb->con = make_unique<Connection>(*pDb->db);
 
+#ifdef BUILD_ICU_EXTENSION
+			pDb->db->LoadExtension<ICUExtension>();
+#endif
 #ifdef BUILD_PARQUET_EXTENSION
 			pDb->db->LoadExtension<ParquetExtension>();
 #endif

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -68,6 +68,10 @@ int sqlite3_open(const char *filename, /* Database filename (UTF-8) */
 	return sqlite3_open_v2(filename, ppDb, 0, NULL);
 }
 
+#ifdef BUILD_PARQUET_EXTENSION
+#include "parquet-extension.hpp"
+#endif
+
 int sqlite3_open_v2(const char *filename, /* Database filename (UTF-8) */
                     sqlite3 **ppDb,       /* OUT: SQLite db handle */
                     int flags,            /* Flags */
@@ -90,6 +94,10 @@ int sqlite3_open_v2(const char *filename, /* Database filename (UTF-8) */
 			}
 			pDb->db = make_unique<DuckDB>(filename, &config);
 			pDb->con = make_unique<Connection>(*pDb->db);
+
+#ifdef BUILD_PARQUET_EXTENSION
+			pDb->db->LoadExtension<ParquetExtension>();
+#endif
 		} catch (std::exception &ex) {
 			if (pDb) {
 				pDb->last_error = ex.what();


### PR DESCRIPTION
When configuring DuckDB with ` -DBUILD_PARQUET_EXTENSION=1` and/or  `-DBUILD_ICU_EXTENSION=1` the Parquet and ICU libraries are linked into the sqlite3 api wrapper and into the command line interface `duckdb`. This is the default for travis binary builds, too.