### PR TITLE
added 'stddev' alias for agg function 'stddev_samp'

### DIFF
--- a/src/function/aggregate/algebraic/stddev.cpp
+++ b/src/function/aggregate/algebraic/stddev.cpp
@@ -122,6 +122,10 @@ void StdDevSampFun::RegisterFunction(BuiltinFunctions &set) {
 	stddev_samp.AddFunction(AggregateFunction::UnaryAggregate<stddev_state_t, double, double, STDDevSampOperation>(
 	    LogicalType::DOUBLE, LogicalType::DOUBLE));
 	set.AddFunction(stddev_samp);
+	AggregateFunctionSet stddev("stddev");
+	stddev.AddFunction(AggregateFunction::UnaryAggregate<stddev_state_t, double, double, STDDevSampOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(stddev);
 }
 
 void StdDevPopFun::RegisterFunction(BuiltinFunctions &set) {

--- a/test/sql/aggregate/aggregates/test_stddev.test
+++ b/test/sql/aggregate/aggregates/test_stddev.test
@@ -104,3 +104,14 @@ select grp, sum(val), round(var_pop(val), 2), min(val) from stddev_test where va
 1	85.000000	0.250000	42
 2	1042.000000	229441.000000	42
 
+statement ok
+create table stddev_test_alias(val integer, grp integer)
+
+statement ok
+insert into stddev_test_alias values (42, 1), (43, 1), (42, 2), (1000, 2), (NULL, 1), (NULL, 3)
+
+# stddev_samp
+query R
+select round(stddev(val), 1) from stddev_test_alias
+----
+478.800000


### PR DESCRIPTION
Just a small PR, because I think it's convenient to have a 'stddev' agg-function, without having to explicitly specify whether it's a population- or sample-based standard deviation. Like in [Oracle](https://docs.oracle.com/cd/B19306_01/server.102/b14200/functions159.htm), 'stddev' can now be used as shorthand for 'stddev_samp'.