### PR TITLE
Fix for Q01 statistics propagation: always propagate decimal statistics

### DIFF
--- a/src/function/scalar/operators/add.cpp
+++ b/src/function/scalar/operators/add.cpp
@@ -132,18 +132,31 @@ template <> bool TryAddOperator::Operation(int64_t left, int64_t right, int64_t 
 //===--------------------------------------------------------------------===//
 // add decimal with overflow check
 //===--------------------------------------------------------------------===//
-template <> bool TryDecimalAdd::Operation(int64_t left, int64_t right, int64_t &result) {
+template<class T, T min, T max>
+bool TryDecimalAddTemplated(T left, T right, T &result) {
 	if (right < 0) {
-		if (-999999999999999999 - right > left) {
+		if (min - right > left) {
 			return false;
 		}
 	} else {
-		if (999999999999999999 - right < left) {
+		if (max - right < left) {
 			return false;
 		}
 	}
 	result = left + right;
 	return true;
+}
+
+template <> bool TryDecimalAdd::Operation(int16_t left, int16_t right, int16_t &result) {
+	return TryDecimalAddTemplated<int16_t, -9999, 9999>(left, right, result);
+}
+
+template <> bool TryDecimalAdd::Operation(int32_t left, int32_t right, int32_t &result) {
+	return TryDecimalAddTemplated<int32_t, -999999999, 999999999>(left, right, result);
+}
+
+template <> bool TryDecimalAdd::Operation(int64_t left, int64_t right, int64_t &result) {
+	return TryDecimalAddTemplated<int64_t, -999999999999999999, 999999999999999999>(left, right, result);
 }
 
 template <> bool TryDecimalAdd::Operation(hugeint_t left, hugeint_t right, hugeint_t &result) {

--- a/src/function/scalar/operators/arithmetic.cpp
+++ b/src/function/scalar/operators/arithmetic.cpp
@@ -190,17 +190,17 @@ unique_ptr<FunctionData> bind_decimal_add_subtract(ClientContext &context, Scala
 	// now select the physical function to execute
 	if (check_overflow) {
 		bound_function.function = GetScalarBinaryFunction<OPOVERFLOWCHECK>(result_type.InternalType());
-		if (result_type.InternalType() != PhysicalType::INT128) {
-			if (IS_SUBTRACT) {
-				bound_function.statistics =
-				    propagate_numeric_statistics<TryDecimalSubtract, SubtractPropagateStatistics, SubtractOperator>;
-			} else {
-				bound_function.statistics =
-				    propagate_numeric_statistics<TryDecimalAdd, AddPropagateStatistics, AddOperator>;
-			}
-		}
 	} else {
 		bound_function.function = GetScalarBinaryFunction<OP>(result_type.InternalType());
+	}
+	if (result_type.InternalType() != PhysicalType::INT128) {
+		if (IS_SUBTRACT) {
+			bound_function.statistics =
+				propagate_numeric_statistics<TryDecimalSubtract, SubtractPropagateStatistics, SubtractOperator>;
+		} else {
+			bound_function.statistics =
+				propagate_numeric_statistics<TryDecimalAdd, AddPropagateStatistics, AddOperator>;
+		}
 	}
 	return nullptr;
 }
@@ -473,12 +473,12 @@ unique_ptr<FunctionData> bind_decimal_multiply(ClientContext &context, ScalarFun
 	// now select the physical function to execute
 	if (check_overflow) {
 		bound_function.function = GetScalarBinaryFunction<DecimalMultiplyOverflowCheck>(result_type.InternalType());
-		if (result_type.InternalType() != PhysicalType::INT128) {
-			bound_function.statistics =
-			    propagate_numeric_statistics<TryDecimalMultiply, MultiplyPropagateStatistics, MultiplyOperator>;
-		}
 	} else {
 		bound_function.function = GetScalarBinaryFunction<MultiplyOperator>(result_type.InternalType());
+	}
+	if (result_type.InternalType() != PhysicalType::INT128) {
+		bound_function.statistics =
+			propagate_numeric_statistics<TryDecimalMultiply, MultiplyPropagateStatistics, MultiplyOperator>;
 	}
 	return nullptr;
 }

--- a/src/function/scalar/operators/multiply.cpp
+++ b/src/function/scalar/operators/multiply.cpp
@@ -127,12 +127,24 @@ template <> bool TryMultiplyOperator::Operation(int64_t left, int64_t right, int
 //===--------------------------------------------------------------------===//
 // multiply  decimal with overflow check
 //===--------------------------------------------------------------------===//
-template <> bool TryDecimalMultiply::Operation(int64_t left, int64_t right, int64_t &result) {
-	if (!TryMultiplyOperator::Operation(left, right, result) || result <= -1000000000000000000 ||
-	    result >= 1000000000000000000) {
+template<class T, T min, T max>
+bool TryDecimalMultiplyTemplated(T left, T right, T &result) {
+	if (!TryMultiplyOperator::Operation(left, right, result) || result < min || result > max) {
 		return false;
 	}
 	return true;
+}
+
+template <> bool TryDecimalMultiply::Operation(int16_t left, int16_t right, int16_t &result) {
+	return TryDecimalMultiplyTemplated<int16_t, -9999, 9999>(left, right, result);
+}
+
+template <> bool TryDecimalMultiply::Operation(int32_t left, int32_t right, int32_t &result) {
+	return TryDecimalMultiplyTemplated<int32_t, -999999999, 999999999>(left, right, result);
+}
+
+template <> bool TryDecimalMultiply::Operation(int64_t left, int64_t right, int64_t &result) {
+	return TryDecimalMultiplyTemplated<int64_t, -999999999999999999, 999999999999999999>(left, right, result);
 }
 
 template <> bool TryDecimalMultiply::Operation(hugeint_t left, hugeint_t right, hugeint_t &result) {

--- a/src/function/scalar/operators/subtract.cpp
+++ b/src/function/scalar/operators/subtract.cpp
@@ -111,18 +111,31 @@ template <> bool TrySubtractOperator::Operation(int64_t left, int64_t right, int
 //===--------------------------------------------------------------------===//
 // subtract decimal with overflow check
 //===--------------------------------------------------------------------===//
-template <> bool TryDecimalSubtract::Operation(int64_t left, int64_t right, int64_t &result) {
+template<class T, T min, T max>
+bool TryDecimalSubtractTemplated(T left, T right, T &result) {
 	if (right < 0) {
-		if (999999999999999999 + right < left) {
+		if (max + right < left) {
 			return false;
 		}
 	} else {
-		if (-999999999999999999 + right > left) {
+		if (min + right > left) {
 			return false;
 		}
 	}
 	result = left - right;
 	return true;
+}
+
+template <> bool TryDecimalSubtract::Operation(int16_t left, int16_t right, int16_t &result) {
+	return TryDecimalSubtractTemplated<int16_t, -9999, 9999>(left, right, result);
+}
+
+template <> bool TryDecimalSubtract::Operation(int32_t left, int32_t right, int32_t &result) {
+	return TryDecimalSubtractTemplated<int32_t, -999999999, 999999999>(left, right, result);
+}
+
+template <> bool TryDecimalSubtract::Operation(int64_t left, int64_t right, int64_t &result) {
+	return TryDecimalSubtractTemplated<int64_t, -999999999999999999, 999999999999999999>(left, right, result);
 }
 
 template <> bool TryDecimalSubtract::Operation(hugeint_t left, hugeint_t right, hugeint_t &result) {

--- a/src/include/duckdb/common/operator/add.hpp
+++ b/src/include/duckdb/common/operator/add.hpp
@@ -55,6 +55,8 @@ struct TryDecimalAdd {
 	}
 };
 
+template <> bool TryDecimalAdd::Operation(int16_t left, int16_t right, int16_t &result);
+template <> bool TryDecimalAdd::Operation(int32_t left, int32_t right, int32_t &result);
 template <> bool TryDecimalAdd::Operation(int64_t left, int64_t right, int64_t &result);
 template <> bool TryDecimalAdd::Operation(hugeint_t left, hugeint_t right, hugeint_t &result);
 

--- a/src/include/duckdb/common/operator/multiply.hpp
+++ b/src/include/duckdb/common/operator/multiply.hpp
@@ -52,6 +52,8 @@ struct TryDecimalMultiply {
 	}
 };
 
+template <> bool TryDecimalMultiply::Operation(int16_t left, int16_t right, int16_t &result);
+template <> bool TryDecimalMultiply::Operation(int32_t left, int32_t right, int32_t &result);
 template <> bool TryDecimalMultiply::Operation(int64_t left, int64_t right, int64_t &result);
 template <> bool TryDecimalMultiply::Operation(hugeint_t left, hugeint_t right, hugeint_t &result);
 

--- a/src/include/duckdb/common/operator/subtract.hpp
+++ b/src/include/duckdb/common/operator/subtract.hpp
@@ -54,6 +54,8 @@ struct TryDecimalSubtract {
 	}
 };
 
+template <> bool TryDecimalSubtract::Operation(int16_t left, int16_t right, int16_t &result);
+template <> bool TryDecimalSubtract::Operation(int32_t left, int32_t right, int32_t &result);
 template <> bool TryDecimalSubtract::Operation(int64_t left, int64_t right, int64_t &result);
 template <> bool TryDecimalSubtract::Operation(hugeint_t left, hugeint_t right, hugeint_t &result);
 

--- a/test/sql/tpch/q01_propagate.test_slow
+++ b/test/sql/tpch/q01_propagate.test_slow
@@ -1,0 +1,28 @@
+# name: test/sql/tpch/q01_propagate.test_slow
+# description: Test statistics propagation in Q01
+# group: [tpch]
+
+require tpch
+
+statement ok
+CALL dbgen(sf=0.01);
+
+query I
+SELECT stats(1 - l_discount) FROM lineitem LIMIT 1;
+----
+<REGEX>:.*0.90.*1.00.*
+
+query I
+SELECT stats(1 + l_tax) FROM lineitem LIMIT 1;
+----
+<REGEX>:.*1.00.*1.08.*
+
+query I
+SELECT stats(l_extendedprice * (1 - l_discount)) FROM lineitem LIMIT 1;
+----
+<REGEX>:.*813.6000.*94949.5000.*
+
+query I
+SELECT stats(l_extendedprice * (1 - l_discount) * (1 + l_tax)) FROM lineitem LIMIT 1;
+----
+<REGEX>:.*813.600000.*102545.460000.*

--- a/test/sql/types/decimal/decimal_arithmetic.test
+++ b/test/sql/types/decimal/decimal_arithmetic.test
@@ -17,8 +17,6 @@ SELECT +('0.1'::DECIMAL), +('-0.1'::DECIMAL)
 ----
 0.1	-0.1
 
-
-
 # addition
 query I
 SELECT '0.1'::DECIMAL + '0.1'::DECIMAL
@@ -173,3 +171,33 @@ SELECT '0.001'::DECIMAL * 100::TINYINT,
 # multiplication could not be performed exactly: throw error
 statement error
 SELECT '0.000000000000000000000000000001'::DECIMAL(38,30) * '0.000000000000000000000000000001'::DECIMAL(38,30)
+
+# test addition, subtraction and multiplication with various scales and precisions
+query IIII
+SELECT 2.0 + 1.0,
+       2.0000 + 1.0000,
+       2.000000000000 + 1.000000000000,
+       2.00000000000000000000 + 1.00000000000000000000
+----
+3.0
+3.0000
+3.000000000000
+3.00000000000000000000
+
+query IIII
+SELECT 2.0 - 1.0,
+       2.0000 - 1.0000,
+       2.000000000000 - 1.000000000000,
+       2.00000000000000000000 - 1.00000000000000000000
+----
+1.0
+1.0000
+1.000000000000
+1.00000000000000000000
+
+query II
+SELECT 2.0 * 1.0,
+       2.0000 * 1.0000
+----
+2.0
+2.0000


### PR DESCRIPTION
Previously decimal statistics would only be propagated when there was a possibility of overflows, now they should always be propagated. This fixes statistics propagation in Q01 which brings a 25%~ speedup from avoiding overflow checks.