### PR TITLE
Fix ingestion of time values

### DIFF
--- a/tools/rpkg/tests/testthat/test-DBItest.R
+++ b/tools/rpkg/tests/testthat/test-DBItest.R
@@ -13,7 +13,6 @@ DBItest::test_all(c(
 
   "data_logical", # casting NULL issue
 
-  "roundtrip_time",
   "roundtrip_field_types", # strange
   "data_64_bit_numeric_warning", # not now
   "data_64_bit_lossless", # not now,


### PR DESCRIPTION
Objects of class `"difftime"` have a `"units"` attribute that decides if the value means seconds, hours, or weeks. This maps to five new internal types with different conversion factors.

Changed the default unit for time values returned to `"secs"`:

- more natural
- fewer rounding errors if computing in seconds
- hms uses this too
- simpler code

Added new `RStrings` class to speed up comparison of strings.

Eventually we should:

- add a new `RSymbols` class in similar fashion for symbols
- `#define R_NO_REMAP` to make the `Rf_` prefix mandatory for the R API