### PR TITLE
Parquet reader: Support unnamed columns and handle NaN values

### DIFF
--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -21,6 +21,8 @@
 
 #include "utf8proc_wrapper.hpp"
 
+#include <sstream>
+
 namespace duckdb {
 
 using namespace parquet;
@@ -457,25 +459,9 @@ bool ParquetReader::PreparePageBuffers(ParquetReaderScanState &state, idx_t col_
 		break;
 	}
 	default: {
-		string codec_name;
-		switch (chunk.meta_data.codec) {
-		case CompressionCodec::LZO:
-			codec_name = "LZ0";
-			break;
-		case CompressionCodec::BROTLI:
-			codec_name = "BROTLI";
-			break;
-		case CompressionCodec::LZ4:
-			codec_name = "LZ4";
-			break;
-		case CompressionCodec::ZSTD:
-			codec_name = "ZSTD";
-			break;
-		default:
-			codec_name = "unknown";
-			break;
-		}
-		throw FormatException("Unsupported compression codec \"" + codec_name + "\". Supported options are uncompressed, gzip or snappy");
+		std::stringstream codec_name;
+		codec_name << chunk.meta_data.codec;
+		throw FormatException("Unsupported compression codec \"" + codec_name.str() + "\". Supported options are uncompressed, gzip or snappy");
 	}
 	}
 	col_data.buf.inc(page_hdr.compressed_page_size);

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -312,6 +312,21 @@ ParquetReader::~ParquetReader() {
 ParquetReaderColumnData::~ParquetReaderColumnData() {
 }
 
+struct ValueIsValid {
+	template<class T>
+	static bool Operation(T value) {
+		return true;
+	}
+};
+
+template<> bool ValueIsValid::Operation(float value) {
+	return Value::FloatIsValid(value);
+}
+
+template<> bool ValueIsValid::Operation(double value) {
+	return Value::DoubleIsValid(value);
+}
+
 template <class T>
 void ParquetReader::fill_from_dict(ParquetReaderColumnData &col_data, idx_t count, Vector &target,
                                    idx_t target_offset) {
@@ -323,7 +338,12 @@ void ParquetReader::fill_from_dict(ParquetReaderColumnData &col_data, idx_t coun
 				                    to_string(col_data.dict_size) + " at " + to_string(i + target_offset) +
 				                    ". Corrupt file?");
 			}
-			((T *)FlatVector::GetData(target))[i + target_offset] = ((const T *)col_data.dict.ptr)[offset];
+			auto value = ((const T *)col_data.dict.ptr)[offset];
+			if (ValueIsValid::Operation(value)) {
+				((T *)FlatVector::GetData(target))[i + target_offset] = value;
+			} else {
+				FlatVector::SetNull(target, i + target_offset, true);
+			}
 		} else {
 			FlatVector::SetNull(target, i + target_offset, true);
 		}
@@ -335,7 +355,12 @@ void ParquetReader::fill_from_plain(ParquetReaderColumnData &col_data, idx_t cou
                                     idx_t target_offset) {
 	for (idx_t i = 0; i < count; i++) {
 		if (!col_data.has_nulls || col_data.defined_buf.ptr[i]) {
-			((T *)FlatVector::GetData(target))[i + target_offset] = col_data.payload.read<T>();
+			auto value = col_data.payload.read<T>();
+			if (ValueIsValid::Operation(value)) {
+				((T *)FlatVector::GetData(target))[i + target_offset] = value;
+			} else {
+				FlatVector::SetNull(target, i + target_offset, true);
+			}
 		} else {
 			FlatVector::SetNull(target, i + target_offset, true);
 		}

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -431,8 +431,27 @@ bool ParquetReader::PreparePageBuffers(ParquetReaderScanState &state, idx_t col_
 		col_data.payload.ptr = col_data.decompressed_buf.ptr;
 		break;
 	}
-	default:
-		throw FormatException("Unsupported compression codec. Try uncompressed, gzip or snappy");
+	default: {
+		string codec_name;
+		switch (chunk.meta_data.codec) {
+		case CompressionCodec::LZO:
+			codec_name = "LZ0";
+			break;
+		case CompressionCodec::BROTLI:
+			codec_name = "BROTLI";
+			break;
+		case CompressionCodec::LZ4:
+			codec_name = "LZ4";
+			break;
+		case CompressionCodec::ZSTD:
+			codec_name = "ZSTD";
+			break;
+		default:
+			codec_name = "unknown";
+			break;
+		}
+		throw FormatException("Unsupported compression codec \"" + codec_name + "\". Supported options are uncompressed, gzip or snappy");
+	}
 	}
 	col_data.buf.inc(page_hdr.compressed_page_size);
 

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -92,6 +92,11 @@ unique_ptr<BoundTableRef> Binder::Bind(TableFunctionRef &ref) {
 	for (idx_t i = 0; i < ref.column_name_alias.size() && i < return_names.size(); i++) {
 		return_names[i] = ref.column_name_alias[i];
 	}
+	for(idx_t i = 0; i < return_names.size(); i++) {
+		if (return_names[i].empty()) {
+			return_names[i] = "C" + to_string(i);
+		}
+	}
 	auto get = make_unique<LogicalGet>(bind_index, table_function, move(bind_data), return_types, return_names);
 	// now add the table function to the bind context so its columns can be bound
 	bind_context.AddTableFunction(bind_index, ref.alias.empty() ? fexpr->function_name : ref.alias, return_names,


### PR DESCRIPTION
Correctly handle unnamed columns in Parquet files by transforming them into C0,... Also transform NaN values (float nan, double nan) into NULL on read.