### PR TITLE
Making Fetchone return None when empty

### DIFF
--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -1610,7 +1610,7 @@ struct DuckDBPyConnection {
 	}
 
 	// these should be functions on the result but well
-	py::tuple fetchone() {
+	py::object fetchone() {
 		if (!result) {
 			throw runtime_error("no open result set");
 		}

--- a/tools/pythonpkg/tests/test_null.py
+++ b/tools/pythonpkg/tests/test_null.py
@@ -1,0 +1,13 @@
+import traceback
+
+class TestNull(object):
+
+    def test_fetchone_null(self, duckdb_cursor):
+        duckdb_cursor.execute("CREATE TABLE atable (Value int)")
+        duckdb_cursor.execute("INSERT INTO atable VALUES (1)")
+        duckdb_cursor.execute("SELECT * FROM atable")
+        assert(duckdb_cursor.fetchone()[0] == 1)
+        assert(duckdb_cursor.fetchone() is None)
+        
+        
+       


### PR DESCRIPTION
Task: #1397

This PR ensures fetchone returns a python object instead of a tuple 