### PR TITLE
Use Arrow's newly exported method for getting a C export

### DIFF
--- a/tools/rpkg/R/register.R
+++ b/tools/rpkg/R/register.R
@@ -54,7 +54,7 @@ duckdb_register_arrow <- function(conn, name, arrow_scannable) {
     # create some R functions to pass to c-land
     export_fun <- function(arrow_scannable, stream_ptr) {
         record_batch_reader <- arrow::Scanner$create(arrow_scannable)$ToRecordBatchReader()
-        utils::getFromNamespace("ExportRecordBatchReader", "arrow")(record_batch_reader, stream_ptr)
+        record_batch_reader$export_to_c(stream_ptr)
     }
   .Call(duckdb_register_arrow_R, conn@conn_ref, as.character(name), export_fun, arrow_scannable)
   invisible(TRUE)


### PR DESCRIPTION
This is functionally the exact same thing as before, just without the `utils:: getFromNamespace` call.