### PR TITLE
Extended Regex Options

### DIFF
--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -8,15 +8,15 @@
 #include "duckdb/common/vector_operations/ternary_executor.hpp"
 #include "utf8proc_wrapper.hpp"
 
-#include "re2/re2.h"
+#include "duckdb/function/scalar/regexp.hpp"
 
 using namespace std;
 
 namespace duckdb {
 
-RegexpMatchesBindData::RegexpMatchesBindData(unique_ptr<RE2> constant_pattern, string range_min, string range_max,
+RegexpMatchesBindData::RegexpMatchesBindData(re2::RE2::Options options, unique_ptr<re2::RE2> constant_pattern, string range_min, string range_max,
                                              bool range_success)
-    : constant_pattern(std::move(constant_pattern)), range_min(range_min), range_max(range_max),
+    : options(move(options)), constant_pattern(std::move(constant_pattern)), range_min(range_min), range_max(range_max),
       range_success(range_success) {
 }
 
@@ -24,22 +24,62 @@ RegexpMatchesBindData::~RegexpMatchesBindData() {
 }
 
 unique_ptr<FunctionData> RegexpMatchesBindData::Copy() {
-	return make_unique<RegexpMatchesBindData>(move(constant_pattern), range_min, range_max, range_success);
+	return make_unique<RegexpMatchesBindData>(options, move(constant_pattern), range_min, range_max, range_success);
 }
 
 static inline re2::StringPiece CreateStringPiece(string_t &input) {
 	return re2::StringPiece(input.GetData(), input.GetSize());
 }
 
+static void ParseRegexOptions(string &options, re2::RE2::Options &result, bool *global_replace = nullptr) {
+	for(idx_t i = 0; i < options.size(); i++) {
+		switch(options[i]) {
+		case 'c':
+			// case-sensitive matching
+			result.set_case_sensitive(true);
+			break;
+		case 'i':
+			// case-insensitive matching
+			result.set_case_sensitive(false);
+			break;
+		case 'm':
+		case 'n':
+		case 'p':
+			// newline-sensitive matching
+			result.set_dot_nl(false);
+			break;
+		case 's':
+			// non-newline-sensitive matching
+			result.set_dot_nl(true);
+			break;
+		case 'g':
+			// global replace, only available for regexp_replace
+			if (global_replace) {
+				*global_replace = true;
+			} else {
+				throw InvalidInputException("Option 'g' (global replace) is only valid for regexp_replace");
+			}
+			break;
+		case ' ':
+		case '\t':
+		case '\n':
+			// ignore whitespace
+			break;
+		default:
+			throw InvalidInputException("Unrecognized Regex option %c", options[i]);
+		}
+	}
+}
+
 struct RegexPartialMatch {
-	static inline bool Operation(const re2::StringPiece &input, RE2 &re) {
-		return RE2::PartialMatch(input, re);
+	static inline bool Operation(const re2::StringPiece &input, re2::RE2 &re) {
+		return re2::RE2::PartialMatch(input, re);
 	}
 };
 
 struct RegexFullMatch {
-	static inline bool Operation(const re2::StringPiece &input, RE2 &re) {
-		return RE2::FullMatch(input, re);
+	static inline bool Operation(const re2::StringPiece &input, re2::RE2 &re) {
+		return re2::RE2::FullMatch(input, re);
 	}
 };
 
@@ -50,18 +90,14 @@ template <class OP> static void regexp_matches_function(DataChunk &args, Express
 	auto &func_expr = (BoundFunctionExpression &)state.expr;
 	auto &info = (RegexpMatchesBindData &)*func_expr.bind_info;
 
-	RE2::Options options;
-	options.set_log_errors(false);
-
 	if (info.constant_pattern) {
-		// FIXME: this should be a unary loop
 		UnaryExecutor::Execute<string_t, bool, true>(strings, result, args.size(), [&](string_t input) {
 			return OP::Operation(CreateStringPiece(input), *info.constant_pattern);
 		});
 	} else {
 		BinaryExecutor::Execute<string_t, string_t, bool, true>(strings, patterns, result, args.size(),
 		                                                        [&](string_t input, string_t pattern) {
-			                                                        RE2 re(CreateStringPiece(pattern), options);
+			                                                        RE2 re(CreateStringPiece(pattern), info.options);
 			                                                        if (!re.ok()) {
 				                                                        throw Exception(re.error());
 			                                                        }
@@ -73,12 +109,22 @@ template <class OP> static void regexp_matches_function(DataChunk &args, Express
 static unique_ptr<FunctionData> regexp_matches_get_bind_function(BoundFunctionExpression &expr,
                                                                  ClientContext &context) {
 	// pattern is the second argument. If its constant, we can already prepare the pattern and store it for later.
-	assert(expr.children.size() == 2);
+	assert(expr.children.size() == 2 || expr.children.size() == 3);
+	RE2::Options options;
+	options.set_log_errors(false);
+	if (expr.children.size() == 3) {
+		if (!expr.children[2]->IsScalar()) {
+			throw InvalidInputException("Regex options field must be a constant");
+		}
+		Value options_str = ExpressionExecutor::EvaluateScalar(*expr.children[2]);
+		if (!options_str.is_null && options_str.type == TypeId::VARCHAR) {
+			ParseRegexOptions(options_str.str_value, options);
+		}
+	}
+
 	if (expr.children[1]->IsScalar()) {
 		Value pattern_str = ExpressionExecutor::EvaluateScalar(*expr.children[1]);
 		if (!pattern_str.is_null && pattern_str.type == TypeId::VARCHAR) {
-			RE2::Options options;
-			options.set_log_errors(false);
 			auto re = make_unique<RE2>(pattern_str.str_value, options);
 			if (!re->ok()) {
 				throw Exception(re->error());
@@ -86,37 +132,80 @@ static unique_ptr<FunctionData> regexp_matches_get_bind_function(BoundFunctionEx
 
 			string range_min, range_max;
 			auto range_success = re->PossibleMatchRange(&range_min, &range_max, 1000);
-			return make_unique<RegexpMatchesBindData>(move(re), range_min, range_max, range_success);
+			return make_unique<RegexpMatchesBindData>(move(options), move(re), range_min, range_max, range_success);
 		}
 	}
-	return make_unique<RegexpMatchesBindData>(nullptr, "", "", false);
+	return make_unique<RegexpMatchesBindData>(move(options), nullptr, "", "", false);
 }
 
 static void regexp_replace_function(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (RegexpReplaceBindData &)*func_expr.bind_info;
+
 	auto &strings = args.data[0];
 	auto &patterns = args.data[1];
 	auto &replaces = args.data[2];
 
-	RE2::Options options;
-	options.set_log_errors(false);
-
 	TernaryExecutor::Execute<string_t, string_t, string_t, string_t>(
 	    strings, patterns, replaces, result, args.size(), [&](string_t input, string_t pattern, string_t replace) {
-		    RE2 re(CreateStringPiece(pattern), options);
+		    RE2 re(CreateStringPiece(pattern), info.options);
 		    std::string sstring(input.GetData(), input.GetSize());
-		    RE2::Replace(&sstring, re, CreateStringPiece(replace));
-		    return StringVector::AddString(result, sstring);
+			if (info.global_replace) {
+				RE2::GlobalReplace(&sstring, re, CreateStringPiece(replace));
+			} else {
+				RE2::Replace(&sstring, re, CreateStringPiece(replace));
+			}
+			return StringVector::AddString(result, sstring);
 	    });
 }
 
+unique_ptr<FunctionData> RegexpReplaceBindData::Copy() {
+	auto copy = make_unique<RegexpReplaceBindData>();
+	copy->options = options;
+	copy->global_replace = global_replace;
+	return move(copy);
+}
+
+static unique_ptr<FunctionData> regexp_replace_bind_function(BoundFunctionExpression &expr, ClientContext &context) {
+	auto data = make_unique<RegexpReplaceBindData>();
+	data->options.set_log_errors(false);
+	if (expr.children.size() == 4) {
+		if (!expr.children[3]->IsScalar()) {
+			throw InvalidInputException("Regex options field must be a constant");
+		}
+		Value options_str = ExpressionExecutor::EvaluateScalar(*expr.children[3]);
+		if (!options_str.is_null && options_str.type == TypeId::VARCHAR) {
+			ParseRegexOptions(options_str.str_value, data->options, &data->global_replace);
+		}
+	}
+
+	return move(data);
+}
+
 void RegexpFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(ScalarFunction("regexp_full_match", {SQLType::VARCHAR, SQLType::VARCHAR}, SQLType::BOOLEAN,
+	ScalarFunctionSet regexp_full_match("regexp_full_match");
+	regexp_full_match.AddFunction(ScalarFunction({SQLType::VARCHAR, SQLType::VARCHAR}, SQLType::BOOLEAN,
 	                               regexp_matches_function<RegexFullMatch>, false, regexp_matches_get_bind_function));
-	set.AddFunction(ScalarFunction("regexp_matches", {SQLType::VARCHAR, SQLType::VARCHAR}, SQLType::BOOLEAN,
+	regexp_full_match.AddFunction(ScalarFunction({SQLType::VARCHAR, SQLType::VARCHAR, SQLType::VARCHAR}, SQLType::BOOLEAN,
+	                               regexp_matches_function<RegexFullMatch>, false, regexp_matches_get_bind_function));
+
+	ScalarFunctionSet regexp_partial_match("regexp_matches");
+	regexp_partial_match.AddFunction(ScalarFunction({SQLType::VARCHAR, SQLType::VARCHAR}, SQLType::BOOLEAN,
 	                               regexp_matches_function<RegexPartialMatch>, false,
 	                               regexp_matches_get_bind_function));
-	set.AddFunction(ScalarFunction("regexp_replace", {SQLType::VARCHAR, SQLType::VARCHAR, SQLType::VARCHAR},
-	                               SQLType::VARCHAR, regexp_replace_function));
+	regexp_partial_match.AddFunction(ScalarFunction({SQLType::VARCHAR, SQLType::VARCHAR, SQLType::VARCHAR}, SQLType::BOOLEAN,
+	                               regexp_matches_function<RegexPartialMatch>, false,
+	                               regexp_matches_get_bind_function));
+
+	ScalarFunctionSet regexp_replace("regexp_replace");
+	regexp_replace.AddFunction(ScalarFunction({SQLType::VARCHAR, SQLType::VARCHAR, SQLType::VARCHAR},
+	                               SQLType::VARCHAR, regexp_replace_function, false, regexp_replace_bind_function));
+	regexp_replace.AddFunction(ScalarFunction({SQLType::VARCHAR, SQLType::VARCHAR, SQLType::VARCHAR, SQLType::VARCHAR},
+	                               SQLType::VARCHAR, regexp_replace_function, false, regexp_replace_bind_function));
+
+	set.AddFunction(regexp_full_match);
+	set.AddFunction(regexp_partial_match);
+	set.AddFunction(regexp_replace);
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/function/scalar/regexp.hpp
+++ b/src/include/duckdb/function/scalar/regexp.hpp
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/function/scalar/regexp.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/function/function_set.hpp"
+#include "re2/re2.h"
+
+namespace duckdb {
+
+struct RegexpMatchesBindData : public FunctionData {
+	RegexpMatchesBindData(re2::RE2::Options options, std::unique_ptr<re2::RE2> constant_pattern, string range_min, string range_max,
+	                      bool range_success);
+	~RegexpMatchesBindData();
+
+	re2::RE2::Options options;
+	std::unique_ptr<re2::RE2> constant_pattern;
+	string range_min, range_max;
+	bool range_success;
+
+	unique_ptr<FunctionData> Copy() override;
+};
+
+struct RegexpReplaceBindData : public FunctionData {
+	re2::RE2::Options options;
+	bool global_replace;
+
+	unique_ptr<FunctionData> Copy() override;
+};
+
+}

--- a/src/include/duckdb/function/scalar/string_functions.hpp
+++ b/src/include/duckdb/function/scalar/string_functions.hpp
@@ -141,16 +141,4 @@ struct UnicodeFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
-struct RegexpMatchesBindData : public FunctionData {
-	RegexpMatchesBindData(std::unique_ptr<re2::RE2> constant_pattern, string range_min, string range_max,
-	                      bool range_success);
-	~RegexpMatchesBindData();
-
-	std::unique_ptr<re2::RE2> constant_pattern;
-	string range_min, range_max;
-	bool range_success;
-
-	unique_ptr<FunctionData> Copy() override;
-};
-
 } // namespace duckdb

--- a/src/optimizer/regex_range_filter.cpp
+++ b/src/optimizer/regex_range_filter.cpp
@@ -11,8 +11,11 @@
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
 
-using namespace duckdb;
+#include "duckdb/function/scalar/regexp.hpp"
+
 using namespace std;
+
+namespace duckdb {
 
 unique_ptr<LogicalOperator> RegexRangeFilter::Rewrite(unique_ptr<LogicalOperator> op) {
 
@@ -56,4 +59,6 @@ unique_ptr<LogicalOperator> RegexRangeFilter::Rewrite(unique_ptr<LogicalOperator
 	}
 
 	return op;
+}
+
 }


### PR DESCRIPTION
This PR implements extended regex options as described in #753.


| Flag | Behavior |
|----:|----------|
|g | replace all occurrences of match instead of only first one (regexp_replace only) |
| c | case-sensitive matching (default) |
| i | case-insensitive matching|
|m, n, p | dot does not match newline |
|s | dot matches newline (default)|

Example:
```sql
-- global replace
SELECT regexp_replace('ana ANA ana', 'ana', 'banana', 'g');
-- banana ANA banana

-- case insensitive and global replace
SELECT regexp_replace('ana ANA ana', 'ana', 'banana', 'gi');
-- banana banana banana
```