### PR TITLE
Fix for parallel pandas scans (fixes #1220)

### DIFF
--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -49,6 +49,7 @@ def includes(extensions):
     includes = []
     includes.append(os.path.join(scripts_dir, '..', 'src', 'include'))
     includes.append(os.path.join(scripts_dir, '..'))
+    includes.append(os.path.join(scripts_dir, '..', 'third_party', 'utf8proc', 'include'))
     for ext in extensions:
         includes.append(os.path.join(scripts_dir, '..', 'extension', ext, 'include'))
     return includes

--- a/src/include/duckdb/common/types/string_type.hpp
+++ b/src/include/duckdb/common/types/string_type.hpp
@@ -25,7 +25,6 @@ public:
 	string_t() = default;
 	string_t(uint32_t len) {
 		value.inlined.length = len;
-		memset(value.inlined.inlined, 0, INLINE_LENGTH);
 	}
 	string_t(const char *data, uint32_t len) {
 		value.inlined.length = len;

--- a/third_party/utf8proc/include/utf8proc_wrapper.hpp
+++ b/third_party/utf8proc/include/utf8proc_wrapper.hpp
@@ -21,6 +21,11 @@ public:
 	static size_t NextGraphemeCluster(const char *s, size_t len, size_t pos);
 	//! Returns the position (in bytes) of the previous grapheme cluster
 	static size_t PreviousGraphemeCluster(const char *s, size_t len, size_t pos);
+
+	//! Transform a codepoint to utf8 and writes it to "c", sets "sz" to the size of the codepoint
+	static bool CodepointToUtf8(int cp, int &sz, char *c);
+	//! Returns the codepoint length in bytes when encoded in UTF8
+	static int CodepointLength(int cp);
 };
 
 }

--- a/third_party/utf8proc/utf8proc_wrapper.cpp
+++ b/third_party/utf8proc/utf8proc_wrapper.cpp
@@ -81,6 +81,14 @@ size_t Utf8Proc::PreviousGraphemeCluster(const char *s, size_t len, size_t cpos)
 	}
 }
 
