### PR TITLE
Add stats function and turn alias/typeof into regular functions

### DIFF
--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -48,11 +48,6 @@ void BuiltinFunctions::Initialize() {
 
 	RegisterPragmaFunctions();
 
-	// binder functions
-	// FIXME shouldn't be here
-	AddFunction(ScalarFunction("alias", {LogicalType::ANY}, LogicalType::VARCHAR, nullptr));
-	AddFunction(ScalarFunction("typeof", {LogicalType::ANY}, LogicalType::VARCHAR, nullptr));
-
 	// initialize collations
 	AddCollation("nocase", LowerFun::GetFunction(), true);
 	AddCollation("noaccent", StripAccentsFun::GetFunction());

--- a/src/function/scalar/generic/CMakeLists.txt
+++ b/src/function/scalar/generic/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library_unity(duckdb_func_generic OBJECT constant_or_null.cpp least.cpp)
+add_library_unity(duckdb_func_generic OBJECT constant_or_null.cpp least.cpp stats.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_generic>
     PARENT_SCOPE)

--- a/src/function/scalar/generic/CMakeLists.txt
+++ b/src/function/scalar/generic/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library_unity(duckdb_func_generic OBJECT constant_or_null.cpp least.cpp stats.cpp)
+add_library_unity(duckdb_func_generic OBJECT alias.cpp constant_or_null.cpp least.cpp stats.cpp typeof.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_generic>
     PARENT_SCOPE)

--- a/src/function/scalar/generic/alias.cpp
+++ b/src/function/scalar/generic/alias.cpp
@@ -1,0 +1,19 @@
+#include "duckdb/function/scalar/generic_functions.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+
+using namespace std;
+
+namespace duckdb {
+
+static void alias_function(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	Value v(state.expr.alias.empty() ? func_expr.children[0]->GetName() : state.expr.alias);
+	result.Reference(v);
+}
+
+void AliasFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("alias", {LogicalType::ANY}, LogicalType::VARCHAR,
+	                                     alias_function));
+}
+
+} // namespace duckdb

--- a/src/function/scalar/generic/stats.cpp
+++ b/src/function/scalar/generic/stats.cpp
@@ -1,0 +1,50 @@
+#include "duckdb/function/scalar/generic_functions.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+
+using namespace std;
+
+namespace duckdb {
+
+struct StatsBindData : public FunctionData {
+	StatsBindData(string stats = string()) : stats(move(stats)) {
+	}
+
+	string stats;
+
+public:
+	unique_ptr<FunctionData> Copy() override {
+		return make_unique<StatsBindData>(stats);
+	}
+};
+
+static void stats_function(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (StatsBindData &)*func_expr.bind_info;
+	if (info.stats.empty()) {
+		info.stats = "No statistics";
+	}
+	Value v(info.stats);
+	result.Reference(v);
+}
+
+unique_ptr<FunctionData> stats_bind(ClientContext &context, ScalarFunction &bound_function,
+                                               vector<unique_ptr<Expression>> &arguments) {
+	return make_unique<StatsBindData>();
+}
+
+static unique_ptr<BaseStatistics> stats_propagate_stats(ClientContext &context, BoundFunctionExpression &expr,
+                                                              FunctionData *bind_data,
+                                                              vector<unique_ptr<BaseStatistics>> &child_stats) {
+	if (child_stats[0]) {
+		auto &info = (StatsBindData &) *bind_data;
+		info.stats = child_stats[0]->ToString();
+	}
+	return nullptr;
+}
+
+void StatsFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("stats", {LogicalType::ANY}, LogicalType::VARCHAR,
+	                                     stats_function, true, stats_bind, nullptr, stats_propagate_stats));
+}
+
+} // namespace duckdb

--- a/src/function/scalar/generic/typeof.cpp
+++ b/src/function/scalar/generic/typeof.cpp
@@ -1,0 +1,17 @@
+#include "duckdb/function/scalar/generic_functions.hpp"
+
+using namespace std;
+
+namespace duckdb {
+
+static void typeof_function(DataChunk &args, ExpressionState &state, Vector &result) {
+	Value v(args.data[0].type.ToString());
+	result.Reference(v);
+}
+
+void TypeOfFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("typeof", {LogicalType::ANY}, LogicalType::VARCHAR,
+	                                     typeof_function));
+}
+
+} // namespace duckdb

--- a/src/function/scalar/generic_functions.cpp
+++ b/src/function/scalar/generic_functions.cpp
@@ -6,6 +6,7 @@ using namespace std;
 void BuiltinFunctions::RegisterGenericFunctions() {
 	Register<LeastFun>();
 	Register<GreatestFun>();
+	Register<StatsFun>();
 }
 
 } // namespace duckdb

