### PR TITLE
Update url of remote parquet tests

### DIFF
--- a/test/sql/copy/parquet/test_parquet_remote.test
+++ b/test/sql/copy/parquet/test_parquet_remote.test
@@ -25,7 +25,7 @@ SELECT * FROM PARQUET_SCAN('https://duckdb.org/');
 
 # straightforward
 query IIII
-SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://raw.githubusercontent.com/cwida/duckdb/master/test/sql/copy/parquet/data/userdata1.parquet') LIMIT 10;
+SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://raw.githubusercontent.com/cwida/duckdb/master/data/parquet-testing/userdata1.parquet') LIMIT 10;
 ----
 1	Amanda	Jordan	ajordan0@com.com
 2	Albert	Freeman	afreeman1@is.gd
@@ -41,7 +41,7 @@ SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://raw.githubuse
 
 # with redirects
 query IIII
-SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://github.com/cwida/duckdb/blob/master/test/sql/copy/parquet/data/userdata1.parquet?raw=true') LIMIT 10;
+SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://github.com/cwida/duckdb/blob/master/data/parquet-testing/userdata1.parquet?raw=true') LIMIT 10;
 ----
 1	Amanda	Jordan	ajordan0@com.com
 2	Albert	Freeman	afreeman1@is.gd
@@ -56,7 +56,7 @@ SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://github.com/cw
 
 # with explicit port nr
 query IIII
-SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://github.com:443/cwida/duckdb/blob/master/test/sql/copy/parquet/data/userdata1.parquet?raw=true') LIMIT 10;
+SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://github.com:443/cwida/duckdb/blob/master/data/parquet-testing/userdata1.parquet?raw=true') LIMIT 10;
 ----
 1	Amanda	Jordan	ajordan0@com.com
 2	Albert	Freeman	afreeman1@is.gd


### PR DESCRIPTION
Remote parquet tests are breaking due to the move of parquet files to another folder.