### PR TITLE
Fix #911: Add support for renaming views via ALTER TABLE statements

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -158,18 +158,15 @@ CatalogEntry *Catalog::GetEntry(ClientContext &context, CatalogType type, string
 }
 
 template <>
-StandardEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists) {
-	auto entry = GetEntry(context, CatalogType::TABLE_ENTRY, move(schema_name), name, if_exists);
+ViewCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists) {
+	auto entry = GetEntry(context, CatalogType::VIEW_ENTRY, move(schema_name), name, if_exists);
 	if (!entry) {
-		entry = GetEntry(context, CatalogType::VIEW_ENTRY, move(schema_name), name, if_exists);
-		if (!entry) {
-			return nullptr;
-		}
+		return nullptr;
 	}
-	if (entry->type != CatalogType::TABLE_ENTRY && entry->type != CatalogType::VIEW_ENTRY) {
-		throw CatalogException("%s is not a table or view", name);
+	if (entry->type != CatalogType::VIEW_ENTRY) {
+		throw CatalogException("%s is not a view", name);
 	}
-	return (StandardEntry *)entry;
+	return (ViewCatalogEntry *)entry;
 }
 
 template <>

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -158,6 +158,21 @@ CatalogEntry *Catalog::GetEntry(ClientContext &context, CatalogType type, string
 }
 
 template <>
+StandardEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists) {
+	auto entry = GetEntry(context, CatalogType::TABLE_ENTRY, move(schema_name), name, if_exists);
+	if (!entry) {
+		entry = GetEntry(context, CatalogType::VIEW_ENTRY, move(schema_name), name, if_exists);
+		if (!entry) {
+			return nullptr;
+		}
+	}
+	if (entry->type != CatalogType::TABLE_ENTRY && entry->type != CatalogType::VIEW_ENTRY) {
+		throw CatalogException("%s is not a table or view", name);
+	}
+	return (StandardEntry *)entry;
+}
+
+template <>
 TableCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists) {
 	auto entry = GetEntry(context, CatalogType::TABLE_ENTRY, move(schema_name), name, if_exists);
 	if (!entry) {

--- a/src/catalog/catalog_entry/schema_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/schema_catalog_entry.cpp
@@ -166,7 +166,7 @@ void SchemaCatalogEntry::AlterTable(ClientContext &context, AlterTableInfo *info
 		if (entry == nullptr) {
 			throw CatalogException("Table \"%s\" doesn't exist!", info->table);
 		}
-		assert(entry->type == CatalogType::TABLE_ENTRY);
+		assert(entry->type == CatalogType::TABLE_ENTRY || entry->type == CatalogType::VIEW_ENTRY);
 
 		auto copied_entry = entry->Copy(context);
 

--- a/src/catalog/catalog_entry/view_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/view_catalog_entry.cpp
@@ -5,7 +5,6 @@
 #include "duckdb/common/serializer.hpp"
 #include "duckdb/parser/parsed_data/create_view_info.hpp"
 #include "duckdb/common/limits.hpp"
-#include "duckdb/planner/binder.hpp"
 
 #include <algorithm>
 
@@ -68,10 +67,10 @@ string ViewCatalogEntry::ToSQL() {
 unique_ptr<CatalogEntry> ViewCatalogEntry::Copy(ClientContext &context) {
 	auto create_info = make_unique<CreateViewInfo>(schema->name, name);
 	create_info->query = move(query);
-	for (int i = 0; i < aliases.size(); i++) {
+	for (idx_t i = 0; i < aliases.size(); i++) {
 		create_info->aliases.push_back(aliases[i]);
 	}
-	for (int i = 0; i < types.size(); i++) {
+	for (idx_t i = 0; i < types.size(); i++) {
 		create_info->types.push_back(types[i]);
 	}
 	create_info->temporary = temporary;

--- a/src/catalog/catalog_entry/view_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/view_catalog_entry.cpp
@@ -66,7 +66,7 @@ string ViewCatalogEntry::ToSQL() {
 
 unique_ptr<CatalogEntry> ViewCatalogEntry::Copy(ClientContext &context) {
 	auto create_info = make_unique<CreateViewInfo>(schema->name, name);
-	create_info->query = move(query);
+	create_info->query = query->Copy();
 	for (idx_t i = 0; i < aliases.size(); i++) {
 		create_info->aliases.push_back(aliases[i]);
 	}

--- a/src/catalog/catalog_entry/view_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/view_catalog_entry.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/serializer.hpp"
 #include "duckdb/parser/parsed_data/create_view_info.hpp"
 #include "duckdb/common/limits.hpp"
+#include "duckdb/planner/binder.hpp"
 
 #include <algorithm>
 
@@ -62,6 +63,21 @@ string ViewCatalogEntry::ToSQL() {
 		throw NotImplementedException("Cannot convert VIEW to SQL because it was not created with a SQL statement");
 	}
 	return sql + "\n;";
+}
+
+unique_ptr<CatalogEntry> ViewCatalogEntry::Copy(ClientContext &context) {
+	auto create_info = make_unique<CreateViewInfo>(schema->name, name);
+	create_info->query = move(query);
+	for (int i = 0; i < aliases.size(); i++) {
+		create_info->aliases.push_back(aliases[i]);
+	}
+	for (int i = 0; i < types.size(); i++) {
+		create_info->types.push_back(types[i]);
+	}
+	create_info->temporary = temporary;
+	create_info->sql = sql;
+
+	return make_unique<ViewCatalogEntry>(catalog, schema, create_info.get());
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -30,8 +30,8 @@ class Transaction;
 class AggregateFunctionCatalogEntry;
 class CollateCatalogEntry;
 class SchemaCatalogEntry;
-class StandardEntry;
 class TableCatalogEntry;
+class ViewCatalogEntry;
 class SequenceCatalogEntry;
 class TableFunctionCatalogEntry;
 class CopyFunctionCatalogEntry;
@@ -102,9 +102,9 @@ private:
 };
 
 template <>
-StandardEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists);
-template <>
 TableCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists);
+template <>
+ViewCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists);
 template <>
 SequenceCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists);
 template <>

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -30,6 +30,7 @@ class Transaction;
 class AggregateFunctionCatalogEntry;
 class CollateCatalogEntry;
 class SchemaCatalogEntry;
+class StandardEntry;
 class TableCatalogEntry;
 class SequenceCatalogEntry;
 class TableFunctionCatalogEntry;
@@ -100,6 +101,8 @@ private:
 	void DropSchema(ClientContext &context, DropInfo *info);
 };
 
+template <>
+StandardEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists);
 template <>
 TableCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists);
 template <>

--- a/src/include/duckdb/catalog/catalog_entry/view_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/view_catalog_entry.hpp
@@ -40,6 +40,8 @@ public:
 	//! Deserializes to a CreateTableInfo
 	static unique_ptr<CreateViewInfo> Deserialize(Deserializer &source);
 
+	unique_ptr<CatalogEntry> Copy(ClientContext &context) override;
+
 	string ToSQL() override;
 
 private:

--- a/src/include/duckdb/parser/parsed_data/alter_table_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/alter_table_info.hpp
@@ -34,7 +34,8 @@ enum class AlterTableType : uint8_t {
 	ADD_COLUMN = 3,
 	REMOVE_COLUMN = 4,
 	ALTER_COLUMN_TYPE = 5,
-	SET_DEFAULT = 6
+	SET_DEFAULT = 6,
+	RENAME_VIEW = 7
 };
 
 struct AlterTableInfo : public AlterInfo {
@@ -79,18 +80,19 @@ public:
 // RenameTableInfo
 //===--------------------------------------------------------------------===//
 struct RenameTableInfo : public AlterTableInfo {
-	RenameTableInfo(string schema, string table, string new_name)
-	    : AlterTableInfo(AlterTableType::RENAME_TABLE, schema, table), new_table_name(new_name) {
+	RenameTableInfo(string schema, string table, string new_name, bool is_view)
+	    : AlterTableInfo(is_view ? AlterTableType::RENAME_VIEW : AlterTableType::RENAME_TABLE, schema, table),
+	      new_table_name(new_name) {
 	}
 	~RenameTableInfo() override {
 	}
 
-	//! Table new name
+	//! Relation new name
 	string new_table_name;
 
 public:
 	void Serialize(Serializer &serializer) override;
-	static unique_ptr<AlterInfo> Deserialize(Deserializer &source, string schema, string table);
+	static unique_ptr<AlterInfo> Deserialize(Deserializer &source, string schema, string table, bool is_view);
 };
 
 //===--------------------------------------------------------------------===//

--- a/src/parser/parsed_data/alter_table_info.cpp
+++ b/src/parser/parsed_data/alter_table_info.cpp
@@ -34,7 +34,9 @@ unique_ptr<AlterInfo> AlterTableInfo::Deserialize(Deserializer &source) {
 	case AlterTableType::RENAME_COLUMN:
 		return RenameColumnInfo::Deserialize(source, schema, table);
 	case AlterTableType::RENAME_TABLE:
-		return RenameTableInfo::Deserialize(source, schema, table);
+		return RenameTableInfo::Deserialize(source, schema, table, false);
+	case AlterTableType::RENAME_VIEW:
+		return RenameTableInfo::Deserialize(source, schema, table, true);
 	case AlterTableType::ADD_COLUMN:
 		return AddColumnInfo::Deserialize(source, schema, table);
 	case AlterTableType::REMOVE_COLUMN:
@@ -71,9 +73,9 @@ void RenameTableInfo::Serialize(Serializer &serializer) {
 	serializer.WriteString(new_table_name);
 }
 
-unique_ptr<AlterInfo> RenameTableInfo::Deserialize(Deserializer &source, string schema, string table) {
+unique_ptr<AlterInfo> RenameTableInfo::Deserialize(Deserializer &source, string schema, string table, bool is_view) {
 	auto new_name = source.Read<string>();
-	return make_unique<RenameTableInfo>(schema, table, new_name);
+	return make_unique<RenameTableInfo>(schema, table, new_name, is_view);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/parser/transform/statement/transform_rename.cpp
+++ b/src/parser/transform/statement/transform_rename.cpp
@@ -47,10 +47,27 @@ unique_ptr<AlterTableStatement> Transformer::TransformRename(PGNode *node) {
 			schema = stmt->relation->schemaname;
 		}
 		string new_name = stmt->newname;
-		info = make_unique<RenameTableInfo>(schema, table, new_name);
+		info = make_unique<RenameTableInfo>(schema, table, new_name, false /* is_view */);
 		break;
 	}
 
+	case PG_OBJECT_VIEW: {
+		// change view name
+
+		// get the view and schema
+		string schema = DEFAULT_SCHEMA;
+		string view;
+		assert(stmt->relation->relname);
+		if (stmt->relation->relname) {
+			view = stmt->relation->relname;
+		}
+		if (stmt->relation->schemaname) {
+			schema = stmt->relation->schemaname;
+		}
+		string new_name = stmt->newname;
+		info = make_unique<RenameTableInfo>(schema, view, new_name, true /* is_view */);
+		break;
+	}
 	case PG_OBJECT_DATABASE:
 	default:
 		throw NotImplementedException("Schema element not supported yet!");

--- a/src/planner/binder/statement/bind_simple.cpp
+++ b/src/planner/binder/statement/bind_simple.cpp
@@ -15,16 +15,8 @@ BoundStatement Binder::Bind(AlterTableStatement &stmt) {
 	BoundStatement result;
 	result.names = {"Success"};
 	result.types = {LogicalType::BOOLEAN};
-	auto table = Catalog::GetCatalog(context).GetEntry(context, CatalogType::TABLE_ENTRY, stmt.info->schema,
-	                                                   stmt.info->table, true);
-	if (!table) {
-		// Check for a view with that name
-		table = Catalog::GetCatalog(context).GetEntry(context, CatalogType::VIEW_ENTRY, stmt.info->schema,
-		                                              stmt.info->table, true);
-		if (!table) {
-			throw new CatalogException("Table or view %s not found", stmt.info->table);
-		}
-	}
+	auto table =
+	    Catalog::GetCatalog(context).GetEntry<StandardEntry>(context, stmt.info->schema, stmt.info->table, true);
 	if (table && !table->temporary) {
 		// we can only alter temporary tables in read-only mode
 		this->read_only = false;

--- a/src/planner/binder/statement/bind_simple.cpp
+++ b/src/planner/binder/statement/bind_simple.cpp
@@ -2,6 +2,8 @@
 #include "duckdb/parser/statement/transaction_statement.hpp"
 #include "duckdb/planner/operator/logical_simple.hpp"
 #include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
 #include "duckdb/planner/binder.hpp"
 
 using namespace std;
@@ -15,10 +17,15 @@ BoundStatement Binder::Bind(AlterTableStatement &stmt) {
 	BoundStatement result;
 	result.names = {"Success"};
 	result.types = {LogicalType::BOOLEAN};
-	auto table =
-	    Catalog::GetCatalog(context).GetEntry<StandardEntry>(context, stmt.info->schema, stmt.info->table, true);
+	Catalog &catalog = Catalog::GetCatalog(context);
+	CatalogEntry *table;
+	if (stmt.info->alter_table_type == AlterTableType::RENAME_VIEW) {
+		table = catalog.GetEntry<ViewCatalogEntry>(context, stmt.info->schema, stmt.info->table, true);
+	} else {
+		table = catalog.GetEntry<TableCatalogEntry>(context, stmt.info->schema, stmt.info->table, true);
+	}
 	if (table && !table->temporary) {
-		// we can only alter temporary tables in read-only mode
+		// we can only alter temporary tables/views in read-only mode
 		this->read_only = false;
 	}
 	result.plan = make_unique<LogicalSimple>(LogicalOperatorType::ALTER, move(stmt.info));

--- a/src/planner/binder/statement/bind_simple.cpp
+++ b/src/planner/binder/statement/bind_simple.cpp
@@ -15,8 +15,16 @@ BoundStatement Binder::Bind(AlterTableStatement &stmt) {
 	BoundStatement result;
 	result.names = {"Success"};
 	result.types = {LogicalType::BOOLEAN};
-	auto table =
-	    Catalog::GetCatalog(context).GetEntry<TableCatalogEntry>(context, stmt.info->schema, stmt.info->table, true);
+	auto table = Catalog::GetCatalog(context).GetEntry(context, CatalogType::TABLE_ENTRY, stmt.info->schema,
+	                                                   stmt.info->table, true);
+	if (!table) {
+		// Check for a view with that name
+		table = Catalog::GetCatalog(context).GetEntry(context, CatalogType::VIEW_ENTRY, stmt.info->schema,
+		                                              stmt.info->table, true);
+		if (!table) {
+			throw new CatalogException("Table or view %s not found", stmt.info->table);
+		}
+	}
 	if (table && !table->temporary) {
 		// we can only alter temporary tables in read-only mode
 		this->read_only = false;

--- a/test/sql/alter/rename_table/test_rename_table_view.test
+++ b/test/sql/alter/rename_table/test_rename_table_view.test
@@ -11,11 +11,11 @@ INSERT INTO tbl VALUES (999), (100)
 statement ok
 CREATE VIEW v1 AS SELECT * FROM tbl
 
-statement error
+statement ok
 ALTER TABLE v1 RENAME TO v2
 
 query I
-SELECT * FROM  v1
+SELECT * FROM v2
 ----
 999
 100

--- a/test/sql/alter/rename_table/test_rename_table_view.test
+++ b/test/sql/alter/rename_table/test_rename_table_view.test
@@ -11,8 +11,11 @@ INSERT INTO tbl VALUES (999), (100)
 statement ok
 CREATE VIEW v1 AS SELECT * FROM tbl
 
-statement ok
+statement error
 ALTER TABLE v1 RENAME TO v2
+
+statement ok
+ALTER VIEW v1 RENAME TO v2
 
 query I
 SELECT * FROM v2

--- a/test/sql/alter/rename_view/test_rename_view.test
+++ b/test/sql/alter/rename_view/test_rename_view.test
@@ -1,0 +1,60 @@
+# name: test/sql/alter/rename_table/test_rename_table.test
+# description: Test RENAME TABLE single transaction
+# group: [rename_table]
+
+statement ok
+CREATE TABLE tbl(i INTEGER);
+INSERT INTO tbl VALUES (999), (100);
+CREATE VIEW vw AS SELECT * FROM tbl;
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+ALTER VIEW vw RENAME TO vw2
+
+query I
+SELECT * FROM vw2
+----
+999
+100
+
+statement error
+SELECT * FROM vw
+
+statement ok
+ROLLBACK
+
+query I
+SELECT * FROM vw;
+----
+999
+100
+
+statement error
+SELECT * FROM vw2
+
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
+ALTER VIEW vw RENAME TO vw2
+
+statement ok
+COMMIT
+
+query I
+SELECT * FROM vw2
+----
+999
+100
+
+statement error
+SELECT * FROM vw
+
+query I
+SELECT * FROM vw2
+----
+999
+100
+

--- a/test/sql/alter/rename_view/test_rename_view.test
+++ b/test/sql/alter/rename_view/test_rename_view.test
@@ -1,6 +1,6 @@
-# name: test/sql/alter/rename_table/test_rename_table.test
-# description: Test RENAME TABLE single transaction
-# group: [rename_table]
+# name: test/sql/alter/rename_view/test_rename_view.test
+# description: Test RENAME VIEW single transaction
+# group: [rename_view]
 
 statement ok
 CREATE TABLE tbl(i INTEGER);

--- a/test/sql/alter/rename_view/test_rename_view_incorrect.test
+++ b/test/sql/alter/rename_view/test_rename_view_incorrect.test
@@ -1,0 +1,21 @@
+# name: test/sql/alter/rename_table/test_rename_table_incorrect.test
+# description: Test RENAME TABLE: table does not exist and rename to an already existing table
+# group: [rename_table]
+
+statement ok
+CREATE TABLE tbl(i INTEGER)
+
+statement ok
+CREATE VIEW vw AS SELECT * FROM tbl
+
+statement ok
+CREATE VIEW vw2 AS SELECT 1729 AS i
+
+# Renaming a non existing view
+statement error
+ALTER VIEW non_view RENAME TO vw
+
+# rename to an already existing view
+statement error
+ALTER VIEW vw2 RENAME TO vw
+

--- a/test/sql/alter/rename_view/test_rename_view_incorrect.test
+++ b/test/sql/alter/rename_view/test_rename_view_incorrect.test
@@ -1,6 +1,6 @@
-# name: test/sql/alter/rename_table/test_rename_table_incorrect.test
-# description: Test RENAME TABLE: table does not exist and rename to an already existing table
-# group: [rename_table]
+# name: test/sql/alter/rename_view/test_rename_view_incorrect.test
+# description: Test RENAME VIEW: view does not exist and rename to an already existing view
+# group: [rename_view]
 
 statement ok
 CREATE TABLE tbl(i INTEGER)

--- a/test/sql/alter/rename_view/test_rename_view_many_transactions.test
+++ b/test/sql/alter/rename_view/test_rename_view_many_transactions.test
@@ -1,0 +1,101 @@
+# name: test/sql/alter/rename_view/test_rename_view_many_transactions.test
+# description: Test RENAME VIEW four view renames and four parallel transactions
+# group: [rename_view]
+
+statement ok con1
+CREATE TABLE tbl1(i INTEGER)
+
+statement ok con1
+INSERT INTO tbl1 VALUES (999), (100)
+
+statement ok con1
+CREATE VIEW vw1 AS SELECT * FROM tbl1
+
+# rename chain
+# con2 starts a transaction now
+statement ok con2
+BEGIN TRANSACTION
+
+# rename in con1, con2 should still see "vw1"
+statement ok con1
+ALTER VIEW vw1 RENAME TO vw2
+
+# con3 starts a transaction now
+statement ok con3
+BEGIN TRANSACTION
+
+# rename in con1, con3 should still see "vw2"
+statement ok con1
+ALTER VIEW vw2 RENAME TO vw3
+
+# con4 starts a transaction now
+statement ok con4
+BEGIN TRANSACTION
+
+# rename in con1, con4 should still see "vw3"
+statement ok con1
+ALTER VIEW vw3 RENAME TO vw4
+
+# con2 sees ONLY vw1
+query I con2
+SELECT * FROM vw1
+----
+999
+100
+
+statement error con2
+SELECT * FROM vw2
+
+statement error con2
+SELECT * FROM vw3
+
+statement error con2
+SELECT * FROM vw4
+
+# con3 sees ONLY vw2
+statement error con3
+SELECT * FROM vw1
+
+query I con3
+SELECT * FROM vw2
+----
+999
+100
+
+statement error con3
+SELECT * FROM vw3
+
+statement error con3
+SELECT * FROM vw4
+
+# con4 sees ONLY vw3
+statement error con4
+SELECT * FROM vw1
+
+statement error con4
+SELECT * FROM vw2
+
+query I con4
+SELECT * FROM vw3
+----
+999
+100
+
+statement error con4
+SELECT * FROM vw4
+
+# con1 sees ONLY vw4
+statement error con1
+SELECT * FROM vw1
+
+statement error con1
+SELECT * FROM vw2
+
+statement error con1
+SELECT * FROM vw3
+
+query I con1
+SELECT * FROM vw4
+----
+999
+100

--- a/test/sql/alter/rename_view/test_rename_view_table.test
+++ b/test/sql/alter/rename_view/test_rename_view_table.test
@@ -1,6 +1,6 @@
-# name: test/sql/alter/rename_table/test_rename_table_view.test
-# description: Test RENAME TABLE with a view as entry
-# group: [rename_table]
+# name: test/sql/alter/rename_view/test_rename_view_table.test
+# description: Test RENAME VIEW with a table as entry
+# group: [rename_view]
 
 statement ok
 CREATE TABLE tbl(i INTEGER)

--- a/test/sql/alter/rename_view/test_rename_view_table.test
+++ b/test/sql/alter/rename_view/test_rename_view_table.test
@@ -12,7 +12,7 @@ statement ok
 CREATE VIEW v1 AS SELECT * FROM tbl
 
 statement error
-ALTER TABLE v1 RENAME TO v2
+ALTER VIEW tbl RENAME TO tbl2
 
 query I
 SELECT * FROM v1

--- a/test/sql/alter/rename_view/test_rename_view_transactions.test
+++ b/test/sql/alter/rename_view/test_rename_view_transactions.test
@@ -1,0 +1,64 @@
+# name: test/sql/alter/rename_table/test_rename_table_transactions.test
+# description: Test RENAME TABLE two parallel transactions
+# group: [rename_table]
+
+statement ok con1
+CREATE TABLE tbl(i INTEGER)
+
+statement ok con1
+INSERT INTO tbl VALUES (999), (100)
+
+statement ok con1
+CREATE VIEW vw AS SELECT * FROM tbl
+
+statement ok con1
+BEGIN TRANSACTION
+
+statement ok con2
+BEGIN TRANSACTION
+
+statement ok con1
+ALTER VIEW vw RENAME TO vw2
+
+query I con1
+SELECT * FROM vw2
+----
+999
+100
+
+statement error con1
+SELECT * FROM vw
+
+query I con2
+SELECT * FROM vw
+----
+999
+100
+
+statement error con2
+SELECT * FROM vw2
+
+statement ok con1
+COMMIT
+
+statement ok con2
+COMMIT
+
+statement error con1
+SELECT * FROM vw
+
+statement error con2
+SELECT * FROM vw
+
+query I con1
+SELECT * FROM vw2
+----
+999
+100
+
+query I con2
+SELECT * FROM vw2
+----
+999
+100
+

--- a/test/sql/alter/rename_view/test_rename_view_transactions.test
+++ b/test/sql/alter/rename_view/test_rename_view_transactions.test
@@ -1,6 +1,6 @@
-# name: test/sql/alter/rename_table/test_rename_table_transactions.test
-# description: Test RENAME TABLE two parallel transactions
-# group: [rename_table]
+# name: test/sql/alter/rename_view/test_rename_view_transactions.test
+# description: Test RENAME VIEW two parallel transactions
+# group: [rename_view]
 
 statement ok con1
 CREATE TABLE tbl(i INTEGER)

--- a/test/sql/storage/catalog/test_store_rename_view.test
+++ b/test/sql/storage/catalog/test_store_rename_view.test
@@ -1,13 +1,9 @@
-# name: test/sql/storage/catalog/test_rename_table.test
-# description: Test storage of alter table rename table
+# name: test/sql/storage/catalog/test_rename_view.test
+# description: Test storage of alter view
 # group: [catalog]
 
-#  FIXME: right now rename is implemented as drop + create
-#  on database restart that means all data is removed from the table
-mode skip
-
 # load the DB from disk
-load __TEST_DIR__/test_rename_table.db
+load __TEST_DIR__/test_rename_view.db
 
 statement ok
 CREATE TABLE test (a INTEGER, b INTEGER);
@@ -16,17 +12,20 @@ statement ok
 INSERT INTO test VALUES (11, 22), (13, 22), (12, 21)
 
 statement ok
+CREATE VIEW vtest AS SELECT * FROM test
+
+statement ok
 BEGIN TRANSACTION
 
 query I
-SELECT a FROM test ORDER BY a
+SELECT a FROM vtest ORDER BY a
 ----
 11
 12
 13
 
 statement ok
-ALTER TABLE test RENAME TO new_name
+ALTER VIEW vtest RENAME TO new_name
 
 query I
 SELECT a FROM new_name ORDER BY 1
@@ -46,7 +45,7 @@ BEGIN TRANSACTION
 
 # verify that the table is still there in the original form
 query I
-SELECT a FROM test ORDER BY a
+SELECT a FROM vtest ORDER BY a
 ----
 11
 12
@@ -54,7 +53,7 @@ SELECT a FROM test ORDER BY a
 
 # now repeat the process, but this time commit
 statement ok
-ALTER TABLE test RENAME TO new_name
+ALTER VIEW vtest RENAME TO new_name
 
 query I
 SELECT a FROM new_name ORDER BY 1


### PR DESCRIPTION
Adds support for renaming views as well as tables via `ALTER TABLE <from_relation> RENAME TO <to_relation>` syntax, which I needed for dbt support. This is currently failing a couple of unit tests related to renaming non-existent tables, which makes sense to me b/c I messed with the logic inside of `bind_simple.cpp` for alter tables, but it's not totally obvious to me how to fix it right now.