### PR TITLE
Fix for statistics propagation in outer joins

### DIFF
--- a/src/optimizer/statistics/operator/propagate_join.cpp
+++ b/src/optimizer/statistics/operator/propagate_join.cpp
@@ -105,9 +105,6 @@ void StatisticsPropagator::PropagateStatistics(LogicalComparisonJoin &join, uniq
 		switch (join.join_type) {
 		case JoinType::INNER:
 		case JoinType::SEMI:
-		case JoinType::LEFT:
-		case JoinType::RIGHT:
-		case JoinType::OUTER:
 			UpdateFilterStatistics(*condition.left, *condition.right, condition.comparison);
 			break;
 		default:


### PR DESCRIPTION
We cannot merge statistics on outer join conditions, e.g. if we have a `FULL OUTER JOIN` on `i=j`, the resulting statistics of `i` and `j` do **not** change. In the case of an inner join, the statistics of i and j can be merged. i.e.:

```
stats [min, max]
i: [1, 4]
j: [2, 6]
INNER:
i: [2, 4]
j: [2, 4]
FULL OUTER:
i: [1, 4]
j: [2, 6]
```

Before we incorrectly had the same behaviour here for both inner and outer joins, which could lead to incorrect statistics (and incorrect optimiser decisions as a result).