### PR TITLE
Add GAMMA and LGAMMA functions, #1251

### DIFF
--- a/src/function/scalar/math/numeric.cpp
+++ b/src/function/scalar/math/numeric.cpp
@@ -179,7 +179,7 @@ void SignFun::RegisterFunction(BuiltinFunctions &set) {
 //===--------------------------------------------------------------------===//
 struct CeilOperator {
 	template <class TA, class TR> static inline TR Operation(TA left) {
-		return ceil(left);
+		return std::ceil(left);
 	}
 };
 
@@ -267,7 +267,7 @@ void CeilFun::RegisterFunction(BuiltinFunctions &set) {
 //===--------------------------------------------------------------------===//
 struct FloorOperator {
 	template <class TA, class TR> static inline TR Operation(TA left) {
-		return floor(left);
+		return std::floor(left);
 	}
 };
 
@@ -519,7 +519,7 @@ void RoundFun::RegisterFunction(BuiltinFunctions &set) {
 //===--------------------------------------------------------------------===//
 struct ExpOperator {
 	template <class TA, class TR> static inline TR Operation(TA left) {
-		return exp(left);
+		return std::exp(left);
 	}
 };
 
@@ -533,7 +533,7 @@ void ExpFun::RegisterFunction(BuiltinFunctions &set) {
 //===--------------------------------------------------------------------===//
 struct PowOperator {
 	template <class TA, class TB, class TR> static inline TR Operation(TA base, TB exponent) {
-		return pow(base, exponent);
+		return std::pow(base, exponent);
 	}
 };
 
@@ -552,7 +552,7 @@ void PowFun::RegisterFunction(BuiltinFunctions &set) {
 //===--------------------------------------------------------------------===//
 struct SqrtOperator {
 	template <class TA, class TR> static inline TR Operation(TA left) {
-		return sqrt(left);
+		return std::sqrt(left);
 	}
 };
 
@@ -566,7 +566,7 @@ void SqrtFun::RegisterFunction(BuiltinFunctions &set) {
 //===--------------------------------------------------------------------===//
 struct CbRtOperator {
 	template <class TA, class TR> static inline TR Operation(TA left) {
-		return cbrt(left);
+		return std::cbrt(left);
 	}
 };
 
@@ -581,7 +581,7 @@ void CbrtFun::RegisterFunction(BuiltinFunctions &set) {
 
 struct LnOperator {
 	template <class TA, class TR> static inline TR Operation(TA left) {
-		return log(left);
+		return std::log(left);
 	}
 };
 
@@ -595,7 +595,7 @@ void LnFun::RegisterFunction(BuiltinFunctions &set) {
 //===--------------------------------------------------------------------===//
 struct Log10Operator {
 	template <class TA, class TR> static inline TR Operation(TA left) {
-		return log10(left);
+		return std::log10(left);
 	}
 };
 
@@ -609,7 +609,7 @@ void Log10Fun::RegisterFunction(BuiltinFunctions &set) {
 //===--------------------------------------------------------------------===//
 struct Log2Operator {
 	template <class TA, class TR> static inline TR Operation(TA left) {
-		return log2(left);
+		return std::log2(left);
 	}
 };
 
@@ -664,7 +664,7 @@ void RadiansFun::RegisterFunction(BuiltinFunctions &set) {
 //===--------------------------------------------------------------------===//
 struct SinOperator {
 	template <class TA, class TR> static inline TR Operation(TA input) {
-		return sin(input);
+		return std::sin(input);
 	}
 };
 
@@ -678,7 +678,7 @@ void SinFun::RegisterFunction(BuiltinFunctions &set) {
 //===--------------------------------------------------------------------===//
 struct CosOperator {
 	template <class TA, class TR> static inline TR Operation(TA input) {
-		return (double)cos(input);
+		return (double)std::cos(input);
 	}
 };
 
@@ -692,7 +692,7 @@ void CosFun::RegisterFunction(BuiltinFunctions &set) {
 //===--------------------------------------------------------------------===//
 struct TanOperator {
 	template <class TA, class TR> static inline TR Operation(TA input) {
-		return (double)tan(input);
+		return (double)std::tan(input);
 	}
 };
 
@@ -709,7 +709,7 @@ struct ASinOperator {
 		if (input < -1 || input > 1) {
 			throw Exception("ASIN is undefined outside [-1,1]");
 		}
-		return (double)asin(input);
+		return (double)std::asin(input);
 	}
 };
 
@@ -723,7 +723,7 @@ void AsinFun::RegisterFunction(BuiltinFunctions &set) {
 //===--------------------------------------------------------------------===//
 struct ATanOperator {
 	template <class TA, class TR> static inline TR Operation(TA input) {
-		return (double)atan(input);
+		return (double)std::atan(input);
 	}
 };
 
@@ -737,7 +737,7 @@ void AtanFun::RegisterFunction(BuiltinFunctions &set) {
 //===--------------------------------------------------------------------===//
 struct ATan2 {
 	template <class TA, class TB, class TR> static inline TR Operation(TA left, TB right) {
-		return (double)atan2(left, right);
+		return (double)std::atan2(left, right);
 	}
 };
 
@@ -751,7 +751,7 @@ void Atan2Fun::RegisterFunction(BuiltinFunctions &set) {
 //===--------------------------------------------------------------------===//
 struct ACos {
 	template <class TA, class TR> static inline TR Operation(TA input) {
-		return (double)acos(input);
+		return (double)std::acos(input);
 	}
 };
 
@@ -765,13 +765,41 @@ void AcosFun::RegisterFunction(BuiltinFunctions &set) {
 //===--------------------------------------------------------------------===//
 struct CotOperator {
 	template <class TA, class TR> static inline TR Operation(TA input) {
-		return 1.0 / (double)tan(input);
+		return 1.0 / (double)std::tan(input);
 	}
 };
 
 void CotFun::RegisterFunction(BuiltinFunctions &set) {
 	set.AddFunction(ScalarFunction("cot", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
 	                               UnaryDoubleFunctionWrapper<double, CotOperator>));
+}
+
+//===--------------------------------------------------------------------===//
+// gamma
+//===--------------------------------------------------------------------===//
+struct GammaOperator {
+	template <class TA, class TR> static inline TR Operation(TA left) {
+		return std::tgamma(left);
+	}
+};
+
+void GammaFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("gamma", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               UnaryDoubleFunctionWrapper<double, GammaOperator>));
+}
+
+//===--------------------------------------------------------------------===//
+// gamma
+//===--------------------------------------------------------------------===//
+struct LogGammaOperator {
+	template <class TA, class TR> static inline TR Operation(TA left) {
+		return std::lgamma(left);
+	}
+};
+
+void LogGammaFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("lgamma", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               UnaryDoubleFunctionWrapper<double, LogGammaOperator>));
 }
 
 } // namespace duckdb

--- a/src/function/scalar/math_functions.cpp
+++ b/src/function/scalar/math_functions.cpp
@@ -27,6 +27,9 @@ void BuiltinFunctions::RegisterMathFunctions() {
 	Register<PiFun>();
 
 	Register<BitCountFun>();
+
+	Register<GammaFun>();
+	Register<LogGammaFun>();
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/function/scalar/math_functions.hpp
+++ b/src/include/duckdb/function/scalar/math_functions.hpp
@@ -85,4 +85,12 @@ struct BitCountFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct GammaFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
+struct LogGammaFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 } // namespace duckdb

--- a/test/sql/function/numeric/test_gamma.test
+++ b/test/sql/function/numeric/test_gamma.test
@@ -1,0 +1,109 @@
+# name: test/sql/function/numeric/test_gamma.test
+# description: Test gamma function
+# group: [numeric]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT gamma(NULL)
+----
+NULL
+
+query I
+SELECT gamma(0)
+----
+NULL
+
+query I
+SELECT gamma(-1)
+----
+NULL
+
+query I
+SELECT gamma(1)
+----
+1
+
+query I
+SELECT gamma(-0.1)
+----
+-10.686287021193193
+
+
+query I
+SELECT gamma(2)
+----
+1
+
+query I
+SELECT gamma(10)
+----
+362880.0
+
+query I
+SELECT gamma(2::tinyint)
+----
+1
+
+query I
+SELECT gamma(2::hugeint)
+----
+1
+
+statement error
+SELECT gamma('asdf')
+
+query I
+SELECT lgamma(NULL)
+----
+NULL
+
+query I
+SELECT lgamma(0)
+----
+NULL
+
+query I
+SELECT lgamma(-1)
+----
+NULL
+
+query I
+SELECT lgamma(-100)
+----
+NULL
+
+query I
+SELECT lgamma(1)
+----
+0
+
+query I
+SELECT lgamma(2)
+----
+0
+
+query I
+SELECT lgamma(3)
+----
+0.693147180559945
+
+query I
+SELECT lgamma(10)
+----
+12.801827480081467
+
+
+query I
+SELECT lgamma(2::tinyint)
+----
+0
+
+query I
+SELECT lgamma(2::hugeint)
+----
+0
+
+statement error
+SELECT lgamma('asdf')


### PR DESCRIPTION
This adds wrappers for `std::tgamma` and `std::lgamma`. The gamma function is undefined for *some* of the input range, for now, we return NULL in those cases. Fixes #1251 