### PR TITLE
Return null instead of initial value in bitwise aggregation functions

### DIFF
--- a/src/function/aggregate/distributive/bitagg.cpp
+++ b/src/function/aggregate/distributive/bitagg.cpp
@@ -7,155 +7,188 @@
 namespace duckdb {
 
 template <class T> struct bit_state_t {
-    bool is_set;
-    T bitwise_ans;
+	bool is_set;
+	T value;
 };
 
 template <class OP> static AggregateFunction GetBitfieldUnaryAggregate(LogicalType type) {
-    switch (type.id()) {
-    case LogicalTypeId::TINYINT:
-        return AggregateFunction::UnaryAggregate<bit_state_t<uint8_t>, int8_t, int8_t, OP>(type, type);
-    case LogicalTypeId::SMALLINT:
-        return AggregateFunction::UnaryAggregate<bit_state_t<uint16_t>, int16_t, int16_t, OP>(type, type);
-    case LogicalTypeId::INTEGER:
-        return AggregateFunction::UnaryAggregate<bit_state_t<uint32_t>, int32_t, int32_t, OP>(type, type);
-    case LogicalTypeId::BIGINT:
-        return AggregateFunction::UnaryAggregate<bit_state_t<uint64_t>, int64_t, int64_t, OP>(type, type);
-    case LogicalTypeId::HUGEINT:
-        return AggregateFunction::UnaryAggregate<bit_state_t<hugeint_t>, hugeint_t, hugeint_t, OP>(type, type);
-    default:
-        throw NotImplementedException("Unimplemented bitfield type for unary aggregate");
-    }
+	switch (type.id()) {
+	case LogicalTypeId::TINYINT:
+		return AggregateFunction::UnaryAggregate<bit_state_t<uint8_t>, int8_t, int8_t, OP>(type, type);
+	case LogicalTypeId::SMALLINT:
+		return AggregateFunction::UnaryAggregate<bit_state_t<uint16_t>, int16_t, int16_t, OP>(type, type);
+	case LogicalTypeId::INTEGER:
+		return AggregateFunction::UnaryAggregate<bit_state_t<uint32_t>, int32_t, int32_t, OP>(type, type);
+	case LogicalTypeId::BIGINT:
+		return AggregateFunction::UnaryAggregate<bit_state_t<uint64_t>, int64_t, int64_t, OP>(type, type);
+	case LogicalTypeId::HUGEINT:
+		return AggregateFunction::UnaryAggregate<bit_state_t<hugeint_t>, hugeint_t, hugeint_t, OP>(type, type);
+	default:
+		throw NotImplementedException("Unimplemented bitfield type for unary aggregate");
+	}
 }
 
 struct BitAndOperation {
-    template <class STATE> static void Initialize(STATE *state) {
-        //  If there are no matching rows, BIT_AND() returns a null value.
-        state->is_set = false;
-        state->bitwise_ans = -1;
-    }
+	template <class STATE> static void Initialize(STATE *state) {
+		//  If there are no matching rows, BIT_AND() returns a null value.
+		state->is_set = false;
+	}
 
-    template <class INPUT_TYPE, class STATE, class OP>
-    static void Operation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t idx) {
-        state->is_set = true;
-        state->bitwise_ans &= input[idx];
-    }
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t idx) {
+		if (!state->is_set) {
+			state->is_set = true;
+			state->value = input[idx];
+		} else {
+			state->value &= input[idx];
+		}
+	}
 
-    template <class INPUT_TYPE, class STATE, class OP>
-    static void ConstantOperation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t count) {
-        //  count is irrelevant
-        Operation<INPUT_TYPE, STATE, OP>(state, input, nullmask, 0);
-    }
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t count) {
+		//  count is irrelevant
+		Operation<INPUT_TYPE, STATE, OP>(state, input, nullmask, 0);
+	}
 
-    template <class T, class STATE>
-    static void Finalize(Vector &result, STATE *state, T *target, nullmask_t &nullmask, idx_t idx) {
-        if (!state->is_set){
-            nullmask[idx] = true;
-        } else {
-            target[idx] = state->bitwise_ans;
-        }
-    }
+	template <class T, class STATE>
+	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, nullmask_t &nullmask, idx_t idx) {
+		if (!state->is_set) {
+			nullmask[idx] = true;
+		} else {
+			target[idx] = state->value;
+		}
+	}
 
