### PR TITLE
Test arrow_scan using an exported RecordBatchReader of the C++ Arrow library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,7 @@ local.properties
 
 # Clang language server (C/C++ tooling)
 /.cache/clangd
+.ccls-cache
 
 # Eclipse Core
 .project

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -19,3 +19,7 @@ endif()
 if(BUILD_R)
   add_subdirectory(rpkg)
 endif()
+
+if(BUILD_ARROW_ABI_TEST)
+  add_subdirectory(arrow_abi_test)
+endif()

--- a/tools/arrow_abi_test/CMakeLists.txt
+++ b/tools/arrow_abi_test/CMakeLists.txt
@@ -74,4 +74,4 @@ include_directories(arrow_abi_test
     ${CMAKE_CURRENT_SOURCE_DIR}/../../src/include
     ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/catch
 )
-target_link_libraries(arrow_abi_test arrow)
+target_link_libraries(arrow_abi_test arrow Threads::Threads)

--- a/tools/arrow_abi_test/CMakeLists.txt
+++ b/tools/arrow_abi_test/CMakeLists.txt
@@ -1,5 +1,7 @@
-include(ExternalProject)
+# Always build the abi test with asan to reveal problems with the release callbacks
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
 
+include(ExternalProject)
 ExternalProject_Add(
     arrow_ep
     GIT_REPOSITORY "https://github.com/apache/arrow"

--- a/tools/arrow_abi_test/CMakeLists.txt
+++ b/tools/arrow_abi_test/CMakeLists.txt
@@ -1,0 +1,75 @@
+include(ExternalProject)
+
+ExternalProject_Add(
+    arrow_ep
+    GIT_REPOSITORY "https://github.com/apache/arrow"
+    GIT_TAG f959141ece4d660bce5f7fa545befc0116a7db79
+    PREFIX "${CMAKE_BINARY_DIR}/third_party/arrow"
+    INSTALL_DIR "${CMAKE_BINARY_DIR}/third_party/arrow/install"
+    CONFIGURE_COMMAND
+        ${CMAKE_COMMAND} 
+            -G${CMAKE_GENERATOR}
+            -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+            -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
+            -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+            -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+            -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+            -DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}
+            -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/third_party/arrow/install
+            -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
+            -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+            -DARROW_ALTIVEC=OFF
+            -DARROW_USE_CCACHE=ON
+            -DARROW_BOOST_USE_SHARED=OFF
+            -DARROW_BUILD_SHARED=OFF
+            -DARROW_BUILD_STATIC=ON
+            -DARROW_BUILD_UTILITIES=OFF
+            -DARROW_COMPUTE=OFF
+            -DARROW_DATASET=OFF
+            -DARROW_FLIGHT=OFF
+            -DARROW_GFLAGS_USE_SHARED=OFF
+            -DARROW_HDFS=OFF
+            -DARROW_IPC=ON
+            -DARROW_JSON=ON
+            -DARROW_CSV=OFF
+            -DARROW_JEMALLOC=OFF
+            -DARROW_ORC=OFF
+            -DARROW_PARQUET=OFF
+            -DARROW_PROTOBUF_USE_SHARED=OFF
+            -DARROW_USE_GLOG=OFF
+            -DARROW_SIMD_LEVEL=NONE
+            -DARROW_RUNTIME_SIMD_LEVEL=NONE
+            -DARROW_WITH_BROTLI=OFF
+            -DARROW_WITH_LZ4=OFF
+            -DARROW_WITH_PROTOBUF=OFF
+            -DARROW_WITH_RAPIDJSON=OFF
+            -DARROW_WITH_SNAPPY=OFF
+            -DARROW_WITH_ZLIB=OFF
+            -DARROW_WITH_ZSTD=OFF
+            -DBOOST_SOURCE=AUTO
+            <SOURCE_DIR>/cpp
+    UPDATE_COMMAND ""
+    BUILD_BYPRODUCTS
+        <INSTALL_DIR>/lib/libarrow.a
+)
+
+ExternalProject_Get_Property(arrow_ep install_dir)
+set(ARROW_INCLUDE_DIR ${install_dir}/include)
+set(ARROW_LIBRARY_PATH ${install_dir}/lib/libarrow.a)
+file(MAKE_DIRECTORY ${ARROW_INCLUDE_DIR})
+
+add_library(arrow STATIC IMPORTED)
+set_property(TARGET arrow PROPERTY IMPORTED_LOCATION ${ARROW_LIBRARY_PATH})
+set_property(TARGET arrow APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${ARROW_INCLUDE_DIR})
+add_dependencies(arrow arrow_ep)
+
+add_executable(arrow_abi_test
+    ${CMAKE_CURRENT_SOURCE_DIR}/abi_test.cc
+)
+
+include_directories(arrow_abi_test
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/catch
+)
+target_link_libraries(arrow_abi_test arrow)

