### PR TITLE
Support home directory in globs & minor glob fixes

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -627,6 +627,14 @@ string FileSystem::GetWorkingDirectory() {
 }
 #endif
 
+string FileSystem::GetHomeDirectory() {
+	const char *homedir = getenv("HOME");
+	if (!homedir) {
+		return string();
+	}
+	return homedir;
+}
+
 void FileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
 	// seek to the location
 	SetFilePointer(handle, location);
@@ -718,6 +726,7 @@ vector<string> FileSystem::Glob(string path) {
 		if (path[i] == '\\' || path[i] == '/') {
 			if (i == last_pos) {
 				// empty: skip this position
+				last_pos = i + 1;
 				continue;
 			}
 			splits.push_back(path.substr(last_pos, i - last_pos));
@@ -733,6 +742,13 @@ vector<string> FileSystem::Glob(string path) {
 	} else if (StringUtil::Contains(splits[0], ":")) {
 		// first split has a colon -  windows absolute path
 		absolute_path = true;
+	} else if (splits[0] == "~") {
+		// starts with home directory
+		auto home_directory = GetHomeDirectory();
+		if (!home_directory.empty()) {
+			absolute_path = true;
+			splits[0] = home_directory;
+		}
 	}
 	vector<string> previous_directories;
 	if (absolute_path) {
@@ -771,7 +787,7 @@ vector<string> FileSystem::Glob(string path) {
 		}
 		previous_directories = move(result);
 	}
-	throw InternalException("Eeek");
+	return vector<string>();
 }
 
 } // namespace duckdb

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -729,7 +729,11 @@ vector<string> FileSystem::Glob(string path) {
 				last_pos = i + 1;
 				continue;
 			}
-			splits.push_back(path.substr(last_pos, i - last_pos));
+			if (splits.empty()) {
+				splits.push_back(path.substr(0, i));
+			} else {
+				splits.push_back(path.substr(last_pos, i - last_pos));
+			}
 			last_pos = i + 1;
 		}
 	}

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -117,6 +117,8 @@ public:
 	virtual void SetWorkingDirectory(string path);
 	//! Gets the working directory
 	virtual string GetWorkingDirectory();
+	//! Gets the users home directory
+	virtual string GetHomeDirectory();
 
 	//! Runs a glob on the file system, returning a list of matching files
 	virtual vector<string> Glob(string path);

--- a/test/sql/copy/csv/glob/read_csv_glob.test
+++ b/test/sql/copy/csv/glob/read_csv_glob.test
@@ -96,11 +96,27 @@ SELECT COUNT(*) FROM glob('test\sql\copy\csv\data\glob\*\*.csv')
 ----
 5
 
+# consecutive slashes are ignored
+query I
+SELECT COUNT(*) FROM glob('test//sql////copy//csv/////data///glob///*//////*.csv')
+----
+5
+
 # nothing matches the glob
 statement error
 SELECT * FROM read_csv('test/sql/copy/csv/data/glob/*/a*a.csv', auto_detect=1) ORDER BY 1
 
 query I
 SELECT COUNT(*) FROM glob('test/sql/copy/csv/data/glob/*/a*a.csv')
+----
+0
+
+query I
+select count(*) from glob('/rewoiarwiouw3rajkawrasdf790273489*.csv') limit 10;
+----
+0
+
+query I
+select count(*) from glob('~/rewoiarwiouw3rajkawrasdf790273489*.py') limit 10;
 ----
 0


### PR DESCRIPTION
* Support using ~ for home directory in globs
* Fix InternalError when querying the root directory (e.g. `/*.csv`)
* Correctly ignore multiple slashes (e.g. `foo///bar///*.csv` is now equivalent to `foo/bar/*.csv`).