### PR TITLE
Dynamic Syntax Highlighting in Shell

### DIFF
--- a/third_party/libpg_query/postgres_parser.cpp
+++ b/third_party/libpg_query/postgres_parser.cpp
@@ -26,7 +26,9 @@ void PostgresParser::Parse(string query) {
 
 vector<duckdb_libpgquery::PGSimplifiedToken> PostgresParser::Tokenize(std::string query) {
 	duckdb_libpgquery::pg_parser_init();
-	return duckdb_libpgquery::tokenize(query.c_str());
+	auto tokens = duckdb_libpgquery::tokenize(query.c_str());
+	duckdb_libpgquery::pg_parser_cleanup();
+	return tokens;
 }
 
 PostgresParser::~PostgresParser()  {

--- a/third_party/libpg_query/src_backend_parser_parser.cpp
+++ b/third_party/libpg_query/src_backend_parser_parser.cpp
@@ -80,7 +80,12 @@ std::vector<PGSimplifiedToken> tokenize(const char *str) {
 	while(true) {
 		YYSTYPE type;
 		YYLTYPE loc;
-		int token = base_yylex(&type, &loc, yyscanner);
+		int token;
+		try {
+			token = base_yylex(&type, &loc, yyscanner);
+		} catch(...) {
+			token = 0;
+		}
 		if (token == 0) {
 			break;
 		}

--- a/tools/shell/CMakeLists.txt
+++ b/tools/shell/CMakeLists.txt
@@ -3,7 +3,7 @@ add_definitions(-DSQLITE_OMIT_LOAD_EXTENSION=1)
 set(SHELL_SOURCES shell.c)
 if(NOT WIN32)
   add_definitions(-DHAVE_LINENOISE=1)
-  set(SHELL_SOURCES ${SHELL_SOURCES} linenoise.c)
+  set(SHELL_SOURCES ${SHELL_SOURCES} linenoise.cpp)
   include_directories(../../third_party/third_party/utf8proc/include)
 endif()
 

--- a/tools/shell/include/linenoise.h
+++ b/tools/shell/include/linenoise.h
@@ -58,6 +58,7 @@ void linenoiseAddCompletion(linenoiseCompletions *, const char *);
 
 char *linenoise(const char *prompt);
 void linenoiseFree(void *ptr);
+int linenoiseParseOption(const char **azArg, int nArg, const char **out_error);
 int linenoiseHistoryAdd(const char *line);
 int linenoiseHistorySetMaxLen(int len);
 int linenoiseHistorySave(const char *filename);

--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -223,11 +223,12 @@ test('.trace %s\n; SELECT 42;' % tf(), err='sqlite3_trace_v2')
 
 outfile = tf()
 test('''
+.mode csv
 .output %s
 SELECT 42;
 ''' % outfile)
-outstr = open(outfile,'r').read()
-if '42' not in outstr:
+outstr = open(outfile,'rb').read()
+if b'42' not in outstr:
      raise Exception('.output test failed')
 
 
@@ -236,10 +237,9 @@ test('''
 .once %s
 SELECT 43;
 ''' % outfile)
-outstr = open(outfile,'r').read()
-if '43' not in outstr:
+outstr = open(outfile,'rb').read()
+if b'43' not in outstr:
      raise Exception('.once test failed')
-
 
 # This somehow does not log nor fail. works for me.
 test('''

--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -41,7 +41,13 @@ def tf():
 test('select \'asdf\' as a;', out='asdf')
 
 # test pragma
-test("CREATE TABLE t0(c0 INT);PRAGMA table_info('t0');", out='0|c0|INTEGER|false||false')
+test("""
+.mode csv
+.headers off
+.sep |
+CREATE TABLE t0(c0 INT);
+PRAGMA table_info('t0');
+""", out='0|c0|INTEGER|false||false')
 
 datafile = tf()
 print("42\n84",  file=open(datafile, 'w'))
@@ -198,9 +204,10 @@ test('.sha3sum')
 
 
 test('''
+.mode csv
 .separator XX
 SELECT 42,43;
-''', out="XX")
+''', out="42XX43")
 
 test('''
 .timer on

--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -19821,12 +19821,19 @@ static int do_meta_command(char *zLine, ShellState *p){
     for(j=1; j<nArg; j++){
       p->colWidth[j-1] = (int)integerValue(azArg[j]);
     }
-  }else
-
+  } else
   {
-    utf8_printf(stderr, "Error: unknown command or invalid arguments: "
-      " \"%s\". Enter \".help\" for help\n", azArg[0]);
-    rc = 1;
+    const char *error = NULL;
+    if (linenoiseParseOption((const char**) azArg, nArg, &error)) {
+      if (error) {
+        utf8_printf(stderr, "Error: %s\n", error);
+        rc = 1;
+      }
+    } else {
+      utf8_printf(stderr, "Error: unknown command or invalid arguments: "
+        " \"%s\". Enter \".help\" for help\n", azArg[0]);
+      rc = 1;
+    }
   }
 
 meta_command_exit:

--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -20122,7 +20122,7 @@ static char *find_home_dir(int clearFlag){
 
 /*
 ** Read input from the file given by sqliterc_override.  Or if that
-** parameter is NULL, take input from ~/.sqliterc
+** parameter is NULL, take input from ~/.duckdbrc
 **
 ** Returns the number of errors.
 */
@@ -20140,10 +20140,10 @@ static void process_sqliterc(
     home_dir = find_home_dir(0);
     if( home_dir==0 ){
       raw_printf(stderr, "-- warning: cannot find home directory;"
-                      " cannot read ~/.sqliterc\n");
+                      " cannot read ~/.duckdbrc\n");
       return;
     }
-    zBuf = sqlite3_mprintf("%s/.sqliterc",home_dir);
+    zBuf = sqlite3_mprintf("%s/.duckdbrc",home_dir);
     sqliterc = zBuf;
   }
   p->in = fopen(sqliterc,"rb");

--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -19834,7 +19834,9 @@ static int do_meta_command(char *zLine, ShellState *p){
       utf8_printf(stderr, "Error: unknown command or invalid arguments: "
         " \"%s\". Enter \".help\" for help\n", azArg[0]);
       rc = 1;
+#ifdef HAVE_LINENOISE
     }
+#endif
   }
 
 meta_command_exit:

--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -1885,7 +1885,7 @@ static unsigned char *SHA3Final(SHA3Context *p){
 ** Implementation of the sha3(X,SIZE) function.
 **
 ** Return a BLOB which is the SIZE-bit SHA3 hash of X.  The default
-** size is 256.  If X is a BLOB, it is hashed as is.  
+** size is 256.  If X is a BLOB, it is hashed as is.
 ** For all other non-NULL types of input, X is converted into a UTF-8 string
 ** and the string is hashed without the trailing 0x00 terminator.  The hash
 ** of a NULL value is NULL.
@@ -2185,8 +2185,8 @@ int sqlite3_shathree_init(
 **            directory, NULL.
 **
 **   If a non-NULL value is specified for the optional $dir parameter and
-**   $path is a relative path, then $path is interpreted relative to $dir. 
-**   And the paths returned in the "name" column of the table are also 
+**   $path is a relative path, then $path is interpreted relative to $dir.
+**   And the paths returned in the "name" column of the table are also
 **   relative to directory $dir.
 */
 /* #include "sqlite3ext.h" */
@@ -2236,7 +2236,7 @@ SQLITE_EXTENSION_INIT1
 
 
 /*
-** Set the result stored by context ctx to a blob containing the 
+** Set the result stored by context ctx to a blob containing the
 ** contents of file zName.  Or, leave the result unchanged (NULL)
 ** if the file does not exist or is unreadable.
 **
@@ -2453,7 +2453,7 @@ static int makeDirectory(
 }
 
 /*
-** This function does the work for the writefile() UDF. Refer to 
+** This function does the work for the writefile() UDF. Refer to
 ** header comments at the top of this file for details.
 */
 static int writeFile(
@@ -2567,7 +2567,7 @@ static int writeFile(
 }
 
 /*
-** Implementation of the "writefile(W,X[,Y[,Z]]])" SQL function.  
+** Implementation of the "writefile(W,X[,Y[,Z]]])" SQL function.
 ** Refer to header comments at the top of this file for details.
 */
 static void writefileFunc(
@@ -2581,7 +2581,7 @@ static void writefileFunc(
   sqlite3_int64 mtime = -1;
 
   if( argc<2 || argc>4 ){
-    sqlite3_result_error(context, 
+    sqlite3_result_error(context,
         "wrong number of arguments to function writefile()", -1
     );
     return;
@@ -2651,7 +2651,7 @@ static void lsModeFunc(
 
 #ifndef SQLITE_OMIT_VIRTUALTABLE
 
-/* 
+/*
 ** Cursor type for recursively iterating through a directory structure.
 */
 typedef struct fsdir_cursor fsdir_cursor;
@@ -2799,7 +2799,7 @@ static int fsdirNext(sqlite3_vtab_cursor *cur){
     }
     pCur->iLvl = iNew;
     pLvl = &pCur->aLvl[iNew];
-    
+
     pLvl->zDir = pCur->zPath;
     pCur->zPath = 0;
     pLvl->pDir = opendir(pLvl->zDir);
@@ -2930,7 +2930,7 @@ static int fsdirEof(sqlite3_vtab_cursor *cur){
 ** idxNum==2   Both PATH and DIR supplied
 */
 static int fsdirFilter(
-  sqlite3_vtab_cursor *cur, 
+  sqlite3_vtab_cursor *cur,
   int idxNum, const char *idxStr,
   int argc, sqlite3_value **argv
 ){
@@ -3019,7 +3019,7 @@ static int fsdirBestIndex(
         }
         break;
       }
-    } 
+    }
   }
   if( seenPath || seenDir ){
     /* If input parameters are unusable, disallow this plan */
@@ -3090,14 +3090,14 @@ static int fsdirRegister(sqlite3 *db){
 
 #endif
 int sqlite3_fileio_init(
-  sqlite3 *db, 
-  char **pzErrMsg, 
+  sqlite3 *db,
+  char **pzErrMsg,
   const sqlite3_api_routines *pApi
 ){
   int rc = SQLITE_OK;
   SQLITE_EXTENSION_INIT2(pApi);
   (void)pzErrMsg;  /* Unused parameter */
-  rc = sqlite3_create_function(db, "readfile", 1, 
+  rc = sqlite3_create_function(db, "readfile", 1,
                                SQLITE_UTF8|SQLITE_DIRECTONLY, 0,
                                readfileFunc, 0, 0);
   if( rc==SQLITE_OK ){
@@ -3466,11 +3466,11 @@ static int completionEof(sqlite3_vtab_cursor *cur){
 /*
 ** This method is called to "rewind" the completion_cursor object back
 ** to the first row of output.  This method is always called at least
-** once prior to any call to completionColumn() or completionRowid() or 
+** once prior to any call to completionColumn() or completionRowid() or
 ** completionEof().
 */
 static int completionFilter(
-  sqlite3_vtab_cursor *pVtabCursor, 
+  sqlite3_vtab_cursor *pVtabCursor,
   int idxNum, const char *idxStr,
   int argc, sqlite3_value **argv
 ){
@@ -3562,7 +3562,7 @@ static int completionBestIndex(
 }
 
 /*
-** This following structure defines all the methods for the 
+** This following structure defines all the methods for the
 ** completion virtual table.
 */
 static sqlite3_module completionModule = {
@@ -3606,8 +3606,8 @@ int sqlite3CompletionVtabInit(sqlite3 *db){
 
 #endif
 int sqlite3_completion_init(
-  sqlite3 *db, 
-  char **pzErrMsg, 
+  sqlite3 *db,
+  char **pzErrMsg,
   const sqlite3_api_routines *pApi
 ){
   int rc = SQLITE_OK;
@@ -3760,7 +3760,7 @@ static sqlite3_vfs apnd_vfs = {
   1024,                         /* mxPathname */
   0,                            /* pNext */
   "apndvfs",                    /* zName */
-  0,                            /* pAppData (set when registered) */ 
+  0,                            /* pAppData (set when registered) */
   apndOpen,                     /* xOpen */
   apndDelete,                   /* xDelete */
   apndAccess,                   /* xAccess */
@@ -3815,9 +3815,9 @@ static int apndClose(sqlite3_file *pFile){
 ** Read data from an apnd-file.
 */
 static int apndRead(
-  sqlite3_file *pFile, 
-  void *zBuf, 
-  int iAmt, 
+  sqlite3_file *pFile,
+  void *zBuf,
+  int iAmt,
   sqlite_int64 iOfst
 ){
   ApndFile *p = (ApndFile *)pFile;
@@ -4034,7 +4034,7 @@ static sqlite3_int64 apndReadMark(sqlite3_int64 sz, sqlite3_file *pFile){
   if( rc ) return -1;
   if( memcmp(a, APND_MARK_PREFIX, APND_MARK_PREFIX_SZ)!=0 ) return -1;
   iMark = ((sqlite3_int64)(a[APND_MARK_PREFIX_SZ]&0x7f))<<56;
-  for(i=1; i<8; i++){    
+  for(i=1; i<8; i++){
     iMark += (sqlite3_int64)a[APND_MARK_PREFIX_SZ+i]<<(56-8*i);
   }
   return iMark;
@@ -4096,17 +4096,17 @@ static int apndDelete(sqlite3_vfs *pVfs, const char *zPath, int dirSync){
   return ORIGVFS(pVfs)->xDelete(ORIGVFS(pVfs), zPath, dirSync);
 }
 static int apndAccess(
-  sqlite3_vfs *pVfs, 
-  const char *zPath, 
-  int flags, 
+  sqlite3_vfs *pVfs,
+  const char *zPath,
+  int flags,
   int *pResOut
 ){
   return ORIGVFS(pVfs)->xAccess(ORIGVFS(pVfs), zPath, flags, pResOut);
 }
 static int apndFullPathname(
-  sqlite3_vfs *pVfs, 
-  const char *zPath, 
-  int nOut, 
+  sqlite3_vfs *pVfs,
+  const char *zPath,
+  int nOut,
   char *zOut
 ){
   return ORIGVFS(pVfs)->xFullPathname(ORIGVFS(pVfs),zPath,nOut,zOut);
@@ -4155,17 +4155,17 @@ static const char *apndNextSystemCall(sqlite3_vfs *pVfs, const char *zName){
   return ORIGVFS(pVfs)->xNextSystemCall(ORIGVFS(pVfs), zName);
 }
 
-  
+
 #ifdef _WIN32
 
 #endif
-/* 
+/*
 ** This routine is called when the extension is loaded.
 ** Register the new VFS.
 */
 int sqlite3_appendvfs_init(
-  sqlite3 *db, 
-  char **pzErrMsg, 
+  sqlite3 *db,
+  char **pzErrMsg,
   const sqlite3_api_routines *pApi
 ){
   int rc = SQLITE_OK;
@@ -4223,7 +4223,7 @@ static FILE *memtraceOut;
 /* Methods that trace memory allocations */
 static void *memtraceMalloc(int n){
   if( memtraceOut ){
-    fprintf(memtraceOut, "MEMTRACE: allocate %d bytes\n", 
+    fprintf(memtraceOut, "MEMTRACE: allocate %d bytes\n",
             memtraceBase.xRoundup(n));
   }
   return memtraceBase.xMalloc(n);
@@ -4384,8 +4384,8 @@ static int uintCollFunc(
 
 #endif
 int sqlite3_uint_init(
-  sqlite3 *db, 
-  char **pzErrMsg, 
+  sqlite3 *db,
+  char **pzErrMsg,
   const sqlite3_api_routines *pApi
 ){
   SQLITE_EXTENSION_INIT2(pApi);
@@ -4538,7 +4538,7 @@ static Decimal *decimal_new(
         p->nFrac = 0;
       }
     }
-    if( iExp>0 ){   
+    if( iExp>0 ){
       p->a = sqlite3_realloc64(p->a, p->nDigit + iExp + 1 );
       if( p->a==0 ) goto new_no_mem;
       memset(p->a+p->nDigit, 0, iExp);
@@ -4945,7 +4945,7 @@ static void decimalMulFunc(
   int minFrac;
   UNUSED_PARAMETER(argc);
   if( pA==0 || pA->oom || pA->isNull
-   || pB==0 || pB->oom || pB->isNull 
+   || pB==0 || pB->oom || pB->isNull
   ){
     goto mul_end;
   }
@@ -4991,8 +4991,8 @@ mul_end:
 
 #endif
 int sqlite3_decimal_init(
-  sqlite3 *db, 
-  char **pzErrMsg, 
+  sqlite3 *db,
+  char **pzErrMsg,
   const sqlite3_api_routines *pApi
 ){
   int rc = SQLITE_OK;
@@ -5283,8 +5283,8 @@ static void ieee754func_to_blob(
 
 #endif
 int sqlite3_ieee_init(
-  sqlite3 *db, 
-  char **pzErrMsg, 
+  sqlite3 *db,
+  char **pzErrMsg,
   const sqlite3_api_routines *pApi
 ){
   static const struct {
@@ -5306,7 +5306,7 @@ int sqlite3_ieee_init(
   SQLITE_EXTENSION_INIT2(pApi);
   (void)pzErrMsg;  /* Unused parameter */
   for(i=0; i<sizeof(aFunc)/sizeof(aFunc[0]) && rc==SQLITE_OK; i++){
-    rc = sqlite3_create_function(db, aFunc[i].zFName, aFunc[i].nArg,	
+    rc = sqlite3_create_function(db, aFunc[i].zFName, aFunc[i].nArg,
                                SQLITE_UTF8|SQLITE_INNOCUOUS,
                                (void*)&aFunc[i].iAux,
                                aFunc[i].xFunc, 0, 0);
@@ -5377,10 +5377,10 @@ typedef unsigned long u32;
 /*
 ** Definitions for mode bitmasks S_IFDIR, S_IFREG and S_IFLNK.
 **
-** In some ways it would be better to obtain these values from system 
+** In some ways it would be better to obtain these values from system
 ** header files. But, the dependency is undesirable and (a) these
 ** have been stable for decades, (b) the values are part of POSIX and
-** are also made explicit in [man stat], and (c) are part of the 
+** are also made explicit in [man stat], and (c) are part of the
 ** file format for zip archives.
 */
 #ifndef S_IFDIR
@@ -5393,7 +5393,7 @@ typedef unsigned long u32;
 # define S_IFLNK 0120000
 #endif
 
-static const char ZIPFILE_SCHEMA[] = 
+static const char ZIPFILE_SCHEMA[] =
   "CREATE TABLE y("
     "name PRIMARY KEY,"  /* 0: Name of file in zip archive */
     "mode,"              /* 1: POSIX mode for file */
@@ -5414,8 +5414,8 @@ static const char ZIPFILE_SCHEMA[] =
 **
 ** ZIPFILE_NEWENTRY_MADEBY:
 **   Use this value for the "version-made-by" field in new zip file
-**   entries. The upper byte indicates "unix", and the lower byte 
-**   indicates that the zip file matches pkzip specification 3.0. 
+**   entries. The upper byte indicates "unix", and the lower byte
+**   indicates that the zip file matches pkzip specification 3.0.
 **   This is what info-zip seems to do.
 **
 ** ZIPFILE_NEWENTRY_REQUIRED:
@@ -5444,7 +5444,7 @@ static const char ZIPFILE_SCHEMA[] =
 #define ZIPFILE_SIGNATURE_EOCD    0x06054b50
 
 /*
-** The sizes of the fixed-size part of each of the three main data 
+** The sizes of the fixed-size part of each of the three main data
 ** structures in a zip archive.
 */
 #define ZIPFILE_LFH_FIXED_SZ      30
@@ -5537,7 +5537,7 @@ struct ZipfileCDS {
 ***   uncompressed size               4 bytes
 ***   file name length                2 bytes
 ***   extra field length              2 bytes
-***   
+***
 */
 typedef struct ZipfileLFH ZipfileLFH;
 struct ZipfileLFH {
@@ -5563,7 +5563,7 @@ struct ZipfileEntry {
   ZipfileEntry *pNext;       /* Next element in in-memory CDS */
 };
 
-/* 
+/*
 ** Cursor type for zipfile tables.
 */
 typedef struct ZipfileCsr ZipfileCsr;
@@ -5636,7 +5636,7 @@ static void zipfileDequote(char *zIn){
 
 /*
 ** Construct a new ZipfileTab virtual table object.
-** 
+**
 **   argv[0]   -> module name  ("zipfile")
 **   argv[1]   -> database name
 **   argv[2]   -> table name
@@ -5704,7 +5704,7 @@ static void zipfileEntryFree(ZipfileEntry *p){
 }
 
 /*
-** Release resources that should be freed at the end of a write 
+** Release resources that should be freed at the end of a write
 ** transaction.
 */
 static void zipfileCleanupTransaction(ZipfileTab *pTab){
@@ -5813,7 +5813,7 @@ static void zipfileCursorErr(ZipfileCsr *pCsr, const char *zFmt, ...){
 /*
 ** Read nRead bytes of data from offset iOff of file pFile into buffer
 ** aRead[]. Return SQLITE_OK if successful, or an SQLite error code
-** otherwise. 
+** otherwise.
 **
 ** If an error does occur, output variable (*pzErrmsg) may be set to point
 ** to an English language error message. It is the responsibility of the
@@ -6018,7 +6018,7 @@ static int zipfileScanExtra(u8 *aExtra, int nExtra, u32 *pmTime){
 **   File modification date:
 **     Bits 00-04: day
 **     Bits 05-08: month (1-12)
-**     Bits 09-15: years from 1980 
+**     Bits 09-15: years from 1980
 **
 ** https://msdn.microsoft.com/en-us/library/9kkf9tah.aspx
 */
@@ -6088,9 +6088,9 @@ static void zipfileMtimeToDos(ZipfileCDS *pCds, u32 mUnixTime){
     pCds->mDate = pCds->mTime = 0;
   }
 
-  assert( mUnixTime<315507600 
-       || mUnixTime==zipfileMtime(pCds) 
-       || ((mUnixTime % 2) && mUnixTime-1==zipfileMtime(pCds)) 
+  assert( mUnixTime<315507600
+       || mUnixTime==zipfileMtime(pCds)
+       || ((mUnixTime % 2) && mUnixTime-1==zipfileMtime(pCds))
        /* || (mUnixTime % 2) */
   );
 }
@@ -6157,7 +6157,7 @@ static int zipfileGetEntry(
 
     if( rc==SQLITE_OK ){
       u32 *pt = &pNew->mUnixTime;
-      pNew->cds.zFile = sqlite3_mprintf("%.*s", nFile, aRead); 
+      pNew->cds.zFile = sqlite3_mprintf("%.*s", nFile, aRead);
       pNew->aExtra = (u8*)&pNew[1];
       memcpy(pNew->aExtra, &aRead[nFile], nExtra);
       if( pNew->cds.zFile==0 ){
@@ -6185,7 +6185,7 @@ static int zipfileGetEntry(
           memcpy(pNew->aData, &aBlob[pNew->iDataOff], pNew->cds.szCompressed);
         }
       }else{
-        *pzErr = sqlite3_mprintf("failed to read LFH at offset %d", 
+        *pzErr = sqlite3_mprintf("failed to read LFH at offset %d",
             (int)pNew->cds.iOffset
         );
       }
@@ -6237,8 +6237,8 @@ static int zipfileNext(sqlite3_vtab_cursor *cur){
   return rc;
 }
 
-static void zipfileFree(void *p) { 
-  sqlite3_free(p); 
+static void zipfileFree(void *p) {
+  sqlite3_free(p);
 }
 
 /*
@@ -6288,7 +6288,7 @@ static void zipfileInflate(
 ** Buffer aIn (size nIn bytes) contains uncompressed data. This function
 ** compresses it and sets (*ppOut) to point to a buffer containing the
 ** compressed data. The caller is responsible for eventually calling
-** sqlite3_free() to release buffer (*ppOut). Before returning, (*pnOut) 
+** sqlite3_free() to release buffer (*ppOut). Before returning, (*pnOut)
 ** is set to the size of buffer (*ppOut) in bytes.
 **
 ** If no error occurs, SQLITE_OK is returned. Otherwise, an SQLite error
@@ -6474,8 +6474,8 @@ static int zipfileReadEOCD(
 
     /* Scan backwards looking for the signature bytes */
     for(i=nRead-20; i>=0; i--){
-      if( aRead[i]==0x50 && aRead[i+1]==0x4b 
-       && aRead[i+2]==0x05 && aRead[i+3]==0x06 
+      if( aRead[i]==0x50 && aRead[i+1]==0x4b
+       && aRead[i+2]==0x05 && aRead[i+3]==0x06
       ){
         break;
       }
@@ -6500,14 +6500,14 @@ static int zipfileReadEOCD(
 }
 
 /*
-** Add object pNew to the linked list that begins at ZipfileTab.pFirstEntry 
+** Add object pNew to the linked list that begins at ZipfileTab.pFirstEntry
 ** and ends with pLastEntry. If argument pBefore is NULL, then pNew is added
 ** to the end of the list. Otherwise, it is added to the list immediately
 ** before pBefore (which is guaranteed to be a part of said list).
 */
 static void zipfileAddEntry(
-  ZipfileTab *pTab, 
-  ZipfileEntry *pBefore, 
+  ZipfileTab *pTab,
+  ZipfileEntry *pBefore,
   ZipfileEntry *pNew
 ){
   assert( (pTab->pFirstEntry==0)==(pTab->pLastEntry==0) );
@@ -6553,7 +6553,7 @@ static int zipfileLoadDirectory(ZipfileTab *pTab, const u8 *aBlob, int nBlob){
 ** xFilter callback.
 */
 static int zipfileFilter(
-  sqlite3_vtab_cursor *cur, 
+  sqlite3_vtab_cursor *cur,
   int idxNum, const char *idxStr,
   int argc, sqlite3_value **argv
 ){
@@ -6707,7 +6707,7 @@ static int zipfileAppendEntry(
 }
 
 static int zipfileGetMode(
-  sqlite3_value *pVal, 
+  sqlite3_value *pVal,
   int bIsDir,                     /* If true, default to directory */
   u32 *pMode,                     /* OUT: Mode value */
   char **pzErr                    /* OUT: Error message */
@@ -6770,7 +6770,7 @@ static int zipfileBegin(sqlite3_vtab *pVtab){
   }
 
   /* Open a write fd on the file. Also load the entire central directory
-  ** structure into memory. During the transaction any new file data is 
+  ** structure into memory. During the transaction any new file data is
   ** appended to the archive file, but the central directory is accumulated
   ** in main-memory until the transaction is committed.  */
   pTab->pWriteFd = fopen(pTab->zFile, "ab+");
@@ -6842,9 +6842,9 @@ static void zipfileRemoveEntryFromList(ZipfileTab *pTab, ZipfileEntry *pOld){
 ** xUpdate method.
 */
 static int zipfileUpdate(
-  sqlite3_vtab *pVtab, 
-  int nVal, 
-  sqlite3_value **apVal, 
+  sqlite3_vtab *pVtab,
+  int nVal,
+  sqlite3_value **apVal,
   sqlite_int64 *pRowid
 ){
   ZipfileTab *pTab = (ZipfileTab*)pVtab;
@@ -6897,7 +6897,7 @@ static int zipfileUpdate(
       rc = SQLITE_CONSTRAINT;
     }
     if( sqlite3_value_type(apVal[6])!=SQLITE_NULL ){
-      zipfileTableErr(pTab, "rawdata must be NULL"); 
+      zipfileTableErr(pTab, "rawdata must be NULL");
       rc = SQLITE_CONSTRAINT;
     }
 
@@ -7483,7 +7483,7 @@ static int zipfileRegister(sqlite3 *db){
   int rc = sqlite3_create_module(db, "zipfile"  , &zipfileModule, 0);
   if( rc==SQLITE_OK ) rc = sqlite3_overload_function(db, "zipfile_cds", -1);
   if( rc==SQLITE_OK ){
-    rc = sqlite3_create_function(db, "zipfile", -1, SQLITE_UTF8, 0, 0, 
+    rc = sqlite3_create_function(db, "zipfile", -1, SQLITE_UTF8, 0, 0,
         zipfileStep, zipfileFinal
     );
   }
@@ -7497,8 +7497,8 @@ static int zipfileRegister(sqlite3 *db){
 
 #endif
 int sqlite3_zipfile_init(
-  sqlite3 *db, 
-  char **pzErrMsg, 
+  sqlite3 *db,
+  char **pzErrMsg,
   const sqlite3_api_routines *pApi
 ){
   SQLITE_EXTENSION_INIT2(pApi);
@@ -7615,14 +7615,14 @@ static void sqlarUncompressFunc(
 
 #endif
 int sqlite3_sqlar_init(
-  sqlite3 *db, 
-  char **pzErrMsg, 
+  sqlite3 *db,
+  char **pzErrMsg,
   const sqlite3_api_routines *pApi
 ){
   int rc = SQLITE_OK;
   SQLITE_EXTENSION_INIT2(pApi);
   (void)pzErrMsg;  /* Unused parameter */
-  rc = sqlite3_create_function(db, "sqlar_compress", 1, 
+  rc = sqlite3_create_function(db, "sqlar_compress", 1,
                                SQLITE_UTF8|SQLITE_INNOCUOUS, 0,
                                sqlarCompressFunc, 0, 0);
   if( rc==SQLITE_OK ){
@@ -7672,7 +7672,7 @@ sqlite3expert *sqlite3_expert_new(sqlite3 *db, char **pzErr);
 **   By default, sqlite3_expert_analyze() generates sqlite_stat1 data for
 **   each candidate index. This involves scanning and sorting the entire
 **   contents of each user database table once for each candidate index
-**   associated with the table. For large databases, this can be 
+**   associated with the table. For large databases, this can be
 **   prohibitively slow. This option allows the sqlite3expert object to
 **   be configured so that sqlite_stat1 data is instead generated based on a
 **   subset of each table, or so that no sqlite_stat1 data is used at all.
@@ -7732,7 +7732,7 @@ int sqlite3_expert_sql(
 ** add further SQL statements to the analysis.
 **
 ** If successful, SQLITE_OK is returned and (*pzErr) is set to NULL. Or, if
-** an error occurs, an SQLite error code is returned and (*pzErr) set to 
+** an error occurs, an SQLite error code is returned and (*pzErr) set to
 ** point to a buffer containing an English language error message. In this
 ** case it is the responsibility of the caller to eventually free the buffer
 ** using sqlite3_free().
@@ -7761,7 +7761,7 @@ int sqlite3_expert_count(sqlite3expert*);
 ** The value passed as the third argument must be one of the EXPERT_REPORT_*
 ** #define constants defined below.
 **
-** For some EXPERT_REPORT_* parameters, the buffer returned contains 
+** For some EXPERT_REPORT_* parameters, the buffer returned contains
 ** information relating to a specific SQL statement. In these cases that
 ** SQL statement is identified by the value passed as the second argument.
 ** SQL statements are numbered from 0 in the order in which they are parsed.
@@ -7774,7 +7774,7 @@ int sqlite3_expert_count(sqlite3expert*);
 **
 ** EXPERT_REPORT_INDEXES:
 **   Return a buffer containing the CREATE INDEX statements for all recommended
-**   indexes for statement iStmt. If there are no new recommeded indexes, NULL 
+**   indexes for statement iStmt. If there are no new recommeded indexes, NULL
 **   is returned.
 **
 ** EXPERT_REPORT_PLAN:
@@ -7782,7 +7782,7 @@ int sqlite3_expert_count(sqlite3expert*);
 **   iStmt after the proposed indexes have been added to the database schema.
 **
 ** EXPERT_REPORT_CANDIDATES:
-**   Return a pointer to a buffer containing the CREATE INDEX statements 
+**   Return a pointer to a buffer containing the CREATE INDEX statements
 **   for all indexes that were tested (for all SQL statements). The iStmt
 **   parameter is ignored for EXPERT_REPORT_CANDIDATES calls.
 */
@@ -7797,8 +7797,8 @@ const char *sqlite3_expert_report(sqlite3expert*, int iStmt, int eReport);
 #define EXPERT_REPORT_CANDIDATES 4
 
 /*
-** Free an (sqlite3expert*) handle and all associated resources. There 
-** should be one call to this function for each successful call to 
+** Free an (sqlite3expert*) handle and all associated resources. There
+** should be one call to this function for each successful call to
 ** sqlite3-expert_new().
 */
 void sqlite3_expert_destroy(sqlite3expert*);
@@ -7824,7 +7824,7 @@ void sqlite3_expert_destroy(sqlite3expert*);
 #include <string.h>
 #include <stdio.h>
 
-#ifndef SQLITE_OMIT_VIRTUALTABLE 
+#ifndef SQLITE_OMIT_VIRTUALTABLE
 
 /* typedef sqlite3_int64 i64; */
 /* typedef sqlite3_uint64 u64; */
@@ -7877,7 +7877,7 @@ struct IdxScan {
 };
 
 /*
-** Information regarding a single database table. Extracted from 
+** Information regarding a single database table. Extracted from
 ** "PRAGMA table_info" by function idxGetTableInfo().
 */
 struct IdxColumn {
@@ -7961,7 +7961,7 @@ struct sqlite3expert {
 
 
 /*
-** Allocate and return nByte bytes of zeroed memory using sqlite3_malloc(). 
+** Allocate and return nByte bytes of zeroed memory using sqlite3_malloc().
 ** If the allocation fails, set *pRc to SQLITE_NOMEM and return NULL.
 */
 static void *idxMalloc(int *pRc, int nByte){
@@ -8017,11 +8017,11 @@ static int idxHashString(const char *z, int n){
 /*
 ** If zKey is already present in the hash table, return non-zero and do
 ** nothing. Otherwise, add an entry with key zKey and payload string zVal to
-** the hash table passed as the second argument. 
+** the hash table passed as the second argument.
 */
 static int idxHashAdd(
-  int *pRc, 
-  IdxHash *pHash, 
+  int *pRc,
+  IdxHash *pHash,
   const char *zKey,
   const char *zVal
 ){
@@ -8053,7 +8053,7 @@ static int idxHashAdd(
 }
 
 /*
-** If zKey/nKey is present in the hash table, return a pointer to the 
+** If zKey/nKey is present in the hash table, return a pointer to the
 ** hash-entry object.
 */
 static IdxHashEntry *idxHashFind(IdxHash *pHash, const char *zKey, int nKey){
@@ -8192,7 +8192,7 @@ static char *expertDequote(const char *zIn){
   return zRet;
 }
 
-/* 
+/*
 ** This function is the implementation of both the xConnect and xCreate
 ** methods of the r-tree virtual table.
 **
@@ -8248,7 +8248,7 @@ static int expertBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pIdxInfo){
   int rc = SQLITE_OK;
   int n = 0;
   IdxScan *pScan;
-  const int opmask = 
+  const int opmask =
     SQLITE_INDEX_CONSTRAINT_EQ | SQLITE_INDEX_CONSTRAINT_GT |
     SQLITE_INDEX_CONSTRAINT_LT | SQLITE_INDEX_CONSTRAINT_GE |
     SQLITE_INDEX_CONSTRAINT_LE;
@@ -8265,10 +8265,10 @@ static int expertBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pIdxInfo){
     /* Add the constraints to the IdxScan object */
     for(i=0; i<pIdxInfo->nConstraint; i++){
       struct sqlite3_index_constraint *pCons = &pIdxInfo->aConstraint[i];
-      if( pCons->usable 
-       && pCons->iColumn>=0 
+      if( pCons->usable
+       && pCons->iColumn>=0
        && p->pTab->aCol[pCons->iColumn].iPk==0
-       && (pCons->op & opmask) 
+       && (pCons->op & opmask)
       ){
         IdxConstraint *pNew;
         const char *zColl = sqlite3_vtab_collation(pIdxInfo, i);
@@ -8311,9 +8311,9 @@ static int expertBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pIdxInfo){
 }
 
 static int expertUpdate(
-  sqlite3_vtab *pVtab, 
-  int nData, 
-  sqlite3_value **azData, 
+  sqlite3_vtab *pVtab,
+  int nData,
+  sqlite3_value **azData,
   sqlite_int64 *pRowid
 ){
   (void)pVtab;
@@ -8323,7 +8323,7 @@ static int expertUpdate(
   return SQLITE_OK;
 }
 
-/* 
+/*
 ** Virtual table module xOpen method.
 */
 static int expertOpen(sqlite3_vtab *pVTab, sqlite3_vtab_cursor **ppCursor){
@@ -8335,7 +8335,7 @@ static int expertOpen(sqlite3_vtab *pVTab, sqlite3_vtab_cursor **ppCursor){
   return rc;
 }
 
-/* 
+/*
 ** Virtual table module xClose method.
 */
 static int expertClose(sqlite3_vtab_cursor *cur){
@@ -8348,7 +8348,7 @@ static int expertClose(sqlite3_vtab_cursor *cur){
 /*
 ** Virtual table module xEof method.
 **
-** Return non-zero if the cursor does not currently point to a valid 
+** Return non-zero if the cursor does not currently point to a valid
 ** record (i.e if the scan has finished), or zero otherwise.
 */
 static int expertEof(sqlite3_vtab_cursor *cur){
@@ -8356,7 +8356,7 @@ static int expertEof(sqlite3_vtab_cursor *cur){
   return pCsr->pData==0;
 }
 
-/* 
+/*
 ** Virtual table module xNext method.
 */
 static int expertNext(sqlite3_vtab_cursor *cur){
@@ -8375,7 +8375,7 @@ static int expertNext(sqlite3_vtab_cursor *cur){
   return rc;
 }
 
-/* 
+/*
 ** Virtual table module xRowid method.
 */
 static int expertRowid(sqlite3_vtab_cursor *cur, sqlite_int64 *pRowid){
@@ -8384,7 +8384,7 @@ static int expertRowid(sqlite3_vtab_cursor *cur, sqlite_int64 *pRowid){
   return SQLITE_OK;
 }
 
-/* 
+/*
 ** Virtual table module xColumn method.
 */
 static int expertColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int i){
@@ -8397,11 +8397,11 @@ static int expertColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int i){
   return SQLITE_OK;
 }
 
-/* 
+/*
 ** Virtual table module xFilter method.
 */
 static int expertFilter(
-  sqlite3_vtab_cursor *cur, 
+  sqlite3_vtab_cursor *cur,
   int idxNum, const char *idxStr,
   int argc, sqlite3_value **argv
 ){
@@ -8554,7 +8554,7 @@ static int idxGetTableInfo(
 }
 
 /*
-** This function is a no-op if *pRc is set to anything other than 
+** This function is a no-op if *pRc is set to anything other than
 ** SQLITE_OK when it is called.
 **
 ** If *pRc is initially set to SQLITE_OK, then the text specified by
@@ -8644,7 +8644,7 @@ static char *idxAppendColDefn(
 
 /*
 ** Search database dbm for an index compatible with the one idxCreateFromCons()
-** would create from arguments pScan, pEq and pTail. If no error occurs and 
+** would create from arguments pScan, pEq and pTail. If no error occurs and
 ** such an index is found, return non-zero. Or, if no such index is found,
 ** return zero.
 **
@@ -8720,7 +8720,7 @@ static int idxFindCompatible(
 static int idxCreateFromCons(
   sqlite3expert *p,
   IdxScan *pScan,
-  IdxConstraint *pEq, 
+  IdxConstraint *pEq,
   IdxConstraint *pTail
 ){
   sqlite3 *dbm = p->dbm;
@@ -8749,7 +8749,7 @@ static int idxCreateFromCons(
         h += ((h<<3) + zCols[i]);
       }
       zName = sqlite3_mprintf("%s_idx_%08x", zTable, h);
-      if( zName==0 ){ 
+      if( zName==0 ){
         rc = SQLITE_NOMEM;
       }else{
         if( idxIdentifierRequiresQuotes(zTable) ){
@@ -8787,7 +8787,7 @@ static int idxFindConstraint(IdxConstraint *pList, IdxConstraint *p){
 }
 
 static int idxCreateFromWhere(
-  sqlite3expert *p, 
+  sqlite3expert *p,
   IdxScan *pScan,                 /* Create indexes for this scan */
   IdxConstraint *pTail            /* range/ORDER BY constraints for inclusion */
 ){
@@ -8822,7 +8822,7 @@ static int idxCreateFromWhere(
 }
 
 /*
-** Create candidate indexes in database [dbm] based on the data in 
+** Create candidate indexes in database [dbm] based on the data in
 ** linked-list pScan.
 */
 static int idxCreateCandidates(sqlite3expert *p){
@@ -8869,7 +8869,7 @@ static void idxScanFree(IdxScan *pScan, IdxScan *pLast){
 }
 
 /*
-** Free all elements of the linked list starting from pStatement up 
+** Free all elements of the linked list starting from pStatement up
 ** until pLast (pLast is not freed).
 */
 static void idxStatementFree(IdxStatement *pStatement, IdxStatement *pLast){
@@ -8947,8 +8947,8 @@ int idxFindIndexes(
         const char *zIdx = 0;
         if( i+13<nDetail && memcmp(&zDetail[i], " USING INDEX ", 13)==0 ){
           zIdx = &zDetail[i+13];
-        }else if( i+22<nDetail 
-            && memcmp(&zDetail[i], " USING COVERING INDEX ", 22)==0 
+        }else if( i+22<nDetail
+            && memcmp(&zDetail[i], " USING COVERING INDEX ", 22)==0
         ){
           zIdx = &zDetail[i+22];
         }
@@ -9023,15 +9023,15 @@ static int idxAuthCallback(
 }
 
 static int idxProcessOneTrigger(
-  sqlite3expert *p, 
-  IdxWrite *pWrite, 
+  sqlite3expert *p,
+  IdxWrite *pWrite,
   char **pzErr
 ){
   static const char *zInt = UNIQUE_TABLE_NAME;
   static const char *zDrop = "DROP TABLE " UNIQUE_TABLE_NAME;
   IdxTable *pTab = pWrite->pTab;
   const char *zTab = pTab->zName;
-  const char *zSql = 
+  const char *zSql =
     "SELECT 'CREATE TEMP' || substr(sql, 7) FROM sqlite_schema "
     "WHERE tbl_name = %Q AND type IN ('table', 'trigger') "
     "ORDER BY type;";
@@ -9072,7 +9072,7 @@ static int idxProcessOneTrigger(
       int i;
       zWrite = idxAppendText(&rc, zWrite, "UPDATE %Q SET ", zInt);
       for(i=0; i<pTab->nCol; i++){
-        zWrite = idxAppendText(&rc, zWrite, "%s%Q=?", i==0 ? "" : ", ", 
+        zWrite = idxAppendText(&rc, zWrite, "%s%Q=?", i==0 ? "" : ", ",
             pTab->aCol[i].zName
         );
       }
@@ -9160,14 +9160,14 @@ static int idxCreateVtabSchema(sqlite3expert *p, char **pzErrmsg){
         /* The statement the vtab will pass to sqlite3_declare_vtab() */
         zInner = idxAppendText(&rc, 0, "CREATE TABLE x(");
         for(i=0; i<pTab->nCol; i++){
-          zInner = idxAppendText(&rc, zInner, "%s%Q COLLATE %s", 
+          zInner = idxAppendText(&rc, zInner, "%s%Q COLLATE %s",
               (i==0 ? "" : ", "), pTab->aCol[i].zName, pTab->aCol[i].zColl
           );
         }
         zInner = idxAppendText(&rc, zInner, ")");
 
         /* The CVT statement to create the vtab */
-        zOuter = idxAppendText(&rc, 0, 
+        zOuter = idxAppendText(&rc, 0,
             "CREATE VIRTUAL TABLE %Q USING expert(%Q)", zName, zInner
         );
         if( rc==SQLITE_OK ){
@@ -9305,7 +9305,7 @@ static void idxRemFunc(
 
 static int idxLargestIndex(sqlite3 *db, int *pnMax, char **pzErr){
   int rc = SQLITE_OK;
-  const char *zMax = 
+  const char *zMax =
     "SELECT max(i.seqno) FROM "
     "  sqlite_schema AS s, "
     "  pragma_index_list(s.name) AS l, "
@@ -9348,7 +9348,7 @@ static int idxPopulateOneStat1(
     const char *zComma = zCols==0 ? "" : ", ";
     const char *zName = (const char*)sqlite3_column_text(pIndexXInfo, 0);
     const char *zColl = (const char*)sqlite3_column_text(pIndexXInfo, 1);
-    zCols = idxAppendText(&rc, zCols, 
+    zCols = idxAppendText(&rc, zCols,
         "%sx.%Q IS rem(%d, x.%Q) COLLATE %s", zComma, zName, nCol, zName, zColl
     );
     zOrder = idxAppendText(&rc, zOrder, "%s%d", zComma, ++nCol);
@@ -9445,13 +9445,13 @@ static int idxBuildSampleTable(sqlite3expert *p, const char *zTab){
 ** indexes have already been created in database sqlite3expert.dbm, this
 ** function populates sqlite_stat1 table in the same database.
 **
-** The stat1 data is generated by querying the 
+** The stat1 data is generated by querying the
 */
 static int idxPopulateStat1(sqlite3expert *p, char **pzErr){
   int rc = SQLITE_OK;
   int nMax =0;
   struct IdxRemCtx *pCtx = 0;
-  struct IdxSampleCtx samplectx; 
+  struct IdxSampleCtx samplectx;
   int i;
   i64 iPrev = -100000;
   sqlite3_stmt *pAllIndex = 0;
@@ -9463,7 +9463,7 @@ static int idxPopulateStat1(sqlite3expert *p, char **pzErr){
     "  sqlite_schema AS s, "
     "  pragma_index_list(s.name) AS l "
     "WHERE s.type = 'table'";
-  const char *zIndexXInfo = 
+  const char *zIndexXInfo =
     "SELECT name, coll FROM pragma_index_xinfo(?) WHERE key";
   const char *zWrite = "INSERT INTO sqlite_stat1 VALUES(?, ?, ?)";
 
@@ -9519,7 +9519,7 @@ static int idxPopulateStat1(sqlite3expert *p, char **pzErr){
     iPrev = iRowid;
   }
   if( rc==SQLITE_OK && p->iSample<100 ){
-    rc = sqlite3_exec(p->dbv, 
+    rc = sqlite3_exec(p->dbv,
         "DROP TABLE IF EXISTS temp." UNIQUE_TABLE_NAME, 0,0,0
     );
   }
@@ -9567,12 +9567,12 @@ sqlite3expert *sqlite3_expert_new(sqlite3 *db, char **pzErrmsg){
       sqlite3_db_config(pNew->dbm, SQLITE_DBCONFIG_TRIGGER_EQP, 1, (int*)0);
     }
   }
-  
+
 
   /* Copy the entire schema of database [db] into [dbm]. */
   if( rc==SQLITE_OK ){
     sqlite3_stmt *pSql;
-    rc = idxPrintfPrepareStmt(pNew->db, &pSql, pzErrmsg, 
+    rc = idxPrintfPrepareStmt(pNew->db, &pSql, pzErrmsg,
         "SELECT sql FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%%'"
         " AND sql NOT LIKE 'CREATE VIRTUAL %%'"
     );
@@ -9693,8 +9693,8 @@ int sqlite3_expert_analyze(sqlite3expert *p, char **pzErr){
 
   /* Formulate the EXPERT_REPORT_CANDIDATES text */
   for(pEntry=p->hIdx.pFirst; pEntry; pEntry=pEntry->pNext){
-    p->zCandidates = idxAppendText(&rc, p->zCandidates, 
-        "%s;%s%s\n", pEntry->zVal, 
+    p->zCandidates = idxAppendText(&rc, p->zCandidates,
+        "%s;%s%s\n", pEntry->zVal,
         pEntry->zVal2 ? " -- stat1: " : "", pEntry->zVal2
     );
   }
@@ -9816,7 +9816,7 @@ void sqlite3_expert_destroy(sqlite3expert *p){
 **     INSERT INTO t1(rowid, a, b) VALUES(5, 'v', 'five');
 **     INSERT INTO t1(rowid, a, b) VALUES(10, 'x', 'ten');
 **
-**   the sqlite_dbdata table contains, as well as from entries related to 
+**   the sqlite_dbdata table contains, as well as from entries related to
 **   page 1, content equivalent to:
 **
 **     INSERT INTO sqlite_dbdata(pgno, cell, field, value) VALUES
@@ -9843,7 +9843,7 @@ void sqlite3_expert_destroy(sqlite3expert *p){
 **   It contains one entry for each b-tree pointer between a parent and
 **   child page in the database.
 */
-#if !defined(SQLITEINT_H) 
+#if !defined(SQLITEINT_H)
 /* #include "sqlite3ext.h" */
 
 /* typedef unsigned char u8; */
@@ -9853,7 +9853,7 @@ SQLITE_EXTENSION_INIT1
 #include <string.h>
 #include <assert.h>
 
-#define DBDATA_PADDING_BYTES 100 
+#define DBDATA_PADDING_BYTES 100
 
 typedef struct DbdataTable DbdataTable;
 typedef struct DbdataCursor DbdataCursor;
@@ -9879,7 +9879,7 @@ struct DbdataCursor {
   int iField;                     /* Current field number */
   u8 *pHdrPtr;
   u8 *pPtr;
-  
+
   sqlite3_int64 iIntkey;          /* Integer key value */
 };
 
@@ -9918,7 +9918,7 @@ struct DbdataTable {
       ")"
 
 /*
-** Connect to an sqlite_dbdata (pAux==0) or sqlite_dbptr (pAux!=0) virtual 
+** Connect to an sqlite_dbdata (pAux==0) or sqlite_dbptr (pAux!=0) virtual
 ** table.
 */
 static int dbdataConnect(
@@ -10037,7 +10037,7 @@ static int dbdataOpen(sqlite3_vtab *pVTab, sqlite3_vtab_cursor **ppCursor){
 }
 
 /*
-** Restore a cursor object to the state it was in when first allocated 
+** Restore a cursor object to the state it was in when first allocated
 ** by dbdataOpen().
 */
 static void dbdataResetCursor(DbdataCursor *pCsr){
@@ -10068,8 +10068,8 @@ static int dbdataClose(sqlite3_vtab_cursor *pCursor){
   return SQLITE_OK;
 }
 
-/* 
-** Utility methods to decode 16 and 32-bit big-endian unsigned integers. 
+/*
+** Utility methods to decode 16 and 32-bit big-endian unsigned integers.
 */
 static unsigned int get_uint16(unsigned char *a){
   return (a[0]<<8)|a[1];
@@ -10176,26 +10176,26 @@ static int dbdataValueBytes(int eType){
 ** result of context object pCtx.
 */
 static void dbdataValue(
-  sqlite3_context *pCtx, 
-  int eType, 
+  sqlite3_context *pCtx,
+  int eType,
   u8 *pData,
   int nData
 ){
   if( eType>=0 && dbdataValueBytes(eType)<=nData ){
     switch( eType ){
-      case 0: 
-      case 10: 
-      case 11: 
+      case 0:
+      case 10:
+      case 11:
         sqlite3_result_null(pCtx);
         break;
-      
-      case 8: 
+
+      case 8:
         sqlite3_result_int(pCtx, 0);
         break;
       case 9:
         sqlite3_result_int(pCtx, 1);
         break;
-  
+
       case 1: case 2: case 3: case 4: case 5: case 6: case 7: {
         sqlite3_uint64 v = (signed char)pData[0];
         pData++;
@@ -10207,7 +10207,7 @@ static void dbdataValue(
           case 3:  v = (v<<8) + pData[0];  pData++;
           case 2:  v = (v<<8) + pData[0];  pData++;
         }
-  
+
         if( eType==7 ){
           double r;
           memcpy(&r, &v, sizeof(r));
@@ -10217,7 +10217,7 @@ static void dbdataValue(
         }
         break;
       }
-  
+
       default: {
         int n = ((eType-12) / 2);
         if( eType % 2 ){
@@ -10278,7 +10278,7 @@ static int dbdataNext(sqlite3_vtab_cursor *pCursor){
         int iHdr;
         int U, X;
         int nLocal;
-  
+
         switch( pCsr->aPage[iOff] ){
           case 0x02:
             nPointer = 4;
@@ -10297,29 +10297,29 @@ static int dbdataNext(sqlite3_vtab_cursor *pCursor){
         if( pCsr->iCell>=pCsr->nCell ){
           bNextPage = 1;
         }else{
-  
+
           iOff += 8 + nPointer + pCsr->iCell*2;
           if( iOff>pCsr->nPage ){
             bNextPage = 1;
           }else{
             iOff = get_uint16(&pCsr->aPage[iOff]);
           }
-    
+
           /* For an interior node cell, skip past the child-page number */
           iOff += nPointer;
-    
+
           /* Load the "byte of payload including overflow" field */
           if( bNextPage || iOff>pCsr->nPage ){
             bNextPage = 1;
           }else{
             iOff += dbdataGetVarint(&pCsr->aPage[iOff], &nPayload);
           }
-    
+
           /* If this is a leaf intkey cell, load the rowid */
           if( bHasRowid && !bNextPage && iOff<pCsr->nPage ){
             iOff += dbdataGetVarint(&pCsr->aPage[iOff], &pCsr->iIntkey);
           }
-    
+
           /* Figure out how much data to read from the local page */
           U = pCsr->nPage;
           if( bHasRowid ){
@@ -10345,7 +10345,7 @@ static int dbdataNext(sqlite3_vtab_cursor *pCursor){
           }else{
 
             /* Allocate space for payload. And a bit more to catch small buffer
-            ** overruns caused by attempting to read a varint or similar from 
+            ** overruns caused by attempting to read a varint or similar from
             ** near the end of a corrupt record.  */
             pCsr->pRec = (u8*)sqlite3_malloc64(nPayload+DBDATA_PADDING_BYTES);
             if( pCsr->pRec==0 ) return SQLITE_NOMEM;
@@ -10378,7 +10378,7 @@ static int dbdataNext(sqlite3_vtab_cursor *pCursor){
                 sqlite3_free(aOvfl);
               }
             }
-    
+
             iHdr = dbdataGetVarint(pCsr->pRec, &nHdr);
             pCsr->nHdr = nHdr;
             pCsr->pHdrPtr = &pCsr->pRec[iHdr];
@@ -10424,7 +10424,7 @@ static int dbdataNext(sqlite3_vtab_cursor *pCursor){
   return SQLITE_OK;
 }
 
-/* 
+/*
 ** Return true if the cursor is at EOF.
 */
 static int dbdataEof(sqlite3_vtab_cursor *pCursor){
@@ -10432,9 +10432,9 @@ static int dbdataEof(sqlite3_vtab_cursor *pCursor){
   return pCsr->aPage==0;
 }
 
-/* 
+/*
 ** Determine the size in pages of database zSchema (where zSchema is
-** "main", "temp" or the name of an attached database) and set 
+** "main", "temp" or the name of an attached database) and set
 ** pCsr->szDb accordingly. If successful, return SQLITE_OK. Otherwise,
 ** an SQLite error code.
 */
@@ -10456,11 +10456,11 @@ static int dbdataDbsize(DbdataCursor *pCsr, const char *zSchema){
   return rc;
 }
 
-/* 
+/*
 ** xFilter method for sqlite_dbdata and sqlite_dbptr.
 */
 static int dbdataFilter(
-  sqlite3_vtab_cursor *pCursor, 
+  sqlite3_vtab_cursor *pCursor,
   int idxNum, const char *idxStr,
   int argc, sqlite3_value **argv
 ){
@@ -10487,7 +10487,7 @@ static int dbdataFilter(
       pCsr->pStmt = pTab->pStmt;
       pTab->pStmt = 0;
     }else{
-      rc = sqlite3_prepare_v2(pTab->db, 
+      rc = sqlite3_prepare_v2(pTab->db,
           "SELECT data FROM sqlite_dbpage(?) WHERE pgno=?", -1,
           &pCsr->pStmt, 0
       );
@@ -10504,12 +10504,12 @@ static int dbdataFilter(
   return rc;
 }
 
-/* 
+/*
 ** Return a column for the sqlite_dbdata or sqlite_dbptr table.
 */
 static int dbdataColumn(
-  sqlite3_vtab_cursor *pCursor, 
-  sqlite3_context *ctx, 
+  sqlite3_vtab_cursor *pCursor,
+  sqlite3_context *ctx,
   int i
 ){
   DbdataCursor *pCsr = (DbdataCursor*)pCursor;
@@ -10562,7 +10562,7 @@ static int dbdataColumn(
   return SQLITE_OK;
 }
 
-/* 
+/*
 ** Return the rowid for an sqlite_dbdata or sqlite_dptr table.
 */
 static int dbdataRowid(sqlite3_vtab_cursor *pCursor, sqlite_int64 *pRowid){
@@ -10614,8 +10614,8 @@ static int sqlite3DbdataRegister(sqlite3 *db){
 
 #endif
 int sqlite3_dbdata_init(
-  sqlite3 *db, 
-  char **pzErrMsg, 
+  sqlite3 *db,
+  char **pzErrMsg,
   const sqlite3_api_routines *pApi
 ){
   SQLITE_EXTENSION_INIT2(pApi);
@@ -10990,7 +10990,7 @@ static void editFunc(
       }
       sz = j;
       p[sz] = 0;
-    } 
+    }
     sqlite3_result_text64(context, (const char*)p, sz,
                           sqlite3_free, SQLITE_UTF8);
   }
@@ -12586,7 +12586,7 @@ static void bind_prepared_stmt(ShellState *pArg, sqlite3_stmt *pStmt){
 ** characters
 */
 static void print_box_line(FILE *out, int N){
-  const char zDash[] = 
+  const char zDash[] =
       BOX_24 BOX_24 BOX_24 BOX_24 BOX_24 BOX_24 BOX_24 BOX_24 BOX_24 BOX_24
       BOX_24 BOX_24 BOX_24 BOX_24 BOX_24 BOX_24 BOX_24 BOX_24 BOX_24 BOX_24;
   const int nDash = sizeof(zDash) - 1;
@@ -12867,8 +12867,8 @@ static void exec_prepared_stmt(
 ** caller to eventually free this buffer using sqlite3_free().
 */
 static int expertHandleSQL(
-  ShellState *pState, 
-  const char *zSql, 
+  ShellState *pState,
+  const char *zSql,
   char **pzErr
 ){
   assert( pState->expert.pExpert );
@@ -12878,7 +12878,7 @@ static int expertHandleSQL(
 
 /*
 ** This function is called either to silently clean up the object
-** created by the ".expert" command (if bCancel==1), or to generate a 
+** created by the ".expert" command (if bCancel==1), or to generate a
 ** report from it and then clean it up (if bCancel==0).
 **
 ** If successful, SQLITE_OK is returned. Otherwise, an SQLite error
@@ -13553,7 +13553,7 @@ static const char *(azHelp[]) = {
   "       -x     Send output as CSV to a spreadsheet (same as \".excel\")",
 #ifdef SQLITE_DEBUG
   ".oom ?--repeat M? ?N?    Simulate an OOM error on the N-th allocation",
-#endif 
+#endif
   ".open ?OPTIONS? ?FILE?   Close existing database and reopen FILE",
   "     Options:",
   "        --append        Use appendvfs to append database to the end of FILE",
@@ -13871,7 +13871,7 @@ int deduceDatabaseType(const char *zName, int dfltZip){
     }
   }
   fclose(f);
-  return rc;  
+  return rc;
 }
 
 #ifdef SQLITE_ENABLE_DESERIALIZE
@@ -13972,8 +13972,8 @@ readHexDb_error:
 ** offset (4*<arg2>) of the blob.
 */
 static void shellInt32(
-  sqlite3_context *context, 
-  int argc, 
+  sqlite3_context *context,
+  int argc,
   sqlite3_value **argv
 ){
   const unsigned char *pBlob;
@@ -14000,8 +14000,8 @@ static void shellInt32(
 ** using "..." with internal double-quote characters doubled.
 */
 static void shellIdQuote(
-  sqlite3_context *context, 
-  int argc, 
+  sqlite3_context *context,
+  int argc,
   sqlite3_value **argv
 ){
   const char *zName = (const char*)sqlite3_value_text(argv[0]);
@@ -14015,7 +14015,7 @@ static void shellIdQuote(
 /*
 ** Scalar function "shell_escape_crnl" used by the .recover command.
 ** The argument passed to this function is the output of built-in
-** function quote(). If the first character of the input is "'", 
+** function quote(). If the first character of the input is "'",
 ** indicating that the value passed to quote() was a text value,
 ** then this function searches the input for "\n" and "\r" characters
 ** and adds a wrapper similar to the following:
@@ -14026,8 +14026,8 @@ static void shellIdQuote(
 ** of the input is returned.
 */
 static void shellEscapeCrnl(
-  sqlite3_context *context, 
-  int argc, 
+  sqlite3_context *context,
+  int argc,
   sqlite3_value **argv
 ){
   const char *zText = (const char*)sqlite3_value_text(argv[0]);
@@ -14126,13 +14126,13 @@ static void open_db(ShellState *p, int openFlags){
       if( p->zDbFilename==0 || p->zDbFilename[0]==0 ){
         p->openMode = SHELL_OPEN_NORMAL;
       }else{
-        p->openMode = (u8)deduceDatabaseType(p->zDbFilename, 
+        p->openMode = (u8)deduceDatabaseType(p->zDbFilename,
                              (openFlags & OPEN_DB_ZIPFILE)!=0);
       }
     }
     switch( p->openMode ){
       case SHELL_OPEN_APPENDVFS: {
-        sqlite3_open_v2(p->zDbFilename, &p->db, 
+        sqlite3_open_v2(p->zDbFilename, &p->db,
            SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE|p->openFlags, "apndvfs");
         break;
       }
@@ -14243,7 +14243,7 @@ void close_db(sqlite3 *db){
   if( rc ){
     utf8_printf(stderr, "Error: sqlite3_close() returns %d: %s\n",
         rc, sqlite3_errmsg(db));
-  } 
+  }
 }
 
 #if HAVE_READLINE || HAVE_EDITLINE
@@ -15475,16 +15475,16 @@ static int lintDotCommand(
 
 #if !defined SQLITE_OMIT_VIRTUALTABLE
 static void shellPrepare(
-  sqlite3 *db, 
-  int *pRc, 
-  const char *zSql, 
+  sqlite3 *db,
+  int *pRc,
+  const char *zSql,
   sqlite3_stmt **ppStmt
 ){
   *ppStmt = 0;
   if( *pRc==SQLITE_OK ){
     int rc = sqlite3_prepare_v2(db, zSql, -1, ppStmt, 0);
     if( rc!=SQLITE_OK ){
-      raw_printf(stderr, "sql error: %s (%d)\n", 
+      raw_printf(stderr, "sql error: %s (%d)\n",
           sqlite3_errmsg(db), sqlite3_errcode(db)
       );
       *pRc = rc;
@@ -15500,10 +15500,10 @@ static void shellPrepare(
 ** nuisance compiler warnings about "defined but not used".
 */
 void shellPreparePrintf(
-  sqlite3 *db, 
-  int *pRc, 
+  sqlite3 *db,
+  int *pRc,
   sqlite3_stmt **ppStmt,
-  const char *zFmt, 
+  const char *zFmt,
   ...
 ){
   *ppStmt = 0;
@@ -15529,7 +15529,7 @@ void shellPreparePrintf(
 ** nuisance compiler warnings about "defined but not used".
 */
 void shellFinalize(
-  int *pRc, 
+  int *pRc,
   sqlite3_stmt *pStmt
 ){
   if( pStmt ){
@@ -15551,7 +15551,7 @@ void shellFinalize(
 ** nuisance compiler warnings about "defined but not used".
 */
 void shellReset(
-  int *pRc, 
+  int *pRc,
   sqlite3_stmt *pStmt
 ){
   int rc = sqlite3_reset(pStmt);
@@ -15598,7 +15598,7 @@ static int arUsage(FILE *f){
 }
 
 /*
-** Print an error message for the .ar command to stderr and return 
+** Print an error message for the .ar command to stderr and return
 ** SQLITE_ERROR.
 */
 static int arErrorMsg(ArCommand *pAr, const char *zFmt, ...){
@@ -15673,7 +15673,7 @@ static int arProcessSwitch(ArCommand *pAr, int eSwitch, const char *zArg){
 /*
 ** Parse the command line for an ".ar" command. The results are written into
 ** structure (*pAr). SQLITE_OK is returned if the command line is parsed
-** successfully, otherwise an error message is written to stderr and 
+** successfully, otherwise an error message is written to stderr and
 ** SQLITE_ERROR returned.
 */
 static int arParseCommand(
@@ -15814,7 +15814,7 @@ static int arParseCommand(
 
 /*
 ** This function assumes that all arguments within the ArCommand.azArg[]
-** array refer to archive members, as for the --extract or --list commands. 
+** array refer to archive members, as for the --extract or --list commands.
 ** It checks that each of them are present. If any specified file is not
 ** present in the archive, an error is printed to stderr and an error
 ** code returned. Otherwise, if all specified arguments are present in
@@ -15831,7 +15831,7 @@ static int arCheckEntries(ArCommand *pAr){
     sqlite3_stmt *pTest = 0;
 
     shellPreparePrintf(pAr->db, &rc, &pTest,
-        "SELECT name FROM %s WHERE name=$name", 
+        "SELECT name FROM %s WHERE name=$name",
         pAr->zSrcTable
     );
     j = sqlite3_bind_parameter_index(pTest, "$name");
@@ -15864,8 +15864,8 @@ static int arCheckEntries(ArCommand *pAr){
 ** any non-NULL (*pzWhere) value.
 */
 static void arWhereClause(
-  int *pRc, 
-  ArCommand *pAr, 
+  int *pRc,
+  ArCommand *pAr,
   char **pzWhere                  /* OUT: New WHERE clause */
 ){
   char *zWhere = 0;
@@ -15878,7 +15878,7 @@ static void arWhereClause(
       for(i=0; i<pAr->nArg; i++){
         const char *z = pAr->azArg[i];
         zWhere = sqlite3_mprintf(
-          "%z%s name = '%q' OR substr(name,1,%d) = '%q/'", 
+          "%z%s name = '%q' OR substr(name,1,%d) = '%q/'",
           zWhere, zSep, z, strlen30(z)+1, z
         );
         if( zWhere==0 ){
@@ -15893,10 +15893,10 @@ static void arWhereClause(
 }
 
 /*
-** Implementation of .ar "lisT" command. 
+** Implementation of .ar "lisT" command.
 */
 static int arListCommand(ArCommand *pAr){
-  const char *zSql = "SELECT %s FROM %s WHERE %s"; 
+  const char *zSql = "SELECT %s FROM %s WHERE %s";
   const char *azCols[] = {
     "name",
     "lsmode(mode), sz, datetime(mtime, 'unixepoch'), name"
@@ -15918,7 +15918,7 @@ static int arListCommand(ArCommand *pAr){
       if( pAr->bVerbose ){
         utf8_printf(pAr->p->out, "%s % 10d  %s  %s\n",
             sqlite3_column_text(pSql, 0),
-            sqlite3_column_int(pSql, 1), 
+            sqlite3_column_int(pSql, 1),
             sqlite3_column_text(pSql, 2),
             sqlite3_column_text(pSql, 3)
         );
@@ -15934,17 +15934,17 @@ static int arListCommand(ArCommand *pAr){
 
 
 /*
-** Implementation of .ar "eXtract" command. 
+** Implementation of .ar "eXtract" command.
 */
 static int arExtractCommand(ArCommand *pAr){
-  const char *zSql1 = 
+  const char *zSql1 =
     "SELECT "
     " ($dir || name),"
     " writefile(($dir || name), %s, mode, mtime) "
     "FROM %s WHERE (%s) AND (data IS NULL OR $dirOnly = 0)"
     " AND name NOT GLOB '*..[/\\]*'";
 
-  const char *azExtraArg[] = { 
+  const char *azExtraArg[] = {
     "sqlar_uncompress(data, sz)",
     "data"
   };
@@ -15970,7 +15970,7 @@ static int arExtractCommand(ArCommand *pAr){
     if( zDir==0 ) rc = SQLITE_NOMEM;
   }
 
-  shellPreparePrintf(pAr->db, &rc, &pSql, zSql1, 
+  shellPreparePrintf(pAr->db, &rc, &pSql, zSql1,
       azExtraArg[pAr->bZip], pAr->zSrcTable, zWhere
   );
 
@@ -16048,7 +16048,7 @@ static int arCreateOrUpdateCommand(
   int bUpdate,                    /* true for a --create. */
   int bOnlyIfChanged              /* Only update if file has changed */
 ){
-  const char *zCreate = 
+  const char *zCreate =
       "CREATE TABLE IF NOT EXISTS sqlar(\n"
       "  name TEXT PRIMARY KEY,  -- name of the file\n"
       "  mode INT,               -- access permissions\n"
@@ -16090,7 +16090,7 @@ static int arCreateOrUpdateCommand(
   arExecSql(pAr, "PRAGMA page_size=512");
   rc = arExecSql(pAr, "SAVEPOINT ar;");
   if( rc!=SQLITE_OK ) return rc;
-  zTemp[0] = 0; 
+  zTemp[0] = 0;
   if( pAr->bZip ){
     /* Initialize the zipfile virtual table, if necessary */
     if( pAr->zFile ){
@@ -16184,7 +16184,7 @@ static int arDotCommand(
     }else if( cmd.zFile ){
       int flags;
       if( cmd.bAppend ) eDbType = SHELL_OPEN_APPENDVFS;
-      if( cmd.eCmd==AR_CMD_CREATE || cmd.eCmd==AR_CMD_INSERT 
+      if( cmd.eCmd==AR_CMD_CREATE || cmd.eCmd==AR_CMD_INSERT
            || cmd.eCmd==AR_CMD_UPDATE ){
         flags = SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE;
       }else{
@@ -16195,10 +16195,10 @@ static int arDotCommand(
         utf8_printf(pState->out, "-- open database '%s'%s\n", cmd.zFile,
              eDbType==SHELL_OPEN_APPENDVFS ? " using 'apndvfs'" : "");
       }
-      rc = sqlite3_open_v2(cmd.zFile, &cmd.db, flags, 
+      rc = sqlite3_open_v2(cmd.zFile, &cmd.db, flags,
              eDbType==SHELL_OPEN_APPENDVFS ? "apndvfs" : 0);
       if( rc!=SQLITE_OK ){
-        utf8_printf(stderr, "cannot open file: %s (%s)\n", 
+        utf8_printf(stderr, "cannot open file: %s (%s)\n",
             cmd.zFile, sqlite3_errmsg(cmd.db)
         );
         goto end_ar_command;
@@ -16319,12 +16319,12 @@ static void *shellMalloc(int *pRc, sqlite3_int64 nByte){
 /*
 ** If *pRc is not SQLITE_OK when this function is called, it is a no-op.
 ** Otherwise, zFmt is treated as a printf() style string. The result of
-** formatting it along with any trailing arguments is written into a 
+** formatting it along with any trailing arguments is written into a
 ** buffer obtained from sqlite3_malloc(), and pointer to which is returned.
 ** It is the responsibility of the caller to eventually free this buffer
 ** using a call to sqlite3_free().
-** 
-** If an OOM error occurs, (*pRc) is set to SQLITE_NOMEM and a NULL 
+**
+** If an OOM error occurs, (*pRc) is set to SQLITE_NOMEM and a NULL
 ** pointer returned.
 */
 static char *shellMPrintf(int *pRc, const char *zFmt, ...){
@@ -16383,7 +16383,7 @@ static RecoverTable *recoverNewTable(
   int *pRc,                       /* IN/OUT: Error code */
   const char *zName,              /* Name of table */
   const char *zSql,               /* CREATE TABLE statement */
-  int bIntkey, 
+  int bIntkey,
   int nCol
 ){
   sqlite3 *dbtmp = 0;             /* sqlite3 handle for testing CREATE TABLE */
@@ -16395,7 +16395,7 @@ static RecoverTable *recoverNewTable(
     int nSqlCol = 0;
     int bSqlIntkey = 0;
     sqlite3_stmt *pStmt = 0;
-    
+
     rc = sqlite3_open("", &dbtmp);
     if( rc==SQLITE_OK ){
       sqlite3_create_function(dbtmp, "shell_idquote", 1, SQLITE_UTF8, 0,
@@ -16411,7 +16411,7 @@ static RecoverTable *recoverNewTable(
         goto finished;
       }
     }
-    shellPreparePrintf(dbtmp, &rc, &pStmt, 
+    shellPreparePrintf(dbtmp, &rc, &pStmt,
         "SELECT count(*) FROM pragma_table_info(%Q)", zName
     );
     if( rc==SQLITE_OK && SQLITE_ROW==sqlite3_step(pStmt) ){
@@ -16423,7 +16423,7 @@ static RecoverTable *recoverNewTable(
       goto finished;
     }
 
-    shellPreparePrintf(dbtmp, &rc, &pStmt, 
+    shellPreparePrintf(dbtmp, &rc, &pStmt,
       "SELECT ("
       "  SELECT substr(data,1,1)==X'0D' FROM sqlite_dbpage WHERE pgno=rootpage"
       ") FROM sqlite_schema WHERE name = %Q", zName
@@ -16445,7 +16445,7 @@ static RecoverTable *recoverNewTable(
       ** leave zPk as "_rowid_" and pTab->iPk at -2.  */
       pTab->iPk = -2;
       if( bIntkey ){
-        shellPreparePrintf(dbtmp, &rc, &pPkFinder, 
+        shellPreparePrintf(dbtmp, &rc, &pPkFinder,
           "SELECT cid, name FROM pragma_table_info(%Q) "
           "  WHERE pk=1 AND type='integer' COLLATE nocase"
           "  AND NOT EXISTS (SELECT cid FROM pragma_table_info(%Q) WHERE pk=2)"
@@ -16467,11 +16467,11 @@ static RecoverTable *recoverNewTable(
         pTab->azlCol[0] = shellMPrintf(&rc, "");
       }
       i = 1;
-      shellPreparePrintf(dbtmp, &rc, &pStmt, 
+      shellPreparePrintf(dbtmp, &rc, &pStmt,
           "SELECT %Q || group_concat(shell_idquote(name), ', ') "
           "  FILTER (WHERE cid!=%d) OVER (ORDER BY %s cid) "
-          "FROM pragma_table_info(%Q)", 
-          bIntkey ? ", " : "", pTab->iPk, 
+          "FROM pragma_table_info(%Q)",
+          bIntkey ? ", " : "", pTab->iPk,
           bIntkey ? "" : "(CASE WHEN pk=0 THEN 1000000 ELSE pk END), ",
           zName
       );
@@ -16505,7 +16505,7 @@ static RecoverTable *recoverNewTable(
 ** those.
 **
 ** If a table is found, a (RecoverTable*) object is returned. Or, if
-** no such table is found, but bIntkey is false and iRoot is the 
+** no such table is found, but bIntkey is false and iRoot is the
 ** root page of an index in the recovered schema, then (*pbNoop) is
 ** set to true and NULL returned. Or, if there is no such table or
 ** index, NULL is returned and (*pbNoop) set to 0, indicating that
@@ -16599,7 +16599,7 @@ static RecoverTable *recoverOrphanTable(
         recoverFreeTable(pTab);
         pTab = 0;
       }else{
-        raw_printf(pState->out, 
+        raw_printf(pState->out,
             "CREATE TABLE %s(rootpgno INTEGER, "
             "pgno INTEGER, nfield INTEGER, id INTEGER", pTab->zQuoted
         );
@@ -16652,14 +16652,14 @@ static int recoverDatabaseCmd(ShellState *pState, int nArg, char **azArg){
       bRowids = 0;
     }
     else{
-      utf8_printf(stderr, "unexpected option: %s\n", azArg[i]); 
+      utf8_printf(stderr, "unexpected option: %s\n", azArg[i]);
       showHelp(pState->out, azArg[0]);
       return 1;
     }
   }
 
   shellExecPrintf(pState->db, &rc,
-    /* Attach an in-memory database named 'recovery'. Create an indexed 
+    /* Attach an in-memory database named 'recovery'. Create an indexed
     ** cache of the sqlite_dbptr virtual table. */
     "PRAGMA writable_schema = on;"
     "ATTACH %Q AS recovery;"
@@ -16693,9 +16693,9 @@ static int recoverDatabaseCmd(ShellState *pState, int nArg, char **azArg){
   }
 
   /* If this is an auto-vacuum database, add all pointer-map pages to
-  ** the freelist table. Do this regardless of whether or not 
+  ** the freelist table. Do this regardless of whether or not
   ** --freelist-corrupt was specified.  */
-  shellExec(pState->db, &rc, 
+  shellExec(pState->db, &rc,
     "WITH ptrmap(pgno) AS ("
     "  SELECT 2 WHERE shell_int32("
     "    (SELECT data FROM sqlite_dbpage WHERE pgno=1), 13"
@@ -16707,7 +16707,7 @@ static int recoverDatabaseCmd(ShellState *pState, int nArg, char **azArg){
     "REPLACE INTO recovery.freelist SELECT pgno FROM ptrmap"
   );
 
-  shellExec(pState->db, &rc, 
+  shellExec(pState->db, &rc,
     "CREATE TABLE recovery.dbptr("
     "      pgno, child, PRIMARY KEY(child, pgno)"
     ") WITHOUT ROWID;"
@@ -16727,7 +16727,7 @@ static int recoverDatabaseCmd(ShellState *pState, int nArg, char **azArg){
     ");"
 
     /* Create the "map" table that will (eventually) contain instructions
-    ** for dealing with each page in the db that contains one or more 
+    ** for dealing with each page in the db that contains one or more
     ** records. */
     "CREATE TABLE recovery.map("
       "pgno INTEGER PRIMARY KEY, maxlen INT, intkey, root INT"
@@ -16776,7 +16776,7 @@ static int recoverDatabaseCmd(ShellState *pState, int nArg, char **azArg){
     "CREATE INDEX recovery.schema_rootpage ON schema(rootpage);"
   );
 
-  /* Open a transaction, then print out all non-virtual, non-"sqlite_%" 
+  /* Open a transaction, then print out all non-virtual, non-"sqlite_%"
   ** CREATE TABLE statements that extracted from the existing schema.  */
   if( rc==SQLITE_OK ){
     sqlite3_stmt *pStmt = 0;
@@ -16793,7 +16793,7 @@ static int recoverDatabaseCmd(ShellState *pState, int nArg, char **azArg){
     );
     while( rc==SQLITE_OK && SQLITE_ROW==sqlite3_step(pStmt) ){
       const char *zCreateTable = (const char*)sqlite3_column_text(pStmt, 0);
-      raw_printf(pState->out, "CREATE TABLE IF NOT EXISTS %s;\n", 
+      raw_printf(pState->out, "CREATE TABLE IF NOT EXISTS %s;\n",
           &zCreateTable[12]
       );
     }
@@ -16802,7 +16802,7 @@ static int recoverDatabaseCmd(ShellState *pState, int nArg, char **azArg){
 
   /* Figure out if an orphan table will be required. And if so, how many
   ** user columns it should contain */
-  shellPrepare(pState->db, &rc, 
+  shellPrepare(pState->db, &rc,
       "SELECT coalesce(max(maxlen), -2) FROM recovery.map WHERE root>1"
       , &pLoop
   );
@@ -16826,8 +16826,8 @@ static int recoverDatabaseCmd(ShellState *pState, int nArg, char **azArg){
   );
 
   /* Loop through each root page. */
-  shellPrepare(pState->db, &rc, 
-      "SELECT root, intkey, max(maxlen) FROM recovery.map" 
+  shellPrepare(pState->db, &rc,
+      "SELECT root, intkey, max(maxlen) FROM recovery.map"
       " WHERE root>1 GROUP BY root, intkey ORDER BY root=("
       "  SELECT rootpage FROM recovery.schema WHERE name='sqlite_sequence'"
       ")", &pLoop
@@ -16880,13 +16880,13 @@ static int recoverDatabaseCmd(ShellState *pState, int nArg, char **azArg){
 
         nField = nField+1;
         if( pTab2==pOrphan ){
-          raw_printf(pState->out, 
+          raw_printf(pState->out,
               "INSERT INTO %s VALUES(%d, %d, %d, %s%s%s);\n",
               pTab2->zQuoted, iRoot, iPgno, nField,
               iMin<0 ? "" : "NULL, ", zVal, pTab2->azlCol[nField]
           );
         }else{
-          raw_printf(pState->out, "INSERT INTO %s(%s) VALUES( %s );\n", 
+          raw_printf(pState->out, "INSERT INTO %s(%s) VALUES( %s );\n",
               pTab2->zQuoted, pTab2->azlCol[nField], zVal
           );
         }
@@ -16904,7 +16904,7 @@ static int recoverDatabaseCmd(ShellState *pState, int nArg, char **azArg){
   /* The rest of the schema */
   if( rc==SQLITE_OK ){
     sqlite3_stmt *pStmt = 0;
-    shellPrepare(pState->db, &rc, 
+    shellPrepare(pState->db, &rc,
         "SELECT sql, name FROM recovery.schema "
         "WHERE sql NOT LIKE 'create table%'", &pStmt
     );
@@ -16912,7 +16912,7 @@ static int recoverDatabaseCmd(ShellState *pState, int nArg, char **azArg){
       const char *zSql = (const char*)sqlite3_column_text(pStmt, 0);
       if( sqlite3_strnicmp(zSql, "create virt", 11)==0 ){
         const char *zName = (const char*)sqlite3_column_text(pStmt, 1);
-        char *zPrint = shellMPrintf(&rc, 
+        char *zPrint = shellMPrintf(&rc,
           "INSERT INTO sqlite_schema VALUES('table', %Q, %Q, 0, %Q)",
           zName, zName, zSql
         );
@@ -17048,7 +17048,7 @@ static int do_meta_command(char *zLine, ShellState *p){
       return 1;
     }
     if( zDb==0 ) zDb = "main";
-    rc = sqlite3_open_v2(zDestFile, &pDest, 
+    rc = sqlite3_open_v2(zDestFile, &pDest,
                   SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE, zVfs);
     if( rc!=SQLITE_OK ){
       utf8_printf(stderr, "Error: cannot open \"%s\"\n", zDestFile);
@@ -17222,7 +17222,7 @@ static int do_meta_command(char *zLine, ShellState *p){
     if( nArg>1 && ii==ArraySize(aDbConfig) ){
       utf8_printf(stderr, "Error: unknown dbconfig \"%s\"\n", azArg[1]);
       utf8_printf(stderr, "Enter \".dbconfig\" with no arguments for a list\n");
-    }   
+    }
   }else
 
   if( c=='d' && n>=3 && strncmp(azArg[0], "dbinfo", n)==0 ){
@@ -17408,7 +17408,7 @@ static int do_meta_command(char *zLine, ShellState *p){
       { "psow",       SQLITE_FCNTL_POWERSAFE_OVERWRITE, "[BOOLEAN]"      },
    /* { "pragma",         SQLITE_FCNTL_PRAGMA,          "NAME ARG"       },*/
       { "tempfilename",   SQLITE_FCNTL_TEMPFILENAME,    ""               },
-      { "has_moved",      SQLITE_FCNTL_HAS_MOVED,       ""               },  
+      { "has_moved",      SQLITE_FCNTL_HAS_MOVED,       ""               },
       { "lock_timeout",   SQLITE_FCNTL_LOCK_TIMEOUT,    "MILLISEC"       },
       { "reserve_bytes",  SQLITE_FCNTL_RESERVE_BYTES,   "[N]"            },
     };
@@ -17423,7 +17423,7 @@ static int do_meta_command(char *zLine, ShellState *p){
     open_db(p, 0);
     zCmd = nArg>=2 ? azArg[1] : "help";
 
-    if( zCmd[0]=='-' 
+    if( zCmd[0]=='-'
      && (strcmp(zCmd,"--schema")==0 || strcmp(zCmd,"-schema")==0)
      && nArg>=4
     ){
@@ -17688,7 +17688,7 @@ static int do_meta_command(char *zLine, ShellState *p){
         goto meta_command_exit;
       }
       if( nSep>1 ){
-        raw_printf(stderr, 
+        raw_printf(stderr,
               "Error: multi-character column separators not allowed"
               " for import\n");
         rc = 1;
@@ -20242,17 +20242,17 @@ static void verify_uninitialized(void){
 */
 static void main_init(ShellState *data) {
   memset(data, 0, sizeof(*data));
-  data->normalMode = data->cMode = data->mode = MODE_List;
+  data->normalMode = data->cMode = data->mode = MODE_Box;
   data->autoExplain = 1;
   memcpy(data->colSeparator,SEP_Column, 2);
   memcpy(data->rowSeparator,SEP_Row, 2);
-  data->showHeader = 0;
+  data->showHeader = 1;
   data->shellFlgs = SHFLG_Lookaside;
   verify_uninitialized();
   sqlite3_config(SQLITE_CONFIG_URI, 1);
   sqlite3_config(SQLITE_CONFIG_LOG, shellLog, data);
   sqlite3_config(SQLITE_CONFIG_MULTITHREAD);
-  sqlite3_snprintf(sizeof(mainPrompt), mainPrompt,"sqlite> ");
+  sqlite3_snprintf(sizeof(mainPrompt), mainPrompt,"D ");
   sqlite3_snprintf(sizeof(continuePrompt), continuePrompt,"   ...> ");
 }
 
@@ -20779,7 +20779,7 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv){
       char *zHistory;
       int nHistory;
       printf(
-        "SQLite version %s %.19s\n" /*extra-version-info*/
+        "%s %.19s\n" /*extra-version-info*/
         "Enter \".help\" for usage hints.\n",
         sqlite3_libversion(), sqlite3_sourceid()
       );
@@ -20789,13 +20789,13 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv){
         printf(".\nUse \".open FILENAME\" to reopen on a "
                "persistent database.\n");
       }
-      zHistory = getenv("SQLITE_HISTORY");
+      zHistory = getenv("DUCKDB_HISTORY");
       if( zHistory ){
         zHistory = strdup(zHistory);
       }else if( (zHome = find_home_dir(0))!=0 ){
         nHistory = strlen30(zHome) + 20;
         if( (zHistory = malloc(nHistory))!=0 ){
-          sqlite3_snprintf(nHistory, zHistory,"%s/.sqlite_history", zHome);
+          sqlite3_snprintf(nHistory, zHistory,"%s/.duckdb_history", zHome);
         }
       }
       if( zHistory ){ shell_read_history(zHistory); }

--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -19821,8 +19821,8 @@ static int do_meta_command(char *zLine, ShellState *p){
     for(j=1; j<nArg; j++){
       p->colWidth[j-1] = (int)integerValue(azArg[j]);
     }
-  } else
-  {
+  } else {
+#ifdef HAVE_LINENOISE
     const char *error = NULL;
     if (linenoiseParseOption((const char**) azArg, nArg, &error)) {
       if (error) {
@@ -19830,6 +19830,7 @@ static int do_meta_command(char *zLine, ShellState *p){
         rc = 1;
       }
     } else {
+#endif
       utf8_printf(stderr, "Error: unknown command or invalid arguments: "
         " \"%s\". Enter \".help\" for help\n", azArg[0]);
       rc = 1;


### PR DESCRIPTION
This PR adds syntax highlighting to the SQLite shell for Linux and MacOS. The system runs the lexer on the current line of user input, and highlights keywords as bold green, and numeric/string constants as yellow. The text is highlighted as you are typing. For now this is disabled on Windows. 

The PR also sets the following options as default in the shell:
```
.headers on
.nullvalue NULL
.prompt "D "
.mode box
```

See the image below for a preview. 

For now the colors are fixed, but should probably be customizable.

Would appreciate it if any shell users would test this PR and submit feedback/report issues :) 

![IMAGE 2020-10-13 12:38:25](https://user-images.githubusercontent.com/3978469/95850353-fdb56380-0d50-11eb-9d97-98caa6e139ab.jpg)
