### PR TITLE
Allow column references to be bound to structs

### DIFF
--- a/src/function/scalar/nested/struct_extract.cpp
+++ b/src/function/scalar/nested/struct_extract.cpp
@@ -51,19 +51,19 @@ static unique_ptr<FunctionData> StructExtractBind(ClientContext &context, Scalar
                                                   vector<unique_ptr<Expression>> &arguments) {
 	auto &struct_children = arguments[0]->return_type.child_types();
 	if (struct_children.empty()) {
-		throw Exception("Can't extract something from an empty struct");
+		throw BinderException("Can't extract something from an empty struct");
 	}
 
 	auto &key_child = arguments[1];
 
 	if (key_child->return_type.id() != LogicalTypeId::VARCHAR ||
 	    key_child->return_type.id() != LogicalTypeId::VARCHAR || !key_child->IsFoldable()) {
-		throw Exception("Key name for struct_extract needs to be a constant string");
+		throw BinderException("Key name for struct_extract needs to be a constant string");
 	}
 	Value key_val = ExpressionExecutor::EvaluateScalar(*key_child.get());
 	D_ASSERT(key_val.type().id() == LogicalTypeId::VARCHAR);
 	if (key_val.is_null || key_val.str_value.length() < 1) {
-		throw Exception("Key name for struct_extract needs to be neither NULL nor empty");
+		throw BinderException("Key name for struct_extract needs to be neither NULL nor empty");
 	}
 	string key = StringUtil::Lower(key_val.str_value);
 
@@ -81,7 +81,13 @@ static unique_ptr<FunctionData> StructExtractBind(ClientContext &context, Scalar
 		}
 	}
 	if (!found_key) {
-		throw Exception("Could not find key in struct");
+		vector<string> candidates;
+		for (auto &kv : struct_children) {
+			candidates.push_back(kv.first);
+		}
+		string candidate_str =
+		    StringUtil::CandidatesMessage(StringUtil::TopNLevenshtein(candidates, key), "Candidate struct keys");
+		throw BinderException("Could not find key  \"%s\" in struct%s", key, candidate_str);
 	}
 
 	bound_function.return_type = return_type;

--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -38,9 +38,16 @@ public:
 	unordered_map<string, std::shared_ptr<idx_t>> cte_references;
 
 public:
-	//! Given a column name, find the matching table it belongs to. Throws an
-	//! exception if no table has a column of the given name.
+	//! Given a column name, find the matching table it belongs to.
+	//! Returns false if there was ambiguity (e.g. two tables with the same column name)
+	//! Returns true but "result" will be empty if no match was found
+	bool TryGetMatchingBinding(const string &column_name, string &result);
+	//! Given a column name, find the matching table it belongs to.
+	//! Throws an exception if there was ambiguity.
+	//! Returns an empty string if no match was found.
 	string GetMatchingBinding(const string &column_name);
+	//! Returns the column type of a (table_name, column_name) pair, or INVALID if no match was found
+	LogicalType GetColumnType(const string &table_name, const string &column_name);
 	//! Like GetMatchingBinding, but instead of throwing an error if multiple tables have the same binding it will
 	//! return a list of all the matching ones
 	unordered_set<string> GetMatchingBindings(const string &column_name);
@@ -111,7 +118,7 @@ private:
 	//! Gets a binding of the specified name. Returns a nullptr and sets the out_error if the binding could not be
 	//! found.
 	Binding *GetBinding(const string &name, string &out_error);
-
+	bool GetMatchingBindingInternal(const string &column_name, string &result, bool throw_exception);
 private:
 	//! The set of bindings
 	unordered_map<string, unique_ptr<Binding>> bindings;

--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -119,6 +119,7 @@ private:
 	//! found.
 	Binding *GetBinding(const string &name, string &out_error);
 	bool GetMatchingBindingInternal(const string &column_name, string &result, bool throw_exception);
+
 private:
 	//! The set of bindings
 	unordered_map<string, unique_ptr<Binding>> bindings;

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -99,6 +99,7 @@ protected:
 	virtual BindResult BindUnnest(FunctionExpression &expr, idx_t depth);
 	virtual BindResult BindMacro(FunctionExpression &expr, MacroCatalogEntry *macro, idx_t depth,
 	                             unique_ptr<ParsedExpression> *expr_ptr);
+	virtual BindResult BindStructExtract(ColumnRefExpression &expr, idx_t depth);
 
 	virtual void ReplaceMacroParametersRecursive(unique_ptr<ParsedExpression> &expr);
 	virtual void ReplaceMacroParametersRecursive(ParsedExpression &expr, QueryNode &node);

--- a/src/include/duckdb/planner/table_binding.hpp
+++ b/src/include/duckdb/planner/table_binding.hpp
@@ -42,6 +42,7 @@ struct Binding {
 public:
 	bool HasMatchingBinding(const string &column_name);
 	virtual BindResult Bind(ColumnRefExpression &colref, idx_t depth);
+	virtual LogicalType GetColumnType(const string &column_name);
 };
 
 //! TableBinding is exactly like the Binding, except it keeps track of which columns were bound in the linked LogicalGet

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -52,6 +52,10 @@ void Executor::Initialize(PhysicalOperator *plan) {
 			task->Execute();
 			task.reset();
 		}
