### PR TITLE
Fixes for multi-statement prepare in Python client and shell

### DIFF
--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -88,6 +88,7 @@ public:
 	//! MaterializedQueryResult. The StreamQueryResult will only be returned in the case of a successful SELECT
 	//! statement.
 	unique_ptr<QueryResult> Query(string query, bool allow_stream_result);
+	unique_ptr<QueryResult> Query(unique_ptr<SQLStatement> statement, bool allow_stream_result);
 	//! Fetch a query from the current result set (if any)
 	unique_ptr<DataChunk> Fetch();
 	//! Cleanup the result set (if any).
@@ -109,6 +110,9 @@ public:
 
 	//! Prepare a query
 	unique_ptr<PreparedStatement> Prepare(string query);
+	//! Directly prepare a SQL statement
+	unique_ptr<PreparedStatement> Prepare(unique_ptr<SQLStatement> statement);
+
 	//! Execute a prepared statement with the given name and set of parameters
 	unique_ptr<QueryResult> Execute(string name, vector<Value> &values, bool allow_stream_result = true,
 	                                string query = string());
@@ -122,7 +126,7 @@ public:
 	void RegisterFunction(CreateFunctionInfo *info);
 
 	//! Parse statements from a query
-	vector<unique_ptr<SQLStatement>> ParseStatements(string query, idx_t *n_prepared_parameters = nullptr);
+	vector<unique_ptr<SQLStatement>> ParseStatements(string query);
 
 	//! Runs a function with a valid transaction context, potentially starting a transaction if the context is in auto
 	//! commit mode.
@@ -156,6 +160,8 @@ private:
 	//! Call CreatePreparedStatement() and ExecutePreparedStatement() without any bound values
 	unique_ptr<QueryResult> RunStatementInternal(const string &query, unique_ptr<SQLStatement> statement,
 	                                             bool allow_stream_result);
+	unique_ptr<PreparedStatement> PrepareInternal(unique_ptr<SQLStatement> statement);
+	void LogQueryInternal(string query);
 
 private:
 	idx_t prepare_count = 0;

--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -65,6 +65,9 @@ public:
 	//! Issues a query to the database and materializes the result (if necessary). Always returns a
 	//! MaterializedQueryResult.
 	unique_ptr<MaterializedQueryResult> Query(string query);
+	//! Issues a query to the database and materializes the result (if necessary). Always returns a
+	//! MaterializedQueryResult.
+	unique_ptr<MaterializedQueryResult> Query(unique_ptr<SQLStatement> statement);
 	// prepared statements
 	template <typename... Args> unique_ptr<QueryResult> Query(string query, Args... args) {
 		vector<Value> values;
@@ -73,6 +76,8 @@ public:
 
 	//! Prepare the specified query, returning a prepared statement object
 	unique_ptr<PreparedStatement> Prepare(string query);
+	//! Prepare the specified statement, returning a prepared statement object
+	unique_ptr<PreparedStatement> Prepare(unique_ptr<SQLStatement> statement);
 
 	//! Get the table info of a specific table (in the default schema), or nullptr if it cannot be found
 	unique_ptr<TableDescription> TableInfo(string table_name);

--- a/src/include/duckdb/parser/parser.hpp
+++ b/src/include/duckdb/parser/parser.hpp
@@ -55,8 +55,6 @@ public:
 	//! The parsed SQL statements from an invocation to ParseQuery.
 	vector<unique_ptr<SQLStatement>> statements;
 
-	idx_t n_prepared_parameters = 0;
-
 private:
 	//! Transform a Postgres parse tree into a set of SQL Statements
 	bool TransformList(duckdb_libpgquery::PGList *tree);

--- a/src/include/duckdb/parser/sql_statement.hpp
+++ b/src/include/duckdb/parser/sql_statement.hpp
@@ -21,9 +21,15 @@ public:
 	virtual ~SQLStatement() {
 	}
 
+	//! The statement type
 	StatementType type;
+	//! The statement location within the query string
 	idx_t stmt_location;
+	//! The statement length within the query string
 	idx_t stmt_length;
+	//! The number of prepared statement parameters (if any)
+	idx_t n_param;
+	//! The query text that corresponds to this SQL statement
 	string query;
 };
 } // namespace duckdb

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -74,8 +74,18 @@ unique_ptr<MaterializedQueryResult> Connection::Query(string query) {
 	return unique_ptr_cast<QueryResult, MaterializedQueryResult>(move(result));
 }
 
