### PR TITLE
test_quoted_column_name.test: Test escaped quotes

### DIFF
--- a/test/sql/catalog/test_quoted_column_name.test
+++ b/test/sql/catalog/test_quoted_column_name.test
@@ -13,3 +13,14 @@ SELECT "42" FROM integers;
 ----
 33
 
+# verify escaped quotes and dots
+statement ok
+CREATE TABLE "table ""." ( "col ""." TEXT)
+
+statement ok
+INSERT INTO "table ""." ("col "".") VALUES ('quote_escaped_quote_''')
+
+query TT
+SELECT "table ""."."col "".", "col ""." FROM "table "".";
+----
+quote_escaped_quote_'	quote_escaped_quote_'


### PR DESCRIPTION
This test verified column names that must be quoted because they are
integers, but did not cover escaped quotes (""), or other special
characters like spaces and dots. Extend this test a tiny bit to cover
these cases.

Feel free to reject this: It is very possible that these cases are covered elsewhere in the DuckDB test suite. However, searching for "" in the .test files shows that `sqlite_master_quotes.test` contains some tests for quoted identifiers. However, this is in the context of the testing the `sqlite_master` table. It seems to me that `test_quoted_column_name` should include tests for escaped quotes.

https://github.com/cwida/duckdb/blob/master/test/sql/table_function/sqlite_master_quotes.test#L19

In general: I may have other similar changes to extend the hand-written `.test` files to make sure they cover cases I am interested in. Are you interested in these, if I make PRs for them? Thanks!
