### PR TITLE
Add a PRAGMA to retrieve version

### DIFF
--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 import shutil
+import subprocess
 amal_dir = os.path.join('src', 'amalgamation')
 header_file = os.path.join(amal_dir, "duckdb.hpp")
 source_file = os.path.join(amal_dir, "duckdb.cpp")
@@ -25,7 +26,7 @@ utf8proc_include_dir = os.path.join('third_party', 'utf8proc', 'include')
 moodycamel_include_dir = os.path.join('third_party', 'concurrentqueue')
 
 # files included in the amalgamated "duckdb.hpp" file
-main_header_files = [os.path.join(include_dir, 'duckdb.hpp'), 
+main_header_files = [os.path.join(include_dir, 'duckdb.hpp'),
 	os.path.join(include_dir, 'duckdb.h'),
 	os.path.join(include_dir, 'duckdb', 'common', 'types', 'date.hpp'),
 	os.path.join(include_dir, 'duckdb', 'common', 'types', 'timestamp.hpp'),
@@ -143,6 +144,9 @@ def copy_if_different(src, dest):
     print("Copying " + src + " to " + dest)
     shutil.copyfile(src, dest)
 
+def git_commit_hash():
+    return subprocess.check_output(['git','log','-1','--format=%h']).strip()
+
 def generate_amalgamation(source_file, header_file):
     # now construct duckdb.hpp from these headers
     print("-----------------------")
@@ -152,6 +156,7 @@ def generate_amalgamation(source_file, header_file):
         hfile.write("// See https://raw.githubusercontent.com/cwida/duckdb/master/LICENSE for licensing information\n\n")
         hfile.write("#pragma once\n")
         hfile.write("#define DUCKDB_AMALGAMATION 1\n")
+        hfile.write("#define DUCKDB_SOURCE_ID \"%s\"\n" % git_commit_hash())
         for fpath in main_header_files:
             hfile.write(write_file(fpath))
 

--- a/src/function/table/CMakeLists.txt
+++ b/src/function/table/CMakeLists.txt
@@ -1,11 +1,13 @@
 add_subdirectory(sqlite)
-add_library_unity(duckdb_func_table
-                  OBJECT
-                  range.cpp
-                  repeat.cpp
-                  copy_csv.cpp
-                  read_csv.cpp
-                  sqlite_functions.cpp)
+add_library_unity(
+  duckdb_func_table
+  OBJECT
+  range.cpp
+  repeat.cpp
+  copy_csv.cpp
+  read_csv.cpp
+  sqlite_functions.cpp)
+
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_table>
     PARENT_SCOPE)

--- a/src/function/table/CMakeLists.txt
+++ b/src/function/table/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(version)
 add_subdirectory(sqlite)
 add_library_unity(
   duckdb_func_table

--- a/src/function/table/sqlite/CMakeLists.txt
+++ b/src/function/table/sqlite/CMakeLists.txt
@@ -1,7 +1,5 @@
-add_definitions(-DDUCKDB_SOURCE_ID="\""${GIT_COMMIT_HASH}"\"")
-
 add_library_unity(duckdb_func_sqlite OBJECT pragma_collations.cpp
-                  pragma_table_info.cpp pragma_version.cpp sqlite_master.cpp)
+                  pragma_table_info.cpp sqlite_master.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_sqlite>
     PARENT_SCOPE)

--- a/src/function/table/sqlite/CMakeLists.txt
+++ b/src/function/table/sqlite/CMakeLists.txt
@@ -1,8 +1,7 @@
-add_library_unity(duckdb_func_sqlite
-                  OBJECT
-                  pragma_collations.cpp
-                  pragma_table_info.cpp
-                  sqlite_master.cpp)
+add_definitions(-DDUCKDB_SOURCE_ID="\""${GIT_COMMIT_HASH}"\"")
+
+add_library_unity(duckdb_func_sqlite OBJECT pragma_collations.cpp
+                  pragma_table_info.cpp pragma_version.cpp sqlite_master.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_sqlite>
     PARENT_SCOPE)

--- a/src/function/table/sqlite/pragma_version.cpp
+++ b/src/function/table/sqlite/pragma_version.cpp
@@ -1,0 +1,39 @@
+#include "duckdb/function/table/sqlite_functions.hpp"
+
+namespace duckdb {
+
+struct PragmaVersionData : public TableFunctionData {
+	PragmaVersionData() : done(false) {
+	}
+	bool done;
+};
+
+static unique_ptr<FunctionData> pragma_version_bind(ClientContext &context, vector<Value> inputs,
+                                                    vector<SQLType> &return_types, vector<string> &names) {
+	names.push_back("library_version");
+	return_types.push_back(SQLType::VARCHAR);
+    names.push_back("source_id");
+    return_types.push_back(SQLType::VARCHAR);
+
+	return make_unique<PragmaVersionData>();
+}
+
+static void pragma_version_info(ClientContext &context, vector<Value> &input, DataChunk &output,
+                                FunctionData *dataptr) {
+	auto &data = *((PragmaVersionData *)dataptr);
+	assert(input.size() == 0);
+	if (data.done) {
+		// finished returning values
+		return;
+	}
+	output.SetCardinality(1);
+	output.SetValue(0, 0, "DuckDB");
+	output.SetValue(1, 0, DUCKDB_SOURCE_ID);
+	data.done = true;
+}
+
+void PragmaVersion::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("pragma_version", {}, pragma_version_bind, pragma_version_info, nullptr));
+}
+
+} // namespace duckdb

