### PR TITLE
Extend function documentation in duckdb.h and generate website docs from comments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1261,3 +1261,26 @@ jobs:
         name: duckdb-wasm32-nothreads
         path: |
           duckdb-wasm32-nothreads.zip
+
+  docs:
+    name: Website Docs
+    runs-on: ubuntu-20.04
+    needs: linux-debug
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Clone Website
+      run: git clone https://github.com/duckdb/duckdb-web
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+
+    - name: Package
+      run: |
+        cd duckdb-web
+        python3 scripts/generate_docs.py ..

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -158,68 +158,239 @@ typedef enum { DuckDBSuccess = 0, DuckDBError = 1 } duckdb_state;
 //===--------------------------------------------------------------------===//
 // Open/Connect
 //===--------------------------------------------------------------------===//
-//! Opens a database file at the given path (nullptr for in-memory). Returns DuckDBSuccess on success, or DuckDBError on
-//! failure. [OUT: database]
+
+/*!
+Creates a new database or opens an existing database file stored at the the given path.
+If no path is given a new in-memory database is created instead.
+
+* path: Path to the database file on disk, or `nullptr` or `:memory:` to open an in-memory database.
+* out_database: The result database object.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
 DUCKDB_API duckdb_state duckdb_open(const char *path, duckdb_database *out_database);
-//! Opens a database file at the given path using the specified configuration
-//! If error is set the error will be reported
+
+/*!
+Extended version of duckdb_open. Creates a new database or opens an existing database file stored at the the given path.
+
+* path: Path to the database file on disk, or `nullptr` or `:memory:` to open an in-memory database.
+* out_database: The result database object.
+* config: (Optional) configuration used to start up the database system.
+* out_error: If set and the function returns DuckDBError, this will contain the reason why the start-up failed.
+Note that the error must be freed using `duckdb_free`.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
 DUCKDB_API duckdb_state duckdb_open_ext(const char *path, duckdb_database *out_database, duckdb_config config,
-                                        char **error);
-//! Closes the database.
+                                        char **out_error);
+
+/*!
+Closes the specified database and de-allocates all memory allocated for that database.
+This should be called after you are done with any database allocated through `duckdb_open`.
+Note that failing to call `duckdb_close` (in case of e.g. a program crash) will not cause data corruption.
+Still it is recommended to always correctly close a database object after you are done with it.
+
+* database: The database object to shut down.
+*/
 DUCKDB_API void duckdb_close(duckdb_database *database);
 
-//! Creates a connection to the specified database. [OUT: connection]
+/*!
+Opens a connection to a database. Connections are required to query the database, and store transactional state
+associated with the connection.
+
+* database: The database file to connect to.
+* out_connection: The result connection object.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
 DUCKDB_API duckdb_state duckdb_connect(duckdb_database database, duckdb_connection *out_connection);
-//! Closes the specified connection handle
+
+/*!
+Closes the specified connection and de-allocates all memory allocated for that connection.
+
+* connection: The connection to close.
+*/
 DUCKDB_API void duckdb_disconnect(duckdb_connection *connection);
-
-//! Executes the specified SQL query in the specified connection handle. [OUT: result descriptor]
-DUCKDB_API duckdb_state duckdb_query(duckdb_connection connection, const char *query, duckdb_result *out_result);
-//! Destroys the specified result
-DUCKDB_API void duckdb_destroy_result(duckdb_result *result);
-
-//===--------------------------------------------------------------------===//
-// Result Helpers
-//===--------------------------------------------------------------------===//
-//! Returns the column name of the specified column. The result does not need to be freed;
-//! the column names will automatically be destroyed when the result is destroyed.
-DUCKDB_API const char *duckdb_column_name(duckdb_result *result, idx_t col);
-//! Returns the column type of the specified column.
-DUCKDB_API duckdb_type duckdb_column_type(duckdb_result *result, idx_t col);
-//! Returns the number of columns in the result.
-DUCKDB_API idx_t duckdb_column_count(duckdb_result *result);
-//! Returns the number of rows in the result.
-DUCKDB_API idx_t duckdb_row_count(duckdb_result *result);
-//! Returns the number of rows changed in the result (relevant for INSERT/UPDATE/DELETE queries)
-DUCKDB_API idx_t duckdb_rows_changed(duckdb_result *result);
-
-//! Returns the data of a specific column of a result in columnar format.
-//! The type of the data depends on the corresponding duckdb_type (as provided in duckdb_column_type).
-//! For the exact type in which the data should be accessed, see the comments in DUCKDB_TYPE.
-//! e.g. for a column of type DUCKDB_TYPE_INTEGER, you can access rows like so:
-//! int32_t *data = (int32_t *) duckdb_column_data(&result, 0);
-//! printf("Data for row %d: %d\n", row, data[row]);
-DUCKDB_API void *duckdb_column_data(duckdb_result *result, idx_t col);
-//! Returns the nullmask of a specific column of a result in columnar format.
-//! The nullmask can be accessed as a boolean array.
-DUCKDB_API bool *duckdb_nullmask_data(duckdb_result *result, idx_t col);
 
 //===--------------------------------------------------------------------===//
 // Configuration
 //===--------------------------------------------------------------------===//
-//! Creates a DuckDB configuration object. The created object must be destroyed with duckdb_destroy_config.
+/*!
+Initializes an empty configuration object that can be used to provide start-up options for the DuckDB instance
+through `duckdb_open_ext`.
+
+This will always succeed unless there is a malloc failure.
+
+* out_config: The result configuration object.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
 DUCKDB_API duckdb_state duckdb_create_config(duckdb_config *out_config);
-//! Returns the amount of config options available.
-//! Should not be called in a loop as it internally loops over all the options.
+
+/*!
+This returns the total amount of configuration options available for usage with `duckdb_get_config_flag`.
+
+This should not be called in a loop as it internally loops over all the options.
+
+* returns: The amount of config options available.
+*/
 DUCKDB_API size_t duckdb_config_count();
-//! Returns the config name and description for the config at the specified index
-//! The result MUST NOT be freed
-//! Returns failure if the index is out of range (i.e. >= duckdb_config_count)
+
+/*!
+Obtains a human-readable name and description of a specific configuration option. This can be used to e.g.
+display configuration options. This will succeed unless `index` is out of range (i.e. `>= duckdb_config_count`).
+
+The result name or description MUST NOT be freed.
+
+* index: The index of the configuration option (between 0 and `duckdb_config_count`)
+* out_name: A name of the configuration flag.
+* out_description: A description of the configuration flag.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
 DUCKDB_API duckdb_state duckdb_get_config_flag(size_t index, const char **out_name, const char **out_description);
-//! Sets the specified config option for the configuration
+
+/*!
+Sets the specified option for the specified configuration. The configuration option is indicated by name.
+To obtain a list of config options, see `duckdb_get_config_flag`.
+
+In the source code, configuration options are defined in `config.cpp`.
+
+This can fail if either the name is invalid, or if the value provided for the option is invalid.
+
+* duckdb_config: The configuration object to set the option on.
+* name: The name of the configuration flag to set.
+* option: The value to set the configuration flag to.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
 DUCKDB_API duckdb_state duckdb_set_config(duckdb_config config, const char *name, const char *option);
-//! Destroys a config object created with duckdb_create_config
+
+/*!
+Destroys the specified configuration option and de-allocates all memory allocated for the object.
+
+* config: The configuration object to destroy.
+*/
 DUCKDB_API void duckdb_destroy_config(duckdb_config *config);
