### PR TITLE
Fix #1723: avoid nullptr dereference on resizable buffer with 0 bytes allocated (happens with vector that is all NULL)

### DIFF
--- a/extension/parquet/include/resizable_buffer.hpp
+++ b/extension/parquet/include/resizable_buffer.hpp
@@ -68,6 +68,9 @@ public:
 		resize(allocator, new_size);
 	}
 	void resize(Allocator &allocator, uint64_t new_size) {
+		if (new_size == 0) {
+			return;
+		}
 		if (new_size > alloc_len) {
 			alloc_len = new_size;
 			allocated_data = allocator.Allocate(alloc_len);

--- a/extension/parquet/include/resizable_buffer.hpp
+++ b/extension/parquet/include/resizable_buffer.hpp
@@ -75,8 +75,8 @@ public:
 		if (new_size > alloc_len) {
 			alloc_len = new_size;
 			allocated_data = allocator.Allocate(alloc_len);
+			ptr = (char *)allocated_data->get();
 		}
-		ptr = (char *)allocated_data->get();
 	}
 
 private:

--- a/extension/parquet/include/resizable_buffer.hpp
+++ b/extension/parquet/include/resizable_buffer.hpp
@@ -68,6 +68,7 @@ public:
 		resize(allocator, new_size);
 	}
 	void resize(Allocator &allocator, uint64_t new_size) {
+		len = new_size;
 		if (new_size == 0) {
 			return;
 		}
@@ -75,7 +76,6 @@ public:
 			alloc_len = new_size;
 			allocated_data = allocator.Allocate(alloc_len);
 		}
-		len = new_size;
 		ptr = (char *)allocated_data->get();
 	}
 

--- a/test/sql/copy/parquet/parquet_1723.test_slow
+++ b/test/sql/copy/parquet/parquet_1723.test_slow
@@ -1,0 +1,14 @@
+# name: test/sql/copy/parquet/parquet_1619.test
+# description: Error: Not implemented Error: Expr of type 347 not implemented
+# group: [parquet]
+
+require parquet
+
+query I nosort query
+select * from 'test/sql/copy/parquet/data/leftdate3_192_loop_1.parquet'
+
+statement ok
+create table test as select * from 'test/sql/copy/parquet/data/leftdate3_192_loop_1.parquet'
+
+query I nosort query
+select * from test

--- a/test/sql/copy/parquet/parquet_1723.test_slow
+++ b/test/sql/copy/parquet/parquet_1723.test_slow
@@ -1,5 +1,5 @@
-# name: test/sql/copy/parquet/parquet_1619.test
-# description: Error: Not implemented Error: Expr of type 347 not implemented
+# name: test/sql/copy/parquet/parquet_1723.test_slow
+# description: CREATE TABLE from parquet crashes latest bleeding edge
 # group: [parquet]
 
 require parquet


### PR DESCRIPTION
@alanpaulkwan could you verify that this fixes the issue for you?