### PR TITLE
Support dates and times output into arrow

### DIFF
--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/serializer.hpp"
 #include "duckdb/common/types/null_value.hpp"
+#include "duckdb/common/types/date.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/types/sel_cache.hpp"
@@ -268,7 +269,7 @@ void DataChunk::ToArrowArray(ArrowArray *out_array) {
 				child.buffers[1] = (void *)FlatVector::GetData(vector);
 				auto target_ptr = (uint32_t *)child.buffers[1];
 				for (idx_t row_idx = 0; row_idx < size(); row_idx++) {
-					target_ptr[row_idx] -= 719528; //EPOCH_DATE;
+					target_ptr[row_idx] = Date::EpochDays(target_ptr[row_idx]);
 				}
 				break;
 			}

--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -263,6 +263,16 @@ void DataChunk::ToArrowArray(ArrowArray *out_array) {
 				child.buffers[1] = (void *)FlatVector::GetData(vector);
 				break;
 
+			case LogicalTypeId::DATE: {
+				child.n_buffers = 2;
+				child.buffers[1] = (void *)FlatVector::GetData(vector);
+				auto target_ptr = (uint32_t *)child.buffers[1];
+				for (idx_t row_idx = 0; row_idx < size(); row_idx++) {
+					target_ptr[row_idx] -= 719528; //EPOCH_DATE;
+				}
+				break;
+			}
+
 			case LogicalTypeId::VARCHAR: {
 				child.n_buffers = 3;
 				holder->string_offsets = unique_ptr<data_t[]>(new data_t[sizeof(uint32_t) * (size() + 1)]);

--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -260,6 +260,7 @@ void DataChunk::ToArrowArray(ArrowArray *out_array) {
 			case LogicalTypeId::FLOAT:
 			case LogicalTypeId::DOUBLE:
 			case LogicalTypeId::HUGEINT:
+			case LogicalTypeId::TIME:
 				child.n_buffers = 2;
 				child.buffers[1] = (void *)FlatVector::GetData(vector);
 				break;

--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/serializer.hpp"
 #include "duckdb/common/types/null_value.hpp"
 #include "duckdb/common/types/date.hpp"
+#include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/types/sel_cache.hpp"
@@ -271,6 +272,16 @@ void DataChunk::ToArrowArray(ArrowArray *out_array) {
 				auto target_ptr = (uint32_t *)child.buffers[1];
 				for (idx_t row_idx = 0; row_idx < size(); row_idx++) {
 					target_ptr[row_idx] = Date::EpochDays(target_ptr[row_idx]);
+				}
+				break;
+			}
+
+			case LogicalTypeId::TIMESTAMP: {
+				child.n_buffers = 2;
+				child.buffers[1] = (void *)FlatVector::GetData(vector);
+				auto target_ptr = (uint64_t *)child.buffers[1];
+				for (idx_t row_idx = 0; row_idx < size(); row_idx++) {
+					target_ptr[row_idx] = Timestamp::GetEpoch(target_ptr[row_idx]) * 1e9;
 				}
 				break;
 			}

--- a/src/common/types/date.cpp
+++ b/src/common/types/date.cpp
@@ -242,6 +242,15 @@ bool Date::IsValidDay(int32_t year, int32_t month, int32_t day) {
 	return IsLeapYear(year) ? day <= LEAPDAYS[month] : day <= NORMALDAYS[month];
 }
 
+date_t Date::EpochDaysToDate(int32_t epoch) {
+	assert(epoch + EPOCH_DATE <= NumericLimits<int32_t>::Maximum());
+	return (date_t)(epoch + EPOCH_DATE);
+}
+
+int32_t Date::EpochDays(date_t date) {
+	return ((int32_t)date - EPOCH_DATE);
+}
+
 date_t Date::EpochToDate(int64_t epoch) {
 	assert((epoch / SECONDS_PER_DAY) + EPOCH_DATE <= NumericLimits<int32_t>::Maximum());
 	return (date_t)((epoch / SECONDS_PER_DAY) + EPOCH_DATE);

--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -255,7 +255,7 @@ static void arrow_scan_function(ClientContext &context, const FunctionData *bind
 
 			for (idx_t row = 0; row < output.size(); row++) {
 				auto source_idx = data.chunk_offset + row;
-				tgt_ptr[row] = src_ptr[source_idx] - 719528; //EPOCH_DATE
+				tgt_ptr[row] = Date::EpochDaysToDate(src_ptr[source_idx]);
 			}
 			break;
 		}

--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -110,6 +110,8 @@ static unique_ptr<FunctionData> arrow_scan_bind(ClientContext &context, vector<V
 			return_types.push_back(LogicalType::TIMESTAMP);
 		} else if (format == "tdD") {
 			return_types.push_back(LogicalType::DATE);
+		} else if (format == "ttm") {
+			return_types.push_back(LogicalType::TIME);
 		} else {
 			throw NotImplementedException("Unsupported Arrow type %s", format);
 		}
@@ -208,6 +210,7 @@ static void arrow_scan_function(ClientContext &context, const FunctionData *bind
 		case LogicalTypeId::DOUBLE:
 		case LogicalTypeId::BIGINT:
 		case LogicalTypeId::HUGEINT:
+		case LogicalTypeId::TIME:
 			FlatVector::SetData(output.data[col_idx],
 			                    (data_ptr_t)array.buffers[1] + GetTypeIdSize(output.data[col_idx].type.InternalType()) *
 			                                                       (data.chunk_offset + array.offset));

--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -108,6 +108,8 @@ static unique_ptr<FunctionData> arrow_scan_bind(ClientContext &context, vector<V
 			return_types.push_back(LogicalType::VARCHAR);
 		} else if (format == "tsn:") {
 			return_types.push_back(LogicalType::TIMESTAMP);
+		} else if (format == "tdD") {
+			return_types.push_back(LogicalType::DATE);
 		} else {
 			throw NotImplementedException("Unsupported Arrow type %s", format);
 		}
@@ -244,6 +246,16 @@ static void arrow_scan_function(ClientContext &context, const FunctionData *bind
 				date_t date = Date::EpochToDate(ms / 1000);
 				dtime_t time = (dtime_t)(ms % ms_per_day);
 				tgt_ptr[row] = Timestamp::FromDatetime(date, time);
+			}
+			break;
+		}
+		case LogicalTypeId::DATE: {
+			auto src_ptr = (int32_t *)array.buffers[1] + data.chunk_offset;
+			auto tgt_ptr = (date_t *)FlatVector::GetData(output.data[col_idx]);
+
+			for (idx_t row = 0; row < output.size(); row++) {
+				auto source_idx = data.chunk_offset + row;
+				tgt_ptr[row] = src_ptr[source_idx] - 719528; //EPOCH_DATE
 			}
 			break;
 		}

--- a/src/include/duckdb/common/types/date.hpp
+++ b/src/include/duckdb/common/types/date.hpp
@@ -52,6 +52,12 @@ public:
 	static int64_t Epoch(date_t date);
 	//! Convert the epoch (seconds since 1970-01-01) to a date_t
 	static date_t EpochToDate(int64_t epoch);
+
+	//! Extract the number of days since epoch (days since 1970-01-01)
+	static int32_t EpochDays(date_t date);
+	//! Convert the epoch number of days to a date_t
+	static date_t EpochDaysToDate(int32_t epoch);
+
 	//! Extract year of a date entry
 	static int32_t ExtractYear(date_t date);
 	//! Extract month of a date entry

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -157,6 +157,9 @@ void QueryResult::ToArrowSchema(ArrowSchema *out_schema) {
 		case LogicalTypeId::TIME:
 			child.format = "ttm";
 			break;
+		case LogicalTypeId::TIMESTAMP:
+			child.format = "tsn:";
+			break;
 		default:
 			throw NotImplementedException("Unsupported Arrow type " + types[col_idx].ToString());
 		}

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -151,6 +151,9 @@ void QueryResult::ToArrowSchema(ArrowSchema *out_schema) {
 		case LogicalTypeId::VARCHAR:
 			child.format = "u";
 			break;
+		case LogicalTypeId::DATE:
+			child.format = "tdD";
+			break;
 		default:
 			throw NotImplementedException("Unsupported Arrow type " + types[col_idx].ToString());
 		}

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -154,6 +154,9 @@ void QueryResult::ToArrowSchema(ArrowSchema *out_schema) {
 		case LogicalTypeId::DATE:
 			child.format = "tdD";
 			break;
+		case LogicalTypeId::TIME:
+			child.format = "ttm";
+			break;
 		default:
 			throw NotImplementedException("Unsupported Arrow type " + types[col_idx].ToString());
 		}

--- a/test/api/test_arrow.cpp
+++ b/test/api/test_arrow.cpp
@@ -70,7 +70,7 @@ TEST_CASE("Test Arrow API round trip", "[arrow]") {
 	    "select NULL c_null, (c % 4 = 0)::bool c_bool, (c%128)::tinyint c_tinyint, c::smallint*1000 c_smallint, "
 	    "c::integer*100000 c_integer, c::bigint*1000000000000 c_bigint, c::hugeint*10000000000000000000000000000000 "
 	    "c_hugeint, c::float c_float, c::double c_double, 'c_' || c::string c_string, current_date::date c_date, "
-	    "'1969-01-01'::date from (select case when range % 2 == 0 then range else null end as c from range(-10000, 10000)) sq";
+	    "'1969-01-01'::date, current_time::time c_time from (select case when range % 2 == 0 then range else null end as c from range(-10000, 10000)) sq";
 
 	// query that creates a bunch of values across the types
 	auto result = con.Query(q);

--- a/test/api/test_arrow.cpp
+++ b/test/api/test_arrow.cpp
@@ -70,7 +70,8 @@ TEST_CASE("Test Arrow API round trip", "[arrow]") {
 	    "select NULL c_null, (c % 4 = 0)::bool c_bool, (c%128)::tinyint c_tinyint, c::smallint*1000 c_smallint, "
 	    "c::integer*100000 c_integer, c::bigint*1000000000000 c_bigint, c::hugeint*10000000000000000000000000000000 "
 	    "c_hugeint, c::float c_float, c::double c_double, 'c_' || c::string c_string, current_date::date c_date, "
-	    "'1969-01-01'::date, current_time::time c_time from (select case when range % 2 == 0 then range else null end as c from range(-10000, 10000)) sq";
+	    "'1969-01-01'::date, current_time::time c_time, now()::timestamp c_timestamp "
+	    "from (select case when range % 2 == 0 then range else null end as c from range(-10000, 10000)) sq";
 
 	// query that creates a bunch of values across the types
 	auto result = con.Query(q);

--- a/test/api/test_arrow.cpp
+++ b/test/api/test_arrow.cpp
@@ -69,8 +69,8 @@ TEST_CASE("Test Arrow API round trip", "[arrow]") {
 	auto q =
 	    "select NULL c_null, (c % 4 = 0)::bool c_bool, (c%128)::tinyint c_tinyint, c::smallint*1000 c_smallint, "
 	    "c::integer*100000 c_integer, c::bigint*1000000000000 c_bigint, c::hugeint*10000000000000000000000000000000 "
-	    "c_hugeint, c::float c_float, c::double c_double, 'c_' || c::string c_string from (select case when range % 2 "
-	    "== 0 then range else null end as c from range(-10000, 10000)) sq";
+	    "c_hugeint, c::float c_float, c::double c_double, 'c_' || c::string c_string, current_date::date c_date, "
+	    "'1969-01-01'::date from (select case when range % 2 == 0 then range else null end as c from range(-10000, 10000)) sq";
 
 	// query that creates a bunch of values across the types
 	auto result = con.Query(q);


### PR DESCRIPTION
The underlying duckdb representation for LogicalTypeId::DATE is almost identical to Arrow's int32 date format, except the reference date is different (Arrow uses the UNIX epoch as the start date). Duckdb's time format matches arrow's int32 millisecond representation.