### PR TITLE
Common Aggregate Optimizer

### DIFF
--- a/benchmark/tpch/aggregate/q1_integer_keys.benchmark
+++ b/benchmark/tpch/aggregate/q1_integer_keys.benchmark
@@ -39,7 +39,28 @@ SELECT l_orderkey,
 FROM lineitem_normal;
 
 run
-PRAGMA tpch(1);
+SELECT
+    l_returnflag,
+    l_linestatus,
+    sum(l_quantity) AS sum_qty,
+    sum(l_extendedprice) AS sum_base_price,
+    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
+    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+    sum(l_quantity) / count(l_quantity) AS avg_qty,
+    sum(l_extendedprice) / count(l_extendedprice) AS avg_price,
+    sum(l_discount) / count(l_discount) AS avg_disc,
+    count(*) AS count_order
+FROM
+    lineitem
+WHERE
+    l_shipdate <= CAST('1998-09-02' AS date)
+GROUP BY
+    l_returnflag,
+    l_linestatus
+ORDER BY
+    l_returnflag,
+    l_linestatus;
+
 
 result IIIIIIIIII
 0	0	37734107	56586554400.73	53758257134.8700	55909065222.827692	25.5220	38273.1297	0.0500	1478493

--- a/benchmark/tpch/aggregate/q1_integer_keys.benchmark
+++ b/benchmark/tpch/aggregate/q1_integer_keys.benchmark
@@ -46,9 +46,9 @@ SELECT
     sum(l_extendedprice) AS sum_base_price,
     sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
     sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-    sum(l_quantity) / count(l_quantity) AS avg_qty,
-    sum(l_extendedprice) / count(l_extendedprice) AS avg_price,
-    sum(l_discount) / count(l_discount) AS avg_disc,
+    sum(l_quantity)::DOUBLE / count(l_quantity)::DOUBLE AS avg_qty,
+    sum(l_extendedprice)::DOUBLE / count(l_extendedprice)::DOUBLE AS avg_price,
+    sum(l_discount)::DOUBLE / count(l_discount)::DOUBLE AS avg_disc,
     count(*) AS count_order
 FROM
     lineitem

--- a/src/execution/operator/aggregate/physical_simple_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_simple_aggregate.cpp
@@ -179,4 +179,15 @@ void PhysicalSimpleAggregate::GetChunkInternal(ExecutionContext &context, DataCh
 	state->finished = true;
 }
 
+string PhysicalSimpleAggregate::ParamsToString() const {
+	string result;
+	for (idx_t i = 0; i < aggregates.size(); i++) {
+		if (i > 0) {
+			result += "\n";
+		}
+		result += aggregates[i]->GetName();
+	}
+	return result;
+}
+
 } // namespace duckdb

