### PR TITLE
Changing Selection Vector Type

### DIFF
--- a/src/include/duckdb/common/constants.hpp
+++ b/src/include/duckdb/common/constants.hpp
@@ -51,7 +51,7 @@ typedef int64_t dtime_t;
 //! Type used to represent timestamps (microseconds since 1970-01-01)
 typedef int64_t timestamp_t;
 //! Type used for the selection vector
-typedef uint16_t sel_t;
+typedef uint32_t sel_t;
 //! Type used for transaction timestamps
 typedef idx_t transaction_t;
 

--- a/test/sql/types/list/list.test_slow
+++ b/test/sql/types/list/list.test_slow
@@ -1,0 +1,14 @@
+# name: test/sql/types/list/list.test_slow
+# description: Test big list
+# group: [list]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE test AS (SELECT range i, 0 as j FROM range(70000));
+
+query I
+SELECT list(i)[69999] FROM test GROUP BY j;
+----
+69999


### PR DESCRIPTION
The selection vector is too small, which creates errors on lists larger than 65536 elements