### PR TITLE
Truncate invalid utf8 in StringStatistics::ToString

### DIFF
--- a/src/storage/statistics/string_statistics.cpp
+++ b/src/storage/statistics/string_statistics.cpp
@@ -125,18 +125,22 @@ bool StringStatistics::CheckZonemap(ExpressionType comparison_type, string const
 	}
 }
 
+static idx_t GetValidMinMaxSubstring(data_ptr_t data) {
+	idx_t len = 0;
+	for(idx_t i = 0; i < StringStatistics::MAX_STRING_MINMAX_SIZE; i++) {
+		if (data[i] == '\0') {
+			return i;
+		}
+		if ((data[i] & 0xC0) != 0x80) {
+			len = i;
+		}
+	}
+	return len;
+}
+
 string StringStatistics::ToString() {
-	idx_t min_len, max_len;
-	for (min_len = 0; min_len < MAX_STRING_MINMAX_SIZE; min_len++) {
-		if (min[min_len] == '\0') {
-			break;
-		}
-	}
-	for (max_len = 0; max_len < MAX_STRING_MINMAX_SIZE; max_len++) {
-		if (max[max_len] == '\0') {
-			break;
-		}
-	}
+	idx_t min_len = GetValidMinMaxSubstring(min);
+	idx_t max_len = GetValidMinMaxSubstring(max);
 	return StringUtil::Format(
 	    "String Statistics [Has Null: %s, Min: %s, Max: %s, Has Unicode: %s, Max String Length: %lld]",
 	    has_null ? "true" : "false", string((const char *)min, min_len), string((const char *)max, max_len),

--- a/test/sql/function/generic/test_stats.test
+++ b/test/sql/function/generic/test_stats.test
@@ -18,6 +18,11 @@ SELECT STATS('hello');
 ----
 <REGEX>:.*hello.*hello.*
 
+query I
+SELECT STATS('1234567ü');
+----
+<REGEX>:.*1234567.*1234567.*
+
 # arithmetic
 query I
 SELECT STATS(5+2);


### PR DESCRIPTION
This prevents invalid UTF8 errors from happening with calls to `stats`.