### PR TITLE
Fix potential deadlock that occurred when there was an error in a pipeline during multi-threaded execution

### DIFF
--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -49,7 +49,6 @@ public:
 	void PushError(const string &exception);
 	bool GetError(string &exception);
 
-
 	//! Flush a thread context into the client context
 	void Flush(ThreadContext &context);
 

--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -60,7 +60,7 @@ private:
 
 	mutex executor_lock;
 	//! The pipelines of the current query
-	vector<unique_ptr<Pipeline>> pipelines;
+	vector<shared_ptr<Pipeline>> pipelines;
 	//! The producer of this query
 	unique_ptr<ProducerToken> producer;
 	//! Exceptions that occurred during the execution of the current query

--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -47,6 +47,8 @@ public:
 
 	//! Push a new error
 	void PushError(const string &exception);
+	bool GetError(string &exception);
+
 
 	//! Flush a thread context into the client context
 	void Flush(ThreadContext &context);

--- a/src/include/duckdb/execution/operator/set/physical_recursive_cte.hpp
+++ b/src/include/duckdb/execution/operator/set/physical_recursive_cte.hpp
@@ -21,7 +21,7 @@ public:
 
 	bool union_all;
 	std::shared_ptr<ChunkCollection> working_table;
-	vector<unique_ptr<Pipeline>> pipelines;
+	vector<shared_ptr<Pipeline>> pipelines;
 
 public:
 	void GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state) const override;

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -20,7 +20,7 @@ class Executor;
 class TaskContext;
 
 //! The Pipeline class represents an execution pipeline
-class Pipeline {
+class Pipeline : public std::enable_shared_from_this<Pipeline> {
 	friend class Executor;
 
 public:
@@ -33,7 +33,7 @@ public:
 	//! Execute a task within the pipeline on a single thread
 	void Execute(TaskContext &task);
 
-	void AddDependency(Pipeline *pipeline);
+	void AddDependency(shared_ptr<Pipeline> &pipeline);
 	void CompleteDependency();
 	bool HasDependencies() {
 		return !dependencies.empty();
@@ -55,9 +55,6 @@ public:
 	}
 	PhysicalOperator *GetRecursiveCTE() {
 		return recursive_cte;
-	}
-	unordered_set<Pipeline *> &GetDependencies() {
-		return dependencies;
 	}
 	void ClearParents();
 
@@ -85,9 +82,9 @@ private:
 	//! The sink (i.e. destination) for data; this is e.g. a hash table to-be-built
 	PhysicalSink *sink;
 	//! The parent pipelines (i.e. pipelines that are dependent on this pipeline to finish)
-	unordered_set<Pipeline *> parents;
+	unordered_map<Pipeline *, weak_ptr<Pipeline>> parents;
 	//! The dependencies of this pipeline
-	unordered_set<Pipeline *> dependencies;
+	unordered_map<Pipeline *, weak_ptr<Pipeline>> dependencies;
 	//! The amount of completed dependencies (the pipeline can only be started after the dependencies have finished
 	//! executing)
 	atomic<idx_t> finished_dependencies;

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -77,7 +77,7 @@ void Executor::Initialize(PhysicalOperator *plan) {
 				}
 			}
 		}
-		throw Exception(move(exception));
+		throw Exception(exception);
 	}
 
 	pipelines.clear();

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -52,6 +52,28 @@ void Executor::Initialize(PhysicalOperator *plan) {
 			task->Execute();
 			task.reset();
 		}
+		if (!exceptions.empty()) {
+			// an exception has occurred executing one of the pipelines
+			// we need to wait until all threads are finished
+			// we do this by creating weak pointers to all pipelines
+			// then clearing our references to the pipelines
+			// and waiting until all pipelines have been destroyed
+			vector<weak_ptr<Pipeline>> weak_references;
+			weak_references.reserve(pipelines.size());
+			for (auto &pipeline : pipelines) {
+				weak_references.push_back(weak_ptr<Pipeline>(pipeline));
+			}
+			pipelines.clear();
+			for (auto &weak_ref : weak_references) {
+				while (true) {
+					auto weak = weak_ref.lock();
+					if (!weak) {
+						break;
+					}
+				}
+			}
+			throw Exception(exceptions[0]);
+		}
 	}
 
 	pipelines.clear();
