### PR TITLE
Correctly handle multiple deletions of the same tuple in the same DELETE clause

### DIFF
--- a/src/execution/operator/persistent/physical_delete.cpp
+++ b/src/execution/operator/persistent/physical_delete.cpp
@@ -24,8 +24,7 @@ void PhysicalDelete::Sink(ExecutionContext &context, GlobalOperatorState &state,
 
 	// delete data in the base table
 	// the row ids are given to us as the last column of the child chunk
-	table.Delete(tableref, context.client, input.data[row_id_index], input.size());
-	gstate.deleted_count += input.size();
+	gstate.deleted_count += table.Delete(tableref, context.client, input.data[row_id_index], input.size());
 }
 
 unique_ptr<GlobalOperatorState> PhysicalDelete::GetGlobalState(ClientContext &context) {

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -150,7 +150,7 @@ public:
 	//! Append a DataChunk to the table. Throws an exception if the columns don't match the tables' columns.
 	void Append(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk);
 	//! Delete the entries with the specified row identifier from the table
-	void Delete(TableCatalogEntry &table, ClientContext &context, Vector &row_ids, idx_t count);
+	idx_t Delete(TableCatalogEntry &table, ClientContext &context, Vector &row_ids, idx_t count);
 	//! Update the entries with the specified row identifier from the table
 	void Update(TableCatalogEntry &table, ClientContext &context, Vector &row_ids, const vector<column_t> &column_ids,
 	            DataChunk &data);

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -80,7 +80,7 @@ public:
 	void CommitAppend(transaction_t commit_id, idx_t start, idx_t end) override;
 
 	void Append(idx_t start, idx_t end, transaction_t commit_id);
-	void Delete(Transaction &transaction, row_t rows[], idx_t count);
+	idx_t Delete(Transaction &transaction, row_t rows[], idx_t count);
 	void CommitDelete(transaction_t commit_id, row_t rows[], idx_t count);
 
 	void Serialize(Serializer &serialize) override;

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -110,7 +110,7 @@ public:
 	void RevertAppend(idx_t start);
 
 	//! Delete the given set of rows in the version manager
-	void Delete(Transaction &transaction, DataTable *table, row_t *row_ids, idx_t count);
+	idx_t Delete(Transaction &transaction, DataTable *table, row_t *row_ids, idx_t count);
 
 	RowGroupPointer Checkpoint(TableDataWriter &writer, vector<unique_ptr<BaseStatistics>> &global_stats);
 	static void Serialize(RowGroupPointer &pointer, Serializer &serializer);

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -59,7 +59,7 @@ public:
 	//! Append a chunk to the local storage
 	void Append(DataTable *table, DataChunk &chunk);
 	//! Delete a set of rows from the local storage
-	void Delete(DataTable *table, Vector &row_ids, idx_t count);
+	idx_t Delete(DataTable *table, Vector &row_ids, idx_t count);
 	//! Update a set of rows in the local storage
 	void Update(DataTable *table, Vector &row_ids, const vector<column_t> &column_ids, DataChunk &data);
 

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -692,7 +692,7 @@ class VersionDeleteState {
 public:
 	VersionDeleteState(RowGroup &info, Transaction &transaction, DataTable *table, idx_t base_row)
 	    : info(info), transaction(transaction), table(table), current_info(nullptr), current_chunk(INVALID_INDEX),
-	      count(0), base_row(base_row) {
+	      count(0), base_row(base_row), delete_count(0) {
 	}
 
 	RowGroup &info;
@@ -704,13 +704,14 @@ public:
 	idx_t count;
 	idx_t base_row;
 	idx_t chunk_row;
+	idx_t delete_count;
 
 public:
 	void Delete(row_t row_id);
 	void Flush();
 };
 
-void RowGroup::Delete(Transaction &transaction, DataTable *table, row_t *ids, idx_t count) {
+idx_t RowGroup::Delete(Transaction &transaction, DataTable *table, row_t *ids, idx_t count) {
 	lock_guard<mutex> lock(row_group_lock);
 	VersionDeleteState del_state(*this, transaction, table, this->start);
 
@@ -721,6 +722,7 @@ void RowGroup::Delete(Transaction &transaction, DataTable *table, row_t *ids, id
 		del_state.Delete(ids[i] - this->start);
 	}
 	del_state.Flush();
+	return del_state.delete_count;
 }
 
 void RowGroup::Verify() {
@@ -769,7 +771,7 @@ void VersionDeleteState::Flush() {
 		return;
 	}
 	// delete in the current info
-	current_info->Delete(transaction, rows, count);
+	delete_count += current_info->Delete(transaction, rows, count);
 	// now push the delete into the undo buffer
 	transaction.PushDelete(table, current_info, rows, count, base_row + chunk_row);
 	count = 0;

--- a/test/sql/delete/test_using_delete_duplicates.test
+++ b/test/sql/delete/test_using_delete_duplicates.test
@@ -1,0 +1,53 @@
+# name: test/sql/delete/test_using_delete_duplicates.test
+# description: Test USING deletion with duplicates
+# group: [delete]
+
+statement ok
+create table integers as select * from generate_series(0, 9, 1);
+
+statement ok
+create table integers2 as select * from generate_series(0, 9, 1);
+
+query I
+DELETE FROM integers USING integers2;
+----
+10
+
+query I
+SELECT COUNT(*) FROM integers
+----
+0
+
+# the same but with transaction local storage
+statement ok
+DROP TABLE integers
+
+statement ok
+DROP TABLE integers2
+
+statement ok
+BEGIN transaction
+
+statement ok
+create table integers as select * from generate_series(0, 9, 1);
+
+statement ok
+create table integers2 as select * from generate_series(0, 9, 1);
+
+query I
+DELETE FROM integers USING integers2;
+----
+10
+
+query I
+SELECT COUNT(*) FROM integers
+----
+0
+
+statement ok
+COMMIT
+
+query I
+SELECT COUNT(*) FROM integers
+----
+0


### PR DESCRIPTION
This can happen if there is a `USING` clause used in a deletion that results in multiple tuples of the source table being matched, e.g.:

```sql
create table integers as select * from generate_series(0, 9, 1);
create table integers2 as select * from generate_series(0, 9, 1);
DELETE FROM integers USING integers2;
```