+
+//===--------------------------------------------------------------------===//
+// Query Execution
+//===--------------------------------------------------------------------===//
+/*!
+Executes a SQL query within a connection and stores the full (materialized) result in the out_result pointer.
+If the query fails to execute, DuckDBError is returned and the error message can be retrieved by calling
+`duckdb_result_error`.
+
+Note that after running `duckdb_query`, `duckdb_destroy_result` must be called on the result object even if the
+query fails, otherwise the error stored within the result will not be freed correctly.
+
+* connection: The connection to perform the query in.
+* query: The SQL query to run.
+* out_result: The query result.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
+DUCKDB_API duckdb_state duckdb_query(duckdb_connection connection, const char *query, duckdb_result *out_result);
+
+/*!
+Closes the result and de-allocates all memory allocated for that connection.
+
+* result: The result to destroy.
+*/
+DUCKDB_API void duckdb_destroy_result(duckdb_result *result);
+
+/*!
+Returns the column name of the specified column. The result should not need be freed; the column names will
+automatically be destroyed when the result is destroyed.
+
+Returns `NULL` if the column is out of range.
+
+* result: The result object to fetch the column name from.
+* col: The column index.
+* returns: The column name of the specified column.
+*/
+DUCKDB_API const char *duckdb_column_name(duckdb_result *result, idx_t col);
+
+/*!
+Returns the column type of the specified column.
+
+Returns `DUCKDB_TYPE_INVALID` if the column is out of range.
+
+* result: The result object to fetch the column type from.
+* col: The column index.
+* returns: The column type of the specified column.
+*/
+DUCKDB_API duckdb_type duckdb_column_type(duckdb_result *result, idx_t col);
+
+/*!
+Returns the number of columns present in a the result object.
+
+* result: The result object.
+* returns: The number of columns present in the result object.
+*/
+DUCKDB_API idx_t duckdb_column_count(duckdb_result *result);
+
+/*!
+Returns the number of rows present in a the result object.
+
+* result: The result object.
+* returns: The number of rows present in the result object.
+*/
+DUCKDB_API idx_t duckdb_row_count(duckdb_result *result);
+
+/*!
+Returns the number of rows changed by the query stored in the result. This is relevant only for INSERT/UPDATE/DELETE
+queries. For other queries the rows_changed will be 0.
+
+* result: The result object.
+* returns: The number of rows changed.
+*/
+DUCKDB_API idx_t duckdb_rows_changed(duckdb_result *result);
+
+/*!
+Returns the data of a specific column of a result in columnar format. This is the fastest way of accessing data in a
+query result, as no conversion or type checking must be performed (outside of the original switch). If performance
+is a concern, it is recommended to use this API over the `duckdb_value` functions.
+
+The function returns a dense array which contains the result data. The exact type stored in the array depends on the
+corresponding duckdb_type (as provided by `duckdb_column_type`). For the exact type by which the data should be
+accessed, see the comments in [the types section](types) or the `DUCKDB_TYPE` enum.
+
+For example, for a column of type `DUCKDB_TYPE_INTEGER`, rows can be accessed in the following manner:
+```c
+int32_t *data = (int32_t *) duckdb_column_data(&result, 0);
+printf("Data for row %d: %d\n", row, data[row]);
+```
+
+* result: The result object to fetch the column data from.
+* col: The column index.
+* returns: The column data of the specified column.
+*/
+DUCKDB_API void *duckdb_column_data(duckdb_result *result, idx_t col);
+
+/*!
+Returns the nullmask of a specific column of a result in columnar format. The nullmask indicates for every row
+whether or not the corresponding row is `NULL`. If a row is `NULL`, the values present in the array provided
+by `duckdb_column_data` are undefined.
+
+```c
+int32_t *data = (int32_t *) duckdb_column_data(&result, 0);
+bool *nullmask = duckdb_nullmask_data(&result, 0);
+if (nullmask[row]) {
+    printf("Data for row %d: NULL\n", row);
+} else {
+    printf("Data for row %d: %d\n", row, data[row]);
+}
+```
+
+* result: The result object to fetch the nullmask from.
+* col: The column index.
+* returns: The nullmask of the specified column.
+*/
+DUCKDB_API bool *duckdb_nullmask_data(duckdb_result *result, idx_t col);
+
+/*!
+Returns the error message contained within the result. The error is only set if `duckdb_query` returns `DuckDBError`.
+
+The result of this function must not be freed. It will be cleaned up when `duckdb_destroy_result` is called.
+
+* result: The result object to fetch the nullmask from.
+* returns: The error of the result.
+*/
+DUCKDB_API char *duckdb_result_error(duckdb_result *result);
 
 //===--------------------------------------------------------------------===//
 // Result Functions
@@ -231,194 +402,647 @@ DUCKDB_API void duckdb_destroy_config(duckdb_config *config);
 // Note that these functions are slow since they perform bounds checking and conversion
 // For fast access of values prefer using duckdb_column_data and duckdb_nullmask_data
 
-//! Converts the specified value to a bool. Returns false on failure or NULL.
+/*!
+ * returns: The boolean value at the specified location, or false if the value cannot be converted.
+ */
 DUCKDB_API bool duckdb_value_boolean(duckdb_result *result, idx_t col, idx_t row);
-//! Converts the specified value to an int8_t. Returns 0 on failure or NULL.
+
+/*!
+ * returns: The int8_t value at the specified location, or 0 if the value cannot be converted.
+ */
 DUCKDB_API int8_t duckdb_value_int8(duckdb_result *result, idx_t col, idx_t row);
-//! Converts the specified value to an int16_t. Returns 0 on failure or NULL.
+
+/*!
+ * returns: The int16_t value at the specified location, or 0 if the value cannot be converted.
+ */
 DUCKDB_API int16_t duckdb_value_int16(duckdb_result *result, idx_t col, idx_t row);
-//! Converts the specified value to an int64_t. Returns 0 on failure or NULL.
+
+/*!
+ * returns: The int32_t value at the specified location, or 0 if the value cannot be converted.
+ */
 DUCKDB_API int32_t duckdb_value_int32(duckdb_result *result, idx_t col, idx_t row);
-//! Converts the specified value to an int64_t. Returns 0 on failure or NULL.
+
+/*!
+ * returns: The int64_t value at the specified location, or 0 if the value cannot be converted.
+ */
 DUCKDB_API int64_t duckdb_value_int64(duckdb_result *result, idx_t col, idx_t row);
-//! Converts the specified value to an duckdb_hugeint. Returns 0 on failure or NULL.
+
+/*!
+ * returns: The duckdb_hugeint value at the specified location, or 0 if the value cannot be converted.
+ */
 DUCKDB_API duckdb_hugeint duckdb_value_hugeint(duckdb_result *result, idx_t col, idx_t row);
 
-//! Converts the specified value to an uint8_t. Returns 0 on failure or NULL.
+/*!
+ * returns: The uint8_t value at the specified location, or 0 if the value cannot be converted.
+ */
 DUCKDB_API uint8_t duckdb_value_uint8(duckdb_result *result, idx_t col, idx_t row);
-//! Converts the specified value to an uint16_t. Returns 0 on failure or NULL.
+
+/*!
+ * returns: The uint16_t value at the specified location, or 0 if the value cannot be converted.
+ */
 DUCKDB_API uint16_t duckdb_value_uint16(duckdb_result *result, idx_t col, idx_t row);
