### PR TITLE
Add DISABLE_THREADS switch that turns off the launching of background threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,7 @@ option(BUILD_TPCE "Enable building of the TPC-E tool." FALSE)
 option(JDBC_DRIVER "Build the DuckDB JDBC driver" FALSE)
 option(BUILD_PYTHON "Build the DuckDB Python extension" FALSE)
 option(BUILD_REST "Build the DuckDB REST server" FALSE)
+option(DISABLE_THREADS "Disable support for multi-threading" FALSE)
 option(
   ASSERT_EXCEPTION
   "Throw an exception on an assert failing, instead of triggering a sigabort"
@@ -371,6 +372,10 @@ function(link_extension_libraries LIBRARY)
   if(${BUILD_TPCH_EXTENSION})
    target_link_libraries(${LIBRARY} tpch_extension)
   endif()
+endfunction()
+
+function(link_threads LIBRARY)
+  target_link_libraries(${LIBRARY} Threads::Threads)
 endfunction()
 
 add_subdirectory(extension)

--- a/extension/icu/CMakeLists.txt
+++ b/extension/icu/CMakeLists.txt
@@ -5,5 +5,5 @@ project(ICUExtension)
 include_directories(include)
 
 add_library(icu_extension STATIC icu-collate.cpp icu-extension.cpp)
-target_link_libraries(icu_extension Threads::Threads)
+link_threads(icu_extension)
 disable_target_warnings(icu_extension)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,8 +31,8 @@ if(AMALGAMATION_BUILD)
   add_library(duckdb_static STATIC
               "${PROJECT_SOURCE_DIR}/src/amalgamation/duckdb.cpp")
 
-  target_link_libraries(duckdb Threads::Threads)
-  target_link_libraries(duckdb_static Threads::Threads)
+  link_threads(duckdb)
+  link_threads(duckdb_static)
 
   install(FILES "${PROJECT_SOURCE_DIR}/src/amalgamation/duckdb.hpp"
           DESTINATION "${INSTALL_INCLUDE_DIR}")
@@ -51,13 +51,15 @@ else()
   add_subdirectory(storage)
   add_subdirectory(transaction)
 
-  set(DUCKDB_LINK_LIBS fmt pg_query duckdb_re2 miniz utf8proc Threads::Threads)
+  set(DUCKDB_LINK_LIBS fmt pg_query duckdb_re2 miniz utf8proc)
 
   add_library(duckdb SHARED ${ALL_OBJECT_FILES})
   target_link_libraries(duckdb ${DUCKDB_LINK_LIBS})
+  link_threads(duckdb)
 
   add_library(duckdb_static STATIC ${ALL_OBJECT_FILES})
   target_link_libraries(duckdb_static ${DUCKDB_LINK_LIBS})
+  link_threads(duckdb_static)
 
   target_include_directories(
     duckdb PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/src/include/duckdb/parallel/task_scheduler.hpp
+++ b/src/include/duckdb/parallel/task_scheduler.hpp
@@ -10,7 +10,6 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/mutex.hpp"
-#include "duckdb/common/thread.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/parallel/task.hpp"
 
@@ -20,6 +19,8 @@ struct ConcurrentQueue;
 struct QueueProducerToken;
 class ClientContext;
 class TaskScheduler;
+
+struct SchedulerThread;
 
 struct ProducerToken {
 	ProducerToken(TaskScheduler &scheduler, unique_ptr<QueueProducerToken> token);
@@ -59,7 +60,7 @@ private:
 	//! The task queue
 	unique_ptr<ConcurrentQueue> queue;
 	//! The active background threads of the task scheduler
-	vector<unique_ptr<thread>> threads;
+	vector<unique_ptr<SchedulerThread>> threads;
 	//! Markers used by the various threads, if the markers are set to "false" the thread execution is stopped
 	vector<unique_ptr<bool>> markers;
 };

--- a/src/parallel/CMakeLists.txt
+++ b/src/parallel/CMakeLists.txt
@@ -1,3 +1,8 @@
+
+if(!${DISABLE_THREADS})
+    add_definitions(-DDUCKDB_NO_THREADS)
+endif()
+
 add_library_unity(duckdb_parallel
                   OBJECT
                   executor.cpp

--- a/src/parallel/CMakeLists.txt
+++ b/src/parallel/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-if(!${DISABLE_THREADS})
+if(${DISABLE_THREADS})
     add_definitions(-DDUCKDB_NO_THREADS)
 endif()
 

--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -59,7 +59,7 @@ bool ConcurrentQueue::dequeue_from_producer(ProducerToken &token, unique_ptr<Tas
 
 #else
 struct ConcurrentQueue {
-	std::queue q;
+	std::queue<std::unique_ptr<Task>> q;
 	mutex qlock;
 
 	void enqueue(ProducerToken &token, unique_ptr<Task> task);
@@ -68,7 +68,7 @@ struct ConcurrentQueue {
 
 void ConcurrentQueue::enqueue(ProducerToken &token, unique_ptr<Task> task) {
 	lock_guard<mutex> lock(qlock);
-	q.enqueue(move(task));
+	q.push(move(task));
 }
 
 bool ConcurrentQueue::dequeue_from_producer(ProducerToken &token, unique_ptr<Task> &task) {
@@ -76,7 +76,8 @@ bool ConcurrentQueue::dequeue_from_producer(ProducerToken &token, unique_ptr<Tas
 	if (q.empty()) {
 		return false;
 	}
-	task = q.dequeue();
+	task = move(q.front());
+	q.pop();
 	return true;
 }
 

--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -106,7 +106,7 @@ void TaskScheduler::SetThreads(int32_t n) {
 	if (n < 1) {
 		throw SyntaxException("Must have at least 1 thread!");
 	}
-	if (threads.size() == n - 1) {
+	if (threads.size() == idx_t(n - 1)) {
 		return;
 	}
 #ifndef DUCKDB_NO_THREADS

--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -17,9 +17,9 @@ namespace duckdb {
 
 struct SchedulerThread {
 #ifndef DUCKDB_NO_THREADS
-	SchedulerThread(unique_ptr<thread> thread) : thread(move(thread)) {}
+	SchedulerThread(unique_ptr<thread> thread_p) : thread_(move(thread_p)) {}
 
-	unique_ptr<thread> thread;
+	unique_ptr<thread> thread_;
 #endif
 };
 
@@ -123,7 +123,7 @@ void TaskScheduler::SetThreads(int32_t n) {
 		}
 		// now join the threads to ensure they are fully stopped before erasing them
 		for (idx_t i = new_thread_count; i < threads.size(); i++) {
-			threads[i]->thread->join();
+			threads[i]->thread_->join();
 		}
 		// erase the threads/markers
 		threads.resize(new_thread_count);

--- a/third_party/sqlsmith/CMakeLists.txt
+++ b/third_party/sqlsmith/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(
   schema.cc
   sqlsmith.cc)
 target_link_libraries(sqlsmith duckdb tpch_extension)
-target_link_libraries(sqlsmith Threads::Threads)
+link_threads(sqlsmith)
 
 set_target_properties(
   sqlsmith

--- a/tools/nodejs/CMakeLists.txt
+++ b/tools/nodejs/CMakeLists.txt
@@ -4,4 +4,5 @@ include_directories(/usr/local/Cellar/node/14.12.0/include/node/)
 
 set(CMAKE_SHARED_LINKER_FLAGS "-bundle" "-undefined dynamic_lookup")
 add_library(node_duckdb src/duckdb_node.cpp src/database.cpp src/connection.cpp src/statement.cpp src/utils.cpp)
-target_link_libraries(node_duckdb duckdb_static Threads::Threads)
+target_link_libraries(node_duckdb duckdb_static)
+link_threads(node_duckdb)

--- a/tools/rest/CMakeLists.txt
+++ b/tools/rest/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 add_extension_definitions()
 
-target_link_libraries(duckdb_rest_server duckdb_static Threads::Threads
-                      ${LINK_EXTRA})
+target_link_libraries(duckdb_rest_server duckdb_static ${LINK_EXTRA})
+link_threads(duckdb_rest_server)
 
 link_extension_libraries(duckdb_rest_server)

--- a/tools/shell/CMakeLists.txt
+++ b/tools/shell/CMakeLists.txt
@@ -12,8 +12,9 @@ option(STATIC_LIBCPP "Statically link CLI to libc++" FALSE)
 include_directories(include)
 include_directories(../sqlite3_api_wrapper/include)
 add_executable(shell ${SHELL_SOURCES})
-target_link_libraries(shell sqlite3_api_wrapper_static Threads::Threads
+target_link_libraries(shell sqlite3_api_wrapper_static
                       ${DUCKDB_EXTRA_LINK_FLAGS})
+link_threads(shell)
 if(STATIC_LIBCPP)
   message("Statically linking CLI")
   target_link_libraries(shell -static-libstdc++ -static-libgcc)

--- a/tools/sqlite3_api_wrapper/CMakeLists.txt
+++ b/tools/sqlite3_api_wrapper/CMakeLists.txt
@@ -6,12 +6,14 @@ add_definitions(-DSQLITE_SHELL_IS_UTF8)
 
 add_library(sqlite3_api_wrapper SHARED sqlite3_api_wrapper.cpp
                                        ${ALL_OBJECT_FILES})
-target_link_libraries(sqlite3_api_wrapper duckdb Threads::Threads
+target_link_libraries(sqlite3_api_wrapper duckdb
                       ${DUCKDB_EXTRA_LINK_FLAGS})
+link_threads(sqlite3_api_wrapper)
 
 add_library(sqlite3_api_wrapper_static STATIC sqlite3_api_wrapper.cpp
                                               ${ALL_OBJECT_FILES})
-target_link_libraries(sqlite3_api_wrapper_static duckdb_static Threads::Threads)
+target_link_libraries(sqlite3_api_wrapper_static duckdb_static)
+link_threads(sqlite3_api_wrapper_static)
 
 link_extension_libraries(sqlite3_api_wrapper)
 link_extension_libraries(sqlite3_api_wrapper_static)


### PR DESCRIPTION
See #1193

@ankoh Can you check if this is sufficient? There are still some places where thread local storage is used (primarily in the Postgres parser), but no threads should be used. We can probably work around that by turning those into globals and adding a global lock around the parser (I assume concurrent parsing is not exactly required in the JS version?).

I believe there is also `std::call_once` being used in RE2 that required linking to pthread on Linux. Not sure if that would be a problem.