--- a/tools/arrow_abi_test/CMakeLists.txt
+++ b/tools/arrow_abi_test/CMakeLists.txt
@@ -1,60 +1,37 @@
-# Always build the abi test with asan to reveal problems with the release callbacks
+# Always build the abi test with asan to reveal problems with the release
+# callbacks
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
 
 include(ExternalProject)
 ExternalProject_Add(
-    arrow_ep
-    GIT_REPOSITORY "https://github.com/apache/arrow"
-    GIT_TAG f959141ece4d660bce5f7fa545befc0116a7db79
-    PREFIX "${CMAKE_BINARY_DIR}/third_party/arrow"
-    INSTALL_DIR "${CMAKE_BINARY_DIR}/third_party/arrow/install"
-    CONFIGURE_COMMAND
-        ${CMAKE_COMMAND} 
-            -G${CMAKE_GENERATOR}
-            -DCMAKE_BUILD_TYPE=Release
-            -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-            -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
-            -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-            -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
-            -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-            -DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}
-            -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/third_party/arrow/install
-            -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
-            -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
-            -DARROW_ALTIVEC=OFF
-            -DARROW_USE_CCACHE=ON
-            -DARROW_BOOST_USE_SHARED=OFF
-            -DARROW_BUILD_SHARED=OFF
-            -DARROW_BUILD_STATIC=ON
-            -DARROW_BUILD_UTILITIES=OFF
-            -DARROW_COMPUTE=OFF
-            -DARROW_DATASET=OFF
-            -DARROW_FLIGHT=OFF
-            -DARROW_GFLAGS_USE_SHARED=OFF
-            -DARROW_HDFS=OFF
-            -DARROW_IPC=ON
-            -DARROW_JSON=ON
-            -DARROW_CSV=OFF
-            -DARROW_JEMALLOC=OFF
-            -DARROW_ORC=OFF
-            -DARROW_PARQUET=OFF
-            -DARROW_PROTOBUF_USE_SHARED=OFF
-            -DARROW_USE_GLOG=OFF
-            -DARROW_SIMD_LEVEL=NONE
-            -DARROW_RUNTIME_SIMD_LEVEL=NONE
-            -DARROW_WITH_BROTLI=OFF
-            -DARROW_WITH_LZ4=OFF
-            -DARROW_WITH_PROTOBUF=OFF
-            -DARROW_WITH_RAPIDJSON=OFF
-            -DARROW_WITH_SNAPPY=OFF
-            -DARROW_WITH_ZLIB=OFF
-            -DARROW_WITH_ZSTD=OFF
-            -DBOOST_SOURCE=AUTO
-            <SOURCE_DIR>/cpp
-    UPDATE_COMMAND ""
-    BUILD_BYPRODUCTS
-        <INSTALL_DIR>/lib/libarrow.a
-)
+  arrow_ep
+  GIT_REPOSITORY "https://github.com/apache/arrow"
+  GIT_TAG f959141ece4d660bce5f7fa545befc0116a7db79
+  PREFIX "${CMAKE_BINARY_DIR}/third_party/arrow"
+  INSTALL_DIR "${CMAKE_BINARY_DIR}/third_party/arrow/install"
+  CONFIGURE_COMMAND
+    ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+    -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
+    -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+    -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    -DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}
+    -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/third_party/arrow/install
+    -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} -DARROW_ALTIVEC=OFF
+    -DARROW_USE_CCACHE=ON -DARROW_BOOST_USE_SHARED=OFF -DARROW_BUILD_SHARED=OFF
+    -DARROW_BUILD_STATIC=ON -DARROW_BUILD_UTILITIES=OFF -DARROW_COMPUTE=OFF
+    -DARROW_DATASET=OFF -DARROW_FLIGHT=OFF -DARROW_GFLAGS_USE_SHARED=OFF
+    -DARROW_HDFS=OFF -DARROW_IPC=ON -DARROW_JSON=ON -DARROW_CSV=OFF
+    -DARROW_JEMALLOC=OFF -DARROW_ORC=OFF -DARROW_PARQUET=OFF
+    -DARROW_PROTOBUF_USE_SHARED=OFF -DARROW_USE_GLOG=OFF -DARROW_SIMD_LEVEL=NONE
+    -DARROW_RUNTIME_SIMD_LEVEL=NONE -DARROW_WITH_BROTLI=OFF -DARROW_WITH_LZ4=OFF
+    -DARROW_WITH_PROTOBUF=OFF -DARROW_WITH_RAPIDJSON=OFF -DARROW_WITH_SNAPPY=OFF
+    -DARROW_WITH_ZLIB=OFF -DARROW_WITH_ZSTD=OFF -DBOOST_SOURCE=AUTO
+    <SOURCE_DIR>/cpp
+  UPDATE_COMMAND ""
+  BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libarrow.a)
 
 ExternalProject_Get_Property(arrow_ep install_dir)
 set(ARROW_INCLUDE_DIR ${install_dir}/include)
