### PR TITLE
Propagate statistics in the child node of an aggregate even if the aggregate itself doesn't

### DIFF
--- a/src/optimizer/statistics/expression/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/expression/propagate_aggregate.cpp
@@ -5,9 +5,6 @@ namespace duckdb {
 
 unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundAggregateExpression &aggr,
                                                                      unique_ptr<Expression> *expr_ptr) {
-	if (!aggr.function.statistics) {
-		return nullptr;
-	}
 	vector<unique_ptr<BaseStatistics>> stats;
 	stats.reserve(aggr.children.size());
 	for (idx_t i = 0; i < aggr.children.size(); i++) {

--- a/src/optimizer/statistics/expression/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/expression/propagate_aggregate.cpp
@@ -13,6 +13,9 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundAggreg
 	for (idx_t i = 0; i < aggr.children.size(); i++) {
 		stats.push_back(PropagateExpression(aggr.children[i]));
 	}
+	if (!aggr.function.statistics){
+		return nullptr;
+	}
 	return aggr.function.statistics(context, aggr, aggr.bind_info.get(), stats, node_stats.get());
 }
 

--- a/src/optimizer/statistics/expression/propagate_function.cpp
+++ b/src/optimizer/statistics/expression/propagate_function.cpp
@@ -13,6 +13,9 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundFuncti
 	for (idx_t i = 0; i < func.children.size(); i++) {
 		stats.push_back(PropagateExpression(func.children[i]));
 	}
+    if (!func.function.statistics){
+        return nullptr;
+    }
 	return func.function.statistics(context, func, func.bind_info.get(), stats);
 }
 

--- a/src/optimizer/statistics/expression/propagate_function.cpp
+++ b/src/optimizer/statistics/expression/propagate_function.cpp
@@ -5,9 +5,6 @@ namespace duckdb {
 
 unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundFunctionExpression &func,
                                                                      unique_ptr<Expression> *expr_ptr) {
-	if (!func.function.statistics) {
-		return nullptr;
-	}
 	vector<unique_ptr<BaseStatistics>> stats;
 	stats.reserve(func.children.size());
 	for (idx_t i = 0; i < func.children.size(); i++) {


### PR DESCRIPTION
This PR fixes a bug related to statistics propagation. We need to propagate stats in the child node of an aggregate even if the aggregate doesn't itself have any statistics propagate function.