### PR TITLE
Fix #1049: Only auto-convert the SQLNULL type to INTEGER at result boundaries or when creating a table

### DIFF
--- a/src/common/vector_operations/vector_cast.cpp
+++ b/src/common/vector_operations/vector_cast.cpp
@@ -547,7 +547,7 @@ bool VectorOperations::TryCast(Vector &source, Vector &result, idx_t count, stri
 	case LogicalTypeId::LIST:
 		return ListCastSwitch(source, result, count, error_message);
 	default:
-		throw UnimplementedCast(source.GetType(), result.GetType());
+		return TryVectorNullCast(source, result, count, error_message);
 	}
 	return true;
 }

--- a/src/common/vector_operations/vector_cast.cpp
+++ b/src/common/vector_operations/vector_cast.cpp
@@ -161,17 +161,11 @@ static bool NumericCastSwitch(Vector &source, Vector &result, idx_t count, strin
 		return ToDecimalCast<SRC>(source, result, count, error_message);
 	case LogicalTypeId::VARCHAR: {
 		VectorStringCast<SRC, duckdb::StringCast>(source, result, count);
-		break;
-	}
-	case LogicalTypeId::LIST: {
-		VectorNullCast(source, result, count);
-		break;
+		return true;
 	}
 	default:
-		VectorNullCast(source, result, count);
-		break;
+		return TryVectorNullCast(source, result, count, error_message);
 	}
-	return true;
 }
 
 static bool VectorStringCastNumericSwitch(Vector &source, Vector &result, idx_t count, bool strict,
@@ -216,10 +210,8 @@ static bool VectorStringCastNumericSwitch(Vector &source, Vector &result, idx_t 
 	case LogicalTypeId::DECIMAL:
 		return ToDecimalCast<string_t>(source, result, count, error_message);
 	default:
-		VectorNullCast(source, result, count);
-		break;
+		return TryVectorNullCast(source, result, count, error_message);
 	}
-	return true;
 }
 
 static bool StringCastSwitch(Vector &source, Vector &result, idx_t count, bool strict, string *error_message) {
@@ -259,31 +251,28 @@ static bool DateCastSwitch(Vector &source, Vector &result, idx_t count, string *
 	case LogicalTypeId::VARCHAR:
 		// date to varchar
 		VectorStringCast<date_t, duckdb::StringCast>(source, result, count);
-		break;
+		return true;
 	case LogicalTypeId::TIMESTAMP:
 		// date to timestamp
 		return VectorTryCastLoop<date_t, timestamp_t, duckdb::TryCast>(source, result, count, error_message);
 	default:
-		VectorNullCast(source, result, count);
-		break;
+		return TryVectorNullCast(source, result, count, error_message);
 	}
-	return true;
 }
 
-static void TimeCastSwitch(Vector &source, Vector &result, idx_t count) {
+static bool TimeCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
 	// now switch on the result type
 	switch (result.GetType().id()) {
 	case LogicalTypeId::VARCHAR:
 		// time to varchar
 		VectorStringCast<dtime_t, duckdb::StringCast>(source, result, count);
-		break;
+		return true;
 	default:
-		VectorNullCast(source, result, count);
-		break;
+		return TryVectorNullCast(source, result, count, error_message);
 	}
 }
 
