### PR TITLE
Improved Error Messages

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -162,7 +162,7 @@ CatalogEntry *Catalog::GetEntry(ClientContext &context, CatalogType type, string
 }
 
 template <>
-ViewCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists) {
+ViewCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists, QueryErrorContext error_context) {
 	auto entry = GetEntry(context, CatalogType::VIEW_ENTRY, move(schema_name), name, if_exists);
 	if (!entry) {
 		return nullptr;
@@ -174,7 +174,7 @@ ViewCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, 
 }
 
 template <>
-TableCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists) {
+TableCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists, QueryErrorContext error_context) {
 	auto entry = GetEntry(context, CatalogType::TABLE_ENTRY, move(schema_name), name, if_exists);
 	if (!entry) {
 		return nullptr;
@@ -187,35 +187,35 @@ TableCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name,
 
 template <>
 SequenceCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name,
-                                        bool if_exists) {
-	return (SequenceCatalogEntry *)GetEntry(context, CatalogType::SEQUENCE_ENTRY, move(schema_name), name, if_exists);
+                                        bool if_exists, QueryErrorContext error_context) {
+	return (SequenceCatalogEntry *)GetEntry(context, CatalogType::SEQUENCE_ENTRY, move(schema_name), name, if_exists, error_context);
 }
 
 template <>
 TableFunctionCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name,
-                                             bool if_exists) {
+                                             bool if_exists, QueryErrorContext error_context) {
 	return (TableFunctionCatalogEntry *)GetEntry(context, CatalogType::TABLE_FUNCTION_ENTRY, move(schema_name), name,
-	                                             if_exists);
+	                                             if_exists, error_context);
 }
 
 template <>
 CopyFunctionCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name,
-                                            bool if_exists) {
+                                            bool if_exists, QueryErrorContext error_context) {
 	return (CopyFunctionCatalogEntry *)GetEntry(context, CatalogType::COPY_FUNCTION_ENTRY, move(schema_name), name,
-	                                            if_exists);
+	                                            if_exists, error_context);
 }
 
 template <>
 PragmaFunctionCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name,
-                                              bool if_exists) {
+                                              bool if_exists, QueryErrorContext error_context) {
 	return (PragmaFunctionCatalogEntry *)GetEntry(context, CatalogType::PRAGMA_FUNCTION_ENTRY, move(schema_name), name,
-	                                              if_exists);
+	                                              if_exists, error_context);
 }
 
 template <>
 AggregateFunctionCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name,
-                                                 bool if_exists) {
-	auto entry = GetEntry(context, CatalogType::AGGREGATE_FUNCTION_ENTRY, move(schema_name), name, if_exists);
+                                                 bool if_exists, QueryErrorContext error_context) {
+	auto entry = GetEntry(context, CatalogType::AGGREGATE_FUNCTION_ENTRY, move(schema_name), name, if_exists, error_context);
 	if (entry->type != CatalogType::AGGREGATE_FUNCTION_ENTRY) {
 		throw CatalogException("%s is not an aggregate function", name);
 	}
@@ -223,8 +223,8 @@ AggregateFunctionCatalogEntry *Catalog::GetEntry(ClientContext &context, string 
 }
 
 template <>
-CollateCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists) {
-	return (CollateCatalogEntry *)GetEntry(context, CatalogType::COLLATION_ENTRY, move(schema_name), name, if_exists);
+CollateCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists, QueryErrorContext error_context) {
+	return (CollateCatalogEntry *)GetEntry(context, CatalogType::COLLATION_ENTRY, move(schema_name), name, if_exists, error_context);
 }
 
 void Catalog::Alter(ClientContext &context, AlterInfo *info) {

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -126,7 +126,8 @@ void Catalog::DropEntry(ClientContext &context, DropInfo *info) {
 	}
 }
 
