### PR TITLE
Issue #1872: Nested type distinguishers 

### DIFF
--- a/src/include/duckdb/common/vector_operations/vector_operations.hpp
+++ b/src/include/duckdb/common/vector_operations/vector_operations.hpp
@@ -65,10 +65,19 @@ struct VectorOperations {
 	static void LessThan(Vector &A, Vector &B, Vector &result, idx_t count);
 	// result = A <= B
 	static void LessThanEquals(Vector &A, Vector &B, Vector &result, idx_t count);
+
 	// result = A != B with nulls being equal
 	static void DistinctFrom(Vector &left, Vector &right, Vector &result, idx_t count);
-	// result = A == B with nulls being equal
+	// result := A == B with nulls being equal
 	static void NotDistinctFrom(Vector &left, Vector &right, Vector &result, idx_t count);
+	// result := A > B with nulls being maximal
+	static void DistinctGreaterThan(Vector &left, Vector &right, Vector &result, idx_t count);
+	// result := A >= B with nulls being maximal
+	static void DistinctGreaterThanEquals(Vector &left, Vector &right, Vector &result, idx_t count);
+	// result := A < B with nulls being maximal
+	static void DistinctLessThan(Vector &left, Vector &right, Vector &result, idx_t count);
+	// result := A <= B with nulls being maximal
+	static void DistinctLessThanEquals(Vector &left, Vector &right, Vector &result, idx_t count);
 
 	//===--------------------------------------------------------------------===//
 	// Select Comparisons
@@ -85,12 +94,25 @@ struct VectorOperations {
 	                      SelectionVector *true_sel, SelectionVector *false_sel);
 	static idx_t LessThanEquals(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
 	                            SelectionVector *true_sel, SelectionVector *false_sel);
-	// result = A != B with nulls being equal
-	static idx_t SelectDistinctFrom(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
-	                                SelectionVector *true_sel, SelectionVector *false_sel);
-	// result = A == B with nulls being equal
-	static idx_t SelectNotDistinctFrom(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
-	                                   SelectionVector *true_sel, SelectionVector *false_sel);
+
+	// true := A != B with nulls being equal
+	static idx_t DistinctFrom(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+	                          SelectionVector *true_sel, SelectionVector *false_sel);
+	// true := A == B with nulls being equal
+	static idx_t NotDistinctFrom(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+	                             SelectionVector *true_sel, SelectionVector *false_sel);
+	// true := A > B with nulls being maximal
+	static idx_t DistinctGreaterThan(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+	                                 SelectionVector *true_sel, SelectionVector *false_sel);
+	// true := A >= B with nulls being maximal
+	static idx_t DistinctGreaterThanEquals(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+	                                       SelectionVector *true_sel, SelectionVector *false_sel);
+	// true := A < B with nulls being maximal
+	static idx_t DistinctLessThan(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+	                              SelectionVector *true_sel, SelectionVector *false_sel);
+	// true := A <= B with nulls being maximal
+	static idx_t DistinctLessThanEquals(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+	                                    SelectionVector *true_sel, SelectionVector *false_sel);
 
 	//===--------------------------------------------------------------------===//
 	// Hash functions

--- a/test/sql/types/list/list_null_members.test
+++ b/test/sql/types/list/list_null_members.test
@@ -1,0 +1,148 @@
+# name: test/sql/types/list/list_null_members.test
+# description: LIST comparison semantics with NULLs
+# group: [list]
+
+statement ok
+PRAGMA enable_verification
+
+# Integer lists with NULLs in various positions
+statement ok
+CREATE VIEW list_int AS
+SELECT * FROM (VALUES
+	([1]),
+	([1, 2]),
+	([1, NULL]),
+	([NULL, 2]),
+	([NULL, NULL]),
+	([NULL]),
+	(NULL)
+) tbl(i);
+
+query IITTTTTTTT
+SELECT lhs.i, rhs.i,
+	lhs.i < rhs.i, lhs.i <= rhs.i,
+	lhs.i = rhs.i, lhs.i <> rhs.i,
+	lhs.i > rhs.i, lhs.i >= rhs.i,
+	lhs.i IS NOT DISTINCT FROM rhs.i, lhs.i IS DISTINCT FROM rhs.i
+FROM list_int lhs, list_int rhs;
+----
+[1]	[1]	False	True	True	False	False	True	True	False
+[1]	[1, 2]	True	True	False	True	False	False	False	True
+[1]	[1, NULL]	True	True	False	True	False	False	False	True
+[1]	[NULL, 2]	True	True	False	True	False	False	False	True
+[1]	[NULL, NULL]	True	True	False	True	False	False	False	True
+[1]	[NULL]	True	True	False	True	False	False	False	True
+[1]	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+[1, 2]	[1]	False	False	False	True	True	True	False	True
+[1, 2]	[1, 2]	False	True	True	False	False	True	True	False
+[1, 2]	[1, NULL]	True	True	False	True	False	False	False	True
+[1, 2]	[NULL, 2]	True	True	False	True	False	False	False	True
+[1, 2]	[NULL, NULL]	True	True	False	True	False	False	False	True
+[1, 2]	[NULL]	True	True	False	True	False	False	False	True
+[1, 2]	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+[1, NULL]	[1]	False	False	False	True	True	True	False	True
+[1, NULL]	[1, 2]	False	False	False	True	True	True	False	True
+[1, NULL]	[1, NULL]	False	True	True	False	False	True	True	False
+[1, NULL]	[NULL, 2]	True	True	False	True	False	False	False	True
+[1, NULL]	[NULL, NULL]	True	True	False	True	False	False	False	True
+[1, NULL]	[NULL]	True	True	False	True	False	False	False	True
+[1, NULL]	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+[NULL, 2]	[1]	False	False	False	True	True	True	False	True
+[NULL, 2]	[1, 2]	False	False	False	True	True	True	False	True
+[NULL, 2]	[1, NULL]	False	False	False	True	True	True	False	True
+[NULL, 2]	[NULL, 2]	False	True	True	False	False	True	True	False
+[NULL, 2]	[NULL, NULL]	True	True	False	True	False	False	False	True
+[NULL, 2]	[NULL]	False	False	False	True	True	True	False	True
+[NULL, 2]	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+[NULL, NULL]	[1]	False	False	False	True	True	True	False	True
+[NULL, NULL]	[1, 2]	False	False	False	True	True	True	False	True
+[NULL, NULL]	[1, NULL]	False	False	False	True	True	True	False	True
+[NULL, NULL]	[NULL, 2]	False	False	False	True	True	True	False	True
+[NULL, NULL]	[NULL, NULL]	False	True	True	False	False	True	True	False
+[NULL, NULL]	[NULL]	False	False	False	True	True	True	False	True
+[NULL, NULL]	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+[NULL]	[1]	False	False	False	True	True	True	False	True
+[NULL]	[1, 2]	False	False	False	True	True	True	False	True
+[NULL]	[1, NULL]	False	False	False	True	True	True	False	True
+[NULL]	[NULL, 2]	True	True	False	True	False	False	False	True
+[NULL]	[NULL, NULL]	True	True	False	True	False	False	False	True
+[NULL]	[NULL]	False	True	True	False	False	True	True	False
+[NULL]	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	[1]	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	[1, 2]	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	[1, NULL]	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	[NULL, 2]	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	[NULL, NULL]	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	[NULL]	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	True	False
+
+# String lists with NULLs in various positions
+statement ok
+CREATE VIEW list_str AS
+SELECT * FROM (VALUES
+	(['duck']),
+	(['duck', 'goose']),
+	(['duck', NULL]),
+	([NULL, 'goose']),
+	([NULL, NULL]),
+	([NULL]),
+	(NULL)
+) tbl(i);
+
+query IITTTTTTTT
+SELECT lhs.i, rhs.i,
+	lhs.i < rhs.i, lhs.i <= rhs.i,
+	lhs.i = rhs.i, lhs.i <> rhs.i,
+	lhs.i > rhs.i, lhs.i >= rhs.i,
+	lhs.i IS NOT DISTINCT FROM rhs.i, lhs.i IS DISTINCT FROM rhs.i
+FROM list_str lhs, list_str rhs;
+----
+[duck]	[duck]	False	True	True	False	False	True	True	False
+[duck]	[duck, goose]	True	True	False	True	False	False	False	True
+[duck]	[duck, NULL]	True	True	False	True	False	False	False	True
+[duck]	[NULL, goose]	True	True	False	True	False	False	False	True
+[duck]	[NULL, NULL]	True	True	False	True	False	False	False	True
+[duck]	[NULL]	True	True	False	True	False	False	False	True
+[duck]	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+[duck, goose]	[duck]	False	False	False	True	True	True	False	True
+[duck, goose]	[duck, goose]	False	True	True	False	False	True	True	False
+[duck, goose]	[duck, NULL]	True	True	False	True	False	False	False	True
+[duck, goose]	[NULL, goose]	True	True	False	True	False	False	False	True
+[duck, goose]	[NULL, NULL]	True	True	False	True	False	False	False	True
+[duck, goose]	[NULL]	True	True	False	True	False	False	False	True
+[duck, goose]	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+[duck, NULL]	[duck]	False	False	False	True	True	True	False	True
+[duck, NULL]	[duck, goose]	False	False	False	True	True	True	False	True
+[duck, NULL]	[duck, NULL]	False	True	True	False	False	True	True	False
+[duck, NULL]	[NULL, goose]	True	True	False	True	False	False	False	True
+[duck, NULL]	[NULL, NULL]	True	True	False	True	False	False	False	True
+[duck, NULL]	[NULL]	True	True	False	True	False	False	False	True
+[duck, NULL]	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+[NULL, goose]	[duck]	False	False	False	True	True	True	False	True
+[NULL, goose]	[duck, goose]	False	False	False	True	True	True	False	True
+[NULL, goose]	[duck, NULL]	False	False	False	True	True	True	False	True
+[NULL, goose]	[NULL, goose]	False	True	True	False	False	True	True	False
+[NULL, goose]	[NULL, NULL]	True	True	False	True	False	False	False	True
+[NULL, goose]	[NULL]	False	False	False	True	True	True	False	True
+[NULL, goose]	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+[NULL, NULL]	[duck]	False	False	False	True	True	True	False	True
+[NULL, NULL]	[duck, goose]	False	False	False	True	True	True	False	True
+[NULL, NULL]	[duck, NULL]	False	False	False	True	True	True	False	True
+[NULL, NULL]	[NULL, goose]	False	False	False	True	True	True	False	True
+[NULL, NULL]	[NULL, NULL]	False	True	True	False	False	True	True	False
+[NULL, NULL]	[NULL]	False	False	False	True	True	True	False	True
+[NULL, NULL]	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+[NULL]	[duck]	False	False	False	True	True	True	False	True
+[NULL]	[duck, goose]	False	False	False	True	True	True	False	True
+[NULL]	[duck, NULL]	False	False	False	True	True	True	False	True
+[NULL]	[NULL, goose]	True	True	False	True	False	False	False	True
+[NULL]	[NULL, NULL]	True	True	False	True	False	False	False	True
+[NULL]	[NULL]	False	True	True	False	False	True	True	False
+[NULL]	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	[duck]	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	[duck, goose]	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	[duck, NULL]	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	[NULL, goose]	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	[NULL, NULL]	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	[NULL]	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	True	False

--- a/test/sql/types/struct/struct_null_members.test
+++ b/test/sql/types/struct/struct_null_members.test
@@ -1,0 +1,148 @@
+# name: test/sql/types/struct/struct_null_members.test
+# description: STRUCT comparison semantics with NULLs
+# group: [struct]
+
+statement ok
+PRAGMA enable_verification
+
+# Integer lists with NULLs in various positions
+statement ok
+CREATE VIEW list_int AS
+SELECT * FROM (VALUES
+	({'x': 1, 'y': 0}),
+	({'x': 1, 'y': 2}),
+	({'x': 1, 'y': NULL}),
+	({'x': NULL, 'y': 2}),
+	({'x': NULL, 'y': NULL}),
+	({'x': NULL, 'y': 0}),
+	(NULL)
+) tbl(i);
+
+query IITTTTTTTT
+SELECT lhs.i, rhs.i,
+	lhs.i < rhs.i, lhs.i <= rhs.i,
+	lhs.i = rhs.i, lhs.i <> rhs.i,
+	lhs.i > rhs.i, lhs.i >= rhs.i,
+	lhs.i IS NOT DISTINCT FROM rhs.i, lhs.i IS DISTINCT FROM rhs.i
+FROM list_int lhs, list_int rhs;
+----
+{'x': 1, 'y': 0}	{'x': 1, 'y': 0}	False	True	True	False	False	True	True	False
+{'x': 1, 'y': 0}	{'x': 1, 'y': 2}	True	True	False	True	False	False	False	True
+{'x': 1, 'y': 0}	{'x': 1, 'y': NULL}	True	True	False	True	False	False	False	True
+{'x': 1, 'y': 0}	{'x': NULL, 'y': 2}	True	True	False	True	False	False	False	True
+{'x': 1, 'y': 0}	{'x': NULL, 'y': NULL}	True	True	False	True	False	False	False	True
+{'x': 1, 'y': 0}	{'x': NULL, 'y': 0}	True	True	False	True	False	False	False	True
+{'x': 1, 'y': 0}	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+{'x': 1, 'y': 2}	{'x': 1, 'y': 0}	False	False	False	True	True	True	False	True
+{'x': 1, 'y': 2}	{'x': 1, 'y': 2}	False	True	True	False	False	True	True	False
+{'x': 1, 'y': 2}	{'x': 1, 'y': NULL}	True	True	False	True	False	False	False	True
+{'x': 1, 'y': 2}	{'x': NULL, 'y': 2}	True	True	False	True	False	False	False	True
+{'x': 1, 'y': 2}	{'x': NULL, 'y': NULL}	True	True	False	True	False	False	False	True
+{'x': 1, 'y': 2}	{'x': NULL, 'y': 0}	True	True	False	True	False	False	False	True
+{'x': 1, 'y': 2}	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+{'x': 1, 'y': NULL}	{'x': 1, 'y': 0}	False	False	False	True	True	True	False	True
+{'x': 1, 'y': NULL}	{'x': 1, 'y': 2}	False	False	False	True	True	True	False	True
+{'x': 1, 'y': NULL}	{'x': 1, 'y': NULL}	False	True	True	False	False	True	True	False
+{'x': 1, 'y': NULL}	{'x': NULL, 'y': 2}	True	True	False	True	False	False	False	True
+{'x': 1, 'y': NULL}	{'x': NULL, 'y': NULL}	True	True	False	True	False	False	False	True
+{'x': 1, 'y': NULL}	{'x': NULL, 'y': 0}	True	True	False	True	False	False	False	True
+{'x': 1, 'y': NULL}	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+{'x': NULL, 'y': 2}	{'x': 1, 'y': 0}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': 2}	{'x': 1, 'y': 2}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': 2}	{'x': 1, 'y': NULL}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': 2}	{'x': NULL, 'y': 2}	False	True	True	False	False	True	True	False
+{'x': NULL, 'y': 2}	{'x': NULL, 'y': NULL}	True	True	False	True	False	False	False	True
+{'x': NULL, 'y': 2}	{'x': NULL, 'y': 0}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': 2}	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+{'x': NULL, 'y': NULL}	{'x': 1, 'y': 0}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': NULL}	{'x': 1, 'y': 2}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': NULL}	{'x': 1, 'y': NULL}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': NULL}	{'x': NULL, 'y': 2}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': NULL}	{'x': NULL, 'y': NULL}	False	True	True	False	False	True	True	False
+{'x': NULL, 'y': NULL}	{'x': NULL, 'y': 0}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': NULL}	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+{'x': NULL, 'y': 0}	{'x': 1, 'y': 0}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': 0}	{'x': 1, 'y': 2}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': 0}	{'x': 1, 'y': NULL}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': 0}	{'x': NULL, 'y': 2}	True	True	False	True	False	False	False	True
+{'x': NULL, 'y': 0}	{'x': NULL, 'y': NULL}	True	True	False	True	False	False	False	True
+{'x': NULL, 'y': 0}	{'x': NULL, 'y': 0}	False	True	True	False	False	True	True	False
+{'x': NULL, 'y': 0}	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	{'x': 1, 'y': 0}	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	{'x': 1, 'y': 2}	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	{'x': 1, 'y': NULL}	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	{'x': NULL, 'y': 2}	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	{'x': NULL, 'y': NULL}	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	{'x': NULL, 'y': 0}	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	True	False
+
+# String lists with NULLs in various positions
+statement ok
+CREATE VIEW list_str AS
+SELECT * FROM (VALUES
+	({'x': 'duck', 'y': ''}),
+	({'x': 'duck', 'y': 'goose'}),
+	({'x': 'duck', 'y': NULL}),
+	({'x': NULL, 'y': 'goose'}),
+	({'x': NULL, 'y': NULL}),
+	({'x': NULL, 'y': 0}),
+	(NULL)
+) tbl(i);
+
+query IITTTTTTTT
+SELECT lhs.i, rhs.i,
+	lhs.i < rhs.i, lhs.i <= rhs.i,
+	lhs.i = rhs.i, lhs.i <> rhs.i,
+	lhs.i > rhs.i, lhs.i >= rhs.i,
+	lhs.i IS NOT DISTINCT FROM rhs.i, lhs.i IS DISTINCT FROM rhs.i
+FROM list_str lhs, list_str rhs;
+----
+{'x': duck, 'y': }	{'x': duck, 'y': }	False	True	True	False	False	True	True	False
+{'x': duck, 'y': }	{'x': duck, 'y': goose}	True	True	False	True	False	False	False	True
+{'x': duck, 'y': }	{'x': duck, 'y': NULL}	True	True	False	True	False	False	False	True
+{'x': duck, 'y': }	{'x': NULL, 'y': goose}	True	True	False	True	False	False	False	True
+{'x': duck, 'y': }	{'x': NULL, 'y': NULL}	True	True	False	True	False	False	False	True
+{'x': duck, 'y': }	{'x': NULL, 'y': 0}	True	True	False	True	False	False	False	True
+{'x': duck, 'y': }	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+{'x': duck, 'y': goose}	{'x': duck, 'y': }	False	False	False	True	True	True	False	True
+{'x': duck, 'y': goose}	{'x': duck, 'y': goose}	False	True	True	False	False	True	True	False
+{'x': duck, 'y': goose}	{'x': duck, 'y': NULL}	True	True	False	True	False	False	False	True
+{'x': duck, 'y': goose}	{'x': NULL, 'y': goose}	True	True	False	True	False	False	False	True
+{'x': duck, 'y': goose}	{'x': NULL, 'y': NULL}	True	True	False	True	False	False	False	True
+{'x': duck, 'y': goose}	{'x': NULL, 'y': 0}	True	True	False	True	False	False	False	True
+{'x': duck, 'y': goose}	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+{'x': duck, 'y': NULL}	{'x': duck, 'y': }	False	False	False	True	True	True	False	True
+{'x': duck, 'y': NULL}	{'x': duck, 'y': goose}	False	False	False	True	True	True	False	True
+{'x': duck, 'y': NULL}	{'x': duck, 'y': NULL}	False	True	True	False	False	True	True	False
+{'x': duck, 'y': NULL}	{'x': NULL, 'y': goose}	True	True	False	True	False	False	False	True
+{'x': duck, 'y': NULL}	{'x': NULL, 'y': NULL}	True	True	False	True	False	False	False	True
+{'x': duck, 'y': NULL}	{'x': NULL, 'y': 0}	True	True	False	True	False	False	False	True
+{'x': duck, 'y': NULL}	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+{'x': NULL, 'y': goose}	{'x': duck, 'y': }	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': goose}	{'x': duck, 'y': goose}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': goose}	{'x': duck, 'y': NULL}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': goose}	{'x': NULL, 'y': goose}	False	True	True	False	False	True	True	False
+{'x': NULL, 'y': goose}	{'x': NULL, 'y': NULL}	True	True	False	True	False	False	False	True
+{'x': NULL, 'y': goose}	{'x': NULL, 'y': 0}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': goose}	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+{'x': NULL, 'y': NULL}	{'x': duck, 'y': }	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': NULL}	{'x': duck, 'y': goose}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': NULL}	{'x': duck, 'y': NULL}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': NULL}	{'x': NULL, 'y': goose}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': NULL}	{'x': NULL, 'y': NULL}	False	True	True	False	False	True	True	False
+{'x': NULL, 'y': NULL}	{'x': NULL, 'y': 0}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': NULL}	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+{'x': NULL, 'y': 0}	{'x': duck, 'y': }	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': 0}	{'x': duck, 'y': goose}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': 0}	{'x': duck, 'y': NULL}	False	False	False	True	True	True	False	True
+{'x': NULL, 'y': 0}	{'x': NULL, 'y': goose}	True	True	False	True	False	False	False	True
+{'x': NULL, 'y': 0}	{'x': NULL, 'y': NULL}	True	True	False	True	False	False	False	True
+{'x': NULL, 'y': 0}	{'x': NULL, 'y': 0}	False	True	True	False	False	True	True	False
+{'x': NULL, 'y': 0}	NULL	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	{'x': duck, 'y': }	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	{'x': duck, 'y': goose}	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	{'x': duck, 'y': NULL}	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	{'x': NULL, 'y': goose}	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	{'x': NULL, 'y': NULL}	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	{'x': NULL, 'y': 0}	NULL	NULL	NULL	NULL	NULL	NULL	False	True
+NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	True	False


### PR DESCRIPTION
Implement nested type comparisons by using "distinguishers" that compare `NULL` values with scalars (e.g., `DistinctLessThan`). For this CL, the distinguishers follow [Postgres'](https://www.postgresql.org/docs/current/functions-comparisons.html#COMPOSITE-TYPE-COMPARISON) semantics where `NULL` is the largest value, but in the future we may extend this to honour the `PRAGMA null_order` directive.