### PR TITLE
Add CSV stand-alone example, and allow CSV reader to be used without ClientContext/Database

### DIFF
--- a/examples/csvcli/csvcli.cpp
+++ b/examples/csvcli/csvcli.cpp
@@ -1,0 +1,51 @@
+
+#include "duckdb.hpp"
+#ifndef DUCKDB_AMALGAMATION
+#include "duckdb/execution/operator/persistent/buffered_csv_reader.hpp"
+#endif
+
+#include <algorithm>
+#include <unordered_map>
+
+/* COMPILATION:
+python3 scripts/amalgamation.py --extended
+clang++ -std=c++11 -O0 -g -Isrc/amalgamation examples/csvcli/csvcli.cpp src/amalgamation/duckdb.cpp
+./a.out test/sql/copy/csv/data/real/lineitem_sample.csv
+*/
+
+using namespace duckdb;
+void PrintUsage() {
+	printf("Usage: csvcli [filename.csv]");
+	exit(1);
+}
+
+int main(int argc, const char **argv) {
+	if (argc < 2) {
+		PrintUsage();
+	}
+	auto filename = std::string(argv[1]);
+
+	BufferedCSVReaderOptions options;
+	options.file_path = move(filename);
+	options.compression = "none";
+	options.auto_detect = true;
+
+	FileSystem fs;
+	BufferedCSVReader reader(fs, move(options));
+
+	if (reader.sql_types.empty()) {
+		throw std::runtime_error("Failed to auto-detect types for CSV file");
+	}
+
+	DataChunk result;
+	result.Initialize(reader.sql_types);
+
+	while(true) {
+		result.Reset();
+		reader.ParseCSV(result);
+		if (result.size() == 0) {
+			break;
+		}
+		result.Print();
+	}
+}

--- a/examples/csvcli/csvcli.cpp
+++ b/examples/csvcli/csvcli.cpp
@@ -40,7 +40,7 @@ int main(int argc, const char **argv) {
 	DataChunk result;
 	result.Initialize(reader.sql_types);
 
-	while(true) {
+	while (true) {
 		result.Reset();
 		reader.ParseCSV(result);
 		if (result.size() == 0) {

--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -73,6 +73,7 @@ if '--extended' in sys.argv:
         "duckdb/storage/statistics/numeric_statistics.hpp",
         "duckdb/planner/filter/conjunction_filter.hpp",
         "duckdb/planner/filter/constant_filter.hpp",
+        "duckdb/execution/operator/persistent/buffered_csv_reader.hpp",
         "duckdb/planner/filter/null_filter.hpp"]]
     main_header_files += add_include_dir(os.path.join(include_dir, 'duckdb/parser/expression'))
     main_header_files += add_include_dir(os.path.join(include_dir, 'duckdb/parser/parsed_data'))

--- a/src/execution/operator/persistent/buffered_csv_reader.cpp
+++ b/src/execution/operator/persistent/buffered_csv_reader.cpp
@@ -124,7 +124,7 @@ TextSearchShiftArray::TextSearchShiftArray(string search_term) : length(search_t
 }
 
 BufferedCSVReader::BufferedCSVReader(FileSystem &fs_p, BufferedCSVReaderOptions options_p,
-					const vector<LogicalType> &requested_types)
+                                     const vector<LogicalType> &requested_types)
     : fs(fs_p), options(move(options_p)), buffer_size(0), position(0), start(0) {
 	file_handle = OpenCSV(options);
 	Initialize(requested_types);

--- a/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
@@ -136,6 +136,9 @@ public:
 	BufferedCSVReader(ClientContext &context, BufferedCSVReaderOptions options,
 	                  const vector<LogicalType> &requested_types = vector<LogicalType>());
 
+	BufferedCSVReader(FileSystem &fs, BufferedCSVReaderOptions options,
+	                  const vector<LogicalType> &requested_types = vector<LogicalType>());
+
 	FileSystem &fs;
 	BufferedCSVReaderOptions options;
 	vector<LogicalType> sql_types;
@@ -219,7 +222,7 @@ private:
 	//! Reads a new buffer from the CSV file if the current one has been exhausted
 	bool ReadBuffer(idx_t &start);
 
-	unique_ptr<FileHandle> OpenCSV(ClientContext &context, const BufferedCSVReaderOptions &options);
+	unique_ptr<FileHandle> OpenCSV(const BufferedCSVReaderOptions &options);
 };
 
 } // namespace duckdb


### PR DESCRIPTION
```cpp
int main(int argc, const char **argv) {
	if (argc < 2) {
		PrintUsage();
	}
	auto filename = std::string(argv[1]);

	BufferedCSVReaderOptions options;
	options.file_path = move(filename);
	options.compression = "none";
	options.auto_detect = true;

	FileSystem fs;
	BufferedCSVReader reader(fs, move(options));

	if (reader.sql_types.empty()) {
		throw std::runtime_error("Failed to auto-detect types for CSV file");
	}

	DataChunk result;
	result.Initialize(reader.sql_types);

	while(true) {
		result.Reset();
		reader.ParseCSV(result);
		if (result.size() == 0) {
			break;
		}
		result.Print();
	}
}

```