### PR TITLE
Run correct TPC-H test for valgrind CI run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -551,7 +551,7 @@ jobs:
       run: make debug
 
     - name: Test
-      run: valgrind ./build/debug/test/unittest -s "Test TPC-H SF0.01"
+      run: valgrind ./build/debug/test/unittest test/sql/tpch/tpch_sf001.test_slow
 
 # borked somehow. needs investigation.
 #  codecov:


### PR DESCRIPTION
The valgrind CI test was still running against an old name of the TPC-H test. As a result, it was not running at all. This PR updates it so it runs the correct test.