### PR TITLE
Increase Appender buffer size, and improve appender performance when appending strings

### DIFF
--- a/benchmark/micro/CMakeLists.txt
+++ b/benchmark/micro/CMakeLists.txt
@@ -1,6 +1,7 @@
 include_directories(../../third_party/sqlite/include)
-add_library(duckdb_benchmark_micro OBJECT append.cpp bulkupdate.cpp cast.cpp
-                                          in.cpp storage.cpp)
+add_library(
+  duckdb_benchmark_micro OBJECT append.cpp append_mix.cpp bulkupdate.cpp
+                                cast.cpp in.cpp storage.cpp)
 set(BENCHMARK_OBJECT_FILES
     ${BENCHMARK_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_benchmark_micro>
     PARENT_SCOPE)

--- a/benchmark/micro/append.cpp
+++ b/benchmark/micro/append.cpp
@@ -114,7 +114,7 @@ FINISH_BENCHMARK(Append100KIntegersPREPAREDPrimary)
 		state->conn.Query(CREATE_STATEMENT);                                                                           \
 	}                                                                                                                  \
 	void RunBenchmark(DuckDBBenchmarkState *state) override {                                                          \
-		state->conn.Query("BEGIN QUERY");                                                                              \
+		state->conn.Query("BEGIN TRANSACTION");                                                                        \
 		Appender appender(state->conn, "integers");                                                                    \
 		for (int32_t i = 0; i < 100000; i++) {                                                                         \
 			appender.BeginRow();                                                                                       \

--- a/benchmark/micro/append_mix.cpp
+++ b/benchmark/micro/append_mix.cpp
@@ -36,7 +36,7 @@ using namespace duckdb;
 		}                                                                                                              \
 	}                                                                                                                  \
 	void RunBenchmark(DuckDBBenchmarkState *state) override {                                                          \
-		state->conn.Query("BEGIN QUERY");                                                                              \
+		state->conn.Query("BEGIN TRANSACTION");                                                                        \
 		Appender appender(state->conn, "test");                                                                        \
 		for (int32_t i = 0; i < 10000000; i++) {                                                                       \
 			appender.BeginRow();                                                                                       \
@@ -46,7 +46,7 @@ using namespace duckdb;
 				get_random_area_code(area_code);                                                                       \
 				appender.Append<string_t>(string_t(area_code, 6));                                                     \
 			} else {                                                                                                   \
-				appender.Append<nullptr_t>(nullptr);                                                                   \
+				appender.Append<std::nullptr_t>(nullptr);                                                              \
 			}                                                                                                          \
 			appender.Append<int32_t>(get_random_age());                                                                \
 			appender.Append<int32_t>(get_random_active());                                                             \

--- a/benchmark/micro/append_mix.cpp
+++ b/benchmark/micro/append_mix.cpp
@@ -64,7 +64,7 @@ using namespace duckdb;
 		return string();                                                                                               \
 	}                                                                                                                  \
 	string BenchmarkInfo() override {                                                                                  \
-		return "Append 10M rows to a table using an Appender";                                                        \
+		return "Append 10M rows to a table using an Appender";                                                         \
 	}                                                                                                                  \
 	size_t Timeout() override {                                                                                        \
 		return 600;                                                                                                    \

--- a/benchmark/micro/append_mix.cpp
+++ b/benchmark/micro/append_mix.cpp
@@ -53,6 +53,7 @@ using namespace duckdb;
 			appender.EndRow();                                                                                         \
 		}                                                                                                              \
 		appender.Close();                                                                                              \
