### PR TITLE
format.py: skip fetching new changes unless comparing to master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,13 @@ format-check-silent:
 	python3 scripts/format.py --all --check --silent
 
 format-fix:
-	python3 scripts/format.py --all --fix
+	python3 scripts/format.py --all --fix --noconfirm
+
+format-head:
+	python3 scripts/format.py HEAD --fix --noconfirm
+
+format-master:
+	python3 scripts/format.py master --fix --noconfirm
 
 third_party/sqllogictest:
 	git clone --depth=1 https://github.com/cwida/sqllogictest.git third_party/sqllogictest

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -107,7 +107,9 @@ elif os.path.isdir(revision):
     for fname in changed_files:
         print(fname)
 elif not format_all:
-    os.system("git fetch origin master:master")
+    if revision == 'master':
+        # fetch new changes when comparing to the master
+        os.system("git fetch origin master:master")
     print(action + " since branch or revision: " + revision)
     changed_files = get_changed_files(revision)
     if len(changed_files) == 0:


### PR DESCRIPTION
Also add `make format-head` alias (which formats all changes since the last commit), and `make format-master` (which formats all files that have changed compared to the master branch).