@@ -63,15 +40,15 @@ file(MAKE_DIRECTORY ${ARROW_INCLUDE_DIR})
 
 add_library(arrow STATIC IMPORTED)
 set_property(TARGET arrow PROPERTY IMPORTED_LOCATION ${ARROW_LIBRARY_PATH})
-set_property(TARGET arrow APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${ARROW_INCLUDE_DIR})
+set_property(
+  TARGET arrow
+  APPEND
+  PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${ARROW_INCLUDE_DIR})
 add_dependencies(arrow arrow_ep)
 
-add_executable(arrow_abi_test
-    ${CMAKE_CURRENT_SOURCE_DIR}/abi_test.cc
-)
+add_executable(arrow_abi_test ${CMAKE_CURRENT_SOURCE_DIR}/abi_test.cc)
 
-include_directories(arrow_abi_test
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/catch
-)
+include_directories(
+  arrow_abi_test ${CMAKE_CURRENT_SOURCE_DIR}/../../src/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/catch)
 target_link_libraries(arrow_abi_test duckdb arrow Threads::Threads)

--- a/tools/arrow_abi_test/CMakeLists.txt
+++ b/tools/arrow_abi_test/CMakeLists.txt
@@ -74,4 +74,4 @@ include_directories(arrow_abi_test
     ${CMAKE_CURRENT_SOURCE_DIR}/../../src/include
     ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/catch
 )
-target_link_libraries(arrow_abi_test arrow Threads::Threads)
+target_link_libraries(arrow_abi_test duckdb arrow Threads::Threads)

--- a/tools/arrow_abi_test/abi_test.cc
+++ b/tools/arrow_abi_test/abi_test.cc
@@ -24,7 +24,7 @@ static arrow::Result<std::shared_ptr<arrow::Array>> GenI32Seq(int32_t n, int32_t
 	for (int32_t i = 0; i < n; ++i) {
 		builder.Append(next++).ok();
 	}
-    REQUIRE(builder.length() == n);
+	REQUIRE(builder.length() == n);
 	return builder.Finish();
 }
 constexpr size_t ARRAY_SIZE = 1024;
