### PR TITLE
Pre-filtering data in zonemaps and #1303

### DIFF
--- a/benchmark/micro/zonemaps/zonemaps.benchmark
+++ b/benchmark/micro/zonemaps/zonemaps.benchmark
@@ -1,0 +1,15 @@
+# name: benchmark/micro/zonemaps/zonemaps.benchmark
+# description: Benchmark Zonemaps
+# group: [zonemaps]
+
+name Zonemaps
+group zonemaps
+
+load
+create table t as select range a, length(range) b, mod(range,10000) c, 5 d, 10000 e from range(100000000);
+
+run
+select count(*) from t where b in (1,2,4) ;
+
+result I
+9100

--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -36,12 +36,9 @@ unique_ptr<TableFilterSet> find_column_index(vector<TableFilter>& table_filters,
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 	D_ASSERT(op.children.empty());
 
-	unique_ptr<TableFilterSet> table_filters, zonemap_checks ;
+	unique_ptr<TableFilterSet> table_filters ;
 	if (!op.table_filters.empty()) {
         table_filters = find_column_index(op.table_filters,op.column_ids);
-	}
-	if (!op.zonemap_checks.empty()) {
-		zonemap_checks = find_column_index(op.zonemap_checks,op.column_ids);
 	}
 
 	if (op.function.dependency) {
@@ -51,7 +48,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 	if (!op.function.projection_pushdown) {
 		// function does not support projection pushdown
 		auto node = make_unique<PhysicalTableScan>(op.returned_types, op.function, move(op.bind_data), op.column_ids,
-		                                           op.names, move(table_filters), move(zonemap_checks));
+		                                           op.names, move(table_filters));
 		// first check if an additional projection is necessary
 		if (op.column_ids.size() == op.returned_types.size()) {
 			bool projection_necessary = false;
@@ -85,7 +82,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 		return move(projection);
 	} else {
 		return make_unique<PhysicalTableScan>(op.types, op.function, move(op.bind_data), op.column_ids, op.names,
-		                                      move(table_filters), move(zonemap_checks));
+		                                      move(table_filters));
 	}
 }
 

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -37,7 +37,6 @@ static unique_ptr<FunctionOperatorData> table_scan_init(ClientContext &context, 
 	auto &bind_data = (const TableScanBindData &)*bind_data_;
 	result->column_ids = column_ids;
 	result->scan_state.table_filters = filters->table_filters;
-	result->scan_state.zonemaps_checks = filters->zonemaps_checks;
 	bind_data.table->storage->InitializeScan(transaction, result->scan_state, result->column_ids, filters->table_filters);
 	return move(result);
 }
