### PR TITLE
RANGE/GENERATE_SERIES for timestamp + interval

### DIFF
--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -632,6 +632,8 @@ T Value::GetValueInternal() const {
 		return Cast::Operation<double, T>(value_.double_);
 	case LogicalTypeId::VARCHAR:
 		return Cast::Operation<string_t, T>(str_value.c_str());
+	case LogicalTypeId::INTERVAL:
+		return Cast::Operation<interval_t, T>(value_.interval);
 	case LogicalTypeId::DECIMAL:
 		return CastAs(LogicalType::DOUBLE).GetValueInternal<T>();
 	default:
@@ -710,6 +712,11 @@ dtime_t Value::GetValue() const {
 template <>
 timestamp_t Value::GetValue() const {
 	return GetValueInternal<timestamp_t>();
+}
+
+template <>
+DUCKDB_API interval_t Value::GetValue() const {
+	return GetValueInternal<interval_t>();
 }
 
 uintptr_t Value::GetPointer() const {

--- a/src/function/scalar/operators/arithmetic.cpp
+++ b/src/function/scalar/operators/arithmetic.cpp
@@ -296,6 +296,15 @@ struct NegateOperator {
 	}
 };
 
+template <>
+interval_t NegateOperator::Operation(interval_t input) {
+	interval_t result;
+	result.months = NegateOperator::Operation<int32_t, int32_t>(input.months);
+	result.days = NegateOperator::Operation<int32_t, int32_t>(input.days);
+	result.micros = NegateOperator::Operation<int64_t, int64_t>(input.micros);
+	return result;
+}
+
 unique_ptr<FunctionData> DecimalNegateBind(ClientContext &context, ScalarFunction &bound_function,
                                            vector<unique_ptr<Expression>> &arguments) {
 	auto &decimal_type = arguments[0]->return_type;
@@ -413,6 +422,8 @@ void SubtractFun::RegisterFunction(BuiltinFunctions &set) {
 			                                     nullptr, nullptr, NegateBindStatistics));
 		}
 	}
+	functions.AddFunction(ScalarFunction({LogicalType::INTERVAL}, LogicalType::INTERVAL,
+	                                     ScalarFunction::UnaryFunction<interval_t, interval_t, NegateOperator>));
 	set.AddFunction(functions);
 }
 