-    template <class STATE, class OP> static void Combine(STATE source, STATE *target) {
-        target->is_set = true;
-        target->bitwise_ans &= source.bitwise_ans;
-    }
+	template <class STATE, class OP> static void Combine(STATE source, STATE *target) {
+		if (!source.is_set) {
+			// source is NULL, nothing to do.
+			return;
+		}
+		if (!target->is_set) {
+			// target is NULL, use source value directly.
+			*target = source;
+		} else {
+			target->value &= source.value;
+		}
+	}
 
-    static bool IgnoreNull() {
-        return true;
-    }
+	static bool IgnoreNull() {
+		return true;
+	}
 };
 
 void BitAndFun::RegisterFunction(BuiltinFunctions &set) {
-    AggregateFunctionSet bit_and("bit_and");
-    for (auto type : LogicalType::INTEGRAL) {
-        bit_and.AddFunction(GetBitfieldUnaryAggregate<BitAndOperation>(type));
-    }
-    set.AddFunction(bit_and);
+	AggregateFunctionSet bit_and("bit_and");
+	for (auto type : LogicalType::INTEGRAL) {
+		bit_and.AddFunction(GetBitfieldUnaryAggregate<BitAndOperation>(type));
+	}
+	set.AddFunction(bit_and);
 }
 
 struct BitOrOperation {
-    template <class STATE> static void Initialize(STATE *state) {
-        //  If there are no matching rows, BIT_OR() returns a null value.
-        state->is_set = false;
-        state->bitwise_ans = 0;
-    }
+	template <class STATE> static void Initialize(STATE *state) {
+		//  If there are no matching rows, BIT_OR() returns a null value.
+		state->is_set = false;
+	}
 
-    template <class INPUT_TYPE, class STATE, class OP>
-    static void Operation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t idx) {
-        state->is_set = true;
-        state->bitwise_ans |= input[idx];
-    }
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t idx) {
+		if (!state->is_set) {
+			state->is_set = true;
+			state->value = input[idx];
+		} else {
+			state->value |= input[idx];
+		}
+	}
 
-    template <class INPUT_TYPE, class STATE, class OP>
-    static void ConstantOperation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t count) {
-        //  count is irrelevant
-        Operation<INPUT_TYPE, STATE, OP>(state, input, nullmask, 0);
-    }
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t count) {
+		//  count is irrelevant
+		Operation<INPUT_TYPE, STATE, OP>(state, input, nullmask, 0);
+	}
 
-    template <class T, class STATE>
-    static void Finalize(Vector &result, STATE *state, T *target, nullmask_t &nullmask, idx_t idx) {
-        if (!state->is_set){
-            nullmask[idx] = true;
-        } else {
-            target[idx] = state->bitwise_ans;
-        }
-    }
+	template <class T, class STATE>
+	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, nullmask_t &nullmask, idx_t idx) {
+		if (!state->is_set) {
+			nullmask[idx] = true;
+		} else {
+			target[idx] = state->value;
+		}
+	}
 
-    template <class STATE, class OP> static void Combine(STATE source, STATE *target) {
-        target->is_set = true;
-        target->bitwise_ans |= source.bitwise_ans;
-    }
+	template <class STATE, class OP> static void Combine(STATE source, STATE *target) {
+		if (!source.is_set) {
+			// source is NULL, nothing to do.
+			return;
+		}
+		if (!target->is_set) {
+			// target is NULL, use source value directly.
+			*target = source;
+		} else {
+			target->value |= source.value;
+		}
+	}
 
-    static bool IgnoreNull() {
-        return true;
-    }
+	static bool IgnoreNull() {
+		return true;
+	}
 };
 
 void BitOrFun::RegisterFunction(BuiltinFunctions &set) {
-    AggregateFunctionSet bit_or("bit_or");
-    for (auto type : LogicalType::INTEGRAL) {
-        bit_or.AddFunction(GetBitfieldUnaryAggregate<BitOrOperation>(type));
-    }
-    set.AddFunction(bit_or);
+	AggregateFunctionSet bit_or("bit_or");
+	for (auto type : LogicalType::INTEGRAL) {
+		bit_or.AddFunction(GetBitfieldUnaryAggregate<BitOrOperation>(type));
+	}
+	set.AddFunction(bit_or);
 }
 
 struct BitXorOperation {
-    template <class STATE> static void Initialize(STATE *state) {
-        //  If there are no matching rows, BIT_XOR() returns a null value.
-        state->is_set = false;
-        state->bitwise_ans = 0;
-    }
+	template <class STATE> static void Initialize(STATE *state) {
+		//  If there are no matching rows, BIT_XOR() returns a null value.
+		state->is_set = false;
+	}
 
-    template <class INPUT_TYPE, class STATE, class OP>
-    static void Operation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t idx) {
-        state->is_set = true;
-        state->bitwise_ans ^= input[idx];
-    }
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t idx) {
+		if (!state->is_set) {
+			state->is_set = true;
+			state->value = input[idx];
+		} else {
+			state->value ^= input[idx];
+		}
+	}
 
