### PR TITLE
Read and write atomically with offsets

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -1,16 +1,16 @@
 #include "duckdb/common/file_system.hpp"
 
+#include "duckdb/common/checksum.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/gzip_file_system.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/string_util.hpp"
-#include "duckdb/common/checksum.hpp"
+#include "duckdb/function/scalar/string_functions.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/database.hpp"
-#include "duckdb/function/scalar/string_functions.hpp"
-#include "duckdb/common/gzip_file_system.hpp"
 
-#include <cstdio>
 #include <cstdint>
+#include <cstdio>
 
 #ifndef _WIN32
 #include <dirent.h>
@@ -167,6 +167,18 @@ idx_t FileSystem::GetFilePointer(FileHandle &handle) {
 	return position;
 }
 
+void FileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	int64_t bytes_read = pread(fd, buffer, nr_bytes, location);
+	if (bytes_read == -1) {
+		throw IOException("Could not read from file \"%s\": %s", handle.path, strerror(errno));
+	}
+	if (bytes_read != nr_bytes) {
+		throw IOException("Could not read all bytes from file \"%s\": wanted=%lld read=%lld", handle.path, nr_bytes,
+		                  bytes_read);
+	}
+}
+
 int64_t FileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
 	int fd = ((UnixFileHandle &)handle).fd;
 	int64_t bytes_read = read(fd, buffer, nr_bytes);
@@ -174,6 +186,18 @@ int64_t FileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
 		throw IOException("Could not read from file \"%s\": %s", handle.path, strerror(errno));
 	}
 	return bytes_read;
+}
+
+void FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	int64_t bytes_written = pwrite(fd, buffer, nr_bytes, location);
+	if (bytes_written == -1) {
+		throw IOException("Could not write file \"%s\": %s", handle.path, strerror(errno));
+	}
+	if (bytes_written != nr_bytes) {
+		throw IOException("Could not write all bytes to file \"%s\": wanted=%lld wrote=%lld", handle.path, nr_bytes,
+		                  bytes_written);
+	}
 }
 
 int64_t FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
@@ -400,7 +424,8 @@ std::string GetLastErrorAsString() {
 
 struct WindowsFileHandle : public FileHandle {
 public:
-	WindowsFileHandle(FileSystem &file_system, string path, HANDLE fd) : FileHandle(file_system, path), fd(fd) {
+	WindowsFileHandle(FileSystem &file_system, string path, HANDLE fd)
+	    : FileHandle(file_system, path), position(0), fd(fd) {
 	}
 	virtual ~WindowsFileHandle() {
 		Close();
@@ -412,6 +437,7 @@ protected:
 	};
 
 public:
+	idx_t position;
 	HANDLE fd;
 };
 
@@ -425,7 +451,7 @@ unique_ptr<FileHandle> FileSystem::OpenFile(const string &path, uint8_t flags, F
 	DWORD desired_access;
 	DWORD share_mode;
 	DWORD creation_disposition = OPEN_EXISTING;
-	DWORD flags_and_attributes = FILE_ATTRIBUTE_NORMAL;
+	DWORD flags_and_attributes = FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED;
 	if (flags & FileFlags::FILE_FLAGS_READ) {
 		desired_access = GENERIC_READ;
 		share_mode = FILE_SHARE_READ;
@@ -454,58 +480,101 @@ unique_ptr<FileHandle> FileSystem::OpenFile(const string &path, uint8_t flags, F
 	}
 	auto handle = make_unique<WindowsFileHandle>(*this, path.c_str(), hFile);
 	if (flags & FileFlags::FILE_FLAGS_APPEND) {
-		SetFilePointer(*handle, GetFileSize(*handle));
+		auto file_size = GetFileSize(*handle);
+		SetFilePointer(*handle, file_size);
 	}
 	return move(handle);
 }
 
 void FileSystem::SetFilePointer(FileHandle &handle, idx_t location) {
-	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
-	LARGE_INTEGER loc;
-	loc.QuadPart = location;
-	auto rc = SetFilePointerEx(hFile, loc, NULL, FILE_BEGIN);
-	if (rc == 0) {
-		auto error = GetLastErrorAsString();
-		throw IOException("Could not seek to location %lld for file \"%s\": %s", location, handle.path, error);
-	}
+	((WindowsFileHandle &)handle).position = location;
 }
 
 idx_t FileSystem::GetFilePointer(FileHandle &handle) {
+	return ((WindowsFileHandle &)handle).position;
+}
+
+void FileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
 	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
-	LARGE_INTEGER ret;
-
-	LARGE_INTEGER loc;
-	loc.QuadPart = 0;
-
-	auto rc = SetFilePointerEx(hFile, loc, &ret, FILE_CURRENT);
+	DWORD bytes_read;
+	OVERLAPPED ov = {};
+	ov.Internal = 0;
+	ov.InternalHigh = 0;
+	ov.Offset = location & 0xFFFFFFFF;
+	ov.OffsetHigh = location >> 32;
+	ov.hEvent = 0;
+	ReadFile(hFile, buffer, (DWORD)nr_bytes, NULL, &ov);
+	auto rc = GetOverlappedResult(hFile, &ov, &bytes_read, true);
 	if (rc == 0) {
 		auto error = GetLastErrorAsString();
-		throw IOException("Could not get file pointer for file \"%s\": %s", handle.path, error);
+		throw IOException("Could not read file \"%s\": %s", handle.path, error);
 	}
-
-	return ret.QuadPart;
+	if (bytes_read != nr_bytes) {
+		throw IOException("Could not read all bytes from file \"%s\": wanted=%lld read=%lld", handle.path, nr_bytes,
+		                  bytes_read);
+	}
 }
 
 int64_t FileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
 	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
 	DWORD bytes_read;
-	auto rc = ReadFile(hFile, buffer, (DWORD)nr_bytes, &bytes_read, NULL);
+	auto &pos = ((WindowsFileHandle &)handle).position;
+	OVERLAPPED ov = {};
+	ov.Internal = 0;
+	ov.InternalHigh = 0;
+	ov.Offset = pos & 0xFFFFFFFF;
+	ov.OffsetHigh = pos >> 32;
+	ov.hEvent = 0;
+	auto n = std::min<idx_t>(std::max<idx_t>(GetFileSize(handle), pos) - pos, nr_bytes);
+	ReadFile(hFile, buffer, (DWORD)n, NULL, &ov);
+	auto rc = GetOverlappedResult(hFile, &ov, &bytes_read, true);
+	if (rc == 0) {
+		auto error = GetLastErrorAsString();
+		throw IOException("Could not read file \"%s\": %s", handle.path, error);
+	}
+	pos += bytes_read;
+	return bytes_read;
+}
+
+void FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
+	DWORD bytes_written;
+	OVERLAPPED ov = {};
+	ov.Internal = 0;
+	ov.InternalHigh = 0;
+	ov.Offset = location & 0xFFFFFFFF;
+	ov.OffsetHigh = location >> 32;
+	ov.hEvent = 0;
+	WriteFile(hFile, buffer, (DWORD)nr_bytes, NULL, &ov);
+	auto rc = GetOverlappedResult(hFile, &ov, &bytes_written, true);
 	if (rc == 0) {
 		auto error = GetLastErrorAsString();
 		throw IOException("Could not write file \"%s\": %s", handle.path, error);
 	}
-	return bytes_read;
+	if (bytes_written != nr_bytes) {
+		throw IOException("Could not write all bytes from file \"%s\": wanted=%lld wrote=%lld", handle.path, nr_bytes,
+		                  bytes_written);
+	}
 }
 
 int64_t FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
 	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
