### PR TITLE
References to stdout, stderr & cout

### DIFF
--- a/src/common/printer.cpp
+++ b/src/common/printer.cpp
@@ -5,5 +5,7 @@
 using namespace duckdb;
 
 void Printer::Print(string str) {
+#ifndef DUCKDB_DISABLE_PRINT
 	fprintf(stderr, "%s\n", str.c_str());
+#endif
 }

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/execution/operator/join/physical_delim_join.hpp"
 #include "duckdb/execution/operator/helper/physical_execute.hpp"
 #include "duckdb/parser/sql_statement.hpp"
+#include "duckdb/common/printer.hpp"
 
 #include <iostream>
 #include <utility>
@@ -51,7 +52,8 @@ void QueryProfiler::EndQuery() {
 		}
 
 		if (save_location.empty()) {
-			cout << query_info << "\n";
+			Printer::Print(query_info);
+			Printer::Print("\n");
 		} else {
 			WriteToFile(save_location.c_str(), query_info);
 		}

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/main/query_result.hpp"
+#include "duckdb/common/printer.hpp"
 
 using namespace duckdb;
 using namespace std;
@@ -57,7 +58,7 @@ bool QueryResult::Equals(QueryResult &other) {
 }
 
 void QueryResult::Print() {
-	fprintf(stderr, "%s\n", ToString().c_str());
+	Printer::Print(ToString());
 }
 
 string QueryResult::HeaderToString() {

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -13,6 +13,8 @@
 #include "duckdb/parser/parsed_data/create_view_info.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
+#include "duckdb/common/printer.hpp"
+#include "duckdb/common/string_util.hpp"
 
 using namespace duckdb;
 using namespace std;
@@ -92,7 +94,7 @@ void WriteAheadLog::Replay(DuckDB &database, string &path) {
 		}
 	} catch (std::exception &ex) {
 		// FIXME: this report a proper warning in the connection
-		fprintf(stderr, "Exception in WAL playback: %s\n", ex.what());
+		Printer::Print(StringUtil::Format("Exception in WAL playback: %s\n", ex.what()));
 		// exception thrown in WAL replay: rollback
 		context.transaction.Rollback();
 	}

--- a/third_party/fmt/include/fmt/format-inl.h
+++ b/third_party/fmt/include/fmt/format-inl.h
@@ -154,9 +154,11 @@ FMT_FUNC void report_error(format_func func, int error_code,
                            string_view message) FMT_NOEXCEPT {
   memory_buffer full_message;
   func(full_message, error_code, message);
+  /*// R does not allow us to have a reference to stderr even if we are not using it
   // Don't use fwrite_fully because the latter may throw.
   (void)std::fwrite(full_message.data(), full_message.size(), 1, stderr);
   std::fputc('\n', stderr);
+  */
 }
 }  // namespace internal
 

--- a/third_party/libpg_query/src_backend_parser_scan.cpp
+++ b/third_party/libpg_query/src_backend_parser_scan.cpp
@@ -9072,11 +9072,13 @@ YY_DECL
 		if ( ! yyg->yy_start )
 			yyg->yy_start = 1;	/* first start state */
 
+		/*// R does not allow us to have a reference to stdout even if we are not using it
 		if ( ! yyin )
 			yyin = stdin;
 
 		if ( ! yyout )
 			yyout = stdout;
+		 */
 
 		if ( ! YY_CURRENT_BUFFER ) {
 			core_yyensure_buffer_stack (yyscanner);

--- a/third_party/re2/util/logging.h
+++ b/third_party/re2/util/logging.h
@@ -62,9 +62,11 @@ class LogMessage {
   }
   void Flush() {
     stream() << "\n";
+	/*// R does not allow us to have a reference to stderr even if we are not using it
     std::string s = str_.str();
     size_t n = s.size();
     if (fwrite(s.data(), 1, n, stderr) < n) {}  // shut up gcc
+    */
     flushed_ = true;
   }
   ~LogMessage() {

--- a/tools/rpkg/src/Makevars
+++ b/tools/rpkg/src/Makevars
@@ -1,2 +1,2 @@
-PKG_CXXFLAGS = -I.
+PKG_CXXFLAGS = -I. -DDUCKDB_DISABLE_PRINT
 OBJECTS=duckdbr.o parquet-extension.o duckdb.o


### PR DESCRIPTION
CRAN does not allow references to `stdout`, `stderr` & `cout`. Cleaned up some places where they were still referenced and added a define `DUCKDB_DISABLE_PRINT` that removes the reference from `Printer::Print()`