### PR TITLE
Fix deadlock from index join

### DIFF
--- a/src/execution/operator/join/physical_index_join.cpp
+++ b/src/execution/operator/join/physical_index_join.cpp
@@ -33,7 +33,6 @@ public:
 	//! Vector of rows that mush be fetched for every LHS key
 	vector<vector<row_t>> rhs_rows;
 	ExpressionExecutor probe_executor;
-	IndexLock lock;
 };
 
 PhysicalIndexJoin::PhysicalIndexJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
@@ -125,7 +124,6 @@ void PhysicalIndexJoin::Output(ExecutionContext &context, DataChunk &chunk, Phys
 
 void PhysicalIndexJoin::GetRHSMatches(ExecutionContext &context, PhysicalOperatorState *state_p) const {
 	auto state = reinterpret_cast<PhysicalIndexJoinOperatorState *>(state_p);
-
 	auto &art = (ART &)*index;
 	auto &transaction = Transaction::GetTransaction(context.client);
 	for (idx_t i = 0; i < state->child_chunk.size(); i++) {
@@ -134,13 +132,13 @@ void PhysicalIndexJoin::GetRHSMatches(ExecutionContext &context, PhysicalOperato
 		state->rhs_rows[i].clear();
 		if (!equal_value.is_null) {
 			if (fetch_types.empty()) {
-				state->lock.index_lock.lock();
+				IndexLock lock;
+				index->InitializeLock(lock);
 				art.SearchEqualJoinNoFetch(equal_value, state->result_sizes[i]);
-				state->lock.index_lock.unlock();
 			} else {
-				state->lock.index_lock.lock();
+				IndexLock lock;
+				index->InitializeLock(lock);
 				art.SearchEqual((ARTIndexScanState *)index_state.get(), (idx_t)-1, state->rhs_rows[i]);
-				state->lock.index_lock.unlock();
 				state->result_sizes[i] = state->rhs_rows[i].size();
 			}
 		} else {
@@ -156,11 +154,6 @@ void PhysicalIndexJoin::GetRHSMatches(ExecutionContext &context, PhysicalOperato
 
 void PhysicalIndexJoin::GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state_p) {
 	auto state = reinterpret_cast<PhysicalIndexJoinOperatorState *>(state_p);
-	//! Nothing to materialize
-	if (!state->lock.index_lock) {
-		index->InitializeLock(state->lock);
-	}
-	state->lock.index_lock.unlock();
 	state->result_size = 0;
 	while (state->result_size == 0) {
 		//! Check if we need to get a new LHS chunk

--- a/test/sql/index/art/test_art_index_join.test
+++ b/test/sql/index/art/test_art_index_join.test
@@ -1,0 +1,33 @@
+# name: test/sql/index/art/test_art_index_join.test
+# description: ART Join
+# group: [art]
+
+statement ok
+CREATE TABLE Person (id bigint PRIMARY KEY);
+
+statement ok
+CREATE TABLE Person_knows_Person (Person1id bigint, Person2id bigint);
+
+statement ok
+INSERT INTO Person VALUES (1), (2), (3), (4), (5);
+
+statement ok
+INSERT INTO Person_knows_Person VALUES (1, 2), (1, 3), (1, 4), (2, 3), (3, 4), (4, 5);
+
+statement ok
+PRAGMA force_index_join;
+
+query II
+SELECT p1.id,p2.id
+FROM Person_knows_Person pkp
+JOIN Person p1
+  ON p1.id = pkp.Person1id
+JOIN Person p2
+  ON p2.id = pkp.Person2id;
+----
+1	2
+1	3
+1	4
+2	3
+3	4
+4	5


### PR DESCRIPTION
If an index join has another index join as one of its children, and both index joins use the same index we have a deadlock. Now the locks are acquired and released before/after art lookups.