### PR TITLE
Write shell history to file when added to allow crash recovery, and fix crash when .importing file with invalid UTF8

### DIFF
--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -414,6 +414,19 @@ SELECT SUM(i)*MAX(i) FROM integers JOIN integers2 USING (i);
 
 shutil.rmtree(target_dir)
 
+# test using .import with a CSV file containing invalid UTF8
+
+duckdb_nonsensecsv = 'duckdbtest_nonsensecsv.csv'
+with open(duckdb_nonsensecsv, 'wb+') as f:
+     f.write(b'\xFF\n')
+test('''
+.nullvalue NULL
+CREATE TABLE test(i INTEGER);
+.import duckdbtest_nonsensecsv.csv test
+SELECT * FROM test;
+''', out="NULL")
+os.remove(duckdb_nonsensecsv)
+
 # dump blobs: FIXME
 # test('''
 # CREATE TABLE a (b BLOB);

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -552,7 +552,11 @@ int sqlite3_bind_text(sqlite3_stmt *stmt, int idx, const char *val, int length, 
 	if (free_func && ((ptrdiff_t)free_func) != -1) {
 		free_func((void *)val);
 	}
-	return sqlite3_internal_bind_value(stmt, idx, Value(value));
+	try {
+		return sqlite3_internal_bind_value(stmt, idx, Value(value));
+	} catch(std::exception &ex) {
+		return SQLITE_ERROR;
+	}
 }
 
 int sqlite3_clear_bindings(sqlite3_stmt *stmt) {


### PR DESCRIPTION
This fixes #1206 and #1207