### PR TITLE
Fix #2057: correctly handle statistics where null_count is set, but min/max is not

### DIFF
--- a/src/common/value_operations/comparison_operations.cpp
+++ b/src/common/value_operations/comparison_operations.cpp
@@ -169,11 +169,8 @@ static bool TemplatedBooleanOperation(const Value &left, const Value &right) {
 }
 
 bool ValueOperations::Equals(const Value &left, const Value &right) {
-	if (left.is_null && right.is_null) {
-		return true;
-	}
-	if (left.is_null != right.is_null) {
-		return false;
+	if (left.is_null || right.is_null) {
+		throw InternalException("Comparison on NULL values");
 	}
 	return TemplatedBooleanOperation<duckdb::Equals>(left, right);
 }
@@ -183,23 +180,15 @@ bool ValueOperations::NotEquals(const Value &left, const Value &right) {
 }
 
 bool ValueOperations::GreaterThan(const Value &left, const Value &right) {
-	if (left.is_null && right.is_null) {
-		return false;
-	} else if (right.is_null) {
-		return true;
-	} else if (left.is_null) {
-		return false;
+	if (left.is_null || right.is_null) {
+		throw InternalException("Comparison on NULL values");
 	}
 	return TemplatedBooleanOperation<duckdb::GreaterThan>(left, right);
 }
 
 bool ValueOperations::GreaterThanEquals(const Value &left, const Value &right) {
-	if (left.is_null && right.is_null) {
-		return true;
-	} else if (right.is_null) {
-		return true;
-	} else if (left.is_null) {
-		return false;
+	if (left.is_null || right.is_null) {
+		throw InternalException("Comparison on NULL values");
 	}
 	return TemplatedBooleanOperation<duckdb::GreaterThanEquals>(left, right);
 }

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -506,27 +506,36 @@ TableFilterSet FilterCombiner::GenerateTableScanFilters(vector<idx_t> &column_id
 				continue;
 			}
 			auto &fst_const_value_expr = (BoundConstantExpression &)*func.children[1].get();
+
 			//! Check if values are consecutive, if yes transform them to >= <= (only for integers)
+			// e.g. if we have x IN (1, 2, 3, 4, 5) we transform this into x >= 1 AND x <= 5
 			if (!fst_const_value_expr.value.type().IsIntegral()) {
 				continue;
 			}
 
+			bool can_simplify_in_clause = true;
 			for (idx_t i = 1; i < func.children.size(); i++) {
 				auto &const_value_expr = (BoundConstantExpression &)*func.children[i].get();
+				if (const_value_expr.value.is_null) {
+					can_simplify_in_clause = false;
+					break;
+				}
 				in_values.push_back(const_value_expr.value);
+			}
+			if (!can_simplify_in_clause || in_values.empty()) {
+				continue;
 			}
 			Value one(1);
 
 			sort(in_values.begin(), in_values.end());
 
-			bool is_consecutive = true;
 			for (idx_t in_val_idx = 1; in_val_idx < in_values.size(); in_val_idx++) {
 				if (in_values[in_val_idx] - in_values[in_val_idx - 1] > one || in_values[in_val_idx - 1].is_null) {
-					is_consecutive = false;
+					can_simplify_in_clause = false;
 					break;
 				}
 			}
-			if (!is_consecutive || in_values.empty()) {
+			if (!can_simplify_in_clause) {
 				continue;
 			}
 			auto lower_bound =

--- a/src/optimizer/rule/move_constants.cpp
+++ b/src/optimizer/rule/move_constants.cpp
@@ -36,6 +36,9 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<Expr
 	if (!arithmetic->return_type.IsNumeric()) {
 		return nullptr;
 	}
+	if (inner_constant->value.is_null || outer_constant->value.is_null) {
+		return make_unique<BoundConstantExpression>(Value(comparison->return_type));
+	}
 
 	int arithmetic_child_index = arithmetic->children[0].get() == inner_constant ? 1 : 0;
 	auto &op_type = arithmetic->function.name;

--- a/src/optimizer/statistics/expression/propagate_constant.cpp
+++ b/src/optimizer/statistics/expression/propagate_constant.cpp
@@ -24,8 +24,10 @@ unique_ptr<BaseStatistics> StatisticsPropagator::StatisticsFromValue(const Value
 	case PhysicalType::VARCHAR: {
 		auto result = make_unique<StringStatistics>(input.type());
 		result->validity_stats = make_unique<ValidityStatistics>(input.is_null, !input.is_null);
-		string_t str(input.str_value.c_str(), input.str_value.size());
-		result->Update(str);
+		if (!input.is_null) {
+			string_t str(input.str_value.c_str(), input.str_value.size());
+			result->Update(str);
+		}
 		return move(result);
 	}
 	case PhysicalType::STRUCT: {

--- a/src/parser/expression/constant_expression.cpp
+++ b/src/parser/expression/constant_expression.cpp
@@ -15,7 +15,7 @@ string ConstantExpression::ToString() const {
 }
 
 bool ConstantExpression::Equals(const ConstantExpression *a, const ConstantExpression *b) {
-	return a->value == b->value;
+	return !ValueOperations::DistinctFrom(a->value, b->value);
 }
 
 hash_t ConstantExpression::Hash() const {

--- a/src/planner/expression/bound_constant_expression.cpp
+++ b/src/planner/expression/bound_constant_expression.cpp
@@ -19,7 +19,7 @@ bool BoundConstantExpression::Equals(const BaseExpression *other_p) const {
 		return false;
 	}
 	auto other = (BoundConstantExpression *)other_p;
-	return value == other->value;
+	return !ValueOperations::DistinctFrom(value, other->value);
 }
 
 hash_t BoundConstantExpression::Hash() const {

--- a/src/storage/statistics/numeric_statistics.cpp
+++ b/src/storage/statistics/numeric_statistics.cpp
@@ -91,15 +91,22 @@ NumericStatistics::NumericStatistics(LogicalType type_p, Value min_p, Value max_
 void NumericStatistics::Merge(const BaseStatistics &other_p) {
 	BaseStatistics::Merge(other_p);
 	auto &other = (const NumericStatistics &)other_p;
-	if (other.min < min) {
+	if (other.min.is_null || min.is_null) {
+		min.is_null = true;
+	} else if (other.min < min) {
 		min = other.min;
 	}
-	if (other.max > max) {
+	if (other.max.is_null || max.is_null) {
+		max.is_null = true;
+	} else if (other.max > max) {
 		max = other.max;
 	}
 }
 
 FilterPropagateResult NumericStatistics::CheckZonemap(ExpressionType comparison_type, const Value &constant) {
+	if (min.is_null || max.is_null) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
 	switch (comparison_type) {
 	case ExpressionType::COMPARE_EQUAL:
 		if (constant == min && constant == max) {

--- a/test/optimizer/table_filter_pushdown.test
+++ b/test/optimizer/table_filter_pushdown.test
@@ -6,6 +6,9 @@ statement ok
 CREATE TABLE integers(i integer, j integer, k integer)
 
 statement ok
+INSERT INTO integers VALUES (5, 5, 5), (10, 10, 10)
+
+statement ok
 PRAGMA explain_output = OPTIMIZED_ONLY;
 
 # complex filter cannot be entirely pushed down
@@ -27,42 +30,51 @@ EXPLAIN SELECT k FROM integers where j = 5 and i = 10
 logical_opt	<!REGEX>:.*FILTER.*
 
 # test different data types
-statement ok
-CREATE TABLE tablinho_numbers(i1 TINYINT, j1 TINYINT, k1 TINYINT, i2 SMALLINT, j2 SMALLINT, k2 SMALLINT, i3 INTEGER, j3 INTEGER, k3 INTEGER, i4 BIGINT, j4 BIGINT, k4 BIGINT, i5 FLOAT, j5 FLOAT, k5 FLOAT, i6 DOUBLE, j6 DOUBLE, k6 DOUBLE)
+foreach type <numeric>
 
-loop i 1 7
+statement ok
+CREATE TABLE tablinho_numbers(i ${type}, j ${type}, k ${type})
+
+statement ok
+INSERT INTO tablinho_numbers VALUES (0, 0, 0), (1, 1, 1), (2, 2, 2)
 
 # simple filters are pushed down
 query II
-EXPLAIN SELECT k${i} FROM tablinho_numbers where j${i} = 1
+EXPLAIN SELECT k FROM tablinho_numbers where j = 1
 ----
 logical_opt	<!REGEX>:.*FILTER.*
 
 query II
-EXPLAIN SELECT k${i} FROM tablinho_numbers where j${i} > 1
+EXPLAIN SELECT k FROM tablinho_numbers where j > 1
 ----
 logical_opt	<!REGEX>:.*FILTER.*
 
 query II
-EXPLAIN SELECT k${i} FROM tablinho_numbers where j${i} >= 1
+EXPLAIN SELECT k FROM tablinho_numbers where j >= 1
 ----
 logical_opt	<!REGEX>:.*FILTER.*
 
 query II
-EXPLAIN SELECT k${i} FROM tablinho_numbers where j${i} < 1
+EXPLAIN SELECT k FROM tablinho_numbers where j < 1
 ----
 logical_opt	<!REGEX>:.*FILTER.*
 
 query II
-EXPLAIN SELECT k${i} FROM tablinho_numbers where j${i} <= 1
+EXPLAIN SELECT k FROM tablinho_numbers where j <= 1
 ----
 logical_opt	<!REGEX>:.*FILTER.*
+
+statement ok
+DROP TABLE tablinho_numbers
 
 endloop
 
 # pushdown string
 statement ok
 CREATE TABLE tablinho(i varchar)
+
+statement ok
+INSERT INTO tablinho VALUES ('a'), ('bla'), ('c')
 
 # simple filters are pushed down
 query II


### PR DESCRIPTION
This fixes an edge case in the statistics propagation that can result from Parquet files with partial statistics (i.e. Parquet files that have the NULL count set, but the min/max value not set). The bug originates from the `ValueOperations::LessThan` silently operating on NULL values in the filter propagation.

I have now made it an explicit exception to run the regular value comparators on NULL values, which should fix this issue. If NULL values should be handled, the explicit `Distinct` methods should be used instead. 