### PR TITLE
Case insensitive binding of column names

### DIFF
--- a/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
@@ -58,6 +58,9 @@ public:
 	//! Returns a list of types of the specified columns of the table
 	vector<TypeId> GetTypes(const vector<column_t> &column_ids);
 
+	//! Add lower case aliases to a name map (e.g. "Hello" -> "hello" is also acceptable)
+	static void AddLowerCaseAliases(unordered_map<string, column_t> &name_map);
+
 	//! Serialize the meta information of the TableCatalogEntry a serializer
 	virtual void Serialize(Serializer &serializer);
 	//! Deserializes to a CreateTableInfo

--- a/src/include/duckdb/planner/table_binding.hpp
+++ b/src/include/duckdb/planner/table_binding.hpp
@@ -65,7 +65,7 @@ struct GenericBinding : public Binding {
 	//! Column names of the subquery
 	vector<string> names;
 	//! Name -> index for the names
-	unordered_map<string, uint64_t> name_map;
+	unordered_map<string, column_t> name_map;
 
 public:
 	bool HasMatchingBinding(const string &column_name) override;

--- a/src/planner/table_binding.cpp
+++ b/src/planner/table_binding.cpp
@@ -81,6 +81,7 @@ GenericBinding::GenericBinding(const string &alias, vector<SQLType> coltypes, ve
 		}
 		name_map[name] = i;
 	}
