### PR TITLE
Pragma view_tables for arrow

### DIFF
--- a/src/catalog/catalog_entry/view_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/view_catalog_entry.cpp
@@ -81,8 +81,8 @@ unique_ptr<CreateViewInfo> ViewCatalogEntry::Deserialize(Deserializer &source) {
 
 string ViewCatalogEntry::ToSQL() {
 	if (sql.empty()) {
-		//! Create dummy sql with view name so pragma view_tables don't complain
-		return "create view " + name + "as select * from tbl";
+		//! Return empty sql with view name so pragma view_tables don't complain
+		return sql;
 	}
 	return sql + "\n;";
 }

--- a/src/catalog/catalog_entry/view_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/view_catalog_entry.cpp
@@ -81,7 +81,8 @@ unique_ptr<CreateViewInfo> ViewCatalogEntry::Deserialize(Deserializer &source) {
 
 string ViewCatalogEntry::ToSQL() {
 	if (sql.empty()) {
-		throw NotImplementedException("Cannot convert VIEW to SQL because it was not created with a SQL statement");
+		//! Create dummy sql with view name so pragma view_tables don't complain
+		return "create view " + name + "as select * from tbl";
 	}
 	return sql + "\n;";
 }

--- a/tools/pythonpkg/tests/arrow/test_view.py
+++ b/tools/pythonpkg/tests/arrow/test_view.py
@@ -1,0 +1,22 @@
+import duckdb
+import os
+import sys
+try:
+    import pyarrow
+    import pyarrow.parquet
+    can_run = True
+except:
+    can_run = False
+
+class TestArrowView(object):
+    def test_arrow_view(self, duckdb_cursor):
+        if not can_run:
+            return
+        parquet_filename = os.path.join(os.path.dirname(os.path.realpath(__file__)),'data','userdata1.parquet')
+        cols = 'id, first_name, last_name, email, gender, ip_address, cc, country, birthdate, salary, title, comments'
+        duckdb_conn = duckdb.connect()
+        userdata_parquet_table = pyarrow.parquet.read_table(parquet_filename)
+        userdata_parquet_table.validate(full=True)
+        duckdb_conn.from_arrow_table(userdata_parquet_table).create_view('arrow_view')
+        assert (duckdb_conn.execute("PRAGMA show_tables").fetchone() == ('arrow_view',))
+        assert(duckdb_conn.execute("select avg(salary)::INT from arrow_view").fetchone()[0] == 149005)


### PR DESCRIPTION
This should fix #1189 

Basically, I'm introducing a dummy SQL in the ToSQL from the view catalog to expose the table name.
Would that conflict with anything else?