### PR TITLE
Test windows.h compilation in CI (#1528)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,6 +96,7 @@ jobs:
 
     - name: Build
       run: |
+        python scripts/windows_ci.py
         cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR_PLATFORM=x64 -DBUILD_ICU_EXTENSION=1 -DBUILD_PARQUET_EXTENSION=1 -DBUILD_TPCH_EXTENSION=1 -DBUILD_FTS_EXTENSION=1 -DBUILD_REST=1 -DJDBC_DRIVER=1
         cmake --build . --target duckdb --config Release
         cmake --build . --target unittest --config Release

--- a/extension/parquet/include/parquet_rle_bp_decoder.hpp
+++ b/extension/parquet/include/parquet_rle_bp_decoder.hpp
@@ -21,12 +21,12 @@ public:
 
 		while (values_read < batch_size) {
 			if (repeat_count_ > 0) {
-				int repeat_batch = std::min(batch_size - values_read, static_cast<uint32_t>(repeat_count_));
+				int repeat_batch = MinValue(batch_size - values_read, static_cast<uint32_t>(repeat_count_));
 				std::fill(values + values_read, values + values_read + repeat_batch, static_cast<T>(current_value_));
 				repeat_count_ -= repeat_batch;
 				values_read += repeat_batch;
 			} else if (literal_count_ > 0) {
-				uint32_t literal_batch = std::min(batch_size - values_read, static_cast<uint32_t>(literal_count_));
+				uint32_t literal_batch = MinValue(batch_size - values_read, static_cast<uint32_t>(literal_count_));
 				uint32_t actual_read = BitUnpack<T>(values + values_read, literal_batch);
 				if (literal_batch != actual_read) {
 					throw std::runtime_error("Did not find enough values");

--- a/scripts/windows_ci.py
+++ b/scripts/windows_ci.py
@@ -1,0 +1,18 @@
+
+import os
+
+common_path = os.path.join('src', 'include', 'duckdb', 'common', 'common.hpp')
+with open(common_path, 'r') as f:
+	text = f.read()
+
+
+text = text.replace('#pragma once', '''#pragma once
+
+#ifdef _WIN32
+#ifdef DUCKDB_MAIN_LIBRARY
+#include <windows.h>
+#endif
+#endif''')
+
+with open(common_path, 'w+') as f:
+	f.write(text)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,8 @@ if(AMALGAMATION_BUILD)
 
 else()
 
+  add_definitions(-DDUCKDB_MAIN_LIBRARY)
+
   add_subdirectory(optimizer)
   add_subdirectory(planner)
   add_subdirectory(parser)

--- a/src/common/limits.cpp
+++ b/src/common/limits.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/limits.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/windows_undefs.hpp"
 #include <limits>
 
 namespace duckdb {

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -24,11 +24,6 @@ PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<Logi
                                              PhysicalOperatorType type)
     : PhysicalSink(type, move(types), estimated_cardinality), groups(move(groups_p)), all_combinable(true),
       any_distinct(false) {
-	// FIXME: added to test windows.h breakage
-	int min = 3;
-	int ERROR = min;
-	int max = min + ERROR;
-	any_distinct = max > 100 || any_distinct;
 	// get a list of all aggregates to be computed
 	// fake a single group with a constant value for aggregation without groups
 	if (this->groups.empty()) {

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -24,6 +24,10 @@ PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<Logi
                                              PhysicalOperatorType type)
     : PhysicalSink(type, move(types), estimated_cardinality), groups(move(groups_p)), all_combinable(true),
       any_distinct(false) {
+	// FIXME: added to test windows.h breakage
+	int min = 3;
+	int ERROR = min;
+	int max = min + ERROR;
 	// get a list of all aggregates to be computed
 	// fake a single group with a constant value for aggregation without groups
 	if (this->groups.empty()) {

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -28,6 +28,7 @@ PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<Logi
 	int min = 3;
 	int ERROR = min;
 	int max = min + ERROR;
+	any_distinct = max > 100 || any_distinct;
 	// get a list of all aggregates to be computed
 	// fake a single group with a constant value for aggregation without groups
 	if (this->groups.empty()) {

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/execution/window_segment_tree.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression/bound_window_expression.hpp"
+#include "duckdb/common/windows_undefs.hpp"
 
 #include <cmath>
 #include <numeric>

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -73,7 +73,7 @@ void TopNHeap::Combine(TopNHeap &other) {
 }
 
 void TopNHeap::Reduce() {
-	heap_size = (heap_data.Count() > offset) ? std::min(limit + offset, heap_data.Count()) : 0;
+	heap_size = (heap_data.Count() > offset) ? MinValue(limit + offset, heap_data.Count()) : 0;
 	if (heap_size == 0) {
 		return;
 	}

--- a/src/function/scalar/operators/add.cpp
+++ b/src/function/scalar/operators/add.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/types/interval.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/types/hugeint.hpp"
+#include "duckdb/common/windows_undefs.hpp"
 
 #include <limits>
 

--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -173,7 +173,7 @@ static void ArrowScanFunction(ClientContext &context, const FunctionData *bind_d
 	}
 
 	output.SetCardinality(
-	    std::min((int64_t)STANDARD_VECTOR_SIZE, (int64_t)(data.current_chunk_root.length - data.chunk_offset)));
+	    MinValue<int64_t>(STANDARD_VECTOR_SIZE, data.current_chunk_root.length - data.chunk_offset));
 
 	for (idx_t col_idx = 0; col_idx < output.ColumnCount(); col_idx++) {
 		auto &array = *data.current_chunk_root.children[col_idx];

--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -172,8 +172,7 @@ static void ArrowScanFunction(ClientContext &context, const FunctionData *bind_d
 		throw InvalidInputException("arrow_scan: array column count mismatch");
 	}
 
-	output.SetCardinality(
-	    MinValue<int64_t>(STANDARD_VECTOR_SIZE, data.current_chunk_root.length - data.chunk_offset));
+	output.SetCardinality(MinValue<int64_t>(STANDARD_VECTOR_SIZE, data.current_chunk_root.length - data.chunk_offset));
 
 	for (idx_t col_idx = 0; col_idx < output.ColumnCount(); col_idx++) {
 		auto &array = *data.current_chunk_root.children[col_idx];

--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
+#include "duckdb/common/windows_undefs.hpp"
 #include <limits>
 
 namespace duckdb {

--- a/src/include/duckdb/common/types/null_value.hpp
+++ b/src/include/duckdb/common/types/null_value.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/limits.hpp"
+#include "duckdb/common/windows_undefs.hpp"
 
 #include <limits>
 #include <cstring>

--- a/src/include/duckdb/common/windows_undefs.hpp
+++ b/src/include/duckdb/common/windows_undefs.hpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/windows_undefs.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#ifdef WIN32
+
+#ifdef min
+#undef min
+#endif
+
+#ifdef max
+#undef max
+#endif
+
+#ifdef ERROR
+#undef ERROR
+#endif
+
+#ifdef GetCValue
+#undef GetCValue
+#endif
+
+#ifdef small
+#undef small
+#endif
+
+#endif

--- a/src/include/duckdb/storage/statistics/numeric_statistics.hpp
+++ b/src/include/duckdb/storage/statistics/numeric_statistics.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/value.hpp"
+#include "duckdb/common/windows_undefs.hpp"
 
 namespace duckdb {
 

--- a/src/main/duckdb-c.cpp
+++ b/src/main/duckdb-c.cpp
@@ -14,6 +14,10 @@
 #define strdup _strdup
 #endif
 
+#ifdef GetCValue
+#undef GetCValue
+#endif
+
 using namespace duckdb;
 
 static duckdb_type ConvertCPPTypeToC(LogicalType type);

--- a/third_party/fmt/include/fmt/printf.h
+++ b/third_party/fmt/include/fmt/printf.h
@@ -13,6 +13,10 @@
 
 #include "fmt/ostream.h"
 
+#ifdef min
+#undef min
+#endif
+
 FMT_BEGIN_NAMESPACE
 namespace internal {
 

--- a/third_party/libpg_query/include/pg_definitions.hpp
+++ b/third_party/libpg_query/include/pg_definitions.hpp
@@ -10,6 +10,10 @@
 #include <stdio.h>
 #include <string>
 
+#ifdef ERROR
+#undef ERROR
+#endif
+
 typedef uintptr_t PGDatum;
 typedef uint64_t PGSize;
 

--- a/third_party/pcg/pcg_random.hpp
+++ b/third_party/pcg/pcg_random.hpp
@@ -100,6 +100,14 @@
     #define PCG_ALWAYS_INLINE inline
 #endif
 
+#ifdef min
+#undef min
+#endif
+
+#ifdef max
+#undef max
+#endif
+
 /*
  * The pcg_extras namespace contains some support code that is likley to
  * be useful for a variety of RNGs, including:

--- a/third_party/re2/re2/stringpiece.h
+++ b/third_party/re2/re2/stringpiece.h
@@ -5,6 +5,10 @@
 #ifndef RE2_STRINGPIECE_H_
 #define RE2_STRINGPIECE_H_
 
+#ifdef min
+#undef min
+#endif
+
 // A string-like object that points to a sized piece of memory.
 //
 // Functions or methods may use const StringPiece& parameters to accept either

--- a/third_party/tdigest/t_digest.hpp
+++ b/third_party/tdigest/t_digest.hpp
@@ -24,6 +24,14 @@
 #include <utility>
 #include <vector>
 
+#ifdef min
+#undef min
+#endif
+
+#ifdef max
+#undef max
+#endif
+
 
 namespace duckdb_tdigest {
 


### PR DESCRIPTION
This PR adds testing of windows.h to the CI by running a script that pushes `#include <windows.h>` into `common.hpp`. As such, any file that does not compile cleanly together with windows.h will fail this CI test case now.

In addition, I have also added the file `duckdb/common/windows_undefs.hpp` which includes undefs for the most common offenders:

```cpp
#ifdef WIN32

#ifdef min
#undef min
#endif

#ifdef max
#undef max
#endif

#ifdef ERROR
#undef ERROR
#endif

#ifdef GetCValue
#undef GetCValue
#endif

#ifdef small
#undef small
#endif

#endif
```