### PR TITLE
Allow CTEs under set operation nodes

### DIFF
--- a/src/include/duckdb/parser/common_table_expression_info.hpp
+++ b/src/include/duckdb/parser/common_table_expression_info.hpp
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/common_table_expression_info.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/parser/statement/select_statement.hpp"
+
+namespace duckdb {
+
+class SelectStatement;
+
+struct CommonTableExpressionInfo {
+	vector<string> aliases;
+	unique_ptr<SelectStatement> query;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/parser/query_node.hpp
+++ b/src/include/duckdb/parser/query_node.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/serializer.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/parser/result_modifier.hpp"
+#include "duckdb/parser/common_table_expression_info.hpp"
 
 namespace duckdb {
 
@@ -33,6 +34,8 @@ public:
 	QueryNodeType type;
 	//! The set of result modifiers associated with this query node
 	vector<unique_ptr<ResultModifier>> modifiers;
+	//! CTEs (used by SelectNode and SetOperationNode)
+	unordered_map<string, unique_ptr<CommonTableExpressionInfo>> cte_map;
 
 	virtual const vector<unique_ptr<ParsedExpression>> &GetSelectList() const = 0;
 

--- a/src/include/duckdb/parser/query_node/select_node.hpp
+++ b/src/include/duckdb/parser/query_node/select_node.hpp
@@ -13,7 +13,6 @@
 #include "duckdb/parser/sql_statement.hpp"
 #include "duckdb/parser/tableref.hpp"
 #include "duckdb/parser/parsed_data/sample_options.hpp"
-#include "duckdb/parser/statement/select_statement.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/parser/query_node/select_node.hpp
+++ b/src/include/duckdb/parser/query_node/select_node.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/parser/sql_statement.hpp"
 #include "duckdb/parser/tableref.hpp"
 #include "duckdb/parser/parsed_data/sample_options.hpp"
+#include "duckdb/parser/statement/select_statement.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/parser/statement/select_statement.hpp
+++ b/src/include/duckdb/parser/statement/select_statement.hpp
@@ -11,18 +11,12 @@
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/parser/query_node.hpp"
-#include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/sql_statement.hpp"
 #include "duckdb/parser/tableref.hpp"
 
 namespace duckdb {
 
-class SelectStatement;
-
-struct CommonTableExpressionInfo {
-	vector<string> aliases;
-	unique_ptr<SelectStatement> query;
-};
+class QueryNode;
 
 //! SelectStatement is a typical SELECT clause
 class SelectStatement : public SQLStatement {
@@ -30,8 +24,6 @@ public:
 	SelectStatement() : SQLStatement(StatementType::SELECT_STATEMENT) {
 	}
 
-	//! CTEs
-	unordered_map<string, unique_ptr<CommonTableExpressionInfo>> cte_map;
 	//! The main query node
 	unique_ptr<QueryNode> node;
 

--- a/src/include/duckdb/parser/transformer.hpp
+++ b/src/include/duckdb/parser/transformer.hpp
@@ -173,7 +173,7 @@ private:
 	// Helpers
 	//===--------------------------------------------------------------------===//
 	string TransformAlias(duckdb_libpgquery::PGAlias *root, vector<string> &column_name_alias);
-	void TransformCTE(duckdb_libpgquery::PGWithClause *de_with_clause, SelectStatement &select);
+	void TransformCTE(duckdb_libpgquery::PGWithClause *de_with_clause, QueryNode &select);
 	unique_ptr<SelectStatement> TransformRecursiveCTE(duckdb_libpgquery::PGCommonTableExpr *node,
 	                                                  CommonTableExpressionInfo &info);
 	// Operator String to ExpressionType (e.g. + => OPERATOR_ADD)

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -14,7 +14,6 @@
 #include "duckdb/parser/tokens.hpp"
 #include "duckdb/planner/expression.hpp"
 
-
 namespace duckdb {
 
 class Binder;

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -99,7 +99,6 @@ protected:
 	                             unique_ptr<ParsedExpression> *expr_ptr);
 
 	virtual void ReplaceMacroParametersRecursive(unique_ptr<ParsedExpression> &expr);
-	void ReplaceMacroParametersRecursive(ParsedExpression &expr, SelectStatement &statement);
 	virtual void ReplaceMacroParametersRecursive(ParsedExpression &expr, QueryNode &node);
 	virtual void ReplaceMacroParametersRecursive(ParsedExpression &expr, TableRef &ref);
 	virtual void CheckForSideEffects(FunctionExpression &function, idx_t depth, string &error);

--- a/src/parser/query_node.cpp
+++ b/src/parser/query_node.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/query_node/set_operation_node.hpp"
 #include "duckdb/parser/query_node/recursive_cte_node.hpp"
+#include "duckdb/common/limits.hpp"
 
 namespace duckdb {
 
@@ -24,12 +25,36 @@ bool QueryNode::Equals(const QueryNode *other) const {
 			return false;
 		}
 	}
+	// WITH clauses (CTEs)
+	if (cte_map.size() != other->cte_map.size()) {
+		return false;
+	}
+	for (auto &entry : cte_map) {
+		auto other_entry = other->cte_map.find(entry.first);
+		if (other_entry == other->cte_map.end()) {
+			return false;
+		}
+		if (entry.second->aliases != other_entry->second->aliases) {
+			return false;
+		}
+		if (!entry.second->query->Equals(other_entry->second->query.get())) {
+			return false;
+		}
+	}
 	return other->type == type;
 }
 
 void QueryNode::CopyProperties(QueryNode &other) {
 	for (auto &modifier : modifiers) {
 		other.modifiers.push_back(modifier->Copy());
+	}
+	for (auto &kv : cte_map) {
+		auto kv_info = make_unique<CommonTableExpressionInfo>();
+		for (auto al : kv.second->aliases) {
+			kv_info->aliases.push_back(al);
+		}
+		kv_info->query = unique_ptr_cast<SQLStatement, SelectStatement>(kv.second->query->Copy());
+		other.cte_map[kv.first] = move(kv_info);
 	}
 }
 
@@ -38,6 +63,14 @@ void QueryNode::Serialize(Serializer &serializer) {
 	serializer.Write<idx_t>(modifiers.size());
 	for (idx_t i = 0; i < modifiers.size(); i++) {
 		modifiers[i]->Serialize(serializer);
+	}
+	// cte_map
+	D_ASSERT(cte_map.size() <= NumericLimits<uint32_t>::Maximum());
+	serializer.Write<uint32_t>((uint32_t)cte_map.size());
+	for (auto &cte : cte_map) {
+		serializer.WriteString(cte.first);
+		serializer.WriteStringVector(cte.second->aliases);
+		cte.second->query->Serialize(serializer);
 	}
 }
 
@@ -48,6 +81,16 @@ unique_ptr<QueryNode> QueryNode::Deserialize(Deserializer &source) {
 	vector<unique_ptr<ResultModifier>> modifiers;
 	for (idx_t i = 0; i < modifier_count; i++) {
 		modifiers.push_back(ResultModifier::Deserialize(source));
+	}
+	// cte_map
+	auto cte_count = source.Read<uint32_t>();
+	unordered_map<string, unique_ptr<CommonTableExpressionInfo>> cte_map;
+	for (idx_t i = 0; i < cte_count; i++) {
+		auto name = source.Read<string>();
+		auto info = make_unique<CommonTableExpressionInfo>();
+		source.ReadStringVector(info->aliases);
+		info->query = SelectStatement::Deserialize(source);
+		cte_map[name] = move(info);
 	}
 	switch (type) {
 	case QueryNodeType::SELECT_NODE:
@@ -63,6 +106,7 @@ unique_ptr<QueryNode> QueryNode::Deserialize(Deserializer &source) {
 		throw SerializationException("Could not deserialize Query Node: unknown type!");
 	}
 	result->modifiers = move(modifiers);
+	result->cte_map = move(cte_map);
 	return result;
 }
 

--- a/src/parser/statement/select_statement.cpp
+++ b/src/parser/statement/select_statement.cpp
@@ -1,7 +1,6 @@
 #include "duckdb/parser/statement/select_statement.hpp"
 
 #include "duckdb/common/serializer.hpp"
-#include "duckdb/common/limits.hpp"
 
 namespace duckdb {
 

--- a/src/parser/statement/select_statement.cpp
+++ b/src/parser/statement/select_statement.cpp
@@ -1,6 +1,5 @@
 #include "duckdb/parser/statement/select_statement.hpp"
 
-#include "duckdb/common/assert.hpp"
 #include "duckdb/common/serializer.hpp"
 #include "duckdb/common/limits.hpp"
 
@@ -8,38 +7,16 @@ namespace duckdb {
 
 unique_ptr<SQLStatement> SelectStatement::Copy() const {
 	auto result = make_unique<SelectStatement>();
-	for (auto &cte : cte_map) {
-		auto info = make_unique<CommonTableExpressionInfo>();
-		info->aliases = cte.second->aliases;
-		info->query = unique_ptr_cast<SQLStatement, SelectStatement>(cte.second->query->Copy());
-		result->cte_map[cte.first] = move(info);
-	}
 	result->node = node->Copy();
 	return move(result);
 }
 
 void SelectStatement::Serialize(Serializer &serializer) {
-	// with clauses
-	D_ASSERT(cte_map.size() <= NumericLimits<uint32_t>::Maximum());
-	serializer.Write<uint32_t>((uint32_t)cte_map.size());
-	for (auto &cte : cte_map) {
-		serializer.WriteString(cte.first);
-		serializer.WriteStringVector(cte.second->aliases);
-		cte.second->query->Serialize(serializer);
-	}
 	node->Serialize(serializer);
 }
 
 unique_ptr<SelectStatement> SelectStatement::Deserialize(Deserializer &source) {
 	auto result = make_unique<SelectStatement>();
-	auto cte_count = source.Read<uint32_t>();
-	for (idx_t i = 0; i < cte_count; i++) {
-		auto name = source.Read<string>();
-		auto info = make_unique<CommonTableExpressionInfo>();
-		source.ReadStringVector(info->aliases);
-		info->query = SelectStatement::Deserialize(source);
-		result->cte_map[name] = move(info);
-	}
 	result->node = QueryNode::Deserialize(source);
 	return result;
 }
@@ -49,22 +26,6 @@ bool SelectStatement::Equals(const SQLStatement *other_) const {
 		return false;
 	}
 	auto other = (SelectStatement *)other_;
-	// WITH clauses (CTEs)
-	if (cte_map.size() != other->cte_map.size()) {
-		return false;
-	}
-	for (auto &entry : cte_map) {
-		auto other_entry = other->cte_map.find(entry.first);
-		if (other_entry == other->cte_map.end()) {
-			return false;
-		}
-		if (entry.second->aliases != other_entry->second->aliases) {
-			return false;
-		}
-		if (!entry.second->query->Equals(other_entry->second->query.get())) {
-			return false;
-		}
-	}
 	return node->Equals(other->node.get());
 }
 

--- a/src/parser/transform/helpers/transform_cte.cpp
+++ b/src/parser/transform/helpers/transform_cte.cpp
@@ -8,7 +8,7 @@ namespace duckdb {
 
 using namespace duckdb_libpgquery;
 
-void Transformer::TransformCTE(PGWithClause *de_with_clause, SelectStatement &select) {
+void Transformer::TransformCTE(PGWithClause *de_with_clause, QueryNode &select) {
 	// TODO: might need to update in case of future lawsuit
 	D_ASSERT(de_with_clause);
 

--- a/src/parser/transform/statement/transform_select.cpp
+++ b/src/parser/transform/statement/transform_select.cpp
@@ -20,11 +20,6 @@ unique_ptr<SelectStatement> Transformer::TransformSelect(PGNode *node, bool isSe
 		}
 	}
 
-	// may contain windows so second
-	if (stmt->withClause) {
-		TransformCTE(reinterpret_cast<PGWithClause *>(stmt->withClause), *result);
-	}
-
 	result->node = TransformSelectNode(stmt);
 	return result;
 }

--- a/src/parser/transform/statement/transform_select_node.cpp
+++ b/src/parser/transform/statement/transform_select_node.cpp
@@ -17,7 +17,9 @@ unique_ptr<QueryNode> Transformer::TransformSelectNode(PGSelectStmt *stmt) {
 	case PG_SETOP_NONE: {
 		node = make_unique<SelectNode>();
 		auto result = (SelectNode *)node.get();
-
+		if (stmt->withClause) {
+			TransformCTE(reinterpret_cast<PGWithClause *>(stmt->withClause), *node);
+		}
 		if (stmt->windowClause) {
 			for (auto window_ele = stmt->windowClause->head; window_ele != NULL; window_ele = window_ele->next) {
 				auto window_def = reinterpret_cast<PGWindowDef *>(window_ele->data.ptr_value);
@@ -79,6 +81,9 @@ unique_ptr<QueryNode> Transformer::TransformSelectNode(PGSelectStmt *stmt) {
 	case PG_SETOP_INTERSECT: {
 		node = make_unique<SetOperationNode>();
 		auto result = (SetOperationNode *)node.get();
+		if (stmt->withClause) {
+			TransformCTE(reinterpret_cast<PGWithClause *>(stmt->withClause), *node);
+		}
 		result->left = TransformSelectNode(stmt->larg);
 		result->right = TransformSelectNode(stmt->rarg);
 		if (!result->left || !result->right) {

--- a/src/planner/binder/expression/bind_subquery_expression.cpp
+++ b/src/planner/binder/expression/bind_subquery_expression.cpp
@@ -32,9 +32,6 @@ BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t dept
 		D_ASSERT(depth == 0);
 		// first bind the actual subquery in a new binder
 		auto subquery_binder = make_unique<Binder>(context, &binder);
-		for (auto &cte_it : expr.subquery->cte_map) {
-			subquery_binder->AddCTE(cte_it.first, cte_it.second.get());
-		}
 		auto bound_node = subquery_binder->BindNode(*expr.subquery->node);
 		// check the correlated columns of the subquery for correlated columns with depth > 1
 		for (idx_t i = 0; i < subquery_binder->correlated_columns.size(); i++) {

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -11,8 +11,8 @@
 
 #include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
-#include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/tableref/basetableref.hpp"
+#include "duckdb/parser/query_node/select_node.hpp"
 
 #include <algorithm>
 

--- a/src/planner/binder/statement/bind_select.cpp
+++ b/src/planner/binder/statement/bind_select.cpp
@@ -6,11 +6,6 @@ namespace duckdb {
 
 BoundStatement Binder::Bind(SelectStatement &stmt) {
 	this->allow_stream_result = true;
-	// first we visit the set of CTEs and add them to the bind context
-	for (auto &cte_it : stmt.cte_map) {
-		AddCTE(cte_it.first, cte_it.second.get());
-	}
-	// now visit the root node of the select statement
 	return Bind(*stmt.node);
 }
 

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
 #include "duckdb/parser/tableref/basetableref.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
+#include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/tableref/bound_basetableref.hpp"
 #include "duckdb/planner/tableref/bound_subqueryref.hpp"
@@ -21,7 +22,8 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		auto ctebinding = bind_context.GetCTEBinding(ref.table_name);
 		if (!ctebinding) {
 			if (CTEIsAlreadyBound(cte)) {
-				throw BinderException("Circular reference to CTE \"%s\", use WITH RECURSIVE to use recursive CTEs", ref.table_name);
+				throw BinderException("Circular reference to CTE \"%s\", use WITH RECURSIVE to use recursive CTEs",
+				                      ref.table_name);
 			}
 			// Move CTE to subquery and bind recursively
 			SubqueryRef subquery(unique_ptr_cast<SQLStatement, SelectStatement>(cte->query->Copy()));

--- a/src/planner/binder/tableref/bind_subqueryref.cpp
+++ b/src/planner/binder/tableref/bind_subqueryref.cpp
@@ -10,9 +10,6 @@ unique_ptr<BoundTableRef> Binder::Bind(SubqueryRef &ref, CommonTableExpressionIn
 		binder->bound_ctes.insert(cte);
 	}
 	binder->alias = ref.alias;
-	for (auto &cte_it : ref.subquery->cte_map) {
-		binder->AddCTE(cte_it.first, cte_it.second.get());
-	}
 	auto subquery = binder->BindNode(*ref.subquery->node);
 	idx_t bind_index = subquery->GetRootIndex();
 	auto result = make_unique<BoundSubqueryRef>(move(binder), move(subquery));

--- a/src/storage/storage_info.cpp
+++ b/src/storage/storage_info.cpp
@@ -2,6 +2,6 @@
 
 namespace duckdb {
 
-const uint64_t VERSION_NUMBER = 10;
+const uint64_t VERSION_NUMBER = 11;
 
 } // namespace duckdb

--- a/test/ldbc/ldbc-empty.test
+++ b/test/ldbc/ldbc-empty.test
@@ -2,57 +2,6 @@
 # description: Run the LDBC benchmark without data
 # group: [ldbc]
 
-# TODO: remove temp tests
-#query I
-#WITH cte1 AS (
-#	WITH cte2 AS (SELECT 1 AS a)
-#	SELECT a FROM cte2
-#)
-#SELECT a FROM cte1;
-#----
-#1
-#
-#query I
-#SELECT 1
-#----
-#2
-
-query I
-select 1 union all (with cte as (select 42) select * from cte);
-----
-1
-42
-
-# with 'c' alias - not working
-query I
-WITH RECURSIVE cte(d) AS (
-		SELECT 1
-	UNION ALL
-		(WITH c(d) AS (SELECT * FROM cte)
-			SELECT d + 1
-			FROM c
-			WHERE FALSE
-		)
-)
-SELECT max(d) FROM cte;
-----
-1
-
-# without 'c' alias - working
-query I
-WITH RECURSIVE cte(d) AS (
-		SELECT 1
-	UNION ALL
-		(WITH cte(d) AS (SELECT * FROM cte)
-			SELECT d + 1
-			FROM cte
-			WHERE FALSE
-		)
-)
-SELECT max(d) FROM cte;
-----
-1
-
 # create the schema
 
 statement ok

--- a/test/ldbc/ldbc-empty.test
+++ b/test/ldbc/ldbc-empty.test
@@ -2,6 +2,57 @@
 # description: Run the LDBC benchmark without data
 # group: [ldbc]
 
+# TODO: remove temp tests
+#query I
+#WITH cte1 AS (
+#	WITH cte2 AS (SELECT 1 AS a)
+#	SELECT a FROM cte2
+#)
+#SELECT a FROM cte1;
+#----
+#1
+#
+#query I
+#SELECT 1
+#----
+#2
+
+query I
+select 1 union all (with cte as (select 42) select * from cte);
+----
+1
+42
+
+# with 'c' alias - not working
+query I
+WITH RECURSIVE cte(d) AS (
+		SELECT 1
+	UNION ALL
+		(WITH c(d) AS (SELECT * FROM cte)
+			SELECT d + 1
+			FROM c
+			WHERE FALSE
+		)
+)
+SELECT max(d) FROM cte;
+----
+1
+
+# without 'c' alias - working
+query I
+WITH RECURSIVE cte(d) AS (
+		SELECT 1
+	UNION ALL
+		(WITH cte(d) AS (SELECT * FROM cte)
+			SELECT d + 1
+			FROM cte
+			WHERE FALSE
+		)
+)
+SELECT max(d) FROM cte;
+----
+1
+
 # create the schema
 
 statement ok

--- a/test/sql/cte/test_cte.test
+++ b/test/sql/cte/test_cte.test
@@ -95,3 +95,25 @@ select * from vb
 ----
 43
 
+# cte in set operation node
+query I
+SELECT 1 UNION ALL (WITH cte AS (SELECT 42) SELECT * FROM cte);
+----
+1
+42
+
+# cte in recursive cte
+query I
+WITH RECURSIVE cte(d) AS (
+		SELECT 1
+	UNION ALL
+		(WITH c(d) AS (SELECT * FROM cte)
+			SELECT d + 1
+			FROM c
+			WHERE FALSE
+		)
+)
+SELECT max(d) FROM cte;
+----
+1
+


### PR DESCRIPTION
This PR moves the `SelectStatement::cte_map` to `QueryNode::cte_map`, so that queries like the following work:
```
SELECT 1 UNION ALL (WITH cte AS (SELECT 42) SELECT * FROM cte);
```
Before, an error would be thrown because the binder was not able to find `cte`.

This was found due to #1088 , which should now also be fixed.

Happy to receive any feedback.