### PR TITLE
JDBC: connect() should return `null` when passed wrong URL

### DIFF
--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBDriver.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBDriver.java
@@ -21,6 +21,9 @@ public class DuckDBDriver implements java.sql.Driver {
 	}
 
 	public Connection connect(String url, Properties info) throws SQLException {
+		if (!acceptsURL(url)) {
+			return null;
+		}
 		boolean read_only = false;
 		if (info != null) {
 			String prop_val = info.getProperty(DUCKDB_READONLY_PROPERTY);

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -6,8 +6,9 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.sql.Connection;
+import java.sql.Driver;
 import java.sql.DriverManager;
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -15,6 +16,8 @@ import java.sql.Statement;
 import java.util.Properties;
 
 import org.duckdb.DuckDBConnection;
+import org.duckdb.DuckDBDriver;
+
 
 public class TestDuckDBJDBC {
 
@@ -685,6 +688,11 @@ public class TestDuckDBJDBC {
 		rs.close();
 		stmt.close();
 		conn.close();
+	}
+
+	public static void test_connect_wrong_url_bug848() throws Exception {
+		Driver d = new DuckDBDriver();
+		assertNull(d.connect("jdbc:h2:", null));
 	}
 
 	public static void main(String[] args) throws Exception {


### PR DESCRIPTION
See here: https://docs.oracle.com/javase/7/docs/api/java/sql/Driver.html#connect(java.lang.String,%20java.util.Properties)