### PR TITLE
Rework assertions & add support for NATURAL JOIN clause + tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
       script:
         - mkdir -p build/release
         - python3 scripts/amalgamation.py
-        - (cd build/release && cmake -DCMAKE_BUILD_TYPE=Release -DDISABLE_UNITY=1 -DBUILD_ICU_EXTENSION=1 -DBUILD_PARQUET_EXTENSION=1 -DBUILD_TPCH_EXTENSION=1 -DBUILD_REST=1 -DJDBC_DRIVER=1 ../.. && cmake --build .)
+        - (cd build/release && cmake -DCMAKE_BUILD_TYPE=Release -DDISABLE_UNITY=1 -DBUILD_ICU_EXTENSION=1 -DBUILD_PARQUET_EXTENSION=1 -DBUILD_TPCH_EXTENSION=1 -DFORCE_ASSERT=1 -DBUILD_REST=1 -DJDBC_DRIVER=1 ../.. && cmake --build .)
 
         - build/release/test/unittest "*"
         - python3.7 tools/shell/shell-test.py build/release/duckdb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,8 @@ option(BUILD_TPCE "Enable building of the TPC-E tool." FALSE)
 option(JDBC_DRIVER "Build the DuckDB JDBC driver" FALSE)
 option(BUILD_PYTHON "Build the DuckDB Python extension" FALSE)
 option(BUILD_REST "Build the DuckDB REST server" FALSE)
+option(ASSERT_EXCEPTION "Throw an exception on an assert failing, instead of triggering a sigabort" TRUE)
+option(FORCE_ASSERT "Enable checking of assertions, even in release mode" FALSE)
 
 option(TREAT_WARNINGS_AS_ERRORS "Treat warnings as errors" FALSE)
 
@@ -148,6 +150,16 @@ endif()
 
 if(TREAT_WARNINGS_AS_ERRORS)
   message("Treating warnings as errors.")
+endif()
+
+if (!ASSERT_EXCEPTION)
+  set(CMAKE_CXX_FLAGS_DEBUG
+      "${CMAKE_CXX_FLAGS_DEBUG} -DDUCKDB_USE_STANDARD_ASSERT")
+endif()
+
+if (FORCE_ASSERT)
+set(CMAKE_CXX_FLAGS
+    "${CMAKE_CXX_FLAGS} -DDUCKDB_FORCE_ASSERT")
 endif()
 
 if(NOT MSVC)

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,12 @@ reldebug:
 	cmake $(GENERATOR) $(FORCE_COLOR) ${WARNINGS_AS_ERRORS} ${DISABLE_UNITY_FLAG} ${DISABLE_SANITIZER_FLAG} ${EXTENSIONS} -DCMAKE_BUILD_TYPE=RelWithDebInfo ../.. && \
 	cmake --build .
 
+relassert:
+	mkdir -p build/relassert && \
+	cd build/relassert && \
+	cmake $(GENERATOR) $(FORCE_COLOR) ${WARNINGS_AS_ERRORS} ${DISABLE_UNITY_FLAG} ${DISABLE_SANITIZER_FLAG} ${EXTENSIONS} -DFORCE_ASSERT=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo ../.. && \
+	cmake --build .
+
 amaldebug:
 	mkdir -p build/amaldebug && \
 	python scripts/amalgamation.py && \

--- a/extension/tpch/dbgen/dbgen.cpp
+++ b/extension/tpch/dbgen/dbgen.cpp
@@ -18,6 +18,7 @@
 #include "dss.h"
 #include "dsstypes.h"
 
+#include <cassert>
 #include <mutex>
 
 using namespace duckdb;

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -93,7 +93,7 @@ CatalogEntry *Catalog::CreateSchema(ClientContext &context, CreateSchemaInfo *in
 		if (info->on_conflict == OnCreateConflict::ERROR_ON_CONFLICT) {
 			throw CatalogException("Schema with name %s already exists!", info->schema);
 		} else {
-			assert(info->on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT);
+			D_ASSERT(info->on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT);
 		}
 		return nullptr;
 	}

--- a/src/catalog/catalog_entry/schema_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/schema_catalog_entry.cpp
@@ -134,7 +134,7 @@ CatalogEntry *SchemaCatalogEntry::CreateFunction(ClientContext &context, CreateF
 		function = make_unique_base<StandardEntry, ScalarFunctionCatalogEntry>(catalog, this,
 		                                                                       (CreateScalarFunctionInfo *)info);
 	} else {
-		assert(info->type == CatalogType::AGGREGATE_FUNCTION_ENTRY);
+		D_ASSERT(info->type == CatalogType::AGGREGATE_FUNCTION_ENTRY);
 		// create an aggregate function
 		function = make_unique_base<StandardEntry, AggregateFunctionCatalogEntry>(catalog, this,
 		                                                                          (CreateAggregateFunctionInfo *)info);

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -79,7 +79,7 @@ TableCatalogEntry::TableCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schem
 				vector<unique_ptr<Expression>> bound_expressions;
 				idx_t key_nr = 0;
 				for (auto &key : unique.keys) {
-					assert(key < columns.size());
+					D_ASSERT(key < columns.size());
 
 					unbound_expressions.push_back(make_unique<BoundColumnRefExpression>(
 					    columns[key].name, columns[key].type, ColumnBinding(0, column_ids.size())));
@@ -100,7 +100,7 @@ bool TableCatalogEntry::ColumnExists(const string &name) {
 }
 
 unique_ptr<CatalogEntry> TableCatalogEntry::AlterEntry(ClientContext &context, AlterInfo *info) {
-	assert(!internal);
+	D_ASSERT(!internal);
 	if (info->type != AlterType::ALTER_TABLE) {
 		throw CatalogException("Can only modify table with ALTER TABLE statement");
 	}
@@ -157,7 +157,7 @@ unique_ptr<CatalogEntry> TableCatalogEntry::RenameColumn(ClientContext &context,
 
 		create_info->columns.push_back(move(copy));
 		if (info.name == columns[i].name) {
-			assert(!found);
+			D_ASSERT(!found);
 			create_info->columns[i].name = info.new_name;
 			found = true;
 		}
@@ -220,7 +220,7 @@ unique_ptr<CatalogEntry> TableCatalogEntry::RemoveColumn(ClientContext &context,
 	create_info->temporary = temporary;
 	for (idx_t i = 0; i < columns.size(); i++) {
 		if (columns[i].name == info.removed_column) {
-			assert(removed_index == INVALID_INDEX);
+			D_ASSERT(removed_index == INVALID_INDEX);
 			removed_index = i;
 			continue;
 		}
@@ -236,7 +236,7 @@ unique_ptr<CatalogEntry> TableCatalogEntry::RemoveColumn(ClientContext &context,
 		throw CatalogException("Cannot drop column: table only has one column remaining!");
 	}
 	// handle constraints for the new table
-	assert(constraints.size() == bound_constraints.size());
+	D_ASSERT(constraints.size() == bound_constraints.size());
 	for (idx_t constr_idx = 0; constr_idx < constraints.size(); constr_idx++) {
 		auto &constraint = constraints[constr_idx];
 		auto &bound_constraint = bound_constraints[constr_idx];
@@ -416,12 +416,12 @@ vector<LogicalType> TableCatalogEntry::GetTypes(const vector<column_t> &column_i
 void TableCatalogEntry::Serialize(Serializer &serializer) {
 	serializer.WriteString(schema->name);
 	serializer.WriteString(name);
-	assert(columns.size() <= NumericLimits<uint32_t>::Maximum());
+	D_ASSERT(columns.size() <= NumericLimits<uint32_t>::Maximum());
 	serializer.Write<uint32_t>((uint32_t)columns.size());
 	for (auto &column : columns) {
 		column.Serialize(serializer);
 	}
-	assert(constraints.size() <= NumericLimits<uint32_t>::Maximum());
+	D_ASSERT(constraints.size() <= NumericLimits<uint32_t>::Maximum());
 	serializer.Write<uint32_t>((uint32_t)constraints.size());
 	for (auto &constraint : constraints) {
 		constraint->Serialize(serializer);

--- a/src/catalog/catalog_entry/table_function_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_function_catalog_entry.cpp
@@ -7,7 +7,7 @@ using namespace std;
 TableFunctionCatalogEntry::TableFunctionCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema,
                                                      CreateTableFunctionInfo *info)
     : StandardEntry(CatalogType::TABLE_FUNCTION_ENTRY, schema, catalog, info->name), functions(move(info->functions)) {
-	assert(this->functions.size() > 0);
+	D_ASSERT(this->functions.size() > 0);
 }
 
 } // namespace duckdb

--- a/src/catalog/catalog_entry/view_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/view_catalog_entry.cpp
@@ -47,12 +47,12 @@ unique_ptr<CatalogEntry> ViewCatalogEntry::AlterEntry(ClientContext &context, Al
 }
 
 void ViewCatalogEntry::Serialize(Serializer &serializer) {
-	assert(!internal);
+	D_ASSERT(!internal);
 	serializer.WriteString(schema->name);
 	serializer.WriteString(name);
 	serializer.WriteString(sql);
 	query->Serialize(serializer);
-	assert(aliases.size() <= NumericLimits<uint32_t>::Maximum());
+	D_ASSERT(aliases.size() <= NumericLimits<uint32_t>::Maximum());
 	serializer.Write<uint32_t>((uint32_t)aliases.size());
 	for (auto &alias : aliases) {
 		serializer.WriteString(alias);
@@ -88,7 +88,7 @@ string ViewCatalogEntry::ToSQL() {
 }
 
 unique_ptr<CatalogEntry> ViewCatalogEntry::Copy(ClientContext &context) {
-	assert(!internal);
+	D_ASSERT(!internal);
 	auto create_info = make_unique<CreateViewInfo>(schema->name, name);
 	create_info->query = query->Copy();
 	for (idx_t i = 0; i < aliases.size(); i++) {

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -207,7 +207,7 @@ bool CatalogSet::DropEntry(ClientContext &context, const string &name, bool casc
 }
 
 idx_t CatalogSet::GetEntryIndex(CatalogEntry *entry) {
-	assert(mapping.find(entry->name) != mapping.end());
+	D_ASSERT(mapping.find(entry->name) != mapping.end());
 	return mapping[entry->name]->index;
 }
 
@@ -231,7 +231,7 @@ MappingValue *CatalogSet::GetMapping(ClientContext &context, const string &name,
 			break;
 		}
 		mapping_value = mapping_value->child.get();
-		assert(mapping_value);
+		D_ASSERT(mapping_value);
 	}
 	return mapping_value;
 }
@@ -252,7 +252,7 @@ void CatalogSet::PutMapping(ClientContext &context, const string &name, idx_t en
 
 void CatalogSet::DeleteMapping(ClientContext &context, const string &name) {
 	auto entry = mapping.find(name);
-	assert(entry != mapping.end());
+	D_ASSERT(entry != mapping.end());
 	auto delete_marker = make_unique<MappingValue>(entry->second->index);
 	delete_marker->deleted = true;
 	delete_marker->timestamp = Transaction::GetTransaction(context).transaction_id;
@@ -280,7 +280,7 @@ CatalogEntry *CatalogSet::GetEntryForTransaction(ClientContext &context, Catalog
 			break;
 		}
 		current = current->child.get();
-		assert(current);
+		D_ASSERT(current);
 	}
 	return current;
 }

--- a/src/catalog/default/default_views.cpp
+++ b/src/catalog/default/default_views.cpp
@@ -33,7 +33,7 @@ static unique_ptr<CreateViewInfo> GetDefaultView(string schema, string name) {
 
 			Parser parser;
 			parser.ParseQuery(internal_views[index].sql);
-			assert(parser.statements.size() == 1 && parser.statements[0]->type == StatementType::SELECT_STATEMENT);
+			D_ASSERT(parser.statements.size() == 1 && parser.statements[0]->type == StatementType::SELECT_STATEMENT);
 			result->query = unique_ptr_cast<SQLStatement, SelectStatement>(move(parser.statements[0]));
 			result->temporary = true;
 			result->internal = true;

--- a/src/catalog/dependency_manager.cpp
+++ b/src/catalog/dependency_manager.cpp
@@ -31,7 +31,7 @@ void DependencyManager::AddObject(ClientContext &context, CatalogEntry *object,
 
 void DependencyManager::DropObject(ClientContext &context, CatalogEntry *object, bool cascade,
                                    set_lock_map_t &lock_set) {
-	assert(dependents_map.find(object) != dependents_map.end());
+	D_ASSERT(dependents_map.find(object) != dependents_map.end());
 
 	// first check the objects that depend on this object
 	auto &dependent_objects = dependents_map[object];
@@ -63,8 +63,8 @@ void DependencyManager::DropObject(ClientContext &context, CatalogEntry *object,
 }
 
 void DependencyManager::AlterObject(ClientContext &context, CatalogEntry *old_obj, CatalogEntry *new_obj) {
-	assert(dependents_map.find(old_obj) != dependents_map.end());
-	assert(dependencies_map.find(old_obj) != dependencies_map.end());
+	D_ASSERT(dependents_map.find(old_obj) != dependents_map.end());
+	D_ASSERT(dependencies_map.find(old_obj) != dependencies_map.end());
 
 	// first check the objects that depend on this object
 	auto &dependent_objects = dependents_map[old_obj];
@@ -104,13 +104,13 @@ void DependencyManager::EraseObjectInternal(CatalogEntry *object) {
 		// dependencies already removed
 		return;
 	}
-	assert(dependents_map.find(object) != dependents_map.end());
-	assert(dependencies_map.find(object) != dependencies_map.end());
+	D_ASSERT(dependents_map.find(object) != dependents_map.end());
+	D_ASSERT(dependencies_map.find(object) != dependencies_map.end());
 	// now for each of the dependencies, erase the entries from the dependents_map
 	for (auto &dependency : dependencies_map[object]) {
 		auto entry = dependents_map.find(dependency);
 		if (entry != dependents_map.end()) {
-			assert(entry->second.find(object) != entry->second.end());
+			D_ASSERT(entry->second.find(object) != entry->second.end());
 			entry->second.erase(object);
 		}
 	}

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory(vector_operations)
 add_library_unity(
   duckdb_common
   OBJECT
+  assert.cpp
   constants.cpp
   checksum.cpp
   exception.cpp

--- a/src/common/assert.cpp
+++ b/src/common/assert.cpp
@@ -1,0 +1,13 @@
+#include "duckdb/common/assert.hpp"
+#include "duckdb/common/exception.hpp"
+
+namespace duckdb {
+
+void duckdb_assert_internal(bool condition, const char *condition_name, const char *file, int linenr) {
+	if (condition) {
+		return;
+	}
+	throw InternalException("Assertion triggered in file \"%s\" on line %d: %s", file, linenr, condition_name);
+}
+
+}

--- a/src/common/file_buffer.cpp
+++ b/src/common/file_buffer.cpp
@@ -15,8 +15,8 @@ FileBuffer::FileBuffer(FileBufferType type, uint64_t bufsiz) : type(type) {
 	if (bufsiz % SECTOR_SIZE != 0) {
 		bufsiz += SECTOR_SIZE - (bufsiz % SECTOR_SIZE);
 	}
-	assert(bufsiz % SECTOR_SIZE == 0);
-	assert(bufsiz >= SECTOR_SIZE);
+	D_ASSERT(bufsiz % SECTOR_SIZE == 0);
+	D_ASSERT(bufsiz >= SECTOR_SIZE);
 	// we add (SECTOR_SIZE - 1) to ensure that we can align the buffer to SECTOR_SIZE
 	malloced_buffer = (data_ptr_t)malloc(bufsiz + (SECTOR_SIZE - 1));
 	if (!malloced_buffer) {
@@ -28,9 +28,9 @@ FileBuffer::FileBuffer(FileBufferType type, uint64_t bufsiz) : type(type) {
 	if (remainder != 0) {
 		num = num + SECTOR_SIZE - remainder;
 	}
-	assert(num % SECTOR_SIZE == 0);
-	assert(num + bufsiz <= ((uint64_t)malloced_buffer + bufsiz + (SECTOR_SIZE - 1)));
-	assert(num >= (uint64_t)malloced_buffer);
+	D_ASSERT(num % SECTOR_SIZE == 0);
+	D_ASSERT(num + bufsiz <= ((uint64_t)malloced_buffer + bufsiz + (SECTOR_SIZE - 1)));
+	D_ASSERT(num >= (uint64_t)malloced_buffer);
 	// construct the FileBuffer object
 	internal_buffer = (data_ptr_t)num;
 	internal_size = bufsiz;

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -45,13 +45,13 @@ FileSystem &FileSystem::GetFileSystem(ClientContext &context) {
 
 static void AssertValidFileFlags(uint8_t flags) {
 	// cannot combine Read and Write flags
-	assert(!(flags & FileFlags::FILE_FLAGS_READ && flags & FileFlags::FILE_FLAGS_WRITE));
+	D_ASSERT(!(flags & FileFlags::FILE_FLAGS_READ && flags & FileFlags::FILE_FLAGS_WRITE));
 	// cannot combine Read and CREATE/Append flags
-	assert(!(flags & FileFlags::FILE_FLAGS_READ && flags & FileFlags::FILE_FLAGS_APPEND));
-	assert(!(flags & FileFlags::FILE_FLAGS_READ && flags & FileFlags::FILE_FLAGS_FILE_CREATE));
-	assert(!(flags & FileFlags::FILE_FLAGS_READ && flags & FileFlags::FILE_FLAGS_FILE_CREATE_NEW));
+	D_ASSERT(!(flags & FileFlags::FILE_FLAGS_READ && flags & FileFlags::FILE_FLAGS_APPEND));
+	D_ASSERT(!(flags & FileFlags::FILE_FLAGS_READ && flags & FileFlags::FILE_FLAGS_FILE_CREATE));
+	D_ASSERT(!(flags & FileFlags::FILE_FLAGS_READ && flags & FileFlags::FILE_FLAGS_FILE_CREATE_NEW));
 	// cannot combine CREATE and CREATE_NEW flags
-	assert(!(flags & FileFlags::FILE_FLAGS_FILE_CREATE && flags & FileFlags::FILE_FLAGS_FILE_CREATE_NEW));
+	D_ASSERT(!(flags & FileFlags::FILE_FLAGS_FILE_CREATE && flags & FileFlags::FILE_FLAGS_FILE_CREATE_NEW));
 }
 
 #ifndef _WIN32
@@ -93,7 +93,7 @@ unique_ptr<FileHandle> FileSystem::OpenFile(const char *path, uint8_t flags, Fil
 		open_flags = O_RDONLY;
 	} else {
 		// need Read or Write
-		assert(flags & FileFlags::FILE_FLAGS_WRITE);
+		D_ASSERT(flags & FileFlags::FILE_FLAGS_WRITE);
 		open_flags = O_RDWR | O_CLOEXEC;
 		if (flags & FileFlags::FILE_FLAGS_FILE_CREATE) {
 			open_flags |= O_CREAT;
@@ -402,7 +402,7 @@ unique_ptr<FileHandle> FileSystem::OpenFile(const char *path, uint8_t flags, Fil
 		share_mode = FILE_SHARE_READ;
 	} else {
 		// need Read or Write
-		assert(flags & FileFlags::FILE_FLAGS_WRITE);
+		D_ASSERT(flags & FileFlags::FILE_FLAGS_WRITE);
 		desired_access = GENERIC_READ | GENERIC_WRITE;
 		share_mode = 0;
 		if (flags & FileFlags::FILE_FLAGS_FILE_CREATE) {

--- a/src/common/gzip_stream.cpp
+++ b/src/common/gzip_stream.cpp
@@ -80,7 +80,7 @@ void GzipStreamBuf::initialize() {
 	if (is_initialized) {
 		return;
 	}
-	assert(BUFFER_SIZE >= 3); // found to work fine with 3
+	D_ASSERT(BUFFER_SIZE >= 3); // found to work fine with 3
 	uint8_t gzip_hdr[10];
 	data_start = GZIP_HEADER_MINSIZE;
 
@@ -139,8 +139,8 @@ streambuf::int_type GzipStreamBuf::underflow() {
 		// pointers for free region in output buffer
 		auto out_buff_free_start = out_buff;
 		do {
-			assert(in_buff_start <= in_buff_end);
-			assert(in_buff_end <= in_buff_start + BUFFER_SIZE);
+			D_ASSERT(in_buff_start <= in_buff_end);
+			D_ASSERT(in_buff_end <= in_buff_start + BUFFER_SIZE);
 
 			// read more input if none available
 			if (in_buff_start == in_buff_end) {
@@ -154,12 +154,12 @@ streambuf::int_type GzipStreamBuf::underflow() {
 			}
 
 			// actually decompress
-			assert(zstrm_p);
+			D_ASSERT(zstrm_p);
 			zstrm_p->next_in = (data_ptr_t)in_buff_start;
-			assert(in_buff_end - in_buff_start < NumericLimits<int32_t>::Maximum());
+			D_ASSERT(in_buff_end - in_buff_start < NumericLimits<int32_t>::Maximum());
 			zstrm_p->avail_in = (uint32_t)(in_buff_end - in_buff_start);
 			zstrm_p->next_out = (data_ptr_t)out_buff_free_start;
-			assert((out_buff + BUFFER_SIZE) - out_buff_free_start < NumericLimits<int32_t>::Maximum());
+			D_ASSERT((out_buff + BUFFER_SIZE) - out_buff_free_start < NumericLimits<int32_t>::Maximum());
 			zstrm_p->avail_out = (uint32_t)((out_buff + BUFFER_SIZE) - out_buff_free_start);
 			auto ret = mz_inflate(zstrm_p, MZ_NO_FLUSH);
 			if (ret != MZ_OK && ret != MZ_STREAM_END) {
@@ -169,7 +169,7 @@ streambuf::int_type GzipStreamBuf::underflow() {
 			in_buff_start = (data_ptr_t)zstrm_p->next_in;
 			in_buff_end = in_buff_start + zstrm_p->avail_in;
 			out_buff_free_start = (data_ptr_t)zstrm_p->next_out;
-			assert(out_buff_free_start + zstrm_p->avail_out == out_buff + BUFFER_SIZE);
+			D_ASSERT(out_buff_free_start + zstrm_p->avail_out == out_buff + BUFFER_SIZE);
 			// if stream ended, deallocate inflator
 			if (ret == MZ_STREAM_END) {
 				mz_inflateEnd(zstrm_p);
@@ -186,14 +186,14 @@ streambuf::int_type GzipStreamBuf::underflow() {
 	}
 
 	// ensure all those pointers point at something sane
-	assert(out_buff);
-	assert(gptr() <= egptr());
-	assert(eback() == (char *)out_buff);
-	assert(gptr() >= (char *)out_buff);
-	assert(gptr() <= (char *)out_buff + BUFFER_SIZE);
-	assert(egptr() >= (char *)out_buff);
-	assert(egptr() <= (char *)out_buff + BUFFER_SIZE);
-	assert(gptr() <= egptr());
+	D_ASSERT(out_buff);
+	D_ASSERT(gptr() <= egptr());
+	D_ASSERT(eback() == (char *)out_buff);
+	D_ASSERT(gptr() >= (char *)out_buff);
+	D_ASSERT(gptr() <= (char *)out_buff + BUFFER_SIZE);
+	D_ASSERT(egptr() >= (char *)out_buff);
+	D_ASSERT(egptr() <= (char *)out_buff + BUFFER_SIZE);
+	D_ASSERT(gptr() <= egptr());
 
 	return this->gptr() == this->egptr() ? traits_type::eof() : traits_type::to_int_type(*this->gptr());
 }

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -819,7 +819,7 @@ template <> string_t CastFromBlob::Operation(string_t input, Vector &vector) {
 void CastFromBlob::ToHexString(string_t input, string_t &output) {
 	const char hexa_table[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 	idx_t input_size = input.GetSize();
-	assert(output.GetSize() == (input_size * 2 + 2));
+	D_ASSERT(output.GetSize() == (input_size * 2 + 2));
 	auto input_data = input.GetData();
 	auto hexa_data = output.GetData();
 	// hex identifier
@@ -846,7 +846,7 @@ void CastFromBlob::FromHexToBytes(string_t input, string_t &output) {
 	in_size -= 2;
 
 	auto out_data = output.GetData();
-	assert(output.GetSize() == (in_size / 2));
+	D_ASSERT(output.GetSize() == (in_size / 2));
 	idx_t out_idx = 0;
 
 	idx_t num_hex_per_byte = 2;

--- a/src/common/serializer/buffered_file_reader.cpp
+++ b/src/common/serializer/buffered_file_reader.cpp
@@ -25,7 +25,7 @@ void BufferedFileReader::ReadData(data_ptr_t target_buffer, uint64_t read_size) 
 			target_buffer += to_read;
 		}
 		if (target_buffer < end_ptr) {
-			assert(offset == read_data);
+			D_ASSERT(offset == read_data);
 			total_read += read_data;
 			// did not finish reading yet but exhausted buffer
 			// read data into buffer

--- a/src/common/serializer/buffered_file_writer.cpp
+++ b/src/common/serializer/buffered_file_writer.cpp
@@ -24,7 +24,7 @@ void BufferedFileWriter::WriteData(const_data_ptr_t buffer, uint64_t write_size)
 	const_data_ptr_t end_ptr = buffer + write_size;
 	while (buffer < end_ptr) {
 		idx_t to_write = min((idx_t)(end_ptr - buffer), FILE_BUFFER_SIZE - offset);
-		assert(to_write > 0);
+		D_ASSERT(to_write > 0);
 		memcpy(data.get() + offset, buffer, to_write);
 		offset += to_write;
 		buffer += to_write;

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -593,8 +593,8 @@ LogicalType LogicalType::MaxLogicalType(LogicalType left, LogicalType right) {
 void LogicalType::Verify() const {
 #ifdef DEBUG
 	if (id_ == LogicalTypeId::DECIMAL) {
-		assert(width_ >= 1 && width_ <= Decimal::MAX_WIDTH_DECIMAL);
-		assert(scale_ >= 0 && scale_ <= width_);
+		D_ASSERT(width_ >= 1 && width_ <= Decimal::MAX_WIDTH_DECIMAL);
+		D_ASSERT(scale_ >= 0 && scale_ <= width_);
 	}
 #endif
 }

--- a/src/common/types/chunk_collection.cpp
+++ b/src/common/types/chunk_collection.cpp
@@ -46,7 +46,7 @@ void ChunkCollection::Append(DataChunk &new_chunk) {
 		types = new_chunk.GetTypes();
 	} else {
 		// the types of the new chunk should match the types of the previous one
-		assert(types.size() == new_chunk.column_count());
+		D_ASSERT(types.size() == new_chunk.column_count());
 		auto new_types = new_chunk.GetTypes();
 		for (idx_t i = 0; i < types.size(); i++) {
 			if (new_types[i] != types[i]) {
@@ -60,8 +60,8 @@ void ChunkCollection::Append(DataChunk &new_chunk) {
 					if (ListVector::HasEntry(chunk_vec) && ListVector::HasEntry(new_vec)) {
 						auto &chunk_types = ListVector::GetEntry(chunk_vec).types;
 						auto &new_types = ListVector::GetEntry(new_vec).types;
-						assert(new_types.size() <= 1);
-						assert(chunk_types.size() <= 1);
+						D_ASSERT(new_types.size() <= 1);
+						D_ASSERT(chunk_types.size() <= 1);
 						if (chunk_types.size() > 0 && new_types.size() > 0 && chunk_types != new_types) {
 							throw TypeMismatchException(chunk_types[0], new_types[0],
 							                            "Type mismatch when combining lists");
@@ -107,7 +107,7 @@ void ChunkCollection::Append(DataChunk &new_chunk) {
 
 template <class TYPE>
 static int8_t templated_compare_value(Vector &left_vec, Vector &right_vec, idx_t left_idx, idx_t right_idx) {
-	assert(left_vec.type == right_vec.type);
+	D_ASSERT(left_vec.type == right_vec.type);
 	auto left_val = FlatVector::GetData<TYPE>(left_vec)[left_idx];
 	auto right_val = FlatVector::GetData<TYPE>(right_vec)[right_idx];
 	if (Equals::Operation<TYPE>(left_val, right_val)) {
@@ -161,7 +161,7 @@ static int32_t compare_value(Vector &left_vec, Vector &right_vec, idx_t vector_i
 
 static int compare_tuple(ChunkCollection *sort_by, vector<OrderType> &desc, vector<OrderByNullType> &null_order,
                          idx_t left, idx_t right) {
-	assert(sort_by);
+	D_ASSERT(sort_by);
 
 	idx_t chunk_idx_left = left / STANDARD_VECTOR_SIZE;
 	idx_t chunk_idx_right = right / STANDARD_VECTOR_SIZE;
@@ -177,9 +177,9 @@ static int compare_tuple(ChunkCollection *sort_by, vector<OrderType> &desc, vect
 		Vector &left_vec = left_chunk->data[col_idx];
 		Vector &right_vec = right_chunk->data[col_idx];
 
-		assert(left_vec.vector_type == VectorType::FLAT_VECTOR);
-		assert(right_vec.vector_type == VectorType::FLAT_VECTOR);
-		assert(left_vec.type == right_vec.type);
+		D_ASSERT(left_vec.vector_type == VectorType::FLAT_VECTOR);
+		D_ASSERT(right_vec.vector_type == VectorType::FLAT_VECTOR);
+		D_ASSERT(left_vec.type == right_vec.type);
 
 		auto comp_res = compare_value(left_vec, right_vec, vector_idx_left, vector_idx_right, null_order[col_idx]);
 
@@ -205,7 +205,7 @@ static int64_t _quicksort_initial(ChunkCollection *sort_by, vector<OrderType> &d
 			result[high--] = i;
 		}
 	}
-	assert(low == high);
+	D_ASSERT(low == high);
 	result[low] = pivot;
 	return low;
 }
@@ -244,7 +244,7 @@ static void _quicksort_inplace(ChunkCollection *sort_by, vector<OrderType> &desc
 	auto left = info.left;
 	auto right = info.right;
 
-	assert(left < right);
+	D_ASSERT(left < right);
 
 	int64_t middle = left + (right - left) / 2;
 	int64_t pivot = result[middle];
@@ -287,7 +287,7 @@ static void _quicksort_inplace(ChunkCollection *sort_by, vector<OrderType> &desc
 }
 
 void ChunkCollection::Sort(vector<OrderType> &desc, vector<OrderByNullType> &null_order, idx_t result[]) {
-	assert(result);
+	D_ASSERT(result);
 	if (count == 0) {
 		return;
 	}
@@ -342,7 +342,7 @@ void ChunkCollection::Reorder(idx_t order_org[]) {
 template <class TYPE>
 static void templated_set_values(ChunkCollection *src_coll, Vector &tgt_vec, idx_t order[], idx_t col_idx,
                                  idx_t start_offset, idx_t remaining_data) {
-	assert(src_coll);
+	D_ASSERT(src_coll);
 
 	for (idx_t row_idx = 0; row_idx < remaining_data; row_idx++) {
 		idx_t chunk_idx_src = order[start_offset + row_idx] / STANDARD_VECTOR_SIZE;
@@ -364,7 +364,7 @@ static void templated_set_values(ChunkCollection *src_coll, Vector &tgt_vec, idx
 // TODO: reorder functionality is similar, perhaps merge
 void ChunkCollection::MaterializeSortedChunk(DataChunk &target, idx_t order[], idx_t start_offset) {
 	idx_t remaining_data = min((idx_t)STANDARD_VECTOR_SIZE, count - start_offset);
-	assert(target.GetTypes() == types);
+	D_ASSERT(target.GetTypes() == types);
 
 	target.SetCardinality(remaining_data);
 	for (idx_t col_idx = 0; col_idx < column_count(); col_idx++) {
@@ -514,7 +514,7 @@ static void _heap_create(ChunkCollection *input, vector<OrderType> &desc, vector
 
 void ChunkCollection::Heap(vector<OrderType> &desc, vector<OrderByNullType> &null_order, idx_t heap[],
                            idx_t heap_size) {
-	assert(heap);
+	D_ASSERT(heap);
 	if (count == 0)
 		return;
 
@@ -529,7 +529,7 @@ void ChunkCollection::Heap(vector<OrderType> &desc, vector<OrderByNullType> &nul
 
 idx_t ChunkCollection::MaterializeHeapChunk(DataChunk &target, idx_t order[], idx_t start_offset, idx_t heap_size) {
 	idx_t remaining_data = min((idx_t)STANDARD_VECTOR_SIZE, heap_size - start_offset);
-	assert(target.GetTypes() == types);
+	D_ASSERT(target.GetTypes() == types);
 
 	target.SetCardinality(remaining_data);
 	for (idx_t col_idx = 0; col_idx < column_count(); col_idx++) {

--- a/src/common/types/date.cpp
+++ b/src/common/types/date.cpp
@@ -243,7 +243,7 @@ bool Date::IsValidDay(int32_t year, int32_t month, int32_t day) {
 }
 
 date_t Date::EpochDaysToDate(int32_t epoch) {
-	assert(epoch + EPOCH_DATE <= NumericLimits<int32_t>::Maximum());
+	D_ASSERT(epoch + EPOCH_DATE <= NumericLimits<int32_t>::Maximum());
 	return (date_t)(epoch + EPOCH_DATE);
 }
 
@@ -252,7 +252,7 @@ int32_t Date::EpochDays(date_t date) {
 }
 
 date_t Date::EpochToDate(int64_t epoch) {
-	assert((epoch / SECONDS_PER_DAY) + EPOCH_DATE <= NumericLimits<int32_t>::Maximum());
+	D_ASSERT((epoch / SECONDS_PER_DAY) + EPOCH_DATE <= NumericLimits<int32_t>::Maximum());
 	return (date_t)((epoch / SECONDS_PER_DAY) + EPOCH_DATE);
 }
 

--- a/src/common/types/hugeint.cpp
+++ b/src/common/types/hugeint.cpp
@@ -80,7 +80,7 @@ static bool positive_hugeint_is_bit_set(hugeint_t lhs, uint8_t bit_position) {
 }
 
 hugeint_t positive_hugeint_leftshift(hugeint_t lhs, uint32_t amount) {
-	assert(amount > 0 && amount < 64);
+	D_ASSERT(amount > 0 && amount < 64);
 	hugeint_t result;
 	result.lower = lhs.lower << amount;
 	result.upper = (lhs.upper << amount) + (lhs.lower >> (64 - amount));
@@ -88,7 +88,7 @@ hugeint_t positive_hugeint_leftshift(hugeint_t lhs, uint32_t amount) {
 }
 
 hugeint_t Hugeint::DivModPositive(hugeint_t lhs, uint64_t rhs, uint64_t &remainder) {
-	assert(lhs.upper >= 0);
+	D_ASSERT(lhs.upper >= 0);
 	// DivMod code adapted from:
 	// https://github.com/calccrypto/uint128_t/blob/master/uint128_t.cpp
 
@@ -227,7 +227,7 @@ hugeint_t Hugeint::Multiply(hugeint_t lhs, hugeint_t rhs) {
 //===--------------------------------------------------------------------===//
 hugeint_t Hugeint::DivMod(hugeint_t lhs, hugeint_t rhs, hugeint_t &remainder) {
 	// division by zero not allowed
-	assert(!(rhs.upper == 0 && rhs.lower == 0));
+	D_ASSERT(!(rhs.upper == 0 && rhs.lower == 0));
 
 	bool lhs_negative = lhs.upper < 0;
 	bool rhs_negative = rhs.upper < 0;
@@ -530,7 +530,7 @@ hugeint_t hugeint_t::operator>>(const hugeint_t &rhs) const {
 		result.lower = (uint64_t(upper) << (64 - shift)) + (lower >> shift);
 		result.upper = uint64_t(upper) >> shift;
 	} else {
-		assert(shift < 128);
+		D_ASSERT(shift < 128);
 		result.lower = uint64_t(upper) >> (shift - 64);
 		result.upper = 0;
 	}
@@ -556,7 +556,7 @@ hugeint_t hugeint_t::operator<<(const hugeint_t &rhs) const {
 		result.lower = lower << shift;
 		result.upper = upper_shift;
 	} else {
-		assert(shift < 128);
+		D_ASSERT(shift < 128);
 		result.lower = 0;
 		result.upper = (lower << (shift - 64)) & 0x7FFFFFFFFFFFFFFF;
 	}

--- a/src/common/types/string_heap.cpp
+++ b/src/common/types/string_heap.cpp
@@ -16,7 +16,7 @@ StringHeap::StringHeap() : tail(nullptr) {
 }
 
 string_t StringHeap::AddString(const char *data, idx_t len) {
-	assert(Utf8Proc::Analyze(data, len) != UnicodeType::INVALID);
+	D_ASSERT(Utf8Proc::Analyze(data, len) != UnicodeType::INVALID);
 	return AddBlob(data, len);
 }
 
@@ -41,7 +41,7 @@ string_t StringHeap::AddBlob(const char *data, idx_t len) {
 }
 
 string_t StringHeap::EmptyString(idx_t len) {
-	assert(len >= string_t::INLINE_LENGTH);
+	D_ASSERT(len >= string_t::INLINE_LENGTH);
 	if (!chunk || chunk->current_position + len >= chunk->maximum_size) {
 		// have to make a new entry
 		auto new_chunk = make_unique<StringChunk>(MaxValue<idx_t>(len + 1, MINIMUM_HEAP_SIZE));

--- a/src/common/types/string_type.cpp
+++ b/src/common/types/string_type.cpp
@@ -8,22 +8,22 @@ namespace duckdb {
 void string_t::Verify() {
 	auto dataptr = GetData();
 	(void)dataptr;
-	assert(dataptr);
+	D_ASSERT(dataptr);
 
 #ifdef DEBUG
 	auto utf_type = Utf8Proc::Analyze(dataptr, GetSize());
-	assert(utf_type != UnicodeType::INVALID);
+	D_ASSERT(utf_type != UnicodeType::INVALID);
 #endif
 
 	// verify that the string is null-terminated and that the length is correct
-	assert(strlen(dataptr) == GetSize());
+	D_ASSERT(strlen(dataptr) == GetSize());
 	// verify that the prefix contains the first four characters of the string
 	for (idx_t i = 0; i < MinValue<uint32_t>(PREFIX_LENGTH, GetSize()); i++) {
-		assert(GetPrefix()[i] == dataptr[i]);
+		D_ASSERT(GetPrefix()[i] == dataptr[i]);
 	}
 	// verify that for strings with length < PREFIX_LENGTH, the rest of the prefix is zero
 	for (idx_t i = GetSize(); i < PREFIX_LENGTH; i++) {
-		assert(GetPrefix()[i] == '\0');
+		D_ASSERT(GetPrefix()[i] == '\0');
 	}
 }
 

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -133,7 +133,7 @@ bool Value::DoubleIsValid(double value) {
 }
 
 Value Value::DECIMAL(int16_t value, uint8_t width, uint8_t scale) {
-	assert(width <= Decimal::MAX_WIDTH_INT16);
+	D_ASSERT(width <= Decimal::MAX_WIDTH_INT16);
 	Value result(LogicalType(LogicalTypeId::DECIMAL, width, scale));
 	result.value_.smallint = value;
 	result.is_null = false;
@@ -141,7 +141,7 @@ Value Value::DECIMAL(int16_t value, uint8_t width, uint8_t scale) {
 }
 
 Value Value::DECIMAL(int32_t value, uint8_t width, uint8_t scale) {
-	assert(width >= Decimal::MAX_WIDTH_INT16 && width <= Decimal::MAX_WIDTH_INT32);
+	D_ASSERT(width >= Decimal::MAX_WIDTH_INT16 && width <= Decimal::MAX_WIDTH_INT32);
 	Value result(LogicalType(LogicalTypeId::DECIMAL, width, scale));
 	result.value_.integer = value;
 	result.is_null = false;
@@ -171,7 +171,7 @@ Value Value::DECIMAL(int64_t value, uint8_t width, uint8_t scale) {
 }
 
 Value Value::DECIMAL(hugeint_t value, uint8_t width, uint8_t scale) {
-	assert(width >= Decimal::MAX_WIDTH_INT64 && width <= Decimal::MAX_WIDTH_INT128);
+	D_ASSERT(width >= Decimal::MAX_WIDTH_INT64 && width <= Decimal::MAX_WIDTH_INT128);
 	Value result(LogicalType(LogicalTypeId::DECIMAL, width, scale));
 	result.value_.hugeint = value;
 	result.is_null = false;
@@ -416,19 +416,19 @@ template <> double Value::GetValue() const {
 	return GetValueInternal<double>();
 }
 template <> uintptr_t Value::GetValue() const {
-	assert(type() == LogicalType::POINTER);
+	D_ASSERT(type() == LogicalType::POINTER);
 	return value_.pointer;
 }
 Value Value::Numeric(LogicalType type, int64_t value) {
 	switch (type.id()) {
 	case LogicalTypeId::TINYINT:
-		assert(value <= NumericLimits<int8_t>::Maximum());
+		D_ASSERT(value <= NumericLimits<int8_t>::Maximum());
 		return Value::TINYINT((int8_t)value);
 	case LogicalTypeId::SMALLINT:
-		assert(value <= NumericLimits<int16_t>::Maximum());
+		D_ASSERT(value <= NumericLimits<int16_t>::Maximum());
 		return Value::SMALLINT((int16_t)value);
 	case LogicalTypeId::INTEGER:
-		assert(value <= NumericLimits<int32_t>::Maximum());
+		D_ASSERT(value <= NumericLimits<int32_t>::Maximum());
 		return Value::INTEGER((int32_t)value);
 	case LogicalTypeId::BIGINT:
 		return Value::BIGINT(value);
@@ -445,10 +445,10 @@ Value Value::Numeric(LogicalType type, int64_t value) {
 	case LogicalTypeId::POINTER:
 		return Value::POINTER(value);
 	case LogicalTypeId::DATE:
-		assert(value <= NumericLimits<int32_t>::Maximum());
+		D_ASSERT(value <= NumericLimits<int32_t>::Maximum());
 		return Value::DATE(value);
 	case LogicalTypeId::TIME:
-		assert(value <= NumericLimits<int32_t>::Maximum());
+		D_ASSERT(value <= NumericLimits<int32_t>::Maximum());
 		return Value::TIME(value);
 	case LogicalTypeId::TIMESTAMP:
 		return Value::TIMESTAMP(value);
@@ -496,7 +496,7 @@ string Value::ToString() const {
 		} else if (internal_type == PhysicalType::INT64) {
 			return Decimal::ToString(value_.bigint, type_.scale());
 		} else {
-			assert(internal_type == PhysicalType::INT128);
+			D_ASSERT(internal_type == PhysicalType::INT128);
 			return Decimal::ToString(value_.hugeint, type_.scale());
 		}
 	}

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -67,7 +67,7 @@ void Vector::Slice(Vector &other, idx_t offset) {
 		Reference(other);
 		return;
 	}
-	assert(other.vector_type == VectorType::FLAT_VECTOR);
+	D_ASSERT(other.vector_type == VectorType::FLAT_VECTOR);
 
 	// create a reference to the other vector
 	Reference(other);
@@ -179,7 +179,7 @@ void Vector::SetValue(idx_t index, Value val) {
 		((hugeint_t *)data)[index] = val.value_.hugeint;
 		break;
 	case LogicalTypeId::DECIMAL:
-		assert(type.width() == val.type().width() && type.scale() == val.type().scale());
+		D_ASSERT(type.width() == val.type().width() && type.scale() == val.type().scale());
 		switch (type.InternalType()) {
 		case PhysicalType::INT16:
 			((int16_t *)data)[index] = val.value_.smallint;
@@ -224,13 +224,13 @@ void Vector::SetValue(idx_t index, Value val) {
 		}
 
 		auto &children = StructVector::GetEntries(*this);
-		assert(children.size() == val.struct_value.size());
+		D_ASSERT(children.size() == val.struct_value.size());
 
 		for (size_t i = 0; i < val.struct_value.size(); i++) {
 			auto &struct_child = val.struct_value[i];
-			assert(vector_type == VectorType::CONSTANT_VECTOR || vector_type == VectorType::FLAT_VECTOR);
+			D_ASSERT(vector_type == VectorType::CONSTANT_VECTOR || vector_type == VectorType::FLAT_VECTOR);
 			auto &vec_child = children[i];
-			assert(vec_child.first == struct_child.first);
+			D_ASSERT(vec_child.first == struct_child.first);
 			vec_child.second->SetValue(index, struct_child.second);
 		}
 	} break;
@@ -517,7 +517,7 @@ void Vector::Normalify(idx_t count) {
 		}
 		case PhysicalType::STRUCT: {
 			for (auto &child : StructVector::GetEntries(*this)) {
-				assert(child.second->vector_type == VectorType::CONSTANT_VECTOR);
+				D_ASSERT(child.second->vector_type == VectorType::CONSTANT_VECTOR);
 				child.second->Normalify(count);
 			}
 		} break;
@@ -703,12 +703,12 @@ void Vector::Verify(const SelectionVector &sel, idx_t count) {
 	}
 	if (vector_type == VectorType::DICTIONARY_VECTOR) {
 		auto &child = DictionaryVector::Child(*this);
-		assert(child.vector_type != VectorType::DICTIONARY_VECTOR);
+		D_ASSERT(child.vector_type != VectorType::DICTIONARY_VECTOR);
 		auto &dict_sel = DictionaryVector::SelVector(*this);
 		for (idx_t i = 0; i < count; i++) {
 			auto oidx = sel.get_index(i);
 			auto idx = dict_sel.get_index(oidx);
-			assert(idx < STANDARD_VECTOR_SIZE);
+			D_ASSERT(idx < STANDARD_VECTOR_SIZE);
 		}
 		// merge the selection vectors and verify the child
 		auto new_buffer = dict_sel.Slice(sel, count);
@@ -718,7 +718,7 @@ void Vector::Verify(const SelectionVector &sel, idx_t count) {
 	}
 	if (TypeIsConstantSize(type.InternalType()) &&
 	    (vector_type == VectorType::CONSTANT_VECTOR || vector_type == VectorType::FLAT_VECTOR)) {
-		assert(!auxiliary);
+		D_ASSERT(!auxiliary);
 	}
 	if (type.InternalType() == PhysicalType::DOUBLE) {
 		// verify that there are no INF or NAN values
@@ -726,7 +726,7 @@ void Vector::Verify(const SelectionVector &sel, idx_t count) {
 		case VectorType::CONSTANT_VECTOR: {
 			auto dbl = ConstantVector::GetData<double>(*this);
 			if (!ConstantVector::IsNull(*this)) {
-				assert(Value::DoubleIsValid(*dbl));
+				D_ASSERT(Value::DoubleIsValid(*dbl));
 			}
 			break;
 		}
@@ -735,7 +735,7 @@ void Vector::Verify(const SelectionVector &sel, idx_t count) {
 			for (idx_t i = 0; i < count; i++) {
 				auto oidx = sel.get_index(i);
 				if (!nullmask[oidx]) {
-					assert(Value::DoubleIsValid(doubles[oidx]));
+					D_ASSERT(Value::DoubleIsValid(doubles[oidx]));
 				}
 			}
 			break;
@@ -748,7 +748,7 @@ void Vector::Verify(const SelectionVector &sel, idx_t count) {
 	if (type.InternalType() == PhysicalType::STRUCT) {
 		if (vector_type == VectorType::FLAT_VECTOR || vector_type == VectorType::CONSTANT_VECTOR) {
 			auto &children = StructVector::GetEntries(*this);
-			assert(children.size() > 0);
+			D_ASSERT(children.size() > 0);
 			for (auto &child : children) {
 				child.second->Verify(sel, count);
 			}
@@ -760,7 +760,7 @@ void Vector::Verify(const SelectionVector &sel, idx_t count) {
 			if (!ConstantVector::IsNull(*this)) {
 				ListVector::GetEntry(*this).Verify();
 				auto le = ConstantVector::GetData<list_entry_t>(*this);
-				assert(le->offset + le->length <= ListVector::GetEntry(*this).count);
+				D_ASSERT(le->offset + le->length <= ListVector::GetEntry(*this).count);
 			}
 		} else if (vector_type == VectorType::FLAT_VECTOR) {
 			if (ListVector::HasEntry(*this)) {
@@ -771,7 +771,7 @@ void Vector::Verify(const SelectionVector &sel, idx_t count) {
 				auto idx = sel.get_index(i);
 				auto &le = list_data[idx];
 				if (!nullmask[idx]) {
-					assert(le.offset + le.length <= ListVector::GetEntry(*this).count);
+					D_ASSERT(le.offset + le.length <= ListVector::GetEntry(*this).count);
 				}
 			}
 		}
@@ -797,7 +797,7 @@ string_t StringVector::AddString(Vector &vector, const string &data) {
 }
 
 string_t StringVector::AddString(Vector &vector, string_t data) {
-	assert(vector.type.id() == LogicalTypeId::VARCHAR);
+	D_ASSERT(vector.type.id() == LogicalTypeId::VARCHAR);
 	if (data.IsInlined()) {
 		// string will be inlined: no need to store in string heap
 		return data;
@@ -805,13 +805,13 @@ string_t StringVector::AddString(Vector &vector, string_t data) {
 	if (!vector.auxiliary) {
 		vector.auxiliary = make_buffer<VectorStringBuffer>();
 	}
-	assert(vector.auxiliary->type == VectorBufferType::STRING_BUFFER);
+	D_ASSERT(vector.auxiliary->type == VectorBufferType::STRING_BUFFER);
 	auto &string_buffer = (VectorStringBuffer &)*vector.auxiliary;
 	return string_buffer.AddString(data);
 }
 
 string_t StringVector::AddStringOrBlob(Vector &vector, string_t data) {
-	assert(vector.type.InternalType() == PhysicalType::VARCHAR);
+	D_ASSERT(vector.type.InternalType() == PhysicalType::VARCHAR);
 	if (data.IsInlined()) {
 		// string will be inlined: no need to store in string heap
 		return data;
@@ -819,27 +819,27 @@ string_t StringVector::AddStringOrBlob(Vector &vector, string_t data) {
 	if (!vector.auxiliary) {
 		vector.auxiliary = make_buffer<VectorStringBuffer>();
 	}
-	assert(vector.auxiliary->type == VectorBufferType::STRING_BUFFER);
+	D_ASSERT(vector.auxiliary->type == VectorBufferType::STRING_BUFFER);
 	auto &string_buffer = (VectorStringBuffer &)*vector.auxiliary;
 	return string_buffer.AddBlob(data);
 }
 
 string_t StringVector::EmptyString(Vector &vector, idx_t len) {
-	assert(vector.type.InternalType() == PhysicalType::VARCHAR);
+	D_ASSERT(vector.type.InternalType() == PhysicalType::VARCHAR);
 	if (len < string_t::INLINE_LENGTH) {
 		return string_t(len);
 	}
 	if (!vector.auxiliary) {
 		vector.auxiliary = make_buffer<VectorStringBuffer>();
 	}
-	assert(vector.auxiliary->type == VectorBufferType::STRING_BUFFER);
+	D_ASSERT(vector.auxiliary->type == VectorBufferType::STRING_BUFFER);
 	auto &string_buffer = (VectorStringBuffer &)*vector.auxiliary;
 	return string_buffer.EmptyString(len);
 }
 
 void StringVector::AddHeapReference(Vector &vector, Vector &other) {
-	assert(vector.type.InternalType() == PhysicalType::VARCHAR);
-	assert(other.type.InternalType() == PhysicalType::VARCHAR);
+	D_ASSERT(vector.type.InternalType() == PhysicalType::VARCHAR);
+	D_ASSERT(other.type.InternalType() == PhysicalType::VARCHAR);
 
 	if (other.vector_type == VectorType::DICTIONARY_VECTOR) {
 		StringVector::AddHeapReference(vector, DictionaryVector::Child(other));
@@ -851,69 +851,69 @@ void StringVector::AddHeapReference(Vector &vector, Vector &other) {
 	if (!vector.auxiliary) {
 		vector.auxiliary = make_buffer<VectorStringBuffer>();
 	}
-	assert(vector.auxiliary->type == VectorBufferType::STRING_BUFFER);
-	assert(other.auxiliary->type == VectorBufferType::STRING_BUFFER);
+	D_ASSERT(vector.auxiliary->type == VectorBufferType::STRING_BUFFER);
+	D_ASSERT(other.auxiliary->type == VectorBufferType::STRING_BUFFER);
 	auto &string_buffer = (VectorStringBuffer &)*vector.auxiliary;
 	string_buffer.AddHeapReference(other.auxiliary);
 }
 
 bool StructVector::HasEntries(const Vector &vector) {
-	assert(vector.type.id() == LogicalTypeId::STRUCT);
-	assert(vector.vector_type == VectorType::FLAT_VECTOR || vector.vector_type == VectorType::CONSTANT_VECTOR);
-	assert(vector.auxiliary == nullptr || vector.auxiliary->type == VectorBufferType::STRUCT_BUFFER);
+	D_ASSERT(vector.type.id() == LogicalTypeId::STRUCT);
+	D_ASSERT(vector.vector_type == VectorType::FLAT_VECTOR || vector.vector_type == VectorType::CONSTANT_VECTOR);
+	D_ASSERT(vector.auxiliary == nullptr || vector.auxiliary->type == VectorBufferType::STRUCT_BUFFER);
 	return vector.auxiliary != nullptr;
 }
 
 child_list_t<unique_ptr<Vector>> &StructVector::GetEntries(const Vector &vector) {
-	assert(vector.type.id() == LogicalTypeId::STRUCT);
-	assert(vector.vector_type == VectorType::FLAT_VECTOR || vector.vector_type == VectorType::CONSTANT_VECTOR);
-	assert(vector.auxiliary);
-	assert(vector.auxiliary->type == VectorBufferType::STRUCT_BUFFER);
+	D_ASSERT(vector.type.id() == LogicalTypeId::STRUCT);
+	D_ASSERT(vector.vector_type == VectorType::FLAT_VECTOR || vector.vector_type == VectorType::CONSTANT_VECTOR);
+	D_ASSERT(vector.auxiliary);
+	D_ASSERT(vector.auxiliary->type == VectorBufferType::STRUCT_BUFFER);
 	return ((VectorStructBuffer *)vector.auxiliary.get())->GetChildren();
 }
 
 void StructVector::AddEntry(Vector &vector, string name, unique_ptr<Vector> entry) {
 	// TODO asser that an entry with this name does not already exist
-	assert(vector.type.id() == LogicalTypeId::STRUCT);
-	assert(vector.vector_type == VectorType::FLAT_VECTOR || vector.vector_type == VectorType::CONSTANT_VECTOR);
+	D_ASSERT(vector.type.id() == LogicalTypeId::STRUCT);
+	D_ASSERT(vector.vector_type == VectorType::FLAT_VECTOR || vector.vector_type == VectorType::CONSTANT_VECTOR);
 	if (!vector.auxiliary) {
 		vector.auxiliary = make_buffer<VectorStructBuffer>();
 	}
-	assert(vector.auxiliary);
-	assert(vector.auxiliary->type == VectorBufferType::STRUCT_BUFFER);
+	D_ASSERT(vector.auxiliary);
+	D_ASSERT(vector.auxiliary->type == VectorBufferType::STRUCT_BUFFER);
 	((VectorStructBuffer *)vector.auxiliary.get())->AddChild(name, move(entry));
 }
 
 bool ListVector::HasEntry(const Vector &vector) {
-	assert(vector.type.id() == LogicalTypeId::LIST);
+	D_ASSERT(vector.type.id() == LogicalTypeId::LIST);
 	if (vector.vector_type == VectorType::DICTIONARY_VECTOR) {
 		auto &child = DictionaryVector::Child(vector);
 		return ListVector::HasEntry(child);
 	}
-	assert(vector.vector_type == VectorType::FLAT_VECTOR || vector.vector_type == VectorType::CONSTANT_VECTOR);
+	D_ASSERT(vector.vector_type == VectorType::FLAT_VECTOR || vector.vector_type == VectorType::CONSTANT_VECTOR);
 	return vector.auxiliary != nullptr;
 }
 
 ChunkCollection &ListVector::GetEntry(const Vector &vector) {
-	assert(vector.type.id() == LogicalTypeId::LIST);
+	D_ASSERT(vector.type.id() == LogicalTypeId::LIST);
 	if (vector.vector_type == VectorType::DICTIONARY_VECTOR) {
 		auto &child = DictionaryVector::Child(vector);
 		return ListVector::GetEntry(child);
 	}
-	assert(vector.vector_type == VectorType::FLAT_VECTOR || vector.vector_type == VectorType::CONSTANT_VECTOR);
-	assert(vector.auxiliary);
-	assert(vector.auxiliary->type == VectorBufferType::LIST_BUFFER);
+	D_ASSERT(vector.vector_type == VectorType::FLAT_VECTOR || vector.vector_type == VectorType::CONSTANT_VECTOR);
+	D_ASSERT(vector.auxiliary);
+	D_ASSERT(vector.auxiliary->type == VectorBufferType::LIST_BUFFER);
 	return ((VectorListBuffer *)vector.auxiliary.get())->GetChild();
 }
 
 void ListVector::SetEntry(Vector &vector, unique_ptr<ChunkCollection> cc) {
-	assert(vector.type.id() == LogicalTypeId::LIST);
-	assert(vector.vector_type == VectorType::FLAT_VECTOR || vector.vector_type == VectorType::CONSTANT_VECTOR);
+	D_ASSERT(vector.type.id() == LogicalTypeId::LIST);
+	D_ASSERT(vector.vector_type == VectorType::FLAT_VECTOR || vector.vector_type == VectorType::CONSTANT_VECTOR);
 	if (!vector.auxiliary) {
 		vector.auxiliary = make_buffer<VectorListBuffer>();
 	}
-	assert(vector.auxiliary);
-	assert(vector.auxiliary->type == VectorBufferType::LIST_BUFFER);
+	D_ASSERT(vector.auxiliary);
+	D_ASSERT(vector.auxiliary->type == VectorBufferType::LIST_BUFFER);
 	((VectorListBuffer *)vector.auxiliary.get())->SetChild(move(cc));
 }
 

--- a/src/common/vector_operations/boolean_operators.cpp
+++ b/src/common/vector_operations/boolean_operators.cpp
@@ -15,7 +15,7 @@ using namespace std;
 // AND/OR
 //===--------------------------------------------------------------------===//
 template <class OP> static void templated_boolean_nullmask(Vector &left, Vector &right, Vector &result, idx_t count) {
-	assert(left.type.id() == LogicalTypeId::BOOLEAN && right.type.id() == LogicalTypeId::BOOLEAN &&
+	D_ASSERT(left.type.id() == LogicalTypeId::BOOLEAN && right.type.id() == LogicalTypeId::BOOLEAN &&
 	       result.type.id() == LogicalTypeId::BOOLEAN);
 
 	if (left.vector_type == VectorType::CONSTANT_VECTOR && right.vector_type == VectorType::CONSTANT_VECTOR) {
@@ -168,7 +168,7 @@ struct NotOperator {
 };
 
 void VectorOperations::Not(Vector &input, Vector &result, idx_t count) {
-	assert(input.type == LogicalType::BOOLEAN && result.type == LogicalType::BOOLEAN);
+	D_ASSERT(input.type == LogicalType::BOOLEAN && result.type == LogicalType::BOOLEAN);
 	UnaryExecutor::Execute<bool, bool, NotOperator>(input, result, count);
 }
 

--- a/src/common/vector_operations/comparison_operators.cpp
+++ b/src/common/vector_operations/comparison_operators.cpp
@@ -21,7 +21,7 @@ private:
 
 public:
 	template <class OP> static inline void Execute(Vector &left, Vector &right, Vector &result, idx_t count) {
-		assert(left.type == right.type && result.type == LogicalType::BOOLEAN);
+		D_ASSERT(left.type == right.type && result.type == LogicalType::BOOLEAN);
 		// the inplace loops take the result as the last parameter
 		switch (left.type.InternalType()) {
 		case PhysicalType::BOOL:

--- a/src/common/vector_operations/gather.cpp
+++ b/src/common/vector_operations/gather.cpp
@@ -28,8 +28,8 @@ template <class T> static void templated_gather_loop(Vector &source, Vector &des
 }
 
 void VectorOperations::Gather::Set(Vector &source, Vector &dest, idx_t count) {
-	assert(source.vector_type == VectorType::FLAT_VECTOR);
-	assert(source.type.id() == LogicalTypeId::POINTER); // "Cannot gather from non-pointer type!"
+	D_ASSERT(source.vector_type == VectorType::FLAT_VECTOR);
+	D_ASSERT(source.type.id() == LogicalTypeId::POINTER); // "Cannot gather from non-pointer type!"
 
 	dest.vector_type = VectorType::FLAT_VECTOR;
 	switch (dest.type.InternalType()) {

--- a/src/common/vector_operations/generators.cpp
+++ b/src/common/vector_operations/generators.cpp
@@ -11,7 +11,7 @@ namespace duckdb {
 using namespace std;
 
 template <class T> void templated_generate_sequence(Vector &result, idx_t count, int64_t start, int64_t increment) {
-	assert(result.type.IsNumeric());
+	D_ASSERT(result.type.IsNumeric());
 	if (start > NumericLimits<T>::Maximum() || increment > NumericLimits<T>::Maximum()) {
 		throw Exception("Sequence start or increment out of type range");
 	}
@@ -55,7 +55,7 @@ void VectorOperations::GenerateSequence(Vector &result, idx_t count, int64_t sta
 template <class T>
 void templated_generate_sequence(Vector &result, idx_t count, const SelectionVector &sel, int64_t start,
                                  int64_t increment) {
-	assert(result.type.IsNumeric());
+	D_ASSERT(result.type.IsNumeric());
 	if (start > NumericLimits<T>::Maximum() || increment > NumericLimits<T>::Maximum()) {
 		throw Exception("Sequence start or increment out of type range");
 	}

--- a/src/common/vector_operations/null_operations.cpp
+++ b/src/common/vector_operations/null_operations.cpp
@@ -11,7 +11,7 @@ namespace duckdb {
 using namespace std;
 
 template <bool INVERSE> void is_null_loop(Vector &input, Vector &result, idx_t count) {
-	assert(result.type == LogicalType::BOOLEAN);
+	D_ASSERT(result.type == LogicalType::BOOLEAN);
 
 	if (input.vector_type == VectorType::CONSTANT_VECTOR) {
 		result.vector_type = VectorType::CONSTANT_VECTOR;

--- a/src/common/vector_operations/numeric_inplace_operators.cpp
+++ b/src/common/vector_operations/numeric_inplace_operators.cpp
@@ -16,19 +16,19 @@ using namespace std;
 //===--------------------------------------------------------------------===//
 
 void VectorOperations::AddInPlace(Vector &input, int64_t right, idx_t count) {
-	assert(input.type.InternalType() == PhysicalType::POINTER);
+	D_ASSERT(input.type.InternalType() == PhysicalType::POINTER);
 	if (right == 0) {
 		return;
 	}
 	switch (input.vector_type) {
 	case VectorType::CONSTANT_VECTOR: {
-		assert(!ConstantVector::IsNull(input));
+		D_ASSERT(!ConstantVector::IsNull(input));
 		auto data = ConstantVector::GetData<uintptr_t>(input);
 		*data += right;
 		break;
 	}
 	default: {
-		assert(input.vector_type == VectorType::FLAT_VECTOR);
+		D_ASSERT(input.vector_type == VectorType::FLAT_VECTOR);
 		auto data = FlatVector::GetData<uintptr_t>(input);
 		for (idx_t i = 0; i < count; i++) {
 			data[i] += right;

--- a/src/common/vector_operations/vector_cast.cpp
+++ b/src/common/vector_operations/vector_cast.cpp
@@ -13,7 +13,7 @@ namespace duckdb {
 using namespace std;
 
 template <class SRC, class OP> static void string_cast(Vector &source, Vector &result, idx_t count) {
-	assert(result.type.InternalType() == PhysicalType::VARCHAR);
+	D_ASSERT(result.type.InternalType() == PhysicalType::VARCHAR);
 	UnaryExecutor::Execute<SRC, string_t, true>(source, result, count,
 	                                            [&](SRC input) { return OP::template Operation<SRC>(input, result); });
 }
@@ -93,7 +93,7 @@ template <class T> static void from_decimal_cast(Vector &source, Vector &result,
 
 template <class SOURCE, class DEST, class POWERS_SOURCE, class POWERS_DEST>
 void decimal_scale_up_loop(Vector &source, Vector &result, idx_t count) {
-	assert(result.type.scale() >= source.type.scale());
+	D_ASSERT(result.type.scale() >= source.type.scale());
 	idx_t scale_difference = result.type.scale() - source.type.scale();
 	auto multiply_factor = POWERS_DEST::PowersOfTen[scale_difference];
 	idx_t target_width = result.type.width() - scale_difference;
@@ -116,7 +116,7 @@ void decimal_scale_up_loop(Vector &source, Vector &result, idx_t count) {
 
 template <class SOURCE, class DEST, class POWERS_SOURCE>
 void decimal_scale_down_loop(Vector &source, Vector &result, idx_t count) {
-	assert(result.type.scale() < source.type.scale());
+	D_ASSERT(result.type.scale() < source.type.scale());
 	idx_t scale_difference = source.type.scale() - result.type.scale();
 	idx_t target_width = result.type.width() + scale_difference;
 	auto divide_factor = POWERS_SOURCE::PowersOfTen[scale_difference];
@@ -483,7 +483,7 @@ static void value_string_cast_switch(Vector &source, Vector &result, idx_t count
 }
 
 void VectorOperations::Cast(Vector &source, Vector &result, idx_t count, bool strict) {
-	assert(source.type != result.type);
+	D_ASSERT(source.type != result.type);
 	// first switch on source type
 	switch (source.type.id()) {
 	case LogicalTypeId::BOOLEAN:

--- a/src/common/vector_operations/vector_copy.cpp
+++ b/src/common/vector_operations/vector_copy.cpp
@@ -26,9 +26,9 @@ static void TemplatedCopy(Vector &source, const SelectionVector &sel, Vector &ta
 
 void VectorOperations::Copy(Vector &source, Vector &target, const SelectionVector &sel, idx_t source_count,
                             idx_t source_offset, idx_t target_offset) {
-	assert(source_offset <= source_count);
-	assert(target.vector_type == VectorType::FLAT_VECTOR);
-	assert(source.type == target.type);
+	D_ASSERT(source_offset <= source_count);
+	D_ASSERT(target.vector_type == VectorType::FLAT_VECTOR);
+	D_ASSERT(source.type == target.type);
 	switch (source.vector_type) {
 	case VectorType::DICTIONARY_VECTOR: {
 		// dictionary vector: merge selection vectors
@@ -56,7 +56,7 @@ void VectorOperations::Copy(Vector &source, Vector &target, const SelectionVecto
 	}
 
 	idx_t copy_count = source_count - source_offset;
-	assert(target_offset + copy_count <= STANDARD_VECTOR_SIZE);
+	D_ASSERT(target_offset + copy_count <= STANDARD_VECTOR_SIZE);
 	if (copy_count == 0) {
 		return;
 	}
@@ -125,14 +125,14 @@ void VectorOperations::Copy(Vector &source, Vector &target, const SelectionVecto
 			// target already has entries: append to them
 			auto &source_children = StructVector::GetEntries(source);
 			auto &target_children = StructVector::GetEntries(target);
-			assert(source_children.size() == target_children.size());
+			D_ASSERT(source_children.size() == target_children.size());
 			for (idx_t i = 0; i < source_children.size(); i++) {
-				assert(target_children[i].first == target_children[i].first);
+				D_ASSERT(target_children[i].first == target_children[i].first);
 				VectorOperations::Copy(*source_children[i].second, *target_children[i].second, sel, source_count,
 				                       source_offset, target_offset);
 			}
 		} else {
-			assert(target_offset == 0);
+			D_ASSERT(target_offset == 0);
 			// target has no entries: create new entries for the target
 			auto &source_children = StructVector::GetEntries(source);
 			for (auto &child : source_children) {
@@ -145,7 +145,7 @@ void VectorOperations::Copy(Vector &source, Vector &target, const SelectionVecto
 		break;
 	}
 	case PhysicalType::LIST: {
-		assert(target.type.InternalType() == PhysicalType::LIST);
+		D_ASSERT(target.type.InternalType() == PhysicalType::LIST);
 		if (ListVector::HasEntry(source)) {
 			// if the source has list offsets, we need to append them to the target
 			if (!ListVector::HasEntry(target)) {

--- a/src/common/vector_operations/vector_hash.cpp
+++ b/src/common/vector_operations/vector_hash.cpp
@@ -55,7 +55,7 @@ static inline void templated_loop_hash(Vector &input, Vector &result, const Sele
 
 template <bool HAS_RSEL>
 static inline void hash_type_switch(Vector &input, Vector &result, const SelectionVector *rsel, idx_t count) {
-	assert(result.type.id() == LogicalTypeId::HASH);
+	D_ASSERT(result.type.id() == LogicalTypeId::HASH);
 	switch (input.type.InternalType()) {
 	case PhysicalType::BOOL:
 	case PhysicalType::INT8:
@@ -165,7 +165,7 @@ void templated_loop_combine_hash(Vector &input, Vector &hashes, const SelectionV
 			                                              FlatVector::GetData<hash_t>(hashes), rsel, count, idata.sel,
 			                                              *idata.nullmask);
 		} else {
-			assert(hashes.vector_type == VectorType::FLAT_VECTOR);
+			D_ASSERT(hashes.vector_type == VectorType::FLAT_VECTOR);
 			tight_loop_combine_hash<HAS_RSEL, T>((T *)idata.data, FlatVector::GetData<hash_t>(hashes), rsel, count,
 			                                     idata.sel, *idata.nullmask);
 		}
@@ -174,7 +174,7 @@ void templated_loop_combine_hash(Vector &input, Vector &hashes, const SelectionV
 
 template <bool HAS_RSEL>
 static inline void combine_hash_type_switch(Vector &hashes, Vector &input, const SelectionVector *rsel, idx_t count) {
-	assert(hashes.type.id() == LogicalTypeId::HASH);
+	D_ASSERT(hashes.type.id() == LogicalTypeId::HASH);
 	switch (input.type.InternalType()) {
 	case PhysicalType::BOOL:
 	case PhysicalType::INT8:

--- a/src/execution/adaptive_filter.cpp
+++ b/src/execution/adaptive_filter.cpp
@@ -9,7 +9,7 @@ namespace duckdb {
 AdaptiveFilter::AdaptiveFilter(Expression &expr)
     : iteration_count(0), observe_interval(10), execute_interval(20), warmup(true) {
 	auto &conj_expr = (BoundConjunctionExpression &)expr;
-	assert(conj_expr.children.size() > 1);
+	D_ASSERT(conj_expr.children.size() > 1);
 	for (idx_t idx = 0; idx < conj_expr.children.size(); idx++) {
 		permutation.push_back(idx);
 		if (idx != conj_expr.children.size() - 1) {

--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -308,10 +308,7 @@ idx_t GroupedAggregateHashTable::AddChunk(DataChunk &groups, DataChunk &payload)
 }
 
 idx_t GroupedAggregateHashTable::AddChunk(DataChunk &groups, Vector &group_hashes, DataChunk &payload) {
-
 	D_ASSERT(!is_finalized);
-
-	D_ASSERT(capacity - entries >= groups.size());
 
 	if (groups.size() == 0) {
 		return 0;
@@ -603,6 +600,7 @@ idx_t GroupedAggregateHashTable::FindOrCreateGroupsInternal(DataChunk &groups, V
 		Resize<T>(capacity * 2);
 	}
 
+	D_ASSERT(capacity - entries >= groups.size());
 	D_ASSERT(groups.column_count() == group_types.size());
 	// we need to be able to fit at least one vector of data
 	D_ASSERT(capacity - entries >= groups.size());

--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -311,7 +311,7 @@ idx_t GroupedAggregateHashTable::AddChunk(DataChunk &groups, Vector &group_hashe
 
 	D_ASSERT(!is_finalized);
 
-	D_ASSERT(capacity - entries > groups.size());
+	D_ASSERT(capacity - entries >= groups.size());
 
 	if (groups.size() == 0) {
 		return 0;

--- a/src/execution/column_binding_resolver.cpp
+++ b/src/execution/column_binding_resolver.cpp
@@ -71,7 +71,7 @@ void ColumnBindingResolver::VisitOperator(LogicalOperator &op) {
 
 unique_ptr<Expression> ColumnBindingResolver::VisitReplace(BoundColumnRefExpression &expr,
                                                            unique_ptr<Expression> *expr_ptr) {
-	assert(expr.depth == 0);
+	D_ASSERT(expr.depth == 0);
 	// check the current set of column bindings to see which index corresponds to the column reference
 	for (idx_t i = 0; i < bindings.size(); i++) {
 		if (expr.binding == bindings[i]) {

--- a/src/execution/expression_executor.cpp
+++ b/src/execution/expression_executor.cpp
@@ -9,7 +9,7 @@ ExpressionExecutor::ExpressionExecutor() {
 }
 
 ExpressionExecutor::ExpressionExecutor(Expression *expression) {
-	assert(expression);
+	D_ASSERT(expression);
 	AddExpression(*expression);
 }
 
@@ -18,7 +18,7 @@ ExpressionExecutor::ExpressionExecutor(Expression &expression) {
 }
 
 ExpressionExecutor::ExpressionExecutor(vector<unique_ptr<Expression>> &exprs) {
-	assert(exprs.size() > 0);
+	D_ASSERT(exprs.size() > 0);
 	for (auto &expr : exprs) {
 		AddExpression(*expr);
 	}
@@ -39,8 +39,8 @@ void ExpressionExecutor::Initialize(Expression &expression, ExpressionExecutorSt
 void ExpressionExecutor::Execute(DataChunk *input, DataChunk &result) {
 	SetChunk(input);
 
-	assert(expressions.size() == result.column_count());
-	assert(expressions.size() > 0);
+	D_ASSERT(expressions.size() == result.column_count());
+	D_ASSERT(expressions.size() > 0);
 	for (idx_t i = 0; i < expressions.size(); i++) {
 		ExecuteExpression(i, result.data[i]);
 	}
@@ -54,38 +54,38 @@ void ExpressionExecutor::ExecuteExpression(DataChunk &input, Vector &result) {
 }
 
 idx_t ExpressionExecutor::SelectExpression(DataChunk &input, SelectionVector &sel) {
-	assert(expressions.size() == 1);
+	D_ASSERT(expressions.size() == 1);
 	SetChunk(&input);
 	return Select(*expressions[0], states[0]->root_state.get(), nullptr, input.size(), &sel, nullptr);
 }
 
 void ExpressionExecutor::ExecuteExpression(Vector &result) {
-	assert(expressions.size() == 1);
+	D_ASSERT(expressions.size() == 1);
 	ExecuteExpression(0, result);
 }
 
 void ExpressionExecutor::ExecuteExpression(idx_t expr_idx, Vector &result) {
-	assert(expr_idx < expressions.size());
-	assert(result.type == expressions[expr_idx]->return_type);
+	D_ASSERT(expr_idx < expressions.size());
+	D_ASSERT(result.type == expressions[expr_idx]->return_type);
 	Execute(*expressions[expr_idx], states[expr_idx]->root_state.get(), nullptr, chunk ? chunk->size() : 1, result);
 }
 
 Value ExpressionExecutor::EvaluateScalar(Expression &expr) {
-	assert(expr.IsFoldable());
+	D_ASSERT(expr.IsFoldable());
 	// use an ExpressionExecutor to execute the expression
 	ExpressionExecutor executor(expr);
 
 	Vector result(expr.return_type);
 	executor.ExecuteExpression(result);
 
-	assert(result.vector_type == VectorType::CONSTANT_VECTOR);
+	D_ASSERT(result.vector_type == VectorType::CONSTANT_VECTOR);
 	auto result_value = result.GetValue(0);
-	assert(result_value.type() == expr.return_type);
+	D_ASSERT(result_value.type() == expr.return_type);
 	return result_value;
 }
 
 void ExpressionExecutor::Verify(Expression &expr, Vector &vector, idx_t count) {
-	assert(expr.return_type == vector.type);
+	D_ASSERT(expr.return_type == vector.type);
 	vector.Verify(count);
 }
 
@@ -163,8 +163,8 @@ idx_t ExpressionExecutor::Select(Expression &expr, ExpressionState *state, const
 	if (count == 0) {
 		return 0;
 	}
-	assert(true_sel || false_sel);
-	assert(expr.return_type.id() == LogicalTypeId::BOOLEAN);
+	D_ASSERT(true_sel || false_sel);
+	D_ASSERT(expr.return_type.id() == LogicalTypeId::BOOLEAN);
 	switch (expr.expression_class) {
 	case ExpressionClass::BOUND_BETWEEN:
 		return Select((BoundBetweenExpression &)expr, state, sel, count, true_sel, false_sel);
@@ -212,7 +212,7 @@ static inline idx_t DefaultSelectSwitch(VectorData &idata, const SelectionVector
 		return DefaultSelectLoop<NO_NULL, true, false>(idata.sel, (uint8_t *)idata.data, *idata.nullmask, sel, count,
 		                                               true_sel, false_sel);
 	} else {
-		assert(false_sel);
+		D_ASSERT(false_sel);
 		return DefaultSelectLoop<NO_NULL, false, true>(idata.sel, (uint8_t *)idata.data, *idata.nullmask, sel, count,
 		                                               true_sel, false_sel);
 	}

--- a/src/execution/expression_executor/execute_case.cpp
+++ b/src/execution/expression_executor/execute_case.cpp
@@ -88,7 +88,7 @@ void case_loop(Vector &res_true, Vector &res_false, Vector &result, SelectionVec
 
 void Case(Vector &res_true, Vector &res_false, Vector &result, SelectionVector &tside, idx_t tcount,
           SelectionVector &fside, idx_t fcount) {
-	assert(res_true.type == res_false.type && res_true.type == result.type);
+	D_ASSERT(res_true.type == res_false.type && res_true.type == result.type);
 
 	switch (result.type.InternalType()) {
 	case PhysicalType::BOOL:
@@ -126,13 +126,13 @@ void Case(Vector &res_true, Vector &res_false, Vector &result, SelectionVector &
 		idx_t offset = 0;
 		if (ListVector::HasEntry(res_true)) {
 			auto &true_child = ListVector::GetEntry(res_true);
-			assert(true_child.types.size() == 1);
+			D_ASSERT(true_child.types.size() == 1);
 			offset += true_child.count;
 			result_child.Append(true_child);
 		}
 		if (ListVector::HasEntry(res_false)) {
 			auto &false_child = ListVector::GetEntry(res_false);
-			assert(false_child.types.size() == 1);
+			D_ASSERT(false_child.types.size() == 1);
 			result_child.Append(false_child);
 		}
 

--- a/src/execution/expression_executor/execute_cast.cpp
+++ b/src/execution/expression_executor/execute_cast.cpp
@@ -26,7 +26,7 @@ void ExpressionExecutor::Execute(BoundCastExpression &expr, ExpressionState *sta
 		result.Reference(child);
 	} else {
 		// cast it to the type specified by the cast expression
-		assert(result.type == expr.return_type);
+		D_ASSERT(result.type == expr.return_type);
 		VectorOperations::Cast(child, result, count);
 	}
 }

--- a/src/execution/expression_executor/execute_constant.cpp
+++ b/src/execution/expression_executor/execute_constant.cpp
@@ -12,7 +12,7 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(BoundConstantExp
 
 void ExpressionExecutor::Execute(BoundConstantExpression &expr, ExpressionState *state, const SelectionVector *sel,
                                  idx_t count, Vector &result) {
-	assert(expr.value.type() == expr.return_type);
+	D_ASSERT(expr.value.type() == expr.return_type);
 	result.Reference(expr.value);
 }
 

--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -21,7 +21,7 @@ void ExpressionExecutor::Execute(BoundFunctionExpression &expr, ExpressionState 
 		arguments.InitializeEmpty(state->types);
 		arguments.Reference(state->intermediate_chunk);
 		for (idx_t i = 0; i < expr.children.size(); i++) {
-			assert(state->types[i] == expr.children[i]->return_type);
+			D_ASSERT(state->types[i] == expr.children[i]->return_type);
 			Execute(*expr.children[i], state->child_states[i].get(), sel, count, arguments.data[i]);
 #ifdef DEBUG
 			if (expr.children[i]->return_type.id() == LogicalTypeId::VARCHAR) {

--- a/src/execution/expression_executor/execute_parameter.cpp
+++ b/src/execution/expression_executor/execute_parameter.cpp
@@ -12,8 +12,8 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(BoundParameterEx
 
 void ExpressionExecutor::Execute(BoundParameterExpression &expr, ExpressionState *state, const SelectionVector *sel,
                                  idx_t count, Vector &result) {
-	assert(expr.value);
-	assert(expr.value->type() == expr.return_type);
+	D_ASSERT(expr.value);
+	D_ASSERT(expr.value->type() == expr.return_type);
 	result.Reference(*expr.value);
 }
 

--- a/src/execution/expression_executor/execute_reference.cpp
+++ b/src/execution/expression_executor/execute_reference.cpp
@@ -11,8 +11,8 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(BoundReferenceEx
 
 void ExpressionExecutor::Execute(BoundReferenceExpression &expr, ExpressionState *state, const SelectionVector *sel,
                                  idx_t count, Vector &result) {
-	assert(expr.index != INVALID_INDEX);
-	assert(expr.index < chunk->column_count());
+	D_ASSERT(expr.index != INVALID_INDEX);
+	D_ASSERT(expr.index < chunk->column_count());
 	if (sel) {
 		result.Slice(chunk->data[expr.index], *sel, count);
 	} else {

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -176,8 +176,8 @@ void ART::GenerateKeys(DataChunk &input, vector<unique_ptr<Key>> &keys) {
 }
 
 bool ART::Insert(IndexLock &lock, DataChunk &input, Vector &row_ids) {
-	assert(row_ids.type.InternalType() == ROW_TYPE);
-	assert(logical_types[0] == input.data[0].type);
+	D_ASSERT(row_ids.type.InternalType() == ROW_TYPE);
+	D_ASSERT(logical_types[0] == input.data[0].type);
 
 	// generate the keys for the given input
 	vector<unique_ptr<Key>> keys;
@@ -377,7 +377,7 @@ void ART::Erase(unique_ptr<Node> &node, Key &key, unsigned depth, row_t row_id) 
 	idx_t pos = node->GetChildPos(key[depth]);
 	if (pos != INVALID_INDEX) {
 		auto child = node->GetChild(pos);
-		assert(child);
+		D_ASSERT(child);
 
 		unique_ptr<Node> &child_ref = *child;
 		if (child_ref->type == NodeType::NLeaf && LeafMatches(child_ref.get(), key, depth)) {
@@ -399,7 +399,7 @@ void ART::Erase(unique_ptr<Node> &node, Key &key, unsigned depth, row_t row_id) 
 // Point Query
 //===--------------------------------------------------------------------===//
 static unique_ptr<Key> CreateKey(ART &art, PhysicalType type, Value &value) {
-	assert(type == value.type().InternalType());
+	D_ASSERT(type == value.type().InternalType());
 	switch (type) {
 	case PhysicalType::BOOL:
 		return Key::CreateKey<bool>(value.value_.boolean, art.is_little_endian);
@@ -477,7 +477,7 @@ Node *ART::Lookup(unique_ptr<Node> &node, Key &key, unsigned depth) {
 			return nullptr;
 		}
 		node_val = node_val->GetChild(pos)->get();
-		assert(node_val);
+		D_ASSERT(node_val);
 
 		depth++;
 	}
@@ -493,7 +493,7 @@ bool ART::IteratorScan(ARTIndexScanState *state, Iterator *it, Key *bound, idx_t
 	bool has_next;
 	do {
 		if (HAS_BOUND) {
-			assert(bound);
+			D_ASSERT(bound);
 			if (INCLUSIVE) {
 				if (*it->node->value > *bound) {
 					break;
@@ -752,7 +752,7 @@ bool ART::Scan(Transaction &transaction, DataTable &table, IndexScanState &table
                vector<row_t> &result_ids) {
 	auto state = (ARTIndexScanState *)&table_state;
 
-	assert(state->values[0].type().InternalType() == types[0]);
+	D_ASSERT(state->values[0].type().InternalType() == types[0]);
 
 	vector<row_t> row_ids;
 	bool success = true;
@@ -781,7 +781,7 @@ bool ART::Scan(Transaction &transaction, DataTable &table, IndexScanState &table
 	} else {
 		lock_guard<mutex> l(lock);
 		// two predicates
-		assert(state->values[1].type().InternalType() == types[0]);
+		D_ASSERT(state->values[1].type().InternalType() == types[0]);
 		bool left_inclusive = state->expressions[0] == ExpressionType ::COMPARE_GREATERTHANOREQUALTO;
 		bool right_inclusive = state->expressions[1] == ExpressionType ::COMPARE_LESSTHANOREQUALTO;
 		success = SearchCloseRange(state, left_inclusive, right_inclusive, max_count, row_ids);

--- a/src/execution/index/art/node.cpp
+++ b/src/execution/index/art/node.cpp
@@ -14,12 +14,12 @@ void Node::CopyPrefix(ART &art, Node *src, Node *dst) {
 }
 
 unique_ptr<Node> *Node::GetChild(idx_t pos) {
-	assert(0);
+	D_ASSERT(0);
 	return nullptr;
 }
 
 idx_t Node::GetMin() {
-	assert(0);
+	D_ASSERT(0);
 	return 0;
 }
 
@@ -48,7 +48,7 @@ void Node::InsertLeaf(ART &art, unique_ptr<Node> &node, uint8_t key, unique_ptr<
 		Node256::insert(art, node, key, newNode);
 		break;
 	default:
-		assert(0);
+		D_ASSERT(0);
 	}
 }
 
@@ -70,7 +70,7 @@ void Node::Erase(ART &art, unique_ptr<Node> &node, idx_t pos) {
 		Node256::erase(art, node, pos);
 		break;
 	default:
-		assert(0);
+		D_ASSERT(0);
 		break;
 	}
 }

--- a/src/execution/index/art/node16.cpp
+++ b/src/execution/index/art/node16.cpp
@@ -44,7 +44,7 @@ idx_t Node16::GetNextPos(idx_t pos) {
 }
 
 unique_ptr<Node> *Node16::GetChild(idx_t pos) {
-	assert(pos < count);
+	D_ASSERT(pos < count);
 	return &child[pos];
 }
 

--- a/src/execution/index/art/node256.cpp
+++ b/src/execution/index/art/node256.cpp
@@ -47,7 +47,7 @@ idx_t Node256::GetNextPos(idx_t pos) {
 }
 
 unique_ptr<Node> *Node256::GetChild(idx_t pos) {
-	assert(child[pos]);
+	D_ASSERT(child[pos]);
 	return &child[pos];
 }
 

--- a/src/execution/index/art/node4.cpp
+++ b/src/execution/index/art/node4.cpp
@@ -44,7 +44,7 @@ idx_t Node4::GetNextPos(idx_t pos) {
 }
 
 unique_ptr<Node> *Node4::GetChild(idx_t pos) {
-	assert(pos < count);
+	D_ASSERT(pos < count);
 	return &child[pos];
 }
 
@@ -82,7 +82,7 @@ void Node4::insert(ART &art, unique_ptr<Node> &node, uint8_t keyByte, unique_ptr
 
 void Node4::erase(ART &art, unique_ptr<Node> &node, int pos) {
 	Node4 *n = static_cast<Node4 *>(node.get());
-	assert(pos < n->count);
+	D_ASSERT(pos < n->count);
 
 	// erase the child and decrease the count
 	n->child[pos].reset();

--- a/src/execution/index/art/node48.cpp
+++ b/src/execution/index/art/node48.cpp
@@ -42,7 +42,7 @@ idx_t Node48::GetNextPos(idx_t pos) {
 }
 
 unique_ptr<Node> *Node48::GetChild(idx_t pos) {
-	assert(childIndex[pos] != Node::EMPTY_MARKER);
+	D_ASSERT(childIndex[pos] != Node::EMPTY_MARKER);
 	return &child[childIndex[pos]];
 }
 

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -19,27 +19,27 @@ JoinHashTable::JoinHashTable(BufferManager &buffer_manager, vector<JoinCondition
     : buffer_manager(buffer_manager), build_types(move(btypes)), equality_size(0), condition_size(0), build_size(0),
       entry_size(0), tuple_size(0), join_type(type), finalized(false), has_null(false), count(0) {
 	for (auto &condition : conditions) {
-		assert(condition.left->return_type == condition.right->return_type);
+		D_ASSERT(condition.left->return_type == condition.right->return_type);
 		auto type = condition.left->return_type;
 		auto type_size = GetTypeIdSize(type.InternalType());
 		if (condition.comparison == ExpressionType::COMPARE_EQUAL) {
 			// all equality conditions should be at the front
 			// all other conditions at the back
 			// this assert checks that
-			assert(equality_types.size() == condition_types.size());
+			D_ASSERT(equality_types.size() == condition_types.size());
 			equality_types.push_back(type);
 			equality_size += type_size;
 		}
 		predicates.push_back(condition.comparison);
 		null_values_are_equal.push_back(condition.null_values_are_equal);
-		assert(!condition.null_values_are_equal ||
+		D_ASSERT(!condition.null_values_are_equal ||
 		       (condition.null_values_are_equal && condition.comparison == ExpressionType::COMPARE_EQUAL));
 
 		condition_types.push_back(type);
 		condition_size += type_size;
 	}
 	// at least one equality is necessary
-	assert(equality_types.size() > 0);
+	D_ASSERT(equality_types.size() > 0);
 
 	for (idx_t i = 0; i < build_types.size(); i++) {
 		build_size += GetTypeIdSize(build_types[i].InternalType());
@@ -72,7 +72,7 @@ JoinHashTable::~JoinHashTable() {
 
 void JoinHashTable::ApplyBitmask(Vector &hashes, idx_t count) {
 	if (hashes.vector_type == VectorType::CONSTANT_VECTOR) {
-		assert(!ConstantVector::IsNull(hashes));
+		D_ASSERT(!ConstantVector::IsNull(hashes));
 		auto indices = ConstantVector::GetData<hash_t>(hashes);
 		*indices = *indices & bitmask;
 	} else {
@@ -257,8 +257,8 @@ idx_t JoinHashTable::PrepareKeys(DataChunk &keys, unique_ptr<VectorData[]> &key_
 }
 
 void JoinHashTable::Build(DataChunk &keys, DataChunk &payload) {
-	assert(!finalized);
-	assert(keys.size() == payload.size());
+	D_ASSERT(!finalized);
+	D_ASSERT(keys.size() == payload.size());
 	if (keys.size() == 0) {
 		return;
 	}
@@ -269,7 +269,7 @@ void JoinHashTable::Build(DataChunk &keys, DataChunk &payload) {
 		// Correlated MARK join
 		// for the correlated mark join we need to keep track of COUNT(*) and COUNT(COLUMN) for each of the correlated
 		// columns push into the aggregate hash table
-		assert(info.correlated_counts);
+		D_ASSERT(info.correlated_counts);
 		info.group_chunk.SetCardinality(keys);
 		for (idx_t i = 0; i < info.correlated_types.size(); i++) {
 			info.group_chunk.data[i].Reference(keys.data[i]);
@@ -361,14 +361,14 @@ void JoinHashTable::Build(DataChunk &keys, DataChunk &payload) {
 }
 
 void JoinHashTable::InsertHashes(Vector &hashes, idx_t count, data_ptr_t key_locations[]) {
-	assert(hashes.type.id() == LogicalTypeId::HASH);
+	D_ASSERT(hashes.type.id() == LogicalTypeId::HASH);
 
 	// use bitmask to get position in array
 	ApplyBitmask(hashes, count);
 
 	hashes.Normalify(count);
 
-	assert(hashes.vector_type == VectorType::FLAT_VECTOR);
+	D_ASSERT(hashes.vector_type == VectorType::FLAT_VECTOR);
 	auto pointers = (data_ptr_t *)hash_map->node->buffer;
 	auto indices = FlatVector::GetData<hash_t>(hashes);
 	for (idx_t i = 0; i < count; i++) {
@@ -388,7 +388,7 @@ void JoinHashTable::Finalize() {
 	// select a HT that has at least 50% empty space
 	idx_t capacity = NextPowerOfTwo(MaxValue<idx_t>(count * 2, (Storage::BLOCK_ALLOC_SIZE / sizeof(data_ptr_t)) + 1));
 	// size needs to be a power of 2
-	assert((capacity & (capacity - 1)) == 0);
+	D_ASSERT((capacity & (capacity - 1)) == 0);
 	bitmask = capacity - 1;
 
 	// allocate the HT and initialize it with all-zero entries
@@ -426,8 +426,8 @@ void JoinHashTable::Finalize() {
 }
 
 unique_ptr<ScanStructure> JoinHashTable::Probe(DataChunk &keys) {
-	assert(count > 0); // should be handled before
-	assert(finalized);
+	D_ASSERT(count > 0); // should be handled before
+	D_ASSERT(finalized);
 
 	// set up the scan structure
 	auto ss = make_unique<ScanStructure>(*this);
@@ -738,7 +738,7 @@ void ScanStructure::GatherResult(Vector &result, const SelectionVector &sel_vect
 }
 
 void ScanStructure::NextInnerJoin(DataChunk &keys, DataChunk &left, DataChunk &result) {
-	assert(result.column_count() == left.column_count() + ht.build_types.size());
+	D_ASSERT(result.column_count() == left.column_count() + ht.build_types.size());
 	if (this->count == 0) {
 		// no pointers left to chase
 		return;
@@ -767,7 +767,7 @@ void ScanStructure::NextInnerJoin(DataChunk &keys, DataChunk &left, DataChunk &r
 		idx_t offset = ht.condition_size;
 		for (idx_t i = 0; i < ht.build_types.size(); i++) {
 			auto &vector = result.data[left.column_count() + i];
-			assert(vector.type == ht.build_types[i]);
+			D_ASSERT(vector.type == ht.build_types[i]);
 			GatherResult(vector, result_vector, result_count, offset);
 		}
 		AdvancePointers();
@@ -796,8 +796,8 @@ void ScanStructure::ScanKeyMatches(DataChunk &keys) {
 }
 
 template <bool MATCH> void ScanStructure::NextSemiOrAntiJoin(DataChunk &keys, DataChunk &left, DataChunk &result) {
-	assert(left.column_count() == result.column_count());
-	assert(keys.size() == left.size());
+	D_ASSERT(left.column_count() == result.column_count());
+	D_ASSERT(keys.size() == left.size());
 	// create the selection vector from the matches that were found
 	SelectionVector sel(STANDARD_VECTOR_SIZE);
 	idx_t result_count = 0;
@@ -813,7 +813,7 @@ template <bool MATCH> void ScanStructure::NextSemiOrAntiJoin(DataChunk &keys, Da
 		// reference the columns of the left side from the result
 		result.Slice(left, sel, result_count);
 	} else {
-		assert(result.size() == 0);
+		D_ASSERT(result.size() == 0);
 	}
 }
 
@@ -879,10 +879,10 @@ void ScanStructure::ConstructMarkJoinResult(DataChunk &join_keys, DataChunk &chi
 }
 
 void ScanStructure::NextMarkJoin(DataChunk &keys, DataChunk &input, DataChunk &result) {
-	assert(result.column_count() == input.column_count() + 1);
-	assert(result.data.back().type == LogicalType::BOOLEAN);
+	D_ASSERT(result.column_count() == input.column_count() + 1);
+	D_ASSERT(result.data.back().type == LogicalType::BOOLEAN);
 	// this method should only be called for a non-empty HT
-	assert(ht.count > 0);
+	D_ASSERT(ht.count > 0);
 
 	ScanKeyMatches(keys);
 	if (ht.correlated_mark_join_info.correlated_types.size() == 0) {
@@ -891,7 +891,7 @@ void ScanStructure::NextMarkJoin(DataChunk &keys, DataChunk &input, DataChunk &r
 		auto &info = ht.correlated_mark_join_info;
 		// there are correlated columns
 		// first we fetch the counts from the aggregate hashtable corresponding to these entries
-		assert(keys.column_count() == info.group_chunk.column_count() + 1);
+		D_ASSERT(keys.column_count() == info.group_chunk.column_count() + 1);
 		info.group_chunk.SetCardinality(keys);
 		for (idx_t i = 0; i < info.group_chunk.column_count(); i++) {
 			info.group_chunk.data[i].Reference(keys.data[i]);
@@ -934,7 +934,7 @@ void ScanStructure::NextMarkJoin(DataChunk &keys, DataChunk &input, DataChunk &r
 		auto count = FlatVector::GetData<int64_t>(info.result_chunk.data[1]);
 		// set the entries to either true or false based on whether a match was found
 		for (idx_t i = 0; i < input.size(); i++) {
-			assert(count_star[i] >= count[i]);
+			D_ASSERT(count_star[i] >= count[i]);
 			bool_result[i] = found_match ? found_match[i] : false;
 			if (!bool_result[i] && count_star[i] > count[i]) {
 				// RHS has NULL value and result is false: set to null
@@ -1004,7 +1004,7 @@ void ScanStructure::NextSingleJoin(DataChunk &keys, DataChunk &input, DataChunk 
 		AdvancePointers(no_match_sel, no_match_count);
 	}
 	// reference the columns of the left side from the result
-	assert(input.column_count() > 0);
+	D_ASSERT(input.column_count() > 0);
 	for (idx_t i = 0; i < input.column_count(); i++) {
 		result.data[i].Reference(input.data[i]);
 	}
@@ -1062,7 +1062,7 @@ void JoinHashTable::ScanFullOuter(DataChunk &result, JoinHTScanState &state) {
 		idx_t offset = condition_size;
 		for (idx_t i = 0; i < build_types.size(); i++) {
 			auto &vector = result.data[left_column_count + i];
-			assert(vector.type == build_types[i]);
+			D_ASSERT(vector.type == build_types[i]);
 			GatherResultVector(vector, FlatVector::IncrementalSelectionVector, (uintptr_t *)key_locations,
 			                   FlatVector::IncrementalSelectionVector, found_entries, offset);
 		}

--- a/src/execution/merge_join/merge_join.cpp
+++ b/src/execution/merge_join/merge_join.cpp
@@ -49,10 +49,10 @@ static idx_t perform_merge_join(L_ARG &l, R_ARG &r, ExpressionType comparison_ty
 }
 
 idx_t MergeJoinComplex::Perform(MergeInfo &l, MergeInfo &r, ExpressionType comparison_type) {
-	assert(l.info_type == MergeInfoType::SCALAR_MERGE_INFO && r.info_type == MergeInfoType::SCALAR_MERGE_INFO);
+	D_ASSERT(l.info_type == MergeInfoType::SCALAR_MERGE_INFO && r.info_type == MergeInfoType::SCALAR_MERGE_INFO);
 	auto &left = (ScalarMergeInfo &)l;
 	auto &right = (ScalarMergeInfo &)r;
-	assert(left.type == right.type);
+	D_ASSERT(left.type == right.type);
 	if (left.order.count == 0 || right.order.count == 0) {
 		return 0;
 	}
@@ -60,10 +60,10 @@ idx_t MergeJoinComplex::Perform(MergeInfo &l, MergeInfo &r, ExpressionType compa
 }
 
 idx_t MergeJoinSimple::Perform(MergeInfo &l, MergeInfo &r, ExpressionType comparison_type) {
-	assert(l.info_type == MergeInfoType::SCALAR_MERGE_INFO && r.info_type == MergeInfoType::CHUNK_MERGE_INFO);
+	D_ASSERT(l.info_type == MergeInfoType::SCALAR_MERGE_INFO && r.info_type == MergeInfoType::CHUNK_MERGE_INFO);
 	auto &left = (ScalarMergeInfo &)l;
 	auto &right = (ChunkMergeInfo &)r;
-	assert(left.type == right.type);
+	D_ASSERT(left.type == right.type);
 	if (left.order.count == 0 || right.data_chunks.count == 0) {
 		return 0;
 	}

--- a/src/execution/nested_loop_join/nested_loop_join_inner.cpp
+++ b/src/execution/nested_loop_join/nested_loop_join_inner.cpp
@@ -55,7 +55,7 @@ struct RefineNestedLoopJoin {
 		// refine phase of the nested loop join
 		// refine lvector and rvector based on matches of subsequent conditions (in case there are multiple conditions
 		// in the join)
-		assert(current_match_count > 0);
+		D_ASSERT(current_match_count > 0);
 		auto ldata = (T *)left_data.data;
 		auto rdata = (T *)right_data.data;
 		idx_t result_count = 0;
@@ -120,7 +120,7 @@ template <class NLTYPE>
 idx_t nested_loop_join_inner(Vector &left, Vector &right, idx_t left_size, idx_t right_size, idx_t &lpos, idx_t &rpos,
                              SelectionVector &lvector, SelectionVector &rvector, idx_t current_match_count,
                              ExpressionType comparison_type) {
-	assert(left.type == right.type);
+	D_ASSERT(left.type == right.type);
 	switch (comparison_type) {
 	case ExpressionType::COMPARE_EQUAL:
 		return nested_loop_join_inner_operator<NLTYPE, duckdb::Equals>(left, right, left_size, right_size, lpos, rpos,
@@ -148,7 +148,7 @@ idx_t nested_loop_join_inner(Vector &left, Vector &right, idx_t left_size, idx_t
 idx_t NestedLoopJoinInner::Perform(idx_t &lpos, idx_t &rpos, DataChunk &left_conditions, DataChunk &right_conditions,
                                    SelectionVector &lvector, SelectionVector &rvector,
                                    vector<JoinCondition> &conditions) {
-	assert(left_conditions.column_count() == right_conditions.column_count());
+	D_ASSERT(left_conditions.column_count() == right_conditions.column_count());
 	if (lpos >= left_conditions.size() || rpos >= right_conditions.size()) {
 		return 0;
 	}

--- a/src/execution/nested_loop_join/nested_loop_join_mark.cpp
+++ b/src/execution/nested_loop_join/nested_loop_join_mark.cpp
@@ -59,7 +59,7 @@ static void mark_join_operator(Vector &left, Vector &right, idx_t lcount, idx_t 
 
 static void mark_join(Vector &left, Vector &right, idx_t lcount, idx_t rcount, bool found_match[],
                       ExpressionType comparison_type) {
-	assert(left.type == right.type);
+	D_ASSERT(left.type == right.type);
 	switch (comparison_type) {
 	case ExpressionType::COMPARE_EQUAL:
 		return mark_join_operator<duckdb::Equals>(left, right, lcount, rcount, found_match);

--- a/src/execution/operator/aggregate/physical_simple_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_simple_aggregate.cpp
@@ -21,7 +21,7 @@ PhysicalSimpleAggregate::PhysicalSimpleAggregate(vector<LogicalType> types, vect
 struct AggregateState {
 	AggregateState(vector<unique_ptr<Expression>> &aggregate_expressions) {
 		for (auto &aggregate : aggregate_expressions) {
-			assert(aggregate->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
+			D_ASSERT(aggregate->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
 			auto &aggr = (BoundAggregateExpression &)*aggregate;
 			auto state = unique_ptr<data_t[]>(new data_t[aggr.function.state_size()]);
 			aggr.function.initialize(state.get());
@@ -30,7 +30,7 @@ struct AggregateState {
 		}
 	}
 	~AggregateState() {
-		assert(destructors.size() == aggregates.size());
+		D_ASSERT(destructors.size() == aggregates.size());
 		for (idx_t i = 0; i < destructors.size(); i++) {
 			if (!destructors[i]) {
 				continue;
@@ -73,7 +73,7 @@ public:
 	SimpleAggregateLocalState(vector<unique_ptr<Expression>> &aggregates) : state(aggregates) {
 		vector<LogicalType> payload_types;
 		for (auto &aggregate : aggregates) {
-			assert(aggregate->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
+			D_ASSERT(aggregate->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
 			auto &aggr = (BoundAggregateExpression &)*aggregate;
 			// initialize the payload chunk
 			if (aggr.children.size()) {

--- a/src/execution/operator/filter/physical_filter.cpp
+++ b/src/execution/operator/filter/physical_filter.cpp
@@ -17,7 +17,7 @@ public:
 
 PhysicalFilter::PhysicalFilter(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list)
     : PhysicalOperator(PhysicalOperatorType::FILTER, move(types)) {
-	assert(select_list.size() > 0);
+	D_ASSERT(select_list.size() > 0);
 	if (select_list.size() > 1) {
 		// create a big AND out of the expressions
 		auto conjunction = make_unique<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);

--- a/src/execution/operator/helper/physical_execute.cpp
+++ b/src/execution/operator/helper/physical_execute.cpp
@@ -5,7 +5,7 @@ using namespace std;
 namespace duckdb {
 
 void PhysicalExecute::GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state_) {
-	assert(plan);
+	D_ASSERT(plan);
 	plan->GetChunk(context, chunk, state_);
 }
 

--- a/src/execution/operator/join/physical_blockwise_nl_join.cpp
+++ b/src/execution/operator/join/physical_blockwise_nl_join.cpp
@@ -15,9 +15,9 @@ PhysicalBlockwiseNLJoin::PhysicalBlockwiseNLJoin(LogicalOperator &op, unique_ptr
 	children.push_back(move(left));
 	children.push_back(move(right));
 	// MARK, SINGLE and RIGHT OUTER joins not handled
-	assert(join_type != JoinType::MARK);
-	assert(join_type != JoinType::RIGHT);
-	assert(join_type != JoinType::SINGLE);
+	D_ASSERT(join_type != JoinType::MARK);
+	D_ASSERT(join_type != JoinType::RIGHT);
+	D_ASSERT(join_type != JoinType::SINGLE);
 }
 
 //===--------------------------------------------------------------------===//
@@ -102,7 +102,7 @@ void PhysicalBlockwiseNLJoin::GetChunkInternal(ExecutionContext &context, DataCh
 			// for SEMI or INNER join: empty RHS means empty result
 			return;
 		}
-		assert(join_type == JoinType::LEFT || join_type == JoinType::OUTER || join_type == JoinType::ANTI);
+		D_ASSERT(join_type == JoinType::LEFT || join_type == JoinType::OUTER || join_type == JoinType::ANTI);
 		// pull a chunk from the LHS
 		children[0]->GetChunk(context, state->child_chunk, state->child_state.get());
 		if (state->child_chunk.size() == 0) {
@@ -169,7 +169,7 @@ void PhysicalBlockwiseNLJoin::GetChunkInternal(ExecutionContext &context, DataCh
 		auto &rchunk = *gstate.right_chunks.chunks[state->right_position];
 
 		// fill in the current element of the LHS into the chunk
-		assert(chunk.column_count() == lchunk.column_count() + rchunk.column_count());
+		D_ASSERT(chunk.column_count() == lchunk.column_count() + rchunk.column_count());
 		for (idx_t i = 0; i < lchunk.column_count(); i++) {
 			auto lvalue = lchunk.GetValue(i, state->left_position);
 			chunk.data[i].Reference(lvalue);

--- a/src/execution/operator/join/physical_comparison_join.cpp
+++ b/src/execution/operator/join/physical_comparison_join.cpp
@@ -38,14 +38,14 @@ void PhysicalComparisonJoin::ConstructEmptyJoinResult(JoinType join_type, bool h
 	if (join_type == JoinType::ANTI) {
 		// anti join with empty hash table, NOP join
 		// return the input
-		assert(input.column_count() == result.column_count());
+		D_ASSERT(input.column_count() == result.column_count());
 		result.Reference(input);
 	} else if (join_type == JoinType::MARK) {
 		// MARK join with empty hash table
-		assert(join_type == JoinType::MARK);
-		assert(result.column_count() == input.column_count() + 1);
+		D_ASSERT(join_type == JoinType::MARK);
+		D_ASSERT(result.column_count() == input.column_count() + 1);
 		auto &result_vector = result.data.back();
-		assert(result_vector.type == LogicalType::BOOLEAN);
+		D_ASSERT(result_vector.type == LogicalType::BOOLEAN);
 		// for every data vector, we just reference the child chunk
 		result.SetCardinality(input);
 		for (idx_t i = 0; i < input.column_count(); i++) {

--- a/src/execution/operator/join/physical_cross_product.cpp
+++ b/src/execution/operator/join/physical_cross_product.cpp
@@ -9,7 +9,7 @@ class PhysicalCrossProductOperatorState : public PhysicalOperatorState {
 public:
 	PhysicalCrossProductOperatorState(PhysicalOperator &op, PhysicalOperator *left, PhysicalOperator *right)
 	    : PhysicalOperatorState(op, left), left_position(0) {
-		assert(left && right);
+		D_ASSERT(left && right);
 	}
 
 	idx_t left_position;

--- a/src/execution/operator/join/physical_delim_join.cpp
+++ b/src/execution/operator/join/physical_delim_join.cpp
@@ -22,7 +22,7 @@ PhysicalDelimJoin::PhysicalDelimJoin(vector<LogicalType> types, unique_ptr<Physi
                                      vector<PhysicalOperator *> delim_scans)
     : PhysicalSink(PhysicalOperatorType::DELIM_JOIN, move(types)), join(move(original_join)),
       delim_scans(move(delim_scans)) {
-	assert(join->children.size() == 2);
+	D_ASSERT(join->children.size() == 2);
 	// now for the original join
 	// we take its left child, this is the side that we will duplicate eliminate
 	children.push_back(move(join->children[0]));
@@ -36,11 +36,11 @@ PhysicalDelimJoin::PhysicalDelimJoin(vector<LogicalType> types, unique_ptr<Physi
 class DelimJoinGlobalState : public GlobalOperatorState {
 public:
 	DelimJoinGlobalState(PhysicalDelimJoin *delim_join) {
-		assert(delim_join->delim_scans.size() > 0);
+		D_ASSERT(delim_join->delim_scans.size() > 0);
 		// for any duplicate eliminated scans in the RHS, point them to the duplicate eliminated chunk that we create
 		// here
 		for (auto op : delim_join->delim_scans) {
-			assert(op->type == PhysicalOperatorType::DELIM_SCAN);
+			D_ASSERT(op->type == PhysicalOperatorType::DELIM_SCAN);
 			auto scan = (PhysicalChunkScan *)op;
 			scan->collection = &delim_data;
 		}

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -18,7 +18,7 @@ PhysicalHashJoin::PhysicalHashJoin(LogicalOperator &op, unique_ptr<PhysicalOpera
 	children.push_back(move(left));
 	children.push_back(move(right));
 
-	assert(left_projection_map.size() == 0);
+	D_ASSERT(left_projection_map.size() == 0);
 	for (auto &condition : conditions) {
 		condition_types.push_back(condition.left->return_type);
 	}

--- a/src/execution/operator/join/physical_index_join.cpp
+++ b/src/execution/operator/join/physical_index_join.cpp
@@ -20,7 +20,7 @@ class PhysicalIndexJoinOperatorState : public PhysicalOperatorState {
 public:
 	PhysicalIndexJoinOperatorState(PhysicalOperator &op, PhysicalOperator *left, PhysicalOperator *right)
 	    : PhysicalOperatorState(op, left) {
-		assert(left && right);
+		D_ASSERT(left && right);
 		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
 			rhs_rows.emplace_back();
 			result_sizes.emplace_back();

--- a/src/execution/operator/join/physical_nested_loop_join.cpp
+++ b/src/execution/operator/join/physical_nested_loop_join.cpp
@@ -37,7 +37,7 @@ static bool HasNullValues(DataChunk &chunk) {
 
 template <bool MATCH>
 static void ConstructSemiOrAntiJoinResult(DataChunk &left, DataChunk &result, bool found_match[]) {
-	assert(left.column_count() == result.column_count());
+	D_ASSERT(left.column_count() == result.column_count());
 	// create the selection vector from the matches that were found
 	idx_t result_count = 0;
 	SelectionVector sel(STANDARD_VECTOR_SIZE);

--- a/src/execution/operator/join/physical_piecewise_merge_join.cpp
+++ b/src/execution/operator/join/physical_piecewise_merge_join.cpp
@@ -14,11 +14,11 @@ PhysicalPiecewiseMergeJoin::PhysicalPiecewiseMergeJoin(LogicalOperator &op, uniq
                                                        JoinType join_type)
     : PhysicalComparisonJoin(op, PhysicalOperatorType::PIECEWISE_MERGE_JOIN, move(cond), join_type) {
 	// for now we only support one condition!
-	assert(conditions.size() == 1);
+	D_ASSERT(conditions.size() == 1);
 	for (auto &cond : conditions) {
 		// COMPARE NOT EQUAL not supported with merge join
-		assert(cond.comparison != ExpressionType::COMPARE_NOTEQUAL);
-		assert(cond.left->return_type == cond.right->return_type);
+		D_ASSERT(cond.comparison != ExpressionType::COMPARE_NOTEQUAL);
+		D_ASSERT(cond.left->return_type == cond.right->return_type);
 		join_key_types.push_back(cond.left->return_type);
 	}
 	children.push_back(move(left));
@@ -104,7 +104,7 @@ void PhysicalPiecewiseMergeJoin::Finalize(Pipeline &pipeline, ClientContext &con
 		gstate.right_orders.resize(gstate.right_conditions.chunks.size());
 		for (idx_t i = 0; i < gstate.right_conditions.chunks.size(); i++) {
 			auto &chunk_to_order = *gstate.right_conditions.chunks[i];
-			assert(chunk_to_order.column_count() == 1);
+			D_ASSERT(chunk_to_order.column_count() == 1);
 			for (idx_t col_idx = 0; col_idx < chunk_to_order.column_count(); col_idx++) {
 				OrderVector(chunk_to_order.data[col_idx], chunk_to_order.size(), gstate.right_orders[i]);
 				if (gstate.right_orders[i].count < chunk_to_order.size()) {
@@ -339,7 +339,7 @@ static sel_t templated_quicksort_initial(T *data, const SelectionVector &sel, co
 			result.set_index(high--, idx);
 		}
 	}
-	assert(low == high);
+	D_ASSERT(low == high);
 	result.set_index(low, pivot_idx);
 	return low;
 }

--- a/src/execution/operator/order/physical_order.cpp
+++ b/src/execution/operator/order/physical_order.cpp
@@ -74,7 +74,7 @@ void PhysicalOrder::Finalize(Pipeline &pipeline, ClientContext &context, unique_
 		sort_collection.Append(sort_chunk);
 	}
 
-	assert(sort_collection.count == big_data.count);
+	D_ASSERT(sort_collection.count == big_data.count);
 
 	// now perform the actual sort
 	sink.sorted_vector = unique_ptr<idx_t[]>(new idx_t[sort_collection.count]);

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -70,7 +70,7 @@ unique_ptr<idx_t[]> PhysicalTopN::ComputeTopN(ChunkCollection &big_data, idx_t &
 		heap_collection.Append(heap_chunk);
 	}
 
-	assert(heap_collection.count == big_data.count);
+	D_ASSERT(heap_collection.count == big_data.count);
 
 	// create and use the heap
 	auto heap = unique_ptr<idx_t[]>(new idx_t[heap_size]);

--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -51,15 +51,15 @@ void PhysicalInsert::Sink(ExecutionContext &context, GlobalOperatorState &state,
 				istate.default_executor.ExecuteExpression(i, istate.insert_chunk.data[i]);
 			} else {
 				// get value from child chunk
-				assert((idx_t)column_index_map[i] < chunk.column_count());
-				assert(istate.insert_chunk.data[i].type == chunk.data[column_index_map[i]].type);
+				D_ASSERT((idx_t)column_index_map[i] < chunk.column_count());
+				D_ASSERT(istate.insert_chunk.data[i].type == chunk.data[column_index_map[i]].type);
 				istate.insert_chunk.data[i].Reference(chunk.data[column_index_map[i]]);
 			}
 		}
 	} else {
 		// no columns specified, just append directly
 		for (idx_t i = 0; i < istate.insert_chunk.column_count(); i++) {
-			assert(istate.insert_chunk.data[i].type == chunk.data[i].type);
+			D_ASSERT(istate.insert_chunk.data[i].type == chunk.data[i].type);
 			istate.insert_chunk.data[i].Reference(chunk.data[i]);
 		}
 	}

--- a/src/execution/operator/persistent/physical_update.cpp
+++ b/src/execution/operator/persistent/physical_update.cpp
@@ -62,7 +62,7 @@ void PhysicalUpdate::Sink(ExecutionContext &context, GlobalOperatorState &state,
 			// default expression, set to the default value of the column
 			ustate.default_executor.ExecuteExpression(columns[i], update_chunk.data[i]);
 		} else {
-			assert(expressions[i]->type == ExpressionType::BOUND_REF);
+			D_ASSERT(expressions[i]->type == ExpressionType::BOUND_REF);
 			// index into child chunk
 			auto &binding = (BoundReferenceExpression &)*expressions[i];
 			update_chunk.data[i].Reference(chunk.data[binding.index]);

--- a/src/execution/operator/projection/physical_projection.cpp
+++ b/src/execution/operator/projection/physical_projection.cpp
@@ -10,7 +10,7 @@ class PhysicalProjectionState : public PhysicalOperatorState {
 public:
 	PhysicalProjectionState(PhysicalOperator &op, PhysicalOperator *child, vector<unique_ptr<Expression>> &expressions)
 	    : PhysicalOperatorState(op, child), executor(expressions) {
-		assert(child);
+		D_ASSERT(child);
 	}
 
 	ExpressionExecutor executor;

--- a/src/execution/operator/projection/physical_unnest.cpp
+++ b/src/execution/operator/projection/physical_unnest.cpp
@@ -29,7 +29,7 @@ PhysicalUnnest::PhysicalUnnest(vector<LogicalType> types, vector<unique_ptr<Expr
                                PhysicalOperatorType type)
     : PhysicalOperator(type, move(types)), select_list(std::move(select_list)) {
 
-	assert(this->select_list.size() > 0);
+	D_ASSERT(this->select_list.size() > 0);
 }
 
 void PhysicalUnnest::GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state_) {
@@ -49,7 +49,7 @@ void PhysicalUnnest::GetChunkInternal(ExecutionContext &context, DataChunk &chun
 			ExpressionExecutor executor;
 			vector<LogicalType> list_data_types;
 			for (auto &exp : select_list) {
-				assert(exp->type == ExpressionType::BOUND_UNNEST);
+				D_ASSERT(exp->type == ExpressionType::BOUND_UNNEST);
 				auto bue = (BoundUnnestExpression *)exp.get();
 				list_data_types.push_back(bue->child->return_type);
 				executor.AddExpression(*bue->child.get());
@@ -61,8 +61,8 @@ void PhysicalUnnest::GetChunkInternal(ExecutionContext &context, DataChunk &chun
 			// paranoia aplenty
 			state->child_chunk.Verify();
 			state->list_data.Verify();
-			assert(state->child_chunk.size() == state->list_data.size());
-			assert(state->list_data.column_count() == select_list.size());
+			D_ASSERT(state->child_chunk.size() == state->list_data.size());
+			D_ASSERT(state->list_data.column_count() == select_list.size());
 		}
 
 		// need to figure out how many times we need to repeat for current row
@@ -70,7 +70,7 @@ void PhysicalUnnest::GetChunkInternal(ExecutionContext &context, DataChunk &chun
 			for (idx_t col_idx = 0; col_idx < state->list_data.column_count(); col_idx++) {
 				auto &v = state->list_data.data[col_idx];
 
-				assert(v.type == LogicalType::LIST);
+				D_ASSERT(v.type == LogicalType::LIST);
 				// TODO deal with NULL values here!
 				auto list_data = FlatVector::GetData<list_entry_t>(v);
 				auto list_entry = list_data[state->parent_position];
@@ -80,7 +80,7 @@ void PhysicalUnnest::GetChunkInternal(ExecutionContext &context, DataChunk &chun
 			}
 		}
 
-		assert(state->list_length >= 0);
+		D_ASSERT(state->list_length >= 0);
 
 		auto this_chunk_len = min((idx_t)STANDARD_VECTOR_SIZE, state->list_length - state->list_position);
 

--- a/src/execution/operator/scan/physical_chunk_scan.cpp
+++ b/src/execution/operator/scan/physical_chunk_scan.cpp
@@ -15,11 +15,11 @@ public:
 
 void PhysicalChunkScan::GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state_) {
 	auto state = (PhysicalChunkScanState *)state_;
-	assert(collection);
+	D_ASSERT(collection);
 	if (collection->count == 0) {
 		return;
 	}
-	assert(chunk.GetTypes() == collection->types);
+	D_ASSERT(chunk.GetTypes() == collection->types);
 	if (state->chunk_index >= collection->chunks.size()) {
 		return;
 	}

--- a/src/execution/operator/scan/physical_expression_scan.cpp
+++ b/src/execution/operator/scan/physical_expression_scan.cpp
@@ -28,7 +28,7 @@ void PhysicalExpressionScan::GetChunkInternal(ExecutionContext &context, DataChu
 
 	if (state->expression_index == 0) {
 		// first run, fetch the chunk from the child
-		assert(children.size() == 1);
+		D_ASSERT(children.size() == 1);
 		children[0]->GetChunk(context, state->child_chunk, state->child_state.get());
 		if (state->child_chunk.size() == 0) {
 			return;

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -71,7 +71,7 @@ void PhysicalTableScan::GetChunkInternal(ExecutionContext &context, DataChunk &c
 		do {
 			function.function(context.client, bind_data.get(), state.operator_data.get(), chunk);
 			if (chunk.size() == 0) {
-				assert(function.parallel_state_next);
+				D_ASSERT(function.parallel_state_next);
 				if (function.parallel_state_next(context.client, bind_data.get(), state.operator_data.get(),
 				                                 state.parallel_state)) {
 					continue;
@@ -83,7 +83,7 @@ void PhysicalTableScan::GetChunkInternal(ExecutionContext &context, DataChunk &c
 			}
 		} while (true);
 	}
-	assert(chunk.size() == 0);
+	D_ASSERT(chunk.size() == 0);
 	if (function.cleanup) {
 		function.cleanup(context.client, bind_data.get(), state.operator_data.get());
 	}

--- a/src/execution/operator/schema/physical_create_index.cpp
+++ b/src/execution/operator/schema/physical_create_index.cpp
@@ -28,7 +28,7 @@ void PhysicalCreateIndex::GetChunkInternal(ExecutionContext &context, DataChunk 
 		break;
 	}
 	default:
-		assert(0);
+		D_ASSERT(0);
 		throw NotImplementedException("Unimplemented index type");
 	}
 	index_entry->index = index.get();

--- a/src/execution/partitionable_hashtable.cpp
+++ b/src/execution/partitionable_hashtable.cpp
@@ -113,7 +113,6 @@ idx_t PartitionableHashTable::AddChunk(DataChunk &groups, DataChunk &payload, bo
 void PartitionableHashTable::Partition() {
 	D_ASSERT(!IsPartitioned());
 	D_ASSERT(radix_partitioned_hts.size() == 0);
-	D_ASSERT(!unpartitioned_hts.empty());
 	D_ASSERT(partition_info.n_partitions > 1);
 
 	vector<GroupedAggregateHashTable *> partition_hts;

--- a/src/execution/partitionable_hashtable.cpp
+++ b/src/execution/partitionable_hashtable.cpp
@@ -11,9 +11,9 @@ RadixPartitionInfo::RadixPartitionInfo(idx_t _n_partitions_upper_bound)
 		}
 	}
 	// finalize_threads needs to be a power of 2
-	assert(n_partitions > 0);
-	assert(n_partitions <= 256);
-	assert((n_partitions & (n_partitions - 1)) == 0);
+	D_ASSERT(n_partitions > 0);
+	D_ASSERT(n_partitions <= 256);
+	D_ASSERT((n_partitions & (n_partitions - 1)) == 0);
 
 	auto radix_partitions_copy = n_partitions;
 	while (radix_partitions_copy - 1) {
@@ -21,7 +21,7 @@ RadixPartitionInfo::RadixPartitionInfo(idx_t _n_partitions_upper_bound)
 		radix_partitions_copy >>= 1;
 	}
 
-	assert(radix_bits <= 8);
+	D_ASSERT(radix_bits <= 8);
 
 	// we use the fifth byte of the 64 bit hash as radix source
 	for (idx_t i = 0; i < radix_bits; i++) {
@@ -76,18 +76,18 @@ idx_t PartitionableHashTable::AddChunk(DataChunk &groups, DataChunk &payload, bo
 	}
 
 	// makes no sense to do this with 1 partition
-	assert(partition_info.n_partitions > 0);
+	D_ASSERT(partition_info.n_partitions > 0);
 
 	for (hash_t r = 0; r < partition_info.n_partitions; r++) {
 		sel_vector_sizes[r] = 0;
 	}
 
-	assert(hashes.vector_type == VectorType::FLAT_VECTOR);
+	D_ASSERT(hashes.vector_type == VectorType::FLAT_VECTOR);
 	auto hashes_ptr = FlatVector::GetData<hash_t>(hashes);
 
 	for (idx_t i = 0; i < groups.size(); i++) {
 		auto partition = (hashes_ptr[i] & partition_info.radix_mask) >> partition_info.RADIX_SHIFT;
-		assert(partition < partition_info.n_partitions);
+		D_ASSERT(partition < partition_info.n_partitions);
 		sel_vectors[partition].set_index(sel_vector_sizes[partition]++, i);
 	}
 
@@ -97,7 +97,7 @@ idx_t PartitionableHashTable::AddChunk(DataChunk &groups, DataChunk &payload, bo
 	for (idx_t r = 0; r < partition_info.n_partitions; r++) {
 		total_count += sel_vector_sizes[r];
 	}
-	assert(total_count == groups.size());
+	D_ASSERT(total_count == groups.size());
 #endif
 	idx_t group_count = 0;
 	for (hash_t r = 0; r < partition_info.n_partitions; r++) {
@@ -111,10 +111,10 @@ idx_t PartitionableHashTable::AddChunk(DataChunk &groups, DataChunk &payload, bo
 }
 
 void PartitionableHashTable::Partition() {
-	assert(!IsPartitioned());
-	assert(radix_partitioned_hts.size() == 0);
-	assert(!unpartitioned_hts.empty());
-	assert(partition_info.n_partitions > 1);
+	D_ASSERT(!IsPartitioned());
+	D_ASSERT(radix_partitioned_hts.size() == 0);
+	D_ASSERT(!unpartitioned_hts.empty());
+	D_ASSERT(partition_info.n_partitions > 1);
 
 	vector<GroupedAggregateHashTable *> partition_hts;
 	for (auto &unpartitioned_ht : unpartitioned_hts) {
@@ -135,13 +135,13 @@ bool PartitionableHashTable::IsPartitioned() {
 }
 
 HashTableList PartitionableHashTable::GetPartition(idx_t partition) {
-	assert(IsPartitioned());
-	assert(partition < partition_info.n_partitions);
-	assert(radix_partitioned_hts.size() > partition);
+	D_ASSERT(IsPartitioned());
+	D_ASSERT(partition < partition_info.n_partitions);
+	D_ASSERT(radix_partitioned_hts.size() > partition);
 	return move(radix_partitioned_hts[partition]);
 }
 HashTableList PartitionableHashTable::GetUnpartitioned() {
-	assert(!IsPartitioned());
+	D_ASSERT(!IsPartitioned());
 	return move(unpartitioned_hts);
 }
 
@@ -149,13 +149,13 @@ void PartitionableHashTable::Finalize() {
 	if (IsPartitioned()) {
 		for (auto &ht_list : radix_partitioned_hts) {
 			for (auto &ht : ht_list.second) {
-				assert(ht);
+				D_ASSERT(ht);
 				ht->Finalize();
 			}
 		}
 	} else {
 		for (auto &ht : unpartitioned_hts) {
-			assert(ht);
+			D_ASSERT(ht);
 			ht->Finalize();
 		}
 	}

--- a/src/execution/physical_plan/plan_aggregate.cpp
+++ b/src/execution/physical_plan/plan_aggregate.cpp
@@ -10,7 +10,7 @@ using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAggregate &op) {
 	unique_ptr<PhysicalOperator> groupby;
-	assert(op.children.size() == 1);
+	D_ASSERT(op.children.size() == 1);
 
 	bool all_combinable = true;
 	for (idx_t i = 0; i < op.expressions.size(); i++) {

--- a/src/execution/physical_plan/plan_any_join.cpp
+++ b/src/execution/physical_plan/plan_any_join.cpp
@@ -7,8 +7,8 @@ using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAnyJoin &op) {
 	// first visit the child nodes
-	assert(op.children.size() == 2);
-	assert(op.condition);
+	D_ASSERT(op.children.size() == 2);
+	D_ASSERT(op.condition);
 
 	auto left = CreatePlan(*op.children[0]);
 	auto right = CreatePlan(*op.children[1]);

--- a/src/execution/physical_plan/plan_chunk_get.cpp
+++ b/src/execution/physical_plan/plan_chunk_get.cpp
@@ -6,8 +6,8 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalChunkGet &op) {
-	assert(op.children.size() == 0);
-	assert(op.collection);
+	D_ASSERT(op.children.size() == 0);
+	D_ASSERT(op.collection);
 
 	// create a PhysicalChunkScan pointing towards the owned collection
 	auto chunk_scan = make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN);

--- a/src/execution/physical_plan/plan_comparison_join.cpp
+++ b/src/execution/physical_plan/plan_comparison_join.cpp
@@ -48,12 +48,12 @@ void TransformIndexJoin(ClientContext &context, LogicalComparisonJoin &op, Index
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalComparisonJoin &op) {
 	// now visit the children
-	assert(op.children.size() == 2);
+	D_ASSERT(op.children.size() == 2);
 	idx_t lhs_cardinality = op.children[0]->EstimateCardinality();
 	idx_t rhs_cardinality = op.children[1]->EstimateCardinality();
 	auto left = CreatePlan(*op.children[0]);
 	auto right = CreatePlan(*op.children[1]);
-	assert(left && right);
+	D_ASSERT(left && right);
 
 	if (op.conditions.size() == 0) {
 		// no conditions: insert a cross product
@@ -62,9 +62,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalComparison
 
 	bool has_equality = false;
 	bool has_inequality = false;
-#ifndef NDEBUG
 	bool has_null_equal_conditions = false;
-#endif
 	for (auto &cond : op.conditions) {
 		if (cond.comparison == ExpressionType::COMPARE_EQUAL) {
 			has_equality = true;
@@ -73,12 +71,12 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalComparison
 			has_inequality = true;
 		}
 		if (cond.null_values_are_equal) {
-#ifndef NDEBUG
 			has_null_equal_conditions = true;
-#endif
-			assert(cond.comparison == ExpressionType::COMPARE_EQUAL);
+			D_ASSERT(cond.comparison == ExpressionType::COMPARE_EQUAL);
 		}
 	}
+	(void) has_null_equal_conditions;
+
 	unique_ptr<PhysicalOperator> plan;
 	if (has_equality) {
 		Index *left_index{}, *right_index{};
@@ -100,7 +98,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalComparison
 		plan = make_unique<PhysicalHashJoin>(op, move(left), move(right), move(op.conditions), op.join_type,
 		                                     op.left_projection_map, op.right_projection_map);
 	} else {
-		assert(!has_null_equal_conditions); // don't support this for anything but hash joins for now
+		D_ASSERT(!has_null_equal_conditions); // don't support this for anything but hash joins for now
 		if (op.conditions.size() == 1 && !has_inequality) {
 			// range join: use piecewise merge join
 			plan =

--- a/src/execution/physical_plan/plan_create_index.cpp
+++ b/src/execution/physical_plan/plan_create_index.cpp
@@ -7,7 +7,7 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreateIndex &op) {
-	assert(op.children.size() == 0);
+	D_ASSERT(op.children.size() == 0);
 	dependencies.insert(&op.table);
 	return make_unique<PhysicalCreateIndex>(op, op.table, op.column_ids, move(op.expressions), move(op.info),
 	                                        move(op.unbound_expressions));

--- a/src/execution/physical_plan/plan_create_table.cpp
+++ b/src/execution/physical_plan/plan_create_table.cpp
@@ -27,7 +27,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreateTabl
 	}
 	auto create = make_unique<PhysicalCreateTable>(op, op.schema, move(op.info));
 	if (op.children.size() > 0) {
-		assert(op.children.size() == 1);
+		D_ASSERT(op.children.size() == 1);
 		auto plan = CreatePlan(*op.children[0]);
 		create->children.push_back(move(plan));
 	}

--- a/src/execution/physical_plan/plan_cross_product.cpp
+++ b/src/execution/physical_plan/plan_cross_product.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCrossProduct &op) {
-	assert(op.children.size() == 2);
+	D_ASSERT(op.children.size() == 2);
 
 	auto left = CreatePlan(*op.children[0]);
 	auto right = CreatePlan(*op.children[1]);

--- a/src/execution/physical_plan/plan_delete.cpp
+++ b/src/execution/physical_plan/plan_delete.cpp
@@ -8,9 +8,9 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelete &op) {
-	assert(op.children.size() == 1);
-	assert(op.expressions.size() == 1);
-	assert(op.expressions[0]->type == ExpressionType::BOUND_REF);
+	D_ASSERT(op.children.size() == 1);
+	D_ASSERT(op.expressions.size() == 1);
+	D_ASSERT(op.expressions[0]->type == ExpressionType::BOUND_REF);
 
 	auto plan = CreatePlan(*op.children[0]);
 

--- a/src/execution/physical_plan/plan_delim_get.cpp
+++ b/src/execution/physical_plan/plan_delim_get.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelimGet &op) {
-	assert(op.children.size() == 0);
+	D_ASSERT(op.children.size() == 0);
 
 	// create a PhysicalChunkScan without an owned_collection, the collection will be added later
 	auto chunk_scan = make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::DELIM_SCAN);

--- a/src/execution/physical_plan/plan_delim_join.cpp
+++ b/src/execution/physical_plan/plan_delim_join.cpp
@@ -14,7 +14,7 @@ using namespace std;
 namespace duckdb {
 
 static void GatherDelimScans(PhysicalOperator *op, vector<PhysicalOperator *> &delim_scans) {
-	assert(op);
+	D_ASSERT(op);
 	if (op->type == PhysicalOperatorType::DELIM_SCAN) {
 		delim_scans.push_back(op);
 	}
@@ -27,7 +27,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelimJoin 
 	// first create the underlying join
 	auto plan = CreatePlan((LogicalComparisonJoin &)op);
 	// this should create a join, not a cross product
-	assert(plan && plan->type != PhysicalOperatorType::CROSS_PRODUCT);
+	D_ASSERT(plan && plan->type != PhysicalOperatorType::CROSS_PRODUCT);
 	// duplicate eliminated join
 	// first gather the scans on the duplicate eliminated data set from the RHS
 	vector<PhysicalOperator *> delim_scans;
@@ -41,13 +41,13 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelimJoin 
 	vector<LogicalType> delim_types;
 	vector<unique_ptr<Expression>> distinct_groups, distinct_expressions;
 	for (auto &delim_expr : op.duplicate_eliminated_columns) {
-		assert(delim_expr->type == ExpressionType::BOUND_REF);
+		D_ASSERT(delim_expr->type == ExpressionType::BOUND_REF);
 		auto &bound_ref = (BoundReferenceExpression &)*delim_expr;
 		delim_types.push_back(bound_ref.return_type);
 		distinct_groups.push_back(make_unique<BoundReferenceExpression>(bound_ref.return_type, bound_ref.index));
 	}
 	if (op.join_type == JoinType::MARK) {
-		assert(plan->type == PhysicalOperatorType::HASH_JOIN);
+		D_ASSERT(plan->type == PhysicalOperatorType::HASH_JOIN);
 		auto &hash_join = (PhysicalHashJoin &)*plan;
 		hash_join.delim_types = delim_types;
 	}

--- a/src/execution/physical_plan/plan_distinct.cpp
+++ b/src/execution/physical_plan/plan_distinct.cpp
@@ -12,8 +12,8 @@ using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreateDistinctOn(unique_ptr<PhysicalOperator> child,
                                                                      vector<unique_ptr<Expression>> distinct_targets) {
-	assert(child);
-	assert(distinct_targets.size() > 0);
+	D_ASSERT(child);
+	D_ASSERT(distinct_targets.size() > 0);
 
 	auto &types = child->GetTypes();
 	vector<unique_ptr<Expression>> groups, aggregates, projections;
@@ -78,7 +78,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreateDistinctOn(unique_ptr<
 }
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDistinct &op) {
-	assert(op.children.size() == 1);
+	D_ASSERT(op.children.size() == 1);
 	auto plan = CreatePlan(*op.children[0]);
 	return CreateDistinctOn(move(plan), move(op.distinct_targets));
 }

--- a/src/execution/physical_plan/plan_dummy_scan.cpp
+++ b/src/execution/physical_plan/plan_dummy_scan.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDummyScan &op) {
-	assert(op.children.size() == 0);
+	D_ASSERT(op.children.size() == 0);
 	return make_unique<PhysicalDummyScan>(op.types);
 }
 

--- a/src/execution/physical_plan/plan_empty_result.cpp
+++ b/src/execution/physical_plan/plan_empty_result.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalEmptyResult &op) {
-	assert(op.children.size() == 0);
+	D_ASSERT(op.children.size() == 0);
 	return make_unique<PhysicalEmptyResult>(op.types);
 }
 

--- a/src/execution/physical_plan/plan_execute.cpp
+++ b/src/execution/physical_plan/plan_execute.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExecute &op) {
-	assert(op.children.size() == 0);
+	D_ASSERT(op.children.size() == 0);
 	return make_unique<PhysicalExecute>(op.prepared->plan.get());
 }
 

--- a/src/execution/physical_plan/plan_explain.cpp
+++ b/src/execution/physical_plan/plan_explain.cpp
@@ -10,7 +10,7 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExplain &op) {
-	assert(op.children.size() == 1);
+	D_ASSERT(op.children.size() == 1);
 	auto logical_plan_opt = op.children[0]->ToString();
 	auto plan = CreatePlan(*op.children[0]);
 

--- a/src/execution/physical_plan/plan_expression_get.cpp
+++ b/src/execution/physical_plan/plan_expression_get.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExpressionGet &op) {
-	assert(op.children.size() == 1);
+	D_ASSERT(op.children.size() == 1);
 	auto plan = CreatePlan(*op.children[0]);
 
 	auto expr_scan = make_unique<PhysicalExpressionScan>(op.types, move(op.expressions));

--- a/src/execution/physical_plan/plan_filter.cpp
+++ b/src/execution/physical_plan/plan_filter.cpp
@@ -12,10 +12,10 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalFilter &op) {
-	assert(op.children.size() == 1);
+	D_ASSERT(op.children.size() == 1);
 	unique_ptr<PhysicalOperator> plan = CreatePlan(*op.children[0]);
 	if (op.expressions.size() > 0) {
-		assert(plan->types.size() > 0);
+		D_ASSERT(plan->types.size() > 0);
 		// create a filter if there is anything to filter
 		auto filter = make_unique<PhysicalFilter>(plan->types, move(op.expressions));
 		filter->children.push_back(move(plan));

--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -10,7 +10,7 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
-	assert(op.children.empty());
+	D_ASSERT(op.children.empty());
 
 	// create the table filter map
 	unordered_map<idx_t, vector<TableFilter>> table_filter_umap;

--- a/src/execution/physical_plan/plan_insert.cpp
+++ b/src/execution/physical_plan/plan_insert.cpp
@@ -9,7 +9,7 @@ using namespace std;
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalInsert &op) {
 	unique_ptr<PhysicalOperator> plan;
 	if (op.children.size() > 0) {
-		assert(op.children.size() == 1);
+		D_ASSERT(op.children.size() == 1);
 		plan = CreatePlan(*op.children[0]);
 	}
 

--- a/src/execution/physical_plan/plan_limit.cpp
+++ b/src/execution/physical_plan/plan_limit.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalLimit &op) {
-	assert(op.children.size() == 1);
+	D_ASSERT(op.children.size() == 1);
 
 	auto plan = CreatePlan(*op.children[0]);
 

--- a/src/execution/physical_plan/plan_order.cpp
+++ b/src/execution/physical_plan/plan_order.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalOrder &op) {
-	assert(op.children.size() == 1);
+	D_ASSERT(op.children.size() == 1);
 
 	auto plan = CreatePlan(*op.children[0]);
 	if (op.orders.size() > 0) {

--- a/src/execution/physical_plan/plan_prepare.cpp
+++ b/src/execution/physical_plan/plan_prepare.cpp
@@ -7,7 +7,7 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalPrepare &op) {
-	assert(op.children.size() == 1);
+	D_ASSERT(op.children.size() == 1);
 
 	// generate physical plan
 	auto plan = CreatePlan(*op.children[0]);

--- a/src/execution/physical_plan/plan_projection.cpp
+++ b/src/execution/physical_plan/plan_projection.cpp
@@ -7,12 +7,12 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalProjection &op) {
-	assert(op.children.size() == 1);
+	D_ASSERT(op.children.size() == 1);
 	auto plan = CreatePlan(*op.children[0]);
 
 #ifdef DEBUG
 	for (auto &expr : op.expressions) {
-		assert(!expr->IsWindow() && !expr->IsAggregate());
+		D_ASSERT(!expr->IsWindow() && !expr->IsAggregate());
 	}
 #endif
 	if (plan->types.size() == op.types.size()) {

--- a/src/execution/physical_plan/plan_recursive_cte.cpp
+++ b/src/execution/physical_plan/plan_recursive_cte.cpp
@@ -9,7 +9,7 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalRecursiveCTE &op) {
-	assert(op.children.size() == 2);
+	D_ASSERT(op.children.size() == 2);
 
 	// Create the working_table that the PhysicalRecursiveCTE will use for evaluation.
 	auto working_table = std::make_shared<ChunkCollection>();
@@ -27,7 +27,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalRecursiveC
 }
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCTERef &op) {
-	assert(op.children.size() == 0);
+	D_ASSERT(op.children.size() == 0);
 
 	auto chunk_scan = make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::RECURSIVE_CTE_SCAN);
 

--- a/src/execution/physical_plan/plan_set_operation.cpp
+++ b/src/execution/physical_plan/plan_set_operation.cpp
@@ -8,7 +8,7 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSetOperation &op) {
-	assert(op.children.size() == 2);
+	D_ASSERT(op.children.size() == 2);
 
 	auto left = CreatePlan(*op.children[0]);
 	auto right = CreatePlan(*op.children[1]);
@@ -23,7 +23,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSetOperati
 		return make_unique<PhysicalUnion>(op.types, move(left), move(right));
 	default: {
 		// EXCEPT/INTERSECT
-		assert(op.type == LogicalOperatorType::EXCEPT || op.type == LogicalOperatorType::INTERSECT);
+		D_ASSERT(op.type == LogicalOperatorType::EXCEPT || op.type == LogicalOperatorType::INTERSECT);
 		auto &types = left->GetTypes();
 		vector<JoinCondition> conditions;
 		// create equality condition for all columns

--- a/src/execution/physical_plan/plan_top_n.cpp
+++ b/src/execution/physical_plan/plan_top_n.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalTopN &op) {
-	assert(op.children.size() == 1);
+	D_ASSERT(op.children.size() == 1);
 
 	auto plan = CreatePlan(*op.children[0]);
 

--- a/src/execution/physical_plan/plan_unnest.cpp
+++ b/src/execution/physical_plan/plan_unnest.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalUnnest &op) {
-	assert(op.children.size() == 1);
+	D_ASSERT(op.children.size() == 1);
 	auto plan = CreatePlan(*op.children[0]);
 	auto unnest = make_unique<PhysicalUnnest>(op.types, move(op.expressions));
 	unnest->children.push_back(move(plan));

--- a/src/execution/physical_plan/plan_update.cpp
+++ b/src/execution/physical_plan/plan_update.cpp
@@ -7,7 +7,7 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalUpdate &op) {
-	assert(op.children.size() == 1);
+	D_ASSERT(op.children.size() == 1);
 
 	auto plan = CreatePlan(*op.children[0]);
 

--- a/src/execution/physical_plan/plan_window.cpp
+++ b/src/execution/physical_plan/plan_window.cpp
@@ -6,12 +6,12 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalWindow &op) {
-	assert(op.children.size() == 1);
+	D_ASSERT(op.children.size() == 1);
 
 	auto plan = CreatePlan(*op.children[0]);
 #ifdef DEBUG
 	for (auto &expr : op.expressions) {
-		assert(expr->IsWindow());
+		D_ASSERT(expr->IsWindow());
 	}
 #endif
 

--- a/src/execution/window_segment_tree.cpp
+++ b/src/execution/window_segment_tree.cpp
@@ -42,7 +42,7 @@ Value WindowSegmentTree::AggegateFinal() {
 }
 
 void WindowSegmentTree::WindowSegmentValue(idx_t l_idx, idx_t begin, idx_t end) {
-	assert(begin <= end);
+	D_ASSERT(begin <= end);
 	if (begin == end) {
 		return;
 	}
@@ -76,7 +76,7 @@ void WindowSegmentTree::WindowSegmentValue(idx_t l_idx, idx_t begin, idx_t end) 
 		}
 		aggregate.update(&inputs.data[0], input_count, s, inputs.size());
 	} else {
-		assert(end - begin <= STANDARD_VECTOR_SIZE);
+		D_ASSERT(end - begin <= STANDARD_VECTOR_SIZE);
 		// find out where the states begin
 		data_ptr_t begin_ptr = levels_flat_native.get() + state.size() * (begin + levels_flat_start[l_idx - 1]);
 		// set up a vector of pointers that point towards the set of states
@@ -91,8 +91,8 @@ void WindowSegmentTree::WindowSegmentValue(idx_t l_idx, idx_t begin, idx_t end) 
 }
 
 void WindowSegmentTree::ConstructTree() {
-	assert(input_ref);
-	assert(inputs.column_count() > 0);
+	D_ASSERT(input_ref);
+	D_ASSERT(inputs.column_count() > 0);
 
 	// compute space required to store internal nodes of segment tree
 	idx_t internal_nodes = 0;
@@ -125,7 +125,7 @@ void WindowSegmentTree::ConstructTree() {
 }
 
 Value WindowSegmentTree::Compute(idx_t begin, idx_t end) {
-	assert(input_ref);
+	D_ASSERT(input_ref);
 
 	// No arguments, so just count
 	if (inputs.column_count() == 0) {

--- a/src/function/aggregate/distributive/first.cpp
+++ b/src/function/aggregate/distributive/first.cpp
@@ -105,7 +105,7 @@ template <class T> static AggregateFunction GetFirstAggregateTemplated(LogicalTy
 }
 
 AggregateFunction GetDecimalFirstFunction(LogicalType type) {
-	assert(type.id() == LogicalTypeId::DECIMAL);
+	D_ASSERT(type.id() == LogicalTypeId::DECIMAL);
 	switch (type.InternalType()) {
 	case PhysicalType::INT16:
 		return FirstFun::GetFunction(LogicalType::SMALLINT);

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -50,7 +50,7 @@ struct MinMaxBase {
 
 	template <class INPUT_TYPE, class STATE, class OP>
 	static void ConstantOperation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t count) {
-		assert(!nullmask[0]);
+		D_ASSERT(!nullmask[0]);
 		if (!state->isset) {
 			OP::template Assign<INPUT_TYPE, STATE>(state, input[0]);
 			state->isset = true;

--- a/src/function/aggregate/nested/list.cpp
+++ b/src/function/aggregate/nested/list.cpp
@@ -30,7 +30,7 @@ struct ListFunction {
 };
 
 static void list_update(Vector inputs[], idx_t input_count, Vector &state_vector, idx_t count) {
-	assert(input_count == 1);
+	D_ASSERT(input_count == 1);
 
 	auto &input = inputs[0];
 	VectorData sdata;
@@ -65,7 +65,7 @@ static void list_combine(Vector &state, Vector &combined, idx_t count) {
 
 	for (idx_t i = 0; i < count; i++) {
 		auto state = states_ptr[sdata.sel->get_index(i)];
-		assert(state->cc);
+		D_ASSERT(state->cc);
 		if (!combined_ptr[i]->cc) {
 			combined_ptr[i]->cc = new ChunkCollection();
 		}
@@ -85,9 +85,9 @@ static void list_finalize(Vector &state_vector, Vector &result, idx_t count) {
 	size_t total_len = 0;
 	for (idx_t i = 0; i < count; i++) {
 		auto state = states[sdata.sel->get_index(i)];
-		assert(state->cc);
+		D_ASSERT(state->cc);
 		auto &state_cc = *state->cc;
-		assert(state_cc.types.size() == 1);
+		D_ASSERT(state_cc.types.size() == 1);
 		list_struct_data[i].length = state_cc.count;
 		list_struct_data[i].offset = total_len;
 		total_len += state_cc.count;
@@ -97,16 +97,16 @@ static void list_finalize(Vector &state_vector, Vector &result, idx_t count) {
 	for (idx_t i = 0; i < count; i++) {
 		auto state = states[sdata.sel->get_index(i)];
 		auto &state_cc = *state->cc;
-		assert(state_cc.chunks[0]->column_count() == 1);
+		D_ASSERT(state_cc.chunks[0]->column_count() == 1);
 		list_child->Append(state_cc);
 	}
-	assert(list_child->count == total_len);
+	D_ASSERT(list_child->count == total_len);
 	ListVector::SetEntry(result, move(list_child));
 }
 
 unique_ptr<FunctionData> list_bind(ClientContext &context, AggregateFunction &function,
                                    vector<unique_ptr<Expression>> &arguments) {
-	assert(arguments.size() == 1);
+	D_ASSERT(arguments.size() == 1);
 	child_list_t<LogicalType> children;
 	children.push_back(make_pair("", arguments[0]->return_type));
 

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -327,7 +327,7 @@ unique_ptr<BoundFunctionExpression> ScalarFunction::BindScalarFunction(ClientCon
                                                                        string &error, bool is_operator) {
 	// bind the function
 	auto function = Catalog::GetCatalog(context).GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, schema, name);
-	assert(function && function->type == CatalogType::SCALAR_FUNCTION_ENTRY);
+	D_ASSERT(function && function->type == CatalogType::SCALAR_FUNCTION_ENTRY);
 	return ScalarFunction::BindScalarFunction(context, (ScalarFunctionCatalogEntry &)*function, move(children), error,
 	                                          is_operator);
 }

--- a/src/function/scalar/date/age.cpp
+++ b/src/function/scalar/date/age.cpp
@@ -11,7 +11,7 @@ using namespace std;
 namespace duckdb {
 
 static void age_function_standard(DataChunk &input, ExpressionState &state, Vector &result) {
-	assert(input.column_count() == 1);
+	D_ASSERT(input.column_count() == 1);
 	auto current_timestamp = Timestamp::GetCurrentTimestamp();
 
 	UnaryExecutor::Execute<timestamp_t, interval_t, true>(input.data[0], result, input.size(), [&](timestamp_t input) {
@@ -20,7 +20,7 @@ static void age_function_standard(DataChunk &input, ExpressionState &state, Vect
 }
 
 static void age_function(DataChunk &input, ExpressionState &state, Vector &result) {
-	assert(input.column_count() == 2);
+	D_ASSERT(input.column_count() == 2);
 
 	BinaryExecutor::Execute<timestamp_t, timestamp_t, interval_t, true>(
 	    input.data[0], input.data[1], result, input.size(),

--- a/src/function/scalar/date/current.cpp
+++ b/src/function/scalar/date/current.cpp
@@ -29,21 +29,21 @@ static timestamp_t get_transaction_ts(ExpressionState &state) {
 }
 
 static void current_time_function(DataChunk &input, ExpressionState &state, Vector &result) {
-	assert(input.column_count() == 0);
+	D_ASSERT(input.column_count() == 0);
 
 	auto val = Value::TIME(Timestamp::GetTime(get_transaction_ts(state)));
 	result.Reference(val);
 }
 
 static void current_date_function(DataChunk &input, ExpressionState &state, Vector &result) {
-	assert(input.column_count() == 0);
+	D_ASSERT(input.column_count() == 0);
 
 	auto val = Value::DATE(Timestamp::GetDate(get_transaction_ts(state)));
 	result.Reference(val);
 }
 
 static void current_timestamp_function(DataChunk &input, ExpressionState &state, Vector &result) {
-	assert(input.column_count() == 0);
+	D_ASSERT(input.column_count() == 0);
 
 	auto val = Value::TIMESTAMP(get_transaction_ts(state));
 	result.Reference(val);

--- a/src/function/scalar/date/epoch.cpp
+++ b/src/function/scalar/date/epoch.cpp
@@ -11,7 +11,7 @@ namespace duckdb {
 
 template<int FACTOR>
 static void epoch_function(DataChunk &input, ExpressionState &state, Vector &result) {
-	assert(input.column_count() == 1);
+	D_ASSERT(input.column_count() == 1);
 
 	string output_buffer;
 	UnaryExecutor::Execute<int64_t, timestamp_t, true>(input.data[0], result, input.size(), [&](int64_t input) {

--- a/src/function/scalar/date/strftime.cpp
+++ b/src/function/scalar/date/strftime.cpp
@@ -184,7 +184,7 @@ char *StrfTimeFormat::WritePadded3(char *target, uint32_t value) {
 
 // write a value in the range of 0..999999 padded to 6 digits
 char *StrfTimeFormat::WritePadded(char *target, int32_t value, int32_t padding) {
-	assert(padding % 2 == 0);
+	D_ASSERT(padding % 2 == 0);
 	for (int i = 0; i < padding / 2; i++) {
 		int decimals = value % 100;
 		WritePadded2(target + padding - 2 * (i + 1), decimals);
@@ -520,7 +520,7 @@ string StrTimeFormat::ParseFormatSpecifier(string format_string, StrTimeFormat &
 					// parse the subformat in a separate format specifier
 					StrfTimeFormat locale_format;
 					string error = StrTimeFormat::ParseFormatSpecifier(subformat, locale_format);
-					assert(error.empty());
+					D_ASSERT(error.empty());
 					// add the previous literal to the first literal of the subformat
 					locale_format.literals[0] = move(current_literal) + locale_format.literals[0];
 					// now push the subformat into the current format specifier

--- a/src/function/scalar/math/numeric.cpp
+++ b/src/function/scalar/math/numeric.cpp
@@ -52,7 +52,7 @@ struct UnaryDoubleWrapper {
 
 template <class T, class OP>
 static void UnaryDoubleFunctionWrapper(DataChunk &input, ExpressionState &state, Vector &result) {
-	assert(input.column_count() >= 1);
+	D_ASSERT(input.column_count() >= 1);
 	errno = 0;
 	UnaryExecutor::Execute<T, T, OP, true, UnaryDoubleWrapper>(input.data[0], result, input.size());
 }
@@ -72,7 +72,7 @@ struct BinaryDoubleWrapper {
 
 template <class T, class OP>
 static void BinaryDoubleFunctionWrapper(DataChunk &input, ExpressionState &state, Vector &result) {
-	assert(input.column_count() >= 2);
+	D_ASSERT(input.column_count() >= 2);
 	errno = 0;
 	BinaryExecutor::Execute<T, T, T, OP, true, BinaryDoubleWrapper>(input.data[0], input.data[1], result, input.size());
 }
@@ -624,7 +624,7 @@ void Log2Fun::RegisterFunction(BuiltinFunctions &set) {
 // pi
 //===--------------------------------------------------------------------===//
 static void pi_function(DataChunk &args, ExpressionState &state, Vector &result) {
-	assert(args.column_count() == 0);
+	D_ASSERT(args.column_count() == 0);
 	Value pi_value = Value::DOUBLE(PI);
 	result.Reference(pi_value);
 }

--- a/src/function/scalar/math/random.cpp
+++ b/src/function/scalar/math/random.cpp
@@ -21,7 +21,7 @@ struct RandomBindData : public FunctionData {
 };
 
 static void random_function(DataChunk &args, ExpressionState &state, Vector &result) {
-	assert(args.column_count() == 0);
+	D_ASSERT(args.column_count() == 0);
 	auto &func_expr = (BoundFunctionExpression &)state.expr;
 	auto &info = (RandomBindData &)*func_expr.bind_info;
 

--- a/src/function/scalar/nested/list_value.cpp
+++ b/src/function/scalar/nested/list_value.cpp
@@ -13,7 +13,7 @@ static void list_value_fun(DataChunk &args, ExpressionState &state, Vector &resu
 	//	auto &func_expr = (BoundFunctionExpression &)state.expr;
 	//	auto &info = (VariableReturnBindData &)*func_expr.bind_info;
 
-	assert(result.type.id() == LogicalTypeId::LIST);
+	D_ASSERT(result.type.id() == LogicalTypeId::LIST);
 	auto list_child = make_unique<ChunkCollection>();
 	ListVector::SetEntry(result, move(list_child));
 

--- a/src/function/scalar/nested/struct_extract.cpp
+++ b/src/function/scalar/nested/struct_extract.cpp
@@ -25,7 +25,7 @@ static void struct_extract_fun(DataChunk &args, ExpressionState &state, Vector &
 	auto &info = (StructExtractBindData &)*func_expr.bind_info;
 
 	// this should be guaranteed by the binder
-	assert(args.column_count() == 1);
+	D_ASSERT(args.column_count() == 1);
 	auto &vec = args.data[0];
 
 	vec.Verify(args.size());
@@ -69,7 +69,7 @@ static unique_ptr<FunctionData> struct_extract_bind(ClientContext &context, Scal
 		throw Exception("Key name for struct_extract needs to be a constant string");
 	}
 	Value key_val = ExpressionExecutor::EvaluateScalar(*key_child.get());
-	assert(key_val.type().id() == LogicalTypeId::VARCHAR);
+	D_ASSERT(key_val.type().id() == LogicalTypeId::VARCHAR);
 	if (key_val.is_null || key_val.str_value.length() < 1) {
 		throw Exception("Key name for struct_extract needs to be neither NULL nor empty");
 	}

--- a/src/function/scalar/nested/struct_pack.cpp
+++ b/src/function/scalar/nested/struct_pack.cpp
@@ -14,7 +14,7 @@ static void struct_pack_fun(DataChunk &args, ExpressionState &state, Vector &res
 	auto &info = (VariableReturnBindData &)*func_expr.bind_info;
 
 	// this should never happen if the binder below is sane
-	assert(args.column_count() == info.stype.child_types().size());
+	D_ASSERT(args.column_count() == info.stype.child_types().size());
 
 	bool all_const = true;
 	for (size_t i = 0; i < args.column_count(); i++) {
@@ -22,7 +22,7 @@ static void struct_pack_fun(DataChunk &args, ExpressionState &state, Vector &res
 			all_const = false;
 		}
 		// same holds for this
-		assert(args.data[i].type == info.stype.child_types()[i].second);
+		D_ASSERT(args.data[i].type == info.stype.child_types()[i].second);
 		auto new_child = make_unique<Vector>();
 		new_child->Reference(args.data[i]);
 		StructVector::AddEntry(result, info.stype.child_types()[i].first, move(new_child));

--- a/src/function/scalar/operators/arithmetic.cpp
+++ b/src/function/scalar/operators/arithmetic.cpp
@@ -294,7 +294,7 @@ unique_ptr<FunctionData> decimal_negate_bind(ClientContext &context, ScalarFunct
 	} else if (decimal_type.width() <= Decimal::MAX_WIDTH_INT64) {
 		bound_function.function = ScalarFunction::GetScalarUnaryFunction<NegateOperator>(LogicalTypeId::BIGINT);
 	} else {
-		assert(decimal_type.width() <= Decimal::MAX_WIDTH_INT128);
+		D_ASSERT(decimal_type.width() <= Decimal::MAX_WIDTH_INT128);
 		bound_function.function = ScalarFunction::GetScalarUnaryFunction<NegateOperator>(LogicalTypeId::HUGEINT);
 	}
 	bound_function.arguments[0] = decimal_type;
@@ -541,12 +541,12 @@ void DivideFun::RegisterFunction(BuiltinFunctions &set) {
 // % [modulo]
 //===--------------------------------------------------------------------===//
 template <> float ModuloOperator::Operation(float left, float right) {
-	assert(right != 0);
+	D_ASSERT(right != 0);
 	return fmod(left, right);
 }
 
 template <> double ModuloOperator::Operation(double left, double right) {
-	assert(right != 0);
+	D_ASSERT(right != 0);
 	return fmod(left, right);
 }
 

--- a/src/function/scalar/sequence/nextval.cpp
+++ b/src/function/scalar/sequence/nextval.cpp
@@ -97,7 +97,7 @@ static unique_ptr<FunctionData> nextval_bind(ClientContext &context, ScalarFunct
 		// evaluate the constant and perform the catalog lookup already
 		Value seqname = ExpressionExecutor::EvaluateScalar(*arguments[0]);
 		if (!seqname.is_null) {
-			assert(seqname.type().id() == LogicalTypeId::VARCHAR);
+			D_ASSERT(seqname.type().id() == LogicalTypeId::VARCHAR);
 			Catalog::ParseRangeVar(seqname.str_value, schema, seq);
 			sequence = Catalog::GetCatalog(context).GetEntry<SequenceCatalogEntry>(context, schema, seq);
 		}

--- a/src/function/scalar/string/caseconvert.cpp
+++ b/src/function/scalar/string/caseconvert.cpp
@@ -22,7 +22,7 @@ template <bool IS_UPPER> static string_t strcase_unicode(Vector &result, const c
 			int codepoint = utf8proc_codepoint(input_data + i, sz);
 			int converted_codepoint = IS_UPPER ? utf8proc_toupper(codepoint) : utf8proc_tolower(codepoint);
 			int new_sz = utf8proc_codepoint_length(converted_codepoint);
-			assert(new_sz >= 0);
+			D_ASSERT(new_sz >= 0);
 			output_length += new_sz;
 			i += sz;
 		} else {
@@ -41,7 +41,7 @@ template <bool IS_UPPER> static string_t strcase_unicode(Vector &result, const c
 			int codepoint = utf8proc_codepoint(input_data + i, sz);
 			int converted_codepoint = IS_UPPER ? utf8proc_toupper(codepoint) : utf8proc_tolower(codepoint);
 			const auto success = utf8proc_codepoint_to_utf8(converted_codepoint, new_sz, result_data);
-			assert(success);
+			D_ASSERT(success);
 			(void)success;
 			result_data += new_sz;
 			i += sz;
@@ -57,7 +57,7 @@ template <bool IS_UPPER> static string_t strcase_unicode(Vector &result, const c
 }
 
 template <bool IS_UPPER> static void caseconvert_function(Vector &input, Vector &result, idx_t count) {
-	assert(input.type.id() == LogicalTypeId::VARCHAR);
+	D_ASSERT(input.type.id() == LogicalTypeId::VARCHAR);
 
 	UnaryExecutor::Execute<string_t, string_t, true>(input, result, count, [&](string_t input) {
 		auto input_data = input.GetData();
@@ -67,12 +67,12 @@ template <bool IS_UPPER> static void caseconvert_function(Vector &input, Vector 
 }
 
 static void caseconvert_upper_function(DataChunk &args, ExpressionState &state, Vector &result) {
-	assert(args.column_count() == 1);
+	D_ASSERT(args.column_count() == 1);
 	caseconvert_function<true>(args.data[0], result, args.size());
 }
 
 static void caseconvert_lower_function(DataChunk &args, ExpressionState &state, Vector &result) {
-	assert(args.column_count() == 1);
+	D_ASSERT(args.column_count() == 1);
 	caseconvert_function<false>(args.data[0], result, args.size());
 }
 

--- a/src/function/scalar/string/concat.cpp
+++ b/src/function/scalar/string/concat.cpp
@@ -18,7 +18,7 @@ static void concat_function(DataChunk &args, ExpressionState &state, Vector &res
 	vector<idx_t> result_lengths(args.size(), 0);
 	for (idx_t col_idx = 0; col_idx < args.column_count(); col_idx++) {
 		auto &input = args.data[col_idx];
-		assert(input.type.id() == LogicalTypeId::VARCHAR);
+		D_ASSERT(input.type.id() == LogicalTypeId::VARCHAR);
 		if (input.vector_type == VectorType::CONSTANT_VECTOR) {
 			if (ConstantVector::IsNull(input)) {
 				// constant null, skip

--- a/src/function/scalar/string/nfc_normalize.cpp
+++ b/src/function/scalar/string/nfc_normalize.cpp
@@ -7,7 +7,7 @@ using namespace std;
 namespace duckdb {
 
 static void nfc_normalize_function(DataChunk &args, ExpressionState &state, Vector &result) {
-	assert(args.column_count() == 1);
+	D_ASSERT(args.column_count() == 1);
 
 	UnaryExecutor::Execute<string_t, string_t, true>(args.data[0], result, args.size(), [&](string_t input) {
 		auto input_data = input.GetData();

--- a/src/function/scalar/string/pad.cpp
+++ b/src/function/scalar/string/pad.cpp
@@ -18,7 +18,7 @@ static pair<idx_t, idx_t> count_chars(const idx_t len, const char *data, const i
 	for (; nchars < len && nbytes < size; ++nchars) {
 		utf8proc_int32_t codepoint;
 		const auto bytes = utf8proc_iterate(str + nbytes, size - nbytes, &codepoint);
-		assert(bytes > 0);
+		D_ASSERT(bytes > 0);
 		nbytes += bytes;
 	}
 
@@ -48,7 +48,7 @@ static bool insert_padding(const idx_t len, const string_t &pad, vector<char> &r
 		//  Write the next character
 		utf8proc_int32_t codepoint;
 		const auto bytes = utf8proc_iterate(str + nbytes, size - nbytes, &codepoint);
-		assert(bytes > 0);
+		D_ASSERT(bytes > 0);
 		nbytes += bytes;
 	}
 

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -110,7 +110,7 @@ template <class OP> static void regexp_matches_function(DataChunk &args, Express
 static unique_ptr<FunctionData> regexp_matches_get_bind_function(ClientContext &context, ScalarFunction &bound_function,
                                                                  vector<unique_ptr<Expression>> &arguments) {
 	// pattern is the second argument. If its constant, we can already prepare the pattern and store it for later.
-	assert(arguments.size() == 2 || arguments.size() == 3);
+	D_ASSERT(arguments.size() == 2 || arguments.size() == 3);
 	RE2::Options options;
 	options.set_log_errors(false);
 	if (arguments.size() == 3) {

--- a/src/function/scalar/string/string_split.cpp
+++ b/src/function/scalar/string/string_split.cpp
@@ -260,7 +260,7 @@ static void string_split_executor(DataChunk &args, ExpressionState &state, Vecto
 		list_child->Append(*split_input);
 	}
 
-	assert(list_child->count == total_len);
+	D_ASSERT(list_child->count == total_len);
 	if (args.data[0].vector_type == VectorType::CONSTANT_VECTOR &&
 	    args.data[1].vector_type == VectorType::CONSTANT_VECTOR)
 		result.vector_type = VectorType::CONSTANT_VECTOR;

--- a/src/function/scalar/string/strip_accents.cpp
+++ b/src/function/scalar/string/strip_accents.cpp
@@ -17,7 +17,7 @@ bool StripAccentsFun::IsAscii(const char *input, idx_t n) {
 }
 
 static void strip_accents_function(DataChunk &args, ExpressionState &state, Vector &result) {
-	assert(args.column_count() == 1);
+	D_ASSERT(args.column_count() == 1);
 
 	UnaryExecutor::Execute<string_t, string_t, true>(args.data[0], result, args.size(), [&](string_t input) {
 		auto input_data = input.GetData();

--- a/src/function/scalar/string/trim.cpp
+++ b/src/function/scalar/string/trim.cpp
@@ -25,7 +25,7 @@ static void unary_trim_function(DataChunk &args, ExpressionState &state, Vector 
 		if (LTRIM) {
 			while (begin < size) {
 				const auto bytes = utf8proc_iterate(str + begin, size - begin, &codepoint);
-				assert(bytes > 0);
+				D_ASSERT(bytes > 0);
 				if (utf8proc_category(codepoint) != UTF8PROC_CATEGORY_ZS) {
 					break;
 				}
@@ -39,7 +39,7 @@ static void unary_trim_function(DataChunk &args, ExpressionState &state, Vector 
 			end = begin;
 			for (auto next = begin; next < size;) {
 				const auto bytes = utf8proc_iterate(str + next, size - next, &codepoint);
-				assert(bytes > 0);
+				D_ASSERT(bytes > 0);
 				next += bytes;
 				if (utf8proc_category(codepoint) != UTF8PROC_CATEGORY_ZS) {
 					end = next;
@@ -101,7 +101,7 @@ static void binary_trim_function(DataChunk &input, ExpressionState &state, Vecto
 			    end = begin;
 			    for (auto next = begin; next < size;) {
 				    const auto bytes = utf8proc_iterate(str + next, size - next, &codepoint);
-				    assert(bytes > 0);
+				    D_ASSERT(bytes > 0);
 				    next += bytes;
 				    if (ignored_codepoints.find(codepoint) == ignored_codepoints.end()) {
 					    end = next;

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -101,7 +101,7 @@ static unique_ptr<FunctionData> read_csv_bind(ClientContext &context, vector<Val
 		result->initial_reader = move(initial_reader);
 	} else {
 		result->sql_types = return_types;
-		assert(return_types.size() == names.size());
+		D_ASSERT(return_types.size() == names.size());
 	}
 	if (result->include_file_name) {
 		return_types.push_back(LogicalType::VARCHAR);

--- a/src/function/table/sqlite/pragma_table_info.cpp
+++ b/src/function/table/sqlite/pragma_table_info.cpp
@@ -106,7 +106,7 @@ static void pragma_table_info_table(PragmaTableOperatorData &data, TableCatalogE
 		bool not_null, pk;
 		auto index = i - data.offset;
 		auto &column = table->columns[i];
-		assert(column.oid < (idx_t)NumericLimits<int32_t>::Maximum());
+		D_ASSERT(column.oid < (idx_t)NumericLimits<int32_t>::Maximum());
 		check_constraints(table, column.oid, not_null, pk);
 
 		// return values:

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -217,8 +217,8 @@ void table_scan_pushdown_complex_filter(ClientContext &context, LogicalGet &get,
 				// bindings[1] = the index expression
 				// bindings[2] = the constant
 				auto comparison = (BoundComparisonExpression *)bindings[0];
-				assert(bindings[0]->GetExpressionClass() == ExpressionClass::BOUND_COMPARISON);
-				assert(bindings[2]->type == ExpressionType::VALUE_CONSTANT);
+				D_ASSERT(bindings[0]->GetExpressionClass() == ExpressionClass::BOUND_COMPARISON);
+				D_ASSERT(bindings[2]->type == ExpressionType::VALUE_CONSTANT);
 
 				auto constant_value = ((BoundConstantExpression *)bindings[2])->value;
 				auto comparison_type = comparison->type;
@@ -278,7 +278,7 @@ void table_scan_pushdown_complex_filter(ClientContext &context, LogicalGet &get,
 				// less than predicate
 				index_state = index->InitializeScanSinglePredicate(transaction, low_value, low_comparison_type);
 			} else {
-				assert(!high_value.is_null);
+				D_ASSERT(!high_value.is_null);
 				index_state = index->InitializeScanSinglePredicate(transaction, high_value, high_comparison_type);
 			}
 			if (index->Scan(transaction, storage, *index_state, STANDARD_VECTOR_SIZE, bind_data.result_ids)) {

--- a/src/include/duckdb/common/assert.hpp
+++ b/src/include/duckdb/common/assert.hpp
@@ -8,4 +8,15 @@
 
 #pragma once
 
+#if (defined (DUCKDB_USE_STANDARD_ASSERT) || !defined(DEBUG)) && !defined(DUCKDB_FORCE_ASSERT)
+
 #include <assert.h>
+#define D_ASSERT assert
+#else
+namespace duckdb {
+void duckdb_assert_internal(bool condition, const char *condition_name, const char *file, int linenr);
+}
+
+#define D_ASSERT(condition) duckdb::duckdb_assert_internal(bool(condition), #condition, __FILE__, __LINE__)
+
+#endif

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -26,7 +26,7 @@ inline void assert_restrict_function(void *left_start, void *left_end, void *rig
 #ifdef DEBUG
 	if (!(left_end <= right_start || right_end <= left_start)) {
 		printf("ASSERT RESTRICT FAILED: %s:%d\n", fname, linenr);
-		assert(0);
+		D_ASSERT(0);
 	}
 #endif
 }

--- a/src/include/duckdb/common/operator/numeric_binary_operators.hpp
+++ b/src/include/duckdb/common/operator/numeric_binary_operators.hpp
@@ -45,14 +45,14 @@ struct MultiplyOperator {
 
 struct DivideOperator {
 	template <class TA, class TB, class TR> static inline TR Operation(TA left, TB right) {
-		assert(right != 0); // this should be checked before!
+		D_ASSERT(right != 0); // this should be checked before!
 		return left / right;
 	}
 };
 
 struct ModuloOperator {
 	template <class TA, class TB, class TR> static inline TR Operation(TA left, TB right) {
-		assert(right != 0);
+		D_ASSERT(right != 0);
 		return left % right;
 	}
 };

--- a/src/include/duckdb/common/storage_util.hpp
+++ b/src/include/duckdb/common/storage_util.hpp
@@ -18,7 +18,7 @@ class StorageUtil {
 	//! Checksum using longitudinal redundancy check algorithm adepted from
 	//! https://en.wikipedia.org/wiki/Longitudinal_redundancy_check
 	static uint8_t CalculateCheckSum(duckdb::data_ptr buffer, size_t buffer_size) {
-		assert(buffer != nullptr && buffer_size > 0);
+		D_ASSERT(buffer != nullptr && buffer_size > 0);
 		uint8_t lrc = 0;
 		for (size_t i = 0; i != buffer_size; ++i) {
 			lrc = ((lrc + buffer[i]) & FULL_MASK);

--- a/src/include/duckdb/common/types/chunk_collection.hpp
+++ b/src/include/duckdb/common/types/chunk_collection.hpp
@@ -76,7 +76,7 @@ public:
 	//! Locates the chunk that belongs to the specific index
 	idx_t LocateChunk(idx_t index) {
 		idx_t result = index / STANDARD_VECTOR_SIZE;
-		assert(result < chunks.size());
+		D_ASSERT(result < chunks.size());
 		return result;
 	}
 

--- a/src/include/duckdb/common/types/data_chunk.hpp
+++ b/src/include/duckdb/common/types/data_chunk.hpp
@@ -49,7 +49,7 @@ public:
 		return data.size();
 	}
 	void SetCardinality(idx_t count) {
-		assert(count <= STANDARD_VECTOR_SIZE);
+		D_ASSERT(count <= STANDARD_VECTOR_SIZE);
 		this->count = count;
 	}
 	void SetCardinality(const DataChunk &other) {

--- a/src/include/duckdb/common/types/null_value.hpp
+++ b/src/include/duckdb/common/types/null_value.hpp
@@ -28,7 +28,7 @@ template <class T> inline T NullValue() {
 constexpr const char str_nil[2] = {'\200', '\0'};
 
 template <> inline const char *NullValue() {
-	assert(str_nil[0] == '\200' && str_nil[1] == '\0');
+	D_ASSERT(str_nil[0] == '\200' && str_nil[1] == '\0');
 	return str_nil;
 }
 

--- a/src/include/duckdb/common/types/numeric_helper.hpp
+++ b/src/include/duckdb/common/types/numeric_helper.hpp
@@ -127,7 +127,7 @@ struct DecimalToString {
 
 struct HugeintToStringCast {
 	static int UnsignedLength(hugeint_t value) {
-		assert(value.upper >= 0);
+		D_ASSERT(value.upper >= 0);
 		if (value.upper == 0) {
 			return NumericHelper::UnsignedLength<uint64_t>(value.lower);
 		}
@@ -237,7 +237,7 @@ struct HugeintToStringCast {
 		if (negative) {
 			*--endptr = '-';
 		}
-		assert(endptr == dataptr);
+		D_ASSERT(endptr == dataptr);
 		result.Finalize();
 		return result;
 	}

--- a/src/include/duckdb/common/types/string_heap.hpp
+++ b/src/include/duckdb/common/types/string_heap.hpp
@@ -25,7 +25,7 @@ public:
 	}
 
 	void Move(StringHeap &other) {
-		assert(!other.chunk);
+		D_ASSERT(!other.chunk);
 		other.tail = tail;
 		other.chunk = move(chunk);
 		tail = nullptr;

--- a/src/include/duckdb/common/types/string_type.hpp
+++ b/src/include/duckdb/common/types/string_type.hpp
@@ -9,8 +9,8 @@
 #pragma once
 
 #include "duckdb/common/constants.hpp"
+#include "duckdb/common/assert.hpp"
 #include <cstring>
-#include <cassert>
 
 namespace duckdb {
 
@@ -29,7 +29,7 @@ public:
 	}
 	string_t(const char *data, uint32_t len) {
 		value.inlined.length = len;
-		assert(data || GetSize() == 0);
+		D_ASSERT(data || GetSize() == 0);
 		if (IsInlined()) {
 			// zero initialize the prefix first
 			// this makes sure that strings with length smaller than 4 still have an equal prefix

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -153,22 +153,22 @@ public:
 
 struct ConstantVector {
 	static inline data_ptr_t GetData(Vector &vector) {
-		assert(vector.vector_type == VectorType::CONSTANT_VECTOR || vector.vector_type == VectorType::FLAT_VECTOR);
+		D_ASSERT(vector.vector_type == VectorType::CONSTANT_VECTOR || vector.vector_type == VectorType::FLAT_VECTOR);
 		return vector.data;
 	}
 	template <class T> static inline T *GetData(Vector &vector) {
 		return (T *)ConstantVector::GetData(vector);
 	}
 	static inline bool IsNull(const Vector &vector) {
-		assert(vector.vector_type == VectorType::CONSTANT_VECTOR);
+		D_ASSERT(vector.vector_type == VectorType::CONSTANT_VECTOR);
 		return vector.nullmask[0];
 	}
 	static inline void SetNull(Vector &vector, bool is_null) {
-		assert(vector.vector_type == VectorType::CONSTANT_VECTOR);
+		D_ASSERT(vector.vector_type == VectorType::CONSTANT_VECTOR);
 		vector.nullmask[0] = is_null;
 	}
 	static inline nullmask_t &Nullmask(Vector &vector) {
-		assert(vector.vector_type == VectorType::CONSTANT_VECTOR);
+		D_ASSERT(vector.vector_type == VectorType::CONSTANT_VECTOR);
 		return vector.nullmask;
 	}
 
@@ -178,11 +178,11 @@ struct ConstantVector {
 
 struct DictionaryVector {
 	static inline SelectionVector &SelVector(const Vector &vector) {
-		assert(vector.vector_type == VectorType::DICTIONARY_VECTOR);
+		D_ASSERT(vector.vector_type == VectorType::DICTIONARY_VECTOR);
 		return ((DictionaryBuffer &)*vector.buffer).GetSelVector();
 	}
 	static inline Vector &Child(const Vector &vector) {
-		assert(vector.vector_type == VectorType::DICTIONARY_VECTOR);
+		D_ASSERT(vector.vector_type == VectorType::DICTIONARY_VECTOR);
 		return ((VectorChildBuffer &)*vector.auxiliary).data;
 	}
 };
@@ -195,27 +195,27 @@ struct FlatVector {
 		return ConstantVector::GetData<T>(vector);
 	}
 	static inline void SetData(Vector &vector, data_ptr_t data) {
-		assert(vector.vector_type == VectorType::FLAT_VECTOR);
+		D_ASSERT(vector.vector_type == VectorType::FLAT_VECTOR);
 		vector.data = data;
 	}
 	template <class T> static inline T GetValue(Vector &vector, idx_t idx) {
-		assert(vector.vector_type == VectorType::FLAT_VECTOR);
+		D_ASSERT(vector.vector_type == VectorType::FLAT_VECTOR);
 		return FlatVector::GetData<T>(vector)[idx];
 	}
 	static inline nullmask_t &Nullmask(Vector &vector) {
-		assert(vector.vector_type == VectorType::FLAT_VECTOR);
+		D_ASSERT(vector.vector_type == VectorType::FLAT_VECTOR);
 		return vector.nullmask;
 	}
 	static inline void SetNullmask(Vector &vector, nullmask_t new_mask) {
-		assert(vector.vector_type == VectorType::FLAT_VECTOR);
+		D_ASSERT(vector.vector_type == VectorType::FLAT_VECTOR);
 		vector.nullmask = move(new_mask);
 	}
 	static inline void SetNull(Vector &vector, idx_t idx, bool value) {
-		assert(vector.vector_type == VectorType::FLAT_VECTOR);
+		D_ASSERT(vector.vector_type == VectorType::FLAT_VECTOR);
 		vector.nullmask[idx] = value;
 	}
 	static inline bool IsNull(const Vector &vector, idx_t idx) {
-		assert(vector.vector_type == VectorType::FLAT_VECTOR);
+		D_ASSERT(vector.vector_type == VectorType::FLAT_VECTOR);
 		return vector.nullmask[idx];
 	}
 
@@ -257,7 +257,7 @@ struct StructVector {
 
 struct SequenceVector {
 	static void GetSequence(const Vector &vector, int64_t &start, int64_t &increment) {
-		assert(vector.vector_type == VectorType::SEQUENCE_VECTOR);
+		D_ASSERT(vector.vector_type == VectorType::SEQUENCE_VECTOR);
 		auto data = (int64_t *)vector.buffer->GetData();
 		start = data[0];
 		increment = data[1];

--- a/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
@@ -209,7 +209,7 @@ public:
 	}
 
 	template <class STATE_TYPE, class OP> static void Combine(Vector &source, Vector &target, idx_t count) {
-		assert(source.type.id() == LogicalTypeId::POINTER && target.type.id() == LogicalTypeId::POINTER);
+		D_ASSERT(source.type.id() == LogicalTypeId::POINTER && target.type.id() == LogicalTypeId::POINTER);
 		auto sdata = FlatVector::GetData<STATE_TYPE *>(source);
 		auto tdata = FlatVector::GetData<STATE_TYPE *>(target);
 
@@ -227,7 +227,7 @@ public:
 			auto rdata = ConstantVector::GetData<RESULT_TYPE>(result);
 			OP::template Finalize<RESULT_TYPE, STATE_TYPE>(result, *sdata, rdata, ConstantVector::Nullmask(result), 0);
 		} else {
-			assert(states.vector_type == VectorType::FLAT_VECTOR);
+			D_ASSERT(states.vector_type == VectorType::FLAT_VECTOR);
 			result.vector_type = VectorType::FLAT_VECTOR;
 
 			auto sdata = FlatVector::GetData<STATE_TYPE *>(states);

--- a/src/include/duckdb/common/vector_operations/binary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/binary_executor.hpp
@@ -270,7 +270,7 @@ public:
 			return SelectFlatLoop<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT, NO_NULL, true, false>(
 			    ldata, rdata, sel, count, nullmask, true_sel, false_sel);
 		} else {
-			assert(false_sel);
+			D_ASSERT(false_sel);
 			return SelectFlatLoop<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT, NO_NULL, false, true>(
 			    ldata, rdata, sel, count, nullmask, true_sel, false_sel);
 		}
@@ -356,7 +356,7 @@ public:
 			return SelectGenericLoop<LEFT_TYPE, RIGHT_TYPE, OP, NO_NULL, true, false>(
 			    ldata, rdata, lsel, rsel, result_sel, count, lnullmask, rnullmask, true_sel, false_sel);
 		} else {
-			assert(false_sel);
+			D_ASSERT(false_sel);
 			return SelectGenericLoop<LEFT_TYPE, RIGHT_TYPE, OP, NO_NULL, false, true>(
 			    ldata, rdata, lsel, rsel, result_sel, count, lnullmask, rnullmask, true_sel, false_sel);
 		}

--- a/src/include/duckdb/common/vector_operations/ternary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/ternary_executor.hpp
@@ -119,7 +119,7 @@ private:
 			    (A_TYPE *)adata.data, (B_TYPE *)bdata.data, (C_TYPE *)cdata.data, sel, count, *adata.sel, *bdata.sel,
 			    *cdata.sel, *adata.nullmask, *bdata.nullmask, *cdata.nullmask, true_sel, false_sel);
 		} else {
-			assert(false_sel);
+			D_ASSERT(false_sel);
 			return SelectLoop<A_TYPE, B_TYPE, C_TYPE, OP, NO_NULL, false, true>(
 			    (A_TYPE *)adata.data, (B_TYPE *)bdata.data, (C_TYPE *)cdata.data, sel, count, *adata.sel, *bdata.sel,
 			    *cdata.sel, *adata.nullmask, *bdata.nullmask, *cdata.nullmask, true_sel, false_sel);

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -122,25 +122,25 @@ public:
 
 	template <class STATE, class T, class OP>
 	static void UnaryScatterUpdate(Vector inputs[], idx_t input_count, Vector &states, idx_t count) {
-		assert(input_count == 1);
+		D_ASSERT(input_count == 1);
 		AggregateExecutor::UnaryScatter<STATE, T, OP>(inputs[0], states, count);
 	}
 
 	template <class STATE, class INPUT_TYPE, class OP>
 	static void UnaryUpdate(Vector inputs[], idx_t input_count, data_ptr_t state, idx_t count) {
-		assert(input_count == 1);
+		D_ASSERT(input_count == 1);
 		AggregateExecutor::UnaryUpdate<STATE, INPUT_TYPE, OP>(inputs[0], state, count);
 	}
 
 	template <class STATE, class A_TYPE, class B_TYPE, class OP>
 	static void BinaryScatterUpdate(Vector inputs[], idx_t input_count, Vector &states, idx_t count) {
-		assert(input_count == 2);
+		D_ASSERT(input_count == 2);
 		AggregateExecutor::BinaryScatter<STATE, A_TYPE, B_TYPE, OP>(inputs[0], inputs[1], states, count);
 	}
 
 	template <class STATE, class A_TYPE, class B_TYPE, class OP>
 	static void BinaryUpdate(Vector inputs[], idx_t input_count, data_ptr_t state, idx_t count) {
-		assert(input_count == 2);
+		D_ASSERT(input_count == 2);
 		AggregateExecutor::BinaryUpdate<STATE, A_TYPE, B_TYPE, OP>(inputs[0], inputs[1], state, count);
 	}
 

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -87,19 +87,19 @@ private:
 
 public:
 	static void NopFunction(DataChunk &input, ExpressionState &state, Vector &result) {
-		assert(input.column_count() >= 1);
+		D_ASSERT(input.column_count() >= 1);
 		result.Reference(input.data[0]);
 	}
 
 	template <class TA, class TR, class OP, bool SKIP_NULLS = false>
 	static void UnaryFunction(DataChunk &input, ExpressionState &state, Vector &result) {
-		assert(input.column_count() >= 1);
+		D_ASSERT(input.column_count() >= 1);
 		UnaryExecutor::Execute<TA, TR, OP, SKIP_NULLS>(input.data[0], result, input.size());
 	}
 
 	template <class TA, class TB, class TR, class OP, bool IGNORE_NULL = false>
 	static void BinaryFunction(DataChunk &input, ExpressionState &state, Vector &result) {
-		assert(input.column_count() == 2);
+		D_ASSERT(input.column_count() == 2);
 		BinaryExecutor::ExecuteStandard<TA, TB, TR, OP, IGNORE_NULL>(input.data[0], input.data[1], result,
 		                                                             input.size());
 	}

--- a/src/include/duckdb/function/udf_function.hpp
+++ b/src/include/duckdb/function/udf_function.hpp
@@ -141,7 +141,7 @@ private:
 	//-------------------------------- Templated functions --------------------------------//
 	template <typename TR, typename... Args>
 	static scalar_function_t CreateUnaryFunction(string name, TR (*udf_func)(Args...)) {
-		assert(sizeof...(Args) == 1);
+		D_ASSERT(sizeof...(Args) == 1);
 		return CreateUnaryFunction<TR, Args...>(name, udf_func);
 	}
 
@@ -154,7 +154,7 @@ private:
 
 	template <typename TR, typename... Args>
 	static scalar_function_t CreateBinaryFunction(string name, TR (*udf_func)(Args...)) {
-		assert(sizeof...(Args) == 2);
+		D_ASSERT(sizeof...(Args) == 2);
 		return CreateBinaryFunction<TR, Args...>(name, udf_func);
 	}
 
@@ -168,7 +168,7 @@ private:
 
 	template <typename TR, typename... Args>
 	static scalar_function_t CreateTernaryFunction(string name, TR (*udf_func)(Args...)) {
-		assert(sizeof...(Args) == 3);
+		D_ASSERT(sizeof...(Args) == 3);
 		return CreateTernaryFunction<TR, Args...>(name, udf_func);
 	}
 
@@ -220,7 +220,7 @@ private:
 	template <typename TR, typename... Args>
 	static scalar_function_t CreateUnaryFunction(string name, vector<LogicalType> args, LogicalType ret_type,
 	                                             TR (*udf_func)(Args...)) {
-		assert(sizeof...(Args) == 1);
+		D_ASSERT(sizeof...(Args) == 1);
 		return CreateUnaryFunction<TR, Args...>(name, args, ret_type, udf_func);
 	}
 
@@ -244,7 +244,7 @@ private:
 	template <typename TR, typename... Args>
 	static scalar_function_t CreateBinaryFunction(string name, vector<LogicalType> args, LogicalType ret_type,
 	                                              TR (*udf_func)(Args...)) {
-		assert(sizeof...(Args) == 2);
+		D_ASSERT(sizeof...(Args) == 2);
 		return CreateBinaryFunction<TR, Args...>(name, args, ret_type, udf_func);
 	}
 
@@ -272,7 +272,7 @@ private:
 	template <typename TR, typename... Args>
 	static scalar_function_t CreateTernaryFunction(string name, vector<LogicalType> args, LogicalType ret_type,
 	                                               TR (*udf_func)(Args...)) {
-		assert(sizeof...(Args) == 3);
+		D_ASSERT(sizeof...(Args) == 3);
 		return CreateTernaryFunction<TR, Args...>(name, args, ret_type, udf_func);
 	}
 

--- a/src/include/duckdb/parser/parsed_data/create_function_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_function_info.hpp
@@ -15,7 +15,7 @@ namespace duckdb {
 
 struct CreateFunctionInfo : public CreateInfo {
 	CreateFunctionInfo(CatalogType type) : CreateInfo(type) {
-		assert(type == CatalogType::SCALAR_FUNCTION_ENTRY || type == CatalogType::AGGREGATE_FUNCTION_ENTRY ||
+		D_ASSERT(type == CatalogType::SCALAR_FUNCTION_ENTRY || type == CatalogType::AGGREGATE_FUNCTION_ENTRY ||
 		       type == CatalogType::TABLE_FUNCTION_ENTRY || type == CatalogType::PRAGMA_FUNCTION_ENTRY);
 	}
 

--- a/src/include/duckdb/parser/qualified_name.hpp
+++ b/src/include/duckdb/parser/qualified_name.hpp
@@ -17,4 +17,13 @@ struct QualifiedName {
 	string name;
 };
 
+struct QualifiedColumnName {
+	QualifiedColumnName(){}
+	QualifiedColumnName(string table_p, string column_p) : table(move(table_p)), column(move(column_p)) {}
+
+	string schema;
+	string table;
+	string column;
+};
+
 } // namespace duckdb

--- a/src/include/duckdb/parser/qualified_name_set.hpp
+++ b/src/include/duckdb/parser/qualified_name_set.hpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/qualified_name_set.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/parser/qualified_name.hpp"
+#include "duckdb/common/types/hash.hpp"
+#include "duckdb/common/unordered_set.hpp"
+
+namespace duckdb {
+
+struct QualifiedColumnHashFunction {
+	uint64_t operator()(const QualifiedColumnName &a) const {
+		std::hash<std::string> str_hasher;
+		return str_hasher(a.schema) ^ str_hasher(a.table) ^ str_hasher(a.column);
+	}
+};
+
+struct QualifiedColumnEquality {
+	bool operator()(const QualifiedColumnName &a, const QualifiedColumnName &b) const {
+		return a.schema == b.schema && a.table == b.table && a.column == b.column;
+	}
+};
+
+using qualified_column_set_t = unordered_set<QualifiedColumnName, QualifiedColumnHashFunction, QualifiedColumnEquality>;
+
+} // namespace duckdb

--- a/src/include/duckdb/parser/tableref/joinref.hpp
+++ b/src/include/duckdb/parser/tableref/joinref.hpp
@@ -18,7 +18,7 @@ namespace duckdb {
 //! Represents a JOIN between two expressions
 class JoinRef : public TableRef {
 public:
-	JoinRef() : TableRef(TableReferenceType::JOIN) {
+	JoinRef() : TableRef(TableReferenceType::JOIN), is_natural(false) {
 	}
 
 	//! The left hand side of the join
@@ -29,6 +29,8 @@ public:
 	unique_ptr<ParsedExpression> condition;
 	//! The join type
 	JoinType type;
+	//! Natural join
+	bool is_natural;
 	//! The set of USING columns (if any)
 	vector<string> using_columns;
 

--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -46,6 +46,9 @@ public:
 	//! referenced tables. This is used to resolve the * expression in a
 	//! selection list.
 	void GenerateAllColumnExpressions(vector<unique_ptr<ParsedExpression>> &new_select_list, string relation_name = "");
+	const vector<std::pair<string, Binding *>>& GetBindingsList() {
+		return bindings_list;
+	}
 
 	//! Adds a base table with the given alias to the BindContext.
 	void AddBaseTable(idx_t index, const string &alias, vector<string> names, vector<LogicalType> types, LogicalGet &get);
@@ -82,6 +85,7 @@ private:
 	//! Gets a binding of the specified name. Returns a nullptr and sets the out_error if the binding could not be
 	//! found.
 	Binding *GetBinding(const string &name, string &out_error);
+	void GenerateAllColumnExpressions(vector<unique_ptr<ParsedExpression>> &new_select_list, Binding *binding);
 
 	//! The set of bindings
 	unordered_map<string, unique_ptr<Binding>> bindings;

--- a/src/include/duckdb/planner/operator/logical_chunk_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_chunk_get.hpp
@@ -18,7 +18,7 @@ class LogicalChunkGet : public LogicalOperator {
 public:
 	LogicalChunkGet(idx_t table_index, vector<LogicalType> types, unique_ptr<ChunkCollection> collection)
 	    : LogicalOperator(LogicalOperatorType::CHUNK_GET), table_index(table_index), collection(move(collection)) {
-		assert(types.size() > 0);
+		D_ASSERT(types.size() > 0);
 		chunk_types = types;
 	}
 

--- a/src/include/duckdb/planner/operator/logical_cteref.hpp
+++ b/src/include/duckdb/planner/operator/logical_cteref.hpp
@@ -18,7 +18,7 @@ class LogicalCTERef : public LogicalOperator {
 public:
 	LogicalCTERef(idx_t table_index, idx_t cte_index, vector<LogicalType> types, vector<string> colnames)
 	    : LogicalOperator(LogicalOperatorType::CTE_REF), table_index(table_index), cte_index(cte_index) {
-		assert(types.size() > 0);
+		D_ASSERT(types.size() > 0);
 		chunk_types = types;
 		bound_columns = colnames;
 	}

--- a/src/include/duckdb/planner/operator/logical_delim_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_delim_get.hpp
@@ -17,7 +17,7 @@ class LogicalDelimGet : public LogicalOperator {
 public:
 	LogicalDelimGet(idx_t table_index, vector<LogicalType> types)
 	    : LogicalOperator(LogicalOperatorType::DELIM_GET), table_index(table_index) {
-		assert(types.size() > 0);
+		D_ASSERT(types.size() > 0);
 		chunk_types = types;
 	}
 

--- a/src/include/duckdb/planner/operator/logical_execute.hpp
+++ b/src/include/duckdb/planner/operator/logical_execute.hpp
@@ -17,7 +17,7 @@ class LogicalExecute : public LogicalOperator {
 public:
 	LogicalExecute(PreparedStatementData *prepared)
 	    : LogicalOperator(LogicalOperatorType::EXECUTE), prepared(prepared) {
-		assert(prepared);
+		D_ASSERT(prepared);
 		types = prepared->types;
 	}
 

--- a/src/include/duckdb/planner/operator/logical_recursive_cte.hpp
+++ b/src/include/duckdb/planner/operator/logical_recursive_cte.hpp
@@ -17,7 +17,7 @@ public:
 	LogicalRecursiveCTE(idx_t table_index, idx_t column_count, bool union_all, unique_ptr<LogicalOperator> top,
 	                    unique_ptr<LogicalOperator> bottom, LogicalOperatorType type)
 	    : LogicalOperator(type), union_all(union_all), table_index(table_index), column_count(column_count) {
-		assert(type == LogicalOperatorType::RECURSIVE_CTE);
+		D_ASSERT(type == LogicalOperatorType::RECURSIVE_CTE);
 		children.push_back(move(top));
 		children.push_back(move(bottom));
 	}

--- a/src/include/duckdb/planner/operator/logical_set_operation.hpp
+++ b/src/include/duckdb/planner/operator/logical_set_operation.hpp
@@ -17,7 +17,7 @@ public:
 	LogicalSetOperation(idx_t table_index, idx_t column_count, unique_ptr<LogicalOperator> top,
 	                    unique_ptr<LogicalOperator> bottom, LogicalOperatorType type)
 	    : LogicalOperator(type), table_index(table_index), column_count(column_count) {
-		assert(type == LogicalOperatorType::UNION || type == LogicalOperatorType::EXCEPT ||
+		D_ASSERT(type == LogicalOperatorType::UNION || type == LogicalOperatorType::EXCEPT ||
 		       type == LogicalOperatorType::INTERSECT);
 		children.push_back(move(top));
 		children.push_back(move(bottom));

--- a/src/include/duckdb/planner/table_binding.hpp
+++ b/src/include/duckdb/planner/table_binding.hpp
@@ -42,7 +42,6 @@ struct Binding {
 public:
 	bool HasMatchingBinding(const string &column_name);
 	virtual BindResult Bind(ColumnRefExpression &colref, idx_t depth);
-	void GenerateAllColumnExpressions(BindContext &context, vector<unique_ptr<ParsedExpression>> &select_list);
 };
 
 //! TableBinding is exactly like the Binding, except it keeps track of which columns were bound in the linked LogicalGet

--- a/src/include/duckdb/planner/tableref/bound_crossproductref.hpp
+++ b/src/include/duckdb/planner/tableref/bound_crossproductref.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/bound_tableref.hpp"
 
 namespace duckdb {
@@ -18,6 +19,10 @@ public:
 	BoundCrossProductRef() : BoundTableRef(TableReferenceType::CROSS_PRODUCT) {
 	}
 
+	//! The binder used to bind the LHS of the cross product
+	unique_ptr<Binder> left_binder;
+	//! The binder used to bind the RHS of the cross product
+	unique_ptr<Binder> right_binder;
 	//! The left hand side of the cross product
 	unique_ptr<BoundTableRef> left;
 	//! The right hand side of the cross product

--- a/src/include/duckdb/planner/tableref/bound_joinref.hpp
+++ b/src/include/duckdb/planner/tableref/bound_joinref.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/planner/binder.hpp"
 #include "duckdb/common/enums/join_type.hpp"
 #include "duckdb/planner/bound_tableref.hpp"
 #include "duckdb/planner/expression.hpp"
@@ -20,6 +21,10 @@ public:
 	BoundJoinRef() : BoundTableRef(TableReferenceType::JOIN) {
 	}
 
+	//! The binder used to bind the LHS of the join
+	unique_ptr<Binder> left_binder;
+	//! The binder used to bind the RHS of the join
+	unique_ptr<Binder> right_binder;
 	//! The left hand side of the join
 	unique_ptr<BoundTableRef> left;
 	//! The right hand side of the join

--- a/src/include/duckdb/storage/uncompressed_segment.hpp
+++ b/src/include/duckdb/storage/uncompressed_segment.hpp
@@ -90,8 +90,8 @@ public:
 
 	//! Get the amount of tuples in a vector
 	idx_t GetVectorCount(idx_t vector_index) {
-		assert(vector_index < max_vector_count);
-		assert(vector_index * STANDARD_VECTOR_SIZE <= tuple_count);
+		D_ASSERT(vector_index < max_vector_count);
+		D_ASSERT(vector_index * STANDARD_VECTOR_SIZE <= tuple_count);
 		return MinValue<idx_t>(STANDARD_VECTOR_SIZE, tuple_count - vector_index * STANDARD_VECTOR_SIZE);
 	}
 

--- a/src/include/duckdb/transaction/transaction_context.hpp
+++ b/src/include/duckdb/transaction/transaction_context.hpp
@@ -27,7 +27,7 @@ public:
 	~TransactionContext();
 
 	Transaction &ActiveTransaction() {
-		assert(current_transaction);
+		D_ASSERT(current_transaction);
 		return *current_transaction;
 	}
 

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -200,7 +200,7 @@ void Appender::Invalidate(string msg, bool close) {
 	if (close) {
 		con.context->RemoveAppender(this);
 	}
-	assert(!msg.empty());
+	D_ASSERT(!msg.empty());
 	invalidated_msg = msg;
 }
 } // namespace duckdb

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -70,7 +70,7 @@ unique_ptr<QueryResult> Connection::SendQuery(string query) {
 
 unique_ptr<MaterializedQueryResult> Connection::Query(string query) {
 	auto result = context->Query(query, false);
-	assert(result->type == QueryResultType::MATERIALIZED_RESULT);
+	D_ASSERT(result->type == QueryResultType::MATERIALIZED_RESULT);
 	return unique_ptr_cast<QueryResult, MaterializedQueryResult>(move(result));
 }
 

--- a/src/main/connection_manager.cpp
+++ b/src/main/connection_manager.cpp
@@ -14,13 +14,13 @@ ConnectionManager::~ConnectionManager() {
 }
 
 void ConnectionManager::AddConnection(Connection *conn) {
-	assert(conn);
+	D_ASSERT(conn);
 	std::lock_guard<std::mutex> lock(connections_lock);
 	connections.insert(conn);
 }
 
 void ConnectionManager::RemoveConnection(Connection *conn) {
-	assert(conn);
+	D_ASSERT(conn);
 	std::lock_guard<std::mutex> lock(connections_lock);
 	connections.erase(conn);
 }

--- a/src/main/duckdb-c.cpp
+++ b/src/main/duckdb-c.cpp
@@ -85,7 +85,7 @@ template <class T> void WriteData(duckdb_result *out, ChunkCollection &source, i
 }
 
 static duckdb_state duckdb_translate_result(MaterializedQueryResult *result, duckdb_result *out) {
-	assert(result);
+	D_ASSERT(result);
 	if (!out) {
 		// no result to write to, only return the status
 		return result->success ? DuckDBSuccess : DuckDBError;
@@ -266,7 +266,7 @@ static duckdb_state duckdb_translate_result(MaterializedQueryResult *result, duc
 		}
 		default:
 			// unsupported type for C API
-			assert(0);
+			D_ASSERT(0);
 			return DuckDBError;
 		}
 	}
@@ -400,7 +400,7 @@ duckdb_state duckdb_execute_prepared(duckdb_prepared_statement prepared_statemen
 		return DuckDBError;
 	}
 	auto result = wrapper->statement->Execute(wrapper->values, false);
-	assert(result->type == QueryResultType::MATERIALIZED_RESULT);
+	D_ASSERT(result->type == QueryResultType::MATERIALIZED_RESULT);
 	auto mat_res = (MaterializedQueryResult *)result.get();
 	return duckdb_translate_result(mat_res, out_result);
 }
@@ -479,13 +479,13 @@ idx_t GetCTypeSize(duckdb_type type) {
 		return sizeof(duckdb_interval);
 	default:
 		// unsupported type
-		assert(0);
+		D_ASSERT(0);
 		return sizeof(const char *);
 	}
 }
 
 template <class T> T UnsafeFetch(duckdb_result *result, idx_t col, idx_t row) {
-	assert(row < result->row_count);
+	D_ASSERT(row < result->row_count);
 	return ((T *)result->columns[col].data)[row];
 }
 
@@ -546,7 +546,7 @@ static Value GetCValue(duckdb_result *result, idx_t col, idx_t row) {
 		return Value(string(UnsafeFetch<const char *>(result, col, row)));
 	default:
 		// invalid type for C to C++ conversion
-		assert(0);
+		D_ASSERT(0);
 		return Value();
 	}
 }

--- a/src/main/prepared_statement.cpp
+++ b/src/main/prepared_statement.cpp
@@ -20,7 +20,7 @@ PreparedStatement::PreparedStatement(string error)
 
 PreparedStatement::~PreparedStatement() {
 	if (!is_invalidated && success) {
-		assert(context);
+		D_ASSERT(context);
 		context->RemovePreparedStatement(this);
 	}
 }
@@ -33,7 +33,7 @@ unique_ptr<QueryResult> PreparedStatement::Execute(vector<Value> &values, bool a
 		return make_unique<MaterializedQueryResult>(
 		    "Cannot execute prepared statement: underlying database or connection has been destroyed");
 	}
-	assert(context);
+	D_ASSERT(context);
 	return context->Execute(name, values, allow_stream_result, query);
 }
 

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -125,7 +125,7 @@ void QueryProfiler::EndPhase() {
 	if (!enabled || !running) {
 		return;
 	}
-	assert(phase_stack.size() > 0);
+	D_ASSERT(phase_stack.size() > 0);
 
 	// end the timer
 	phase_profiler.End();
@@ -189,7 +189,7 @@ void OperatorProfiler::EndOperator(DataChunk *chunk) {
 
 	AddTiming(execution_stack.top(), op.Elapsed(), chunk ? chunk->size() : 0);
 
-	assert(!execution_stack.empty());
+	D_ASSERT(!execution_stack.empty());
 	execution_stack.pop();
 
 	// start timing again for the previous element, if any
@@ -221,7 +221,7 @@ void QueryProfiler::Flush(OperatorProfiler &profiler) {
 
 	for (auto &node : profiler.timings) {
 		auto entry = tree_map.find(node.first);
-		assert(entry != tree_map.end());
+		D_ASSERT(entry != tree_map.end());
 
 		entry->second->info.time += node.second.time;
 		entry->second->info.elements += node.second.elements;
@@ -444,7 +444,7 @@ vector<QueryProfiler::PhaseTimingItem> QueryProfiler::GetOrderedPhaseTimings() c
 	std::sort(phases.begin(), phases.end());
 	for (const auto &phase : phases) {
 		auto entry = phase_timings.find(phase);
-		assert(entry != phase_timings.end());
+		D_ASSERT(entry != phase_timings.end());
 		result.emplace_back(entry->first, entry->second);
 	}
 	return result;

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -12,7 +12,7 @@ QueryResult::QueryResult(QueryResultType type, StatementType statement_type)
 QueryResult::QueryResult(QueryResultType type, StatementType statement_type, vector<LogicalType> types,
                          vector<string> names)
     : type(type), statement_type(statement_type), types(move(types)), names(move(names)), success(true) {
-	assert(types.size() == names.size());
+	D_ASSERT(types.size() == names.size());
 }
 
 QueryResult::QueryResult(QueryResultType type, string error) : type(type), success(false), error(error) {
@@ -45,7 +45,7 @@ bool QueryResult::Equals(QueryResult &other) {
 		if (lchunk->size() != rchunk->size()) {
 			return false;
 		}
-		assert(lchunk->column_count() == rchunk->column_count());
+		D_ASSERT(lchunk->column_count() == rchunk->column_count());
 		for (idx_t col = 0; col < rchunk->column_count(); col++) {
 			for (idx_t row = 0; row < rchunk->size(); row++) {
 				auto lvalue = lchunk->GetValue(col, row);
@@ -92,7 +92,7 @@ static void release_duckdb_arrow_schema(ArrowSchema *schema) {
 }
 
 void QueryResult::ToArrowSchema(ArrowSchema *out_schema) {
-	assert(out_schema);
+	D_ASSERT(out_schema);
 
 	auto root_holder = new DuckDBArrowSchemaHolder();
 

--- a/src/main/relation/aggregate_relation.cpp
+++ b/src/main/relation/aggregate_relation.cpp
@@ -36,7 +36,7 @@ unique_ptr<QueryNode> AggregateRelation::GetQueryNode() {
 		select->from_table = child->GetTableRef();
 		result = move(select);
 	}
-	assert(result->type == QueryNodeType::SELECT_NODE);
+	D_ASSERT(result->type == QueryNodeType::SELECT_NODE);
 	auto &select_node = (SelectNode &)*result;
 	if (groups.size() > 0) {
 		// explicit groups provided: use standard handling

--- a/src/main/relation/filter_relation.cpp
+++ b/src/main/relation/filter_relation.cpp
@@ -21,7 +21,7 @@ unique_ptr<QueryNode> FilterRelation::GetQueryNode() {
 	if (child_ptr->type == RelationType::JOIN_RELATION) {
 		// child node is a join: push filter into WHERE clause of select node
 		auto child_node = child->GetQueryNode();
-		assert(child_node->type == QueryNodeType::SELECT_NODE);
+		D_ASSERT(child_node->type == QueryNodeType::SELECT_NODE);
 		auto &select_node = (SelectNode &)*child_node;
 		if (!select_node.where_clause) {
 			select_node.where_clause = condition->Copy();

--- a/src/main/relation/projection_relation.cpp
+++ b/src/main/relation/projection_relation.cpp
@@ -36,7 +36,7 @@ unique_ptr<QueryNode> ProjectionRelation::GetQueryNode() {
 		select->from_table = child->GetTableRef();
 		result = move(select);
 	}
-	assert(result->type == QueryNodeType::SELECT_NODE);
+	D_ASSERT(result->type == QueryNodeType::SELECT_NODE);
 	auto &select_node = (SelectNode &)*result;
 	select_node.aggregate_handling = AggregateHandling::NO_AGGREGATES_ALLOWED;
 	select_node.select_list.clear();

--- a/src/main/relation/update_relation.cpp
+++ b/src/main/relation/update_relation.cpp
@@ -11,7 +11,7 @@ UpdateRelation::UpdateRelation(ClientContext &context, unique_ptr<ParsedExpressi
                                vector<unique_ptr<ParsedExpression>> expressions_p)
     : Relation(context, RelationType::UPDATE_RELATION), condition(move(condition_p)), schema_name(move(schema_name_p)),
       table_name(move(table_name_p)), update_columns(move(update_columns_p)), expressions(move(expressions_p)) {
-	assert(update_columns.size() == expressions.size());
+	D_ASSERT(update_columns.size() == expressions.size());
 	context.TryBindRelation(*this, this->columns);
 }
 

--- a/src/main/relation/value_relation.cpp
+++ b/src/main/relation/value_relation.cpp
@@ -48,7 +48,7 @@ unique_ptr<TableRef> ValueRelation::GetTableRef() {
 		for (idx_t i = 0; i < columns.size(); i++) {
 			table_ref->expected_names.push_back(columns[i].name);
 			table_ref->expected_types.push_back(columns[i].type);
-			assert(names.size() == 0 || columns[i].name == names[i]);
+			D_ASSERT(names.size() == 0 || columns[i].name == names[i]);
 		}
 	}
 	// copy the expressions

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -25,14 +25,14 @@ Expression *FilterCombiner::GetNode(Expression *expr) {
 	// expression does not exist yet: create a copy and store it
 	auto copy = expr->Copy();
 	auto pointer_copy = copy.get();
-	assert(stored_expressions.find(pointer_copy) == stored_expressions.end());
+	D_ASSERT(stored_expressions.find(pointer_copy) == stored_expressions.end());
 	stored_expressions.insert(make_pair(pointer_copy, move(copy)));
 	return pointer_copy;
 }
 
 idx_t FilterCombiner::GetEquivalenceSet(Expression *expr) {
-	assert(stored_expressions.find(expr) != stored_expressions.end());
-	assert(stored_expressions.find(expr)->second.get() == expr);
+	D_ASSERT(stored_expressions.find(expr) != stored_expressions.end());
+	D_ASSERT(stored_expressions.find(expr)->second.get() == expr);
 
 	auto entry = equivalence_set_map.find(expr);
 	if (entry == equivalence_set_map.end()) {
@@ -279,7 +279,7 @@ FilterResult FilterCombiner::AddFilter(Expression *expr) {
 			return FilterResult::SUCCESS;
 		}
 	}
-	assert(!expr->IsFoldable());
+	D_ASSERT(!expr->IsFoldable());
 	if (expr->GetExpressionClass() == ExpressionClass::BOUND_BETWEEN) {
 		auto &comparison = (BoundBetweenExpression &)*expr;
 		//! check if one of the sides is a scalar value
@@ -302,7 +302,7 @@ FilterResult FilterCombiner::AddFilter(Expression *expr) {
 			info.constant = constant_value;
 
 			// get the current bucket of constant values
-			assert(constant_values.find(equivalence_set) != constant_values.end());
+			D_ASSERT(constant_values.find(equivalence_set) != constant_values.end());
 			auto &info_list = constant_values.find(equivalence_set)->second;
 			// check the existing constant comparisons to see if we can do any pruning
 			AddConstantComparison(info_list, info);
@@ -318,7 +318,7 @@ FilterResult FilterCombiner::AddFilter(Expression *expr) {
 			info.constant = constant_value;
 
 			// get the current bucket of constant values
-			assert(constant_values.find(equivalence_set) != constant_values.end());
+			D_ASSERT(constant_values.find(equivalence_set) != constant_values.end());
 			// check the existing constant comparisons to see if we can do any pruning
 			return AddConstantComparison(constant_values.find(equivalence_set)->second, info);
 		}
@@ -348,7 +348,7 @@ FilterResult FilterCombiner::AddFilter(Expression *expr) {
 			info.constant = constant_value;
 
 			// get the current bucket of constant values
-			assert(constant_values.find(equivalence_set) != constant_values.end());
+			D_ASSERT(constant_values.find(equivalence_set) != constant_values.end());
 			auto &info_list = constant_values.find(equivalence_set)->second;
 			// check the existing constant comparisons to see if we can do any pruning
 			auto ret = AddConstantComparison(info_list, info);
@@ -387,8 +387,8 @@ FilterResult FilterCombiner::AddFilter(Expression *expr) {
 				return FilterResult::SUCCESS;
 			}
 			// add the right bucket into the left bucket
-			assert(equivalence_map.find(left_equivalence_set) != equivalence_map.end());
-			assert(equivalence_map.find(right_equivalence_set) != equivalence_map.end());
+			D_ASSERT(equivalence_map.find(left_equivalence_set) != equivalence_map.end());
+			D_ASSERT(equivalence_map.find(right_equivalence_set) != equivalence_map.end());
 
 			auto &left_bucket = equivalence_map.find(left_equivalence_set)->second;
 			auto &right_bucket = equivalence_map.find(right_equivalence_set)->second;
@@ -399,8 +399,8 @@ FilterResult FilterCombiner::AddFilter(Expression *expr) {
 				left_bucket.push_back(right_bucket[i]);
 			}
 			// now add all constant values from the right bucket to the left bucket
-			assert(constant_values.find(left_equivalence_set) != constant_values.end());
-			assert(constant_values.find(right_equivalence_set) != constant_values.end());
+			D_ASSERT(constant_values.find(left_equivalence_set) != constant_values.end());
+			D_ASSERT(constant_values.find(right_equivalence_set) != constant_values.end());
 			auto &left_constant_bucket = constant_values.find(left_equivalence_set)->second;
 			auto &right_constant_bucket = constant_values.find(right_equivalence_set)->second;
 			for (idx_t i = 0; i < right_constant_bucket.size(); i++) {
@@ -421,7 +421,7 @@ FilterResult FilterCombiner::AddFilter(Expression *expr) {
 * It's missing to create another method to add transitive filters from scalar filters, e.g, i > 10
 */
 FilterResult FilterCombiner::AddTransitiveFilters(BoundComparisonExpression &comparison) {
-	assert(IsGreaterThan(comparison.type) || IsLessThan(comparison.type));
+	D_ASSERT(IsGreaterThan(comparison.type) || IsLessThan(comparison.type));
 	// get the LHS and RHS nodes
 	Expression *left_node = GetNode(comparison.left.get());
 	Expression *right_node = GetNode(comparison.right.get());
@@ -559,7 +559,7 @@ ValueComparisonResult CompareValueInformation(ExpressionValueInformation &left, 
 			prune_right_side = left.constant != right.constant;
 			break;
 		default:
-			assert(right.comparison_type == ExpressionType::COMPARE_EQUAL);
+			D_ASSERT(right.comparison_type == ExpressionType::COMPARE_EQUAL);
 			prune_right_side = left.constant == right.constant;
 			break;
 		}
@@ -590,7 +590,7 @@ ValueComparisonResult CompareValueInformation(ExpressionValueInformation &left, 
 			prune_left_side = left.constant < right.constant;
 			break;
 		default:
-			assert(right.comparison_type == ExpressionType::COMPARE_NOTEQUAL);
+			D_ASSERT(right.comparison_type == ExpressionType::COMPARE_NOTEQUAL);
 			prune_left_side = left.constant == right.constant;
 			break;
 		}
@@ -644,7 +644,7 @@ ValueComparisonResult CompareValueInformation(ExpressionValueInformation &left, 
 			}
 		}
 	} else if (IsLessThan(left.comparison_type)) {
-		assert(IsGreaterThan(right.comparison_type));
+		D_ASSERT(IsGreaterThan(right.comparison_type));
 		// left is [<] and right is [>], in this case we can either
 		// (1) prune nothing or
 		// (2) return UNSATISFIABLE
@@ -656,7 +656,7 @@ ValueComparisonResult CompareValueInformation(ExpressionValueInformation &left, 
 		}
 	} else {
 		// left is [>] and right is [<] or [!=]
-		assert(IsLessThan(right.comparison_type) && IsGreaterThan(left.comparison_type));
+		D_ASSERT(IsLessThan(right.comparison_type) && IsGreaterThan(left.comparison_type));
 		return InvertValueComparisonResult(CompareValueInformation(right, left));
 	}
 }

--- a/src/optimizer/filter_pushdown.cpp
+++ b/src/optimizer/filter_pushdown.cpp
@@ -10,7 +10,7 @@ using namespace std;
 using Filter = FilterPushdown::Filter;
 
 unique_ptr<LogicalOperator> FilterPushdown::Rewrite(unique_ptr<LogicalOperator> op) {
-	assert(!combiner.HasFilters());
+	D_ASSERT(!combiner.HasFilters());
 	switch (op->type) {
 	case LogicalOperatorType::AGGREGATE_AND_GROUP_BY:
 		return PushdownAggregate(move(op));
@@ -42,7 +42,7 @@ unique_ptr<LogicalOperator> FilterPushdown::Rewrite(unique_ptr<LogicalOperator> 
 }
 
 unique_ptr<LogicalOperator> FilterPushdown::PushdownJoin(unique_ptr<LogicalOperator> op) {
-	assert(op->type == LogicalOperatorType::COMPARISON_JOIN || op->type == LogicalOperatorType::ANY_JOIN ||
+	D_ASSERT(op->type == LogicalOperatorType::COMPARISON_JOIN || op->type == LogicalOperatorType::ANY_JOIN ||
 	       op->type == LogicalOperatorType::DELIM_JOIN);
 	auto &join = (LogicalJoin &)*op;
 	unordered_set<idx_t> left_bindings, right_bindings;
@@ -66,7 +66,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownJoin(unique_ptr<LogicalOpera
 void FilterPushdown::PushFilters() {
 	for (auto &f : filters) {
 		auto result = combiner.AddFilter(move(f->filter));
-		assert(result == FilterResult::SUCCESS);
+		D_ASSERT(result == FilterResult::SUCCESS);
 		(void)result;
 	}
 	filters.clear();
@@ -88,7 +88,7 @@ FilterResult FilterPushdown::AddFilter(unique_ptr<Expression> expr) {
 
 void FilterPushdown::GenerateFilters() {
 	if (filters.size() > 0) {
-		assert(!combiner.HasFilters());
+		D_ASSERT(!combiner.HasFilters());
 		return;
 	}
 	combiner.GenerateFilters([&](unique_ptr<Expression> filter) {

--- a/src/optimizer/in_clause_rewriter.cpp
+++ b/src/optimizer/in_clause_rewriter.cpp
@@ -27,14 +27,14 @@ unique_ptr<Expression> InClauseRewriter::VisitReplace(BoundOperatorExpression &e
 	if (expr.type != ExpressionType::COMPARE_IN && expr.type != ExpressionType::COMPARE_NOT_IN) {
 		return nullptr;
 	}
-	assert(root);
+	D_ASSERT(root);
 	auto in_type = expr.children[0]->return_type;
 	bool is_regular_in = expr.type == ExpressionType::COMPARE_IN;
 	bool all_scalar = true;
 	// IN clause with many children: try to generate a mark join that replaces this IN expression
 	// we can only do this if the expressions in the expression list are scalar
 	for (idx_t i = 1; i < expr.children.size(); i++) {
-		assert(expr.children[i]->return_type == in_type);
+		D_ASSERT(expr.children[i]->return_type == in_type);
 		if (!expr.children[i]->IsFoldable()) {
 			// non-scalar expression
 			all_scalar = false;

--- a/src/optimizer/join_order/query_graph.cpp
+++ b/src/optimizer/join_order/query_graph.cpp
@@ -32,7 +32,7 @@ string QueryGraph::ToString() const {
 }
 
 QueryEdge *QueryGraph::GetQueryEdge(JoinRelationSet *left) {
-	assert(left && left->count > 0);
+	D_ASSERT(left && left->count > 0);
 	// find the EdgeInfo corresponding to the left set
 	QueryEdge *info = &root;
 	for (idx_t i = 0; i < left->count; i++) {
@@ -49,7 +49,7 @@ QueryEdge *QueryGraph::GetQueryEdge(JoinRelationSet *left) {
 }
 
 void QueryGraph::CreateEdge(JoinRelationSet *left, JoinRelationSet *right, FilterInfo *filter_info) {
-	assert(left && right && left->count > 0 && right->count > 0);
+	D_ASSERT(left && right && left->count > 0 && right->count > 0);
 	// find the EdgeInfo corresponding to the left set
 	auto info = GetQueryEdge(left);
 	// now insert the edge to the right relation, if it does not exist

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -32,7 +32,7 @@ Optimizer::Optimizer(Binder &binder, ClientContext &context) : context(context),
 #ifdef DEBUG
 	for (auto &rule : rewriter.rules) {
 		// root not defined in rule
-		assert(rule->root);
+		D_ASSERT(rule->root);
 	}
 #endif
 }

--- a/src/optimizer/pushdown/pushdown_aggregate.cpp
+++ b/src/optimizer/pushdown/pushdown_aggregate.cpp
@@ -13,9 +13,9 @@ using Filter = FilterPushdown::Filter;
 static unique_ptr<Expression> ReplaceGroupBindings(LogicalAggregate &proj, unique_ptr<Expression> expr) {
 	if (expr->type == ExpressionType::BOUND_COLUMN_REF) {
 		auto &colref = (BoundColumnRefExpression &)*expr;
-		assert(colref.binding.table_index == proj.group_index);
-		assert(colref.binding.column_index < proj.groups.size());
-		assert(colref.depth == 0);
+		D_ASSERT(colref.binding.table_index == proj.group_index);
+		D_ASSERT(colref.binding.column_index < proj.groups.size());
+		D_ASSERT(colref.depth == 0);
 		// replace the binding with a copy to the expression at the referenced index
 		return proj.groups[colref.binding.column_index]->Copy();
 	}
@@ -26,7 +26,7 @@ static unique_ptr<Expression> ReplaceGroupBindings(LogicalAggregate &proj, uniqu
 }
 
 unique_ptr<LogicalOperator> FilterPushdown::PushdownAggregate(unique_ptr<LogicalOperator> op) {
-	assert(op->type == LogicalOperatorType::AGGREGATE_AND_GROUP_BY);
+	D_ASSERT(op->type == LogicalOperatorType::AGGREGATE_AND_GROUP_BY);
 	auto &aggr = (LogicalAggregate &)*op;
 
 	// pushdown into AGGREGATE and GROUP BY

--- a/src/optimizer/pushdown/pushdown_cross_product.cpp
+++ b/src/optimizer/pushdown/pushdown_cross_product.cpp
@@ -8,7 +8,7 @@ using namespace std;
 using Filter = FilterPushdown::Filter;
 
 unique_ptr<LogicalOperator> FilterPushdown::PushdownCrossProduct(unique_ptr<LogicalOperator> op) {
-	assert(op->type == LogicalOperatorType::CROSS_PRODUCT);
+	D_ASSERT(op->type == LogicalOperatorType::CROSS_PRODUCT);
 	FilterPushdown left_pushdown(optimizer), right_pushdown(optimizer);
 	vector<unique_ptr<Expression>> join_conditions;
 	unordered_set<idx_t> left_bindings, right_bindings;
@@ -27,7 +27,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownCrossProduct(unique_ptr<Logi
 				// bindings match right side: push into right
 				right_pushdown.filters.push_back(move(f));
 			} else {
-				assert(side == JoinSide::BOTH);
+				D_ASSERT(side == JoinSide::BOTH);
 				// bindings match both: turn into join condition
 				join_conditions.push_back(move(f->filter));
 			}

--- a/src/optimizer/pushdown/pushdown_filter.cpp
+++ b/src/optimizer/pushdown/pushdown_filter.cpp
@@ -8,7 +8,7 @@ using namespace std;
 using Filter = FilterPushdown::Filter;
 
 unique_ptr<LogicalOperator> FilterPushdown::PushdownFilter(unique_ptr<LogicalOperator> op) {
-	assert(op->type == LogicalOperatorType::FILTER);
+	D_ASSERT(op->type == LogicalOperatorType::FILTER);
 	auto &filter = (LogicalFilter &)*op;
 	// filter: gather the filters and remove the filter from the set of operations
 	for (idx_t i = 0; i < filter.expressions.size(); i++) {

--- a/src/optimizer/pushdown/pushdown_get.cpp
+++ b/src/optimizer/pushdown/pushdown_get.cpp
@@ -9,7 +9,7 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<LogicalOperator> FilterPushdown::PushdownGet(unique_ptr<LogicalOperator> op) {
-	assert(op->type == LogicalOperatorType::GET);
+	D_ASSERT(op->type == LogicalOperatorType::GET);
 	auto &get = (LogicalGet &)*op;
 	// first push down arbitrary filters
 	if (get.function.pushdown_complex_filter) {

--- a/src/optimizer/pushdown/pushdown_inner_join.cpp
+++ b/src/optimizer/pushdown/pushdown_inner_join.cpp
@@ -13,8 +13,8 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownInnerJoin(unique_ptr<Logical
                                                               unordered_set<idx_t> &left_bindings,
                                                               unordered_set<idx_t> &right_bindings) {
 	auto &join = (LogicalJoin &)*op;
-	assert(join.join_type == JoinType::INNER);
-	assert(op->type != LogicalOperatorType::DELIM_JOIN);
+	D_ASSERT(join.join_type == JoinType::INNER);
+	D_ASSERT(op->type != LogicalOperatorType::DELIM_JOIN);
 	// inner join: gather all the conditions of the inner join and add to the filter list
 	if (op->type == LogicalOperatorType::ANY_JOIN) {
 		auto &any_join = (LogicalAnyJoin &)join;
@@ -25,7 +25,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownInnerJoin(unique_ptr<Logical
 		}
 	} else {
 		// comparison join
-		assert(op->type == LogicalOperatorType::COMPARISON_JOIN);
+		D_ASSERT(op->type == LogicalOperatorType::COMPARISON_JOIN);
 		auto &comp_join = (LogicalComparisonJoin &)join;
 		// turn the conditions into filters
 		for (idx_t i = 0; i < comp_join.conditions.size(); i++) {

--- a/src/optimizer/pushdown/pushdown_left_join.cpp
+++ b/src/optimizer/pushdown/pushdown_left_join.cpp
@@ -62,8 +62,8 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownLeftJoin(unique_ptr<LogicalO
                                                              unordered_set<idx_t> &left_bindings,
                                                              unordered_set<idx_t> &right_bindings) {
 	auto &join = (LogicalJoin &)*op;
-	assert(join.join_type == JoinType::LEFT);
-	assert(op->type != LogicalOperatorType::DELIM_JOIN);
+	D_ASSERT(join.join_type == JoinType::LEFT);
+	D_ASSERT(op->type != LogicalOperatorType::DELIM_JOIN);
 	FilterPushdown left_pushdown(optimizer), right_pushdown(optimizer);
 	// for a comparison join we create a FilterCombiner that checks if we can push conditions on LHS join conditions
 	// into the RHS of the join

--- a/src/optimizer/pushdown/pushdown_mark_join.cpp
+++ b/src/optimizer/pushdown/pushdown_mark_join.cpp
@@ -12,8 +12,8 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownMarkJoin(unique_ptr<LogicalO
                                                              unordered_set<idx_t> &right_bindings) {
 	auto &join = (LogicalJoin &)*op;
 	auto &comp_join = (LogicalComparisonJoin &)*op;
-	assert(join.join_type == JoinType::MARK);
-	assert(op->type == LogicalOperatorType::COMPARISON_JOIN || op->type == LogicalOperatorType::DELIM_JOIN);
+	D_ASSERT(join.join_type == JoinType::MARK);
+	D_ASSERT(op->type == LogicalOperatorType::COMPARISON_JOIN || op->type == LogicalOperatorType::DELIM_JOIN);
 
 	right_bindings.insert(comp_join.mark_index);
 	FilterPushdown left_pushdown(optimizer), right_pushdown(optimizer);
@@ -32,7 +32,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownMarkJoin(unique_ptr<LogicalO
 		} else if (side == JoinSide::RIGHT) {
 			// there can only be at most one filter referencing the marker
 #ifndef NDEBUG
-			assert(!found_mark_reference);
+			D_ASSERT(!found_mark_reference);
 			found_mark_reference = true;
 #endif
 			// this filter references the marker

--- a/src/optimizer/pushdown/pushdown_projection.cpp
+++ b/src/optimizer/pushdown/pushdown_projection.cpp
@@ -10,9 +10,9 @@ using namespace std;
 static unique_ptr<Expression> ReplaceProjectionBindings(LogicalProjection &proj, unique_ptr<Expression> expr) {
 	if (expr->type == ExpressionType::BOUND_COLUMN_REF) {
 		auto &colref = (BoundColumnRefExpression &)*expr;
-		assert(colref.binding.table_index == proj.table_index);
-		assert(colref.binding.column_index < proj.expressions.size());
-		assert(colref.depth == 0);
+		D_ASSERT(colref.binding.table_index == proj.table_index);
+		D_ASSERT(colref.binding.column_index < proj.expressions.size());
+		D_ASSERT(colref.depth == 0);
 		// replace the binding with a copy to the expression at the referenced index
 		return proj.expressions[colref.binding.column_index]->Copy();
 	}
@@ -23,7 +23,7 @@ static unique_ptr<Expression> ReplaceProjectionBindings(LogicalProjection &proj,
 }
 
 unique_ptr<LogicalOperator> FilterPushdown::PushdownProjection(unique_ptr<LogicalOperator> op) {
-	assert(op->type == LogicalOperatorType::PROJECTION);
+	D_ASSERT(op->type == LogicalOperatorType::PROJECTION);
 	auto &proj = (LogicalProjection &)*op;
 	// push filter through logical projection
 	// all the BoundColumnRefExpressions in the filter should refer to the LogicalProjection
@@ -31,7 +31,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownProjection(unique_ptr<Logica
 	FilterPushdown child_pushdown(optimizer);
 	for (idx_t i = 0; i < filters.size(); i++) {
 		auto &f = *filters[i];
-		assert(f.bindings.size() <= 1);
+		D_ASSERT(f.bindings.size() <= 1);
 		// rewrite the bindings within this subquery
 		f.filter = ReplaceProjectionBindings(proj, move(f.filter));
 		// add the filter to the child pushdown

--- a/src/optimizer/pushdown/pushdown_set_operation.cpp
+++ b/src/optimizer/pushdown/pushdown_set_operation.cpp
@@ -16,8 +16,8 @@ static void ReplaceSetOpBindings(vector<ColumnBinding> &bindings, Filter &filter
                                  LogicalSetOperation &setop) {
 	if (expr.type == ExpressionType::BOUND_COLUMN_REF) {
 		auto &colref = (BoundColumnRefExpression &)expr;
-		assert(colref.binding.table_index == setop.table_index);
-		assert(colref.depth == 0);
+		D_ASSERT(colref.binding.table_index == setop.table_index);
+		D_ASSERT(colref.depth == 0);
 
 		// rewrite the binding by looking into the bound_tables list of the subquery
 		colref.binding = bindings[colref.binding.column_index];
@@ -29,11 +29,11 @@ static void ReplaceSetOpBindings(vector<ColumnBinding> &bindings, Filter &filter
 }
 
 unique_ptr<LogicalOperator> FilterPushdown::PushdownSetOperation(unique_ptr<LogicalOperator> op) {
-	assert(op->type == LogicalOperatorType::UNION || op->type == LogicalOperatorType::EXCEPT ||
+	D_ASSERT(op->type == LogicalOperatorType::UNION || op->type == LogicalOperatorType::EXCEPT ||
 	       op->type == LogicalOperatorType::INTERSECT);
 	auto &setop = (LogicalSetOperation &)*op;
 
-	assert(op->children.size() == 2);
+	D_ASSERT(op->children.size() == 2);
 	auto left_bindings = op->children[0]->GetColumnBindings();
 	auto right_bindings = op->children[1]->GetColumnBindings();
 

--- a/src/optimizer/pushdown/pushdown_single_join.cpp
+++ b/src/optimizer/pushdown/pushdown_single_join.cpp
@@ -9,7 +9,7 @@ using Filter = FilterPushdown::Filter;
 unique_ptr<LogicalOperator> FilterPushdown::PushdownSingleJoin(unique_ptr<LogicalOperator> op,
                                                                unordered_set<idx_t> &left_bindings,
                                                                unordered_set<idx_t> &right_bindings) {
-	assert(((LogicalJoin &)*op).join_type == JoinType::SINGLE);
+	D_ASSERT(((LogicalJoin &)*op).join_type == JoinType::SINGLE);
 	FilterPushdown left_pushdown(optimizer), right_pushdown(optimizer);
 	// now check the set of filters
 	for (idx_t i = 0; i < filters.size(); i++) {

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -26,7 +26,7 @@ void RemoveUnusedColumns::ReplaceBinding(ColumnBinding current_binding, ColumnBi
 	auto colrefs = column_references.find(current_binding);
 	if (colrefs != column_references.end()) {
 		for (auto &colref : colrefs->second) {
-			assert(colref->binding == current_binding);
+			D_ASSERT(colref->binding == current_binding);
 			colref->binding = new_binding;
 		}
 	}

--- a/src/optimizer/rule/arithmetic_simplification.cpp
+++ b/src/optimizer/rule/arithmetic_simplification.cpp
@@ -27,7 +27,7 @@ unique_ptr<Expression> ArithmeticSimplificationRule::Apply(LogicalOperator &op, 
 	auto root = (BoundFunctionExpression *)bindings[0];
 	auto constant = (BoundConstantExpression *)bindings[1];
 	int constant_child = root->children[0].get() == constant ? 0 : 1;
-	assert(root->children.size() == 2);
+	D_ASSERT(root->children.size() == 2);
 	(void)root;
 	// any arithmetic operator involving NULL is always NULL
 	if (constant->value.is_null) {
@@ -52,7 +52,7 @@ unique_ptr<Expression> ArithmeticSimplificationRule::Apply(LogicalOperator &op, 
 			return move(root->children[1 - constant_child]);
 		}
 	} else {
-		assert(func_name == "/");
+		D_ASSERT(func_name == "/");
 		if (constant_child == 1) {
 			if (constant->value == 1) {
 				// divide by 1, replace with non-constant child

--- a/src/optimizer/rule/case_simplification.cpp
+++ b/src/optimizer/rule/case_simplification.cpp
@@ -18,7 +18,7 @@ unique_ptr<Expression> CaseSimplificationRule::Apply(LogicalOperator &op, vector
 	auto root = (BoundCaseExpression *)bindings[0];
 	auto constant_expr = bindings[1];
 	// the constant_expr is a scalar expression that we have to fold
-	assert(constant_expr->IsFoldable());
+	D_ASSERT(constant_expr->IsFoldable());
 
 	// use an ExpressionExecutor to execute the expression
 	auto constant_value = ExpressionExecutor::EvaluateScalar(*constant_expr);

--- a/src/optimizer/rule/comparison_simplification.cpp
+++ b/src/optimizer/rule/comparison_simplification.cpp
@@ -17,14 +17,14 @@ ComparisonSimplificationRule::ComparisonSimplificationRule(ExpressionRewriter &r
 
 unique_ptr<Expression> ComparisonSimplificationRule::Apply(LogicalOperator &op, vector<Expression *> &bindings,
                                                            bool &changes_made) {
-	assert(bindings[0]->expression_class == ExpressionClass::BOUND_COMPARISON);
+	D_ASSERT(bindings[0]->expression_class == ExpressionClass::BOUND_COMPARISON);
 	auto expr = (BoundComparisonExpression *)bindings[0];
 	auto constant_expr = bindings[1];
 	bool column_ref_left = expr->left.get() != constant_expr;
 	auto column_ref_expr = !column_ref_left ? expr->right.get() : expr->left.get();
 	// the constant_expr is a scalar expression that we have to fold
 	// use an ExpressionExecutor to execute the expression
-	assert(constant_expr->IsFoldable());
+	D_ASSERT(constant_expr->IsFoldable());
 	auto constant_value = ExpressionExecutor::EvaluateScalar(*constant_expr);
 	if (constant_value.is_null) {
 		// comparison with constant NULL, return NULL

--- a/src/optimizer/rule/conjunction_simplification.cpp
+++ b/src/optimizer/rule/conjunction_simplification.cpp
@@ -37,7 +37,7 @@ unique_ptr<Expression> ConjunctionSimplificationRule::Apply(LogicalOperator &op,
 	auto constant_expr = bindings[1];
 	// the constant_expr is a scalar expression that we have to fold
 	// use an ExpressionExecutor to execute the expression
-	assert(constant_expr->IsFoldable());
+	D_ASSERT(constant_expr->IsFoldable());
 	auto constant_value = ExpressionExecutor::EvaluateScalar(*constant_expr).CastAs(LogicalType::BOOLEAN);
 	if (constant_value.is_null) {
 		// we can't simplify conjunctions with a constant NULL
@@ -52,7 +52,7 @@ unique_ptr<Expression> ConjunctionSimplificationRule::Apply(LogicalOperator &op,
 			return RemoveExpression(*conjunction, constant_expr);
 		}
 	} else {
-		assert(conjunction->type == ExpressionType::CONJUNCTION_OR);
+		D_ASSERT(conjunction->type == ExpressionType::CONJUNCTION_OR);
 		if (!constant_value.value_.boolean) {
 			// FALSE in OR, remove the expression from the set
 			return RemoveExpression(*conjunction, constant_expr);

--- a/src/optimizer/rule/constant_folding.cpp
+++ b/src/optimizer/rule/constant_folding.cpp
@@ -29,11 +29,11 @@ unique_ptr<Expression> ConstantFoldingRule::Apply(LogicalOperator &op, vector<Ex
                                                   bool &changes_made) {
 	auto root = bindings[0];
 	// the root is a scalar expression that we have to fold
-	assert(root->IsFoldable() && root->type != ExpressionType::VALUE_CONSTANT);
+	D_ASSERT(root->IsFoldable() && root->type != ExpressionType::VALUE_CONSTANT);
 
 	// use an ExpressionExecutor to execute the expression
 	auto result_value = ExpressionExecutor::EvaluateScalar(*root);
-	assert(result_value.type() == root->return_type);
+	D_ASSERT(result_value.type() == root->return_type);
 	// now get the value from the result vector and insert it back into the plan as a constant expression
 	return make_unique<BoundConstantExpression>(result_value);
 }

--- a/src/optimizer/rule/distributivity.cpp
+++ b/src/optimizer/rule/distributivity.cpp
@@ -46,11 +46,11 @@ unique_ptr<Expression> DistributivityRule::ExtractExpression(BoundConjunctionExp
 	} else {
 		// not an AND node! remove the entire expression
 		// this happens in the case of e.g. (X AND B) OR X
-		assert(Expression::Equals(child.get(), &expr));
+		D_ASSERT(Expression::Equals(child.get(), &expr));
 		result = move(child);
 		conj.children[idx] = nullptr;
 	}
-	assert(result);
+	D_ASSERT(result);
 	return result;
 }
 
@@ -86,7 +86,7 @@ unique_ptr<Expression> DistributivityRule::Apply(LogicalOperator &op, vector<Exp
 	// the OR
 	auto new_root = make_unique<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
 	for (auto &expr : candidate_set) {
-		assert(initial_or->children.size() > 0);
+		D_ASSERT(initial_or->children.size() > 0);
 
 		// extract the expression from the first child of the OR
 		auto result = ExtractExpression(*initial_or, 0, (Expression &)*expr);

--- a/src/optimizer/rule/empty_needle_removal.cpp
+++ b/src/optimizer/rule/empty_needle_removal.cpp
@@ -24,7 +24,7 @@ EmptyNeedleRemovalRule::EmptyNeedleRemovalRule(ExpressionRewriter &rewriter) : R
 unique_ptr<Expression> EmptyNeedleRemovalRule::Apply(LogicalOperator &op, vector<Expression *> &bindings,
                                                      bool &changes_made) {
 	auto root = (BoundFunctionExpression *)bindings[0];
-	assert(root->children.size() == 2);
+	D_ASSERT(root->children.size() == 2);
 	(void)root;
 	auto prefix_expr = bindings[2];
 
@@ -32,7 +32,7 @@ unique_ptr<Expression> EmptyNeedleRemovalRule::Apply(LogicalOperator &op, vector
 	if (!prefix_expr->IsFoldable()) {
 		return nullptr;
 	}
-	assert(root->return_type.id() == LogicalTypeId::BOOLEAN);
+	D_ASSERT(root->return_type.id() == LogicalTypeId::BOOLEAN);
 
 	auto prefix_value = ExpressionExecutor::EvaluateScalar(*prefix_expr);
 
@@ -40,7 +40,7 @@ unique_ptr<Expression> EmptyNeedleRemovalRule::Apply(LogicalOperator &op, vector
 		return make_unique<BoundConstantExpression>(Value(LogicalType::BOOLEAN));
 	}
 
-	assert(prefix_value.type() == prefix_expr->return_type);
+	D_ASSERT(prefix_value.type() == prefix_expr->return_type);
 	string needle_string = string(((string_t)prefix_value.str_value).GetData());
 
 	/* PREFIX('xyz', '') is TRUE, PREFIX(NULL, '') is NULL, so rewrite PREFIX(x, '') to (CASE WHEN x IS NOT NULL THEN

--- a/src/optimizer/rule/like_optimizations.cpp
+++ b/src/optimizer/rule/like_optimizations.cpp
@@ -24,7 +24,7 @@ unique_ptr<Expression> LikeOptimizationRule::Apply(LogicalOperator &op, vector<E
                                                    bool &changes_made) {
 	auto root = (BoundFunctionExpression *)bindings[0];
 	auto constant_expr = (BoundConstantExpression *)bindings[1];
-	assert(root->children.size() == 2);
+	D_ASSERT(root->children.size() == 2);
 
 	if (constant_expr->value.is_null) {
 		return make_unique<BoundConstantExpression>(Value(root->return_type));
@@ -36,7 +36,7 @@ unique_ptr<Expression> LikeOptimizationRule::Apply(LogicalOperator &op, vector<E
 	}
 
 	auto constant_value = ExpressionExecutor::EvaluateScalar(*constant_expr);
-	assert(constant_value.type() == constant_expr->return_type);
+	D_ASSERT(constant_value.type() == constant_expr->return_type);
 	string patt_str = string(((string_t)constant_value.str_value).GetData());
 
 	duckdb_re2::RE2 prefix_pattern("[^%_]*[%]+");

--- a/src/optimizer/rule/move_constants.cpp
+++ b/src/optimizer/rule/move_constants.cpp
@@ -61,7 +61,7 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<Expr
 			comparison->type = FlipComparisionExpression(comparison->type);
 		}
 	} else {
-		assert(op_type == "*");
+		D_ASSERT(op_type == "*");
 		// [x * 2 COMP 10] OR [2 * x COMP 10]
 		// order does not matter in multiplication:
 		// change right side to 10/2 (outer_constant / inner_constant)

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -146,10 +146,10 @@ void Executor::BuildPipelines(PhysicalOperator *op, Pipeline *parent) {
 		case PhysicalOperatorType::DELIM_SCAN: {
 			// check if this chunk scan scans a duplicate eliminated join collection
 			auto entry = delim_join_dependencies.find(op);
-			assert(entry != delim_join_dependencies.end());
+			D_ASSERT(entry != delim_join_dependencies.end());
 			// this chunk scan introduces a dependency to the current pipeline
 			// namely a dependency on the duplicate elimination pipeline to finish
-			assert(parent);
+			D_ASSERT(parent);
 			parent->AddDependency(entry->second);
 			break;
 		}
@@ -210,7 +210,7 @@ void Executor::BuildPipelines(PhysicalOperator *op, Pipeline *parent) {
 }
 
 vector<LogicalType> Executor::GetTypes() {
-	assert(physical_plan);
+	D_ASSERT(physical_plan);
 	return physical_plan->GetTypes();
 }
 
@@ -228,7 +228,7 @@ void Executor::Flush(ThreadContext &tcontext) {
 }
 
 unique_ptr<DataChunk> Executor::FetchChunk() {
-	assert(physical_plan);
+	D_ASSERT(physical_plan);
 
 	ThreadContext thread(context);
 	TaskContext task;

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -72,7 +72,7 @@ void Pipeline::Execute(TaskContext &task) {
 }
 
 void Pipeline::FinishTask() {
-	assert(finished_tasks < total_tasks);
+	D_ASSERT(finished_tasks < total_tasks);
 	idx_t current_finished = ++finished_tasks;
 	if (current_finished == total_tasks) {
 		try {
@@ -111,8 +111,8 @@ bool Pipeline::ScheduleOperator(PhysicalOperator *op) {
 			// table function cannot be parallelized
 			return false;
 		}
-		assert(get.function.init_parallel_state);
-		assert(get.function.parallel_state_next);
+		D_ASSERT(get.function.init_parallel_state);
+		D_ASSERT(get.function.parallel_state_next);
 		idx_t max_threads = get.function.max_threads(executor.context, get.bind_data.get());
 		if (max_threads > executor.context.db.NumberOfThreads()) {
 			max_threads = executor.context.db.NumberOfThreads();
@@ -150,9 +150,9 @@ void Pipeline::Reset(ClientContext &context) {
 }
 
 void Pipeline::Schedule() {
-	assert(finished_tasks == 0);
-	assert(total_tasks == 0);
-	assert(finished_dependencies == dependencies.size());
+	D_ASSERT(finished_tasks == 0);
+	D_ASSERT(total_tasks == 0);
+	D_ASSERT(finished_dependencies == dependencies.size());
 	// check if we can parallelize this task based on the sink
 	switch (sink->type) {
 	case PhysicalOperatorType::SIMPLE_AGGREGATE: {
@@ -209,7 +209,7 @@ void Pipeline::CompleteDependency() {
 }
 
 void Pipeline::Finish() {
-	assert(!finished);
+	D_ASSERT(!finished);
 	finished = true;
 	// finished processing the pipeline, now we can schedule pipelines that depend on this pipeline
 	for (auto &parent : parents) {

--- a/src/parser/constraints/unique_constraint.cpp
+++ b/src/parser/constraints/unique_constraint.cpp
@@ -23,7 +23,7 @@ unique_ptr<Constraint> UniqueConstraint::Copy() {
 	if (index == INVALID_INDEX) {
 		return make_unique<UniqueConstraint>(columns, is_primary_key);
 	} else {
-		assert(columns.size() == 0);
+		D_ASSERT(columns.size() == 0);
 		return make_unique<UniqueConstraint>(index, is_primary_key);
 	}
 }
@@ -32,7 +32,7 @@ void UniqueConstraint::Serialize(Serializer &serializer) {
 	Constraint::Serialize(serializer);
 	serializer.Write<bool>(is_primary_key);
 	serializer.Write<uint64_t>(index);
-	assert(columns.size() <= NumericLimits<uint32_t>::Maximum());
+	D_ASSERT(columns.size() <= NumericLimits<uint32_t>::Maximum());
 	serializer.Write<uint32_t>((uint32_t)columns.size());
 	for (auto &column : columns) {
 		serializer.WriteString(column);

--- a/src/parser/expression/cast_expression.cpp
+++ b/src/parser/expression/cast_expression.cpp
@@ -7,7 +7,7 @@ using namespace std;
 
 CastExpression::CastExpression(LogicalType target, unique_ptr<ParsedExpression> child)
     : ParsedExpression(ExpressionType::OPERATOR_CAST, ExpressionClass::CAST), cast_type(target) {
-	assert(child);
+	D_ASSERT(child);
 	this->child = move(child);
 }
 

--- a/src/parser/expression/collate_expression.cpp
+++ b/src/parser/expression/collate_expression.cpp
@@ -7,7 +7,7 @@ namespace duckdb {
 
 CollateExpression::CollateExpression(string collation, unique_ptr<ParsedExpression> child)
     : ParsedExpression(ExpressionType::COLLATE, ExpressionClass::COLLATE), collation(collation) {
-	assert(child);
+	D_ASSERT(child);
 	this->child = move(child);
 }
 

--- a/src/parser/expression/window_expression.cpp
+++ b/src/parser/expression/window_expression.cpp
@@ -109,7 +109,7 @@ void WindowExpression::Serialize(Serializer &serializer) {
 	serializer.WriteString(schema);
 	serializer.WriteList(children);
 	serializer.WriteList(partitions);
-	assert(orders.size() <= NumericLimits<uint32_t>::Maximum());
+	D_ASSERT(orders.size() <= NumericLimits<uint32_t>::Maximum());
 	serializer.Write<uint32_t>((uint32_t)orders.size());
 	for (auto &order : orders) {
 		order.Serialize(serializer);

--- a/src/parser/statement/select_statement.cpp
+++ b/src/parser/statement/select_statement.cpp
@@ -22,7 +22,7 @@ unique_ptr<SelectStatement> SelectStatement::Copy() {
 
 void SelectStatement::Serialize(Serializer &serializer) {
 	// with clauses
-	assert(cte_map.size() <= NumericLimits<uint32_t>::Maximum());
+	D_ASSERT(cte_map.size() <= NumericLimits<uint32_t>::Maximum());
 	serializer.Write<uint32_t>((uint32_t)cte_map.size());
 	for (auto &cte : cte_map) {
 		serializer.WriteString(cte.first);

--- a/src/parser/tableref/joinref.cpp
+++ b/src/parser/tableref/joinref.cpp
@@ -32,6 +32,7 @@ unique_ptr<TableRef> JoinRef::Copy() {
 		copy->condition = condition->Copy();
 	}
 	copy->type = type;
+	copy->is_natural = is_natural;
 	copy->alias = alias;
 	copy->using_columns = using_columns;
 	return move(copy);
@@ -44,6 +45,7 @@ void JoinRef::Serialize(Serializer &serializer) {
 	right->Serialize(serializer);
 	serializer.WriteOptional(condition);
 	serializer.Write<JoinType>(type);
+	serializer.Write<bool>(is_natural);
 	assert(using_columns.size() <= NumericLimits<uint32_t>::Maximum());
 	serializer.Write<uint32_t>((uint32_t)using_columns.size());
 	for (auto &using_column : using_columns) {
@@ -58,6 +60,7 @@ unique_ptr<TableRef> JoinRef::Deserialize(Deserializer &source) {
 	result->right = TableRef::Deserialize(source);
 	result->condition = source.ReadOptional<ParsedExpression>();
 	result->type = source.Read<JoinType>();
+	result->is_natural = source.Read<bool>();
 	auto count = source.Read<uint32_t>();
 	for (idx_t i = 0; i < count; i++) {
 		result->using_columns.push_back(source.Read<string>());

--- a/src/parser/tableref/joinref.cpp
+++ b/src/parser/tableref/joinref.cpp
@@ -46,7 +46,7 @@ void JoinRef::Serialize(Serializer &serializer) {
 	serializer.WriteOptional(condition);
 	serializer.Write<JoinType>(type);
 	serializer.Write<bool>(is_natural);
-	assert(using_columns.size() <= NumericLimits<uint32_t>::Maximum());
+	D_ASSERT(using_columns.size() <= NumericLimits<uint32_t>::Maximum());
 	serializer.Write<uint32_t>((uint32_t)using_columns.size());
 	for (auto &using_column : using_columns) {
 		serializer.WriteString(using_column);

--- a/src/parser/transform/constraint/transform_constraint.cpp
+++ b/src/parser/transform/constraint/transform_constraint.cpp
@@ -36,7 +36,7 @@ unique_ptr<Constraint> Transformer::TransformConstraint(PGListCell *cell) {
 
 unique_ptr<Constraint> Transformer::TransformConstraint(PGListCell *cell, ColumnDefinition &column, idx_t index) {
 	auto constraint = reinterpret_cast<PGConstraint *>(cell->data.ptr_value);
-	assert(constraint);
+	D_ASSERT(constraint);
 	switch (constraint->contype) {
 	case PG_CONSTR_NOTNULL:
 		return make_unique<NotNullConstraint>(index);

--- a/src/parser/transform/expression/transform_cast.cpp
+++ b/src/parser/transform/expression/transform_cast.cpp
@@ -27,7 +27,7 @@ unique_ptr<ParsedExpression> Transformer::TransformTypeCast(PGTypeCast *root) {
 		// handle post-fix notation of INTERVAL
 		if (root->typeName->typmods && root->typeName->typmods->length > 0) {
 			PGAConst *c = reinterpret_cast<PGAConst *>(root->arg);
-			assert(c->val.type == T_PGString);
+			D_ASSERT(c->val.type == T_PGString);
 
 			int64_t amount;
 			if (!TryCast::Operation<string_t, int64_t>(c->val.val.str, amount)) {

--- a/src/parser/transform/expression/transform_constant.cpp
+++ b/src/parser/transform/expression/transform_constant.cpp
@@ -11,7 +11,7 @@ using namespace duckdb_libpgquery;
 unique_ptr<ConstantExpression> Transformer::TransformValue(PGValue val) {
 	switch (val.type) {
 	case T_PGInteger:
-		assert(val.val.ival <= NumericLimits<int32_t>::Maximum());
+		D_ASSERT(val.val.ival <= NumericLimits<int32_t>::Maximum());
 		return make_unique<ConstantExpression>(Value::INTEGER((int32_t)val.val.ival));
 	case T_PGBitString: // FIXME: this should actually convert to BLOB
 	case T_PGString:

--- a/src/parser/transform/expression/transform_function.cpp
+++ b/src/parser/transform/expression/transform_function.cpp
@@ -38,8 +38,8 @@ static ExpressionType WindowToExpressionType(string &fun_name) {
 }
 
 void Transformer::TransformWindowDef(PGWindowDef *window_spec, WindowExpression *expr) {
-	assert(window_spec);
-	assert(expr);
+	D_ASSERT(window_spec);
+	D_ASSERT(expr);
 
 	// next: partitioning/ordering expressions
 	TransformExpressionList(window_spec->partitionClause, expr->partitions);
@@ -83,7 +83,7 @@ void Transformer::TransformWindowDef(PGWindowDef *window_spec, WindowExpression 
 		expr->end = WindowBoundary::CURRENT_ROW_ROWS;
 	}
 
-	assert(expr->start != WindowBoundary::INVALID && expr->end != WindowBoundary::INVALID);
+	D_ASSERT(expr->start != WindowBoundary::INVALID && expr->end != WindowBoundary::INVALID);
 	if (((expr->start == WindowBoundary::EXPR_PRECEDING || expr->start == WindowBoundary::EXPR_PRECEDING) &&
 	     !expr->start_expr) ||
 	    ((expr->end == WindowBoundary::EXPR_PRECEDING || expr->end == WindowBoundary::EXPR_PRECEDING) &&
@@ -142,14 +142,14 @@ unique_ptr<ParsedExpression> Transformer::TransformFuncCall(PGFuncCall *root) {
 					expr->children.push_back(move(function_list[0]));
 				}
 				if (function_list.size() > 1) {
-					assert(win_fun_type == ExpressionType::WINDOW_LEAD || win_fun_type == ExpressionType::WINDOW_LAG);
+					D_ASSERT(win_fun_type == ExpressionType::WINDOW_LEAD || win_fun_type == ExpressionType::WINDOW_LAG);
 					expr->offset_expr = move(function_list[1]);
 				}
 				if (function_list.size() > 2) {
-					assert(win_fun_type == ExpressionType::WINDOW_LEAD || win_fun_type == ExpressionType::WINDOW_LAG);
+					D_ASSERT(win_fun_type == ExpressionType::WINDOW_LEAD || win_fun_type == ExpressionType::WINDOW_LAG);
 					expr->default_expr = move(function_list[2]);
 				}
-				assert(function_list.size() <= 3);
+				D_ASSERT(function_list.size() <= 3);
 			}
 		}
 		auto window_spec = reinterpret_cast<PGWindowDef *>(root->over);
@@ -159,7 +159,7 @@ unique_ptr<ParsedExpression> Transformer::TransformFuncCall(PGFuncCall *root) {
 				throw ParserException("window \"%s\" does not exist", window_spec->name);
 			}
 			window_spec = it->second;
-			assert(window_spec);
+			D_ASSERT(window_spec);
 		}
 		TransformWindowDef(window_spec, expr.get());
 

--- a/src/parser/transform/expression/transform_is_null.cpp
+++ b/src/parser/transform/expression/transform_is_null.cpp
@@ -7,7 +7,7 @@ using namespace std;
 using namespace duckdb_libpgquery;
 
 unique_ptr<ParsedExpression> Transformer::TransformNullTest(PGNullTest *root) {
-	assert(root);
+	D_ASSERT(root);
 	auto arg = TransformExpression(reinterpret_cast<PGNode *>(root->arg));
 	if (root->argisrow) {
 		throw NotImplementedException("IS NULL argisrow");

--- a/src/parser/transform/expression/transform_operator.cpp
+++ b/src/parser/transform/expression/transform_operator.cpp
@@ -143,8 +143,8 @@ unique_ptr<ParsedExpression> Transformer::TransformAExpr(PGAExpr *root) {
 		children.push_back(move(left_expr));
 
 		auto &similar_func = reinterpret_cast<FunctionExpression &>(*right_expr);
-		assert(similar_func.function_name == "similar_escape");
-		assert(similar_func.children.size() == 2);
+		D_ASSERT(similar_func.function_name == "similar_escape");
+		D_ASSERT(similar_func.children.size() == 2);
 		if (similar_func.children[1]->type != ExpressionType::VALUE_CONSTANT) {
 			throw NotImplementedException("Custom escape in SIMILAR TO");
 		}

--- a/src/parser/transform/expression/transform_subquery.cpp
+++ b/src/parser/transform/expression/transform_subquery.cpp
@@ -15,7 +15,7 @@ unique_ptr<ParsedExpression> Transformer::TransformSubquery(PGSubLink *root) {
 	if (!subquery_expr->subquery) {
 		return nullptr;
 	}
-	assert(subquery_expr->subquery->node->GetSelectList().size() > 0);
+	D_ASSERT(subquery_expr->subquery->node->GetSelectList().size() > 0);
 
 	switch (root->subLinkType) {
 	case PG_EXISTS_SUBLINK: {
@@ -35,7 +35,7 @@ unique_ptr<ParsedExpression> Transformer::TransformSubquery(PGSubLink *root) {
 			auto operator_name = string((reinterpret_cast<PGValue *>(root->operName->head->data.ptr_value))->val.str);
 			subquery_expr->comparison_type = OperatorToExpressionType(operator_name);
 		}
-		assert(subquery_expr->comparison_type == ExpressionType::COMPARE_EQUAL ||
+		D_ASSERT(subquery_expr->comparison_type == ExpressionType::COMPARE_EQUAL ||
 		       subquery_expr->comparison_type == ExpressionType::COMPARE_NOTEQUAL ||
 		       subquery_expr->comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
 		       subquery_expr->comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO ||

--- a/src/parser/transform/helpers/nodetype_to_string.cpp
+++ b/src/parser/transform/helpers/nodetype_to_string.cpp
@@ -812,7 +812,7 @@ std::string Transformer::NodetypeToString(PGNodeTag type) {
 	case T_PGForeignKeyCacheInfo:
 		return "T_ForeignKeyCacheInfo";
 	default:
-		assert(0);
+		D_ASSERT(0);
 		return "";
 	}
 }

--- a/src/parser/transform/helpers/transform_cte.cpp
+++ b/src/parser/transform/helpers/transform_cte.cpp
@@ -10,9 +10,9 @@ using namespace duckdb_libpgquery;
 
 void Transformer::TransformCTE(PGWithClause *de_with_clause, SelectStatement &select) {
 	// TODO: might need to update in case of future lawsuit
-	assert(de_with_clause);
+	D_ASSERT(de_with_clause);
 
-	assert(de_with_clause->ctes);
+	D_ASSERT(de_with_clause->ctes);
 	for (auto cte_ele = de_with_clause->ctes->head; cte_ele != NULL; cte_ele = cte_ele->next) {
 		auto info = make_unique<CommonTableExpressionInfo>();
 

--- a/src/parser/transform/statement/transform_alter_table.cpp
+++ b/src/parser/transform/statement/transform_alter_table.cpp
@@ -10,8 +10,8 @@ using namespace duckdb_libpgquery;
 
 unique_ptr<AlterStatement> Transformer::TransformAlter(PGNode *node) {
 	auto stmt = reinterpret_cast<PGAlterTableStmt *>(node);
-	assert(stmt);
-	assert(stmt->relation);
+	D_ASSERT(stmt);
+	D_ASSERT(stmt->relation);
 
 	auto result = make_unique<AlterStatement>();
 

--- a/src/parser/transform/statement/transform_call.cpp
+++ b/src/parser/transform/statement/transform_call.cpp
@@ -7,7 +7,7 @@ using namespace duckdb_libpgquery;
 
 unique_ptr<CallStatement> Transformer::TransformCall(PGNode *node) {
 	auto stmt = reinterpret_cast<PGCallStmt *>(node);
-	assert(stmt);
+	D_ASSERT(stmt);
 
 	auto result = make_unique<CallStatement>();
 	result->function = TransformFuncCall((PGFuncCall *)stmt->func);

--- a/src/parser/transform/statement/transform_copy.cpp
+++ b/src/parser/transform/statement/transform_copy.cpp
@@ -58,7 +58,7 @@ void Transformer::TransformCopyOptions(CopyInfo &info, PGList *options) {
 
 unique_ptr<CopyStatement> Transformer::TransformCopy(PGNode *node) {
 	auto stmt = reinterpret_cast<PGCopyStmt *>(node);
-	assert(stmt);
+	D_ASSERT(stmt);
 	auto result = make_unique<CopyStatement>();
 	auto &info = *result->info;
 

--- a/src/parser/transform/statement/transform_create_index.cpp
+++ b/src/parser/transform/statement/transform_create_index.cpp
@@ -23,7 +23,7 @@ static IndexType StringToIndexType(const string &str) {
 
 unique_ptr<CreateStatement> Transformer::TransformCreateIndex(PGNode *node) {
 	auto stmt = reinterpret_cast<PGIndexStmt *>(node);
-	assert(stmt);
+	D_ASSERT(stmt);
 	auto result = make_unique<CreateStatement>();
 	auto info = make_unique<CreateIndexInfo>();
 
@@ -44,7 +44,7 @@ unique_ptr<CreateStatement> Transformer::TransformCreateIndex(PGNode *node) {
 			info->expressions.push_back(make_unique<ColumnRefExpression>(index_element->name, stmt->relation->relname));
 		} else {
 			// parse the index expression
-			assert(index_element->expr);
+			D_ASSERT(index_element->expr);
 			info->expressions.push_back(TransformExpression(index_element->expr));
 		}
 	}

--- a/src/parser/transform/statement/transform_create_schema.cpp
+++ b/src/parser/transform/statement/transform_create_schema.cpp
@@ -8,11 +8,11 @@ using namespace duckdb_libpgquery;
 
 unique_ptr<CreateStatement> Transformer::TransformCreateSchema(PGNode *node) {
 	auto stmt = reinterpret_cast<PGCreateSchemaStmt *>(node);
-	assert(stmt);
+	D_ASSERT(stmt);
 	auto result = make_unique<CreateStatement>();
 	auto info = make_unique<CreateSchemaInfo>();
 
-	assert(stmt->schemaname);
+	D_ASSERT(stmt->schemaname);
 	info->schema = stmt->schemaname;
 	info->on_conflict = stmt->if_not_exists ? OnCreateConflict::IGNORE_ON_CONFLICT : OnCreateConflict::ERROR_ON_CONFLICT;
 

--- a/src/parser/transform/statement/transform_create_sequence.cpp
+++ b/src/parser/transform/statement/transform_create_sequence.cpp
@@ -27,7 +27,7 @@ unique_ptr<CreateStatement> Transformer::TransformCreateSequence(PGNode *node) {
 			if (def_elem->defaction == PG_DEFELEM_UNSPEC && !val) { // e.g. NO MINVALUE
 				continue;
 			}
-			assert(val);
+			D_ASSERT(val);
 			int64_t opt_value;
 			if (val->type == T_PGInteger) {
 				opt_value = val->val.ival;

--- a/src/parser/transform/statement/transform_create_table.cpp
+++ b/src/parser/transform/statement/transform_create_table.cpp
@@ -52,14 +52,14 @@ ColumnDefinition Transformer::TransformColumnDefinition(PGColumnDef *cdef) {
 
 unique_ptr<CreateStatement> Transformer::TransformCreateTable(PGNode *node) {
 	auto stmt = reinterpret_cast<PGCreateStmt *>(node);
-	assert(stmt);
+	D_ASSERT(stmt);
 	auto result = make_unique<CreateStatement>();
 	auto info = make_unique<CreateTableInfo>();
 
 	if (stmt->inhRelations) {
 		throw NotImplementedException("inherited relations not implemented");
 	}
-	assert(stmt->relation);
+	D_ASSERT(stmt->relation);
 
 	info->schema = INVALID_SCHEMA;
 	if (stmt->relation->schemaname) {

--- a/src/parser/transform/statement/transform_create_table_as.cpp
+++ b/src/parser/transform/statement/transform_create_table_as.cpp
@@ -8,7 +8,7 @@ using namespace duckdb_libpgquery;
 
 unique_ptr<CreateStatement> Transformer::TransformCreateTableAs(PGNode *node) {
 	auto stmt = reinterpret_cast<PGCreateTableAsStmt *>(node);
-	assert(stmt);
+	D_ASSERT(stmt);
 	if (stmt->relkind == PG_OBJECT_MATVIEW) {
 		throw NotImplementedException("Materialized view not implemented");
 	}

--- a/src/parser/transform/statement/transform_create_view.cpp
+++ b/src/parser/transform/statement/transform_create_view.cpp
@@ -7,12 +7,12 @@ using namespace std;
 using namespace duckdb_libpgquery;
 
 unique_ptr<CreateStatement> Transformer::TransformCreateView(PGNode *node) {
-	assert(node);
-	assert(node->type == T_PGViewStmt);
+	D_ASSERT(node);
+	D_ASSERT(node->type == T_PGViewStmt);
 
 	auto stmt = reinterpret_cast<PGViewStmt *>(node);
-	assert(stmt);
-	assert(stmt->view);
+	D_ASSERT(stmt);
+	D_ASSERT(stmt->view);
 
 	auto result = make_unique<CreateStatement>();
 	auto info = make_unique<CreateViewInfo>();

--- a/src/parser/transform/statement/transform_delete.cpp
+++ b/src/parser/transform/statement/transform_delete.cpp
@@ -7,7 +7,7 @@ using namespace duckdb_libpgquery;
 
 unique_ptr<DeleteStatement> Transformer::TransformDelete(PGNode *node) {
 	auto stmt = reinterpret_cast<PGDeleteStmt *>(node);
-	assert(stmt);
+	D_ASSERT(stmt);
 	auto result = make_unique<DeleteStatement>();
 
 	result->condition = TransformExpression(stmt->whereClause);

--- a/src/parser/transform/statement/transform_drop.cpp
+++ b/src/parser/transform/statement/transform_drop.cpp
@@ -9,7 +9,7 @@ unique_ptr<SQLStatement> Transformer::TransformDrop(PGNode *node) {
 	auto stmt = (PGDropStmt *)(node);
 	auto result = make_unique<DropStatement>();
 	auto &info = *result->info.get();
-	assert(stmt);
+	D_ASSERT(stmt);
 	if (stmt->objects->length != 1) {
 		throw NotImplementedException("Can only drop one object at a time");
 	}
@@ -35,7 +35,7 @@ unique_ptr<SQLStatement> Transformer::TransformDrop(PGNode *node) {
 
 	switch (stmt->removeType) {
 	case PG_OBJECT_SCHEMA:
-		assert(stmt->objects && stmt->objects->length == 1);
+		D_ASSERT(stmt->objects && stmt->objects->length == 1);
 		info.name = ((PGValue *)stmt->objects->head->data.ptr_value)->val.str;
 		break;
 	default: {

--- a/src/parser/transform/statement/transform_explain.cpp
+++ b/src/parser/transform/statement/transform_explain.cpp
@@ -7,7 +7,7 @@ using namespace duckdb_libpgquery;
 
 unique_ptr<ExplainStatement> Transformer::TransformExplain(PGNode *node) {
 	PGExplainStmt *stmt = reinterpret_cast<PGExplainStmt *>(node);
-	assert(stmt);
+	D_ASSERT(stmt);
 	return make_unique<ExplainStatement>(TransformStatement(stmt->query));
 }
 

--- a/src/parser/transform/statement/transform_insert.cpp
+++ b/src/parser/transform/statement/transform_insert.cpp
@@ -28,7 +28,7 @@ unique_ptr<TableRef> Transformer::TransformValuesList(PGList *list) {
 
 unique_ptr<InsertStatement> Transformer::TransformInsert(PGNode *node) {
 	auto stmt = reinterpret_cast<PGInsertStmt *>(node);
-	assert(stmt);
+	D_ASSERT(stmt);
 
 	auto result = make_unique<InsertStatement>();
 

--- a/src/parser/transform/statement/transform_prepare.cpp
+++ b/src/parser/transform/statement/transform_prepare.cpp
@@ -9,7 +9,7 @@ using namespace duckdb_libpgquery;
 
 unique_ptr<PrepareStatement> Transformer::TransformPrepare(PGNode *node) {
 	auto stmt = reinterpret_cast<PGPrepareStmt *>(node);
-	assert(stmt);
+	D_ASSERT(stmt);
 
 	if (stmt->argtypes && stmt->argtypes->length > 0) {
 		throw NotImplementedException("Prepared statement argument types are not supported, use CAST");
@@ -25,7 +25,7 @@ unique_ptr<PrepareStatement> Transformer::TransformPrepare(PGNode *node) {
 
 unique_ptr<ExecuteStatement> Transformer::TransformExecute(PGNode *node) {
 	auto stmt = reinterpret_cast<PGExecuteStmt *>(node);
-	assert(stmt);
+	D_ASSERT(stmt);
 
 	auto result = make_unique<ExecuteStatement>();
 	result->name = string(stmt->name);
@@ -41,7 +41,7 @@ unique_ptr<ExecuteStatement> Transformer::TransformExecute(PGNode *node) {
 
 unique_ptr<DropStatement> Transformer::TransformDeallocate(PGNode *node) {
 	auto stmt = reinterpret_cast<PGDeallocateStmt *>(node);
-	assert(stmt);
+	D_ASSERT(stmt);
 
 	auto result = make_unique<DropStatement>();
 	result->info->type = CatalogType::PREPARED_STATEMENT;

--- a/src/parser/transform/statement/transform_rename.cpp
+++ b/src/parser/transform/statement/transform_rename.cpp
@@ -7,8 +7,8 @@ using namespace duckdb_libpgquery;
 
 unique_ptr<AlterStatement> Transformer::TransformRename(PGNode *node) {
 	auto stmt = reinterpret_cast<PGRenameStmt *>(node);
-	assert(stmt);
-	assert(stmt->relation);
+	D_ASSERT(stmt);
+	D_ASSERT(stmt->relation);
 
 	unique_ptr<AlterInfo> info;
 
@@ -20,7 +20,7 @@ unique_ptr<AlterStatement> Transformer::TransformRename(PGNode *node) {
 		// get the table and schema
 		string schema = INVALID_SCHEMA;
 		string table;
-		assert(stmt->relation->relname);
+		D_ASSERT(stmt->relation->relname);
 		if (stmt->relation->relname) {
 			table = stmt->relation->relname;
 		}
@@ -39,7 +39,7 @@ unique_ptr<AlterStatement> Transformer::TransformRename(PGNode *node) {
 		// get the table and schema
 		string schema = DEFAULT_SCHEMA;
 		string table;
-		assert(stmt->relation->relname);
+		D_ASSERT(stmt->relation->relname);
 		if (stmt->relation->relname) {
 			table = stmt->relation->relname;
 		}
@@ -57,7 +57,7 @@ unique_ptr<AlterStatement> Transformer::TransformRename(PGNode *node) {
 		// get the view and schema
 		string schema = DEFAULT_SCHEMA;
 		string view;
-		assert(stmt->relation->relname);
+		D_ASSERT(stmt->relation->relname);
 		if (stmt->relation->relname) {
 			view = stmt->relation->relname;
 		}
@@ -72,7 +72,7 @@ unique_ptr<AlterStatement> Transformer::TransformRename(PGNode *node) {
 	default:
 		throw NotImplementedException("Schema element not supported yet!");
 	}
-	assert(info);
+	D_ASSERT(info);
 	return make_unique<AlterStatement>(move(info));
 }
 

--- a/src/parser/transform/statement/transform_select_node.cpp
+++ b/src/parser/transform/statement/transform_select_node.cpp
@@ -21,8 +21,8 @@ unique_ptr<QueryNode> Transformer::TransformSelectNode(PGSelectStmt *stmt) {
 		if (stmt->windowClause) {
 			for (auto window_ele = stmt->windowClause->head; window_ele != NULL; window_ele = window_ele->next) {
 				auto window_def = reinterpret_cast<PGWindowDef *>(window_ele->data.ptr_value);
-				assert(window_def);
-				assert(window_def->name);
+				D_ASSERT(window_def);
+				D_ASSERT(window_def->name);
 				auto window_name = StringUtil::Lower(string(window_def->name));
 
 				auto it = window_clauses.find(window_name);
@@ -36,7 +36,7 @@ unique_ptr<QueryNode> Transformer::TransformSelectNode(PGSelectStmt *stmt) {
 		// do this early so the value lists also have a `FROM`
 		if (stmt->valuesLists) {
 			// VALUES list, create an ExpressionList
-			assert(!stmt->fromClause);
+			D_ASSERT(!stmt->fromClause);
 			result->from_table = TransformValuesList(stmt->valuesLists);
 			result->select_list.push_back(make_unique<StarExpression>());
 		} else {

--- a/src/parser/transform/statement/transform_transaction.cpp
+++ b/src/parser/transform/statement/transform_transaction.cpp
@@ -7,7 +7,7 @@ using namespace duckdb_libpgquery;
 
 unique_ptr<TransactionStatement> Transformer::TransformTransaction(PGNode *node) {
 	auto stmt = reinterpret_cast<PGTransactionStmt *>(node);
-	assert(stmt);
+	D_ASSERT(stmt);
 	switch (stmt->kind) {
 	case PG_TRANS_STMT_BEGIN:
 	case PG_TRANS_STMT_START:

--- a/src/parser/transform/statement/transform_update.cpp
+++ b/src/parser/transform/statement/transform_update.cpp
@@ -7,7 +7,7 @@ using namespace duckdb_libpgquery;
 
 unique_ptr<UpdateStatement> Transformer::TransformUpdate(PGNode *node) {
 	auto stmt = reinterpret_cast<PGUpdateStmt *>(node);
-	assert(stmt);
+	D_ASSERT(stmt);
 
 	auto result = make_unique<UpdateStatement>();
 

--- a/src/parser/transform/statement/transform_vacuum.cpp
+++ b/src/parser/transform/statement/transform_vacuum.cpp
@@ -7,7 +7,7 @@ using namespace duckdb_libpgquery;
 
 unique_ptr<VacuumStatement> Transformer::TransformVacuum(PGNode *node) {
 	auto stmt = reinterpret_cast<PGVacuumStmt *>(node);
-	assert(stmt);
+	D_ASSERT(stmt);
 	(void)stmt;
 	auto result = make_unique<VacuumStatement>();
 	return result;

--- a/src/parser/transform/tableref/transform_join.cpp
+++ b/src/parser/transform/tableref/transform_join.cpp
@@ -46,7 +46,7 @@ unique_ptr<TableRef> Transformer::TransformJoin(PGJoinExpr *root) {
 		// usingClause is a list of strings
 		for (auto node = root->usingClause->head; node != nullptr; node = node->next) {
 			auto target = reinterpret_cast<PGNode *>(node->data.ptr_value);
-			assert(target->type == T_PGString);
+			D_ASSERT(target->type == T_PGString);
 			auto column_name = string(reinterpret_cast<PGValue *>(target)->val.str);
 			result->using_columns.push_back(column_name);
 		}

--- a/src/parser/transform/tableref/transform_table_function.cpp
+++ b/src/parser/transform/tableref/transform_table_function.cpp
@@ -20,11 +20,11 @@ unique_ptr<TableRef> Transformer::TransformRangeFunction(PGRangeFunction *root) 
 		throw NotImplementedException("Need exactly one function");
 	}
 	auto function_sublist = (PGList *)root->functions->head->data.ptr_value;
-	assert(function_sublist->length == 2);
+	D_ASSERT(function_sublist->length == 2);
 	auto call_tree = (PGNode *)function_sublist->head->data.ptr_value;
 	auto coldef = function_sublist->head->next->data.ptr_value;
 
-	assert(call_tree->type == T_PGFuncCall);
+	D_ASSERT(call_tree->type == T_PGFuncCall);
 	if (coldef) {
 		throw NotImplementedException("Explicit column definition not supported yet");
 	}

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -100,7 +100,7 @@ BindResult BindContext::BindColumn(ColumnRefExpression &colref, idx_t depth) {
 
 void BindContext::GenerateAllColumnExpressions(vector<unique_ptr<ParsedExpression>> &new_select_list, Binding *binding) {
 	for (auto &column_name : binding->names) {
-		assert(!column_name.empty());
+		D_ASSERT(!column_name.empty());
 		if (BindingIsHidden(binding->alias, column_name)) {
 			continue;
 		}

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -71,7 +71,7 @@ unique_ptr<BoundQueryNode> Binder::BindNode(QueryNode &node) {
 		result = BindNode((RecursiveCTENode &)node);
 		break;
 	default:
-		assert(node.type == QueryNodeType::SET_OPERATION_NODE);
+		D_ASSERT(node.type == QueryNodeType::SET_OPERATION_NODE);
 		result = BindNode((SetOperationNode &)node);
 		break;
 	}
@@ -148,8 +148,8 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundTableRef &ref) {
 }
 
 void Binder::AddCTE(const string &name, CommonTableExpressionInfo *info) {
-	assert(info);
-	assert(!name.empty());
+	D_ASSERT(info);
+	D_ASSERT(!name.empty());
 	auto entry = CTE_bindings.find(name);
 	if (entry != CTE_bindings.end()) {
 		throw BinderException("Duplicate CTE \"%s\" in query!", name);
@@ -182,12 +182,12 @@ void Binder::PushExpressionBinder(ExpressionBinder *binder) {
 }
 
 void Binder::PopExpressionBinder() {
-	assert(HasActiveBinder());
+	D_ASSERT(HasActiveBinder());
 	GetActiveBinders().pop_back();
 }
 
 void Binder::SetActiveBinder(ExpressionBinder *binder) {
-	assert(HasActiveBinder());
+	D_ASSERT(HasActiveBinder());
 	GetActiveBinders().back() = binder;
 }
 

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -8,7 +8,7 @@ namespace duckdb {
 using namespace std;
 
 BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref, idx_t depth) {
-	assert(!colref.column_name.empty());
+	D_ASSERT(!colref.column_name.empty());
 	// individual column reference
 	// resolve to either a base table or a subquery expression
 	if (colref.table_name.empty()) {

--- a/src/planner/binder/expression/bind_operator_expression.cpp
+++ b/src/planner/binder/expression/bind_operator_expression.cpp
@@ -8,7 +8,7 @@ using namespace std;
 
 static LogicalType ResolveNotType(OperatorExpression &op, vector<BoundExpression *> &children) {
 	// NOT expression, cast child to BOOLEAN
-	assert(children.size() == 1);
+	D_ASSERT(children.size() == 1);
 	children[0]->expr = BoundCastExpression::AddCastToType(move(children[0]->expr), LogicalType::BOOLEAN);
 	return LogicalType(LogicalTypeId::BOOLEAN);
 }
@@ -37,7 +37,7 @@ static LogicalType ResolveOperatorType(OperatorExpression &op, vector<BoundExpre
 	case ExpressionType::COMPARE_NOT_IN:
 		return ResolveInType(op, children);
 	default:
-		assert(op.type == ExpressionType::OPERATOR_NOT);
+		D_ASSERT(op.type == ExpressionType::OPERATOR_NOT);
 		return ResolveNotType(op, children);
 	}
 }
@@ -54,7 +54,7 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 	// all children bound successfully, extract them
 	vector<BoundExpression *> children;
 	for (idx_t i = 0; i < op.children.size(); i++) {
-		assert(op.children[i]->expression_class == ExpressionClass::BOUND_EXPRESSION);
+		D_ASSERT(op.children[i]->expression_class == ExpressionClass::BOUND_EXPRESSION);
 		children.push_back((BoundExpression *)op.children[i].get());
 	}
 	// now resolve the types

--- a/src/planner/binder/expression/bind_subquery_expression.cpp
+++ b/src/planner/binder/expression/bind_subquery_expression.cpp
@@ -30,7 +30,7 @@ public:
 
 BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t depth) {
 	if (expr.subquery->node->type != QueryNodeType::BOUND_SUBQUERY_NODE) {
-		assert(depth == 0);
+		D_ASSERT(depth == 0);
 		// first bind the actual subquery in a new binder
 		auto subquery_binder = make_unique<Binder>(context, &binder);
 		for (auto &cte_it : expr.subquery->cte_map) {
@@ -64,7 +64,7 @@ BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t dept
 		}
 	}
 	// both binding the child and binding the subquery was successful
-	assert(expr.subquery->node->type == QueryNodeType::BOUND_SUBQUERY_NODE);
+	D_ASSERT(expr.subquery->node->type == QueryNodeType::BOUND_SUBQUERY_NODE);
 	auto bound_subquery = (BoundSubqueryNode *)expr.subquery->node.get();
 	auto child = (BoundExpression *)expr.child.get();
 	auto subquery_binder = move(bound_subquery->subquery_binder);
@@ -79,7 +79,7 @@ BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t dept
 	if (expr.subquery_type == SubqueryType::ANY) {
 		// ANY comparison
 		// cast child and subquery child to equivalent types
-		assert(bound_node->types.size() == 1);
+		D_ASSERT(bound_node->types.size() == 1);
 		auto compare_type = LogicalType::MaxLogicalType(child->expr->return_type, bound_node->types[0]);
 		child->expr = BoundCastExpression::AddCastToType(move(child->expr), compare_type);
 		result->child_type = bound_node->types[0];

--- a/src/planner/binder/expression/bind_unnest_expression.cpp
+++ b/src/planner/binder/expression/bind_unnest_expression.cpp
@@ -28,7 +28,7 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth) {
 		return BindResult(binder.FormatError(function, "Unnest() can only be applied to lists"));
 	}
 	LogicalType return_type = LogicalType::ANY;
-	assert(child_type.child_types().size() <= 1);
+	D_ASSERT(child_type.child_types().size() <= 1);
 	if (child_type.child_types().size() == 1) {
 		return_type = child_type.child_types()[0].second;
 	}

--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -26,12 +26,12 @@ static LogicalType ResolveWindowExpressionType(ExpressionType window_type, Logic
 		return LogicalType::BIGINT;
 	case ExpressionType::WINDOW_FIRST_VALUE:
 	case ExpressionType::WINDOW_LAST_VALUE:
-		assert(child_type.id() != LogicalTypeId::INVALID); // "Window function needs an expression"
+		D_ASSERT(child_type.id() != LogicalTypeId::INVALID); // "Window function needs an expression"
 		return child_type;
 	case ExpressionType::WINDOW_LEAD:
 	default:
-		assert(window_type == ExpressionType::WINDOW_LAG || window_type == ExpressionType::WINDOW_LEAD);
-		assert(child_type.id() != LogicalTypeId::INVALID); // "Window function needs an expression"
+		D_ASSERT(window_type == ExpressionType::WINDOW_LAG || window_type == ExpressionType::WINDOW_LEAD);
+		D_ASSERT(child_type.id() != LogicalTypeId::INVALID); // "Window function needs an expression"
 		return child_type;
 	}
 }
@@ -40,8 +40,8 @@ static unique_ptr<Expression> GetExpression(unique_ptr<ParsedExpression> &expr) 
 	if (!expr) {
 		return nullptr;
 	}
-	assert(expr.get());
-	assert(expr->expression_class == ExpressionClass::BOUND_EXPRESSION);
+	D_ASSERT(expr.get());
+	D_ASSERT(expr->expression_class == ExpressionClass::BOUND_EXPRESSION);
 	return move(((BoundExpression &)*expr).expr);
 }
 
@@ -78,8 +78,8 @@ BindResult SelectBinder::BindWindow(WindowExpression &window, idx_t depth) {
 	vector<LogicalType> types;
 	vector<unique_ptr<Expression>> children;
 	for (auto &child : window.children) {
-		assert(child.get());
-		assert(child->expression_class == ExpressionClass::BOUND_EXPRESSION);
+		D_ASSERT(child.get());
+		D_ASSERT(child->expression_class == ExpressionClass::BOUND_EXPRESSION);
 		auto &bound = (BoundExpression &)*child;
 		types.push_back(bound.expr->return_type);
 		children.push_back(move(bound.expr));

--- a/src/planner/binder/query_node/bind_recursive_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_recursive_cte_node.cpp
@@ -14,8 +14,8 @@ unique_ptr<BoundQueryNode> Binder::BindNode(RecursiveCTENode &statement) {
 
 	// first recursively visit the recursive CTE operations
 	// the left side is visited first and is added to the BindContext of the right side
-	assert(statement.left);
-	assert(statement.right);
+	D_ASSERT(statement.left);
+	D_ASSERT(statement.right);
 
 	result->ctename = statement.ctename;
 	result->union_all = statement.union_all;

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -43,7 +43,7 @@ unique_ptr<Expression> Binder::BindOrderExpression(OrderBinder &order_binder, un
 		// remove the expression from the DISTINCT ON list
 		return nullptr;
 	}
-	assert(bound_expr->type == ExpressionType::BOUND_COLUMN_REF);
+	D_ASSERT(bound_expr->type == ExpressionType::BOUND_COLUMN_REF);
 	return bound_expr;
 }
 
@@ -127,12 +127,12 @@ void Binder::BindModifierTypes(BoundQueryNode &result, const vector<LogicalType>
 				// DISTINCT with target list: set types
 				for (idx_t i = 0; i < distinct.target_distincts.size(); i++) {
 					auto &expr = distinct.target_distincts[i];
-					assert(expr->type == ExpressionType::BOUND_COLUMN_REF);
+					D_ASSERT(expr->type == ExpressionType::BOUND_COLUMN_REF);
 					auto &bound_colref = (BoundColumnRefExpression &)*expr;
 					if (bound_colref.binding.column_index == INVALID_INDEX) {
 						throw BinderException("Ambiguous name in DISTINCT ON!");
 					}
-					assert(bound_colref.binding.column_index < sql_types.size());
+					D_ASSERT(bound_colref.binding.column_index < sql_types.size());
 					bound_colref.return_type = sql_types[bound_colref.binding.column_index];
 				}
 			}
@@ -150,12 +150,12 @@ void Binder::BindModifierTypes(BoundQueryNode &result, const vector<LogicalType>
 			auto &order = (BoundOrderModifier &)*bound_mod;
 			for (idx_t i = 0; i < order.orders.size(); i++) {
 				auto &expr = order.orders[i].expression;
-				assert(expr->type == ExpressionType::BOUND_COLUMN_REF);
+				D_ASSERT(expr->type == ExpressionType::BOUND_COLUMN_REF);
 				auto &bound_colref = (BoundColumnRefExpression &)*expr;
 				if (bound_colref.binding.column_index == INVALID_INDEX) {
 					throw BinderException("Ambiguous name in ORDER BY!");
 				}
-				assert(bound_colref.binding.column_index < sql_types.size());
+				D_ASSERT(bound_colref.binding.column_index < sql_types.size());
 				auto sql_type = sql_types[bound_colref.binding.column_index];
 				bound_colref.return_type = sql_types[bound_colref.binding.column_index];
 				if (sql_type.id() == LogicalTypeId::VARCHAR) {
@@ -244,7 +244,7 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SelectNode &statement) {
 			// bind the groups
 			LogicalType group_type;
 			auto bound_expr = group_binder.Bind(statement.groups[i], &group_type);
-			assert(bound_expr->return_type.id() != LogicalTypeId::INVALID);
+			D_ASSERT(bound_expr->return_type.id() != LogicalTypeId::INVALID);
 
 			// push a potential collation, if necessary
 			bound_expr = ExpressionBinder::PushCollation(context, move(bound_expr), group_type.collation(), true);

--- a/src/planner/binder/query_node/bind_setop_node.cpp
+++ b/src/planner/binder/query_node/bind_setop_node.cpp
@@ -22,7 +22,7 @@ static void GatherAliases(BoundQueryNode &node, unordered_map<string, idx_t> &al
 		GatherAliases(*setop.right, aliases, expressions);
 	} else {
 		// query node
-		assert(node.type == QueryNodeType::SELECT_NODE);
+		D_ASSERT(node.type == QueryNodeType::SELECT_NODE);
 		auto &select = (BoundSelectNode &)node;
 		// fill the alias lists
 		for (idx_t i = 0; i < select.names.size(); i++) {
@@ -65,8 +65,8 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SetOperationNode &statement) {
 
 	// first recursively visit the set operations
 	// both the left and right sides have an independent BindContext and Binder
-	assert(statement.left);
-	assert(statement.right);
+	D_ASSERT(statement.left);
+	D_ASSERT(statement.right);
 
 	result->setop_index = GenerateTableIndex();
 

--- a/src/planner/binder/query_node/plan_query_node.cpp
+++ b/src/planner/binder/query_node/plan_query_node.cpp
@@ -8,7 +8,7 @@ namespace duckdb {
 using namespace std;
 
 unique_ptr<LogicalOperator> Binder::VisitQueryNode(BoundQueryNode &node, unique_ptr<LogicalOperator> root) {
-	assert(root);
+	D_ASSERT(root);
 	for (auto &mod : node.modifiers) {
 		switch (mod->type) {
 		case ResultModifierType::DISTINCT_MODIFIER: {

--- a/src/planner/binder/query_node/plan_select_node.cpp
+++ b/src/planner/binder/query_node/plan_select_node.cpp
@@ -16,9 +16,9 @@ unique_ptr<LogicalOperator> Binder::PlanFilter(unique_ptr<Expression> condition,
 
 unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSelectNode &statement) {
 	unique_ptr<LogicalOperator> root;
-	assert(statement.from_table);
+	D_ASSERT(statement.from_table);
 	root = CreatePlan(*statement.from_table);
-	assert(root);
+	D_ASSERT(root);
 
 	if (statement.where_clause) {
 		root = PlanFilter(move(statement.where_clause), move(root));
@@ -60,7 +60,7 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSelectNode &statement) {
 		for (auto &expr : win->expressions) {
 			PlanSubqueries(&expr, &root);
 		}
-		assert(win->expressions.size() > 0);
+		D_ASSERT(win->expressions.size() > 0);
 		win->AddChild(move(root));
 		root = move(win);
 	}
@@ -72,7 +72,7 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSelectNode &statement) {
 		for (auto &expr : unnest->expressions) {
 			PlanSubqueries(&expr, &root);
 		}
-		assert(unnest->expressions.size() > 0);
+		D_ASSERT(unnest->expressions.size() > 0);
 		unnest->AddChild(move(root));
 		root = move(unnest);
 	}
@@ -92,7 +92,7 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSelectNode &statement) {
 
 	// add a prune node if necessary
 	if (statement.need_prune) {
-		assert(root);
+		D_ASSERT(root);
 		vector<unique_ptr<Expression>> prune_expressions;
 		for (idx_t i = 0; i < statement.column_count; i++) {
 			prune_expressions.push_back(make_unique<BoundColumnRefExpression>(

--- a/src/planner/binder/query_node/plan_setop.cpp
+++ b/src/planner/binder/query_node/plan_setop.cpp
@@ -11,9 +11,9 @@ using namespace std;
 unique_ptr<LogicalOperator> Binder::CastLogicalOperatorToTypes(vector<LogicalType> &source_types,
                                                                vector<LogicalType> &target_types,
                                                                unique_ptr<LogicalOperator> op) {
-	assert(op);
+	D_ASSERT(op);
 	// first check if we even need to cast
-	assert(source_types.size() == target_types.size());
+	D_ASSERT(source_types.size() == target_types.size());
 	if (source_types == target_types) {
 		// source and target types are equal: don't need to cast
 		return op;
@@ -22,7 +22,7 @@ unique_ptr<LogicalOperator> Binder::CastLogicalOperatorToTypes(vector<LogicalTyp
 	auto node = op.get();
 	if (node->type == LogicalOperatorType::PROJECTION) {
 		// "node" is a projection; we can just do the casts in there
-		assert(node->expressions.size() == source_types.size());
+		D_ASSERT(node->expressions.size() == source_types.size());
 		// add the casts to the selection list
 		for (idx_t i = 0; i < target_types.size(); i++) {
 			if (source_types[i] != target_types[i]) {
@@ -39,7 +39,7 @@ unique_ptr<LogicalOperator> Binder::CastLogicalOperatorToTypes(vector<LogicalTyp
 
 		// fetch the set of column bindings
 		auto setop_columns = op->GetColumnBindings();
-		assert(setop_columns.size() == source_types.size());
+		D_ASSERT(setop_columns.size() == source_types.size());
 
 		// now generate the expression list
 		vector<unique_ptr<Expression>> select_list;
@@ -83,7 +83,7 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSetOperationNode &node) {
 		logical_type = LogicalOperatorType::EXCEPT;
 		break;
 	default:
-		assert(node.setop_type == SetOperationType::INTERSECT);
+		D_ASSERT(node.setop_type == SetOperationType::INTERSECT);
 		logical_type = LogicalOperatorType::INTERSECT;
 		break;
 	}

--- a/src/planner/binder/statement/bind_call.cpp
+++ b/src/planner/binder/statement/bind_call.cpp
@@ -16,7 +16,7 @@ BoundStatement Binder::Bind(CallStatement &stmt) {
 	auto bound_func = Bind(ref);
 	auto &bound_table_func = (BoundTableFunction &)*bound_func;
 	auto &get = (LogicalGet &)*bound_table_func.get;
-	assert(get.returned_types.size() > 0);
+	D_ASSERT(get.returned_types.size() > 0);
 	for (idx_t i = 0; i < get.returned_types.size(); i++) {
 		get.column_ids.push_back(i);
 	}

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -57,7 +57,7 @@ BoundStatement Binder::BindCopyFrom(CopyStatement &stmt) {
 	result.types = {LogicalType::BIGINT};
 	result.names = {"Count"};
 
-	assert(!stmt.info->table.empty());
+	D_ASSERT(!stmt.info->table.empty());
 	// COPY FROM a file
 	// generate an insert statement for the the to-be-inserted table
 	InsertStatement insert;
@@ -67,7 +67,7 @@ BoundStatement Binder::BindCopyFrom(CopyStatement &stmt) {
 
 	// bind the insert statement to the base table
 	auto insert_statement = Bind(insert);
-	assert(insert_statement.plan->type == LogicalOperatorType::INSERT);
+	D_ASSERT(insert_statement.plan->type == LogicalOperatorType::INSERT);
 
 	auto &bound_insert = (LogicalInsert &)*insert_statement.plan;
 

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -35,7 +35,7 @@ SchemaCatalogEntry *Binder::BindSchema(CreateInfo &info) {
 	}
 	// fetch the schema in which we want to create the object
 	auto schema_obj = Catalog::GetCatalog(context).GetSchema(context, info.schema);
-	assert(schema_obj->type == CatalogType::SCHEMA_ENTRY);
+	D_ASSERT(schema_obj->type == CatalogType::SCHEMA_ENTRY);
 	info.schema = schema_obj->name;
 	return schema_obj;
 }

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -58,13 +58,13 @@ static void BindConstraints(Binder &binder, BoundCreateTableInfo &info) {
 			// have to resolve columns of the unique constraint
 			unordered_set<idx_t> keys;
 			if (unique.index != INVALID_INDEX) {
-				assert(unique.index < base.columns.size());
+				D_ASSERT(unique.index < base.columns.size());
 				// unique constraint is given by single index
 				keys.insert(unique.index);
 			} else {
 				// unique constraint is given by list of names
 				// have to resolve names
-				assert(unique.columns.size() > 0);
+				D_ASSERT(unique.columns.size() > 0);
 				for (auto &keyname : unique.columns) {
 					auto entry = info.name_map.find(keyname);
 					if (entry == info.name_map.end()) {
@@ -134,7 +134,7 @@ unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableInfo(unique_ptr<CreateIn
 		// construct the set of columns based on the names and types of the query
 		auto &names = query_obj.names;
 		auto &sql_types = query_obj.types;
-		assert(names.size() == sql_types.size());
+		D_ASSERT(names.size() == sql_types.size());
 		for (idx_t i = 0; i < names.size(); i++) {
 			base.columns.push_back(ColumnDefinition(names[i], sql_types[i]));
 		}

--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -23,7 +23,7 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 
 	auto root = CreatePlan(*bound_table);
 	auto &get = (LogicalGet &)*root;
-	assert(root->type == LogicalOperatorType::GET);
+	D_ASSERT(root->type == LogicalOperatorType::GET);
 
 	if (!table->temporary) {
 		// delete from persistent table: not read only!

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -29,7 +29,7 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 	result.types = {LogicalType::BIGINT};
 
 	auto table = Catalog::GetCatalog(context).GetEntry<TableCatalogEntry>(context, stmt.schema, stmt.table);
-	assert(table);
+	D_ASSERT(table);
 	if (!table->temporary) {
 		// inserting into a non-temporary table: alters underlying database
 		this->read_only = false;
@@ -88,14 +88,14 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 			expr_list.expected_types.resize(expected_columns);
 			expr_list.expected_names.resize(expected_columns);
 
-			assert(expr_list.values.size() > 0);
+			D_ASSERT(expr_list.values.size() > 0);
 			CheckInsertColumnCountMismatch(expected_columns, expr_list.values[0].size(), stmt.columns.size() != 0,
 			                               table->name.c_str());
 
 			// VALUES list!
 			for (idx_t col_idx = 0; col_idx < expected_columns; col_idx++) {
 				idx_t table_col_idx = stmt.columns.size() == 0 ? col_idx : named_column_map[col_idx];
-				assert(table_col_idx < table->columns.size());
+				D_ASSERT(table_col_idx < table->columns.size());
 
 				// set the expected types as the types for the INSERT statement
 				auto &column = table->columns[table_col_idx];

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -131,7 +131,7 @@ BoundStatement Binder::Bind(UpdateStatement &stmt) {
 		root = move(filter);
 	}
 
-	assert(stmt.columns.size() == stmt.expressions.size());
+	D_ASSERT(stmt.columns.size() == stmt.expressions.size());
 
 	auto proj_index = GenerateTableIndex();
 	vector<unique_ptr<Expression>> projection_expressions;

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -92,7 +92,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		    BindContext::AliasColumnNames(subquery.alias, view_catalog_entry->aliases, ref.column_name_alias);
 		// bind the child subquery
 		auto bound_child = view_binder.Bind(subquery);
-		assert(bound_child->type == TableReferenceType::SUBQUERY);
+		D_ASSERT(bound_child->type == TableReferenceType::SUBQUERY);
 		// verify that the types and names match up with the expected types and names
 		auto &bound_subquery = (BoundSubqueryRef &)*bound_child;
 		if (bound_subquery.subquery->types != view_catalog_entry->types) {

--- a/src/planner/binder/tableref/bind_crossproductref.cpp
+++ b/src/planner/binder/tableref/bind_crossproductref.cpp
@@ -7,8 +7,14 @@ using namespace std;
 
 unique_ptr<BoundTableRef> Binder::Bind(CrossProductRef &ref) {
 	auto result = make_unique<BoundCrossProductRef>();
-	result->left = Bind(*ref.left);
-	result->right = Bind(*ref.right);
+	Binder left_binder(context, this);
+	Binder right_binder(context, this);
+
+	result->left = left_binder.Bind(*ref.left);
+	result->right = right_binder.Bind(*ref.right);
+
+	bind_context.AddContext(move(left_binder.bind_context));
+	bind_context.AddContext(move(right_binder.bind_context));
 	return move(result);
 }
 

--- a/src/planner/binder/tableref/bind_crossproductref.cpp
+++ b/src/planner/binder/tableref/bind_crossproductref.cpp
@@ -7,8 +7,10 @@ using namespace std;
 
 unique_ptr<BoundTableRef> Binder::Bind(CrossProductRef &ref) {
 	auto result = make_unique<BoundCrossProductRef>();
-	Binder left_binder(context, this);
-	Binder right_binder(context, this);
+	result->left_binder = make_unique<Binder>(context, this);
+	result->right_binder = make_unique<Binder>(context, this);
+	auto &left_binder = *result->left_binder;
+	auto &right_binder = *result->right_binder;
 
 	result->left = left_binder.Bind(*ref.left);
 	result->right = right_binder.Bind(*ref.right);

--- a/src/planner/binder/tableref/bind_crossproductref.cpp
+++ b/src/planner/binder/tableref/bind_crossproductref.cpp
@@ -15,6 +15,8 @@ unique_ptr<BoundTableRef> Binder::Bind(CrossProductRef &ref) {
 
 	bind_context.AddContext(move(left_binder.bind_context));
 	bind_context.AddContext(move(right_binder.bind_context));
+	MoveCorrelatedExpressions(left_binder);
+	MoveCorrelatedExpressions(right_binder);
 	return move(result);
 }
 

--- a/src/planner/binder/tableref/bind_joinref.cpp
+++ b/src/planner/binder/tableref/bind_joinref.cpp
@@ -24,10 +24,12 @@ static void AddCondition(JoinRef &ref, string left_alias, string right_alias, st
 }
 
 unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
-	Binder left_binder(context, this);
-	Binder right_binder(context, this);
-
 	auto result = make_unique<BoundJoinRef>();
+	result->left_binder = make_unique<Binder>(context, this);
+	result->right_binder = make_unique<Binder>(context, this);
+	auto &left_binder = *result->left_binder;
+	auto &right_binder = *result->right_binder;
+
 	result->type = ref.type;
 	result->left = left_binder.Bind(*ref.left);
 	result->right = right_binder.Bind(*ref.right);

--- a/src/planner/binder/tableref/bind_joinref.cpp
+++ b/src/planner/binder/tableref/bind_joinref.cpp
@@ -171,6 +171,8 @@ unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
 	}
 	bind_context.AddContext(move(left_binder.bind_context));
 	bind_context.AddContext(move(right_binder.bind_context));
+	MoveCorrelatedExpressions(left_binder);
+	MoveCorrelatedExpressions(right_binder);
 	if (ref.condition) {
 		WhereBinder binder(*this, context);
 		result->condition = binder.Bind(ref.condition);

--- a/src/planner/binder/tableref/bind_joinref.cpp
+++ b/src/planner/binder/tableref/bind_joinref.cpp
@@ -3,16 +3,86 @@
 #include "duckdb/planner/expression_binder/where_binder.hpp"
 #include "duckdb/planner/tableref/bound_joinref.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
+#include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/comparison_expression.hpp"
 #include "duckdb/parser/expression/conjunction_expression.hpp"
 
 namespace duckdb {
 using namespace std;
 
+static void AddCondition(JoinRef &ref, string left_alias, string right_alias, string column_name) {
+	auto left_expr = make_unique<ColumnRefExpression>(column_name, left_alias);
+	auto right_expr = make_unique<ColumnRefExpression>(column_name, right_alias);
+	auto comp_expr =
+		make_unique<ComparisonExpression>(ExpressionType::COMPARE_EQUAL, move(left_expr), move(right_expr));
+	if (!ref.condition) {
+		ref.condition = move(comp_expr);
+	} else {
+		ref.condition = make_unique<ConjunctionExpression>(ExpressionType::CONJUNCTION_AND, move(ref.condition),
+															move(comp_expr));
+	}
+}
+
 unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
 	auto result = make_unique<BoundJoinRef>();
 	result->type = ref.type;
-	if (ref.using_columns.size() > 0) {
+	if (ref.is_natural) {
+		// natural join, figure out which column names are present in both sides of the join
+		// first bind the left hand side and get a list of all the tables and column names
+		result->left = Bind(*ref.left);
+		unordered_set<string> lhs_tables;
+		unordered_set<string> lhs_columns;
+		auto &binding_list = bind_context.GetBindingsList();
+		for(auto &binding : binding_list) {
+			lhs_tables.insert(binding.first);
+			for(auto &column_name : binding.second->names) {
+				lhs_columns.insert(column_name);
+			}
+		}
+		// now bind the rhs
+		result->right = Bind(*ref.right);
+		for (auto &column_name : lhs_columns) {
+			// loop over the set of lhs columns, and figure out if there is a table in the rhs with the same name
+			auto all_bindings = bind_context.GetMatchingBindings(column_name);
+			string left_binding;
+			string right_binding;
+			for (auto &binding : all_bindings) {
+				if (lhs_tables.find(binding) == lhs_tables.end()) {
+					assert(right_binding.empty());
+					right_binding = binding;
+				} else {
+					left_binding = binding;
+				}
+			}
+			if (right_binding.empty()) {
+				continue;
+			}
+			assert(!left_binding.empty());
+			// there is a match! create the join condition
+			AddCondition(ref, left_binding, right_binding, column_name);
+			bind_context.hidden_columns.insert(right_binding + "." + column_name);
+		}
+		if (!ref.condition) {
+			// no matching bindings found in natural join: throw an exception
+			string error_msg = "No columns found to join on in NATURAL JOIN.\n";
+			error_msg += "Use CROSS JOIN if you intended for this to be a cross-product.";
+			// gather all left/right candidates
+			string left_candidates, right_candidates;
+			for(auto &binding : binding_list) {
+				bool lhs_table = lhs_tables.find(binding.first) != lhs_tables.end();
+				auto &candidates = lhs_table ? left_candidates : right_candidates;
+				for(auto &column_name : binding.second->names) {
+					if (!candidates.empty()) {
+						candidates += ", ";
+					}
+					candidates += binding.first + "." + column_name;
+				}
+			}
+			error_msg += "\n   Left candidates: " + left_candidates;
+			error_msg += "\n   Right candidates: " + right_candidates;
+			throw BinderException(FormatError(ref, error_msg));
+		}
+	} else if (ref.using_columns.size() > 0) {
 		// USING columns
 		assert(!result->condition);
 		vector<string> left_join_bindings;
@@ -62,17 +132,8 @@ unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
 				throw BinderException("Column \"%s\" does not exist on right side of join!", using_column);
 			}
 			assert(!left_binding.empty());
-			auto left_expr = make_unique<ColumnRefExpression>(using_column, left_binding);
-			auto right_expr = make_unique<ColumnRefExpression>(using_column, right_binding);
-			bind_context.hidden_columns.insert(right_expr->table_name + "." + right_expr->column_name);
-			auto comp_expr =
-			    make_unique<ComparisonExpression>(ExpressionType::COMPARE_EQUAL, move(left_expr), move(right_expr));
-			if (!ref.condition) {
-				ref.condition = move(comp_expr);
-			} else {
-				ref.condition = make_unique<ConjunctionExpression>(ExpressionType::CONJUNCTION_AND, move(ref.condition),
-				                                                   move(comp_expr));
-			}
+			AddCondition(ref, left_binding, right_binding, using_column);
+			bind_context.hidden_columns.insert(right_binding + "." + using_column);
 		}
 	} else {
 		result->left = Bind(*ref.left);

--- a/src/planner/binder/tableref/bind_joinref.cpp
+++ b/src/planner/binder/tableref/bind_joinref.cpp
@@ -48,7 +48,7 @@ unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
 			string right_binding;
 			for (auto &binding : all_bindings) {
 				if (lhs_tables.find(binding) == lhs_tables.end()) {
-					assert(right_binding.empty());
+					D_ASSERT(right_binding.empty());
 					right_binding = binding;
 				} else {
 					left_binding = binding;
@@ -57,7 +57,7 @@ unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
 			if (right_binding.empty()) {
 				continue;
 			}
-			assert(!left_binding.empty());
+			D_ASSERT(!left_binding.empty());
 			// there is a match! create the join condition
 			AddCondition(ref, left_binding, right_binding, column_name);
 			bind_context.hidden_columns.insert(right_binding + "." + column_name);
@@ -84,7 +84,7 @@ unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
 		}
 	} else if (ref.using_columns.size() > 0) {
 		// USING columns
-		assert(!result->condition);
+		D_ASSERT(!result->condition);
 		vector<string> left_join_bindings;
 		vector<unordered_set<string>> matching_left_bindings;
 
@@ -124,14 +124,14 @@ unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
 			string right_binding;
 			for (auto &binding : all_bindings) {
 				if (left_bindings.find(binding) == left_bindings.end()) {
-					assert(right_binding.empty());
+					D_ASSERT(right_binding.empty());
 					right_binding = binding;
 				}
 			}
 			if (right_binding.empty()) {
 				throw BinderException("Column \"%s\" does not exist on right side of join!", using_column);
 			}
-			assert(!left_binding.empty());
+			D_ASSERT(!left_binding.empty());
 			AddCondition(ref, left_binding, right_binding, using_column);
 			bind_context.hidden_columns.insert(right_binding + "." + using_column);
 		}

--- a/src/planner/binder/tableref/bind_joinref.cpp
+++ b/src/planner/binder/tableref/bind_joinref.cpp
@@ -24,43 +24,64 @@ static void AddCondition(JoinRef &ref, string left_alias, string right_alias, st
 }
 
 unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
+	Binder left_binder(context, this);
+	Binder right_binder(context, this);
+
 	auto result = make_unique<BoundJoinRef>();
 	result->type = ref.type;
+	result->left = left_binder.Bind(*ref.left);
+	result->right = right_binder.Bind(*ref.right);
 	if (ref.is_natural) {
 		// natural join, figure out which column names are present in both sides of the join
 		// first bind the left hand side and get a list of all the tables and column names
-		result->left = Bind(*ref.left);
-		unordered_set<string> lhs_tables;
-		unordered_set<string> lhs_columns;
-		auto &binding_list = bind_context.GetBindingsList();
-		for(auto &binding : binding_list) {
-			lhs_tables.insert(binding.first);
+		unordered_map<string, string> lhs_columns;
+		auto &lhs_binding_list = left_binder.bind_context.GetBindingsList();
+		for(auto &binding : lhs_binding_list) {
 			for(auto &column_name : binding.second->names) {
-				lhs_columns.insert(column_name);
+				if (left_binder.bind_context.BindingIsHidden(binding.first, column_name)) {
+					continue;
+				}
+				if (lhs_columns.find(column_name) == lhs_columns.end()) {
+					// new column candidate: add it to the set
+					lhs_columns[column_name] = binding.first;
+				} else {
+					// this column candidate appears multiple times on the left-hand side of the join
+					// this is fine ONLY if the column name does not occur in the right hand side
+					// replace the binding with an empty string
+					lhs_columns[column_name] = string();
+				}
 			}
 		}
 		// now bind the rhs
-		result->right = Bind(*ref.right);
-		for (auto &column_name : lhs_columns) {
+		for (auto &column : lhs_columns) {
+			auto &column_name = column.first;
+			auto &left_binding = column.second;
 			// loop over the set of lhs columns, and figure out if there is a table in the rhs with the same name
-			auto all_bindings = bind_context.GetMatchingBindings(column_name);
-			string left_binding;
+			auto right_bindings = right_binder.bind_context.GetMatchingBindings(column_name);
 			string right_binding;
-			for (auto &binding : all_bindings) {
-				if (lhs_tables.find(binding) == lhs_tables.end()) {
-					D_ASSERT(right_binding.empty());
-					right_binding = binding;
-				} else {
-					left_binding = binding;
-				}
-			}
-			if (right_binding.empty()) {
+
+			if (right_bindings.size() == 0) {
+				// no match found for this column on the rhs
 				continue;
 			}
-			D_ASSERT(!left_binding.empty());
+			// found this column name in both the LHS and the RHS of this join
+			// add it to the natural join!
+			// first check if the binding is ambiguous
+			bool left_ambiguous = left_binding.empty();
+			bool right_ambiguous = right_bindings.size() > 1;
+			if (left_ambiguous || right_ambiguous) {
+				// binding is ambiguous on left or right side: throw an exception
+				string error_msg = "Column name \"" + column_name + "\" is ambiguous: it exists more than once on the ";
+				error_msg += left_ambiguous ? "left" : "right";
+				error_msg += " side of the join.";
+				throw BinderException(FormatError(ref, error_msg));
+			}
+			for (auto &binding : right_bindings) {
+				right_binding = binding;
+			}
 			// there is a match! create the join condition
 			AddCondition(ref, left_binding, right_binding, column_name);
-			bind_context.hidden_columns.insert(right_binding + "." + column_name);
+			bind_context.HideBinding(right_binding, column_name);
 		}
 		if (!ref.condition) {
 			// no matching bindings found in natural join: throw an exception
@@ -68,14 +89,21 @@ unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
 			error_msg += "Use CROSS JOIN if you intended for this to be a cross-product.";
 			// gather all left/right candidates
 			string left_candidates, right_candidates;
-			for(auto &binding : binding_list) {
-				bool lhs_table = lhs_tables.find(binding.first) != lhs_tables.end();
-				auto &candidates = lhs_table ? left_candidates : right_candidates;
+			auto &rhs_binding_list = right_binder.bind_context.GetBindingsList();
+			for(auto &binding : lhs_binding_list) {
 				for(auto &column_name : binding.second->names) {
-					if (!candidates.empty()) {
-						candidates += ", ";
+					if (!left_candidates.empty()) {
+						left_candidates += ", ";
 					}
-					candidates += binding.first + "." + column_name;
+					left_candidates += binding.first + "." + column_name;
+				}
+			}
+			for(auto &binding : rhs_binding_list) {
+				for(auto &column_name : binding.second->names) {
+					if (!right_candidates.empty()) {
+						right_candidates += ", ";
+					}
+					right_candidates += binding.first + "." + column_name;
 				}
 			}
 			error_msg += "\n   Left candidates: " + left_candidates;
@@ -86,45 +114,50 @@ unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
 		// USING columns
 		D_ASSERT(!result->condition);
 		vector<string> left_join_bindings;
-		vector<unordered_set<string>> matching_left_bindings;
 
-		result->left = Bind(*ref.left);
 		for (auto &using_column : ref.using_columns) {
 			// for each using column, get the matching binding
-			auto left_bindings = bind_context.GetMatchingBindings(using_column);
+			auto left_bindings = left_binder.bind_context.GetMatchingBindings(using_column);
 			if (left_bindings.size() == 0) {
 				throw BinderException("Column \"%s\" does not exist on left side of join!", using_column);
 			}
 			// find the join binding
 			string left_binding;
 			for (auto &binding : left_bindings) {
-				if (!bind_context.BindingIsHidden(binding, using_column)) {
-					if (!left_binding.empty()) {
-						string error = "Column name \"" + using_column +
-						               "\" is ambiguous: it exists more than once on left side of join.\nCandidates:";
-						for (auto &binding : left_bindings) {
-							error += "\n\t" + binding + "." + using_column;
-						}
-						throw BinderException(error);
-					} else {
-						left_binding = binding;
+				if (left_binder.bind_context.BindingIsHidden(binding, using_column)) {
+					continue;
+				}
+				if (!left_binding.empty()) {
+					string error = "Column name \"" + using_column +
+									"\" is ambiguous: it exists more than once on left side of join.\nCandidates:";
+					for (auto &binding : left_bindings) {
+						error += "\n\t" + binding + "." + using_column;
 					}
+					throw BinderException(error);
+				} else {
+					left_binding = binding;
 				}
 			}
 			left_join_bindings.push_back(left_binding);
-			matching_left_bindings.push_back(move(left_bindings));
 		}
-		result->right = Bind(*ref.right);
 		for (idx_t i = 0; i < ref.using_columns.size(); i++) {
 			auto &using_column = ref.using_columns[i];
-			auto &left_bindings = matching_left_bindings[i];
 			auto left_binding = left_join_bindings[i];
 
-			auto all_bindings = bind_context.GetMatchingBindings(using_column);
+			auto right_bindings = right_binder.bind_context.GetMatchingBindings(using_column);
 			string right_binding;
-			for (auto &binding : all_bindings) {
-				if (left_bindings.find(binding) == left_bindings.end()) {
-					D_ASSERT(right_binding.empty());
+			for (auto &binding : right_bindings) {
+				if (right_binder.bind_context.BindingIsHidden(binding, using_column)) {
+					continue;
+				}
+				if (!right_binding.empty()) {
+					string error = "Column name \"" + using_column +
+									"\" is ambiguous: it exists more than once on right side of join.\nCandidates:";
+					for (auto &binding : right_bindings) {
+						error += "\n\t" + binding + "." + using_column;
+					}
+					throw BinderException(error);
+				} else {
 					right_binding = binding;
 				}
 			}
@@ -133,12 +166,11 @@ unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
 			}
 			D_ASSERT(!left_binding.empty());
 			AddCondition(ref, left_binding, right_binding, using_column);
-			bind_context.hidden_columns.insert(right_binding + "." + using_column);
+			right_binder.bind_context.HideBinding(right_binding, using_column);
 		}
-	} else {
-		result->left = Bind(*ref.left);
-		result->right = Bind(*ref.right);
 	}
+	bind_context.AddContext(move(left_binder.bind_context));
+	bind_context.AddContext(move(right_binder.bind_context));
 	if (ref.condition) {
 		WhereBinder binder(*this, context);
 		result->condition = binder.Bind(ref.condition);

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -17,7 +17,7 @@ unique_ptr<BoundTableRef> Binder::Bind(TableFunctionRef &ref) {
 	QueryErrorContext error_context(root_statement, ref.query_location);
 	auto bind_index = GenerateTableIndex();
 
-	assert(ref.function->type == ExpressionType::FUNCTION);
+	D_ASSERT(ref.function->type == ExpressionType::FUNCTION);
 	auto fexpr = (FunctionExpression *)ref.function.get();
 
 	// evaluate the input parameters to the function
@@ -87,8 +87,8 @@ unique_ptr<BoundTableRef> Binder::Bind(TableFunctionRef &ref) {
 	if (table_function.bind) {
 		bind_data = table_function.bind(context, parameters, named_parameters, return_types, return_names);
 	}
-	assert(return_types.size() == return_names.size());
-	assert(return_types.size() > 0);
+	D_ASSERT(return_types.size() == return_names.size());
+	D_ASSERT(return_types.size() > 0);
 	// overwrite the names with any supplied aliases
 	for (idx_t i = 0; i < ref.column_name_alias.size() && i < return_names.size(); i++) {
 		return_names[i] = ref.column_name_alias[i];

--- a/src/planner/expression/bound_cast_expression.cpp
+++ b/src/planner/expression/bound_cast_expression.cpp
@@ -10,7 +10,7 @@ BoundCastExpression::BoundCastExpression(unique_ptr<Expression> child, LogicalTy
 }
 
 unique_ptr<Expression> BoundCastExpression::AddCastToType(unique_ptr<Expression> expr, LogicalType target_type) {
-	assert(expr);
+	D_ASSERT(expr);
 	if (expr->expression_class == ExpressionClass::BOUND_PARAMETER) {
 		auto &parameter = (BoundParameterExpression &)*expr;
 		parameter.return_type = target_type;

--- a/src/planner/expression/common_subexpression.cpp
+++ b/src/planner/expression/common_subexpression.cpp
@@ -10,14 +10,14 @@ CommonSubExpression::CommonSubExpression(unique_ptr<Expression> child, string al
 	this->child = child.get();
 	this->owned_child = move(child);
 	this->alias = alias;
-	assert(this->child);
+	D_ASSERT(this->child);
 }
 
 CommonSubExpression::CommonSubExpression(Expression *child, string alias)
     : Expression(ExpressionType::COMMON_SUBEXPRESSION, ExpressionClass::COMMON_SUBEXPRESSION, child->return_type),
       child(child) {
 	this->alias = alias;
-	assert(child);
+	D_ASSERT(child);
 }
 
 string CommonSubExpression::ToString() const {

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -118,7 +118,7 @@ unique_ptr<Expression> ExpressionBinder::Bind(unique_ptr<ParsedExpression> &expr
 		auto bound_expr = (BoundExpression *)expr.get();
 		ExtractCorrelatedExpressions(binder, *bound_expr->expr);
 	}
-	assert(expr->expression_class == ExpressionClass::BOUND_EXPRESSION);
+	D_ASSERT(expr->expression_class == ExpressionClass::BOUND_EXPRESSION);
 	auto bound_expr = (BoundExpression *)expr.get();
 	unique_ptr<Expression> result = move(bound_expr->expr);
 	if (target_type.id() != LogicalTypeId::INVALID) {
@@ -153,7 +153,7 @@ string ExpressionBinder::Bind(unique_ptr<ParsedExpression> *expr, idx_t depth, b
 		// successfully bound: replace the node with a BoundExpression
 		*expr = make_unique<BoundExpression>(move(result.expression), move(*expr));
 		auto be = (BoundExpression *)expr->get();
-		assert(be);
+		D_ASSERT(be);
 		be->alias = alias;
 		if (!alias.empty()) {
 			be->expr->alias = alias;

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -51,8 +51,8 @@ idx_t SelectBinder::TryBindGroup(ParsedExpression &expr, idx_t depth) {
 	}
 #ifdef DEBUG
 	for (auto entry : info.map) {
-		assert(!entry.first->Equals(&expr));
-		assert(!expr.Equals(entry.first));
+		D_ASSERT(!entry.first->Equals(&expr));
+		D_ASSERT(!expr.Equals(entry.first));
 	}
 #endif
 	return INVALID_INDEX;

--- a/src/planner/expression_iterator.cpp
+++ b/src/planner/expression_iterator.cpp
@@ -126,7 +126,7 @@ void ExpressionIterator::EnumerateChildren(Expression &expr,
 		break;
 	default:
 		// called on non BoundExpression type!
-		assert(0);
+		D_ASSERT(0);
 		break;
 	}
 }
@@ -165,7 +165,7 @@ void ExpressionIterator::EnumerateTableRefChildren(BoundTableRef &ref,
 		break;
 	}
 	default:
-		assert(ref.type == TableReferenceType::TABLE_FUNCTION || ref.type == TableReferenceType::BASE_TABLE ||
+		D_ASSERT(ref.type == TableReferenceType::TABLE_FUNCTION || ref.type == TableReferenceType::BASE_TABLE ||
 		       ref.type == TableReferenceType::EMPTY);
 		break;
 	}
@@ -181,7 +181,7 @@ void ExpressionIterator::EnumerateQueryNodeChildren(BoundQueryNode &node,
 		break;
 	}
 	default:
-		assert(node.type == QueryNodeType::SELECT_NODE);
+		D_ASSERT(node.type == QueryNodeType::SELECT_NODE);
 		auto &bound_select = (BoundSelectNode &)node;
 		for (idx_t i = 0; i < bound_select.select_list.size(); i++) {
 			EnumerateExpression(bound_select.select_list[i], callback);

--- a/src/planner/joinside.cpp
+++ b/src/planner/joinside.cpp
@@ -29,11 +29,11 @@ JoinSide JoinSide::GetJoinSide(idx_t table_binding, unordered_set<idx_t> &left_b
                                unordered_set<idx_t> &right_bindings) {
 	if (left_bindings.find(table_binding) != left_bindings.end()) {
 		// column references table on left side
-		assert(right_bindings.find(table_binding) == right_bindings.end());
+		D_ASSERT(right_bindings.find(table_binding) == right_bindings.end());
 		return JoinSide::LEFT;
 	} else {
 		// column references table on right side
-		assert(right_bindings.find(table_binding) != right_bindings.end());
+		D_ASSERT(right_bindings.find(table_binding) != right_bindings.end());
 		return JoinSide::RIGHT;
 	}
 }
@@ -47,9 +47,9 @@ JoinSide JoinSide::GetJoinSide(Expression &expression, unordered_set<idx_t> &lef
 		}
 		return GetJoinSide(colref.binding.table_index, left_bindings, right_bindings);
 	}
-	assert(expression.type != ExpressionType::BOUND_REF);
+	D_ASSERT(expression.type != ExpressionType::BOUND_REF);
 	if (expression.type == ExpressionType::SUBQUERY) {
-		assert(expression.GetExpressionClass() == ExpressionClass::BOUND_SUBQUERY);
+		D_ASSERT(expression.GetExpressionClass() == ExpressionClass::BOUND_SUBQUERY);
 		auto &subquery = (BoundSubqueryExpression &)expression;
 		JoinSide side = JoinSide::NONE;
 		if (subquery.child) {

--- a/src/planner/logical_operator_visitor.cpp
+++ b/src/planner/logical_operator_visitor.cpp
@@ -141,7 +141,7 @@ void LogicalOperatorVisitor::VisitExpression(unique_ptr<Expression> *expression)
 		result = VisitReplace((BoundUnnestExpression &)expr, expression);
 		break;
 	default:
-		assert(0);
+		D_ASSERT(0);
 	}
 	if (result) {
 		*expression = move(result);

--- a/src/planner/operator/logical_join.cpp
+++ b/src/planner/operator/logical_join.cpp
@@ -53,7 +53,7 @@ void LogicalJoin::GetTableReferences(LogicalOperator &op, unordered_set<idx_t> &
 void LogicalJoin::GetExpressionBindings(Expression &expr, unordered_set<idx_t> &bindings) {
 	if (expr.type == ExpressionType::BOUND_COLUMN_REF) {
 		auto &colref = (BoundColumnRefExpression &)expr;
-		assert(colref.depth == 0);
+		D_ASSERT(colref.depth == 0);
 		bindings.insert(colref.binding.table_index);
 	}
 	ExpressionIterator::EnumerateChildren(expr, [&](Expression &child) { GetExpressionBindings(child, bindings); });

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -58,7 +58,7 @@ void Planner::CreatePlan(SQLStatement &statement) {
 }
 
 void Planner::CreatePlan(unique_ptr<SQLStatement> statement) {
-	assert(statement);
+	D_ASSERT(statement);
 	switch (statement->type) {
 	case StatementType::SELECT_STATEMENT:
 	case StatementType::INSERT_STATEMENT:
@@ -146,12 +146,12 @@ void Planner::CreatePlan(unique_ptr<SQLStatement> statement) {
 // 				auto inner_hash = copies[j]->Hash();
 // 				if (outer_hash != inner_hash) {
 // 					// if hashes are not equivalent the expressions should not be equivalent
-// 					assert(!Expression::Equals(copies[i].get(), copies[j].get()));
+// 					D_ASSERT(!Expression::Equals(copies[i].get(), copies[j].get()));
 // 				}
 // 			}
 // 		}
 // 	} else {
-// 		assert(node.type == QueryNodeType::SET_OPERATION_NODE);
+// 		D_ASSERT(node.type == QueryNodeType::SET_OPERATION_NODE);
 // 		auto &setop_node = (BoundSetOperationNode &)node;
 // 		VerifyNode(*setop_node.left);
 // 		VerifyNode(*setop_node.right);
@@ -166,8 +166,8 @@ void Planner::CreatePlan(unique_ptr<SQLStatement> statement) {
 // 	// verify that the copy of expressions works
 // 	auto copy = expr.Copy();
 // 	// copy should have identical hash and identical equality function
-// 	assert(copy->Hash() == expr.Hash());
-// 	assert(Expression::Equals(copy.get(), &expr));
+// 	D_ASSERT(copy->Hash() == expr.Hash());
+// 	D_ASSERT(Expression::Equals(copy.get(), &expr));
 // 	copies.push_back(move(copy));
 // }
 

--- a/src/planner/subquery/has_correlated_expressions.cpp
+++ b/src/planner/subquery/has_correlated_expressions.cpp
@@ -23,7 +23,7 @@ unique_ptr<Expression> HasCorrelatedExpressions::VisitReplace(BoundColumnRefExpr
 		return nullptr;
 	}
 	// correlated column reference
-	assert(expr.depth == 1);
+	D_ASSERT(expr.depth == 1);
 	has_correlated_expressions = true;
 	return nullptr;
 }

--- a/src/planner/subquery/rewrite_correlated_expressions.cpp
+++ b/src/planner/subquery/rewrite_correlated_expressions.cpp
@@ -26,9 +26,9 @@ unique_ptr<Expression> RewriteCorrelatedExpressions::VisitReplace(BoundColumnRef
 	}
 	// correlated column reference
 	// replace with the entry referring to the duplicate eliminated scan
-	assert(expr.depth == 1);
+	D_ASSERT(expr.depth == 1);
 	auto entry = correlated_map.find(expr.binding);
-	assert(entry != correlated_map.end());
+	D_ASSERT(entry != correlated_map.end());
 
 	expr.binding = ColumnBinding(base_binding.table_index, base_binding.column_index + entry->second);
 	expr.depth = 0;
@@ -86,7 +86,7 @@ void RewriteCorrelatedExpressions::RewriteCorrelatedRecursive::RewriteCorrelated
 		}
 	} else if (child.type == ExpressionType::SUBQUERY) {
 		// we encountered another subquery: rewrite recursively
-		assert(child.GetExpressionClass() == ExpressionClass::BOUND_SUBQUERY);
+		D_ASSERT(child.GetExpressionClass() == ExpressionClass::BOUND_SUBQUERY);
 		auto &bound_subquery = (BoundSubqueryExpression &)child;
 		RewriteCorrelatedRecursive rewrite(bound_subquery, base_binding, correlated_map);
 		rewrite.RewriteCorrelatedSubquery(bound_subquery);

--- a/src/planner/table_binding.cpp
+++ b/src/planner/table_binding.cpp
@@ -15,10 +15,10 @@ using namespace std;
 
 Binding::Binding(const string &alias, vector<LogicalType> coltypes, vector<string> colnames, idx_t index)
     : alias(alias), index(index), types(move(coltypes)), names(move(colnames)) {
-	assert(types.size() == names.size());
+	D_ASSERT(types.size() == names.size());
 	for (idx_t i = 0; i < names.size(); i++) {
 		auto &name = names[i];
-		assert(!name.empty());
+		D_ASSERT(!name.empty());
 		if (name_map.find(name) != name_map.end()) {
 			throw BinderException("table \"%s\" has duplicate column name \"%s\"", alias, name);
 		}

--- a/src/planner/table_binding.cpp
+++ b/src/planner/table_binding.cpp
@@ -48,16 +48,6 @@ BindResult Binding::Bind(ColumnRefExpression &colref, idx_t depth) {
 	return BindResult(make_unique<BoundColumnRefExpression>(colref.GetName(), sql_type, binding, depth));
 }
 
-void Binding::GenerateAllColumnExpressions(BindContext &context, vector<unique_ptr<ParsedExpression>> &select_list) {
-	for (auto &column_name : names) {
-		assert(!column_name.empty());
-		if (context.BindingIsHidden(alias, column_name)) {
-			continue;
-		}
-		select_list.push_back(make_unique<ColumnRefExpression>(column_name, alias));
-	}
-}
-
 TableBinding::TableBinding(const string &alias, vector<LogicalType> types_, vector<string> names_, LogicalGet &get,
                            idx_t index, bool add_row_id)
     : Binding(alias, move(types_), move(names_), index), get(get) {

--- a/src/storage/buffer/buffer_list.cpp
+++ b/src/storage/buffer/buffer_list.cpp
@@ -24,8 +24,8 @@ unique_ptr<BufferEntry> BufferList::Pop() {
 }
 
 unique_ptr<BufferEntry> BufferList::Erase(BufferEntry *entry) {
-	assert(entry->prev || entry == root.get());
-	assert(entry->next || entry == last);
+	D_ASSERT(entry->prev || entry == root.get());
+	D_ASSERT(entry->next || entry == last);
 	// first get the entry, either from the previous entry or from the root node
 	auto current = entry->prev ? move(entry->prev->next) : move(root);
 	auto prev = entry->prev;
@@ -44,9 +44,9 @@ unique_ptr<BufferEntry> BufferList::Erase(BufferEntry *entry) {
 		} else {
 			last = nullptr;
 		}
-		assert(!root || !root->prev);
+		D_ASSERT(!root || !root->prev);
 	} else if (prev != last) {
-		assert(next);
+		D_ASSERT(next);
 		next->prev = prev;
 		prev->next = move(next);
 	}
@@ -55,7 +55,7 @@ unique_ptr<BufferEntry> BufferList::Erase(BufferEntry *entry) {
 }
 
 void BufferList::Append(unique_ptr<BufferEntry> entry) {
-	assert(!entry->next);
+	D_ASSERT(!entry->next);
 	if (!last) {
 		// empty list: set as root
 		entry->prev = nullptr;

--- a/src/storage/buffer/managed_buffer.cpp
+++ b/src/storage/buffer/managed_buffer.cpp
@@ -6,8 +6,8 @@ using namespace std;
 
 ManagedBuffer::ManagedBuffer(BufferManager &manager, idx_t size, bool can_destroy, block_id_t id)
     : FileBuffer(FileBufferType::MANAGED_BUFFER, size), manager(manager), can_destroy(can_destroy), id(id) {
-	assert(id >= MAXIMUM_BLOCK);
-	assert(size >= Storage::BLOCK_ALLOC_SIZE);
+	D_ASSERT(id >= MAXIMUM_BLOCK);
+	D_ASSERT(size >= Storage::BLOCK_ALLOC_SIZE);
 }
 
 } // namespace duckdb

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -31,7 +31,7 @@ unique_ptr<BufferHandle> BufferManager::Pin(block_id_t block_id, bool can_destro
 
 unique_ptr<BufferHandle> BufferManager::PinBlock(block_id_t block_id) {
 	// this method should only be used to pin blocks that exist in the file
-	assert(block_id < MAXIMUM_BLOCK);
+	D_ASSERT(block_id < MAXIMUM_BLOCK);
 
 	// check if the block is already loaded
 	Block *result_block;
@@ -63,7 +63,7 @@ unique_ptr<BufferHandle> BufferManager::PinBlock(block_id_t block_id) {
 		used_list.Append(move(buffer_entry));
 	} else {
 		auto buffer = entry->second->buffer.get();
-		assert(buffer->type == FileBufferType::BLOCK);
+		D_ASSERT(buffer->type == FileBufferType::BLOCK);
 		result_block = (Block *)buffer;
 		// add one to the reference count
 		AddReference(entry->second);
@@ -85,11 +85,11 @@ void BufferManager::Unpin(block_id_t block_id) {
 	lock_guard<mutex> lock(block_lock);
 	// first find the block in the set of blocks
 	auto entry = blocks.find(block_id);
-	assert(entry != blocks.end());
+	D_ASSERT(entry != blocks.end());
 
 	auto buffer_entry = entry->second;
 	// then decerase the ref count
-	assert(buffer_entry->ref_count > 0);
+	D_ASSERT(buffer_entry->ref_count > 0);
 	buffer_entry->ref_count--;
 	if (buffer_entry->ref_count == 0) {
 		// no references left: move block out of used list and into lru list
@@ -117,7 +117,7 @@ unique_ptr<Block> BufferManager::EvictBlock() {
 	if (!entry) {
 		throw Exception("Not enough memory to complete operation!");
 	}
-	assert(entry->ref_count == 0);
+	D_ASSERT(entry->ref_count == 0);
 	// erase this identifier from the set of blocks
 	auto buffer = entry->buffer.get();
 	if (buffer->type == FileBufferType::BLOCK) {
@@ -131,7 +131,7 @@ unique_ptr<Block> BufferManager::EvictBlock() {
 	} else {
 		// managed buffer: cannot return a block here
 		auto managed = (ManagedBuffer *)buffer;
-		assert(!managed->can_destroy);
+		D_ASSERT(!managed->can_destroy);
 
 		// cannot destroy this buffer: write it to disk first so it can be reloaded later
 		WriteTemporaryBuffer(*managed);
@@ -144,7 +144,7 @@ unique_ptr<Block> BufferManager::EvictBlock() {
 }
 
 unique_ptr<BufferHandle> BufferManager::Allocate(idx_t alloc_size, bool can_destroy) {
-	assert(alloc_size >= Storage::BLOCK_ALLOC_SIZE);
+	D_ASSERT(alloc_size >= Storage::BLOCK_ALLOC_SIZE);
 
 	lock_guard<mutex> lock(block_lock);
 	// first evict blocks until we have enough memory to store this buffer
@@ -167,7 +167,7 @@ unique_ptr<BufferHandle> BufferManager::Allocate(idx_t alloc_size, bool can_dest
 void BufferManager::DestroyBuffer(block_id_t buffer_id, bool can_destroy) {
 	lock_guard<mutex> lock(block_lock);
 
-	assert(buffer_id >= MAXIMUM_BLOCK);
+	D_ASSERT(buffer_id >= MAXIMUM_BLOCK);
 	// this is like unpin, except we just destroy the entry entirely instead of adding it to the LRU list
 	// first find the block in the set of blocks
 	auto entry = blocks.find(buffer_id);
@@ -182,7 +182,7 @@ void BufferManager::DestroyBuffer(block_id_t buffer_id, bool can_destroy) {
 	}
 
 	auto handle = entry->second;
-	assert(handle->ref_count == 0);
+	D_ASSERT(handle->ref_count == 0);
 
 	current_memory -= handle->buffer->AllocSize();
 	blocks.erase(buffer_id);
@@ -199,7 +199,7 @@ void BufferManager::SetLimit(idx_t limit) {
 }
 
 unique_ptr<BufferHandle> BufferManager::PinBuffer(block_id_t buffer_id, bool can_destroy) {
-	assert(buffer_id >= MAXIMUM_BLOCK);
+	D_ASSERT(buffer_id >= MAXIMUM_BLOCK);
 	// check if we have this buffer here
 	auto entry = blocks.find(buffer_id);
 	if (entry == blocks.end()) {
@@ -215,9 +215,9 @@ unique_ptr<BufferHandle> BufferManager::PinBuffer(block_id_t buffer_id, bool can
 	auto buffer = entry->second->buffer.get();
 	AddReference(entry->second);
 	// now return it
-	assert(buffer->type == FileBufferType::MANAGED_BUFFER);
+	D_ASSERT(buffer->type == FileBufferType::MANAGED_BUFFER);
 	auto managed = (ManagedBuffer *)buffer;
-	assert(managed->id == buffer_id);
+	D_ASSERT(managed->id == buffer_id);
 	return make_unique<BufferHandle>(*this, buffer_id, managed);
 }
 
@@ -226,7 +226,7 @@ string BufferManager::GetTemporaryPath(block_id_t id) {
 }
 
 void BufferManager::WriteTemporaryBuffer(ManagedBuffer &buffer) {
-	assert(buffer.size + Storage::BLOCK_HEADER_SIZE >= Storage::BLOCK_ALLOC_SIZE);
+	D_ASSERT(buffer.size + Storage::BLOCK_HEADER_SIZE >= Storage::BLOCK_ALLOC_SIZE);
 	// get the path to write to
 	auto path = GetTemporaryPath(buffer.id);
 	// create the file and write the size followed by the buffer contents

--- a/src/storage/checkpoint/table_data_reader.cpp
+++ b/src/storage/checkpoint/table_data_reader.cpp
@@ -23,7 +23,7 @@ TableDataReader::TableDataReader(CheckpointManager &manager, MetaBlockReader &re
 
 void TableDataReader::ReadTableData() {
 	auto &columns = info.Base().columns;
-	assert(columns.size() > 0);
+	D_ASSERT(columns.size() > 0);
 
 	// load the data pointers for the table
 	idx_t table_count = 0;

--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -79,7 +79,7 @@ void TableDataWriter::WriteTableData(ClientContext &context) {
 		// for each column, we append whatever we can fit into the block
 		idx_t chunk_size = chunk.size();
 		for (idx_t i = 0; i < table.columns.size(); i++) {
-			assert(chunk.data[i].type == table.columns[i].type);
+			D_ASSERT(chunk.data[i].type == table.columns[i].type);
 			AppendData(transaction, i, chunk.data[i], chunk_size);
 		}
 	}

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -39,7 +39,7 @@ CheckpointManager::CheckpointManager(StorageManager &manager)
 
 void CheckpointManager::CreateCheckpoint() {
 	// assert that the checkpoint manager hasn't been used before
-	assert(!metadata_writer);
+	D_ASSERT(!metadata_writer);
 
 	Connection con(database);
 	con.BeginTransaction();

--- a/src/storage/column_data.cpp
+++ b/src/storage/column_data.cpp
@@ -113,13 +113,13 @@ void ColumnData::InitializeAppend(ColumnAppendState &state) {
 		if (data.root_node.get() == segment) {
 			data.root_node = move(transient);
 		} else {
-			assert(data.nodes.size() >= 2);
+			D_ASSERT(data.nodes.size() >= 2);
 			data.nodes[data.nodes.size() - 2].node->next = move(transient);
 		}
 	} else {
 		state.current = (TransientSegment *)segment;
 	}
-	assert(state.current->segment_type == ColumnSegmentType::TRANSIENT);
+	D_ASSERT(state.current->segment_type == ColumnSegmentType::TRANSIENT);
 	state.current->InitializeAppend(state);
 }
 
@@ -150,14 +150,14 @@ void ColumnData::RevertAppend(row_t start_row) {
 	// check if this row is in the segment tree at all
 	if (idx_t(start_row) >= data.nodes.back().row_start + data.nodes.back().node->count) {
 		// the start row is equal to the final portion of the column data: nothing was ever appended here
-		assert(idx_t(start_row) == data.nodes.back().row_start + data.nodes.back().node->count);
+		D_ASSERT(idx_t(start_row) == data.nodes.back().row_start + data.nodes.back().node->count);
 		return;
 	}
 	// find the segment index that the current row belongs to
 	idx_t segment_index = data.GetSegmentIndex(start_row);
 	auto segment = data.nodes[segment_index].node;
 	auto &transient = (TransientSegment &)*segment;
-	assert(transient.segment_type == ColumnSegmentType::TRANSIENT);
+	D_ASSERT(transient.segment_type == ColumnSegmentType::TRANSIENT);
 
 	// remove any segments AFTER this segment: they should be deleted entirely
 	if (segment_index < data.nodes.size() - 1) {

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -35,7 +35,7 @@ LocalScanState::~LocalScanState() {
 
 void LocalScanState::SetStorage(LocalTableStorage *new_storage) {
 	if (storage != nullptr) {
-		assert(storage->active_scans > 0);
+		D_ASSERT(storage->active_scans > 0);
 		storage->active_scans--;
 	}
 	storage = new_storage;
@@ -51,7 +51,7 @@ void LocalTableStorage::Clear() {
 	indexes.clear();
 	deleted_rows = 0;
 	for (auto &index : table.info->indexes) {
-		assert(index->type == IndexType::ART);
+		D_ASSERT(index->type == IndexType::ART);
 		auto &art = (ART &)*index;
 		if (art.is_unique) {
 			// unique index: create a local ART index that maintains the same unique constraint
@@ -186,7 +186,7 @@ void LocalStorage::Append(DataTable *table, DataChunk &chunk) {
 
 LocalTableStorage *LocalStorage::GetStorage(DataTable *table) {
 	auto entry = table_storage.find(table);
-	assert(entry != table_storage.end());
+	D_ASSERT(entry != table_storage.end());
 	return entry->second.get();
 }
 
@@ -201,7 +201,7 @@ void LocalStorage::Delete(DataTable *table, Vector &row_ids, idx_t count) {
 	auto storage = GetStorage(table);
 	// figure out the chunk from which these row ids came
 	idx_t chunk_idx = GetChunk(row_ids);
-	assert(chunk_idx < storage->collection.chunks.size());
+	D_ASSERT(chunk_idx < storage->collection.chunks.size());
 
 	// get a pointer to the deleted entries for this chunk
 	bool *deleted;
@@ -247,8 +247,8 @@ static void update_data(Vector &data_vector, Vector &update_vector, Vector &row_
 }
 
 static void update_chunk(Vector &data, Vector &updates, Vector &row_ids, idx_t count, idx_t base_index) {
-	assert(data.type == updates.type);
-	assert(row_ids.type == LOGICAL_ROW_TYPE);
+	D_ASSERT(data.type == updates.type);
+	D_ASSERT(row_ids.type == LOGICAL_ROW_TYPE);
 
 	switch (data.type.InternalType()) {
 	case PhysicalType::INT8:
@@ -278,7 +278,7 @@ void LocalStorage::Update(DataTable *table, Vector &row_ids, vector<column_t> &c
 	auto storage = GetStorage(table);
 	// figure out the chunk from which these row ids came
 	idx_t chunk_idx = GetChunk(row_ids);
-	assert(chunk_idx < storage->collection.chunks.size());
+	D_ASSERT(chunk_idx < storage->collection.chunks.size());
 
 	idx_t base_index = MAX_ROW_ID + chunk_idx * STANDARD_VECTOR_SIZE;
 

--- a/src/storage/meta_block_writer.cpp
+++ b/src/storage/meta_block_writer.cpp
@@ -25,7 +25,7 @@ void MetaBlockWriter::WriteData(const_data_ptr_t buffer, idx_t write_size) {
 	while (offset + write_size > block->size) {
 		// we need to make a new block
 		// first copy what we can
-		assert(offset <= block->size);
+		D_ASSERT(offset <= block->size);
 		idx_t copy_amount = block->size - offset;
 		if (copy_amount > 0) {
 			memcpy(block->buffer + offset, buffer, copy_amount);

--- a/src/storage/numeric_segment.cpp
+++ b/src/storage/numeric_segment.cpp
@@ -200,8 +200,8 @@ static void templated_select_operation_between(SelectionVector &sel, Vector &res
 void NumericSegment::Select(ColumnScanState &state, Vector &result, SelectionVector &sel, idx_t &approved_tuple_count,
                             vector<TableFilter> &tableFilter) {
 	auto vector_index = state.vector_index;
-	assert(vector_index < max_vector_count);
-	assert(vector_index * STANDARD_VECTOR_SIZE <= tuple_count);
+	D_ASSERT(vector_index < max_vector_count);
+	D_ASSERT(vector_index * STANDARD_VECTOR_SIZE <= tuple_count);
 
 	// pin the buffer for this segment
 	auto handle = manager.Pin(block_id);
@@ -242,9 +242,9 @@ void NumericSegment::Select(ColumnScanState &state, Vector &result, SelectionVec
 			throw NotImplementedException("Unknown comparison type for filter pushed down to table!");
 		}
 	} else {
-		assert(tableFilter[0].comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
+		D_ASSERT(tableFilter[0].comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
 		       tableFilter[0].comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO);
-		assert(tableFilter[1].comparison_type == ExpressionType::COMPARE_LESSTHAN ||
+		D_ASSERT(tableFilter[1].comparison_type == ExpressionType::COMPARE_LESSTHAN ||
 		       tableFilter[1].comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO);
 
 		if (tableFilter[0].comparison_type == ExpressionType::COMPARE_GREATERTHAN) {
@@ -275,8 +275,8 @@ void NumericSegment::Select(ColumnScanState &state, Vector &result, SelectionVec
 // Fetch base data
 //===--------------------------------------------------------------------===//
 void NumericSegment::FetchBaseData(ColumnScanState &state, idx_t vector_index, Vector &result) {
-	assert(vector_index < max_vector_count);
-	assert(vector_index * STANDARD_VECTOR_SIZE <= tuple_count);
+	D_ASSERT(vector_index < max_vector_count);
+	D_ASSERT(vector_index * STANDARD_VECTOR_SIZE <= tuple_count);
 
 	// pin the buffer for this segment
 	auto handle = manager.Pin(block_id);
@@ -320,8 +320,8 @@ static void templated_assignment(SelectionVector &sel, data_ptr_t source, data_p
 void NumericSegment::FilterFetchBaseData(ColumnScanState &state, Vector &result, SelectionVector &sel,
                                          idx_t &approved_tuple_count) {
 	auto vector_index = state.vector_index;
-	assert(vector_index < max_vector_count);
-	assert(vector_index * STANDARD_VECTOR_SIZE <= tuple_count);
+	D_ASSERT(vector_index < max_vector_count);
+	D_ASSERT(vector_index * STANDARD_VECTOR_SIZE <= tuple_count);
 
 	// pin the buffer for this segment
 	auto handle = manager.Pin(block_id);
@@ -390,7 +390,7 @@ void NumericSegment::FetchRow(ColumnFetchState &state, Transaction &transaction,
 	// get the vector index
 	idx_t vector_index = row_id / STANDARD_VECTOR_SIZE;
 	idx_t id_in_vector = row_id - vector_index * STANDARD_VECTOR_SIZE;
-	assert(vector_index < max_vector_count);
+	D_ASSERT(vector_index < max_vector_count);
 
 	// first fetch the data from the base table
 	auto data = handle->node->buffer + vector_index * vector_size;
@@ -410,7 +410,7 @@ void NumericSegment::FetchRow(ColumnFetchState &state, Transaction &transaction,
 // Append
 //===--------------------------------------------------------------------===//
 idx_t NumericSegment::Append(SegmentStatistics &stats, Vector &data, idx_t offset, idx_t count) {
-	assert(data.type.InternalType() == type);
+	D_ASSERT(data.type.InternalType() == type);
 	auto handle = manager.Pin(block_id);
 
 	idx_t initial_count = tuple_count;

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -72,7 +72,7 @@ SingleFileBlockManager::SingleFileBlockManager(FileSystem &fs, string path, bool
 	uint8_t flags;
 	FileLockType lock;
 	if (read_only) {
-		assert(!create_new);
+		D_ASSERT(!create_new);
 		flags = FileFlags::FILE_FLAGS_READ;
 		lock = FileLockType::READ_LOCK;
 	} else {
@@ -214,13 +214,13 @@ unique_ptr<Block> SingleFileBlockManager::CreateBlock() {
 }
 
 void SingleFileBlockManager::Read(Block &block) {
-	assert(block.id >= 0);
-	assert(std::find(free_list.begin(), free_list.end(), block.id) == free_list.end());
+	D_ASSERT(block.id >= 0);
+	D_ASSERT(std::find(free_list.begin(), free_list.end(), block.id) == free_list.end());
 	block.Read(*handle, BLOCK_START + block.id * Storage::BLOCK_ALLOC_SIZE);
 }
 
 void SingleFileBlockManager::Write(FileBuffer &buffer, block_id_t block_id) {
-	assert(block_id >= 0);
+	D_ASSERT(block_id >= 0);
 	buffer.Write(*handle, BLOCK_START + block_id * Storage::BLOCK_ALLOC_SIZE);
 }
 

--- a/src/storage/storage_lock.cpp
+++ b/src/storage/storage_lock.cpp
@@ -12,7 +12,7 @@ StorageLockKey::~StorageLockKey() {
 	if (type == StorageLockType::EXCLUSIVE) {
 		lock.ReleaseExclusiveLock();
 	} else {
-		assert(type == StorageLockType::SHARED);
+		D_ASSERT(type == StorageLockType::SHARED);
 		lock.ReleaseSharedLock();
 	}
 }

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -132,7 +132,7 @@ void StorageManager::LoadDatabase() {
 			// replay the WAL
 			WriteAheadLog::Replay(database, wal_path);
 			if (database.config.checkpoint_only) {
-				assert(!read_only);
+				D_ASSERT(!read_only);
 				// checkpoint the database
 				checkpointer.CreateCheckpoint();
 				// remove the WAL

--- a/src/storage/string_segment.cpp
+++ b/src/storage/string_segment.cpp
@@ -99,8 +99,8 @@ void StringSegment::read_string(string_t *result_data, buffer_handle_set_t &hand
 void StringSegment::Select(ColumnScanState &state, Vector &result, SelectionVector &sel, idx_t &approved_tuple_count,
                            vector<TableFilter> &tableFilter) {
 	auto vector_index = state.vector_index;
-	assert(vector_index < max_vector_count);
-	assert(vector_index * STANDARD_VECTOR_SIZE <= tuple_count);
+	D_ASSERT(vector_index < max_vector_count);
+	D_ASSERT(vector_index * STANDARD_VECTOR_SIZE <= tuple_count);
 
 	auto handle = state.primary_handle.get();
 	state.handles.clear();
@@ -325,7 +325,7 @@ string_location_t StringSegment::FetchStringLocation(data_ptr_t baseptr, int32_t
 
 string_t StringSegment::FetchStringFromDict(buffer_handle_set_t &handles, data_ptr_t baseptr, int32_t dict_offset) {
 	// fetch base data
-	assert(dict_offset <= Storage::BLOCK_SIZE);
+	D_ASSERT(dict_offset <= Storage::BLOCK_SIZE);
 	string_location_t location = FetchStringLocation(baseptr, dict_offset);
 	return FetchString(handles, baseptr, location);
 }
@@ -354,7 +354,7 @@ void StringSegment::FetchRow(ColumnFetchState &state, Transaction &transaction, 
 
 	idx_t vector_index = row_id / STANDARD_VECTOR_SIZE;
 	idx_t id_in_vector = row_id - vector_index * STANDARD_VECTOR_SIZE;
-	assert(vector_index < max_vector_count);
+	D_ASSERT(vector_index < max_vector_count);
 
 	data_ptr_t baseptr;
 
@@ -422,7 +422,7 @@ void StringSegment::FetchRow(ColumnFetchState &state, Transaction &transaction, 
 // Append
 //===--------------------------------------------------------------------===//
 idx_t StringSegment::Append(SegmentStatistics &stats, Vector &data, idx_t offset, idx_t count) {
-	assert(data.type.InternalType() == PhysicalType::VARCHAR);
+	D_ASSERT(data.type.InternalType() == PhysicalType::VARCHAR);
 	auto handle = manager.Pin(block_id);
 	idx_t initial_count = tuple_count;
 	while (count > 0) {
@@ -484,7 +484,7 @@ static void update_min_max_string_segment(string value, char *__restrict min, ch
 
 idx_t StringSegment::RemainingSpace(BufferHandle &handle) {
 	idx_t used_space = GetDictionaryOffset(handle) + max_vector_count * vector_size;
-	assert(Storage::BLOCK_SIZE >= used_space);
+	D_ASSERT(Storage::BLOCK_SIZE >= used_space);
 	return Storage::BLOCK_SIZE - used_space;
 }
 
@@ -510,7 +510,7 @@ void StringSegment::AppendData(BufferHandle &handle, SegmentStatistics &stats, d
 			stats.has_null = true;
 		} else {
 			auto dictionary_offset = GetDictionaryOffset(handle);
-			assert(dictionary_offset < Storage::BLOCK_SIZE);
+			D_ASSERT(dictionary_offset < Storage::BLOCK_SIZE);
 			// non-null value, check if we can fit it within the block
 			idx_t string_length = sdata[source_idx].GetSize();
 			idx_t total_length = string_length + 1 + sizeof(uint16_t);
@@ -525,7 +525,7 @@ void StringSegment::AppendData(BufferHandle &handle, SegmentStatistics &stats, d
 			if (total_length > BIG_STRING_MARKER_BASE_SIZE &&
 			    (total_length >= STRING_BLOCK_LIMIT ||
 			     total_length + (remaining_strings * BIG_STRING_MARKER_SIZE) > RemainingSpace(handle))) {
-				assert(RemainingSpace(handle) >= BIG_STRING_MARKER_SIZE);
+				D_ASSERT(RemainingSpace(handle) >= BIG_STRING_MARKER_SIZE);
 				// string is too big for block: write to overflow blocks
 				block_id_t block;
 				int32_t offset;
@@ -542,7 +542,7 @@ void StringSegment::AppendData(BufferHandle &handle, SegmentStatistics &stats, d
 				stats.has_overflow_strings = true;
 			} else {
 				// string fits in block, append to dictionary and increment dictionary position
-				assert(string_length < NumericLimits<uint16_t>::Maximum());
+				D_ASSERT(string_length < NumericLimits<uint16_t>::Maximum());
 				dictionary_offset += total_length;
 				auto dict_pos = end - dictionary_offset;
 				//! Update min/max of column segment
@@ -552,9 +552,9 @@ void StringSegment::AppendData(BufferHandle &handle, SegmentStatistics &stats, d
 				// now write the actual string data into the dictionary
 				memcpy(dict_pos + sizeof(uint16_t), sdata[source_idx].GetData(), string_length + 1);
 			}
-			assert(RemainingSpace(handle) <= Storage::BLOCK_SIZE);
+			D_ASSERT(RemainingSpace(handle) <= Storage::BLOCK_SIZE);
 			// place the dictionary offset into the set of vectors
-			assert(dictionary_offset <= Storage::BLOCK_SIZE);
+			D_ASSERT(dictionary_offset <= Storage::BLOCK_SIZE);
 			result_data[target_idx] = dictionary_offset;
 			SetDictionaryOffset(handle, dictionary_offset);
 		}
@@ -563,7 +563,7 @@ void StringSegment::AppendData(BufferHandle &handle, SegmentStatistics &stats, d
 }
 
 void StringSegment::WriteString(string_t string, block_id_t &result_block, int32_t &result_offset) {
-	assert(strlen(string.GetData()) == string.GetSize());
+	D_ASSERT(strlen(string.GetData()) == string.GetSize());
 	if (overflow_writer) {
 		// overflow writer is set: write string there
 		overflow_writer->WriteString(string, result_block, result_offset);
@@ -606,7 +606,7 @@ void StringSegment::WriteStringMemory(string_t string, block_id_t &result_block,
 }
 
 string_t StringSegment::ReadString(buffer_handle_set_t &handles, block_id_t block, int32_t offset) {
-	assert(offset < Storage::BLOCK_SIZE);
+	D_ASSERT(offset < Storage::BLOCK_SIZE);
 	if (block == INVALID_BLOCK) {
 		return string_t(nullptr, 0);
 	}
@@ -767,13 +767,13 @@ void StringSegment::MergeUpdateInfo(UpdateInfo *node, row_t *ids, idx_t update_c
 	// now we perform a merge of the new ids with the old ids
 	auto merge = [&](idx_t id, idx_t aidx, idx_t bidx, idx_t count) {
 		// new_id and old_id are the same, insert the old data in the UpdateInfo
-		assert(old_data[bidx].IsValid());
+		D_ASSERT(old_data[bidx].IsValid());
 		info_data[count] = old_data[bidx];
 		node->tuples[count] = id;
 	};
 	auto pick_new = [&](idx_t id, idx_t aidx, idx_t count) {
 		// new_id comes before the old id, insert the base table data into the update info
-		assert(base_data[aidx].IsValid());
+		D_ASSERT(base_data[aidx].IsValid());
 		info_data[count] = base_data[aidx];
 		node->nullmask[id] = base_nullmask[aidx];
 
@@ -781,7 +781,7 @@ void StringSegment::MergeUpdateInfo(UpdateInfo *node, row_t *ids, idx_t update_c
 	};
 	auto pick_old = [&](idx_t id, idx_t bidx, idx_t count) {
 		// old_id comes before new_id, insert the old data
-		assert(old_data[bidx].IsValid());
+		D_ASSERT(old_data[bidx].IsValid());
 		info_data[count] = old_data[bidx];
 		node->tuples[count] = id;
 	};
@@ -863,7 +863,7 @@ void StringSegment::RollbackUpdate(UpdateInfo *info) {
 	idx_t old_idx = 0;
 	for (idx_t i = 0; i < update_info.count; i++) {
 		if (old_idx >= info->N || update_info.ids[i] != info->tuples[old_idx]) {
-			assert(old_idx >= info->N || update_info.ids[i] < info->tuples[old_idx]);
+			D_ASSERT(old_idx >= info->N || update_info.ids[i] < info->tuples[old_idx]);
 			// this entry is not rolled back: insert entry directly
 			update_info.ids[new_count] = update_info.ids[i];
 			update_info.block_ids[new_count] = update_info.block_ids[i];

--- a/src/storage/table/chunk_info.cpp
+++ b/src/storage/table/chunk_info.cpp
@@ -27,7 +27,7 @@ bool ChunkConstantInfo::Fetch(Transaction &transaction, row_t row) {
 }
 
 void ChunkConstantInfo::CommitAppend(transaction_t commit_id, idx_t start, idx_t end) {
-	assert(start == 0 && end == STANDARD_VECTOR_SIZE);
+	D_ASSERT(start == 0 && end == STANDARD_VECTOR_SIZE);
 	insert_id = commit_id;
 }
 

--- a/src/storage/table/morsel_info.cpp
+++ b/src/storage/table/morsel_info.cpp
@@ -29,7 +29,7 @@ idx_t MorselInfo::GetSelVector(Transaction &transaction, idx_t vector_idx, Selec
 }
 
 bool MorselInfo::Fetch(Transaction &transaction, idx_t row) {
-	assert(row < MorselInfo::MORSEL_SIZE);
+	D_ASSERT(row < MorselInfo::MORSEL_SIZE);
 	lock_guard<mutex> lock(morsel_lock);
 
 	idx_t vector_index = row / STANDARD_VECTOR_SIZE;
@@ -69,7 +69,7 @@ void MorselInfo::Append(Transaction &transaction, idx_t morsel_start, idx_t coun
 				info = insert_info.get();
 				root->info[vector_idx] = move(insert_info);
 			} else {
-				assert(root->info[vector_idx]->type == ChunkInfoType::VECTOR_INFO);
+				D_ASSERT(root->info[vector_idx]->type == ChunkInfoType::VECTOR_INFO);
 				// use existing vector
 				info = (ChunkVectorInfo *)root->info[vector_idx].get();
 			}
@@ -79,7 +79,7 @@ void MorselInfo::Append(Transaction &transaction, idx_t morsel_start, idx_t coun
 }
 
 void MorselInfo::CommitAppend(transaction_t commit_id, idx_t morsel_start, idx_t count) {
-	assert(root.get());
+	D_ASSERT(root.get());
 	idx_t morsel_end = morsel_start + count;
 	lock_guard<mutex> lock(morsel_lock);
 
@@ -163,7 +163,7 @@ void VersionDeleteState::Delete(row_t row_id) {
 			new_info->insert_id = constant.insert_id;
 			info.root->info[vector_idx] = move(new_info);
 		}
-		assert(info.root->info[vector_idx]->type == ChunkInfoType::VECTOR_INFO);
+		D_ASSERT(info.root->info[vector_idx]->type == ChunkInfoType::VECTOR_INFO);
 		current_info = (ChunkVectorInfo *)info.root->info[vector_idx].get();
 		current_chunk = vector_idx;
 		chunk_row = vector_idx * STANDARD_VECTOR_SIZE;

--- a/src/storage/table/persistent_segment.cpp
+++ b/src/storage/table/persistent_segment.cpp
@@ -16,7 +16,7 @@ PersistentSegment::PersistentSegment(BufferManager &manager, block_id_t id, idx_
                                      idx_t start, idx_t count, data_t stats_min[], data_t stats_max[])
     : ColumnSegment(type, ColumnSegmentType::PERSISTENT, start, count, stats_min, stats_max), manager(manager),
       block_id(id), offset(offset) {
-	assert(offset == 0);
+	D_ASSERT(offset == 0);
 	if (type == PhysicalType::VARCHAR) {
 		data = make_unique<StringSegment>(manager, start, id);
 		data->max_vector_count = count / STANDARD_VECTOR_SIZE + (count % STANDARD_VECTOR_SIZE == 0 ? 0 : 1);

--- a/src/storage/table/transient_segment.cpp
+++ b/src/storage/table/transient_segment.cpp
@@ -27,7 +27,7 @@ TransientSegment::TransientSegment(PersistentSegment &segment)
 	data = move(segment.data);
 	stats = move(segment.stats);
 	count = segment.count;
-	assert(!segment.next);
+	D_ASSERT(!segment.next);
 }
 
 void TransientSegment::InitializeScan(ColumnScanState &state) {

--- a/src/storage/uncompressed_segment.cpp
+++ b/src/storage/uncompressed_segment.cpp
@@ -73,7 +73,7 @@ static void CheckForConflicts(UpdateInfo *info, Transaction &transaction, row_t 
 void UncompressedSegment::Update(ColumnData &column_data, SegmentStatistics &stats, Transaction &transaction,
                                  Vector &update, row_t *ids, idx_t count, row_t offset) {
 	// can only perform in-place updates on temporary blocks
-	assert(block_id >= MAXIMUM_BLOCK);
+	D_ASSERT(block_id >= MAXIMUM_BLOCK);
 
 	// obtain an exclusive lock
 	auto write_lock = lock.GetExclusiveLock();
@@ -81,7 +81,7 @@ void UncompressedSegment::Update(ColumnData &column_data, SegmentStatistics &sta
 #ifdef DEBUG
 	// verify that the ids are sorted and there are no duplicates
 	for (idx_t i = 1; i < count; i++) {
-		assert(ids[i] > ids[i - 1]);
+		D_ASSERT(ids[i] > ids[i - 1]);
 	}
 #endif
 
@@ -99,8 +99,8 @@ void UncompressedSegment::Update(ColumnData &column_data, SegmentStatistics &sta
 	idx_t vector_index = (first_id - offset) / STANDARD_VECTOR_SIZE;
 	idx_t vector_offset = offset + vector_index * STANDARD_VECTOR_SIZE;
 
-	assert(first_id >= offset);
-	assert(vector_index < max_vector_count);
+	D_ASSERT(first_id >= offset);
+	D_ASSERT(vector_index < max_vector_count);
 
 	// first check the version chain
 	UpdateInfo *node = nullptr;
@@ -129,7 +129,7 @@ UpdateInfo *UncompressedSegment::CreateUpdateInfo(ColumnData &column_data, Trans
 	// set up the tuple ids
 	node->N = count;
 	for (idx_t i = 0; i < count; i++) {
-		assert((idx_t)ids[i] >= vector_offset && (idx_t)ids[i] < vector_offset + STANDARD_VECTOR_SIZE);
+		D_ASSERT((idx_t)ids[i] >= vector_offset && (idx_t)ids[i] < vector_offset + STANDARD_VECTOR_SIZE);
 		node->tuples[i] = ids[i] - vector_offset;
 	};
 	return node;

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -274,7 +274,7 @@ void ReplayState::ReplayDelete() {
 	DataChunk chunk;
 	chunk.Deserialize(source);
 
-	assert(chunk.column_count() == 1 && chunk.data[0].type == LOGICAL_ROW_TYPE);
+	D_ASSERT(chunk.column_count() == 1 && chunk.data[0].type == LOGICAL_ROW_TYPE);
 	row_t row_ids[1];
 	Vector row_identifiers(LOGICAL_ROW_TYPE, (data_ptr_t)row_ids);
 

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -108,7 +108,7 @@ void WriteAheadLog::WriteSetTable(string &schema, string &table) {
 }
 
 void WriteAheadLog::WriteInsert(DataChunk &chunk) {
-	assert(chunk.size() > 0);
+	D_ASSERT(chunk.size() > 0);
 	chunk.Verify();
 
 	writer->Write<WALType>(WALType::INSERT_TUPLE);
@@ -116,8 +116,8 @@ void WriteAheadLog::WriteInsert(DataChunk &chunk) {
 }
 
 void WriteAheadLog::WriteDelete(DataChunk &chunk) {
-	assert(chunk.size() > 0);
-	assert(chunk.column_count() == 1 && chunk.data[0].type == LOGICAL_ROW_TYPE);
+	D_ASSERT(chunk.size() > 0);
+	D_ASSERT(chunk.column_count() == 1 && chunk.data[0].type == LOGICAL_ROW_TYPE);
 	chunk.Verify();
 
 	writer->Write<WALType>(WALType::DELETE_TUPLE);
@@ -125,7 +125,7 @@ void WriteAheadLog::WriteDelete(DataChunk &chunk) {
 }
 
 void WriteAheadLog::WriteUpdate(DataChunk &chunk, column_t col_idx) {
-	assert(chunk.size() > 0);
+	D_ASSERT(chunk.size() > 0);
 	chunk.Verify();
 
 	writer->Write<WALType>(WALType::UPDATE_TUPLE);

--- a/src/transaction/cleanup_state.cpp
+++ b/src/transaction/cleanup_state.cpp
@@ -24,7 +24,7 @@ void CleanupState::CleanupEntry(UndoFlags type, data_ptr_t data) {
 	case UndoFlags::CATALOG_ENTRY: {
 		auto catalog_entry = Load<CatalogEntry *>(data);
 		// destroy the backed up entry: it is no longer required
-		assert(catalog_entry->parent);
+		D_ASSERT(catalog_entry->parent);
 		if (catalog_entry->parent->type != CatalogType::UPDATED_ENTRY) {
 			if (!catalog_entry->deleted) {
 				// delete the entry from the dependency manager, if it is not deleted yet

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -31,7 +31,7 @@ void CommitState::WriteCatalogEntry(CatalogEntry *entry, data_ptr_t dataptr) {
 	if (entry->temporary || entry->parent->temporary) {
 		return;
 	}
-	assert(log);
+	D_ASSERT(log);
 	// look at the type of the parent entry
 	auto parent = entry->parent;
 	switch (parent->type) {
@@ -107,7 +107,7 @@ void CommitState::WriteCatalogEntry(CatalogEntry *entry, data_ptr_t dataptr) {
 }
 
 void CommitState::WriteDelete(DeleteInfo *info) {
-	assert(log);
+	D_ASSERT(log);
 	// switch to the current table, if necessary
 	SwitchTable(info->table->info.get(), UndoFlags::DELETE_TUPLE);
 
@@ -125,7 +125,7 @@ void CommitState::WriteDelete(DeleteInfo *info) {
 }
 
 void CommitState::WriteUpdate(UpdateInfo *info) {
-	assert(log);
+	D_ASSERT(log);
 	// switch to the current table, if necessary
 	SwitchTable(&info->column_data->table_info, UndoFlags::UPDATE_TUPLE);
 
@@ -155,7 +155,7 @@ template <bool HAS_LOG> void CommitState::CommitEntry(UndoFlags type, data_ptr_t
 	case UndoFlags::CATALOG_ENTRY: {
 		// set the commit timestamp of the catalog entry to the given id
 		auto catalog_entry = Load<CatalogEntry *>(data);
-		assert(catalog_entry->parent);
+		D_ASSERT(catalog_entry->parent);
 		catalog_entry->set->UpdateTimestamp(catalog_entry->parent, commit_id);
 		if (catalog_entry->name != catalog_entry->parent->name) {
 			catalog_entry->set->UpdateTimestamp(catalog_entry, commit_id);
@@ -207,7 +207,7 @@ void CommitState::RevertCommit(UndoFlags type, data_ptr_t data) {
 	case UndoFlags::CATALOG_ENTRY: {
 		// set the commit timestamp of the catalog entry to the given id
 		auto catalog_entry = Load<CatalogEntry *>(data);
-		assert(catalog_entry->parent);
+		D_ASSERT(catalog_entry->parent);
 		catalog_entry->set->UpdateTimestamp(catalog_entry->parent, transaction_id);
 		if (catalog_entry->name != catalog_entry->parent->name) {
 			catalog_entry->set->UpdateTimestamp(catalog_entry, transaction_id);

--- a/src/transaction/rollback_state.cpp
+++ b/src/transaction/rollback_state.cpp
@@ -18,7 +18,7 @@ void RollbackState::RollbackEntry(UndoFlags type, data_ptr_t data) {
 	case UndoFlags::CATALOG_ENTRY: {
 		// undo this catalog entry
 		auto catalog_entry = Load<CatalogEntry *>(data);
-		assert(catalog_entry->set);
+		D_ASSERT(catalog_entry->set);
 		catalog_entry->set->Undo(catalog_entry);
 		break;
 	}
@@ -40,7 +40,7 @@ void RollbackState::RollbackEntry(UndoFlags type, data_ptr_t data) {
 		break;
 	}
 	default:
-		assert(type == UndoFlags::EMPTY_ENTRY);
+		D_ASSERT(type == UndoFlags::EMPTY_ENTRY);
 		break;
 	}
 }

--- a/src/transaction/transaction_context.cpp
+++ b/src/transaction/transaction_context.cpp
@@ -20,12 +20,12 @@ TransactionContext::~TransactionContext() {
 }
 
 void TransactionContext::BeginTransaction() {
-	assert(!current_transaction); // cannot start a transaction within a transaction
+	D_ASSERT(!current_transaction); // cannot start a transaction within a transaction
 	current_transaction = transaction_manager.StartTransaction();
 }
 
 void TransactionContext::Commit() {
-	assert(current_transaction); // cannot commit if there is no active transaction
+	D_ASSERT(current_transaction); // cannot commit if there is no active transaction
 	auto transaction = current_transaction;
 	SetAutoCommit(true);
 	current_transaction = nullptr;
@@ -36,7 +36,7 @@ void TransactionContext::Commit() {
 }
 
 void TransactionContext::Rollback() {
-	assert(current_transaction); // cannot rollback if there is no active transaction
+	D_ASSERT(current_transaction); // cannot rollback if there is no active transaction
 	auto transaction = current_transaction;
 	SetAutoCommit(true);
 	current_transaction = nullptr;

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -97,7 +97,7 @@ void TransactionManager::RemoveTransaction(Transaction *transaction) noexcept {
 		}
 	}
 	transaction_t lowest_stored_query = lowest_start_time;
-	assert(t_index != active_transactions.size());
+	D_ASSERT(t_index != active_transactions.size());
 	auto current_transaction = move(active_transactions[t_index]);
 	if (transaction->commit_id != 0) {
 		// the transaction was committed, add it to the list of recently
@@ -114,7 +114,7 @@ void TransactionManager::RemoveTransaction(Transaction *transaction) noexcept {
 	// traverse the recently_committed transactions to see if we can remove any
 	idx_t i = 0;
 	for (; i < recently_committed_transactions.size(); i++) {
-		assert(recently_committed_transactions[i]);
+		D_ASSERT(recently_committed_transactions[i]);
 		lowest_stored_query = MinValue(recently_committed_transactions[i]->start_time, lowest_stored_query);
 		if (recently_committed_transactions[i]->commit_id < lowest_start_time) {
 			// changes made BEFORE this transaction are no longer relevant
@@ -149,8 +149,8 @@ void TransactionManager::RemoveTransaction(Transaction *transaction) noexcept {
 	// check if we can free the memory of any old transactions
 	i = active_transactions.size() == 0 ? old_transactions.size() : 0;
 	for (; i < old_transactions.size(); i++) {
-		assert(old_transactions[i]);
-		assert(old_transactions[i]->highest_active_query > 0);
+		D_ASSERT(old_transactions[i]);
+		D_ASSERT(old_transactions[i]->highest_active_query > 0);
 		if (old_transactions[i]->highest_active_query >= lowest_active_query) {
 			// there is still a query running that could be using
 			// this transactions' data
@@ -163,7 +163,7 @@ void TransactionManager::RemoveTransaction(Transaction *transaction) noexcept {
 	}
 	// check if we can free the memory of any old catalog sets
 	for (i = 0; i < old_catalog_sets.size(); i++) {
-		assert(old_catalog_sets[i].highest_active_query > 0);
+		D_ASSERT(old_catalog_sets[i].highest_active_query > 0);
 		if (old_catalog_sets[i].highest_active_query >= lowest_stored_query) {
 			// there is still a query running that could be using
 			// this catalog sets' data

--- a/src/transaction/undo_buffer.cpp
+++ b/src/transaction/undo_buffer.cpp
@@ -43,7 +43,7 @@ UndoChunk::~UndoChunk() {
 
 data_ptr_t UndoChunk::WriteEntry(UndoFlags type, uint32_t len) {
 	len = AlignLength(len);
-	assert(sizeof(UndoFlags) + sizeof(len) == 8);
+	D_ASSERT(sizeof(UndoFlags) + sizeof(len) == 8);
 	Store<UndoFlags>(type, data.get() + current_position);
 	current_position += sizeof(UndoFlags);
 	Store<uint32_t>(len, data.get() + current_position);
@@ -55,7 +55,7 @@ data_ptr_t UndoChunk::WriteEntry(UndoFlags type, uint32_t len) {
 }
 
 data_ptr_t UndoBuffer::CreateEntry(UndoFlags type, idx_t len) {
-	assert(len <= NumericLimits<uint32_t>::Maximum());
+	D_ASSERT(len <= NumericLimits<uint32_t>::Maximum());
 	idx_t needed_space = AlignLength(len + UNDO_ENTRY_HEADER_SIZE);
 	if (head->current_position + needed_space >= head->maximum_size) {
 		auto new_chunk =

--- a/test/api/test_arrow.cpp
+++ b/test/api/test_arrow.cpp
@@ -15,7 +15,7 @@ struct MyArrowArrayStream {
 	}
 
 	static int my_stream_getschema(struct ArrowArrayStream *stream, struct ArrowSchema *out) {
-		assert(stream->private_data);
+		D_ASSERT(stream->private_data);
 		auto my_stream = (MyArrowArrayStream *)stream->private_data;
 		if (!stream->release) {
 			my_stream->last_error = "stream was released";
@@ -26,7 +26,7 @@ struct MyArrowArrayStream {
 	}
 
 	static int my_stream_getnext(struct ArrowArrayStream *stream, struct ArrowArray *out) {
-		assert(stream->private_data);
+		D_ASSERT(stream->private_data);
 		auto my_stream = (MyArrowArrayStream *)stream->private_data;
 		if (!stream->release) {
 			my_stream->last_error = "stream was released";
@@ -52,7 +52,7 @@ struct MyArrowArrayStream {
 		if (!stream->release) {
 			return "stream was released";
 		}
-		assert(stream->private_data);
+		D_ASSERT(stream->private_data);
 		auto my_stream = (MyArrowArrayStream *)stream->private_data;
 		return my_stream->last_error.c_str();
 	}

--- a/test/api/udf_function/udf_functions_to_test.hpp
+++ b/test/api/udf_function/udf_functions_to_test.hpp
@@ -282,7 +282,7 @@ template <typename TYPE> static void udf_max_constant(DataChunk &args, Expressio
  * Vectorized MAX function with varargs and input columns
  */
 template <typename TYPE> static void udf_max_flat(DataChunk &args, ExpressionState &state, Vector &result) {
-	assert(TypeIsNumeric(GetTypeId<TYPE>()));
+	D_ASSERT(TypeIsNumeric(GetTypeId<TYPE>()));
 
 	result.vector_type = VectorType::FLAT_VECTOR;
 	auto result_data = FlatVector::GetData<TYPE>(result);
@@ -292,7 +292,7 @@ template <typename TYPE> static void udf_max_flat(DataChunk &args, ExpressionSta
 
 	for (idx_t col_idx = 0; col_idx < args.column_count(); col_idx++) {
 		auto &input = args.data[col_idx];
-		assert((GetTypeId<TYPE>()) == input.type.InternalType());
+		D_ASSERT((GetTypeId<TYPE>()) == input.type.InternalType());
 		auto input_data = FlatVector::GetData<TYPE>(input);
 		for (idx_t i = 0; i < args.size(); ++i) {
 			if (result_data[i] < input_data[i]) {
@@ -454,7 +454,7 @@ struct UDFSum {
 
 	template <class STATE_TYPE, class INPUT_TYPE>
 	static void Update(Vector inputs[], idx_t input_count, Vector &states, idx_t count) {
-		assert(input_count == 1);
+		D_ASSERT(input_count == 1);
 
 		if (inputs[0].vector_type == VectorType::CONSTANT_VECTOR && states.vector_type == VectorType::CONSTANT_VECTOR) {
 			if (ConstantVector::IsNull(inputs[0])) {
@@ -489,7 +489,7 @@ struct UDFSum {
 
 	template <class STATE_TYPE, class INPUT_TYPE>
 	static void SimpleUpdate(Vector inputs[], idx_t input_count, data_ptr_t state, idx_t count) {
-		assert(input_count == 1);
+		D_ASSERT(input_count == 1);
 		switch (inputs[0].vector_type) {
 		case VectorType::CONSTANT_VECTOR: {
 			if (ConstantVector::IsNull(inputs[0])) {
@@ -524,7 +524,7 @@ struct UDFSum {
 	}
 
 	template <class STATE_TYPE> static void Combine(Vector &source, Vector &target, idx_t count) {
-		assert(source.type.id() == LogicalTypeId::POINTER && target.type.id() == LogicalTypeId::POINTER);
+		D_ASSERT(source.type.id() == LogicalTypeId::POINTER && target.type.id() == LogicalTypeId::POINTER);
 		auto sdata = FlatVector::GetData<STATE_TYPE *>(source);
 		auto tdata = FlatVector::GetData<STATE_TYPE *>(target);
 		// OP::template Combine<STATE_TYPE, OP>(*sdata[i], tdata[i]);
@@ -551,7 +551,7 @@ struct UDFSum {
 			auto rdata = ConstantVector::GetData<RESULT_TYPE>(result);
 			UDFSum::Finalize<RESULT_TYPE, STATE_TYPE>(result, *sdata, rdata, ConstantVector::Nullmask(result), 0);
 		} else {
-			assert(states.vector_type == VectorType::FLAT_VECTOR);
+			D_ASSERT(states.vector_type == VectorType::FLAT_VECTOR);
 			result.vector_type = VectorType::FLAT_VECTOR;
 
 			auto sdata = FlatVector::GetData<STATE_TYPE *>(states);

--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -176,7 +176,7 @@ bool CHECK_COLUMN(unique_ptr<duckdb::MaterializedQueryResult> &result, size_t co
 }
 
 string compare_csv(duckdb::QueryResult &result, string csv, bool header) {
-	assert(result.type == QueryResultType::MATERIALIZED_RESULT);
+	D_ASSERT(result.type == QueryResultType::MATERIALIZED_RESULT);
 	auto &materialized = (MaterializedQueryResult &)result;
 	if (!materialized.success) {
 		fprintf(stderr, "Query failed with message: %s\n", materialized.error.c_str());
@@ -258,7 +258,7 @@ bool compare_chunk(DataChunk &left, DataChunk &right) {
 //! Returns true if they are equal, and stores an error_message otherwise
 bool compare_result(string csv, ChunkCollection &collection, vector<LogicalType> sql_types, bool has_header,
                     string &error_message) {
-	assert(collection.count == 0 || collection.types.size() == sql_types.size());
+	D_ASSERT(collection.count == 0 || collection.types.size() == sql_types.size());
 
 	// set up the CSV reader
 	BufferedCSVReaderOptions options;

--- a/test/sql/join/inner/join_cross_product.test
+++ b/test/sql/join/inner/join_cross_product.test
@@ -1,0 +1,39 @@
+# name: test/sql/join/inner/join_cross_product.test
+# description: Test column binding in cross product of multiple joins
+# group: [inner]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table t1(i integer);
+
+statement ok
+create table t2(j integer);
+
+statement ok
+create table t3(k integer);
+
+statement ok
+create table t4(l integer);
+
+statement ok
+insert into t1 values (1);
+
+statement ok
+insert into t2 values (1);
+
+statement ok
+insert into t3 values (2), (3);
+
+statement ok
+insert into t4 values (2), (3);
+
+query IIII
+select * from t1 join t2 on (i=j), t3 join t4 on (k=l) order by 1, 2, 3, 4;
+----
+1	1	2	2
+1	1	3	3
+
+statement error
+select * from t1 join t2 on (i=j), t3 join t4 on (i+k=j+l)

--- a/test/sql/join/inner/test_using_join.test
+++ b/test/sql/join/inner/test_using_join.test
@@ -71,6 +71,10 @@ SELECT * FROM t1 JOIN t2 USING(a,b)
 statement error
 SELECT * FROM t1 JOIN t2 USING(a) JOIN t2 t2b USING (b);
 
+# this is the same, but now with a duplicate potential binding on the RHS
+statement error
+select * from (values (1)) tbl(i) join ((values (1)) tbl2(i) join  (values (1)) tbl3(i) on tbl2.i=tbl3.i) using (i)
+
 # a chain with the same column name is allowed though!
 query IIIIIII
 SELECT * FROM t1 JOIN t2 USING(a) JOIN t2 t2b USING (a) ORDER BY 1, 2, 3, 4, 5, 6, 7
@@ -79,4 +83,3 @@ SELECT * FROM t1 JOIN t2 USING(a) JOIN t2 t2b USING (a) ORDER BY 1, 2, 3, 4, 5, 
 1	2	3	2	3	3	4
 1	2	3	3	4	2	3
 1	2	3	3	4	3	4
-

--- a/test/sql/join/natural/natural_join.test
+++ b/test/sql/join/natural/natural_join.test
@@ -1,0 +1,85 @@
+# name: test/sql/join/inner/test_using_join.test
+# description: Test USING joins
+# group: [inner]
+
+statement ok
+PRAGMA enable_verification
+
+# create tables
+statement ok
+CREATE TABLE t1 (a INTEGER, b INTEGER)
+
+statement ok
+INSERT INTO t1 VALUES (1, 2)
+
+statement ok
+CREATE TABLE t2 (a INTEGER, c INTEGER)
+
+statement ok
+INSERT INTO t2 VALUES (1, 3), (2, 4)
+
+# NATURAL join with one column
+query III
+SELECT * FROM t1 NATURAL JOIN t2
+----
+1	2	3
+
+query III
+SELECT t1.a, t1.b, t2.c FROM t1 NATURAL JOIN t2
+----
+1	2	3
+
+query III
+SELECT t1.a, t1.b, t2.c FROM t1 NATURAL JOIN t2 ORDER BY t2.a
+----
+1	2	3
+
+# natural join with multiple matching columns
+statement ok
+CREATE TABLE t3 (a INTEGER, b INTEGER, c INTEGER)
+
+statement ok
+INSERT INTO t3 VALUES (1, 2, 3)
+
+query III
+SELECT * FROM t1 NATURAL JOIN t3
+----
+1	2	3
+
+query III
+SELECT * FROM t3 NATURAL JOIN t2
+----
+1	2	3
+
+# natural join chain
+query III
+SELECT * FROM t1 NATURAL JOIN t2 NATURAL JOIN t3
+----
+1	2	3
+
+# no matching columns
+statement error
+select * from (values (1)) tbl(a) natural join (values (1), (2)) tbl2(b) order by 1, 2
+
+# long join chain
+query I
+select * from (values (1)) tbl(a) natural join (values (1)) tbl2(a) natural join (values (1)) tbl3(a)
+              natural join (values (1)) tbl4(a) natural join (values (1)) tbl5(a)
+----
+1
+
+# natural join with subqueries
+query I
+select * from (select 42) tbl(a) natural join (select 42) tbl2(a)
+----
+42
+
+# uncorrelated scalar subquery
+query I
+select (select * from (select 42) tbl(a) natural join (select 42) tbl2(a))
+----
+42
+
+# error: duplicate table alias on both sides
+statement error
+select (select * from (select 42) tbl(a) natural join (select 42) tbl(a))

--- a/test/sql/join/natural/natural_join.test
+++ b/test/sql/join/natural/natural_join.test
@@ -1,6 +1,6 @@
-# name: test/sql/join/inner/test_using_join.test
-# description: Test USING joins
-# group: [inner]
+# name: test/sql/join/natural/natural_join.test
+# description: Test natural joins
+# group: [natural]
 
 statement ok
 PRAGMA enable_verification
@@ -83,3 +83,32 @@ select (select * from (select 42) tbl(a) natural join (select 42) tbl2(a))
 # error: duplicate table alias on both sides
 statement error
 select (select * from (select 42) tbl(a) natural join (select 42) tbl(a))
+
+statement ok
+DROP TABLE t1
+
+statement ok
+CREATE TABLE t0(c0 DATE, c1 DATE DEFAULT('0.5868720116119102'), c2 INT1, PRIMARY KEY(c1, c2, c0));
+
+statement ok
+CREATE TABLE t1(c0 DATETIME, c1 DATE DEFAULT(TIMESTAMP '1970-01-11 02:37:59'), PRIMARY KEY(c0));
+
+statement ok
+CREATE VIEW v0(c0) AS SELECT false FROM t1, t0 HAVING 1689380428;
+
+statement ok
+SELECT COUNT(t1.rowid) FROM t1, v0 NATURAL RIGHT JOIN t0;
+
+statement ok
+SELECT COUNT(t1.rowid) FROM t1, v0 RIGHT JOIN t0 ON v0.c0=t0.c0;
+
+statement error
+SELECT COUNT(t1.rowid) FROM t1, v0 RIGHT JOIN t0 ON t1.c1=t0.c1 AND v0.c0=t0.c0;
+
+# column name appears more than once on left side of the natural join
+statement error
+select * from (values (1)) t1(i) join (values (1)) t2(i) on (t1.i=t2.i) natural join (values (1)) t3(i);
+
+# column name appears more than once on right side of the natural join
+statement error
+select * from (values (1)) t1(i) natural join ((values (1)) t2(i)  join (values (1)) t3(i) on (t2.i=t3.i))

--- a/test/sql/parallelism/interquery/test_concurrentappend.cpp
+++ b/test/sql/parallelism/interquery/test_concurrentappend.cpp
@@ -28,7 +28,7 @@ TEST_CASE("Sequential append", "[interquery][.]") {
 
 	for (size_t i = 0; i < CONCURRENT_APPEND_THREAD_COUNT; i++) {
 		result = connections[i]->Query("SELECT COUNT(*) FROM integers");
-		assert(result->collection.count > 0);
+		D_ASSERT(result->collection.count > 0);
 		Value count = result->collection.chunks[0]->GetValue(0, 0);
 		REQUIRE(count == 0);
 		for (size_t j = 0; j < CONCURRENT_APPEND_INSERT_ELEMENTS; j++) {

--- a/test/sqlite/test_sqllogictest.cpp
+++ b/test/sqlite/test_sqllogictest.cpp
@@ -604,7 +604,16 @@ void Statement::Execute() {
 
 	/* Check to see if we are expecting success or failure */
 	if (!expect_ok) {
-		error = !error;
+		// even in the case of "statement error", we do not accept ALL errors
+		// internal errors are never expected
+		// neither are "unoptimized result differs from original result" errors
+		bool internal_error = StringUtil::Contains(result->error, "Unoptimized Result differs from original result!");
+		internal_error = internal_error || StringUtil::Contains(result->error, "INTERNAL");
+		if (!internal_error) {
+			error = !error;
+		} else {
+			expect_ok = true;
+		}
 	}
 
 	/* Report an error if the results do not match expectation */

--- a/third_party/dsdgen/dsdgen.cpp
+++ b/third_party/dsdgen/dsdgen.cpp
@@ -5,6 +5,7 @@
 #include "tpcds_constants.hpp"
 #include "append_info.hpp"
 #include "dsdgen_helpers.hpp"
+#include <cassert>
 
 using namespace duckdb;
 using namespace std;

--- a/third_party/libpg_query/grammar/statements/select.y
+++ b/third_party/libpg_query/grammar/statements/select.y
@@ -774,6 +774,7 @@ joined_table:
 					n->rarg = $4;
 					n->usingClause = NIL;
 					n->quals = NULL;
+					n->location = @2;
 					$$ = n;
 				}
 			| table_ref join_type JOIN table_ref join_qual
@@ -787,6 +788,7 @@ joined_table:
 						n->usingClause = (PGList *) $5; /* USING clause */
 					else
 						n->quals = $5; /* ON clause */
+					n->location = @2;
 					$$ = n;
 				}
 			| table_ref JOIN table_ref join_qual
@@ -801,6 +803,7 @@ joined_table:
 						n->usingClause = (PGList *) $4; /* USING clause */
 					else
 						n->quals = $4; /* ON clause */
+					n->location = @2;
 					$$ = n;
 				}
 			| table_ref NATURAL join_type JOIN table_ref
@@ -812,6 +815,7 @@ joined_table:
 					n->rarg = $5;
 					n->usingClause = NIL; /* figure out which columns later... */
 					n->quals = NULL; /* fill later */
+					n->location = @2;
 					$$ = n;
 				}
 			| table_ref NATURAL JOIN table_ref
@@ -824,6 +828,7 @@ joined_table:
 					n->rarg = $4;
 					n->usingClause = NIL; /* figure out which columns later... */
 					n->quals = NULL; /* fill later */
+					n->location = @2;
 					$$ = n;
 				}
 		;

--- a/third_party/libpg_query/include/nodes/primnodes.hpp
+++ b/third_party/libpg_query/include/nodes/primnodes.hpp
@@ -1343,6 +1343,7 @@ typedef struct PGJoinExpr {
 	PGNode *quals;       /* qualifiers on join, if any */
 	PGAlias *alias;      /* user-written alias clause, if any */
 	int rtindex;         /* RT index assigned for join, or 0 */
+	int location;          /* token location, or -1 if unknown */
 } PGJoinExpr;
 
 /*----------

--- a/third_party/libpg_query/src_backend_parser_gram.cpp
+++ b/third_party/libpg_query/src_backend_parser_gram.cpp
@@ -2253,51 +2253,51 @@ static const yytype_uint16 yyrline[] =
      554,   555,   559,   560,   564,   565,   569,   570,   574,   585,
      586,   587,   588,   592,   593,   598,   599,   600,   609,   615,
      633,   634,   638,   639,   645,   650,   658,   665,   673,   708,
-     733,   737,   763,   767,   779,   792,   806,   817,   832,   838,
-     843,   849,   856,   857,   865,   869,   873,   879,   886,   891,
-     892,   893,   894,   898,   899,   911,   912,   917,   924,   931,
-     938,   961,   974,   975,   990,  1000,  1012,  1017,  1018,  1021,
-    1022,  1025,  1026,  1031,  1032,  1037,  1041,  1047,  1068,  1076,
-    1088,  1093,  1100,  1105,  1111,  1116,  1125,  1127,  1130,  1134,
-    1135,  1136,  1137,  1138,  1139,  1144,  1164,  1165,  1166,  1167,
-    1178,  1184,  1192,  1193,  1199,  1204,  1209,  1214,  1219,  1224,
-    1229,  1234,  1240,  1246,  1252,  1259,  1281,  1290,  1294,  1302,
-    1306,  1314,  1326,  1347,  1351,  1357,  1361,  1374,  1382,  1392,
-    1394,  1396,  1398,  1400,  1402,  1407,  1408,  1415,  1424,  1432,
-    1441,  1452,  1460,  1461,  1462,  1466,  1468,  1470,  1472,  1474,
-    1476,  1478,  1483,  1488,  1494,  1502,  1507,  1514,  1521,  1525,
-    1529,  1565,  1566,  1568,  1576,  1591,  1593,  1595,  1597,  1599,
-    1601,  1603,  1605,  1607,  1609,  1611,  1613,  1615,  1617,  1620,
-    1622,  1624,  1627,  1629,  1631,  1633,  1636,  1641,  1646,  1653,
-    1658,  1665,  1670,  1678,  1683,  1692,  1700,  1708,  1716,  1734,
-    1742,  1750,  1758,  1766,  1774,  1790,  1798,  1806,  1814,  1822,
-    1830,  1838,  1842,  1846,  1850,  1854,  1862,  1870,  1878,  1886,
-    1906,  1928,  1939,  1946,  1971,  1973,  1975,  1977,  1979,  1981,
-    1983,  1985,  1987,  1989,  1991,  1993,  1995,  1997,  1999,  2001,
-    2003,  2005,  2007,  2009,  2013,  2017,  2021,  2035,  2036,  2037,
-    2049,  2064,  2076,  2078,  2080,  2091,  2115,  2128,  2132,  2138,
-    2145,  2152,  2162,  2169,  2197,  2232,  2243,  2244,  2251,  2257,
-    2261,  2265,  2269,  2273,  2277,  2281,  2285,  2289,  2293,  2297,
-    2301,  2305,  2309,  2313,  2317,  2319,  2323,  2332,  2337,  2344,
-    2359,  2366,  2370,  2374,  2378,  2382,  2396,  2397,  2401,  2402,
-    2410,  2411,  2415,  2416,  2421,  2429,  2431,  2445,  2448,  2475,
-    2476,  2479,  2480,  2491,  2509,  2516,  2525,  2542,  2587,  2595,
-    2603,  2611,  2619,  2640,  2641,  2642,  2645,  2646,  2647,  2650,
-    2651,  2654,  2655,  2656,  2657,  2658,  2659,  2660,  2661,  2662,
-    2663,  2664,  2665,  2668,  2670,  2675,  2677,  2682,  2684,  2686,
-    2688,  2690,  2692,  2694,  2696,  2710,  2712,  2716,  2720,  2727,
-    2731,  2737,  2741,  2750,  2761,  2762,  2766,  2770,  2777,  2778,
-    2779,  2780,  2781,  2782,  2783,  2784,  2794,  2798,  2805,  2812,
-    2813,  2829,  2833,  2838,  2842,  2857,  2862,  2866,  2869,  2872,
-    2873,  2874,  2877,  2884,  2894,  2908,  2909,  2913,  2924,  2925,
-    2928,  2929,  2932,  2936,  2943,  2947,  2951,  2959,  2970,  2971,
-    2975,  2976,  2980,  2981,  2984,  2985,  2995,  2996,  3000,  3001,
-    3004,  3020,  3028,  3036,  3058,  3059,  3070,  3074,  3101,  3103,
-    3108,  3110,  3120,  3122,  3133,  3137,  3141,  3145,  3149,  3158,
-    3165,  3197,  3201,  3207,  3215,  3227,  3231,  3235,  3241,  3242,
-    3258,  3259,  3260,  3263,  3264,  3269,  3270,  3271,  3274,  3275,
-    3278,  3280,  3285,  3286,  3289,  3297,  3298,  3299,  3300,  3301,
-    3304,  3305,     7,    18,    19,    23,    24,    25,    26,     7,
+     733,   737,   763,   767,   780,   794,   809,   821,   837,   843,
+     848,   854,   861,   862,   870,   874,   878,   884,   891,   896,
+     897,   898,   899,   903,   904,   916,   917,   922,   929,   936,
+     943,   966,   979,   980,   995,  1005,  1017,  1022,  1023,  1026,
+    1027,  1030,  1031,  1036,  1037,  1042,  1046,  1052,  1073,  1081,
+    1093,  1098,  1105,  1110,  1116,  1121,  1130,  1132,  1135,  1139,
+    1140,  1141,  1142,  1143,  1144,  1149,  1169,  1170,  1171,  1172,
+    1183,  1189,  1197,  1198,  1204,  1209,  1214,  1219,  1224,  1229,
+    1234,  1239,  1245,  1251,  1257,  1264,  1286,  1295,  1299,  1307,
+    1311,  1319,  1331,  1352,  1356,  1362,  1366,  1379,  1387,  1397,
+    1399,  1401,  1403,  1405,  1407,  1412,  1413,  1420,  1429,  1437,
+    1446,  1457,  1465,  1466,  1467,  1471,  1473,  1475,  1477,  1479,
+    1481,  1483,  1488,  1493,  1499,  1507,  1512,  1519,  1526,  1530,
+    1534,  1570,  1571,  1573,  1581,  1596,  1598,  1600,  1602,  1604,
+    1606,  1608,  1610,  1612,  1614,  1616,  1618,  1620,  1622,  1625,
+    1627,  1629,  1632,  1634,  1636,  1638,  1641,  1646,  1651,  1658,
+    1663,  1670,  1675,  1683,  1688,  1697,  1705,  1713,  1721,  1739,
+    1747,  1755,  1763,  1771,  1779,  1795,  1803,  1811,  1819,  1827,
+    1835,  1843,  1847,  1851,  1855,  1859,  1867,  1875,  1883,  1891,
+    1911,  1933,  1944,  1951,  1976,  1978,  1980,  1982,  1984,  1986,
+    1988,  1990,  1992,  1994,  1996,  1998,  2000,  2002,  2004,  2006,
+    2008,  2010,  2012,  2014,  2018,  2022,  2026,  2040,  2041,  2042,
+    2054,  2069,  2081,  2083,  2085,  2096,  2120,  2133,  2137,  2143,
+    2150,  2157,  2167,  2174,  2202,  2237,  2248,  2249,  2256,  2262,
+    2266,  2270,  2274,  2278,  2282,  2286,  2290,  2294,  2298,  2302,
+    2306,  2310,  2314,  2318,  2322,  2324,  2328,  2337,  2342,  2349,
+    2364,  2371,  2375,  2379,  2383,  2387,  2401,  2402,  2406,  2407,
+    2415,  2416,  2420,  2421,  2426,  2434,  2436,  2450,  2453,  2480,
+    2481,  2484,  2485,  2496,  2514,  2521,  2530,  2547,  2592,  2600,
+    2608,  2616,  2624,  2645,  2646,  2647,  2650,  2651,  2652,  2655,
+    2656,  2659,  2660,  2661,  2662,  2663,  2664,  2665,  2666,  2667,
+    2668,  2669,  2670,  2673,  2675,  2680,  2682,  2687,  2689,  2691,
+    2693,  2695,  2697,  2699,  2701,  2715,  2717,  2721,  2725,  2732,
+    2736,  2742,  2746,  2755,  2766,  2767,  2771,  2775,  2782,  2783,
+    2784,  2785,  2786,  2787,  2788,  2789,  2799,  2803,  2810,  2817,
+    2818,  2834,  2838,  2843,  2847,  2862,  2867,  2871,  2874,  2877,
+    2878,  2879,  2882,  2889,  2899,  2913,  2914,  2918,  2929,  2930,
+    2933,  2934,  2937,  2941,  2948,  2952,  2956,  2964,  2975,  2976,
+    2980,  2981,  2985,  2986,  2989,  2990,  3000,  3001,  3005,  3006,
+    3009,  3025,  3033,  3041,  3063,  3064,  3075,  3079,  3106,  3108,
+    3113,  3115,  3125,  3127,  3138,  3142,  3146,  3150,  3154,  3163,
+    3170,  3202,  3206,  3212,  3220,  3232,  3236,  3240,  3246,  3247,
+    3263,  3264,  3265,  3268,  3269,  3274,  3275,  3276,  3279,  3280,
+    3283,  3285,  3290,  3291,  3294,  3302,  3303,  3304,  3305,  3306,
+    3309,  3310,     7,    18,    19,    23,    24,    25,    26,     7,
       16,    34,    41,    46,    47,    48,    49,     8,    33,    62,
       66,    67,    72,    73,    78,    79,    83,    84,    89,    90,
        7,    16,    25,    34,    43,    52,     5,     7,    20,     9,
@@ -17698,12 +17698,13 @@ yyreduce:
 					n->rarg = (yyvsp[(4) - (4)].node);
 					n->usingClause = NIL;
 					n->quals = NULL;
+					n->location = (yylsp[(2) - (4)]);
 					(yyval.jexpr) = n;
 				;}
     break;
 
   case 544:
-#line 780 "third_party/libpg_query/grammar/statements/select.y"
+#line 781 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGJoinExpr *n = makeNode(PGJoinExpr);
 					n->jointype = (yyvsp[(2) - (5)].jtype);
@@ -17714,12 +17715,13 @@ yyreduce:
 						n->usingClause = (PGList *) (yyvsp[(5) - (5)].node); /* USING clause */
 					else
 						n->quals = (yyvsp[(5) - (5)].node); /* ON clause */
+					n->location = (yylsp[(2) - (5)]);
 					(yyval.jexpr) = n;
 				;}
     break;
 
   case 545:
-#line 793 "third_party/libpg_query/grammar/statements/select.y"
+#line 795 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/* letting join_type reduce to empty doesn't work */
 					PGJoinExpr *n = makeNode(PGJoinExpr);
@@ -17731,12 +17733,13 @@ yyreduce:
 						n->usingClause = (PGList *) (yyvsp[(4) - (4)].node); /* USING clause */
 					else
 						n->quals = (yyvsp[(4) - (4)].node); /* ON clause */
+					n->location = (yylsp[(2) - (4)]);
 					(yyval.jexpr) = n;
 				;}
     break;
 
   case 546:
-#line 807 "third_party/libpg_query/grammar/statements/select.y"
+#line 810 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGJoinExpr *n = makeNode(PGJoinExpr);
 					n->jointype = (yyvsp[(3) - (5)].jtype);
@@ -17745,12 +17748,13 @@ yyreduce:
 					n->rarg = (yyvsp[(5) - (5)].node);
 					n->usingClause = NIL; /* figure out which columns later... */
 					n->quals = NULL; /* fill later */
+					n->location = (yylsp[(2) - (5)]);
 					(yyval.jexpr) = n;
 				;}
     break;
 
   case 547:
-#line 818 "third_party/libpg_query/grammar/statements/select.y"
+#line 822 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/* letting join_type reduce to empty doesn't work */
 					PGJoinExpr *n = makeNode(PGJoinExpr);
@@ -17760,12 +17764,13 @@ yyreduce:
 					n->rarg = (yyvsp[(4) - (4)].node);
 					n->usingClause = NIL; /* figure out which columns later... */
 					n->quals = NULL; /* fill later */
+					n->location = (yylsp[(2) - (4)]);
 					(yyval.jexpr) = n;
 				;}
     break;
 
   case 548:
-#line 833 "third_party/libpg_query/grammar/statements/select.y"
+#line 838 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.alias) = makeNode(PGAlias);
 					(yyval.alias)->aliasname = (yyvsp[(2) - (5)].str);
@@ -17774,7 +17779,7 @@ yyreduce:
     break;
 
   case 549:
-#line 839 "third_party/libpg_query/grammar/statements/select.y"
+#line 844 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.alias) = makeNode(PGAlias);
 					(yyval.alias)->aliasname = (yyvsp[(2) - (2)].str);
@@ -17782,7 +17787,7 @@ yyreduce:
     break;
 
   case 550:
-#line 844 "third_party/libpg_query/grammar/statements/select.y"
+#line 849 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.alias) = makeNode(PGAlias);
 					(yyval.alias)->aliasname = (yyvsp[(1) - (4)].str);
@@ -17791,7 +17796,7 @@ yyreduce:
     break;
 
   case 551:
-#line 850 "third_party/libpg_query/grammar/statements/select.y"
+#line 855 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.alias) = makeNode(PGAlias);
 					(yyval.alias)->aliasname = (yyvsp[(1) - (1)].str);
@@ -17799,31 +17804,31 @@ yyreduce:
     break;
 
   case 552:
-#line 856 "third_party/libpg_query/grammar/statements/select.y"
+#line 861 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.alias) = (yyvsp[(1) - (1)].alias); ;}
     break;
 
   case 553:
-#line 857 "third_party/libpg_query/grammar/statements/select.y"
+#line 862 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.alias) = NULL; ;}
     break;
 
   case 554:
-#line 866 "third_party/libpg_query/grammar/statements/select.y"
+#line 871 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = list_make2((yyvsp[(1) - (1)].alias), NIL);
 				;}
     break;
 
   case 555:
-#line 870 "third_party/libpg_query/grammar/statements/select.y"
+#line 875 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = list_make2(NULL, (yyvsp[(3) - (4)].list));
 				;}
     break;
 
   case 556:
-#line 874 "third_party/libpg_query/grammar/statements/select.y"
+#line 879 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGAlias *a = makeNode(PGAlias);
 					a->aliasname = (yyvsp[(2) - (5)].str);
@@ -17832,7 +17837,7 @@ yyreduce:
     break;
 
   case 557:
-#line 880 "third_party/libpg_query/grammar/statements/select.y"
+#line 885 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGAlias *a = makeNode(PGAlias);
 					a->aliasname = (yyvsp[(1) - (4)].str);
@@ -17841,54 +17846,54 @@ yyreduce:
     break;
 
   case 558:
-#line 886 "third_party/libpg_query/grammar/statements/select.y"
+#line 891 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = list_make2(NULL, NIL);
 				;}
     break;
 
   case 559:
-#line 891 "third_party/libpg_query/grammar/statements/select.y"
+#line 896 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.jtype) = PG_JOIN_FULL; ;}
     break;
 
   case 560:
-#line 892 "third_party/libpg_query/grammar/statements/select.y"
+#line 897 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.jtype) = PG_JOIN_LEFT; ;}
     break;
 
   case 561:
-#line 893 "third_party/libpg_query/grammar/statements/select.y"
+#line 898 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.jtype) = PG_JOIN_RIGHT; ;}
     break;
 
   case 562:
-#line 894 "third_party/libpg_query/grammar/statements/select.y"
+#line 899 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.jtype) = PG_JOIN_INNER; ;}
     break;
 
   case 563:
-#line 898 "third_party/libpg_query/grammar/statements/select.y"
+#line 903 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = NULL; ;}
     break;
 
   case 564:
-#line 899 "third_party/libpg_query/grammar/statements/select.y"
+#line 904 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = NULL; ;}
     break;
 
   case 565:
-#line 911 "third_party/libpg_query/grammar/statements/select.y"
+#line 916 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) (yyvsp[(3) - (4)].list); ;}
     break;
 
   case 566:
-#line 912 "third_party/libpg_query/grammar/statements/select.y"
+#line 917 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (yyvsp[(2) - (2)].node); ;}
     break;
 
   case 567:
-#line 918 "third_party/libpg_query/grammar/statements/select.y"
+#line 923 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/* inheritance query, implicitly */
 					(yyval.range) = (yyvsp[(1) - (1)].range);
@@ -17898,7 +17903,7 @@ yyreduce:
     break;
 
   case 568:
-#line 925 "third_party/libpg_query/grammar/statements/select.y"
+#line 930 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/* inheritance query, explicitly */
 					(yyval.range) = (yyvsp[(1) - (2)].range);
@@ -17908,7 +17913,7 @@ yyreduce:
     break;
 
   case 569:
-#line 932 "third_party/libpg_query/grammar/statements/select.y"
+#line 937 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/* no inheritance */
 					(yyval.range) = (yyvsp[(2) - (2)].range);
@@ -17918,7 +17923,7 @@ yyreduce:
     break;
 
   case 570:
-#line 939 "third_party/libpg_query/grammar/statements/select.y"
+#line 944 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/* no inheritance, SQL99-style syntax */
 					(yyval.range) = (yyvsp[(3) - (4)].range);
@@ -17928,7 +17933,7 @@ yyreduce:
     break;
 
   case 571:
-#line 962 "third_party/libpg_query/grammar/statements/select.y"
+#line 967 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGRangeTableSample *n = makeNode(PGRangeTableSample);
 					/* n->relation will be filled in later */
@@ -17941,17 +17946,17 @@ yyreduce:
     break;
 
   case 572:
-#line 974 "third_party/libpg_query/grammar/statements/select.y"
+#line 979 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) (yyvsp[(3) - (4)].node); ;}
     break;
 
   case 573:
-#line 975 "third_party/libpg_query/grammar/statements/select.y"
+#line 980 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = NULL; ;}
     break;
 
   case 574:
-#line 991 "third_party/libpg_query/grammar/statements/select.y"
+#line 996 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGRangeFunction *n = makeNode(PGRangeFunction);
 					n->lateral = false;
@@ -17964,7 +17969,7 @@ yyreduce:
     break;
 
   case 575:
-#line 1001 "third_party/libpg_query/grammar/statements/select.y"
+#line 1006 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGRangeFunction *n = makeNode(PGRangeFunction);
 					n->lateral = false;
@@ -17977,66 +17982,66 @@ yyreduce:
     break;
 
   case 576:
-#line 1013 "third_party/libpg_query/grammar/statements/select.y"
+#line 1018 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make2((yyvsp[(1) - (2)].node), (yyvsp[(2) - (2)].list)); ;}
     break;
 
   case 577:
-#line 1017 "third_party/libpg_query/grammar/statements/select.y"
+#line 1022 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1((yyvsp[(1) - (1)].list)); ;}
     break;
 
   case 578:
-#line 1018 "third_party/libpg_query/grammar/statements/select.y"
+#line 1023 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = lappend((yyvsp[(1) - (3)].list), (yyvsp[(3) - (3)].list)); ;}
     break;
 
   case 579:
-#line 1021 "third_party/libpg_query/grammar/statements/select.y"
+#line 1026 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = (yyvsp[(3) - (4)].list); ;}
     break;
 
   case 580:
-#line 1022 "third_party/libpg_query/grammar/statements/select.y"
+#line 1027 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = NIL; ;}
     break;
 
   case 581:
-#line 1025 "third_party/libpg_query/grammar/statements/select.y"
+#line 1030 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.boolean) = true; ;}
     break;
 
   case 582:
-#line 1026 "third_party/libpg_query/grammar/statements/select.y"
+#line 1031 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.boolean) = false; ;}
     break;
 
   case 583:
-#line 1031 "third_party/libpg_query/grammar/statements/select.y"
+#line 1036 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (yyvsp[(2) - (2)].node); ;}
     break;
 
   case 584:
-#line 1032 "third_party/libpg_query/grammar/statements/select.y"
+#line 1037 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = NULL; ;}
     break;
 
   case 585:
-#line 1038 "third_party/libpg_query/grammar/statements/select.y"
+#line 1043 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = list_make1((yyvsp[(1) - (1)].node));
 				;}
     break;
 
   case 586:
-#line 1042 "third_party/libpg_query/grammar/statements/select.y"
+#line 1047 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = lappend((yyvsp[(1) - (3)].list), (yyvsp[(3) - (3)].node));
 				;}
     break;
 
   case 587:
-#line 1048 "third_party/libpg_query/grammar/statements/select.y"
+#line 1053 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGColumnDef *n = makeNode(PGColumnDef);
 					n->colname = (yyvsp[(1) - (3)].str);
@@ -18057,7 +18062,7 @@ yyreduce:
     break;
 
   case 588:
-#line 1069 "third_party/libpg_query/grammar/statements/select.y"
+#line 1074 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGCollateClause *n = makeNode(PGCollateClause);
 					n->arg = NULL;
@@ -18068,12 +18073,12 @@ yyreduce:
     break;
 
   case 589:
-#line 1076 "third_party/libpg_query/grammar/statements/select.y"
+#line 1081 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = NULL; ;}
     break;
 
   case 590:
-#line 1089 "third_party/libpg_query/grammar/statements/select.y"
+#line 1094 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = (yyvsp[(1) - (2)].typnam);
 					(yyval.typnam)->arrayBounds = (yyvsp[(2) - (2)].list);
@@ -18081,7 +18086,7 @@ yyreduce:
     break;
 
   case 591:
-#line 1094 "third_party/libpg_query/grammar/statements/select.y"
+#line 1099 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = (yyvsp[(2) - (3)].typnam);
 					(yyval.typnam)->arrayBounds = (yyvsp[(3) - (3)].list);
@@ -18090,7 +18095,7 @@ yyreduce:
     break;
 
   case 592:
-#line 1101 "third_party/libpg_query/grammar/statements/select.y"
+#line 1106 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = (yyvsp[(1) - (5)].typnam);
 					(yyval.typnam)->arrayBounds = list_make1(makeInteger((yyvsp[(4) - (5)].ival)));
@@ -18098,7 +18103,7 @@ yyreduce:
     break;
 
   case 593:
-#line 1106 "third_party/libpg_query/grammar/statements/select.y"
+#line 1111 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = (yyvsp[(2) - (6)].typnam);
 					(yyval.typnam)->arrayBounds = list_make1(makeInteger((yyvsp[(5) - (6)].ival)));
@@ -18107,7 +18112,7 @@ yyreduce:
     break;
 
   case 594:
-#line 1112 "third_party/libpg_query/grammar/statements/select.y"
+#line 1117 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = (yyvsp[(1) - (2)].typnam);
 					(yyval.typnam)->arrayBounds = list_make1(makeInteger(-1));
@@ -18115,7 +18120,7 @@ yyreduce:
     break;
 
   case 595:
-#line 1117 "third_party/libpg_query/grammar/statements/select.y"
+#line 1122 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = (yyvsp[(2) - (3)].typnam);
 					(yyval.typnam)->arrayBounds = list_make1(makeInteger(-1));
@@ -18124,47 +18129,47 @@ yyreduce:
     break;
 
   case 596:
-#line 1126 "third_party/libpg_query/grammar/statements/select.y"
+#line 1131 "third_party/libpg_query/grammar/statements/select.y"
     {  (yyval.list) = lappend((yyvsp[(1) - (3)].list), makeInteger(-1)); ;}
     break;
 
   case 597:
-#line 1128 "third_party/libpg_query/grammar/statements/select.y"
+#line 1133 "third_party/libpg_query/grammar/statements/select.y"
     {  (yyval.list) = lappend((yyvsp[(1) - (4)].list), makeInteger((yyvsp[(3) - (4)].ival))); ;}
     break;
 
   case 598:
-#line 1130 "third_party/libpg_query/grammar/statements/select.y"
+#line 1135 "third_party/libpg_query/grammar/statements/select.y"
     {  (yyval.list) = NIL; ;}
     break;
 
   case 599:
-#line 1134 "third_party/libpg_query/grammar/statements/select.y"
+#line 1139 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.typnam) = (yyvsp[(1) - (1)].typnam); ;}
     break;
 
   case 600:
-#line 1135 "third_party/libpg_query/grammar/statements/select.y"
+#line 1140 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.typnam) = (yyvsp[(1) - (1)].typnam); ;}
     break;
 
   case 601:
-#line 1136 "third_party/libpg_query/grammar/statements/select.y"
+#line 1141 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.typnam) = (yyvsp[(1) - (1)].typnam); ;}
     break;
 
   case 602:
-#line 1137 "third_party/libpg_query/grammar/statements/select.y"
+#line 1142 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.typnam) = (yyvsp[(1) - (1)].typnam); ;}
     break;
 
   case 603:
-#line 1138 "third_party/libpg_query/grammar/statements/select.y"
+#line 1143 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.typnam) = (yyvsp[(1) - (1)].typnam); ;}
     break;
 
   case 604:
-#line 1140 "third_party/libpg_query/grammar/statements/select.y"
+#line 1145 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = (yyvsp[(1) - (2)].typnam);
 					(yyval.typnam)->typmods = (yyvsp[(2) - (2)].list);
@@ -18172,7 +18177,7 @@ yyreduce:
     break;
 
   case 605:
-#line 1145 "third_party/libpg_query/grammar/statements/select.y"
+#line 1150 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = (yyvsp[(1) - (4)].typnam);
 					(yyval.typnam)->typmods = list_make2(makeIntConst(INTERVAL_FULL_RANGE, -1),
@@ -18181,27 +18186,27 @@ yyreduce:
     break;
 
   case 606:
-#line 1164 "third_party/libpg_query/grammar/statements/select.y"
+#line 1169 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.typnam) = (yyvsp[(1) - (1)].typnam); ;}
     break;
 
   case 607:
-#line 1165 "third_party/libpg_query/grammar/statements/select.y"
+#line 1170 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.typnam) = (yyvsp[(1) - (1)].typnam); ;}
     break;
 
   case 608:
-#line 1166 "third_party/libpg_query/grammar/statements/select.y"
+#line 1171 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.typnam) = (yyvsp[(1) - (1)].typnam); ;}
     break;
 
   case 609:
-#line 1167 "third_party/libpg_query/grammar/statements/select.y"
+#line 1172 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.typnam) = (yyvsp[(1) - (1)].typnam); ;}
     break;
 
   case 610:
-#line 1179 "third_party/libpg_query/grammar/statements/select.y"
+#line 1184 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = makeTypeName((yyvsp[(1) - (2)].str));
 					(yyval.typnam)->typmods = (yyvsp[(2) - (2)].list);
@@ -18210,7 +18215,7 @@ yyreduce:
     break;
 
   case 611:
-#line 1185 "third_party/libpg_query/grammar/statements/select.y"
+#line 1190 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = makeTypeNameFromNameList(lcons(makeString((yyvsp[(1) - (3)].str)), (yyvsp[(2) - (3)].list)));
 					(yyval.typnam)->typmods = (yyvsp[(3) - (3)].list);
@@ -18219,24 +18224,16 @@ yyreduce:
     break;
 
   case 612:
-#line 1192 "third_party/libpg_query/grammar/statements/select.y"
+#line 1197 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = (yyvsp[(2) - (3)].list); ;}
     break;
 
   case 613:
-#line 1193 "third_party/libpg_query/grammar/statements/select.y"
+#line 1198 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = NIL; ;}
     break;
 
   case 614:
-#line 1200 "third_party/libpg_query/grammar/statements/select.y"
-    {
-					(yyval.typnam) = SystemTypeName("int4");
-					(yyval.typnam)->location = (yylsp[(1) - (1)]);
-				;}
-    break;
-
-  case 615:
 #line 1205 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = SystemTypeName("int4");
@@ -18244,8 +18241,16 @@ yyreduce:
 				;}
     break;
 
-  case 616:
+  case 615:
 #line 1210 "third_party/libpg_query/grammar/statements/select.y"
+    {
+					(yyval.typnam) = SystemTypeName("int4");
+					(yyval.typnam)->location = (yylsp[(1) - (1)]);
+				;}
+    break;
+
+  case 616:
+#line 1215 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = SystemTypeName("int2");
 					(yyval.typnam)->location = (yylsp[(1) - (1)]);
@@ -18253,7 +18258,7 @@ yyreduce:
     break;
 
   case 617:
-#line 1215 "third_party/libpg_query/grammar/statements/select.y"
+#line 1220 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = SystemTypeName("int8");
 					(yyval.typnam)->location = (yylsp[(1) - (1)]);
@@ -18261,7 +18266,7 @@ yyreduce:
     break;
 
   case 618:
-#line 1220 "third_party/libpg_query/grammar/statements/select.y"
+#line 1225 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = SystemTypeName("float4");
 					(yyval.typnam)->location = (yylsp[(1) - (1)]);
@@ -18269,7 +18274,7 @@ yyreduce:
     break;
 
   case 619:
-#line 1225 "third_party/libpg_query/grammar/statements/select.y"
+#line 1230 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = (yyvsp[(2) - (2)].typnam);
 					(yyval.typnam)->location = (yylsp[(1) - (2)]);
@@ -18277,7 +18282,7 @@ yyreduce:
     break;
 
   case 620:
-#line 1230 "third_party/libpg_query/grammar/statements/select.y"
+#line 1235 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = SystemTypeName("float8");
 					(yyval.typnam)->location = (yylsp[(1) - (2)]);
@@ -18285,7 +18290,7 @@ yyreduce:
     break;
 
   case 621:
-#line 1235 "third_party/libpg_query/grammar/statements/select.y"
+#line 1240 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = SystemTypeName("numeric");
 					(yyval.typnam)->typmods = (yyvsp[(2) - (2)].list);
@@ -18294,7 +18299,7 @@ yyreduce:
     break;
 
   case 622:
-#line 1241 "third_party/libpg_query/grammar/statements/select.y"
+#line 1246 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = SystemTypeName("numeric");
 					(yyval.typnam)->typmods = (yyvsp[(2) - (2)].list);
@@ -18303,7 +18308,7 @@ yyreduce:
     break;
 
   case 623:
-#line 1247 "third_party/libpg_query/grammar/statements/select.y"
+#line 1252 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = SystemTypeName("numeric");
 					(yyval.typnam)->typmods = (yyvsp[(2) - (2)].list);
@@ -18312,7 +18317,7 @@ yyreduce:
     break;
 
   case 624:
-#line 1253 "third_party/libpg_query/grammar/statements/select.y"
+#line 1258 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = SystemTypeName("bool");
 					(yyval.typnam)->location = (yylsp[(1) - (1)]);
@@ -18320,7 +18325,7 @@ yyreduce:
     break;
 
   case 625:
-#line 1260 "third_party/libpg_query/grammar/statements/select.y"
+#line 1265 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/*
 					 * Check FLOAT() precision limits assuming IEEE floating
@@ -18344,35 +18349,35 @@ yyreduce:
     break;
 
   case 626:
-#line 1281 "third_party/libpg_query/grammar/statements/select.y"
+#line 1286 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = SystemTypeName("float4");
 				;}
     break;
 
   case 627:
-#line 1291 "third_party/libpg_query/grammar/statements/select.y"
+#line 1296 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = (yyvsp[(1) - (1)].typnam);
 				;}
     break;
 
   case 628:
-#line 1295 "third_party/libpg_query/grammar/statements/select.y"
+#line 1300 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = (yyvsp[(1) - (1)].typnam);
 				;}
     break;
 
   case 629:
-#line 1303 "third_party/libpg_query/grammar/statements/select.y"
+#line 1308 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = (yyvsp[(1) - (1)].typnam);
 				;}
     break;
 
   case 630:
-#line 1307 "third_party/libpg_query/grammar/statements/select.y"
+#line 1312 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = (yyvsp[(1) - (1)].typnam);
 					(yyval.typnam)->typmods = NIL;
@@ -18380,7 +18385,7 @@ yyreduce:
     break;
 
   case 631:
-#line 1315 "third_party/libpg_query/grammar/statements/select.y"
+#line 1320 "third_party/libpg_query/grammar/statements/select.y"
     {
 					const char *typname;
 
@@ -18392,7 +18397,7 @@ yyreduce:
     break;
 
   case 632:
-#line 1327 "third_party/libpg_query/grammar/statements/select.y"
+#line 1332 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/* bit defaults to bit(1), varbit to no limit */
 					if ((yyvsp[(2) - (2)].boolean))
@@ -18409,28 +18414,28 @@ yyreduce:
     break;
 
   case 633:
-#line 1348 "third_party/libpg_query/grammar/statements/select.y"
+#line 1353 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = (yyvsp[(1) - (1)].typnam);
 				;}
     break;
 
   case 634:
-#line 1352 "third_party/libpg_query/grammar/statements/select.y"
+#line 1357 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = (yyvsp[(1) - (1)].typnam);
 				;}
     break;
 
   case 635:
-#line 1358 "third_party/libpg_query/grammar/statements/select.y"
+#line 1363 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = (yyvsp[(1) - (1)].typnam);
 				;}
     break;
 
   case 636:
-#line 1362 "third_party/libpg_query/grammar/statements/select.y"
+#line 1367 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/* Length was not specified so allow to be unrestricted.
 					 * This handles problems with fixed-length (bpchar) strings
@@ -18444,7 +18449,7 @@ yyreduce:
     break;
 
   case 637:
-#line 1375 "third_party/libpg_query/grammar/statements/select.y"
+#line 1380 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = SystemTypeName((yyvsp[(1) - (4)].conststr));
 					(yyval.typnam)->typmods = list_make1(makeIntConst((yyvsp[(3) - (4)].ival), (yylsp[(3) - (4)])));
@@ -18453,7 +18458,7 @@ yyreduce:
     break;
 
   case 638:
-#line 1383 "third_party/libpg_query/grammar/statements/select.y"
+#line 1388 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = SystemTypeName((yyvsp[(1) - (1)].conststr));
 					/* char defaults to char(1), varchar to no limit */
@@ -18464,47 +18469,47 @@ yyreduce:
     break;
 
   case 639:
-#line 1393 "third_party/libpg_query/grammar/statements/select.y"
+#line 1398 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.conststr) = (yyvsp[(2) - (2)].boolean) ? "varchar": "bpchar"; ;}
     break;
 
   case 640:
-#line 1395 "third_party/libpg_query/grammar/statements/select.y"
+#line 1400 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.conststr) = (yyvsp[(2) - (2)].boolean) ? "varchar": "bpchar"; ;}
     break;
 
   case 641:
-#line 1397 "third_party/libpg_query/grammar/statements/select.y"
+#line 1402 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.conststr) = "varchar"; ;}
     break;
 
   case 642:
-#line 1399 "third_party/libpg_query/grammar/statements/select.y"
+#line 1404 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.conststr) = (yyvsp[(3) - (3)].boolean) ? "varchar": "bpchar"; ;}
     break;
 
   case 643:
-#line 1401 "third_party/libpg_query/grammar/statements/select.y"
+#line 1406 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.conststr) = (yyvsp[(3) - (3)].boolean) ? "varchar": "bpchar"; ;}
     break;
 
   case 644:
-#line 1403 "third_party/libpg_query/grammar/statements/select.y"
+#line 1408 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.conststr) = (yyvsp[(2) - (2)].boolean) ? "varchar": "bpchar"; ;}
     break;
 
   case 645:
-#line 1407 "third_party/libpg_query/grammar/statements/select.y"
+#line 1412 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.boolean) = true; ;}
     break;
 
   case 646:
-#line 1408 "third_party/libpg_query/grammar/statements/select.y"
+#line 1413 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.boolean) = false; ;}
     break;
 
   case 647:
-#line 1416 "third_party/libpg_query/grammar/statements/select.y"
+#line 1421 "third_party/libpg_query/grammar/statements/select.y"
     {
 					if ((yyvsp[(5) - (5)].boolean))
 						(yyval.typnam) = SystemTypeName("timestamptz");
@@ -18516,7 +18521,7 @@ yyreduce:
     break;
 
   case 648:
-#line 1425 "third_party/libpg_query/grammar/statements/select.y"
+#line 1430 "third_party/libpg_query/grammar/statements/select.y"
     {
 					if ((yyvsp[(2) - (2)].boolean))
 						(yyval.typnam) = SystemTypeName("timestamptz");
@@ -18527,7 +18532,7 @@ yyreduce:
     break;
 
   case 649:
-#line 1433 "third_party/libpg_query/grammar/statements/select.y"
+#line 1438 "third_party/libpg_query/grammar/statements/select.y"
     {
 					if ((yyvsp[(5) - (5)].boolean))
 						(yyval.typnam) = SystemTypeName("timetz");
@@ -18539,7 +18544,7 @@ yyreduce:
     break;
 
   case 650:
-#line 1442 "third_party/libpg_query/grammar/statements/select.y"
+#line 1447 "third_party/libpg_query/grammar/statements/select.y"
     {
 					if ((yyvsp[(2) - (2)].boolean))
 						(yyval.typnam) = SystemTypeName("timetz");
@@ -18550,7 +18555,7 @@ yyreduce:
     break;
 
   case 651:
-#line 1453 "third_party/libpg_query/grammar/statements/select.y"
+#line 1458 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.typnam) = SystemTypeName("interval");
 					(yyval.typnam)->location = (yylsp[(1) - (1)]);
@@ -18558,52 +18563,52 @@ yyreduce:
     break;
 
   case 652:
-#line 1460 "third_party/libpg_query/grammar/statements/select.y"
+#line 1465 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.boolean) = true; ;}
     break;
 
   case 653:
-#line 1461 "third_party/libpg_query/grammar/statements/select.y"
+#line 1466 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.boolean) = false; ;}
     break;
 
   case 654:
-#line 1462 "third_party/libpg_query/grammar/statements/select.y"
+#line 1467 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.boolean) = false; ;}
     break;
 
   case 655:
-#line 1467 "third_party/libpg_query/grammar/statements/select.y"
+#line 1472 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1(makeIntConst(INTERVAL_MASK(YEAR), (yylsp[(1) - (1)]))); ;}
     break;
 
   case 656:
-#line 1469 "third_party/libpg_query/grammar/statements/select.y"
+#line 1474 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1(makeIntConst(INTERVAL_MASK(MONTH), (yylsp[(1) - (1)]))); ;}
     break;
 
   case 657:
-#line 1471 "third_party/libpg_query/grammar/statements/select.y"
+#line 1476 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1(makeIntConst(INTERVAL_MASK(DAY), (yylsp[(1) - (1)]))); ;}
     break;
 
   case 658:
-#line 1473 "third_party/libpg_query/grammar/statements/select.y"
+#line 1478 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1(makeIntConst(INTERVAL_MASK(HOUR), (yylsp[(1) - (1)]))); ;}
     break;
 
   case 659:
-#line 1475 "third_party/libpg_query/grammar/statements/select.y"
+#line 1480 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1(makeIntConst(INTERVAL_MASK(MINUTE), (yylsp[(1) - (1)]))); ;}
     break;
 
   case 660:
-#line 1477 "third_party/libpg_query/grammar/statements/select.y"
+#line 1482 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = (yyvsp[(1) - (1)].list); ;}
     break;
 
   case 661:
-#line 1479 "third_party/libpg_query/grammar/statements/select.y"
+#line 1484 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = list_make1(makeIntConst(INTERVAL_MASK(YEAR) |
 												 INTERVAL_MASK(MONTH), (yylsp[(1) - (3)])));
@@ -18611,7 +18616,7 @@ yyreduce:
     break;
 
   case 662:
-#line 1484 "third_party/libpg_query/grammar/statements/select.y"
+#line 1489 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = list_make1(makeIntConst(INTERVAL_MASK(DAY) |
 												 INTERVAL_MASK(HOUR), (yylsp[(1) - (3)])));
@@ -18619,7 +18624,7 @@ yyreduce:
     break;
 
   case 663:
-#line 1489 "third_party/libpg_query/grammar/statements/select.y"
+#line 1494 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = list_make1(makeIntConst(INTERVAL_MASK(DAY) |
 												 INTERVAL_MASK(HOUR) |
@@ -18628,7 +18633,7 @@ yyreduce:
     break;
 
   case 664:
-#line 1495 "third_party/libpg_query/grammar/statements/select.y"
+#line 1500 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = (yyvsp[(3) - (3)].list);
 					linitial((yyval.list)) = makeIntConst(INTERVAL_MASK(DAY) |
@@ -18639,7 +18644,7 @@ yyreduce:
     break;
 
   case 665:
-#line 1503 "third_party/libpg_query/grammar/statements/select.y"
+#line 1508 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = list_make1(makeIntConst(INTERVAL_MASK(HOUR) |
 												 INTERVAL_MASK(MINUTE), (yylsp[(1) - (3)])));
@@ -18647,7 +18652,7 @@ yyreduce:
     break;
 
   case 666:
-#line 1508 "third_party/libpg_query/grammar/statements/select.y"
+#line 1513 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = (yyvsp[(3) - (3)].list);
 					linitial((yyval.list)) = makeIntConst(INTERVAL_MASK(HOUR) |
@@ -18657,7 +18662,7 @@ yyreduce:
     break;
 
   case 667:
-#line 1515 "third_party/libpg_query/grammar/statements/select.y"
+#line 1520 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = (yyvsp[(3) - (3)].list);
 					linitial((yyval.list)) = makeIntConst(INTERVAL_MASK(MINUTE) |
@@ -18666,19 +18671,19 @@ yyreduce:
     break;
 
   case 668:
-#line 1521 "third_party/libpg_query/grammar/statements/select.y"
+#line 1526 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = NIL; ;}
     break;
 
   case 669:
-#line 1526 "third_party/libpg_query/grammar/statements/select.y"
+#line 1531 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = list_make1(makeIntConst(INTERVAL_MASK(SECOND), (yylsp[(1) - (1)])));
 				;}
     break;
 
   case 670:
-#line 1530 "third_party/libpg_query/grammar/statements/select.y"
+#line 1535 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = list_make2(makeIntConst(INTERVAL_MASK(SECOND), (yylsp[(1) - (4)])),
 									makeIntConst((yyvsp[(3) - (4)].ival), (yylsp[(3) - (4)])));
@@ -18686,17 +18691,17 @@ yyreduce:
     break;
 
   case 671:
-#line 1565 "third_party/libpg_query/grammar/statements/select.y"
+#line 1570 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (yyvsp[(1) - (1)].node); ;}
     break;
 
   case 672:
-#line 1567 "third_party/libpg_query/grammar/statements/select.y"
+#line 1572 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = makeTypeCast((yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].typnam), (yylsp[(2) - (3)])); ;}
     break;
 
   case 673:
-#line 1569 "third_party/libpg_query/grammar/statements/select.y"
+#line 1574 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGCollateClause *n = makeNode(PGCollateClause);
 					n->arg = (yyvsp[(1) - (3)].node);
@@ -18707,7 +18712,7 @@ yyreduce:
     break;
 
   case 674:
-#line 1577 "third_party/libpg_query/grammar/statements/select.y"
+#line 1582 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeFuncCall(SystemFuncName("timezone"),
 											   list_make2((yyvsp[(5) - (5)].node), (yyvsp[(1) - (5)].node)),
@@ -18716,112 +18721,112 @@ yyreduce:
     break;
 
   case 675:
-#line 1592 "third_party/libpg_query/grammar/statements/select.y"
+#line 1597 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "+", NULL, (yyvsp[(2) - (2)].node), (yylsp[(1) - (2)])); ;}
     break;
 
   case 676:
-#line 1594 "third_party/libpg_query/grammar/statements/select.y"
+#line 1599 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = doNegate((yyvsp[(2) - (2)].node), (yylsp[(1) - (2)])); ;}
     break;
 
   case 677:
-#line 1596 "third_party/libpg_query/grammar/statements/select.y"
+#line 1601 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "+", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 678:
-#line 1598 "third_party/libpg_query/grammar/statements/select.y"
+#line 1603 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "-", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 679:
-#line 1600 "third_party/libpg_query/grammar/statements/select.y"
+#line 1605 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "*", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 680:
-#line 1602 "third_party/libpg_query/grammar/statements/select.y"
+#line 1607 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "/", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 681:
-#line 1604 "third_party/libpg_query/grammar/statements/select.y"
+#line 1609 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "%", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 682:
-#line 1606 "third_party/libpg_query/grammar/statements/select.y"
+#line 1611 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "^", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 683:
-#line 1608 "third_party/libpg_query/grammar/statements/select.y"
+#line 1613 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "<", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 684:
-#line 1610 "third_party/libpg_query/grammar/statements/select.y"
+#line 1615 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, ">", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 685:
-#line 1612 "third_party/libpg_query/grammar/statements/select.y"
+#line 1617 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "=", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 686:
-#line 1614 "third_party/libpg_query/grammar/statements/select.y"
+#line 1619 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "<=", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 687:
-#line 1616 "third_party/libpg_query/grammar/statements/select.y"
+#line 1621 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, ">=", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 688:
-#line 1618 "third_party/libpg_query/grammar/statements/select.y"
+#line 1623 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "<>", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 689:
-#line 1621 "third_party/libpg_query/grammar/statements/select.y"
+#line 1626 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeAExpr(PG_AEXPR_OP, (yyvsp[(2) - (3)].list), (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 690:
-#line 1623 "third_party/libpg_query/grammar/statements/select.y"
+#line 1628 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeAExpr(PG_AEXPR_OP, (yyvsp[(1) - (2)].list), NULL, (yyvsp[(2) - (2)].node), (yylsp[(1) - (2)])); ;}
     break;
 
   case 691:
-#line 1625 "third_party/libpg_query/grammar/statements/select.y"
+#line 1630 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeAExpr(PG_AEXPR_OP, (yyvsp[(2) - (2)].list), (yyvsp[(1) - (2)].node), NULL, (yylsp[(2) - (2)])); ;}
     break;
 
   case 692:
-#line 1628 "third_party/libpg_query/grammar/statements/select.y"
+#line 1633 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = makeAndExpr((yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 693:
-#line 1630 "third_party/libpg_query/grammar/statements/select.y"
+#line 1635 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = makeOrExpr((yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 694:
-#line 1632 "third_party/libpg_query/grammar/statements/select.y"
+#line 1637 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = makeNotExpr((yyvsp[(2) - (2)].node), (yylsp[(1) - (2)])); ;}
     break;
 
   case 695:
-#line 1634 "third_party/libpg_query/grammar/statements/select.y"
+#line 1639 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = makeNotExpr((yyvsp[(2) - (2)].node), (yylsp[(1) - (2)])); ;}
     break;
 
   case 696:
-#line 1637 "third_party/libpg_query/grammar/statements/select.y"
+#line 1642 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_GLOB, "~~~",
 												   (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)]));
@@ -18829,7 +18834,7 @@ yyreduce:
     break;
 
   case 697:
-#line 1642 "third_party/libpg_query/grammar/statements/select.y"
+#line 1647 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_LIKE, "~~",
 												   (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)]));
@@ -18837,7 +18842,7 @@ yyreduce:
     break;
 
   case 698:
-#line 1647 "third_party/libpg_query/grammar/statements/select.y"
+#line 1652 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGFuncCall *n = makeFuncCall(SystemFuncName("like_escape"),
 											   list_make3((yyvsp[(1) - (5)].node), (yyvsp[(3) - (5)].node), (yyvsp[(5) - (5)].node)),
@@ -18847,7 +18852,7 @@ yyreduce:
     break;
 
   case 699:
-#line 1654 "third_party/libpg_query/grammar/statements/select.y"
+#line 1659 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_LIKE, "!~~",
 												   (yyvsp[(1) - (4)].node), (yyvsp[(4) - (4)].node), (yylsp[(2) - (4)]));
@@ -18855,7 +18860,7 @@ yyreduce:
     break;
 
   case 700:
-#line 1659 "third_party/libpg_query/grammar/statements/select.y"
+#line 1664 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGFuncCall *n = makeFuncCall(SystemFuncName("not_like_escape"),
 											   list_make3((yyvsp[(1) - (6)].node), (yyvsp[(4) - (6)].node), (yyvsp[(6) - (6)].node)),
@@ -18865,7 +18870,7 @@ yyreduce:
     break;
 
   case 701:
-#line 1666 "third_party/libpg_query/grammar/statements/select.y"
+#line 1671 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_ILIKE, "~~*",
 												   (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)]));
@@ -18873,7 +18878,7 @@ yyreduce:
     break;
 
   case 702:
-#line 1671 "third_party/libpg_query/grammar/statements/select.y"
+#line 1676 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGFuncCall *n = makeFuncCall(SystemFuncName("like_escape"),
 											   list_make2((yyvsp[(3) - (5)].node), (yyvsp[(5) - (5)].node)),
@@ -18884,7 +18889,7 @@ yyreduce:
     break;
 
   case 703:
-#line 1679 "third_party/libpg_query/grammar/statements/select.y"
+#line 1684 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_ILIKE, "!~~*",
 												   (yyvsp[(1) - (4)].node), (yyvsp[(4) - (4)].node), (yylsp[(2) - (4)]));
@@ -18892,7 +18897,7 @@ yyreduce:
     break;
 
   case 704:
-#line 1684 "third_party/libpg_query/grammar/statements/select.y"
+#line 1689 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGFuncCall *n = makeFuncCall(SystemFuncName("not_like_escape"),
 											   list_make2((yyvsp[(4) - (6)].node), (yyvsp[(6) - (6)].node)),
@@ -18903,7 +18908,7 @@ yyreduce:
     break;
 
   case 705:
-#line 1693 "third_party/libpg_query/grammar/statements/select.y"
+#line 1698 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGFuncCall *n = makeFuncCall(SystemFuncName("similar_escape"),
 											   list_make2((yyvsp[(4) - (4)].node), makeNullAConst(-1)),
@@ -18914,7 +18919,7 @@ yyreduce:
     break;
 
   case 706:
-#line 1701 "third_party/libpg_query/grammar/statements/select.y"
+#line 1706 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGFuncCall *n = makeFuncCall(SystemFuncName("similar_escape"),
 											   list_make2((yyvsp[(4) - (6)].node), (yyvsp[(6) - (6)].node)),
@@ -18925,7 +18930,7 @@ yyreduce:
     break;
 
   case 707:
-#line 1709 "third_party/libpg_query/grammar/statements/select.y"
+#line 1714 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGFuncCall *n = makeFuncCall(SystemFuncName("similar_escape"),
 											   list_make2((yyvsp[(5) - (5)].node), makeNullAConst(-1)),
@@ -18936,7 +18941,7 @@ yyreduce:
     break;
 
   case 708:
-#line 1717 "third_party/libpg_query/grammar/statements/select.y"
+#line 1722 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGFuncCall *n = makeFuncCall(SystemFuncName("similar_escape"),
 											   list_make2((yyvsp[(5) - (7)].node), (yyvsp[(7) - (7)].node)),
@@ -18947,7 +18952,7 @@ yyreduce:
     break;
 
   case 709:
-#line 1735 "third_party/libpg_query/grammar/statements/select.y"
+#line 1740 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGNullTest *n = makeNode(PGNullTest);
 					n->arg = (PGExpr *) (yyvsp[(1) - (3)].node);
@@ -18958,7 +18963,7 @@ yyreduce:
     break;
 
   case 710:
-#line 1743 "third_party/libpg_query/grammar/statements/select.y"
+#line 1748 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGNullTest *n = makeNode(PGNullTest);
 					n->arg = (PGExpr *) (yyvsp[(1) - (2)].node);
@@ -18969,7 +18974,7 @@ yyreduce:
     break;
 
   case 711:
-#line 1751 "third_party/libpg_query/grammar/statements/select.y"
+#line 1756 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGNullTest *n = makeNode(PGNullTest);
 					n->arg = (PGExpr *) (yyvsp[(1) - (4)].node);
@@ -18980,7 +18985,7 @@ yyreduce:
     break;
 
   case 712:
-#line 1759 "third_party/libpg_query/grammar/statements/select.y"
+#line 1764 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGNullTest *n = makeNode(PGNullTest);
 					n->arg = (PGExpr *) (yyvsp[(1) - (3)].node);
@@ -18991,7 +18996,7 @@ yyreduce:
     break;
 
   case 713:
-#line 1767 "third_party/libpg_query/grammar/statements/select.y"
+#line 1772 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGNullTest *n = makeNode(PGNullTest);
 					n->arg = (PGExpr *) (yyvsp[(1) - (2)].node);
@@ -19002,7 +19007,7 @@ yyreduce:
     break;
 
   case 714:
-#line 1775 "third_party/libpg_query/grammar/statements/select.y"
+#line 1780 "third_party/libpg_query/grammar/statements/select.y"
     {
 					if (list_length((yyvsp[(1) - (3)].list)) != 2)
 						ereport(ERROR,
@@ -19021,7 +19026,7 @@ yyreduce:
     break;
 
   case 715:
-#line 1791 "third_party/libpg_query/grammar/statements/select.y"
+#line 1796 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGBooleanTest *b = makeNode(PGBooleanTest);
 					b->arg = (PGExpr *) (yyvsp[(1) - (3)].node);
@@ -19032,7 +19037,7 @@ yyreduce:
     break;
 
   case 716:
-#line 1799 "third_party/libpg_query/grammar/statements/select.y"
+#line 1804 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGBooleanTest *b = makeNode(PGBooleanTest);
 					b->arg = (PGExpr *) (yyvsp[(1) - (4)].node);
@@ -19043,7 +19048,7 @@ yyreduce:
     break;
 
   case 717:
-#line 1807 "third_party/libpg_query/grammar/statements/select.y"
+#line 1812 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGBooleanTest *b = makeNode(PGBooleanTest);
 					b->arg = (PGExpr *) (yyvsp[(1) - (3)].node);
@@ -19054,7 +19059,7 @@ yyreduce:
     break;
 
   case 718:
-#line 1815 "third_party/libpg_query/grammar/statements/select.y"
+#line 1820 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGBooleanTest *b = makeNode(PGBooleanTest);
 					b->arg = (PGExpr *) (yyvsp[(1) - (4)].node);
@@ -19065,7 +19070,7 @@ yyreduce:
     break;
 
   case 719:
-#line 1823 "third_party/libpg_query/grammar/statements/select.y"
+#line 1828 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGBooleanTest *b = makeNode(PGBooleanTest);
 					b->arg = (PGExpr *) (yyvsp[(1) - (3)].node);
@@ -19076,7 +19081,7 @@ yyreduce:
     break;
 
   case 720:
-#line 1831 "third_party/libpg_query/grammar/statements/select.y"
+#line 1836 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGBooleanTest *b = makeNode(PGBooleanTest);
 					b->arg = (PGExpr *) (yyvsp[(1) - (4)].node);
@@ -19087,35 +19092,35 @@ yyreduce:
     break;
 
   case 721:
-#line 1839 "third_party/libpg_query/grammar/statements/select.y"
+#line 1844 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_DISTINCT, "=", (yyvsp[(1) - (5)].node), (yyvsp[(5) - (5)].node), (yylsp[(2) - (5)]));
 				;}
     break;
 
   case 722:
-#line 1843 "third_party/libpg_query/grammar/statements/select.y"
+#line 1848 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_NOT_DISTINCT, "=", (yyvsp[(1) - (6)].node), (yyvsp[(6) - (6)].node), (yylsp[(2) - (6)]));
 				;}
     break;
 
   case 723:
-#line 1847 "third_party/libpg_query/grammar/statements/select.y"
+#line 1852 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OF, "=", (yyvsp[(1) - (6)].node), (PGNode *) (yyvsp[(5) - (6)].list), (yylsp[(2) - (6)]));
 				;}
     break;
 
   case 724:
-#line 1851 "third_party/libpg_query/grammar/statements/select.y"
+#line 1856 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OF, "<>", (yyvsp[(1) - (7)].node), (PGNode *) (yyvsp[(6) - (7)].list), (yylsp[(2) - (7)]));
 				;}
     break;
 
   case 725:
-#line 1855 "third_party/libpg_query/grammar/statements/select.y"
+#line 1860 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_BETWEEN,
 												   "BETWEEN",
@@ -19126,7 +19131,7 @@ yyreduce:
     break;
 
   case 726:
-#line 1863 "third_party/libpg_query/grammar/statements/select.y"
+#line 1868 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_NOT_BETWEEN,
 												   "NOT BETWEEN",
@@ -19137,7 +19142,7 @@ yyreduce:
     break;
 
   case 727:
-#line 1871 "third_party/libpg_query/grammar/statements/select.y"
+#line 1876 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_BETWEEN_SYM,
 												   "BETWEEN SYMMETRIC",
@@ -19148,7 +19153,7 @@ yyreduce:
     break;
 
   case 728:
-#line 1879 "third_party/libpg_query/grammar/statements/select.y"
+#line 1884 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_NOT_BETWEEN_SYM,
 												   "NOT BETWEEN SYMMETRIC",
@@ -19159,7 +19164,7 @@ yyreduce:
     break;
 
   case 729:
-#line 1887 "third_party/libpg_query/grammar/statements/select.y"
+#line 1892 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/* in_expr returns a PGSubLink or a list of a_exprs */
 					if (IsA((yyvsp[(3) - (3)].node), PGSubLink))
@@ -19182,7 +19187,7 @@ yyreduce:
     break;
 
   case 730:
-#line 1907 "third_party/libpg_query/grammar/statements/select.y"
+#line 1912 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/* in_expr returns a PGSubLink or a list of a_exprs */
 					if (IsA((yyvsp[(4) - (4)].node), PGSubLink))
@@ -19207,7 +19212,7 @@ yyreduce:
     break;
 
   case 731:
-#line 1929 "third_party/libpg_query/grammar/statements/select.y"
+#line 1934 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGSubLink *n = makeNode(PGSubLink);
 					n->subLinkType = (yyvsp[(3) - (4)].subquerytype);
@@ -19221,7 +19226,7 @@ yyreduce:
     break;
 
   case 732:
-#line 1940 "third_party/libpg_query/grammar/statements/select.y"
+#line 1945 "third_party/libpg_query/grammar/statements/select.y"
     {
 					if ((yyvsp[(3) - (6)].subquerytype) == PG_ANY_SUBLINK)
 						(yyval.node) = (PGNode *) makeAExpr(PG_AEXPR_OP_ANY, (yyvsp[(2) - (6)].list), (yyvsp[(1) - (6)].node), (yyvsp[(5) - (6)].node), (yylsp[(2) - (6)]));
@@ -19231,7 +19236,7 @@ yyreduce:
     break;
 
   case 733:
-#line 1947 "third_party/libpg_query/grammar/statements/select.y"
+#line 1952 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/*
 					 * The SQL spec only allows DEFAULT in "contextually typed
@@ -19248,140 +19253,140 @@ yyreduce:
     break;
 
   case 734:
-#line 1972 "third_party/libpg_query/grammar/statements/select.y"
+#line 1977 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (yyvsp[(1) - (1)].node); ;}
     break;
 
   case 735:
-#line 1974 "third_party/libpg_query/grammar/statements/select.y"
+#line 1979 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = makeTypeCast((yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].typnam), (yylsp[(2) - (3)])); ;}
     break;
 
   case 736:
-#line 1976 "third_party/libpg_query/grammar/statements/select.y"
+#line 1981 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "+", NULL, (yyvsp[(2) - (2)].node), (yylsp[(1) - (2)])); ;}
     break;
 
   case 737:
-#line 1978 "third_party/libpg_query/grammar/statements/select.y"
+#line 1983 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = doNegate((yyvsp[(2) - (2)].node), (yylsp[(1) - (2)])); ;}
     break;
 
   case 738:
-#line 1980 "third_party/libpg_query/grammar/statements/select.y"
+#line 1985 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "+", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 739:
-#line 1982 "third_party/libpg_query/grammar/statements/select.y"
+#line 1987 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "-", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 740:
-#line 1984 "third_party/libpg_query/grammar/statements/select.y"
+#line 1989 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "*", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 741:
-#line 1986 "third_party/libpg_query/grammar/statements/select.y"
+#line 1991 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "/", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 742:
-#line 1988 "third_party/libpg_query/grammar/statements/select.y"
+#line 1993 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "%", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 743:
-#line 1990 "third_party/libpg_query/grammar/statements/select.y"
+#line 1995 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "^", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 744:
-#line 1992 "third_party/libpg_query/grammar/statements/select.y"
+#line 1997 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "<", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 745:
-#line 1994 "third_party/libpg_query/grammar/statements/select.y"
+#line 1999 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, ">", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 746:
-#line 1996 "third_party/libpg_query/grammar/statements/select.y"
+#line 2001 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "=", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 747:
-#line 1998 "third_party/libpg_query/grammar/statements/select.y"
+#line 2003 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "<=", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 748:
-#line 2000 "third_party/libpg_query/grammar/statements/select.y"
+#line 2005 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, ">=", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 749:
-#line 2002 "third_party/libpg_query/grammar/statements/select.y"
+#line 2007 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OP, "<>", (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 750:
-#line 2004 "third_party/libpg_query/grammar/statements/select.y"
+#line 2009 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeAExpr(PG_AEXPR_OP, (yyvsp[(2) - (3)].list), (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yylsp[(2) - (3)])); ;}
     break;
 
   case 751:
-#line 2006 "third_party/libpg_query/grammar/statements/select.y"
+#line 2011 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeAExpr(PG_AEXPR_OP, (yyvsp[(1) - (2)].list), NULL, (yyvsp[(2) - (2)].node), (yylsp[(1) - (2)])); ;}
     break;
 
   case 752:
-#line 2008 "third_party/libpg_query/grammar/statements/select.y"
+#line 2013 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *) makeAExpr(PG_AEXPR_OP, (yyvsp[(2) - (2)].list), (yyvsp[(1) - (2)].node), NULL, (yylsp[(2) - (2)])); ;}
     break;
 
   case 753:
-#line 2010 "third_party/libpg_query/grammar/statements/select.y"
+#line 2015 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_DISTINCT, "=", (yyvsp[(1) - (5)].node), (yyvsp[(5) - (5)].node), (yylsp[(2) - (5)]));
 				;}
     break;
 
   case 754:
-#line 2014 "third_party/libpg_query/grammar/statements/select.y"
+#line 2019 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_NOT_DISTINCT, "=", (yyvsp[(1) - (6)].node), (yyvsp[(6) - (6)].node), (yylsp[(2) - (6)]));
 				;}
     break;
 
   case 755:
-#line 2018 "third_party/libpg_query/grammar/statements/select.y"
+#line 2023 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OF, "=", (yyvsp[(1) - (6)].node), (PGNode *) (yyvsp[(5) - (6)].list), (yylsp[(2) - (6)]));
 				;}
     break;
 
   case 756:
-#line 2022 "third_party/libpg_query/grammar/statements/select.y"
+#line 2027 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_OF, "<>", (yyvsp[(1) - (7)].node), (PGNode *) (yyvsp[(6) - (7)].list), (yylsp[(2) - (7)]));
 				;}
     break;
 
   case 757:
-#line 2035 "third_party/libpg_query/grammar/statements/select.y"
+#line 2040 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (yyvsp[(1) - (1)].node); ;}
     break;
 
   case 758:
-#line 2036 "third_party/libpg_query/grammar/statements/select.y"
+#line 2041 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (yyvsp[(1) - (1)].node); ;}
     break;
 
   case 759:
-#line 2038 "third_party/libpg_query/grammar/statements/select.y"
+#line 2043 "third_party/libpg_query/grammar/statements/select.y"
     {
 					if ((yyvsp[(2) - (2)].list))
 					{
@@ -19396,7 +19401,7 @@ yyreduce:
     break;
 
   case 760:
-#line 2050 "third_party/libpg_query/grammar/statements/select.y"
+#line 2055 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGParamRef *p = makeNode(PGParamRef);
 					p->number = (yyvsp[(1) - (2)].ival);
@@ -19414,7 +19419,7 @@ yyreduce:
     break;
 
   case 761:
-#line 2065 "third_party/libpg_query/grammar/statements/select.y"
+#line 2070 "third_party/libpg_query/grammar/statements/select.y"
     {
 					if ((yyvsp[(4) - (4)].list))
 					{
@@ -19429,17 +19434,17 @@ yyreduce:
     break;
 
   case 762:
-#line 2077 "third_party/libpg_query/grammar/statements/select.y"
+#line 2082 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (yyvsp[(1) - (1)].node); ;}
     break;
 
   case 763:
-#line 2079 "third_party/libpg_query/grammar/statements/select.y"
+#line 2084 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (yyvsp[(1) - (1)].node); ;}
     break;
 
   case 764:
-#line 2081 "third_party/libpg_query/grammar/statements/select.y"
+#line 2086 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGSubLink *n = makeNode(PGSubLink);
 					n->subLinkType = PG_EXPR_SUBLINK;
@@ -19453,7 +19458,7 @@ yyreduce:
     break;
 
   case 765:
-#line 2092 "third_party/libpg_query/grammar/statements/select.y"
+#line 2097 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/*
 					 * Because the select_with_parens nonterminal is designed
@@ -19480,7 +19485,7 @@ yyreduce:
     break;
 
   case 766:
-#line 2116 "third_party/libpg_query/grammar/statements/select.y"
+#line 2121 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGSubLink *n = makeNode(PGSubLink);
 					n->subLinkType = PG_EXISTS_SUBLINK;
@@ -19494,14 +19499,14 @@ yyreduce:
     break;
 
   case 767:
-#line 2129 "third_party/libpg_query/grammar/statements/select.y"
+#line 2134 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeFuncCall((yyvsp[(1) - (3)].list), NIL, (yylsp[(1) - (3)]));
 				;}
     break;
 
   case 768:
-#line 2133 "third_party/libpg_query/grammar/statements/select.y"
+#line 2138 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGFuncCall *n = makeFuncCall((yyvsp[(1) - (5)].list), (yyvsp[(3) - (5)].list), (yylsp[(1) - (5)]));
 					n->agg_order = (yyvsp[(4) - (5)].list);
@@ -19510,7 +19515,7 @@ yyreduce:
     break;
 
   case 769:
-#line 2139 "third_party/libpg_query/grammar/statements/select.y"
+#line 2144 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGFuncCall *n = makeFuncCall((yyvsp[(1) - (6)].list), list_make1((yyvsp[(4) - (6)].node)), (yylsp[(1) - (6)]));
 					n->func_variadic = true;
@@ -19520,7 +19525,7 @@ yyreduce:
     break;
 
   case 770:
-#line 2146 "third_party/libpg_query/grammar/statements/select.y"
+#line 2151 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGFuncCall *n = makeFuncCall((yyvsp[(1) - (8)].list), lappend((yyvsp[(3) - (8)].list), (yyvsp[(6) - (8)].node)), (yylsp[(1) - (8)]));
 					n->func_variadic = true;
@@ -19530,7 +19535,7 @@ yyreduce:
     break;
 
   case 771:
-#line 2153 "third_party/libpg_query/grammar/statements/select.y"
+#line 2158 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGFuncCall *n = makeFuncCall((yyvsp[(1) - (6)].list), (yyvsp[(4) - (6)].list), (yylsp[(1) - (6)]));
 					n->agg_order = (yyvsp[(5) - (6)].list);
@@ -19543,7 +19548,7 @@ yyreduce:
     break;
 
   case 772:
-#line 2163 "third_party/libpg_query/grammar/statements/select.y"
+#line 2168 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGFuncCall *n = makeFuncCall((yyvsp[(1) - (6)].list), (yyvsp[(4) - (6)].list), (yylsp[(1) - (6)]));
 					n->agg_order = (yyvsp[(5) - (6)].list);
@@ -19553,7 +19558,7 @@ yyreduce:
     break;
 
   case 773:
-#line 2170 "third_party/libpg_query/grammar/statements/select.y"
+#line 2175 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/*
 					 * We consider AGGREGATE(*) to invoke a parameterless
@@ -19572,7 +19577,7 @@ yyreduce:
     break;
 
   case 774:
-#line 2198 "third_party/libpg_query/grammar/statements/select.y"
+#line 2203 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGFuncCall *n = (PGFuncCall *) (yyvsp[(1) - (4)].node);
 					/*
@@ -19610,22 +19615,22 @@ yyreduce:
     break;
 
   case 775:
-#line 2233 "third_party/libpg_query/grammar/statements/select.y"
+#line 2238 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (yyvsp[(1) - (1)].node); ;}
     break;
 
   case 776:
-#line 2243 "third_party/libpg_query/grammar/statements/select.y"
+#line 2248 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (yyvsp[(1) - (1)].node); ;}
     break;
 
   case 777:
-#line 2244 "third_party/libpg_query/grammar/statements/select.y"
+#line 2249 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (yyvsp[(1) - (1)].node); ;}
     break;
 
   case 778:
-#line 2252 "third_party/libpg_query/grammar/statements/select.y"
+#line 2257 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeFuncCall(SystemFuncName("pg_collation_for"),
 											   list_make1((yyvsp[(4) - (5)].node)),
@@ -19634,124 +19639,124 @@ yyreduce:
     break;
 
   case 779:
-#line 2258 "third_party/libpg_query/grammar/statements/select.y"
+#line 2263 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeSQLValueFunction(PG_SVFOP_CURRENT_DATE, -1, (yylsp[(1) - (1)]));
 				;}
     break;
 
   case 780:
-#line 2262 "third_party/libpg_query/grammar/statements/select.y"
+#line 2267 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeSQLValueFunction(PG_SVFOP_CURRENT_TIME, -1, (yylsp[(1) - (1)]));
 				;}
     break;
 
   case 781:
-#line 2266 "third_party/libpg_query/grammar/statements/select.y"
+#line 2271 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeSQLValueFunction(PG_SVFOP_CURRENT_TIME_N, (yyvsp[(3) - (4)].ival), (yylsp[(1) - (4)]));
 				;}
     break;
 
   case 782:
-#line 2270 "third_party/libpg_query/grammar/statements/select.y"
+#line 2275 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeSQLValueFunction(PG_SVFOP_CURRENT_TIMESTAMP, -1, (yylsp[(1) - (1)]));
 				;}
     break;
 
   case 783:
-#line 2274 "third_party/libpg_query/grammar/statements/select.y"
+#line 2279 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeSQLValueFunction(PG_SVFOP_CURRENT_TIMESTAMP_N, (yyvsp[(3) - (4)].ival), (yylsp[(1) - (4)]));
 				;}
     break;
 
   case 784:
-#line 2278 "third_party/libpg_query/grammar/statements/select.y"
+#line 2283 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeSQLValueFunction(PG_SVFOP_LOCALTIME, -1, (yylsp[(1) - (1)]));
 				;}
     break;
 
   case 785:
-#line 2282 "third_party/libpg_query/grammar/statements/select.y"
+#line 2287 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeSQLValueFunction(PG_SVFOP_LOCALTIME_N, (yyvsp[(3) - (4)].ival), (yylsp[(1) - (4)]));
 				;}
     break;
 
   case 786:
-#line 2286 "third_party/libpg_query/grammar/statements/select.y"
+#line 2291 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeSQLValueFunction(PG_SVFOP_LOCALTIMESTAMP, -1, (yylsp[(1) - (1)]));
 				;}
     break;
 
   case 787:
-#line 2290 "third_party/libpg_query/grammar/statements/select.y"
+#line 2295 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeSQLValueFunction(PG_SVFOP_LOCALTIMESTAMP_N, (yyvsp[(3) - (4)].ival), (yylsp[(1) - (4)]));
 				;}
     break;
 
   case 788:
-#line 2294 "third_party/libpg_query/grammar/statements/select.y"
+#line 2299 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeSQLValueFunction(PG_SVFOP_CURRENT_ROLE, -1, (yylsp[(1) - (1)]));
 				;}
     break;
 
   case 789:
-#line 2298 "third_party/libpg_query/grammar/statements/select.y"
+#line 2303 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeSQLValueFunction(PG_SVFOP_CURRENT_USER, -1, (yylsp[(1) - (1)]));
 				;}
     break;
 
   case 790:
-#line 2302 "third_party/libpg_query/grammar/statements/select.y"
+#line 2307 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeSQLValueFunction(PG_SVFOP_SESSION_USER, -1, (yylsp[(1) - (1)]));
 				;}
     break;
 
   case 791:
-#line 2306 "third_party/libpg_query/grammar/statements/select.y"
+#line 2311 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeSQLValueFunction(PG_SVFOP_USER, -1, (yylsp[(1) - (1)]));
 				;}
     break;
 
   case 792:
-#line 2310 "third_party/libpg_query/grammar/statements/select.y"
+#line 2315 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeSQLValueFunction(PG_SVFOP_CURRENT_CATALOG, -1, (yylsp[(1) - (1)]));
 				;}
     break;
 
   case 793:
-#line 2314 "third_party/libpg_query/grammar/statements/select.y"
+#line 2319 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeSQLValueFunction(PG_SVFOP_CURRENT_SCHEMA, -1, (yylsp[(1) - (1)]));
 				;}
     break;
 
   case 794:
-#line 2318 "third_party/libpg_query/grammar/statements/select.y"
+#line 2323 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = makeTypeCast((yyvsp[(3) - (6)].node), (yyvsp[(5) - (6)].typnam), (yylsp[(1) - (6)])); ;}
     break;
 
   case 795:
-#line 2320 "third_party/libpg_query/grammar/statements/select.y"
+#line 2325 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeFuncCall(SystemFuncName("date_part"), (yyvsp[(3) - (4)].list), (yylsp[(1) - (4)]));
 				;}
     break;
 
   case 796:
-#line 2324 "third_party/libpg_query/grammar/statements/select.y"
+#line 2329 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/* overlay(A PLACING B FROM C FOR D) is converted to
 					 * overlay(A, B, C, D)
@@ -19763,7 +19768,7 @@ yyreduce:
     break;
 
   case 797:
-#line 2333 "third_party/libpg_query/grammar/statements/select.y"
+#line 2338 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/* position(A in B) is converted to position(B, A) */
 					(yyval.node) = (PGNode *) makeFuncCall(SystemFuncName("position"), (yyvsp[(3) - (4)].list), (yylsp[(1) - (4)]));
@@ -19771,7 +19776,7 @@ yyreduce:
     break;
 
   case 798:
-#line 2338 "third_party/libpg_query/grammar/statements/select.y"
+#line 2343 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/* substring(A from B for C) is converted to
 					 * substring(A, B, C) - thomas 2000-11-28
@@ -19781,7 +19786,7 @@ yyreduce:
     break;
 
   case 799:
-#line 2345 "third_party/libpg_query/grammar/statements/select.y"
+#line 2350 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/* TREAT(expr AS target) converts expr of a particular type to target,
 					 * which is defined to be a subtype of the original expression.
@@ -19799,7 +19804,7 @@ yyreduce:
     break;
 
   case 800:
-#line 2360 "third_party/libpg_query/grammar/statements/select.y"
+#line 2365 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/* various trim expressions are defined in SQL
 					 * - thomas 1997-07-19
@@ -19809,35 +19814,35 @@ yyreduce:
     break;
 
   case 801:
-#line 2367 "third_party/libpg_query/grammar/statements/select.y"
+#line 2372 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeFuncCall(SystemFuncName("ltrim"), (yyvsp[(4) - (5)].list), (yylsp[(1) - (5)]));
 				;}
     break;
 
   case 802:
-#line 2371 "third_party/libpg_query/grammar/statements/select.y"
+#line 2376 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeFuncCall(SystemFuncName("rtrim"), (yyvsp[(4) - (5)].list), (yylsp[(1) - (5)]));
 				;}
     break;
 
   case 803:
-#line 2375 "third_party/libpg_query/grammar/statements/select.y"
+#line 2380 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeFuncCall(SystemFuncName("trim"), (yyvsp[(3) - (4)].list), (yylsp[(1) - (4)]));
 				;}
     break;
 
   case 804:
-#line 2379 "third_party/libpg_query/grammar/statements/select.y"
+#line 2384 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeSimpleAExpr(PG_AEXPR_NULLIF, "=", (yyvsp[(3) - (6)].node), (yyvsp[(5) - (6)].node), (yylsp[(1) - (6)]));
 				;}
     break;
 
   case 805:
-#line 2383 "third_party/libpg_query/grammar/statements/select.y"
+#line 2388 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGCoalesceExpr *c = makeNode(PGCoalesceExpr);
 					c->args = (yyvsp[(3) - (4)].list);
@@ -19847,47 +19852,47 @@ yyreduce:
     break;
 
   case 806:
-#line 2396 "third_party/libpg_query/grammar/statements/select.y"
+#line 2401 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = (yyvsp[(4) - (5)].list); ;}
     break;
 
   case 807:
-#line 2397 "third_party/libpg_query/grammar/statements/select.y"
+#line 2402 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = NIL; ;}
     break;
 
   case 808:
-#line 2401 "third_party/libpg_query/grammar/statements/select.y"
+#line 2406 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (yyvsp[(4) - (5)].node); ;}
     break;
 
   case 809:
-#line 2402 "third_party/libpg_query/grammar/statements/select.y"
+#line 2407 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = NULL; ;}
     break;
 
   case 810:
-#line 2410 "third_party/libpg_query/grammar/statements/select.y"
+#line 2415 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = (yyvsp[(2) - (2)].list); ;}
     break;
 
   case 811:
-#line 2411 "third_party/libpg_query/grammar/statements/select.y"
+#line 2416 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = NIL; ;}
     break;
 
   case 812:
-#line 2415 "third_party/libpg_query/grammar/statements/select.y"
+#line 2420 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1((yyvsp[(1) - (1)].windef)); ;}
     break;
 
   case 813:
-#line 2417 "third_party/libpg_query/grammar/statements/select.y"
+#line 2422 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = lappend((yyvsp[(1) - (3)].list), (yyvsp[(3) - (3)].windef)); ;}
     break;
 
   case 814:
-#line 2422 "third_party/libpg_query/grammar/statements/select.y"
+#line 2427 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGWindowDef *n = (yyvsp[(3) - (3)].windef);
 					n->name = (yyvsp[(1) - (3)].str);
@@ -19896,12 +19901,12 @@ yyreduce:
     break;
 
   case 815:
-#line 2430 "third_party/libpg_query/grammar/statements/select.y"
+#line 2435 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.windef) = (yyvsp[(2) - (2)].windef); ;}
     break;
 
   case 816:
-#line 2432 "third_party/libpg_query/grammar/statements/select.y"
+#line 2437 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGWindowDef *n = makeNode(PGWindowDef);
 					n->name = (yyvsp[(2) - (2)].str);
@@ -19917,12 +19922,12 @@ yyreduce:
     break;
 
   case 817:
-#line 2445 "third_party/libpg_query/grammar/statements/select.y"
+#line 2450 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.windef) = NULL; ;}
     break;
 
   case 818:
-#line 2450 "third_party/libpg_query/grammar/statements/select.y"
+#line 2455 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGWindowDef *n = makeNode(PGWindowDef);
 					n->name = NULL;
@@ -19939,27 +19944,27 @@ yyreduce:
     break;
 
   case 819:
-#line 2475 "third_party/libpg_query/grammar/statements/select.y"
+#line 2480 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = (yyvsp[(1) - (1)].str); ;}
     break;
 
   case 820:
-#line 2476 "third_party/libpg_query/grammar/statements/select.y"
+#line 2481 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = NULL; ;}
     break;
 
   case 821:
-#line 2479 "third_party/libpg_query/grammar/statements/select.y"
+#line 2484 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = (yyvsp[(3) - (3)].list); ;}
     break;
 
   case 822:
-#line 2480 "third_party/libpg_query/grammar/statements/select.y"
+#line 2485 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = NIL; ;}
     break;
 
   case 823:
-#line 2492 "third_party/libpg_query/grammar/statements/select.y"
+#line 2497 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGWindowDef *n = (yyvsp[(2) - (2)].windef);
 					n->frameOptions |= FRAMEOPTION_NONDEFAULT | FRAMEOPTION_RANGE;
@@ -19980,7 +19985,7 @@ yyreduce:
     break;
 
   case 824:
-#line 2510 "third_party/libpg_query/grammar/statements/select.y"
+#line 2515 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGWindowDef *n = (yyvsp[(2) - (2)].windef);
 					n->frameOptions |= FRAMEOPTION_NONDEFAULT | FRAMEOPTION_ROWS;
@@ -19989,7 +19994,7 @@ yyreduce:
     break;
 
   case 825:
-#line 2516 "third_party/libpg_query/grammar/statements/select.y"
+#line 2521 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGWindowDef *n = makeNode(PGWindowDef);
 					n->frameOptions = FRAMEOPTION_DEFAULTS;
@@ -20000,7 +20005,7 @@ yyreduce:
     break;
 
   case 826:
-#line 2526 "third_party/libpg_query/grammar/statements/select.y"
+#line 2531 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGWindowDef *n = (yyvsp[(1) - (1)].windef);
 					/* reject invalid cases */
@@ -20020,7 +20025,7 @@ yyreduce:
     break;
 
   case 827:
-#line 2543 "third_party/libpg_query/grammar/statements/select.y"
+#line 2548 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGWindowDef *n1 = (yyvsp[(2) - (4)].windef);
 					PGWindowDef *n2 = (yyvsp[(4) - (4)].windef);
@@ -20060,7 +20065,7 @@ yyreduce:
     break;
 
   case 828:
-#line 2588 "third_party/libpg_query/grammar/statements/select.y"
+#line 2593 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGWindowDef *n = makeNode(PGWindowDef);
 					n->frameOptions = FRAMEOPTION_START_UNBOUNDED_PRECEDING;
@@ -20071,7 +20076,7 @@ yyreduce:
     break;
 
   case 829:
-#line 2596 "third_party/libpg_query/grammar/statements/select.y"
+#line 2601 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGWindowDef *n = makeNode(PGWindowDef);
 					n->frameOptions = FRAMEOPTION_START_UNBOUNDED_FOLLOWING;
@@ -20082,7 +20087,7 @@ yyreduce:
     break;
 
   case 830:
-#line 2604 "third_party/libpg_query/grammar/statements/select.y"
+#line 2609 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGWindowDef *n = makeNode(PGWindowDef);
 					n->frameOptions = FRAMEOPTION_START_CURRENT_ROW;
@@ -20093,7 +20098,7 @@ yyreduce:
     break;
 
   case 831:
-#line 2612 "third_party/libpg_query/grammar/statements/select.y"
+#line 2617 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGWindowDef *n = makeNode(PGWindowDef);
 					n->frameOptions = FRAMEOPTION_START_VALUE_PRECEDING;
@@ -20104,7 +20109,7 @@ yyreduce:
     break;
 
   case 832:
-#line 2620 "third_party/libpg_query/grammar/statements/select.y"
+#line 2625 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGWindowDef *n = makeNode(PGWindowDef);
 					n->frameOptions = FRAMEOPTION_START_VALUE_FOLLOWING;
@@ -20115,212 +20120,212 @@ yyreduce:
     break;
 
   case 833:
-#line 2640 "third_party/libpg_query/grammar/statements/select.y"
+#line 2645 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = (yyvsp[(3) - (4)].list); ;}
     break;
 
   case 834:
-#line 2641 "third_party/libpg_query/grammar/statements/select.y"
+#line 2646 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = NIL; ;}
     break;
 
   case 835:
-#line 2642 "third_party/libpg_query/grammar/statements/select.y"
+#line 2647 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = lappend((yyvsp[(2) - (5)].list), (yyvsp[(4) - (5)].node)); ;}
     break;
 
   case 836:
-#line 2645 "third_party/libpg_query/grammar/statements/select.y"
+#line 2650 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.subquerytype) = PG_ANY_SUBLINK; ;}
     break;
 
   case 837:
-#line 2646 "third_party/libpg_query/grammar/statements/select.y"
+#line 2651 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.subquerytype) = PG_ANY_SUBLINK; ;}
     break;
 
   case 838:
-#line 2647 "third_party/libpg_query/grammar/statements/select.y"
+#line 2652 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.subquerytype) = PG_ALL_SUBLINK; ;}
     break;
 
   case 839:
-#line 2650 "third_party/libpg_query/grammar/statements/select.y"
+#line 2655 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = (yyvsp[(1) - (1)].str); ;}
     break;
 
   case 840:
-#line 2651 "third_party/libpg_query/grammar/statements/select.y"
+#line 2656 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = (char*) (yyvsp[(1) - (1)].conststr); ;}
     break;
 
   case 841:
-#line 2654 "third_party/libpg_query/grammar/statements/select.y"
+#line 2659 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.conststr) = "+"; ;}
     break;
 
   case 842:
-#line 2655 "third_party/libpg_query/grammar/statements/select.y"
+#line 2660 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.conststr) = "-"; ;}
     break;
 
   case 843:
-#line 2656 "third_party/libpg_query/grammar/statements/select.y"
+#line 2661 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.conststr) = "*"; ;}
     break;
 
   case 844:
-#line 2657 "third_party/libpg_query/grammar/statements/select.y"
+#line 2662 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.conststr) = "/"; ;}
     break;
 
   case 845:
-#line 2658 "third_party/libpg_query/grammar/statements/select.y"
+#line 2663 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.conststr) = "%"; ;}
     break;
 
   case 846:
-#line 2659 "third_party/libpg_query/grammar/statements/select.y"
+#line 2664 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.conststr) = "^"; ;}
     break;
 
   case 847:
-#line 2660 "third_party/libpg_query/grammar/statements/select.y"
+#line 2665 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.conststr) = "<"; ;}
     break;
 
   case 848:
-#line 2661 "third_party/libpg_query/grammar/statements/select.y"
+#line 2666 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.conststr) = ">"; ;}
     break;
 
   case 849:
-#line 2662 "third_party/libpg_query/grammar/statements/select.y"
+#line 2667 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.conststr) = "="; ;}
     break;
 
   case 850:
-#line 2663 "third_party/libpg_query/grammar/statements/select.y"
+#line 2668 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.conststr) = "<="; ;}
     break;
 
   case 851:
-#line 2664 "third_party/libpg_query/grammar/statements/select.y"
+#line 2669 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.conststr) = ">="; ;}
     break;
 
   case 852:
-#line 2665 "third_party/libpg_query/grammar/statements/select.y"
+#line 2670 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.conststr) = "<>"; ;}
     break;
 
   case 853:
-#line 2669 "third_party/libpg_query/grammar/statements/select.y"
+#line 2674 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1(makeString((yyvsp[(1) - (1)].str))); ;}
     break;
 
   case 854:
-#line 2671 "third_party/libpg_query/grammar/statements/select.y"
+#line 2676 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = (yyvsp[(3) - (4)].list); ;}
     break;
 
   case 855:
-#line 2676 "third_party/libpg_query/grammar/statements/select.y"
+#line 2681 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1(makeString((yyvsp[(1) - (1)].str))); ;}
     break;
 
   case 856:
-#line 2678 "third_party/libpg_query/grammar/statements/select.y"
+#line 2683 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = (yyvsp[(3) - (4)].list); ;}
     break;
 
   case 857:
-#line 2683 "third_party/libpg_query/grammar/statements/select.y"
+#line 2688 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1(makeString((yyvsp[(1) - (1)].str))); ;}
     break;
 
   case 858:
-#line 2685 "third_party/libpg_query/grammar/statements/select.y"
+#line 2690 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = (yyvsp[(3) - (4)].list); ;}
     break;
 
   case 859:
-#line 2687 "third_party/libpg_query/grammar/statements/select.y"
+#line 2692 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1(makeString("~~")); ;}
     break;
 
   case 860:
-#line 2689 "third_party/libpg_query/grammar/statements/select.y"
+#line 2694 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1(makeString("!~~")); ;}
     break;
 
   case 861:
-#line 2691 "third_party/libpg_query/grammar/statements/select.y"
+#line 2696 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1(makeString("~~~")); ;}
     break;
 
   case 862:
-#line 2693 "third_party/libpg_query/grammar/statements/select.y"
+#line 2698 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1(makeString("!~~~")); ;}
     break;
 
   case 863:
-#line 2695 "third_party/libpg_query/grammar/statements/select.y"
+#line 2700 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1(makeString("~~*")); ;}
     break;
 
   case 864:
-#line 2697 "third_party/libpg_query/grammar/statements/select.y"
+#line 2702 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1(makeString("!~~*")); ;}
     break;
 
   case 865:
-#line 2711 "third_party/libpg_query/grammar/statements/select.y"
+#line 2716 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1(makeString((yyvsp[(1) - (1)].str))); ;}
     break;
 
   case 866:
-#line 2713 "third_party/libpg_query/grammar/statements/select.y"
+#line 2718 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = lcons(makeString((yyvsp[(1) - (3)].str)), (yyvsp[(3) - (3)].list)); ;}
     break;
 
   case 867:
-#line 2717 "third_party/libpg_query/grammar/statements/select.y"
+#line 2722 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = list_make1((yyvsp[(1) - (1)].node));
 				;}
     break;
 
   case 868:
-#line 2721 "third_party/libpg_query/grammar/statements/select.y"
+#line 2726 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = lappend((yyvsp[(1) - (3)].list), (yyvsp[(3) - (3)].node));
 				;}
     break;
 
   case 869:
-#line 2728 "third_party/libpg_query/grammar/statements/select.y"
+#line 2733 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = list_make1((yyvsp[(1) - (1)].node));
 				;}
     break;
 
   case 870:
-#line 2732 "third_party/libpg_query/grammar/statements/select.y"
+#line 2737 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = lappend((yyvsp[(1) - (3)].list), (yyvsp[(3) - (3)].node));
 				;}
     break;
 
   case 871:
-#line 2738 "third_party/libpg_query/grammar/statements/select.y"
+#line 2743 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (yyvsp[(1) - (1)].node);
 				;}
     break;
 
   case 872:
-#line 2742 "third_party/libpg_query/grammar/statements/select.y"
+#line 2747 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGNamedArgExpr *na = makeNode(PGNamedArgExpr);
 					na->name = (yyvsp[(1) - (3)].str);
@@ -20332,7 +20337,7 @@ yyreduce:
     break;
 
   case 873:
-#line 2751 "third_party/libpg_query/grammar/statements/select.y"
+#line 2756 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGNamedArgExpr *na = makeNode(PGNamedArgExpr);
 					na->name = (yyvsp[(1) - (3)].str);
@@ -20344,105 +20349,105 @@ yyreduce:
     break;
 
   case 874:
-#line 2761 "third_party/libpg_query/grammar/statements/select.y"
+#line 2766 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1((yyvsp[(1) - (1)].typnam)); ;}
     break;
 
   case 875:
-#line 2762 "third_party/libpg_query/grammar/statements/select.y"
+#line 2767 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = lappend((yyvsp[(1) - (3)].list), (yyvsp[(3) - (3)].typnam)); ;}
     break;
 
   case 876:
-#line 2767 "third_party/libpg_query/grammar/statements/select.y"
+#line 2772 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = list_make2(makeStringConst((yyvsp[(1) - (3)].str), (yylsp[(1) - (3)])), (yyvsp[(3) - (3)].node));
 				;}
     break;
 
   case 877:
-#line 2770 "third_party/libpg_query/grammar/statements/select.y"
+#line 2775 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = NIL; ;}
     break;
 
   case 878:
-#line 2777 "third_party/libpg_query/grammar/statements/select.y"
+#line 2782 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = (yyvsp[(1) - (1)].str); ;}
     break;
 
   case 879:
-#line 2778 "third_party/libpg_query/grammar/statements/select.y"
+#line 2783 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = (char*) "year"; ;}
     break;
 
   case 880:
-#line 2779 "third_party/libpg_query/grammar/statements/select.y"
+#line 2784 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = (char*) "month"; ;}
     break;
 
   case 881:
-#line 2780 "third_party/libpg_query/grammar/statements/select.y"
+#line 2785 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = (char*) "day"; ;}
     break;
 
   case 882:
-#line 2781 "third_party/libpg_query/grammar/statements/select.y"
+#line 2786 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = (char*) "hour"; ;}
     break;
 
   case 883:
-#line 2782 "third_party/libpg_query/grammar/statements/select.y"
+#line 2787 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = (char*) "minute"; ;}
     break;
 
   case 884:
-#line 2783 "third_party/libpg_query/grammar/statements/select.y"
+#line 2788 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = (char*) "second"; ;}
     break;
 
   case 885:
-#line 2784 "third_party/libpg_query/grammar/statements/select.y"
+#line 2789 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = (yyvsp[(1) - (1)].str); ;}
     break;
 
   case 886:
-#line 2795 "third_party/libpg_query/grammar/statements/select.y"
+#line 2800 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = list_make4((yyvsp[(1) - (4)].node), (yyvsp[(2) - (4)].node), (yyvsp[(3) - (4)].node), (yyvsp[(4) - (4)].node));
 				;}
     break;
 
   case 887:
-#line 2799 "third_party/libpg_query/grammar/statements/select.y"
+#line 2804 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = list_make3((yyvsp[(1) - (3)].node), (yyvsp[(2) - (3)].node), (yyvsp[(3) - (3)].node));
 				;}
     break;
 
   case 888:
-#line 2806 "third_party/libpg_query/grammar/statements/select.y"
+#line 2811 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (yyvsp[(2) - (2)].node); ;}
     break;
 
   case 889:
-#line 2812 "third_party/libpg_query/grammar/statements/select.y"
+#line 2817 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make2((yyvsp[(3) - (3)].node), (yyvsp[(1) - (3)].node)); ;}
     break;
 
   case 890:
-#line 2813 "third_party/libpg_query/grammar/statements/select.y"
+#line 2818 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = NIL; ;}
     break;
 
   case 891:
-#line 2830 "third_party/libpg_query/grammar/statements/select.y"
+#line 2835 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = list_make3((yyvsp[(1) - (3)].node), (yyvsp[(2) - (3)].node), (yyvsp[(3) - (3)].node));
 				;}
     break;
 
   case 892:
-#line 2834 "third_party/libpg_query/grammar/statements/select.y"
+#line 2839 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/* not legal per SQL99, but might as well allow it */
 					(yyval.list) = list_make3((yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), (yyvsp[(2) - (3)].node));
@@ -20450,14 +20455,14 @@ yyreduce:
     break;
 
   case 893:
-#line 2839 "third_party/libpg_query/grammar/statements/select.y"
+#line 2844 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = list_make2((yyvsp[(1) - (2)].node), (yyvsp[(2) - (2)].node));
 				;}
     break;
 
   case 894:
-#line 2843 "third_party/libpg_query/grammar/statements/select.y"
+#line 2848 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/*
 					 * Since there are no cases where this syntax allows
@@ -20475,44 +20480,44 @@ yyreduce:
     break;
 
   case 895:
-#line 2858 "third_party/libpg_query/grammar/statements/select.y"
+#line 2863 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.list) = (yyvsp[(1) - (1)].list);
 				;}
     break;
 
   case 896:
-#line 2862 "third_party/libpg_query/grammar/statements/select.y"
+#line 2867 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = NIL; ;}
     break;
 
   case 897:
-#line 2866 "third_party/libpg_query/grammar/statements/select.y"
+#line 2871 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (yyvsp[(2) - (2)].node); ;}
     break;
 
   case 898:
-#line 2869 "third_party/libpg_query/grammar/statements/select.y"
+#line 2874 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (yyvsp[(2) - (2)].node); ;}
     break;
 
   case 899:
-#line 2872 "third_party/libpg_query/grammar/statements/select.y"
+#line 2877 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = lappend((yyvsp[(3) - (3)].list), (yyvsp[(1) - (3)].node)); ;}
     break;
 
   case 900:
-#line 2873 "third_party/libpg_query/grammar/statements/select.y"
+#line 2878 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = (yyvsp[(2) - (2)].list); ;}
     break;
 
   case 901:
-#line 2874 "third_party/libpg_query/grammar/statements/select.y"
+#line 2879 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = (yyvsp[(1) - (1)].list); ;}
     break;
 
   case 902:
-#line 2878 "third_party/libpg_query/grammar/statements/select.y"
+#line 2883 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGSubLink *n = makeNode(PGSubLink);
 					n->subselect = (yyvsp[(1) - (1)].node);
@@ -20522,12 +20527,12 @@ yyreduce:
     break;
 
   case 903:
-#line 2884 "third_party/libpg_query/grammar/statements/select.y"
+#line 2889 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (PGNode *)(yyvsp[(2) - (3)].list); ;}
     break;
 
   case 904:
-#line 2895 "third_party/libpg_query/grammar/statements/select.y"
+#line 2900 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGCaseExpr *c = makeNode(PGCaseExpr);
 					c->casetype = InvalidOid; /* not analyzed yet */
@@ -20540,17 +20545,17 @@ yyreduce:
     break;
 
   case 905:
-#line 2908 "third_party/libpg_query/grammar/statements/select.y"
+#line 2913 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1((yyvsp[(1) - (1)].node)); ;}
     break;
 
   case 906:
-#line 2909 "third_party/libpg_query/grammar/statements/select.y"
+#line 2914 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = lappend((yyvsp[(1) - (2)].list), (yyvsp[(2) - (2)].node)); ;}
     break;
 
   case 907:
-#line 2914 "third_party/libpg_query/grammar/statements/select.y"
+#line 2919 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGCaseWhen *w = makeNode(PGCaseWhen);
 					w->expr = (PGExpr *) (yyvsp[(2) - (4)].node);
@@ -20561,55 +20566,55 @@ yyreduce:
     break;
 
   case 908:
-#line 2924 "third_party/libpg_query/grammar/statements/select.y"
+#line 2929 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (yyvsp[(2) - (2)].node); ;}
     break;
 
   case 909:
-#line 2925 "third_party/libpg_query/grammar/statements/select.y"
+#line 2930 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = NULL; ;}
     break;
 
   case 910:
-#line 2928 "third_party/libpg_query/grammar/statements/select.y"
+#line 2933 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (yyvsp[(1) - (1)].node); ;}
     break;
 
   case 911:
-#line 2929 "third_party/libpg_query/grammar/statements/select.y"
+#line 2934 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = NULL; ;}
     break;
 
   case 912:
-#line 2933 "third_party/libpg_query/grammar/statements/select.y"
+#line 2938 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeColumnRef((yyvsp[(1) - (1)].str), NIL, (yylsp[(1) - (1)]), yyscanner);
 				;}
     break;
 
   case 913:
-#line 2937 "third_party/libpg_query/grammar/statements/select.y"
+#line 2942 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeColumnRef((yyvsp[(1) - (2)].str), (yyvsp[(2) - (2)].list), (yylsp[(1) - (2)]), yyscanner);
 				;}
     break;
 
   case 914:
-#line 2944 "third_party/libpg_query/grammar/statements/select.y"
+#line 2949 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeString((yyvsp[(2) - (2)].str));
 				;}
     break;
 
   case 915:
-#line 2948 "third_party/libpg_query/grammar/statements/select.y"
+#line 2953 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = (PGNode *) makeNode(PGAStar);
 				;}
     break;
 
   case 916:
-#line 2952 "third_party/libpg_query/grammar/statements/select.y"
+#line 2957 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGAIndices *ai = makeNode(PGAIndices);
 					ai->is_slice = false;
@@ -20620,7 +20625,7 @@ yyreduce:
     break;
 
   case 917:
-#line 2960 "third_party/libpg_query/grammar/statements/select.y"
+#line 2965 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGAIndices *ai = makeNode(PGAIndices);
 					ai->is_slice = true;
@@ -20631,57 +20636,57 @@ yyreduce:
     break;
 
   case 918:
-#line 2970 "third_party/libpg_query/grammar/statements/select.y"
+#line 2975 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = (yyvsp[(1) - (1)].node); ;}
     break;
 
   case 919:
-#line 2971 "third_party/libpg_query/grammar/statements/select.y"
+#line 2976 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.node) = NULL; ;}
     break;
 
   case 920:
-#line 2975 "third_party/libpg_query/grammar/statements/select.y"
+#line 2980 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1((yyvsp[(1) - (1)].node)); ;}
     break;
 
   case 921:
-#line 2976 "third_party/libpg_query/grammar/statements/select.y"
-    { (yyval.list) = lappend((yyvsp[(1) - (2)].list), (yyvsp[(2) - (2)].node)); ;}
-    break;
-
-  case 922:
-#line 2980 "third_party/libpg_query/grammar/statements/select.y"
-    { (yyval.list) = NIL; ;}
-    break;
-
-  case 923:
 #line 2981 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = lappend((yyvsp[(1) - (2)].list), (yyvsp[(2) - (2)].node)); ;}
     break;
 
+  case 922:
+#line 2985 "third_party/libpg_query/grammar/statements/select.y"
+    { (yyval.list) = NIL; ;}
+    break;
+
+  case 923:
+#line 2986 "third_party/libpg_query/grammar/statements/select.y"
+    { (yyval.list) = lappend((yyvsp[(1) - (2)].list), (yyvsp[(2) - (2)].node)); ;}
+    break;
+
   case 926:
-#line 2995 "third_party/libpg_query/grammar/statements/select.y"
+#line 3000 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = (yyvsp[(1) - (1)].list); ;}
     break;
 
   case 927:
-#line 2996 "third_party/libpg_query/grammar/statements/select.y"
+#line 3001 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = NIL; ;}
     break;
 
   case 928:
-#line 3000 "third_party/libpg_query/grammar/statements/select.y"
+#line 3005 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1((yyvsp[(1) - (1)].target)); ;}
     break;
 
   case 929:
-#line 3001 "third_party/libpg_query/grammar/statements/select.y"
+#line 3006 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = lappend((yyvsp[(1) - (3)].list), (yyvsp[(3) - (3)].target)); ;}
     break;
 
   case 930:
-#line 3005 "third_party/libpg_query/grammar/statements/select.y"
+#line 3010 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.target) = makeNode(PGResTarget);
 					(yyval.target)->name = (yyvsp[(3) - (3)].str);
@@ -20692,7 +20697,7 @@ yyreduce:
     break;
 
   case 931:
-#line 3021 "third_party/libpg_query/grammar/statements/select.y"
+#line 3026 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.target) = makeNode(PGResTarget);
 					(yyval.target)->name = (yyvsp[(2) - (2)].str);
@@ -20703,7 +20708,7 @@ yyreduce:
     break;
 
   case 932:
-#line 3029 "third_party/libpg_query/grammar/statements/select.y"
+#line 3034 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.target) = makeNode(PGResTarget);
 					(yyval.target)->name = NULL;
@@ -20714,7 +20719,7 @@ yyreduce:
     break;
 
   case 933:
-#line 3037 "third_party/libpg_query/grammar/statements/select.y"
+#line 3042 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGColumnRef *n = makeNode(PGColumnRef);
 					n->fields = list_make1(makeNode(PGAStar));
@@ -20729,24 +20734,24 @@ yyreduce:
     break;
 
   case 934:
-#line 3058 "third_party/libpg_query/grammar/statements/select.y"
+#line 3063 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1((yyvsp[(1) - (1)].range)); ;}
     break;
 
   case 935:
-#line 3059 "third_party/libpg_query/grammar/statements/select.y"
+#line 3064 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = lappend((yyvsp[(1) - (3)].list), (yyvsp[(3) - (3)].range)); ;}
     break;
 
   case 936:
-#line 3071 "third_party/libpg_query/grammar/statements/select.y"
+#line 3076 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.range) = makeRangeVar(NULL, (yyvsp[(1) - (1)].str), (yylsp[(1) - (1)]));
 				;}
     break;
 
   case 937:
-#line 3075 "third_party/libpg_query/grammar/statements/select.y"
+#line 3080 "third_party/libpg_query/grammar/statements/select.y"
     {
 					check_qualified_name((yyvsp[(2) - (2)].list), yyscanner);
 					(yyval.range) = makeRangeVar(NULL, NULL, (yylsp[(1) - (2)]));
@@ -20774,32 +20779,32 @@ yyreduce:
     break;
 
   case 938:
-#line 3102 "third_party/libpg_query/grammar/statements/select.y"
+#line 3107 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1(makeString((yyvsp[(1) - (1)].str))); ;}
     break;
 
   case 939:
-#line 3104 "third_party/libpg_query/grammar/statements/select.y"
+#line 3109 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = lappend((yyvsp[(1) - (3)].list), makeString((yyvsp[(3) - (3)].str))); ;}
     break;
 
   case 940:
-#line 3108 "third_party/libpg_query/grammar/statements/select.y"
+#line 3113 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = (yyvsp[(1) - (1)].str); ;}
     break;
 
   case 941:
-#line 3110 "third_party/libpg_query/grammar/statements/select.y"
+#line 3115 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = (yyvsp[(1) - (1)].str); ;}
     break;
 
   case 942:
-#line 3121 "third_party/libpg_query/grammar/statements/select.y"
+#line 3126 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1(makeString((yyvsp[(1) - (1)].str))); ;}
     break;
 
   case 943:
-#line 3123 "third_party/libpg_query/grammar/statements/select.y"
+#line 3128 "third_party/libpg_query/grammar/statements/select.y"
     {
 						(yyval.list) = check_func_name(lcons(makeString((yyvsp[(1) - (2)].str)), (yyvsp[(2) - (2)].list)),
 											 yyscanner);
@@ -20807,35 +20812,35 @@ yyreduce:
     break;
 
   case 944:
-#line 3134 "third_party/libpg_query/grammar/statements/select.y"
+#line 3139 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeIntConst((yyvsp[(1) - (1)].ival), (yylsp[(1) - (1)]));
 				;}
     break;
 
   case 945:
-#line 3138 "third_party/libpg_query/grammar/statements/select.y"
+#line 3143 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeFloatConst((yyvsp[(1) - (1)].str), (yylsp[(1) - (1)]));
 				;}
     break;
 
   case 946:
-#line 3142 "third_party/libpg_query/grammar/statements/select.y"
+#line 3147 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeStringConst((yyvsp[(1) - (1)].str), (yylsp[(1) - (1)]));
 				;}
     break;
 
   case 947:
-#line 3146 "third_party/libpg_query/grammar/statements/select.y"
+#line 3151 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeBitStringConst((yyvsp[(1) - (1)].str), (yylsp[(1) - (1)]));
 				;}
     break;
 
   case 948:
-#line 3150 "third_party/libpg_query/grammar/statements/select.y"
+#line 3155 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/* This is a bit constant per SQL99:
 					 * Without Feature F511, "BIT data type",
@@ -20847,7 +20852,7 @@ yyreduce:
     break;
 
   case 949:
-#line 3159 "third_party/libpg_query/grammar/statements/select.y"
+#line 3164 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/* generic type 'literal' syntax */
 					PGTypeName *t = makeTypeNameFromNameList((yyvsp[(1) - (2)].list));
@@ -20857,7 +20862,7 @@ yyreduce:
     break;
 
   case 950:
-#line 3166 "third_party/libpg_query/grammar/statements/select.y"
+#line 3171 "third_party/libpg_query/grammar/statements/select.y"
     {
 					/* generic syntax with a type modifier */
 					PGTypeName *t = makeTypeNameFromNameList((yyvsp[(1) - (6)].list));
@@ -20892,14 +20897,14 @@ yyreduce:
     break;
 
   case 951:
-#line 3198 "third_party/libpg_query/grammar/statements/select.y"
+#line 3203 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeStringConstCast((yyvsp[(2) - (2)].str), (yylsp[(2) - (2)]), (yyvsp[(1) - (2)].typnam));
 				;}
     break;
 
   case 952:
-#line 3202 "third_party/libpg_query/grammar/statements/select.y"
+#line 3207 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGTypeName *t = (yyvsp[(1) - (3)].typnam);
 					t->typmods = (yyvsp[(3) - (3)].list);
@@ -20908,7 +20913,7 @@ yyreduce:
     break;
 
   case 953:
-#line 3208 "third_party/libpg_query/grammar/statements/select.y"
+#line 3213 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGTypeName *t = (yyvsp[(1) - (5)].typnam);
 					t->typmods = list_make2(makeIntConst(INTERVAL_FULL_RANGE, -1),
@@ -20918,7 +20923,7 @@ yyreduce:
     break;
 
   case 954:
-#line 3216 "third_party/libpg_query/grammar/statements/select.y"
+#line 3221 "third_party/libpg_query/grammar/statements/select.y"
     {
 					PGTypeName *t = (yyvsp[(1) - (6)].typnam);
 					if ((yyvsp[(6) - (6)].list) != NIL)
@@ -20933,138 +20938,138 @@ yyreduce:
     break;
 
   case 955:
-#line 3228 "third_party/libpg_query/grammar/statements/select.y"
+#line 3233 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeBoolAConst(true, (yylsp[(1) - (1)]));
 				;}
     break;
 
   case 956:
-#line 3232 "third_party/libpg_query/grammar/statements/select.y"
+#line 3237 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeBoolAConst(false, (yylsp[(1) - (1)]));
 				;}
     break;
 
   case 957:
-#line 3236 "third_party/libpg_query/grammar/statements/select.y"
+#line 3241 "third_party/libpg_query/grammar/statements/select.y"
     {
 					(yyval.node) = makeNullAConst((yylsp[(1) - (1)]));
 				;}
     break;
 
   case 958:
-#line 3241 "third_party/libpg_query/grammar/statements/select.y"
+#line 3246 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.ival) = (yyvsp[(1) - (1)].ival); ;}
     break;
 
   case 959:
-#line 3242 "third_party/libpg_query/grammar/statements/select.y"
+#line 3247 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = (yyvsp[(1) - (1)].str); ;}
     break;
 
   case 960:
-#line 3258 "third_party/libpg_query/grammar/statements/select.y"
-    { (yyval.str) = (yyvsp[(1) - (1)].str); ;}
-    break;
-
-  case 961:
-#line 3259 "third_party/libpg_query/grammar/statements/select.y"
-    { (yyval.str) = pstrdup((yyvsp[(1) - (1)].keyword)); ;}
-    break;
-
-  case 962:
-#line 3260 "third_party/libpg_query/grammar/statements/select.y"
-    { (yyval.str) = pstrdup((yyvsp[(1) - (1)].keyword)); ;}
-    break;
-
-  case 963:
 #line 3263 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = (yyvsp[(1) - (1)].str); ;}
     break;
 
-  case 964:
+  case 961:
 #line 3264 "third_party/libpg_query/grammar/statements/select.y"
+    { (yyval.str) = pstrdup((yyvsp[(1) - (1)].keyword)); ;}
+    break;
+
+  case 962:
+#line 3265 "third_party/libpg_query/grammar/statements/select.y"
+    { (yyval.str) = pstrdup((yyvsp[(1) - (1)].keyword)); ;}
+    break;
+
+  case 963:
+#line 3268 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = (yyvsp[(1) - (1)].str); ;}
     break;
 
-  case 965:
+  case 964:
 #line 3269 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = (yyvsp[(1) - (1)].str); ;}
     break;
 
+  case 965:
+#line 3274 "third_party/libpg_query/grammar/statements/select.y"
+    { (yyval.str) = (yyvsp[(1) - (1)].str); ;}
+    break;
+
   case 966:
-#line 3270 "third_party/libpg_query/grammar/statements/select.y"
+#line 3275 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = pstrdup((yyvsp[(1) - (1)].keyword)); ;}
     break;
 
   case 967:
-#line 3271 "third_party/libpg_query/grammar/statements/select.y"
+#line 3276 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = pstrdup((yyvsp[(1) - (1)].keyword)); ;}
     break;
 
   case 968:
-#line 3274 "third_party/libpg_query/grammar/statements/select.y"
+#line 3279 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1(makeString((yyvsp[(1) - (1)].str))); ;}
     break;
 
   case 969:
-#line 3275 "third_party/libpg_query/grammar/statements/select.y"
+#line 3280 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = lcons(makeString((yyvsp[(1) - (2)].str)), (yyvsp[(2) - (2)].list)); ;}
     break;
 
   case 970:
-#line 3279 "third_party/libpg_query/grammar/statements/select.y"
+#line 3284 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = list_make1(makeString((yyvsp[(2) - (2)].str))); ;}
     break;
 
   case 971:
-#line 3281 "third_party/libpg_query/grammar/statements/select.y"
+#line 3286 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = lappend((yyvsp[(1) - (3)].list), makeString((yyvsp[(3) - (3)].str))); ;}
     break;
 
   case 972:
-#line 3285 "third_party/libpg_query/grammar/statements/select.y"
+#line 3290 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = (yyvsp[(2) - (3)].list); ;}
     break;
 
   case 973:
-#line 3286 "third_party/libpg_query/grammar/statements/select.y"
+#line 3291 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.list) = NIL; ;}
     break;
 
   case 975:
-#line 3297 "third_party/libpg_query/grammar/statements/select.y"
+#line 3302 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = (yyvsp[(1) - (1)].str); ;}
     break;
 
   case 976:
-#line 3298 "third_party/libpg_query/grammar/statements/select.y"
+#line 3303 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = pstrdup((yyvsp[(1) - (1)].keyword)); ;}
     break;
 
   case 977:
-#line 3299 "third_party/libpg_query/grammar/statements/select.y"
+#line 3304 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = pstrdup((yyvsp[(1) - (1)].keyword)); ;}
     break;
 
   case 978:
-#line 3300 "third_party/libpg_query/grammar/statements/select.y"
+#line 3305 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = pstrdup((yyvsp[(1) - (1)].keyword)); ;}
     break;
 
   case 979:
-#line 3301 "third_party/libpg_query/grammar/statements/select.y"
+#line 3306 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = pstrdup((yyvsp[(1) - (1)].keyword)); ;}
     break;
 
   case 980:
-#line 3304 "third_party/libpg_query/grammar/statements/select.y"
+#line 3309 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = (yyvsp[(1) - (1)].str); ;}
     break;
 
   case 981:
-#line 3305 "third_party/libpg_query/grammar/statements/select.y"
+#line 3310 "third_party/libpg_query/grammar/statements/select.y"
     { (yyval.str) = (yyvsp[(1) - (1)].str); ;}
     break;
 
@@ -22178,7 +22183,7 @@ yyreduce:
 
 
 /* Line 1267 of yacc.c.  */
-#line 22182 "third_party/libpg_query/grammar/grammar_out.cpp"
+#line 22187 "third_party/libpg_query/grammar/grammar_out.cpp"
       default: break;
     }
   YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);

--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -524,7 +524,7 @@ struct DuckDBPyResult {
 				break;
 
 			case LogicalTypeId::TIMESTAMP: {
-				assert(result->types[col_idx].InternalType() == PhysicalType::INT64);
+				D_ASSERT(result->types[col_idx].InternalType() == PhysicalType::INT64);
 
 				auto timestamp = val.GetValue<int64_t>();
 				auto date = Timestamp::GetDate(timestamp);
@@ -536,7 +536,7 @@ struct DuckDBPyResult {
 				break;
 			}
 			case LogicalTypeId::TIME: {
-				assert(result->types[col_idx].InternalType() == PhysicalType::INT32);
+				D_ASSERT(result->types[col_idx].InternalType() == PhysicalType::INT32);
 
 				int32_t hour, min, sec, msec;
 				auto time = val.GetValue<int32_t>();
@@ -545,7 +545,7 @@ struct DuckDBPyResult {
 				break;
 			}
 			case LogicalTypeId::DATE: {
-				assert(result->types[col_idx].InternalType() == PhysicalType::INT32);
+				D_ASSERT(result->types[col_idx].InternalType() == PhysicalType::INT32);
 
 				auto date = val.GetValue<int32_t>();
 				res[col_idx] = PyDate_FromDate(duckdb::Date::ExtractYear(date), duckdb::Date::ExtractMonth(date),
@@ -586,7 +586,7 @@ struct DuckDBPyResult {
 		} else {
 			mres = (MaterializedQueryResult *)result.get();
 		}
-		assert(mres);
+		D_ASSERT(mres);
 
 		py::dict res;
 		for (idx_t col_idx = 0; col_idx < mres->types.size(); col_idx++) {
@@ -868,7 +868,7 @@ struct DuckDBPyConnection {
 		}
 
 		static int my_stream_getschema(struct ArrowArrayStream *stream, struct ArrowSchema *out) {
-			assert(stream->private_data);
+			D_ASSERT(stream->private_data);
 			auto my_stream = (PythonTableArrowArrayStream *)stream->private_data;
 			if (!stream->release) {
 				my_stream->last_error = "stream was released";
@@ -879,7 +879,7 @@ struct DuckDBPyConnection {
 		}
 
 		static int my_stream_getnext(struct ArrowArrayStream *stream, struct ArrowArray *out) {
-			assert(stream->private_data);
+			D_ASSERT(stream->private_data);
 			auto my_stream = (PythonTableArrowArrayStream *)stream->private_data;
 			if (!stream->release) {
 				my_stream->last_error = "stream was released";
@@ -905,7 +905,7 @@ struct DuckDBPyConnection {
 			if (!stream->release) {
 				return "stream was released";
 			}
-			assert(stream->private_data);
+			D_ASSERT(stream->private_data);
 			auto my_stream = (PythonTableArrowArrayStream *)stream->private_data;
 			return my_stream->last_error.c_str();
 		}

--- a/tools/rest/server.cpp
+++ b/tools/rest/server.cpp
@@ -97,7 +97,7 @@ static void assign_json_string_loop(Vector &v, idx_t col_idx, idx_t count, json 
 }
 
 void serialize_chunk(QueryResult *res, DataChunk *chunk, json &j) {
-	assert(res);
+	D_ASSERT(res);
 	for (size_t col_idx = 0; col_idx < chunk->column_count(); col_idx++) {
 		Vector &v = chunk->data[col_idx];
 		switch (v.type.id()) {
@@ -193,8 +193,8 @@ void sleep_thread(Connection *conn, bool *is_active, int timeout_duration) {
 	// timeout is given in seconds
 	// we wait 10ms per iteration, so timeout * 100 gives us the amount of
 	// iterations
-	assert(conn);
-	assert(is_active);
+	D_ASSERT(conn);
+	D_ASSERT(is_active);
 
 	if (timeout_duration < 0) {
 		return;

--- a/tools/rpkg/src/duckdbr.cpp
+++ b/tools/rpkg/src/duckdbr.cpp
@@ -404,7 +404,7 @@ SEXP duckdb_execute_R(SEXP stmtsexp) {
 		if (!generic_result->success) {
 			Rf_error("duckdb_execute_R: Failed to run query\nError: %s", generic_result->error.c_str());
 		}
-		assert(generic_result->type == QueryResultType::MATERIALIZED_RESULT);
+		D_ASSERT(generic_result->type == QueryResultType::MATERIALIZED_RESULT);
 		MaterializedQueryResult *result = (MaterializedQueryResult *)generic_result.get();
 
 		// Protect during destruction of generic_result
@@ -468,8 +468,8 @@ SEXP duckdb_execute_R_impl(MaterializedQueryResult *result) {
 		if (chunk->size() == 0) {
 			break;
 		}
-		assert(chunk->column_count() == ncols);
-		assert(chunk->column_count() == LENGTH(retlist));
+		D_ASSERT(chunk->column_count() == ncols);
+		D_ASSERT(chunk->column_count() == LENGTH(retlist));
 		for (size_t col_idx = 0; col_idx < chunk->column_count(); col_idx++) {
 			SEXP dest = VECTOR_ELT(retlist, col_idx);
 			switch (result->types[col_idx].id()) {
@@ -619,7 +619,7 @@ SEXP duckdb_execute_R_impl(MaterializedQueryResult *result) {
 		dest_offset += chunk->size();
 	}
 
-	assert(dest_offset == nrows);
+	D_ASSERT(dest_offset == nrows);
 	UNPROTECT(1); /* retlist */
 	return retlist;
 }

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -10,6 +10,7 @@
 #include <time.h>
 #include <string>
 #include <chrono>
+#include <cassert>
 
 #include "extension_helper.hpp"
 


### PR DESCRIPTION
This PR adds support for natural joins. Previously these were ignored by the transformer, which lead to them being treated as cross products.

#### Assertion rework
Triggered by a SQLancer test failing with an assertion trigger, I have also added an assertion rework to this PR. This rework replaces the standard `assert` macro with our own macro `D_ASSERT`, which throws an Internal exception instead of aborting the program. This is usually more desirable because it aborts the query, but doesn't take the host down with it (i.e. SQLancer or unit test suite).

The work also adds two additional CMake options: `ASSERT_EXCEPTION` (default true, if set to false switch back to standard assert), and `FORCE_ASSERT` (default false, if set to true check assertions even in release mode). This also adds a new Makefile entry `relassert`, which is like `reldebug` but with assertions enabled as well. We also run "release but with assertions" on one travis job to catch assertion errors in slow tests as well.
