### PR TITLE
Optimizing expressions in grouping keys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.12)
 cmake_policy(SET CMP0026 NEW)
 cmake_policy(SET CMP0051 NEW)
 # if(APPLE) # needs to be before project() SET(CMAKE_CXX_FLAGS -stdlib=libc++)

--- a/examples/embedded-c++/CMakeLists.txt
+++ b/examples/embedded-c++/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.12)
 project(example-c++)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/examples/embedded-c/CMakeLists.txt
+++ b/examples/embedded-c/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.12)
 project(example-c)
 
 include_directories(../../src/include)

--- a/extension/icu/CMakeLists.txt
+++ b/extension/icu/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(ICUExtension)
 

--- a/extension/parquet/CMakeLists.txt
+++ b/extension/parquet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(ParquetExtension)
 

--- a/extension/tpch/CMakeLists.txt
+++ b/extension/tpch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(TPCHExtension)
 

--- a/extension/tpch/dbgen/CMakeLists.txt
+++ b/extension/tpch/dbgen/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(dbgen CXX C)
 

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -275,9 +275,7 @@ void JoinHashTable::Build(DataChunk &keys, DataChunk &payload) {
 			info.group_chunk.data[i].Reference(keys.data[i]);
 		}
 		info.payload_chunk.SetCardinality(keys);
-		for (idx_t i = 0; i < 2; i++) {
-			info.payload_chunk.data[i].Reference(keys.data[info.correlated_types.size()]);
-		}
+		info.payload_chunk.data[0].Reference(keys.data[info.correlated_types.size()]);
 		info.correlated_counts->AddChunk(info.group_chunk, info.payload_chunk);
 	}
 

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -27,8 +27,7 @@ PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<Logi
 	// get a list of all aggregates to be computed
 	// fake a single group with a constant value for aggregation without groups
 	if (this->groups.size() == 0) {
-		auto ce = make_unique<BoundConstantExpression>(Value::TINYINT(42));
-		this->groups.push_back(move(ce));
+		group_types.push_back(LogicalType::TINYINT);
 		is_implicit_aggr = true;
 	} else {
 		is_implicit_aggr = false;
@@ -47,14 +46,11 @@ PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<Logi
 			any_distinct = true;
 		}
 