-//! Converts the specified value to an uint32_t. Returns 0 on failure or NULL.
+
+/*!
+ * returns: The uint32_t value at the specified location, or 0 if the value cannot be converted.
+ */
 DUCKDB_API uint32_t duckdb_value_uint32(duckdb_result *result, idx_t col, idx_t row);
-//! Converts the specified value to an uint64_t. Returns 0 on failure or NULL.
+
+/*!
+ * returns: The uint64_t value at the specified location, or 0 if the value cannot be converted.
+ */
 DUCKDB_API uint64_t duckdb_value_uint64(duckdb_result *result, idx_t col, idx_t row);
 
-//! Converts the specified value to a float. Returns 0.0 on failure or NULL.
+/*!
+ * returns: The float value at the specified location, or 0 if the value cannot be converted.
+ */
 DUCKDB_API float duckdb_value_float(duckdb_result *result, idx_t col, idx_t row);
-//! Converts the specified value to a double. Returns 0.0 on failure or NULL.
+
+/*!
+ * returns: The double value at the specified location, or 0 if the value cannot be converted.
+ */
 DUCKDB_API double duckdb_value_double(duckdb_result *result, idx_t col, idx_t row);
 
-//! Converts the specified value to a duckdb_date. Returns 0 on failure or NULL.
+/*!
+ * returns: The duckdb_date value at the specified location, or 0 if the value cannot be converted.
+ */
 DUCKDB_API duckdb_date duckdb_value_date(duckdb_result *result, idx_t col, idx_t row);
-//! Converts the specified value to a duckdb_time. Returns 0 on failure or NULL.
+
+/*!
+ * returns: The duckdb_time value at the specified location, or 0 if the value cannot be converted.
+ */
 DUCKDB_API duckdb_time duckdb_value_time(duckdb_result *result, idx_t col, idx_t row);
-//! Converts the specified value to a duckdb_timestamp. Returns 0 on failure or NULL.
+
+/*!
+ * returns: The duckdb_timestamp value at the specified location, or 0 if the value cannot be converted.
+ */
 DUCKDB_API duckdb_timestamp duckdb_value_timestamp(duckdb_result *result, idx_t col, idx_t row);
-//! Converts the specified value to a duckdb_interval. Returns 0 on failure or NULL.
+
+/*!
+ * returns: The duckdb_interval value at the specified location, or 0 if the value cannot be converted.
+ */
 DUCKDB_API duckdb_interval duckdb_value_interval(duckdb_result *result, idx_t col, idx_t row);
 
-//! Converts the specified value to a string. Returns nullptr on failure or NULL. The result must be freed with
-//! duckdb_free.
+/*!
+* returns: The char* value at the specified location, or nullptr if the value cannot be converted.
+The result must be freed with `duckdb_free`.
+*/
 DUCKDB_API char *duckdb_value_varchar(duckdb_result *result, idx_t col, idx_t row);
-//! Fetches a blob from a result set column. Returns a blob with blob.data set to nullptr on failure or NULL. The
-//! resulting "blob.data" must be freed with duckdb_free.
+
+/*!
+* returns: The char* value at the specified location. ONLY works on VARCHAR columns and does not auto-cast.
+If the column is NOT a VARCHAR column this function will return NULL.
+
+The result must NOT be freed.
+*/
+DUCKDB_API char *duckdb_value_varchar_internal(duckdb_result *result, idx_t col, idx_t row);
+
+/*!
+* returns: The duckdb_blob value at the specified location. Returns a blob with blob.data set to nullptr if the
+value cannot be converted. The resulting "blob.data" must be freed with `duckdb_free.`
+*/
 DUCKDB_API duckdb_blob duckdb_value_blob(duckdb_result *result, idx_t col, idx_t row);
+
+/*!
+ * returns: Returns true if the value at the specified index is NULL, and false otherwise.
+ */
+DUCKDB_API bool duckdb_value_is_null(duckdb_result *result, idx_t col, idx_t row);
 
 //===--------------------------------------------------------------------===//
 // Helpers
 //===--------------------------------------------------------------------===//
-//! Allocate [size] amounts of memory using the duckdb internal malloc function. Any memory allocated in this manner
-//! should be freed using duckdb_free
+/*!
+Allocate `size` bytes of memory using the duckdb internal malloc function. Any memory allocated in this manner
+should be freed using `duckdb_free`.
+
+* size: The number of bytes to allocate.
+* returns: A pointer to the allocated memory region.
+*/
 DUCKDB_API void *duckdb_malloc(size_t size);
-//! Free a value returned from duckdb_malloc, duckdb_value_varchar or duckdb_value_blob
+
+/*!
+Free a value returned from `duckdb_malloc`, `duckdb_value_varchar` or `duckdb_value_blob`.
+
+* ptr: The memory region to de-allocate.
+*/
 DUCKDB_API void duckdb_free(void *ptr);
 
 //===--------------------------------------------------------------------===//
 // Date/Time/Timestamp Helpers
 //===--------------------------------------------------------------------===//
+/*!
+Decompose a `duckdb_date` object into year, month and date (stored as `duckdb_date_struct`).
+
+* date: The date object, as obtained from a `DUCKDB_TYPE_DATE` column.
+* returns: The `duckdb_date_struct` with the decomposed elements.
+*/
 DUCKDB_API duckdb_date_struct duckdb_from_date(duckdb_date date);
+
+/*!
+Re-compose a `duckdb_date` from year, month and date (`duckdb_date_struct`).
+
+* date: The year, month and date stored in a `duckdb_date_struct`.
+* returns: The `duckdb_date` element.
+*/
 DUCKDB_API duckdb_date duckdb_to_date(duckdb_date_struct date);
 
+/*!
+Decompose a `duckdb_time` object into hour, minute, second and microsecond (stored as `duckdb_time_struct`).
+
+* time: The time object, as obtained from a `DUCKDB_TYPE_TIME` column.
+* returns: The `duckdb_time_struct` with the decomposed elements.
+*/
 DUCKDB_API duckdb_time_struct duckdb_from_time(duckdb_time time);
+
+/*!
+Re-compose a `duckdb_time` from hour, minute, second and microsecond (`duckdb_time_struct`).
+
+* time: The hour, minute, second and microsecond in a `duckdb_time_struct`.
+* returns: The `duckdb_time` element.
+*/
 DUCKDB_API duckdb_time duckdb_to_time(duckdb_time_struct time);
 
+/*!
+Decompose a `duckdb_timestamp` object into a `duckdb_timestamp_struct`.
+
+* ts: The ts object, as obtained from a `DUCKDB_TYPE_TIMESTAMP` column.
+* returns: The `duckdb_timestamp_struct` with the decomposed elements.
+*/
 DUCKDB_API duckdb_timestamp_struct duckdb_from_timestamp(duckdb_timestamp ts);
+
+/*!
+Re-compose a `duckdb_timestamp` from a duckdb_timestamp_struct.
+
+* ts: The de-composed elements in a `duckdb_timestamp_struct`.
+* returns: The `duckdb_timestamp` element.
+*/
 DUCKDB_API duckdb_timestamp duckdb_to_timestamp(duckdb_timestamp_struct ts);
 
 //===--------------------------------------------------------------------===//
 // Hugeint Helpers
 //===--------------------------------------------------------------------===//
-//! Convert a hugeint to a double
+/*!
+Converts a duckdb_hugeint object (as obtained from a `DUCKDB_TYPE_HUGEINT` column) into a double.
+
+* val: The hugeint value.
+* returns: The converted `double` element.
+*/
 DUCKDB_API double duckdb_hugeint_to_double(duckdb_hugeint val);
