### PR TITLE
shell: add install rule for CLI binary

### DIFF
--- a/tools/shell/CMakeLists.txt
+++ b/tools/shell/CMakeLists.txt
@@ -19,3 +19,6 @@ endif()
 set_target_properties(shell PROPERTIES OUTPUT_NAME duckdb)
 set_target_properties(shell PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                        ${CMAKE_BINARY_DIR})
+
+install(TARGETS shell
+        RUNTIME DESTINATION "${INSTALL_BIN_DIR}")


### PR DESCRIPTION
This adds an install rule for the CLI binary, so that it's automatically included in distro packages.