+bool Utf8Proc::CodepointToUtf8(int cp, int &sz, char *c) {
+	return utf8proc_codepoint_to_utf8(cp, sz, c);
+}
+
+int Utf8Proc::CodepointLength(int cp) {
+	return utf8proc_codepoint_length(cp);
+}
+
 }
 
 size_t utf8proc_next_grapheme_cluster(const char *s, size_t len, size_t pos) {

--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -458,18 +458,7 @@ struct PandasScanFunction : public TableFunction {
 					}
 					tgt_ptr[row] = string_t(dataptr, size);
 				} else if (PyUnicode_CheckExact(val)) {
-					auto data = PyUnicode_AS_UNICODE(val);
-					auto unicode_size = sizeof(Py_UNICODE);
-					switch(unicode_size) {
-					case 2:
-						tgt_ptr[row] = DecodePythonUnicode<Py_UNICODE>(data, PyUnicode_GET_SIZE(val), out);
-						break;
-					case 4:
-						tgt_ptr[row] = DecodePythonUnicode<Py_UNICODE>(data, PyUnicode_GET_SIZE(val), out);
-						break;
-					default:
-						throw runtime_error("Unsupported unicode size");
-					}
+					throw std::runtime_error("Unicode is only supported in Python 3 and up.");
 				} else {
 					FlatVector::SetNull(out, row, true);
 					continue;

--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -282,11 +282,7 @@ struct PandasScanFunction : public TableFunction {
 			} else {
 				// regular type
 				auto column = get_fun(df_columns[col_idx]);
-				if (py::hasattr(column, "to_numpy")) {
-					bind_data.numpy_col = py::array(column.attr("to_numpy")());
-				} else {
-					bind_data.numpy_col = py::array(column);
-				}
+				bind_data.numpy_col = py::array(column.attr("to_numpy")());
 				bind_data.mask = nullptr;
 				if (col_type == "category") {
 					// for category types, we use the converted numpy type

--- a/tools/pythonpkg/tests/test_dbapi12.py
+++ b/tools/pythonpkg/tests/test_dbapi12.py
@@ -2,52 +2,55 @@ import duckdb
 import tempfile
 import os
 import pandas as pd
+import sys
 
 class TestRelationApi(object):
-	def test_readonly(self, duckdb_cursor):
+    def test_readonly(self, duckdb_cursor):
+        if sys.version_info.major < 3:
+            return
 
-		test_df = pd.DataFrame.from_dict({"i":[1, 2, 3], "j":["one", "two", "three"]})
+        test_df = pd.DataFrame.from_dict({"i":[1, 2, 3], "j":["one", "two", "three"]})
 
-		def test_rel(rel, duckdb_cursor):
-			res = rel.filter('i < 3').order('j').project('i').union(rel.filter('i > 2').project('i')).join(rel.set_alias('a1'), 'i').project('CAST(i as BIGINT) i, j').order('i')
-			pd.testing.assert_frame_equal(res.to_df(), test_df)
-			res3 = duckdb_cursor.from_df(res.to_df()).to_df()
-			pd.testing.assert_frame_equal(res3, test_df)
+        def test_rel(rel, duckdb_cursor):
+            res = rel.filter('i < 3').order('j').project('i').union(rel.filter('i > 2').project('i')).join(rel.set_alias('a1'), 'i').project('CAST(i as BIGINT) i, j').order('i')
+            pd.testing.assert_frame_equal(res.to_df(), test_df)
+            res3 = duckdb_cursor.from_df(res.to_df()).to_df()
+            pd.testing.assert_frame_equal(res3, test_df)
 
-			df_sql = res.query('x', 'select CAST(i as BIGINT) i, j from x')
-			pd.testing.assert_frame_equal(df_sql.fetchdf(), test_df)
+            df_sql = res.query('x', 'select CAST(i as BIGINT) i, j from x')
+            pd.testing.assert_frame_equal(df_sql.fetchdf(), test_df)
 
-			res2 = res.aggregate('i, count(j) as cj', 'i').order('i')
-			cmp_df = pd.DataFrame.from_dict({"i":[1, 2, 3], "cj":[1, 1, 1]})
-			pd.testing.assert_frame_equal(res2.to_df(), cmp_df)
+            res2 = res.aggregate('i, count(j) as cj', 'i').order('i')
+            cmp_df = pd.DataFrame.from_dict({"i":[1, 2, 3], "cj":[1, 1, 1]})
+            pd.testing.assert_frame_equal(res2.to_df(), cmp_df)
 
-			rel.create('a2')
-			rel_a2 = duckdb_cursor.table('a2').project('CAST(i as BIGINT) i, j').to_df()
-			pd.testing.assert_frame_equal(rel_a2, test_df)
+            rel.create('a2')
+            rel_a2 = duckdb_cursor.table('a2').project('CAST(i as BIGINT) i, j').to_df()
+            pd.testing.assert_frame_equal(rel_a2, test_df)
 
-			duckdb_cursor.execute('DROP TABLE IF EXISTS a3')
-			duckdb_cursor.execute('CREATE TABLE a3 (i INTEGER, j STRING)')
-			rel.insert_into('a3')
-			rel_a3 = duckdb_cursor.table('a3').project('CAST(i as BIGINT) i, j').to_df()
-			pd.testing.assert_frame_equal(rel_a3, test_df)
+            duckdb_cursor.execute('DROP TABLE IF EXISTS a3')
+            duckdb_cursor.execute('CREATE TABLE a3 (i INTEGER, j STRING)')
+            rel.insert_into('a3')
+            rel_a3 = duckdb_cursor.table('a3').project('CAST(i as BIGINT) i, j').to_df()
+            pd.testing.assert_frame_equal(rel_a3, test_df)
 
-		duckdb_cursor.execute('CREATE TABLE a (i INTEGER, j STRING)')
-		duckdb_cursor.execute("INSERT INTO a VALUES (1, 'one'), (2, 'two'), (3, 'three')")
-		duckdb_cursor.execute('CREATE VIEW v AS SELECT * FROM a')
+        duckdb_cursor.execute('CREATE TABLE a (i INTEGER, j STRING)')
+        duckdb_cursor.execute("INSERT INTO a VALUES (1, 'one'), (2, 'two'), (3, 'three')")
+        duckdb_cursor.execute('CREATE VIEW v AS SELECT * FROM a')
 
-		duckdb_cursor.execute('CREATE TEMPORARY TABLE at (i INTEGER)')
-		duckdb_cursor.execute('CREATE TEMPORARY VIEW vt AS SELECT * FROM at')
+        duckdb_cursor.execute('CREATE TEMPORARY TABLE at (i INTEGER)')
+        duckdb_cursor.execute('CREATE TEMPORARY VIEW vt AS SELECT * FROM at')
 
-		rel_a = duckdb_cursor.table('a')
-		rel_v = duckdb_cursor.view('v')
-		#rel_at = duckdb_cursor.table('at')
-		#rel_vt = duckdb_cursor.view('vt')
+        rel_a = duckdb_cursor.table('a')
+        rel_v = duckdb_cursor.view('v')
+        #rel_at = duckdb_cursor.table('at')
+        #rel_vt = duckdb_cursor.view('vt')
 
-		rel_df = duckdb_cursor.from_df(test_df)
+        rel_df = duckdb_cursor.from_df(test_df)
 
-		test_rel(rel_a, duckdb_cursor)
-		test_rel(rel_v, duckdb_cursor)
-		test_rel(rel_df, duckdb_cursor)
+        test_rel(rel_a, duckdb_cursor)
+        test_rel(rel_v, duckdb_cursor)
+        test_rel(rel_df, duckdb_cursor)
 
 # cursor = duckdb.connect().cursor()
 # TestRelationApi().test_readonly(cursor)

--- a/tools/pythonpkg/tests/test_parallel_pandas_scan.py
+++ b/tools/pythonpkg/tests/test_parallel_pandas_scan.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 import duckdb
 import pandas as pd
 import numpy

--- a/tools/pythonpkg/tests/test_parallel_pandas_scan.py
+++ b/tools/pythonpkg/tests/test_parallel_pandas_scan.py
@@ -1,0 +1,69 @@
+import duckdb
+import pandas as pd
+import numpy
+import datetime
+
+def run_parallel_queries(main_table, left_join_table, expected_df, iteration_count = 5):
+    for i in range(0, iteration_count):
+        output_df = None
+        sql = """
+        select
+            main_table.*
+            ,t1.*
+            ,t2.*
+        from main_table
+        left join left_join_table t1
+            on main_table.join_column = t1.join_column
+        left join left_join_table t2
+            on main_table.join_column = t2.join_column
+        """
+        try:
+            duckdb_conn = duckdb.connect()
+            duckdb_conn.execute("PRAGMA threads=4")
+            duckdb_conn.register('main_table', main_table)
+            duckdb_conn.register('left_join_table', left_join_table)
+            output_df = duckdb_conn.execute(sql).fetchdf()
+            pd.testing.assert_frame_equal(expected_df, output_df)
+            print(output_df)
+        except Exception as err:
+            print(err)
+        finally:
+            duckdb_conn.close()
+
+class TestParallelPandasScan(object):
+    def test_parallel_numeric_scan(self, duckdb_cursor):
+        main_table = pd.DataFrame([{"join_column": 3}])
+        left_join_table = pd.DataFrame([{"join_column": 3,"other_column": 4}])
+        run_parallel_queries(main_table, left_join_table, left_join_table)
+
+    def test_parallel_ascii_text(self, duckdb_cursor):
+        main_table = pd.DataFrame([{"join_column":"text"}])
+        left_join_table = pd.DataFrame([{"join_column":"text","other_column":"more text"}])
+        run_parallel_queries(main_table, left_join_table, left_join_table)
+
+    def test_parallel_unicode_text(self, duckdb_cursor):
+        main_table = pd.DataFrame([{"join_column":"mühleisen"}])
+        left_join_table = pd.DataFrame([{"join_column": u"mühleisen","other_column":u"höhöhö"}])
+        run_parallel_queries(main_table, left_join_table, left_join_table)
+
+    def test_parallel_complex_unicode_text(self, duckdb_cursor):
+        main_table = pd.DataFrame([{"join_column":"鴨"}])
+        left_join_table = pd.DataFrame([{"join_column": u"鴨","other_column":u"數據庫"}])
+        run_parallel_queries(main_table, left_join_table, left_join_table)
+
+    def test_parallel_emojis(self, duckdb_cursor):
+        main_table = pd.DataFrame([{"join_column":"🤦🏼‍♂️ L🤦🏼‍♂️R 🤦🏼‍♂️"}])
+        left_join_table = pd.DataFrame([{"join_column": u"🤦🏼‍♂️ L🤦🏼‍♂️R 🤦🏼‍♂️","other_column":u"🦆🍞🦆"}])
+        run_parallel_queries(main_table, left_join_table, left_join_table)
+
+    def test_parallel_numeric_object(self, duckdb_cursor):
+        main_table = pd.DataFrame({ 'join_column': pd.Series([3], dtype="Int8") })
+        left_join_table = pd.DataFrame({ 'join_column': pd.Series([3], dtype="Int8"), 'other_column': pd.Series([4], dtype="Int8") })
+        expected_df = pd.DataFrame({ "join_column": numpy.array([3], dtype=numpy.int8), "other_column": numpy.array([4], dtype=numpy.int8)})
+        run_parallel_queries(main_table, left_join_table, expected_df)
+
+    def test_parallel_timestamp(self, duckdb_cursor):
+        main_table = pd.DataFrame({ 'join_column': [pd.Timestamp('20180310T11:17:54Z')] })
+        left_join_table = pd.DataFrame({ 'join_column': [pd.Timestamp('20180310T11:17:54Z')], 'other_column': [pd.Timestamp('20190310T11:17:54Z')] })
+        expected_df = pd.DataFrame({ "join_column": numpy.array([datetime.datetime(2018, 3, 10, 11, 17, 54)], dtype='datetime64[ns]'), "other_column": numpy.array([datetime.datetime(2019, 3, 10, 11, 17, 54)], dtype='datetime64[ns]')})
+        run_parallel_queries(main_table, left_join_table, expected_df)

--- a/tools/pythonpkg/tests/test_parallel_pandas_scan.py
+++ b/tools/pythonpkg/tests/test_parallel_pandas_scan.py
@@ -4,6 +4,7 @@ import duckdb
 import pandas as pd
 import numpy
 import datetime
+import sys
 
 def run_parallel_queries(main_table, left_join_table, expected_df, iteration_count = 5):
     for i in range(0, iteration_count):
@@ -49,11 +50,15 @@ class TestParallelPandasScan(object):
         run_parallel_queries(main_table, left_join_table, left_join_table)
 
     def test_parallel_complex_unicode_text(self, duckdb_cursor):
+        if sys.version_info.major < 3:
+            return
         main_table = pd.DataFrame([{"join_column":u"鴨"}])
         left_join_table = pd.DataFrame([{"join_column": u"鴨","other_column":u"數據庫"}])
         run_parallel_queries(main_table, left_join_table, left_join_table)
 
     def test_parallel_emojis(self, duckdb_cursor):
+        if sys.version_info.major < 3:
+            return
         main_table = pd.DataFrame([{"join_column":u"🤦🏼‍♂️ L🤦🏼‍♂️R 🤦🏼‍♂️"}])
         left_join_table = pd.DataFrame([{"join_column": u"🤦🏼‍♂️ L🤦🏼‍♂️R 🤦🏼‍♂️","other_column":u"🦆🍞🦆"}])
         run_parallel_queries(main_table, left_join_table, left_join_table)

--- a/tools/pythonpkg/tests/test_parallel_pandas_scan.py
+++ b/tools/pythonpkg/tests/test_parallel_pandas_scan.py
@@ -44,12 +44,12 @@ class TestParallelPandasScan(object):
         run_parallel_queries(main_table, left_join_table, left_join_table)
 
     def test_parallel_unicode_text(self, duckdb_cursor):
-        main_table = pd.DataFrame([{"join_column":"mühleisen"}])
+        main_table = pd.DataFrame([{"join_column":u"mühleisen"}])
         left_join_table = pd.DataFrame([{"join_column": u"mühleisen","other_column":u"höhöhö"}])
         run_parallel_queries(main_table, left_join_table, left_join_table)
 
     def test_parallel_complex_unicode_text(self, duckdb_cursor):
-        main_table = pd.DataFrame([{"join_column":"鴨"}])
+        main_table = pd.DataFrame([{"join_column":u"鴨"}])
         left_join_table = pd.DataFrame([{"join_column": u"鴨","other_column":u"數據庫"}])
         run_parallel_queries(main_table, left_join_table, left_join_table)
 

--- a/tools/pythonpkg/tests/test_parallel_pandas_scan.py
+++ b/tools/pythonpkg/tests/test_parallel_pandas_scan.py
@@ -54,7 +54,7 @@ class TestParallelPandasScan(object):
         run_parallel_queries(main_table, left_join_table, left_join_table)
 
     def test_parallel_emojis(self, duckdb_cursor):
-        main_table = pd.DataFrame([{"join_column":"🤦🏼‍♂️ L🤦🏼‍♂️R 🤦🏼‍♂️"}])
+        main_table = pd.DataFrame([{"join_column":u"🤦🏼‍♂️ L🤦🏼‍♂️R 🤦🏼‍♂️"}])
         left_join_table = pd.DataFrame([{"join_column": u"🤦🏼‍♂️ L🤦🏼‍♂️R 🤦🏼‍♂️","other_column":u"🦆🍞🦆"}])
         run_parallel_queries(main_table, left_join_table, left_join_table)
 

--- a/tools/pythonpkg/tests/test_unicode.py
+++ b/tools/pythonpkg/tests/test_unicode.py
@@ -5,7 +5,6 @@ import duckdb
 import pandas as pd
 import sys
 
-
 class TestUnicode(object):
     def test_unicode_pandas_scan(self, duckdb_cursor):
         if sys.version_info.major < 3:

--- a/tools/pythonpkg/tests/test_unicode.py
+++ b/tools/pythonpkg/tests/test_unicode.py
@@ -3,10 +3,13 @@
 
 import duckdb
 import pandas as pd
+import sys
 
 
 class TestUnicode(object):
     def test_unicode_pandas_scan(self, duckdb_cursor):
+        if sys.version_info.major < 3:
+            return
         con = duckdb.connect(database=':memory:', read_only=False)
         test_df = pd.DataFrame.from_dict({"i":[1, 2, 3], "j":["a", "c", u"ë"]})
         con.register('test_df_view', test_df)


### PR DESCRIPTION
Pandas scans can happen in parallel in threads that do not hold the GIL when background threads are enabled (i.e. `PRAGMA threads=X` where X > 1). This PR modifies the pandas scans to make sure that we are not constructing Python objects or doing anything that can invoke race conditions (e.g. adding new references to objects).  This PR should also significantly speed up pandas scans of strings, "nullable" integers (e.g. Int8, Int16) and timestamps with timezones, as we are now directly scanning the underlying NumPy arrays rather than doing Python object construction.