### PR TITLE
Fixing 32 bit R test runs on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -891,7 +891,7 @@ jobs:
   rstats-linux:
     name: R Package Linux
     runs-on: ubuntu-20.04
-    needs: linux-debug
+#    needs: linux-debug
 
     steps:
     - uses: actions/checkout@v2
@@ -929,7 +929,7 @@ jobs:
   rstats-windows:
     name: R Package Windows
     runs-on: windows-latest
-    needs: linux-debug
+#    needs: linux-debug
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -929,7 +929,6 @@ jobs:
   rstats-windows:
     name: R Package Windows
     runs-on: windows-latest
-    needs: linux-debug
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -929,6 +929,7 @@ jobs:
   rstats-windows:
     name: R Package Windows
     runs-on: windows-latest
+    needs: linux-debug
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -891,7 +891,7 @@ jobs:
   rstats-linux:
     name: R Package Linux
     runs-on: ubuntu-20.04
-#    needs: linux-debug
+    needs: linux-debug
 
     steps:
     - uses: actions/checkout@v2
@@ -929,7 +929,7 @@ jobs:
   rstats-windows:
     name: R Package Windows
     runs-on: windows-latest
-#    needs: linux-debug
+    needs: linux-debug
 
     steps:
     - uses: actions/checkout@v2

--- a/tools/rpkg/dependencies.R
+++ b/tools/rpkg/dependencies.R
@@ -1,3 +1,3 @@
 repo <- "https://cloud.r-project.org/"
 install.packages(c("DBI", "callr", "DBItest", "dbplyr", "nycflights13", "testthat"), repos=repo)
-install.packages("testthat", type="source", repos=repo)
+install.packages(c("testthat", "magrittr"), type="source", repos=repo)

--- a/tools/rpkg/dependencies.R
+++ b/tools/rpkg/dependencies.R
@@ -1,3 +1,2 @@
 repo <- "https://cloud.r-project.org/"
-install.packages(c("DBI", "callr", "DBItest", "dbplyr", "nycflights13", "testthat"), repos=repo)
-install.packages(c("testthat", "magrittr"), type="source", repos=repo)
+install.packages(c("DBI", "callr", "DBItest", "dbplyr", "nycflights13", "testthat"), repos=repo, type="source")

--- a/tools/rpkg/dependencies.R
+++ b/tools/rpkg/dependencies.R
@@ -1,1 +1,3 @@
-install.packages(c("DBI", "callr", "DBItest", "dbplyr", "nycflights13", "testthat"), repos="https://cloud.r-project.org/")
+repo <- "https://cloud.r-project.org/"
+install.packages(c("DBI", "callr", "DBItest", "dbplyr", "nycflights13", "testthat"), repos=repo)
+install.packages("testthat", type="source", repos=repo)


### PR DESCRIPTION
Started failing due to R dropping 32 bit on Windows from 4.2 onwards. Now forcing source install which seems to do the trick.