-    template <class INPUT_TYPE, class STATE, class OP>
-    static void ConstantOperation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t count) {
-        //  count is irrelevant
-        Operation<INPUT_TYPE, STATE, OP>(state, input, nullmask, 0);
-    }
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t count) {
+		//  count is irrelevant
+		Operation<INPUT_TYPE, STATE, OP>(state, input, nullmask, 0);
+	}
 
-    template <class T, class STATE>
-    static void Finalize(Vector &result, STATE *state, T *target, nullmask_t &nullmask, idx_t idx) {
-        if (!state->is_set){
-            nullmask[idx] = true;
-        } else {
-            target[idx] = state->bitwise_ans;
-        }
-    }
+	template <class T, class STATE>
+	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, nullmask_t &nullmask, idx_t idx) {
+		if (!state->is_set) {
+			nullmask[idx] = true;
+		} else {
+			target[idx] = state->value;
+		}
+	}
 
-    template <class STATE, class OP> static void Combine(STATE source, STATE *target) {
-        target->is_set = true;
-        target->bitwise_ans ^= source.bitwise_ans;
-    }
+	template <class STATE, class OP> static void Combine(STATE source, STATE *target) {
+		if (!source.is_set) {
+			// source is NULL, nothing to do.
+			return;
+		}
+		if (!target->is_set) {
+			// target is NULL, use source value directly.
+			*target = source;
+		} else {
+			target->value ^= source.value;
+		}
+	}
 
-    static bool IgnoreNull() {
-        return true;
-    }
+	static bool IgnoreNull() {
+		return true;
+	}
 };
 
 void BitXorFun::RegisterFunction(BuiltinFunctions &set) {

--- a/src/function/aggregate/distributive/bitagg.cpp
+++ b/src/function/aggregate/distributive/bitagg.cpp
@@ -6,134 +6,156 @@
 
 namespace duckdb {
 
+template <class T> struct bit_state_t {
+    bool is_set;
+    T bitwise_ans;
+};
+
 template <class OP> static AggregateFunction GetBitfieldUnaryAggregate(LogicalType type) {
-	switch (type.id()) {
-	case LogicalTypeId::TINYINT:
-		return AggregateFunction::UnaryAggregate<uint8_t, int8_t, int8_t, OP>(type, type);
-	case LogicalTypeId::SMALLINT:
-		return AggregateFunction::UnaryAggregate<uint16_t, int16_t, int16_t, OP>(type, type);
-	case LogicalTypeId::INTEGER:
-		return AggregateFunction::UnaryAggregate<uint32_t, int32_t, int32_t, OP>(type, type);
-	case LogicalTypeId::BIGINT:
-		return AggregateFunction::UnaryAggregate<uint64_t, int64_t, int64_t, OP>(type, type);
-	case LogicalTypeId::HUGEINT:
-		return AggregateFunction::UnaryAggregate<hugeint_t, hugeint_t, hugeint_t, OP>(type, type);
-	default:
-		throw NotImplementedException("Unimplemented bitfield type for unary aggregate");
-	}
+    switch (type.id()) {
+    case LogicalTypeId::TINYINT:
+        return AggregateFunction::UnaryAggregate<bit_state_t<uint8_t>, int8_t, int8_t, OP>(type, type);
+    case LogicalTypeId::SMALLINT:
+        return AggregateFunction::UnaryAggregate<bit_state_t<uint16_t>, int16_t, int16_t, OP>(type, type);
+    case LogicalTypeId::INTEGER:
+        return AggregateFunction::UnaryAggregate<bit_state_t<uint32_t>, int32_t, int32_t, OP>(type, type);
+    case LogicalTypeId::BIGINT:
+        return AggregateFunction::UnaryAggregate<bit_state_t<uint64_t>, int64_t, int64_t, OP>(type, type);
+    case LogicalTypeId::HUGEINT:
+        return AggregateFunction::UnaryAggregate<bit_state_t<hugeint_t>, hugeint_t, hugeint_t, OP>(type, type);
+    default:
+        throw NotImplementedException("Unimplemented bitfield type for unary aggregate");
+    }
 }
 
 struct BitAndOperation {
-	template <class STATE> static void Initialize(STATE *state) {
-		//  If there are no matching rows, BIT_AND() returns a neutral value (all bits set to 1)
-		//  having the same length as the argument values.
-		*state = 0;
-		*state = ~*state;
-	}
+    template <class STATE> static void Initialize(STATE *state) {
+        //  If there are no matching rows, BIT_AND() returns a null value.
+        state->is_set = false;
+        state->bitwise_ans = -1;
+    }
 
-	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t idx) {
-		*state &= STATE(input[idx]);
-	}
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t idx) {
+        state->is_set = true;
+        state->bitwise_ans &= input[idx];
+    }
 
-	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t count) {
-		//  count is irrelevant
-		Operation<INPUT_TYPE, STATE, OP>(state, input, nullmask, 0);
-	}
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t count) {
+        //  count is irrelevant
+        Operation<INPUT_TYPE, STATE, OP>(state, input, nullmask, 0);
+    }
 