@@ -75,7 +75,7 @@ TEST_CASE("Test random integers") {
 		int32_t start_a = 0, start_b = 0xFFFF, start_c = 0xFFFFF;
 
 		DYNAMIC_SECTION("N=" << n) {
-		    int32_t next_a = start_a, next_b = start_b, next_c = start_c;
+			int32_t next_a = start_a, next_b = start_b, next_c = start_c;
 
 			std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
 			while (n > 0) {
@@ -83,36 +83,36 @@ TEST_CASE("Test random integers") {
 				REQUIRE_RESULT(auto a, GenI32Seq(here, next_a));
 				REQUIRE_RESULT(auto b, GenI32Seq(here, next_b));
 				REQUIRE_RESULT(auto c, GenI32Seq(here, next_c));
-                next_a += here;
-                next_b += here;
-                next_c += here;
+				next_a += here;
+				next_b += here;
+				next_c += here;
 				batches.push_back(arrow::RecordBatch::Make(schema, here, {a, b, c}));
-                n -= here;
+				n -= here;
 			}
 
 			SECTION("Batch reader") {
 				REQUIRE_RESULT(auto reader, arrow::RecordBatchReader::Make(batches, schema));
 
-		        int32_t expected_a = start_a, expected_b = start_b, expected_c = start_c;
+				int32_t expected_a = start_a, expected_b = start_b, expected_c = start_c;
 
-                for (auto next = reader->Next(); next.ok() && next.ValueUnsafe(); next = reader->Next()) {
-                    auto& batch = *next.ValueUnsafe();
-                    REQUIRE(batch.num_columns() == 3);
+				for (auto next = reader->Next(); next.ok() && next.ValueUnsafe(); next = reader->Next()) {
+					auto &batch = *next.ValueUnsafe();
+					REQUIRE(batch.num_columns() == 3);
 
-                    auto a_array = batch.column(0);
-                    auto b_array = batch.column(1);
-                    auto c_array = batch.column(2);
-                    REQUIRE(a_array->type_id() == arrow::Type::INT32);
-                    REQUIRE(b_array->type_id() == arrow::Type::INT32);
-                    REQUIRE(c_array->type_id() == arrow::Type::INT32);
+					auto a_array = batch.column(0);
+					auto b_array = batch.column(1);
+					auto c_array = batch.column(2);
+					REQUIRE(a_array->type_id() == arrow::Type::INT32);
+					REQUIRE(b_array->type_id() == arrow::Type::INT32);
+					REQUIRE(c_array->type_id() == arrow::Type::INT32);
 
-                    for (int64_t i = 0; i < batch.num_rows(); ++i) {
-                        INFO(a_array->ToString());
-                        REQUIRE(reinterpret_cast<const arrow::Int32Array*>(a_array.get())->Value(i) == expected_a++);
-                        REQUIRE(reinterpret_cast<const arrow::Int32Array*>(b_array.get())->Value(i) == expected_b++);
-                        REQUIRE(reinterpret_cast<const arrow::Int32Array*>(c_array.get())->Value(i) == expected_c++);
-                    }
-                }
+					for (int64_t i = 0; i < batch.num_rows(); ++i) {
+						INFO(a_array->ToString());
+						REQUIRE(reinterpret_cast<const arrow::Int32Array *>(a_array.get())->Value(i) == expected_a++);
+						REQUIRE(reinterpret_cast<const arrow::Int32Array *>(b_array.get())->Value(i) == expected_b++);
+						REQUIRE(reinterpret_cast<const arrow::Int32Array *>(c_array.get())->Value(i) == expected_c++);
+					}
+				}
 			}
 
 			SECTION("DuckDB scan") {
@@ -128,6 +128,6 @@ TEST_CASE("Test random integers") {
 				// XXX Never gets here atm
 				(void)result;
 			}
-        }
+		}
 	}
 }

--- a/tools/arrow_abi_test/abi_test.cc
+++ b/tools/arrow_abi_test/abi_test.cc
@@ -1,4 +1,3 @@
-#include "duckdb/common/helper.hpp"
 #include "arrow/array.h"
 #include "arrow/array/builder_primitive.h"
 #include "arrow/c/abi.h"
@@ -8,6 +7,11 @@
 #include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/type_fwd.h"
+#include "duckdb/common/helper.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
 
 #include <arrow/type_traits.h>
 #include <memory>
@@ -15,11 +19,12 @@
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
 
