### PR TITLE
Remove extra extension register

### DIFF
--- a/extension/httpfs/httpfs-extension.cpp
+++ b/extension/httpfs/httpfs-extension.cpp
@@ -8,7 +8,6 @@ void HTTPFsExtension::Load(DuckDB &db) {
 	S3FileSystem::Verify(); // run some tests to see if all the hashes work out
 	auto &fs = db.instance->GetFileSystem();
 	fs.RegisterSubSystem(make_unique<HTTPFileSystem>());
-	fs.RegisterSubSystem(make_unique<HTTPFileSystem>());
 	fs.RegisterSubSystem(make_unique<S3FileSystem>(*db.instance));
 }
 


### PR DESCRIPTION
Since the extension now services http and https, I think that it only needs to be registered once.