### PR TITLE
Add a QueryRelation object that can be used to convert a query directly into a relation object

### DIFF
--- a/src/include/duckdb/common/enums/relation_type.hpp
+++ b/src/include/duckdb/common/enums/relation_type.hpp
@@ -38,7 +38,8 @@ enum class RelationType : uint8_t {
 	READ_CSV_RELATION,
 	SUBQUERY_RELATION,
 	TABLE_FUNCTION_RELATION,
-	VIEW_RELATION
+	VIEW_RELATION,
+	QUERY_RELATION
 };
 
 string RelationTypeToString(RelationType type);

--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -111,6 +111,8 @@ public:
 	//! Reads CSV file
 	DUCKDB_API shared_ptr<Relation> ReadCSV(const string &csv_file);
 	DUCKDB_API shared_ptr<Relation> ReadCSV(const string &csv_file, const vector<string> &columns);
+	//! Returns a relation from a query
+	DUCKDB_API shared_ptr<Relation> RelationFromQuery(string query, string alias = "queryrelation");
 
 	DUCKDB_API void BeginTransaction();
 	DUCKDB_API void Commit();

--- a/src/include/duckdb/main/relation/query_relation.hpp
+++ b/src/include/duckdb/main/relation/query_relation.hpp
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/main/relation/query_relation.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/main/relation.hpp"
+#include "duckdb/parser/query_node.hpp"
+
+namespace duckdb {
+class SelectStatement;
+
+class QueryRelation : public Relation {
+public:
+	QueryRelation(ClientContext &context, string query, string alias = "query_relation");
+
+	string query;
+	string alias;
+	vector<ColumnDefinition> columns;
+
+public:
+	unique_ptr<QueryNode> GetQueryNode() override;
+	unique_ptr<TableRef> GetTableRef() override;
+
+	const vector<ColumnDefinition> &Columns() override;
+	string ToString(idx_t depth) override;
+	string GetAlias() override;
+
+private:
+	unique_ptr<SelectStatement> GetSelectStatement();
+};
+
+} // namespace duckdb

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/appender.hpp"
+#include "duckdb/main/relation/query_relation.hpp"
 #include "duckdb/main/relation/read_csv_relation.hpp"
 #include "duckdb/main/relation/table_relation.hpp"
 #include "duckdb/main/relation/table_function_relation.hpp"
@@ -174,6 +175,10 @@ shared_ptr<Relation> Connection::ReadCSV(const string &csv_file, const vector<st
 		column_list.push_back(move(col_list[0]));
 	}
 	return make_shared<ReadCSVRelation>(*context, csv_file, move(column_list));
+}
+
+shared_ptr<Relation> Connection::RelationFromQuery(string query, string alias) {
+	return make_shared<QueryRelation>(*context, move(query), move(alias));
 }
 
 void Connection::BeginTransaction() {

--- a/src/main/relation/CMakeLists.txt
+++ b/src/main/relation/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library_unity(
   order_relation.cpp
   update_relation.cpp
   projection_relation.cpp
+  query_relation.cpp
   read_csv_relation.cpp
   setop_relation.cpp
   subquery_relation.cpp

--- a/src/main/relation/query_relation.cpp
+++ b/src/main/relation/query_relation.cpp
@@ -1,0 +1,48 @@
+#include "duckdb/main/relation/query_relation.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/statement/select_statement.hpp"
+#include "duckdb/parser/tableref/subqueryref.hpp"
+
+namespace duckdb {
+
+QueryRelation::QueryRelation(ClientContext &context, string query, string alias)
+    : Relation(context, RelationType::QUERY_RELATION), query(move(query)), alias(move(alias)) {
+	context.TryBindRelation(*this, this->columns);
+}
+
+unique_ptr<SelectStatement> QueryRelation::GetSelectStatement() {
+	Parser parser;
+	parser.ParseQuery(query);
+	if (parser.statements.size() != 1) {
+		throw ParserException("Expected a single SELECT statement");
+	}
+	if (parser.statements[0]->type != StatementType::SELECT_STATEMENT) {
+		throw ParserException("Expected a single SELECT statement");
+	}
+	return unique_ptr_cast<SQLStatement, SelectStatement>(move(parser.statements[0]));
+}
+
+unique_ptr<QueryNode> QueryRelation::GetQueryNode() {
+	auto select = GetSelectStatement();
+	return move(select->node);
+}
+
+unique_ptr<TableRef> QueryRelation::GetTableRef() {
+	auto subquery_ref = make_unique<SubqueryRef>(GetSelectStatement(), GetAlias());
+	return move(subquery_ref);
+}
+
+string QueryRelation::GetAlias() {
+	return alias;
+}
+
+const vector<ColumnDefinition> &QueryRelation::Columns() {
+	return columns;
+}
+
+string QueryRelation::ToString(idx_t depth) {
+	return RenderWhitespace(depth) + "Subquery [" + query + "]";
+}
+
+} // namespace duckdb

--- a/test/api/test_relation_api.cpp
+++ b/test/api/test_relation_api.cpp
@@ -741,3 +741,26 @@ TEST_CASE("Test CSV reading/writing from relations", "[relation_api]") {
 
 	REQUIRE_THROWS(con.ReadCSV(csv_file, {"i INTEGER); SELECT 42;--"}));
 }
+
+TEST_CASE("Test query relation", "[relation_api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	con.EnableQueryVerification();
+	unique_ptr<QueryResult> result;
+	shared_ptr<Relation> tbl;
+
+	// create some tables
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (1), (2), (3)"));
+
+	REQUIRE_NOTHROW(tbl = con.RelationFromQuery("SELECT * FROM integers WHERE i >= 2"));
+	REQUIRE_NOTHROW(result = tbl->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {2, 3}));
+	REQUIRE_NOTHROW(result = tbl->Project("i + 1")->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {3, 4}));
+
+	REQUIRE_NOTHROW(result = tbl->Alias("q1")->Join(tbl->Alias("q2")->Filter("i=3"), "q1.i=q2.i")->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {3}));
+
+	REQUIRE_THROWS(tbl->Project("k+1"));
+}


### PR DESCRIPTION
This partially addresses #1634 (only in the C++ API at the moment).