### PR TITLE
Fix error message

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -174,7 +174,7 @@ string TypeIdToString(PhysicalType type) {
 	case PhysicalType::INVALID:
 		return "INVALID";
 	default:
-		throw ConversionException("Invalid PhysicalType %d", type);
+		throw ConversionException("Invalid PhysicalType %d", (int32_t)type);
 	}
 }
 
@@ -209,7 +209,7 @@ idx_t GetTypeIdSize(PhysicalType type) {
 	case PhysicalType::LIST:
 		return 16; // offset + len
 	default:
-		throw ConversionException("Invalid PhysicalType %d", type);
+		throw ConversionException("Invalid PhysicalType %d", (int32_t)type);
 	}
 }
 

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -174,7 +174,7 @@ string TypeIdToString(PhysicalType type) {
 	case PhysicalType::INVALID:
 		return "INVALID";
 	default:
-		throw ConversionException("Invalid PhysicalType %d", (int32_t)type);
+		throw ConversionException("Invalid PhysicalType %s", type);
 	}
 }
 
@@ -209,7 +209,7 @@ idx_t GetTypeIdSize(PhysicalType type) {
 	case PhysicalType::LIST:
 		return 16; // offset + len
 	default:
-		throw ConversionException("Invalid PhysicalType %d", (int32_t)type);
+		throw ConversionException("Invalid PhysicalType %s", type);
 	}
 }
 


### PR DESCRIPTION
that occurs with certain parametrized queries.

`uint8_t` is interpreted as `char` by the formatter routines. Are there other enums that are mapped to an `uint8_t` internally?