### PR TITLE
Extend globbing with bash-style brackets

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -736,17 +736,29 @@ vector<string> FileSystem::Glob(string path) {
 	}
 	for (idx_t i = absolute_path ? 1 : 0; i < splits.size(); i++) {
 		bool is_last_chunk = i + 1 == splits.size();
+		bool has_glob = HasGlob(splits[i]);
 		// if it's the last chunk we need to find files, otherwise we find directories
 		// not the last chunk: gather a list of all directories that match the glob pattern
 		vector<string> result;
-		if (previous_directories.empty()) {
-			// no previous directories: list in the current path
-			GlobFiles(*this, ".", splits[i], !is_last_chunk, result, false);
+		if (!has_glob) {
+			// no glob, just append as-is
+			if (previous_directories.empty()) {
+				previous_directories.push_back(splits[i]);
+			} else {
+				for (auto &prev_directory : previous_directories) {
+					result.push_back(JoinPath(prev_directory, splits[i]));
+				}
+			}
 		} else {
-			// previous directories
-			// we iterate over each of the previous directories, and apply the glob of the current directory
-			for (auto &prev_directory : previous_directories) {
-				GlobFiles(*this, prev_directory, splits[i], !is_last_chunk, result, true);
+			if (previous_directories.empty()) {
+				// no previous directories: list in the current path
+				GlobFiles(*this, ".", splits[i], !is_last_chunk, result, false);
+			} else {
+				// previous directories
+				// we iterate over each of the previous directories, and apply the glob of the current directory
+				for (auto &prev_directory : previous_directories) {
+					GlobFiles(*this, prev_directory, splits[i], !is_last_chunk, result, true);
+				}
 			}
 		}
 		if (is_last_chunk || result.size() == 0) {

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -674,7 +674,6 @@ static bool HasGlob(const string &str) {
 		case '*':
 		case '?':
 		case '[':
-		case '\\':
 			return true;
 		default:
 			break;
@@ -749,7 +748,7 @@ vector<string> FileSystem::Glob(string path) {
 		if (!has_glob) {
 			// no glob, just append as-is
 			if (previous_directories.empty()) {
-				previous_directories.push_back(splits[i]);
+				result.push_back(splits[i]);
 			} else {
 				for (auto &prev_directory : previous_directories) {
 					result.push_back(JoinPath(prev_directory, splits[i]));

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -670,8 +670,14 @@ void FileHandle::Truncate(int64_t new_size) {
 
 static bool HasGlob(const string &str) {
 	for (idx_t i = 0; i < str.size(); i++) {
-		if (str[i] == '*' || str[i] == '?') {
+		switch(str[i]) {
+		case '*':
+		case '?':
+		case '[':
+		case '\\':
 			return true;
+		default:
+			break;
 		}
 	}
 	return false;

--- a/src/function/scalar/string/like.cpp
+++ b/src/function/scalar/string/like.cpp
@@ -89,8 +89,6 @@ main_loop : {
 		}
 		case '?':
 			// wildcard: matches anything but null
-			sidx++;
-			pidx++;
 			break;
 		case '[':
 			pidx++;
@@ -106,18 +104,16 @@ main_loop : {
 			if (s != p) {
 				return false;
 			}
-			sidx++;
-			pidx++;
 			break;
 		default:
 			// not a control character: characters need to match literally
 			if (s != p) {
 				return false;
 			}
-			sidx++;
-			pidx++;
 			break;
 		}
+		sidx++;
+		pidx++;
 	}
 	while (pidx < plen && pattern[pidx] == '*') {
 		pidx++;

--- a/src/function/scalar/string/like.cpp
+++ b/src/function/scalar/string/like.cpp
@@ -10,7 +10,7 @@ template <char PERCENTAGE, char UNDERSCORE>
 bool templated_like_operator(const char *sdata, idx_t slen, const char *pdata, idx_t plen, char escape) {
 	idx_t pidx = 0;
 	idx_t sidx = 0;
-	for(; pidx < plen && sidx < slen; pidx++) {
+	for (; pidx < plen && sidx < slen; pidx++) {
 		char pchar = pdata[pidx];
 		char schar = sdata[sidx];
 		if (pchar == escape) {
@@ -33,7 +33,8 @@ bool templated_like_operator(const char *sdata, idx_t slen, const char *pdata, i
 				return true; /* tail is acceptable */
 			}
 			for (; sidx < slen; sidx++) {
-				if (templated_like_operator<PERCENTAGE, UNDERSCORE>(sdata + sidx, slen - sidx, pdata + pidx, plen - pidx, escape)) {
+				if (templated_like_operator<PERCENTAGE, UNDERSCORE>(sdata + sidx, slen - sidx, pdata + pidx,
+				                                                    plen - pidx, escape)) {
 					return true;
 				}
 			}
@@ -44,7 +45,7 @@ bool templated_like_operator(const char *sdata, idx_t slen, const char *pdata, i
 			return false;
 		}
 	}
-	while(pidx < plen && pdata[pidx] == PERCENTAGE) {
+	while (pidx < plen && pdata[pidx] == PERCENTAGE) {
 		pidx++;
 	}
 	return pidx == plen && sidx == slen;
@@ -61,17 +62,17 @@ bool like_operator(string_t &s, string_t &pat, char escape = '\0') {
 bool LikeFun::Glob(const char *string, idx_t slen, const char *pattern, idx_t plen) {
 	idx_t sidx = 0;
 	idx_t pidx = 0;
-main_loop: {
+main_loop : {
 	// main matching loop
-	while(sidx < slen && pidx < plen) {
+	while (sidx < slen && pidx < plen) {
 		char s = string[sidx];
 		char p = pattern[pidx];
-		switch(p) {
+		switch (p) {
 		case '*': {
 			// asterisk: match any set of characters
 			// skip any subsequent asterisks
 			pidx++;
-			while(pidx < plen && pattern[pidx] == '*') {
+			while (pidx < plen && pattern[pidx] == '*') {
 				pidx++;
 			}
 			// if the asterisk is the last character, the pattern always matches
@@ -116,15 +117,15 @@ main_loop: {
 			sidx++;
 			pidx++;
 			break;
-
 		}
 	}
-	while(pidx < plen && pattern[pidx] == '*') {
+	while (pidx < plen && pattern[pidx] == '*') {
 		pidx++;
 	}
 	// we are finished only if we have consumed the full pattern
-	return pidx == plen && sidx == slen;}
-parse_bracket: {
+	return pidx == plen && sidx == slen;
+}
+parse_bracket : {
 	// inside a bracket
 	if (pidx == plen) {
 		return false;
@@ -142,7 +143,7 @@ parse_bracket: {
 	idx_t start_pos = pidx;
 	bool found_closing_bracket = false;
 	// now check the remainder of the pattern
-	while(pidx < plen) {
+	while (pidx < plen) {
 		p = pattern[pidx];
 		// if the first character is a closing bracket, we match it literally
 		// otherwise it indicates an end of bracket
@@ -203,7 +204,8 @@ struct LikeEscapeOperator {
 			throw SyntaxException("Invalid escape string. Escape string must be empty or one character.");
 		}
 		char escape_char = escape.GetSize() == 0 ? '\0' : *escape.GetDataUnsafe();
-		return like_operator(str.GetDataUnsafe(), str.GetSize(), pattern.GetDataUnsafe(), pattern.GetSize(), escape_char);
+		return like_operator(str.GetDataUnsafe(), str.GetSize(), pattern.GetDataUnsafe(), pattern.GetSize(),
+		                     escape_char);
 	}
 };
 

--- a/src/include/duckdb/function/scalar/string_functions.hpp
+++ b/src/include/duckdb/function/scalar/string_functions.hpp
@@ -66,7 +66,7 @@ struct LengthFun {
 
 struct LikeFun {
 	static void RegisterFunction(BuiltinFunctions &set);
-	static bool Glob(const char *s, idx_t slen, const char *pattern, idx_t plen, char escape = '\0');
+	static bool Glob(const char *s, idx_t slen, const char *pattern, idx_t plen);
 };
 
 struct LikeEscapeFun {

--- a/test/sql/copy/parquet/parquet_glob.test
+++ b/test/sql/copy/parquet/parquet_glob.test
@@ -13,6 +13,11 @@ select count(*) from parquet_scan('*/sql/*/parquet/*/glob/t?.parquet')
 2
 
 query I
+select count(*) from parquet_scan('*/sql/*/parquet/*/glob/t[0-9].parquet')
+----
+2
+
+query I
 select count(*) from parquet_scan('test/sql/copy/parquet/data/glob/*')
 ----
 2

--- a/test/sql/function/string/test_glob.test
+++ b/test/sql/function/string/test_glob.test
@@ -66,6 +66,158 @@ SELECT 'ababac' GLOB '*abac'
 ----
 1
 
+# bracket matching
+query T
+SELECT '3' GLOB '[0-9]'
+----
+1
+
+query T
+SELECT 'a' GLOB '[0-9]'
+----
+0
+
+# multiple brackets in a row
+query T
+SELECT '012' GLOB '[0-9][0-9][0-9]'
+----
+1
+
+# trailing in pattern after brackets
+query T
+SELECT '012' GLOB '[0-9][0-9][0-9]a'
+----
+0
+
+# trailing in string after brackets
+query T
+SELECT '012a' GLOB '[0-9][0-9][0-9]'
+----
+0
+
+# more complicated brackets
+query T
+SELECT 'b3' GLOB '[abc0-9][abc0-9]'
+----
+1
+
+query T
+SELECT 'd3' GLOB '[abc0-9][abc0-9]'
+----
+0
+
+# inverse brackets
+query T
+SELECT 'a' GLOB '[!0-9]'
+----
+1
+
+query T
+SELECT '1' GLOB '[!0-9]'
+----
+0
+
+# escapes
+query T
+SELECT '*' GLOB '\*'
+----
+1
+
+query T
+SELECT 'a' GLOB '\*'
+----
+0
+
+# escaped escape
+query T
+SELECT '\' GLOB '\\'
+----
+1
+
+# '
+query T
+SELECT 'a' GLOB '\\'
+----
+0
+
+# bracket in a bracket
+# this is valid as long as the closing bracket is the first non-exclamation mark character
+query T
+SELECT '3]' GLOB '[]3][]]'
+----
+1
+
+query T
+SELECT '3]' GLOB '[]3][]]'
+----
+1
+
+# bracket is not properly closed
+query T
+SELECT '3' GLOB '[3'
+----
+0
+
+# trailing range
+query T
+SELECT '3' GLOB '[3-'
+----
+0
+
+# trailing escape
+query T
+SELECT '3' GLOB '\\'
+----
+0
+
+# a bunch of asterisks
+query T
+SELECT '3' GLOB '3***'
+----
+1
+
+query T
+SELECT '1245' GLOB '**1***2*******4*5***'
+----
+1
+
+query T
+SELECT 'aaaaaaaaaaaaaaaaaaaaaaa' GLOB '*a'
+----
+1
+
+# special characters in brackets
+query T
+SELECT '?' GLOB '[?]'
+----
+1
+
+query T
+SELECT '3' GLOB '[?]'
+----
+0
+
+query T
+SELECT '*' GLOB '[*]'
+----
+1
+
+query T
+SELECT '3' GLOB '[*]'
+----
+0
+
+# multiple ranges in a bracket
+query T
+SELECT '6' GLOB '[1-35-7]'
+----
+1
+
+query T
+SELECT '4' GLOB '[1-35-7]'
+----
+0
+
 # like with table
 statement ok
 CREATE TABLE strings(s STRING, pat STRING);


### PR DESCRIPTION
This PR extends globbing with support for bash-style bracket operators, i.e. the following now works properly according to bash semantics

```sql
SELECT 'abc0' GLOB 'abc[0-9]';
-- true
```

The bracket syntax can now also be used in e.g. the Parquet/CSV file globbers.