### PR TITLE
Adding number of vectors in returned chunk from fetch_df_chunk

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
@@ -102,7 +102,7 @@ public:
 	py::dict FetchNumpy();
 	py::object FetchDF();
 
-	py::object FetchDFChunk() const;
+	py::object FetchDFChunk(const idx_t vectors_per_chunk = 1) const;
 
 	py::object FetchArrow();
 

--- a/tools/pythonpkg/src/include/duckdb_python/pyresult.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyresult.hpp
@@ -27,11 +27,11 @@ public:
 
 	py::list Fetchall();
 
-	py::dict FetchNumpy(bool stream = false);
+	py::dict FetchNumpy(bool stream = false, idx_t vectors_per_chunk = 1);
 
 	py::object FetchDF();
 
-	py::object FetchDFChunk();
+	py::object FetchDFChunk(idx_t vectors_per_chunk);
 
 	py::object FetchArrowTable();
 

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -43,7 +43,7 @@ void DuckDBPyConnection::Initialize(py::handle &m) {
 	    .def("fetchdf", &DuckDBPyConnection::FetchDF, "Fetch a result as Data.Frame following execute()")
 	    .def("fetch_df", &DuckDBPyConnection::FetchDF, "Fetch a result as Data.Frame following execute()")
 	    .def("fetch_df_chunk", &DuckDBPyConnection::FetchDFChunk,
-	         "Fetch a chunk of the result as Data.Frame following execute()")
+	         "Fetch a chunk of the result as Data.Frame following execute()", py::arg("vectors_per_chunk") = 1)
 	    .def("df", &DuckDBPyConnection::FetchDF, "Fetch a result as Data.Frame following execute()")
 	    .def("fetch_arrow_table", &DuckDBPyConnection::FetchArrow, "Fetch a result as Arrow table following execute()")
 	    .def("arrow", &DuckDBPyConnection::FetchArrow, "Fetch a result as Arrow table following execute()")
@@ -377,11 +377,11 @@ py::object DuckDBPyConnection::FetchDF() {
 	return result->FetchDF();
 }
 
-py::object DuckDBPyConnection::FetchDFChunk() const {
+py::object DuckDBPyConnection::FetchDFChunk(const idx_t vectors_per_chunk) const {
 	if (!result) {
 		throw std::runtime_error("no open result set");
 	}
-	return result->FetchDFChunk();
+	return result->FetchDFChunk(vectors_per_chunk);
 }
 
 py::object DuckDBPyConnection::FetchArrow() {

--- a/tools/pythonpkg/src/pyresult.cpp
+++ b/tools/pythonpkg/src/pyresult.cpp
@@ -162,7 +162,7 @@ py::list DuckDBPyResult::Fetchall() {
 	return res;
 }
 
-py::dict DuckDBPyResult::FetchNumpy(bool stream) {
+py::dict DuckDBPyResult::FetchNumpy(bool stream, idx_t vectors_per_chunk) {
 	if (!result) {
 		throw std::runtime_error("result closed");
 	}
@@ -184,21 +184,32 @@ py::dict DuckDBPyResult::FetchNumpy(bool stream) {
 			}
 			materialized.collection.Reset();
 		} else {
-			conversion.Append(*materialized.Fetch());
+			for (idx_t count_vec = 0; count_vec < vectors_per_chunk; count_vec++) {
+				auto chunk = materialized.Fetch();
+				if (!chunk || chunk->size() == 0) {
+					//! finished
+					break;
+				}
+				conversion.Append(*chunk);
+			}
 		}
 	} else {
 		if (!stream) {
 			while (true) {
 				auto chunk = result->FetchRaw();
 				if (!chunk || chunk->size() == 0) {
-					// finished
+					//! finished
 					break;
 				}
 				conversion.Append(*chunk);
 			}
 		} else {
-			auto chunk = result->FetchRaw();
-			if (chunk && chunk->size() > 0) {
+			for (idx_t count_vec = 0; count_vec < vectors_per_chunk; count_vec++) {
+				auto chunk = result->FetchRaw();
+				if (!chunk || chunk->size() == 0) {
+					//! finished
+					break;
+				}
 				conversion.Append(*chunk);
 			}
 		}
@@ -216,8 +227,8 @@ py::object DuckDBPyResult::FetchDF() {
 	return py::module::import("pandas").attr("DataFrame").attr("from_dict")(FetchNumpy());
 }
 
-py::object DuckDBPyResult::FetchDFChunk() {
-	return py::module::import("pandas").attr("DataFrame").attr("from_dict")(FetchNumpy(true));
+py::object DuckDBPyResult::FetchDFChunk(idx_t num_of_vectors) {
+	return py::module::import("pandas").attr("DataFrame").attr("from_dict")(FetchNumpy(true, num_of_vectors));
 }
 
 py::object DuckDBPyResult::FetchArrowTable() {

--- a/tools/pythonpkg/tests/pandas/test_fetch_df_chunk.py
+++ b/tools/pythonpkg/tests/pandas/test_fetch_df_chunk.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 class TestType(object):
 
     def test_fetch_df_chunk(self, duckdb_cursor):
@@ -36,3 +39,44 @@ class TestType(object):
         except Exception as err:
             print(err)
  
+    def test_fetch_df_chunk_parameter(self, duckdb_cursor):
+        duckdb_cursor.execute("CREATE table t as select range a from range(10000);")
+        query = duckdb_cursor.execute("SELECT a FROM t")
+        
+        # Return 2 vectors
+        cur_chunk = query.fetch_df_chunk(2)
+        assert(cur_chunk['a'][0] == 0)
+        assert(len(cur_chunk) == 2048)
+        
+        # Return Default 1 vector
+        cur_chunk = query.fetch_df_chunk()
+        assert(cur_chunk['a'][0] == 2048)
+        assert(len(cur_chunk) == 1024)
+        
+        # Return 3 vectors
+        cur_chunk = query.fetch_df_chunk(3)
+        assert(cur_chunk['a'][0] == 3072)
+        assert(len(cur_chunk) == 3072)
+        
+        # Return 0 vectors
+        cur_chunk = query.fetch_df_chunk(0)
+        assert(len(cur_chunk) == 0)
+
+
+        # Return 1 vector
+        cur_chunk = query.fetch_df_chunk(1)
+        assert(cur_chunk['a'][0] == 6144)
+        assert(len(cur_chunk) == 1024)
+
+         # Return more vectors than we have remaining
+        cur_chunk = query.fetch_df_chunk(100)
+        assert(cur_chunk['a'][0] == 7168)
+        assert(len(cur_chunk) == 2832)
+
+    def test_fetch_df_chunk_negative_parameter(self, duckdb_cursor):
+        duckdb_cursor.execute("CREATE table t as select range a from range(100);")
+        query = duckdb_cursor.execute("SELECT a FROM t")
+        
+        # Return -1 vector should not work
+        with pytest.raises(Exception):
+            cur_chunk = query.fetch_df_chunk(-1)


### PR DESCRIPTION
This PR expands the python fetch_df_chunk function to accept a vectors_per_chunk parameter.

This function now returns vectors_per_chunk*STANDARD_VECTOR_SIZE per call.

By default that value is 1.