### PR TITLE
Python binding: Add module attributes for introspecting DuckDB version

### DIFF
--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -1382,6 +1382,11 @@ static py::object py_tokenize(string query) {
 }
 
 PYBIND11_MODULE(duckdb, m) {
+	m.doc() = "DuckDB is an embeddable SQL OLAP Database Management System";
+	m.attr("__package__") = "duckdb";
+	m.attr("__version__") = DuckDB::LibraryVersion();
+	m.attr("__git_revision__") = DuckDB::SourceID();
+
 	m.def("connect", &DuckDBPyConnection::connect,
 	      "Create a DuckDB database instance. Can take a database file name to read/write persistent data and a "
 	      "read_only flag if no changes are desired",


### PR DESCRIPTION
Dear Mark and Hannes,

this is just a humble improvement to the Python binding. It will bring:
```
>>> import duckdb
>>> duckdb.__doc__
'DuckDB is an embeddable SQL OLAP Database Management System'
```

Actually, I wanted to just add the `__version__` attribute in order to be able to find out about the DuckDB version at runtime. However, the current implementation using `DuckDB::LibraryVersion()` just yields:
```
>>> duckdb.__version__
'DuckDB'
```

Maybe you will have a hint about this?

With kind regards,
Andreas.
