### PR TITLE
Move make_context() to helper file

### DIFF
--- a/tools/rpkg/tests/testthat/helper-DBItest.R
+++ b/tools/rpkg/tests/testthat/helper-DBItest.R
@@ -1,0 +1,11 @@
+DBItest::make_context(
+  duckdb::duckdb(),
+  list(debug = F),
+  tweaks = DBItest::tweaks(
+    omit_blob_tests = TRUE,
+    temporary_tables = FALSE,
+    timestamp_cast = function(x) sprintf("CAST('%s' AS TIMESTAMP)", x),
+    date_cast = function(x) sprintf("CAST('%s' AS DATE)", x),
+    time_cast = function(x) sprintf("CAST('%s' AS TIME)", x)),
+  name = "duckdb"
+)

--- a/tools/rpkg/tests/testthat/test-DBItest.R
+++ b/tools/rpkg/tests/testthat/test-DBItest.R
@@ -1,4 +1,3 @@
-DBItest::make_context(duckdb::duckdb(), list(debug = F), tweaks = DBItest::tweaks(omit_blob_tests = TRUE, temporary_tables = FALSE, timestamp_cast = function(x) sprintf("CAST('%s' AS TIMESTAMP)", x), date_cast = function(x) sprintf("CAST('%s' AS DATE)", x), time_cast = function(x) sprintf("CAST('%s' AS TIME)", x)), name = "duckdb")
 DBItest::test_all(c(
   "package_name", # wontfix
   "constructor", # wontfix


### PR DESCRIPTION
This ensures that the context is available after `devtools::load_all()`, so that we can run e.g. `DBItest::test_some(...)` directly.