### PR TITLE
Avoid doing complex clean-up in destructors if there is an uncaught exception

### DIFF
--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -29,7 +29,10 @@ Appender::Appender(Connection &con, const string &table_name) : Appender(con, DE
 }
 
 Appender::~Appender() {
-	// flush any remaining chunks
+	if (std::uncaught_exception()) {
+		return;
+	}
+	// flush any remaining chunks, but only if we are not cleaning up the appender as part of an exception stack unwind
 	// wrapped in a try/catch because Close() can throw if the table was dropped in the meantime
 	try {
 		Close();

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -58,6 +58,11 @@ ClientContext::ClientContext(shared_ptr<DatabaseInstance> database)
 }
 
 ClientContext::~ClientContext() {
+	if (std::uncaught_exception()) {
+		return;
+	}
+	// destroy the client context and rollback if there is an active transaction
+	// but only if we are not destroying this client context as part of an exception stack unwind
 	Destroy();
 }
 

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -27,7 +27,12 @@ DatabaseInstance::DatabaseInstance() {
 }
 
 DatabaseInstance::~DatabaseInstance() {
+	if (std::uncaught_exception()) {
+		return;
+	}
+
 	// shutting down: attempt to checkpoint the database
+	// but only if we are not cleaning up as part of an exception unwind
 	try {
 		auto &storage = StorageManager::GetStorageManager(*this);
 		if (!storage.InMemory()) {

--- a/src/main/stream_query_result.cpp
+++ b/src/main/stream_query_result.cpp
@@ -13,6 +13,9 @@ StreamQueryResult::StreamQueryResult(StatementType statement_type, shared_ptr<Cl
 }
 
 StreamQueryResult::~StreamQueryResult() {
+	if (std::uncaught_exception()) {
+		return;
+	}
 	Close();
 }
 

--- a/src/main/stream_query_result.cpp
+++ b/src/main/stream_query_result.cpp
@@ -13,9 +13,6 @@ StreamQueryResult::StreamQueryResult(StatementType statement_type, shared_ptr<Cl
 }
 
 StreamQueryResult::~StreamQueryResult() {
-	if (std::uncaught_exception()) {
-		return;
-	}
 	Close();
 }
 

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -395,6 +395,18 @@ TEST_CASE("Test fetch API with big results", "[api][.]") {
 	VerifyStreamResult(move(result));
 }
 
+TEST_CASE("Test streaming query during stack unwinding", "[api]") {
+	DuckDB db;
+	Connection con(db);
+
+	try {
+		auto result = con.SendQuery("SELECT * FROM range(1000000)");
+
+		throw std::runtime_error("hello");
+	} catch (...) {
+	}
+}
+
 TEST_CASE("Test prepare dependencies with multiple connections", "[catalog]") {
 	unique_ptr<QueryResult> result;
 	DuckDB db(nullptr);


### PR DESCRIPTION
This allows us to distinguish situations in which objects are destroyed "naturally" (i.e. out-of-scope) versus when they are destroyed as part of stack unwinding when an exception is thrown. This prevents us from throwing an exception while the stack is unwinding, which causes an unrecoverable failure.