### PR TITLE
Improve duplicate constraint error reporting and add assertion that art removal correctly works

### DIFF
--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -354,7 +354,7 @@ unique_ptr<CatalogEntry> TableCatalogEntry::ChangeColumnType(ClientContext &cont
 			break;
 		case ConstraintType::UNIQUE: {
 			auto &bound_unique = (BoundUniqueConstraint &)*bound_constraints[i];
-			if (bound_unique.keys.find(change_idx) != bound_unique.keys.end()) {
+			if (bound_unique.key_set.find(change_idx) != bound_unique.key_set.end()) {
 				throw BinderException(
 				    "Cannot change the type of a column that has a UNIQUE or PRIMARY KEY constraint specified");
 			}

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -392,7 +392,7 @@ void ART::Delete(IndexLock &state, DataChunk &input, Vector &row_ids) {
 		auto node = Lookup(tree, *keys[i], 0);
 		if (node) {
 			auto leaf = static_cast<Leaf *>(node);
-			for(idx_t k = 0; k < leaf->num_elements; k++) {
+			for (idx_t k = 0; k < leaf->num_elements; k++) {
 				D_ASSERT(leaf->GetRowId(k) != row_identifiers[i]);
 			}
 		}

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -388,7 +388,15 @@ void ART::Delete(IndexLock &state, DataChunk &input, Vector &row_ids) {
 			continue;
 		}
 		Erase(tree, *keys[i], 0, row_identifiers[i]);
-		D_ASSERT(!is_unique || Lookup(tree, *keys[i], 0) == nullptr);
+#ifdef DEBUG
+		auto node = Lookup(tree, *keys[i], 0);
+		if (node) {
+			auto leaf = static_cast<Leaf *>(node);
+			for(idx_t k = 0; k < leaf->num_elements; k++) {
+				D_ASSERT(leaf->GetRowId(k) != row_identifiers[i]);
+			}
+		}
+#endif
 	}
 }
 

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -280,10 +280,10 @@ void ART::VerifyAppend(DataChunk &chunk) {
 				if (k > 0) {
 					key_name += ", ";
 				}
-				key_name += expression_result.data[k].GetValue(i).ToString();
+				key_name += unbound_expressions[k]->GetName() + ": " + expression_result.data[k].GetValue(i).ToString();
 			}
 			// node already exists in tree
-			throw ConstraintException("duplicate key \"%s\" violates primary key or unique constraint", key_name);
+			throw ConstraintException("duplicate key \"%s\" violates %s constraint", key_name, is_primary ? "primary key" : "unique");
 		}
 	}
 }

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -276,7 +276,7 @@ void ART::VerifyAppend(DataChunk &chunk) {
 		}
 		if (Lookup(tree, *keys[i], 0) != nullptr) {
 			string key_name;
-			for(idx_t k = 0; k < expression_result.ColumnCount(); k++) {
+			for (idx_t k = 0; k < expression_result.ColumnCount(); k++) {
 				if (k > 0) {
 					key_name += ", ";
 				}

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -283,7 +283,8 @@ void ART::VerifyAppend(DataChunk &chunk) {
 				key_name += unbound_expressions[k]->GetName() + ": " + expression_result.data[k].GetValue(i).ToString();
 			}
 			// node already exists in tree
-			throw ConstraintException("duplicate key \"%s\" violates %s constraint", key_name, is_primary ? "primary key" : "unique");
+			throw ConstraintException("duplicate key \"%s\" violates %s constraint", key_name,
+			                          is_primary ? "primary key" : "unique");
 		}
 	}
 }

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -275,8 +275,15 @@ void ART::VerifyAppend(DataChunk &chunk) {
 			continue;
 		}
 		if (Lookup(tree, *keys[i], 0) != nullptr) {
+			string key_name;
+			for(idx_t k = 0; k < expression_result.ColumnCount(); k++) {
+				if (k > 0) {
+					key_name += ", ";
+				}
+				key_name += expression_result.data[k].GetValue(i).ToString();
+			}
 			// node already exists in tree
-			throw ConstraintException("duplicate key value violates primary key or unique constraint");
+			throw ConstraintException("duplicate key \"%s\" violates primary key or unique constraint", key_name);
 		}
 	}
 }
