### PR TITLE
Add Value::EMPTY_LIST method, and create a test case where LIST values are used with the appender

### DIFF
--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -448,7 +448,9 @@ Value Value::MAP(Value key, Value value) {
 }
 
 Value Value::LIST(vector<Value> values) {
-	D_ASSERT(!values.empty());
+	if (values.empty()) {
+		throw InternalException("Value::LIST requires a non-empty list of values. Use Value::EMPTY_LIST instead.");
+	}
 #ifdef DEBUG
 	for (idx_t i = 1; i < values.size(); i++) {
 		D_ASSERT(values[i].type() == values[0].type());
@@ -457,6 +459,13 @@ Value Value::LIST(vector<Value> values) {
 	Value result;
 	result.type_ = LogicalType::LIST(values[0].type());
 	result.list_value = move(values);
+	result.is_null = false;
+	return result;
+}
+
+Value Value::EMPTY_LIST(LogicalType child_type) {
+	Value result;
+	result.type_ = LogicalType::LIST(move(child_type));
 	result.is_null = false;
 	return result;
 }

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -449,7 +449,7 @@ Value Value::MAP(Value key, Value value) {
 
 Value Value::LIST(vector<Value> values) {
 	if (values.empty()) {
-		throw InternalException("Value::LIST requires a non-empty list of values. Use Value::EMPTY_LIST instead.");
+		throw InternalException("Value::LIST requires a non-empty list of values. Use Value::EMPTYLIST instead.");
 	}
 #ifdef DEBUG
 	for (idx_t i = 1; i < values.size(); i++) {
@@ -463,7 +463,7 @@ Value Value::LIST(vector<Value> values) {
 	return result;
 }
 
-Value Value::EMPTY_LIST(LogicalType child_type) {
+Value Value::EMPTYLIST(LogicalType child_type) {
 	Value result;
 	result.type_ = LogicalType::LIST(move(child_type));
 	result.is_null = false;

--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -113,6 +113,8 @@ public:
 	DUCKDB_API static Value STRUCT(child_list_t<Value> values);
 	//! Create a list value with the given entries
 	DUCKDB_API static Value LIST(vector<Value> values);
+	//! Create an empty list with the specified type
+	DUCKDB_API static Value EMPTY_LIST(LogicalType child_type);
 	//! Creat a map value from a (key, value) pair
 	DUCKDB_API static Value MAP(Value key, Value value);
 

--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -114,7 +114,7 @@ public:
 	//! Create a list value with the given entries
 	DUCKDB_API static Value LIST(vector<Value> values);
 	//! Create an empty list with the specified type
-	DUCKDB_API static Value EMPTY_LIST(LogicalType child_type);
+	DUCKDB_API static Value EMPTYLIST(LogicalType child_type);
 	//! Creat a map value from a (key, value) pair
 	DUCKDB_API static Value MAP(Value key, Value value);
 

--- a/test/appender/CMakeLists.txt
+++ b/test/appender/CMakeLists.txt
@@ -1,5 +1,11 @@
-add_library_unity(test_appender OBJECT test_appender_abort.cpp
-                  test_appender.cpp test_concurrent_append.cpp)
+add_library_unity(
+  test_appender
+  OBJECT
+  test_appender_abort.cpp
+  test_appender.cpp
+  test_concurrent_append.cpp
+  test_appender_transactions.cpp
+  test_nested_appender.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:test_appender>
     PARENT_SCOPE)

--- a/test/appender/test_appender_transactions.cpp
+++ b/test/appender/test_appender_transactions.cpp
@@ -17,7 +17,6 @@ TEST_CASE("Test the way appenders interact with transactions", "[appender]") {
 	// begin a transaction manually
 	REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION"));
 
-	return;
 	// append a value to the table
 	Appender appender(con, "integers");
 
@@ -33,4 +32,8 @@ TEST_CASE("Test the way appenders interact with transactions", "[appender]") {
 
 	// rolling back cancels the transaction
 	REQUIRE_NO_FAIL(con.Query("ROLLBACK"));
+
+	// now the values are gone
+	result = con.Query("SELECT * FROM integers");
+	REQUIRE(CHECK_COLUMN(result, 0, {}));
 }

--- a/test/appender/test_nested_appender.cpp
+++ b/test/appender/test_nested_appender.cpp
@@ -1,0 +1,56 @@
+#include "catch.hpp"
+#include "duckdb/main/appender.hpp"
+#include "test_helpers.hpp"
+
+#include <vector>
+
+using namespace duckdb;
+using namespace std;
+
+TEST_CASE("Test appender with lists", "[appender]") {
+	unique_ptr<QueryResult> result;
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE lists(i INTEGER[])"));
+
+	// append a value to the table
+	Appender appender(con, "lists");
+
+	auto list_value = Value::LIST({Value::INTEGER(3)});
+	auto empty_list_value = Value::EMPTY_LIST(LogicalType::INTEGER);
+
+	appender.AppendRow(list_value);
+	appender.AppendRow(empty_list_value);
+
+	appender.Close();
+
+	// we can select the value now
+	result = con.Query("SELECT * FROM lists");
+	REQUIRE(CHECK_COLUMN(result, 0, {list_value, empty_list_value}));
+}
+
+TEST_CASE("Test appender with nested lists", "[appender]") {
+	unique_ptr<QueryResult> result;
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE lists(i INTEGER[][])"));
+
+	// append a value to the table
+	Appender appender(con, "lists");
+
+	auto list_value =
+	    Value::LIST({Value::LIST({Value::INTEGER(1)}), Value::LIST({Value::INTEGER(2), Value::INTEGER(3)})});
+	auto empty_list_value = Value::EMPTY_LIST(LogicalType::LIST(LogicalType::INTEGER));
+	auto null_list_value = Value(LogicalType::LIST(LogicalType::LIST(LogicalType::INTEGER)));
+	appender.AppendRow(list_value);
+	appender.AppendRow(empty_list_value);
+	appender.AppendRow(null_list_value);
+
+	appender.Close();
+
+	// we can select the value now
+	result = con.Query("SELECT * FROM lists");
+	REQUIRE(CHECK_COLUMN(result, 0, {list_value, empty_list_value, null_list_value}));
+}

--- a/test/appender/test_nested_appender.cpp
+++ b/test/appender/test_nested_appender.cpp
@@ -18,7 +18,7 @@ TEST_CASE("Test appender with lists", "[appender]") {
 	Appender appender(con, "lists");
 
 	auto list_value = Value::LIST({Value::INTEGER(3)});
-	auto empty_list_value = Value::EMPTY_LIST(LogicalType::INTEGER);
+	auto empty_list_value = Value::EMPTYLIST(LogicalType::INTEGER);
 
 	appender.AppendRow(list_value);
 	appender.AppendRow(empty_list_value);
@@ -42,7 +42,7 @@ TEST_CASE("Test appender with nested lists", "[appender]") {
 
 	auto list_value =
 	    Value::LIST({Value::LIST({Value::INTEGER(1)}), Value::LIST({Value::INTEGER(2), Value::INTEGER(3)})});
-	auto empty_list_value = Value::EMPTY_LIST(LogicalType::LIST(LogicalType::INTEGER));
+	auto empty_list_value = Value::EMPTYLIST(LogicalType::LIST(LogicalType::INTEGER));
 	auto null_list_value = Value(LogicalType::LIST(LogicalType::LIST(LogicalType::INTEGER)));
 	appender.AppendRow(list_value);
 	appender.AppendRow(empty_list_value);


### PR DESCRIPTION
CC @mbasmanova

```cpp
TEST_CASE("Test appender with lists", "[appender]") {
 	unique_ptr<QueryResult> result;
 	DuckDB db(nullptr);
 	Connection con(db);

 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE lists(i INTEGER[])"));

 	// append a value to the table
 	Appender appender(con, "lists");

 	auto list_value = Value::LIST({Value::INTEGER(3)});
 	auto empty_list_value = Value::EMPTY_LIST(LogicalType::INTEGER);

 	appender.AppendRow(list_value);
 	appender.AppendRow(empty_list_value);

 	appender.Close();

 	// we can select the value now
 	result = con.Query("SELECT * FROM lists");
 	REQUIRE(CHECK_COLUMN(result, 0, {list_value, empty_list_value}));
 }

```