### PR TITLE
Faster string comparison and 64-bit string hash

### DIFF
--- a/src/common/types/hash.cpp
+++ b/src/common/types/hash.cpp
@@ -53,7 +53,7 @@ hash_t Hash(char *val) {
 }
 
 // Jenkins hash function: https://en.wikipedia.org/wiki/Jenkins_hash_function
-uint32_t jenkins_one_at_a_time_hash(const char* key, size_t length) {
+uint32_t jenkins_one_at_a_time_hash(const char *key, size_t length) {
 	size_t i = 0;
 	uint32_t hash = 0;
 	while (i != length) {

--- a/src/common/types/hash.cpp
+++ b/src/common/types/hash.cpp
@@ -39,14 +39,7 @@ hash_t Hash(interval_t val) {
 
 template <>
 hash_t Hash(const char *str) {
-	hash_t hash = 5381;
-	hash_t c;
-
-	while ((c = *str++)) {
-		hash = ((hash << 5) + hash) + c;
-	}
-
-	return hash;
+	return Hash(str, strlen(str));
 }
 
 template <>
@@ -59,14 +52,24 @@ hash_t Hash(char *val) {
 	return Hash<const char *>(val);
 }
 
-hash_t Hash(const char *val, size_t size) {
-	hash_t hash = 5381;
-
-	for (size_t i = 0; i < size; i++) {
-		hash = ((hash << 5) + hash) + val[i];
+// Jenkins hash function: https://en.wikipedia.org/wiki/Jenkins_hash_function
+uint32_t jenkins_one_at_a_time_hash(const char* key, size_t length) {
+	size_t i = 0;
+	uint32_t hash = 0;
+	while (i != length) {
+		hash += key[i++];
+		hash += hash << 10;
+		hash ^= hash >> 6;
 	}
-
+	hash += hash << 3;
+	hash ^= hash >> 11;
+	hash += hash << 15;
 	return hash;
+}
+
+hash_t Hash(const char *val, size_t size) {
+	auto hash_val = jenkins_one_at_a_time_hash(val, size);
+	return Hash<uint32_t>(hash_val);
 }
 
 hash_t Hash(char *val, size_t size) {

--- a/src/common/types/hash.cpp
+++ b/src/common/types/hash.cpp
@@ -53,7 +53,7 @@ hash_t Hash(char *val) {
 }
 
 // Jenkins hash function: https://en.wikipedia.org/wiki/Jenkins_hash_function
-uint32_t jenkins_one_at_a_time_hash(const char *key, size_t length) {
+uint32_t JenkinsOneAtATimeHash(const char *key, size_t length) {
 	size_t i = 0;
 	uint32_t hash = 0;
 	while (i != length) {
@@ -68,7 +68,7 @@ uint32_t jenkins_one_at_a_time_hash(const char *key, size_t length) {
 }
 
 hash_t Hash(const char *val, size_t size) {
-	auto hash_val = jenkins_one_at_a_time_hash(val, size);
+	auto hash_val = JenkinsOneAtATimeHash(val, size);
 	return Hash<uint32_t>(hash_val);
 }
 

--- a/src/include/duckdb/common/operator/comparison_operators.hpp
+++ b/src/include/duckdb/common/operator/comparison_operators.hpp
@@ -89,16 +89,16 @@ inline bool LessThan::Operation(bool left, bool right) {
 struct StringComparisonOperators {
 	template <bool INVERSE>
 	static inline bool EqualsOrNot(const string_t a, const string_t b) {
-		if (memcmp(&a, &b, sizeof(uint32_t) + string_t::PREFIX_LENGTH) == 0) {
-			// prefix and length are equal
-			if (a.IsInlined()) {
-				// small string: compare entire inlined string
-				if (memcmp(a.value.inlined.inlined, b.value.inlined.inlined, a.GetSize()) == 0) {
-					// entire string is equal
-					return INVERSE ? false : true;
-				}
-			} else {
-				// large string: check main data source
+		if (a.IsInlined()) {
+			// small string: compare entire string
+			if (memcmp(&a, &b, sizeof(string_t)) == 0) {
+				// entire string is equal
+				return INVERSE ? false : true;
+			}
+		} else {
+			// large string: first check prefix and length
+			if (memcmp(&a, &b, sizeof(uint32_t) + string_t::PREFIX_LENGTH) == 0) {
+				// prefix and length are equal: check main string
 				if (memcmp(a.value.pointer.ptr, b.value.pointer.ptr, a.GetSize()) == 0) {
 					// entire string is equal
 					return INVERSE ? false : true;
@@ -109,6 +109,7 @@ struct StringComparisonOperators {
 		return INVERSE ? true : false;
 	}
 };
+
 template <>
 inline bool Equals::Operation(string_t left, string_t right) {
 	return StringComparisonOperators::EqualsOrNot<false>(left, right);

--- a/src/include/duckdb/common/operator/comparison_operators.hpp
+++ b/src/include/duckdb/common/operator/comparison_operators.hpp
@@ -89,15 +89,20 @@ inline bool LessThan::Operation(bool left, bool right) {
 struct StringComparisonOperators {
 	template <bool INVERSE>
 	static inline bool EqualsOrNot(const string_t a, const string_t b) {
-		if (a.IsInlined()) {
+		auto alen = a.value.inlined.length;
+		auto blen = b.value.inlined.length;
+		if (alen != blen) {
+			return false;
+		}
+		if (alen <= string_t::INLINE_LENGTH) {
 			// small string: compare entire string
-			if (memcmp(&a, &b, sizeof(string_t)) == 0) {
+			if (memcmp(&a.value.inlined.inlined, &b.value.inlined.inlined, alen) == 0) {
 				// entire string is equal
 				return INVERSE ? false : true;
 			}
 		} else {
-			// large string: first check prefix and length
-			if (memcmp(&a, &b, sizeof(uint32_t) + string_t::PREFIX_LENGTH) == 0) {
+			// large string: first check prefix
+			if (memcmp(a.value.pointer.prefix, b.value.pointer.prefix, string_t::PREFIX_LENGTH) == 0) {
 				// prefix and length are equal: check main string
 				if (memcmp(a.value.pointer.ptr, b.value.pointer.ptr, a.GetSize()) == 0) {
 					// entire string is equal

--- a/src/include/duckdb/common/operator/comparison_operators.hpp
+++ b/src/include/duckdb/common/operator/comparison_operators.hpp
@@ -89,20 +89,15 @@ inline bool LessThan::Operation(bool left, bool right) {
 struct StringComparisonOperators {
 	template <bool INVERSE>
 	static inline bool EqualsOrNot(const string_t a, const string_t b) {
-		auto alen = a.value.inlined.length;
-		auto blen = b.value.inlined.length;
-		if (alen != blen) {
-			return false;
-		}
-		if (alen <= string_t::INLINE_LENGTH) {
+		if (a.IsInlined()) {
 			// small string: compare entire string
-			if (memcmp(&a.value.inlined.inlined, &b.value.inlined.inlined, alen) == 0) {
+			if (memcmp(&a, &b, sizeof(string_t)) == 0) {
 				// entire string is equal
 				return INVERSE ? false : true;
 			}
 		} else {
-			// large string: first check prefix
-			if (memcmp(a.value.pointer.prefix, b.value.pointer.prefix, string_t::PREFIX_LENGTH) == 0) {
+			// large string: first check prefix and length
+			if (memcmp(&a, &b, sizeof(uint32_t) + string_t::PREFIX_LENGTH) == 0) {
 				// prefix and length are equal: check main string
 				if (memcmp(a.value.pointer.ptr, b.value.pointer.ptr, a.GetSize()) == 0) {
 					// entire string is equal

--- a/src/include/duckdb/common/types/string_type.hpp
+++ b/src/include/duckdb/common/types/string_type.hpp
@@ -33,7 +33,7 @@ public:
 		if (IsInlined()) {
 			// zero initialize the prefix first
 			// this makes sure that strings with length smaller than 4 still have an equal prefix
-			memset(value.inlined.inlined, 0, INLINE_LENGTH);
+			memset(value.inlined.inlined, 0, PREFIX_LENGTH);
 			if (GetSize() == 0) {
 				return;
 			}
@@ -89,7 +89,7 @@ public:
 		auto dataptr = (char *)GetDataUnsafe();
 		if (GetSize() <= INLINE_LENGTH) {
 			// fill prefix with zeros if the length is smaller than the prefix length
-			for (idx_t i = GetSize(); i < INLINE_LENGTH; i++) {
+			for (idx_t i = GetSize(); i < PREFIX_LENGTH; i++) {
 				value.inlined.inlined[i] = '\0';
 			}
 		} else {

--- a/src/include/duckdb/common/types/string_type.hpp
+++ b/src/include/duckdb/common/types/string_type.hpp
@@ -33,7 +33,7 @@ public:
 		if (IsInlined()) {
 			// zero initialize the prefix first
 			// this makes sure that strings with length smaller than 4 still have an equal prefix
-			memset(value.inlined.inlined, 0, PREFIX_LENGTH);
+			memset(value.inlined.inlined, 0, INLINE_LENGTH);
 			if (GetSize() == 0) {
 				return;
 			}
@@ -89,7 +89,7 @@ public:
 		auto dataptr = (char *)GetDataUnsafe();
 		if (GetSize() <= INLINE_LENGTH) {
 			// fill prefix with zeros if the length is smaller than the prefix length
-			for (idx_t i = GetSize(); i < PREFIX_LENGTH; i++) {
+			for (idx_t i = GetSize(); i < INLINE_LENGTH; i++) {
 				value.inlined.inlined[i] = '\0';
 			}
 		} else {


### PR DESCRIPTION
This PR improves the performance of the string comparison for short inlined strings by performing the entire comparison in one pass. This does require the string_t struct to be padded with zero's for shorter strings, however, as we now compare past the string length boundary for strings with a length smaller than 12 (i.e. we always compare the entire string_t struct). 

Furthermore, this PR improves the string hash and actually converts it into a 64-bit string hash. This solves issues relating to radix partitioned hash tables on string columns, as the radix partitioning uses the upper bits of the hash. The previous string hash was a 32-bit hash, which lead to these upper bits always being zero and everything being placed into the same radix partition.