### PR TITLE
WASM hello world test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -979,3 +979,27 @@ jobs:
 
     - name: Node 15
       run: ./scripts/node_build.sh 15
+
+  linux-wasm:
+    name: WASM
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Build Amalgamation
+      run: python scripts/amalgamation.py
+
+    - name: Setup
+      run: ./scripts/wasm_configure.sh
+
+    - name: Build Library Module
+      run: ./scripts/wasm_build_lib.sh
+
+    - name: Build Test Module
+      run: ./scripts/wasm_build_test.sh
+
+    - name: Test WASM Module
+      run: node ./test/wasm/hello_wasm_test.js

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -983,6 +983,7 @@ jobs:
   linux-wasm:
     name: WASM
     runs-on: ubuntu-20.04
+    needs: linux-debug
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ cscope.out
 autoconf/aclocal.m4
 autoconf/autom4te.cache
 /compile_commands.json
+/.wasm
 
 #==============================================================================#
 # Directories to ignore (do not add trailing '/'s, they skip symlinks).
@@ -169,6 +170,9 @@ local.properties
 .settings/
 .loadpath
 .recommenders
+
+# Clang language server (C/C++ tooling)
+/.cache/clangd
 
 # Eclipse Core
 .project

--- a/scripts/wasm_build_lib.sh
+++ b/scripts/wasm_build_lib.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "$BASH_SOURCE[0]")/wasm_env.sh"
+
+DUCKDB_CC="${PROJECT_ROOT}/src/amalgamation/duckdb.cpp"
+DUCKDB_H="${PROJECT_ROOT}/src/amalgamation/duckdb.hpp"
+
+test -f "${DUCKDB_CC}" \
+    && { echo "[ OK  ] Amalgamation Source: ${DUCKDB_CC}"; } \
+    || { echo "[ ERR ] Amalgamation Source: ${DUCKDB_CC}"; exit 1; }
+
+test -f "${DUCKDB_H}" \
+    && { echo "[ OK  ] Amalgamation Header: ${DUCKDB_H}"; } \
+    || { echo "[ ERR ] Amalgamation Header: ${DUCKDB_H}"; exit 1; }
+
+set -x
+BUILD_DIR="${PROJECT_ROOT}/.wasm/build"
+if [ -d ${BUILD_DIR} ]; then
+    rm -r "${BUILD_DIR}"
+fi
+mkdir -p ${BUILD_DIR}
+
+source "${EMSDK_ENV}"
+
+${EMCPP} \
+    -std=gnu++17 \
+    -O2 -g \
+    -fexceptions \
+    -sDISABLE_EXCEPTION_CATCHING=0 \
+    -sUSE_PTHREADS=0 \
+    -DNDEBUG \
+    -DDUCKDB_NO_THREADS=1 \
+    -I ${PROJECT_ROOT}/src/include \
+    -I ${PROJECT_ROOT}/third_party/concurrentqueue/ \
+    -o ${DUCKDB_WASM} \
+    -c ${DUCKDB_CC}

--- a/scripts/wasm_build_lib.sh
+++ b/scripts/wasm_build_lib.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-source "$(dirname "$BASH_SOURCE[0]")/wasm_env.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/wasm_env.sh"
 
 DUCKDB_CC="${PROJECT_ROOT}/src/amalgamation/duckdb.cpp"
 DUCKDB_H="${PROJECT_ROOT}/src/amalgamation/duckdb.hpp"

--- a/scripts/wasm_build_test.sh
+++ b/scripts/wasm_build_test.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-source "$(dirname "$BASH_SOURCE[0]")/wasm_env.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/wasm_env.sh"
 
 HELLO_WASM_CPP="${PROJECT_ROOT}/test/wasm/hello_wasm.cpp"
 

--- a/scripts/wasm_build_test.sh
+++ b/scripts/wasm_build_test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "$BASH_SOURCE[0]")/wasm_env.sh"
+
+HELLO_WASM_CPP="${PROJECT_ROOT}/test/wasm/hello_wasm.cpp"
+
+test -f "${DUCKDB_WASM}" \
+    && { echo "[ OK  ] DuckDB WASM: ${DUCKDB_WASM}"; } \
+    || { echo "[ ERR ] DuckDB WASM: ${DUCKDB_WASM}"; exit 1; }
+
+set -x
+
+source "${EMSDK_ENV}"
+
+${EMCC} \
+    -std=gnu++17 \
+    -O2 -g \
+    -fexceptions \
+    -D NDEBUG \
+    -D DUCKDB_NO_THREADS=1 \
+    -s WASM=1 \
+    -s LLD_REPORT_UNDEFINED=1 \
+    -s WARN_ON_UNDEFINED_SYMBOLS=1 \
+    -s ALLOW_MEMORY_GROWTH=1 \
+    -s USE_PTHREADS=0 \
+    -s DISABLE_EXCEPTION_CATCHING=0 \
+    -s MODULARIZE=1 \
+    -s EXPORT_NAME='DuckDB' \
+    -s EXPORTED_FUNCTIONS='[ _main, _HelloWasm ]' \
+    -I ${PROJECT_ROOT}/src/include \
+    -I ${PROJECT_ROOT}/third_party/concurrentqueue/ \
+    ${DUCKDB_WASM} \
+    ${HELLO_WASM_CPP} \
+    -o ${BUILD_DIR}/hello_wasm.js