-	template <class T, class STATE>
-	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, nullmask_t &nullmask, idx_t idx) {
-		target[idx] = T(*state);
-	}
+    template <class T, class STATE>
+    static void Finalize(Vector &result, STATE *state, T *target, nullmask_t &nullmask, idx_t idx) {
+        if (!state->is_set){
+            nullmask[idx] = true;
+        } else {
+            target[idx] = state->bitwise_ans;
+        }
+    }
 
-	template <class STATE, class OP> static void Combine(STATE source, STATE *target) {
-		*target &= source;
-	}
+    template <class STATE, class OP> static void Combine(STATE source, STATE *target) {
+        target->is_set = true;
+        target->bitwise_ans &= source.bitwise_ans;
+    }
 
-	static bool IgnoreNull() {
-		return true;
-	}
+    static bool IgnoreNull() {
+        return true;
+    }
 };
 
 void BitAndFun::RegisterFunction(BuiltinFunctions &set) {
-	AggregateFunctionSet bit_and("bit_and");
-	for (auto type : LogicalType::INTEGRAL) {
-		bit_and.AddFunction(GetBitfieldUnaryAggregate<BitAndOperation>(type));
-	}
-	set.AddFunction(bit_and);
+    AggregateFunctionSet bit_and("bit_and");
+    for (auto type : LogicalType::INTEGRAL) {
+        bit_and.AddFunction(GetBitfieldUnaryAggregate<BitAndOperation>(type));
+    }
+    set.AddFunction(bit_and);
 }
 
 struct BitOrOperation {
-	template <class STATE> static void Initialize(STATE *state) {
-		//  If there are no matching rows, BIT_OR() returns a neutral value (all bits set to 0)
-		//  having the same length as the argument values.
-		*state = 0;
-	}
+    template <class STATE> static void Initialize(STATE *state) {
+        //  If there are no matching rows, BIT_OR() returns a null value.
+        state->is_set = false;
+        state->bitwise_ans = 0;
+    }
 
-	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t idx) {
-		*state |= STATE(input[idx]);
-	}
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t idx) {
+        state->is_set = true;
+        state->bitwise_ans |= input[idx];
+    }
 
-	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t count) {
-		//  count is irrelevant
-		Operation<INPUT_TYPE, STATE, OP>(state, input, nullmask, 0);
-	}
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t count) {
+        //  count is irrelevant
+        Operation<INPUT_TYPE, STATE, OP>(state, input, nullmask, 0);
+    }
 
-	template <class T, class STATE>
-	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, nullmask_t &nullmask, idx_t idx) {
-		target[idx] = T(*state);
-	}
+    template <class T, class STATE>
+    static void Finalize(Vector &result, STATE *state, T *target, nullmask_t &nullmask, idx_t idx) {
+        if (!state->is_set){
+            nullmask[idx] = true;
+        } else {
+            target[idx] = state->bitwise_ans;
+        }
+    }
 
-	template <class STATE, class OP> static void Combine(STATE source, STATE *target) {
-		*target |= source;
-	}
+    template <class STATE, class OP> static void Combine(STATE source, STATE *target) {
+        target->is_set = true;
+        target->bitwise_ans |= source.bitwise_ans;
+    }
 
