### PR TITLE
Build option for allowing concurrent stale read processes with an append writer process (default OFF)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ option(
   "Throw an exception on an assert failing, instead of triggering a sigabort"
   TRUE)
 option(FORCE_ASSERT "Enable checking of assertions, even in release mode" FALSE)
+option(STALE_READ "Allow stale reads with concurrent writes" FALSE)
 
 option(TREAT_WARNINGS_AS_ERRORS "Treat warnings as errors" FALSE)
 option(EXPORT_DLL_SYMBOLS "Export dll symbols on Windows, else import" TRUE)
@@ -190,6 +191,10 @@ endif()
 
 if(FORCE_ASSERT)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDUCKDB_FORCE_ASSERT")
+endif()
+
+if(STALE_READ)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDUCKDB_STALE_READ")
 endif()
 
 if(NOT MSVC)

--- a/src/common/serializer/buffered_file_reader.cpp
+++ b/src/common/serializer/buffered_file_reader.cpp
@@ -9,7 +9,11 @@ namespace duckdb {
 
 BufferedFileReader::BufferedFileReader(FileSystem &fs, const char *path)
     : fs(fs), data(unique_ptr<data_t[]>(new data_t[FILE_BUFFER_SIZE])), offset(0), read_data(0), total_read(0) {
+#ifdef DUCKDB_STALE_READ
+	handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ, FileLockType::NO_LOCK);
+#else
 	handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ, FileLockType::READ_LOCK);
+#endif // STALE_READ
 	file_size = fs.GetFileSize(*handle);
 }
 

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -74,7 +74,11 @@ SingleFileBlockManager::SingleFileBlockManager(DatabaseInstance &db, string path
 	if (read_only) {
 		D_ASSERT(!create_new);
 		flags = FileFlags::FILE_FLAGS_READ;
+#ifdef DUCKDB_STALE_READ
+		lock = FileLockType::NO_LOCK;
+#else
 		lock = FileLockType::READ_LOCK;
+#endif // STALE_READS
 	} else {
 		flags = FileFlags::FILE_FLAGS_WRITE;
 		lock = FileLockType::WRITE_LOCK;


### PR DESCRIPTION
## Allow concurrent stale read processes with an append writer process

This PR replaces `READ_LOCK` with `NO_LOCK` when CMake option `STALE_READ` is set `ON`, for allowing concurrent db reading while the db is being written to (`WRITE_LOCK`). As a result the reader will not see new writes on the db before it opens the db again as the in-mem caches are not invalidated by the other writer process through the db file itself.

**Example usage scenario**: DuckDB with AWS Lambda (short lived db connections) and EFS (network filesystem). Lambda containers live for short time and workloads do not require strict read after write consistency, but possibility to have multiple concurrent readers on the db while the db is being written to (e.g. with a single writer). Furthermore, as with the nature of Lambda, reads should not wait for long time but complete as soon as possible, while writes of bigger batches may take longer time to complete. Reads are consistent on the time the db file was opened for read and complete without requiring to wait for `READ_LOCK` availability. This way, there can a be single **append** writer (`INSERTS`) that possibly updates the db a whole lot all the time, whilst the readers (possibly many concurrent) still get consistent snapshot results.

### Tests

- [x] Compiled the code with `STALE_READ` enabled and started duckdb client in write mode and in readonly mode with the same database file. Writer was able to write and also read its writes. Reader was able to see the results at the time the db was opened, but not the new `INSERT`s. Once quitting the `-readonly` client and starting it again, it was able to see the latest results.