### PR TITLE
Catch std::exception instead of Exception

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -91,7 +91,7 @@ unique_ptr<DataChunk> ClientContext::Fetch() {
 		// fetch the chunk and return it
 		auto chunk = FetchInternal(*lock);
 		return chunk;
-	} catch (Exception &ex) {
+	} catch (std::exception &ex) {
 		open_result->error = ex.what();
 	} catch (...) {
 		open_result->error = "Unhandled exception in Fetch";
@@ -128,7 +128,7 @@ string ClientContext::FinalizeQuery(ClientContextLock &lock, bool success) {
 					transaction.Rollback();
 				}
 			}
-		} catch (Exception &ex) {
+		} catch (std::exception &ex) {
 			error = ex.what();
 		} catch (...) {
 			error = "Unhandled exception!";

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -390,7 +390,7 @@ static void VerifyCheckConstraint(TableCatalogEntry &table, Expression &expr, Da
 	Vector result(LogicalType::INTEGER);
 	try {
 		executor.ExecuteExpression(chunk, result);
-	} catch (Exception &ex) {
+	} catch (std::exception &ex) {
 		throw ConstraintException("CHECK constraint failed: %s (Error: %s)", table.name, ex.what());
 	} catch (...) {
 		throw ConstraintException("CHECK constraint failed: %s (Unknown Error)", table.name);

--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -293,7 +293,7 @@ bool compare_result(string csv, ChunkCollection &collection, vector<LogicalType>
 		try {
 			parsed_result.Reset();
 			reader.ParseCSV(parsed_result);
-		} catch (Exception &ex) {
+		} catch (std::exception &ex) {
 			error_message = "Could not parse CSV: " + string(ex.what());
 			return false;
 		}

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -23,7 +23,7 @@ int main(int argc, char *argv[]) {
 		TestDeleteDirectory(dir);
 		// create the empty testing directory
 		TestCreateDirectory(dir);
-	} catch (Exception &ex) {
+	} catch (std::exception &ex) {
 		fprintf(stderr, "Failed to create testing directory \"%s\": %s", dir.c_str(), ex.what());
 		return 1;
 	}


### PR DESCRIPTION
Since we throw std::exception instead of Exception in some places (e.g. the parquet reader, or out-of-memory errors), this prevents us from throwing generic errors (`Unhandled exception in Fetch`).