### PR TITLE
CSV sniffer improvements

### DIFF
--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -5,11 +5,11 @@
 namespace duckdb {
 using namespace std;
 
-Exception::Exception(string message) : std::exception(), type(ExceptionType::INVALID), message_raw(message) {
+Exception::Exception(string message) : std::exception(), type(ExceptionType::INVALID) {
 	exception_message_ = message;
 }
 
-Exception::Exception(ExceptionType exception_type, string message) : std::exception(), type(exception_type), message_raw(message) {
+Exception::Exception(ExceptionType exception_type, string message) : std::exception(), type(exception_type) {
 	exception_message_ = ExceptionTypeToString(exception_type) + " Error: " + message;
 }
 
@@ -85,6 +85,8 @@ string Exception::ExceptionTypeToString(ExceptionType type) {
 		return "FATAL";
 	case ExceptionType::INTERNAL:
 		return "INTERNAL";
+	case ExceptionType::INVALID_INPUT:
+		return "Invalid Input";
 	default:
 		return "Unknown";
 	}

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -5,11 +5,11 @@
 namespace duckdb {
 using namespace std;
 
-Exception::Exception(string message) : std::exception(), type(ExceptionType::INVALID) {
+Exception::Exception(string message) : std::exception(), type(ExceptionType::INVALID), message_raw(message) {
 	exception_message_ = message;
 }
 
-Exception::Exception(ExceptionType exception_type, string message) : std::exception(), type(exception_type) {
+Exception::Exception(ExceptionType exception_type, string message) : std::exception(), type(exception_type), message_raw(message) {
 	exception_message_ = ExceptionTypeToString(exception_type) + " Error: " + message;
 }
 

--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -207,19 +207,19 @@ static unique_ptr<FunctionData> read_csv_bind(ClientContext &context, CopyInfo &
 		} else if (ParseBaseOption(options, loption, set)) {
 			// parsed option in base CSV options: continue
 			continue;
-		} else if (loption == "sample_size") {
-			options.sample_size = ParseInteger(set);
-			if (options.sample_size > STANDARD_VECTOR_SIZE) {
+		} else if (loption == "sample_chunk_size") {
+			options.sample_chunk_size = ParseInteger(set);
+			if (options.sample_chunk_size > STANDARD_VECTOR_SIZE) {
 				throw BinderException(
-				    "Unsupported parameter for SAMPLE_SIZE: cannot be bigger than STANDARD_VECTOR_SIZE %d",
+				    "Unsupported parameter for SAMPLE_CHUNK_SIZE: cannot be bigger than STANDARD_VECTOR_SIZE %d",
 				    STANDARD_VECTOR_SIZE);
-			} else if (options.sample_size < 1) {
-				throw BinderException("Unsupported parameter for SAMPLE_SIZE: cannot be smaller than 1");
+			} else if (options.sample_chunk_size < 1) {
+				throw BinderException("Unsupported parameter for SAMPLE_CHUNK_SIZE: cannot be smaller than 1");
 			}
-		} else if (loption == "num_samples") {
-			options.num_samples = ParseInteger(set);
-			if (options.num_samples < 1) {
-				throw BinderException("Unsupported parameter for NUM_SAMPLES: cannot be smaller than 1");
+		} else if (loption == "sample_chunks") {
+			options.sample_chunks = ParseInteger(set);
+			if (options.sample_chunks < 1) {
+				throw BinderException("Unsupported parameter for SAMPLE_CHUNKS: cannot be smaller than 1");
 			}
 		} else if (loption == "force_not_null") {
 			options.force_not_null = ParseColumnList(set, expected_names);

--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
+#include <limits>
 
 using namespace std;
 
@@ -225,7 +226,7 @@ static unique_ptr<FunctionData> read_csv_bind(ClientContext &context, CopyInfo &
 				throw BinderException("Unsupported parameter for SAMPLE_SIZE: cannot be smaller than 1");
 			}
 			if (sample_size == -1) {
-				options.sample_chunks = ULLONG_MAX;
+				options.sample_chunks = std::numeric_limits<long>::max();
 				options.sample_chunk_size = STANDARD_VECTOR_SIZE;
 			} else if (sample_size <= STANDARD_VECTOR_SIZE) {
 				options.sample_chunk_size = sample_size;

--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -207,6 +207,19 @@ static unique_ptr<FunctionData> read_csv_bind(ClientContext &context, CopyInfo &
 		} else if (ParseBaseOption(options, loption, set)) {
 			// parsed option in base CSV options: continue
 			continue;
+		} else if (loption == "sample_size") {
+			options.sample_size = ParseInteger(set);
+			if (options.sample_size < 1) {
+				throw BinderException("Unsupported parameter for SAMPLE_SIZE: cannot be smaller than 1");
+			}
+
+			if (options.sample_size <= STANDARD_VECTOR_SIZE) {
+				options.sample_chunk_size = options.sample_size;
+				options.sample_chunks = 1;
+			} else {
+				options.sample_chunk_size = STANDARD_VECTOR_SIZE;
+				options.sample_chunks = options.sample_size / STANDARD_VECTOR_SIZE;
+			}
 		} else if (loption == "sample_chunk_size") {
 			options.sample_chunk_size = ParseInteger(set);
 			if (options.sample_chunk_size > STANDARD_VECTOR_SIZE) {

--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -48,26 +48,10 @@ static string ParseString(vector<Value> &set) {
 	return set[0].GetValue<string>();
 }
 
-static idx_t ParseInteger(vector<Value> &set) {
+static int64_t ParseInteger(vector<Value> &set) {
 	if (set.size() != 1) {
 		// no option specified or multiple options specified
 		throw BinderException("Expected a single argument as a integer value");
-	}
-	if (set[0].type().id() == LogicalTypeId::FLOAT || set[0].type().id() == LogicalTypeId::DOUBLE ||
-	    set[0].type().id() == LogicalTypeId::DECIMAL) {
-		throw BinderException("Expected a integer argument!");
-	}
-	return set[0].GetValue<int64_t>();
-}
-
-static int64_t ParseIntegerUnsigned(vector<Value> &set) {
-	if (set.size() != 1) {
-		// no option specified or multiple options specified
-		throw BinderException("Expected a single argument as a integer value");
-	}
-	if (set[0].type().id() == LogicalTypeId::FLOAT || set[0].type().id() == LogicalTypeId::DOUBLE ||
-	    set[0].type().id() == LogicalTypeId::DECIMAL) {
-		throw BinderException("Expected a integer argument!");
 	}
 	return set[0].GetValue<int64_t>();
 }
@@ -221,12 +205,12 @@ static unique_ptr<FunctionData> read_csv_bind(ClientContext &context, CopyInfo &
 			// parsed option in base CSV options: continue
 			continue;
 		} else if (loption == "sample_size") {
-			int64_t sample_size = ParseIntegerUnsigned(set);
+			int64_t sample_size = ParseInteger(set);
 			if (sample_size < 1 && sample_size != -1) {
 				throw BinderException("Unsupported parameter for SAMPLE_SIZE: cannot be smaller than 1");
 			}
 			if (sample_size == -1) {
-				options.sample_chunks = std::numeric_limits<long>::max();
+				options.sample_chunks = std::numeric_limits<uint64_t>::max();
 				options.sample_chunk_size = STANDARD_VECTOR_SIZE;
 			} else if (sample_size <= STANDARD_VECTOR_SIZE) {
 				options.sample_chunk_size = sample_size;

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -44,6 +44,19 @@ static unique_ptr<FunctionData> read_csv_bind(ClientContext &context, vector<Val
 			options.has_escape = true;
 		} else if (kv.first == "nullstr") {
 			options.null_str = kv.second.str_value;
+		} else if (kv.first == "sample_size") {
+			options.sample_size = kv.second.GetValue<int64_t>();
+			if (options.sample_size < 1) {
+				throw BinderException("Unsupported parameter for SAMPLE_SIZE: cannot be smaller than 1");
+			}
+
+			if (options.sample_size <= STANDARD_VECTOR_SIZE) {
+				options.sample_chunk_size = options.sample_size;
+				options.sample_chunks = 1;
+			} else {
+				options.sample_chunk_size = STANDARD_VECTOR_SIZE;
+				options.sample_chunks = options.sample_size / STANDARD_VECTOR_SIZE;
+			}
 		} else if (kv.first == "sample_chunk_size") {
 			options.sample_chunk_size = kv.second.GetValue<int64_t>();
 			if (options.sample_chunk_size > STANDARD_VECTOR_SIZE) {
@@ -58,8 +71,8 @@ static unique_ptr<FunctionData> read_csv_bind(ClientContext &context, vector<Val
 			if (options.sample_chunks < 1) {
 				throw BinderException("Unsupported parameter for SAMPLE_CHUNKS: cannot be smaller than 1");
 			}
-		} else if (kv.first == "fallback_to_all_varchar") {
-			options.fallback_to_all_varchar = kv.second.value_.boolean;
+		} else if (kv.first == "all_varchar") {
+			options.all_varchar = kv.second.value_.boolean;
 		} else if (kv.first == "dateformat") {
 			options.has_format[LogicalTypeId::DATE] = true;
 			auto &date_format = options.date_format[LogicalTypeId::DATE];
@@ -92,7 +105,8 @@ static unique_ptr<FunctionData> read_csv_bind(ClientContext &context, vector<Val
 		}
 	}
 	if (!options.auto_detect && return_types.size() == 0) {
-		throw BinderException("read_csv requires columns to be specified. Use read_csv_auto or set read_csv(..., AUTO_DETECT=TRUE) to automatically guess columns.");
+		throw BinderException("read_csv requires columns to be specified. Use read_csv_auto or set read_csv(..., "
+		                      "AUTO_DETECT=TRUE) to automatically guess columns.");
 	}
 	if (options.auto_detect) {
 		options.file_path = result->files[0];
@@ -173,9 +187,10 @@ static void add_named_parameters(TableFunction &table_function) {
 	table_function.named_parameters["columns"] = LogicalType::STRUCT;
 	table_function.named_parameters["header"] = LogicalType::BOOLEAN;
 	table_function.named_parameters["auto_detect"] = LogicalType::BOOLEAN;
+	table_function.named_parameters["sample_size"] = LogicalType::BIGINT;
 	table_function.named_parameters["sample_chunk_size"] = LogicalType::BIGINT;
 	table_function.named_parameters["sample_chunks"] = LogicalType::BIGINT;
-	table_function.named_parameters["fallback_to_all_varchar"] = LogicalType::BOOLEAN;
+	table_function.named_parameters["all_varchar"] = LogicalType::BOOLEAN;
 	table_function.named_parameters["dateformat"] = LogicalType::VARCHAR;
 	table_function.named_parameters["timestampformat"] = LogicalType::VARCHAR;
 	table_function.named_parameters["filename"] = LogicalType::BOOLEAN;

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -48,7 +48,7 @@ static unique_ptr<FunctionData> read_csv_bind(ClientContext &context, vector<Val
 				throw BinderException("Unsupported parameter for SAMPLE_SIZE: cannot be smaller than 1");
 			}
 			if (sample_size == -1) {
-				options.sample_chunks = std::numeric_limits<long>::max();
+				options.sample_chunks = std::numeric_limits<uint64_t>::max();
 				options.sample_chunk_size = STANDARD_VECTOR_SIZE;
 			} else if (sample_size <= STANDARD_VECTOR_SIZE) {
 				options.sample_chunk_size = sample_size;

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -5,6 +5,8 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/database.hpp"
 
+#include <limits>
+
 using namespace std;
 
 namespace duckdb {
@@ -46,7 +48,7 @@ static unique_ptr<FunctionData> read_csv_bind(ClientContext &context, vector<Val
 				throw BinderException("Unsupported parameter for SAMPLE_SIZE: cannot be smaller than 1");
 			}
 			if (sample_size == -1) {
-				options.sample_chunks = ULLONG_MAX;
+				options.sample_chunks = std::numeric_limits<long>::max();
 				options.sample_chunk_size = STANDARD_VECTOR_SIZE;
 			} else if (sample_size <= STANDARD_VECTOR_SIZE) {
 				options.sample_chunk_size = sample_size;

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -81,7 +81,6 @@ public:
 	Exception(ExceptionType exception_type, string message);
 
 	ExceptionType type;
-	string message_raw;
 
 public:
 	const char *what() const noexcept override;

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -81,6 +81,7 @@ public:
 	Exception(ExceptionType exception_type, string message);
 
 	ExceptionType type;
+	string message_raw;
 
 public:
 	const char *what() const noexcept override;

--- a/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
@@ -81,17 +81,22 @@ struct BufferedCSVReaderOptions {
 	//! True, if column with that index must skip null check
 	vector<bool> force_not_null;
 	//! Size of sample chunk used for dialect and type detection
-	idx_t sample_size = DEFAULT_SAMPLE_CHUNK_SIZE;
+	idx_t sample_chunk_size = DEFAULT_SAMPLE_CHUNK_SIZE;
 	//! Number of sample chunks used for type detection
-	idx_t num_samples = 10;
+	idx_t sample_chunks = 10;
+	//! If automatic type detection fails, recover and default to varchar types
+	bool fallback_to_all_varchar = false;
 	//! The date format to use (if any is specified)
 	std::map<LogicalTypeId, StrpTimeFormat> date_format = {{LogicalTypeId::DATE, {}}, {LogicalTypeId::TIMESTAMP, {}}};
 	//! Whether or not a type format is specified
 	std::map<LogicalTypeId, bool> has_format = {{LogicalTypeId::DATE, false}, {LogicalTypeId::TIMESTAMP, false}};
 
 	std::string toString() const {
-		return "delimiter=" + delimiter + ", quote=" + quote + ", escape=" + escape +
-		       ", header=" + (header ? "TRUE" : "FALSE");
+		return "delimiter='" + delimiter +
+			   "', quote='" + quote +
+		       "', escape='" + escape +
+		       "', header=" + (header ? "TRUE" : "FALSE") +
+			   "', auto_detect=" + (auto_detect ? "TRUE" : "FALSE");
 	}
 };
 
@@ -193,6 +198,8 @@ private:
 	void ConfigureSampling();
 	//! Prepare candidate sets for auto detection based on user input
 	void PrepareCandidateSets();
+	//! Generates error message with line info, column info and user guidance
+	ConversionException GenerateConversionException(Exception e_orig, idx_t col_idx);
 
 	//! Parses a CSV file with a one-byte delimiter, escape and quote character
 	void ParseSimpleCSV(DataChunk &insert_chunk);

--- a/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
@@ -183,8 +183,6 @@ private:
 	bool TryCastVector(Vector &parse_chunk_col, idx_t size, LogicalType sql_type);
 	//! Skips skip_rows, reads header row from input stream
 	void SkipRowsAndReadHeader(idx_t skip_rows, bool skip_header);
-	//! Extracts column names from header row
-	void GenerateColumnNames(DataChunk &header_row);
 	//! Jumps back to the beginning of input stream and resets necessary internal states
 	void JumpToBeginning(idx_t skip_rows, bool skip_header);
 	//! Jumps back to the beginning of input stream and resets necessary internal states

--- a/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
@@ -145,7 +145,7 @@ public:
 	bool linenr_estimated = false;
 
 	vector<idx_t> sniffed_column_counts;
-	int64_t sample_chunk_idx = -1;
+	idx_t sample_chunk_idx = 0;
 	bool jumping_samples = false;
 	bool end_of_file_reached = false;
 

--- a/test/sql/copy/csv/auto/test_auto_voter.test
+++ b/test/sql/copy/csv/auto/test_auto_voter.test
@@ -2,6 +2,8 @@
 # description: Test read_csv_auto from voter tsv
 # group: [auto]
 
+require vector_size 512
+
 statement ok
 CREATE TABLE voters AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/real/voter.tsv');
 

--- a/test/sql/copy/csv/auto/test_fallback_all_varchar.test
+++ b/test/sql/copy/csv/auto/test_fallback_all_varchar.test
@@ -1,0 +1,33 @@
+# name: test/sql/copy/csv/auto/test_sample_size.test
+# description: Test optional parameters for read csv
+# group: [auto]
+
+require vector_size 512
+
+# CSV file with irregularity in first column and default sample size
+statement error
+CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/test_fallback.csv');
+
+query IIII
+SELECT typeof(TestDoubleError), typeof(TestDouble), typeof(TestText), typeof(TestInteger) FROM test LIMIT 1
+----
+VARCHAR	DOUBLE	VARCHAR INTEGER
+
+statement ok
+DROP TABLE test
+
+# CSV file with irregularity in first column and small sample size
+statement error
+CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/test_fallback.csv', SAMPLE_CHUNKS=2, SAMPLE_CHUNK_SIZE=2);
+
+# CSV file with irregularity in first column, small sample size and fallback activated
+statement error
+CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/test_fallback.csv', SAMPLE_CHUNK_SIZE=2, SAMPLE_CHUNKS=2, FALLBACK_TO_ALL_VARCHAR=1);
+
+query IIII
+SELECT typeof(TestDoubleError), typeof(TestDouble), typeof(TestText), typeof(TestInteger) FROM test LIMIT 1
+----
+VARCHAR	VARCHAR	VARCHAR VARCHAR
+
+statement ok
+DROP TABLE test

--- a/test/sql/copy/csv/auto/test_fallback_all_varchar.test
+++ b/test/sql/copy/csv/auto/test_fallback_all_varchar.test
@@ -1,17 +1,17 @@
-# name: test/sql/copy/csv/auto/test_sample_size.test
+# name: test/sql/copy/csv/auto/test_fallback_all_varchar.test
 # description: Test optional parameters for read csv
 # group: [auto]
 
 require vector_size 512
 
 # CSV file with irregularity in first column and default sample size
-statement error
+statement ok
 CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/test_fallback.csv');
 
-query IIII
+query TTTT
 SELECT typeof(TestDoubleError), typeof(TestDouble), typeof(TestText), typeof(TestInteger) FROM test LIMIT 1
 ----
-VARCHAR	DOUBLE	VARCHAR INTEGER
+VARCHAR	DOUBLE	VARCHAR	INTEGER
 
 statement ok
 DROP TABLE test
@@ -21,13 +21,13 @@ statement error
 CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/test_fallback.csv', SAMPLE_CHUNKS=2, SAMPLE_CHUNK_SIZE=2);
 
 # CSV file with irregularity in first column, small sample size and fallback activated
-statement error
-CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/test_fallback.csv', SAMPLE_CHUNK_SIZE=2, SAMPLE_CHUNKS=2, FALLBACK_TO_ALL_VARCHAR=1);
+statement ok
+CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/test_fallback.csv', SAMPLE_CHUNK_SIZE=2, SAMPLE_CHUNKS=2, ALL_VARCHAR=1);
 
-query IIII
+query TTTT
 SELECT typeof(TestDoubleError), typeof(TestDouble), typeof(TestText), typeof(TestInteger) FROM test LIMIT 1
 ----
-VARCHAR	VARCHAR	VARCHAR VARCHAR
+VARCHAR	VARCHAR	VARCHAR	VARCHAR
 
 statement ok
 DROP TABLE test

--- a/test/sql/copy/csv/auto/test_sample_size.test
+++ b/test/sql/copy/csv/auto/test_sample_size.test
@@ -6,7 +6,7 @@ require vector_size 512
 
 # CSV file with very sparse column
 statement ok
-CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/issue_811.csv');
+CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/issue_811.csv', SAMPLE_SIZE=1024);
 
 query IIII
 SELECT typeof(TestInteger), typeof(TestDouble), typeof(TestDate), typeof(TestText) FROM test LIMIT 1

--- a/test/sql/copy/csv/auto/test_sample_size.test
+++ b/test/sql/copy/csv/auto/test_sample_size.test
@@ -16,6 +16,18 @@ INTEGER	VARCHAR	DATE	VARCHAR
 statement ok
 DROP TABLE test
 
+# CSV file with very sparse column
+statement ok
+CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/issue_811.csv', SAMPLE_SIZE=-1);
+
+query IIII
+SELECT typeof(TestInteger), typeof(TestDouble), typeof(TestDate), typeof(TestText) FROM test LIMIT 1
+----
+INTEGER	DOUBLE	DATE	VARCHAR
+
+statement ok
+DROP TABLE test
+
 # CSV file with very sparse column and sample size 500
 statement ok
 CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/issue_811.csv', SAMPLE_CHUNK_SIZE = 500);
@@ -73,4 +85,18 @@ CREATE TABLE test (TestInteger integer, TestDouble double, TestDate varchar, Tes
 
 # CSV file with very sparse column, automatically aligns column types, small sample size
 statement ok
-COPY test FROM 'test/sql/copy/csv/data/auto/issue_811.csv' (SAMPLE_CHUNK_SIZE 2, AUTO_DETECT TRUE);
+COPY test FROM 'test/sql/copy/csv/data/auto/issue_811.csv' (SAMPLE_CHUNK_SIZE 4, AUTO_DETECT TRUE);
+
+statement ok
+drop table test;
+
+# CSV file with very sparse column using copy into
+statement ok
+CREATE TABLE test (TestInteger integer, TestDouble double, TestDate varchar, TestText varchar);
+
+# CSV file with very sparse column, automatically aligns column types, small sample size
+statement ok
+COPY test FROM 'test/sql/copy/csv/data/auto/issue_811.csv' (SAMPLE_SIZE -1, AUTO_DETECT TRUE);
+
+statement ok
+drop table test;

--- a/test/sql/copy/csv/auto/test_sample_size.test
+++ b/test/sql/copy/csv/auto/test_sample_size.test
@@ -18,7 +18,7 @@ DROP TABLE test
 
 # CSV file with very sparse column and sample size 500
 statement ok
-CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/issue_811.csv', SAMPLE_SIZE = 500);
+CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/issue_811.csv', SAMPLE_CHUNK_SIZE = 500);
 
 query IRTT
 SELECT TestInteger, TestDouble, TestDate, TestText FROM test WHERE TestDouble is not NULL ;
@@ -35,7 +35,7 @@ drop table test;
 
 # CSV file with very sparse column and number of samples 50
 statement ok
-CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/issue_811.csv', NUM_SAMPLES = 50);
+CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/issue_811.csv', SAMPLE_CHUNKS = 50);
 
 query IRTT
 SELECT TestInteger, TestDouble, TestDate, TestText FROM test WHERE TestDouble is not NULL ;
@@ -52,7 +52,7 @@ drop table test;
 
 # CSV file with very sparse column with sample size 200 and number of samples 20
 statement ok
-CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/issue_811.csv', SAMPLE_SIZE = 200, NUM_SAMPLES = 20);
+CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/issue_811.csv', SAMPLE_CHUNK_SIZE = 200, SAMPLE_CHUNKS = 20);
 
 query IRTT
 SELECT TestInteger, TestDouble, TestDate, TestText FROM test WHERE TestDouble is not NULL ;
@@ -73,4 +73,4 @@ CREATE TABLE test (TestInteger integer, TestDouble double, TestDate varchar, Tes
 
 # CSV file with very sparse column, automatically aligns column types, small sample size
 statement ok
-COPY test FROM 'test/sql/copy/csv/data/auto/issue_811.csv' (SAMPLE_SIZE 2, AUTO_DETECT TRUE);
+COPY test FROM 'test/sql/copy/csv/data/auto/issue_811.csv' (SAMPLE_CHUNK_SIZE 2, AUTO_DETECT TRUE);

--- a/test/sql/copy/csv/auto/test_type_detection.test
+++ b/test/sql/copy/csv/auto/test_type_detection.test
@@ -6,7 +6,7 @@ require vector_size 512
 
 # a CSV file with many strings
 statement ok
-CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/large_mixed_data.csv');
+CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/large_mixed_data.csv', SAMPLE_CHUNKS=20);
 
 query ITR
 SELECT linenr, mixed_string, mixed_double FROM test LIMIT 3;

--- a/test/sql/copy/csv/data/auto/test_fallback.csv
+++ b/test/sql/copy/csv/data/auto/test_fallback.csv
@@ -1,0 +1,13 @@
+TestDoubleError,TestDouble,TestText,TestInteger
+1.1,1.1,c,1
+2,2.2,d,2
+1,3,e,3
+2,4,f,4
+1,5,g,5
+2,6,h,6
+1,7,i,7
+2,8,j,8
+1,9,k,9
+2.2.2,10,l,10
+1,11,m,11
+2,12,n,12

--- a/test/sql/copy/csv/glob/copy_csv_glob.test
+++ b/test/sql/copy/csv/glob/copy_csv_glob.test
@@ -7,7 +7,7 @@ CREATE TABLE dates(d DATE);
 
 # simple globbing
 statement ok
-COPY dates FROM 'test/sql/copy/csv/data/glob/a?/*.csv';
+COPY dates FROM 'test/sql/copy/csv/data/glob/a?/*.csv' (AUTO_DETECT 1);
 
 query I
 SELECT * FROM dates ORDER BY 1

--- a/test/sql/copy/csv/test_empty_quote.test
+++ b/test/sql/copy/csv/test_empty_quote.test
@@ -7,7 +7,7 @@ CREATE TABLE no_quote(a VARCHAR, b VARCHAR);
 
 # empty quote
 query I
-COPY no_quote FROM 'test/sql/copy/csv/data/no_quote.csv' (HEADER 1, QUOTE '', ESCAPE '');
+COPY no_quote FROM 'test/sql/copy/csv/data/no_quote.csv' (HEADER 1, QUOTE '', ESCAPE '', AUTO_DETECT 1);
 ----
 3
 


### PR DESCRIPTION
- Improved error messages
- Replaced user parameters SAMPLE_SIZE (now SAMPLE_CHUNK_SIZE) and SAMPLE_CHUNKS with single SAMPLE_SIZE parameter (with -1 magic parameter for full scan)
- Increased default SAMPLE_CHUNK_SIZE from 100 to STANDARD_VECTOR_SIZE
- Added ALL_VARCHAR parameter
- Added buffering of sample chunks during type detection to speedup parsing step 
- Cleanup of code

relates to https://github.com/cwida/duckdb/issues/1014