### PR TITLE
test_sqllogictest: Fix typos in comment from upstream

### DIFF
--- a/test/sqlite/test_sqllogictest.cpp
+++ b/test/sqlite/test_sqllogictest.cpp
@@ -1074,13 +1074,13 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 			int bMatch;
 			/* The "skipif" and "onlyif" modifiers allow skipping or using
 			** statement or query record for a particular database engine.
-			** In this way, SQL features implmented by a majority of the
+			** In this way, SQL features implemented by a majority of the
 			** engines can be tested without causing spurious errors for
 			** engines that don't support it.
 			**
-			** Once this record is encountered, an the current selected
+			** Once this record is encountered, and the current selected
 			** db interface matches the db engine specified in the record,
-			** the we skip this rest of this record for "skipif" or for
+			** then we skip this rest of this record for "skipif". For
 			** "onlyif" we skip the record if the record does not match.
 			*/
 			bMatch = stricmp(sScript.azToken[1], zDbEngine) == 0;


### PR DESCRIPTION
This comment had typos, and was also very confusing. Split a long
sentence into two to help clarify. These typos exist in the upstream
sqllogictest. Unfortunately, the SQLite project does not accept
contributions, so I can't fix it there.

Feel free to close this without accepting it: I understand if you don't want to diverge from the original upstream version too much. However, I have found that DuckDB's test suite seems to be excellent since it is mostly just "plain SQL", so it can be used with systems that are not DuckDB. At this point, I figure you might as well improve this tool yourselves. As I continue to play with it, I'll be sure to try and push relevant changes back to DuckDB, since I think even just having a high quality, open source, SQL test suite would be an enormous benefit to the database industry.

Thanks!