### PR TITLE
Silence test warning

### DIFF
--- a/tools/rpkg/tests/testthat/test_parquet.R
+++ b/tools/rpkg/tests/testthat/test_parquet.R
@@ -2,4 +2,6 @@ test_that("parquet reader works on the notorious userdata1 file", {
   con <- dbConnect(duckdb::duckdb())
   res <- dbGetQuery(con, "SELECT * FROM parquet_scan('userdata1.parquet')")
   dbDisconnect(con, shutdown = T)
+
+  expect_true(T)
 })


### PR DESCRIPTION
by introducing a dummy `expect_true()`.