-//! Convert a double to a hugeint. If the conversion fails because the double value is too big the result will be 0.
+
+/*!
+Converts a double value to a duckdb_hugeint object.
+
+If the conversion fails because the double value is too big the result will be 0.
+
+* val: The double value.
+* returns: The converted `duckdb_hugeint` element.
+*/
 DUCKDB_API duckdb_hugeint duckdb_double_to_hugeint(double val);
 
 //===--------------------------------------------------------------------===//
 // Prepared Statements
 //===--------------------------------------------------------------------===//
-//! prepares the specified SQL query in the specified connection handle. [OUT: prepared statement descriptor]
+// A prepared statement is a parameterized query that allows you to bind parameters to it.
+// * This is useful to easily supply parameters to functions and avoid SQL injection attacks.
+// * This is useful to speed up queries that you will execute several times with different parameters.
+// Because the query will only be parsed, bound, optimized and planned once during the prepare stage,
+// rather than once per execution.
+// For example:
+//   SELECT * FROM tbl WHERE id=?
+// Or a query with multiple parameters:
+//   SELECT * FROM tbl WHERE id=$1 OR name=$2
+
+/*!
+Create a prepared statement object from a query.
+
+Note that after calling `duckdb_prepare`, the prepared statement should always be destroyed using
+`duckdb_destroy_prepare`, even if the prepare fails.
+
+If the prepare fails, `duckdb_prepare_error` can be called to obtain the reason why the prepare failed.
+
+* connection: The connection object
+* query: The SQL query to prepare
+* out_prepared_statement: The resulting prepared statement object
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
 DUCKDB_API duckdb_state duckdb_prepare(duckdb_connection connection, const char *query,
                                        duckdb_prepared_statement *out_prepared_statement);
 
-DUCKDB_API const char *duckdb_prepare_error(duckdb_prepared_statement prepared_statement);
-DUCKDB_API duckdb_state duckdb_nparams(duckdb_prepared_statement prepared_statement, idx_t *nparams_out);
+/*!
+Closes the prepared statement and de-allocates all memory allocated for that connection.
 
-//! binds parameters to prepared statement
+* prepared_statement: The prepared statement to destroy.
+*/
+DUCKDB_API void duckdb_destroy_prepare(duckdb_prepared_statement *prepared_statement);
+
+/*!
+Returns the error message associated with the given prepared statement.
+If the prepared statement has no error message, this returns `nullptr` instead.
+
+The error message should not be freed. It will be de-allocated when `duckdb_destroy_prepare` is called.
+
+* prepared_statement: The prepared statement to obtain the error from.
+* returns: The error message, or `nullptr` if there is none.
+*/
+DUCKDB_API const char *duckdb_prepare_error(duckdb_prepared_statement prepared_statement);
+
+/*!
+Returns the number of parameters that can be provided to the given prepared statement.
+
+Returns 0 if the query was not successfully prepared.
+
+* prepared_statement: The prepared statement to obtain the number of parameters for.
+*/
+DUCKDB_API idx_t duckdb_nparams(duckdb_prepared_statement prepared_statement);
+
+/*!
+Returns the parameter type for the parameter at the given index.
+
+Returns `DUCKDB_TYPE_INVALID` if the parameter index is out of range or the statement was not successfully prepared.
+
+* prepared_statement: The prepared statement.
+* param_idx: The parameter index.
+* returns: The parameter type
+*/
+DUCKDB_API duckdb_type duckdb_param_type(duckdb_prepared_statement prepared_statement, idx_t param_idx);
+
+/*!
+Binds a bool value to the prepared statement at the specified index.
+*/
 DUCKDB_API duckdb_state duckdb_bind_boolean(duckdb_prepared_statement prepared_statement, idx_t param_idx, bool val);
+
+/*!
+Binds an int8_t value to the prepared statement at the specified index.
+*/
 DUCKDB_API duckdb_state duckdb_bind_int8(duckdb_prepared_statement prepared_statement, idx_t param_idx, int8_t val);
+
+/*!
+Binds an int16_t value to the prepared statement at the specified index.
+*/
 DUCKDB_API duckdb_state duckdb_bind_int16(duckdb_prepared_statement prepared_statement, idx_t param_idx, int16_t val);
+
+/*!
+Binds an int32_t value to the prepared statement at the specified index.
+*/
 DUCKDB_API duckdb_state duckdb_bind_int32(duckdb_prepared_statement prepared_statement, idx_t param_idx, int32_t val);
+
+/*!
+Binds an int64_t value to the prepared statement at the specified index.
+*/
 DUCKDB_API duckdb_state duckdb_bind_int64(duckdb_prepared_statement prepared_statement, idx_t param_idx, int64_t val);
+
+/*!
+Binds an duckdb_hugeint value to the prepared statement at the specified index.
+*/
 DUCKDB_API duckdb_state duckdb_bind_hugeint(duckdb_prepared_statement prepared_statement, idx_t param_idx,
                                             duckdb_hugeint val);
 
+/*!
+Binds an uint8_t value to the prepared statement at the specified index.
+*/
 DUCKDB_API duckdb_state duckdb_bind_uint8(duckdb_prepared_statement prepared_statement, idx_t param_idx, uint8_t val);
+
+/*!
+Binds an uint16_t value to the prepared statement at the specified index.
+*/
 DUCKDB_API duckdb_state duckdb_bind_uint16(duckdb_prepared_statement prepared_statement, idx_t param_idx, uint16_t val);
+
+/*!
+Binds an uint32_t value to the prepared statement at the specified index.
+*/
 DUCKDB_API duckdb_state duckdb_bind_uint32(duckdb_prepared_statement prepared_statement, idx_t param_idx, uint32_t val);
+
+/*!
+Binds an uint64_t value to the prepared statement at the specified index.
+*/
 DUCKDB_API duckdb_state duckdb_bind_uint64(duckdb_prepared_statement prepared_statement, idx_t param_idx, uint64_t val);
 
+/*!
+Binds an float value to the prepared statement at the specified index.
+*/
 DUCKDB_API duckdb_state duckdb_bind_float(duckdb_prepared_statement prepared_statement, idx_t param_idx, float val);
+
+/*!
+Binds an double value to the prepared statement at the specified index.
+*/
 DUCKDB_API duckdb_state duckdb_bind_double(duckdb_prepared_statement prepared_statement, idx_t param_idx, double val);
 
+/*!
+Binds a duckdb_date value to the prepared statement at the specified index.
+*/
 DUCKDB_API duckdb_state duckdb_bind_date(duckdb_prepared_statement prepared_statement, idx_t param_idx,
                                          duckdb_date val);
+
+/*!
+Binds a duckdb_time value to the prepared statement at the specified index.
+*/
 DUCKDB_API duckdb_state duckdb_bind_time(duckdb_prepared_statement prepared_statement, idx_t param_idx,
                                          duckdb_time val);
+
+/*!
+Binds a duckdb_timestamp value to the prepared statement at the specified index.
+*/
 DUCKDB_API duckdb_state duckdb_bind_timestamp(duckdb_prepared_statement prepared_statement, idx_t param_idx,
                                               duckdb_timestamp val);
+
+/*!
+Binds a duckdb_interval value to the prepared statement at the specified index.
+*/
 DUCKDB_API duckdb_state duckdb_bind_interval(duckdb_prepared_statement prepared_statement, idx_t param_idx,
                                              duckdb_interval val);
 
+/*!
+Binds a null-terminated varchar value to the prepared statement at the specified index.
+*/
 DUCKDB_API duckdb_state duckdb_bind_varchar(duckdb_prepared_statement prepared_statement, idx_t param_idx,
                                             const char *val);