-		aggregate_types.push_back(aggr.return_type);
+		aggregate_return_types.push_back(aggr.return_type);
 		if (aggr.children.size()) {
 			for (idx_t i = 0; i < aggr.children.size(); ++i) {
 				payload_types.push_back(aggr.children[i]->return_type);
 			}
-		} else {
-			// COUNT(*)
-			payload_types.push_back(LogicalType::BIGINT);
 		}
 		if (!aggr.function.combine) {
 			all_combinable = false;
@@ -92,43 +88,24 @@ public:
 
 class HashAggregateLocalState : public LocalSinkState {
 public:
-	HashAggregateLocalState(PhysicalHashAggregate &_op) : op(_op), group_executor(op.groups), is_empty(true) {
-		for (auto &aggr : op.bindings) {
-			if (aggr->children.size()) {
-				for (idx_t i = 0; i < aggr->children.size(); ++i) {
-					payload_executor.AddExpression(*aggr->children[i]);
-				}
-			}
-		}
-		group_chunk_template.Initialize(op.group_types);
+	HashAggregateLocalState(PhysicalHashAggregate &_op) : op(_op), is_empty(true) {
 		group_chunk.InitializeEmpty(op.group_types);
 		if (op.payload_types.size() > 0) {
-			payload_chunk_template.Initialize(op.payload_types);
-			payload_chunk.InitializeEmpty(op.payload_types);
+			aggregate_input_chunk.InitializeEmpty(op.payload_types);
+		}
+
+		// if there are no groups we create a fake group so everything has the same group
+		if (op.groups.size() == 0) {
+			group_chunk.data[0].Reference(Value::TINYINT(42));
 		}
 	}
 
 	PhysicalHashAggregate &op;
 
-	//! Expression executor for the GROUP BY chunk
-	ExpressionExecutor group_executor;
-	//! Expression state for the payload
-	ExpressionExecutor payload_executor;
-	//! Materialized GROUP BY expression
-	DataChunk group_chunk_template;
-	//! The payload chunk
-	DataChunk payload_chunk_template;
-	//! The aggregate HT
 	DataChunk group_chunk;
-
-	DataChunk payload_chunk;
-
+	DataChunk aggregate_input_chunk;
+	//! The aggregate HT
 	unique_ptr<PartitionableHashTable> ht;
-
-	void Reset() {
-		group_chunk.Reference(group_chunk_template);
-		payload_chunk.Reference(payload_chunk_template);
-	}
 
 	//! Whether or not any tuples were added to the HT
 	bool is_empty;
@@ -147,31 +124,31 @@ void PhysicalHashAggregate::Sink(ExecutionContext &context, GlobalOperatorState 
 	auto &llstate = (HashAggregateLocalState &)lstate;
 	auto &gstate = (HashAggregateGlobalState &)state;
 
-	llstate.Reset();
 	DataChunk &group_chunk = llstate.group_chunk;
-	DataChunk &payload_chunk = llstate.payload_chunk;
-	llstate.group_executor.Execute(input, group_chunk);
-	llstate.payload_executor.SetChunk(input);
+	DataChunk &aggregate_input_chunk = llstate.aggregate_input_chunk;
 
-	payload_chunk.Reset();
-	idx_t payload_idx = 0, payload_expr_idx = 0;
-	payload_chunk.SetCardinality(group_chunk);
+	for (idx_t group_idx = 0; group_idx < groups.size(); group_idx++) {
+		auto &group = groups[group_idx];
+		D_ASSERT(group->type == ExpressionType::BOUND_REF);
+		auto &bound_ref_expr = (BoundReferenceExpression &)*group;
+		group_chunk.data[group_idx].Reference(input.data[bound_ref_expr.index]);
+	}
+	idx_t aggregate_input_idx = 0;
 	for (idx_t i = 0; i < aggregates.size(); i++) {
 		auto &aggr = (BoundAggregateExpression &)*aggregates[i];
-		if (aggr.children.size()) {
-			for (idx_t j = 0; j < aggr.children.size(); ++j) {
-				llstate.payload_executor.ExecuteExpression(payload_expr_idx, payload_chunk.data[payload_idx]);
-				payload_idx++;
-				payload_expr_idx++;
-			}
-		} else {
-			payload_idx++;
+		for (auto &child_expr : aggr.children) {
+			D_ASSERT(child_expr->type == ExpressionType::BOUND_REF);
+			auto &bound_ref_expr = (BoundReferenceExpression &)*child_expr;
+			aggregate_input_chunk.data[aggregate_input_idx++].Reference(input.data[bound_ref_expr.index]);
 		}
 	}
 
+	group_chunk.SetCardinality(input.size());
+	aggregate_input_chunk.SetCardinality(input.size());
+
 	group_chunk.Verify();
-	payload_chunk.Verify();
-	D_ASSERT(payload_chunk.column_count() == 0 || group_chunk.size() == payload_chunk.size());
+	aggregate_input_chunk.Verify();
+	D_ASSERT(aggregate_input_chunk.column_count() == 0 || group_chunk.size() == aggregate_input_chunk.size());
 
 	// if we have non-combinable aggregates (e.g. string_agg) or any distinct aggregates we cannot keep parallel hash
 	// tables
@@ -184,7 +161,7 @@ void PhysicalHashAggregate::Sink(ExecutionContext &context, GlobalOperatorState 
 			                                           payload_types, bindings, HtEntryType::HT_WIDTH_64));
 		}
 		D_ASSERT(gstate.finalized_hts.size() == 1);
-		gstate.lossy_total_groups += gstate.finalized_hts[0]->AddChunk(group_chunk, payload_chunk);
+		gstate.lossy_total_groups += gstate.finalized_hts[0]->AddChunk(group_chunk, aggregate_input_chunk);
 		return;
 	}
 
@@ -200,8 +177,9 @@ void PhysicalHashAggregate::Sink(ExecutionContext &context, GlobalOperatorState 
 		                                                 gstate.partition_info, group_types, payload_types, bindings);
 	}
 
-	gstate.lossy_total_groups += llstate.ht->AddChunk(
-	    group_chunk, payload_chunk, gstate.lossy_total_groups > radix_limit && gstate.partition_info.n_partitions > 1);
+	gstate.lossy_total_groups +=
+	    llstate.ht->AddChunk(group_chunk, aggregate_input_chunk,
+	                         gstate.lossy_total_groups > radix_limit && gstate.partition_info.n_partitions > 1);
 }
 
 class PhysicalHashAggregateState : public PhysicalOperatorState {
@@ -437,7 +415,7 @@ void PhysicalHashAggregate::GetChunkInternal(ExecutionContext &context, DataChun
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalHashAggregate::GetOperatorState() {
-	return make_unique<PhysicalHashAggregateState>(*this, group_types, aggregate_types,
+	return make_unique<PhysicalHashAggregateState>(*this, group_types, aggregate_return_types,
 	                                               children.size() == 0 ? nullptr : children[0].get());
 }
 

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -73,16 +73,25 @@ unique_ptr<GlobalOperatorState> PhysicalHashJoin::GetGlobalState(ClientContext &
 			auto &info = state->hash_table->correlated_mark_join_info;
 
 			vector<LogicalType> payload_types;
-			vector<AggregateFunction> aggregate_functions = {CountStarFun::GetFunction(), CountFun::GetFunction()};
 			vector<BoundAggregateExpression *> correlated_aggregates;
-			for (idx_t i = 0; i < aggregate_functions.size(); ++i) {
-				vector<unique_ptr<Expression>> children;
-				auto aggr =
-				    AggregateFunction::BindAggregateFunction(context, aggregate_functions[i], move(children), false);
-				correlated_aggregates.push_back(&*aggr);
-				info.correlated_aggregates.push_back(move(aggr));
-				payload_types.push_back(aggregate_functions[i].return_type);
-			}
+			unique_ptr<BoundAggregateExpression> aggr;
+
+			// jury-rigging the GroupedAggregateHashTable
+			// we need a count_star and a count to get counts with and without NULLs
+			aggr = AggregateFunction::BindAggregateFunction(context, CountStarFun::GetFunction(), {}, false);
+			correlated_aggregates.push_back(&*aggr);
+			payload_types.push_back(aggr->return_type);
+			info.correlated_aggregates.push_back(move(aggr));
+
+			auto count_fun = CountFun::GetFunction();
+			vector<unique_ptr<Expression>> children;
+			// this is a dummy but we need it to make the hash table understand whats going on
+			children.push_back(make_unique_base<Expression, BoundReferenceExpression>(count_fun.return_type, 0));
+			aggr = AggregateFunction::BindAggregateFunction(context, count_fun, move(children), false);
+			correlated_aggregates.push_back(&*aggr);
+			payload_types.push_back(aggr->return_type);
+			info.correlated_aggregates.push_back(move(aggr));
+
 			info.correlated_counts = make_unique<GroupedAggregateHashTable>(
 			    BufferManager::GetBufferManager(context), delim_types, payload_types, correlated_aggregates);
 			info.correlated_types = delim_types;

--- a/src/execution/physical_plan/plan_aggregate.cpp
+++ b/src/execution/physical_plan/plan_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
+#include "duckdb/execution/operator/projection/physical_projection.hpp"
 
 namespace duckdb {
 using namespace std;
@@ -23,6 +24,9 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAggregate 
 	}
 
 	auto plan = CreatePlan(*op.children[0]);
+
+	plan = ExtractAggregateExpressions(move(plan), op.expressions, op.groups);
+
 	if (op.groups.size() == 0) {
 		// no groups, check if we can use a simple aggregation
 		// special case: aggregate entire columns together
@@ -50,6 +54,39 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAggregate 
 	}
 	groupby->children.push_back(move(plan));
 	return groupby;
+}
+
+unique_ptr<PhysicalOperator>
+PhysicalPlanGenerator::ExtractAggregateExpressions(unique_ptr<PhysicalOperator> child,
+                                                   vector<unique_ptr<Expression>> &aggregates,
+                                                   vector<unique_ptr<Expression>> &groups) {
+	vector<unique_ptr<Expression>> expressions;
+	vector<LogicalType> types;
+
+	for (idx_t group_idx = 0; group_idx < groups.size(); group_idx++) {
+		auto &group = groups[group_idx];
+		auto ref = make_unique<BoundReferenceExpression>(group->return_type, expressions.size());
+		types.push_back(group->return_type);
+		expressions.push_back(move(group));
+		groups[group_idx] = move(ref);
+	}
+
+	for (auto &aggr : aggregates) {
+		auto &bound_aggr = (BoundAggregateExpression &)*aggr;
+		for (idx_t child_idx = 0; child_idx < bound_aggr.children.size(); child_idx++) {
+			auto &child = bound_aggr.children[child_idx];
+			auto ref = make_unique<BoundReferenceExpression>(child->return_type, expressions.size());
+			types.push_back(child->return_type);
+			expressions.push_back(move(child));
+			bound_aggr.children[child_idx] = move(ref);
+		}
+	}
+	if (expressions.empty()) {
+		return child;
+	}
+	auto projection = make_unique<PhysicalProjection>(move(types), move(expressions));
+	projection->children.push_back(move(child));
+	return move(projection);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_distinct.cpp
+++ b/src/execution/physical_plan/plan_distinct.cpp
@@ -3,7 +3,6 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/function/aggregate/distributive_functions.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
-#include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_distinct.hpp"
 
@@ -62,6 +61,8 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreateDistinctOn(unique_ptr<
 			requires_projection = true;
 		}
 	}
+
+	child = ExtractAggregateExpressions(move(child), aggregates, groups);
 
 	// we add a physical hash aggregation in the plan to select the distinct groups
 	auto groupby = make_unique<PhysicalHashAggregate>(context, aggregate_types, move(aggregates), move(groups),

--- a/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
@@ -17,6 +17,22 @@ struct FunctionData;
 
 class AggregateExecutor {
 private:
+	template <class STATE_TYPE, class OP>
+	static inline void NullaryFlatLoop(STATE_TYPE **__restrict states, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			OP::template Operation<STATE_TYPE, OP>(states[i], i);
+		}
+	}
+
+	template <class STATE_TYPE, class OP>
+	static inline void NullaryScatterLoop(STATE_TYPE **__restrict states, const SelectionVector &ssel, idx_t count) {
+
+		for (idx_t i = 0; i < count; i++) {
+			auto sidx = ssel.get_index(i);
+			OP::template Operation<STATE_TYPE, OP>(states[sidx], sidx);
+		}
+	}
+
 	template <class STATE_TYPE, class INPUT_TYPE, class OP>
 	static inline void UnaryFlatLoop(INPUT_TYPE *__restrict idata, STATE_TYPE **__restrict states, nullmask_t &nullmask,
 	                                 idx_t count) {
@@ -131,6 +147,24 @@ private:
 	}
 
 public:
+	template <class STATE_TYPE, class OP> static void NullaryScatter(Vector &states, idx_t count) {
+		if (states.vector_type == VectorType::CONSTANT_VECTOR) {
+			auto sdata = ConstantVector::GetData<STATE_TYPE *>(states);
+			OP::template ConstantOperation<STATE_TYPE, OP>(*sdata, count);
+		} else if (states.vector_type == VectorType::FLAT_VECTOR) {
+			auto sdata = FlatVector::GetData<STATE_TYPE *>(states);
+			NullaryFlatLoop<STATE_TYPE, OP>(sdata, count);
+		} else {
+			VectorData sdata;
+			states.Orrify(count, sdata);
+			NullaryScatterLoop<STATE_TYPE, OP>((STATE_TYPE **)sdata.data, *sdata.sel, count);
+		}
+	}
+
+	template <class STATE_TYPE, class OP> static void NullaryUpdate(data_ptr_t state, idx_t count) {
+		OP::template ConstantOperation<STATE_TYPE, OP>((STATE_TYPE *)state, count);
+	}
+
 	template <class STATE_TYPE, class INPUT_TYPE, class OP>
 	static void UnaryScatter(Vector &input, Vector &states, idx_t count) {
 		if (input.vector_type == VectorType::CONSTANT_VECTOR && states.vector_type == VectorType::CONSTANT_VECTOR) {

--- a/src/include/duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp
@@ -43,7 +43,7 @@ public:
 	//! The payload types
 	vector<LogicalType> payload_types;
 	//! The aggregate return types
-	vector<LogicalType> aggregate_types;
+	vector<LogicalType> aggregate_return_types;
 
 	//! Pointers to the aggregates
 	vector<BoundAggregateExpression *> bindings;

--- a/src/include/duckdb/execution/physical_plan_generator.hpp
+++ b/src/include/duckdb/execution/physical_plan_generator.hpp
@@ -78,6 +78,10 @@ protected:
 	unique_ptr<PhysicalOperator> CreateDistinctOn(unique_ptr<PhysicalOperator> child,
 	                                              vector<unique_ptr<Expression>> distinct_targets);
 
+	unique_ptr<PhysicalOperator> ExtractAggregateExpressions(unique_ptr<PhysicalOperator> child,
+	                                                         vector<unique_ptr<Expression>> &expressions,
+	                                                         vector<unique_ptr<Expression>> &groups);
+
 private:
 	ClientContext &context;
 };

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -97,6 +97,14 @@ public:
 	                                                                  bool is_distinct = false);
 
 public:
+	template <class STATE, class RESULT_TYPE, class OP>
+	static AggregateFunction NullaryAggregate(LogicalType return_type) {
+		return AggregateFunction(
+		    {}, return_type, AggregateFunction::StateSize<STATE>, AggregateFunction::StateInitialize<STATE, OP>,
+		    AggregateFunction::NullaryScatterUpdate<STATE, OP>, AggregateFunction::StateCombine<STATE, OP>,
+		    AggregateFunction::StateFinalize<STATE, RESULT_TYPE, OP>, AggregateFunction::NullaryUpdate<STATE, OP>);
+	}
+
 	template <class STATE, class INPUT_TYPE, class RESULT_TYPE, class OP>
 	static AggregateFunction UnaryAggregate(LogicalType input_type, LogicalType return_type) {
 		return AggregateFunction(
@@ -130,6 +138,18 @@ public:
 
 	template <class STATE, class OP> static void StateInitialize(data_ptr_t state) {
 		OP::Initialize((STATE *)state);
+	}
+
+	template <class STATE, class OP>
+	static void NullaryScatterUpdate(Vector inputs[], idx_t input_count, Vector &states, idx_t count) {
+		D_ASSERT(input_count == 0);
+		AggregateExecutor::NullaryScatter<STATE, OP>(states, count);
+	}
+
+	template <class STATE, class OP>
+	static void NullaryUpdate(Vector inputs[], idx_t input_count, data_ptr_t state, idx_t count) {
+		D_ASSERT(input_count == 0);
+		AggregateExecutor::NullaryUpdate<STATE, OP>(state, count);
 	}
 
 	template <class STATE, class T, class OP>

--- a/src/include/duckdb/planner/query_node/bound_select_node.hpp
+++ b/src/include/duckdb/planner/query_node/bound_select_node.hpp
@@ -44,6 +44,8 @@ public:
 
 	//! Group index used by the LogicalAggregate (only used if HasAggregation is true)
 	idx_t group_index;
+	//! Table index for the projection child of the group op
+	idx_t group_projection_index;
 	//! Aggregate index used by the LogicalAggregate (only used if HasAggregation is true)
 	idx_t aggregate_index;
 	//! Aggregate functions to compute (only used if HasAggregation is true)

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -42,7 +42,7 @@ unique_ptr<LogicalOperator> Optimizer::Optimize(unique_ptr<LogicalOperator> plan
 	// first we perform expression rewrites using the ExpressionRewriter
 	// this does not change the logical plan structure, but only simplifies the expression trees
 	context.profiler.StartPhase("expression_rewriter");
-	rewriter.Apply(*plan);
+	rewriter.VisitOperator(*plan);
 	context.profiler.EndPhase();
 
 	// perform filter pushdown

--- a/src/optimizer/pushdown/pushdown_left_join.cpp
+++ b/src/optimizer/pushdown/pushdown_left_join.cpp
@@ -39,7 +39,7 @@ static bool FilterRemovesNull(ExpressionRewriter &rewriter, Expression *expr, un
 	// attempt to flatten the expression by running the expression rewriter on it
 	auto filter = make_unique<LogicalFilter>();
 	filter->expressions.push_back(move(copy));
-	rewriter.Apply(*filter);
+	rewriter.VisitOperator(*filter);
 
 	// check if all expressions are foldable
 	for (idx_t i = 0; i < filter->expressions.size(); i++) {

--- a/src/parser/transform/expression/transform_function.cpp
+++ b/src/parser/transform/expression/transform_function.cpp
@@ -63,9 +63,11 @@ void Transformer::TransformWindowDef(PGWindowDef *window_spec, WindowExpression 
 		expr->start = WindowBoundary::EXPR_PRECEDING;
 	} else if (window_spec->frameOptions & FRAMEOPTION_START_VALUE_FOLLOWING) {
 		expr->start = WindowBoundary::EXPR_FOLLOWING;
-	} else if ((window_spec->frameOptions & FRAMEOPTION_START_CURRENT_ROW) && (window_spec->frameOptions & FRAMEOPTION_RANGE)) {
+	} else if ((window_spec->frameOptions & FRAMEOPTION_START_CURRENT_ROW) &&
+	           (window_spec->frameOptions & FRAMEOPTION_RANGE)) {
 		expr->start = WindowBoundary::CURRENT_ROW_RANGE;
-	} else if ((window_spec->frameOptions & FRAMEOPTION_START_CURRENT_ROW) && (window_spec->frameOptions & FRAMEOPTION_ROWS)) {
+	} else if ((window_spec->frameOptions & FRAMEOPTION_START_CURRENT_ROW) &&
+	           (window_spec->frameOptions & FRAMEOPTION_ROWS)) {
 		expr->start = WindowBoundary::CURRENT_ROW_ROWS;
 	}
 
@@ -77,9 +79,11 @@ void Transformer::TransformWindowDef(PGWindowDef *window_spec, WindowExpression 
 		expr->end = WindowBoundary::EXPR_PRECEDING;
 	} else if (window_spec->frameOptions & FRAMEOPTION_END_VALUE_FOLLOWING) {
 		expr->end = WindowBoundary::EXPR_FOLLOWING;
-	} else if ((window_spec->frameOptions & FRAMEOPTION_END_CURRENT_ROW) && (window_spec->frameOptions & FRAMEOPTION_RANGE)) {
+	} else if ((window_spec->frameOptions & FRAMEOPTION_END_CURRENT_ROW) &&
+	           (window_spec->frameOptions & FRAMEOPTION_RANGE)) {
 		expr->end = WindowBoundary::CURRENT_ROW_RANGE;
-	} else if ((window_spec->frameOptions & FRAMEOPTION_END_CURRENT_ROW) && (window_spec->frameOptions & FRAMEOPTION_ROWS)) {
+	} else if ((window_spec->frameOptions & FRAMEOPTION_END_CURRENT_ROW) &&
+	           (window_spec->frameOptions & FRAMEOPTION_ROWS)) {
 		expr->end = WindowBoundary::CURRENT_ROW_ROWS;
 	}
 
@@ -173,6 +177,11 @@ unique_ptr<ParsedExpression> Transformer::TransformFuncCall(PGFuncCall *root) {
 			auto child_expr = TransformExpression((PGNode *)node->data.ptr_value);
 			children.push_back(move(child_expr));
 		}
+	}
+
+	// star gets eaten in the parser
+	if (lowercase_name == "count" && children.size() == 0) {
+		lowercase_name = "count_star";
 	}
 
 	if (lowercase_name == "if") {

--- a/test/optimizer/grouping_expression_simplification.test
+++ b/test/optimizer/grouping_expression_simplification.test
@@ -1,0 +1,17 @@
+# name: test/optimizer/grouping_expression_simplification.test
+# description: Make sure expressions are optimized in the groups too
+# group: [optimizer]
+
+statement ok
+CREATE TABLE test(t timestamp);
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
+query I nosort year
+EXPLAIN SELECT COUNT(*) FROM test GROUP BY EXTRACT(year from t)
+----
+
+query I nosort year
+EXPLAIN SELECT COUNT(*) FROM test GROUP BY YEAR(t)
+----

--- a/test/sql/function/string/test_string_split.test_slow
+++ b/test/sql/function/string/test_string_split.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/function/string/test_string_split.test
+# name: test/sql/function/string/test_string_split.test_slow
 # description: String split test
 # group: [string]
 

--- a/test/sql/types/string/test_scan_big_varchar.test_slow
+++ b/test/sql/types/string/test_scan_big_varchar.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/types/string/test_scan_big_varchar.test
+# name: test/sql/types/string/test_scan_big_varchar.test_slow
 # description: Test scanning many big varchar strings with limited memory
 # group: [string]
 

--- a/third_party/dsdgen/CMakeLists.txt
+++ b/third_party/dsdgen/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(dsdgen CXX)
 cmake_policy(SET CMP0063 NEW)

--- a/third_party/imdb/CMakeLists.txt
+++ b/third_party/imdb/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(imdb CXX)
 cmake_policy(SET CMP0063 NEW)

--- a/third_party/libpg_query/CMakeLists.txt
+++ b/third_party/libpg_query/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(pg_query CXX C)
 cmake_policy(SET CMP0063 NEW)

--- a/third_party/tpce-tool/CMakeLists.txt
+++ b/third_party/tpce-tool/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(tpce CXX C)
 


### PR DESCRIPTION
This PR fixes a bug where expressions in `GROUP BY` keys would not be optimised before and are now. This addresses a performance issue discovered while looking at #1121. The PR also changes the physical hash aggregate operator so it no longer executes those expressions itself. Rather, a projection is created in the physical planner. Finally, we introduce a "Nullary" aggregate without any input (e..g `COUNT(*)` and `COUNT()`) which simplifies the aggregate hash table in that we don't have to create dummy input for those operators any more. 