### PR TITLE
Disable shallow cloning in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ env:
     - TWINE_USERNAME=hfmuehleisen
     - SETUPTOOLS_SCM_DEBUG=please
 
+git:
+  depth: false
+
 matrix:
   include:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
     - CIBW_TEST_COMMAND='python -m pytest {project}/tests'
     - SETUPTOOLS_SCM_NO_LOCAL=yes
     - TWINE_USERNAME=hfmuehleisen
+    - SETUPTOOLS_SCM_DEBUG=please
 
 matrix:
   include:


### PR DESCRIPTION
To fix an issue with `setuptools_scm`