### PR TITLE
Disable the single thread pointer for now

### DIFF
--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -81,11 +81,11 @@ struct string_t;
 template <class T>
 using child_list_t = std::vector<std::pair<std::string, T>>;
 template <class T>
-using buffer_ptr = single_thread_ptr<T>;
+using buffer_ptr = shared_ptr<T>;
 
 template <class T, typename... Args>
 buffer_ptr<T> make_buffer(Args &&...args) {
-	return single_thread_make_shared<T>(std::forward<Args>(args)...);
+	return make_shared<T>(std::forward<Args>(args)...);
 }
 
 struct list_entry_t {


### PR DESCRIPTION
The single-thread pointer has a bug that triggers sanitizer issues when compiling the code with C++17. We disable it for now and revert back to using shared pointers.