### PR TITLE
Fix for buffer overflow in ART (#956)

### DIFF
--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -507,6 +507,13 @@ bool ART::IteratorScan(ARTIndexScanState *state, Iterator *it, Key *bound, idx_t
 	return true;
 }
 
+void Iterator::SetEntry(idx_t entry_depth, IteratorEntry entry) {
+	if (stack.size() < entry_depth + 1) {
+		stack.resize(MaxValue<idx_t>(8, MaxValue<idx_t>(entry_depth + 1, stack.size() * 2)));
+	}
+	stack[entry_depth] = entry;
+}
+
 bool ART::IteratorNext(Iterator &it) {
 	// Skip leaf
 	if ((it.depth) && ((it.stack[it.depth - 1].node)->type == NodeType::NLeaf)) {
@@ -528,8 +535,7 @@ bool ART::IteratorNext(Iterator &it) {
 		top.pos = node->GetNextPos(top.pos);
 		if (top.pos != INVALID_INDEX) {
 			// next node found: go there
-			it.stack[it.depth].node = node->GetChild(top.pos)->get();
-			it.stack[it.depth].pos = INVALID_INDEX;
+			it.SetEntry(it.depth, IteratorEntry(node->GetChild(top.pos)->get(), INVALID_INDEX));
 			it.depth++;
 		} else {
 			// no node found: move up the tree
@@ -678,8 +684,7 @@ static Leaf &FindMinimum(Iterator &it, Node &node) {
 		break;
 	}
 	}
-	it.stack[it.depth].node = &node;
-	it.stack[it.depth].pos = pos;
+	it.SetEntry(it.depth, IteratorEntry(&node, pos));
 	it.depth++;
 	return FindMinimum(it, *next);
 }

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -560,8 +560,8 @@ bool ART::Bound(unique_ptr<Node> &n, Key &key, Iterator &it, bool inclusive) {
 
 	idx_t depth = 0;
 	while (true) {
+		it.SetEntry(it.depth, IteratorEntry(node, 0));
 		auto &top = it.stack[it.depth];
-		top.node = node;
 		it.depth++;
 		if (!equal) {
 			while (node->type != NodeType::NLeaf) {

--- a/src/include/duckdb/execution/index/art/art.hpp
+++ b/src/include/duckdb/execution/index/art/art.hpp
@@ -25,6 +25,9 @@
 
 namespace duckdb {
 struct IteratorEntry {
+	IteratorEntry(){}
+	IteratorEntry(Node *node, idx_t pos) : node(node), pos(pos) {}
+
 	Node *node = nullptr;
 	idx_t pos = 0;
 };
@@ -34,10 +37,12 @@ struct Iterator {
 	Leaf *node = nullptr;
 	//! The current depth
 	int32_t depth = 0;
-	//! Stack, actually the size is determined at runtime
-	IteratorEntry stack[9];
+	//! Stack, the size is determined at runtime
+	vector<IteratorEntry> stack;
 
 	bool start = false;
+
+	void SetEntry(idx_t depth, IteratorEntry entry);
 };
 
 struct ARTIndexScanState : public IndexScanState {

--- a/test/issues/rigger/test_956.test
+++ b/test/issues/rigger/test_956.test
@@ -1,0 +1,13 @@
+# name: test/issues/rigger/test_956.test
+# description: Issue 956
+# group: [rigger]
+
+# Buffer overflow in duckdb::ART::IteratorNext
+statement ok
+CREATE TABLE t0(c0 VARCHAR UNIQUE);
+
+statement ok
+INSERT INTO t0 VALUES('19691214 051350'), (1), ('19700118'), (0), ('1969-1214 102704'), ('1969-12-14'), ('1969-12-14 114142'), ('1969-12-30 040325'), ('1969-12-18 044750'), ('1969-12-14 100915');
+
+statement ok
+SELECT * FROM t0 WHERE '19691' > c0;


### PR DESCRIPTION
The problem was related to lookups in a string ART; previously the iterator was hard-coded to a depth of 8 entries. This is sufficient for all numeric types (<= 8 bytes), but not for longer strings.