### PR TITLE
Fix for issue #1625: only scan deleted tuples in create index that are still required for open transactions

### DIFF
--- a/src/common/constants.cpp
+++ b/src/common/constants.cpp
@@ -11,6 +11,7 @@ const sel_t ZERO_VECTOR[STANDARD_VECTOR_SIZE] = {0};
 const double PI = 3.141592653589793;
 
 const transaction_t TRANSACTION_ID_START = 4611686018427388000ULL;                // 2^62
+const transaction_t MAX_TRANSACTION_ID = NumericLimits<transaction_t>::Maximum(); // 2^63
 const transaction_t NOT_DELETED_ID = NumericLimits<transaction_t>::Maximum() - 1; // 2^64 - 1
 const transaction_t MAXIMUM_QUERY_ID = NumericLimits<transaction_t>::Maximum();   // 2^64
 

--- a/src/include/duckdb/common/constants.hpp
+++ b/src/include/duckdb/common/constants.hpp
@@ -58,6 +58,7 @@ extern const column_t COLUMN_IDENTIFIER_ROW_ID;
 extern const row_t MAX_ROW_ID;
 
 extern const transaction_t TRANSACTION_ID_START;
+extern const transaction_t MAX_TRANSACTION_ID;
 extern const transaction_t MAXIMUM_QUERY_ID;
 extern const transaction_t NOT_DELETED_ID;
 

--- a/src/include/duckdb/common/enums/scan_options.hpp
+++ b/src/include/duckdb/common/enums/scan_options.hpp
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/scan_options.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+
+enum class TableScanType : uint8_t {
+	//! Regular table scan: scan all tuples that are relevant for the current transaction
+	TABLE_SCAN_REGULAR = 0,
+	//! Scan all rows, including any deleted rows. Committed updates are merged in.
+	TABLE_SCAN_COMMITTED_ROWS = 1,
+	//! Scan all rows, including any deleted rows. Throws an exception if there are any uncommitted updates.
+	TABLE_SCAN_COMMITTED_ROWS_DISALLOW_UPDATES = 2,
+	//! Scan all rows, excluding any permanently deleted rows.
+	//! Permanently deleted rows are rows which no transaction will ever need again.
+	TABLE_SCAN_COMMITTED_ROWS_OMIT_PERMANENTLY_DELETED = 3
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -18,6 +18,7 @@
 #include "duckdb/transaction/local_storage.hpp"
 #include "duckdb/storage/table/persistent_table_data.hpp"
 #include "duckdb/storage/table/row_group.hpp"
+#include "duckdb/common/enums/scan_options.hpp"
 
 #include "duckdb/common/atomic.hpp"
 #include "duckdb/common/mutex.hpp"
@@ -229,12 +230,10 @@ private:
 	                              TableFilterSet *table_filters, RowGroup *row_group, idx_t vector_index,
 	                              idx_t max_row);
 	bool ScanBaseTable(Transaction &transaction, DataChunk &result, TableScanState &state);
-	bool ScanCreateIndex(CreateIndexScanState &state, DataChunk &result, bool allow_pending_updates = false);
 
 	//! The CreateIndexScan is a special scan that is used to create an index on the table, it keeps locks on the table
 	void InitializeCreateIndexScan(CreateIndexScanState &state, const vector<column_t> &column_ids);
-	void CreateIndexScan(CreateIndexScanState &structure, const vector<column_t> &column_ids, DataChunk &result,
-	                     bool allow_pending_updates = false);
+	bool ScanCreateIndex(CreateIndexScanState &state, DataChunk &result, TableScanType type);
 
 private:
 	//! Lock for appending entries to the table

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -35,6 +35,8 @@ public:
 	//! Gets up to max_count entries from the chunk info. If the ret is 0>ret>max_count, the selection vector is filled
 	//! with the tuples
 	virtual idx_t GetSelVector(Transaction &transaction, SelectionVector &sel_vector, idx_t max_count) = 0;
+	virtual idx_t GetCommittedSelVector(transaction_t min_start_id, transaction_t min_transaction_id,
+	                                    SelectionVector &sel_vector, idx_t max_count) = 0;
 	//! Returns whether or not a single row in the ChunkInfo should be used or not for the given transaction
 	virtual bool Fetch(Transaction &transaction, row_t row) = 0;
 	virtual void CommitAppend(transaction_t commit_id, idx_t start, idx_t end) = 0;
@@ -52,11 +54,18 @@ public:
 
 public:
 	idx_t GetSelVector(Transaction &transaction, SelectionVector &sel_vector, idx_t max_count) override;
