### PR TITLE
Add ExtractPlan to Connection/ClientContext and add example of alternative execution engine

### DIFF
--- a/examples/standalone-plan/CMakeLists.txt
+++ b/examples/standalone-plan/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(example-window)
+
+set(CMAKE_CXX_STANDARD 11)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+
+include_directories(../../src/include)
+link_directories(../../build/debug/src)
+
+add_executable(example main.cpp)
+target_link_libraries(example duckdb)

--- a/examples/standalone-plan/Makefile
+++ b/examples/standalone-plan/Makefile
@@ -1,0 +1,18 @@
+
+
+.PHONY: duckdb clean main
+
+all: duckdb main
+
+clean:
+	rm -rf build
+
+duckdb:
+	cd ../.. && make
+
+main:
+	mkdir -p build
+	cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug && cmake --build .
+	build/example
+
+

--- a/examples/standalone-plan/main.cpp
+++ b/examples/standalone-plan/main.cpp
@@ -1,0 +1,391 @@
+#include "duckdb.hpp"
+#ifndef DUCKDB_AMALGAMATION
+#include "duckdb/planner/logical_operator.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/planner/operator/logical_aggregate.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/function/table/table_scan.hpp"
+#include "duckdb/planner/expression.hpp"
+#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#endif
+
+using namespace duckdb;
+
+// in this example we build a simple volcano model executor on top of the DuckDB logical plans
+// for simplicity, the executor only handles integer values and doesn't handle null values
+
+void ExecuteQuery(Connection &con, const string &query);
+
+int main() {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	// disable the optimizer
+	// for now this is required since the statistics propagator will truncate our plan
+	// (e.g. it will recognize the table is empty that satisfy the predicate i=3
+	//       and then prune the entire plan)
+	// we can fix this by disabling ONLY the statistics propagator, but for now this is easier
+	// alternatively we could just insert the same values into our table (or at least the min/max values)
+	con.Query("PRAGMA disable_optimizer");
+	// create a dummy table (for our binding purposes)
+	con.Query("CREATE TABLE mytable(i INTEGER, j INTEGER)");
+	con.Query("CREATE TABLE myothertable(k INTEGER)");
+	// contents of the tables
+	// mytable:
+	// i: 1, 2, 3, 4, 5
+	// j: 2, 3, 4, 5, 6
+	// myothertable
+	// k: 1, 10, 20
+	// (see MyScanNode)
+
+	// standard projections
+	ExecuteQuery(con, "SELECT * FROM mytable");
+	ExecuteQuery(con, "SELECT i FROM mytable");
+	ExecuteQuery(con, "SELECT j FROM mytable");
+	ExecuteQuery(con, "SELECT k FROM myothertable");
+	// some simple filter + projection
+	ExecuteQuery(con, "SELECT i+1 FROM mytable WHERE i=3 OR i=4");
+	// more complex filters
+	ExecuteQuery(con, "SELECT i+1 FROM mytable WHERE (i<=2 AND j<=3) OR (i=4 AND j=5)");
+	// aggregate
+	ExecuteQuery(con, "SELECT COUNT(*), SUM(i) + 1, SUM(j) + 2 FROM mytable WHERE i>2");
+	// with a subquery
+	ExecuteQuery(con,
+	             "SELECT a, b + 1, c + 2 FROM (SELECT COUNT(*), SUM(i), SUM(j) FROM mytable WHERE i > 2) tbl(a, b, c)");
+}
+
+class MyNode {
+public:
+	virtual ~MyNode() {
+	}
+	virtual vector<int> GetNextRow() = 0;
+
+	unique_ptr<MyNode> child;
+};
+
+class MyPlanGenerator {
+public:
+	unique_ptr<MyNode> TransformPlan(LogicalOperator &op);
+};
+
+void ExecuteQuery(Connection &con, const string &query) {
+	// create the logical plan
+	auto plan = con.ExtractPlan(query);
+	// plan->Print();
+
+	// transform the logical plan into our own plan
+	MyPlanGenerator generator;
+	auto my_plan = generator.TransformPlan(*plan);
+
+	// execute the plan and print the result
+	printf("Executing query: %s\n", query.c_str());
+	printf("----------------------\n");
+	vector<int> result;
+	while (true) {
+		result = my_plan->GetNextRow();
+		if (result.empty()) {
+			break;
+		}
+		string str;
+		for (size_t i = 0; i < result.size(); i++) {
+			if (i > 0) {
+				str += ", ";
+			}
+			str += std::to_string(result[i]);
+		}
+		printf("%s\n", str.c_str());
+	}
+	printf("----------------------\n");
+}
+
+// table scan node
+class MyScanNode : public MyNode {
+public:
+	MyScanNode(string name_p, vector<column_t> column_ids_p) : name(move(name_p)), column_ids(move(column_ids_p)) {
+		// fill up the data based on which table we are scanning
+		if (name == "mytable") {
+			// i
+			data.push_back({1, 2, 3, 4, 5});
+			// j
+			data.push_back({2, 3, 4, 5, 6});
+		} else if (name == "myothertable") {
+			// k
+			data.push_back({1, 10, 20});
+		} else {
+			throw std::runtime_error("Unsupported table!");
+		}
+	}
+
+	string name;
+	vector<column_t> column_ids;
+	vector<vector<int>> data;
+	int index = 0;
+
+	vector<int> GetNextRow() override {
+		vector<int> result;
+		if (index >= data[0].size()) {
+			return result;
+		}
+		// fill the result based on the projection list (column_ids)
+		for (size_t i = 0; i < column_ids.size(); i++) {
+			result.push_back(data[column_ids[i]][index]);
+		}
+		index++;
+		return result;
+	};
+};
+
+class MyExpressionExecutor {
+public:
+	MyExpressionExecutor(vector<int> current_row_p) : current_row(move(current_row_p)) {
+	}
+
+	vector<int> current_row;
+
+	int Execute(Expression &expression);
+
+protected:
+	int Execute(BoundReferenceExpression &expr);
+	int Execute(BoundCastExpression &expr);
+	int Execute(BoundComparisonExpression &expr);
+	int Execute(BoundConjunctionExpression &expr);
+	int Execute(BoundConstantExpression &expr);
+	int Execute(BoundFunctionExpression &expr);
+};
+
+class MyFilterNode : public MyNode {
+public:
+	MyFilterNode(unique_ptr<Expression> filter_node) : filter(move(filter_node)) {
+	}
+
+	unique_ptr<Expression> filter;
+
+	bool ExecuteFilter(Expression &expr, const vector<int> &current_row) {
+		MyExpressionExecutor executor(current_row);
+		auto val = executor.Execute(expr);
+		return val != 0;
+	}
+
+	vector<int> GetNextRow() override {
+		D_ASSERT(child);
+		while (true) {
+			auto next = child->GetNextRow();
+			if (next.empty()) {
+				return next;
+			}
+			// check if the filter passes, if it does we return the row
+			// if not we return the next row
+			if (ExecuteFilter(*filter, next)) {
+				return next;
+			}
+		}
+	};
+};
+
+class MyProjectionNode : public MyNode {
+public:
+	MyProjectionNode(vector<unique_ptr<Expression>> projections_p) : projections(move(projections_p)) {
+	}
+
+	vector<unique_ptr<Expression>> projections;
+
+	vector<int> GetNextRow() override {
+		auto next = child->GetNextRow();
+		if (next.empty()) {
+			return next;
+		}
+		MyExpressionExecutor executor(next);
+		vector<int> result;
+		for (size_t i = 0; i < projections.size(); i++) {
+			result.push_back(executor.Execute(*projections[i]));
+		}
+		return result;
+	};
+};
+
+class MyAggregateNode : public MyNode {
+public:
+	MyAggregateNode(vector<unique_ptr<Expression>> aggregates_p) : aggregates(move(aggregates_p)) {
+		// initialize aggregate states to 0
+		aggregate_states.resize(aggregates.size(), 0);
+	}
+
+	vector<unique_ptr<Expression>> aggregates;
+	vector<int> aggregate_states;
+
+	void ExecuteAggregate(MyExpressionExecutor &executor, int index, BoundAggregateExpression &expr) {
+		if (expr.function.name == "sum") {
+			int child = executor.Execute(*expr.children[0]);
+			aggregate_states[index] += child;
+		} else if (expr.function.name == "count_star") {
+			aggregate_states[index]++;
+		} else {
+			throw std::runtime_error("Unsupported aggregate function " + expr.function.name);
+		}
+	}
+
+	vector<int> GetNextRow() override {
+		if (aggregate_states.empty()) {
+			// finished aggregating
+			return aggregate_states;
+		}
+		while (true) {
+			auto next = child->GetNextRow();
+			if (next.empty()) {
+				return move(aggregate_states);
+			}
+			MyExpressionExecutor executor(next);
+			for (size_t i = 0; i < aggregates.size(); i++) {
+				ExecuteAggregate(executor, i, (BoundAggregateExpression &)*aggregates[i]);
+			}
+		}
+	};
+};
+
+unique_ptr<MyNode> MyPlanGenerator::TransformPlan(LogicalOperator &op) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_PROJECTION: {
+		// projection
+		auto child = TransformPlan(*op.children[0]);
+		auto node = make_unique<MyProjectionNode>(move(op.expressions));
+		node->child = move(child);
+		return move(node);
+	}
+	case LogicalOperatorType::LOGICAL_FILTER: {
+		// filter
+		auto child = TransformPlan(*op.children[0]);
+		auto node = make_unique<MyFilterNode>(move(op.expressions[0]));
+		node->child = move(child);
+		return move(node);
+	}
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY: {
+		auto &aggr = (LogicalAggregate &)op;
+		if (!aggr.groups.empty()) {
+			throw std::runtime_error("Grouped aggregate not supported");
+		}
+		auto child = TransformPlan(*op.children[0]);
+		auto node = make_unique<MyAggregateNode>(move(op.expressions));
+		node->child = move(child);
+		return move(node);
+	}
+	case LogicalOperatorType::LOGICAL_GET: {
+		auto &get = (LogicalGet &)op;
+		// table scan or table function
+		// note that table selections (e.g. SELECT FROM tbl) are transformed into table functions (seq_scan or
+		// index_scan)
+		if (get.function.name != "seq_scan") {
+			throw std::runtime_error("Unsupported table function");
+		}
+		// get nodes have two properties: table_filters (filter pushdown) and column_ids (projection pushdown)
+		// table_filters are only generated if optimizers are enabled (through the filter pushdown optimizer)
+		// column_ids are always generated
+		// the column_ids specify which columns should be emitted and in which order
+		// e.g. if we have a table "i, j, k" and the column_ids are {0, 2} we should emit ONLY "i, k" and in that order
+		auto &table = (TableScanBindData &)*get.bind_data;
+		if (!get.table_filters.filters.empty()) {
+			// note: filter pushdown will only be triggered if optimizers are enabled
+			throw std::runtime_error("Filter pushdown unsupported");
+		}
+		return make_unique<MyScanNode>(table.table->name, get.column_ids);
+	}
+	default:
+		throw std::runtime_error("Unsupported logical operator for transformation");
+	}
+}
+
+int MyExpressionExecutor::Execute(BoundReferenceExpression &expr) {
+	// column references (e.g. "SELECT a FROM tbl") are turned into BoundReferences
+	// these refer to an index within the row they come from
+	// because of that it is important to correctly handle the get.column_ids
+	//
+	return current_row[expr.index];
+}
+
+int MyExpressionExecutor::Execute(BoundCastExpression &expr) {
+	return Execute(*expr.child);
+}
+
+int MyExpressionExecutor::Execute(BoundConjunctionExpression &expr) {
+	int result;
+	if (expr.GetExpressionType() == ExpressionType::CONJUNCTION_AND) {
+		result = 1;
+		for (size_t i = 0; i < expr.children.size(); i++) {
+			result = result && Execute(*expr.children[i]);
+		}
+	} else if (expr.GetExpressionType() == ExpressionType::CONJUNCTION_OR) {
+		result = 0;
+		for (size_t i = 0; i < expr.children.size(); i++) {
+			result = result || Execute(*expr.children[i]);
+		}
+	} else {
+		throw std::runtime_error("Unrecognized conjunction (this shouldn't be possible)");
+	}
+	return result;
+}
+
+int MyExpressionExecutor::Execute(BoundConstantExpression &expr) {
+	return expr.value.GetValue<int32_t>();
+}
+
+int MyExpressionExecutor::Execute(BoundComparisonExpression &expr) {
+	auto lchild = Execute(*expr.left);
+	auto rchild = Execute(*expr.right);
+	bool cmp;
+	switch (expr.GetExpressionType()) {
+	case ExpressionType::COMPARE_EQUAL:
+		cmp = lchild == rchild;
+		break;
+	case ExpressionType::COMPARE_NOTEQUAL:
+		cmp = lchild != rchild;
+		break;
+	case ExpressionType::COMPARE_LESSTHAN:
+		cmp = lchild < rchild;
+		break;
+	case ExpressionType::COMPARE_GREATERTHAN:
+		cmp = lchild > rchild;
+		break;
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		cmp = lchild <= rchild;
+		break;
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		cmp = lchild >= rchild;
+		break;
+	default:
+		throw std::runtime_error("Unsupported comparison");
+	}
+	return cmp ? 1 : 0;
+}
+
+int MyExpressionExecutor::Execute(BoundFunctionExpression &expr) {
+	if (expr.function.name == "+") {
+		auto lchild = Execute(*expr.children[0]);
+		auto rchild = Execute(*expr.children[1]);
+		return lchild + rchild;
+	}
+	throw std::runtime_error("Unsupported function " + expr.function.name);
+}
+
+int MyExpressionExecutor::Execute(Expression &expression) {
+	switch (expression.GetExpressionClass()) {
+	case ExpressionClass::BOUND_REF:
+		return Execute((BoundReferenceExpression &)expression);
+	case ExpressionClass::BOUND_CAST:
+		return Execute((BoundCastExpression &)expression);
+	case ExpressionClass::BOUND_COMPARISON:
+		return Execute((BoundComparisonExpression &)expression);
+	case ExpressionClass::BOUND_CONJUNCTION:
+		return Execute((BoundConjunctionExpression &)expression);
+	case ExpressionClass::BOUND_CONSTANT:
+		return Execute((BoundConstantExpression &)expression);
+	case ExpressionClass::BOUND_FUNCTION:
+		return Execute((BoundFunctionExpression &)expression);
+	default:
+		throw std::runtime_error("Unsupported expression for expression executor " + expression.ToString());
+	}
+}

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -28,6 +28,7 @@ namespace duckdb {
 class Appender;
 class Catalog;
 class DatabaseInstance;
+class LogicalOperator;
 class PreparedStatementData;
 class Relation;
 class BufferedFileWriter;
@@ -148,6 +149,8 @@ public:
 
 	//! Parse statements from a query
 	DUCKDB_API vector<unique_ptr<SQLStatement>> ParseStatements(const string &query);
+	//! Extract the logical plan of a query
+	DUCKDB_API unique_ptr<LogicalOperator> ExtractPlan(const string &query);
 	void HandlePragmaStatements(vector<unique_ptr<SQLStatement>> &statements);
 
 	//! Runs a function with a valid transaction context, potentially starting a transaction if the context is in auto

--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -25,6 +25,7 @@ namespace duckdb {
 class ClientContext;
 class DatabaseInstance;
 class DuckDB;
+class LogicalOperator;
 
 typedef void (*warning_callback)(std::string);
 
@@ -88,6 +89,8 @@ public:
 
 	//! Extract a set of SQL statements from a specific query
 	DUCKDB_API vector<unique_ptr<SQLStatement>> ExtractStatements(const string &query);
+	//! Extract the logical plan that corresponds to a query
+	DUCKDB_API unique_ptr<LogicalOperator> ExtractPlan(const string &query);
 
 	//! Appends a DataChunk to the specified table
 	DUCKDB_API void Append(TableDescription &description, DataChunk &chunk);

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -101,6 +101,10 @@ vector<unique_ptr<SQLStatement>> Connection::ExtractStatements(const string &que
 	return context->ParseStatements(query);
 }
 
+unique_ptr<LogicalOperator> Connection::ExtractPlan(const string &query) {
+	return context->ExtractPlan(query);
+}
+
 void Connection::Append(TableDescription &description, DataChunk &chunk) {
 	context->Append(description, chunk);
 }

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/execution/operator/persistent/buffered_csv_reader.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/main/connection_manager.hpp"
+#include "duckdb/planner/logical_operator.hpp"
 
 namespace duckdb {
 


### PR DESCRIPTION
This PR adds an example of using an alternative execution engine with DuckDB. The essence of it is that we create some tables inside DuckDB, and then use the new ExtractPlan function to receive a fully bound and (potentially) optimized logical plan from any query we want to fire. We then have a transformer phase that transforms DuckDB's logical plan to our own (custom) physical plan and execute that plan. 

Simplified/shortened code snippet:

```cpp
 class MyNode {
 public:
 	virtual ~MyNode() {
 	}
 	virtual vector<int> GetNextRow() = 0;

 	unique_ptr<MyNode> child;
 };

 class MyPlanGenerator {
 public:
 	unique_ptr<MyNode> TransformPlan(LogicalOperator &op);
 };

int main() {
	DuckDB db(nullptr);
	Connection con(db);

	con.Query("CREATE TABLE mytable(i INTEGER, j INTEGER)");
	con.Query("CREATE TABLE myothertable(k INTEGER)");

	// extract DuckDB's logical plan
	auto plan = con.ExtractPlan(query);

	// transform the logical plan into our own plan
	MyPlanGenerator generator;
	auto my_plan = generator.TransformPlan(*plan);

	// execute!
	...
}
```