### PR TITLE
Fixing "No exported functions in windows dll" issue

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -14,6 +14,14 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifdef _WIN32
+#define DUCKDBAPI __declspec(dllexport)
+#define DUCKDBCALL __cdecl
+#else
+#define DUCKDBAPI
+#define DUCKDBCALL
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -112,69 +120,70 @@ typedef enum { DuckDBSuccess = 0, DuckDBError = 1 } duckdb_state;
 
 //! Opens a database file at the given path (nullptr for in-memory). Returns DuckDBSuccess on success, or DuckDBError on
 //! failure. [OUT: database]
-duckdb_state duckdb_open(const char *path, duckdb_database *out_database);
+DUCKDBAPI duckdb_state duckdb_open(const char *path, duckdb_database *out_database);
 //! Closes the database.
-void duckdb_close(duckdb_database *database);
+DUCKDBAPI void duckdb_close(duckdb_database *database);
 
 //! Creates a connection to the specified database. [OUT: connection]
-duckdb_state duckdb_connect(duckdb_database database, duckdb_connection *out_connection);
+DUCKDBAPI duckdb_state duckdb_connect(duckdb_database database, duckdb_connection *out_connection);
 //! Closes the specified connection handle
-void duckdb_disconnect(duckdb_connection *connection);
+DUCKDBAPI void duckdb_disconnect(duckdb_connection *connection);
 
 //! Executes the specified SQL query in the specified connection handle. [OUT: result descriptor]
-duckdb_state duckdb_query(duckdb_connection connection, const char *query, duckdb_result *out_result);
+DUCKDBAPI duckdb_state duckdb_query(duckdb_connection connection, const char *query, duckdb_result *out_result);
 //! Destroys the specified result
-void duckdb_destroy_result(duckdb_result *result);
+DUCKDBAPI void duckdb_destroy_result(duckdb_result *result);
 
 //! Returns the column name of the specified column. The result does not need to be freed;
 //! the column names will automatically be destroyed when the result is destroyed.
-const char *duckdb_column_name(duckdb_result *result, idx_t col);
+DUCKDBAPI const char *duckdb_column_name(duckdb_result *result, idx_t col);
 
 // SAFE fetch functions
 // These functions will perform conversions if necessary. On failure (e.g. if conversion cannot be performed) a special
 // value is returned.
 
 //! Converts the specified value to a bool. Returns false on failure or NULL.
-bool duckdb_value_boolean(duckdb_result *result, idx_t col, idx_t row);
+DUCKDBAPI bool duckdb_value_boolean(duckdb_result *result, idx_t col, idx_t row);
 //! Converts the specified value to an int8_t. Returns 0 on failure or NULL.
-int8_t duckdb_value_int8(duckdb_result *result, idx_t col, idx_t row);
+DUCKDBAPI int8_t duckdb_value_int8(duckdb_result *result, idx_t col, idx_t row);
 //! Converts the specified value to an int16_t. Returns 0 on failure or NULL.
-int16_t duckdb_value_int16(duckdb_result *result, idx_t col, idx_t row);
+DUCKDBAPI int16_t duckdb_value_int16(duckdb_result *result, idx_t col, idx_t row);
 //! Converts the specified value to an int64_t. Returns 0 on failure or NULL.
-int32_t duckdb_value_int32(duckdb_result *result, idx_t col, idx_t row);
+DUCKDBAPI int32_t duckdb_value_int32(duckdb_result *result, idx_t col, idx_t row);
 //! Converts the specified value to an int64_t. Returns 0 on failure or NULL.
-int64_t duckdb_value_int64(duckdb_result *result, idx_t col, idx_t row);
+DUCKDBAPI int64_t duckdb_value_int64(duckdb_result *result, idx_t col, idx_t row);
 //! Converts the specified value to a float. Returns 0.0 on failure or NULL.
-float duckdb_value_float(duckdb_result *result, idx_t col, idx_t row);
+DUCKDBAPI float duckdb_value_float(duckdb_result *result, idx_t col, idx_t row);
 //! Converts the specified value to a double. Returns 0.0 on failure or NULL.
-double duckdb_value_double(duckdb_result *result, idx_t col, idx_t row);
+DUCKDBAPI double duckdb_value_double(duckdb_result *result, idx_t col, idx_t row);
 //! Converts the specified value to a string. Returns nullptr on failure or NULL. The result must be freed with free.
