### PR TITLE
Fix #1926: avoid double format in binder exception format

### DIFF
--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -123,8 +123,19 @@ public:
 
 	string FormatError(ParsedExpression &expr_context, const string &message);
 	string FormatError(TableRef &ref_context, const string &message);
-	string FormatError(idx_t query_location, const string &message);
 
+	string FormatErrorRecursive(idx_t query_location, const string &message, vector<ExceptionFormatValue> &values);
+	template <class T, typename... Args>
+	string FormatErrorRecursive(idx_t query_location, const string &msg, vector<ExceptionFormatValue> &values, T param, Args... params) {
+		values.push_back(ExceptionFormatValue::CreateFormatValue<T>(param));
+		return FormatErrorRecursive(query_location, msg, values, params...);
+	}
+
+	template <typename... Args>
+	string FormatError(idx_t query_location, const string &msg, Args... params) {
+		vector<ExceptionFormatValue> values;
+		return FormatErrorRecursive(query_location, msg, values, params...);
+	}
 private:
 	//! The parent binder (if any)
 	shared_ptr<Binder> parent;

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -126,7 +126,8 @@ public:
 
 	string FormatErrorRecursive(idx_t query_location, const string &message, vector<ExceptionFormatValue> &values);
 	template <class T, typename... Args>
-	string FormatErrorRecursive(idx_t query_location, const string &msg, vector<ExceptionFormatValue> &values, T param, Args... params) {
+	string FormatErrorRecursive(idx_t query_location, const string &msg, vector<ExceptionFormatValue> &values, T param,
+	                            Args... params) {
 		values.push_back(ExceptionFormatValue::CreateFormatValue<T>(param));
 		return FormatErrorRecursive(query_location, msg, values, params...);
 	}
@@ -136,6 +137,7 @@ public:
 		vector<ExceptionFormatValue> values;
 		return FormatErrorRecursive(query_location, msg, values, params...);
 	}
+
 private:
 	//! The parent binder (if any)
 	shared_ptr<Binder> parent;

--- a/src/parser/query_error_context.cpp
+++ b/src/parser/query_error_context.cpp
@@ -110,7 +110,7 @@ string QueryErrorContext::Format(const string &query, const string &error_messag
 }
 
 string QueryErrorContext::FormatErrorRecursive(const string &msg, vector<ExceptionFormatValue> &values) {
-	string error_message = ExceptionFormatValue::Format(msg, values);
+	string error_message = values.empty() ? msg : ExceptionFormatValue::Format(msg, values);
 	if (!statement || query_location >= statement->query.size()) {
 		// no statement provided or query location out of range
 		return error_message;

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -286,9 +286,9 @@ string Binder::FormatError(TableRef &ref_context, const string &message) {
 	return FormatError(ref_context.query_location, message);
 }
 
-string Binder::FormatError(idx_t query_location, const string &message) {
+string Binder::FormatErrorRecursive(idx_t query_location, const string &message, vector<ExceptionFormatValue> &values) {
 	QueryErrorContext context(root_statement, query_location);
-	return context.FormatError(message);
+	return context.FormatErrorRecursive(message, values);
 }
 
 } // namespace duckdb

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -41,8 +41,7 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref, idx_t d
 			auto similar_bindings = binder.bind_context.GetSimilarBindings(colref.column_name);
 			string candidate_str = StringUtil::CandidatesMessage(similar_bindings, "Candidate bindings");
 			return BindResult(
-			    binder.FormatError(colref, StringUtil::Format("Referenced column \"%s\" not found in FROM clause!%s",
-			                                                  colref.column_name.c_str(), candidate_str)));
+			    binder.FormatError(colref.query_location, "Referenced column \"%s\" not found in FROM clause!%s", colref.column_name.c_str(), candidate_str));
 		}
 	}
 	// if it was a macro parameter, let macro_binding bind it to the argument

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -40,8 +40,9 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref, idx_t d
 		if (colref.table_name.empty()) {
 			auto similar_bindings = binder.bind_context.GetSimilarBindings(colref.column_name);
 			string candidate_str = StringUtil::CandidatesMessage(similar_bindings, "Candidate bindings");
-			return BindResult(
-			    binder.FormatError(colref.query_location, "Referenced column \"%s\" not found in FROM clause!%s", colref.column_name.c_str(), candidate_str));
+			return BindResult(binder.FormatError(colref.query_location,
+			                                     "Referenced column \"%s\" not found in FROM clause!%s",
+			                                     colref.column_name.c_str(), candidate_str));
 		}
 	}
 	// if it was a macro parameter, let macro_binding bind it to the argument

--- a/test/sql/error/escape_percent_sign.test
+++ b/test/sql/error/escape_percent_sign.test
@@ -1,0 +1,10 @@
+# name: test/sql/error/escape_percent_sign.test
+# description: Issue 1926: Exception messages need to escape percent signs
+# group: [error]
+
+statement ok
+CREATE VIEW list_int AS
+SELECT case when i%2 <> 0 then [1] else NULL end FROM range(10000) tbl(i);
+
+statement error
+select count(*) from list_int where l is distinct from NULL;


### PR DESCRIPTION
The problem here was that the format was called twice. The first would insert the column names in the string, and the second would (generally) not do anything, except if the column name had a percentage sign in it.

This is now fixed so that the double format is not called anymore. In addition, we don't format errors anymore when there are no input arguments.