### PR TITLE
Add support for (NOT) ILIKE, and optimize certain types of LIKE expressions

### DIFF
--- a/src/common/types/hugeint.cpp
+++ b/src/common/types/hugeint.cpp
@@ -163,7 +163,6 @@ bool Hugeint::TryMultiply(hugeint_t lhs, hugeint_t rhs, hugeint_t &result) {
 		return false;
 	}
 	uint64_t upper = uint64_t(result_i128 >> 64);
-	;
 	if (upper & 0x8000000000000000) {
 		return false;
 	}

--- a/src/function/scalar/string/contains.cpp
+++ b/src/function/scalar/string/contains.cpp
@@ -98,15 +98,8 @@ idx_t ContainsGeneric(const unsigned char *haystack, idx_t haystack_size, const 
 	}
 }
 
-idx_t ContainsFun::Find(const string_t &haystack_s, const string_t &needle_s) {
-	auto haystack      = (const unsigned char*) haystack_s.GetDataUnsafe();
-	auto haystack_size = haystack_s.GetSize();
-	auto needle        = (const unsigned char*) needle_s.GetDataUnsafe();
-	auto needle_size   = needle_s.GetSize();
-	if (needle_size == 0) {
-		// empty needle: always true
-		return 0;
-	}
+idx_t ContainsFun::Find(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle, idx_t needle_size) {
+	D_ASSERT(needle_size > 0);
 	// start off by performing a memchr to find the first character of the
 	auto location = memchr(haystack, needle[0], haystack_size);
 	if (location == nullptr) {
@@ -136,6 +129,18 @@ idx_t ContainsFun::Find(const string_t &haystack_s, const string_t &needle_s) {
 	default:
 		return ContainsGeneric(haystack, haystack_size, needle, needle_size, base_offset);
 	}
+}
+
+idx_t ContainsFun::Find(const string_t &haystack_s, const string_t &needle_s) {
+	auto haystack      = (const unsigned char*) haystack_s.GetDataUnsafe();
+	auto haystack_size = haystack_s.GetSize();
+	auto needle        = (const unsigned char*) needle_s.GetDataUnsafe();
+	auto needle_size   = needle_s.GetSize();
+	if (needle_size == 0) {
+		// empty needle: always true
+		return 0;
+	}
+	return ContainsFun::Find(haystack, haystack_size, needle, needle_size);
 }
 
 struct ContainsOperator {

--- a/src/function/scalar/string/like.cpp
+++ b/src/function/scalar/string/like.cpp
@@ -182,7 +182,7 @@ private:
 static unique_ptr<FunctionData> like_bind_function(ClientContext &context, ScalarFunction &bound_function, vector<unique_ptr<Expression>> &arguments) {
 	// pattern is the second argument. If its constant, we can already prepare the pattern and store it for later.
 	D_ASSERT(arguments.size() == 2 || arguments.size() == 3);
-	if (arguments[1]->IsScalar()) {
+	if (arguments[1]->IsFoldable()) {
 		Value pattern_str = ExpressionExecutor::EvaluateScalar(*arguments[1]);
 		return LikeMatcher::CreateLikeMatcher(pattern_str.ToString());
 	}

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -114,7 +114,7 @@ static unique_ptr<FunctionData> regexp_matches_get_bind_function(ClientContext &
 	RE2::Options options;
 	options.set_log_errors(false);
 	if (arguments.size() == 3) {
-		if (!arguments[2]->IsScalar()) {
+		if (!arguments[2]->IsFoldable()) {
 			throw InvalidInputException("Regex options field must be a constant");
 		}
 		Value options_str = ExpressionExecutor::EvaluateScalar(*arguments[2]);
@@ -123,7 +123,7 @@ static unique_ptr<FunctionData> regexp_matches_get_bind_function(ClientContext &
 		}
 	}
 
-	if (arguments[1]->IsScalar()) {
+	if (arguments[1]->IsFoldable()) {
 		Value pattern_str = ExpressionExecutor::EvaluateScalar(*arguments[1]);
 		if (!pattern_str.is_null && pattern_str.type().id() == LogicalTypeId::VARCHAR) {
 			auto re = make_unique<RE2>(pattern_str.str_value, options);
@@ -172,7 +172,7 @@ static unique_ptr<FunctionData> regexp_replace_bind_function(ClientContext &cont
 	auto data = make_unique<RegexpReplaceBindData>();
 	data->options.set_log_errors(false);
 	if (arguments.size() == 4) {
-		if (!arguments[3]->IsScalar()) {
+		if (!arguments[3]->IsFoldable()) {
 			throw InvalidInputException("Regex options field must be a constant");
 		}
 		Value options_str = ExpressionExecutor::EvaluateScalar(*arguments[3]);

--- a/src/include/duckdb/function/scalar/string_functions.hpp
+++ b/src/include/duckdb/function/scalar/string_functions.hpp
@@ -22,11 +22,20 @@ struct ReverseFun {
 };
 
 struct LowerFun {
+	static uint8_t ASCIIToLowerMap[];
+
+	//! Returns the length of the result string obtained from lowercasing the given input (in bytes)
+	static idx_t LowerLength(const char *input_data, idx_t input_length);
+	//! Lowercases the string to the target output location, result_data must have space for at least LowerLength bytes
+	static void LowerCase(const char *input_data, idx_t input_length, char *result_data);
+
 	static ScalarFunction GetFunction();
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
 struct UpperFun {
+	static uint8_t ASCIIToUpperMap[];
+
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 

--- a/src/include/duckdb/function/scalar/string_functions.hpp
+++ b/src/include/duckdb/function/scalar/string_functions.hpp
@@ -150,6 +150,7 @@ struct ContainsFun {
 	static ScalarFunction GetFunction();
 	static void RegisterFunction(BuiltinFunctions &set);
 	static idx_t Find(const string_t &haystack, const string_t &needle);
+	static idx_t Find(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle, idx_t needle_size);
 };
 
 struct UnicodeFun {

--- a/test/sql/function/string/test_ilike.test
+++ b/test/sql/function/string/test_ilike.test
@@ -1,0 +1,136 @@
+# name: test/sql/function/string/test_ilike.test
+# description: Test ILIKE statement
+# group: [string]
+
+statement ok
+PRAGMA enable_verification
+
+# scalar like
+query T
+SELECT 'aaa' ILIKE 'bbb'
+----
+0
+
+query T
+SELECT 'aaa' ILIKE 'aAa'
+----
+1
+
+query T
+SELECT 'aaa' ILIKE '%'
+----
+1
+
+query T
+SELECT 'aaa' ILIKE '%A'
+----
+1
+
+query T
+SELECT 'aaa' ILIKE '%b'
+----
+0
+
+query T
+SELECT 'aaa' ILIKE 'A%'
+----
+1
+
+query T
+SELECT 'aaa' ILIKE 'b%'
+----
+0
+
+query T
+SELECT 'aaa' ILIKE 'A_a'
+----
+1
+
+query T
+SELECT 'aaa' ILIKE 'a_'
+----
+0
+
+query T
+SELECT 'aaa' ILIKE '__%'
+----
+1
+
+query T
+SELECT 'aaa' ILIKE '____%'
+----
+0
+
+query T
+SELECT 'ababac' ILIKE '%abac'
+----
+1
+
+query T
+SELECT 'ababac' ILIKE '%%%aBac'
+----
+1
+
+query T
+SELECT 'ababac' ILIKE 'abab%%%%%'
+----
+1
+
+query T
+SELECT 'ababac' ILIKE '%%%a%%%b%%a%b%%%%%a%c%%'
+----
+1
+
+query T
+SELECT 'ababac' ILIKE '%%%a%%%b%%a%b%%%%%a%d%%'
+----
+0
+
+query T
+SELECT 'ababac' NOT ILIKE '%Abac'
+----
+0
+
+# like with table
+statement ok
+CREATE TABLE strings(s STRING, pat STRING);
+
+statement ok
+INSERT INTO strings VALUES ('abab', 'Ab%'), ('aaa', 'A_a'), ('aaa', '%b%')
+
+query T
+SELECT s FROM strings WHERE s LIKE 'ab%'
+----
+abab
+
+query T
+SELECT s FROM strings WHERE 'aba' ILIKE pat
+----
+abab
+aaa
+aaa
+
+query T
+SELECT s FROM strings WHERE s ILIKE pat
+----
+abab
+aaa
+
+# unicode
+query T
+SELECT 'MÜHLEISEN' ILIKE 'mühleisen'
+----
+1
+
+
+statement ok
+CREATE TABLE unicode_strings(s STRING, pat STRING);
+
+statement ok
+INSERT INTO unicode_strings VALUES ('öäb', 'Ö%B'), ('aaÄ', 'A_ä'), ('aaa', '%b%')
+
+query T
+SELECT s FROM unicode_strings WHERE s ILIKE pat
+----
+öäb
+aaÄ

--- a/test/sql/function/string/test_like.test
+++ b/test/sql/function/string/test_like.test
@@ -12,6 +12,11 @@ SELECT 'aaa' LIKE 'bbb'
 0
 
 query T
+SELECT 'aaa' LIKE 'abab'
+----
+0
+
+query T
 SELECT 'aaa' LIKE 'aaa'
 ----
 1
@@ -90,6 +95,171 @@ query T
 SELECT 'ababac' NOT LIKE '%abac'
 ----
 0
+
+query T
+SELECT 'aabbccc' LIKE '%aa%bb%cc'
+----
+1
+
+query T
+SELECT 'zebra elephant tiger horse' LIKE ''
+----
+0
+
+query T
+SELECT 'zebra elephant tiger horse' LIKE '%'
+----
+1
+
+query T
+SELECT 'zebra elephant tiger horse' LIKE 'zebra'
+----
+0
+
+query T
+SELECT 'zebra elephant tiger horse' LIKE 'zebra elephant tiger horse'
+----
+1
+
+query T
+SELECT 'zebra elephant tiger horse' LIKE 'zebra elephant tiger horse%'
+----
+1
+
+query T
+SELECT 'zebra elephant tiger horse' LIKE '%zebra elephant tiger horse%'
+----
+1
+
+query T
+SELECT 'zebra elephant tiger horse' LIKE '%zebra elephant tiger horse blabla'
+----
+0
+
+query T
+SELECT 'zebra elephant tiger horse' LIKE 'zebra elephant tiger horse blabla%'
+----
+0
+
+query T
+SELECT 'zebra elephant tiger horse' LIKE 'zebra%'
+----
+1
+
+query T
+SELECT 'zebra elephant tiger horse' LIKE '%horse'
+----
+1
+
+query T
+SELECT 'zebra elephant tiger horse' LIKE 'zebra%elephant%horse'
+----
+1
+
+query T
+SELECT 'zebra elephant tiger horse' LIKE 'zebra%elephant%tiger%horse'
+----
+1
+
+query T
+SELECT 'zebra elephant tiger horse' LIKE '%zebra%elephant%tiger%horse'
+----
+1
+
+query T
+SELECT 'zebra elephant tiger horse' LIKE 'zebra%elephant%tiger%horse%'
+----
+1
+
+query T
+SELECT 'zebra elephant tiger horse' LIKE '%zebra%elephant%tiger%horse%'
+----
+1
+
+query T
+SELECT 'zebra elephant tiger horse' LIKE '%%zebra %%%ele%phan%t t%ig%er% horse%'
+----
+1
+
+query T
+SELECT 'zebra elephant tiger horse' LIKE 'zebra%tiger%horse'
+----
+1
+
+query T
+SELECT 'zebra elephant tiger horse' LIKE 'zebra%tiger%elephant%horse'
+----
+0
+
+query T
+SELECT 'zebra elephant tiger horse' NOT LIKE ''
+----
+1
+
+query T
+SELECT 'zebra elephant tiger horse' NOT LIKE '%'
+----
+0
+
+query T
+SELECT 'zebra elephant tiger horse' NOT LIKE 'zebra'
+----
+1
+
+query T
+SELECT 'zebra elephant tiger horse' NOT LIKE 'zebra elephant tiger horse'
+----
+0
+
+query T
+SELECT 'zebra elephant tiger horse' NOT LIKE 'zebra%'
+----
+0
+
+query T
+SELECT 'zebra elephant tiger horse' NOT LIKE '%horse'
+----
+0
+
+query T
+SELECT 'zebra elephant tiger horse' NOT LIKE 'zebra%elephant%horse'
+----
+0
+
+query T
+SELECT 'zebra elephant tiger horse' NOT LIKE 'zebra%elephant%tiger%horse'
+----
+0
+
+query T
+SELECT 'zebra elephant tiger horse' NOT LIKE '%zebra%elephant%tiger%horse'
+----
+0
+
+query T
+SELECT 'zebra elephant tiger horse' NOT LIKE 'zebra%elephant%tiger%horse%'
+----
+0
+
+query T
+SELECT 'zebra elephant tiger horse' NOT LIKE '%zebra%elephant%tiger%horse%'
+----
+0
+
+query T
+SELECT 'zebra elephant tiger horse' NOT LIKE '%%zebra %%%ele%phan%t t%ig%er% horse%'
+----
+0
+
+query T
+SELECT 'zebra elephant tiger horse' NOT LIKE 'zebra%tiger%horse'
+----
+0
+
+query T
+SELECT 'zebra elephant tiger horse' NOT LIKE 'zebra%tiger%elephant%horse'
+----
+1
 
 # like with table
 statement ok


### PR DESCRIPTION
* Implement (NOT) ILIKE, the unicode version uses lower() on both the haystack and the needle and then runs the regular like code
* There is an optimized ASCII-only version, that directly runs the like code while looking up the matching lowercase character for every character in the map
* We also implement an optimized LIKE matcher for like expressions that allow for greedy consumption, i.e. expressions that don't have any underscores (e.g. `%X%Y%Z`)