### PR TITLE
Add support for compression codec in Parquet writer

### DIFF
--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -103,10 +103,6 @@ private:
 	void fill_from_plain(ParquetReaderColumnData &col_data, idx_t count, Vector &target, idx_t target_offset);
 
 private:
-	static constexpr uint8_t GZIP_HEADER_MINSIZE = 10;
-	static constexpr uint8_t GZIP_COMPRESSION_DEFLATE = 0x08;
-	static constexpr unsigned char GZIP_FLAG_UNSUPPORTED = 0x1 | 0x2 | 0x4 | 0x10 | 0x20;
-
 	ClientContext &context;
 };
 

--- a/extension/parquet/include/parquet_writer.hpp
+++ b/extension/parquet/include/parquet_writer.hpp
@@ -22,7 +22,7 @@ class FileSystem;
 
 class ParquetWriter {
 public:
-	ParquetWriter(FileSystem &fs, string file_name, vector<LogicalType> types, vector<string> names);
+	ParquetWriter(FileSystem &fs, string file_name, vector<LogicalType> types, vector<string> names, parquet::format::CompressionCodec::type codec);
 
 public:
 	void Flush(ChunkCollection &buffer);
@@ -32,6 +32,7 @@ private:
 	string file_name;
 	vector<LogicalType> sql_types;
 	vector<string> column_names;
+	parquet::format::CompressionCodec::type codec;
 
 	unique_ptr<BufferedFileWriter> writer;
 	shared_ptr<apache::thrift::protocol::TProtocol> protocol;

--- a/extension/parquet/parquet-extension.cpp
+++ b/extension/parquet/parquet-extension.cpp
@@ -212,7 +212,7 @@ struct ParquetWriteBindData : public FunctionData {
 	vector<LogicalType> sql_types;
 	string file_name;
 	vector<string> column_names;
-	// TODO compression flag to test the param passing stuff
+	parquet::format::CompressionCodec::type codec = parquet::format::CompressionCodec::SNAPPY;
 };
 
 struct ParquetWriteGlobalState : public GlobalFunctionData {
@@ -230,6 +230,27 @@ struct ParquetWriteLocalState : public LocalFunctionData {
 unique_ptr<FunctionData> parquet_write_bind(ClientContext &context, CopyInfo &info, vector<string> &names,
                                             vector<LogicalType> &sql_types) {
 	auto bind_data = make_unique<ParquetWriteBindData>();
+	for (auto &option : info.options) {
+		auto loption = StringUtil::Lower(option.first);
+		if (loption == "compression" || loption == "codec") {
+			if (option.second.size() > 0) {
+				auto roption = StringUtil::Lower(option.second[0].ToString());
+				if (roption == "uncompressed") {
+					bind_data->codec = parquet::format::CompressionCodec::UNCOMPRESSED;
+					continue;
+				} else if (roption == "snappy") {
+					bind_data->codec = parquet::format::CompressionCodec::SNAPPY;
+					continue;
+				} else if (roption == "gzip") {
+					bind_data->codec = parquet::format::CompressionCodec::GZIP;
+					continue;
+				}
+			}
+			throw ParserException("Expected %s argument to be either [uncompressed, snappy, or gzip]", loption);
+		} else {
+			throw NotImplementedException("Unrecognized option for PARQUET: %s", option.first.c_str());
+		}
+	}
 	bind_data->sql_types = sql_types;
 	bind_data->column_names = names;
 	bind_data->file_name = info.file_path;
@@ -242,7 +263,7 @@ unique_ptr<GlobalFunctionData> parquet_write_initialize_global(ClientContext &co
 
 	auto &fs = FileSystem::GetFileSystem(context);
 	global_state->writer =
-	    make_unique<ParquetWriter>(fs, parquet_bind.file_name, parquet_bind.sql_types, parquet_bind.column_names);
+	    make_unique<ParquetWriter>(fs, parquet_bind.file_name, parquet_bind.sql_types, parquet_bind.column_names, parquet_bind.codec);
 	return move(global_state);
 }
 

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/serializer/buffered_serializer.hpp"
 
 #include "snappy.h"
+#include "miniz_wrapper.hpp"
 
 namespace duckdb {
 
@@ -22,6 +23,7 @@ using namespace parquet;
 using namespace apache::thrift;
 using namespace apache::thrift::protocol;
 using namespace apache::thrift::transport;
+using namespace duckdb_miniz;
 
 using parquet::format::CompressionCodec;
 using parquet::format::ConvertedType;
@@ -126,8 +128,8 @@ static void _write_plain(Vector &col, idx_t length, nullmask_t &nullmask, Serial
 	}
 }
 
-ParquetWriter::ParquetWriter(FileSystem &fs, string file_name_, vector<LogicalType> types_, vector<string> names_)
-    : file_name(file_name_), sql_types(move(types_)), column_names(move(names_)) {
+ParquetWriter::ParquetWriter(FileSystem &fs, string file_name_, vector<LogicalType> types_, vector<string> names_, CompressionCodec::type codec)
+    : file_name(file_name_), sql_types(move(types_)), column_names(move(names_)), codec(codec) {
 	// initialize the file writer
 	writer = make_unique<BufferedFileWriter>(fs, file_name.c_str(),
 	                                         FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
@@ -173,7 +175,7 @@ void ParquetWriter::Flush(ChunkCollection &buffer) {
 	// iterate over each of the columns of the chunk collection and write them
 	for (idx_t i = 0; i < buffer.ColumnCount(); i++) {
 		// we start off by writing everything into a temporary buffer
-		// this is necessary to (1) know the total written size, and (2) to compress it with snappy afterwards
+		// this is necessary to (1) know the total written size, and (2) to compress it afterwards
 		BufferedSerializer temp_writer;
 
 		// set up some metadata
@@ -309,23 +311,46 @@ void ParquetWriter::Flush(ChunkCollection &buffer) {
 		// now that we have finished writing the data we know the uncompressed size
 		hdr.uncompressed_page_size = temp_writer.blob.size;
 
-		// we perform snappy compression (FIXME: this should be a flag, possibly also include gzip?)
-		size_t compressed_size = snappy::MaxCompressedLength(temp_writer.blob.size);
-		auto compressed_buf = unique_ptr<data_t[]>(new data_t[compressed_size]);
-		snappy::RawCompress((const char *)temp_writer.blob.data.get(), temp_writer.blob.size,
-		                    (char *)compressed_buf.get(), &compressed_size);
+		// compress the data based
+		size_t compressed_size;
+		data_ptr_t compressed_data;
+		unique_ptr<data_t[]> compressed_buf;
+		switch(codec) {
+		case CompressionCodec::UNCOMPRESSED:
+			compressed_size = temp_writer.blob.size;
+			compressed_data = temp_writer.blob.data.get();
+			break;
+		case CompressionCodec::SNAPPY: {
+			compressed_size = snappy::MaxCompressedLength(temp_writer.blob.size);
+			compressed_buf = unique_ptr<data_t[]>(new data_t[compressed_size]);
+			snappy::RawCompress((const char *)temp_writer.blob.data.get(), temp_writer.blob.size,
+								(char *)compressed_buf.get(), &compressed_size);
+			compressed_data = compressed_buf.get();
+			break;
+		}
+		case CompressionCodec::GZIP: {
+			MiniZStream s;
+			compressed_size = s.MaxCompressedLength(temp_writer.blob.size);
+			compressed_buf = unique_ptr<data_t[]>(new data_t[compressed_size]);
+			s.Compress((const char *)temp_writer.blob.data.get(), temp_writer.blob.size,
+								(char *)compressed_buf.get(), &compressed_size);
+			compressed_data = compressed_buf.get();
+			break;
+		}
+		default:
+			throw InternalException("Unsupported codec for Parquet Writer");
+		}
 
 		hdr.compressed_page_size = compressed_size;
-
 		// now finally write the data to the actual file
 		hdr.write(protocol.get());
-		writer->WriteData(compressed_buf.get(), compressed_size);
+		writer->WriteData(compressed_data, compressed_size);
 
 		auto &column_chunk = row_group.columns[i];
 		column_chunk.__isset.meta_data = true;
 		column_chunk.meta_data.data_page_offset = start_offset;
 		column_chunk.meta_data.total_compressed_size = writer->GetTotalWritten() - start_offset;
-		column_chunk.meta_data.codec = CompressionCodec::SNAPPY;
+		column_chunk.meta_data.codec = codec;
 		column_chunk.meta_data.path_in_schema.push_back(file_meta_data.schema[i + 1].name);
 		column_chunk.meta_data.num_values = buffer.Count();
 		column_chunk.meta_data.type = file_meta_data.schema[i + 1].type;

--- a/test/sql/copy/parquet/parquet_write_codecs.test
+++ b/test/sql/copy/parquet/parquet_write_codecs.test
@@ -1,0 +1,44 @@
+# name: test/sql/copy/parquet/parquet_write_codecs.test
+# description: Parquet write with various codecs
+# group: [parquet]
+
+require parquet
+
+# codec uncompressed
+statement ok
+COPY (SELECT 42, 'hello') TO '__TEST_DIR__/uncompressed.parquet' (FORMAT 'parquet', CODEC 'UNCOMPRESSED');
+
+query II
+SELECT * FROM parquet_scan('__TEST_DIR__/uncompressed.parquet');
+----
+42	hello
+
+# codec snappy
+statement ok
+COPY (SELECT 42, 'hello') TO '__TEST_DIR__/snappy.parquet' (FORMAT 'parquet', CODEC 'SNAPPY');
+
+query II
+SELECT * FROM parquet_scan('__TEST_DIR__/snappy.parquet');
+----
+42	hello
+
+# codec gzip
+statement ok
+COPY (SELECT 42, 'hello') TO '__TEST_DIR__/gzip.parquet' (FORMAT 'parquet', CODEC 'GZIP');
+
+query II
+SELECT * FROM parquet_scan('__TEST_DIR__/gzip.parquet');
+----
+42	hello
+
+# unsupported codec
+statement error
+COPY (SELECT 42, 'hello') TO '__TEST_DIR__/gzip.parquet' (FORMAT 'parquet', CODEC 'BLABLABLA');
+
+# empty codec
+statement error
+COPY (SELECT 42, 'hello') TO '__TEST_DIR__/gzip.parquet' (FORMAT 'parquet', CODEC);
+
+# integer codec
+statement error
+COPY (SELECT 42, 'hello') TO '__TEST_DIR__/gzip.parquet' (FORMAT 'parquet', CODEC 3);

--- a/test/sql/copy/parquet/test_parquet_gzip.test
+++ b/test/sql/copy/parquet/test_parquet_gzip.test
@@ -7,8 +7,8 @@ require parquet
 statement ok
 PRAGMA enable_verification
 
-query I
-select count(*) from parquet_scan('test/sql/copy/parquet/data/lineitem-top10000.gzip.parquet')
+query IIIIIIIIIIIIIIII
+select * from parquet_scan('test/sql/copy/parquet/data/lineitem-top10000.gzip.parquet')
 ----
-10000
+160000 values hashing to 06285f9574c31130c01a6723d3d667ec
 

--- a/test/sql/copy/parquet/test_parquet_write_complex.test
+++ b/test/sql/copy/parquet/test_parquet_write_complex.test
@@ -41,3 +41,19 @@ COPY (SELECT * FROM parquet_scan('test/sql/copy/parquet/data/userdata1.parquet')
 query I nosort userdata1.parquet
 SELECT * FROM parquet_scan('__TEST_DIR__/userdata1.parquet') ORDER BY 1 LIMIT 10;
 ----
+
+# gzip codec
+statement ok
+COPY (SELECT * FROM parquet_scan('test/sql/copy/parquet/data/userdata1.parquet')) TO '__TEST_DIR__/userdata1-gzip.parquet' (FORMAT 'PARQUET', CODEC 'GZIP')
+
+query I nosort userdata1.parquet
+SELECT * FROM parquet_scan('__TEST_DIR__/userdata1-gzip.parquet') ORDER BY 1 LIMIT 10;
+----
+
+# uncompressed codec
+statement ok
+COPY (SELECT * FROM parquet_scan('test/sql/copy/parquet/data/userdata1.parquet')) TO '__TEST_DIR__/userdata1-uncompressed.parquet' (FORMAT 'PARQUET', CODEC 'UNCOMPRESSED')
+
+query I nosort userdata1.parquet
+SELECT * FROM parquet_scan('__TEST_DIR__/userdata1-uncompressed.parquet') ORDER BY 1 LIMIT 10;
+----

--- a/third_party/miniz/miniz_wrapper.hpp
+++ b/third_party/miniz/miniz_wrapper.hpp
@@ -1,0 +1,129 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// miniz_wrapper.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "miniz.hpp"
+#include <string>
+#include <stdexcept>
+
+namespace duckdb {
+
+enum class MiniZStreamType {
+	MINIZ_TYPE_NONE,
+	MINIZ_TYPE_INFLATE,
+	MINIZ_TYPE_DEFLATE
+};
+
+struct MiniZStream {
+	MiniZStream() : type(MiniZStreamType::MINIZ_TYPE_NONE) {
+		memset(&stream, 0, sizeof(duckdb_miniz::mz_stream));
+	}
+	~MiniZStream() {
+		switch(type) {
+		case MiniZStreamType::MINIZ_TYPE_INFLATE:
+			duckdb_miniz::mz_inflateEnd(&stream);
+			break;
+		case MiniZStreamType::MINIZ_TYPE_DEFLATE:
+			duckdb_miniz::mz_deflateEnd(&stream);
+			break;
+		default:
+			break;
+		}
+	}
+	void FormatException(std::string error_msg) {
+		throw std::runtime_error(error_msg);
+	}
+	void FormatException(const char *error_msg, int mz_ret) {
+		auto err = duckdb_miniz::mz_error(mz_ret);
+		FormatException(error_msg + std::string(": ") + (err ? err : "Unknown error code"));
+	}
+	void Decompress(const char *compressed_data, size_t compressed_size, char *out_data, size_t out_size) {
+		auto mz_ret = mz_inflateInit2(&stream, -MZ_DEFAULT_WINDOW_BITS);
+		if (mz_ret != duckdb_miniz::MZ_OK) {
+			FormatException("Failed to initialize miniz", mz_ret);
+		}
+		type = MiniZStreamType::MINIZ_TYPE_INFLATE;
+
+		if (compressed_size < GZIP_HEADER_MINSIZE) {
+			FormatException("Failed to decompress GZIP block: compressed size is less than gzip header size");
+		}
+		auto gzip_hdr = (const unsigned char *)compressed_data;
+		if (gzip_hdr[0] != 0x1F || gzip_hdr[1] != 0x8B || gzip_hdr[2] != GZIP_COMPRESSION_DEFLATE ||
+		    gzip_hdr[3] & GZIP_FLAG_UNSUPPORTED) {
+			FormatException("Input is invalid/unsupported GZIP stream");
+		}
+
+		stream.next_in = (const unsigned char *)compressed_data + GZIP_HEADER_MINSIZE;
+		stream.avail_in = compressed_size - GZIP_HEADER_MINSIZE;
+		stream.next_out = (unsigned char *)out_data;
+		stream.avail_out = out_size;
+
+		mz_ret = mz_inflate(&stream, duckdb_miniz::MZ_FINISH);
+		if (mz_ret != duckdb_miniz::MZ_OK && mz_ret != duckdb_miniz::MZ_STREAM_END) {
+			FormatException("Failed to decompress GZIP block", mz_ret);
+		}
+	}
+	size_t MaxCompressedLength(size_t input_size) {
+		return duckdb_miniz::mz_compressBound(input_size) + GZIP_HEADER_MINSIZE + GZIP_FOOTER_SIZE;
+	}
+	void Compress(const char *uncompressed_data, size_t uncompressed_size, char *out_data, size_t *out_size) {
+		auto mz_ret = mz_deflateInit2(&stream, duckdb_miniz::MZ_BEST_COMPRESSION, MZ_DEFLATED, -MZ_DEFAULT_WINDOW_BITS, 1, 0);
+		if (mz_ret != duckdb_miniz::MZ_OK) {
+			FormatException("Failed to initialize miniz", mz_ret);
+		}
+		type = MiniZStreamType::MINIZ_TYPE_DEFLATE;
+
+		auto gzip_header = (unsigned char*) out_data;
+		memset(gzip_header, 0, GZIP_HEADER_MINSIZE);
+		gzip_header[0] = 0x1F;
+		gzip_header[1] = 0x8B;
+		gzip_header[2] = GZIP_COMPRESSION_DEFLATE;
+		gzip_header[3] = 0;
+		gzip_header[4] = 0;
+		gzip_header[5] = 0;
+		gzip_header[6] = 0;
+		gzip_header[7] = 0;
+		gzip_header[8] = 0;
+		gzip_header[9] = 0xFF;
+
+		auto gzip_body = gzip_header + GZIP_HEADER_MINSIZE;
+
+		stream.next_in = (const unsigned char*) uncompressed_data;
+		stream.avail_in = uncompressed_size;
+		stream.next_out = gzip_body;
+		stream.avail_out = *out_size - GZIP_HEADER_MINSIZE;
+
+		mz_ret = mz_deflate(&stream, duckdb_miniz::MZ_FINISH);
+		if (mz_ret != duckdb_miniz::MZ_OK && mz_ret != duckdb_miniz::MZ_STREAM_END) {
+			FormatException("Failed to compress GZIP block", mz_ret);
+		}
+		auto gzip_footer = gzip_body + stream.total_out;
+		auto crc = duckdb_miniz::mz_crc32(MZ_CRC32_INIT, (const unsigned char*) uncompressed_data, uncompressed_size);
+		gzip_footer[0] = crc & 0xFF;
+		gzip_footer[1] = (crc >> 8) & 0xFF;
+		gzip_footer[2] = (crc >> 16) & 0xFF;
+		gzip_footer[3] = (crc >> 24) & 0xFF;
+		gzip_footer[4] = uncompressed_size & 0xFF;
+		gzip_footer[5] = (uncompressed_size >> 8) & 0xFF;
+		gzip_footer[6] = (uncompressed_size >> 16) & 0xFF;
+		gzip_footer[7] = (uncompressed_size >> 24) & 0xFF;
+
+		*out_size = stream.total_out + GZIP_HEADER_MINSIZE + GZIP_FOOTER_SIZE;
+	}
+
+private:
+	static constexpr uint8_t GZIP_HEADER_MINSIZE = 10;
+	static constexpr uint8_t GZIP_FOOTER_SIZE = 8;
+	static constexpr uint8_t GZIP_COMPRESSION_DEFLATE = 0x08;
+	static constexpr unsigned char GZIP_FLAG_UNSUPPORTED = 0x1 | 0x2 | 0x4 | 0x10 | 0x20;
+	duckdb_miniz::mz_stream stream;
+	MiniZStreamType type;
+};
+
+}


### PR DESCRIPTION
This adds a `CODEC` (or `COMPRESSION`) parameter to the COPY TO for Parquet (implements #1154). Supported codecs now are `uncompressed`, `snappy` (default) and `gzip`.

Example usage:

```sql
COPY (SELECT 42 AS a) TO 'uncompressed.parquet' (FORMAT 'parquet', CODEC 'UNCOMPRESSED');
COPY (SELECT 43 AS a) TO 'snappy.parquet' (FORMAT 'parquet', CODEC 'SNAPPY');
COPY (SELECT 44 AS a) TO 'gzip.parquet' (FORMAT 'parquet', CODEC 'GZIP');

-- read the files again
SELECT * FROM parquet_scan('*.parquet') ORDER BY 1;
--
42
43
44
```

Compressing SF1 lineitem with these three codecs gives the following sizes:
```
-rw-r--r--  1 myth  staff   840M Nov 28 18:49 lineitem-sf1-uncompressed.parquet
-rw-r--r--  1 myth  staff   291M Nov 28 18:50 lineitem-sf1-snappy.parquet
-rw-r--r--  1 myth  staff   159M Nov 28 18:52 lineitem-sf1-gzip.parquet
```