### PR TITLE
ODBC: enable nanodbc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -862,8 +862,8 @@ jobs:
     - name: Build
       run: DISABLE_SANITIZER=1 make debug
 
-    # - name: Test nanodbc
-    #   run: NANODBC_TEST_CONNSTR_ODBC="DRIVER=./build/debug/tools/odbc/libduckdb_odbc.so" ./nanodbc/build/test/odbc_tests test_simple
+    - name: Test nanodbc
+      run: NANODBC_TEST_CONNSTR_ODBC="DRIVER=./build/debug/tools/odbc/libduckdb_odbc.so" ./nanodbc/build/test/odbc_tests test_simple
 
     - name: Test psqlodbc
       run: |

--- a/tools/odbc/api_info.cpp
+++ b/tools/odbc/api_info.cpp
@@ -256,7 +256,7 @@ SQLLEN ApiInfo::PointerSizeOf(SQLSMALLINT sql_type) {
 }
 
 //! https://docs.microsoft.com/en-us/sql/odbc/reference/appendixes/display-size?view=sql-server-ver15
-SQLRETURN ApiInfo::GetColumnSize(duckdb::LogicalType logical_type, SQLULEN *col_size_ptr) {
+SQLRETURN ApiInfo::GetColumnSize(const duckdb::LogicalType &logical_type, SQLULEN *col_size_ptr) {
 	auto sql_type = FindRelatedSQLType(logical_type.id());
 	switch (sql_type) {
 	case SQL_DECIMAL:

--- a/tools/odbc/api_info.cpp
+++ b/tools/odbc/api_info.cpp
@@ -254,3 +254,49 @@ SQLLEN ApiInfo::PointerSizeOf(SQLSMALLINT sql_type) {
 		return -1;
 	}
 }
+
+//! https://docs.microsoft.com/en-us/sql/odbc/reference/appendixes/display-size?view=sql-server-ver15
+SQLRETURN ApiInfo::GetColumnSize(duckdb::LogicalType logical_type, SQLLEN *col_size_ptr) {
+	auto sql_type = FindRelatedSQLType(logical_type.id());
+	switch (sql_type) {
+	case SQL_DECIMAL:
+	case SQL_NUMERIC:
+		*col_size_ptr = duckdb::DecimalType::GetWidth(logical_type) + duckdb::DecimalType::GetScale(logical_type);
+		return SQL_SUCCESS;
+	case SQL_BIT:
+		*col_size_ptr = 1;
+		return SQL_SUCCESS;
+	case SQL_TINYINT:
+		*col_size_ptr = 6;
+		return SQL_SUCCESS;
+	case SQL_INTEGER:
+		*col_size_ptr = 11;
+		return SQL_SUCCESS;
+	case SQL_BIGINT:
+		*col_size_ptr = 20;
+		return SQL_SUCCESS;
+	case SQL_REAL:
+		*col_size_ptr = 14;
+		return SQL_SUCCESS;
+	case SQL_FLOAT:
+	case SQL_DOUBLE:
+		*col_size_ptr = 24;
+		return SQL_SUCCESS;
+	case SQL_TYPE_DATE:
+		*col_size_ptr = 10;
+		return SQL_SUCCESS;
+	case SQL_TYPE_TIME:
+		*col_size_ptr = 9;
+		return SQL_SUCCESS;
+	case SQL_TYPE_TIMESTAMP:
+		*col_size_ptr = 20;
+		return SQL_SUCCESS;
+	case SQL_VARCHAR:
+	case SQL_VARBINARY:
+		// we don't know the number of characters
+		*col_size_ptr = 0;
+		return SQL_SUCCESS;
+	default:
+		return SQL_ERROR;
+	}
+}

--- a/tools/odbc/api_info.cpp
+++ b/tools/odbc/api_info.cpp
@@ -256,7 +256,7 @@ SQLLEN ApiInfo::PointerSizeOf(SQLSMALLINT sql_type) {
 }
 
 //! https://docs.microsoft.com/en-us/sql/odbc/reference/appendixes/display-size?view=sql-server-ver15
-SQLRETURN ApiInfo::GetColumnSize(duckdb::LogicalType logical_type, SQLLEN *col_size_ptr) {
+SQLRETURN ApiInfo::GetColumnSize(duckdb::LogicalType logical_type, SQLULEN *col_size_ptr) {
 	auto sql_type = FindRelatedSQLType(logical_type.id());
 	switch (sql_type) {
 	case SQL_DECIMAL:

--- a/tools/odbc/duckdb_odbc.cpp
+++ b/tools/odbc/duckdb_odbc.cpp
@@ -4,7 +4,7 @@
 using duckdb::OdbcHandleStmt;
 
 OdbcHandleStmt::OdbcHandleStmt(OdbcHandleDbc *dbc_p)
-    : OdbcHandle(OdbcHandleType::STMT), dbc(dbc_p), rows_fetched_ptr(nullptr) {
+    : OdbcHandle(OdbcHandleType::STMT), dbc(dbc_p), paramset_size(1), rows_fetched_ptr(nullptr) {
 	D_ASSERT(dbc_p);
 	D_ASSERT(dbc_p->conn);
 

--- a/tools/odbc/include/api_info.hpp
+++ b/tools/odbc/include/api_info.hpp
@@ -37,7 +37,7 @@ public:
 
 	static SQLLEN PointerSizeOf(SQLSMALLINT sql_type);
 
-	static SQLRETURN GetColumnSize(duckdb::LogicalType logical_type, SQLULEN *col_size_ptr);
+	static SQLRETURN GetColumnSize(const duckdb::LogicalType &logical_type, SQLULEN *col_size_ptr);
 
 }; // end ApiInfo struct
 

--- a/tools/odbc/include/api_info.hpp
+++ b/tools/odbc/include/api_info.hpp
@@ -37,7 +37,7 @@ public:
 
 	static SQLLEN PointerSizeOf(SQLSMALLINT sql_type);
 
-	static SQLRETURN GetColumnSize(duckdb::LogicalType logical_type, SQLLEN *col_size_ptr);
+	static SQLRETURN GetColumnSize(duckdb::LogicalType logical_type, SQLULEN *col_size_ptr);
 
 }; // end ApiInfo struct
 

--- a/tools/odbc/include/api_info.hpp
+++ b/tools/odbc/include/api_info.hpp
@@ -37,6 +37,8 @@ public:
 
 	static SQLLEN PointerSizeOf(SQLSMALLINT sql_type);
 
+	static SQLRETURN GetColumnSize(duckdb::LogicalType logical_type, SQLLEN *col_size_ptr);
+
 }; // end ApiInfo struct
 
 } // namespace duckdb

--- a/tools/odbc/include/duckdb_odbc.hpp
+++ b/tools/odbc/include/duckdb_odbc.hpp
@@ -129,6 +129,7 @@ struct OdbcHandleStmt : public OdbcHandle {
 	unique_ptr<PreparedStatement> stmt;
 	unique_ptr<QueryResult> res;
 	vector<Value> params;
+	SQLULEN paramset_size;
 	vector<OdbcBoundCol> bound_cols;
 	bool open;
 	SQLULEN *rows_fetched_ptr;

--- a/tools/odbc/prepared.cpp
+++ b/tools/odbc/prepared.cpp
@@ -229,7 +229,7 @@ SQLRETURN SQLDescribeCol(SQLHSTMT statement_handle, SQLUSMALLINT column_number, 
 			*data_type_ptr = duckdb::ApiInfo::FindRelatedSQLType(col_type.id());
 		}
 		if (column_size_ptr) {
-			auto ret = duckdb::ApiInfo::GetColumnSize(stmt->stmt->GetTypes()[col_idx], (SQLLEN *)column_size_ptr);
+			auto ret = duckdb::ApiInfo::GetColumnSize(stmt->stmt->GetTypes()[col_idx], column_size_ptr);
 			if (ret == SQL_ERROR) {
 				*column_size_ptr = 0;
 			}

--- a/tools/odbc/prepared.cpp
+++ b/tools/odbc/prepared.cpp
@@ -213,21 +213,26 @@ SQLRETURN SQLDescribeCol(SQLHSTMT statement_handle, SQLUSMALLINT column_number, 
 		if (column_number > stmt->stmt->ColumnCount()) {
 			return SQL_ERROR;
 		}
+
+		duckdb::idx_t col_idx = column_number - 1;
+
 		if (column_name && buffer_length > 0) {
-			auto out_len =
-			    snprintf((char *)column_name, buffer_length, "%s", stmt->stmt->GetNames()[column_number - 1].c_str());
+			auto out_len = snprintf((char *)column_name, buffer_length, "%s", stmt->stmt->GetNames()[col_idx].c_str());
 			if (name_length_ptr) {
 				*name_length_ptr = out_len;
 			}
 		}
 
-		LogicalType col_type = stmt->stmt->GetTypes()[column_number - 1];
+		LogicalType col_type = stmt->stmt->GetTypes()[col_idx];
 
 		if (data_type_ptr) {
 			*data_type_ptr = duckdb::ApiInfo::FindRelatedSQLType(col_type.id());
 		}
 		if (column_size_ptr) {
-			*column_size_ptr = 0;
+			auto ret = duckdb::ApiInfo::GetColumnSize(stmt->stmt->GetTypes()[col_idx], (SQLLEN *)column_size_ptr);
+			if (ret == SQL_ERROR) {
+				*column_size_ptr = 0;
+			}
 		}
 		if (decimal_digits_ptr) {
 			*decimal_digits_ptr = 0;

--- a/tools/odbc/statement.cpp
+++ b/tools/odbc/statement.cpp
@@ -12,6 +12,7 @@ SQLRETURN SQLSetStmtAttr(SQLHSTMT statement_handle, SQLINTEGER attribute, SQLPOI
 			 return (size == 1) ? SQL_SUCCESS : SQL_ERROR;
 			 */
 			// this should be 1
+			stmt->paramset_size = (SQLULEN)value_ptr;
 			return SQL_SUCCESS;
 		}
 		case SQL_ATTR_QUERY_TIMEOUT: {
@@ -164,7 +165,7 @@ SQLRETURN SQLColumns(SQLHSTMT statement_handle, SQLCHAR *catalog_name, SQLSMALLI
 
 SQLRETURN SQLColAttribute(SQLHSTMT statement_handle, SQLUSMALLINT column_number, SQLUSMALLINT field_identifier,
                           SQLPOINTER character_attribute_ptr, SQLSMALLINT buffer_length, SQLSMALLINT *string_length_ptr,
-                          SQLLEN *numeric_attribute_ptr) {
+                          *numeric_attribute_ptr) {
 
 	return duckdb::WithStatementPrepared(statement_handle, [&](duckdb::OdbcHandleStmt *stmt) {
 		if (column_number < 1 || column_number > stmt->stmt->GetTypes().size()) {
@@ -210,50 +211,9 @@ SQLRETURN SQLColAttribute(SQLHSTMT statement_handle, SQLUSMALLINT column_number,
 
 			return SQL_SUCCESS;
 		}
-		// https://docs.microsoft.com/en-us/sql/odbc/reference/appendixes/display-size?view=sql-server-ver15
 		case SQL_DESC_DISPLAY_SIZE: {
-			auto logical_type = stmt->stmt->GetTypes()[col_idx];
-			auto sql_type = duckdb::ApiInfo::FindRelatedSQLType(logical_type.id());
-			switch (sql_type) {
-			case SQL_DECIMAL:
-			case SQL_NUMERIC:
-				*numeric_attribute_ptr =
-				    duckdb::DecimalType::GetWidth(logical_type) + duckdb::DecimalType::GetScale(logical_type);
-				return SQL_SUCCESS;
-			case SQL_BIT:
-				*numeric_attribute_ptr = 1;
-				return SQL_SUCCESS;
-			case SQL_TINYINT:
-				*numeric_attribute_ptr = 6;
-				return SQL_SUCCESS;
-			case SQL_INTEGER:
-				*numeric_attribute_ptr = 11;
-				return SQL_SUCCESS;
-			case SQL_BIGINT:
-				*numeric_attribute_ptr = 20;
-				return SQL_SUCCESS;
-			case SQL_REAL:
-				*numeric_attribute_ptr = 14;
-				return SQL_SUCCESS;
-			case SQL_FLOAT:
-			case SQL_DOUBLE:
-				*numeric_attribute_ptr = 24;
-				return SQL_SUCCESS;
-			case SQL_TYPE_DATE:
-				*numeric_attribute_ptr = 10;
-				return SQL_SUCCESS;
-			case SQL_TYPE_TIME:
-				*numeric_attribute_ptr = 9;
-				return SQL_SUCCESS;
-			case SQL_TYPE_TIMESTAMP:
-				*numeric_attribute_ptr = 20;
-				return SQL_SUCCESS;
-			case SQL_VARCHAR:
-			case SQL_VARBINARY:
-				// we don't know the number of characters
-				*numeric_attribute_ptr = 0;
-				return SQL_SUCCESS;
-			default:
+			auto ret = duckdb::ApiInfo::GetColumnSize(stmt->stmt->GetTypes()[col_idx], numeric_attribute_ptr);
+			if (ret == SQL_ERROR) {
 				stmt->error_messages.emplace_back("Unsupported type for display size.");
 				return SQL_ERROR;
 			}

--- a/tools/odbc/statement.cpp
+++ b/tools/odbc/statement.cpp
@@ -165,7 +165,7 @@ SQLRETURN SQLColumns(SQLHSTMT statement_handle, SQLCHAR *catalog_name, SQLSMALLI
 
 SQLRETURN SQLColAttribute(SQLHSTMT statement_handle, SQLUSMALLINT column_number, SQLUSMALLINT field_identifier,
                           SQLPOINTER character_attribute_ptr, SQLSMALLINT buffer_length, SQLSMALLINT *string_length_ptr,
-                          *numeric_attribute_ptr) {
+                          SQLLEN *numeric_attribute_ptr) {
 
 	return duckdb::WithStatementPrepared(statement_handle, [&](duckdb::OdbcHandleStmt *stmt) {
 		if (column_number < 1 || column_number > stmt->stmt->GetTypes().size()) {
@@ -212,7 +212,8 @@ SQLRETURN SQLColAttribute(SQLHSTMT statement_handle, SQLUSMALLINT column_number,
 			return SQL_SUCCESS;
 		}
 		case SQL_DESC_DISPLAY_SIZE: {
-			auto ret = duckdb::ApiInfo::GetColumnSize(stmt->stmt->GetTypes()[col_idx], numeric_attribute_ptr);
+			auto ret =
+			    duckdb::ApiInfo::GetColumnSize(stmt->stmt->GetTypes()[col_idx], (SQLULEN *)numeric_attribute_ptr);
 			if (ret == SQL_ERROR) {
 				stmt->error_messages.emplace_back("Unsupported type for display size.");
 				return SQL_ERROR;


### PR DESCRIPTION
This PR enables the nanodbc test suite. For now, the _simple_test_ is working.