### PR TITLE
Switching to even older compiler for Linux binary builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,7 +170,7 @@ jobs:
   linux-release-64:
     name: Linux (64 Bit)
     runs-on: ubuntu-16.04
-    # needs: linux-debug
+    needs: linux-debug
 
     env:
       GEN: ninja

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,11 +170,9 @@ jobs:
   linux-release-64:
     name: Linux (64 Bit)
     runs-on: ubuntu-16.04
-    needs: linux-debug
+    # needs: linux-debug
 
     env:
-      CC: gcc-9
-      CXX: g++-9
       GEN: ninja
       BUILD_ICU: 1
       BUILD_TPCH: 1
@@ -189,10 +187,7 @@ jobs:
         python-version: '3.7'
 
     - name: Install
-      run: |
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-        sudo apt-get update
-        sudo apt-get install gcc-9 ninja-build
+      run: sudo apt-get install ninja-build
 
     - name: Build
       run: make


### PR DESCRIPTION
GCC bakes a specific `libstdc++` version symbol in the binaries, for example `GLIBCXX_3.4.26`. If we build DuckDB on - say- Ubuntu 20.x this will make it not run on - say - Ubuntu 18.x. So the safe way around this is to use an old compiler on an old OS to avoid any modern leakage. 