### PR TITLE
In the sqllogictests only destroy database files that are part of the test directory

### DIFF
--- a/test/sqlite/test_sqllogictest.cpp
+++ b/test/sqlite/test_sqllogictest.cpp
@@ -1037,6 +1037,10 @@ SQLLogicTestRunner::~SQLLogicTestRunner() {
 		if (loaded_path.empty()) {
 			continue;
 		}
+		// only delete database files that were created during the tests
+		if (!StringUtil::StartsWith(loaded_path, TestDirectoryPath())) {
+			continue;
+		}
 		DeleteDatabase(loaded_path);
 	}
 }


### PR DESCRIPTION
This avoids deleting `storage_version.db` after running the tests.