### PR TITLE
Fix #2102: Correctly reset cached chunk in join HT so nullmask gets reset

### DIFF
--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -198,7 +198,7 @@ void PhysicalHashJoin::GetChunkInternal(ExecutionContext &context, DataChunk &ch
 			if (state->cached_chunk.size() > 0) {
 				// finished probing but cached data remains, return cached chunk
 				chunk.Reference(state->cached_chunk);
-				state->cached_chunk.SetCardinality(0);
+				state->cached_chunk.Reset();
 			} else
 #endif
 			    if (IsRightOuterJoin(join_type)) {
@@ -214,7 +214,7 @@ void PhysicalHashJoin::GetChunkInternal(ExecutionContext &context, DataChunk &ch
 				if (state->cached_chunk.size() >= (STANDARD_VECTOR_SIZE - 64)) {
 					// chunk cache full: return it
 					chunk.Reference(state->cached_chunk);
-					state->cached_chunk.SetCardinality(0);
+					state->cached_chunk.Reset();
 					return;
 				} else {
 					// chunk cache not full: probe again

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -225,8 +225,8 @@ void PhysicalHashJoin::GetChunkInternal(ExecutionContext &context, DataChunk &ch
 #if STANDARD_VECTOR_SIZE >= 128
 			if (state->cached_chunk.size() > 0) {
 				// finished probing but cached data remains, return cached chunk
-				chunk.Reference(state->cached_chunk);
-				state->cached_chunk.Reset();
+				chunk.Move(state->cached_chunk);
+				state->cached_chunk.Initialize(types);
 			} else
 #endif
 			    if (IsRightOuterJoin(join_type)) {
@@ -241,8 +241,8 @@ void PhysicalHashJoin::GetChunkInternal(ExecutionContext &context, DataChunk &ch
 				state->cached_chunk.Append(chunk);
 				if (state->cached_chunk.size() >= (STANDARD_VECTOR_SIZE - 64)) {
 					// chunk cache full: return it
-					chunk.Reference(state->cached_chunk);
-					state->cached_chunk.Reset();
+					chunk.Move(state->cached_chunk);
+					state->cached_chunk.Initialize(types);
 					return;
 				} else {
 					// chunk cache not full: probe again

--- a/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
@@ -34,6 +34,8 @@ public:
 	vector<LogicalType> build_types;
 	//! Duplicate eliminated types; only used for delim_joins (i.e. correlated subqueries)
 	vector<LogicalType> delim_types;
+	//! Whether or not we can cache the chunk
+	bool can_cache;
 
 public:
 	unique_ptr<GlobalOperatorState> GetGlobalState(ClientContext &context) override;

--- a/test/sql/copy/parquet/parquet_2102.test_slow
+++ b/test/sql/copy/parquet/parquet_2102.test_slow
@@ -1,0 +1,69 @@
+# name: test/sql/copy/parquet/parquet_2102.test_slow
+# description: Missing Column Data After Adding Left Join To Query in DuckDB Version 0.2.8
+# group: [parquet]
+
+require parquet
+
+require httpfs
+
+statement ok
+CREATE TABLE view_one AS SELECT * FROM 'https://github.com/cwida/duckdb-data/releases/download/v1.0/issue2102_one.parquet';
+
+statement ok
+CREATE TABLE view_two AS SELECT * FROM 'https://github.com/cwida/duckdb-data/releases/download/v1.0/issue2102_two.parquet';
+
+query I
+SELECT COUNT(*) FROM view_one WHERE date IS NULL
+----
+6219
+
+statement ok
+CREATE TABLE tbl1 AS SELECT one.id id, one.date date
+FROM
+	view_one AS one
+JOIN
+	view_two two ON two.id = one.id AND two.line = 1;
+
+query I
+SELECT COUNT(*) FROM tbl1
+----
+691951
+
+query I
+SELECT COUNT(*) FROM tbl1 WHERE date IS NULL
+----
+4742
+
+statement ok
+CREATE TABLE tbl2 AS SELECT one.id id, one.date date
+FROM
+	view_one AS one
+LEFT JOIN
+	view_two two ON two.id = one.id AND two.line = 1;
+
+query I
+SELECT COUNT(*) FROM tbl2
+----
+695434
+
+query I
+SELECT COUNT(*) FROM tbl2 WHERE date IS NULL
+----
+6219
+
+statement ok
+CREATE TABLE tbl3 AS SELECT one.id id, one.date date
+FROM
+	view_one AS one
+LEFT JOIN
+	view_two two ON two.id = one.id;
+
+query I
+SELECT COUNT(*) FROM tbl3
+----
+768666
+
+query I
+SELECT COUNT(*) FROM tbl3 WHERE date IS NULL
+----
+7124


### PR DESCRIPTION
This PR fixes issue #2102. A regression had occurred that was caused by the validity mask not being reset properly in the join HT cache. This caused earlier NULL values to "linger around" which could cause NULL values to be (incorrectly) added to the result.