### PR TITLE
Add blob support to C API

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -49,7 +49,9 @@ typedef enum DUCKDB_TYPE {
 	// duckdb_hugeint
 	DUCKDB_TYPE_HUGEINT,
 	// const char*
-	DUCKDB_TYPE_VARCHAR
+	DUCKDB_TYPE_VARCHAR,
+	// duckdb_blob
+	DUCKDB_TYPE_BLOB
 } duckdb_type;
 
 typedef struct {
@@ -80,6 +82,11 @@ typedef struct {
 	uint64_t lower;
 	int64_t upper;
 } duckdb_hugeint;
+
+typedef struct {
+	void *data;
+	idx_t size;
+} duckdb_blob;
 
 typedef struct {
 	void *data;
@@ -152,6 +159,8 @@ DUCKDB_API float duckdb_value_float(duckdb_result *result, idx_t col, idx_t row)
 DUCKDB_API double duckdb_value_double(duckdb_result *result, idx_t col, idx_t row);
 //! Converts the specified value to a string. Returns nullptr on failure or NULL. The result must be freed with free.
 DUCKDB_API char *duckdb_value_varchar(duckdb_result *result, idx_t col, idx_t row);
+//! Fetches a blob from a result set column. Returns a blob with blob.data set to nullptr on failure or NULL. The resulting "blob.data" must be freed with free.
+DUCKDB_API duckdb_blob duckdb_value_blob(duckdb_result *result, idx_t col, idx_t row);
 
 // Prepared Statements
 

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -178,8 +178,9 @@ DUCKDB_API duckdb_state duckdb_bind_int32(duckdb_prepared_statement prepared_sta
 DUCKDB_API duckdb_state duckdb_bind_int64(duckdb_prepared_statement prepared_statement, idx_t param_idx, int64_t val);
 DUCKDB_API duckdb_state duckdb_bind_float(duckdb_prepared_statement prepared_statement, idx_t param_idx, float val);
 DUCKDB_API duckdb_state duckdb_bind_double(duckdb_prepared_statement prepared_statement, idx_t param_idx, double val);
-DUCKDB_API duckdb_state duckdb_bind_varchar(duckdb_prepared_statement prepared_statement, idx_t param_idx,
-                                            const char *val);
+DUCKDB_API duckdb_state duckdb_bind_varchar(duckdb_prepared_statement prepared_statement, idx_t param_idx, const char *val);
+DUCKDB_API duckdb_state duckdb_bind_varchar_length(duckdb_prepared_statement prepared_statement, idx_t param_idx, const char *val, idx_t length);
+DUCKDB_API duckdb_state duckdb_bind_blob(duckdb_prepared_statement prepared_statement, idx_t param_idx, const void *data, idx_t length);
 DUCKDB_API duckdb_state duckdb_bind_null(duckdb_prepared_statement prepared_statement, idx_t param_idx);
 
 //! Executes the prepared statements with currently bound parameters

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -159,7 +159,8 @@ DUCKDB_API float duckdb_value_float(duckdb_result *result, idx_t col, idx_t row)
 DUCKDB_API double duckdb_value_double(duckdb_result *result, idx_t col, idx_t row);
 //! Converts the specified value to a string. Returns nullptr on failure or NULL. The result must be freed with free.
 DUCKDB_API char *duckdb_value_varchar(duckdb_result *result, idx_t col, idx_t row);
-//! Fetches a blob from a result set column. Returns a blob with blob.data set to nullptr on failure or NULL. The resulting "blob.data" must be freed with free.
+//! Fetches a blob from a result set column. Returns a blob with blob.data set to nullptr on failure or NULL. The
+//! resulting "blob.data" must be freed with free.
 DUCKDB_API duckdb_blob duckdb_value_blob(duckdb_result *result, idx_t col, idx_t row);
 
 // Prepared Statements
@@ -178,9 +179,12 @@ DUCKDB_API duckdb_state duckdb_bind_int32(duckdb_prepared_statement prepared_sta
 DUCKDB_API duckdb_state duckdb_bind_int64(duckdb_prepared_statement prepared_statement, idx_t param_idx, int64_t val);
 DUCKDB_API duckdb_state duckdb_bind_float(duckdb_prepared_statement prepared_statement, idx_t param_idx, float val);
 DUCKDB_API duckdb_state duckdb_bind_double(duckdb_prepared_statement prepared_statement, idx_t param_idx, double val);
-DUCKDB_API duckdb_state duckdb_bind_varchar(duckdb_prepared_statement prepared_statement, idx_t param_idx, const char *val);
-DUCKDB_API duckdb_state duckdb_bind_varchar_length(duckdb_prepared_statement prepared_statement, idx_t param_idx, const char *val, idx_t length);
-DUCKDB_API duckdb_state duckdb_bind_blob(duckdb_prepared_statement prepared_statement, idx_t param_idx, const void *data, idx_t length);
+DUCKDB_API duckdb_state duckdb_bind_varchar(duckdb_prepared_statement prepared_statement, idx_t param_idx,
+                                            const char *val);
+DUCKDB_API duckdb_state duckdb_bind_varchar_length(duckdb_prepared_statement prepared_statement, idx_t param_idx,
+                                                   const char *val, idx_t length);
+DUCKDB_API duckdb_state duckdb_bind_blob(duckdb_prepared_statement prepared_statement, idx_t param_idx,
+                                         const void *data, idx_t length);
 DUCKDB_API duckdb_state duckdb_bind_null(duckdb_prepared_statement prepared_statement, idx_t param_idx);
 
 //! Executes the prepared statements with currently bound parameters

--- a/src/main/duckdb-c.cpp
+++ b/src/main/duckdb-c.cpp
@@ -317,7 +317,7 @@ static void duckdb_destroy_column(duckdb_column column, idx_t count) {
 			auto data = (duckdb_blob *)column.data;
 			for (idx_t i = 0; i < count; i++) {
 				if (data[i].data) {
-					free( (void *) data[i].data);
+					free((void *)data[i].data);
 				}
 			}
 		}
@@ -421,12 +421,14 @@ duckdb_state duckdb_bind_varchar(duckdb_prepared_statement prepared_statement, i
 	return duckdb_bind_value(prepared_statement, param_idx, Value(val));
 }
 
-duckdb_state duckdb_bind_varchar_length(duckdb_prepared_statement prepared_statement, idx_t param_idx, const char *val, idx_t length) {
+duckdb_state duckdb_bind_varchar_length(duckdb_prepared_statement prepared_statement, idx_t param_idx, const char *val,
+                                        idx_t length) {
 	return duckdb_bind_value(prepared_statement, param_idx, Value(string(val, length)));
 }
 
-duckdb_state duckdb_bind_blob(duckdb_prepared_statement prepared_statement, idx_t param_idx, const void *data, idx_t length) {
-	return duckdb_bind_value(prepared_statement, param_idx, Value::BLOB((const_data_ptr_t) data, length));
+duckdb_state duckdb_bind_blob(duckdb_prepared_statement prepared_statement, idx_t param_idx, const void *data,
+                              idx_t length) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value::BLOB((const_data_ptr_t)data, length));
 }
 
 duckdb_state duckdb_bind_null(duckdb_prepared_statement prepared_statement, idx_t param_idx) {
@@ -590,7 +592,7 @@ static Value GetCValue(duckdb_result *result, idx_t col, idx_t row) {
 		return Value(string(UnsafeFetch<const char *>(result, col, row)));
 	case DUCKDB_TYPE_BLOB: {
 		auto blob = UnsafeFetch<duckdb_blob>(result, col, row);
-		return Value::BLOB((const_data_ptr_t) blob.data, blob.size);
+		return Value::BLOB((const_data_ptr_t)blob.data, blob.size);
 	}
 	default:
 		// invalid type for C to C++ conversion
@@ -682,7 +684,7 @@ duckdb_blob duckdb_value_blob(duckdb_result *result, idx_t col, idx_t row) {
 		blob.size = 0;
 	} else {
 		blob.data = malloc(val.str_value.size());
-		memcpy((void *) blob.data, val.str_value.c_str(), val.str_value.size());
+		memcpy((void *)blob.data, val.str_value.c_str(), val.str_value.size());
 		blob.size = val.str_value.size();
 	}
 	return blob;

--- a/src/main/duckdb-c.cpp
+++ b/src/main/duckdb-c.cpp
@@ -421,6 +421,14 @@ duckdb_state duckdb_bind_varchar(duckdb_prepared_statement prepared_statement, i
 	return duckdb_bind_value(prepared_statement, param_idx, Value(val));
 }
 
+duckdb_state duckdb_bind_varchar_length(duckdb_prepared_statement prepared_statement, idx_t param_idx, const char *val, idx_t length) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value(string(val, length)));
+}
+
+duckdb_state duckdb_bind_blob(duckdb_prepared_statement prepared_statement, idx_t param_idx, const void *data, idx_t length) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value::BLOB((const_data_ptr_t) data, length));
+}
+
 duckdb_state duckdb_bind_null(duckdb_prepared_statement prepared_statement, idx_t param_idx) {
 	return duckdb_bind_value(prepared_statement, param_idx, Value());
 }

--- a/test/api/capi/test_capi.cpp
+++ b/test/api/capi/test_capi.cpp
@@ -457,6 +457,29 @@ TEST_CASE("Test prepared statements in C API", "[capi][.]") {
 	duckdb_destroy_result(&res);
 	duckdb_destroy_prepare(&stmt);
 
+
+	status = duckdb_prepare(tester.connection, "SELECT CAST($1 AS VARCHAR)", &stmt);
+	REQUIRE(status == DuckDBSuccess);
+	REQUIRE(stmt != nullptr);
+
+	duckdb_bind_varchar_length(stmt, 1, "hello world", 5);
+	status = duckdb_execute_prepared(stmt, &res);
+	REQUIRE(status == DuckDBSuccess);
+	auto value = duckdb_value_varchar(&res, 0, 0);
+	REQUIRE(string(value) == "hello");
+	free(value);
+	duckdb_destroy_result(&res);
+
+	duckdb_bind_blob(stmt, 1, "hello\0world", 11);
+	status = duckdb_execute_prepared(stmt, &res);
+	REQUIRE(status == DuckDBSuccess);
+	value = duckdb_value_varchar(&res, 0, 0);
+	REQUIRE(string(value) == "hello\\x00world");
+	free(value);
+	duckdb_destroy_result(&res);
+
+	duckdb_destroy_prepare(&stmt);
+
 	status = duckdb_query(tester.connection, "CREATE TABLE a (i INTEGER)", NULL);
 	REQUIRE(status == DuckDBSuccess);
 

--- a/test/api/capi/test_capi.cpp
+++ b/test/api/capi/test_capi.cpp
@@ -100,6 +100,12 @@ duckdb_timestamp CAPIResult::Fetch(idx_t col, idx_t row) {
 }
 
 template <>
+duckdb_blob CAPIResult::Fetch(idx_t col, idx_t row) {
+	auto data = (duckdb_blob *)result.columns[col].data;
+	return data[row];
+}
+
+template <>
 string CAPIResult::Fetch(idx_t col, idx_t row) {
 	auto value = duckdb_value_varchar(&result, col, row);
 	string strval = string(value);
@@ -176,6 +182,28 @@ TEST_CASE("Basic test of C API", "[capi]") {
 	REQUIRE(result->ColumnCount() == 1);
 	REQUIRE(result->row_count() == 1);
 	REQUIRE(result->Fetch<string>(0, 0) == "hello");
+	REQUIRE(!result->IsNull(0, 0));
+
+	result = tester.Query("SELECT 1=1");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->ColumnCount() == 1);
+	REQUIRE(result->row_count() == 1);
+	REQUIRE(result->Fetch<bool>(0, 0) == true);
+	REQUIRE(!result->IsNull(0, 0));
+
+	result = tester.Query("SELECT 1=0");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->ColumnCount() == 1);
+	REQUIRE(result->row_count() == 1);
+	REQUIRE(result->Fetch<bool>(0, 0) == false);
+	REQUIRE(!result->IsNull(0, 0));
+
+	result = tester.Query("SELECT i FROM (values (true), (false)) tbl(i) group by i order by i");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->ColumnCount() == 1);
+	REQUIRE(result->row_count() == 2);
+	REQUIRE(result->Fetch<bool>(0, 0) == false);
+	REQUIRE(result->Fetch<bool>(0, 1) == true);
 	REQUIRE(!result->IsNull(0, 0));
 
 	// multiple insertions
@@ -299,6 +327,22 @@ TEST_CASE("Test different types of C API", "[capi]") {
 	REQUIRE(stamp.time.sec == 30);
 	REQUIRE(stamp.time.micros == 0);
 	REQUIRE(result->Fetch<string>(0, 1) == Value::TIMESTAMP(1992, 9, 20, 12, 1, 30, 0).ToString());
+
+	// blob columns
+	REQUIRE_NO_FAIL(tester.Query("CREATE TABLE blobs(b BLOB)"));
+	REQUIRE_NO_FAIL(tester.Query("INSERT INTO blobs VALUES ('hello\\x12world'), ('\\x00'), (NULL)"));
+
+	result = tester.Query("SELECT * FROM blobs");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(!result->IsNull(0, 0));
+	duckdb_blob blob = result->Fetch<duckdb_blob>(0, 0);
+	REQUIRE(blob.size == 11);
+	REQUIRE(memcmp(blob.data, "hello\012world", 11));
+	REQUIRE(result->Fetch<string>(0, 1) == "\\x00");
+	REQUIRE(result->IsNull(0, 2));
+	blob = result->Fetch<duckdb_blob>(0, 2);
+	REQUIRE(blob.data == nullptr);
+	REQUIRE(blob.size == 0);
 
 	// boolean columns
 	REQUIRE_NO_FAIL(tester.Query("CREATE TABLE booleans(b BOOLEAN)"));

--- a/test/api/capi/test_capi.cpp
+++ b/test/api/capi/test_capi.cpp
@@ -457,7 +457,6 @@ TEST_CASE("Test prepared statements in C API", "[capi][.]") {
 	duckdb_destroy_result(&res);
 	duckdb_destroy_prepare(&stmt);
 
-
 	status = duckdb_prepare(tester.connection, "SELECT CAST($1 AS VARCHAR)", &stmt);
 	REQUIRE(status == DuckDBSuccess);
 	REQUIRE(stmt != nullptr);


### PR DESCRIPTION
This implements the missing C API functions proposed in #1407, specifically the following functions are implemented, and in general the blob type is added:

```c++

typedef struct {
	void *data;
	idx_t size;
} duckdb_blob;

duckdb_blob duckdb_value_blob(duckdb_result *result, idx_t col, idx_t row);
duckdb_state duckdb_bind_varchar_length(duckdb_prepared_statement prepared_statement, idx_t param_idx, const char *val, idx_t length);
duckdb_state duckdb_bind_blob(duckdb_prepared_statement prepared_statement, idx_t param_idx, const void *data, idx_t length);

```