### PR TITLE
Make dbListTables also list views

### DIFF
--- a/tools/rpkg/R/Connection.R
+++ b/tools/rpkg/R/Connection.R
@@ -222,7 +222,7 @@ setMethod(
     dbGetQuery(
       conn,
       SQL(
-        "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        "SELECT name FROM sqlite_master WHERE type='table' OR type='view' ORDER BY name"
       )
     )[[1]]
   }


### PR DESCRIPTION
This change makes the`dbListTables` method also list views.

According [DBI help](https://dbi.r-dbi.org/reference/dblisttables), `dbListTables()` does the following:

> Returns the unquoted names of remote tables accessible through this connection. This should include views and temporary objects, but not all database backends (in particular RMariaDB and RMySQL) support this.

So this change makes the package better conform with the DBI spec.