### PR TITLE
ODBC: Allowing to pass nullptr value to SQLSetStmtAttr

### DIFF
--- a/tools/odbc/statement.cpp
+++ b/tools/odbc/statement.cpp
@@ -6,9 +6,6 @@
 SQLRETURN SQLSetStmtAttr(SQLHSTMT statement_handle, SQLINTEGER attribute, SQLPOINTER value_ptr,
                          SQLINTEGER string_length) {
 	return duckdb::WithStatement(statement_handle, [&](duckdb::OdbcHandleStmt *stmt) {
-		if (!value_ptr) {
-			return SQL_ERROR;
-		}
 		switch (attribute) {
 		case SQL_ATTR_PARAMSET_SIZE: {
 			/* auto size = Load<SQLLEN>((data_ptr_t) value_ptr);


### PR DESCRIPTION
This PR allows to pass nullptr value to the SQLSetStmtAttr because nullptr has to be interpreted according with parameter semantic.

This PR and _isql_ tests in PR #2078 try to fix the issue #2015.