### PR TITLE
Fixing a pretty evil nested type reading bug in the parquet reader

### DIFF
--- a/extension/parquet/include/list_column_reader.hpp
+++ b/extension/parquet/include/list_column_reader.hpp
@@ -40,7 +40,8 @@ private:
 	uint8_t *child_defines_ptr;
 	uint8_t *child_repeats_ptr;
 
-	DataChunk child_result;
+	Vector overflow_read_vector;
+
 	parquet_filter_t child_filter;
 
 	idx_t overflow_child_count;

--- a/src/common/types/validity_mask.cpp
+++ b/src/common/types/validity_mask.cpp
@@ -78,6 +78,12 @@ void ValidityMask::Slice(const ValidityMask &other, idx_t offset) {
 	}
 	Initialize(STANDARD_VECTOR_SIZE);
 
+// FIXME THIS NEEDS FIXING!
+#if 1
+	for (idx_t i = offset; i < STANDARD_VECTOR_SIZE; i++) {
+		Set(i - offset, other.RowIsValid(i));
+	}
+#else
 	// first shift the "whole" units
 	idx_t entire_units = offset / BITS_PER_VALUE;
 	idx_t sub_units = offset - entire_units * BITS_PER_VALUE;
@@ -104,6 +110,12 @@ void ValidityMask::Slice(const ValidityMask &other, idx_t offset) {
 		}
 		validity_mask[validity_idx] >>= sub_units;
 	}
+#ifdef DEBUG
+	for (idx_t i = offset; i < STANDARD_VECTOR_SIZE; i++) {
+		D_ASSERT(RowIsValid(i - offset) == other.RowIsValid(i));
+	}
+#endif
+#endif
 }
 
 } // namespace duckdb


### PR DESCRIPTION
Found tons of other stuff in the process, among others a validity list slicing bug