### PR TITLE
Expand example of using external execution engine, add flags to disable optimizers and to disable default function registration

### DIFF
--- a/examples/standalone-plan/main.cpp
+++ b/examples/standalone-plan/main.cpp
@@ -16,6 +16,11 @@
 #include "duckdb/function/function_set.hpp"
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+#include "duckdb/parser/tableref/table_function_ref.hpp"
+#include "duckdb/parser/expression/constant_expression.hpp"
+#include "duckdb/parser/expression/function_expression.hpp"
+#include "duckdb/storage/statistics/numeric_statistics.hpp"
 #endif
 
 using namespace duckdb;
@@ -24,33 +29,17 @@ using namespace duckdb;
 // for simplicity, the executor only handles integer values and doesn't handle null values
 
 void ExecuteQuery(Connection &con, const string &query);
+void CreateFunction(Connection &con, string name, vector<LogicalType> arguments, LogicalType return_type);
+void CreateAggregateFunction(Connection &con, string name, vector<LogicalType> arguments, LogicalType return_type);
 
-void CreateFunction(Connection &con, string name, vector<LogicalType> arguments, LogicalType return_type) {
-	auto &context = *con.context;
-	auto &catalog = Catalog::GetCatalog(context);
+//===--------------------------------------------------------------------===//
+// Example Using DuckDB Catalog/Tables
+//===--------------------------------------------------------------------===//
+void RunExampleDuckDBCatalog() {
+	// in this example we use the DuckDB CREATE TABLE syntax to create tables to link against
+	// this works and the tables are easy to define, but since the tables are empty there are no statistics available
+	// we can use our own table functions (see RunExampleTableScan), but this is slightly more involved
 
-	// we can register multiple functions here if we want overloads
-	// you may also want to set has_side_effects or varargs in the ScalarFunction (if required)
-	ScalarFunctionSet set(name);
-	set.AddFunction(ScalarFunction(move(arguments), move(return_type), nullptr));
-
-	CreateScalarFunctionInfo info(move(set));
-	catalog.CreateFunction(context, &info);
-}
-
-void CreateAggregateFunction(Connection &con, string name, vector<LogicalType> arguments, LogicalType return_type) {
-	auto &context = *con.context;
-	auto &catalog = Catalog::GetCatalog(context);
-
-	// we can register multiple functions here if we want overloads
-	AggregateFunctionSet set(name);
-	set.AddFunction(AggregateFunction(move(arguments), move(return_type), nullptr, nullptr, nullptr, nullptr, nullptr));
-
-	CreateAggregateFunctionInfo info(move(set));
-	catalog.CreateFunction(context, &info);
-}
-
-int main() {
 	DBConfig config;
 	config.initialize_default_database = false;
 
@@ -104,6 +93,178 @@ int main() {
 	             "SELECT a, b + 1, c + 2 FROM (SELECT COUNT(*), SUM(i), SUM(j) FROM mytable WHERE i > 2) tbl(a, b, c)");
 }
 
+//===--------------------------------------------------------------------===//
+// Example Using Custom Scan Function
+//===--------------------------------------------------------------------===//
+void CreateMyScanFunction(Connection &con);
+
+unique_ptr<TableFunctionRef> MyReplacementScan(const string &table_name, void *data) {
+	auto table_function = make_unique<TableFunctionRef>();
+	vector<unique_ptr<ParsedExpression>> children;
+	children.push_back(make_unique<ConstantExpression>(Value(table_name)));
+	table_function->function = make_unique<FunctionExpression>("my_scan", move(children));
+	return table_function;
+}
+
+void RunExampleTableScan() {
+	// in this example we use our own TableFunction instead of the built-in "seq_scan"
+	// this allows us to emit our own statistics without needing to insert them into the DuckDB tables
+	// it also allows us to define ourselves what we do/do not support
+	// (e.g. we can disable projection or filter pushdown in the table function if desired)
+	// this means we don't need to disable optimizers anymore
+
+	DBConfig config;
+	config.initialize_default_database = false;
+	config.replacement_scans.push_back(ReplacementScan(MyReplacementScan));
+
+	DuckDB db(nullptr, &config);
+	Connection con(db);
+
+	// we perform an explicit BEGIN TRANSACTION here
+	// since "CreateFunction" will directly poke around in the catalog
+	// which requires an active transaction
+	con.Query("BEGIN TRANSACTION");
+
+	// register functions and aggregates (for our binding purposes)
+	CreateFunction(con, "+", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER);
+	CreateAggregateFunction(con, "count_star", {}, LogicalType::BIGINT);
+	CreateAggregateFunction(con, "sum", {LogicalType::INTEGER}, LogicalType::INTEGER);
+
+	CreateMyScanFunction(con);
+
+	con.Query("COMMIT");
+
+	// standard projections
+	ExecuteQuery(con, "SELECT * FROM mytable");
+	ExecuteQuery(con, "SELECT i FROM mytable");
+	ExecuteQuery(con, "SELECT j FROM mytable");
+	ExecuteQuery(con, "SELECT k FROM myothertable");
+	// some simple filter + projection
+	ExecuteQuery(con, "SELECT i+1 FROM mytable WHERE i=3 OR i=4");
+	// more complex filters
+	ExecuteQuery(con, "SELECT i+1 FROM mytable WHERE (i<=2 AND j<=3) OR (i=4 AND j=5)");
+	// aggregate
+	ExecuteQuery(con, "SELECT COUNT(*), SUM(i) + 1, SUM(j) + 2 FROM mytable WHERE i>2");
+	// with a subquery
+	ExecuteQuery(con,
+	             "SELECT a, b + 1, c + 2 FROM (SELECT COUNT(*), SUM(i), SUM(j) FROM mytable WHERE i > 2) tbl(a, b, c)");
+}
+
+int main() {
+	RunExampleDuckDBCatalog();
+	RunExampleTableScan();
+}
+
+//===--------------------------------------------------------------------===//
+// Create Dummy Scalar/Aggregate Functions in the Catalog
+//===--------------------------------------------------------------------===//
+void CreateFunction(Connection &con, string name, vector<LogicalType> arguments, LogicalType return_type) {
+	auto &context = *con.context;
+	auto &catalog = Catalog::GetCatalog(context);
+
+	// we can register multiple functions here if we want overloads
+	// you may also want to set has_side_effects or varargs in the ScalarFunction (if required)
+	ScalarFunctionSet set(name);
+	set.AddFunction(ScalarFunction(move(arguments), move(return_type), nullptr));
+
+	CreateScalarFunctionInfo info(move(set));
+	catalog.CreateFunction(context, &info);
+}
+
+void CreateAggregateFunction(Connection &con, string name, vector<LogicalType> arguments, LogicalType return_type) {
+	auto &context = *con.context;
+	auto &catalog = Catalog::GetCatalog(context);
+
+	// we can register multiple functions here if we want overloads
+	AggregateFunctionSet set(name);
+	set.AddFunction(AggregateFunction(move(arguments), move(return_type), nullptr, nullptr, nullptr, nullptr, nullptr));
+
+	CreateAggregateFunctionInfo info(move(set));
+	catalog.CreateFunction(context, &info);
+}
+
+//===--------------------------------------------------------------------===//
+// Custom Table Scan Function
+//===--------------------------------------------------------------------===//
+struct MyBindData : public FunctionData {
+	MyBindData(string name_p) : table_name(move(name_p)) {}
+
+	string table_name;
+};
+
+// contents of the tables
+// mytable:
+// i: 1, 2, 3, 4, 5
+// j: 2, 3, 4, 5, 6
+// myothertable
+// k: 1, 10, 20
+// (see MyScanNode)
+static unique_ptr<FunctionData> MyScanBind(ClientContext &context, vector<Value> &inputs,
+                                           unordered_map<string, Value> &named_parameters,
+                                           vector<LogicalType> &input_table_types,
+                                           vector<string> &input_table_names, vector<LogicalType> &return_types,
+                                           vector<string> &names) {
+	auto table_name = inputs[0].ToString();
+	if (table_name == "mytable") {
+		names.emplace_back("i");
+		return_types.push_back(LogicalType::INTEGER);
+
+		names.emplace_back("j");
+		return_types.push_back(LogicalType::INTEGER);
+	} else if (table_name == "myothertable") {
+		names.emplace_back("k");
+		return_types.push_back(LogicalType::INTEGER);
+	} else {
+		throw std::runtime_error("Unknown table " + table_name);
+	}
+	auto result = make_unique<MyBindData>(table_name);
+	return move(result);
+}
+
+static unique_ptr<BaseStatistics> MyScanStatistics(ClientContext &context, const FunctionData *bind_data_p,
+                                                      column_t column_id) {
+	auto &bind_data = (MyBindData &) *bind_data_p;
+	if (bind_data.table_name == "mytable") {
+		if (column_id == 0) {
+			// i: 1, 2, 3, 4, 5
+			return make_unique<NumericStatistics>(LogicalType::INTEGER, Value::INTEGER(1), Value::INTEGER(5));
+		} else if (column_id == 1) {
+			// j: 2, 3, 4, 5, 6
+			return make_unique<NumericStatistics>(LogicalType::INTEGER, Value::INTEGER(2), Value::INTEGER(6));
+		}
+	} else if (bind_data.table_name == "myothertable") {
+		// k: 1, 10, 20
+		return make_unique<NumericStatistics>(LogicalType::INTEGER, Value::INTEGER(1), Value::INTEGER(20));
+	}
+	return nullptr;
+}
+
+unique_ptr<NodeStatistics> MyScanCardinality(ClientContext &context, const FunctionData *bind_data_p) {
+	auto &bind_data = (MyBindData &) *bind_data_p;
+	if (bind_data.table_name == "mytable") {
+		// 5 tuples
+		return make_unique<NodeStatistics>(5, 5);
+	} else if (bind_data.table_name == "myothertable") {
+		return make_unique<NodeStatistics>(3, 3);
+	}
+	return nullptr;
+}
+
+void CreateMyScanFunction(Connection &con) {
+	auto &context = *con.context;
+	auto &catalog = Catalog::GetCatalog(context);
+
+	TableFunction my_scan("my_scan", {LogicalType::VARCHAR}, nullptr, MyScanBind, nullptr, MyScanStatistics, nullptr, nullptr, MyScanCardinality);
+	my_scan.projection_pushdown = true;
+	my_scan.filter_pushdown = false;
+
+	CreateTableFunctionInfo info(move(my_scan));
+	catalog.CreateTableFunction(context, &info);
+}
+
+//===--------------------------------------------------------------------===//
+// Example Execution Engine: Row-based volcano style that only supports int32
+//===--------------------------------------------------------------------===//
 class MyNode {
 public:
 	virtual ~MyNode() {
@@ -121,7 +282,7 @@ public:
 void ExecuteQuery(Connection &con, const string &query) {
 	// create the logical plan
 	auto plan = con.ExtractPlan(query);
-	// plan->Print();
+	plan->Print();
 
 	// transform the logical plan into our own plan
 	MyPlanGenerator generator;
@@ -148,7 +309,9 @@ void ExecuteQuery(Connection &con, const string &query) {
 	printf("----------------------\n");
 }
 
-// table scan node
+//===--------------------------------------------------------------------===//
+// Table Scan Node
+//===--------------------------------------------------------------------===//
 class MyScanNode : public MyNode {
 public:
 	MyScanNode(string name_p, vector<column_t> column_ids_p) : name(move(name_p)), column_ids(move(column_ids_p)) {
@@ -185,6 +348,12 @@ public:
 	};
 };
 
+//===--------------------------------------------------------------------===//
+// Expression Execution
+//===--------------------------------------------------------------------===//
+
+// note that we run expression execution directly on top of DuckDB expressions
+// it is also possible to transform the expressions into our own expressions (MyExpression)
 class MyExpressionExecutor {
 public:
 	MyExpressionExecutor(vector<int> current_row_p) : current_row(move(current_row_p)) {
@@ -203,6 +372,9 @@ protected:
 	int Execute(BoundFunctionExpression &expr);
 };
 
+//===--------------------------------------------------------------------===//
+// Filter
+//===--------------------------------------------------------------------===//
 class MyFilterNode : public MyNode {
 public:
 	MyFilterNode(unique_ptr<Expression> filter_node) : filter(move(filter_node)) {
@@ -232,6 +404,9 @@ public:
 	};
 };
 
+//===--------------------------------------------------------------------===//
+// Projection
+//===--------------------------------------------------------------------===//
 class MyProjectionNode : public MyNode {
 public:
 	MyProjectionNode(vector<unique_ptr<Expression>> projections_p) : projections(move(projections_p)) {
@@ -253,6 +428,9 @@ public:
 	};
 };
 
+//===--------------------------------------------------------------------===//
+// Aggregate
+//===--------------------------------------------------------------------===//
 class MyAggregateNode : public MyNode {
 public:
 	MyAggregateNode(vector<unique_ptr<Expression>> aggregates_p) : aggregates(move(aggregates_p)) {
@@ -292,6 +470,9 @@ public:
 	};
 };
 
+//===--------------------------------------------------------------------===//
+// Plan Transformer - Transform a DuckDB logical plan into a custom plan (MyNode)
+//===--------------------------------------------------------------------===//
 unique_ptr<MyNode> MyPlanGenerator::TransformPlan(LogicalOperator &op) {
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_PROJECTION: {
@@ -321,33 +502,40 @@ unique_ptr<MyNode> MyPlanGenerator::TransformPlan(LogicalOperator &op) {
 	case LogicalOperatorType::LOGICAL_GET: {
 		auto &get = (LogicalGet &)op;
 		// table scan or table function
-		// note that table selections (e.g. SELECT FROM tbl) are transformed into table functions (seq_scan or
-		// index_scan)
-		if (get.function.name != "seq_scan") {
-			throw std::runtime_error("Unsupported table function");
-		}
+
 		// get nodes have two properties: table_filters (filter pushdown) and column_ids (projection pushdown)
 		// table_filters are only generated if optimizers are enabled (through the filter pushdown optimizer)
 		// column_ids are always generated
 		// the column_ids specify which columns should be emitted and in which order
 		// e.g. if we have a table "i, j, k" and the column_ids are {0, 2} we should emit ONLY "i, k" and in that order
-		auto &table = (TableScanBindData &)*get.bind_data;
-		if (!get.table_filters.filters.empty()) {
-			// note: filter pushdown will only be triggered if optimizers are enabled
-			throw std::runtime_error("Filter pushdown unsupported");
+		if (get.function.name == "seq_scan") {
+			// built-in table scan
+			auto &table = (TableScanBindData &)*get.bind_data;
+			if (!get.table_filters.filters.empty()) {
+				// note: filter pushdown will only be triggered if optimizers are enabled
+				throw std::runtime_error("Filter pushdown unsupported");
+			}
+			return make_unique<MyScanNode>(table.table->name, get.column_ids);
+		} else if (get.function.name == "my_scan") {
+			// our own scan
+			auto &my_bind_data = (MyBindData &) *get.bind_data;
+			return make_unique<MyScanNode>(my_bind_data.table_name, get.column_ids);
+		} else {
+			throw std::runtime_error("Unsupported table function");
 		}
-		return make_unique<MyScanNode>(table.table->name, get.column_ids);
 	}
 	default:
 		throw std::runtime_error("Unsupported logical operator for transformation");
 	}
 }
 
+//===--------------------------------------------------------------------===//
+// Expression Execution for various built-in expressions
+//===--------------------------------------------------------------------===//
 int MyExpressionExecutor::Execute(BoundReferenceExpression &expr) {
 	// column references (e.g. "SELECT a FROM tbl") are turned into BoundReferences
 	// these refer to an index within the row they come from
 	// because of that it is important to correctly handle the get.column_ids
-	//
 	return current_row[expr.index];
 }
 
@@ -406,6 +594,9 @@ int MyExpressionExecutor::Execute(BoundComparisonExpression &expr) {
 	return cmp ? 1 : 0;
 }
 
+//===--------------------------------------------------------------------===//
+// Expression Execution for built-in functions
+//===--------------------------------------------------------------------===//
 int MyExpressionExecutor::Execute(BoundFunctionExpression &expr) {
 	if (expr.function.name == "+") {
 		auto lchild = Execute(*expr.children[0]);

--- a/src/common/enums/CMakeLists.txt
+++ b/src/common/enums/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library_unity(
   expression_type.cpp
   join_type.cpp
   logical_operator_type.cpp
+  optimizer_type.cpp
   physical_operator_type.cpp
   statement_type.cpp
   relation_type.cpp)

--- a/src/common/enums/optimizer_type.cpp
+++ b/src/common/enums/optimizer_type.cpp
@@ -5,7 +5,7 @@
 namespace duckdb {
 
 string OptimizerTypeToString(OptimizerType type) {
-	switch(type) {
+	switch (type) {
 	case OptimizerType::EXPRESSION_REWRITER:
 		return "expression_rewriter";
 	case OptimizerType::FILTER_PULLUP:
@@ -40,4 +40,4 @@ string OptimizerTypeToString(OptimizerType type) {
 	return "INVALID";
 }
 
-}
+} // namespace duckdb

--- a/src/common/enums/optimizer_type.cpp
+++ b/src/common/enums/optimizer_type.cpp
@@ -1,0 +1,43 @@
+#include "duckdb/common/enums/optimizer_type.hpp"
+
+#include "duckdb/common/exception.hpp"
+
+namespace duckdb {
+
+string OptimizerTypeToString(OptimizerType type) {
+	switch(type) {
+	case OptimizerType::EXPRESSION_REWRITER:
+		return "expression_rewriter";
+	case OptimizerType::FILTER_PULLUP:
+		return "filter_pullup";
+	case OptimizerType::FILTER_PUSHDOWN:
+		return "filter_pushdown";
+	case OptimizerType::REGEX_RANGE:
+		return "regex_range";
+	case OptimizerType::IN_CLAUSE:
+		return "in_clause";
+	case OptimizerType::JOIN_ORDER:
+		return "join_order";
+	case OptimizerType::DELIMINATOR:
+		return "deliminator";
+	case OptimizerType::UNUSED_COLUMNS:
+		return "unused_columns";
+	case OptimizerType::STATISTICS_PROPAGATION:
+		return "statistics_propagation";
+	case OptimizerType::COMMON_SUBEXPRESSIONS:
+		return "common_subexpressions";
+	case OptimizerType::COMMON_AGGREGATE:
+		return "common_aggregate";
+	case OptimizerType::COLUMN_LIFETIME:
+		return "column_lifetime";
+	case OptimizerType::TOP_N:
+		return "top_n";
+	case OptimizerType::REORDER_FILTER:
+		return "reorder_filter";
+	case OptimizerType::INVALID:
+		break;
+	}
+	return "INVALID";
+}
+
+}

--- a/src/include/duckdb/common/enums/optimizer_type.hpp
+++ b/src/include/duckdb/common/enums/optimizer_type.hpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/optimizer_type.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+
+enum class OptimizerType : uint32_t {
+	INVALID = 0,
+	EXPRESSION_REWRITER,
+	FILTER_PULLUP,
+	FILTER_PUSHDOWN,
+	REGEX_RANGE,
+	IN_CLAUSE,
+	JOIN_ORDER,
+	DELIMINATOR,
+	UNUSED_COLUMNS,
+	STATISTICS_PROPAGATION,
+	COMMON_SUBEXPRESSIONS,
+	COMMON_AGGREGATE,
+	COLUMN_LIFETIME,
+	TOP_N,
+	REORDER_FILTER
+};
+
+string OptimizerTypeToString(OptimizerType type);
+
+} // namespace duckdb

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -16,6 +16,8 @@
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/function/replacement_scan.hpp"
+#include "duckdb/common/set.hpp"
+#include "duckdb/common/enums/optimizer_type.hpp"
 
 namespace duckdb {
 class ClientContext;
@@ -89,6 +91,11 @@ public:
 	CheckpointAbort checkpoint_abort = CheckpointAbort::NO_ABORT;
 	//! Replacement table scans are automatically attempted when a table name cannot be found in the schema
 	vector<ReplacementScan> replacement_scans;
+	//! Initialize the database with the standard set of DuckDB functions
+	//! You should probably not touch this unless you know what you are doing
+	bool initialize_default_database = true;
+	//! The set of disabled optimizers (default empty)
+	set<OptimizerType> disabled_optimizers;
 
 public:
 	DUCKDB_API static DBConfig &GetConfig(ClientContext &context);

--- a/src/include/duckdb/optimizer/optimizer.hpp
+++ b/src/include/duckdb/optimizer/optimizer.hpp
@@ -29,7 +29,7 @@ public:
 	ExpressionRewriter rewriter;
 
 private:
-	void RunOptimizer(OptimizerType type, std::function<void()> callback);
+	void RunOptimizer(OptimizerType type, const std::function<void()> &callback);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/optimizer/optimizer.hpp
+++ b/src/include/duckdb/optimizer/optimizer.hpp
@@ -11,6 +11,9 @@
 #include "duckdb/optimizer/expression_rewriter.hpp"
 #include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/planner/logical_operator_visitor.hpp"
+#include "duckdb/common/enums/optimizer_type.hpp"
+
+#include <functional>
 
 namespace duckdb {
 class Binder;
@@ -24,6 +27,9 @@ public:
 	ClientContext &context;
 	Binder &binder;
 	ExpressionRewriter rewriter;
+
+private:
+	void RunOptimizer(OptimizerType type, std::function<void()> callback);
 };
 
 } // namespace duckdb

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -208,6 +208,8 @@ void DatabaseInstance::Configure(DBConfig &new_config) {
 	config.default_null_order = new_config.default_null_order;
 	config.enable_external_access = new_config.enable_external_access;
 	config.replacement_scans = move(new_config.replacement_scans);
+	config.initialize_default_database = new_config.initialize_default_database;
+	config.disabled_optimizers = move(new_config.disabled_optimizers);
 }
 
 DBConfig &DBConfig::GetConfig(ClientContext &context) {

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -58,9 +58,7 @@ void Optimizer::RunOptimizer(OptimizerType type, std::function<void()> callback)
 unique_ptr<LogicalOperator> Optimizer::Optimize(unique_ptr<LogicalOperator> plan) {
 	// first we perform expression rewrites using the ExpressionRewriter
 	// this does not change the logical plan structure, but only simplifies the expression trees
-	RunOptimizer(OptimizerType::EXPRESSION_REWRITER, [&]() {
-		rewriter.VisitOperator(*plan);
-	});
+	RunOptimizer(OptimizerType::EXPRESSION_REWRITER, [&]() { rewriter.VisitOperator(*plan); });
 
 	// perform filter pullup
 	RunOptimizer(OptimizerType::FILTER_PULLUP, [&]() {

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -44,7 +44,7 @@ Optimizer::Optimizer(Binder &binder, ClientContext &context) : context(context),
 #endif
 }
 
-void Optimizer::RunOptimizer(OptimizerType type, std::function<void()> callback) {
+void Optimizer::RunOptimizer(OptimizerType type, const std::function<void()> &callback) {
 	auto &config = DBConfig::GetConfig(context);
 	if (config.disabled_optimizers.find(type) != config.disabled_optimizers.end()) {
 		// optimizer is marked as disabled: skip


### PR DESCRIPTION
This PR adds two new flags to the db config:

```cpp
// Initialize the database with the standard set of DuckDB functions
bool initialize_default_database = true;
// The set of disabled optimizers (default empty)
set<OptimizerType> disabled_optimizers;
```

This allows you to disable any of the system optimizers, and disable registration of the default set of functions in DuckDB.

The purpose of this is to extend upon #1897 and allow the user to register their own functions in addition to their own tables. The example of this is also extended to perform registration of built-in functions. Small (shortened) code snippet below, full example is in `main.cpp`:

```cpp
DBConfig config;
config.initialize_default_database = false;

config.disabled_optimizers.insert(OptimizerType::STATISTICS_PROPAGATION);
config.disabled_optimizers.insert(OptimizerType::FILTER_PUSHDOWN);

DuckDB db(nullptr, &config);
Connection con(db);

con.Query("BEGIN TRANSACTION");

con.Query("CREATE TABLE mytable(i INTEGER, j INTEGER)");
con.Query("CREATE TABLE myothertable(k INTEGER)");

CreateFunction(con, "+", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER);
CreateAggregateFunction(con, "count_star", {}, LogicalType::BIGINT);
CreateAggregateFunction(con, "sum", {LogicalType::INTEGER}, LogicalType::INTEGER);

con.Query("COMMIT");
```

### Column & Table Statistics
By using the regular DuckDB tables (e.g. `CREATE TABLE mytable(i INTEGER, j INTEGER)`) we don't have any statistics (since the table is empty). This forces us to disable the statistics propagation optimizer and limits usage of the join order optimizer. By defining our own table function instead of using the DuckDB table function `seq_scan` we can provide statistics to the system, example shown below with extended example integrated into the code:

```cpp
// contents of the tables
// mytable:
// i: 1, 2, 3, 4, 5
// j: 2, 3, 4, 5, 6
// myothertable
// k: 1, 10, 20
// (see MyScanNode)

static unique_ptr<BaseStatistics> MyScanStatistics(ClientContext &context, const FunctionData *bind_data_p,
                                                      column_t column_id) {
	auto &bind_data = (MyBindData &) *bind_data_p;
	if (bind_data.table_name == "mytable") {
		if (column_id == 0) {
			// i: 1, 2, 3, 4, 5
			return make_unique<NumericStatistics>(LogicalType::INTEGER, Value::INTEGER(1), Value::INTEGER(5));
		} else if (column_id == 1) {
			// j: 2, 3, 4, 5, 6
			return make_unique<NumericStatistics>(LogicalType::INTEGER, Value::INTEGER(2), Value::INTEGER(6));
		}
	} else if (bind_data.table_name == "myothertable") {
		// k: 1, 10, 20
		return make_unique<NumericStatistics>(LogicalType::INTEGER, Value::INTEGER(1), Value::INTEGER(20));
	}
	return nullptr;
}

unique_ptr<NodeStatistics> MyScanCardinality(ClientContext &context, const FunctionData *bind_data_p) {
	auto &bind_data = (MyBindData &) *bind_data_p;
	if (bind_data.table_name == "mytable") {
		// 5 tuples
		return make_unique<NodeStatistics>(5, 5);
	} else if (bind_data.table_name == "myothertable") {
		return make_unique<NodeStatistics>(3, 3);
	}
	return nullptr;
}

```