+
+/*!
+Binds a varchar value to the prepared statement at the specified index.
+*/
 DUCKDB_API duckdb_state duckdb_bind_varchar_length(duckdb_prepared_statement prepared_statement, idx_t param_idx,
                                                    const char *val, idx_t length);
+
+/*!
+Binds a blob value to the prepared statement at the specified index.
+*/
 DUCKDB_API duckdb_state duckdb_bind_blob(duckdb_prepared_statement prepared_statement, idx_t param_idx,
                                          const void *data, idx_t length);
+
+/*!
+Binds a NULL value to the prepared statement at the specified index.
+*/
 DUCKDB_API duckdb_state duckdb_bind_null(duckdb_prepared_statement prepared_statement, idx_t param_idx);
 
-//! Executes the prepared statements with currently bound parameters
+/*!
+Executes the prepared statement with the given bound parameters, and returns a materialized query result.
+
+This method can be called multiple times for each prepared statement, and the parameters can be modified
+between calls to this function.
+
+* prepared_statement: The prepared statement to execute.
+* out_result: The query result.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
 DUCKDB_API duckdb_state duckdb_execute_prepared(duckdb_prepared_statement prepared_statement,
                                                 duckdb_result *out_result);
 
-//! Executes the prepared statements with currently bound parameters and return arrow result
+/*!
+Executes the prepared statement with the given bound parameters, and returns an arrow query result.
+
+* prepared_statement: The prepared statement to execute.
+* out_result: The query result.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
 DUCKDB_API duckdb_state duckdb_execute_prepared_arrow(duckdb_prepared_statement prepared_statement,
                                                       duckdb_arrow *out_result);
-
-//! Destroys the specified prepared statement descriptor
-DUCKDB_API void duckdb_destroy_prepare(duckdb_prepared_statement *prepared_statement);
 
 //===--------------------------------------------------------------------===//
 // Appender
 //===--------------------------------------------------------------------===//
+
+// Appenders are the most efficient way of loading data into DuckDB from within the C interface, and are recommended for
+// fast data loading. The appender is much faster than using prepared statements or individual `INSERT INTO` statements.
+
+// Appends are made in row-wise format. For every column, a `duckdb_append_[type]` call should be made, after which
+// the row should be finished by calling `duckdb_appender_end_row`. After all rows have been appended,
+// `duckdb_appender_destroy` should be used to finalize the appender and clean up the resulting memory.
+
+// Note that `duckdb_appender_destroy` should always be called on the resulting appender, even if the function returns
+// `DuckDBError`.
+
+/*!
+Creates an appender object.
+
+* connection: The connection context to create the appender in.
+* schema: The schema of the table to append to, or `nullptr` for the default schema.
+* table: The table name to append to.
+* out_appender: The resulting appender object.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
 DUCKDB_API duckdb_state duckdb_appender_create(duckdb_connection connection, const char *schema, const char *table,
                                                duckdb_appender *out_appender);
 
-DUCKDB_API duckdb_state duckdb_appender_begin_row(duckdb_appender appender);
-DUCKDB_API duckdb_state duckdb_appender_end_row(duckdb_appender appender);
+/*!
+Returns the error message associated with the given appender.
+If the appender has no error message, this returns `nullptr` instead.
 
-DUCKDB_API duckdb_state duckdb_append_bool(duckdb_appender appender, bool value);
+The error message should be freed using `duckdb_free`.
 
-DUCKDB_API duckdb_state duckdb_append_int8(duckdb_appender appender, int8_t value);
-DUCKDB_API duckdb_state duckdb_append_int16(duckdb_appender appender, int16_t value);
-DUCKDB_API duckdb_state duckdb_append_int32(duckdb_appender appender, int32_t value);
-DUCKDB_API duckdb_state duckdb_append_int64(duckdb_appender appender, int64_t value);
-DUCKDB_API duckdb_state duckdb_append_hugeint(duckdb_appender appender, duckdb_hugeint value);
-
-DUCKDB_API duckdb_state duckdb_append_uint8(duckdb_appender appender, uint8_t value);
-DUCKDB_API duckdb_state duckdb_append_uint16(duckdb_appender appender, uint16_t value);
-DUCKDB_API duckdb_state duckdb_append_uint32(duckdb_appender appender, uint32_t value);
-DUCKDB_API duckdb_state duckdb_append_uint64(duckdb_appender appender, uint64_t value);
-
-DUCKDB_API duckdb_state duckdb_append_float(duckdb_appender appender, float value);
-DUCKDB_API duckdb_state duckdb_append_double(duckdb_appender appender, double value);
-
-DUCKDB_API duckdb_state duckdb_append_date(duckdb_appender appender, duckdb_date value);
-DUCKDB_API duckdb_state duckdb_append_time(duckdb_appender appender, duckdb_time value);
-DUCKDB_API duckdb_state duckdb_append_timestamp(duckdb_appender appender, duckdb_timestamp value);
-DUCKDB_API duckdb_state duckdb_append_interval(duckdb_appender appender, duckdb_interval value);
-
-DUCKDB_API duckdb_state duckdb_append_varchar(duckdb_appender appender, const char *val);
-DUCKDB_API duckdb_state duckdb_append_varchar_length(duckdb_appender appender, const char *val, idx_t length);
-DUCKDB_API duckdb_state duckdb_append_blob(duckdb_appender appender, const void *data, idx_t length);
-DUCKDB_API duckdb_state duckdb_append_null(duckdb_appender appender);
-
+* appender: The appender to get the error from.
+* returns: The error message, or `nullptr` if there is none.
+*/
 DUCKDB_API const char *duckdb_appender_error(duckdb_appender appender);
