### PR TITLE
Window Aggregation Fixes

### DIFF
--- a/src/common/vector_operations/vector_cast.cpp
+++ b/src/common/vector_operations/vector_cast.cpp
@@ -475,7 +475,6 @@ static void value_string_cast_switch(Vector &source, Vector &result, idx_t count
 			auto src_val = source.GetValue(i);
 			auto str_val = src_val.ToString();
 			result.SetValue(i, Value(str_val));
-			break;
 		}
 		break;
 	default:

--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -821,7 +821,6 @@ void GroupedAggregateHashTable::Combine(GroupedAggregateHashTable &other) {
 	});
 	FlushMove(addresses, hashes, group_idx);
 	string_heap.MergeHeap(other.string_heap);
-	other.entries = 0; // disable finalizers
 	Verify();
 }
 

--- a/src/execution/operator/aggregate/physical_simple_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_simple_aggregate.cpp
@@ -151,7 +151,6 @@ void PhysicalSimpleAggregate::Combine(ExecutionContext &context, GlobalOperatorS
 
 			aggregate.function.combine(source_state, dest_state, 1);
 		}
-		source.state.Clear();
 	} else {
 		// complex aggregates: this is necessarily a non-parallel aggregate
 		// simply move over the source state into the global state

--- a/src/execution/operator/aggregate/physical_simple_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_simple_aggregate.cpp
@@ -46,10 +46,6 @@ struct AggregateState {
 		other.aggregates = move(aggregates);
 		other.destructors = move(destructors);
 	}
-	void Clear() {
-		aggregates.clear();
-		destructors.clear();
-	}
 
 	//! The aggregate values
 	vector<unique_ptr<data_t[]>> aggregates;

--- a/src/function/aggregate/distributive/first.cpp
+++ b/src/function/aggregate/distributive/first.cpp
@@ -71,13 +71,12 @@ struct FirstFunctionString : public FirstFunctionBase {
 			} else {
 				// non-inlined string, need to allocate space for it
 				auto len = value.GetSize();
-				auto ptr = new char[len + 1];
-				memcpy(ptr, value.GetDataUnsafe(), len + 1);
+				auto ptr = new char[len];
+				memcpy(ptr, value.GetDataUnsafe(), len);
 
 				state->value = string_t(ptr, len);
 			}
 		}
