### PR TITLE
Inline winapi.hpp in duckdb.h

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -10,7 +10,15 @@
 
 #pragma once
 
-#include "duckdb/common/winapi.hpp"
+#ifdef _WIN32
+#ifdef DUCKDB_BUILD_LIBRARY
+#define DUCKDB_API __declspec(dllexport)
+#else
+#define DUCKDB_API __declspec(dllimport)
+#endif
+#else
+#define DUCKDB_API
+#endif
 
 #include <stdbool.h>
 #include <stdint.h>


### PR DESCRIPTION
For the C API to be usable from the downloads, it cannot contain references to other header files, so we inline winapi.hpp here.