### PR TITLE
Handle filters transitivity for non-scalar expressions

### DIFF
--- a/src/include/duckdb/optimizer/filter_combiner.hpp
+++ b/src/include/duckdb/optimizer/filter_combiner.hpp
@@ -41,6 +41,7 @@ public:
 
 private:
 	FilterResult AddFilter(Expression *expr);
+	FilterResult AddTransitiveFilters(BoundComparisonExpression &comparison);
 
 	Expression *GetNode(Expression *expr);
 	idx_t GetEquivalenceSet(Expression *expr);

--- a/test/sql/filter/test_transitive_filters.test
+++ b/test/sql/filter/test_transitive_filters.test
@@ -1,0 +1,139 @@
+# name: test/sql/filter/test_transitive_filters.test
+# description: Test expressions with transitive filters
+# group: [filter]
+
+statement ok
+PRAGMA enable_verification
+
+# Test various transitive filters with simple constant comparisons followed by non-scalar comparisons
+# The main point here is to check that the optimizer handles all these cases correctly
+
+# Inserting i, j = i
+statement ok
+CREATE TABLE vals1 AS SELECT i AS i, i AS j FROM range(0, 11, 1) t1(i)
+
+# Inserting i, j = i+1
+statement ok
+INSERT INTO vals1 SELECT i, i+1 FROM vals1
+
+# Inserting i, j = i-1
+statement ok
+INSERT INTO vals1 SELECT DISTINCT(i), i-1 FROM vals1 ORDER by i
+
+### constant comparison [=, >, >=, <, <=] followed by j >= i #########################
+
+query II
+SELECT * FROM vals1 WHERE i=5 AND j>=i
+----
+5	5   
+5	6
+
+query II
+SELECT * FROM vals1 WHERE i>9 AND j>=i
+----
+10	10   
+10	11
+
+query II
+SELECT * FROM vals1 WHERE i>=10 AND j>=i
+----
+10	10   
+10	11
+
+query II
+SELECT * FROM vals1 WHERE i<1 AND j>=i
+----
+0	0   
+0	1
+
+query II
+SELECT * FROM vals1 WHERE i<=0 AND j>=i
+----
+0	0   
+0	1
+
+### constant comparison [=, >, >=, <, <=] followed by j <= i #########################
+
+query II
+SELECT * FROM vals1 WHERE i=5 AND j<=i
+----
+5	5   
+5	4
+
+query II
+SELECT * FROM vals1 WHERE i>9 AND j<=i
+----
+10	10
+10	9
+
+query II
+SELECT * FROM vals1 WHERE i>=10 AND j<=i
+----
+10	10 
+10	9
+
+query II
+SELECT * FROM vals1 WHERE i<1 AND j<=i
+----
+0	0
+0	-1
+
+query II
+SELECT * FROM vals1 WHERE i<=0 AND j<=i
+----
+0	0
+0	-1
+
+### constant comparison [=, >, >=, <, <=] followed by j > i #########################
+
+query II
+SELECT * FROM vals1 WHERE i=5 AND j>i
+----
+5	6
+
+query II
+SELECT * FROM vals1 WHERE i>9 AND j>i
+----
+10	11
+
+query II
+SELECT * FROM vals1 WHERE i>=10 AND j>i
+----
+10	11
+
+query II
+SELECT * FROM vals1 WHERE i<1 AND j>i
+----
+0	1
+
+query II
+SELECT * FROM vals1 WHERE i<=0 AND j>i
+----
+0	1
+
+### constant comparison [=, >, >=, <, <=] followed by j < i #########################
+
+query II
+SELECT * FROM vals1 WHERE i=5 AND j<i
+----
+5	4
+
+query II
+SELECT * FROM vals1 WHERE i>9 AND j<i
+----
+10	9
+
+query II
+SELECT * FROM vals1 WHERE i>=10 AND j<i
+----
+10	9
+
+query II
+SELECT * FROM vals1 WHERE i<1 AND j<i
+----
+0	-1
+
+query II
+SELECT * FROM vals1 WHERE i<=0 AND j<i
+----
+0	-1


### PR DESCRIPTION
Hey all,

This PR handles filters transitivity for non-scalar expressions, e.g., j <= i. We check all constant values already inserted by the right scalar and added new filters for the left, for instance:

`WHERE i>10 AND j>=i`, a new filter `j>10` will be created.

P.S. It's missing to treat the case when we already have a non-scalar filter, e.g., j >= i, and we need to add a scalar one (i > 10), for instance: `WHERE j>=i  AND i>10`.