### PR TITLE
Cancellaton workflow

### DIFF
--- a/.github/workflows/cancel.yaml
+++ b/.github/workflows/cancel.yaml
@@ -1,0 +1,13 @@
+name: Cancel
+on:
+  workflow_run:
+    workflows: ["main"]
+    types:
+      - requested
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: styfle/cancel-workflow-action@0.9.0
+      with:
+        workflow_id: ${{ github.event.workflow.id }}


### PR DESCRIPTION
Helps reduce contention in the actions build queue by cancelling running workflows if a branch is updated. Works for me in my repos.

This helps somewhat, this action itself might become stalled too (livelock) if all workers are busy. Better than nothing though..