### PR TITLE
Using ALTREP to speed up string column transfer to R

### DIFF
--- a/tools/rpkg/DESCRIPTION
+++ b/tools/rpkg/DESCRIPTION
@@ -45,7 +45,7 @@ URL: https://duckdb.org/, https://github.com/cwida/duckdb
 BugReports: https://github.com/cwida/duckdb/issues
 Depends:
     DBI,
-    R (>= 3.5.0)
+    R (>= 3.6.0)
 Imports:
     methods,
     utils

--- a/tools/rpkg/src/duckdbr.cpp
+++ b/tools/rpkg/src/duckdbr.cpp
@@ -13,8 +13,9 @@
 #define R_NO_REMAP
 
 #include <Rdefines.h>
+#include <R_ext/Altrep.h>
+
 #include <algorithm>
-#include <sstream>
 
 using namespace duckdb;
 using namespace std;
@@ -290,6 +291,13 @@ static RType detect_rtype(SEXP v) {
 	}
 	return RType::UNKNOWN;
 }
+
+static R_altrep_class_t duckdb_altrep_string_class;
+
+struct DuckDBAltrepStringWrapper {
+	vector<Vector> vectors;
+	idx_t length;
+};
 
 extern "C" {
 
@@ -583,9 +591,18 @@ SEXP duckdb_execute_R_impl(MaterializedQueryResult *result) {
 		case LogicalTypeId::TIME:
 			varvalue = r_varvalue.Protect(NEW_NUMERIC(nrows));
 			break;
-		case LogicalTypeId::VARCHAR:
-			varvalue = r_varvalue.Protect(NEW_STRING(nrows));
+		case LogicalTypeId::VARCHAR: {
+			auto wrapper = new DuckDBAltrepStringWrapper();
+			wrapper->length = nrows;
+			wrapper->vectors.resize(result->collection.Chunks().size());
+
+			auto ptr = PROTECT(R_MakeExternalPtr((void *)wrapper, R_NilValue, R_NilValue));
+			// TODO R_RegisterCFinalizer(ptr, duckdb_altrep_strings_finalizer);
+			varvalue = r_varvalue.Protect(R_new_altrep(duckdb_altrep_string_class, ptr, R_NilValue));
+			UNPROTECT(1);
 			break;
+		}
+
 		case LogicalTypeId::BLOB:
 			varvalue = r_varvalue.Protect(NEW_LIST(nrows));
 			break;
@@ -603,11 +620,13 @@ SEXP duckdb_execute_R_impl(MaterializedQueryResult *result) {
 
 	// step 3: set values from chunks
 	uint64_t dest_offset = 0;
+	idx_t chunk_idx = 0;
 	while (true) {
 		auto chunk = result->Fetch();
 		if (!chunk || chunk->size() == 0) {
 			break;
 		}
+
 		D_ASSERT(chunk->ColumnCount() == ncols);
 		D_ASSERT(chunk->ColumnCount() == (idx_t)Rf_length(retlist));
 		for (size_t col_idx = 0; col_idx < chunk->ColumnCount(); col_idx++) {
@@ -733,17 +752,8 @@ SEXP duckdb_execute_R_impl(MaterializedQueryResult *result) {
 				                            NA_REAL);
 				break;
 			case LogicalTypeId::VARCHAR: {
-				auto src_ptr = FlatVector::GetData<string_t>(chunk->data[col_idx]);
-				auto &mask = FlatVector::Validity(chunk->data[col_idx]);
-				for (size_t row_idx = 0; row_idx < chunk->size(); row_idx++) {
-					if (!mask.RowIsValid(row_idx)) {
-						SET_STRING_ELT(dest, dest_offset + row_idx, NA_STRING);
-					} else {
-						SET_STRING_ELT(
-						    dest, dest_offset + row_idx,
-						    Rf_mkCharLenCE(src_ptr[row_idx].GetDataUnsafe(), src_ptr[row_idx].GetSize(), CE_UTF8));
-					}
-				}
+				auto wrapper = (DuckDBAltrepStringWrapper *)R_ExternalPtrAddr(R_altrep_data1(dest));
+				wrapper->vectors[chunk_idx].Reference(chunk->data[col_idx]);
 				break;
 			}
 			case LogicalTypeId::BLOB: {
@@ -770,6 +780,7 @@ SEXP duckdb_execute_R_impl(MaterializedQueryResult *result) {
 			}
 		}
 		dest_offset += chunk->size();
+		chunk_idx++;
 	}
 
 	D_ASSERT(dest_offset == nrows);
@@ -1120,6 +1131,82 @@ SEXP duckdb_ptr_to_str(SEXP extptr) {
 	return ret;
 }
 
+static DuckDBAltrepStringWrapper *duckdb_altrep_wrapper(SEXP x) {
+	auto wrapper = (DuckDBAltrepStringWrapper *)R_ExternalPtrAddr(R_altrep_data1(x));
+	if (!wrapper) {
+		Rf_error("This looks like it has been freed");
+	}
+	return wrapper;
+}
+
+static Rboolean duckdb_altrep_strings_inspect(SEXP x, int pre, int deep, int pvec,
+                                              void (*inspect_subtree)(SEXP, int, int, int)) {
+	Rprintf("DUCKDB_STR \n");
+	return TRUE;
+}
+
+static R_xlen_t duckdb_altrep_strings_length(SEXP x) {
+	return duckdb_altrep_wrapper(x)->length;
+}
+
+static void *duckdb_altrep_strings_dataptr(SEXP x, Rboolean writeable) {
+	auto *wrapper = duckdb_altrep_wrapper(x);
+	if (R_altrep_data2(x) == R_NilValue) {
+		R_set_altrep_data2(x, NEW_STRING(wrapper->length));
+		idx_t dest_offset = 0;
+		for (auto &vec : wrapper->vectors) {
+			auto src_ptr = FlatVector::GetData<string_t>(vec);
+			auto &mask = FlatVector::Validity(vec);
+			for (size_t row_idx = 0; row_idx < MinValue<idx_t>(STANDARD_VECTOR_SIZE, wrapper->length - dest_offset);
+			     row_idx++) {
+				if (!mask.RowIsValid(row_idx)) {
+					SET_STRING_ELT(R_altrep_data2(x), dest_offset + row_idx, NA_STRING);
+				} else {
+					SET_STRING_ELT(
+					    R_altrep_data2(x), dest_offset + row_idx,
+					    Rf_mkCharLenCE(src_ptr[row_idx].GetDataUnsafe(), src_ptr[row_idx].GetSize(), CE_UTF8));
+				}
+			}
+			dest_offset += STANDARD_VECTOR_SIZE;
+		}
+	}
+	return CHARACTER_POINTER(R_altrep_data2(x));
+}
+
+static const void *duckdb_altrep_strings_dataptr_or_null(SEXP x) {
+	return nullptr;
+}
+
+static SEXP duckdb_altrep_strings_elt(SEXP x, R_xlen_t i) {
+	auto *wrapper = duckdb_altrep_wrapper(x);
+	if (R_altrep_data2(x) != R_NilValue) {
+		return STRING_ELT(R_altrep_data2(x), i);
+	}
+	auto &vec = wrapper->vectors[i / STANDARD_VECTOR_SIZE];
+	auto src_ptr = FlatVector::GetData<string_t>(vec);
+	auto &mask = FlatVector::Validity(vec);
+	auto vec_idx = i % STANDARD_VECTOR_SIZE;
+	if (!mask.RowIsValid(vec_idx)) {
+		return NA_STRING;
+	}
+	return Rf_mkCharLenCE(src_ptr[vec_idx].GetDataUnsafe(), src_ptr[vec_idx].GetSize(), CE_UTF8);
+}
+
+static void duckdb_altrep_strings_set_elt(SEXP x, R_xlen_t i, SEXP val) {
+	duckdb_altrep_strings_dataptr(x, TRUE);
+	SET_STRING_ELT(R_altrep_data2(x), i, val);
+}
+
+static int duckdb_altrep_strings_is_sorted(SEXP x) {
+	// we don't know
+	return 0;
+}
+
+static int duckdb_altrep_strings_no_na(SEXP x) {
+	// we kinda know but it matters little
+	return 0;
+}
+
 // R native routine registration
 #define CALLDEF(name, n)                                                                                               \
 	{ #name, (DL_FUNC)&name, n }
@@ -1140,5 +1227,23 @@ static const R_CallMethodDef R_CallDef[] = {CALLDEF(duckdb_startup_R, 2),
 void R_init_duckdb(DllInfo *dll) {
 	R_registerRoutines(dll, NULL, R_CallDef, NULL, NULL);
 	R_useDynamicSymbols(dll, FALSE);
+
+	duckdb_altrep_string_class = R_make_altstring_class("duckdb_strings", "duckdb", dll);
+
+	/* override ALTREP methods */
+	R_set_altrep_Inspect_method(duckdb_altrep_string_class, duckdb_altrep_strings_inspect);
+	R_set_altrep_Length_method(duckdb_altrep_string_class, duckdb_altrep_strings_length);
+
+	/* override ALTVEC methods */
+	R_set_altvec_Dataptr_method(duckdb_altrep_string_class, duckdb_altrep_strings_dataptr);
+	R_set_altvec_Dataptr_or_null_method(duckdb_altrep_string_class, duckdb_altrep_strings_dataptr_or_null);
+
+	/* override ALTSTRING methods */
+	R_set_altstring_Elt_method(duckdb_altrep_string_class, duckdb_altrep_strings_elt);
+	R_set_altstring_Is_sorted_method(duckdb_altrep_string_class, duckdb_altrep_strings_is_sorted);
+	R_set_altstring_No_NA_method(duckdb_altrep_string_class, duckdb_altrep_strings_no_na);
+	R_set_altstring_Set_elt_method(duckdb_altrep_string_class, duckdb_altrep_strings_set_elt);
+
+	// TODO implement SEXP (*R_altvec_Extract_subset_method_t)(SEXP, SEXP, SEXP);
 }
 }


### PR DESCRIPTION
Since version 3.5.0 R provides the `ALTREP` framework to allow lazy vector representations. With this PR, we implement lazy String vectors for DuckDB query results in R. This defers conversion from DuckDB's internal `string_t` string type to R's `CHARSXP` to whenever the result column is actually accessed. Since "whenever" is often "never" or "only partial", this can save quite a bit of effort, especially given that R maintains a global hash table for strings. See below for a simple benchmark.