### PR TITLE
Add in support for Python datetime types in bindings

### DIFF
--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -965,26 +965,26 @@ struct DuckDBPyConnection {
 				args.push_back(Value::DOUBLE(ele.cast<double>()));
 			} else if (py::isinstance<py::str>(ele)) {
 				args.push_back(Value(ele.cast<string>()));
-			} else if (ele.get_type().is(datetime_time)) {
+			} else if (py::isinstance(ele, datetime_datetime)) {
+                                auto year = PyDateTime_GET_YEAR(ele.ptr());
+                                auto month = PyDateTime_GET_MONTH(ele.ptr());
+                                auto day = PyDateTime_GET_DAY(ele.ptr());
+                                auto hour = PyDateTime_DATE_GET_HOUR(ele.ptr());
+                                auto minute = PyDateTime_DATE_GET_MINUTE(ele.ptr());
+                                auto second = PyDateTime_DATE_GET_SECOND(ele.ptr());
+                                auto millis = PyDateTime_DATE_GET_MICROSECOND(ele.ptr()) / 1000;
+                                args.push_back(Value::TIMESTAMP(year, month, day, hour, minute, second, millis));
+			} else if (py::isinstance(ele, datetime_time)) {
 				auto hour = PyDateTime_TIME_GET_HOUR(ele.ptr());
 				auto minute = PyDateTime_TIME_GET_MINUTE(ele.ptr());
 				auto second = PyDateTime_TIME_GET_SECOND(ele.ptr());
 				auto millis = PyDateTime_TIME_GET_MICROSECOND(ele.ptr()) / 1000;
 				args.push_back(Value::TIME(hour, minute, second, millis));
-			} else if (ele.get_type().is(datetime_date)) {
+			} else if (py::isinstance(ele, datetime_date)) {
 				auto year = PyDateTime_GET_YEAR(ele.ptr());
 				auto month = PyDateTime_GET_MONTH(ele.ptr());
 				auto day = PyDateTime_GET_DAY(ele.ptr());
 				args.push_back(Value::DATE(year, month, day));
-			} else if (ele.get_type().is(datetime_datetime)) {
-				auto year = PyDateTime_GET_YEAR(ele.ptr());
-				auto month = PyDateTime_GET_MONTH(ele.ptr());
-				auto day = PyDateTime_GET_DAY(ele.ptr());
-				auto hour = PyDateTime_DATE_GET_HOUR(ele.ptr());
-				auto minute = PyDateTime_DATE_GET_MINUTE(ele.ptr());
-				auto second = PyDateTime_DATE_GET_SECOND(ele.ptr());
-				auto millis = PyDateTime_DATE_GET_MICROSECOND(ele.ptr()) / 1000;
-				args.push_back(Value::TIMESTAMP(year, month, day, hour, minute, second, millis));
 			} else {
 				throw runtime_error("unknown param type " + py::str(ele.get_type()).cast<string>());
 			}

