### PR TITLE
Fix for strptime: parse a limited amount of numbers depending on the specifier

### DIFF
--- a/src/include/duckdb/function/scalar/strftime.hpp
+++ b/src/include/duckdb/function/scalar/strftime.hpp
@@ -36,7 +36,7 @@ enum class StrTimeSpecifier : uint8_t {
 	SECOND_PADDED = 19,              // %S - Second as a zero-padded decimal number. (00, 01, ..., 59)
 	SECOND_DECIMAL = 20,             // %-S - Second as a decimal number. (0, 1, ..., 59)
 	MICROSECOND_PADDED = 21,         // %f - Microsecond as a decimal number, zero-padded on the left. (000000 - 999999)
-	MILLISECOND_PADDED = 22,         // %g - Millisecond as a decimal number, zero-padded on the left. (000000 - 999999)
+	MILLISECOND_PADDED = 22,         // %g - Millisecond as a decimal number, zero-padded on the left. (000 - 999)
 	UTC_OFFSET = 23,                 // %z - UTC offset in the form +HHMM or -HHMM. ( )
 	TZ_NAME = 24,                    // %Z - Time zone name. ( )
 	DAY_OF_YEAR_PADDED = 25,         // %j - Day of the year as a zero-padded decimal number. (001, 002, ..., 366)
@@ -69,8 +69,8 @@ protected:
 	vector<string> literals;
 	//! The constant size that appears in the format string
 	idx_t constant_size;
-	//! Whether or not the specifier is a numeric specifier (i.e. is parsed as a number)
-	vector<bool> is_numeric;
+	//! The max numeric width of the specifier (if it is parsed as a number), or -1 if it is not a number
+	vector<int> numeric_width;
 	void AddLiteral(string literal);
 	virtual void AddFormatSpecifier(string preceding_literal, StrTimeSpecifier specifier);
 };
@@ -118,7 +118,7 @@ public:
 protected:
 	string FormatStrpTimeError(string input, idx_t position);
 	void AddFormatSpecifier(string preceding_literal, StrTimeSpecifier specifier);
-	bool IsNumericSpecifier(StrTimeSpecifier specifier);
+	int NumericSpecifierWidth(StrTimeSpecifier specifier);
 	int32_t TryParseCollection(const char *data, idx_t &pos, idx_t size, string_t collection[], idx_t collection_count);
 };
 

--- a/test/sql/function/timestamp/test_strptime.test
+++ b/test/sql/function/timestamp/test_strptime.test
@@ -21,6 +21,11 @@ SELECT strptime('2018-20-10', '%Y-%d-%m')
 2018-10-20 00:00:00
 
 query I
+SELECT strptime('20182010', '%Y%d%m')
+----
+2018-10-20 00:00:00
+
+query I
 SELECT strptime('Mon 30, June 2003, 12:03:10 AM', '%a %d, %B %Y, %I:%M:%S %p')
 ----
 2003-06-30 00:03:10


### PR DESCRIPTION
This allows dates to be parsed that do not have separators in between the numbers (e.g. `strptime('20182010', '%Y%d%m')` now parses 2018-20-10). This fixes issue #1158.