--- a/src/function/table/range.cpp
+++ b/src/function/table/range.cpp
@@ -165,7 +165,7 @@ RangeDateTimeBind(ClientContext &context, vector<Value> &inputs, unordered_map<s
 }
 
 struct RangeDateTimeState : public FunctionOperatorData {
-	RangeDateTimeState(timestamp_t start_p) : current_state(start_p) {
+	explicit RangeDateTimeState(timestamp_t start_p) : current_state(start_p) {
 	}
 
 	timestamp_t current_state;

--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -335,6 +335,8 @@ template <>
 DUCKDB_API dtime_t Value::GetValue() const;
 template <>
 DUCKDB_API timestamp_t Value::GetValue() const;
+template <>
+DUCKDB_API interval_t Value::GetValue() const;
 
 template <>
 DUCKDB_API int8_t &Value::GetValueUnsafe();

--- a/test/sql/table_function/range_timestamp.test
+++ b/test/sql/table_function/range_timestamp.test
@@ -1,0 +1,117 @@
+# name: test/sql/table_function/range_timestamp.test
+# description: Test range function with DATE/TIMESTAMP
+# group: [table_function]
+
+# date
+query I
+SELECT d::DATE FROM range(DATE '1992-01-01', DATE '1992-10-01', INTERVAL (1) MONTH) tbl(d)
+----
+1992-01-01
+1992-02-01
+1992-03-01
+1992-04-01
+1992-05-01
+1992-06-01
+1992-07-01
+1992-08-01
+1992-09-01
+
+# generate_series is inclusive
+query I
+SELECT d::DATE FROM generate_series(DATE '1992-01-01', DATE '1992-10-01', INTERVAL (1) MONTH) tbl(d)
+----
+1992-01-01
+1992-02-01
+1992-03-01
+1992-04-01
+1992-05-01
+1992-06-01
+1992-07-01
+1992-08-01
+1992-09-01
+1992-10-01
+
+# timestamp
+query I
+SELECT d FROM range(TIMESTAMP '1992-01-01 00:00:00', TIMESTAMP '1992-01-01 12:00:00', INTERVAL (1) HOUR) tbl(d)
+----
+1992-01-01 00:00:00
+1992-01-01 01:00:00
+1992-01-01 02:00:00
+1992-01-01 03:00:00
+1992-01-01 04:00:00
+1992-01-01 05:00:00
+1992-01-01 06:00:00
+1992-01-01 07:00:00
+1992-01-01 08:00:00
+1992-01-01 09:00:00
+1992-01-01 10:00:00
+1992-01-01 11:00:00
+
+# negative interval
+query I
+SELECT d FROM range(TIMESTAMP '1992-01-01 00:00:00', TIMESTAMP '1991-06-01 00:00:00', INTERVAL '1 MONTH ago') tbl(d)
+----
+1992-01-01 00:00:00
+1991-12-01 00:00:00
+1991-11-01 00:00:00
+1991-10-01 00:00:00
+1991-09-01 00:00:00
+1991-08-01 00:00:00
+1991-07-01 00:00:00
+
+query I
+SELECT d FROM generate_series(TIMESTAMP '1992-01-01 00:00:00', TIMESTAMP '1991-06-01 00:00:00', -INTERVAL '1 MONTH') tbl(d)
+----
+1992-01-01 00:00:00
+1991-12-01 00:00:00
+1991-11-01 00:00:00
+1991-10-01 00:00:00
+1991-09-01 00:00:00
+1991-08-01 00:00:00
+1991-07-01 00:00:00
+1991-06-01 00:00:00
+
+# composite interval
+query I
+SELECT d FROM range(TIMESTAMP '1992-01-01 00:00:00', TIMESTAMP '1992-12-31 12:00:00', INTERVAL '1 MONTH 1 DAY 1 HOUR') tbl(d)
+----
+1992-01-01 00:00:00
+1992-02-02 01:00:00
+1992-03-03 02:00:00
+1992-04-04 03:00:00
+1992-05-05 04:00:00
+1992-06-06 05:00:00
+1992-07-07 06:00:00
+1992-08-08 07:00:00
+1992-09-09 08:00:00
+1992-10-10 09:00:00
+1992-11-11 10:00:00
+1992-12-12 11:00:00
+
+# large result
+query I
+SELECT COUNT(*) FROM range(TIMESTAMP '1992-01-01 00:00:00', TIMESTAMP '2020-01-01 00:00:00', INTERVAL '1 DAY') tbl(d)
+----
+10227
+
+query I
+SELECT COUNT(*) FROM generate_series(TIMESTAMP '1992-01-01 00:00:00', TIMESTAMP '2020-01-01 00:00:00', INTERVAL '1 DAY') tbl(d)
+----
+10228
+
+# zero interval not supported
+statement error
+SELECT d FROM range(TIMESTAMP '1992-01-01 00:00:00', TIMESTAMP '1992-12-31 12:00:00', INTERVAL '0 MONTH') tbl(d)
+
+# start is smaller than end but we have a negative interval
+statement error
+SELECT d FROM range(TIMESTAMP '1992-01-01 00:00:00', TIMESTAMP '1992-12-31 12:00:00', INTERVAL '1 MONTH ago') tbl(d)
+
+# start is bigger than end but we have a positive interval
+statement error
+SELECT d FROM range(TIMESTAMP '1993-01-01 00:00:00', TIMESTAMP '1992-01-01 00:00:00', INTERVAL '1 MONTH') tbl(d)
+
+# composite interval with negative types not supported
+statement error
+SELECT d FROM range(TIMESTAMP '1992-01-01 00:00:00', TIMESTAMP '1992-12-31 12:00:00', INTERVAL '1 MONTH' - INTERVAL '1 HOUR') tbl(d)


### PR DESCRIPTION
This PR implements range/generate_series for timestamps with intervals (#1114), i.e. the following code works:

```sql
select * from range(date '1992-01-01', date '1992-12-01', interval '1' month);
┌─────────────────────┐
│        range        │
├─────────────────────┤
│ 1992-01-01 00:00:00 │
│ 1992-02-01 00:00:00 │
│ 1992-03-01 00:00:00 │
│ 1992-04-01 00:00:00 │
│ 1992-05-01 00:00:00 │
│ 1992-06-01 00:00:00 │
│ 1992-07-01 00:00:00 │
│ 1992-08-01 00:00:00 │
│ 1992-09-01 00:00:00 │
│ 1992-10-01 00:00:00 │
│ 1992-11-01 00:00:00 │
└─────────────────────┘
```