### PR TITLE
src/CMakeLists.txt: add missing ${CMAKE_DL_LIBS}

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,10 +32,12 @@ if(AMALGAMATION_BUILD)
   endif()
 
   add_library(duckdb SHARED "${PROJECT_SOURCE_DIR}/src/amalgamation/duckdb.cpp")
+  target_link_libraries(duckdb ${CMAKE_DL_LIBS})
+  link_threads(duckdb)
+
   add_library(duckdb_static STATIC
               "${PROJECT_SOURCE_DIR}/src/amalgamation/duckdb.cpp")
-
-  link_threads(duckdb)
+  target_link_libraries(duckdb_static ${CMAKE_DL_LIBS})
   link_threads(duckdb_static)
 
   install(FILES "${PROJECT_SOURCE_DIR}/src/amalgamation/duckdb.hpp"


### PR DESCRIPTION
This fixes amalgamation build failures on all platforms with a
separate library for `dlopen` _et al_ (Linux in particular).

Tested on Debian 10 and macOS Big Sur.

Closes #2047.