+		if (!exceptions.empty()) {
+			// an exception has occurred executing one of the pipelines
+			throw Exception(exceptions[0]);
+		}
 	}
 
 	pipelines.clear();

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -25,8 +25,8 @@ bool BindContext::GetMatchingBindingInternal(const string &column_name, string &
 			if (!result.empty() || is_using_binding) {
 				if (throw_exception) {
 					throw BinderException("Ambiguous reference to column name \"%s\" (use: \"%s.%s\" "
-										"or \"%s.%s\")",
-										column_name, result, column_name, kv.first, column_name);
+					                      "or \"%s.%s\")",
+					                      column_name, result, column_name, kv.first, column_name);
 				} else {
 					return false;
 				}

--- a/src/planner/table_binding.cpp
+++ b/src/planner/table_binding.cpp
@@ -47,6 +47,14 @@ BindResult Binding::Bind(ColumnRefExpression &colref, idx_t depth) {
 	return BindResult(make_unique<BoundColumnRefExpression>(colref.GetName(), sql_type, binding, depth));
 }
 
+LogicalType Binding::GetColumnType(const string &column_name) {
+	auto column_entry = name_map.find(column_name);
+	if (column_entry == name_map.end()) {
+		return LogicalType::INVALID;
+	}
+	return types[column_entry->second];
+}
+
 TableBinding::TableBinding(const string &alias, vector<LogicalType> types_p, vector<string> names_p, LogicalGet &get,
                            idx_t index, bool add_row_id)
     : Binding(alias, move(types_p), move(names_p), index), get(get) {

--- a/test/sql/types/struct/struct_colref.test
+++ b/test/sql/types/struct/struct_colref.test
@@ -1,0 +1,32 @@
+# name: test/sql/types/struct/struct_colref.test
+# description: Test referring to struct elements without brackets
+# group: [struct]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT a.i FROM (VALUES ({'i': 1, 'j': 2})) tbl(a)
+----
+1
+
+query I
+SELECT a.i + a.j FROM (VALUES ({'i': 1, 'j': 2})) tbl(a)
+----
+3
+
+# not a struct
+statement error
+SELECT a.i FROM (VALUES (1)) tbl(a)
+
+# cannot access like this
+statement error
+SELECT i FROM (VALUES ({'i': 1, 'j': 2})) tbl(a)
+
+# column not found
+statement error
+SELECT a.jj FROM (VALUES ({'i': 1, 'j': 2})) tbl(a)
+
+# table not found
+statement error
+SELECT b.k FROM (VALUES ({'i': 1, 'j': 2})) tbl(a)

--- a/test/sql/types/struct/struct_colref.test
+++ b/test/sql/types/struct/struct_colref.test
@@ -15,6 +15,27 @@ SELECT a.i + a.j FROM (VALUES ({'i': 1, 'j': 2})) tbl(a)
 ----
 3
 
+# correlated subqueries
+# binding works
+statement ok
+explain SELECT (SELECT STRUCT_EXTRACT(a, 'i')) FROM (VALUES ({'i': 1, 'j': 2})) tbl(a)
+
+statement ok
+explain SELECT (SELECT a.i) FROM (VALUES ({'i': 1, 'j': 2})) tbl(a)
+
+statement ok
+explain SELECT (SELECT a.i + b.j FROM (VALUES ({'i': 1, 'j': 2})) tbl(b)) FROM (VALUES ({'i': 1, 'j': 2})) tbl(a)
+
+# FIXME: correlated subqueries execute a DISTINCT, which is not supported yet for structs
+statement error
+SELECT (SELECT STRUCT_EXTRACT(a, 'i')) FROM (VALUES ({'i': 1, 'j': 2})) tbl(a)
+
+statement error
+SELECT (SELECT a.i) FROM (VALUES ({'i': 1, 'j': 2})) tbl(a)
+
+statement error
+SELECT (SELECT a.i + b.j FROM (VALUES ({'i': 1, 'j': 2})) tbl(b)) FROM (VALUES ({'i': 1, 'j': 2})) tbl(a)
+
 # not a struct
 statement error
 SELECT a.i FROM (VALUES (1)) tbl(a)


### PR DESCRIPTION
This PR allows column references to be bound to structs so brackets are not required, e.g.:

```sql
SELECT a.i FROM (VALUES ({'i': 1, 'j': 2})) tbl(a)
-- 1
```

We will first try to bind `a.i` to `table: a, column: i`.
If that fails, we try to find a column called `a` (in this case, we find `tbl.a`).
If we find such a table, and the column is of type struct, we instead emit a struct_extract(a, 'i').

This results in the following error messages:

```sql
-- column does not exist
D SELECT b.k FROM (VALUES ({'i': 1, 'j': 2})) tbl(a);
-- Error: Binder Error: Referenced table "b" not found!
-- Candidate tables: "tbl"
-- LINE 1: SELECT b.k FROM (VALUES ({'i': 1, 'j': 2})) tb...

-- column is found, but column is not a struct
D SELECT a.i FROM (VALUES (1)) tbl(a);
-- Error: Binder Error: Referenced table "a" not found!
-- Candidate tables: "tbl"
-- LINE 1: SELECT a.i FROM (VALUES (1)) tbl(a)

-- column is found and column is a struct, but key is not found
D SELECT a.jj FROM (VALUES ({'i': 1, 'j': 2})) tbl(a);
-- Error: Binder Error: Could not find key  "jj" in struct
-- Candidate struct keys: "j", "i"
```

In addition, this PR fixes a bug where run-time errors within pipelines were not correctly detected, which resulted in a pipeline being aborted and total_pipelines never reaching completed_pipelines, which caused the system to hang. 