### PR TITLE
Add a separate duckdb_free method to the C API

### DIFF
--- a/examples/embedded-c/main.c
+++ b/examples/embedded-c/main.c
@@ -36,7 +36,7 @@ int main() {
 		for (size_t col_idx = 0; col_idx < result.column_count; col_idx++) {
 			char *val = duckdb_value_varchar(&result, col_idx, row_idx);
 			printf("%s ", val);
-			free(val);
+			duckdb_free(val);
 		}
 		printf("\n");
 	}

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -180,7 +180,8 @@ DUCKDB_API uint64_t duckdb_value_uint64(duckdb_result *result, idx_t col, idx_t 
 DUCKDB_API float duckdb_value_float(duckdb_result *result, idx_t col, idx_t row);
 //! Converts the specified value to a double. Returns 0.0 on failure or NULL.
 DUCKDB_API double duckdb_value_double(duckdb_result *result, idx_t col, idx_t row);
-//! Converts the specified value to a string. Returns nullptr on failure or NULL. The result must be freed with duckdb_free.
+//! Converts the specified value to a string. Returns nullptr on failure or NULL. The result must be freed with
+//! duckdb_free.
 DUCKDB_API char *duckdb_value_varchar(duckdb_result *result, idx_t col, idx_t row);
 //! Fetches a blob from a result set column. Returns a blob with blob.data set to nullptr on failure or NULL. The
 //! resulting "blob.data" must be freed with duckdb_free.

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -187,7 +187,10 @@ DUCKDB_API char *duckdb_value_varchar(duckdb_result *result, idx_t col, idx_t ro
 //! resulting "blob.data" must be freed with duckdb_free.
 DUCKDB_API duckdb_blob duckdb_value_blob(duckdb_result *result, idx_t col, idx_t row);
 
-//! Free a value returned from duckdb_value_varchar or duckdb_value_blob
+//! Allocate [size] amounts of memory using the duckdb internal malloc function. Any memory allocated in this manner
+//! should be freed using duckdb_free
+DUCKDB_API void *duckdb_malloc(size_t size);
+//! Free a value returned from duckdb_malloc, duckdb_value_varchar or duckdb_value_blob
 DUCKDB_API void duckdb_free(void *ptr);
 
 // Prepared Statements

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -180,11 +180,14 @@ DUCKDB_API uint64_t duckdb_value_uint64(duckdb_result *result, idx_t col, idx_t 
 DUCKDB_API float duckdb_value_float(duckdb_result *result, idx_t col, idx_t row);
 //! Converts the specified value to a double. Returns 0.0 on failure or NULL.
 DUCKDB_API double duckdb_value_double(duckdb_result *result, idx_t col, idx_t row);
-//! Converts the specified value to a string. Returns nullptr on failure or NULL. The result must be freed with free.
+//! Converts the specified value to a string. Returns nullptr on failure or NULL. The result must be freed with duckdb_free.
 DUCKDB_API char *duckdb_value_varchar(duckdb_result *result, idx_t col, idx_t row);
 //! Fetches a blob from a result set column. Returns a blob with blob.data set to nullptr on failure or NULL. The
-//! resulting "blob.data" must be freed with free.
+//! resulting "blob.data" must be freed with duckdb_free.
 DUCKDB_API duckdb_blob duckdb_value_blob(duckdb_result *result, idx_t col, idx_t row);
+
+//! Free a value returned from duckdb_value_varchar or duckdb_value_blob
+DUCKDB_API void duckdb_free(void *ptr);
 
 // Prepared Statements
 

--- a/src/main/duckdb-c.cpp
+++ b/src/main/duckdb-c.cpp
@@ -773,7 +773,7 @@ duckdb_blob duckdb_value_blob(duckdb_result *result, idx_t col, idx_t row) {
 	return blob;
 }
 
-void* duckdb_malloc(size_t size) {
+void *duckdb_malloc(size_t size) {
 	return malloc(size);
 }
 

--- a/src/main/duckdb-c.cpp
+++ b/src/main/duckdb-c.cpp
@@ -773,6 +773,10 @@ duckdb_blob duckdb_value_blob(duckdb_result *result, idx_t col, idx_t row) {
 	return blob;
 }
 
+void* duckdb_malloc(size_t size) {
+	return malloc(size);
+}
+
 void duckdb_free(void *ptr) {
 	free(ptr);
 }

--- a/src/main/duckdb-c.cpp
+++ b/src/main/duckdb-c.cpp
@@ -773,6 +773,10 @@ duckdb_blob duckdb_value_blob(duckdb_result *result, idx_t col, idx_t row) {
 	return blob;
 }
 
+void duckdb_free(void *ptr) {
+	free(ptr);
+}
+
 duckdb_state duckdb_appender_create(duckdb_connection connection, const char *schema, const char *table,
                                     duckdb_appender *out_appender) {
 	Connection *conn = (Connection *)connection;

--- a/test/api/capi/test_capi.cpp
+++ b/test/api/capi/test_capi.cpp
@@ -531,6 +531,12 @@ TEST_CASE("Test prepared statements in C API", "[capi][.]") {
 	REQUIRE(status == DuckDBError);
 	duckdb_destroy_result(&res);
 	duckdb_destroy_prepare(&stmt);
+
+	// test duckdb_malloc explicitly
+	auto malloced_data = duckdb_malloc(100);
+	memcpy(malloced_data, "hello\0", 6);
+	REQUIRE(string((char *) malloced_data) == "hello");
+	duckdb_free(malloced_data);
 }
 
 TEST_CASE("Test appender statements in C API", "[capi][.]") {

--- a/test/api/capi/test_capi.cpp
+++ b/test/api/capi/test_capi.cpp
@@ -535,7 +535,7 @@ TEST_CASE("Test prepared statements in C API", "[capi][.]") {
 	// test duckdb_malloc explicitly
 	auto malloced_data = duckdb_malloc(100);
 	memcpy(malloced_data, "hello\0", 6);
-	REQUIRE(string((char *) malloced_data) == "hello");
+	REQUIRE(string((char *)malloced_data) == "hello");
 	duckdb_free(malloced_data);
 }
 

--- a/test/api/capi/test_capi.cpp
+++ b/test/api/capi/test_capi.cpp
@@ -476,7 +476,7 @@ TEST_CASE("Test prepared statements in C API", "[capi][.]") {
 	REQUIRE(status == DuckDBSuccess);
 	auto value = duckdb_value_varchar(&res, 0, 0);
 	REQUIRE(string(value) == "hello");
-	free(value);
+	duckdb_free(value);
 	duckdb_destroy_result(&res);
 
 	duckdb_bind_blob(stmt, 1, "hello\0world", 11);
@@ -484,7 +484,7 @@ TEST_CASE("Test prepared statements in C API", "[capi][.]") {
 	REQUIRE(status == DuckDBSuccess);
 	value = duckdb_value_varchar(&res, 0, 0);
 	REQUIRE(string(value) == "hello\\x00world");
-	free(value);
+	duckdb_free(value);
 	duckdb_destroy_result(&res);
 
 	duckdb_destroy_prepare(&stmt);


### PR DESCRIPTION
This can be used to free values returned by `duckdb_value_varchar` and friends, potentially helping solve #1748