### PR TITLE
Rework the way in which USING columns and natural joins are bound

### DIFF
--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -71,10 +71,14 @@ public:
 	//! We need this to correctly bind recursive CTEs with multiple references.
 	void AddCTEBinding(idx_t index, const string &alias, vector<string> names, vector<LogicalType> types);
 
-	//! Hide a binding
-	void HideBinding(const string &binding_name, const string &column_name);
-	//! Returns true if the given column is hidden from the given binding
-	bool BindingIsHidden(const string &binding_name, const string &column_name);
+	//! Add an implicit join condition (e.g. USING (x))
+	void AddUsingCondition(const string &column_name, const string &binding);
+	void MergeUsingCondition(const string &column_name, BindContext &context);
+
+	bool IsUsingBinding(const string &column_name);
+	bool IsUsingBinding(const string &column_name, const string &binding_name);
+
+	vector<string> &UsingBindings(const string &column_name);
 
 	unordered_map<string, std::shared_ptr<Binding>> GetCTEBindings() {
 		return cte_bindings;
@@ -103,8 +107,8 @@ private:
 	unordered_map<string, unique_ptr<Binding>> bindings;
 	//! The list of bindings in insertion order
 	vector<std::pair<string, Binding *>> bindings_list;
-	//! The set of hidden columns from the result
-	qualified_column_set_t hidden_columns;
+	//! The set of columns used in USING join conditions
+	unordered_map<string, vector<string>> using_columns;
 
 	//! The set of CTE bindings
 	unordered_map<string, std::shared_ptr<Binding>> cte_bindings;

--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -77,6 +77,8 @@ public:
 
 	bool IsUsingBinding(const string &column_name);
 	bool IsUsingBinding(const string &column_name, const string &binding_name);
+	const string &GetPrimaryUsingBinding(const string &column_name);
+	void SetPrimaryUsingBinding(const string &column_name, const string &binding_name);
 
 	vector<string> &UsingBindings(const string &column_name);
 
@@ -109,6 +111,8 @@ private:
 	vector<std::pair<string, Binding *>> bindings_list;
 	//! The set of columns used in USING join conditions
 	unordered_map<string, vector<string>> using_columns;
+	//! The using binding we should use when referencing the using column
+	unordered_map<string, string> using_bindings;
 
 	//! The set of CTE bindings
 	unordered_map<string, std::shared_ptr<Binding>> cte_bindings;

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -219,6 +219,9 @@ private:
 	unique_ptr<LogicalOperator> CastLogicalOperatorToTypes(vector<LogicalType> &source_types,
 	                                                       vector<LogicalType> &target_types,
 	                                                       unique_ptr<LogicalOperator> op);
+
+	string FindBinding(const string &using_column, const string &join_side);
+	bool TryFindBinding(const string &using_column, const string &join_side, string &result);
 };
 
 } // namespace duckdb

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -65,10 +65,13 @@ vector<string> &BindContext::UsingBindings(const string &column_name) {
 	return using_columns[column_name];
 }
 
