### PR TITLE
Use buffer for strftime

### DIFF
--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -1,3 +1,5 @@
+#include <cstring>
+#include <iostream>
 #include "s3fs.hpp"
 #include "crypto.hpp"
 #include "duckdb.hpp"
@@ -14,11 +16,13 @@ static HeaderMap create_s3_get_header(std::string url, std::string host, std::st
 	if (datetime_now.empty()) {
 		auto t = std::time(NULL);
 		auto tmp = std::gmtime(&t);
-		date_now.resize(8);
-		datetime_now.resize(16);
+		char buf[18];
 
-		strftime((char *)date_now.c_str(), date_now.size(), "%Y%m%d", tmp);
-		strftime((char *)datetime_now.c_str(), datetime_now.size(), "%Y%m%dT%H%M%SZ", tmp);
+		std::memset(buf, 0, sizeof(buf));
+		strftime(buf, sizeof(buf)-1, "%Y%m%d", tmp);
+		date_now = buf;
+		strftime(buf, sizeof(buf)-1, "%Y%m%dT%H%M%SZ", tmp);
+		datetime_now = buf;
 	}
 
 	HeaderMap res;


### PR DESCRIPTION
I was getting memory corruption from the code working on c_str().
I allocate a buffer for the strftime and leave the std::string
internals alone.
This code removes the cast to char * of the const char *.
The buffer is a byte larger and doesn't trust strftime to
terminate the string.

My date_now was "202107\0\0" in the debugger.  I couldn't figure out why.  My gcc version is 7.5.  My opinion was it was easier to let std::string do the copy.  It's not a malloc either.