### PR TITLE
Correctly handle column name aliases in standard SELECT * FROM tbl queries

### DIFF
--- a/src/include/duckdb/parser/tableref/basetableref.hpp
+++ b/src/include/duckdb/parser/tableref/basetableref.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/parser/tableref.hpp"
+#include "duckdb/common/vector.hpp"
 
 namespace duckdb {
 //! Represents a TableReference to a base table in the schema
@@ -21,6 +22,8 @@ public:
 	string schema_name;
 	//! Table name
 	string table_name;
+	//! Alises for the column names
+	vector<string> column_name_alias;
 
 public:
 	string ToString() const override {

--- a/src/include/duckdb/parser/transformer.hpp
+++ b/src/include/duckdb/parser/transformer.hpp
@@ -165,7 +165,7 @@ private:
 	//===--------------------------------------------------------------------===//
 	// Helpers
 	//===--------------------------------------------------------------------===//
-	string TransformAlias(duckdb_libpgquery::PGAlias *root);
+	string TransformAlias(duckdb_libpgquery::PGAlias *root, vector<string> &column_name_alias);
 	void TransformCTE(duckdb_libpgquery::PGWithClause *de_with_clause, SelectStatement &select);
 	unique_ptr<QueryNode> TransformRecursiveCTE(duckdb_libpgquery::PGCommonTableExpr *node,
 	                                            CommonTableExpressionInfo &info);

--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -48,8 +48,7 @@ public:
 	void GenerateAllColumnExpressions(vector<unique_ptr<ParsedExpression>> &new_select_list, string relation_name = "");
 
 	//! Adds a base table with the given alias to the BindContext.
-	void AddBaseTable(idx_t index, const string &alias, vector<string> names, vector<LogicalType> types,
-	                  unordered_map<string, column_t> name_map, LogicalGet &get);
+	void AddBaseTable(idx_t index, const string &alias, vector<string> names, vector<LogicalType> types, LogicalGet &get);
 	//! Adds a call to a table function with the given alias to the BindContext.
 	void AddTableFunction(idx_t index, const string &alias, vector<string> names, vector<LogicalType> types,
 	                      LogicalGet &get);
@@ -74,6 +73,9 @@ public:
 	void SetCTEBindings(unordered_map<string, std::shared_ptr<Binding>> bindings) {
 		cte_bindings = bindings;
 	}
+
+	//! Alias a set of column names for the specified table, using the original names if there are not enough aliases specified.
+	static vector<string> AliasColumnNames(string table_name, const vector<string> &names, const vector<string> &column_aliases);
 
 private:
 	void AddBinding(const string &alias, unique_ptr<Binding> binding);

--- a/src/include/duckdb/planner/table_binding.hpp
+++ b/src/include/duckdb/planner/table_binding.hpp
@@ -50,8 +50,6 @@ public:
 //! node for projection pushdown purposes.
 struct TableBinding : public Binding {
 	TableBinding(const string &alias, vector<LogicalType> types, vector<string> names, LogicalGet &get, idx_t index);
-	TableBinding(const string &alias, vector<LogicalType> types, vector<string> names,
-	             unordered_map<string, column_t> name_map, LogicalGet &get, idx_t index);
 
 	//! the underlying LogicalGet
 	LogicalGet &get;

--- a/src/include/duckdb/planner/table_binding.hpp
+++ b/src/include/duckdb/planner/table_binding.hpp
@@ -27,7 +27,6 @@ class BoundTableFunction;
 //! A Binding represents a binding to a table, table-producing function or subquery with a specified table index.
 struct Binding {
 	Binding(const string &alias, vector<LogicalType> types, vector<string> names, idx_t index);
-	Binding(const string &alias, idx_t index);
 	virtual ~Binding() = default;
 
 	//! The alias of the binding
@@ -49,7 +48,7 @@ public:
 //! TableBinding is exactly like the Binding, except it keeps track of which columns were bound in the linked LogicalGet
 //! node for projection pushdown purposes.
 struct TableBinding : public Binding {
-	TableBinding(const string &alias, vector<LogicalType> types, vector<string> names, LogicalGet &get, idx_t index);
+	TableBinding(const string &alias, vector<LogicalType> types, vector<string> names, LogicalGet &get, idx_t index, bool add_row_id = false);
 
 	//! the underlying LogicalGet
 	LogicalGet &get;

--- a/src/parser/tableref/basetableref.cpp
+++ b/src/parser/tableref/basetableref.cpp
@@ -10,7 +10,7 @@ bool BaseTableRef::Equals(const TableRef *other_) const {
 		return false;
 	}
 	auto other = (BaseTableRef *)other_;
-	return other->schema_name == schema_name && other->table_name == table_name;
+	return other->schema_name == schema_name && other->table_name == table_name && column_name_alias == other->column_name_alias;
 }
 
 void BaseTableRef::Serialize(Serializer &serializer) {
@@ -18,6 +18,7 @@ void BaseTableRef::Serialize(Serializer &serializer) {
 
 	serializer.WriteString(schema_name);
 	serializer.WriteString(table_name);
+	serializer.WriteStringVector(column_name_alias);
 }
 
 unique_ptr<TableRef> BaseTableRef::Deserialize(Deserializer &source) {
@@ -25,6 +26,7 @@ unique_ptr<TableRef> BaseTableRef::Deserialize(Deserializer &source) {
 
 	result->schema_name = source.Read<string>();
 	result->table_name = source.Read<string>();
+	source.ReadStringVector(result->column_name_alias);
 
 	return move(result);
 }
@@ -35,6 +37,7 @@ unique_ptr<TableRef> BaseTableRef::Copy() {
 	copy->schema_name = schema_name;
 	copy->table_name = table_name;
 	copy->alias = alias;
+	copy->column_name_alias = column_name_alias;
 
 	return move(copy);
 }

--- a/src/parser/transform/helpers/transform_alias.cpp
+++ b/src/parser/transform/helpers/transform_alias.cpp
@@ -4,9 +4,14 @@ namespace duckdb {
 using namespace std;
 using namespace duckdb_libpgquery;
 
-string Transformer::TransformAlias(PGAlias *root) {
+string Transformer::TransformAlias(PGAlias *root, vector<string> &column_name_alias) {
 	if (!root) {
 		return "";
+	}
+	if (root->colnames) {
+		for (auto node = root->colnames->head; node != nullptr; node = node->next) {
+			column_name_alias.push_back(reinterpret_cast<PGValue *>(node->data.ptr_value)->val.str);
+		}
 	}
 	return root->aliasname;
 }

--- a/src/parser/transform/tableref/transform_base_tableref.cpp
+++ b/src/parser/transform/tableref/transform_base_tableref.cpp
@@ -8,7 +8,7 @@ using namespace duckdb_libpgquery;
 unique_ptr<TableRef> Transformer::TransformRangeVar(PGRangeVar *root) {
 	auto result = make_unique<BaseTableRef>();
 
-	result->alias = TransformAlias(root->alias);
+	result->alias = TransformAlias(root->alias, result->column_name_alias);
 	if (root->relname) {
 		result->table_name = root->relname;
 	}

--- a/src/parser/transform/tableref/transform_subquery.cpp
+++ b/src/parser/transform/tableref/transform_subquery.cpp
@@ -11,13 +11,8 @@ unique_ptr<TableRef> Transformer::TransformRangeSubselect(PGRangeSubselect *root
 	if (!subquery) {
 		return nullptr;
 	}
-	auto alias = TransformAlias(root->alias);
-	auto result = make_unique<SubqueryRef>(move(subquery), alias);
-	if (root->alias->colnames) {
-		for (auto node = root->alias->colnames->head; node != nullptr; node = node->next) {
-			result->column_name_alias.push_back(reinterpret_cast<PGValue *>(node->data.ptr_value)->val.str);
-		}
-	}
+	auto result = make_unique<SubqueryRef>(move(subquery));
+	result->alias = TransformAlias(root->alias, result->column_name_alias);
 	return move(result);
 }
 

--- a/src/parser/transform/tableref/transform_table_function.cpp
+++ b/src/parser/transform/tableref/transform_table_function.cpp
@@ -32,12 +32,7 @@ unique_ptr<TableRef> Transformer::TransformRangeFunction(PGRangeFunction *root) 
 	// transform the function call
 	auto result = make_unique<TableFunctionRef>();
 	result->function = TransformFuncCall(func_call);
-	result->alias = TransformAlias(root->alias);
-	if (root->alias && root->alias->colnames) {
-		for (auto node = root->alias->colnames->head; node != nullptr; node = node->next) {
-			result->column_name_alias.push_back(reinterpret_cast<PGValue *>(node->data.ptr_value)->val.str);
-		}
-	}
+	result->alias = TransformAlias(root->alias, result->column_name_alias);
 	result->query_location = func_call->location;
 	return move(result);
 }

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -129,7 +129,7 @@ void BindContext::AddBinding(const string &alias, unique_ptr<Binding> binding) {
 
 void BindContext::AddBaseTable(idx_t index, const string &alias, vector<string> names, vector<LogicalType> types,
                                LogicalGet &get) {
-	AddBinding(alias, make_unique<TableBinding>(alias, move(types), move(names), get, index));
+	AddBinding(alias, make_unique<TableBinding>(alias, move(types), move(names), get, index, true));
 }
 
 void BindContext::AddTableFunction(idx_t index, const string &alias, vector<string> names, vector<LogicalType> types,

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -128,8 +128,8 @@ void BindContext::AddBinding(const string &alias, unique_ptr<Binding> binding) {
 }
 
 void BindContext::AddBaseTable(idx_t index, const string &alias, vector<string> names, vector<LogicalType> types,
-                               unordered_map<string, column_t> name_map, LogicalGet &get) {
-	AddBinding(alias, make_unique<TableBinding>(alias, move(types), move(names), move(name_map), get, index));
+                               LogicalGet &get) {
+	AddBinding(alias, make_unique<TableBinding>(alias, move(types), move(names), get, index));
 }
 
 void BindContext::AddTableFunction(idx_t index, const string &alias, vector<string> names, vector<LogicalType> types,
@@ -137,20 +137,25 @@ void BindContext::AddTableFunction(idx_t index, const string &alias, vector<stri
 	AddBinding(alias, make_unique<TableBinding>(alias, move(types), move(names), get, index));
 }
 
-void BindContext::AddSubquery(idx_t index, const string &alias, SubqueryRef &ref, BoundQueryNode &subquery) {
-	vector<string> names;
-	if (ref.column_name_alias.size() > subquery.names.size()) {
-		throw BinderException("table \"%s\" has %lld columns available but %lld columns specified", alias,
-		                      subquery.names.size(), ref.column_name_alias.size());
+vector<string> BindContext::AliasColumnNames(string table_name, const vector<string> &names, const vector<string> &column_aliases) {
+	vector<string> result;
+	if (column_aliases.size() > names.size()) {
+		throw BinderException("table \"%s\" has %lld columns available but %lld columns specified", table_name,
+		                      names.size(), column_aliases.size());
 	}
-	// use any provided aliases from the subquery
-	for (idx_t i = 0; i < ref.column_name_alias.size(); i++) {
-		names.push_back(ref.column_name_alias[i]);
+	// use any provided column aliases first
+	for (idx_t i = 0; i < column_aliases.size(); i++) {
+		result.push_back(column_aliases[i]);
 	}
 	// if not enough aliases were provided, use the default names for remaining columns
-	for (idx_t i = ref.column_name_alias.size(); i < subquery.names.size(); i++) {
-		names.push_back(subquery.names[i]);
+	for (idx_t i = column_aliases.size(); i < names.size(); i++) {
+		result.push_back(names[i]);
 	}
+	return result;
+}
+
+void BindContext::AddSubquery(idx_t index, const string &alias, SubqueryRef &ref, BoundQueryNode &subquery) {
+	auto names = AliasColumnNames(alias, subquery.names, ref.column_name_alias);
 	AddGenericBinding(index, alias, names, subquery.types);
 }
 

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -25,6 +25,13 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 			SubqueryRef subquery(cte->query->Copy());
 			subquery.alias = ref.alias.empty() ? ref.table_name : ref.alias;
 			subquery.column_name_alias = cte->aliases;
+			for(idx_t i = 0; i < ref.column_name_alias.size(); i++) {
+				if (i < subquery.column_name_alias.size()) {
+					subquery.column_name_alias[i] = ref.column_name_alias[i];
+				} else {
+					subquery.column_name_alias.push_back(ref.column_name_alias[i]);
+				}
+			}
 			return Bind(subquery);
 		} else {
 			// There is a CTE binding in the BindContext.
@@ -32,14 +39,16 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 			auto index = GenerateTableIndex();
 			auto result = make_unique<BoundCTERef>(index, ctebinding->index);
 			auto b = ctebinding;
+			auto alias = ref.alias.empty() ? ref.table_name : ref.alias;
+			auto names = BindContext::AliasColumnNames(alias, b->names, ref.column_name_alias);
 
-			bind_context.AddGenericBinding(index, ref.alias.empty() ? ref.table_name : ref.alias, b->names, b->types);
+			bind_context.AddGenericBinding(index, alias, names, b->types);
 			// Update references to CTE
 			auto cteref = bind_context.cte_references[ref.table_name];
 			(*cteref)++;
 
 			result->types = b->types;
-			result->bound_columns = b->names;
+			result->bound_columns = move(names);
 			return move(result);
 		}
 	}
@@ -55,18 +64,18 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 
 		auto scan_function = TableScanFunction::GetFunction();
 		auto bind_data = make_unique<TableScanBindData>(table);
+		auto alias = ref.alias.empty() ? ref.table_name : ref.alias;
 		vector<LogicalType> table_types;
 		vector<string> table_names;
 		for (auto &col : table->columns) {
 			table_types.push_back(col.type);
 			table_names.push_back(col.name);
 		}
+		table_names = BindContext::AliasColumnNames(alias, table_names, ref.column_name_alias);
 
 		auto logical_get =
 		    make_unique<LogicalGet>(table_index, scan_function, move(bind_data), table_types, table_names);
-		auto alias = ref.alias.empty() ? ref.table_name : ref.alias;
-		bind_context.AddBaseTable(table_index, alias, move(table_names), move(table_types), table->name_map,
-		                          *logical_get);
+		bind_context.AddBaseTable(table_index, alias, move(table_names), move(table_types), *logical_get);
 		return make_unique_base<BoundTableRef, BoundBaseTableRef>(table, move(logical_get));
 	}
 	case CatalogType::VIEW_ENTRY: {
@@ -82,7 +91,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		}
 		SubqueryRef subquery(view_catalog_entry->query->node->Copy());
 		subquery.alias = ref.alias.empty() ? ref.table_name : ref.alias;
-		subquery.column_name_alias = view_catalog_entry->aliases;
+		subquery.column_name_alias = BindContext::AliasColumnNames(subquery.alias, view_catalog_entry->aliases, ref.column_name_alias);
 		// bind the child subquery
 		auto bound_child = view_binder.Bind(subquery);
 		assert(bound_child->type == TableReferenceType::SUBQUERY);

--- a/src/planner/table_binding.cpp
+++ b/src/planner/table_binding.cpp
@@ -13,9 +13,6 @@
 namespace duckdb {
 using namespace std;
 
-Binding::Binding(const string &alias, idx_t index) : alias(alias), index(index) {
-}
-
 Binding::Binding(const string &alias, vector<LogicalType> coltypes, vector<string> colnames, idx_t index)
     : alias(alias), index(index), types(move(coltypes)), names(move(colnames)) {
 	assert(types.size() == names.size());
@@ -59,8 +56,13 @@ void Binding::GenerateAllColumnExpressions(BindContext &context, vector<unique_p
 }
 
 TableBinding::TableBinding(const string &alias, vector<LogicalType> types_, vector<string> names_, LogicalGet &get,
-                           idx_t index)
+                           idx_t index, bool add_row_id)
     : Binding(alias, move(types_), move(names_), index), get(get) {
+	if (add_row_id) {
+		if (name_map.find("rowid") == name_map.end()) {
+			name_map["rowid"] = COLUMN_IDENTIFIER_ROW_ID;
+		}
+	}
 }
 
 BindResult TableBinding::Bind(ColumnRefExpression &colref, idx_t depth) {

--- a/src/planner/table_binding.cpp
+++ b/src/planner/table_binding.cpp
@@ -63,12 +63,6 @@ TableBinding::TableBinding(const string &alias, vector<LogicalType> types_, vect
     : Binding(alias, move(types_), move(names_), index), get(get) {
 }
 
-TableBinding::TableBinding(const string &alias, vector<LogicalType> types, vector<string> names,
-                           unordered_map<string, column_t> name_map, LogicalGet &get, idx_t index)
-    : TableBinding(alias, move(types), move(names), get, index) {
-	this->name_map = move(name_map);
-}
-
 BindResult TableBinding::Bind(ColumnRefExpression &colref, idx_t depth) {
 	auto entry = name_map.find(colref.column_name);
 	if (entry == name_map.end()) {

--- a/src/storage/storage_info.cpp
+++ b/src/storage/storage_info.cpp
@@ -3,6 +3,6 @@
 namespace duckdb {
 using namespace std;
 
-const uint64_t VERSION_NUMBER = 2;
+const uint64_t VERSION_NUMBER = 3;
 
 } // namespace duckdb

--- a/test/sql/catalog/view/test_view.test
+++ b/test/sql/catalog/view/test_view.test
@@ -23,6 +23,12 @@ SELECT j FROM v1 WHERE j > 41
 ----
 42
 
+# name alias in view
+query I
+SELECT x FROM v1 t1(x) WHERE x > 41
+----
+42
+
 statement ok
 DROP VIEW v1
 

--- a/test/sql/cte/test_cte.test
+++ b/test/sql/cte/test_cte.test
@@ -17,7 +17,17 @@ with cte1 as (Select i as j from a) select * from cte1;
 42
 
 query I
+with cte1 as (Select i as j from a) select x from cte1 t1(x);
+----
+42
+
+query I
 with cte1(xxx) as (Select i as j from a) select xxx from cte1;
+----
+42
+
+query I
+with cte1(xxx) as (Select i as j from a) select x from cte1 t1(x);
 ----
 42
 
@@ -55,6 +65,12 @@ with cte1 as (Select i as j from a) select * from cte1 where j = (select max(j) 
 ----
 42
 
+# multi-column name alias
+query II
+with cte1(x, y) as (select 42 a, 84 b) select zzz, y from cte1 t1(zzz);
+----
+42	84
+
 # use a CTE in a view definition
 statement ok
 create view va AS (with cte as (Select i as j from a) select * from cte);
@@ -78,4 +94,4 @@ query I
 select * from vb
 ----
 43
- 
+

--- a/test/sql/cte/test_recursive_cte_union.test
+++ b/test/sql/cte/test_recursive_cte_union.test
@@ -6,15 +6,30 @@ statement ok
 PRAGMA enable_verification
 
 # simple recursive CTE
-# query I
-# with recursive t as (select 1 as x union select x+1 from t where x < 3) select * from t order by x
-# ----
-# 1
-# 2
-# 3
+query I
+with recursive t as (select 1 as x union select x+1 from t where x < 3) select * from t order by x
+----
+1
+2
+3
 
 query I
 with recursive t(x) as (select 1 union select x+1 from t where x < 3) select * from t order by x
+----
+1
+2
+3
+
+# test some aliases
+query I
+with recursive t(x) as (select 1 union select x+1 from t where x < 3) select zz from t t1(zz) order by zz
+----
+1
+2
+3
+
+query I
+with recursive t(x) as (select 1 union select zzz+1 from t t1(zzz) where zzz < 3) select zz from t t1(zz) order by zz
 ----
 1
 2

--- a/test/sql/projection/test_simple_projection.test
+++ b/test/sql/projection/test_simple_projection.test
@@ -18,6 +18,12 @@ SELECT * FROM a;
 ----
 42	84
 
+# name alias
+query II
+SELECT x, y FROM a i1(x, y);
+----
+42	84
+
 # multiple insertions
 statement ok
 CREATE TABLE test (a INTEGER, b INTEGER);


### PR DESCRIPTION
This PR introduces correct handling of column name aliases in standard table selections, e.g.

```sql
SELECT * FROM tbl t1(a, b);
```
Prior to this PR the name alias was handled correctly (t1) but the column name aliases (a, b) were silently ignored. This PR fixes it for regular tables, views, CTEs and recursive CTEs + adds tests for each of these cases.