-	static bool IgnoreNull() {
-		return true;
-	}
+    static bool IgnoreNull() {
+        return true;
+    }
 };
 
 void BitOrFun::RegisterFunction(BuiltinFunctions &set) {
-	AggregateFunctionSet bit_or("bit_or");
-	for (auto type : LogicalType::INTEGRAL) {
-		bit_or.AddFunction(GetBitfieldUnaryAggregate<BitOrOperation>(type));
-	}
-	set.AddFunction(bit_or);
+    AggregateFunctionSet bit_or("bit_or");
+    for (auto type : LogicalType::INTEGRAL) {
+        bit_or.AddFunction(GetBitfieldUnaryAggregate<BitOrOperation>(type));
+    }
+    set.AddFunction(bit_or);
 }
 
 struct BitXorOperation {
-	template <class STATE> static void Initialize(STATE *state) {
-		//  If there are no matching rows, BIT_XOR() returns a neutral value (all bits set to 0)
-		//  having the same length as the argument values.
-		*state = 0;
-	}
+    template <class STATE> static void Initialize(STATE *state) {
+        //  If there are no matching rows, BIT_XOR() returns a null value.
+        state->is_set = false;
+        state->bitwise_ans = 0;
+    }
 
-	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t idx) {
-		*state ^= STATE(input[idx]);
-	}
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t idx) {
+        state->is_set = true;
+        state->bitwise_ans ^= input[idx];
+    }
 
-	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t count) {
-		//  count is irrelevant
-		Operation<INPUT_TYPE, STATE, OP>(state, input, nullmask, 0);
-	}
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE *state, INPUT_TYPE *input, nullmask_t &nullmask, idx_t count) {
+        //  count is irrelevant
+        Operation<INPUT_TYPE, STATE, OP>(state, input, nullmask, 0);
+    }
 
-	template <class T, class STATE>
-	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, nullmask_t &nullmask, idx_t idx) {
-		target[idx] = T(*state);
-	}
+    template <class T, class STATE>
+    static void Finalize(Vector &result, STATE *state, T *target, nullmask_t &nullmask, idx_t idx) {
+        if (!state->is_set){
+            nullmask[idx] = true;
+        } else {
+            target[idx] = state->bitwise_ans;
+        }
+    }
 
-	template <class STATE, class OP> static void Combine(STATE source, STATE *target) {
-		*target ^= source;
-	}
+    template <class STATE, class OP> static void Combine(STATE source, STATE *target) {
+        target->is_set = true;
+        target->bitwise_ans ^= source.bitwise_ans;
+    }
 
-	static bool IgnoreNull() {
-		return true;
-	}
+    static bool IgnoreNull() {
+        return true;
+    }
 };
 
 void BitXorFun::RegisterFunction(BuiltinFunctions &set) {

--- a/test/sql/aggregate/aggregates/test_bit_and.test
+++ b/test/sql/aggregate/aggregates/test_bit_and.test
@@ -7,7 +7,7 @@ query II
 SELECT BIT_AND(3), BIT_AND(NULL)
 ----
 3
--1
+NULL
 
 # test on a sequence
 statement ok
@@ -36,13 +36,13 @@ SELECT BIT_AND(i), BIT_AND(1), BIT_AND(DISTINCT i), BIT_AND(NULL) FROM integers
 3
 1
 3
--1
+NULL
 
 # test on an empty set
 query I
 SELECT BIT_AND(i) FROM integers WHERE i > 100
 ----
--1
+NULL
 
 # test incorrect usage
 statement error

--- a/test/sql/aggregate/aggregates/test_bit_or.test
+++ b/test/sql/aggregate/aggregates/test_bit_or.test
@@ -7,7 +7,7 @@ query II
 SELECT BIT_OR(3), BIT_OR(NULL)
 ----
 3
-0
+NULL
 
 # test on a sequence
 statement ok
@@ -36,13 +36,13 @@ SELECT BIT_OR(i), BIT_OR(1), BIT_OR(DISTINCT i), BIT_OR(NULL) FROM integers
 31
 1
 31
-0
+NULL
 
 # test on an empty set
 query I
 SELECT BIT_OR(i) FROM integers WHERE i > 100
 ----
-0
+NULL
 
 # test incorrect usage
 statement error

--- a/test/sql/aggregate/aggregates/test_bit_xor.test
+++ b/test/sql/aggregate/aggregates/test_bit_xor.test
@@ -7,7 +7,7 @@ query II
 SELECT BIT_XOR(3), BIT_XOR(NULL)
 ----
 3
-0
+NULL
 
 # test on a sequence
 statement ok
@@ -36,13 +36,13 @@ SELECT BIT_XOR(i), BIT_XOR(1), BIT_XOR(DISTINCT i), BIT_XOR(NULL) FROM integers
 24
 0
 20
-0
+NULL
 
 # test on an empty set
 query I
 SELECT BIT_XOR(i) FROM integers WHERE i > 100
 ----
-0
+NULL
 
 # test incorrect usage
 statement error


### PR DESCRIPTION
Return null for no input or when all values are null in Bitwise aggregate functions, as mentioned in issue #1246.