--- a/src/function/table/sqlite_functions.cpp
+++ b/src/function/table/sqlite_functions.cpp
@@ -11,6 +11,7 @@ using namespace std;
 namespace duckdb {
 
 void BuiltinFunctions::RegisterSQLiteFunctions() {
+	PragmaVersion::RegisterFunction(*this);
 	PragmaCollations::RegisterFunction(*this);
 	PragmaTableInfo::RegisterFunction(*this);
 	SQLiteMaster::RegisterFunction(*this);

--- a/src/function/table/version/CMakeLists.txt
+++ b/src/function/table/version/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_definitions(-DDUCKDB_SOURCE_ID="\""${GIT_COMMIT_HASH}"\"")
+
+add_library_unity(duckdb_func_table_version OBJECT pragma_version.cpp)
+
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_table_version>
+    PARENT_SCOPE)

--- a/src/function/table/version/pragma_version.cpp
+++ b/src/function/table/version/pragma_version.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/function/table/sqlite_functions.hpp"
+#include "duckdb/main/database.hpp"
 
 namespace duckdb {
 
@@ -12,8 +13,8 @@ static unique_ptr<FunctionData> pragma_version_bind(ClientContext &context, vect
                                                     vector<SQLType> &return_types, vector<string> &names) {
 	names.push_back("library_version");
 	return_types.push_back(SQLType::VARCHAR);
-    names.push_back("source_id");
-    return_types.push_back(SQLType::VARCHAR);
+	names.push_back("source_id");
+	return_types.push_back(SQLType::VARCHAR);
 
 	return make_unique<PragmaVersionData>();
 }
@@ -27,13 +28,21 @@ static void pragma_version_info(ClientContext &context, vector<Value> &input, Da
 		return;
 	}
 	output.SetCardinality(1);
-	output.SetValue(0, 0, "DuckDB");
-	output.SetValue(1, 0, DUCKDB_SOURCE_ID);
+	output.SetValue(0, 0, DuckDB::LibraryVersion());
+	output.SetValue(1, 0, DuckDB::SourceID());
 	data.done = true;
 }
 
 void PragmaVersion::RegisterFunction(BuiltinFunctions &set) {
 	set.AddFunction(TableFunction("pragma_version", {}, pragma_version_bind, pragma_version_info, nullptr));
+}
+
+const char *DuckDB::SourceID() {
+	return DUCKDB_SOURCE_ID;
+}
+
+const char *DuckDB::LibraryVersion() {
+	return "DuckDB";
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/function/table/sqlite_functions.hpp
+++ b/src/include/duckdb/function/table/sqlite_functions.hpp
@@ -24,4 +24,8 @@ struct SQLiteMaster {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct PragmaVersion {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 } // namespace duckdb

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -45,6 +45,9 @@ public:
 
 	FileSystem &GetFileSystem();
 
+	static const char *SourceID();
+	static const char *LibraryVersion();
+
 private:
 	void Configure(DBConfig &config);
 };

--- a/src/planner/pragma_handler.cpp
+++ b/src/planner/pragma_handler.cpp
@@ -77,6 +77,13 @@ unique_ptr<SQLStatement> PragmaHandler::HandlePragma(PragmaInfo &pragma) {
 		auto &function = (FunctionExpression &)*table_function.function;
 		function.children.push_back(make_unique<ConstantExpression>(SQLTypeId::VARCHAR, pragma.parameters[0]));
 		return select_statement;
+	} else if (keyword == "version") {
+		if (pragma.pragma_type != PragmaType::NOTHING) {
+			throw ParserException("Invalid PRAGMA version: cannot be called");
+		}
+		Parser parser;
+		parser.ParseQuery("SELECT * FROM pragma_version()");
+		return move(parser.statements[0]);
 	}
 	return nullptr;
 }

--- a/test/sql/pragma/test_pragma_version.test
+++ b/test/sql/pragma/test_pragma_version.test
@@ -1,0 +1,15 @@
+# name: test/sql/pragma/version.test
+# description: Test version pragma
+# group: [pragma]
+
+statement ok
+PRAGMA version;
+
+statement ok
+select * from pragma_version();
+
+query I
+select library_version from pragma_version();
+----
+DuckDB
+

--- a/tools/rest/CMakeLists.txt
+++ b/tools/rest/CMakeLists.txt
@@ -1,16 +1,15 @@
 include_directories(.)
 include_directories(../../third_party/dbgen/include)
 
-add_definitions(-DDUCKDB_SOURCE_ID="\""${GIT_COMMIT_HASH}"\"")
-
 add_executable(duckdb_rest_server server.cpp)
 
 if(${BUILD_SUN})
   set(LINK_EXTRA -lsocket)
 endif()
 
-target_link_libraries(duckdb_rest_server duckdb_static Threads::Threads ${LINK_EXTRA})
+target_link_libraries(duckdb_rest_server duckdb_static Threads::Threads
+                      ${LINK_EXTRA})
 if(${BUILD_UNITTESTS})
-	add_executable(duckdb_dbgen dbgen.cpp)
-	target_link_libraries(duckdb_dbgen dbgen duckdb_static)
+  add_executable(duckdb_dbgen dbgen.cpp)
+  target_link_libraries(duckdb_dbgen dbgen duckdb_static)
 endif()

--- a/tools/rest/server.cpp
+++ b/tools/rest/server.cpp
@@ -31,8 +31,7 @@ void print_help() {
 	fprintf(stderr, "          --query_timeout=[sec] query timeout in seconds\n");
 	fprintf(stderr, "          --fetch_timeout=[sec] result set timeout in seconds\n");
 	fprintf(stderr, "          --log=[file]          log queries to file\n\n");
-	fprintf(stderr, "Version: %s\n", DUCKDB_SOURCE_ID);
-
+	fprintf(stderr, "Version: %s\n", DuckDB::SourceID());
 }
 
 // https://stackoverflow.com/a/12468109/2652376
@@ -131,7 +130,7 @@ void serialize_chunk(QueryResult *res, DataChunk *chunk, json &j) {
 
 void serialize_json(const Request &req, Response &resp, json &j) {
 	auto return_type = ReturnContentType::JSON;
-	j["duckdb_version"] = DUCKDB_SOURCE_ID;
+	j["duckdb_version"] = DuckDB::SourceID();
 
 	if (req.has_header("Accept")) {
 		auto accept = req.get_header_value("Accept");

--- a/tools/shell/CMakeLists.txt
+++ b/tools/shell/CMakeLists.txt
@@ -1,7 +1,5 @@
 add_definitions(-DSQLITE_OMIT_LOAD_EXTENSION=1)
 
-add_definitions(-DDUCKDB_SOURCE_ID="\""${GIT_COMMIT_HASH}"\"")
-
 set(SHELL_SOURCES shell.c)
 if(NOT WIN32)
   add_definitions(-DHAVE_LINENOISE=1)
@@ -19,5 +17,5 @@ if(NOT AMALGAMATION_BUILD AND NOT WIN32)
 endif()
 
 set_target_properties(shell PROPERTIES OUTPUT_NAME duckdb)
-set_target_properties(shell
-                      PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set_target_properties(shell PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+                                       ${CMAKE_BINARY_DIR})

--- a/tools/sqlite3_api_wrapper/CMakeLists.txt
+++ b/tools/sqlite3_api_wrapper/CMakeLists.txt
@@ -1,6 +1,5 @@
 include_directories(include)
 
-
 if(${BUILD_ICU_EXTENSION})
   add_definitions(-DBUILD_ICU_EXTENSION=${BUILD_ICU_EXTENSION})
 endif()
@@ -9,8 +8,6 @@ if(${BUILD_PARQUET_EXTENSION})
   add_definitions(-DBUILD_PARQUET_EXTENSION=${BUILD_PARQUET_EXTENSION})
 endif()
 
-add_definitions(-DDUCKDB_SOURCE_ID="\""${GIT_COMMIT_HASH}"\"")
-
 add_library(sqlite3_api_wrapper SHARED sqlite3_api_wrapper.cpp printf.c)
 target_link_libraries(sqlite3_api_wrapper duckdb Threads::Threads)
 
@@ -18,24 +15,21 @@ add_library(sqlite3_api_wrapper_static STATIC sqlite3_api_wrapper.cpp printf.c)
 target_link_libraries(sqlite3_api_wrapper_static duckdb_static Threads::Threads)
 
 if(${BUILD_PARQUET_EXTENSION})
-	include_directories(../../extension/parquet/include)
-    target_link_libraries(sqlite3_api_wrapper parquet_extension)
-    target_link_libraries(sqlite3_api_wrapper_static parquet_extension)
+  include_directories(../../extension/parquet/include)
+  target_link_libraries(sqlite3_api_wrapper parquet_extension)
+  target_link_libraries(sqlite3_api_wrapper_static parquet_extension)
 endif()
 
 if(${BUILD_ICU_EXTENSION})
-	include_directories(../../extension/icu/include)
-    target_link_libraries(sqlite3_api_wrapper icu_extension)
-    target_link_libraries(sqlite3_api_wrapper_static icu_extension)
+  include_directories(../../extension/icu/include)
+  target_link_libraries(sqlite3_api_wrapper icu_extension)
+  target_link_libraries(sqlite3_api_wrapper_static icu_extension)
 endif()
 
 include_directories(../../third_party/catch)
 
 add_executable(test_sqlite3_api_wrapper test_sqlite3_api_wrapper.cpp)
-target_link_libraries(test_sqlite3_api_wrapper
-                      sqlite3_api_wrapper)
-
-
+target_link_libraries(test_sqlite3_api_wrapper sqlite3_api_wrapper)
 
 # For testing only: compile a version of test_sqlite3_api_wrapper that is bound
 # to SQLite: this should have the same behavior as binding to DuckDB

--- a/tools/sqlite3_api_wrapper/include/sqlite3.h
+++ b/tools/sqlite3_api_wrapper/include/sqlite3.h
@@ -125,7 +125,7 @@ extern "C" {
 */
 #define SQLITE_VERSION        "3.23.0"
 #define SQLITE_VERSION_NUMBER 3023000
-#define SQLITE_SOURCE_ID      DUCKDB_SOURCE_ID
+#define SQLITE_SOURCE_ID      sqlite3_sourceid()
 
 
 /*


### PR DESCRIPTION
Fix: https://github.com/cwida/duckdb/issues/672

This adds a way for users to retrieve the version of duck db using SQL.
The possible methods which are all equivalent are:

`select * from  pragma_version();`

`PRAGMA version;`

These should return

library_version | source_id
DuckDB          | 76khli0

Theres another way to fetch the version using the inbuilt `.version`
function. This will go through the sqlite.c file and return the same
information, but it will also return the compiler version.

That is something that could also be added. Another thing we could add
to the output would be the git tag.

I'm proposing a minimal change set that we can iterate on.