### PR TITLE
Progress Bar

### DIFF
--- a/src/catalog/catalog_entry/schema_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/schema_catalog_entry.cpp
@@ -93,6 +93,7 @@ CatalogEntry *SchemaCatalogEntry::CreateSequence(ClientContext &context, CreateS
 
 CatalogEntry *SchemaCatalogEntry::CreateTable(ClientContext &context, BoundCreateTableInfo *info) {
 	auto table = make_unique<TableCatalogEntry>(catalog, this, info);
+	table->storage->info->cardinality = table->storage->GetTotalRows();
 	return AddEntry(context, move(table), info->Base().on_conflict, info->dependencies);
 }
 

--- a/src/catalog/catalog_entry/schema_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/schema_catalog_entry.cpp
@@ -28,7 +28,7 @@
 #include "duckdb/parser/parsed_data/drop_info.hpp"
 #include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
 #include "duckdb/transaction/transaction.hpp"
-
+#include "duckdb/storage/data_table.hpp"
 #include <algorithm>
 #include <sstream>
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library_unity(
   gzip_stream.cpp
   limits.cpp
   printer.cpp
+  progress_bar.cpp
   serializer.cpp
   string_util.cpp
   symbols.cpp

--- a/src/common/printer.cpp
+++ b/src/common/printer.cpp
@@ -1,5 +1,5 @@
 #include "duckdb/common/printer.hpp"
-
+#include "duckdb/common/progress_bar.hpp"
 #include <stdio.h>
 
 namespace duckdb {
@@ -7,6 +7,22 @@ namespace duckdb {
 void Printer::Print(const string &str) {
 #ifndef DUCKDB_DISABLE_PRINT
 	fprintf(stderr, "%s\n", str.c_str());
+#endif
+}
+void ProgressBar::PrintProgress(int percentage) {
+#ifndef DUCKDB_DISABLE_PRINT
+	int lpad = (int)(percentage / 100.0 * pbwidth);
+	int rpad = pbwidth - lpad;
+	printf("\r%3d%% [%.*s%*s]", percentage, lpad, pbstr.c_str(), rpad, "");
+	fflush(stdout);
+#endif
+}
+
+void ProgressBar::FinishPrint() {
+#ifndef DUCKDB_DISABLE_PRINT
+	PrintProgress(100);
+	printf(" \n");
+	fflush(stdout);
 #endif
 }
 

--- a/src/common/printer.cpp
+++ b/src/common/printer.cpp
@@ -9,18 +9,18 @@ void Printer::Print(const string &str) {
 	fprintf(stderr, "%s\n", str.c_str());
 #endif
 }
-void ProgressBar::PrintProgress(int percentage) {
+void Printer::PrintProgress(int percentage, const char* pbstr, int pbwidth) {
 #ifndef DUCKDB_DISABLE_PRINT
 	int lpad = (int)(percentage / 100.0 * pbwidth);
 	int rpad = pbwidth - lpad;
-	printf("\r%3d%% [%.*s%*s]", percentage, lpad, pbstr.c_str(), rpad, "");
+	printf("\r%3d%% [%.*s%*s]", percentage, lpad, pbstr, rpad, "");
 	fflush(stdout);
 #endif
 }
 
-void ProgressBar::FinishPrint() {
+void Printer::FinishProgressBarPrint(const char* pbstr, int pbwidth) {
 #ifndef DUCKDB_DISABLE_PRINT
-	PrintProgress(100);
+	PrintProgress(100,pbstr,pbwidth);
 	printf(" \n");
 	fflush(stdout);
 #endif

--- a/src/common/printer.cpp
+++ b/src/common/printer.cpp
@@ -9,7 +9,7 @@ void Printer::Print(const string &str) {
 	fprintf(stderr, "%s\n", str.c_str());
 #endif
 }
-void Printer::PrintProgress(int percentage, const char* pbstr, int pbwidth) {
+void Printer::PrintProgress(int percentage, const char *pbstr, int pbwidth) {
 #ifndef DUCKDB_DISABLE_PRINT
 	int lpad = (int)(percentage / 100.0 * pbwidth);
 	int rpad = pbwidth - lpad;
@@ -18,9 +18,9 @@ void Printer::PrintProgress(int percentage, const char* pbstr, int pbwidth) {
 #endif
 }
 
-void Printer::FinishProgressBarPrint(const char* pbstr, int pbwidth) {
+void Printer::FinishProgressBarPrint(const char *pbstr, int pbwidth) {
 #ifndef DUCKDB_DISABLE_PRINT
-	PrintProgress(100,pbstr,pbwidth);
+	PrintProgress(100, pbstr, pbwidth);
 	printf(" \n");
 	fflush(stdout);
 #endif

--- a/src/common/progress_bar.cpp
+++ b/src/common/progress_bar.cpp
@@ -1,68 +1,51 @@
 #include "duckdb/common/progress_bar.hpp"
 
 namespace duckdb {
-void ProgressBar::PrintProgress(int percentage) {
-	int lpad = (int)(percentage / 100.0 * pbwidth);
-	int rpad = pbwidth - lpad;
-	printf("\r%3d%% [%.*s%*s]", percentage, lpad, pbstr.c_str(), rpad, "");
-	fflush(stdout);
-}
 
 void ProgressBar::ProgressBarThread() {
-	std::this_thread::sleep_for(std::chrono::milliseconds(show_progress_after));
-	while (!StopRequested()) {
-		int percentage = executor->GetPipelinesProgress(supported);
-		if (supported && percentage > 0) {
-			PrintProgress(percentage);
+	WaitFor(std::chrono::milliseconds(show_progress_after));
+	while (!stop) {
+		auto new_percentage = executor->GetPipelinesProgress(supported);
+		if (new_percentage > 100 || new_percentage < cur_percentage) {
+			valid_percentage = false;
 		}
-
-		std::this_thread::sleep_for(std::chrono::milliseconds(time_update_bar));
-	}
-}
-
-void ProgressBar::ProgressBarThreadTest() {
-	std::this_thread::sleep_for(std::chrono::milliseconds(show_progress_after));
-	while (!StopRequested()) {
-		int percentage = executor->GetPipelinesProgress(supported);
-		bool acceptable_percentage = cur_percentage <= percentage && percentage <= 100;
-		valid_percentage = valid_percentage && acceptable_percentage;
-		cur_percentage = percentage;
-		std::this_thread::sleep_for(std::chrono::milliseconds(time_update_bar));
-	}
-}
-
-void ProgressBar::Start() {
-	exit_signal = std::promise<void>();
-	future_obj = exit_signal.get_future();
-	valid_percentage = true;
-	cur_percentage = 0;
-	if (running_test) {
-		progress_bar_thread = std::thread(&ProgressBar::ProgressBarThreadTest, this);
-	} else {
-		progress_bar_thread = std::thread(&ProgressBar::ProgressBarThread, this);
-	}
-}
-
-bool ProgressBar::StopRequested() {
-	if (future_obj.wait_for(std::chrono::milliseconds(0)) == std::future_status::timeout) {
-		return false;
-	}
-	return true;
-}
-
-void ProgressBar::Stop() {
-	if (progress_bar_thread.joinable()) {
-		exit_signal.set_value();
-		progress_bar_thread.join();
-		if (!running_test || !supported) {
-			printf(" \n");
-			fflush(stdout);
+		cur_percentage = new_percentage;
+		if (supported && cur_percentage > -1) {
+			PrintProgress(cur_percentage);
 		}
+		WaitFor(std::chrono::milliseconds(100));
 	}
+}
+
+int ProgressBar::GetCurPercentage() {
+	return cur_percentage;
 }
 
 bool ProgressBar::IsPercentageValid() {
 	return valid_percentage;
 }
 
+void ProgressBar::Start() {
+#ifndef DUCKDB_NO_THREADS
+	valid_percentage = true;
+	cur_percentage = 0;
+	progress_bar_thread = std::thread(&ProgressBar::ProgressBarThread, this);
+#endif
+}
+
+void ProgressBar::Stop() {
+#ifndef DUCKDB_NO_THREADS
+	if (progress_bar_thread.joinable()) {
+		{
+			std::lock_guard<std::mutex> l(m);
+			stop = true;
+		}
+		c.notify_one();
+		progress_bar_thread.join();
+		if (supported) {
+			FinishPrint();
+		}
+	}
+#endif
+}
 } // namespace duckdb

--- a/src/common/progress_bar.cpp
+++ b/src/common/progress_bar.cpp
@@ -1,18 +1,19 @@
 #include "duckdb/common/progress_bar.hpp"
+#include "duckdb/common/printer.hpp"
 
 namespace duckdb {
 
 void ProgressBar::ProgressBarThread() {
 	WaitFor(std::chrono::milliseconds(show_progress_after));
 	while (!stop) {
-	    int new_percentage;
+		int new_percentage;
 		supported = executor->GetPipelinesProgress(new_percentage);
 		if (new_percentage > 100 || new_percentage < current_percentage) {
 			valid_percentage = false;
 		}
-        current_percentage = new_percentage;
+		current_percentage = new_percentage;
 		if (supported && current_percentage > -1) {
-			Printer::PrintProgress(current_percentage,PROGRESS_BAR_STRING.c_str(),PROGRESS_BAR_WIDTH);
+			Printer::PrintProgress(current_percentage, PROGRESS_BAR_STRING.c_str(), PROGRESS_BAR_WIDTH);
 		}
 		WaitFor(std::chrono::milliseconds(time_update_bar));
 	}
@@ -29,7 +30,7 @@ bool ProgressBar::IsPercentageValid() {
 void ProgressBar::Start() {
 #ifndef DUCKDB_NO_THREADS
 	valid_percentage = true;
-    current_percentage = 0;
+	current_percentage = 0;
 	progress_bar_thread = std::thread(&ProgressBar::ProgressBarThread, this);
 #endif
 }
@@ -44,7 +45,7 @@ void ProgressBar::Stop() {
 		c.notify_one();
 		progress_bar_thread.join();
 		if (supported) {
-			Printer::FinishProgressBarPrint(PROGRESS_BAR_STRING.c_str(),PROGRESS_BAR_WIDTH);
+			Printer::FinishProgressBarPrint(PROGRESS_BAR_STRING.c_str(), PROGRESS_BAR_WIDTH);
 		}
 	}
 #endif

--- a/src/common/progress_bar.cpp
+++ b/src/common/progress_bar.cpp
@@ -1,61 +1,67 @@
 #include "duckdb/common/progress_bar.hpp"
 
 namespace duckdb {
-void ProgressBar::PrintProgress(int percentage) {
-	int lpad = (int)(percentage / 100.0 * pbwidth);
-	int rpad = pbwidth - lpad;
-	printf("\r%3d%% [%.*s%*s]", percentage, lpad, pbstr.c_str(), rpad, "");
-	fflush(stdout);
-}
+    void ProgressBar::PrintProgress(int percentage) {
+        int lpad = (int) (percentage / 100.0 * pbwidth);
+        int rpad = pbwidth - lpad;
+        printf("\r%3d%% [%.*s%*s]", percentage, lpad, pbstr.c_str(), rpad, "");
+        fflush(stdout);
+    }
 
-void ProgressBar::ProgressBarThread() {
-	std::this_thread::sleep_for(std::chrono::milliseconds(show_progress_after));
-	while (!StopRequested()) {
-		PrintProgress(executor->GetPipelinesProgress());
-		std::this_thread::sleep_for(std::chrono::milliseconds(time_update_bar));
-	}
-}
+    void ProgressBar::ProgressBarThread() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(show_progress_after));
+        while (!StopRequested()) {
+            int percentage = executor->GetPipelinesProgress(supported);
+            if (supported && percentage > 0) {
+                PrintProgress(percentage);
+            }
 
-void ProgressBar::ProgressBarThreadTest() {
-	std::this_thread::sleep_for(std::chrono::milliseconds(show_progress_after));
-	while (!StopRequested()) {
-		bool acceptable_percentage =
-		    cur_percentage <= executor->GetPipelinesProgress() && executor->GetPipelinesProgress() <= 100;
-		valid_percentage = valid_percentage && acceptable_percentage;
-		cur_percentage = executor->GetPipelinesProgress();
-		std::this_thread::sleep_for(std::chrono::milliseconds(time_update_bar));
-	}
-}
+            std::this_thread::sleep_for(std::chrono::milliseconds(time_update_bar));
+        }
+    }
 
-void ProgressBar::Start() {
-	exit_signal = std::promise<void>();
-	valid_percentage = true;
-	cur_percentage = 0;
-	if (running_test) {
-		progress_bar_thread = std::thread(&ProgressBar::ProgressBarThreadTest, this);
-	} else {
-		progress_bar_thread = std::thread(&ProgressBar::ProgressBarThread, this);
-	}
-}
+    void ProgressBar::ProgressBarThreadTest() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(show_progress_after));
+        while (!StopRequested()) {
+             int percentage = executor->GetPipelinesProgress(supported);
+            bool acceptable_percentage =
+                    cur_percentage <= percentage && percentage <= 100;
+            valid_percentage = valid_percentage && acceptable_percentage;
+            cur_percentage = percentage;
+            std::this_thread::sleep_for(std::chrono::milliseconds(time_update_bar));
+        }
+    }
 
-bool ProgressBar::StopRequested() {
-	if (future_obj.wait_for(std::chrono::milliseconds(0)) == std::future_status::timeout) {
-		return false;
-	}
-	return true;
-}
+    void ProgressBar::Start() {
+        exit_signal = std::promise<void>();
+        future_obj = exit_signal.get_future();
+        valid_percentage = true;
+        cur_percentage = 0;
+        if (running_test) {
+            progress_bar_thread = std::thread(&ProgressBar::ProgressBarThreadTest, this);
+        } else {
+            progress_bar_thread = std::thread(&ProgressBar::ProgressBarThread, this);
+        }
+    }
 
-void ProgressBar::Stop() {
-	if (progress_bar_thread.joinable()) {
-		exit_signal.set_value();
-		progress_bar_thread.join();
-		printf(" \n");
-		fflush(stdout);
-	}
-}
+    bool ProgressBar::StopRequested() {
+        if (future_obj.wait_for(std::chrono::milliseconds(0)) == std::future_status::timeout) {
+            return false;
+        }
+        return true;
+    }
 
-bool ProgressBar::IsPercentageValid() {
-	return valid_percentage;
-}
+    void ProgressBar::Stop() {
+        if (progress_bar_thread.joinable()) {
+            exit_signal.set_value();
+            progress_bar_thread.join();
+            printf(" \n");
+            fflush(stdout);
+        }
+    }
+
+    bool ProgressBar::IsPercentageValid() {
+        return valid_percentage;
+    }
 
 } // namespace duckdb

--- a/src/common/progress_bar.cpp
+++ b/src/common/progress_bar.cpp
@@ -1,67 +1,68 @@
 #include "duckdb/common/progress_bar.hpp"
 
 namespace duckdb {
-    void ProgressBar::PrintProgress(int percentage) {
-        int lpad = (int) (percentage / 100.0 * pbwidth);
-        int rpad = pbwidth - lpad;
-        printf("\r%3d%% [%.*s%*s]", percentage, lpad, pbstr.c_str(), rpad, "");
-        fflush(stdout);
-    }
+void ProgressBar::PrintProgress(int percentage) {
+	int lpad = (int)(percentage / 100.0 * pbwidth);
+	int rpad = pbwidth - lpad;
+	printf("\r%3d%% [%.*s%*s]", percentage, lpad, pbstr.c_str(), rpad, "");
+	fflush(stdout);
+}
 
-    void ProgressBar::ProgressBarThread() {
-        std::this_thread::sleep_for(std::chrono::milliseconds(show_progress_after));
-        while (!StopRequested()) {
-            int percentage = executor->GetPipelinesProgress(supported);
-            if (supported && percentage > 0) {
-                PrintProgress(percentage);
-            }
+void ProgressBar::ProgressBarThread() {
+	std::this_thread::sleep_for(std::chrono::milliseconds(show_progress_after));
+	while (!StopRequested()) {
+		int percentage = executor->GetPipelinesProgress(supported);
+		if (supported && percentage > 0) {
+			PrintProgress(percentage);
+		}
 
-            std::this_thread::sleep_for(std::chrono::milliseconds(time_update_bar));
-        }
-    }
+		std::this_thread::sleep_for(std::chrono::milliseconds(time_update_bar));
+	}
+}
 
-    void ProgressBar::ProgressBarThreadTest() {
-        std::this_thread::sleep_for(std::chrono::milliseconds(show_progress_after));
-        while (!StopRequested()) {
-             int percentage = executor->GetPipelinesProgress(supported);
-            bool acceptable_percentage =
-                    cur_percentage <= percentage && percentage <= 100;
-            valid_percentage = valid_percentage && acceptable_percentage;
-            cur_percentage = percentage;
-            std::this_thread::sleep_for(std::chrono::milliseconds(time_update_bar));
-        }
-    }
+void ProgressBar::ProgressBarThreadTest() {
+	std::this_thread::sleep_for(std::chrono::milliseconds(show_progress_after));
+	while (!StopRequested()) {
+		int percentage = executor->GetPipelinesProgress(supported);
+		bool acceptable_percentage = cur_percentage <= percentage && percentage <= 100;
+		valid_percentage = valid_percentage && acceptable_percentage;
+		cur_percentage = percentage;
+		std::this_thread::sleep_for(std::chrono::milliseconds(time_update_bar));
+	}
+}
 
-    void ProgressBar::Start() {
-        exit_signal = std::promise<void>();
-        future_obj = exit_signal.get_future();
-        valid_percentage = true;
-        cur_percentage = 0;
-        if (running_test) {
-            progress_bar_thread = std::thread(&ProgressBar::ProgressBarThreadTest, this);
-        } else {
-            progress_bar_thread = std::thread(&ProgressBar::ProgressBarThread, this);
-        }
-    }
+void ProgressBar::Start() {
+	exit_signal = std::promise<void>();
+	future_obj = exit_signal.get_future();
+	valid_percentage = true;
+	cur_percentage = 0;
+	if (running_test) {
+		progress_bar_thread = std::thread(&ProgressBar::ProgressBarThreadTest, this);
+	} else {
+		progress_bar_thread = std::thread(&ProgressBar::ProgressBarThread, this);
+	}
+}
 
-    bool ProgressBar::StopRequested() {
-        if (future_obj.wait_for(std::chrono::milliseconds(0)) == std::future_status::timeout) {
-            return false;
-        }
-        return true;
-    }
+bool ProgressBar::StopRequested() {
+	if (future_obj.wait_for(std::chrono::milliseconds(0)) == std::future_status::timeout) {
+		return false;
+	}
+	return true;
+}
 
-    void ProgressBar::Stop() {
-        if (progress_bar_thread.joinable()) {
-            exit_signal.set_value();
-            progress_bar_thread.join();
-            printf(" \n");
-            fflush(stdout);
-        }
-    }
+void ProgressBar::Stop() {
+	if (progress_bar_thread.joinable()) {
+		exit_signal.set_value();
+		progress_bar_thread.join();
+		if (!running_test || !supported) {
+			printf(" \n");
+			fflush(stdout);
+		}
+	}
+}
 
-    bool ProgressBar::IsPercentageValid() {
-        return valid_percentage;
-    }
+bool ProgressBar::IsPercentageValid() {
+	return valid_percentage;
+}
 
 } // namespace duckdb

--- a/src/common/progress_bar.cpp
+++ b/src/common/progress_bar.cpp
@@ -4,6 +4,7 @@
 namespace duckdb {
 
 void ProgressBar::ProgressBarThread() {
+#ifndef DUCKDB_NO_THREADS
 	WaitFor(std::chrono::milliseconds(show_progress_after));
 	while (!stop) {
 		int new_percentage;
@@ -17,6 +18,7 @@ void ProgressBar::ProgressBarThread() {
 		}
 		WaitFor(std::chrono::milliseconds(time_update_bar));
 	}
+#endif
 }
 
 int ProgressBar::GetCurrentPercentage() {
@@ -24,7 +26,11 @@ int ProgressBar::GetCurrentPercentage() {
 }
 
 bool ProgressBar::IsPercentageValid() {
+#ifndef DUCKDB_NO_THREADS
 	return valid_percentage;
+#else
+	return true;
+#endif
 }
 
 void ProgressBar::Start() {

--- a/src/common/progress_bar.cpp
+++ b/src/common/progress_bar.cpp
@@ -1,0 +1,61 @@
+#include "duckdb/common/progress_bar.hpp"
+
+namespace duckdb {
+void ProgressBar::PrintProgress(int percentage) {
+	int lpad = (int)(percentage / 100.0 * pbwidth);
+	int rpad = pbwidth - lpad;
+	printf("\r%3d%% [%.*s%*s]", percentage, lpad, pbstr.c_str(), rpad, "");
+	fflush(stdout);
+}
+
+void ProgressBar::ProgressBarThread() {
+	std::this_thread::sleep_for(std::chrono::milliseconds(show_progress_after));
+	while (!StopRequested()) {
+		PrintProgress(executor->GetPipelinesProgress());
+		std::this_thread::sleep_for(std::chrono::milliseconds(time_update_bar));
+	}
+}
+
+void ProgressBar::ProgressBarThreadTest() {
+	std::this_thread::sleep_for(std::chrono::milliseconds(show_progress_after));
+	while (!StopRequested()) {
+		bool acceptable_percentage =
+		    cur_percentage <= executor->GetPipelinesProgress() && executor->GetPipelinesProgress() <= 100;
+		valid_percentage = valid_percentage && acceptable_percentage;
+		cur_percentage = executor->GetPipelinesProgress();
+		std::this_thread::sleep_for(std::chrono::milliseconds(time_update_bar));
+	}
+}
+
+void ProgressBar::Start() {
+	exit_signal = std::promise<void>();
+	valid_percentage = true;
+	cur_percentage = 0;
+	if (running_test) {
+		progress_bar_thread = std::thread(&ProgressBar::ProgressBarThreadTest, this);
+	} else {
+		progress_bar_thread = std::thread(&ProgressBar::ProgressBarThread, this);
+	}
+}
+
+bool ProgressBar::StopRequested() {
+	if (future_obj.wait_for(std::chrono::milliseconds(0)) == std::future_status::timeout) {
+		return false;
+	}
+	return true;
+}
+
+void ProgressBar::Stop() {
+	if (progress_bar_thread.joinable()) {
+		exit_signal.set_value();
+		progress_bar_thread.join();
+		printf(" \n");
+		fflush(stdout);
+	}
+}
+
+bool ProgressBar::IsPercentageValid() {
+	return valid_percentage;
+}
+
+} // namespace duckdb

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -13,14 +13,17 @@
 namespace duckdb {
 
 PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types,
-                                             vector<unique_ptr<Expression>> expressions, idx_t estimated_cardinality, PhysicalOperatorType type)
-    : PhysicalHashAggregate(context, move(types), move(expressions), {},estimated_cardinality, type) {
+                                             vector<unique_ptr<Expression>> expressions, idx_t estimated_cardinality,
+                                             PhysicalOperatorType type)
+    : PhysicalHashAggregate(context, move(types), move(expressions), {}, estimated_cardinality, type) {
 }
 
 PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types,
                                              vector<unique_ptr<Expression>> expressions,
-                                             vector<unique_ptr<Expression>> groups_p, idx_t estimated_cardinality, PhysicalOperatorType type)
-    : PhysicalSink(type, move(types),estimated_cardinality), groups(move(groups_p)), all_combinable(true), any_distinct(false) {
+                                             vector<unique_ptr<Expression>> groups_p, idx_t estimated_cardinality,
+                                             PhysicalOperatorType type)
+    : PhysicalSink(type, move(types), estimated_cardinality), groups(move(groups_p)), all_combinable(true),
+      any_distinct(false) {
 	// get a list of all aggregates to be computed
 	// fake a single group with a constant value for aggregation without groups
 	if (this->groups.empty()) {

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -13,14 +13,14 @@
 namespace duckdb {
 
 PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types,
-                                             vector<unique_ptr<Expression>> expressions, PhysicalOperatorType type)
-    : PhysicalHashAggregate(context, move(types), move(expressions), {}, type) {
+                                             vector<unique_ptr<Expression>> expressions, idx_t estimated_cardinality, PhysicalOperatorType type)
+    : PhysicalHashAggregate(context, move(types), move(expressions), {},estimated_cardinality, type) {
 }
 
 PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types,
                                              vector<unique_ptr<Expression>> expressions,
-                                             vector<unique_ptr<Expression>> groups_p, PhysicalOperatorType type)
-    : PhysicalSink(type, move(types)), groups(move(groups_p)), all_combinable(true), any_distinct(false) {
+                                             vector<unique_ptr<Expression>> groups_p, idx_t estimated_cardinality, PhysicalOperatorType type)
+    : PhysicalSink(type, move(types),estimated_cardinality), groups(move(groups_p)), all_combinable(true), any_distinct(false) {
 	// get a list of all aggregates to be computed
 	// fake a single group with a constant value for aggregation without groups
 	if (this->groups.empty()) {

--- a/src/execution/operator/aggregate/physical_perfecthash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_perfecthash_aggregate.cpp
@@ -12,8 +12,8 @@ PhysicalPerfectHashAggregate::PhysicalPerfectHashAggregate(ClientContext &contex
                                                            vector<unique_ptr<Expression>> aggregates_p,
                                                            vector<unique_ptr<Expression>> groups_p,
                                                            vector<unique_ptr<BaseStatistics>> group_stats,
-                                                           vector<idx_t> required_bits_p)
-    : PhysicalSink(PhysicalOperatorType::PERFECT_HASH_GROUP_BY, move(types_p)), groups(move(groups_p)),
+                                                           vector<idx_t> required_bits_p, idx_t estimated_cardinality)
+    : PhysicalSink(PhysicalOperatorType::PERFECT_HASH_GROUP_BY, move(types_p),estimated_cardinality), groups(move(groups_p)),
       aggregates(move(aggregates_p)), required_bits(move(required_bits_p)) {
 	D_ASSERT(groups.size() == group_stats.size());
 	group_minima.reserve(group_stats.size());

--- a/src/execution/operator/aggregate/physical_perfecthash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_perfecthash_aggregate.cpp
@@ -13,8 +13,8 @@ PhysicalPerfectHashAggregate::PhysicalPerfectHashAggregate(ClientContext &contex
                                                            vector<unique_ptr<Expression>> groups_p,
                                                            vector<unique_ptr<BaseStatistics>> group_stats,
                                                            vector<idx_t> required_bits_p, idx_t estimated_cardinality)
-    : PhysicalSink(PhysicalOperatorType::PERFECT_HASH_GROUP_BY, move(types_p),estimated_cardinality), groups(move(groups_p)),
-      aggregates(move(aggregates_p)), required_bits(move(required_bits_p)) {
+    : PhysicalSink(PhysicalOperatorType::PERFECT_HASH_GROUP_BY, move(types_p), estimated_cardinality),
+      groups(move(groups_p)), aggregates(move(aggregates_p)), required_bits(move(required_bits_p)) {
 	D_ASSERT(groups.size() == group_stats.size());
 	group_minima.reserve(group_stats.size());
 	for (auto &stats : group_stats) {

--- a/src/execution/operator/aggregate/physical_simple_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_simple_aggregate.cpp
@@ -8,8 +8,8 @@
 namespace duckdb {
 
 PhysicalSimpleAggregate::PhysicalSimpleAggregate(vector<LogicalType> types, vector<unique_ptr<Expression>> expressions,
-                                                 bool all_combinable)
-    : PhysicalSink(PhysicalOperatorType::SIMPLE_AGGREGATE, move(types)), aggregates(move(expressions)),
+                                                 bool all_combinable, idx_t estimated_cardinality)
+    : PhysicalSink(PhysicalOperatorType::SIMPLE_AGGREGATE, move(types),estimated_cardinality), aggregates(move(expressions)),
       all_combinable(all_combinable) {
 }
 

--- a/src/execution/operator/aggregate/physical_simple_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_simple_aggregate.cpp
@@ -9,8 +9,8 @@ namespace duckdb {
 
 PhysicalSimpleAggregate::PhysicalSimpleAggregate(vector<LogicalType> types, vector<unique_ptr<Expression>> expressions,
                                                  bool all_combinable, idx_t estimated_cardinality)
-    : PhysicalSink(PhysicalOperatorType::SIMPLE_AGGREGATE, move(types),estimated_cardinality), aggregates(move(expressions)),
-      all_combinable(all_combinable) {
+    : PhysicalSink(PhysicalOperatorType::SIMPLE_AGGREGATE, move(types), estimated_cardinality),
+      aggregates(move(expressions)), all_combinable(all_combinable) {
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -42,9 +42,9 @@ public:
 };
 
 // this implements a sorted window functions variant
-PhysicalWindow::PhysicalWindow(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality,
-                               PhysicalOperatorType type)
-    : PhysicalSink(type, move(types),estimated_cardinality), select_list(move(select_list)) {
+PhysicalWindow::PhysicalWindow(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
+                               idx_t estimated_cardinality, PhysicalOperatorType type)
+    : PhysicalSink(type, move(types), estimated_cardinality), select_list(move(select_list)) {
 }
 
 static bool EqualsSubset(vector<Value> &a, vector<Value> &b, idx_t start, idx_t end) {

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -42,9 +42,9 @@ public:
 };
 
 // this implements a sorted window functions variant
-PhysicalWindow::PhysicalWindow(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
+PhysicalWindow::PhysicalWindow(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality,
                                PhysicalOperatorType type)
-    : PhysicalSink(type, move(types)), select_list(move(select_list)) {
+    : PhysicalSink(type, move(types),estimated_cardinality), select_list(move(select_list)) {
 }
 
 static bool EqualsSubset(vector<Value> &a, vector<Value> &b, idx_t start, idx_t end) {

--- a/src/execution/operator/filter/physical_filter.cpp
+++ b/src/execution/operator/filter/physical_filter.cpp
@@ -13,8 +13,9 @@ public:
 	ExpressionExecutor executor;
 };
 
-PhysicalFilter::PhysicalFilter(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::FILTER, move(types),estimated_cardinality) {
+PhysicalFilter::PhysicalFilter(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
+                               idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::FILTER, move(types), estimated_cardinality) {
 	D_ASSERT(select_list.size() > 0);
 	if (select_list.size() > 1) {
 		// create a big AND out of the expressions

--- a/src/execution/operator/filter/physical_filter.cpp
+++ b/src/execution/operator/filter/physical_filter.cpp
@@ -13,8 +13,8 @@ public:
 	ExpressionExecutor executor;
 };
 
-PhysicalFilter::PhysicalFilter(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list)
-    : PhysicalOperator(PhysicalOperatorType::FILTER, move(types)) {
+PhysicalFilter::PhysicalFilter(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::FILTER, move(types),estimated_cardinality) {
 	D_ASSERT(select_list.size() > 0);
 	if (select_list.size() > 1) {
 		// create a big AND out of the expressions

--- a/src/execution/operator/helper/physical_streaming_sample.cpp
+++ b/src/execution/operator/helper/physical_streaming_sample.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 
 PhysicalStreamingSample::PhysicalStreamingSample(vector<LogicalType> types, SampleMethod method, double percentage,
                                                  int64_t seed, idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::STREAMING_SAMPLE, move(types),estimated_cardinality), method(method),
+    : PhysicalOperator(PhysicalOperatorType::STREAMING_SAMPLE, move(types), estimated_cardinality), method(method),
       percentage(percentage / 100), seed(seed) {
 }
 

--- a/src/execution/operator/helper/physical_streaming_sample.cpp
+++ b/src/execution/operator/helper/physical_streaming_sample.cpp
@@ -5,8 +5,8 @@
 namespace duckdb {
 
 PhysicalStreamingSample::PhysicalStreamingSample(vector<LogicalType> types, SampleMethod method, double percentage,
-                                                 int64_t seed)
-    : PhysicalOperator(PhysicalOperatorType::STREAMING_SAMPLE, move(types)), method(method),
+                                                 int64_t seed, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::STREAMING_SAMPLE, move(types),estimated_cardinality), method(method),
       percentage(percentage / 100), seed(seed) {
 }
 

--- a/src/execution/operator/join/physical_blockwise_nl_join.cpp
+++ b/src/execution/operator/join/physical_blockwise_nl_join.cpp
@@ -8,8 +8,8 @@ namespace duckdb {
 
 PhysicalBlockwiseNLJoin::PhysicalBlockwiseNLJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
                                                  unique_ptr<PhysicalOperator> right, unique_ptr<Expression> condition,
-                                                 JoinType join_type)
-    : PhysicalJoin(op, PhysicalOperatorType::BLOCKWISE_NL_JOIN, join_type), condition(move(condition)) {
+                                                 JoinType join_type, idx_t estimated_cardinality)
+    : PhysicalJoin(op, PhysicalOperatorType::BLOCKWISE_NL_JOIN, join_type, estimated_cardinality), condition(move(condition)) {
 	children.push_back(move(left));
 	children.push_back(move(right));
 	// MARK, SINGLE and RIGHT OUTER joins not handled

--- a/src/execution/operator/join/physical_blockwise_nl_join.cpp
+++ b/src/execution/operator/join/physical_blockwise_nl_join.cpp
@@ -9,7 +9,8 @@ namespace duckdb {
 PhysicalBlockwiseNLJoin::PhysicalBlockwiseNLJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
                                                  unique_ptr<PhysicalOperator> right, unique_ptr<Expression> condition,
                                                  JoinType join_type, idx_t estimated_cardinality)
-    : PhysicalJoin(op, PhysicalOperatorType::BLOCKWISE_NL_JOIN, join_type, estimated_cardinality), condition(move(condition)) {
+    : PhysicalJoin(op, PhysicalOperatorType::BLOCKWISE_NL_JOIN, join_type, estimated_cardinality),
+      condition(move(condition)) {
 	children.push_back(move(left));
 	children.push_back(move(right));
 	// MARK, SINGLE and RIGHT OUTER joins not handled

--- a/src/execution/operator/join/physical_comparison_join.cpp
+++ b/src/execution/operator/join/physical_comparison_join.cpp
@@ -4,8 +4,8 @@
 namespace duckdb {
 
 PhysicalComparisonJoin::PhysicalComparisonJoin(LogicalOperator &op, PhysicalOperatorType type,
-                                               vector<JoinCondition> conditions_p, JoinType join_type)
-    : PhysicalJoin(op, type, join_type) {
+                                               vector<JoinCondition> conditions_p, JoinType join_type, idx_t estimated_cardinality)
+    : PhysicalJoin(op, type, join_type,estimated_cardinality) {
 	conditions.resize(conditions_p.size());
 	// we reorder conditions so the ones with COMPARE_EQUAL occur first
 	idx_t equal_position = 0;

--- a/src/execution/operator/join/physical_comparison_join.cpp
+++ b/src/execution/operator/join/physical_comparison_join.cpp
@@ -4,8 +4,9 @@
 namespace duckdb {
 
 PhysicalComparisonJoin::PhysicalComparisonJoin(LogicalOperator &op, PhysicalOperatorType type,
-                                               vector<JoinCondition> conditions_p, JoinType join_type, idx_t estimated_cardinality)
-    : PhysicalJoin(op, type, join_type,estimated_cardinality) {
+                                               vector<JoinCondition> conditions_p, JoinType join_type,
+                                               idx_t estimated_cardinality)
+    : PhysicalJoin(op, type, join_type, estimated_cardinality) {
 	conditions.resize(conditions_p.size());
 	// we reorder conditions so the ones with COMPARE_EQUAL occur first
 	idx_t equal_position = 0;

--- a/src/execution/operator/join/physical_cross_product.cpp
+++ b/src/execution/operator/join/physical_cross_product.cpp
@@ -5,8 +5,8 @@
 namespace duckdb {
 
 PhysicalCrossProduct::PhysicalCrossProduct(vector<LogicalType> types, unique_ptr<PhysicalOperator> left,
-                                           unique_ptr<PhysicalOperator> right)
-    : PhysicalSink(PhysicalOperatorType::CROSS_PRODUCT, move(types)) {
+                                           unique_ptr<PhysicalOperator> right, idx_t estimated_cardinality)
+    : PhysicalSink(PhysicalOperatorType::CROSS_PRODUCT, move(types),estimated_cardinality) {
 	children.push_back(move(left));
 	children.push_back(move(right));
 }

--- a/src/execution/operator/join/physical_cross_product.cpp
+++ b/src/execution/operator/join/physical_cross_product.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 
 PhysicalCrossProduct::PhysicalCrossProduct(vector<LogicalType> types, unique_ptr<PhysicalOperator> left,
                                            unique_ptr<PhysicalOperator> right, idx_t estimated_cardinality)
-    : PhysicalSink(PhysicalOperatorType::CROSS_PRODUCT, move(types),estimated_cardinality) {
+    : PhysicalSink(PhysicalOperatorType::CROSS_PRODUCT, move(types), estimated_cardinality) {
 	children.push_back(move(left));
 	children.push_back(move(right));
 }

--- a/src/execution/operator/join/physical_delim_join.cpp
+++ b/src/execution/operator/join/physical_delim_join.cpp
@@ -17,8 +17,8 @@ public:
 };
 
 PhysicalDelimJoin::PhysicalDelimJoin(vector<LogicalType> types, unique_ptr<PhysicalOperator> original_join,
-                                     vector<PhysicalOperator *> delim_scans)
-    : PhysicalSink(PhysicalOperatorType::DELIM_JOIN, move(types)), join(move(original_join)),
+                                     vector<PhysicalOperator *> delim_scans, idx_t estimated_cardinality)
+    : PhysicalSink(PhysicalOperatorType::DELIM_JOIN, move(types),estimated_cardinality), join(move(original_join)),
       delim_scans(move(delim_scans)) {
 	D_ASSERT(join->children.size() == 2);
 	// now for the original join
@@ -27,7 +27,7 @@ PhysicalDelimJoin::PhysicalDelimJoin(vector<LogicalType> types, unique_ptr<Physi
 
 	// we replace it with a PhysicalChunkCollectionScan, that scans the ChunkCollection that we keep cached
 	// the actual chunk collection to scan will be created in the DelimJoinGlobalState
-	auto cached_chunk_scan = make_unique<PhysicalChunkScan>(children[0]->GetTypes(), PhysicalOperatorType::CHUNK_SCAN);
+	auto cached_chunk_scan = make_unique<PhysicalChunkScan>(children[0]->GetTypes(), PhysicalOperatorType::CHUNK_SCAN,estimated_cardinality);
 	join->children[0] = move(cached_chunk_scan);
 }
 

--- a/src/execution/operator/join/physical_delim_join.cpp
+++ b/src/execution/operator/join/physical_delim_join.cpp
@@ -18,7 +18,7 @@ public:
 
 PhysicalDelimJoin::PhysicalDelimJoin(vector<LogicalType> types, unique_ptr<PhysicalOperator> original_join,
                                      vector<PhysicalOperator *> delim_scans, idx_t estimated_cardinality)
-    : PhysicalSink(PhysicalOperatorType::DELIM_JOIN, move(types),estimated_cardinality), join(move(original_join)),
+    : PhysicalSink(PhysicalOperatorType::DELIM_JOIN, move(types), estimated_cardinality), join(move(original_join)),
       delim_scans(move(delim_scans)) {
 	D_ASSERT(join->children.size() == 2);
 	// now for the original join
@@ -27,7 +27,8 @@ PhysicalDelimJoin::PhysicalDelimJoin(vector<LogicalType> types, unique_ptr<Physi
 
 	// we replace it with a PhysicalChunkCollectionScan, that scans the ChunkCollection that we keep cached
 	// the actual chunk collection to scan will be created in the DelimJoinGlobalState
-	auto cached_chunk_scan = make_unique<PhysicalChunkScan>(children[0]->GetTypes(), PhysicalOperatorType::CHUNK_SCAN,estimated_cardinality);
+	auto cached_chunk_scan = make_unique<PhysicalChunkScan>(children[0]->GetTypes(), PhysicalOperatorType::CHUNK_SCAN,
+	                                                        estimated_cardinality);
 	join->children[0] = move(cached_chunk_scan);
 }
 

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -11,8 +11,9 @@ namespace duckdb {
 PhysicalHashJoin::PhysicalHashJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
                                    unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type,
                                    const vector<idx_t> &left_projection_map,
-                                   const vector<idx_t> &right_projection_map_p, vector<LogicalType> delim_types,idx_t estimated_cardinality)
-    : PhysicalComparisonJoin(op, PhysicalOperatorType::HASH_JOIN, move(cond), join_type,estimated_cardinality),
+                                   const vector<idx_t> &right_projection_map_p, vector<LogicalType> delim_types,
+                                   idx_t estimated_cardinality)
+    : PhysicalComparisonJoin(op, PhysicalOperatorType::HASH_JOIN, move(cond), join_type, estimated_cardinality),
       right_projection_map(right_projection_map_p), delim_types(move(delim_types)) {
 	children.push_back(move(left));
 	children.push_back(move(right));
@@ -29,8 +30,9 @@ PhysicalHashJoin::PhysicalHashJoin(LogicalOperator &op, unique_ptr<PhysicalOpera
 }
 
 PhysicalHashJoin::PhysicalHashJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
-                                   unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type, idx_t estimated_cardinality)
-    : PhysicalHashJoin(op, move(left), move(right), move(cond), join_type, {}, {}, {},estimated_cardinality) {
+                                   unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type,
+                                   idx_t estimated_cardinality)
+    : PhysicalHashJoin(op, move(left), move(right), move(cond), join_type, {}, {}, {}, estimated_cardinality) {
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -11,8 +11,8 @@ namespace duckdb {
 PhysicalHashJoin::PhysicalHashJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
                                    unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type,
                                    const vector<idx_t> &left_projection_map,
-                                   const vector<idx_t> &right_projection_map_p, vector<LogicalType> delim_types)
-    : PhysicalComparisonJoin(op, PhysicalOperatorType::HASH_JOIN, move(cond), join_type),
+                                   const vector<idx_t> &right_projection_map_p, vector<LogicalType> delim_types,idx_t estimated_cardinality)
+    : PhysicalComparisonJoin(op, PhysicalOperatorType::HASH_JOIN, move(cond), join_type,estimated_cardinality),
       right_projection_map(right_projection_map_p), delim_types(move(delim_types)) {
 	children.push_back(move(left));
 	children.push_back(move(right));
@@ -29,8 +29,8 @@ PhysicalHashJoin::PhysicalHashJoin(LogicalOperator &op, unique_ptr<PhysicalOpera
 }
 
 PhysicalHashJoin::PhysicalHashJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
-                                   unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type)
-    : PhysicalHashJoin(op, move(left), move(right), move(cond), join_type, {}, {}, {}) {
+                                   unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type, idx_t estimated_cardinality)
+    : PhysicalHashJoin(op, move(left), move(right), move(cond), join_type, {}, {}, {},estimated_cardinality) {
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/join/physical_index_join.cpp
+++ b/src/execution/operator/join/physical_index_join.cpp
@@ -39,10 +39,11 @@ public:
 PhysicalIndexJoin::PhysicalIndexJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
                                      unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type,
                                      const vector<idx_t> &left_projection_map, vector<idx_t> right_projection_map,
-                                     vector<column_t> column_ids_p, Index *index, bool lhs_first, idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::INDEX_JOIN, move(op.types),estimated_cardinality), left_projection_map(left_projection_map),
-      right_projection_map(move(right_projection_map)), index(index), conditions(move(cond)), join_type(join_type),
-      lhs_first(lhs_first) {
+                                     vector<column_t> column_ids_p, Index *index, bool lhs_first,
+                                     idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::INDEX_JOIN, move(op.types), estimated_cardinality),
+      left_projection_map(left_projection_map), right_projection_map(move(right_projection_map)), index(index),
+      conditions(move(cond)), join_type(join_type), lhs_first(lhs_first) {
 	column_ids = move(column_ids_p);
 	children.push_back(move(left));
 	children.push_back(move(right));

--- a/src/execution/operator/join/physical_index_join.cpp
+++ b/src/execution/operator/join/physical_index_join.cpp
@@ -39,8 +39,8 @@ public:
 PhysicalIndexJoin::PhysicalIndexJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
                                      unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type,
                                      const vector<idx_t> &left_projection_map, vector<idx_t> right_projection_map,
-                                     vector<column_t> column_ids_p, Index *index, bool lhs_first)
-    : PhysicalOperator(PhysicalOperatorType::INDEX_JOIN, move(op.types)), left_projection_map(left_projection_map),
+                                     vector<column_t> column_ids_p, Index *index, bool lhs_first, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::INDEX_JOIN, move(op.types),estimated_cardinality), left_projection_map(left_projection_map),
       right_projection_map(move(right_projection_map)), index(index), conditions(move(cond)), join_type(join_type),
       lhs_first(lhs_first) {
 	column_ids = move(column_ids_p);

--- a/src/execution/operator/join/physical_join.cpp
+++ b/src/execution/operator/join/physical_join.cpp
@@ -2,8 +2,8 @@
 
 namespace duckdb {
 
-PhysicalJoin::PhysicalJoin(LogicalOperator &op, PhysicalOperatorType type, JoinType join_type)
-    : PhysicalSink(type, op.types), join_type(join_type) {
+PhysicalJoin::PhysicalJoin(LogicalOperator &op, PhysicalOperatorType type, JoinType join_type, idx_t estimated_cardinality)
+    : PhysicalSink(type, op.types,estimated_cardinality), join_type(join_type) {
 }
 
 } // namespace duckdb

--- a/src/execution/operator/join/physical_join.cpp
+++ b/src/execution/operator/join/physical_join.cpp
@@ -2,8 +2,9 @@
 
 namespace duckdb {
 
-PhysicalJoin::PhysicalJoin(LogicalOperator &op, PhysicalOperatorType type, JoinType join_type, idx_t estimated_cardinality)
-    : PhysicalSink(type, op.types,estimated_cardinality), join_type(join_type) {
+PhysicalJoin::PhysicalJoin(LogicalOperator &op, PhysicalOperatorType type, JoinType join_type,
+                           idx_t estimated_cardinality)
+    : PhysicalSink(type, op.types, estimated_cardinality), join_type(join_type) {
 }
 
 } // namespace duckdb

--- a/src/execution/operator/join/physical_nested_loop_join.cpp
+++ b/src/execution/operator/join/physical_nested_loop_join.cpp
@@ -10,7 +10,7 @@ namespace duckdb {
 PhysicalNestedLoopJoin::PhysicalNestedLoopJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
                                                unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond,
                                                JoinType join_type, idx_t estimated_cardinality)
-    : PhysicalComparisonJoin(op, PhysicalOperatorType::NESTED_LOOP_JOIN, move(cond), join_type,estimated_cardinality) {
+    : PhysicalComparisonJoin(op, PhysicalOperatorType::NESTED_LOOP_JOIN, move(cond), join_type, estimated_cardinality) {
 	children.push_back(move(left));
 	children.push_back(move(right));
 }

--- a/src/execution/operator/join/physical_nested_loop_join.cpp
+++ b/src/execution/operator/join/physical_nested_loop_join.cpp
@@ -9,8 +9,8 @@ namespace duckdb {
 
 PhysicalNestedLoopJoin::PhysicalNestedLoopJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
                                                unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond,
-                                               JoinType join_type)
-    : PhysicalComparisonJoin(op, PhysicalOperatorType::NESTED_LOOP_JOIN, move(cond), join_type) {
+                                               JoinType join_type, idx_t estimated_cardinality)
+    : PhysicalComparisonJoin(op, PhysicalOperatorType::NESTED_LOOP_JOIN, move(cond), join_type,estimated_cardinality) {
 	children.push_back(move(left));
 	children.push_back(move(right));
 }

--- a/src/execution/operator/join/physical_piecewise_merge_join.cpp
+++ b/src/execution/operator/join/physical_piecewise_merge_join.cpp
@@ -9,8 +9,8 @@ namespace duckdb {
 
 PhysicalPiecewiseMergeJoin::PhysicalPiecewiseMergeJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
                                                        unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond,
-                                                       JoinType join_type)
-    : PhysicalComparisonJoin(op, PhysicalOperatorType::PIECEWISE_MERGE_JOIN, move(cond), join_type) {
+                                                       JoinType join_type, idx_t estimated_cardinality)
+    : PhysicalComparisonJoin(op, PhysicalOperatorType::PIECEWISE_MERGE_JOIN, move(cond), join_type, estimated_cardinality) {
 	// for now we only support one condition!
 	D_ASSERT(conditions.size() == 1);
 	for (auto &cond : conditions) {

--- a/src/execution/operator/join/physical_piecewise_merge_join.cpp
+++ b/src/execution/operator/join/physical_piecewise_merge_join.cpp
@@ -10,7 +10,8 @@ namespace duckdb {
 PhysicalPiecewiseMergeJoin::PhysicalPiecewiseMergeJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
                                                        unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond,
                                                        JoinType join_type, idx_t estimated_cardinality)
-    : PhysicalComparisonJoin(op, PhysicalOperatorType::PIECEWISE_MERGE_JOIN, move(cond), join_type, estimated_cardinality) {
+    : PhysicalComparisonJoin(op, PhysicalOperatorType::PIECEWISE_MERGE_JOIN, move(cond), join_type,
+                             estimated_cardinality) {
 	// for now we only support one condition!
 	D_ASSERT(conditions.size() == 1);
 	for (auto &cond : conditions) {

--- a/src/execution/operator/projection/physical_unnest.cpp
+++ b/src/execution/operator/projection/physical_unnest.cpp
@@ -24,9 +24,9 @@ public:
 };
 
 // this implements a sorted window functions variant
-PhysicalUnnest::PhysicalUnnest(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
+PhysicalUnnest::PhysicalUnnest(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality,
                                PhysicalOperatorType type)
-    : PhysicalOperator(type, move(types)), select_list(std::move(select_list)) {
+    : PhysicalOperator(type, move(types),estimated_cardinality), select_list(std::move(select_list)) {
 
 	D_ASSERT(this->select_list.size() > 0);
 }

--- a/src/execution/operator/projection/physical_unnest.cpp
+++ b/src/execution/operator/projection/physical_unnest.cpp
@@ -24,9 +24,9 @@ public:
 };
 
 // this implements a sorted window functions variant
-PhysicalUnnest::PhysicalUnnest(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality,
-                               PhysicalOperatorType type)
-    : PhysicalOperator(type, move(types),estimated_cardinality), select_list(std::move(select_list)) {
+PhysicalUnnest::PhysicalUnnest(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
+                               idx_t estimated_cardinality, PhysicalOperatorType type)
+    : PhysicalOperator(type, move(types), estimated_cardinality), select_list(std::move(select_list)) {
 
 	D_ASSERT(this->select_list.size() > 0);
 }

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -24,9 +24,10 @@ public:
 
 PhysicalTableScan::PhysicalTableScan(vector<LogicalType> types, TableFunction function_p,
                                      unique_ptr<FunctionData> bind_data_p, vector<column_t> column_ids_p,
-                                     vector<string> names_p, unique_ptr<TableFilterSet> table_filters_p, idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::TABLE_SCAN, move(types),estimated_cardinality), function(move(function_p)),
-      bind_data(move(bind_data_p)), column_ids(move(column_ids_p)), names(move(names_p)),
+                                     vector<string> names_p, unique_ptr<TableFilterSet> table_filters_p,
+                                     idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::TABLE_SCAN, move(types), estimated_cardinality),
+      function(move(function_p)), bind_data(move(bind_data_p)), column_ids(move(column_ids_p)), names(move(names_p)),
       table_filters(move(table_filters_p)) {
 }
 

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -24,8 +24,8 @@ public:
 
 PhysicalTableScan::PhysicalTableScan(vector<LogicalType> types, TableFunction function_p,
                                      unique_ptr<FunctionData> bind_data_p, vector<column_t> column_ids_p,
-                                     vector<string> names_p, unique_ptr<TableFilterSet> table_filters_p)
-    : PhysicalOperator(PhysicalOperatorType::TABLE_SCAN, move(types)), function(move(function_p)),
+                                     vector<string> names_p, unique_ptr<TableFilterSet> table_filters_p, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::TABLE_SCAN, move(types),estimated_cardinality), function(move(function_p)),
       bind_data(move(bind_data_p)), column_ids(move(column_ids_p)), names(move(names_p)),
       table_filters(move(table_filters_p)) {
 }

--- a/src/execution/operator/schema/physical_create_table.cpp
+++ b/src/execution/operator/schema/physical_create_table.cpp
@@ -9,7 +9,8 @@ namespace duckdb {
 
 PhysicalCreateTable::PhysicalCreateTable(LogicalOperator &op, SchemaCatalogEntry *schema,
                                          unique_ptr<BoundCreateTableInfo> info, idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::CREATE_TABLE, op.types,estimated_cardinality), schema(schema), info(move(info)) {
+    : PhysicalOperator(PhysicalOperatorType::CREATE_TABLE, op.types, estimated_cardinality), schema(schema),
+      info(move(info)) {
 }
 
 void PhysicalCreateTable::GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state) {

--- a/src/execution/operator/schema/physical_create_table.cpp
+++ b/src/execution/operator/schema/physical_create_table.cpp
@@ -8,8 +8,8 @@
 namespace duckdb {
 
 PhysicalCreateTable::PhysicalCreateTable(LogicalOperator &op, SchemaCatalogEntry *schema,
-                                         unique_ptr<BoundCreateTableInfo> info)
-    : PhysicalOperator(PhysicalOperatorType::CREATE_TABLE, op.types), schema(schema), info(move(info)) {
+                                         unique_ptr<BoundCreateTableInfo> info, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::CREATE_TABLE, op.types,estimated_cardinality), schema(schema), info(move(info)) {
 }
 
 void PhysicalCreateTable::GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state) {

--- a/src/execution/operator/schema/physical_create_table_as.cpp
+++ b/src/execution/operator/schema/physical_create_table_as.cpp
@@ -8,7 +8,8 @@ namespace duckdb {
 
 PhysicalCreateTableAs::PhysicalCreateTableAs(LogicalOperator &op, SchemaCatalogEntry *schema,
                                              unique_ptr<BoundCreateTableInfo> info, idx_t estimated_cardinality)
-    : PhysicalSink(PhysicalOperatorType::CREATE_TABLE_AS, op.types,estimated_cardinality), schema(schema), info(move(info)) {
+    : PhysicalSink(PhysicalOperatorType::CREATE_TABLE_AS, op.types, estimated_cardinality), schema(schema),
+      info(move(info)) {
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/schema/physical_create_table_as.cpp
+++ b/src/execution/operator/schema/physical_create_table_as.cpp
@@ -7,8 +7,8 @@
 namespace duckdb {
 
 PhysicalCreateTableAs::PhysicalCreateTableAs(LogicalOperator &op, SchemaCatalogEntry *schema,
-                                             unique_ptr<BoundCreateTableInfo> info)
-    : PhysicalSink(PhysicalOperatorType::CREATE_TABLE_AS, op.types), schema(schema), info(move(info)) {
+                                             unique_ptr<BoundCreateTableInfo> info, idx_t estimated_cardinality)
+    : PhysicalSink(PhysicalOperatorType::CREATE_TABLE_AS, op.types,estimated_cardinality), schema(schema), info(move(info)) {
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/set/physical_recursive_cte.cpp
+++ b/src/execution/operator/set/physical_recursive_cte.cpp
@@ -25,8 +25,8 @@ public:
 };
 
 PhysicalRecursiveCTE::PhysicalRecursiveCTE(vector<LogicalType> types, bool union_all, unique_ptr<PhysicalOperator> top,
-                                           unique_ptr<PhysicalOperator> bottom)
-    : PhysicalOperator(PhysicalOperatorType::RECURSIVE_CTE, move(types)), union_all(union_all) {
+                                           unique_ptr<PhysicalOperator> bottom, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::RECURSIVE_CTE, move(types),estimated_cardinality), union_all(union_all) {
 	children.push_back(move(top));
 	children.push_back(move(bottom));
 }

--- a/src/execution/operator/set/physical_recursive_cte.cpp
+++ b/src/execution/operator/set/physical_recursive_cte.cpp
@@ -26,7 +26,7 @@ public:
 
 PhysicalRecursiveCTE::PhysicalRecursiveCTE(vector<LogicalType> types, bool union_all, unique_ptr<PhysicalOperator> top,
                                            unique_ptr<PhysicalOperator> bottom, idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::RECURSIVE_CTE, move(types),estimated_cardinality), union_all(union_all) {
+    : PhysicalOperator(PhysicalOperatorType::RECURSIVE_CTE, move(types), estimated_cardinality), union_all(union_all) {
 	children.push_back(move(top));
 	children.push_back(move(bottom));
 }

--- a/src/execution/operator/set/physical_union.cpp
+++ b/src/execution/operator/set/physical_union.cpp
@@ -13,7 +13,7 @@ public:
 
 PhysicalUnion::PhysicalUnion(vector<LogicalType> types, unique_ptr<PhysicalOperator> top,
                              unique_ptr<PhysicalOperator> bottom, idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::UNION, move(types),estimated_cardinality) {
+    : PhysicalOperator(PhysicalOperatorType::UNION, move(types), estimated_cardinality) {
 	children.push_back(move(top));
 	children.push_back(move(bottom));
 }

--- a/src/execution/operator/set/physical_union.cpp
+++ b/src/execution/operator/set/physical_union.cpp
@@ -12,8 +12,8 @@ public:
 };
 
 PhysicalUnion::PhysicalUnion(vector<LogicalType> types, unique_ptr<PhysicalOperator> top,
-                             unique_ptr<PhysicalOperator> bottom)
-    : PhysicalOperator(PhysicalOperatorType::UNION, move(types)) {
+                             unique_ptr<PhysicalOperator> bottom, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::UNION, move(types),estimated_cardinality) {
 	children.push_back(move(top));
 	children.push_back(move(bottom));
 }

--- a/src/execution/physical_plan/plan_aggregate.cpp
+++ b/src/execution/physical_plan/plan_aggregate.cpp
@@ -145,11 +145,11 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAggregate 
 			}
 		}
 		if (use_simple_aggregation) {
-			groupby = make_unique_base<PhysicalOperator, PhysicalSimpleAggregate>(op.types, move(op.expressions),
-			                                                                      all_combinable,op.estimated_cardinality);
+			groupby = make_unique_base<PhysicalOperator, PhysicalSimpleAggregate>(
+			    op.types, move(op.expressions), all_combinable, op.estimated_cardinality);
 		} else {
-			groupby =
-			    make_unique_base<PhysicalOperator, PhysicalHashAggregate>(context, op.types, move(op.expressions),op.estimated_cardinality);
+			groupby = make_unique_base<PhysicalOperator, PhysicalHashAggregate>(context, op.types, move(op.expressions),
+			                                                                    op.estimated_cardinality);
 		}
 	} else {
 		// groups! create a GROUP BY aggregator
@@ -157,10 +157,11 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAggregate 
 		vector<idx_t> required_bits;
 		if (CanUsePerfectHashAggregate(context, op, required_bits)) {
 			groupby = make_unique_base<PhysicalOperator, PhysicalPerfectHashAggregate>(
-			    context, op.types, move(op.expressions), move(op.groups), move(op.group_stats), move(required_bits),op.estimated_cardinality);
+			    context, op.types, move(op.expressions), move(op.groups), move(op.group_stats), move(required_bits),
+			    op.estimated_cardinality);
 		} else {
-			groupby = make_unique_base<PhysicalOperator, PhysicalHashAggregate>(context, op.types, move(op.expressions),
-			                                                                    move(op.groups),op.estimated_cardinality);
+			groupby = make_unique_base<PhysicalOperator, PhysicalHashAggregate>(
+			    context, op.types, move(op.expressions), move(op.groups), op.estimated_cardinality);
 		}
 	}
 	groupby->children.push_back(move(plan));
@@ -200,7 +201,7 @@ PhysicalPlanGenerator::ExtractAggregateExpressions(unique_ptr<PhysicalOperator> 
 	if (expressions.empty()) {
 		return child;
 	}
-	auto projection = make_unique<PhysicalProjection>(move(types), move(expressions),child->estimated_cardinality);
+	auto projection = make_unique<PhysicalProjection>(move(types), move(expressions), child->estimated_cardinality);
 	projection->children.push_back(move(child));
 	return move(projection);
 }

--- a/src/execution/physical_plan/plan_aggregate.cpp
+++ b/src/execution/physical_plan/plan_aggregate.cpp
@@ -146,10 +146,10 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAggregate 
 		}
 		if (use_simple_aggregation) {
 			groupby = make_unique_base<PhysicalOperator, PhysicalSimpleAggregate>(op.types, move(op.expressions),
-			                                                                      all_combinable);
+			                                                                      all_combinable,op.estimated_cardinality);
 		} else {
 			groupby =
-			    make_unique_base<PhysicalOperator, PhysicalHashAggregate>(context, op.types, move(op.expressions));
+			    make_unique_base<PhysicalOperator, PhysicalHashAggregate>(context, op.types, move(op.expressions),op.estimated_cardinality);
 		}
 	} else {
 		// groups! create a GROUP BY aggregator
@@ -157,10 +157,10 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAggregate 
 		vector<idx_t> required_bits;
 		if (CanUsePerfectHashAggregate(context, op, required_bits)) {
 			groupby = make_unique_base<PhysicalOperator, PhysicalPerfectHashAggregate>(
-			    context, op.types, move(op.expressions), move(op.groups), move(op.group_stats), move(required_bits));
+			    context, op.types, move(op.expressions), move(op.groups), move(op.group_stats), move(required_bits),op.estimated_cardinality);
 		} else {
 			groupby = make_unique_base<PhysicalOperator, PhysicalHashAggregate>(context, op.types, move(op.expressions),
-			                                                                    move(op.groups));
+			                                                                    move(op.groups),op.estimated_cardinality);
 		}
 	}
 	groupby->children.push_back(move(plan));
@@ -200,7 +200,7 @@ PhysicalPlanGenerator::ExtractAggregateExpressions(unique_ptr<PhysicalOperator> 
 	if (expressions.empty()) {
 		return child;
 	}
-	auto projection = make_unique<PhysicalProjection>(move(types), move(expressions));
+	auto projection = make_unique<PhysicalProjection>(move(types), move(expressions),child->estimated_cardinality);
 	projection->children.push_back(move(child));
 	return move(projection);
 }

--- a/src/execution/physical_plan/plan_any_join.cpp
+++ b/src/execution/physical_plan/plan_any_join.cpp
@@ -13,7 +13,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAnyJoin &o
 	auto right = CreatePlan(*op.children[1]);
 
 	// create the blockwise NL join
-	return make_unique<PhysicalBlockwiseNLJoin>(op, move(left), move(right), move(op.condition), op.join_type);
+	return make_unique<PhysicalBlockwiseNLJoin>(op, move(left), move(right), move(op.condition), op.join_type,op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_any_join.cpp
+++ b/src/execution/physical_plan/plan_any_join.cpp
@@ -13,7 +13,8 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAnyJoin &o
 	auto right = CreatePlan(*op.children[1]);
 
 	// create the blockwise NL join
-	return make_unique<PhysicalBlockwiseNLJoin>(op, move(left), move(right), move(op.condition), op.join_type,op.estimated_cardinality);
+	return make_unique<PhysicalBlockwiseNLJoin>(op, move(left), move(right), move(op.condition), op.join_type,
+	                                            op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_chunk_get.cpp
+++ b/src/execution/physical_plan/plan_chunk_get.cpp
@@ -9,7 +9,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalChunkGet &
 	D_ASSERT(op.collection);
 
 	// create a PhysicalChunkScan pointing towards the owned collection
-	auto chunk_scan = make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN);
+	auto chunk_scan = make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN,op.estimated_cardinality);
 	chunk_scan->owned_collection = move(op.collection);
 	chunk_scan->collection = chunk_scan->owned_collection.get();
 	return move(chunk_scan);

--- a/src/execution/physical_plan/plan_chunk_get.cpp
+++ b/src/execution/physical_plan/plan_chunk_get.cpp
@@ -9,7 +9,8 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalChunkGet &
 	D_ASSERT(op.collection);
 
 	// create a PhysicalChunkScan pointing towards the owned collection
-	auto chunk_scan = make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN,op.estimated_cardinality);
+	auto chunk_scan =
+	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN, op.estimated_cardinality);
 	chunk_scan->owned_collection = move(op.collection);
 	chunk_scan->collection = chunk_scan->owned_collection.get();
 	return move(chunk_scan);

--- a/src/execution/physical_plan/plan_comparison_join.cpp
+++ b/src/execution/physical_plan/plan_comparison_join.cpp
@@ -74,7 +74,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalComparison
 
 	if (op.conditions.empty()) {
 		// no conditions: insert a cross product
-		return make_unique<PhysicalCrossProduct>(op.types, move(left), move(right),op.estimated_cardinality);
+		return make_unique<PhysicalCrossProduct>(op.types, move(left), move(right), op.estimated_cardinality);
 	}
 
 	bool has_equality = false;
@@ -104,26 +104,28 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalComparison
 			swap(op.conditions[0].left, op.conditions[0].right);
 			return make_unique<PhysicalIndexJoin>(op, move(right), move(left), move(op.conditions), op.join_type,
 			                                      op.right_projection_map, op.left_projection_map, tbl_scan.column_ids,
-			                                      left_index, false,op.estimated_cardinality);
+			                                      left_index, false, op.estimated_cardinality);
 		}
 		if (right_index && (context.force_index_join || lhs_cardinality < 0.01 * rhs_cardinality)) {
 			auto &tbl_scan = (PhysicalTableScan &)*right;
 			return make_unique<PhysicalIndexJoin>(op, move(left), move(right), move(op.conditions), op.join_type,
 			                                      op.left_projection_map, op.right_projection_map, tbl_scan.column_ids,
-			                                      right_index, true,op.estimated_cardinality);
+			                                      right_index, true, op.estimated_cardinality);
 		}
 		// equality join: use hash join
 		plan = make_unique<PhysicalHashJoin>(op, move(left), move(right), move(op.conditions), op.join_type,
-		                                     op.left_projection_map, op.right_projection_map, move(op.delim_types),op.estimated_cardinality);
+		                                     op.left_projection_map, op.right_projection_map, move(op.delim_types),
+		                                     op.estimated_cardinality);
 	} else {
 		D_ASSERT(!has_null_equal_conditions); // don't support this for anything but hash joins for now
 		if (op.conditions.size() == 1 && !has_inequality) {
 			// range join: use piecewise merge join
-			plan =
-			    make_unique<PhysicalPiecewiseMergeJoin>(op, move(left), move(right), move(op.conditions), op.join_type,op.estimated_cardinality);
+			plan = make_unique<PhysicalPiecewiseMergeJoin>(op, move(left), move(right), move(op.conditions),
+			                                               op.join_type, op.estimated_cardinality);
 		} else {
 			// inequality join: use nested loop
-			plan = make_unique<PhysicalNestedLoopJoin>(op, move(left), move(right), move(op.conditions), op.join_type,op.estimated_cardinality);
+			plan = make_unique<PhysicalNestedLoopJoin>(op, move(left), move(right), move(op.conditions), op.join_type,
+			                                           op.estimated_cardinality);
 		}
 	}
 	return plan;

--- a/src/execution/physical_plan/plan_comparison_join.cpp
+++ b/src/execution/physical_plan/plan_comparison_join.cpp
@@ -74,7 +74,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalComparison
 
 	if (op.conditions.empty()) {
 		// no conditions: insert a cross product
-		return make_unique<PhysicalCrossProduct>(op.types, move(left), move(right));
+		return make_unique<PhysicalCrossProduct>(op.types, move(left), move(right),op.estimated_cardinality);
 	}
 
 	bool has_equality = false;
@@ -104,26 +104,26 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalComparison
 			swap(op.conditions[0].left, op.conditions[0].right);
 			return make_unique<PhysicalIndexJoin>(op, move(right), move(left), move(op.conditions), op.join_type,
 			                                      op.right_projection_map, op.left_projection_map, tbl_scan.column_ids,
-			                                      left_index, false);
+			                                      left_index, false,op.estimated_cardinality);
 		}
 		if (right_index && (context.force_index_join || lhs_cardinality < 0.01 * rhs_cardinality)) {
 			auto &tbl_scan = (PhysicalTableScan &)*right;
 			return make_unique<PhysicalIndexJoin>(op, move(left), move(right), move(op.conditions), op.join_type,
 			                                      op.left_projection_map, op.right_projection_map, tbl_scan.column_ids,
-			                                      right_index, true);
+			                                      right_index, true,op.estimated_cardinality);
 		}
 		// equality join: use hash join
 		plan = make_unique<PhysicalHashJoin>(op, move(left), move(right), move(op.conditions), op.join_type,
-		                                     op.left_projection_map, op.right_projection_map, move(op.delim_types));
+		                                     op.left_projection_map, op.right_projection_map, move(op.delim_types),op.estimated_cardinality);
 	} else {
 		D_ASSERT(!has_null_equal_conditions); // don't support this for anything but hash joins for now
 		if (op.conditions.size() == 1 && !has_inequality) {
 			// range join: use piecewise merge join
 			plan =
-			    make_unique<PhysicalPiecewiseMergeJoin>(op, move(left), move(right), move(op.conditions), op.join_type);
+			    make_unique<PhysicalPiecewiseMergeJoin>(op, move(left), move(right), move(op.conditions), op.join_type,op.estimated_cardinality);
 		} else {
 			// inequality join: use nested loop
-			plan = make_unique<PhysicalNestedLoopJoin>(op, move(left), move(right), move(op.conditions), op.join_type);
+			plan = make_unique<PhysicalNestedLoopJoin>(op, move(left), move(right), move(op.conditions), op.join_type,op.estimated_cardinality);
 		}
 	}
 	return plan;

--- a/src/execution/physical_plan/plan_copy_to_file.cpp
+++ b/src/execution/physical_plan/plan_copy_to_file.cpp
@@ -7,7 +7,7 @@ namespace duckdb {
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile &op) {
 	auto plan = CreatePlan(*op.children[0]);
 	// COPY from select statement to file
-	auto copy = make_unique<PhysicalCopyToFile>(op.types, op.function, move(op.bind_data));
+	auto copy = make_unique<PhysicalCopyToFile>(op.types, op.function, move(op.bind_data),op.estimated_cardinality);
 
 	copy->children.push_back(move(plan));
 	return move(copy);

--- a/src/execution/physical_plan/plan_copy_to_file.cpp
+++ b/src/execution/physical_plan/plan_copy_to_file.cpp
@@ -7,7 +7,7 @@ namespace duckdb {
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile &op) {
 	auto plan = CreatePlan(*op.children[0]);
 	// COPY from select statement to file
-	auto copy = make_unique<PhysicalCopyToFile>(op.types, op.function, move(op.bind_data),op.estimated_cardinality);
+	auto copy = make_unique<PhysicalCopyToFile>(op.types, op.function, move(op.bind_data), op.estimated_cardinality);
 
 	copy->children.push_back(move(plan));
 	return move(copy);

--- a/src/execution/physical_plan/plan_create.cpp
+++ b/src/execution/physical_plan/plan_create.cpp
@@ -12,13 +12,13 @@ namespace duckdb {
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreate &op) {
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_CREATE_SEQUENCE:
-		return make_unique<PhysicalCreateSequence>(unique_ptr_cast<CreateInfo, CreateSequenceInfo>(move(op.info)));
+		return make_unique<PhysicalCreateSequence>(unique_ptr_cast<CreateInfo, CreateSequenceInfo>(move(op.info)),op.estimated_cardinality);
 	case LogicalOperatorType::LOGICAL_CREATE_VIEW:
-		return make_unique<PhysicalCreateView>(unique_ptr_cast<CreateInfo, CreateViewInfo>(move(op.info)));
+		return make_unique<PhysicalCreateView>(unique_ptr_cast<CreateInfo, CreateViewInfo>(move(op.info)),op.estimated_cardinality);
 	case LogicalOperatorType::LOGICAL_CREATE_SCHEMA:
-		return make_unique<PhysicalCreateSchema>(unique_ptr_cast<CreateInfo, CreateSchemaInfo>(move(op.info)));
+		return make_unique<PhysicalCreateSchema>(unique_ptr_cast<CreateInfo, CreateSchemaInfo>(move(op.info)),op.estimated_cardinality);
 	case LogicalOperatorType::LOGICAL_CREATE_MACRO:
-		return make_unique<PhysicalCreateFunction>(unique_ptr_cast<CreateInfo, CreateMacroInfo>(move(op.info)));
+		return make_unique<PhysicalCreateFunction>(unique_ptr_cast<CreateInfo, CreateMacroInfo>(move(op.info)),op.estimated_cardinality);
 	default:
 		throw NotImplementedException("Unimplemented type for logical simple create");
 	}

--- a/src/execution/physical_plan/plan_create.cpp
+++ b/src/execution/physical_plan/plan_create.cpp
@@ -12,13 +12,17 @@ namespace duckdb {
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreate &op) {
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_CREATE_SEQUENCE:
-		return make_unique<PhysicalCreateSequence>(unique_ptr_cast<CreateInfo, CreateSequenceInfo>(move(op.info)),op.estimated_cardinality);
+		return make_unique<PhysicalCreateSequence>(unique_ptr_cast<CreateInfo, CreateSequenceInfo>(move(op.info)),
+		                                           op.estimated_cardinality);
 	case LogicalOperatorType::LOGICAL_CREATE_VIEW:
-		return make_unique<PhysicalCreateView>(unique_ptr_cast<CreateInfo, CreateViewInfo>(move(op.info)),op.estimated_cardinality);
+		return make_unique<PhysicalCreateView>(unique_ptr_cast<CreateInfo, CreateViewInfo>(move(op.info)),
+		                                       op.estimated_cardinality);
 	case LogicalOperatorType::LOGICAL_CREATE_SCHEMA:
-		return make_unique<PhysicalCreateSchema>(unique_ptr_cast<CreateInfo, CreateSchemaInfo>(move(op.info)),op.estimated_cardinality);
+		return make_unique<PhysicalCreateSchema>(unique_ptr_cast<CreateInfo, CreateSchemaInfo>(move(op.info)),
+		                                         op.estimated_cardinality);
 	case LogicalOperatorType::LOGICAL_CREATE_MACRO:
-		return make_unique<PhysicalCreateFunction>(unique_ptr_cast<CreateInfo, CreateMacroInfo>(move(op.info)),op.estimated_cardinality);
+		return make_unique<PhysicalCreateFunction>(unique_ptr_cast<CreateInfo, CreateMacroInfo>(move(op.info)),
+		                                           op.estimated_cardinality);
 	default:
 		throw NotImplementedException("Unimplemented type for logical simple create");
 	}

--- a/src/execution/physical_plan/plan_create_index.cpp
+++ b/src/execution/physical_plan/plan_create_index.cpp
@@ -6,10 +6,10 @@
 namespace duckdb {
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreateIndex &op) {
-	D_ASSERT(op.children.size() == 0);
+	D_ASSERT(op.children.empty());
 	dependencies.insert(&op.table);
 	return make_unique<PhysicalCreateIndex>(op, op.table, op.column_ids, move(op.expressions), move(op.info),
-	                                        move(op.unbound_expressions));
+	                                        move(op.unbound_expressions),op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_create_index.cpp
+++ b/src/execution/physical_plan/plan_create_index.cpp
@@ -9,7 +9,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreateInde
 	D_ASSERT(op.children.empty());
 	dependencies.insert(&op.table);
 	return make_unique<PhysicalCreateIndex>(op, op.table, op.column_ids, move(op.expressions), move(op.info),
-	                                        move(op.unbound_expressions),op.estimated_cardinality);
+	                                        move(op.unbound_expressions), op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_create_table.cpp
+++ b/src/execution/physical_plan/plan_create_table.cpp
@@ -27,12 +27,12 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreateTabl
 	}
 	if (!op.children.empty()) {
 		D_ASSERT(op.children.size() == 1);
-		auto create = make_unique<PhysicalCreateTableAs>(op, op.schema, move(op.info));
+		auto create = make_unique<PhysicalCreateTableAs>(op, op.schema, move(op.info),op.estimated_cardinality);
 		auto plan = CreatePlan(*op.children[0]);
 		create->children.push_back(move(plan));
 		return move(create);
 	} else {
-		return make_unique<PhysicalCreateTable>(op, op.schema, move(op.info));
+		return make_unique<PhysicalCreateTable>(op, op.schema, move(op.info),op.estimated_cardinality);
 	}
 }
 

--- a/src/execution/physical_plan/plan_create_table.cpp
+++ b/src/execution/physical_plan/plan_create_table.cpp
@@ -27,12 +27,12 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreateTabl
 	}
 	if (!op.children.empty()) {
 		D_ASSERT(op.children.size() == 1);
-		auto create = make_unique<PhysicalCreateTableAs>(op, op.schema, move(op.info),op.estimated_cardinality);
+		auto create = make_unique<PhysicalCreateTableAs>(op, op.schema, move(op.info), op.estimated_cardinality);
 		auto plan = CreatePlan(*op.children[0]);
 		create->children.push_back(move(plan));
 		return move(create);
 	} else {
-		return make_unique<PhysicalCreateTable>(op, op.schema, move(op.info),op.estimated_cardinality);
+		return make_unique<PhysicalCreateTable>(op, op.schema, move(op.info), op.estimated_cardinality);
 	}
 }
 

--- a/src/execution/physical_plan/plan_cross_product.cpp
+++ b/src/execution/physical_plan/plan_cross_product.cpp
@@ -9,7 +9,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCrossProdu
 
 	auto left = CreatePlan(*op.children[0]);
 	auto right = CreatePlan(*op.children[1]);
-	return make_unique<PhysicalCrossProduct>(op.types, move(left), move(right));
+	return make_unique<PhysicalCrossProduct>(op.types, move(left), move(right),op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_cross_product.cpp
+++ b/src/execution/physical_plan/plan_cross_product.cpp
@@ -9,7 +9,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCrossProdu
 
 	auto left = CreatePlan(*op.children[0]);
 	auto right = CreatePlan(*op.children[1]);
-	return make_unique<PhysicalCrossProduct>(op.types, move(left), move(right),op.estimated_cardinality);
+	return make_unique<PhysicalCrossProduct>(op.types, move(left), move(right), op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_delete.cpp
+++ b/src/execution/physical_plan/plan_delete.cpp
@@ -17,7 +17,8 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelete &op
 	auto &bound_ref = (BoundReferenceExpression &)*op.expressions[0];
 
 	dependencies.insert(op.table);
-	auto del = make_unique<PhysicalDelete>(op.types, *op.table, *op.table->storage, bound_ref.index,op.estimated_cardinality);
+	auto del =
+	    make_unique<PhysicalDelete>(op.types, *op.table, *op.table->storage, bound_ref.index, op.estimated_cardinality);
 	del->children.push_back(move(plan));
 	return move(del);
 }

--- a/src/execution/physical_plan/plan_delete.cpp
+++ b/src/execution/physical_plan/plan_delete.cpp
@@ -17,7 +17,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelete &op
 	auto &bound_ref = (BoundReferenceExpression &)*op.expressions[0];
 
 	dependencies.insert(op.table);
-	auto del = make_unique<PhysicalDelete>(op.types, *op.table, *op.table->storage, bound_ref.index);
+	auto del = make_unique<PhysicalDelete>(op.types, *op.table, *op.table->storage, bound_ref.index,op.estimated_cardinality);
 	del->children.push_back(move(plan));
 	return move(del);
 }

--- a/src/execution/physical_plan/plan_delim_get.cpp
+++ b/src/execution/physical_plan/plan_delim_get.cpp
@@ -5,10 +5,10 @@
 namespace duckdb {
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelimGet &op) {
-	D_ASSERT(op.children.size() == 0);
+	D_ASSERT(op.children.empty());
 
 	// create a PhysicalChunkScan without an owned_collection, the collection will be added later
-	auto chunk_scan = make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::DELIM_SCAN);
+	auto chunk_scan = make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::DELIM_SCAN,op.estimated_cardinality);
 	return move(chunk_scan);
 }
 

--- a/src/execution/physical_plan/plan_delim_get.cpp
+++ b/src/execution/physical_plan/plan_delim_get.cpp
@@ -8,7 +8,8 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelimGet &
 	D_ASSERT(op.children.empty());
 
 	// create a PhysicalChunkScan without an owned_collection, the collection will be added later
-	auto chunk_scan = make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::DELIM_SCAN,op.estimated_cardinality);
+	auto chunk_scan =
+	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::DELIM_SCAN, op.estimated_cardinality);
 	return move(chunk_scan);
 }
 

--- a/src/execution/physical_plan/plan_delim_join.cpp
+++ b/src/execution/physical_plan/plan_delim_join.cpp
@@ -45,10 +45,10 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelimJoin 
 		distinct_groups.push_back(make_unique<BoundReferenceExpression>(bound_ref.return_type, bound_ref.index));
 	}
 	// now create the duplicate eliminated join
-	auto delim_join = make_unique<PhysicalDelimJoin>(op.types, move(plan), delim_scans,op.estimated_cardinality);
+	auto delim_join = make_unique<PhysicalDelimJoin>(op.types, move(plan), delim_scans, op.estimated_cardinality);
 	// we still have to create the DISTINCT clause that is used to generate the duplicate eliminated chunk
-	delim_join->distinct =
-	    make_unique<PhysicalHashAggregate>(context, delim_types, move(distinct_expressions), move(distinct_groups),op.estimated_cardinality);
+	delim_join->distinct = make_unique<PhysicalHashAggregate>(context, delim_types, move(distinct_expressions),
+	                                                          move(distinct_groups), op.estimated_cardinality);
 	return move(delim_join);
 }
 

--- a/src/execution/physical_plan/plan_delim_join.cpp
+++ b/src/execution/physical_plan/plan_delim_join.cpp
@@ -45,10 +45,10 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelimJoin 
 		distinct_groups.push_back(make_unique<BoundReferenceExpression>(bound_ref.return_type, bound_ref.index));
 	}
 	// now create the duplicate eliminated join
-	auto delim_join = make_unique<PhysicalDelimJoin>(op.types, move(plan), delim_scans);
+	auto delim_join = make_unique<PhysicalDelimJoin>(op.types, move(plan), delim_scans,op.estimated_cardinality);
 	// we still have to create the DISTINCT clause that is used to generate the duplicate eliminated chunk
 	delim_join->distinct =
-	    make_unique<PhysicalHashAggregate>(context, delim_types, move(distinct_expressions), move(distinct_groups));
+	    make_unique<PhysicalHashAggregate>(context, delim_types, move(distinct_expressions), move(distinct_groups),op.estimated_cardinality);
 	return move(delim_join);
 }
 

--- a/src/execution/physical_plan/plan_distinct.cpp
+++ b/src/execution/physical_plan/plan_distinct.cpp
@@ -11,7 +11,7 @@ namespace duckdb {
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreateDistinctOn(unique_ptr<PhysicalOperator> child,
                                                                      vector<unique_ptr<Expression>> distinct_targets) {
 	D_ASSERT(child);
-	D_ASSERT(distinct_targets.size() > 0);
+	D_ASSERT(!distinct_targets.empty());
 
 	auto &types = child->GetTypes();
 	vector<unique_ptr<Expression>> groups, aggregates, projections;
@@ -64,14 +64,14 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreateDistinctOn(unique_ptr<
 	child = ExtractAggregateExpressions(move(child), aggregates, groups);
 
 	// we add a physical hash aggregation in the plan to select the distinct groups
-	auto groupby = make_unique<PhysicalHashAggregate>(context, aggregate_types, move(aggregates), move(groups));
+	auto groupby = make_unique<PhysicalHashAggregate>(context, aggregate_types, move(aggregates), move(groups),child->estimated_cardinality);
 	groupby->children.push_back(move(child));
 	if (!requires_projection) {
 		return move(groupby);
 	}
 
 	// we add a physical projection on top of the aggregation to project all members in the select list
-	auto aggr_projection = make_unique<PhysicalProjection>(types, move(projections));
+	auto aggr_projection = make_unique<PhysicalProjection>(types, move(projections),groupby->estimated_cardinality);
 	aggr_projection->children.push_back(move(groupby));
 	return move(aggr_projection);
 }

--- a/src/execution/physical_plan/plan_distinct.cpp
+++ b/src/execution/physical_plan/plan_distinct.cpp
@@ -64,14 +64,15 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreateDistinctOn(unique_ptr<
 	child = ExtractAggregateExpressions(move(child), aggregates, groups);
 
 	// we add a physical hash aggregation in the plan to select the distinct groups
-	auto groupby = make_unique<PhysicalHashAggregate>(context, aggregate_types, move(aggregates), move(groups),child->estimated_cardinality);
+	auto groupby = make_unique<PhysicalHashAggregate>(context, aggregate_types, move(aggregates), move(groups),
+	                                                  child->estimated_cardinality);
 	groupby->children.push_back(move(child));
 	if (!requires_projection) {
 		return move(groupby);
 	}
 
 	// we add a physical projection on top of the aggregation to project all members in the select list
-	auto aggr_projection = make_unique<PhysicalProjection>(types, move(projections),groupby->estimated_cardinality);
+	auto aggr_projection = make_unique<PhysicalProjection>(types, move(projections), groupby->estimated_cardinality);
 	aggr_projection->children.push_back(move(groupby));
 	return move(aggr_projection);
 }

--- a/src/execution/physical_plan/plan_dummy_scan.cpp
+++ b/src/execution/physical_plan/plan_dummy_scan.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDummyScan &op) {
 	D_ASSERT(op.children.size() == 0);
-	return make_unique<PhysicalDummyScan>(op.types);
+	return make_unique<PhysicalDummyScan>(op.types,op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_dummy_scan.cpp
+++ b/src/execution/physical_plan/plan_dummy_scan.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDummyScan &op) {
 	D_ASSERT(op.children.size() == 0);
-	return make_unique<PhysicalDummyScan>(op.types,op.estimated_cardinality);
+	return make_unique<PhysicalDummyScan>(op.types, op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_empty_result.cpp
+++ b/src/execution/physical_plan/plan_empty_result.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalEmptyResult &op) {
 	D_ASSERT(op.children.size() == 0);
-	return make_unique<PhysicalEmptyResult>(op.types,op.estimated_cardinality);
+	return make_unique<PhysicalEmptyResult>(op.types, op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_empty_result.cpp
+++ b/src/execution/physical_plan/plan_empty_result.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalEmptyResult &op) {
 	D_ASSERT(op.children.size() == 0);
-	return make_unique<PhysicalEmptyResult>(op.types);
+	return make_unique<PhysicalEmptyResult>(op.types,op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_explain.cpp
+++ b/src/execution/physical_plan/plan_explain.cpp
@@ -47,7 +47,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExplain &o
 	collection->Append(chunk);
 
 	// create a chunk scan to output the result
-	auto chunk_scan = make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN);
+	auto chunk_scan = make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN,op.estimated_cardinality);
 	chunk_scan->owned_collection = move(collection);
 	chunk_scan->collection = chunk_scan->owned_collection.get();
 	return move(chunk_scan);

--- a/src/execution/physical_plan/plan_explain.cpp
+++ b/src/execution/physical_plan/plan_explain.cpp
@@ -47,7 +47,8 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExplain &o
 	collection->Append(chunk);
 
 	// create a chunk scan to output the result
-	auto chunk_scan = make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN,op.estimated_cardinality);
+	auto chunk_scan =
+	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN, op.estimated_cardinality);
 	chunk_scan->owned_collection = move(collection);
 	chunk_scan->collection = chunk_scan->owned_collection.get();
 	return move(chunk_scan);

--- a/src/execution/physical_plan/plan_export.cpp
+++ b/src/execution/physical_plan/plan_export.cpp
@@ -5,7 +5,7 @@
 namespace duckdb {
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExport &op) {
-	auto export_node = make_unique<PhysicalExport>(op.types, op.function, move(op.copy_info));
+	auto export_node = make_unique<PhysicalExport>(op.types, op.function, move(op.copy_info),op.estimated_cardinality);
 	// plan the underlying copy statements, if any
 	if (!op.children.empty()) {
 		auto plan = CreatePlan(*op.children[0]);

--- a/src/execution/physical_plan/plan_export.cpp
+++ b/src/execution/physical_plan/plan_export.cpp
@@ -5,7 +5,7 @@
 namespace duckdb {
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExport &op) {
-	auto export_node = make_unique<PhysicalExport>(op.types, op.function, move(op.copy_info),op.estimated_cardinality);
+	auto export_node = make_unique<PhysicalExport>(op.types, op.function, move(op.copy_info), op.estimated_cardinality);
 	// plan the underlying copy statements, if any
 	if (!op.children.empty()) {
 		auto plan = CreatePlan(*op.children[0]);

--- a/src/execution/physical_plan/plan_expression_get.cpp
+++ b/src/execution/physical_plan/plan_expression_get.cpp
@@ -8,7 +8,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExpression
 	D_ASSERT(op.children.size() == 1);
 	auto plan = CreatePlan(*op.children[0]);
 
-	auto expr_scan = make_unique<PhysicalExpressionScan>(op.types, move(op.expressions),op.estimated_cardinality);
+	auto expr_scan = make_unique<PhysicalExpressionScan>(op.types, move(op.expressions), op.estimated_cardinality);
 	expr_scan->children.push_back(move(plan));
 	return move(expr_scan);
 }

--- a/src/execution/physical_plan/plan_expression_get.cpp
+++ b/src/execution/physical_plan/plan_expression_get.cpp
@@ -8,7 +8,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExpression
 	D_ASSERT(op.children.size() == 1);
 	auto plan = CreatePlan(*op.children[0]);
 
-	auto expr_scan = make_unique<PhysicalExpressionScan>(op.types, move(op.expressions));
+	auto expr_scan = make_unique<PhysicalExpressionScan>(op.types, move(op.expressions),op.estimated_cardinality);
 	expr_scan->children.push_back(move(plan));
 	return move(expr_scan);
 }

--- a/src/execution/physical_plan/plan_filter.cpp
+++ b/src/execution/physical_plan/plan_filter.cpp
@@ -16,7 +16,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalFilter &op
 	if (!op.expressions.empty()) {
 		D_ASSERT(plan->types.size() > 0);
 		// create a filter if there is anything to filter
-		auto filter = make_unique<PhysicalFilter>(plan->types, move(op.expressions),op.estimated_cardinality);
+		auto filter = make_unique<PhysicalFilter>(plan->types, move(op.expressions), op.estimated_cardinality);
 		filter->children.push_back(move(plan));
 		plan = move(filter);
 	}
@@ -26,7 +26,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalFilter &op
 		for (idx_t i = 0; i < op.projection_map.size(); i++) {
 			select_list.push_back(make_unique<BoundReferenceExpression>(op.types[i], op.projection_map[i]));
 		}
-		auto proj = make_unique<PhysicalProjection>(op.types, move(select_list),op.estimated_cardinality);
+		auto proj = make_unique<PhysicalProjection>(op.types, move(select_list), op.estimated_cardinality);
 		proj->children.push_back(move(plan));
 		plan = move(proj);
 	}

--- a/src/execution/physical_plan/plan_filter.cpp
+++ b/src/execution/physical_plan/plan_filter.cpp
@@ -16,7 +16,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalFilter &op
 	if (!op.expressions.empty()) {
 		D_ASSERT(plan->types.size() > 0);
 		// create a filter if there is anything to filter
-		auto filter = make_unique<PhysicalFilter>(plan->types, move(op.expressions));
+		auto filter = make_unique<PhysicalFilter>(plan->types, move(op.expressions),op.estimated_cardinality);
 		filter->children.push_back(move(plan));
 		plan = move(filter);
 	}
@@ -26,7 +26,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalFilter &op
 		for (idx_t i = 0; i < op.projection_map.size(); i++) {
 			select_list.push_back(make_unique<BoundReferenceExpression>(op.types[i], op.projection_map[i]));
 		}
-		auto proj = make_unique<PhysicalProjection>(op.types, move(select_list));
+		auto proj = make_unique<PhysicalProjection>(op.types, move(select_list),op.estimated_cardinality);
 		proj->children.push_back(move(plan));
 		plan = move(proj);
 	}

--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -48,7 +48,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 	if (!op.function.projection_pushdown) {
 		// function does not support projection pushdown
 		auto node = make_unique<PhysicalTableScan>(op.returned_types, op.function, move(op.bind_data), op.column_ids,
-		                                           op.names, move(table_filters));
+		                                           op.names, move(table_filters),op.estimated_cardinality);
 		// first check if an additional projection is necessary
 		if (op.column_ids.size() == op.returned_types.size()) {
 			bool projection_necessary = false;
@@ -77,12 +77,12 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 				expressions.push_back(make_unique<BoundReferenceExpression>(type, column_id));
 			}
 		}
-		auto projection = make_unique<PhysicalProjection>(move(types), move(expressions));
+		auto projection = make_unique<PhysicalProjection>(move(types), move(expressions),op.estimated_cardinality);
 		projection->children.push_back(move(node));
 		return move(projection);
 	} else {
 		return make_unique<PhysicalTableScan>(op.types, op.function, move(op.bind_data), op.column_ids, op.names,
-		                                      move(table_filters));
+		                                      move(table_filters),op.estimated_cardinality);
 	}
 }
 

--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -48,7 +48,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 	if (!op.function.projection_pushdown) {
 		// function does not support projection pushdown
 		auto node = make_unique<PhysicalTableScan>(op.returned_types, op.function, move(op.bind_data), op.column_ids,
-		                                           op.names, move(table_filters),op.estimated_cardinality);
+		                                           op.names, move(table_filters), op.estimated_cardinality);
 		// first check if an additional projection is necessary
 		if (op.column_ids.size() == op.returned_types.size()) {
 			bool projection_necessary = false;
@@ -77,12 +77,12 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 				expressions.push_back(make_unique<BoundReferenceExpression>(type, column_id));
 			}
 		}
-		auto projection = make_unique<PhysicalProjection>(move(types), move(expressions),op.estimated_cardinality);
+		auto projection = make_unique<PhysicalProjection>(move(types), move(expressions), op.estimated_cardinality);
 		projection->children.push_back(move(node));
 		return move(projection);
 	} else {
 		return make_unique<PhysicalTableScan>(op.types, op.function, move(op.bind_data), op.column_ids, op.names,
-		                                      move(table_filters),op.estimated_cardinality);
+		                                      move(table_filters), op.estimated_cardinality);
 	}
 }
 

--- a/src/execution/physical_plan/plan_insert.cpp
+++ b/src/execution/physical_plan/plan_insert.cpp
@@ -13,7 +13,8 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalInsert &op
 	}
 
 	dependencies.insert(op.table);
-	auto insert = make_unique<PhysicalInsert>(op.types, op.table, op.column_index_map, move(op.bound_defaults),op.estimated_cardinality);
+	auto insert = make_unique<PhysicalInsert>(op.types, op.table, op.column_index_map, move(op.bound_defaults),
+	                                          op.estimated_cardinality);
 	if (plan) {
 		insert->children.push_back(move(plan));
 	}

--- a/src/execution/physical_plan/plan_insert.cpp
+++ b/src/execution/physical_plan/plan_insert.cpp
@@ -13,7 +13,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalInsert &op
 	}
 
 	dependencies.insert(op.table);
-	auto insert = make_unique<PhysicalInsert>(op.types, op.table, op.column_index_map, move(op.bound_defaults));
+	auto insert = make_unique<PhysicalInsert>(op.types, op.table, op.column_index_map, move(op.bound_defaults),op.estimated_cardinality);
 	if (plan) {
 		insert->children.push_back(move(plan));
 	}

--- a/src/execution/physical_plan/plan_limit.cpp
+++ b/src/execution/physical_plan/plan_limit.cpp
@@ -9,7 +9,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalLimit &op)
 
 	auto plan = CreatePlan(*op.children[0]);
 
-	auto limit = make_unique<PhysicalLimit>(op.types, op.limit_val, op.offset_val, move(op.limit), move(op.offset));
+	auto limit = make_unique<PhysicalLimit>(op.types, op.limit_val, op.offset_val, move(op.limit), move(op.offset),op.estimated_cardinality);
 	limit->children.push_back(move(plan));
 	return move(limit);
 }

--- a/src/execution/physical_plan/plan_limit.cpp
+++ b/src/execution/physical_plan/plan_limit.cpp
@@ -9,7 +9,8 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalLimit &op)
 
 	auto plan = CreatePlan(*op.children[0]);
 
-	auto limit = make_unique<PhysicalLimit>(op.types, op.limit_val, op.offset_val, move(op.limit), move(op.offset),op.estimated_cardinality);
+	auto limit = make_unique<PhysicalLimit>(op.types, op.limit_val, op.offset_val, move(op.limit), move(op.offset),
+	                                        op.estimated_cardinality);
 	limit->children.push_back(move(plan));
 	return move(limit);
 }

--- a/src/execution/physical_plan/plan_order.cpp
+++ b/src/execution/physical_plan/plan_order.cpp
@@ -9,7 +9,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalOrder &op)
 
 	auto plan = CreatePlan(*op.children[0]);
 	if (!op.orders.empty()) {
-		auto order = make_unique<PhysicalOrder>(op.types, move(op.orders),op.estimated_cardinality);
+		auto order = make_unique<PhysicalOrder>(op.types, move(op.orders), op.estimated_cardinality);
 		order->children.push_back(move(plan));
 		plan = move(order);
 	}

--- a/src/execution/physical_plan/plan_order.cpp
+++ b/src/execution/physical_plan/plan_order.cpp
@@ -9,7 +9,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalOrder &op)
 
 	auto plan = CreatePlan(*op.children[0]);
 	if (!op.orders.empty()) {
-		auto order = make_unique<PhysicalOrder>(op.types, move(op.orders));
+		auto order = make_unique<PhysicalOrder>(op.types, move(op.orders),op.estimated_cardinality);
 		order->children.push_back(move(plan));
 		plan = move(order);
 	}

--- a/src/execution/physical_plan/plan_pragma.cpp
+++ b/src/execution/physical_plan/plan_pragma.cpp
@@ -5,7 +5,7 @@
 namespace duckdb {
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalPragma &op) {
-	return make_unique<PhysicalPragma>(op.function, op.info);
+	return make_unique<PhysicalPragma>(op.function, op.info,op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_pragma.cpp
+++ b/src/execution/physical_plan/plan_pragma.cpp
@@ -5,7 +5,7 @@
 namespace duckdb {
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalPragma &op) {
-	return make_unique<PhysicalPragma>(op.function, op.info,op.estimated_cardinality);
+	return make_unique<PhysicalPragma>(op.function, op.info, op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_prepare.cpp
+++ b/src/execution/physical_plan/plan_prepare.cpp
@@ -13,7 +13,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalPrepare &o
 	op.prepared->types = plan->types;
 	op.prepared->plan = move(plan);
 
-	return make_unique<PhysicalPrepare>(op.name, move(op.prepared),op.estimated_cardinality);
+	return make_unique<PhysicalPrepare>(op.name, move(op.prepared), op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_prepare.cpp
+++ b/src/execution/physical_plan/plan_prepare.cpp
@@ -13,7 +13,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalPrepare &o
 	op.prepared->types = plan->types;
 	op.prepared->plan = move(plan);
 
-	return make_unique<PhysicalPrepare>(op.name, move(op.prepared));
+	return make_unique<PhysicalPrepare>(op.name, move(op.prepared),op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_projection.cpp
+++ b/src/execution/physical_plan/plan_projection.cpp
@@ -35,7 +35,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalProjection
 		}
 	}
 
-	auto projection = make_unique<PhysicalProjection>(op.types, move(op.expressions));
+	auto projection = make_unique<PhysicalProjection>(op.types, move(op.expressions),op.estimated_cardinality);
 	projection->children.push_back(move(plan));
 	return move(projection);
 }

--- a/src/execution/physical_plan/plan_projection.cpp
+++ b/src/execution/physical_plan/plan_projection.cpp
@@ -35,7 +35,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalProjection
 		}
 	}
 
-	auto projection = make_unique<PhysicalProjection>(op.types, move(op.expressions),op.estimated_cardinality);
+	auto projection = make_unique<PhysicalProjection>(op.types, move(op.expressions), op.estimated_cardinality);
 	projection->children.push_back(move(plan));
 	return move(projection);
 }

--- a/src/execution/physical_plan/plan_recursive_cte.cpp
+++ b/src/execution/physical_plan/plan_recursive_cte.cpp
@@ -19,7 +19,8 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalRecursiveC
 	auto left = CreatePlan(*op.children[0]);
 	auto right = CreatePlan(*op.children[1]);
 
-	auto cte = make_unique<PhysicalRecursiveCTE>(op.types, op.union_all, move(left), move(right),op.estimated_cardinality);
+	auto cte =
+	    make_unique<PhysicalRecursiveCTE>(op.types, op.union_all, move(left), move(right), op.estimated_cardinality);
 	cte->working_table = working_table;
 
 	return move(cte);
@@ -28,7 +29,8 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalRecursiveC
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCTERef &op) {
 	D_ASSERT(op.children.empty());
 
-	auto chunk_scan = make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::RECURSIVE_CTE_SCAN,op.estimated_cardinality);
+	auto chunk_scan =
+	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::RECURSIVE_CTE_SCAN, op.estimated_cardinality);
 
 	// CreatePlan of a LogicalRecursiveCTE must have happened before.
 	auto cte = rec_ctes.find(op.cte_index);

--- a/src/execution/physical_plan/plan_recursive_cte.cpp
+++ b/src/execution/physical_plan/plan_recursive_cte.cpp
@@ -19,16 +19,16 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalRecursiveC
 	auto left = CreatePlan(*op.children[0]);
 	auto right = CreatePlan(*op.children[1]);
 
-	auto cte = make_unique<PhysicalRecursiveCTE>(op.types, op.union_all, move(left), move(right));
+	auto cte = make_unique<PhysicalRecursiveCTE>(op.types, op.union_all, move(left), move(right),op.estimated_cardinality);
 	cte->working_table = working_table;
 
 	return move(cte);
 }
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCTERef &op) {
-	D_ASSERT(op.children.size() == 0);
+	D_ASSERT(op.children.empty());
 
-	auto chunk_scan = make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::RECURSIVE_CTE_SCAN);
+	auto chunk_scan = make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::RECURSIVE_CTE_SCAN,op.estimated_cardinality);
 
 	// CreatePlan of a LogicalRecursiveCTE must have happened before.
 	auto cte = rec_ctes.find(op.cte_index);

--- a/src/execution/physical_plan/plan_sample.cpp
+++ b/src/execution/physical_plan/plan_sample.cpp
@@ -13,7 +13,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSample &op
 	unique_ptr<PhysicalOperator> sample;
 	switch (op.sample_options->method) {
 	case SampleMethod::RESERVOIR_SAMPLE:
-		sample = make_unique<PhysicalReservoirSample>(op.types, move(op.sample_options));
+		sample = make_unique<PhysicalReservoirSample>(op.types, move(op.sample_options),op.estimated_cardinality);
 		break;
 	case SampleMethod::SYSTEM_SAMPLE:
 	case SampleMethod::BERNOULLI_SAMPLE:
@@ -24,7 +24,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSample &op
 		}
 		sample = make_unique<PhysicalStreamingSample>(op.types, op.sample_options->method,
 		                                              op.sample_options->sample_size.GetValue<double>(),
-		                                              op.sample_options->seed);
+		                                              op.sample_options->seed,op.estimated_cardinality);
 		break;
 	default:
 		throw InternalException("Unimplemented sample method");

--- a/src/execution/physical_plan/plan_sample.cpp
+++ b/src/execution/physical_plan/plan_sample.cpp
@@ -13,7 +13,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSample &op
 	unique_ptr<PhysicalOperator> sample;
 	switch (op.sample_options->method) {
 	case SampleMethod::RESERVOIR_SAMPLE:
-		sample = make_unique<PhysicalReservoirSample>(op.types, move(op.sample_options),op.estimated_cardinality);
+		sample = make_unique<PhysicalReservoirSample>(op.types, move(op.sample_options), op.estimated_cardinality);
 		break;
 	case SampleMethod::SYSTEM_SAMPLE:
 	case SampleMethod::BERNOULLI_SAMPLE:
@@ -24,7 +24,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSample &op
 		}
 		sample = make_unique<PhysicalStreamingSample>(op.types, op.sample_options->method,
 		                                              op.sample_options->sample_size.GetValue<double>(),
-		                                              op.sample_options->seed,op.estimated_cardinality);
+		                                              op.sample_options->seed, op.estimated_cardinality);
 		break;
 	default:
 		throw InternalException("Unimplemented sample method");

--- a/src/execution/physical_plan/plan_set.cpp
+++ b/src/execution/physical_plan/plan_set.cpp
@@ -5,7 +5,7 @@
 namespace duckdb {
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSet &op) {
-	return make_unique<PhysicalSet>(op.name, op.value);
+	return make_unique<PhysicalSet>(op.name, op.value,op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_set.cpp
+++ b/src/execution/physical_plan/plan_set.cpp
@@ -5,7 +5,7 @@
 namespace duckdb {
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSet &op) {
-	return make_unique<PhysicalSet>(op.name, op.value,op.estimated_cardinality);
+	return make_unique<PhysicalSet>(op.name, op.value, op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_set_operation.cpp
+++ b/src/execution/physical_plan/plan_set_operation.cpp
@@ -19,7 +19,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSetOperati
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_UNION:
 		// UNION
-		return make_unique<PhysicalUnion>(op.types, move(left), move(right),op.estimated_cardinality);
+		return make_unique<PhysicalUnion>(op.types, move(left), move(right), op.estimated_cardinality);
 	default: {
 		// EXCEPT/INTERSECT
 		D_ASSERT(op.type == LogicalOperatorType::LOGICAL_EXCEPT || op.type == LogicalOperatorType::LOGICAL_INTERSECT);
@@ -37,7 +37,8 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSetOperati
 		// EXCEPT is ANTI join
 		// INTERSECT is SEMI join
 		JoinType join_type = op.type == LogicalOperatorType::LOGICAL_EXCEPT ? JoinType::ANTI : JoinType::SEMI;
-		return make_unique<PhysicalHashJoin>(op, move(left), move(right), move(conditions), join_type,op.estimated_cardinality);
+		return make_unique<PhysicalHashJoin>(op, move(left), move(right), move(conditions), join_type,
+		                                     op.estimated_cardinality);
 	}
 	}
 }

--- a/src/execution/physical_plan/plan_set_operation.cpp
+++ b/src/execution/physical_plan/plan_set_operation.cpp
@@ -19,7 +19,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSetOperati
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_UNION:
 		// UNION
-		return make_unique<PhysicalUnion>(op.types, move(left), move(right));
+		return make_unique<PhysicalUnion>(op.types, move(left), move(right),op.estimated_cardinality);
 	default: {
 		// EXCEPT/INTERSECT
 		D_ASSERT(op.type == LogicalOperatorType::LOGICAL_EXCEPT || op.type == LogicalOperatorType::LOGICAL_INTERSECT);
@@ -37,7 +37,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSetOperati
 		// EXCEPT is ANTI join
 		// INTERSECT is SEMI join
 		JoinType join_type = op.type == LogicalOperatorType::LOGICAL_EXCEPT ? JoinType::ANTI : JoinType::SEMI;
-		return make_unique<PhysicalHashJoin>(op, move(left), move(right), move(conditions), join_type);
+		return make_unique<PhysicalHashJoin>(op, move(left), move(right), move(conditions), join_type,op.estimated_cardinality);
 	}
 	}
 }

--- a/src/execution/physical_plan/plan_show_select.cpp
+++ b/src/execution/physical_plan/plan_show_select.cpp
@@ -37,7 +37,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalShow &op) 
 	collection->Append(output);
 
 	// create a chunk scan to output the result
-	auto chunk_scan = make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN);
+	auto chunk_scan = make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN,op.estimated_cardinality);
 	chunk_scan->owned_collection = move(collection);
 	chunk_scan->collection = chunk_scan->owned_collection.get();
 	return move(chunk_scan);

--- a/src/execution/physical_plan/plan_show_select.cpp
+++ b/src/execution/physical_plan/plan_show_select.cpp
@@ -37,7 +37,8 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalShow &op) 
 	collection->Append(output);
 
 	// create a chunk scan to output the result
-	auto chunk_scan = make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN,op.estimated_cardinality);
+	auto chunk_scan =
+	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN, op.estimated_cardinality);
 	chunk_scan->owned_collection = move(collection);
 	chunk_scan->collection = chunk_scan->owned_collection.get();
 	return move(chunk_scan);

--- a/src/execution/physical_plan/plan_simple.cpp
+++ b/src/execution/physical_plan/plan_simple.cpp
@@ -15,13 +15,16 @@ namespace duckdb {
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSimple &op) {
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_ALTER:
-		return make_unique<PhysicalAlter>(unique_ptr_cast<ParseInfo, AlterInfo>(move(op.info)),op.estimated_cardinality);
+		return make_unique<PhysicalAlter>(unique_ptr_cast<ParseInfo, AlterInfo>(move(op.info)),
+		                                  op.estimated_cardinality);
 	case LogicalOperatorType::LOGICAL_DROP:
-		return make_unique<PhysicalDrop>(unique_ptr_cast<ParseInfo, DropInfo>(move(op.info)),op.estimated_cardinality);
+		return make_unique<PhysicalDrop>(unique_ptr_cast<ParseInfo, DropInfo>(move(op.info)), op.estimated_cardinality);
 	case LogicalOperatorType::LOGICAL_TRANSACTION:
-		return make_unique<PhysicalTransaction>(unique_ptr_cast<ParseInfo, TransactionInfo>(move(op.info)),op.estimated_cardinality);
+		return make_unique<PhysicalTransaction>(unique_ptr_cast<ParseInfo, TransactionInfo>(move(op.info)),
+		                                        op.estimated_cardinality);
 	case LogicalOperatorType::LOGICAL_VACUUM:
-		return make_unique<PhysicalVacuum>(unique_ptr_cast<ParseInfo, VacuumInfo>(move(op.info)),op.estimated_cardinality);
+		return make_unique<PhysicalVacuum>(unique_ptr_cast<ParseInfo, VacuumInfo>(move(op.info)),
+		                                   op.estimated_cardinality);
 	default:
 		throw NotImplementedException("Unimplemented type for logical simple operator");
 	}

--- a/src/execution/physical_plan/plan_simple.cpp
+++ b/src/execution/physical_plan/plan_simple.cpp
@@ -15,13 +15,13 @@ namespace duckdb {
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSimple &op) {
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_ALTER:
-		return make_unique<PhysicalAlter>(unique_ptr_cast<ParseInfo, AlterInfo>(move(op.info)));
+		return make_unique<PhysicalAlter>(unique_ptr_cast<ParseInfo, AlterInfo>(move(op.info)),op.estimated_cardinality);
 	case LogicalOperatorType::LOGICAL_DROP:
-		return make_unique<PhysicalDrop>(unique_ptr_cast<ParseInfo, DropInfo>(move(op.info)));
+		return make_unique<PhysicalDrop>(unique_ptr_cast<ParseInfo, DropInfo>(move(op.info)),op.estimated_cardinality);
 	case LogicalOperatorType::LOGICAL_TRANSACTION:
-		return make_unique<PhysicalTransaction>(unique_ptr_cast<ParseInfo, TransactionInfo>(move(op.info)));
+		return make_unique<PhysicalTransaction>(unique_ptr_cast<ParseInfo, TransactionInfo>(move(op.info)),op.estimated_cardinality);
 	case LogicalOperatorType::LOGICAL_VACUUM:
-		return make_unique<PhysicalVacuum>(unique_ptr_cast<ParseInfo, VacuumInfo>(move(op.info)));
+		return make_unique<PhysicalVacuum>(unique_ptr_cast<ParseInfo, VacuumInfo>(move(op.info)),op.estimated_cardinality);
 	default:
 		throw NotImplementedException("Unimplemented type for logical simple operator");
 	}

--- a/src/execution/physical_plan/plan_top_n.cpp
+++ b/src/execution/physical_plan/plan_top_n.cpp
@@ -9,7 +9,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalTopN &op) 
 
 	auto plan = CreatePlan(*op.children[0]);
 
-	auto top_n = make_unique<PhysicalTopN>(op.types, move(op.orders), op.limit, op.offset);
+	auto top_n = make_unique<PhysicalTopN>(op.types, move(op.orders), op.limit, op.offset,op.estimated_cardinality);
 	top_n->children.push_back(move(plan));
 	return move(top_n);
 }

--- a/src/execution/physical_plan/plan_top_n.cpp
+++ b/src/execution/physical_plan/plan_top_n.cpp
@@ -9,7 +9,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalTopN &op) 
 
 	auto plan = CreatePlan(*op.children[0]);
 
-	auto top_n = make_unique<PhysicalTopN>(op.types, move(op.orders), op.limit, op.offset,op.estimated_cardinality);
+	auto top_n = make_unique<PhysicalTopN>(op.types, move(op.orders), op.limit, op.offset, op.estimated_cardinality);
 	top_n->children.push_back(move(plan));
 	return move(top_n);
 }

--- a/src/execution/physical_plan/plan_unnest.cpp
+++ b/src/execution/physical_plan/plan_unnest.cpp
@@ -7,7 +7,7 @@ namespace duckdb {
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalUnnest &op) {
 	D_ASSERT(op.children.size() == 1);
 	auto plan = CreatePlan(*op.children[0]);
-	auto unnest = make_unique<PhysicalUnnest>(op.types, move(op.expressions));
+	auto unnest = make_unique<PhysicalUnnest>(op.types, move(op.expressions),op.estimated_cardinality);
 	unnest->children.push_back(move(plan));
 	return move(unnest);
 }

--- a/src/execution/physical_plan/plan_unnest.cpp
+++ b/src/execution/physical_plan/plan_unnest.cpp
@@ -7,7 +7,7 @@ namespace duckdb {
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalUnnest &op) {
 	D_ASSERT(op.children.size() == 1);
 	auto plan = CreatePlan(*op.children[0]);
-	auto unnest = make_unique<PhysicalUnnest>(op.types, move(op.expressions),op.estimated_cardinality);
+	auto unnest = make_unique<PhysicalUnnest>(op.types, move(op.expressions), op.estimated_cardinality);
 	unnest->children.push_back(move(plan));
 	return move(unnest);
 }

--- a/src/execution/physical_plan/plan_update.cpp
+++ b/src/execution/physical_plan/plan_update.cpp
@@ -12,7 +12,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalUpdate &op
 
 	dependencies.insert(op.table);
 	auto update = make_unique<PhysicalUpdate>(op.types, *op.table, *op.table->storage, op.columns, move(op.expressions),
-	                                          move(op.bound_defaults),op.estimated_cardinality);
+	                                          move(op.bound_defaults), op.estimated_cardinality);
 	update->is_index_update = op.is_index_update;
 	update->children.push_back(move(plan));
 	return move(update);

--- a/src/execution/physical_plan/plan_update.cpp
+++ b/src/execution/physical_plan/plan_update.cpp
@@ -12,7 +12,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalUpdate &op
 
 	dependencies.insert(op.table);
 	auto update = make_unique<PhysicalUpdate>(op.types, *op.table, *op.table->storage, op.columns, move(op.expressions),
-	                                          move(op.bound_defaults));
+	                                          move(op.bound_defaults),op.estimated_cardinality);
 	update->is_index_update = op.is_index_update;
 	update->children.push_back(move(plan));
 	return move(update);

--- a/src/execution/physical_plan/plan_window.cpp
+++ b/src/execution/physical_plan/plan_window.cpp
@@ -14,7 +14,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalWindow &op
 	}
 #endif
 
-	auto window = make_unique<PhysicalWindow>(op.types, move(op.expressions));
+	auto window = make_unique<PhysicalWindow>(op.types, move(op.expressions),op.estimated_cardinality);
 	window->children.push_back(move(plan));
 	return move(window);
 }

--- a/src/execution/physical_plan/plan_window.cpp
+++ b/src/execution/physical_plan/plan_window.cpp
@@ -14,7 +14,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalWindow &op
 	}
 #endif
 
-	auto window = make_unique<PhysicalWindow>(op.types, move(op.expressions),op.estimated_cardinality);
+	auto window = make_unique<PhysicalWindow>(op.types, move(op.expressions), op.estimated_cardinality);
 	window->children.push_back(move(plan));
 	return move(window);
 }

--- a/src/execution/physical_plan_generator.cpp
+++ b/src/execution/physical_plan_generator.cpp
@@ -49,7 +49,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(unique_ptr<Logica
 }
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalOperator &op) {
-    op.estimated_cardinality = op.EstimateCardinality(context);
+	op.estimated_cardinality = op.EstimateCardinality(context);
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_GET:
 		return CreatePlan((LogicalGet &)op);

--- a/src/execution/physical_plan_generator.cpp
+++ b/src/execution/physical_plan_generator.cpp
@@ -49,6 +49,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(unique_ptr<Logica
 }
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalOperator &op) {
+    op.estimated_cardinality = op.EstimateCardinality(context);
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_GET:
 		return CreatePlan((LogicalGet &)op);

--- a/src/function/pragma/pragma_functions.cpp
+++ b/src/function/pragma/pragma_functions.cpp
@@ -98,6 +98,18 @@ static void PragmaSetThreads(ClientContext &context, const FunctionParameters &p
 	TaskScheduler::GetScheduler(context).SetThreads(nr_threads);
 }
 
+static void PragmaEnableProgressBar(ClientContext &context, const FunctionParameters &parameters) {
+	context.enable_progress_bar = true;
+}
+static void PragmaSetProgressBarWaitTime(ClientContext &context, const FunctionParameters &parameters) {
+	context.wait_time = parameters.values[0].GetValue<int>();
+	context.enable_progress_bar = true;
+}
+
+static void PragmaDisableProgressBar(ClientContext &context, const FunctionParameters &parameters) {
+	context.enable_progress_bar = false;
+}
+
 static void PragmaEnableVerification(ClientContext &context, const FunctionParameters &parameters) {
 	context.query_verification_enabled = true;
 }
@@ -239,6 +251,11 @@ void PragmaFunctions::RegisterFunction(BuiltinFunctions &set) {
 
 	set.AddFunction(PragmaFunction::PragmaStatement("force_index_join", PragmaEnableForceIndexJoin));
 	set.AddFunction(PragmaFunction::PragmaStatement("force_checkpoint", PragmaForceCheckpoint));
+
+	set.AddFunction(PragmaFunction::PragmaStatement("enable_progress_bar", PragmaEnableProgressBar));
+	set.AddFunction(
+	    PragmaFunction::PragmaAssignment("set_progress_bar_time", PragmaSetProgressBarWaitTime, LogicalType::INTEGER));
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_progress_bar", PragmaDisableProgressBar));
 
 	set.AddFunction(PragmaFunction::PragmaStatement("enable_checkpoint_on_shutdown", PragmaEnableCheckpointOnShutdown));
 	set.AddFunction(

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -66,10 +66,11 @@ static unique_ptr<FunctionOperatorData> TableScanParallelInit(ClientContext &con
 
 static void TableScanFunc(ClientContext &context, const FunctionData *bind_data_p, FunctionOperatorData *operator_state,
                           DataChunk &output) {
-	auto &bind_data = (const TableScanBindData &)*bind_data_p;
+	auto &bind_data = (TableScanBindData &)*bind_data_p;
 	auto &state = (TableScanOperatorData &)*operator_state;
 	auto &transaction = Transaction::GetTransaction(context);
 	bind_data.table->storage->Scan(transaction, output, state.scan_state, state.column_ids);
+	bind_data.chunk_count++;
 }
 
 struct ParallelTableFunctionScanState : public ParallelState {
@@ -102,8 +103,17 @@ bool TableScanParallelStateNext(ClientContext &context, const FunctionData *bind
 
 int TableScanProgress(ClientContext &context, const FunctionData *bind_data_p) {
 	auto &bind_data = (TableScanBindData &)*bind_data_p;
-	bind_data.chunk_count++;
-	return (bind_data.chunk_count*STANDARD_VECTOR_SIZE*100)/bind_data.table->storage->GetTotalRows();
+	if (bind_data.table->storage->GetTotalRows() == 0 || bind_data.table->storage->GetTotalRows() < STANDARD_VECTOR_SIZE){
+	    //! Table is either empty or smaller than a vector size, so it is finished
+	    return 100;
+	}
+	auto percentage = (bind_data.chunk_count*STANDARD_VECTOR_SIZE*100)/bind_data.table->storage->GetTotalRows();
+    if (percentage > 100){
+        //! In case the last chunk has less elements than STANDARD_VECTOR_SIZE, if our percentage is over 100
+        //! It means we finished this table.
+        return 100;
+    }
+    return percentage;
 }
 
 void TableScanDependency(unordered_set<CatalogEntry *> &entries, const FunctionData *bind_data_p) {

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -70,7 +70,10 @@ static void TableScanFunc(ClientContext &context, const FunctionData *bind_data_
 	auto &state = (TableScanOperatorData &)*operator_state;
 	auto &transaction = Transaction::GetTransaction(context);
 	bind_data.table->storage->Scan(transaction, output, state.scan_state, state.column_ids);
-	bind_data.chunk_count++;
+	{
+		std::lock_guard<decltype(bind_data.mutex)> lock(bind_data.mutex);
+		bind_data.chunk_count++;
+	}
 }
 
 struct ParallelTableFunctionScanState : public ParallelState {

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -103,17 +103,18 @@ bool TableScanParallelStateNext(ClientContext &context, const FunctionData *bind
 
 int TableScanProgress(ClientContext &context, const FunctionData *bind_data_p) {
 	auto &bind_data = (TableScanBindData &)*bind_data_p;
-	if (bind_data.table->storage->GetTotalRows() == 0 || bind_data.table->storage->GetTotalRows() < STANDARD_VECTOR_SIZE){
-	    //! Table is either empty or smaller than a vector size, so it is finished
-	    return 100;
+	if (bind_data.table->storage->GetTotalRows() == 0 ||
+	    bind_data.table->storage->GetTotalRows() < STANDARD_VECTOR_SIZE) {
+		//! Table is either empty or smaller than a vector size, so it is finished
+		return 100;
 	}
-	auto percentage = (bind_data.chunk_count*STANDARD_VECTOR_SIZE*100)/bind_data.table->storage->GetTotalRows();
-    if (percentage > 100){
-        //! In case the last chunk has less elements than STANDARD_VECTOR_SIZE, if our percentage is over 100
-        //! It means we finished this table.
-        return 100;
-    }
-    return percentage;
+	auto percentage = (bind_data.chunk_count * STANDARD_VECTOR_SIZE * 100) / bind_data.table->storage->GetTotalRows();
+	if (percentage > 100) {
+		//! In case the last chunk has less elements than STANDARD_VECTOR_SIZE, if our percentage is over 100
+		//! It means we finished this table.
+		return 100;
+	}
+	return percentage;
 }
 
 void TableScanDependency(unordered_set<CatalogEntry *> &entries, const FunctionData *bind_data_p) {

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -71,7 +71,7 @@ static void TableScanFunc(ClientContext &context, const FunctionData *bind_data_
 	auto &transaction = Transaction::GetTransaction(context);
 	bind_data.table->storage->Scan(transaction, output, state.scan_state, state.column_ids);
 	{
-		std::lock_guard<decltype(bind_data.mutex)> lock(bind_data.mutex);
+		lock_guard<mutex> read_lock(bind_data.mutex);
 		bind_data.chunk_count++;
 	}
 }

--- a/src/include/duckdb/common/printer.hpp
+++ b/src/include/duckdb/common/printer.hpp
@@ -18,8 +18,8 @@ public:
 	//! Print the object to stderr
 	static void Print(const string &str);
 	//! Prints Progress
-	static void PrintProgress(int percentage, const char* pbstr, int pbwidth);
+	static void PrintProgress(int percentage, const char *pbstr, int pbwidth);
 	//! Prints an empty line when progress bar is done
-	static void FinishProgressBarPrint(const char* pbstr, int pbwidth);
+	static void FinishProgressBarPrint(const char *pbstr, int pbwidth);
 };
 } // namespace duckdb

--- a/src/include/duckdb/common/printer.hpp
+++ b/src/include/duckdb/common/printer.hpp
@@ -17,5 +17,9 @@ class Printer {
 public:
 	//! Print the object to stderr
 	static void Print(const string &str);
+	//! Prints Progress
+	static void PrintProgress(int percentage, const char* pbstr, int pbwidth);
+	//! Prints an empty line when progress bar is done
+	static void FinishProgressBarPrint(const char* pbstr, int pbwidth);
 };
 } // namespace duckdb

--- a/src/include/duckdb/common/progress_bar.hpp
+++ b/src/include/duckdb/common/progress_bar.hpp
@@ -37,13 +37,15 @@ private:
 	const string PROGRESS_BAR_STRING = "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||";
 	static constexpr const idx_t PROGRESS_BAR_WIDTH = 60;
 	Executor *executor = nullptr;
+#ifndef DUCKDB_NO_THREADS
 	std::thread progress_bar_thread;
-	idx_t show_progress_after;
-	idx_t time_update_bar;
-	int current_percentage = -1;
 	std::atomic<bool> valid_percentage;
 	std::condition_variable c;
 	std::mutex m;
+#endif
+	idx_t show_progress_after;
+	idx_t time_update_bar;
+	int current_percentage = -1;
 	bool stop = false;
 	//! In case our progress bar tries to use a scan operator that is not implemented we don't print anything
 	bool supported = true;

--- a/src/include/duckdb/common/progress_bar.hpp
+++ b/src/include/duckdb/common/progress_bar.hpp
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/progress_bar.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <iostream>
+#include <thread>
+#include <future>
+#include "duckdb.h"
+#include "duckdb/execution/executor.hpp"
+
+namespace duckdb {
+
+class ProgressBar {
+public:
+	explicit ProgressBar(Executor *executor, idx_t show_progress_after, idx_t time_update_bar, bool test = false)
+	    : executor(executor), show_progress_after(show_progress_after), time_update_bar(time_update_bar),
+	      running_test(test) {
+
+	      };
+
+	//! Starts the thread
+	void Start();
+	//! Stops the thread
+	void Stop();
+	//! If all values of the percentage were valid
+	bool IsPercentageValid();
+
+private:
+	string pbstr = "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||";
+	idx_t pbwidth = 60;
+	Executor *executor = nullptr;
+	std::thread progress_bar_thread;
+	std::promise<void> exit_signal;
+	std::future<void> future_obj = exit_signal.get_future();
+	idx_t show_progress_after;
+	idx_t time_update_bar;
+	int cur_percentage = 0;
+	std::atomic<bool> valid_percentage;
+	bool running_test;
+	//! Prints Progress
+	void PrintProgress(int percentage);
+	//! Starts the Progress Bar Thread that prints the progress bar
+	void ProgressBarThread();
+	//! Starts the Progress Bar Thread that updates the cur_percentage (Used for testing)
+	void ProgressBarThreadTest();
+	//! Check if stop was requests
+	bool StopRequested();
+};
+} // namespace duckdb

--- a/src/include/duckdb/common/progress_bar.hpp
+++ b/src/include/duckdb/common/progress_bar.hpp
@@ -34,7 +34,7 @@ public:
 	bool IsPercentageValid();
 
 private:
-    const string PROGRESS_BAR_STRING = "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||";
+	const string PROGRESS_BAR_STRING = "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||";
 	static constexpr const idx_t PROGRESS_BAR_WIDTH = 60;
 	Executor *executor = nullptr;
 	std::thread progress_bar_thread;
@@ -50,12 +50,12 @@ private:
 	//! Starts the Progress Bar Thread that prints the progress bar
 	void ProgressBarThread();
 
-	#ifndef DUCKDB_NO_THREADS
+#ifndef DUCKDB_NO_THREADS
 	template <class DURATION>
 	bool WaitFor(DURATION duration) {
 		std::unique_lock<std::mutex> l(m);
 		return !c.wait_for(l, duration, [this]() { return stop; });
 	}
-    #endif
+#endif
 };
 } // namespace duckdb

--- a/src/include/duckdb/common/progress_bar.hpp
+++ b/src/include/duckdb/common/progress_bar.hpp
@@ -37,12 +37,14 @@ private:
 	Executor *executor = nullptr;
 	std::thread progress_bar_thread;
 	std::promise<void> exit_signal;
-	std::future<void> future_obj = exit_signal.get_future();
+	std::future<void> future_obj;
 	idx_t show_progress_after;
 	idx_t time_update_bar;
 	int cur_percentage = 0;
 	std::atomic<bool> valid_percentage;
 	bool running_test;
+	//! In case our progress bar tries to use a scan operator that is not implemented we don't print anything
+	bool supported = true;
 	//! Prints Progress
 	void PrintProgress(int percentage);
 	//! Starts the Progress Bar Thread that prints the progress bar

--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -52,7 +52,7 @@ public:
 	void Flush(ThreadContext &context);
 
 	//! Returns the progress of the pipelines
-	int GetPipelinesProgress(bool& supported);
+	int GetPipelinesProgress(bool &supported);
 
 private:
 	PhysicalOperator *physical_plan;

--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -52,7 +52,7 @@ public:
 	void Flush(ThreadContext &context);
 
 	//! Returns the progress of the pipelines
-	int GetPipelinesProgress(bool &supported);
+	bool GetPipelinesProgress(int &current_progress);
 
 private:
 	PhysicalOperator *physical_plan;

--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -52,7 +52,7 @@ public:
 	void Flush(ThreadContext &context);
 
 	//! Returns the progress of the pipelines
-	int GetPipelinesProgress();
+	int GetPipelinesProgress(bool& supported);
 
 private:
 	PhysicalOperator *physical_plan;

--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -51,6 +51,9 @@ public:
 	//! Flush a thread context into the client context
 	void Flush(ThreadContext &context);
 
+	//! Returns the progress of the pipelines
+	int GetPipelinesProgress();
+
 private:
 	PhysicalOperator *physical_plan;
 	unique_ptr<PhysicalOperatorState> physical_state;

--- a/src/include/duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp
@@ -20,8 +20,8 @@ class BufferManager;
 //! a hash table to perform the grouping
 class PhysicalHashAggregate : public PhysicalSink {
 public:
-	PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types, vector<unique_ptr<Expression>> expressions, idx_t estimated_cardinality,
-	                      PhysicalOperatorType type = PhysicalOperatorType::HASH_GROUP_BY);
+	PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types, vector<unique_ptr<Expression>> expressions,
+	                      idx_t estimated_cardinality, PhysicalOperatorType type = PhysicalOperatorType::HASH_GROUP_BY);
 	PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types, vector<unique_ptr<Expression>> expressions,
 	                      vector<unique_ptr<Expression>> groups, idx_t estimated_cardinality,
 	                      PhysicalOperatorType type = PhysicalOperatorType::HASH_GROUP_BY);

--- a/src/include/duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp
@@ -20,10 +20,10 @@ class BufferManager;
 //! a hash table to perform the grouping
 class PhysicalHashAggregate : public PhysicalSink {
 public:
-	PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types, vector<unique_ptr<Expression>> expressions,
+	PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types, vector<unique_ptr<Expression>> expressions, idx_t estimated_cardinality,
 	                      PhysicalOperatorType type = PhysicalOperatorType::HASH_GROUP_BY);
 	PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types, vector<unique_ptr<Expression>> expressions,
-	                      vector<unique_ptr<Expression>> groups,
+	                      vector<unique_ptr<Expression>> groups, idx_t estimated_cardinality,
 	                      PhysicalOperatorType type = PhysicalOperatorType::HASH_GROUP_BY);
 
 	//! The groups

--- a/src/include/duckdb/execution/operator/aggregate/physical_perfecthash_aggregate.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_perfecthash_aggregate.hpp
@@ -20,7 +20,7 @@ class PhysicalPerfectHashAggregate : public PhysicalSink {
 public:
 	PhysicalPerfectHashAggregate(ClientContext &context, vector<LogicalType> types,
 	                             vector<unique_ptr<Expression>> aggregates, vector<unique_ptr<Expression>> groups,
-	                             vector<unique_ptr<BaseStatistics>> group_stats, vector<idx_t> required_bits);
+	                             vector<unique_ptr<BaseStatistics>> group_stats, vector<idx_t> required_bits, idx_t estimated_cardinality);
 
 	//! The groups
 	vector<unique_ptr<Expression>> groups;

--- a/src/include/duckdb/execution/operator/aggregate/physical_perfecthash_aggregate.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_perfecthash_aggregate.hpp
@@ -20,7 +20,8 @@ class PhysicalPerfectHashAggregate : public PhysicalSink {
 public:
 	PhysicalPerfectHashAggregate(ClientContext &context, vector<LogicalType> types,
 	                             vector<unique_ptr<Expression>> aggregates, vector<unique_ptr<Expression>> groups,
-	                             vector<unique_ptr<BaseStatistics>> group_stats, vector<idx_t> required_bits, idx_t estimated_cardinality);
+	                             vector<unique_ptr<BaseStatistics>> group_stats, vector<idx_t> required_bits,
+	                             idx_t estimated_cardinality);
 
 	//! The groups
 	vector<unique_ptr<Expression>> groups;

--- a/src/include/duckdb/execution/operator/aggregate/physical_simple_aggregate.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_simple_aggregate.hpp
@@ -15,7 +15,8 @@ namespace duckdb {
 //! without any DISTINCT aggregates
 class PhysicalSimpleAggregate : public PhysicalSink {
 public:
-	PhysicalSimpleAggregate(vector<LogicalType> types, vector<unique_ptr<Expression>> expressions, bool all_combinable, idx_t estimated_cardinality);
+	PhysicalSimpleAggregate(vector<LogicalType> types, vector<unique_ptr<Expression>> expressions, bool all_combinable,
+	                        idx_t estimated_cardinality);
 
 	//! The aggregates that have to be computed
 	vector<unique_ptr<Expression>> aggregates;

--- a/src/include/duckdb/execution/operator/aggregate/physical_simple_aggregate.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_simple_aggregate.hpp
@@ -15,7 +15,7 @@ namespace duckdb {
 //! without any DISTINCT aggregates
 class PhysicalSimpleAggregate : public PhysicalSink {
 public:
-	PhysicalSimpleAggregate(vector<LogicalType> types, vector<unique_ptr<Expression>> expressions, bool all_combinable);
+	PhysicalSimpleAggregate(vector<LogicalType> types, vector<unique_ptr<Expression>> expressions, bool all_combinable, idx_t estimated_cardinality);
 
 	//! The aggregates that have to be computed
 	vector<unique_ptr<Expression>> aggregates;

--- a/src/include/duckdb/execution/operator/aggregate/physical_window.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_window.hpp
@@ -16,7 +16,7 @@ namespace duckdb {
 //! PhysicalWindow implements window functions
 class PhysicalWindow : public PhysicalSink {
 public:
-	PhysicalWindow(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
+	PhysicalWindow(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality,
 	               PhysicalOperatorType type = PhysicalOperatorType::WINDOW);
 
 	void GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;

--- a/src/include/duckdb/execution/operator/filter/physical_filter.hpp
+++ b/src/include/duckdb/execution/operator/filter/physical_filter.hpp
@@ -17,7 +17,7 @@ namespace duckdb {
 //! adds a selection vector to the chunk.
 class PhysicalFilter : public PhysicalOperator {
 public:
-	PhysicalFilter(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list);
+	PhysicalFilter(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality);
 
 	//! The filter expression
 	unique_ptr<Expression> expression;

--- a/src/include/duckdb/execution/operator/helper/physical_execute.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_execute.hpp
@@ -15,7 +15,7 @@ namespace duckdb {
 class PhysicalExecute : public PhysicalOperator {
 public:
 	explicit PhysicalExecute(PhysicalOperator *plan)
-	    : PhysicalOperator(PhysicalOperatorType::EXECUTE, plan->types,-1), plan(plan) {
+	    : PhysicalOperator(PhysicalOperatorType::EXECUTE, plan->types, -1), plan(plan) {
 	}
 
 	PhysicalOperator *plan;

--- a/src/include/duckdb/execution/operator/helper/physical_execute.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_execute.hpp
@@ -15,7 +15,7 @@ namespace duckdb {
 class PhysicalExecute : public PhysicalOperator {
 public:
 	explicit PhysicalExecute(PhysicalOperator *plan)
-	    : PhysicalOperator(PhysicalOperatorType::EXECUTE, plan->types), plan(plan) {
+	    : PhysicalOperator(PhysicalOperatorType::EXECUTE, plan->types,-1), plan(plan) {
 	}
 
 	PhysicalOperator *plan;

--- a/src/include/duckdb/execution/operator/helper/physical_limit.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_limit.hpp
@@ -16,8 +16,8 @@ class PhysicalLimit : public PhysicalOperator {
 public:
 	PhysicalLimit(vector<LogicalType> types, idx_t limit, idx_t offset, unique_ptr<Expression> limit_expression,
 	              unique_ptr<Expression> offset_expression, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::LIMIT, move(types),estimated_cardinality), limit(limit), offset(offset),
-	      limit_expression(move(limit_expression)), offset_expression(move(offset_expression)) {
+	    : PhysicalOperator(PhysicalOperatorType::LIMIT, move(types), estimated_cardinality), limit(limit),
+	      offset(offset), limit_expression(move(limit_expression)), offset_expression(move(offset_expression)) {
 	}
 
 	idx_t limit;

--- a/src/include/duckdb/execution/operator/helper/physical_limit.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_limit.hpp
@@ -15,8 +15,8 @@ namespace duckdb {
 class PhysicalLimit : public PhysicalOperator {
 public:
 	PhysicalLimit(vector<LogicalType> types, idx_t limit, idx_t offset, unique_ptr<Expression> limit_expression,
-	              unique_ptr<Expression> offset_expression)
-	    : PhysicalOperator(PhysicalOperatorType::LIMIT, move(types)), limit(limit), offset(offset),
+	              unique_ptr<Expression> offset_expression, idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::LIMIT, move(types),estimated_cardinality), limit(limit), offset(offset),
 	      limit_expression(move(limit_expression)), offset_expression(move(offset_expression)) {
 	}
 

--- a/src/include/duckdb/execution/operator/helper/physical_pragma.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_pragma.hpp
@@ -18,8 +18,8 @@ namespace duckdb {
 class PhysicalPragma : public PhysicalOperator {
 public:
 	PhysicalPragma(PragmaFunction function_p, PragmaInfo info_p, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::PRAGMA, {LogicalType::BOOLEAN},estimated_cardinality), function(move(function_p)),
-	      info(move(info_p)) {
+	    : PhysicalOperator(PhysicalOperatorType::PRAGMA, {LogicalType::BOOLEAN}, estimated_cardinality),
+	      function(move(function_p)), info(move(info_p)) {
 	}
 
 	//! The pragma function to call

--- a/src/include/duckdb/execution/operator/helper/physical_pragma.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_pragma.hpp
@@ -17,8 +17,8 @@ namespace duckdb {
 //! PhysicalPragma represents the PRAGMA operator
 class PhysicalPragma : public PhysicalOperator {
 public:
-	PhysicalPragma(PragmaFunction function_p, PragmaInfo info_p)
-	    : PhysicalOperator(PhysicalOperatorType::PRAGMA, {LogicalType::BOOLEAN}), function(move(function_p)),
+	PhysicalPragma(PragmaFunction function_p, PragmaInfo info_p, idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::PRAGMA, {LogicalType::BOOLEAN},estimated_cardinality), function(move(function_p)),
 	      info(move(info_p)) {
 	}
 

--- a/src/include/duckdb/execution/operator/helper/physical_prepare.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_prepare.hpp
@@ -17,7 +17,7 @@ namespace duckdb {
 class PhysicalPrepare : public PhysicalOperator {
 public:
 	PhysicalPrepare(string name, shared_ptr<PreparedStatementData> prepared, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::PREPARE, {LogicalType::BOOLEAN},estimated_cardinality), name(name),
+	    : PhysicalOperator(PhysicalOperatorType::PREPARE, {LogicalType::BOOLEAN}, estimated_cardinality), name(name),
 	      prepared(move(prepared)) {
 	}
 

--- a/src/include/duckdb/execution/operator/helper/physical_prepare.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_prepare.hpp
@@ -16,8 +16,8 @@ namespace duckdb {
 
 class PhysicalPrepare : public PhysicalOperator {
 public:
-	PhysicalPrepare(string name, shared_ptr<PreparedStatementData> prepared)
-	    : PhysicalOperator(PhysicalOperatorType::PREPARE, {LogicalType::BOOLEAN}), name(name),
+	PhysicalPrepare(string name, shared_ptr<PreparedStatementData> prepared, idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::PREPARE, {LogicalType::BOOLEAN},estimated_cardinality), name(name),
 	      prepared(move(prepared)) {
 	}
 

--- a/src/include/duckdb/execution/operator/helper/physical_reservoir_sample.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_reservoir_sample.hpp
@@ -17,7 +17,8 @@ namespace duckdb {
 class PhysicalReservoirSample : public PhysicalSink {
 public:
 	PhysicalReservoirSample(vector<LogicalType> types, unique_ptr<SampleOptions> options, idx_t estimated_cardinality)
-	    : PhysicalSink(PhysicalOperatorType::RESERVOIR_SAMPLE, move(types),estimated_cardinality), options(move(options)) {
+	    : PhysicalSink(PhysicalOperatorType::RESERVOIR_SAMPLE, move(types), estimated_cardinality),
+	      options(move(options)) {
 	}
 
 	unique_ptr<SampleOptions> options;

--- a/src/include/duckdb/execution/operator/helper/physical_reservoir_sample.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_reservoir_sample.hpp
@@ -16,8 +16,8 @@ namespace duckdb {
 //! PhysicalReservoirSample represents a sample taken using reservoir sampling, which is a blocking sampling method
 class PhysicalReservoirSample : public PhysicalSink {
 public:
-	PhysicalReservoirSample(vector<LogicalType> types, unique_ptr<SampleOptions> options)
-	    : PhysicalSink(PhysicalOperatorType::RESERVOIR_SAMPLE, move(types)), options(move(options)) {
+	PhysicalReservoirSample(vector<LogicalType> types, unique_ptr<SampleOptions> options, idx_t estimated_cardinality)
+	    : PhysicalSink(PhysicalOperatorType::RESERVOIR_SAMPLE, move(types),estimated_cardinality), options(move(options)) {
 	}
 
 	unique_ptr<SampleOptions> options;

--- a/src/include/duckdb/execution/operator/helper/physical_set.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_set.hpp
@@ -16,8 +16,8 @@ namespace duckdb {
 //! PhysicalSet represents a SET operation (e.g. SET a = 42)
 class PhysicalSet : public PhysicalOperator {
 public:
-	PhysicalSet(std::string name_p, Value value_p)
-	    : PhysicalOperator(PhysicalOperatorType::SET, {LogicalType::BOOLEAN}), name(name_p), value(value_p) {
+	PhysicalSet(std::string name_p, Value value_p, idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::SET, {LogicalType::BOOLEAN},estimated_cardinality), name(name_p), value(value_p) {
 	}
 
 public:

--- a/src/include/duckdb/execution/operator/helper/physical_set.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_set.hpp
@@ -17,7 +17,8 @@ namespace duckdb {
 class PhysicalSet : public PhysicalOperator {
 public:
 	PhysicalSet(std::string name_p, Value value_p, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::SET, {LogicalType::BOOLEAN},estimated_cardinality), name(name_p), value(value_p) {
+	    : PhysicalOperator(PhysicalOperatorType::SET, {LogicalType::BOOLEAN}, estimated_cardinality), name(name_p),
+	      value(value_p) {
 	}
 
 public:

--- a/src/include/duckdb/execution/operator/helper/physical_streaming_sample.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_streaming_sample.hpp
@@ -16,7 +16,8 @@ namespace duckdb {
 //! PhysicalStreamingSample represents a streaming sample using either system or bernoulli sampling
 class PhysicalStreamingSample : public PhysicalOperator {
 public:
-	PhysicalStreamingSample(vector<LogicalType> types, SampleMethod method, double percentage, int64_t seed, idx_t estimated_cardinality);
+	PhysicalStreamingSample(vector<LogicalType> types, SampleMethod method, double percentage, int64_t seed,
+	                        idx_t estimated_cardinality);
 
 	SampleMethod method;
 	double percentage;

--- a/src/include/duckdb/execution/operator/helper/physical_streaming_sample.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_streaming_sample.hpp
@@ -16,7 +16,7 @@ namespace duckdb {
 //! PhysicalStreamingSample represents a streaming sample using either system or bernoulli sampling
 class PhysicalStreamingSample : public PhysicalOperator {
 public:
-	PhysicalStreamingSample(vector<LogicalType> types, SampleMethod method, double percentage, int64_t seed);
+	PhysicalStreamingSample(vector<LogicalType> types, SampleMethod method, double percentage, int64_t seed, idx_t estimated_cardinality);
 
 	SampleMethod method;
 	double percentage;

--- a/src/include/duckdb/execution/operator/helper/physical_transaction.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_transaction.hpp
@@ -16,8 +16,8 @@ namespace duckdb {
 //! PhysicalTransaction represents a transaction operator (e.g. BEGIN or COMMIT)
 class PhysicalTransaction : public PhysicalOperator {
 public:
-	explicit PhysicalTransaction(unique_ptr<TransactionInfo> info)
-	    : PhysicalOperator(PhysicalOperatorType::TRANSACTION, {LogicalType::BOOLEAN}), info(move(info)) {
+	explicit PhysicalTransaction(unique_ptr<TransactionInfo> info, idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::TRANSACTION, {LogicalType::BOOLEAN},estimated_cardinality), info(move(info)) {
 	}
 
 	unique_ptr<TransactionInfo> info;

--- a/src/include/duckdb/execution/operator/helper/physical_transaction.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_transaction.hpp
@@ -17,7 +17,8 @@ namespace duckdb {
 class PhysicalTransaction : public PhysicalOperator {
 public:
 	explicit PhysicalTransaction(unique_ptr<TransactionInfo> info, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::TRANSACTION, {LogicalType::BOOLEAN},estimated_cardinality), info(move(info)) {
+	    : PhysicalOperator(PhysicalOperatorType::TRANSACTION, {LogicalType::BOOLEAN}, estimated_cardinality),
+	      info(move(info)) {
 	}
 
 	unique_ptr<TransactionInfo> info;

--- a/src/include/duckdb/execution/operator/helper/physical_vacuum.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_vacuum.hpp
@@ -17,7 +17,8 @@ namespace duckdb {
 class PhysicalVacuum : public PhysicalOperator {
 public:
 	explicit PhysicalVacuum(unique_ptr<VacuumInfo> info, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::VACUUM, {LogicalType::BOOLEAN},estimated_cardinality), info(move(info)) {
+	    : PhysicalOperator(PhysicalOperatorType::VACUUM, {LogicalType::BOOLEAN}, estimated_cardinality),
+	      info(move(info)) {
 	}
 
 	unique_ptr<VacuumInfo> info;

--- a/src/include/duckdb/execution/operator/helper/physical_vacuum.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_vacuum.hpp
@@ -16,8 +16,8 @@ namespace duckdb {
 //! PhysicalVacuum represents a VACUUM operation (e.g. VACUUM or ANALYZE)
 class PhysicalVacuum : public PhysicalOperator {
 public:
-	explicit PhysicalVacuum(unique_ptr<VacuumInfo> info)
-	    : PhysicalOperator(PhysicalOperatorType::VACUUM, {LogicalType::BOOLEAN}), info(move(info)) {
+	explicit PhysicalVacuum(unique_ptr<VacuumInfo> info, idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::VACUUM, {LogicalType::BOOLEAN},estimated_cardinality), info(move(info)) {
 	}
 
 	unique_ptr<VacuumInfo> info;

--- a/src/include/duckdb/execution/operator/join/physical_blockwise_nl_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_blockwise_nl_join.hpp
@@ -19,7 +19,7 @@ namespace duckdb {
 class PhysicalBlockwiseNLJoin : public PhysicalJoin {
 public:
 	PhysicalBlockwiseNLJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left, unique_ptr<PhysicalOperator> right,
-	                        unique_ptr<Expression> condition, JoinType join_type);
+	                        unique_ptr<Expression> condition, JoinType join_type, idx_t estimated_cardinality);
 
 	unique_ptr<Expression> condition;
 

--- a/src/include/duckdb/execution/operator/join/physical_comparison_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_comparison_join.hpp
@@ -18,7 +18,7 @@ class ChunkCollection;
 class PhysicalComparisonJoin : public PhysicalJoin {
 public:
 	PhysicalComparisonJoin(LogicalOperator &op, PhysicalOperatorType type, vector<JoinCondition> cond,
-	                       JoinType join_type);
+	                       JoinType join_type, idx_t estimated_cardinality);
 
 	vector<JoinCondition> conditions;
 

--- a/src/include/duckdb/execution/operator/join/physical_cross_product.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_cross_product.hpp
@@ -16,7 +16,7 @@ namespace duckdb {
 class PhysicalCrossProduct : public PhysicalSink {
 public:
 	PhysicalCrossProduct(vector<LogicalType> types, unique_ptr<PhysicalOperator> left,
-	                     unique_ptr<PhysicalOperator> right);
+	                     unique_ptr<PhysicalOperator> right, idx_t estimated_cardinality);
 
 public:
 	unique_ptr<GlobalOperatorState> GetGlobalState(ClientContext &context) override;

--- a/src/include/duckdb/execution/operator/join/physical_delim_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_delim_join.hpp
@@ -19,7 +19,7 @@ class PhysicalHashAggregate;
 class PhysicalDelimJoin : public PhysicalSink {
 public:
 	PhysicalDelimJoin(vector<LogicalType> types, unique_ptr<PhysicalOperator> original_join,
-	                  vector<PhysicalOperator *> delim_scans);
+	                  vector<PhysicalOperator *> delim_scans, idx_t estimated_cardinality);
 
 	unique_ptr<PhysicalOperator> join;
 	unique_ptr<PhysicalHashAggregate> distinct;

--- a/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
@@ -21,7 +21,8 @@ class PhysicalHashJoin : public PhysicalComparisonJoin {
 public:
 	PhysicalHashJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left, unique_ptr<PhysicalOperator> right,
 	                 vector<JoinCondition> cond, JoinType join_type, const vector<idx_t> &left_projection_map,
-	                 const vector<idx_t> &right_projection_map, vector<LogicalType> delim_types, idx_t estimated_cardinality);
+	                 const vector<idx_t> &right_projection_map, vector<LogicalType> delim_types,
+	                 idx_t estimated_cardinality);
 	PhysicalHashJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left, unique_ptr<PhysicalOperator> right,
 	                 vector<JoinCondition> cond, JoinType join_type, idx_t estimated_cardinality);
 

--- a/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
@@ -21,9 +21,9 @@ class PhysicalHashJoin : public PhysicalComparisonJoin {
 public:
 	PhysicalHashJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left, unique_ptr<PhysicalOperator> right,
 	                 vector<JoinCondition> cond, JoinType join_type, const vector<idx_t> &left_projection_map,
-	                 const vector<idx_t> &right_projection_map, vector<LogicalType> delim_types);
+	                 const vector<idx_t> &right_projection_map, vector<LogicalType> delim_types, idx_t estimated_cardinality);
 	PhysicalHashJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left, unique_ptr<PhysicalOperator> right,
-	                 vector<JoinCondition> cond, JoinType join_type);
+	                 vector<JoinCondition> cond, JoinType join_type, idx_t estimated_cardinality);
 
 	vector<idx_t> right_projection_map;
 	//! The types of the keys

--- a/src/include/duckdb/execution/operator/join/physical_index_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_index_join.hpp
@@ -21,7 +21,7 @@ class PhysicalIndexJoin : public PhysicalOperator {
 public:
 	PhysicalIndexJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left, unique_ptr<PhysicalOperator> right,
 	                  vector<JoinCondition> cond, JoinType join_type, const vector<idx_t> &left_projection_map,
-	                  vector<idx_t> right_projection_map, vector<column_t> column_ids, Index *index, bool lhs_first);
+	                  vector<idx_t> right_projection_map, vector<column_t> column_ids, Index *index, bool lhs_first, idx_t estimated_cardinality);
 	//! Columns from RHS used in the query
 	vector<column_t> column_ids;
 	//! Columns to be fetched

--- a/src/include/duckdb/execution/operator/join/physical_index_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_index_join.hpp
@@ -21,7 +21,8 @@ class PhysicalIndexJoin : public PhysicalOperator {
 public:
 	PhysicalIndexJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left, unique_ptr<PhysicalOperator> right,
 	                  vector<JoinCondition> cond, JoinType join_type, const vector<idx_t> &left_projection_map,
-	                  vector<idx_t> right_projection_map, vector<column_t> column_ids, Index *index, bool lhs_first, idx_t estimated_cardinality);
+	                  vector<idx_t> right_projection_map, vector<column_t> column_ids, Index *index, bool lhs_first,
+	                  idx_t estimated_cardinality);
 	//! Columns from RHS used in the query
 	vector<column_t> column_ids;
 	//! Columns to be fetched

--- a/src/include/duckdb/execution/operator/join/physical_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_join.hpp
@@ -16,7 +16,7 @@ namespace duckdb {
 //! PhysicalJoin represents the base class of the join operators
 class PhysicalJoin : public PhysicalSink {
 public:
-	PhysicalJoin(LogicalOperator &op, PhysicalOperatorType type, JoinType join_type);
+	PhysicalJoin(LogicalOperator &op, PhysicalOperatorType type, JoinType join_type, idx_t estimated_cardinality);
 
 	JoinType join_type;
 

--- a/src/include/duckdb/execution/operator/join/physical_nested_loop_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_nested_loop_join.hpp
@@ -21,7 +21,7 @@ idx_t nested_loop_comparison(ExpressionType op, Vector &left, Vector &right, sel
 class PhysicalNestedLoopJoin : public PhysicalComparisonJoin {
 public:
 	PhysicalNestedLoopJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left, unique_ptr<PhysicalOperator> right,
-	                       vector<JoinCondition> cond, JoinType join_type);
+	                       vector<JoinCondition> cond, JoinType join_type, idx_t estimated_cardinality);
 
 public:
 	unique_ptr<GlobalOperatorState> GetGlobalState(ClientContext &context) override;

--- a/src/include/duckdb/execution/operator/join/physical_piecewise_merge_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_piecewise_merge_join.hpp
@@ -18,7 +18,8 @@ namespace duckdb {
 class PhysicalPiecewiseMergeJoin : public PhysicalComparisonJoin {
 public:
 	PhysicalPiecewiseMergeJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
-	                           unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type, idx_t estimated_cardinality);
+	                           unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type,
+	                           idx_t estimated_cardinality);
 
 	vector<LogicalType> join_key_types;
 

--- a/src/include/duckdb/execution/operator/join/physical_piecewise_merge_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_piecewise_merge_join.hpp
@@ -18,7 +18,7 @@ namespace duckdb {
 class PhysicalPiecewiseMergeJoin : public PhysicalComparisonJoin {
 public:
 	PhysicalPiecewiseMergeJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
-	                           unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type);
+	                           unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type, idx_t estimated_cardinality);
 
 	vector<LogicalType> join_key_types;
 

--- a/src/include/duckdb/execution/operator/order/physical_order.hpp
+++ b/src/include/duckdb/execution/operator/order/physical_order.hpp
@@ -18,8 +18,8 @@ namespace duckdb {
 //! the data but only add a selection vector.
 class PhysicalOrder : public PhysicalSink {
 public:
-	PhysicalOrder(vector<LogicalType> types, vector<BoundOrderByNode> orders)
-	    : PhysicalSink(PhysicalOperatorType::ORDER_BY, move(types)), orders(move(orders)) {
+	PhysicalOrder(vector<LogicalType> types, vector<BoundOrderByNode> orders, idx_t estimated_cardinality)
+	    : PhysicalSink(PhysicalOperatorType::ORDER_BY, move(types),estimated_cardinality), orders(move(orders)) {
 	}
 
 	vector<BoundOrderByNode> orders;

--- a/src/include/duckdb/execution/operator/order/physical_order.hpp
+++ b/src/include/duckdb/execution/operator/order/physical_order.hpp
@@ -19,7 +19,7 @@ namespace duckdb {
 class PhysicalOrder : public PhysicalSink {
 public:
 	PhysicalOrder(vector<LogicalType> types, vector<BoundOrderByNode> orders, idx_t estimated_cardinality)
-	    : PhysicalSink(PhysicalOperatorType::ORDER_BY, move(types),estimated_cardinality), orders(move(orders)) {
+	    : PhysicalSink(PhysicalOperatorType::ORDER_BY, move(types), estimated_cardinality), orders(move(orders)) {
 	}
 
 	vector<BoundOrderByNode> orders;

--- a/src/include/duckdb/execution/operator/order/physical_top_n.hpp
+++ b/src/include/duckdb/execution/operator/order/physical_top_n.hpp
@@ -18,8 +18,10 @@ namespace duckdb {
 //! the data but only add a selection vector.
 class PhysicalTopN : public PhysicalSink {
 public:
-	PhysicalTopN(vector<LogicalType> types, vector<BoundOrderByNode> orders, idx_t limit, idx_t offset, idx_t estimated_cardinality)
-	    : PhysicalSink(PhysicalOperatorType::TOP_N, move(types),estimated_cardinality), orders(move(orders)), limit(limit), offset(offset) {
+	PhysicalTopN(vector<LogicalType> types, vector<BoundOrderByNode> orders, idx_t limit, idx_t offset,
+	             idx_t estimated_cardinality)
+	    : PhysicalSink(PhysicalOperatorType::TOP_N, move(types), estimated_cardinality), orders(move(orders)),
+	      limit(limit), offset(offset) {
 	}
 
 	vector<BoundOrderByNode> orders;

--- a/src/include/duckdb/execution/operator/order/physical_top_n.hpp
+++ b/src/include/duckdb/execution/operator/order/physical_top_n.hpp
@@ -18,8 +18,8 @@ namespace duckdb {
 //! the data but only add a selection vector.
 class PhysicalTopN : public PhysicalSink {
 public:
-	PhysicalTopN(vector<LogicalType> types, vector<BoundOrderByNode> orders, idx_t limit, idx_t offset)
-	    : PhysicalSink(PhysicalOperatorType::TOP_N, move(types)), orders(move(orders)), limit(limit), offset(offset) {
+	PhysicalTopN(vector<LogicalType> types, vector<BoundOrderByNode> orders, idx_t limit, idx_t offset, idx_t estimated_cardinality)
+	    : PhysicalSink(PhysicalOperatorType::TOP_N, move(types),estimated_cardinality), orders(move(orders)), limit(limit), offset(offset) {
 	}
 
 	vector<BoundOrderByNode> orders;

--- a/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
@@ -17,8 +17,9 @@ namespace duckdb {
 //! Copy the contents of a query into a table
 class PhysicalCopyToFile : public PhysicalSink {
 public:
-	PhysicalCopyToFile(vector<LogicalType> types, CopyFunction function, unique_ptr<FunctionData> bind_data, idx_t estimated_cardinality)
-	    : PhysicalSink(PhysicalOperatorType::COPY_TO_FILE, move(types),estimated_cardinality), function(function),
+	PhysicalCopyToFile(vector<LogicalType> types, CopyFunction function, unique_ptr<FunctionData> bind_data,
+	                   idx_t estimated_cardinality)
+	    : PhysicalSink(PhysicalOperatorType::COPY_TO_FILE, move(types), estimated_cardinality), function(function),
 	      bind_data(move(bind_data)) {
 	}
 

--- a/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
@@ -17,8 +17,8 @@ namespace duckdb {
 //! Copy the contents of a query into a table
 class PhysicalCopyToFile : public PhysicalSink {
 public:
-	PhysicalCopyToFile(vector<LogicalType> types, CopyFunction function, unique_ptr<FunctionData> bind_data)
-	    : PhysicalSink(PhysicalOperatorType::COPY_TO_FILE, move(types)), function(function),
+	PhysicalCopyToFile(vector<LogicalType> types, CopyFunction function, unique_ptr<FunctionData> bind_data, idx_t estimated_cardinality)
+	    : PhysicalSink(PhysicalOperatorType::COPY_TO_FILE, move(types),estimated_cardinality), function(function),
 	      bind_data(move(bind_data)) {
 	}
 

--- a/src/include/duckdb/execution/operator/persistent/physical_delete.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_delete.hpp
@@ -16,9 +16,10 @@ class DataTable;
 //! Physically delete data from a table
 class PhysicalDelete : public PhysicalSink {
 public:
-	PhysicalDelete(vector<LogicalType> types, TableCatalogEntry &tableref, DataTable &table, idx_t row_id_index, idx_t estimated_cardinality)
-	    : PhysicalSink(PhysicalOperatorType::DELETE_OPERATOR, move(types),estimated_cardinality), tableref(tableref), table(table),
-	      row_id_index(row_id_index) {
+	PhysicalDelete(vector<LogicalType> types, TableCatalogEntry &tableref, DataTable &table, idx_t row_id_index,
+	               idx_t estimated_cardinality)
+	    : PhysicalSink(PhysicalOperatorType::DELETE_OPERATOR, move(types), estimated_cardinality), tableref(tableref),
+	      table(table), row_id_index(row_id_index) {
 	}
 
 	TableCatalogEntry &tableref;

--- a/src/include/duckdb/execution/operator/persistent/physical_delete.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_delete.hpp
@@ -16,8 +16,8 @@ class DataTable;
 //! Physically delete data from a table
 class PhysicalDelete : public PhysicalSink {
 public:
-	PhysicalDelete(vector<LogicalType> types, TableCatalogEntry &tableref, DataTable &table, idx_t row_id_index)
-	    : PhysicalSink(PhysicalOperatorType::DELETE_OPERATOR, move(types)), tableref(tableref), table(table),
+	PhysicalDelete(vector<LogicalType> types, TableCatalogEntry &tableref, DataTable &table, idx_t row_id_index, idx_t estimated_cardinality)
+	    : PhysicalSink(PhysicalOperatorType::DELETE_OPERATOR, move(types),estimated_cardinality), tableref(tableref), table(table),
 	      row_id_index(row_id_index) {
 	}
 

--- a/src/include/duckdb/execution/operator/persistent/physical_export.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_export.hpp
@@ -18,8 +18,10 @@ namespace duckdb {
 //! Parse a file from disk using a specified copy function and return the set of chunks retrieved from the file
 class PhysicalExport : public PhysicalOperator {
 public:
-	PhysicalExport(vector<LogicalType> types, CopyFunction function, unique_ptr<CopyInfo> info, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::EXPORT, move(types),estimated_cardinality), function(std::move(function)), info(move(info)) {
+	PhysicalExport(vector<LogicalType> types, CopyFunction function, unique_ptr<CopyInfo> info,
+	               idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::EXPORT, move(types), estimated_cardinality),
+	      function(std::move(function)), info(move(info)) {
 	}
 
 	//! The copy function to use to read the file

--- a/src/include/duckdb/execution/operator/persistent/physical_export.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_export.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <utility>
+
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/function/copy_function.hpp"
 #include "duckdb/parser/parsed_data/copy_info.hpp"
@@ -16,8 +18,8 @@ namespace duckdb {
 //! Parse a file from disk using a specified copy function and return the set of chunks retrieved from the file
 class PhysicalExport : public PhysicalOperator {
 public:
-	PhysicalExport(vector<LogicalType> types, CopyFunction function, unique_ptr<CopyInfo> info)
-	    : PhysicalOperator(PhysicalOperatorType::EXPORT, move(types)), function(function), info(move(info)) {
+	PhysicalExport(vector<LogicalType> types, CopyFunction function, unique_ptr<CopyInfo> info, idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::EXPORT, move(types),estimated_cardinality), function(std::move(function)), info(move(info)) {
 	}
 
 	//! The copy function to use to read the file

--- a/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <utility>
-
 #include "duckdb/execution/physical_sink.hpp"
 
 namespace duckdb {

--- a/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <utility>
+
 #include "duckdb/execution/physical_sink.hpp"
 
 namespace duckdb {
@@ -16,8 +18,8 @@ namespace duckdb {
 class PhysicalInsert : public PhysicalSink {
 public:
 	PhysicalInsert(vector<LogicalType> types, TableCatalogEntry *table, vector<idx_t> column_index_map,
-	               vector<unique_ptr<Expression>> bound_defaults)
-	    : PhysicalSink(PhysicalOperatorType::INSERT, move(types)), column_index_map(column_index_map), table(table),
+	               vector<unique_ptr<Expression>> bound_defaults, idx_t estimated_cardinality)
+	    : PhysicalSink(PhysicalOperatorType::INSERT, move(types),estimated_cardinality), column_index_map(std::move(column_index_map)), table(table),
 	      bound_defaults(move(bound_defaults)) {
 	}
 

--- a/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
@@ -19,8 +19,8 @@ class PhysicalInsert : public PhysicalSink {
 public:
 	PhysicalInsert(vector<LogicalType> types, TableCatalogEntry *table, vector<idx_t> column_index_map,
 	               vector<unique_ptr<Expression>> bound_defaults, idx_t estimated_cardinality)
-	    : PhysicalSink(PhysicalOperatorType::INSERT, move(types),estimated_cardinality), column_index_map(std::move(column_index_map)), table(table),
-	      bound_defaults(move(bound_defaults)) {
+	    : PhysicalSink(PhysicalOperatorType::INSERT, move(types), estimated_cardinality),
+	      column_index_map(std::move(column_index_map)), table(table), bound_defaults(move(bound_defaults)) {
 	}
 
 	vector<idx_t> column_index_map;

--- a/src/include/duckdb/execution/operator/persistent/physical_update.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_update.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <utility>
+
 #include "duckdb/execution/physical_sink.hpp"
 
 namespace duckdb {
@@ -17,8 +19,8 @@ class DataTable;
 class PhysicalUpdate : public PhysicalSink {
 public:
 	PhysicalUpdate(vector<LogicalType> types, TableCatalogEntry &tableref, DataTable &table, vector<column_t> columns,
-	               vector<unique_ptr<Expression>> expressions, vector<unique_ptr<Expression>> bound_defaults)
-	    : PhysicalSink(PhysicalOperatorType::UPDATE, move(types)), tableref(tableref), table(table), columns(columns),
+	               vector<unique_ptr<Expression>> expressions, vector<unique_ptr<Expression>> bound_defaults, idx_t estimated_cardinality)
+	    : PhysicalSink(PhysicalOperatorType::UPDATE, move(types),estimated_cardinality), tableref(tableref), table(table), columns(std::move(columns)),
 	      expressions(move(expressions)), bound_defaults(move(bound_defaults)) {
 	}
 

--- a/src/include/duckdb/execution/operator/persistent/physical_update.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_update.hpp
@@ -19,9 +19,11 @@ class DataTable;
 class PhysicalUpdate : public PhysicalSink {
 public:
 	PhysicalUpdate(vector<LogicalType> types, TableCatalogEntry &tableref, DataTable &table, vector<column_t> columns,
-	               vector<unique_ptr<Expression>> expressions, vector<unique_ptr<Expression>> bound_defaults, idx_t estimated_cardinality)
-	    : PhysicalSink(PhysicalOperatorType::UPDATE, move(types),estimated_cardinality), tableref(tableref), table(table), columns(std::move(columns)),
-	      expressions(move(expressions)), bound_defaults(move(bound_defaults)) {
+	               vector<unique_ptr<Expression>> expressions, vector<unique_ptr<Expression>> bound_defaults,
+	               idx_t estimated_cardinality)
+	    : PhysicalSink(PhysicalOperatorType::UPDATE, move(types), estimated_cardinality), tableref(tableref),
+	      table(table), columns(std::move(columns)), expressions(move(expressions)),
+	      bound_defaults(move(bound_defaults)) {
 	}
 
 	TableCatalogEntry &tableref;

--- a/src/include/duckdb/execution/operator/persistent/physical_update.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_update.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <utility>
-
 #include "duckdb/execution/physical_sink.hpp"
 
 namespace duckdb {

--- a/src/include/duckdb/execution/operator/projection/physical_projection.hpp
+++ b/src/include/duckdb/execution/operator/projection/physical_projection.hpp
@@ -14,8 +14,8 @@ namespace duckdb {
 
 class PhysicalProjection : public PhysicalOperator {
 public:
-	PhysicalProjection(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list)
-	    : PhysicalOperator(PhysicalOperatorType::PROJECTION, move(types)), select_list(move(select_list)) {
+	PhysicalProjection(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::PROJECTION, move(types),estimated_cardinality), select_list(move(select_list)) {
 	}
 
 	vector<unique_ptr<Expression>> select_list;

--- a/src/include/duckdb/execution/operator/projection/physical_projection.hpp
+++ b/src/include/duckdb/execution/operator/projection/physical_projection.hpp
@@ -14,8 +14,10 @@ namespace duckdb {
 
 class PhysicalProjection : public PhysicalOperator {
 public:
-	PhysicalProjection(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::PROJECTION, move(types),estimated_cardinality), select_list(move(select_list)) {
+	PhysicalProjection(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
+	                   idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::PROJECTION, move(types), estimated_cardinality),
+	      select_list(move(select_list)) {
 	}
 
 	vector<unique_ptr<Expression>> select_list;

--- a/src/include/duckdb/execution/operator/projection/physical_unnest.hpp
+++ b/src/include/duckdb/execution/operator/projection/physical_unnest.hpp
@@ -16,7 +16,7 @@ namespace duckdb {
 //! PhysicalWindow implements window functions
 class PhysicalUnnest : public PhysicalOperator {
 public:
-	PhysicalUnnest(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
+	PhysicalUnnest(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,idx_t estimated_cardinality,
 	               PhysicalOperatorType type = PhysicalOperatorType::UNNEST);
 
 	void GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;

--- a/src/include/duckdb/execution/operator/projection/physical_unnest.hpp
+++ b/src/include/duckdb/execution/operator/projection/physical_unnest.hpp
@@ -16,7 +16,7 @@ namespace duckdb {
 //! PhysicalWindow implements window functions
 class PhysicalUnnest : public PhysicalOperator {
 public:
-	PhysicalUnnest(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,idx_t estimated_cardinality,
+	PhysicalUnnest(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality,
 	               PhysicalOperatorType type = PhysicalOperatorType::UNNEST);
 
 	void GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;

--- a/src/include/duckdb/execution/operator/scan/physical_chunk_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_chunk_scan.hpp
@@ -16,7 +16,7 @@ namespace duckdb {
 //! The PhysicalChunkCollectionScan scans a Chunk Collection
 class PhysicalChunkScan : public PhysicalOperator {
 public:
-	PhysicalChunkScan(vector<LogicalType> types, PhysicalOperatorType op_type,idx_t estimated_cardinality)
+	PhysicalChunkScan(vector<LogicalType> types, PhysicalOperatorType op_type, idx_t estimated_cardinality)
 	    : PhysicalOperator(op_type, move(types), estimated_cardinality), collection(nullptr) {
 	}
 

--- a/src/include/duckdb/execution/operator/scan/physical_chunk_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_chunk_scan.hpp
@@ -16,8 +16,8 @@ namespace duckdb {
 //! The PhysicalChunkCollectionScan scans a Chunk Collection
 class PhysicalChunkScan : public PhysicalOperator {
 public:
-	PhysicalChunkScan(vector<LogicalType> types, PhysicalOperatorType op_type)
-	    : PhysicalOperator(op_type, move(types)), collection(nullptr) {
+	PhysicalChunkScan(vector<LogicalType> types, PhysicalOperatorType op_type,idx_t estimated_cardinality)
+	    : PhysicalOperator(op_type, move(types), estimated_cardinality), collection(nullptr) {
 	}
 
 	void GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;

--- a/src/include/duckdb/execution/operator/scan/physical_dummy_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_dummy_scan.hpp
@@ -14,8 +14,8 @@ namespace duckdb {
 
 class PhysicalDummyScan : public PhysicalOperator {
 public:
-	explicit PhysicalDummyScan(vector<LogicalType> types)
-	    : PhysicalOperator(PhysicalOperatorType::DUMMY_SCAN, move(types)) {
+	explicit PhysicalDummyScan(vector<LogicalType> types, idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::DUMMY_SCAN, move(types),estimated_cardinality) {
 	}
 
 public:

--- a/src/include/duckdb/execution/operator/scan/physical_dummy_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_dummy_scan.hpp
@@ -15,7 +15,7 @@ namespace duckdb {
 class PhysicalDummyScan : public PhysicalOperator {
 public:
 	explicit PhysicalDummyScan(vector<LogicalType> types, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::DUMMY_SCAN, move(types),estimated_cardinality) {
+	    : PhysicalOperator(PhysicalOperatorType::DUMMY_SCAN, move(types), estimated_cardinality) {
 	}
 
 public:

--- a/src/include/duckdb/execution/operator/scan/physical_empty_result.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_empty_result.hpp
@@ -15,7 +15,7 @@ namespace duckdb {
 class PhysicalEmptyResult : public PhysicalOperator {
 public:
 	explicit PhysicalEmptyResult(vector<LogicalType> types, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::EMPTY_RESULT, move(types),estimated_cardinality) {
+	    : PhysicalOperator(PhysicalOperatorType::EMPTY_RESULT, move(types), estimated_cardinality) {
 	}
 
 public:

--- a/src/include/duckdb/execution/operator/scan/physical_empty_result.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_empty_result.hpp
@@ -14,8 +14,8 @@ namespace duckdb {
 
 class PhysicalEmptyResult : public PhysicalOperator {
 public:
-	explicit PhysicalEmptyResult(vector<LogicalType> types)
-	    : PhysicalOperator(PhysicalOperatorType::EMPTY_RESULT, move(types)) {
+	explicit PhysicalEmptyResult(vector<LogicalType> types, idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::EMPTY_RESULT, move(types),estimated_cardinality) {
 	}
 
 public:

--- a/src/include/duckdb/execution/operator/scan/physical_expression_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_expression_scan.hpp
@@ -16,8 +16,8 @@ namespace duckdb {
 //! The PhysicalExpressionScan scans a set of expressions
 class PhysicalExpressionScan : public PhysicalOperator {
 public:
-	PhysicalExpressionScan(vector<LogicalType> types, vector<vector<unique_ptr<Expression>>> expressions)
-	    : PhysicalOperator(PhysicalOperatorType::EXPRESSION_SCAN, move(types)), expressions(move(expressions)) {
+	PhysicalExpressionScan(vector<LogicalType> types, vector<vector<unique_ptr<Expression>>> expressions, idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::EXPRESSION_SCAN, move(types),estimated_cardinality), expressions(move(expressions)) {
 	}
 
 	//! The set of expressions to scan

--- a/src/include/duckdb/execution/operator/scan/physical_expression_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_expression_scan.hpp
@@ -16,8 +16,10 @@ namespace duckdb {
 //! The PhysicalExpressionScan scans a set of expressions
 class PhysicalExpressionScan : public PhysicalOperator {
 public:
-	PhysicalExpressionScan(vector<LogicalType> types, vector<vector<unique_ptr<Expression>>> expressions, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::EXPRESSION_SCAN, move(types),estimated_cardinality), expressions(move(expressions)) {
+	PhysicalExpressionScan(vector<LogicalType> types, vector<vector<unique_ptr<Expression>>> expressions,
+	                       idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::EXPRESSION_SCAN, move(types), estimated_cardinality),
+	      expressions(move(expressions)) {
 	}
 
 	//! The set of expressions to scan

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -19,7 +19,7 @@ namespace duckdb {
 class PhysicalTableScan : public PhysicalOperator {
 public:
 	PhysicalTableScan(vector<LogicalType> types, TableFunction function, unique_ptr<FunctionData> bind_data,
-	                  vector<column_t> column_ids, vector<string> names, unique_ptr<TableFilterSet> table_filters);
+	                  vector<column_t> column_ids, vector<string> names, unique_ptr<TableFilterSet> table_filters, idx_t estimated_cardinality);
 
 	//! The table function
 	TableFunction function;

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -19,7 +19,8 @@ namespace duckdb {
 class PhysicalTableScan : public PhysicalOperator {
 public:
 	PhysicalTableScan(vector<LogicalType> types, TableFunction function, unique_ptr<FunctionData> bind_data,
-	                  vector<column_t> column_ids, vector<string> names, unique_ptr<TableFilterSet> table_filters, idx_t estimated_cardinality);
+	                  vector<column_t> column_ids, vector<string> names, unique_ptr<TableFilterSet> table_filters,
+	                  idx_t estimated_cardinality);
 
 	//! The table function
 	TableFunction function;

--- a/src/include/duckdb/execution/operator/schema/physical_alter.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_alter.hpp
@@ -16,8 +16,8 @@ namespace duckdb {
 //! PhysicalAlter represents an ALTER TABLE command
 class PhysicalAlter : public PhysicalOperator {
 public:
-	explicit PhysicalAlter(unique_ptr<AlterInfo> info)
-	    : PhysicalOperator(PhysicalOperatorType::ALTER, {LogicalType::BOOLEAN}), info(move(info)) {
+	explicit PhysicalAlter(unique_ptr<AlterInfo> info, idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::ALTER, {LogicalType::BOOLEAN},estimated_cardinality), info(move(info)) {
 	}
 
 	unique_ptr<AlterInfo> info;

--- a/src/include/duckdb/execution/operator/schema/physical_alter.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_alter.hpp
@@ -17,7 +17,8 @@ namespace duckdb {
 class PhysicalAlter : public PhysicalOperator {
 public:
 	explicit PhysicalAlter(unique_ptr<AlterInfo> info, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::ALTER, {LogicalType::BOOLEAN},estimated_cardinality), info(move(info)) {
+	    : PhysicalOperator(PhysicalOperatorType::ALTER, {LogicalType::BOOLEAN}, estimated_cardinality),
+	      info(move(info)) {
 	}
 
 	unique_ptr<AlterInfo> info;

--- a/src/include/duckdb/execution/operator/schema/physical_create_function.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_function.hpp
@@ -16,8 +16,8 @@ namespace duckdb {
 //! PhysicalCreateFunction represents a CREATE FUNCTION command
 class PhysicalCreateFunction : public PhysicalOperator {
 public:
-	explicit PhysicalCreateFunction(unique_ptr<CreateMacroInfo> info)
-	    : PhysicalOperator(PhysicalOperatorType::CREATE_MACRO, {LogicalType::BIGINT}), info(move(info)) {
+	explicit PhysicalCreateFunction(unique_ptr<CreateMacroInfo> info, idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::CREATE_MACRO, {LogicalType::BIGINT},estimated_cardinality), info(move(info)) {
 	}
 
 	unique_ptr<CreateMacroInfo> info;

--- a/src/include/duckdb/execution/operator/schema/physical_create_function.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_function.hpp
@@ -17,7 +17,8 @@ namespace duckdb {
 class PhysicalCreateFunction : public PhysicalOperator {
 public:
 	explicit PhysicalCreateFunction(unique_ptr<CreateMacroInfo> info, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::CREATE_MACRO, {LogicalType::BIGINT},estimated_cardinality), info(move(info)) {
+	    : PhysicalOperator(PhysicalOperatorType::CREATE_MACRO, {LogicalType::BIGINT}, estimated_cardinality),
+	      info(move(info)) {
 	}
 
 	unique_ptr<CreateMacroInfo> info;

--- a/src/include/duckdb/execution/operator/schema/physical_create_index.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_index.hpp
@@ -23,8 +23,8 @@ class PhysicalCreateIndex : public PhysicalOperator {
 public:
 	PhysicalCreateIndex(LogicalOperator &op, TableCatalogEntry &table, vector<column_t> column_ids,
 	                    vector<unique_ptr<Expression>> expressions, unique_ptr<CreateIndexInfo> info,
-	                    vector<unique_ptr<Expression>> unbinded_expressions)
-	    : PhysicalOperator(PhysicalOperatorType::CREATE_INDEX, op.types), table(table), column_ids(column_ids),
+	                    vector<unique_ptr<Expression>> unbinded_expressions, idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::CREATE_INDEX, op.types,estimated_cardinality), table(table), column_ids(column_ids),
 	      expressions(move(expressions)), info(std::move(info)), unbound_expressions(move(unbinded_expressions)) {
 	}
 

--- a/src/include/duckdb/execution/operator/schema/physical_create_index.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_index.hpp
@@ -24,8 +24,9 @@ public:
 	PhysicalCreateIndex(LogicalOperator &op, TableCatalogEntry &table, vector<column_t> column_ids,
 	                    vector<unique_ptr<Expression>> expressions, unique_ptr<CreateIndexInfo> info,
 	                    vector<unique_ptr<Expression>> unbinded_expressions, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::CREATE_INDEX, op.types,estimated_cardinality), table(table), column_ids(column_ids),
-	      expressions(move(expressions)), info(std::move(info)), unbound_expressions(move(unbinded_expressions)) {
+	    : PhysicalOperator(PhysicalOperatorType::CREATE_INDEX, op.types, estimated_cardinality), table(table),
+	      column_ids(column_ids), expressions(move(expressions)), info(std::move(info)),
+	      unbound_expressions(move(unbinded_expressions)) {
 	}
 
 	//! The table to create the index for

--- a/src/include/duckdb/execution/operator/schema/physical_create_schema.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_schema.hpp
@@ -17,7 +17,8 @@ namespace duckdb {
 class PhysicalCreateSchema : public PhysicalOperator {
 public:
 	explicit PhysicalCreateSchema(unique_ptr<CreateSchemaInfo> info, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::CREATE_SCHEMA, {LogicalType::BIGINT},estimated_cardinality), info(move(info)) {
+	    : PhysicalOperator(PhysicalOperatorType::CREATE_SCHEMA, {LogicalType::BIGINT}, estimated_cardinality),
+	      info(move(info)) {
 	}
 
 	unique_ptr<CreateSchemaInfo> info;

--- a/src/include/duckdb/execution/operator/schema/physical_create_schema.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_schema.hpp
@@ -16,8 +16,8 @@ namespace duckdb {
 //! PhysicalCreateSchema represents a CREATE SCHEMA command
 class PhysicalCreateSchema : public PhysicalOperator {
 public:
-	explicit PhysicalCreateSchema(unique_ptr<CreateSchemaInfo> info)
-	    : PhysicalOperator(PhysicalOperatorType::CREATE_SCHEMA, {LogicalType::BIGINT}), info(move(info)) {
+	explicit PhysicalCreateSchema(unique_ptr<CreateSchemaInfo> info, idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::CREATE_SCHEMA, {LogicalType::BIGINT},estimated_cardinality), info(move(info)) {
 	}
 
 	unique_ptr<CreateSchemaInfo> info;

--- a/src/include/duckdb/execution/operator/schema/physical_create_sequence.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_sequence.hpp
@@ -16,8 +16,8 @@ namespace duckdb {
 //! PhysicalCreateSequence represents a CREATE SEQUENCE command
 class PhysicalCreateSequence : public PhysicalOperator {
 public:
-	explicit PhysicalCreateSequence(unique_ptr<CreateSequenceInfo> info)
-	    : PhysicalOperator(PhysicalOperatorType::CREATE_SEQUENCE, {LogicalType::BIGINT}), info(move(info)) {
+	explicit PhysicalCreateSequence(unique_ptr<CreateSequenceInfo> info, idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::CREATE_SEQUENCE, {LogicalType::BIGINT},estimated_cardinality), info(move(info)) {
 	}
 
 	unique_ptr<CreateSequenceInfo> info;

--- a/src/include/duckdb/execution/operator/schema/physical_create_sequence.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_sequence.hpp
@@ -17,7 +17,8 @@ namespace duckdb {
 class PhysicalCreateSequence : public PhysicalOperator {
 public:
 	explicit PhysicalCreateSequence(unique_ptr<CreateSequenceInfo> info, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::CREATE_SEQUENCE, {LogicalType::BIGINT},estimated_cardinality), info(move(info)) {
+	    : PhysicalOperator(PhysicalOperatorType::CREATE_SEQUENCE, {LogicalType::BIGINT}, estimated_cardinality),
+	      info(move(info)) {
 	}
 
 	unique_ptr<CreateSequenceInfo> info;

--- a/src/include/duckdb/execution/operator/schema/physical_create_table.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_table.hpp
@@ -16,7 +16,8 @@ namespace duckdb {
 //! Physically CREATE TABLE statement
 class PhysicalCreateTable : public PhysicalOperator {
 public:
-	PhysicalCreateTable(LogicalOperator &op, SchemaCatalogEntry *schema, unique_ptr<BoundCreateTableInfo> info, idx_t estimated_cardinality);
+	PhysicalCreateTable(LogicalOperator &op, SchemaCatalogEntry *schema, unique_ptr<BoundCreateTableInfo> info,
+	                    idx_t estimated_cardinality);
 
 	//! Schema to insert to
 	SchemaCatalogEntry *schema;

--- a/src/include/duckdb/execution/operator/schema/physical_create_table.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_table.hpp
@@ -16,7 +16,7 @@ namespace duckdb {
 //! Physically CREATE TABLE statement
 class PhysicalCreateTable : public PhysicalOperator {
 public:
-	PhysicalCreateTable(LogicalOperator &op, SchemaCatalogEntry *schema, unique_ptr<BoundCreateTableInfo> info);
+	PhysicalCreateTable(LogicalOperator &op, SchemaCatalogEntry *schema, unique_ptr<BoundCreateTableInfo> info, idx_t estimated_cardinality);
 
 	//! Schema to insert to
 	SchemaCatalogEntry *schema;

--- a/src/include/duckdb/execution/operator/schema/physical_create_table_as.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_table_as.hpp
@@ -16,7 +16,7 @@ namespace duckdb {
 //! Physically CREATE TABLE AS statement
 class PhysicalCreateTableAs : public PhysicalSink {
 public:
-	PhysicalCreateTableAs(LogicalOperator &op, SchemaCatalogEntry *schema, unique_ptr<BoundCreateTableInfo> info);
+	PhysicalCreateTableAs(LogicalOperator &op, SchemaCatalogEntry *schema, unique_ptr<BoundCreateTableInfo> info, idx_t estimated_cardinality);
 
 	//! Schema to insert to
 	SchemaCatalogEntry *schema;

--- a/src/include/duckdb/execution/operator/schema/physical_create_table_as.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_table_as.hpp
@@ -16,7 +16,8 @@ namespace duckdb {
 //! Physically CREATE TABLE AS statement
 class PhysicalCreateTableAs : public PhysicalSink {
 public:
-	PhysicalCreateTableAs(LogicalOperator &op, SchemaCatalogEntry *schema, unique_ptr<BoundCreateTableInfo> info, idx_t estimated_cardinality);
+	PhysicalCreateTableAs(LogicalOperator &op, SchemaCatalogEntry *schema, unique_ptr<BoundCreateTableInfo> info,
+	                      idx_t estimated_cardinality);
 
 	//! Schema to insert to
 	SchemaCatalogEntry *schema;

--- a/src/include/duckdb/execution/operator/schema/physical_create_view.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_view.hpp
@@ -17,7 +17,8 @@ namespace duckdb {
 class PhysicalCreateView : public PhysicalOperator {
 public:
 	explicit PhysicalCreateView(unique_ptr<CreateViewInfo> info, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::CREATE_VIEW, {LogicalType::BIGINT},estimated_cardinality), info(move(info)) {
+	    : PhysicalOperator(PhysicalOperatorType::CREATE_VIEW, {LogicalType::BIGINT}, estimated_cardinality),
+	      info(move(info)) {
 	}
 
 	unique_ptr<CreateViewInfo> info;

--- a/src/include/duckdb/execution/operator/schema/physical_create_view.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_view.hpp
@@ -16,8 +16,8 @@ namespace duckdb {
 //! PhysicalCreateView represents a CREATE VIEW command
 class PhysicalCreateView : public PhysicalOperator {
 public:
-	explicit PhysicalCreateView(unique_ptr<CreateViewInfo> info)
-	    : PhysicalOperator(PhysicalOperatorType::CREATE_VIEW, {LogicalType::BIGINT}), info(move(info)) {
+	explicit PhysicalCreateView(unique_ptr<CreateViewInfo> info, idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::CREATE_VIEW, {LogicalType::BIGINT},estimated_cardinality), info(move(info)) {
 	}
 
 	unique_ptr<CreateViewInfo> info;

--- a/src/include/duckdb/execution/operator/schema/physical_drop.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_drop.hpp
@@ -17,7 +17,8 @@ namespace duckdb {
 class PhysicalDrop : public PhysicalOperator {
 public:
 	explicit PhysicalDrop(unique_ptr<DropInfo> info, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::DROP, {LogicalType::BOOLEAN},estimated_cardinality), info(move(info)) {
+	    : PhysicalOperator(PhysicalOperatorType::DROP, {LogicalType::BOOLEAN}, estimated_cardinality),
+	      info(move(info)) {
 	}
 
 	unique_ptr<DropInfo> info;

--- a/src/include/duckdb/execution/operator/schema/physical_drop.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_drop.hpp
@@ -16,8 +16,8 @@ namespace duckdb {
 //! PhysicalDrop represents a DROP [...] command
 class PhysicalDrop : public PhysicalOperator {
 public:
-	explicit PhysicalDrop(unique_ptr<DropInfo> info)
-	    : PhysicalOperator(PhysicalOperatorType::DROP, {LogicalType::BOOLEAN}), info(move(info)) {
+	explicit PhysicalDrop(unique_ptr<DropInfo> info, idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::DROP, {LogicalType::BOOLEAN},estimated_cardinality), info(move(info)) {
 	}
 
 	unique_ptr<DropInfo> info;

--- a/src/include/duckdb/execution/operator/set/physical_recursive_cte.hpp
+++ b/src/include/duckdb/execution/operator/set/physical_recursive_cte.hpp
@@ -17,7 +17,7 @@ class Pipeline;
 class PhysicalRecursiveCTE : public PhysicalOperator {
 public:
 	PhysicalRecursiveCTE(vector<LogicalType> types, bool union_all, unique_ptr<PhysicalOperator> top,
-	                     unique_ptr<PhysicalOperator> bottom);
+	                     unique_ptr<PhysicalOperator> bottom, idx_t estimated_cardinality);
 	~PhysicalRecursiveCTE() override;
 
 	bool union_all;

--- a/src/include/duckdb/execution/operator/set/physical_union.hpp
+++ b/src/include/duckdb/execution/operator/set/physical_union.hpp
@@ -13,7 +13,7 @@
 namespace duckdb {
 class PhysicalUnion : public PhysicalOperator {
 public:
-	PhysicalUnion(vector<LogicalType> types, unique_ptr<PhysicalOperator> top, unique_ptr<PhysicalOperator> bottom);
+	PhysicalUnion(vector<LogicalType> types, unique_ptr<PhysicalOperator> top, unique_ptr<PhysicalOperator> bottom, idx_t estimated_cardinality);
 
 public:
 	void GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;

--- a/src/include/duckdb/execution/operator/set/physical_union.hpp
+++ b/src/include/duckdb/execution/operator/set/physical_union.hpp
@@ -13,7 +13,8 @@
 namespace duckdb {
 class PhysicalUnion : public PhysicalOperator {
 public:
-	PhysicalUnion(vector<LogicalType> types, unique_ptr<PhysicalOperator> top, unique_ptr<PhysicalOperator> bottom, idx_t estimated_cardinality);
+	PhysicalUnion(vector<LogicalType> types, unique_ptr<PhysicalOperator> top, unique_ptr<PhysicalOperator> bottom,
+	              idx_t estimated_cardinality);
 
 public:
 	void GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -16,6 +16,7 @@
 #include "duckdb/execution/execution_context.hpp"
 
 #include <functional>
+#include <utility>
 
 namespace duckdb {
 class ExpressionExecutor;
@@ -52,7 +53,7 @@ public:
 */
 class PhysicalOperator {
 public:
-	PhysicalOperator(PhysicalOperatorType type, vector<LogicalType> types) : type(type), types(types) {
+	PhysicalOperator(PhysicalOperatorType type, vector<LogicalType> types, idx_t estimated_cardinality) : type(type), types(std::move(types)), estimated_cardinality(estimated_cardinality) {
 	}
 	virtual ~PhysicalOperator() {
 	}
@@ -63,6 +64,8 @@ public:
 	vector<unique_ptr<PhysicalOperator>> children;
 	//! The types returned by this physical operator
 	vector<LogicalType> types;
+	//! The extimated cardinality of this physical operator
+	idx_t estimated_cardinality;
 
 public:
 	virtual string GetName() const;

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -53,7 +53,8 @@ public:
 */
 class PhysicalOperator {
 public:
-	PhysicalOperator(PhysicalOperatorType type, vector<LogicalType> types, idx_t estimated_cardinality) : type(type), types(std::move(types)), estimated_cardinality(estimated_cardinality) {
+	PhysicalOperator(PhysicalOperatorType type, vector<LogicalType> types, idx_t estimated_cardinality)
+	    : type(type), types(std::move(types)), estimated_cardinality(estimated_cardinality) {
 	}
 	virtual ~PhysicalOperator() {
 	}

--- a/src/include/duckdb/execution/physical_sink.hpp
+++ b/src/include/duckdb/execution/physical_sink.hpp
@@ -28,7 +28,7 @@ public:
 
 class PhysicalSink : public PhysicalOperator {
 public:
-	PhysicalSink(PhysicalOperatorType type, vector<LogicalType> types) : PhysicalOperator(type, move(types)) {
+	PhysicalSink(PhysicalOperatorType type, vector<LogicalType> types, idx_t estimated_cardinality) : PhysicalOperator(type, move(types),estimated_cardinality) {
 	}
 
 	unique_ptr<GlobalOperatorState> sink_state;

--- a/src/include/duckdb/execution/physical_sink.hpp
+++ b/src/include/duckdb/execution/physical_sink.hpp
@@ -28,7 +28,8 @@ public:
 
 class PhysicalSink : public PhysicalOperator {
 public:
-	PhysicalSink(PhysicalOperatorType type, vector<LogicalType> types, idx_t estimated_cardinality) : PhysicalOperator(type, move(types),estimated_cardinality) {
+	PhysicalSink(PhysicalOperatorType type, vector<LogicalType> types, idx_t estimated_cardinality)
+	    : PhysicalOperator(type, move(types), estimated_cardinality) {
 	}
 
 	unique_ptr<GlobalOperatorState> sink_state;

--- a/src/include/duckdb/function/table/table_scan.hpp
+++ b/src/include/duckdb/function/table/table_scan.hpp
@@ -28,6 +28,8 @@ struct TableScanBindData : public FunctionData {
 	//! How many chunks we already scanned
 	idx_t chunk_count = 0;
 
+	std::mutex mutex;
+
 	unique_ptr<FunctionData> Copy() override {
 		auto result = make_unique<TableScanBindData>(table);
 		result->is_index_scan = is_index_scan;

--- a/src/include/duckdb/function/table/table_scan.hpp
+++ b/src/include/duckdb/function/table/table_scan.hpp
@@ -9,12 +9,11 @@
 #pragma once
 
 #include "duckdb/function/table_function.hpp"
-#include <mutex>
 namespace duckdb {
 class TableCatalogEntry;
 
 struct TableScanBindData : public FunctionData {
-	explicit TableScanBindData(TableCatalogEntry *table) : table(table), is_index_scan(false) {
+	explicit TableScanBindData(TableCatalogEntry *table) : table(table), is_index_scan(false),chunk_count(0) {
 	}
 
 	//! The table to scan
@@ -26,9 +25,8 @@ struct TableScanBindData : public FunctionData {
 	vector<row_t> result_ids;
 
 	//! How many chunks we already scanned
-	idx_t chunk_count = 0;
+	std::atomic<idx_t> chunk_count;
 
-	std::mutex mutex;
 
 	unique_ptr<FunctionData> Copy() override {
 		auto result = make_unique<TableScanBindData>(table);

--- a/src/include/duckdb/function/table/table_scan.hpp
+++ b/src/include/duckdb/function/table/table_scan.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "duckdb/function/table_function.hpp"
-
+#include <mutex>
 namespace duckdb {
 class TableCatalogEntry;
 

--- a/src/include/duckdb/function/table/table_scan.hpp
+++ b/src/include/duckdb/function/table/table_scan.hpp
@@ -9,11 +9,13 @@
 #pragma once
 
 #include "duckdb/function/table_function.hpp"
+#include <atomic>
+
 namespace duckdb {
 class TableCatalogEntry;
 
 struct TableScanBindData : public FunctionData {
-	explicit TableScanBindData(TableCatalogEntry *table) : table(table), is_index_scan(false),chunk_count(0) {
+	explicit TableScanBindData(TableCatalogEntry *table) : table(table), is_index_scan(false), chunk_count(0) {
 	}
 
 	//! The table to scan
@@ -26,7 +28,6 @@ struct TableScanBindData : public FunctionData {
 
 	//! How many chunks we already scanned
 	std::atomic<idx_t> chunk_count;
-
 
 	unique_ptr<FunctionData> Copy() override {
 		auto result = make_unique<TableScanBindData>(table);

--- a/src/include/duckdb/function/table/table_scan.hpp
+++ b/src/include/duckdb/function/table/table_scan.hpp
@@ -25,6 +25,9 @@ struct TableScanBindData : public FunctionData {
 	//! The row ids to fetch (in case of an index scan)
 	vector<row_t> result_ids;
 
+	//! How many chunks we already scanned
+	idx_t chunk_count = 0;
+
 	unique_ptr<FunctionData> Copy() override {
 		auto result = make_unique<TableScanBindData>(table);
 		result->is_index_scan = is_index_scan;

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/storage/statistics/node_statistics.hpp"
 
 #include <functional>
+#include <utility>
 
 namespace duckdb {
 class BaseStatistics;
@@ -53,6 +54,7 @@ typedef unique_ptr<FunctionOperatorData> (*table_function_init_parallel_t)(Clien
                                                                            TableFilterCollection *filters);
 typedef bool (*table_function_parallel_state_next_t)(ClientContext &context, const FunctionData *bind_data,
                                                      FunctionOperatorData *state, ParallelState *parallel_state);
+typedef int (*table_function_progress_t)(ClientContext &context, const FunctionData *bind_data);
 typedef void (*table_function_dependency_t)(unordered_set<CatalogEntry *> &dependencies, const FunctionData *bind_data);
 typedef unique_ptr<NodeStatistics> (*table_function_cardinality_t)(ClientContext &context,
                                                                    const FunctionData *bind_data);
@@ -71,16 +73,16 @@ public:
 	              table_function_to_string_t to_string = nullptr, table_function_max_threads_t max_threads = nullptr,
 	              table_function_init_parallel_state_t init_parallel_state = nullptr,
 	              table_function_init_parallel_t parallel_init = nullptr,
-	              table_function_parallel_state_next_t parallel_state_next = nullptr, bool projection_pushdown = false,
+	              table_function_parallel_state_next_t parallel_state_next = nullptr, table_function_progress_t query_progress = nullptr, bool projection_pushdown = false,
 	              bool filter_pushdown = false)
-	    : SimpleNamedParameterFunction(name, move(arguments)), bind(bind), init(init), function(function),
-	      statistics(statistics), cleanup(cleanup), dependency(dependency), cardinality(cardinality),
-	      pushdown_complex_filter(pushdown_complex_filter), to_string(to_string), max_threads(max_threads),
-	      init_parallel_state(init_parallel_state), parallel_init(parallel_init),
-	      parallel_state_next(parallel_state_next), projection_pushdown(projection_pushdown),
-	      filter_pushdown(filter_pushdown) {
+	    : SimpleNamedParameterFunction(std::move(name), move(arguments)), bind(bind), init(init), function(function),
+          statistics(statistics), cleanup(cleanup), dependency(dependency), cardinality(cardinality),
+          pushdown_complex_filter(pushdown_complex_filter), to_string(to_string), max_threads(max_threads),
+          init_parallel_state(init_parallel_state), parallel_init(parallel_init),
+          parallel_state_next(parallel_state_next), table_scan_progress(query_progress), projection_pushdown(projection_pushdown),
+          filter_pushdown(filter_pushdown) {
 	}
-	TableFunction(vector<LogicalType> arguments, table_function_t function, table_function_bind_t bind = nullptr,
+	TableFunction(const vector<LogicalType>& arguments, table_function_t function, table_function_bind_t bind = nullptr,
 	              table_function_init_t init = nullptr, table_statistics_t statistics = nullptr,
 	              table_function_cleanup_t cleanup = nullptr, table_function_dependency_t dependency = nullptr,
 	              table_function_cardinality_t cardinality = nullptr,
@@ -88,11 +90,11 @@ public:
 	              table_function_to_string_t to_string = nullptr, table_function_max_threads_t max_threads = nullptr,
 	              table_function_init_parallel_state_t init_parallel_state = nullptr,
 	              table_function_init_parallel_t parallel_init = nullptr,
-	              table_function_parallel_state_next_t parallel_state_next = nullptr, bool projection_pushdown = false,
+	              table_function_parallel_state_next_t parallel_state_next = nullptr, table_function_progress_t query_progress = nullptr, bool projection_pushdown = false,
 	              bool filter_pushdown = false)
 	    : TableFunction(string(), move(arguments), function, bind, init, statistics, cleanup, dependency, cardinality,
 	                    pushdown_complex_filter, to_string, max_threads, init_parallel_state, parallel_init,
-	                    parallel_state_next, projection_pushdown, filter_pushdown) {
+	                    parallel_state_next,query_progress, projection_pushdown, filter_pushdown) {
 	}
 	TableFunction() : SimpleNamedParameterFunction("", {}) {
 	}
@@ -133,7 +135,8 @@ public:
 	table_function_init_parallel_t parallel_init;
 	//! (Optional) return the next chunk to process in the parallel scan, or return nullptr if there is none
 	table_function_parallel_state_next_t parallel_state_next;
-
+	//! (Optional) return how much of the table we have scanned up to this point (% of the data)
+    table_function_progress_t table_scan_progress;
 	//! Whether or not the table function supports projection pushdown. If not supported a projection will be added
 	//! that filters out unused columns.
 	bool projection_pushdown;

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -73,16 +73,16 @@ public:
 	              table_function_to_string_t to_string = nullptr, table_function_max_threads_t max_threads = nullptr,
 	              table_function_init_parallel_state_t init_parallel_state = nullptr,
 	              table_function_init_parallel_t parallel_init = nullptr,
-	              table_function_parallel_state_next_t parallel_state_next = nullptr, table_function_progress_t query_progress = nullptr, bool projection_pushdown = false,
-	              bool filter_pushdown = false)
+	              table_function_parallel_state_next_t parallel_state_next = nullptr, bool projection_pushdown = false,
+	              bool filter_pushdown = false, table_function_progress_t query_progress = nullptr)
 	    : SimpleNamedParameterFunction(std::move(name), move(arguments)), bind(bind), init(init), function(function),
-          statistics(statistics), cleanup(cleanup), dependency(dependency), cardinality(cardinality),
-          pushdown_complex_filter(pushdown_complex_filter), to_string(to_string), max_threads(max_threads),
-          init_parallel_state(init_parallel_state), parallel_init(parallel_init),
-          parallel_state_next(parallel_state_next), table_scan_progress(query_progress), projection_pushdown(projection_pushdown),
-          filter_pushdown(filter_pushdown) {
+	      statistics(statistics), cleanup(cleanup), dependency(dependency), cardinality(cardinality),
+	      pushdown_complex_filter(pushdown_complex_filter), to_string(to_string), max_threads(max_threads),
+	      init_parallel_state(init_parallel_state), parallel_init(parallel_init),
+	      parallel_state_next(parallel_state_next), table_scan_progress(query_progress),
+	      projection_pushdown(projection_pushdown), filter_pushdown(filter_pushdown) {
 	}
-	TableFunction(const vector<LogicalType>& arguments, table_function_t function, table_function_bind_t bind = nullptr,
+	TableFunction(const vector<LogicalType> &arguments, table_function_t function, table_function_bind_t bind = nullptr,
 	              table_function_init_t init = nullptr, table_statistics_t statistics = nullptr,
 	              table_function_cleanup_t cleanup = nullptr, table_function_dependency_t dependency = nullptr,
 	              table_function_cardinality_t cardinality = nullptr,
@@ -90,11 +90,11 @@ public:
 	              table_function_to_string_t to_string = nullptr, table_function_max_threads_t max_threads = nullptr,
 	              table_function_init_parallel_state_t init_parallel_state = nullptr,
 	              table_function_init_parallel_t parallel_init = nullptr,
-	              table_function_parallel_state_next_t parallel_state_next = nullptr, table_function_progress_t query_progress = nullptr, bool projection_pushdown = false,
-	              bool filter_pushdown = false)
-	    : TableFunction(string(), move(arguments), function, bind, init, statistics, cleanup, dependency, cardinality,
+	              table_function_parallel_state_next_t parallel_state_next = nullptr, bool projection_pushdown = false,
+	              bool filter_pushdown = false, table_function_progress_t query_progress = nullptr)
+	    : TableFunction(string(), arguments, function, bind, init, statistics, cleanup, dependency, cardinality,
 	                    pushdown_complex_filter, to_string, max_threads, init_parallel_state, parallel_init,
-	                    parallel_state_next,query_progress, projection_pushdown, filter_pushdown) {
+	                    parallel_state_next, projection_pushdown, filter_pushdown, query_progress) {
 	}
 	TableFunction() : SimpleNamedParameterFunction("", {}) {
 	}
@@ -136,7 +136,7 @@ public:
 	//! (Optional) return the next chunk to process in the parallel scan, or return nullptr if there is none
 	table_function_parallel_state_next_t parallel_state_next;
 	//! (Optional) return how much of the table we have scanned up to this point (% of the data)
-    table_function_progress_t table_scan_progress;
+	table_function_progress_t table_scan_progress;
 	//! Whether or not the table function supports projection pushdown. If not supported a projection will be added
 	//! that filters out unused columns.
 	bool projection_pushdown;

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -13,7 +13,6 @@
 #include "duckdb/storage/statistics/node_statistics.hpp"
 
 #include <functional>
-#include <utility>
 
 namespace duckdb {
 class BaseStatistics;

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -21,6 +21,7 @@
 #include "duckdb/transaction/transaction_context.hpp"
 
 #include <random>
+#include "duckdb/common/progress_bar.hpp"
 
 namespace duckdb {
 class Appender;
@@ -54,6 +55,13 @@ public:
 
 	//! The query executor
 	Executor executor;
+
+	//! The Progress Bar
+	unique_ptr<ProgressBar> progress_bar;
+	//! If the progress bar is enabled or not.
+	bool enable_progress_bar = false;
+	//! The wait time before showing the progress bar
+	int wait_time = 2000;
 
 	unique_ptr<SchemaCatalogEntry> temporary_objects;
 	unordered_map<string, shared_ptr<PreparedStatementData>> prepared_statements;
@@ -121,6 +129,9 @@ public:
 	//! modified in between the prepared statement being bound and the prepared statement being run.
 	DUCKDB_API unique_ptr<QueryResult> Execute(const string &query, shared_ptr<PreparedStatementData> &prepared,
 	                                           vector<Value> &values, bool allow_stream_result = true);
+
+	//! Gets current percentage of the query's progress, returns 0 in case the progress bar is disabled.
+	int GetProgress();
 
 	//! Register function in the temporary schema
 	DUCKDB_API void RegisterFunction(CreateFunctionInfo *info);

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -51,7 +51,7 @@ public:
 	OrderByNullType default_null_order = OrderByNullType::NULLS_FIRST;
 	//! enable COPY and related commands
 	bool enable_copy = true;
-	//! Wether or not object cache is used
+	//! Whether or not object cache is used
 	bool object_cache_enable = false;
 	//! Database configuration variables as controlled by SET
 	unordered_map<std::string, Value> set_variables;

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -69,7 +69,7 @@ public:
 		return finished;
 	}
 	//! Returns query progress
-	int GetProgress(bool& supported);
+	int GetProgress(bool &supported);
 
 public:
 	//! The current threads working on the pipeline
@@ -103,7 +103,7 @@ private:
 	PhysicalOperator *recursive_cte;
 
 private:
-	int GetProgress(ClientContext &context, PhysicalOperator *op,bool& supported);
+	int GetProgress(ClientContext &context, PhysicalOperator *op, bool &supported);
 	void ScheduleSequentialTask();
 	bool ScheduleOperator(PhysicalOperator *op);
 };

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -68,6 +68,8 @@ public:
 	bool IsFinished() {
 		return finished;
 	}
+    // Returns query progress
+	int GetProgress();
 
 public:
 	//! The current threads working on the pipeline
@@ -100,10 +102,8 @@ private:
 	//! The recursive CTE node that this pipeline belongs to, and may be executed multiple times
 	PhysicalOperator *recursive_cte;
 
-	//! Current progress on the table scan
-	int query_progress = 0;
-
 private:
+    int GetProgress(ClientContext &context,PhysicalOperator * op);
 	void ScheduleSequentialTask();
 	bool ScheduleOperator(PhysicalOperator *op);
 };

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -36,7 +36,7 @@ public:
 	void AddDependency(Pipeline *pipeline);
 	void CompleteDependency();
 	bool HasDependencies() {
-		return dependencies.size() != 0;
+		return !dependencies.empty();
 	}
 
 	void Reset(ClientContext &context);
@@ -68,8 +68,8 @@ public:
 	bool IsFinished() {
 		return finished;
 	}
-	// Returns query progress
-	int GetProgress();
+	//! Returns query progress
+	int GetProgress(bool& supported);
 
 public:
 	//! The current threads working on the pipeline
@@ -103,7 +103,7 @@ private:
 	PhysicalOperator *recursive_cte;
 
 private:
-	int GetProgress(ClientContext &context, PhysicalOperator *op);
+	int GetProgress(ClientContext &context, PhysicalOperator *op,bool& supported);
 	void ScheduleSequentialTask();
 	bool ScheduleOperator(PhysicalOperator *op);
 };

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -68,7 +68,7 @@ public:
 	bool IsFinished() {
 		return finished;
 	}
-    // Returns query progress
+	// Returns query progress
 	int GetProgress();
 
 public:
@@ -103,7 +103,7 @@ private:
 	PhysicalOperator *recursive_cte;
 
 private:
-    int GetProgress(ClientContext &context,PhysicalOperator * op);
+	int GetProgress(ClientContext &context, PhysicalOperator *op);
 	void ScheduleSequentialTask();
 	bool ScheduleOperator(PhysicalOperator *op);
 };

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -69,7 +69,7 @@ public:
 		return finished;
 	}
 	//! Returns query progress
-	int GetProgress(bool &supported);
+	bool GetProgress(int &current_percentage);
 
 public:
 	//! The current threads working on the pipeline
@@ -103,7 +103,7 @@ private:
 	PhysicalOperator *recursive_cte;
 
 private:
-	int GetProgress(ClientContext &context, PhysicalOperator *op, bool &supported);
+	bool GetProgress(ClientContext &context, PhysicalOperator *op, int &current_percentage);
 	void ScheduleSequentialTask();
 	bool ScheduleOperator(PhysicalOperator *op);
 };

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -100,6 +100,9 @@ private:
 	//! The recursive CTE node that this pipeline belongs to, and may be executed multiple times
 	PhysicalOperator *recursive_cte;
 
+	//! Current progress on the table scan
+	int query_progress = 0;
+
 private:
 	void ScheduleSequentialTask();
 	bool ScheduleOperator(PhysicalOperator *op);

--- a/src/include/duckdb/planner/logical_operator.hpp
+++ b/src/include/duckdb/planner/logical_operator.hpp
@@ -40,6 +40,8 @@ public:
 	vector<unique_ptr<Expression>> expressions;
 	//! The types returned by this logical operator. Set by calling LogicalOperator::ResolveTypes.
 	vector<LogicalType> types;
+	//! Estimated Cardinality
+	idx_t estimated_cardinality = 0;
 
 public:
 	virtual vector<ColumnBinding> GetColumnBindings() {

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -146,6 +146,8 @@ public:
 	void CommitDropTable();
 	void CommitDropColumn(idx_t index);
 
+	idx_t GetTotalRows();
+
 private:
 	//! Verify constraints with a chunk from the Append containing all columns of the table
 	void VerifyAppendConstraints(TableCatalogEntry &table, DataChunk &chunk);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -35,6 +35,7 @@ class ClientContextLock {
 public:
 	explicit ClientContextLock(mutex &context_lock) : client_guard(context_lock) {
 	}
+
 	~ClientContextLock() {
 	}
 
@@ -182,6 +183,10 @@ shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatement(ClientC
 	return result;
 }
 
+int ClientContext::GetProgress() {
+	return progress_bar->GetCurPercentage();
+}
+
 unique_ptr<QueryResult> ClientContext::ExecutePreparedStatement(ClientContextLock &lock, const string &query,
                                                                 shared_ptr<PreparedStatementData> statement_p,
                                                                 vector<Value> bound_values, bool allow_stream_result) {
@@ -199,7 +204,13 @@ unique_ptr<QueryResult> ClientContext::ExecutePreparedStatement(ClientContextLoc
 	statement.Bind(move(bound_values));
 
 	bool create_stream_result = statement.allow_stream_result && allow_stream_result;
-
+	if (enable_progress_bar) {
+		if (progress_bar) {
+			progress_bar.reset();
+		}
+		progress_bar = make_unique<ProgressBar>(&executor, wait_time);
+		progress_bar->Start();
+	}
 	// store the physical plan in the context for calls to Fetch()
 	executor.Initialize(statement.plan.get());
 
@@ -228,6 +239,9 @@ unique_ptr<QueryResult> ClientContext::ExecutePreparedStatement(ClientContextLoc
 		}
 #endif
 		result->collection.Append(*chunk);
+	}
+	if (progress_bar) {
+		progress_bar->Stop();
 	}
 	return move(result);
 }

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -184,7 +184,7 @@ shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatement(ClientC
 }
 
 int ClientContext::GetProgress() {
-	return progress_bar->GetCurPercentage();
+	return progress_bar->GetCurrentPercentage();
 }
 
 unique_ptr<QueryResult> ClientContext::ExecutePreparedStatement(ClientContextLock &lock, const string &query,
@@ -204,7 +204,7 @@ unique_ptr<QueryResult> ClientContext::ExecutePreparedStatement(ClientContextLoc
 	statement.Bind(move(bound_values));
 
 	bool create_stream_result = statement.allow_stream_result && allow_stream_result;
-	if (enable_progress_bar) {
+	if (enable_progress_bar && !create_stream_result) {
 		if (progress_bar) {
 			progress_bar.reset();
 		}

--- a/src/main/prepared_statement.cpp
+++ b/src/main/prepared_statement.cpp
@@ -42,7 +42,8 @@ unique_ptr<QueryResult> PreparedStatement::Execute(vector<Value> &values, bool a
 		throw InvalidInputException("Attempting to execute an unsuccessfully prepared statement!");
 	}
 	D_ASSERT(data);
-	return context->Execute(query, data, values, allow_stream_result && data->allow_stream_result);
+	auto result = context->Execute(query, data, values, allow_stream_result && data->allow_stream_result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -233,7 +233,7 @@ void Executor::Flush(ThreadContext &tcontext) {
 	context.profiler.Flush(tcontext.profiler);
 }
 
-int Executor::GetPipelinesProgress(bool& supported) {
+int Executor::GetPipelinesProgress(bool &supported) {
 	if (!pipelines.empty()) {
 		return pipelines.back()->GetProgress(supported);
 	} else {

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -234,11 +234,13 @@ void Executor::Flush(ThreadContext &tcontext) {
 }
 
 int Executor::GetPipelinesProgress(){
-    int progress = 0;
-    for (auto& pipeline: pipelines){
-        progress += pipeline->query_progress;
+    if (!pipelines.empty()){
+        return pipelines.back()->GetProgress();
     }
-    return progress;
+    else {
+        return 0;
+    }
+
 }
 
 unique_ptr<DataChunk> Executor::FetchChunk() {

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -233,14 +233,12 @@ void Executor::Flush(ThreadContext &tcontext) {
 	context.profiler.Flush(tcontext.profiler);
 }
 
-int Executor::GetPipelinesProgress(){
-    if (!pipelines.empty()){
-        return pipelines.back()->GetProgress();
-    }
-    else {
-        return 0;
-    }
-
+int Executor::GetPipelinesProgress() {
+	if (!pipelines.empty()) {
+		return pipelines.back()->GetProgress();
+	} else {
+		return 0;
+	}
 }
 
 unique_ptr<DataChunk> Executor::FetchChunk() {

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -233,11 +233,12 @@ void Executor::Flush(ThreadContext &tcontext) {
 	context.profiler.Flush(tcontext.profiler);
 }
 
-int Executor::GetPipelinesProgress(bool &supported) {
+bool Executor::GetPipelinesProgress(int &current_progress) {
 	if (!pipelines.empty()) {
-		return pipelines.back()->GetProgress(supported);
+		return pipelines.back()->GetProgress(current_progress);
 	} else {
-		return -1;
+	    current_progress = -1;
+		return true;
 	}
 }
 

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -233,6 +233,14 @@ void Executor::Flush(ThreadContext &tcontext) {
 	context.profiler.Flush(tcontext.profiler);
 }
 
+int Executor::GetPipelinesProgress(){
+    int progress = 0;
+    for (auto& pipeline: pipelines){
+        progress += pipeline->query_progress;
+    }
+    return progress;
+}
+
 unique_ptr<DataChunk> Executor::FetchChunk() {
 	D_ASSERT(physical_plan);
 

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -233,9 +233,9 @@ void Executor::Flush(ThreadContext &tcontext) {
 	context.profiler.Flush(tcontext.profiler);
 }
 
-int Executor::GetPipelinesProgress() {
+int Executor::GetPipelinesProgress(bool& supported) {
 	if (!pipelines.empty()) {
-		return pipelines.back()->GetProgress();
+		return pipelines.back()->GetProgress(supported);
 	} else {
 		return 0;
 	}

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -237,7 +237,7 @@ bool Executor::GetPipelinesProgress(int &current_progress) {
 	if (!pipelines.empty()) {
 		return pipelines.back()->GetProgress(current_progress);
 	} else {
-	    current_progress = -1;
+		current_progress = -1;
 		return true;
 	}
 }

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -237,7 +237,7 @@ int Executor::GetPipelinesProgress(bool &supported) {
 	if (!pipelines.empty()) {
 		return pipelines.back()->GetProgress(supported);
 	} else {
-		return 0;
+		return -1;
 	}
 }
 

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -40,7 +40,8 @@ bool Pipeline::GetProgress(ClientContext &context, PhysicalOperator *op, int &cu
 	case PhysicalOperatorType::TABLE_SCAN: {
 		auto &get = (PhysicalTableScan &)*op;
 		if (get.function.table_scan_progress) {
-			return get.function.table_scan_progress(context, get.bind_data.get());
+			current_percentage = get.function.table_scan_progress(context, get.bind_data.get());
+			return true;
 		}
 		//! If the table_scan_progress is not implemented it means we don't support this function yet in the progress
 		//! bar

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -11,265 +11,286 @@
 #include "duckdb/execution/operator/aggregate/physical_simple_aggregate.hpp"
 #include "duckdb/execution/operator/scan/physical_table_scan.hpp"
 #include "duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp"
+#include "duckdb/execution/operator/join/physical_hash_join.hpp"
 
 namespace duckdb {
 
-class PipelineTask : public Task {
-public:
-	explicit PipelineTask(Pipeline *pipeline_p) : pipeline(pipeline_p) {
-	}
+    class PipelineTask : public Task {
+    public:
+        explicit PipelineTask(Pipeline *pipeline_p) : pipeline(pipeline_p) {
+        }
 
-	TaskContext task;
-	Pipeline *pipeline;
+        TaskContext task;
+        Pipeline *pipeline;
 
-public:
-	void Execute() override {
-		pipeline->Execute(task);
-		pipeline->FinishTask();
-	}
-};
+    public:
+        void Execute() override {
+            pipeline->Execute(task);
+            pipeline->FinishTask();
+        }
+    };
 
-Pipeline::Pipeline(Executor &executor_p, ProducerToken &token_p)
-    : executor(executor_p), token(token_p), finished_tasks(0), total_tasks(0), finished_dependencies(0),
-      finished(false), recursive_cte(nullptr) {
-}
+    Pipeline::Pipeline(Executor &executor_p, ProducerToken &token_p)
+            : executor(executor_p), token(token_p), finished_tasks(0), total_tasks(0), finished_dependencies(0),
+              finished(false), recursive_cte(nullptr) {
+    }
 
-void Pipeline::Execute(TaskContext &task) {
-	auto &client = executor.context;
-	if (client.interrupted) {
-		return;
-	}
-	if (parallel_state) {
-		task.task_info[parallel_node] = parallel_state.get();
-	}
+    int Pipeline::GetProgress(ClientContext &context,PhysicalOperator * op) {
+        switch (op->type) {
+            case PhysicalOperatorType::TABLE_SCAN: {
+                auto &get = (PhysicalTableScan &) *op;
+                if (get.function.table_scan_progress) {
+                   return get.function.table_scan_progress(context, get.bind_data.get());
+                }
+                return -1;
+            }
+            case PhysicalOperatorType::HASH_JOIN:{
+                auto &hash_join = (PhysicalHashJoin&) *op;
+                int lhs = GetProgress(context,op->children[0].get());
+                int rhs = GetProgress(context,op->children[1].get());
+                return (lhs+rhs)/2;
+            }
+            default:
+                return -1;
+        }
+    }
 
-	ThreadContext thread(client);
-	ExecutionContext context(client, thread, task);
-	try {
-		auto state = child->GetOperatorState();
-		auto lstate = sink->GetLocalSinkState(context);
-		// incrementally process the pipeline
-		DataChunk intermediate;
-		child->InitializeChunkEmpty(intermediate);
-		while (true) {
-			child->GetChunk(context, intermediate, state.get());
-			if (child->type == PhysicalOperatorType::TABLE_SCAN){
-			    auto &get = (PhysicalTableScan &)*child;
-			    if(get.function.table_scan_progress){
-			        query_progress = get.function.table_scan_progress(context.client, get.bind_data.get());
-			    }
-			}
-			thread.profiler.StartOperator(sink);
-			if (intermediate.size() == 0) {
-				sink->Combine(context, *sink_state, *lstate);
-				break;
-			}
-			sink->Sink(context, *sink_state, *lstate, intermediate);
-			thread.profiler.EndOperator(nullptr);
-		}
-	} catch (std::exception &ex) {
-		executor.PushError(ex.what());
-	} catch (...) {
-		executor.PushError("Unknown exception in pipeline!");
-	}
-	executor.Flush(thread);
-}
+    int Pipeline::GetProgress() {
+        auto &client = executor.context;
+        return GetProgress(client,child);
+    }
 
-void Pipeline::FinishTask() {
-	D_ASSERT(finished_tasks < total_tasks);
-	idx_t current_finished = ++finished_tasks;
-	if (current_finished == total_tasks) {
-		try {
-			sink->Finalize(*this, executor.context, move(sink_state));
-		} catch (std::exception &ex) {
-			executor.PushError(ex.what());
-		} catch (...) {
-			executor.PushError("Unknown exception in Finalize!");
-		}
-		if (current_finished == total_tasks) {
-			Finish();
-		}
-	}
-}
 
-void Pipeline::ScheduleSequentialTask() {
-	auto &scheduler = TaskScheduler::GetScheduler(executor.context);
-	auto task = make_unique<PipelineTask>(this);
+    void Pipeline::Execute(TaskContext &task) {
+        auto &client = executor.context;
+        if (client.interrupted) {
+            return;
+        }
+        if (parallel_state) {
+            task.task_info[parallel_node] = parallel_state.get();
+        }
 
-	this->total_tasks = 1;
-	scheduler.ScheduleTask(*executor.producer, move(task));
-}
+        ThreadContext thread(client);
+        ExecutionContext context(client, thread, task);
+        try {
+            auto state = child->GetOperatorState();
+            auto lstate = sink->GetLocalSinkState(context);
+            // incrementally process the pipeline
+            DataChunk intermediate;
+            child->InitializeChunkEmpty(intermediate);
+            while (true) {
+                child->GetChunk(context, intermediate, state.get());
+                thread.profiler.StartOperator(sink);
+                if (intermediate.size() == 0) {
+                    sink->Combine(context, *sink_state, *lstate);
+                    break;
+                }
+                sink->Sink(context, *sink_state, *lstate, intermediate);
+                thread.profiler.EndOperator(nullptr);
+            }
+        } catch (std::exception &ex) {
+            executor.PushError(ex.what());
+        } catch (...) {
+            executor.PushError("Unknown exception in pipeline!");
+        }
+        executor.Flush(thread);
+    }
 
-bool Pipeline::ScheduleOperator(PhysicalOperator *op) {
-	switch (op->type) {
-	case PhysicalOperatorType::UNNEST:
-	case PhysicalOperatorType::FILTER:
-	case PhysicalOperatorType::PROJECTION:
-	case PhysicalOperatorType::HASH_JOIN:
-	case PhysicalOperatorType::CROSS_PRODUCT:
-	case PhysicalOperatorType::STREAMING_SAMPLE:
-		// filter, projection or hash probe: continue in children
-		return ScheduleOperator(op->children[0].get());
-	case PhysicalOperatorType::TABLE_SCAN: {
-		// we reached a scan: split it up into parts and schedule the parts
-		auto &scheduler = TaskScheduler::GetScheduler(executor.context);
-		auto &get = (PhysicalTableScan &)*op;
-		if (!get.function.max_threads) {
-			// table function cannot be parallelized
-			return false;
-		}
-		D_ASSERT(get.function.init_parallel_state);
-		D_ASSERT(get.function.parallel_state_next);
-		idx_t max_threads = get.function.max_threads(executor.context, get.bind_data.get());
-		if (max_threads > executor.context.db->NumberOfThreads()) {
-			max_threads = executor.context.db->NumberOfThreads();
-		}
-		if (max_threads <= 1) {
-			// table is too small to parallelize
-			return false;
-		}
-		this->parallel_state = get.function.init_parallel_state(executor.context, get.bind_data.get());
-		this->parallel_node = op;
+    void Pipeline::FinishTask() {
+        D_ASSERT(finished_tasks < total_tasks);
+        idx_t current_finished = ++finished_tasks;
+        if (current_finished == total_tasks) {
+            try {
+                sink->Finalize(*this, executor.context, move(sink_state));
+            } catch (std::exception &ex) {
+                executor.PushError(ex.what());
+            } catch (...) {
+                executor.PushError("Unknown exception in Finalize!");
+            }
+            if (current_finished == total_tasks) {
+                Finish();
+            }
+        }
+    }
 
-		// launch a task for every thread
-		this->total_tasks = max_threads;
-		for (idx_t i = 0; i < max_threads; i++) {
-			auto task = make_unique<PipelineTask>(this);
-			scheduler.ScheduleTask(*executor.producer, move(task));
-		}
-		return true;
-	}
-	case PhysicalOperatorType::HASH_GROUP_BY: {
-		// FIXME: parallelize scan of GROUP_BY HT
-		return false;
-	}
-	default:
-		// unknown operator: skip parallel task scheduling
-		return false;
-	}
-}
+    void Pipeline::ScheduleSequentialTask() {
+        auto &scheduler = TaskScheduler::GetScheduler(executor.context);
+        auto task = make_unique<PipelineTask>(this);
 
-void Pipeline::ClearParents() {
-	for (auto &parent : parents) {
-		parent->dependencies.erase(this);
-	}
-	for (auto &dep : dependencies) {
-		dep->parents.erase(this);
-	}
-	parents.clear();
-	dependencies.clear();
-}
+        this->total_tasks = 1;
+        scheduler.ScheduleTask(*executor.producer, move(task));
+    }
 
-void Pipeline::Reset(ClientContext &context) {
-	sink_state = sink->GetGlobalState(context);
-	finished_tasks = 0;
-	total_tasks = 0;
-	finished = false;
-}
+    bool Pipeline::ScheduleOperator(PhysicalOperator *op) {
+        switch (op->type) {
+            case PhysicalOperatorType::UNNEST:
+            case PhysicalOperatorType::FILTER:
+            case PhysicalOperatorType::PROJECTION:
+            case PhysicalOperatorType::HASH_JOIN:
+            case PhysicalOperatorType::CROSS_PRODUCT:
+            case PhysicalOperatorType::STREAMING_SAMPLE:
+                // filter, projection or hash probe: continue in children
+                return ScheduleOperator(op->children[0].get());
+            case PhysicalOperatorType::TABLE_SCAN: {
+                // we reached a scan: split it up into parts and schedule the parts
+                auto &scheduler = TaskScheduler::GetScheduler(executor.context);
+                auto &get = (PhysicalTableScan &) *op;
+                if (!get.function.max_threads) {
+                    // table function cannot be parallelized
+                    return false;
+                }
+                D_ASSERT(get.function.init_parallel_state);
+                D_ASSERT(get.function.parallel_state_next);
+                idx_t max_threads = get.function.max_threads(executor.context, get.bind_data.get());
+                if (max_threads > executor.context.db->NumberOfThreads()) {
+                    max_threads = executor.context.db->NumberOfThreads();
+                }
+                if (max_threads <= 1) {
+                    // table is too small to parallelize
+                    return false;
+                }
+                this->parallel_state = get.function.init_parallel_state(executor.context, get.bind_data.get());
+                this->parallel_node = op;
 
-void Pipeline::Schedule() {
-	D_ASSERT(finished_tasks == 0);
-	D_ASSERT(total_tasks == 0);
-	D_ASSERT(finished_dependencies == dependencies.size());
-	// check if we can parallelize this task based on the sink
-	switch (sink->type) {
-	case PhysicalOperatorType::SIMPLE_AGGREGATE: {
-		auto &simple_aggregate = (PhysicalSimpleAggregate &)*sink;
-		// simple aggregate: check if we can parallelize it
-		if (!simple_aggregate.all_combinable) {
-			// not all aggregates are parallelizable: switch to sequential mode
-			break;
-		}
-		if (ScheduleOperator(sink->children[0].get())) {
-			// all parallel tasks have been scheduled: return
-			return;
-		}
-		break;
-	}
-	case PhysicalOperatorType::CREATE_TABLE_AS:
-	case PhysicalOperatorType::ORDER_BY:
-	case PhysicalOperatorType::RESERVOIR_SAMPLE:
-	case PhysicalOperatorType::PERFECT_HASH_GROUP_BY: {
-		// perfect hash aggregate can always be parallelized
-		if (ScheduleOperator(sink->children[0].get())) {
-			// all parallel tasks have been scheduled: return
-			return;
-		}
-		break;
-	}
-	case PhysicalOperatorType::HASH_GROUP_BY: {
-		auto &hash_aggr = (PhysicalHashAggregate &)*sink;
-		if (!hash_aggr.all_combinable) {
-			// not all aggregates are parallelizable: switch to sequential mode
-			break;
-		}
-		if (ScheduleOperator(sink->children[0].get())) {
-			// all parallel tasks have been scheduled: return
-			return;
-		}
-		break;
-	}
-	case PhysicalOperatorType::CROSS_PRODUCT:
-	case PhysicalOperatorType::HASH_JOIN: {
-		// schedule build side of the join
-		if (ScheduleOperator(sink->children[1].get())) {
-			// all parallel tasks have been scheduled: return
-			return;
-		}
-		break;
-	}
-	case PhysicalOperatorType::WINDOW: {
-		// schedule child op
-		if (ScheduleOperator(sink->children[0].get())) {
-			// all parallel tasks have been scheduled: return
-			return;
-		}
-		break;
-	}
-	default:
-		break;
-	}
-	// could not parallelize this pipeline: push a sequential task instead
-	ScheduleSequentialTask();
-}
+                // launch a task for every thread
+                this->total_tasks = max_threads;
+                for (idx_t i = 0; i < max_threads; i++) {
+                    auto task = make_unique<PipelineTask>(this);
+                    scheduler.ScheduleTask(*executor.producer, move(task));
+                }
+                return true;
+            }
+            case PhysicalOperatorType::HASH_GROUP_BY: {
+                // FIXME: parallelize scan of GROUP_BY HT
+                return false;
+            }
+            default:
+                // unknown operator: skip parallel task scheduling
+                return false;
+        }
+    }
 
-void Pipeline::AddDependency(Pipeline *pipeline) {
-	this->dependencies.insert(pipeline);
-	pipeline->parents.insert(this);
-}
+    void Pipeline::ClearParents() {
+        for (auto &parent : parents) {
+            parent->dependencies.erase(this);
+        }
+        for (auto &dep : dependencies) {
+            dep->parents.erase(this);
+        }
+        parents.clear();
+        dependencies.clear();
+    }
 
-void Pipeline::CompleteDependency() {
-	idx_t current_finished = ++finished_dependencies;
-	D_ASSERT(current_finished <= dependencies.size());
-	if (current_finished == dependencies.size()) {
-		// all dependencies have been completed: schedule the pipeline
-		Schedule();
-	}
-}
+    void Pipeline::Reset(ClientContext &context) {
+        sink_state = sink->GetGlobalState(context);
+        finished_tasks = 0;
+        total_tasks = 0;
+        finished = false;
+    }
 
-void Pipeline::Finish() {
-	D_ASSERT(!finished);
-	finished = true;
-	// finished processing the pipeline, now we can schedule pipelines that depend on this pipeline
-	for (auto &parent : parents) {
-		// mark a dependency as completed for each of the parents
-		parent->CompleteDependency();
-	}
-	executor.completed_pipelines++;
-}
+    void Pipeline::Schedule() {
+        D_ASSERT(finished_tasks == 0);
+        D_ASSERT(total_tasks == 0);
+        D_ASSERT(finished_dependencies == dependencies.size());
+        // check if we can parallelize this task based on the sink
+        switch (sink->type) {
+            case PhysicalOperatorType::SIMPLE_AGGREGATE: {
+                auto &simple_aggregate = (PhysicalSimpleAggregate &) *sink;
+                // simple aggregate: check if we can parallelize it
+                if (!simple_aggregate.all_combinable) {
+                    // not all aggregates are parallelizable: switch to sequential mode
+                    break;
+                }
+                if (ScheduleOperator(sink->children[0].get())) {
+                    // all parallel tasks have been scheduled: return
+                    return;
+                }
+                break;
+            }
+            case PhysicalOperatorType::CREATE_TABLE_AS:
+            case PhysicalOperatorType::ORDER_BY:
+            case PhysicalOperatorType::RESERVOIR_SAMPLE:
+            case PhysicalOperatorType::PERFECT_HASH_GROUP_BY: {
+                // perfect hash aggregate can always be parallelized
+                if (ScheduleOperator(sink->children[0].get())) {
+                    // all parallel tasks have been scheduled: return
+                    return;
+                }
+                break;
+            }
+            case PhysicalOperatorType::HASH_GROUP_BY: {
+                auto &hash_aggr = (PhysicalHashAggregate &) *sink;
+                if (!hash_aggr.all_combinable) {
+                    // not all aggregates are parallelizable: switch to sequential mode
+                    break;
+                }
+                if (ScheduleOperator(sink->children[0].get())) {
+                    // all parallel tasks have been scheduled: return
+                    return;
+                }
+                break;
+            }
+            case PhysicalOperatorType::CROSS_PRODUCT:
+            case PhysicalOperatorType::HASH_JOIN: {
+                // schedule build side of the join
+                if (ScheduleOperator(sink->children[1].get())) {
+                    // all parallel tasks have been scheduled: return
+                    return;
+                }
+                break;
+            }
+            case PhysicalOperatorType::WINDOW: {
+                // schedule child op
+                if (ScheduleOperator(sink->children[0].get())) {
+                    // all parallel tasks have been scheduled: return
+                    return;
+                }
+                break;
+            }
+            default:
+                break;
+        }
+        // could not parallelize this pipeline: push a sequential task instead
+        ScheduleSequentialTask();
+    }
 
-string Pipeline::ToString() const {
-	string str = PhysicalOperatorToString(sink->type);
-	auto node = this->child;
-	while (node) {
-		str = PhysicalOperatorToString(node->type) + " -> " + str;
-		node = node->children[0].get();
-	}
-	return str;
-}
+    void Pipeline::AddDependency(Pipeline *pipeline) {
+        this->dependencies.insert(pipeline);
+        pipeline->parents.insert(this);
+    }
 
-void Pipeline::Print() const {
-	Printer::Print(ToString());
-}
+    void Pipeline::CompleteDependency() {
+        idx_t current_finished = ++finished_dependencies;
+        D_ASSERT(current_finished <= dependencies.size());
+        if (current_finished == dependencies.size()) {
+            // all dependencies have been completed: schedule the pipeline
+            Schedule();
+        }
+    }
+
+    void Pipeline::Finish() {
+        D_ASSERT(!finished);
+        finished = true;
+        // finished processing the pipeline, now we can schedule pipelines that depend on this pipeline
+        for (auto &parent : parents) {
+            // mark a dependency as completed for each of the parents
+            parent->CompleteDependency();
+        }
+        executor.completed_pipelines++;
+    }
+
+    string Pipeline::ToString() const {
+        string str = PhysicalOperatorToString(sink->type);
+        auto node = this->child;
+        while (node) {
+            str = PhysicalOperatorToString(node->type) + " -> " + str;
+            node = node->children[0].get();
+        }
+        return str;
+    }
+
+    void Pipeline::Print() const {
+        Printer::Print(ToString());
+    }
 
 } // namespace duckdb

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -35,14 +35,15 @@ Pipeline::Pipeline(Executor &executor_p, ProducerToken &token_p)
       finished(false), recursive_cte(nullptr) {
 }
 
-int Pipeline::GetProgress(ClientContext &context, PhysicalOperator *op, bool& supported) {
+int Pipeline::GetProgress(ClientContext &context, PhysicalOperator *op, bool &supported) {
 	switch (op->type) {
 	case PhysicalOperatorType::TABLE_SCAN: {
 		auto &get = (PhysicalTableScan &)*op;
 		if (get.function.table_scan_progress) {
 			return get.function.table_scan_progress(context, get.bind_data.get());
 		}
-		//! If the table_scan_progress is not implemented it means we don't support this function yet in the progress bar
+		//! If the table_scan_progress is not implemented it means we don't support this function yet in the progress
+		//! bar
 		supported = false;
 		return -1;
 	}
@@ -52,7 +53,7 @@ int Pipeline::GetProgress(ClientContext &context, PhysicalOperator *op, bool& su
 		double total_cardinality = 0;
 		double cur_percentage = 0;
 		for (auto &op_child : op->children) {
-			progress.push_back(GetProgress(context, op_child.get(),supported));
+			progress.push_back(GetProgress(context, op_child.get(), supported));
 			cardinality.push_back(op_child->estimated_cardinality);
 			total_cardinality += op_child->estimated_cardinality;
 		}
@@ -64,7 +65,7 @@ int Pipeline::GetProgress(ClientContext &context, PhysicalOperator *op, bool& su
 	}
 }
 
-int Pipeline::GetProgress(bool& supported) {
+int Pipeline::GetProgress(bool &supported) {
 	auto &client = executor.context;
 	return GetProgress(client, child, supported);
 }

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -53,6 +53,12 @@ void Pipeline::Execute(TaskContext &task) {
 		child->InitializeChunkEmpty(intermediate);
 		while (true) {
 			child->GetChunk(context, intermediate, state.get());
+			if (child->type == PhysicalOperatorType::TABLE_SCAN){
+			    auto &get = (PhysicalTableScan &)*child;
+			    if(get.function.table_scan_progress){
+			        query_progress = get.function.table_scan_progress(context.client, get.bind_data.get());
+			    }
+			}
 			thread.profiler.StartOperator(sink);
 			if (intermediate.size() == 0) {
 				sink->Combine(context, *sink_state, *lstate);

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -15,289 +15,288 @@
 
 namespace duckdb {
 
-    class PipelineTask : public Task {
-    public:
-        explicit PipelineTask(Pipeline *pipeline_p) : pipeline(pipeline_p) {
-        }
+class PipelineTask : public Task {
+public:
+	explicit PipelineTask(Pipeline *pipeline_p) : pipeline(pipeline_p) {
+	}
 
-        TaskContext task;
-        Pipeline *pipeline;
+	TaskContext task;
+	Pipeline *pipeline;
 
-    public:
-        void Execute() override {
-            pipeline->Execute(task);
-            pipeline->FinishTask();
-        }
-    };
+public:
+	void Execute() override {
+		pipeline->Execute(task);
+		pipeline->FinishTask();
+	}
+};
 
-    Pipeline::Pipeline(Executor &executor_p, ProducerToken &token_p)
-            : executor(executor_p), token(token_p), finished_tasks(0), total_tasks(0), finished_dependencies(0),
-              finished(false), recursive_cte(nullptr) {
-    }
+Pipeline::Pipeline(Executor &executor_p, ProducerToken &token_p)
+    : executor(executor_p), token(token_p), finished_tasks(0), total_tasks(0), finished_dependencies(0),
+      finished(false), recursive_cte(nullptr) {
+}
 
-    int Pipeline::GetProgress(ClientContext &context, PhysicalOperator *op) {
-        switch (op->type) {
-            case PhysicalOperatorType::TABLE_SCAN: {
-                auto &get = (PhysicalTableScan &) *op;
-                if (get.function.table_scan_progress) {
-                    return get.function.table_scan_progress(context, get.bind_data.get());
-                }
-                return -1;
-            }
-            default:{
-                vector<idx_t> progress;
-                vector<idx_t> cardinality;
-                double total_cardinality = 0;
-                double cur_percentage = 0;
-                for (auto& op_child : op->children){
-                    progress.push_back(GetProgress(context, op_child.get()));
-                    cardinality.push_back(op_child->estimated_cardinality);
-                    total_cardinality+=op_child->estimated_cardinality;
-                }
-                for (size_t i = 0; i < progress.size(); i++){
-                    cur_percentage += progress[i]*cardinality[i]/total_cardinality;
-                }
-                return cur_percentage;
-            }
-        }
-    }
+int Pipeline::GetProgress(ClientContext &context, PhysicalOperator *op) {
+	switch (op->type) {
+	case PhysicalOperatorType::TABLE_SCAN: {
+		auto &get = (PhysicalTableScan &)*op;
+		if (get.function.table_scan_progress) {
+			return get.function.table_scan_progress(context, get.bind_data.get());
+		}
+		return -1;
+	}
+	default: {
+		vector<idx_t> progress;
+		vector<idx_t> cardinality;
+		double total_cardinality = 0;
+		double cur_percentage = 0;
+		for (auto &op_child : op->children) {
+			progress.push_back(GetProgress(context, op_child.get()));
+			cardinality.push_back(op_child->estimated_cardinality);
+			total_cardinality += op_child->estimated_cardinality;
+		}
+		for (size_t i = 0; i < progress.size(); i++) {
+			cur_percentage += progress[i] * cardinality[i] / total_cardinality;
+		}
+		return cur_percentage;
+	}
+	}
+}
 
-    int Pipeline::GetProgress() {
-        auto &client = executor.context;
-        return GetProgress(client, child);
-    }
+int Pipeline::GetProgress() {
+	auto &client = executor.context;
+	return GetProgress(client, child);
+}
 
+void Pipeline::Execute(TaskContext &task) {
+	auto &client = executor.context;
+	if (client.interrupted) {
+		return;
+	}
+	if (parallel_state) {
+		task.task_info[parallel_node] = parallel_state.get();
+	}
 
-    void Pipeline::Execute(TaskContext &task) {
-        auto &client = executor.context;
-        if (client.interrupted) {
-            return;
-        }
-        if (parallel_state) {
-            task.task_info[parallel_node] = parallel_state.get();
-        }
+	ThreadContext thread(client);
+	ExecutionContext context(client, thread, task);
+	try {
+		auto state = child->GetOperatorState();
+		auto lstate = sink->GetLocalSinkState(context);
+		// incrementally process the pipeline
+		DataChunk intermediate;
+		child->InitializeChunkEmpty(intermediate);
+		while (true) {
+			child->GetChunk(context, intermediate, state.get());
+			thread.profiler.StartOperator(sink);
+			if (intermediate.size() == 0) {
+				sink->Combine(context, *sink_state, *lstate);
+				break;
+			}
+			sink->Sink(context, *sink_state, *lstate, intermediate);
+			thread.profiler.EndOperator(nullptr);
+		}
+	} catch (std::exception &ex) {
+		executor.PushError(ex.what());
+	} catch (...) {
+		executor.PushError("Unknown exception in pipeline!");
+	}
+	executor.Flush(thread);
+}
 
-        ThreadContext thread(client);
-        ExecutionContext context(client, thread, task);
-        try {
-            auto state = child->GetOperatorState();
-            auto lstate = sink->GetLocalSinkState(context);
-            // incrementally process the pipeline
-            DataChunk intermediate;
-            child->InitializeChunkEmpty(intermediate);
-            while (true) {
-                child->GetChunk(context, intermediate, state.get());
-                thread.profiler.StartOperator(sink);
-                if (intermediate.size() == 0) {
-                    sink->Combine(context, *sink_state, *lstate);
-                    break;
-                }
-                sink->Sink(context, *sink_state, *lstate, intermediate);
-                thread.profiler.EndOperator(nullptr);
-            }
-        } catch (std::exception &ex) {
-            executor.PushError(ex.what());
-        } catch (...) {
-            executor.PushError("Unknown exception in pipeline!");
-        }
-        executor.Flush(thread);
-    }
+void Pipeline::FinishTask() {
+	D_ASSERT(finished_tasks < total_tasks);
+	idx_t current_finished = ++finished_tasks;
+	if (current_finished == total_tasks) {
+		try {
+			sink->Finalize(*this, executor.context, move(sink_state));
+		} catch (std::exception &ex) {
+			executor.PushError(ex.what());
+		} catch (...) {
+			executor.PushError("Unknown exception in Finalize!");
+		}
+		if (current_finished == total_tasks) {
+			Finish();
+		}
+	}
+}
 
-    void Pipeline::FinishTask() {
-        D_ASSERT(finished_tasks < total_tasks);
-        idx_t current_finished = ++finished_tasks;
-        if (current_finished == total_tasks) {
-            try {
-                sink->Finalize(*this, executor.context, move(sink_state));
-            } catch (std::exception &ex) {
-                executor.PushError(ex.what());
-            } catch (...) {
-                executor.PushError("Unknown exception in Finalize!");
-            }
-            if (current_finished == total_tasks) {
-                Finish();
-            }
-        }
-    }
+void Pipeline::ScheduleSequentialTask() {
+	auto &scheduler = TaskScheduler::GetScheduler(executor.context);
+	auto task = make_unique<PipelineTask>(this);
 
-    void Pipeline::ScheduleSequentialTask() {
-        auto &scheduler = TaskScheduler::GetScheduler(executor.context);
-        auto task = make_unique<PipelineTask>(this);
+	this->total_tasks = 1;
+	scheduler.ScheduleTask(*executor.producer, move(task));
+}
 
-        this->total_tasks = 1;
-        scheduler.ScheduleTask(*executor.producer, move(task));
-    }
+bool Pipeline::ScheduleOperator(PhysicalOperator *op) {
+	switch (op->type) {
+	case PhysicalOperatorType::UNNEST:
+	case PhysicalOperatorType::FILTER:
+	case PhysicalOperatorType::PROJECTION:
+	case PhysicalOperatorType::HASH_JOIN:
+	case PhysicalOperatorType::CROSS_PRODUCT:
+	case PhysicalOperatorType::STREAMING_SAMPLE:
+		// filter, projection or hash probe: continue in children
+		return ScheduleOperator(op->children[0].get());
+	case PhysicalOperatorType::TABLE_SCAN: {
+		// we reached a scan: split it up into parts and schedule the parts
+		auto &scheduler = TaskScheduler::GetScheduler(executor.context);
+		auto &get = (PhysicalTableScan &)*op;
+		if (!get.function.max_threads) {
+			// table function cannot be parallelized
+			return false;
+		}
+		D_ASSERT(get.function.init_parallel_state);
+		D_ASSERT(get.function.parallel_state_next);
+		idx_t max_threads = get.function.max_threads(executor.context, get.bind_data.get());
+		if (max_threads > executor.context.db->NumberOfThreads()) {
+			max_threads = executor.context.db->NumberOfThreads();
+		}
+		if (max_threads <= 1) {
+			// table is too small to parallelize
+			return false;
+		}
+		this->parallel_state = get.function.init_parallel_state(executor.context, get.bind_data.get());
+		this->parallel_node = op;
 
-    bool Pipeline::ScheduleOperator(PhysicalOperator *op) {
-        switch (op->type) {
-            case PhysicalOperatorType::UNNEST:
-            case PhysicalOperatorType::FILTER:
-            case PhysicalOperatorType::PROJECTION:
-            case PhysicalOperatorType::HASH_JOIN:
-            case PhysicalOperatorType::CROSS_PRODUCT:
-            case PhysicalOperatorType::STREAMING_SAMPLE:
-                // filter, projection or hash probe: continue in children
-                return ScheduleOperator(op->children[0].get());
-            case PhysicalOperatorType::TABLE_SCAN: {
-                // we reached a scan: split it up into parts and schedule the parts
-                auto &scheduler = TaskScheduler::GetScheduler(executor.context);
-                auto &get = (PhysicalTableScan &) *op;
-                if (!get.function.max_threads) {
-                    // table function cannot be parallelized
-                    return false;
-                }
-                D_ASSERT(get.function.init_parallel_state);
-                D_ASSERT(get.function.parallel_state_next);
-                idx_t max_threads = get.function.max_threads(executor.context, get.bind_data.get());
-                if (max_threads > executor.context.db->NumberOfThreads()) {
-                    max_threads = executor.context.db->NumberOfThreads();
-                }
-                if (max_threads <= 1) {
-                    // table is too small to parallelize
-                    return false;
-                }
-                this->parallel_state = get.function.init_parallel_state(executor.context, get.bind_data.get());
-                this->parallel_node = op;
+		// launch a task for every thread
+		this->total_tasks = max_threads;
+		for (idx_t i = 0; i < max_threads; i++) {
+			auto task = make_unique<PipelineTask>(this);
+			scheduler.ScheduleTask(*executor.producer, move(task));
+		}
+		return true;
+	}
+	case PhysicalOperatorType::HASH_GROUP_BY: {
+		// FIXME: parallelize scan of GROUP_BY HT
+		return false;
+	}
+	default:
+		// unknown operator: skip parallel task scheduling
+		return false;
+	}
+}
 
-                // launch a task for every thread
-                this->total_tasks = max_threads;
-                for (idx_t i = 0; i < max_threads; i++) {
-                    auto task = make_unique<PipelineTask>(this);
-                    scheduler.ScheduleTask(*executor.producer, move(task));
-                }
-                return true;
-            }
-            case PhysicalOperatorType::HASH_GROUP_BY: {
-                // FIXME: parallelize scan of GROUP_BY HT
-                return false;
-            }
-            default:
-                // unknown operator: skip parallel task scheduling
-                return false;
-        }
-    }
+void Pipeline::ClearParents() {
+	for (auto &parent : parents) {
+		parent->dependencies.erase(this);
+	}
+	for (auto &dep : dependencies) {
+		dep->parents.erase(this);
+	}
+	parents.clear();
+	dependencies.clear();
+}
 
-    void Pipeline::ClearParents() {
-        for (auto &parent : parents) {
-            parent->dependencies.erase(this);
-        }
-        for (auto &dep : dependencies) {
-            dep->parents.erase(this);
-        }
-        parents.clear();
-        dependencies.clear();
-    }
+void Pipeline::Reset(ClientContext &context) {
+	sink_state = sink->GetGlobalState(context);
+	finished_tasks = 0;
+	total_tasks = 0;
+	finished = false;
+}
 
-    void Pipeline::Reset(ClientContext &context) {
-        sink_state = sink->GetGlobalState(context);
-        finished_tasks = 0;
-        total_tasks = 0;
-        finished = false;
-    }
+void Pipeline::Schedule() {
+	D_ASSERT(finished_tasks == 0);
+	D_ASSERT(total_tasks == 0);
+	D_ASSERT(finished_dependencies == dependencies.size());
+	// check if we can parallelize this task based on the sink
+	switch (sink->type) {
+	case PhysicalOperatorType::SIMPLE_AGGREGATE: {
+		auto &simple_aggregate = (PhysicalSimpleAggregate &)*sink;
+		// simple aggregate: check if we can parallelize it
+		if (!simple_aggregate.all_combinable) {
+			// not all aggregates are parallelizable: switch to sequential mode
+			break;
+		}
+		if (ScheduleOperator(sink->children[0].get())) {
+			// all parallel tasks have been scheduled: return
+			return;
+		}
+		break;
+	}
+	case PhysicalOperatorType::CREATE_TABLE_AS:
+	case PhysicalOperatorType::ORDER_BY:
+	case PhysicalOperatorType::RESERVOIR_SAMPLE:
+	case PhysicalOperatorType::PERFECT_HASH_GROUP_BY: {
+		// perfect hash aggregate can always be parallelized
+		if (ScheduleOperator(sink->children[0].get())) {
+			// all parallel tasks have been scheduled: return
+			return;
+		}
+		break;
+	}
+	case PhysicalOperatorType::HASH_GROUP_BY: {
+		auto &hash_aggr = (PhysicalHashAggregate &)*sink;
+		if (!hash_aggr.all_combinable) {
+			// not all aggregates are parallelizable: switch to sequential mode
+			break;
+		}
+		if (ScheduleOperator(sink->children[0].get())) {
+			// all parallel tasks have been scheduled: return
+			return;
+		}
+		break;
+	}
+	case PhysicalOperatorType::CROSS_PRODUCT:
+	case PhysicalOperatorType::HASH_JOIN: {
+		// schedule build side of the join
+		if (ScheduleOperator(sink->children[1].get())) {
+			// all parallel tasks have been scheduled: return
+			return;
+		}
+		break;
+	}
+	case PhysicalOperatorType::WINDOW: {
+		// schedule child op
+		if (ScheduleOperator(sink->children[0].get())) {
+			// all parallel tasks have been scheduled: return
+			return;
+		}
+		break;
+	}
+	default:
+		break;
+	}
+	// could not parallelize this pipeline: push a sequential task instead
+	ScheduleSequentialTask();
+}
 
-    void Pipeline::Schedule() {
-        D_ASSERT(finished_tasks == 0);
-        D_ASSERT(total_tasks == 0);
-        D_ASSERT(finished_dependencies == dependencies.size());
-        // check if we can parallelize this task based on the sink
-        switch (sink->type) {
-            case PhysicalOperatorType::SIMPLE_AGGREGATE: {
-                auto &simple_aggregate = (PhysicalSimpleAggregate &) *sink;
-                // simple aggregate: check if we can parallelize it
-                if (!simple_aggregate.all_combinable) {
-                    // not all aggregates are parallelizable: switch to sequential mode
-                    break;
-                }
-                if (ScheduleOperator(sink->children[0].get())) {
-                    // all parallel tasks have been scheduled: return
-                    return;
-                }
-                break;
-            }
-            case PhysicalOperatorType::CREATE_TABLE_AS:
-            case PhysicalOperatorType::ORDER_BY:
-            case PhysicalOperatorType::RESERVOIR_SAMPLE:
-            case PhysicalOperatorType::PERFECT_HASH_GROUP_BY: {
-                // perfect hash aggregate can always be parallelized
-                if (ScheduleOperator(sink->children[0].get())) {
-                    // all parallel tasks have been scheduled: return
-                    return;
-                }
-                break;
-            }
-            case PhysicalOperatorType::HASH_GROUP_BY: {
-                auto &hash_aggr = (PhysicalHashAggregate &) *sink;
-                if (!hash_aggr.all_combinable) {
-                    // not all aggregates are parallelizable: switch to sequential mode
-                    break;
-                }
-                if (ScheduleOperator(sink->children[0].get())) {
-                    // all parallel tasks have been scheduled: return
-                    return;
-                }
-                break;
-            }
-            case PhysicalOperatorType::CROSS_PRODUCT:
-            case PhysicalOperatorType::HASH_JOIN: {
-                // schedule build side of the join
-                if (ScheduleOperator(sink->children[1].get())) {
-                    // all parallel tasks have been scheduled: return
-                    return;
-                }
-                break;
-            }
-            case PhysicalOperatorType::WINDOW: {
-                // schedule child op
-                if (ScheduleOperator(sink->children[0].get())) {
-                    // all parallel tasks have been scheduled: return
-                    return;
-                }
-                break;
-            }
-            default:
-                break;
-        }
-        // could not parallelize this pipeline: push a sequential task instead
-        ScheduleSequentialTask();
-    }
+void Pipeline::AddDependency(Pipeline *pipeline) {
+	this->dependencies.insert(pipeline);
+	pipeline->parents.insert(this);
+}
 
-    void Pipeline::AddDependency(Pipeline *pipeline) {
-        this->dependencies.insert(pipeline);
-        pipeline->parents.insert(this);
-    }
+void Pipeline::CompleteDependency() {
+	idx_t current_finished = ++finished_dependencies;
+	D_ASSERT(current_finished <= dependencies.size());
+	if (current_finished == dependencies.size()) {
+		// all dependencies have been completed: schedule the pipeline
+		Schedule();
+	}
+}
 
-    void Pipeline::CompleteDependency() {
-        idx_t current_finished = ++finished_dependencies;
-        D_ASSERT(current_finished <= dependencies.size());
-        if (current_finished == dependencies.size()) {
-            // all dependencies have been completed: schedule the pipeline
-            Schedule();
-        }
-    }
+void Pipeline::Finish() {
+	D_ASSERT(!finished);
+	finished = true;
+	// finished processing the pipeline, now we can schedule pipelines that depend on this pipeline
+	for (auto &parent : parents) {
+		// mark a dependency as completed for each of the parents
+		parent->CompleteDependency();
+	}
+	executor.completed_pipelines++;
+}
 
-    void Pipeline::Finish() {
-        D_ASSERT(!finished);
-        finished = true;
-        // finished processing the pipeline, now we can schedule pipelines that depend on this pipeline
-        for (auto &parent : parents) {
-            // mark a dependency as completed for each of the parents
-            parent->CompleteDependency();
-        }
-        executor.completed_pipelines++;
-    }
+string Pipeline::ToString() const {
+	string str = PhysicalOperatorToString(sink->type);
+	auto node = this->child;
+	while (node) {
+		str = PhysicalOperatorToString(node->type) + " -> " + str;
+		node = node->children[0].get();
+	}
+	return str;
+}
 
-    string Pipeline::ToString() const {
-        string str = PhysicalOperatorToString(sink->type);
-        auto node = this->child;
-        while (node) {
-            str = PhysicalOperatorToString(node->type) + " -> " + str;
-            node = node->children[0].get();
-        }
-        return str;
-    }
-
-    void Pipeline::Print() const {
-        Printer::Print(ToString());
-    }
+void Pipeline::Print() const {
+	Printer::Print(ToString());
+}
 
 } // namespace duckdb

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1081,6 +1081,10 @@ void DataTable::CommitDropColumn(idx_t index) {
 	}
 }
 
+idx_t DataTable::GetTotalRows(){
+    return total_rows;
+}
+
 void DataTable::CommitDropTable() {
 	// commit a drop of this table: mark all blocks as modified so they can be reclaimed later on
 	for (size_t i = 0; i < columns.size(); i++) {

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1081,8 +1081,8 @@ void DataTable::CommitDropColumn(idx_t index) {
 	}
 }
 
-idx_t DataTable::GetTotalRows(){
-    return total_rows;
+idx_t DataTable::GetTotalRows() {
+	return total_rows;
 }
 
 void DataTable::CommitDropTable() {

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -10,7 +10,8 @@ set(TEST_API_OBJECTS
     test_appender_api.cpp
     test_relation_api.cpp
     test_query_profiler.cpp
-    test_dbdir.cpp)
+    test_dbdir.cpp
+    test_progress_bar.cpp)
 
 if(NOT WIN32)
   set(TEST_API_OBJECTS ${TEST_API_OBJECTS} test_read_only.cpp)

--- a/test/api/test_progress_bar.cpp
+++ b/test/api/test_progress_bar.cpp
@@ -14,6 +14,7 @@ TEST_CASE("Test Progress Bar", "[api]") {
 	ProgressBar progress_check(&con.context->executor, 0, 10, true);
 	REQUIRE_NO_FAIL(con.Query("create  table tbl as select range a from range(100000000);"));
 	REQUIRE_NO_FAIL(con.Query("create  table tbl_2 as select range a from range(1000);"));
+
 	//! Simple Aggregation
 	progress_check.Start();
 	REQUIRE_NO_FAIL(con.Query("select count(*) from tbl"));
@@ -25,6 +26,7 @@ TEST_CASE("Test Progress Bar", "[api]") {
 	REQUIRE_NO_FAIL(con.Query("select count(*) from tbl inner join tbl_2 on (tbl.a = tbl_2.a)"));
 	progress_check.Stop();
 	REQUIRE(progress_check.IsPercentageValid());
+
 
 	//! Test Multiple threads
 	REQUIRE_NO_FAIL(con.Query("PRAGMA threads=4"));
@@ -39,6 +41,19 @@ TEST_CASE("Test Progress Bar", "[api]") {
 	//! Simple Join
 	progress_check.Start();
 	REQUIRE_NO_FAIL(con.Query("select count(*) from tbl inner join tbl_2 on (tbl.a = tbl_2.a)"));
+	progress_check.Stop();
+	REQUIRE(progress_check.IsPercentageValid());
+}
+
+TEST_CASE("Test Progress Bar CSV Reader", "[api]") {
+	unique_ptr<QueryResult> result;
+	DuckDB db(nullptr);
+	Connection con(db);
+	ProgressBar progress_check(&con.context->executor, 0, 1, false);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE test (a INTEGER, b INTEGER, c VARCHAR(10));"));
+	//! Simple Aggregation
+	progress_check.Start();
+	REQUIRE_NO_FAIL(con.Query("COPY test FROM 'test/sql/copy/csv/data/test/test.csv';"));
 	progress_check.Stop();
 	REQUIRE(progress_check.IsPercentageValid());
 }

--- a/test/api/test_progress_bar.cpp
+++ b/test/api/test_progress_bar.cpp
@@ -3,78 +3,42 @@
 #include "catch.hpp"
 #include "test_helpers.hpp"
 #include "duckdb/main/client_context.hpp"
-
+#include "duckdb/common/progress_bar.hpp"
 using namespace duckdb;
 using namespace std;
-
-class ProgressCheck {
-public:
-	bool finished = false;
-	Executor *executor = nullptr;
-	thread progress_bar_thread;
-	promise<void> exit_signal;
-	future<void> future_obj = exit_signal.get_future();
-	int cur_percentage = 0;
-
-	explicit ProgressCheck(Executor *executor)
-	    : executor(executor) {
-
-	      };
-
-	void GetProgress() {
-		while (!StopRequested()) {
-			assert(cur_percentage <= executor->GetPipelinesProgress() && executor->GetPipelinesProgress() <= 100);
-			cur_percentage = executor->GetPipelinesProgress();
-			std::this_thread::sleep_for(std::chrono::milliseconds(10));
-		}
-	}
-
-	void Start() {
-		exit_signal = promise<void>();
-		cur_percentage = 0;
-		progress_bar_thread = std::thread(&ProgressCheck::GetProgress, this);
-	}
-
-	bool StopRequested() {
-		if (future_obj.wait_for(std::chrono::milliseconds(0)) == std::future_status::timeout) {
-			return false;
-		}
-		return true;
-	}
-
-	void Stop() {
-		if (progress_bar_thread.joinable()) {
-			exit_signal.set_value();
-			progress_bar_thread.join();
-		}
-	}
-};
 
 TEST_CASE("Test Progress Bar", "[api]") {
 	unique_ptr<QueryResult> result;
 	DuckDB db(nullptr);
 	Connection con(db);
-	ProgressCheck progress_check(&con.context->executor);
+	ProgressBar progress_check(&con.context->executor, 0, 10, true);
 	REQUIRE_NO_FAIL(con.Query("create  table tbl as select range a from range(100000000);"));
 	REQUIRE_NO_FAIL(con.Query("create  table tbl_2 as select range a from range(1000);"));
 	//! Simple Aggregation
 	progress_check.Start();
 	REQUIRE_NO_FAIL(con.Query("select count(*) from tbl"));
 	progress_check.Stop();
+	REQUIRE(progress_check.IsPercentageValid());
+
 	//! Simple Join
 	progress_check.Start();
 	REQUIRE_NO_FAIL(con.Query("select count(*) from tbl inner join tbl_2 on (tbl.a = tbl_2.a)"));
 	progress_check.Stop();
+	REQUIRE(progress_check.IsPercentageValid());
 
 	//! Test Multiple threads
 	REQUIRE_NO_FAIL(con.Query("PRAGMA threads=4"));
 	REQUIRE_NO_FAIL(con.Query("PRAGMA force_parallelism"));
+
 	//! Simple Aggregation
 	progress_check.Start();
 	REQUIRE_NO_FAIL(con.Query("select count(*) from tbl"));
 	progress_check.Stop();
+	REQUIRE(progress_check.IsPercentageValid());
+
 	//! Simple Join
 	progress_check.Start();
 	REQUIRE_NO_FAIL(con.Query("select count(*) from tbl inner join tbl_2 on (tbl.a = tbl_2.a)"));
 	progress_check.Stop();
+	REQUIRE(progress_check.IsPercentageValid());
 }

--- a/test/api/test_progress_bar.cpp
+++ b/test/api/test_progress_bar.cpp
@@ -11,48 +11,27 @@ TEST_CASE("Test Progress Bar", "[api]") {
 	unique_ptr<QueryResult> result;
 	DuckDB db(nullptr);
 	Connection con(db);
-	ProgressBar progress_check(&con.context->executor, 0, 10, true);
 	REQUIRE_NO_FAIL(con.Query("create  table tbl as select range a from range(10000000);"));
-	REQUIRE_NO_FAIL(con.Query("create  table tbl_2 as select range a from range(1000);"));
+	REQUIRE_NO_FAIL(con.Query("create  table tbl_2 as select range a from range(10000000);"));
 
+	REQUIRE_NO_FAIL(con.Query("PRAGMA set_progress_bar_time=10"));
 	//! Simple Aggregation
-	progress_check.Start();
 	REQUIRE_NO_FAIL(con.Query("select count(*) from tbl"));
-	progress_check.Stop();
-	REQUIRE(progress_check.IsPercentageValid());
+	REQUIRE(con.context->progress_bar->IsPercentageValid());
 
 	//! Simple Join
-	progress_check.Start();
 	REQUIRE_NO_FAIL(con.Query("select count(*) from tbl inner join tbl_2 on (tbl.a = tbl_2.a)"));
-	progress_check.Stop();
-	REQUIRE(progress_check.IsPercentageValid());
+	REQUIRE(con.context->progress_bar->IsPercentageValid());
 
 	//! Test Multiple threads
 	REQUIRE_NO_FAIL(con.Query("PRAGMA threads=4"));
 	REQUIRE_NO_FAIL(con.Query("PRAGMA force_parallelism"));
 
 	//! Simple Aggregation
-	progress_check.Start();
 	REQUIRE_NO_FAIL(con.Query("select count(*) from tbl"));
-	progress_check.Stop();
-	REQUIRE(progress_check.IsPercentageValid());
+	REQUIRE(con.context->progress_bar->IsPercentageValid());
 
 	//! Simple Join
-	progress_check.Start();
 	REQUIRE_NO_FAIL(con.Query("select count(*) from tbl inner join tbl_2 on (tbl.a = tbl_2.a)"));
-	progress_check.Stop();
-	REQUIRE(progress_check.IsPercentageValid());
-}
-
-TEST_CASE("Test Progress Bar CSV Reader", "[api]") {
-	unique_ptr<QueryResult> result;
-	DuckDB db(nullptr);
-	Connection con(db);
-	ProgressBar progress_check(&con.context->executor, 0, 1, false);
-	REQUIRE_NO_FAIL(con.Query("CREATE TABLE test (a INTEGER, b INTEGER, c VARCHAR(10));"));
-	//! Simple Aggregation
-	progress_check.Start();
-	REQUIRE_NO_FAIL(con.Query("COPY test FROM 'test/sql/copy/csv/data/test/test.csv';"));
-	progress_check.Stop();
-	REQUIRE(progress_check.IsPercentageValid());
+	REQUIRE(con.context->progress_bar->IsPercentageValid());
 }

--- a/test/api/test_progress_bar.cpp
+++ b/test/api/test_progress_bar.cpp
@@ -1,0 +1,80 @@
+#include <duckdb/execution/executor.hpp>
+#include <future>
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "duckdb/main/client_context.hpp"
+
+using namespace duckdb;
+using namespace std;
+
+class ProgressCheck {
+public:
+	bool finished = false;
+	Executor *executor = nullptr;
+	thread progress_bar_thread;
+	promise<void> exit_signal;
+	future<void> future_obj = exit_signal.get_future();
+	int cur_percentage = 0;
+
+	explicit ProgressCheck(Executor *executor)
+	    : executor(executor) {
+
+	      };
+
+	void GetProgress() {
+		while (!StopRequested()) {
+			assert(cur_percentage <= executor->GetPipelinesProgress() && executor->GetPipelinesProgress() <= 100);
+			cur_percentage = executor->GetPipelinesProgress();
+			std::this_thread::sleep_for(std::chrono::milliseconds(10));
+		}
+	}
+
+	void Start() {
+		exit_signal = promise<void>();
+		cur_percentage = 0;
+		progress_bar_thread = std::thread(&ProgressCheck::GetProgress, this);
+	}
+
+	bool StopRequested() {
+		if (future_obj.wait_for(std::chrono::milliseconds(0)) == std::future_status::timeout) {
+			return false;
+		}
+		return true;
+	}
+
+	void Stop() {
+		if (progress_bar_thread.joinable()) {
+			exit_signal.set_value();
+			progress_bar_thread.join();
+		}
+	}
+};
+
+TEST_CASE("Test Progress Bar", "[api]") {
+	unique_ptr<QueryResult> result;
+	DuckDB db(nullptr);
+	Connection con(db);
+	ProgressCheck progress_check(&con.context->executor);
+	REQUIRE_NO_FAIL(con.Query("create  table tbl as select range a from range(100000000);"));
+	REQUIRE_NO_FAIL(con.Query("create  table tbl_2 as select range a from range(1000);"));
+	//! Simple Aggregation
+	progress_check.Start();
+	REQUIRE_NO_FAIL(con.Query("select count(*) from tbl"));
+	progress_check.Stop();
+	//! Simple Join
+	progress_check.Start();
+	REQUIRE_NO_FAIL(con.Query("select count(*) from tbl inner join tbl_2 on (tbl.a = tbl_2.a)"));
+	progress_check.Stop();
+
+	//! Test Multiple threads
+	REQUIRE_NO_FAIL(con.Query("PRAGMA threads=4"));
+	REQUIRE_NO_FAIL(con.Query("PRAGMA force_parallelism"));
+	//! Simple Aggregation
+	progress_check.Start();
+	REQUIRE_NO_FAIL(con.Query("select count(*) from tbl"));
+	progress_check.Stop();
+	//! Simple Join
+	progress_check.Start();
+	REQUIRE_NO_FAIL(con.Query("select count(*) from tbl inner join tbl_2 on (tbl.a = tbl_2.a)"));
+	progress_check.Stop();
+}

--- a/test/api/test_progress_bar.cpp
+++ b/test/api/test_progress_bar.cpp
@@ -12,7 +12,7 @@ TEST_CASE("Test Progress Bar", "[api]") {
 	DuckDB db(nullptr);
 	Connection con(db);
 	ProgressBar progress_check(&con.context->executor, 0, 10, true);
-	REQUIRE_NO_FAIL(con.Query("create  table tbl as select range a from range(100000000);"));
+	REQUIRE_NO_FAIL(con.Query("create  table tbl as select range a from range(10000000);"));
 	REQUIRE_NO_FAIL(con.Query("create  table tbl_2 as select range a from range(1000);"));
 
 	//! Simple Aggregation
@@ -26,7 +26,6 @@ TEST_CASE("Test Progress Bar", "[api]") {
 	REQUIRE_NO_FAIL(con.Query("select count(*) from tbl inner join tbl_2 on (tbl.a = tbl_2.a)"));
 	progress_check.Stop();
 	REQUIRE(progress_check.IsPercentageValid());
-
 
 	//! Test Multiple threads
 	REQUIRE_NO_FAIL(con.Query("PRAGMA threads=4"));

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -15,8 +15,6 @@
 
 #include "extension_helper.hpp"
 
-#include "duckdb/common/progress_bar.hpp"
-
 using namespace duckdb;
 using namespace std;
 
@@ -217,13 +215,8 @@ int sqlite3_step(sqlite3_stmt *pStmt) {
 	}
 	pStmt->current_text = nullptr;
 	if (!pStmt->result) {
-		ProgressBar progress_bar(&pStmt->prepared->context->executor, 2000, 100);
-		if (pStmt->prepared->GetStatementType() == StatementType::SELECT_STATEMENT) {
-			progress_bar.Start();
-		}
 		// no result yet! call Execute()
 		pStmt->result = pStmt->prepared->Execute(pStmt->bound_values, false);
-		progress_bar.Stop();
 		if (!pStmt->result->success) {
 			// error in execute: clear prepared statement
 			pStmt->db->last_error = pStmt->result->error;

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -14,6 +14,10 @@
 #include <cassert>
 
 #include "extension_helper.hpp"
+#include <unistd.h>
+#include <iostream>
+#include <thread>
+#include <future>
 
 using namespace duckdb;
 using namespace std;
@@ -21,54 +25,54 @@ using namespace std;
 static char *sqlite3_strdup(const char *str);
 
 struct sqlite3_string_buffer {
-	//! String data
-	unique_ptr<char[]> data;
+    //! String data
+    unique_ptr<char[]> data;
 };
 
 struct sqlite3_stmt {
-	//! The DB object that this statement belongs to
-	sqlite3 *db;
-	//! The query string
-	string query_string;
-	//! The prepared statement object, if successfully prepared
-	unique_ptr<PreparedStatement> prepared;
-	//! The result object, if successfully executed
-	unique_ptr<QueryResult> result;
-	//! The current chunk that we are iterating over
-	unique_ptr<DataChunk> current_chunk;
-	//! The current row into the current chunk that we are iterating over
-	int64_t current_row;
-	//! Bound values, used for binding to the prepared statement
-	vector<Value> bound_values;
-	//! Names of the prepared parameters
-	vector<string> bound_names;
-	//! The current column values converted to string, used and filled by sqlite3_column_text
-	unique_ptr<sqlite3_string_buffer[]> current_text;
+    //! The DB object that this statement belongs to
+    sqlite3 *db;
+    //! The query string
+    string query_string;
+    //! The prepared statement object, if successfully prepared
+    unique_ptr<PreparedStatement> prepared;
+    //! The result object, if successfully executed
+    unique_ptr<QueryResult> result;
+    //! The current chunk that we are iterating over
+    unique_ptr<DataChunk> current_chunk;
+    //! The current row into the current chunk that we are iterating over
+    int64_t current_row;
+    //! Bound values, used for binding to the prepared statement
+    vector<Value> bound_values;
+    //! Names of the prepared parameters
+    vector<string> bound_names;
+    //! The current column values converted to string, used and filled by sqlite3_column_text
+    unique_ptr<sqlite3_string_buffer[]> current_text;
 };
 
 struct sqlite3 {
-	unique_ptr<DuckDB> db;
-	unique_ptr<Connection> con;
-	string last_error;
+    unique_ptr<DuckDB> db;
+    unique_ptr<Connection> con;
+    string last_error;
 };
 
 void sqlite3_randomness(int N, void *pBuf) {
-	static bool init = false;
-	if (!init) {
-		srand(time(NULL));
-		init = true;
-	}
-	unsigned char *zBuf = (unsigned char *)pBuf;
-	while (N--) {
-		unsigned char nextByte = rand() % 255;
-		zBuf[N] = nextByte;
-	}
+    static bool init = false;
+    if (!init) {
+        srand(time(NULL));
+        init = true;
+    }
+    unsigned char *zBuf = (unsigned char *) pBuf;
+    while (N--) {
+        unsigned char nextByte = rand() % 255;
+        zBuf[N] = nextByte;
+    }
 }
 
 int sqlite3_open(const char *filename, /* Database filename (UTF-8) */
                  sqlite3 **ppDb        /* OUT: SQLite db handle */
 ) {
-	return sqlite3_open_v2(filename, ppDb, 0, NULL);
+    return sqlite3_open_v2(filename, ppDb, 0, NULL);
 }
 
 int sqlite3_open_v2(const char *filename, /* Database filename (UTF-8) */
@@ -76,44 +80,44 @@ int sqlite3_open_v2(const char *filename, /* Database filename (UTF-8) */
                     int flags,            /* Flags */
                     const char *zVfs      /* Name of VFS module to use */
 ) {
-	if (filename && strcmp(filename, ":memory:") == 0) {
-		filename = NULL;
-	}
-	*ppDb = nullptr;
-	if (zVfs) { /* unsupported so if set we complain */
-		return SQLITE_ERROR;
-	}
-	sqlite3 *pDb = nullptr;
-	try {
-		pDb = new sqlite3();
-		DBConfig config;
-		config.access_mode = AccessMode::AUTOMATIC;
-		if (flags & SQLITE_OPEN_READONLY) {
-			config.access_mode = AccessMode::READ_ONLY;
-		}
-		pDb->db = make_unique<DuckDB>(filename, &config);
-		pDb->con = make_unique<Connection>(*pDb->db);
+    if (filename && strcmp(filename, ":memory:") == 0) {
+        filename = NULL;
+    }
+    *ppDb = nullptr;
+    if (zVfs) { /* unsupported so if set we complain */
+        return SQLITE_ERROR;
+    }
+    sqlite3 *pDb = nullptr;
+    try {
+        pDb = new sqlite3();
+        DBConfig config;
+        config.access_mode = AccessMode::AUTOMATIC;
+        if (flags & SQLITE_OPEN_READONLY) {
+            config.access_mode = AccessMode::READ_ONLY;
+        }
+        pDb->db = make_unique<DuckDB>(filename, &config);
+        pDb->con = make_unique<Connection>(*pDb->db);
 
-		ExtensionHelper::LoadAllExtensions(*pDb->db);
-	} catch (std::exception &ex) {
-		if (pDb) {
-			pDb->last_error = ex.what();
-		}
-		return SQLITE_ERROR;
-	}
-	*ppDb = pDb;
-	return SQLITE_OK;
+        ExtensionHelper::LoadAllExtensions(*pDb->db);
+    } catch (std::exception &ex) {
+        if (pDb) {
+            pDb->last_error = ex.what();
+        }
+        return SQLITE_ERROR;
+    }
+    *ppDb = pDb;
+    return SQLITE_OK;
 }
 
 int sqlite3_close(sqlite3 *db) {
-	if (db) {
-		delete db;
-	}
-	return SQLITE_OK;
+    if (db) {
+        delete db;
+    }
+    return SQLITE_OK;
 }
 
 int sqlite3_shutdown(void) {
-	return SQLITE_OK;
+    return SQLITE_OK;
 }
 
 /* In SQLite this function compiles the query into VDBE bytecode,
@@ -125,126 +129,185 @@ int sqlite3_prepare_v2(sqlite3 *db,           /* Database handle */
                        sqlite3_stmt **ppStmt, /* OUT: Statement handle */
                        const char **pzTail    /* OUT: Pointer to unused portion of zSql */
 ) {
-	if (!db || !ppStmt || !zSql) {
-		return SQLITE_MISUSE;
-	}
-	*ppStmt = nullptr;
-	string query = nByte < 0 ? zSql : string(zSql, nByte);
-	if (pzTail) {
-		*pzTail = zSql + query.size();
-	}
-	try {
-		Parser parser;
-		parser.ParseQuery(query);
-		if (parser.statements.size() == 0) {
-			return SQLITE_OK;
-		}
-		// extract the remainder
-		idx_t next_location = parser.statements[0]->stmt_location + parser.statements[0]->stmt_length;
-		bool set_remainder = next_location < query.size();
+    if (!db || !ppStmt || !zSql) {
+        return SQLITE_MISUSE;
+    }
+    *ppStmt = nullptr;
+    string query = nByte < 0 ? zSql : string(zSql, nByte);
+    if (pzTail) {
+        *pzTail = zSql + query.size();
+    }
+    try {
+        Parser parser;
+        parser.ParseQuery(query);
+        if (parser.statements.size() == 0) {
+            return SQLITE_OK;
+        }
+        // extract the remainder
+        idx_t next_location = parser.statements[0]->stmt_location + parser.statements[0]->stmt_length;
+        bool set_remainder = next_location < query.size();
 
-		// extract the first statement
-		vector<unique_ptr<SQLStatement>> statements;
-		statements.push_back(move(parser.statements[0]));
+        // extract the first statement
+        vector<unique_ptr<SQLStatement>> statements;
+        statements.push_back(move(parser.statements[0]));
 
-		db->con->context->HandlePragmaStatements(statements);
+        db->con->context->HandlePragmaStatements(statements);
 
-		// if there are multiple statements here, we are dealing with an import database statement
-		// we directly execute all statements besides the final one
-		for (idx_t i = 0; i + 1 < statements.size(); i++) {
-			auto res = db->con->Query(move(statements[i]));
-			if (!res->success) {
-				db->last_error = res->error;
-				return SQLITE_ERROR;
-			}
-		}
+        // if there are multiple statements here, we are dealing with an import database statement
+        // we directly execute all statements besides the final one
+        for (idx_t i = 0; i + 1 < statements.size(); i++) {
+            auto res = db->con->Query(move(statements[i]));
+            if (!res->success) {
+                db->last_error = res->error;
+                return SQLITE_ERROR;
+            }
+        }
 
-		// now prepare the query
-		auto prepared = db->con->Prepare(move(statements.back()));
-		if (!prepared->success) {
-			// failed to prepare: set the error message
-			db->last_error = prepared->error;
-			return SQLITE_ERROR;
-		}
+        // now prepare the query
+        auto prepared = db->con->Prepare(move(statements.back()));
+        if (!prepared->success) {
+            // failed to prepare: set the error message
+            db->last_error = prepared->error;
+            return SQLITE_ERROR;
+        }
 
-		// create the statement entry
-		unique_ptr<sqlite3_stmt> stmt = make_unique<sqlite3_stmt>();
-		stmt->db = db;
-		stmt->query_string = query;
-		stmt->prepared = move(prepared);
-		stmt->current_row = -1;
-		for (idx_t i = 0; i < stmt->prepared->n_param; i++) {
-			stmt->bound_names.push_back("$" + to_string(i + 1));
-			stmt->bound_values.push_back(Value());
-		}
+        // create the statement entry
+        unique_ptr<sqlite3_stmt> stmt = make_unique<sqlite3_stmt>();
+        stmt->db = db;
+        stmt->query_string = query;
+        stmt->prepared = move(prepared);
+        stmt->current_row = -1;
+        for (idx_t i = 0; i < stmt->prepared->n_param; i++) {
+            stmt->bound_names.push_back("$" + to_string(i + 1));
+            stmt->bound_values.push_back(Value());
+        }
 
-		// extract the remainder of the query and assign it to the pzTail
-		if (pzTail && set_remainder) {
-			*pzTail = zSql + next_location + 1;
-		}
+        // extract the remainder of the query and assign it to the pzTail
+        if (pzTail && set_remainder) {
+            *pzTail = zSql + next_location + 1;
+        }
 
-		*ppStmt = stmt.release();
-		return SQLITE_OK;
-	} catch (std::exception &ex) {
-		db->last_error = ex.what();
-		return SQLITE_ERROR;
-	}
+        *ppStmt = stmt.release();
+        return SQLITE_OK;
+    } catch (std::exception &ex) {
+        db->last_error = ex.what();
+        return SQLITE_ERROR;
+    }
 }
 
 bool sqlite3_display_result(StatementType type) {
-	switch (type) {
-	case StatementType::EXECUTE_STATEMENT:
-	case StatementType::EXPLAIN_STATEMENT:
-	case StatementType::PRAGMA_STATEMENT:
-	case StatementType::SELECT_STATEMENT:
-	case StatementType::SHOW_STATEMENT:
-		return true;
-	default:
-		return false;
-	}
+    switch (type) {
+        case StatementType::EXECUTE_STATEMENT:
+        case StatementType::EXPLAIN_STATEMENT:
+        case StatementType::PRAGMA_STATEMENT:
+        case StatementType::SELECT_STATEMENT:
+        case StatementType::SHOW_STATEMENT:
+            return true;
+        default:
+            return false;
+    }
 }
+
+class ProgressBar {
+public:
+
+//    string pbstr = "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||";
+    string pbstr = "🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆";
+    idx_t pbwidth = 60;
+    bool finished = false;
+    Executor *executor = nullptr;
+    std::thread progress_bar_thread;
+    std::promise<void> exit_signal;
+    std::future<void> future_obj = exit_signal.get_future();
+
+    explicit ProgressBar(Executor *executor) : executor(executor) {
+
+    };
+
+    void PrintProgress(int percentage) {
+        int lpad = (int) (percentage / 100.0 * pbwidth*2);
+        int rpad = pbwidth - lpad*0.5;
+        printf("\r%3d%% [%.*s%*s]", percentage, lpad, pbstr.c_str(), rpad, "");
+        fflush(stdout);
+    }
+
+    void ProgressBarThread() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        while (!StopRequested()) {
+            PrintProgress(executor->GetPipelinesProgress());
+            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        }
+    }
+
+    void Start() {
+        progress_bar_thread = std::thread(&ProgressBar::ProgressBarThread, this);
+    }
+
+    bool StopRequested() {
+        if (future_obj.wait_for(std::chrono::milliseconds(0)) == std::future_status::timeout) {
+            return false;
+        }
+        return true;
+    }
+
+    void Stop() {
+        if (progress_bar_thread.joinable()) {
+            exit_signal.set_value();
+            progress_bar_thread.join();
+            printf("\n");
+            fflush(stdout);
+        }
+
+    }
+};
+
 
 /* Prepare the next result to be retrieved */
 int sqlite3_step(sqlite3_stmt *pStmt) {
-	if (!pStmt) {
-		return SQLITE_MISUSE;
-	}
-	if (!pStmt->prepared) {
-		pStmt->db->last_error = "Attempting sqlite3_step() on a non-successfully prepared statement";
-		return SQLITE_ERROR;
-	}
-	pStmt->current_text = nullptr;
-	if (!pStmt->result) {
-		// no result yet! call Execute()
-		pStmt->result = pStmt->prepared->Execute(pStmt->bound_values, false);
-		if (!pStmt->result->success) {
-			// error in execute: clear prepared statement
-			pStmt->db->last_error = pStmt->result->error;
-			pStmt->prepared = nullptr;
-			return SQLITE_ERROR;
-		}
-		// fetch a chunk
-		pStmt->current_chunk = pStmt->result->Fetch();
-		pStmt->current_row = -1;
-		if (!sqlite3_display_result(pStmt->prepared->GetStatementType())) {
-			// only SELECT statements return results
-			sqlite3_reset(pStmt);
-		}
-	}
-	if (!pStmt->current_chunk || pStmt->current_chunk->size() == 0) {
-		return SQLITE_DONE;
-	}
-	pStmt->current_row++;
-	if (pStmt->current_row >= (int32_t)pStmt->current_chunk->size()) {
-		// have to fetch again!
-		pStmt->current_row = 0;
-		pStmt->current_chunk = pStmt->result->Fetch();
-		if (!pStmt->current_chunk || pStmt->current_chunk->size() == 0) {
-			sqlite3_reset(pStmt);
-			return SQLITE_DONE;
-		}
-	}
-	return SQLITE_ROW;
+    if (!pStmt) {
+        return SQLITE_MISUSE;
+    }
+    if (!pStmt->prepared) {
+        pStmt->db->last_error = "Attempting sqlite3_step() on a non-successfully prepared statement";
+        return SQLITE_ERROR;
+    }
+    pStmt->current_text = nullptr;
+    if (!pStmt->result) {
+        ProgressBar progess_bar(&pStmt->prepared->context->executor);
+        if (pStmt->prepared->GetStatementType() == StatementType::SELECT_STATEMENT) {
+            progess_bar.Start();
+        }
+        // no result yet! call Execute()
+        pStmt->result = pStmt->prepared->Execute(pStmt->bound_values, false);
+        progess_bar.Stop();
+        if (!pStmt->result->success) {
+            // error in execute: clear prepared statement
+            pStmt->db->last_error = pStmt->result->error;
+            pStmt->prepared = nullptr;
+            return SQLITE_ERROR;
+        }
+        // fetch a chunk
+        pStmt->current_chunk = pStmt->result->Fetch();
+        pStmt->current_row = -1;
+        if (!sqlite3_display_result(pStmt->prepared->GetStatementType())) {
+            // only SELECT statements return results
+            sqlite3_reset(pStmt);
+        }
+    }
+    if (!pStmt->current_chunk || pStmt->current_chunk->size() == 0) {
+        return SQLITE_DONE;
+    }
+    pStmt->current_row++;
+    if (pStmt->current_row >= (int32_t) pStmt->current_chunk->size()) {
+        // have to fetch again!
+        pStmt->current_row = 0;
+        pStmt->current_chunk = pStmt->result->Fetch();
+        if (!pStmt->current_chunk || pStmt->current_chunk->size() == 0) {
+            sqlite3_reset(pStmt);
+            return SQLITE_DONE;
+        }
+    }
+    return SQLITE_ROW;
 }
 
 /* Execute multiple semicolon separated SQL statements
@@ -256,331 +319,331 @@ int sqlite3_exec(sqlite3 *db,                /* The database on which the SQL ex
                  void *pArg,                 /* First argument to xCallback() */
                  char **pzErrMsg             /* Write error messages here */
 ) {
-	int rc = SQLITE_OK;            /* Return code */
-	const char *zLeftover;         /* Tail of unprocessed SQL */
-	sqlite3_stmt *pStmt = nullptr; /* The current SQL statement */
-	char **azCols = nullptr;       /* Names of result columns */
-	char **azVals = nullptr;       /* Result values */
+    int rc = SQLITE_OK;            /* Return code */
+    const char *zLeftover;         /* Tail of unprocessed SQL */
+    sqlite3_stmt *pStmt = nullptr; /* The current SQL statement */
+    char **azCols = nullptr;       /* Names of result columns */
+    char **azVals = nullptr;       /* Result values */
 
-	if (zSql == nullptr) {
-		zSql = "";
-	}
+    if (zSql == nullptr) {
+        zSql = "";
+    }
 
-	while (rc == SQLITE_OK && zSql[0]) {
-		int nCol;
+    while (rc == SQLITE_OK && zSql[0]) {
+        int nCol;
 
-		pStmt = nullptr;
-		rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, &zLeftover);
-		if (rc != SQLITE_OK) {
-			if (pzErrMsg) {
-				auto errmsg = sqlite3_errmsg(db);
-				*pzErrMsg = errmsg ? sqlite3_strdup(errmsg) : nullptr;
-			}
-			continue;
-		}
-		if (!pStmt) {
-			/* this happens for a comment or white-space */
-			zSql = zLeftover;
-			continue;
-		}
+        pStmt = nullptr;
+        rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, &zLeftover);
+        if (rc != SQLITE_OK) {
+            if (pzErrMsg) {
+                auto errmsg = sqlite3_errmsg(db);
+                *pzErrMsg = errmsg ? sqlite3_strdup(errmsg) : nullptr;
+            }
+            continue;
+        }
+        if (!pStmt) {
+            /* this happens for a comment or white-space */
+            zSql = zLeftover;
+            continue;
+        }
 
-		nCol = sqlite3_column_count(pStmt);
-		azCols = (char **)malloc(nCol * sizeof(const char *));
-		azVals = (char **)malloc(nCol * sizeof(const char *));
-		if (!azCols || !azVals) {
-			goto exec_out;
-		}
-		for (int i = 0; i < nCol; i++) {
-			azCols[i] = (char *)sqlite3_column_name(pStmt, i);
-		}
+        nCol = sqlite3_column_count(pStmt);
+        azCols = (char **) malloc(nCol * sizeof(const char *));
+        azVals = (char **) malloc(nCol * sizeof(const char *));
+        if (!azCols || !azVals) {
+            goto exec_out;
+        }
+        for (int i = 0; i < nCol; i++) {
+            azCols[i] = (char *) sqlite3_column_name(pStmt, i);
+        }
 
-		while (true) {
-			rc = sqlite3_step(pStmt);
+        while (true) {
+            rc = sqlite3_step(pStmt);
 
-			/* Invoke the callback function if required */
-			if (xCallback && rc == SQLITE_ROW) {
-				for (int i = 0; i < nCol; i++) {
-					azVals[i] = (char *)sqlite3_column_text(pStmt, i);
-					if (!azVals[i] && sqlite3_column_type(pStmt, i) != SQLITE_NULL) {
-						fprintf(stderr, "sqlite3_exec: out of memory.\n");
-						goto exec_out;
-					}
-				}
-				if (xCallback(pArg, nCol, azVals, azCols)) {
-					/* EVIDENCE-OF: R-38229-40159 If the callback function to
-					** sqlite3_exec() returns non-zero, then sqlite3_exec() will
-					** return SQLITE_ABORT. */
-					rc = SQLITE_ABORT;
-					sqlite3_finalize(pStmt);
-					pStmt = 0;
-					fprintf(stderr, "sqlite3_exec: callback returned non-zero. "
-					                "Aborting.\n");
-					goto exec_out;
-				}
-			}
-			if (rc == SQLITE_DONE) {
-				rc = sqlite3_finalize(pStmt);
-				pStmt = nullptr;
-				zSql = zLeftover;
-				while (isspace(zSql[0]))
-					zSql++;
-				break;
-			} else if (rc != SQLITE_ROW) {
-				// error
-				if (pzErrMsg) {
-					auto errmsg = sqlite3_errmsg(db);
-					*pzErrMsg = errmsg ? sqlite3_strdup(errmsg) : nullptr;
-				}
-				goto exec_out;
-			}
-		}
+            /* Invoke the callback function if required */
+            if (xCallback && rc == SQLITE_ROW) {
+                for (int i = 0; i < nCol; i++) {
+                    azVals[i] = (char *) sqlite3_column_text(pStmt, i);
+                    if (!azVals[i] && sqlite3_column_type(pStmt, i) != SQLITE_NULL) {
+                        fprintf(stderr, "sqlite3_exec: out of memory.\n");
+                        goto exec_out;
+                    }
+                }
+                if (xCallback(pArg, nCol, azVals, azCols)) {
+                    /* EVIDENCE-OF: R-38229-40159 If the callback function to
+                    ** sqlite3_exec() returns non-zero, then sqlite3_exec() will
+                    ** return SQLITE_ABORT. */
+                    rc = SQLITE_ABORT;
+                    sqlite3_finalize(pStmt);
+                    pStmt = 0;
+                    fprintf(stderr, "sqlite3_exec: callback returned non-zero. "
+                                    "Aborting.\n");
+                    goto exec_out;
+                }
+            }
+            if (rc == SQLITE_DONE) {
+                rc = sqlite3_finalize(pStmt);
+                pStmt = nullptr;
+                zSql = zLeftover;
+                while (isspace(zSql[0]))
+                    zSql++;
+                break;
+            } else if (rc != SQLITE_ROW) {
+                // error
+                if (pzErrMsg) {
+                    auto errmsg = sqlite3_errmsg(db);
+                    *pzErrMsg = errmsg ? sqlite3_strdup(errmsg) : nullptr;
+                }
+                goto exec_out;
+            }
+        }
 
-		sqlite3_free(azCols);
-		sqlite3_free(azVals);
-		azCols = nullptr;
-		azVals = nullptr;
-	}
+        sqlite3_free(azCols);
+        sqlite3_free(azVals);
+        azCols = nullptr;
+        azVals = nullptr;
+    }
 
-exec_out:
-	if (pStmt) {
-		sqlite3_finalize(pStmt);
-	}
-	sqlite3_free(azCols);
-	sqlite3_free(azVals);
-	if (rc != SQLITE_OK && pzErrMsg && !*pzErrMsg) {
-		// error but no error message set
-		*pzErrMsg = sqlite3_strdup("Unknown error in DuckDB!");
-	}
-	return rc;
+    exec_out:
+    if (pStmt) {
+        sqlite3_finalize(pStmt);
+    }
+    sqlite3_free(azCols);
+    sqlite3_free(azVals);
+    if (rc != SQLITE_OK && pzErrMsg && !*pzErrMsg) {
+        // error but no error message set
+        *pzErrMsg = sqlite3_strdup("Unknown error in DuckDB!");
+    }
+    return rc;
 }
 
 /* Return the text of the SQL that was used to prepare the statement */
 const char *sqlite3_sql(sqlite3_stmt *pStmt) {
-	return pStmt->query_string.c_str();
+    return pStmt->query_string.c_str();
 }
 
 int sqlite3_column_count(sqlite3_stmt *pStmt) {
-	if (!pStmt || !pStmt->prepared) {
-		return 0;
-	}
-	return (int)pStmt->prepared->ColumnCount();
+    if (!pStmt || !pStmt->prepared) {
+        return 0;
+    }
+    return (int) pStmt->prepared->ColumnCount();
 }
 
 ////////////////////////////
 //     sqlite3_column     //
 ////////////////////////////
 int sqlite3_column_type(sqlite3_stmt *pStmt, int iCol) {
-	if (!pStmt || !pStmt->result || !pStmt->current_chunk) {
-		return 0;
-	}
-	if (FlatVector::IsNull(pStmt->current_chunk->data[iCol], pStmt->current_row)) {
-		return SQLITE_NULL;
-	}
-	auto column_type = pStmt->result->types[iCol];
-	switch (column_type.id()) {
-	case LogicalTypeId::BOOLEAN:
-	case LogicalTypeId::TINYINT:
-	case LogicalTypeId::SMALLINT:
-	case LogicalTypeId::INTEGER:
-	case LogicalTypeId::BIGINT: /* TODO: Maybe blob? */
-		return SQLITE_INTEGER;
-	case LogicalTypeId::FLOAT:
-	case LogicalTypeId::DOUBLE:
-	case LogicalTypeId::DECIMAL:
-		return SQLITE_FLOAT;
-	case LogicalTypeId::DATE:
-	case LogicalTypeId::TIME:
-	case LogicalTypeId::TIMESTAMP:
-	case LogicalTypeId::VARCHAR:
-	case LogicalTypeId::LIST:
-	case LogicalTypeId::STRUCT:
-		return SQLITE_TEXT;
-	case LogicalTypeId::BLOB:
-		return SQLITE_BLOB;
-	default:
-		return 0;
-	}
-	return 0;
+    if (!pStmt || !pStmt->result || !pStmt->current_chunk) {
+        return 0;
+    }
+    if (FlatVector::IsNull(pStmt->current_chunk->data[iCol], pStmt->current_row)) {
+        return SQLITE_NULL;
+    }
+    auto column_type = pStmt->result->types[iCol];
+    switch (column_type.id()) {
+        case LogicalTypeId::BOOLEAN:
+        case LogicalTypeId::TINYINT:
+        case LogicalTypeId::SMALLINT:
+        case LogicalTypeId::INTEGER:
+        case LogicalTypeId::BIGINT: /* TODO: Maybe blob? */
+            return SQLITE_INTEGER;
+        case LogicalTypeId::FLOAT:
+        case LogicalTypeId::DOUBLE:
+        case LogicalTypeId::DECIMAL:
+            return SQLITE_FLOAT;
+        case LogicalTypeId::DATE:
+        case LogicalTypeId::TIME:
+        case LogicalTypeId::TIMESTAMP:
+        case LogicalTypeId::VARCHAR:
+        case LogicalTypeId::LIST:
+        case LogicalTypeId::STRUCT:
+            return SQLITE_TEXT;
+        case LogicalTypeId::BLOB:
+            return SQLITE_BLOB;
+        default:
+            return 0;
+    }
+    return 0;
 }
 
 const char *sqlite3_column_name(sqlite3_stmt *pStmt, int N) {
-	if (!pStmt || !pStmt->prepared) {
-		return nullptr;
-	}
-	return pStmt->prepared->GetNames()[N].c_str();
+    if (!pStmt || !pStmt->prepared) {
+        return nullptr;
+    }
+    return pStmt->prepared->GetNames()[N].c_str();
 }
 
 static bool sqlite3_column_has_value(sqlite3_stmt *pStmt, int iCol, LogicalType target_type, Value &val) {
-	if (!pStmt || !pStmt->result || !pStmt->current_chunk) {
-		return false;
-	}
-	if (iCol < 0 || iCol >= (int)pStmt->result->types.size()) {
-		return false;
-	}
-	if (FlatVector::IsNull(pStmt->current_chunk->data[iCol], pStmt->current_row)) {
-		return false;
-	}
-	try {
-		val = pStmt->current_chunk->data[iCol].GetValue(pStmt->current_row).CastAs(target_type);
-	} catch (...) {
-		return false;
-	}
-	return true;
+    if (!pStmt || !pStmt->result || !pStmt->current_chunk) {
+        return false;
+    }
+    if (iCol < 0 || iCol >= (int) pStmt->result->types.size()) {
+        return false;
+    }
+    if (FlatVector::IsNull(pStmt->current_chunk->data[iCol], pStmt->current_row)) {
+        return false;
+    }
+    try {
+        val = pStmt->current_chunk->data[iCol].GetValue(pStmt->current_row).CastAs(target_type);
+    } catch (...) {
+        return false;
+    }
+    return true;
 }
 
 double sqlite3_column_double(sqlite3_stmt *stmt, int iCol) {
-	Value val;
-	if (!sqlite3_column_has_value(stmt, iCol, LogicalType::DOUBLE, val)) {
-		return 0;
-	}
-	return val.value_.double_;
+    Value val;
+    if (!sqlite3_column_has_value(stmt, iCol, LogicalType::DOUBLE, val)) {
+        return 0;
+    }
+    return val.value_.double_;
 }
 
 int sqlite3_column_int(sqlite3_stmt *stmt, int iCol) {
-	Value val;
-	if (!sqlite3_column_has_value(stmt, iCol, LogicalType::INTEGER, val)) {
-		return 0;
-	}
-	return val.value_.integer;
+    Value val;
+    if (!sqlite3_column_has_value(stmt, iCol, LogicalType::INTEGER, val)) {
+        return 0;
+    }
+    return val.value_.integer;
 }
 
 sqlite3_int64 sqlite3_column_int64(sqlite3_stmt *stmt, int iCol) {
-	Value val;
-	if (!sqlite3_column_has_value(stmt, iCol, LogicalType::BIGINT, val)) {
-		return 0;
-	}
-	return val.value_.bigint;
+    Value val;
+    if (!sqlite3_column_has_value(stmt, iCol, LogicalType::BIGINT, val)) {
+        return 0;
+    }
+    return val.value_.bigint;
 }
 
 const unsigned char *sqlite3_column_text(sqlite3_stmt *pStmt, int iCol) {
-	Value val;
-	if (!sqlite3_column_has_value(pStmt, iCol, LogicalType::VARCHAR, val)) {
-		return nullptr;
-	}
-	try {
-		if (!pStmt->current_text) {
-			pStmt->current_text =
-			    unique_ptr<sqlite3_string_buffer[]>(new sqlite3_string_buffer[pStmt->result->types.size()]);
-		}
-		auto &entry = pStmt->current_text[iCol];
-		if (!entry.data) {
-			// not initialized yet, convert the value and initialize it
-			entry.data = unique_ptr<char[]>(new char[val.str_value.size() + 1]);
-			memcpy(entry.data.get(), val.str_value.c_str(), val.str_value.size() + 1);
-		}
-		return (const unsigned char *)entry.data.get();
-	} catch (...) {
-		// memory error!
-		return nullptr;
-	}
+    Value val;
+    if (!sqlite3_column_has_value(pStmt, iCol, LogicalType::VARCHAR, val)) {
+        return nullptr;
+    }
+    try {
+        if (!pStmt->current_text) {
+            pStmt->current_text =
+                    unique_ptr<sqlite3_string_buffer[]>(new sqlite3_string_buffer[pStmt->result->types.size()]);
+        }
+        auto &entry = pStmt->current_text[iCol];
+        if (!entry.data) {
+            // not initialized yet, convert the value and initialize it
+            entry.data = unique_ptr<char[]>(new char[val.str_value.size() + 1]);
+            memcpy(entry.data.get(), val.str_value.c_str(), val.str_value.size() + 1);
+        }
+        return (const unsigned char *) entry.data.get();
+    } catch (...) {
+        // memory error!
+        return nullptr;
+    }
 }
 
 ////////////////////////////
 //      sqlite3_bind      //
 ////////////////////////////
 int sqlite3_bind_parameter_count(sqlite3_stmt *stmt) {
-	if (!stmt) {
-		return 0;
-	}
-	return stmt->prepared->n_param;
+    if (!stmt) {
+        return 0;
+    }
+    return stmt->prepared->n_param;
 }
 
 const char *sqlite3_bind_parameter_name(sqlite3_stmt *stmt, int idx) {
-	if (!stmt) {
-		return nullptr;
-	}
-	if (idx < 1 || idx > (int)stmt->prepared->n_param) {
-		return nullptr;
-	}
-	return stmt->bound_names[idx - 1].c_str();
+    if (!stmt) {
+        return nullptr;
+    }
+    if (idx < 1 || idx > (int) stmt->prepared->n_param) {
+        return nullptr;
+    }
+    return stmt->bound_names[idx - 1].c_str();
 }
 
 int sqlite3_bind_parameter_index(sqlite3_stmt *stmt, const char *zName) {
-	if (!stmt || !zName) {
-		return 0;
-	}
-	for (idx_t i = 0; i < stmt->bound_names.size(); i++) {
-		if (stmt->bound_names[i] == string(zName)) {
-			return i + 1;
-		}
-	}
-	return 0;
+    if (!stmt || !zName) {
+        return 0;
+    }
+    for (idx_t i = 0; i < stmt->bound_names.size(); i++) {
+        if (stmt->bound_names[i] == string(zName)) {
+            return i + 1;
+        }
+    }
+    return 0;
 }
 
 int sqlite3_internal_bind_value(sqlite3_stmt *stmt, int idx, Value value) {
-	if (!stmt || !stmt->prepared || stmt->result) {
-		return SQLITE_MISUSE;
-	}
-	if (idx < 1 || idx > (int)stmt->prepared->n_param) {
-		return SQLITE_RANGE;
-	}
-	stmt->bound_values[idx - 1] = value;
-	return SQLITE_OK;
+    if (!stmt || !stmt->prepared || stmt->result) {
+        return SQLITE_MISUSE;
+    }
+    if (idx < 1 || idx > (int) stmt->prepared->n_param) {
+        return SQLITE_RANGE;
+    }
+    stmt->bound_values[idx - 1] = value;
+    return SQLITE_OK;
 }
 
 int sqlite3_bind_int(sqlite3_stmt *stmt, int idx, int val) {
-	return sqlite3_internal_bind_value(stmt, idx, Value::INTEGER(val));
+    return sqlite3_internal_bind_value(stmt, idx, Value::INTEGER(val));
 }
 
 int sqlite3_bind_int64(sqlite3_stmt *stmt, int idx, sqlite3_int64 val) {
-	return sqlite3_internal_bind_value(stmt, idx, Value::BIGINT(val));
+    return sqlite3_internal_bind_value(stmt, idx, Value::BIGINT(val));
 }
 
 int sqlite3_bind_double(sqlite3_stmt *stmt, int idx, double val) {
-	return sqlite3_internal_bind_value(stmt, idx, Value::DOUBLE(val));
+    return sqlite3_internal_bind_value(stmt, idx, Value::DOUBLE(val));
 }
 
 int sqlite3_bind_null(sqlite3_stmt *stmt, int idx) {
-	return sqlite3_internal_bind_value(stmt, idx, Value());
+    return sqlite3_internal_bind_value(stmt, idx, Value());
 }
 
 SQLITE_API int sqlite3_bind_value(sqlite3_stmt *, int, const sqlite3_value *) {
-	fprintf(stderr, "sqlite3_bind_value: unsupported.\n");
-	return SQLITE_ERROR;
+    fprintf(stderr, "sqlite3_bind_value: unsupported.\n");
+    return SQLITE_ERROR;
 }
 
 int sqlite3_bind_text(sqlite3_stmt *stmt, int idx, const char *val, int length, void (*free_func)(void *)) {
-	if (!val) {
-		return SQLITE_MISUSE;
-	}
-	string value;
-	if (length < 0) {
-		value = string(val);
-	} else {
-		value = string(val, val + length);
-	}
-	if (free_func && ((ptrdiff_t)free_func) != -1) {
-		free_func((void *)val);
-	}
-	try {
-		return sqlite3_internal_bind_value(stmt, idx, Value(value));
-	} catch (std::exception &ex) {
-		return SQLITE_ERROR;
-	}
+    if (!val) {
+        return SQLITE_MISUSE;
+    }
+    string value;
+    if (length < 0) {
+        value = string(val);
+    } else {
+        value = string(val, val + length);
+    }
+    if (free_func && ((ptrdiff_t) free_func) != -1) {
+        free_func((void *) val);
+    }
+    try {
+        return sqlite3_internal_bind_value(stmt, idx, Value(value));
+    } catch (std::exception &ex) {
+        return SQLITE_ERROR;
+    }
 }
 
 int sqlite3_clear_bindings(sqlite3_stmt *stmt) {
-	if (!stmt) {
-		return SQLITE_MISUSE;
-	}
-	return SQLITE_OK;
+    if (!stmt) {
+        return SQLITE_MISUSE;
+    }
+    return SQLITE_OK;
 }
 
 int sqlite3_initialize(void) {
-	return SQLITE_OK;
+    return SQLITE_OK;
 }
 
 int sqlite3_finalize(sqlite3_stmt *pStmt) {
-	if (pStmt) {
-		if (pStmt->result && !pStmt->result->success) {
-			pStmt->db->last_error = string(pStmt->result->error);
-			delete pStmt;
-			return SQLITE_ERROR;
-		}
+    if (pStmt) {
+        if (pStmt->result && !pStmt->result->success) {
+            pStmt->db->last_error = string(pStmt->result->error);
+            delete pStmt;
+            return SQLITE_ERROR;
+        }
 
-		delete pStmt;
-	}
-	return SQLITE_OK;
+        delete pStmt;
+    }
+    return SQLITE_OK;
 }
 
 /*
@@ -595,146 +658,148 @@ int sqlite3_finalize(sqlite3_stmt *pStmt) {
 */
 
 const unsigned char sqlite3UpperToLower[] = {
-    0,   1,   2,   3,   4,   5,   6,   7,   8,   9,   10,  11,  12,  13,  14,  15,  16,  17,  18,  19,  20,  21,
-    22,  23,  24,  25,  26,  27,  28,  29,  30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,
-    44,  45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,  60,  61,  62,  63,  64,  97,
-    98,  99,  100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
-    120, 121, 122, 91,  92,  93,  94,  95,  96,  97,  98,  99,  100, 101, 102, 103, 104, 105, 106, 107, 108, 109,
-    110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131,
-    132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153,
-    154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175,
-    176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197,
-    198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219,
-    220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241,
-    242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255};
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+        22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43,
+        44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 97,
+        98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
+        120, 121, 122, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109,
+        110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131,
+        132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153,
+        154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175,
+        176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197,
+        198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219,
+        220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241,
+        242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255};
 
 int sqlite3StrICmp(const char *zLeft, const char *zRight) {
-	unsigned char *a, *b;
-	int c;
-	a = (unsigned char *)zLeft;
-	b = (unsigned char *)zRight;
-	for (;;) {
-		c = (int)sqlite3UpperToLower[*a] - (int)sqlite3UpperToLower[*b];
-		if (c || *a == 0)
-			break;
-		a++;
-		b++;
-	}
-	return c;
+    unsigned char *a, *b;
+    int c;
+    a = (unsigned char *) zLeft;
+    b = (unsigned char *) zRight;
+    for (;;) {
+        c = (int) sqlite3UpperToLower[*a] - (int) sqlite3UpperToLower[*b];
+        if (c || *a == 0)
+            break;
+        a++;
+        b++;
+    }
+    return c;
 }
 
 SQLITE_API int sqlite3_stricmp(const char *zLeft, const char *zRight) {
-	if (zLeft == 0) {
-		return zRight ? -1 : 0;
-	} else if (zRight == 0) {
-		return 1;
-	}
-	return sqlite3StrICmp(zLeft, zRight);
+    if (zLeft == 0) {
+        return zRight ? -1 : 0;
+    } else if (zRight == 0) {
+        return 1;
+    }
+    return sqlite3StrICmp(zLeft, zRight);
 }
 
 SQLITE_API int sqlite3_strnicmp(const char *zLeft, const char *zRight, int N) {
-	unsigned char *a, *b;
-	if (zLeft == 0) {
-		return zRight ? -1 : 0;
-	} else if (zRight == 0) {
-		return 1;
-	}
-	a = (unsigned char *)zLeft;
-	b = (unsigned char *)zRight;
-	while (N-- > 0 && *a != 0 && sqlite3UpperToLower[*a] == sqlite3UpperToLower[*b]) {
-		a++;
-		b++;
-	}
-	return N < 0 ? 0 : sqlite3UpperToLower[*a] - sqlite3UpperToLower[*b];
+    unsigned char *a, *b;
+    if (zLeft == 0) {
+        return zRight ? -1 : 0;
+    } else if (zRight == 0) {
+        return 1;
+    }
+    a = (unsigned char *) zLeft;
+    b = (unsigned char *) zRight;
+    while (N-- > 0 && *a != 0 && sqlite3UpperToLower[*a] == sqlite3UpperToLower[*b]) {
+        a++;
+        b++;
+    }
+    return N < 0 ? 0 : sqlite3UpperToLower[*a] - sqlite3UpperToLower[*b];
 }
 
 char *sqlite3_strdup(const char *str) {
-	char *result = (char *)sqlite3_malloc64(strlen(str) + 1);
-	strcpy(result, str);
-	return result;
+    char *result = (char *) sqlite3_malloc64(strlen(str) + 1);
+    strcpy(result, str);
+    return result;
 }
 
 void *sqlite3_malloc64(sqlite3_uint64 n) {
-	return malloc(n);
+    return malloc(n);
 }
+
 void sqlite3_free(void *pVoid) {
-	free(pVoid);
+    free(pVoid);
 }
 
 void *sqlite3_malloc(int n) {
-	return sqlite3_malloc64(n);
+    return sqlite3_malloc64(n);
 }
 
 void *sqlite3_realloc(void *ptr, int n) {
-	return sqlite3_realloc64(ptr, n);
+    return sqlite3_realloc64(ptr, n);
 }
 
 void *sqlite3_realloc64(void *ptr, sqlite3_uint64 n) {
-	return realloc(ptr, n);
+    return realloc(ptr, n);
 }
 
 // TODO: stub
 int sqlite3_config(int i, ...) {
-	return SQLITE_OK;
+    return SQLITE_OK;
 }
 
 int sqlite3_errcode(sqlite3 *db) {
-	if (!db) {
-		return SQLITE_MISUSE;
-	}
-	return db->last_error.empty() ? SQLITE_OK : SQLITE_ERROR;
+    if (!db) {
+        return SQLITE_MISUSE;
+    }
+    return db->last_error.empty() ? SQLITE_OK : SQLITE_ERROR;
 }
 
 int sqlite3_extended_errcode(sqlite3 *db) {
-	return sqlite3_errcode(db);
+    return sqlite3_errcode(db);
 }
 
 const char *sqlite3_errmsg(sqlite3 *db) {
-	if (!db) {
-		return "";
-	}
-	return db->last_error.c_str();
+    if (!db) {
+        return "";
+    }
+    return db->last_error.c_str();
 }
 
 void sqlite3_interrupt(sqlite3 *db) {
-	if (db) {
-		db->con->Interrupt();
-	}
+    if (db) {
+        db->con->Interrupt();
+    }
 }
 
 const char *sqlite3_libversion(void) {
-	return DuckDB::LibraryVersion();
+    return DuckDB::LibraryVersion();
 }
+
 const char *sqlite3_sourceid(void) {
-	return DuckDB::SourceID();
+    return DuckDB::SourceID();
 }
 
 int sqlite3_reset(sqlite3_stmt *stmt) {
-	if (stmt) {
-		stmt->result = nullptr;
-		stmt->current_chunk = nullptr;
-	}
-	return SQLITE_OK;
+    if (stmt) {
+        stmt->result = nullptr;
+        stmt->current_chunk = nullptr;
+    }
+    return SQLITE_OK;
 }
 
 // support functions for shell.c
 // most are dummies, we don't need them really
 
 int sqlite3_db_status(sqlite3 *, int op, int *pCur, int *pHiwtr, int resetFlg) {
-	fprintf(stderr, "sqlite3_db_status: unsupported.\n");
-	return -1;
+    fprintf(stderr, "sqlite3_db_status: unsupported.\n");
+    return -1;
 }
 
 // TODO these should eventually be implemented
 
 int sqlite3_changes(sqlite3 *db) {
-	fprintf(stderr, "sqlite3_changes: unsupported.\n");
-	return 0;
+    fprintf(stderr, "sqlite3_changes: unsupported.\n");
+    return 0;
 }
 
 int sqlite3_total_changes(sqlite3 *) {
-	fprintf(stderr, "sqlite3_total_changes: unsupported.\n");
-	return 0;
+    fprintf(stderr, "sqlite3_total_changes: unsupported.\n");
+    return 0;
 }
 
 // some code borrowed from sqlite
@@ -751,210 +816,210 @@ typedef uint8_t u8;
 #define tkOTHER 2
 
 const unsigned char sqlite3CtypeMap[256] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 00..07    ........ */
-    0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, /* 08..0f    ........ */
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 10..17    ........ */
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 18..1f    ........ */
-    0x01, 0x00, 0x80, 0x00, 0x40, 0x00, 0x00, 0x80, /* 20..27     !"#$%&' */
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 28..2f    ()*+,-./ */
-    0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, /* 30..37    01234567 */
-    0x0c, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 38..3f    89:;<=>? */
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 00..07    ........ */
+        0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, /* 08..0f    ........ */
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 10..17    ........ */
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 18..1f    ........ */
+        0x01, 0x00, 0x80, 0x00, 0x40, 0x00, 0x00, 0x80, /* 20..27     !"#$%&' */
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 28..2f    ()*+,-./ */
+        0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, /* 30..37    01234567 */
+        0x0c, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 38..3f    89:;<=>? */
 
-    0x00, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x02, /* 40..47    @ABCDEFG */
-    0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, /* 48..4f    HIJKLMNO */
-    0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, /* 50..57    PQRSTUVW */
-    0x02, 0x02, 0x02, 0x80, 0x00, 0x00, 0x00, 0x40, /* 58..5f    XYZ[\]^_ */
-    0x80, 0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x22, /* 60..67    `abcdefg */
-    0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, /* 68..6f    hijklmno */
-    0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, /* 70..77    pqrstuvw */
-    0x22, 0x22, 0x22, 0x00, 0x00, 0x00, 0x00, 0x00, /* 78..7f    xyz{|}~. */
+        0x00, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x02, /* 40..47    @ABCDEFG */
+        0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, /* 48..4f    HIJKLMNO */
+        0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, /* 50..57    PQRSTUVW */
+        0x02, 0x02, 0x02, 0x80, 0x00, 0x00, 0x00, 0x40, /* 58..5f    XYZ[\]^_ */
+        0x80, 0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x22, /* 60..67    `abcdefg */
+        0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, /* 68..6f    hijklmno */
+        0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, /* 70..77    pqrstuvw */
+        0x22, 0x22, 0x22, 0x00, 0x00, 0x00, 0x00, 0x00, /* 78..7f    xyz{|}~. */
 
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* 80..87    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* 88..8f    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* 90..97    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* 98..9f    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* a0..a7    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* a8..af    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* b0..b7    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* b8..bf    ........ */
+        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* 80..87    ........ */
+        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* 88..8f    ........ */
+        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* 90..97    ........ */
+        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* 98..9f    ........ */
+        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* a0..a7    ........ */
+        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* a8..af    ........ */
+        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* b0..b7    ........ */
+        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* b8..bf    ........ */
 
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* c0..c7    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* c8..cf    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* d0..d7    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* d8..df    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* e0..e7    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* e8..ef    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* f0..f7    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40  /* f8..ff    ........ */
+        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* c0..c7    ........ */
+        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* c8..cf    ........ */
+        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* d0..d7    ........ */
+        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* d8..df    ........ */
+        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* e0..e7    ........ */
+        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* e8..ef    ........ */
+        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* f0..f7    ........ */
+        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40  /* f8..ff    ........ */
 };
 
 // TODO this can probably be simplified
 #define IdChar(C) ((sqlite3CtypeMap[(unsigned char)C] & 0x46) != 0)
 
 int sqlite3_complete(const char *zSql) {
-	u8 state = 0; /* Current state, using numbers defined in header comment */
-	u8 token;     /* Value of the next token */
+    u8 state = 0; /* Current state, using numbers defined in header comment */
+    u8 token;     /* Value of the next token */
 
-	/* If triggers are not supported by this compile then the statement machine
-	 ** used to detect the end of a statement is much simpler
-	 */
-	static const u8 trans[3][3] = {
-	    /* Token:           */
-	    /* State:       **  SEMI  WS  OTHER */
-	    /* 0 INVALID: */ {
-	        1,
-	        0,
-	        2,
-	    },
-	    /* 1   START: */
-	    {
-	        1,
-	        1,
-	        2,
-	    },
-	    /* 2  NORMAL: */
-	    {
-	        1,
-	        2,
-	        2,
-	    },
-	};
+    /* If triggers are not supported by this compile then the statement machine
+     ** used to detect the end of a statement is much simpler
+     */
+    static const u8 trans[3][3] = {
+            /* Token:           */
+            /* State:       **  SEMI  WS  OTHER */
+            /* 0 INVALID: */ {
+                                     1,
+                                     0,
+                                     2,
+                             },
+            /* 1   START: */
+                             {
+                                     1,
+                                     1,
+                                     2,
+                             },
+            /* 2  NORMAL: */
+                             {
+                                     1,
+                                     2,
+                                     2,
+                             },
+    };
 
-	while (*zSql) {
-		switch (*zSql) {
-		case ';': { /* A semicolon */
-			token = tkSEMI;
-			break;
-		}
-		case ' ':
-		case '\r':
-		case '\t':
-		case '\n':
-		case '\f': { /* White space is ignored */
-			token = tkWS;
-			break;
-		}
-		case '/': { /* C-style comments */
-			if (zSql[1] != '*') {
-				token = tkOTHER;
-				break;
-			}
-			zSql += 2;
-			while (zSql[0] && (zSql[0] != '*' || zSql[1] != '/')) {
-				zSql++;
-			}
-			if (zSql[0] == 0)
-				return 0;
-			zSql++;
-			token = tkWS;
-			break;
-		}
-		case '-': { /* SQL-style comments from "--" to end of line */
-			if (zSql[1] != '-') {
-				token = tkOTHER;
-				break;
-			}
-			while (*zSql && *zSql != '\n') {
-				zSql++;
-			}
-			if (*zSql == 0)
-				return state == 1;
-			token = tkWS;
-			break;
-		}
-		case '[': { /* Microsoft-style identifiers in [...] */
-			zSql++;
-			while (*zSql && *zSql != ']') {
-				zSql++;
-			}
-			if (*zSql == 0)
-				return 0;
-			token = tkOTHER;
-			break;
-		}
-		case '`': /* Grave-accent quoted symbols used by MySQL */
-		case '"': /* single- and double-quoted strings */
-		case '\'': {
-			int c = *zSql;
-			zSql++;
-			while (*zSql && *zSql != c) {
-				zSql++;
-			}
-			if (*zSql == 0)
-				return 0;
-			token = tkOTHER;
-			break;
-		}
-		default: {
+    while (*zSql) {
+        switch (*zSql) {
+            case ';': { /* A semicolon */
+                token = tkSEMI;
+                break;
+            }
+            case ' ':
+            case '\r':
+            case '\t':
+            case '\n':
+            case '\f': { /* White space is ignored */
+                token = tkWS;
+                break;
+            }
+            case '/': { /* C-style comments */
+                if (zSql[1] != '*') {
+                    token = tkOTHER;
+                    break;
+                }
+                zSql += 2;
+                while (zSql[0] && (zSql[0] != '*' || zSql[1] != '/')) {
+                    zSql++;
+                }
+                if (zSql[0] == 0)
+                    return 0;
+                zSql++;
+                token = tkWS;
+                break;
+            }
+            case '-': { /* SQL-style comments from "--" to end of line */
+                if (zSql[1] != '-') {
+                    token = tkOTHER;
+                    break;
+                }
+                while (*zSql && *zSql != '\n') {
+                    zSql++;
+                }
+                if (*zSql == 0)
+                    return state == 1;
+                token = tkWS;
+                break;
+            }
+            case '[': { /* Microsoft-style identifiers in [...] */
+                zSql++;
+                while (*zSql && *zSql != ']') {
+                    zSql++;
+                }
+                if (*zSql == 0)
+                    return 0;
+                token = tkOTHER;
+                break;
+            }
+            case '`': /* Grave-accent quoted symbols used by MySQL */
+            case '"': /* single- and double-quoted strings */
+            case '\'': {
+                int c = *zSql;
+                zSql++;
+                while (*zSql && *zSql != c) {
+                    zSql++;
+                }
+                if (*zSql == 0)
+                    return 0;
+                token = tkOTHER;
+                break;
+            }
+            default: {
 
-			if (IdChar((u8)*zSql)) {
-				/* Keywords and unquoted identifiers */
-				int nId;
-				for (nId = 1; IdChar(zSql[nId]); nId++) {
-				}
-				token = tkOTHER;
+                if (IdChar((u8) *zSql)) {
+                    /* Keywords and unquoted identifiers */
+                    int nId;
+                    for (nId = 1; IdChar(zSql[nId]); nId++) {
+                    }
+                    token = tkOTHER;
 
-				zSql += nId - 1;
-			} else {
-				/* Operators and special symbols */
-				token = tkOTHER;
-			}
-			break;
-		}
-		}
-		state = trans[state][token];
-		zSql++;
-	}
-	return state == 1;
+                    zSql += nId - 1;
+                } else {
+                    /* Operators and special symbols */
+                    token = tkOTHER;
+                }
+                break;
+            }
+        }
+        state = trans[state][token];
+        zSql++;
+    }
+    return state == 1;
 }
 
 // checks if input ends with ;
 int sqlite3_complete_old(const char *sql) {
-	fprintf(stderr, "sqlite3_complete: unsupported. '%s'\n", sql);
-	return -1;
+    fprintf(stderr, "sqlite3_complete: unsupported. '%s'\n", sql);
+    return -1;
 }
 
 int sqlite3_bind_blob(sqlite3_stmt *, int, const void *, int n, void (*)(void *)) {
-	fprintf(stderr, "sqlite3_bind_blob: unsupported.\n");
-	return -1;
+    fprintf(stderr, "sqlite3_bind_blob: unsupported.\n");
+    return -1;
 }
 
 const void *sqlite3_column_blob(sqlite3_stmt *, int iCol) {
-	fprintf(stderr, "sqlite3_column_blob: unsupported.\n");
-	return nullptr;
+    fprintf(stderr, "sqlite3_column_blob: unsupported.\n");
+    return nullptr;
 }
 
 // length of varchar or blob value
 int sqlite3_column_bytes(sqlite3_stmt *, int iCol) {
-	fprintf(stderr, "sqlite3_column_bytes: unsupported.\n");
-	return -1;
+    fprintf(stderr, "sqlite3_column_bytes: unsupported.\n");
+    return -1;
 }
 
 sqlite3_value *sqlite3_column_value(sqlite3_stmt *, int iCol) {
-	fprintf(stderr, "sqlite3_column_value: unsupported.\n");
-	return nullptr;
+    fprintf(stderr, "sqlite3_column_value: unsupported.\n");
+    return nullptr;
 }
 
 int sqlite3_db_config(sqlite3 *, int op, ...) {
-	fprintf(stderr, "sqlite3_db_config: unsupported.\n");
-	return -1;
+    fprintf(stderr, "sqlite3_db_config: unsupported.\n");
+    return -1;
 }
 
 int sqlite3_get_autocommit(sqlite3 *db) {
-	return 1;
-	// TODO fix this
-	// return db->con->context->transaction.IsAutoCommit();
-	fprintf(stderr, "sqlite3_get_autocommit: unsupported.\n");
+    return 1;
+    // TODO fix this
+    // return db->con->context->transaction.IsAutoCommit();
+    fprintf(stderr, "sqlite3_get_autocommit: unsupported.\n");
 }
 
 int sqlite3_limit(sqlite3 *, int id, int newVal) {
-	fprintf(stderr, "sqlite3_limit: unsupported.\n");
-	return -1;
+    fprintf(stderr, "sqlite3_limit: unsupported.\n");
+    return -1;
 }
 
 int sqlite3_stmt_readonly(sqlite3_stmt *pStmt) {
-	fprintf(stderr, "sqlite3_stmt_readonly: unsupported.\n");
-	return -1;
+    fprintf(stderr, "sqlite3_stmt_readonly: unsupported.\n");
+    return -1;
 }
 
 // TODO pretty easy schema lookup
@@ -968,107 +1033,107 @@ int sqlite3_table_column_metadata(sqlite3 *db,             /* Connection handle 
                                   int *pPrimaryKey,        /* OUTPUT: True if column part of PK */
                                   int *pAutoinc            /* OUTPUT: True if column is auto-increment */
 ) {
-	fprintf(stderr, "sqlite3_table_column_metadata: unsupported.\n");
-	return -1;
+    fprintf(stderr, "sqlite3_table_column_metadata: unsupported.\n");
+    return -1;
 }
 
 const char *sqlite3_column_decltype(sqlite3_stmt *pStmt, int iCol) {
-	if (!pStmt || !pStmt->prepared) {
-		return NULL;
-	}
-	auto column_type = pStmt->prepared->GetTypes()[iCol];
-	switch (column_type.id()) {
-	case LogicalTypeId::BOOLEAN:
-		return "BOOLEAN";
-	case LogicalTypeId::TINYINT:
-		return "TINYINT";
-	case LogicalTypeId::SMALLINT:
-		return "SMALLINT";
-	case LogicalTypeId::INTEGER:
-		return "INTEGER";
-	case LogicalTypeId::BIGINT:
-		return "BIGINT";
-	case LogicalTypeId::FLOAT:
-		return "FLOAT";
-	case LogicalTypeId::DOUBLE:
-		return "DOUBLE";
-	case LogicalTypeId::DECIMAL:
-		return "DECIMAL";
-	case LogicalTypeId::DATE:
-		return "DATE";
-	case LogicalTypeId::TIME:
-		return "TIME";
-	case LogicalTypeId::TIMESTAMP:
-		return "TIMESTAMP";
-	case LogicalTypeId::VARCHAR:
-		return "VARCHAR";
-	case LogicalTypeId::LIST:
-		return "LIST";
-	case LogicalTypeId::STRUCT:
-		return "STRUCT";
-	case LogicalTypeId::BLOB:
-		return "BLOB";
-	default:
-		return NULL;
-	}
-	return NULL;
+    if (!pStmt || !pStmt->prepared) {
+        return NULL;
+    }
+    auto column_type = pStmt->prepared->GetTypes()[iCol];
+    switch (column_type.id()) {
+        case LogicalTypeId::BOOLEAN:
+            return "BOOLEAN";
+        case LogicalTypeId::TINYINT:
+            return "TINYINT";
+        case LogicalTypeId::SMALLINT:
+            return "SMALLINT";
+        case LogicalTypeId::INTEGER:
+            return "INTEGER";
+        case LogicalTypeId::BIGINT:
+            return "BIGINT";
+        case LogicalTypeId::FLOAT:
+            return "FLOAT";
+        case LogicalTypeId::DOUBLE:
+            return "DOUBLE";
+        case LogicalTypeId::DECIMAL:
+            return "DECIMAL";
+        case LogicalTypeId::DATE:
+            return "DATE";
+        case LogicalTypeId::TIME:
+            return "TIME";
+        case LogicalTypeId::TIMESTAMP:
+            return "TIMESTAMP";
+        case LogicalTypeId::VARCHAR:
+            return "VARCHAR";
+        case LogicalTypeId::LIST:
+            return "LIST";
+        case LogicalTypeId::STRUCT:
+            return "STRUCT";
+        case LogicalTypeId::BLOB:
+            return "BLOB";
+        default:
+            return NULL;
+    }
+    return NULL;
 }
 
 int sqlite3_status64(int op, sqlite3_int64 *pCurrent, sqlite3_int64 *pHighwater, int resetFlag) {
-	fprintf(stderr, "sqlite3_status64: unsupported.\n");
-	return -1;
+    fprintf(stderr, "sqlite3_status64: unsupported.\n");
+    return -1;
 }
 
 int sqlite3_status64(sqlite3 *, int op, int *pCur, int *pHiwtr, int resetFlg) {
-	fprintf(stderr, "sqlite3_status64: unsupported.\n");
-	return -1;
+    fprintf(stderr, "sqlite3_status64: unsupported.\n");
+    return -1;
 }
 
 int sqlite3_stmt_status(sqlite3_stmt *, int op, int resetFlg) {
-	fprintf(stderr, "sqlite3_stmt_status: unsupported.\n");
-	return -1;
+    fprintf(stderr, "sqlite3_stmt_status: unsupported.\n");
+    return -1;
 }
 
 int sqlite3_file_control(sqlite3 *, const char *zDbName, int op, void *) {
-	fprintf(stderr, "sqlite3_file_control: unsupported.\n");
-	return -1;
+    fprintf(stderr, "sqlite3_file_control: unsupported.\n");
+    return -1;
 }
 
 int sqlite3_declare_vtab(sqlite3 *, const char *zSQL) {
-	fprintf(stderr, "sqlite3_declare_vtab: unsupported.\n");
-	return -1;
+    fprintf(stderr, "sqlite3_declare_vtab: unsupported.\n");
+    return -1;
 }
 
 const char *sqlite3_vtab_collation(sqlite3_index_info *, int) {
-	fprintf(stderr, "sqlite3_vtab_collation: unsupported.\n");
-	return nullptr;
+    fprintf(stderr, "sqlite3_vtab_collation: unsupported.\n");
+    return nullptr;
 }
 
 int sqlite3_sleep(int) {
-	fprintf(stderr, "sqlite3_sleep: unsupported.\n");
-	return -1;
+    fprintf(stderr, "sqlite3_sleep: unsupported.\n");
+    return -1;
 }
 
 int sqlite3_busy_timeout(sqlite3 *, int ms) {
-	fprintf(stderr, "sqlite3_busy_timeout: unsupported.\n");
-	return -1;
+    fprintf(stderr, "sqlite3_busy_timeout: unsupported.\n");
+    return -1;
 }
 
 // unlikely to be supported
 
 int sqlite3_trace_v2(sqlite3 *, unsigned uMask, int (*xCallback)(unsigned, void *, void *, void *), void *pCtx) {
-	fprintf(stderr, "sqlite3_trace_v2: unsupported.\n");
-	return -1;
+    fprintf(stderr, "sqlite3_trace_v2: unsupported.\n");
+    return -1;
 }
 
 int sqlite3_test_control(int op, ...) {
-	fprintf(stderr, "sqlite3_test_control: unsupported.\n");
-	return -1;
+    fprintf(stderr, "sqlite3_test_control: unsupported.\n");
+    return -1;
 }
 
 int sqlite3_enable_load_extension(sqlite3 *db, int onoff) {
-	// fprintf(stderr, "sqlite3_enable_load_extension: unsupported.\n");
-	return -1;
+    // fprintf(stderr, "sqlite3_enable_load_extension: unsupported.\n");
+    return -1;
 }
 
 int sqlite3_load_extension(sqlite3 *db,       /* Load the extension into this database connection */
@@ -1076,8 +1141,8 @@ int sqlite3_load_extension(sqlite3 *db,       /* Load the extension into this da
                            const char *zProc, /* Entry point.  Derived from zFile if 0 */
                            char **pzErrMsg    /* Put error message here if not 0 */
 ) {
-	// fprintf(stderr, "sqlite3_load_extension: unsupported.\n");
-	return -1;
+    // fprintf(stderr, "sqlite3_load_extension: unsupported.\n");
+    return -1;
 }
 
 int sqlite3_create_module(sqlite3 *db,             /* SQLite connection to register module with */
@@ -1085,57 +1150,59 @@ int sqlite3_create_module(sqlite3 *db,             /* SQLite connection to regis
                           const sqlite3_module *p, /* Methods for the module */
                           void *pClientData        /* Client data for xCreate/xConnect */
 ) {
-	// fprintf(stderr, "sqlite3_create_module: unsupported.\n");
-	return -1;
+    // fprintf(stderr, "sqlite3_create_module: unsupported.\n");
+    return -1;
 }
 
 int sqlite3_create_function(sqlite3 *db, const char *zFunctionName, int nArg, int eTextRep, void *pApp,
                             void (*xFunc)(sqlite3_context *, int, sqlite3_value **),
                             void (*xStep)(sqlite3_context *, int, sqlite3_value **),
                             void (*xFinal)(sqlite3_context *)) {
-	// fprintf(stderr, "sqlite3_create_function: unsupported.\n");
-	return -1;
+    // fprintf(stderr, "sqlite3_create_function: unsupported.\n");
+    return -1;
 }
 
 int sqlite3_set_authorizer(sqlite3 *, int (*xAuth)(void *, int, const char *, const char *, const char *, const char *),
                            void *pUserData) {
-	fprintf(stderr, "sqlite3_set_authorizer: unsupported.\n");
-	return -1;
+    fprintf(stderr, "sqlite3_set_authorizer: unsupported.\n");
+    return -1;
 }
 
 // needed in shell timer
 static int unixCurrentTimeInt64(sqlite3_vfs *NotUsed, sqlite3_int64 *piNow) {
-	using namespace std::chrono;
-	*piNow = (sqlite3_int64)duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-	return SQLITE_OK;
+    using namespace std::chrono;
+    *piNow = (sqlite3_int64) duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+    return SQLITE_OK;
 }
 
 // virtual file system, providing some dummies to avoid crashes
 sqlite3_vfs *sqlite3_vfs_find(const char *zVfsName) {
-	// return a dummy because the shell does not check the return code.
-	// fprintf(stderr, "sqlite3_vfs_find: unsupported.\n");
-	sqlite3_vfs *res = (sqlite3_vfs *)sqlite3_malloc(sizeof(sqlite3_vfs));
-	res->xCurrentTimeInt64 = unixCurrentTimeInt64;
-	res->iVersion = 2;
-	res->zName = "dummy";
-	res->pNext = nullptr;
-	assert(res);
-	return res;
+    // return a dummy because the shell does not check the return code.
+    // fprintf(stderr, "sqlite3_vfs_find: unsupported.\n");
+    sqlite3_vfs *res = (sqlite3_vfs *) sqlite3_malloc(sizeof(sqlite3_vfs));
+    res->xCurrentTimeInt64 = unixCurrentTimeInt64;
+    res->iVersion = 2;
+    res->zName = "dummy";
+    res->pNext = nullptr;
+    assert(res);
+    return res;
 }
+
 int sqlite3_vfs_register(sqlite3_vfs *, int makeDflt) {
-	// fprintf(stderr, "sqlite3_vfs_register: unsupported.\n");
-	return -1;
+    // fprintf(stderr, "sqlite3_vfs_register: unsupported.\n");
+    return -1;
 }
 
 // backups, unused
 
 int sqlite3_backup_step(sqlite3_backup *p, int nPage) {
-	fprintf(stderr, "sqlite3_backup_step: unsupported.\n");
-	return -1;
+    fprintf(stderr, "sqlite3_backup_step: unsupported.\n");
+    return -1;
 }
+
 int sqlite3_backup_finish(sqlite3_backup *p) {
-	fprintf(stderr, "sqlite3_backup_finish: unsupported.\n");
-	return -1;
+    fprintf(stderr, "sqlite3_backup_finish: unsupported.\n");
+    return -1;
 }
 
 sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest,         /* Destination database handle */
@@ -1143,152 +1210,152 @@ sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest,         /* Destination datab
                                     sqlite3 *pSource,       /* Source database handle */
                                     const char *zSourceName /* Source database name */
 ) {
-	fprintf(stderr, "sqlite3_backup_init: unsupported.\n");
-	return nullptr;
+    fprintf(stderr, "sqlite3_backup_init: unsupported.\n");
+    return nullptr;
 }
 
 // UDF support stuff, unused for now. These cannot be called as create_function above is disabled
 
 SQLITE_API sqlite3 *sqlite3_context_db_handle(sqlite3_context *) {
-	return nullptr;
+    return nullptr;
 }
 
 void *sqlite3_user_data(sqlite3_context *) {
-	return nullptr;
+    return nullptr;
 }
 
 #ifdef _WIN32
 #include <windows.h>
 
 static void *sqlite3MallocZero(size_t n) {
-	auto res = sqlite3_malloc(n);
-	assert(res);
-	memset(res, 0, n);
-	return res;
+    auto res = sqlite3_malloc(n);
+    assert(res);
+    memset(res, 0, n);
+    return res;
 }
 
 static LPWSTR winUtf8ToUnicode(const char *zText) {
-	int nChar;
-	LPWSTR zWideText;
+    int nChar;
+    LPWSTR zWideText;
 
-	nChar = MultiByteToWideChar(CP_UTF8, 0, zText, -1, NULL, 0);
-	if (nChar == 0) {
-		return 0;
-	}
-	zWideText = (LPWSTR)sqlite3MallocZero(nChar * sizeof(WCHAR));
-	if (zWideText == 0) {
-		return 0;
-	}
-	nChar = MultiByteToWideChar(CP_UTF8, 0, zText, -1, zWideText, nChar);
-	if (nChar == 0) {
-		sqlite3_free(zWideText);
-		zWideText = 0;
-	}
-	return zWideText;
+    nChar = MultiByteToWideChar(CP_UTF8, 0, zText, -1, NULL, 0);
+    if (nChar == 0) {
+        return 0;
+    }
+    zWideText = (LPWSTR)sqlite3MallocZero(nChar * sizeof(WCHAR));
+    if (zWideText == 0) {
+        return 0;
+    }
+    nChar = MultiByteToWideChar(CP_UTF8, 0, zText, -1, zWideText, nChar);
+    if (nChar == 0) {
+        sqlite3_free(zWideText);
+        zWideText = 0;
+    }
+    return zWideText;
 }
 
 static char *winUnicodeToMbcs(LPCWSTR zWideText, int useAnsi) {
-	int nByte;
-	char *zText;
-	int codepage = useAnsi ? CP_ACP : CP_OEMCP;
+    int nByte;
+    char *zText;
+    int codepage = useAnsi ? CP_ACP : CP_OEMCP;
 
-	nByte = WideCharToMultiByte(codepage, 0, zWideText, -1, 0, 0, 0, 0);
-	if (nByte == 0) {
-		return 0;
-	}
-	zText = (char *)sqlite3MallocZero(nByte);
-	if (zText == 0) {
-		return 0;
-	}
-	nByte = WideCharToMultiByte(codepage, 0, zWideText, -1, zText, nByte, 0, 0);
-	if (nByte == 0) {
-		sqlite3_free(zText);
-		zText = 0;
-	}
-	return zText;
+    nByte = WideCharToMultiByte(codepage, 0, zWideText, -1, 0, 0, 0, 0);
+    if (nByte == 0) {
+        return 0;
+    }
+    zText = (char *)sqlite3MallocZero(nByte);
+    if (zText == 0) {
+        return 0;
+    }
+    nByte = WideCharToMultiByte(codepage, 0, zWideText, -1, zText, nByte, 0, 0);
+    if (nByte == 0) {
+        sqlite3_free(zText);
+        zText = 0;
+    }
+    return zText;
 }
 
 static char *winUtf8ToMbcs(const char *zText, int useAnsi) {
-	char *zTextMbcs;
-	LPWSTR zTmpWide;
+    char *zTextMbcs;
+    LPWSTR zTmpWide;
 
-	zTmpWide = winUtf8ToUnicode(zText);
-	if (zTmpWide == 0) {
-		return 0;
-	}
-	zTextMbcs = winUnicodeToMbcs(zTmpWide, useAnsi);
-	sqlite3_free(zTmpWide);
-	return zTextMbcs;
+    zTmpWide = winUtf8ToUnicode(zText);
+    if (zTmpWide == 0) {
+        return 0;
+    }
+    zTextMbcs = winUnicodeToMbcs(zTmpWide, useAnsi);
+    sqlite3_free(zTmpWide);
+    return zTextMbcs;
 }
 
 SQLITE_API char *sqlite3_win32_utf8_to_mbcs_v2(const char *zText, int useAnsi) {
-	return winUtf8ToMbcs(zText, useAnsi);
+    return winUtf8ToMbcs(zText, useAnsi);
 }
 
 LPWSTR sqlite3_win32_utf8_to_unicode(const char *zText) {
-	return winUtf8ToUnicode(zText);
+    return winUtf8ToUnicode(zText);
 }
 
 static LPWSTR winMbcsToUnicode(const char *zText, int useAnsi) {
-	int nByte;
-	LPWSTR zMbcsText;
-	int codepage = useAnsi ? CP_ACP : CP_OEMCP;
+    int nByte;
+    LPWSTR zMbcsText;
+    int codepage = useAnsi ? CP_ACP : CP_OEMCP;
 
-	nByte = MultiByteToWideChar(codepage, 0, zText, -1, NULL, 0) * sizeof(WCHAR);
-	if (nByte == 0) {
-		return 0;
-	}
-	zMbcsText = (LPWSTR)sqlite3MallocZero(nByte * sizeof(WCHAR));
-	if (zMbcsText == 0) {
-		return 0;
-	}
-	nByte = MultiByteToWideChar(codepage, 0, zText, -1, zMbcsText, nByte);
-	if (nByte == 0) {
-		sqlite3_free(zMbcsText);
-		zMbcsText = 0;
-	}
-	return zMbcsText;
+    nByte = MultiByteToWideChar(codepage, 0, zText, -1, NULL, 0) * sizeof(WCHAR);
+    if (nByte == 0) {
+        return 0;
+    }
+    zMbcsText = (LPWSTR)sqlite3MallocZero(nByte * sizeof(WCHAR));
+    if (zMbcsText == 0) {
+        return 0;
+    }
+    nByte = MultiByteToWideChar(codepage, 0, zText, -1, zMbcsText, nByte);
+    if (nByte == 0) {
+        sqlite3_free(zMbcsText);
+        zMbcsText = 0;
+    }
+    return zMbcsText;
 }
 
 static char *winUnicodeToUtf8(LPCWSTR zWideText) {
-	int nByte;
-	char *zText;
+    int nByte;
+    char *zText;
 
-	nByte = WideCharToMultiByte(CP_UTF8, 0, zWideText, -1, 0, 0, 0, 0);
-	if (nByte == 0) {
-		return 0;
-	}
-	zText = (char *)sqlite3MallocZero(nByte);
-	if (zText == 0) {
-		return 0;
-	}
-	nByte = WideCharToMultiByte(CP_UTF8, 0, zWideText, -1, zText, nByte, 0, 0);
-	if (nByte == 0) {
-		sqlite3_free(zText);
-		zText = 0;
-	}
-	return zText;
+    nByte = WideCharToMultiByte(CP_UTF8, 0, zWideText, -1, 0, 0, 0, 0);
+    if (nByte == 0) {
+        return 0;
+    }
+    zText = (char *)sqlite3MallocZero(nByte);
+    if (zText == 0) {
+        return 0;
+    }
+    nByte = WideCharToMultiByte(CP_UTF8, 0, zWideText, -1, zText, nByte, 0, 0);
+    if (nByte == 0) {
+        sqlite3_free(zText);
+        zText = 0;
+    }
+    return zText;
 }
 
 static char *winMbcsToUtf8(const char *zText, int useAnsi) {
-	char *zTextUtf8;
-	LPWSTR zTmpWide;
+    char *zTextUtf8;
+    LPWSTR zTmpWide;
 
-	zTmpWide = winMbcsToUnicode(zText, useAnsi);
-	if (zTmpWide == 0) {
-		return 0;
-	}
-	zTextUtf8 = winUnicodeToUtf8(zTmpWide);
-	sqlite3_free(zTmpWide);
-	return zTextUtf8;
+    zTmpWide = winMbcsToUnicode(zText, useAnsi);
+    if (zTmpWide == 0) {
+        return 0;
+    }
+    zTextUtf8 = winUnicodeToUtf8(zTmpWide);
+    sqlite3_free(zTmpWide);
+    return zTextUtf8;
 }
 
 SQLITE_API char *sqlite3_win32_mbcs_to_utf8_v2(const char *zText, int useAnsi) {
-	return winMbcsToUtf8(zText, useAnsi);
+    return winMbcsToUtf8(zText, useAnsi);
 }
 
 SQLITE_API char *sqlite3_win32_unicode_to_utf8(LPCWSTR zWideText) {
-	return winUnicodeToUtf8(zWideText);
+    return winUnicodeToUtf8(zWideText);
 }
 
 #endif
@@ -1296,100 +1363,132 @@ SQLITE_API char *sqlite3_win32_unicode_to_utf8(LPCWSTR zWideText) {
 // TODO complain
 SQLITE_API void sqlite3_result_blob(sqlite3_context *, const void *, int, void (*)(void *)) {
 }
+
 SQLITE_API void sqlite3_result_blob64(sqlite3_context *, const void *, sqlite3_uint64, void (*)(void *)) {
 }
+
 SQLITE_API void sqlite3_result_double(sqlite3_context *, double) {
 }
+
 SQLITE_API void sqlite3_result_error(sqlite3_context *, const char *, int) {
 }
+
 SQLITE_API void sqlite3_result_error16(sqlite3_context *, const void *, int) {
 }
+
 SQLITE_API void sqlite3_result_error_toobig(sqlite3_context *) {
 }
+
 SQLITE_API void sqlite3_result_error_nomem(sqlite3_context *) {
 }
+
 SQLITE_API void sqlite3_result_error_code(sqlite3_context *, int) {
 }
+
 SQLITE_API void sqlite3_result_int(sqlite3_context *, int) {
 }
+
 SQLITE_API void sqlite3_result_int64(sqlite3_context *, sqlite3_int64) {
 }
+
 SQLITE_API void sqlite3_result_null(sqlite3_context *) {
 }
+
 SQLITE_API void sqlite3_result_text(sqlite3_context *, const char *, int, void (*)(void *)) {
 }
+
 SQLITE_API void sqlite3_result_text64(sqlite3_context *, const char *, sqlite3_uint64, void (*)(void *),
                                       unsigned char encoding) {
 }
+
 SQLITE_API void sqlite3_result_text16(sqlite3_context *, const void *, int, void (*)(void *)) {
 }
+
 SQLITE_API void sqlite3_result_text16le(sqlite3_context *, const void *, int, void (*)(void *)) {
 }
+
 SQLITE_API void sqlite3_result_text16be(sqlite3_context *, const void *, int, void (*)(void *)) {
 }
+
 SQLITE_API void sqlite3_result_value(sqlite3_context *, sqlite3_value *) {
 }
+
 SQLITE_API void sqlite3_result_pointer(sqlite3_context *, void *, const char *, void (*)(void *)) {
 }
+
 SQLITE_API void sqlite3_result_zeroblob(sqlite3_context *, int n) {
 }
+
 SQLITE_API int sqlite3_result_zeroblob64(sqlite3_context *, sqlite3_uint64 n) {
-	return -1;
+    return -1;
 }
 
 // TODO complain
 const void *sqlite3_value_blob(sqlite3_value *) {
-	return nullptr;
+    return nullptr;
 }
+
 double sqlite3_value_double(sqlite3_value *) {
-	return 0;
+    return 0;
 }
+
 int sqlite3_value_int(sqlite3_value *) {
-	return 0;
+    return 0;
 }
+
 sqlite3_int64 sqlite3_value_int64(sqlite3_value *) {
-	return 0;
+    return 0;
 }
+
 void *sqlite3_value_pointer(sqlite3_value *, const char *) {
-	return nullptr;
+    return nullptr;
 }
+
 const unsigned char *sqlite3_value_text(sqlite3_value *) {
-	return nullptr;
+    return nullptr;
 }
+
 SQLITE_API const void *sqlite3_value_text16(sqlite3_value *) {
-	return nullptr;
+    return nullptr;
 }
+
 SQLITE_API const void *sqlite3_value_text16le(sqlite3_value *) {
-	return nullptr;
+    return nullptr;
 }
+
 SQLITE_API const void *sqlite3_value_text16be(sqlite3_value *) {
-	return nullptr;
+    return nullptr;
 }
+
 SQLITE_API int sqlite3_value_bytes(sqlite3_value *) {
-	return 0;
+    return 0;
 }
+
 SQLITE_API int sqlite3_value_bytes16(sqlite3_value *) {
-	return 0;
+    return 0;
 }
+
 SQLITE_API int sqlite3_value_type(sqlite3_value *) {
-	return 0;
+    return 0;
 }
+
 SQLITE_API int sqlite3_value_numeric_type(sqlite3_value *) {
-	return 0;
+    return 0;
 }
+
 SQLITE_API int sqlite3_value_nochange(sqlite3_value *) {
-	return 0;
+    return 0;
 }
 
 SQLITE_API void *sqlite3_aggregate_context(sqlite3_context *, int nBytes) {
-	fprintf(stderr, "sqlite3_aggregate_context: unsupported.\n");
+    fprintf(stderr, "sqlite3_aggregate_context: unsupported.\n");
 
-	return nullptr;
+    return nullptr;
 }
 
 SQLITE_API int sqlite3_create_collation(sqlite3 *, const char *zName, int eTextRep, void *pArg,
                                         int (*xCompare)(void *, int, const void *, int, const void *)) {
-	return SQLITE_ERROR;
+    return SQLITE_ERROR;
 }
 
 SQLITE_API int sqlite3_create_window_function(sqlite3 *db, const char *zFunctionName, int nArg, int eTextRep,
@@ -1397,45 +1496,45 @@ SQLITE_API int sqlite3_create_window_function(sqlite3 *db, const char *zFunction
                                               void (*xFinal)(sqlite3_context *), void (*xValue)(sqlite3_context *),
                                               void (*xInverse)(sqlite3_context *, int, sqlite3_value **),
                                               void (*xDestroy)(void *)) {
-	fprintf(stderr, "sqlite3_create_window_function: unsupported.\n");
-	return SQLITE_ERROR;
+    fprintf(stderr, "sqlite3_create_window_function: unsupported.\n");
+    return SQLITE_ERROR;
 }
 
 SQLITE_API sqlite3 *sqlite3_db_handle(sqlite3_stmt *s) {
-	return s->db;
+    return s->db;
 }
 
 SQLITE_API char *sqlite3_expanded_sql(sqlite3_stmt *pStmt) {
-	fprintf(stderr, "sqlite3_expanded_sql: unsupported.\n");
-	return nullptr;
+    fprintf(stderr, "sqlite3_expanded_sql: unsupported.\n");
+    return nullptr;
 }
 
 SQLITE_API int sqlite3_keyword_check(const char *str, int len) {
-	return Parser::IsKeyword(std::string(str, len));
+    return Parser::IsKeyword(std::string(str, len));
 }
 
 SQLITE_API int sqlite3_keyword_count(void) {
-	fprintf(stderr, "sqlite3_keyword_count: unsupported.\n");
-	return 0;
+    fprintf(stderr, "sqlite3_keyword_count: unsupported.\n");
+    return 0;
 }
 
 SQLITE_API int sqlite3_keyword_name(int, const char **, int *) {
-	fprintf(stderr, "sqlite3_keyword_name: unsupported.\n");
-	return 0;
+    fprintf(stderr, "sqlite3_keyword_name: unsupported.\n");
+    return 0;
 }
 
 SQLITE_API void sqlite3_progress_handler(sqlite3 *, int, int (*)(void *), void *) {
-	fprintf(stderr, "sqlite3_progress_handler: unsupported.\n");
+    fprintf(stderr, "sqlite3_progress_handler: unsupported.\n");
 }
 
 SQLITE_API int sqlite3_stmt_isexplain(sqlite3_stmt *pStmt) {
-	if (!pStmt || !pStmt->prepared) {
-		return 0;
-	}
-	return pStmt->prepared->GetStatementType() == StatementType::EXPLAIN_STATEMENT;
+    if (!pStmt || !pStmt->prepared) {
+        return 0;
+    }
+    return pStmt->prepared->GetStatementType() == StatementType::EXPLAIN_STATEMENT;
 }
 
 SQLITE_API int sqlite3_vtab_config(sqlite3 *, int op, ...) {
-	fprintf(stderr, "sqlite3_vtab_config: unsupported.\n");
-	return SQLITE_ERROR;
+    fprintf(stderr, "sqlite3_vtab_config: unsupported.\n");
+    return SQLITE_ERROR;
 }

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -211,8 +211,7 @@ bool sqlite3_display_result(StatementType type) {
 class ProgressBar {
 public:
 
-//    string pbstr = "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||";
-    string pbstr = "🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆";
+    string pbstr = "🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆";
     idx_t pbwidth = 60;
     bool finished = false;
     Executor *executor = nullptr;
@@ -232,10 +231,10 @@ public:
     }
 
     void ProgressBarThread() {
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+//        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
         while (!StopRequested()) {
             PrintProgress(executor->GetPipelinesProgress());
-            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
     }
 
@@ -254,7 +253,7 @@ public:
         if (progress_bar_thread.joinable()) {
             exit_signal.set_value();
             progress_bar_thread.join();
-            printf("\n");
+            printf(" \n");
             fflush(stdout);
         }
 

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -233,6 +233,11 @@ public:
     void ProgressBarThread() {
 //        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
         while (!StopRequested()) {
+            int cur_percentage = executor->GetPipelinesProgress();
+            if (cur_percentage == -1){
+                //!uh-oh this operator is not supported for the progressive bar
+                return;
+            }
             PrintProgress(executor->GetPipelinesProgress());
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -14,7 +14,6 @@
 #include <cassert>
 
 #include "extension_helper.hpp"
-#include <unistd.h>
 #include <iostream>
 #include <thread>
 #include <future>
@@ -25,54 +24,54 @@ using namespace std;
 static char *sqlite3_strdup(const char *str);
 
 struct sqlite3_string_buffer {
-    //! String data
-    unique_ptr<char[]> data;
+	//! String data
+	unique_ptr<char[]> data;
 };
 
 struct sqlite3_stmt {
-    //! The DB object that this statement belongs to
-    sqlite3 *db;
-    //! The query string
-    string query_string;
-    //! The prepared statement object, if successfully prepared
-    unique_ptr<PreparedStatement> prepared;
-    //! The result object, if successfully executed
-    unique_ptr<QueryResult> result;
-    //! The current chunk that we are iterating over
-    unique_ptr<DataChunk> current_chunk;
-    //! The current row into the current chunk that we are iterating over
-    int64_t current_row;
-    //! Bound values, used for binding to the prepared statement
-    vector<Value> bound_values;
-    //! Names of the prepared parameters
-    vector<string> bound_names;
-    //! The current column values converted to string, used and filled by sqlite3_column_text
-    unique_ptr<sqlite3_string_buffer[]> current_text;
+	//! The DB object that this statement belongs to
+	sqlite3 *db;
+	//! The query string
+	string query_string;
+	//! The prepared statement object, if successfully prepared
+	unique_ptr<PreparedStatement> prepared;
+	//! The result object, if successfully executed
+	unique_ptr<QueryResult> result;
+	//! The current chunk that we are iterating over
+	unique_ptr<DataChunk> current_chunk;
+	//! The current row into the current chunk that we are iterating over
+	int64_t current_row;
+	//! Bound values, used for binding to the prepared statement
+	vector<Value> bound_values;
+	//! Names of the prepared parameters
+	vector<string> bound_names;
+	//! The current column values converted to string, used and filled by sqlite3_column_text
+	unique_ptr<sqlite3_string_buffer[]> current_text;
 };
 
 struct sqlite3 {
-    unique_ptr<DuckDB> db;
-    unique_ptr<Connection> con;
-    string last_error;
+	unique_ptr<DuckDB> db;
+	unique_ptr<Connection> con;
+	string last_error;
 };
 
 void sqlite3_randomness(int N, void *pBuf) {
-    static bool init = false;
-    if (!init) {
-        srand(time(NULL));
-        init = true;
-    }
-    unsigned char *zBuf = (unsigned char *) pBuf;
-    while (N--) {
-        unsigned char nextByte = rand() % 255;
-        zBuf[N] = nextByte;
-    }
+	static bool init = false;
+	if (!init) {
+		srand(time(NULL));
+		init = true;
+	}
+	unsigned char *zBuf = (unsigned char *)pBuf;
+	while (N--) {
+		unsigned char nextByte = rand() % 255;
+		zBuf[N] = nextByte;
+	}
 }
 
 int sqlite3_open(const char *filename, /* Database filename (UTF-8) */
                  sqlite3 **ppDb        /* OUT: SQLite db handle */
 ) {
-    return sqlite3_open_v2(filename, ppDb, 0, NULL);
+	return sqlite3_open_v2(filename, ppDb, 0, NULL);
 }
 
 int sqlite3_open_v2(const char *filename, /* Database filename (UTF-8) */
@@ -80,44 +79,44 @@ int sqlite3_open_v2(const char *filename, /* Database filename (UTF-8) */
                     int flags,            /* Flags */
                     const char *zVfs      /* Name of VFS module to use */
 ) {
-    if (filename && strcmp(filename, ":memory:") == 0) {
-        filename = NULL;
-    }
-    *ppDb = nullptr;
-    if (zVfs) { /* unsupported so if set we complain */
-        return SQLITE_ERROR;
-    }
-    sqlite3 *pDb = nullptr;
-    try {
-        pDb = new sqlite3();
-        DBConfig config;
-        config.access_mode = AccessMode::AUTOMATIC;
-        if (flags & SQLITE_OPEN_READONLY) {
-            config.access_mode = AccessMode::READ_ONLY;
-        }
-        pDb->db = make_unique<DuckDB>(filename, &config);
-        pDb->con = make_unique<Connection>(*pDb->db);
+	if (filename && strcmp(filename, ":memory:") == 0) {
+		filename = NULL;
+	}
+	*ppDb = nullptr;
+	if (zVfs) { /* unsupported so if set we complain */
+		return SQLITE_ERROR;
+	}
+	sqlite3 *pDb = nullptr;
+	try {
+		pDb = new sqlite3();
+		DBConfig config;
+		config.access_mode = AccessMode::AUTOMATIC;
+		if (flags & SQLITE_OPEN_READONLY) {
+			config.access_mode = AccessMode::READ_ONLY;
+		}
+		pDb->db = make_unique<DuckDB>(filename, &config);
+		pDb->con = make_unique<Connection>(*pDb->db);
 
-        ExtensionHelper::LoadAllExtensions(*pDb->db);
-    } catch (std::exception &ex) {
-        if (pDb) {
-            pDb->last_error = ex.what();
-        }
-        return SQLITE_ERROR;
-    }
-    *ppDb = pDb;
-    return SQLITE_OK;
+		ExtensionHelper::LoadAllExtensions(*pDb->db);
+	} catch (std::exception &ex) {
+		if (pDb) {
+			pDb->last_error = ex.what();
+		}
+		return SQLITE_ERROR;
+	}
+	*ppDb = pDb;
+	return SQLITE_OK;
 }
 
 int sqlite3_close(sqlite3 *db) {
-    if (db) {
-        delete db;
-    }
-    return SQLITE_OK;
+	if (db) {
+		delete db;
+	}
+	return SQLITE_OK;
 }
 
 int sqlite3_shutdown(void) {
-    return SQLITE_OK;
+	return SQLITE_OK;
 }
 
 /* In SQLite this function compiles the query into VDBE bytecode,
@@ -129,189 +128,188 @@ int sqlite3_prepare_v2(sqlite3 *db,           /* Database handle */
                        sqlite3_stmt **ppStmt, /* OUT: Statement handle */
                        const char **pzTail    /* OUT: Pointer to unused portion of zSql */
 ) {
-    if (!db || !ppStmt || !zSql) {
-        return SQLITE_MISUSE;
-    }
-    *ppStmt = nullptr;
-    string query = nByte < 0 ? zSql : string(zSql, nByte);
-    if (pzTail) {
-        *pzTail = zSql + query.size();
-    }
-    try {
-        Parser parser;
-        parser.ParseQuery(query);
-        if (parser.statements.size() == 0) {
-            return SQLITE_OK;
-        }
-        // extract the remainder
-        idx_t next_location = parser.statements[0]->stmt_location + parser.statements[0]->stmt_length;
-        bool set_remainder = next_location < query.size();
+	if (!db || !ppStmt || !zSql) {
+		return SQLITE_MISUSE;
+	}
+	*ppStmt = nullptr;
+	string query = nByte < 0 ? zSql : string(zSql, nByte);
+	if (pzTail) {
+		*pzTail = zSql + query.size();
+	}
+	try {
+		Parser parser;
+		parser.ParseQuery(query);
+		if (parser.statements.size() == 0) {
+			return SQLITE_OK;
+		}
+		// extract the remainder
+		idx_t next_location = parser.statements[0]->stmt_location + parser.statements[0]->stmt_length;
+		bool set_remainder = next_location < query.size();
 
-        // extract the first statement
-        vector<unique_ptr<SQLStatement>> statements;
-        statements.push_back(move(parser.statements[0]));
+		// extract the first statement
+		vector<unique_ptr<SQLStatement>> statements;
+		statements.push_back(move(parser.statements[0]));
 
-        db->con->context->HandlePragmaStatements(statements);
+		db->con->context->HandlePragmaStatements(statements);
 
-        // if there are multiple statements here, we are dealing with an import database statement
-        // we directly execute all statements besides the final one
-        for (idx_t i = 0; i + 1 < statements.size(); i++) {
-            auto res = db->con->Query(move(statements[i]));
-            if (!res->success) {
-                db->last_error = res->error;
-                return SQLITE_ERROR;
-            }
-        }
+		// if there are multiple statements here, we are dealing with an import database statement
+		// we directly execute all statements besides the final one
+		for (idx_t i = 0; i + 1 < statements.size(); i++) {
+			auto res = db->con->Query(move(statements[i]));
+			if (!res->success) {
+				db->last_error = res->error;
+				return SQLITE_ERROR;
+			}
+		}
 
-        // now prepare the query
-        auto prepared = db->con->Prepare(move(statements.back()));
-        if (!prepared->success) {
-            // failed to prepare: set the error message
-            db->last_error = prepared->error;
-            return SQLITE_ERROR;
-        }
+		// now prepare the query
+		auto prepared = db->con->Prepare(move(statements.back()));
+		if (!prepared->success) {
+			// failed to prepare: set the error message
+			db->last_error = prepared->error;
+			return SQLITE_ERROR;
+		}
 
-        // create the statement entry
-        unique_ptr<sqlite3_stmt> stmt = make_unique<sqlite3_stmt>();
-        stmt->db = db;
-        stmt->query_string = query;
-        stmt->prepared = move(prepared);
-        stmt->current_row = -1;
-        for (idx_t i = 0; i < stmt->prepared->n_param; i++) {
-            stmt->bound_names.push_back("$" + to_string(i + 1));
-            stmt->bound_values.push_back(Value());
-        }
+		// create the statement entry
+		unique_ptr<sqlite3_stmt> stmt = make_unique<sqlite3_stmt>();
+		stmt->db = db;
+		stmt->query_string = query;
+		stmt->prepared = move(prepared);
+		stmt->current_row = -1;
+		for (idx_t i = 0; i < stmt->prepared->n_param; i++) {
+			stmt->bound_names.push_back("$" + to_string(i + 1));
+			stmt->bound_values.push_back(Value());
+		}
 
-        // extract the remainder of the query and assign it to the pzTail
-        if (pzTail && set_remainder) {
-            *pzTail = zSql + next_location + 1;
-        }
+		// extract the remainder of the query and assign it to the pzTail
+		if (pzTail && set_remainder) {
+			*pzTail = zSql + next_location + 1;
+		}
 
-        *ppStmt = stmt.release();
-        return SQLITE_OK;
-    } catch (std::exception &ex) {
-        db->last_error = ex.what();
-        return SQLITE_ERROR;
-    }
+		*ppStmt = stmt.release();
+		return SQLITE_OK;
+	} catch (std::exception &ex) {
+		db->last_error = ex.what();
+		return SQLITE_ERROR;
+	}
 }
 
 bool sqlite3_display_result(StatementType type) {
-    switch (type) {
-        case StatementType::EXECUTE_STATEMENT:
-        case StatementType::EXPLAIN_STATEMENT:
-        case StatementType::PRAGMA_STATEMENT:
-        case StatementType::SELECT_STATEMENT:
-        case StatementType::SHOW_STATEMENT:
-            return true;
-        default:
-            return false;
-    }
+	switch (type) {
+	case StatementType::EXECUTE_STATEMENT:
+	case StatementType::EXPLAIN_STATEMENT:
+	case StatementType::PRAGMA_STATEMENT:
+	case StatementType::SELECT_STATEMENT:
+	case StatementType::SHOW_STATEMENT:
+		return true;
+	default:
+		return false;
+	}
 }
 
 class ProgressBar {
 public:
+	string pbstr = "🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆"
+	               "🦆🦆🦆🦆🦆🦆🦆🦆";
+	idx_t pbwidth = 60;
+	bool finished = false;
+	Executor *executor = nullptr;
+	std::thread progress_bar_thread;
+	std::promise<void> exit_signal;
+	std::future<void> future_obj = exit_signal.get_future();
 
-    string pbstr = "🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆";
-    idx_t pbwidth = 60;
-    bool finished = false;
-    Executor *executor = nullptr;
-    std::thread progress_bar_thread;
-    std::promise<void> exit_signal;
-    std::future<void> future_obj = exit_signal.get_future();
+	explicit ProgressBar(Executor *executor)
+	    : executor(executor) {
 
-    explicit ProgressBar(Executor *executor) : executor(executor) {
+	      };
 
-    };
+	void PrintProgress(int percentage) {
+		int lpad = (int)(percentage / 100.0 * pbwidth * 2);
+		int rpad = pbwidth - lpad * 0.5;
+		printf("\r%3d%% [%.*s%*s]", percentage, lpad, pbstr.c_str(), rpad, "");
+		fflush(stdout);
+	}
 
-    void PrintProgress(int percentage) {
-        int lpad = (int) (percentage / 100.0 * pbwidth*2);
-        int rpad = pbwidth - lpad*0.5;
-        printf("\r%3d%% [%.*s%*s]", percentage, lpad, pbstr.c_str(), rpad, "");
-        fflush(stdout);
-    }
+	void ProgressBarThread() {
+		//        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+		while (!StopRequested()) {
+			int cur_percentage = executor->GetPipelinesProgress();
+			if (cur_percentage == -1) {
+				//! uh-oh this operator is not supported for the progressive bar
+				return;
+			}
+			PrintProgress(executor->GetPipelinesProgress());
+			std::this_thread::sleep_for(std::chrono::milliseconds(10));
+		}
+	}
 
-    void ProgressBarThread() {
-//        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-        while (!StopRequested()) {
-            int cur_percentage = executor->GetPipelinesProgress();
-            if (cur_percentage == -1){
-                //!uh-oh this operator is not supported for the progressive bar
-                return;
-            }
-            PrintProgress(executor->GetPipelinesProgress());
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        }
-    }
+	void Start() {
+		progress_bar_thread = std::thread(&ProgressBar::ProgressBarThread, this);
+	}
 
-    void Start() {
-        progress_bar_thread = std::thread(&ProgressBar::ProgressBarThread, this);
-    }
+	bool StopRequested() {
+		if (future_obj.wait_for(std::chrono::milliseconds(0)) == std::future_status::timeout) {
+			return false;
+		}
+		return true;
+	}
 
-    bool StopRequested() {
-        if (future_obj.wait_for(std::chrono::milliseconds(0)) == std::future_status::timeout) {
-            return false;
-        }
-        return true;
-    }
-
-    void Stop() {
-        if (progress_bar_thread.joinable()) {
-            exit_signal.set_value();
-            progress_bar_thread.join();
-            printf(" \n");
-            fflush(stdout);
-        }
-
-    }
+	void Stop() {
+		if (progress_bar_thread.joinable()) {
+			exit_signal.set_value();
+			progress_bar_thread.join();
+			printf(" \n");
+			fflush(stdout);
+		}
+	}
 };
-
 
 /* Prepare the next result to be retrieved */
 int sqlite3_step(sqlite3_stmt *pStmt) {
-    if (!pStmt) {
-        return SQLITE_MISUSE;
-    }
-    if (!pStmt->prepared) {
-        pStmt->db->last_error = "Attempting sqlite3_step() on a non-successfully prepared statement";
-        return SQLITE_ERROR;
-    }
-    pStmt->current_text = nullptr;
-    if (!pStmt->result) {
-        ProgressBar progess_bar(&pStmt->prepared->context->executor);
-        if (pStmt->prepared->GetStatementType() == StatementType::SELECT_STATEMENT) {
-            progess_bar.Start();
-        }
-        // no result yet! call Execute()
-        pStmt->result = pStmt->prepared->Execute(pStmt->bound_values, false);
-        progess_bar.Stop();
-        if (!pStmt->result->success) {
-            // error in execute: clear prepared statement
-            pStmt->db->last_error = pStmt->result->error;
-            pStmt->prepared = nullptr;
-            return SQLITE_ERROR;
-        }
-        // fetch a chunk
-        pStmt->current_chunk = pStmt->result->Fetch();
-        pStmt->current_row = -1;
-        if (!sqlite3_display_result(pStmt->prepared->GetStatementType())) {
-            // only SELECT statements return results
-            sqlite3_reset(pStmt);
-        }
-    }
-    if (!pStmt->current_chunk || pStmt->current_chunk->size() == 0) {
-        return SQLITE_DONE;
-    }
-    pStmt->current_row++;
-    if (pStmt->current_row >= (int32_t) pStmt->current_chunk->size()) {
-        // have to fetch again!
-        pStmt->current_row = 0;
-        pStmt->current_chunk = pStmt->result->Fetch();
-        if (!pStmt->current_chunk || pStmt->current_chunk->size() == 0) {
-            sqlite3_reset(pStmt);
-            return SQLITE_DONE;
-        }
-    }
-    return SQLITE_ROW;
+	if (!pStmt) {
+		return SQLITE_MISUSE;
+	}
+	if (!pStmt->prepared) {
+		pStmt->db->last_error = "Attempting sqlite3_step() on a non-successfully prepared statement";
+		return SQLITE_ERROR;
+	}
+	pStmt->current_text = nullptr;
+	if (!pStmt->result) {
+		ProgressBar progess_bar(&pStmt->prepared->context->executor);
+		if (pStmt->prepared->GetStatementType() == StatementType::SELECT_STATEMENT) {
+			progess_bar.Start();
+		}
+		// no result yet! call Execute()
+		pStmt->result = pStmt->prepared->Execute(pStmt->bound_values, false);
+		progess_bar.Stop();
+		if (!pStmt->result->success) {
+			// error in execute: clear prepared statement
+			pStmt->db->last_error = pStmt->result->error;
+			pStmt->prepared = nullptr;
+			return SQLITE_ERROR;
+		}
+		// fetch a chunk
+		pStmt->current_chunk = pStmt->result->Fetch();
+		pStmt->current_row = -1;
+		if (!sqlite3_display_result(pStmt->prepared->GetStatementType())) {
+			// only SELECT statements return results
+			sqlite3_reset(pStmt);
+		}
+	}
+	if (!pStmt->current_chunk || pStmt->current_chunk->size() == 0) {
+		return SQLITE_DONE;
+	}
+	pStmt->current_row++;
+	if (pStmt->current_row >= (int32_t)pStmt->current_chunk->size()) {
+		// have to fetch again!
+		pStmt->current_row = 0;
+		pStmt->current_chunk = pStmt->result->Fetch();
+		if (!pStmt->current_chunk || pStmt->current_chunk->size() == 0) {
+			sqlite3_reset(pStmt);
+			return SQLITE_DONE;
+		}
+	}
+	return SQLITE_ROW;
 }
 
 /* Execute multiple semicolon separated SQL statements
@@ -323,331 +321,331 @@ int sqlite3_exec(sqlite3 *db,                /* The database on which the SQL ex
                  void *pArg,                 /* First argument to xCallback() */
                  char **pzErrMsg             /* Write error messages here */
 ) {
-    int rc = SQLITE_OK;            /* Return code */
-    const char *zLeftover;         /* Tail of unprocessed SQL */
-    sqlite3_stmt *pStmt = nullptr; /* The current SQL statement */
-    char **azCols = nullptr;       /* Names of result columns */
-    char **azVals = nullptr;       /* Result values */
+	int rc = SQLITE_OK;            /* Return code */
+	const char *zLeftover;         /* Tail of unprocessed SQL */
+	sqlite3_stmt *pStmt = nullptr; /* The current SQL statement */
+	char **azCols = nullptr;       /* Names of result columns */
+	char **azVals = nullptr;       /* Result values */
 
-    if (zSql == nullptr) {
-        zSql = "";
-    }
+	if (zSql == nullptr) {
+		zSql = "";
+	}
 
-    while (rc == SQLITE_OK && zSql[0]) {
-        int nCol;
+	while (rc == SQLITE_OK && zSql[0]) {
+		int nCol;
 
-        pStmt = nullptr;
-        rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, &zLeftover);
-        if (rc != SQLITE_OK) {
-            if (pzErrMsg) {
-                auto errmsg = sqlite3_errmsg(db);
-                *pzErrMsg = errmsg ? sqlite3_strdup(errmsg) : nullptr;
-            }
-            continue;
-        }
-        if (!pStmt) {
-            /* this happens for a comment or white-space */
-            zSql = zLeftover;
-            continue;
-        }
+		pStmt = nullptr;
+		rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, &zLeftover);
+		if (rc != SQLITE_OK) {
+			if (pzErrMsg) {
+				auto errmsg = sqlite3_errmsg(db);
+				*pzErrMsg = errmsg ? sqlite3_strdup(errmsg) : nullptr;
+			}
+			continue;
+		}
+		if (!pStmt) {
+			/* this happens for a comment or white-space */
+			zSql = zLeftover;
+			continue;
+		}
 
-        nCol = sqlite3_column_count(pStmt);
-        azCols = (char **) malloc(nCol * sizeof(const char *));
-        azVals = (char **) malloc(nCol * sizeof(const char *));
-        if (!azCols || !azVals) {
-            goto exec_out;
-        }
-        for (int i = 0; i < nCol; i++) {
-            azCols[i] = (char *) sqlite3_column_name(pStmt, i);
-        }
+		nCol = sqlite3_column_count(pStmt);
+		azCols = (char **)malloc(nCol * sizeof(const char *));
+		azVals = (char **)malloc(nCol * sizeof(const char *));
+		if (!azCols || !azVals) {
+			goto exec_out;
+		}
+		for (int i = 0; i < nCol; i++) {
+			azCols[i] = (char *)sqlite3_column_name(pStmt, i);
+		}
 
-        while (true) {
-            rc = sqlite3_step(pStmt);
+		while (true) {
+			rc = sqlite3_step(pStmt);
 
-            /* Invoke the callback function if required */
-            if (xCallback && rc == SQLITE_ROW) {
-                for (int i = 0; i < nCol; i++) {
-                    azVals[i] = (char *) sqlite3_column_text(pStmt, i);
-                    if (!azVals[i] && sqlite3_column_type(pStmt, i) != SQLITE_NULL) {
-                        fprintf(stderr, "sqlite3_exec: out of memory.\n");
-                        goto exec_out;
-                    }
-                }
-                if (xCallback(pArg, nCol, azVals, azCols)) {
-                    /* EVIDENCE-OF: R-38229-40159 If the callback function to
-                    ** sqlite3_exec() returns non-zero, then sqlite3_exec() will
-                    ** return SQLITE_ABORT. */
-                    rc = SQLITE_ABORT;
-                    sqlite3_finalize(pStmt);
-                    pStmt = 0;
-                    fprintf(stderr, "sqlite3_exec: callback returned non-zero. "
-                                    "Aborting.\n");
-                    goto exec_out;
-                }
-            }
-            if (rc == SQLITE_DONE) {
-                rc = sqlite3_finalize(pStmt);
-                pStmt = nullptr;
-                zSql = zLeftover;
-                while (isspace(zSql[0]))
-                    zSql++;
-                break;
-            } else if (rc != SQLITE_ROW) {
-                // error
-                if (pzErrMsg) {
-                    auto errmsg = sqlite3_errmsg(db);
-                    *pzErrMsg = errmsg ? sqlite3_strdup(errmsg) : nullptr;
-                }
-                goto exec_out;
-            }
-        }
+			/* Invoke the callback function if required */
+			if (xCallback && rc == SQLITE_ROW) {
+				for (int i = 0; i < nCol; i++) {
+					azVals[i] = (char *)sqlite3_column_text(pStmt, i);
+					if (!azVals[i] && sqlite3_column_type(pStmt, i) != SQLITE_NULL) {
+						fprintf(stderr, "sqlite3_exec: out of memory.\n");
+						goto exec_out;
+					}
+				}
+				if (xCallback(pArg, nCol, azVals, azCols)) {
+					/* EVIDENCE-OF: R-38229-40159 If the callback function to
+					** sqlite3_exec() returns non-zero, then sqlite3_exec() will
+					** return SQLITE_ABORT. */
+					rc = SQLITE_ABORT;
+					sqlite3_finalize(pStmt);
+					pStmt = 0;
+					fprintf(stderr, "sqlite3_exec: callback returned non-zero. "
+					                "Aborting.\n");
+					goto exec_out;
+				}
+			}
+			if (rc == SQLITE_DONE) {
+				rc = sqlite3_finalize(pStmt);
+				pStmt = nullptr;
+				zSql = zLeftover;
+				while (isspace(zSql[0]))
+					zSql++;
+				break;
+			} else if (rc != SQLITE_ROW) {
+				// error
+				if (pzErrMsg) {
+					auto errmsg = sqlite3_errmsg(db);
+					*pzErrMsg = errmsg ? sqlite3_strdup(errmsg) : nullptr;
+				}
+				goto exec_out;
+			}
+		}
 
-        sqlite3_free(azCols);
-        sqlite3_free(azVals);
-        azCols = nullptr;
-        azVals = nullptr;
-    }
+		sqlite3_free(azCols);
+		sqlite3_free(azVals);
+		azCols = nullptr;
+		azVals = nullptr;
+	}
 
-    exec_out:
-    if (pStmt) {
-        sqlite3_finalize(pStmt);
-    }
-    sqlite3_free(azCols);
-    sqlite3_free(azVals);
-    if (rc != SQLITE_OK && pzErrMsg && !*pzErrMsg) {
-        // error but no error message set
-        *pzErrMsg = sqlite3_strdup("Unknown error in DuckDB!");
-    }
-    return rc;
+exec_out:
+	if (pStmt) {
+		sqlite3_finalize(pStmt);
+	}
+	sqlite3_free(azCols);
+	sqlite3_free(azVals);
+	if (rc != SQLITE_OK && pzErrMsg && !*pzErrMsg) {
+		// error but no error message set
+		*pzErrMsg = sqlite3_strdup("Unknown error in DuckDB!");
+	}
+	return rc;
 }
 
 /* Return the text of the SQL that was used to prepare the statement */
 const char *sqlite3_sql(sqlite3_stmt *pStmt) {
-    return pStmt->query_string.c_str();
+	return pStmt->query_string.c_str();
 }
 
 int sqlite3_column_count(sqlite3_stmt *pStmt) {
-    if (!pStmt || !pStmt->prepared) {
-        return 0;
-    }
-    return (int) pStmt->prepared->ColumnCount();
+	if (!pStmt || !pStmt->prepared) {
+		return 0;
+	}
+	return (int)pStmt->prepared->ColumnCount();
 }
 
 ////////////////////////////
 //     sqlite3_column     //
 ////////////////////////////
 int sqlite3_column_type(sqlite3_stmt *pStmt, int iCol) {
-    if (!pStmt || !pStmt->result || !pStmt->current_chunk) {
-        return 0;
-    }
-    if (FlatVector::IsNull(pStmt->current_chunk->data[iCol], pStmt->current_row)) {
-        return SQLITE_NULL;
-    }
-    auto column_type = pStmt->result->types[iCol];
-    switch (column_type.id()) {
-        case LogicalTypeId::BOOLEAN:
-        case LogicalTypeId::TINYINT:
-        case LogicalTypeId::SMALLINT:
-        case LogicalTypeId::INTEGER:
-        case LogicalTypeId::BIGINT: /* TODO: Maybe blob? */
-            return SQLITE_INTEGER;
-        case LogicalTypeId::FLOAT:
-        case LogicalTypeId::DOUBLE:
-        case LogicalTypeId::DECIMAL:
-            return SQLITE_FLOAT;
-        case LogicalTypeId::DATE:
-        case LogicalTypeId::TIME:
-        case LogicalTypeId::TIMESTAMP:
-        case LogicalTypeId::VARCHAR:
-        case LogicalTypeId::LIST:
-        case LogicalTypeId::STRUCT:
-            return SQLITE_TEXT;
-        case LogicalTypeId::BLOB:
-            return SQLITE_BLOB;
-        default:
-            return 0;
-    }
-    return 0;
+	if (!pStmt || !pStmt->result || !pStmt->current_chunk) {
+		return 0;
+	}
+	if (FlatVector::IsNull(pStmt->current_chunk->data[iCol], pStmt->current_row)) {
+		return SQLITE_NULL;
+	}
+	auto column_type = pStmt->result->types[iCol];
+	switch (column_type.id()) {
+	case LogicalTypeId::BOOLEAN:
+	case LogicalTypeId::TINYINT:
+	case LogicalTypeId::SMALLINT:
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT: /* TODO: Maybe blob? */
+		return SQLITE_INTEGER;
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		return SQLITE_FLOAT;
+	case LogicalTypeId::DATE:
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::LIST:
+	case LogicalTypeId::STRUCT:
+		return SQLITE_TEXT;
+	case LogicalTypeId::BLOB:
+		return SQLITE_BLOB;
+	default:
+		return 0;
+	}
+	return 0;
 }
 
 const char *sqlite3_column_name(sqlite3_stmt *pStmt, int N) {
-    if (!pStmt || !pStmt->prepared) {
-        return nullptr;
-    }
-    return pStmt->prepared->GetNames()[N].c_str();
+	if (!pStmt || !pStmt->prepared) {
+		return nullptr;
+	}
+	return pStmt->prepared->GetNames()[N].c_str();
 }
 
 static bool sqlite3_column_has_value(sqlite3_stmt *pStmt, int iCol, LogicalType target_type, Value &val) {
-    if (!pStmt || !pStmt->result || !pStmt->current_chunk) {
-        return false;
-    }
-    if (iCol < 0 || iCol >= (int) pStmt->result->types.size()) {
-        return false;
-    }
-    if (FlatVector::IsNull(pStmt->current_chunk->data[iCol], pStmt->current_row)) {
-        return false;
-    }
-    try {
-        val = pStmt->current_chunk->data[iCol].GetValue(pStmt->current_row).CastAs(target_type);
-    } catch (...) {
-        return false;
-    }
-    return true;
+	if (!pStmt || !pStmt->result || !pStmt->current_chunk) {
+		return false;
+	}
+	if (iCol < 0 || iCol >= (int)pStmt->result->types.size()) {
+		return false;
+	}
+	if (FlatVector::IsNull(pStmt->current_chunk->data[iCol], pStmt->current_row)) {
+		return false;
+	}
+	try {
+		val = pStmt->current_chunk->data[iCol].GetValue(pStmt->current_row).CastAs(target_type);
+	} catch (...) {
+		return false;
+	}
+	return true;
 }
 
 double sqlite3_column_double(sqlite3_stmt *stmt, int iCol) {
-    Value val;
-    if (!sqlite3_column_has_value(stmt, iCol, LogicalType::DOUBLE, val)) {
-        return 0;
-    }
-    return val.value_.double_;
+	Value val;
+	if (!sqlite3_column_has_value(stmt, iCol, LogicalType::DOUBLE, val)) {
+		return 0;
+	}
+	return val.value_.double_;
 }
 
 int sqlite3_column_int(sqlite3_stmt *stmt, int iCol) {
-    Value val;
-    if (!sqlite3_column_has_value(stmt, iCol, LogicalType::INTEGER, val)) {
-        return 0;
-    }
-    return val.value_.integer;
+	Value val;
+	if (!sqlite3_column_has_value(stmt, iCol, LogicalType::INTEGER, val)) {
+		return 0;
+	}
+	return val.value_.integer;
 }
 
 sqlite3_int64 sqlite3_column_int64(sqlite3_stmt *stmt, int iCol) {
-    Value val;
-    if (!sqlite3_column_has_value(stmt, iCol, LogicalType::BIGINT, val)) {
-        return 0;
-    }
-    return val.value_.bigint;
+	Value val;
+	if (!sqlite3_column_has_value(stmt, iCol, LogicalType::BIGINT, val)) {
+		return 0;
+	}
+	return val.value_.bigint;
 }
 
 const unsigned char *sqlite3_column_text(sqlite3_stmt *pStmt, int iCol) {
-    Value val;
-    if (!sqlite3_column_has_value(pStmt, iCol, LogicalType::VARCHAR, val)) {
-        return nullptr;
-    }
-    try {
-        if (!pStmt->current_text) {
-            pStmt->current_text =
-                    unique_ptr<sqlite3_string_buffer[]>(new sqlite3_string_buffer[pStmt->result->types.size()]);
-        }
-        auto &entry = pStmt->current_text[iCol];
-        if (!entry.data) {
-            // not initialized yet, convert the value and initialize it
-            entry.data = unique_ptr<char[]>(new char[val.str_value.size() + 1]);
-            memcpy(entry.data.get(), val.str_value.c_str(), val.str_value.size() + 1);
-        }
-        return (const unsigned char *) entry.data.get();
-    } catch (...) {
-        // memory error!
-        return nullptr;
-    }
+	Value val;
+	if (!sqlite3_column_has_value(pStmt, iCol, LogicalType::VARCHAR, val)) {
+		return nullptr;
+	}
+	try {
+		if (!pStmt->current_text) {
+			pStmt->current_text =
+			    unique_ptr<sqlite3_string_buffer[]>(new sqlite3_string_buffer[pStmt->result->types.size()]);
+		}
+		auto &entry = pStmt->current_text[iCol];
+		if (!entry.data) {
+			// not initialized yet, convert the value and initialize it
+			entry.data = unique_ptr<char[]>(new char[val.str_value.size() + 1]);
+			memcpy(entry.data.get(), val.str_value.c_str(), val.str_value.size() + 1);
+		}
+		return (const unsigned char *)entry.data.get();
+	} catch (...) {
+		// memory error!
+		return nullptr;
+	}
 }
 
 ////////////////////////////
 //      sqlite3_bind      //
 ////////////////////////////
 int sqlite3_bind_parameter_count(sqlite3_stmt *stmt) {
-    if (!stmt) {
-        return 0;
-    }
-    return stmt->prepared->n_param;
+	if (!stmt) {
+		return 0;
+	}
+	return stmt->prepared->n_param;
 }
 
 const char *sqlite3_bind_parameter_name(sqlite3_stmt *stmt, int idx) {
-    if (!stmt) {
-        return nullptr;
-    }
-    if (idx < 1 || idx > (int) stmt->prepared->n_param) {
-        return nullptr;
-    }
-    return stmt->bound_names[idx - 1].c_str();
+	if (!stmt) {
+		return nullptr;
+	}
+	if (idx < 1 || idx > (int)stmt->prepared->n_param) {
+		return nullptr;
+	}
+	return stmt->bound_names[idx - 1].c_str();
 }
 
 int sqlite3_bind_parameter_index(sqlite3_stmt *stmt, const char *zName) {
-    if (!stmt || !zName) {
-        return 0;
-    }
-    for (idx_t i = 0; i < stmt->bound_names.size(); i++) {
-        if (stmt->bound_names[i] == string(zName)) {
-            return i + 1;
-        }
-    }
-    return 0;
+	if (!stmt || !zName) {
+		return 0;
+	}
+	for (idx_t i = 0; i < stmt->bound_names.size(); i++) {
+		if (stmt->bound_names[i] == string(zName)) {
+			return i + 1;
+		}
+	}
+	return 0;
 }
 
 int sqlite3_internal_bind_value(sqlite3_stmt *stmt, int idx, Value value) {
-    if (!stmt || !stmt->prepared || stmt->result) {
-        return SQLITE_MISUSE;
-    }
-    if (idx < 1 || idx > (int) stmt->prepared->n_param) {
-        return SQLITE_RANGE;
-    }
-    stmt->bound_values[idx - 1] = value;
-    return SQLITE_OK;
+	if (!stmt || !stmt->prepared || stmt->result) {
+		return SQLITE_MISUSE;
+	}
+	if (idx < 1 || idx > (int)stmt->prepared->n_param) {
+		return SQLITE_RANGE;
+	}
+	stmt->bound_values[idx - 1] = value;
+	return SQLITE_OK;
 }
 
 int sqlite3_bind_int(sqlite3_stmt *stmt, int idx, int val) {
-    return sqlite3_internal_bind_value(stmt, idx, Value::INTEGER(val));
+	return sqlite3_internal_bind_value(stmt, idx, Value::INTEGER(val));
 }
 
 int sqlite3_bind_int64(sqlite3_stmt *stmt, int idx, sqlite3_int64 val) {
-    return sqlite3_internal_bind_value(stmt, idx, Value::BIGINT(val));
+	return sqlite3_internal_bind_value(stmt, idx, Value::BIGINT(val));
 }
 
 int sqlite3_bind_double(sqlite3_stmt *stmt, int idx, double val) {
-    return sqlite3_internal_bind_value(stmt, idx, Value::DOUBLE(val));
+	return sqlite3_internal_bind_value(stmt, idx, Value::DOUBLE(val));
 }
 
 int sqlite3_bind_null(sqlite3_stmt *stmt, int idx) {
-    return sqlite3_internal_bind_value(stmt, idx, Value());
+	return sqlite3_internal_bind_value(stmt, idx, Value());
 }
 
 SQLITE_API int sqlite3_bind_value(sqlite3_stmt *, int, const sqlite3_value *) {
-    fprintf(stderr, "sqlite3_bind_value: unsupported.\n");
-    return SQLITE_ERROR;
+	fprintf(stderr, "sqlite3_bind_value: unsupported.\n");
+	return SQLITE_ERROR;
 }
 
 int sqlite3_bind_text(sqlite3_stmt *stmt, int idx, const char *val, int length, void (*free_func)(void *)) {
-    if (!val) {
-        return SQLITE_MISUSE;
-    }
-    string value;
-    if (length < 0) {
-        value = string(val);
-    } else {
-        value = string(val, val + length);
-    }
-    if (free_func && ((ptrdiff_t) free_func) != -1) {
-        free_func((void *) val);
-    }
-    try {
-        return sqlite3_internal_bind_value(stmt, idx, Value(value));
-    } catch (std::exception &ex) {
-        return SQLITE_ERROR;
-    }
+	if (!val) {
+		return SQLITE_MISUSE;
+	}
+	string value;
+	if (length < 0) {
+		value = string(val);
+	} else {
+		value = string(val, val + length);
+	}
+	if (free_func && ((ptrdiff_t)free_func) != -1) {
+		free_func((void *)val);
+	}
+	try {
+		return sqlite3_internal_bind_value(stmt, idx, Value(value));
+	} catch (std::exception &ex) {
+		return SQLITE_ERROR;
+	}
 }
 
 int sqlite3_clear_bindings(sqlite3_stmt *stmt) {
-    if (!stmt) {
-        return SQLITE_MISUSE;
-    }
-    return SQLITE_OK;
+	if (!stmt) {
+		return SQLITE_MISUSE;
+	}
+	return SQLITE_OK;
 }
 
 int sqlite3_initialize(void) {
-    return SQLITE_OK;
+	return SQLITE_OK;
 }
 
 int sqlite3_finalize(sqlite3_stmt *pStmt) {
-    if (pStmt) {
-        if (pStmt->result && !pStmt->result->success) {
-            pStmt->db->last_error = string(pStmt->result->error);
-            delete pStmt;
-            return SQLITE_ERROR;
-        }
+	if (pStmt) {
+		if (pStmt->result && !pStmt->result->success) {
+			pStmt->db->last_error = string(pStmt->result->error);
+			delete pStmt;
+			return SQLITE_ERROR;
+		}
 
-        delete pStmt;
-    }
-    return SQLITE_OK;
+		delete pStmt;
+	}
+	return SQLITE_OK;
 }
 
 /*
@@ -662,148 +660,148 @@ int sqlite3_finalize(sqlite3_stmt *pStmt) {
 */
 
 const unsigned char sqlite3UpperToLower[] = {
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-        22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43,
-        44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 97,
-        98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
-        120, 121, 122, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109,
-        110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131,
-        132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153,
-        154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175,
-        176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197,
-        198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219,
-        220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241,
-        242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255};
+    0,   1,   2,   3,   4,   5,   6,   7,   8,   9,   10,  11,  12,  13,  14,  15,  16,  17,  18,  19,  20,  21,
+    22,  23,  24,  25,  26,  27,  28,  29,  30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,
+    44,  45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,  60,  61,  62,  63,  64,  97,
+    98,  99,  100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
+    120, 121, 122, 91,  92,  93,  94,  95,  96,  97,  98,  99,  100, 101, 102, 103, 104, 105, 106, 107, 108, 109,
+    110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131,
+    132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153,
+    154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175,
+    176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197,
+    198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219,
+    220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241,
+    242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255};
 
 int sqlite3StrICmp(const char *zLeft, const char *zRight) {
-    unsigned char *a, *b;
-    int c;
-    a = (unsigned char *) zLeft;
-    b = (unsigned char *) zRight;
-    for (;;) {
-        c = (int) sqlite3UpperToLower[*a] - (int) sqlite3UpperToLower[*b];
-        if (c || *a == 0)
-            break;
-        a++;
-        b++;
-    }
-    return c;
+	unsigned char *a, *b;
+	int c;
+	a = (unsigned char *)zLeft;
+	b = (unsigned char *)zRight;
+	for (;;) {
+		c = (int)sqlite3UpperToLower[*a] - (int)sqlite3UpperToLower[*b];
+		if (c || *a == 0)
+			break;
+		a++;
+		b++;
+	}
+	return c;
 }
 
 SQLITE_API int sqlite3_stricmp(const char *zLeft, const char *zRight) {
-    if (zLeft == 0) {
-        return zRight ? -1 : 0;
-    } else if (zRight == 0) {
-        return 1;
-    }
-    return sqlite3StrICmp(zLeft, zRight);
+	if (zLeft == 0) {
+		return zRight ? -1 : 0;
+	} else if (zRight == 0) {
+		return 1;
+	}
+	return sqlite3StrICmp(zLeft, zRight);
 }
 
 SQLITE_API int sqlite3_strnicmp(const char *zLeft, const char *zRight, int N) {
-    unsigned char *a, *b;
-    if (zLeft == 0) {
-        return zRight ? -1 : 0;
-    } else if (zRight == 0) {
-        return 1;
-    }
-    a = (unsigned char *) zLeft;
-    b = (unsigned char *) zRight;
-    while (N-- > 0 && *a != 0 && sqlite3UpperToLower[*a] == sqlite3UpperToLower[*b]) {
-        a++;
-        b++;
-    }
-    return N < 0 ? 0 : sqlite3UpperToLower[*a] - sqlite3UpperToLower[*b];
+	unsigned char *a, *b;
+	if (zLeft == 0) {
+		return zRight ? -1 : 0;
+	} else if (zRight == 0) {
+		return 1;
+	}
+	a = (unsigned char *)zLeft;
+	b = (unsigned char *)zRight;
+	while (N-- > 0 && *a != 0 && sqlite3UpperToLower[*a] == sqlite3UpperToLower[*b]) {
+		a++;
+		b++;
+	}
+	return N < 0 ? 0 : sqlite3UpperToLower[*a] - sqlite3UpperToLower[*b];
 }
 
 char *sqlite3_strdup(const char *str) {
-    char *result = (char *) sqlite3_malloc64(strlen(str) + 1);
-    strcpy(result, str);
-    return result;
+	char *result = (char *)sqlite3_malloc64(strlen(str) + 1);
+	strcpy(result, str);
+	return result;
 }
 
 void *sqlite3_malloc64(sqlite3_uint64 n) {
-    return malloc(n);
+	return malloc(n);
 }
 
 void sqlite3_free(void *pVoid) {
-    free(pVoid);
+	free(pVoid);
 }
 
 void *sqlite3_malloc(int n) {
-    return sqlite3_malloc64(n);
+	return sqlite3_malloc64(n);
 }
 
 void *sqlite3_realloc(void *ptr, int n) {
-    return sqlite3_realloc64(ptr, n);
+	return sqlite3_realloc64(ptr, n);
 }
 
 void *sqlite3_realloc64(void *ptr, sqlite3_uint64 n) {
-    return realloc(ptr, n);
+	return realloc(ptr, n);
 }
 
 // TODO: stub
 int sqlite3_config(int i, ...) {
-    return SQLITE_OK;
+	return SQLITE_OK;
 }
 
 int sqlite3_errcode(sqlite3 *db) {
-    if (!db) {
-        return SQLITE_MISUSE;
-    }
-    return db->last_error.empty() ? SQLITE_OK : SQLITE_ERROR;
+	if (!db) {
+		return SQLITE_MISUSE;
+	}
+	return db->last_error.empty() ? SQLITE_OK : SQLITE_ERROR;
 }
 
 int sqlite3_extended_errcode(sqlite3 *db) {
-    return sqlite3_errcode(db);
+	return sqlite3_errcode(db);
 }
 
 const char *sqlite3_errmsg(sqlite3 *db) {
-    if (!db) {
-        return "";
-    }
-    return db->last_error.c_str();
+	if (!db) {
+		return "";
+	}
+	return db->last_error.c_str();
 }
 
 void sqlite3_interrupt(sqlite3 *db) {
-    if (db) {
-        db->con->Interrupt();
-    }
+	if (db) {
+		db->con->Interrupt();
+	}
 }
 
 const char *sqlite3_libversion(void) {
-    return DuckDB::LibraryVersion();
+	return DuckDB::LibraryVersion();
 }
 
 const char *sqlite3_sourceid(void) {
-    return DuckDB::SourceID();
+	return DuckDB::SourceID();
 }
 
 int sqlite3_reset(sqlite3_stmt *stmt) {
-    if (stmt) {
-        stmt->result = nullptr;
-        stmt->current_chunk = nullptr;
-    }
-    return SQLITE_OK;
+	if (stmt) {
+		stmt->result = nullptr;
+		stmt->current_chunk = nullptr;
+	}
+	return SQLITE_OK;
 }
 
 // support functions for shell.c
 // most are dummies, we don't need them really
 
 int sqlite3_db_status(sqlite3 *, int op, int *pCur, int *pHiwtr, int resetFlg) {
-    fprintf(stderr, "sqlite3_db_status: unsupported.\n");
-    return -1;
+	fprintf(stderr, "sqlite3_db_status: unsupported.\n");
+	return -1;
 }
 
 // TODO these should eventually be implemented
 
 int sqlite3_changes(sqlite3 *db) {
-    fprintf(stderr, "sqlite3_changes: unsupported.\n");
-    return 0;
+	fprintf(stderr, "sqlite3_changes: unsupported.\n");
+	return 0;
 }
 
 int sqlite3_total_changes(sqlite3 *) {
-    fprintf(stderr, "sqlite3_total_changes: unsupported.\n");
-    return 0;
+	fprintf(stderr, "sqlite3_total_changes: unsupported.\n");
+	return 0;
 }
 
 // some code borrowed from sqlite
@@ -820,210 +818,210 @@ typedef uint8_t u8;
 #define tkOTHER 2
 
 const unsigned char sqlite3CtypeMap[256] = {
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 00..07    ........ */
-        0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, /* 08..0f    ........ */
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 10..17    ........ */
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 18..1f    ........ */
-        0x01, 0x00, 0x80, 0x00, 0x40, 0x00, 0x00, 0x80, /* 20..27     !"#$%&' */
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 28..2f    ()*+,-./ */
-        0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, /* 30..37    01234567 */
-        0x0c, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 38..3f    89:;<=>? */
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 00..07    ........ */
+    0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, /* 08..0f    ........ */
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 10..17    ........ */
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 18..1f    ........ */
+    0x01, 0x00, 0x80, 0x00, 0x40, 0x00, 0x00, 0x80, /* 20..27     !"#$%&' */
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 28..2f    ()*+,-./ */
+    0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, /* 30..37    01234567 */
+    0x0c, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 38..3f    89:;<=>? */
 
-        0x00, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x02, /* 40..47    @ABCDEFG */
-        0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, /* 48..4f    HIJKLMNO */
-        0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, /* 50..57    PQRSTUVW */
-        0x02, 0x02, 0x02, 0x80, 0x00, 0x00, 0x00, 0x40, /* 58..5f    XYZ[\]^_ */
-        0x80, 0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x22, /* 60..67    `abcdefg */
-        0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, /* 68..6f    hijklmno */
-        0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, /* 70..77    pqrstuvw */
-        0x22, 0x22, 0x22, 0x00, 0x00, 0x00, 0x00, 0x00, /* 78..7f    xyz{|}~. */
+    0x00, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x02, /* 40..47    @ABCDEFG */
+    0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, /* 48..4f    HIJKLMNO */
+    0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, /* 50..57    PQRSTUVW */
+    0x02, 0x02, 0x02, 0x80, 0x00, 0x00, 0x00, 0x40, /* 58..5f    XYZ[\]^_ */
+    0x80, 0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x22, /* 60..67    `abcdefg */
+    0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, /* 68..6f    hijklmno */
+    0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, /* 70..77    pqrstuvw */
+    0x22, 0x22, 0x22, 0x00, 0x00, 0x00, 0x00, 0x00, /* 78..7f    xyz{|}~. */
 
-        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* 80..87    ........ */
-        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* 88..8f    ........ */
-        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* 90..97    ........ */
-        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* 98..9f    ........ */
-        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* a0..a7    ........ */
-        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* a8..af    ........ */
-        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* b0..b7    ........ */
-        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* b8..bf    ........ */
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* 80..87    ........ */
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* 88..8f    ........ */
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* 90..97    ........ */
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* 98..9f    ........ */
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* a0..a7    ........ */
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* a8..af    ........ */
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* b0..b7    ........ */
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* b8..bf    ........ */
 
-        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* c0..c7    ........ */
-        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* c8..cf    ........ */
-        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* d0..d7    ........ */
-        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* d8..df    ........ */
-        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* e0..e7    ........ */
-        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* e8..ef    ........ */
-        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* f0..f7    ........ */
-        0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40  /* f8..ff    ........ */
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* c0..c7    ........ */
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* c8..cf    ........ */
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* d0..d7    ........ */
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* d8..df    ........ */
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* e0..e7    ........ */
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* e8..ef    ........ */
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* f0..f7    ........ */
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40  /* f8..ff    ........ */
 };
 
 // TODO this can probably be simplified
 #define IdChar(C) ((sqlite3CtypeMap[(unsigned char)C] & 0x46) != 0)
 
 int sqlite3_complete(const char *zSql) {
-    u8 state = 0; /* Current state, using numbers defined in header comment */
-    u8 token;     /* Value of the next token */
+	u8 state = 0; /* Current state, using numbers defined in header comment */
+	u8 token;     /* Value of the next token */
 
-    /* If triggers are not supported by this compile then the statement machine
-     ** used to detect the end of a statement is much simpler
-     */
-    static const u8 trans[3][3] = {
-            /* Token:           */
-            /* State:       **  SEMI  WS  OTHER */
-            /* 0 INVALID: */ {
-                                     1,
-                                     0,
-                                     2,
-                             },
-            /* 1   START: */
-                             {
-                                     1,
-                                     1,
-                                     2,
-                             },
-            /* 2  NORMAL: */
-                             {
-                                     1,
-                                     2,
-                                     2,
-                             },
-    };
+	/* If triggers are not supported by this compile then the statement machine
+	 ** used to detect the end of a statement is much simpler
+	 */
+	static const u8 trans[3][3] = {
+	    /* Token:           */
+	    /* State:       **  SEMI  WS  OTHER */
+	    /* 0 INVALID: */ {
+	        1,
+	        0,
+	        2,
+	    },
+	    /* 1   START: */
+	    {
+	        1,
+	        1,
+	        2,
+	    },
+	    /* 2  NORMAL: */
+	    {
+	        1,
+	        2,
+	        2,
+	    },
+	};
 
-    while (*zSql) {
-        switch (*zSql) {
-            case ';': { /* A semicolon */
-                token = tkSEMI;
-                break;
-            }
-            case ' ':
-            case '\r':
-            case '\t':
-            case '\n':
-            case '\f': { /* White space is ignored */
-                token = tkWS;
-                break;
-            }
-            case '/': { /* C-style comments */
-                if (zSql[1] != '*') {
-                    token = tkOTHER;
-                    break;
-                }
-                zSql += 2;
-                while (zSql[0] && (zSql[0] != '*' || zSql[1] != '/')) {
-                    zSql++;
-                }
-                if (zSql[0] == 0)
-                    return 0;
-                zSql++;
-                token = tkWS;
-                break;
-            }
-            case '-': { /* SQL-style comments from "--" to end of line */
-                if (zSql[1] != '-') {
-                    token = tkOTHER;
-                    break;
-                }
-                while (*zSql && *zSql != '\n') {
-                    zSql++;
-                }
-                if (*zSql == 0)
-                    return state == 1;
-                token = tkWS;
-                break;
-            }
-            case '[': { /* Microsoft-style identifiers in [...] */
-                zSql++;
-                while (*zSql && *zSql != ']') {
-                    zSql++;
-                }
-                if (*zSql == 0)
-                    return 0;
-                token = tkOTHER;
-                break;
-            }
-            case '`': /* Grave-accent quoted symbols used by MySQL */
-            case '"': /* single- and double-quoted strings */
-            case '\'': {
-                int c = *zSql;
-                zSql++;
-                while (*zSql && *zSql != c) {
-                    zSql++;
-                }
-                if (*zSql == 0)
-                    return 0;
-                token = tkOTHER;
-                break;
-            }
-            default: {
+	while (*zSql) {
+		switch (*zSql) {
+		case ';': { /* A semicolon */
+			token = tkSEMI;
+			break;
+		}
+		case ' ':
+		case '\r':
+		case '\t':
+		case '\n':
+		case '\f': { /* White space is ignored */
+			token = tkWS;
+			break;
+		}
+		case '/': { /* C-style comments */
+			if (zSql[1] != '*') {
+				token = tkOTHER;
+				break;
+			}
+			zSql += 2;
+			while (zSql[0] && (zSql[0] != '*' || zSql[1] != '/')) {
+				zSql++;
+			}
+			if (zSql[0] == 0)
+				return 0;
+			zSql++;
+			token = tkWS;
+			break;
+		}
+		case '-': { /* SQL-style comments from "--" to end of line */
+			if (zSql[1] != '-') {
+				token = tkOTHER;
+				break;
+			}
+			while (*zSql && *zSql != '\n') {
+				zSql++;
+			}
+			if (*zSql == 0)
+				return state == 1;
+			token = tkWS;
+			break;
+		}
+		case '[': { /* Microsoft-style identifiers in [...] */
+			zSql++;
+			while (*zSql && *zSql != ']') {
+				zSql++;
+			}
+			if (*zSql == 0)
+				return 0;
+			token = tkOTHER;
+			break;
+		}
+		case '`': /* Grave-accent quoted symbols used by MySQL */
+		case '"': /* single- and double-quoted strings */
+		case '\'': {
+			int c = *zSql;
+			zSql++;
+			while (*zSql && *zSql != c) {
+				zSql++;
+			}
+			if (*zSql == 0)
+				return 0;
+			token = tkOTHER;
+			break;
+		}
+		default: {
 
-                if (IdChar((u8) *zSql)) {
-                    /* Keywords and unquoted identifiers */
-                    int nId;
-                    for (nId = 1; IdChar(zSql[nId]); nId++) {
-                    }
-                    token = tkOTHER;
+			if (IdChar((u8)*zSql)) {
+				/* Keywords and unquoted identifiers */
+				int nId;
+				for (nId = 1; IdChar(zSql[nId]); nId++) {
+				}
+				token = tkOTHER;
 
-                    zSql += nId - 1;
-                } else {
-                    /* Operators and special symbols */
-                    token = tkOTHER;
-                }
-                break;
-            }
-        }
-        state = trans[state][token];
-        zSql++;
-    }
-    return state == 1;
+				zSql += nId - 1;
+			} else {
+				/* Operators and special symbols */
+				token = tkOTHER;
+			}
+			break;
+		}
+		}
+		state = trans[state][token];
+		zSql++;
+	}
+	return state == 1;
 }
 
 // checks if input ends with ;
 int sqlite3_complete_old(const char *sql) {
-    fprintf(stderr, "sqlite3_complete: unsupported. '%s'\n", sql);
-    return -1;
+	fprintf(stderr, "sqlite3_complete: unsupported. '%s'\n", sql);
+	return -1;
 }
 
 int sqlite3_bind_blob(sqlite3_stmt *, int, const void *, int n, void (*)(void *)) {
-    fprintf(stderr, "sqlite3_bind_blob: unsupported.\n");
-    return -1;
+	fprintf(stderr, "sqlite3_bind_blob: unsupported.\n");
+	return -1;
 }
 
 const void *sqlite3_column_blob(sqlite3_stmt *, int iCol) {
-    fprintf(stderr, "sqlite3_column_blob: unsupported.\n");
-    return nullptr;
+	fprintf(stderr, "sqlite3_column_blob: unsupported.\n");
+	return nullptr;
 }
 
 // length of varchar or blob value
 int sqlite3_column_bytes(sqlite3_stmt *, int iCol) {
-    fprintf(stderr, "sqlite3_column_bytes: unsupported.\n");
-    return -1;
+	fprintf(stderr, "sqlite3_column_bytes: unsupported.\n");
+	return -1;
 }
 
 sqlite3_value *sqlite3_column_value(sqlite3_stmt *, int iCol) {
-    fprintf(stderr, "sqlite3_column_value: unsupported.\n");
-    return nullptr;
+	fprintf(stderr, "sqlite3_column_value: unsupported.\n");
+	return nullptr;
 }
 
 int sqlite3_db_config(sqlite3 *, int op, ...) {
-    fprintf(stderr, "sqlite3_db_config: unsupported.\n");
-    return -1;
+	fprintf(stderr, "sqlite3_db_config: unsupported.\n");
+	return -1;
 }
 
 int sqlite3_get_autocommit(sqlite3 *db) {
-    return 1;
-    // TODO fix this
-    // return db->con->context->transaction.IsAutoCommit();
-    fprintf(stderr, "sqlite3_get_autocommit: unsupported.\n");
+	return 1;
+	// TODO fix this
+	// return db->con->context->transaction.IsAutoCommit();
+	fprintf(stderr, "sqlite3_get_autocommit: unsupported.\n");
 }
 
 int sqlite3_limit(sqlite3 *, int id, int newVal) {
-    fprintf(stderr, "sqlite3_limit: unsupported.\n");
-    return -1;
+	fprintf(stderr, "sqlite3_limit: unsupported.\n");
+	return -1;
 }
 
 int sqlite3_stmt_readonly(sqlite3_stmt *pStmt) {
-    fprintf(stderr, "sqlite3_stmt_readonly: unsupported.\n");
-    return -1;
+	fprintf(stderr, "sqlite3_stmt_readonly: unsupported.\n");
+	return -1;
 }
 
 // TODO pretty easy schema lookup
@@ -1037,107 +1035,107 @@ int sqlite3_table_column_metadata(sqlite3 *db,             /* Connection handle 
                                   int *pPrimaryKey,        /* OUTPUT: True if column part of PK */
                                   int *pAutoinc            /* OUTPUT: True if column is auto-increment */
 ) {
-    fprintf(stderr, "sqlite3_table_column_metadata: unsupported.\n");
-    return -1;
+	fprintf(stderr, "sqlite3_table_column_metadata: unsupported.\n");
+	return -1;
 }
 
 const char *sqlite3_column_decltype(sqlite3_stmt *pStmt, int iCol) {
-    if (!pStmt || !pStmt->prepared) {
-        return NULL;
-    }
-    auto column_type = pStmt->prepared->GetTypes()[iCol];
-    switch (column_type.id()) {
-        case LogicalTypeId::BOOLEAN:
-            return "BOOLEAN";
-        case LogicalTypeId::TINYINT:
-            return "TINYINT";
-        case LogicalTypeId::SMALLINT:
-            return "SMALLINT";
-        case LogicalTypeId::INTEGER:
-            return "INTEGER";
-        case LogicalTypeId::BIGINT:
-            return "BIGINT";
-        case LogicalTypeId::FLOAT:
-            return "FLOAT";
-        case LogicalTypeId::DOUBLE:
-            return "DOUBLE";
-        case LogicalTypeId::DECIMAL:
-            return "DECIMAL";
-        case LogicalTypeId::DATE:
-            return "DATE";
-        case LogicalTypeId::TIME:
-            return "TIME";
-        case LogicalTypeId::TIMESTAMP:
-            return "TIMESTAMP";
-        case LogicalTypeId::VARCHAR:
-            return "VARCHAR";
-        case LogicalTypeId::LIST:
-            return "LIST";
-        case LogicalTypeId::STRUCT:
-            return "STRUCT";
-        case LogicalTypeId::BLOB:
-            return "BLOB";
-        default:
-            return NULL;
-    }
-    return NULL;
+	if (!pStmt || !pStmt->prepared) {
+		return NULL;
+	}
+	auto column_type = pStmt->prepared->GetTypes()[iCol];
+	switch (column_type.id()) {
+	case LogicalTypeId::BOOLEAN:
+		return "BOOLEAN";
+	case LogicalTypeId::TINYINT:
+		return "TINYINT";
+	case LogicalTypeId::SMALLINT:
+		return "SMALLINT";
+	case LogicalTypeId::INTEGER:
+		return "INTEGER";
+	case LogicalTypeId::BIGINT:
+		return "BIGINT";
+	case LogicalTypeId::FLOAT:
+		return "FLOAT";
+	case LogicalTypeId::DOUBLE:
+		return "DOUBLE";
+	case LogicalTypeId::DECIMAL:
+		return "DECIMAL";
+	case LogicalTypeId::DATE:
+		return "DATE";
+	case LogicalTypeId::TIME:
+		return "TIME";
+	case LogicalTypeId::TIMESTAMP:
+		return "TIMESTAMP";
+	case LogicalTypeId::VARCHAR:
+		return "VARCHAR";
+	case LogicalTypeId::LIST:
+		return "LIST";
+	case LogicalTypeId::STRUCT:
+		return "STRUCT";
+	case LogicalTypeId::BLOB:
+		return "BLOB";
+	default:
+		return NULL;
+	}
+	return NULL;
 }
 
 int sqlite3_status64(int op, sqlite3_int64 *pCurrent, sqlite3_int64 *pHighwater, int resetFlag) {
-    fprintf(stderr, "sqlite3_status64: unsupported.\n");
-    return -1;
+	fprintf(stderr, "sqlite3_status64: unsupported.\n");
+	return -1;
 }
 
 int sqlite3_status64(sqlite3 *, int op, int *pCur, int *pHiwtr, int resetFlg) {
-    fprintf(stderr, "sqlite3_status64: unsupported.\n");
-    return -1;
+	fprintf(stderr, "sqlite3_status64: unsupported.\n");
+	return -1;
 }
 
 int sqlite3_stmt_status(sqlite3_stmt *, int op, int resetFlg) {
-    fprintf(stderr, "sqlite3_stmt_status: unsupported.\n");
-    return -1;
+	fprintf(stderr, "sqlite3_stmt_status: unsupported.\n");
+	return -1;
 }
 
 int sqlite3_file_control(sqlite3 *, const char *zDbName, int op, void *) {
-    fprintf(stderr, "sqlite3_file_control: unsupported.\n");
-    return -1;
+	fprintf(stderr, "sqlite3_file_control: unsupported.\n");
+	return -1;
 }
 
 int sqlite3_declare_vtab(sqlite3 *, const char *zSQL) {
-    fprintf(stderr, "sqlite3_declare_vtab: unsupported.\n");
-    return -1;
+	fprintf(stderr, "sqlite3_declare_vtab: unsupported.\n");
+	return -1;
 }
 
 const char *sqlite3_vtab_collation(sqlite3_index_info *, int) {
-    fprintf(stderr, "sqlite3_vtab_collation: unsupported.\n");
-    return nullptr;
+	fprintf(stderr, "sqlite3_vtab_collation: unsupported.\n");
+	return nullptr;
 }
 
 int sqlite3_sleep(int) {
-    fprintf(stderr, "sqlite3_sleep: unsupported.\n");
-    return -1;
+	fprintf(stderr, "sqlite3_sleep: unsupported.\n");
+	return -1;
 }
 
 int sqlite3_busy_timeout(sqlite3 *, int ms) {
-    fprintf(stderr, "sqlite3_busy_timeout: unsupported.\n");
-    return -1;
+	fprintf(stderr, "sqlite3_busy_timeout: unsupported.\n");
+	return -1;
 }
 
 // unlikely to be supported
 
 int sqlite3_trace_v2(sqlite3 *, unsigned uMask, int (*xCallback)(unsigned, void *, void *, void *), void *pCtx) {
-    fprintf(stderr, "sqlite3_trace_v2: unsupported.\n");
-    return -1;
+	fprintf(stderr, "sqlite3_trace_v2: unsupported.\n");
+	return -1;
 }
 
 int sqlite3_test_control(int op, ...) {
-    fprintf(stderr, "sqlite3_test_control: unsupported.\n");
-    return -1;
+	fprintf(stderr, "sqlite3_test_control: unsupported.\n");
+	return -1;
 }
 
 int sqlite3_enable_load_extension(sqlite3 *db, int onoff) {
-    // fprintf(stderr, "sqlite3_enable_load_extension: unsupported.\n");
-    return -1;
+	// fprintf(stderr, "sqlite3_enable_load_extension: unsupported.\n");
+	return -1;
 }
 
 int sqlite3_load_extension(sqlite3 *db,       /* Load the extension into this database connection */
@@ -1145,8 +1143,8 @@ int sqlite3_load_extension(sqlite3 *db,       /* Load the extension into this da
                            const char *zProc, /* Entry point.  Derived from zFile if 0 */
                            char **pzErrMsg    /* Put error message here if not 0 */
 ) {
-    // fprintf(stderr, "sqlite3_load_extension: unsupported.\n");
-    return -1;
+	// fprintf(stderr, "sqlite3_load_extension: unsupported.\n");
+	return -1;
 }
 
 int sqlite3_create_module(sqlite3 *db,             /* SQLite connection to register module with */
@@ -1154,59 +1152,59 @@ int sqlite3_create_module(sqlite3 *db,             /* SQLite connection to regis
                           const sqlite3_module *p, /* Methods for the module */
                           void *pClientData        /* Client data for xCreate/xConnect */
 ) {
-    // fprintf(stderr, "sqlite3_create_module: unsupported.\n");
-    return -1;
+	// fprintf(stderr, "sqlite3_create_module: unsupported.\n");
+	return -1;
 }
 
 int sqlite3_create_function(sqlite3 *db, const char *zFunctionName, int nArg, int eTextRep, void *pApp,
                             void (*xFunc)(sqlite3_context *, int, sqlite3_value **),
                             void (*xStep)(sqlite3_context *, int, sqlite3_value **),
                             void (*xFinal)(sqlite3_context *)) {
-    // fprintf(stderr, "sqlite3_create_function: unsupported.\n");
-    return -1;
+	// fprintf(stderr, "sqlite3_create_function: unsupported.\n");
+	return -1;
 }
 
 int sqlite3_set_authorizer(sqlite3 *, int (*xAuth)(void *, int, const char *, const char *, const char *, const char *),
                            void *pUserData) {
-    fprintf(stderr, "sqlite3_set_authorizer: unsupported.\n");
-    return -1;
+	fprintf(stderr, "sqlite3_set_authorizer: unsupported.\n");
+	return -1;
 }
 
 // needed in shell timer
 static int unixCurrentTimeInt64(sqlite3_vfs *NotUsed, sqlite3_int64 *piNow) {
-    using namespace std::chrono;
-    *piNow = (sqlite3_int64) duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-    return SQLITE_OK;
+	using namespace std::chrono;
+	*piNow = (sqlite3_int64)duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+	return SQLITE_OK;
 }
 
 // virtual file system, providing some dummies to avoid crashes
 sqlite3_vfs *sqlite3_vfs_find(const char *zVfsName) {
-    // return a dummy because the shell does not check the return code.
-    // fprintf(stderr, "sqlite3_vfs_find: unsupported.\n");
-    sqlite3_vfs *res = (sqlite3_vfs *) sqlite3_malloc(sizeof(sqlite3_vfs));
-    res->xCurrentTimeInt64 = unixCurrentTimeInt64;
-    res->iVersion = 2;
-    res->zName = "dummy";
-    res->pNext = nullptr;
-    assert(res);
-    return res;
+	// return a dummy because the shell does not check the return code.
+	// fprintf(stderr, "sqlite3_vfs_find: unsupported.\n");
+	sqlite3_vfs *res = (sqlite3_vfs *)sqlite3_malloc(sizeof(sqlite3_vfs));
+	res->xCurrentTimeInt64 = unixCurrentTimeInt64;
+	res->iVersion = 2;
+	res->zName = "dummy";
+	res->pNext = nullptr;
+	assert(res);
+	return res;
 }
 
 int sqlite3_vfs_register(sqlite3_vfs *, int makeDflt) {
-    // fprintf(stderr, "sqlite3_vfs_register: unsupported.\n");
-    return -1;
+	// fprintf(stderr, "sqlite3_vfs_register: unsupported.\n");
+	return -1;
 }
 
 // backups, unused
 
 int sqlite3_backup_step(sqlite3_backup *p, int nPage) {
-    fprintf(stderr, "sqlite3_backup_step: unsupported.\n");
-    return -1;
+	fprintf(stderr, "sqlite3_backup_step: unsupported.\n");
+	return -1;
 }
 
 int sqlite3_backup_finish(sqlite3_backup *p) {
-    fprintf(stderr, "sqlite3_backup_finish: unsupported.\n");
-    return -1;
+	fprintf(stderr, "sqlite3_backup_finish: unsupported.\n");
+	return -1;
 }
 
 sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest,         /* Destination database handle */
@@ -1214,152 +1212,152 @@ sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest,         /* Destination datab
                                     sqlite3 *pSource,       /* Source database handle */
                                     const char *zSourceName /* Source database name */
 ) {
-    fprintf(stderr, "sqlite3_backup_init: unsupported.\n");
-    return nullptr;
+	fprintf(stderr, "sqlite3_backup_init: unsupported.\n");
+	return nullptr;
 }
 
 // UDF support stuff, unused for now. These cannot be called as create_function above is disabled
 
 SQLITE_API sqlite3 *sqlite3_context_db_handle(sqlite3_context *) {
-    return nullptr;
+	return nullptr;
 }
 
 void *sqlite3_user_data(sqlite3_context *) {
-    return nullptr;
+	return nullptr;
 }
 
 #ifdef _WIN32
 #include <windows.h>
 
 static void *sqlite3MallocZero(size_t n) {
-    auto res = sqlite3_malloc(n);
-    assert(res);
-    memset(res, 0, n);
-    return res;
+	auto res = sqlite3_malloc(n);
+	assert(res);
+	memset(res, 0, n);
+	return res;
 }
 
 static LPWSTR winUtf8ToUnicode(const char *zText) {
-    int nChar;
-    LPWSTR zWideText;
+	int nChar;
+	LPWSTR zWideText;
 
-    nChar = MultiByteToWideChar(CP_UTF8, 0, zText, -1, NULL, 0);
-    if (nChar == 0) {
-        return 0;
-    }
-    zWideText = (LPWSTR)sqlite3MallocZero(nChar * sizeof(WCHAR));
-    if (zWideText == 0) {
-        return 0;
-    }
-    nChar = MultiByteToWideChar(CP_UTF8, 0, zText, -1, zWideText, nChar);
-    if (nChar == 0) {
-        sqlite3_free(zWideText);
-        zWideText = 0;
-    }
-    return zWideText;
+	nChar = MultiByteToWideChar(CP_UTF8, 0, zText, -1, NULL, 0);
+	if (nChar == 0) {
+		return 0;
+	}
+	zWideText = (LPWSTR)sqlite3MallocZero(nChar * sizeof(WCHAR));
+	if (zWideText == 0) {
+		return 0;
+	}
+	nChar = MultiByteToWideChar(CP_UTF8, 0, zText, -1, zWideText, nChar);
+	if (nChar == 0) {
+		sqlite3_free(zWideText);
+		zWideText = 0;
+	}
+	return zWideText;
 }
 
 static char *winUnicodeToMbcs(LPCWSTR zWideText, int useAnsi) {
-    int nByte;
-    char *zText;
-    int codepage = useAnsi ? CP_ACP : CP_OEMCP;
+	int nByte;
+	char *zText;
+	int codepage = useAnsi ? CP_ACP : CP_OEMCP;
 
-    nByte = WideCharToMultiByte(codepage, 0, zWideText, -1, 0, 0, 0, 0);
-    if (nByte == 0) {
-        return 0;
-    }
-    zText = (char *)sqlite3MallocZero(nByte);
-    if (zText == 0) {
-        return 0;
-    }
-    nByte = WideCharToMultiByte(codepage, 0, zWideText, -1, zText, nByte, 0, 0);
-    if (nByte == 0) {
-        sqlite3_free(zText);
-        zText = 0;
-    }
-    return zText;
+	nByte = WideCharToMultiByte(codepage, 0, zWideText, -1, 0, 0, 0, 0);
+	if (nByte == 0) {
+		return 0;
+	}
+	zText = (char *)sqlite3MallocZero(nByte);
+	if (zText == 0) {
+		return 0;
+	}
+	nByte = WideCharToMultiByte(codepage, 0, zWideText, -1, zText, nByte, 0, 0);
+	if (nByte == 0) {
+		sqlite3_free(zText);
+		zText = 0;
+	}
+	return zText;
 }
 
 static char *winUtf8ToMbcs(const char *zText, int useAnsi) {
-    char *zTextMbcs;
-    LPWSTR zTmpWide;
+	char *zTextMbcs;
+	LPWSTR zTmpWide;
 
-    zTmpWide = winUtf8ToUnicode(zText);
-    if (zTmpWide == 0) {
-        return 0;
-    }
-    zTextMbcs = winUnicodeToMbcs(zTmpWide, useAnsi);
-    sqlite3_free(zTmpWide);
-    return zTextMbcs;
+	zTmpWide = winUtf8ToUnicode(zText);
+	if (zTmpWide == 0) {
+		return 0;
+	}
+	zTextMbcs = winUnicodeToMbcs(zTmpWide, useAnsi);
+	sqlite3_free(zTmpWide);
+	return zTextMbcs;
 }
 
 SQLITE_API char *sqlite3_win32_utf8_to_mbcs_v2(const char *zText, int useAnsi) {
-    return winUtf8ToMbcs(zText, useAnsi);
+	return winUtf8ToMbcs(zText, useAnsi);
 }
 
 LPWSTR sqlite3_win32_utf8_to_unicode(const char *zText) {
-    return winUtf8ToUnicode(zText);
+	return winUtf8ToUnicode(zText);
 }
 
 static LPWSTR winMbcsToUnicode(const char *zText, int useAnsi) {
-    int nByte;
-    LPWSTR zMbcsText;
-    int codepage = useAnsi ? CP_ACP : CP_OEMCP;
+	int nByte;
+	LPWSTR zMbcsText;
+	int codepage = useAnsi ? CP_ACP : CP_OEMCP;
 
-    nByte = MultiByteToWideChar(codepage, 0, zText, -1, NULL, 0) * sizeof(WCHAR);
-    if (nByte == 0) {
-        return 0;
-    }
-    zMbcsText = (LPWSTR)sqlite3MallocZero(nByte * sizeof(WCHAR));
-    if (zMbcsText == 0) {
-        return 0;
-    }
-    nByte = MultiByteToWideChar(codepage, 0, zText, -1, zMbcsText, nByte);
-    if (nByte == 0) {
-        sqlite3_free(zMbcsText);
-        zMbcsText = 0;
-    }
-    return zMbcsText;
+	nByte = MultiByteToWideChar(codepage, 0, zText, -1, NULL, 0) * sizeof(WCHAR);
+	if (nByte == 0) {
+		return 0;
+	}
+	zMbcsText = (LPWSTR)sqlite3MallocZero(nByte * sizeof(WCHAR));
+	if (zMbcsText == 0) {
+		return 0;
+	}
+	nByte = MultiByteToWideChar(codepage, 0, zText, -1, zMbcsText, nByte);
+	if (nByte == 0) {
+		sqlite3_free(zMbcsText);
+		zMbcsText = 0;
+	}
+	return zMbcsText;
 }
 
 static char *winUnicodeToUtf8(LPCWSTR zWideText) {
-    int nByte;
-    char *zText;
+	int nByte;
+	char *zText;
 
-    nByte = WideCharToMultiByte(CP_UTF8, 0, zWideText, -1, 0, 0, 0, 0);
-    if (nByte == 0) {
-        return 0;
-    }
-    zText = (char *)sqlite3MallocZero(nByte);
-    if (zText == 0) {
-        return 0;
-    }
-    nByte = WideCharToMultiByte(CP_UTF8, 0, zWideText, -1, zText, nByte, 0, 0);
-    if (nByte == 0) {
-        sqlite3_free(zText);
-        zText = 0;
-    }
-    return zText;
+	nByte = WideCharToMultiByte(CP_UTF8, 0, zWideText, -1, 0, 0, 0, 0);
+	if (nByte == 0) {
+		return 0;
+	}
+	zText = (char *)sqlite3MallocZero(nByte);
+	if (zText == 0) {
+		return 0;
+	}
+	nByte = WideCharToMultiByte(CP_UTF8, 0, zWideText, -1, zText, nByte, 0, 0);
+	if (nByte == 0) {
+		sqlite3_free(zText);
+		zText = 0;
+	}
+	return zText;
 }
 
 static char *winMbcsToUtf8(const char *zText, int useAnsi) {
-    char *zTextUtf8;
-    LPWSTR zTmpWide;
+	char *zTextUtf8;
+	LPWSTR zTmpWide;
 
-    zTmpWide = winMbcsToUnicode(zText, useAnsi);
-    if (zTmpWide == 0) {
-        return 0;
-    }
-    zTextUtf8 = winUnicodeToUtf8(zTmpWide);
-    sqlite3_free(zTmpWide);
-    return zTextUtf8;
+	zTmpWide = winMbcsToUnicode(zText, useAnsi);
+	if (zTmpWide == 0) {
+		return 0;
+	}
+	zTextUtf8 = winUnicodeToUtf8(zTmpWide);
+	sqlite3_free(zTmpWide);
+	return zTextUtf8;
 }
 
 SQLITE_API char *sqlite3_win32_mbcs_to_utf8_v2(const char *zText, int useAnsi) {
-    return winMbcsToUtf8(zText, useAnsi);
+	return winMbcsToUtf8(zText, useAnsi);
 }
 
 SQLITE_API char *sqlite3_win32_unicode_to_utf8(LPCWSTR zWideText) {
-    return winUnicodeToUtf8(zWideText);
+	return winUnicodeToUtf8(zWideText);
 }
 
 #endif
@@ -1424,75 +1422,75 @@ SQLITE_API void sqlite3_result_zeroblob(sqlite3_context *, int n) {
 }
 
 SQLITE_API int sqlite3_result_zeroblob64(sqlite3_context *, sqlite3_uint64 n) {
-    return -1;
+	return -1;
 }
 
 // TODO complain
 const void *sqlite3_value_blob(sqlite3_value *) {
-    return nullptr;
+	return nullptr;
 }
 
 double sqlite3_value_double(sqlite3_value *) {
-    return 0;
+	return 0;
 }
 
 int sqlite3_value_int(sqlite3_value *) {
-    return 0;
+	return 0;
 }
 
 sqlite3_int64 sqlite3_value_int64(sqlite3_value *) {
-    return 0;
+	return 0;
 }
 
 void *sqlite3_value_pointer(sqlite3_value *, const char *) {
-    return nullptr;
+	return nullptr;
 }
 
 const unsigned char *sqlite3_value_text(sqlite3_value *) {
-    return nullptr;
+	return nullptr;
 }
 
 SQLITE_API const void *sqlite3_value_text16(sqlite3_value *) {
-    return nullptr;
+	return nullptr;
 }
 
 SQLITE_API const void *sqlite3_value_text16le(sqlite3_value *) {
-    return nullptr;
+	return nullptr;
 }
 
 SQLITE_API const void *sqlite3_value_text16be(sqlite3_value *) {
-    return nullptr;
+	return nullptr;
 }
 
 SQLITE_API int sqlite3_value_bytes(sqlite3_value *) {
-    return 0;
+	return 0;
 }
 
 SQLITE_API int sqlite3_value_bytes16(sqlite3_value *) {
-    return 0;
+	return 0;
 }
 
 SQLITE_API int sqlite3_value_type(sqlite3_value *) {
-    return 0;
+	return 0;
 }
 
 SQLITE_API int sqlite3_value_numeric_type(sqlite3_value *) {
-    return 0;
+	return 0;
 }
 
 SQLITE_API int sqlite3_value_nochange(sqlite3_value *) {
-    return 0;
+	return 0;
 }
 
 SQLITE_API void *sqlite3_aggregate_context(sqlite3_context *, int nBytes) {
-    fprintf(stderr, "sqlite3_aggregate_context: unsupported.\n");
+	fprintf(stderr, "sqlite3_aggregate_context: unsupported.\n");
 
-    return nullptr;
+	return nullptr;
 }
 
 SQLITE_API int sqlite3_create_collation(sqlite3 *, const char *zName, int eTextRep, void *pArg,
                                         int (*xCompare)(void *, int, const void *, int, const void *)) {
-    return SQLITE_ERROR;
+	return SQLITE_ERROR;
 }
 
 SQLITE_API int sqlite3_create_window_function(sqlite3 *db, const char *zFunctionName, int nArg, int eTextRep,
@@ -1500,45 +1498,45 @@ SQLITE_API int sqlite3_create_window_function(sqlite3 *db, const char *zFunction
                                               void (*xFinal)(sqlite3_context *), void (*xValue)(sqlite3_context *),
                                               void (*xInverse)(sqlite3_context *, int, sqlite3_value **),
                                               void (*xDestroy)(void *)) {
-    fprintf(stderr, "sqlite3_create_window_function: unsupported.\n");
-    return SQLITE_ERROR;
+	fprintf(stderr, "sqlite3_create_window_function: unsupported.\n");
+	return SQLITE_ERROR;
 }
 
 SQLITE_API sqlite3 *sqlite3_db_handle(sqlite3_stmt *s) {
-    return s->db;
+	return s->db;
 }
 
 SQLITE_API char *sqlite3_expanded_sql(sqlite3_stmt *pStmt) {
-    fprintf(stderr, "sqlite3_expanded_sql: unsupported.\n");
-    return nullptr;
+	fprintf(stderr, "sqlite3_expanded_sql: unsupported.\n");
+	return nullptr;
 }
 
 SQLITE_API int sqlite3_keyword_check(const char *str, int len) {
-    return Parser::IsKeyword(std::string(str, len));
+	return Parser::IsKeyword(std::string(str, len));
 }
 
 SQLITE_API int sqlite3_keyword_count(void) {
-    fprintf(stderr, "sqlite3_keyword_count: unsupported.\n");
-    return 0;
+	fprintf(stderr, "sqlite3_keyword_count: unsupported.\n");
+	return 0;
 }
 
 SQLITE_API int sqlite3_keyword_name(int, const char **, int *) {
-    fprintf(stderr, "sqlite3_keyword_name: unsupported.\n");
-    return 0;
+	fprintf(stderr, "sqlite3_keyword_name: unsupported.\n");
+	return 0;
 }
 
 SQLITE_API void sqlite3_progress_handler(sqlite3 *, int, int (*)(void *), void *) {
-    fprintf(stderr, "sqlite3_progress_handler: unsupported.\n");
+	fprintf(stderr, "sqlite3_progress_handler: unsupported.\n");
 }
 
 SQLITE_API int sqlite3_stmt_isexplain(sqlite3_stmt *pStmt) {
-    if (!pStmt || !pStmt->prepared) {
-        return 0;
-    }
-    return pStmt->prepared->GetStatementType() == StatementType::EXPLAIN_STATEMENT;
+	if (!pStmt || !pStmt->prepared) {
+		return 0;
+	}
+	return pStmt->prepared->GetStatementType() == StatementType::EXPLAIN_STATEMENT;
 }
 
 SQLITE_API int sqlite3_vtab_config(sqlite3 *, int op, ...) {
-    fprintf(stderr, "sqlite3_vtab_config: unsupported.\n");
-    return SQLITE_ERROR;
+	fprintf(stderr, "sqlite3_vtab_config: unsupported.\n");
+	return SQLITE_ERROR;
 }


### PR DESCRIPTION
This PR has a progress bar for base table scans.
If a query takes longer than 2s it automatically starts printing a progress bar.
 (Unfortunately, windows was not very fond of 🦆 so I had to use a rather boring | to depict progress :-( )
Of course, other table scans are still missing,  I can think of the CSV and Parquet Reader, but maybe others as well, we can list them on task #983 and I'm more than happy to implement it.
Also, this PR only implement the call in the shell, other APIs still have to be implemented (I guess python, R, ...), should add those on the task as well