### PR TITLE
Automatically drop index when table is dropped & display indexes in sqlite_master

### DIFF
--- a/src/catalog/catalog_entry/index_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/index_catalog_entry.cpp
@@ -3,6 +3,11 @@
 
 namespace duckdb {
 
+
+IndexCatalogEntry::IndexCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, CreateIndexInfo *info)
+	: StandardEntry(CatalogType::INDEX_ENTRY, schema, catalog, info->index_name), index(nullptr), sql(info->sql) {
+}
+
 IndexCatalogEntry::~IndexCatalogEntry() {
 	// remove the associated index from the info
 	if (!info || !index) {
@@ -14,6 +19,13 @@ IndexCatalogEntry::~IndexCatalogEntry() {
 			break;
 		}
 	}
+}
+
+string IndexCatalogEntry::ToSQL() {
+	if (sql.size() == 0) {
+		throw NotImplementedException("Cannot convert INDEX to SQL because it was not created with a SQL statement");
+	}
+	return sql;
 }
 
 } // namespace duckdb

--- a/src/catalog/catalog_entry/schema_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/schema_catalog_entry.cpp
@@ -100,9 +100,11 @@ CatalogEntry *SchemaCatalogEntry::CreateView(ClientContext &context, CreateViewI
 	return AddEntry(context, move(view), info->on_conflict);
 }
 
