### PR TITLE
remove extra file seeks for csv reader

### DIFF
--- a/src/execution/operator/persistent/buffered_csv_reader.cpp
+++ b/src/execution/operator/persistent/buffered_csv_reader.cpp
@@ -137,7 +137,8 @@ void BufferedCSVReader::Initialize(const vector<LogicalType> &requested_types) {
 		}
 	} else {
 		sql_types = requested_types;
-		JumpToBeginning(options.skip_rows, options.header);
+		ResetBuffer();
+		SkipRowsAndReadHeader(options.skip_rows, options.header);
 	}
 	InitParseChunk(sql_types.size());
 }
@@ -216,17 +217,9 @@ void BufferedCSVReader::InitParseChunk(idx_t num_cols) {
 void BufferedCSVReader::JumpToBeginning(idx_t skip_rows = 0, bool skip_header = false) {
 	ResetBuffer();
 	ResetStream();
-	SkipBOM();
 	SkipRowsAndReadHeader(skip_rows, skip_header);
 	sample_chunk_idx = 0;
-}
-
-void BufferedCSVReader::SkipBOM() {
-	char bom_buffer[3];
-	file_handle->Read(bom_buffer, 3);
-	if (bom_buffer[0] != '\xEF' || bom_buffer[1] != '\xBB' || bom_buffer[2] != '\xBF') {
-		ResetStream();
-	}
+	bom_checked = false;
 }
 
 void BufferedCSVReader::SkipRowsAndReadHeader(idx_t skip_rows, bool skip_header) {
@@ -1231,6 +1224,12 @@ bool BufferedCSVReader::ReadBuffer(idx_t &start) {
 	}
 	start = 0;
 	position = remaining;
+	if (!bom_checked) {
+		bom_checked = true;
+		if (read_count >= 3 && buffer[0] == '\xEF' && buffer[1] == '\xBB' && buffer[2] == '\xBF') {
+			position += 3;
+		}
+	}
 
 	return read_count > 0;
 }

--- a/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
@@ -156,6 +156,7 @@ public:
 	idx_t sample_chunk_idx = 0;
 	bool jumping_samples = false;
 	bool end_of_file_reached = false;
+	bool bom_checked = false;
 
 	idx_t bytes_in_chunk = 0;
 	double bytes_per_line_avg = 0;
@@ -191,8 +192,6 @@ private:
 	bool TryCastVector(Vector &parse_chunk_col, idx_t size, const LogicalType &sql_type);
 	//! Skips skip_rows, reads header row from input stream
 	void SkipRowsAndReadHeader(idx_t skip_rows, bool skip_header);
-	//! Skip Byte Order Mark
-	void SkipBOM();
 	//! Jumps back to the beginning of input stream and resets necessary internal states
 	void JumpToBeginning(idx_t skip_rows, bool skip_header);
 	//! Jumps back to the beginning of input stream and resets necessary internal states


### PR DESCRIPTION
csv reader was too eager to seek in files
which makes it impossible to read csv from streamed sources like pipes

preparation for #1417