### PR TITLE
Build wheels for Python 3.6 on macOS again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -689,7 +689,7 @@ jobs:
     needs: linux-debug
 
     env:
-      CIBW_BUILD: 'cp37-* cp38-* cp39-*'
+      CIBW_BUILD: 'cp36-* cp37-* cp38-* cp39-*'
       CIBW_BEFORE_BUILD: 'pip install --prefer-binary "pandas>=0.24" "pytest>=4.3"'
       CIBW_TEST_REQUIRES: 'pytest'
       CIBW_BEFORE_TEST: 'pip install --prefer-binary "pandas>=0.24"'


### PR DESCRIPTION
Hi again,

#1081 apparently dropped building wheels for Python 3.6 on macOS. I don't know about the background yet, but this patch humbly tries to bring it back in order to align with the builds for Linux and Windows.

At [Wetterdienst](https://github.com/earthobservations/wetterdienst), we still support Python 3.6 and after upgrading to the most recent `0.2.3.dev517`, GHA croaked [1].

With kind regards,
Andreas.

[1] https://github.com/earthobservations/wetterdienst/runs/1486934616