### PR TITLE
Fix #2040: disallow stream result for insert/delete/update/create/drop statements

### DIFF
--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -126,6 +126,7 @@ BoundStatement Binder::Bind(CopyStatement &stmt) {
 		}
 		stmt.select_statement = move(statement);
 	}
+	this->allow_stream_result = false;
 	if (stmt.info->is_from) {
 		return BindCopyFrom(stmt);
 	} else {

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -156,6 +156,7 @@ unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableInfo(unique_ptr<CreateIn
 	for (auto &column : base.columns) {
 		ExpressionBinder::TestCollation(context, StringType::GetCollation(column.type));
 	}
+	this->allow_stream_result = false;
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -78,6 +78,7 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 	result.plan = move(del);
 	result.names = {"Count"};
 	result.types = {LogicalType::BIGINT};
+	this->allow_stream_result = false;
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_drop.cpp
+++ b/src/planner/binder/statement/bind_drop.cpp
@@ -43,6 +43,7 @@ BoundStatement Binder::Bind(DropStatement &stmt) {
 	result.plan = make_unique<LogicalSimple>(LogicalOperatorType::LOGICAL_DROP, move(stmt.info));
 	result.names = {"Success"};
 	result.types = {LogicalType::BOOLEAN};
+	this->allow_stream_result = false;
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_export.cpp
+++ b/src/planner/binder/statement/bind_export.cpp
@@ -135,6 +135,7 @@ BoundStatement Binder::Bind(ExportStatement &stmt) {
 	}
 
 	result.plan = move(export_node);
+	this->allow_stream_result = false;
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -125,6 +125,7 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 	insert->AddChild(move(root));
 
 	result.plan = move(insert);
+	this->allow_stream_result = false;
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_load.cpp
+++ b/src/planner/binder/statement/bind_load.cpp
@@ -11,6 +11,7 @@ BoundStatement Binder::Bind(LoadStatement &stmt) {
 	result.names = {"Success"};
 
 	result.plan = make_unique<LogicalSimple>(LogicalOperatorType::LOGICAL_LOAD, move(stmt.info));
+	this->allow_stream_result = false;
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -205,6 +205,7 @@ BoundStatement Binder::Bind(UpdateStatement &stmt) {
 	result.names = {"Count"};
 	result.types = {LogicalType::BIGINT};
 	result.plan = move(update);
+	this->allow_stream_result = false;
 	return result;
 }
 

--- a/test/sql/index/art/test_create_unique_index.test
+++ b/test/sql/index/art/test_create_unique_index.test
@@ -1,0 +1,23 @@
+# name: test/sql/index/art/test_create_unique_index.test
+# description: CREATE UNIQUE INDEX
+# group: [art]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t0(c0 INTEGER);
+
+statement ok
+CREATE UNIQUE INDEX i0 ON t0(c0);
+
+statement ok
+INSERT INTO t0(c0) VALUES (1);
+
+statement error
+INSERT INTO t0(c0) VALUES (1);
+
+query I
+SELECT * FROM t0 WHERE t0.c0 = 1;
+----
+1


### PR DESCRIPTION
The issue was that the streaming query result caused the SQLite shell to hide the constraint error. Since the streaming query result messes with when specific parts of the execution happen (e.g. when a commit happens), the errors pop up in unexpected places. Specifically the commit would occur in the `sqlite3_reset` statement, when the result set is closed, which the SQLite shell does not handle correctly.

In general, streaming query results don't make sense for these types of statements since they always return only a single row, so we force queries with these statements to return a materialized query result. 