### PR TITLE
More meaningful error message on R database startup

### DIFF
--- a/tools/rpkg/src/duckdbr.cpp
+++ b/tools/rpkg/src/duckdbr.cpp
@@ -861,7 +861,7 @@ struct DataFrameScanFunction : public TableFunction {
 
 	static unique_ptr<FunctionOperatorData> dataframe_scan_init(ClientContext &context, const FunctionData *bind_data,
 	                                                            vector<column_t> &column_ids,
-	                                                            TableFilterCollection* filters) {
+	                                                            TableFilterCollection *filters) {
 		return make_unique<DataFrameScanState>();
 	}
 
@@ -976,8 +976,8 @@ SEXP duckdb_startup_R(SEXP dbdirsexp, SEXP readonlysexp) {
 	DuckDB *dbaddr;
 	try {
 		dbaddr = new DuckDB(dbdir, &config);
-	} catch (...) {
-		Rf_error("duckdb_startup_R: Failed to open database");
+	} catch (exception &e) {
+		Rf_error("duckdb_startup_R: Failed to open database: %s", e.what());
 	}
 	ExtensionHelper::LoadAllExtensions(*dbaddr);
 


### PR DESCRIPTION
For example:
````R
library(DBI)
con <- dbConnect(duckdb::duckdb(), "/dev/null")
````
now includes a reason for the failure
````
Error in initialize(value, ...) : 
  duckdb_startup_R: Failed to open database: IO Error: Could not read sufficient bytes from file "/dev/null"
````