### PR TITLE
Optimize expressions in aggregates by not re-allocating vectors

### DIFF
--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -16,7 +16,9 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(BoundFunctionExp
 		result->AddChild(child.get());
 	}
 	result->Finalize();
-	result->arguments.InitializeEmpty(result->types);
+    if (result->types.size() > 0) {
+		result->arguments.InitializeEmpty(result->types);
+	}
 	return move(result);
 }
 


### PR DESCRIPTION
This PR optimizes the simple aggregate, the InitializeEmpty, and Vector constructors.

For a query like the following which adds a tuple 100 times to itself, from a table consists of 3 billion TINYINTs
```
SELECT  min(i + i + i + i + i + i + i + i + i + i +
	               i + i + i + i + i + i + i + i + i + i +
                        i + i + i + i + i + i + i + i + i + i +
	               i + i + i + i + i + i + i + i + i + i +
                        i + i + i + i + i + i + i + i + i + i +
                        i + i + i + i + i + i + i + i + i + i +
                        i + i + i + i + i + i + i + i + i + i +
	               i + i + i + i + i + i + i + i + i + i +
	               i + i + i + i + i + i + i + i + i + i +
	               i + i + i + i + i + i + i + i + i + i )
                                FROM tbl)";
```
The result of the perf command before the optimization is:
```
15.60%  example  libduckdb.so         [.] duckdb::Vector::Reference
  11.53%  example  libduckdb.so         [.] duckdb::Vector::Vector
   9.39%  example  libduckdb.so         [.] duckdb::ExpressionExecutor::Execute
   8.91%  example  libduckdb.so         [.] duckdb::BinaryExecutor::ExecuteFlat<signed char, signed char, signed char, duckdb::BinaryStandardOperatorWrapper, duckdb::AddOperator, bool,
   6.13%  example  libduckdb.so         [.] duckdb::DataChunk::InitializeEmpty
   5.34%  example  libduckdb.so         [.] duckdb::Vector::Vector
   4.94%  example  libduckdb.so         [.] std::vector<duckdb::Vector, std::allocator<duckdb::Vector> >::_M_realloc_insert<duckdb::Vector>
   4.05%  example  libc-2.27.so         [.] _int_free
   3.67%  example  libduckdb.so         [.] std::vector<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, duckdb::LogicalType>, std::allocator<s
   3.66%  example  libc-2.27.so         [.] _int_malloc
   3.51%  example  libduckdb.so         [.] std::__uninitialized_copy<false>::__uninit_copy<__gnu_cxx::__normal_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char
   3.34%  example  libduckdb.so         [.] duckdb::ExpressionExecutor::Execute
   3.17%  example  libc-2.27.so         [.] malloc
   2.52%  example  libduckdb.so         [.] duckdb::LogicalType::~LogicalType
   2.28%  example  libstdc++.so.6.0.25  [.] std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_assign
   1.77%  example  libduckdb.so         [.] duckdb::AggregateExecutor::UnaryUpdate<duckdb::min_max_state_t<signed char>, signed char, duckdb::MinOperation>
   1.29%  example  libduckdb.so         [.] duckdb::DataChunk::Reference
   0.83%  example  libc-2.27.so         [.] cfree@GLIBC_2.2.5
   0.72%  example  libduckdb.so         [.] duckdb::LogicalType::~LogicalType@plt
   0.70%  example  libduckdb.so         [.] std::__uninitialized_copy<false>::__uninit_copy<__gnu_cxx::__normal_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char
   0.57%  example  libstdc++.so.6.0.25  [.] operator new
   0.56%  example  libduckdb.so         [.] duckdb::BinaryExecutor::ExecuteSwitch<signed char, signed char, signed char, duckdb::BinaryStandardOperatorWrapper, duckdb::AddOperator, bool
   0.30%  example  libduckdb.so         [.] duckdb::Vector::Reference@plt
```
After:
```
26.66%  example  libduckdb.so         [.] duckdb::BinaryExecutor::ExecuteSwitch<signed char, signed char, signed char, duckdb::BinaryStandardOperatorWrapper, duckdb::AddOperator, bool
  24.67%  example  libduckdb.so         [.] duckdb::Vector::Reference
  13.30%  example  libc-2.27.so         [.] __memmove_avx_unaligned_erms
   8.09%  example  libduckdb.so         [.] duckdb::AggregateExecutor::UnaryUpdate<duckdb::min_max_state_t<signed char>, signed char, duckdb::MinOperation>
   7.19%  example  libduckdb.so         [.] duckdb::ExpressionExecutor::Execute
   5.29%  example  libduckdb.so         [.] duckdb::ExpressionExecutor::Execute
   3.92%  example  libduckdb.so         [.] std::vector<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, duckdb::LogicalType>, std::allocator<s
   2.94%  example  libduckdb.so         [.] std::_Base_bitset<64ul>::_M_is_any
   2.16%  example  libstdc++.so.6.0.25  [.] std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_assign
   0.73%  example  libduckdb.so         [.] duckdb::DataChunk::Reference
   0.57%  example  libduckdb.so         [.] duckdb::ExpressionExecutor::Execute
```
As can be seen, after optimization, more time has been spent on real computation.

