### PR TITLE
Integrating deltatime from Pandas/Numpy

### DIFF
--- a/src/common/types/interval.cpp
+++ b/src/common/types/interval.cpp
@@ -225,6 +225,27 @@ string Interval::ToString(interval_t interval) {
 	return string(buffer, length);
 }
 
+int64_t Interval::GetMilli(interval_t val) {
+	int64_t milli_month, milli_day, milli;
+	int64_t ns_in_us = 1000;
+	if (!TryMultiplyOperator::Operation((int64_t)val.months, Interval::MICROS_PER_MONTH, milli_month)) {
+		throw ConversionException("Could not convert Interval to Milliseconds");
+	}
+	if (!TryMultiplyOperator::Operation((int64_t)val.days, Interval::MICROS_PER_DAY, milli_day)) {
+		throw ConversionException("Could not convert Interval to Milliseconds");
+	}
+	if (!TryMultiplyOperator::Operation(val.micros, ns_in_us, milli)) {
+		throw ConversionException("Could not convert Interval to Milliseconds");
+	}
+	if (!TryAddOperator::Operation<int64_t, int64_t, int64_t>(milli, milli_month, milli)) {
+		throw ConversionException("Could not convert Interval to Milliseconds");
+	}
+	if (!TryAddOperator::Operation<int64_t, int64_t, int64_t>(milli, milli_day, milli)) {
+		throw ConversionException("Could not convert Interval to Milliseconds");
+	}
+	return milli;
+}
+
 interval_t Interval::GetDifference(timestamp_t timestamp_1, timestamp_t timestamp_2) {
 	date_t date1, date2;
 	dtime_t time1, time2;

--- a/src/include/duckdb/common/types/interval.hpp
+++ b/src/include/duckdb/common/types/interval.hpp
@@ -45,6 +45,9 @@ public:
 	//! Convert an interval object to a string
 	static string ToString(interval_t date);
 
+	//! Get Interval in milliseconds
+	static int64_t GetMilli(interval_t val);
+
 	//! Returns the difference between two timestamps
 	static interval_t GetDifference(timestamp_t timestamp_1, timestamp_t timestamp_2);
 

--- a/tools/pythonpkg/src/include/duckdb_python/vector_conversion.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/vector_conversion.hpp
@@ -27,6 +27,7 @@ enum class PandasType : uint8_t {
 	FLOAT,
 	DOUBLE,
 	TIMESTAMP,
+	INTERVAL,
 	VARCHAR
 };
 

--- a/tools/pythonpkg/src/vector_conversion.cpp
+++ b/tools/pythonpkg/src/vector_conversion.cpp
@@ -124,6 +124,31 @@ void VectorConversion::NumpyToDuckDB(PandasColumnBindData &bind_data, py::array 
 		}
 		break;
 	}
+	case PandasType::INTERVAL: {
+		auto src_ptr = (int64_t *)numpy_col.data();
+		auto tgt_ptr = FlatVector::GetData<interval_t>(out);
+		auto &mask = FlatVector::Validity(out);
+
+		for (idx_t row = 0; row < count; row++) {
+			auto source_idx = offset + row;
+			if (src_ptr[source_idx] <= NumericLimits<int64_t>::Minimum()) {
+				// pandas Not a Time (NaT)
+				mask.SetInvalid(row);
+				continue;
+			}
+			int64_t micro = src_ptr[source_idx] / 1000;
+			int64_t days = micro / Interval::MICROS_PER_DAY;
+			micro = micro % Interval::MICROS_PER_DAY;
+			int64_t months = days / Interval::DAYS_PER_MONTH;
+			days = days % Interval::DAYS_PER_MONTH;
+			interval_t interval;
+			interval.months = months;
+			interval.days = days;
+			interval.micros = micro;
+			tgt_ptr[row] = interval;
+		}
+		break;
+	}
 	case PandasType::VARCHAR: {
 		auto src_ptr = (PyObject **)numpy_col.data();
 		auto tgt_ptr = FlatVector::GetData<string_t>(out);
@@ -236,6 +261,9 @@ static void ConvertPandasType(const string &col_type, LogicalType &duckdb_col_ty
 		// this better be strings
 		duckdb_col_type = LogicalType::VARCHAR;
 		pandas_type = PandasType::VARCHAR;
+	} else if (col_type == "timedelta64[ns]") {
+		duckdb_col_type = LogicalType::INTERVAL;
+		pandas_type = PandasType::INTERVAL;
 	} else {
 		throw std::runtime_error("unsupported python type " + col_type);
 	}

--- a/tools/pythonpkg/tests/pandas/test_timestamp.py
+++ b/tools/pythonpkg/tests/pandas/test_timestamp.py
@@ -17,3 +17,8 @@ class TestPandasTimestamps(object):
         df = pd.DataFrame(data=d)
         df_from_duck = duckdb.from_df(df).df()
         assert (df_from_duck.equals(df))
+
+    def test_timestamp_timedelta(self, duckdb_cursor):
+        df = pd.DataFrame({'a': [pd.Timedelta(1, unit='s')], 'b': [pd.Timedelta(None, unit='s')], 'c': [pd.Timedelta(1, unit='us')] , 'd': [pd.Timedelta(1, unit='ms')]})
+        df_from_duck = duckdb.from_df(df).df()
+        assert (df_from_duck.equals(df))


### PR DESCRIPTION
Task: #1700 

This PR transforms deltatime to interval in duckdb.

The only problem is that if the deltatime is in ns, the ns are lost since in duckdb we store it as us.
If that's a big no-no, then I can extend the interval_t to either store the remaining ns, or change from us to ns.
(the latter can be a reasonable amount of work).