### PR TITLE
Add support for reading Python date/datetime params via bindings

### DIFF
--- a/tools/pythonpkg/tests/test_datetime.py
+++ b/tools/pythonpkg/tests/test_datetime.py
@@ -15,4 +15,3 @@ class TestDatetime(object):
         duckdb_cursor.execute("INSERT INTO t2 VALUES (?)", (now, ))
         result = duckdb_cursor.execute("SELECT * FROM t2").fetchone()
         assert result == (now, )
-

--- a/tools/pythonpkg/tests/test_datetime.py
+++ b/tools/pythonpkg/tests/test_datetime.py
@@ -1,0 +1,18 @@
+
+import datetime
+
+class TestDatetime(object):
+    def test_date(self, duckdb_cursor):
+        today = datetime.date.today()
+        duckdb_cursor.execute("CREATE TABLE t1 (d date)")
+        duckdb_cursor.execute("INSERT INTO t1 VALUES (?)", (today, ))
+        result = duckdb_cursor.execute("SELECT * FROM t1").fetchone()
+        assert result == (today, )
+
+    def test_datetime(self, duckdb_cursor):
+        now = datetime.datetime.utcnow().replace(microsecond=0)
+        duckdb_cursor.execute("CREATE TABLE t2 (t timestamp)")
+        duckdb_cursor.execute("INSERT INTO t2 VALUES (?)", (now, ))
+        result = duckdb_cursor.execute("SELECT * FROM t2").fetchone()
+        assert result == (now, )
+

--- a/tools/pythonpkg/tests/test_dbapi05.py
+++ b/tools/pythonpkg/tests/test_dbapi05.py
@@ -1,5 +1,6 @@
 #simple DB API testcase
 
+from datetime import date
 
 class TestSimpleDBAPI(object):
 	def test_prepare(self, duckdb_cursor):
@@ -10,7 +11,7 @@ class TestSimpleDBAPI(object):
 		
 		# from python docs
 		c.execute('''CREATE TABLE stocks
-			 (date text, trans text, symbol text, qty real, price real)''')
+			 (date date, trans text, symbol text, qty real, price real)''')
 		c.execute("INSERT INTO stocks VALUES ('2006-01-05','BUY','RHAT',100,35.14)")
 
 		t = ('RHAT',)
@@ -23,11 +24,14 @@ class TestSimpleDBAPI(object):
 		assert result == (1,)
 
 		# Larger example that inserts many records at a time
-		purchases = [('2006-03-28', 'BUY', 'IBM', 1000, 45.00),
-					 ('2006-04-05', 'BUY', 'MSFT', 1000, 72.00),
-					 ('2006-04-06', 'SELL', 'IBM', 500, 53.00),
+		purchases = [(date(2006, 3, 28), 'BUY', 'IBM', 1000, 45.00),
+					 (date(2006, 4, 5), 'BUY', 'MSFT', 1000, 72.00),
+					 (date(2006, 4, 6), 'SELL', 'IBM', 500, 53.00),
 					]
 		c.executemany('INSERT INTO stocks VALUES (?,?,?,?,?)', purchases)
 
 		result = c.execute('SELECT count(*) FROM stocks').fetchone()
 		assert result == (4, )
+
+		result = c.execute('SELECT date FROM stocks ORDER BY date DESC LIMIT 1').fetchone()
+		assert result == (date(2006, 4, 6), )

--- a/tools/pythonpkg/tests/test_module.py
+++ b/tools/pythonpkg/tests/test_module.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import duckdb
+
+class TestModule(object):
+
+    def test_module_attributes(self, duckdb_cursor):
+        assert 'qmark' == duckdb.paramstyle
+        assert '1.0' == duckdb.apilevel
+        assert 1 == duckdb.threadsafety      


### PR DESCRIPTION
I punted on adding explicit support for the microseconds -> milliseconds conversion for the `datetime` object, but I'll try to revisit it this evening (US Pacific time) when I have some more cycles and see if I can get it ready.

I also added in a couple of module attributes that the dbapi expects (`apilevel`, `threadsafety`, and `paramstyle`)- I needed `paramstyle` for my use case and added the other two while I was there.

I added tests for all of the above but played things a little fast-and-loose as the test structure here isn't as obvious to me as it is for the sql stuff.