### PR TITLE
Fix unused argument warnings in the public headers.

### DIFF
--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -54,10 +54,10 @@ public:
 		return make_unique<AllocatedData>(*this, AllocateData(size));
 	}
 
-	static data_ptr_t DefaultAllocate(PrivateAllocatorData *private_data, idx_t size) {
+	static data_ptr_t DefaultAllocate(PrivateAllocatorData * /*private_data*/, idx_t size) {
 		return new data_t[size];
 	}
-	static void DefaultFree(PrivateAllocatorData *private_data, data_ptr_t pointer) {
+	static void DefaultFree(PrivateAllocatorData * /*private_data*/, data_ptr_t pointer) {
 		delete[] pointer;
 	}
 	static Allocator &Get(ClientContext &context);

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -10,8 +10,8 @@
 
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/common.hpp"
-#include "duckdb/common/vector.hpp"
 #include "duckdb/common/exception_format_value.hpp"
+#include "duckdb/common/vector.hpp"
 
 #include <stdexcept>
 

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -148,11 +148,11 @@ public:
 	virtual idx_t GetAvailableMemory();
 
 	//! registers a sub-file system to handle certain file name prefixes, e.g. http:// etc.
-	virtual void RegisterSubSystem(unique_ptr<FileSystem> sub_fs) {
+	virtual void RegisterSubSystem(unique_ptr<FileSystem> /*sub_fs*/) {
 		throw NotImplementedException("Can't register a sub system on a non-virtual file system");
 	}
 
-	virtual bool CanHandleFile(const string &fpath) {
+	virtual bool CanHandleFile(const string & /*fpath*/) {
 		//! Whether or not a sub-system can handle a specific file path
 		return false;
 	}

--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -124,7 +124,7 @@ public:
 		throw NotImplementedException("Unimplemented template type for Value::GetValue");
 	}
 	template <class T>
-	static Value CreateValue(T value) {
+	static Value CreateValue(T /*value*/) {
 		throw NotImplementedException("Unimplemented template type for Value::CreateValue");
 	}
 	// Returns the internal value. Unlike GetValue(), this method does not perform casting, and assumes T matches the
@@ -184,7 +184,7 @@ public:
 	static bool DoubleIsValid(double value);
 
 	template <class T>
-	static bool IsValid(T value) {
+	static bool IsValid(T /*value*/) {
 		return true;
 	}
 

--- a/src/include/duckdb/common/vector_operations/binary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/binary_executor.hpp
@@ -18,14 +18,15 @@ namespace duckdb {
 
 struct DefaultNullCheckOperator {
 	template <class LEFT_TYPE, class RIGHT_TYPE>
-	static inline bool Operation(LEFT_TYPE left, RIGHT_TYPE right) {
+	static inline bool Operation(LEFT_TYPE /*left*/, RIGHT_TYPE /*right*/) {
 		return false;
 	}
 };
 
 struct BinaryStandardOperatorWrapper {
 	template <class FUNC, class OP, class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE>
-	static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, ValidityMask &mask, idx_t idx) {
+	static inline RESULT_TYPE Operation(FUNC /*fun*/, LEFT_TYPE left, RIGHT_TYPE right, ValidityMask & /*mask*/,
+	                                    idx_t /*idx*/) {
 		return OP::template Operation<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE>(left, right);
 	}
 
@@ -36,7 +37,8 @@ struct BinaryStandardOperatorWrapper {
 
 struct BinarySingleArgumentOperatorWrapper {
 	template <class FUNC, class OP, class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE>
-	static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, ValidityMask &mask, idx_t idx) {
+	static inline RESULT_TYPE Operation(FUNC /*fun*/, LEFT_TYPE left, RIGHT_TYPE right, ValidityMask & /*mask*/,
+	                                    idx_t /*idx*/) {
 		return OP::template Operation<LEFT_TYPE>(left, right);
 	}
 
@@ -47,7 +49,8 @@ struct BinarySingleArgumentOperatorWrapper {
 
 struct BinaryLambdaWrapper {
 	template <class FUNC, class OP, class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE>
-	static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, ValidityMask &mask, idx_t idx) {
+	static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, ValidityMask & /*mask*/,
+	                                    idx_t /*idx*/) {
 		return fun(left, right);
 	}
 

--- a/src/include/duckdb/common/vector_operations/unary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/unary_executor.hpp
@@ -18,7 +18,7 @@ namespace duckdb {
 
 struct UnaryOperatorWrapper {
 	template <class FUNC, class OP, class INPUT_TYPE, class RESULT_TYPE>
-	static inline RESULT_TYPE Operation(FUNC fun, INPUT_TYPE input, ValidityMask &mask, idx_t idx) {
+	static inline RESULT_TYPE Operation(FUNC /*fun*/, INPUT_TYPE input, ValidityMask & /*mask*/, idx_t /*idx*/) {
 		return OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input);
 	}
 
@@ -29,7 +29,7 @@ struct UnaryOperatorWrapper {
 
 struct UnaryLambdaWrapper {
 	template <class FUNC, class OP, class INPUT_TYPE, class RESULT_TYPE>
-	static inline RESULT_TYPE Operation(FUNC fun, INPUT_TYPE input, ValidityMask &mask, idx_t idx) {
+	static inline RESULT_TYPE Operation(FUNC fun, INPUT_TYPE input, ValidityMask &/*mask*/, idx_t /*idx*/) {
 		return fun(input);
 	}
 

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -10,9 +10,9 @@
 
 #include "duckdb/common/vector_operations/aggregate_executor.hpp"
 #include "duckdb/function/function.hpp"
+#include "duckdb/planner/expression.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/storage/statistics/node_statistics.hpp"
-#include "duckdb/planner/expression.hpp"
 
 namespace duckdb {
 
@@ -154,14 +154,14 @@ public:
 	}
 
 	template <class STATE, class OP>
-	static void NullaryScatterUpdate(Vector inputs[], FunctionData *bind_data, idx_t input_count, Vector &states,
+	static void NullaryScatterUpdate(Vector * /*inputs[]*/, FunctionData *bind_data, idx_t input_count, Vector &states,
 	                                 idx_t count) {
 		D_ASSERT(input_count == 0);
 		AggregateExecutor::NullaryScatter<STATE, OP>(states, bind_data, count);
 	}
 
 	template <class STATE, class OP>
-	static void NullaryUpdate(Vector inputs[], FunctionData *bind_data, idx_t input_count, data_ptr_t state,
+	static void NullaryUpdate(Vector * /*inputs[]*/, FunctionData *bind_data, idx_t input_count, data_ptr_t state,
 	                          idx_t count) {
 		D_ASSERT(input_count == 0);
 		AggregateExecutor::NullaryUpdate<STATE, OP>(state, bind_data, count);

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -39,7 +39,7 @@ struct FunctionData {
 	virtual unique_ptr<FunctionData> Copy() {
 		return make_unique<FunctionData>();
 	};
-	virtual bool Equals(FunctionData &other) {
+	virtual bool Equals(FunctionData & /*other*/) {
 		return true;
 	}
 	static bool Equals(FunctionData *left, FunctionData *right) {

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -95,19 +95,19 @@ private:
 	}
 
 public:
-	static void NopFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	static void NopFunction(DataChunk &input, ExpressionState & /*state*/, Vector &result) {
 		D_ASSERT(input.ColumnCount() >= 1);
 		result.Reference(input.data[0]);
 	}
 
 	template <class TA, class TR, class OP>
-	static void UnaryFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	static void UnaryFunction(DataChunk &input, ExpressionState & /*state*/, Vector &result) {
 		D_ASSERT(input.ColumnCount() >= 1);
 		UnaryExecutor::Execute<TA, TR, OP>(input.data[0], result, input.size());
 	}
 
 	template <class TA, class TB, class TR, class OP>
-	static void BinaryFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	static void BinaryFunction(DataChunk &input, ExpressionState & /*state*/, Vector &result) {
 		D_ASSERT(input.ColumnCount() == 2);
 		BinaryExecutor::ExecuteStandard<TA, TB, TR, OP>(input.data[0], input.data[1], result, input.size());
 	}

--- a/src/include/duckdb/function/udf_function.hpp
+++ b/src/include/duckdb/function/udf_function.hpp
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include "duckdb/function/scalar_function.hpp"
 #include "duckdb/function/aggregate_function.hpp"
+#include "duckdb/function/scalar_function.hpp"
 
 namespace duckdb {
 
@@ -133,24 +133,24 @@ private:
 	//-------------------------------- Templated functions --------------------------------//
 
 	template <typename TR, typename TA>
-	static scalar_function_t CreateUnaryFunction(const string &name, TR (*udf_func)(TA)) {
-		scalar_function_t udf_function = [=](DataChunk &input, ExpressionState &state, Vector &result) -> void {
+	static scalar_function_t CreateUnaryFunction(const string & /*name*/, TR (*udf_func)(TA)) {
+		scalar_function_t udf_function = [=](DataChunk &input, ExpressionState & /*state*/, Vector &result) -> void {
 			UnaryExecutor::Execute<TA, TR>(input.data[0], result, input.size(), udf_func);
 		};
 		return udf_function;
 	}
 
 	template <typename TR, typename TA, typename TB>
-	static scalar_function_t CreateBinaryFunction(const string &name, TR (*udf_func)(TA, TB)) {
-		scalar_function_t udf_function = [=](DataChunk &input, ExpressionState &state, Vector &result) -> void {
+	static scalar_function_t CreateBinaryFunction(const string & /*name*/, TR (*udf_func)(TA, TB)) {
+		scalar_function_t udf_function = [=](DataChunk &input, ExpressionState & /*state*/, Vector &result) -> void {
 			BinaryExecutor::Execute<TA, TB, TR>(input.data[0], input.data[1], result, input.size(), udf_func);
 		};
 		return udf_function;
 	}
 
 	template <typename TR, typename TA, typename TB, typename TC>
-	static scalar_function_t CreateTernaryFunction(const string &name, TR (*udf_func)(TA, TB, TC)) {
-		scalar_function_t udf_function = [=](DataChunk &input, ExpressionState &state, Vector &result) -> void {
+	static scalar_function_t CreateTernaryFunction(const string & /*name*/, TR (*udf_func)(TA, TB, TC)) {
+		scalar_function_t udf_function = [=](DataChunk &input, ExpressionState & /*state*/, Vector &result) -> void {
 			TernaryExecutor::Execute<TA, TB, TC, TR>(input.data[0], input.data[1], input.data[2], result, input.size(),
 			                                         udf_func);
 		};
@@ -158,17 +158,17 @@ private:
 	}
 
 	template <typename TR, typename... Args>
-	static scalar_function_t CreateUnaryFunction(const string &name, TR (*udf_func)(Args...)) {
+	static scalar_function_t CreateUnaryFunction(const string & /*name*/, TR /*(*udf_func)(Args...)*/) {
 		throw std::runtime_error("Incorrect number of arguments for unary function");
 	}
 
 	template <typename TR, typename... Args>
-	static scalar_function_t CreateBinaryFunction(const string &name, TR (*udf_func)(Args...)) {
+	static scalar_function_t CreateBinaryFunction(const string & /*name*/, TR /*(*udf_func)(Args...)*/) {
 		throw std::runtime_error("Incorrect number of arguments for binary function");
 	}
 
 	template <typename TR, typename... Args>
-	static scalar_function_t CreateTernaryFunction(const string &name, TR (*udf_func)(Args...)) {
+	static scalar_function_t CreateTernaryFunction(const string & /*name*/, TR /*(*udf_func)(Args...)*/) {
 		throw std::runtime_error("Incorrect number of arguments for ternary function");
 	}
 
@@ -211,14 +211,14 @@ private:
 	//-------------------------------- Argumented functions --------------------------------//
 
 	template <typename TR, typename... Args>
-	static scalar_function_t CreateUnaryFunction(const string &name, vector<LogicalType> args, LogicalType ret_type,
-	                                             TR (*udf_func)(Args...)) {
+	static scalar_function_t CreateUnaryFunction(const string & /*name*/, vector<LogicalType> /*args*/,
+	                                             LogicalType /*ret_type*/, TR /*(*udf_func)(Args...)*/) {
 		throw std::runtime_error("Incorrect number of arguments for unary function");
 	}
 
 	template <typename TR, typename TA>
-	static scalar_function_t CreateUnaryFunction(const string &name, vector<LogicalType> args, LogicalType ret_type,
-	                                             TR (*udf_func)(TA)) {
+	static scalar_function_t CreateUnaryFunction(const string & /*name*/, vector<LogicalType> args,
+	                                             LogicalType /*ret_type*/, TR (*udf_func)(TA)) {
 		if (args.size() != 1) {
 			throw std::runtime_error("The number of LogicalType arguments (\"args\") should be 1!");
 		}
@@ -226,21 +226,21 @@ private:
 			throw std::runtime_error("The first arguments don't match!");
 		}
 
-		scalar_function_t udf_function = [=](DataChunk &input, ExpressionState &state, Vector &result) -> void {
+		scalar_function_t udf_function = [=](DataChunk &input, ExpressionState & /*state*/, Vector &result) -> void {
 			UnaryExecutor::Execute<TA, TR>(input.data[0], result, input.size(), udf_func);
 		};
 		return udf_function;
 	}
 
 	template <typename TR, typename... Args>
-	static scalar_function_t CreateBinaryFunction(const string &name, vector<LogicalType> args, LogicalType ret_type,
-	                                              TR (*udf_func)(Args...)) {
+	static scalar_function_t CreateBinaryFunction(const string & /*name*/, vector<LogicalType> /*args*/,
+	                                              LogicalType /*ret_type*/, TR /*(*udf_func)(Args...)*/) {
 		throw std::runtime_error("Incorrect number of arguments for binary function");
 	}
 
 	template <typename TR, typename TA, typename TB>
-	static scalar_function_t CreateBinaryFunction(const string &name, vector<LogicalType> args, LogicalType ret_type,
-	                                              TR (*udf_func)(TA, TB)) {
+	static scalar_function_t CreateBinaryFunction(const string & /*name*/, vector<LogicalType> args,
+	                                              LogicalType /*ret_type*/, TR (*udf_func)(TA, TB)) {
 		if (args.size() != 2) {
 			throw std::runtime_error("The number of LogicalType arguments (\"args\") should be 2!");
 		}
@@ -251,21 +251,21 @@ private:
 			throw std::runtime_error("The second arguments don't match!");
 		}
 
-		scalar_function_t udf_function = [=](DataChunk &input, ExpressionState &state, Vector &result) {
+		scalar_function_t udf_function = [=](DataChunk &input, ExpressionState & /*state*/, Vector &result) {
 			BinaryExecutor::Execute<TA, TB, TR>(input.data[0], input.data[1], result, input.size(), udf_func);
 		};
 		return udf_function;
 	}
 
 	template <typename TR, typename... Args>
-	static scalar_function_t CreateTernaryFunction(const string &name, vector<LogicalType> args, LogicalType ret_type,
-	                                               TR (*udf_func)(Args...)) {
+	static scalar_function_t CreateTernaryFunction(const string & /*name*/, vector<LogicalType> /*args*/,
+	                                               LogicalType /*ret_type*/, TR /*(*udf_func)(Args...)*/) {
 		throw std::runtime_error("Incorrect number of arguments for ternary function");
 	}
 
 	template <typename TR, typename TA, typename TB, typename TC>
-	static scalar_function_t CreateTernaryFunction(const string &name, vector<LogicalType> args, LogicalType ret_type,
-	                                               TR (*udf_func)(TA, TB, TC)) {
+	static scalar_function_t CreateTernaryFunction(const string & /*name*/, vector<LogicalType> args,
+	                                               LogicalType /*ret_type*/, TR (*udf_func)(TA, TB, TC)) {
 		if (args.size() != 3) {
 			throw std::runtime_error("The number of LogicalType arguments (\"args\") should be 3!");
 		}
@@ -279,7 +279,7 @@ private:
 			throw std::runtime_error("The second arguments don't match!");
 		}
 
-		scalar_function_t udf_function = [=](DataChunk &input, ExpressionState &state, Vector &result) -> void {
+		scalar_function_t udf_function = [=](DataChunk &input, ExpressionState & /*state*/, Vector &result) -> void {
 			TernaryExecutor::Execute<TA, TB, TC, TR>(input.data[0], input.data[1], input.data[2], result, input.size(),
 			                                         udf_func);
 		};

--- a/src/include/duckdb/main/query_result.hpp
+++ b/src/include/duckdb/main/query_result.hpp
@@ -117,7 +117,7 @@ private:
 			Next();
 			return *this;
 		}
-		bool operator!=(const QueryResultIterator &other) const {
+		bool operator!=(const QueryResultIterator & /*other*/) const {
 			return result->iterator_chunk && result->iterator_chunk->ColumnCount() > 0;
 		}
 		const QueryResultRow &operator*() const {


### PR DESCRIPTION
**What are issues?**

I have a lot of warnings when compiling a duckdb examples with clang-13. Below is the sample output

```
[100%] Building CXX object unittests/CMakeFiles/duckdb_test.dir/duckdb_test.cpp.o
In file included from /home/hungptit/working/workflow/unittests/duckdb_test.cpp:14:
In file included from /home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb.hpp:11:
In file included from /home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/main/connection.hpp:12:
In file included from /home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/common/serializer/buffered_file_writer.hpp:11:
In file included from /home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/common/serializer.hpp:12:
/home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/common/exception.hpp:23:44: warning: unused parameter 'left_start' [-Wunused-parameter]
inline void assert_restrict_function(void *left_start, void *left_end, void *right_start, void *right_end,
                                           ^
/home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/common/exception.hpp:23:62: warning: unused parameter 'left_end' [-Wunused-parameter]
inline void assert_restrict_function(void *left_start, void *left_end, void *right_start, void *right_end,
                                                             ^
/home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/common/exception.hpp:23:78: warning: unused parameter 'right_start' [-Wunused-parameter]
inline void assert_restrict_function(void *left_start, void *left_end, void *right_start, void *right_end,
                                                                             ^
/home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/common/exception.hpp:23:97: warning: unused parameter 'right_end' [-Wunused-parameter]
inline void assert_restrict_function(void *left_start, void *left_end, void *right_start, void *right_end,
                                                                                                ^
/home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/common/exception.hpp:24:50: warning: unused parameter 'fname' [-Wunused-parameter]
                                     const char *fname, int linenr) {
                                                 ^
/home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/common/exception.hpp:24:61: warning: unused parameter 'linenr' [-Wunused-parameter]
                                     const char *fname, int linenr) {
                                                            ^
In file included from /home/hungptit/working/workflow/unittests/duckdb_test.cpp:14:
In file included from /home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb.hpp:11:
In file included from /home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/main/connection.hpp:12:
In file included from /home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/common/serializer/buffered_file_writer.hpp:12:
/home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/common/file_system.hpp:151:56: warning: unused parameter 'sub_fs' [-Wunused-parameter]
        virtual void RegisterSubSystem(unique_ptr<FileSystem> sub_fs) {
                                                              ^
/home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/common/file_system.hpp:155:43: warning: unused parameter 'fpath' [-Wunused-parameter]
        virtual bool CanHandleFile(const string &fpath) {
                                                 ^
In file included from /home/hungptit/working/workflow/unittests/duckdb_test.cpp:14:
In file included from /home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb.hpp:11:
In file included from /home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/main/connection.hpp:14:
In file included from /home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/function/udf_function.hpp:11:
In file included from /home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/function/scalar_function.hpp:11:
In file included from /home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/common/vector_operations/binary_executor.hpp:12:
In file included from /home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/common/types/vector.hpp:14:
/home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/common/types/value.hpp:129:29: warning: unused parameter 'value' [-Wunused-parameter]
        static Value CreateValue(T value) {
                                   ^
/home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/common/types/value.hpp:189:24: warning: unused parameter 'value' [-Wunused-parameter]
        static bool IsValid(T value) {
                              ^
In file included from /home/hungptit/working/workflow/unittests/duckdb_test.cpp:14:
In file included from /home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb.hpp:11:
In file included from /home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/main/connection.hpp:14:
In file included from /home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/function/udf_function.hpp:11:
In file included from /home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/function/scalar_function.hpp:11:
/home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/common/vector_operations/binary_executor.hpp:21:41: warning: unused parameter 'left' [-Wunused-parameter]
        static inline bool Operation(LEFT_TYPE left, RIGHT_TYPE right) {
                                               ^
/home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/common/vector_operations/binary_executor.hpp:21:58: warning: unused parameter 'right' [-Wunused-parameter]
        static inline bool Operation(LEFT_TYPE left, RIGHT_TYPE right) {
                                                                ^
/home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/common/vector_operations/binary_executor.hpp:28:43: warning: unused parameter 'fun' [-Wunused-parameter]
        static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, ValidityMask &mask, idx_t idx) {
                                                 ^
/home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/common/vector_operations/binary_executor.hpp:28:96: warning: unused parameter 'mask' [-Wunused-parameter]
        static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, ValidityMask &mask, idx_t idx) {
                                                                                                      ^
/home/hungptit/working/workflow/_deps/duckdb-src/src/include/duckdb/common/vector_operations/binary_executor.hpp:28:108: warning: unused parameter 'idx' [-Wunused-parameter]
        static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, ValidityMask &mask, idx_t idx) {
```

**Solution**

Comments out the unused arguments to remove all warnings come from the public headers. 

