### PR TITLE
Fix issue #980: support rename after drop before cleanup

### DIFF
--- a/src/catalog/catalog_entry/schema_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/schema_catalog_entry.cpp
@@ -178,7 +178,7 @@ CatalogEntry *SchemaCatalogEntry::GetEntry(ClientContext &context, CatalogType t
 	auto entry = set.GetEntry(context, entry_name);
 	if (!entry) {
 		if (!if_exists) {
-			auto entry = set.SimilarEntry(entry_name);
+			auto entry = set.SimilarEntry(context, entry_name);
 			string did_you_mean;
 			if (!entry.empty()) {
 				did_you_mean = "\nDid you mean \"" + entry + "\"?";

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -287,16 +287,19 @@ CatalogEntry *CatalogSet::GetEntryForTransaction(ClientContext &context, Catalog
 	return current;
 }
 
-string CatalogSet::SimilarEntry(const string &name) {
+string CatalogSet::SimilarEntry(ClientContext &context, const string &name) {
 	lock_guard<mutex> lock(catalog_lock);
 
 	string result;
 	idx_t current_score = (idx_t)-1;
 	for (auto &kv : mapping) {
-		auto ldist = StringUtil::LevenshteinDistance(kv.first, name);
-		if (ldist < current_score && !kv.second->deleted) {
-			current_score = ldist;
-			result = kv.first;
+		auto mapping_value = GetMapping(context, kv.first);
+		if (mapping_value) {
+			auto ldist = StringUtil::LevenshteinDistance(kv.first, name);
+			if (ldist < current_score && !kv.second->deleted) {
+				current_score = ldist;
+				result = kv.first;
+			}
 		}
 	}
 	return result;

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -101,13 +101,6 @@ bool CatalogSet::GetEntryInternal(ClientContext &context, const string &name, id
 	return GetEntryInternal(context, entry_index, catalog_entry);
 }
 
-void CatalogSet::ClearEntryName(string name) {
-	auto entry = mapping.find(name);
-	if (entry != mapping.end()) {
-		mapping.erase(entry);
-	}
-}
-
 bool CatalogSet::AlterEntry(ClientContext &context, const string &name, AlterInfo *alter_info) {
 	auto &transaction = Transaction::GetTransaction(context);
 	// lock the catalog for writing

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -383,9 +383,13 @@ void CatalogSet::Undo(CatalogEntry *entry) {
 
 	// restore the name if it was deleted
 	auto restored_entry = mapping.find(entry->name);
-	if (restored_entry->second->deleted) {
-		restored_entry->second->child->parent = nullptr;
-		mapping[entry->name] = move(restored_entry->second->child);
+	if (restored_entry->second->deleted || entry->type == CatalogType::INVALID) {
+		if (restored_entry->second->child) {
+			restored_entry->second->child->parent = nullptr;
+			mapping[entry->name] = move(restored_entry->second->child);
+		} else {
+			mapping.erase(restored_entry);
+		}
 	}
 }
 

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -291,7 +291,7 @@ string CatalogSet::SimilarEntry(ClientContext &context, const string &name) {
 		auto mapping_value = GetMapping(context, kv.first);
 		if (mapping_value && !mapping_value->deleted) {
 			auto ldist = StringUtil::LevenshteinDistance(kv.first, name);
-			if (ldist < current_score && !kv.second->deleted) {
+			if (ldist < current_score) {
 				current_score = ldist;
 				result = kv.first;
 			}

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -318,6 +318,7 @@ CatalogEntry *CatalogSet::GetEntry(ClientContext &context, const string &name) {
 				entry->timestamp = 0;
 
 				PutMapping(context, name, entry_index);
+				mapping[name]->timestamp = 0;
 				entries[entry_index] = move(entry);
 				return catalog_entry;
 			}
@@ -327,7 +328,7 @@ CatalogEntry *CatalogSet::GetEntry(ClientContext &context, const string &name) {
 	auto catalog_entry = entries[mapping_value->index].get();
 	// if it does, we have to check version numbers
 	CatalogEntry *current = GetEntryForTransaction(context, catalog_entry);
-	if (current->deleted || current->name != name) {
+	if (current->deleted || (current->name != name && !UseTimestamp(context, mapping_value->timestamp))) {
 		return nullptr;
 	}
 	return current;

--- a/src/catalog/dependency_manager.cpp
+++ b/src/catalog/dependency_manager.cpp
@@ -37,8 +37,8 @@ void DependencyManager::DropObject(ClientContext &context, CatalogEntry *object,
 	auto &dependent_objects = dependents_map[object];
 	for (auto &dep : dependent_objects) {
 		// look up the entry in the catalog set
-		auto &catalog_set = *dep->set;
-		auto mapping_value = catalog_set.GetMapping(context, dep->name, true /* get_latest */);
+		auto &catalog_set = *dep.entry->set;
+		auto mapping_value = catalog_set.GetMapping(context, dep.entry->name, true /* get_latest */);
 		if (mapping_value == nullptr) {
 			continue;
 		}

--- a/src/catalog/dependency_manager.cpp
+++ b/src/catalog/dependency_manager.cpp
@@ -37,11 +37,15 @@ void DependencyManager::DropObject(ClientContext &context, CatalogEntry *object,
 	auto &dependent_objects = dependents_map[object];
 	for (auto &dep : dependent_objects) {
 		// look up the entry in the catalog set
-		auto &catalog_set = *dep.entry->set;
-		idx_t entry_index;
+		auto &catalog_set = *dep->set;
+		auto mapping_value = catalog_set.GetMapping(context, dep->name, true /* get_latest */);
+		if (mapping_value == nullptr) {
+			continue;
+		}
+		idx_t entry_index = mapping_value->index;
 		CatalogEntry *dependency_entry;
 
-		if (!catalog_set.GetEntryInternal(context, dep.entry->name, entry_index, dependency_entry)) {
+		if (!catalog_set.GetEntryInternal(context, entry_index, dependency_entry)) {
 			// the dependent object was already deleted, no conflict
 			continue;
 		}

--- a/src/include/duckdb/catalog/catalog_set.hpp
+++ b/src/include/duckdb/catalog/catalog_set.hpp
@@ -26,8 +26,7 @@ class ClientContext;
 typedef unordered_map<CatalogSet *, std::unique_lock<std::mutex>> set_lock_map_t;
 
 struct MappingValue {
-
-	MappingValue(idx_t index_) : index(index_), timestamp(0), deleted(false) {
+	MappingValue(idx_t index_) : index(index_), timestamp(0), deleted(false), parent(nullptr) {
 	}
 
 	idx_t index;

--- a/src/include/duckdb/catalog/catalog_set.hpp
+++ b/src/include/duckdb/catalog/catalog_set.hpp
@@ -58,7 +58,7 @@ public:
 
 	//! Gets the entry that is most similar to the given name (i.e. smallest levenshtein distance), or empty string if
 	//! none is found
-	string SimilarEntry(const string &name);
+	string SimilarEntry(ClientContext &context, const string &name);
 
 	//! Rollback <entry> to be the currently valid entry for a certain catalog
 	//! entry

--- a/src/include/duckdb/catalog/catalog_set.hpp
+++ b/src/include/duckdb/catalog/catalog_set.hpp
@@ -82,7 +82,6 @@ public:
 
 	idx_t GetEntryIndex(CatalogEntry *entry);
 	CatalogEntry *GetEntryFromIndex(idx_t index);
-	void ClearEntryName(string name);
 	void UpdateTimestamp(CatalogEntry *entry, transaction_t timestamp);
 
 private:

--- a/src/include/duckdb/catalog/catalog_set.hpp
+++ b/src/include/duckdb/catalog/catalog_set.hpp
@@ -77,8 +77,8 @@ public:
 		}
 	}
 
-	static bool HasConflict(ClientContext &context, CatalogEntry &current);
-	static bool HasConflict(ClientContext &context, MappingValue &current);
+	static bool HasConflict(ClientContext &context, transaction_t timestamp);
+	static bool UseTimestamp(ClientContext &context, transaction_t timestamp);
 
 	idx_t GetEntryIndex(CatalogEntry *entry);
 	CatalogEntry *GetEntryFromIndex(idx_t index);

--- a/src/include/duckdb/catalog/catalog_set.hpp
+++ b/src/include/duckdb/catalog/catalog_set.hpp
@@ -25,6 +25,18 @@ class ClientContext;
 
 typedef unordered_map<CatalogSet *, std::unique_lock<std::mutex>> set_lock_map_t;
 
+struct MappingValue {
+
+	MappingValue(idx_t index_) : index(index_), timestamp(0), deleted(false) {
+	}
+
+	idx_t index;
+	transaction_t timestamp;
+	bool deleted;
+	unique_ptr<MappingValue> child;
+	MappingValue *parent;
+};
+
 //! The Catalog Set stores (key, value) map of a set of AbstractCatalogEntries
 class CatalogSet {
 	friend class DependencyManager;
@@ -67,10 +79,12 @@ public:
 	}
 
 	static bool HasConflict(ClientContext &context, CatalogEntry &current);
+	static bool HasConflict(ClientContext &context, MappingValue &current);
 
 	idx_t GetEntryIndex(CatalogEntry *entry);
 	CatalogEntry *GetEntryFromIndex(idx_t index);
 	void ClearEntryName(string name);
+	void UpdateTimestamp(CatalogEntry *entry, transaction_t timestamp);
 
 private:
 	//! Given a root entry, gets the entry valid for this transaction
@@ -80,13 +94,16 @@ private:
 	//! Drops an entry from the catalog set; must hold the catalog_lock to safely call this
 	void DropEntryInternal(ClientContext &context, idx_t entry_index, CatalogEntry &entry, bool cascade,
 	                       set_lock_map_t &lock_set);
+	MappingValue *GetMapping(ClientContext &context, const string &name);
+	void PutMapping(ClientContext &context, const string &name, idx_t entry_index);
+	void DeleteMapping(ClientContext &context, const string &name);
 
 private:
 	Catalog &catalog;
 	//! The catalog lock is used to make changes to the data
 	mutex catalog_lock;
 	//! Mapping of string to catalog entry
-	unordered_map<string, idx_t> mapping;
+	unordered_map<string, unique_ptr<MappingValue>> mapping;
 	//! The set of catalog entries
 	unordered_map<idx_t, unique_ptr<CatalogEntry>> entries;
 	//! The current catalog entry index

--- a/src/include/duckdb/catalog/catalog_set.hpp
+++ b/src/include/duckdb/catalog/catalog_set.hpp
@@ -93,7 +93,7 @@ private:
 	//! Drops an entry from the catalog set; must hold the catalog_lock to safely call this
 	void DropEntryInternal(ClientContext &context, idx_t entry_index, CatalogEntry &entry, bool cascade,
 	                       set_lock_map_t &lock_set);
-	MappingValue *GetMapping(ClientContext &context, const string &name);
+	MappingValue *GetMapping(ClientContext &context, const string &name, bool get_latest = false);
 	void PutMapping(ClientContext &context, const string &name, idx_t entry_index);
 	void DeleteMapping(ClientContext &context, const string &name);
 

--- a/src/transaction/cleanup_state.cpp
+++ b/src/transaction/cleanup_state.cpp
@@ -30,9 +30,6 @@ void CleanupState::CleanupEntry(UndoFlags type, data_ptr_t data) {
 				// delete the entry from the dependency manager, if it is not deleted yet
 				catalog_entry->catalog->dependency_manager->EraseObject(catalog_entry);
 			}
-			if (catalog_entry->name != catalog_entry->parent->name) {
-				catalog_entry->set->ClearEntryName(catalog_entry->name);
-			}
 			catalog_entry->parent->child = move(catalog_entry->child);
 		}
 		break;

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/write_ahead_log.hpp"
 #include "duckdb/storage/uncompressed_segment.hpp"
+#include "duckdb/catalog/catalog_set.hpp"
 #include "duckdb/common/serializer/buffered_deserializer.hpp"
 #include "duckdb/parser/parsed_data/alter_table_info.hpp"
 

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -155,7 +155,7 @@ template <bool HAS_LOG> void CommitState::CommitEntry(UndoFlags type, data_ptr_t
 		// set the commit timestamp of the catalog entry to the given id
 		auto catalog_entry = Load<CatalogEntry *>(data);
 		assert(catalog_entry->parent);
-		catalog_entry->parent->timestamp = commit_id;
+		catalog_entry->set->UpdateTimestamp(catalog_entry->parent, commit_id);
 
 		if (HAS_LOG) {
 			// push the catalog update to the WAL
@@ -205,7 +205,7 @@ void CommitState::RevertCommit(UndoFlags type, data_ptr_t data) {
 		// set the commit timestamp of the catalog entry to the given id
 		auto catalog_entry = Load<CatalogEntry *>(data);
 		assert(catalog_entry->parent);
-		catalog_entry->parent->timestamp = transaction_id;
+		catalog_entry->set->UpdateTimestamp(catalog_entry->parent, transaction_id);
 		break;
 	}
 	case UndoFlags::INSERT_TUPLE: {

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -156,7 +156,9 @@ template <bool HAS_LOG> void CommitState::CommitEntry(UndoFlags type, data_ptr_t
 		auto catalog_entry = Load<CatalogEntry *>(data);
 		assert(catalog_entry->parent);
 		catalog_entry->set->UpdateTimestamp(catalog_entry->parent, commit_id);
-
+		if (catalog_entry->name != catalog_entry->parent->name) {
+			catalog_entry->set->UpdateTimestamp(catalog_entry, commit_id);
+		}
 		if (HAS_LOG) {
 			// push the catalog update to the WAL
 			WriteCatalogEntry(catalog_entry, data + sizeof(CatalogEntry *));

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -208,6 +208,9 @@ void CommitState::RevertCommit(UndoFlags type, data_ptr_t data) {
 		auto catalog_entry = Load<CatalogEntry *>(data);
 		assert(catalog_entry->parent);
 		catalog_entry->set->UpdateTimestamp(catalog_entry->parent, transaction_id);
+		if (catalog_entry->name != catalog_entry->parent->name) {
+			catalog_entry->set->UpdateTimestamp(catalog_entry, transaction_id);
+		}
 		break;
 	}
 	case UndoFlags::INSERT_TUPLE: {

--- a/test/sql/alter/rename_table/test_rename_table_chain_commit.test
+++ b/test/sql/alter/rename_table/test_rename_table_chain_commit.test
@@ -22,6 +22,9 @@ statement ok con1
 CREATE TABLE entry(j INTEGER);
 
 statement ok con1
+INSERT INTO entry VALUES (2)
+
+statement ok con1
 ALTER TABLE entry2 RENAME TO entry3;
 
 statement ok con1
@@ -64,8 +67,10 @@ SELECT * FROM entry4
 ----
 1
 
-statement ok con2
+query I con2
 SELECT * FROM entry3
+----
+2
 
 statement ok con2
 SELECT * FROM entry2

--- a/test/sql/alter/rename_table/test_rename_table_chain_commit.test
+++ b/test/sql/alter/rename_table/test_rename_table_chain_commit.test
@@ -1,3 +1,5 @@
+# name: test/sql/alter/rename_table/test_rename_table_chain_commit.test
+# group: [rename_table]
 
 statement ok con1
 CREATE TABLE entry(i INTEGER);
@@ -17,7 +19,7 @@ statement ok con1
 ALTER TABLE entry RENAME TO entry2;
 
 statement ok con1
-CREATE TABLE entry(i INTEGER);
+CREATE TABLE entry(j INTEGER);
 
 statement ok con1
 ALTER TABLE entry2 RENAME TO entry3;
@@ -26,7 +28,7 @@ statement ok con1
 ALTER TABLE entry RENAME TO entry2;
 
 statement ok con1
-CREATE TABLE entry(i INTEGER);
+CREATE TABLE entry(k INTEGER);
 
 statement ok con1
 ALTER TABLE entry3 RENAME TO entry4;
@@ -62,4 +64,8 @@ SELECT * FROM entry4
 ----
 1
 
+statement ok con2
+SELECT * FROM entry3
 
+statement ok con2
+SELECT * FROM entry2

--- a/test/sql/alter/rename_table/test_rename_table_chain_commit.test
+++ b/test/sql/alter/rename_table/test_rename_table_chain_commit.test
@@ -1,4 +1,5 @@
 # name: test/sql/alter/rename_table/test_rename_table_chain_commit.test
+# description: test a chain of table creates and renames in a transaction, followed by a commit
 # group: [rename_table]
 
 statement ok con1

--- a/test/sql/alter/rename_table/test_rename_table_chain_commit.test
+++ b/test/sql/alter/rename_table/test_rename_table_chain_commit.test
@@ -1,0 +1,65 @@
+
+statement ok con1
+CREATE TABLE entry(i INTEGER);
+
+statement ok con1
+INSERT INTO entry VALUES (1)
+
+query I con2
+SELECT * FROM entry
+----
+1
+
+statement ok con1
+BEGIN TRANSACTION;
+
+statement ok con1
+ALTER TABLE entry RENAME TO entry2;
+
+statement ok con1
+CREATE TABLE entry(i INTEGER);
+
+statement ok con1
+ALTER TABLE entry2 RENAME TO entry3;
+
+statement ok con1
+ALTER TABLE entry RENAME TO entry2;
+
+statement ok con1
+CREATE TABLE entry(i INTEGER);
+
+statement ok con1
+ALTER TABLE entry3 RENAME TO entry4;
+
+statement ok con1
+ALTER TABLE entry2 RENAME TO entry3;
+
+statement ok con1
+ALTER TABLE entry RENAME TO entry2;
+
+query I con2
+SELECT * FROM entry
+----
+1
+
+statement error con2
+SELECT * FROM entry2
+
+statement error con2
+SELECT * FROM entry3
+
+statement error con2
+SELECT * FROM entry4
+
+statement ok con1
+COMMIT
+
+statement error con2
+SELECT * FROM entry
+
+query I con2
+SELECT * FROM entry4
+----
+1
+
+

--- a/test/sql/alter/rename_table/test_rename_table_chain_rollback.test
+++ b/test/sql/alter/rename_table/test_rename_table_chain_rollback.test
@@ -1,3 +1,6 @@
+# name: test/sql/alter/rename_table/test_rename_table_chain_rollback.test
+# description: test a chain of table creates and renames in a transaction, followed by a rollback
+# group: [rename_table]
 
 statement ok con1
 CREATE TABLE entry(i INTEGER);

--- a/test/sql/alter/rename_table/test_rename_table_chain_rollback.test
+++ b/test/sql/alter/rename_table/test_rename_table_chain_rollback.test
@@ -1,0 +1,65 @@
+
+statement ok con1
+CREATE TABLE entry(i INTEGER);
+
+statement ok con1
+INSERT INTO entry VALUES (1)
+
+query I con2
+SELECT * FROM entry
+----
+1
+
+statement ok con1
+BEGIN TRANSACTION;
+
+statement ok con1
+ALTER TABLE entry RENAME TO entry2;
+
+statement ok con1
+CREATE TABLE entry(i INTEGER);
+
+statement ok con1
+ALTER TABLE entry2 RENAME TO entry3;
+
+statement ok con1
+ALTER TABLE entry RENAME TO entry2;
+
+statement ok con1
+CREATE TABLE entry(i INTEGER);
+
+statement ok con1
+ALTER TABLE entry3 RENAME TO entry4;
+
+statement ok con1
+ALTER TABLE entry2 RENAME TO entry3;
+
+statement ok con1
+ALTER TABLE entry RENAME TO entry2;
+
+query I con2
+SELECT * FROM entry
+----
+1
+
+statement error con2
+SELECT * FROM entry2
+
+statement error con2
+SELECT * FROM entry3
+
+statement error con2
+SELECT * FROM entry4
+
+statement ok con1
+ROLLBACK
+
+query I con2
+SELECT * FROM entry
+----
+1
+
+statement error con2
+SELECT * FROM entry4
+
+

--- a/test/sql/alter/rename_table/test_rename_table_collision.test
+++ b/test/sql/alter/rename_table/test_rename_table_collision.test
@@ -56,3 +56,65 @@ SELECT i FROM t2 ORDER BY i;
 
 statement error con1
 SELECT * FROM t1
+
+
+# Now we're going to do a rollback instead of a commit
+
+statement ok con2
+BEGIN TRANSACTION
+
+statement ok con2
+ALTER TABLE t2 RENAME TO t3;
+
+statement error con1
+SELECT i FROM t3 ORDER BY i
+
+statement error con2
+SELECT i FROM t2 ORDER BY i
+
+query I con2
+SELECT i FROM t3 ORDER BY i
+----
+1
+2
+3
+
+statement ok con2
+DROP TABLE t3;
+
+query I con1
+SELECT i FROM t2 ORDER BY i;
+----
+1
+2
+3
+
+statement ok con2
+CREATE TABLE t2 (i integer)
+
+statement ok con2
+INSERT INTO t2 VALUES (7), (8), (9)
+
+query I con2
+SELECT i FROM t2 ORDER BY i
+----
+7
+8
+9
+
+statement ok con2
+ROLLBACK
+
+query I con1
+SELECT i FROM t2 ORDER BY i;
+----
+1
+2
+3
+
+query I con2
+SELECT i FROM t2 ORDER BY i;
+----
+1
+2
+3

--- a/test/sql/alter/rename_table/test_rename_table_collision.test
+++ b/test/sql/alter/rename_table/test_rename_table_collision.test
@@ -118,3 +118,77 @@ SELECT i FROM t2 ORDER BY i;
 1
 2
 3
+
+# alter/create collision
+
+statement ok con1
+BEGIN TRANSACTION
+
+statement ok con2
+BEGIN TRANSACTION
+
+statement ok con1
+ALTER TABLE t2 RENAME TO t3
+
+statement error con2
+CREATE TABLE t3 (i INTEGER)
+
+statement ok con1
+ROLLBACK
+
+statement ok con2
+ROLLBACK
+
+# alter/alter collision
+
+statement ok con1
+BEGIN TRANSACTION
+
+statement ok con2
+BEGIN TRANSACTION
+
+statement ok con2
+ALTER TABLE t2 RENAME TO t3
+
+statement error con1
+ALTER TABLE t2 RENAME TO t4
+
+statement ok con1
+ROLLBACK
+
+statement ok con2
+ROLLBACK
+
+# create some additional reference tables
+# for testing, outside of any transaction
+
+statement ok con1
+CREATE TABLE e1 (i INTEGER)
+
+statement ok con2
+CREATE TABLE e2 (i INTEGER)
+
+# crossing drops/renames
+statement ok con1
+BEGIN TRANSACTION
+
+statement ok con2
+BEGIN TRANSACTION
+
+statement ok con1
+DROP TABLE e2
+
+statement ok con2
+DROP TABLE e1
+
+statement error con1
+ALTER TABLE e1 RENAME TO e2
+
+statement error con2
+ALTER TABLE e2 RENAME TO e1
+
+statement ok con1
+ROLLBACK
+
+statement ok con2
+ROLLBACK

--- a/test/sql/alter/rename_table/test_rename_table_collision.test
+++ b/test/sql/alter/rename_table/test_rename_table_collision.test
@@ -1,0 +1,58 @@
+# name: test/sql/alter/rename_table/test_rename_table_collision.test
+# description: Test RENAME TABLE multiple transactions with rename after drop
+# group: [rename_table]
+
+statement ok con1
+CREATE TABLE t1(i INTEGER);
+
+statement ok con1
+INSERT INTO t1 VALUES (1), (2), (3);
+
+statement ok con2
+CREATE TABLE t2(i VARCHAR);
+
+statement ok con2
+INSERT INTO t2 VALUES (4), (5), (6);
+
+statement ok con2
+BEGIN TRANSACTION
+
+statement ok con2
+DROP TABLE t2;
+
+statement ok con2
+ALTER TABLE t1 RENAME TO t2;
+
+query I con2
+SELECT i FROM t2 ORDER BY i;
+----
+1
+2
+3
+
+query I con1
+SELECT i FROM t1 ORDER BY i;
+----
+1
+2
+3
+
+query I con1
+SELECT i FROM t2 ORDER BY i;
+----
+4
+5
+6
+
+statement ok con2
+COMMIT
+
+query I con1
+SELECT i FROM t2 ORDER BY i;
+----
+1
+2
+3
+
+statement error con1
+SELECT * FROM t1

--- a/test/sql/alter/rename_view/test_rename_view.test
+++ b/test/sql/alter/rename_view/test_rename_view.test
@@ -52,9 +52,11 @@ SELECT * FROM vw2
 statement error
 SELECT * FROM vw
 
-query I
-SELECT * FROM vw2
-----
-999
-100
+statement ok
+CREATE VIEW vw AS SELECT i+1 AS i FROM tbl
 
+query I
+SELECT * FROM vw
+----
+1000
+101


### PR DESCRIPTION
Hey Mark, I got a rev of this working this evening, including a simple test based on [your comment here](https://github.com/cwida/duckdb/pull/979#issuecomment-701993795). 

There's one interesting test failure that I can't quite sort out b/c it looks like a desired consequence of this change: [this](https://github.com/cwida/duckdb/blob/master/test/sql/catalog/dependencies/test_prepare_dependencies_transactions.test#L54) `DROP INTEGERS` statement in `test_prepare_dependencies_transactions.test` succeeds when it isn't supposed to because the prepared statement that depends on the table is created in another transaction and is no longer visible to the transaction where the drop occurs (using the transaction-aware mapping logic). Should I special-case the dependency finding logic to ensure that other transactions can see them so this test works as it did before, or is there another way to remedy this?

Otherwise, I'd love your overall impression of the code; I'll address any fixes and add many more tests tomorrow PST if the basic approach is sound. Thanks!