### PR TITLE
Getting rid of `using namespace duckdb;` in `src/`

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -21,7 +21,7 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/catalog/dependency_manager.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 Catalog::Catalog(StorageManager &storage)
@@ -252,3 +252,5 @@ end:
 		throw ParserException("Expected schema.entry or entry: too many entries found");
 	}
 }
+
+} // namespace duckdb

--- a/src/catalog/catalog_entry.cpp
+++ b/src/catalog/catalog_entry.cpp
@@ -2,8 +2,10 @@
 
 #include "duckdb/catalog/catalog.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 CatalogEntry::~CatalogEntry() {
 }
+
+} // namespace duckdb

--- a/src/catalog/catalog_entry/copy_function_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/copy_function_catalog_entry.cpp
@@ -3,10 +3,12 @@
 
 #include <algorithm>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 CopyFunctionCatalogEntry::CopyFunctionCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema,
                                                    CreateCopyFunctionInfo *info)
     : StandardEntry(CatalogType::COPY_FUNCTION, schema, catalog, info->name), function(info->function) {
 }
+
+} // namespace duckdb

--- a/src/catalog/catalog_entry/schema_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/schema_catalog_entry.cpp
@@ -25,7 +25,7 @@
 
 #include <algorithm>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 SchemaCatalogEntry::SchemaCatalogEntry(Catalog *catalog, string name)
@@ -232,3 +232,5 @@ CatalogSet &SchemaCatalogEntry::GetCatalogSet(CatalogType type) {
 		throw CatalogException("Unsupported catalog type in schema");
 	}
 }
+
+} // namespace duckdb

--- a/src/catalog/catalog_entry/sequence_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/sequence_catalog_entry.cpp
@@ -7,7 +7,7 @@
 
 #include <algorithm>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 SequenceCatalogEntry::SequenceCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, CreateSequenceInfo *info)
@@ -42,3 +42,5 @@ unique_ptr<CreateSequenceInfo> SequenceCatalogEntry::Deserialize(Deserializer &s
 	info->cycle = source.Read<bool>();
 	return info;
 }
+
+} // namespace duckdb

--- a/src/catalog/catalog_entry/table_function_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_function_catalog_entry.cpp
@@ -1,11 +1,13 @@
 #include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 TableFunctionCatalogEntry::TableFunctionCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema,
                                                      CreateTableFunctionInfo *info)
     : StandardEntry(CatalogType::TABLE_FUNCTION, schema, catalog, info->name), functions(move(info->functions)) {
-    assert(this->functions.size() > 0);
+	assert(this->functions.size() > 0);
 }
+
+} // namespace duckdb

--- a/src/catalog/catalog_entry/view_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/view_catalog_entry.cpp
@@ -7,7 +7,7 @@
 
 #include <algorithm>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 void ViewCatalogEntry::Initialize(CreateViewInfo *info) {
@@ -52,3 +52,5 @@ unique_ptr<CreateViewInfo> ViewCatalogEntry::Deserialize(Deserializer &source) {
 	}
 	return info;
 }
+
+} // namespace duckdb

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -8,7 +8,7 @@
 #include "duckdb/parser/parsed_data/alter_table_info.hpp"
 #include "duckdb/catalog/dependency_manager.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 CatalogSet::CatalogSet(Catalog &catalog) : catalog(catalog) {
@@ -238,3 +238,5 @@ void CatalogSet::Undo(CatalogEntry *entry) {
 		entry->parent = nullptr;
 	}
 }
+
+} // namespace duckdb

--- a/src/catalog/dependency_manager.cpp
+++ b/src/catalog/dependency_manager.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/catalog/catalog.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 DependencyManager::DependencyManager(Catalog &catalog) : catalog(catalog) {
@@ -138,3 +138,5 @@ void DependencyManager::ClearDependencies(CatalogSet &set) {
 		}
 	}
 }
+
+} // namespace duckdb

--- a/src/common/constants.cpp
+++ b/src/common/constants.cpp
@@ -2,10 +2,8 @@
 #include "duckdb/common/vector_size.hpp"
 #include "duckdb/common/limits.hpp"
 