-static arrow::Result<std::shared_ptr<arrow::Array>> GenI32Seq(int32_t n, int32_t &next) {
+static arrow::Result<std::shared_ptr<arrow::Array>> GenI32Seq(int32_t n, int32_t next) {
 	arrow::TypeTraits<arrow::Int32Type>::BuilderType builder;
 	for (int32_t i = 0; i < n; ++i) {
 		builder.Append(next++).ok();
 	}
+    REQUIRE(builder.length() == n);
 	return builder.Finish();
 }
 constexpr size_t ARRAY_SIZE = 1024;
@@ -27,6 +32,37 @@ constexpr size_t ARRAY_SIZE = 1024;
 #define REQUIRE_RESULT(OUT, IN)                                                                                        \
 	REQUIRE(IN.ok());                                                                                                  \
 	OUT = IN.ValueUnsafe();
+
+struct SimpleFactory {
+	/// All materialized batches
+	arrow::RecordBatchVector batches;
+	/// The schema
+	std::shared_ptr<arrow::Schema> schema;
+
+	SimpleFactory(arrow::RecordBatchVector batches, std::shared_ptr<arrow::Schema> schema)
+	    : batches(std::move(batches)), schema(std::move(schema)) {
+	}
+
+	static ArrowArrayStream *CreateStream(uintptr_t this_ptr) {
+		// Create a new batch reader
+		auto &factory = *reinterpret_cast<SimpleFactory *>(this_ptr); // NOLINT
+		REQUIRE_RESULT(auto reader, arrow::RecordBatchReader::Make(factory.batches, factory.schema));
+
+		// Export C arrow stream stream
+		auto stream = duckdb::make_unique<ArrowArrayStream>();
+		stream->release = nullptr;
+		auto maybe_ok = arrow::ExportRecordBatchReader(reader, stream.get());
+		if (!maybe_ok.ok()) {
+			if (stream->release) {
+				stream->release(stream.get());
+			}
+			return nullptr;
+		}
+
+		// Release the stream
+		return stream.release();
+	}
+};
 
 TEST_CASE("Test random integers") {
 
@@ -37,27 +73,61 @@ TEST_CASE("Test random integers") {
 		    arrow::field("c", arrow::int32()),
 		});
 		int32_t start_a = 0, start_b = 0xFFFF, start_c = 0xFFFFF;
-		int32_t next_a = start_a, next_b = start_b, next_c = start_c;
 
 		DYNAMIC_SECTION("N=" << n) {
+		    int32_t next_a = start_a, next_b = start_b, next_c = start_c;
+
 			std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
-			for (size_t ofs = 0; ofs < n;) {
-				auto here = std::min<size_t>(ARRAY_SIZE, n - ofs);
-				REQUIRE_RESULT(auto a, GenI32Seq(ofs, next_a));
-				REQUIRE_RESULT(auto b, GenI32Seq(ofs, next_b));
-				REQUIRE_RESULT(auto c, GenI32Seq(ofs, next_c));
+			while (n > 0) {
+				auto here = std::min<size_t>(ARRAY_SIZE, n);
+				REQUIRE_RESULT(auto a, GenI32Seq(here, next_a));
+				REQUIRE_RESULT(auto b, GenI32Seq(here, next_b));
+				REQUIRE_RESULT(auto c, GenI32Seq(here, next_c));
+                next_a += here;
+                next_b += here;
+                next_c += here;
 				batches.push_back(arrow::RecordBatch::Make(schema, here, {a, b, c}));
-				ofs += ARRAY_SIZE;
+                n -= here;
 			}
-			REQUIRE_RESULT(auto reader, arrow::RecordBatchReader::Make(std::move(batches), schema));
 
-			auto stream = duckdb::make_unique<::ArrowArrayStream>();
-			REQUIRE(arrow::ExportRecordBatchReader(reader, stream.get()).ok());
+			SECTION("Batch reader") {
+				REQUIRE_RESULT(auto reader, arrow::RecordBatchReader::Make(batches, schema));
 
-            if (stream->release) {
-                stream->release(stream.get());
-                stream->release = nullptr;
-            }
-		}
+		        int32_t expected_a = start_a, expected_b = start_b, expected_c = start_c;
+
+                for (auto next = reader->Next(); next.ok() && next.ValueUnsafe(); next = reader->Next()) {
+                    auto& batch = *next.ValueUnsafe();
+                    REQUIRE(batch.num_columns() == 3);
+
+                    auto a_array = batch.column(0);
+                    auto b_array = batch.column(1);
+                    auto c_array = batch.column(2);
+                    REQUIRE(a_array->type_id() == arrow::Type::INT32);
+                    REQUIRE(b_array->type_id() == arrow::Type::INT32);
+                    REQUIRE(c_array->type_id() == arrow::Type::INT32);
+
+                    for (int64_t i = 0; i < batch.num_rows(); ++i) {
+                        INFO(a_array->ToString());
+                        REQUIRE(reinterpret_cast<const arrow::Int32Array*>(a_array.get())->Value(i) == expected_a++);
+                        REQUIRE(reinterpret_cast<const arrow::Int32Array*>(b_array.get())->Value(i) == expected_b++);
+                        REQUIRE(reinterpret_cast<const arrow::Int32Array*>(c_array.get())->Value(i) == expected_c++);
+                    }
+                }
+			}
+
+			SECTION("DuckDB scan") {
+				SimpleFactory factory {batches, schema};
+				duckdb::DuckDB db;
+				duckdb::Connection conn {db};
+
+				duckdb::vector<duckdb::Value> params;
+				params.push_back(duckdb::Value::POINTER((uintptr_t)&factory));
+				params.push_back(duckdb::Value::POINTER((uintptr_t)&SimpleFactory::CreateStream));
+				auto result = conn.TableFunction("arrow_scan", params)->Execute();
+
+				// XXX Never gets here atm
+				(void)result;
+			}
+        }
 	}
 }