+
+/*!
+Flush the appender to the table, forcing the cache of the appender to be cleared and the data to be appended to the
+base table.
+
+This should generally not be used unless you know what you are doing. Instead, call `duckdb_appender_destroy` when you
+are done with the appender.
+
+* appender: The appender to flush.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
 DUCKDB_API duckdb_state duckdb_appender_flush(duckdb_appender appender);
+
+/*!
+Close the appender, flushing all intermediate state in the appender to the table and closing it for further appends.
+
+This is generally not necessary. Call `duckdb_appender_destroy` instead.
+
+* appender: The appender to flush and close.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
 DUCKDB_API duckdb_state duckdb_appender_close(duckdb_appender appender);
 
+/*!
+Close the appender and destroy it. Flushing all intermediate state in the appender to the table, and de-allocating
+all memory associated with the appender.
+
+* appender: The appender to flush, close and destroy.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
 DUCKDB_API duckdb_state duckdb_appender_destroy(duckdb_appender *appender);
+
+/*!
+A nop function, provided for backwards compatibility reasons. Does nothing. Only `duckdb_appender_end_row` is required.
+*/
+DUCKDB_API duckdb_state duckdb_appender_begin_row(duckdb_appender appender);
+
+/*!
+Finish the current row of appends. After end_row is called, the next row can be appended.
+
+* appender: The appender.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
+DUCKDB_API duckdb_state duckdb_appender_end_row(duckdb_appender appender);
+
+/*!
+Append a bool value to the appender.
+*/
+DUCKDB_API duckdb_state duckdb_append_bool(duckdb_appender appender, bool value);
+
+/*!
+Append an int8_t value to the appender.
+*/
+DUCKDB_API duckdb_state duckdb_append_int8(duckdb_appender appender, int8_t value);
+/*!
+Append an int16_t value to the appender.
+*/
+DUCKDB_API duckdb_state duckdb_append_int16(duckdb_appender appender, int16_t value);
+/*!
+Append an int32_t value to the appender.
+*/
+DUCKDB_API duckdb_state duckdb_append_int32(duckdb_appender appender, int32_t value);
+/*!
+Append an int64_t value to the appender.
+*/
+DUCKDB_API duckdb_state duckdb_append_int64(duckdb_appender appender, int64_t value);
+/*!
+Append a duckdb_hugeint value to the appender.
+*/
+DUCKDB_API duckdb_state duckdb_append_hugeint(duckdb_appender appender, duckdb_hugeint value);
+
+/*!
+Append a uint8_t value to the appender.
+*/
+DUCKDB_API duckdb_state duckdb_append_uint8(duckdb_appender appender, uint8_t value);
+/*!
+Append a uint16_t value to the appender.
+*/
+DUCKDB_API duckdb_state duckdb_append_uint16(duckdb_appender appender, uint16_t value);
+/*!
+Append a uint32_t value to the appender.
+*/
+DUCKDB_API duckdb_state duckdb_append_uint32(duckdb_appender appender, uint32_t value);
+/*!
+Append a uint64_t value to the appender.
+*/
+DUCKDB_API duckdb_state duckdb_append_uint64(duckdb_appender appender, uint64_t value);
+
+/*!
+Append a float value to the appender.
+*/
+DUCKDB_API duckdb_state duckdb_append_float(duckdb_appender appender, float value);
+/*!
+Append a double value to the appender.
+*/
+DUCKDB_API duckdb_state duckdb_append_double(duckdb_appender appender, double value);
+
+/*!
+Append a duckdb_date value to the appender.
+*/
+DUCKDB_API duckdb_state duckdb_append_date(duckdb_appender appender, duckdb_date value);
+/*!
+Append a duckdb_time value to the appender.
+*/
+DUCKDB_API duckdb_state duckdb_append_time(duckdb_appender appender, duckdb_time value);
+/*!
+Append a duckdb_timestamp value to the appender.
+*/
+DUCKDB_API duckdb_state duckdb_append_timestamp(duckdb_appender appender, duckdb_timestamp value);
+/*!
+Append a duckdb_interval value to the appender.
+*/
+DUCKDB_API duckdb_state duckdb_append_interval(duckdb_appender appender, duckdb_interval value);
+
+/*!
+Append a varchar value to the appender.
+*/
+DUCKDB_API duckdb_state duckdb_append_varchar(duckdb_appender appender, const char *val);
+/*!
+Append a varchar value to the appender.
+*/
+DUCKDB_API duckdb_state duckdb_append_varchar_length(duckdb_appender appender, const char *val, idx_t length);
+/*!
+Append a blob value to the appender.
+*/
+DUCKDB_API duckdb_state duckdb_append_blob(duckdb_appender appender, const void *data, idx_t length);
+/*!
+Append a NULL value to the appender (of any type).
+*/
+DUCKDB_API duckdb_state duckdb_append_null(duckdb_appender appender);
 
 //===--------------------------------------------------------------------===//
 // Arrow Interface
 //===--------------------------------------------------------------------===//
-//! query duckdb result as arrow data structure
+/*!
+Executes a SQL query within a connection and stores the full (materialized) result in an arrow structure.
+If the query fails to execute, DuckDBError is returned and the error message can be retrieved by calling
+`duckdb_query_arrow_error`.
+
+Note that after running `duckdb_query_arrow`, `duckdb_destroy_arrow` must be called on the result object even if the
+query fails, otherwise the error stored within the result will not be freed correctly.
+
+* connection: The connection to perform the query in.
+* query: The SQL query to run.
+* out_result: The query result.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
 DUCKDB_API duckdb_state duckdb_query_arrow(duckdb_connection connection, const char *query, duckdb_arrow *out_result);
-//! get arrow schema
+
+/*!
+Fetch the internal arrow schema from the arrow result.
+
+* result: The result to fetch the schema from.
+* out_schema: The output schema.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
 DUCKDB_API duckdb_state duckdb_query_arrow_schema(duckdb_arrow result, duckdb_arrow_schema *out_schema);
-//! get arrow data array
-//! This function can be called multiple time to get next chunks, which will free the previous out_array.
-//! So consume the out_array before call this function again
+
+/*!
+Fetch an internal arrow array from the arrow result.
+
+This function can be called multiple time to get next chunks, which will free the previous out_array.
+So consume the out_array before calling this function again.
+
+* result: The result to fetch the array from.
+* out_array: The output array.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
 DUCKDB_API duckdb_state duckdb_query_arrow_array(duckdb_arrow result, duckdb_arrow_array *out_array);
-//! get arrow row count
-DUCKDB_API idx_t duckdb_arrow_row_count(duckdb_arrow result);
-//! get arrow column count
+
+/*!
+Returns the number of columns present in a the arrow result object.
+
+* result: The result object.
+* returns: The number of columns present in the result object.
+*/
 DUCKDB_API idx_t duckdb_arrow_column_count(duckdb_arrow result);
-//! get arrow rows changed
+
+/*!
+Returns the number of rows present in a the arrow result object.
+
+* result: The result object.
+* returns: The number of rows present in the result object.
+*/
+DUCKDB_API idx_t duckdb_arrow_row_count(duckdb_arrow result);
+
+/*!
+Returns the number of rows changed by the query stored in the arrow result. This is relevant only for
+INSERT/UPDATE/DELETE queries. For other queries the rows_changed will be 0.
+
+* result: The result object.
+* returns: The number of rows changed.
+*/
 DUCKDB_API idx_t duckdb_arrow_rows_changed(duckdb_arrow result);
-//! get arrow error message
+
+/*!
+Returns the error message contained within the result. The error is only set if `duckdb_query_arrow` returns
+`DuckDBError`.
+
+The result should be freed using `duckdb_free`.
+
+* result: The result object to fetch the nullmask from.
+* returns: The error of the result.
+*/
 DUCKDB_API const char *duckdb_query_arrow_error(duckdb_arrow result);
-//! Destroys the arrow result
+
+/*!
+Closes the result and de-allocates all memory allocated for the arrow result.
+
+* result: The result to destroy.
+*/
 DUCKDB_API void duckdb_destroy_arrow(duckdb_arrow *result);
 
 #ifdef __cplusplus

--- a/src/include/duckdb/main/capi_internal.hpp
+++ b/src/include/duckdb/main/capi_internal.hpp
@@ -42,7 +42,7 @@ struct AppenderWrapper {
 	string error;
 };
 
-duckdb_type ConvertCPPTypeToC(LogicalType type);
+duckdb_type ConvertCPPTypeToC(const LogicalType &type);
 idx_t GetCTypeSize(duckdb_type type);
 duckdb_state duckdb_translate_result(MaterializedQueryResult *result, duckdb_result *out);
 

--- a/src/main/capi/appender-c.cpp
+++ b/src/main/capi/appender-c.cpp
@@ -53,6 +53,9 @@ duckdb_state duckdb_appender_run_function(duckdb_appender appender, FUN &&functi
 		return DuckDBError;
 	}
 	auto wrapper = (AppenderWrapper *)appender;
