### PR TITLE
Issue #2125: fall back to VARCHAR when the type of a prepared statement parameter is ambiguous

### DIFF
--- a/src/function/scalar/nested/list_value.cpp
+++ b/src/function/scalar/nested/list_value.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/storage/statistics/list_statistics.hpp"
+#include "duckdb/planner/expression_binder.hpp"
 
 namespace duckdb {
 
@@ -38,6 +39,7 @@ static unique_ptr<FunctionData> ListValueBind(ClientContext &context, ScalarFunc
 	for (idx_t i = 0; i < arguments.size(); i++) {
 		child_type = LogicalType::MaxLogicalType(child_type, arguments[i]->return_type);
 	}
+	ExpressionBinder::ResolveParameterType(child_type);
 
 	// this is more for completeness reasons
 	bound_function.varargs = child_type;

--- a/src/function/scalar/nested/struct_pack.cpp
+++ b/src/function/scalar/nested/struct_pack.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/common/unordered_set.hpp"
 #include "duckdb/storage/statistics/struct_statistics.hpp"
+#include "duckdb/planner/expression_binder.hpp"
 
 namespace duckdb {
 
@@ -48,6 +49,7 @@ static unique_ptr<FunctionData> StructPackBind(ClientContext &context, ScalarFun
 		if (name_collision_set.find(child->alias) != name_collision_set.end()) {
 			throw BinderException("Duplicate struct entry name \"%s\"", child->alias);
 		}
+		ExpressionBinder::ResolveParameterType(arguments[i]);
 		name_collision_set.insert(child->alias);
 		struct_children.push_back(make_pair(child->alias, arguments[i]->return_type));
 	}

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -77,6 +77,11 @@ public:
 
 	static bool ContainsNullType(const LogicalType &type);
 	static LogicalType ExchangeNullType(const LogicalType &type);
+	static bool ContainsType(const LogicalType &type, LogicalTypeId target);
+	static LogicalType ExchangeType(const LogicalType &type, LogicalTypeId target, LogicalType new_type);
+
+	static void ResolveParameterType(LogicalType &type);
+	static void ResolveParameterType(unique_ptr<Expression> &expr);
 
 protected:
 	virtual BindResult BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth,

--- a/src/planner/binder/expression/bind_case_expression.cpp
+++ b/src/planner/binder/expression/bind_case_expression.cpp
@@ -23,7 +23,9 @@ BindResult ExpressionBinder::BindExpression(CaseExpression &expr, idx_t depth) {
 		auto &then_expr = (BoundExpression &)*check.then_expr;
 		return_type = LogicalType::MaxLogicalType(return_type, then_expr.expr->return_type);
 	}
-	// now rewrite hte case into a chain of cases
+	ExpressionBinder::ResolveParameterType(return_type);
+
+	// now rewrite the case into a chain of cases
 
 	// CASE WHEN e1 THEN r1 WHEN w2 THEN r2 ELSE r3 is rewritten to
 	// CASE WHEN e1 THEN r1 ELSE CASE WHEN e2 THEN r2 ELSE r3

--- a/src/planner/binder/expression/bind_comparison_expression.cpp
+++ b/src/planner/binder/expression/bind_comparison_expression.cpp
@@ -101,7 +101,9 @@ LogicalType BoundComparisonExpression::BindComparison(LogicalType left_type, Log
 		}
 		return result_type;
 	case LogicalTypeId::UNKNOWN:
-		throw BinderException("Could not determine type of parameters: try adding explicit type casts");
+		// comparing two prepared statement parameters (e.g. SELECT ?=?)
+		// default to VARCHAR
+		return LogicalType::VARCHAR;
 	default:
 		return result_type;
 	}

--- a/src/planner/binder/expression/bind_operator_expression.cpp
+++ b/src/planner/binder/expression/bind_operator_expression.cpp
@@ -23,6 +23,8 @@ static LogicalType ResolveInType(OperatorExpression &op, vector<BoundExpression 
 	for (idx_t i = 1; i < children.size(); i++) {
 		max_type = LogicalType::MaxLogicalType(max_type, children[i]->expr->return_type);
 	}
+	ExpressionBinder::ResolveParameterType(max_type);
+
 	// cast all children to the same type
 	for (idx_t i = 0; i < children.size(); i++) {
 		children[i]->expr = BoundCastExpression::AddCastToType(move(children[i]->expr), max_type);
@@ -36,6 +38,7 @@ static LogicalType ResolveOperatorType(OperatorExpression &op, vector<BoundExpre
 	case ExpressionType::OPERATOR_IS_NULL:
 	case ExpressionType::OPERATOR_IS_NOT_NULL:
 		// IS (NOT) NULL always returns a boolean, and does not cast its children
+		ExpressionBinder::ResolveParameterType(children[0]->expr);
 		return LogicalType::BOOLEAN;
 	case ExpressionType::COMPARE_IN:
 	case ExpressionType::COMPARE_NOT_IN:

--- a/src/planner/binder/expression/bind_subquery_expression.cpp
+++ b/src/planner/binder/expression/bind_subquery_expression.cpp
@@ -68,9 +68,7 @@ BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t dept
 	auto bound_node = move(bound_subquery->bound_node);
 	LogicalType return_type =
 	    expr.subquery_type == SubqueryType::SCALAR ? bound_node->types[0] : LogicalType(LogicalTypeId::BOOLEAN);
-	if (return_type.id() == LogicalTypeId::UNKNOWN) {
-		throw BinderException("Could not determine type of parameters: try adding explicit type casts");
-	}
+	D_ASSERT(return_type.id() != LogicalTypeId::UNKNOWN);
 
 	auto result = make_unique<BoundSubqueryExpression>(return_type);
 	if (expr.subquery_type == SubqueryType::ANY) {

--- a/src/planner/expression/bound_parameter_expression.cpp
+++ b/src/planner/expression/bound_parameter_expression.cpp
@@ -42,6 +42,7 @@ unique_ptr<Expression> BoundParameterExpression::Copy() {
 	auto result = make_unique<BoundParameterExpression>(parameter_nr);
 	result->value = value;
 	result->return_type = return_type;
+	result->CopyProperties(*this);
 	return move(result);
 }
 

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -113,45 +113,68 @@ void ExpressionBinder::ExtractCorrelatedExpressions(Binder &binder, Expression &
 	                                      [&](Expression &child) { ExtractCorrelatedExpressions(binder, child); });
 }
 
-bool ExpressionBinder::ContainsNullType(const LogicalType &type) {
+bool ExpressionBinder::ContainsType(const LogicalType &type, LogicalTypeId target) {
+	if (type.id() == target) {
+		return true;
+	}
 	switch (type.id()) {
 	case LogicalTypeId::STRUCT:
 	case LogicalTypeId::MAP: {
 		auto child_count = StructType::GetChildCount(type);
 		for (idx_t i = 0; i < child_count; i++) {
-			if (ContainsNullType(StructType::GetChildType(type, i))) {
+			if (ContainsType(StructType::GetChildType(type, i), target)) {
 				return true;
 			}
 		}
 		return false;
 	}
 	case LogicalTypeId::LIST:
-		return ContainsNullType(ListType::GetChildType(type));
-	case LogicalTypeId::SQLNULL:
-		return true;
+		return ContainsType(ListType::GetChildType(type), target);
 	default:
 		return false;
 	}
 }
 
-LogicalType ExpressionBinder::ExchangeNullType(const LogicalType &type) {
+LogicalType ExpressionBinder::ExchangeType(const LogicalType &type, LogicalTypeId target, LogicalType new_type) {
+	if (type.id() == target) {
+		return new_type;
+	}
 	switch (type.id()) {
 	case LogicalTypeId::STRUCT:
 	case LogicalTypeId::MAP: {
 		// we make a copy of the child types of the struct here
 		auto child_types = StructType::GetChildTypes(type);
 		for (auto &child_type : child_types) {
-			child_type.second = ExchangeNullType(child_type.second);
+			child_type.second = ExchangeType(child_type.second, target, new_type);
 		}
 		return type.id() == LogicalTypeId::MAP ? LogicalType::MAP(move(child_types))
 		                                       : LogicalType::STRUCT(move(child_types));
 	}
 	case LogicalTypeId::LIST:
-		return LogicalType::LIST(ExchangeNullType(ListType::GetChildType(type)));
-	case LogicalTypeId::SQLNULL:
-		return LogicalType::INTEGER;
+		return LogicalType::LIST(ExchangeType(ListType::GetChildType(type), target, new_type));
 	default:
 		return type;
+	}
+}
+
+bool ExpressionBinder::ContainsNullType(const LogicalType &type) {
+	return ContainsType(type, LogicalTypeId::SQLNULL);
+}
+
+LogicalType ExpressionBinder::ExchangeNullType(const LogicalType &type) {
+	return ExchangeType(type, LogicalTypeId::SQLNULL, LogicalType::INTEGER);
+}
+
+void ExpressionBinder::ResolveParameterType(LogicalType &type) {
+	if (type.id() == LogicalTypeId::UNKNOWN) {
+		type = LogicalType::VARCHAR;
+	}
+}
+
+void ExpressionBinder::ResolveParameterType(unique_ptr<Expression> &expr) {
+	if (ContainsType(expr->return_type, LogicalTypeId::UNKNOWN)) {
+		auto result_type = ExchangeType(expr->return_type, LogicalTypeId::UNKNOWN, LogicalType::VARCHAR);
+		expr = BoundCastExpression::AddCastToType(move(expr), result_type);
 	}
 }
 
@@ -175,14 +198,17 @@ unique_ptr<Expression> ExpressionBinder::Bind(unique_ptr<ParsedExpression> &expr
 		// the binder has a specific target type: add a cast to that type
 		result = BoundCastExpression::AddCastToType(move(result), target_type);
 	} else {
-		// SQL NULL type is only used internally in the binder
-		// cast to INTEGER if we encounter it outside of the binder
 		if (!binder.can_contain_nulls) {
+			// SQL NULL type is only used internally in the binder
+			// cast to INTEGER if we encounter it outside of the binder
 			if (ContainsNullType(result->return_type)) {
 				auto result_type = ExchangeNullType(result->return_type);
 				result = BoundCastExpression::AddCastToType(move(result), result_type);
 			}
 		}
+		// check if we failed to convert any parameters
+		// if we did, we push a cast
+		ExpressionBinder::ResolveParameterType(result);
 	}
 	if (result_type) {
 		*result_type = result->return_type;

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -40,7 +40,7 @@ void Planner::CreatePlan(SQLStatement &statement) {
 	for (auto &expr : bound_parameters) {
 		// check if the type of the parameter could be resolved
 		if (expr->return_type.id() == LogicalTypeId::INVALID || expr->return_type.id() == LogicalTypeId::UNKNOWN) {
-			throw BinderException("Could not determine type of parameters: try adding explicit type casts");
+			throw InternalException("Could not determine type of parameters");
 		}
 		auto value = make_unique<Value>(expr->return_type);
 		expr->value = value.get();

--- a/test/sql/prepared/prepare_default_varchar.test
+++ b/test/sql/prepared/prepare_default_varchar.test
@@ -1,0 +1,271 @@
+# name: test/sql/prepared/prepare_default_varchar.test
+# description: Prepared parameters default to VARCHAR if the type could not be deduced
+# group: [prepared]
+
+statement ok
+PRAGMA enable_verification
+
+# single unbound parameter
+statement ok
+PREPARE v1 AS SELECT ?
+
+query I
+EXECUTE v1(27)
+----
+27
+
+query I
+EXECUTE v1('hello world')
+----
+hello world
+
+query I
+EXECUTE v1([1, 2, 3])
+----
+[1, 2, 3]
+
+# comparison between two parameters
+statement ok
+PREPARE v2 AS SELECT ?=?
+
+query I
+EXECUTE v2(27, 27)
+----
+true
+
+query I
+EXECUTE v2('hello world', 'hello mars')
+----
+false
+
+query I
+EXECUTE v2([1, 2, 3], '[1, 2, 3]')
+----
+true
+
+# unbound parameter in scalar subquery
+statement ok
+PREPARE v3 AS SELECT (SELECT ?)
+
+query I
+EXECUTE v3(27)
+----
+27
+
+query I
+EXECUTE v3('hello world')
+----
+hello world
+
+query I
+EXECUTE v3([1, 2, 3])
+----
+[1, 2, 3]
+
+# unbound parameter with IS NULL
+statement ok
+PREPARE v4 AS SELECT ? IS NULL
+
+query I
+EXECUTE v4(27)
+----
+false
+
+query I
+EXECUTE v4('hello world')
+----
+false
+
+query I
+EXECUTE v4(NULL)
+----
+true
+
+# unbound parameter with IN list
+statement ok
+PREPARE v5 AS SELECT ? IN (?, ?)
+
+query I
+EXECUTE v5(27, 27, 28)
+----
+true
+
+query I
+EXECUTE v5('hello world', 'hello', 'world')
+----
+false
+
+query I
+EXECUTE v5(NULL, 27, 28)
+----
+NULL
+
+# unbound parameter with COUNT
+statement ok
+PREPARE v6 AS SELECT COUNT(?)
+
+query I
+EXECUTE v6(27)
+----
+1
+
+query I
+EXECUTE v6('hello world')
+----
+1
+
+query I
+EXECUTE v6(NULL)
+----
+0
+
+# unbound parameter with printf
+statement ok
+PREPARE v7 AS SELECT printf('%s: %s', ?, ?)
+
+query I
+EXECUTE v7('time', 27)
+----
+time: 27
+
+query I
+EXECUTE v7('hello world', [1, 2, 3])
+----
+hello world: [1, 2, 3]
+
+# unbound parameter with lists
+statement ok
+PREPARE v8 AS SELECT [?]
+
+query I
+EXECUTE v8(27)
+----
+[27]
+
+query I
+EXECUTE v8('hello world')
+----
+[hello world]
+
+query I
+EXECUTE v8(NULL)
+----
+[NULL]
+
+# unbound parameter with lists and NULL
+statement ok
+PREPARE v9 AS SELECT [?, NULL]
+
+query I
+EXECUTE v9(27)
+----
+[27, NULL]
+
+query I
+EXECUTE v9('hello world')
+----
+[hello world, NULL]
+
+query I
+EXECUTE v9(NULL)
+----
+[NULL, NULL]
+
+# unbound parameter with structs
+statement ok
+PREPARE v10 AS SELECT {'x': ?}
+
+query I
+EXECUTE v10(27)
+----
+{'x': 27}
+
+query I
+EXECUTE v10('hello world')
+----
+{'x': hello world}
+
+query I
+EXECUTE v10(NULL)
+----
+{'x': NULL}
+
+# unbound parameter with structs and NULL
+statement ok
+PREPARE v11 AS SELECT {'x': ?, 'y': NULL}
+
+query I
+EXECUTE v11(27)
+----
+{'x': 27, 'y': NULL}
+
+query I
+EXECUTE v11('hello world')
+----
+{'x': hello world, 'y': NULL}
+
+query I
+EXECUTE v11(NULL)
+----
+{'x': NULL, 'y': NULL}
+
+# values list
+statement ok
+PREPARE v12 AS SELECT * FROM (VALUES (?, ?), (?, ?)) tbl(i, j)
+
+query II
+EXECUTE v12(27, 28, 29, 30)
+----
+27	28
+29	30
+
+query II
+EXECUTE v12('hello', 'world', 'a', NULL)
+----
+hello	world
+a	NULL
+
+# case
+statement ok
+PREPARE v13 AS SELECT CASE WHEN ? THEN ? ELSE ? END
+
+query I
+EXECUTE v13(1=1, 1, 2)
+----
+1
+
+query I
+EXECUTE v13(1=0, 'hello', 'world')
+----
+world
+
+# parameter and null
+statement ok
+PREPARE v14 AS SELECT ?+NULL
+
+query I
+EXECUTE v14(1)
+----
+NULL
+
+statement ok
+PREPARE v15 AS SELECT ?=NULL
+
+query I
+EXECUTE v15(1)
+----
+NULL
+
+# issue #2125
+statement ok
+PREPARE v16 AS SELECT CASE WHEN (? = 1) AND (? = 2) AND (? = 3) AND ((? IS NULL)) THEN 1.5 ELSE 2.5 END AS a
+
+query I
+EXECUTE v16(1, 2, 3, NULL)
+----
+1.5
+
+query I
+EXECUTE v16(1, 2, 4, NULL)
+----
+2.5

--- a/test/sql/prepared/test_basic_prepare.test
+++ b/test/sql/prepared/test_basic_prepare.test
@@ -58,13 +58,13 @@ PREPARE s1 AS SELECT NOT($1), 10+$2, $3+20, 4 IN (2, 3, $4), $5 IN (2, 3, 4)
 statement ok
 EXECUTE s1(1, 2, 3, 4, 2)
 
-# cannot resolve these types
-statement error
+# these types default to varchar
+statement ok
 PREPARE s1 AS SELECT $1
 
-statement error
-PREPARE s1 AS SELECT (SELECT $1)
+statement ok
+PREPARE s2 AS SELECT (SELECT $1)
 
-statement error
-PREPARE s1 AS SELECT $1=$2
+statement ok
+PREPARE s3 AS SELECT $1=$2
 

--- a/test/sql/prepared/test_issue_2079.test
+++ b/test/sql/prepared/test_issue_2079.test
@@ -28,3 +28,29 @@ query I
 EXECUTE v3(2.0)
 ----
 True
+
+statement ok
+PREPARE v4 AS SELECT 2.0 IN (1.0, 1.5, ?)
+
+query I
+EXECUTE v4(2.0)
+----
+True
+
+query I
+EXECUTE v4(2.5)
+----
+False
+
+statement ok
+PREPARE v5 AS SELECT ? IN (1.0, 1.5, 2.0)
+
+query I
+EXECUTE v5(2.0)
+----
+True
+
+query I
+EXECUTE v5(2.5)
+----
+False


### PR DESCRIPTION
This addresses #2125.

A query such as this which used to fail because of ambiguity in type will now successfully bind:

```sql
PREPARE v1 AS SELECT ?
```

The prepared statement type in this case will default to `VARCHAR` instead of throwing an error.  