-CatalogEntry *SchemaCatalogEntry::CreateIndex(ClientContext &context, CreateIndexInfo *info) {
+CatalogEntry *SchemaCatalogEntry::CreateIndex(ClientContext &context, CreateIndexInfo *info, TableCatalogEntry *table) {
+	unordered_set<CatalogEntry *> dependencies;
+	dependencies.insert(table);
 	auto index = make_unique<IndexCatalogEntry>(catalog, this, info);
-	return AddEntry(context, move(index), info->on_conflict);
+	return AddEntry(context, move(index), info->on_conflict, dependencies);
 }
 
 CatalogEntry *SchemaCatalogEntry::CreateCollation(ClientContext &context, CreateCollationInfo *info) {

--- a/src/execution/operator/schema/physical_create_index.cpp
+++ b/src/execution/operator/schema/physical_create_index.cpp
@@ -15,7 +15,7 @@ void PhysicalCreateIndex::GetChunkInternal(ExecutionContext &context, DataChunk 
 	}
 
 	auto &schema = *table.schema;
-	auto index_entry = (IndexCatalogEntry *)schema.CreateIndex(context.client, info.get());
+	auto index_entry = (IndexCatalogEntry *)schema.CreateIndex(context.client, info.get(), &table);
 	if (!index_entry) {
 		// index already exists, but error ignored because of IF NOT EXISTS
 		return;

--- a/src/include/duckdb/catalog/catalog_entry/index_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/index_catalog_entry.hpp
@@ -20,13 +20,15 @@ class Index;
 class IndexCatalogEntry : public StandardEntry {
 public:
 	//! Create a real TableCatalogEntry and initialize storage for it
-	IndexCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, CreateIndexInfo *info)
-	    : StandardEntry(CatalogType::INDEX_ENTRY, schema, catalog, info->index_name), index(nullptr) {
-	}
+	IndexCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, CreateIndexInfo *info);
 	~IndexCatalogEntry();
 
 	Index *index;
 	shared_ptr<DataTableInfo> info;
+	string sql;
+
+public:
+	string ToSQL() override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/catalog/catalog_entry/schema_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/schema_catalog_entry.hpp
@@ -68,7 +68,7 @@ public:
 	//! Creates a sequence with the given name in the schema
 	CatalogEntry *CreateSequence(ClientContext &context, CreateSequenceInfo *info);
 	//! Creates an index with the given name in the schema
-	CatalogEntry *CreateIndex(ClientContext &context, CreateIndexInfo *info);
+	CatalogEntry *CreateIndex(ClientContext &context, CreateIndexInfo *info, TableCatalogEntry *table);
 	//! Create a table function within the given schema
 	CatalogEntry *CreateTableFunction(ClientContext &context, CreateTableFunctionInfo *info);
 	//! Create a copy function within the given schema

--- a/src/include/duckdb/catalog/dependency.hpp
+++ b/src/include/duckdb/catalog/dependency.hpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/catalog/dependency.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/unordered_set.hpp"
+
+namespace duckdb {
+class CatalogEntry;
+
+struct Dependency {
+	Dependency(CatalogEntry *entry, bool requires_cascade = true) :
+		entry(entry), requires_cascade(requires_cascade) {}
+
+	//! The catalog entry this depends on
+	CatalogEntry *entry;
+	//! Whether or not this dependency requires a cascade to drop
+	bool requires_cascade;
+};
+
+
+struct DependencyHashFunction {
+	uint64_t operator()(const Dependency &a) const {
+		std::hash<void*> hash_func;
+		return hash_func((void*)a.entry);
+	}
+};
+
+struct DependencyEquality {
+	bool operator()(const Dependency &a, const Dependency &b) const {
+		return a.entry == b.entry;
+	}
+};
+
+using dependency_set_t = unordered_set<Dependency, DependencyHashFunction, DependencyEquality>;
+
+} // namespace duckdb

--- a/src/include/duckdb/catalog/dependency_manager.hpp
+++ b/src/include/duckdb/catalog/dependency_manager.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/catalog/catalog_entry.hpp"
 #include "duckdb/catalog/catalog_set.hpp"
+#include "duckdb/catalog/dependency.hpp"
 
 namespace duckdb {
 class Catalog;
@@ -31,7 +32,7 @@ private:
 	Catalog &catalog;
 	//! Map of objects that DEPEND on [object], i.e. [object] can only be deleted when all entries in the dependency map
 	//! are deleted.
-	unordered_map<CatalogEntry *, unordered_set<CatalogEntry *>> dependents_map;
+	unordered_map<CatalogEntry *, dependency_set_t> dependents_map;
 	//! Map of objects that the source object DEPENDS on, i.e. when any of the entries in the vector perform a CASCADE
 	//! drop then [object] is deleted as wel
 	unordered_map<CatalogEntry *, unordered_set<CatalogEntry *>> dependencies_map;

--- a/src/include/duckdb/parser/parsed_data/create_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_info.hpp
@@ -40,6 +40,8 @@ struct CreateInfo : public ParseInfo {
 	bool temporary;
 	//! Whether or not the entry is an internal entry
 	bool internal;
+	//! The SQL string of the CREATE statement
+	string sql;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/parsed_data/create_view_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_view_info.hpp
@@ -22,8 +22,6 @@ struct CreateViewInfo : public CreateInfo {
 
 	//! Table name to insert to
 	string view_name;
-	//! The SQL query (if any)
-	string sql;
 	//! Aliases of the view
 	vector<string> aliases;
 	//! Return types

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -65,6 +65,7 @@ bool QueryProfiler::OperatorRequiresProfiling(PhysicalOperatorType op_type) {
 	case PhysicalOperatorType::DELIM_JOIN:
 	case PhysicalOperatorType::UNION:
 	case PhysicalOperatorType::RECURSIVE_CTE:
+	case PhysicalOperatorType::EMPTY_RESULT:
 		return true;
 	default:
 		return false;
@@ -199,6 +200,10 @@ void OperatorProfiler::EndOperator(DataChunk *chunk) {
 }
 
 void OperatorProfiler::AddTiming(PhysicalOperator *op, double time, idx_t elements) {
+	if (!enabled) {
+		return;
+	}
+
 	auto entry = timings.find(op);
 	if (entry == timings.end()) {
 		// add new entry
@@ -211,6 +216,10 @@ void OperatorProfiler::AddTiming(PhysicalOperator *op, double time, idx_t elemen
 }
 
 void QueryProfiler::Flush(OperatorProfiler &profiler) {
+	if (!enabled || !running) {
+		return;
+	}
+
 	for (auto &node : profiler.timings) {
 		auto entry = tree_map.find(node.first);
 		assert(entry != tree_map.end());

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -39,11 +39,15 @@ void Parser::ParseQuery(string query) {
 		n_prepared_parameters = transformer.ParamCount();
 	}
 	if (statements.size() > 0) {
-		for (auto &statement : statements) {
-			statement->query = query;
-		}
 		auto &last_statement = statements.back();
 		last_statement->stmt_length = query.size() - last_statement->stmt_location;
+		for (auto &statement : statements) {
+			statement->query = query;
+			if (statement->type == StatementType::CREATE_STATEMENT) {
+				auto &create = (CreateStatement &) *statement;
+				create.info->sql = query.substr(statement->stmt_location, statement->stmt_length);
+			}
+		}
 	}
 }
 

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -69,10 +69,6 @@ BoundStatement Binder::Bind(CreateStatement &stmt) {
 		break;
 	case CatalogType::VIEW_ENTRY: {
 		auto &base = (CreateViewInfo &)*stmt.info;
-		// extract the SQL from the query, if any
-		if (stmt.stmt_location + stmt.stmt_length <= context.query.size()) {
-			base.sql = context.query.substr(stmt.stmt_location, stmt.stmt_length);
-		}
 		// bind the schema
 		auto schema = BindSchema(*stmt.info);
 

--- a/test/issues/rigger/delete_empty_result.test
+++ b/test/issues/rigger/delete_empty_result.test
@@ -1,0 +1,18 @@
+# name: test/issues/rigger/delete_empty_result.test
+# description: SQLancer bug that detected an assertion in the query profiler when deleting with a static false condition
+# group: [rigger]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+PRAGMA enable_profiling
+
+statement ok
+PRAGMA profile_output='__TEST_DIR__/out.log';
+
+statement ok
+CREATE TABLE t0(c0 INTEGER);
+
+statement ok
+DELETE FROM t0 WHERE false;

--- a/test/sql/catalog/test_catalog_errors.test
+++ b/test/sql/catalog/test_catalog_errors.test
@@ -51,3 +51,13 @@ DROP INDEX i_index
 statement ok
 DROP INDEX IF EXISTS i_index
 
+# create the index again
+statement ok
+CREATE INDEX i_index ON integers(i);
+
+# dropping the table also drops the index
+statement ok
+DROP TABLE integers;
+
+statement error
+DROP INDEX i_index

--- a/test/sql/table_function/sqlite_master.test
+++ b/test/sql/table_function/sqlite_master.test
@@ -50,3 +50,11 @@ query IIIII
 SELECT * FROM sqlite_master WHERE name='tconstraint2';
 ----
 table	tconstraint2	tconstraint2	0	CREATE TABLE tconstraint2(i INTEGER, j INTEGER, k INTEGER, l INTEGER UNIQUE, PRIMARY KEY(i, j, k));
+
+statement ok
+CREATE INDEX i_index ON integers(i);
+
+query IIIII
+SELECT * FROM sqlite_master WHERE name='i_index';
+----
+index	i_index	integers	0	CREATE INDEX i_index ON integers(i);

--- a/test/sqlite/test_sqllogictest.cpp
+++ b/test/sqlite/test_sqllogictest.cpp
@@ -344,10 +344,8 @@ static void print_sql(string sql) {
 		case SimplifiedTokenType::SIMPLIFIED_TOKEN_IDENTIFIER:
 			break;
 		case SimplifiedTokenType::SIMPLIFIED_TOKEN_NUMERIC_CONSTANT:
-			std::cerr << termcolor::yellow;
-			break;
 		case SimplifiedTokenType::SIMPLIFIED_TOKEN_STRING_CONSTANT:
-			std::cerr << termcolor::magenta;
+			std::cerr << termcolor::yellow;
 			break;
 		case SimplifiedTokenType::SIMPLIFIED_TOKEN_OPERATOR:
 			break;

--- a/test/sqlite/test_sqllogictest.cpp
+++ b/test/sqlite/test_sqllogictest.cpp
@@ -1111,11 +1111,6 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 			// perform any renames in zScript
 			command->sql_query = ReplaceKeywords(zScript);
 
-			// skip CREATE INDEX in original sqlite tests (for now...)
-			if (original_sqlite_test && StringUtil::StartsWith(StringUtil::Upper(command->sql_query), "CREATE INDEX")) {
-				fprintf(stderr, "Ignoring CREATE INDEX statement %s\n", command->sql_query.c_str());
-				continue;
-			}
 			// parse
 			if (strcmp(sScript.azToken[1], "ok") == 0) {
 				command->expect_ok = true;

--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -7,7 +7,7 @@ using namespace duckdb;
 using namespace std;
 
 static string byte_array_to_string(JNIEnv *env, jbyteArray ba_j) {
-	auto len = env->GetArrayLength(ba_j);
+	idx_t len = env->GetArrayLength(ba_j);
 	string ret;
 	ret.resize(len);
 
@@ -122,7 +122,7 @@ JNIEXPORT jobject JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1execute(JNI
 	auto res_ref = new ResultHolder();
 	vector<Value> duckdb_params;
 
-	auto param_len = env->GetArrayLength(params);
+	idx_t param_len = env->GetArrayLength(params);
 	if (param_len != stmt_ref->stmt->n_param) {
 		env->ThrowNew(env->FindClass("java/sql/SQLException"), "Parameter count mismatch");
 	}

--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -186,12 +186,11 @@ CREATE TABLE csda (i INTEGER);
 
 test('.indexes',  out="")
 
-# FIXME: indexes currently not exported in sqlite_master
-# test('''
-# CREATE TABLE a (i INTEGER);
-# CREATE INDEX a_idx ON a(i);
-# .indexes a%
-# ''',  err="a_idx")
+test('''
+CREATE TABLE a (i INTEGER);
+CREATE INDEX a_idx ON a(i);
+.indexes a%
+''',  out="a_idx")
 
 # this does not seem to output anything
 test('.sha3sum')


### PR DESCRIPTION
This PR enables automatic dropping of indexes when the corresponding table is dropped. This was the last open issue for #776  and allows us to enable indexes for the sqllogic test suite. In addition, this PR also adds index output to the sqlite_master table, which in turn allows the `.indexes` command of the shell to function properly.