+	TableCatalogEntry::AddLowerCaseAliases(name_map);
 }
 
 bool GenericBinding::HasMatchingBinding(const string &column_name) {

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(aggregate)
 add_subdirectory(append)
 add_subdirectory(blob)
+add_subdirectory(binder)
 add_subdirectory(catalog)
 add_subdirectory(collate)
 add_subdirectory(create)

--- a/test/sql/binder/CMakeLists.txt
+++ b/test/sql/binder/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library_unity(test_sql_binder OBJECT test_case_insensitive_binding.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:test_sql_binder>
+    PARENT_SCOPE)

--- a/test/sql/binder/test_case_insensitive_binding.cpp
+++ b/test/sql/binder/test_case_insensitive_binding.cpp
@@ -1,0 +1,79 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb;
+using namespace std;
+
+TEST_CASE("Test case insensitive binding of columns", "[binder]") {
+	unique_ptr<QueryResult> result;
+	DuckDB db(nullptr);
+	Connection con(db);
+	con.EnableQueryVerification();
+
+	// we can bind case insensitive column names
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE test (\"HeLlO\" INTEGER)"));
+
+	// lowercase names are aliased
+	REQUIRE_NO_FAIL(con.Query("SELECT HeLlO FROM test"));
+	REQUIRE_NO_FAIL(con.Query("SELECT hello FROM test"));
+	REQUIRE_NO_FAIL(con.Query("SELECT \"HeLlO\" FROM test"));
+	// specifying a different, non-lower, case does fail!
+	REQUIRE_FAIL(con.Query("SELECT \"HELLO\" FROM test"));
+	REQUIRE_FAIL(con.Query("SELECT \"HELLo\" FROM test"));
+
+	REQUIRE_NO_FAIL(con.Query("SELECT test.HeLlO FROM test"));
+	REQUIRE_NO_FAIL(con.Query("SELECT test.hello FROM test"));
+	REQUIRE_NO_FAIL(con.Query("SELECT test.\"HeLlO\" FROM test"));
+	REQUIRE_FAIL(con.Query("SELECT test.\"HELLO\" FROM test"));
+	REQUIRE_FAIL(con.Query("SELECT test.\"HELLo\" FROM test"));
+
+	REQUIRE_NO_FAIL(con.Query("UPDATE test SET hello=3"));
+	REQUIRE_NO_FAIL(con.Query("UPDATE test SET HeLlO=3"));
+
+	// but ONLY if there are no conflicts!
+	// if the reference is ambiguous (e.g. hello -> HeLlO, HELLO) the name must match exactly
+	REQUIRE_NO_FAIL(con.Query("DROP TABLE test"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE test(\"HeLlO\" INTEGER, \"HELLO\" INTEGER)"));
+
+	REQUIRE_FAIL(con.Query("SELECT HeLlO FROM test"));
+	REQUIRE_FAIL(con.Query("SELECT hello FROM test"));
+	REQUIRE_NO_FAIL(con.Query("SELECT \"HeLlO\" FROM test"));
+	REQUIRE_NO_FAIL(con.Query("SELECT \"HELLO\" FROM test"));
+	REQUIRE_FAIL(con.Query("SELECT \"HELLo\" FROM test"));
+	REQUIRE_FAIL(con.Query("UPDATE test SET hello = 3"));
+	REQUIRE_NO_FAIL(con.Query("UPDATE test SET \"HeLlO\" = 3"));
+	REQUIRE_NO_FAIL(con.Query("UPDATE test SET \"HELLO\" = 3"));
+
+	REQUIRE_FAIL(con.Query("SELECT test.HeLlO FROM test"));
+	REQUIRE_FAIL(con.Query("SELECT test.hello FROM test"));
+	REQUIRE_NO_FAIL(con.Query("SELECT test.\"HeLlO\" FROM test"));
+	REQUIRE_NO_FAIL(con.Query("SELECT test.\"HELLO\" FROM test"));
+	REQUIRE_FAIL(con.Query("SELECT test.\"HELLo\" FROM test"));
+
+	// conflicts can also come from different sources!
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE test1(\"HeLlO\" INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE test2(\"HELLO\" INTEGER)"));
+
+	REQUIRE_FAIL(con.Query("SELECT HeLlO FROM test1, test2"));
+	REQUIRE_FAIL(con.Query("SELECT hello FROM test1, test2"));
+	REQUIRE_NO_FAIL(con.Query("SELECT \"HeLlO\" FROM test1, test2"));
+	REQUIRE_NO_FAIL(con.Query("SELECT \"HELLO\" FROM test1, test2"));
+	REQUIRE_FAIL(con.Query("SELECT \"HELLo\" FROM test1, test2"));
+
+	// in this case we can eliminate the conflict by specifically selecting the source
+	REQUIRE_NO_FAIL(con.Query("SELECT test1.HeLlO FROM test1, test2"));
+	REQUIRE_NO_FAIL(con.Query("SELECT test1.hello FROM test1, test2"));
+	REQUIRE_NO_FAIL(con.Query("SELECT test1.\"HeLlO\" FROM test1, test2"));
+	REQUIRE_FAIL(con.Query("SELECT test1.\"HELLO\" FROM test1, test2"));
+	REQUIRE_FAIL(con.Query("SELECT test1.\"HELLo\" FROM test1, test2"));
+
+	REQUIRE_NO_FAIL(con.Query("SELECT test2.HeLlO FROM test1, test2"));
+	REQUIRE_NO_FAIL(con.Query("SELECT test2.hello FROM test1, test2"));
+	REQUIRE_FAIL(con.Query("SELECT test2.\"HeLlO\" FROM test1, test2"));
+	REQUIRE_NO_FAIL(con.Query("SELECT test2.\"HELLO\" FROM test1, test2"));
+	REQUIRE_FAIL(con.Query("SELECT test2.\"HELLo\" FROM test1, test2"));
+
+	REQUIRE_NO_FAIL(con.Query("SELECT * FROM test1 JOIN test2 USING (hello)"));
+
+	REQUIRE_NO_FAIL(con.Query("SELECT hello FROM (SELECT 42) tbl(\"HeLlO\")"));
+}


### PR DESCRIPTION
This PR adds support for case insensitive binding of column names, even when they are specifically constructed to have a case. The case insensitive binding only works if there are no conflicts, e.g. if a table has both the columns "Hello" and "HELLO", there is a conflict when trying to bind "hello", and as such the exact name must be specified. However, if the table only has the column "Hello", then "hello" has no conflict and will bind to it just fine.

This is a quality-of-life change that makes it easier to use column names with different casings, as previously any non-lowercase name had to be quoted to be used in SQL, i.e. `SELECT Hello FROM table` does not match the column "Hello". This now works, simplifying life somewhat. It also fixes the problems caused by #673.