### PR TITLE
Add 'regexp_split_to_array' alias to 'string_split_regex'

### DIFF
--- a/src/function/scalar/string/string_split.cpp
+++ b/src/function/scalar/string/string_split.cpp
@@ -274,7 +274,7 @@ void StringSplitFun::RegisterFunction(BuiltinFunctions &set) {
 	    {"string_split", "str_split", "string_to_array"},
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, varchar_list_type, string_split_function));
 	set.AddFunction(
-	    {"string_split_regex", "str_split_regex"},
+	    {"string_split_regex", "str_split_regex", "regexp_split_to_array"},
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, varchar_list_type, string_split_regex_function));
 }
 


### PR DESCRIPTION
Followup of #1006.

This commit adds the Postgres-compatible [`regexp_split_to_array`](https://www.postgresql.org/docs/12/functions-matching.html) alias to `string_split_regex`.

cc @lnkuiper 