### PR TITLE
Document usage of dblog

### DIFF
--- a/tools/rpkg/tests/testthat/helper-DBItest.R
+++ b/tools/rpkg/tests/testthat/helper-DBItest.R
@@ -1,5 +1,9 @@
+# remotes::install_github("r-dbi/dblog")
+# Then, use dblog::dblog(duckdb::duckdb()) in conjunction with DBItest::test_some()
+# to see the DBI calls emitted by the tests
 DBItest::make_context(
   duckdb::duckdb(),
+  # dblog::dblog(duckdb::duckdb()),
   list(debug = F),
   tweaks = DBItest::tweaks(
     omit_blob_tests = TRUE,


### PR DESCRIPTION
for easier understanding of test failures.