+	idx_t GetCommittedSelVector(transaction_t min_start_id, transaction_t min_transaction_id,
+	                            SelectionVector &sel_vector, idx_t max_count) override;
 	bool Fetch(Transaction &transaction, row_t row) override;
 	void CommitAppend(transaction_t commit_id, idx_t start, idx_t end) override;
 
 	void Serialize(Serializer &serialize) override;
 	static unique_ptr<ChunkInfo> Deserialize(Deserializer &source);
+
+private:
+	template <class OP>
+	idx_t TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id, SelectionVector &sel_vector,
+	                            idx_t max_count);
 };
 
 class ChunkVectorInfo : public ChunkInfo {
@@ -76,6 +85,8 @@ public:
 	idx_t GetSelVector(transaction_t start_time, transaction_t transaction_id, SelectionVector &sel_vector,
 	                   idx_t max_count);
 	idx_t GetSelVector(Transaction &transaction, SelectionVector &sel_vector, idx_t max_count) override;
+	idx_t GetCommittedSelVector(transaction_t min_start_id, transaction_t min_transaction_id,
+	                            SelectionVector &sel_vector, idx_t max_count) override;
 	bool Fetch(Transaction &transaction, row_t row) override;
 	void CommitAppend(transaction_t commit_id, idx_t start, idx_t end) override;
 
@@ -85,6 +96,11 @@ public:
 
 	void Serialize(Serializer &serialize) override;
 	static unique_ptr<ChunkInfo> Deserialize(Deserializer &source);
+
+private:
+	template <class OP>
+	idx_t TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id, SelectionVector &sel_vector,
+	                            idx_t max_count);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -69,6 +69,8 @@ public:
 	                    SelectionVector &sel, idx_t &count, const TableFilter &filter);
 	virtual void FilterScan(Transaction &transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
 	                        SelectionVector &sel, idx_t count);
+	virtual void FilterScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, SelectionVector &sel,
+	                                 idx_t count, bool allow_updates);
 
 	//! Skip the scan forward by "count" rows
 	virtual void Skip(ColumnScanState &state, idx_t count = STANDARD_VECTOR_SIZE);

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/storage/table/append_state.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
 #include "duckdb/storage/statistics/segment_statistics.hpp"
