### PR TITLE
fix java unit test fail issue due to utf-8 java source file

### DIFF
--- a/tools/jdbc/CMakeLists.txt
+++ b/tools/jdbc/CMakeLists.txt
@@ -13,7 +13,7 @@ project(DuckDBJDummy NONE)
 file(GLOB JAVA_SRC_FILES src/main/java/org/duckdb/*.java)
 file(GLOB JAVA_TEST_FILES src/test/java/org/duckdb/test/*.java)
 
-set(CMAKE_JAVA_COMPILE_FLAGS -source 1.7 -target 1.7)
+set(CMAKE_JAVA_COMPILE_FLAGS -source 1.7 -target 1.7 -encoding utf-8)
 
 add_jar(duckdb_jdbc ${JAVA_SRC_FILES} ${JAVA_TEST_FILES}
         META-INF/services/java.sql.Driver GENERATE_NATIVE_HEADERS duckdb-native)


### PR DESCRIPTION
When I build duckdb's source code in linux (Centos 7), the build process will fail when execute java related unit test. 

The error message is like this:

duckdb/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java:1290: error: unmappable character for encoding ASCII
		ResultSet rs = stmt.executeQuery("SELECT 'M??hleisen', '????', '??????????123456789'");

And we can set the java compile flag " -encoding utf-8"  to tell java compiler the source code (and strings inside that source code file) are utf-8