-static void TimestampCastSwitch(Vector &source, Vector &result, idx_t count) {
+static bool TimestampCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
 	// now switch on the result type
 	switch (result.GetType().id()) {
 	case LogicalTypeId::VARCHAR:
@@ -311,12 +300,12 @@ static void TimestampCastSwitch(Vector &source, Vector &result, idx_t count) {
 		UnaryExecutor::Execute<timestamp_t, timestamp_t, duckdb::CastTimestampUsToSec>(source, result, count);
 		break;
 	default:
-		VectorNullCast(source, result, count);
-		break;
+		return TryVectorNullCast(source, result, count, error_message);
 	}
+	return true;
 }
 
-static void TimestampNsCastSwitch(Vector &source, Vector &result, idx_t count) {
+static bool TimestampNsCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
 	// now switch on the result type
 	switch (result.GetType().id()) {
 	case LogicalTypeId::VARCHAR:
@@ -328,12 +317,12 @@ static void TimestampNsCastSwitch(Vector &source, Vector &result, idx_t count) {
 		UnaryExecutor::Execute<timestamp_t, timestamp_t, duckdb::CastTimestampNsToUs>(source, result, count);
 		break;
 	default:
-		VectorNullCast(source, result, count);
-		break;
+		return TryVectorNullCast(source, result, count, error_message);
 	}
+	return true;
 }
 
-static void TimestampMsCastSwitch(Vector &source, Vector &result, idx_t count) {
+static bool TimestampMsCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
 	// now switch on the result type
 	switch (result.GetType().id()) {
 	case LogicalTypeId::VARCHAR:
@@ -345,12 +334,12 @@ static void TimestampMsCastSwitch(Vector &source, Vector &result, idx_t count) {
 		UnaryExecutor::Execute<timestamp_t, timestamp_t, duckdb::CastTimestampMsToUs>(source, result, count);
 		break;
 	default:
-		VectorNullCast(source, result, count);
-		break;
+		return TryVectorNullCast(source, result, count, error_message);
 	}
+	return true;
 }
 
-static void TimestampSecCastSwitch(Vector &source, Vector &result, idx_t count) {
+static bool TimestampSecCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
 	// now switch on the result type
 	switch (result.GetType().id()) {
 	case LogicalTypeId::VARCHAR:
@@ -362,12 +351,12 @@ static void TimestampSecCastSwitch(Vector &source, Vector &result, idx_t count) 
 		UnaryExecutor::Execute<timestamp_t, timestamp_t, duckdb::CastTimestampSecToUs>(source, result, count);
 		break;
 	default:
-		VectorNullCast(source, result, count);
-		break;
+		return TryVectorNullCast(source, result, count, error_message);
 	}
+	return true;
 }
 
-static void IntervalCastSwitch(Vector &source, Vector &result, idx_t count) {
+static bool IntervalCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
 	// now switch on the result type
 	switch (result.GetType().id()) {
 	case LogicalTypeId::VARCHAR:
@@ -375,12 +364,12 @@ static void IntervalCastSwitch(Vector &source, Vector &result, idx_t count) {
 		VectorStringCast<interval_t, duckdb::StringCast>(source, result, count);
 		break;
 	default:
-		VectorNullCast(source, result, count);
-		break;
+		return TryVectorNullCast(source, result, count, error_message);
 	}
+	return true;
 }
 
-static void BlobCastSwitch(Vector &source, Vector &result, idx_t count) {
+static bool BlobCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
 	// now switch on the result type
 	switch (result.GetType().id()) {
 	case LogicalTypeId::VARCHAR:
@@ -388,12 +377,12 @@ static void BlobCastSwitch(Vector &source, Vector &result, idx_t count) {
 		VectorStringCast<string_t, duckdb::CastFromBlob>(source, result, count);
 		break;
 	default:
-		VectorNullCast(source, result, count);
-		break;
+		return TryVectorNullCast(source, result, count, error_message);
 	}
+	return true;
 }
 
-static void ValueStringCastSwitch(Vector &source, Vector &result, idx_t count) {
+static bool ValueStringCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
 	switch (result.GetType().id()) {
 	case LogicalTypeId::VARCHAR:
 		if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
@@ -406,14 +395,13 @@ static void ValueStringCastSwitch(Vector &source, Vector &result, idx_t count) {
 			auto str_val = src_val.ToString();
 			result.SetValue(i, Value(str_val));
 		}
-		break;
+		return true;
 	default:
-		VectorNullCast(source, result, count);
-		break;
+		return TryVectorNullCast(source, result, count, error_message);
 	}
 }
 
-static void ListCastSwitch(Vector &source, Vector &result, idx_t count) {
+static bool ListCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
 	switch (result.GetType().id()) {
 	case LogicalTypeId::LIST: {
 		// only handle constant and flat vectors here for now
@@ -444,15 +432,14 @@ static void ListCastSwitch(Vector &source, Vector &result, idx_t count) {
 		VectorOperations::Cast(source_cc, append_vector, source_size);
 		ListVector::SetListSize(result, source_size);
 		D_ASSERT(ListVector::GetListSize(result) == source_size);
-		break;
+		return true;
 	}
 	default:
-		ValueStringCastSwitch(source, result, count);
-		break;
+		return ValueStringCastSwitch(source, result, count, error_message);
 	}
 }
 
-static void StructCastSwitch(Vector &source, Vector &result, idx_t count) {
+static bool StructCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
 	switch (result.GetType().id()) {
 	case LogicalTypeId::STRUCT:
 	case LogicalTypeId::MAP: {
@@ -481,8 +468,7 @@ static void StructCastSwitch(Vector &source, Vector &result, idx_t count) {
 			source.Normalify(count);
 			FlatVector::Validity(result) = FlatVector::Validity(source);
 		}
-
-		break;
+		return true;
 	}
 	case LogicalTypeId::VARCHAR:
 		if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
@@ -495,11 +481,9 @@ static void StructCastSwitch(Vector &source, Vector &result, idx_t count) {
 			auto str_val = src_val.ToString();
 			result.SetValue(i, Value(str_val));
 		}
-		break;
-
+		return true;
 	default:
-		VectorNullCast(source, result, count);
-		break;
+		return TryVectorNullCast(source, result, count, error_message);
 	}
 }
 
@@ -536,28 +520,21 @@ bool VectorOperations::TryCast(Vector &source, Vector &result, idx_t count, stri
 	case LogicalTypeId::DATE:
 		return DateCastSwitch(source, result, count, error_message);
 	case LogicalTypeId::TIME:
-		TimeCastSwitch(source, result, count);
-		break;
+		return TimeCastSwitch(source, result, count, error_message);
 	case LogicalTypeId::TIMESTAMP:
-		TimestampCastSwitch(source, result, count);
-		break;
+		return TimestampCastSwitch(source, result, count, error_message);
 	case LogicalTypeId::TIMESTAMP_NS:
-		TimestampNsCastSwitch(source, result, count);
-		break;
+		return TimestampNsCastSwitch(source, result, count, error_message);
 	case LogicalTypeId::TIMESTAMP_MS:
-		TimestampMsCastSwitch(source, result, count);
-		break;
+		return TimestampMsCastSwitch(source, result, count, error_message);
 	case LogicalTypeId::TIMESTAMP_SEC:
-		TimestampSecCastSwitch(source, result, count);
-		break;
+		return TimestampSecCastSwitch(source, result, count, error_message);
 	case LogicalTypeId::INTERVAL:
-		IntervalCastSwitch(source, result, count);
-		break;
+		return IntervalCastSwitch(source, result, count, error_message);
 	case LogicalTypeId::VARCHAR:
 		return StringCastSwitch(source, result, count, strict, error_message);
 	case LogicalTypeId::BLOB:
-		BlobCastSwitch(source, result, count);
-		break;
+		return BlobCastSwitch(source, result, count, error_message);
 	case LogicalTypeId::SQLNULL: {
 		// cast a NULL to another type, just copy the properties and change the type
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
@@ -566,11 +543,9 @@ bool VectorOperations::TryCast(Vector &source, Vector &result, idx_t count, stri
 	}
 	case LogicalTypeId::MAP:
 	case LogicalTypeId::STRUCT:
-		StructCastSwitch(source, result, count);
-		break;
+		return StructCastSwitch(source, result, count, error_message);
 	case LogicalTypeId::LIST:
-		ListCastSwitch(source, result, count);
-		break;
+		return ListCastSwitch(source, result, count, error_message);
 	default:
 		throw UnimplementedCast(source.GetType(), result.GetType());
 	}

--- a/src/include/duckdb/common/vector_operations/decimal_cast.hpp
+++ b/src/include/duckdb/common/vector_operations/decimal_cast.hpp
@@ -342,8 +342,7 @@ static bool DecimalCastSwitch(Vector &source, Vector &result, idx_t count, strin
 		return true;
 	}
 	default:
-		VectorNullCast(source, result, count);
-		return true;
+		return TryVectorNullCast(source, result, count, error_message);
 	}
 }
 

--- a/src/include/duckdb/common/vector_operations/general_cast.hpp
+++ b/src/include/duckdb/common/vector_operations/general_cast.hpp
@@ -44,8 +44,4 @@ static bool TryVectorNullCast(Vector &source, Vector &result, idx_t count, strin
 	return success;
 }
 
-static void VectorNullCast(Vector &source, Vector &result, idx_t count) {
-	TryVectorNullCast(source, result, count, nullptr);
-}
-
 } // namespace duckdb

--- a/src/include/duckdb/common/vector_operations/general_cast.hpp
+++ b/src/include/duckdb/common/vector_operations/general_cast.hpp
@@ -28,10 +28,6 @@ static string UnimplementedCastMessage(const LogicalType &source_type, const Log
 	return StringUtil::Format("Unimplemented type for cast (%s -> %s)", source_type.ToString(), target_type.ToString());
 }
 
-static NotImplementedException UnimplementedCast(const LogicalType &source_type, const LogicalType &target_type) {
-	return NotImplementedException(UnimplementedCastMessage(source_type, target_type));
-}
-
 // NULL cast only works if all values in source are NULL, otherwise an unimplemented cast exception is thrown
 static bool TryVectorNullCast(Vector &source, Vector &result, idx_t count, string *error_message) {
 	bool success = true;

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -151,6 +151,8 @@ private:
 	bool plan_subquery = true;
 	//! Whether CTEs should reference the parent binder (if it exists)
 	bool inherit_ctes = true;
+	//! Whether or not the binder can contain NULLs as the root of expressions
+	bool can_contain_nulls = false;
 	//! The root statement of the query that is currently being parsed
 	SQLStatement *root_statement = nullptr;
 

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -75,6 +75,8 @@ public:
 	void BindChild(unique_ptr<ParsedExpression> &expr, idx_t depth, string &error);
 	static void ExtractCorrelatedExpressions(Binder &binder, Expression &expr);
 
+	static bool ContainsNullType(const LogicalType &type);
+	static LogicalType ExchangeNullType(const LogicalType &type);
 protected:
 	virtual BindResult BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth,
 	                                  bool root_expression = false);

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -77,6 +77,7 @@ public:
 
 	static bool ContainsNullType(const LogicalType &type);
 	static LogicalType ExchangeNullType(const LogicalType &type);
+
 protected:
 	virtual BindResult BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth,
 	                                  bool root_expression = false);

--- a/src/planner/binder/expression/bind_subquery_expression.cpp
+++ b/src/planner/binder/expression/bind_subquery_expression.cpp
@@ -32,6 +32,7 @@ BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t dept
 		D_ASSERT(depth == 0);
 		// first bind the actual subquery in a new binder
 		auto subquery_binder = Binder::CreateBinder(context, &binder);
+		subquery_binder->can_contain_nulls = true;
 		auto bound_node = subquery_binder->BindNode(*expr.subquery->node);
 		// check the correlated columns of the subquery for correlated columns with depth > 1
 		for (idx_t i = 0; i < subquery_binder->correlated_columns.size(); i++) {

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -51,6 +51,8 @@ void Binder::BindCreateViewInfo(CreateViewInfo &base) {
 	// bind the view as if it were a query so we can catch errors
 	// note that we bind the original, and replace the original with a copy
 	// this is because the original has
+	this->can_contain_nulls = true;
+
 	auto copy = base.query->Copy();
 	auto query_node = Bind(*base.query);
 	base.query = unique_ptr_cast<SQLStatement, SelectStatement>(move(copy));
@@ -123,7 +125,6 @@ BoundStatement Binder::Bind(CreateStatement &stmt) {
 		auto &base = (CreateViewInfo &)*stmt.info;
 		// bind the schema
 		auto schema = BindSchema(*stmt.info);
-
 		BindCreateViewInfo(base);
 		result.plan = make_unique<LogicalCreate>(LogicalOperatorType::LOGICAL_CREATE_VIEW, move(stmt.info), schema);
 		break;

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -109,6 +109,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		// for the view and for the current query
 		bool inherit_ctes = false;
 		auto view_binder = Binder::CreateBinder(context, this, inherit_ctes);
+		view_binder->can_contain_nulls = true;
 		SubqueryRef subquery(unique_ptr_cast<SQLStatement, SelectStatement>(view_catalog_entry->query->Copy()));
 		subquery.alias = ref.alias.empty() ? ref.table_name : ref.alias;
 		subquery.column_name_alias =

--- a/src/planner/binder/tableref/bind_subqueryref.cpp
+++ b/src/planner/binder/tableref/bind_subqueryref.cpp
@@ -6,6 +6,7 @@ namespace duckdb {
 
 unique_ptr<BoundTableRef> Binder::Bind(SubqueryRef &ref, CommonTableExpressionInfo *cte) {
 	auto binder = Binder::CreateBinder(context, this);
+	binder->can_contain_nulls = true;
 	if (cte) {
 		binder->bound_ctes.insert(cte);
 	}

--- a/test/sql/binder/test_null_type_propagation.test
+++ b/test/sql/binder/test_null_type_propagation.test
@@ -1,0 +1,189 @@
+# name: test/sql/binder/test_null_type_propagation.test
+# description: Test binding of NULL type
+# group: [binder]
+
+statement ok
+PRAGMA enable_verification
+
+# regular binding
+query I
+SELECT NULL
+----
+NULL
+
+# union
+query I
+SELECT NULL UNION ALL SELECT CAST(1 AS BOOLEAN)
+----
+NULL
+True
+
+query I
+SELECT NULL UNION ALL SELECT NULL
+----
+NULL
+NULL
+
+# mutliple unions
+query I
+SELECT NULL UNION ALL SELECT NULL UNION ALL SELECT NULL UNION ALL SELECT NULL UNION ALL SELECT CAST(1 AS BOOLEAN)
+----
+NULL
+NULL
+NULL
+NULL
+True
+
+# scalar subquery
+query I
+SELECT (SELECT NULL) UNION ALL SELECT CAST(1 AS BOOLEAN)
+----
+NULL
+True
+
+# table subquery
+query I
+SELECT * FROM (SELECT NULL) tbl(i) UNION ALL SELECT CAST(1 AS BOOLEAN)
+----
+NULL
+True
+
+query I
+SELECT * FROM (SELECT (SELECT NULL) UNION ALL SELECT CAST(1 AS BOOLEAN)) tbl(i)
+----
+NULL
+True
+
+query I
+SELECT * FROM (SELECT NULL) tbl(i) UNION ALL SELECT NULL
+----
+NULL
+NULL
+
+# bool_and
+query I
+SELECT bool_and(i) FROM (SELECT * FROM (SELECT NULL) tbl(i) UNION ALL SELECT CAST(1 as BOOLEAN)) tbl(i)
+----
+True
+
+# this wouldn't work if we would upcast to integer
+statement error
+SELECT bool_and(i) FROM (SELECT * FROM (SELECT NULL::INTEGER) tbl(i) UNION ALL SELECT CAST(1 as BOOLEAN)) tbl(i)
+
+# cross product
+query II
+SELECT * FROM (SELECT NULL) tbl(i), (SELECT NULL) tbl2(j)
+----
+NULL	NULL
+
+query II
+SELECT bool_and(i), bool_and(j) FROM (SELECT NULL) tbl(i), (SELECT NULL) tbl2(j)
+----
+NULL	NULL
+
+# Issue #1049: Should a UNION with untyped NULL preserve the type?
+query III
+SELECT NULL as a, NULL as b, 1 as id UNION SELECT CAST(1 AS BOOLEAN) as a, CAST(0 AS BOOLEAN) as b, 2 as id
+----
+NULL	NULL	1
+True	False	2
+
+query III
+SELECT CAST(1 AS BOOLEAN) as a, CAST(0 AS BOOLEAN) as b, 1 as id UNION SELECT NULL as a, NULL as b, 2 as id
+----
+True	False	1
+NULL	NULL	2
+
+# old behavior: cast NULL to integer explicitly
+query III
+SELECT NULL::INTEGER as a, NULL::INTEGER as b, 1 as id UNION SELECT CAST(1 AS BOOLEAN) as a, CAST(0 AS BOOLEAN) as b, 2 as id
+----
+NULL	NULL	1
+1	0	2
+
+query III
+SELECT CAST(1 AS BOOLEAN) as a, CAST(0 AS BOOLEAN) as b, 1 as id UNION SELECT NULL::INTEGER as a, NULL::INTEGER as b, 2 as id
+----
+1	0	1
+NULL	NULL	2
+
+# NULL is auto-cast to integer for storage purposes
+statement ok
+CREATE TABLE tbl AS SELECT NULL UNION ALL SELECT NULL
+
+query I
+SELECT * FROM tbl
+----
+NULL
+NULL
+
+query I
+SELECT typeof(#1) FROM tbl LIMIT 1
+----
+INTEGER
+
+# views preserve NULLs
+statement ok
+CREATE VIEW v1 AS SELECT NULL
+
+query I
+SELECT * FROM v1
+----
+NULL
+
+query I
+SELECT * FROM v1 UNION ALL SELECT CAST(1 AS BOOLEAN)
+----
+NULL
+True
+
+query I
+SELECT typeof(#1) FROM v1
+----
+NULL
+
+# also with unions
+statement ok
+CREATE VIEW v2 AS SELECT NULL UNION ALL SELECT NULL
+
+query I
+SELECT * FROM v2
+----
+NULL
+NULL
+
+query I
+SELECT * FROM v2 UNION ALL SELECT CAST(1 AS BOOLEAN)
+----
+NULL
+NULL
+True
+
+query I
+SELECT typeof(#1) FROM v2 LIMIT 1
+----
+NULL
+
+# nulls in lists
+query I
+SELECT [NULL]
+----
+[NULL]
+
+query I
+SELECT [NULL] UNION ALL SELECT [True]
+----
+[NULL]
+[True]
+
+# nulls in structs
+query I
+SELECT [NULL]
+----
+[NULL]
+
+query I
+SELECT {'x': NULL} UNION ALL SELECT {'x': True}
+----
+{'x': NULL}
+{'x': True}

--- a/test/sql/binder/test_null_type_propagation.test
+++ b/test/sql/binder/test_null_type_propagation.test
@@ -178,9 +178,9 @@ SELECT [NULL] UNION ALL SELECT [True]
 
 # nulls in structs
 query I
-SELECT [NULL]
+SELECT {'x': NULL}
 ----
-[NULL]
+{'x': NULL}
 
 query I
 SELECT {'x': NULL} UNION ALL SELECT {'x': True}

--- a/test/sql/binder/test_null_type_propagation.test
+++ b/test/sql/binder/test_null_type_propagation.test
@@ -187,3 +187,17 @@ SELECT {'x': NULL} UNION ALL SELECT {'x': True}
 ----
 {'x': NULL}
 {'x': True}
+
+# ctes
+query I
+WITH cte AS (SELECT NULL)
+SELECT * FROM cte
+----
+NULL
+
+query I
+WITH cte AS (SELECT NULL)
+SELECT * FROM cte UNION ALL SELECT CAST(1 AS BOOLEAN)
+----
+NULL
+True


### PR DESCRIPTION
This allows the SQLNULL type to continue to exist past union, view, subquery and CTE boundaries. 