### PR TITLE
Fix for Dataframes created from numpy strides

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/vector_conversion.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/vector_conversion.hpp
@@ -42,6 +42,7 @@ struct NumPyArrayWrapper {
 struct PandasColumnBindData {
 	PandasType pandas_type;
 	py::array numpy_col;
+	idx_t numpy_stride;
 	unique_ptr<NumPyArrayWrapper> mask;
 };
 

--- a/tools/pythonpkg/tests/pandas/test_stride.py
+++ b/tools/pythonpkg/tests/pandas/test_stride.py
@@ -1,0 +1,13 @@
+import pandas as pd
+import duckdb
+import numpy as np
+
+class TestPandasStride(object):
+
+    def test_stride(self, duckdb_cursor): 
+        expected_df = pd.DataFrame(np.arange(20).reshape(5, 4), columns=["a", "b", "c", "d"])
+        con = duckdb.connect()
+        con.register('df_view', expected_df)
+        output_df = con.execute("SELECT * FROM df_view;").fetchdf()
+        pd.testing.assert_frame_equal(expected_df, output_df)
+   


### PR DESCRIPTION
Task: #2132 

Basically taking stride values into consideration when scanning the underlying DF NumPy arrays.