+unique_ptr<MaterializedQueryResult> Connection::Query(unique_ptr<SQLStatement> statement) {
+	auto result = context->Query(move(statement), false);
+	D_ASSERT(result->type == QueryResultType::MATERIALIZED_RESULT);
+	return unique_ptr_cast<QueryResult, MaterializedQueryResult>(move(result));
+}
+
 unique_ptr<PreparedStatement> Connection::Prepare(string query) {
 	return context->Prepare(query);
+}
+
+unique_ptr<PreparedStatement> Connection::Prepare(unique_ptr<SQLStatement> statement) {
+	return context->Prepare(move(statement));
 }
 
 unique_ptr<QueryResult> Connection::QueryParamsRecursive(string query, vector<Value> &values) {

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -36,7 +36,6 @@ void Parser::ParseQuery(string query) {
 		// if it succeeded, we transform the Postgres parse tree into a list of
 		// SQLStatements
 		transformer.TransformParseTree(parser.parse_tree, statements);
-		n_prepared_parameters = transformer.ParamCount();
 	}
 	if (statements.size() > 0) {
 		auto &last_statement = statements.back();

--- a/src/parser/transformer.cpp
+++ b/src/parser/transformer.cpp
@@ -10,11 +10,13 @@ using namespace duckdb_libpgquery;
 
 bool Transformer::TransformParseTree(PGList *tree, vector<unique_ptr<SQLStatement>> &statements) {
 	for (auto entry = tree->head; entry != nullptr; entry = entry->next) {
+		SetParamCount(0);
 		auto stmt = TransformStatement((PGNode *)entry->data.ptr_value);
 		if (!stmt) {
 			statements.clear();
 			return false;
 		}
+		stmt->n_param = ParamCount();
 		statements.push_back(move(stmt));
 	}
 	return true;

--- a/tools/pythonpkg/tests/test_multi_statement.py
+++ b/tools/pythonpkg/tests/test_multi_statement.py
@@ -1,0 +1,38 @@
+import duckdb
+import os
+import shutil
+
+class TestMultiStatement(object):
+    def test_multi_statement(self, duckdb_cursor):
+        import duckdb
+        con = duckdb.connect(':memory:')
+
+        # test empty statement
+        con.execute('')
+
+        # run multiple statements in one call to execute
+        con.execute('''
+        CREATE TABLE integers(i integer);
+        insert into integers select * from range(10);
+        select * from integers;
+        ''')
+        results = [x[0] for x in con.fetchall()]
+        assert results == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+        # test export/import
+        export_location = os.path.join(os.getcwd(), 'duckdb_pytest_dir_export')
+        try:
+            shutil.rmtree(export_location)
+        except:
+            pass
+        con.execute('CREATE TABLE integers2(i INTEGER)')
+        con.execute('INSERT INTO integers2 VALUES (1), (5), (7), (1928)')
+        con.execute("EXPORT DATABASE '%s'" % (export_location,))
+        # reset connection
+        con = duckdb.connect(':memory:')
+        con.execute("IMPORT DATABASE '%s'" % (export_location,))
+        integers = [x[0] for x in con.execute('SELECT * FROM integers').fetchall()]
+        integers2 = [x[0] for x in con.execute('SELECT * FROM integers2').fetchall()]
+        assert integers == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        assert integers2 == [1, 5, 7, 1928]
+        shutil.rmtree(export_location)

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb.hpp"
 #include "duckdb/parser/parser.hpp"
+#include "duckdb/planner/pragma_handler.hpp"
 
 #include <ctype.h>
 #include <stdio.h>
@@ -133,21 +134,34 @@ int sqlite3_prepare_v2(sqlite3 *db,           /* Database handle */
 		*pzTail = zSql + query.size();
 	}
 	try {
-		// extract the statements from the SQL query
-		auto statements = db->con->ExtractStatements(query);
-		if (statements.size() == 0) {
-			// no statements to prepare!
+		Parser parser;
+		parser.ParseQuery(query);
+		if (parser.statements.size() == 0) {
 			return SQLITE_OK;
 		}
+		// extract the remainder
+		idx_t next_location = parser.statements[0]->stmt_location + parser.statements[0]->stmt_length;
+		bool set_remainder = next_location < query.size();
 
 		// extract the first statement
-		auto statement = statements[0].get();
-		// extract the remainder
-		bool set_remainder = statement->stmt_location + statement->stmt_length < query.size();
-		query = query.substr(statement->stmt_location, statement->stmt_length);
+		vector<unique_ptr<SQLStatement>> statements;
+		statements.push_back(move(parser.statements[0]));
+
+		PragmaHandler handler(*db->con->context);
+		handler.HandlePragmaStatements(statements);
+
+		// if there are multiple statements here, we are dealing with an import database statement
+		// we directly execute all statements besides the final one
+		for(idx_t i = 0; i + 1 < statements.size(); i++) {
+			auto res = db->con->Query(move(statements[i]));
+			if (!res->success) {
+				db->last_error = res->error;
+				return SQLITE_ERROR;
+			}
+		}
 
 		// now prepare the query
-		auto prepared = db->con->Prepare(query);
+		auto prepared = db->con->Prepare(move(statements.back()));
 		if (!prepared->success) {
 			// failed to prepare: set the error message
 			db->last_error = prepared->error;
@@ -167,7 +181,7 @@ int sqlite3_prepare_v2(sqlite3 *db,           /* Database handle */
 
 		// extract the remainder of the query and assign it to the pzTail
 		if (pzTail && set_remainder) {
-			*pzTail = zSql + query.size() + 1;
+			*pzTail = zSql + next_location + 1;
 		}
 
 		*ppStmt = stmt.release();


### PR DESCRIPTION
This fixes issue #1100, and in general allows multiple statements to be executed in a single `execute` call in the Python client (#400). 