--- a/tools/arrow_abi_test/abi_test.cc
+++ b/tools/arrow_abi_test/abi_test.cc
@@ -1,5 +1,49 @@
+#include <arrow/type_traits.h>
+#define CATCH_CONFIG_MAIN
+#include "arrow/array.h"
+#include "arrow/array/builder_primitive.h"
+#include "arrow/c/bridge.h"
+#include "arrow/record_batch.h"
+#include "arrow/result.h"
+#include "arrow/status.h"
+#include "arrow/type.h"
+#include "arrow/type_fwd.h"
 #include "catch.hpp"
 
-int main() {
-    return 0;
+static arrow::Result<std::shared_ptr<arrow::Array>> GenI32Seq(int32_t n, int32_t& next) {
+	arrow::TypeTraits<arrow::Int32Type>::BuilderType builder;
+	for (int32_t i = 0; i < n; ++i) {
+		builder.Append(next++).ok();
+	}
+	return builder.Finish();
+}
+constexpr size_t ARRAY_SIZE = 1024;
+
+#define REQUIRE_RESULT(OUT, IN) REQUIRE(IN.ok()); OUT = IN.ValueUnsafe();
+
+TEST_CASE("Test random integers") {
+
+	for (size_t n : std::vector<size_t> {100, 1000, 10000, 100000}) {
+		auto schema = arrow::schema({
+		    arrow::field("a", arrow::int32()),
+		    arrow::field("b", arrow::int32()),
+		    arrow::field("c", arrow::int32()),
+		});
+        int32_t start_a = 0, start_b = 0xFFFF, start_c = 0xFFFFF;
+        int32_t next_a = start_a, next_b = start_b, next_c = start_c;
+
+		DYNAMIC_SECTION("N=" << n) {
+			std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+			for (size_t ofs = 0; ofs < n;) {
+				auto here = std::min<size_t>(ARRAY_SIZE, n - ofs);
+                REQUIRE_RESULT(auto a, GenI32Seq(ofs, next_a));
+                REQUIRE_RESULT(auto b, GenI32Seq(ofs, next_b));
+                REQUIRE_RESULT(auto c, GenI32Seq(ofs, next_c));
+				batches.push_back(
+				    arrow::RecordBatch::Make(schema, here, {a, b, c}));
+                ofs += ARRAY_SIZE;
+			}
+            REQUIRE_RESULT(auto maybe_reader, arrow::RecordBatchReader::Make(std::move(batches), schema));
+		}
+	}
 }

--- a/tools/arrow_abi_test/abi_test.cc
+++ b/tools/arrow_abi_test/abi_test.cc
@@ -59,7 +59,7 @@ struct SimpleFactory {
 			return nullptr;
 		}
 
-		// Release the stream
+		// Pass ownership to caller
 		return stream.release();
 	}
 };

--- a/tools/arrow_abi_test/abi_test.cc
+++ b/tools/arrow_abi_test/abi_test.cc
@@ -1,0 +1,5 @@
+#include "catch.hpp"
+
+int main() {
+    return 0;
+}


### PR DESCRIPTION
This PR drafts a failing test that uses an exported RecordBatchReader of the C++ Arrow library with the arrow_scan function.
It should probably be merged into @pdet s branch rather than with master.
Also, the test isn't built with any CI actions yet and does not yet test the DuckDB result rows.

Fixing this will resolve https://github.com/duckdb/duckdb/issues/1760.