### PR TITLE
Query Profiling Fix for Shell

### DIFF
--- a/src/common/enums/logical_operator_type.cpp
+++ b/src/common/enums/logical_operator_type.cpp
@@ -84,9 +84,23 @@ string LogicalOperatorToString(LogicalOperatorType type) {
 	case LogicalOperatorType::CTE_REF:
 		return "CTE_SCAN";
 	case LogicalOperatorType::INVALID:
-	default:
 		return "INVALID";
+	case LogicalOperatorType::ALTER:
+		return "ALTER";
+	case LogicalOperatorType::CREATE_SEQUENCE:
+		return "CREATE_SEQUENCE";
+	case LogicalOperatorType::CREATE_VIEW:
+		return "CREATE_VIEW";
+	case LogicalOperatorType::CREATE_SCHEMA:
+		return "CREATE_SCHEMA";
+	case LogicalOperatorType::DROP:
+		return "DROP";
+	case LogicalOperatorType::PRAGMA:
+		return "PRAGMA";
+	case LogicalOperatorType::TRANSACTION:
+		return "TRANSACTION";
 	}
+	return "UNDEFINED";
 }
 
 } // namespace duckdb

--- a/src/common/enums/physical_operator_type.cpp
+++ b/src/common/enums/physical_operator_type.cpp
@@ -91,9 +91,27 @@ string PhysicalOperatorToString(PhysicalOperatorType type) {
 	case PhysicalOperatorType::RECURSIVE_CTE:
 		return "REC_CTE";
 	case PhysicalOperatorType::INVALID:
-	default:
 		return "INVALID";
+	case PhysicalOperatorType::EXPRESSION_SCAN:
+		return "EXPRESSION_SCAN";
+	case PhysicalOperatorType::ALTER:
+		return "ALTER";
+	case PhysicalOperatorType::CREATE_SEQUENCE:
+		return "CREATE_SEQUENCE";
+	case PhysicalOperatorType::CREATE_VIEW:
+		return "CREATE_VIEW";
+	case PhysicalOperatorType::CREATE_SCHEMA:
+		return "CREATE_SCHEMA";
+	case PhysicalOperatorType::DROP:
+		return "DROP";
+	case PhysicalOperatorType::PRAGMA:
+		return "PRAGMA";
+	case PhysicalOperatorType::TRANSACTION:
+		return "TRANSACTION";
+	case PhysicalOperatorType::PREPARE:
+		return "PREPARE";
 	}
+	return "UNDEFINED";
 }
 
 } // namespace duckdb

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -223,9 +223,12 @@ string SQLTypeIdToString(SQLTypeId id) {
 		return "STRUCT<?>";
 	case SQLTypeId::LIST:
 		return "LIST<?>";
-	default:
+	case SQLTypeId::INVALID:
 		return "INVALID";
+	case SQLTypeId::UNKNOWN:
+		return "UNKNOWN";
 	}
+	return "UNDEFINED";
 }
 
 string SQLTypeToString(SQLType type) {

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -118,6 +118,8 @@ private:
 	//! Whether or not the query profiler is running
 	bool running;
 
+	bool query_requires_profiling;
+
 	//! The root of the query tree
 	unique_ptr<TreeNode> root;
 	//! The query string
@@ -139,5 +141,8 @@ private:
 
 private:
 	vector<PhaseTimingItem> GetOrderedPhaseTimings() const;
+
+	//! Check whether or not an operator type requires query profiling. If none of the ops in a query require profiling no profiling information is output.
+	bool OperatorRequiresProfiling(PhysicalOperatorType op_type);
 };
 } // namespace duckdb

--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -306,8 +306,16 @@ with open(duckdb_nonsense_db, 'w+') as f:
 test('', err='unable to open', extra_commands=[duckdb_nonsense_db])
 os.remove(duckdb_nonsense_db)
 
+# enable_profiling doesn't result in any output
+test('''
+PRAGMA enable_profiling
+''', err="")
 
-
+# only when we follow it up by an actual query does something get printed to the terminal
+test('''
+PRAGMA enable_profiling;
+SELECT 42;
+''', out="42", err="<<Query Profiling Information>>")
 
 # not working for now, probably for the better
 


### PR DESCRIPTION
This PR fixes query profiling output in the shell. Before the fix any query would result in query profiling output being printed, including pragma statements, preparing statements, and dropping prepared statements. This is problematic because in the shell (and other APIs as well) normal statements do a cycle of "prepare -> execute -> deallocate" which resulted in a lot of useless profiling information being printed. In this PR we change it so the query profiler looks at the query to determine if profiling information should be output. Any non-trivial ops (e.g. table scan, filter, projection, join, etc) cause the query profiler to be enabled. 