### PR TITLE
Allow CTEs in subqueries (including CTEs themselves)

### DIFF
--- a/src/include/duckdb/parser/expression/subquery_expression.hpp
+++ b/src/include/duckdb/parser/expression/subquery_expression.hpp
@@ -10,7 +10,7 @@
 
 #include "duckdb/common/enums/subquery_type.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
-#include "duckdb/parser/query_node.hpp"
+#include "duckdb/parser/statement/select_statement.hpp"
 
 namespace duckdb {
 
@@ -20,7 +20,7 @@ public:
 	SubqueryExpression();
 
 	//! The actual subquery
-	unique_ptr<QueryNode> subquery;
+	unique_ptr<SelectStatement> subquery;
 	//! The subquery type
 	SubqueryType subquery_type;
 	//! the child expression to compare with (in case of IN, ANY, ALL operators, empty for EXISTS queries and scalar

--- a/src/include/duckdb/parser/statement/select_statement.hpp
+++ b/src/include/duckdb/parser/statement/select_statement.hpp
@@ -17,9 +17,11 @@
 
 namespace duckdb {
 
+class SelectStatement;
+
 struct CommonTableExpressionInfo {
 	vector<string> aliases;
-	unique_ptr<QueryNode> query;
+	unique_ptr<SelectStatement> query;
 };
 
 //! SelectStatement is a typical SELECT clause

--- a/src/include/duckdb/parser/tableref/subqueryref.hpp
+++ b/src/include/duckdb/parser/tableref/subqueryref.hpp
@@ -8,17 +8,18 @@
 
 #pragma once
 
-#include "duckdb/parser/query_node.hpp"
+#include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/tableref.hpp"
 
 namespace duckdb {
 //! Represents a subquery
 class SubqueryRef : public TableRef {
 public:
-	SubqueryRef(unique_ptr<QueryNode> subquery, string alias = string());
+	SubqueryRef(unique_ptr<QueryNode> node, string alias = string());
+	SubqueryRef(unique_ptr<SelectStatement> subquery, string alias = string());
 
 	//! The subquery
-	unique_ptr<QueryNode> subquery;
+	unique_ptr<SelectStatement> subquery;
 	//! Alises for the column names
 	vector<string> column_name_alias;
 

--- a/src/include/duckdb/parser/tableref/subqueryref.hpp
+++ b/src/include/duckdb/parser/tableref/subqueryref.hpp
@@ -15,7 +15,6 @@ namespace duckdb {
 //! Represents a subquery
 class SubqueryRef : public TableRef {
 public:
-	SubqueryRef(unique_ptr<QueryNode> node, string alias = string());
 	SubqueryRef(unique_ptr<SelectStatement> subquery, string alias = string());
 
 	//! The subquery

--- a/src/include/duckdb/parser/transformer.hpp
+++ b/src/include/duckdb/parser/transformer.hpp
@@ -167,8 +167,8 @@ private:
 	//===--------------------------------------------------------------------===//
 	string TransformAlias(duckdb_libpgquery::PGAlias *root, vector<string> &column_name_alias);
 	void TransformCTE(duckdb_libpgquery::PGWithClause *de_with_clause, SelectStatement &select);
-	unique_ptr<QueryNode> TransformRecursiveCTE(duckdb_libpgquery::PGCommonTableExpr *node,
-	                                            CommonTableExpressionInfo &info);
+	unique_ptr<SelectStatement> TransformRecursiveCTE(duckdb_libpgquery::PGCommonTableExpr *node,
+	                                                  CommonTableExpressionInfo &info);
 	// Operator String to ExpressionType (e.g. + => OPERATOR_ADD)
 	ExpressionType OperatorToExpressionType(string &op);
 

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -73,6 +73,8 @@ public:
 	bool read_only;
 	//! Whether or not the statement requires a valid transaction to run
 	bool requires_valid_transaction = true;
+	//! The alias for the currently processing subquery, if it exists
+	string alias;
 
 public:
 	BoundStatement Bind(SQLStatement &statement);
@@ -91,7 +93,7 @@ public:
 	//! Add a common table expression to the binder
 	void AddCTE(const string &name, CommonTableExpressionInfo *cte);
 	//! Find a common table expression by name; returns nullptr if none exists
-	CommonTableExpressionInfo *FindCTE(const string &name);
+	CommonTableExpressionInfo *FindCTE(const string &name, bool skip = false);
 
 	void PushExpressionBinder(ExpressionBinder *binder);
 	void PopExpressionBinder();

--- a/src/main/relation.cpp
+++ b/src/main/relation.cpp
@@ -181,7 +181,9 @@ string Relation::GetAlias() {
 }
 
 unique_ptr<TableRef> Relation::GetTableRef() {
-	return make_unique<SubqueryRef>(GetQueryNode(), GetAlias());
+	auto select = make_unique<SelectStatement>();
+	select->node = GetQueryNode();
+	return make_unique<SubqueryRef>(move(select), GetAlias());
 }
 
 unique_ptr<QueryResult> Relation::Execute() {

--- a/src/parser/expression/subquery_expression.cpp
+++ b/src/parser/expression/subquery_expression.cpp
@@ -42,7 +42,7 @@ void SubqueryExpression::Serialize(Serializer &serializer) {
 
 unique_ptr<ParsedExpression> SubqueryExpression::Deserialize(ExpressionType type, Deserializer &source) {
 	auto subquery_type = source.Read<SubqueryType>();
-	auto subquery = QueryNode::Deserialize(source);
+	auto subquery = SelectStatement::Deserialize(source);
 
 	auto expression = make_unique<SubqueryExpression>();
 	expression->subquery_type = subquery_type;

--- a/src/parser/statement/select_statement.cpp
+++ b/src/parser/statement/select_statement.cpp
@@ -39,7 +39,7 @@ unique_ptr<SelectStatement> SelectStatement::Deserialize(Deserializer &source) {
 		auto name = source.Read<string>();
 		auto info = make_unique<CommonTableExpressionInfo>();
 		source.ReadStringVector(info->aliases);
-		info->query = QueryNode::Deserialize(source);
+		info->query = SelectStatement::Deserialize(source);
 		result->cte_map[name] = move(info);
 	}
 	result->node = QueryNode::Deserialize(source);

--- a/src/parser/tableref/subqueryref.cpp
+++ b/src/parser/tableref/subqueryref.cpp
@@ -7,12 +7,6 @@ using namespace std;
 
 namespace duckdb {
 
-SubqueryRef::SubqueryRef(unique_ptr<QueryNode> node_p, string alias_p) : TableRef(TableReferenceType::SUBQUERY) {
-	this->subquery = make_unique<SelectStatement>();
-	this->subquery->node = move(node_p);
-	this->alias = alias_p;
-}
-
 SubqueryRef::SubqueryRef(unique_ptr<SelectStatement> subquery_p, string alias_p)
     : TableRef(TableReferenceType::SUBQUERY), subquery(move(subquery_p)) {
 	this->alias = alias_p;

--- a/src/parser/tableref/subqueryref.cpp
+++ b/src/parser/tableref/subqueryref.cpp
@@ -7,7 +7,13 @@ using namespace std;
 
 namespace duckdb {
 
-SubqueryRef::SubqueryRef(unique_ptr<QueryNode> subquery_p, string alias_p)
+SubqueryRef::SubqueryRef(unique_ptr<QueryNode> node_p, string alias_p) : TableRef(TableReferenceType::SUBQUERY) {
+	this->subquery = make_unique<SelectStatement>();
+	this->subquery->node = move(node_p);
+	this->alias = alias_p;
+}
+
+SubqueryRef::SubqueryRef(unique_ptr<SelectStatement> subquery_p, string alias_p)
     : TableRef(TableReferenceType::SUBQUERY), subquery(move(subquery_p)) {
 	this->alias = alias_p;
 }
@@ -33,7 +39,7 @@ void SubqueryRef::Serialize(Serializer &serializer) {
 }
 
 unique_ptr<TableRef> SubqueryRef::Deserialize(Deserializer &source) {
-	auto subquery = QueryNode::Deserialize(source);
+	auto subquery = SelectStatement::Deserialize(source);
 	if (!subquery) {
 		return nullptr;
 	}

--- a/src/parser/transform/expression/transform_subquery.cpp
+++ b/src/parser/transform/expression/transform_subquery.cpp
@@ -11,11 +11,11 @@ unique_ptr<ParsedExpression> Transformer::TransformSubquery(PGSubLink *root) {
 		return nullptr;
 	}
 	auto subquery_expr = make_unique<SubqueryExpression>();
-	subquery_expr->subquery = TransformSelectNode((PGSelectStmt *)root->subselect);
+	subquery_expr->subquery = TransformSelect(root->subselect);
 	if (!subquery_expr->subquery) {
 		return nullptr;
 	}
-	assert(subquery_expr->subquery->GetSelectList().size() > 0);
+	assert(subquery_expr->subquery->node->GetSelectList().size() > 0);
 
 	switch (root->subLinkType) {
 	case PG_EXISTS_SUBLINK: {

--- a/src/parser/transform/tableref/transform_subquery.cpp
+++ b/src/parser/transform/tableref/transform_subquery.cpp
@@ -7,7 +7,7 @@ using namespace duckdb_libpgquery;
 
 unique_ptr<TableRef> Transformer::TransformRangeSubselect(PGRangeSubselect *root) {
 	Transformer subquery_transformer(this);
-	auto subquery = subquery_transformer.TransformSelectNode((PGSelectStmt *)root->subquery);
+	auto subquery = subquery_transformer.TransformSelect(root->subquery);
 	if (!subquery) {
 		return nullptr;
 	}

--- a/src/planner/binder/expression/bind_subquery_expression.cpp
+++ b/src/planner/binder/expression/bind_subquery_expression.cpp
@@ -10,14 +10,14 @@ using namespace std;
 class BoundSubqueryNode : public QueryNode {
 public:
 	BoundSubqueryNode(unique_ptr<Binder> subquery_binder, unique_ptr<BoundQueryNode> bound_node,
-	                  unique_ptr<QueryNode> subquery)
+	                  unique_ptr<SelectStatement> subquery)
 	    : QueryNode(QueryNodeType::BOUND_SUBQUERY_NODE), subquery_binder(move(subquery_binder)),
 	      bound_node(move(bound_node)), subquery(move(subquery)) {
 	}
 
 	unique_ptr<Binder> subquery_binder;
 	unique_ptr<BoundQueryNode> bound_node;
-	unique_ptr<QueryNode> subquery;
+	unique_ptr<SelectStatement> subquery;
 
 	const vector<unique_ptr<ParsedExpression>> &GetSelectList() const {
 		throw Exception("Cannot get select list of bound subquery node");
@@ -29,13 +29,16 @@ public:
 };
 
 BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t depth) {
-	if (expr.subquery->type != QueryNodeType::BOUND_SUBQUERY_NODE) {
+	if (expr.subquery->node->type != QueryNodeType::BOUND_SUBQUERY_NODE) {
 		assert(depth == 0);
 		// first bind the actual subquery in a new binder
 		auto subquery_binder = make_unique<Binder>(context, &binder);
 		// the subquery may refer to CTEs from the parent query
 		subquery_binder->CTE_bindings = binder.CTE_bindings;
-		auto bound_node = subquery_binder->BindNode(*expr.subquery);
+		for (auto &cte_it : expr.subquery->cte_map) {
+			subquery_binder->AddCTE(cte_it.first, cte_it.second.get());
+		}
+		auto bound_node = subquery_binder->BindNode(*expr.subquery->node);
 		// check the correlated columns of the subquery for correlated columns with depth > 1
 		for (idx_t i = 0; i < subquery_binder->correlated_columns.size(); i++) {
 			CorrelatedColumnInfo corr = subquery_binder->correlated_columns[i];
@@ -49,7 +52,10 @@ BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t dept
 		if (expr.subquery_type != SubqueryType::EXISTS && bound_node->types.size() > 1) {
 			throw BinderException("Subquery returns %zu columns - expected 1", bound_node->types.size());
 		}
-		expr.subquery = make_unique<BoundSubqueryNode>(move(subquery_binder), move(bound_node), move(expr.subquery));
+		auto prior_subquery = move(expr.subquery);
+		expr.subquery = make_unique<SelectStatement>();
+		expr.subquery->node =
+		    make_unique<BoundSubqueryNode>(move(subquery_binder), move(bound_node), move(prior_subquery));
 	}
 	// now bind the child node of the subquery
 	if (expr.child) {
@@ -60,8 +66,8 @@ BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t dept
 		}
 	}
 	// both binding the child and binding the subquery was successful
-	assert(expr.subquery->type == QueryNodeType::BOUND_SUBQUERY_NODE);
-	auto bound_subquery = (BoundSubqueryNode *)expr.subquery.get();
+	assert(expr.subquery->node->type == QueryNodeType::BOUND_SUBQUERY_NODE);
+	auto bound_subquery = (BoundSubqueryNode *)expr.subquery->node.get();
 	auto child = (BoundExpression *)expr.child.get();
 	auto subquery_binder = move(bound_subquery->subquery_binder);
 	auto bound_node = move(bound_subquery->bound_node);

--- a/src/planner/binder/expression/bind_subquery_expression.cpp
+++ b/src/planner/binder/expression/bind_subquery_expression.cpp
@@ -33,8 +33,6 @@ BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t dept
 		assert(depth == 0);
 		// first bind the actual subquery in a new binder
 		auto subquery_binder = make_unique<Binder>(context, &binder);
-		// the subquery may refer to CTEs from the parent query
-		subquery_binder->CTE_bindings = binder.CTE_bindings;
 		for (auto &cte_it : expr.subquery->cte_map) {
 			subquery_binder->AddCTE(cte_it.first, cte_it.second.get());
 		}

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -16,7 +16,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 	QueryErrorContext error_context(root_statement, ref.query_location);
 	// CTEs and views are also referred to using BaseTableRefs, hence need to distinguish here
 	// check if the table name refers to a CTE
-	auto cte = FindCTE(ref.table_name);
+	auto cte = FindCTE(ref.table_name, ref.table_name == alias);
 	if (cte) {
 		// Check if there is a CTE binding in the BindContext
 		auto ctebinding = bind_context.GetCTEBinding(ref.table_name);

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -25,7 +25,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 			SubqueryRef subquery(cte->query->Copy());
 			subquery.alias = ref.alias.empty() ? ref.table_name : ref.alias;
 			subquery.column_name_alias = cte->aliases;
-			for(idx_t i = 0; i < ref.column_name_alias.size(); i++) {
+			for (idx_t i = 0; i < ref.column_name_alias.size(); i++) {
 				if (i < subquery.column_name_alias.size()) {
 					subquery.column_name_alias[i] = ref.column_name_alias[i];
 				} else {
@@ -86,12 +86,10 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		// for the view and for the current query
 		bool inherit_ctes = false;
 		Binder view_binder(context, this, inherit_ctes);
-		for (auto &cte_it : view_catalog_entry->query->cte_map) {
-			view_binder.AddCTE(cte_it.first, cte_it.second.get());
-		}
-		SubqueryRef subquery(view_catalog_entry->query->node->Copy());
+		SubqueryRef subquery(view_catalog_entry->query->Copy());
 		subquery.alias = ref.alias.empty() ? ref.table_name : ref.alias;
-		subquery.column_name_alias = BindContext::AliasColumnNames(subquery.alias, view_catalog_entry->aliases, ref.column_name_alias);
+		subquery.column_name_alias =
+		    BindContext::AliasColumnNames(subquery.alias, view_catalog_entry->aliases, ref.column_name_alias);
 		// bind the child subquery
 		auto bound_child = view_binder.Bind(subquery);
 		assert(bound_child->type == TableReferenceType::SUBQUERY);

--- a/src/planner/binder/tableref/bind_subqueryref.cpp
+++ b/src/planner/binder/tableref/bind_subqueryref.cpp
@@ -7,6 +7,7 @@ using namespace std;
 
 unique_ptr<BoundTableRef> Binder::Bind(SubqueryRef &ref) {
 	auto binder = make_unique<Binder>(context, this);
+	binder->alias = ref.alias;
 	for (auto &cte_it : ref.subquery->cte_map) {
 		binder->AddCTE(cte_it.first, cte_it.second.get());
 	}

--- a/src/planner/binder/tableref/bind_subqueryref.cpp
+++ b/src/planner/binder/tableref/bind_subqueryref.cpp
@@ -7,7 +7,10 @@ using namespace std;
 
 unique_ptr<BoundTableRef> Binder::Bind(SubqueryRef &ref) {
 	auto binder = make_unique<Binder>(context, this);
-	auto subquery = binder->BindNode(*ref.subquery);
+	for (auto &cte_it : ref.subquery->cte_map) {
+		binder->AddCTE(cte_it.first, cte_it.second.get());
+	}
+	auto subquery = binder->BindNode(*ref.subquery->node);
 	idx_t bind_index = subquery->GetRootIndex();
 	auto result = make_unique<BoundSubqueryRef>(move(binder), move(subquery));
 

--- a/src/storage/storage_info.cpp
+++ b/src/storage/storage_info.cpp
@@ -3,6 +3,6 @@
 namespace duckdb {
 using namespace std;
 
-const uint64_t VERSION_NUMBER = 3;
+const uint64_t VERSION_NUMBER = 4;
 
 } // namespace duckdb

--- a/test/sql/cte/test_cte_in_cte.test
+++ b/test/sql/cte/test_cte_in_cte.test
@@ -46,3 +46,13 @@ query I
 with cte1 as (Select i as j from a) select * from cte1 where j = (with cte2 as (select max(j) as j from cte1) select j from cte2);
 ----
 42
+
+# refer to same-named CTE in a subquery expression
+query I
+with cte as (Select i as j from a) select * from cte where j = (with cte as (select max(j) as j from cte) select j from cte);
+----
+42
+
+# self-refer to non-existent cte
+statement error
+with cte as (select * from cte) select * from cte

--- a/test/sql/cte/test_cte_in_cte.test
+++ b/test/sql/cte/test_cte_in_cte.test
@@ -1,0 +1,42 @@
+# name: test/sql/cte/test_cte_in_cte.test
+# description: Test Nested Common Table Expressions (CTE)
+# group: [cte]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table a(i integer);
+
+statement ok
+insert into a values (42);
+
+query I
+with cte1 as (Select i as j from a) select * from cte1;
+----
+42
+
+query I
+with cte1 as (with b as (Select i as j from a) Select j from b) select x from cte1 t1(x);
+----
+42
+
+query I
+with cte1(xxx) as (with ncte(yyy) as (Select i as j from a) Select yyy from ncte) select xxx from cte1;
+----
+42
+
+query II
+with cte1 as (with b as (Select i as j from a) select j from b), cte2 as (with c as (select ref.j+1 as k from cte1 as ref) select k from c) select * from cte1 , cte2;
+----
+42	43
+
+# duplicate CTE alias
+statement error
+with cte1 as (select 42), cte1 as (select 42) select * FROM cte1;
+
+# refer to CTE in subquery
+query I
+with cte1 as (Select i as j from a) select * from cte1 where j = (with cte2 as (select max(j) as j from cte1) select j from cte2);
+----
+42

--- a/test/sql/cte/test_cte_in_cte.test
+++ b/test/sql/cte/test_cte_in_cte.test
@@ -37,6 +37,6 @@ with cte1 as (select 42), cte1 as (select 42) select * FROM cte1;
 
 # refer to CTE in subquery
 query I
-with cte1 as (Select i as j from a) select * from cte1 where j = (with cte2 as (select max(j) as j from cte1) select j from cte2);
+with cte1 as (Select i as j from a) select * from (with cte2 as (select max(j) as j from cte1) select * from cte2) f
 ----
 42

--- a/test/sql/cte/test_cte_in_cte.test
+++ b/test/sql/cte/test_cte_in_cte.test
@@ -35,8 +35,14 @@ with cte1 as (with b as (Select i as j from a) select j from b), cte2 as (with c
 statement error
 with cte1 as (select 42), cte1 as (select 42) select * FROM cte1;
 
-# refer to CTE in subquery
+# refer to CTE in subquery tableref
 query I
 with cte1 as (Select i as j from a) select * from (with cte2 as (select max(j) as j from cte1) select * from cte2) f
+----
+42
+
+# refer to CTE in subquery expression
+query I
+with cte1 as (Select i as j from a) select * from cte1 where j = (with cte2 as (select max(j) as j from cte1) select j from cte2);
 ----
 42

--- a/test/sql/subquery/scalar/test_correlated_subquery_cte.test
+++ b/test/sql/subquery/scalar/test_correlated_subquery_cte.test
@@ -1,0 +1,147 @@
+# name: test/sql/subquery/scalar/test_correlated_subquery.test
+# description: Test correlated subqueries
+# group: [scalar]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE integers(i INTEGER)
+
+statement ok
+INSERT INTO integers VALUES (1), (2), (3), (NULL)
+
+# scalar select with correlation
+query II
+SELECT i, (WITH i2 AS (SELECT 42+i1.i AS j) SELECT j FROM i2) AS j FROM integers i1 ORDER BY i;
+----
+NULL	NULL
+1	43
+2	44
+3	45
+
+# ORDER BY correlated subquery
+query I
+SELECT i FROM integers i1 ORDER BY (WITH i2 AS (SELECT 100-i1.i as j) SELECT j FROM i2);
+----
+NULL
+3
+2
+1
+
+# subquery returning multiple results
+query II
+SELECT i, (WITH i2 AS (SELECT 42+i1.i AS j FROM integers) SELECT j FROM i2) AS j FROM integers i1 ORDER BY i;
+----
+NULL	NULL
+1	43
+2	44
+3	45
+
+# subquery with LIMIT
+query II
+SELECT i, (WITH i2 AS (SELECT 42+i1.i AS j FROM integers) SELECT j FROM i2 LIMIT 1) AS j FROM integers i1 ORDER BY i;
+----
+NULL	NULL
+1	43
+2	44
+3	45
+
+# subquery with LIMIT 0
+query II
+SELECT i, (WITH i2 AS (SELECT 42+i1.i AS j FROM integers) SELECT j FROM i2 LIMIT 0) AS j FROM integers i1 ORDER BY i;
+----
+NULL	NULL
+1	NULL
+2	NULL
+3	NULL
+
+# subquery with WHERE clause that is always FALSE
+query II
+SELECT i, (WITH i2 AS (SELECT i FROM integers WHERE 1=0 AND i1.i=i) SELECT i FROM i2) AS j FROM integers i1 ORDER BY i;
+----
+NULL	NULL
+1	NULL
+2	NULL
+3	NULL
+
+# correlated EXISTS with WHERE clause that is always FALSE
+query IT
+SELECT i, EXISTS(WITH i2 AS (SELECT i FROM integers WHERE 1=0 AND i1.i=i) SELECT i FROM i2) AS j FROM integers i1 ORDER BY i;
+----
+NULL	0
+1	0
+2	0
+3	0
+
+# correlated ANY with WHERE clause that is always FALSE
+query IT
+SELECT i, i=ANY(WITH i2 AS (SELECT i FROM integers WHERE 1=0 AND i1.i=i) SELECT i FROM i2) AS j FROM integers i1 ORDER BY i;
+----
+NULL	0
+1	0
+2	0
+3	0
+
+# subquery with OFFSET is not supported
+statement error
+SELECT i, (WITH i2 AS (SELECT i+i1.i FROM integers LIMIT 1 OFFSET 1) SELECT * FROM i2) AS j FROM integers i1 ORDER BY i;
+
+# subquery with ORDER BY is not supported
+statement error
+SELECT i, (WITH i2 AS (SELECT i+i1.i FROM integers ORDER BY 1 LIMIT 1 OFFSET 1) SELECT * FROM i2) AS j FROM integers i1 ORDER BY i;
+
+# correlated filter without FROM clause
+query II
+SELECT i, (WITH i2 AS (SELECT 42 WHERE i1.i>2) SELECT * FROM i2) AS j FROM integers i1 ORDER BY i;
+----
+NULL	NULL
+1	NULL
+2	NULL
+3	42
+
+# correlated filter with matching entry on NULL
+query II
+SELECT i, (WITH i2 AS (SELECT 42 WHERE i1.i IS NULL) SELECT * FROM i2) AS j FROM integers i1 ORDER BY i;
+----
+NULL	42
+1	NULL
+2	NULL
+3	NULL
+
+# scalar select with correlation in projection
+query II
+SELECT i, (WITH i2 AS (SELECT i+i1.i FROM integers WHERE i=1) SELECT * FROM i2) AS j FROM integers i1 ORDER BY i;
+----
+NULL	NULL
+1	2
+2	3
+3	4
+
+# scalar select with correlation in filter
+query II
+SELECT i, (WITH i2 AS (SELECT i FROM integers WHERE i=i1.i) SELECT * FROM i2) AS j FROM integers i1 ORDER BY i;
+----
+NULL	NULL
+1	1
+2	2
+3	3
+
+# scalar select with operation in projection
+query II
+SELECT i, (WITH i2 AS (SELECT i+1 FROM integers WHERE i=i1.i) SELECT * FROM i2) AS j FROM integers i1 ORDER BY i;
+----
+NULL	NULL
+1	2
+2	3
+3	4
+
+# correlated scalar select with constant in projection
+query II
+SELECT i, (WITH i2 AS (SELECT 42 FROM integers WHERE i=i1.i) SELECT * FROM i2) AS j FROM integers i1 ORDER BY i;
+----
+NULL	NULL
+1	42
+2	42
+3	42
+

--- a/test/sql/subquery/scalar/test_scalar_subquery_cte.test
+++ b/test/sql/subquery/scalar/test_scalar_subquery_cte.test
@@ -1,0 +1,153 @@
+# name: test/sql/subquery/scalar/test_scalar_subquery_cte.test
+# description: Test subqueries with CTEs
+# group: [scalar]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT 1+(WITH cte AS (SELECT 1) SELECT * FROM cte)
+----
+2
+
+query T
+SELECT 1=(WITH cte AS (SELECT 1) SELECT * FROM cte)
+----
+1
+
+query T
+SELECT 1<>(WITH cte AS (SELECT 1) SELECT * FROM cte)
+----
+0
+
+query T
+SELECT 1=(WITH cte AS (SELECT NULL) SELECT * FROM cte)
+----
+NULL
+
+query T
+SELECT NULL=(SELECT 1)
+----
+NULL
+
+# scalar subquery
+query I
+SELECT (WITH cte AS (SELECT 42) SELECT * FROM cte)
+----
+42
+
+# nested subquery
+query I
+SELECT (WITH cte1 AS (WITH cte2 AS (SELECT 42) SELECT * FROM cte2) SELECT * FROM cte1)
+----
+42
+
+# test aliasing of subquery
+query I
+SELECT * FROM (WITH cte(x) AS (SELECT 42) SELECT x FROM cte) v1(a);
+----
+42
+
+# not enough aliases: defaults to using names for missing columns
+query II
+SELECT * FROM (WITH cte AS (SELECT 42, 41 AS x) SELECT * FROM cte) v1(a);
+----
+42	41
+
+# too many aliases: fails
+statement error
+SELECT * FROM (WITH cte AS (SELECT 42, 41 AS x) SELECT * FROM cte) v1(a, b, c);
+
+statement ok
+CREATE TABLE test (a INTEGER, b INTEGER);
+
+statement ok
+INSERT INTO test VALUES (11, 22)
+
+statement ok
+INSERT INTO test VALUES (12, 21)
+
+statement ok
+INSERT INTO test VALUES (13, 22)
+
+# select single tuple only in scalar subquery
+query I
+SELECT (WITH cte AS (SELECT a * 42 FROM test) SELECT * FROM cte)
+----
+462
+
+# operations on subquery
+query I
+SELECT a*(WITH cte AS (SELECT 42) SELECT * FROM cte) FROM test
+----
+462
+504
+546
+
+statement ok
+CREATE TABLE t1(a INTEGER, b INTEGER, c INTEGER, d INTEGER, e INTEGER)
+
+statement ok
+INSERT INTO t1(e,c,b,d,a) VALUES(103,102,100,101,104)
+
+statement ok
+INSERT INTO t1(a,c,d,e,b) VALUES(107,106,108,109,105)
+
+query R
+SELECT c-(WITH cte AS (SELECT sum(c) FROM t1) SELECT * FROM cte) FROM t1
+----
+-106.000000
+-102.000000
+
+query I
+SELECT CASE WHEN c>(WITH cte AS (SELECT sum(c)/count(*) FROM t1) SELECT * FROM cte) THEN a*2 ELSE b*10 END FROM t1
+----
+1000
+214
+
+# correlated subqueries
+query IR
+SELECT a, (WITH cte AS (SELECT SUM(b) FROM test tsub WHERE test.a=tsub.a) SELECT * FROM cte) FROM test
+----
+11	22.000000
+12	21.000000
+13	22.000000
+
+query II
+SELECT a, (WITH cte AS (SELECT CASE WHEN test.a=11 THEN 22 ELSE NULL END) SELECT * FROM cte) FROM test ORDER BY a
+----
+11	22
+12	NULL
+13	NULL
+
+query II
+SELECT a, (WITH cte AS (SELECT CASE WHEN test.a=11 THEN b ELSE NULL END FROM test tsub) SELECT * FROM cte) FROM test ORDER BY a
+----
+11	22
+12	NULL
+13	NULL
+
+query II
+SELECT a, (WITH cte AS (SELECT CASE WHEN test.a=11 THEN b ELSE NULL END FROM test tsub LIMIT 1) SELECT * FROM cte) FROM test ORDER BY a
+----
+11	22
+12	NULL
+13	NULL
+
+query II
+SELECT * from test where a=(WITH cte AS (SELECT a FROM test t WHERE t.b=test.b) SELECT min(a) FROM cte)
+----
+11	22
+12	21
+
+# exists / in / any subqueries
+query II
+SELECT * FROM test WHERE EXISTS (WITH cte AS (SELECT * FROM test ts WHERE ts.a = test.a AND b>21) SELECT a FROM cte)
+----
+11	22
+13	22
+
+# duplicate name in subquery
+statement error
+SELECT * FROM (WITH cte AS (SELECT 42 AS a, 44 AS a) SELECT * FROM cte) tbl1
+


### PR DESCRIPTION
This was the last bit of functionality I needed for full compatibility with the adapter tests for [dbt-duckdb](https://github.com/jwills/dbt-duckdb): the ability to use CTEs inside of subqueries (including CTEs themselves.)

I built on the work from #987 and went ahead and updated the storage version b/c it's safe to say that this will break backwards compatibility with view definitions. Assuming this passes the basic suite of integration tests, I'll start adding in a full suite of CTEs-inside-of-CTE tests tomorrow, but if there's anything you see here that looks concerning, please let me know!

It feels really, really good to have dbt working end-to-end with DuckDB: thanks so much for reviewing all of my PRs!