-SchemaCatalogEntry *Catalog::GetSchema(ClientContext &context, const string &schema_name, QueryErrorContext error_context) {
+SchemaCatalogEntry *Catalog::GetSchema(ClientContext &context, const string &schema_name,
+                                       QueryErrorContext error_context) {
 	if (schema_name == INVALID_SCHEMA) {
 		throw CatalogException("Schema not specified");
 	}

--- a/src/catalog/catalog_entry/schema_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/schema_catalog_entry.cpp
@@ -181,7 +181,8 @@ CatalogEntry *SchemaCatalogEntry::GetEntry(ClientContext &context, CatalogType t
 			if (!entry.empty()) {
 				did_you_mean = "\nDid you mean \"" + entry + "\"?";
 			}
-			throw CatalogException(error_context.FormatError("%s with name %s does not exist!%s", CatalogTypeToString(type), entry_name, did_you_mean));
+			throw CatalogException(error_context.FormatError("%s with name %s does not exist!%s",
+			                                                 CatalogTypeToString(type), entry_name, did_you_mean));
 		}
 		return nullptr;
 	}

--- a/src/catalog/catalog_entry/schema_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/schema_catalog_entry.cpp
@@ -170,7 +170,7 @@ void SchemaCatalogEntry::Alter(ClientContext &context, AlterInfo *info) {
 }
 
 CatalogEntry *SchemaCatalogEntry::GetEntry(ClientContext &context, CatalogType type, const string &entry_name,
-                                           bool if_exists) {
+                                           bool if_exists, QueryErrorContext error_context) {
 	auto &set = GetCatalogSet(type);
 
 	auto entry = set.GetEntry(context, entry_name);
@@ -181,7 +181,7 @@ CatalogEntry *SchemaCatalogEntry::GetEntry(ClientContext &context, CatalogType t
 			if (!entry.empty()) {
 				did_you_mean = "\nDid you mean \"" + entry + "\"?";
 			}
-			throw CatalogException("%s with name %s does not exist!%s", CatalogTypeToString(type), entry_name, did_you_mean);
+			throw CatalogException(error_context.FormatError("%s with name %s does not exist!%s", CatalogTypeToString(type), entry_name, did_you_mean));
 		}
 		return nullptr;
 	}

--- a/src/catalog/catalog_entry/schema_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/schema_catalog_entry.cpp
@@ -176,7 +176,12 @@ CatalogEntry *SchemaCatalogEntry::GetEntry(ClientContext &context, CatalogType t
 	auto entry = set.GetEntry(context, entry_name);
 	if (!entry) {
 		if (!if_exists) {
-			throw CatalogException("%s with name %s does not exist!", CatalogTypeToString(type), entry_name);
+			auto entry = set.SimilarEntry(entry_name);
+			string did_you_mean;
+			if (!entry.empty()) {
+				did_you_mean = "\nDid you mean \"" + entry + "\"?";
+			}
+			throw CatalogException("%s with name %s does not exist!%s", CatalogTypeToString(type), entry_name, did_you_mean);
 		}
 		return nullptr;
 	}

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -239,8 +239,8 @@ string CatalogSet::SimilarEntry(const string &name) {
 	lock_guard<mutex> lock(catalog_lock);
 
 	string result;
-	idx_t current_score = (idx_t) -1;
-	for(auto &kv : mapping) {
+	idx_t current_score = (idx_t)-1;
+	for (auto &kv : mapping) {
 		auto ldist = StringUtil::LevenshteinDistance(kv.first, name);
 		if (ldist < current_score) {
 			current_score = ldist;

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -5,22 +5,23 @@ add_subdirectory(types)
 add_subdirectory(value_operations)
 add_subdirectory(vector_operations)
 
-add_library_unity(duckdb_common
-                  OBJECT
-                  constants.cpp
-                  checksum.cpp
-                  exception.cpp
-                  exception_format_value.cpp
-                  file_buffer.cpp
-                  file_system.cpp
-                  gzip_stream.cpp
-                  limits.cpp
-                  printer.cpp
-                  serializer.cpp
-                  string_util.cpp
-                  symbols.cpp
-                  types.cpp
-                  fstream_util.cpp)
+add_library_unity(
+  duckdb_common
+  OBJECT
+  constants.cpp
+  checksum.cpp
+  exception.cpp
+  exception_format_value.cpp
+  file_buffer.cpp
+  file_system.cpp
+  gzip_stream.cpp
+  limits.cpp
+  printer.cpp
+  serializer.cpp
+  string_util.cpp
+  symbols.cpp
+  types.cpp
+  fstream_util.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_common>
     PARENT_SCOPE)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library_unity(duckdb_common
                   constants.cpp
                   checksum.cpp
                   exception.cpp
+                  exception_format_value.cpp
                   file_buffer.cpp
                   file_system.cpp
                   gzip_stream.cpp

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -1,8 +1,6 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types.hpp"
-#include "fmt/format.h"
-#include "fmt/printf.h"
 
 namespace duckdb {
 using namespace std;
@@ -19,45 +17,8 @@ const char *Exception::what() const noexcept {
 	return exception_message_.c_str();
 }
 
-template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(PhysicalType value) {
-	return ExceptionFormatValue(TypeIdToString(value));
-}
-template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(LogicalType value) {
-	return ExceptionFormatValue(value.ToString());
-}
-template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(float value) {
-	return ExceptionFormatValue(double(value));
-}
-template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(double value) {
-	return ExceptionFormatValue(double(value));
-}
-template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(string value) {
-	return ExceptionFormatValue(string(value));
-}
-template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const char *value) {
-	return ExceptionFormatValue(string(value));
-}
-template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(char *value) {
-	return ExceptionFormatValue(string(value));
-}
-
 string Exception::ConstructMessageRecursive(string msg, vector<ExceptionFormatValue> &values) {
-	std::vector<duckdb_fmt::basic_format_arg<duckdb_fmt::printf_context>> format_args;
-	for (auto &val : values) {
-		switch (val.type) {
-		case ExceptionFormatValueType::FORMAT_VALUE_TYPE_DOUBLE:
-			format_args.push_back(duckdb_fmt::internal::make_arg<duckdb_fmt::printf_context>(val.dbl_val));
-			break;
-		case ExceptionFormatValueType::FORMAT_VALUE_TYPE_INTEGER:
-			format_args.push_back(duckdb_fmt::internal::make_arg<duckdb_fmt::printf_context>(val.int_val));
-			break;
-		case ExceptionFormatValueType::FORMAT_VALUE_TYPE_STRING:
-			format_args.push_back(duckdb_fmt::internal::make_arg<duckdb_fmt::printf_context>(val.str_val));
-			break;
-		}
-	}
-	return duckdb_fmt::vsprintf(msg, duckdb_fmt::basic_format_args<duckdb_fmt::printf_context>(
-	                                     format_args.data(), static_cast<int>(format_args.size())));
+	return ExceptionFormatValue::Format(msg, values);
 }
 
 string Exception::ExceptionTypeToString(ExceptionType type) {

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -118,13 +118,11 @@ ValueOutOfRangeException::ValueOutOfRangeException(const double value, const Phy
 
 ValueOutOfRangeException::ValueOutOfRangeException(const hugeint_t value, const PhysicalType origType,
                                                    const PhysicalType newType)
-    : Exception(ExceptionType::CONVERSION, "Type " + TypeIdToString(origType) + " with value " +
-                                               value.ToString() +
+    : Exception(ExceptionType::CONVERSION, "Type " + TypeIdToString(origType) + " with value " + value.ToString() +
                                                " can't be cast because the value is out of range "
                                                "for the destination type " +
                                                TypeIdToString(newType)) {
 }
-
 
 ValueOutOfRangeException::ValueOutOfRangeException(const PhysicalType varType, const idx_t length)
     : Exception(ExceptionType::OUT_OF_RANGE, "The value is too long to fit into type " + TypeIdToString(varType) + "(" +

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -12,7 +12,7 @@ Exception::Exception(string message) : std::exception(), type(ExceptionType::INV
 }
 
 Exception::Exception(ExceptionType exception_type, string message) : std::exception(), type(exception_type) {
-	exception_message_ = ExceptionTypeToString(exception_type) + ": " + message;
+	exception_message_ = ExceptionTypeToString(exception_type) + " Error: " + message;
 }
 
 const char *Exception::what() const noexcept {
@@ -92,6 +92,8 @@ string Exception::ExceptionTypeToString(ExceptionType type) {
 		return "Catalog";
 	case ExceptionType::PARSER:
 		return "Parser";
+	case ExceptionType::BINDER:
+		return "Binder";
 	case ExceptionType::PLANNER:
 		return "Planner";
 	case ExceptionType::SCHEDULER:

--- a/src/common/exception_format_value.cpp
+++ b/src/common/exception_format_value.cpp
@@ -1,0 +1,49 @@
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/types.hpp"
+#include "fmt/format.h"
+#include "fmt/printf.h"
+
+namespace duckdb {
+
+template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(PhysicalType value) {
+	return ExceptionFormatValue(TypeIdToString(value));
+}
+template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(LogicalType value) {
+	return ExceptionFormatValue(value.ToString());
+}
+template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(float value) {
+	return ExceptionFormatValue(double(value));
+}
+template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(double value) {
+	return ExceptionFormatValue(double(value));
+}
+template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(string value) {
+	return ExceptionFormatValue(string(value));
+}
+template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const char *value) {
+	return ExceptionFormatValue(string(value));
+}
+template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(char *value) {
+	return ExceptionFormatValue(string(value));
+}
+
+string ExceptionFormatValue::Format(string msg, vector<ExceptionFormatValue> &values) {
+	std::vector<duckdb_fmt::basic_format_arg<duckdb_fmt::printf_context>> format_args;
+	for (auto &val : values) {
+		switch (val.type) {
+		case ExceptionFormatValueType::FORMAT_VALUE_TYPE_DOUBLE:
+			format_args.push_back(duckdb_fmt::internal::make_arg<duckdb_fmt::printf_context>(val.dbl_val));
+			break;
+		case ExceptionFormatValueType::FORMAT_VALUE_TYPE_INTEGER:
+			format_args.push_back(duckdb_fmt::internal::make_arg<duckdb_fmt::printf_context>(val.int_val));
+			break;
+		case ExceptionFormatValueType::FORMAT_VALUE_TYPE_STRING:
+			format_args.push_back(duckdb_fmt::internal::make_arg<duckdb_fmt::printf_context>(val.str_val));
+			break;
+		}
+	}
+	return duckdb_fmt::vsprintf(msg, duckdb_fmt::basic_format_args<duckdb_fmt::printf_context>(
+	                                     format_args.data(), static_cast<int>(format_args.size())));
+}
+
+}

--- a/src/common/exception_format_value.cpp
+++ b/src/common/exception_format_value.cpp
@@ -46,4 +46,4 @@ string ExceptionFormatValue::Format(string msg, vector<ExceptionFormatValue> &va
 	                                     format_args.data(), static_cast<int>(format_args.size())));
 }
 
-}
+} // namespace duckdb

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -191,6 +191,9 @@ idx_t StringUtil::LevenshteinDistance(const string &s1, const string &s2) {
 }
 
 vector<string> StringUtil::TopNStrings(vector<std::pair<string, idx_t>> scores, idx_t n, idx_t threshold) {
+	if (scores.size() == 0) {
+		return vector<string>();
+	}
 	sort(scores.begin(), scores.end(), [](const pair<string, idx_t> & a, const pair<string, idx_t> & b) -> bool {
 		return a.second < b.second;
 	});

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -153,4 +153,78 @@ string StringUtil::Replace(string source, const string &from, const string &to) 
 	return source;
 }
 
+// adapted from https://www.tutorialspoint.com/cplusplus-program-to-implement-levenshtein-distance-computing-algorithm
+idx_t StringUtil::LevenshteinDistance(const string &s1, const string &s2) {
+    idx_t l1 = s1.size();
+    idx_t l2 = s2.size();
+    if (l1 == 0) {
+        return l2;
+    }
+    if (l2 == 0) {
+        return l1;
+    }
+	auto dist = unique_ptr<idx_t[]>(new idx_t[(l1 + 1) * (l2 + 1)]);
+   for(idx_t j = 0; j <= l2; j++) {
+       dist[j * l1 + 0] = j;
+   }
+   for(idx_t i = 0; i <= l1; i++) {
+      dist[i] = i;
+   }
+
+   for (idx_t j=1;j<=l1;j++) {
+      for(idx_t i=1;i<=l2;i++) {
+		idx_t track;
+         if(s1[i-1] == s2[j-1]) {
+            track= 0;
+         } else {
+            track = 1;
+         }
+		 idx_t adjacent_score1 = dist[(i - 1) * l1 + j] + 1;
+		 idx_t adjacent_score2 = dist[i * l1 + (j - 1)] + 1;
+		 idx_t adjacent_score3 = dist[(i - 1) * l1 + (j - 1)] + track;
+
+         idx_t t = MinValue<idx_t>(adjacent_score1, adjacent_score2);
+         dist[i * l1 + j] = MinValue<idx_t>(t, adjacent_score3);
+      }
+   }
+    return dist[l2 * l1 + l1];
+}
+
+vector<string> StringUtil::TopNStrings(vector<std::pair<string, idx_t>> scores, idx_t n, idx_t threshold) {
+	sort(scores.begin(), scores.end(), [](const pair<string, idx_t> & a, const pair<string, idx_t> & b) -> bool {
+		return a.second < b.second;
+	});
+	vector<string> result;
+	result.push_back(scores[0].first);
+	for(idx_t i = 1; i < MinValue<idx_t>(scores.size(), n); i++) {
+		if (scores[i].second > threshold) {
+			break;
+		}
+		result.push_back(scores[i].first);
+	}
+	return result;
+}
+
+vector<string> StringUtil::TopNLevenshtein(vector<string> strings, const string &target, idx_t n, idx_t threshold) {
+	vector<std::pair<string, idx_t>> scores;
+	for(auto &str : strings) {
+		scores.push_back(make_pair(str, LevenshteinDistance(str, target)));
+	}
+	return TopNStrings(scores, n, threshold);
+}
+
+string StringUtil::CandidatesMessage(const vector<string> &candidates, string candidate) {
+	string result_str;
+	if (candidates.size() > 0) {
+		result_str = "\n" + candidate + ": ";
+		for(idx_t i = 0; i < candidates.size(); i++) {
+			if (i > 0) {
+				result_str += ", ";
+			}
+			result_str += "\"" + candidates[i] + "\"";
+		}
+	}
+	return result_str;
+}
+
 } // namespace duckdb

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -171,8 +171,8 @@ vector<string> StringUtil::TopNStrings(vector<std::pair<string, idx_t>> scores, 
 	return result;
 }
 
-struct Simple2DArray {
-	Simple2DArray(idx_t len1, idx_t len2) : len1(len1) {
+struct LevenshteinArray {
+	LevenshteinArray(idx_t len1, idx_t len2) : len1(len1) {
 		dist = unique_ptr<idx_t[]>(new idx_t[len1 * len2]);
 	}
 
@@ -199,7 +199,7 @@ idx_t StringUtil::LevenshteinDistance(const string &s1, const string &s2) {
 	if (len2 == 0) {
 		return len1;
 	}
-	Simple2DArray array(len1 + 1, len2 + 1);
+	LevenshteinArray array(len1 + 1, len2 + 1);
 	array.score(0, 0) = 0;
 	for (idx_t i = 0; i <= len1; i++) {
 		array.score(i, 0) = i;
@@ -212,7 +212,7 @@ idx_t StringUtil::LevenshteinDistance(const string &s1, const string &s2) {
 			// d[i][j] = std::min({ d[i - 1][j] + 1,
 			//                      d[i][j - 1] + 1,
 			//                      d[i - 1][j - 1] + (s1[i - 1] == s2[j - 1] ? 0 : 1) });
-			int equal = s1[i - 1] == s2[j - 1] ? 1 : 0;
+			int equal = s1[i - 1] == s2[j - 1] ? 0 : 1;
 			idx_t adjacent_score1 = array.score(i - 1, j) + 1;
 			idx_t adjacent_score2 = array.score(i, j - 1) + 1;
 			idx_t adjacent_score3 = array.score(i - 1, j - 1) + equal;

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -25,7 +25,8 @@ void StringUtil::LTrim(string &str) {
 
 // Remove trailing ' ', '\f', '\n', '\r', '\t', '\v'
 void StringUtil::RTrim(string &str) {
-	str.erase(find_if(str.rbegin(), str.rend(), [](int ch) { return ch > 0 && !CharacterIsSpace(ch); }).base(), str.end());
+	str.erase(find_if(str.rbegin(), str.rend(), [](int ch) { return ch > 0 && !CharacterIsSpace(ch); }).base(),
+	          str.end());
 }
 
 void StringUtil::Trim(string &str) {
@@ -153,53 +154,15 @@ string StringUtil::Replace(string source, const string &from, const string &to) 
 	return source;
 }
 
-// adapted from https://www.tutorialspoint.com/cplusplus-program-to-implement-levenshtein-distance-computing-algorithm
-idx_t StringUtil::LevenshteinDistance(const string &s1, const string &s2) {
-    idx_t l1 = s1.size();
-    idx_t l2 = s2.size();
-    if (l1 == 0) {
-        return l2;
-    }
-    if (l2 == 0) {
-        return l1;
-    }
-	auto dist = unique_ptr<idx_t[]>(new idx_t[(l1 + 1) * (l2 + 1)]);
-   for(idx_t j = 0; j <= l2; j++) {
-       dist[j * l1 + 0] = j;
-   }
-   for(idx_t i = 0; i <= l1; i++) {
-      dist[i] = i;
-   }
-
-   for (idx_t j=1;j<=l1;j++) {
-      for(idx_t i=1;i<=l2;i++) {
-		idx_t track;
-         if(s1[i-1] == s2[j-1]) {
-            track= 0;
-         } else {
-            track = 1;
-         }
-		 idx_t adjacent_score1 = dist[(i - 1) * l1 + j] + 1;
-		 idx_t adjacent_score2 = dist[i * l1 + (j - 1)] + 1;
-		 idx_t adjacent_score3 = dist[(i - 1) * l1 + (j - 1)] + track;
-
-         idx_t t = MinValue<idx_t>(adjacent_score1, adjacent_score2);
-         dist[i * l1 + j] = MinValue<idx_t>(t, adjacent_score3);
-      }
-   }
-    return dist[l2 * l1 + l1];
-}
-
 vector<string> StringUtil::TopNStrings(vector<std::pair<string, idx_t>> scores, idx_t n, idx_t threshold) {
 	if (scores.size() == 0) {
 		return vector<string>();
 	}
-	sort(scores.begin(), scores.end(), [](const pair<string, idx_t> & a, const pair<string, idx_t> & b) -> bool {
-		return a.second < b.second;
-	});
+	sort(scores.begin(), scores.end(),
+	     [](const pair<string, idx_t> &a, const pair<string, idx_t> &b) -> bool { return a.second < b.second; });
 	vector<string> result;
 	result.push_back(scores[0].first);
-	for(idx_t i = 1; i < MinValue<idx_t>(scores.size(), n); i++) {
+	for (idx_t i = 1; i < MinValue<idx_t>(scores.size(), n); i++) {
 		if (scores[i].second > threshold) {
 			break;
 		}
@@ -208,9 +171,62 @@ vector<string> StringUtil::TopNStrings(vector<std::pair<string, idx_t>> scores, 
 	return result;
 }
 
+struct Simple2DArray {
+	Simple2DArray(idx_t len1, idx_t len2) : len1(len1) {
+		dist = unique_ptr<idx_t[]>(new idx_t[len1 * len2]);
+	}
+
+	idx_t &score(idx_t i, idx_t j) {
+		return dist[get_index(i, j)];
+	}
+
+private:
+	idx_t len1;
+	unique_ptr<idx_t[]> dist;
+
+	idx_t get_index(idx_t i, idx_t j) {
+		return j * len1 + i;
+	}
+};
+
+// adapted from https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Levenshtein_distance#C++
+idx_t StringUtil::LevenshteinDistance(const string &s1, const string &s2) {
+	idx_t len1 = s1.size();
+	idx_t len2 = s2.size();
+	if (len1 == 0) {
+		return len2;
+	}
+	if (len2 == 0) {
+		return len1;
+	}
+	Simple2DArray array(len1 + 1, len2 + 1);
+	array.score(0, 0) = 0;
+	for (idx_t i = 0; i <= len1; i++) {
+		array.score(i, 0) = i;
+	}
+	for (idx_t j = 0; j <= len2; j++) {
+		array.score(0, j) = j;
+	}
+	for (idx_t i = 1; i <= len1; i++) {
+		for (idx_t j = 1; j <= len2; j++) {
+			// d[i][j] = std::min({ d[i - 1][j] + 1,
+			//                      d[i][j - 1] + 1,
+			//                      d[i - 1][j - 1] + (s1[i - 1] == s2[j - 1] ? 0 : 1) });
+			int equal = s1[i - 1] == s2[j - 1] ? 1 : 0;
+			idx_t adjacent_score1 = array.score(i - 1, j) + 1;
+			idx_t adjacent_score2 = array.score(i, j - 1) + 1;
+			idx_t adjacent_score3 = array.score(i - 1, j - 1) + equal;
+
+			idx_t t = MinValue<idx_t>(adjacent_score1, adjacent_score2);
+			array.score(i, j) = MinValue<idx_t>(t, adjacent_score3);
+		}
+	}
+	return array.score(len1, len2);
+}
+
 vector<string> StringUtil::TopNLevenshtein(vector<string> strings, const string &target, idx_t n, idx_t threshold) {
 	vector<std::pair<string, idx_t>> scores;
-	for(auto &str : strings) {
+	for (auto &str : strings) {
 		scores.push_back(make_pair(str, LevenshteinDistance(str, target)));
 	}
 	return TopNStrings(scores, n, threshold);
@@ -220,7 +236,7 @@ string StringUtil::CandidatesMessage(const vector<string> &candidates, string ca
 	string result_str;
 	if (candidates.size() > 0) {
 		result_str = "\n" + candidate + ": ";
-		for(idx_t i = 0; i < candidates.size(); i++) {
+		for (idx_t i = 0; i < candidates.size(); i++) {
 			if (i > 0) {
 				result_str += ", ";
 			}

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -265,6 +265,9 @@ idx_t Function::BindFunction(string name, vector<PragmaFunction> &functions, Pra
 		types.push_back(value.type());
 	}
 	idx_t entry = BindFunctionFromArguments(name, functions, types, error);
+	if (entry == INVALID_INDEX) {
+		throw BinderException(error);
+	}
 	auto &candidate_function = functions[entry];
 	// cast the input parameters
 	for (idx_t i = 0; i < info.parameters.size(); i++) {

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -194,7 +194,7 @@ static int64_t BindFunctionCost(SimpleFunction &func, vector<LogicalType> &argum
 }
 
 template <class T>
-static idx_t BindFunctionFromArguments(string name, vector<T> &functions, vector<LogicalType> &arguments) {
+static idx_t BindFunctionFromArguments(string name, vector<T> &functions, vector<LogicalType> &arguments, string &error) {
 	idx_t best_function = INVALID_INDEX;
 	int64_t lowest_cost = NumericLimits<int64_t>::Maximum();
 	vector<idx_t> conflicting_functions;
@@ -227,9 +227,10 @@ static idx_t BindFunctionFromArguments(string name, vector<T> &functions, vector
 			auto &f = functions[conf];
 			candidate_str += "\t" + f.ToString() + "\n";
 		}
-		throw BinderException("Could not choose a best candidate function for the function call \"%s\". In order to "
+		error = StringUtil::Format("Could not choose a best candidate function for the function call \"%s\". In order to "
 		                      "select one, please add explicit type casts.\n\tCandidate functions:\n%s",
 		                      call_str, candidate_str);
+		return INVALID_INDEX;
 	}
 	if (best_function == INVALID_INDEX) {
 		// no matching function was found, throw an error
@@ -238,31 +239,32 @@ static idx_t BindFunctionFromArguments(string name, vector<T> &functions, vector
 		for (auto &f : functions) {
 			candidate_str += "\t" + f.ToString() + "\n";
 		}
-		throw BinderException("No function matches the given name and argument types '%s'. You might need to add "
+		error = StringUtil::Format("No function matches the given name and argument types '%s'. You might need to add "
 		                      "explicit type casts.\n\tCandidate functions:\n%s",
 		                      call_str, candidate_str);
+		return INVALID_INDEX;
 	}
 	return best_function;
 }
 
-idx_t Function::BindFunction(string name, vector<ScalarFunction> &functions, vector<LogicalType> &arguments) {
-	return BindFunctionFromArguments(name, functions, arguments);
+idx_t Function::BindFunction(string name, vector<ScalarFunction> &functions, vector<LogicalType> &arguments, string &error) {
+	return BindFunctionFromArguments(name, functions, arguments, error);
 }
 
-idx_t Function::BindFunction(string name, vector<AggregateFunction> &functions, vector<LogicalType> &arguments) {
-	return BindFunctionFromArguments(name, functions, arguments);
+idx_t Function::BindFunction(string name, vector<AggregateFunction> &functions, vector<LogicalType> &arguments, string &error) {
+	return BindFunctionFromArguments(name, functions, arguments, error);
 }
 
-idx_t Function::BindFunction(string name, vector<TableFunction> &functions, vector<LogicalType> &arguments) {
-	return BindFunctionFromArguments(name, functions, arguments);
+idx_t Function::BindFunction(string name, vector<TableFunction> &functions, vector<LogicalType> &arguments, string &error) {
+	return BindFunctionFromArguments(name, functions, arguments, error);
 }
 
-idx_t Function::BindFunction(string name, vector<PragmaFunction> &functions, PragmaInfo &info) {
+idx_t Function::BindFunction(string name, vector<PragmaFunction> &functions, PragmaInfo &info, string &error) {
 	vector<LogicalType> types;
 	for (auto &value : info.parameters) {
 		types.push_back(value.type());
 	}
-	idx_t entry = BindFunctionFromArguments(name, functions, types);
+	idx_t entry = BindFunctionFromArguments(name, functions, types, error);
 	auto &candidate_function = functions[entry];
 	// cast the input parameters
 	for (idx_t i = 0; i < info.parameters.size(); i++) {
@@ -282,20 +284,20 @@ vector<LogicalType> GetLogicalTypesFromExpressions(vector<unique_ptr<Expression>
 }
 
 idx_t Function::BindFunction(string name, vector<ScalarFunction> &functions,
-                             vector<unique_ptr<Expression>> &arguments) {
+                             vector<unique_ptr<Expression>> &arguments, string &error) {
 	auto types = GetLogicalTypesFromExpressions(arguments);
-	return Function::BindFunction(name, functions, types);
+	return Function::BindFunction(name, functions, types, error);
 }
 
 idx_t Function::BindFunction(string name, vector<AggregateFunction> &functions,
-                             vector<unique_ptr<Expression>> &arguments) {
+                             vector<unique_ptr<Expression>> &arguments, string &error) {
 	auto types = GetLogicalTypesFromExpressions(arguments);
-	return Function::BindFunction(name, functions, types);
+	return Function::BindFunction(name, functions, types, error);
 }
 
-idx_t Function::BindFunction(string name, vector<TableFunction> &functions, vector<unique_ptr<Expression>> &arguments) {
+idx_t Function::BindFunction(string name, vector<TableFunction> &functions, vector<unique_ptr<Expression>> &arguments, string &error) {
 	auto types = GetLogicalTypesFromExpressions(arguments);
-	return Function::BindFunction(name, functions, types);
+	return Function::BindFunction(name, functions, types, error);
 }
 
 void BaseScalarFunction::CastToFunctionArguments(vector<unique_ptr<Expression>> &children) {
@@ -312,20 +314,25 @@ void BaseScalarFunction::CastToFunctionArguments(vector<unique_ptr<Expression>> 
 unique_ptr<BoundFunctionExpression> ScalarFunction::BindScalarFunction(ClientContext &context, string schema,
                                                                        string name,
                                                                        vector<unique_ptr<Expression>> children,
+																	   string &error,
                                                                        bool is_operator) {
 	// bind the function
 	auto function = Catalog::GetCatalog(context).GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, schema, name);
 	assert(function && function->type == CatalogType::SCALAR_FUNCTION_ENTRY);
 	return ScalarFunction::BindScalarFunction(context, (ScalarFunctionCatalogEntry &)*function, move(children),
-	                                          is_operator);
+	                                          error, is_operator);
 }
 
 unique_ptr<BoundFunctionExpression> ScalarFunction::BindScalarFunction(ClientContext &context,
                                                                        ScalarFunctionCatalogEntry &func,
                                                                        vector<unique_ptr<Expression>> children,
+																	   string &error,
                                                                        bool is_operator) {
 	// bind the function
-	idx_t best_function = Function::BindFunction(func.name, func.functions, children);
+	idx_t best_function = Function::BindFunction(func.name, func.functions, children, error);
+	if (best_function == INVALID_INDEX) {
+		return nullptr;
+	}
 	// found a matching function!
 	auto &bound_function = func.functions[best_function];
 	return ScalarFunction::BindScalarFunction(context, bound_function, move(children), is_operator);

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -95,7 +95,7 @@ public:
 	                       bool if_exists = false, QueryErrorContext error_context = QueryErrorContext());
 
 	template <class T>
-	T *GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists = false);
+	T *GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists = false, QueryErrorContext error_context = QueryErrorContext());
 
 	//! Alter an existing entry in the catalog.
 	void Alter(ClientContext &context, AlterInfo *info);
@@ -109,24 +109,24 @@ private:
 };
 
 template <>
-TableCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists);
+TableCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists, QueryErrorContext error_context);
 template <>
-ViewCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists);
+ViewCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists, QueryErrorContext error_context);
 template <>
-SequenceCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists);
+SequenceCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists, QueryErrorContext error_context);
 template <>
 TableFunctionCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name,
-                                             bool if_exists);
+                                             bool if_exists, QueryErrorContext error_context);
 template <>
 CopyFunctionCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name,
-                                            bool if_exists);
+                                            bool if_exists, QueryErrorContext error_context);
 template <>
 PragmaFunctionCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name,
-                                              bool if_exists);
+                                              bool if_exists, QueryErrorContext error_context);
 template <>
 AggregateFunctionCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name,
-                                                 bool if_exists);
+                                                 bool if_exists, QueryErrorContext error_context);
 template <>
-CollateCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists);
+CollateCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists, QueryErrorContext error_context);
 
 } // namespace duckdb

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/catalog/catalog_entry.hpp"
 #include "duckdb/common/mutex.hpp"
+#include "duckdb/parser/query_error_context.hpp"
 
 #include <functional>
 
@@ -84,13 +85,14 @@ public:
 	void DropEntry(ClientContext &context, DropInfo *info);
 
 	//! Returns the schema object with the specified name, or throws an exception if it does not exist
-	SchemaCatalogEntry *GetSchema(ClientContext &context, const string &name = DEFAULT_SCHEMA);
+	SchemaCatalogEntry *GetSchema(ClientContext &context, const string &name = DEFAULT_SCHEMA, QueryErrorContext error_context = QueryErrorContext());
 	//! Scans all the schemas in the system one-by-one, invoking the callback for each entry
 	void ScanSchemas(ClientContext &context, std::function<void(CatalogEntry *)> callback);
 	//! Gets the "schema.name" entry of the specified type, if if_exists=true returns nullptr if entry does not exist,
 	//! otherwise an exception is thrown
 	CatalogEntry *GetEntry(ClientContext &context, CatalogType type, string schema, const string &name,
-	                       bool if_exists = false);
+	                       bool if_exists = false, QueryErrorContext error_context = QueryErrorContext());
+
 	template <class T>
 	T *GetEntry(ClientContext &context, string schema_name, const string &name, bool if_exists = false);
 

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -85,7 +85,8 @@ public:
 	void DropEntry(ClientContext &context, DropInfo *info);
 
 	//! Returns the schema object with the specified name, or throws an exception if it does not exist
-	SchemaCatalogEntry *GetSchema(ClientContext &context, const string &name = DEFAULT_SCHEMA, QueryErrorContext error_context = QueryErrorContext());
+	SchemaCatalogEntry *GetSchema(ClientContext &context, const string &name = DEFAULT_SCHEMA,
+	                              QueryErrorContext error_context = QueryErrorContext());
 	//! Scans all the schemas in the system one-by-one, invoking the callback for each entry
 	void ScanSchemas(ClientContext &context, std::function<void(CatalogEntry *)> callback);
 	//! Gets the "schema.name" entry of the specified type, if if_exists=true returns nullptr if entry does not exist,

--- a/src/include/duckdb/catalog/catalog_entry/schema_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/schema_catalog_entry.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/catalog/catalog_entry.hpp"
 #include "duckdb/catalog/catalog_set.hpp"
+#include "duckdb/parser/query_error_context.hpp"
 
 namespace duckdb {
 class ClientContext;
@@ -86,7 +87,7 @@ public:
 	void Alter(ClientContext &context, AlterInfo *info);
 
 	//! Gets a catalog entry from the given catalog set matching the given name
-	CatalogEntry *GetEntry(ClientContext &context, CatalogType type, const string &name, bool if_exists);
+	CatalogEntry *GetEntry(ClientContext &context, CatalogType type, const string &name, bool if_exists, QueryErrorContext error_context = QueryErrorContext());
 
 	//! Serialize the meta information of the SchemaCatalogEntry a serializer
 	virtual void Serialize(Serializer &serializer);

--- a/src/include/duckdb/catalog/catalog_entry/schema_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/schema_catalog_entry.hpp
@@ -87,7 +87,8 @@ public:
 	void Alter(ClientContext &context, AlterInfo *info);
 
 	//! Gets a catalog entry from the given catalog set matching the given name
-	CatalogEntry *GetEntry(ClientContext &context, CatalogType type, const string &name, bool if_exists, QueryErrorContext error_context = QueryErrorContext());
+	CatalogEntry *GetEntry(ClientContext &context, CatalogType type, const string &name, bool if_exists,
+	                       QueryErrorContext error_context = QueryErrorContext());
 
 	//! Serialize the meta information of the SchemaCatalogEntry a serializer
 	virtual void Serialize(Serializer &serializer);

--- a/src/include/duckdb/catalog/catalog_set.hpp
+++ b/src/include/duckdb/catalog/catalog_set.hpp
@@ -45,7 +45,8 @@ public:
 	//! Returns the root entry with the specified name regardless of transaction (or nullptr if there are none)
 	CatalogEntry *GetRootEntry(const string &name);
 
-	//! Gets the entry that is most similar to the given name (i.e. smallest levenshtein distance), or empty string if none is found
+	//! Gets the entry that is most similar to the given name (i.e. smallest levenshtein distance), or empty string if
+	//! none is found
 	string SimilarEntry(const string &name);
 
 	//! Rollback <entry> to be the currently valid entry for a certain catalog

--- a/src/include/duckdb/catalog/catalog_set.hpp
+++ b/src/include/duckdb/catalog/catalog_set.hpp
@@ -45,6 +45,9 @@ public:
 	//! Returns the root entry with the specified name regardless of transaction (or nullptr if there are none)
 	CatalogEntry *GetRootEntry(const string &name);
 
+	//! Gets the entry that is most similar to the given name (i.e. smallest levenshtein distance), or empty string if none is found
+	string SimilarEntry(const string &name);
+
 	//! Rollback <entry> to be the currently valid entry for a certain catalog
 	//! entry
 	void Undo(CatalogEntry *entry);

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/vector.hpp"
+#include "duckdb/common/exception_format_value.hpp"
 
 #include <stdexcept>
 
@@ -73,40 +74,6 @@ enum class ExceptionType {
 	    31, // Internal exception: exception that indicates something went wrong internally (i.e. bug in the code base)
 	INVALID_INPUT = 32 // Input or arguments error
 };
-
-enum class ExceptionFormatValueType : uint8_t {
-	FORMAT_VALUE_TYPE_DOUBLE,
-	FORMAT_VALUE_TYPE_INTEGER,
-	FORMAT_VALUE_TYPE_STRING
-};
-
-struct ExceptionFormatValue {
-	ExceptionFormatValue(double dbl_val) : type(ExceptionFormatValueType::FORMAT_VALUE_TYPE_DOUBLE), dbl_val(dbl_val) {
-	}
-	ExceptionFormatValue(int64_t int_val)
-	    : type(ExceptionFormatValueType::FORMAT_VALUE_TYPE_INTEGER), int_val(int_val) {
-	}
-	ExceptionFormatValue(string str_val) : type(ExceptionFormatValueType::FORMAT_VALUE_TYPE_STRING), str_val(str_val) {
-	}
-
-	ExceptionFormatValueType type;
-
-	double dbl_val;
-	int64_t int_val;
-	string str_val;
-
-	template <class T> static ExceptionFormatValue CreateFormatValue(T value) {
-		return int64_t(value);
-	}
-};
-
-template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(PhysicalType value);
-template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(LogicalType value);
-template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(float value);
-template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(double value);
-template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(string value);
-template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const char *value);
-template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(char *value);
 
 class Exception : public std::exception {
 public:

--- a/src/include/duckdb/common/exception_format_value.hpp
+++ b/src/include/duckdb/common/exception_format_value.hpp
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/exception_format_value.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/types.hpp"
+
+namespace duckdb {
+
+enum class ExceptionFormatValueType : uint8_t {
+	FORMAT_VALUE_TYPE_DOUBLE,
+	FORMAT_VALUE_TYPE_INTEGER,
+	FORMAT_VALUE_TYPE_STRING
+};
+
+struct ExceptionFormatValue {
+	ExceptionFormatValue(double dbl_val) : type(ExceptionFormatValueType::FORMAT_VALUE_TYPE_DOUBLE), dbl_val(dbl_val) {
+	}
+	ExceptionFormatValue(int64_t int_val)
+	    : type(ExceptionFormatValueType::FORMAT_VALUE_TYPE_INTEGER), int_val(int_val) {
+	}
+	ExceptionFormatValue(string str_val) : type(ExceptionFormatValueType::FORMAT_VALUE_TYPE_STRING), str_val(str_val) {
+	}
+
+	ExceptionFormatValueType type;
+
+	double dbl_val;
+	int64_t int_val;
+	string str_val;
+public:
+	template <class T> static ExceptionFormatValue CreateFormatValue(T value) {
+		return int64_t(value);
+	}
+	static string Format(string msg, vector<ExceptionFormatValue> &values);
+};
+
+template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(PhysicalType value);
+template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(LogicalType value);
+template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(float value);
+template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(double value);
+template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(string value);
+template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const char *value);
+template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(char *value);
+
+}

--- a/src/include/duckdb/common/exception_format_value.hpp
+++ b/src/include/duckdb/common/exception_format_value.hpp
@@ -33,6 +33,7 @@ struct ExceptionFormatValue {
 	double dbl_val;
 	int64_t int_val;
 	string str_val;
+
 public:
 	template <class T> static ExceptionFormatValue CreateFormatValue(T value) {
 		return int64_t(value);
@@ -48,4 +49,4 @@ template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(string 
 template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const char *value);
 template <> ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(char *value);
 
-}
+} // namespace duckdb

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -92,5 +92,16 @@ public:
 	static void Trim(string &str);
 
 	static string Replace(string source, const string &from, const string &to);
+
+	//! Get the levenshtein distance from two strings
+	static idx_t LevenshteinDistance(const string &s1, const string &s2);
+
+	//! Get the top-n strings (sorted by the given score distance) from a set of scores.
+	//! At least one entry is returned (if there is one).
+	//! Strings are only returned if they have a score less than the threshold.
+	static vector<string> TopNStrings(vector<std::pair<string, idx_t>> scores, idx_t n = 5, idx_t threshold = 5);
+	//! Computes the levenshtein distance of each string in strings, and compares it to target, then returns TopNStrings with the given params.
+	static vector<string> TopNLevenshtein(vector<string> strings, const string &target, idx_t n = 5, idx_t threshold = 5);
+	static string CandidatesMessage(const vector<string> &candidates, string candidate = "Candidate bindings");
 };
 } // namespace duckdb

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -24,6 +24,9 @@ public:
 	static bool CharacterIsSpace(char c) {
 		return c == ' ' || c == '\t' || c == '\n' || c == '\v'  || c ==  '\f'  || c == '\r';
 	}
+	static bool CharacterIsNewline(char c) {
+		return c == '\n' || c == '\r';
+	}
 
 	//! Returns true if the needle string exists in the haystack
 	static bool Contains(const string &haystack, const string &needle);

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -22,7 +22,7 @@ namespace duckdb {
 class StringUtil {
 public:
 	static bool CharacterIsSpace(char c) {
-		return c == ' ' || c == '\t' || c == '\n' || c == '\v'  || c ==  '\f'  || c == '\r';
+		return c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r';
 	}
 	static bool CharacterIsNewline(char c) {
 		return c == '\n' || c == '\r';
@@ -103,8 +103,10 @@ public:
 	//! At least one entry is returned (if there is one).
 	//! Strings are only returned if they have a score less than the threshold.
 	static vector<string> TopNStrings(vector<std::pair<string, idx_t>> scores, idx_t n = 5, idx_t threshold = 5);
-	//! Computes the levenshtein distance of each string in strings, and compares it to target, then returns TopNStrings with the given params.
-	static vector<string> TopNLevenshtein(vector<string> strings, const string &target, idx_t n = 5, idx_t threshold = 5);
+	//! Computes the levenshtein distance of each string in strings, and compares it to target, then returns TopNStrings
+	//! with the given params.
+	static vector<string> TopNLevenshtein(vector<string> strings, const string &target, idx_t n = 5,
+	                                      idx_t threshold = 5);
 	static string CandidatesMessage(const vector<string> &candidates, string candidate = "Candidate bindings");
 };
 } // namespace duckdb

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -66,21 +66,21 @@ public:
 	static string CallToString(string name, vector<LogicalType> arguments, LogicalType return_type);
 
 	//! Bind a scalar function from the set of functions and input arguments. Returns the index of the chosen function,
-	//! or throws an exception if none could be found.
-	static idx_t BindFunction(string name, vector<ScalarFunction> &functions, vector<LogicalType> &arguments);
+	//! returns INVALID_INDEX and sets error if none could be found
+	static idx_t BindFunction(string name, vector<ScalarFunction> &functions, vector<LogicalType> &arguments, string &error);
 	static idx_t BindFunction(string name, vector<ScalarFunction> &functions,
-	                          vector<unique_ptr<Expression>> &arguments);
+	                          vector<unique_ptr<Expression>> &arguments, string &error);
 	//! Bind an aggregate function from the set of functions and input arguments. Returns the index of the chosen
-	//! function, or throws an exception if none could be found.
-	static idx_t BindFunction(string name, vector<AggregateFunction> &functions, vector<LogicalType> &arguments);
+	//! function, returns INVALID_INDEX and sets error if none could be found
+	static idx_t BindFunction(string name, vector<AggregateFunction> &functions, vector<LogicalType> &arguments, string &error);
 	static idx_t BindFunction(string name, vector<AggregateFunction> &functions,
-	                          vector<unique_ptr<Expression>> &arguments);
+	                          vector<unique_ptr<Expression>> &arguments, string &error);
 	//! Bind a table function from the set of functions and input arguments. Returns the index of the chosen
-	//! function, or throws an exception if none could be found.
-	static idx_t BindFunction(string name, vector<TableFunction> &functions, vector<LogicalType> &arguments);
-	static idx_t BindFunction(string name, vector<TableFunction> &functions, vector<unique_ptr<Expression>> &arguments);
+	//! function, returns INVALID_INDEX and sets error if none could be found
+	static idx_t BindFunction(string name, vector<TableFunction> &functions, vector<LogicalType> &arguments, string &error);
+	static idx_t BindFunction(string name, vector<TableFunction> &functions, vector<unique_ptr<Expression>> &arguments, string &error);
 	//! Bind a pragma function from the set of functions and input arguments
-	static idx_t BindFunction(string name, vector<PragmaFunction> &functions, PragmaInfo &info);
+	static idx_t BindFunction(string name, vector<PragmaFunction> &functions, PragmaInfo &info, string &error);
 };
 
 class SimpleFunction : public Function {

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -51,10 +51,12 @@ public:
 
 	static unique_ptr<BoundFunctionExpression> BindScalarFunction(ClientContext &context, string schema, string name,
 	                                                              vector<unique_ptr<Expression>> children,
+																  string &error,
 	                                                              bool is_operator = false);
 	static unique_ptr<BoundFunctionExpression> BindScalarFunction(ClientContext &context,
 	                                                              ScalarFunctionCatalogEntry &function,
 	                                                              vector<unique_ptr<Expression>> children,
+																  string &error,
 	                                                              bool is_operator = false);
 
 	static unique_ptr<BoundFunctionExpression> BindScalarFunction(ClientContext &context, ScalarFunction bound_function,

--- a/src/include/duckdb/parser/parsed_expression.hpp
+++ b/src/include/duckdb/parser/parsed_expression.hpp
@@ -29,6 +29,8 @@ public:
 	ParsedExpression(ExpressionType type, ExpressionClass expression_class) : BaseExpression(type, expression_class) {
 	}
 
+	//! The location in the query (if any)
+	idx_t query_location = INVALID_INDEX;
 public:
 	bool IsAggregate() const override;
 	bool IsWindow() const override;

--- a/src/include/duckdb/parser/parsed_expression.hpp
+++ b/src/include/duckdb/parser/parsed_expression.hpp
@@ -31,6 +31,7 @@ public:
 
 	//! The location in the query (if any)
 	idx_t query_location = INVALID_INDEX;
+
 public:
 	bool IsAggregate() const override;
 	bool IsWindow() const override;

--- a/src/include/duckdb/parser/parser.hpp
+++ b/src/include/duckdb/parser/parser.hpp
@@ -33,8 +33,6 @@ public:
 	//! variable.
 	void ParseQuery(string query);
 
-	//! Formats an error message that has occurred within a query at a specified location
-	static std::string FormatErrorMessage(std::string query, std::string error_message, int error_location);
 	//! Parses a list of expressions (i.e. the list found in a SELECT clause)
 	static vector<unique_ptr<ParsedExpression>> ParseExpressionList(string select_list);
 	//! Parses a list as found in an ORDER BY expression (i.e. including optional ASCENDING/DESCENDING modifiers)

--- a/src/include/duckdb/parser/parser.hpp
+++ b/src/include/duckdb/parser/parser.hpp
@@ -33,6 +33,8 @@ public:
 	//! variable.
 	void ParseQuery(string query);
 
+	//! Formats an error message that has occurred within a query at a specified location
+	static std::string FormatErrorMessage(std::string query, std::string error_message, int error_location);
 	//! Parses a list of expressions (i.e. the list found in a SELECT clause)
 	static vector<unique_ptr<ParsedExpression>> ParseExpressionList(string select_list);
 	//! Parses a list as found in an ORDER BY expression (i.e. including optional ASCENDING/DESCENDING modifiers)

--- a/src/include/duckdb/parser/query_error_context.hpp
+++ b/src/include/duckdb/parser/query_error_context.hpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/query_error_context.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+
+namespace duckdb {
+class SQLStatement;
+
+class QueryErrorContext {
+public:
+	QueryErrorContext(SQLStatement *statement_ = nullptr, idx_t query_location_ = INVALID_INDEX) :
+	  statement(statement_), query_location(query_location_) {}
+
+	//! The query statement
+	SQLStatement *statement;
+	//! The location in which the error should be thrown
+	idx_t query_location;
+public:
+	static string Format(string &query, string error_message, int error_location);
+
+	string FormatErrorRecursive(string msg, vector<ExceptionFormatValue> &values);
+	template <class T, typename... Args>
+	string FormatErrorRecursive(string msg, vector<ExceptionFormatValue> &values, T param, Args... params) {
+		values.push_back(ExceptionFormatValue::CreateFormatValue<T>(param));
+		return FormatErrorRecursive(msg, values, params...);
+	}
+
+	template <typename... Args> string FormatError(string msg, Args... params) {
+		vector<ExceptionFormatValue> values;
+		return FormatErrorRecursive(msg, values, params...);
+	}
+};
+
+
+} // namespace duckdb

--- a/src/include/duckdb/parser/query_error_context.hpp
+++ b/src/include/duckdb/parser/query_error_context.hpp
@@ -9,6 +9,8 @@
 #pragma once
 
 #include "duckdb/common/common.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/common/exception_format_value.hpp"
 
 namespace duckdb {
 class SQLStatement;

--- a/src/include/duckdb/parser/query_error_context.hpp
+++ b/src/include/duckdb/parser/query_error_context.hpp
@@ -15,13 +15,15 @@ class SQLStatement;
 
 class QueryErrorContext {
 public:
-	QueryErrorContext(SQLStatement *statement_ = nullptr, idx_t query_location_ = INVALID_INDEX) :
-	  statement(statement_), query_location(query_location_) {}
+	QueryErrorContext(SQLStatement *statement_ = nullptr, idx_t query_location_ = INVALID_INDEX)
+	    : statement(statement_), query_location(query_location_) {
+	}
 
 	//! The query statement
 	SQLStatement *statement;
 	//! The location in which the error should be thrown
 	idx_t query_location;
+
 public:
 	static string Format(string &query, string error_message, int error_location);
 
@@ -37,6 +39,5 @@ public:
 		return FormatErrorRecursive(msg, values, params...);
 	}
 };
-
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/sql_statement.hpp
+++ b/src/include/duckdb/parser/sql_statement.hpp
@@ -24,5 +24,6 @@ public:
 	StatementType type;
 	idx_t stmt_location;
 	idx_t stmt_length;
+	string query;
 };
 } // namespace duckdb

--- a/src/include/duckdb/parser/tableref.hpp
+++ b/src/include/duckdb/parser/tableref.hpp
@@ -25,6 +25,8 @@ public:
 
 	TableReferenceType type;
 	string alias;
+	//! The location in the query (if any)
+	idx_t query_location = INVALID_INDEX;
 
 public:
 	//! Convert the object to a string

--- a/src/include/duckdb/parser/tableref/basetableref.hpp
+++ b/src/include/duckdb/parser/tableref/basetableref.hpp
@@ -21,7 +21,8 @@ public:
 	string schema_name;
 	//! Table name
 	string table_name;
-
+	//! The location in the query (if any)
+	idx_t query_location = INVALID_INDEX;
 public:
 	string ToString() const override {
 		return "GET(" + schema_name + "." + table_name + ")";

--- a/src/include/duckdb/parser/tableref/basetableref.hpp
+++ b/src/include/duckdb/parser/tableref/basetableref.hpp
@@ -21,8 +21,6 @@ public:
 	string schema_name;
 	//! Table name
 	string table_name;
-	//! The location in the query (if any)
-	idx_t query_location = INVALID_INDEX;
 
 public:
 	string ToString() const override {

--- a/src/include/duckdb/parser/tableref/basetableref.hpp
+++ b/src/include/duckdb/parser/tableref/basetableref.hpp
@@ -23,6 +23,7 @@ public:
 	string table_name;
 	//! The location in the query (if any)
 	idx_t query_location = INVALID_INDEX;
+
 public:
 	string ToString() const override {
 		return "GET(" + schema_name + "." + table_name + ")";

--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -33,7 +33,8 @@ public:
 	//! Like GetMatchingBinding, but instead of throwing an error if multiple tables have the same binding it will
 	//! return a list of all the matching ones
 	unordered_set<string> GetMatchingBindings(const string &column_name);
-	//! Like GetMatchingBindings, but returns the top 3 most similar bindings (in levenshtein distance) instead of the matching ones
+	//! Like GetMatchingBindings, but returns the top 3 most similar bindings (in levenshtein distance) instead of the
+	//! matching ones
 	vector<string> GetSimilarBindings(const string &column_name);
 
 	Binding *GetCTEBinding(const string &ctename);
@@ -76,7 +77,8 @@ public:
 
 private:
 	void AddBinding(const string &alias, unique_ptr<Binding> binding);
-	//! Gets a binding of the specified name. Returns a nullptr and sets the out_error if the binding could not be found.
+	//! Gets a binding of the specified name. Returns a nullptr and sets the out_error if the binding could not be
+	//! found.
 	Binding *GetBinding(const string &name, string &out_error);
 
 	//! The set of bindings

--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -33,6 +33,8 @@ public:
 	//! Like GetMatchingBinding, but instead of throwing an error if multiple tables have the same binding it will
 	//! return a list of all the matching ones
 	unordered_set<string> GetMatchingBindings(const string &column_name);
+	//! Like GetMatchingBindings, but returns the top 3 most similar bindings (in levenshtein distance) instead of the matching ones
+	vector<string> GetSimilarBindings(const string &column_name);
 
 	Binding *GetCTEBinding(const string &ctename);
 	//! Binds a column expression to the base table. Returns the bound expression
@@ -74,6 +76,8 @@ public:
 
 private:
 	void AddBinding(const string &alias, unique_ptr<Binding> binding);
+	//! Gets a binding of the specified name. Returns a nullptr and sets the out_error if the binding could not be found.
+	Binding *GetBinding(const string &name, string &out_error);
 
 	//! The set of bindings
 	unordered_map<string, unique_ptr<Binding>> bindings;

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -105,6 +105,10 @@ public:
 	//! Add a correlated column to this binder (if it does not exist)
 	void AddCorrelatedColumn(CorrelatedColumnInfo info);
 
+	string FormatError(ParsedExpression &expr_context, string message);
+	string FormatError(TableRef &ref_context, string message);
+	string FormatError(idx_t query_location, string message);
+
 private:
 	//! The parent binder (if any)
 	Binder *parent;
@@ -118,7 +122,7 @@ private:
 	bool plan_subquery = true;
 	//! Whether CTEs should reference the parent binder (if it exists)
 	bool inherit_ctes = true;
-
+	//! The root statement of the query that is currently being parsed
 	SQLStatement *root_statement = nullptr;
 
 private:

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -119,6 +119,8 @@ private:
 	//! Whether CTEs should reference the parent binder (if it exists)
 	bool inherit_ctes = true;
 
+	SQLStatement *root_statement = nullptr;
+
 private:
 	//! Bind the default values of the columns of a table
 	void BindDefaultValues(vector<ColumnDefinition> &columns, vector<unique_ptr<Expression>> &bound_defaults);

--- a/src/main/materialized_query_result.cpp
+++ b/src/main/materialized_query_result.cpp
@@ -37,7 +37,7 @@ string MaterializedQueryResult::ToString() {
 		}
 		result += "\n";
 	} else {
-		result = "Query Error: " + error + "\n";
+		result = error + "\n";
 	}
 	return result;
 }

--- a/src/main/stream_query_result.cpp
+++ b/src/main/stream_query_result.cpp
@@ -21,7 +21,7 @@ string StreamQueryResult::ToString() {
 		result = HeaderToString();
 		result += "[[STREAM RESULT]]";
 	} else {
-		result = "Query Error: " + error + "\n";
+		result = error + "\n";
 	}
 	return result;
 }

--- a/src/optimizer/rule/date_part_simplification.cpp
+++ b/src/optimizer/rule/date_part_simplification.cpp
@@ -92,8 +92,13 @@ unique_ptr<Expression> DatePartSimplificationRule::Apply(LogicalOperator &op, ve
 	vector<unique_ptr<Expression>> children;
 	children.push_back(move(date_part.children[1]));
 
-	return ScalarFunction::BindScalarFunction(rewriter.context, DEFAULT_SCHEMA, new_function_name, move(children),
-	                                          false);
+	string error;
+	auto function =
+		ScalarFunction::BindScalarFunction(rewriter.context, DEFAULT_SCHEMA, new_function_name, move(children), error, false);
+	if (!function) {
+		throw BinderException(error);
+	}
+	return move(function);
 }
 
 } // namespace duckdb

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library_unity(
   parsed_expression.cpp
   parsed_expression_iterator.cpp
   parser.cpp
+  query_error_context.cpp
   query_node.cpp
   result_modifier.cpp
   tableref.cpp

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -39,7 +39,7 @@ void Parser::ParseQuery(string query) {
 		n_prepared_parameters = transformer.ParamCount();
 	}
 	if (statements.size() > 0) {
-		for(auto &statement : statements) {
+		for (auto &statement : statements) {
 			statement->query = query;
 		}
 		auto &last_statement = statements.back();

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -24,7 +24,7 @@ void Parser::ParseQuery(string query) {
 		parser.Parse(query);
 
 		if (!parser.success) {
-			throw ParserException(PostgresParser::FormatErrorMessage(query, parser.error_message, parser.error_location));
+			throw ParserException(Parser::FormatErrorMessage(query, parser.error_message, parser.error_location));
 		}
 
 		if (!parser.parse_tree) {
@@ -41,6 +41,46 @@ void Parser::ParseQuery(string query) {
 		auto &last_statement = statements.back();
 		last_statement->stmt_length = query.size() - last_statement->stmt_location;
 	}
+}
+
+string Parser::FormatErrorMessage(string query, string error_message, int error_loc) {
+	error_loc--;
+	if (error_loc < 0 || size_t(error_loc) >= query.size()) {
+		// no location in query provided
+		return error_message;
+	}
+	size_t error_location = size_t(error_loc);
+	// count the line numbers until the error location
+	size_t line_number = 1;
+	for(size_t i = 0; i < error_location; i++) {
+		if (query[i] == '\n' || query[i] == '\r') {
+			line_number++;
+		}
+	}
+	// scan the query backwards from the error location to find the first newline
+	// we also show max 40 characters before the error location, to deal with long lines
+	size_t start_pos = 0;
+	for(size_t i = error_location; i > 0 && error_location - i < 40; i--) {
+		if (query[i - 1] == '\n' || query[i - 1] == '\r') {
+			start_pos = i;
+			break;
+		}
+	}
+	// find the end of the line, or max 40 characters AFTER the error location
+	size_t end_pos = query.size() - 1;
+	for(size_t i = error_location; i < query.size() - 1 && i - error_location < 40; i++) {
+		if (query[i] == '\n' || query[i] == '\r') {
+			end_pos = i;
+			break;
+		}
+	}
+	string line_indicator = "LINE " + to_string(line_number) + ": ";
+
+	// now first print the error message plus the current line (or a subset of the line)
+	error_message += "\n" + line_indicator + query.substr(start_pos, end_pos - start_pos);
+	// print an arrow pointing at the error location
+	error_message += "\n" + string(error_location - start_pos + line_indicator.size(), ' ') + "^";
+	return error_message;
 }
 
 vector<unique_ptr<ParsedExpression>> Parser::ParseExpressionList(string select_list) {

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -24,7 +24,7 @@ void Parser::ParseQuery(string query) {
 		parser.Parse(query);
 
 		if (!parser.success) {
-			throw ParserException("%s [%d]", parser.error_message.c_str(), parser.error_location);
+			throw ParserException(PostgresParser::FormatErrorMessage(query, parser.error_message, parser.error_location));
 		}
 
 		if (!parser.parse_tree) {

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/tableref/expressionlistref.hpp"
 #include "postgres_parser.hpp"
+#include "duckdb/parser/query_error_context.hpp"
 
 #include "parser/parser.hpp"
 
@@ -24,7 +25,7 @@ void Parser::ParseQuery(string query) {
 		parser.Parse(query);
 
 		if (!parser.success) {
-			throw ParserException(Parser::FormatErrorMessage(query, parser.error_message, parser.error_location));
+			throw ParserException(QueryErrorContext::Format(query, parser.error_message, parser.error_location - 1));
 		}
 
 		if (!parser.parse_tree) {
@@ -38,49 +39,12 @@ void Parser::ParseQuery(string query) {
 		n_prepared_parameters = transformer.ParamCount();
 	}
 	if (statements.size() > 0) {
+		for(auto &statement : statements) {
+			statement->query = query;
+		}
 		auto &last_statement = statements.back();
 		last_statement->stmt_length = query.size() - last_statement->stmt_location;
 	}
-}
-
-string Parser::FormatErrorMessage(string query, string error_message, int error_loc) {
-	error_loc--;
-	if (error_loc < 0 || size_t(error_loc) >= query.size()) {
-		// no location in query provided
-		return error_message;
-	}
-	size_t error_location = size_t(error_loc);
-	// count the line numbers until the error location
-	size_t line_number = 1;
-	for(size_t i = 0; i < error_location; i++) {
-		if (query[i] == '\n' || query[i] == '\r') {
-			line_number++;
-		}
-	}
-	// scan the query backwards from the error location to find the first newline
-	// we also show max 40 characters before the error location, to deal with long lines
-	size_t start_pos = 0;
-	for(size_t i = error_location; i > 0 && error_location - i < 40; i--) {
-		if (query[i - 1] == '\n' || query[i - 1] == '\r') {
-			start_pos = i;
-			break;
-		}
-	}
-	// find the end of the line, or max 40 characters AFTER the error location
-	size_t end_pos = query.size() - 1;
-	for(size_t i = error_location; i < query.size() - 1 && i - error_location < 40; i++) {
-		if (query[i] == '\n' || query[i] == '\r') {
-			end_pos = i;
-			break;
-		}
-	}
-	string line_indicator = "LINE " + to_string(line_number) + ": ";
-
-	// now first print the error message plus the current line (or a subset of the line)
-	error_message += "\n" + line_indicator + query.substr(start_pos, end_pos - start_pos);
-	// print an arrow pointing at the error location
-	error_message += "\n" + string(error_location - start_pos + line_indicator.size(), ' ') + "^";
-	return error_message;
 }
 
 vector<unique_ptr<ParsedExpression>> Parser::ParseExpressionList(string select_list) {

--- a/src/parser/query_error_context.cpp
+++ b/src/parser/query_error_context.cpp
@@ -1,0 +1,118 @@
+#include "duckdb/parser/query_error_context.hpp"
+#include "duckdb/parser/sql_statement.hpp"
+#include "utf8proc_wrapper.h"
+
+namespace duckdb {
+
+string QueryErrorContext::Format(string &query, string error_message, int error_loc) {
+	if (error_loc < 0 || size_t(error_loc) >= query.size()) {
+		// no location in query provided
+		return error_message;
+	}
+	idx_t error_location = idx_t(error_loc);
+	// count the line numbers until the error location
+	// and set the start position as the first character of that line
+	idx_t start_pos = 0;
+	idx_t line_number = 1;
+	for(idx_t i = 0; i < error_location; i++) {
+		if (StringUtil::CharacterIsNewline(query[i])) {
+			line_number++;
+			start_pos = i + 1;
+		}
+	}
+	// now find either the next newline token after the query, or find the end of string
+	// this is the initial end position
+	idx_t end_pos = query.size();
+	for(idx_t i = error_location; i < query.size(); i++) {
+		if (StringUtil::CharacterIsNewline(query[i])) {
+			end_pos = i;
+			break;
+		}
+	}
+	// now start scanning from the start pos
+	// we want to figure out the start and end pos of what we are going to render
+	// we want to render at most 80 characters in total, with the error_location located in the middle
+	const char *buf = query.c_str() + start_pos;
+	idx_t len = end_pos - start_pos;
+	vector<idx_t> render_widths;
+	vector<idx_t> positions;
+	if (utf8proc_is_valid(buf, len)) {
+		// for unicode awareness, we traverse the graphemes of the current line and keep track of their render widths
+		// and of their position in the string
+		for(idx_t cpos = 0; cpos < len;) {
+			auto char_render_width = utf8proc_render_width(buf, len, cpos);
+			positions.push_back(cpos);
+			render_widths.push_back(char_render_width);
+			cpos = utf8proc_next_grapheme_cluster(buf, len, cpos);
+		}
+	} else {
+		// invalid utf-8, we can't do much at this point
+		// we just assume every character is a character, and every character has a render width of 1
+		for(idx_t cpos = 0; cpos < len; cpos++) {
+			positions.push_back(cpos);
+			render_widths.push_back(1);
+		}
+	}
+	// now we want to find the (unicode aware) start and end position
+	idx_t epos = 0;
+	// start by finding the error location inside the array
+	for(idx_t i = 0; i < positions.size(); i++) {
+		if (positions[i] >= error_location) {
+			epos = i;
+			break;
+		}
+	}
+	bool truncate_beginning = false;
+	bool truncate_end = false;
+	idx_t spos = 0;
+	// now we iterate backwards from the error location
+	// we show max 40 render width before the error location
+	idx_t current_render_width = 0;
+	for(idx_t i = epos; i > 0; i--) {
+		current_render_width += render_widths[i];
+		if (current_render_width >= 40) {
+			truncate_beginning = true;
+			start_pos = positions[i];
+			spos = i;
+			break;
+		}
+	}
+	// now do the same, but going forward
+	current_render_width = 0;
+	for(idx_t i = epos; i < positions.size(); i++) {
+		current_render_width += render_widths[i];
+		if (current_render_width >= 40) {
+			truncate_end = true;
+			end_pos = positions[i];
+			break;
+		}
+	}
+	string line_indicator = "LINE " + std::to_string(line_number) + ": ";
+	string begin_trunc = truncate_beginning ? "..." : "";
+	string end_trunc = truncate_end ? "..." : "";
+
+	// get the render width of the error indicator (i.e. how many spaces we need to insert before the ^)
+	idx_t error_render_width = 0;
+	for(idx_t i = spos; i < epos; i++) {
+		error_render_width += render_widths[i];
+	}
+	error_render_width += line_indicator.size() + begin_trunc.size();
+
+
+	// now first print the error message plus the current line (or a subset of the line)
+	error_message += "\n" + line_indicator + begin_trunc + query.substr(start_pos, end_pos - start_pos) + end_trunc;
+	// print an arrow pointing at the error location
+	error_message += "\n" + string(error_render_width, ' ') + "^";
+	return error_message;
+}
+
+string QueryErrorContext::FormatErrorRecursive(string msg, vector<ExceptionFormatValue> &values) {
+	string error_message = ExceptionFormatValue::Format(msg, values);
+	if (!statement || query_location >= statement->query.size()) {
+		// no statement provided or query location out of range
+		return error_message;
+	}
+	return Format(statement->query, error_message, query_location);
+}
+
+}

--- a/src/parser/query_error_context.cpp
+++ b/src/parser/query_error_context.cpp
@@ -14,7 +14,7 @@ string QueryErrorContext::Format(string &query, string error_message, int error_
 	// and set the start position as the first character of that line
 	idx_t start_pos = 0;
 	idx_t line_number = 1;
-	for(idx_t i = 0; i < error_location; i++) {
+	for (idx_t i = 0; i < error_location; i++) {
 		if (StringUtil::CharacterIsNewline(query[i])) {
 			line_number++;
 			start_pos = i + 1;
@@ -23,7 +23,7 @@ string QueryErrorContext::Format(string &query, string error_message, int error_
 	// now find either the next newline token after the query, or find the end of string
 	// this is the initial end position
 	idx_t end_pos = query.size();
-	for(idx_t i = error_location; i < query.size(); i++) {
+	for (idx_t i = error_location; i < query.size(); i++) {
 		if (StringUtil::CharacterIsNewline(query[i])) {
 			end_pos = i;
 			break;
@@ -39,7 +39,7 @@ string QueryErrorContext::Format(string &query, string error_message, int error_
 	if (utf8proc_is_valid(buf, len)) {
 		// for unicode awareness, we traverse the graphemes of the current line and keep track of their render widths
 		// and of their position in the string
-		for(idx_t cpos = 0; cpos < len;) {
+		for (idx_t cpos = 0; cpos < len;) {
 			auto char_render_width = utf8proc_render_width(buf, len, cpos);
 			positions.push_back(cpos);
 			render_widths.push_back(char_render_width);
@@ -48,7 +48,7 @@ string QueryErrorContext::Format(string &query, string error_message, int error_
 	} else {
 		// invalid utf-8, we can't do much at this point
 		// we just assume every character is a character, and every character has a render width of 1
-		for(idx_t cpos = 0; cpos < len; cpos++) {
+		for (idx_t cpos = 0; cpos < len; cpos++) {
 			positions.push_back(cpos);
 			render_widths.push_back(1);
 		}
@@ -56,7 +56,7 @@ string QueryErrorContext::Format(string &query, string error_message, int error_
 	// now we want to find the (unicode aware) start and end position
 	idx_t epos = 0;
 	// start by finding the error location inside the array
-	for(idx_t i = 0; i < positions.size(); i++) {
+	for (idx_t i = 0; i < positions.size(); i++) {
 		if (positions[i] >= error_location) {
 			epos = i;
 			break;
@@ -68,7 +68,7 @@ string QueryErrorContext::Format(string &query, string error_message, int error_
 	// now we iterate backwards from the error location
 	// we show max 40 render width before the error location
 	idx_t current_render_width = 0;
-	for(idx_t i = epos; i > 0; i--) {
+	for (idx_t i = epos; i > 0; i--) {
 		current_render_width += render_widths[i];
 		if (current_render_width >= 40) {
 			truncate_beginning = true;
@@ -79,7 +79,7 @@ string QueryErrorContext::Format(string &query, string error_message, int error_
 	}
 	// now do the same, but going forward
 	current_render_width = 0;
-	for(idx_t i = epos; i < positions.size(); i++) {
+	for (idx_t i = epos; i < positions.size(); i++) {
 		current_render_width += render_widths[i];
 		if (current_render_width >= 40) {
 			truncate_end = true;
@@ -93,11 +93,10 @@ string QueryErrorContext::Format(string &query, string error_message, int error_
 
 	// get the render width of the error indicator (i.e. how many spaces we need to insert before the ^)
 	idx_t error_render_width = 0;
-	for(idx_t i = spos; i < epos; i++) {
+	for (idx_t i = spos; i < epos; i++) {
 		error_render_width += render_widths[i];
 	}
 	error_render_width += line_indicator.size() + begin_trunc.size();
-
 
 	// now first print the error message plus the current line (or a subset of the line)
 	error_message += "\n" + line_indicator + begin_trunc + query.substr(start_pos, end_pos - start_pos) + end_trunc;
@@ -115,4 +114,4 @@ string QueryErrorContext::FormatErrorRecursive(string msg, vector<ExceptionForma
 	return Format(statement->query, error_message, query_location);
 }
 
-}
+} // namespace duckdb

--- a/src/parser/query_error_context.cpp
+++ b/src/parser/query_error_context.cpp
@@ -57,7 +57,7 @@ string QueryErrorContext::Format(string &query, string error_message, int error_
 	idx_t epos = 0;
 	// start by finding the error location inside the array
 	for (idx_t i = 0; i < positions.size(); i++) {
-		if (positions[i] >= error_location) {
+		if (positions[i] >= (error_location - start_pos)) {
 			epos = i;
 			break;
 		}

--- a/src/parser/query_error_context.cpp
+++ b/src/parser/query_error_context.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/parser/query_error_context.hpp"
 #include "duckdb/parser/sql_statement.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "utf8proc_wrapper.h"
 
 namespace duckdb {

--- a/src/parser/transform/expression/transform_columnref.cpp
+++ b/src/parser/transform/expression/transform_columnref.cpp
@@ -18,14 +18,18 @@ unique_ptr<ParsedExpression> Transformer::TransformColumnRef(PGColumnRef *root) 
 		string column_name, table_name;
 		if (fields->length == 1) {
 			column_name = string(reinterpret_cast<PGValue *>(fields->head->data.ptr_value)->val.str);
-			return make_unique<ColumnRefExpression>(column_name, table_name);
+			auto colref = make_unique<ColumnRefExpression>(column_name, table_name);
+			colref->query_location = root->location;
+			return move(colref);
 		} else {
 			table_name = string(reinterpret_cast<PGValue *>(fields->head->data.ptr_value)->val.str);
 			auto col_node = reinterpret_cast<PGNode *>(fields->head->next->data.ptr_value);
 			switch (col_node->type) {
 			case T_PGString: {
 				column_name = string(reinterpret_cast<PGValue *>(col_node)->val.str);
-				return make_unique<ColumnRefExpression>(column_name, table_name);
+				auto colref = make_unique<ColumnRefExpression>(column_name, table_name);
+				colref->query_location = root->location;
+				return move(colref);
 			}
 			case T_PGAStar: {
 				return make_unique<TableStarExpression>(table_name);

--- a/src/parser/transform/expression/transform_function.cpp
+++ b/src/parser/transform/expression/transform_function.cpp
@@ -199,7 +199,9 @@ unique_ptr<ParsedExpression> Transformer::TransformFuncCall(PGFuncCall *root) {
 		return move(expr);
 	}
 
-	return make_unique<FunctionExpression>(schema, lowercase_name.c_str(), children, root->agg_distinct);
+	auto function = make_unique<FunctionExpression>(schema, lowercase_name.c_str(), children, root->agg_distinct);
+	function->query_location = root->location;
+	return move(function);
 }
 
 static string SQLValueOpToString(PGSQLValueFunctionOp op) {

--- a/src/parser/transform/tableref/transform_base_tableref.cpp
+++ b/src/parser/transform/tableref/transform_base_tableref.cpp
@@ -15,6 +15,7 @@ unique_ptr<TableRef> Transformer::TransformRangeVar(PGRangeVar *root) {
 	if (root->schemaname) {
 		result->schema_name = root->schemaname;
 	}
+	result->query_location = root->location;
 	return move(result);
 }
 

--- a/src/parser/transform/tableref/transform_table_function.cpp
+++ b/src/parser/transform/tableref/transform_table_function.cpp
@@ -28,15 +28,17 @@ unique_ptr<TableRef> Transformer::TransformRangeFunction(PGRangeFunction *root) 
 	if (coldef) {
 		throw NotImplementedException("Explicit column definition not supported yet");
 	}
+	auto func_call = (PGFuncCall *)call_tree;
 	// transform the function call
 	auto result = make_unique<TableFunctionRef>();
-	result->function = TransformFuncCall((PGFuncCall *)call_tree);
+	result->function = TransformFuncCall(func_call);
 	result->alias = TransformAlias(root->alias);
 	if (root->alias && root->alias->colnames) {
 		for (auto node = root->alias->colnames->head; node != nullptr; node = node->next) {
 			result->column_name_alias.push_back(reinterpret_cast<PGValue *>(node->data.ptr_value)->val.str);
 		}
 	}
+	result->query_location = func_call->location;
 	return move(result);
 }
 

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -37,7 +37,7 @@ vector<string> BindContext::GetSimilarBindings(const string &column_name) {
 	vector<pair<string, idx_t>> scores;
 	for (auto &kv : bindings) {
 		auto binding = kv.second.get();
-		for(auto &name : binding->names) {
+		for (auto &name : binding->names) {
 			idx_t distance = StringUtil::LevenshteinDistance(name, column_name);
 			scores.push_back(make_pair(binding->alias + "." + name, distance));
 		}
@@ -74,11 +74,12 @@ Binding *BindContext::GetBinding(const string &name, string &out_error) {
 	if (match == bindings.end()) {
 		// alias not found in this BindContext
 		vector<string> candidates;
-		for(auto &kv : bindings) {
+		for (auto &kv : bindings) {
 			candidates.push_back(kv.first);
 		}
-		string candidate_str = StringUtil::CandidatesMessage(StringUtil::TopNLevenshtein(candidates, name), "Candidate tables");
-		out_error =StringUtil::Format("Referenced table \"%s\" not found!%s", name, candidate_str);
+		string candidate_str =
+		    StringUtil::CandidatesMessage(StringUtil::TopNLevenshtein(candidates, name), "Candidate tables");
+		out_error = StringUtil::Format("Referenced table \"%s\" not found!%s", name, candidate_str);
 		return nullptr;
 	}
 	return match->second.get();

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -22,6 +22,7 @@ Binder::Binder(ClientContext &context, Binder *parent_, bool inherit_ctes_)
 }
 
 BoundStatement Binder::Bind(SQLStatement &statement) {
+	root_statement = &statement;
 	switch (statement.type) {
 	case StatementType::SELECT_STATEMENT:
 		return Bind((SelectStatement &)statement);

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -223,4 +223,17 @@ void Binder::AddCorrelatedColumn(CorrelatedColumnInfo info) {
 	}
 }
 
+string Binder::FormatError(ParsedExpression &expr_context, string message) {
+	return FormatError(expr_context.query_location, message);
+}
+
+string Binder::FormatError(TableRef &ref_context, string message) {
+	return FormatError(ref_context.query_location, message);
+}
+
+string Binder::FormatError(idx_t query_location, string message) {
+	QueryErrorContext context(root_statement, query_location);
+	return context.FormatError(message);
+}
+
 } // namespace duckdb

--- a/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/planner/expression_binder/aggregate_binder.hpp"
 #include "duckdb/planner/expression_binder/select_binder.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
+#include "duckdb/planner/binder.hpp"
 
 namespace duckdb {
 using namespace std;
@@ -51,7 +52,10 @@ BindResult SelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFuncti
 	}
 
 	// bind the aggregate
-	idx_t best_function = Function::BindFunction(func->name, func->functions, types);
+	idx_t best_function = Function::BindFunction(func->name, func->functions, types, error);
+	if (best_function == INVALID_INDEX) {
+		throw BinderException(binder.FormatError(aggr, error));
+	}
 	// found a matching function!
 	auto &bound_function = func->functions[best_function];
 

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -17,8 +17,8 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref, idx_t d
 		if (colref.table_name.empty()) {
 			auto similar_bindings = binder.bind_context.GetSimilarBindings(colref.column_name);
 			string candidate_str = StringUtil::CandidatesMessage(similar_bindings, "Candidate bindings");
-			return BindResult(
-			    StringUtil::Format("Referenced column \"%s\" not found in FROM clause!%s", colref.column_name.c_str(), candidate_str));
+			return BindResult(StringUtil::Format("Referenced column \"%s\" not found in FROM clause!%s",
+			                                     colref.column_name.c_str(), candidate_str));
 		}
 	}
 	BindResult result = binder.bind_context.BindColumn(colref, depth);

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -24,6 +24,8 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref, idx_t d
 	BindResult result = binder.bind_context.BindColumn(colref, depth);
 	if (!result.HasError()) {
 		bound_columns = true;
+	} else {
+		result.error = binder.FormatError(colref, result.error);
 	}
 	return result;
 }

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -15,8 +15,10 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref, idx_t d
 		// no table name: find a binding that contains this
 		colref.table_name = binder.bind_context.GetMatchingBinding(colref.column_name);
 		if (colref.table_name.empty()) {
+			auto similar_bindings = binder.bind_context.GetSimilarBindings(colref.column_name);
+			string candidate_str = StringUtil::CandidatesMessage(similar_bindings, "Candidate bindings");
 			return BindResult(
-			    StringUtil::Format("Referenced column \"%s\" not found in FROM clause!", colref.column_name.c_str()));
+			    StringUtil::Format("Referenced column \"%s\" not found in FROM clause!%s", colref.column_name.c_str(), candidate_str));
 		}
 	}
 	BindResult result = binder.bind_context.BindColumn(colref, depth);

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -17,8 +17,8 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref, idx_t d
 		if (colref.table_name.empty()) {
 			auto similar_bindings = binder.bind_context.GetSimilarBindings(colref.column_name);
 			string candidate_str = StringUtil::CandidatesMessage(similar_bindings, "Candidate bindings");
-			return BindResult(StringUtil::Format("Referenced column \"%s\" not found in FROM clause!%s",
-			                                     colref.column_name.c_str(), candidate_str));
+			return BindResult(binder.FormatError(colref, StringUtil::Format("Referenced column \"%s\" not found in FROM clause!%s",
+			                                     colref.column_name.c_str(), candidate_str)));
 		}
 	}
 	BindResult result = binder.bind_context.BindColumn(colref, depth);

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
+#include "duckdb/planner/binder.hpp"
 
 namespace duckdb {
 using namespace std;

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -12,6 +12,7 @@ using namespace std;
 
 BindResult ExpressionBinder::BindExpression(FunctionExpression &function, idx_t depth) {
 	// lookup the function in the catalog
+	QueryErrorContext error_context(binder.root_statement, function.query_location);
 
 	if (function.function_name == "unnest" || function.function_name == "unlist") {
 		// special case, not in catalog
@@ -19,9 +20,9 @@ BindResult ExpressionBinder::BindExpression(FunctionExpression &function, idx_t 
 		// have unnest live in catalog, too
 		return BindUnnest(function, depth);
 	}
-
-	auto func = Catalog::GetCatalog(context).GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, function.schema,
-	                                                  function.function_name);
+	auto &catalog = Catalog::GetCatalog(context);
+	auto func = catalog.GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, function.schema,
+	                             function.function_name, false, error_context);
 	if (func->type == CatalogType::SCALAR_FUNCTION_ENTRY) {
 		// scalar function
 		return BindFunction(function, (ScalarFunctionCatalogEntry *)func, depth);
@@ -51,30 +52,33 @@ BindResult ExpressionBinder::BindFunction(FunctionExpression &function, ScalarFu
 	// FIXME: these shouldn't be special
 	if (function.function_name == "alias") {
 		if (children.size() != 1) {
-			throw BinderException("alias function expects a single argument");
+			throw BinderException(binder.FormatError(function, "alias function expects a single argument"));
 		}
 		// alias function: returns the alias of the current expression, or the name of the child
 		string alias = !function.alias.empty() ? function.alias : children[0]->GetName();
 		return BindResult(make_unique<BoundConstantExpression>(Value(alias)));
 	} else if (function.function_name == "typeof") {
 		if (children.size() != 1) {
-			throw BinderException("typeof function expects a single argument");
+			throw BinderException(binder.FormatError(function, "typeof function expects a single argument"));
 		}
 		// typeof function: returns the type of the child expression
 		string type = children[0]->return_type.ToString();
 		return BindResult(make_unique<BoundConstantExpression>(Value(type)));
 	}
-	auto result = ScalarFunction::BindScalarFunction(context, *func, move(children), function.is_operator);
+	auto result = ScalarFunction::BindScalarFunction(context, *func, move(children), error, function.is_operator);
+	if (!result) {
+		throw BinderException(binder.FormatError(function, error));
+	}
 	return BindResult(move(result));
 }
 
 BindResult ExpressionBinder::BindAggregate(FunctionExpression &expr, AggregateFunctionCatalogEntry *function,
                                            idx_t depth) {
-	return BindResult(UnsupportedAggregateMessage());
+	return BindResult(binder.FormatError(expr, UnsupportedAggregateMessage()));
 }
 
 BindResult ExpressionBinder::BindUnnest(FunctionExpression &expr, idx_t depth) {
-	return BindResult(UnsupportedUnnestMessage());
+	return BindResult(binder.FormatError(expr, UnsupportedUnnestMessage()));
 }
 
 string ExpressionBinder::UnsupportedAggregateMessage() {

--- a/src/planner/binder/expression/bind_unnest_expression.cpp
+++ b/src/planner/binder/expression/bind_unnest_expression.cpp
@@ -15,7 +15,7 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth) {
 	// bind the children of the function expression
 	string error;
 	if (function.children.size() != 1) {
-		return BindResult("Unnest() needs exactly one child expressions");
+		return BindResult(binder.FormatError(function, "Unnest() needs exactly one child expressions"));
 	}
 	BindChild(function.children[0], depth, error);
 	if (!error.empty()) {
@@ -24,7 +24,7 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth) {
 	auto &child = (BoundExpression &)*function.children[0];
 	LogicalType child_type = child.expr->return_type;
 	if (child_type.id() != LogicalTypeId::LIST) {
-		return BindResult("Unnest() can only be applied to lists");
+		return BindResult(binder.FormatError(function, "Unnest() can only be applied to lists"));
 	}
 	LogicalType return_type = LogicalType::ANY;
 	assert(child_type.child_types().size() <= 1);

--- a/src/planner/binder/expression/bind_unnest_expression.cpp
+++ b/src/planner/binder/expression/bind_unnest_expression.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/planner/expression_binder/select_binder.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
 #include "duckdb/planner/expression/bound_unnest_expression.hpp"
+#include "duckdb/planner/binder.hpp"
 
 namespace duckdb {
 using namespace std;

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -42,9 +42,11 @@ SchemaCatalogEntry *Binder::BindSchema(CreateInfo &info) {
 
 void Binder::BindCreateViewInfo(CreateViewInfo &base) {
 	// bind the view as if it were a query so we can catch errors
-	// note that we bind a copy and don't actually use the bind result
+	// note that we bind the original, and replace the original with a copy
+	// this is because the original has
 	auto copy = base.query->Copy();
-	auto query_node = Bind(*copy);
+	auto query_node = Bind(*base.query);
+	base.query = move(copy);
 	if (base.aliases.size() > query_node.names.size()) {
 		throw BinderException("More VIEW aliases than columns in query result");
 	}

--- a/src/planner/binder/statement/bind_pragma.cpp
+++ b/src/planner/binder/statement/bind_pragma.cpp
@@ -10,7 +10,11 @@ BoundStatement Binder::Bind(PragmaStatement &stmt) {
 	auto &catalog = Catalog::GetCatalog(context);
 	// bind the pragma function
 	auto entry = catalog.GetEntry<PragmaFunctionCatalogEntry>(context, DEFAULT_SCHEMA, stmt.info->name, false);
-	idx_t bound_idx = Function::BindFunction(entry->name, entry->functions, *stmt.info);
+	string error;
+	idx_t bound_idx = Function::BindFunction(entry->name, entry->functions, *stmt.info, error);
+	if (bound_idx != INVALID_INDEX) {
+		throw BinderException(FormatError(stmt.stmt_location, error));
+	}
 	auto &bound_function = entry->functions[bound_idx];
 	if (!bound_function.function) {
 		throw BinderException("PRAGMA function does not have a function specified");

--- a/src/planner/binder/statement/bind_pragma.cpp
+++ b/src/planner/binder/statement/bind_pragma.cpp
@@ -12,7 +12,7 @@ BoundStatement Binder::Bind(PragmaStatement &stmt) {
 	auto entry = catalog.GetEntry<PragmaFunctionCatalogEntry>(context, DEFAULT_SCHEMA, stmt.info->name, false);
 	string error;
 	idx_t bound_idx = Function::BindFunction(entry->name, entry->functions, *stmt.info, error);
-	if (bound_idx != INVALID_INDEX) {
+	if (bound_idx == INVALID_INDEX) {
 		throw BinderException(FormatError(stmt.stmt_location, error));
 	}
 	auto &bound_function = entry->functions[bound_idx];

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -45,8 +45,8 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 	}
 	// not a CTE
 	// extract a table or view from the catalog
-	auto table_or_view =
-	    Catalog::GetCatalog(context).GetEntry(context, CatalogType::TABLE_ENTRY, ref.schema_name, ref.table_name, false, error_context);
+	auto table_or_view = Catalog::GetCatalog(context).GetEntry(context, CatalogType::TABLE_ENTRY, ref.schema_name,
+	                                                           ref.table_name, false, error_context);
 	switch (table_or_view->type) {
 	case CatalogType::TABLE_ENTRY: {
 		// base table: create the BoundBaseTableRef node

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -13,6 +13,7 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
+	QueryErrorContext error_context(root_statement, ref.query_location);
 	// CTEs and views are also referred to using BaseTableRefs, hence need to distinguish here
 	// check if the table name refers to a CTE
 	auto cte = FindCTE(ref.table_name);
@@ -45,7 +46,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 	// not a CTE
 	// extract a table or view from the catalog
 	auto table_or_view =
-	    Catalog::GetCatalog(context).GetEntry(context, CatalogType::TABLE_ENTRY, ref.schema_name, ref.table_name);
+	    Catalog::GetCatalog(context).GetEntry(context, CatalogType::TABLE_ENTRY, ref.schema_name, ref.table_name, false, error_context);
 	switch (table_or_view->type) {
 	case CatalogType::TABLE_ENTRY: {
 		// base table: create the BoundBaseTableRef node
@@ -95,7 +96,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		return bound_child;
 	}
 	default:
-		throw NotImplementedException("Catalog entry type");
+		throw InternalException("Catalog entry type");
 	}
 }
 } // namespace duckdb

--- a/src/planner/pragma_handler.cpp
+++ b/src/planner/pragma_handler.cpp
@@ -63,7 +63,11 @@ void PragmaHandler::HandlePragmaStatements(vector<unique_ptr<SQLStatement>> &sta
 string PragmaHandler::HandlePragma(PragmaInfo &info) {
 	auto entry =
 	    Catalog::GetCatalog(context).GetEntry<PragmaFunctionCatalogEntry>(context, DEFAULT_SCHEMA, info.name, false);
-	idx_t bound_idx = Function::BindFunction(entry->name, entry->functions, info);
+	string error;
+	idx_t bound_idx = Function::BindFunction(entry->name, entry->functions, info, error);
+	if (bound_idx != INVALID_INDEX) {
+		throw BinderException(error);
+	}
 	auto &bound_function = entry->functions[bound_idx];
 	if (bound_function.query) {
 		return bound_function.query(context, info.parameters);

--- a/src/planner/pragma_handler.cpp
+++ b/src/planner/pragma_handler.cpp
@@ -65,7 +65,7 @@ string PragmaHandler::HandlePragma(PragmaInfo &info) {
 	    Catalog::GetCatalog(context).GetEntry<PragmaFunctionCatalogEntry>(context, DEFAULT_SCHEMA, info.name, false);
 	string error;
 	idx_t bound_idx = Function::BindFunction(entry->name, entry->functions, info, error);
-	if (bound_idx != INVALID_INDEX) {
+	if (bound_idx == INVALID_INDEX) {
 		throw BinderException(error);
 	}
 	auto &bound_function = entry->functions[bound_idx];

--- a/test/sql/error/incorrect_sql.test
+++ b/test/sql/error/incorrect_sql.test
@@ -12,8 +12,36 @@ SELEC 42, 'thisisareallylongstringloremipsumblablathisisareallylongstringloremip
 statement error
 SELEC 42, '🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆';
 
+# unrecognized column
 statement error
 SELECT '🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆', x, '🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆';
+
+# unrecognized scalar function
+statement error
+SELECT FUNFUNFUN();
+
+statement error
+CREATE VIEW v1
+AS SELECT FUNFUNFUN();
+
+# unrecognized aggregate parameters
+statement error
+SELECT SUM(42, 84, 11, 'hello')
+
+# no matching function
+statement error
+SELECT cos(0, 1, 2, 3);
+
+# unrecognized table function
+statement error
+SELECT * FROM RANG();
+
+# unknown named parameters
+statement error
+SELECT * FROM RANGE(1, hello=3);
+
+statement error
+SELECT * FROM READ_CSV('x', hello=3);
 
 # multiple where clauses
 statement error

--- a/test/sql/error/incorrect_sql.test
+++ b/test/sql/error/incorrect_sql.test
@@ -1,0 +1,61 @@
+# name: test/sql/error/incorrect_sql.test
+# description: Test various incorrect SQL strings
+# group: [error]
+
+# typo
+statement error
+SELEC 42;
+
+# multiple where clauses
+statement error
+SELECT 42 WHERE 1=1 WHERE 1=0;
+
+# multiple statements without semi colon
+statement error
+SELECT 42
+SELECT 42;
+
+# non-existant table
+statement error
+SELECT * FROM integers2;
+
+statement ok
+CREATE TABLE integers(integ INTEGER);
+
+statement ok
+CREATE TABLE strings(str VARCHAR);
+
+statement ok
+CREATE TABLE chickens(feather INTEGER, beak INTEGER);
+
+# non-existant table, with several tables available
+statement error
+SELECT * FROM integres;
+
+# non-existant column
+statement error
+SELECT feathe FROM chickens;
+
+# non-existant column, with multiple tables
+statement error
+SELECT feathe FROM chickens, integers, strings;
+
+statement error
+SELECT st FROM chickens, integers, strings;
+
+statement error
+SELECT chicken.feather FROM chickens
+
+# table-qualified non-existant column
+statement error
+SELECT chicken.st FROM chickens, integers, strings;
+
+# now with unicode
+statement ok
+CREATE TABLE 🦆🍞(🦆🦆🦆 INTEGER, 🍞🍞🍞 INTEGER);
+
+statement error
+SELECT 🦆.🦆🦆🦆 FROM 🦆🍞
+
+statement error
+SELECT 🦆🦆 FROM 🦆🍞, chickens

--- a/test/sql/error/incorrect_sql.test
+++ b/test/sql/error/incorrect_sql.test
@@ -6,6 +6,15 @@
 statement error
 SELEC 42;
 
+statement error
+SELEC 42, 'thisisareallylongstringloremipsumblablathisisareallylongstringloremipsumblablalthisisareallylongstringloremipsumblablalthisisareallylongstringloremipsumblablal';
+
+statement error
+SELEC 42, '🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆';
+
+statement error
+SELECT '🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆', x, '🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆';
+
 # multiple where clauses
 statement error
 SELECT 42 WHERE 1=1 WHERE 1=0;
@@ -15,9 +24,61 @@ statement error
 SELECT 42
 SELECT 42;
 
-# non-existant table
+# multiple statements, but error is only in second statement
+statement error
+SELECT 42; SELEC 42;
+
+# non-existent table
 statement error
 SELECT * FROM integers2;
+
+# non-existent schema
+statement error
+SELECT * FROM bla.integers2;
+
+# non-existent table in view
+statement error
+CREATE VIEW v1 AS SELECT * FROM integers2;
+
+# non-existent table in long single-line query
+statement error
+with cte1 as (select 42 as j), cte2 as (select ref.j as k from cte1 as ref), cte3 as (select ref2.j+1 as i from cte1 as ref2) SELECT * FROM integers9;
+
+statement error
+with cte1 as (select 42 as j), cte2 as (select ref.j as k from cte1 as ref), cte3 as (select ref2.j+1 as i from cte1 as ref2) SELECT * FROM integers9 where x=3 order by x+1+1+1+1+1+1+1+1+1+1+1;
+
+# non-existent table in multi-line query (Q1)
+statement error
+SELECT
+    l_returnflag,
+    l_linestatus,
+    sum(l_quantity) AS sum_qty,
+    sum(l_extendedprice) AS sum_base_price,
+    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
+    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+    avg(l_quantity) AS avg_qty,
+    avg(l_extendedprice) AS avg_price,
+    avg(l_discount) AS avg_disc,
+    count(*) AS count_order
+FROM
+    lineitem
+WHERE
+    l_shipdate <= CAST('1998-09-02' AS date)
+GROUP BY
+    l_returnflag,
+    l_linestatus
+ORDER BY
+    l_returnflag,
+    l_linestatus;
+
+# now with unicode
+# short unicode error
+statement error
+select 🦆🍞 from 🦆🍞;
+
+# long unicode error
+statement error
+with 🍞🍞 as (select 'bread' as 🍞), 🦆🦆 as (select ref.🍞 as "🍞" from 🍞🍞 as ref) SELECT * FROM integers9 where x LIKE '🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆' order by x+1+1+1+1+1+1+1+1+1+1+1;
 
 statement ok
 CREATE TABLE integers(integ INTEGER);
@@ -28,15 +89,15 @@ CREATE TABLE strings(str VARCHAR);
 statement ok
 CREATE TABLE chickens(feather INTEGER, beak INTEGER);
 
-# non-existant table, with several tables available
+# non-existent table, with several tables available
 statement error
 SELECT * FROM integres;
 
-# non-existant column
+# non-existent column
 statement error
 SELECT feathe FROM chickens;
 
-# non-existant column, with multiple tables
+# non-existent column, with multiple tables
 statement error
 SELECT feathe FROM chickens, integers, strings;
 
@@ -46,7 +107,7 @@ SELECT st FROM chickens, integers, strings;
 statement error
 SELECT chicken.feather FROM chickens
 
-# table-qualified non-existant column
+# table-qualified non-existent column
 statement error
 SELECT chicken.st FROM chickens, integers, strings;
 

--- a/test/sqlite/test_sqllogictest.cpp
+++ b/test/sqlite/test_sqllogictest.cpp
@@ -305,8 +305,7 @@ static string sqllogictest_convert_value(Value value, LogicalType sql_type, bool
 }
 
 // standard result conversion: one line per value
-static int duckdbConvertResult(MaterializedQueryResult &result,
-                               bool original_sqlite_test,
+static int duckdbConvertResult(MaterializedQueryResult &result, bool original_sqlite_test,
                                vector<string> &pazResult /* RETURN:  Array of result values */
 ) {
 	size_t r, c;
@@ -1466,7 +1465,7 @@ struct AutoRegTests {
 		    "evidence/slt_lang_dropindex.test",                // "
 		    "evidence/slt_lang_createtrigger.test",            // "
 		    "evidence/slt_lang_droptrigger.test",              // "
-			"evidence/slt_lang_update.test"                    //  Multiple assignments to same column "x"
+		    "evidence/slt_lang_update.test"                    //  Multiple assignments to same column "x"
 		};
 		FileSystem fs;
 		fs.SetWorkingDirectory(DUCKDB_ROOT_DIRECTORY);

--- a/third_party/libpg_query/include/postgres_parser.hpp
+++ b/third_party/libpg_query/include/postgres_parser.hpp
@@ -14,5 +14,7 @@ public:
 	duckdb_libpgquery::PGList *parse_tree;
 	std::string error_message;
 	int error_location;
+
+	static std::string FormatErrorMessage(std::string query, std::string error_message, int error_location);
 };
 }

--- a/third_party/libpg_query/include/postgres_parser.hpp
+++ b/third_party/libpg_query/include/postgres_parser.hpp
@@ -14,7 +14,5 @@ public:
 	duckdb_libpgquery::PGList *parse_tree;
 	std::string error_message;
 	int error_location;
-
-	static std::string FormatErrorMessage(std::string query, std::string error_message, int error_location);
 };
 }

--- a/third_party/libpg_query/pg_functions.cpp
+++ b/third_party/libpg_query/pg_functions.cpp
@@ -70,7 +70,6 @@ void pg_parser_init() {
 }
 
 void pg_parser_parse(const char *query, parse_result *res) {
-
 	res->parse_tree = nullptr;
 	try {
 		res->parse_tree = duckdb_libpgquery::raw_parser(query);

--- a/third_party/libpg_query/postgres_parser.cpp
+++ b/third_party/libpg_query/postgres_parser.cpp
@@ -23,6 +23,46 @@ void PostgresParser::Parse(string query) {
 	}
 }
 
+string PostgresParser::FormatErrorMessage(string query, string error_message, int error_loc) {
+	error_loc--;
+	if (error_loc < 0 || size_t(error_loc) >= query.size()) {
+		// no location in query provided
+		return error_message;
+	}
+	size_t error_location = size_t(error_loc);
+	// count the line numbers until the error location
+	size_t line_number = 1;
+	for(size_t i = 0; i < error_location; i++) {
+		if (query[i] == '\n' || query[i] == '\r') {
+			line_number++;
+		}
+	}
+	// scan the query backwards from the error location to find the first newline
+	// we also show max 40 characters before the error location, to deal with long lines
+	size_t start_pos = 0;
+	for(size_t i = error_location; i > 0 && error_location - i < 40; i--) {
+		if (query[i - 1] == '\n' || query[i - 1] == '\r') {
+			start_pos = i;
+			break;
+		}
+	}
+	// find the end of the line, or max 40 characters AFTER the error location
+	size_t end_pos = query.size() - 1;
+	for(size_t i = error_location; i < query.size() - 1 && i - error_location < 40; i++) {
+		if (query[i] == '\n' || query[i] == '\r') {
+			end_pos = i;
+			break;
+		}
+	}
+	string line_indicator = "LINE " + to_string(line_number) + ": ";
+
+	// now first print the error message plus the current line (or a subset of the line)
+	error_message += "\n" + line_indicator + query.substr(start_pos, end_pos - start_pos);
+	// print an arrow pointing at the error location
+	error_message += "\n" + string(error_location - start_pos + line_indicator.size(), ' ') + "^";
+	return error_message;
+}
+
 PostgresParser::~PostgresParser()  {
     duckdb_libpgquery::pg_parser_cleanup();
 }

--- a/third_party/libpg_query/postgres_parser.cpp
+++ b/third_party/libpg_query/postgres_parser.cpp
@@ -23,46 +23,6 @@ void PostgresParser::Parse(string query) {
 	}
 }
 
-string PostgresParser::FormatErrorMessage(string query, string error_message, int error_loc) {
-	error_loc--;
-	if (error_loc < 0 || size_t(error_loc) >= query.size()) {
-		// no location in query provided
-		return error_message;
-	}
-	size_t error_location = size_t(error_loc);
-	// count the line numbers until the error location
-	size_t line_number = 1;
-	for(size_t i = 0; i < error_location; i++) {
-		if (query[i] == '\n' || query[i] == '\r') {
-			line_number++;
-		}
-	}
-	// scan the query backwards from the error location to find the first newline
-	// we also show max 40 characters before the error location, to deal with long lines
-	size_t start_pos = 0;
-	for(size_t i = error_location; i > 0 && error_location - i < 40; i--) {
-		if (query[i - 1] == '\n' || query[i - 1] == '\r') {
-			start_pos = i;
-			break;
-		}
-	}
-	// find the end of the line, or max 40 characters AFTER the error location
-	size_t end_pos = query.size() - 1;
-	for(size_t i = error_location; i < query.size() - 1 && i - error_location < 40; i++) {
-		if (query[i] == '\n' || query[i] == '\r') {
-			end_pos = i;
-			break;
-		}
-	}
-	string line_indicator = "LINE " + to_string(line_number) + ": ";
-
-	// now first print the error message plus the current line (or a subset of the line)
-	error_message += "\n" + line_indicator + query.substr(start_pos, end_pos - start_pos);
-	// print an arrow pointing at the error location
-	error_message += "\n" + string(error_location - start_pos + line_indicator.size(), ' ') + "^";
-	return error_message;
-}
-
 PostgresParser::~PostgresParser()  {
     duckdb_libpgquery::pg_parser_cleanup();
 }

--- a/third_party/sqlsmith/duckdb.cc
+++ b/third_party/sqlsmith/duckdb.cc
@@ -13,7 +13,7 @@
 using namespace duckdb;
 using namespace std;
 
-static regex e_syntax("Query Error: syntax error at or near .*");
+static regex e_syntax("syntax error at or near .*");
 
 duckdb_connection::duckdb_connection(string &conninfo) {
 	// in-memory database


### PR DESCRIPTION
This branch improves error messages that are printed for common errors made by the user. We introduce a method of printing the location in the query in which an error occurs, and we try to offer suggestions for alternatives. Printing the location in the query in which an error occurs is not enabled everywhere, but it is enabled in certain common errors (column not found in from clause, table/view not found, unrecognized function/table function).

For an example of new error message, see e.g.:

```sql
create table integers(i integer);
select x from integers;
-- Binder Error: Referenced column "x" not found in FROM clause!
-- Candidate bindings: "integers.i"
-- LINE 1: select x from integers;
                  ^
```

The candidate bindings are extracted and ordered using a LevenshteinDistance distance metric, which means the most similar bindings are shown first. For example, if we have a bunch of tables with very random and totally non-specific names, error messages extract the most similar name and offer it as a suggestion:

```sql
CREATE TABLE part(i INTEGER);
CREATE TABLE partsupp(i INTEGER);
CREATE TABLE supplier(i INTEGER);
CREATE TABLE customer(i INTEGER);
CREATE TABLE orders(i INTEGER);
CREATE TABLE lineitem(i INTEGER);
CREATE TABLE nation(i INTEGER);
CREATE TABLE region(i INTEGER);
SELECT * FROM suppleir;
-- Catalog Error: Table with name suppleir does not exist!
-- Did you mean "supplier"?
-- LINE 1: SELECT * FROM suppleir;
SELECT * FROM linetime;
-- Catalog Error: Table with name linetime does not exist!
-- Did you mean "lineitem"?
-- LINE 1: SELECT * FROM linetime;
```

This also works with misspelled column names:
```sql
CREATE TABLE lineitem(l_orderkey INT NOT NULL,
                      l_partkey INT NOT NULL,
                      l_suppkey INT NOT NULL,
                      l_linenumber INT NOT NULL,
                      l_quantity INTEGER NOT NULL,
                      l_extendedprice DECIMAL(15, 2) NOT NULL,
                      l_discount DECIMAL(15, 2) NOT NULL,
                      l_tax DECIMAL(15, 2) NOT NULL,
                      l_returnflag VARCHAR(1) NOT NULL,
                      l_linestatus VARCHAR(1) NOT NULL,
                      l_shipdate DATE NOT NULL,
                      l_commitdate DATE NOT NULL,
                      l_receiptdate DATE NOT NULL,
                      l_shipinstruct VARCHAR(25) NOT NULL,
                      l_shipmode VARCHAR(10) NOT NULL,
                      l_comment VARCHAR(44) NOT NULL);
select l_odorkey FROM lineitem;
-- Binder Error: Referenced column "l_odorkey" not found in FROM clause!
-- Candidate bindings: "lineitem.l_orderkey", "lineitem.l_partkey", "lineitem.l_suppkey"
-- LINE 1: select l_odorkey FROM lineitem;
select l_recieptdate FROM lineitem;
-- Binder Error: Referenced column "l_recieptdate" not found in FROM clause!
-- Candidate bindings: "lineitem.l_receiptdate", "lineitem.l_shipdate"
-- LINE 1: select l_recieptdate FROM lineitem
```

... and with functions/table functions:
```sql
select 'hello', 
            substrong('hello', 1, 3);
-- Catalog Error: Scalar Function with name substrong does not exist!
-- Did you mean "substring"?
-- LINE 2:             substrong('hello', 1, 3);
```

Currently only parser/binder errors show the query context; there is still some work to be done so run-time errors (e.g. failing casts) also show the location in the query where they fail. 