--- a/scripts/wasm_configure.sh
+++ b/scripts/wasm_configure.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "$BASH_SOURCE[0]")/wasm_env.sh"
+
+curl --version \
+    && { echo "[ OK  ] Command: curl"; } \
+    || { echo "[ ERR ] Command: curl"; exit 1; }
+
+tar --version \
+    && { echo "[ OK  ] Command: tar"; } \
+    || { echo "[ ERR ] Command: tar"; exit 1; }
+
+# Get the release archive
+mkdir -p ${WASM_WD}
+if [ ! -f "${EMSDK_RELEASE_TARBALL}" ]; then
+    echo "[ RUN ] Download: ${EMSDK_RELEASE_URL}"
+    curl -Lo "${EMSDK_RELEASE_TARBALL}" "${EMSDK_RELEASE_URL}"
+fi
+echo "[ OK  ] Release Archive: ${EMSDK_RELEASE_TARBALL}"
+
+# Unpack the release archive
+if [ ! -f "${EMSDK_TOOL}" ]; then
+    set -x
+    mkdir -p "${EMSDK_REPO_DIR}"
+    tar -xvzf "${EMSDK_RELEASE_TARBALL}" -C "${EMSDK_REPO_DIR}" --strip-components=1
+    set +x
+fi
+echo "[ OK  ] Unpacked Release: ${EMSDK_REPO_DIR}"
+
+# Install & activate the emscripten version
+set +x
+${EMSDK_TOOL} install ${EMSCRIPTEN_VERSION}
+${EMSDK_TOOL} activate ${EMSCRIPTEN_VERSION}

--- a/scripts/wasm_configure.sh
+++ b/scripts/wasm_configure.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-source "$(dirname "$BASH_SOURCE[0]")/wasm_env.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/wasm_env.sh"
 
 curl --version \
     && { echo "[ OK  ] Command: curl"; } \

--- a/scripts/wasm_env.sh
+++ b/scripts/wasm_env.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+PROJECT_ROOT="$(cd "$(dirname "$BASH_SOURCE[0]")/.." && pwd)" &> /dev/null
+
+EMSCRIPTEN_VERSION="2.0.14"
+EMSDK_VERSION="2.0.14"
+
+WASM_WD="${PROJECT_ROOT}/.wasm/"
+EMSDK_REPO_DIR="${WASM_WD}/emsdk/"
+EMSDK_RELEASE_URL="https://github.com/emscripten-core/emsdk/archive/${EMSDK_VERSION}.tar.gz"
+EMSDK_RELEASE_TARBALL="${WASM_WD}/${EMSDK_VERSION}.tar.gz"
+EMSDK_TOOL="${EMSDK_REPO_DIR}/emsdk"
+EMSDK_ENV="${EMSDK_REPO_DIR}/emsdk_env.sh"
+
+EMSCRIPTEN_DIR="${EMSDK_REPO_DIR}/upstream/emscripten/"
+EMCMAKE="${EMSCRIPTEN_DIR}/emcmake"
+EMMAKE="${EMSCRIPTEN_DIR}/emmake"
+EMCC="${EMSCRIPTEN_DIR}/emcc"
+EMCPP="${EMSCRIPTEN_DIR}/em++"
+
+BUILD_DIR="${PROJECT_ROOT}/.wasm/build"
+DUCKDB_WASM="${BUILD_DIR}/duckdb.o"

--- a/scripts/wasm_env.sh
+++ b/scripts/wasm_env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-PROJECT_ROOT="$(cd "$(dirname "$BASH_SOURCE[0]")/.." && pwd)" &> /dev/null
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" &> /dev/null
 
 EMSCRIPTEN_VERSION="2.0.14"
 EMSDK_VERSION="2.0.14"

