### PR TITLE
Replace default destructor of SegmentBase

### DIFF
--- a/src/include/duckdb/storage/table/segment_base.hpp
+++ b/src/include/duckdb/storage/table/segment_base.hpp
@@ -17,6 +17,10 @@ public:
 	SegmentBase(idx_t start, idx_t count) : start(start), count(count) {
 	}
 	virtual ~SegmentBase() {
+		// destroy the chain of segments iteratively (rather than recursively)
+		while (next && next->next) {
+			next = move(next->next);
+		}
 	}
 
 	//! The start row id of this chunk


### PR DESCRIPTION
The default destructor of SegmentBase recursively destroys next->next->next->etc., which leads to segfaults due to stack depth with huge tables. This PR changes the destructor so it destroys iteratively, avoiding the stack depth. 