### PR TITLE
JDBC getColumns does not get all available data types

### DIFF
--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java
@@ -706,9 +706,10 @@ public class DuckDBDatabaseMetaData implements DatabaseMetaData {
 		// types :/
 		ResultSet rs = gunky_statement
 				.executeQuery("SELECT DISTINCT data_type FROM information_schema_columns() ORDER BY data_type");
-		rs.next();
-		values_str += ", ('" + rs.getString(1) + "', "
-				+ Integer.toString(DuckDBResultSetMetaData.type_to_int(rs.getString(1))) + ")";
+		while (rs.next()) {
+			values_str += ", ('" + rs.getString(1) + "', "
+					+ Integer.toString(DuckDBResultSetMetaData.type_to_int(rs.getString(1))) + ")";
+		}
 		rs.close();
 		gunky_statement.close();
 

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -917,7 +917,7 @@ public class TestDuckDBJDBC {
 		assertFalse(rs.next());
 		rs.close();
 
-		rs = md.getColumns(null, null, null, null);
+		rs = md.getColumns(null, null, "a", null);
 		assertTrue(rs.next());
 		assertNull(rs.getObject("TABLE_CAT"));
 		assertNull(rs.getObject(1));


### PR DESCRIPTION
When calling getMetaData().getColumns to get the columns of a table from the information schema, only the first column gets returned.

Example snippet
```
Connection con;
Class loaded = Class.forName("org.duckdb.DuckDBDriver");
Properties config = new Properties();
config.setProperty("duckdb.read_only", "true");
con = DriverManager.getConnection("jdbc:duckdb:C:\\Temp\\duckdb_test", config);
ResultSet rs = con.getMetaData().getColumns(null, null, "weather", null);
```

It turns out that the issue is due to the fact that to optimize the retrieval, the information schema is first queried with all the possible column types, but that Resultset is not cycled through: only the first record is used.

Adding a while cycle fixes the problem.


