### PR TITLE
Add root expression monitor

### DIFF
--- a/src/execution/expression_executor.cpp
+++ b/src/execution/expression_executor.cpp
@@ -27,7 +27,7 @@ ExpressionExecutor::ExpressionExecutor(vector<unique_ptr<Expression>> &exprs) : 
 
 void ExpressionExecutor::AddExpression(Expression &expr) {
 	expressions.push_back(&expr);
-	auto state = make_unique<ExpressionExecutorState>();
+	auto state = make_unique<ExpressionExecutorState>(expr.ToString());
 	Initialize(expr, *state);
 	states.push_back(move(state));
 }
@@ -39,11 +39,18 @@ void ExpressionExecutor::Initialize(Expression &expression, ExpressionExecutorSt
 
 void ExpressionExecutor::Execute(DataChunk *input, DataChunk &result) {
 	SetChunk(input);
-
 	D_ASSERT(expressions.size() == result.ColumnCount());
 	D_ASSERT(!expressions.empty());
+
 	for (idx_t i = 0; i < expressions.size(); i++) {
+        if (current_count >= next_sample) {
+			states[i]->profiler.Start();
+		}
 		ExecuteExpression(i, result.data[i]);
+        if (current_count >= next_sample) {
+			states[i]->profiler.End();
+			states[i]->time += states[i]->profiler.Elapsed();
+		}
 		if (current_count >= next_sample) {
 			next_sample = 50 + random.NextRandomInteger() % 100;
 			++sample_count;

--- a/src/execution/expression_executor.cpp
+++ b/src/execution/expression_executor.cpp
@@ -43,11 +43,11 @@ void ExpressionExecutor::Execute(DataChunk *input, DataChunk &result) {
 	D_ASSERT(!expressions.empty());
 
 	for (idx_t i = 0; i < expressions.size(); i++) {
-        if (current_count >= next_sample) {
+		if (current_count >= next_sample) {
 			states[i]->profiler.Start();
 		}
 		ExecuteExpression(i, result.data[i]);
-        if (current_count >= next_sample) {
+		if (current_count >= next_sample) {
 			states[i]->profiler.End();
 			states[i]->time += states[i]->profiler.Elapsed();
 		}

--- a/src/execution/expression_executor_state.cpp
+++ b/src/execution/expression_executor_state.cpp
@@ -18,6 +18,6 @@ ExpressionState::ExpressionState(Expression &expr, ExpressionExecutorState &root
     : expr(expr), root(root), name(expr.ToString()) {
 }
 
-ExpressionExecutorState::ExpressionExecutorState(const string &name) : profiler() , name(name){
+ExpressionExecutorState::ExpressionExecutorState(const string &name) : profiler(), name(name) {
 }
 } // namespace duckdb

--- a/src/execution/expression_executor_state.cpp
+++ b/src/execution/expression_executor_state.cpp
@@ -18,4 +18,6 @@ ExpressionState::ExpressionState(Expression &expr, ExpressionExecutorState &root
     : expr(expr), root(root), name(expr.ToString()) {
 }
 
+ExpressionExecutorState::ExpressionExecutorState(const string &name) : profiler() , name(name){
+}
 } // namespace duckdb

--- a/src/function/table/CMakeLists.txt
+++ b/src/function/table/CMakeLists.txt
@@ -15,7 +15,8 @@ add_library_unity(
   information_schema_functions.cpp
   table_scan.cpp
   pragma_last_profiling_output.cpp
-  pragma_detailed_profiling_output.cpp)
+  pragma_detailed_profiling_output.cpp
+  pragma_expression_profiling_output.cpp)
 
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_table>

--- a/src/function/table/pragma_expression_profiling_output.cpp
+++ b/src/function/table/pragma_expression_profiling_output.cpp
@@ -1,0 +1,105 @@
+#include "duckdb/function/table/sqlite_functions.hpp"
+
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
+#include "duckdb/planner/constraints/bound_not_null_constraint.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "iostream"
+
+#include "duckdb/common/limits.hpp"
+namespace duckdb {
+
+struct PragmaExpressionsProfilingOutputOperatorData : public FunctionOperatorData {
+    explicit PragmaExpressionsProfilingOutputOperatorData() : chunk_index(0), initialized(false) {
+    }
+    idx_t chunk_index;
+    bool initialized;
+};
+
+struct PragmaExpressionsProfilingOutputData : public TableFunctionData {
+    explicit PragmaExpressionsProfilingOutputData(vector<LogicalType> &types) : types(types) {
+    }
+    unique_ptr<ChunkCollection> collection;
+    vector<LogicalType> types;
+};
+
+static unique_ptr<FunctionData> PragmaExpressionsProfilingOutputBind(ClientContext &context, vector<Value> &inputs,
+                                                                  unordered_map<string, Value> &named_parameters,
+                                                                  vector<LogicalType> &return_types,
+                                                                  vector<string> &names) {
+    names.emplace_back("OPERATOR_ID");
+    return_types.push_back(LogicalType::INTEGER);
+
+    names.emplace_back("EXPRESSION_ID");
+    return_types.push_back(LogicalType::INTEGER);
+
+    names.emplace_back("NAME");
+    return_types.push_back(LogicalType::VARCHAR);
+
+    names.emplace_back("TIME");
+    return_types.push_back(LogicalType::DOUBLE);
+
+    return make_unique<PragmaExpressionsProfilingOutputData>(return_types);
+}
+
+unique_ptr<FunctionOperatorData> PragmaExpressionsProfilingOutputInit(ClientContext &context,
+                                                                   const FunctionData *bind_data,
+                                                                   vector<column_t> &column_ids,
+                                                                   TableFilterCollection *filters) {
+    return make_unique<PragmaExpressionsProfilingOutputOperatorData>();
+}
+
+static void ExpressionSetValue(DataChunk &output, int index, int op_id, int exp_id, string name, double time) {
+    output.SetValue(0, index, op_id);
+    output.SetValue(1, index, exp_id);
+    output.SetValue(2, index, move(name));
+    output.SetValue(3, index, time);
+}
+
+
+
+static void PragmaExpressionsProfilingOutputFunction(ClientContext &context, const FunctionData *bind_data_p,
+                                                  FunctionOperatorData *operator_state, DataChunk &output) {
+    auto &state = (PragmaExpressionsProfilingOutputOperatorData &)*operator_state;
+    auto &data = (PragmaExpressionsProfilingOutputData &)*bind_data_p;
+    if (!state.initialized) {
+        // create a ChunkCollection
+        auto collection = make_unique<ChunkCollection>();
+
+        DataChunk chunk;
+        chunk.Initialize(data.types);
+
+        int operator_counter = 1;
+        if (!context.query_profiler_history.GetPrevProfilers().empty()) {
+            for (auto op : context.query_profiler_history.GetPrevProfilers().back().second.GetTreeMap()) {
+                int expression_counter = 1;
+                if (op.second->info.has_executor) {
+                    for (auto &info : op.second->info.executors_info->roots) {
+                        ExpressionSetValue(chunk, chunk.size(), operator_counter, expression_counter++, info->name, double(info->time) / op.second->info.executors_info->sample_tuples_count);
+                        chunk.SetCardinality(chunk.size() + 1);
+                        if (chunk.size() == STANDARD_VECTOR_SIZE) {
+                            collection->Append(chunk);
+                            chunk.Reset();
+                        }                    }
+                }
+                operator_counter++;
+            }
+        }
+        collection->Append(chunk);
+        data.collection = move(collection);
+        state.initialized = true;
+    }
+
+    if (state.chunk_index >= data.collection->ChunkCount()) {
+        output.SetCardinality(0);
+        return;
+    }
+    output.Reference(data.collection->GetChunk(state.chunk_index++));
+}
+
+void PragmaExpressionsProfilingOutput::RegisterFunction(BuiltinFunctions &set) {
+    set.AddFunction(TableFunction("pragma_expressions_profiling_output", {}, PragmaExpressionsProfilingOutputFunction,
+                                  PragmaExpressionsProfilingOutputBind, PragmaExpressionsProfilingOutputInit));
+}
+
+} // namespace duckdb

--- a/src/function/table/pragma_expression_profiling_output.cpp
+++ b/src/function/table/pragma_expression_profiling_output.cpp
@@ -4,102 +4,101 @@
 #include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
 #include "duckdb/planner/constraints/bound_not_null_constraint.hpp"
 #include "duckdb/main/client_context.hpp"
-#include "iostream"
 
 #include "duckdb/common/limits.hpp"
 namespace duckdb {
 
 struct PragmaExpressionsProfilingOutputOperatorData : public FunctionOperatorData {
-    explicit PragmaExpressionsProfilingOutputOperatorData() : chunk_index(0), initialized(false) {
-    }
-    idx_t chunk_index;
-    bool initialized;
+	explicit PragmaExpressionsProfilingOutputOperatorData() : chunk_index(0), initialized(false) {
+	}
+	idx_t chunk_index;
+	bool initialized;
 };
 
 struct PragmaExpressionsProfilingOutputData : public TableFunctionData {
-    explicit PragmaExpressionsProfilingOutputData(vector<LogicalType> &types) : types(types) {
-    }
-    unique_ptr<ChunkCollection> collection;
-    vector<LogicalType> types;
+	explicit PragmaExpressionsProfilingOutputData(vector<LogicalType> &types) : types(types) {
+	}
+	unique_ptr<ChunkCollection> collection;
+	vector<LogicalType> types;
 };
 
 static unique_ptr<FunctionData> PragmaExpressionsProfilingOutputBind(ClientContext &context, vector<Value> &inputs,
-                                                                  unordered_map<string, Value> &named_parameters,
-                                                                  vector<LogicalType> &return_types,
-                                                                  vector<string> &names) {
-    names.emplace_back("OPERATOR_ID");
-    return_types.push_back(LogicalType::INTEGER);
+                                                                     unordered_map<string, Value> &named_parameters,
+                                                                     vector<LogicalType> &return_types,
+                                                                     vector<string> &names) {
+	names.emplace_back("OPERATOR_ID");
+	return_types.push_back(LogicalType::INTEGER);
 
-    names.emplace_back("EXPRESSION_ID");
-    return_types.push_back(LogicalType::INTEGER);
+	names.emplace_back("EXPRESSION_ID");
+	return_types.push_back(LogicalType::INTEGER);
 
-    names.emplace_back("NAME");
-    return_types.push_back(LogicalType::VARCHAR);
+	names.emplace_back("NAME");
+	return_types.push_back(LogicalType::VARCHAR);
 
-    names.emplace_back("TIME");
-    return_types.push_back(LogicalType::DOUBLE);
+	names.emplace_back("TIME");
+	return_types.push_back(LogicalType::DOUBLE);
 
-    return make_unique<PragmaExpressionsProfilingOutputData>(return_types);
+	return make_unique<PragmaExpressionsProfilingOutputData>(return_types);
 }
 
 unique_ptr<FunctionOperatorData> PragmaExpressionsProfilingOutputInit(ClientContext &context,
-                                                                   const FunctionData *bind_data,
-                                                                   vector<column_t> &column_ids,
-                                                                   TableFilterCollection *filters) {
-    return make_unique<PragmaExpressionsProfilingOutputOperatorData>();
+                                                                      const FunctionData *bind_data,
+                                                                      vector<column_t> &column_ids,
+                                                                      TableFilterCollection *filters) {
+	return make_unique<PragmaExpressionsProfilingOutputOperatorData>();
 }
 
 static void ExpressionSetValue(DataChunk &output, int index, int op_id, int exp_id, string name, double time) {
-    output.SetValue(0, index, op_id);
-    output.SetValue(1, index, exp_id);
-    output.SetValue(2, index, move(name));
-    output.SetValue(3, index, time);
+	output.SetValue(0, index, op_id);
+	output.SetValue(1, index, exp_id);
+	output.SetValue(2, index, move(name));
+	output.SetValue(3, index, time);
 }
 
-
-
 static void PragmaExpressionsProfilingOutputFunction(ClientContext &context, const FunctionData *bind_data_p,
-                                                  FunctionOperatorData *operator_state, DataChunk &output) {
-    auto &state = (PragmaExpressionsProfilingOutputOperatorData &)*operator_state;
-    auto &data = (PragmaExpressionsProfilingOutputData &)*bind_data_p;
-    if (!state.initialized) {
-        // create a ChunkCollection
-        auto collection = make_unique<ChunkCollection>();
+                                                     FunctionOperatorData *operator_state, DataChunk &output) {
+	auto &state = (PragmaExpressionsProfilingOutputOperatorData &)*operator_state;
+	auto &data = (PragmaExpressionsProfilingOutputData &)*bind_data_p;
+	if (!state.initialized) {
+		// create a ChunkCollection
+		auto collection = make_unique<ChunkCollection>();
 
-        DataChunk chunk;
-        chunk.Initialize(data.types);
+		DataChunk chunk;
+		chunk.Initialize(data.types);
 
-        int operator_counter = 1;
-        if (!context.query_profiler_history.GetPrevProfilers().empty()) {
-            for (auto op : context.query_profiler_history.GetPrevProfilers().back().second.GetTreeMap()) {
-                int expression_counter = 1;
-                if (op.second->info.has_executor) {
-                    for (auto &info : op.second->info.executors_info->roots) {
-                        ExpressionSetValue(chunk, chunk.size(), operator_counter, expression_counter++, info->name, double(info->time) / op.second->info.executors_info->sample_tuples_count);
-                        chunk.SetCardinality(chunk.size() + 1);
-                        if (chunk.size() == STANDARD_VECTOR_SIZE) {
-                            collection->Append(chunk);
-                            chunk.Reset();
-                        }                    }
-                }
-                operator_counter++;
-            }
-        }
-        collection->Append(chunk);
-        data.collection = move(collection);
-        state.initialized = true;
-    }
+		int operator_counter = 1;
+		if (!context.query_profiler_history.GetPrevProfilers().empty()) {
+			for (auto op : context.query_profiler_history.GetPrevProfilers().back().second.GetTreeMap()) {
+				int expression_counter = 1;
+				if (op.second->info.has_executor) {
+					for (auto &info : op.second->info.executors_info->roots) {
+						ExpressionSetValue(chunk, chunk.size(), operator_counter, expression_counter++, info->name,
+						                   double(info->time) / op.second->info.executors_info->sample_tuples_count);
+						chunk.SetCardinality(chunk.size() + 1);
+						if (chunk.size() == STANDARD_VECTOR_SIZE) {
+							collection->Append(chunk);
+							chunk.Reset();
+						}
+					}
+				}
+				operator_counter++;
+			}
+		}
+		collection->Append(chunk);
+		data.collection = move(collection);
+		state.initialized = true;
+	}
 
-    if (state.chunk_index >= data.collection->ChunkCount()) {
-        output.SetCardinality(0);
-        return;
-    }
-    output.Reference(data.collection->GetChunk(state.chunk_index++));
+	if (state.chunk_index >= data.collection->ChunkCount()) {
+		output.SetCardinality(0);
+		return;
+	}
+	output.Reference(data.collection->GetChunk(state.chunk_index++));
 }
 
 void PragmaExpressionsProfilingOutput::RegisterFunction(BuiltinFunctions &set) {
-    set.AddFunction(TableFunction("pragma_expressions_profiling_output", {}, PragmaExpressionsProfilingOutputFunction,
-                                  PragmaExpressionsProfilingOutputBind, PragmaExpressionsProfilingOutputInit));
+	set.AddFunction(TableFunction("pragma_expressions_profiling_output", {}, PragmaExpressionsProfilingOutputFunction,
+	                              PragmaExpressionsProfilingOutputBind, PragmaExpressionsProfilingOutputInit));
 }
 
 } // namespace duckdb

--- a/src/function/table/sqlite_functions.cpp
+++ b/src/function/table/sqlite_functions.cpp
@@ -18,7 +18,7 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 	PragmaDatabaseList::RegisterFunction(*this);
 	PragmaLastProfilingOutput::RegisterFunction(*this);
 	PragmaDetailedProfilingOutput::RegisterFunction(*this);
-    PragmaExpressionsProfilingOutput::RegisterFunction(*this);
+	PragmaExpressionsProfilingOutput::RegisterFunction(*this);
 
 	// CreateViewInfo info;
 	// info.schema = DEFAULT_SCHEMA;

--- a/src/function/table/sqlite_functions.cpp
+++ b/src/function/table/sqlite_functions.cpp
@@ -18,6 +18,7 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 	PragmaDatabaseList::RegisterFunction(*this);
 	PragmaLastProfilingOutput::RegisterFunction(*this);
 	PragmaDetailedProfilingOutput::RegisterFunction(*this);
+    PragmaExpressionsProfilingOutput::RegisterFunction(*this);
 
 	// CreateViewInfo info;
 	// info.schema = DEFAULT_SCHEMA;

--- a/src/include/duckdb/execution/expression_executor_state.hpp
+++ b/src/include/duckdb/execution/expression_executor_state.hpp
@@ -37,8 +37,12 @@ public:
 };
 
 struct ExpressionExecutorState {
+	explicit ExpressionExecutorState(const string &name);
 	unique_ptr<ExpressionState> root_state;
 	ExpressionExecutor *executor;
+    string name;
+    CycleCounter profiler;
+    double time;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/expression_executor_state.hpp
+++ b/src/include/duckdb/execution/expression_executor_state.hpp
@@ -40,9 +40,9 @@ struct ExpressionExecutorState {
 	explicit ExpressionExecutorState(const string &name);
 	unique_ptr<ExpressionState> root_state;
 	ExpressionExecutor *executor;
-    string name;
-    CycleCounter profiler;
-    double time;
+	CycleCounter profiler;
+	string name;
+	double time;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/function/table/sqlite_functions.hpp
+++ b/src/include/duckdb/function/table/sqlite_functions.hpp
@@ -33,7 +33,7 @@ struct PragmaDetailedProfilingOutput {
 };
 
 struct PragmaExpressionsProfilingOutput {
-    static void RegisterFunction(BuiltinFunctions &set);
+	static void RegisterFunction(BuiltinFunctions &set);
 };
 
 struct SQLiteMaster {

--- a/src/include/duckdb/function/table/sqlite_functions.hpp
+++ b/src/include/duckdb/function/table/sqlite_functions.hpp
@@ -32,6 +32,10 @@ struct PragmaDetailedProfilingOutput {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct PragmaExpressionsProfilingOutput {
+    static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct SQLiteMaster {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -28,13 +28,14 @@ class PhysicalOperator;
 class SQLStatement;
 
 struct ExpressionInformation {
-	ExpressionInformation(string &name, double time) : name(name), time(time) {
+	explicit ExpressionInformation(string &name) : name(name) {
 	}
 	void ExtractExpressionsRecursive(unique_ptr<ExpressionState> &state);
 	vector<unique_ptr<ExpressionInformation>> children;
 	bool hasfunction = false;
 	string name;
 	string function_name;
+	uint64_t function_time = 0;
 	uint64_t time = 0;
 };
 

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -485,8 +485,7 @@ ExpressionExecutorInformation::ExpressionExecutorInformation(ExpressionExecutor 
     : total_count(executor.total_count), current_count(executor.current_count), sample_count(executor.sample_count),
       sample_tuples_count(executor.sample_tuples_count), tuples_count(executor.tuples_count) {
 	for (auto &state : executor.GetStates()) {
-		auto expression_info_p =
-		    make_unique<ExpressionInformation>(state.get()->root_state->name);
+		auto expression_info_p = make_unique<ExpressionInformation>(state.get()->root_state->name);
 		expression_info_p->time = state->time;
 		if (state->root_state->expr.expression_class == ExpressionClass::BOUND_FUNCTION) {
 			expression_info_p->hasfunction = true;

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -470,7 +470,7 @@ void ExpressionInformation::ExtractExpressionsRecursive(unique_ptr<ExpressionSta
 	}
 	// extract the children of this node
 	for (auto &child : state->child_states) {
-		auto expression_info_p = make_unique<ExpressionInformation>(child.get()->name, child.get()->time);
+		auto expression_info_p = make_unique<ExpressionInformation>(child.get()->name);
 		if (child->expr.expression_class == ExpressionClass::BOUND_FUNCTION) {
 			expression_info_p->hasfunction = true;
 			expression_info_p->function_name = ((BoundFunctionExpression &)child->expr).function.name;
@@ -486,7 +486,8 @@ ExpressionExecutorInformation::ExpressionExecutorInformation(ExpressionExecutor 
       sample_tuples_count(executor.sample_tuples_count), tuples_count(executor.tuples_count) {
 	for (auto &state : executor.GetStates()) {
 		auto expression_info_p =
-		    make_unique<ExpressionInformation>(state.get()->root_state->name, state.get()->root_state.get()->time);
+		    make_unique<ExpressionInformation>(state.get()->root_state->name);
+		expression_info_p->time = state->time;
 		if (state->root_state->expr.expression_class == ExpressionClass::BOUND_FUNCTION) {
 			expression_info_p->hasfunction = true;
 			expression_info_p->function_name = ((BoundFunctionExpression &)state->root_state->expr).function.name;


### PR DESCRIPTION
This PR adds pragma_expressions_profiling_output which could be used to profile expression roots.
For example :
```SQL
SELECT  min(i + i) , min(i - I)   

OPERATOR_ID	EXPRESSION_ID	NAME	TIME	
INTEGER	INTEGER	VARCHAR	DOUBLE	
[ Rows: 2]
2	1	+(i, i)	0.527682	
2	2	-(i, i)	0.445501	

```