### PR TITLE
Add .mode latex support to sqlite shell

### DIFF
--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -427,6 +427,15 @@ SELECT * FROM test;
 ''', out="NULL")
 os.remove(duckdb_nonsensecsv)
 
+# .mode latex
+test('''
+.mode latex
+CREATE TABLE a (I INTEGER);
+.changes off
+INSERT INTO a VALUES (42);
+SELECT * FROM a;
+''', '\\begin{tabular}')
+
 # dump blobs: FIXME
 # test('''
 # CREATE TABLE a (b BLOB);

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -801,9 +801,46 @@ int sqlite3_table_column_metadata(sqlite3 *db,             /* Connection handle 
 	return -1;
 }
 
-const char *sqlite3_column_decltype(sqlite3_stmt *stmt, int col) {
-	fprintf(stderr, "sqlite3_column_decltype: unsupported.\n");
-	return nullptr;
+const char *sqlite3_column_decltype(sqlite3_stmt *pStmt, int iCol) {
+	if (!pStmt || !pStmt->prepared) {
+		return NULL;
+	}
+	auto column_type = pStmt->prepared->types[iCol];
+	switch (column_type.id()) {
+	case LogicalTypeId::BOOLEAN:
+		return "BOOLEAN";
+	case LogicalTypeId::TINYINT:
+		return "TINYINT";
+	case LogicalTypeId::SMALLINT:
+		return "SMALLINT";
+	case LogicalTypeId::INTEGER:
+		return "INTEGER";
+	case LogicalTypeId::BIGINT:
+		return "BIGINT";
+	case LogicalTypeId::FLOAT:
+		return "FLOAT";
+	case LogicalTypeId::DOUBLE:
+		return "DOUBLE";
+	case LogicalTypeId::DECIMAL:
+		return "DECIMAL";
+	case LogicalTypeId::DATE:
+		return "DATE";
+	case LogicalTypeId::TIME:
+		return "TIME";
+	case LogicalTypeId::TIMESTAMP:
+		return "TIMESTAMP";
+	case LogicalTypeId::VARCHAR:
+		return "VARCHAR";
+	case LogicalTypeId::LIST:
+		return "LIST";
+	case LogicalTypeId::STRUCT:
+		return "STRUCT";
+	case LogicalTypeId::BLOB:
+		return "BLOB";
+	default:
+		return NULL;
+	}
+	return NULL;
 }
 
 int sqlite3_status64(int op, sqlite3_int64 *pCurrent, sqlite3_int64 *pHighwater, int resetFlag) {


### PR DESCRIPTION
For those of us that have to write papers :)

Input:
```sql
.mode latex
create table benchmark_results(benchmark varchar, old float, new float);
insert into benchmark_results values ('100000000 unique ASCII strings', '4.45', '0.85');
insert into benchmark_results values ('100000000 integers (numpy.int32)', '0.15', '0.02');
insert into benchmark_results values ('100000000 integers (Int32)', '8.77', '0.06');
select * from benchmark_results;
```

Output:
```latex
\begin{tabular}{|lrr|}
\hline
           benchmark             & old  & new  \\
\hline
100000000 unique ASCII strings   & 4.45 & 0.85 \\
100000000 integers (numpy.int32) & 0.15 & 0.02 \\
100000000 integers (Int32)       & 8.77 & 0.06 \\
\hline
\end{tabular}

```