### PR TITLE
Remove explicit creation of sqlite_master in duckdb_python

### DIFF
--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -1028,10 +1028,6 @@ struct DuckDBPyConnection {
 		context.catalog.CreateTableFunction(context, &info);
 		context.transaction.Commit();
 
-		if (!read_only) {
-			res->connection->Query("CREATE OR REPLACE VIEW sqlite_master AS SELECT * FROM sqlite_master()");
-		}
-
 		return res;
 	}
 


### PR DESCRIPTION
This is handled by the default generator now and is (I think?) superfluous.