### PR TITLE
Use Allocator class in buffer manager and add a test for a custom allocator usage

### DIFF
--- a/scripts/format.py
+++ b/scripts/format.py
@@ -18,7 +18,7 @@ ignored_files = ['tpch_constants.hpp', 'tpcds_constants.hpp', '_generated', 'tpc
                  'test_csv_header.hpp', 'duckdb.cpp', 'duckdb.hpp', 'json.hpp', 'sqlite3.h', 'shell.c',
                  'termcolor.hpp', 'test_insert_invalid.test', 'httplib.hpp', 'os_win.c', 'glob.c', 'printf.c',
                  'helper.hpp', 'single_thread_ptr.hpp','types.hpp']
-ignored_directories = ['.eggs', '__pycache__', 'icu', 'dbgen']
+ignored_directories = ['.eggs', '__pycache__', 'icu', 'dbgen', os.path.join('tools', 'pythonpkg', 'duckdb'), os.path.join('tools', 'pythonpkg', 'build')]
 format_all = False
 check_only = True
 confirm = True
@@ -258,7 +258,7 @@ def format_directory(directory):
     for f in files:
         full_path = os.path.join(directory, f)
         if os.path.isdir(full_path):
-            if f in ignored_directories:
+            if f in ignored_directories or full_path in ignored_directories:
                 continue
             if not silent:
                 print(full_path)

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -2,8 +2,8 @@
 
 namespace duckdb {
 
-AllocatedData::AllocatedData(Allocator &allocator, data_ptr_t pointer, idx_t allocated_size) :
-    allocator(allocator), pointer(pointer), allocated_size(allocated_size) {
+AllocatedData::AllocatedData(Allocator &allocator, data_ptr_t pointer, idx_t allocated_size)
+    : allocator(allocator), pointer(pointer), allocated_size(allocated_size) {
 }
 AllocatedData::~AllocatedData() {
 	Reset();

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -2,7 +2,8 @@
 
 namespace duckdb {
 
-AllocatedData::AllocatedData(Allocator &allocator, data_ptr_t pointer) : allocator(allocator), pointer(pointer) {
+AllocatedData::AllocatedData(Allocator &allocator, data_ptr_t pointer, idx_t allocated_size) :
+    allocator(allocator), pointer(pointer), allocated_size(allocated_size) {
 }
 AllocatedData::~AllocatedData() {
 	Reset();
@@ -12,7 +13,7 @@ void AllocatedData::Reset() {
 	if (!pointer) {
 		return;
 	}
-	allocator.FreeData(pointer);
+	allocator.FreeData(pointer, allocated_size);
 	pointer = nullptr;
 }
 
@@ -28,11 +29,11 @@ data_ptr_t Allocator::AllocateData(idx_t size) {
 	return allocate_function(private_data.get(), size);
 }
 
-void Allocator::FreeData(data_ptr_t pointer) {
+void Allocator::FreeData(data_ptr_t pointer, idx_t size) {
 	if (!pointer) {
 		return;
 	}
-	return free_function(private_data.get(), pointer);
+	return free_function(private_data.get(), pointer, size);
 }
 
 } // namespace duckdb

--- a/src/common/file_buffer.cpp
+++ b/src/common/file_buffer.cpp
@@ -3,12 +3,14 @@
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/checksum.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/allocator.hpp"
 
 #include <cstring>
 
 namespace duckdb {
 
-FileBuffer::FileBuffer(FileBufferType type, uint64_t bufsiz) : type(type) {
+FileBuffer::FileBuffer(Allocator &allocator, FileBufferType type, uint64_t bufsiz) :
+	allocator(allocator), type(type), malloced_buffer(nullptr) {
 	const int sector_size = Storage::SECTOR_SIZE;
 	// round up to the nearest sector_size, this is only really necessary if the file buffer will be used for Direct IO
 	if (bufsiz % sector_size != 0) {
@@ -17,7 +19,8 @@ FileBuffer::FileBuffer(FileBufferType type, uint64_t bufsiz) : type(type) {
 	D_ASSERT(bufsiz % sector_size == 0);
 	D_ASSERT(bufsiz >= sector_size);
 	// we add (sector_size - 1) to ensure that we can align the buffer to sector_size
-	malloced_buffer = (data_ptr_t)malloc(bufsiz + (sector_size - 1));
+	malloced_size = bufsiz + (sector_size - 1);
+	malloced_buffer = allocator.AllocateData(malloced_size);
 	if (!malloced_buffer) {
 		throw std::bad_alloc();
 	}
@@ -38,7 +41,7 @@ FileBuffer::FileBuffer(FileBufferType type, uint64_t bufsiz) : type(type) {
 }
 
 FileBuffer::~FileBuffer() {
-	free(malloced_buffer);
+	allocator.FreeData(malloced_buffer, malloced_size);
 }
 
 void FileBuffer::Read(FileHandle &handle, uint64_t location) {

--- a/src/common/file_buffer.cpp
+++ b/src/common/file_buffer.cpp
@@ -9,8 +9,8 @@
 
 namespace duckdb {
 
-FileBuffer::FileBuffer(Allocator &allocator, FileBufferType type, uint64_t bufsiz) :
-	allocator(allocator), type(type), malloced_buffer(nullptr) {
+FileBuffer::FileBuffer(Allocator &allocator, FileBufferType type, uint64_t bufsiz)
+    : allocator(allocator), type(type), malloced_buffer(nullptr) {
 	const int sector_size = Storage::SECTOR_SIZE;
 	// round up to the nearest sector_size, this is only really necessary if the file buffer will be used for Direct IO
 	if (bufsiz % sector_size != 0) {

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -21,11 +21,11 @@ struct PrivateAllocatorData {
 };
 
 typedef data_ptr_t (*allocate_function_ptr_t)(PrivateAllocatorData *private_data, idx_t size);
-typedef void (*free_function_ptr_t)(PrivateAllocatorData *private_data, data_ptr_t pointer);
+typedef void (*free_function_ptr_t)(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t size);
 
 class AllocatedData {
 public:
-	AllocatedData(Allocator &allocator, data_ptr_t pointer);
+	AllocatedData(Allocator &allocator, data_ptr_t pointer, idx_t allocated_size);
 	~AllocatedData();
 
 	data_ptr_t get() {
@@ -39,6 +39,7 @@ public:
 private:
 	Allocator &allocator;
 	data_ptr_t pointer;
+	idx_t allocated_size;
 };
 
 class Allocator {
@@ -48,21 +49,24 @@ public:
 	          unique_ptr<PrivateAllocatorData> private_data);
 
 	data_ptr_t AllocateData(idx_t size);
-	void FreeData(data_ptr_t pointer);
+	void FreeData(data_ptr_t pointer, idx_t size);
 
 	unique_ptr<AllocatedData> Allocate(idx_t size) {
-		return make_unique<AllocatedData>(*this, AllocateData(size));
+		return make_unique<AllocatedData>(*this, AllocateData(size), size);
 	}
 
 	static data_ptr_t DefaultAllocate(PrivateAllocatorData *private_data, idx_t size) {
 		return new data_t[size];
 	}
-	static void DefaultFree(PrivateAllocatorData *private_data, data_ptr_t pointer) {
+	static void DefaultFree(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t size) {
 		delete[] pointer;
 	}
 	static Allocator &Get(ClientContext &context);
 	static Allocator &Get(DatabaseInstance &db);
 
+	PrivateAllocatorData *GetPrivateData() {
+		return private_data.get();
+	}
 private:
 	allocate_function_ptr_t allocate_function;
 	free_function_ptr_t free_function;

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -67,6 +67,7 @@ public:
 	PrivateAllocatorData *GetPrivateData() {
 		return private_data.get();
 	}
+
 private:
 	allocate_function_ptr_t allocate_function;
 	free_function_ptr_t free_function;

--- a/src/include/duckdb/common/file_buffer.hpp
+++ b/src/include/duckdb/common/file_buffer.hpp
@@ -14,7 +14,6 @@ namespace duckdb {
 class Allocator;
 struct FileHandle;
 
-
 enum class FileBufferType : uint8_t { BLOCK = 1, MANAGED_BUFFER = 2 };
 
 //! The FileBuffer represents a buffer that can be read or written to a Direct IO FileHandle.

--- a/src/include/duckdb/common/file_buffer.hpp
+++ b/src/include/duckdb/common/file_buffer.hpp
@@ -11,7 +11,9 @@
 #include "duckdb/common/constants.hpp"
 
 namespace duckdb {
+class Allocator;
 struct FileHandle;
+
 
 enum class FileBufferType : uint8_t { BLOCK = 1, MANAGED_BUFFER = 2 };
 
@@ -22,9 +24,10 @@ public:
 	//! FileSystemConstants::FILE_BUFFER_BLOCK_SIZE. The content in this buffer can be written to FileHandles that have
 	//! been opened with DIRECT_IO on all operating systems, however, the entire buffer must be written to the file.
 	//! Note that the returned size is 8 bytes less than the allocation size to account for the checksum.
-	FileBuffer(FileBufferType type, uint64_t bufsiz);
+	FileBuffer(Allocator &allocator, FileBufferType type, uint64_t bufsiz);
 	virtual ~FileBuffer();
 
+	Allocator &allocator;
 	//! The type of the buffer
 	FileBufferType type;
 	//! The buffer that users can write to
@@ -54,6 +57,7 @@ private:
 
 	//! The buffer that was actually malloc'd, i.e. the pointer that must be freed when the FileBuffer is destroyed
 	data_ptr_t malloced_buffer;
+	uint64_t malloced_size;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/block.hpp
+++ b/src/include/duckdb/storage/block.hpp
@@ -16,7 +16,7 @@ namespace duckdb {
 
 class Block : public FileBuffer {
 public:
-	explicit Block(block_id_t id);
+	Block(Allocator &allocator, block_id_t id);
 
 	block_id_t id;
 };

--- a/src/storage/block.cpp
+++ b/src/storage/block.cpp
@@ -2,7 +2,8 @@
 
 namespace duckdb {
 
-Block::Block(block_id_t id) : FileBuffer(FileBufferType::BLOCK, Storage::BLOCK_ALLOC_SIZE), id(id) {
+Block::Block(Allocator &allocator, block_id_t id) :
+	FileBuffer(allocator, FileBufferType::BLOCK, Storage::BLOCK_ALLOC_SIZE), id(id) {
 }
 
 } // namespace duckdb

--- a/src/storage/block.cpp
+++ b/src/storage/block.cpp
@@ -2,8 +2,8 @@
 
 namespace duckdb {
 
-Block::Block(Allocator &allocator, block_id_t id) :
-	FileBuffer(allocator, FileBufferType::BLOCK, Storage::BLOCK_ALLOC_SIZE), id(id) {
+Block::Block(Allocator &allocator, block_id_t id)
+    : FileBuffer(allocator, FileBufferType::BLOCK, Storage::BLOCK_ALLOC_SIZE), id(id) {
 }
 
 } // namespace duckdb

--- a/src/storage/buffer/managed_buffer.cpp
+++ b/src/storage/buffer/managed_buffer.cpp
@@ -1,10 +1,11 @@
 #include "duckdb/storage/buffer/managed_buffer.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/allocator.hpp"
 
 namespace duckdb {
 
 ManagedBuffer::ManagedBuffer(DatabaseInstance &db, idx_t size, bool can_destroy, block_id_t id)
-    : FileBuffer(FileBufferType::MANAGED_BUFFER, size), db(db), can_destroy(can_destroy), id(id) {
+    : FileBuffer(Allocator::Get(db), FileBufferType::MANAGED_BUFFER, size), db(db), can_destroy(can_destroy), id(id) {
 	D_ASSERT(id >= MAXIMUM_BLOCK);
 	D_ASSERT(size >= Storage::BLOCK_ALLOC_SIZE);
 }

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -3,6 +3,7 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/parallel/concurrentqueue.hpp"
+#include "duckdb/common/allocator.hpp"
 
 namespace duckdb {
 
@@ -48,7 +49,7 @@ unique_ptr<BufferHandle> BlockHandle::Load(shared_ptr<BlockHandle> &handle) {
 		// this is mainly down to the block manager only having a single pointer into the file
 		// this is relatively easy to fix later on
 		lock_guard<mutex> buffer_lock(buffer_manager.manager_lock);
-		auto block = make_unique<Block>(handle->block_id);
+		auto block = make_unique<Block>(Allocator::Get(handle->db), handle->block_id);
 		block_manager.Read(*block);
 		handle->buffer = move(block);
 	} else {

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -5,6 +5,7 @@
 
 #include "duckdb/common/serializer/buffered_deserializer.hpp"
 #include "duckdb/common/serializer/buffered_serializer.hpp"
+#include "duckdb/common/allocator.hpp"
 
 #include <algorithm>
 #include <cstring>

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -67,7 +67,7 @@ T DeserializeHeaderStructure(data_ptr_t ptr) {
 
 SingleFileBlockManager::SingleFileBlockManager(DatabaseInstance &db, string path_p, bool read_only, bool create_new,
                                                bool use_direct_io)
-    : db(db), path(move(path_p)), header_buffer(FileBufferType::MANAGED_BUFFER, Storage::FILE_HEADER_SIZE),
+    : db(db), path(move(path_p)), header_buffer(Allocator::Get(db), FileBufferType::MANAGED_BUFFER, Storage::FILE_HEADER_SIZE),
       iteration_count(0), read_only(read_only), use_direct_io(use_direct_io) {
 	uint8_t flags;
 	FileLockType lock;
@@ -217,7 +217,7 @@ block_id_t SingleFileBlockManager::GetMetaBlock() {
 }
 
 unique_ptr<Block> SingleFileBlockManager::CreateBlock() {
-	return make_unique<Block>(GetFreeBlockId());
+	return make_unique<Block>(Allocator::Get(db), GetFreeBlockId());
 }
 
 void SingleFileBlockManager::Read(Block &block) {

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -67,8 +67,9 @@ T DeserializeHeaderStructure(data_ptr_t ptr) {
 
 SingleFileBlockManager::SingleFileBlockManager(DatabaseInstance &db, string path_p, bool read_only, bool create_new,
                                                bool use_direct_io)
-    : db(db), path(move(path_p)), header_buffer(Allocator::Get(db), FileBufferType::MANAGED_BUFFER, Storage::FILE_HEADER_SIZE),
-      iteration_count(0), read_only(read_only), use_direct_io(use_direct_io) {
+    : db(db), path(move(path_p)),
+      header_buffer(Allocator::Get(db), FileBufferType::MANAGED_BUFFER, Storage::FILE_HEADER_SIZE), iteration_count(0),
+      read_only(read_only), use_direct_io(use_direct_io) {
 	uint8_t flags;
 	FileLockType lock;
 	if (read_only) {

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(udf_function)
 
 set(TEST_API_OBJECTS
     test_api.cpp
+    test_custom_allocator.cpp
     test_results.cpp
     test_prepared_api.cpp
     test_table_info.cpp

--- a/test/api/test_custom_allocator.cpp
+++ b/test/api/test_custom_allocator.cpp
@@ -7,21 +7,20 @@ using namespace duckdb;
 using namespace std;
 
 struct MyAllocateData : public PrivateAllocatorData {
-	MyAllocateData(atomic<idx_t> *memory_counter_p) :
-		memory_counter(memory_counter_p) {
+	MyAllocateData(atomic<idx_t> *memory_counter_p) : memory_counter(memory_counter_p) {
 	}
 
 	atomic<idx_t> *memory_counter;
 };
 
 data_ptr_t my_allocate_function(PrivateAllocatorData *private_data, idx_t size) {
-	auto my_allocate_data = (MyAllocateData *) private_data;
+	auto my_allocate_data = (MyAllocateData *)private_data;
 	*my_allocate_data->memory_counter += size;
-	return (data_ptr_t) malloc(size);
+	return (data_ptr_t)malloc(size);
 }
 
 void my_free_function(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t size) {
-	auto my_allocate_data = (MyAllocateData *) private_data;
+	auto my_allocate_data = (MyAllocateData *)private_data;
 	*my_allocate_data->memory_counter -= size;
 	free(pointer);
 }
@@ -30,10 +29,7 @@ TEST_CASE("Test using a custom allocator", "[api]") {
 	atomic<idx_t> memory_counter;
 	memory_counter = 0;
 
-	Allocator my_allocator(
-		my_allocate_function,
-		my_free_function,
-		make_unique<MyAllocateData>(&memory_counter));
+	Allocator my_allocator(my_allocate_function, my_free_function, make_unique<MyAllocateData>(&memory_counter));
 
 	DBConfig config;
 	config.allocator = move(my_allocator);

--- a/test/api/test_custom_allocator.cpp
+++ b/test/api/test_custom_allocator.cpp
@@ -1,0 +1,49 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "duckdb/main/appender.hpp"
+#include "duckdb/common/atomic.hpp"
+
+using namespace duckdb;
+using namespace std;
+
+struct MyAllocateData : public PrivateAllocatorData {
+	MyAllocateData(atomic<idx_t> *memory_counter_p) :
+		memory_counter(memory_counter_p) {
+	}
+
+	atomic<idx_t> *memory_counter;
+};
+
+data_ptr_t my_allocate_function(PrivateAllocatorData *private_data, idx_t size) {
+	auto my_allocate_data = (MyAllocateData *) private_data;
+	*my_allocate_data->memory_counter += size;
+	return (data_ptr_t) malloc(size);
+}
+
+void my_free_function(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t size) {
+	auto my_allocate_data = (MyAllocateData *) private_data;
+	*my_allocate_data->memory_counter -= size;
+	free(pointer);
+}
+
+TEST_CASE("Test using a custom allocator", "[api]") {
+	atomic<idx_t> memory_counter;
+	memory_counter = 0;
+
+	Allocator my_allocator(
+		my_allocate_function,
+		my_free_function,
+		make_unique<MyAllocateData>(&memory_counter));
+
+	DBConfig config;
+	config.allocator = move(my_allocator);
+	DuckDB db(nullptr, &config);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE tbl AS SELECT * FROM range(1000000)"));
+
+	// printf("\nMemory usage: %lld\n", memory_counter.load());
+
+	REQUIRE_NO_FAIL(con.Query("DROP TABLE tbl"));
+
+	// printf("\nMemory usage: %lld\n", memory_counter.load());
+}

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -100,11 +100,12 @@ TEST_CASE("Test file operations", "[file_system]") {
 TEST_CASE("Test file buffers for reading/writing to file", "[file_system]") {
 	FileSystem fs;
 	unique_ptr<FileHandle> handle;
+	Allocator allocator;
 
 	auto fname = TestCreatePath("test_file");
 
 	// create the buffer and fill it with data
-	auto buf = make_unique<FileBuffer>(FileBufferType::MANAGED_BUFFER, 4096);
+	auto buf = make_unique<FileBuffer>(allocator, FileBufferType::MANAGED_BUFFER, 4096);
 	int64_t *ptr = (int64_t *)buf->buffer;
 	for (size_t i = 0; i < 10; i++) {
 		ptr[i] = i;


### PR DESCRIPTION
This PR enlarges the scope of the allocator so it is also used by the buffer manager. In this manner large memory allocations should pass through the allocator class. Small intermediate allocations (such as vectors) do not use this infrastructure yet, however.

This PR also adds a test with example usage of the allocator class, inlined below:

```cpp
struct MyAllocateData : public PrivateAllocatorData {
	MyAllocateData(atomic<idx_t> *memory_counter_p) : memory_counter(memory_counter_p) {
	}

	atomic<idx_t> *memory_counter;
};

data_ptr_t my_allocate_function(PrivateAllocatorData *private_data, idx_t size) {
	auto my_allocate_data = (MyAllocateData *)private_data;
	*my_allocate_data->memory_counter += size;
	return (data_ptr_t)malloc(size);
}

void my_free_function(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t size) {
	auto my_allocate_data = (MyAllocateData *)private_data;
	*my_allocate_data->memory_counter -= size;
	free(pointer);
}

TEST_CASE("Test using a custom allocator", "[api]") {
	atomic<idx_t> memory_counter;
	memory_counter = 0;

	Allocator my_allocator(my_allocate_function, my_free_function, make_unique<MyAllocateData>(&memory_counter));

	DBConfig config;
	config.allocator = move(my_allocator);
	DuckDB db(nullptr, &config);
	Connection con(db);
	REQUIRE_NO_FAIL(con.Query("CREATE TABLE tbl AS SELECT * FROM range(1000000)"));

	// printf("\nMemory usage: %lld\n", memory_counter.load());

	REQUIRE_NO_FAIL(con.Query("DROP TABLE tbl"));

	// printf("\nMemory usage: %lld\n", memory_counter.load());
}
```