-	DWORD bytes_read;
-	auto rc = WriteFile(hFile, buffer, (DWORD)nr_bytes, &bytes_read, NULL);
+	DWORD bytes_written;
+	auto &pos = ((WindowsFileHandle &)handle).position;
+	OVERLAPPED ov = {};
+	ov.Internal = 0;
+	ov.InternalHigh = 0;
+	ov.Offset = pos & 0xFFFFFFFF;
+	ov.OffsetHigh = pos >> 32;
+	ov.hEvent = 0;
+	WriteFile(hFile, buffer, (DWORD)nr_bytes, NULL, &ov);
+	auto rc = GetOverlappedResult(hFile, &ov, &bytes_written, true);
 	if (rc == 0) {
 		auto error = GetLastErrorAsString();
 		throw IOException("Could not write file \"%s\": %s", handle.path, error);
 	}
-	return bytes_read;
+	pos += bytes_written;
+	return bytes_written;
 }
 
 int64_t FileSystem::GetFileSize(FileHandle &handle) {
@@ -704,26 +773,6 @@ string FileSystem::GetHomeDirectory() {
 		return string();
 	}
 	return homedir;
-}
-
-void FileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
-	// seek to the location
-	SetFilePointer(handle, location);
-	// now read from the location
-	int64_t bytes_read = Read(handle, buffer, nr_bytes);
-	if (bytes_read != nr_bytes) {
-		throw IOException("Could not read sufficient bytes from file \"%s\"", handle.path);
-	}
-}
-
-void FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
-	// seek to the location
-	SetFilePointer(handle, location);
-	// now write to the location
-	int64_t bytes_written = Write(handle, buffer, nr_bytes);
-	if (bytes_written != nr_bytes) {
-		throw IOException("Could not write sufficient bytes from file \"%s\"", handle.path);
-	}
 }
 
 bool FileSystem::CanSeek() {

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -45,10 +45,6 @@ unique_ptr<BufferHandle> BlockHandle::Load(shared_ptr<BlockHandle> &handle) {
 	auto &buffer_manager = BufferManager::GetBufferManager(handle->db);
 	auto &block_manager = BlockManager::GetBlockManager(handle->db);
 	if (handle->block_id < MAXIMUM_BLOCK) {
-		// FIXME: currently we still require a lock for reading blocks from disk
-		// this is mainly down to the block manager only having a single pointer into the file
-		// this is relatively easy to fix later on
-		lock_guard<mutex> buffer_lock(buffer_manager.manager_lock);
 		auto block = make_unique<Block>(Allocator::Get(handle->db), handle->block_id);
 		block_manager.Read(*block);
 		handle->buffer = move(block);


### PR DESCRIPTION
This PR uses pread, pwrite (Posix) and OVERLAPPED (Windows) to read and write atomically with offsets.
This also eliminates a lock that was held during block I/O in the buffer manager.

[pread](https://linux.die.net/man/2/pread)
[pwrite](https://linux.die.net/man/2/pwrite)
[Windows ReadFile](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfile)
[Windows WriteFile](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-writefile)
[Windows Overlapped](https://docs.microsoft.com/en-us/windows/win32/devio/overlapped-operations)