@@ -75,12 +97,12 @@ void Executor::Reset() {
 void Executor::BuildPipelines(PhysicalOperator *op, Pipeline *parent) {
 	if (op->IsSink()) {
 		// operator is a sink, build a pipeline
-		auto pipeline = make_unique<Pipeline>(*this, *producer);
+		auto pipeline = make_shared<Pipeline>(*this, *producer);
 		pipeline->sink = (PhysicalSink *)op;
 		pipeline->sink_state = pipeline->sink->GetGlobalState(context);
 		if (parent) {
 			// the parent is dependent on this pipeline to complete
-			parent->AddDependency(pipeline.get());
+			parent->AddDependency(pipeline);
 		}
 		switch (op->type) {
 		case PhysicalOperatorType::CREATE_TABLE_AS:
@@ -119,7 +141,8 @@ void Executor::BuildPipelines(PhysicalOperator *op, Pipeline *parent) {
 		}
 		// recurse into the pipeline child
 		BuildPipelines(pipeline->child, pipeline.get());
-		for (auto &dependency : pipeline->GetDependencies()) {
+		for (auto &entry : pipeline->dependencies) {
+			auto dependency = entry.second.lock();
 			auto dependency_cte = dependency->GetRecursiveCTE();
 			if (dependency_cte) {
 				pipeline->SetRecursiveCTE(dependency_cte);
@@ -155,7 +178,8 @@ void Executor::BuildPipelines(PhysicalOperator *op, Pipeline *parent) {
 			// this chunk scan introduces a dependency to the current pipeline
 			// namely a dependency on the duplicate elimination pipeline to finish
 			D_ASSERT(parent);
-			parent->AddDependency(entry->second);
+			auto delim_dependency = entry->second->shared_from_this();
+			parent->AddDependency(delim_dependency);
 			break;
 		}
 		case PhysicalOperatorType::EXECUTE: {
@@ -177,7 +201,7 @@ void Executor::BuildPipelines(PhysicalOperator *op, Pipeline *parent) {
 			BuildPipelines(op->children[1].get(), parent);
 			// re-order the pipelines such that they are executed in the correct order of dependencies
 			for (idx_t i = 0; i < cte_node.pipelines.size(); i++) {
-				auto &deps = cte_node.pipelines[i]->GetDependencies();
+				auto &deps = cte_node.pipelines[i]->dependencies;
 				for (idx_t j = i + 1; j < cte_node.pipelines.size(); j++) {
 					if (deps.find(cte_node.pipelines[j].get()) != deps.end()) {
 						// pipeline "i" depends on pipeline "j" but pipeline "i" is scheduled to be executed before

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -19,11 +19,11 @@ namespace duckdb {
 
 class PipelineTask : public Task {
 public:
-	explicit PipelineTask(Pipeline *pipeline_p) : pipeline(pipeline_p) {
+	explicit PipelineTask(shared_ptr<Pipeline> pipeline_p) : pipeline(move(pipeline_p)) {
 	}
 
 	TaskContext task;
-	Pipeline *pipeline;
+	shared_ptr<Pipeline> pipeline;
 
 public:
 	void Execute() override {
@@ -134,7 +134,7 @@ void Pipeline::FinishTask() {
 
 void Pipeline::ScheduleSequentialTask() {
 	auto &scheduler = TaskScheduler::GetScheduler(executor.context);
-	auto task = make_unique<PipelineTask>(this);
+	auto task = make_unique<PipelineTask>(shared_from_this());
 
 	this->total_tasks = 1;
 	scheduler.ScheduleTask(*executor.producer, move(task));
@@ -157,7 +157,7 @@ bool Pipeline::LaunchScanTasks(PhysicalOperator *op, idx_t max_threads, unique_p
 	// launch a task for every thread
 	this->total_tasks = max_threads;
 	for (idx_t i = 0; i < max_threads; i++) {
-		auto task = make_unique<PipelineTask>(this);
+		auto task = make_unique<PipelineTask>(shared_from_this());
 		scheduler.ScheduleTask(*executor.producer, move(task));
 	}
 
@@ -211,10 +211,18 @@ bool Pipeline::ScheduleOperator(PhysicalOperator *op) {
 }
 
 void Pipeline::ClearParents() {
-	for (auto &parent : parents) {
+	for (auto &parent_entry : parents) {
+		auto parent = parent_entry.second.lock();
+		if (!parent) {
+			continue;
+		}
 		parent->dependencies.erase(this);
 	}
-	for (auto &dep : dependencies) {
+	for (auto &dep_entry : dependencies) {
+		auto dep = dep_entry.second.lock();
+		if (!dep) {
+			continue;
+		}
 		dep->parents.erase(this);
 	}
 	parents.clear();
@@ -294,9 +302,12 @@ void Pipeline::Schedule() {
 	ScheduleSequentialTask();
 }
 
-void Pipeline::AddDependency(Pipeline *pipeline) {
-	this->dependencies.insert(pipeline);
-	pipeline->parents.insert(this);
+void Pipeline::AddDependency(shared_ptr<Pipeline> &pipeline) {
+	if (!pipeline) {
+		return;
+	}
+	dependencies[pipeline.get()] = weak_ptr<Pipeline>(pipeline);
+	pipeline->parents[this] = weak_ptr<Pipeline>(shared_from_this());
 }
 
 void Pipeline::CompleteDependency() {
@@ -312,7 +323,11 @@ void Pipeline::Finish() {
 	D_ASSERT(!finished);
 	finished = true;
 	// finished processing the pipeline, now we can schedule pipelines that depend on this pipeline
-	for (auto &parent : parents) {
+	for (auto &parent_entry : parents) {
+		auto parent = parent_entry.second.lock();
+		if (!parent) {
+			continue;
+		}
 		// mark a dependency as completed for each of the parents
 		parent->CompleteDependency();
 	}

--- a/test/sql/parallelism/intraquery/error_in_pipeline.test
+++ b/test/sql/parallelism/intraquery/error_in_pipeline.test
@@ -1,0 +1,19 @@
+# name: test/sql/parallelism/intraquery/error_in_pipeline.test
+# description: Test errors happening in pipelines
+# group: [intraquery]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+PRAGMA threads=16
+
+statement ok
+create table varchars as select i::varchar i from range(1000000) tbl(i);
+
+statement ok
+insert into varchars values ('hello')
+
+# we get a conversion error in the pipeline here
+statement error
+select (select min(i::int)+tbl.k from varchars) from (values (1), (2), (3)) tbl(k);


### PR DESCRIPTION
This PR fixes a deadlock that could occur when there was an error in a pipeline. What happened was that the main thread would be waiting for the pipelines to complete without correctly checking if there was an error thrown in the meantime, which could cause the program to get stuck.

The fix is semi-involved because we need to wait until all of the other threads running tasks have finished to be able to terminate the query safely. This usually does not take long as pushing an error also sets the interrupted flag, but we don't want another data race there. We do this by converting the pipelines into shared pointers (which is probably a good idea anyway) and checking if the shared pointers have been deleted. Once all pipelines have been deleted we know that all tasks have finished and we can safely terminate the query. 