### PR TITLE
FIRST implementation for nested types

### DIFF
--- a/src/function/aggregate/distributive/first.cpp
+++ b/src/function/aggregate/distributive/first.cpp
@@ -118,6 +118,64 @@ struct FirstFunctionString : public FirstFunctionBase {
 	}
 };
 
+struct FirstStateValue {
+	Value *value;
+};
+
+struct FirstValueFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->value = nullptr;
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->value) {
+			delete state->value;
+		}
+	}
+	static bool IgnoreNull() {
+		return false;
+	}
+
+	static void Update(Vector inputs[], FunctionData *, idx_t input_count, Vector &state_vector, idx_t count) {
+		auto &input = inputs[0];
+		VectorData sdata;
+		state_vector.Orrify(count, sdata);
+
+		auto states = (FirstStateValue **)sdata.data;
+		for (idx_t i = 0; i < count; i++) {
+			auto state = states[sdata.sel->get_index(i)];
+			if (!state->value) {
+				state->value = new Value(input.GetValue(i));
+			}
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target) {
+		if (source.value && !target->value) {
+			target->value = new Value(*source.value);
+		}
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->value) {
+			mask.SetInvalid(idx);
+		} else {
+			result.SetValue(idx, *state->value);
+		}
+	}
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
+	                                     vector<unique_ptr<Expression>> &arguments) {
+		function.arguments[0] = arguments[0]->return_type;
+		function.return_type = arguments[0]->return_type;
+		return nullptr;
+	}
+};
+
 template <class T>
 static AggregateFunction GetFirstAggregateTemplated(LogicalType type) {
 	return AggregateFunction::UnaryAggregate<FirstState<T>, T, T, FirstFunction>(type, type);
@@ -180,7 +238,12 @@ AggregateFunction FirstFun::GetFunction(const LogicalType &type) {
 		return function;
 	}
 	default:
-		throw NotImplementedException("Unimplemented type for FIRST aggregate");
+		return AggregateFunction(
+		    {type}, type, AggregateFunction::StateSize<FirstStateValue>,
+		    AggregateFunction::StateInitialize<FirstStateValue, FirstValueFunction>, FirstValueFunction::Update,
+		    AggregateFunction::StateCombine<FirstStateValue, FirstValueFunction>,
+		    AggregateFunction::StateFinalize<FirstStateValue, void, FirstValueFunction>, nullptr,
+		    FirstValueFunction::Bind, AggregateFunction::StateDestroy<FirstStateValue, FirstValueFunction>);
 	}
 }
 
@@ -201,19 +264,12 @@ void FirstFun::RegisterFunction(BuiltinFunctions &set) {
 			first.AddFunction(FirstFun::GetFunction(type));
 		}
 	}
+	first.AddFunction(FirstFun::GetFunction(LogicalTypeId::LIST));
+	first.AddFunction(FirstFun::GetFunction(LogicalTypeId::STRUCT));
+	first.AddFunction(FirstFun::GetFunction(LogicalTypeId::MAP));
+	set.AddFunction(first);
+	first.name = "arbitrary";
 	set.AddFunction(first);
 }
 
-void ArbitraryFun::RegisterFunction(BuiltinFunctions &set) {
-	AggregateFunctionSet first("arbitrary");
-	for (const auto &type : LogicalType::ALL_TYPES) {
-		if (type.id() == LogicalTypeId::DECIMAL) {
-			first.AddFunction(AggregateFunction({type}, type, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-			                                    BindDecimalFirst));
-		} else {
-			first.AddFunction(FirstFun::GetFunction(type));
-		}
-	}
-	set.AddFunction(first);
-}
 } // namespace duckdb

--- a/src/function/aggregate/distributive_functions.cpp
+++ b/src/function/aggregate/distributive_functions.cpp
@@ -25,7 +25,6 @@ void BuiltinFunctions::RegisterDistributiveAggregates() {
 	Register<BoolAndFun>();
 	Register<ArgMinFun>();
 	Register<ArgMaxFun>();
-	Register<ArbitraryFun>();
 	Register<SkewFun>();
 	Register<KurtosisFun>();
 	Register<EntropyFun>();

--- a/src/function/aggregate/nested/list.cpp
+++ b/src/function/aggregate/nested/list.cpp
@@ -36,7 +36,6 @@ static void ListUpdateFunction(Vector inputs[], FunctionData *, idx_t input_coun
 	auto list_vector_type = LogicalType::LIST(input.GetType());
 
 	auto states = (ListAggState **)sdata.data;
-	SelectionVector sel(STANDARD_VECTOR_SIZE);
 	if (input.GetVectorType() == VectorType::SEQUENCE_VECTOR) {
 		input.Normalify(count);
 	}

--- a/src/include/duckdb/function/aggregate/distributive_functions.hpp
+++ b/src/include/duckdb/function/aggregate/distributive_functions.hpp
@@ -74,10 +74,6 @@ struct FirstFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
-struct ArbitraryFun {
-	static void RegisterFunction(BuiltinFunctions &set);
-};
-
 struct MaxFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/test/sql/types/nested/list/list_aggregates.test
+++ b/test/sql/types/nested/list/list_aggregates.test
@@ -18,6 +18,25 @@ select min(list_value(i)), max(list_value(i)) from range(10) tbl(i);
 [0]	[9]
 
 query I
+select first([i]) from range(10) tbl(i);
+----
+[0]
+
+query II
+select i%3 a, first([i]) from range(10) tbl(i) group by a order by a;
+----
+0	[0]
+1	[1]
+2	[2]
+
+query II
+select i%3 a, unnest(first([i])) from range(10) tbl(i) group by a order by a;
+----
+0	0
+1	1
+2	2
+
+query I
 select string_agg(list_value(i), ',') from range(10) tbl(i);
 ----
 [0],[1],[2],[3],[4],[5],[6],[7],[8],[9]

--- a/test/sql/types/nested/list/list_subquery.test
+++ b/test/sql/types/nested/list/list_subquery.test
@@ -1,0 +1,37 @@
+# name: test/sql/types/nested/list/list_subquery.test
+# description: Test lists in basic subqueries
+# group: [list]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT (SELECT [1, 2])
+----
+[1, 2]
+
+query I
+SELECT UNNEST((SELECT [1, 2]))
+----
+1
+2
+
+query I
+SELECT (SELECT [[1, 2], [3, 4]])
+----
+[[1, 2], [3, 4]]
+
+query I
+SELECT (SELECT {'a': [1, 2, 3], 'b': 7})
+----
+{'a': [1, 2, 3], 'b': 7}
+
+query I
+SELECT (SELECT LIST_VALUE())
+----
+[]
+
+query I
+SELECT (SELECT CASE WHEN 1=0 THEN LIST_VALUE() ELSE NULL END)
+----
+NULL

--- a/test/sql/types/nested/struct/struct_subquery.test
+++ b/test/sql/types/nested/struct/struct_subquery.test
@@ -1,0 +1,21 @@
+# name: test/sql/types/nested/struct/struct_subquery.test
+# description: Test structs in basic subqueries
+# group: [struct]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT (SELECT {'a': 3})
+----
+{'a': 3}
+
+query I
+SELECT (SELECT {'a': 3})['a']
+----
+3
+
+query I
+SELECT (SELECT CASE WHEN 1=0 THEN {'a': 3} ELSE NULL END)
+----
+NULL


### PR DESCRIPTION
This PR implements FIRST for nested types using the Value API. This is primarily important since FIRST is used internally by scalar subqueries (e.g. when doing `SELECT (SELECT [1,2])` we use the FIRST aggregate). 