### PR TITLE
Return None from description property if there is no open result set

### DIFF
--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -323,7 +323,7 @@ DuckDBPyConnection *DuckDBPyConnection::Rollback() {
 py::object DuckDBPyConnection::GetAttr(const py::str &key) {
 	if (key.cast<string>() == "description") {
 		if (!result) {
-			throw std::runtime_error("no open result set");
+			return py::none();
 		}
 		return result->Description();
 	}

--- a/tools/pythonpkg/tests/api/test_dbapi10.py
+++ b/tools/pythonpkg/tests/api/test_dbapi10.py
@@ -4,3 +4,6 @@ class TestCursorDescription(object):
     def test_description(self, duckdb_cursor):
         description = duckdb_cursor.execute("SELECT * FROM integers").description
         assert description == [('i', None, None, None, None, None, None)]
+
+    def test_none_description(self, duckdb_cursor):
+        assert duckdb_cursor.description is None

--- a/tools/pythonpkg/tests/api/test_dbapi10.py
+++ b/tools/pythonpkg/tests/api/test_dbapi10.py
@@ -5,5 +5,5 @@ class TestCursorDescription(object):
         description = duckdb_cursor.execute("SELECT * FROM integers").description
         assert description == [('i', None, None, None, None, None, None)]
 
-    def test_none_description(self, duckdb_cursor):
-        assert duckdb_cursor.description is None
+    def test_none_description(self, duckdb_empty_cursor):
+        assert duckdb_empty_cursor.description is None

--- a/tools/pythonpkg/tests/conftest.py
+++ b/tools/pythonpkg/tests/conftest.py
@@ -7,11 +7,10 @@ import duckdb
 
 @pytest.fixture(scope="function")
 def duckdb_empty_cursor(request):
-    test_dbfarm = tmp_path.resolve().as_posix()
-
     connection = duckdb.connect('')
     cursor = connection.cursor()
     return cursor
+
 
 @pytest.fixture(scope="function")
 def duckdb_cursor(request):


### PR DESCRIPTION
This is per the db api 2.0 specification: https://www.python.org/dev/peps/pep-0249/#description