### PR TITLE
Remove deref from duckdb_close

### DIFF
--- a/src/main/duckdb-c.cpp
+++ b/src/main/duckdb-c.cpp
@@ -49,7 +49,7 @@ duckdb_state duckdb_open(const char *path, duckdb_database *out) {
 
 void duckdb_close(duckdb_database *database) {
 	if (*database) {
-		auto wrapper = (DatabaseData *)*database;
+		auto wrapper = (DatabaseData *)database;
 		delete wrapper;
 		*database = nullptr;
 	}


### PR DESCRIPTION
I'm far from a C/C++ expert, but this seemed to fix the issues I was having with segfaults calling this function