### PR TITLE
Add table functions that take a subquery parameter

### DIFF
--- a/extension/parquet/parquet-extension.cpp
+++ b/extension/parquet/parquet-extension.cpp
@@ -134,6 +134,8 @@ public:
 
 	static unique_ptr<FunctionData> ParquetScanBind(ClientContext &context, vector<Value> &inputs,
 	                                                unordered_map<string, Value> &named_parameters,
+	                                                vector<LogicalType> &input_table_types,
+	                                                vector<string> &input_table_names,
 	                                                vector<LogicalType> &return_types, vector<string> &names) {
 		auto file_name = inputs[0].GetValue<string>();
 		auto result = make_unique<ParquetReadBindData>();
@@ -198,7 +200,7 @@ public:
 	}
 
 	static void ParquetScanImplementation(ClientContext &context, const FunctionData *bind_data_p,
-	                                      FunctionOperatorData *operator_state, DataChunk &output) {
+	                                      FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
 		auto &data = (ParquetReadOperatorData &)*operator_state;
 		auto &bind_data = (ParquetReadBindData &)*bind_data_p;
 

--- a/extension/tpch/tpch-extension.cpp
+++ b/extension/tpch/tpch-extension.cpp
@@ -26,6 +26,7 @@ struct DBGenFunctionData : public TableFunctionData {
 
 static unique_ptr<FunctionData> dbgen_bind(ClientContext &context, vector<Value> &inputs,
                                            unordered_map<string, Value> &named_parameters,
+                                           vector<LogicalType> &input_table_types, vector<string> &input_table_names,
                                            vector<LogicalType> &return_types, vector<string> &names) {
 	auto result = make_unique<DBGenFunctionData>();
 	for (auto &kv : named_parameters) {
@@ -45,7 +46,7 @@ static unique_ptr<FunctionData> dbgen_bind(ClientContext &context, vector<Value>
 }
 
 static void dbgen_function(ClientContext &context, const FunctionData *bind_data, FunctionOperatorData *operator_state,
-                           DataChunk &output) {
+                           DataChunk *input, DataChunk &output) {
 	auto &data = (DBGenFunctionData &)*bind_data;
 	if (data.finished) {
 		return;

--- a/src/common/enums/physical_operator_type.cpp
+++ b/src/common/enums/physical_operator_type.cpp
@@ -118,6 +118,8 @@ string PhysicalOperatorToString(PhysicalOperatorType type) {
 		return "EXPORT";
 	case PhysicalOperatorType::SET:
 		return "SET";
+	case PhysicalOperatorType::INOUT_FUNCTION:
+		return "INOUT_FUNCTION";
 	}
 	return "UNDEFINED";
 }

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -98,6 +98,7 @@ PhysicalType LogicalType::GetInternalType() {
 		return PhysicalType::HASH;
 	case LogicalTypeId::POINTER:
 		return PhysicalType::POINTER;
+	case LogicalTypeId::TABLE:
 	case LogicalTypeId::ANY:
 	case LogicalTypeId::INVALID:
 	case LogicalTypeId::UNKNOWN:
@@ -137,6 +138,7 @@ const LogicalType LogicalType::INTERVAL = LogicalType(LogicalTypeId::INTERVAL);
 const LogicalType LogicalType::STRUCT = LogicalType(LogicalTypeId::STRUCT);
 const LogicalType LogicalType::LIST = LogicalType(LogicalTypeId::LIST);
 const LogicalType LogicalType::MAP = LogicalType(LogicalTypeId::MAP);
+const LogicalType LogicalType::TABLE = LogicalType(LogicalTypeId::TABLE);
 
 const LogicalType LogicalType::ANY = LogicalType(LogicalTypeId::ANY);
 
@@ -351,6 +353,8 @@ string LogicalTypeIdToString(LogicalTypeId id) {
 		return "HASH";
 	case LogicalTypeId::POINTER:
 		return "POINTER";
+	case LogicalTypeId::TABLE:
+		return "TABLE";
 	case LogicalTypeId::INVALID:
 		return "INVALID";
 	case LogicalTypeId::UNKNOWN:

--- a/src/execution/operator/projection/CMakeLists.txt
+++ b/src/execution/operator/projection/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library_unity(duckdb_operator_projection OBJECT physical_projection.cpp
-                  physical_unnest.cpp)
+                  physical_tableinout_function.cpp physical_unnest.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_operator_projection>
     PARENT_SCOPE)

--- a/src/execution/operator/projection/physical_tableinout_function.cpp
+++ b/src/execution/operator/projection/physical_tableinout_function.cpp
@@ -18,8 +18,8 @@ public:
 PhysicalTableInOutFunction::PhysicalTableInOutFunction(vector<LogicalType> types, TableFunction function_p,
                                                        unique_ptr<FunctionData> bind_data_p,
                                                        vector<column_t> column_ids_p, idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::INOUT_FUNCTION, move(types), estimated_cardinality), function(function_p),
-      bind_data(move(bind_data_p)), column_ids(move(column_ids_p)) {
+    : PhysicalOperator(PhysicalOperatorType::INOUT_FUNCTION, move(types), estimated_cardinality),
+      function(move(function_p)), bind_data(move(bind_data_p)), column_ids(move(column_ids_p)) {
 }
 
 void PhysicalTableInOutFunction::GetChunkInternal(ExecutionContext &context, DataChunk &chunk,

--- a/src/execution/operator/projection/physical_tableinout_function.cpp
+++ b/src/execution/operator/projection/physical_tableinout_function.cpp
@@ -1,0 +1,49 @@
+#include "duckdb/execution/operator/projection/physical_tableinout_function.hpp"
+
+namespace duckdb {
+
+class PhysicalTableInOutFunctionState : public PhysicalOperatorState {
+public:
+	PhysicalTableInOutFunctionState(PhysicalOperator &op, PhysicalOperator *child) : PhysicalOperatorState(op, child) {
+		D_ASSERT(child);
+	}
+
+	unique_ptr<PhysicalOperatorState> child_state;
+	DataChunk child_chunk;
+	unique_ptr<FunctionOperatorData> operator_data;
+	bool initialized;
+};
+
+// this implements a sorted window functions variant
+PhysicalTableInOutFunction::PhysicalTableInOutFunction(vector<LogicalType> types, TableFunction function_p,
+                                                       unique_ptr<FunctionData> bind_data_p,
+                                                       vector<column_t> column_ids_p, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::INOUT_FUNCTION, move(types), estimated_cardinality), function(function_p),
+      bind_data(move(bind_data_p)), column_ids(move(column_ids_p)) {
+}
+
+void PhysicalTableInOutFunction::GetChunkInternal(ExecutionContext &context, DataChunk &chunk,
+                                                  PhysicalOperatorState *state_p) {
+	auto &state = (PhysicalTableInOutFunctionState &)*state_p;
+
+	if (!state.initialized) {
+		if (function.init) {
+			state.operator_data = function.init(context.client, bind_data.get(), column_ids, nullptr);
+		}
+		state.initialized = true;
+	}
+
+	D_ASSERT(children.size() == 1);
+	children[0]->GetChunkInternal(context, state.child_chunk, state.child_state.get());
+	function.function(context.client, bind_data.get(), state.operator_data.get(), &state.child_chunk, chunk);
+}
+
+unique_ptr<PhysicalOperatorState> PhysicalTableInOutFunction::GetOperatorState() {
+	auto state = make_unique<PhysicalTableInOutFunctionState>(*this, children[0].get());
+	state->child_chunk.Initialize(children[0]->GetTypes());
+	state->child_state = children[0]->GetOperatorState();
+
+	return move(state);
+}
+
+} // namespace duckdb

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -62,14 +62,15 @@ void PhysicalTableScan::GetChunkInternal(ExecutionContext &context, DataChunk &c
 	}
 	if (!state.parallel_state) {
 		// sequential scan
-		function.function(context.client, bind_data.get(), state.operator_data.get(), chunk);
+		function.function(context.client, bind_data.get(), state.operator_data.get(), nullptr, chunk);
 		if (chunk.size() != 0) {
 			return;
 		}
 	} else {
+		D_ASSERT(false); // TODO
 		// parallel scan
 		do {
-			function.function(context.client, bind_data.get(), state.operator_data.get(), chunk);
+			function.function(context.client, bind_data.get(), state.operator_data.get(), nullptr, chunk);
 			if (chunk.size() == 0) {
 				D_ASSERT(function.parallel_state_next);
 				if (function.parallel_state_next(context.client, bind_data.get(), state.operator_data.get(),

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -67,7 +67,6 @@ void PhysicalTableScan::GetChunkInternal(ExecutionContext &context, DataChunk &c
 			return;
 		}
 	} else {
-		D_ASSERT(false); // TODO
 		// parallel scan
 		do {
 			function.function(context.client, bind_data.get(), state.operator_data.get(), nullptr, chunk);

--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -42,7 +42,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 		auto node = make_unique<PhysicalTableInOutFunction>(op.returned_types, op.function, move(op.bind_data),
 		                                                    op.column_ids, op.estimated_cardinality);
 		node->children.push_back(CreatePlan(move(op.children[0])));
-		return node;
+		return move(node);
 	}
 
 	unique_ptr<TableFilterSet> table_filters;

--- a/src/function/table/CMakeLists.txt
+++ b/src/function/table/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library_unity(
   copy_csv.cpp
   read_csv.cpp
   sqlite_functions.cpp
+  summary.cpp
   information_schema_functions.cpp
   table_scan.cpp
   pragma_last_profiling_output.cpp

--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -55,6 +55,7 @@ struct ArrowScanFunctionData : public TableFunctionData {
 
 static unique_ptr<FunctionData> ArrowScanBind(ClientContext &context, vector<Value> &inputs,
                                               unordered_map<string, Value> &named_parameters,
+                                              vector<LogicalType> &input_table_types, vector<string> &input_table_names,
                                               vector<LogicalType> &return_types, vector<string> &names) {
 
 	auto res = make_unique<ArrowScanFunctionData>();
@@ -145,7 +146,7 @@ static unique_ptr<FunctionOperatorData> ArrowScanInit(ClientContext &context, co
 }
 
 static void ArrowScanFunction(ClientContext &context, const FunctionData *bind_data,
-                              FunctionOperatorData *operator_state, DataChunk &output) {
+                              FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
 	auto &data = (ArrowScanFunctionData &)*bind_data;
 	if (!data.stream->release) {
 		// no more chunks

--- a/src/function/table/checkpoint.cpp
+++ b/src/function/table/checkpoint.cpp
@@ -7,7 +7,9 @@ namespace duckdb {
 
 static unique_ptr<FunctionData> CheckpointBind(ClientContext &context, vector<Value> &inputs,
                                                unordered_map<string, Value> &named_parameters,
-                                               vector<LogicalType> &return_types, vector<string> &names) {
+                                               vector<LogicalType> &input_table_types,
+                                               vector<string> &input_table_names, vector<LogicalType> &return_types,
+                                               vector<string> &names) {
 	return_types.push_back(LogicalType::BOOLEAN);
 	names.emplace_back("Success");
 	return nullptr;
@@ -15,7 +17,7 @@ static unique_ptr<FunctionData> CheckpointBind(ClientContext &context, vector<Va
 
 template <bool FORCE>
 static void TemplatedCheckpointFunction(ClientContext &context, const FunctionData *bind_data_p,
-                                        FunctionOperatorData *operator_state, DataChunk &output) {
+                                        FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
 	auto &transaction_manager = TransactionManager::Get(context);
 	transaction_manager.Checkpoint(context, FORCE);
 }

--- a/src/function/table/glob.cpp
+++ b/src/function/table/glob.cpp
@@ -11,7 +11,9 @@ struct GlobFunctionBindData : public TableFunctionData {
 
 static unique_ptr<FunctionData> GlobFunctionBind(ClientContext &context, vector<Value> &inputs,
                                                  unordered_map<string, Value> &named_parameters,
-                                                 vector<LogicalType> &return_types, vector<string> &names) {
+                                                 vector<LogicalType> &input_table_types,
+                                                 vector<string> &input_table_names, vector<LogicalType> &return_types,
+                                                 vector<string> &names) {
 	auto result = make_unique<GlobFunctionBindData>();
 	auto &fs = FileSystem::GetFileSystem(context);
 	result->files = fs.Glob(inputs[0].str_value);
@@ -33,7 +35,7 @@ static unique_ptr<FunctionOperatorData> GlobFunctionInit(ClientContext &context,
 }
 
 static void GlobFunction(ClientContext &context, const FunctionData *bind_data_p, FunctionOperatorData *state_p,
-                         DataChunk &output) {
+                         DataChunk *input, DataChunk &output) {
 	auto &bind_data = (GlobFunctionBindData &)*bind_data_p;
 	auto &state = (GlobFunctionState &)*state_p;
 

--- a/src/function/table/information_schema/information_schema_columns.cpp
+++ b/src/function/table/information_schema/information_schema_columns.cpp
@@ -22,6 +22,8 @@ struct InformationSchemaColumnsData : public FunctionOperatorData {
 
 static unique_ptr<FunctionData> InformationSchemaColumnsBind(ClientContext &context, vector<Value> &inputs,
                                                              unordered_map<string, Value> &named_parameters,
+                                                             vector<LogicalType> &input_table_types,
+                                                             vector<string> &input_table_names,
                                                              vector<LogicalType> &return_types, vector<string> &names) {
 	names.emplace_back("table_catalog");
 	return_types.push_back(LogicalType::VARCHAR);
@@ -275,7 +277,7 @@ void ColumnHelper::WriteColumns(idx_t start_index, idx_t start_col, idx_t end_co
 } // anonymous namespace
 
 void InformationSchemaColumnsFunction(ClientContext &context, const FunctionData *bind_data,
-                                      FunctionOperatorData *operator_state, DataChunk &output) {
+                                      FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
 	auto &data = (InformationSchemaColumnsData &)*operator_state;
 	if (data.offset >= data.entries.size()) {
 		// finished returning values

--- a/src/function/table/information_schema/information_schema_schemata.cpp
+++ b/src/function/table/information_schema/information_schema_schemata.cpp
@@ -17,6 +17,8 @@ struct InformationSchemaSchemataData : public FunctionOperatorData {
 
 static unique_ptr<FunctionData> InformationSchemaSchemataBind(ClientContext &context, vector<Value> &inputs,
                                                               unordered_map<string, Value> &named_parameters,
+                                                              vector<LogicalType> &input_table_types,
+                                                              vector<string> &input_table_names,
                                                               vector<LogicalType> &return_types,
                                                               vector<string> &names) {
 	names.emplace_back("catalog_name");
@@ -58,7 +60,7 @@ unique_ptr<FunctionOperatorData> InformationSchemaSchemataInit(ClientContext &co
 }
 
 void InformationSchemaSchemataFunction(ClientContext &context, const FunctionData *bind_data,
-                                       FunctionOperatorData *operator_state, DataChunk &output) {
+                                       FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
 	auto &data = (InformationSchemaSchemataData &)*operator_state;
 	if (data.offset >= data.entries.size()) {
 		// finished returning values

--- a/src/function/table/information_schema/information_schema_tables.cpp
+++ b/src/function/table/information_schema/information_schema_tables.cpp
@@ -18,6 +18,8 @@ struct InformationSchemaTablesData : public FunctionOperatorData {
 
 static unique_ptr<FunctionData> InformationSchemaTablesBind(ClientContext &context, vector<Value> &inputs,
                                                             unordered_map<string, Value> &named_parameters,
+                                                            vector<LogicalType> &input_table_types,
+                                                            vector<string> &input_table_names,
                                                             vector<LogicalType> &return_types, vector<string> &names) {
 	names.emplace_back("table_catalog");
 	return_types.push_back(LogicalType::VARCHAR);
@@ -76,7 +78,7 @@ unique_ptr<FunctionOperatorData> InformationSchemaTablesInit(ClientContext &cont
 }
 
 void InformationSchemaTablesFunction(ClientContext &context, const FunctionData *bind_data,
-                                     FunctionOperatorData *operator_state, DataChunk &output) {
+                                     FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
 	auto &data = (InformationSchemaTablesData &)*operator_state;
 	if (data.offset >= data.entries.size()) {
 		// finished returning values

--- a/src/function/table/pragma_detailed_profiling_output.cpp
+++ b/src/function/table/pragma_detailed_profiling_output.cpp
@@ -25,6 +25,8 @@ struct PragmaDetailedProfilingOutputData : public TableFunctionData {
 
 static unique_ptr<FunctionData> PragmaDetailedProfilingOutputBind(ClientContext &context, vector<Value> &inputs,
                                                                   unordered_map<string, Value> &named_parameters,
+                                                                  vector<LogicalType> &input_table_types,
+                                                                  vector<string> &input_table_names,
                                                                   vector<LogicalType> &return_types,
                                                                   vector<string> &names) {
 	names.emplace_back("OPERATOR_ID");
@@ -76,7 +78,8 @@ static void ExtractExpressions(ChunkCollection &collection, ExpressionInformatio
 }
 
 static void PragmaDetailedProfilingOutputFunction(ClientContext &context, const FunctionData *bind_data_p,
-                                                  FunctionOperatorData *operator_state, DataChunk &output) {
+                                                  FunctionOperatorData *operator_state, DataChunk *input,
+                                                  DataChunk &output) {
 	auto &state = (PragmaDetailedProfilingOutputOperatorData &)*operator_state;
 	auto &data = (PragmaDetailedProfilingOutputData &)*bind_data_p;
 	if (!state.initialized) {

--- a/src/function/table/pragma_last_profiling_output.cpp
+++ b/src/function/table/pragma_last_profiling_output.cpp
@@ -23,6 +23,8 @@ struct PragmaLastProfilingOutputData : public TableFunctionData {
 
 static unique_ptr<FunctionData> PragmaLastProfilingOutputBind(ClientContext &context, vector<Value> &inputs,
                                                               unordered_map<string, Value> &named_parameters,
+                                                              vector<LogicalType> &input_table_types,
+                                                              vector<string> &input_table_names,
                                                               vector<LogicalType> &return_types,
                                                               vector<string> &names) {
 	names.emplace_back("OPERATOR_ID");
@@ -59,7 +61,8 @@ unique_ptr<FunctionOperatorData> PragmaLastProfilingOutputInit(ClientContext &co
 }
 
 static void PragmaLastProfilingOutputFunction(ClientContext &context, const FunctionData *bind_data_p,
-                                              FunctionOperatorData *operator_state, DataChunk &output) {
+                                              FunctionOperatorData *operator_state, DataChunk *input,
+                                              DataChunk &output) {
 	auto &state = (PragmaLastProfilingOutputOperatorData &)*operator_state;
 	auto &data = (PragmaLastProfilingOutputData &)*bind_data_p;
 	if (!state.initialized) {

--- a/src/function/table/range.cpp
+++ b/src/function/table/range.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/function/table/range.hpp"
+#include "duckdb/function/table/summary.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/function/function_set.hpp"
 #include "duckdb/common/algorithm.hpp"
@@ -12,9 +13,10 @@ struct RangeFunctionBindData : public TableFunctionData {
 };
 
 template <bool GENERATE_SERIES>
-static unique_ptr<FunctionData> RangeFunctionBind(ClientContext &context, vector<Value> &inputs,
-                                                  unordered_map<string, Value> &named_parameters,
-                                                  vector<LogicalType> &return_types, vector<string> &names) {
+static unique_ptr<FunctionData>
+RangeFunctionBind(ClientContext &context, vector<Value> &inputs, unordered_map<string, Value> &named_parameters,
+                  vector<LogicalType> &input_table_types, vector<string> &input_table_names,
+                  vector<LogicalType> &return_types, vector<string> &names) {
 	auto result = make_unique<RangeFunctionBindData>();
 	if (inputs.size() < 2) {
 		// single argument: only the end is specified
@@ -67,7 +69,7 @@ static unique_ptr<FunctionOperatorData> RangeFunctionInit(ClientContext &context
 }
 
 static void RangeFunction(ClientContext &context, const FunctionData *bind_data_p, FunctionOperatorData *state_p,
-                          DataChunk &output) {
+                          DataChunk *input, DataChunk &output) {
 	auto &bind_data = (RangeFunctionBindData &)*bind_data_p;
 	auto &state = (RangeFunctionState &)*state_p;
 
@@ -120,6 +122,7 @@ void BuiltinFunctions::RegisterTableFunctions() {
 	GlobTableFunction::RegisterFunction(*this);
 	RangeTableFunction::RegisterFunction(*this);
 	RepeatTableFunction::RegisterFunction(*this);
+	SummaryTableFunction::RegisterFunction(*this);
 }
 
 } // namespace duckdb

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -16,6 +16,7 @@ namespace duckdb {
 
 static unique_ptr<FunctionData> ReadCSVBind(ClientContext &context, vector<Value> &inputs,
                                             unordered_map<string, Value> &named_parameters,
+                                            vector<LogicalType> &input_table_types, vector<string> &input_table_names,
                                             vector<LogicalType> &return_types, vector<string> &names) {
 	auto result = make_unique<ReadCSVData>();
 	auto &options = result->options;
@@ -163,13 +164,15 @@ static unique_ptr<FunctionOperatorData> ReadCSVInit(ClientContext &context, cons
 
 static unique_ptr<FunctionData> ReadCSVAutoBind(ClientContext &context, vector<Value> &inputs,
                                                 unordered_map<string, Value> &named_parameters,
-                                                vector<LogicalType> &return_types, vector<string> &names) {
+                                                vector<LogicalType> &input_table_types,
+                                                vector<string> &input_table_names, vector<LogicalType> &return_types,
+                                                vector<string> &names) {
 	named_parameters["auto_detect"] = Value::BOOLEAN(true);
-	return ReadCSVBind(context, inputs, named_parameters, return_types, names);
+	return ReadCSVBind(context, inputs, named_parameters, input_table_types, input_table_names, return_types, names);
 }
 
 static void ReadCSVFunction(ClientContext &context, const FunctionData *bind_data_p,
-                            FunctionOperatorData *operator_state, DataChunk &output) {
+                            FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
 	auto &bind_data = (ReadCSVData &)*bind_data_p;
 	auto &data = (ReadCSVOperatorData &)*operator_state;
 	do {

--- a/src/function/table/repeat.cpp
+++ b/src/function/table/repeat.cpp
@@ -19,6 +19,7 @@ struct RepeatOperatorData : public FunctionOperatorData {
 
 static unique_ptr<FunctionData> RepeatBind(ClientContext &context, vector<Value> &inputs,
                                            unordered_map<string, Value> &named_parameters,
+                                           vector<LogicalType> &input_table_types, vector<string> &input_table_names,
                                            vector<LogicalType> &return_types, vector<string> &names) {
 	// the repeat function returns the type of the first argument
 	return_types.push_back(inputs[0].type());
@@ -32,7 +33,7 @@ static unique_ptr<FunctionOperatorData> RepeatInit(ClientContext &context, const
 }
 
 static void RepeatFunction(ClientContext &context, const FunctionData *bind_data_p,
-                           FunctionOperatorData *operator_state, DataChunk &output) {
+                           FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
 	auto &bind_data = (RepeatFunctionData &)*bind_data_p;
 	auto &state = (RepeatOperatorData &)*operator_state;
 

--- a/src/function/table/sqlite/pragma_collations.cpp
+++ b/src/function/table/sqlite/pragma_collations.cpp
@@ -17,7 +17,9 @@ struct PragmaCollateData : public FunctionOperatorData {
 
 static unique_ptr<FunctionData> PragmaCollateBind(ClientContext &context, vector<Value> &inputs,
                                                   unordered_map<string, Value> &named_parameters,
-                                                  vector<LogicalType> &return_types, vector<string> &names) {
+                                                  vector<LogicalType> &input_table_types,
+                                                  vector<string> &input_table_names, vector<LogicalType> &return_types,
+                                                  vector<string> &names) {
 	names.emplace_back("collname");
 	return_types.push_back(LogicalType::VARCHAR);
 
@@ -38,7 +40,7 @@ unique_ptr<FunctionOperatorData> PragmaCollateInit(ClientContext &context, const
 }
 
 static void PragmaCollateFunction(ClientContext &context, const FunctionData *bind_data,
-                                  FunctionOperatorData *operator_state, DataChunk &output) {
+                                  FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
 	auto &data = (PragmaCollateData &)*operator_state;
 	if (data.offset >= data.entries.size()) {
 		// finished returning values

--- a/src/function/table/sqlite/pragma_database_list.cpp
+++ b/src/function/table/sqlite/pragma_database_list.cpp
@@ -13,6 +13,8 @@ struct PragmaDatabaseListData : public FunctionOperatorData {
 
 static unique_ptr<FunctionData> PragmaDatabaseListBind(ClientContext &context, vector<Value> &inputs,
                                                        unordered_map<string, Value> &named_parameters,
+                                                       vector<LogicalType> &input_table_types,
+                                                       vector<string> &input_table_names,
                                                        vector<LogicalType> &return_types, vector<string> &names) {
 	names.emplace_back("seq");
 	return_types.push_back(LogicalType::INTEGER);
@@ -32,7 +34,7 @@ unique_ptr<FunctionOperatorData> PragmaDatabaseListInit(ClientContext &context, 
 }
 
 void PragmaDatabaseListFunction(ClientContext &context, const FunctionData *bind_data,
-                                FunctionOperatorData *operator_state, DataChunk &output) {
+                                FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
 	auto &data = (PragmaDatabaseListData &)*operator_state;
 	if (data.finished) {
 		return;

--- a/src/function/table/sqlite/pragma_database_size.cpp
+++ b/src/function/table/sqlite/pragma_database_size.cpp
@@ -16,6 +16,8 @@ struct PragmaDatabaseSizeData : public FunctionOperatorData {
 
 static unique_ptr<FunctionData> PragmaDatabaseSizeBind(ClientContext &context, vector<Value> &inputs,
                                                        unordered_map<string, Value> &named_parameters,
+                                                       vector<LogicalType> &input_table_types,
+                                                       vector<string> &input_table_names,
                                                        vector<LogicalType> &return_types, vector<string> &names) {
 	names.emplace_back("database_size");
 	return_types.push_back(LogicalType::VARCHAR);
@@ -72,7 +74,7 @@ static string BytesToHumanReadableString(idx_t bytes) {
 }
 
 void PragmaDatabaseSizeFunction(ClientContext &context, const FunctionData *bind_data,
-                                FunctionOperatorData *operator_state, DataChunk &output) {
+                                FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
 	auto &data = (PragmaDatabaseSizeData &)*operator_state;
 	if (data.finished) {
 		return;

--- a/src/function/table/sqlite/pragma_functions.cpp
+++ b/src/function/table/sqlite/pragma_functions.cpp
@@ -20,6 +20,8 @@ struct PragmaFunctionsData : public FunctionOperatorData {
 
 static unique_ptr<FunctionData> PragmaFunctionsBind(ClientContext &context, vector<Value> &inputs,
                                                     unordered_map<string, Value> &named_parameters,
+                                                    vector<LogicalType> &input_table_types,
+                                                    vector<string> &input_table_names,
                                                     vector<LogicalType> &return_types, vector<string> &names) {
 	names.emplace_back("name");
 	return_types.push_back(LogicalType::VARCHAR);
@@ -79,7 +81,7 @@ void AddFunction(BaseScalarFunction &f, idx_t &count, DataChunk &output, bool is
 }
 
 static void PragmaFunctionsFunction(ClientContext &context, const FunctionData *bind_data,
-                                    FunctionOperatorData *operator_state, DataChunk &output) {
+                                    FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
 	auto &data = (PragmaFunctionsData &)*operator_state;
 	if (data.offset >= data.entries.size()) {
 		// finished returning values

--- a/src/function/table/sqlite/pragma_table_info.cpp
+++ b/src/function/table/sqlite/pragma_table_info.cpp
@@ -29,6 +29,8 @@ struct PragmaTableOperatorData : public FunctionOperatorData {
 
 static unique_ptr<FunctionData> PragmaTableInfoBind(ClientContext &context, vector<Value> &inputs,
                                                     unordered_map<string, Value> &named_parameters,
+                                                    vector<LogicalType> &input_table_types,
+                                                    vector<string> &input_table_names,
                                                     vector<LogicalType> &return_types, vector<string> &names) {
 	names.emplace_back("cid");
 	return_types.push_back(LogicalType::INTEGER);
@@ -156,7 +158,7 @@ static void PragmaTableInfoView(PragmaTableOperatorData &data, ViewCatalogEntry 
 }
 
 static void PragmaTableInfoFunction(ClientContext &context, const FunctionData *bind_data_p,
-                                    FunctionOperatorData *operator_state, DataChunk &output) {
+                                    FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
 	auto &bind_data = (PragmaTableFunctionData &)*bind_data_p;
 	auto &state = (PragmaTableOperatorData &)*operator_state;
 	switch (bind_data.entry->type) {

--- a/src/function/table/sqlite/sqlite_master.cpp
+++ b/src/function/table/sqlite/sqlite_master.cpp
@@ -21,7 +21,9 @@ struct SQLiteMasterData : public FunctionOperatorData {
 
 static unique_ptr<FunctionData> SQLiteMasterBind(ClientContext &context, vector<Value> &inputs,
                                                  unordered_map<string, Value> &named_parameters,
-                                                 vector<LogicalType> &return_types, vector<string> &names) {
+                                                 vector<LogicalType> &input_table_types,
+                                                 vector<string> &input_table_names, vector<LogicalType> &return_types,
+                                                 vector<string> &names) {
 	names.emplace_back("type");
 	return_types.push_back(LogicalType::VARCHAR);
 
@@ -55,7 +57,7 @@ unique_ptr<FunctionOperatorData> SQLiteMasterInit(ClientContext &context, const 
 }
 
 void SQLiteMasterFunction(ClientContext &context, const FunctionData *bind_data, FunctionOperatorData *operator_state,
-                          DataChunk &output) {
+                          DataChunk *input, DataChunk &output) {
 	auto &data = (SQLiteMasterData &)*operator_state;
 	if (data.offset >= data.entries.size()) {
 		// finished returning values

--- a/src/function/table/summary.cpp
+++ b/src/function/table/summary.cpp
@@ -14,11 +14,11 @@ static unique_ptr<FunctionData> SummaryFunctionBind(ClientContext &context, vect
                                                     vector<LogicalType> &return_types, vector<string> &names) {
 
 	return_types.push_back(LogicalType::VARCHAR);
-	names.push_back("summary");
+	names.emplace_back("summary");
 
 	for (idx_t i = 0; i < input_table_types.size(); i++) {
 		return_types.push_back(input_table_types[i]);
-		names.push_back(input_table_names[i]);
+		names.emplace_back(input_table_names[i]);
 	}
 
 	return make_unique<TableFunctionData>();

--- a/src/function/table/summary.cpp
+++ b/src/function/table/summary.cpp
@@ -1,0 +1,55 @@
+#include "duckdb/function/table/summary.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/common/file_system.hpp"
+
+// this function makes not that much sense on its own but is a demo for table-parameter table-producing functions
+
+namespace duckdb {
+
+static unique_ptr<FunctionData> SummaryFunctionBind(ClientContext &context, vector<Value> &inputs,
+                                                    unordered_map<string, Value> &named_parameters,
+                                                    vector<LogicalType> &input_table_types,
+                                                    vector<string> &input_table_names,
+                                                    vector<LogicalType> &return_types, vector<string> &names) {
+
+	return_types.push_back(LogicalType::VARCHAR);
+	names.push_back("summary");
+
+	for (idx_t i = 0; i < input_table_types.size(); i++) {
+		return_types.push_back(input_table_types[i]);
+		names.push_back(input_table_names[i]);
+	}
+
+	return make_unique<TableFunctionData>();
+}
+
+static void SummaryFunction(ClientContext &context, const FunctionData *bind_data_p, FunctionOperatorData *state_p,
+                            DataChunk *input, DataChunk &output) {
+	D_ASSERT(input);
+	output.SetCardinality(input->size());
+
+	for (idx_t row_idx = 0; row_idx < input->size(); row_idx++) {
+		string summary_val = "[";
+
+		for (idx_t col_idx = 0; col_idx < input->ColumnCount(); col_idx++) {
+			summary_val += input->GetValue(col_idx, row_idx).ToString();
+			if (col_idx < input->ColumnCount() - 1) {
+				summary_val += ", ";
+			}
+		}
+		summary_val += "]";
+		output.SetValue(0, row_idx, Value(summary_val));
+	}
+	for (idx_t col_idx = 0; col_idx < input->ColumnCount(); col_idx++) {
+		output.data[col_idx + 1].Reference(input->data[col_idx]);
+	}
+}
+
+void SummaryTableFunction::RegisterFunction(BuiltinFunctions &set) {
+	TableFunctionSet summary("summary");
+	summary.AddFunction(TableFunction({LogicalType::TABLE}, SummaryFunction, SummaryFunctionBind));
+	set.AddFunction(summary);
+}
+
+} // namespace duckdb

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -65,7 +65,7 @@ static unique_ptr<FunctionOperatorData> TableScanParallelInit(ClientContext &con
 }
 
 static void TableScanFunc(ClientContext &context, const FunctionData *bind_data_p, FunctionOperatorData *operator_state,
-                          DataChunk &output) {
+                          DataChunk *, DataChunk &output) {
 	auto &bind_data = (TableScanBindData &)*bind_data_p;
 	auto &state = (TableScanOperatorData &)*operator_state;
 	auto &transaction = Transaction::GetTransaction(context);
@@ -159,7 +159,7 @@ static unique_ptr<FunctionOperatorData> IndexScanInit(ClientContext &context, co
 }
 
 static void IndexScanFunction(ClientContext &context, const FunctionData *bind_data_p,
-                              FunctionOperatorData *operator_state, DataChunk &output) {
+                              FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
 	auto &bind_data = (const TableScanBindData &)*bind_data_p;
 	auto &state = (IndexScanOperatorData &)*operator_state;
 	auto &transaction = Transaction::GetTransaction(context);

--- a/src/function/table/version/pragma_version.cpp
+++ b/src/function/table/version/pragma_version.cpp
@@ -11,7 +11,9 @@ struct PragmaVersionData : public FunctionOperatorData {
 
 static unique_ptr<FunctionData> PragmaVersionBind(ClientContext &context, vector<Value> &inputs,
                                                   unordered_map<string, Value> &named_parameters,
-                                                  vector<LogicalType> &return_types, vector<string> &names) {
+                                                  vector<LogicalType> &input_table_types,
+                                                  vector<string> &input_table_names, vector<LogicalType> &return_types,
+                                                  vector<string> &names) {
 	names.emplace_back("library_version");
 	return_types.push_back(LogicalType::VARCHAR);
 	names.emplace_back("source_id");
@@ -26,7 +28,7 @@ static unique_ptr<FunctionOperatorData> PragmaVersionInit(ClientContext &context
 }
 
 static void PragmaVersionFunction(ClientContext &context, const FunctionData *bind_data,
-                                  FunctionOperatorData *operator_state, DataChunk &output) {
+                                  FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
 	auto &data = (PragmaVersionData &)*operator_state;
 	if (data.finished) {
 		// finished returning values

--- a/src/include/duckdb/common/enums/physical_operator_type.hpp
+++ b/src/include/duckdb/common/enums/physical_operator_type.hpp
@@ -93,6 +93,7 @@ enum class PhysicalOperatorType : uint8_t {
 	PREPARE,
 	VACUUM,
 	EXPORT,
+	INOUT_FUNCTION,
 	SET
 };
 

--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -256,7 +256,8 @@ enum class LogicalTypeId : uint8_t {
 
 	STRUCT = 100,
 	LIST = 101,
-	MAP = 102
+	MAP = 102,
+	TABLE = 103
 };
 
 struct LogicalType {
@@ -351,6 +352,7 @@ public:
 	static const LogicalType HUGEINT;
 	static const LogicalType HASH;
 	static const LogicalType POINTER;
+	static const LogicalType TABLE;
 	static const LogicalType INVALID;
 
 	//! A list of all NUMERIC types (integral and floating point types)

--- a/src/include/duckdb/execution/operator/projection/physical_tableinout_function.hpp
+++ b/src/include/duckdb/execution/operator/projection/physical_tableinout_function.hpp
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/operator/projection/physical_unnest.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/execution/physical_operator.hpp"
+#include "duckdb/function/function.hpp"
+#include "duckdb/function/table_function.hpp"
+
+namespace duckdb {
+
+//! PhysicalWindow implements window functions
+class PhysicalTableInOutFunction : public PhysicalOperator {
+public:
+	PhysicalTableInOutFunction(vector<LogicalType> types, TableFunction function_p,
+	                           unique_ptr<FunctionData> bind_data_p, vector<column_t> column_ids_p,
+	                           idx_t estimated_cardinality);
+
+	void GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state) override;
+
+public:
+	unique_ptr<PhysicalOperatorState> GetOperatorState() override;
+
+private:
+	//! The table function
+	TableFunction function;
+	//! Bind data of the function
+	unique_ptr<FunctionData> bind_data;
+
+	vector<column_t> column_ids;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/function/table/list.hpp
+++ b/src/include/duckdb/function/table/list.hpp
@@ -1,3 +1,4 @@
 #include "duckdb/function/table/read_csv.hpp"
 #include "duckdb/function/table/sqlite_functions.hpp"
 #include "duckdb/function/table/range.hpp"
+#include "duckdb/function/table/summary.hpp"

--- a/src/include/duckdb/function/table/summary.hpp
+++ b/src/include/duckdb/function/table/summary.hpp
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/function/table/summary.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/function/table_function.hpp"
+
+namespace duckdb {
+
+struct SummaryTableFunction {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -33,6 +33,8 @@ struct TableFilterCollection {
 
 typedef unique_ptr<FunctionData> (*table_function_bind_t)(ClientContext &context, vector<Value> &inputs,
                                                           unordered_map<string, Value> &named_parameters,
+                                                          vector<LogicalType> &input_table_types,
+                                                          vector<string> &input_table_names,
                                                           vector<LogicalType> &return_types, vector<string> &names);
 typedef unique_ptr<FunctionOperatorData> (*table_function_init_t)(ClientContext &context, const FunctionData *bind_data,
                                                                   vector<column_t> &column_ids,
@@ -40,7 +42,7 @@ typedef unique_ptr<FunctionOperatorData> (*table_function_init_t)(ClientContext 
 typedef unique_ptr<BaseStatistics> (*table_statistics_t)(ClientContext &context, const FunctionData *bind_data,
                                                          column_t column_index);
 typedef void (*table_function_t)(ClientContext &context, const FunctionData *bind_data,
-                                 FunctionOperatorData *operator_state, DataChunk &output);
+                                 FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output);
 typedef void (*table_function_cleanup_t)(ClientContext &context, const FunctionData *bind_data,
                                          FunctionOperatorData *operator_state);
 typedef idx_t (*table_function_max_threads_t)(ClientContext &context, const FunctionData *bind_data);

--- a/src/include/duckdb/parser/tableref/table_function_ref.hpp
+++ b/src/include/duckdb/parser/tableref/table_function_ref.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/parser/tableref.hpp"
 #include "duckdb/common/vector.hpp"
+#include "duckdb/parser/statement/select_statement.hpp"
 
 namespace duckdb {
 //! Represents a Table producing function
@@ -21,6 +22,9 @@ public:
 
 	unique_ptr<ParsedExpression> function;
 	vector<string> column_name_alias;
+
+	// if the function takes a subquery as argument its in here
+	unique_ptr<SelectStatement> subquery;
 
 public:
 	string ToString() const override {

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -187,7 +187,7 @@ private:
 
 	bool BindFunctionParameters(vector<unique_ptr<ParsedExpression>> &expressions, vector<LogicalType> &arguments,
 	                            vector<Value> &parameters, unordered_map<string, Value> &named_parameters,
-	                            string &error);
+	                            unique_ptr<BoundSubqueryRef> &subquery, string &error);
 
 	unique_ptr<LogicalOperator> CreatePlan(BoundBaseTableRef &ref);
 	unique_ptr<LogicalOperator> CreatePlan(BoundCrossProductRef &ref);

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -144,6 +144,7 @@ bool Pipeline::ScheduleOperator(PhysicalOperator *op) {
 	case PhysicalOperatorType::HASH_JOIN:
 	case PhysicalOperatorType::CROSS_PRODUCT:
 	case PhysicalOperatorType::STREAMING_SAMPLE:
+	case PhysicalOperatorType::INOUT_FUNCTION:
 		// filter, projection or hash probe: continue in children
 		return ScheduleOperator(op->children[0].get());
 	case PhysicalOperatorType::TABLE_SCAN: {

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -8,10 +8,10 @@
 #include "duckdb/planner/expression_binder/select_binder.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/tableref/bound_table_function.hpp"
+#include "duckdb/planner/tableref/bound_subqueryref.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/common/algorithm.hpp"
-#include "duckdb/common/to_string.hpp"
 #include "duckdb/parser/expression/subquery_expression.hpp"
 
 namespace duckdb {

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -5,21 +5,25 @@
 #include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/parser/expression/comparison_expression.hpp"
 #include "duckdb/planner/expression_binder/constant_binder.hpp"
+#include "duckdb/planner/expression_binder/select_binder.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/tableref/bound_table_function.hpp"
+#include "duckdb/planner/query_node/bound_select_node.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/common/algorithm.hpp"
 #include "duckdb/common/to_string.hpp"
+#include "duckdb/parser/expression/subquery_expression.hpp"
 
 namespace duckdb {
 
 bool Binder::BindFunctionParameters(vector<unique_ptr<ParsedExpression>> &expressions, vector<LogicalType> &arguments,
                                     vector<Value> &parameters, unordered_map<string, Value> &named_parameters,
-                                    string &error) {
+                                    unique_ptr<BoundSubqueryRef> &subquery, string &error) {
+	bool seen_subquery = false;
 	for (auto &child : expressions) {
 		string parameter_name;
 
-		ConstantBinder binder(*this, context, "TABLE FUNCTION parameter");
+		// hack to make named parameters work
 		if (child->type == ExpressionType::COMPARE_EQUAL) {
 			// comparison, check if the LHS is a columnref
 			auto &comp = (ComparisonExpression &)*child;
@@ -31,6 +35,20 @@ bool Binder::BindFunctionParameters(vector<unique_ptr<ParsedExpression>> &expres
 				}
 			}
 		}
+		if (child->type == ExpressionType::SUBQUERY) {
+			if (seen_subquery) {
+				error = "Table function can have at most one subquery parameter ";
+				return false;
+			}
+			auto binder = Binder::CreateBinder(this->context, this, true);
+			auto &se = (SubqueryExpression &)*child;
+			auto node = binder->BindNode(*se.subquery->node);
+			subquery = make_unique<BoundSubqueryRef>(move(binder), move(node));
+			seen_subquery = true;
+			arguments.push_back(LogicalTypeId::TABLE);
+			continue;
+		}
+		ConstantBinder binder(*this, context, "TABLE FUNCTION parameter");
 		LogicalType sql_type;
 		auto expr = binder.Bind(child, &sql_type);
 		if (!expr->IsFoldable()) {
@@ -64,8 +82,9 @@ unique_ptr<BoundTableRef> Binder::Bind(TableFunctionRef &ref) {
 	vector<LogicalType> arguments;
 	vector<Value> parameters;
 	unordered_map<string, Value> named_parameters;
+	unique_ptr<BoundSubqueryRef> subquery;
 	string error;
-	if (!BindFunctionParameters(fexpr->children, arguments, parameters, named_parameters, error)) {
+	if (!BindFunctionParameters(fexpr->children, arguments, parameters, named_parameters, subquery, error)) {
 		throw BinderException(FormatError(ref, error));
 	}
 
@@ -86,9 +105,17 @@ unique_ptr<BoundTableRef> Binder::Bind(TableFunctionRef &ref) {
 
 	// cast the parameters to the type of the function
 	for (idx_t i = 0; i < arguments.size(); i++) {
-		if (table_function.arguments[i] != LogicalType::ANY) {
+		if (table_function.arguments[i] != LogicalType::ANY && table_function.arguments[i] != LogicalType::TABLE) {
 			parameters[i] = parameters[i].CastAs(table_function.arguments[i]);
 		}
+	}
+
+	vector<LogicalType> input_table_types;
+	vector<string> input_table_names;
+
+	if (subquery) {
+		input_table_types = subquery->subquery->types;
+		input_table_names = subquery->subquery->names;
 	}
 
 	// perform the binding
@@ -96,7 +123,8 @@ unique_ptr<BoundTableRef> Binder::Bind(TableFunctionRef &ref) {
 	vector<LogicalType> return_types;
 	vector<string> return_names;
 	if (table_function.bind) {
-		bind_data = table_function.bind(context, parameters, named_parameters, return_types, return_names);
+		bind_data = table_function.bind(context, parameters, named_parameters, input_table_types, input_table_names,
+		                                return_types, return_names);
 	}
 	D_ASSERT(return_types.size() == return_names.size());
 	D_ASSERT(return_types.size() > 0);
@@ -113,6 +141,9 @@ unique_ptr<BoundTableRef> Binder::Bind(TableFunctionRef &ref) {
 	// now add the table function to the bind context so its columns can be bound
 	bind_context.AddTableFunction(bind_index, ref.alias.empty() ? fexpr->function_name : ref.alias, return_names,
 	                              return_types, *get);
+	if (subquery) {
+		get->children.push_back(Binder::CreatePlan(*subquery));
+	}
 
 	return make_unique_base<BoundTableRef, BoundTableFunction>(move(get));
 }

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -45,7 +45,7 @@ bool Binder::BindFunctionParameters(vector<unique_ptr<ParsedExpression>> &expres
 			auto node = binder->BindNode(*se.subquery->node);
 			subquery = make_unique<BoundSubqueryRef>(move(binder), move(node));
 			seen_subquery = true;
-			arguments.push_back(LogicalTypeId::TABLE);
+			arguments.emplace_back(LogicalTypeId::TABLE);
 			continue;
 		}
 		ConstantBinder binder(*this, context, "TABLE FUNCTION parameter");
@@ -62,8 +62,8 @@ bool Binder::BindFunctionParameters(vector<unique_ptr<ParsedExpression>> &expres
 				error = "Unnamed parameters cannot come after named parameters";
 				return false;
 			}
-			arguments.push_back(sql_type);
-			parameters.push_back(move(constant));
+			arguments.emplace_back(sql_type);
+			parameters.emplace_back(move(constant));
 		} else {
 			named_parameters[parameter_name] = move(constant);
 		}

--- a/test/sql/function/generic/test_table_param.test
+++ b/test/sql/function/generic/test_table_param.test
@@ -1,0 +1,36 @@
+# name: test/sql/function/generic/test_table_param.test
+# description: Test stats function
+# group: [generic]
+
+# scalar stats
+
+statement ok
+pragma enable_verification
+
+statement ok
+create table a (i double, j double);
+
+statement ok
+insert into a values (1, 10), (42, 420);
+
+statement ok
+EXPLAIN SELECT * FROM summary((SELECT * FROM a))
+
+query III
+SELECT * FROM summary((SELECT * FROM a))
+----
+[1.000000, 10.000000]	1.000000	10.000000
+[42.000000, 420.000000]	42.000000	420.000000
+
+
+statement ok
+pragma threads=4
+
+statement ok
+pragma force_parallelism
+
+query III
+SELECT * FROM summary((SELECT * FROM a))
+----
+[1.000000, 10.000000]	1.000000	10.000000
+[42.000000, 420.000000]	42.000000	420.000000

--- a/tools/pythonpkg/src/include/duckdb_python/pandas_scan.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pandas_scan.hpp
@@ -22,7 +22,9 @@ public:
 
 	static unique_ptr<FunctionData> PandasScanBind(ClientContext &context, vector<Value> &inputs,
 	                                               unordered_map<string, Value> &named_parameters,
-	                                               vector<LogicalType> &return_types, vector<string> &names);
+	                                               vector<LogicalType> &input_table_types,
+	                                               vector<string> &input_table_names, vector<LogicalType> &return_types,
+	                                               vector<string> &names);
 
 	static unique_ptr<FunctionOperatorData> PandasScanInit(ClientContext &context, const FunctionData *bind_data_p,
 	                                                       vector<column_t> &column_ids,
@@ -46,7 +48,7 @@ public:
 	//! The main pandas scan function: note that this can be called in parallel without the GIL
 	//! hence this needs to be GIL-safe, i.e. no methods that create Python objects are allowed
 	static void PandasScanFunc(ClientContext &context, const FunctionData *bind_data,
-	                           FunctionOperatorData *operator_state, DataChunk &output);
+	                           FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output);
 
 	static unique_ptr<NodeStatistics> PandasScanCardinality(ClientContext &context, const FunctionData *bind_data);
 };

--- a/tools/pythonpkg/src/pandas_scan.cpp
+++ b/tools/pythonpkg/src/pandas_scan.cpp
@@ -119,6 +119,8 @@ static void ConvertPandasType(const string &col_type, LogicalType &duckdb_col_ty
 
 unique_ptr<FunctionData> PandasScanFunction::PandasScanBind(ClientContext &context, vector<Value> &inputs,
                                                             unordered_map<string, Value> &named_parameters,
+                                                            vector<LogicalType> &input_table_types,
+                                                            vector<string> &input_table_names,
                                                             vector<LogicalType> &return_types, vector<string> &names) {
 	// Hey, it works (TM)
 	py::gil_scoped_acquire acquire;
@@ -438,7 +440,7 @@ static void ConvertVector(PandasColumnBindData &bind_data, py::array &numpy_col,
 //! The main pandas scan function: note that this can be called in parallel without the GIL
 //! hence this needs to be GIL-safe, i.e. no methods that create Python objects are allowed
 void PandasScanFunction::PandasScanFunc(ClientContext &context, const FunctionData *bind_data,
-                                        FunctionOperatorData *operator_state, DataChunk &output) {
+                                        FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
 	auto &data = (PandasScanFunctionData &)*bind_data;
 	auto &state = (PandasScanState &)*operator_state;
 

--- a/tools/rpkg/src/duckdbr.cpp
+++ b/tools/rpkg/src/duckdbr.cpp
@@ -909,6 +909,8 @@ struct DataFrameScanFunction : public TableFunction {
 
 	static unique_ptr<FunctionData> dataframe_scan_bind(ClientContext &context, vector<Value> &inputs,
 	                                                    unordered_map<string, Value> &named_parameters,
+	                                                    vector<LogicalType> &input_table_types,
+	                                                    vector<string> &input_table_names,
 	                                                    vector<LogicalType> &return_types, vector<string> &names) {
 		RProtector r;
 		SEXP df((SEXP)inputs[0].GetValue<uintptr_t>());
@@ -965,7 +967,7 @@ struct DataFrameScanFunction : public TableFunction {
 	}
 
 	static void dataframe_scan_function(ClientContext &context, const FunctionData *bind_data,
-	                                    FunctionOperatorData *operator_state, DataChunk &output) {
+	                                    FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
 		auto &data = (DataFrameScanFunctionData &)*bind_data;
 		auto &state = (DataFrameScanState &)*operator_state;
 		if (state.position >= data.row_count) {


### PR DESCRIPTION
Example: 
```SQL
SELECT * FROM some_function((SELECT * FROM some_table))
```
The cool thing here is the function can select/project at will. We will use this for Python UDFs.