-// bool BindContext::BindingIsHidden(const string &binding_name, const string &column_name) {
-// 	QualifiedColumnName qcolumn(binding_name, column_name);
-// 	return hidden_columns.find(qcolumn) != hidden_columns.end();
-// }
+const string &BindContext::GetPrimaryUsingBinding(const string &column_name) {
+	return using_bindings[column_name];
+}
+
+void BindContext::SetPrimaryUsingBinding(const string &column_name, const string &binding_name) {
+	using_bindings[column_name] = binding_name;
+}
 
 unordered_set<string> BindContext::GetMatchingBindings(const string &column_name) {
 	unordered_set<string> result;

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -13,6 +13,11 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref, idx_t d
 	// resolve to either a base table or a subquery expression
 	if (colref.table_name.empty()) {
 		if (binder.bind_context.IsUsingBinding(colref.column_name)) {
+			// FIXME: can optimize this
+			// INNER join -> can use either column (doesn't matter)
+			// LEFT join -> can use left column
+			// RIGHT join -> can use right column
+			// FULL OUTER join (need to do coalesce)
 			auto &entry = binder.bind_context.UsingBindings(colref.column_name);
 			// using column, bind this as a coalesce between the LHS and RHS
 			auto coalesce = make_unique<OperatorExpression>(ExpressionType::OPERATOR_COALESCE);

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
+#include "duckdb/parser/expression/operator_expression.hpp"
 #include "duckdb/common/string_util.hpp"
 
 namespace duckdb {
@@ -11,6 +12,15 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref, idx_t d
 	// individual column reference
 	// resolve to either a base table or a subquery expression
 	if (colref.table_name.empty()) {
+		if (binder.bind_context.IsUsingBinding(colref.column_name)) {
+			auto &entry = binder.bind_context.UsingBindings(colref.column_name);
+			// using column, bind this as a coalesce between the LHS and RHS
+			auto coalesce = make_unique<OperatorExpression>(ExpressionType::OPERATOR_COALESCE);
+			for(size_t i = 0; i < entry.size(); i++) {
+				coalesce->children.push_back(make_unique<ColumnRefExpression>(colref.column_name, entry[i]));
+			}
+			return BindExpression(*coalesce, depth);
+		}
 		// no table name: find a binding that contains this
 		if (binder.macro_binding != nullptr && binder.macro_binding->HasMatchingBinding(colref.column_name)) {
 			// priority to macro parameter bindings TODO: throw a warning when this name conflicts

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -13,18 +13,23 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref, idx_t d
 	// resolve to either a base table or a subquery expression
 	if (colref.table_name.empty()) {
 		if (binder.bind_context.IsUsingBinding(colref.column_name)) {
-			// FIXME: can optimize this
-			// INNER join -> can use either column (doesn't matter)
-			// LEFT join -> can use left column
-			// RIGHT join -> can use right column
-			// FULL OUTER join (need to do coalesce)
-			auto &entry = binder.bind_context.UsingBindings(colref.column_name);
-			// using column, bind this as a coalesce between the LHS and RHS
-			auto coalesce = make_unique<OperatorExpression>(ExpressionType::OPERATOR_COALESCE);
-			for(size_t i = 0; i < entry.size(); i++) {
-				coalesce->children.push_back(make_unique<ColumnRefExpression>(colref.column_name, entry[i]));
+			// we are referencing a USING column
+			// check if we can refer to one of the base columns directly
+			auto &binding = binder.bind_context.GetPrimaryUsingBinding(colref.column_name);
+			unique_ptr<Expression> expression;
+			if (!binding.empty()) {
+				// we can! just assign the table name and re-bind
+				colref.table_name = binding;
+				return BindExpression(colref, depth);
+			} else {
+				// we cannot! we need to bind this as a coalesce between all the relevant columns
+				auto &entry = binder.bind_context.UsingBindings(colref.column_name);
+				auto coalesce = make_unique<OperatorExpression>(ExpressionType::OPERATOR_COALESCE);
+				for(size_t i = 0; i < entry.size(); i++) {
+					coalesce->children.push_back(make_unique<ColumnRefExpression>(colref.column_name, entry[i]));
+				}
+				return BindExpression(*coalesce, depth);
 			}
-			return BindExpression(*coalesce, depth);
 		}
 		// no table name: find a binding that contains this
 		if (binder.macro_binding != nullptr && binder.macro_binding->HasMatchingBinding(colref.column_name)) {

--- a/src/planner/binder/expression/bind_operator_expression.cpp
+++ b/src/planner/binder/expression/bind_operator_expression.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/parser/expression/operator_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
+#include "duckdb/planner/expression/bound_case_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 
 namespace duckdb {
@@ -13,6 +14,9 @@ static LogicalType ResolveNotType(OperatorExpression &op, vector<BoundExpression
 }
 
 static LogicalType ResolveInType(OperatorExpression &op, vector<BoundExpression *> &children) {
+	if (children.size() == 0) {
+		return LogicalType::BOOLEAN;
+	}
 	// get the maximum type from the children
 	LogicalType max_type = children[0]->expr->return_type;
 	for (idx_t i = 1; i < children.size(); i++) {
@@ -23,7 +27,7 @@ static LogicalType ResolveInType(OperatorExpression &op, vector<BoundExpression 
 		children[i]->expr = BoundCastExpression::AddCastToType(move(children[i]->expr), max_type);
 	}
 	// (NOT) IN always returns a boolean
-	return LogicalType(LogicalTypeId::BOOLEAN);
+	return LogicalType::BOOLEAN;
 }
 
 static LogicalType ResolveOperatorType(OperatorExpression &op, vector<BoundExpression *> &children) {
@@ -34,6 +38,7 @@ static LogicalType ResolveOperatorType(OperatorExpression &op, vector<BoundExpre
 		return LogicalType::BOOLEAN;
 	case ExpressionType::COMPARE_IN:
 	case ExpressionType::COMPARE_NOT_IN:
+	case ExpressionType::OPERATOR_COALESCE:
 		return ResolveInType(op, children);
 	default:
 		D_ASSERT(op.type == ExpressionType::OPERATOR_NOT);
@@ -58,6 +63,25 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 	}
 	// now resolve the types
 	LogicalType result_type = ResolveOperatorType(op, children);
+	if (op.type == ExpressionType::OPERATOR_COALESCE) {
+		if (children.size() == 0) {
+			return BindResult("COALESCE needs at least one child");
+		}
+		unique_ptr<Expression> current_node;
+		for(size_t i = children.size(); i > 0; i--) {
+			auto child = move(children[i - 1]->expr);
+			if (!current_node) {
+				// no node yet: simply move the child
+				current_node = move(child);
+			} else {
+				// create a case statement
+				auto check = make_unique<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NOT_NULL, LogicalType::BOOLEAN);
+				check->children.push_back(child->Copy());
+				current_node = make_unique<BoundCaseExpression>(move(check), move(child), move(current_node));
+			}
+		}
+		return BindResult(move(current_node));
+	}
 
 	auto result = make_unique<BoundOperatorExpression>(op.type, result_type);
 	for (auto &child : children) {

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -200,8 +200,7 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SelectNode &statement) {
 			// * statement, expand to all columns from the FROM clause
 			bind_context.GenerateAllColumnExpressions(new_select_list);
 		} else if (select_element->GetExpressionType() == ExpressionType::TABLE_STAR) {
-			auto table_star =
-			    (TableStarExpression *)select_element.get(); // TODO this cast to explicit class is a bit dirty?
+			auto table_star = (TableStarExpression *)select_element.get();
 			bind_context.GenerateAllColumnExpressions(new_select_list, table_star->relation_name);
 		} else {
 			// regular statement, add it to the list

--- a/src/planner/binder/tableref/bind_joinref.cpp
+++ b/src/planner/binder/tableref/bind_joinref.cpp
@@ -4,21 +4,58 @@
 #include "duckdb/planner/tableref/bound_joinref.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
-#include "duckdb/parser/expression/comparison_expression.hpp"
-#include "duckdb/parser/expression/conjunction_expression.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 
 namespace duckdb {
 
-static void AddCondition(JoinRef &ref, string left_alias, string right_alias, string column_name) {
-	auto left_expr = make_unique<ColumnRefExpression>(column_name, left_alias);
-	auto right_expr = make_unique<ColumnRefExpression>(column_name, right_alias);
-	auto comp_expr =
-	    make_unique<ComparisonExpression>(ExpressionType::COMPARE_EQUAL, move(left_expr), move(right_expr));
-	if (!ref.condition) {
-		ref.condition = move(comp_expr);
+static unique_ptr<Expression> BindColumn(Binder &binder, ClientContext &context, const string &alias, const string &column_name) {
+	auto expr = make_unique_base<ParsedExpression, ColumnRefExpression>(column_name, alias);
+	ExpressionBinder expr_binder(binder, context);
+	return expr_binder.Bind(expr);
+}
+
+static unique_ptr<Expression> AddCondition(ClientContext &context, Binder &left_binder, Binder &right_binder, const string &left_alias, const string &right_alias, const string &column_name) {
+	auto left = BindColumn(left_binder, context, left_alias, column_name);
+	auto right = BindColumn(right_binder, context, right_alias, column_name);
+	return make_unique<BoundComparisonExpression>(ExpressionType::COMPARE_EQUAL, move(left), move(right));
+}
+
+bool Binder::TryFindBinding(const string &using_column, const string &join_side, string &result) {
+	// for each using column, get the matching binding
+	auto bindings = bind_context.GetMatchingBindings(using_column);
+	if (bindings.size() == 0) {
+		return false;
+	}
+	// find the join binding
+	for (auto &binding : bindings) {
+		if (!result.empty()) {
+			string error = "Column name \"" + using_column +
+							"\" is ambiguous: it exists more than once on " + join_side + " side of join.\nCandidates:";
+			for (auto &binding : bindings) {
+				error += "\n\t" + binding + "." + using_column;
+			}
+			throw BinderException(error);
+		} else {
+			result = binding;
+		}
+	}
+	return true;
+}
+
+string Binder::FindBinding(const string &using_column, const string &join_side) {
+	string result;
+	if (!TryFindBinding(using_column, join_side, result)) {
+		throw BinderException("Column \"%s\" does not exist on %s side of join!", using_column, join_side);
+	}
+	return result;
+}
+
+void AddUsingCondition(BindContext &target, const string &column_name, const string &binding, BindContext &child, bool is_using_column) {
+	if (is_using_column) {
+		target.MergeUsingCondition(column_name, child);
 	} else {
-		ref.condition =
-		    make_unique<ConjunctionExpression>(ExpressionType::CONJUNCTION_AND, move(ref.condition), move(comp_expr));
+		target.AddUsingCondition(column_name, binding);
 	}
 }
 
@@ -32,6 +69,8 @@ unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
 	result->type = ref.type;
 	result->left = left_binder.Bind(*ref.left);
 	result->right = right_binder.Bind(*ref.right);
+
+	vector<unique_ptr<Expression>> extra_conditions;
 	if (ref.is_natural) {
 		// natural join, figure out which column names are present in both sides of the join
 		// first bind the left hand side and get a list of all the tables and column names
@@ -39,10 +78,10 @@ unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
 		auto &lhs_binding_list = left_binder.bind_context.GetBindingsList();
 		for (auto &binding : lhs_binding_list) {
 			for (auto &column_name : binding.second->names) {
-				if (left_binder.bind_context.BindingIsHidden(binding.first, column_name)) {
-					continue;
-				}
-				if (lhs_columns.find(column_name) == lhs_columns.end()) {
+				bool is_using_column = left_binder.bind_context.IsUsingBinding(column_name);
+				if (is_using_column) {
+					lhs_columns[column_name] = string();
+				} else if (lhs_columns.find(column_name) == lhs_columns.end()) {
 					// new column candidate: add it to the set
 					lhs_columns[column_name] = binding.first;
 				} else {
@@ -57,34 +96,32 @@ unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
 		for (auto &column : lhs_columns) {
 			auto &column_name = column.first;
 			auto &left_binding = column.second;
-			// loop over the set of lhs columns, and figure out if there is a table in the rhs with the same name
-			auto right_bindings = right_binder.bind_context.GetMatchingBindings(column_name);
-			string right_binding;
 
-			if (right_bindings.size() == 0) {
-				// no match found for this column on the rhs
-				continue;
+			bool left_is_using = left_binder.bind_context.IsUsingBinding(column_name);
+			bool right_is_using = right_binder.bind_context.IsUsingBinding(column_name);
+
+			string right_binding;
+			// loop over the set of lhs columns, and figure out if there is a table in the rhs with the same name
+			if (!right_is_using) {
+				if (!right_binder.TryFindBinding(column_name, "right", right_binding)) {
+					// no match found for this column on the rhs: skip
+					continue;
+				}
 			}
 			// found this column name in both the LHS and the RHS of this join
 			// add it to the natural join!
-			// first check if the binding is ambiguous
-			bool left_ambiguous = left_binding.empty();
-			bool right_ambiguous = right_bindings.size() > 1;
-			if (left_ambiguous || right_ambiguous) {
+			// first check if the binding is ambiguous on the LHS
+			if (!left_is_using && left_binding.empty()) {
 				// binding is ambiguous on left or right side: throw an exception
-				string error_msg = "Column name \"" + column_name + "\" is ambiguous: it exists more than once on the ";
-				error_msg += left_ambiguous ? "left" : "right";
-				error_msg += " side of the join.";
+				string error_msg = "Column name \"" + column_name + "\" is ambiguous: it exists more than once on the left side of the join.";
 				throw BinderException(FormatError(ref, error_msg));
 			}
-			for (auto &binding : right_bindings) {
-				right_binding = binding;
-			}
 			// there is a match! create the join condition
-			AddCondition(ref, left_binding, right_binding, column_name);
-			bind_context.HideBinding(right_binding, column_name);
+			extra_conditions.push_back(AddCondition(context, left_binder, right_binder, left_binding, right_binding, column_name));
+			AddUsingCondition(bind_context, column_name, left_binding, left_binder.bind_context, left_is_using);
+			AddUsingCondition(bind_context, column_name, right_binding, right_binder.bind_context, right_is_using);
 		}
-		if (!ref.condition) {
+		if (extra_conditions.size() == 0) {
 			// no matching bindings found in natural join: throw an exception
 			string error_msg = "No columns found to join on in NATURAL JOIN.\n";
 			error_msg += "Use CROSS JOIN if you intended for this to be a cross-product.";
@@ -114,60 +151,22 @@ unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
 	} else if (ref.using_columns.size() > 0) {
 		// USING columns
 		D_ASSERT(!result->condition);
-		vector<string> left_join_bindings;
 
-		for (auto &using_column : ref.using_columns) {
-			// for each using column, get the matching binding
-			auto left_bindings = left_binder.bind_context.GetMatchingBindings(using_column);
-			if (left_bindings.size() == 0) {
-				throw BinderException("Column \"%s\" does not exist on left side of join!", using_column);
-			}
-			// find the join binding
-			string left_binding;
-			for (auto &binding : left_bindings) {
-				if (left_binder.bind_context.BindingIsHidden(binding, using_column)) {
-					continue;
-				}
-				if (!left_binding.empty()) {
-					string error = "Column name \"" + using_column +
-					               "\" is ambiguous: it exists more than once on left side of join.\nCandidates:";
-					for (auto &binding : left_bindings) {
-						error += "\n\t" + binding + "." + using_column;
-					}
-					throw BinderException(error);
-				} else {
-					left_binding = binding;
-				}
-			}
-			left_join_bindings.push_back(left_binding);
-		}
 		for (idx_t i = 0; i < ref.using_columns.size(); i++) {
 			auto &using_column = ref.using_columns[i];
-			auto left_binding = left_join_bindings[i];
-
-			auto right_bindings = right_binder.bind_context.GetMatchingBindings(using_column);
+			string left_binding;
 			string right_binding;
-			for (auto &binding : right_bindings) {
-				if (right_binder.bind_context.BindingIsHidden(binding, using_column)) {
-					continue;
-				}
-				if (!right_binding.empty()) {
-					string error = "Column name \"" + using_column +
-					               "\" is ambiguous: it exists more than once on right side of join.\nCandidates:";
-					for (auto &binding : right_bindings) {
-						error += "\n\t" + binding + "." + using_column;
-					}
-					throw BinderException(error);
-				} else {
-					right_binding = binding;
-				}
+			bool left_is_using = left_binder.bind_context.IsUsingBinding(using_column);
+			bool right_is_using = right_binder.bind_context.IsUsingBinding(using_column);
+			if (!left_is_using) {
+				left_binding = left_binder.FindBinding(using_column, "left");
 			}
-			if (right_binding.empty()) {
-				throw BinderException("Column \"%s\" does not exist on right side of join!", using_column);
+			if (!right_is_using) {
+				right_binding = right_binder.FindBinding(using_column, "right");
 			}
-			D_ASSERT(!left_binding.empty());
-			AddCondition(ref, left_binding, right_binding, using_column);
-			right_binder.bind_context.HideBinding(right_binding, using_column);
+			extra_conditions.push_back(AddCondition(context, left_binder, right_binder, left_binding, right_binding, using_column));
+			AddUsingCondition(bind_context, using_column, left_binding, left_binder.bind_context, left_is_using);
+			AddUsingCondition(bind_context, using_column, right_binding, right_binder.bind_context, right_is_using);
 		}
 	}
 	bind_context.AddContext(move(left_binder.bind_context));
@@ -178,6 +177,14 @@ unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
 		WhereBinder binder(*this, context);
 		result->condition = binder.Bind(ref.condition);
 	}
+	for(auto &condition : extra_conditions) {
+		if (result->condition) {
+			result->condition = make_unique<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND, move(result->condition), move(condition));
+		} else {
+			result->condition = move(condition);
+		}
+	}
+	D_ASSERT(result->condition);
 	return move(result);
 }
 

--- a/test/issues/general/test_1290.test
+++ b/test/issues/general/test_1290.test
@@ -19,7 +19,7 @@ select i, a.i, b.i from a inner join b using (i);
 ----
 
 query III
-	select i, a.i, b.i from a left outer join b using (i);
+select i, a.i, b.i from a left outer join b using (i);
 ----
 42	42	NULL
 

--- a/test/issues/general/test_1290.test
+++ b/test/issues/general/test_1290.test
@@ -1,0 +1,94 @@
+# name: test/issues/general/test_1248.test
+# description: Issue 1290: FULL JOIN reports missing values for join key
+# group: [general]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table a as select 42 as i, 80 as j;
+
+statement ok
+create table b as select 43 as i, 84 as k;
+
+statement ok
+create table c as select 44 as i, 84 as l;
+
+query III
+select i, a.i, b.i from a inner join b using (i);
+----
+
+query III
+	select i, a.i, b.i from a left outer join b using (i);
+----
+42	42	NULL
+
+query III
+select i, a.i, b.i from a right outer join b using (i);
+----
+43	NULL	43
+
+query III
+select i, a.i, b.i from a natural full outer join b order by 1;
+----
+42	42	NULL
+43	NULL	43
+
+query III
+select i, a.i, b.i from a full outer join b using (i) order by 1;
+----
+42	42	NULL
+43	NULL	43
+
+query III
+select * from a full outer join b using (i) order by 1;
+----
+42	80	NULL
+43	NULL	84
+
+query IIII
+select i, a.i, b.i, c.i from a full outer join b using (i) full outer join c using (i) order by 1;
+----
+42	42	NULL	NULL
+43	NULL	43	NULL
+44	NULL	NULL	44
+
+query IIII
+select * from a full outer join b using (i) full outer join c using (i) order by 1;
+----
+42	80	NULL	NULL
+43	NULL	84	NULL
+44	NULL	NULL	84
+
+query IIII
+select i, a.i, b.i, c.i from a natural full outer join b natural full outer join (values (42)) c(i) order by 1;
+----
+42	42	NULL	42
+43	NULL	43	NULL
+
+query IIII
+select i, a.i, b.i, c.i from a natural full outer join b natural full outer join (values (43)) c(i) order by 1;
+----
+42	42	NULL	NULL
+43	NULL	43	43
+
+query IIII
+select i, a.i, b.i, c.i from a natural full outer join b natural full outer join (values (44)) c(i) order by 1;
+----
+42	42	NULL	NULL
+43	NULL	43	NULL
+44	NULL	NULL	44
+
+query IIII
+select i, a.i, b.i, c.i from a natural full outer join b natural full outer join c order by 1;
+----
+42	42	NULL	NULL
+43	NULL	43	NULL
+44	NULL	NULL	44
+
+query IIII
+select * from a natural full outer join b natural full outer join c order by 1;
+----
+42	80	NULL	NULL
+43	NULL	84	NULL
+44	NULL	NULL	84

--- a/test/issues/general/test_1290.test
+++ b/test/issues/general/test_1290.test
@@ -92,3 +92,32 @@ select * from a natural full outer join b natural full outer join c order by 1;
 42	80	NULL	NULL
 43	NULL	84	NULL
 44	NULL	NULL	84
+
+# right join
+query III
+select * from a natural right outer join b order by 1;
+----
+43	NULL	84
+
+query IIIII
+select * from a, b natural right outer join c;
+----
+42	80	44	NULL	84
+
+query IIIIIIIIII
+select *, * from a, b natural right outer join c;
+----
+42	80	44	NULL	84	42	80	44	NULL	84
+
+query IIIIII
+select a.*, b.*, c.* from a, b natural right outer join c;
+----
+42	80	NULL	NULL	44	84
+
+query IIIIII
+select * from a natural full outer join b, a a1 natural full outer join c;
+----
+42	80	NULL	42	80	NULL
+42	80	NULL	44	NULL	84
+43	NULL	84	42	80	NULL
+43	NULL	84	44	NULL	84

--- a/test/optimizer/using_optimizer.test
+++ b/test/optimizer/using_optimizer.test
@@ -1,0 +1,131 @@
+# name: test/optimizer/using_optimizer.test
+# description: Test optimization of USING columns
+# group: [optimizer]
+
+statement ok
+PRAGMA explain_output='optimized_only';
+
+statement ok
+create table a as select 42 as i, 80 as j;
+
+statement ok
+create table b as select 43 as i, 84 as k;
+
+statement ok
+create table c as select 44 as i, 84 as l;
+
+# inner join
+query II nosort inner
+explain select i from a inner join b using (i);
+----
+
+query II nosort inner
+explain select a.i from a, b where a.i=b.i;
+----
+
+query II nosort inner
+explain select a.i from a natural join b;
+----
+
+# left join
+query II nosort left
+explain select i from a left outer join b using (i);
+----
+
+query II nosort left
+explain select a.i from a left outer join b using (i);
+----
+
+query II nosort left
+explain select a.i from a left outer join b on (a.i=b.i);
+----
+
+# right join
+query II nosort right
+explain select i from a right outer join b using (i);
+----
+
+query II nosort right
+explain select b.i from a right outer join b using (i);
+----
+
+query II nosort right
+explain select b.i from a right outer join b on (a.i=b.i);
+----
+
+# left join followed by inner join
+query I
+select i from a left outer join b using (i) inner join c using (i);
+----
+
+query I
+select a.i from a left outer join b on (a.i=b.i) inner join c on (a.i=c.i);
+----
+
+query II nosort leftinner
+explain select i from a left outer join b using (i) inner join c using (i);
+----
+
+query II nosort leftinner
+explain select a.i from a left outer join b on (a.i=b.i) inner join c on (a.i=c.i);
+----
+
+# left join followed by left join
+query I
+select i from a left outer join b using (i) left outer join c using (i);
+----
+42
+
+query I
+select a.i from a left outer join b on (a.i=b.i) left outer join c on (a.i=c.i);
+----
+42
+
+query II nosort leftleft
+explain select i from a left outer join b using (i) left outer join c using (i);
+----
+
+query II nosort leftleft
+explain select a.i from a left outer join b on (a.i=b.i) left outer join c on (a.i=c.i);
+----
+
+# left join followed by right join
+query I
+select i from a left outer join b using (i) right join c using (i);
+----
+44
+
+query I
+select c.i from a left outer join b on (a.i=b.i) right join c on (a.i=c.i);
+----
+44
+
+query II nosort leftright
+explain select i from a left outer join b using (i) right join c using (i);
+----
+
+query II nosort leftright
+explain select a.i from a left outer join b on (a.i=b.i) right join c on (a.i=c.i);
+----
+
+# full outer join
+# need to use a case expression here
+query I
+select i from a full outer join b using (i);
+----
+42
+43
+
+query I
+select case when(a.i is not null) then a.i else b.i end from a full outer join b on (a.i=b.i);
+----
+42
+43
+
+query II nosort fullouter
+explain select i from a full outer join b using (i);
+----
+
+query II nosort fullouter
+explain select case when(a.i is not null) then a.i else b.i end from a full outer join b on (a.i=b.i);
+----

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -197,6 +197,7 @@ bool sqlite3_display_result(StatementType type) {
 	case StatementType::EXPLAIN_STATEMENT:
 	case StatementType::PRAGMA_STATEMENT:
 	case StatementType::SELECT_STATEMENT:
+	case StatementType::SHOW_STATEMENT:
 		return true;
 	default:
 		return false;


### PR DESCRIPTION
Previously in a query such as:

```sql
SELECT i FROM a JOIN b USING (i);
```

We would simply bind "i" to "a.i" from the join. This is correct for inner joins, but not necessarily for other join types. This is because "i" should always return the join key, which is effectively equivalent to `COALESCE(a.i, b.i, [c.i, d.i, etc])`. For inner joins, the comparison ensures that `a.i` is never `NULL`, thus simply returning "a.i" is correct. For left joins, returning a.i is also correct since if a.i is `NULL`, necessarily b.i, c.i, etc are also `NULL`. For right joins, we need to reverse this and instead need to return `b.i`. For full outer joins, both a.i and b.i can be NULL, and we need to compute the "true" join key through a coalesce.

As an example, in a full outer join with using referencing the join key (i) is distinct from referencing each of the individual join keys:

```sql
query IIII
select i, a.i, b.i, c.i from a full outer join b using (i) full outer join c using (i) order by 1;
----
42	42	NULL	NULL
43	NULL	43	NULL
44	NULL	NULL	44
```

We could also emit the keys directly from the join hashtable itself later on, which could be a potential optimization here, but since this is only relevant for full outer joins that explicitly use the `using` keyword we don't care too much about that right now.