### PR TITLE
Replacement scans: by default set alias to the supplied table name

### DIFF
--- a/src/common/types/hugeint.cpp
+++ b/src/common/types/hugeint.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/limits.hpp"
 
 #include <cmath>
+#include <limits>
 
 namespace duckdb {
 

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -70,7 +70,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		for (auto &scan : config.replacement_scans) {
 			auto replacement_function = scan.function(ref.table_name, scan.data);
 			if (replacement_function) {
-				replacement_function->alias = ref.alias;
+				replacement_function->alias = ref.alias.empty() ? ref.table_name : ref.alias;
 				replacement_function->column_name_alias = ref.column_name_alias;
 				return Bind(*replacement_function);
 			}

--- a/test/sql/copy/csv/test_replacement_scan_alias.test
+++ b/test/sql/copy/csv/test_replacement_scan_alias.test
@@ -1,5 +1,5 @@
 # name: test/sql/copy/csv/test_replacement_scan_alias.test
-# description: Test CSV with UTF8 NFC Normalization
+# description: Test replacement scan aliases
 # group: [csv]
 
 # implicit alias is equal to the table name

--- a/test/sql/copy/csv/test_replacement_scan_alias.test
+++ b/test/sql/copy/csv/test_replacement_scan_alias.test
@@ -1,0 +1,20 @@
+# name: test/sql/copy/csv/test_nfc.test
+# description: Test CSV with UTF8 NFC Normalization
+# group: [csv]
+
+# implicit alias is equal to the table name
+statement ok
+select "test/sql/copy/csv/data/abac/abac.csv".column0 from 'test/sql/copy/csv/data/abac/abac.csv';
+
+statement ok
+select * from 'test/sql/copy/csv/data/test/dateformat.csv';
+
+statement ok
+select * from 'test/sql/copy/csv/data/abac/abac.csv', 'test/sql/copy/csv/data/test/dateformat.csv';
+
+# explicit alias
+statement ok
+select mytbl.column0 from 'test/sql/copy/csv/data/abac/abac.csv' mytbl;
+
+statement ok
+select mytbl.mycol from 'test/sql/copy/csv/data/abac/abac.csv' mytbl(mycol);

--- a/test/sql/copy/csv/test_replacement_scan_alias.test
+++ b/test/sql/copy/csv/test_replacement_scan_alias.test
@@ -1,4 +1,4 @@
-# name: test/sql/copy/csv/test_nfc.test
+# name: test/sql/copy/csv/test_replacement_scan_alias.test
 # description: Test CSV with UTF8 NFC Normalization
 # group: [csv]
 


### PR DESCRIPTION
The previous behavior was to set the alias to the function being called if no explicit alias was supplied, which caused a query such as this to fail with a duplicate alias error:

```sql
select * from 'test/sql/copy/csv/data/abac/abac.csv', 'test/sql/copy/csv/data/test/dateformat.csv';
```

This is particularly relevant for Pandas scans.