### PR TITLE
Avoid calls to DataChunk::Reset and many vector initializations

### DIFF
--- a/src/execution/expression_executor.cpp
+++ b/src/execution/expression_executor.cpp
@@ -41,7 +41,6 @@ void ExpressionExecutor::Execute(DataChunk *input, DataChunk &result) {
 
 	assert(expressions.size() == result.column_count());
 	assert(expressions.size() > 0);
-	result.Reset();
 	for (idx_t i = 0; i < expressions.size(); i++) {
 		ExecuteExpression(i, result.data[i]);
 	}

--- a/src/execution/expression_executor/execute_between.cpp
+++ b/src/execution/expression_executor/execute_between.cpp
@@ -70,13 +70,18 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(BoundBetweenExpr
 	result->AddChild(expr.input.get());
 	result->AddChild(expr.lower.get());
 	result->AddChild(expr.upper.get());
+	result->Finalize();
 	return result;
 }
 
 void ExpressionExecutor::Execute(BoundBetweenExpression &expr, ExpressionState *state, const SelectionVector *sel,
                                  idx_t count, Vector &result) {
 	// resolve the children
-	Vector input(expr.input->return_type), lower(expr.lower->return_type), upper(expr.upper->return_type);
+	Vector input, lower, upper;
+	input.Reference(state->intermediate_chunk.data[0]);
+	lower.Reference(state->intermediate_chunk.data[1]);
+	upper.Reference(state->intermediate_chunk.data[2]);
+
 	Execute(*expr.input, state->child_states[0].get(), sel, count, input);
 	Execute(*expr.lower, state->child_states[1].get(), sel, count, lower);
 	Execute(*expr.upper, state->child_states[2].get(), sel, count, upper);
@@ -103,7 +108,11 @@ void ExpressionExecutor::Execute(BoundBetweenExpression &expr, ExpressionState *
 idx_t ExpressionExecutor::Select(BoundBetweenExpression &expr, ExpressionState *state, const SelectionVector *sel,
                                  idx_t count, SelectionVector *true_sel, SelectionVector *false_sel) {
 	// resolve the children
-	Vector input(expr.input->return_type), lower(expr.lower->return_type), upper(expr.upper->return_type);
+	Vector input, lower, upper;
+	input.Reference(state->intermediate_chunk.data[0]);
+	lower.Reference(state->intermediate_chunk.data[1]);
+	upper.Reference(state->intermediate_chunk.data[2]);
+
 	Execute(*expr.input, state->child_states[0].get(), sel, count, input);
 	Execute(*expr.lower, state->child_states[1].get(), sel, count, lower);
 	Execute(*expr.upper, state->child_states[2].get(), sel, count, upper);

--- a/src/execution/expression_executor/execute_case.cpp
+++ b/src/execution/expression_executor/execute_case.cpp
@@ -15,12 +15,15 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(BoundCaseExpress
 	result->AddChild(expr.check.get());
 	result->AddChild(expr.result_if_true.get());
 	result->AddChild(expr.result_if_false.get());
+	result->Finalize();
 	return result;
 }
 
 void ExpressionExecutor::Execute(BoundCaseExpression &expr, ExpressionState *state, const SelectionVector *sel,
                                  idx_t count, Vector &result) {
-	Vector res_true(expr.result_if_true->return_type), res_false(expr.result_if_false->return_type);
+	Vector res_true, res_false;
+	res_true.Reference(state->intermediate_chunk.data[1]);
+	res_false.Reference(state->intermediate_chunk.data[2]);
 
 	auto check_state = state->child_states[0].get();
 	auto res_true_state = state->child_states[1].get();

--- a/src/execution/expression_executor/execute_cast.cpp
+++ b/src/execution/expression_executor/execute_cast.cpp
@@ -9,13 +9,15 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(BoundCastExpress
                                                                 ExpressionExecutorState &root) {
 	auto result = make_unique<ExpressionState>(expr, root);
 	result->AddChild(expr.child.get());
+	result->Finalize();
 	return result;
 }
 
 void ExpressionExecutor::Execute(BoundCastExpression &expr, ExpressionState *state, const SelectionVector *sel,
                                  idx_t count, Vector &result) {
 	// resolve the child
-	Vector child(expr.child->return_type);
+	Vector child;
+	child.Reference(state->intermediate_chunk.data[0]);
 	auto child_state = state->child_states[0].get();
 
 	Execute(*expr.child, child_state, sel, count, child);

--- a/src/execution/expression_executor/execute_conjunction.cpp
+++ b/src/execution/expression_executor/execute_conjunction.cpp
@@ -23,6 +23,7 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(BoundConjunction
 	for (auto &child : expr.children) {
 		result->AddChild(child.get());
 	}
+	result->Finalize();
 	return move(result);
 }
 
@@ -30,7 +31,8 @@ void ExpressionExecutor::Execute(BoundConjunctionExpression &expr, ExpressionSta
                                  idx_t count, Vector &result) {
 	// execute the children
 	for (idx_t i = 0; i < expr.children.size(); i++) {
-		Vector current_result(LogicalType::BOOLEAN);
+		Vector current_result;
+		current_result.Reference(state->intermediate_chunk.data[i]);
 		Execute(*expr.children[i], state->child_states[i].get(), sel, count, current_result);
 		if (i == 0) {
 			// move the result

--- a/src/execution/expression_executor/execute_operator.cpp
+++ b/src/execution/expression_executor/execute_operator.cpp
@@ -11,6 +11,7 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(BoundOperatorExp
 	for (auto &child : expr.children) {
 		result->AddChild(child.get());
 	}
+	result->Finalize();
 	return result;
 }
 
@@ -59,7 +60,9 @@ void ExpressionExecutor::Execute(BoundOperatorExpression &expr, ExpressionState 
 			result.Reference(intermediate);
 		}
 	} else if (expr.children.size() == 1) {
-		Vector child(expr.children[0]->return_type);
+		Vector child;
+		child.Reference(state->intermediate_chunk.data[0]);
+
 		Execute(*expr.children[0], state->child_states[0].get(), sel, count, child);
 		switch (expr.type) {
 		case ExpressionType::OPERATOR_NOT: {

--- a/src/execution/expression_executor_state.cpp
+++ b/src/execution/expression_executor_state.cpp
@@ -6,7 +6,14 @@ namespace duckdb {
 using namespace std;
 
 void ExpressionState::AddChild(Expression *expr) {
+	types.push_back(expr->return_type);
 	child_states.push_back(ExpressionExecutor::InitializeState(*expr, root));
+}
+
+void ExpressionState::Finalize() {
+	if (types.size() > 0) {
+		intermediate_chunk.Initialize(types);
+	}
 }
 
 } // namespace duckdb

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -147,9 +147,9 @@ void PhysicalHashAggregate::Sink(ExecutionContext &context, GlobalOperatorState 
 //===--------------------------------------------------------------------===//
 class PhysicalHashAggregateState : public PhysicalOperatorState {
 public:
-	PhysicalHashAggregateState(vector<LogicalType> &group_types, vector<LogicalType> &aggregate_types,
+	PhysicalHashAggregateState(PhysicalOperator &op, vector<LogicalType> &group_types, vector<LogicalType> &aggregate_types,
 	                           PhysicalOperator *child)
-	    : PhysicalOperatorState(child), ht_scan_position(0) {
+	    : PhysicalOperatorState(op, child), ht_scan_position(0) {
 		group_chunk.Initialize(group_types);
 		if (aggregate_types.size() > 0) {
 			aggregate_chunk.Initialize(aggregate_types);
@@ -212,7 +212,7 @@ void PhysicalHashAggregate::GetChunkInternal(ExecutionContext &context, DataChun
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalHashAggregate::GetOperatorState() {
-	return make_unique<PhysicalHashAggregateState>(group_types, aggregate_types,
+	return make_unique<PhysicalHashAggregateState>(*this, group_types, aggregate_types,
 	                                               children.size() == 0 ? nullptr : children[0].get());
 }
 

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -16,7 +16,7 @@ namespace duckdb {
 //! The operator state of the window
 class PhysicalWindowOperatorState : public PhysicalOperatorState {
 public:
-	PhysicalWindowOperatorState(PhysicalOperator *child) : PhysicalOperatorState(child), position(0) {
+	PhysicalWindowOperatorState(PhysicalOperator &op, PhysicalOperator *child) : PhysicalOperatorState(op, child), position(0) {
 	}
 
 	idx_t position;
@@ -533,7 +533,7 @@ void PhysicalWindow::GetChunkInternal(ExecutionContext &context, DataChunk &chun
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalWindow::GetOperatorState() {
-	return make_unique<PhysicalWindowOperatorState>(children[0].get());
+	return make_unique<PhysicalWindowOperatorState>(*this, children[0].get());
 }
 
 } // namespace duckdb

--- a/src/execution/operator/filter/physical_filter.cpp
+++ b/src/execution/operator/filter/physical_filter.cpp
@@ -8,7 +8,7 @@ namespace duckdb {
 
 class PhysicalFilterState : public PhysicalOperatorState {
 public:
-	PhysicalFilterState(PhysicalOperator *child, Expression &expr) : PhysicalOperatorState(child), executor(expr) {
+	PhysicalFilterState(PhysicalOperator &op, PhysicalOperator *child, Expression &expr) : PhysicalOperatorState(op, child), executor(expr) {
 	}
 
 	ExpressionExecutor executor;
@@ -53,7 +53,7 @@ void PhysicalFilter::GetChunkInternal(ExecutionContext &context, DataChunk &chun
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalFilter::GetOperatorState() {
-	return make_unique<PhysicalFilterState>(children[0].get(), *expression);
+	return make_unique<PhysicalFilterState>(*this, children[0].get(), *expression);
 }
 
 string PhysicalFilter::ExtraRenderInformation() const {

--- a/src/execution/operator/helper/physical_limit.cpp
+++ b/src/execution/operator/helper/physical_limit.cpp
@@ -8,8 +8,8 @@ namespace duckdb {
 
 class PhysicalLimitOperatorState : public PhysicalOperatorState {
 public:
-	PhysicalLimitOperatorState(PhysicalOperator *child, idx_t current_offset = 0)
-	    : PhysicalOperatorState(child), current_offset(current_offset) {
+	PhysicalLimitOperatorState(PhysicalOperator &op, PhysicalOperator *child, idx_t current_offset = 0)
+	    : PhysicalOperatorState(op, child), current_offset(current_offset) {
 	}
 
 	idx_t current_offset;
@@ -64,7 +64,7 @@ void PhysicalLimit::GetChunkInternal(ExecutionContext &context, DataChunk &chunk
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalLimit::GetOperatorState() {
-	return make_unique<PhysicalLimitOperatorState>(children[0].get(), 0);
+	return make_unique<PhysicalLimitOperatorState>(*this, children[0].get(), 0);
 }
 
 } // namespace duckdb

--- a/src/execution/operator/join/physical_blockwise_nl_join.cpp
+++ b/src/execution/operator/join/physical_blockwise_nl_join.cpp
@@ -72,8 +72,8 @@ void PhysicalBlockwiseNLJoin::Finalize(ClientContext &context, unique_ptr<Global
 //===--------------------------------------------------------------------===//
 class PhysicalBlockwiseNLJoinState : public PhysicalOperatorState {
 public:
-	PhysicalBlockwiseNLJoinState(PhysicalOperator *left, JoinType join_type, Expression &condition)
-	    : PhysicalOperatorState(left), left_position(0), right_position(0), fill_in_rhs(false),
+	PhysicalBlockwiseNLJoinState(PhysicalOperator &op, PhysicalOperator *left, JoinType join_type, Expression &condition)
+	    : PhysicalOperatorState(op, left), left_position(0), right_position(0), fill_in_rhs(false),
 	      checked_found_match(false), executor(condition) {
 		if (join_type == JoinType::LEFT || join_type == JoinType::OUTER) {
 			lhs_found_match = unique_ptr<bool[]>(new bool[STANDARD_VECTOR_SIZE]);
@@ -213,7 +213,7 @@ void PhysicalBlockwiseNLJoin::GetChunkInternal(ExecutionContext &context, DataCh
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalBlockwiseNLJoin::GetOperatorState() {
-	return make_unique<PhysicalBlockwiseNLJoinState>(children[0].get(), join_type, *condition);
+	return make_unique<PhysicalBlockwiseNLJoinState>(*this, children[0].get(), join_type, *condition);
 }
 
 string PhysicalBlockwiseNLJoin::ExtraRenderInformation() const {

--- a/src/execution/operator/join/physical_cross_product.cpp
+++ b/src/execution/operator/join/physical_cross_product.cpp
@@ -7,8 +7,8 @@ using namespace std;
 
 class PhysicalCrossProductOperatorState : public PhysicalOperatorState {
 public:
-	PhysicalCrossProductOperatorState(PhysicalOperator *left, PhysicalOperator *right)
-	    : PhysicalOperatorState(left), left_position(0) {
+	PhysicalCrossProductOperatorState(PhysicalOperator &op, PhysicalOperator *left, PhysicalOperator *right)
+	    : PhysicalOperatorState(op, left), left_position(0) {
 		assert(left && right);
 	}
 
@@ -87,7 +87,7 @@ void PhysicalCrossProduct::GetChunkInternal(ExecutionContext &context, DataChunk
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalCrossProduct::GetOperatorState() {
-	return make_unique<PhysicalCrossProductOperatorState>(children[0].get(), children[1].get());
+	return make_unique<PhysicalCrossProductOperatorState>(*this, children[0].get(), children[1].get());
 }
 
 } // namespace duckdb

--- a/src/execution/operator/join/physical_delim_join.cpp
+++ b/src/execution/operator/join/physical_delim_join.cpp
@@ -12,7 +12,7 @@ namespace duckdb {
 
 class PhysicalDelimJoinState : public PhysicalOperatorState {
 public:
-	PhysicalDelimJoinState(PhysicalOperator *left) : PhysicalOperatorState(left) {
+	PhysicalDelimJoinState(PhysicalOperator &op, PhysicalOperator *left) : PhysicalOperatorState(op, left) {
 	}
 
 	unique_ptr<PhysicalOperatorState> join_state;
@@ -102,7 +102,7 @@ void PhysicalDelimJoin::GetChunkInternal(ExecutionContext &context, DataChunk &c
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalDelimJoin::GetOperatorState() {
-	return make_unique<PhysicalDelimJoinState>(children[0].get());
+	return make_unique<PhysicalDelimJoinState>(*this, children[0].get());
 }
 
 string PhysicalDelimJoin::ExtraRenderInformation() const {

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -143,8 +143,8 @@ void PhysicalHashJoin::Finalize(ClientContext &context, unique_ptr<GlobalOperato
 //===--------------------------------------------------------------------===//
 class PhysicalHashJoinState : public PhysicalOperatorState {
 public:
-	PhysicalHashJoinState(PhysicalOperator *left, PhysicalOperator *right, vector<JoinCondition> &conditions)
-	    : PhysicalOperatorState(left) {
+	PhysicalHashJoinState(PhysicalOperator &op, PhysicalOperator *left, PhysicalOperator *right, vector<JoinCondition> &conditions)
+	    : PhysicalOperatorState(op, left) {
 	}
 
 	DataChunk cached_chunk;
@@ -154,7 +154,7 @@ public:
 };
 
 unique_ptr<PhysicalOperatorState> PhysicalHashJoin::GetOperatorState() {
-	auto state = make_unique<PhysicalHashJoinState>(children[0].get(), children[1].get(), conditions);
+	auto state = make_unique<PhysicalHashJoinState>(*this, children[0].get(), children[1].get(), conditions);
 	state->cached_chunk.Initialize(types);
 	state->join_keys.Initialize(condition_types);
 	for (auto &cond : conditions) {

--- a/src/execution/operator/join/physical_nested_loop_join.cpp
+++ b/src/execution/operator/join/physical_nested_loop_join.cpp
@@ -187,8 +187,8 @@ unique_ptr<LocalSinkState> PhysicalNestedLoopJoin::GetLocalSinkState(ExecutionCo
 //===--------------------------------------------------------------------===//
 class PhysicalNestedLoopJoinState : public PhysicalOperatorState {
 public:
-	PhysicalNestedLoopJoinState(PhysicalOperator *left, vector<JoinCondition> &conditions)
-	    : PhysicalOperatorState(left), fetch_next_left(true), fetch_next_right(false), right_chunk(0), left_tuple(0),
+	PhysicalNestedLoopJoinState(PhysicalOperator &op, PhysicalOperator *left, vector<JoinCondition> &conditions)
+	    : PhysicalOperatorState(op, left), fetch_next_left(true), fetch_next_right(false), right_chunk(0), left_tuple(0),
 	      right_tuple(0) {
 		vector<LogicalType> condition_types;
 		for (auto &cond : conditions) {
@@ -389,7 +389,7 @@ void PhysicalNestedLoopJoin::GetChunkInternal(ExecutionContext &context, DataChu
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalNestedLoopJoin::GetOperatorState() {
-	return make_unique<PhysicalNestedLoopJoinState>(children[0].get(), conditions);
+	return make_unique<PhysicalNestedLoopJoinState>(*this, children[0].get(), conditions);
 }
 
 } // namespace duckdb

--- a/src/execution/operator/join/physical_piecewise_merge_join.cpp
+++ b/src/execution/operator/join/physical_piecewise_merge_join.cpp
@@ -128,8 +128,8 @@ void PhysicalPiecewiseMergeJoin::Finalize(ClientContext &context, unique_ptr<Glo
 //===--------------------------------------------------------------------===//
 class PhysicalPiecewiseMergeJoinState : public PhysicalOperatorState {
 public:
-	PhysicalPiecewiseMergeJoinState(PhysicalOperator *left, vector<JoinCondition> &conditions)
-	    : PhysicalOperatorState(left), fetch_next_left(true), left_position(0), right_position(0),
+	PhysicalPiecewiseMergeJoinState(PhysicalOperator &op, PhysicalOperator *left, vector<JoinCondition> &conditions)
+	    : PhysicalOperatorState(op, left), fetch_next_left(true), left_position(0), right_position(0),
 	      right_chunk_index(0) {
 		vector<LogicalType> condition_types;
 		for (auto &cond : conditions) {
@@ -315,7 +315,7 @@ void PhysicalPiecewiseMergeJoin::GetChunkInternal(ExecutionContext &context, Dat
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalPiecewiseMergeJoin::GetOperatorState() {
-	return make_unique<PhysicalPiecewiseMergeJoinState>(children[0].get(), conditions);
+	return make_unique<PhysicalPiecewiseMergeJoinState>(*this, children[0].get(), conditions);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/order/physical_order.cpp
+++ b/src/execution/operator/order/physical_order.cpp
@@ -12,7 +12,7 @@ namespace duckdb {
 
 class PhysicalOrderOperatorState : public PhysicalOperatorState {
 public:
-	PhysicalOrderOperatorState(PhysicalOperator *child) : PhysicalOperatorState(child), position(0) {
+	PhysicalOrderOperatorState(PhysicalOperator &op, PhysicalOperator *child) : PhysicalOperatorState(op, child), position(0) {
 	}
 
 	idx_t position;
@@ -98,7 +98,7 @@ void PhysicalOrder::GetChunkInternal(ExecutionContext &context, DataChunk &chunk
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalOrder::GetOperatorState() {
-	return make_unique<PhysicalOrderOperatorState>(children[0].get());
+	return make_unique<PhysicalOrderOperatorState>(*this, children[0].get());
 }
 
 } // namespace duckdb

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -120,7 +120,7 @@ void PhysicalTopN::Finalize(ClientContext &context, unique_ptr<GlobalOperatorSta
 //===--------------------------------------------------------------------===//
 class PhysicalTopNOperatorState : public PhysicalOperatorState {
 public:
-	PhysicalTopNOperatorState(PhysicalOperator *child) : PhysicalOperatorState(child), position(0) {
+	PhysicalTopNOperatorState(PhysicalOperator &op, PhysicalOperator *child) : PhysicalOperatorState(op, child), position(0) {
 	}
 
 	idx_t position;
@@ -140,7 +140,7 @@ void PhysicalTopN::GetChunkInternal(ExecutionContext &context, DataChunk &chunk,
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalTopN::GetOperatorState() {
-	return make_unique<PhysicalTopNOperatorState>(children[0].get());
+	return make_unique<PhysicalTopNOperatorState>(*this, children[0].get());
 }
 
 } // namespace duckdb

--- a/src/execution/operator/persistent/physical_copy_from_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_from_file.cpp
@@ -10,7 +10,7 @@ namespace duckdb {
 
 class PhysicalCopyFromFileOperatorState : public PhysicalOperatorState {
 public:
-	PhysicalCopyFromFileOperatorState() : PhysicalOperatorState(nullptr) {}
+	PhysicalCopyFromFileOperatorState(PhysicalOperator &op) : PhysicalOperatorState(op, nullptr) {}
 	//! The global function data
 	unique_ptr<GlobalFunctionData> gdata;
 };
@@ -27,7 +27,7 @@ void PhysicalCopyFromFile::GetChunkInternal(ExecutionContext &context, DataChunk
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalCopyFromFile::GetOperatorState() {
-	return make_unique<PhysicalCopyFromFileOperatorState>();
+	return make_unique<PhysicalCopyFromFileOperatorState>(*this);
 }
 
 } // namespace duckdb

--- a/src/execution/operator/projection/physical_projection.cpp
+++ b/src/execution/operator/projection/physical_projection.cpp
@@ -8,8 +8,8 @@ namespace duckdb {
 
 class PhysicalProjectionState : public PhysicalOperatorState {
 public:
-	PhysicalProjectionState(PhysicalOperator *child, vector<unique_ptr<Expression>> &expressions)
-	    : PhysicalOperatorState(child), executor(expressions) {
+	PhysicalProjectionState(PhysicalOperator &op, PhysicalOperator *child, vector<unique_ptr<Expression>> &expressions)
+	    : PhysicalOperatorState(op, child), executor(expressions) {
 		assert(child);
 	}
 
@@ -29,7 +29,7 @@ void PhysicalProjection::GetChunkInternal(ExecutionContext &context, DataChunk &
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalProjection::GetOperatorState() {
-	return make_unique<PhysicalProjectionState>(children[0].get(), select_list);
+	return make_unique<PhysicalProjectionState>(*this, children[0].get(), select_list);
 }
 
 string PhysicalProjection::ExtraRenderInformation() const {

--- a/src/execution/operator/projection/physical_unnest.cpp
+++ b/src/execution/operator/projection/physical_unnest.cpp
@@ -13,8 +13,8 @@ namespace duckdb {
 //! The operator state of the window
 class PhysicalUnnestOperatorState : public PhysicalOperatorState {
 public:
-	PhysicalUnnestOperatorState(PhysicalOperator *child)
-	    : PhysicalOperatorState(child), parent_position(0), list_position(0), list_length(-1) {
+	PhysicalUnnestOperatorState(PhysicalOperator &op, PhysicalOperator *child)
+	    : PhysicalOperatorState(op, child), parent_position(0), list_position(0), list_length(-1) {
 	}
 
 	idx_t parent_position;
@@ -128,7 +128,7 @@ void PhysicalUnnest::GetChunkInternal(ExecutionContext &context, DataChunk &chun
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalUnnest::GetOperatorState() {
-	return make_unique<PhysicalUnnestOperatorState>(children[0].get());
+	return make_unique<PhysicalUnnestOperatorState>(*this, children[0].get());
 }
 
 } // namespace duckdb

--- a/src/execution/operator/scan/physical_chunk_scan.cpp
+++ b/src/execution/operator/scan/physical_chunk_scan.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 
 class PhysicalChunkScanState : public PhysicalOperatorState {
 public:
-	PhysicalChunkScanState() : PhysicalOperatorState(nullptr), chunk_index(0) {
+	PhysicalChunkScanState(PhysicalOperator &op) : PhysicalOperatorState(op, nullptr), chunk_index(0) {
 	}
 
 	//! The current position in the scan
@@ -29,7 +29,7 @@ void PhysicalChunkScan::GetChunkInternal(ExecutionContext &context, DataChunk &c
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalChunkScan::GetOperatorState() {
-	return make_unique<PhysicalChunkScanState>();
+	return make_unique<PhysicalChunkScanState>(*this);
 }
 
 } // namespace duckdb

--- a/src/execution/operator/scan/physical_expression_scan.cpp
+++ b/src/execution/operator/scan/physical_expression_scan.cpp
@@ -8,7 +8,7 @@ namespace duckdb {
 
 class PhysicalExpressionScanState : public PhysicalOperatorState {
 public:
-	PhysicalExpressionScanState(PhysicalOperator *child) : PhysicalOperatorState(child), expression_index(0) {
+	PhysicalExpressionScanState(PhysicalOperator &op, PhysicalOperator *child) : PhysicalOperatorState(op, child), expression_index(0) {
 	}
 
 	//! The current position in the scan
@@ -41,7 +41,7 @@ void PhysicalExpressionScan::GetChunkInternal(ExecutionContext &context, DataChu
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalExpressionScan::GetOperatorState() {
-	return make_unique<PhysicalExpressionScanState>(children[0].get());
+	return make_unique<PhysicalExpressionScanState>(*this, children[0].get());
 }
 
 } // namespace duckdb

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -14,7 +14,7 @@ namespace duckdb {
 
 class PhysicalTableScanOperatorState : public PhysicalOperatorState {
 public:
-	PhysicalTableScanOperatorState() : PhysicalOperatorState(nullptr), initialized(false) {
+	PhysicalTableScanOperatorState(PhysicalOperator &op) : PhysicalOperatorState(op, nullptr), initialized(false) {
 	}
 
 	unique_ptr<FunctionOperatorData> operator_data;
@@ -72,7 +72,7 @@ string PhysicalTableScan::ToString(idx_t depth) const {
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalTableScan::GetOperatorState() {
-	return make_unique<PhysicalTableScanOperatorState>();
+	return make_unique<PhysicalTableScanOperatorState>(*this);
 }
 
 } // namespace duckdb

--- a/src/execution/operator/set/physical_recursive_cte.cpp
+++ b/src/execution/operator/set/physical_recursive_cte.cpp
@@ -12,7 +12,7 @@ namespace duckdb {
 
 class PhysicalRecursiveCTEState : public PhysicalOperatorState {
 public:
-	PhysicalRecursiveCTEState() : PhysicalOperatorState(nullptr), top_done(false) {
+	PhysicalRecursiveCTEState(PhysicalOperator &op) : PhysicalOperatorState(op, nullptr), top_done(false) {
 	}
 	unique_ptr<PhysicalOperatorState> top_state;
 	unique_ptr<PhysicalOperatorState> bottom_state;
@@ -143,7 +143,7 @@ idx_t PhysicalRecursiveCTE::ProbeHT(DataChunk &chunk, PhysicalOperatorState *sta
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalRecursiveCTE::GetOperatorState() {
-	auto state = make_unique<PhysicalRecursiveCTEState>();
+	auto state = make_unique<PhysicalRecursiveCTEState>(*this);
 	state->top_state = children[0]->GetOperatorState();
 	state->bottom_state = children[1]->GetOperatorState();
 	state->ht =

--- a/src/execution/operator/set/physical_union.cpp
+++ b/src/execution/operator/set/physical_union.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 
 class PhysicalUnionOperatorState : public PhysicalOperatorState {
 public:
-	PhysicalUnionOperatorState() : PhysicalOperatorState(nullptr), top_done(false) {
+	PhysicalUnionOperatorState(PhysicalOperator &op) : PhysicalOperatorState(op, nullptr), top_done(false) {
 	}
 	unique_ptr<PhysicalOperatorState> top_state;
 	unique_ptr<PhysicalOperatorState> bottom_state;
@@ -38,7 +38,7 @@ void PhysicalUnion::GetChunkInternal(ExecutionContext &context, DataChunk &chunk
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalUnion::GetOperatorState() {
-	auto state = make_unique<PhysicalUnionOperatorState>();
+	auto state = make_unique<PhysicalUnionOperatorState>(*this);
 	state->top_state = children[0]->GetOperatorState();
 	state->bottom_state = children[1]->GetOperatorState();
 	return (move(state));

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -28,9 +28,10 @@ string PhysicalOperator::ToString(idx_t depth) const {
 	return result;
 }
 
-PhysicalOperatorState::PhysicalOperatorState(PhysicalOperator *child) : finished(false) {
+PhysicalOperatorState::PhysicalOperatorState(PhysicalOperator &op, PhysicalOperator *child) : finished(false) {
+	op.InitializeChunk(initial_chunk);
 	if (child) {
-		child->InitializeChunk(child_chunk);
+		child->InitializeChunkEmpty(child_chunk);
 		child_state = child->GetOperatorState();
 	}
 }
@@ -39,12 +40,14 @@ void PhysicalOperator::GetChunk(ExecutionContext &context, DataChunk &chunk, Phy
 	if (context.client.interrupted) {
 		throw InterruptException();
 	}
+	// reset the chunk back to its initial state
+	chunk.Reference(state->initial_chunk);
 
-	chunk.Reset();
 	if (state->finished) {
 		return;
 	}
 
+	// execute the operator
 	context.thread.profiler.StartOperator(this);
 	GetChunkInternal(context, chunk, state);
 	context.thread.profiler.EndOperator(&chunk);

--- a/src/include/duckdb/execution/expression_executor_state.hpp
+++ b/src/include/duckdb/execution/expression_executor_state.hpp
@@ -25,9 +25,12 @@ struct ExpressionState {
 	Expression &expr;
 	ExpressionExecutorState &root;
 	vector<unique_ptr<ExpressionState>> child_states;
+	vector<LogicalType> types;
+	DataChunk intermediate_chunk;
 
 public:
 	void AddChild(Expression *expr);
+	void Finalize();
 };
 
 struct ExpressionExecutorState {

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -28,7 +28,7 @@ class OperatorTaskInfo;
 //! data source is exhausted.
 class PhysicalOperatorState {
 public:
-	PhysicalOperatorState(PhysicalOperator *child);
+	PhysicalOperatorState(PhysicalOperator &op, PhysicalOperator *child);
 	virtual ~PhysicalOperatorState() = default;
 
 	//! Flag indicating whether or not the operator is finished [note: not all
@@ -38,6 +38,8 @@ public:
 	DataChunk child_chunk;
 	//! State of the child of this operator
 	unique_ptr<PhysicalOperatorState> child_state;
+	//! The initial chunk
+	DataChunk initial_chunk;
 };
 
 //! PhysicalOperator is the base class of the physical operators present in the
@@ -78,6 +80,10 @@ public:
 		auto &types = GetTypes();
 		chunk.Initialize(types);
 	}
+	virtual void InitializeChunkEmpty(DataChunk &chunk) {
+		auto &types = GetTypes();
+		chunk.InitializeEmpty(types);
+	}
 	//! Retrieves a chunk from this operator and stores it in the chunk
 	//! variable.
 	virtual void GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state) = 0;
@@ -86,7 +92,7 @@ public:
 
 	//! Create a new empty instance of the operator state
 	virtual unique_ptr<PhysicalOperatorState> GetOperatorState() {
-		return make_unique<PhysicalOperatorState>(children.size() == 0 ? nullptr : children[0].get());
+		return make_unique<PhysicalOperatorState>(*this, children.size() == 0 ? nullptr : children[0].get());
 	}
 
 	virtual string ExtraRenderInformation() const {

--- a/src/optimizer/pushdown/pushdown_get.cpp
+++ b/src/optimizer/pushdown/pushdown_get.cpp
@@ -23,7 +23,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownGet(unique_ptr<LogicalOperat
 		get.function.pushdown_complex_filter(optimizer.context, get, get.bind_data.get(), expressions);
 
 		if (expressions.size() == 0) {
-			return move(op);
+			return op;
 		}
 		// re-generate the filters
 		for (auto &expr : expressions) {

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -222,7 +222,7 @@ unique_ptr<DataChunk> Executor::FetchChunk() {
 
 	auto chunk = make_unique<DataChunk>();
 	// run the plan to get the next chunks
-	physical_plan->InitializeChunk(*chunk);
+	physical_plan->InitializeChunkEmpty(*chunk);
 	physical_plan->GetChunk(econtext, *chunk, physical_state.get());
 	return chunk;
 }

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -48,7 +48,7 @@ void Pipeline::Execute(TaskContext &task) {
 		auto lstate = sink->GetLocalSinkState(context);
 		// incrementally process the pipeline
 		DataChunk intermediate;
-		child->InitializeChunk(intermediate);
+		child->InitializeChunkEmpty(intermediate);
 		while (true) {
 			child->GetChunk(context, intermediate, state.get());
 			thread.profiler.StartOperator(sink);


### PR DESCRIPTION
Move back to keeping data chunks and vector intermediates cached in the OperatorState/ExpressionState, rather than constantly re-allocating the vectors.