### PR TITLE
Parallel Task Rework

### DIFF
--- a/extension/parquet/parquet-extension.cpp
+++ b/extension/parquet/parquet-extension.cpp
@@ -989,7 +989,7 @@ public:
 	}
 
 	static unique_ptr<FunctionOperatorData>
-	parquet_scan_init(ClientContext &context, const FunctionData *bind_data, OperatorTaskInfo *task_info,
+	parquet_scan_init(ClientContext &context, const FunctionData *bind_data, ParallelState *state,
 	                  vector<column_t> &column_ids, unordered_map<idx_t, vector<TableFilter>> &table_filters) {
 		auto &data = (ParquetScanFunctionData &)*bind_data;
 		data.column_ids = column_ids;

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -59,9 +59,4 @@ void PhysicalOperator::Print() {
 	Printer::Print(ToString());
 }
 
-void PhysicalOperator::ParallelScanInfo(ClientContext &context,
-                                        std::function<void(unique_ptr<OperatorTaskInfo>)> callback) {
-	throw InternalException("Unsupported operator for parallel scan!");
-}
-
 } // namespace duckdb

--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -120,7 +120,7 @@ static unique_ptr<FunctionData> arrow_scan_bind(ClientContext &context, vector<V
 }
 
 static unique_ptr<FunctionOperatorData> arrow_scan_init(ClientContext &context, const FunctionData *bind_data,
-                                                        OperatorTaskInfo *task_info, vector<column_t> &column_ids,
+                                                        ParallelState *state, vector<column_t> &column_ids,
                                                         unordered_map<idx_t, vector<TableFilter>> &table_filters) {
 	auto &data = (ArrowScanFunctionData &)*bind_data;
 	if (data.is_consumed) {

--- a/src/function/table/range.cpp
+++ b/src/function/table/range.cpp
@@ -63,7 +63,7 @@ struct RangeFunctionState : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionOperatorData> range_function_init(ClientContext &context, const FunctionData *bind_data,
-                                                            OperatorTaskInfo *task_info, vector<column_t> &column_ids,
+                                                            ParallelState *state, vector<column_t> &column_ids,
                                                             unordered_map<idx_t, vector<TableFilter>> &table_filters) {
 	return make_unique<RangeFunctionState>();
 }
@@ -94,25 +94,25 @@ void RangeTableFunction::RegisterFunction(BuiltinFunctions &set) {
 
 	// single argument range: (end) - implicit start = 0 and increment = 1
 	range.AddFunction(TableFunction({LogicalType::BIGINT}, range_function, range_function_bind<false>,
-	                                range_function_init, nullptr, nullptr, nullptr, range_cardinality));
+	                                range_function_init, nullptr, nullptr, range_cardinality));
 	// two arguments range: (start, end) - implicit increment = 1
 	range.AddFunction(TableFunction({LogicalType::BIGINT, LogicalType::BIGINT}, range_function,
-	                                range_function_bind<false>, range_function_init, nullptr, nullptr, nullptr,
+	                                range_function_bind<false>, range_function_init, nullptr, nullptr,
 	                                range_cardinality));
 	// three arguments range: (start, end, increment)
 	range.AddFunction(TableFunction({LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT}, range_function,
-	                                range_function_bind<false>, range_function_init, nullptr, nullptr, nullptr,
+	                                range_function_bind<false>, range_function_init, nullptr, nullptr,
 	                                range_cardinality));
 	set.AddFunction(range);
 	// generate_series: similar to range, but inclusive instead of exclusive bounds on the RHS
 	TableFunctionSet generate_series("generate_series");
 	generate_series.AddFunction(TableFunction({LogicalType::BIGINT}, range_function, range_function_bind<true>,
-	                                          range_function_init, nullptr, nullptr, nullptr, range_cardinality));
+	                                          range_function_init, nullptr, nullptr, range_cardinality));
 	generate_series.AddFunction(TableFunction({LogicalType::BIGINT, LogicalType::BIGINT}, range_function,
-	                                          range_function_bind<true>, range_function_init, nullptr, nullptr, nullptr,
+	                                          range_function_bind<true>, range_function_init, nullptr, nullptr,
 	                                          range_cardinality));
 	generate_series.AddFunction(TableFunction({LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT},
-	                                          range_function, range_function_bind<true>, range_function_init, nullptr,
+	                                          range_function, range_function_bind<true>, range_function_init,
 	                                          nullptr, nullptr, range_cardinality));
 	set.AddFunction(generate_series);
 }

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -105,7 +105,7 @@ static unique_ptr<FunctionData> read_csv_bind(ClientContext &context, vector<Val
 }
 
 static unique_ptr<FunctionOperatorData> read_csv_init(ClientContext &context, const FunctionData *bind_data_,
-                                                      OperatorTaskInfo *task_info, vector<column_t> &column_ids,
+                                                      ParallelState *state, vector<column_t> &column_ids,
                                                       unordered_map<idx_t, vector<TableFilter>> &table_filters) {
 	auto &bind_data = (ReadCSVFunctionData &)*bind_data_;
 	if (bind_data.is_consumed) {

--- a/src/function/table/repeat.cpp
+++ b/src/function/table/repeat.cpp
@@ -29,7 +29,7 @@ static unique_ptr<FunctionData> repeat_bind(ClientContext &context, vector<Value
 }
 
 static unique_ptr<FunctionOperatorData> repeat_init(ClientContext &context, const FunctionData *bind_data,
-                                                    OperatorTaskInfo *task_info, vector<column_t> &column_ids,
+                                                    ParallelState *state, vector<column_t> &column_ids,
                                                     unordered_map<idx_t, vector<TableFilter>> &table_filters) {
 	return make_unique<RepeatOperatorData>();
 }
@@ -52,7 +52,7 @@ static idx_t repeat_cardinality(const FunctionData *bind_data_) {
 
 void RepeatTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	TableFunction repeat("repeat", {LogicalType::ANY, LogicalType::BIGINT}, repeat_function, repeat_bind, repeat_init,
-	                     nullptr, nullptr, nullptr, repeat_cardinality);
+	                     nullptr, nullptr, repeat_cardinality);
 	set.AddFunction(repeat);
 }
 

--- a/src/function/table/sqlite/pragma_collations.cpp
+++ b/src/function/table/sqlite/pragma_collations.cpp
@@ -28,7 +28,7 @@ static unique_ptr<FunctionData> pragma_collate_bind(ClientContext &context, vect
 }
 
 unique_ptr<FunctionOperatorData> pragma_collate_init(ClientContext &context, const FunctionData *bind_data,
-                                                     OperatorTaskInfo *task_info, vector<column_t> &column_ids,
+                                                     ParallelState *state, vector<column_t> &column_ids,
                                                      unordered_map<idx_t, vector<TableFilter>> &table_filters) {
 	auto result = make_unique<PragmaCollateData>();
 

--- a/src/function/table/sqlite/pragma_database_list.cpp
+++ b/src/function/table/sqlite/pragma_database_list.cpp
@@ -29,7 +29,7 @@ static unique_ptr<FunctionData> pragma_database_list_bind(ClientContext &context
 }
 
 unique_ptr<FunctionOperatorData> pragma_database_list_init(ClientContext &context, const FunctionData *bind_data,
-                                                           OperatorTaskInfo *task_info, vector<column_t> &column_ids,
+                                                           ParallelState *state, vector<column_t> &column_ids,
                                                            unordered_map<idx_t, vector<TableFilter>> &table_filters) {
 	return make_unique<PragmaDatabaseListData>();
 }

--- a/src/function/table/sqlite/pragma_table_info.cpp
+++ b/src/function/table/sqlite/pragma_table_info.cpp
@@ -57,7 +57,7 @@ static unique_ptr<FunctionData> pragma_table_info_bind(ClientContext &context, v
 }
 
 unique_ptr<FunctionOperatorData> pragma_table_info_init(ClientContext &context, const FunctionData *bind_data,
-                                                        OperatorTaskInfo *task_info, vector<column_t> &column_ids,
+                                                        ParallelState *state, vector<column_t> &column_ids,
                                                         unordered_map<idx_t, vector<TableFilter>> &table_filters) {
 	return make_unique<PragmaTableOperatorData>();
 }

--- a/src/function/table/sqlite/sqlite_master.cpp
+++ b/src/function/table/sqlite/sqlite_master.cpp
@@ -42,7 +42,7 @@ static unique_ptr<FunctionData> sqlite_master_bind(ClientContext &context, vecto
 }
 
 unique_ptr<FunctionOperatorData> sqlite_master_init(ClientContext &context, const FunctionData *bind_data,
-                                                    OperatorTaskInfo *task_info, vector<column_t> &column_ids,
+                                                    ParallelState *state, vector<column_t> &column_ids,
                                                     unordered_map<idx_t, vector<TableFilter>> &table_filters) {
 	auto result = make_unique<SQLiteMasterData>();
 

--- a/src/function/table/version/pragma_version.cpp
+++ b/src/function/table/version/pragma_version.cpp
@@ -20,7 +20,7 @@ static unique_ptr<FunctionData> pragma_version_bind(ClientContext &context, vect
 }
 
 static unique_ptr<FunctionOperatorData> pragma_version_init(ClientContext &context, const FunctionData *bind_data,
-                                                            OperatorTaskInfo *task_info, vector<column_t> &column_ids,
+                                                            ParallelState *state, vector<column_t> &column_ids,
                                                             unordered_map<idx_t, vector<TableFilter>> &table_filters) {
 	return make_unique<PragmaVersionData>();
 }

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -33,8 +33,6 @@ public:
 	void GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;
 	string ToString(idx_t depth = 0) const override;
 	unique_ptr<PhysicalOperatorState> GetOperatorState() override;
-
-	void ParallelScanInfo(ClientContext &context, std::function<void(unique_ptr<OperatorTaskInfo>)> callback) override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -20,7 +20,6 @@
 namespace duckdb {
 class ExpressionExecutor;
 class PhysicalOperator;
-class OperatorTaskInfo;
 
 //! The current state/context of the operator. The PhysicalOperatorState is
 //! updated using the GetChunk function, and allows the caller to repeatedly
@@ -102,10 +101,6 @@ public:
 	virtual bool IsSink() const {
 		return false;
 	}
-
-	//! Provides an interface for parallel scans of this operator. For every OperatorTaskInfo returned, one task is
-	//! created. The OperatorTaskInfo can be accessed as part of the TaskContext during execution.
-	virtual void ParallelScanInfo(ClientContext &context, std::function<void(unique_ptr<OperatorTaskInfo>)> callback);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -45,6 +45,7 @@ public:
 
 	FileSystem &GetFileSystem();
 
+	idx_t NumberOfThreads();
 	static const char *SourceID();
 	static const char *LibraryVersion();
 

--- a/src/include/duckdb/parallel/parallel_state.hpp
+++ b/src/include/duckdb/parallel/parallel_state.hpp
@@ -1,16 +1,18 @@
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// duckdb/common/mutex.hpp
+// duckdb/parallel/parallel_state.hpp
 //
 //
 //===----------------------------------------------------------------------===//
 
 #pragma once
 
-#include <mutex>
-
 namespace duckdb {
-using std::mutex;
-using std::lock_guard;
-}
+
+struct ParallelState {
+	virtual ~ParallelState() {
+	}
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -9,7 +9,9 @@
 #pragma once
 
 #include "duckdb/execution/physical_sink.hpp"
+#include "duckdb/parallel/parallel_state.hpp"
 #include "duckdb/common/unordered_set.hpp"
+#include "duckdb/function/table_function.hpp"
 
 #include <atomic>
 
@@ -74,6 +76,11 @@ private:
 	//! The amount of completed dependencies (the pipeline can only be started after the dependencies have finished
 	//! executing)
 	std::atomic<idx_t> finished_dependencies;
+
+	//! The parallel operator (if any)
+	PhysicalOperator *parallel_node;
+	//! The parallel state (if any)
+	unique_ptr<ParallelState> parallel_state;
 
 	//! Whether or not the pipeline is finished executing
 	bool finished;

--- a/src/include/duckdb/parallel/task_context.hpp
+++ b/src/include/duckdb/parallel/task_context.hpp
@@ -10,15 +10,10 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/unordered_map.hpp"
+#include "duckdb/parallel/parallel_state.hpp"
 
 namespace duckdb {
 class PhysicalOperator;
-
-class OperatorTaskInfo {
-public:
-	virtual ~OperatorTaskInfo() {
-	}
-};
 
 //! TaskContext holds task specific information relating to the excution
 class TaskContext {
@@ -27,7 +22,7 @@ public:
 	}
 
 	//! Per-operator task info
-	unordered_map<PhysicalOperator *, unique_ptr<OperatorTaskInfo>> task_info;
+	unordered_map<PhysicalOperator *, ParallelState*> task_info;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -51,6 +51,12 @@ struct DataTableInfo {
 	}
 };
 
+struct ParallelTableScanState {
+	idx_t persistent_row_idx;
+	idx_t transient_row_idx;
+	bool transaction_local_data;
+};
+
 //! DataTable represents a physical table on disk
 class DataTable {
 public:
@@ -76,9 +82,12 @@ public:
 	void InitializeScan(Transaction &transaction, TableScanState &state, const vector<column_t> &column_ids,
 	                    unordered_map<idx_t, vector<TableFilter>> *table_filters = nullptr);
 
-	void InitializeParallelScan(ClientContext &context, const vector<column_t> &column_ids,
-	                            unordered_map<idx_t, vector<TableFilter>> *table_filters,
-	                            std::function<void(TableScanState)> callback);
+	//! Returns the maximum amount of threads that should be assigned to scan this data table
+	idx_t MaxThreads(ClientContext &context);
+	void InitializeParallelScan(ParallelTableScanState &state);
+	bool NextParallelScan(ClientContext &context, ParallelTableScanState &state, TableScanState &scan_state, const vector<column_t> &column_ids,
+	                    unordered_map<idx_t, vector<TableFilter>> *table_filters);
+
 
 	//! Scans up to STANDARD_VECTOR_SIZE elements from the table starting
 	//! from offset and store them in result. Offset is incremented with how many

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -84,4 +84,8 @@ DBConfig &DBConfig::GetConfig(ClientContext &context) {
 	return context.db.config;
 }
 
+idx_t DuckDB::NumberOfThreads() {
+	return scheduler->NumberOfThreads();
+}
+
 } // namespace duckdb

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/parallel/task_context.hpp"
 #include "duckdb/parallel/thread_context.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
+#include "duckdb/main/database.hpp"
 
 #include "duckdb/execution/operator/aggregate/physical_simple_aggregate.hpp"
 #include "duckdb/execution/operator/scan/physical_table_scan.hpp"
@@ -39,6 +40,9 @@ void Pipeline::Execute(TaskContext &task) {
 	auto &client = executor.context;
 	if (client.interrupted) {
 		return;
+	}
+	if (parallel_state) {
+		task.task_info[parallel_node] = parallel_state.get();
 	}
 
 	ThreadContext thread(client);
@@ -100,22 +104,28 @@ bool Pipeline::ScheduleOperator(PhysicalOperator *op) {
 	case PhysicalOperatorType::TABLE_SCAN: {
 		// we reached a scan: split it up into parts and schedule the parts
 		auto &scheduler = TaskScheduler::GetScheduler(executor.context);
-
-		// first we gather all of the tasks of this pipeline
-		// we gather the tasks first because we want to set total_tasks to the actual task amount
-		// otherwise we can encounter race conditions in which a pipeline could finish twice
-		vector<unique_ptr<OperatorTaskInfo>> tasks;
-		op->ParallelScanInfo(executor.context, [&](unique_ptr<OperatorTaskInfo> info) { tasks.push_back(move(info)); });
-		this->total_tasks = tasks.size();
-		if (this->total_tasks == 0) {
-			// could not generate parallel tasks, or parallel tasks were determined as not worthwhile
-			// move on to sequential execution
+		auto &get = (PhysicalTableScan &) *op;
+		if (!get.function.max_threads) {
+			// table function cannot be parallelized
 			return false;
 		}
-		// after we have gathered all the tasks we actually schedule them for execution
-		for (auto &info : tasks) {
+		assert(get.function.init_parallel_state);
+		assert(get.function.parallel_state_next);
+		idx_t max_threads = get.function.max_threads(executor.context, get.bind_data.get());
+		if (max_threads > executor.context.db.NumberOfThreads()) {
+			max_threads = executor.context.db.NumberOfThreads();
+		}
+		if (max_threads <= 1) {
+			// table is too small to parallelize
+			return false;
+		}
+		this->parallel_state = get.function.init_parallel_state(executor.context, get.bind_data.get());
+		this->parallel_node = op;
+
+		// launch a task for every thread
+		this->total_tasks = max_threads;
+		for(idx_t i = 0; i < max_threads; i++) {
 			auto task = make_unique<PipelineTask>(this);
-			task->task.task_info[op] = move(info);
 			scheduler.ScheduleTask(*executor.producer, move(task));
 		}
 		return true;

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -229,63 +229,75 @@ void DataTable::InitializeScanWithOffset(TableScanState &state, const vector<col
 	state.max_persistent_row = 0;
 	state.current_transient_row = 0;
 	state.max_transient_row = 0;
-	if (table_filters && table_filters->size() > 0) {
+	if (table_filters && table_filters->size() > 0 && !state.adaptive_filter) {
 		state.adaptive_filter = make_unique<AdaptiveFilter>(*table_filters);
 	}
 }
 
-void DataTable::InitializeParallelScan(ClientContext &context, const vector<column_t> &column_ids,
-                                       unordered_map<idx_t, vector<TableFilter>> *table_filters,
-                                       std::function<void(TableScanState)> callback) {
+idx_t DataTable::MaxThreads(ClientContext &context) {
 	idx_t PARALLEL_SCAN_VECTOR_COUNT = 100;
+	if (context.force_parallelism) {
+		PARALLEL_SCAN_VECTOR_COUNT = 1;
+	}
 	idx_t PARALLEL_SCAN_TUPLE_COUNT = STANDARD_VECTOR_SIZE * PARALLEL_SCAN_VECTOR_COUNT;
 
-	idx_t current_offset = 0;
-	// create parallel scans for the persistent rows
-	for (idx_t i = 0; i < persistent_manager->max_row; i += PARALLEL_SCAN_TUPLE_COUNT) {
-		idx_t current = i;
-		idx_t next = MinValue(i + PARALLEL_SCAN_TUPLE_COUNT, persistent_manager->max_row);
+	return (persistent_manager->max_row + transient_manager->max_row) / PARALLEL_SCAN_TUPLE_COUNT + 1;
+}
 
-		TableScanState state;
-		InitializeScanWithOffset(state, column_ids, table_filters, current_offset);
-		state.current_persistent_row = current;
-		state.max_persistent_row = next;
+void DataTable::InitializeParallelScan(ParallelTableScanState &state) {
+	state.persistent_row_idx = 0;
+	state.transient_row_idx = 0;
+	state.transaction_local_data = false;
+}
 
-		callback(move(state));
-
-		current_offset += PARALLEL_SCAN_VECTOR_COUNT;
-	}
-	if (persistent_manager->max_row > 0) {
-		current_offset = (persistent_manager->max_row / STANDARD_VECTOR_SIZE) + 1;
-	}
-	// now create parallel scans for the transient rows
+bool DataTable::NextParallelScan(ClientContext &context, ParallelTableScanState &state, TableScanState &scan_state, const vector<column_t> &column_ids,
+	                    unordered_map<idx_t, vector<TableFilter>> *table_filters) {
+	idx_t PARALLEL_SCAN_VECTOR_COUNT = 100;
 	if (context.force_parallelism) {
-		// force parallelism: create one task per vector
 		PARALLEL_SCAN_VECTOR_COUNT = 1;
-		PARALLEL_SCAN_TUPLE_COUNT = STANDARD_VECTOR_SIZE * PARALLEL_SCAN_VECTOR_COUNT;
 	}
-	for (idx_t i = 0; i < transient_manager->max_row; i += PARALLEL_SCAN_TUPLE_COUNT) {
-		idx_t current = i;
-		idx_t next = MinValue(i + PARALLEL_SCAN_TUPLE_COUNT, transient_manager->max_row);
+	idx_t PARALLEL_SCAN_TUPLE_COUNT = STANDARD_VECTOR_SIZE * PARALLEL_SCAN_VECTOR_COUNT;
 
-		TableScanState state;
-		InitializeScanWithOffset(state, column_ids, table_filters, current_offset);
-		state.current_transient_row = current;
-		state.max_transient_row = next;
+	if (state.persistent_row_idx < persistent_manager->max_row) {
+		idx_t next = MinValue(state.persistent_row_idx + PARALLEL_SCAN_TUPLE_COUNT, persistent_manager->max_row);
 
-		callback(move(state));
+		idx_t vector_offset = persistent_manager->max_row / STANDARD_VECTOR_SIZE;
+		// scan a morsel from the persistent rows
+		InitializeScanWithOffset(scan_state, column_ids, table_filters, vector_offset);
+		scan_state.current_persistent_row = state.persistent_row_idx;
+		scan_state.max_persistent_row = next;
 
-		current_offset += PARALLEL_SCAN_VECTOR_COUNT;
+		state.persistent_row_idx = next;
+		return true;
+	} else if (state.transient_row_idx < transient_manager->max_row) {
+		idx_t next = MinValue(state.transient_row_idx + PARALLEL_SCAN_TUPLE_COUNT, transient_manager->max_row);
+		// scan a morsel from the transient rows
+		idx_t vector_offset = 0;
+		if (persistent_manager->max_row > 0) {
+			vector_offset = (persistent_manager->max_row / STANDARD_VECTOR_SIZE) + 1;
+		}
+		vector_offset += state.transient_row_idx / STANDARD_VECTOR_SIZE;
+
+		InitializeScanWithOffset(scan_state, column_ids, table_filters, vector_offset);
+		scan_state.current_transient_row = state.transient_row_idx;
+		scan_state.max_transient_row = next;
+
+		state.transient_row_idx = next;
+		return true;
+	} else if (!state.transaction_local_data) {
+		auto &transaction = Transaction::GetTransaction(context);
+		// create a task for scanning the local data
+		// FIXME: this should also be potentially parallelized
+		scan_state.current_persistent_row = scan_state.max_persistent_row = 0;
+		scan_state.current_transient_row = scan_state.max_transient_row = 0;
+		transaction.storage.InitializeScan(this, scan_state.local_state);
+		state.transaction_local_data = true;
+		return true;
+	} else {
+		// finished all scans: no more scans remaining
+		return false;
 	}
 
-	// create a task for scanning the local data
-	// FIXME: this should also be potentially parallelized
-	auto &transaction = Transaction::GetTransaction(context);
-	TableScanState state;
-	state.current_persistent_row = state.max_persistent_row = 0;
-	state.current_transient_row = state.max_transient_row = 0;
-	transaction.storage.InitializeScan(this, state.local_state);
-	callback(move(state));
 }
 
 void DataTable::Scan(Transaction &transaction, DataChunk &result, TableScanState &state, vector<column_t> &column_ids,

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -261,7 +261,7 @@ bool DataTable::NextParallelScan(ClientContext &context, ParallelTableScanState 
 	if (state.persistent_row_idx < persistent_manager->max_row) {
 		idx_t next = MinValue(state.persistent_row_idx + PARALLEL_SCAN_TUPLE_COUNT, persistent_manager->max_row);
 
-		idx_t vector_offset = persistent_manager->max_row / STANDARD_VECTOR_SIZE;
+		idx_t vector_offset = state.persistent_row_idx / STANDARD_VECTOR_SIZE;
 		// scan a morsel from the persistent rows
 		InitializeScanWithOffset(scan_state, column_ids, table_filters, vector_offset);
 		scan_state.current_persistent_row = state.persistent_row_idx;

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -274,7 +274,10 @@ bool DataTable::NextParallelScan(ClientContext &context, ParallelTableScanState 
 		// scan a morsel from the transient rows
 		idx_t vector_offset = 0;
 		if (persistent_manager->max_row > 0) {
-			vector_offset = (persistent_manager->max_row / STANDARD_VECTOR_SIZE) + 1;
+			vector_offset = persistent_manager->max_row / STANDARD_VECTOR_SIZE;
+			if (persistent_manager->max_row % STANDARD_VECTOR_SIZE != 0) {
+				vector_offset++;
+			}
 		}
 		vector_offset += state.transient_row_idx / STANDARD_VECTOR_SIZE;
 

--- a/test/sql/parallelism/intraquery/test_force_parallelism.test
+++ b/test/sql/parallelism/intraquery/test_force_parallelism.test
@@ -1,4 +1,4 @@
-# name: test/sql/parallelism/intraquery/test/sql/parallelism/intraquery/test_force_parallelism.test
+# name: test/sql/parallelism/intraquery/test_force_parallelism.test
 # description: Test force parallelism on small-ish tables (few thousand rows)
 # group: [intraquery]
 
@@ -14,7 +14,6 @@ PRAGMA force_parallelism
 statement ok
 CREATE TABLE integers AS SELECT * FROM range(0, 5000) tbl(i)
 
-# perform a query with many pipelines
 query II
 SELECT MIN(i), MAX(i) FROM integers
 ----

--- a/test/sql/parallelism/intraquery/test_force_parallelism.test
+++ b/test/sql/parallelism/intraquery/test_force_parallelism.test
@@ -1,0 +1,21 @@
+# name: test/sql/parallelism/intraquery/test/sql/parallelism/intraquery/test_force_parallelism.test
+# description: Test force parallelism on small-ish tables (few thousand rows)
+# group: [intraquery]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+PRAGMA threads=4
+
+statement ok
+PRAGMA force_parallelism
+
+statement ok
+CREATE TABLE integers AS SELECT * FROM range(0, 5000) tbl(i)
+
+# perform a query with many pipelines
+query II
+SELECT MIN(i), MAX(i) FROM integers
+----
+0	4999

--- a/test/sql/parallelism/intraquery/test_persistent_parallelism.test
+++ b/test/sql/parallelism/intraquery/test_persistent_parallelism.test
@@ -5,7 +5,23 @@
 load __TEST_DIR__/test_parallelism.db
 
 statement ok
+BEGIN TRANSACTION
+
+statement ok
 CREATE TABLE integers AS SELECT * FROM range(0, 5000) tbl(i)
+
+query II
+SELECT MIN(i), MAX(i) FROM integers
+----
+0	4999
+
+statement ok
+COMMIT
+
+query II
+SELECT MIN(i), MAX(i) FROM integers
+----
+0	4999
 
 restart
 

--- a/test/sql/parallelism/intraquery/test_persistent_parallelism.test
+++ b/test/sql/parallelism/intraquery/test_persistent_parallelism.test
@@ -1,0 +1,44 @@
+# name: test/sql/parallelism/intraquery/test/sql/parallelism/intraquery/test_force_parallelism.test
+# description: Test force parallelism on small-ish tables (few thousand rows)
+# group: [intraquery]
+
+load __TEST_DIR__/test_parallelism.db
+
+statement ok
+CREATE TABLE integers AS SELECT * FROM range(0, 5000) tbl(i)
+
+restart
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+PRAGMA threads=4
+
+statement ok
+PRAGMA force_parallelism
+
+query II
+SELECT MIN(i), MAX(i) FROM integers
+----
+0	4999
+
+# add some transient data
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+INSERT INTO integers SELECT * FROM range(5000, 10000)
+
+query II
+SELECT MIN(i), MAX(i) FROM integers
+----
+0	9999
+
+statement ok
+COMMIT
+
+query II
+SELECT MIN(i), MAX(i) FROM integers
+----
+0	9999

--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -228,7 +228,7 @@ struct PandasScanFunction : public TableFunction {
 	}
 
 	static unique_ptr<FunctionOperatorData> pandas_scan_init(ClientContext &context, const FunctionData *bind_data,
-	                                                         OperatorTaskInfo *task_info, vector<column_t> &column_ids,
+	                                                         ParallelState *state, vector<column_t> &column_ids,
 	                                                         unordered_map<idx_t, vector<TableFilter>> &table_filters) {
 		return make_unique<PandasScanState>();
 	}

--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -172,7 +172,7 @@ struct PandasScanState : public FunctionOperatorData {
 struct PandasScanFunction : public TableFunction {
 	PandasScanFunction()
 	    : TableFunction("pandas_scan", {LogicalType::VARCHAR}, pandas_scan_function, pandas_scan_bind, pandas_scan_init,
-	                    nullptr, nullptr, nullptr, pandas_scan_cardinality){};
+	                    nullptr, nullptr, pandas_scan_cardinality){};
 
 	static unique_ptr<FunctionData> pandas_scan_bind(ClientContext &context, vector<Value> &inputs,
 	                                                 unordered_map<string, Value> &named_parameters,

--- a/tools/rpkg/src/duckdbr.cpp
+++ b/tools/rpkg/src/duckdbr.cpp
@@ -643,7 +643,7 @@ struct DataFrameScanState : public FunctionOperatorData {
 struct DataFrameScanFunction : public TableFunction {
 	DataFrameScanFunction()
 	    : TableFunction("dataframe_scan", {LogicalType::VARCHAR}, dataframe_scan_function, dataframe_scan_bind,
-	                    dataframe_scan_init, nullptr, nullptr, nullptr, dataframe_scan_cardinality){};
+	                    dataframe_scan_init, nullptr, nullptr, dataframe_scan_cardinality){};
 
 	static unique_ptr<FunctionData> dataframe_scan_bind(ClientContext &context, vector<Value> &inputs,
 	                                                    unordered_map<string, Value> &named_parameters,

--- a/tools/rpkg/src/duckdbr.cpp
+++ b/tools/rpkg/src/duckdbr.cpp
@@ -690,7 +690,7 @@ struct DataFrameScanFunction : public TableFunction {
 	}
 
 	static unique_ptr<FunctionOperatorData>
-	dataframe_scan_init(ClientContext &context, const FunctionData *bind_data, OperatorTaskInfo *task_info,
+	dataframe_scan_init(ClientContext &context, const FunctionData *bind_data, ParallelState *state,
 	                    vector<column_t> &column_ids, unordered_map<idx_t, vector<TableFilter>> &table_filters) {
 		return make_unique<DataFrameScanState>();
 	}


### PR DESCRIPTION
This PR reworks the way in which parallel tasks work by no longer materializing all tasks up front, and instead pushing N tasks (where N is the amount of active threads). Every thread working on a task will now work on that pipeline until it is completed, with a shared `ParallelState` that is used to fetch new morsels from the base table. This speeds up the parallelism by no longer requiring many tasks to be materialized, and also means `Initialize` and `Combine` are called much less frequently (max once per thread per pipeline, rather than once per task). 