--- a/src/function/scalar/generic_functions.cpp
+++ b/src/function/scalar/generic_functions.cpp
@@ -4,9 +4,11 @@ namespace duckdb {
 using namespace std;
 
 void BuiltinFunctions::RegisterGenericFunctions() {
+	Register<AliasFun>();
 	Register<LeastFun>();
 	Register<GreatestFun>();
 	Register<StatsFun>();
+	Register<TypeOfFun>();
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/common/operator/comparison_operators.hpp
+++ b/src/include/duckdb/common/operator/comparison_operators.hpp
@@ -97,7 +97,6 @@ template <class OP> static bool templated_string_compare_op(string_t left, strin
 	auto memcmp_res =
 	    memcmp(left.GetDataUnsafe(), right.GetDataUnsafe(), MinValue<idx_t>(left.GetSize(), right.GetSize()));
 	auto final_res = memcmp_res == 0 ? OP::Operation(left.GetSize(), right.GetSize()) : OP::Operation(memcmp_res, 0);
-	D_ASSERT(final_res == OP::Operation(strcmp(left.GetString().c_str(), right.GetString().c_str()), 0));
 	return final_res;
 }
 

--- a/src/include/duckdb/function/scalar/generic_functions.hpp
+++ b/src/include/duckdb/function/scalar/generic_functions.hpp
@@ -22,6 +22,10 @@ struct GreatestFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct StatsFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct ConstantOrNull {
 	static ScalarFunction GetFunction(LogicalType return_type);
 	static unique_ptr<FunctionData> Bind(Value value);

--- a/src/include/duckdb/function/scalar/generic_functions.hpp
+++ b/src/include/duckdb/function/scalar/generic_functions.hpp
@@ -14,6 +14,10 @@
 namespace duckdb {
 class BoundFunctionExpression;
 
+struct AliasFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct LeastFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
@@ -23,6 +27,10 @@ struct GreatestFun {
 };
 
 struct StatsFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
+struct TypeOfFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 

--- a/src/optimizer/statistics/expression/propagate_constant.cpp
+++ b/src/optimizer/statistics/expression/propagate_constant.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/optimizer/statistics_propagator.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/storage/statistics/numeric_statistics.hpp"
+#include "duckdb/storage/statistics/string_statistics.hpp"
 
 namespace duckdb {
 
@@ -16,6 +17,13 @@ unique_ptr<BaseStatistics> StatisticsPropagator::StatisticsFromValue(const Value
 	case PhysicalType::DOUBLE: {
 		auto result = make_unique<NumericStatistics>(input.type(), input, input);
 		result->has_null = input.is_null;
+		return move(result);
+	}
+	case PhysicalType::VARCHAR: {
+		auto result = make_unique<StringStatistics>(input.type());
+		result->has_null = input.is_null;
+		string_t str(input.str_value.c_str(), input.str_value.size());
+		result->Update(str);
 		return move(result);
 	}
 	default:

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -54,23 +54,6 @@ BindResult ExpressionBinder::BindFunction(FunctionExpression &function, ScalarFu
 		auto &child = (BoundExpression &)*function.children[i];
 		children.push_back(move(child.expr));
 	}
-	// special binder-only functions
-	// FIXME: these shouldn't be special
-	if (function.function_name == "alias") {
-		if (children.size() != 1) {
-			throw BinderException(binder.FormatError(function, "alias function expects a single argument"));
-		}
-		// alias function: returns the alias of the current expression, or the name of the child
-		string alias = !function.alias.empty() ? function.alias : children[0]->GetName();
-		return BindResult(make_unique<BoundConstantExpression>(Value(alias)));
-	} else if (function.function_name == "typeof") {
-		if (children.size() != 1) {
-			throw BinderException(binder.FormatError(function, "typeof function expects a single argument"));
-		}
-		// typeof function: returns the type of the child expression
-		string type = children[0]->return_type.ToString();
-		return BindResult(make_unique<BoundConstantExpression>(Value(type)));
-	}
 	unique_ptr<Expression> result =
 	    ScalarFunction::BindScalarFunction(context, *func, move(children), error, function.is_operator);
 	if (!result) {

--- a/test/sql/function/generic/test_stats.test
+++ b/test/sql/function/generic/test_stats.test
@@ -1,0 +1,59 @@
+# name: test/sql/function/generic/test_stats.test
+# description: Test stats function
+# group: [generic]
+
+# scalar stats
+query I
+SELECT STATS(5);
+----
+<REGEX>:.*5.*5.*
+
+query I
+SELECT STATS(7);
+----
+<REGEX>:.*7.*7.*
+
+query I
+SELECT STATS('hello');
+----
+<REGEX>:.*hello.*hello.*
+
+# arithmetic
+query I
+SELECT STATS(5+2);
+----
+<REGEX>:.*7.*7.*
+
+# non-scalar stats
+statement ok
+CREATE TABLE integers(i INTEGER);
+
+statement ok
+INSERT INTO integers VALUES (1), (2), (3);
+
+# read stats
+query I
+SELECT STATS(i) FROM integers LIMIT 1;
+----
+<REGEX>:.*1.*3.*
+
+# arithmetic
+query I
+SELECT STATS(i+2) FROM integers LIMIT 1;
+----
+<REGEX>:.*3.*5.*
+
+query I
+SELECT STATS(i-5) FROM integers LIMIT 1;
+----
+<REGEX>:.*-4.*-2.*
+
+query I
+SELECT STATS(i*2) FROM integers LIMIT 1;
+----
+<REGEX>:.*2.*6.*
+
+query I
+SELECT STATS(i*-1) FROM integers LIMIT 1;
+----
+<REGEX>:.*-3.*-1.*


### PR DESCRIPTION
This PR adds the `stats` function that can be used to inspect the statistics of expressions, e.g.:

```sql
D select stats(5);
┌───────────────────────────────────────────────────────────────┐
│                           stats(5)                            │
├───────────────────────────────────────────────────────────────┤
│ Numeric Statistics<INTEGER> [Has Null: false, Min: 5, Max: 5] │
└───────────────────────────────────────────────────────────────┘
```