@@ -58,7 +57,6 @@ static unique_ptr<FunctionOperatorData> table_scan_parallel_init(ClientContext &
 	auto result = make_unique<TableScanOperatorData>();
 	result->column_ids = column_ids;
 	result->scan_state.table_filters = filters->table_filters;
-	result->scan_state.zonemaps_checks = filters->zonemaps_checks;
 	if (!table_scan_parallel_state_next(context, bind_data_, result.get(), state)) {
 		return nullptr;
 	}

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -19,8 +19,7 @@ namespace duckdb {
 class PhysicalTableScan : public PhysicalOperator {
 public:
 	PhysicalTableScan(vector<LogicalType> types, TableFunction function, unique_ptr<FunctionData> bind_data,
-	                  vector<column_t> column_ids, vector<string> names, unique_ptr<TableFilterSet> table_filters,
-	                  unique_ptr<TableFilterSet> zonemap_checks);
+	                  vector<column_t> column_ids, vector<string> names, unique_ptr<TableFilterSet> table_filters);
 
 	//! The table function
 	TableFunction function;
@@ -32,8 +31,7 @@ public:
 	vector<string> names;
 	//! The table filters
 	unique_ptr<TableFilterSet> table_filters;
-    //! The zonemap checks (i.e., pre-filtering is done but the filter is not completely pushed-down)
-    unique_ptr<TableFilterSet> zonemap_checks;
+
 public:
 	string GetName() const override;
 	string ParamsToString() const override;

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -27,9 +27,8 @@ struct FunctionOperatorData {
 
 struct TableFilterCollection {
 	TableFilterSet *table_filters;
-	TableFilterSet *zonemaps_checks;
-	TableFilterCollection(TableFilterSet *table_filters, TableFilterSet *zonemaps_checks)
-	    : table_filters(table_filters), zonemaps_checks(zonemaps_checks) {
+	TableFilterCollection(TableFilterSet *table_filters)
+	    : table_filters(table_filters) {
 	}
 };
 

--- a/src/include/duckdb/optimizer/matcher/expression_matcher.hpp
+++ b/src/include/duckdb/optimizer/matcher/expression_matcher.hpp
@@ -91,6 +91,18 @@ public:
 	bool Match(Expression *expr_, vector<Expression *> &bindings) override;
 };
 
+class InClauseExpressionMatcher : public ExpressionMatcher {
+public:
+	InClauseExpressionMatcher() : ExpressionMatcher(ExpressionClass::BOUND_OPERATOR) {
+	}
+	//! The matchers for the child expressions
+	vector<unique_ptr<ExpressionMatcher>> matchers;
+	//! The set matcher matching policy to use
+	SetMatcher::Policy policy;
+
+	bool Match(Expression *expr_, vector<Expression *> &bindings) override;
+};
+
 class ConjunctionExpressionMatcher : public ExpressionMatcher {
 public:
 	ConjunctionExpressionMatcher() : ExpressionMatcher(ExpressionClass::BOUND_CONJUNCTION) {

--- a/src/include/duckdb/optimizer/rule/in_clause_simplification.hpp
+++ b/src/include/duckdb/optimizer/rule/in_clause_simplification.hpp
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/rule/in_clause_simplification.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/optimizer/rule.hpp"
+
+namespace duckdb {
+
+// The in clause simplification rule rewrites cases where left is a column ref with a cast and right are constant values
+class InClauseSimplificationRule : public Rule {
+public:
+	InClauseSimplificationRule(ExpressionRewriter &rewriter);
+
+	unique_ptr<Expression> Apply(LogicalOperator &op, vector<Expression *> &bindings, bool &changes_made) override;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/planner/operator/logical_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_get.hpp
@@ -35,8 +35,6 @@ public:
 	//! Filters pushed down for table scan
 	vector<TableFilter> table_filters;
 
-	//! Zonemap Checks
-    vector<TableFilter> zonemap_checks;
 	string GetName() const override;
 	string ParamsToString() const override;
 

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -79,7 +79,6 @@ public:
 	unique_ptr<ColumnScanState[]> column_scans;
 	idx_t column_count;
 	TableFilterSet *table_filters = nullptr;
-	TableFilterSet *zonemaps_checks = nullptr;
 	unique_ptr<AdaptiveFilter> adaptive_filter;
 	LocalScanState local_state;
 	MorselInfo *version_info;

--- a/src/include/duckdb/storage/uncompressed_segment.hpp
+++ b/src/include/duckdb/storage/uncompressed_segment.hpp
@@ -59,7 +59,7 @@ public:
 	//! Fetch the vector at index "vector_index" from the uncompressed segment, throwing an exception if there are any
 	//! outstanding updates
 	void IndexScan(ColumnScanState &state, idx_t vector_index, Vector &result);
-	static void filterSelection(SelectionVector &sel, Vector &result, TableFilter filter, idx_t &approved_tuple_count,
+	static void filterSelection(SelectionVector &sel, Vector &result, const TableFilter& filter, idx_t &approved_tuple_count,
 	                            nullmask_t &nullmask);
 	//! Executes the filters directly in the table's data
 	void Select(Transaction &transaction, Vector &result, vector<TableFilter> &tableFilters, SelectionVector &sel,

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -12,6 +12,8 @@
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/table_filter.hpp"
 
+#include <duckdb/common/operator/cast_operators.hpp>
+
 namespace duckdb {
 
 using ExpressionValueInformation = FilterCombiner::ExpressionValueInformation;

--- a/src/optimizer/matcher/expression_matcher.cpp
+++ b/src/optimizer/matcher/expression_matcher.cpp
@@ -63,6 +63,14 @@ bool ComparisonExpressionMatcher::Match(Expression *expr_, vector<Expression *> 
 	return SetMatcher::Match(matchers, expressions, bindings, policy);
 }
 
+bool InClauseExpressionMatcher::Match(Expression *expr_, vector<Expression *> &bindings) {
+	if (!ExpressionMatcher::Match(expr_, bindings)) {
+		return false;
+	}
+	auto expr = (BoundOperatorExpression *)expr_;
+	return SetMatcher::Match(matchers, expr->children, bindings, policy);
+}
+
 bool ConjunctionExpressionMatcher::Match(Expression *expr_, vector<Expression *> &bindings) {
 	if (!ExpressionMatcher::Match(expr_, bindings)) {
 		return false;

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -6,16 +6,18 @@
 #include "duckdb/optimizer/common_aggregate_optimizer.hpp"
 #include "duckdb/optimizer/cse_optimizer.hpp"
 #include "duckdb/optimizer/expression_heuristics.hpp"
-#include "duckdb/optimizer/filter_pushdown.hpp"
 #include "duckdb/optimizer/filter_pullup.hpp"
+#include "duckdb/optimizer/filter_pushdown.hpp"
 #include "duckdb/optimizer/in_clause_rewriter.hpp"
 #include "duckdb/optimizer/join_order_optimizer.hpp"
 #include "duckdb/optimizer/regex_range_filter.hpp"
 #include "duckdb/optimizer/remove_unused_columns.hpp"
 #include "duckdb/optimizer/rule/list.hpp"
-#include "duckdb/optimizer/topn_optimizer.hpp"
 #include "duckdb/optimizer/statistics_propagator.hpp"
+#include "duckdb/optimizer/topn_optimizer.hpp"
 #include "duckdb/planner/binder.hpp"
+
+#include "duckdb/optimizer/rule/in_clause_simplification.hpp"
 
 namespace duckdb {
 
@@ -27,6 +29,7 @@ Optimizer::Optimizer(Binder &binder, ClientContext &context) : context(context),
 	rewriter.rules.push_back(make_unique<ConjunctionSimplificationRule>(rewriter));
 	rewriter.rules.push_back(make_unique<DatePartSimplificationRule>(rewriter));
 	rewriter.rules.push_back(make_unique<ComparisonSimplificationRule>(rewriter));
+	rewriter.rules.push_back(make_unique<InClauseSimplificationRule>(rewriter));
 	rewriter.rules.push_back(make_unique<MoveConstantsRule>(rewriter));
 	rewriter.rules.push_back(make_unique<LikeOptimizationRule>(rewriter));
 	rewriter.rules.push_back(make_unique<EmptyNeedleRemovalRule>(rewriter));

--- a/src/optimizer/pushdown/pushdown_get.cpp
+++ b/src/optimizer/pushdown/pushdown_get.cpp
@@ -44,10 +44,18 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownGet(unique_ptr<LogicalOperat
 
 	//! For more complex filters if all filters to a column are constants we generate a min max boundary used to check
 	//! the zonemaps.
-	get.zonemap_checks = combiner.GenerateZonemapChecks(get.column_ids, get.table_filters);
+	auto zonemap_checks = combiner.GenerateZonemapChecks(get.column_ids, get.table_filters);
 
 	for (auto &f : get.table_filters) {
 		f.column_index = get.column_ids[f.column_index];
+	}
+
+	//! Use zonemap checks as table filters for pre-processing
+	for (auto& zonemap_check: zonemap_checks){
+		if (zonemap_check.column_index != COLUMN_IDENTIFIER_ROW_ID){
+			get.table_filters.push_back(zonemap_check);
+		}
+
 	}
 
 	GenerateFilters();

--- a/src/optimizer/pushdown/pushdown_get.cpp
+++ b/src/optimizer/pushdown/pushdown_get.cpp
@@ -55,7 +55,6 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownGet(unique_ptr<LogicalOperat
 		if (zonemap_check.column_index != COLUMN_IDENTIFIER_ROW_ID){
 			get.table_filters.push_back(zonemap_check);
 		}
-
 	}
 
 	GenerateFilters();

--- a/src/optimizer/rule/CMakeLists.txt
+++ b/src/optimizer/rule/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library_unity(duckdb_optimizer_rules
                   distributivity.cpp
                   empty_needle_removal.cpp
                   move_constants.cpp
-                  like_optimizations.cpp)
+                  like_optimizations.cpp
+                  in_clause_simplification_rule.cpp)
 set(ALL_OBJECT_FILES ${ALL_OBJECT_FILES}
                      $<TARGET_OBJECTS:duckdb_optimizer_rules> PARENT_SCOPE)

--- a/src/optimizer/rule/in_clause_simplification_rule.cpp
+++ b/src/optimizer/rule/in_clause_simplification_rule.cpp
@@ -1,0 +1,51 @@
+#include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/optimizer/rule/in_clause_simplification.hpp"
+#include "duckdb/planner/expression/bound_case_expression.hpp"
+
+namespace duckdb {
+
+InClauseSimplificationRule::InClauseSimplificationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	// match on InClauseExpression that has a ConstantExpression as a check
+	auto op = make_unique<InClauseExpressionMatcher>();
+	op->policy = SetMatcher::Policy::SOME;
+	root = move(op);
+}
+
+unique_ptr<Expression> InClauseSimplificationRule::Apply(LogicalOperator &op, vector<Expression *> &bindings,
+                                                         bool &changes_made) {
+	D_ASSERT(bindings[0]->expression_class == ExpressionClass::BOUND_OPERATOR);
+	auto expr = (BoundOperatorExpression *)bindings[0];
+	if (expr->children[0]->expression_class != ExpressionClass::BOUND_CAST) {
+		return nullptr;
+	}
+	auto cast_expression = (BoundCastExpression *)expr->children[0].get();
+	if (cast_expression->child->expression_class != ExpressionClass::BOUND_COLUMN_REF) {
+		return nullptr;
+	}
+	//! Here we check if we can apply the expression on the constant side
+	auto target_type = cast_expression->source_type();
+	if (!BoundCastExpression::CastIsInvertible(target_type, cast_expression->return_type)) {
+		return nullptr;
+	}
+	for (size_t i{1}; i < expr->children.size(); i++) {
+		if (expr->children[i]->expression_class != ExpressionClass::BOUND_CONSTANT) {
+			return nullptr;
+		}
+		D_ASSERT(expr->children[i]->IsFoldable());
+		auto constant_value = ExpressionExecutor::EvaluateScalar(*expr->children[i]);
+		auto new_constant = constant_value.TryCastAs(target_type);
+		if (new_constant) {
+			//! We can cast, so we move the new constant
+			auto new_constant_expr = make_unique<BoundConstantExpression>(constant_value);
+			expr->children[i] = move(new_constant_expr);
+		}
+		else {
+			return nullptr;
+		}
+	}
+	//! We can cast the full list, so we move the column
+	expr->children[0] = move(cast_expression->child);
+	return nullptr;
+}
+
+} // namespace duckdb

--- a/src/optimizer/rule/in_clause_simplification_rule.cpp
+++ b/src/optimizer/rule/in_clause_simplification_rule.cpp
@@ -28,6 +28,7 @@ unique_ptr<Expression> InClauseSimplificationRule::Apply(LogicalOperator &op, ve
 	if (!BoundCastExpression::CastIsInvertible(target_type, cast_expression->return_type)) {
 		return nullptr;
 	}
+	vector<unique_ptr<BoundConstantExpression>> cast_list;
 	//! First check if we can cast all children
 	for (size_t i = 1; i < expr->children.size();i++){
 		if (expr->children[i]->expression_class != ExpressionClass::BOUND_CONSTANT) {
@@ -39,12 +40,16 @@ unique_ptr<Expression> InClauseSimplificationRule::Apply(LogicalOperator &op, ve
 		if (!new_constant) {
 		    return nullptr;
 		}
+		else{
+		    auto new_constant_expr = make_unique<BoundConstantExpression>(constant_value);
+			cast_list.push_back(move(new_constant_expr));
+		}
 	}
 	//! We can cast, so we move the new constant
 	for (size_t i = 1; i < expr->children.size(); i++) {
-		auto constant_value = ExpressionExecutor::EvaluateScalar(*expr->children[i]);
-		auto new_constant_expr = make_unique<BoundConstantExpression>(constant_value);
-		expr->children[i] = move(new_constant_expr);
+		expr->children[i] = move(cast_list[i-1]);
+
+//		expr->children[i] = move(new_constant_expr);
 	}
 	//! We can cast the full list, so we move the column
 	expr->children[0] = move(cast_expression->child);

--- a/src/optimizer/rule/in_clause_simplification_rule.cpp
+++ b/src/optimizer/rule/in_clause_simplification_rule.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/optimizer/rule/in_clause_simplification.hpp"
-#include "duckdb/planner/expression/bound_case_expression.hpp"
+#include "duckdb/planner/expression/list.hpp"
+#include "duckdb/planner/expression/bound_operator_expression.hpp"
 
 namespace duckdb {
 

--- a/src/optimizer/statistics/expression/propagate_comparison.cpp
+++ b/src/optimizer/statistics/expression/propagate_comparison.cpp
@@ -22,6 +22,19 @@ FilterPropagateResult StatisticsPropagator::PropagateComparison(BaseStatistics &
 	default:
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
+	switch (right.type.InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+	case PhysicalType::INT16:
+	case PhysicalType::INT32:
+	case PhysicalType::INT64:
+	case PhysicalType::INT128:
+	case PhysicalType::FLOAT:
+	case PhysicalType::DOUBLE:
+		break;
+	default:
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
 	auto &lstats = (NumericStatistics &)left;
 	auto &rstats = (NumericStatistics &)right;
 	if (lstats.min.is_null || lstats.max.is_null || rstats.min.is_null || rstats.max.is_null) {

--- a/src/optimizer/statistics/expression/propagate_comparison.cpp
+++ b/src/optimizer/statistics/expression/propagate_comparison.cpp
@@ -22,19 +22,6 @@ FilterPropagateResult StatisticsPropagator::PropagateComparison(BaseStatistics &
 	default:
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
-	switch (right.type.InternalType()) {
-	case PhysicalType::BOOL:
-	case PhysicalType::INT8:
-	case PhysicalType::INT16:
-	case PhysicalType::INT32:
-	case PhysicalType::INT64:
-	case PhysicalType::INT128:
-	case PhysicalType::FLOAT:
-	case PhysicalType::DOUBLE:
-		break;
-	default:
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-	}
 	auto &lstats = (NumericStatistics &)left;
 	auto &rstats = (NumericStatistics &)right;
 	if (lstats.min.is_null || lstats.max.is_null || rstats.min.is_null || rstats.max.is_null) {

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -354,9 +354,6 @@ bool DataTable::ScanBaseTable(Transaction &transaction, DataChunk &result, Table
 	if (!CheckZonemap(state, state.table_filters, current_row)) {
 		return true;
 	}
-	if (!CheckZonemap(state, state.zonemaps_checks, current_row)) {
-		return true;
-	}
 	// second, scan the version chunk manager to figure out which tuples to load for this transaction
 	SelectionVector valid_sel(STANDARD_VECTOR_SIZE);
 	if (vector_offset >= MorselInfo::MORSEL_VECTOR_COUNT) {

--- a/src/storage/numeric_segment.cpp
+++ b/src/storage/numeric_segment.cpp
@@ -195,6 +195,11 @@ static void templated_select_operation_between(SelectionVector &sel, Vector &res
 		                         constantRight.value_.double_, approved_tuple_count);
 		break;
 	}
+	case PhysicalType::BOOL: {
+		Select<bool, OPL, OPR>(sel, result, source, source_mask, constantLeft.value_.boolean,
+		                         constantRight.value_.boolean, approved_tuple_count);
+		break;
+	}
 	default:
 		throw InvalidTypeException(type, "Invalid type for filter pushed down to table comparison");
 	}

--- a/src/storage/numeric_segment.cpp
+++ b/src/storage/numeric_segment.cpp
@@ -123,7 +123,6 @@ static void templated_select_operation(SelectionVector &sel, Vector &result, Phy
 	}
 	case PhysicalType::INT16: {
 		Select<int16_t, OP>(sel, result, source, source_mask, constant.value_.smallint, approved_tuple_count);
-		;
 		break;
 	}
 	case PhysicalType::INT32: {
@@ -144,6 +143,10 @@ static void templated_select_operation(SelectionVector &sel, Vector &result, Phy
 	}
 	case PhysicalType::DOUBLE: {
 		Select<double, OP>(sel, result, source, source_mask, constant.value_.double_, approved_tuple_count);
+		break;
+	}
+	case PhysicalType::BOOL: {
+		Select<bool, OP>(sel, result, source, source_mask, constant.value_.boolean, approved_tuple_count);
 		break;
 	}
 	default:

--- a/src/storage/uncompressed_segment.cpp
+++ b/src/storage/uncompressed_segment.cpp
@@ -215,7 +215,7 @@ static void filterSelectionType(T *vec, T *predicate, SelectionVector &sel, idx_
 	sel.Initialize(new_sel);
 }
 
-void UncompressedSegment::filterSelection(SelectionVector &sel, Vector &result, TableFilter filter,
+void UncompressedSegment::filterSelection(SelectionVector &sel, Vector &result, const TableFilter& filter,
                                           idx_t &approved_tuple_count, nullmask_t &nullmask) {
 	// the inplace loops take the result as the last parameter
 	switch (result.type.InternalType()) {
@@ -271,6 +271,14 @@ void UncompressedSegment::filterSelection(SelectionVector &sel, Vector &result, 
 		auto predicate_vector = Vector(filter.constant.str_value);
 		auto predicate = FlatVector::GetData<string_t>(predicate_vector);
 		filterSelectionType<string_t>(result_flat, predicate, sel, approved_tuple_count, filter.comparison_type,
+		                              nullmask);
+		break;
+	}
+	case PhysicalType::BOOL: {
+		auto result_flat = FlatVector::GetData<bool>(result);
+		auto predicate_vector = Vector(filter.constant.value_.boolean);
+		auto predicate = FlatVector::GetData<bool>(predicate_vector);
+		filterSelectionType<bool>(result_flat, predicate, sel, approved_tuple_count, filter.comparison_type,
 		                              nullmask);
 		break;
 	}

--- a/test/optimizer/zonemaps.test
+++ b/test/optimizer/zonemaps.test
@@ -5,169 +5,268 @@
 statement ok
 PRAGMA explain_output = PHYSICAL_ONLY;
 
+statement ok
+create temporary table t as select range a, length(range) b, mod(range,10000) c, 5 d, 10000 e from range(100000);
+
+# 1) In-clause based on in-clause range/boundary zonemap check
+query II
+explain select count(*) from t where b in (1,2,3) ;
+----
+physical_plan	<REGEX>:.*Filters:.*
+
+query II
+explain select count(*) from t where b <=3 and b>=0;
+----
+physical_plan	<REGEX>:.*Filters:.*
+
+#   2) In-clause based on in-clause range/boundary zonemap check
+
+query II
+explain select count(*) from t where b in (1, 3) ;
+----
+physical_plan	<REGEX>:.*Filters:.*b<=3.*
+
+query II
+explain select count(*) from t where b = 1 or b = 3 ;
+----
+physical_plan	<REGEX>:.*Filters:.*b<=3.*
+
+#   3) Transitive Filters
+query II
+explain select count(*) from t where b < 5 and d = 5;
+----
+physical_plan	<REGEX>:.*Filters:.*
+
+query II
+explain select count(*) from t where  d = 5 and b < d;
+----
+physical_plan	<REGEX>:.*Filters:.*
+
+#   4)  Check zonemap before joins
+statement ok
+create temporary table t1 as select range a, length(range) nationkey from range(100000);
+
+statement ok
+create table t2 as select range  nationkey, concat('Nation_',range) n_name from range(25);
+
+query II
+explain select count(*) from t1 join t2 using (nationkey)
+where t2.n_name = 'Nation_1' and t1.nationkey =1;
+----
+physical_plan	<REGEX>:.*Filters:.*Filters:.*
+
+query II
+explain select count(*) from t1 join t2 using (nationkey)
+where t2.n_name = 'Nation_1' and t2.nationkey =1;
+----
+physical_plan	<REGEX>:.*Filters:.*Filters:.*
+
+query II
+explain select count(*) from t1 join t2 using (nationkey) where t2.n_name = 'Nation_1';
+----
+physical_plan	<REGEX>:.*Filters:.*n_name=Nation_1.*
+
+query II
+explain select count(*) from t1 join t2 using (nationkey) where t2.nationkey =2 or n_name= 'Nation_2';
+----
+physical_plan	<!REGEX>:.*Filters:.*
+
+query II
+explain select count(*) from t1 join t2 using (nationkey) where t2.n_name in ( 'Nation_1', 'Nation_2');
+----
+physical_plan	<REGEX>:.*Filters:.*
+
+
+
 # 5) More General Tests
 statement ok
 CREATE TABLE test(a tinyint, b smallint, c integer, d bigint, e double, f real, g varchar);
+
+statement ok
+INSERT INTO test values (1,1,1,1,1,1,'1')
+
+statement ok
+INSERT INTO test values (10,10,10,10,10,10,'10')
 
 # 5.1) Flipping filters
 query II
 explain select count(*) from test where (2 < a and 7 > a) or (a >5 and a < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*a>=2.*a<=7.*
+physical_plan	<REGEX>:.* Filters: .*a>=2.*a<=7.*
 
 query II
 explain select count(*) from test where (2 < a and a < 7) or (a >5 and a < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*a>=2.*a<=7.*
+physical_plan	<REGEX>:.* Filters: .*a>=2.*a<=7.*
 
 query II
 explain select count(*) from test where (a >=2 and 7 > a)  or (a >5 and a < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*a>=2.*a<=7.*
+physical_plan	<REGEX>:.* Filters: .*a>=2.*a<=7.*
 
 query II
 explain select count(*) from test where (4=a) or (a >5 and a < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*a>=4.*a<=6.*
+physical_plan	<REGEX>:.* Filters: .*a>=4.*a<=6.*
 
 # 5.2) Different Data Types
 
 query II
 explain select count(*) from test where (a >=2 and a < 7) or (a >5 and a < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*a>=2.*a<=7.*
+physical_plan	<REGEX>:.* Filters: .*a>=2.*a<=7.*
 
 query II
 explain select count(*) from test where a >2 and a < 7 or (a >5 and a < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*a>=2.*a<=7.*
+physical_plan	<REGEX>:.* Filters: .*a>=2.*a<=7.*
 
 query II
 explain select count(*) from test where a >2 and a <= 7 or (a >5 and a < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*a>=2.*a<=7.*
+physical_plan	<REGEX>:.* Filters: .*a>=2.*a<=7.*
 
 query II
 explain select count(*) from test where a >=2 and a <= 7 or (a >5 and a < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*a>=2.*a<=7.*
+physical_plan	<REGEX>:.* Filters: .*a>=2.*a<=7.*
 
 query II
 explain select count(*) from test where (b >=2 and b < 7) or (b >5 and b < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*b>=2.*b<=7.*
+physical_plan	<REGEX>:.* Filters: .*b>=2.*b<=7.*
 
 query II
 explain select count(*) from test where b >2 and b < 7 or (b >5 and b < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*b>=2.*b<=7.*
+physical_plan	<REGEX>:.* Filters: .*b>=2.*b<=7.*
 
 query II
 explain select count(*) from test where b >2 and b <= 7 or (b >5 and b < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*b>=2.*b<=7.*
+physical_plan	<REGEX>:.* Filters: .*b>=2.*b<=7.*
 
 query II
 explain select count(*) from test where b >=2 and b <= 7 or (b >5 and b < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*b>=2.*b<=7.*
+physical_plan	<REGEX>:.* Filters: .*b>=2.*b<=7.*
 
 query II
 explain select count(*) from test where (c >=2 and c < 7) or (c >5 and c < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*c>=2.*c<=7.*
+physical_plan	<REGEX>:.* Filters: .*c>=2.*c<=7.*
 
 query II
 explain select count(*) from test where c >2 and c < 7 or (c >5 and c < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*c>=2.*c<=7.*
+physical_plan	<REGEX>:.* Filters: .*c>=2.*c<=7.*
 
 query II
 explain select count(*) from test where c >2 and c <= 7 or (c >5 and c < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*c>=2.*c<=7.*
+physical_plan	<REGEX>:.* Filters: .*c>=2.*c<=7.*
 
 query II
 explain select count(*) from test where c >=2 and c <= 7 or (c >5 and c < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*c>=2.*c<=7.*
+physical_plan	<REGEX>:.* Filters: .*c>=2.*c<=7.*
 
 query II
 explain select count(*) from test where (d >=2 and d < 7) or (d >5 and d < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*d>=2.*d<=7.*
+physical_plan	<REGEX>:.* Filters: .*d>=2.*d<=7.*
 
 query II
 explain select count(*) from test where d >2 and d < 7 or (d >5 and d < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*d>=2.*d<=7.*
+physical_plan	<REGEX>:.* Filters: .*d>=2.*d<=7.*
 
 query II
 explain select count(*) from test where d >2 and d <= 7 or (d >5 and d < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*d>=2.*d<=7.*
+physical_plan	<REGEX>:.* Filters: .*d>=2.*d<=7.*
 
 query II
 explain select count(*) from test where d >=2 and d <= 7 or (d >5 and d < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*d>=2.*d<=7.*
+physical_plan	<REGEX>:.* Filters: .*d>=2.*d<=7.*
 
 query II
 explain select count(*) from test where (e >=2 and e < 7) or (e >5 and e < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*e>=2.*e<=7.*
+physical_plan	<REGEX>:.* Filters: .*e>=2.*e<=7.*
 
 query II
 explain select count(*) from test where e >2 and e < 7 or (e >5 and e < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*e>=2.*e<=7.*
+physical_plan	<REGEX>:.* Filters: .*e>=2.*e<=7.*
 
 query II
 explain select count(*) from test where e >2 and e <= 7 or (e >5 and e < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*e>=2.*e<=7.*
+physical_plan	<REGEX>:.* Filters: .*e>=2.*e<=7.*
 
 query II
 explain select count(*) from test where e >=2 and e <= 7 or (e >5 and e < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*e>=2.*e<=7.*
+physical_plan	<REGEX>:.* Filters: .*e>=2.*e<=7.*
 
 query II
 explain select count(*) from test where (f >=2 and f < 7) or (f >5 and f < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*f>=2.*f<=7.*
+physical_plan	<REGEX>:.* Filters: .*f>=2.*f<=7.*
 
 query II
 explain select count(*) from test where f >2 and f < 7 or (f >5 and f < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*f>=2.*f<=7.*
+physical_plan	<REGEX>:.* Filters: .*f>=2.*f<=7.*
 
 query II
 explain select count(*) from test where f >2 and f <= 7 or (f >5 and f < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*f>=2.*f<=7.*
+physical_plan	<REGEX>:.* Filters: .*f>=2.*f<=7.*
 
 query II
 explain select count(*) from test where f >=2 and f <= 7 or (f >5 and f < 6)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*f>=2.*f<=7.*
+physical_plan	<REGEX>:.* Filters: .*f>=2.*f<=7.*
 
 query II
 explain select count(*) from test where (g >='2' and g < '7') or (g >'5' and g < '6')
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*g>=2.*g<=7.*
+physical_plan	<REGEX>:.* Filters: .*g>=2.*g<=7.*
 
 query II
 explain select count(*) from test where g >'2' and g < '7' or (g >'5' and g < '6')
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*g>=2.*g<=7.*
+physical_plan	<REGEX>:.* Filters: .*g>=2.*g<=7.*
 
 query II
 explain select count(*) from test where g >'2' and g <= '7' or (g >'5' and g < '6')
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*g>=2.*g<=7.*
+physical_plan	<REGEX>:.* Filters: .*g>=2.*g<=7.*
 
 query II
 explain select count(*) from test where g >='2' and g <= '7' or (g >'5' and g < '6')
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*g>=2.*g<=7.*
+physical_plan	<REGEX>:.* Filters: .*g>=2.*g<=7.*
+
+# 5.3) Casting
+statement ok
+CREATE TABLE test_date(a date);
+
+statement ok
+insert into test_date values ('1995-12-01')
+
+statement ok
+insert into test_date values ('1995-12-10')
+
+query II
+explain select count(*) from test_date where a = '1995-12-01'
+----
+physical_plan	<REGEX>:.* Filters: .*a=1995-12-01.*
+
+query II
+explain select count(*) from test_date where a in ( '1995-12-01', '1995-12-02')
+----
+physical_plan	<REGEX>:.* Filters: .*a<=1995-12-02.*

--- a/test/sql/filter/test_zonemap.test_slow
+++ b/test/sql/filter/test_zonemap.test_slow
@@ -16,7 +16,7 @@ select count(*) from t where a > 500 or a <= 700
 query II
 explain select count(*) from t where (a > 500 and b = 3) or (a > 7000 and b = 2)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*b>=2.*b<=3.*
+physical_plan	<REGEX>:.* Filters: .*b>=2.*b<=3.*
 
 query I
 select count(*) from t where (a > 500 and b = 3) or (a > 7000 and b = 2)
@@ -26,7 +26,7 @@ select count(*) from t where (a > 500 and b = 3) or (a > 7000 and b = 2)
 query II
 explain select count(*) from t where (a > 500 AND b = 3) OR (a > 400) OR (a > 300 AND b=4) OR (a > 600 AND a > 300)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*a>=300.*
+physical_plan	<REGEX>:.* Filters: .*a>=300.*
 
 
 query I
@@ -37,7 +37,7 @@ select count(*) from t where (a > 500 AND b = 3) OR (a > 400) OR (a > 300 AND b=
 query II
 explain select count(*) from t where (a > 500 AND b = 3) OR (a > 400) OR (a > 300 AND b=4) OR (a > 600 AND a > 300)
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*a>=300.*
+physical_plan	<REGEX>:.* Filters: .*a>=300.*
 
 
 query I
@@ -49,7 +49,7 @@ select count(*) from t where (a > 500 AND b = 3) OR (a > 400) OR (a > 300 AND b=
 query II
 explain select count(*) from t where (a > 500 AND b = 3) OR (c = 400) OR (a > 300 AND b=4) OR (a > 600 AND a > 300) or (d < 10)
 ----
-physical_plan	<!REGEX>:.* Zonemaps Checks: .*a>=300.*
+physical_plan	<!REGEX>:.* Filters: .*a>=300.*
 
 
 query I
@@ -61,7 +61,7 @@ select count(*) from t where (a > 500 AND b = 3) OR (a > 400) OR (a > 300 AND b=
 query II
 explain select count(*) from t where (a > 500 AND b = 1) OR b < 2
 ----
-physical_plan	<REGEX>:.* Zonemaps Checks: .*b<=2.*
+physical_plan	<REGEX>:.* Filters: .*b<=2.*
 
 
 query I

--- a/test/sql/optimizer/test_in_rewrite_rule.test
+++ b/test/sql/optimizer/test_in_rewrite_rule.test
@@ -1,0 +1,31 @@
+# name: test/sql/optimizer/test_in_rewrite_rule.test
+# description: Test In Rewrite Rule
+# group: [optimizer]
+
+#statement ok
+#create table t (i integer);
+#
+#statement ok
+#insert into t values (1)
+#
+#statement ok
+#insert into t values (2)
+
+
+#query T
+#select * from t where i in ('1','2','y');
+#----
+#1
+#2
+#
+#query T
+#SELECT x::VARCHAR IN ('1', y) FROM (VALUES (1, 2), (2, 3)) tbl(x, y);
+#----
+#1
+#0
+
+query T
+SELECT x::BIGINT IN (1::BIGINT, y) FROM (VALUES (1::INTEGER, 2::BIGINT), (2::INTEGER, 3::BIGINT)) tbl(x, y);
+----
+1
+0

--- a/test/sql/optimizer/test_in_rewrite_rule.test
+++ b/test/sql/optimizer/test_in_rewrite_rule.test
@@ -2,27 +2,27 @@
 # description: Test In Rewrite Rule
 # group: [optimizer]
 
-#statement ok
-#create table t (i integer);
-#
-#statement ok
-#insert into t values (1)
-#
-#statement ok
-#insert into t values (2)
+statement ok
+create table t (i integer);
+
+statement ok
+insert into t values (1)
+
+statement ok
+insert into t values (2)
 
 
-#query T
-#select * from t where i in ('1','2','y');
-#----
-#1
-#2
-#
-#query T
-#SELECT x::VARCHAR IN ('1', y) FROM (VALUES (1, 2), (2, 3)) tbl(x, y);
-#----
-#1
-#0
+query T
+select * from t where i in ('1','2','y');
+----
+1
+2
+
+query T
+SELECT x::VARCHAR IN ('1', y) FROM (VALUES (1, 2), (2, 3)) tbl(x, y);
+----
+1
+0
 
 query T
 SELECT x::BIGINT IN (1::BIGINT, y) FROM (VALUES (1::INTEGER, 2::BIGINT), (2::INTEGER, 3::BIGINT)) tbl(x, y);


### PR DESCRIPTION
Zonemaps checks are also used to filter data during scanning and to enjoy the benefits of the adaptive filters.

In this PR there is also a new rewrite rule that flips a cast from a column_ref to all constant elements from an in clause allowing them to be pushed down to the zonemaps.