@@ -380,6 +387,7 @@ void ART::Delete(IndexLock &state, DataChunk &input, Vector &row_ids) {
 			continue;
 		}
 		Erase(tree, *keys[i], 0, row_identifiers[i]);
+		D_ASSERT(!is_unique || Lookup(tree, *keys[i], 0) == nullptr);
 	}
 }
 

--- a/src/function/table/system/pragma_table_info.cpp
+++ b/src/function/table/system/pragma_table_info.cpp
@@ -80,7 +80,7 @@ static void CheckConstraints(TableCatalogEntry *table, idx_t oid, bool &out_not_
 		}
 		case ConstraintType::UNIQUE: {
 			auto &unique = (BoundUniqueConstraint &)*constraint;
-			if (unique.is_primary_key && unique.keys.find(oid) != unique.keys.end()) {
+			if (unique.is_primary_key && unique.key_set.find(oid) != unique.key_set.end()) {
 				out_pk = true;
 			}
 			break;

--- a/src/include/duckdb/planner/constraints/bound_unique_constraint.hpp
+++ b/src/include/duckdb/planner/constraints/bound_unique_constraint.hpp
@@ -16,9 +16,10 @@ namespace duckdb {
 class BoundUniqueConstraint : public BoundConstraint {
 public:
 	BoundUniqueConstraint(vector<idx_t> keys, unordered_set<idx_t> key_set, bool is_primary_key)
-	    : BoundConstraint(ConstraintType::UNIQUE), keys(move(keys)), key_set(move(key_set)), is_primary_key(is_primary_key) {
+	    : BoundConstraint(ConstraintType::UNIQUE), keys(move(keys)), key_set(move(key_set)),
+	      is_primary_key(is_primary_key) {
 		D_ASSERT(keys.size() == key_set.size());
-		for(auto &key : keys) {
+		for (auto &key : keys) {
 			D_ASSERT(key_set.find(key) != key_set.end());
 		}
 	}

--- a/src/include/duckdb/planner/constraints/bound_unique_constraint.hpp
+++ b/src/include/duckdb/planner/constraints/bound_unique_constraint.hpp
@@ -15,12 +15,18 @@ namespace duckdb {
 
 class BoundUniqueConstraint : public BoundConstraint {
 public:
-	BoundUniqueConstraint(unordered_set<idx_t> keys, bool is_primary_key)
-	    : BoundConstraint(ConstraintType::UNIQUE), keys(keys), is_primary_key(is_primary_key) {
+	BoundUniqueConstraint(vector<idx_t> keys, unordered_set<idx_t> key_set, bool is_primary_key)
+	    : BoundConstraint(ConstraintType::UNIQUE), keys(move(keys)), key_set(move(key_set)), is_primary_key(is_primary_key) {
+		D_ASSERT(keys.size() == key_set.size());
+		for(auto &key : keys) {
+			D_ASSERT(key_set.find(key) != key_set.end());
+		}
 	}
 
-	//! The same keys but represented as an unordered set
-	unordered_set<idx_t> keys;
+	//! The keys that define the unique constraint
+	vector<idx_t> keys;
+	//! The same keys but stored as an unordered set
+	unordered_set<idx_t> key_set;
 	//! Whether or not the unique constraint is a primary key
 	bool is_primary_key;
 };

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -90,7 +90,8 @@ static void BindConstraints(Binder &binder, BoundCreateTableInfo &info) {
 				has_primary_key = true;
 				primary_keys = keys;
 			}
-			info.bound_constraints.push_back(make_unique<BoundUniqueConstraint>(move(keys), move(key_set), unique.is_primary_key));
+			info.bound_constraints.push_back(
+			    make_unique<BoundUniqueConstraint>(move(keys), move(key_set), unique.is_primary_key));
 			break;
 		}
 		default:

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -29,7 +29,7 @@ static void BindConstraints(Binder &binder, BoundCreateTableInfo &info) {
 	auto &base = (CreateTableInfo &)*info.base;
 
 	bool has_primary_key = false;
-	unordered_set<idx_t> primary_keys;
+	vector<idx_t> primary_keys;
 	for (idx_t i = 0; i < base.constraints.size(); i++) {
 		auto &cond = base.constraints[i];
 		switch (cond->type) {
@@ -55,12 +55,14 @@ static void BindConstraints(Binder &binder, BoundCreateTableInfo &info) {
 		case ConstraintType::UNIQUE: {
 			auto &unique = (UniqueConstraint &)*cond;
 			// have to resolve columns of the unique constraint
-			unordered_set<idx_t> keys;
+			vector<idx_t> keys;
+			unordered_set<idx_t> key_set;
 			if (unique.index != INVALID_INDEX) {
 				D_ASSERT(unique.index < base.columns.size());
 				// unique constraint is given by single index
 				unique.columns.push_back(base.columns[unique.index].name);
-				keys.insert(unique.index);
+				keys.push_back(unique.index);
+				key_set.insert(unique.index);
 			} else {
 				// unique constraint is given by list of names
 				// have to resolve names
@@ -70,12 +72,13 @@ static void BindConstraints(Binder &binder, BoundCreateTableInfo &info) {
 					if (entry == info.name_map.end()) {
 						throw ParserException("column \"%s\" named in key does not exist", keyname);
 					}
-					if (keys.find(entry->second) != keys.end()) {
+					if (key_set.find(entry->second) != key_set.end()) {
 						throw ParserException("column \"%s\" appears twice in "
 						                      "primary key constraint",
 						                      keyname);
 					}
-					keys.insert(entry->second);
+					keys.push_back(entry->second);
+					key_set.insert(entry->second);
 				}
 			}
 
@@ -87,7 +90,7 @@ static void BindConstraints(Binder &binder, BoundCreateTableInfo &info) {
 				has_primary_key = true;
 				primary_keys = keys;
 			}
-			info.bound_constraints.push_back(make_unique<BoundUniqueConstraint>(keys, unique.is_primary_key));
+			info.bound_constraints.push_back(make_unique<BoundUniqueConstraint>(move(keys), move(key_set), unique.is_primary_key));
 			break;
 		}
 		default:

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -480,6 +480,7 @@ void DataTable::Append(Transaction &transaction, DataChunk &chunk, TableAppendSt
 	D_ASSERT(chunk.ColumnCount() == types.size());
 	chunk.Verify();
 
+	idx_t append_count = chunk.size();
 	idx_t remaining = chunk.size();
 	while (true) {
 		auto current_row_group = state.row_group_append_state.row_group;
@@ -519,7 +520,7 @@ void DataTable::Append(Transaction &transaction, DataChunk &chunk, TableAppendSt
 			break;
 		}
 	}
-	state.current_row += chunk.size();
+	state.current_row += append_count;
 }
 
 void DataTable::ScanTableSegment(idx_t row_start, idx_t count, const std::function<void(DataChunk &chunk)> &function) {

--- a/test/sql/index/art/index_large_abort.test
+++ b/test/sql/index/art/index_large_abort.test
@@ -1,0 +1,57 @@
+# name: test/sql/index/art/index_large_abort.test
+# description: Test abort of large insertion of negative values into index and verify that all elements are correctly deleted
+# group: [art]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE a(id INTEGER PRIMARY KEY, c INT);
+
+statement ok
+INSERT INTO a VALUES (1, 4)
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+INSERT INTO a SELECT i id, NULL c FROM range(-2, -250000, -1) tbl(i)
+
+statement error
+INSERT INTO a VALUES (1, 5)
+
+statement ok
+ROLLBACK
+
+query I
+SELECT c FROM a WHERE id=1
+----
+4
+
+query II
+SELECT * FROM a
+----
+1	4
+
+# now with non-null values
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+INSERT INTO a SELECT i id, -i c FROM range(-2, -250000, -1) tbl(i)
+
+statement error
+INSERT INTO a VALUES (1, 5)
+
+statement ok
+ROLLBACK
+
+query I
+SELECT c FROM a WHERE id=1
+----
+4
+
+query II
+SELECT * FROM a
+----
+1	4


### PR DESCRIPTION
This PR improves the duplicate key constraint error by reporting which key is violating the constraint, e.g.:

```sql
create table integers(i integer, j integer, primary key(i, j));
insert into integers values (1, 1);
insert into integers values (1, 1);
-- Constraint Error: duplicate key "i: 1, j: 1" violates primary key constraint
``` 

In addition, we add an assertion to the Erase method of the ART that asserts an element is actually removed after Erase is called (but only for a non-unique index, since for a non-unique index the same key might be in there multiple times).