### PR TITLE
csv sniffer: increased buffer size, drop buffer if file is too large,…

### DIFF
--- a/src/execution/operator/persistent/buffered_csv_reader.cpp
+++ b/src/execution/operator/persistent/buffered_csv_reader.cpp
@@ -4,15 +4,14 @@
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/gzip_stream.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/to_string.hpp"
+#include "duckdb/common/types/cast_helpers.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/function/scalar/strftime.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/parser/column_definition.hpp"
 #include "duckdb/storage/data_table.hpp"
-#include "duckdb/common/types/cast_helpers.hpp"
-#include "duckdb/common/to_string.hpp"
-
 #include "utf8proc_wrapper.hpp"
 
 #include <algorithm>
@@ -796,6 +795,8 @@ vector<LogicalType> BufferedCSVReader::SniffCSV(vector<LogicalType> requested_ty
 					chunk->Initialize(parse_chunk_types);
 					chunk->Reference(parse_chunk);
 					cached_chunks.push(move(chunk));
+				} else {
+					while (!cached_chunks.empty()) cached_chunks.pop();
 				}
 			}
 		}
@@ -1414,7 +1415,8 @@ void BufferedCSVReader::Flush(DataChunk &insert_chunk) {
 				if (options.auto_detect) {
 					throw InvalidInputException(
 					    "%s in column %s, between line %llu and %llu. Parser "
-					    "options: %s. Consider either increasing the sample size (using SAMPLE_SIZE=X) "
+					    "options: %s. Consider either increasing the sample size "
+						"(SAMPLE_SIZE=X [X rows] or SAMPLE_SIZE=-1 [all rows]), "
 					    "or skipping column conversion (ALL_VARCHAR=1)",
 					    e.what(), col_name, linenr - parse_chunk.size() + 1, linenr, options.toString());
 				} else {

--- a/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
@@ -81,7 +81,7 @@ struct BufferedCSVReaderOptions {
 	//! Number of sample chunks used for type detection
 	idx_t sample_chunks = 10;
 	//! Number of samples to buffer
-	idx_t buffer_size = STANDARD_VECTOR_SIZE * 10;
+	idx_t buffer_size = STANDARD_VECTOR_SIZE * 100;
 	//! Consider all columns to be of type varchar
 	bool all_varchar = false;
 	//! The date format to use (if any is specified)
@@ -94,7 +94,7 @@ struct BufferedCSVReaderOptions {
 		       ", QUOTE='" + quote + (has_quote ? "'" : (auto_detect ? "' (auto detected)" : "' (default)")) +
 		       ", ESCAPE='" + escape + (has_escape ? "'" : (auto_detect ? "' (auto detected)" : "' (default)")) +
 		       ", HEADER=" + std::to_string(header) +
-		       (has_header ? "" : (auto_detect ? "' (auto detected)" : "' (default)")) +
+		       (has_header ? "" : (auto_detect ? " (auto detected)" : "' (default)")) +
 		       ", SAMPLE_SIZE=" + std::to_string(sample_chunk_size * sample_chunks) +
 		       ", ALL_VARCHAR=" + std::to_string(all_varchar);
 	}

--- a/test/sql/copy/csv/auto/test_type_detection.test
+++ b/test/sql/copy/csv/auto/test_type_detection.test
@@ -6,7 +6,7 @@ require vector_size 512
 
 # a CSV file with many strings
 statement ok
-CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/large_mixed_data.csv', SAMPLE_CHUNKS=20);
+CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/large_mixed_data.csv', SAMPLE_SIZE=-1);
 
 query ITR
 SELECT linenr, mixed_string, mixed_double FROM test LIMIT 3;
@@ -26,6 +26,11 @@ SELECT linenr, mixed_string, mixed_double FROM test WHERE linenr > 27000 LIMIT 3
 27001	1	1.000000
 27002	2	2.000000
 27003	3	3.500000
+
+query I
+SELECT count(*) FROM test;
+----
+27003
 
 statement ok
 DROP TABLE test;


### PR DESCRIPTION
Small PR to fix an issue related to the read_csv_auto function when using sample_size=-1 (all rows). 
Fixed a typo and added an additional note to the read_csv_auto type detection error message which suggests setting sample_size=-1.