### PR TITLE
Add support for the ".tables" command in the shell (#815)

### DIFF
--- a/src/function/table/sqlite/CMakeLists.txt
+++ b/src/function/table/sqlite/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library_unity(duckdb_func_sqlite OBJECT pragma_collations.cpp
+add_library_unity(duckdb_func_sqlite OBJECT pragma_collations.cpp pragma_database_list.cpp
                   pragma_table_info.cpp sqlite_master.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_sqlite>

--- a/src/function/table/sqlite/pragma_database_list.cpp
+++ b/src/function/table/sqlite/pragma_database_list.cpp
@@ -1,0 +1,49 @@
+#include "duckdb/function/table/sqlite_functions.hpp"
+
+#include "duckdb/storage/storage_manager.hpp"
+
+using namespace std;
+
+namespace duckdb {
+
+struct PragmaDatabaseListData : public TableFunctionData {
+	PragmaDatabaseListData() : finished(false) {
+	}
+
+	bool finished;
+};
+
+static unique_ptr<FunctionData> pragma_database_list_bind(ClientContext &context, vector<Value> inputs,
+                                                   vector<SQLType> &return_types, vector<string> &names) {
+	names.push_back("seq");
+	return_types.push_back(SQLType::INTEGER);
+
+	names.push_back("name");
+	return_types.push_back(SQLType::VARCHAR);
+
+	names.push_back("file");
+	return_types.push_back(SQLType::VARCHAR);
+
+	// initialize the function data structure
+	return make_unique<PragmaDatabaseListData>();
+}
+
+void pragma_database_list(ClientContext &context, vector<Value> &input, DataChunk &output, FunctionData *dataptr) {
+	auto &data = *((PragmaDatabaseListData *)dataptr);
+	if (data.finished) {
+		return;
+	}
+
+	output.SetCardinality(1);
+	output.data[0].SetValue(0, Value::INTEGER(0));
+	output.data[1].SetValue(0, Value("main"));
+	output.data[2].SetValue(0, Value(StorageManager::GetStorageManager(context).GetDBPath()));
+
+	data.finished = true;
+}
+
+void PragmaDatabaseList::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("pragma_database_list", {}, pragma_database_list_bind, pragma_database_list, nullptr));
+}
+
+} // namespace duckdb

--- a/src/function/table/sqlite_functions.cpp
+++ b/src/function/table/sqlite_functions.cpp
@@ -15,6 +15,7 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 	PragmaCollations::RegisterFunction(*this);
 	PragmaTableInfo::RegisterFunction(*this);
 	SQLiteMaster::RegisterFunction(*this);
+	PragmaDatabaseList::RegisterFunction(*this);
 
 	CreateViewInfo info;
 	info.schema = DEFAULT_SCHEMA;

--- a/src/include/duckdb/function/table/sqlite_functions.hpp
+++ b/src/include/duckdb/function/table/sqlite_functions.hpp
@@ -28,4 +28,8 @@ struct PragmaVersion {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct PragmaDatabaseList {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 } // namespace duckdb

--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -27,6 +27,8 @@ public:
 	StorageManager(DuckDB &database, string path, bool read_only);
 	~StorageManager();
 
+	static StorageManager &GetStorageManager(ClientContext &context);
+
 	//! Initialize a database or load an existing database from the given path
 	void Initialize();
 	//! Get the WAL of the StorageManager, returns nullptr if in-memory
@@ -36,6 +38,10 @@ public:
 
 	DuckDB &GetDatabase() {
 		return database;
+	}
+
+	string GetDBPath() {
+		return path;
 	}
 	//! The BlockManager to read/store meta information and data in blocks
 	unique_ptr<BlockManager> block_manager;

--- a/src/planner/pragma_handler.cpp
+++ b/src/planner/pragma_handler.cpp
@@ -48,6 +48,14 @@ unique_ptr<SQLStatement> PragmaHandler::HandlePragma(PragmaInfo &pragma) {
 		Parser parser;
 		parser.ParseQuery("SELECT name FROM sqlite_master() ORDER BY name");
 		return move(parser.statements[0]);
+	} else if (keyword == "database_list") {
+		if (pragma.pragma_type != PragmaType::NOTHING) {
+			throw ParserException("Invalid PRAGMA database_list: cannot be called");
+		}
+		// turn into SELECT * FROM pragma_collations();
+		Parser parser;
+		parser.ParseQuery("SELECT * FROM pragma_database_list() ORDER BY 1");
+		return move(parser.statements[0]);
 	} else if (keyword == "collations") {
 		if (pragma.pragma_type != PragmaType::NOTHING) {
 			throw ParserException("Invalid PRAGMA collations: cannot be called");

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -23,6 +23,10 @@ StorageManager::StorageManager(DuckDB &db, string path, bool read_only)
 StorageManager::~StorageManager() {
 }
 
+StorageManager &StorageManager::GetStorageManager(ClientContext &context) {
+	return *context.db.storage;
+}
+
 BufferManager &BufferManager::GetBufferManager(ClientContext &context) {
 	return *context.db.storage->buffer_manager;
 }

--- a/test/sql/pragma/test_pragma_database_list.test
+++ b/test/sql/pragma/test_pragma_database_list.test
@@ -1,0 +1,25 @@
+# name: test/sql/pragma/test_pragma_database_list.test
+# description: Test PRAGMA database_list
+# group: [pragma]
+
+query III
+PRAGMA database_list
+----
+0	main	(empty)
+
+query III
+SELECT * FROM pragma_database_list()
+----
+0	main	(empty)
+
+statement error
+PRAGMA database_list()
+
+# FIXME: need to merge changes from hugeint branch
+# # load a database file
+# load __TEST_DIR__/test.db
+
+# query III
+# SELECT * FROM pragma_database_list()
+# ----
+# 0	main	(empty)

--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -160,13 +160,13 @@ test('.stats on')
 test('.stats off')
 
 # FIXME
-test('.schema', err="pragma_database_list")
+test('.schema', err="subquery in FROM must have an alias")
 
 # FIXME need sqlite3_strlike for this
 test('''
 CREATE TABLE asdf (i INTEGER);
 .schema as%
-''', err="pragma_database_list")
+''', err="subquery in FROM must have an alias")
 
 test('.fullschema')
 
@@ -346,7 +346,7 @@ SELECT 42;
 
 # fails because view pragma_database_list does not exist
 
-# test('.databases')
+test('.databases', out='main:')
 
 
 # fails

--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -140,7 +140,7 @@ test('.limit length 42', err='sqlite3_limit')
 test('.lint fkey-indexes')
 
 # this should probably be fixed, sqlite generates an internal query that duckdb does not like
-test('.indexes', err='syntax error')
+test('.indexes', err='indexes not supported')
 
 
 test('.timeout', err='sqlite3_busy_timeout')
@@ -170,23 +170,27 @@ CREATE TABLE asdf (i INTEGER);
 
 test('.fullschema')
 
-test('.tables', err="syntax error")
+test('''
+CREATE TABLE asda (i INTEGER);
+CREATE TABLE bsdf (i INTEGER);
+CREATE TABLE csda (i INTEGER);
+.tables
+''', out="asda  bsdf  csda")
 
 test('''
-CREATE TABLE asdf (i INTEGER);
-.tables as%
-''', err="syntax error")
+CREATE TABLE asda (i INTEGER);
+CREATE TABLE bsdf (i INTEGER);
+CREATE TABLE csda (i INTEGER);
+.tables %da
+''', out="asda  csda")
 
-
-test('.indexes',  err="syntax error")
+test('.indexes',  err="indexes not supported")
 
 test('''
 CREATE TABLE a (i INTEGER);
 CREATE INDEX a_idx ON a(i);
 .indexes a_%
-''',  err="syntax error")
-
-
+''',  err="indexes not supported")
 
 # this does not seem to output anything
 test('.sha3sum')

--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -14469,45 +14469,13 @@ static int do_meta_command(char *zLine, ShellState *p) {
 		if (rc)
 			return shellDatabaseError(p->db);
 
-		if (nArg > 2 && c == 'i') {
-			/* It is an historical accident that the .indexes command shows an error
-			** when called with the wrong number of arguments whereas the .tables
-			** command does not. */
-			raw_printf(stderr, "Usage: .indexes ?LIKE-PATTERN?\n");
+		if (c == 'i') {
+			raw_printf(stderr, ".indexes not supported currently");
 			rc = 1;
 			goto meta_command_exit;
 		}
-		for (ii = 0; sqlite3_step(pStmt) == SQLITE_ROW; ii++) {
-			const char *zDbName = (const char *)sqlite3_column_text(pStmt, 1);
-			if (zDbName == 0)
-				continue;
-			if (s.z && s.z[0])
-				appendText(&s, " UNION ALL ", 0);
-			if (sqlite3_stricmp(zDbName, "main") == 0) {
-				appendText(&s, "SELECT name FROM ", 0);
-			} else {
-				appendText(&s, "SELECT ", 0);
-				appendText(&s, zDbName, '\'');
-				appendText(&s, "||'.'||name FROM ", 0);
-			}
-			appendText(&s, zDbName, '"');
-			appendText(&s, ".sqlite_master ", 0);
-			if (c == 't') {
-				appendText(&s,
-				           " WHERE type IN ('table','view')"
-				           "   AND name NOT LIKE 'sqlite_%'"
-				           "   AND name LIKE ?1",
-				           0);
-			} else {
-				appendText(&s,
-				           " WHERE type='index'"
-				           "   AND tbl_name LIKE ?1",
-				           0);
-			}
-		}
-		rc = sqlite3_finalize(pStmt);
-		appendText(&s, " ORDER BY 1", 0);
-		rc = sqlite3_prepare_v2(p->db, s.z, -1, &pStmt, 0);
+
+		rc = sqlite3_prepare_v2(p->db, "SELECT name FROM sqlite_master() WHERE name LIKE $1 ORDER BY name", -1, &pStmt, 0);
 		freeText(&s);
 		if (rc)
 			return shellDatabaseError(p->db);

--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -12901,7 +12901,7 @@ static int do_meta_command(char *zLine, ShellState *p) {
 		data.cMode = data.mode = MODE_List;
 		sqlite3_snprintf(sizeof(data.colSeparator), data.colSeparator, ": ");
 		data.cnt = 0;
-		sqlite3_exec(p->db, "SELECT name, file FROM pragma_database_list", callback, &data, &zErrMsg);
+		sqlite3_exec(p->db, "SELECT name, file FROM pragma_database_list()", callback, &data, &zErrMsg);
 		if (zErrMsg) {
 			utf8_printf(stderr, "Error: %s\n", zErrMsg);
 			sqlite3_free(zErrMsg);
@@ -13851,7 +13851,7 @@ static int do_meta_command(char *zLine, ShellState *p) {
 		}
 		if (zDiv) {
 			sqlite3_stmt *pStmt = 0;
-			rc = sqlite3_prepare_v2(p->db, "SELECT name FROM pragma_database_list", -1, &pStmt, 0);
+			rc = sqlite3_prepare_v2(p->db, "SELECT name FROM pragma_database_list()", -1, &pStmt, 0);
 			if (rc) {
 				utf8_printf(stderr, "Error: %s\n", sqlite3_errmsg(p->db));
 				sqlite3_finalize(pStmt);


### PR DESCRIPTION
Usage:
```sql
-- print all tables
.tables
-- print all tables whose name matches a LIKE expression
.tables as%
```