--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -950,8 +950,9 @@ struct DuckDBPyConnection {
 		vector<Value> args;
 
 		auto datetime_mod = py::module::import("datetime");
-		auto datetime_date = datetime_mod.attr("datetime");
-		auto datetime_datetime = datetime_mod.attr("date");
+		auto datetime_date = datetime_mod.attr("date");
+		auto datetime_datetime = datetime_mod.attr("datetime");
+		auto datetime_time = datetime_mod.attr("time");
 
 		for (auto &ele : params) {
 			if (ele.is_none()) {
@@ -964,12 +965,26 @@ struct DuckDBPyConnection {
 				args.push_back(Value::DOUBLE(ele.cast<double>()));
 			} else if (py::isinstance<py::str>(ele)) {
 				args.push_back(Value(ele.cast<string>()));
+			} else if (ele.get_type().is(datetime_time)) {
+				auto hour = PyDateTime_TIME_GET_HOUR(ele.ptr());
+				auto minute = PyDateTime_TIME_GET_MINUTE(ele.ptr());
+				auto second = PyDateTime_TIME_GET_SECOND(ele.ptr());
+				auto millis = PyDateTime_TIME_GET_MICROSECOND(ele.ptr()) / 1000;
+				args.push_back(Value::TIME(hour, minute, second, millis));
 			} else if (ele.get_type().is(datetime_date)) {
-				throw runtime_error("date parameters not supported yet :/");
-				// args.push_back(Value::DATE(1984, 4, 24));
+				auto year = PyDateTime_GET_YEAR(ele.ptr());
+				auto month = PyDateTime_GET_MONTH(ele.ptr());
+				auto day = PyDateTime_GET_DAY(ele.ptr());
+				args.push_back(Value::DATE(year, month, day));
 			} else if (ele.get_type().is(datetime_datetime)) {
-				throw runtime_error("datetime parameters not supported yet :/");
-				// args.push_back(Value::TIMESTAMP(1984, 4, 24, 14, 42, 0, 0));
+				auto year = PyDateTime_GET_YEAR(ele.ptr());
+				auto month = PyDateTime_GET_MONTH(ele.ptr());
+				auto day = PyDateTime_GET_DAY(ele.ptr());
+				auto hour = PyDateTime_DATE_GET_HOUR(ele.ptr());
+				auto minute = PyDateTime_DATE_GET_MINUTE(ele.ptr());
+				auto second = PyDateTime_DATE_GET_SECOND(ele.ptr());
+				auto millis = PyDateTime_DATE_GET_MICROSECOND(ele.ptr()) / 1000;
+				args.push_back(Value::TIMESTAMP(year, month, day, hour, minute, second, millis));
 			} else {
 				throw runtime_error("unknown param type " + py::str(ele.get_type()).cast<string>());
 			}

--- a/tools/pythonpkg/tests/sqlite/test_types.py
+++ b/tools/pythonpkg/tests/sqlite/test_types.py
@@ -40,10 +40,10 @@ class DuckDBTypeTests(unittest.TestCase):
         self.con.close()
 
     def test_CheckString(self):
-        self.cur.execute("insert into test(s) values (?)", (u"�sterreich",))
+        self.cur.execute("insert into test(s) values (?)", (u"Österreich",))
         self.cur.execute("select s from test")
         row = self.cur.fetchone()
-        self.assertEqual(row[0], u"�sterreich")
+        self.assertEqual(row[0], u"Österreich")
 
     def test_CheckSmallInt(self):
         self.cur.execute("insert into test(i) values (?)", (42,))
@@ -66,9 +66,9 @@ class DuckDBTypeTests(unittest.TestCase):
         self.assertEqual(row[0], val)
 
     def test_CheckUnicodeExecute(self):
-        self.cur.execute("select '�sterreich'")
+        self.cur.execute(u"select 'Österreich'")
         row = self.cur.fetchone()
-        self.assertEqual(row[0], u"�sterreich")
+        self.assertEqual(row[0], u"Österreich")
 
 
 

--- a/tools/pythonpkg/tests/sqlite/test_types.py
+++ b/tools/pythonpkg/tests/sqlite/test_types.py
@@ -165,15 +165,3 @@ class DateTimeTests(unittest.TestCase):
         self.assertEqual(ts.year, ts2.year)
         # this is modified because DuckDB only has millisecond precision
         self.assertEqual(ts2.microsecond, 510000)
-
-def suite():
-    duckdb_type_suite = unittest.makeSuite(DuckDBTypeTests, "Check")
-    date_suite = unittest.makeSuite(DateTimeTests, "Check")
-    cte_suite = unittest.makeSuite(CommonTableExpressionTests, "Check")
-    return unittest.TestSuite((duckdb_type_suite, date_suite, cte_suite))
-
-def test():
-    print("I'm running")
-    runner = unittest.TextTestRunner()
-    runner.run(suite())
-    print("I'm done")

--- a/tools/pythonpkg/tests/sqlite/test_types.py
+++ b/tools/pythonpkg/tests/sqlite/test_types.py
@@ -1,0 +1,179 @@
+#-*- coding: iso-8859-1 -*-
+# pysqlite2/test/types.py: tests for type conversion and detection
+#
+# Copyright (C) 2005 Gerhard H�ring <gh@ghaering.de>
+#
+# This file is part of pyduckdb.
+#
+# This software is provided 'as-is', without any express or implied
+# warranty.  In no event will the authors be held liable for any damages
+# arising from the use of this software.
+#
+# Permission is granted to anyone to use this software for any purpose,
+# including commercial applications, and to alter it and redistribute it
+# freely, subject to the following restrictions:
+#
+# 1. The origin of this software must not be misrepresented; you must not
+#    claim that you wrote the original software. If you use this software
+#    in a product, an acknowledgment in the product documentation would be
+#    appreciated but is not required.
+# 2. Altered source versions must be plainly marked as such, and must not be
+#    misrepresented as being the original software.
+# 3. This notice may not be removed or altered from any source distribution.
+#
+# This library is derived from the pysqlite testing library, with small modifications
+# to remove tests that are for features that are not supported by DuckDB.
+
+import datetime
+import unittest
+import duckdb
+
+
+class DuckDBTypeTests(unittest.TestCase):
+    def setUp(self):
+        self.con = duckdb.connect(":memory:")
+        self.cur = self.con.cursor()
+        self.cur.execute("create table test(i bigint, s varchar, f double)")
+
+    def tearDown(self):
+        self.cur.close()
+        self.con.close()
+
+    def test_CheckString(self):
+        self.cur.execute("insert into test(s) values (?)", ("�sterreich",))
+        self.cur.execute("select s from test")
+        row = self.cur.fetchone()
+        self.assertEqual(row[0], "�sterreich")
+
+    def test_CheckSmallInt(self):
+        self.cur.execute("insert into test(i) values (?)", (42,))
+        self.cur.execute("select i from test")
+        row = self.cur.fetchone()
+        self.assertEqual(row[0], 42)
+
+    def test_CheckLargeInt(self):
+        num = 2**40
+        self.cur.execute("insert into test(i) values (?)", (num,))
+        self.cur.execute("select i from test")
+        row = self.cur.fetchone()
+        self.assertEqual(row[0], num)
+
+    def test_CheckFloat(self):
+        val = 3.14
+        self.cur.execute("insert into test(f) values (?)", (val,))
+        self.cur.execute("select f from test")
+        row = self.cur.fetchone()
+        self.assertEqual(row[0], val)
+
+    def test_CheckUnicodeExecute(self):
+        self.cur.execute("select '�sterreich'")
+        row = self.cur.fetchone()
+        self.assertEqual(row[0], "�sterreich")
+
+
+
+class CommonTableExpressionTests(unittest.TestCase):
+
+    def setUp(self):
+        self.con = duckdb.connect(":memory:")
+        self.cur = self.con.cursor()
+        self.cur.execute("create table test(x int)")
+
+    def tearDown(self):
+        self.cur.close()
+        self.con.close()
+
+    def test_CheckCursorDescriptionCTESimple(self):
+        self.cur.execute("with one as (select 1) select * from one")
+        self.assertIsNotNone(self.cur.description)
+        self.assertEqual(self.cur.description[0][0], "1")
+
+    def test_CheckCursorDescriptionCTESMultipleColumns(self):
+        self.cur.execute("insert into test values(1)")
+        self.cur.execute("insert into test values(2)")
+        self.cur.execute("with testCTE as (select * from test) select * from testCTE")
+        self.assertIsNotNone(self.cur.description)
+        self.assertEqual(self.cur.description[0][0], "x")
+
+    def test_CheckCursorDescriptionCTE(self):
+        self.cur.execute("insert into test values (1)")
+        self.cur.execute("with bar as (select * from test) select * from test where x = 1")
+        self.assertIsNotNone(self.cur.description)
+        self.assertEqual(self.cur.description[0][0], "x")
+        self.cur.execute("with bar as (select * from test) select * from test where x = 2")
+        self.assertIsNotNone(self.cur.description)
+        self.assertEqual(self.cur.description[0][0], "x")
+
+class DateTimeTests(unittest.TestCase):
+    def setUp(self):
+        self.con = duckdb.connect(":memory:")
+        self.cur = self.con.cursor()
+        self.cur.execute("create table test(d date, t time, ts timestamp)")
+
+    def tearDown(self):
+        self.cur.close()
+        self.con.close()
+
+    def test_CheckDate(self):
+        d = datetime.date(2004, 2, 14)
+        self.cur.execute("insert into test(d) values (?)", (d,))
+        self.cur.execute("select d from test")
+        d2 = self.cur.fetchone()[0]
+        self.assertEqual(d, d2)
+
+    def test_CheckTime(self):
+        t = datetime.time(7, 15, 0)
+        self.cur.execute("insert into test(t) values (?)", (t,))
+        self.cur.execute("select t from test")
+        t2 = self.cur.fetchone()[0]
+        self.assertEqual(t, t2)
+
+    def test_CheckTimestamp(self):
+        ts = datetime.datetime(2004, 2, 14, 7, 15, 0)
+        self.cur.execute("insert into test(ts) values (?)", (ts,))
+        self.cur.execute("select ts from test")
+        ts2 = self.cur.fetchone()[0]
+        self.assertEqual(ts, ts2)
+
+    def test_CheckSqlTimestamp(self):
+        now = datetime.datetime.utcnow()
+        self.cur.execute("insert into test(ts) values (current_timestamp)")
+        self.cur.execute("select ts from test")
+        ts = self.cur.fetchone()[0]
+        self.assertEqual(type(ts), datetime.datetime)
+        self.assertEqual(ts.year, now.year)
+
+    def test_CheckDateTimeSubSeconds(self):
+        ts = datetime.datetime(2004, 2, 14, 7, 15, 0, 500000)
+        self.cur.execute("insert into test(ts) values (?)", (ts,))
+        self.cur.execute("select ts from test")
+        ts2 = self.cur.fetchone()[0]
+        self.assertEqual(ts, ts2)
+
+    def test_CheckTimeSubSeconds(self):
+        t = datetime.time(7, 15, 0, 500000)
+        self.cur.execute("insert into test(t) values (?)", (t,))
+        self.cur.execute("select t from test")
+        t2 = self.cur.fetchone()[0]
+        self.assertEqual(t, t2)
+
+    def test_CheckDateTimeSubSecondsFloatingPoint(self):
+        ts = datetime.datetime(2004, 2, 14, 7, 15, 0, 510241)
+        self.cur.execute("insert into test(ts) values (?)", (ts,))
+        self.cur.execute("select ts from test")
+        ts2 = self.cur.fetchone()[0]
+        self.assertEqual(ts.year, ts2.year)
+        # this is modified because DuckDB only has millisecond precision
+        self.assertEqual(ts2.microsecond, 510000)
+
+def suite():
+    duckdb_type_suite = unittest.makeSuite(DuckDBTypeTests, "Check")
+    date_suite = unittest.makeSuite(DateTimeTests, "Check")
+    cte_suite = unittest.makeSuite(CommonTableExpressionTests, "Check")
+    return unittest.TestSuite((duckdb_type_suite, date_suite, cte_suite))
+
+def test():
+    print("I'm running")
+    runner = unittest.TextTestRunner()
+    runner.run(suite())
+    print("I'm done")

--- a/tools/pythonpkg/tests/sqlite/test_types.py
+++ b/tools/pythonpkg/tests/sqlite/test_types.py
@@ -40,10 +40,10 @@ class DuckDBTypeTests(unittest.TestCase):
         self.con.close()
 
     def test_CheckString(self):
-        self.cur.execute("insert into test(s) values (?)", ("�sterreich",))
+        self.cur.execute("insert into test(s) values (?)", (u"�sterreich",))
         self.cur.execute("select s from test")
         row = self.cur.fetchone()
-        self.assertEqual(row[0], "�sterreich")
+        self.assertEqual(row[0], u"�sterreich")
 
     def test_CheckSmallInt(self):
         self.cur.execute("insert into test(i) values (?)", (42,))
@@ -68,7 +68,7 @@ class DuckDBTypeTests(unittest.TestCase):
     def test_CheckUnicodeExecute(self):
         self.cur.execute("select '�sterreich'")
         row = self.cur.fetchone()
-        self.assertEqual(row[0], "�sterreich")
+        self.assertEqual(row[0], u"�sterreich")
 
 
 


### PR DESCRIPTION
...and start porting over tests from the Python sqlite3 module, starting with a pytest-enabled version of https://github.com/python/cpython/blob/master/Lib/sqlite3/test/types.py.

I feel better about this rev; focused only on `datetime` classes (including `datetime.time`) in bindings and it correctly handles micro/millisecond conversions. Let's see how the test run goes.