--- a/src/include/duckdb/parallel/concurrentqueue.hpp
+++ b/src/include/duckdb/parallel/concurrentqueue.hpp
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//						 DuckDB
+//
+// duckdb/parallel/concurrentqueue.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DUCKDB_NO_THREADS
+#include "concurrentqueue.h"
+#else
+
+#include <cstddef>
+#include <deque>
+#include <queue>
+
+namespace moodycamel {
+
+template <typename T>
+class ConcurrentQueue;
+template <typename T>
+class BlockingConcurrentQueue;
+
+struct ProducerToken {
+	//! Constructor
+	template <typename T, typename Traits>
+	explicit ProducerToken(ConcurrentQueue<T> &);
+	//! Constructor
+	template <typename T, typename Traits>
+	explicit ProducerToken(BlockingConcurrentQueue<T> &);
+	//! Constructor
+	ProducerToken(ProducerToken &&) {
+	}
+	//! Is valid token?
+	inline bool valid() const {
+		return true;
+	}
+};
+
+template <typename T>
+class ConcurrentQueue {
+private:
+	//! The queue
+	std::queue<T, std::deque<T>> q;
+
+public:
+	//! Constructor
+	ConcurrentQueue() = default;
+	//! Constructor
+	explicit ConcurrentQueue(size_t capacity) {
+		q.reserve(capacity);
+	}
+
+	//! Enqueue item
+	template <typename U>
+	bool enqueue(U &&item) {
+		q.push(std::forward<U>(item));
+		return true;
+	}
+	//! Try to dequeue an item
+	bool try_dequeue(T &item) {
+		if (q.empty()) {
+			return false;
+		}
+		item = std::move(q.front());
+		q.pop();
+		return true;
+	}
+};
+
+} // namespace moodycamel
+
+#endif

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/storage/storage_manager.hpp"
 
 #include "duckdb/common/exception.hpp"
-#include "concurrentqueue.h"
+#include "duckdb/parallel/concurrentqueue.hpp"
 
 namespace duckdb {
 

--- a/test/wasm/hello_wasm.cpp
+++ b/test/wasm/hello_wasm.cpp
@@ -1,0 +1,26 @@
+#include "duckdb.hpp"
+
+#include <iostream>
+
+extern "C" {
+
+int main() {
+	std::cout << "Hello from WASM" << std::endl;
+}
+
+int32_t HelloWasm() {
+	duckdb::DuckDB db(nullptr);
+	duckdb::Connection con(db);
+	auto result = con.Query("CREATE TABLE sometable AS SELECT x FROM generate_series(1,10000) AS a(x)");
+	if (!result->success) {
+		std::cerr << result->error << std::endl;
+		return -1;
+	}
+	result = con.Query("SELECT sum(x) FROM sometable");
+	if (!result->success) {
+		std::cerr << result->error << std::endl;
+		return -1;
+	}
+	return result->GetValue(0, 0).value_.bigint;
+}
+}

--- a/test/wasm/hello_wasm_test.js
+++ b/test/wasm/hello_wasm_test.js
@@ -1,0 +1,19 @@
+const DuckDB = require('../../.wasm/build/hello_wasm.js');
+
+async function main() {
+    const db = await DuckDB();
+    const HelloWasm = db['_HelloWasm'];
+    const result = HelloWasm();
+    const n = 10000;
+    const expected = n * (n + 1) / 2;
+    console.log(`expected ${expected}, received ${result}`);
+    if (result != expected) {
+        console.log('result differs');
+        process.exit(1);
+    } else {
+        console.log('result ok');
+        process.exit(0);
+    }
+}
+
+main();


### PR DESCRIPTION
This PR adds a first hello world WASM test.
The scripts take care of the emsdk setup and compile the amalgamation build.

More precisely:
- `./scripts/wasm_configure.sh` prepares the emscripten sdk in .wasm/emsdk
- `./scripts/wasm_build_lib.sh` compiles the amalgamation build in .wasm/build
- `./scripts/wasm_build_test.sh` compiles a hello world test module
- `node ./test/wasm/hello_wasm_test.js` with a recent enough node will run the test

The concurrentqueue is still causing some trouble at the moment.
This PR also adds `/include/duckdb/parallel/concurrentqueue.hpp` that acts as simple stub in case DUCKDB_NO_THREADS is set.
This patches the recent queue references in the buffer_manager.
The other user of concurrentqueue is the task_scheduler that has its own stub at the moment.
If you're ok with it, I can replace that as well.

This PR still lacks the GitHub action.
I'll add it here if you want to merge the scripts upstream.
In the long run, this should totally be part of a dedicated CMakelists but bash would suffice for the CI for now.

Note that the single wasm build is very slow (single threaded, ~10 min).
Compiling the test will add a few more minutes.
The output of the test should be the following:
```
> node test/wasm/hello_wasm_test.js
Hello from WASM
expected 50005000, received 50005000
result ok
```