+		state->conn.Query("COMMIT");                                                                                   \
 	}                                                                                                                  \
 	void Cleanup(DuckDBBenchmarkState *state) override {                                                               \
 		state->conn.Query("DROP INDEX IF EXISTS pk_index");                                                            \
@@ -63,7 +64,7 @@ using namespace duckdb;
 		return string();                                                                                               \
 	}                                                                                                                  \
 	string BenchmarkInfo() override {                                                                                  \
-		return "Append 100M rows to a table using an Appender";                                                        \
+		return "Append 10M rows to a table using an Appender";                                                        \
 	}                                                                                                                  \
 	size_t Timeout() override {                                                                                        \
 		return 600;                                                                                                    \

--- a/benchmark/micro/append_mix.cpp
+++ b/benchmark/micro/append_mix.cpp
@@ -1,0 +1,92 @@
+#include "benchmark_runner.hpp"
+#include "duckdb_benchmark_macro.hpp"
+#include "duckdb/main/appender.hpp"
+#include "duckdb/common/random_engine.hpp"
+#include "duckdb/common/types/cast_helpers.hpp"
+
+using namespace duckdb;
+
+#define APPEND_MIX_BENCHMARK(PRIMARY_KEY)                                                                              \
+	RandomEngine random;                                                                                               \
+	void Load(DuckDBBenchmarkState *state) override {                                                                  \
+		if (!PRIMARY_KEY)                                                                                              \
+			state->conn.Query("create table IF NOT EXISTS test(id INTEGER not null, area CHAR(6), age TINYINT not "    \
+			                  "null, active TINYINT not null);");                                                      \
+		else                                                                                                           \
+			state->conn.Query("create table IF NOT EXISTS test(id INTEGER primary key, area CHAR(6), age TINYINT not " \
+			                  "null, active TINYINT not null);");                                                      \
+	}                                                                                                                  \
+	int32_t get_random_age() {                                                                                         \
+		/* 5, 10, 15 */                                                                                                \
+		return 5 + 5 * random.NextRandom(0, 3);                                                                        \
+	}                                                                                                                  \
+	bool get_random_bool() {                                                                                           \
+		return random.NextRandom() > 0.5;                                                                              \
+	}                                                                                                                  \
+	int32_t get_random_active() {                                                                                      \
+		return int32_t(random.NextRandom(0, 2));                                                                       \
+	}                                                                                                                  \
+	void get_random_area_code(char *area_code) {                                                                       \
+		uint32_t code = uint32_t(random.NextRandom(0, 999999));                                                        \
+		auto endptr = area_code + 6;                                                                                   \
+		endptr = NumericHelper::FormatUnsigned(code, endptr);                                                          \
+		while (endptr > area_code) {                                                                                   \
+			*endptr = '0';                                                                                             \
+			endptr--;                                                                                                  \
+		}                                                                                                              \
+	}                                                                                                                  \
+	void RunBenchmark(DuckDBBenchmarkState *state) override {                                                          \
+		state->conn.Query("BEGIN QUERY");                                                                              \
+		Appender appender(state->conn, "test");                                                                        \
+		for (int32_t i = 0; i < 10000000; i++) {                                                                       \
+			appender.BeginRow();                                                                                       \
+			appender.Append<int32_t>(i);                                                                               \
+			if (get_random_bool()) {                                                                                   \
+				char area_code[6];                                                                                     \
+				get_random_area_code(area_code);                                                                       \
+				appender.Append<string_t>(string_t(area_code, 6));                                                     \
+			} else {                                                                                                   \
+				appender.Append<nullptr_t>(nullptr);                                                                   \
+			}                                                                                                          \
+			appender.Append<int32_t>(get_random_age());                                                                \
+			appender.Append<int32_t>(get_random_active());                                                             \
+			appender.EndRow();                                                                                         \
+		}                                                                                                              \
+		appender.Close();                                                                                              \
+	}                                                                                                                  \
+	void Cleanup(DuckDBBenchmarkState *state) override {                                                               \
+		state->conn.Query("DROP INDEX IF EXISTS pk_index");                                                            \
+		state->conn.Query("DROP TABLE IF EXISTS test");                                                                \
+		Load(state);                                                                                                   \
+	}                                                                                                                  \
+	string VerifyResult(QueryResult *result) override {                                                                \
+		return string();                                                                                               \
+	}                                                                                                                  \
+	string BenchmarkInfo() override {                                                                                  \
+		return "Append 100M rows to a table using an Appender";                                                        \
+	}                                                                                                                  \
+	size_t Timeout() override {                                                                                        \
+		return 600;                                                                                                    \
+	}
+
+DUCKDB_BENCHMARK(Appender10MRows, "[append_mix]")
+APPEND_MIX_BENCHMARK(false);
+FINISH_BENCHMARK(Appender10MRows)
+
+DUCKDB_BENCHMARK(Appender10MRowsPrimaryKey, "[append_mix]")
+APPEND_MIX_BENCHMARK(true);
+FINISH_BENCHMARK(Appender10MRowsPrimaryKey)
+
+DUCKDB_BENCHMARK(Appender10MRowsDisk, "[append_mix]")
+APPEND_MIX_BENCHMARK(false);
+bool InMemory() override {
+	return false;
+}
+FINISH_BENCHMARK(Appender10MRowsDisk)
+
+DUCKDB_BENCHMARK(Appender10MRowsDiskPrimaryKey, "[append_mix]")
+APPEND_MIX_BENCHMARK(true);
+bool InMemory() override {
+	return false;
+}
+FINISH_BENCHMARK(Appender10MRowsDiskPrimaryKey)

--- a/src/common/operator/string_cast.cpp
+++ b/src/common/operator/string_cast.cpp
@@ -146,4 +146,9 @@ duckdb::string_t StringCast::Operation(timestamp_t input, Vector &vector) {
 	return result;
 }
 
+template <>
+duckdb::string_t StringCast::Operation(duckdb::string_t input, Vector &result) {
+	return StringVector::AddStringOrBlob(result, input);
+}
+
 } // namespace duckdb