+	if (!wrapper->appender) {
+		return DuckDBError;
+	}
 	try {
 		function(*wrapper->appender);
 	} catch (std::exception &ex) {

--- a/src/main/capi/appender-c.cpp
+++ b/src/main/capi/appender-c.cpp
@@ -38,6 +38,7 @@ duckdb_state duckdb_appender_destroy(duckdb_appender *appender) {
 	if (!appender || !*appender) {
 		return DuckDBError;
 	}
+	duckdb_appender_close(*appender);
 	auto wrapper = (AppenderWrapper *)*appender;
 	if (wrapper) {
 		delete wrapper;
@@ -76,7 +77,7 @@ const char *duckdb_appender_error(duckdb_appender appender) {
 }
 
 duckdb_state duckdb_appender_begin_row(duckdb_appender appender) {
-	return duckdb_appender_run_function(appender, [&](Appender &appender) { appender.BeginRow(); });
+	return DuckDBSuccess;
 }
 
 duckdb_state duckdb_appender_end_row(duckdb_appender appender) {

--- a/src/main/capi/helper-c.cpp
+++ b/src/main/capi/helper-c.cpp
@@ -2,7 +2,7 @@
 
 namespace duckdb {
 
-duckdb_type ConvertCPPTypeToC(LogicalType sql_type) {
+duckdb_type ConvertCPPTypeToC(const LogicalType &sql_type) {
 	switch (sql_type.id()) {
 	case LogicalTypeId::BOOLEAN:
 		return DUCKDB_TYPE_BOOLEAN;

--- a/src/main/capi/result-c.cpp
+++ b/src/main/capi/result-c.cpp
@@ -311,3 +311,10 @@ bool *duckdb_nullmask_data(duckdb_result *result, idx_t col) {
 	}
 	return result->columns[col].nullmask;
 }
+
+char *duckdb_result_error(duckdb_result *result) {
+	if (!result) {
+		return nullptr;
+	}
+	return result->error_message;
+}

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -339,6 +339,7 @@ void BufferManager::UnregisterBlock(block_id_t block_id, bool can_destroy) {
 		blocks.erase(block_id);
 	}
 }
+
 void BufferManager::SetLimit(idx_t limit) {
 	lock_guard<mutex> buffer_lock(manager_lock);
 	// try to evict until the limit is reached

--- a/test/api/capi/test_capi.cpp
+++ b/test/api/capi/test_capi.cpp
@@ -44,7 +44,12 @@ public:
 
 	bool IsNull(idx_t col, idx_t row) {
 		auto nullmask_ptr = duckdb_nullmask_data(&result, col);
+		REQUIRE(duckdb_value_is_null(&result, col, row) == nullmask_ptr[row]);
 		return nullmask_ptr[row];
+	}
+
+	char *ErrorMessage() {
+		return duckdb_result_error(&result);
 	}
 
 	string ColumnName(idx_t col) {
@@ -313,10 +318,12 @@ TEST_CASE("Basic test of C API", "[capi]") {
 	REQUIRE(result->rows_changed() == 2);
 
 	// several error conditions
+	REQUIRE(duckdb_value_is_null(nullptr, 0, 0) == false);
 	REQUIRE(duckdb_column_type(nullptr, 0) == DUCKDB_TYPE_INVALID);
 	REQUIRE(duckdb_column_count(nullptr) == 0);
 	REQUIRE(duckdb_row_count(nullptr) == 0);
 	REQUIRE(duckdb_rows_changed(nullptr) == 0);
+	REQUIRE(duckdb_result_error(nullptr) == nullptr);
 	REQUIRE(duckdb_nullmask_data(nullptr, 0) == nullptr);
 	REQUIRE(duckdb_column_data(nullptr, 0) == nullptr);
 }
@@ -517,7 +524,6 @@ TEST_CASE("Test errors in C API", "[capi]") {
 	REQUIRE(stmt != nullptr);
 	auto err_msg = duckdb_prepare_error(stmt);
 	REQUIRE(err_msg != nullptr);
-	duckdb_free((void *)err_msg);
 	duckdb_destroy_prepare(&stmt);
 
 	REQUIRE(duckdb_bind_boolean(NULL, 0, true) == DuckDBError);
@@ -729,11 +735,11 @@ TEST_CASE("Test prepared statements in C API", "[capi]") {
 	status = duckdb_prepare(tester.connection, "INSERT INTO a VALUES (?)", &stmt);
 	REQUIRE(status == DuckDBSuccess);
 	REQUIRE(stmt != nullptr);
-	idx_t nparams;
-	REQUIRE(duckdb_nparams(nullptr, &nparams) == DuckDBError);
-	REQUIRE(duckdb_nparams(stmt, nullptr) == DuckDBError);
-	REQUIRE(duckdb_nparams(stmt, &nparams) == DuckDBSuccess);
-	REQUIRE(nparams == 1);
+	REQUIRE(duckdb_nparams(nullptr) == 0);
+	REQUIRE(duckdb_nparams(stmt) == 1);
+	REQUIRE(duckdb_param_type(nullptr, 0) == DUCKDB_TYPE_INVALID);
+	REQUIRE(duckdb_param_type(stmt, 0) == DUCKDB_TYPE_INTEGER);
+	REQUIRE(duckdb_param_type(stmt, 1) == DUCKDB_TYPE_INVALID);
 
 	for (int32_t i = 1; i <= 1000; i++) {
 		duckdb_bind_int32(stmt, 1, i);
@@ -793,6 +799,7 @@ TEST_CASE("Test appender statements in C API", "[capi]") {
 	REQUIRE(msg != nullptr);
 	duckdb_free((void *)msg);
 	REQUIRE(duckdb_appender_destroy(&appender) == DuckDBSuccess);
+	REQUIRE(duckdb_appender_destroy(nullptr) == DuckDBError);
 
 	status = duckdb_appender_create(tester.connection, nullptr, "test", nullptr);
 	REQUIRE(status == DuckDBError);
@@ -1384,4 +1391,183 @@ TEST_CASE("Issue #2058: Cleanup after execution of invalid SQL statement causes 
 
 	duckdb_disconnect(&con);
 	duckdb_close(&db);
+}
+
+TEST_CASE("Test C API examples from the website", "[capi]") {
+	// NOTE: if any of these break and need to be changed, the website also needs to be updated!
+	SECTION("connect") {
+		duckdb_database db;
+		duckdb_connection con;
+
+		if (duckdb_open(NULL, &db) == DuckDBError) {
+			// handle error
+		}
+		if (duckdb_connect(db, &con) == DuckDBError) {
+			// handle error
+		}
+
+		// run queries...
+
+		// cleanup
+		duckdb_disconnect(&con);
+		duckdb_close(&db);
+	}
+	SECTION("config") {
+		duckdb_database db;
+		duckdb_config config;
+
+		// create the configuration object
+		if (duckdb_create_config(&config) == DuckDBError) {
+			REQUIRE(1 == 0);
+		}
+		// set some configuration options
+		duckdb_set_config(config, "access_mode", "READ_WRITE");
+		duckdb_set_config(config, "threads", "8");
+		duckdb_set_config(config, "max_memory", "8GB");
+		duckdb_set_config(config, "default_order", "DESC");
+
+		// open the database using the configuration
+		if (duckdb_open_ext(NULL, &db, config, NULL) == DuckDBError) {
+			REQUIRE(1 == 0);
+		}
+		// cleanup the configuration object
+		duckdb_destroy_config(&config);
+
+		// run queries...
+
+		// cleanup
+		duckdb_close(&db);
+	}
+	SECTION("query") {
+		duckdb_database db;
+		duckdb_connection con;
+		duckdb_state state;
+		duckdb_result result;
+
+		duckdb_open(NULL, &db);
+		duckdb_connect(db, &con);
+
+		// create a table
+		state = duckdb_query(con, "CREATE TABLE integers(i INTEGER, j INTEGER);", NULL);
+		if (state == DuckDBError) {
+			REQUIRE(1 == 0);
+		}
+		// insert three rows into the table
+		state = duckdb_query(con, "INSERT INTO integers VALUES (3, 4), (5, 6), (7, NULL);", NULL);
+		if (state == DuckDBError) {
+			REQUIRE(1 == 0);
+		}
+		// query rows again
+		state = duckdb_query(con, "SELECT * FROM integers", &result);
+		if (state == DuckDBError) {
+			REQUIRE(1 == 0);
+		}
+		// handle the result
+		idx_t row_count = duckdb_row_count(&result);
+		idx_t column_count = duckdb_column_count(&result);
+		for (idx_t row = 0; row < row_count; row++) {
+			for (idx_t col = 0; col < column_count; col++) {
+				// if (col > 0) printf(",");
+				auto str_val = duckdb_value_varchar(&result, col, row);
+				// printf("%s", str_val);
+				REQUIRE(1 == 1);
+				duckdb_free(str_val);
+			}
+			//	printf("\n");
+		}
+
+		int32_t *i_data = (int32_t *)duckdb_column_data(&result, 0);
+		int32_t *j_data = (int32_t *)duckdb_column_data(&result, 1);
+		bool *i_mask = duckdb_nullmask_data(&result, 0);
+		bool *j_mask = duckdb_nullmask_data(&result, 1);
+		for (idx_t row = 0; row < row_count; row++) {
+			if (i_mask[row]) {
+				// printf("NULL");
+			} else {
+				REQUIRE(i_data[row] > 0);
+				// printf("%d", i_data[row]);
+			}
+			// printf(",");
+			if (j_mask[row]) {
+				// printf("NULL");
+			} else {
+				REQUIRE(j_data[row] > 0);
+				// printf("%d", j_data[row]);
+			}
+			// printf("\n");
+		}
+
+		// destroy the result after we are done with it
+		duckdb_destroy_result(&result);
+		duckdb_disconnect(&con);
+		duckdb_close(&db);
+	}
+	SECTION("prepared") {
+		duckdb_database db;
+		duckdb_connection con;
+		duckdb_open(NULL, &db);
+		duckdb_connect(db, &con);
+		duckdb_query(con, "CREATE TABLE integers(i INTEGER, j INTEGER)", NULL);
+
+		duckdb_prepared_statement stmt;
+		duckdb_result result;
+		if (duckdb_prepare(con, "INSERT INTO integers VALUES ($1, $2)", &stmt) == DuckDBError) {
+			REQUIRE(1 == 0);
+		}
+
+		duckdb_bind_int32(stmt, 1, 42); // the parameter index starts counting at 1!
+		duckdb_bind_int32(stmt, 2, 43);
+		// NULL as second parameter means no result set is requested
+		duckdb_execute_prepared(stmt, NULL);
+		duckdb_destroy_prepare(&stmt);
+
+		// we can also query result sets using prepared statements
+		if (duckdb_prepare(con, "SELECT * FROM integers WHERE i = ?", &stmt) == DuckDBError) {
+			REQUIRE(1 == 0);
+		}
+		duckdb_bind_int32(stmt, 1, 42);
+		duckdb_execute_prepared(stmt, &result);
+
+		// do something with result
+
+		// clean up
+		duckdb_destroy_result(&result);
+		duckdb_destroy_prepare(&stmt);
+
+		duckdb_disconnect(&con);
+		duckdb_close(&db);
+	}
+	SECTION("appender") {
+		duckdb_database db;
+		duckdb_connection con;
+		duckdb_open(NULL, &db);
+		duckdb_connect(db, &con);
+		duckdb_query(con, "CREATE TABLE people(id INTEGER, name VARCHAR)", NULL);
+
+		duckdb_appender appender;
+		if (duckdb_appender_create(con, NULL, "people", &appender) == DuckDBError) {
+			REQUIRE(1 == 0);
+		}
+		duckdb_append_int32(appender, 1);
+		duckdb_append_varchar(appender, "Mark");
+		duckdb_appender_end_row(appender);
+
+		duckdb_append_int32(appender, 2);
+		duckdb_append_varchar(appender, "Hannes");
+		duckdb_appender_end_row(appender);
+
+		duckdb_appender_destroy(&appender);
+
+		duckdb_result result;
+		duckdb_query(con, "SELECT * FROM people", &result);
+		REQUIRE(duckdb_value_int32(&result, 0, 0) == 1);
+		REQUIRE(duckdb_value_int32(&result, 0, 1) == 2);
+		REQUIRE(string(duckdb_value_varchar_internal(&result, 1, 0)) == "Mark");
+		REQUIRE(string(duckdb_value_varchar_internal(&result, 1, 1)) == "Hannes");
+
+		duckdb_destroy_result(&result);
+
+		duckdb_disconnect(&con);
+		duckdb_close(&db);
+	}
 }

--- a/test/api/capi/test_capi.cpp
+++ b/test/api/capi/test_capi.cpp
@@ -738,8 +738,9 @@ TEST_CASE("Test prepared statements in C API", "[capi]") {
 	REQUIRE(duckdb_nparams(nullptr) == 0);
 	REQUIRE(duckdb_nparams(stmt) == 1);
 	REQUIRE(duckdb_param_type(nullptr, 0) == DUCKDB_TYPE_INVALID);
-	REQUIRE(duckdb_param_type(stmt, 0) == DUCKDB_TYPE_INTEGER);
-	REQUIRE(duckdb_param_type(stmt, 1) == DUCKDB_TYPE_INVALID);
+	REQUIRE(duckdb_param_type(stmt, 0) == DUCKDB_TYPE_INVALID);
+	REQUIRE(duckdb_param_type(stmt, 1) == DUCKDB_TYPE_INTEGER);
+	REQUIRE(duckdb_param_type(stmt, 2) == DUCKDB_TYPE_INVALID);
 
 	for (int32_t i = 1; i <= 1000; i++) {
 		duckdb_bind_int32(stmt, 1, i);
@@ -885,9 +886,6 @@ TEST_CASE("Test appender statements in C API", "[capi]") {
 	status = duckdb_appender_flush(appender);
 	REQUIRE(status == DuckDBError);
 
-	status = duckdb_appender_begin_row(appender);
-	REQUIRE(status == DuckDBError);
-
 	status = duckdb_appender_end_row(appender);
 	REQUIRE(status == DuckDBError);
 
@@ -901,9 +899,6 @@ TEST_CASE("Test appender statements in C API", "[capi]") {
 	REQUIRE(status == DuckDBError);
 
 	status = duckdb_appender_flush(nullptr);
-	REQUIRE(status == DuckDBError);
-
-	status = duckdb_appender_begin_row(nullptr);
 	REQUIRE(status == DuckDBError);
 
 	status = duckdb_appender_end_row(nullptr);


### PR DESCRIPTION
This PR extends the documentation provided for the C API in `duckdb.h`. The idea is that we inline the documentation in there. In the `duckdb-web` repo, we have a [script](https://github.com/duckdb/duckdb-web/blob/master/scripts/generate_docs.py) that uses ~~hacky regexes~~ advanced text mining techniques to extract the comments and function prototypes and converts them into proper documentation (see e.g. [here](https://duckdb.org/docs/api/c/connect), or the [complete API reference](https://duckdb.org/docs/api/c/api)). The idea is that by inlining documentation into the code it is easier to update and will not go out of date.