### PR TITLE
Add support for key/value style configuration, and expose this in the Python API

### DIFF
--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -24,6 +24,24 @@ class TableFunctionRef;
 enum class AccessMode : uint8_t { UNDEFINED = 0, AUTOMATIC = 1, READ_ONLY = 2, READ_WRITE = 3 };
 enum class CheckpointAbort : uint8_t { NO_ABORT = 0, DEBUG_ABORT_BEFORE_TRUNCATE = 1, DEBUG_ABORT_BEFORE_HEADER = 2 };
 
+enum class ConfigurationOptionType : uint32_t {
+	INVALID = 0,
+	ACCESS_MODE,
+	DEFAULT_ORDER_TYPE,
+	DEFAULT_NULL_ORDER,
+	ENABLE_EXTERNAL_ACCESS,
+	ENABLE_OBJECT_CACHE,
+	MAXIMUM_MEMORY,
+	THREADS
+};
+
+struct ConfigurationOption {
+	ConfigurationOptionType type;
+	const char *name;
+	const char *description;
+	LogicalTypeId parameter_type;
+};
+
 // this is optional and only used in tests at the moment
 struct DBConfig {
 	friend class DatabaseInstance;
@@ -58,7 +76,7 @@ public:
 	//! Null ordering used when none is specified (default: NULLS FIRST)
 	OrderByNullType default_null_order = OrderByNullType::NULLS_FIRST;
 	//! enable COPY and related commands
-	bool enable_copy = true;
+	bool enable_external_access = true;
 	//! Whether or not object cache is used
 	bool object_cache_enable = false;
 	//! Database configuration variables as controlled by SET
@@ -75,6 +93,14 @@ public:
 public:
 	DUCKDB_API static DBConfig &GetConfig(ClientContext &context);
 	DUCKDB_API static DBConfig &GetConfig(DatabaseInstance &db);
+	DUCKDB_API static vector<ConfigurationOption> GetOptions();
+
+	//! Fetch an option by name. Returns a pointer to the option, or nullptr if none exists.
+	DUCKDB_API static ConfigurationOption *GetOptionByName(const string &name);
+
+	DUCKDB_API void SetOption(const ConfigurationOption &option, Value value);
+
+	DUCKDB_API static idx_t ParseMemoryLimit(const string &arg);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -98,7 +98,7 @@ public:
 	//! Fetch an option by name. Returns a pointer to the option, or nullptr if none exists.
 	DUCKDB_API static ConfigurationOption *GetOptionByName(const string &name);
 
-	DUCKDB_API void SetOption(const ConfigurationOption &option, Value value);
+	DUCKDB_API void SetOption(const ConfigurationOption &option, const Value &value);
 
 	DUCKDB_API static idx_t ParseMemoryLimit(const string &arg);
 };

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(relation)
 set(DUCKDB_MAIN_FILES
     appender.cpp
     client_context.cpp
+    config.cpp
     connection.cpp
     database.cpp
     materialized_query_result.cpp

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -69,11 +69,11 @@ void DBConfig::SetOption(const ConfigurationOption &option, Value value) {
 		break;
 	}
 	case ConfigurationOptionType::ENABLE_EXTERNAL_ACCESS: {
-		enable_external_access = value.GetValue<bool>();
+		enable_external_access = value.CastAs(LogicalType::BOOLEAN).GetValueUnsafe<int8_t>();
 		break;
 	}
 	case ConfigurationOptionType::ENABLE_OBJECT_CACHE: {
-		object_cache_enable = value.GetValue<bool>();
+		object_cache_enable = value.CastAs(LogicalType::BOOLEAN).GetValueUnsafe<int8_t>();
 		break;
 	}
 	case ConfigurationOptionType::MAXIMUM_MEMORY: {

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -5,25 +5,34 @@
 namespace duckdb {
 
 static ConfigurationOption internal_options[] = {
-    { ConfigurationOptionType::ACCESS_MODE, "access_mode", "Access mode of the database (AUTOMATIC, READ_ONLY or READ_WRITE)", LogicalTypeId::VARCHAR},
-    { ConfigurationOptionType::DEFAULT_ORDER_TYPE, "default_order", "The order type used when none is specified (default: ASC)", LogicalTypeId::VARCHAR},
-    { ConfigurationOptionType::DEFAULT_NULL_ORDER, "default_null_order", "Null ordering used when none is specified (default: NULLS FIRST)", LogicalTypeId::VARCHAR},
-    { ConfigurationOptionType::ENABLE_EXTERNAL_ACCESS, "enable_external_access", "Allow the database to access external state (through e.g. COPY TO/FROM, CSV readers, pandas replacement scans, etc)", LogicalTypeId::BOOLEAN},
-    { ConfigurationOptionType::ENABLE_OBJECT_CACHE, "enable_object_cache", "Whether or not object cache is used to cache e.g. Parquet metadata", LogicalTypeId::BOOLEAN},
-	{ ConfigurationOptionType::MAXIMUM_MEMORY, "max_memory", "The maximum memory of the system", LogicalTypeId::VARCHAR},
-	{ ConfigurationOptionType::THREADS, "threads", "The number of total threads used by the system", LogicalTypeId::BIGINT},
-    { ConfigurationOptionType::INVALID, nullptr, nullptr, LogicalTypeId::INVALID }};
+    {ConfigurationOptionType::ACCESS_MODE, "access_mode",
+     "Access mode of the database ([AUTOMATIC], READ_ONLY or READ_WRITE)", LogicalTypeId::VARCHAR},
+    {ConfigurationOptionType::DEFAULT_ORDER_TYPE, "default_order",
+     "The order type used when none is specified ([ASC] or DESC)", LogicalTypeId::VARCHAR},
+    {ConfigurationOptionType::DEFAULT_NULL_ORDER, "default_null_order",
+     "Null ordering used when none is specified ([NULLS_FIRST] or NULLS_LAST)", LogicalTypeId::VARCHAR},
+    {ConfigurationOptionType::ENABLE_EXTERNAL_ACCESS, "enable_external_access",
+     "Allow the database to access external state (through e.g. COPY TO/FROM, CSV readers, pandas replacement scans, "
+     "etc)",
+     LogicalTypeId::BOOLEAN},
+    {ConfigurationOptionType::ENABLE_OBJECT_CACHE, "enable_object_cache",
+     "Whether or not object cache is used to cache e.g. Parquet metadata", LogicalTypeId::BOOLEAN},
+    {ConfigurationOptionType::MAXIMUM_MEMORY, "max_memory", "The maximum memory of the system (e.g. 1GB)",
+     LogicalTypeId::VARCHAR},
+    {ConfigurationOptionType::THREADS, "threads", "The number of total threads used by the system",
+     LogicalTypeId::BIGINT},
+    {ConfigurationOptionType::INVALID, nullptr, nullptr, LogicalTypeId::INVALID}};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {
 	vector<ConfigurationOption> options;
-	for(idx_t index = 0; internal_options[index].name; index++) {
+	for (idx_t index = 0; internal_options[index].name; index++) {
 		options.push_back(internal_options[index]);
 	}
 	return options;
 }
 
 ConfigurationOption *DBConfig::GetOptionByName(const string &name) {
-	for(idx_t index = 0; internal_options[index].name; index++) {
+	for (idx_t index = 0; internal_options[index].name; index++) {
 		if (internal_options[index].name == name) {
 			return internal_options + index;
 		}
@@ -32,7 +41,7 @@ ConfigurationOption *DBConfig::GetOptionByName(const string &name) {
 }
 
 void DBConfig::SetOption(const ConfigurationOption &option, Value value) {
-	switch(option.type) {
+	switch (option.type) {
 	case ConfigurationOptionType::ACCESS_MODE: {
 		auto parameter = StringUtil::Lower(value.ToString());
 		if (parameter == "automatic") {
@@ -42,7 +51,8 @@ void DBConfig::SetOption(const ConfigurationOption &option, Value value) {
 		} else if (parameter == "read_write") {
 			access_mode = AccessMode::READ_WRITE;
 		} else {
-			throw InvalidInputException("Unrecognized parameter for option ACCESS_MODE \"%s\". Expected READ_ONLY or READ_WRITE.", parameter);
+			throw InvalidInputException(
+			    "Unrecognized parameter for option ACCESS_MODE \"%s\". Expected READ_ONLY or READ_WRITE.", parameter);
 		}
 		break;
 	}
@@ -53,7 +63,8 @@ void DBConfig::SetOption(const ConfigurationOption &option, Value value) {
 		} else if (parameter == "desc") {
 			default_order_type = OrderType::DESCENDING;
 		} else {
-			throw InvalidInputException("Unrecognized parameter for option DEFAULT_ORDER \"%s\". Expected ASC or DESC.", parameter);
+			throw InvalidInputException("Unrecognized parameter for option DEFAULT_ORDER \"%s\". Expected ASC or DESC.",
+			                            parameter);
 		}
 		break;
 	}
@@ -64,7 +75,8 @@ void DBConfig::SetOption(const ConfigurationOption &option, Value value) {
 		} else if (parameter == "nulls_last") {
 			default_null_order = OrderByNullType::NULLS_LAST;
 		} else {
-			throw InvalidInputException("Unrecognized parameter for option NULL_ORDER \"%s\". Expected NULLS_FIRST or NULLS_LAST.", parameter);
+			throw InvalidInputException(
+			    "Unrecognized parameter for option NULL_ORDER \"%s\". Expected NULLS_FIRST or NULLS_LAST.", parameter);
 		}
 		break;
 	}
@@ -141,4 +153,4 @@ idx_t DBConfig::ParseMemoryLimit(const string &arg) {
 	return (idx_t)multiplier * limit;
 }
 
-}
+} // namespace duckdb

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -1,0 +1,144 @@
+#include "duckdb/main/config.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/operator/cast_operators.hpp"
+
+namespace duckdb {
+
+static ConfigurationOption internal_options[] = {
+    { ConfigurationOptionType::ACCESS_MODE, "access_mode", "Access mode of the database (AUTOMATIC, READ_ONLY or READ_WRITE)", LogicalTypeId::VARCHAR},
+    { ConfigurationOptionType::DEFAULT_ORDER_TYPE, "default_order", "The order type used when none is specified (default: ASC)", LogicalTypeId::VARCHAR},
+    { ConfigurationOptionType::DEFAULT_NULL_ORDER, "default_null_order", "Null ordering used when none is specified (default: NULLS FIRST)", LogicalTypeId::VARCHAR},
+    { ConfigurationOptionType::ENABLE_EXTERNAL_ACCESS, "enable_external_access", "Allow the database to access external state (through e.g. COPY TO/FROM, CSV readers, pandas replacement scans, etc)", LogicalTypeId::BOOLEAN},
+    { ConfigurationOptionType::ENABLE_OBJECT_CACHE, "enable_object_cache", "Whether or not object cache is used to cache e.g. Parquet metadata", LogicalTypeId::BOOLEAN},
+	{ ConfigurationOptionType::MAXIMUM_MEMORY, "max_memory", "The maximum memory of the system", LogicalTypeId::VARCHAR},
+	{ ConfigurationOptionType::THREADS, "threads", "The number of total threads used by the system", LogicalTypeId::BIGINT},
+    { ConfigurationOptionType::INVALID, nullptr, nullptr, LogicalTypeId::INVALID }};
+
+vector<ConfigurationOption> DBConfig::GetOptions() {
+	vector<ConfigurationOption> options;
+	for(idx_t index = 0; internal_options[index].name; index++) {
+		options.push_back(internal_options[index]);
+	}
+	return options;
+}
+
+ConfigurationOption *DBConfig::GetOptionByName(const string &name) {
+	for(idx_t index = 0; internal_options[index].name; index++) {
+		if (internal_options[index].name == name) {
+			return internal_options + index;
+		}
+	}
+	return nullptr;
+}
+
+void DBConfig::SetOption(const ConfigurationOption &option, Value value) {
+	switch(option.type) {
+	case ConfigurationOptionType::ACCESS_MODE: {
+		auto parameter = StringUtil::Lower(value.ToString());
+		if (parameter == "automatic") {
+			access_mode = AccessMode::AUTOMATIC;
+		} else if (parameter == "read_only") {
+			access_mode = AccessMode::READ_ONLY;
+		} else if (parameter == "read_write") {
+			access_mode = AccessMode::READ_WRITE;
+		} else {
+			throw InvalidInputException("Unrecognized parameter for option ACCESS_MODE \"%s\". Expected READ_ONLY or READ_WRITE.", parameter);
+		}
+		break;
+	}
+	case ConfigurationOptionType::DEFAULT_ORDER_TYPE: {
+		auto parameter = StringUtil::Lower(value.ToString());
+		if (parameter == "asc") {
+			default_order_type = OrderType::ASCENDING;
+		} else if (parameter == "desc") {
+			default_order_type = OrderType::DESCENDING;
+		} else {
+			throw InvalidInputException("Unrecognized parameter for option DEFAULT_ORDER \"%s\". Expected ASC or DESC.", parameter);
+		}
+		break;
+	}
+	case ConfigurationOptionType::DEFAULT_NULL_ORDER: {
+		auto parameter = StringUtil::Lower(value.ToString());
+		if (parameter == "nulls_first") {
+			default_null_order = OrderByNullType::NULLS_FIRST;
+		} else if (parameter == "nulls_last") {
+			default_null_order = OrderByNullType::NULLS_LAST;
+		} else {
+			throw InvalidInputException("Unrecognized parameter for option NULL_ORDER \"%s\". Expected NULLS_FIRST or NULLS_LAST.", parameter);
+		}
+		break;
+	}
+	case ConfigurationOptionType::ENABLE_EXTERNAL_ACCESS: {
+		enable_external_access = value.GetValue<bool>();
+		break;
+	}
+	case ConfigurationOptionType::ENABLE_OBJECT_CACHE: {
+		object_cache_enable = value.GetValue<bool>();
+		break;
+	}
+	case ConfigurationOptionType::MAXIMUM_MEMORY: {
+		maximum_memory = ParseMemoryLimit(value.ToString());
+		break;
+	}
+	case ConfigurationOptionType::THREADS: {
+		maximum_threads = value.GetValue<int64_t>();
+		break;
+	}
+	default:
+		break;
+	}
+}
+
+idx_t DBConfig::ParseMemoryLimit(const string &arg) {
+	if (arg[0] == '-' || arg == "null" || arg == "none") {
+		return INVALID_INDEX;
+	}
+	// split based on the number/non-number
+	idx_t idx = 0;
+	while (StringUtil::CharacterIsSpace(arg[idx])) {
+		idx++;
+	}
+	idx_t num_start = idx;
+	while ((arg[idx] >= '0' && arg[idx] <= '9') || arg[idx] == '.' || arg[idx] == 'e' || arg[idx] == 'E' ||
+	       arg[idx] == '-') {
+		idx++;
+	}
+	if (idx == num_start) {
+		throw ParserException("Memory limit must have a number (e.g. PRAGMA memory_limit=1GB");
+	}
+	string number = arg.substr(num_start, idx - num_start);
+
+	// try to parse the number
+	double limit = Cast::Operation<string_t, double>(string_t(number));
+
+	// now parse the memory limit unit (e.g. bytes, gb, etc)
+	while (StringUtil::CharacterIsSpace(arg[idx])) {
+		idx++;
+	}
+	idx_t start = idx;
+	while (idx < arg.size() && !StringUtil::CharacterIsSpace(arg[idx])) {
+		idx++;
+	}
+	if (limit < 0) {
+		// limit < 0, set limit to infinite
+		return (idx_t)-1;
+	}
+	string unit = StringUtil::Lower(arg.substr(start, idx - start));
+	idx_t multiplier;
+	if (unit == "byte" || unit == "bytes" || unit == "b") {
+		multiplier = 1;
+	} else if (unit == "kilobyte" || unit == "kilobytes" || unit == "kb" || unit == "k") {
+		multiplier = 1000LL;
+	} else if (unit == "megabyte" || unit == "megabytes" || unit == "mb" || unit == "m") {
+		multiplier = 1000LL * 1000LL;
+	} else if (unit == "gigabyte" || unit == "gigabytes" || unit == "gb" || unit == "g") {
+		multiplier = 1000LL * 1000LL * 1000LL;
+	} else if (unit == "terabyte" || unit == "terabytes" || unit == "tb" || unit == "t") {
+		multiplier = 1000LL * 1000LL * 1000LL * 1000LL;
+	} else {
+		throw ParserException("Unknown unit for memory_limit: %s (expected: b, mb, gb or tb)", unit);
+	}
+	return (idx_t)multiplier * limit;
+}
+
+}

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -40,7 +40,7 @@ ConfigurationOption *DBConfig::GetOptionByName(const string &name) {
 	return nullptr;
 }
 
-void DBConfig::SetOption(const ConfigurationOption &option, Value value) {
+void DBConfig::SetOption(const ConfigurationOption &option, const Value &value) {
 	switch (option.type) {
 	case ConfigurationOptionType::ACCESS_MODE: {
 		auto parameter = StringUtil::Lower(value.ToString());

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -206,7 +206,7 @@ void DatabaseInstance::Configure(DBConfig &new_config) {
 	config.collation = new_config.collation;
 	config.default_order_type = new_config.default_order_type;
 	config.default_null_order = new_config.default_null_order;
-	config.enable_copy = new_config.enable_copy;
+	config.enable_external_access = new_config.enable_external_access;
 	config.replacement_scans = move(new_config.replacement_scans);
 }
 

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -21,7 +21,7 @@ namespace duckdb {
 BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 	// COPY TO a file
 	auto &config = DBConfig::GetConfig(context);
-	if (!config.enable_copy) {
+	if (!config.enable_external_access) {
 		throw Exception("COPY TO is disabled by configuration");
 	}
 	BoundStatement result;
@@ -51,7 +51,7 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 
 BoundStatement Binder::BindCopyFrom(CopyStatement &stmt) {
 	auto &config = DBConfig::GetConfig(context);
-	if (!config.enable_copy) {
+	if (!config.enable_external_access) {
 		throw Exception("COPY FROM is disabled by configuration");
 	}
 	BoundStatement result;

--- a/src/planner/binder/statement/bind_export.cpp
+++ b/src/planner/binder/statement/bind_export.cpp
@@ -16,7 +16,7 @@ namespace duckdb {
 BoundStatement Binder::Bind(ExportStatement &stmt) {
 	// COPY TO a file
 	auto &config = DBConfig::GetConfig(context);
-	if (!config.enable_copy) {
+	if (!config.enable_external_access) {
 		throw Exception("COPY TO is disabled by configuration");
 	}
 	BoundStatement result;

--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -74,7 +74,7 @@ PYBIND11_MODULE(duckdb, m) {
 	m.def("connect", &DuckDBPyConnection::Connect,
 	      "Create a DuckDB database instance. Can take a database file name to read/write persistent data and a "
 	      "read_only flag if no changes are desired",
-	      py::arg("database") = ":memory:", py::arg("read_only") = false);
+	      py::arg("database") = ":memory:", py::arg("read_only") = false, py::arg("config") = py::dict());
 	m.def("tokenize", PyTokenize,
 	      "Tokenizes a SQL string, returning a list of (position, type) tuples that can be "
 	      "used for e.g. syntax highlighting",

--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
@@ -106,7 +106,7 @@ public:
 
 	py::object FetchArrow();
 
-	static shared_ptr<DuckDBPyConnection> Connect(const string &database, bool read_only, py::dict config);
+	static shared_ptr<DuckDBPyConnection> Connect(const string &database, bool read_only, const py::dict &config);
 
 	static vector<Value> TransformPythonParamList(py::handle params);
 

--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
@@ -106,7 +106,7 @@ public:
 
 	py::object FetchArrow();
 
-	static shared_ptr<DuckDBPyConnection> Connect(const string &database, bool read_only);
+	static shared_ptr<DuckDBPyConnection> Connect(const string &database, bool read_only, py::dict config);
 
 	static vector<Value> TransformPythonParamList(py::handle params);
 

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -432,7 +432,9 @@ shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Connect(const string &databas
 		}
 		config.SetOption(*config_property, Value(val));
 	}
-	config.replacement_scans.emplace_back(PandasScanReplacement);
+	if (config.enable_external_access) {
+		config.replacement_scans.emplace_back(PandasScanReplacement);
+	}
 
 	res->database = make_unique<DuckDB>(database, &config);
 	ExtensionHelper::LoadAllExtensions(*res->database);

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -418,7 +418,7 @@ static unique_ptr<TableFunctionRef> PandasScanReplacement(const string &table_na
 }
 
 shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Connect(const string &database, bool read_only,
-                                                           py::dict config_dict) {
+                                                           const py::dict &config_dict) {
 	auto res = make_shared<DuckDBPyConnection>();
 	DBConfig config;
 	if (read_only) {

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -417,13 +417,14 @@ static unique_ptr<TableFunctionRef> PandasScanReplacement(const string &table_na
 	return TryPandasReplacement(global_dict, py_table_name);
 }
 
-shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Connect(const string &database, bool read_only, py::dict config_dict) {
+shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Connect(const string &database, bool read_only,
+                                                           py::dict config_dict) {
 	auto res = make_shared<DuckDBPyConnection>();
 	DBConfig config;
 	if (read_only) {
 		config.access_mode = AccessMode::READ_ONLY;
 	}
-	for(auto &kv : config_dict) {
+	for (auto &kv : config_dict) {
 		string key = py::str(kv.first);
 		string val = py::str(kv.second);
 		auto config_property = DBConfig::GetOptionByName(key);

--- a/tools/pythonpkg/tests/api/test_config.py
+++ b/tools/pythonpkg/tests/api/test_config.py
@@ -1,0 +1,57 @@
+# simple DB API testcase
+
+import duckdb
+import numpy
+import pandas
+
+class TestDBConfig(object):
+    def test_default_order(self, duckdb_cursor):
+        df = pandas.DataFrame({'a': [1,2,3]})
+        con = duckdb.connect(':memory:', config={'default_order': 'desc'})
+        result = con.execute('select * from df order by a').fetchall()
+        assert result == [(3,), (2,), (1,)]
+
+    def test_null_order(self, duckdb_cursor):
+        df = pandas.DataFrame({'a': [1,2,3,None]})
+        con = duckdb.connect(':memory:', config={'default_null_order': 'nulls_last'})
+        result = con.execute('select * from df order by a').fetchall()
+        assert result == [(1,), (2,), (3,), (None,)]
+
+    def test_multiple_options(self, duckdb_cursor):
+        df = pandas.DataFrame({'a': [1,2,3,None]})
+        con = duckdb.connect(':memory:', config={'default_null_order': 'nulls_last', 'default_order': 'desc'})
+        result = con.execute('select * from df order by a').fetchall()
+        assert result == [(3,), (2,), (1,), (None,)]
+
+    def test_external_access(self, duckdb_cursor):
+        df = pandas.DataFrame({'a': [1,2,3]})
+        # this works (replacement scan)
+        con_regular = duckdb.connect(':memory:', config={})
+        con_regular.execute('select * from df')
+        # disable external access: this also disables pandas replacement scans
+        con = duckdb.connect(':memory:', config={'enable_external_access': False})
+        # this should fail
+        query_failed = False
+        try:
+            con.execute('select * from df').fetchall()
+        except:
+            query_failed = True
+        assert query_failed == True
+
+    def test_unrecognized_option(self, duckdb_cursor):
+        success = True
+        try:
+            con_regular = duckdb.connect(':memory:', config={'thisoptionisprobablynotthere': '42'})
+        except:
+            success = False
+        assert success==False
+
+    def test_incorrect_parameter(self, duckdb_cursor):
+        success = True
+        try:
+            con_regular = duckdb.connect(':memory:', config={'default_null_order': '42'})
+        except:
+            success = False
+        assert success==False
+
+

--- a/tools/rest/server.cpp
+++ b/tools/rest/server.cpp
@@ -259,7 +259,7 @@ int main(int argc, char **argv) {
 		} else if (arg == "--read_only") {
 			config.access_mode = AccessMode::READ_ONLY;
 		} else if (arg == "--disable_copy") {
-			config.enable_copy = false;
+			config.enable_external_access = false;
 		} else if (StringUtil::StartsWith(arg, "--database=")) {
 			auto splits = StringUtil::Split(arg, '=');
 			if (splits.size() != 2) {


### PR DESCRIPTION
In addition, this PR turns the configuration option `enable_copy` into `enable_external_access`. Disabling this flag also disables Pandas replacement scans (so only Pandas DataFrames that are explicitly registered can be scanned). This should resolve #1771.

Currently configuration is done through a dictionary in Python, e.g.:

```py
con = duckdb.connect(':memory:', config={'enable_external_access': False})
```

Later on we might want to extend this to have our own custom class, as this allows for more natural documentation (you can call `help(duckdb.DBConfig)` to get a list of options), e.g.:

```py
con = duckdb.connect(':memory:', config=duckdb.DBConfig(enable_external_access=False))
```