### PR TITLE
Optimize Version Manager for common cases

### DIFF
--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -48,15 +48,17 @@ public:
 	ChunkDeleteInfo(VersionManager &manager, idx_t start_row, ChunkInfoType type = ChunkInfoType::DELETE_INFO);
 	ChunkDeleteInfo(ChunkDeleteInfo &info, ChunkInfoType type);
 
-	//! The transaction ids of the transactions that deleted the tuples (if any)
-	transaction_t deleted[STANDARD_VECTOR_SIZE];
-
 public:
 	idx_t GetSelVector(Transaction &transaction, SelectionVector &sel_vector, idx_t max_count) override;
 	bool Fetch(Transaction &transaction, row_t row) override;
 
 	void Delete(Transaction &transaction, row_t rows[], idx_t count) override;
 	void CommitDelete(transaction_t commit_id, row_t rows[], idx_t count) override;
+protected:
+	//! The transaction ids of the transactions that deleted the tuples (if any)
+	transaction_t deleted[STANDARD_VECTOR_SIZE];
+
+	bool any_deleted;
 };
 
 class ChunkInsertInfo : public ChunkDeleteInfo {
@@ -64,12 +66,17 @@ public:
 	ChunkInsertInfo(VersionManager &manager, idx_t start_row);
 	ChunkInsertInfo(ChunkDeleteInfo &info);
 
-	//! The transaction ids of the transactions that inserted the tuples (if any)
-	transaction_t inserted[STANDARD_VECTOR_SIZE];
-
 public:
 	idx_t GetSelVector(Transaction &transaction, SelectionVector &sel_vector, idx_t max_count) override;
 	bool Fetch(Transaction &transaction, row_t row) override;
+
+	void Append(idx_t start, idx_t end, transaction_t commit_id);
+protected:
+	//! The transaction ids of the transactions that inserted the tuples (if any)
+	transaction_t inserted[STANDARD_VECTOR_SIZE];
+
+	transaction_t same_id;
+	bool all_same_id;
 };
 
 } // namespace duckdb

