### PR TITLE
Default Views and Schemas

### DIFF
--- a/src/catalog/CMakeLists.txt
+++ b/src/catalog/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_subdirectory(catalog_entry)
+add_subdirectory(default)
 
 add_library_unity(duckdb_catalog
                   OBJECT
                   catalog_entry.cpp
                   catalog.cpp
                   catalog_set.cpp
-                  default_views.cpp
                   dependency_manager.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_catalog>

--- a/src/catalog/CMakeLists.txt
+++ b/src/catalog/CMakeLists.txt
@@ -1,12 +1,8 @@
 add_subdirectory(catalog_entry)
 add_subdirectory(default)
 
-add_library_unity(duckdb_catalog
-                  OBJECT
-                  catalog_entry.cpp
-                  catalog.cpp
-                  catalog_set.cpp
-                  dependency_manager.cpp)
+add_library_unity(duckdb_catalog OBJECT catalog_entry.cpp catalog.cpp
+                  catalog_set.cpp dependency_manager.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_catalog>
     PARENT_SCOPE)

--- a/src/catalog/CMakeLists.txt
+++ b/src/catalog/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library_unity(duckdb_catalog
                   catalog_entry.cpp
                   catalog.cpp
                   catalog_set.cpp
+                  default_views.cpp
                   dependency_manager.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_catalog>

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -22,6 +22,8 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/catalog/dependency_manager.hpp"
 
+#include "duckdb/catalog/default/default_schemas.hpp"
+
 namespace duckdb {
 using namespace std;
 
@@ -85,7 +87,7 @@ CatalogEntry *Catalog::CreateSchema(ClientContext &context, CreateSchemaInfo *in
 	}
 
 	unordered_set<CatalogEntry *> dependencies;
-	auto entry = make_unique<SchemaCatalogEntry>(this, info->schema);
+	auto entry = make_unique<SchemaCatalogEntry>(this, info->schema, info->internal);
 	auto result = entry.get();
 	if (!schemas->CreateEntry(context.ActiveTransaction(), info->schema, move(entry), dependencies)) {
 		if (info->on_conflict == OnCreateConflict::ERROR_ON_CONFLICT) {
@@ -102,10 +104,6 @@ void Catalog::DropSchema(ClientContext &context, DropInfo *info) {
 	if (info->name == INVALID_SCHEMA) {
 		throw CatalogException("Schema not specified");
 	}
-	if (info->name == DEFAULT_SCHEMA || info->name == TEMP_SCHEMA) {
-		throw CatalogException("Cannot drop schema \"%s\" because it is required by the database system", info->name);
-	}
-
 	if (!schemas->DropEntry(context.ActiveTransaction(), info->name, info->cascade)) {
 		if (!info->if_exists) {
 			throw CatalogException("Schema with name \"%s\" does not exist!", info->name);
@@ -137,9 +135,20 @@ SchemaCatalogEntry *Catalog::GetSchema(ClientContext &context, const string &sch
 	}
 	auto entry = schemas->GetEntry(context.ActiveTransaction(), schema_name);
 	if (!entry) {
+		if (DefaultSchemas::GetDefaultSchema(schema_name)) {
+			// this schema does not exist yet, but it is a default schema
+			// create it
+			auto schema = make_unique_base<CatalogEntry, SchemaCatalogEntry>(this, schema_name, true);
+			return (SchemaCatalogEntry *) schemas->CreateEntry(schema_name, move(schema));
+		}
 		throw CatalogException("Schema with name %s does not exist!", schema_name);
 	}
 	return (SchemaCatalogEntry *)entry;
+}
+
+void Catalog::ScanSchemas(Transaction &transaction, std::function<void(CatalogEntry*)> callback) {
+	// create all default schemas
+	schemas->Scan(transaction, [&](CatalogEntry *entry) { callback(entry); });
 }
 
 CatalogEntry *Catalog::GetEntry(ClientContext &context, CatalogType type, string schema_name, const string &name,

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -140,7 +140,7 @@ SchemaCatalogEntry *Catalog::GetSchema(ClientContext &context, const string &sch
 	return (SchemaCatalogEntry *)entry;
 }
 
-void Catalog::ScanSchemas(ClientContext &context, std::function<void(CatalogEntry*)> callback) {
+void Catalog::ScanSchemas(ClientContext &context, std::function<void(CatalogEntry *)> callback) {
 	// create all default schemas first
 	schemas->Scan(context, [&](CatalogEntry *entry) { callback(entry); });
 }

--- a/src/catalog/catalog_entry/schema_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/schema_catalog_entry.cpp
@@ -36,9 +36,9 @@ using namespace std;
 
 SchemaCatalogEntry::SchemaCatalogEntry(Catalog *catalog, string name, bool internal)
     : CatalogEntry(CatalogType::SCHEMA_ENTRY, catalog, name),
-      tables(*catalog, make_unique<DefaultViewGenerator>(*catalog, this)), indexes(*catalog),
-      table_functions(*catalog), copy_functions(*catalog), pragma_functions(*catalog), functions(*catalog),
-      sequences(*catalog), collations(*catalog) {
+      tables(*catalog, make_unique<DefaultViewGenerator>(*catalog, this)), indexes(*catalog), table_functions(*catalog),
+      copy_functions(*catalog), pragma_functions(*catalog), functions(*catalog), sequences(*catalog),
+      collations(*catalog) {
 	this->internal = internal;
 }
 

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -98,6 +98,7 @@ bool TableCatalogEntry::ColumnExists(const string &name) {
 }
 
 unique_ptr<CatalogEntry> TableCatalogEntry::AlterEntry(ClientContext &context, AlterInfo *info) {
+	assert(!internal);
 	if (info->type != AlterType::ALTER_TABLE) {
 		throw CatalogException("Can only modify table with ALTER TABLE statement");
 	}

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -209,6 +209,9 @@ bool CatalogSet::DropEntry(Transaction &transaction, const string &name, bool ca
 	if (!GetEntryInternal(transaction, name, entry_index, entry)) {
 		return false;
 	}
+	if (entry->internal) {
+		throw CatalogException("Cannot drop entry \"%s\" because it is an internal system entry", entry->name);
+	}
 
 	// create the lock set for this delete operation
 	set_lock_map_t lock_set;

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -11,31 +11,12 @@
 namespace duckdb {
 using namespace std;
 
-CatalogSet::CatalogSet(Catalog &catalog) : catalog(catalog) {
+CatalogSet::CatalogSet(Catalog &catalog, unique_ptr<DefaultGenerator> defaults) : catalog(catalog), defaults(move(defaults)) {
 }
 
-CatalogEntry* CatalogSet::CreateEntry(const string &name, unique_ptr<CatalogEntry> value) {
-	// lock the catalog for writing
-	lock_guard<mutex> write_lock(catalog.write_lock);
-	// lock this catalog set to disallow reading
-	lock_guard<mutex> read_lock(catalog_lock);
-	auto entry = mapping.find(value->name);
-	if (entry != mapping.end()) {
-		// entry already exists: return that entry
-		return entries[entry->second].get();
-	}
-	idx_t entry_index = current_entry++;
-
-	value->timestamp = 0;
-
-	auto result = value.get();
-	mapping[value->name] = entry_index;
-	entries[entry_index] = move(value);
-	return result;
-}
-
-bool CatalogSet::CreateEntry(Transaction &transaction, const string &name, unique_ptr<CatalogEntry> value,
+bool CatalogSet::CreateEntry(ClientContext &context, const string &name, unique_ptr<CatalogEntry> value,
                              unordered_set<CatalogEntry *> &dependencies) {
+	auto &transaction = Transaction::GetTransaction(context);
 	// lock the catalog for writing
 	lock_guard<mutex> write_lock(catalog.write_lock);
 	// lock this catalog set to disallow reading
@@ -62,7 +43,7 @@ bool CatalogSet::CreateEntry(Transaction &transaction, const string &name, uniqu
 		entry_index = entry->second;
 		auto &current = *entries[entry_index];
 		// if it does, we have to check version numbers
-		if (HasConflict(transaction, current)) {
+		if (HasConflict(context, current)) {
 			// current version has been written to by a currently active
 			// transaction
 			throw TransactionException("Catalog write-write conflict on create with \"%s\"", current.name);
@@ -80,7 +61,7 @@ bool CatalogSet::CreateEntry(Transaction &transaction, const string &name, uniqu
 	value->set = this;
 
 	// now add the dependency set of this object to the dependency manager
-	catalog.dependency_manager->AddObject(transaction, value.get(), dependencies);
+	catalog.dependency_manager->AddObject(context, value.get(), dependencies);
 
 	value->child = move(entries[entry_index]);
 	value->child->parent = value.get();
@@ -90,10 +71,10 @@ bool CatalogSet::CreateEntry(Transaction &transaction, const string &name, uniqu
 	return true;
 }
 
-bool CatalogSet::GetEntryInternal(Transaction &transaction, idx_t entry_index, CatalogEntry *&catalog_entry) {
+bool CatalogSet::GetEntryInternal(ClientContext &context, idx_t entry_index, CatalogEntry *&catalog_entry) {
 	catalog_entry = entries[entry_index].get();
 	// if it does: we have to retrieve the entry and to check version numbers
-	if (HasConflict(transaction, *catalog_entry)) {
+	if (HasConflict(context, *catalog_entry)) {
 		// current version has been written to by a currently active
 		// transaction
 		throw TransactionException("Catalog write-write conflict on alter with \"%s\"", catalog_entry->name);
@@ -107,15 +88,15 @@ bool CatalogSet::GetEntryInternal(Transaction &transaction, idx_t entry_index, C
 	return true;
 }
 
-bool CatalogSet::GetEntryInternal(Transaction &transaction, const string &name, idx_t &entry_index,
+bool CatalogSet::GetEntryInternal(ClientContext &context, const string &name, idx_t &entry_index,
                                   CatalogEntry *&catalog_entry) {
 	auto entry = mapping.find(name);
 	if (entry == mapping.end()) {
-		// if it does not: entry has never been created and cannot be altered
+		// the entry does not exist, check if we can create a default entry
 		return false;
 	}
 	entry_index = entry->second;
-	return GetEntryInternal(transaction, entry_index, catalog_entry);
+	return GetEntryInternal(context, entry_index, catalog_entry);
 }
 
 void CatalogSet::ClearEntryName(string name) {
@@ -132,8 +113,11 @@ bool CatalogSet::AlterEntry(ClientContext &context, const string &name, AlterInf
 	// first check if the entry exists in the unordered set
 	idx_t entry_index;
 	CatalogEntry *entry;
-	if (!GetEntryInternal(transaction, name, entry_index, entry)) {
+	if (!GetEntryInternal(context, name, entry_index, entry)) {
 		return false;
+	}
+	if (entry->internal) {
+		throw CatalogException("Cannot alter entry \"%s\" because it is an internal system entry", entry->name);
 	}
 
 	// lock this catalog set to disallow reading
@@ -155,7 +139,7 @@ bool CatalogSet::AlterEntry(ClientContext &context, const string &name, AlterInf
 		mapping[value->name] = entry_index;
 	}
 	//! Check the dependency manager to verify that there are no conflicting dependencies with this alter
-	catalog.dependency_manager->AlterObject(transaction, entry, value.get());
+	catalog.dependency_manager->AlterObject(context, entry, value.get());
 
 	value->timestamp = transaction.transaction_id;
 	value->child = move(entries[entry_index]);
@@ -174,10 +158,11 @@ bool CatalogSet::AlterEntry(ClientContext &context, const string &name, AlterInf
 	return true;
 }
 
-void CatalogSet::DropEntryInternal(Transaction &transaction, idx_t entry_index, CatalogEntry &entry, bool cascade,
+void CatalogSet::DropEntryInternal(ClientContext &context, idx_t entry_index, CatalogEntry &entry, bool cascade,
                                    set_lock_map_t &lock_set) {
+	auto &transaction = Transaction::GetTransaction(context);
 	// check any dependencies of this object
-	entry.catalog->dependency_manager->DropObject(transaction, &entry, cascade, lock_set);
+	entry.catalog->dependency_manager->DropObject(context, &entry, cascade, lock_set);
 
 	// add this catalog to the lock set, if it is not there yet
 	if (lock_set.find(this) == lock_set.end()) {
@@ -200,13 +185,13 @@ void CatalogSet::DropEntryInternal(Transaction &transaction, idx_t entry_index, 
 	entries[entry_index] = move(value);
 }
 
-bool CatalogSet::DropEntry(Transaction &transaction, const string &name, bool cascade) {
+bool CatalogSet::DropEntry(ClientContext &context, const string &name, bool cascade) {
 	// lock the catalog for writing
 	lock_guard<mutex> write_lock(catalog.write_lock);
 	// we can only delete an entry that exists
 	idx_t entry_index;
 	CatalogEntry *entry;
-	if (!GetEntryInternal(transaction, name, entry_index, entry)) {
+	if (!GetEntryInternal(context, name, entry_index, entry)) {
 		return false;
 	}
 	if (entry->internal) {
@@ -215,7 +200,7 @@ bool CatalogSet::DropEntry(Transaction &transaction, const string &name, bool ca
 
 	// create the lock set for this delete operation
 	set_lock_map_t lock_set;
-	DropEntryInternal(transaction, entry_index, *entry, cascade, lock_set);
+	DropEntryInternal(context, entry_index, *entry, cascade, lock_set);
 	return true;
 }
 
@@ -225,12 +210,14 @@ idx_t CatalogSet::GetEntryIndex(CatalogEntry *entry) {
 	return entry_index;
 }
 
-bool CatalogSet::HasConflict(Transaction &transaction, CatalogEntry &current) {
+bool CatalogSet::HasConflict(ClientContext &context, CatalogEntry &current) {
+	auto &transaction = Transaction::GetTransaction(context);
 	return (current.timestamp >= TRANSACTION_ID_START && current.timestamp != transaction.transaction_id) ||
 	       (current.timestamp < TRANSACTION_ID_START && current.timestamp > transaction.start_time);
 }
 
-CatalogEntry *CatalogSet::GetEntryForTransaction(Transaction &transaction, CatalogEntry *current) {
+CatalogEntry *CatalogSet::GetEntryForTransaction(ClientContext &context, CatalogEntry *current) {
+	auto &transaction = Transaction::GetTransaction(context);
 	while (current->child) {
 		if (current->timestamp == transaction.transaction_id) {
 			// we created this version
@@ -246,16 +233,33 @@ CatalogEntry *CatalogSet::GetEntryForTransaction(Transaction &transaction, Catal
 	return current;
 }
 
-CatalogEntry *CatalogSet::GetEntry(Transaction &transaction, const string &name) {
+CatalogEntry *CatalogSet::GetEntry(ClientContext &context, const string &name) {
 	lock_guard<mutex> lock(catalog_lock);
 
 	auto entry = mapping.find(name);
 	if (entry == mapping.end()) {
+		// no entry found with this name
+		if (defaults) {
+			// ... but this catalog set has a default map defined
+			// check if there is a default entry that we can create with this name
+			auto entry = defaults->CreateDefaultEntry(context, name);
+			if (entry) {
+				// there is a default entry!
+				auto entry_index = current_entry++;
+				auto catalog_entry = entry.get();
+
+				entry->timestamp = 0;
+
+				mapping[entry->name] = entry_index;
+				entries[entry_index] = move(entry);
+				return catalog_entry;
+			}
+		}
 		return nullptr;
 	}
 	auto catalog_entry = entries[entry->second].get();
 	// if it does, we have to check version numbers
-	CatalogEntry *current = GetEntryForTransaction(transaction, catalog_entry);
+	CatalogEntry *current = GetEntryForTransaction(context, catalog_entry);
 	if (current->deleted || current->name != name) {
 		return nullptr;
 	}

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -11,7 +11,8 @@
 namespace duckdb {
 using namespace std;
 
-CatalogSet::CatalogSet(Catalog &catalog, unique_ptr<DefaultGenerator> defaults) : catalog(catalog), defaults(move(defaults)) {
+CatalogSet::CatalogSet(Catalog &catalog, unique_ptr<DefaultGenerator> defaults)
+    : catalog(catalog), defaults(move(defaults)) {
 }
 
 bool CatalogSet::CreateEntry(ClientContext &context, const string &name, unique_ptr<CatalogEntry> value,

--- a/src/catalog/default/CMakeLists.txt
+++ b/src/catalog/default/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library_unity(
+  duckdb_catalog_default_entries
+  OBJECT
+  default_schemas.cpp
+  default_views.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_catalog_default_entries>
+    PARENT_SCOPE)

--- a/src/catalog/default/CMakeLists.txt
+++ b/src/catalog/default/CMakeLists.txt
@@ -1,8 +1,5 @@
-add_library_unity(
-  duckdb_catalog_default_entries
-  OBJECT
-  default_schemas.cpp
-  default_views.cpp)
+add_library_unity(duckdb_catalog_default_entries OBJECT default_schemas.cpp
+                  default_views.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_catalog_default_entries>
     PARENT_SCOPE)

--- a/src/catalog/default/default_schemas.cpp
+++ b/src/catalog/default/default_schemas.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/catalog/default/default_schemas.hpp"
+#include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 
 namespace duckdb {
 
@@ -6,18 +7,32 @@ struct DefaultSchema {
 	const char *name;
 };
 
+static idx_t total_internal_schemas = 1;
+
 static DefaultSchema internal_schemas[] = {
 	{ "information_schema" },
 	{ nullptr }
 };
 
-bool DefaultSchemas::GetDefaultSchema(string schema) {
+static bool GetDefaultSchema(string schema) {
 	for(idx_t index = 0; internal_schemas[index].name != nullptr; index++) {
 		if (internal_schemas[index].name == schema) {
 			return true;
 		}
 	}
 	return false;
+}
+
+
+DefaultSchemaGenerator::DefaultSchemaGenerator(Catalog &catalog) : DefaultGenerator(catalog) {
+
+}
+
+unique_ptr<CatalogEntry> DefaultSchemaGenerator::CreateDefaultEntry(ClientContext &context, const string &entry_name) {
+	if (GetDefaultSchema(entry_name)) {
+		return make_unique_base<CatalogEntry, SchemaCatalogEntry>(&catalog, entry_name, true);
+	}
+	return nullptr;
 }
 
 }

--- a/src/catalog/default/default_schemas.cpp
+++ b/src/catalog/default/default_schemas.cpp
@@ -7,8 +7,6 @@ struct DefaultSchema {
 	const char *name;
 };
 
-static idx_t total_internal_schemas = 1;
-
 static DefaultSchema internal_schemas[] = {
 	{ "information_schema" },
 	{ nullptr }

--- a/src/catalog/default/default_schemas.cpp
+++ b/src/catalog/default/default_schemas.cpp
@@ -7,13 +7,10 @@ struct DefaultSchema {
 	const char *name;
 };
 
-static DefaultSchema internal_schemas[] = {
-	{ "information_schema" },
-	{ nullptr }
-};
+static DefaultSchema internal_schemas[] = {{"information_schema"}, {nullptr}};
 
 static bool GetDefaultSchema(string schema) {
-	for(idx_t index = 0; internal_schemas[index].name != nullptr; index++) {
+	for (idx_t index = 0; internal_schemas[index].name != nullptr; index++) {
 		if (internal_schemas[index].name == schema) {
 			return true;
 		}
@@ -21,9 +18,7 @@ static bool GetDefaultSchema(string schema) {
 	return false;
 }
 
-
 DefaultSchemaGenerator::DefaultSchemaGenerator(Catalog &catalog) : DefaultGenerator(catalog) {
-
 }
 
 unique_ptr<CatalogEntry> DefaultSchemaGenerator::CreateDefaultEntry(ClientContext &context, const string &entry_name) {
@@ -33,4 +28,4 @@ unique_ptr<CatalogEntry> DefaultSchemaGenerator::CreateDefaultEntry(ClientContex
 	return nullptr;
 }
 
-}
+} // namespace duckdb

--- a/src/catalog/default/default_schemas.cpp
+++ b/src/catalog/default/default_schemas.cpp
@@ -1,0 +1,23 @@
+#include "duckdb/catalog/default/default_schemas.hpp"
+
+namespace duckdb {
+
+struct DefaultSchema {
+	const char *name;
+};
+
+static DefaultSchema internal_schemas[] = {
+	{ "information_schema" },
+	{ nullptr }
+};
+
+bool DefaultSchemas::GetDefaultSchema(string schema) {
+	for(idx_t index = 0; internal_schemas[index].name != nullptr; index++) {
+		if (internal_schemas[index].name == schema) {
+			return true;
+		}
+	}
+	return false;
+}
+
+}

--- a/src/catalog/default/default_views.cpp
+++ b/src/catalog/default/default_views.cpp
@@ -14,15 +14,14 @@ struct DefaultView {
 };
 
 static DefaultView internal_views[] = {
-	{ DEFAULT_SCHEMA, "sqlite_master", "SELECT * FROM sqlite_master()" },
-	{ "information_schema", "columns", "SELECT * FROM information_schema_columns()"},
-	{ "information_schema", "schemata", "SELECT * FROM information_schema_schemata()"},
-	{ "information_schema", "tables", "SELECT * FROM information_schema_tables()"},
-	{ nullptr, nullptr, nullptr }
-};
+    {DEFAULT_SCHEMA, "sqlite_master", "SELECT * FROM sqlite_master()"},
+    {"information_schema", "columns", "SELECT * FROM information_schema_columns()"},
+    {"information_schema", "schemata", "SELECT * FROM information_schema_schemata()"},
+    {"information_schema", "tables", "SELECT * FROM information_schema_tables()"},
+    {nullptr, nullptr, nullptr}};
 
 static unique_ptr<CreateViewInfo> GetDefaultView(string schema, string name) {
-	for(idx_t index = 0; internal_views[index].name != nullptr; index++) {
+	for (idx_t index = 0; internal_views[index].name != nullptr; index++) {
 		if (internal_views[index].schema == schema && internal_views[index].name == name) {
 			auto result = make_unique<CreateViewInfo>();
 			result->schema = schema;
@@ -31,7 +30,7 @@ static unique_ptr<CreateViewInfo> GetDefaultView(string schema, string name) {
 			Parser parser;
 			parser.ParseQuery(internal_views[index].sql);
 			assert(parser.statements.size() == 1 && parser.statements[0]->type == StatementType::SELECT_STATEMENT);
-			result->query = move(((SelectStatement &) *parser.statements[0]).node);
+			result->query = move(((SelectStatement &)*parser.statements[0]).node);
 			result->temporary = true;
 			result->internal = true;
 			result->view_name = name;
@@ -41,8 +40,9 @@ static unique_ptr<CreateViewInfo> GetDefaultView(string schema, string name) {
 	return nullptr;
 }
 
-DefaultViewGenerator::DefaultViewGenerator(Catalog &catalog, SchemaCatalogEntry *schema) :
-	DefaultGenerator(catalog), schema(schema) {}
+DefaultViewGenerator::DefaultViewGenerator(Catalog &catalog, SchemaCatalogEntry *schema)
+    : DefaultGenerator(catalog), schema(schema) {
+}
 
 unique_ptr<CatalogEntry> DefaultViewGenerator::CreateDefaultEntry(ClientContext &context, const string &entry_name) {
 	auto info = GetDefaultView(schema->name, entry_name);
@@ -55,4 +55,4 @@ unique_ptr<CatalogEntry> DefaultViewGenerator::CreateDefaultEntry(ClientContext 
 	return nullptr;
 }
 
-}
+} // namespace duckdb

--- a/src/catalog/default/default_views.cpp
+++ b/src/catalog/default/default_views.cpp
@@ -1,24 +1,28 @@
-#include "duckdb/catalog/default_views.hpp"
+#include "duckdb/catalog/default/default_views.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
 
 namespace duckdb {
 
 struct DefaultView {
+	const char *schema;
 	const char *name;
 	const char *sql;
 };
 
 static DefaultView internal_views[] = {
-	{ "sqlite_master", "SELECT * FROM sqlite_master()" },
-	{ nullptr, nullptr }
+	{ DEFAULT_SCHEMA, "sqlite_master", "SELECT * FROM sqlite_master()" },
+	{ "information_schema", "columns", "SELECT * FROM information_schema_columns()"},
+	{ "information_schema", "schemata", "SELECT * FROM information_schema_schemata()"},
+	{ "information_schema", "tables", "SELECT * FROM information_schema_tables()"},
+	{ nullptr, nullptr, nullptr }
 };
 
-unique_ptr<CreateViewInfo> DefaultViews::GetDefaultView(string name) {
+unique_ptr<CreateViewInfo> DefaultViews::GetDefaultView(string schema, string name) {
 	for(idx_t index = 0; internal_views[index].name != nullptr; index++) {
-		if (internal_views[index].name == name) {
+		if (internal_views[index].schema == schema && internal_views[index].name == name) {
 			auto result = make_unique<CreateViewInfo>();
-			result->schema = DEFAULT_SCHEMA;
+			result->schema = schema;
 			result->sql = internal_views[index].sql;
 
 			Parser parser;

--- a/src/catalog/default/default_views.cpp
+++ b/src/catalog/default/default_views.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/planner/binder.hpp"
+#include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
 
 namespace duckdb {

--- a/src/catalog/default_views.cpp
+++ b/src/catalog/default_views.cpp
@@ -1,0 +1,37 @@
+#include "duckdb/catalog/default_views.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/statement/select_statement.hpp"
+
+namespace duckdb {
+
+struct DefaultView {
+	const char *name;
+	const char *sql;
+};
+
+static DefaultView internal_views[] = {
+	{ "sqlite_master", "SELECT * FROM sqlite_master()" },
+	{ nullptr, nullptr }
+};
+
+unique_ptr<CreateViewInfo> DefaultViews::GetDefaultView(string name) {
+	for(idx_t index = 0; internal_views[index].name != nullptr; index++) {
+		if (internal_views[index].name == name) {
+			auto result = make_unique<CreateViewInfo>();
+			result->schema = DEFAULT_SCHEMA;
+			result->sql = internal_views[index].sql;
+
+			Parser parser;
+			parser.ParseQuery(internal_views[index].sql);
+			assert(parser.statements.size() == 1 && parser.statements[0]->type == StatementType::SELECT_STATEMENT);
+			result->query = move(((SelectStatement &) *parser.statements[0]).node);
+			result->temporary = true;
+			result->internal = true;
+			result->view_name = name;
+			return result;
+		}
+	}
+	return nullptr;
+}
+
+}

--- a/src/catalog/dependency_manager.cpp
+++ b/src/catalog/dependency_manager.cpp
@@ -8,13 +8,13 @@ using namespace std;
 DependencyManager::DependencyManager(Catalog &catalog) : catalog(catalog) {
 }
 
-void DependencyManager::AddObject(Transaction &transaction, CatalogEntry *object,
+void DependencyManager::AddObject(ClientContext &context, CatalogEntry *object,
                                   unordered_set<CatalogEntry *> &dependencies) {
 	// check for each object in the sources if they were not deleted yet
 	for (auto &dependency : dependencies) {
 		idx_t entry_index;
 		CatalogEntry *catalog_entry;
-		if (!dependency->set->GetEntryInternal(transaction, dependency->name, entry_index, catalog_entry)) {
+		if (!dependency->set->GetEntryInternal(context, dependency->name, entry_index, catalog_entry)) {
 			throw InternalException("Dependency has already been deleted?");
 		}
 	}
@@ -27,7 +27,7 @@ void DependencyManager::AddObject(Transaction &transaction, CatalogEntry *object
 	dependencies_map[object] = dependencies;
 }
 
-void DependencyManager::DropObject(Transaction &transaction, CatalogEntry *object, bool cascade,
+void DependencyManager::DropObject(ClientContext &context, CatalogEntry *object, bool cascade,
                                    set_lock_map_t &lock_set) {
 	assert(dependents_map.find(object) != dependents_map.end());
 
@@ -39,14 +39,14 @@ void DependencyManager::DropObject(Transaction &transaction, CatalogEntry *objec
 		idx_t entry_index;
 		CatalogEntry *dependency_entry;
 
-		if (!catalog_set.GetEntryInternal(transaction, dep->name, entry_index, dependency_entry)) {
+		if (!catalog_set.GetEntryInternal(context, dep->name, entry_index, dependency_entry)) {
 			// the dependent object was already deleted, no conflict
 			continue;
 		}
 		// conflict: attempting to delete this object but the dependent object still exists
 		if (cascade) {
 			// cascade: drop the dependent object
-			catalog_set.DropEntryInternal(transaction, entry_index, *dependency_entry, cascade, lock_set);
+			catalog_set.DropEntryInternal(context, entry_index, *dependency_entry, cascade, lock_set);
 		} else {
 			// no cascade and there are objects that depend on this object: throw error
 			throw CatalogException("Cannot drop entry \"%s\" because there are entries that "
@@ -56,7 +56,7 @@ void DependencyManager::DropObject(Transaction &transaction, CatalogEntry *objec
 	}
 }
 
-void DependencyManager::AlterObject(Transaction &transaction, CatalogEntry *old_obj, CatalogEntry *new_obj) {
+void DependencyManager::AlterObject(ClientContext &context, CatalogEntry *old_obj, CatalogEntry *new_obj) {
 	assert(dependents_map.find(old_obj) != dependents_map.end());
 	assert(dependencies_map.find(old_obj) != dependencies_map.end());
 
@@ -67,7 +67,7 @@ void DependencyManager::AlterObject(Transaction &transaction, CatalogEntry *old_
 		auto &catalog_set = *dep->set;
 		idx_t entry_index;
 		CatalogEntry *dependency_entry;
-		if (!catalog_set.GetEntryInternal(transaction, dep->name, entry_index, dependency_entry)) {
+		if (!catalog_set.GetEntryInternal(context, dep->name, entry_index, dependency_entry)) {
 			// the dependent object was already deleted, no conflict
 			continue;
 		}

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -692,8 +692,15 @@ template <> date_t StrictCastToDate::Operation(string_t input) {
 //===--------------------------------------------------------------------===//
 struct TimeToStringCast {
 	static idx_t Length(int32_t time[]) {
-		// format is HH:MM:DD.msec
-		return 12;
+		// format is HH:MM:DD
+		// regular length is 8
+		idx_t length = 8;
+		if (time[3] > 0) {
+			// if there are msecs, we add the miliseconds after the time with a period separator
+			// i.e. the format becomes HH:MM:DD.msec
+			length += 4;
+		}
+		return length;
 	}
 
 	static void Format(char *data, idx_t length, int32_t time[]) {
@@ -711,13 +718,15 @@ struct TimeToStringCast {
 			ptr[2] = ':';
 			ptr += 3;
 		}
-		// now write ms at the end
-		auto start = ptr;
-		ptr = NumericHelper::FormatUnsigned(time[3], data + length);
-		while (ptr > start) {
-			*--ptr = '0';
+		// now optionally write ms at the end
+		if (time[3] > 0) {
+			auto start = ptr;
+			ptr = NumericHelper::FormatUnsigned(time[3], data + length);
+			while (ptr > start) {
+				*--ptr = '0';
+			}
+			*--ptr = '.';
 		}
-		*--ptr = '.';
 	}
 };
 

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -692,15 +692,8 @@ template <> date_t StrictCastToDate::Operation(string_t input) {
 //===--------------------------------------------------------------------===//
 struct TimeToStringCast {
 	static idx_t Length(int32_t time[]) {
-		// format is HH:MM:DD
-		// regular length is 8
-		idx_t length = 8;
-		if (time[3] > 0) {
-			// if there are msecs, we add the miliseconds after the time with a period separator
-			// i.e. the format becomes HH:MM:DD.msec
-			length += 4;
-		}
-		return length;
+		// format is HH:MM:DD.msec
+		return 12;
 	}
 
 	static void Format(char *data, idx_t length, int32_t time[]) {
@@ -718,15 +711,13 @@ struct TimeToStringCast {
 			ptr[2] = ':';
 			ptr += 3;
 		}
-		// now optionally write ms at the end
-		if (time[3] > 0) {
-			auto start = ptr;
-			ptr = NumericHelper::FormatUnsigned(time[3], data + length);
-			while (ptr > start) {
-				*--ptr = '0';
-			}
-			*--ptr = '.';
+		// now write ms at the end
+		auto start = ptr;
+		ptr = NumericHelper::FormatUnsigned(time[3], data + length);
+		while (ptr > start) {
+			*--ptr = '0';
 		}
+		*--ptr = '.';
 	}
 };
 

--- a/src/common/types/time.cpp
+++ b/src/common/types/time.cpp
@@ -153,11 +153,7 @@ string Time::ToString(dtime_t time) {
 	int32_t hour, min, sec, msec;
 	number_to_time(time, hour, min, sec, msec);
 
-	if (msec > 0) {
-		return StringUtil::Format("%02d:%02d:%02d.%03d", hour, min, sec, msec);
-	} else {
-		return StringUtil::Format("%02d:%02d:%02d", hour, min, sec);
-	}
+	return StringUtil::Format("%02d:%02d:%02d.%03d", hour, min, sec, msec);
 }
 
 string Time::Format(int32_t hour, int32_t minute, int32_t second, int32_t milisecond) {

--- a/src/common/types/time.cpp
+++ b/src/common/types/time.cpp
@@ -153,7 +153,11 @@ string Time::ToString(dtime_t time) {
 	int32_t hour, min, sec, msec;
 	number_to_time(time, hour, min, sec, msec);
 
-	return StringUtil::Format("%02d:%02d:%02d.%03d", hour, min, sec, msec);
+	if (msec > 0) {
+		return StringUtil::Format("%02d:%02d:%02d.%03d", hour, min, sec, msec);
+	} else {
+		return StringUtil::Format("%02d:%02d:%02d", hour, min, sec);
+	}
 }
 
 string Time::Format(int32_t hour, int32_t minute, int32_t second, int32_t milisecond) {

--- a/src/execution/operator/helper/physical_prepare.cpp
+++ b/src/execution/operator/helper/physical_prepare.cpp
@@ -14,7 +14,7 @@ void PhysicalPrepare::GetChunkInternal(ExecutionContext &context, DataChunk &chu
 
 	// now store plan in context
 	auto &dependencies = entry->prepared->dependencies;
-	if (!client.prepared_statements->CreateEntry(client.ActiveTransaction(), name, move(entry), dependencies)) {
+	if (!client.prepared_statements->CreateEntry(client, name, move(entry), dependencies)) {
 		throw Exception("Failed to prepare statement");
 	}
 	state->finished = true;

--- a/src/execution/operator/persistent/physical_export.cpp
+++ b/src/execution/operator/persistent/physical_export.cpp
@@ -84,22 +84,21 @@ void PhysicalExport::GetChunkInternal(ExecutionContext &context, DataChunk &chun
 	vector<CatalogEntry *> views;
 	vector<CatalogEntry *> indexes;
 
-	auto &transaction = Transaction::GetTransaction(ccontext);
-	Catalog::GetCatalog(ccontext).schemas->Scan(transaction, [&](CatalogEntry *entry) {
+	Catalog::GetCatalog(ccontext).schemas->Scan(context.client, [&](CatalogEntry *entry) {
 		auto schema = (SchemaCatalogEntry *)entry;
 		if (schema->name != DEFAULT_SCHEMA) {
 			// export schema
 			schemas.push_back(schema);
 		}
-		schema->tables.Scan(transaction, [&](CatalogEntry *entry) {
+		schema->tables.Scan(context.client, [&](CatalogEntry *entry) {
 			if (entry->type == CatalogType::TABLE_ENTRY) {
 				tables.push_back(entry);
 			} else {
 				views.push_back(entry);
 			}
 		});
-		schema->sequences.Scan(transaction, [&](CatalogEntry *entry) { sequences.push_back(entry); });
-		schema->indexes.Scan(transaction, [&](CatalogEntry *entry) { indexes.push_back(entry); });
+		schema->sequences.Scan(context.client, [&](CatalogEntry *entry) { sequences.push_back(entry); });
+		schema->indexes.Scan(context.client, [&](CatalogEntry *entry) { indexes.push_back(entry); });
 	});
 
 	// write the schema.sql file

--- a/src/execution/operator/schema/physical_drop.cpp
+++ b/src/execution/operator/schema/physical_drop.cpp
@@ -8,7 +8,7 @@ namespace duckdb {
 void PhysicalDrop::GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state) {
 	switch (info->type) {
 	case CatalogType::PREPARED_STATEMENT:
-		if (!context.client.prepared_statements->DropEntry(context.client.ActiveTransaction(), info->name, false)) {
+		if (!context.client.prepared_statements->DropEntry(context.client, info->name, false)) {
 			// silently ignore
 		}
 		break;

--- a/src/function/table/information_schema/information_schema_columns.cpp
+++ b/src/function/table/information_schema/information_schema_columns.cpp
@@ -6,7 +6,6 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/constraints/not_null_constraint.hpp"
-#include "duckdb/transaction/transaction.hpp"
 
 #include <set>
 
@@ -75,14 +74,13 @@ information_schema_columns_init(ClientContext &context, const FunctionData *bind
 	auto result = make_unique<InformationSchemaColumnsData>();
 
 	// scan all the schemas for tables and views and collect them
-	auto &transaction = Transaction::GetTransaction(context);
-	Catalog::GetCatalog(context).schemas->Scan(transaction, [&](CatalogEntry *entry) {
+	Catalog::GetCatalog(context).schemas->Scan(context, [&](CatalogEntry *entry) {
 		auto schema = (SchemaCatalogEntry *)entry;
-		schema->tables.Scan(transaction, [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+		schema->tables.Scan(context, [&](CatalogEntry *entry) { result->entries.push_back(entry); });
 	});
 
 	// check the temp schema as well
-	context.temporary_objects->tables.Scan(transaction, [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+	context.temporary_objects->tables.Scan(context, [&](CatalogEntry *entry) { result->entries.push_back(entry); });
 	return move(result);
 }
 

--- a/src/function/table/information_schema/information_schema_schemata.cpp
+++ b/src/function/table/information_schema/information_schema_schemata.cpp
@@ -4,7 +4,6 @@
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/client_context.hpp"
-#include "duckdb/transaction/transaction.hpp"
 
 using namespace std;
 
@@ -52,8 +51,7 @@ information_schema_schemata_init(ClientContext &context, const FunctionData *bin
 	auto result = make_unique<InformationSchemaSchemataData>();
 
 	// scan all the schemas and collect them
-	auto &transaction = Transaction::GetTransaction(context);
-	Catalog::GetCatalog(context).ScanSchemas(transaction, [&](CatalogEntry *entry) {
+	Catalog::GetCatalog(context).ScanSchemas(context, [&](CatalogEntry *entry) {
 		result->entries.push_back((SchemaCatalogEntry *)entry);
 	});
 	// get the temp schema as well

--- a/src/function/table/information_schema/information_schema_schemata.cpp
+++ b/src/function/table/information_schema/information_schema_schemata.cpp
@@ -51,9 +51,8 @@ information_schema_schemata_init(ClientContext &context, const FunctionData *bin
 	auto result = make_unique<InformationSchemaSchemataData>();
 
 	// scan all the schemas and collect them
-	Catalog::GetCatalog(context).ScanSchemas(context, [&](CatalogEntry *entry) {
-		result->entries.push_back((SchemaCatalogEntry *)entry);
-	});
+	Catalog::GetCatalog(context).ScanSchemas(
+	    context, [&](CatalogEntry *entry) { result->entries.push_back((SchemaCatalogEntry *)entry); });
 	// get the temp schema as well
 	result->entries.push_back(context.temporary_objects.get());
 
@@ -70,7 +69,7 @@ void information_schema_schemata(ClientContext &context, const FunctionData *bin
 	// start returning values
 	// either fill up the chunk or return all the remaining columns
 	idx_t count = 0;
-	while(data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
 		auto &entry = data.entries[data.offset++];
 
 		// return values:

--- a/src/function/table/information_schema/information_schema_schemata.cpp
+++ b/src/function/table/information_schema/information_schema_schemata.cpp
@@ -53,8 +53,9 @@ information_schema_schemata_init(ClientContext &context, const FunctionData *bin
 
 	// scan all the schemas and collect them
 	auto &transaction = Transaction::GetTransaction(context);
-	Catalog::GetCatalog(context).schemas->Scan(
-	    transaction, [&](CatalogEntry *entry) { result->entries.push_back((SchemaCatalogEntry *)entry); });
+	Catalog::GetCatalog(context).ScanSchemas(transaction, [&](CatalogEntry *entry) {
+		result->entries.push_back((SchemaCatalogEntry *)entry);
+	});
 	// get the temp schema as well
 	result->entries.push_back(context.temporary_objects.get());
 
@@ -68,32 +69,30 @@ void information_schema_schemata(ClientContext &context, const FunctionData *bin
 		// finished returning values
 		return;
 	}
-	idx_t next = min(data.offset + STANDARD_VECTOR_SIZE, (idx_t)data.entries.size());
-	output.SetCardinality(next - data.offset);
-
 	// start returning values
 	// either fill up the chunk or return all the remaining columns
-	for (idx_t i = data.offset; i < next; i++) {
-		auto index = i - data.offset;
-		auto &entry = data.entries[i];
+	idx_t count = 0;
+	while(data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.entries[data.offset++];
 
 		// return values:
 		// "catalog_name", PhysicalType::VARCHAR
-		output.SetValue(0, index, Value());
+		output.SetValue(0, count, Value());
 		// "schema_name", PhysicalType::VARCHAR
-		output.SetValue(1, index, Value(entry->name));
+		output.SetValue(1, count, Value(entry->name));
 		// "schema_owner", PhysicalType::VARCHAR
-		output.SetValue(2, index, Value());
+		output.SetValue(2, count, Value());
 		// "default_character_set_catalog", PhysicalType::VARCHAR
-		output.SetValue(3, index, Value());
+		output.SetValue(3, count, Value());
 		// "default_character_set_schema", PhysicalType::VARCHAR
-		output.SetValue(4, index, Value());
+		output.SetValue(4, count, Value());
 		// "default_character_set_name", PhysicalType::VARCHAR
-		output.SetValue(5, index, Value());
+		output.SetValue(5, count, Value());
 		// "sql_path", PhysicalType::VARCHAR
-		output.SetValue(6, index, Value());
+		output.SetValue(6, count, Value());
+		count++;
 	}
-	data.offset = next;
+	output.SetCardinality(count);
 }
 
 void InformationSchemaSchemata::RegisterFunction(BuiltinFunctions &set) {

--- a/src/function/table/information_schema/information_schema_tables.cpp
+++ b/src/function/table/information_schema/information_schema_tables.cpp
@@ -67,14 +67,13 @@ information_schema_tables_init(ClientContext &context, const FunctionData *bind_
 	auto result = make_unique<InformationSchemaTablesData>();
 
 	// scan all the schemas for tables and views and collect them
-	auto &transaction = Transaction::GetTransaction(context);
-	Catalog::GetCatalog(context).schemas->Scan(transaction, [&](CatalogEntry *entry) {
+	Catalog::GetCatalog(context).schemas->Scan(context, [&](CatalogEntry *entry) {
 		auto schema = (SchemaCatalogEntry *)entry;
-		schema->tables.Scan(transaction, [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+		schema->tables.Scan(context, [&](CatalogEntry *entry) { result->entries.push_back(entry); });
 	});
 
 	// check the temp schema as well
-	context.temporary_objects->tables.Scan(transaction, [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+	context.temporary_objects->tables.Scan(context, [&](CatalogEntry *entry) { result->entries.push_back(entry); });
 	return move(result);
 }
 

--- a/src/function/table/sqlite/pragma_collations.cpp
+++ b/src/function/table/sqlite/pragma_collations.cpp
@@ -46,7 +46,7 @@ static void pragma_collate(ClientContext &context, const FunctionData *bind_data
 		// finished returning values
 		return;
 	}
-	idx_t next = min(data.offset + STANDARD_VECTOR_SIZE, (idx_t)data.entries.size());
+	idx_t next = MinValue<idx_t>(data.offset + STANDARD_VECTOR_SIZE, data.entries.size());
 	output.SetCardinality(next - data.offset);
 	for (idx_t i = data.offset; i < next; i++) {
 		auto index = i - data.offset;

--- a/src/function/table/sqlite/pragma_collations.cpp
+++ b/src/function/table/sqlite/pragma_collations.cpp
@@ -4,7 +4,6 @@
 #include "duckdb/catalog/catalog_entry/collate_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/common/exception.hpp"
-#include "duckdb/transaction/transaction.hpp"
 
 using namespace std;
 
@@ -32,10 +31,9 @@ unique_ptr<FunctionOperatorData> pragma_collate_init(ClientContext &context, con
                                                      unordered_map<idx_t, vector<TableFilter>> &table_filters) {
 	auto result = make_unique<PragmaCollateData>();
 
-	auto &transaction = Transaction::GetTransaction(context);
-	Catalog::GetCatalog(context).schemas->Scan(transaction, [&](CatalogEntry *entry) {
+	Catalog::GetCatalog(context).schemas->Scan(context, [&](CatalogEntry *entry) {
 		auto schema = (SchemaCatalogEntry *)entry;
-		schema->collations.Scan(transaction, [&](CatalogEntry *entry) { result->entries.push_back(entry->name); });
+		schema->collations.Scan(context, [&](CatalogEntry *entry) { result->entries.push_back(entry->name); });
 	});
 
 	return move(result);

--- a/src/function/table/sqlite/sqlite_master.cpp
+++ b/src/function/table/sqlite/sqlite_master.cpp
@@ -65,7 +65,7 @@ void sqlite_master(ClientContext &context, const FunctionData *bind_data, Functi
 	// start returning values
 	// either fill up the chunk or return all the remaining columns
 	idx_t count = 0;
-	while(data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
 		auto &entry = data.entries[data.offset++];
 		if (entry->internal) {
 			continue;

--- a/src/function/table/sqlite/sqlite_master.cpp
+++ b/src/function/table/sqlite/sqlite_master.cpp
@@ -4,7 +4,6 @@
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/common/exception.hpp"
-#include "duckdb/transaction/transaction.hpp"
 
 #include <algorithm>
 
@@ -47,10 +46,9 @@ unique_ptr<FunctionOperatorData> sqlite_master_init(ClientContext &context, cons
 	auto result = make_unique<SQLiteMasterData>();
 
 	// scan all the schemas for tables and views and collect them
-	auto &transaction = Transaction::GetTransaction(context);
-	Catalog::GetCatalog(context).schemas->Scan(transaction, [&](CatalogEntry *entry) {
+	Catalog::GetCatalog(context).schemas->Scan(context, [&](CatalogEntry *entry) {
 		auto schema = (SchemaCatalogEntry *)entry;
-		schema->tables.Scan(transaction, [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+		schema->tables.Scan(context, [&](CatalogEntry *entry) { result->entries.push_back(entry); });
 	});
 
 	return move(result);

--- a/src/function/table/sqlite/sqlite_master.cpp
+++ b/src/function/table/sqlite/sqlite_master.cpp
@@ -63,14 +63,15 @@ void sqlite_master(ClientContext &context, const FunctionData *bind_data, Functi
 		// finished returning values
 		return;
 	}
-	idx_t next = min(data.offset + STANDARD_VECTOR_SIZE, (idx_t)data.entries.size());
-	output.SetCardinality(next - data.offset);
 
 	// start returning values
 	// either fill up the chunk or return all the remaining columns
-	for (idx_t i = data.offset; i < next; i++) {
-		auto index = i - data.offset;
-		auto &entry = data.entries[i];
+	idx_t count = 0;
+	while(data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.entries[data.offset++];
+		if (entry->internal) {
+			continue;
+		}
 
 		// return values:
 		// "type", PhysicalType::VARCHAR
@@ -91,17 +92,18 @@ void sqlite_master(ClientContext &context, const FunctionData *bind_data, Functi
 		default:
 			type_str = "unknown";
 		}
-		output.SetValue(0, index, Value(type_str));
+		output.SetValue(0, count, Value(type_str));
 		// "name", PhysicalType::VARCHAR
-		output.SetValue(1, index, Value(entry->name));
+		output.SetValue(1, count, Value(entry->name));
 		// "tbl_name", PhysicalType::VARCHAR
-		output.SetValue(2, index, Value(entry->name));
+		output.SetValue(2, count, Value(entry->name));
 		// "rootpage", PhysicalType::INT32
-		output.SetValue(3, index, Value::INTEGER(0));
+		output.SetValue(3, count, Value::INTEGER(0));
 		// "sql", PhysicalType::VARCHAR
-		output.SetValue(4, index, Value(entry->ToSQL()));
+		output.SetValue(4, count, Value(entry->ToSQL()));
+		count++;
 	}
-	data.offset = next;
+	output.SetCardinality(count);
 }
 
 void SQLiteMaster::RegisterFunction(BuiltinFunctions &set) {

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -84,7 +84,7 @@ public:
 	//! Returns the schema object with the specified name, or throws an exception if it does not exist
 	SchemaCatalogEntry *GetSchema(ClientContext &context, const string &name = DEFAULT_SCHEMA);
 	//! Scans all the schemas in the system one-by-one, invoking the callback for each entry
-	void ScanSchemas(Transaction &transaction, std::function<void(CatalogEntry*)> callback);
+	void ScanSchemas(ClientContext &context, std::function<void(CatalogEntry*)> callback);
 	//! Gets the "schema.name" entry of the specified type, if if_exists=true returns nullptr if entry does not exist,
 	//! otherwise an exception is thrown
 	CatalogEntry *GetEntry(ClientContext &context, CatalogType type, string schema, const string &name,

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -86,7 +86,7 @@ public:
 	//! Returns the schema object with the specified name, or throws an exception if it does not exist
 	SchemaCatalogEntry *GetSchema(ClientContext &context, const string &name = DEFAULT_SCHEMA);
 	//! Scans all the schemas in the system one-by-one, invoking the callback for each entry
-	void ScanSchemas(ClientContext &context, std::function<void(CatalogEntry*)> callback);
+	void ScanSchemas(ClientContext &context, std::function<void(CatalogEntry *)> callback);
 	//! Gets the "schema.name" entry of the specified type, if if_exists=true returns nullptr if entry does not exist,
 	//! otherwise an exception is thrown
 	CatalogEntry *GetEntry(ClientContext &context, CatalogType type, string schema, const string &name,

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -11,6 +11,8 @@
 #include "duckdb/catalog/catalog_entry.hpp"
 #include "duckdb/common/mutex.hpp"
 
+#include <functional>
+
 namespace duckdb {
 struct CreateSchemaInfo;
 struct DropInfo;

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -83,6 +83,8 @@ public:
 
 	//! Returns the schema object with the specified name, or throws an exception if it does not exist
 	SchemaCatalogEntry *GetSchema(ClientContext &context, const string &name = DEFAULT_SCHEMA);
+	//! Scans all the schemas in the system one-by-one, invoking the callback for each entry
+	void ScanSchemas(Transaction &transaction, std::function<void(CatalogEntry*)> callback);
 	//! Gets the "schema.name" entry of the specified type, if if_exists=true returns nullptr if entry does not exist,
 	//! otherwise an exception is thrown
 	CatalogEntry *GetEntry(ClientContext &context, CatalogType type, string schema, const string &name,

--- a/src/include/duckdb/catalog/catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry.hpp
@@ -23,7 +23,8 @@ class ClientContext;
 class CatalogEntry {
 public:
 	CatalogEntry(CatalogType type, Catalog *catalog, string name)
-	    : type(type), catalog(catalog), set(nullptr), name(name), deleted(false), temporary(false), internal(false), parent(nullptr) {
+	    : type(type), catalog(catalog), set(nullptr), name(name), deleted(false), temporary(false), internal(false),
+	      parent(nullptr) {
 	}
 	virtual ~CatalogEntry();
 

--- a/src/include/duckdb/catalog/catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry.hpp
@@ -23,7 +23,7 @@ class ClientContext;
 class CatalogEntry {
 public:
 	CatalogEntry(CatalogType type, Catalog *catalog, string name)
-	    : type(type), catalog(catalog), set(nullptr), name(name), deleted(false), temporary(false), parent(nullptr) {
+	    : type(type), catalog(catalog), set(nullptr), name(name), deleted(false), temporary(false), internal(false), parent(nullptr) {
 	}
 	virtual ~CatalogEntry();
 
@@ -55,6 +55,8 @@ public:
 	bool deleted;
 	//! Whether or not the object is temporary and should not be added to the WAL
 	bool temporary;
+	//! Whether or not the entry is an internal entry (cannot be deleted, not dumped, etc)
+	bool internal;
 	//! Timestamp at which the catalog entry was created
 	transaction_t timestamp;
 	//! Child entry

--- a/src/include/duckdb/catalog/catalog_entry/schema_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/schema_catalog_entry.hpp
@@ -40,7 +40,7 @@ struct DropInfo;
 //! A schema in the catalog
 class SchemaCatalogEntry : public CatalogEntry {
 public:
-	SchemaCatalogEntry(Catalog *catalog, string name);
+	SchemaCatalogEntry(Catalog *catalog, string name, bool is_internal);
 
 	//! The catalog set holding the tables
 	CatalogSet tables;

--- a/src/include/duckdb/catalog/catalog_entry/schema_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/schema_catalog_entry.hpp
@@ -96,8 +96,6 @@ public:
 	string ToSQL() override;
 
 private:
-	//! Creates a default catalog entry (if it has not been created yet). Returns nullptr if no default entry with "entry_name" exists.
-	CatalogEntry *CreateDefaultEntry(ClientContext &context, CatalogType type, const string &entry_name);
 	//! Add a catalog entry to this schema
 	CatalogEntry *AddEntry(ClientContext &context, unique_ptr<StandardEntry> entry, OnCreateConflict on_conflict);
 	//! Add a catalog entry to this schema

--- a/src/include/duckdb/catalog/catalog_entry/schema_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/schema_catalog_entry.hpp
@@ -96,6 +96,8 @@ public:
 	string ToSQL() override;
 
 private:
+	//! Creates a default catalog entry (if it has not been created yet). Returns nullptr if no default entry with "entry_name" exists.
+	CatalogEntry *CreateDefaultEntry(ClientContext &context, CatalogType type, const string &entry_name);
 	//! Add a catalog entry to this schema
 	CatalogEntry *AddEntry(ClientContext &context, unique_ptr<StandardEntry> entry, OnCreateConflict on_conflict);
 	//! Add a catalog entry to this schema

--- a/src/include/duckdb/catalog/catalog_set.hpp
+++ b/src/include/duckdb/catalog/catalog_set.hpp
@@ -36,6 +36,10 @@ public:
 	bool CreateEntry(Transaction &transaction, const string &name, unique_ptr<CatalogEntry> value,
 	                 unordered_set<CatalogEntry *> &dependencies);
 
+	//! Creates an entry in the catalog without any transactional semantics (i.e. it is instantly committed)
+	//! Returns either the entry as written, or the entry that was already there (if any)
+	CatalogEntry* CreateEntry(const string &name, unique_ptr<CatalogEntry> value);
+
 	bool AlterEntry(ClientContext &context, const string &name, AlterInfo *alter_info);
 
 	bool DropEntry(Transaction &transaction, const string &name, bool cascade);

--- a/src/include/duckdb/catalog/default/default_generator.hpp
+++ b/src/include/duckdb/catalog/default/default_generator.hpp
@@ -15,10 +15,13 @@ class ClientContext;
 
 class DefaultGenerator {
 public:
-	DefaultGenerator(Catalog &catalog) : catalog(catalog) {}
-	virtual ~DefaultGenerator(){}
+	DefaultGenerator(Catalog &catalog) : catalog(catalog) {
+	}
+	virtual ~DefaultGenerator() {
+	}
 
 	Catalog &catalog;
+
 public:
 	//! Creates a default entry with the specified name, or returns nullptr if no such entry can be generated
 	virtual unique_ptr<CatalogEntry> CreateDefaultEntry(ClientContext &context, const string &entry_name) = 0;

--- a/src/include/duckdb/catalog/default/default_generator.hpp
+++ b/src/include/duckdb/catalog/default/default_generator.hpp
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/catalog/default/default_generator.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/catalog/catalog_entry.hpp"
+
+namespace duckdb {
+class ClientContext;
+
+class DefaultGenerator {
+public:
+	DefaultGenerator(Catalog &catalog) : catalog(catalog) {}
+	virtual ~DefaultGenerator(){}
+
+	Catalog &catalog;
+public:
+	//! Creates a default entry with the specified name, or returns nullptr if no such entry can be generated
+	virtual unique_ptr<CatalogEntry> CreateDefaultEntry(ClientContext &context, const string &entry_name) = 0;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/catalog/default/default_schemas.hpp
+++ b/src/include/duckdb/catalog/default/default_schemas.hpp
@@ -8,12 +8,15 @@
 
 #pragma once
 
-#include "duckdb/parser/parsed_data/create_view_info.hpp"
+#include "duckdb/catalog/default/default_generator.hpp"
 
 namespace duckdb {
 
-struct DefaultSchemas {
-	static bool GetDefaultSchema(string schema);
+class DefaultSchemaGenerator : public DefaultGenerator {
+public:
+	DefaultSchemaGenerator(Catalog &catalog);
+public:
+	unique_ptr<CatalogEntry> CreateDefaultEntry(ClientContext &context, const string &entry_name) override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/catalog/default/default_schemas.hpp
+++ b/src/include/duckdb/catalog/default/default_schemas.hpp
@@ -15,6 +15,7 @@ namespace duckdb {
 class DefaultSchemaGenerator : public DefaultGenerator {
 public:
 	DefaultSchemaGenerator(Catalog &catalog);
+
 public:
 	unique_ptr<CatalogEntry> CreateDefaultEntry(ClientContext &context, const string &entry_name) override;
 };

--- a/src/include/duckdb/catalog/default/default_schemas.hpp
+++ b/src/include/duckdb/catalog/default/default_schemas.hpp
@@ -1,7 +1,7 @@
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// duckdb/catalog/default_views.hpp
+// duckdb/catalog/default/default_schemas.hpp
 //
 //
 //===----------------------------------------------------------------------===//
@@ -12,8 +12,8 @@
 
 namespace duckdb {
 
-struct DefaultViews {
-	static unique_ptr<CreateViewInfo> GetDefaultView(string name);
+struct DefaultSchemas {
+	static bool GetDefaultSchema(string schema);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/catalog/default/default_views.hpp
+++ b/src/include/duckdb/catalog/default/default_views.hpp
@@ -19,6 +19,7 @@ public:
 	DefaultViewGenerator(Catalog &catalog, SchemaCatalogEntry *schema);
 
 	SchemaCatalogEntry *schema;
+
 public:
 	unique_ptr<CatalogEntry> CreateDefaultEntry(ClientContext &context, const string &entry_name) override;
 };

--- a/src/include/duckdb/catalog/default/default_views.hpp
+++ b/src/include/duckdb/catalog/default/default_views.hpp
@@ -9,11 +9,18 @@
 #pragma once
 
 #include "duckdb/parser/parsed_data/create_view_info.hpp"
+#include "duckdb/catalog/default/default_generator.hpp"
 
 namespace duckdb {
+class SchemaCatalogEntry;
 
-struct DefaultViews {
-	static unique_ptr<CreateViewInfo> GetDefaultView(string schema, string name);
+class DefaultViewGenerator : public DefaultGenerator {
+public:
+	DefaultViewGenerator(Catalog &catalog, SchemaCatalogEntry *schema);
+
+	SchemaCatalogEntry *schema;
+public:
+	unique_ptr<CatalogEntry> CreateDefaultEntry(ClientContext &context, const string &entry_name) override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/catalog/default/default_views.hpp
+++ b/src/include/duckdb/catalog/default/default_views.hpp
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/catalog/default/default_views.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/parser/parsed_data/create_view_info.hpp"
+
+namespace duckdb {
+
+struct DefaultViews {
+	static unique_ptr<CreateViewInfo> GetDefaultView(string schema, string name);
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/catalog/default_views.hpp
+++ b/src/include/duckdb/catalog/default_views.hpp
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/catalog/default_views.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/parser/parsed_data/create_view_info.hpp"
+
+namespace duckdb {
+
+struct DefaultViews {
+	static unique_ptr<CreateViewInfo> GetDefaultView(string name);
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/catalog/dependency_manager.hpp
+++ b/src/include/duckdb/catalog/dependency_manager.hpp
@@ -13,7 +13,7 @@
 
 namespace duckdb {
 class Catalog;
-class Transaction;
+class ClientContext;
 
 //! The DependencyManager is in charge of managing dependencies between catalog entries
 class DependencyManager {
@@ -37,9 +37,9 @@ private:
 	unordered_map<CatalogEntry *, unordered_set<CatalogEntry *>> dependencies_map;
 
 private:
-	void AddObject(Transaction &transaction, CatalogEntry *object, unordered_set<CatalogEntry *> &dependencies);
-	void DropObject(Transaction &transaction, CatalogEntry *object, bool cascade, set_lock_map_t &lock_set);
-	void AlterObject(Transaction &transaction, CatalogEntry *old_obj, CatalogEntry *new_obj);
+	void AddObject(ClientContext &context, CatalogEntry *object, unordered_set<CatalogEntry *> &dependencies);
+	void DropObject(ClientContext &context, CatalogEntry *object, bool cascade, set_lock_map_t &lock_set);
+	void AlterObject(ClientContext &context, CatalogEntry *old_obj, CatalogEntry *new_obj);
 	void EraseObjectInternal(CatalogEntry *object);
 };
 } // namespace duckdb

--- a/src/include/duckdb/parser/parsed_data/create_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_info.hpp
@@ -24,7 +24,7 @@ enum class OnCreateConflict : uint8_t {
 
 struct CreateInfo : public ParseInfo {
 	CreateInfo(CatalogType type, string schema = DEFAULT_SCHEMA)
-	    : type(type), schema(schema), on_conflict(OnCreateConflict::ERROR_ON_CONFLICT), temporary(false) {
+	    : type(type), schema(schema), on_conflict(OnCreateConflict::ERROR_ON_CONFLICT), temporary(false), internal(false) {
 	}
 	virtual ~CreateInfo() {
 	}
@@ -37,6 +37,8 @@ struct CreateInfo : public ParseInfo {
 	OnCreateConflict on_conflict;
 	//! Whether or not the entry is temporary
 	bool temporary;
+	//! Whether or not the entry is an internal entry
+	bool internal;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/parsed_data/create_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_info.hpp
@@ -24,7 +24,8 @@ enum class OnCreateConflict : uint8_t {
 
 struct CreateInfo : public ParseInfo {
 	CreateInfo(CatalogType type, string schema = DEFAULT_SCHEMA)
-	    : type(type), schema(schema), on_conflict(OnCreateConflict::ERROR_ON_CONFLICT), temporary(false), internal(false) {
+	    : type(type), schema(schema), on_conflict(OnCreateConflict::ERROR_ON_CONFLICT), temporary(false),
+	      internal(false) {
 	}
 	virtual ~CreateInfo() {
 	}

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -79,6 +79,7 @@ public:
 	BoundStatement Bind(QueryNode &node);
 
 	unique_ptr<BoundCreateTableInfo> BindCreateTableInfo(unique_ptr<CreateInfo> info);
+	void BindCreateViewInfo(CreateViewInfo &base);
 	SchemaCatalogEntry *BindSchema(CreateInfo &info);
 
 	unique_ptr<BoundTableRef> Bind(TableRef &ref);

--- a/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
@@ -21,7 +21,7 @@ public:
 	TableDataWriter(CheckpointManager &manager, TableCatalogEntry &table);
 	~TableDataWriter();
 
-	void WriteTableData(Transaction &transaction);
+	void WriteTableData(ClientContext &context);
 
 private:
 	void AppendData(Transaction &transaction, idx_t col_idx, Vector &data, idx_t count);

--- a/src/include/duckdb/storage/checkpoint_manager.hpp
+++ b/src/include/duckdb/storage/checkpoint_manager.hpp
@@ -59,8 +59,8 @@ public:
 	unique_ptr<MetaBlockWriter> tabledata_writer;
 
 private:
-	void WriteSchema(Transaction &transaction, SchemaCatalogEntry &schema);
-	void WriteTable(Transaction &transaction, TableCatalogEntry &table);
+	void WriteSchema(ClientContext &context, SchemaCatalogEntry &schema);
+	void WriteTable(ClientContext &context, TableCatalogEntry &table);
 	void WriteView(ViewCatalogEntry &table);
 	void WriteSequence(SequenceCatalogEntry &table);
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -36,7 +36,8 @@ namespace duckdb {
 
 ClientContext::ClientContext(DuckDB &database)
     : db(database), transaction(*database.transaction_manager), interrupted(false), executor(*this),
-      catalog(*database.catalog), temporary_objects(make_unique<SchemaCatalogEntry>(db.catalog.get(), TEMP_SCHEMA, true)),
+      catalog(*database.catalog),
+      temporary_objects(make_unique<SchemaCatalogEntry>(db.catalog.get(), TEMP_SCHEMA, true)),
       prepared_statements(make_unique<CatalogSet>(*db.catalog)), open_result(nullptr) {
 	random_device rd;
 	random_engine.seed(rd());

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -36,7 +36,7 @@ namespace duckdb {
 
 ClientContext::ClientContext(DuckDB &database)
     : db(database), transaction(*database.transaction_manager), interrupted(false), executor(*this),
-      catalog(*database.catalog), temporary_objects(make_unique<SchemaCatalogEntry>(db.catalog.get(), TEMP_SCHEMA)),
+      catalog(*database.catalog), temporary_objects(make_unique<SchemaCatalogEntry>(db.catalog.get(), TEMP_SCHEMA, true)),
       prepared_statements(make_unique<CatalogSet>(*db.catalog)), open_result(nullptr) {
 	random_device rd;
 	random_engine.seed(rd());

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -40,6 +40,21 @@ SchemaCatalogEntry *Binder::BindSchema(CreateInfo &info) {
 	return schema_obj;
 }
 
+void Binder::BindCreateViewInfo(CreateViewInfo &base) {
+	// bind the view as if it were a query so we can catch errors
+	// note that we bind a copy and don't actually use the bind result
+	auto copy = base.query->Copy();
+	auto query_node = Bind(*copy);
+	if (base.aliases.size() > query_node.names.size()) {
+		throw BinderException("More VIEW aliases than columns in query result");
+	}
+	// fill up the aliases with the remaining names of the bound query
+	for (idx_t i = base.aliases.size(); i < query_node.names.size(); i++) {
+		base.aliases.push_back(query_node.names[i]);
+	}
+	base.types = query_node.types;
+}
+
 BoundStatement Binder::Bind(CreateStatement &stmt) {
 	BoundStatement result;
 	result.names = {"Count"};
@@ -59,18 +74,7 @@ BoundStatement Binder::Bind(CreateStatement &stmt) {
 		// bind the schema
 		auto schema = BindSchema(*stmt.info);
 
-		// bind the view as if it were a query so we can catch errors
-		// note that we bind a copy and don't actually use the bind result
-		auto copy = base.query->Copy();
-		auto query_node = Bind(*copy);
-		if (base.aliases.size() > query_node.names.size()) {
-			throw BinderException("More VIEW aliases than columns in query result");
-		}
-		// fill up the aliases with the remaining names of the bound query
-		for (idx_t i = base.aliases.size(); i < query_node.names.size(); i++) {
-			base.aliases.push_back(query_node.names[i]);
-		}
-		base.types = query_node.types;
+		BindCreateViewInfo(base);
 		result.plan = make_unique<LogicalCreate>(LogicalOperatorType::CREATE_VIEW, move(stmt.info), schema);
 		break;
 	}

--- a/src/planner/binder/statement/bind_execute.cpp
+++ b/src/planner/binder/statement/bind_execute.cpp
@@ -13,8 +13,7 @@ BoundStatement Binder::Bind(ExecuteStatement &stmt) {
 	BoundStatement result;
 
 	// bind the prepared statement
-	auto entry =
-	    (PreparedStatementCatalogEntry *)context.prepared_statements->GetEntry(context, stmt.name);
+	auto entry = (PreparedStatementCatalogEntry *)context.prepared_statements->GetEntry(context, stmt.name);
 	if (!entry || entry->deleted) {
 		throw BinderException("Could not find prepared statement with that name");
 	}

--- a/src/planner/binder/statement/bind_execute.cpp
+++ b/src/planner/binder/statement/bind_execute.cpp
@@ -14,7 +14,7 @@ BoundStatement Binder::Bind(ExecuteStatement &stmt) {
 
 	// bind the prepared statement
 	auto entry =
-	    (PreparedStatementCatalogEntry *)context.prepared_statements->GetEntry(context.ActiveTransaction(), stmt.name);
+	    (PreparedStatementCatalogEntry *)context.prepared_statements->GetEntry(context, stmt.name);
 	if (!entry || entry->deleted) {
 		throw BinderException("Could not find prepared statement with that name");
 	}

--- a/src/planner/binder/statement/bind_export.cpp
+++ b/src/planner/binder/statement/bind_export.cpp
@@ -6,7 +6,6 @@
 #include "duckdb/parser/statement/copy_statement.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/database.hpp"
-#include "duckdb/transaction/transaction.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/planner/operator/logical_set_operation.hpp"
 
@@ -32,11 +31,10 @@ BoundStatement Binder::Bind(ExportStatement &stmt) {
 	}
 
 	// gather a list of all the tables
-	auto &transaction = Transaction::GetTransaction(context);
 	vector<TableCatalogEntry *> tables;
-	Catalog::GetCatalog(context).schemas->Scan(transaction, [&](CatalogEntry *entry) {
+	Catalog::GetCatalog(context).schemas->Scan(context, [&](CatalogEntry *entry) {
 		auto schema = (SchemaCatalogEntry *)entry;
-		schema->tables.Scan(transaction, [&](CatalogEntry *entry) {
+		schema->tables.Scan(context, [&](CatalogEntry *entry) {
 			if (entry->type == CatalogType::TABLE_ENTRY) {
 				tables.push_back((TableCatalogEntry *)entry);
 			}

--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/storage/numeric_segment.hpp"
 #include "duckdb/storage/string_segment.hpp"
 #include "duckdb/storage/table/column_segment.hpp"
+#include "duckdb/transaction/transaction.hpp"
 
 namespace duckdb {
 using namespace std;
@@ -43,7 +44,8 @@ TableDataWriter::TableDataWriter(CheckpointManager &manager, TableCatalogEntry &
 TableDataWriter::~TableDataWriter() {
 }
 
-void TableDataWriter::WriteTableData(Transaction &transaction) {
+void TableDataWriter::WriteTableData(ClientContext &context) {
+	auto &transaction = Transaction::GetTransaction(context);
 	// allocate segments to write the table to
 	segments.resize(table.columns.size());
 	data_pointers.resize(table.columns.size());

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -110,8 +110,7 @@ void CheckpointManager::WriteSchema(ClientContext &context, SchemaCatalogEntry &
 		}
 	});
 	vector<SequenceCatalogEntry *> sequences;
-	schema.sequences.Scan(context,
-	                      [&](CatalogEntry *entry) { sequences.push_back((SequenceCatalogEntry *)entry); });
+	schema.sequences.Scan(context, [&](CatalogEntry *entry) { sequences.push_back((SequenceCatalogEntry *)entry); });
 
 	// write the sequences
 	metadata_writer->Write<uint32_t>(sequences.size());

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -46,6 +46,7 @@ void StorageManager::Initialize() {
 	// create the default schema
 	CreateSchemaInfo info;
 	info.schema = DEFAULT_SCHEMA;
+	info.internal = true;
 	database.catalog->CreateSchema(context, &info);
 
 	// initialize default functions

--- a/test/sql/table_function/information_schema.test
+++ b/test/sql/table_function/information_schema.test
@@ -32,7 +32,7 @@ SELECT ordinal_position, column_name, data_type FROM information_schema_columns(
 1	i	INTEGER
 
 query ITT
-SELECT ordinal_position, column_name, data_type FROM information_schema.columns() WHERE table_name='integers'
+SELECT ordinal_position, column_name, data_type FROM information_schema.columns WHERE table_name='integers'
 ----
 1	i	INTEGER
 
@@ -63,7 +63,7 @@ SELECT table_type FROM information_schema_tables() WHERE table_schema='scheme' A
 VIEW
 
 query T
-SELECT table_type FROM information_schema.tables() WHERE table_schema='scheme' AND table_name='vintegers'
+SELECT table_type FROM information_schema.tables WHERE table_schema='scheme' AND table_name='vintegers'
 ----
 VIEW
 

--- a/test/sql/table_function/information_schema.test
+++ b/test/sql/table_function/information_schema.test
@@ -2,11 +2,13 @@
 # description: Test information_schema functions
 # group: [table_function]
 
-query TTTTTTT
+query TTTTTTT rowsort schema_list
+SELECT * FROM information_schema.schemata;
+----
+
+query TTTTTTT rowsort schema_list
 SELECT * FROM information_schema_schemata();
 ----
-NULL	main	NULL	NULL	NULL	NULL	NULL				
-NULL	temp	NULL	NULL	NULL	NULL	NULL
 
 statement ok
 CREATE SCHEMA scheme;
@@ -26,6 +28,11 @@ BASE TABLE
 
 query ITT
 SELECT ordinal_position, column_name, data_type FROM information_schema_columns() WHERE table_name='integers'
+----
+1	i	INTEGER
+
+query ITT
+SELECT ordinal_position, column_name, data_type FROM information_schema.columns() WHERE table_name='integers'
 ----
 1	i	INTEGER
 
@@ -52,6 +59,11 @@ CREATE VIEW scheme.vintegers AS SELECT * FROM scheme.integers;
 
 query T
 SELECT table_type FROM information_schema_tables() WHERE table_schema='scheme' AND table_name='vintegers'
+----
+VIEW
+
+query T
+SELECT table_type FROM information_schema.tables() WHERE table_schema='scheme' AND table_name='vintegers'
 ----
 VIEW
 

--- a/test/sql/table_function/sqlite_master.test
+++ b/test/sql/table_function/sqlite_master.test
@@ -6,6 +6,11 @@ statement ok
 CREATE TABLE integers(i INTEGER);
 
 query IIIII
+SELECT * FROM sqlite_master;
+----
+table	integers	integers	0	CREATE TABLE integers(i INTEGER);
+
+query IIIII
 SELECT * FROM sqlite_master();
 ----
 table	integers	integers	0	CREATE TABLE integers(i INTEGER);
@@ -19,7 +24,6 @@ query I
 SELECT EXISTS(SELECT * FROM sqlite_master() OFFSET 1)
 ----
 0
-
 
 query I
 SELECT COUNT(*) FROM sqlite_master() WHERE name='test'

--- a/test/sql/table_function/sqlite_master_connections.test
+++ b/test/sql/table_function/sqlite_master_connections.test
@@ -1,0 +1,27 @@
+# name: test/sql/table_function/sqlite_master_connections.test
+# description: Use the internal sqlite_master view from different tables
+# group: [table_function]
+
+statement ok con1
+BEGIN TRANSACTION
+
+statement ok con2
+BEGIN TRANSACTION
+
+statement ok con1
+SELECT * FROM sqlite_master;
+
+statement ok con2
+SELECT * FROM sqlite_master;
+
+statement ok con1
+ROLLBACK
+
+statement ok con2
+ROLLBACK
+
+statement ok
+SELECT * FROM sqlite_master;
+
+statement error
+DROP VIEW sqlite_master


### PR DESCRIPTION
This PR introduces the concept of *default catalog generators*. Default catalog generators can be set in a CatalogSet, and can be used to lazily generate catalog entries when no matching entry is found. The idea behind these is that we can define internal systems schemas, views, functions, etc without requiring them to be explicitly loaded into the system on startup. Instead, they can be lazily loaded when accessed. The benefit here is that adding more internal structures will not slow down database startup speed, and we can freely add as many internal functions, views, etc as we want without worrying. 

This PR specifically introduces lazy schemas and lazy views, and adds the `sqlite_master`, `information_schema.columns`, `information_schema.tables` and `information_schema.columns` views. In the future, we want all built-in catalog entries (including scalar functions, aggregates and table functions) to use the same infrastructure rather than loading everything up-front (as is currently done). 