--- a/src/common/types/chunk_collection.cpp
+++ b/src/common/types/chunk_collection.cpp
@@ -120,6 +120,16 @@ void ChunkCollection::Append(DataChunk &new_chunk) {
 	}
 }
 
+void ChunkCollection::Append(unique_ptr<DataChunk> new_chunk) {
+	if (types.empty()) {
+		types = new_chunk->GetTypes();
+	}
+	D_ASSERT(types == new_chunk->GetTypes());
+	count += new_chunk->size();
+	chunks.push_back(move(new_chunk));
+}
+
+
 void ChunkCollection::Fuse(ChunkCollection &other) {
 	if (count == 0) {
 		Append(other);

--- a/src/common/types/chunk_collection.cpp
+++ b/src/common/types/chunk_collection.cpp
@@ -129,7 +129,6 @@ void ChunkCollection::Append(unique_ptr<DataChunk> new_chunk) {
 	chunks.push_back(move(new_chunk));
 }
 
-
 void ChunkCollection::Fuse(ChunkCollection &other) {
 	if (count == 0) {
 		Append(other);

--- a/src/include/duckdb/common/operator/string_cast.hpp
+++ b/src/include/duckdb/common/operator/string_cast.hpp
@@ -52,6 +52,8 @@ duckdb::string_t StringCast::Operation(double input, Vector &result);
 template <>
 duckdb::string_t StringCast::Operation(interval_t input, Vector &result);
 template <>
+duckdb::string_t StringCast::Operation(duckdb::string_t input, Vector &result);
+template <>
 duckdb::string_t StringCast::Operation(date_t input, Vector &result);
 template <>
 duckdb::string_t StringCast::Operation(dtime_t input, Vector &result);

--- a/src/include/duckdb/common/types/chunk_collection.hpp
+++ b/src/include/duckdb/common/types/chunk_collection.hpp
@@ -48,6 +48,9 @@ public:
 	//! Append a new DataChunk directly to this ChunkCollection
 	DUCKDB_API void Append(DataChunk &new_chunk);
 
+	//! Append a new DataChunk directly to this ChunkCollection
+	DUCKDB_API void Append(unique_ptr<DataChunk> new_chunk);
+
 	//! Append another ChunkCollection directly to this ChunkCollection
 	DUCKDB_API void Append(ChunkCollection &other);
 

--- a/src/include/duckdb/main/appender.hpp
+++ b/src/include/duckdb/main/appender.hpp
@@ -130,6 +130,8 @@ void DUCKDB_API Appender::Append(timestamp_t value);
 template <>
 void DUCKDB_API Appender::Append(const char *value);
 template <>
+void DUCKDB_API Appender::Append(string_t value);
+template <>
 void DUCKDB_API Appender::Append(Value value);
 template <>
 void DUCKDB_API Appender::Append(std::nullptr_t value);

--- a/src/include/duckdb/main/appender.hpp
+++ b/src/include/duckdb/main/appender.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/winapi.hpp"
 #include "duckdb/main/table_description.hpp"
+#include "duckdb/common/types/chunk_collection.hpp"
 
 namespace duckdb {
 
@@ -21,12 +22,19 @@ class Connection;
 
 //! The Appender class can be used to append elements to a table.
 class Appender {
+	//! The amount of chunks that will be gathered in the chunk collection before flushing
+	static constexpr const idx_t FLUSH_COUNT = 100;
+
 	//! A reference to a database connection that created this appender
 	shared_ptr<ClientContext> context;
 	//! The table description (including column names)
 	unique_ptr<TableDescription> description;
+	//! The append types
+	vector<LogicalType> types;
+	//! The buffered data for the append
+	ChunkCollection collection;
 	//! Internal chunk used for appends
-	DataChunk chunk;
+	unique_ptr<DataChunk> chunk;
 	//! The current column to append to
 	idx_t column = 0;
 
@@ -62,16 +70,17 @@ public:
 	//! Flush the changes made by the appender and close it. The appender cannot be used after this point
 	DUCKDB_API void Close();
 
-	//! Obtain a reference to the internal vector that is used to append to the table
-	DUCKDB_API DataChunk &GetAppendChunk() {
-		return chunk;
+	DUCKDB_API vector<LogicalType> &GetTypes() {
+		return types;
 	}
-
 	DUCKDB_API idx_t CurrentColumn() {
 		return column;
 	}
 
 private:
+	void InitializeChunk();
+	void FlushChunk();
+
 	template <class T>
 	void AppendValueInternal(T value);
 	template <class SRC, class DST>

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -27,6 +27,7 @@
 namespace duckdb {
 class Appender;
 class Catalog;
+class ChunkCollection;
 class DatabaseInstance;
 class LogicalOperator;
 class PreparedStatementData;
@@ -124,7 +125,7 @@ public:
 	//! Get the table info of a specific table, or nullptr if it cannot be found
 	DUCKDB_API unique_ptr<TableDescription> TableInfo(const string &schema_name, const string &table_name);
 	//! Appends a DataChunk to the specified table. Returns whether or not the append was successful.
-	DUCKDB_API void Append(TableDescription &description, DataChunk &chunk);
+	DUCKDB_API void Append(TableDescription &description, ChunkCollection &collection);
 	//! Try to bind a relation in the current client context; either throws an exception or fills the result_columns
 	//! list with the set of returned columns
 	DUCKDB_API void TryBindRelation(Relation &relation, vector<ColumnDefinition> &result_columns);

--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -22,6 +22,7 @@
 
 namespace duckdb {
 
+class ChunkCollection;
 class ClientContext;
 class DatabaseInstance;
 class DuckDB;
@@ -94,6 +95,8 @@ public:
 
 	//! Appends a DataChunk to the specified table
 	DUCKDB_API void Append(TableDescription &description, DataChunk &chunk);
+	//! Appends a ChunkCollection to the specified table
+	DUCKDB_API void Append(TableDescription &description, ChunkCollection &collection);
 
 	//! Returns a relation that produces a table from this connection
 	DUCKDB_API shared_ptr<Relation> Table(const string &tname);

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -17,13 +17,11 @@ Appender::Appender(Connection &con, const string &schema_name, const string &tab
 	if (!description) {
 		// table could not be found
 		throw CatalogException(StringUtil::Format("Table \"%s.%s\" could not be found", schema_name, table_name));
-	} else {
-		vector<LogicalType> types;
-		for (auto &column : description->columns) {
-			types.push_back(column.type);
-		}
-		chunk.Initialize(types);
 	}
+	for (auto &column : description->columns) {
+		types.push_back(column.type);
+	}
+	InitializeChunk();
 }
 
 Appender::Appender(Connection &con, const string &table_name) : Appender(con, DEFAULT_SCHEMA, table_name) {
@@ -38,32 +36,37 @@ Appender::~Appender() {
 	}
 }
 
+void Appender::InitializeChunk() {
+	chunk = make_unique<DataChunk>();
+	chunk->Initialize(types);
+}
+
 void Appender::BeginRow() {
 }
 
 void Appender::EndRow() {
 	// check that all rows have been appended to
-	if (column != chunk.ColumnCount()) {
+	if (column != chunk->ColumnCount()) {
 		throw InvalidInputException("Call to EndRow before all rows have been appended to!");
 	}
 	column = 0;
-	chunk.SetCardinality(chunk.size() + 1);
-	if (chunk.size() >= STANDARD_VECTOR_SIZE) {
-		Flush();
+	chunk->SetCardinality(chunk->size() + 1);
+	if (chunk->size() >= STANDARD_VECTOR_SIZE) {
+		FlushChunk();
 	}
 }
 
 template <class SRC, class DST>
 void Appender::AppendValueInternal(Vector &col, SRC input) {
-	FlatVector::GetData<DST>(col)[chunk.size()] = Cast::Operation<SRC, DST>(input);
+	FlatVector::GetData<DST>(col)[chunk->size()] = Cast::Operation<SRC, DST>(input);
 }
 
 template <class T>
 void Appender::AppendValueInternal(T input) {
-	if (column >= chunk.ColumnCount()) {
+	if (column >= types.size()) {
 		throw InvalidInputException("Too many appends for chunk!");
 	}
-	auto &col = chunk.data[column];
+	auto &col = chunk->data[column];
 	switch (col.GetType().InternalType()) {
 	case PhysicalType::BOOL:
 		AppendValueInternal<T, bool>(col, input);
@@ -192,7 +195,7 @@ void Appender::Append(timestamp_t value) {
 
 template <>
 void Appender::Append(Value value) { // NOLINT: template shtuff
-	if (column >= chunk.ColumnCount()) {
+	if (column >= chunk->ColumnCount()) {
 		throw InvalidInputException("Too many appends for chunk!");
 	}
 	AppendValue(value);
@@ -200,16 +203,27 @@ void Appender::Append(Value value) { // NOLINT: template shtuff
 
 template <>
 void Appender::Append(std::nullptr_t value) {
-	if (column >= chunk.ColumnCount()) {
+	if (column >= chunk->ColumnCount()) {
 		throw InvalidInputException("Too many appends for chunk!");
 	}
-	auto &col = chunk.data[column++];
-	FlatVector::SetNull(col, chunk.size(), true);
+	auto &col = chunk->data[column++];
+	FlatVector::SetNull(col, chunk->size(), true);
 }
 
 void Appender::AppendValue(const Value &value) {
-	chunk.SetValue(column, chunk.size(), value);
+	chunk->SetValue(column, chunk->size(), value);
 	column++;
+}
+
+void Appender::FlushChunk() {
+	if (chunk->size() == 0) {
+		return;
+	}
+	collection.Append(move(chunk));
+	InitializeChunk();
+	if (collection.ChunkCount() >= FLUSH_COUNT) {
+		Flush();
+	}
 }
 
 void Appender::Flush() {
@@ -218,17 +232,18 @@ void Appender::Flush() {
 		throw InvalidInputException("Failed to Flush appender: incomplete append to row!");
 	}
 
-	if (chunk.size() == 0) {
+	FlushChunk();
+	if (collection.Count() == 0) {
 		return;
 	}
-	context->Append(*description, chunk);
+	context->Append(*description, collection);
 
-	chunk.Reset();
+	collection.Reset();
 	column = 0;
 }
 
 void Appender::Close() {
-	if (column == 0 || column == chunk.ColumnCount()) {
+	if (column == 0 || column == types.size()) {
 		Flush();
 	}
 }

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
+#include "duckdb/common/operator/string_cast.hpp"
 
 namespace duckdb {
 
@@ -101,6 +102,9 @@ void Appender::AppendValueInternal(T input) {
 	case PhysicalType::DOUBLE:
 		AppendValueInternal<T, double>(col, input);
 		break;
+	case PhysicalType::VARCHAR:
+		FlatVector::GetData<string_t>(col)[chunk->size()] = StringCast::Operation<T>(input, col);
+		break;
 	default:
 		AppendValue(Value::CreateValue<T>(input));
 		return;
@@ -160,6 +164,11 @@ void Appender::Append(const char *value) {
 
 void Appender::Append(const char *value, uint32_t length) {
 	AppendValueInternal<string_t>(string_t(value, length));
+}
+
+template <>
+void Appender::Append(string_t value) {
+	AppendValueInternal<string_t>(value);
 }
 
 template <>

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -825,7 +825,7 @@ unique_ptr<TableDescription> ClientContext::TableInfo(const string &schema_name,
 	return result;
 }
 
-void ClientContext::Append(TableDescription &description, DataChunk &chunk) {
+void ClientContext::Append(TableDescription &description, ChunkCollection &collection) {
 	RunFunctionInTransaction([&]() {
 		auto &catalog = Catalog::GetCatalog(*this);
 		auto table_entry = catalog.GetEntry<TableCatalogEntry>(*this, description.schema, description.table);
@@ -838,7 +838,9 @@ void ClientContext::Append(TableDescription &description, DataChunk &chunk) {
 				throw Exception("Failed to append: table entry has different number of columns!");
 			}
 		}
-		table_entry->storage->Append(*table_entry, *this, chunk);
+		for(auto &chunk : collection.Chunks()) {
+			table_entry->storage->Append(*table_entry, *this, *chunk);
+		}
 	});
 }
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -838,7 +838,7 @@ void ClientContext::Append(TableDescription &description, ChunkCollection &colle
 				throw Exception("Failed to append: table entry has different number of columns!");
 			}
 		}
-		for(auto &chunk : collection.Chunks()) {
+		for (auto &chunk : collection.Chunks()) {
 			table_entry->storage->Append(*table_entry, *this, *chunk);
 		}
 	});

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -107,7 +107,13 @@ unique_ptr<LogicalOperator> Connection::ExtractPlan(const string &query) {
 }
 
 void Connection::Append(TableDescription &description, DataChunk &chunk) {
-	context->Append(description, chunk);
+	ChunkCollection collection;
+	collection.Append(chunk);
+	Append(description, collection);
+}
+
+void Connection::Append(TableDescription &description, ChunkCollection &collection) {
+	context->Append(description, collection);
 }
 
 shared_ptr<Relation> Connection::Table(const string &table_name) {

--- a/src/main/duckdb-c.cpp
+++ b/src/main/duckdb-c.cpp
@@ -1122,14 +1122,14 @@ duckdb_state duckdb_append_null(duckdb_appender appender) {
 }
 
 duckdb_state duckdb_append_varchar(duckdb_appender appender, const char *val) {
-	return duckdb_append_internal<Value>(appender, Value(val));
+	return duckdb_append_internal<const char *>(appender, val);
 }
 
 duckdb_state duckdb_append_varchar_length(duckdb_appender appender, const char *val, idx_t length) {
-	return duckdb_append_internal<Value>(appender, Value(string(val, length)));
+	return duckdb_append_internal<string_t>(appender, string_t(val, length));
 }
 duckdb_state duckdb_append_blob(duckdb_appender appender, const void *data, idx_t length) {
-	return duckdb_append_internal<Value>(appender, Value::BLOB((const_data_ptr_t)data, length));
+	return duckdb_append_internal<string_t>(appender, string_t((const char *)data, length));
 }
 
 duckdb_state duckdb_appender_flush(duckdb_appender appender) {

--- a/test/api/capi/test_capi.cpp
+++ b/test/api/capi/test_capi.cpp
@@ -760,7 +760,9 @@ TEST_CASE("Test appender statements in C API", "[capi]") {
 	status = duckdb_append_varchar_length(tappender, "hello world", 5);
 	REQUIRE(status == DuckDBSuccess);
 
-	status = duckdb_append_blob(tappender, "hello", 5);
+	auto str = strdup("hello world this is my long string");
+	status = duckdb_append_blob(tappender, str, strlen(str));
+	free(str);
 	REQUIRE(status == DuckDBSuccess);
 
 	status = duckdb_appender_end_row(tappender);
@@ -832,8 +834,8 @@ TEST_CASE("Test appender statements in C API", "[capi]") {
 	REQUIRE(result->Fetch<string>(10, 0) == "hello");
 
 	auto blob = duckdb_value_blob(&result->InternalResult(), 11, 0);
-	REQUIRE(blob.size == 5);
-	REQUIRE(memcmp(blob.data, "hello", 5) == 0);
+	REQUIRE(blob.size == 34);
+	REQUIRE(memcmp(blob.data, "hello world this is my long string", 34) == 0);
 	duckdb_free(blob.data);
 
 	REQUIRE(result->IsNull(0, 1));


### PR DESCRIPTION
This PR fixes two performance problems with the appender:

* The buffer size is increased (from 1024 entries to 102400 entries). This especially matters when the appender is used in auto-commit mode (i.e. not wrapped in a `BEGIN/COMMIT` block).
* Improve performance of appending strings, particularly from the C API, by avoiding constructing Value and string objects constantly

We also add a benchmark based on [this blog post](https://avi.im/blag/2021/fast-sqlite-inserts/), but only with 10M rows instead of 100M to avoid requiring a machine with too much memory to run the benchmarks. Results:

|       Configuration       | Time  |
|---------------------------|-------|
| In-Memory, No Primary Key | 0.97s |
| In-Memory, Primary Key    | 6.5s  |
| On-Disk, No Primary Key   | 1.66s |
| On-Disk, Primary Key      | 7.35s |

Running this locally with 100M rows confirms linear performance degradation with inserted data size:

|       Configuration       | Time  |
|---------------------------|-------|
| In-Memory, No Primary Key | 9.5s |
| In-Memory, Primary Key    | 72.9s  |
| On-Disk, No Primary Key   | 18.2s |
| On-Disk, Primary Key      | 80.4s |

