### PR TITLE
Table functions information_schema_schemata() and information_schema_tables()

### DIFF
--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -29,6 +29,7 @@ void BuiltinFunctions::Initialize() {
 	RegisterReadFunctions();
 	RegisterTableFunctions();
 	RegisterArrowFunctions();
+	RegisterInformationSchemaFunctions();
 
 	RegisterAlgebraicAggregates();
 	RegisterDistributiveAggregates();

--- a/src/function/table/CMakeLists.txt
+++ b/src/function/table/CMakeLists.txt
@@ -1,5 +1,6 @@
-add_subdirectory(version)
+add_subdirectory(information_schema)
 add_subdirectory(sqlite)
+add_subdirectory(version)
 add_library_unity(
   duckdb_func_table
   OBJECT
@@ -9,6 +10,7 @@ add_library_unity(
   copy_csv.cpp
   read_csv.cpp
   sqlite_functions.cpp
+  information_schema_functions.cpp
   table_scan.cpp)
 
 set(ALL_OBJECT_FILES

--- a/src/function/table/information_schema/CMakeLists.txt
+++ b/src/function/table/information_schema/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library_unity(duckdb_func_information_schema OBJECT information_schema_schemata.cpp)
+add_library_unity(duckdb_func_information_schema OBJECT
+                  information_schema_schemata.cpp information_schema_tables.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_information_schema>
     PARENT_SCOPE)

--- a/src/function/table/information_schema/CMakeLists.txt
+++ b/src/function/table/information_schema/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library_unity(duckdb_func_information_schema OBJECT information_schema_schemata.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_information_schema>
+    PARENT_SCOPE)

--- a/src/function/table/information_schema/information_schema_schemata.cpp
+++ b/src/function/table/information_schema/information_schema_schemata.cpp
@@ -51,7 +51,7 @@ information_schema_schemata_init(ClientContext &context, const FunctionData *bin
                                  unordered_map<idx_t, vector<TableFilter>> &table_filters) {
 	auto result = make_unique<InformationSchemaSchemataData>();
 
-	// scan all the schemas for tables and views and collect them
+	// scan all the schemas and collect them
 	auto &transaction = Transaction::GetTransaction(context);
 	Catalog::GetCatalog(context).schemas->Scan(transaction,
 	                                           [&](CatalogEntry *entry) { result->entries.push_back(entry); });

--- a/src/function/table/information_schema/information_schema_schemata.cpp
+++ b/src/function/table/information_schema/information_schema_schemata.cpp
@@ -14,7 +14,7 @@ struct InformationSchemaSchemataData : public FunctionOperatorData {
 	InformationSchemaSchemataData() : offset(0) {
 	}
 
-	vector<CatalogEntry *> entries;
+	vector<SchemaCatalogEntry *> entries;
 	idx_t offset;
 };
 
@@ -54,8 +54,8 @@ information_schema_schemata_init(ClientContext &context, const FunctionData *bin
 
 	// scan all the schemas and collect them
 	auto &transaction = Transaction::GetTransaction(context);
-	Catalog::GetCatalog(context).schemas->Scan(transaction,
-	                                           [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+	Catalog::GetCatalog(context).schemas->Scan(
+	    transaction, [&](CatalogEntry *entry) { result->entries.push_back((SchemaCatalogEntry *)entry); });
 	// get the temp schema as well
 	result->entries.push_back(context.temporary_objects.get());
 

--- a/src/function/table/information_schema/information_schema_schemata.cpp
+++ b/src/function/table/information_schema/information_schema_schemata.cpp
@@ -1,0 +1,101 @@
+#include "duckdb/function/table/information_schema_functions.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/transaction/transaction.hpp"
+
+using namespace std;
+
+namespace duckdb {
+
+struct InformationSchemaSchemataData : public FunctionOperatorData {
+	InformationSchemaSchemataData() : offset(0) {
+	}
+
+	vector<SchemaCatalogEntry *> entries;
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> information_schema_schemata_bind(ClientContext &context, vector<Value> &inputs,
+                                                                 unordered_map<string, Value> &named_parameters,
+                                                                 vector<LogicalType> &return_types, vector<string> &names) {
+	names.push_back("catalog_name");
+	return_types.push_back(LogicalType::VARCHAR);
+
+	names.push_back("schema_name");
+	return_types.push_back(LogicalType::VARCHAR);
+
+	names.push_back("schema_owner");
+	return_types.push_back(LogicalType::VARCHAR);
+
+	names.push_back("default_character_set_catalog");
+	return_types.push_back(LogicalType::VARCHAR);
+
+	names.push_back("default_character_set_schema");
+	return_types.push_back(LogicalType::VARCHAR);
+
+	names.push_back("default_character_set_name");
+	return_types.push_back(LogicalType::VARCHAR);
+
+	names.push_back("sql_path");
+	return_types.push_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+unique_ptr<FunctionOperatorData> information_schema_schemata_init(ClientContext &context, const FunctionData *bind_data,
+                                                                  ParallelState *state, vector<column_t> &column_ids,
+                                                                  unordered_map<idx_t, vector<TableFilter>> &table_filters) {
+	auto result = make_unique<InformationSchemaSchemataData>();
+
+	// scan all the schemas for tables and views and collect them
+	auto &transaction = Transaction::GetTransaction(context);
+	Catalog::GetCatalog(context).schemas->Scan(transaction, [&](SchemaCatalogEntry *entry) {
+                result->entries.push_back(entry);
+	});
+
+	return move(result);
+}
+
+void information_schema_schemata(ClientContext &context, const FunctionData *bind_data, FunctionOperatorData *operator_state,
+                                 DataChunk &output) {
+	auto &data = (InformationSchemaSchemataData &)*operator_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	idx_t next = min(data.offset + STANDARD_VECTOR_SIZE, (idx_t)data.entries.size());
+	output.SetCardinality(next - data.offset);
+
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	for (idx_t i = data.offset; i < next; i++) {
+		auto index = i - data.offset;
+		auto &entry = data.entries[i];
+
+		// return values:
+		// "catalog_name", PhysicalType::VARCHAR
+                // TODO(jwills): how to determine this?
+		output.SetValue(0, index, Value("main"));
+		// "schema_name", PhysicalType::VARCHAR
+		output.SetValue(1, index, Value(entry->name));
+		// "schema_owner", PhysicalType::VARCHAR
+		output.SetValue(2, index, Value());
+		// "default_character_set_catalog", PhysicalType::VARCHAR
+		output.SetValue(3, index, Value());
+		// "default_character_set_schema", PhysicalType::VARCHAR
+		output.SetValue(4, index, Value());
+		// "default_character_set_name", PhysicalType::VARCHAR
+		output.SetValue(5, index, Value());
+		// "sql_path", PhysicalType::VARCHAR
+		output.SetValue(6, index, Value());
+	}
+	data.offset = next;
+}
+
+void InformationSchemaSchemata::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("information_schema_schemata", {}, information_schema_schemata, information_schema_schemata_bind, information_schema_schemata_init));
+}
+
+} // namespace duckdb

--- a/src/function/table/information_schema/information_schema_schemata.cpp
+++ b/src/function/table/information_schema/information_schema_schemata.cpp
@@ -80,8 +80,7 @@ void information_schema_schemata(ClientContext &context, const FunctionData *bin
 
 		// return values:
 		// "catalog_name", PhysicalType::VARCHAR
-		// TODO(jwills): how to determine this?
-		output.SetValue(0, index, Value("main"));
+		output.SetValue(0, index, Value());
 		// "schema_name", PhysicalType::VARCHAR
 		output.SetValue(1, index, Value(entry->name));
 		// "schema_owner", PhysicalType::VARCHAR

--- a/src/function/table/information_schema/information_schema_schemata.cpp
+++ b/src/function/table/information_schema/information_schema_schemata.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/main/client_context.hpp"
 #include "duckdb/transaction/transaction.hpp"
 
 using namespace std;
@@ -55,6 +56,8 @@ information_schema_schemata_init(ClientContext &context, const FunctionData *bin
 	auto &transaction = Transaction::GetTransaction(context);
 	Catalog::GetCatalog(context).schemas->Scan(transaction,
 	                                           [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+	// get the temp schema as well
+	result->entries.push_back(context.temporary_objects.get());
 
 	return move(result);
 }

--- a/src/function/table/information_schema/information_schema_tables.cpp
+++ b/src/function/table/information_schema/information_schema_tables.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/function/table/information_schema_functions.hpp"
 
 #include "duckdb/catalog/catalog.hpp"
-#include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
+#include "duckdb/catalog/standard_entry.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/transaction/transaction.hpp"

--- a/src/function/table/information_schema/information_schema_tables.cpp
+++ b/src/function/table/information_schema/information_schema_tables.cpp
@@ -96,12 +96,10 @@ void information_schema_tables(ClientContext &context, const FunctionData *bind_
 
 		const char *table_type;
 		const char *is_insertable_into = "NO";
-		bool is_temp = false;
 		switch (entry->type) {
 		case CatalogType::TABLE_ENTRY:
 			if (entry->temporary) {
 				table_type = "LOCAL TEMPORARY";
-				is_temp = true;
 			} else {
 				table_type = "BASE TABLE";
 			}
@@ -140,7 +138,7 @@ void information_schema_tables(ClientContext &context, const FunctionData *bind_
 		// "is_typed", PhysicalType::VARCHAR (YES/NO)
 		output.SetValue(10, index, Value("NO"));
 		// "commit_action", PhysicalType::VARCHAR
-		output.SetValue(11, index, is_temp ? Value("PRESERVE") : Value());
+		output.SetValue(11, index, Value());
 	}
 	data.offset = next;
 }

--- a/src/function/table/information_schema/information_schema_tables.cpp
+++ b/src/function/table/information_schema/information_schema_tables.cpp
@@ -115,8 +115,7 @@ void information_schema_tables(ClientContext &context, const FunctionData *bind_
 
 		// return values:
 		// "table_catalog", PhysicalType::VARCHAR
-		// TODO(jwills): how to determine this?
-		output.SetValue(0, index, Value("main"));
+		output.SetValue(0, index, Value());
 		// "table_schema", PhysicalType::VARCHAR
 		output.SetValue(1, index, Value(entry->schema->name));
 		// "table_name", PhysicalType::VARCHAR

--- a/src/function/table/information_schema/information_schema_tables.cpp
+++ b/src/function/table/information_schema/information_schema_tables.cpp
@@ -1,0 +1,152 @@
+#include "duckdb/function/table/information_schema_functions.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/transaction/transaction.hpp"
+
+using namespace std;
+
+namespace duckdb {
+
+struct InformationSchemaTablesData : public FunctionOperatorData {
+	InformationSchemaTablesData() : offset(0) {
+	}
+
+	vector<CatalogEntry *> entries;
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> information_schema_tables_bind(ClientContext &context, vector<Value> &inputs,
+                                                               unordered_map<string, Value> &named_parameters,
+                                                               vector<LogicalType> &return_types,
+                                                               vector<string> &names) {
+	names.push_back("table_catalog");
+	return_types.push_back(LogicalType::VARCHAR);
+
+	names.push_back("table_schema");
+	return_types.push_back(LogicalType::VARCHAR);
+
+	names.push_back("table_name");
+	return_types.push_back(LogicalType::VARCHAR);
+
+	names.push_back("table_type");
+	return_types.push_back(LogicalType::VARCHAR);
+
+	names.push_back("self_referencing_column_name");
+	return_types.push_back(LogicalType::VARCHAR);
+
+	names.push_back("reference_generation");
+	return_types.push_back(LogicalType::VARCHAR);
+
+	names.push_back("user_defined_type_catalog");
+	return_types.push_back(LogicalType::VARCHAR);
+
+	names.push_back("user_defined_type_schema");
+	return_types.push_back(LogicalType::VARCHAR);
+
+	names.push_back("user_defined_type_name");
+	return_types.push_back(LogicalType::VARCHAR);
+
+	names.push_back("is_insertable_into");
+	return_types.push_back(LogicalType::VARCHAR);
+
+	names.push_back("is_typed");
+	return_types.push_back(LogicalType::VARCHAR);
+
+	names.push_back("commit_action");
+	return_types.push_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+unique_ptr<FunctionOperatorData>
+information_schema_tables_init(ClientContext &context, const FunctionData *bind_data, ParallelState *state,
+                               vector<column_t> &column_ids,
+                               unordered_map<idx_t, vector<TableFilter>> &table_filters) {
+	auto result = make_unique<InformationSchemaTablesData>();
+
+	// scan all the schemas for tables and views and collect them
+	auto &transaction = Transaction::GetTransaction(context);
+	Catalog::GetCatalog(context).schemas->Scan(transaction, [&](CatalogEntry *entry) {
+		auto schema = (SchemaCatalogEntry *)entry;
+		schema->tables.Scan(transaction, [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+	});
+
+	return move(result);
+}
+
+void information_schema_tables(ClientContext &context, const FunctionData *bind_data,
+                               FunctionOperatorData *operator_state, DataChunk &output) {
+	auto &data = (InformationSchemaTablesData &)*operator_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	idx_t next = min(data.offset + STANDARD_VECTOR_SIZE, (idx_t)data.entries.size());
+	output.SetCardinality(next - data.offset);
+
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	for (idx_t i = data.offset; i < next; i++) {
+		auto index = i - data.offset;
+		auto entry = reinterpret_cast<StandardEntry *>(data.entries[i]);
+
+        const char *table_type;
+        const char *is_insertable_into = "NO";
+        bool is_temp = false;
+        switch (entry->type) {
+		case CatalogType::TABLE_ENTRY:
+			if (entry->temporary) {
+                table_type = "LOCAL TEMPORARY";
+                is_temp = true;
+            } else {
+                table_type = "BASE TABLE";
+            }
+            is_insertable_into = "YES";
+			break;
+		case CatalogType::VIEW_ENTRY:
+			table_type = "VIEW";
+			break;
+		default:
+            table_type = "UNKNOWN";
+            break;
+		}
+
+ 		// return values:
+		// "table_catalog", PhysicalType::VARCHAR
+		// TODO(jwills): how to determine this?
+		output.SetValue(0, index, Value("main"));
+		// "table_schema", PhysicalType::VARCHAR
+		output.SetValue(1, index, Value(entry->schema->name));
+		// "table_name", PhysicalType::VARCHAR
+		output.SetValue(2, index, Value(entry->name));
+		// "table_type", PhysicalType::VARCHAR
+ 		output.SetValue(3, index, Value(table_type));
+        // "self_referencing_column_name", PhysicalType::VARCHAR
+        output.SetValue(4, index, Value());
+        // "reference_generation", PhysicalType::VARCHAR
+        output.SetValue(5, index, Value());
+		// "user_defined_type_catalog", PhysicalType::VARCHAR
+		output.SetValue(6, index, Value());
+		// "user_defined_type_schema", PhysicalType::VARCHAR
+		output.SetValue(7, index, Value());
+		// "user_defined_type_name", PhysicalType::VARCHAR
+		output.SetValue(8, index, Value());
+		// "is_insertable_into", PhysicalType::VARCHAR (YES/NO)
+		output.SetValue(9, index, Value(is_insertable_into));
+		// "is_typed", PhysicalType::VARCHAR (YES/NO)
+		output.SetValue(10, index, Value("NO"));
+		// "commit_action", PhysicalType::VARCHAR
+		output.SetValue(11, index, is_temp ? Value("PRESERVE") : Value());
+
+	}
+	data.offset = next;
+}
+
+void InformationSchemaTables::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("information_schema_tables", {}, information_schema_tables,
+	                              information_schema_tables_bind, information_schema_tables_init));
+}
+
+} // namespace duckdb

--- a/src/function/table/information_schema_functions.cpp
+++ b/src/function/table/information_schema_functions.cpp
@@ -1,0 +1,11 @@
+#include "duckdb/function/table/information_schema_functions.hpp"
+
+using namespace std;
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterInformationSchemaFunctions() {
+    InformationSchemaSchemata::RegisterFunction(*this);
+}
+
+} // namespace duckdb

--- a/src/function/table/information_schema_functions.cpp
+++ b/src/function/table/information_schema_functions.cpp
@@ -5,7 +5,8 @@ using namespace std;
 namespace duckdb {
 
 void BuiltinFunctions::RegisterInformationSchemaFunctions() {
-    InformationSchemaSchemata::RegisterFunction(*this);
+	InformationSchemaSchemata::RegisterFunction(*this);
+	InformationSchemaTables::RegisterFunction(*this);
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -168,6 +168,7 @@ private:
 	void RegisterReadFunctions();
 	void RegisterTableFunctions();
 	void RegisterArrowFunctions();
+	void RegisterInformationSchemaFunctions();
 
 	// aggregates
 	void RegisterAlgebraicAggregates();

--- a/src/include/duckdb/function/table/information_schema_functions.hpp
+++ b/src/include/duckdb/function/table/information_schema_functions.hpp
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/function/table/information_schema_functions.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/function/table_function.hpp"
+
+namespace duckdb {
+
+struct InformationSchemaSchemata {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
+struct InformationSchemaTables {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
+struct InformationSchemaColumns {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
+} // namespace duckdb

--- a/test/sql/table_function/information_schema.test
+++ b/test/sql/table_function/information_schema.test
@@ -1,0 +1,21 @@
+# name: test/sql/table_function/information_schema.test
+# description: Test information_schema functions
+# group: [table_function]
+
+query TTTTTTT
+SELECT * FROM information_schema_schemata();
+----
+main	main	NULL	NULL	NULL	NULL	NULL				
+
+statement ok
+CREATE SCHEMA scheme;
+
+query I
+SELECT COUNT(*) FROM information_schema_schemata() WHERE schema_name='main'
+----
+1
+
+query I
+SELECT COUNT(*) FROM information_schema_schemata() WHERE schema_name='scheme'
+----
+1

--- a/test/sql/table_function/information_schema.test
+++ b/test/sql/table_function/information_schema.test
@@ -5,8 +5,8 @@
 query TTTTTTT
 SELECT * FROM information_schema_schemata();
 ----
-main	main	NULL	NULL	NULL	NULL	NULL				
-main	temp	NULL	NULL	NULL	NULL	NULL
+NULL	main	NULL	NULL	NULL	NULL	NULL				
+NULL	temp	NULL	NULL	NULL	NULL	NULL
 
 statement ok
 CREATE SCHEMA scheme;

--- a/test/sql/table_function/information_schema.test
+++ b/test/sql/table_function/information_schema.test
@@ -6,16 +6,49 @@ query TTTTTTT
 SELECT * FROM information_schema_schemata();
 ----
 main	main	NULL	NULL	NULL	NULL	NULL				
+main	temp	NULL	NULL	NULL	NULL	NULL
 
 statement ok
 CREATE SCHEMA scheme;
 
 query I
-SELECT COUNT(*) FROM information_schema_schemata() WHERE schema_name='main'
+SELECT COUNT(*) FROM information_schema_schemata() WHERE schema_name='scheme'
 ----
 1
+
+statement ok
+CREATE TABLE scheme.integers (i INTEGER);
+
+query T
+SELECT table_type FROM information_schema_tables() WHERE table_schema='scheme' AND table_name='integers'
+----
+BASE TABLE
+
+statement ok
+CREATE TEMPORARY TABLE floats (f FLOAT);
+
+query T
+SELECT table_type FROM information_schema_tables() WHERE table_schema='temp' AND table_name='floats'
+----
+LOCAL TEMPORARY
+
+statement ok
+CREATE VIEW scheme.vintegers AS SELECT * FROM scheme.integers;
+
+query T
+SELECT table_type FROM information_schema_tables() WHERE table_schema='scheme' AND table_name='vintegers'
+----
+VIEW
+
+statement ok
+DROP SCHEMA scheme CASCADE;
 
 query I
 SELECT COUNT(*) FROM information_schema_schemata() WHERE schema_name='scheme'
 ----
-1
+0
+
+query I
+SELECT COUNT(*) FROM information_schema_tables() WHERE table_schema='scheme'
+----
+0


### PR DESCRIPTION
Per issue #658, we would like to have support for the metadata tables defined in the `information_schema` schema (specifically, `schemata`, `tables`, and `columns`) to support tools like DBeaver and dbt that depend on this metadata in order to operate against a broad class of SQL databases. This PR adds the `information_schema_schemata()` and `information_schema_tables()` table functions that implement the columns in [information_schema.schemata](https://www.postgresql.org/docs/9.1/infoschema-schemata.html) and [information_schema.tables](https://www.postgresql.org/docs/9.1/infoschema-tables.html) in support of this goal.

Since this is my first PR to the project (and first time writing C++ in a pretty long time), I thought I would submit this bit to get feedback on while I work on implementing the more involved (but still straightforward) `information_schema_columns()` table function in a separate PR.