### PR TITLE
Add LDBC SNB Interactive queries

### DIFF
--- a/benchmark/ldbc/README
+++ b/benchmark/ldbc/README
@@ -1,3 +1,0 @@
-load the data like so
-
-sed "s|PATHVAR|`pwd`/sf0.1|" snb-load.sql | duckdb ldbc.duckdb        

--- a/benchmark/ldbc/README.md
+++ b/benchmark/ldbc/README.md
@@ -1,19 +1,9 @@
 DuckDB implementation of the queries from the [LDBC Social Network Benchmark](https://arxiv.org/abs/2001.02299).
 
-Download the data:
+Download the data, initialize the schema, and load the data.
 
 ```bash
 python download-benchmark-data.py
-```
-
-Initialize the schema:
-
-```bash
 cat schema.sql | duckdb ldbc.duckdb
-```
-
-Load the data:
-
-```bash
 sed "s|PATHVAR|`pwd`/sf0.1|" snb-load.sql | duckdb ldbc.duckdb
 ```

--- a/benchmark/ldbc/README.md
+++ b/benchmark/ldbc/README.md
@@ -1,0 +1,19 @@
+DuckDB implementation of the queries from the [LDBC Social Network Benchmark](https://arxiv.org/abs/2001.02299).
+
+Download the data:
+
+```bash
+python download-benchmark-data.py
+```
+
+Initialize the schema:
+
+```bash
+cat schema.sql | duckdb ldbc.duckdb
+```
+
+Load the data:
+
+```bash
+sed "s|PATHVAR|`pwd`/sf0.1|" snb-load.sql | duckdb ldbc.duckdb
+```

--- a/benchmark/ldbc/queries/interactive-complex-10.sql
+++ b/benchmark/ldbc/queries/interactive-complex-10.sql
@@ -1,0 +1,34 @@
+select p_personid, p_firstname, p_lastname,
+       ( select count(distinct m_messageid)
+         from message, message_tag pt1
+         where
+         m_creatorid = p_personid and
+         m_c_replyof IS NULL and -- post, not comment
+         m_messageid = mt_messageid and
+         exists (select * from person_tag where pt_personid = 21990232556256 and pt_tagid = pt1.mt_tagid)
+       ) -
+       ( select count(*)
+         from message
+         where
+         m_creatorid = p_personid and
+         m_c_replyof IS NULL and -- post, not comment
+         not exists (select * from person_tag, message_tag where pt_personid = 21990232556256 and pt_tagid = mt_tagid and mt_messageid = m_messageid)
+       ) as score,
+       p_gender, pl_name
+from person, place,
+ ( select distinct k2.k_person2id
+   from knows k1, knows k2
+   where
+   k1.k_person1id = 21990232556256 and k1.k_person2id = k2.k_person1id and k2.k_person2id <> 21990232556256 and
+   not exists (select * from knows where k_person1id = 21990232556256 and k_person2id = k2.k_person2id)
+ ) f
+where
+p_placeid = pl_placeid and
+p_personid = f.k_person2id and
+(
+	(extract(month from p_birthday) = 10 and (case when extract(day from p_birthday) >= 21 then true else false end)) -- :month
+	or
+	(extract(month from p_birthday) = 11 and (case when extract(day from p_birthday) <  22 then true else false end)) -- :nextMonth
+)
+order by score desc, p_personid
+limit 10

--- a/benchmark/ldbc/queries/interactive-complex-11.sql
+++ b/benchmark/ldbc/queries/interactive-complex-11.sql
@@ -1,0 +1,21 @@
+select p_personid,p_firstname, p_lastname, o_name, pc_workfrom
+from person, person_company, organisation, place,
+ ( select k_person2id
+   from knows
+   where
+   k_person1id = 21990232556256
+   union
+   select k2.k_person2id
+   from knows k1, knows k2
+   where
+   k1.k_person1id = 21990232556256 and k1.k_person2id = k2.k_person1id and k2.k_person2id <> 21990232556256
+ ) f
+where
+    p_personid = f.k_person2id and
+    p_personid = pc_personid and
+    pc_organisationid = o_organisationid and
+    pc_workfrom < 2012 and -- :workFromYear
+    o_placeid = pl_placeid and
+    pl_name = 'United_States' -- :countryName
+order by pc_workfrom, p_personid, o_name desc
+limit 10

--- a/benchmark/ldbc/queries/interactive-complex-12.sql
+++ b/benchmark/ldbc/queries/interactive-complex-12.sql
@@ -1,0 +1,23 @@
+with recursive extended_tags(s_subtagclassid,s_supertagclassid) as (
+	select tc_tagclassid, tc_tagclassid from tagclass
+	UNION
+	select tc.tc_tagclassid, t.s_supertagclassid from tagclass tc, extended_tags t
+		where tc.tc_subclassoftagclassid=t.s_subtagclassid
+)
+select p_personid, p_firstname, p_lastname, array_agg(distinct t_name), count(*)
+from person, message p1, knows, message p2, message_tag, 
+	(select distinct t_tagid, t_name from tag where (t_tagclassid in (
+  		select distinct s_subtagclassid from extended_tags k, tagclass
+		where tc_tagclassid = k.s_supertagclassid and tc_name = 'OfficeHolder') -- :tagClassName
+   )) selected_tags
+where
+  k_person1id = 21990232556256 and 
+  k_person2id = p_personid and 
+  p_personid = p1.m_creatorid and 
+  p1.m_c_replyof = p2.m_messageid and 
+  p2.m_c_replyof is null and
+  p2.m_messageid = mt_messageid and 
+  mt_tagid = t_tagid
+group by p_personid, p_firstname, p_lastname
+order by 5 desc, 1
+limit 20

--- a/benchmark/ldbc/queries/interactive-complex-2.sql
+++ b/benchmark/ldbc/queries/interactive-complex-2.sql
@@ -1,0 +1,9 @@
+select p_personid, p_firstname, p_lastname, m_messageid, COALESCE(m_ps_imagefile, m_content, '') AS content, m_creationdate
+from person, message, knows
+where
+    p_personid = m_creatorid and
+    m_creationdate < '2011-07-21T22:00:00' and
+    k_person1id = 21990232556256 and
+    k_person2id = p_personid
+order by m_creationdate desc, m_messageid asc
+limit 20

--- a/benchmark/ldbc/queries/interactive-complex-3.sql
+++ b/benchmark/ldbc/queries/interactive-complex-3.sql
@@ -1,0 +1,37 @@
+select p_personid, p_firstname, p_lastname, ct1, ct2, total
+from
+ ( select k_person2id
+   from knows
+   where
+   k_person1id = 6597069767251
+   union
+   select k2.k_person2id
+   from knows k1, knows k2
+   where
+   k1.k_person1id = 6597069767251 and k1.k_person2id = k2.k_person1id and k2.k_person2id <> 15393162789164
+ ) f,  person, place p1, place p2,
+ (
+  select chn.m_c_creatorid, ct1, ct2, ct1 + ct2 as total
+  from
+   (
+      select m_creatorid as m_c_creatorid, count(*) as ct1 from message, place
+      where
+        m_locationid = pl_placeid and pl_name = 'United_States' and
+        m_creationdate >= '2010-07-21T22:00:00' and  m_creationdate < '2012-07-26T22:00:00' --('2011-07-21T22:00:00' + INTERVAL '1 days' * 5)
+      group by m_c_creatorid
+   ) chn,
+   (
+      select m_creatorid as m_c_creatorid, count(*) as ct2 from message, place
+      where
+        m_locationid = pl_placeid and pl_name = 'Canada' and
+        m_creationdate >= '2010-07-21T22:00:00' and  m_creationdate < '2012-01-26T22:00:00' --('2011-07-21T22:00:00' + INTERVAL '1 days' * 5)
+      group by m_creatorid --m_c_creatorid
+   ) ind
+  where chn.m_c_creatorid = ind.m_c_creatorid
+ ) cpc
+where
+f.k_person2id = p_personid and p_placeid = p1.pl_placeid and
+p1.pl_containerplaceid = p2.pl_placeid and p2.pl_name <> 'United_States' and p2.pl_name <> 'Canada' and
+f.k_person2id = cpc.m_c_creatorid
+order by 6 desc, 1
+limit 20

--- a/benchmark/ldbc/queries/interactive-complex-4.sql
+++ b/benchmark/ldbc/queries/interactive-complex-4.sql
@@ -1,0 +1,22 @@
+select t_name, count(*)
+from tag, message, message_tag recent, knows
+where
+    m_messageid = mt_messageid and
+    mt_tagid = t_tagid and
+    m_creatorid = k_person2id and
+    m_c_replyof IS NULL and -- post, not comment
+    k_person1id = 21990232556256 and
+    m_creationdate >= '2011-07-21T22:00:00' and  m_creationdate < '2012-07-26T22:00:00' and --('2011-07-21T22:00:00' + INTERVAL '1 days' * 5)
+    not exists (
+        select * from
+  (select distinct mt_tagid from message, message_tag, knows
+        where
+	k_person1id = 21990232556256 and
+        k_person2id = m_creatorid and
+        m_c_replyof IS NULL and -- post, not comment
+        mt_messageid = m_messageid and
+        m_creationdate < '2011-07-21T22:00:00') tags
+  where  tags.mt_tagid = recent.mt_tagid)
+group by t_name
+order by 2 desc, t_name
+limit 10

--- a/benchmark/ldbc/queries/interactive-complex-5.sql
+++ b/benchmark/ldbc/queries/interactive-complex-5.sql
@@ -1,0 +1,21 @@
+select f_title, count(m_messageid)
+from (
+select f_title, f_forumid, f.k_person2id
+from forum, forum_person,
+ ( select k_person2id
+   from knows
+   where
+   k_person1id = 21990232556256
+   union
+   select k2.k_person2id
+   from knows k1, knows k2
+   where
+   k1.k_person1id = 21990232556256 and k1.k_person2id = k2.k_person1id and k2.k_person2id <> 21990232556256
+ ) f
+where f_forumid = fp_forumid and fp_personid = f.k_person2id and
+      fp_creationdate >= '2011-07-21T22:00:00'
+) tmp left join message
+on tmp.f_forumid = m_ps_forumid and m_creatorid = tmp.k_person2id
+group by f_forumid, f_title
+order by 2 desc, f_forumid
+limit 20

--- a/benchmark/ldbc/queries/interactive-complex-6.sql
+++ b/benchmark/ldbc/queries/interactive-complex-6.sql
@@ -1,0 +1,22 @@
+select t_name, count(*)
+from tag, message_tag, message,
+ ( select k_person2id
+   from knows
+   where
+   k_person1id = 21990232556256
+   union
+   select k2.k_person2id
+   from knows k1, knows k2
+   where
+   k1.k_person1id = 21990232556256 and k1.k_person2id = k2.k_person1id and k2.k_person2id <> 21990232556256
+ ) f
+where
+m_creatorid = f.k_person2id and
+m_c_replyof IS NULL and -- post, not comment
+m_messageid = mt_messageid and
+mt_tagid = t_tagid and
+t_name <> 'Hamid_Karzai' and
+exists (select * from tag, message_tag where mt_messageid = m_messageid and mt_tagid = t_tagid and t_name = 'Hamid_Karzai')
+group by t_name
+order by 2 desc, t_name
+limit 10

--- a/benchmark/ldbc/queries/interactive-complex-7.sql
+++ b/benchmark/ldbc/queries/interactive-complex-7.sql
@@ -1,0 +1,21 @@
+select p_personid, p_firstname, p_lastname, l.l_creationdate, m_messageid,
+	COALESCE(m_ps_imagefile,'')||COALESCE(m_content,''),
+  0 as lag, -- TODO
+  --EXTRACT(EPOCH FROM (l.l_creationdate - m_creationdate)) / 60 as lag,
+    (case when exists (select 1 from knows where k_person1id = 21990232556256 and k_person2id = p_personid) then 0 else 1 end) as isnew
+from
+  (select l_personid, max(l_creationdate) as l_creationdate
+   from likes, message
+   where
+     m_messageid = l_messageid and
+     m_creatorid = 21990232556256
+   group by l_personid
+   order by 2 desc
+   limit 20
+  ) tmp, message, person, likes as l
+where
+	p_personid = tmp.l_personid and
+	tmp.l_personid = l.l_personid and
+	tmp.l_creationdate = l.l_creationdate and
+	l.l_messageid = m_messageid
+order by 4 desc, 1

--- a/benchmark/ldbc/queries/interactive-complex-8.sql
+++ b/benchmark/ldbc/queries/interactive-complex-8.sql
@@ -1,0 +1,8 @@
+select p1.m_creatorid, p_firstname, p_lastname, p1.m_creationdate, p1.m_messageid, p1.m_content
+  from message p1, message p2, person
+  where
+      p1.m_c_replyof = p2.m_messageid and
+      p2.m_creatorid = 21990232556256 and
+      p_personid = p1.m_creatorid
+order by p1.m_creationdate desc, 5
+limit 20

--- a/benchmark/ldbc/queries/interactive-complex-9.sql
+++ b/benchmark/ldbc/queries/interactive-complex-9.sql
@@ -1,0 +1,18 @@
+select p_personid, p_firstname, p_lastname,
+       m_messageid, COALESCE(m_ps_imagefile,'')||COALESCE(m_content,'') AS content, m_creationdate
+from
+  ( select k_person2id
+    from knows
+    where
+    k_person1id = 21990232556256
+    union
+    select k2.k_person2id
+    from knows k1, knows k2
+    where
+    k1.k_person1id = 21990232556256 and k1.k_person2id = k2.k_person1id and k2.k_person2id <> 21990232556256
+  ) f, person, message
+where
+  p_personid = m_creatorid and p_personid = f.k_person2id and
+  m_creationdate < '2012-07-26T22:00:00'
+order by m_creationdate desc, m_messageid asc
+limit 20

--- a/benchmark/ldbc/queries/interactive-short-1.sql
+++ b/benchmark/ldbc/queries/interactive-short-1.sql
@@ -1,0 +1,3 @@
+select p_firstname, p_lastname, p_birthday, p_locationip, p_browserused, p_placeid, p_gender,  p_creationdate
+from person
+where p_personid = 21990232556256;

--- a/benchmark/ldbc/queries/interactive-short-2.sql
+++ b/benchmark/ldbc/queries/interactive-short-2.sql
@@ -1,0 +1,25 @@
+with recursive cposts(m_messageid, m_content, m_ps_imagefile, m_creationdate, m_c_replyof, m_creatorid) AS (
+	  select m_messageid, m_content, m_ps_imagefile, m_creationdate, m_c_replyof, m_creatorid
+	  from message
+	  where m_creatorid = 21990232556256
+	  order by m_creationdate desc
+	  limit 10
+), parent(postid,replyof,orig_postid,creator) AS (
+	  select m_messageid, m_c_replyof, m_messageid, m_creatorid from cposts
+	UNION ALL
+	  select m_messageid, m_c_replyof, orig_postid, m_creatorid
+      from message,parent
+      where m_messageid=replyof
+)
+select p1.m_messageid, COALESCE(m_ps_imagefile,'')||COALESCE(m_content,'') as content, p1.m_creationdate,
+       p2.m_messageid, p2.p_personid, p2.p_firstname, p2.p_lastname
+from 
+     (select m_messageid, m_content, m_ps_imagefile, m_creationdate, m_c_replyof from cposts
+     ) p1
+     left join
+     (select orig_postid, postid as m_messageid, p_personid, p_firstname, p_lastname
+      from parent, person
+      where replyof is null and creator = p_personid
+     )p2  
+     on p2.orig_postid = p1.m_messageid
+      order by m_creationdate desc, p2.m_messageid desc;

--- a/benchmark/ldbc/queries/interactive-short-3.sql
+++ b/benchmark/ldbc/queries/interactive-short-3.sql
@@ -1,0 +1,4 @@
+select p_personid, p_firstname, p_lastname, k_creationdate
+from knows, person
+where k_person1id = 21990232556256 and k_person2id = p_personid
+order by k_creationdate desc, p_personid asc;

--- a/benchmark/ldbc/queries/interactive-short-4.sql
+++ b/benchmark/ldbc/queries/interactive-short-4.sql
@@ -1,0 +1,3 @@
+select COALESCE(m_ps_imagefile,'')||COALESCE(m_content,'') AS content, m_creationdate
+from message
+where m_messageid = 687194767741;

--- a/benchmark/ldbc/queries/interactive-short-5.sql
+++ b/benchmark/ldbc/queries/interactive-short-5.sql
@@ -1,0 +1,3 @@
+select p_personid, p_firstname, p_lastname
+from message, person
+where m_messageid = 687194767741 and m_creatorid = p_personid;

--- a/benchmark/ldbc/queries/interactive-short-6.sql
+++ b/benchmark/ldbc/queries/interactive-short-6.sql
@@ -1,0 +1,9 @@
+WITH RECURSIVE chain(parent, child) as(
+	SELECT m_c_replyof, m_messageid FROM message where m_messageid = 687194767741
+	UNION ALL
+	SELECT p.m_c_replyof, p.m_messageid FROM message p, chain c where p.m_messageid = c.parent 
+)
+select f_forumid, f_title, p_personid, p_firstname, p_lastname
+from message, person, forum
+where m_messageid = (select coalesce(min(parent), 687194767741) from chain)
+  and m_ps_forumid = f_forumid and f_moderatorid = p_personid;

--- a/benchmark/ldbc/queries/interactive-short-7.sql
+++ b/benchmark/ldbc/queries/interactive-short-7.sql
@@ -1,0 +1,11 @@
+select p2.m_messageid, p2.m_content, p2.m_creationdate, p_personid, p_firstname, p_lastname,
+    (case when exists (
+     	   	       select 1 from knows
+		       where p1.m_creatorid = k_person1id and p2.m_creatorid = k_person2id)
+      then TRUE
+      else FALSE
+      end) as knows
+from message p1, message p2, person
+where
+  p1.m_messageid = 687194767741 and p2.m_c_replyof = p1.m_messageid and p2.m_creatorid = p_personid
+order by p2.m_creationdate desc, p2.m_creatorid asc;


### PR DESCRIPTION
This PR contains a few queries from the LDBC SNB Interactive workload. While this is primarily an OLTP workload, implementing its queries can still be beneficial for testing features in DuckDB, and a DuckDB implementation can be useful for validating the SQL reference implementation of the Interactive workload.

This PR contains all 'short' queries (1-7) and the following 'complex' queries: 2 3 5 6 7 8 9 10 11 12.

The reasons for omitting the rest of the queries are the following:

* 1: needs `array`
* ~4: uses `not exists` (probably possible to rewrite to an antijoin)~
* 13: uses `not exists`, needs recursive views, runs into an infinite loop
* 14: needs `array`

To elaborate on Q13, other than missing clauses, one of its subqueries runs into an infinite loop (presumably caused by the graph having cycles):

```sql
WITH RECURSIVE search_graph(link, depth) AS (
		SELECT 17592186044856, 0 -- the big number is the start person Id
		UNION ALL
		(SELECT distinct k_person2id, x.depth+1
		FROM knows, search_graph x
		WHERE x.link = k_person1id)
)
select * from search_graph
```

Interestingly, the same code terminates under Postgres (v12.4):
```console
      link      | depth 
----------------+-------
 17592186044856 |     0
(1 row)
```

Do you have any advice on how to stop infinite loops caused by recursive queries? (Checked PR #404 but it doesn't seem conclusive regarding this.)