--- a/src/storage/table/chunk_info.cpp
+++ b/src/storage/table/chunk_info.cpp
@@ -12,20 +12,23 @@ static bool UseVersion(Transaction &transaction, transaction_t id) {
 // Delete info
 //===--------------------------------------------------------------------===//
 ChunkDeleteInfo::ChunkDeleteInfo(VersionManager &manager, idx_t start_row, ChunkInfoType type)
-    : ChunkInfo(manager, start_row, type) {
+    : ChunkInfo(manager, start_row, type), any_deleted(false) {
 	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
 		deleted[i] = NOT_DELETED_ID;
 	}
 }
 
 ChunkDeleteInfo::ChunkDeleteInfo(ChunkDeleteInfo &info, ChunkInfoType type)
-    : ChunkInfo(info.manager, info.start, type) {
+    : ChunkInfo(info.manager, info.start, type), any_deleted(false) {
 	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
 		deleted[i] = info.deleted[i];
 	}
 }
 
 idx_t ChunkDeleteInfo::GetSelVector(Transaction &transaction, SelectionVector &sel_vector, idx_t max_count) {
+	if (!any_deleted) {
+		return max_count;
+	}
 	idx_t count = 0;
 	for (idx_t i = 0; i < max_count; i++) {
 		if (!UseVersion(transaction, deleted[i])) {
@@ -40,6 +43,8 @@ bool ChunkDeleteInfo::Fetch(Transaction &transaction, row_t row) {
 }
 
 void ChunkDeleteInfo::Delete(Transaction &transaction, row_t rows[], idx_t count) {
+	any_deleted = true;
+
 	// first check the chunk for conflicts
 	for (idx_t i = 0; i < count; i++) {
 		if (deleted[rows[i]] != NOT_DELETED_ID) {
@@ -63,30 +68,71 @@ void ChunkDeleteInfo::CommitDelete(transaction_t commit_id, row_t rows[], idx_t 
 // Insert info
 //===--------------------------------------------------------------------===//
 ChunkInsertInfo::ChunkInsertInfo(VersionManager &manager, idx_t start_row)
-    : ChunkDeleteInfo(manager, start_row, ChunkInfoType::INSERT_INFO) {
+    : ChunkDeleteInfo(manager, start_row, ChunkInfoType::INSERT_INFO), all_same_id(true) {
 	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
 		inserted[i] = NOT_DELETED_ID;
 	}
 }
 
-ChunkInsertInfo::ChunkInsertInfo(ChunkDeleteInfo &info) : ChunkDeleteInfo(info, ChunkInfoType::INSERT_INFO) {
+ChunkInsertInfo::ChunkInsertInfo(ChunkDeleteInfo &info) : ChunkDeleteInfo(info, ChunkInfoType::INSERT_INFO), all_same_id(true) {
 	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
 		inserted[i] = NOT_DELETED_ID;
 	}
 }
 
 idx_t ChunkInsertInfo::GetSelVector(Transaction &transaction, SelectionVector &sel_vector, idx_t max_count) {
-	idx_t count = 0;
-	for (idx_t i = 0; i < max_count; i++) {
-		if (UseVersion(transaction, inserted[i]) && !UseVersion(transaction, deleted[i])) {
-			sel_vector.set_index(count++, i);
+	if (all_same_id && !any_deleted) {
+		// all tuples have the same id, and nothing is deleted: only need to check same id
+		if (UseVersion(transaction, same_id)) {
+			return max_count;
+		} else {
+			return 0;
 		}
+	} else if (all_same_id) {
+		// all same id, but elements are deleted
+		// first check the insertion flag to see if we need to use any elements at all
+		if (!UseVersion(transaction, same_id)) {
+			return 0;
+		}
+		// have to check the deleted count
+		return ChunkDeleteInfo::GetSelVector(transaction, sel_vector, max_count);
+	} else if (!any_deleted) {
+		// not same id, but nothing is deleted
+		// only check insertion flag
+		idx_t count = 0;
+		for (idx_t i = 0; i < max_count; i++) {
+			if (UseVersion(transaction, inserted[i])) {
+				sel_vector.set_index(count++, i);
+			}
+		}
+		return count;
+	} else {
+		// not same id, and elements are deleted
+		// have to check both flags
+		idx_t count = 0;
+		for (idx_t i = 0; i < max_count; i++) {
+			if (UseVersion(transaction, inserted[i]) && !UseVersion(transaction, deleted[i])) {
+				sel_vector.set_index(count++, i);
+			}
+		}
+		return count;
 	}
-	return count;
 }
 
 bool ChunkInsertInfo::Fetch(Transaction &transaction, row_t row) {
 	return UseVersion(transaction, inserted[row]) && !UseVersion(transaction, deleted[row]);
+}
+
+void ChunkInsertInfo::Append(idx_t start, idx_t end, transaction_t commit_id) {
+	if (start == 0) {
+		same_id = commit_id;
+	} else if (same_id != commit_id) {
+		all_same_id = false;
+		same_id = NOT_DELETED_ID;
+	}
+	for(idx_t i = start; i < end; i++) {
+		inserted[i] = commit_id;
+	}
 }
 
 } // namespace duckdb

--- a/src/storage/table/version_manager.cpp
+++ b/src/storage/table/version_manager.cpp
@@ -117,13 +117,21 @@ void VersionManager::Append(Transaction &transaction, row_t row_start, idx_t cou
 	// obtain a write lock
 	auto write_lock = lock.GetExclusiveLock();
 	auto current_info = GetInsertInfo(chunk_idx);
-	for (idx_t i = 0; i < count; i++) {
-		current_info->inserted[idx_in_chunk] = commit_id;
-		idx_in_chunk++;
-		if (idx_in_chunk == STANDARD_VECTOR_SIZE) {
+	idx_t remaining = count;
+	while(true) {
+		idx_t start = idx_in_chunk;
+		idx_t to_process = MinValue<idx_t>(STANDARD_VECTOR_SIZE - start, remaining);
+		idx_t end = start + to_process;
+		current_info->Append(start, end, commit_id);
+		remaining -= to_process;
+		if (remaining > 0) {
 			chunk_idx++;
 			idx_in_chunk = 0;
+			// more to be inserted
 			current_info = GetInsertInfo(chunk_idx);
+			continue;
+		} else {
+			break;
 		}
 	}
 	max_row += count;

--- a/test/sql/transactions/test_interleaved_versions.test
+++ b/test/sql/transactions/test_interleaved_versions.test
@@ -1,0 +1,141 @@
+# name: test/sql/transactions/test_interleaved_versions.test
+# description: Test interleaved versions of tuples
+# group: [transactions]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE integers(i INTEGER)
+
+statement ok con1
+BEGIN TRANSACTION
+
+statement ok con1
+INSERT INTO integers VALUES (1)
+
+statement ok con2
+BEGIN TRANSACTION
+
+statement ok con2
+INSERT INTO integers VALUES (2)
+
+# transaction local only
+query I con1
+SELECT SUM(i) FROM integers
+----
+1
+
+query I con2
+SELECT SUM(i) FROM integers
+----
+2
+
+query I con3
+SELECT SUM(i) FROM integers
+----
+NULL
+
+# commit con1 only
+statement ok con1
+COMMIT
+
+query I con1
+SELECT SUM(i) FROM integers
+----
+1
+
+query I con2
+SELECT SUM(i) FROM integers
+----
+2
+
+query I con3
+SELECT SUM(i) FROM integers
+----
+1
+
+# commit con2 as well
+statement ok con2
+COMMIT
+
+query I con1
+SELECT SUM(i) FROM integers
+----
+3
+
+query I con2
+SELECT SUM(i) FROM integers
+----
+3
+
+query I con3
+SELECT SUM(i) FROM integers
+----
+3
+
+# now delete a tuple in both con1 and con2
+statement ok con1
+BEGIN TRANSACTION
+
+statement ok con2
+BEGIN TRANSACTION
+
+statement ok con1
+DELETE FROM integers WHERE i=1
+
+statement ok con2
+DELETE FROM integers WHERE i=2
+
+query I con1
+SELECT SUM(i) FROM integers
+----
+2
+
+query I con2
+SELECT SUM(i) FROM integers
+----
+1
+
+query I con3
+SELECT SUM(i) FROM integers
+----
+3
+
+# commit con1
+statement ok con1
+COMMIT
+
+query I con1
+SELECT SUM(i) FROM integers
+----
+2
+
+query I con2
+SELECT SUM(i) FROM integers
+----
+1
+
+query I con3
+SELECT SUM(i) FROM integers
+----
+2
+
+# commit con2
+statement ok con2
+COMMIT
+
+query I con1
+SELECT SUM(i) FROM integers
+----
+NULL
+
+query I con2
+SELECT SUM(i) FROM integers
+----
+NULL
+
+query I con3
+SELECT SUM(i) FROM integers
+----
+NULL


### PR DESCRIPTION
This PR optimizes the version manager for some common cases:

* Keep track of whether any tuples are deleted in a version chunk. If no tuples are deleted we can skip the deleted flags check entirely.
* Keep track of whether all tuples are inserted by the same transaction (as is mostly the case with bulk appends). If all tuples are inserted by the same transaction we only need to check a single transaction id, instead of all VECTOR_SIZE ids.

More work to be done to keep a version manager per morsel to avoid contention in the version manager entirely, as well as cleaning up version infos that are not required at all anymore, but this should already make the version manager a significantly smaller bottleneck.