### PR TITLE
Arrow Binary Integration

### DIFF
--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -502,10 +502,9 @@ void SetArrowChild(DuckDBArrowArrayChildHolder &child_holder, const LogicalType 
 		}
 		break;
 	}
-
+	case LogicalTypeId::BLOB:
 	case LogicalTypeId::VARCHAR: {
 		child_holder.vector = make_unique<Vector>(data);
-
 		child.n_buffers = 3;
 		child_holder.offsets = unique_ptr<data_t[]>(new data_t[sizeof(uint32_t) * (size + 1)]);
 		child.buffers[1] = child_holder.offsets.get();

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1175,6 +1175,10 @@ string_t StringVector::AddString(Vector &vector, const char *data, idx_t len) {
 	return StringVector::AddString(vector, string_t(data, len));
 }
 
+string_t StringVector::AddStringOrBlob(Vector &vector, const char *data, idx_t len) {
+	return StringVector::AddStringOrBlob(vector, string_t(data, len));
+}
+
 string_t StringVector::AddString(Vector &vector, const char *data) {
 	return StringVector::AddString(vector, string_t(data, strlen(data)));
 }

--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -21,10 +21,11 @@ LogicalType GetArrowLogicalType(ArrowSchema &schema,
                                 std::unordered_map<idx_t, unique_ptr<ArrowConvertData>> &arrow_convert_data,
                                 idx_t col_idx) {
 	auto format = string(schema.format);
-	if (format == "+l" || format == "+L" || (format[0] == '+' && format[1] == 'w')) {
-		//! This is a list, we might have to create a list_convert_data in our arrow_convert_data
+	if (format == "+l" || format == "+L" || (format[0] == '+' && format[1] == 'w') || format == "z" || format == "Z" ||
+	    format[0] == 'w') {
+		//! This is a list or a binary, we might have to create a list_convert_data in our arrow_convert_data
 		if (arrow_convert_data.find(col_idx) == arrow_convert_data.end()) {
-			arrow_convert_data[col_idx] = make_unique<ListArrowConvertData>();
+			arrow_convert_data[col_idx] = make_unique<ArrowVariableSizeConvertData>();
 		}
 	}
 	if (format == "n") {
@@ -74,20 +75,20 @@ LogicalType GetArrowLogicalType(ArrowSchema &schema,
 	} else if (format == "ttm") {
 		return LogicalType::TIME;
 	} else if (format == "+l") {
-
-		((ListArrowConvertData *)arrow_convert_data[col_idx].get())->list_type.emplace_back(ArrowListType::NORMAL, 0);
+		((ArrowVariableSizeConvertData *)arrow_convert_data[col_idx].get())
+		    ->variable_sz_type.emplace_back(ArrowVariableSizeType::NORMAL, 0);
 		auto child_type = GetArrowLogicalType(*schema.children[0], arrow_convert_data, col_idx);
 		return LogicalType::LIST(child_type);
 	} else if (format == "+L") {
-		((ListArrowConvertData *)arrow_convert_data[col_idx].get())
-		    ->list_type.emplace_back(ArrowListType::SUPER_SIZE, 0);
+		((ArrowVariableSizeConvertData *)arrow_convert_data[col_idx].get())
+		    ->variable_sz_type.emplace_back(ArrowVariableSizeType::SUPER_SIZE, 0);
 		auto child_type = GetArrowLogicalType(*schema.children[0], arrow_convert_data, col_idx);
 		return LogicalType::LIST(child_type);
 	} else if (format[0] == '+' && format[1] == 'w') {
 		std::string parameters = format.substr(format.find(':') + 1);
 		idx_t fixed_size = std::stoi(parameters);
-		((ListArrowConvertData *)arrow_convert_data[col_idx].get())
-		    ->list_type.emplace_back(ArrowListType::FIXED_SIZE, fixed_size);
+		((ArrowVariableSizeConvertData *)arrow_convert_data[col_idx].get())
+		    ->variable_sz_type.emplace_back(ArrowVariableSizeType::FIXED_SIZE, fixed_size);
 		auto child_type = GetArrowLogicalType(*schema.children[0], arrow_convert_data, col_idx);
 		return LogicalType::LIST(move(child_type));
 	} else if (format == "+s") {
@@ -110,6 +111,20 @@ LogicalType GetArrowLogicalType(ArrowSchema &schema,
 			child_types.push_back({struct_schema.children[type_idx]->name, list_type});
 		}
 		return LogicalType::MAP(move(child_types));
+	} else if (format == "z") {
+		((ArrowVariableSizeConvertData *)arrow_convert_data[col_idx].get())
+		    ->variable_sz_type.emplace_back(ArrowVariableSizeType::NORMAL, 0);
+		return LogicalType::BLOB;
+	} else if (format == "Z") {
+		((ArrowVariableSizeConvertData *)arrow_convert_data[col_idx].get())
+		    ->variable_sz_type.emplace_back(ArrowVariableSizeType::SUPER_SIZE, 0);
+		return LogicalType::BLOB;
+	} else if (format[0] == 'w') {
+		std::string parameters = format.substr(format.find(':') + 1);
+		idx_t fixed_size = std::stoi(parameters);
+		((ArrowVariableSizeConvertData *)arrow_convert_data[col_idx].get())
+		    ->variable_sz_type.emplace_back(ArrowVariableSizeType::FIXED_SIZE, fixed_size);
+		return LogicalType::BLOB;
 	} else {
 		throw NotImplementedException("Unsupported Internal Arrow Type %s", format);
 	}
@@ -236,14 +251,15 @@ void ColumnArrowToDuckDB(Vector &vector, ArrowArray &array, ArrowScanState &scan
 void ArrowToDuckDBList(Vector &vector, ArrowArray &array, ArrowScanState &scan_state, idx_t size,
                        std::unordered_map<idx_t, unique_ptr<ArrowConvertData>> &arrow_convert_data, idx_t col_idx,
                        idx_t &list_col_idx, idx_t nested_offset, ValidityMask *parent_mask) {
-	auto original_type = ((ListArrowConvertData *)arrow_convert_data[col_idx].get())->list_type[list_col_idx++];
+	auto original_type =
+	    ((ArrowVariableSizeConvertData *)arrow_convert_data[col_idx].get())->variable_sz_type[list_col_idx++];
 	idx_t list_size = 0;
 	SetValidityMask(vector, array, scan_state, size, nested_offset);
 	idx_t start_offset = 0;
 	idx_t cur_offset = 0;
-	if (original_type.first == ArrowListType::FIXED_SIZE) {
+	if (original_type.first == ArrowVariableSizeType::FIXED_SIZE) {
 		//! Have to check validity mask before setting this up
-		idx_t offset = (scan_state.chunk_offset + array.offset) * nested_offset;
+		idx_t offset = (scan_state.chunk_offset + array.offset) * original_type.second;
 		if (nested_offset != 0) {
 			offset = original_type.second * nested_offset;
 		}
@@ -256,7 +272,7 @@ void ArrowToDuckDBList(Vector &vector, ArrowArray &array, ArrowScanState &scan_s
 			cur_offset += original_type.second;
 		}
 		list_size = cur_offset;
-	} else if (original_type.first == ArrowListType::NORMAL) {
+	} else if (original_type.first == ArrowVariableSizeType::NORMAL) {
 		auto offsets = (uint32_t *)array.buffers[1] + array.offset + scan_state.chunk_offset;
 		if (nested_offset != 0) {
 			offsets = (uint32_t *)array.buffers[1] + nested_offset;
@@ -304,6 +320,60 @@ void ArrowToDuckDBList(Vector &vector, ArrowArray &array, ArrowScanState &scan_s
 	ColumnArrowToDuckDB(child_vector, *array.children[0], scan_state, list_size, arrow_convert_data, col_idx,
 	                    list_col_idx, start_offset);
 }
+
+void ArrowToDuckDBBlob(Vector &vector, ArrowArray &array, ArrowScanState &scan_state, idx_t size,
+                       std::unordered_map<idx_t, unique_ptr<ArrowConvertData>> &arrow_convert_data, idx_t col_idx,
+                       idx_t &list_col_idx, idx_t nested_offset) {
+	auto original_type =
+	    ((ArrowVariableSizeConvertData *)arrow_convert_data[col_idx].get())->variable_sz_type[list_col_idx++];
+	SetValidityMask(vector, array, scan_state, size, nested_offset);
+	if (original_type.first == ArrowVariableSizeType::FIXED_SIZE) {
+		//! Have to check validity mask before setting this up
+		idx_t offset = (scan_state.chunk_offset + array.offset) * original_type.second;
+		if (nested_offset != 0) {
+			offset = original_type.second * nested_offset;
+		}
+		auto cdata = (char *)array.buffers[1];
+		for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+			if (FlatVector::IsNull(vector, row_idx)) {
+				continue;
+			}
+			auto bptr = cdata + offset;
+			auto blob_len = original_type.second;
+			FlatVector::GetData<string_t>(vector)[row_idx] = StringVector::AddStringOrBlob(vector, bptr, blob_len);
+			offset += blob_len;
+		}
+	} else if (original_type.first == ArrowVariableSizeType::NORMAL) {
+		auto offsets = (uint32_t *)array.buffers[1] + array.offset + scan_state.chunk_offset;
+		if (nested_offset != 0) {
+			offsets = (uint32_t *)array.buffers[1] + array.offset + nested_offset;
+		}
+		auto cdata = (char *)array.buffers[2];
+		for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+			if (FlatVector::IsNull(vector, row_idx)) {
+				continue;
+			}
+			auto bptr = cdata + offsets[row_idx];
+			auto blob_len = offsets[row_idx + 1] - offsets[row_idx];
+			FlatVector::GetData<string_t>(vector)[row_idx] = StringVector::AddStringOrBlob(vector, bptr, blob_len);
+		}
+	} else {
+		auto offsets = (uint64_t *)array.buffers[1] + array.offset + scan_state.chunk_offset;
+		if (nested_offset != 0) {
+			offsets = (uint64_t *)array.buffers[1] + array.offset + nested_offset;
+		}
+		auto cdata = (char *)array.buffers[2];
+		for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+			if (FlatVector::IsNull(vector, row_idx)) {
+				continue;
+			}
+			auto bptr = cdata + offsets[row_idx];
+			auto blob_len = offsets[row_idx + 1] - offsets[row_idx];
+			FlatVector::GetData<string_t>(vector)[row_idx] = StringVector::AddStringOrBlob(vector, bptr, blob_len);
+		}
+	}
+}
+
 void ArrowToDuckDBMapList(Vector &vector, ArrowArray &array, ArrowScanState &scan_state, idx_t size,
                           std::unordered_map<idx_t, unique_ptr<ArrowConvertData>> &arrow_convert_data, idx_t col_idx,
                           idx_t &list_col_idx, uint32_t *offsets, ValidityMask *parent_mask) {
@@ -499,6 +569,10 @@ void ColumnArrowToDuckDB(Vector &vector, ArrowArray &array, ArrowScanState &scan
 			throw std::runtime_error("Unsupported physical type for Decimal" +
 			                         TypeIdToString(vector.GetType().InternalType()));
 		}
+		break;
+	}
+	case LogicalTypeId::BLOB: {
+		ArrowToDuckDBBlob(vector, array, scan_state, size, arrow_convert_data, col_idx, list_col_idx, nested_offset);
 		break;
 	}
 	case LogicalTypeId::LIST: {

--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -355,7 +355,7 @@ void ArrowToDuckDBBlob(Vector &vector, ArrowArray &array, ArrowScanState &scan_s
 		}
 	} else {
 		//! Check if last offset is higher than max uint32
-		if (((uint64_t *)array.buffers[1])[array.length] > std::numeric_limits<uint32_t>::max()) {
+		if (((uint64_t *)array.buffers[1])[array.length] > NumericLimits<uint32_t>::Maximum()) {
 			throw std::runtime_error("We do not support Blobs over 4GB");
 		}
 		auto offsets = (uint64_t *)array.buffers[1] + array.offset + scan_state.chunk_offset;
@@ -499,7 +499,7 @@ void ColumnArrowToDuckDB(Vector &vector, ArrowArray &array, ArrowScanState &scan
 		auto original_type = arrow_convert_data[col_idx]->variable_sz_type[list_col_idx++];
 		auto cdata = (char *)array.buffers[2];
 		if (original_type.first == ArrowVariableSizeType::SUPER_SIZE) {
-			if (((uint64_t *)array.buffers[1])[array.length] > std::numeric_limits<uint32_t>::max()) {
+			if (((uint64_t *)array.buffers[1])[array.length] > NumericLimits<uint32_t>::Maximum()) {
 				throw std::runtime_error("We do not support Strings over 4GB");
 			}
 			auto offsets = (uint64_t *)array.buffers[1] + array.offset + scan_state.chunk_offset;

--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -22,10 +22,10 @@ LogicalType GetArrowLogicalType(ArrowSchema &schema,
                                 idx_t col_idx) {
 	auto format = string(schema.format);
 	if (format == "+l" || format == "+L" || (format[0] == '+' && format[1] == 'w') || format == "z" || format == "Z" ||
-	    format[0] == 'w') {
-		//! This is a list or a binary, we might have to create a list_convert_data in our arrow_convert_data
+	    format == "u" || format == "U" || format[0] == 'w') {
+		//! This is a list, string or a binary, we might have to create a list_convert_data in our arrow_convert_data
 		if (arrow_convert_data.find(col_idx) == arrow_convert_data.end()) {
-			arrow_convert_data[col_idx] = make_unique<ArrowVariableSizeConvertData>();
+			arrow_convert_data[col_idx] = make_unique<ArrowConvertData>();
 		}
 	}
 	if (format == "n") {
@@ -61,6 +61,10 @@ LogicalType GetArrowLogicalType(ArrowSchema &schema,
 		}
 		return LogicalType::DECIMAL(width, scale);
 	} else if (format == "u") {
+		arrow_convert_data[col_idx]->variable_sz_type.emplace_back(ArrowVariableSizeType::NORMAL, 0);
+		return LogicalType::VARCHAR;
+	} else if (format == "U") {
+		arrow_convert_data[col_idx]->variable_sz_type.emplace_back(ArrowVariableSizeType::SUPER_SIZE, 0);
 		return LogicalType::VARCHAR;
 	} else if (format == "tsn:") {
 		return LogicalTypeId::TIMESTAMP_NS;
@@ -75,20 +79,17 @@ LogicalType GetArrowLogicalType(ArrowSchema &schema,
 	} else if (format == "ttm") {
 		return LogicalType::TIME;
 	} else if (format == "+l") {
-		((ArrowVariableSizeConvertData *)arrow_convert_data[col_idx].get())
-		    ->variable_sz_type.emplace_back(ArrowVariableSizeType::NORMAL, 0);
+		arrow_convert_data[col_idx]->variable_sz_type.emplace_back(ArrowVariableSizeType::NORMAL, 0);
 		auto child_type = GetArrowLogicalType(*schema.children[0], arrow_convert_data, col_idx);
 		return LogicalType::LIST(child_type);
 	} else if (format == "+L") {
-		((ArrowVariableSizeConvertData *)arrow_convert_data[col_idx].get())
-		    ->variable_sz_type.emplace_back(ArrowVariableSizeType::SUPER_SIZE, 0);
+		arrow_convert_data[col_idx]->variable_sz_type.emplace_back(ArrowVariableSizeType::SUPER_SIZE, 0);
 		auto child_type = GetArrowLogicalType(*schema.children[0], arrow_convert_data, col_idx);
 		return LogicalType::LIST(child_type);
 	} else if (format[0] == '+' && format[1] == 'w') {
 		std::string parameters = format.substr(format.find(':') + 1);
 		idx_t fixed_size = std::stoi(parameters);
-		((ArrowVariableSizeConvertData *)arrow_convert_data[col_idx].get())
-		    ->variable_sz_type.emplace_back(ArrowVariableSizeType::FIXED_SIZE, fixed_size);
+		arrow_convert_data[col_idx]->variable_sz_type.emplace_back(ArrowVariableSizeType::FIXED_SIZE, fixed_size);
 		auto child_type = GetArrowLogicalType(*schema.children[0], arrow_convert_data, col_idx);
 		return LogicalType::LIST(move(child_type));
 	} else if (format == "+s") {
@@ -112,18 +113,15 @@ LogicalType GetArrowLogicalType(ArrowSchema &schema,
 		}
 		return LogicalType::MAP(move(child_types));
 	} else if (format == "z") {
-		((ArrowVariableSizeConvertData *)arrow_convert_data[col_idx].get())
-		    ->variable_sz_type.emplace_back(ArrowVariableSizeType::NORMAL, 0);
+		arrow_convert_data[col_idx]->variable_sz_type.emplace_back(ArrowVariableSizeType::NORMAL, 0);
 		return LogicalType::BLOB;
 	} else if (format == "Z") {
-		((ArrowVariableSizeConvertData *)arrow_convert_data[col_idx].get())
-		    ->variable_sz_type.emplace_back(ArrowVariableSizeType::SUPER_SIZE, 0);
+		arrow_convert_data[col_idx]->variable_sz_type.emplace_back(ArrowVariableSizeType::SUPER_SIZE, 0);
 		return LogicalType::BLOB;
 	} else if (format[0] == 'w') {
 		std::string parameters = format.substr(format.find(':') + 1);
 		idx_t fixed_size = std::stoi(parameters);
-		((ArrowVariableSizeConvertData *)arrow_convert_data[col_idx].get())
-		    ->variable_sz_type.emplace_back(ArrowVariableSizeType::FIXED_SIZE, fixed_size);
+		arrow_convert_data[col_idx]->variable_sz_type.emplace_back(ArrowVariableSizeType::FIXED_SIZE, fixed_size);
 		return LogicalType::BLOB;
 	} else {
 		throw NotImplementedException("Unsupported Internal Arrow Type %s", format);
@@ -157,7 +155,7 @@ unique_ptr<FunctionData> ArrowTableFunction::ArrowScanBind(ClientContext &contex
 		}
 		if (schema.dictionary) {
 			res->arrow_convert_data[col_idx] =
-			    make_unique<DictionaryArrowConvertData>(GetArrowLogicalType(schema, res->arrow_convert_data, col_idx));
+			    make_unique<ArrowConvertData>(GetArrowLogicalType(schema, res->arrow_convert_data, col_idx));
 			return_types.emplace_back(GetArrowLogicalType(*schema.dictionary, res->arrow_convert_data, col_idx));
 		} else {
 			return_types.emplace_back(GetArrowLogicalType(schema, res->arrow_convert_data, col_idx));
@@ -251,8 +249,7 @@ void ColumnArrowToDuckDB(Vector &vector, ArrowArray &array, ArrowScanState &scan
 void ArrowToDuckDBList(Vector &vector, ArrowArray &array, ArrowScanState &scan_state, idx_t size,
                        std::unordered_map<idx_t, unique_ptr<ArrowConvertData>> &arrow_convert_data, idx_t col_idx,
                        idx_t &list_col_idx, idx_t nested_offset, ValidityMask *parent_mask) {
-	auto original_type =
-	    ((ArrowVariableSizeConvertData *)arrow_convert_data[col_idx].get())->variable_sz_type[list_col_idx++];
+	auto original_type = arrow_convert_data[col_idx]->variable_sz_type[list_col_idx++];
 	idx_t list_size = 0;
 	SetValidityMask(vector, array, scan_state, size, nested_offset);
 	idx_t start_offset = 0;
@@ -324,8 +321,7 @@ void ArrowToDuckDBList(Vector &vector, ArrowArray &array, ArrowScanState &scan_s
 void ArrowToDuckDBBlob(Vector &vector, ArrowArray &array, ArrowScanState &scan_state, idx_t size,
                        std::unordered_map<idx_t, unique_ptr<ArrowConvertData>> &arrow_convert_data, idx_t col_idx,
                        idx_t &list_col_idx, idx_t nested_offset) {
-	auto original_type =
-	    ((ArrowVariableSizeConvertData *)arrow_convert_data[col_idx].get())->variable_sz_type[list_col_idx++];
+	auto original_type = arrow_convert_data[col_idx]->variable_sz_type[list_col_idx++];
 	SetValidityMask(vector, array, scan_state, size, nested_offset);
 	if (original_type.first == ArrowVariableSizeType::FIXED_SIZE) {
 		//! Have to check validity mask before setting this up
@@ -358,6 +354,10 @@ void ArrowToDuckDBBlob(Vector &vector, ArrowArray &array, ArrowScanState &scan_s
 			FlatVector::GetData<string_t>(vector)[row_idx] = StringVector::AddStringOrBlob(vector, bptr, blob_len);
 		}
 	} else {
+		//! Check if last offset is higher than max uint32
+		if (((uint64_t *)array.buffers[1])[array.length] > std::numeric_limits<uint32_t>::max()) {
+			throw std::runtime_error("We do not support Blobs over 4GB");
+		}
 		auto offsets = (uint64_t *)array.buffers[1] + array.offset + scan_state.chunk_offset;
 		if (nested_offset != 0) {
 			offsets = (uint64_t *)array.buffers[1] + array.offset + nested_offset;
@@ -404,6 +404,22 @@ void ArrowToDuckDBMapList(Vector &vector, ArrowArray &array, ArrowScanState &sca
 	}
 	ColumnArrowToDuckDB(child_vector, array, scan_state, list_size, arrow_convert_data, col_idx, list_col_idx,
 	                    offsets[0]);
+}
+template <class T>
+static void SetVectorString(Vector &vector, idx_t size, char *cdata, T *offsets) {
+	for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+		if (FlatVector::IsNull(vector, row_idx)) {
+			continue;
+		}
+		auto cptr = cdata + offsets[row_idx];
+		auto str_len = offsets[row_idx + 1] - offsets[row_idx];
+
+		auto utf_type = Utf8Proc::Analyze(cptr, str_len);
+		if (utf_type == UnicodeType::INVALID) {
+			throw std::runtime_error("Invalid UTF8 string encoding");
+		}
+		FlatVector::GetData<string_t>(vector)[row_idx] = StringVector::AddString(vector, cptr, str_len);
+	}
 }
 
 void ColumnArrowToDuckDB(Vector &vector, ArrowArray &array, ArrowScanState &scan_state, idx_t size,
@@ -480,24 +496,24 @@ void ColumnArrowToDuckDB(Vector &vector, ArrowArray &array, ArrowScanState &scan
 		break;
 	}
 	case LogicalTypeId::VARCHAR: {
-		auto offsets = (uint32_t *)array.buffers[1] + array.offset + scan_state.chunk_offset;
-		if (nested_offset != 0) {
-			offsets = (uint32_t *)array.buffers[1] + array.offset + nested_offset;
-		}
+		auto original_type = arrow_convert_data[col_idx]->variable_sz_type[list_col_idx++];
 		auto cdata = (char *)array.buffers[2];
-
-		for (idx_t row_idx = 0; row_idx < size; row_idx++) {
-			if (FlatVector::IsNull(vector, row_idx)) {
-				continue;
+		if (original_type.first == ArrowVariableSizeType::SUPER_SIZE) {
+			if (((uint64_t *)array.buffers[1])[array.length] > std::numeric_limits<uint32_t>::max()) {
+				throw std::runtime_error("We do not support Strings over 4GB");
 			}
-			auto cptr = cdata + offsets[row_idx];
-			auto str_len = offsets[row_idx + 1] - offsets[row_idx];
-
-			auto utf_type = Utf8Proc::Analyze(cptr, str_len);
-			if (utf_type == UnicodeType::INVALID) {
-				throw std::runtime_error("Invalid UTF8 string encoding");
+			auto offsets = (uint64_t *)array.buffers[1] + array.offset + scan_state.chunk_offset;
+			if (nested_offset != 0) {
+				offsets = (uint64_t *)array.buffers[1] + array.offset + nested_offset;
 			}
-			FlatVector::GetData<string_t>(vector)[row_idx] = StringVector::AddString(vector, cptr, str_len);
+			SetVectorString(vector, size, cdata, offsets);
+
+		} else {
+			auto offsets = (uint32_t *)array.buffers[1] + array.offset + scan_state.chunk_offset;
+			if (nested_offset != 0) {
+				offsets = (uint32_t *)array.buffers[1] + array.offset + nested_offset;
+			}
+			SetVectorString(vector, size, cdata, offsets);
 		}
 
 		break;
@@ -749,7 +765,7 @@ void ColumnArrowToDuckDBDictionary(Vector &vector, ArrowArray &array, ArrowScanS
 		                    col_idx, list_col_idx);
 		dict_vectors[col_idx] = move(base_vector);
 	}
-	auto dictionary_type = ((DictionaryArrowConvertData *)arrow_convert_data[col_idx].get())->dictionary_type;
+	auto dictionary_type = arrow_convert_data[col_idx]->dictionary_type;
 	//! Get Pointer to Indices of Dictionary
 	auto indices = (data_ptr_t)array.buffers[1] +
 	               GetTypeIdSize(dictionary_type.InternalType()) * (scan_state.chunk_offset + array.offset);

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -316,6 +316,9 @@ struct ListVector {
 struct StringVector {
 	//! Add a string to the string heap of the vector (auxiliary data)
 	DUCKDB_API static string_t AddString(Vector &vector, const char *data, idx_t len);
+	//! Add a string or a blob to the string heap of the vector (auxiliary data)
+	//! This function is the same as ::AddString, except the added data does not need to be valid UTF8
+	DUCKDB_API static string_t AddStringOrBlob(Vector &vector, const char *data, idx_t len);
 	//! Add a string to the string heap of the vector (auxiliary data)
 	DUCKDB_API static string_t AddString(Vector &vector, const char *data);
 	//! Add a string to the string heap of the vector (auxiliary data)

--- a/src/include/duckdb/function/table/arrow.hpp
+++ b/src/include/duckdb/function/table/arrow.hpp
@@ -19,17 +19,9 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 enum class ArrowVariableSizeType : uint8_t { FIXED_SIZE = 0, NORMAL = 1, SUPER_SIZE = 2 };
 struct ArrowConvertData {
-	virtual ~ArrowConvertData() = default;
-};
-
-struct DictionaryArrowConvertData : public ArrowConvertData {
-	DictionaryArrowConvertData(LogicalType type) : dictionary_type(type) {};
+	ArrowConvertData(LogicalType type) : dictionary_type(type) {};
+	ArrowConvertData() {};
 	LogicalType dictionary_type;
-};
-
-struct ArrowVariableSizeConvertData : public ArrowConvertData {
-	ArrowVariableSizeConvertData() {
-	}
 	vector<std::pair<ArrowVariableSizeType, idx_t>> variable_sz_type;
 };
 

--- a/src/include/duckdb/function/table/arrow.hpp
+++ b/src/include/duckdb/function/table/arrow.hpp
@@ -15,9 +15,9 @@
 
 namespace duckdb {
 //===--------------------------------------------------------------------===//
-// Arrow List Types
+// Arrow Variable Size Types
 //===--------------------------------------------------------------------===//
-enum class ArrowListType : uint8_t { FIXED_SIZE = 0, NORMAL = 1, SUPER_SIZE = 2 };
+enum class ArrowVariableSizeType : uint8_t { FIXED_SIZE = 0, NORMAL = 1, SUPER_SIZE = 2 };
 struct ArrowConvertData {
 	virtual ~ArrowConvertData() = default;
 };
@@ -27,10 +27,10 @@ struct DictionaryArrowConvertData : public ArrowConvertData {
 	LogicalType dictionary_type;
 };
 
-struct ListArrowConvertData : public ArrowConvertData {
-	ListArrowConvertData() {
+struct ArrowVariableSizeConvertData : public ArrowConvertData {
+	ArrowVariableSizeConvertData() {
 	}
-	vector<std::pair<ArrowListType, idx_t>> list_type;
+	vector<std::pair<ArrowVariableSizeType, idx_t>> variable_sz_type;
 };
 
 struct ArrowScanFunctionData : public TableFunctionData {

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -222,6 +222,10 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		child.format = "n";
 		break;
 	}
+	case LogicalTypeId::BLOB: {
+		child.format = "z";
+		break;
+	}
 	case LogicalTypeId::LIST: {
 		child.format = "+l";
 		child.n_children = 1;

--- a/test/arrow/parquet_test.cpp
+++ b/test/arrow/parquet_test.cpp
@@ -167,7 +167,6 @@ TEST_CASE("Test Parquet Files", "[arrow]") {
 
 	auto parquet_files = fs.Glob("test/sql/copy/parquet/data/*.parquet");
 	for (auto &parquet_path : parquet_files) {
-		std::cout << parquet_path << std::endl;
 		REQUIRE(RoundTrip(parquet_path, skip, conn));
 	}
 	skip.clear();
@@ -184,7 +183,6 @@ TEST_CASE("Test Parquet Files", "[arrow]") {
 	}
 	parquet_files = fs.Glob("test/sql/copy/parquet/data/glob/*.parquet");
 	for (auto &parquet_path : parquet_files) {
-		std::cout << parquet_path << std::endl;
 		REQUIRE(RoundTrip(parquet_path, skip, conn));
 	}
 }

--- a/test/arrow/parquet_test.cpp
+++ b/test/arrow/parquet_test.cpp
@@ -120,6 +120,22 @@ TEST_CASE("Test Parquet File NaN", "[arrow]") {
 	REQUIRE(CHECK_COLUMN(result, 2, {true, false, true}));
 }
 
+TEST_CASE("Test Parquet File Fixed Size Binary", "[arrow]") {
+	std::vector<std::string> skip;
+
+	duckdb::DuckDB db;
+	duckdb::Connection conn {db};
+
+	//! Impossible to round-trip Fixed Binaries so we just validate that the duckdb table is correct-o
+	std::string parquet_path = "test/sql/copy/parquet/data/fixed.parquet";
+	auto table = ReadParquetFile(parquet_path);
+
+	auto result = ArrowToDuck(conn, *table);
+	REQUIRE(result->success);
+	REQUIRE(
+	    CHECK_COLUMN(result, 0, {"\\x00\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08\\x09\\x0A\\x0B\\x0C\\x0D\\x0E\\x0F"}));
+}
+
 TEST_CASE("Test Parquet Long Files", "[arrow]") {
 	std::vector<std::string> skip;
 
@@ -137,16 +153,11 @@ TEST_CASE("Test Parquet Long Files", "[arrow]") {
 
 TEST_CASE("Test Parquet Files", "[arrow]") {
 
-	std::vector<std::string> skip {"aws2.parquet"};     //! Not supported by arrow
-	skip.emplace_back("datapage_v2.snappy.parquet");    //! Not supported by arrow
-	skip.emplace_back("broken-arrow.parquet");          //! Arrow can't read this
-	skip.emplace_back("nan-float.parquet");             //! Can't roundtrip NaNs
-	skip.emplace_back("alltypes_dictionary.parquet");   //! FIXME: Contains binary columns, we don't support those yet
-	skip.emplace_back("blob.parquet");                  //! FIXME: Contains binary columns, we don't support those yet
-	skip.emplace_back("alltypes_plain.parquet");        //! FIXME: Contains binary columns, we don't support those yet
-	skip.emplace_back("alltypes_plain.snappy.parquet"); //! FIXME: Contains binary columns, we don't support those yet
-	skip.emplace_back("data-types.parquet");            //! FIXME: Contains binary columns, we don't support those yet
-	skip.emplace_back("fixed.parquet"); //! FIXME: Contains fixed-width-binary columns, we don't support those yet
+	std::vector<std::string> skip {"aws2.parquet"};    //! Not supported by arrow
+	skip.emplace_back("datapage_v2.snappy.parquet");   //! Not supported by arrow
+	skip.emplace_back("broken-arrow.parquet");         //! Arrow can't read this
+	skip.emplace_back("nan-float.parquet");            //! Can't roundtrip NaNs
+	skip.emplace_back("fixed.parquet");                //! Can't roundtrip Fixed-size Binaries
 	skip.emplace_back("leftdate3_192_loop_1.parquet"); //! This is just crazy slow
 	skip.emplace_back("bug687_nulls.parquet");         //! This is just crazy slow
 
@@ -156,6 +167,7 @@ TEST_CASE("Test Parquet Files", "[arrow]") {
 
 	auto parquet_files = fs.Glob("test/sql/copy/parquet/data/*.parquet");
 	for (auto &parquet_path : parquet_files) {
+		std::cout << parquet_path << std::endl;
 		REQUIRE(RoundTrip(parquet_path, skip, conn));
 	}
 	skip.clear();
@@ -166,17 +178,13 @@ TEST_CASE("Test Parquet Files", "[arrow]") {
 		REQUIRE(RoundTrip(parquet_path, skip, conn));
 	}
 
-	skip.emplace_back("cache1.parquet"); //! FIXME: Contains binary columns, we don't support those yet
-
-	//! FIXME: Cache Files
 	parquet_files = fs.Glob("test/sql/copy/parquet/data/cache/*.parquet");
 	for (auto &parquet_path : parquet_files) {
 		REQUIRE(RoundTrip(parquet_path, skip, conn));
 	}
-	//! FIXME: GLOB Files (More binaries)
-	//	parquet_files = fs.Glob("test/sql/copy/parquet/data/glob/*.parquet");
-	//	for (auto &parquet_path : parquet_files) {
-	//	    std::cout << parquet_path <<  std::endl;
-	//        REQUIRE(RoundTrip(parquet_path,skip,conn));
-	//	}
+	parquet_files = fs.Glob("test/sql/copy/parquet/data/glob/*.parquet");
+	for (auto &parquet_path : parquet_files) {
+		std::cout << parquet_path << std::endl;
+		REQUIRE(RoundTrip(parquet_path, skip, conn));
+	}
 }

--- a/tools/pythonpkg/tests/arrow/test_binary_type.py
+++ b/tools/pythonpkg/tests/arrow/test_binary_type.py
@@ -1,0 +1,40 @@
+import duckdb
+import os
+import sys
+try:
+    import pyarrow as pa
+    from pyarrow import parquet as pq
+    import numpy as np
+    can_run = True
+except:
+    can_run = False
+
+def create_binary_table(type):
+    schema = pa.schema([("data", type)])
+    inputs = [pa.array([b"foo", b"bar", b"baz"], type=type)]
+    return pa.Table.from_arrays(inputs, schema=schema)
+
+class TestArrowBinary(object):
+    def test_binary_types(self,duckdb_cursor):
+        if not can_run:
+            return
+
+        # Fixed Size Binary
+        arrow_table = create_binary_table(pa.binary(3))
+        rel = duckdb.from_arrow_table(arrow_table)
+        res = rel.execute().fetchall()
+        assert res == [(b"foo",), (b"bar",), (b"baz",)]
+
+        # Normal Binary
+        arrow_table = create_binary_table(pa.binary())
+        rel = duckdb.from_arrow_table(arrow_table)
+        res = rel.execute().fetchall()
+        assert res == [(b"foo",), (b"bar",), (b"baz",)]
+
+        # Large Binary
+        arrow_table = create_binary_table(pa.large_binary())
+        rel = duckdb.from_arrow_table(arrow_table)
+        res = rel.execute().fetchall()
+        assert res == [(b"foo",), (b"bar",), (b"baz",)]
+
+    

--- a/tools/pythonpkg/tests/arrow/test_large_string.py
+++ b/tools/pythonpkg/tests/arrow/test_large_string.py
@@ -1,0 +1,24 @@
+import duckdb
+import os
+import sys
+try:
+    import pyarrow as pa
+    from pyarrow import parquet as pq
+    import numpy as np
+    can_run = True
+except:
+    can_run = False
+
+class TestArrowLargeString(object):
+    def test_large_string_type(self,duckdb_cursor):
+        if not can_run:
+
+            return
+        schema = pa.schema([("data", pa.large_string())])
+        inputs = [pa.array(["foo", "baaaar", "b"], type=pa.large_string())]
+        arrow_table = pa.Table.from_arrays(inputs, schema=schema)
+
+        rel = duckdb.from_arrow_table(arrow_table)
+        res = rel.execute().fetchall()
+        assert res == [('foo',), ('baaaar',), ('b',)]
+            


### PR DESCRIPTION
This PR implements the integration of arrow binary types to DuckDB's Blobs.

I've also enabled the parquet files with binary types for the tests.