### PR TITLE
Alignment for hash tables

### DIFF
--- a/extension/parquet/parquet-extension.cpp
+++ b/extension/parquet/parquet-extension.cpp
@@ -69,7 +69,7 @@ public:
 
 	template <class T> T read() {
 		available(sizeof(T));
-		T val = *(T *)ptr;
+		T val = Load<T>((data_ptr_t)ptr);
 		inc(sizeof(T));
 		return val;
 	}

--- a/src/common/file_buffer.cpp
+++ b/src/common/file_buffer.cpp
@@ -46,7 +46,7 @@ void FileBuffer::Read(FileHandle &handle, uint64_t location) {
 	// read the buffer from disk
 	handle.Read(internal_buffer, internal_size, location);
 	// compute the checksum
-	uint64_t stored_checksum = *((uint64_t *)internal_buffer);
+	auto stored_checksum = Load<uint64_t>(internal_buffer);
 	uint64_t computed_checksum = Checksum(buffer, size);
 	// verify the checksum
 	if (stored_checksum != computed_checksum) {
@@ -58,7 +58,7 @@ void FileBuffer::Read(FileHandle &handle, uint64_t location) {
 void FileBuffer::Write(FileHandle &handle, uint64_t location) {
 	// compute the checksum and write it to the start of the buffer
 	uint64_t checksum = Checksum(buffer, size);
-	*((uint64_t *)internal_buffer) = checksum;
+	Store<uint64_t>(checksum, internal_buffer);
 	// now write the buffer
 	handle.Write(internal_buffer, internal_size, location);
 }

--- a/src/common/types/null_value.cpp
+++ b/src/common/types/null_value.cpp
@@ -20,25 +20,25 @@ void SetNullValue(data_ptr_t ptr, PhysicalType type) {
 	switch (type) {
 	case PhysicalType::BOOL:
 	case PhysicalType::INT8:
-		*((int8_t *)ptr) = NullValue<int8_t>();
+		Store<int8_t>(NullValue<int8_t>(), ptr);
 		break;
 	case PhysicalType::INT16:
-		*((int16_t *)ptr) = NullValue<int16_t>();
+		Store<int16_t>(NullValue<int16_t>(), ptr);
 		break;
 	case PhysicalType::INT32:
-		*((int32_t *)ptr) = NullValue<int32_t>();
+		Store<int32_t>(NullValue<int32_t>(), ptr);
 		break;
 	case PhysicalType::INT64:
-		*((int64_t *)ptr) = NullValue<int64_t>();
+		Store<int64_t>(NullValue<int64_t>(), ptr);
 		break;
 	case PhysicalType::FLOAT:
-		*((float *)ptr) = NullValue<float>();
+		Store<float>(NullValue<float>(), ptr);
 		break;
 	case PhysicalType::DOUBLE:
-		*((double *)ptr) = NullValue<double>();
+		Store<double>(NullValue<double>(), ptr);
 		break;
 	case PhysicalType::VARCHAR:
-		*((string_t *)ptr) = string_t(NullValue<const char *>());
+		Store<string_t>(string_t(NullValue<const char *>()), ptr);
 		break;
 	default:
 		throw InvalidTypeException(type, "Unsupported type for SetNullValue!");

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -179,7 +179,7 @@ void Vector::SetValue(idx_t index, Value val) {
 		break;
 	case LogicalTypeId::DECIMAL:
 		assert(type.width() == val.type().width() && type.scale() == val.type().scale());
-		switch(type.InternalType()) {
+		switch (type.InternalType()) {
 		case PhysicalType::INT16:
 			((int16_t *)data)[index] = val.value_.smallint;
 			break;
@@ -314,7 +314,7 @@ Value Vector::GetValue(idx_t index) const {
 	case LogicalTypeId::HUGEINT:
 		return Value::HUGEINT(((hugeint_t *)data)[index]);
 	case LogicalTypeId::DECIMAL: {
-		switch(type.InternalType()) {
+		switch (type.InternalType()) {
 		case PhysicalType::INT16:
 			return Value::DECIMAL(((int16_t *)data)[index], type.width(), type.scale());
 		case PhysicalType::INT32:
@@ -441,7 +441,7 @@ void Vector::Print() {
 }
 
 template <class T> static void flatten_constant_vector_loop(data_ptr_t data, data_ptr_t old_data, idx_t count) {
-	auto constant = *((T *)old_data);
+	auto constant = Load<T>(old_data);
 	auto output = (T *)data;
 	for (idx_t i = 0; i < count; i++) {
 		output[i] = constant;

--- a/src/common/vector_operations/numeric_inplace_operators.cpp
+++ b/src/common/vector_operations/numeric_inplace_operators.cpp
@@ -17,6 +17,9 @@ using namespace std;
 
 void VectorOperations::AddInPlace(Vector &input, int64_t right, idx_t count) {
 	assert(input.type.InternalType() == PhysicalType::POINTER);
+	if (right == 0) {
+		return;
+	}
 	switch (input.vector_type) {
 	case VectorType::CONSTANT_VECTOR: {
 		assert(!ConstantVector::IsNull(input));

--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -15,6 +15,10 @@
 namespace duckdb {
 using namespace std;
 
+static idx_t Align(idx_t n) {
+	return ((n + 7) / 8) * 8;
+}
+
 SuperLargeHashTable::SuperLargeHashTable(idx_t initial_capacity, vector<LogicalType> group_types,
                                          vector<LogicalType> payload_types, vector<BoundAggregateExpression *> bindings,
                                          bool parallel)
@@ -25,9 +29,9 @@ SuperLargeHashTable::SuperLargeHashTable(idx_t initial_capacity, vector<LogicalT
 vector<AggregateObject> AggregateObject::CreateAggregateObjects(vector<BoundAggregateExpression *> bindings) {
 	vector<AggregateObject> aggregates;
 	for (auto &binding : bindings) {
-		auto payload_size = binding->function.state_size();
-		aggregates.push_back(AggregateObject(binding->function, binding->children.size(), payload_size,
-		                                     binding->distinct, binding->return_type.InternalType()));
+		aggregates.push_back(AggregateObject(binding->function, binding->children.size(),
+		                                     Align(binding->function.state_size()), binding->distinct,
+		                                     binding->return_type.InternalType()));
 	}
 	return aggregates;
 }
@@ -36,7 +40,7 @@ SuperLargeHashTable::SuperLargeHashTable(idx_t initial_capacity, vector<LogicalT
                                          vector<LogicalType> payload_types, vector<AggregateObject> aggregate_objects,
                                          bool parallel)
     : aggregates(move(aggregate_objects)), group_types(group_types), payload_types(payload_types), group_width(0),
-      payload_width(0), capacity(0), entries(0), data(nullptr), parallel(parallel) {
+      group_padding(0), payload_width(0), capacity(0), entries(0), data(nullptr), parallel(parallel) {
 	// HT tuple layout is as follows:
 	// [FLAG][GROUPS][PAYLOAD]
 	// [FLAG] is the state of the tuple in memory
@@ -45,7 +49,12 @@ SuperLargeHashTable::SuperLargeHashTable(idx_t initial_capacity, vector<LogicalT
 	for (idx_t i = 0; i < group_types.size(); i++) {
 		group_width += GetTypeIdSize(group_types[i].InternalType());
 	}
+	auto aligned_flag_and_group_width = Align(FLAG_SIZE + group_width);
+	group_padding = aligned_flag_and_group_width - FLAG_SIZE - group_width;
+	group_width += group_padding;
+
 	for (idx_t i = 0; i < aggregates.size(); i++) {
+		assert(aggregates[i].payload_size % 8 == 0);
 		payload_width += aggregates[i].payload_size;
 	}
 	empty_payload_data = unique_ptr<data_t[]>(new data_t[payload_width]);
@@ -82,6 +91,7 @@ SuperLargeHashTable::SuperLargeHashTable(idx_t initial_capacity, vector<LogicalT
 	}
 
 	tuple_size = FLAG_SIZE + (group_width + payload_width);
+	assert(tuple_size % 8 == 0);
 	Resize(initial_capacity);
 }
 
@@ -186,6 +196,8 @@ void SuperLargeHashTable::Resize(idx_t size) {
 			assert(groups.size() == found_entries);
 			Vector new_addresses(LogicalType::POINTER);
 			new_table->FindOrCreateGroups(groups, new_addresses);
+
+			VectorOperations::AddInPlace(addresses, group_padding, groups.size());
 
 			// NB: both address vectors already point to the payload start
 			assert(addresses.type == new_addresses.type && addresses.type == LogicalType::POINTER);
@@ -327,12 +339,8 @@ static void templated_scatter(VectorData &gdata, Vector &addresses, const Select
 			auto pointer_idx = sel.get_index(i);
 			auto group_idx = gdata.sel->get_index(pointer_idx);
 			auto ptr = (T *)pointers[pointer_idx];
-
-			if ((*gdata.nullmask)[group_idx]) {
-				*ptr = NullValue<T>();
-			} else {
-				*ptr = data[group_idx];
-			}
+			T store_value = (*gdata.nullmask)[group_idx] ? NullValue<T>() : data[group_idx];
+			Store<T>(store_value, (data_ptr_t)ptr);
 			pointers[pointer_idx] += type_size;
 		}
 	} else {
@@ -340,8 +348,7 @@ static void templated_scatter(VectorData &gdata, Vector &addresses, const Select
 			auto pointer_idx = sel.get_index(i);
 			auto group_idx = gdata.sel->get_index(pointer_idx);
 			auto ptr = (T *)pointers[pointer_idx];
-
-			*ptr = data[group_idx];
+			Store<T>(data[group_idx], (data_ptr_t)ptr);
 			pointers[pointer_idx] += type_size;
 		}
 	}
@@ -417,10 +424,10 @@ static void templated_compare_groups(VectorData &gdata, Vector &addresses, Selec
 		for (idx_t i = 0; i < count; i++) {
 			auto idx = sel.get_index(i);
 			auto group_idx = gdata.sel->get_index(idx);
-			auto value = (T *)pointers[idx];
+			auto value = Load<T>((data_ptr_t)pointers[idx]);
 
 			if ((*gdata.nullmask)[group_idx]) {
-				if (IsNullValue<T>(*value)) {
+				if (IsNullValue<T>(value)) {
 					// match: move to next value to compare
 					sel.set_index(match_count++, idx);
 					pointers[idx] += type_size;
@@ -428,7 +435,7 @@ static void templated_compare_groups(VectorData &gdata, Vector &addresses, Selec
 					no_match.set_index(no_match_count++, idx);
 				}
 			} else {
-				if (Equals::Operation<T>(data[group_idx], *value)) {
+				if (Equals::Operation<T>(data[group_idx], value)) {
 					sel.set_index(match_count++, idx);
 					pointers[idx] += type_size;
 				} else {
@@ -440,9 +447,9 @@ static void templated_compare_groups(VectorData &gdata, Vector &addresses, Selec
 		for (idx_t i = 0; i < count; i++) {
 			auto idx = sel.get_index(i);
 			auto group_idx = gdata.sel->get_index(idx);
-			auto value = (T *)pointers[idx];
+			auto value = Load<T>((data_ptr_t)pointers[idx]);
 
-			if (Equals::Operation<T>(data[group_idx], *value)) {
+			if (Equals::Operation<T>(data[group_idx], value)) {
 				sel.set_index(match_count++, idx);
 				pointers[idx] += type_size;
 			} else {
@@ -580,6 +587,12 @@ idx_t SuperLargeHashTable::FindOrCreateGroups(DataChunk &groups, Vector &address
 		std::swap(next_vector, no_match_vector);
 		remaining_entries = no_match_count;
 	}
+#ifdef DEBUG
+	for (idx_t i = 0; i < groups.size(); i++) {
+		assert((ptrdiff_t)data_pointers[i] % 8 == 0);
+	}
+#endif
+
 	return new_group_count;
 }
 
@@ -619,11 +632,12 @@ idx_t SuperLargeHashTable::Scan(idx_t &scan_position, DataChunk &groups, DataChu
 		VectorOperations::Gather::Set(addresses, column, groups.size());
 	}
 
-	for (idx_t i = 0; i < aggregates.size(); i++) {
-		auto &target = result.data[i];
-		auto &aggr = aggregates[i];
-		aggr.function.finalize(addresses, target, groups.size());
+	// there might be some padding, increment pointers further to addresss this
+	VectorOperations::AddInPlace(addresses, group_padding, groups.size());
 
+	for (idx_t i = 0; i < aggregates.size(); i++) {
+		auto &aggr = aggregates[i];
+		aggr.function.finalize(addresses, result.data[i], groups.size());
 		VectorOperations::AddInPlace(addresses, aggr.payload_size, groups.size());
 	}
 	scan_position = ptr - data;

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -124,11 +124,8 @@ static void templated_serialize_vdata(VectorData &vdata, const SelectionVector &
 			auto source_idx = vdata.sel->get_index(idx);
 
 			auto target = (T *)key_locations[i];
-			if ((*vdata.nullmask)[source_idx]) {
-				*target = NullValue<T>();
-			} else {
-				*target = source[source_idx];
-			}
+			T value = (*vdata.nullmask)[source_idx] ? NullValue<T>() : source[source_idx];
+			Store<T>(value, (data_ptr_t)target);
 			key_locations[i] += sizeof(T);
 		}
 	} else {
@@ -137,7 +134,7 @@ static void templated_serialize_vdata(VectorData &vdata, const SelectionVector &
 			auto source_idx = vdata.sel->get_index(idx);
 
 			auto target = (T *)key_locations[i];
-			*target = source[source_idx];
+			Store<T>(source[source_idx], (data_ptr_t)target);
 			key_locations[i] += sizeof(T);
 		}
 	}
@@ -378,7 +375,7 @@ void JoinHashTable::InsertHashes(Vector &hashes, idx_t count, data_ptr_t key_loc
 		// set prev in current key to the value (NOTE: this will be nullptr if
 		// there is none)
 		auto prev_pointer = (data_ptr_t *)(key_locations[i] + pointer_offset);
-		*prev_pointer = pointers[index];
+		Store<data_ptr_t>(pointers[index], (data_ptr_t)prev_pointer);
 
 		// set pointer to current tuple
 		pointers[index] = key_locations[i];
@@ -412,7 +409,7 @@ void JoinHashTable::Finalize() {
 			// fetch the next vector of entries from the blocks
 			idx_t next = MinValue<idx_t>(STANDARD_VECTOR_SIZE, block.count - entry);
 			for (idx_t i = 0; i < next; i++) {
-				hash_data[i] = *((hash_t *)(dataptr + pointer_offset));
+				hash_data[i] = Load<hash_t>((data_ptr_t)(dataptr + pointer_offset));
 				key_locations[i] = dataptr;
 				dataptr += entry_size;
 			}
@@ -512,8 +509,9 @@ static idx_t TemplatedGather(VectorData &vdata, Vector &pointers, const Selectio
 		auto idx = current_sel.get_index(i);
 		auto kidx = vdata.sel->get_index(idx);
 		auto gdata = (T *)(ptrs[idx] + offset);
+		T val = Load<T>((data_ptr_t)gdata);
 		if ((*vdata.nullmask)[kidx]) {
-			if (IsNullValue<T>(*gdata)) {
+			if (IsNullValue<T>(val)) {
 				match_sel->set_index(result_count++, idx);
 			} else {
 				if (NO_MATCH_SEL) {
@@ -521,7 +519,7 @@ static idx_t TemplatedGather(VectorData &vdata, Vector &pointers, const Selectio
 				}
 			}
 		} else {
-			if (OP::template Operation<T>(data[kidx], *gdata)) {
+			if (OP::template Operation<T>(data[kidx], val)) {
 				match_sel->set_index(result_count++, idx);
 			} else {
 				if (NO_MATCH_SEL) {
@@ -660,7 +658,7 @@ void ScanStructure::AdvancePointers(const SelectionVector &sel, idx_t sel_count)
 	for (idx_t i = 0; i < sel_count; i++) {
 		auto idx = sel.get_index(i);
 		auto chain_pointer = (data_ptr_t *)(ptrs[idx] + ht.pointer_offset);
-		ptrs[idx] = *chain_pointer;
+		ptrs[idx] = Load<data_ptr_t>((data_ptr_t)chain_pointer);
 		if (ptrs[idx]) {
 			this->sel_vector.set_index(new_count++, idx);
 		}
@@ -680,11 +678,11 @@ static void TemplatedGatherResult(Vector &result, uintptr_t *pointers, const Sel
 	for (idx_t i = 0; i < count; i++) {
 		auto ridx = result_vector.get_index(i);
 		auto pidx = sel_vector.get_index(i);
-		auto hdata = (T *)(pointers[pidx] + offset);
-		if (IsNullValue<T>(*hdata)) {
+		T hdata = Load<T>((data_ptr_t)(pointers[pidx] + offset));
+		if (IsNullValue<T>(hdata)) {
 			nullmask[ridx] = true;
 		} else {
-			rdata[ridx] = *hdata;
+			rdata[ridx] = hdata;
 		}
 	}
 }

--- a/src/function/aggregate/distributive/string_agg.cpp
+++ b/src/function/aggregate/distributive/string_agg.cpp
@@ -9,9 +9,9 @@ using namespace std;
 namespace duckdb {
 
 struct string_agg_state_t {
-	char *dataptr;
 	idx_t size;
 	idx_t alloc_size;
+	char *dataptr;
 };
 
 struct StringAggBaseFunction {

--- a/src/include/duckdb/execution/aggregate_hashtable.hpp
+++ b/src/include/duckdb/execution/aggregate_hashtable.hpp
@@ -84,6 +84,8 @@ private:
 	vector<LogicalType> payload_types;
 	//! The size of the groups in bytes
 	idx_t group_width;
+	//! some optional padding to align payload
+	idx_t group_padding;
 	//! The size of the payload (aggregations) in bytes
 	idx_t payload_width;
 	//! The total tuple size

--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -218,7 +218,7 @@ void WriteOverflowStringsToDisk::WriteString(string_t string, block_id_t &result
 
 	// write the length field
 	auto string_length = string.GetSize();
-	*((uint32_t *)(handle->node->buffer + offset)) = string_length;
+	Store<uint32_t>(string_length, handle->node->buffer + offset);
 	offset += sizeof(uint32_t);
 	// now write the remainder of the string
 	auto strptr = string.GetData();
@@ -236,7 +236,7 @@ void WriteOverflowStringsToDisk::WriteString(string_t string, block_id_t &result
 			// there is still remaining stuff to write
 			// first get the new block id and write it to the end of the previous block
 			auto new_block_id = manager.block_manager.GetFreeBlockId();
-			*((block_id_t *)(handle->node->buffer + offset)) = new_block_id;
+			Store<block_id_t>(new_block_id, handle->node->buffer + offset);
 			// now write the current block to disk and allocate a new block
 			AllocateNewBlock(new_block_id);
 		}

--- a/src/storage/meta_block_reader.cpp
+++ b/src/storage/meta_block_reader.cpp
@@ -31,7 +31,7 @@ void MetaBlockReader::ReadData(data_ptr_t buffer, idx_t read_size) {
 void MetaBlockReader::ReadNewBlock(block_id_t id) {
 	handle = manager.Pin(id);
 
-	next_block = *((block_id_t *)handle->node->buffer);
+	next_block = Load<block_id_t>(handle->node->buffer);
 	offset = sizeof(block_id_t);
 }
 

--- a/src/storage/meta_block_writer.cpp
+++ b/src/storage/meta_block_writer.cpp
@@ -36,7 +36,7 @@ void MetaBlockWriter::WriteData(const_data_ptr_t buffer, idx_t write_size) {
 		// now we need to get a new block id
 		block_id_t new_block_id = manager.GetFreeBlockId();
 		// write the block id of the new block to the start of the current block
-		*((block_id_t *)block->buffer) = new_block_id;
+		Store<block_id_t>(new_block_id, block->buffer);
 		// first flush the old block
 		Flush();
 		// now update the block id of the lbock

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -15,16 +15,16 @@ using namespace std;
 const char MainHeader::MAGIC_BYTES[] = "DUCK";
 
 void MainHeader::Serialize(Serializer &ser) {
-	ser.WriteData((data_ptr_t) MAGIC_BYTES, MAGIC_BYTE_SIZE);
+	ser.WriteData((data_ptr_t)MAGIC_BYTES, MAGIC_BYTE_SIZE);
 	ser.Write<uint64_t>(version_number);
-	for(idx_t i = 0; i < FLAG_COUNT; i++) {
+	for (idx_t i = 0; i < FLAG_COUNT; i++) {
 		ser.Write<uint64_t>(flags[i]);
 	}
 }
 
 MainHeader MainHeader::Deserialize(Deserializer &source) {
 	char magic_bytes[MAGIC_BYTE_SIZE];
-	source.ReadData((data_ptr_t) magic_bytes, MAGIC_BYTE_SIZE);
+	source.ReadData((data_ptr_t)magic_bytes, MAGIC_BYTE_SIZE);
 	if (memcmp(magic_bytes, MainHeader::MAGIC_BYTES, MainHeader::MAGIC_BYTE_SIZE) != 0) {
 		throw IOException("The file is not a valid DuckDB database file!");
 	}
@@ -32,7 +32,7 @@ MainHeader MainHeader::Deserialize(Deserializer &source) {
 	MainHeader header;
 	header.version_number = source.Read<uint64_t>();
 	// read the flags
-	for(idx_t i = 0; i < FLAG_COUNT; i++) {
+	for (idx_t i = 0; i < FLAG_COUNT; i++) {
 		header.flags[i] = source.Read<uint64_t>();
 	}
 	return header;
@@ -54,14 +54,12 @@ DatabaseHeader DatabaseHeader::Deserialize(Deserializer &source) {
 	return header;
 }
 
-template<class T>
-void SerializeHeaderStructure(T header, data_ptr_t ptr) {
+template <class T> void SerializeHeaderStructure(T header, data_ptr_t ptr) {
 	BufferedSerializer ser(ptr, Storage::FILE_HEADER_SIZE);
 	header.Serialize(ser);
 }
 
-template<class T>
-T DeserializeHeaderStructure(data_ptr_t ptr) {
+template <class T> T DeserializeHeaderStructure(data_ptr_t ptr) {
 	BufferedDeserializer source(ptr, Storage::FILE_HEADER_SIZE);
 	return T::Deserialize(source);
 }
@@ -133,15 +131,15 @@ SingleFileBlockManager::SingleFileBlockManager(FileSystem &fs, string path, bool
 		// check the version number
 		if (header.version_number != VERSION_NUMBER) {
 			throw IOException(
-				"Trying to read a database file with version number %lld, but we can only read version %lld.\n"
-				"The database file was created with an %s version of DuckDB.\n\n"
-				"The storage of DuckDB is not yet stable; newer versions of DuckDB cannot read old database files and "
-				"vice versa.\n"
-				"The storage will be stabilized when version 1.0 releases.\n\n"
-				"For now, we recommend that you load the database file in a supported version of DuckDB, and use the "
-				"EXPORT DATABASE command "
-				"followed by IMPORT DATABASE on the current version of DuckDB.",
-				header.version_number, VERSION_NUMBER, VERSION_NUMBER > header.version_number ? "older" : "newer");
+			    "Trying to read a database file with version number %lld, but we can only read version %lld.\n"
+			    "The database file was created with an %s version of DuckDB.\n\n"
+			    "The storage of DuckDB is not yet stable; newer versions of DuckDB cannot read old database files and "
+			    "vice versa.\n"
+			    "The storage will be stabilized when version 1.0 releases.\n\n"
+			    "For now, we recommend that you load the database file in a supported version of DuckDB, and use the "
+			    "EXPORT DATABASE command "
+			    "followed by IMPORT DATABASE on the current version of DuckDB.",
+			    header.version_number, VERSION_NUMBER, VERSION_NUMBER > header.version_number ? "older" : "newer");
 		}
 
 		// read the database headers from disk
@@ -263,7 +261,7 @@ void SingleFileBlockManager::WriteHeader(DatabaseHeader header) {
 	}
 	// set the header inside the buffer
 	header_buffer.Clear();
-	*((DatabaseHeader *)header_buffer.buffer) = header;
+	Store<DatabaseHeader>(header, header_buffer.buffer);
 	// now write the header to the file, active_header determines whether we write to h1 or h2
 	// note that if active_header is h1 we write to h2, and vice versa
 	header_buffer.Write(*handle, active_header == 1 ? Storage::FILE_HEADER_SIZE : Storage::FILE_HEADER_SIZE * 2);

--- a/src/storage/string_segment.cpp
+++ b/src/storage/string_segment.cpp
@@ -597,7 +597,7 @@ string_t StringSegment::ReadString(buffer_handle_set_t &handles, block_id_t bloc
 		// read the overflow string from disk
 		// pin the initial handle and read the length
 		auto handle = manager.Pin(block);
-		uint32_t length = *((uint32_t *)(handle->node->buffer + offset));
+		uint32_t length = Load<uint32_t>(handle->node->buffer + offset);
 		uint32_t remaining = length + 1;
 		offset += sizeof(uint32_t);
 
@@ -606,7 +606,7 @@ string_t StringSegment::ReadString(buffer_handle_set_t &handles, block_id_t bloc
 		auto target_handle = manager.Allocate(alloc_size, true);
 		auto target_ptr = target_handle->node->buffer;
 		// write the length in this block as well
-		*((uint32_t *)target_ptr) = length;
+		Store<uint32_t>(length, target_ptr);
 		target_ptr += sizeof(uint32_t);
 		// now append the string to the single buffer
 		while (remaining > 0) {
@@ -618,7 +618,7 @@ string_t StringSegment::ReadString(buffer_handle_set_t &handles, block_id_t bloc
 			target_ptr += to_write;
 			if (remaining > 0) {
 				// read the next block
-				block_id_t next_block = *((block_id_t *)(handle->node->buffer + offset));
+				block_id_t next_block = Load<block_id_t>(handle->node->buffer + offset);
 				handle = manager.Pin(next_block);
 				offset = 0;
 			}
@@ -646,7 +646,7 @@ string_t StringSegment::ReadString(buffer_handle_set_t &handles, block_id_t bloc
 
 string_t StringSegment::ReadString(data_ptr_t target, int32_t offset) {
 	auto ptr = target + offset;
-	auto str_length = *((uint32_t *)ptr);
+	auto str_length = Load<uint32_t>(ptr);
 	auto str_ptr = (char *)(ptr + sizeof(uint32_t));
 	return string_t(str_ptr, str_length);
 }

--- a/src/transaction/cleanup_state.cpp
+++ b/src/transaction/cleanup_state.cpp
@@ -21,7 +21,7 @@ CleanupState::~CleanupState() {
 void CleanupState::CleanupEntry(UndoFlags type, data_ptr_t data) {
 	switch (type) {
 	case UndoFlags::CATALOG_ENTRY: {
-		CatalogEntry *catalog_entry = *((CatalogEntry **)data);
+		auto catalog_entry = Load<CatalogEntry *>(data);
 		// destroy the backed up entry: it is no longer required
 		assert(catalog_entry->parent);
 		if (catalog_entry->parent->type != CatalogType::UPDATED_ENTRY) {

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -34,7 +34,7 @@ void CommitState::WriteCatalogEntry(CatalogEntry *entry, data_ptr_t dataptr) {
 		}
 		if (entry->type == CatalogType::TABLE_ENTRY) {
 			// ALTER TABLE statement, read the extra data after the entry
-			auto extra_data_size = *((idx_t *)dataptr);
+			auto extra_data_size = Load<idx_t>(dataptr);
 			auto extra_data = (data_ptr_t)(dataptr + sizeof(idx_t));
 			// deserialize it
 			BufferedDeserializer source(extra_data, extra_data_size);
@@ -139,7 +139,7 @@ template <bool HAS_LOG> void CommitState::CommitEntry(UndoFlags type, data_ptr_t
 	switch (type) {
 	case UndoFlags::CATALOG_ENTRY: {
 		// set the commit timestamp of the catalog entry to the given id
-		CatalogEntry *catalog_entry = *((CatalogEntry **)data);
+		auto catalog_entry = Load<CatalogEntry *>(data);
 		assert(catalog_entry->parent);
 		catalog_entry->parent->timestamp = commit_id;
 
@@ -179,7 +179,7 @@ void CommitState::RevertCommit(UndoFlags type, data_ptr_t data) {
 	switch (type) {
 	case UndoFlags::CATALOG_ENTRY: {
 		// set the commit timestamp of the catalog entry to the given id
-		CatalogEntry *catalog_entry = *((CatalogEntry **)data);
+		auto catalog_entry = Load<CatalogEntry *>(data);
 		assert(catalog_entry->parent);
 		catalog_entry->parent->timestamp = transaction_id;
 		break;

--- a/src/transaction/rollback_state.cpp
+++ b/src/transaction/rollback_state.cpp
@@ -15,7 +15,7 @@ void RollbackState::RollbackEntry(UndoFlags type, data_ptr_t data) {
 	switch (type) {
 	case UndoFlags::CATALOG_ENTRY: {
 		// undo this catalog entry
-		CatalogEntry *catalog_entry = *((CatalogEntry **)data);
+		auto catalog_entry = Load<CatalogEntry *>(data);
 		assert(catalog_entry->set);
 		catalog_entry->set->Undo(catalog_entry);
 		break;

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -26,12 +26,12 @@ void Transaction::PushCatalogEntry(CatalogEntry *entry, data_ptr_t extra_data, i
 	}
 	auto baseptr = undo_buffer.CreateEntry(UndoFlags::CATALOG_ENTRY, alloc_size);
 	// store the pointer to the catalog entry
-	*((CatalogEntry **)baseptr) = entry;
+	Store<CatalogEntry *>(entry, baseptr);
 	if (extra_data_size > 0) {
 		// copy the extra data behind the catalog entry pointer (if any)
 		baseptr += sizeof(CatalogEntry *);
 		// first store the extra data size
-		*((idx_t *)baseptr) = extra_data_size;
+		Store<idx_t>(extra_data_size, baseptr);
 		baseptr += sizeof(idx_t);
 		// then copy over the actual data
 		memcpy(baseptr, extra_data, extra_data_size);

--- a/src/transaction/undo_buffer.cpp
+++ b/src/transaction/undo_buffer.cpp
@@ -39,9 +39,9 @@ UndoChunk::~UndoChunk() {
 
 data_ptr_t UndoChunk::WriteEntry(UndoFlags type, uint32_t len) {
 	assert(sizeof(UndoFlags) + sizeof(len) == 8);
-	*((UndoFlags *)(data.get() + current_position)) = type;
+	Store<UndoFlags>(type, data.get() + current_position);
 	current_position += sizeof(UndoFlags);
-	*((uint32_t *)(data.get() + current_position)) = len;
+	Store<uint32_t>(len, data.get() + current_position);
 	current_position += sizeof(uint32_t);
 
 	data_ptr_t result = data.get() + current_position;
@@ -69,9 +69,10 @@ template <class T> void UndoBuffer::IterateEntries(UndoBuffer::IteratorState &st
 		state.start = state.current->data.get();
 		state.end = state.start + state.current->current_position;
 		while (state.start < state.end) {
-			UndoFlags type = *((UndoFlags *)state.start);
+			UndoFlags type = Load<UndoFlags>(state.start);
 			state.start += sizeof(UndoFlags);
-			uint32_t len = *((uint32_t *)state.start);
+
+			uint32_t len = Load<uint32_t>(state.start);
 			state.start += sizeof(uint32_t);
 			callback(type, state.start);
 			state.start += len;
@@ -89,9 +90,9 @@ void UndoBuffer::IterateEntries(UndoBuffer::IteratorState &state, UndoBuffer::It
 		state.end =
 		    state.current == end_state.current ? end_state.start : state.start + state.current->current_position;
 		while (state.start < state.end) {
-			UndoFlags type = *((UndoFlags *)state.start);
+			auto type = Load<UndoFlags>(state.start);
 			state.start += sizeof(UndoFlags);
-			uint32_t len = *((uint32_t *)state.start);
+			auto len = Load<uint32_t>(state.start);
 			state.start += sizeof(uint32_t);
 			callback(type, state.start);
 			state.start += len;
@@ -113,9 +114,9 @@ template <class T> void UndoBuffer::ReverseIterateEntries(T &&callback) {
 		// create a vector with all nodes in this chunk
 		vector<pair<UndoFlags, data_ptr_t>> nodes;
 		while (start < end) {
-			UndoFlags type = *((UndoFlags *)start);
+			auto type = Load<UndoFlags>(start);
 			start += sizeof(UndoFlags);
-			uint32_t len = *((uint32_t *)start);
+			auto len = Load<uint32_t>(start);
 			start += sizeof(uint32_t);
 			nodes.push_back(make_pair(type, start));
 			start += len;


### PR DESCRIPTION
The aggregate functions read and write their state from/to the aggregate hash table payload data. This PR ensures that the payload pointers are 8-byte aligned to avoid triggering undefined behaviour. We also fix alignment issues in the Join HT.