+#include "duckdb/common/enums/scan_options.hpp"
 #include "duckdb/common/mutex.hpp"
 
 namespace duckdb {
@@ -92,9 +93,11 @@ public:
 	//! skipped.
 	bool CheckZonemapSegments(RowGroupScanState &state);
 	void Scan(Transaction &transaction, RowGroupScanState &state, DataChunk &result);
-	void IndexScan(RowGroupScanState &state, DataChunk &result, bool allow_pending_updates);
+	void ScanCommitted(RowGroupScanState &state, DataChunk &result, TableScanType type);
 
 	idx_t GetSelVector(Transaction &transaction, idx_t vector_idx, SelectionVector &sel_vector, idx_t max_count);
+	idx_t GetCommittedSelVector(transaction_t start_time, transaction_t transaction_id, idx_t vector_idx,
+	                            SelectionVector &sel_vector, idx_t max_count);
 
 	//! For a specific row, returns true if it should be used for the transaction and false otherwise.
 	bool Fetch(Transaction &transaction, idx_t row);
@@ -138,7 +141,7 @@ public:
 private:
 	ChunkInfo *GetChunkInfo(idx_t vector_idx);
 
-	template <bool SCAN_DELETES, bool SCAN_COMMITTED, bool ALLOW_UPDATES>
+	template <TableScanType TYPE>
 	void TemplatedScan(Transaction *transaction, RowGroupScanState &state, DataChunk &result);
 
 	static void CheckpointDeletes(VersionNode *versions, Serializer &serializer);

--- a/src/include/duckdb/transaction/transaction_manager.hpp
+++ b/src/include/duckdb/transaction/transaction_manager.hpp
@@ -49,6 +49,12 @@ public:
 	transaction_t GetQueryNumber() {
 		return current_query_number++;
 	}
+	transaction_t LowestActiveId() {
+		return lowest_active_id;
+	}
+	transaction_t LowestActiveStart() {
+		return lowest_active_start;
+	}
 
 	void Checkpoint(ClientContext &context, bool force = false);
 
@@ -69,6 +75,10 @@ private:
 	transaction_t current_start_timestamp;
 	//! The current transaction ID used by transactions
 	transaction_t current_transaction_id;
+	//! The lowest active transaction id
+	atomic<transaction_t> lowest_active_id;
+	//! The lowest active transaction timestamp
+	atomic<transaction_t> lowest_active_start;
 	//! Set of currently running transactions
 	vector<unique_ptr<Transaction>> active_transactions;
 	//! Set of recently committed transactions

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -542,7 +542,7 @@ void DataTable::ScanTableSegment(idx_t row_start, idx_t count, const std::functi
 
 	idx_t current_row = row_start_aligned;
 	while (current_row < end) {
-		CreateIndexScan(state, column_ids, chunk, true);
+		ScanCreateIndex(state, chunk, TableScanType::TABLE_SCAN_COMMITTED_ROWS);
 		if (chunk.size() == 0) {
 			break;
 		}
@@ -731,7 +731,8 @@ void DataTable::RemoveFromIndexes(Vector &row_identifiers, idx_t count) {
 	result.Initialize(types);
 
 	row_group->InitializeScanWithOffset(state.row_group_scan_state, row_group_vector_idx);
-	row_group->IndexScan(state.row_group_scan_state, result, false);
+	row_group->ScanCommitted(state.row_group_scan_state, result,
+	                         TableScanType::TABLE_SCAN_COMMITTED_ROWS_DISALLOW_UPDATES);
 	result.Slice(sel, count);
 
 	info->indexes.Scan([&](Index &index) {
@@ -970,18 +971,10 @@ void DataTable::InitializeCreateIndexScan(CreateIndexScanState &state, const vec
 	InitializeScan(state, column_ids);
 }
 
-void DataTable::CreateIndexScan(CreateIndexScanState &state, const vector<column_t> &column_ids, DataChunk &result,
-                                bool allow_pending_updates) {
-	// scan the persistent segments
-	if (ScanCreateIndex(state, result, allow_pending_updates)) {
-		return;
-	}
-}
-
-bool DataTable::ScanCreateIndex(CreateIndexScanState &state, DataChunk &result, bool allow_pending_updates) {
+bool DataTable::ScanCreateIndex(CreateIndexScanState &state, DataChunk &result, TableScanType type) {
 	auto current_row_group = state.row_group_scan_state.row_group;
 	while (current_row_group) {
-		current_row_group->IndexScan(state.row_group_scan_state, result, allow_pending_updates);
+		current_row_group->ScanCommitted(state.row_group_scan_state, result, type);
 		if (result.size() > 0) {
 			return true;
 		} else {
@@ -1024,7 +1017,7 @@ void DataTable::AddIndex(unique_ptr<Index> index, const vector<unique_ptr<Expres
 		while (true) {
 			intermediate.Reset();
 			// scan a new chunk from the table to index
-			CreateIndexScan(state, column_ids, intermediate);
+			ScanCreateIndex(state, intermediate, TableScanType::TABLE_SCAN_COMMITTED_ROWS_OMIT_PERMANENTLY_DELETED);
 			if (intermediate.size() == 0) {
 				// finished scanning for index creation
 				// release all locks

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -166,6 +166,12 @@ void ColumnData::FilterScan(Transaction &transaction, idx_t vector_index, Column
 	result.Slice(sel, count);
 }
 
+void ColumnData::FilterScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, SelectionVector &sel,
+                                     idx_t count, bool allow_updates) {
+	ScanCommitted(vector_index, state, result, allow_updates);
+	result.Slice(sel, count);
+}
+
 void ColumnData::Skip(ColumnScanState &state, idx_t count) {
 	state.Next(count);
 }

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -48,6 +48,8 @@ TransactionManager::TransactionManager(DatabaseInstance &db) : db(db), thread_is
 	current_transaction_id = TRANSACTION_ID_START;
 	// the current active query id
 	current_query_number = 1;
+	lowest_active_id = TRANSACTION_ID_START;
+	lowest_active_start = MAX_TRANSACTION_ID;
 }
 
 TransactionManager::~TransactionManager() {
@@ -65,6 +67,10 @@ Transaction *TransactionManager::StartTransaction(ClientContext &context) {
 	transaction_t start_time = current_start_timestamp++;
 	transaction_t transaction_id = current_transaction_id++;
 	timestamp_t start_timestamp = Timestamp::GetCurrentTimestamp();
+	if (active_transactions.empty()) {
+		lowest_active_start = start_time;
+		lowest_active_id = transaction_id;
+	}
 
 	// create the actual transaction
 	auto &catalog = Catalog::GetCatalog(db);
@@ -240,6 +246,7 @@ void TransactionManager::RemoveTransaction(Transaction *transaction) noexcept {
 	idx_t t_index = active_transactions.size();
 	// check for the lowest and highest start time in the list of transactions
 	transaction_t lowest_start_time = TRANSACTION_ID_START;
+	transaction_t lowest_transaction_id = MAX_TRANSACTION_ID;
 	transaction_t lowest_active_query = MAXIMUM_QUERY_ID;
 	for (idx_t i = 0; i < active_transactions.size(); i++) {
 		if (active_transactions[i].get() == transaction) {
@@ -248,8 +255,12 @@ void TransactionManager::RemoveTransaction(Transaction *transaction) noexcept {
 			transaction_t active_query = active_transactions[i]->active_query;
 			lowest_start_time = MinValue(lowest_start_time, active_transactions[i]->start_time);
 			lowest_active_query = MinValue(lowest_active_query, active_query);
+			lowest_transaction_id = MinValue(lowest_transaction_id, active_transactions[i]->transaction_id);
 		}
 	}
+	lowest_active_start = lowest_start_time;
+	lowest_active_id = lowest_transaction_id;
+
 	transaction_t lowest_stored_query = lowest_start_time;
 	D_ASSERT(t_index != active_transactions.size());
 	auto current_transaction = move(active_transactions[t_index]);

--- a/test/sql/index/art/test_art_create_index_delete.test
+++ b/test/sql/index/art/test_art_create_index_delete.test
@@ -1,0 +1,48 @@
+# name: test/sql/index/art/test_art_create_index_delete.test
+# description: ART Create index with deletes
+# group: [art]
+
+statement ok
+CREATE TABLE integers(i INTEGER)
+
+statement ok
+INSERT INTO integers SELECT * FROM range(10)
+
+statement ok con1
+BEGIN
+
+statement ok
+DELETE FROM integers WHERE i=2 OR i=7
+
+query I con1
+SELECT * FROM integers WHERE i=1;
+----
+1
+
+query I con1
+SELECT * FROM integers WHERE i=2;
+----
+2
+
+statement ok
+CREATE INDEX i_index ON integers(i)
+
+query I
+SELECT * FROM integers WHERE i=1;
+----
+1
+
+query I
+SELECT * FROM integers WHERE i=2;
+----
+
+# con1 still sees the old state
+query I con1
+SELECT * FROM integers WHERE i=1;
+----
+1
+
+query I con1
+SELECT * FROM integers WHERE i=2;
+----
+2

--- a/test/sql/index/art/test_art_create_index_duplicate_deletes.test
+++ b/test/sql/index/art/test_art_create_index_duplicate_deletes.test
@@ -1,0 +1,28 @@
+# name: test/sql/index/art/test_art_create_index_duplicate_deletes.test
+# description: ART Create index with deletes
+# group: [art]
+
+statement ok
+CREATE TABLE integers(i INTEGER)
+
+statement ok
+INSERT INTO integers SELECT * FROM range(10)
+
+statement ok
+DELETE FROM integers
+
+statement ok
+INSERT INTO integers SELECT * FROM range(10)
+
+statement ok
+CREATE INDEX i_index ON integers(i)
+
+query I
+SELECT * FROM integers WHERE i=1;
+----
+1
+
+query I
+SELECT * FROM integers WHERE i=2;
+----
+2

--- a/test/sql/storage/test_ignore_duplicate_deletes_unique_index.test
+++ b/test/sql/storage/test_ignore_duplicate_deletes_unique_index.test
@@ -1,0 +1,42 @@
+# name: test/sql/storage/test_ignore_duplicate_deletes_unique_index.test
+# description: Test ignoring of old tuples in unique index creation
+# group: [storage]
+
+# load the DB from disk
+load __TEST_DIR__/test_ignore_duplicate_delete.db
+
+statement ok
+CREATE TABLE TBL (id INT NOT NULL, age INT NOT NULL, PRIMARY KEY ( id ))
+
+statement ok
+INSERT INTO TBL VALUES (1, 1);
+
+statement ok
+DELETE FROM TBL WHERE id = 1;
+
+statement ok
+INSERT INTO TBL VALUES (1, 1);
+
+query II
+SELECT * FROM TBL
+----
+1	1
+
+query II
+SELECT * FROM TBL WHERE id=1
+----
+1	1
+
+restart
+
+query II
+SELECT * FROM TBL
+----
+1	1
+
+query II
+SELECT * FROM TBL WHERE id=1
+----
+1	1
+
+


### PR DESCRIPTION
We fix this issue by keeping track of the lowest active transaction_id, and the lowest active start_time in the TransactionManager. In this manner, we can figure out which rows in the tables still need to exist (and hence which rows should be added to the index). Any rows that can never be scanned again (because no active transaction would ever need them) can be omitted from the index. After a restart, there will be no active transactions, so all deleted rows will be emitted. 