### PR TITLE
Add PRAGMA for enabling/disabling optimizer & extend output for query graph 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
       script:
         - mkdir -p build/release
         - python3 scripts/amalgamation.py
-        - (cd build/release && cmake -DCMAKE_BUILD_TYPE=Release -DDISABLE_UNITY=1 -DBUILD_ICU_EXTENSION=1 -DBUILD_PARQUET_EXTENSION=1 -DBUILD_TPCH_EXTENSION=1 -DBUILD_REST=1 -DJDBC_DRIVER=1 ../.. && cmake --build .)
+        - (cd build/release && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDISABLE_UNITY=1 -DBUILD_ICU_EXTENSION=1 -DBUILD_PARQUET_EXTENSION=1 -DBUILD_TPCH_EXTENSION=1 -DBUILD_REST=1 -DJDBC_DRIVER=1 ../.. && cmake --build .)
 
         - build/release/test/unittest "*"
         - python3.7 tools/shell/shell-test.py build/release/duckdb

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
       script:
         - mkdir -p build/release
         - python3 scripts/amalgamation.py
-        - (cd build/release && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDISABLE_UNITY=1 -DBUILD_ICU_EXTENSION=1 -DBUILD_PARQUET_EXTENSION=1 -DBUILD_TPCH_EXTENSION=1 -DBUILD_REST=1 -DJDBC_DRIVER=1 ../.. && cmake --build .)
+        - (cd build/release && cmake -DCMAKE_BUILD_TYPE=Release -DDISABLE_UNITY=1 -DBUILD_ICU_EXTENSION=1 -DBUILD_PARQUET_EXTENSION=1 -DBUILD_TPCH_EXTENSION=1 -DBUILD_REST=1 -DJDBC_DRIVER=1 ../.. && cmake --build .)
 
         - build/release/test/unittest "*"
         - python3.7 tools/shell/shell-test.py build/release/duckdb