-using namespace duckdb;
-using namespace std;
-
 namespace duckdb {
+using namespace std;
 
 const idx_t INVALID_INDEX = (idx_t)-1;
 const row_t MAX_ROW_ID = 4611686018427388000ULL; // 2^62
@@ -13,7 +11,7 @@ const column_t COLUMN_IDENTIFIER_ROW_ID = (column_t)-1;
 const sel_t ZERO_VECTOR[STANDARD_VECTOR_SIZE] = {0};
 const double PI = 3.141592653589793;
 
-const transaction_t TRANSACTION_ID_START = 4611686018427388000ULL;                  // 2^62
+const transaction_t TRANSACTION_ID_START = 4611686018427388000ULL;                // 2^62
 const transaction_t NOT_DELETED_ID = NumericLimits<transaction_t>::Maximum() - 1; // 2^64 - 1
 const transaction_t MAXIMUM_QUERY_ID = NumericLimits<transaction_t>::Maximum();   // 2^64
 

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 #define FORMAT_CONSTRUCTOR(msg)                                                                                        \
@@ -189,3 +189,5 @@ InternalException::InternalException(string msg, ...) : Exception(ExceptionType:
 InvalidInputException::InvalidInputException(string msg, ...) : Exception(ExceptionType::INVALID_INPUT, msg) {
 	FORMAT_CONSTRUCTOR(msg);
 }
+
+} // namespace duckdb

--- a/src/common/file_buffer.cpp
+++ b/src/common/file_buffer.cpp
@@ -6,7 +6,7 @@
 
 #include <cstring>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 FileBuffer::FileBuffer(FileBufferType type, uint64_t bufsiz) : type(type) {
@@ -66,3 +66,4 @@ void FileBuffer::Write(FileHandle &handle, uint64_t location) {
 void FileBuffer::Clear() {
 	memset(internal_buffer, 0, internal_size);
 }
+} // namespace duckdb

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -324,7 +324,7 @@ void FileSystem::MoveFile(const string &source, const string &target) {
 // Returns the last Win32 error, in string format. Returns an empty string if there is no error.
 std::string GetLastErrorAsString() {
 	// Get the error message, if any.
-	DWORD errorMessageID = ::GetLastError();
+	DWORD errorMessageID = GetLastError();
 	if (errorMessageID == 0)
 		return std::string(); // No error message has been recorded
 

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -7,7 +7,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/database.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 #include <cstdio>
@@ -609,3 +609,5 @@ void FileHandle::Sync() {
 void FileHandle::Truncate(int64_t new_size) {
 	file_system.Truncate(*this, new_size);
 }
+
+} // namespace duckdb

--- a/src/common/fstream_util.cpp
+++ b/src/common/fstream_util.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/common/fstream_util.hpp"
 
 using namespace std;
-using namespace duckdb;
+namespace duckdb {
 
 void FstreamUtil::OpenFile(const string &file_path, fstream &new_file, ios_base::openmode mode) {
 	new_file.open(file_path, mode);
@@ -31,3 +31,5 @@ data_ptr FstreamUtil::ReadBinary(fstream &file) {
 
 	return result;
 }
+
+} // namespace duckdb

--- a/src/common/gzip_stream.cpp
+++ b/src/common/gzip_stream.cpp
@@ -9,7 +9,7 @@
 #include "duckdb/common/limits.hpp"
 
 using namespace std;
-using namespace duckdb;
+namespace duckdb {
 
 /*
 
@@ -207,3 +207,5 @@ GzipStreamBuf::~GzipStreamBuf() {
 	}
 	delete zstrm_p;
 }
+
+} // namespace duckdb

--- a/src/common/printer.cpp
+++ b/src/common/printer.cpp
@@ -2,10 +2,12 @@
 
 #include <stdio.h>
 
-using namespace duckdb;
+namespace duckdb {
 
 void Printer::Print(string str) {
 #ifndef DUCKDB_DISABLE_PRINT
 	fprintf(stderr, "%s\n", str.c_str());
 #endif
 }
+
+} // namespace duckdb

--- a/src/common/serializer.cpp
+++ b/src/common/serializer.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/common/serializer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 template <> string Deserializer::Read() {
@@ -9,3 +9,5 @@ template <> string Deserializer::Read() {
 	ReadData(buffer.get(), size);
 	return string((char *)buffer.get(), size);
 }
+
+} // namespace duckdb

--- a/src/common/serializer/buffered_deserializer.cpp
+++ b/src/common/serializer/buffered_deserializer.cpp
@@ -2,7 +2,7 @@
 
 #include <cstring>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BufferedDeserializer::BufferedDeserializer(data_ptr_t ptr, idx_t data_size) : ptr(ptr), endptr(ptr + data_size) {
@@ -19,3 +19,5 @@ void BufferedDeserializer::ReadData(data_ptr_t buffer, idx_t read_size) {
 	memcpy(buffer, ptr, read_size);
 	ptr += read_size;
 }
+
+} // namespace duckdb

--- a/src/common/serializer/buffered_file_reader.cpp
+++ b/src/common/serializer/buffered_file_reader.cpp
@@ -5,7 +5,7 @@
 #include <cstring>
 #include <algorithm>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BufferedFileReader::BufferedFileReader(FileSystem &fs, const char *path)
@@ -43,3 +43,5 @@ void BufferedFileReader::ReadData(data_ptr_t target_buffer, uint64_t read_size) 
 bool BufferedFileReader::Finished() {
 	return total_read + offset == file_size;
 }
+
+} // namespace duckdb

--- a/src/common/serializer/buffered_file_writer.cpp
+++ b/src/common/serializer/buffered_file_writer.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/common/algorithm.hpp"
 #include <cstring>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BufferedFileWriter::BufferedFileWriter(FileSystem &fs, string path, uint8_t open_flags)
@@ -16,9 +16,8 @@ int64_t BufferedFileWriter::GetFileSize() {
 }
 
 idx_t BufferedFileWriter::GetTotalWritten() {
-    return total_written + offset;
+	return total_written + offset;
 }
-
 
 void BufferedFileWriter::WriteData(const_data_ptr_t buffer, uint64_t write_size) {
 	// first copy anything we can from the buffer
@@ -55,3 +54,5 @@ void BufferedFileWriter::Truncate(int64_t size) {
 	// reset anything written in the buffer
 	offset = 0;
 }
+
+} // namespace duckdb

--- a/src/common/serializer/buffered_serializer.cpp
+++ b/src/common/serializer/buffered_serializer.cpp
@@ -2,7 +2,7 @@
 
 #include <cstring>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BufferedSerializer::BufferedSerializer(idx_t maximum_size)
@@ -28,3 +28,5 @@ void BufferedSerializer::WriteData(const_data_ptr_t buffer, idx_t write_size) {
 	memcpy(blob.data.get() + blob.size, buffer, write_size);
 	blob.size += write_size;
 }
+
+} // namespace duckdb

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -8,7 +8,7 @@
 #include <stdarg.h>
 #include <string.h>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 bool StringUtil::Contains(const string &haystack, const string &needle) {
@@ -191,3 +191,5 @@ string StringUtil::Replace(string source, const string &from, const string &to) 
 	}
 	return source;
 }
+
+} // namespace duckdb

--- a/src/common/types/date.cpp
+++ b/src/common/types/date.cpp
@@ -9,11 +9,13 @@
 #include <cctype>
 #include <algorithm>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
-string_t Date::MonthNamesAbbreviated[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
-string_t Date::MonthNames[] = {"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"};
+string_t Date::MonthNamesAbbreviated[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                                          "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+string_t Date::MonthNames[] = {"January", "February", "March",     "April",   "May",      "June",
+                               "July",    "August",   "September", "October", "November", "December"};
 string_t Date::DayNames[] = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
 string_t Date::DayNamesAbbreviated[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
 
@@ -161,10 +163,8 @@ bool Date::TryConvertDate(const char *buf, idx_t &pos, date_t &result, bool stri
 	}
 
 	// check for an optional trailing " (BC)""
-	if (std::isspace(buf[pos]) && buf[pos + 1] == '(' &&
-	                              buf[pos + 2] == 'B' &&
-								  buf[pos + 3] == 'C' &&
-								  buf[pos + 4] == ')') {
+	if (std::isspace(buf[pos]) && buf[pos + 1] == '(' && buf[pos + 2] == 'B' && buf[pos + 3] == 'C' &&
+	    buf[pos + 4] == ')') {
 		year = -year;
 		pos += 5;
 	}
@@ -363,3 +363,5 @@ date_t Date::GetMondayOfCurrentWeek(date_t date) {
 
 	return (Date::FromDate(year, month, day));
 }
+
+} // namespace duckdb

--- a/src/common/types/hyperloglog.cpp
+++ b/src/common/types/hyperloglog.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/common/exception.hpp"
 #include "hyperloglog.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 HyperLogLog::HyperLogLog() : hll(nullptr) {
@@ -54,3 +54,5 @@ unique_ptr<HyperLogLog> HyperLogLog::Merge(HyperLogLog logs[], idx_t count) {
 	}
 	return unique_ptr<HyperLogLog>(new HyperLogLog((void *)new_hll));
 }
+
+} // namespace duckdb

--- a/src/common/types/string_heap.cpp
+++ b/src/common/types/string_heap.cpp
@@ -7,7 +7,7 @@
 
 #include <cstring>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 #define MINIMUM_HEAP_SIZE 4096
@@ -67,3 +67,5 @@ void StringHeap::MergeHeap(StringHeap &other) {
 	}
 	other.tail = nullptr;
 }
+
+} // namespace duckdb

--- a/src/common/types/time.cpp
+++ b/src/common/types/time.cpp
@@ -10,7 +10,7 @@
 #include <sstream>
 #include <cctype>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 // string format is hh:mm:ssZ
@@ -175,3 +175,5 @@ bool Time::IsValidTime(int32_t hour, int32_t minute, int32_t second, int32_t mil
 void Time::Convert(dtime_t time, int32_t &out_hour, int32_t &out_min, int32_t &out_sec, int32_t &out_msec) {
 	number_to_time(time, out_hour, out_min, out_sec, out_msec);
 }
+
+} // namespace duckdb

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -21,7 +21,7 @@
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/common/string_util.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 Value::Value(string_t val) : Value(string(val.GetData(), val.GetSize())) {
@@ -255,7 +255,7 @@ Value Value::BLOB(string data, bool must_cast) {
 	// single '\x' is a special char for hex chars in C++,
 	// e.g., '\xAA' will be transformed into the char "ª" (1010 1010),
 	// and Postgres uses double "\\x" for hex -> SELECT E'\\xDEADBEEF';
-	if(must_cast && data.size() >= 2 && data.substr(0,2) == "\\x") {
+	if (must_cast && data.size() >= 2 && data.substr(0, 2) == "\\x") {
 		size_t hex_size = (data.size() - 2) / 2;
 		unique_ptr<char[]> hex_data(new char[hex_size + 1]);
 		string_t hex_str(hex_data.get(), hex_size);
@@ -732,3 +732,5 @@ bool Value::ValuesAreEqual(Value result_value, Value value) {
 		return value == result_value;
 	}
 }
+
+} // namespace duckdb

--- a/src/common/types/vector_buffer.cpp
+++ b/src/common/types/vector_buffer.cpp
@@ -4,7 +4,7 @@
 
 #include "duckdb/common/assert.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 VectorBuffer::VectorBuffer(idx_t data_size) : type(VectorBufferType::STANDARD_BUFFER) {
@@ -39,3 +39,5 @@ void VectorListBuffer::SetChild(unique_ptr<ChunkCollection> new_child) {
 
 VectorListBuffer::~VectorListBuffer() {
 }
+
+} // namespace duckdb

--- a/src/common/value_operations/comparison_operations.cpp
+++ b/src/common/value_operations/comparison_operations.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/common/value_operations/value_operations.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 //===--------------------------------------------------------------------===//
@@ -114,3 +114,5 @@ bool ValueOperations::LessThan(const Value &left, const Value &right) {
 bool ValueOperations::LessThanEquals(const Value &left, const Value &right) {
 	return ValueOperations::GreaterThanEquals(right, left);
 }
+
+} // namespace duckdb

--- a/src/common/value_operations/hash.cpp
+++ b/src/common/value_operations/hash.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/value_operations/value_operations.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 hash_t ValueOperations::Hash(const Value &op) {
@@ -35,3 +35,5 @@ hash_t ValueOperations::Hash(const Value &op) {
 		throw NotImplementedException("Unimplemented type for value hash");
 	}
 }
+
+} // namespace duckdb

--- a/src/common/value_operations/numeric_operations.cpp
+++ b/src/common/value_operations/numeric_operations.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/common/value_operations/value_operations.hpp"
 #include "duckdb/common/operator/aggregate_operators.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 template <class OP, bool IGNORE_NULL> static Value templated_binary_operation(const Value &left, const Value &right) {
@@ -161,3 +161,5 @@ Value ValueOperations::Divide(const Value &left, const Value &right) {
 // Value ValueOperations::Max(const Value &left, const Value &right) {
 // 	return templated_binary_operation<duckdb::Max, true>(left, right);
 // }
+
+} // namespace duckdb

--- a/src/common/vector_operations/boolean_operators.cpp
+++ b/src/common/vector_operations/boolean_operators.cpp
@@ -8,7 +8,7 @@
 #include "duckdb/common/vector_operations/unary_executor.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 //===--------------------------------------------------------------------===//
@@ -170,3 +170,5 @@ void VectorOperations::Not(Vector &input, Vector &result, idx_t count) {
 	assert(input.type == TypeId::BOOL && result.type == TypeId::BOOL);
 	UnaryExecutor::Execute<bool, bool, NotOperator>(input, result, count);
 }
+
+} // namespace duckdb

--- a/src/common/vector_operations/comparison_operators.cpp
+++ b/src/common/vector_operations/comparison_operators.cpp
@@ -9,7 +9,7 @@
 #include "duckdb/common/vector_operations/binary_executor.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 struct ComparisonExecutor {
@@ -84,3 +84,5 @@ void VectorOperations::GreaterThan(Vector &left, Vector &right, Vector &result, 
 void VectorOperations::LessThan(Vector &left, Vector &right, Vector &result, idx_t count) {
 	ComparisonExecutor::Execute<duckdb::LessThan>(left, right, result, count);
 }
+
+} // namespace duckdb

--- a/src/common/vector_operations/gather.cpp
+++ b/src/common/vector_operations/gather.cpp
@@ -8,7 +8,7 @@
 #include "duckdb/common/types/null_value.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 template <class T> static void templated_gather_loop(Vector &source, Vector &dest, idx_t count) {
@@ -68,3 +68,5 @@ void VectorOperations::Gather::Set(Vector &source, Vector &dest, idx_t count) {
 		throw NotImplementedException("Unimplemented type for gather");
 	}
 }
+
+} // namespace duckdb

--- a/src/common/vector_operations/generators.cpp
+++ b/src/common/vector_operations/generators.cpp
@@ -7,7 +7,7 @@
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/common/limits.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 template <class T> void templated_generate_sequence(Vector &result, idx_t count, int64_t start, int64_t increment) {
@@ -96,3 +96,5 @@ void VectorOperations::GenerateSequence(Vector &result, idx_t count, const Selec
 		throw NotImplementedException("Unimplemented type for generate sequence");
 	}
 }
+
+} // namespace duckdb

--- a/src/common/vector_operations/null_operations.cpp
+++ b/src/common/vector_operations/null_operations.cpp
@@ -7,7 +7,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 template <bool INVERSE> void is_null_loop(Vector &input, Vector &result, idx_t count) {
@@ -84,3 +84,5 @@ bool VectorOperations::HasNull(Vector &input, idx_t count) {
 		return false;
 	}
 }
+
+} // namespace duckdb

--- a/src/common/vector_operations/numeric_inplace_operators.cpp
+++ b/src/common/vector_operations/numeric_inplace_operators.cpp
@@ -8,7 +8,7 @@
 
 #include <algorithm>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 //===--------------------------------------------------------------------===//
@@ -34,3 +34,5 @@ void VectorOperations::AddInPlace(Vector &input, int64_t right, idx_t count) {
 	}
 	}
 }
+
+} // namespace duckdb

--- a/src/common/vector_operations/vector_cast.cpp
+++ b/src/common/vector_operations/vector_cast.cpp
@@ -7,7 +7,7 @@
 #include "duckdb/common/vector_operations/unary_executor.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 template <class SRC, class OP> static void string_cast(Vector &source, Vector &result, idx_t count) {
@@ -91,7 +91,7 @@ static void numeric_cast_switch(Vector &source, Vector &result, SQLType source_t
 
 template <class OP>
 static void string_cast_numeric_switch(Vector &source, Vector &result, SQLType source_type, SQLType target_type,
-                                      idx_t count) {
+                                       idx_t count) {
 	// now switch on the result type
 	switch (target_type.id) {
 	case SQLTypeId::BOOLEAN:
@@ -227,7 +227,8 @@ static void timestamp_cast_switch(Vector &source, Vector &result, SQLType source
 	}
 }
 
-static void interval_cast_switch(Vector &source, Vector &result, SQLType source_type, SQLType target_type, idx_t count) {
+static void interval_cast_switch(Vector &source, Vector &result, SQLType source_type, SQLType target_type,
+                                 idx_t count) {
 	// now switch on the result type
 	switch (target_type.id) {
 	case SQLTypeId::VARCHAR:
@@ -240,8 +241,7 @@ static void interval_cast_switch(Vector &source, Vector &result, SQLType source_
 	}
 }
 
-static void blob_cast_switch(Vector &source, Vector &result, SQLType source_type, SQLType target_type,
-                                  idx_t count) {
+static void blob_cast_switch(Vector &source, Vector &result, SQLType source_type, SQLType target_type, idx_t count) {
 	// now switch on the result type
 	switch (target_type.id) {
 	case SQLTypeId::VARCHAR:
@@ -331,3 +331,5 @@ void VectorOperations::Cast(Vector &source, Vector &result, idx_t count, bool st
 	return VectorOperations::Cast(source, result, SQLTypeFromInternalType(source.type),
 	                              SQLTypeFromInternalType(result.type), count, strict);
 }
+
+} // namespace duckdb

--- a/src/common/vector_operations/vector_copy.cpp
+++ b/src/common/vector_operations/vector_copy.cpp
@@ -10,7 +10,7 @@
 
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 template <class T>
@@ -197,3 +197,5 @@ void VectorOperations::Copy(Vector &source, Vector &target, idx_t source_count, 
 		break;
 	}
 }
+
+} // namespace duckdb

--- a/src/common/vector_operations/vector_hash.cpp
+++ b/src/common/vector_operations/vector_hash.cpp
@@ -7,7 +7,7 @@
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/types/null_value.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 struct HashOp {
@@ -216,3 +216,5 @@ void VectorOperations::CombineHash(Vector &hashes, Vector &input, idx_t count) {
 void VectorOperations::CombineHash(Vector &hashes, Vector &input, const SelectionVector &rsel, idx_t count) {
 	combine_hash_type_switch<true>(hashes, input, &rsel, count);
 }
+
+} // namespace duckdb

--- a/src/execution/adaptive_filter.cpp
+++ b/src/execution/adaptive_filter.cpp
@@ -1,10 +1,10 @@
-#include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/execution/adaptive_filter.hpp"
 #include <vector>
 
-using namespace duckdb;
 using namespace std;
+
+namespace duckdb {
 
 AdaptiveFilter::AdaptiveFilter(Expression &expr)
     : iteration_count(0), observe_interval(10), execute_interval(20), warmup(true) {
@@ -87,3 +87,5 @@ void AdaptiveFilter::AdaptRuntimeStatistics(double duration) {
 		}
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -12,7 +12,7 @@
 #include <cmath>
 #include <map>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 SuperLargeHashTable::SuperLargeHashTable(idx_t initial_capacity, vector<TypeId> group_types,
@@ -630,3 +630,4 @@ idx_t SuperLargeHashTable::Scan(idx_t &scan_position, DataChunk &groups, DataChu
 	scan_position = ptr - data;
 	return entry;
 }
+} // namespace duckdb

--- a/src/execution/column_binding_resolver.cpp
+++ b/src/execution/column_binding_resolver.cpp
@@ -9,7 +9,7 @@
 
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 ColumnBindingResolver::ColumnBindingResolver() {
@@ -92,3 +92,5 @@ unique_ptr<Expression> ColumnBindingResolver::VisitReplace(BoundColumnRefExpress
 	throw InternalException("Failed to bind column reference \"%s\" [%d.%d] (bindings: %s)", expr.alias.c_str(),
 	                        (int)expr.binding.table_index, (int)expr.binding.column_index, bound_columns.c_str());
 }
+
+} // namespace duckdb

--- a/src/execution/expression_executor.cpp
+++ b/src/execution/expression_executor.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 ExpressionExecutor::ExpressionExecutor() {
@@ -237,3 +237,5 @@ idx_t ExpressionExecutor::DefaultSelect(Expression &expr, ExpressionState *state
 		return DefaultSelectSwitch<true>(idata, sel, count, true_sel, false_sel);
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/expression_executor/execute_between.cpp
+++ b/src/execution/expression_executor/execute_between.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/common/vector_operations/ternary_executor.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 struct BothInclusiveBetweenOperator {
@@ -50,7 +50,7 @@ static idx_t between_loop_type_switch(Vector &input, Vector &lower, Vector &uppe
 		                                                              false_sel);
 	case TypeId::INT128:
 		return TernaryExecutor::Select<hugeint_t, hugeint_t, hugeint_t, OP>(input, lower, upper, sel, count, true_sel,
-		                                                              false_sel);
+		                                                                    false_sel);
 	case TypeId::FLOAT:
 		return TernaryExecutor::Select<float, float, float, OP>(input, lower, upper, sel, count, true_sel, false_sel);
 	case TypeId::DOUBLE:
@@ -121,3 +121,5 @@ idx_t ExpressionExecutor::Select(BoundBetweenExpression &expr, ExpressionState *
 		return between_loop_type_switch<ExclusiveBetweenOperator>(input, lower, upper, sel, count, true_sel, false_sel);
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/expression_executor/execute_case.cpp
+++ b/src/execution/expression_executor/execute_case.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/planner/expression/bound_case_expression.hpp"
 #include "duckdb/common/types/chunk_collection.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 void Case(Vector &res_true, Vector &res_false, Vector &result, SelectionVector &tside, idx_t tcount,
@@ -159,3 +159,5 @@ void Case(Vector &res_true, Vector &res_false, Vector &result, SelectionVector &
 		                              TypeIdToString(result.type).c_str());
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/expression_executor/execute_cast.cpp
+++ b/src/execution/expression_executor/execute_cast.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(BoundCastExpression &expr,
@@ -27,3 +27,5 @@ void ExpressionExecutor::Execute(BoundCastExpression &expr, ExpressionState *sta
 		VectorOperations::Cast(child, result, expr.source_type, expr.target_type, count);
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/expression_executor/execute_comparison.cpp
+++ b/src/execution/expression_executor/execute_comparison.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/common/vector_operations/binary_executor.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(BoundComparisonExpression &expr,
@@ -105,3 +105,5 @@ idx_t ExpressionExecutor::Select(BoundComparisonExpression &expr, ExpressionStat
 		throw NotImplementedException("Unknown comparison type!");
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/expression_executor/execute_conjunction.cpp
+++ b/src/execution/expression_executor/execute_conjunction.cpp
@@ -6,16 +6,15 @@
 #include <chrono>
 #include <random>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 using namespace chrono;
 
 struct ConjunctionState : public ExpressionState {
-	ConjunctionState(Expression &expr, ExpressionExecutorState &root)
-	    : ExpressionState(expr, root) {
-        adaptive_filter = make_unique<AdaptiveFilter>(expr);
-    }
-     unique_ptr<AdaptiveFilter> adaptive_filter;
+	ConjunctionState(Expression &expr, ExpressionExecutorState &root) : ExpressionState(expr, root) {
+		adaptive_filter = make_unique<AdaptiveFilter>(expr);
+	}
+	unique_ptr<AdaptiveFilter> adaptive_filter;
 };
 
 unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(BoundConjunctionExpression &expr,
@@ -75,9 +74,9 @@ idx_t ExpressionExecutor::Select(BoundConjunctionExpression &expr, ExpressionSta
 			true_sel = temp_true.get();
 		}
 		for (idx_t i = 0; i < expr.children.size(); i++) {
-			idx_t tcount =
-			    Select(*expr.children[state->adaptive_filter->permutation[i]], state->child_states[state->adaptive_filter->permutation[i]].get(),
-			           current_sel, current_count, true_sel, temp_false.get());
+			idx_t tcount = Select(*expr.children[state->adaptive_filter->permutation[i]],
+			                      state->child_states[state->adaptive_filter->permutation[i]].get(), current_sel,
+			                      current_count, true_sel, temp_false.get());
 			idx_t fcount = current_count - tcount;
 			if (fcount > 0 && false_sel) {
 				// move failing tuples into the false_sel
@@ -99,8 +98,7 @@ idx_t ExpressionExecutor::Select(BoundConjunctionExpression &expr, ExpressionSta
 
 		// adapt runtime statistics
 		auto end_time = high_resolution_clock::now();
-		state->adaptive_filter->AdaptRuntimeStatistics(
-		                       duration_cast<duration<double>>(end_time - start_time).count());
+		state->adaptive_filter->AdaptRuntimeStatistics(duration_cast<duration<double>>(end_time - start_time).count());
 		return current_count;
 	} else {
 		// get runtime statistics
@@ -119,9 +117,9 @@ idx_t ExpressionExecutor::Select(BoundConjunctionExpression &expr, ExpressionSta
 			false_sel = temp_false.get();
 		}
 		for (idx_t i = 0; i < expr.children.size(); i++) {
-			idx_t tcount =
-			    Select(*expr.children[state->adaptive_filter->permutation[i]], state->child_states[state->adaptive_filter->permutation[i]].get(),
-			           current_sel, current_count, temp_true.get(), false_sel);
+			idx_t tcount = Select(*expr.children[state->adaptive_filter->permutation[i]],
+			                      state->child_states[state->adaptive_filter->permutation[i]].get(), current_sel,
+			                      current_count, temp_true.get(), false_sel);
 			if (tcount > 0) {
 				if (true_sel) {
 					// tuples passed, move them into the actual result vector
@@ -137,8 +135,9 @@ idx_t ExpressionExecutor::Select(BoundConjunctionExpression &expr, ExpressionSta
 
 		// adapt runtime statistics
 		auto end_time = high_resolution_clock::now();
-		state->adaptive_filter->AdaptRuntimeStatistics(
-		                      duration_cast<duration<double>>(end_time - start_time).count());
+		state->adaptive_filter->AdaptRuntimeStatistics(duration_cast<duration<double>>(end_time - start_time).count());
 		return result_count;
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/expression_executor/execute_constant.cpp
+++ b/src/execution/expression_executor/execute_constant.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(BoundConstantExpression &expr,
@@ -14,3 +14,5 @@ void ExpressionExecutor::Execute(BoundConstantExpression &expr, ExpressionState 
                                  idx_t count, Vector &result) {
 	result.Reference(expr.value);
 }
+
+} // namespace duckdb

--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 struct FunctionState : public ExpressionState {
@@ -50,3 +50,5 @@ void ExpressionExecutor::Execute(BoundFunctionExpression &expr, ExpressionState 
 		                            "but the function returned the latter");
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/expression_executor/execute_operator.cpp
+++ b/src/execution/expression_executor/execute_operator.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(BoundOperatorExpression &expr,
@@ -81,3 +81,5 @@ void ExpressionExecutor::Execute(BoundOperatorExpression &expr, ExpressionState 
 		throw NotImplementedException("operator");
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/expression_executor/execute_parameter.cpp
+++ b/src/execution/expression_executor/execute_parameter.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(BoundParameterExpression &expr,
@@ -16,3 +16,5 @@ void ExpressionExecutor::Execute(BoundParameterExpression &expr, ExpressionState
 	assert(expr.value->type == expr.return_type);
 	result.Reference(*expr.value);
 }
+
+} // namespace duckdb

--- a/src/execution/expression_executor/execute_reference.cpp
+++ b/src/execution/expression_executor/execute_reference.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(BoundReferenceExpression &expr,
@@ -19,3 +19,5 @@ void ExpressionExecutor::Execute(BoundReferenceExpression &expr, ExpressionState
 		result.Reference(chunk->data[expr.index]);
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/expression_executor_state.cpp
+++ b/src/execution/expression_executor_state.cpp
@@ -2,9 +2,11 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 void ExpressionState::AddChild(Expression *expr) {
 	child_states.push_back(ExpressionExecutor::InitializeState(*expr, root));
 }
+
+} // namespace duckdb

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -4,11 +4,11 @@
 #include <algorithm>
 #include <ctgmath>
 
-using namespace duckdb;
+namespace duckdb {
+
 using namespace std;
 
-ART::ART(vector<column_t> column_ids, vector<unique_ptr<Expression>> unbound_expressions,
-         bool is_unique)
+ART::ART(vector<column_t> column_ids, vector<unique_ptr<Expression>> unbound_expressions, bool is_unique)
     : Index(IndexType::ART, column_ids, move(unbound_expressions)), is_unique(is_unique) {
 	tree = nullptr;
 	expression_result.Initialize(types);
@@ -796,3 +796,4 @@ void ART::Scan(Transaction &transaction, DataTable &table, TableIndexScanState &
 	// move to the next set of row ids
 	state->result_index += scan_count;
 }
+} // namespace duckdb

--- a/src/execution/index/art/art_key.cpp
+++ b/src/execution/index/art/art_key.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/execution/index/art/art_key.hpp"
 #include "duckdb/execution/index/art/art.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 
 //! these are optimized and assume a particular byte order
 #define BSWAP16(x) ((uint16_t)((((uint16_t)(x)&0xff00) >> 8) | (((uint16_t)(x)&0x00ff) << 8)))
@@ -181,3 +181,4 @@ bool Key::operator==(const Key &k) const {
 	}
 	return true;
 }
+} // namespace duckdb

--- a/src/execution/index/art/leaf.cpp
+++ b/src/execution/index/art/leaf.cpp
@@ -3,7 +3,7 @@
 
 #include <cstring>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 Leaf::Leaf(ART &art, unique_ptr<Key> value, row_t row_id) : Node(art, NodeType::NLeaf, 0) {
@@ -42,3 +42,5 @@ void Leaf::Remove(row_t row_id) {
 		row_ids[j] = row_ids[j + 1];
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/index/art/node.cpp
+++ b/src/execution/index/art/node.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/index/art/art.hpp"
 #include "duckdb/common/exception.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 
 Node::Node(ART &art, NodeType type, size_t compressedPrefixSize) : prefix_length(0), count(0), type(type) {
 	this->prefix = unique_ptr<uint8_t[]>(new uint8_t[compressedPrefixSize]);
@@ -74,3 +74,5 @@ void Node::Erase(ART &art, unique_ptr<Node> &node, idx_t pos) {
 		break;
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/index/art/node16.cpp
+++ b/src/execution/index/art/node16.cpp
@@ -4,7 +4,7 @@
 
 #include <cstring>
 
-using namespace duckdb;
+namespace duckdb {
 
 Node16::Node16(ART &art, size_t compressionLength) : Node(art, NodeType::N16, compressionLength) {
 	memset(key, 16, sizeof(key));
@@ -105,3 +105,5 @@ void Node16::erase(ART &art, unique_ptr<Node> &node, int pos) {
 		node = move(newNode);
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/index/art/node256.cpp
+++ b/src/execution/index/art/node256.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/execution/index/art/node48.hpp"
 #include "duckdb/execution/index/art/node256.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 
 Node256::Node256(ART &art, size_t compressionLength) : Node(art, NodeType::N256, compressionLength) {
 }
@@ -76,3 +76,5 @@ void Node256::erase(ART &art, unique_ptr<Node> &node, int pos) {
 		node = move(newNode);
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/index/art/node4.cpp
+++ b/src/execution/index/art/node4.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/index/art/node16.hpp"
 #include "duckdb/execution/index/art/art.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 
 Node4::Node4(ART &art, size_t compressionLength) : Node(art, NodeType::N4, compressionLength) {
 	memset(key, 0, sizeof(key));
@@ -118,3 +118,5 @@ void Node4::erase(ART &art, unique_ptr<Node> &node, int pos) {
 		node = move(n->child[0]);
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/index/art/node48.cpp
+++ b/src/execution/index/art/node48.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/index/art/node48.hpp"
 #include "duckdb/execution/index/art/node256.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 
 Node48::Node48(ART &art, size_t compressionLength) : Node(art, NodeType::N48, compressionLength) {
 	for (idx_t i = 0; i < 256; i++) {
@@ -105,3 +105,5 @@ void Node48::erase(ART &art, unique_ptr<Node> &node, int pos) {
 		node = move(newNode);
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/nested_loop_join/nested_loop_join_inner.cpp
+++ b/src/execution/nested_loop_join/nested_loop_join_inner.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/execution/nested_loop_join.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 struct InitialNestedLoopJoin {
@@ -97,8 +97,8 @@ static idx_t nested_loop_join_inner_operator(Vector &left, Vector &right, idx_t 
 		return NLTYPE::template Operation<int64_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector, rvector,
 		                                               current_match_count);
 	case TypeId::INT128:
-		return NLTYPE::template Operation<hugeint_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector, rvector,
-		                                               current_match_count);
+		return NLTYPE::template Operation<hugeint_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector,
+		                                                 rvector, current_match_count);
 	case TypeId::FLOAT:
 		return NLTYPE::template Operation<float, OP>(left, right, left_size, right_size, lpos, rpos, lvector, rvector,
 		                                             current_match_count);
@@ -106,8 +106,8 @@ static idx_t nested_loop_join_inner_operator(Vector &left, Vector &right, idx_t 
 		return NLTYPE::template Operation<double, OP>(left, right, left_size, right_size, lpos, rpos, lvector, rvector,
 		                                              current_match_count);
 	case TypeId::INTERVAL:
-		return NLTYPE::template Operation<interval_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector, rvector,
-		                                              current_match_count);
+		return NLTYPE::template Operation<interval_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector,
+		                                                  rvector, current_match_count);
 	case TypeId::VARCHAR:
 		return NLTYPE::template Operation<string_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector,
 		                                                rvector, current_match_count);
@@ -173,3 +173,5 @@ idx_t NestedLoopJoinInner::Perform(idx_t &lpos, idx_t &rpos, DataChunk &left_con
 	}
 	return match_count;
 }
+
+} // namespace duckdb

--- a/src/execution/nested_loop_join/nested_loop_join_mark.cpp
+++ b/src/execution/nested_loop_join/nested_loop_join_mark.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/nested_loop_join.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 template <class T, class OP>
@@ -90,3 +90,5 @@ void NestedLoopJoinMark::Perform(DataChunk &left, ChunkCollection &right, bool f
 		}
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -6,7 +6,7 @@
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 PhysicalHashAggregate::PhysicalHashAggregate(vector<TypeId> types, vector<unique_ptr<Expression>> expressions,
@@ -214,3 +214,5 @@ unique_ptr<PhysicalOperatorState> PhysicalHashAggregate::GetOperatorState() {
 	return make_unique<PhysicalHashAggregateState>(group_types, aggregate_types,
 	                                               children.size() == 0 ? nullptr : children[0].get());
 }
+
+} // namespace duckdb

--- a/src/execution/operator/aggregate/physical_simple_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_simple_aggregate.cpp
@@ -5,8 +5,8 @@
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 
-using namespace duckdb;
 using namespace std;
+namespace duckdb {
 
 PhysicalSimpleAggregate::PhysicalSimpleAggregate(vector<TypeId> types, vector<unique_ptr<Expression>> expressions,
                                                  bool all_combinable)
@@ -17,6 +17,7 @@ PhysicalSimpleAggregate::PhysicalSimpleAggregate(vector<TypeId> types, vector<un
 //===--------------------------------------------------------------------===//
 // Sink
 //===--------------------------------------------------------------------===//
+
 struct AggregateState {
 	AggregateState(vector<unique_ptr<Expression>> &aggregate_expressions) {
 		for (auto &aggregate : aggregate_expressions) {
@@ -179,3 +180,5 @@ void PhysicalSimpleAggregate::GetChunkInternal(ExecutionContext &context, DataCh
 	}
 	state->finished = true;
 }
+
+} // namespace duckdb

--- a/src/execution/operator/join/physical_cross_product.cpp
+++ b/src/execution/operator/join/physical_cross_product.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 class PhysicalCrossProductOperatorState : public PhysicalOperatorState {
@@ -89,3 +89,5 @@ void PhysicalCrossProduct::GetChunkInternal(ExecutionContext &context, DataChunk
 unique_ptr<PhysicalOperatorState> PhysicalCrossProduct::GetOperatorState() {
 	return make_unique<PhysicalCrossProductOperatorState>(children[0].get(), children[1].get());
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_aggregate.cpp
+++ b/src/execution/physical_plan/plan_aggregate.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAggregate &op) {
@@ -49,3 +49,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAggregate 
 	groupby->children.push_back(move(plan));
 	return groupby;
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_any_join.cpp
+++ b/src/execution/physical_plan/plan_any_join.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_any_join.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAnyJoin &op) {
@@ -16,3 +16,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAnyJoin &o
 	// create the blockwise NL join
 	return make_unique<PhysicalBlockwiseNLJoin>(op, move(left), move(right), move(op.condition), op.join_type);
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_chunk_get.cpp
+++ b/src/execution/physical_plan/plan_chunk_get.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_chunk_get.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalChunkGet &op) {
@@ -15,3 +15,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalChunkGet &
 	chunk_scan->collection = chunk_scan->owned_collection.get();
 	return move(chunk_scan);
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_comparison_join.cpp
+++ b/src/execution/physical_plan/plan_comparison_join.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalComparisonJoin &op) {
@@ -54,3 +54,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalComparison
 	}
 	return plan;
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_copy_from_file.cpp
+++ b/src/execution/physical_plan/plan_copy_from_file.cpp
@@ -2,10 +2,12 @@
 #include "duckdb/execution/operator/persistent/physical_copy_from_file.hpp"
 #include "duckdb/planner/operator/logical_copy_from_file.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCopyFromFile &op) {
 	// COPY from file into a table
 	return make_unique<PhysicalCopyFromFile>(op.types, op.function, move(op.info), move(op.sql_types));
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_copy_to_file.cpp
+++ b/src/execution/physical_plan/plan_copy_to_file.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/operator/persistent/physical_copy_to_file.hpp"
 #include "duckdb/planner/operator/logical_copy_to_file.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile &op) {
@@ -13,3 +13,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile
 	copy->children.push_back(move(plan));
 	return move(copy);
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_create_index.cpp
+++ b/src/execution/physical_plan/plan_create_index.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_create_index.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreateIndex &op) {
@@ -12,3 +12,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreateInde
 	return make_unique<PhysicalCreateIndex>(op, op.table, op.column_ids, move(op.expressions), move(op.info),
 	                                        move(op.unbound_expressions));
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_create_table.cpp
+++ b/src/execution/physical_plan/plan_create_table.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_create_table.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 static void ExtractDependencies(Expression &expr, unordered_set<CatalogEntry *> &dependencies) {
@@ -33,3 +33,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreateTabl
 	}
 	return move(create);
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_cross_product.cpp
+++ b/src/execution/physical_plan/plan_cross_product.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_cross_product.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCrossProduct &op) {
@@ -12,3 +12,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCrossProdu
 	auto right = CreatePlan(*op.children[1]);
 	return make_unique<PhysicalCrossProduct>(op.types, move(left), move(right));
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_delete.cpp
+++ b/src/execution/physical_plan/plan_delete.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_delete.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelete &op) {
@@ -22,3 +22,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelete &op
 	del->children.push_back(move(plan));
 	return move(del);
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_delim_get.cpp
+++ b/src/execution/physical_plan/plan_delim_get.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_delim_get.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelimGet &op) {
@@ -12,3 +12,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelimGet &
 	auto chunk_scan = make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::DELIM_SCAN);
 	return move(chunk_scan);
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_distinct.cpp
+++ b/src/execution/physical_plan/plan_distinct.cpp
@@ -7,7 +7,7 @@
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_distinct.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreateDistinct(unique_ptr<PhysicalOperator> child) {
@@ -69,3 +69,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDistinct &
 		return CreateDistinct(move(plan));
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_empty_result.cpp
+++ b/src/execution/physical_plan/plan_empty_result.cpp
@@ -2,10 +2,12 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_empty_result.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalEmptyResult &op) {
 	assert(op.children.size() == 0);
 	return make_unique<PhysicalEmptyResult>(op.types);
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_execute.cpp
+++ b/src/execution/physical_plan/plan_execute.cpp
@@ -2,10 +2,12 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_execute.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExecute &op) {
 	assert(op.children.size() == 0);
 	return make_unique<PhysicalExecute>(op.prepared->plan.get());
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_explain.cpp
+++ b/src/execution/physical_plan/plan_explain.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_explain.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExplain &op) {
@@ -37,3 +37,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExplain &o
 	chunk_scan->collection = chunk_scan->owned_collection.get();
 	return move(chunk_scan);
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_expression_get.cpp
+++ b/src/execution/physical_plan/plan_expression_get.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_expression_get.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExpressionGet &op) {
@@ -13,3 +13,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExpression
 	expr_scan->children.push_back(move(plan));
 	return move(expr_scan);
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_filter.cpp
+++ b/src/execution/physical_plan/plan_filter.cpp
@@ -8,7 +8,7 @@
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalFilter &op) {
@@ -32,3 +32,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalFilter &op
 	}
 	return plan;
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
@@ -31,3 +31,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 		                                      move(table_filter_umap));
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_index_scan.cpp
+++ b/src/execution/physical_plan/plan_index_scan.cpp
@@ -3,7 +3,7 @@
 
 #include "duckdb/planner/operator/logical_index_scan.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalIndexScan &op) {
@@ -26,3 +26,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalIndexScan 
 	plan = move(node);
 	return plan;
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_insert.cpp
+++ b/src/execution/physical_plan/plan_insert.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_insert.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalInsert &op) {
@@ -20,3 +20,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalInsert &op
 	}
 	return move(insert);
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_limit.cpp
+++ b/src/execution/physical_plan/plan_limit.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_limit.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalLimit &op) {
@@ -14,3 +14,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalLimit &op)
 	limit->children.push_back(move(plan));
 	return move(limit);
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_order.cpp
+++ b/src/execution/physical_plan/plan_order.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_order.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalOrder &op) {
@@ -16,3 +16,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalOrder &op)
 	}
 	return plan;
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_prepare.cpp
+++ b/src/execution/physical_plan/plan_prepare.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/planner/operator/logical_prepare.hpp"
 #include "duckdb/execution/operator/helper/physical_prepare.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalPrepare &op) {
@@ -17,3 +17,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalPrepare &o
 
 	return make_unique<PhysicalPrepare>(op.name, move(op.prepared));
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_projection.cpp
+++ b/src/execution/physical_plan/plan_projection.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalProjection &op) {
@@ -19,3 +19,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalProjection
 	projection->children.push_back(move(plan));
 	return move(projection);
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_recursive_cte.cpp
+++ b/src/execution/physical_plan/plan_recursive_cte.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/planner/operator/logical_recursive_cte.hpp"
 #include "duckdb/planner/operator/logical_cteref.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalRecursiveCTE &op) {
@@ -39,3 +39,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCTERef &op
 	chunk_scan->collection = cte->second.get();
 	return move(chunk_scan);
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_set_operation.cpp
+++ b/src/execution/physical_plan/plan_set_operation.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_set_operation.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSetOperation &op) {
@@ -42,3 +42,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSetOperati
 	}
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_simple.cpp
+++ b/src/execution/physical_plan/plan_simple.cpp
@@ -11,7 +11,7 @@
 #include "duckdb/execution/operator/schema/physical_drop.hpp"
 #include "duckdb/execution/operator/helper/physical_vacuum.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSimple &op) {
@@ -30,3 +30,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSimple &op
 		throw NotImplementedException("Unimplemented type for logical simple operator");
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_table_function.cpp
+++ b/src/execution/physical_plan/plan_table_function.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_table_function.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalTableFunction &op) {
@@ -14,3 +14,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalTableFunct
 	tfd->column_ids = op.column_ids;
 	return make_unique<PhysicalTableFunction>(op.types, op.function, move(op.bind_data), move(op.parameters));
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_top_n.cpp
+++ b/src/execution/physical_plan/plan_top_n.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_top_n.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalTopN &op) {
@@ -14,3 +14,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalTopN &op) 
 	top_n->children.push_back(move(plan));
 	return move(top_n);
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_unnest.cpp
+++ b/src/execution/physical_plan/plan_unnest.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_unnest.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalUnnest &op) {
@@ -12,3 +12,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalUnnest &op
 	unnest->children.push_back(move(plan));
 	return move(unnest);
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_update.cpp
+++ b/src/execution/physical_plan/plan_update.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_update.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalUpdate &op) {
@@ -18,3 +18,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalUpdate &op
 	update->children.push_back(move(plan));
 	return move(update);
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan/plan_window.cpp
+++ b/src/execution/physical_plan/plan_window.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_window.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalWindow &op) {
@@ -19,3 +19,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalWindow &op
 	window->children.push_back(move(plan));
 	return move(window);
 }
+
+} // namespace duckdb

--- a/src/execution/physical_plan_generator.cpp
+++ b/src/execution/physical_plan_generator.cpp
@@ -5,10 +5,8 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
-using namespace duckdb;
-using namespace std;
-
 namespace duckdb {
+using namespace std;
 
 class DependencyExtractor : public LogicalOperatorVisitor {
 public:
@@ -27,7 +25,6 @@ protected:
 private:
 	unordered_set<CatalogEntry *> &dependencies;
 };
-} // namespace duckdb
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(unique_ptr<LogicalOperator> op) {
 	// first resolve column references
@@ -136,3 +133,5 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalOperator &
 		throw NotImplementedException("Unimplemented logical operator type!");
 	}
 }
+
+} // namespace duckdb

--- a/src/execution/window_segment_tree.cpp
+++ b/src/execution/window_segment_tree.cpp
@@ -5,14 +5,14 @@
 
 #include <cmath>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 WindowSegmentTree::WindowSegmentTree(AggregateFunction &aggregate, TypeId result_type, ChunkCollection *input)
     : aggregate(aggregate), state(aggregate.state_size()), statep(TypeId::POINTER), result_type(result_type),
       input_ref(input) {
 #if STANDARD_VECTOR_SIZE < 512
-		throw NotImplementedException("Window functions are not supported for vector sizes < 512");
+	throw NotImplementedException("Window functions are not supported for vector sizes < 512");
 #endif
 
 	statep.SetCount(STANDARD_VECTOR_SIZE);
@@ -162,3 +162,5 @@ Value WindowSegmentTree::Compute(idx_t begin, idx_t end) {
 
 	return AggegateFinal();
 }
+
+} // namespace duckdb

--- a/src/function/aggregate/algebraic/avg.cpp
+++ b/src/function/aggregate/algebraic/avg.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/function/function_set.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 template <class T> struct avg_state_t {
@@ -57,3 +57,4 @@ void AvgFun::RegisterFunction(BuiltinFunctions &set) {
 	    SQLType::DOUBLE, SQLType::DOUBLE));
 	set.AddFunction(avg);
 }
+} // namespace duckdb

--- a/src/function/aggregate/algebraic/covar.cpp
+++ b/src/function/aggregate/algebraic/covar.cpp
@@ -6,7 +6,7 @@
 
 #include <cmath>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 struct covar_state_t {
@@ -105,3 +105,5 @@ void CovarSampFun::RegisterFunction(BuiltinFunctions &set) {
 	        SQLType::DOUBLE, SQLType::DOUBLE, SQLType::DOUBLE));
 	set.AddFunction(covar_samp);
 }
+
+} // namespace duckdb

--- a/src/function/aggregate/algebraic/stddev.cpp
+++ b/src/function/aggregate/algebraic/stddev.cpp
@@ -4,7 +4,7 @@
 
 #include <cmath>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 struct stddev_state_t {
@@ -145,3 +145,5 @@ void VarSampFun::RegisterFunction(BuiltinFunctions &set) {
 	    SQLType::DOUBLE, SQLType::DOUBLE));
 	set.AddFunction(var_samp);
 }
+
+} // namespace duckdb

--- a/src/function/cast_rules.cpp
+++ b/src/function/cast_rules.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/function/cast_rules.hpp"
 #include "duckdb/common/exception.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 //! The target type determines the preferred implicit casts
@@ -116,7 +116,6 @@ static int64_t ImplicitCastDate(SQLType to) {
 	}
 }
 
-
 int64_t CastRules::ImplicitCast(SQLType from, SQLType to) {
 	if (to.id == SQLTypeId::ANY) {
 		// anything can be cast to ANY type for no cost
@@ -127,7 +126,7 @@ int64_t CastRules::ImplicitCast(SQLType from, SQLType to) {
 		return TargetTypeCost(to);
 	}
 	if (from.id == SQLTypeId::BLOB && to.id == SQLTypeId::VARCHAR) {
-		//Implicit cast not allowed from BLOB to VARCHAR
+		// Implicit cast not allowed from BLOB to VARCHAR
 		return -1;
 	}
 	if (to.id == SQLTypeId::VARCHAR) {
@@ -155,3 +154,5 @@ int64_t CastRules::ImplicitCast(SQLType from, SQLType to) {
 		return -1;
 	}
 }
+
+} // namespace duckdb

--- a/src/function/scalar/date_functions.cpp
+++ b/src/function/scalar/date_functions.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/function/scalar/date_functions.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 void BuiltinFunctions::RegisterDateFunctions() {
@@ -14,3 +14,5 @@ void BuiltinFunctions::RegisterDateFunctions() {
 	Register<StrfTimeFun>();
 	Register<StrpTimeFun>();
 }
+
+} // namespace duckdb

--- a/src/function/scalar/generic_functions.cpp
+++ b/src/function/scalar/generic_functions.cpp
@@ -1,9 +1,11 @@
 #include "duckdb/function/scalar/generic_functions.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 void BuiltinFunctions::RegisterGenericFunctions() {
 	Register<LeastFun>();
 	Register<GreatestFun>();
 }
+
+} // namespace duckdb

--- a/src/function/scalar/math/random.cpp
+++ b/src/function/scalar/math/random.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include <random>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 struct RandomBindData : public FunctionData {
@@ -40,3 +40,5 @@ unique_ptr<FunctionData> random_bind(BoundFunctionExpression &expr, ClientContex
 void RandomFun::RegisterFunction(BuiltinFunctions &set) {
 	set.AddFunction(ScalarFunction("random", {}, SQLType::DOUBLE, random_function, true, random_bind));
 }
+
+} // namespace duckdb

--- a/src/function/scalar/math/setseed.cpp
+++ b/src/function/scalar/math/setseed.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 struct SetseedBindData : public FunctionData {
@@ -49,3 +49,5 @@ void SetseedFun::RegisterFunction(BuiltinFunctions &set) {
 	set.AddFunction(
 	    ScalarFunction("setseed", {SQLType::DOUBLE}, SQLType::SQLNULL, setseed_function, true, setseed_bind));
 }
+
+} // namespace duckdb

--- a/src/function/scalar/math_functions.cpp
+++ b/src/function/scalar/math_functions.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/function/scalar/math_functions.hpp"
 #include "duckdb/common/exception.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 void BuiltinFunctions::RegisterMathFunctions() {
@@ -29,3 +29,5 @@ void BuiltinFunctions::RegisterMathFunctions() {
 
 	Register<BitCountFun>();
 }
+
+} // namespace duckdb

--- a/src/function/scalar/operators.cpp
+++ b/src/function/scalar/operators.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/function/scalar/operators.hpp"
 #include "duckdb/common/exception.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 void BuiltinFunctions::RegisterOperators() {
@@ -17,3 +17,5 @@ void BuiltinFunctions::RegisterOperators() {
 	Register<BitwiseXorFun>();
 	Register<BitwiseNotFun>();
 }
+
+} // namespace duckdb

--- a/src/function/scalar/operators/bitwise.cpp
+++ b/src/function/scalar/operators/bitwise.cpp
@@ -1,10 +1,8 @@
 #include "duckdb/function/scalar/operators.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 
-using namespace duckdb;
-using namespace std;
-
 namespace duckdb {
+using namespace std;
 
 template <class OP> static scalar_function_t GetScalarIntegerUnaryFunction(SQLType type) {
 	scalar_function_t function;
@@ -66,8 +64,8 @@ struct BitwiseANDOperator {
 void BitwiseAndFun::RegisterFunction(BuiltinFunctions &set) {
 	ScalarFunctionSet functions("&");
 	for (auto &type : SQLType::INTEGRAL) {
-		functions.AddFunction(ScalarFunction({type, type}, type,
-		                                     GetScalarIntegerBinaryFunction<BitwiseANDOperator>(type)));
+		functions.AddFunction(
+		    ScalarFunction({type, type}, type, GetScalarIntegerBinaryFunction<BitwiseANDOperator>(type)));
 	}
 	set.AddFunction(functions);
 }
@@ -84,8 +82,8 @@ struct BitwiseOROperator {
 void BitwiseOrFun::RegisterFunction(BuiltinFunctions &set) {
 	ScalarFunctionSet functions("|");
 	for (auto &type : SQLType::INTEGRAL) {
-		functions.AddFunction(ScalarFunction({type, type}, type,
-		                                     GetScalarIntegerBinaryFunction<BitwiseOROperator>(type)));
+		functions.AddFunction(
+		    ScalarFunction({type, type}, type, GetScalarIntegerBinaryFunction<BitwiseOROperator>(type)));
 	}
 	set.AddFunction(functions);
 }
@@ -102,8 +100,8 @@ struct BitwiseXOROperator {
 void BitwiseXorFun::RegisterFunction(BuiltinFunctions &set) {
 	ScalarFunctionSet functions("#");
 	for (auto &type : SQLType::INTEGRAL) {
-		functions.AddFunction(ScalarFunction({type, type}, type,
-		                                     GetScalarIntegerBinaryFunction<BitwiseXOROperator>(type)));
+		functions.AddFunction(
+		    ScalarFunction({type, type}, type, GetScalarIntegerBinaryFunction<BitwiseXOROperator>(type)));
 	}
 	set.AddFunction(functions);
 }
@@ -124,8 +122,8 @@ struct BitwiseShiftLeftOperator {
 void LeftShiftFun::RegisterFunction(BuiltinFunctions &set) {
 	ScalarFunctionSet functions("<<");
 	for (auto &type : SQLType::INTEGRAL) {
-		functions.AddFunction(ScalarFunction(
-		    {type, type}, type, GetScalarIntegerBinaryFunction<BitwiseShiftLeftOperator>(type)));
+		functions.AddFunction(
+		    ScalarFunction({type, type}, type, GetScalarIntegerBinaryFunction<BitwiseShiftLeftOperator>(type)));
 	}
 	set.AddFunction(functions);
 }
@@ -142,8 +140,8 @@ struct BitwiseShiftRightOperator {
 void RightShiftFun::RegisterFunction(BuiltinFunctions &set) {
 	ScalarFunctionSet functions(">>");
 	for (auto &type : SQLType::INTEGRAL) {
-		functions.AddFunction(ScalarFunction(
-		    {type, type}, type, GetScalarIntegerBinaryFunction<BitwiseShiftRightOperator>(type)));
+		functions.AddFunction(
+		    ScalarFunction({type, type}, type, GetScalarIntegerBinaryFunction<BitwiseShiftRightOperator>(type)));
 	}
 	set.AddFunction(functions);
 }
@@ -160,8 +158,7 @@ struct BitwiseNotOperator {
 void BitwiseNotFun::RegisterFunction(BuiltinFunctions &set) {
 	ScalarFunctionSet functions("~");
 	for (auto &type : SQLType::INTEGRAL) {
-		functions.AddFunction(ScalarFunction(
-		    {type}, type, GetScalarIntegerUnaryFunction<BitwiseNotOperator>(type)));
+		functions.AddFunction(ScalarFunction({type}, type, GetScalarIntegerUnaryFunction<BitwiseNotOperator>(type)));
 	}
 	set.AddFunction(functions);
 }

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -9,7 +9,7 @@
 
 #include "duckdb/common/operator/cast_operators.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 Appender::Appender(Connection &con, string schema_name, string table_name) : con(con), column(0) {
@@ -204,3 +204,4 @@ void Appender::Invalidate(string msg, bool close) {
 	assert(!msg.empty());
 	invalidated_msg = msg;
 }
+} // namespace duckdb

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -11,7 +11,7 @@
 #include "duckdb/main/relation/view_relation.hpp"
 #include "duckdb/parser/parser.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 Connection::Connection(DuckDB &database) : db(database), context(make_unique<ClientContext>(database)) {
@@ -183,3 +183,5 @@ void Connection::Rollback() {
 		throw Exception(result->error);
 	}
 }
+
+} // namespace duckdb

--- a/src/main/connection_manager.cpp
+++ b/src/main/connection_manager.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/connection.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 ConnectionManager::~ConnectionManager() {
@@ -24,3 +24,5 @@ void ConnectionManager::RemoveConnection(Connection *conn) {
 	std::lock_guard<std::mutex> lock(connections_lock);
 	connections.erase(conn);
 }
+
+} // namespace duckdb

--- a/src/main/materialized_query_result.cpp
+++ b/src/main/materialized_query_result.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/main/materialized_query_result.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 MaterializedQueryResult::MaterializedQueryResult(StatementType statement_type)
@@ -53,3 +53,5 @@ unique_ptr<DataChunk> MaterializedQueryResult::Fetch() {
 	collection.chunks.erase(collection.chunks.begin() + 0);
 	return chunk;
 }
+
+} // namespace duckdb

--- a/src/main/prepared_statement.cpp
+++ b/src/main/prepared_statement.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/prepared_statement_data.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 PreparedStatement::PreparedStatement(ClientContext *context, string name, string query, PreparedStatementData &data,
@@ -36,3 +36,5 @@ unique_ptr<QueryResult> PreparedStatement::Execute(vector<Value> &values, bool a
 	assert(context);
 	return context->Execute(name, values, allow_stream_result, query);
 }
+
+} // namespace duckdb

--- a/src/main/prepared_statement_data.cpp
+++ b/src/main/prepared_statement_data.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/main/prepared_statement_data.hpp"
 #include "duckdb/execution/physical_operator.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 PreparedStatementData::PreparedStatementData(StatementType type)
@@ -40,3 +40,5 @@ SQLType PreparedStatementData::GetType(idx_t param_idx) {
 	}
 	return it->second.target_type;
 }
+
+} // namespace duckdb

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/main/query_result.hpp"
 #include "duckdb/common/printer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 QueryResult::QueryResult(QueryResultType type, StatementType statement_type)
@@ -73,3 +73,5 @@ string QueryResult::HeaderToString() {
 	result += "\n";
 	return result;
 }
+
+} // namespace duckdb

--- a/src/main/stream_query_result.cpp
+++ b/src/main/stream_query_result.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/materialized_query_result.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 StreamQueryResult::StreamQueryResult(StatementType statement_type, ClientContext &context, vector<SQLType> sql_types,
@@ -58,3 +58,5 @@ void StreamQueryResult::Close() {
 	}
 	context.Cleanup();
 }
+
+} // namespace duckdb

--- a/src/optimizer/column_lifetime_analyzer.cpp
+++ b/src/optimizer/column_lifetime_analyzer.cpp
@@ -6,7 +6,7 @@
 #include "duckdb/planner/operator/logical_delim_join.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 void ColumnLifetimeAnalyzer::ExtractUnusedColumnBindings(vector<ColumnBinding> bindings,
@@ -148,3 +148,5 @@ unique_ptr<Expression> ColumnLifetimeAnalyzer::VisitReplace(BoundReferenceExpres
 	// BoundReferenceExpression should not be used here yet, they only belong in the physical plan
 	throw InternalException("BoundReferenceExpression should not be used here yet!");
 }
+
+} // namespace duckdb

--- a/src/optimizer/cse_optimizer.cpp
+++ b/src/optimizer/cse_optimizer.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 void CommonSubExpressionOptimizer::VisitOperator(LogicalOperator &op) {
@@ -94,3 +94,5 @@ void CommonSubExpressionOptimizer::ExtractCommonSubExpresions(LogicalOperator &o
 		PerformCSEReplacement(&op.expressions[i], expression_count);
 	}
 }
+
+} // namespace duckdb

--- a/src/optimizer/expression_heuristics.cpp
+++ b/src/optimizer/expression_heuristics.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/optimizer/expression_heuristics.hpp"
 #include "duckdb/planner/expression/list.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<LogicalOperator> ExpressionHeuristics::Rewrite(unique_ptr<LogicalOperator> op) {
@@ -73,7 +73,7 @@ idx_t ExpressionHeuristics::ExpressionCost(BoundCastExpression &expr) {
 		// if cast from or to varchar
 		// TODO: we might want to add more cases
 		if (expr.target_type == SQLType::VARCHAR || expr.source_type == SQLType::VARCHAR ||
-            expr.target_type == SQLType::BLOB || expr.source_type == SQLType::BLOB) {
+		    expr.target_type == SQLType::BLOB || expr.source_type == SQLType::BLOB) {
 			cast_cost = 200;
 		} else {
 			cast_cost = 5;
@@ -197,3 +197,5 @@ idx_t ExpressionHeuristics::Cost(Expression &expr) {
 	// return a very high value if nothing matches
 	return 1000;
 }
+
+} // namespace duckdb

--- a/src/optimizer/expression_rewriter.cpp
+++ b/src/optimizer/expression_rewriter.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<Expression> ExpressionRewriter::ApplyRules(LogicalOperator &op, const vector<Rule *> &rules,
@@ -74,3 +74,5 @@ void ExpressionRewriter::Apply(LogicalOperator &root) {
 		filter.SplitPredicates();
 	}
 }
+
+} // namespace duckdb

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -9,7 +9,7 @@
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression.hpp"
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 using ExpressionValueInformation = FilterCombiner::ExpressionValueInformation;
@@ -571,3 +571,5 @@ ValueComparisonResult CompareValueInformation(ExpressionValueInformation &left, 
 		return InvertValueComparisonResult(CompareValueInformation(right, left));
 	}
 }
+
+} // namespace duckdb

--- a/src/optimizer/filter_pushdown.cpp
+++ b/src/optimizer/filter_pushdown.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/operator/logical_join.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 using Filter = FilterPushdown::Filter;
@@ -121,3 +121,5 @@ void FilterPushdown::Filter::ExtractBindings() {
 	bindings.clear();
 	LogicalJoin::GetExpressionBindings(*filter, bindings);
 }
+
+} // namespace duckdb

--- a/src/optimizer/index_scan.cpp
+++ b/src/optimizer/index_scan.cpp
@@ -12,7 +12,7 @@
 #include "duckdb/planner/operator/logical_index_scan.hpp"
 
 #include "duckdb/storage/data_table.hpp"
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<LogicalOperator> IndexScan::Optimize(unique_ptr<LogicalOperator> op) {
@@ -151,3 +151,5 @@ unique_ptr<LogicalOperator> IndexScan::TransformFilterToIndexScan(unique_ptr<Log
 	}
 	return op;
 }
+
+} // namespace duckdb

--- a/src/optimizer/join_order/query_graph.cpp
+++ b/src/optimizer/join_order/query_graph.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/assert.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 using QueryEdge = QueryGraph::QueryEdge;
@@ -125,3 +125,5 @@ NeighborInfo *QueryGraph::GetConnection(JoinRelationSet *node, JoinRelationSet *
 void QueryGraph::Print() {
 	Printer::Print(ToString());
 }
+
+} // namespace duckdb

--- a/src/optimizer/join_order_optimizer.cpp
+++ b/src/optimizer/join_order_optimizer.cpp
@@ -6,7 +6,7 @@
 
 #include <algorithm>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 using JoinNode = JoinOrderOptimizer::JoinNode;
@@ -763,3 +763,5 @@ unique_ptr<LogicalOperator> JoinOrderOptimizer::Optimize(unique_ptr<LogicalOpera
 	// now perform the actual reordering
 	return RewritePlan(move(plan), final_plan->second.get());
 }
+
+} // namespace duckdb

--- a/src/optimizer/matcher/expression_matcher.cpp
+++ b/src/optimizer/matcher/expression_matcher.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/planner/expression/list.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 bool ExpressionMatcher::Match(Expression *expr, vector<Expression *> &bindings) {
@@ -105,3 +105,5 @@ bool FoldableConstantMatcher::Match(Expression *expr, vector<Expression *> &bind
 	bindings.push_back(expr);
 	return true;
 }
+
+} // namespace duckdb

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -15,7 +15,7 @@
 #include "duckdb/optimizer/topn_optimizer.hpp"
 #include "duckdb/planner/binder.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 Optimizer::Optimizer(Binder &binder, ClientContext &context) : context(context), binder(binder), rewriter(context) {
@@ -104,3 +104,5 @@ unique_ptr<LogicalOperator> Optimizer::Optimize(unique_ptr<LogicalOperator> plan
 
 	return plan;
 }
+
+} // namespace duckdb

--- a/src/optimizer/pushdown/pushdown_aggregate.cpp
+++ b/src/optimizer/pushdown/pushdown_aggregate.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/planner/operator/logical_empty_result.hpp"
 #include "duckdb/planner/operator/logical_join.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 using Filter = FilterPushdown::Filter;
@@ -54,3 +54,5 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownAggregate(unique_ptr<Logical
 	op->children[0] = child_pushdown.Rewrite(move(op->children[0]));
 	return FinishPushdown(move(op));
 }
+
+} // namespace duckdb

--- a/src/optimizer/pushdown/pushdown_cross_product.cpp
+++ b/src/optimizer/pushdown/pushdown_cross_product.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_cross_product.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 using Filter = FilterPushdown::Filter;
@@ -45,3 +45,5 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownCrossProduct(unique_ptr<Logi
 		return op;
 	}
 }
+
+} // namespace duckdb

--- a/src/optimizer/pushdown/pushdown_filter.cpp
+++ b/src/optimizer/pushdown/pushdown_filter.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/planner/operator/logical_empty_result.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 using Filter = FilterPushdown::Filter;
@@ -20,3 +20,5 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownFilter(unique_ptr<LogicalOpe
 	GenerateFilters();
 	return Rewrite(move(filter.children[0]));
 }
+
+} // namespace duckdb

--- a/src/optimizer/pushdown/pushdown_get.cpp
+++ b/src/optimizer/pushdown/pushdown_get.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/storage/data_table.hpp"
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<LogicalOperator> FilterPushdown::PushdownGet(unique_ptr<LogicalOperator> op) {
@@ -66,3 +66,5 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownGet(unique_ptr<LogicalOperat
 	}
 	return op;
 }
+
+} // namespace duckdb

--- a/src/optimizer/pushdown/pushdown_inner_join.cpp
+++ b/src/optimizer/pushdown/pushdown_inner_join.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/planner/operator/logical_cross_product.hpp"
 #include "duckdb/planner/operator/logical_empty_result.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 using Filter = FilterPushdown::Filter;
@@ -45,3 +45,5 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownInnerJoin(unique_ptr<Logical
 	// then push down cross product
 	return PushdownCrossProduct(move(cross_product));
 }
+
+} // namespace duckdb

--- a/src/optimizer/pushdown/pushdown_left_join.cpp
+++ b/src/optimizer/pushdown/pushdown_left_join.cpp
@@ -9,7 +9,7 @@
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 using Filter = FilterPushdown::Filter;
@@ -124,3 +124,5 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownLeftJoin(unique_ptr<LogicalO
 	op->children[1] = right_pushdown.Rewrite(move(op->children[1]));
 	return FinishPushdown(move(op));
 }
+
+} // namespace duckdb

--- a/src/optimizer/pushdown/pushdown_mark_join.cpp
+++ b/src/optimizer/pushdown/pushdown_mark_join.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 using Filter = FilterPushdown::Filter;
@@ -70,3 +70,5 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownMarkJoin(unique_ptr<LogicalO
 	op->children[1] = right_pushdown.Rewrite(move(op->children[1]));
 	return FinishPushdown(move(op));
 }
+
+} // namespace duckdb

--- a/src/optimizer/pushdown/pushdown_projection.cpp
+++ b/src/optimizer/pushdown/pushdown_projection.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/planner/operator/logical_empty_result.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 static unique_ptr<Expression> ReplaceProjectionBindings(LogicalProjection &proj, unique_ptr<Expression> expr) {
@@ -45,3 +45,5 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownProjection(unique_ptr<Logica
 	op->children[0] = child_pushdown.Rewrite(move(op->children[0]));
 	return op;
 }
+
+} // namespace duckdb

--- a/src/optimizer/pushdown/pushdown_set_operation.cpp
+++ b/src/optimizer/pushdown/pushdown_set_operation.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_set_operation.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 using Filter = FilterPushdown::Filter;
@@ -60,3 +60,5 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownSetOperation(unique_ptr<Logi
 	op->children[1] = right_pushdown.Rewrite(move(op->children[1]));
 	return op;
 }
+
+} // namespace duckdb

--- a/src/optimizer/pushdown/pushdown_single_join.cpp
+++ b/src/optimizer/pushdown/pushdown_single_join.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/optimizer/filter_pushdown.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 using Filter = FilterPushdown::Filter;
@@ -26,3 +26,5 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownSingleJoin(unique_ptr<Logica
 	op->children[1] = right_pushdown.Rewrite(move(op->children[1]));
 	return FinishPushdown(move(op));
 }
+
+} // namespace duckdb

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -18,7 +18,7 @@
 
 #include "duckdb/planner/expression_iterator.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 void RemoveUnusedColumns::ReplaceBinding(ColumnBinding current_binding, ColumnBinding new_binding) {
@@ -197,3 +197,5 @@ unique_ptr<Expression> RemoveUnusedColumns::VisitReplace(BoundReferenceExpressio
 	// BoundReferenceExpression should not be used here yet, they only belong in the physical plan
 	throw InternalException("BoundReferenceExpression should not be used here yet!");
 }
+
+} // namespace duckdb

--- a/src/optimizer/rule/arithmetic_simplification.cpp
+++ b/src/optimizer/rule/arithmetic_simplification.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 ArithmeticSimplificationRule::ArithmeticSimplificationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
@@ -64,3 +64,4 @@ unique_ptr<Expression> ArithmeticSimplificationRule::Apply(LogicalOperator &op, 
 	}
 	return nullptr;
 }
+} // namespace duckdb

--- a/src/optimizer/rule/case_simplification.cpp
+++ b/src/optimizer/rule/case_simplification.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_case_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 CaseSimplificationRule::CaseSimplificationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
@@ -31,3 +31,5 @@ unique_ptr<Expression> CaseSimplificationRule::Apply(LogicalOperator &op, vector
 		return move(root->result_if_true);
 	}
 }
+
+} // namespace duckdb

--- a/src/optimizer/rule/comparison_simplification.cpp
+++ b/src/optimizer/rule/comparison_simplification.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 ComparisonSimplificationRule::ComparisonSimplificationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
@@ -53,3 +53,5 @@ unique_ptr<Expression> ComparisonSimplificationRule::Apply(LogicalOperator &op, 
 	}
 	return nullptr;
 }
+
+} // namespace duckdb

--- a/src/optimizer/rule/conjunction_simplification.cpp
+++ b/src/optimizer/rule/conjunction_simplification.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 ConjunctionSimplificationRule::ConjunctionSimplificationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
@@ -62,3 +62,5 @@ unique_ptr<Expression> ConjunctionSimplificationRule::Apply(LogicalOperator &op,
 		}
 	}
 }
+
+} // namespace duckdb

--- a/src/optimizer/rule/constant_folding.cpp
+++ b/src/optimizer/rule/constant_folding.cpp
@@ -5,10 +5,8 @@
 #include "duckdb/optimizer/expression_rewriter.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 
-using namespace duckdb;
-using namespace std;
-
 namespace duckdb {
+using namespace std;
 
 //! The ConstantFoldingExpressionMatcher matches on any scalar expression (i.e. Expression::IsFoldable is true)
 class ConstantFoldingExpressionMatcher : public FoldableConstantMatcher {
@@ -21,7 +19,6 @@ public:
 		return FoldableConstantMatcher::Match(expr, bindings);
 	}
 };
-} // namespace duckdb
 
 ConstantFoldingRule::ConstantFoldingRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
 	auto op = make_unique<ConstantFoldingExpressionMatcher>();
@@ -40,3 +37,5 @@ unique_ptr<Expression> ConstantFoldingRule::Apply(LogicalOperator &op, vector<Ex
 	// now get the value from the result vector and insert it back into the plan as a constant expression
 	return make_unique<BoundConstantExpression>(result_value);
 }
+
+} // namespace duckdb

--- a/src/optimizer/rule/date_part_simplification.cpp
+++ b/src/optimizer/rule/date_part_simplification.cpp
@@ -8,7 +8,7 @@
 #include "duckdb/common/enums/date_part_specifier.hpp"
 #include "duckdb/function/function.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 DatePartSimplificationRule::DatePartSimplificationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
@@ -96,3 +96,5 @@ unique_ptr<Expression> DatePartSimplificationRule::Apply(LogicalOperator &op, ve
 	return ScalarFunction::BindScalarFunction(rewriter.context, DEFAULT_SCHEMA, new_function_name, arguments,
 	                                          move(children), false);
 }
+
+} // namespace duckdb

--- a/src/optimizer/rule/distributivity.cpp
+++ b/src/optimizer/rule/distributivity.cpp
@@ -6,7 +6,7 @@
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 DistributivityRule::DistributivityRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
@@ -122,3 +122,5 @@ unique_ptr<Expression> DistributivityRule::Apply(LogicalOperator &op, vector<Exp
 	}
 	return move(new_root);
 }
+
+} // namespace duckdb

--- a/src/optimizer/rule/empty_needle_removal.cpp
+++ b/src/optimizer/rule/empty_needle_removal.cpp
@@ -8,7 +8,7 @@
 
 #include <regex>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 EmptyNeedleRemovalRule::EmptyNeedleRemovalRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
@@ -57,3 +57,5 @@ unique_ptr<Expression> EmptyNeedleRemovalRule::Apply(LogicalOperator &op, vector
 
 	return nullptr;
 }
+
+} // namespace duckdb

--- a/src/optimizer/rule/empty_needle_removal.cpp
+++ b/src/optimizer/rule/empty_needle_removal.cpp
@@ -6,8 +6,6 @@
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression/bound_case_expression.hpp"
 
-#include <regex>
-
 namespace duckdb {
 using namespace std;
 

--- a/src/optimizer/rule/like_optimizations.cpp
+++ b/src/optimizer/rule/like_optimizations.cpp
@@ -6,7 +6,7 @@
 
 #include <regex>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 LikeOptimizationRule::LikeOptimizationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
@@ -69,3 +69,5 @@ unique_ptr<Expression> LikeOptimizationRule::ApplyRule(BoundFunctionExpression *
 
 	return expr->Copy();
 }
+
+} // namespace duckdb

--- a/src/optimizer/rule/move_constants.cpp
+++ b/src/optimizer/rule/move_constants.cpp
@@ -6,7 +6,7 @@
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 MoveConstantsRule::MoveConstantsRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
@@ -94,3 +94,5 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<Expr
 	changes_made = true;
 	return nullptr;
 }
+
+} // namespace duckdb

--- a/src/optimizer/topn_optimizer.cpp
+++ b/src/optimizer/topn_optimizer.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/planner/operator/logical_limit.hpp"
 #include "duckdb/planner/operator/logical_top_n.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<LogicalOperator> TopN::Optimize(unique_ptr<LogicalOperator> op) {
@@ -24,3 +24,5 @@ unique_ptr<LogicalOperator> TopN::Optimize(unique_ptr<LogicalOperator> op) {
 	}
 	return op;
 }
+
+} // namespace duckdb

--- a/src/parser/base_expression.cpp
+++ b/src/parser/base_expression.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/common/printer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 void BaseExpression::Print() {
@@ -18,3 +18,5 @@ bool BaseExpression::Equals(const BaseExpression *other) const {
 	}
 	return true;
 }
+
+} // namespace duckdb

--- a/src/parser/constraint.cpp
+++ b/src/parser/constraint.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/common/serializer.hpp"
 #include "duckdb/parser/constraints/list.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 void Constraint::Serialize(Serializer &serializer) {
@@ -29,3 +29,5 @@ unique_ptr<Constraint> Constraint::Deserialize(Deserializer &source) {
 void Constraint::Print() {
 	Printer::Print(ToString());
 }
+
+} // namespace duckdb

--- a/src/parser/constraints/check_constraint.cpp
+++ b/src/parser/constraints/check_constraint.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/common/serializer.hpp"
 
 using namespace std;
-using namespace duckdb;
+namespace duckdb {
 
 string CheckConstraint::ToString() const {
 	return "CHECK(" + expression->ToString() + ")";
@@ -22,3 +22,5 @@ unique_ptr<Constraint> CheckConstraint::Deserialize(Deserializer &source) {
 	auto expression = ParsedExpression::Deserialize(source);
 	return make_unique<CheckConstraint>(move(expression));
 }
+
+} // namespace duckdb

--- a/src/parser/constraints/not_null_constraint.cpp
+++ b/src/parser/constraints/not_null_constraint.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/common/serializer.hpp"
 
 using namespace std;
-using namespace duckdb;
+namespace duckdb {
 
 string NotNullConstraint::ToString() const {
 	return "NOT NULL Constraint";
@@ -22,3 +22,5 @@ unique_ptr<Constraint> NotNullConstraint::Deserialize(Deserializer &source) {
 	auto index = source.Read<idx_t>();
 	return make_unique_base<Constraint, NotNullConstraint>(index);
 }
+
+} // namespace duckdb

--- a/src/parser/expression/case_expression.cpp
+++ b/src/parser/expression/case_expression.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/common/exception.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 CaseExpression::CaseExpression() : ParsedExpression(ExpressionType::CASE_EXPR, ExpressionClass::CASE) {
@@ -49,3 +49,5 @@ unique_ptr<ParsedExpression> CaseExpression::Deserialize(ExpressionType type, De
 	expression->result_if_false = ParsedExpression::Deserialize(source);
 	return move(expression);
 }
+
+} // namespace duckdb

--- a/src/parser/expression/cast_expression.cpp
+++ b/src/parser/expression/cast_expression.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/common/exception.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 CastExpression::CastExpression(SQLType target, unique_ptr<ParsedExpression> child)
@@ -42,3 +42,5 @@ unique_ptr<ParsedExpression> CastExpression::Deserialize(ExpressionType type, De
 	auto cast_type = SQLType::Deserialize(source);
 	return make_unique_base<ParsedExpression, CastExpression>(cast_type, move(child));
 }
+
+} // namespace duckdb

--- a/src/parser/expression/columnref_expression.cpp
+++ b/src/parser/expression/columnref_expression.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/common/serializer.hpp"
 #include "duckdb/common/types/hash.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 //! Specify both the column and table name
@@ -56,3 +56,5 @@ unique_ptr<ParsedExpression> ColumnRefExpression::Deserialize(ExpressionType typ
 	auto expression = make_unique<ColumnRefExpression>(column_name, table_name);
 	return move(expression);
 }
+
+} // namespace duckdb

--- a/src/parser/expression/comparison_expression.cpp
+++ b/src/parser/expression/comparison_expression.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/common/serializer.hpp"
 #include "duckdb/parser/expression/cast_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 ComparisonExpression::ComparisonExpression(ExpressionType type, unique_ptr<ParsedExpression> left,
@@ -45,3 +45,5 @@ unique_ptr<ParsedExpression> ComparisonExpression::Deserialize(ExpressionType ty
 	auto right_child = ParsedExpression::Deserialize(source);
 	return make_unique<ComparisonExpression>(type, move(left_child), move(right_child));
 }
+
+} // namespace duckdb

--- a/src/parser/expression/conjunction_expression.cpp
+++ b/src/parser/expression/conjunction_expression.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/common/serializer.hpp"
 #include "duckdb/parser/expression_util.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 ConjunctionExpression::ConjunctionExpression(ExpressionType type)
@@ -67,3 +67,5 @@ unique_ptr<ParsedExpression> ConjunctionExpression::Deserialize(ExpressionType t
 	source.ReadList<ParsedExpression>(result->children);
 	return move(result);
 }
+
+} // namespace duckdb

--- a/src/parser/expression/constant_expression.cpp
+++ b/src/parser/expression/constant_expression.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/value_operations/value_operations.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 ConstantExpression::ConstantExpression(SQLType sql_type, Value val)
@@ -40,3 +40,5 @@ unique_ptr<ParsedExpression> ConstantExpression::Deserialize(ExpressionType type
 	auto sql_type = SQLType::Deserialize(source);
 	return make_unique<ConstantExpression>(sql_type, value);
 }
+
+} // namespace duckdb

--- a/src/parser/expression/default_expression.cpp
+++ b/src/parser/expression/default_expression.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/common/exception.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 DefaultExpression::DefaultExpression() : ParsedExpression(ExpressionType::VALUE_DEFAULT, ExpressionClass::DEFAULT) {
@@ -21,3 +21,5 @@ unique_ptr<ParsedExpression> DefaultExpression::Copy() const {
 unique_ptr<ParsedExpression> DefaultExpression::Deserialize(ExpressionType type, Deserializer &source) {
 	return make_unique<DefaultExpression>();
 }
+
+} // namespace duckdb

--- a/src/parser/expression/function_expression.cpp
+++ b/src/parser/expression/function_expression.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/common/serializer.hpp"
 #include "duckdb/common/types/hash.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 FunctionExpression::FunctionExpression(string schema, string function_name,
@@ -92,3 +92,5 @@ unique_ptr<ParsedExpression> FunctionExpression::Deserialize(ExpressionType type
 	function->schema = schema;
 	return move(function);
 }
+
+} // namespace duckdb

--- a/src/parser/expression/operator_expression.cpp
+++ b/src/parser/expression/operator_expression.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/common/serializer.hpp"
 #include "duckdb/common/string_util.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 OperatorExpression::OperatorExpression(ExpressionType type, unique_ptr<ParsedExpression> left,
@@ -67,3 +67,5 @@ unique_ptr<ParsedExpression> OperatorExpression::Deserialize(ExpressionType type
 	source.ReadList<ParsedExpression>(expression->children);
 	return move(expression);
 }
+
+} // namespace duckdb

--- a/src/parser/expression/parameter_expression.cpp
+++ b/src/parser/expression/parameter_expression.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/common/serializer.hpp"
 #include "duckdb/common/types/hash.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 ParameterExpression::ParameterExpression()
@@ -36,3 +36,5 @@ unique_ptr<ParsedExpression> ParameterExpression::Deserialize(ExpressionType typ
 	expression->parameter_nr = source.Read<idx_t>();
 	return move(expression);
 }
+
+} // namespace duckdb

--- a/src/parser/expression/star_expression.cpp
+++ b/src/parser/expression/star_expression.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/parser/expression/star_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 StarExpression::StarExpression() : ParsedExpression(ExpressionType::STAR, ExpressionClass::STAR) {
@@ -19,3 +19,5 @@ unique_ptr<ParsedExpression> StarExpression::Copy() const {
 unique_ptr<ParsedExpression> StarExpression::Deserialize(ExpressionType type, Deserializer &source) {
 	return make_unique<StarExpression>();
 }
+
+} // namespace duckdb

--- a/src/parser/expression/subquery_expression.cpp
+++ b/src/parser/expression/subquery_expression.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/serializer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 SubqueryExpression::SubqueryExpression()
@@ -51,3 +51,5 @@ unique_ptr<ParsedExpression> SubqueryExpression::Deserialize(ExpressionType type
 	expression->comparison_type = source.Read<ExpressionType>();
 	return move(expression);
 }
+
+} // namespace duckdb

--- a/src/parser/expression/table_star_expression.cpp
+++ b/src/parser/expression/table_star_expression.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/parser/expression/table_star_expression.hpp"
 #include "duckdb/common/serializer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 TableStarExpression::TableStarExpression(string relation_name)
@@ -30,3 +30,5 @@ void TableStarExpression::Serialize(Serializer &serializer) {
 unique_ptr<ParsedExpression> TableStarExpression::Deserialize(ExpressionType type, Deserializer &source) {
 	return make_unique<TableStarExpression>(source.Read<string>());
 }
+
+} // namespace duckdb

--- a/src/parser/expression_util.cpp
+++ b/src/parser/expression_util.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/parser/expression_map.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 template <class T>
@@ -69,3 +69,5 @@ bool ExpressionUtil::SetEquals(const vector<unique_ptr<ParsedExpression>> &a,
 bool ExpressionUtil::SetEquals(const vector<unique_ptr<Expression>> &a, const vector<unique_ptr<Expression>> &b) {
 	return ExpressionSetEquals<Expression>(a, b);
 }
+
+} // namespace duckdb

--- a/src/parser/parsed_data/alter_table_info.cpp
+++ b/src/parser/parsed_data/alter_table_info.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/parser/parsed_data/alter_table_info.hpp"
 #include "duckdb/common/serializer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 void AlterInfo::Serialize(Serializer &serializer) {
@@ -135,3 +135,4 @@ unique_ptr<AlterInfo> SetDefaultInfo::Deserialize(Deserializer &source, string s
 	auto new_default = source.ReadOptional<ParsedExpression>();
 	return make_unique<SetDefaultInfo>(schema, table, move(column_name), move(new_default));
 }
+} // namespace duckdb

--- a/src/parser/parsed_expression.cpp
+++ b/src/parser/parsed_expression.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/parser/expression/list.hpp"
 #include "duckdb/parser/parsed_expression_iterator.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 bool ParsedExpression::IsAggregate() const {
@@ -160,3 +160,5 @@ unique_ptr<ParsedExpression> ParsedExpression::Deserialize(Deserializer &source)
 	result->alias = alias;
 	return result;
 }
+
+} // namespace duckdb

--- a/src/parser/parsed_expression_iterator.cpp
+++ b/src/parser/parsed_expression_iterator.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/parser/expression/list.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 void ParsedExpressionIterator::EnumerateChildren(const ParsedExpression &expr,
@@ -92,3 +92,5 @@ void ParsedExpressionIterator::EnumerateChildren(const ParsedExpression &expr,
 		throw NotImplementedException("Unimplemented expression class");
 	}
 }
+
+} // namespace duckdb

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -11,7 +11,7 @@
 
 #include "parser/parser.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 Parser::Parser() {
@@ -134,3 +134,5 @@ vector<ColumnDefinition> Parser::ParseColumnList(string column_list) {
 	auto &info = ((CreateTableInfo &)*create.info);
 	return move(info.columns);
 }
+
+} // namespace duckdb

--- a/src/parser/query_node.cpp
+++ b/src/parser/query_node.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/parser/query_node/set_operation_node.hpp"
 #include "duckdb/parser/query_node/recursive_cte_node.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 bool QueryNode::Equals(const QueryNode *other) const {
@@ -66,3 +66,5 @@ unique_ptr<QueryNode> QueryNode::Deserialize(Deserializer &source) {
 	result->modifiers = move(modifiers);
 	return result;
 }
+
+} // namespace duckdb

--- a/src/parser/query_node/recursive_cte_node.cpp
+++ b/src/parser/query_node/recursive_cte_node.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/parser/query_node/recursive_cte_node.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 bool RecursiveCTENode::Equals(const QueryNode *other_) const {
@@ -50,3 +50,5 @@ unique_ptr<QueryNode> RecursiveCTENode::Deserialize(Deserializer &source) {
 	result->right = QueryNode::Deserialize(source);
 	return move(result);
 }
+
+} // namespace duckdb

--- a/src/parser/query_node/select_node.cpp
+++ b/src/parser/query_node/select_node.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/expression_util.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 bool SelectNode::Equals(const QueryNode *other_) const {
@@ -86,3 +86,5 @@ unique_ptr<QueryNode> SelectNode::Deserialize(Deserializer &source) {
 	result->having = source.ReadOptional<ParsedExpression>();
 	return move(result);
 }
+
+} // namespace duckdb

--- a/src/parser/query_node/set_operation_node.cpp
+++ b/src/parser/query_node/set_operation_node.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/parser/query_node/set_operation_node.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 bool SetOperationNode::Equals(const QueryNode *other_) const {
@@ -46,3 +46,5 @@ unique_ptr<QueryNode> SetOperationNode::Deserialize(Deserializer &source) {
 	result->right = QueryNode::Deserialize(source);
 	return move(result);
 }
+
+} // namespace duckdb

--- a/src/parser/tableref.cpp
+++ b/src/parser/tableref.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/common/serializer.hpp"
 #include "duckdb/parser/tableref/list.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 void TableRef::Serialize(Serializer &serializer) {
@@ -50,3 +50,5 @@ unique_ptr<TableRef> TableRef::Deserialize(Deserializer &source) {
 void TableRef::Print() {
 	Printer::Print(ToString());
 }
+
+} // namespace duckdb

--- a/src/parser/tableref/basetableref.cpp
+++ b/src/parser/tableref/basetableref.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/common/serializer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 bool BaseTableRef::Equals(const TableRef *other_) const {
@@ -38,3 +38,4 @@ unique_ptr<TableRef> BaseTableRef::Copy() {
 
 	return move(copy);
 }
+} // namespace duckdb

--- a/src/parser/tableref/crossproductref.cpp
+++ b/src/parser/tableref/crossproductref.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/common/serializer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 bool CrossProductRef::Equals(const TableRef *other_) const {
@@ -40,3 +40,5 @@ unique_ptr<TableRef> CrossProductRef::Deserialize(Deserializer &source) {
 
 	return move(result);
 }
+
+} // namespace duckdb

--- a/src/parser/tableref/emptytableref.cpp
+++ b/src/parser/tableref/emptytableref.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/common/serializer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 bool EmptyTableRef::Equals(const TableRef *other) const {
@@ -20,3 +20,5 @@ void EmptyTableRef::Serialize(Serializer &serializer) {
 unique_ptr<TableRef> EmptyTableRef::Deserialize(Deserializer &source) {
 	return make_unique<EmptyTableRef>();
 }
+
+} // namespace duckdb

--- a/src/parser/tableref/expressionlistref.cpp
+++ b/src/parser/tableref/expressionlistref.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/common/serializer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 bool ExpressionListRef::Equals(const TableRef *other_) const {
@@ -77,3 +77,5 @@ unique_ptr<TableRef> ExpressionListRef::Deserialize(Deserializer &source) {
 	}
 	return move(result);
 }
+
+} // namespace duckdb

--- a/src/parser/tableref/table_function.cpp
+++ b/src/parser/tableref/table_function.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/common/serializer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 bool TableFunctionRef::Equals(const TableRef *other_) const {
@@ -34,3 +34,5 @@ unique_ptr<TableRef> TableFunctionRef::Copy() {
 
 	return move(copy);
 }
+
+} // namespace duckdb

--- a/src/parser/transform/constraint/transform_constraint.cpp
+++ b/src/parser/transform/constraint/transform_constraint.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/parser/constraints/list.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<Constraint> Transformer::TransformConstraint(PGListCell *cell) {
@@ -53,3 +53,5 @@ unique_ptr<Constraint> Transformer::TransformConstraint(PGListCell *cell, Column
 		throw NotImplementedException("Constraint not implemented!");
 	}
 }
+
+} // namespace duckdb

--- a/src/parser/transform/expression/transform_bool_expr.cpp
+++ b/src/parser/transform/expression/transform_bool_expr.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/parser/expression/operator_expression.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<ParsedExpression> Transformer::TransformBoolExpr(PGBoolExpr *root) {
@@ -47,3 +47,5 @@ unique_ptr<ParsedExpression> Transformer::TransformBoolExpr(PGBoolExpr *root) {
 	}
 	return result;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/expression/transform_case.cpp
+++ b/src/parser/transform/expression/transform_case.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<ParsedExpression> Transformer::TransformCase(PGCaseExpr *root) {
@@ -55,3 +55,5 @@ unique_ptr<ParsedExpression> Transformer::TransformCase(PGCaseExpr *root) {
 
 	return move(exp_root);
 }
+
+} // namespace duckdb

--- a/src/parser/transform/expression/transform_coalesce.cpp
+++ b/src/parser/transform/expression/transform_coalesce.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/parser/expression/operator_expression.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 // COALESCE(a,b,c) returns the first argument that is NOT NULL, so
@@ -35,3 +35,5 @@ unique_ptr<ParsedExpression> Transformer::TransformCoalesce(PGAExpr *root) {
 	}
 	return move(exp_root);
 }
+
+} // namespace duckdb

--- a/src/parser/transform/expression/transform_columnref.cpp
+++ b/src/parser/transform/expression/transform_columnref.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/parser/expression/table_star_expression.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<ParsedExpression> Transformer::TransformColumnRef(PGColumnRef *root) {
@@ -42,3 +42,5 @@ unique_ptr<ParsedExpression> Transformer::TransformColumnRef(PGColumnRef *root) 
 	}
 	throw NotImplementedException("ColumnRef not implemented!");
 }
+
+} // namespace duckdb

--- a/src/parser/transform/expression/transform_constant.cpp
+++ b/src/parser/transform/expression/transform_constant.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/limits.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<ConstantExpression> Transformer::TransformValue(PGValue val) {
@@ -54,3 +54,5 @@ unique_ptr<ConstantExpression> Transformer::TransformValue(PGValue val) {
 unique_ptr<ParsedExpression> Transformer::TransformConstant(PGAConst *c) {
 	return TransformValue(c->val);
 }
+
+} // namespace duckdb

--- a/src/parser/transform/expression/transform_expression.cpp
+++ b/src/parser/transform/expression/transform_expression.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/parser/expression/default_expression.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<ParsedExpression> Transformer::TransformResTarget(PGResTarget *root) {
@@ -67,7 +67,7 @@ unique_ptr<ParsedExpression> Transformer::TransformExpression(PGNode *node) {
 	case T_PGSetToDefault:
 		return make_unique<DefaultExpression>();
 	case T_PGCollateClause:
-		return TransformCollateExpr(reinterpret_cast<PGCollateClause*>(node));
+		return TransformCollateExpr(reinterpret_cast<PGCollateClause *>(node));
 	default:
 		throw NotImplementedException("Expr of type %d not implemented\n", (int)node->type);
 	}
@@ -90,3 +90,5 @@ bool Transformer::TransformExpressionList(PGList *list, vector<unique_ptr<Parsed
 	}
 	return true;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/expression/transform_function.cpp
+++ b/src/parser/transform/expression/transform_function.cpp
@@ -7,7 +7,7 @@
 #include "duckdb/parser/transformer.hpp"
 #include "duckdb/common/string_util.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 static ExpressionType WindowToExpressionType(string &fun_name) {
@@ -100,7 +100,7 @@ unique_ptr<ParsedExpression> Transformer::TransformFuncCall(PGFuncCall *root) {
 		function_name = reinterpret_cast<PGValue *>(name->head->next->data.ptr_value)->val.str;
 	} else {
 		// unqualified name
-//		schema = DEFAULT_SCHEMA;
+		//		schema = DEFAULT_SCHEMA;
 		schema = INVALID_SCHEMA;
 		function_name = reinterpret_cast<PGValue *>(name->head->data.ptr_value)->val.str;
 	}
@@ -246,3 +246,5 @@ unique_ptr<ParsedExpression> Transformer::TransformSQLValueFunction(PGSQLValueFu
 	auto fname = SQLValueOpToString(node->op);
 	return make_unique<FunctionExpression>(DEFAULT_SCHEMA, fname, children);
 }
+
+} // namespace duckdb

--- a/src/parser/transform/expression/transform_is_null.cpp
+++ b/src/parser/transform/expression/transform_is_null.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/parser/expression/operator_expression.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<ParsedExpression> Transformer::TransformNullTest(PGNullTest *root) {
@@ -16,3 +16,5 @@ unique_ptr<ParsedExpression> Transformer::TransformNullTest(PGNullTest *root) {
 
 	return unique_ptr<ParsedExpression>(new OperatorExpression(expr_type, move(arg)));
 }
+
+} // namespace duckdb

--- a/src/parser/transform/expression/transform_operator.cpp
+++ b/src/parser/transform/expression/transform_operator.cpp
@@ -7,7 +7,7 @@
 #include "duckdb/parser/expression/operator_expression.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 ExpressionType Transformer::OperatorToExpressionType(string &op) {
@@ -185,3 +185,5 @@ unique_ptr<ParsedExpression> Transformer::TransformAExpr(PGAExpr *root) {
 		return TransformBinaryOperator(name, move(left_expr), move(right_expr));
 	}
 }
+
+} // namespace duckdb

--- a/src/parser/transform/expression/transform_param_ref.cpp
+++ b/src/parser/transform/expression/transform_param_ref.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/parser/transformer.hpp"
 #include "duckdb/common/algorithm.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<ParsedExpression> Transformer::TransformParamRef(PGParamRef *node) {
@@ -18,3 +18,5 @@ unique_ptr<ParsedExpression> Transformer::TransformParamRef(PGParamRef *node) {
 	SetParamCount(max(ParamCount(), expr->parameter_nr));
 	return move(expr);
 }
+
+} // namespace duckdb

--- a/src/parser/transform/expression/transform_subquery.cpp
+++ b/src/parser/transform/expression/transform_subquery.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/parser/expression/subquery_expression.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<ParsedExpression> Transformer::TransformSubquery(PGSubLink *root) {
@@ -60,3 +60,5 @@ unique_ptr<ParsedExpression> Transformer::TransformSubquery(PGSubLink *root) {
 	}
 	return move(subquery_expr);
 }
+
+} // namespace duckdb

--- a/src/parser/transform/helpers/nodetype_to_string.cpp
+++ b/src/parser/transform/helpers/nodetype_to_string.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 
 std::string Transformer::NodetypeToString(PGNodeTag type) {
 	switch (type) {
@@ -813,3 +813,5 @@ std::string Transformer::NodetypeToString(PGNodeTag type) {
 		return "";
 	}
 }
+
+} // namespace duckdb

--- a/src/parser/transform/helpers/transform_alias.cpp
+++ b/src/parser/transform/helpers/transform_alias.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 string Transformer::TransformAlias(PGAlias *root) {
@@ -9,3 +9,5 @@ string Transformer::TransformAlias(PGAlias *root) {
 	}
 	return root->aliasname;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/helpers/transform_cte.cpp
+++ b/src/parser/transform/helpers/transform_cte.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/parser/query_node/recursive_cte_node.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 void Transformer::TransformCTE(PGWithClause *de_with_clause, SelectStatement &select) {
@@ -110,3 +110,5 @@ unique_ptr<QueryNode> Transformer::TransformRecursiveCTE(PGCommonTableExpr *cte)
 	}
 	return node;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/helpers/transform_groupby.cpp
+++ b/src/parser/transform/helpers/transform_groupby.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 // FIXME: what is the difference between GroupBy and expression list?
@@ -16,3 +16,5 @@ bool Transformer::TransformGroupBy(PGList *group, vector<unique_ptr<ParsedExpres
 	}
 	return true;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/helpers/transform_orderby.cpp
+++ b/src/parser/transform/helpers/transform_orderby.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 bool Transformer::TransformOrderBy(PGList *order, vector<OrderByNode> &result) {
@@ -43,3 +43,5 @@ bool Transformer::TransformOrderBy(PGList *order, vector<OrderByNode> &result) {
 	}
 	return true;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/helpers/transform_typename.cpp
+++ b/src/parser/transform/helpers/transform_typename.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 SQLType Transformer::TransformTypeName(PGTypeName *type_name) {
@@ -10,3 +10,5 @@ SQLType Transformer::TransformTypeName(PGTypeName *type_name) {
 	// transform it to the SQL type
 	return TransformStringToSQLType(name);
 }
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_copy.cpp
+++ b/src/parser/transform/statement/transform_copy.cpp
@@ -10,7 +10,7 @@
 
 #include <cstring>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<CopyStatement> Transformer::TransformCopy(PGNode *node) {
@@ -68,7 +68,8 @@ unique_ptr<CopyStatement> Transformer::TransformCopy(PGNode *node) {
 				// format specifier: interpret this option
 				auto *format_val = (PGValue *)(def_elem->arg);
 				if (!format_val || format_val->type != T_PGString) {
-					throw ParserException("Unsupported parameter type for FORMAT: expected e.g. FORMAT 'csv', 'csv_auto'");
+					throw ParserException(
+					    "Unsupported parameter type for FORMAT: expected e.g. FORMAT 'csv', 'csv_auto'");
 				}
 				info.format = StringUtil::Lower(format_val->val.str);
 				continue;
@@ -102,3 +103,5 @@ unique_ptr<CopyStatement> Transformer::TransformCopy(PGNode *node) {
 
 	return result;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_create_index.cpp
+++ b/src/parser/transform/statement/transform_create_index.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/parser/transformer.hpp"
 #include "duckdb/common/string_util.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 static IndexType StringToIndexType(const string &str) {
@@ -63,3 +63,5 @@ unique_ptr<CreateStatement> Transformer::TransformCreateIndex(PGNode *node) {
 	result->info = move(info);
 	return result;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_create_schema.cpp
+++ b/src/parser/transform/statement/transform_create_schema.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/parser/parsed_data/create_schema_info.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<CreateStatement> Transformer::TransformCreateSchema(PGNode *node) {
@@ -30,3 +30,5 @@ unique_ptr<CreateStatement> Transformer::TransformCreateSchema(PGNode *node) {
 	result->info = move(info);
 	return result;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_create_sequence.cpp
+++ b/src/parser/transform/statement/transform_create_sequence.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/parser/tableref/basetableref.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<CreateStatement> Transformer::TransformCreateSequence(PGNode *node) {
@@ -81,3 +81,5 @@ unique_ptr<CreateStatement> Transformer::TransformCreateSequence(PGNode *node) {
 	result->info = move(info);
 	return result;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_create_table.cpp
+++ b/src/parser/transform/statement/transform_create_table.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/parser/constraint.hpp"
 #include "duckdb/parser/expression/collate_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 string Transformer::TransformCollation(PGCollateClause *collate) {
@@ -95,3 +95,5 @@ unique_ptr<CreateStatement> Transformer::TransformCreateTable(PGNode *node) {
 	result->info = move(info);
 	return result;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_create_table_as.cpp
+++ b/src/parser/transform/statement/transform_create_table_as.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/parser/tableref/basetableref.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<CreateStatement> Transformer::TransformCreateTableAs(PGNode *node) {
@@ -28,3 +28,5 @@ unique_ptr<CreateStatement> Transformer::TransformCreateTableAs(PGNode *node) {
 	result->info = move(info);
 	return result;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_create_view.cpp
+++ b/src/parser/transform/statement/transform_create_view.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/parser/transformer.hpp"
 #include "duckdb/parser/parsed_data/create_view_info.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<CreateStatement> Transformer::TransformCreateView(PGNode *node) {
@@ -56,3 +56,5 @@ unique_ptr<CreateStatement> Transformer::TransformCreateView(PGNode *node) {
 	result->info = move(info);
 	return result;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_delete.cpp
+++ b/src/parser/transform/statement/transform_delete.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/parser/statement/delete_statement.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<DeleteStatement> Transformer::TransformDelete(PGNode *node) {
@@ -16,3 +16,5 @@ unique_ptr<DeleteStatement> Transformer::TransformDelete(PGNode *node) {
 	}
 	return result;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_drop.cpp
+++ b/src/parser/transform/statement/transform_drop.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/parser/statement/drop_statement.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<SQLStatement> Transformer::TransformDrop(PGNode *node) {
@@ -52,3 +52,5 @@ unique_ptr<SQLStatement> Transformer::TransformDrop(PGNode *node) {
 	info.if_exists = stmt->missing_ok;
 	return move(result);
 }
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_explain.cpp
+++ b/src/parser/transform/statement/transform_explain.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/parser/statement/explain_statement.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<ExplainStatement> Transformer::TransformExplain(PGNode *node) {
@@ -9,3 +9,5 @@ unique_ptr<ExplainStatement> Transformer::TransformExplain(PGNode *node) {
 	assert(stmt);
 	return make_unique<ExplainStatement>(TransformStatement(stmt->query));
 }
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_insert.cpp
+++ b/src/parser/transform/statement/transform_insert.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/parser/tableref/expressionlistref.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<TableRef> Transformer::TransformValuesList(PGList *list) {
@@ -47,3 +47,5 @@ unique_ptr<InsertStatement> Transformer::TransformInsert(PGNode *node) {
 	result->schema = table.schema_name;
 	return result;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_pragma.cpp
+++ b/src/parser/transform/statement/transform_pragma.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/parser/transformer.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PragmaStatement> Transformer::TransformPragma(PGNode *node) {
@@ -46,3 +46,5 @@ unique_ptr<PragmaStatement> Transformer::TransformPragma(PGNode *node) {
 
 	return result;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_prepare.cpp
+++ b/src/parser/transform/statement/transform_prepare.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/parser/statement/prepare_statement.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PrepareStatement> Transformer::TransformPrepare(PGNode *node) {
@@ -47,3 +47,5 @@ unique_ptr<DropStatement> Transformer::TransformDeallocate(PGNode *node) {
 	result->info->name = string(stmt->name);
 	return result;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_rename.cpp
+++ b/src/parser/transform/statement/transform_rename.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/parser/statement/alter_table_statement.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<AlterTableStatement> Transformer::TransformRename(PGNode *node) {
@@ -57,3 +57,5 @@ unique_ptr<AlterTableStatement> Transformer::TransformRename(PGNode *node) {
 	assert(info);
 	return make_unique<AlterTableStatement>(move(info));
 }
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_select.cpp
+++ b/src/parser/transform/statement/transform_select.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/parser/transformer.hpp"
 #include "duckdb/common/string_util.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<SelectStatement> Transformer::TransformSelect(PGNode *node) {
@@ -17,3 +17,5 @@ unique_ptr<SelectStatement> Transformer::TransformSelect(PGNode *node) {
 	result->node = TransformSelectNode(stmt);
 	return result;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_select_node.cpp
+++ b/src/parser/transform/statement/transform_select_node.cpp
@@ -6,7 +6,7 @@
 #include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/common/string_util.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<QueryNode> Transformer::TransformSelectNode(PGSelectStmt *stmt) {
@@ -124,3 +124,5 @@ unique_ptr<QueryNode> Transformer::TransformSelectNode(PGSelectStmt *stmt) {
 	}
 	return node;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_show.cpp
+++ b/src/parser/transform/statement/transform_show.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/parser/statement/pragma_statement.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<PragmaStatement> Transformer::TransformShow(PGNode *node) {
@@ -25,3 +25,5 @@ unique_ptr<PragmaStatement> Transformer::TransformShow(PGNode *node) {
 
 	return result;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_transaction.cpp
+++ b/src/parser/transform/statement/transform_transaction.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/parser/statement/transaction_statement.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<TransactionStatement> Transformer::TransformTransaction(PGNode *node) {
@@ -19,3 +19,5 @@ unique_ptr<TransactionStatement> Transformer::TransformTransaction(PGNode *node)
 		throw NotImplementedException("Transaction type %d not implemented yet", stmt->kind);
 	}
 }
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_update.cpp
+++ b/src/parser/transform/statement/transform_update.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/parser/statement/update_statement.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<UpdateStatement> Transformer::TransformUpdate(PGNode *node) {
@@ -21,3 +21,5 @@ unique_ptr<UpdateStatement> Transformer::TransformUpdate(PGNode *node) {
 	}
 	return result;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_vacuum.cpp
+++ b/src/parser/transform/statement/transform_vacuum.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/parser/statement/vacuum_statement.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<VacuumStatement> Transformer::TransformVacuum(PGNode *node) {
@@ -10,3 +10,5 @@ unique_ptr<VacuumStatement> Transformer::TransformVacuum(PGNode *node) {
 	auto result = make_unique<VacuumStatement>();
 	return result;
 }
+
+} // namespace duckdb

--- a/src/parser/transform/tableref/transform_base_tableref.cpp
+++ b/src/parser/transform/tableref/transform_base_tableref.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/parser/tableref/basetableref.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<TableRef> Transformer::TransformRangeVar(PGRangeVar *root) {
@@ -14,3 +14,5 @@ unique_ptr<TableRef> Transformer::TransformRangeVar(PGRangeVar *root) {
 		result->schema_name = root->schemaname;
 	return move(result);
 }
+
+} // namespace duckdb

--- a/src/parser/transform/tableref/transform_from.cpp
+++ b/src/parser/transform/tableref/transform_from.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/parser/tableref/emptytableref.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<TableRef> Transformer::TransformFrom(PGList *root) {
@@ -35,3 +35,5 @@ unique_ptr<TableRef> Transformer::TransformFrom(PGList *root) {
 	auto n = reinterpret_cast<PGNode *>(root->head->data.ptr_value);
 	return TransformTableRefNode(n);
 }
+
+} // namespace duckdb

--- a/src/parser/transform/tableref/transform_join.cpp
+++ b/src/parser/transform/tableref/transform_join.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/parser/tableref/joinref.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<TableRef> Transformer::TransformJoin(PGJoinExpr *root) {
@@ -58,3 +58,5 @@ unique_ptr<TableRef> Transformer::TransformJoin(PGJoinExpr *root) {
 	result->condition = TransformExpression(root->quals);
 	return move(result);
 }
+
+} // namespace duckdb

--- a/src/parser/transform/tableref/transform_subquery.cpp
+++ b/src/parser/transform/tableref/transform_subquery.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/parser/tableref/subqueryref.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<TableRef> Transformer::TransformRangeSubselect(PGRangeSubselect *root) {
@@ -19,3 +19,5 @@ unique_ptr<TableRef> Transformer::TransformRangeSubselect(PGRangeSubselect *root
 	}
 	return move(result);
 }
+
+} // namespace duckdb

--- a/src/parser/transform/tableref/transform_table_function.cpp
+++ b/src/parser/transform/tableref/transform_table_function.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/parser/tableref/table_function_ref.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<TableRef> Transformer::TransformRangeFunction(PGRangeFunction *root) {
@@ -38,3 +38,5 @@ unique_ptr<TableRef> Transformer::TransformRangeFunction(PGRangeFunction *root) 
 	}
 	return move(result);
 }
+
+} // namespace duckdb

--- a/src/parser/transform/tableref/transform_tableref.cpp
+++ b/src/parser/transform/tableref/transform_tableref.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/parser/tableref.hpp"
 #include "duckdb/parser/transformer.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<TableRef> Transformer::TransformTableRefNode(PGNode *n) {
@@ -19,3 +19,5 @@ unique_ptr<TableRef> Transformer::TransformTableRefNode(PGNode *n) {
 		throw NotImplementedException("From Type %d not supported yet...", n->type);
 	}
 }
+
+} // namespace duckdb

--- a/src/parser/transformer.cpp
+++ b/src/parser/transformer.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/parser/statement/list.hpp"
 #include "duckdb/parser/tableref/emptytableref.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 bool Transformer::TransformParseTree(PGList *tree, vector<unique_ptr<SQLStatement>> &statements) {
@@ -79,3 +79,5 @@ unique_ptr<SQLStatement> Transformer::TransformStatement(PGNode *stmt) {
 	}
 	return nullptr;
 }
+
+} // namespace duckdb

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -9,7 +9,7 @@
 
 #include <algorithm>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 string BindContext::GetMatchingBinding(const string &column_name) {
@@ -136,3 +136,5 @@ void BindContext::AddCTEBinding(idx_t index, const string &alias, vector<string>
 	cte_bindings[alias] = move(binding);
 	cte_references[alias] = std::make_shared<idx_t>(0);
 }
+
+} // namespace duckdb

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -7,7 +7,7 @@
 
 #include <algorithm>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 Binder::Binder(ClientContext &context, Binder *parent_)
@@ -220,3 +220,5 @@ void Binder::AddCorrelatedColumn(CorrelatedColumnInfo info) {
 		correlated_columns.push_back(info);
 	}
 }
+
+} // namespace duckdb

--- a/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -6,7 +6,7 @@
 #include "duckdb/planner/expression_binder/select_binder.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BindResult SelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFunctionCatalogEntry *func, idx_t depth) {
@@ -89,3 +89,4 @@ BindResult SelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFuncti
 	// move the aggregate expression into the set of bound aggregates
 	return BindResult(move(colref), return_type);
 }
+} // namespace duckdb

--- a/src/planner/binder/expression/bind_case_expression.cpp
+++ b/src/planner/binder/expression/bind_case_expression.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BindResult ExpressionBinder::BindExpression(CaseExpression &expr, idx_t depth) {
@@ -34,3 +34,4 @@ BindResult ExpressionBinder::BindExpression(CaseExpression &expr, idx_t depth) {
 	    make_unique<BoundCaseExpression>(move(check.expr), move(result_if_true.expr), move(result_if_false.expr)),
 	    return_type);
 }
+} // namespace duckdb

--- a/src/planner/binder/expression/bind_cast_expression.cpp
+++ b/src/planner/binder/expression/bind_cast_expression.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BindResult ExpressionBinder::BindExpression(CastExpression &expr, idx_t depth) {
@@ -25,3 +25,4 @@ BindResult ExpressionBinder::BindExpression(CastExpression &expr, idx_t depth) {
 	}
 	return BindResult(move(child.expr), expr.cast_type);
 }
+} // namespace duckdb

--- a/src/planner/binder/expression/bind_collate_expression.cpp
+++ b/src/planner/binder/expression/bind_collate_expression.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/parser/expression/collate_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BindResult ExpressionBinder::BindExpression(CollateExpression &expr, idx_t depth) {
@@ -17,3 +17,5 @@ BindResult ExpressionBinder::BindExpression(CollateExpression &expr, idx_t depth
 	child.sql_type.collation = expr.collation;
 	return BindResult(move(child.expr), child.sql_type);
 }
+
+} // namespace duckdb

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/common/string_util.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref, idx_t depth) {
@@ -25,3 +25,5 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref, idx_t d
 	}
 	return result;
 }
+
+} // namespace duckdb

--- a/src/planner/binder/expression/bind_conjunction_expression.cpp
+++ b/src/planner/binder/expression/bind_conjunction_expression.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BindResult ExpressionBinder::BindExpression(ConjunctionExpression &expr, idx_t depth) {
@@ -27,3 +27,5 @@ BindResult ExpressionBinder::BindExpression(ConjunctionExpression &expr, idx_t d
 	// now create the bound conjunction expression
 	return BindResult(move(result), SQLType(SQLTypeId::BOOLEAN));
 }
+
+} // namespace duckdb

--- a/src/planner/binder/expression/bind_constant_expression.cpp
+++ b/src/planner/binder/expression/bind_constant_expression.cpp
@@ -2,9 +2,11 @@
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BindResult ExpressionBinder::BindExpression(ConstantExpression &expr, idx_t depth) {
 	return BindResult(make_unique<BoundConstantExpression>(expr.value), expr.sql_type);
 }
+
+} // namespace duckdb

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -7,7 +7,7 @@
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BindResult ExpressionBinder::BindExpression(FunctionExpression &function, idx_t depth) {
@@ -87,3 +87,5 @@ string ExpressionBinder::UnsupportedAggregateMessage() {
 string ExpressionBinder::UnsupportedUnnestMessage() {
 	return "UNNEST not supported here";
 }
+
+} // namespace duckdb

--- a/src/planner/binder/expression/bind_operator_expression.cpp
+++ b/src/planner/binder/expression/bind_operator_expression.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 static SQLType ResolveNotType(OperatorExpression &op, vector<BoundExpression *> &children) {
@@ -68,3 +68,5 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 	}
 	return BindResult(move(result), result_type);
 }
+
+} // namespace duckdb

--- a/src/planner/binder/expression/bind_parameter_expression.cpp
+++ b/src/planner/binder/expression/bind_parameter_expression.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BindResult ExpressionBinder::BindExpression(ParameterExpression &expr, idx_t depth) {
@@ -12,3 +12,5 @@ BindResult ExpressionBinder::BindExpression(ParameterExpression &expr, idx_t dep
 	binder.parameters->push_back(bound_parameter.get());
 	return BindResult(move(bound_parameter), sql_type);
 }
+
+} // namespace duckdb

--- a/src/planner/binder/expression/bind_subquery_expression.cpp
+++ b/src/planner/binder/expression/bind_subquery_expression.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/planner/expression/bound_subquery_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 class BoundSubqueryNode : public QueryNode {
@@ -89,3 +89,5 @@ BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t dept
 
 	return BindResult(move(result), return_type);
 }
+
+} // namespace duckdb

--- a/src/planner/binder/expression/bind_unnest_expression.cpp
+++ b/src/planner/binder/expression/bind_unnest_expression.cpp
@@ -8,7 +8,7 @@
 #include "duckdb/planner/query_node/bound_select_node.hpp"
 #include "duckdb/planner/expression/bound_unnest_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth) {
@@ -46,3 +46,5 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth) {
 	// move the aggregate expression into the set of bound aggregates
 	return BindResult(move(colref), return_type);
 }
+
+} // namespace duckdb

--- a/src/planner/binder/query_node/bind_recursive_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_recursive_cte_node.cpp
@@ -6,7 +6,7 @@
 #include "duckdb/planner/query_node/bound_recursive_cte_node.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<BoundQueryNode> Binder::BindNode(RecursiveCTENode &statement) {
@@ -68,3 +68,5 @@ unique_ptr<BoundQueryNode> Binder::BindNode(RecursiveCTENode &statement) {
 
 	return move(result);
 }
+
+} // namespace duckdb

--- a/src/planner/binder/query_node/plan_query_node.cpp
+++ b/src/planner/binder/query_node/plan_query_node.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/planner/operator/logical_limit.hpp"
 #include "duckdb/planner/operator/logical_order.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<LogicalOperator> Binder::VisitQueryNode(BoundQueryNode &node, unique_ptr<LogicalOperator> root) {
@@ -38,3 +38,5 @@ unique_ptr<LogicalOperator> Binder::VisitQueryNode(BoundQueryNode &node, unique_
 	}
 	return root;
 }
+
+} // namespace duckdb

--- a/src/planner/binder/query_node/plan_recursive_cte_node.cpp
+++ b/src/planner/binder/query_node/plan_recursive_cte_node.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/planner/operator/logical_set_operation.hpp"
 #include "duckdb/planner/query_node/bound_recursive_cte_node.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<LogicalOperator> Binder::CreatePlan(BoundRecursiveCTENode &node) {
@@ -34,3 +34,5 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundRecursiveCTENode &node) {
 
 	return VisitQueryNode(node, move(root));
 }
+
+} // namespace duckdb

--- a/src/planner/binder/query_node/plan_select_node.cpp
+++ b/src/planner/binder/query_node/plan_select_node.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/planner/operator/logical_expression_get.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<LogicalOperator> Binder::PlanFilter(unique_ptr<Expression> condition, unique_ptr<LogicalOperator> root) {
@@ -104,3 +104,5 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSelectNode &statement) {
 	}
 	return root;
 }
+
+} // namespace duckdb

--- a/src/planner/binder/query_node/plan_setop.cpp
+++ b/src/planner/binder/query_node/plan_setop.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/planner/operator/logical_set_operation.hpp"
 #include "duckdb/planner/query_node/bound_set_operation_node.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<LogicalOperator> Binder::CastLogicalOperatorToTypes(vector<SQLType> &source_types,
@@ -95,3 +95,5 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSetOperationNode &node) {
 
 	return VisitQueryNode(node, move(root));
 }
+
+} // namespace duckdb

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -11,7 +11,7 @@
 
 #include <algorithm>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
@@ -107,3 +107,5 @@ BoundStatement Binder::Bind(CopyStatement &stmt) {
 		return BindCopyFrom(stmt);
 	}
 }
+
+} // namespace duckdb

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -13,7 +13,7 @@
 #include "duckdb/planner/bound_query_node.hpp"
 #include "duckdb/planner/tableref/bound_basetableref.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 SchemaCatalogEntry *Binder::BindSchema(CreateInfo &info) {
@@ -123,3 +123,5 @@ BoundStatement Binder::Bind(CreateStatement &stmt) {
 	}
 	return result;
 }
+
+} // namespace duckdb

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -9,7 +9,7 @@
 #include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
 #include <algorithm>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 static void CreateColumnMap(BoundCreateTableInfo &info) {
@@ -154,3 +154,5 @@ unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableInfo(unique_ptr<CreateIn
 	}
 	return result;
 }
+
+} // namespace duckdb

--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -6,7 +6,7 @@
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/bound_tableref.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundStatement Binder::Bind(DeleteStatement &stmt) {
@@ -50,3 +50,5 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 	result.types = {SQLType::BIGINT};
 	return result;
 }
+
+} // namespace duckdb

--- a/src/planner/binder/statement/bind_drop.cpp
+++ b/src/planner/binder/statement/bind_drop.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/catalog/standard_entry.hpp"
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundStatement Binder::Bind(DropStatement &stmt) {
@@ -45,3 +45,5 @@ BoundStatement Binder::Bind(DropStatement &stmt) {
 	result.types = {SQLType::BOOLEAN};
 	return result;
 }
+
+} // namespace duckdb

--- a/src/planner/binder/statement/bind_execute.cpp
+++ b/src/planner/binder/statement/bind_execute.cpp
@@ -6,7 +6,7 @@
 #include "duckdb/planner/expression_binder/constant_binder.hpp"
 #include "duckdb/catalog/catalog_entry/prepared_statement_catalog_entry.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundStatement Binder::Bind(ExecuteStatement &stmt) {
@@ -39,3 +39,5 @@ BoundStatement Binder::Bind(ExecuteStatement &stmt) {
 
 	return result;
 }
+
+} // namespace duckdb

--- a/src/planner/binder/statement/bind_explain.cpp
+++ b/src/planner/binder/statement/bind_explain.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/parser/statement/explain_statement.hpp"
 #include "duckdb/planner/operator/logical_explain.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundStatement Binder::Bind(ExplainStatement &stmt) {
@@ -20,3 +20,5 @@ BoundStatement Binder::Bind(ExplainStatement &stmt) {
 	result.types = {SQLType::VARCHAR, SQLType::VARCHAR};
 	return result;
 }
+
+} // namespace duckdb

--- a/src/planner/binder/statement/bind_select.cpp
+++ b/src/planner/binder/statement/bind_select.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/bound_query_node.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundStatement Binder::Bind(SelectStatement &stmt) {
@@ -13,3 +13,5 @@ BoundStatement Binder::Bind(SelectStatement &stmt) {
 	// now visit the root node of the select statement
 	return Bind(*stmt.node);
 }
+
+} // namespace duckdb

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -7,7 +7,7 @@
 #include "duckdb/planner/tableref/bound_cteref.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
@@ -74,3 +74,4 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		throw NotImplementedException("Catalog entry type");
 	}
 }
+} // namespace duckdb

--- a/src/planner/binder/tableref/bind_crossproductref.cpp
+++ b/src/planner/binder/tableref/bind_crossproductref.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/tableref/bound_crossproductref.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<BoundTableRef> Binder::Bind(CrossProductRef &ref) {
@@ -11,3 +11,5 @@ unique_ptr<BoundTableRef> Binder::Bind(CrossProductRef &ref) {
 	result->right = Bind(*ref.right);
 	return move(result);
 }
+
+} // namespace duckdb

--- a/src/planner/binder/tableref/bind_emptytableref.cpp
+++ b/src/planner/binder/tableref/bind_emptytableref.cpp
@@ -2,9 +2,11 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/tableref/bound_dummytableref.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<BoundTableRef> Binder::Bind(EmptyTableRef &ref) {
 	return make_unique<BoundEmptyTableRef>(GenerateTableIndex());
 }
+
+} // namespace duckdb

--- a/src/planner/binder/tableref/bind_expressionlistref.cpp
+++ b/src/planner/binder/tableref/bind_expressionlistref.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/parser/tableref/expressionlistref.hpp"
 #include "duckdb/planner/expression_binder/insert_binder.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<BoundTableRef> Binder::Bind(ExpressionListRef &expr) {
@@ -44,3 +44,5 @@ unique_ptr<BoundTableRef> Binder::Bind(ExpressionListRef &expr) {
 	bind_context.AddGenericBinding(result->bind_index, expr.alias, result->names, result->types);
 	return move(result);
 }
+
+} // namespace duckdb

--- a/src/planner/binder/tableref/bind_joinref.cpp
+++ b/src/planner/binder/tableref/bind_joinref.cpp
@@ -6,7 +6,7 @@
 #include "duckdb/parser/expression/comparison_expression.hpp"
 #include "duckdb/parser/expression/conjunction_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
@@ -84,3 +84,5 @@ unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
 	}
 	return move(result);
 }
+
+} // namespace duckdb

--- a/src/planner/binder/tableref/bind_subqueryref.cpp
+++ b/src/planner/binder/tableref/bind_subqueryref.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/tableref/bound_subqueryref.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<BoundTableRef> Binder::Bind(SubqueryRef &ref) {
@@ -15,3 +15,5 @@ unique_ptr<BoundTableRef> Binder::Bind(SubqueryRef &ref) {
 	MoveCorrelatedExpressions(*result->binder);
 	return move(result);
 }
+
+} // namespace duckdb

--- a/src/planner/binder/tableref/plan_basetableref.cpp
+++ b/src/planner/binder/tableref/plan_basetableref.cpp
@@ -2,9 +2,11 @@
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/tableref/bound_basetableref.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<LogicalOperator> Binder::CreatePlan(BoundBaseTableRef &ref) {
 	return move(ref.get);
 }
+
+} // namespace duckdb

--- a/src/planner/binder/tableref/plan_crossproductref.cpp
+++ b/src/planner/binder/tableref/plan_crossproductref.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/planner/operator/logical_cross_product.hpp"
 #include "duckdb/planner/tableref/bound_crossproductref.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<LogicalOperator> Binder::CreatePlan(BoundCrossProductRef &expr) {
@@ -16,3 +16,5 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundCrossProductRef &expr) {
 
 	return move(cross_product);
 }
+
+} // namespace duckdb

--- a/src/planner/binder/tableref/plan_cteref.cpp
+++ b/src/planner/binder/tableref/plan_cteref.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/planner/operator/logical_cteref.hpp"
 #include "duckdb/planner/tableref/bound_cteref.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<LogicalOperator> Binder::CreatePlan(BoundCTERef &ref) {
@@ -15,3 +15,5 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundCTERef &ref) {
 
 	return make_unique<LogicalCTERef>(index, ref.cte_index, types, ref.bound_columns);
 }
+
+} // namespace duckdb

--- a/src/planner/binder/tableref/plan_dummytableref.cpp
+++ b/src/planner/binder/tableref/plan_dummytableref.cpp
@@ -2,9 +2,11 @@
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/tableref/bound_dummytableref.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<LogicalOperator> Binder::CreatePlan(BoundEmptyTableRef &ref) {
 	return make_unique<LogicalGet>(ref.bind_index);
 }
+
+} // namespace duckdb

--- a/src/planner/binder/tableref/plan_expressionlistref.cpp
+++ b/src/planner/binder/tableref/plan_expressionlistref.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/planner/operator/logical_expression_get.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<LogicalOperator> Binder::CreatePlan(BoundExpressionListRef &ref) {
@@ -24,3 +24,5 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundExpressionListRef &ref) {
 	expr_get->AddChild(move(root));
 	return move(expr_get);
 }
+
+} // namespace duckdb

--- a/src/planner/binder/tableref/plan_joinref.cpp
+++ b/src/planner/binder/tableref/plan_joinref.cpp
@@ -12,7 +12,7 @@
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/tableref/bound_joinref.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 //! Create a JoinCondition from a comparison
@@ -69,7 +69,7 @@ unique_ptr<LogicalOperator> LogicalComparisonJoin::CreateJoin(JoinType type, uni
 					continue;
 				}
 			} else if (expr->type >= ExpressionType::COMPARE_EQUAL &&
-					expr->type <= ExpressionType::COMPARE_GREATERTHANOREQUALTO) {
+			           expr->type <= ExpressionType::COMPARE_GREATERTHANOREQUALTO) {
 				// comparison, check if we can create a comparison JoinCondition
 				if (CreateJoinCondition(*expr, left_bindings, right_bindings, conditions)) {
 					// successfully created the join condition
@@ -186,3 +186,5 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundJoinRef &ref) {
 	}
 	return result;
 }
+
+} // namespace duckdb

--- a/src/planner/binder/tableref/plan_subqueryref.cpp
+++ b/src/planner/binder/tableref/plan_subqueryref.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/tableref/bound_subqueryref.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSubqueryRef &ref) {
@@ -14,3 +14,5 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSubqueryRef &ref) {
 	}
 	return subquery;
 }
+
+} // namespace duckdb

--- a/src/planner/binder/tableref/plan_table_function.cpp
+++ b/src/planner/binder/tableref/plan_table_function.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/planner/operator/logical_table_function.hpp"
 #include "duckdb/planner/tableref/bound_table_function.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<LogicalOperator> Binder::CreatePlan(BoundTableFunction &ref) {
@@ -14,3 +14,5 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundTableFunction &ref) {
 	}
 	return move(logical_fun);
 }
+
+} // namespace duckdb

--- a/src/planner/expression.cpp
+++ b/src/planner/expression.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 Expression::Expression(ExpressionType type, ExpressionClass expression_class, TypeId return_type)
@@ -63,3 +63,5 @@ hash_t Expression::Hash() const {
 	                                      [&](const Expression &child) { hash = CombineHash(child.Hash(), hash); });
 	return hash;
 }
+
+} // namespace duckdb

--- a/src/planner/expression/bound_aggregate_expression.cpp
+++ b/src/planner/expression/bound_aggregate_expression.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/string_util.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundAggregateExpression::BoundAggregateExpression(TypeId return_type, AggregateFunction function, bool distinct)
@@ -58,3 +58,5 @@ unique_ptr<Expression> BoundAggregateExpression::Copy() {
 	copy->CopyProperties(*this);
 	return move(copy);
 }
+
+} // namespace duckdb

--- a/src/planner/expression/bound_between_expression.cpp
+++ b/src/planner/expression/bound_between_expression.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/planner/expression/bound_between_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundBetweenExpression::BoundBetweenExpression(unique_ptr<Expression> input, unique_ptr<Expression> lower,
@@ -36,3 +36,5 @@ unique_ptr<Expression> BoundBetweenExpression::Copy() {
 	copy->CopyProperties(*this);
 	return move(copy);
 }
+
+} // namespace duckdb

--- a/src/planner/expression/bound_case_expression.cpp
+++ b/src/planner/expression/bound_case_expression.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/planner/expression/bound_case_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundCaseExpression::BoundCaseExpression(unique_ptr<Expression> check, unique_ptr<Expression> res_if_true,
@@ -36,3 +36,5 @@ unique_ptr<Expression> BoundCaseExpression::Copy() {
 	new_case->CopyProperties(*this);
 	return move(new_case);
 }
+
+} // namespace duckdb

--- a/src/planner/expression/bound_cast_expression.cpp
+++ b/src/planner/expression/bound_cast_expression.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/planner/expression/bound_default_expression.hpp"
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundCastExpression::BoundCastExpression(TypeId target, unique_ptr<Expression> child, SQLType source_type,
@@ -70,3 +70,5 @@ unique_ptr<Expression> BoundCastExpression::Copy() {
 	copy->CopyProperties(*this);
 	return move(copy);
 }
+
+} // namespace duckdb

--- a/src/planner/expression/bound_columnref_expression.cpp
+++ b/src/planner/expression/bound_columnref_expression.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/common/types/hash.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundColumnRefExpression::BoundColumnRefExpression(string alias, TypeId type, ColumnBinding binding, idx_t depth)
@@ -37,3 +37,5 @@ bool BoundColumnRefExpression::Equals(const BaseExpression *other_) const {
 string BoundColumnRefExpression::ToString() const {
 	return "#[" + to_string(binding.table_index) + "." + to_string(binding.column_index) + "]";
 }
+
+} // namespace duckdb

--- a/src/planner/expression/bound_comparison_expression.cpp
+++ b/src/planner/expression/bound_comparison_expression.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundComparisonExpression::BoundComparisonExpression(ExpressionType type, unique_ptr<Expression> left,
@@ -31,3 +31,5 @@ unique_ptr<Expression> BoundComparisonExpression::Copy() {
 	copy->CopyProperties(*this);
 	return move(copy);
 }
+
+} // namespace duckdb

--- a/src/planner/expression/bound_conjunction_expression.cpp
+++ b/src/planner/expression/bound_conjunction_expression.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/parser/expression_util.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundConjunctionExpression::BoundConjunctionExpression(ExpressionType type)
@@ -39,3 +39,5 @@ unique_ptr<Expression> BoundConjunctionExpression::Copy() {
 	copy->CopyProperties(*this);
 	return move(copy);
 }
+
+} // namespace duckdb

--- a/src/planner/expression/bound_constant_expression.cpp
+++ b/src/planner/expression/bound_constant_expression.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/value_operations/value_operations.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundConstantExpression::BoundConstantExpression(Value value)
@@ -32,3 +32,5 @@ unique_ptr<Expression> BoundConstantExpression::Copy() {
 	copy->CopyProperties(*this);
 	return move(copy);
 }
+
+} // namespace duckdb

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -4,17 +4,20 @@
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/string_util.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundFunctionExpression::BoundFunctionExpression(TypeId return_type, ScalarFunction bound_function, bool is_operator)
     : Expression(ExpressionType::BOUND_FUNCTION, ExpressionClass::BOUND_FUNCTION, return_type),
-      function(bound_function), arguments(bound_function.arguments), sql_return_type(bound_function.return_type), is_operator(is_operator) {
+      function(bound_function), arguments(bound_function.arguments), sql_return_type(bound_function.return_type),
+      is_operator(is_operator) {
 }
 
-BoundFunctionExpression::BoundFunctionExpression(TypeId return_type, ScalarFunction bound_function, vector<SQLType> arguments, SQLType sql_return_type, bool is_operator)
+BoundFunctionExpression::BoundFunctionExpression(TypeId return_type, ScalarFunction bound_function,
+                                                 vector<SQLType> arguments, SQLType sql_return_type, bool is_operator)
     : Expression(ExpressionType::BOUND_FUNCTION, ExpressionClass::BOUND_FUNCTION, return_type),
-      function(bound_function), arguments(move(arguments)), sql_return_type(move(sql_return_type)), is_operator(is_operator) {
+      function(bound_function), arguments(move(arguments)), sql_return_type(move(sql_return_type)),
+      is_operator(is_operator) {
 }
 
 bool BoundFunctionExpression::IsFoldable() const {
@@ -63,3 +66,5 @@ unique_ptr<Expression> BoundFunctionExpression::Copy() {
 	copy->CopyProperties(*this);
 	return move(copy);
 }
+
+} // namespace duckdb

--- a/src/planner/expression/bound_operator_expression.cpp
+++ b/src/planner/expression/bound_operator_expression.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/common/string_util.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundOperatorExpression::BoundOperatorExpression(ExpressionType type, TypeId return_type)
@@ -50,3 +50,5 @@ unique_ptr<Expression> BoundOperatorExpression::Copy() {
 	}
 	return move(copy);
 }
+
+} // namespace duckdb

--- a/src/planner/expression/bound_parameter_expression.cpp
+++ b/src/planner/expression/bound_parameter_expression.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
 #include "duckdb/common/types/hash.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundParameterExpression::BoundParameterExpression(idx_t parameter_nr)
@@ -45,3 +45,5 @@ unique_ptr<Expression> BoundParameterExpression::Copy() {
 	result->return_type = return_type;
 	return move(result);
 }
+
+} // namespace duckdb

--- a/src/planner/expression/bound_reference_expression.cpp
+++ b/src/planner/expression/bound_reference_expression.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/common/serializer.hpp"
 #include "duckdb/common/types/hash.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundReferenceExpression::BoundReferenceExpression(string alias, TypeId type, idx_t index)
@@ -33,3 +33,5 @@ hash_t BoundReferenceExpression::Hash() const {
 unique_ptr<Expression> BoundReferenceExpression::Copy() {
 	return make_unique<BoundReferenceExpression>(alias, return_type, index);
 }
+
+} // namespace duckdb

--- a/src/planner/expression/bound_subquery_expression.cpp
+++ b/src/planner/expression/bound_subquery_expression.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/common/exception.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundSubqueryExpression::BoundSubqueryExpression(TypeId return_type)
@@ -21,3 +21,5 @@ bool BoundSubqueryExpression::Equals(const BaseExpression *other_) const {
 unique_ptr<Expression> BoundSubqueryExpression::Copy() {
 	throw SerializationException("Cannot copy BoundSubqueryExpression");
 }
+
+} // namespace duckdb

--- a/src/planner/expression/bound_unnest_expression.cpp
+++ b/src/planner/expression/bound_unnest_expression.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/string_util.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundUnnestExpression::BoundUnnestExpression(SQLType sql_return_type)
@@ -40,3 +40,5 @@ unique_ptr<Expression> BoundUnnestExpression::Copy() {
 	copy->child = child->Copy();
 	return move(copy);
 }
+
+} // namespace duckdb

--- a/src/planner/expression/bound_window_expression.cpp
+++ b/src/planner/expression/bound_window_expression.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/planner/expression/bound_window_expression.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BoundWindowExpression::BoundWindowExpression(ExpressionType type, TypeId return_type,
@@ -91,3 +91,5 @@ unique_ptr<Expression> BoundWindowExpression::Copy() {
 
 	return move(new_window);
 }
+
+} // namespace duckdb

--- a/src/planner/expression/common_subexpression.cpp
+++ b/src/planner/expression/common_subexpression.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/common/exception.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 CommonSubExpression::CommonSubExpression(unique_ptr<Expression> child, string alias)
@@ -35,3 +35,5 @@ bool CommonSubExpression::Equals(const BaseExpression *other_) const {
 unique_ptr<Expression> CommonSubExpression::Copy() {
 	throw SerializationException("CSEs cannot be copied");
 }
+
+} // namespace duckdb

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -10,7 +10,7 @@
 #include "duckdb/planner/expression/bound_subquery_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 ExpressionBinder::ExpressionBinder(Binder &binder, ClientContext &context, bool replace_binder)
@@ -174,3 +174,5 @@ void ExpressionBinder::BindTableNames(Binder &binder, ParsedExpression &expr) {
 	ParsedExpressionIterator::EnumerateChildren(
 	    expr, [&](const ParsedExpression &child) { BindTableNames(binder, (ParsedExpression &)child); });
 }
+
+} // namespace duckdb

--- a/src/planner/expression_binder/aggregate_binder.cpp
+++ b/src/planner/expression_binder/aggregate_binder.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/planner/binder.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 AggregateBinder::AggregateBinder(Binder &binder, ClientContext &context) : ExpressionBinder(binder, context, true) {
@@ -20,3 +20,4 @@ BindResult AggregateBinder::BindExpression(ParsedExpression &expr, idx_t depth, 
 string AggregateBinder::UnsupportedAggregateMessage() {
 	return "aggregate function calls cannot be nested";
 }
+} // namespace duckdb

--- a/src/planner/expression_binder/check_binder.cpp
+++ b/src/planner/expression_binder/check_binder.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 CheckBinder::CheckBinder(Binder &binder, ClientContext &context, string table, vector<ColumnDefinition> &columns,
@@ -44,3 +44,5 @@ BindResult CheckBinder::BindCheckColumn(ColumnRefExpression &colref) {
 	throw BinderException("Table does not contain column %s referenced in check constraint!",
 	                      colref.column_name.c_str());
 }
+
+} // namespace duckdb

--- a/src/planner/expression_binder/constant_binder.cpp
+++ b/src/planner/expression_binder/constant_binder.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/planner/expression_binder/constant_binder.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 ConstantBinder::ConstantBinder(Binder &binder, ClientContext &context, string clause)
@@ -25,3 +25,5 @@ BindResult ConstantBinder::BindExpression(ParsedExpression &expr, idx_t depth, b
 string ConstantBinder::UnsupportedAggregateMessage() {
 	return clause + "cannot contain aggregates!";
 }
+
+} // namespace duckdb

--- a/src/planner/expression_binder/group_binder.cpp
+++ b/src/planner/expression_binder/group_binder.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 GroupBinder::GroupBinder(Binder &binder, ClientContext &context, SelectNode &node, idx_t group_index,
@@ -104,3 +104,5 @@ BindResult GroupBinder::BindColumnRef(ColumnRefExpression &colref) {
 	}
 	return result;
 }
+
+} // namespace duckdb

--- a/src/planner/expression_binder/having_binder.cpp
+++ b/src/planner/expression_binder/having_binder.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/planner/expression_binder/aggregate_binder.hpp"
 #include "duckdb/common/string_util.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 HavingBinder::HavingBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info)
@@ -30,3 +30,5 @@ BindResult HavingBinder::BindExpression(ParsedExpression &expr, idx_t depth, boo
 		return ExpressionBinder::BindExpression(expr, depth);
 	}
 }
+
+} // namespace duckdb

--- a/src/planner/expression_binder/index_binder.cpp
+++ b/src/planner/expression_binder/index_binder.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/planner/expression_binder/index_binder.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 IndexBinder::IndexBinder(Binder &binder, ClientContext &context) : ExpressionBinder(binder, context) {
@@ -20,3 +20,5 @@ BindResult IndexBinder::BindExpression(ParsedExpression &expr, idx_t depth, bool
 string IndexBinder::UnsupportedAggregateMessage() {
 	return "aggregate functions are not allowed in index expressions";
 }
+
+} // namespace duckdb

--- a/src/planner/expression_binder/insert_binder.cpp
+++ b/src/planner/expression_binder/insert_binder.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/planner/expression/bound_default_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 InsertBinder::InsertBinder(Binder &binder, ClientContext &context) : ExpressionBinder(binder, context) {
@@ -22,3 +22,5 @@ BindResult InsertBinder::BindExpression(ParsedExpression &expr, idx_t depth, boo
 string InsertBinder::UnsupportedAggregateMessage() {
 	return "INSERT statement cannot contain aggregates!";
 }
+
+} // namespace duckdb

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -8,7 +8,7 @@
 #include "duckdb/planner/expression_binder/aggregate_binder.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 SelectBinder::SelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info)
@@ -65,3 +65,5 @@ BindResult SelectBinder::BindGroup(ParsedExpression &expr, idx_t depth, idx_t gr
 	                                                        ColumnBinding(node.group_index, group_index), depth),
 	                  info.group_types[group_index]);
 }
+
+} // namespace duckdb

--- a/src/planner/expression_binder/update_binder.cpp
+++ b/src/planner/expression_binder/update_binder.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/planner/expression_binder/update_binder.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 UpdateBinder::UpdateBinder(Binder &binder, ClientContext &context) : ExpressionBinder(binder, context) {
@@ -18,3 +18,5 @@ BindResult UpdateBinder::BindExpression(ParsedExpression &expr, idx_t depth, boo
 string UpdateBinder::UnsupportedAggregateMessage() {
 	return "aggregate functions are not allowed in UPDATE";
 }
+
+} // namespace duckdb

--- a/src/planner/expression_binder/where_binder.cpp
+++ b/src/planner/expression_binder/where_binder.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/planner/expression_binder/where_binder.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 WhereBinder::WhereBinder(Binder &binder, ClientContext &context) : ExpressionBinder(binder, context) {
@@ -21,3 +21,5 @@ BindResult WhereBinder::BindExpression(ParsedExpression &expr, idx_t depth, bool
 string WhereBinder::UnsupportedAggregateMessage() {
 	return "WHERE clause cannot contain aggregates!";
 }
+
+} // namespace duckdb

--- a/src/planner/expression_iterator.cpp
+++ b/src/planner/expression_iterator.cpp
@@ -6,7 +6,7 @@
 #include "duckdb/planner/query_node/bound_set_operation_node.hpp"
 #include "duckdb/planner/tableref/list.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 void ExpressionIterator::EnumerateChildren(const Expression &expr, function<void(const Expression &child)> callback) {
@@ -219,3 +219,5 @@ void ExpressionIterator::EnumerateQueryNodeChildren(BoundQueryNode &node,
 		}
 	}
 }
+
+} // namespace duckdb

--- a/src/planner/joinside.cpp
+++ b/src/planner/joinside.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/planner/expression/bound_subquery_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<Expression> JoinCondition::CreateExpression(JoinCondition cond) {
@@ -80,3 +80,5 @@ JoinSide JoinSide::GetJoinSide(unordered_set<idx_t> bindings, unordered_set<idx_
 	}
 	return side;
 }
+
+} // namespace duckdb

--- a/src/planner/logical_operator.cpp
+++ b/src/planner/logical_operator.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/string_util.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 string LogicalOperator::ParamsToString() const {
@@ -81,3 +81,5 @@ string LogicalOperator::ToString(idx_t depth) const {
 void LogicalOperator::Print() {
 	Printer::Print(ToString());
 }
+
+} // namespace duckdb

--- a/src/planner/logical_operator_visitor.cpp
+++ b/src/planner/logical_operator_visitor.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/list.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 void LogicalOperatorVisitor::VisitOperator(LogicalOperator &op) {
@@ -242,3 +242,5 @@ unique_ptr<Expression> LogicalOperatorVisitor::VisitReplace(CommonSubExpression 
                                                             unique_ptr<Expression> *expr_ptr) {
 	return nullptr;
 }
+
+} // namespace duckdb

--- a/src/planner/operator/logical_aggregate.cpp
+++ b/src/planner/operator/logical_aggregate.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/common/string_util.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 LogicalAggregate::LogicalAggregate(idx_t group_index, idx_t aggregate_index, vector<unique_ptr<Expression>> select_list)
@@ -41,3 +41,5 @@ string LogicalAggregate::ParamsToString() const {
 
 	return result;
 }
+
+} // namespace duckdb

--- a/src/planner/operator/logical_any_join.cpp
+++ b/src/planner/operator/logical_any_join.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/planner/operator/logical_any_join.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 LogicalAnyJoin::LogicalAnyJoin(JoinType type) : LogicalJoin(type, LogicalOperatorType::ANY_JOIN) {
@@ -9,3 +9,5 @@ LogicalAnyJoin::LogicalAnyJoin(JoinType type) : LogicalJoin(type, LogicalOperato
 string LogicalAnyJoin::ParamsToString() const {
 	return "[" + condition->ToString() + "]";
 }
+
+} // namespace duckdb

--- a/src/planner/operator/logical_comparison_join.cpp
+++ b/src/planner/operator/logical_comparison_join.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/common/string_util.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 LogicalComparisonJoin::LogicalComparisonJoin(JoinType join_type, LogicalOperatorType logical_type)
@@ -21,3 +21,5 @@ string LogicalComparisonJoin::ParamsToString() const {
 
 	return result;
 }
+
+} // namespace duckdb

--- a/src/planner/operator/logical_cross_product.cpp
+++ b/src/planner/operator/logical_cross_product.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/planner/operator/logical_cross_product.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 LogicalCrossProduct::LogicalCrossProduct() : LogicalOperator(LogicalOperatorType::CROSS_PRODUCT) {
@@ -17,3 +17,5 @@ void LogicalCrossProduct::ResolveTypes() {
 	types.insert(types.end(), children[0]->types.begin(), children[0]->types.end());
 	types.insert(types.end(), children[1]->types.begin(), children[1]->types.end());
 }
+
+} // namespace duckdb

--- a/src/planner/operator/logical_distinct.cpp
+++ b/src/planner/operator/logical_distinct.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/planner/operator/logical_distinct.hpp"
 #include "duckdb/common/string_util.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 using namespace duckdb;
@@ -18,3 +18,5 @@ string LogicalDistinct::ParamsToString() const {
 
 	return result;
 }
+
+} // namespace duckdb

--- a/src/planner/operator/logical_empty_result.cpp
+++ b/src/planner/operator/logical_empty_result.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/planner/operator/logical_empty_result.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 LogicalEmptyResult::LogicalEmptyResult(unique_ptr<LogicalOperator> op)
@@ -11,3 +11,5 @@ LogicalEmptyResult::LogicalEmptyResult(unique_ptr<LogicalOperator> op)
 	op->ResolveOperatorTypes();
 	this->return_types = op->types;
 }
+
+} // namespace duckdb

--- a/src/planner/operator/logical_filter.cpp
+++ b/src/planner/operator/logical_filter.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 LogicalFilter::LogicalFilter(unique_ptr<Expression> expression) : LogicalOperator(LogicalOperatorType::FILTER) {
@@ -43,3 +43,5 @@ bool LogicalFilter::SplitPredicates(vector<unique_ptr<Expression>> &expressions)
 	}
 	return found_conjunction;
 }
+
+} // namespace duckdb

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/storage/data_table.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 LogicalGet::LogicalGet(idx_t table_index)
@@ -51,3 +51,5 @@ idx_t LogicalGet::EstimateCardinality() {
 		return 1;
 	}
 }
+
+} // namespace duckdb

--- a/src/planner/operator/logical_join.cpp
+++ b/src/planner/operator/logical_join.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 LogicalJoin::LogicalJoin(JoinType join_type, LogicalOperatorType logical_type)
@@ -58,3 +58,5 @@ void LogicalJoin::GetExpressionBindings(Expression &expr, unordered_set<idx_t> &
 	}
 	ExpressionIterator::EnumerateChildren(expr, [&](Expression &child) { GetExpressionBindings(child, bindings); });
 }
+
+} // namespace duckdb

--- a/src/planner/operator/logical_projection.cpp
+++ b/src/planner/operator/logical_projection.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/planner/operator/logical_projection.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 LogicalProjection::LogicalProjection(idx_t table_index, vector<unique_ptr<Expression>> select_list)
@@ -16,3 +16,5 @@ void LogicalProjection::ResolveTypes() {
 		types.push_back(expr->return_type);
 	}
 }
+
+} // namespace duckdb

--- a/src/planner/operator/logical_table_function.cpp
+++ b/src/planner/operator/logical_table_function.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 vector<ColumnBinding> LogicalTableFunction::GetColumnBindings() {
@@ -26,3 +26,5 @@ void LogicalTableFunction::ResolveTypes() {
 string LogicalTableFunction::ParamsToString() const {
 	return "(" + function.name + ")";
 }
+
+} // namespace duckdb

--- a/src/planner/operator/logical_unnest.cpp
+++ b/src/planner/operator/logical_unnest.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/planner/operator/logical_unnest.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 vector<ColumnBinding> LogicalUnnest::GetColumnBindings() {
@@ -17,3 +17,5 @@ void LogicalUnnest::ResolveTypes() {
 		types.push_back(expr->return_type);
 	}
 }
+
+} // namespace duckdb

--- a/src/planner/operator/logical_window.cpp
+++ b/src/planner/operator/logical_window.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/planner/operator/logical_window.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 vector<ColumnBinding> LogicalWindow::GetColumnBindings() {
@@ -17,3 +17,5 @@ void LogicalWindow::ResolveTypes() {
 		types.push_back(expr->return_type);
 	}
 }
+
+} // namespace duckdb

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -13,7 +13,7 @@
 #include "duckdb/planner/pragma_handler.hpp"
 #include "duckdb/parser/parsed_data/drop_info.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 Planner::Planner(ClientContext &context) : binder(context), context(context) {
@@ -185,3 +185,5 @@ void Planner::CreatePlan(unique_ptr<SQLStatement> statement) {
 // 	assert(Expression::Equals(copy.get(), &expr));
 // 	copies.push_back(move(copy));
 // }
+
+} // namespace duckdb

--- a/src/planner/pragma_handler.cpp
+++ b/src/planner/pragma_handler.cpp
@@ -12,7 +12,7 @@
 
 #include "duckdb/common/string_util.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 PragmaHandler::PragmaHandler(ClientContext &context) : context(context) {
@@ -95,3 +95,5 @@ unique_ptr<SQLStatement> PragmaHandler::HandlePragma(PragmaInfo &pragma) {
 	}
 	return nullptr;
 }
+
+} // namespace duckdb

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -11,7 +11,7 @@
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "duckdb/function/aggregate/distributive_functions.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 FlattenDependentJoins::FlattenDependentJoins(Binder &binder, const vector<CorrelatedColumnInfo> &correlated)
@@ -313,3 +313,5 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 		                              LogicalOperatorToString(plan->type).c_str());
 	}
 }
+
+} // namespace duckdb

--- a/src/planner/subquery/has_correlated_expressions.cpp
+++ b/src/planner/subquery/has_correlated_expressions.cpp
@@ -5,7 +5,7 @@
 
 #include <algorithm>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 HasCorrelatedExpressions::HasCorrelatedExpressions(const vector<CorrelatedColumnInfo> &correlated)
@@ -43,3 +43,5 @@ unique_ptr<Expression> HasCorrelatedExpressions::VisitReplace(BoundSubqueryExpre
 	}
 	return nullptr;
 }
+
+} // namespace duckdb

--- a/src/planner/subquery/rewrite_correlated_expressions.cpp
+++ b/src/planner/subquery/rewrite_correlated_expressions.cpp
@@ -7,7 +7,7 @@
 #include "duckdb/planner/expression/bound_subquery_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 RewriteCorrelatedExpressions::RewriteCorrelatedExpressions(ColumnBinding base_binding,
@@ -112,3 +112,5 @@ unique_ptr<Expression> RewriteCountAggregates::VisitReplace(BoundColumnRefExpres
 	}
 	return nullptr;
 }
+
+} // namespace duckdb

--- a/src/planner/table_binding.cpp
+++ b/src/planner/table_binding.cpp
@@ -10,7 +10,7 @@
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 TableBinding::TableBinding(const string &alias, TableCatalogEntry &table, LogicalGet &get, idx_t index)
@@ -113,3 +113,5 @@ void GenericBinding::GenerateAllColumnExpressions(BindContext &context,
 		select_list.push_back(make_unique<ColumnRefExpression>(column_name, alias));
 	}
 }
+
+} // namespace duckdb

--- a/src/storage/block.cpp
+++ b/src/storage/block.cpp
@@ -1,7 +1,9 @@
 #include "duckdb/storage/block.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 Block::Block(block_id_t id) : FileBuffer(FileBufferType::BLOCK, Storage::BLOCK_ALLOC_SIZE), id(id) {
 }
+
+} // namespace duckdb

--- a/src/storage/buffer/buffer_handle.cpp
+++ b/src/storage/buffer/buffer_handle.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/storage/buffer/buffer_handle.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BufferHandle::BufferHandle(BufferManager &manager, block_id_t block_id, FileBuffer *node)
@@ -11,3 +11,5 @@ BufferHandle::BufferHandle(BufferManager &manager, block_id_t block_id, FileBuff
 BufferHandle::~BufferHandle() {
 	manager.Unpin(block_id);
 }
+
+} // namespace duckdb

--- a/src/storage/buffer/buffer_list.cpp
+++ b/src/storage/buffer/buffer_list.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/common/exception.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 unique_ptr<BufferEntry> BufferList::Pop() {
@@ -69,3 +69,5 @@ void BufferList::Append(unique_ptr<BufferEntry> entry) {
 	}
 	count++;
 }
+
+} // namespace duckdb

--- a/src/storage/buffer/managed_buffer.cpp
+++ b/src/storage/buffer/managed_buffer.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/storage/buffer/managed_buffer.hpp"
 #include "duckdb/common/exception.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 ManagedBuffer::ManagedBuffer(BufferManager &manager, idx_t size, bool can_destroy, block_id_t id)
@@ -9,3 +9,5 @@ ManagedBuffer::ManagedBuffer(BufferManager &manager, idx_t size, bool can_destro
 	assert(id >= MAXIMUM_BLOCK);
 	assert(size >= Storage::BLOCK_ALLOC_SIZE);
 }
+
+} // namespace duckdb

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/common/exception.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 BufferManager::BufferManager(FileSystem &fs, BlockManager &manager, string tmp, idx_t maximum_memory)
@@ -269,3 +269,5 @@ void BufferManager::DeleteTemporaryFile(block_id_t id) {
 		fs.RemoveFile(path);
 	}
 }
+
+} // namespace duckdb

--- a/src/storage/checkpoint/table_data_reader.cpp
+++ b/src/storage/checkpoint/table_data_reader.cpp
@@ -12,7 +12,7 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/client_context.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 TableDataReader::TableDataReader(CheckpointManager &manager, MetaBlockReader &reader, BoundCreateTableInfo &info)
@@ -59,3 +59,5 @@ void TableDataReader::ReadTableData() {
 		}
 	}
 }
+
+} // namespace duckdb

--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -10,7 +10,7 @@
 #include "duckdb/storage/string_segment.hpp"
 #include "duckdb/storage/table/column_segment.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 class WriteOverflowStringsToDisk : public OverflowStringWriter {
@@ -251,3 +251,5 @@ void WriteOverflowStringsToDisk::AllocateNewBlock(block_id_t new_block_id) {
 	offset = 0;
 	block_id = new_block_id;
 }
+
+} // namespace duckdb

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -27,7 +27,7 @@
 #include "duckdb/storage/checkpoint/table_data_writer.hpp"
 #include "duckdb/storage/checkpoint/table_data_reader.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 // constexpr uint64_t CheckpointManager::DATA_BLOCK_HEADER_SIZE;
@@ -53,7 +53,7 @@ void CheckpointManager::CreateCheckpoint() {
 	vector<SchemaCatalogEntry *> schemas;
 	// we scan the schemas
 	database.catalog->schemas->Scan(*transaction,
-	                               [&](CatalogEntry *entry) { schemas.push_back((SchemaCatalogEntry *)entry); });
+	                                [&](CatalogEntry *entry) { schemas.push_back((SchemaCatalogEntry *)entry); });
 	// write the actual data into the database
 	// write the amount of schemas
 	metadata_writer->Write<uint32_t>(schemas.size());
@@ -210,3 +210,5 @@ void CheckpointManager::ReadTable(ClientContext &context, MetaBlockReader &reade
 	// finally create the table in the catalog
 	database.catalog->CreateTable(context, bound_info.get());
 }
+
+} // namespace duckdb

--- a/src/storage/column_data.cpp
+++ b/src/storage/column_data.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/storage_manager.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 ColumnData::ColumnData(BufferManager &manager, DataTableInfo &table_info)
@@ -183,3 +183,5 @@ void ColumnData::AppendTransientSegment(idx_t start_row) {
 	auto new_segment = make_unique<TransientSegment>(manager, type, start_row);
 	data.AppendSegment(move(new_segment));
 }
+
+} // namespace duckdb

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -12,7 +12,7 @@
 #include "duckdb/storage/storage_manager.hpp"
 #include "duckdb/main/client_context.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 using namespace chrono;
 
@@ -354,9 +354,9 @@ bool DataTable::CheckZonemap(TableScanState &state, unordered_map<idx_t, vector<
                              idx_t &current_row) {
 	for (auto &table_filter : table_filters) {
 		for (auto &predicate_constant : table_filter.second) {
-            bool readSegment = true;
+			bool readSegment = true;
 
-            if (!state.column_scans[predicate_constant.column_index].segment_checked) {
+			if (!state.column_scans[predicate_constant.column_index].segment_checked) {
 				state.column_scans[predicate_constant.column_index].segment_checked = true;
 				if (!state.column_scans[predicate_constant.column_index].current) {
 					return true;
@@ -1056,3 +1056,5 @@ void DataTable::AddIndex(unique_ptr<Index> index, vector<unique_ptr<Expression>>
 	}
 	info->indexes.push_back(move(index));
 }
+
+} // namespace duckdb

--- a/src/storage/index.cpp
+++ b/src/storage/index.cpp
@@ -5,11 +5,10 @@
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/storage/table/append_state.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
-Index::Index(IndexType type, vector<column_t> column_ids,
-             vector<unique_ptr<Expression>> unbound_expressions)
+Index::Index(IndexType type, vector<column_t> column_ids, vector<unique_ptr<Expression>> unbound_expressions)
     : type(type), column_ids(column_ids), unbound_expressions(move(unbound_expressions)) {
 	for (auto &expr : this->unbound_expressions) {
 		types.push_back(expr->return_type);
@@ -61,3 +60,5 @@ bool Index::IndexIsUpdated(vector<column_t> &column_ids) {
 	}
 	return false;
 }
+
+} // namespace duckdb

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/storage/uncompressed_segment.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 LocalTableStorage::LocalTableStorage(DataTable &table) : max_row(0) {
@@ -395,3 +395,5 @@ void LocalStorage::ChangeType(DataTable *old_dt, DataTable *new_dt, idx_t change
 	}
 	throw NotImplementedException("FIXME: ALTER TYPE with transaction local data not currently supported");
 }
+
+} // namespace duckdb

--- a/src/storage/meta_block_reader.cpp
+++ b/src/storage/meta_block_reader.cpp
@@ -2,7 +2,7 @@
 
 #include <cstring>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 MetaBlockReader::MetaBlockReader(BufferManager &manager, block_id_t block_id)
@@ -34,3 +34,5 @@ void MetaBlockReader::ReadNewBlock(block_id_t id) {
 	next_block = *((block_id_t *)handle->node->buffer);
 	offset = sizeof(block_id_t);
 }
+
+} // namespace duckdb

--- a/src/storage/meta_block_writer.cpp
+++ b/src/storage/meta_block_writer.cpp
@@ -2,7 +2,7 @@
 
 #include <cstring>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 MetaBlockWriter::MetaBlockWriter(BlockManager &manager) : manager(manager) {
@@ -45,3 +45,5 @@ void MetaBlockWriter::WriteData(const_data_ptr_t buffer, idx_t write_size) {
 	memcpy(block->buffer + offset, buffer, write_size);
 	offset += write_size;
 }
+
+} // namespace duckdb

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -5,7 +5,7 @@
 
 #include <algorithm>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 SingleFileBlockManager::SingleFileBlockManager(FileSystem &fs, string path, bool read_only, bool create_new,
@@ -205,3 +205,5 @@ void SingleFileBlockManager::WriteHeader(DatabaseHeader header) {
 	}
 	used_blocks.clear();
 }
+
+} // namespace duckdb

--- a/src/storage/storage_info.cpp
+++ b/src/storage/storage_info.cpp
@@ -1,9 +1,7 @@
 #include "duckdb/storage/storage_info.hpp"
 
-using namespace duckdb;
-using namespace std;
-
 namespace duckdb {
+using namespace std;
 
 const uint64_t VERSION_NUMBER = 1;
 

--- a/src/storage/storage_lock.cpp
+++ b/src/storage/storage_lock.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/assert.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 StorageLockKey::StorageLockKey(StorageLock &lock, StorageLockType type) : lock(lock), type(type) {
@@ -41,3 +41,5 @@ void StorageLock::ReleaseExclusiveLock() {
 void StorageLock::ReleaseSharedLock() {
 	read_count--;
 }
+
+} // namespace duckdb

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -13,7 +13,7 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/common/serializer/buffered_file_reader.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 StorageManager::StorageManager(DuckDB &db, string path, bool read_only)
@@ -61,13 +61,13 @@ void StorageManager::Initialize() {
 	} else {
 		block_manager = make_unique<InMemoryBlockManager>();
 		buffer_manager =
-		    make_unique<BufferManager>(database.GetFileSystem(), *block_manager,
-		                               database.config.temporary_directory, database.config.maximum_memory);
+		    make_unique<BufferManager>(database.GetFileSystem(), *block_manager, database.config.temporary_directory,
+		                               database.config.maximum_memory);
 	}
 }
 
 void StorageManager::Checkpoint(string wal_path) {
-    auto &fs = database.GetFileSystem();
+	auto &fs = database.GetFileSystem();
 	if (!fs.FileExists(wal_path)) {
 		// no WAL to checkpoint
 		return;
@@ -110,19 +110,17 @@ void StorageManager::LoadDatabase() {
 			fs.RemoveFile(wal_path);
 		}
 		// initialize the block manager while creating a new db file
-		block_manager = make_unique<SingleFileBlockManager>(fs, path, read_only, true,
-		                                                    database.config.use_direct_io);
-		buffer_manager = make_unique<BufferManager>(
-		    fs, *block_manager, database.config.temporary_directory, database.config.maximum_memory);
+		block_manager = make_unique<SingleFileBlockManager>(fs, path, read_only, true, database.config.use_direct_io);
+		buffer_manager = make_unique<BufferManager>(fs, *block_manager, database.config.temporary_directory,
+		                                            database.config.maximum_memory);
 	} else {
 		if (!database.config.checkpoint_only) {
 			Checkpoint(wal_path);
 		}
 		// initialize the block manager while loading the current db file
-		auto sf = make_unique<SingleFileBlockManager>(fs, path, read_only, false,
-		                                              database.config.use_direct_io);
-		buffer_manager = make_unique<BufferManager>(fs, *sf, database.config.temporary_directory,
-		                                            database.config.maximum_memory);
+		auto sf = make_unique<SingleFileBlockManager>(fs, path, read_only, false, database.config.use_direct_io);
+		buffer_manager =
+		    make_unique<BufferManager>(fs, *sf, database.config.temporary_directory, database.config.maximum_memory);
 		sf->LoadFreeList(*buffer_manager);
 		block_manager = move(sf);
 
@@ -147,3 +145,5 @@ void StorageManager::LoadDatabase() {
 		wal.Initialize(wal_path);
 	}
 }
+
+} // namespace duckdb

--- a/src/storage/table/chunk_info.cpp
+++ b/src/storage/table/chunk_info.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/storage/table/chunk_info.hpp"
 #include "duckdb/transaction/transaction.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 static bool UseVersion(Transaction &transaction, transaction_t id) {
@@ -88,3 +88,5 @@ idx_t ChunkInsertInfo::GetSelVector(Transaction &transaction, SelectionVector &s
 bool ChunkInsertInfo::Fetch(Transaction &transaction, row_t row) {
 	return UseVersion(transaction, inserted[row]) && !UseVersion(transaction, deleted[row]);
 }
+
+} // namespace duckdb

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/storage/table/column_segment.hpp"
 #include <cstring>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 ColumnSegment::ColumnSegment(TypeId type, ColumnSegmentType segment_type, idx_t start, idx_t count)
@@ -117,18 +117,20 @@ void SegmentStatistics::Reset() {
 		break;
 	}
 	case TypeId::INTERVAL: {
-		auto min = (interval_t *) minimum.get();
-		auto max = (interval_t *) maximum.get();
+		auto min = (interval_t *)minimum.get();
+		auto max = (interval_t *)maximum.get();
 		min->months = NumericLimits<int32_t>::Maximum();
-		min->days   = NumericLimits<int32_t>::Maximum();
-		min->msecs  = NumericLimits<int64_t>::Maximum();
+		min->days = NumericLimits<int32_t>::Maximum();
+		min->msecs = NumericLimits<int64_t>::Maximum();
 
 		max->months = NumericLimits<int32_t>::Minimum();
-		max->days   = NumericLimits<int32_t>::Minimum();
-		max->msecs  = NumericLimits<int64_t>::Minimum();
+		max->days = NumericLimits<int32_t>::Minimum();
+		max->msecs = NumericLimits<int64_t>::Minimum();
 		break;
 	}
 	default:
 		throw NotImplementedException("Unimplemented type for SEGMENT statistics");
 	}
 }
+
+} // namespace duckdb

--- a/src/storage/table/persistent_segment.cpp
+++ b/src/storage/table/persistent_segment.cpp
@@ -9,7 +9,7 @@
 #include "duckdb/storage/numeric_segment.hpp"
 #include "duckdb/storage/string_segment.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 PersistentSegment::PersistentSegment(BufferManager &manager, block_id_t id, idx_t offset, TypeId type, idx_t start,
@@ -67,3 +67,5 @@ void PersistentSegment::Update(ColumnData &column_data, Transaction &transaction
 	}
 	data->Update(column_data, stats, transaction, updates, ids, count, this->start);
 }
+
+} // namespace duckdb

--- a/src/storage/table/segment_tree.cpp
+++ b/src/storage/table/segment_tree.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/storage/table/segment_tree.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 SegmentBase *SegmentTree::GetRootSegment() {
@@ -49,3 +49,5 @@ void SegmentTree::AppendSegment(unique_ptr<SegmentBase> segment) {
 		root_node = move(segment);
 	}
 }
+
+} // namespace duckdb

--- a/src/storage/table/transient_segment.cpp
+++ b/src/storage/table/transient_segment.cpp
@@ -6,7 +6,7 @@
 #include "duckdb/storage/string_segment.hpp"
 #include "duckdb/storage/table/append_state.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 TransientSegment::TransientSegment(BufferManager &manager, TypeId type, idx_t start)
@@ -68,3 +68,5 @@ void TransientSegment::RevertAppend(idx_t start_row) {
 	data->tuple_count = start_row - this->start;
 	this->count = start_row - this->start;
 }
+
+} // namespace duckdb

--- a/src/storage/table/version_manager.cpp
+++ b/src/storage/table/version_manager.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/transaction/transaction.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 idx_t VersionManager::GetSelVector(Transaction &transaction, idx_t index, SelectionVector &sel_vector,
@@ -162,3 +162,5 @@ void VersionManager::RevertAppend(row_t row_start, row_t row_end) {
 		info.erase(chunk_start);
 	}
 }
+
+} // namespace duckdb

--- a/src/storage/uncompressed_segment.cpp
+++ b/src/storage/uncompressed_segment.cpp
@@ -7,292 +7,290 @@
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/transaction/update_info.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 UncompressedSegment::UncompressedSegment(BufferManager &manager, TypeId type, idx_t row_start)
-        : manager(manager), type(type), block_id(INVALID_BLOCK), max_vector_count(0), tuple_count(0),
-          row_start(row_start),
-          versions(nullptr) {
+    : manager(manager), type(type), block_id(INVALID_BLOCK), max_vector_count(0), tuple_count(0), row_start(row_start),
+      versions(nullptr) {
 }
 
 UncompressedSegment::~UncompressedSegment() {
-    if (block_id >= MAXIMUM_BLOCK) {
-        // if the uncompressed segment had an in-memory segment, destroy it when the uncompressed segment is destroyed
-        manager.DestroyBuffer(block_id);
-    }
+	if (block_id >= MAXIMUM_BLOCK) {
+		// if the uncompressed segment had an in-memory segment, destroy it when the uncompressed segment is destroyed
+		manager.DestroyBuffer(block_id);
+	}
 }
 
 void UncompressedSegment::Verify(Transaction &transaction) {
 #ifdef DEBUG
-    ColumnScanState state;
-    InitializeScan(state);
+	ColumnScanState state;
+	InitializeScan(state);
 
-    Vector result(this->type);
-    for (idx_t i = 0; i < this->tuple_count; i += STANDARD_VECTOR_SIZE) {
-        idx_t vector_idx = i / STANDARD_VECTOR_SIZE;
-        idx_t count = std::min((idx_t)STANDARD_VECTOR_SIZE, tuple_count - i);
-        Scan(transaction, state, vector_idx, result);
-        result.Verify(count);
-    }
+	Vector result(this->type);
+	for (idx_t i = 0; i < this->tuple_count; i += STANDARD_VECTOR_SIZE) {
+		idx_t vector_idx = i / STANDARD_VECTOR_SIZE;
+		idx_t count = std::min((idx_t)STANDARD_VECTOR_SIZE, tuple_count - i);
+		Scan(transaction, state, vector_idx, result);
+		result.Verify(count);
+	}
 #endif
 }
 
 static void CheckForConflicts(UpdateInfo *info, Transaction &transaction, row_t *ids, idx_t count, row_t offset,
                               UpdateInfo *&node) {
-    if (info->version_number == transaction.transaction_id) {
-        // this UpdateInfo belongs to the current transaction, set it in the node
-        node = info;
-    } else if (info->version_number > transaction.start_time) {
-        // potential conflict, check that tuple ids do not conflict
-        // as both ids and info->tuples are sorted, this is similar to a merge join
-        idx_t i = 0, j = 0;
-        while (true) {
-            auto id = ids[i] - offset;
-            if (id == info->tuples[j]) {
-                throw TransactionException("Conflict on update!");
-            } else if (id < info->tuples[j]) {
-                // id < the current tuple in info, move to next id
-                i++;
-                if (i == count) {
-                    break;
-                }
-            } else {
-                // id > the current tuple, move to next tuple in info
-                j++;
-                if (j == info->N) {
-                    break;
-                }
-            }
-        }
-    }
-    if (info->next) {
-        CheckForConflicts(info->next, transaction, ids, count, offset, node);
-    }
+	if (info->version_number == transaction.transaction_id) {
+		// this UpdateInfo belongs to the current transaction, set it in the node
+		node = info;
+	} else if (info->version_number > transaction.start_time) {
+		// potential conflict, check that tuple ids do not conflict
+		// as both ids and info->tuples are sorted, this is similar to a merge join
+		idx_t i = 0, j = 0;
+		while (true) {
+			auto id = ids[i] - offset;
+			if (id == info->tuples[j]) {
+				throw TransactionException("Conflict on update!");
+			} else if (id < info->tuples[j]) {
+				// id < the current tuple in info, move to next id
+				i++;
+				if (i == count) {
+					break;
+				}
+			} else {
+				// id > the current tuple, move to next tuple in info
+				j++;
+				if (j == info->N) {
+					break;
+				}
+			}
+		}
+	}
+	if (info->next) {
+		CheckForConflicts(info->next, transaction, ids, count, offset, node);
+	}
 }
 
 void UncompressedSegment::Update(ColumnData &column_data, SegmentStatistics &stats, Transaction &transaction,
                                  Vector &update, row_t *ids, idx_t count, row_t offset) {
-    // can only perform in-place updates on temporary blocks
-    assert(block_id >= MAXIMUM_BLOCK);
+	// can only perform in-place updates on temporary blocks
+	assert(block_id >= MAXIMUM_BLOCK);
 
-    // obtain an exclusive lock
-    auto write_lock = lock.GetExclusiveLock();
+	// obtain an exclusive lock
+	auto write_lock = lock.GetExclusiveLock();
 
 #ifdef DEBUG
-    // verify that the ids are sorted and there are no duplicates
-    for (idx_t i = 1; i < count; i++) {
-        assert(ids[i] > ids[i - 1]);
-    }
+	// verify that the ids are sorted and there are no duplicates
+	for (idx_t i = 1; i < count; i++) {
+		assert(ids[i] > ids[i - 1]);
+	}
 #endif
 
-    // create the versions for this segment, if there are none yet
-    if (!versions) {
-        this->versions = unique_ptr<UpdateInfo *[]>(new UpdateInfo *[max_vector_count]);
-        for (idx_t i = 0; i < max_vector_count; i++) {
-            this->versions[i] = nullptr;
-        }
-    }
+	// create the versions for this segment, if there are none yet
+	if (!versions) {
+		this->versions = unique_ptr<UpdateInfo *[]>(new UpdateInfo *[max_vector_count]);
+		for (idx_t i = 0; i < max_vector_count; i++) {
+			this->versions[i] = nullptr;
+		}
+	}
 
-    // get the vector index based on the first id
-    // we assert that all updates must be part of the same vector
-    auto first_id = ids[0];
-    idx_t vector_index = (first_id - offset) / STANDARD_VECTOR_SIZE;
-    idx_t vector_offset = offset + vector_index * STANDARD_VECTOR_SIZE;
+	// get the vector index based on the first id
+	// we assert that all updates must be part of the same vector
+	auto first_id = ids[0];
+	idx_t vector_index = (first_id - offset) / STANDARD_VECTOR_SIZE;
+	idx_t vector_offset = offset + vector_index * STANDARD_VECTOR_SIZE;
 
-    assert(first_id >= offset);
-    assert(vector_index < max_vector_count);
+	assert(first_id >= offset);
+	assert(vector_index < max_vector_count);
 
-    // first check the version chain
-    UpdateInfo *node = nullptr;
-    if (versions[vector_index]) {
-        // there is already a version here, check if there are any conflicts and search for the node that belongs to
-        // this transaction in the version chain
-        CheckForConflicts(versions[vector_index], transaction, ids, count, vector_offset, node);
-    }
-    Update(column_data, stats, transaction, update, ids, count, vector_index, vector_offset, node);
+	// first check the version chain
+	UpdateInfo *node = nullptr;
+	if (versions[vector_index]) {
+		// there is already a version here, check if there are any conflicts and search for the node that belongs to
+		// this transaction in the version chain
+		CheckForConflicts(versions[vector_index], transaction, ids, count, vector_offset, node);
+	}
+	Update(column_data, stats, transaction, update, ids, count, vector_index, vector_offset, node);
 }
 
 UpdateInfo *UncompressedSegment::CreateUpdateInfo(ColumnData &column_data, Transaction &transaction, row_t *ids,
                                                   idx_t count, idx_t vector_index, idx_t vector_offset,
                                                   idx_t type_size) {
-    auto node = transaction.CreateUpdateInfo(type_size, STANDARD_VECTOR_SIZE);
-    node->column_data = &column_data;
-    node->segment = this;
-    node->vector_index = vector_index;
-    node->prev = nullptr;
-    node->next = versions[vector_index];
-    if (node->next) {
-        node->next->prev = node;
-    }
-    versions[vector_index] = node;
+	auto node = transaction.CreateUpdateInfo(type_size, STANDARD_VECTOR_SIZE);
+	node->column_data = &column_data;
+	node->segment = this;
+	node->vector_index = vector_index;
+	node->prev = nullptr;
+	node->next = versions[vector_index];
+	if (node->next) {
+		node->next->prev = node;
+	}
+	versions[vector_index] = node;
 
-    // set up the tuple ids
-    node->N = count;
-    for (idx_t i = 0; i < count; i++) {
-        assert((idx_t) ids[i] >= vector_offset && (idx_t) ids[i] < vector_offset + STANDARD_VECTOR_SIZE);
-        node->tuples[i] = ids[i] - vector_offset;
-    };
-    return node;
+	// set up the tuple ids
+	node->N = count;
+	for (idx_t i = 0; i < count; i++) {
+		assert((idx_t)ids[i] >= vector_offset && (idx_t)ids[i] < vector_offset + STANDARD_VECTOR_SIZE);
+		node->tuples[i] = ids[i] - vector_offset;
+	};
+	return node;
 }
 
 void UncompressedSegment::Fetch(ColumnScanState &state, idx_t vector_index, Vector &result) {
-    auto read_lock = lock.GetSharedLock();
-    InitializeScan(state);
-    FetchBaseData(state, vector_index, result);
+	auto read_lock = lock.GetSharedLock();
+	InitializeScan(state);
+	FetchBaseData(state, vector_index, result);
 }
 
 //===--------------------------------------------------------------------===//
 // Filter
 //===--------------------------------------------------------------------===//
-template<class T>
+template <class T>
 static void filterSelectionType(T *vec, T *predicate, SelectionVector &sel, idx_t &approved_tuple_count,
                                 ExpressionType comparison_type, nullmask_t &nullmask) {
-    SelectionVector new_sel(approved_tuple_count);
-    // the inplace loops take the result as the last parameter
-    switch (comparison_type) {
-        case ExpressionType::COMPARE_EQUAL: {
-            if (nullmask.any()) {
-                approved_tuple_count = BinaryExecutor::SelectFlatLoop<T, T, Equals, false, true, true, true, false>(
-                        vec, predicate, &sel, approved_tuple_count, nullmask, &new_sel, &sel);
-            } else {
-                approved_tuple_count = BinaryExecutor::SelectFlatLoop<T, T, Equals, false, true, false, true, false>(
-                        vec, predicate, &sel, approved_tuple_count, nullmask, &new_sel, &sel);
-            }
-            break;
-        }
-        case ExpressionType::COMPARE_LESSTHAN: {
-            if (nullmask.any()) {
-                approved_tuple_count = BinaryExecutor::SelectFlatLoop<T, T, LessThan, false, true, true, true, false>(
-                        vec, predicate, &sel, approved_tuple_count, nullmask, &new_sel, &sel);
-            } else {
-                approved_tuple_count = BinaryExecutor::SelectFlatLoop<T, T, LessThan, false, true, false, true, false>(
-                        vec, predicate, &sel, approved_tuple_count, nullmask, &new_sel, &sel);
-            }
-            break;
-        }
-        case ExpressionType::COMPARE_GREATERTHAN: {
-            if (nullmask.any()) {
-                approved_tuple_count = BinaryExecutor::SelectFlatLoop<T, T, GreaterThan, false, true, true, true, false>(
-                        vec, predicate, &sel, approved_tuple_count, nullmask, &new_sel, &sel);
-            } else {
-                approved_tuple_count = BinaryExecutor::SelectFlatLoop<T, T, GreaterThan, false, true, false, true, false>(
-                        vec, predicate, &sel, approved_tuple_count, nullmask, &new_sel, &sel);
-            }
-            break;
-        }
-        case ExpressionType::COMPARE_LESSTHANOREQUALTO: {
-            if (nullmask.any()) {
-                approved_tuple_count = BinaryExecutor::SelectFlatLoop<T, T, LessThanEquals, false, true, true, true, false>(
-                        vec, predicate, &sel, approved_tuple_count, nullmask, &new_sel, &sel);
-            } else {
-                approved_tuple_count =
-                        BinaryExecutor::SelectFlatLoop<T, T, LessThanEquals, false, true, false, true, false>(
-                                vec, predicate, &sel, approved_tuple_count, nullmask, &new_sel, &sel);
-            }
-            break;
-        }
-        case ExpressionType::COMPARE_GREATERTHANOREQUALTO: {
-            if (nullmask.any()) {
-                approved_tuple_count =
-                        BinaryExecutor::SelectFlatLoop<T, T, GreaterThanEquals, false, true, true, true, false>(
-                                vec, predicate, &sel, approved_tuple_count, nullmask, &new_sel, &sel);
-            } else {
-                approved_tuple_count =
-                        BinaryExecutor::SelectFlatLoop<T, T, GreaterThanEquals, false, true, false, true, false>(
-                                vec, predicate, &sel, approved_tuple_count, nullmask, &new_sel, &sel);
-            }
-            break;
-        }
-        default:
-            throw NotImplementedException("Unknown comparison type for filter pushed down to table!");
-    }
-    sel.Initialize(new_sel);
+	SelectionVector new_sel(approved_tuple_count);
+	// the inplace loops take the result as the last parameter
+	switch (comparison_type) {
+	case ExpressionType::COMPARE_EQUAL: {
+		if (nullmask.any()) {
+			approved_tuple_count = BinaryExecutor::SelectFlatLoop<T, T, Equals, false, true, true, true, false>(
+			    vec, predicate, &sel, approved_tuple_count, nullmask, &new_sel, &sel);
+		} else {
+			approved_tuple_count = BinaryExecutor::SelectFlatLoop<T, T, Equals, false, true, false, true, false>(
+			    vec, predicate, &sel, approved_tuple_count, nullmask, &new_sel, &sel);
+		}
+		break;
+	}
+	case ExpressionType::COMPARE_LESSTHAN: {
+		if (nullmask.any()) {
+			approved_tuple_count = BinaryExecutor::SelectFlatLoop<T, T, LessThan, false, true, true, true, false>(
+			    vec, predicate, &sel, approved_tuple_count, nullmask, &new_sel, &sel);
+		} else {
+			approved_tuple_count = BinaryExecutor::SelectFlatLoop<T, T, LessThan, false, true, false, true, false>(
+			    vec, predicate, &sel, approved_tuple_count, nullmask, &new_sel, &sel);
+		}
+		break;
+	}
+	case ExpressionType::COMPARE_GREATERTHAN: {
+		if (nullmask.any()) {
+			approved_tuple_count = BinaryExecutor::SelectFlatLoop<T, T, GreaterThan, false, true, true, true, false>(
+			    vec, predicate, &sel, approved_tuple_count, nullmask, &new_sel, &sel);
+		} else {
+			approved_tuple_count = BinaryExecutor::SelectFlatLoop<T, T, GreaterThan, false, true, false, true, false>(
+			    vec, predicate, &sel, approved_tuple_count, nullmask, &new_sel, &sel);
+		}
+		break;
+	}
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO: {
+		if (nullmask.any()) {
+			approved_tuple_count = BinaryExecutor::SelectFlatLoop<T, T, LessThanEquals, false, true, true, true, false>(
+			    vec, predicate, &sel, approved_tuple_count, nullmask, &new_sel, &sel);
+		} else {
+			approved_tuple_count =
+			    BinaryExecutor::SelectFlatLoop<T, T, LessThanEquals, false, true, false, true, false>(
+			        vec, predicate, &sel, approved_tuple_count, nullmask, &new_sel, &sel);
+		}
+		break;
+	}
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO: {
+		if (nullmask.any()) {
+			approved_tuple_count =
+			    BinaryExecutor::SelectFlatLoop<T, T, GreaterThanEquals, false, true, true, true, false>(
+			        vec, predicate, &sel, approved_tuple_count, nullmask, &new_sel, &sel);
+		} else {
+			approved_tuple_count =
+			    BinaryExecutor::SelectFlatLoop<T, T, GreaterThanEquals, false, true, false, true, false>(
+			        vec, predicate, &sel, approved_tuple_count, nullmask, &new_sel, &sel);
+		}
+		break;
+	}
+	default:
+		throw NotImplementedException("Unknown comparison type for filter pushed down to table!");
+	}
+	sel.Initialize(new_sel);
 }
 
 void UncompressedSegment::filterSelection(SelectionVector &sel, Vector &result, TableFilter filter,
                                           idx_t &approved_tuple_count, nullmask_t &nullmask) {
-    // the inplace loops take the result as the last parameter
-    switch (result.type) {
-        case TypeId::INT8: {
-            auto result_flat = FlatVector::GetData<int8_t>(result);
-            auto predicate_vector = Vector(filter.constant.value_.tinyint);
-            auto predicate = FlatVector::GetData<int8_t>(predicate_vector);
-            filterSelectionType<int8_t>(result_flat, predicate, sel, approved_tuple_count, filter.comparison_type,
-                                        nullmask);
-            break;
-        }
-        case TypeId::INT16: {
-            auto result_flat = FlatVector::GetData<int16_t>(result);
-            auto predicate_vector = Vector(filter.constant.value_.smallint);
-            auto predicate = FlatVector::GetData<int16_t>(predicate_vector);
-            filterSelectionType<int16_t>(result_flat, predicate, sel, approved_tuple_count, filter.comparison_type,
-                                         nullmask);
-            break;
-        }
-        case TypeId::INT32: {
-            auto result_flat = FlatVector::GetData<int32_t>(result);
-            auto predicate_vector = Vector(filter.constant.value_.integer);
-            auto predicate = FlatVector::GetData<int32_t>(predicate_vector);
-            filterSelectionType<int32_t>(result_flat, predicate, sel, approved_tuple_count, filter.comparison_type,
-                                         nullmask);
-            break;
-        }
-        case TypeId::INT64: {
-            auto result_flat = FlatVector::GetData<int64_t>(result);
-            auto predicate_vector = Vector(filter.constant.value_.bigint);
-            auto predicate = FlatVector::GetData<int64_t>(predicate_vector);
-            filterSelectionType<int64_t>(result_flat, predicate, sel, approved_tuple_count, filter.comparison_type,
-                                         nullmask);
-            break;
-        }
-        case TypeId::FLOAT: {
-            auto result_flat = FlatVector::GetData<float>(result);
-            auto predicate_vector = Vector(filter.constant.value_.float_);
-            auto predicate = FlatVector::GetData<float>(predicate_vector);
-            filterSelectionType<float>(result_flat, predicate, sel, approved_tuple_count, filter.comparison_type,
-                                       nullmask);
-            break;
-        }
-        case TypeId::DOUBLE: {
-            auto result_flat = FlatVector::GetData<double>(result);
-            auto predicate_vector = Vector(filter.constant.value_.double_);
-            auto predicate = FlatVector::GetData<double>(predicate_vector);
-            filterSelectionType<double>(result_flat, predicate, sel, approved_tuple_count, filter.comparison_type,
-                                        nullmask);
-            break;
-        }
-        case TypeId::VARCHAR: {
-            auto result_flat = FlatVector::GetData<string_t>(result);
-            auto predicate_vector = Vector(filter.constant.str_value);
-            auto predicate = FlatVector::GetData<string_t>(predicate_vector);
-            filterSelectionType<string_t>(result_flat, predicate, sel, approved_tuple_count, filter.comparison_type,
-                                          nullmask);
-            break;
-        }
-        default:
-            throw InvalidTypeException(result.type, "Invalid type for filter pushed down to table comparison");
-    }
+	// the inplace loops take the result as the last parameter
+	switch (result.type) {
+	case TypeId::INT8: {
+		auto result_flat = FlatVector::GetData<int8_t>(result);
+		auto predicate_vector = Vector(filter.constant.value_.tinyint);
+		auto predicate = FlatVector::GetData<int8_t>(predicate_vector);
+		filterSelectionType<int8_t>(result_flat, predicate, sel, approved_tuple_count, filter.comparison_type,
+		                            nullmask);
+		break;
+	}
+	case TypeId::INT16: {
+		auto result_flat = FlatVector::GetData<int16_t>(result);
+		auto predicate_vector = Vector(filter.constant.value_.smallint);
+		auto predicate = FlatVector::GetData<int16_t>(predicate_vector);
+		filterSelectionType<int16_t>(result_flat, predicate, sel, approved_tuple_count, filter.comparison_type,
+		                             nullmask);
+		break;
+	}
+	case TypeId::INT32: {
+		auto result_flat = FlatVector::GetData<int32_t>(result);
+		auto predicate_vector = Vector(filter.constant.value_.integer);
+		auto predicate = FlatVector::GetData<int32_t>(predicate_vector);
+		filterSelectionType<int32_t>(result_flat, predicate, sel, approved_tuple_count, filter.comparison_type,
+		                             nullmask);
+		break;
+	}
+	case TypeId::INT64: {
+		auto result_flat = FlatVector::GetData<int64_t>(result);
+		auto predicate_vector = Vector(filter.constant.value_.bigint);
+		auto predicate = FlatVector::GetData<int64_t>(predicate_vector);
+		filterSelectionType<int64_t>(result_flat, predicate, sel, approved_tuple_count, filter.comparison_type,
+		                             nullmask);
+		break;
+	}
+	case TypeId::FLOAT: {
+		auto result_flat = FlatVector::GetData<float>(result);
+		auto predicate_vector = Vector(filter.constant.value_.float_);
+		auto predicate = FlatVector::GetData<float>(predicate_vector);
+		filterSelectionType<float>(result_flat, predicate, sel, approved_tuple_count, filter.comparison_type, nullmask);
+		break;
+	}
+	case TypeId::DOUBLE: {
+		auto result_flat = FlatVector::GetData<double>(result);
+		auto predicate_vector = Vector(filter.constant.value_.double_);
+		auto predicate = FlatVector::GetData<double>(predicate_vector);
+		filterSelectionType<double>(result_flat, predicate, sel, approved_tuple_count, filter.comparison_type,
+		                            nullmask);
+		break;
+	}
+	case TypeId::VARCHAR: {
+		auto result_flat = FlatVector::GetData<string_t>(result);
+		auto predicate_vector = Vector(filter.constant.str_value);
+		auto predicate = FlatVector::GetData<string_t>(predicate_vector);
+		filterSelectionType<string_t>(result_flat, predicate, sel, approved_tuple_count, filter.comparison_type,
+		                              nullmask);
+		break;
+	}
+	default:
+		throw InvalidTypeException(result.type, "Invalid type for filter pushed down to table comparison");
+	}
 }
 
 void UncompressedSegment::Select(Transaction &transaction, Vector &result, vector<TableFilter> &tableFilters,
                                  SelectionVector &sel, idx_t &approved_tuple_count, ColumnScanState &state) {
-    auto read_lock = lock.GetSharedLock();
-    if (versions && versions[state.vector_index]) {
-        Scan(transaction, state, state.vector_index, result, false);
-        auto vector_index = state.vector_index;
-        // pin the buffer for this segment
-        auto handle = manager.Pin(block_id);
-        auto data = handle->node->buffer;
-        auto offset = vector_index * vector_size;
-        auto source_nullmask = (nullmask_t *) (data + offset);
-        for (auto &table_filter : tableFilters) {
-            filterSelection(sel, result, table_filter, approved_tuple_count, *source_nullmask);
-        }
-    } else {
-        //! Select the data from the base table
-        Select(state, result, sel, approved_tuple_count, tableFilters);
-    }
+	auto read_lock = lock.GetSharedLock();
+	if (versions && versions[state.vector_index]) {
+		Scan(transaction, state, state.vector_index, result, false);
+		auto vector_index = state.vector_index;
+		// pin the buffer for this segment
+		auto handle = manager.Pin(block_id);
+		auto data = handle->node->buffer;
+		auto offset = vector_index * vector_size;
+		auto source_nullmask = (nullmask_t *)(data + offset);
+		for (auto &table_filter : tableFilters) {
+			filterSelection(sel, result, table_filter, approved_tuple_count, *source_nullmask);
+		}
+	} else {
+		//! Select the data from the base table
+		Select(state, result, sel, approved_tuple_count, tableFilters);
+	}
 }
 
 //===--------------------------------------------------------------------===//
@@ -300,77 +298,79 @@ void UncompressedSegment::Select(Transaction &transaction, Vector &result, vecto
 //===--------------------------------------------------------------------===//
 void UncompressedSegment::Scan(Transaction &transaction, ColumnScanState &state, idx_t vector_index, Vector &result,
                                bool get_lock) {
-    unique_ptr<StorageLockKey> read_lock;
-    if (get_lock) {
-        read_lock = lock.GetSharedLock();
-    }
-    // first fetch the data from the base table
-    FetchBaseData(state, vector_index, result);
-    if (versions && versions[vector_index]) {
-        // if there are any versions, check if we need to overwrite the data with the versioned data
-        FetchUpdateData(state, transaction, versions[vector_index], result);
-    }
+	unique_ptr<StorageLockKey> read_lock;
+	if (get_lock) {
+		read_lock = lock.GetSharedLock();
+	}
+	// first fetch the data from the base table
+	FetchBaseData(state, vector_index, result);
+	if (versions && versions[vector_index]) {
+		// if there are any versions, check if we need to overwrite the data with the versioned data
+		FetchUpdateData(state, transaction, versions[vector_index], result);
+	}
 }
 
 void UncompressedSegment::FilterScan(Transaction &transaction, ColumnScanState &state, Vector &result,
                                      SelectionVector &sel, idx_t &approved_tuple_count) {
-    auto read_lock = lock.GetSharedLock();
-    if (versions && versions[state.vector_index]) {
-        // if there are any versions, we do a regular scan
-        Scan(transaction, state, state.vector_index, result, false);
-        result.Slice(sel, approved_tuple_count);
-    } else {
-        FilterFetchBaseData(state, result, sel, approved_tuple_count);
-    }
+	auto read_lock = lock.GetSharedLock();
+	if (versions && versions[state.vector_index]) {
+		// if there are any versions, we do a regular scan
+		Scan(transaction, state, state.vector_index, result, false);
+		result.Slice(sel, approved_tuple_count);
+	} else {
+		FilterFetchBaseData(state, result, sel, approved_tuple_count);
+	}
 }
 
 void UncompressedSegment::IndexScan(ColumnScanState &state, idx_t vector_index, Vector &result) {
-    if (vector_index == 0) {
-        // vector_index = 0, obtain a shared lock on the segment that we keep until the index scan is complete
-        state.locks.push_back(lock.GetSharedLock());
-    }
-    if (versions && versions[vector_index]) {
-        throw TransactionException("Cannot create index with outstanding updates");
-    }
-    FetchBaseData(state, vector_index, result);
+	if (vector_index == 0) {
+		// vector_index = 0, obtain a shared lock on the segment that we keep until the index scan is complete
+		state.locks.push_back(lock.GetSharedLock());
+	}
+	if (versions && versions[vector_index]) {
+		throw TransactionException("Cannot create index with outstanding updates");
+	}
+	FetchBaseData(state, vector_index, result);
 }
 
 //===--------------------------------------------------------------------===//
 // Update
 //===--------------------------------------------------------------------===//
 void UncompressedSegment::CleanupUpdate(UpdateInfo *info) {
-    if (info->prev) {
-        // there is a prev info: remove from the chain
-        auto prev = info->prev;
-        prev->next = info->next;
-        if (prev->next) {
-            prev->next->prev = prev;
-        }
-    } else {
-        // there is no prev info: remove from base segment
-        info->segment->versions[info->vector_index] = info->next;
-        if (info->next) {
-            info->next->prev = nullptr;
-        }
-    }
+	if (info->prev) {
+		// there is a prev info: remove from the chain
+		auto prev = info->prev;
+		prev->next = info->next;
+		if (prev->next) {
+			prev->next->prev = prev;
+		}
+	} else {
+		// there is no prev info: remove from base segment
+		info->segment->versions[info->vector_index] = info->next;
+		if (info->next) {
+			info->next->prev = nullptr;
+		}
+	}
 }
 
 //===--------------------------------------------------------------------===//
 // ToTemporary
 //===--------------------------------------------------------------------===//
 void UncompressedSegment::ToTemporary() {
-    auto write_lock = lock.GetExclusiveLock();
+	auto write_lock = lock.GetExclusiveLock();
 
-    if (block_id >= MAXIMUM_BLOCK) {
-        // conversion has already been performed by a different thread
-        return;
-    }
-    // pin the current block
-    auto current = manager.Pin(block_id);
+	if (block_id >= MAXIMUM_BLOCK) {
+		// conversion has already been performed by a different thread
+		return;
+	}
+	// pin the current block
+	auto current = manager.Pin(block_id);
 
-    // now allocate a new block from the buffer manager
-    auto handle = manager.Allocate(Storage::BLOCK_ALLOC_SIZE);
-    // now copy the data over and switch to using the new block id
-    memcpy(handle->node->buffer, current->node->buffer, Storage::BLOCK_SIZE);
-    this->block_id = handle->block_id;
+	// now allocate a new block from the buffer manager
+	auto handle = manager.Allocate(Storage::BLOCK_ALLOC_SIZE);
+	// now copy the data over and switch to using the new block id
+	memcpy(handle->node->buffer, current->node->buffer, Storage::BLOCK_SIZE);
+	this->block_id = handle->block_id;
 }
+
+} // namespace duckdb

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -1,7 +1,6 @@
 #include "duckdb/storage/write_ahead_log.hpp"
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/common/serializer/buffered_file_reader.hpp"
-#include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -16,9 +15,9 @@
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/string_util.hpp"
 
-using namespace duckdb;
 using namespace std;
 
+namespace duckdb {
 class ReplayState {
 public:
 	ReplayState(DuckDB &db, ClientContext &context, Deserializer &source)
@@ -313,3 +312,5 @@ void ReplayState::ReplayUpdate() {
 	// now perform the update
 	current_table->storage->Update(*current_table, context, row_ids, column_ids, chunk);
 }
+
+} // namespace duckdb

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -6,14 +6,16 @@
 #include "duckdb/parser/parsed_data/alter_table_info.hpp"
 #include <cstring>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 WriteAheadLog::WriteAheadLog(DuckDB &database) : initialized(false), database(database) {
 }
 
 void WriteAheadLog::Initialize(string &path) {
-	writer = make_unique<BufferedFileWriter>(database.GetFileSystem(), path.c_str(), FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE | FileFlags::FILE_FLAGS_APPEND);
+	writer = make_unique<BufferedFileWriter>(database.GetFileSystem(), path.c_str(),
+	                                         FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE |
+	                                             FileFlags::FILE_FLAGS_APPEND);
 	initialized = true;
 }
 
@@ -148,3 +150,5 @@ void WriteAheadLog::Flush() {
 	// flushes all changes made to the WAL to disk
 	writer->Sync();
 }
+
+} // namespace duckdb

--- a/src/transaction/cleanup_state.cpp
+++ b/src/transaction/cleanup_state.cpp
@@ -8,7 +8,7 @@
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/dependency_manager.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 CleanupState::CleanupState() : current_table(nullptr), count(0) {
@@ -87,3 +87,5 @@ void CleanupState::Flush() {
 
 	count = 0;
 }
+
+} // namespace duckdb

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -8,7 +8,7 @@
 #include "duckdb/common/serializer/buffered_deserializer.hpp"
 #include "duckdb/parser/parsed_data/alter_table_info.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 CommitState::CommitState(transaction_t commit_id, WriteAheadLog *log)
@@ -204,3 +204,5 @@ void CommitState::RevertCommit(UndoFlags type, data_ptr_t data) {
 
 template void CommitState::CommitEntry<true>(UndoFlags type, data_ptr_t data);
 template void CommitState::CommitEntry<false>(UndoFlags type, data_ptr_t data);
+
+} // namespace duckdb

--- a/src/transaction/rollback_state.cpp
+++ b/src/transaction/rollback_state.cpp
@@ -8,7 +8,7 @@
 #include "duckdb/catalog/catalog_entry.hpp"
 #include "duckdb/catalog/catalog_set.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 void RollbackState::RollbackEntry(UndoFlags type, data_ptr_t data) {
@@ -36,3 +36,5 @@ void RollbackState::RollbackEntry(UndoFlags type, data_ptr_t data) {
 		break;
 	}
 }
+
+} // namespace duckdb

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -12,7 +12,7 @@
 
 #include <cstring>
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 Transaction &Transaction::GetTransaction(ClientContext &context) {
@@ -94,3 +94,5 @@ string Transaction::Commit(WriteAheadLog *log, transaction_t commit_id) noexcept
 		return ex.what();
 	}
 }
+
+} // namespace duckdb

--- a/src/transaction/transaction_context.cpp
+++ b/src/transaction/transaction_context.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/transaction/transaction.hpp"
 #include "duckdb/transaction/transaction_manager.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 TransactionContext::~TransactionContext() {
@@ -42,3 +42,5 @@ void TransactionContext::Rollback() {
 	current_transaction = nullptr;
 	transaction_manager.RollbackTransaction(transaction);
 }
+
+} // namespace duckdb

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -9,7 +9,7 @@
 #include "duckdb/storage/storage_manager.hpp"
 #include "duckdb/transaction/transaction.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 using namespace std;
 
 TransactionManager::TransactionManager(StorageManager &storage) : storage(storage) {
@@ -190,3 +190,5 @@ void TransactionManager::AddCatalogSet(ClientContext &context, unique_ptr<Catalo
 		old_catalog_sets.push_back(move(set));
 	}
 }
+
+} // namespace duckdb

--- a/third_party/re2/util/logging.h
+++ b/third_party/re2/util/logging.h
@@ -54,6 +54,9 @@
 
 #define VLOG(x) if((x)>0){}else LOG_INFO.stream()
 
+namespace duckdb_re2 {
+
+
 class LogMessage {
  public:
   LogMessage(const char* file, int line)
@@ -103,6 +106,7 @@ class LogMessageFatal : public LogMessage {
   LogMessageFatal(const LogMessageFatal&) = delete;
   LogMessageFatal& operator=(const LogMessageFatal&) = delete;
 };
+} // namespace
 
 #ifdef _MSC_VER
 //#pragma warning(pop)


### PR DESCRIPTION
We want to not leak symbols into the global namespace. We therefore remove `using namespace duckdb;` from the `.cpp` files and wrap their contents in `namespace duckdb {` ... `}`.