### PR TITLE
SQLite: Avoid parsing queries twice

### DIFF
--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -108,7 +108,7 @@ public:
 	//! Prepare a query
 	unique_ptr<PreparedStatement> Prepare(string query);
 
-	unique_ptr<PreparedStatement> PrepareParsedStatement(vector<unique_ptr<SQLStatement>> *statements,
+	unique_ptr<PreparedStatement> PrepareParsedStatement(vector<unique_ptr<SQLStatement>> &statements,
                                                          idx_t parsed_parameters);
 
 	//! Execute a prepared statement with the given name and set of parameters

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -107,6 +107,10 @@ public:
 
 	//! Prepare a query
 	unique_ptr<PreparedStatement> Prepare(string query);
+
+	unique_ptr<PreparedStatement> PrepareParsedStatement(vector<unique_ptr<SQLStatement>> *statements,
+                                                         idx_t parsed_parameters);
+
 	//! Execute a prepared statement with the given name and set of parameters
 	unique_ptr<QueryResult> Execute(string name, vector<Value> &values, bool allow_stream_result = true,
 	                                string query = string());

--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -73,7 +73,7 @@ public:
 
 	//! Prepare the specified query, returning a prepared statement object
 	unique_ptr<PreparedStatement> Prepare(string query);
-    unique_ptr<PreparedStatement> PrepareStatements(vector<unique_ptr<SQLStatement>> *statements,
+    unique_ptr<PreparedStatement> PrepareStatements(vector<unique_ptr<SQLStatement>> &statements,
 	                                                idx_t n_prepared_parameters);
 
 	//! Get the table info of a specific table (in the default schema), or nullptr if it cannot be found

--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -73,6 +73,8 @@ public:
 
 	//! Prepare the specified query, returning a prepared statement object
 	unique_ptr<PreparedStatement> Prepare(string query);
+    unique_ptr<PreparedStatement> PrepareStatements(vector<unique_ptr<SQLStatement>> *statements,
+	                                                idx_t n_prepared_parameters);
 
 	//! Get the table info of a specific table (in the default schema), or nullptr if it cannot be found
 	unique_ptr<TableDescription> TableInfo(string table_name);
@@ -80,7 +82,8 @@ public:
 	unique_ptr<TableDescription> TableInfo(string schema_name, string table_name);
 
 	//! Extract a set of SQL statements from a specific query
-	vector<unique_ptr<SQLStatement>> ExtractStatements(string query);
+	vector<unique_ptr<SQLStatement>> ExtractStatements(string query,
+                                                       idx_t *n_prepared_statements = nullptr) const;
 
 	//! Appends a DataChunk to the specified table
 	void Append(TableDescription &description, DataChunk &chunk);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -277,14 +277,14 @@ unique_ptr<PreparedStatement> ClientContext::Prepare(string query) {
         if (statements.empty()) {
             throw Exception("No statement to prepare!");
         }
-        return this->PrepareParsedStatement(&statements, n_prepared_parameters);
+        return this->PrepareParsedStatement(statements, n_prepared_parameters);
 	} catch (Exception &ex) {
 		return make_unique<PreparedStatement>(ex.what());
 	}
 }
-unique_ptr<PreparedStatement> ClientContext::PrepareParsedStatement(vector<unique_ptr<SQLStatement>> *statements,
+unique_ptr<PreparedStatement> ClientContext::PrepareParsedStatement(vector<unique_ptr<SQLStatement>> &statements,
                                                                     idx_t n_prepared_parameters) {
-    if (statements->size() > 1) {
+    if (statements.size() > 1) {
         throw Exception("Cannot prepare multiple statements at once!");
     }
     // now write the prepared statement data into the catalog
@@ -293,7 +293,7 @@ unique_ptr<PreparedStatement> ClientContext::PrepareParsedStatement(vector<uniqu
     // create a prepare statement out of the underlying statement
     auto prepare = make_unique<PrepareStatement>();
     prepare->name = prepare_name;
-    prepare->statement = move(statements->front());
+    prepare->statement = move(statements[0]);
 
     // now perform the actual PREPARE query
     auto result = RunStatement(query, move(prepare), false);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -277,6 +277,9 @@ unique_ptr<PreparedStatement> ClientContext::Prepare(string query) {
         if (statements.empty()) {
             throw Exception("No statement to prepare!");
         }
+        if (statements.size() > 1) {
+            throw Exception("Cannot prepare multiple statements at once!");
+        }
         return this->PrepareParsedStatement(statements, n_prepared_parameters);
 	} catch (Exception &ex) {
 		return make_unique<PreparedStatement>(ex.what());
@@ -284,9 +287,6 @@ unique_ptr<PreparedStatement> ClientContext::Prepare(string query) {
 }
 unique_ptr<PreparedStatement> ClientContext::PrepareParsedStatement(vector<unique_ptr<SQLStatement>> &statements,
                                                                     idx_t n_prepared_parameters) {
-    if (statements.size() > 1) {
-        throw Exception("Cannot prepare multiple statements at once!");
-    }
     // now write the prepared statement data into the catalog
     string prepare_name = "____duckdb_internal_prepare_" + to_string(prepare_count);
     prepare_count++;

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -78,6 +78,11 @@ unique_ptr<PreparedStatement> Connection::Prepare(string query) {
 	return context->Prepare(query);
 }
 
+unique_ptr<PreparedStatement> Connection::PrepareStatements(vector<unique_ptr<SQLStatement>> *statements,
+                                                            idx_t n_prepared_parameters) {
+	return context->PrepareParsedStatement(statements, n_prepared_parameters);
+}
+
 unique_ptr<QueryResult> Connection::QueryParamsRecursive(string query, vector<Value> &values) {
 	auto statement = Prepare(query);
 	if (!statement->success) {
@@ -94,8 +99,9 @@ unique_ptr<TableDescription> Connection::TableInfo(string schema_name, string ta
 	return context->TableInfo(schema_name, table_name);
 }
 
-vector<unique_ptr<SQLStatement>> Connection::ExtractStatements(string query) {
-	return context->ParseStatements(query);
+vector<unique_ptr<SQLStatement>> Connection::ExtractStatements(string query,
+                                                               idx_t *n_prepared_statements) const {
+	return context->ParseStatements(query, n_prepared_statements);
 }
 
 void Connection::Append(TableDescription &description, DataChunk &chunk) {

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -78,7 +78,7 @@ unique_ptr<PreparedStatement> Connection::Prepare(string query) {
 	return context->Prepare(query);
 }
 
-unique_ptr<PreparedStatement> Connection::PrepareStatements(vector<unique_ptr<SQLStatement>> *statements,
+unique_ptr<PreparedStatement> Connection::PrepareStatements(vector<unique_ptr<SQLStatement>> &statements,
                                                             idx_t n_prepared_parameters) {
 	return context->PrepareParsedStatement(statements, n_prepared_parameters);
 }

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -132,8 +132,9 @@ int sqlite3_prepare_v2(sqlite3 *db,           /* Database handle */
 
 	try {
 		// extract the statements from the SQL query
-		auto statements = db->con->ExtractStatements(query);
-		if (statements.size() == 0) {
+        idx_t n_prepared_parameters;
+		auto statements = db->con->ExtractStatements(query, &n_prepared_parameters);
+		if (statements.empty()) {
 			// no statements to prepare!
 			return SQLITE_OK;
 		}
@@ -145,7 +146,7 @@ int sqlite3_prepare_v2(sqlite3 *db,           /* Database handle */
 		query = query.substr(statement->stmt_location, statement->stmt_length);
 
 		// now prepare the query
-		auto prepared = db->con->Prepare(query);
+		auto prepared = db->con->PrepareStatements(&statements, n_prepared_parameters);
 		if (!prepared->success) {
 			// failed to prepare: set the error message
 			db->last_error = prepared->error;

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -146,7 +146,7 @@ int sqlite3_prepare_v2(sqlite3 *db,           /* Database handle */
 		query = query.substr(statement->stmt_location, statement->stmt_length);
 
 		// now prepare the query
-		auto prepared = db->con->PrepareStatements(&statements, n_prepared_parameters);
+		auto prepared = db->con->PrepareStatements(statements, n_prepared_parameters);
 		if (!prepared->success) {
 			// failed to prepare: set the error message
 			db->last_error = prepared->error;


### PR DESCRIPTION
Introduce and APIs that allows the SQLite3 wrapper to parse queries
into statements and then prepare them without reparsing.

Also includes minor cleanups: vector.empty.

Fixes #946

