### PR TITLE
Fix #1812: "X OR (X AND A)" should be rewritten to "X", not to "X AND A"

### DIFF
--- a/src/optimizer/rule/distributivity.cpp
+++ b/src/optimizer/rule/distributivity.cpp
@@ -95,11 +95,21 @@ unique_ptr<Expression> DistributivityRule::Apply(LogicalOperator &op, vector<Exp
 		}
 		// now we add the expression to the new root
 		new_root->children.push_back(move(result));
-		// remove any expressions that were set to nullptr
-		for (idx_t i = 0; i < initial_or->children.size(); i++) {
-			if (!initial_or->children[i]) {
-				initial_or->children.erase(initial_or->children.begin() + i);
-				i--;
+	}
+
+	// check if we completely erased one of the children of the OR
+	// this happens if we have an OR in the form of "X OR (X AND A)"
+	// the left child will be completely empty, as it only contains common expressions
+	// in this case, any other children are not useful:
+	// X OR (X AND A) is the same as "X"
+	// since (1) only tuples that do not qualify "X" will not pass this predicate
+	//   and (2) all tuples that qualify "X" will pass this predicate
+	for (idx_t i = 0; i < initial_or->children.size(); i++) {
+		if (!initial_or->children[i]) {
+			if (new_root->children.size() <= 1) {
+				return move(new_root->children[0]);
+			} else {
+				return move(new_root);
 			}
 		}
 	}

--- a/test/optimizer/distributivity_rule.test
+++ b/test/optimizer/distributivity_rule.test
@@ -32,10 +32,6 @@ EXPLAIN SELECT X OR X FROM test
 ----
 
 query I nosort distributivity3
-EXPLAIN SELECT X FROM test
-----
-
-query I nosort distributivity3
 EXPLAIN SELECT X OR X OR X OR X FROM test
 ----
 
@@ -43,13 +39,13 @@ query I nosort distributivity3
 EXPLAIN SELECT X OR (X OR (X OR X)) FROM test
 ----
 
-# X OR (X AND A) => X AND A
+# X OR (X AND A) => X
 query I nosort distributivity4
 EXPLAIN SELECT X OR (X AND A) FROM test
 ----
 
 query I nosort distributivity4
-EXPLAIN SELECT X AND A FROM test
+EXPLAIN SELECT X OR X FROM test
 ----
 
 statement ok

--- a/test/sql/function/string/test_issue_1812.test
+++ b/test/sql/function/string/test_issue_1812.test
@@ -1,0 +1,58 @@
+# name: test/sql/function/string/test_issue_1812.test
+# description: Test LIKE statement
+# group: [string]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t (str VARCHAR);
+
+statement ok
+INSERT INTO t VALUES ('hello1'), ('hello2'), ('hello3'), ('world1'), ('world2'), ('world3');
+
+query I
+SELECT COUNT(*) FROM t WHERE str LIKE '%o%'; -- 6
+----
+6
+
+query I
+SELECT COUNT(*) FROM t WHERE str LIKE '%rld%'; -- 3
+----
+3
+
+query I
+SELECT COUNT(*) FROM t WHERE str LIKE '%o%' OR (str LIKE '%o%' AND str LIKE '%rld%');
+----
+6
+
+query I
+SELECT COUNT(*) FROM t
+WHERE (str LIKE '%o%' AND str LIKE '%rld%')
+    OR str LIKE '%o%';
+----
+6
+
+query I
+SELECT COUNT(*) FROM t
+WHERE (str LIKE '%o%' AND str LIKE '%rld%')
+   OR (str LIKE '%o%')
+   OR (str LIKE '%o%');
+----
+6
+
+query I
+SELECT COUNT(*) FROM t
+WHERE (str LIKE '%o%' AND str LIKE '%rld%')
+   OR (str LIKE '%o%')
+   OR (str LIKE '%o%' AND str LIKE 'blabla%');
+----
+6
+
+query I
+SELECT COUNT(*) FROM t
+WHERE (str LIKE '%o%' AND str LIKE '%1%')
+   OR (str LIKE '%o%' AND str LIKE '%1%' AND str LIKE 'blabla%')
+   OR (str LIKE '%o%' AND str LIKE '%1%' AND str LIKE 'blabla2%')
+----
+2


### PR DESCRIPTION
This PR fixes an issue with the distributivity rule optimizer. This optimizer performs rewrite such as:

```(X AND A) OR (X AND B) -> X AND (A OR B)```

Essentially trying to push the `AND` as far down as possible, since `AND` expressions allow for more optimizations than `OR`.

However, following the same code-path this optimizer would incorrectly perform the following rewrite:

```X OR (X AND A) -> X AND A```

Which resulted in the bug shown in #1812.

This PR fixes this behavior so it performs the correct rewrite:

```
X OR (X AND A) -> X
```