-char *duckdb_value_varchar(duckdb_result *result, idx_t col, idx_t row);
+DUCKDBAPI char *duckdb_value_varchar(duckdb_result *result, idx_t col, idx_t row);
 
 // Prepared Statements
 
 //! prepares the specified SQL query in the specified connection handle. [OUT: prepared statement descriptor]
-duckdb_state duckdb_prepare(duckdb_connection connection, const char *query,
-                            duckdb_prepared_statement *out_prepared_statement);
+DUCKDBAPI duckdb_state duckdb_prepare(duckdb_connection connection, const char *query,
+                                      duckdb_prepared_statement *out_prepared_statement);
 
-duckdb_state duckdb_nparams(duckdb_prepared_statement prepared_statement, idx_t *nparams_out);
+DUCKDBAPI duckdb_state duckdb_nparams(duckdb_prepared_statement prepared_statement, idx_t *nparams_out);
 
 //! binds parameters to prepared statement
-duckdb_state duckdb_bind_boolean(duckdb_prepared_statement prepared_statement, idx_t param_idx, bool val);
-duckdb_state duckdb_bind_int8(duckdb_prepared_statement prepared_statement, idx_t param_idx, int8_t val);
-duckdb_state duckdb_bind_int16(duckdb_prepared_statement prepared_statement, idx_t param_idx, int16_t val);
-duckdb_state duckdb_bind_int32(duckdb_prepared_statement prepared_statement, idx_t param_idx, int32_t val);
-duckdb_state duckdb_bind_int64(duckdb_prepared_statement prepared_statement, idx_t param_idx, int64_t val);
-duckdb_state duckdb_bind_float(duckdb_prepared_statement prepared_statement, idx_t param_idx, float val);
-duckdb_state duckdb_bind_double(duckdb_prepared_statement prepared_statement, idx_t param_idx, double val);
-duckdb_state duckdb_bind_varchar(duckdb_prepared_statement prepared_statement, idx_t param_idx, const char *val);
-duckdb_state duckdb_bind_null(duckdb_prepared_statement prepared_statement, idx_t param_idx);
+DUCKDBAPI duckdb_state duckdb_bind_boolean(duckdb_prepared_statement prepared_statement, idx_t param_idx, bool val);
+DUCKDBAPI duckdb_state duckdb_bind_int8(duckdb_prepared_statement prepared_statement, idx_t param_idx, int8_t val);
+DUCKDBAPI duckdb_state duckdb_bind_int16(duckdb_prepared_statement prepared_statement, idx_t param_idx, int16_t val);
+DUCKDBAPI duckdb_state duckdb_bind_int32(duckdb_prepared_statement prepared_statement, idx_t param_idx, int32_t val);
+DUCKDBAPI duckdb_state duckdb_bind_int64(duckdb_prepared_statement prepared_statement, idx_t param_idx, int64_t val);
+DUCKDBAPI duckdb_state duckdb_bind_float(duckdb_prepared_statement prepared_statement, idx_t param_idx, float val);
+DUCKDBAPI duckdb_state duckdb_bind_double(duckdb_prepared_statement prepared_statement, idx_t param_idx, double val);
+DUCKDBAPI duckdb_state duckdb_bind_varchar(duckdb_prepared_statement prepared_statement, idx_t param_idx,
+                                           const char *val);
+DUCKDBAPI duckdb_state duckdb_bind_null(duckdb_prepared_statement prepared_statement, idx_t param_idx);
 
 //! Executes the prepared statements with currently bound parameters
-duckdb_state duckdb_execute_prepared(duckdb_prepared_statement prepared_statement, duckdb_result *out_result);
+DUCKDBAPI duckdb_state duckdb_execute_prepared(duckdb_prepared_statement prepared_statement, duckdb_result *out_result);
 
 //! Destroys the specified prepared statement descriptor
-void duckdb_destroy_prepare(duckdb_prepared_statement *prepared_statement);
+DUCKDBAPI void duckdb_destroy_prepare(duckdb_prepared_statement *prepared_statement);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Patch is related to issue https://github.com/cwida/duckdb/issues/934
This patch only exposes the C API of duckdb via DLL