### PR TITLE
Add .multiline and .singleline options to shell

### DIFF
--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -226,6 +226,9 @@ FILE *lndebug_fp = NULL;
 /* Set if to use or not the multi line mode. */
 void linenoiseSetMultiLine(int ml) {
 	mlmode = ml;
+	if (ml) {
+		keyword = "\033[32m";
+	}
 }
 
 /* Return true if the terminal name is in the list of terminals we know are
@@ -545,20 +548,22 @@ void refreshShowHints(struct abuf *ab, struct linenoiseState *l, int plen) {
 }
 
 size_t linenoiseComputeRenderWidth(const char *buf, size_t len) {
-	if (duckdb::Utf8Proc::IsValid(buf, len)) {
-		// utf8 in prompt, get render width
-		size_t cpos = 0;
-		size_t render_width = 0;
-		while (cpos < len) {
-			size_t char_render_width = duckdb::Utf8Proc::RenderWidth(buf, len, cpos);
-			cpos = duckdb::Utf8Proc::NextGraphemeCluster(buf, len, cpos);
-			render_width += char_render_width;
+	// utf8 in prompt, get render width
+	size_t cpos = 0;
+	size_t render_width = 0;
+	int sz;
+	while (cpos < len) {
+		if (duckdb::Utf8Proc::UTF8ToCodepoint(buf + cpos, sz) < 0) {
+			cpos++;
+			render_width++;
+			continue;
 		}
-		return render_width;
-	} else {
-		// invalid utf8 in prompt, use length in bytes
-		return len;
+
+		size_t char_render_width = duckdb::Utf8Proc::RenderWidth(buf, len, cpos);
+		cpos = duckdb::Utf8Proc::NextGraphemeCluster(buf, len, cpos);
+		render_width += char_render_width;
 	}
+	return render_width;
 }
 
 int linenoiseGetRenderPosition(const char *buf, size_t len, int max_width, int *n) {
@@ -647,6 +652,12 @@ int linenoiseParseOption(const char **azArg, int nArg, const char **out_error) {
 			return 1;
 		}
 		*out_error = "Expected usage: .constantcode [terminal_code]";
+		return 1;
+	} else if (strcmp(azArg[0], "multiline") == 0) {
+		linenoiseSetMultiLine(1);
+		return 1;
+	} else if (strcmp(azArg[0], "singleline") == 0) {
+		linenoiseSetMultiLine(0);
 		return 1;
 	}
 #endif
@@ -791,18 +802,35 @@ static void refreshSingleLine(struct linenoiseState *l) {
  * cursor position, and number of columns of the terminal. */
 static void refreshMultiLine(struct linenoiseState *l) {
 	char seq[64];
-	int plen = strlen(l->prompt);
-	int rows = (plen + l->len + l->cols - 1) / l->cols; /* rows used by current buf. */
-	int rpos = (plen + l->oldpos + l->cols) / l->cols;  /* cursor relative row. */
+	int plen = linenoiseComputeRenderWidth(l->prompt, strlen(l->prompt));
+	int total_len = linenoiseComputeRenderWidth(l->buf, l->len);
+	int cursor_old_pos = linenoiseComputeRenderWidth(l->buf, l->oldpos);
+	int cursor_pos = linenoiseComputeRenderWidth(l->buf, l->pos);
+	int rows = (plen + total_len + l->cols - 1) / l->cols; /* rows used by current buf. */
+	int rpos = (plen + cursor_old_pos + l->cols) / l->cols;  /* cursor relative row. */
 	int rpos2;                                          /* rpos after refresh. */
 	int col;                                            /* colum position, zero-based. */
 	int old_rows = l->maxrows;
 	int fd = l->ofd, j;
 	struct abuf ab;
+	std::string highlight_buffer;
+	auto buf = l->buf;
+	auto len = l->len;
 
 	/* Update maxrows if needed. */
-	if (rows > (int)l->maxrows)
+	if (rows > (int)l->maxrows) {
 		l->maxrows = rows;
+	}
+
+	if (duckdb::Utf8Proc::IsValid(l->buf, l->len)) {
+#ifndef DISABLE_HIGHLIGHT
+		if (enableHighlighting) {
+			highlight_buffer = highlightText(buf, len, 0, len);
+			buf = (char *)highlight_buffer.c_str();
+			len = highlight_buffer.size();
+		}
+#endif
+	}
 
 	/* First step: clear all the lines used before. To do so start by
 	 * going to the last row. */
@@ -827,14 +855,14 @@ static void refreshMultiLine(struct linenoiseState *l) {
 
 	/* Write the prompt and the current buffer content */
 	abAppend(&ab, l->prompt, strlen(l->prompt));
-	abAppend(&ab, l->buf, l->len);
+	abAppend(&ab, buf, len);
 
-	/* Show hits if any. */
+	/* Show hints if any. */
 	refreshShowHints(&ab, l, plen);
 
 	/* If we are at the very end of the screen with our prompt, we need to
 	 * emit a newline and move the prompt to the first column. */
-	if (l->pos && l->pos == l->len && (l->pos + plen) % l->cols == 0) {
+	if (l->pos && l->pos == len && (cursor_pos + plen) % l->cols == 0) {
 		lndebug("<newline>", 0);
 		abAppend(&ab, "\n", 1);
 		snprintf(seq, 64, "\r");
@@ -845,7 +873,7 @@ static void refreshMultiLine(struct linenoiseState *l) {
 	}
 
 	/* Move cursor to right position. */
-	rpos2 = (plen + l->pos + l->cols) / l->cols; /* current cursor relative row. */
+	rpos2 = (plen + cursor_pos + l->cols) / l->cols; /* current cursor relative row. */
 	lndebug("rpos2 %d", rpos2);
 
 	/* Go up till we reach the expected positon. */
@@ -856,7 +884,7 @@ static void refreshMultiLine(struct linenoiseState *l) {
 	}
 
 	/* Set column. */
-	col = (plen + (int)l->pos) % (int)l->cols;
+	col = (plen + (int)cursor_pos) % (int)l->cols;
 	lndebug("set col %d", 1 + col);
 	if (col)
 		snprintf(seq, 64, "\r\x1b[%dC", col);

--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -806,10 +806,10 @@ static void refreshMultiLine(struct linenoiseState *l) {
 	int total_len = linenoiseComputeRenderWidth(l->buf, l->len);
 	int cursor_old_pos = linenoiseComputeRenderWidth(l->buf, l->oldpos);
 	int cursor_pos = linenoiseComputeRenderWidth(l->buf, l->pos);
-	int rows = (plen + total_len + l->cols - 1) / l->cols; /* rows used by current buf. */
-	int rpos = (plen + cursor_old_pos + l->cols) / l->cols;  /* cursor relative row. */
-	int rpos2;                                          /* rpos after refresh. */
-	int col;                                            /* colum position, zero-based. */
+	int rows = (plen + total_len + l->cols - 1) / l->cols;  /* rows used by current buf. */
+	int rpos = (plen + cursor_old_pos + l->cols) / l->cols; /* cursor relative row. */
+	int rpos2;                                              /* rpos after refresh. */
+	int col;                                                /* colum position, zero-based. */
 	int old_rows = l->maxrows;
 	int fd = l->ofd, j;
 	struct abuf ab;


### PR DESCRIPTION
Multiline mode working in the shell now. This works pretty well, but not perfectly when using complex unicode characters (i.e. unicode characters with combining characters that form single grapheme clusters, such as e.g. 🤦🏼‍♂️).

For now I have left the default as single-line mode.