--- a/src/execution/operator/persistent/buffered_csv_reader.cpp
+++ b/src/execution/operator/persistent/buffered_csv_reader.cpp
@@ -259,6 +259,9 @@ bool BufferedCSVReader::JumpToNextSample() {
 	// get bytes contained in the previously read chunk
 	idx_t remaining_bytes_in_buffer = buffer_size - start;
 	bytes_in_chunk -= remaining_bytes_in_buffer;
+	if (remaining_bytes_in_buffer == 0) {
+		return false;
+	}
 
 	// assess if it makes sense to jump, based on size of the first chunk relative to size of the entire file
 	if (sample_chunk_idx == 0) {

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -64,6 +64,7 @@ unique_ptr<BaseStatistics> count_propagate_stats(ClientContext &context, BoundAg
 	if (child_stats[0] && !child_stats[0]->has_null && !expr.distinct) {
 		// count on a column without null values: use count star
 		expr.function = CountStarFun::GetFunction();
+		expr.function.name = "count_star";
 		expr.children.clear();
 	}
 	return nullptr;

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
+#include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/aggregate_function.hpp"
@@ -116,6 +117,14 @@ void BuiltinFunctions::AddFunction(TableFunctionSet set) {
 void BuiltinFunctions::AddFunction(CopyFunction function) {
 	CreateCopyFunctionInfo info(function);
 	catalog.CreateCopyFunction(context, &info);
+}
+
+hash_t BaseScalarFunction::Hash() const {
+	hash_t hash = return_type.Hash();
+	for(auto &arg : arguments) {
+		duckdb::CombineHash(hash, arg.Hash());
+	}
+	return hash;
 }
 
 string Function::CallToString(string name, vector<LogicalType> arguments) {

--- a/src/include/duckdb/execution/operator/aggregate/physical_simple_aggregate.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_simple_aggregate.hpp
@@ -32,6 +32,8 @@ public:
 	unique_ptr<GlobalOperatorState> GetGlobalState(ClientContext &context) override;
 
 	void GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;
+
+	string ParamsToString() const override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -127,7 +127,7 @@ public:
 		return Function::CallToString(name, arguments);
 	}
 
-	bool HasVarArgs() {
+	bool HasVarArgs() const {
 		return varargs.id() != LogicalTypeId::INVALID;
 	}
 };
@@ -174,6 +174,8 @@ public:
 	bool has_side_effects;
 
 public:
+	hash_t Hash() const;
+
 	//! Cast a set of expressions to the arguments of this function
 	void CastToFunctionArguments(vector<unique_ptr<Expression>> &children);
 

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -71,7 +71,7 @@ public:
 	                                                              bool is_operator = false);
 
 	bool operator==(const ScalarFunction &rhs) const {
-		return CompareScalarFunctionT(rhs.function) && bind == rhs.bind && dependency == rhs.dependency;
+		return CompareScalarFunctionT(rhs.function) && bind == rhs.bind && dependency == rhs.dependency && statistics == rhs.statistics;
 	}
 	bool operator!=(const ScalarFunction &rhs) const {
 		return !(*this == rhs);

--- a/src/include/duckdb/optimizer/common_aggregate_optimizer.hpp
+++ b/src/include/duckdb/optimizer/common_aggregate_optimizer.hpp
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/common_aggregate_optimizer.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/planner/logical_operator_visitor.hpp"
+#include "duckdb/planner/column_binding_map.hpp"
+
+namespace duckdb {
+//! The CommonAggregateOptimizer optimizer eliminates duplicate aggregates from aggregate nodes
+class CommonAggregateOptimizer : public LogicalOperatorVisitor {
+public:
+	void VisitOperator(LogicalOperator &op) override;
+
+private:
+	unique_ptr<Expression> VisitReplace(BoundColumnRefExpression &expr, unique_ptr<Expression> *expr_ptr) override;
+
+	void ExtractCommonAggregates(LogicalAggregate &aggr);
+
+private:
+	column_binding_map_t<ColumnBinding> aggregate_map;
+};
+} // namespace duckdb

--- a/src/include/duckdb/parser/base_expression.hpp
+++ b/src/include/duckdb/parser/base_expression.hpp
@@ -60,9 +60,7 @@ public:
 	virtual bool HasParameter() const = 0;
 
 	//! Get the name of the expression
-	virtual string GetName() const {
-		return !alias.empty() ? alias : ToString();
-	}
+	virtual string GetName() const;
 	//! Convert the Expression to a String
 	virtual string ToString() const = 0;
 	//! Print the expression to stdout

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(statistics)
 add_library_unity(
   duckdb_optimizer
   OBJECT
+  common_aggregate_optimizer.cpp
   cse_optimizer.cpp
   column_lifetime_analyzer.cpp
   expression_heuristics.cpp

--- a/src/optimizer/common_aggregate_optimizer.cpp
+++ b/src/optimizer/common_aggregate_optimizer.cpp
@@ -10,7 +10,6 @@ using namespace std;
 
 void CommonAggregateOptimizer::VisitOperator(LogicalOperator &op) {
 	LogicalOperatorVisitor::VisitOperator(op);
-	LogicalOperatorVisitor::VisitOperatorExpressions(op);
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
 		ExtractCommonAggregates((LogicalAggregate &) op);

--- a/src/optimizer/common_aggregate_optimizer.cpp
+++ b/src/optimizer/common_aggregate_optimizer.cpp
@@ -1,0 +1,62 @@
+#include "duckdb/optimizer/common_aggregate_optimizer.hpp"
+
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/operator/logical_aggregate.hpp"
+#include "duckdb/parser/expression_map.hpp"
+#include "duckdb/planner/column_binding_map.hpp"
+
+namespace duckdb {
+using namespace std;
+
+void CommonAggregateOptimizer::VisitOperator(LogicalOperator &op) {
+	LogicalOperatorVisitor::VisitOperator(op);
+	LogicalOperatorVisitor::VisitOperatorExpressions(op);
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+		ExtractCommonAggregates((LogicalAggregate &) op);
+		break;
+	default:
+		break;
+	}
+}
+
+unique_ptr<Expression> CommonAggregateOptimizer::VisitReplace(BoundColumnRefExpression &expr, unique_ptr<Expression> *expr_ptr) {
+	// check if this column ref points to an aggregate that was remapped; if it does we remap it
+	auto entry = aggregate_map.find(expr.binding);
+	if (entry != aggregate_map.end()) {
+		expr.binding = entry->second;
+	}
+	return nullptr;
+}
+
+void CommonAggregateOptimizer::ExtractCommonAggregates(LogicalAggregate &aggr) {
+	expression_map_t<idx_t> aggregate_remap;
+	idx_t total_erased = 0;
+	for(idx_t i = 0; i < aggr.expressions.size(); i++) {
+		idx_t original_index = i + total_erased;
+		auto entry = aggregate_remap.find(aggr.expressions[i].get());
+		if (entry == aggregate_remap.end()) {
+			// aggregate does not exist yet: add it to the map
+			aggregate_remap[aggr.expressions[i].get()] = i;
+			if (i != original_index) {
+				// this aggregate is not erased, however an agregate BEFORE it has been erased
+				// so we need to remap this aggregaet
+				ColumnBinding original_binding(aggr.aggregate_index, original_index);
+				ColumnBinding new_binding(aggr.aggregate_index, i);
+				aggregate_map[original_binding] = new_binding;
+			}
+		} else {
+			// aggregate already exists! we can remove this entry
+			total_erased++;
+			aggr.expressions.erase(aggr.expressions.begin() + i);
+			i--;
+			// we need to remap any references to this aggregate so they point to the other aggregate
+			ColumnBinding original_binding(aggr.aggregate_index, original_index);
+			ColumnBinding new_binding(aggr.aggregate_index, entry->second);
+			aggregate_map[original_binding] = new_binding;
+		}
+	}
+}
+
+
+} // namespace duckdb

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/optimizer/column_lifetime_optimizer.hpp"
+#include "duckdb/optimizer/common_aggregate_optimizer.hpp"
 #include "duckdb/optimizer/cse_optimizer.hpp"
 #include "duckdb/optimizer/expression_heuristics.hpp"
 #include "duckdb/optimizer/filter_pushdown.hpp"
@@ -100,6 +101,11 @@ unique_ptr<LogicalOperator> Optimizer::Optimize(unique_ptr<LogicalOperator> plan
 	context.profiler.StartPhase("common_subexpressions");
 	CommonSubExpressionOptimizer cse_optimizer(binder);
 	cse_optimizer.VisitOperator(*plan);
+	context.profiler.EndPhase();
+
+	context.profiler.StartPhase("common_aggregate");
+	CommonAggregateOptimizer common_aggregate;
+	common_aggregate.VisitOperator(*plan);
 	context.profiler.EndPhase();
 
 	return plan;

--- a/src/parser/base_expression.cpp
+++ b/src/parser/base_expression.cpp
@@ -9,6 +9,14 @@ void BaseExpression::Print() {
 	Printer::Print(ToString());
 }
 
+string BaseExpression::GetName() const {
+	if (alias.empty()) {
+		return ToString();
+	} else {
+		return alias + " -> " + ToString();
+	}
+}
+
 bool BaseExpression::Equals(const BaseExpression *other) const {
 	if (!other) {
 		return false;

--- a/src/parser/base_expression.cpp
+++ b/src/parser/base_expression.cpp
@@ -10,11 +10,7 @@ void BaseExpression::Print() {
 }
 
 string BaseExpression::GetName() const {
-	if (alias.empty()) {
-		return ToString();
-	} else {
-		return alias + " -> " + ToString();
-	}
+	return !alias.empty() ? alias : ToString();
 }
 
 bool BaseExpression::Equals(const BaseExpression *other) const {

--- a/src/planner/expression/bound_aggregate_expression.cpp
+++ b/src/planner/expression/bound_aggregate_expression.cpp
@@ -17,14 +17,15 @@ string BoundAggregateExpression::ToString() const {
 	if (distinct) {
 		result += "DISTINCT ";
 	}
-	StringUtil::Join(children, children.size(), ", ",
+	result += StringUtil::Join(children, children.size(), ", ",
 	                 [](const unique_ptr<Expression> &child) { return child->ToString(); });
 	result += ")";
 	return result;
 }
+
 hash_t BoundAggregateExpression::Hash() const {
 	hash_t result = Expression::Hash();
-	result = CombineHash(result, duckdb::Hash(function.name.c_str()));
+	result = CombineHash(result, function.Hash());
 	result = CombineHash(result, duckdb::Hash(distinct));
 	return result;
 }

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -33,7 +33,7 @@ string BoundFunctionExpression::ToString() const {
 
 hash_t BoundFunctionExpression::Hash() const {
 	hash_t result = Expression::Hash();
-	return CombineHash(result, duckdb::Hash(function.name.c_str()));
+	return CombineHash(result, function.Hash());
 }
 
 bool BoundFunctionExpression::Equals(const BaseExpression *other_) const {

--- a/test/sql/optimizer/expression/test_common_aggregate.test
+++ b/test/sql/optimizer/expression/test_common_aggregate.test
@@ -50,3 +50,23 @@ query IIIII
 SELECT COUNT(*), COUNT(), SUM(i), COUNT(i), SUM(i) / COUNT(i) FROM integers;
 ----
 4	4	6	3	2
+
+statement ok
+CREATE TABLE groups(grp INTEGER, aggr1 INTEGER, aggr2 INTEGER, aggr3 INTEGER)
+
+statement ok
+INSERT INTO groups VALUES (1, 1, 2, 3), (1, 2, 4, 6), (2, 1, 2, 3),  (2, 3, 6, 9);
+
+query III
+SELECT
+    sum(aggr1)::DOUBLE / count(aggr1)::DOUBLE AS avg_qty,
+    sum(aggr2)::DOUBLE / count(aggr2)::DOUBLE AS avg_price,
+    sum(aggr3)::DOUBLE / count(aggr3)::DOUBLE AS avg_disc
+FROM
+    groups
+GROUP BY
+    grp
+ORDER BY grp;
+----
+1.5	3	4.5
+2	4	6

--- a/test/sql/optimizer/expression/test_common_aggregate.test
+++ b/test/sql/optimizer/expression/test_common_aggregate.test
@@ -1,0 +1,52 @@
+# name: test/sql/optimizer/expression/test_common_aggregate.test
+# description: Test common aggregate
+# group: [expression]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE integers(i INTEGER);
+
+statement ok
+INSERT INTO integers VALUES (1), (2), (3)
+
+statement ok
+PRAGMA explain_output = 'OPTIMIZED_ONLY';
+
+# all of these are identical, i.e. this gets folded into a single count aggregate
+query II
+EXPLAIN SELECT COUNT(*), COUNT(), COUNT(i) FROM integers;
+----
+logical_opt	<!REGEX>:.*AGGREGATE.*count.*count.*
+
+query III
+SELECT COUNT(*), COUNT(), COUNT(i) FROM integers;
+----
+3	3	3
+
+# again, here there is only a single count and a single sum
+query II
+EXPLAIN SELECT COUNT(*), COUNT(), SUM(i), COUNT(i), SUM(i) / COUNT(i) FROM integers;
+----
+logical_opt	<!REGEX>:.*AGGREGATE.*count.*count.*
+
+query IIIII
+SELECT COUNT(*), COUNT(), SUM(i), COUNT(i), SUM(i) / COUNT(i) FROM integers;
+----
+3	3	6	3	2
+
+# however, once we add a null value COUNT(i) is no longer equal to COUNT(*)
+statement ok
+INSERT INTO integers VALUES (NULL)
+
+# now there are two counts!
+query II
+EXPLAIN SELECT COUNT(*), COUNT(), SUM(i), COUNT(i), SUM(i) / COUNT(i) FROM integers;
+----
+logical_opt	<REGEX>:.*AGGREGATE.*count.*count.*
+
+query IIIII
+SELECT COUNT(*), COUNT(), SUM(i), COUNT(i), SUM(i) / COUNT(i) FROM integers;
+----
+4	4	6	3	2


### PR DESCRIPTION
This PR adds a separate common aggregate optimizer pass that merges common aggregates together to avoid doing unnecessary duplicate work. We already handled this in the binding phase, however, the new statistics propagation pass rewrites certain aggregates (e.g. `COUNT(column)` into `COUNT(*)`), which can then potentially be merged again by this optimizer pass.