### PR TITLE
Support bindings that use python's decimal type

### DIFF
--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -953,6 +953,8 @@ struct DuckDBPyConnection {
 		auto datetime_date = datetime_mod.attr("date");
 		auto datetime_datetime = datetime_mod.attr("datetime");
 		auto datetime_time = datetime_mod.attr("time");
+		auto decimal_mod = py::module::import("decimal");
+		auto decimal_decimal = decimal_mod.attr("Decimal");
 
 		for (auto &ele : params) {
 			if (ele.is_none()) {
@@ -964,6 +966,8 @@ struct DuckDBPyConnection {
 			} else if (py::isinstance<py::float_>(ele)) {
 				args.push_back(Value::DOUBLE(ele.cast<double>()));
 			} else if (py::isinstance<py::str>(ele)) {
+				args.push_back(Value(ele.cast<string>()));
+			} else if (py::isinstance(ele, decimal_decimal)) {
 				args.push_back(Value(ele.cast<string>()));
 			} else if (py::isinstance(ele, datetime_datetime)) {
 				auto year = PyDateTime_GET_YEAR(ele.ptr());

--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -968,7 +968,7 @@ struct DuckDBPyConnection {
 			} else if (py::isinstance<py::str>(ele)) {
 				args.push_back(Value(ele.cast<string>()));
 			} else if (py::isinstance(ele, decimal_decimal)) {
-				args.push_back(Value(ele.cast<string>()));
+				args.push_back(Value(py::str(ele).cast<string>()));
 			} else if (py::isinstance(ele, datetime_datetime)) {
 				auto year = PyDateTime_GET_YEAR(ele.ptr());
 				auto month = PyDateTime_GET_MONTH(ele.ptr());

--- a/tools/pythonpkg/tests/sqlite/test_types.py
+++ b/tools/pythonpkg/tests/sqlite/test_types.py
@@ -25,6 +25,7 @@
 # to remove tests that are for features that are not supported by DuckDB.
 
 import datetime
+import decimal
 import unittest
 import duckdb
 
@@ -65,6 +66,13 @@ class DuckDBTypeTests(unittest.TestCase):
         row = self.cur.fetchone()
         self.assertEqual(row[0], val)
 
+    def test_CheckDecimal(self):
+        val = 17.29
+        self.cur.execute("insert into test(f) values (?)", (decimal.Decimal(val),))
+        self.cur.execute("select f from test")
+        row = self.cur.fetchone()
+        self.assertEqual(row[0], val)
+ 
     def test_CheckUnicodeExecute(self):
         self.cur.execute(u"select 'Österreich'")
         row = self.cur.fetchone()

--- a/tools/pythonpkg/tests/sqlite/test_types.py
+++ b/tools/pythonpkg/tests/sqlite/test_types.py
@@ -72,6 +72,15 @@ class DuckDBTypeTests(unittest.TestCase):
         self.cur.execute("select f from test")
         row = self.cur.fetchone()
         self.assertEqual(row[0], val)
+
+    def test_CheckNaN(self):
+        with self.assertRaises(RuntimeError) as context:
+            self.cur.execute("insert into test(f) values (?)", (decimal.Decimal('nan'),))
+
+    def test_CheckInf(self):
+        with self.assertRaises(RuntimeError) as context:
+            self.cur.execute("insert into test(f) values (?)", (decimal.Decimal('inf'),))
+
  
     def test_CheckUnicodeExecute(self):
         self.cur.execute(u"select 'Österreich'")


### PR DESCRIPTION
Another one from my dbt integration work (which is currently [here](https://github.com/jwills/dbt-duckdb) if you all are interested): I need to be able to map Python's `decimal.Decimal` type for binding values; I followed the methodology used by the [psycopg2 adapter](https://github.com/psycopg/psycopg2/blob/master/psycopg/adapter_pdecimal.c) but was wondering what I should do for the case where the Decimal value is `Inf` or `NaN`? Thanks!