### PR TITLE
Fix #1834: don't assume all deleted tuples in a single batch belong to the same row group

### DIFF
--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -110,7 +110,7 @@ public:
 	void RevertAppend(idx_t start);
 
 	//! Delete the given set of rows in the version manager
-	void Delete(Transaction &transaction, DataTable *table, Vector &row_ids, idx_t count);
+	void Delete(Transaction &transaction, DataTable *table, row_t *row_ids, idx_t count);
 
 	RowGroupPointer Checkpoint(TableDataWriter &writer, vector<unique_ptr<BaseStatistics>> &global_stats);
 	static void Serialize(RowGroupPointer &pointer, Serializer &serializer);

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -766,7 +766,7 @@ void DataTable::Delete(TableCatalogEntry &table, ClientContext &context, Vector 
 		do {
 			idx_t start = pos;
 			auto row_group = (RowGroup *)row_groups->GetSegment(ids[pos]);
-			for(pos++; pos < count; pos++) {
+			for (pos++; pos < count; pos++) {
 				D_ASSERT(ids[pos] >= 0);
 				// check if this id still belongs to this row group
 				if (idx_t(ids[pos]) < row_group->start) {
@@ -779,7 +779,7 @@ void DataTable::Delete(TableCatalogEntry &table, ClientContext &context, Vector 
 				}
 			}
 			row_group->Delete(transaction, this, ids + start, pos - start);
-		} while(pos < count);
+		} while (pos < count);
 	}
 }
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -758,8 +758,28 @@ void DataTable::Delete(TableCatalogEntry &table, ClientContext &context, Vector 
 		// deletion is in transaction-local storage: push delete into local chunk collection
 		transaction.storage.Delete(this, row_identifiers, count);
 	} else {
-		auto row_group = (RowGroup *)row_groups->GetSegment(first_id);
-		row_group->Delete(transaction, this, row_identifiers, count);
+		// delete is in the row groups
+		// we need to figure out for each id to which row group it belongs
+		// usually all (or many) ids belong to the same row group
+		// we iterate over the ids and check for every id if it belongs to the same row group as their predecessor
+		idx_t pos = 0;
+		do {
+			idx_t start = pos;
+			auto row_group = (RowGroup *)row_groups->GetSegment(ids[pos]);
+			for(pos++; pos < count; pos++) {
+				D_ASSERT(ids[pos] >= 0);
+				// check if this id still belongs to this row group
+				if (idx_t(ids[pos]) < row_group->start) {
+					// id is before row_group start -> it does not
+					break;
+				}
+				if (idx_t(ids[pos]) >= row_group->start + row_group->count) {
+					// id is after row group end -> it does not
+					break;
+				}
+			}
+			row_group->Delete(transaction, this, ids + start, pos - start);
+		} while(pos < count);
 	}
 }
 

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -710,19 +710,15 @@ public:
 	void Flush();
 };
 
-void RowGroup::Delete(Transaction &transaction, DataTable *table, Vector &row_ids, idx_t count) {
+void RowGroup::Delete(Transaction &transaction, DataTable *table, row_t *ids, idx_t count) {
 	lock_guard<mutex> lock(row_group_lock);
 	VersionDeleteState del_state(*this, transaction, table, this->start);
 
-	VectorData rdata;
-	row_ids.Orrify(count, rdata);
 	// obtain a write lock
-	auto ids = (row_t *)rdata.data;
 	for (idx_t i = 0; i < count; i++) {
-		auto ridx = rdata.sel->get_index(i);
-		D_ASSERT(ids[ridx] >= 0);
-		D_ASSERT(idx_t(ids[ridx]) >= this->start && idx_t(ids[ridx]) < this->start + this->count);
-		del_state.Delete(ids[ridx] - this->start);
+		D_ASSERT(ids[i] >= 0);
+		D_ASSERT(idx_t(ids[i]) >= this->start && idx_t(ids[i]) < this->start + this->count);
+		del_state.Delete(ids[i] - this->start);
 	}
 	del_state.Flush();
 }

--- a/test/sql/delete/test_issue_1834.test_slow
+++ b/test/sql/delete/test_issue_1834.test_slow
@@ -1,0 +1,26 @@
+# name: test/sql/delete/test_issue_1834.test_slow
+# description: Deleting with DELETE USING causes a segmentation fault
+# group: [delete]
+
+require httpfs
+
+statement ok
+CREATE TABLE Person_likes_Comment (creationDate timestamp without time zone not null, id bigint not null, likes_Comment bigint not null);
+
+statement ok
+CREATE TABLE Person_Delete_candidates (deletionDate timestamp without time zone not null, id bigint);
+
+statement ok
+COPY Person_likes_Comment FROM 'https://github.com/cwida/duckdb-data/releases/download/v1.0/Person_likes_Comment.csv' (DELIMITER '|', TIMESTAMPFORMAT '%Y-%m-%dT%H:%M:%S.%g+00:00');
+
+statement ok
+COPY Person_Delete_candidates FROM 'https://github.com/cwida/duckdb-data/releases/download/v1.0/Person_Delete_candidates.csv' (DELIMITER '|', HEADER, TIMESTAMPFORMAT '%Y-%m-%dT%H:%M:%S.%g+00:00');
+
+statement ok
+DELETE FROM Person_likes_Comment USING Person_Delete_candidates WHERE Person_Delete_candidates.id = Person_likes_Comment.id;
+
+# all tuples fulfilling this predicate should have been deleted
+query I
+SELECT COUNT(*) FROM Person_likes_Comment, Person_Delete_candidates WHERE Person_Delete_candidates.id = Person_likes_Comment.id;
+----
+0


### PR DESCRIPTION
In the case of more complex joins the row identifiers will not be streamed sequentially and may come from different row groups, so we need to explicitly check which row group the identifiers belong to. 

This should fix issue #1834.