### PR TITLE
add single_thread_pointer

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -349,10 +349,10 @@ private:
 };
 
 void StringColumnReader::DictReference(Vector &result) {
-	StringVector::AddBuffer(result, make_unique<ParquetStringVectorBuffer>(dict));
+	StringVector::AddBuffer(result, make_buffer<ParquetStringVectorBuffer>(dict));
 }
 void StringColumnReader::PlainReference(shared_ptr<ByteBuffer> plain_data, Vector &result) {
-	StringVector::AddBuffer(result, make_unique<ParquetStringVectorBuffer>(move(plain_data)));
+	StringVector::AddBuffer(result, make_buffer<ParquetStringVectorBuffer>(move(plain_data)));
 }
 
 string_t StringParquetValueConversion::DictRead(ByteBuffer &dict, uint32_t &offset, ColumnReader &reader) {

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -92,13 +92,13 @@ void Vector::Slice(const SelectionVector &sel, idx_t count) {
 		// already a dictionary, slice the current dictionary
 		auto &current_sel = DictionaryVector::SelVector(*this);
 		auto sliced_dictionary = current_sel.Slice(sel, count);
-		buffer = make_unique<DictionaryBuffer>(move(sliced_dictionary));
+		buffer = make_buffer<DictionaryBuffer>(move(sliced_dictionary));
 		return;
 	}
 	auto child_ref = make_buffer<VectorChildBuffer>();
 	child_ref->data.Reference(*this);
 
-	auto dict_buffer = make_unique<DictionaryBuffer>(sel);
+	auto dict_buffer = make_buffer<DictionaryBuffer>(sel);
 	buffer = move(dict_buffer);
 	auxiliary = move(child_ref);
 	vector_type = VectorType::DICTIONARY_VECTOR;
@@ -606,7 +606,7 @@ void Vector::Orrify(idx_t count, VectorData &data) {
 			data.nullmask = &FlatVector::Nullmask(child);
 		} else {
 			// dictionary with non-flat child: create a new reference to the child and normalify it
-			auto new_aux = make_unique<VectorChildBuffer>();
+			auto new_aux = make_buffer<VectorChildBuffer>();
 			new_aux->data.Reference(child);
 			new_aux->data.Normalify(sel, count);
 
@@ -896,10 +896,10 @@ void StringVector::AddHandle(Vector &vector, unique_ptr<BufferHandle> handle) {
 		vector.auxiliary = make_buffer<VectorStringBuffer>();
 	}
 	auto &string_buffer = (VectorStringBuffer &)*vector.auxiliary;
-	string_buffer.AddHeapReference(make_unique<ManagedVectorBuffer>(move(handle)));
+	string_buffer.AddHeapReference(make_buffer<ManagedVectorBuffer>(move(handle)));
 }
 
-void StringVector::AddBuffer(Vector &vector, unique_ptr<VectorBuffer> buffer) {
+void StringVector::AddBuffer(Vector &vector, buffer_ptr<VectorBuffer> buffer) {
 	D_ASSERT(vector.type.InternalType() == PhysicalType::VARCHAR);
 	if (!vector.auxiliary) {
 		vector.auxiliary = make_buffer<VectorStringBuffer>();

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -247,6 +247,9 @@ bool ART::Insert(IndexLock &lock, DataChunk &input, Vector &row_ids) {
 }
 
 bool ART::Append(IndexLock &lock, DataChunk &appended_data, Vector &row_identifiers) {
+	DataChunk expression_result;
+	expression_result.Initialize(logical_types);
+
 	// first resolve the expressions for the index
 	ExecuteExpressions(appended_data, expression_result);
 
@@ -258,6 +261,10 @@ void ART::VerifyAppend(DataChunk &chunk) {
 	if (!is_unique) {
 		return;
 	}
+
+	DataChunk expression_result;
+	expression_result.Initialize(logical_types);
+
 	// unique index, check
 	lock_guard<mutex> l(lock);
 	// first resolve the expressions for the index
@@ -358,6 +365,9 @@ bool ART::Insert(unique_ptr<Node> &node, unique_ptr<Key> value, unsigned depth, 
 // Delete
 //===--------------------------------------------------------------------===//
 void ART::Delete(IndexLock &state, DataChunk &input, Vector &row_ids) {
+	DataChunk expression_result;
+	expression_result.Initialize(logical_types);
+
 	// first resolve the expressions
 	ExecuteExpressions(input, expression_result);
 

--- a/src/include/duckdb/common/single_thread_ptr.hpp
+++ b/src/include/duckdb/common/single_thread_ptr.hpp
@@ -1,0 +1,164 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/single_thread_ptr.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+namespace duckdb {
+template <typename T>
+class single_thread_ptr {
+public:
+	T *ptr;              // contained pointer
+	uint32_t *ref_count; // reference counter
+
+public:
+	// Default constructor, constructs an empty single_thread_ptr.
+	constexpr single_thread_ptr() : ptr(nullptr), ref_count(nullptr) {
+	}
+	// Construct empty single_thread_ptr.
+	constexpr single_thread_ptr(std::nullptr_t) : ptr(nullptr), ref_count(nullptr) {
+	}
+	// Construct a single_thread_ptr that wraps raw pointer.
+
+	single_thread_ptr(uint32_t *r, T *p) {
+		ptr = p;
+		ref_count = r;
+	}
+
+	template <class U>
+	single_thread_ptr(uint32_t *r, U *p) {
+		ptr = p;
+		ref_count = r;
+	}
+
+	// Copy  constructor.
+	single_thread_ptr(const single_thread_ptr &sp) : ptr(nullptr), ref_count(nullptr) {
+		if (sp.ptr) {
+			ptr = sp.ptr;
+			ref_count = sp.ref_count;
+			++(*ref_count);
+		}
+	}
+
+	// Conversion constructor.
+	template <typename U>
+	single_thread_ptr(const single_thread_ptr<U> &sp) : ptr(nullptr), ref_count(nullptr) {
+		if (sp.ptr) {
+			ptr = sp.ptr;
+			ref_count = sp.ref_count;
+			++(*ref_count);
+		}
+	}
+
+	// move  constructor.
+	single_thread_ptr(single_thread_ptr &&sp) noexcept : ptr {sp.ptr}, ref_count {sp.ref_count} {
+		sp.ptr = nullptr;
+		sp.ref_count = nullptr;
+	}
+
+	// move  constructor.
+	template <class U>
+	single_thread_ptr(single_thread_ptr<U> &&sp) noexcept : ptr {sp.ptr}, ref_count {sp.ref_count} {
+		sp.ptr = nullptr;
+		sp.ref_count = nullptr;
+	}
+
+	// No effect if single_thread_ptr is empty or use_count() > 1, otherwise release the resources.
+	~single_thread_ptr() {
+		release();
+	}
+
+	void release() {
+		if (ptr && ref_count) {
+			if (--(*ref_count) == 0) {
+				delete ptr;
+			}
+		}
+		ptr = nullptr;
+	}
+
+	// Copy assignment.
+	single_thread_ptr &operator=(single_thread_ptr sp) noexcept {
+		std::swap(this->ptr, sp.ptr);
+		std::swap(this->ref_count, sp.ref_count);
+		return *this;
+	}
+
+	// Dereference pointer to managed object.
+	T &operator*() const noexcept {
+		return *ptr;
+	}
+	T *operator->() const noexcept {
+		return ptr;
+	}
+
+	// Return the contained pointer.
+	T *get() const noexcept {
+		return ptr;
+	}
+
+	// Return use count (use count == 0 if single_thread_ptr is empty).
+	long use_count() const noexcept {
+		if (ptr)
+			return *ref_count;
+		else
+			return 0;
+	}
+
+	// Check if there is an associated managed object.
+	explicit operator bool() const noexcept {
+		return (ptr);
+	}
+
+	// Resets single_thread_ptr to empty.
+	void reset() noexcept {
+		release();
+	}
+};
+
+template <class T>
+struct _object_and_block {
+	T object;
+	uint32_t pn = 1;
+
+	template <class... Args>
+	explicit _object_and_block(Args &&...args) : object(std::forward<Args>(args)...) {
+	}
+};
+
+// Operator overloading.
+template <typename T, typename U>
+inline bool operator==(const single_thread_ptr<T> &sp1, const single_thread_ptr<U> &sp2) {
+	return sp1.get() == sp2.get();
+}
+
+template <typename T>
+inline bool operator==(const single_thread_ptr<T> &sp, std::nullptr_t) noexcept {
+	return !sp;
+}
+
+template <typename T, typename U>
+inline bool operator!=(const single_thread_ptr<T> &sp1, const single_thread_ptr<U> &sp2) {
+	return sp1.get() != sp2.get();
+}
+
+template <typename T>
+inline bool operator!=(const single_thread_ptr<T> &sp, std::nullptr_t) noexcept {
+	return sp.get();
+}
+
+template <typename T>
+inline bool operator!=(std::nullptr_t, const single_thread_ptr<T> &sp) noexcept {
+	return sp.get();
+}
+
+template <class T, class... Args>
+single_thread_ptr<T> single_thread_make_shared(Args &&...args) {
+	auto tmp_object = new _object_and_block<T>(std::forward<Args>(args)...);
+	return single_thread_ptr<T>(&tmp_object->pn, &(tmp_object->object));
+}
+} // namespace duckdb

--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/constants.hpp"
+#include "duckdb/common/single_thread_ptr.hpp"
 #include "duckdb/common/vector.hpp"
 
 namespace duckdb {
@@ -80,11 +81,11 @@ struct string_t;
 template <class T>
 using child_list_t = std::vector<std::pair<std::string, T>>;
 template <class T>
-using buffer_ptr = std::shared_ptr<T>;
+using buffer_ptr = single_thread_ptr<T>;
 
 template <class T, typename... Args>
 buffer_ptr<T> make_buffer(Args &&...args) {
-	return std::make_shared<T>(std::forward<Args>(args)...);
+	return single_thread_make_shared<T>(std::forward<Args>(args)...);
 }
 
 struct list_entry_t {

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -251,7 +251,7 @@ struct StringVector {
 	//! Adds a reference to a handle that stores strings of this vector
 	static void AddHandle(Vector &vector, unique_ptr<BufferHandle> handle);
 	//! Adds a reference to an unspecified vector buffer that stores strings of this vector
-	static void AddBuffer(Vector &vector, unique_ptr<VectorBuffer> buffer);
+	static void AddBuffer(Vector &vector, buffer_ptr<VectorBuffer> buffer);
 	//! Add a reference from this vector to the string heap of the provided vector
 	static void AddHeapReference(Vector &vector, Vector &other);
 };


### PR DESCRIPTION
This PR implements a single thread pointer, which unlike a shared_pointer, does not use atomic operations to inc/dec the reference counter. This pointer could improve performance when a shared pointer is edited by only one thread.