--- a/src/common/value_operations/numeric_operations.cpp
+++ b/src/common/value_operations/numeric_operations.cpp
@@ -52,7 +52,7 @@ Value ValueOperations::Multiply(const Value &left, const Value &right) {
 
 Value ValueOperations::Modulo(const Value &left, const Value &right) {
 	if (right == 0) {
-		return templated_binary_operation<duckdb::ModuloOperator>(left, Value(right.type()));
+		return Value(right.type());
 	} else {
 		return templated_binary_operation<duckdb::ModuloOperator>(left, right);
 	}
@@ -60,7 +60,7 @@ Value ValueOperations::Modulo(const Value &left, const Value &right) {
 
 Value ValueOperations::Divide(const Value &left, const Value &right) {
 	if (right == 0) {
-		return templated_binary_operation<duckdb::DivideOperator>(left, Value(right.type()));
+		return Value(right.type());
 	} else {
 		return templated_binary_operation<duckdb::DivideOperator>(left, right);
 	}

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -189,9 +189,8 @@ void PhysicalHashAggregate::Sink(ExecutionContext &context, GlobalOperatorState 
 		                                                 gstate.partition_info, group_types, payload_types, bindings);
 	}
 
-	gstate.lossy_total_groups +=
-	    llstate.ht->AddChunk(group_chunk, payload_chunk,
-	                         gstate.lossy_total_groups > radix_limit && gstate.partition_info.n_partitions > 1);
+	gstate.lossy_total_groups += llstate.ht->AddChunk(
+	    group_chunk, payload_chunk, gstate.lossy_total_groups > radix_limit && gstate.partition_info.n_partitions > 1);
 }
 
 class PhysicalHashAggregateState : public PhysicalOperatorState {
@@ -431,8 +430,8 @@ unique_ptr<PhysicalOperatorState> PhysicalHashAggregate::GetOperatorState() {
 	                                               children.size() == 0 ? nullptr : children[0].get());
 }
 
-bool PhysicalHashAggregate::ForceSingleHT(GlobalOperatorState& state) {
-	auto &gstate = (HashAggregateGlobalState &) state;
+bool PhysicalHashAggregate::ForceSingleHT(GlobalOperatorState &state) {
+	auto &gstate = (HashAggregateGlobalState &)state;
 
 	return !all_combinable || any_distinct || gstate.partition_info.n_partitions < 2;
 }

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -432,10 +432,26 @@ unique_ptr<PhysicalOperatorState> PhysicalHashAggregate::GetOperatorState() {
 }
 
 bool PhysicalHashAggregate::ForceSingleHT(GlobalOperatorState& state) {
-auto &gstate = (HashAggregateGlobalState &) state;
+	auto &gstate = (HashAggregateGlobalState &) state;
 
-return !all_combinable || any_distinct || gstate.partition_info.n_partitions < 2;
+	return !all_combinable || any_distinct || gstate.partition_info.n_partitions < 2;
 }
 
+string PhysicalHashAggregate::ParamsToString() const {
+	string result;
+	for (idx_t i = 0; i < groups.size(); i++) {
+		if (i > 0) {
+			result += "\n";
+		}
+		result += groups[i]->GetName();
+	}
+	for (idx_t i = 0; i < aggregates.size(); i++) {
+		if (i > 0 || groups.size() > 0) {
+			result += "\n";
+		}
+		result += aggregates[i]->GetName();
+	}
+	return result;
+}
 
 } // namespace duckdb

--- a/src/execution/operator/join/physical_index_join.cpp
+++ b/src/execution/operator/join/physical_index_join.cpp
@@ -91,7 +91,10 @@ void PhysicalIndexJoin::Output(ExecutionContext &context, DataChunk &chunk, Phys
 		}
 	}
 	//! Now we fetch the RHS data
-	if (!fetch_types.empty()) {
+	if (!fetch_types.empty() ) {
+		if (fetch_rows.size() == 0) {
+			return;
+		}
 		rhs_chunk.Initialize(fetch_types);
 		ColumnFetchState fetch_state;
 		Vector row_ids;

--- a/src/execution/operator/join/physical_index_join.cpp
+++ b/src/execution/operator/join/physical_index_join.cpp
@@ -91,7 +91,7 @@ void PhysicalIndexJoin::Output(ExecutionContext &context, DataChunk &chunk, Phys
 		}
 	}
 	//! Now we fetch the RHS data
-	if (!fetch_types.empty() ) {
+	if (!fetch_types.empty()) {
 		if (fetch_rows.size() == 0) {
 			return;
 		}

--- a/src/execution/operator/order/physical_order.cpp
+++ b/src/execution/operator/order/physical_order.cpp
@@ -104,7 +104,7 @@ unique_ptr<PhysicalOperatorState> PhysicalOrder::GetOperatorState() {
 
 string PhysicalOrder::ParamsToString() const {
 	string result;
-	for(idx_t i = 0; i < orders.size(); i++) {
+	for (idx_t i = 0; i < orders.size(); i++) {
 		if (i > 0) {
 			result += "\n";
 		}

--- a/src/execution/operator/order/physical_order.cpp
+++ b/src/execution/operator/order/physical_order.cpp
@@ -102,4 +102,16 @@ unique_ptr<PhysicalOperatorState> PhysicalOrder::GetOperatorState() {
 	return make_unique<PhysicalOrderOperatorState>(*this, children[0].get());
 }
 
+string PhysicalOrder::ParamsToString() const {
+	string result;
+	for(idx_t i = 0; i < orders.size(); i++) {
+		if (i > 0) {
+			result += "\n";
+		}
+		result += orders[i].expression->ToString() + " ";
+		result += orders[i].type == OrderType::DESCENDING ? "DESC" : "ASC";
+	}
+	return result;
+}
+
 } // namespace duckdb

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -144,4 +144,20 @@ unique_ptr<PhysicalOperatorState> PhysicalTopN::GetOperatorState() {
 	return make_unique<PhysicalTopNOperatorState>(*this, children[0].get());
 }
 
+string PhysicalTopN::ParamsToString() const {
+	string result;
+	result += "Top " + std::to_string(limit);
+	if (offset > 0) {
+		result += "\n";
+		result += "Offset " + std::to_string(offset);
+	}
+	result += "\n[INFOSEPARATOR]";
+	for(idx_t i = 0; i < orders.size(); i++) {
+		result += "\n";
+		result += orders[i].expression->ToString() + " ";
+		result += orders[i].type == OrderType::DESCENDING ? "DESC" : "ASC";
+	}
+	return result;
+}
+
 } // namespace duckdb

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -152,7 +152,7 @@ string PhysicalTopN::ParamsToString() const {
 		result += "Offset " + std::to_string(offset);
 	}
 	result += "\n[INFOSEPARATOR]";
-	for(idx_t i = 0; i < orders.size(); i++) {
+	for (idx_t i = 0; i < orders.size(); i++) {
 		result += "\n";
 		result += orders[i].expression->ToString() + " ";
 		result += orders[i].type == OrderType::DESCENDING ? "DESC" : "ASC";

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -95,17 +95,30 @@ string PhysicalTableScan::GetName() const {
 
 string PhysicalTableScan::ParamsToString() const {
 	string result;
-	for (auto &f : table_filters) {
-		for (auto &filter : f.second) {
-			result += names[filter.column_index] + ExpressionTypeToOperator(filter.comparison_type) +
-			          filter.constant.ToString();
-			result += "\n";
+	if (function.to_string) {
+		result = function.to_string(bind_data.get());
+		result += "\n[INFOSEPARATOR]\n";
+	}
+	for(idx_t i = 0; i < column_ids.size(); i++) {
+		if (column_ids[i] < names.size()) {
+			if (i > 0) {
+				result += "\n";
+			}
+			result += names[column_ids[i]];
 		}
 	}
-	if (!function.to_string) {
-		return string();
+	if (table_filters.size() > 0) {
+		result += "\n[INFOSEPARATOR]\n";
+		result += "Filters: ";
+		for (auto &f : table_filters) {
+			for (auto &filter : f.second) {
+				result += "\n";
+				result += names[filter.column_index] + ExpressionTypeToOperator(filter.comparison_type) +
+						filter.constant.ToString();
+			}
+		}
 	}
-	return function.to_string(bind_data.get());
+	return result;
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalTableScan::GetOperatorState() {

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -99,7 +99,7 @@ string PhysicalTableScan::ParamsToString() const {
 		result = function.to_string(bind_data.get());
 		result += "\n[INFOSEPARATOR]\n";
 	}
-	for(idx_t i = 0; i < column_ids.size(); i++) {
+	for (idx_t i = 0; i < column_ids.size(); i++) {
 		if (column_ids[i] < names.size()) {
 			if (i > 0) {
 				result += "\n";
@@ -114,7 +114,7 @@ string PhysicalTableScan::ParamsToString() const {
 			for (auto &filter : f.second) {
 				result += "\n";
 				result += names[filter.column_index] + ExpressionTypeToOperator(filter.comparison_type) +
-						filter.constant.ToString();
+				          filter.constant.ToString();
 			}
 		}
 	}

--- a/src/execution/physical_plan/plan_filter.cpp
+++ b/src/execution/physical_plan/plan_filter.cpp
@@ -15,8 +15,9 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalFilter &op
 	assert(op.children.size() == 1);
 	unique_ptr<PhysicalOperator> plan = CreatePlan(*op.children[0]);
 	if (op.expressions.size() > 0) {
+		assert(plan->types.size() > 0);
 		// create a filter if there is anything to filter
-		auto filter = make_unique<PhysicalFilter>(op.children[0]->types, move(op.expressions));
+		auto filter = make_unique<PhysicalFilter>(plan->types, move(op.expressions));
 		filter->children.push_back(move(plan));
 		plan = move(filter);
 	}

--- a/src/function/pragma/pragma_functions.cpp
+++ b/src/function/pragma/pragma_functions.cpp
@@ -24,8 +24,10 @@ static void pragma_enable_profiling_assignment(ClientContext &context, vector<Va
 		context.profiler.automatic_print_format = ProfilerPrintFormat::JSON;
 	} else if (assignment == "query_tree") {
 		context.profiler.automatic_print_format = ProfilerPrintFormat::QUERY_TREE;
+	} else if (assignment == "query_tree_optimizer") {
+		context.profiler.automatic_print_format = ProfilerPrintFormat::QUERY_TREE_OPTIMIZER;
 	} else {
-		throw ParserException("Unrecognized print format %s, supported formats: [json, query_tree]", assignment);
+		throw ParserException("Unrecognized print format %s, supported formats: [json, query_tree, query_tree_optimizer]", assignment);
 	}
 	context.profiler.Enable();
 }

--- a/src/function/pragma/pragma_functions.cpp
+++ b/src/function/pragma/pragma_functions.cpp
@@ -139,6 +139,14 @@ static void pragma_explain_output(ClientContext &context, vector<Value> paramete
 	}
 }
 
+static void pragma_enable_optimizer(ClientContext &context, vector<Value> parameters) {
+	context.enable_optimizer = true;
+}
+
+static void pragma_disable_optimizer(ClientContext &context, vector<Value> parameters) {
+	context.enable_optimizer = false;
+}
+
 void PragmaFunctions::RegisterFunction(BuiltinFunctions &set) {
 	register_enable_profiling(set);
 
@@ -167,6 +175,9 @@ void PragmaFunctions::RegisterFunction(BuiltinFunctions &set) {
 
 	set.AddFunction(PragmaFunction::PragmaStatement("force_parallelism", pragma_enable_force_parallelism));
 	set.AddFunction(PragmaFunction::PragmaStatement("disable_force_parallelism", pragma_disable_force_parallelism));
+
+	set.AddFunction(PragmaFunction::PragmaStatement("enable_optimizer", pragma_enable_optimizer));
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_optimizer", pragma_disable_optimizer));
 
 	set.AddFunction(PragmaFunction::PragmaAssignment("log_query_path", pragma_log_query_path, LogicalType::VARCHAR));
 	set.AddFunction(PragmaFunction::PragmaAssignment("explain_output", pragma_explain_output, LogicalType::VARCHAR));

--- a/src/function/scalar/operators/arithmetic.cpp
+++ b/src/function/scalar/operators/arithmetic.cpp
@@ -486,9 +486,9 @@ struct BinaryZeroIsNullHugeintWrapper {
 	}
 };
 
-template <class TA, class TB, class TC, class OP>
+template <class TA, class TB, class TC, class OP, class ZWRAPPER=BinaryZeroIsNullWrapper>
 static void BinaryScalarFunctionIgnoreZero(DataChunk &input, ExpressionState &state, Vector &result) {
-	BinaryExecutor::Execute<TA, TB, TC, OP, true, BinaryZeroIsNullWrapper>(input.data[0], input.data[1], result,
+	BinaryExecutor::Execute<TA, TB, TC, OP, true, ZWRAPPER>(input.data[0], input.data[1], result,
 	                                                                       input.size());
 }
 
@@ -503,7 +503,7 @@ template <class OP> static scalar_function_t GetBinaryFunctionIgnoreZero(Logical
 	case LogicalTypeId::BIGINT:
 		return BinaryScalarFunctionIgnoreZero<int64_t, int64_t, int64_t, OP>;
 	case LogicalTypeId::HUGEINT:
-		return BinaryScalarFunctionIgnoreZero<hugeint_t, hugeint_t, hugeint_t, OP>;
+		return BinaryScalarFunctionIgnoreZero<hugeint_t, hugeint_t, hugeint_t, OP, BinaryZeroIsNullHugeintWrapper>;
 	case LogicalTypeId::FLOAT:
 		return BinaryScalarFunctionIgnoreZero<float, float, float, OP>;
 	case LogicalTypeId::DOUBLE:

--- a/src/include/duckdb/common/enums/profiler_format.hpp
+++ b/src/include/duckdb/common/enums/profiler_format.hpp
@@ -12,6 +12,6 @@
 
 namespace duckdb {
 
-enum class ProfilerPrintFormat : uint8_t { NONE, QUERY_TREE, JSON };
+enum class ProfilerPrintFormat : uint8_t { NONE, QUERY_TREE, JSON, QUERY_TREE_OPTIMIZER };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp
@@ -61,6 +61,7 @@ public:
 	void GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;
 	unique_ptr<PhysicalOperatorState> GetOperatorState() override;
 
+	string ParamsToString() const override;
 private:
 	//! how many groups can we have in the operator before we switch to radix partitioning
 	idx_t radix_limit;

--- a/src/include/duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp
@@ -62,6 +62,7 @@ public:
 	unique_ptr<PhysicalOperatorState> GetOperatorState() override;
 
 	string ParamsToString() const override;
+
 private:
 	//! how many groups can we have in the operator before we switch to radix partitioning
 	idx_t radix_limit;
@@ -69,7 +70,7 @@ private:
 private:
 	void FinalizeInternal(ClientContext &context, unique_ptr<GlobalOperatorState> gstate, bool immediate,
 	                      Pipeline *pipeline);
-	bool ForceSingleHT(GlobalOperatorState& state);
+	bool ForceSingleHT(GlobalOperatorState &state);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/order/physical_order.hpp
+++ b/src/include/duckdb/execution/operator/order/physical_order.hpp
@@ -31,6 +31,8 @@ public:
 
 	void GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;
 	unique_ptr<PhysicalOperatorState> GetOperatorState() override;
+
+	string ParamsToString() const override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/order/physical_top_n.hpp
+++ b/src/include/duckdb/execution/operator/order/physical_top_n.hpp
@@ -37,6 +37,7 @@ public:
 	unique_ptr<PhysicalOperatorState> GetOperatorState() override;
 
 	string ParamsToString() const override;
+
 private:
 	unique_ptr<idx_t[]> ComputeTopN(ChunkCollection &big_data, idx_t &heap_size);
 };

--- a/src/include/duckdb/execution/operator/order/physical_top_n.hpp
+++ b/src/include/duckdb/execution/operator/order/physical_top_n.hpp
@@ -36,6 +36,7 @@ public:
 	void GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;
 	unique_ptr<PhysicalOperatorState> GetOperatorState() override;
 
+	string ParamsToString() const override;
 private:
 	unique_ptr<idx_t[]> ComputeTopN(ChunkCollection &big_data, idx_t &heap_size);
 };

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -97,8 +97,8 @@ public:
 
 	void Initialize(PhysicalOperator *root);
 
-	string ToString() const;
-	void ToStream(std::ostream &str) const;
+	string ToString(bool print_optimizer_output = false) const;
+	void ToStream(std::ostream &str, bool print_optimizer_output = false) const;
 	void Print();
 
 	string ToJSON() const;

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -176,17 +176,13 @@ unique_ptr<PreparedStatementData> ClientContext::CreatePreparedStatement(const s
 	result->types = planner.types;
 	result->value_map = move(planner.value_map);
 
-#ifdef DEBUG
 	if (enable_optimizer) {
-#endif
 		profiler.StartPhase("optimizer");
 		Optimizer optimizer(planner.binder, *this);
 		plan = optimizer.Optimize(move(plan));
 		assert(plan);
 		profiler.EndPhase();
-#ifdef DEBUG
 	}
-#endif
 
 	profiler.StartPhase("physical_planner");
 	// now convert logical query plan into a physical query plan

--- a/src/optimizer/rule/move_constants.cpp
+++ b/src/optimizer/rule/move_constants.cpp
@@ -34,6 +34,9 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<Expr
 	auto outer_constant = (BoundConstantExpression *)bindings[1];
 	auto arithmetic = (BoundFunctionExpression *)bindings[2];
 	auto inner_constant = (BoundConstantExpression *)bindings[3];
+	if (!arithmetic->return_type.IsNumeric()) {
+		return nullptr;
+	}
 
 	int arithmetic_child_index = arithmetic->children[0].get() == inner_constant ? 1 : 0;
 	auto &op_type = arithmetic->function.name;

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -238,6 +238,7 @@ unique_ptr<DataChunk> Executor::FetchChunk() {
 	// run the plan to get the next chunks
 	physical_plan->InitializeChunkEmpty(*chunk);
 	physical_plan->GetChunk(econtext, *chunk, physical_state.get());
+	context.profiler.Flush(thread.profiler);
 	return chunk;
 }
 

--- a/src/planner/binder/tableref/plan_joinref.cpp
+++ b/src/planner/binder/tableref/plan_joinref.cpp
@@ -140,7 +140,7 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundJoinRef &ref) {
 		std::swap(left, right);
 	}
 
-	if (ref.type == JoinType::INNER) {
+	if (ref.type == JoinType::INNER && ref.condition->HasSubquery()) {
 		// inner join, generate a cross product + filter
 		// this will be later turned into a proper join by the join order optimizer
 		auto cross_product = make_unique<LogicalCrossProduct>();

--- a/src/planner/binder/tableref/plan_joinref.cpp
+++ b/src/planner/binder/tableref/plan_joinref.cpp
@@ -132,6 +132,23 @@ unique_ptr<LogicalOperator> LogicalComparisonJoin::CreateJoin(JoinType type, uni
 	}
 }
 
+static bool HasCorrelatedColumns(Expression &expression) {
+	if (expression.type == ExpressionType::BOUND_COLUMN_REF) {
+		auto &colref = (BoundColumnRefExpression &)expression;
+		if (colref.depth > 0) {
+			return true;
+		}
+	}
+	bool has_correlated_columns = false;
+	ExpressionIterator::EnumerateChildren(expression, [&](Expression &child) {
+		if (HasCorrelatedColumns(child)) {
+			has_correlated_columns = true;
+		}
+	});
+	return has_correlated_columns;
+
+}
+
 unique_ptr<LogicalOperator> Binder::CreatePlan(BoundJoinRef &ref) {
 	auto left = CreatePlan(*ref.left);
 	auto right = CreatePlan(*ref.right);
@@ -140,7 +157,9 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundJoinRef &ref) {
 		std::swap(left, right);
 	}
 
-	if (ref.type == JoinType::INNER && ref.condition->HasSubquery()) {
+	if (ref.type == JoinType::INNER &&
+		(ref.condition->HasSubquery() ||
+		 HasCorrelatedColumns(*ref.condition))) {
 		// inner join, generate a cross product + filter
 		// this will be later turned into a proper join by the join order optimizer
 		auto cross_product = make_unique<LogicalCrossProduct>();

--- a/src/planner/binder/tableref/plan_joinref.cpp
+++ b/src/planner/binder/tableref/plan_joinref.cpp
@@ -146,7 +146,6 @@ static bool HasCorrelatedColumns(Expression &expression) {
 		}
 	});
 	return has_correlated_columns;
-
 }
 
 unique_ptr<LogicalOperator> Binder::CreatePlan(BoundJoinRef &ref) {
@@ -157,9 +156,7 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundJoinRef &ref) {
 		std::swap(left, right);
 	}
 
-	if (ref.type == JoinType::INNER &&
-		(ref.condition->HasSubquery() ||
-		 HasCorrelatedColumns(*ref.condition))) {
+	if (ref.type == JoinType::INNER && (ref.condition->HasSubquery() || HasCorrelatedColumns(*ref.condition))) {
 		// inner join, generate a cross product + filter
 		// this will be later turned into a proper join by the join order optimizer
 		auto cross_product = make_unique<LogicalCrossProduct>();

--- a/test/issues/rigger/collate_union.test
+++ b/test/issues/rigger/collate_union.test
@@ -1,0 +1,16 @@
+# name: test/issues/rigger/collate_union.test
+# description: SQLancer bug that detected an error in collations combined with union
+# group: [rigger]
+
+statement ok
+CREATE TABLE t0(c0 BIGINT, c1 SMALLINT, c2 VARCHAR COLLATE NOACCENT);
+
+statement ok
+insert into t0 values (0, 1, NULL), (0, 0, '0.5652217975848206'), (0, 3, 'false');
+
+query II
+SELECT t0.c0, t0.c2 FROM t0 WHERE t0.c1 UNION SELECT t0.c0, t0.c2 FROM t0 WHERE (NOT t0.c1) UNION SELECT t0.c0, t0.c2 FROM t0 WHERE ((t0.c1) IS NULL) ORDER BY 1, 2;
+----
+0	NULL
+0	0.5652217975848206
+0	false

--- a/test/issues/rigger/date_get_value.test
+++ b/test/issues/rigger/date_get_value.test
@@ -1,0 +1,12 @@
+# name: test/issues/rigger/date_get_value.test
+# description: SQLancer bug that detected an error with "GetValue" not being supported for the Date type
+# group: [rigger]
+
+statement ok
+CREATE TABLE t0(c0 BOOLEAN, c1 TINYINT, PRIMARY KEY(c1, c0));
+
+statement ok
+INSERT INTO t0 VALUES (false, 1);
+
+statement error
+SELECT t0.c0, t0.c1 FROM t0 WHERE REVERSE((CASE 0.020672069925445347 WHEN (((DATE '1970-01-18')+(t0.c1)) NOT BETWEEN t0.c0 AND DATE '1970-01-10') THEN t0.c1 ELSE t0.c1 END )) GROUP BY t0.c0, t0.c1 UNION SELECT t0.c0, t0.c1 FROM t0 WHERE (NOT REVERSE((CASE 0.020672069925445347 WHEN (((DATE '1970-01-18')+(t0.c1)) NOT BETWEEN t0.c0 AND DATE '1970-01-10') THEN t0.c1 ELSE t0.c1 END ))) GROUP BY t0.c0, t0.c1 UNION SELECT t0.c0, t0.c1 FROM t0 WHERE ((REVERSE((CASE 0.020672069925445347 WHEN (((DATE '1970-01-18')+(t0.c1)) NOT BETWEEN t0.c0 AND DATE '1970-01-10') THEN t0.c1 ELSE t0.c1 END ))) IS NULL) GROUP BY t0.c0, t0.c1;

--- a/test/sql/types/list/array_agg.test
+++ b/test/sql/types/list/array_agg.test
@@ -3,9 +3,6 @@
 # group: [list]
 
 statement ok
-PRAGMA enable_verification
-
-statement ok
 CREATE TABLE films(film_id INTEGER, title VARCHAR)
 
 statement ok

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -7,7 +7,6 @@ import subprocess
 import shutil
 import platform
 
-
 from setuptools import setup, Extension
 from setuptools.command.sdist import sdist
 import distutils.spawn

--- a/tools/rpkg/src/duckdbr.cpp
+++ b/tools/rpkg/src/duckdbr.cpp
@@ -704,8 +704,8 @@ struct DataFrameScanFunction : public TableFunction {
 	}
 
 	static unique_ptr<FunctionOperatorData>
-	dataframe_scan_init(ClientContext &context, const FunctionData *bind_data,
-	                    vector<column_t> &column_ids, unordered_map<idx_t, vector<TableFilter>> &table_filters) {
+	dataframe_scan_init(ClientContext &context, const FunctionData *bind_data, vector<column_t> &column_ids,
+	                    unordered_map<idx_t, vector<TableFilter>> &table_filters) {
 		return make_unique<DataFrameScanState>();
 	}
 


### PR DESCRIPTION
* Add pragma for enabling/disabling optimizer (`PRAGMA enable_optimizer/disable_optimizer`)
* Add more descriptive output to several query graph nodes
* Only convert inner join into cross product + filter in case of subqueries or correlated columns in the join condition; this doesn't really matter when optimizers are turned on but when optimizers are turned off this allows users to actually specify joins 