-
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
@@ -108,7 +107,7 @@ struct FirstFunctionString : public FirstFunctionBase {
 	}
 
 	template <class STATE> static void Destroy(STATE *state) {
-		if (state->is_set && !state->value.IsInlined()) {
+		if (state->is_set && !state->is_null && !state->value.IsInlined()) {
 			delete[] state->value.GetDataUnsafe();
 		}
 	}

--- a/src/function/aggregate/distributive/first.cpp
+++ b/src/function/aggregate/distributive/first.cpp
@@ -1,6 +1,5 @@
 #include "duckdb/function/aggregate/distributive_functions.hpp"
 #include "duckdb/common/exception.hpp"
-#include "duckdb/common/types/null_value.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/planner/expression.hpp"
 
@@ -11,17 +10,12 @@ namespace duckdb {
 template <class T> struct FirstState {
 	T value;
 	bool is_set;
+	bool is_null;
 };
 
 struct FirstFunctionBase {
 	template <class STATE> static void Initialize(STATE *state) {
 		state->is_set = false;
-	}
-
-	template <class STATE, class OP> static void Combine(STATE source, STATE *target) {
-		if (!target->is_set) {
-			*target = source;
-		}
 	}
 
 	static bool IgnoreNull() {
@@ -35,8 +29,9 @@ struct FirstFunction : public FirstFunctionBase {
 		if (!state->is_set) {
 			state->is_set = true;
 			if (nullmask[idx]) {
-				state->value = NullValue<INPUT_TYPE>();
+				state->is_null = true;
 			} else {
+				state->is_null = false;
 				state->value = input[idx];
 			}
 		}
@@ -47,9 +42,15 @@ struct FirstFunction : public FirstFunctionBase {
 		Operation<INPUT_TYPE, STATE, OP>(state, input, nullmask, 0);
 	}
 
+	template <class STATE, class OP> static void Combine(STATE source, STATE *target) {
+		if (!target->is_set) {
+			*target = source;
+		}
+	}
+
 	template <class T, class STATE>
 	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, nullmask_t &nullmask, idx_t idx) {
-		if (!state->is_set || IsNullValue<T>(state->value)) {
+		if (!state->is_set || state->is_null) {
 			nullmask[idx] = true;
 		} else {
 			target[idx] = state->value;
@@ -58,24 +59,30 @@ struct FirstFunction : public FirstFunctionBase {
 };
 
 struct FirstFunctionString : public FirstFunctionBase {
+	template<class STATE>
+	static void SetValue(STATE *state, string_t value, bool is_null) {
+		state->is_set = true;
+		if (is_null) {
+			state->is_null = true;
+		} else {
+			if (value.IsInlined()) {
+				state->value = value;
+			} else {
+				// non-inlined string, need to allocate space for it
+				auto len = value.GetSize();
+				auto ptr = new char[len + 1];
+				memcpy(ptr, value.GetDataUnsafe(), len + 1);
+
+				state->value = string_t(ptr, len);
+			}
+		}
+
+	}
+
 	template <class INPUT_TYPE, class STATE, class OP>
 	static void Operation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t idx) {
 		if (!state->is_set) {
-			state->is_set = true;
-			if (nullmask[idx]) {
-				state->value = NullValue<INPUT_TYPE>();
-			} else {
-				if (input[idx].IsInlined()) {
-					state->value = input[idx];
-				} else {
-					// non-inlined string, need to allocate space for it
-					auto len = input[idx].GetSize();
-					auto ptr = new char[len + 1];
-					memcpy(ptr, input[idx].GetDataUnsafe(), len + 1);
-
-					state->value = string_t(ptr, len);
-				}
-			}
+			SetValue(state, input[idx], nullmask[idx]);
 		}
 	}
 
@@ -84,9 +91,15 @@ struct FirstFunctionString : public FirstFunctionBase {
 		Operation<INPUT_TYPE, STATE, OP>(state, input, nullmask, 0);
 	}
 
+	template <class STATE, class OP> static void Combine(STATE source, STATE *target) {
+		if (source.is_set && !target->is_set) {
+			SetValue(target, source.value, source.is_null);
+		}
+	}
+
 	template <class T, class STATE>
 	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, nullmask_t &nullmask, idx_t idx) {
-		if (!state->is_set || IsNullValue<T>(state->value)) {
+		if (!state->is_set || state->is_null) {
 			nullmask[idx] = true;
 		} else {
 			target[idx] = StringVector::AddString(result, state->value);

--- a/src/function/aggregate/distributive/first.cpp
+++ b/src/function/aggregate/distributive/first.cpp
@@ -16,6 +16,7 @@ template <class T> struct FirstState {
 struct FirstFunctionBase {
 	template <class STATE> static void Initialize(STATE *state) {
 		state->is_set = false;
+		state->is_null = false;
 	}
 
 	static bool IgnoreNull() {

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -165,7 +165,8 @@ struct StringMinMaxBase : public MinMaxBase {
 		}
 		if (!target->isset) {
 			// target is NULL, use source value directly
-			*target = source;
+			Assign(target, source.value);
+			target->isset = true;
 		} else {
 			OP::template Execute<string_t, STATE>(target, source.value);
 		}

--- a/src/function/aggregate/distributive/string_agg.cpp
+++ b/src/function/aggregate/distributive/string_agg.cpp
@@ -46,7 +46,7 @@ struct StringAggBaseFunction {
 			// first iteration: allocate space for the string and copy it into the state
 			state->alloc_size = MaxValue<idx_t>(8, NextPowerOfTwo(str_size));
 			state->dataptr = new char[state->alloc_size];
-			state->size = str_size - 1;
+			state->size = str_size;
 			memcpy(state->dataptr, str, str_size);
 		} else {
 			// subsequent iteration: first check if we have space to place the string and separator
@@ -66,16 +66,16 @@ struct StringAggBaseFunction {
 			state->size += sep_size;
 			// copy the string
 			memcpy(state->dataptr + state->size, str, str_size);
-			state->size += str_size - 1;
+			state->size += str_size;
 		}
 	}
 
 	static inline void PerformOperation(string_agg_state_t *state, string_t str, string_t sep) {
-		PerformOperation(state, str.GetDataUnsafe(), sep.GetDataUnsafe(), str.GetSize() + 1, sep.GetSize());
+		PerformOperation(state, str.GetDataUnsafe(), sep.GetDataUnsafe(), str.GetSize(), sep.GetSize());
 	}
 
 	static inline void PerformOperation(string_agg_state_t *state, string_t str) {
-		PerformOperation(state, str.GetDataUnsafe(), ",", str.GetSize() + 1, 1);
+		PerformOperation(state, str.GetDataUnsafe(), ",", str.GetSize(), 1);
 	}
 };
 

--- a/src/function/aggregate/distributive/string_agg.cpp
+++ b/src/function/aggregate/distributive/string_agg.cpp
@@ -106,7 +106,6 @@ struct StringAggSingleFunction : public StringAggBaseFunction {
 			return;
 		}
 		PerformOperation(target, string_t(source.dataptr, source.size));
-		Destroy(&source);
 	}
 };
 

--- a/src/function/aggregate/nested/list.cpp
+++ b/src/function/aggregate/nested/list.cpp
@@ -70,7 +70,6 @@ static void list_combine(Vector &state, Vector &combined, idx_t count) {
 			combined_ptr[i]->cc = new ChunkCollection();
 		}
 		combined_ptr[i]->cc->Append(*state->cc);
-		delete state->cc;
 	}
 }
 

--- a/src/include/duckdb/execution/window_segment_tree.hpp
+++ b/src/include/duckdb/execution/window_segment_tree.hpp
@@ -18,6 +18,8 @@ class WindowSegmentTree {
 public:
 	WindowSegmentTree(AggregateFunction &aggregate, FunctionData *bind_info, LogicalType result_type,
 	                  ChunkCollection *input);
+	~WindowSegmentTree();
+
 	Value Compute(idx_t start, idx_t end);
 
 private:
@@ -26,15 +28,29 @@ private:
 	void AggregateInit();
 	Value AggegateFinal();
 
+	//! The aggregate that the window function is computed over
 	AggregateFunction aggregate;
+	//! The bind info of the aggregate
 	FunctionData *bind_info;
-	vector<data_t> state;
-	DataChunk inputs;
-	Vector statep;
+	//! The result type of the window function
 	LogicalType result_type;
+
+	//! Data pointer that contains a single state, used for intermediate window segment aggregation
+	vector<data_t> state;
+	//! Input data chunk, used for intermediate window segment aggregation
+	DataChunk inputs;
+	//! A vector of pointers to "state", used for intermediate window segment aggregation
+	Vector statep;
+
+	//! The actual window segment tree: an array of aggregate states that represent all the intermediate nodes
 	unique_ptr<data_t[]> levels_flat_native;
+	//! For each level, the starting location in the levels_flat_native array
 	vector<idx_t> levels_flat_start;
 
+	//! The total number of internal nodes of the tree, stored in levels_flat_native
+	idx_t internal_nodes;
+
+	//! The (sorted) input chunk collection on which the tree is built
 	ChunkCollection *input_ref;
 
 	// TREE_FANOUT needs to cleanly divide STANDARD_VECTOR_SIZE

--- a/test/sql/types/list/list_aggregates.test
+++ b/test/sql/types/list/list_aggregates.test
@@ -49,3 +49,17 @@ select i, i % 2, list(i) over(partition by i % 2 order by i) from range(10) tbl(
 5	1	[1, 3, 5]
 7	1	[1, 3, 5, 7]
 9	1	[1, 3, 5, 7, 9]
+
+query III
+select i, i % 2, list(i) over(partition by i % 2 order by i rows between 1 preceding and 1 following) from range(10) tbl(i) ORDER BY 2, 1;
+----
+0	0	[0, 2]
+2	0	[0, 2, 4]
+4	0	[2, 4, 6]
+6	0	[4, 6, 8]
+8	0	[6, 8]
+1	1	[1, 3]
+3	1	[1, 3, 5]
+5	1	[3, 5, 7]
+7	1	[5, 7, 9]
+9	1	[7, 9]

--- a/test/sql/types/list/list_aggregates.test
+++ b/test/sql/types/list/list_aggregates.test
@@ -2,6 +2,8 @@
 # description: Test lists with aggregations
 # group: [list]
 
+require vector_size 512
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/types/list/list_aggregates.test
+++ b/test/sql/types/list/list_aggregates.test
@@ -19,3 +19,33 @@ query I
 select string_agg(list_value(i), ',') from range(10) tbl(i);
 ----
 [0],[1],[2],[3],[4],[5],[6],[7],[8],[9]
+
+# window aggregate
+query III
+select i, i % 2, min(list_value(i)) over(partition by i % 2 order by i) from range(10) tbl(i) ORDER BY 1;
+----
+0	0	[0]
+1	1	[1]
+2	0	[0]
+3	1	[1]
+4	0	[0]
+5	1	[1]
+6	0	[0]
+7	1	[1]
+8	0	[0]
+9	1	[1]
+
+# list
+query III
+select i, i % 2, list(i) over(partition by i % 2 order by i) from range(10) tbl(i) ORDER BY 2, 1;
+----
+0	0	[0]
+2	0	[0, 2]
+4	0	[0, 2, 4]
+6	0	[0, 2, 4, 6]
+8	0	[0, 2, 4, 6, 8]
+1	1	[1]
+3	1	[1, 3]
+5	1	[1, 3, 5]
+7	1	[1, 3, 5, 7]
+9	1	[1, 3, 5, 7, 9]

--- a/test/sql/types/list/list_aggregates.test
+++ b/test/sql/types/list/list_aggregates.test
@@ -1,0 +1,21 @@
+# name: test/sql/types/list/array_agg.test
+# description: Test lists with aggregations
+# group: [list]
+
+statement ok
+PRAGMA enable_verification
+
+query II
+select min(i::varchar), max(i::varchar) from range(10) tbl(i);
+----
+0	9
+
+query II
+select min(list_value(i)), max(list_value(i)) from range(10) tbl(i);
+----
+[0]	[9]
+
+query I
+select string_agg(list_value(i), ',') from range(10) tbl(i);
+----
+[0],[1],[2],[3],[4],[5],[6],[7],[8],[9]

--- a/test/sql/types/struct/struct_aggregates.test
+++ b/test/sql/types/struct/struct_aggregates.test
@@ -1,0 +1,16 @@
+# name: test/sql/types/struct/struct_aggregates.test
+# description: Test structs with aggregations
+# group: [struct]
+
+statement ok
+PRAGMA enable_verification
+
+query II
+select min(struct_pack(i :=  i, j := i + 2)), max(struct_pack(i :=  i, j := i + 2)) from range(10) tbl(i);
+----
+<i: 0, j: 2>	<i: 9, j: 11>
+
+query I
+select string_agg(struct_pack(i :=  i, j := i + 2), ',') from range(10) tbl(i);
+----
+<i: 0, j: 2>,<i: 1, j: 3>,<i: 2, j: 4>,<i: 3, j: 5>,<i: 4, j: 6>,<i: 5, j: 7>,<i: 6, j: 8>,<i: 7, j: 9>,<i: 8, j: 10>,<i: 9, j: 11>

--- a/test/sql/types/struct/struct_aggregates.test
+++ b/test/sql/types/struct/struct_aggregates.test
@@ -5,10 +5,10 @@
 statement ok
 PRAGMA enable_verification
 
-query II
-select min(struct_pack(i :=  i, j := i + 2)), max(struct_pack(i :=  i, j := i + 2)) from range(10) tbl(i);
+query III
+select min(struct_pack(i :=  i, j := i + 2)), max(struct_pack(i :=  i, j := i + 2)), first(struct_pack(i :=  i, j := i + 2)) from range(10) tbl(i);
 ----
-<i: 0, j: 2>	<i: 9, j: 11>
+<i: 0, j: 2>	<i: 9, j: 11>	<i: 0, j: 2>
 
 query I
 select string_agg(struct_pack(i :=  i, j := i + 2), ',') from range(10) tbl(i);


### PR DESCRIPTION
This PR fixes several bugs involving window functions and aggregate functions that relied on destructors (e.g. `LIST`, `STRING_AGG`, etc). Previously, the window segment tree would not call the destructors, which would lead to memory leaking. In addition, `combine` was previously designed to be *destructive* (i.e., it would destroy the source). This behavior was fine for regular aggregates (since `combine` would only be called when we were finished with the source hash table anyway), but caused problems for window functions because it would lead to destruction of the inner nodes of the segment tree, which could cause use-after-free bugs.