### PR TITLE
Allow CTEs in CREATE VIEW statements

### DIFF
--- a/src/catalog/catalog_entry/view_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/view_catalog_entry.cpp
@@ -68,7 +68,7 @@ unique_ptr<CreateViewInfo> ViewCatalogEntry::Deserialize(Deserializer &source) {
 	info->schema = source.Read<string>();
 	info->view_name = source.Read<string>();
 	info->sql = source.Read<string>();
-	info->query = QueryNode::Deserialize(source);
+	info->query = SelectStatement::Deserialize(source);
 	auto alias_count = source.Read<uint32_t>();
 	for (uint32_t i = 0; i < alias_count; i++) {
 		info->aliases.push_back(source.Read<string>());

--- a/src/catalog/default/default_views.cpp
+++ b/src/catalog/default/default_views.cpp
@@ -30,7 +30,7 @@ static unique_ptr<CreateViewInfo> GetDefaultView(string schema, string name) {
 			Parser parser;
 			parser.ParseQuery(internal_views[index].sql);
 			assert(parser.statements.size() == 1 && parser.statements[0]->type == StatementType::SELECT_STATEMENT);
-			result->query = move(((SelectStatement &)*parser.statements[0]).node);
+			result->query = unique_ptr_cast<SQLStatement, SelectStatement>(move(parser.statements[0]));
 			result->temporary = true;
 			result->internal = true;
 			result->view_name = name;

--- a/src/include/duckdb/catalog/catalog_entry/view_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/view_catalog_entry.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "duckdb/catalog/standard_entry.hpp"
-#include "duckdb/parser/query_node.hpp"
+#include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/vector.hpp"
 
@@ -26,7 +26,7 @@ public:
 	ViewCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, CreateViewInfo *info);
 
 	//! The query of the view
-	unique_ptr<QueryNode> query;
+	unique_ptr<SelectStatement> query;
 	//! The SQL query (if any)
 	string sql;
 	//! The set of aliases associated with the view

--- a/src/include/duckdb/parser/parsed_data/create_view_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_view_info.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/parser/parsed_data/create_info.hpp"
 #include "duckdb/parser/query_node.hpp"
+#include "duckdb/parser/statement/select_statement.hpp"
 
 namespace duckdb {
 
@@ -28,7 +29,7 @@ struct CreateViewInfo : public CreateInfo {
 	//! Return types
 	vector<LogicalType> types;
 	//! The QueryNode of the view
-	unique_ptr<QueryNode> query;
+	unique_ptr<SelectStatement> query;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/parsed_data/create_view_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_view_info.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "duckdb/parser/parsed_data/create_info.hpp"
-#include "duckdb/parser/query_node.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
 
 namespace duckdb {
@@ -17,7 +16,8 @@ namespace duckdb {
 struct CreateViewInfo : public CreateInfo {
 	CreateViewInfo() : CreateInfo(CatalogType::VIEW_ENTRY) {
 	}
-	CreateViewInfo(string schema, string view_name) : CreateInfo(CatalogType::VIEW_ENTRY, schema), view_name(view_name) {
+	CreateViewInfo(string schema, string view_name)
+	    : CreateInfo(CatalogType::VIEW_ENTRY, schema), view_name(view_name) {
 	}
 
 	//! Table name to insert to
@@ -28,7 +28,7 @@ struct CreateViewInfo : public CreateInfo {
 	vector<string> aliases;
 	//! Return types
 	vector<LogicalType> types;
-	//! The QueryNode of the view
+	//! The SelectStatement of the view
 	unique_ptr<SelectStatement> query;
 };
 

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -56,7 +56,7 @@ class Binder {
 	friend class RecursiveSubqueryPlanner;
 
 public:
-	Binder(ClientContext &context, Binder *parent = nullptr);
+	Binder(ClientContext &context, Binder *parent = nullptr, bool disable_parent_CTEs = false);
 
 	//! The client context
 	ClientContext &context;
@@ -88,8 +88,6 @@ public:
 	//! Generates an unused index for a table
 	idx_t GenerateTableIndex();
 
-	//! Disable the use of the parent binder for CTE references
-	void DisableParentCTEs();
 	//! Add a common table expression to the binder
 	void AddCTE(const string &name, CommonTableExpressionInfo *cte);
 	//! Find a common table expression by name; returns nullptr if none exists
@@ -119,7 +117,7 @@ private:
 	//! Whether or not subqueries should be planned already
 	bool plan_subquery = true;
 	//! Whether CTEs should reference the parent binder (if it exists)
-	bool use_parent_CTEs = true;
+	bool disable_parent_CTEs = false;
 
 private:
 	//! Bind the default values of the columns of a table

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -88,6 +88,8 @@ public:
 	//! Generates an unused index for a table
 	idx_t GenerateTableIndex();
 
+	//! Disable the use of the parent binder for CTE references
+	void DisableParentCTEs();
 	//! Add a common table expression to the binder
 	void AddCTE(const string &name, CommonTableExpressionInfo *cte);
 	//! Find a common table expression by name; returns nullptr if none exists
@@ -116,6 +118,8 @@ private:
 	bool has_unplanned_subqueries = false;
 	//! Whether or not subqueries should be planned already
 	bool plan_subquery = true;
+	//! Whether CTEs should reference the parent binder (if it exists)
+	bool use_parent_CTEs = true;
 
 private:
 	//! Bind the default values of the columns of a table

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -56,7 +56,7 @@ class Binder {
 	friend class RecursiveSubqueryPlanner;
 
 public:
-	Binder(ClientContext &context, Binder *parent = nullptr, bool disable_parent_CTEs = false);
+	Binder(ClientContext &context, Binder *parent = nullptr, bool inherit_ctes = true);
 
 	//! The client context
 	ClientContext &context;
@@ -117,7 +117,7 @@ private:
 	//! Whether or not subqueries should be planned already
 	bool plan_subquery = true;
 	//! Whether CTEs should reference the parent binder (if it exists)
-	bool disable_parent_CTEs = false;
+	bool inherit_ctes = true;
 
 private:
 	//! Bind the default values of the columns of a table

--- a/src/main/relation/create_view_relation.cpp
+++ b/src/main/relation/create_view_relation.cpp
@@ -17,9 +17,12 @@ unique_ptr<QueryNode> CreateViewRelation::GetQueryNode() {
 }
 
 BoundStatement CreateViewRelation::Bind(Binder &binder) {
+	auto select = make_unique<SelectStatement>();
+	select->node = child->GetQueryNode();
+
 	CreateStatement stmt;
 	auto info = make_unique<CreateViewInfo>();
-	info->query = child->GetQueryNode();
+	info->query = move(select);
 	info->view_name = view_name;
 	info->on_conflict = replace ? OnCreateConflict::REPLACE_ON_CONFLICT : OnCreateConflict::ERROR_ON_CONFLICT;
 	stmt.info = move(info);

--- a/src/parser/transform/statement/transform_create_view.cpp
+++ b/src/parser/transform/statement/transform_create_view.cpp
@@ -27,7 +27,7 @@ unique_ptr<CreateStatement> Transformer::TransformCreateView(PGNode *node) {
 	}
 	info->on_conflict = stmt->replace ? OnCreateConflict::REPLACE_ON_CONFLICT : OnCreateConflict::ERROR_ON_CONFLICT;
 
-	info->query = TransformSelectNode((PGSelectStmt *)stmt->query);
+	info->query = TransformSelect(stmt->query, false);
 
 	if (stmt->aliases && stmt->aliases->length > 0) {
 		for (auto c = stmt->aliases->head; c != NULL; c = lnext(c)) {

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -10,9 +10,9 @@
 namespace duckdb {
 using namespace std;
 
-Binder::Binder(ClientContext &context, Binder *parent_, bool disable_parent_CTEs_)
-    : context(context), read_only(true), parent(parent_), bound_tables(0), disable_parent_CTEs(disable_parent_CTEs_) {
-	if (parent_ && !disable_parent_CTEs_) {
+Binder::Binder(ClientContext &context, Binder *parent_, bool inherit_ctes_)
+    : context(context), read_only(true), parent(parent_), bound_tables(0), inherit_ctes(inherit_ctes_) {
+	if (parent_ && inherit_ctes_) {
 		// We have to inherit CTE bindings from the parent bind_context, if there is a parent.
 		bind_context.SetCTEBindings(parent_->bind_context.GetCTEBindings());
 		bind_context.cte_references = parent_->bind_context.cte_references;
@@ -160,7 +160,7 @@ void Binder::AddCTE(const string &name, CommonTableExpressionInfo *info) {
 CommonTableExpressionInfo *Binder::FindCTE(const string &name) {
 	auto entry = CTE_bindings.find(name);
 	if (entry == CTE_bindings.end()) {
-		if (parent && !disable_parent_CTEs) {
+		if (parent && inherit_ctes) {
 			return parent->FindCTE(name);
 		}
 		return nullptr;

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -11,8 +11,7 @@ namespace duckdb {
 using namespace std;
 
 Binder::Binder(ClientContext &context, Binder *parent_)
-    : context(context), read_only(true), parent(!parent_ ? nullptr : (parent_->parent ? parent_->parent : parent_)),
-      bound_tables(0) {
+    : context(context), read_only(true), parent(parent_), bound_tables(0) {
 	if (parent_) {
 		// We have to inherit CTE bindings from the parent bind_context, if there is a parent.
 		bind_context.SetCTEBindings(parent_->bind_context.GetCTEBindings());

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -23,6 +23,14 @@ Binder::Binder(ClientContext &context, Binder *parent_)
 	}
 }
 
+void Binder::DisableParentCTEs() {
+	unordered_map<string, shared_ptr<Binding>> cleared_bindings;
+	bind_context.SetCTEBindings(cleared_bindings);
+	bind_context.cte_references.clear();
+	CTE_bindings.clear();
+	use_parent_CTEs = false;
+}
+
 BoundStatement Binder::Bind(SQLStatement &statement) {
 	switch (statement.type) {
 	case StatementType::SELECT_STATEMENT:
@@ -162,7 +170,7 @@ void Binder::AddCTE(const string &name, CommonTableExpressionInfo *info) {
 CommonTableExpressionInfo *Binder::FindCTE(const string &name) {
 	auto entry = CTE_bindings.find(name);
 	if (entry == CTE_bindings.end()) {
-		if (parent) {
+		if (parent && use_parent_CTEs) {
 			return parent->FindCTE(name);
 		}
 		return nullptr;

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -10,25 +10,15 @@
 namespace duckdb {
 using namespace std;
 
-Binder::Binder(ClientContext &context, Binder *parent_)
-    : context(context), read_only(true), parent(parent_), bound_tables(0) {
-	if (parent_) {
+Binder::Binder(ClientContext &context, Binder *parent_, bool disable_parent_CTEs_)
+    : context(context), read_only(true), parent(parent_), bound_tables(0), disable_parent_CTEs(disable_parent_CTEs_) {
+	if (parent_ && !disable_parent_CTEs_) {
 		// We have to inherit CTE bindings from the parent bind_context, if there is a parent.
 		bind_context.SetCTEBindings(parent_->bind_context.GetCTEBindings());
 		bind_context.cte_references = parent_->bind_context.cte_references;
+		parameters = parent_->parameters;
+		CTE_bindings = parent_->CTE_bindings;
 	}
-	if (parent) {
-		parameters = parent->parameters;
-		CTE_bindings = parent->CTE_bindings;
-	}
-}
-
-void Binder::DisableParentCTEs() {
-	unordered_map<string, shared_ptr<Binding>> cleared_bindings;
-	bind_context.SetCTEBindings(cleared_bindings);
-	bind_context.cte_references.clear();
-	CTE_bindings.clear();
-	use_parent_CTEs = false;
 }
 
 BoundStatement Binder::Bind(SQLStatement &statement) {
@@ -170,7 +160,7 @@ void Binder::AddCTE(const string &name, CommonTableExpressionInfo *info) {
 CommonTableExpressionInfo *Binder::FindCTE(const string &name) {
 	auto entry = CTE_bindings.find(name);
 	if (entry == CTE_bindings.end()) {
-		if (parent && use_parent_CTEs) {
+		if (parent && !disable_parent_CTEs) {
 			return parent->FindCTE(name);
 		}
 		return nullptr;

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -71,6 +71,10 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 	case CatalogType::VIEW_ENTRY: {
 		// the node is a view: get the query that the view represents
 		auto view_catalog_entry = (ViewCatalogEntry *)table_or_view;
+		// first we visit the set of CTEs and add them to the bind context
+        for (auto &cte_it : view_catalog_entry->query->cte_map) {
+                AddCTE(cte_it.first, cte_it.second.get());
+        }
 		SubqueryRef subquery(view_catalog_entry->query->node->Copy());
 		subquery.alias = ref.alias.empty() ? ref.table_name : ref.alias;
 		subquery.column_name_alias = view_catalog_entry->aliases;

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -73,9 +73,8 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		auto view_catalog_entry = (ViewCatalogEntry *)table_or_view;
 		// first we visit the set of CTEs and add them to the bind context
 		Binder view_binder(context, this);
-		// Need to clear out the parent CTEs so there are no name collisions
-		// with the view's CTEs
-		view_binder.CTE_bindings.clear();
+		// isolate the view's CTEs from the parent's
+		view_binder.DisableParentCTEs();
 		for (auto &cte_it : view_catalog_entry->query->cte_map) {
 			view_binder.AddCTE(cte_it.first, cte_it.second.get());
 		}

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -73,6 +73,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		auto view_catalog_entry = (ViewCatalogEntry *)table_or_view;
 		// first we visit the set of CTEs and add them to the bind context
 		Binder view_binder(context, this);
+		view_binder.CTE_bindings.clear();
 		for (auto &cte_it : view_catalog_entry->query->cte_map) {
 			view_binder.AddCTE(cte_it.first, cte_it.second.get());
 		}

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -73,6 +73,8 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		auto view_catalog_entry = (ViewCatalogEntry *)table_or_view;
 		// first we visit the set of CTEs and add them to the bind context
 		Binder view_binder(context, this);
+		// Need to clear out the parent CTEs so there are no name collisions
+		// with the view's CTEs
 		view_binder.CTE_bindings.clear();
 		for (auto &cte_it : view_catalog_entry->query->cte_map) {
 			view_binder.AddCTE(cte_it.first, cte_it.second.get());

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -71,7 +71,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 	case CatalogType::VIEW_ENTRY: {
 		// the node is a view: get the query that the view represents
 		auto view_catalog_entry = (ViewCatalogEntry *)table_or_view;
-		SubqueryRef subquery(view_catalog_entry->query->Copy());
+		SubqueryRef subquery(view_catalog_entry->query->node->Copy());
 		subquery.alias = ref.alias.empty() ? ref.table_name : ref.alias;
 		subquery.column_name_alias = view_catalog_entry->aliases;
 		// bind the child subquery

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -74,8 +74,8 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		// We need to use a new binder for the view that doesn't reference any CTEs
 		// defined for this binder so there are no collisions between the CTEs defined
 		// for the view and for the current query
-		bool disable_parent_CTEs = true;
-		Binder view_binder(context, this, disable_parent_CTEs);
+		bool inherit_ctes = false;
+		Binder view_binder(context, this, inherit_ctes);
 		for (auto &cte_it : view_catalog_entry->query->cte_map) {
 			view_binder.AddCTE(cte_it.first, cte_it.second.get());
 		}

--- a/src/storage/storage_info.cpp
+++ b/src/storage/storage_info.cpp
@@ -3,6 +3,6 @@
 namespace duckdb {
 using namespace std;
 
-const uint64_t VERSION_NUMBER = 1;
+const uint64_t VERSION_NUMBER = 2;
 
 } // namespace duckdb

--- a/test/sql/cte/test_cte.test
+++ b/test/sql/cte/test_cte.test
@@ -55,3 +55,11 @@ with cte1 as (Select i as j from a) select * from cte1 where j = (select max(j) 
 ----
 42
 
+# use a CTE in a view definition
+statement ok
+create view va AS (with cte as (Select i as j from a) select * from cte);
+
+query I
+select * from va
+----
+42

--- a/test/sql/cte/test_cte.test
+++ b/test/sql/cte/test_cte.test
@@ -64,8 +64,10 @@ select * from va
 ----
 42
 
-# nested CTE views
+# nested CTE views that re-use CTE aliases
 query I
-with v AS (SELECT * FROM va) SELECT * FROM v;
+with cte AS (SELECT * FROM va) SELECT * FROM cte;
 ----
 42
+
+

--- a/test/sql/cte/test_cte.test
+++ b/test/sql/cte/test_cte.test
@@ -63,3 +63,9 @@ query I
 select * from va
 ----
 42
+
+# nested CTE views
+query I
+with v AS (SELECT * FROM va) SELECT * FROM v;
+----
+42

--- a/test/sql/cte/test_cte.test
+++ b/test/sql/cte/test_cte.test
@@ -70,4 +70,12 @@ with cte AS (SELECT * FROM va) SELECT * FROM cte;
 ----
 42
 
+# multiple ctes in a view definition
+statement ok
+create view vb AS (with cte1 as (Select i as j from a), cte2 as (select ref.j+1 as k from cte1 as ref) select * from cte2);
 
+query I
+select * from vb
+----
+43
+ 

--- a/test/sql/cte/test_cte_overflow.test
+++ b/test/sql/cte/test_cte_overflow.test
@@ -1,0 +1,17 @@
+# name: test/sql/cte/test_cte_overflow
+# description: Ensure no stack overflow for CTE names that match existing tables
+# group: [cte]
+
+statement ok
+create table a (id integer)
+
+statement ok
+insert into a values (1729)
+
+statement ok
+create view va as (with v as (select * from a) select * from v)
+
+query I
+with a as (select * from va) select * from a
+----
+1729

--- a/test/sql/cte/test_recursive_cte_tutorial.test
+++ b/test/sql/cte/test_recursive_cte_tutorial.test
@@ -81,6 +81,29 @@ SELECT * FROM ctename;
 7902	FORD	JONES -> FORD
 7369	SMITH	JONES -> FORD -> SMITH
 
+statement ok
+CREATE VIEW ctenames AS (
+  WITH RECURSIVE ctename AS (
+      SELECT empno, ename,
+             ename AS path
+      FROM emp
+      WHERE empno = 7566
+     UNION ALL
+      SELECT emp.empno, emp.ename,
+             ctename.path || ' -> ' || emp.ename
+      FROM emp
+         JOIN ctename ON emp.mgr = ctename.empno
+  )
+  SELECT * FROM ctename
+);
+
+query III
+SELECT * FROM ctenames;
+----
+7566	JONES	JONES
+7902	FORD	JONES -> FORD
+7369	SMITH	JONES -> FORD -> SMITH
+
 query II
 WITH RECURSIVE fib AS (
       SELECT 1 AS n,

--- a/test/sql/cte/test_recursive_cte_union.test
+++ b/test/sql/cte/test_recursive_cte_union.test
@@ -101,3 +101,13 @@ with recursive t as (select 1 as x union select sum(x+1) from t where x < 3 OFFS
 statement error
 with recursive t as (select 1 as x union select sum(x+1) from t where x < 3 LIMIT 1 OFFSET 1) select * from t
 
+# create a view from a recursive cte
+statement ok
+create view vr as (with recursive t(x) as (select 1 union select x+1 from t where x < 3) select * from t order by x)
+
+query I
+select * from vr
+----
+1
+2
+3


### PR DESCRIPTION
I got this to work locally by moving from using a `QueryNode` to a `SelectStatement` for the `ViewCatalogEntry` information (and associated structs) and adding a block in the `bind_tableref.cpp` code to incorporate the CTEs into the query context before execution-- where should I put the new tests for this stuff within the `test/sql/` directories?

Thanks!