### PR TITLE
Skip running the SQLancer tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -370,7 +370,7 @@ matrix:
         - (cd build/release && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DJDBC_DRIVER=1 -DBUILD_UNITTESTS=FALSE ../.. && cmake --build .)
         - java -cp build/release/tools/jdbc/duckdb_jdbc.jar org.duckdb.test.TestDuckDBJDBC
         - git clone https://github.com/sqlancer/sqlancer.git
-        - (cd sqlancer && mvn package)
+        - (cd sqlancer && mvn package -DskipTests)
         - cp build/release/tools/jdbc/duckdb_jdbc.jar sqlancer/target/lib/duckdb_jdbc-*.jar
         - java -jar sqlancer/target/SQLancer-*.jar --num-queries 1000 --num-threads 1 --random-seed 0 --timeout-seconds 600 duckdb
 


### PR DESCRIPTION
This saves some time by not running the SQLancer test suite while SQLancer is being built.