### PR TITLE
Issue #2181: QUANTILE coverage issues

### DIFF
--- a/src/function/aggregate/holistic/quantile.cpp
+++ b/src/function/aggregate/holistic/quantile.cpp
@@ -12,6 +12,11 @@
 
 namespace duckdb {
 
+// HUGEINT scaling by a double
+hugeint_t operator*(const hugeint_t &h, const double &d) {
+	return Hugeint::Convert(Hugeint::Cast<double>(h) * d);
+}
+
 using FrameBounds = std::pair<idx_t, idx_t>;
 
 struct QuantileState {
@@ -147,7 +152,7 @@ struct IndirectLess {
 
 template <class INPUT_TYPE, class TARGET_TYPE, bool DISCRETE>
 struct Interpolator {
-	Interpolator(const float q, const idx_t n_p) : n(n_p), RN((double)(n_p - 1) * q), FRN(floor(RN)), CRN(ceil(RN)) {
+	Interpolator(const double q, const idx_t n_p) : n(n_p), RN((double)(n_p - 1) * q), FRN(floor(RN)), CRN(ceil(RN)) {
 	}
 
 	TARGET_TYPE operator()(INPUT_TYPE *v_t) const {
@@ -183,7 +188,7 @@ struct Interpolator {
 
 template <class INPUT_TYPE, class TARGET_TYPE>
 struct Interpolator<INPUT_TYPE, TARGET_TYPE, true> {
-	Interpolator(const float q, const idx_t n_p) : n(n_p), RN((double)(n_p - 1) * q), FRN(floor(RN)), CRN(FRN) {
+	Interpolator(const double q, const idx_t n_p) : n(n_p), RN((double)(n_p - 1) * q), FRN(floor(RN)), CRN(FRN) {
 	}
 
 	TARGET_TYPE operator()(INPUT_TYPE *v_t) const {
@@ -202,15 +207,15 @@ struct Interpolator<INPUT_TYPE, TARGET_TYPE, true> {
 };
 
 struct QuantileBindData : public FunctionData {
-	explicit QuantileBindData(float quantile_p) : quantiles(1, quantile_p), order(1, 0) {
+	explicit QuantileBindData(double quantile_p) : quantiles(1, quantile_p), order(1, 0) {
 	}
 
-	explicit QuantileBindData(const vector<float> &quantiles_p) : quantiles(quantiles_p) {
+	explicit QuantileBindData(const vector<double> &quantiles_p) : quantiles(quantiles_p) {
 		for (idx_t i = 0; i < quantiles.size(); ++i) {
 			order.push_back(i);
 		}
 
-		IndirectLess<float> lt(quantiles.data());
+		IndirectLess<double> lt(quantiles.data());
 		std::sort(order.begin(), order.end(), lt);
 	}
 
@@ -223,7 +228,7 @@ struct QuantileBindData : public FunctionData {
 		return quantiles == other.quantiles;
 	}
 
-	vector<float> quantiles;
+	vector<double> quantiles;
 	vector<idx_t> order;
 };
 
@@ -649,7 +654,7 @@ AggregateFunction GetContinuousQuantileAggregateFunction(const LogicalType &type
 		case PhysicalType::INT128:
 			return GetTypedContinuousQuantileAggregateFunction<hugeint_t, hugeint_t>(type, type);
 		default:
-			throw NotImplementedException("Unimplemented discrete quantile list aggregate");
+			throw NotImplementedException("Unimplemented continuous quantile DECIMAL aggregate");
 		}
 		break;
 
@@ -661,7 +666,7 @@ AggregateFunction GetContinuousQuantileAggregateFunction(const LogicalType &type
 		return GetTypedContinuousQuantileAggregateFunction<dtime_t, dtime_t>(type, type);
 
 	default:
-		throw NotImplementedException("Unimplemented discrete quantile list aggregate");
+		throw NotImplementedException("Unimplemented continuous quantile aggregate");
 	}
 }
 
@@ -695,15 +700,15 @@ AggregateFunction GetContinuousQuantileListAggregateFunction(const LogicalType &
 	case LogicalTypeId::DECIMAL:
 		switch (type.InternalType()) {
 		case PhysicalType::INT16:
-			return GetTypedContinuousQuantileListAggregateFunction<int16_t, double>(type, LogicalType::DOUBLE);
+			return GetTypedContinuousQuantileListAggregateFunction<int16_t, int16_t>(type, type);
 		case PhysicalType::INT32:
-			return GetTypedContinuousQuantileListAggregateFunction<int32_t, double>(type, LogicalType::DOUBLE);
+			return GetTypedContinuousQuantileListAggregateFunction<int32_t, int32_t>(type, type);
 		case PhysicalType::INT64:
-			return GetTypedContinuousQuantileListAggregateFunction<int64_t, double>(type, LogicalType::DOUBLE);
+			return GetTypedContinuousQuantileListAggregateFunction<int64_t, int64_t>(type, type);
 		case PhysicalType::INT128:
-			return GetTypedContinuousQuantileListAggregateFunction<hugeint_t, double>(type, LogicalType::DOUBLE);
+			return GetTypedContinuousQuantileListAggregateFunction<hugeint_t, hugeint_t>(type, type);
 		default:
-			throw NotImplementedException("Unimplemented discrete quantile list aggregate");
+			throw NotImplementedException("Unimplemented discrete quantile DECIMAL list aggregate");
 		}
 		break;
 
@@ -733,8 +738,8 @@ unique_ptr<FunctionData> BindMedianDecimal(ClientContext &context, AggregateFunc
 	return bind_data;
 }
 
-static float CheckQuantile(const Value &quantile_val) {
-	auto quantile = quantile_val.GetValue<float>();
+static double CheckQuantile(const Value &quantile_val) {
+	auto quantile = quantile_val.GetValue<double>();
 
 	if (quantile_val.is_null || quantile < 0 || quantile > 1) {
 		throw BinderException("QUANTILE can only take parameters in the range [0, 1]");
@@ -749,7 +754,7 @@ unique_ptr<FunctionData> BindQuantile(ClientContext &context, AggregateFunction 
 		throw BinderException("QUANTILE can only take constant parameters");
 	}
 	Value quantile_val = ExpressionExecutor::EvaluateScalar(*arguments[1]);
-	vector<float> quantiles;
+	vector<double> quantiles;
 	if (quantile_val.type().id() != LogicalTypeId::LIST) {
 		quantiles.push_back(CheckQuantile(quantile_val));
 	} else {
@@ -770,10 +775,26 @@ unique_ptr<FunctionData> BindDiscreteQuantileDecimal(ClientContext &context, Agg
 	return bind_data;
 }
 
+unique_ptr<FunctionData> BindDiscreteQuantileDecimalList(ClientContext &context, AggregateFunction &function,
+                                                         vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = BindQuantile(context, function, arguments);
+	function = GetDiscreteQuantileListAggregateFunction(arguments[0]->return_type);
+	function.name = "quantile_disc";
+	return bind_data;
+}
+
 unique_ptr<FunctionData> BindContinuousQuantileDecimal(ClientContext &context, AggregateFunction &function,
                                                        vector<unique_ptr<Expression>> &arguments) {
 	auto bind_data = BindQuantile(context, function, arguments);
 	function = GetContinuousQuantileAggregateFunction(arguments[0]->return_type);
+	function.name = "quantile_cont";
+	return bind_data;
+}
+
+unique_ptr<FunctionData> BindContinuousQuantileDecimalList(ClientContext &context, AggregateFunction &function,
+                                                           vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = BindQuantile(context, function, arguments);
+	function = GetContinuousQuantileListAggregateFunction(arguments[0]->return_type);
 	function.name = "quantile_cont";
 	return bind_data;
 }
@@ -789,7 +810,7 @@ AggregateFunction GetDiscreteQuantileAggregate(const LogicalType &type) {
 	auto fun = GetDiscreteQuantileAggregateFunction(type);
 	fun.bind = BindQuantile;
 	// temporarily push an argument so we can bind the actual quantile
-	fun.arguments.push_back(LogicalType::FLOAT);
+	fun.arguments.push_back(LogicalType::DOUBLE);
 	return fun;
 }
 
@@ -797,8 +818,8 @@ AggregateFunction GetDiscreteQuantileListAggregate(const LogicalType &type) {
 	auto fun = GetDiscreteQuantileListAggregateFunction(type);
 	fun.bind = BindQuantile;
 	// temporarily push an argument so we can bind the actual quantile
-	auto list_of_float = LogicalType::LIST(LogicalType::FLOAT);
-	fun.arguments.push_back(list_of_float);
+	auto list_of_double = LogicalType::LIST(LogicalType::DOUBLE);
+	fun.arguments.push_back(list_of_double);
 	return fun;
 }
 
@@ -806,7 +827,7 @@ AggregateFunction GetContinuousQuantileAggregate(const LogicalType &type) {
 	auto fun = GetContinuousQuantileAggregateFunction(type);
 	fun.bind = BindQuantile;
 	// temporarily push an argument so we can bind the actual quantile
-	fun.arguments.push_back(LogicalType::FLOAT);
+	fun.arguments.push_back(LogicalType::DOUBLE);
 	return fun;
 }
 
@@ -830,14 +851,20 @@ void QuantileFun::RegisterFunction(BuiltinFunctions &set) {
 	                                     nullptr, nullptr, nullptr, BindMedianDecimal));
 
 	AggregateFunctionSet quantile_disc("quantile_disc");
-	quantile_disc.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::FLOAT}, LogicalTypeId::DECIMAL,
+	quantile_disc.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::DOUBLE}, LogicalTypeId::DECIMAL,
 	                                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
 	                                            BindDiscreteQuantileDecimal));
+	quantile_disc.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::LIST(LogicalType::DOUBLE)},
+	                                            LogicalType::LIST(LogicalTypeId::DECIMAL), nullptr, nullptr, nullptr,
+	                                            nullptr, nullptr, nullptr, BindDiscreteQuantileDecimalList));
 
 	AggregateFunctionSet quantile_cont("quantile_cont");
-	quantile_cont.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::FLOAT}, LogicalTypeId::DECIMAL,
+	quantile_cont.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::DOUBLE}, LogicalTypeId::DECIMAL,
 	                                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
 	                                            BindContinuousQuantileDecimal));
+	quantile_cont.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::LIST(LogicalType::DOUBLE)},
+	                                            LogicalType::LIST(LogicalTypeId::DECIMAL), nullptr, nullptr, nullptr,
+	                                            nullptr, nullptr, nullptr, BindContinuousQuantileDecimalList));
 
 	for (const auto &type : QUANTILES) {
 		median.AddFunction(GetMedianAggregate(type));

--- a/test/sql/aggregate/aggregates/test_quantile_cont.test
+++ b/test/sql/aggregate/aggregates/test_quantile_cont.test
@@ -60,6 +60,16 @@ SELECT quantile_cont(r, 0.25), quantile_cont(r, 0.5), quantile_cont(r, 0.75) fro
 499950
 749925
 
+foreach type decimal(4,1) decimal(8,1) decimal(12,1) decimal(18,1) decimal(24,1)
+
+query III
+SELECT quantile_cont(d::${type}, 0.25), quantile_cont(d::${type}, 0.5), quantile_cont(d::${type}, 0.75)
+FROM range(0,100) tbl(d)
+----
+24.7	49.5	74.2
+
+endloop
+
 # multiple groups
 query RR
 SELECT mod(r,1000) as g, quantile_cont(r, 0.25) FROM quantile GROUP BY 1 ORDER BY 1

--- a/test/sql/aggregate/aggregates/test_quantile_cont_list.test
+++ b/test/sql/aggregate/aggregates/test_quantile_cont_list.test
@@ -11,34 +11,45 @@ create table quantiles as select range r, random() FROM range(0,1000000,100) uni
 
 # temporal types
 query I
-SELECT quantile_cont('2021-01-01'::TIMESTAMP + interval (r/100) hour, LIST_VALUE(0.25, 0.5, 0.75)) FROM quantiles
+SELECT quantile_cont('2021-01-01'::TIMESTAMP + interval (r/100) hour, [0.25, 0.5, 0.75]) FROM quantiles
 ----
 [2021-04-15 03:45:00, 2021-07-28 07:30:00, 2021-11-09 11:15:00]
 
 query I
-SELECT quantile_cont('1990-01-01'::DATE + interval (r/100) day, LIST_VALUE(0.25, 0.5, 0.75)) FROM quantiles
+SELECT quantile_cont('1990-01-01'::DATE + interval (r/100) day, [0.25, 0.5, 0.75]) FROM quantiles
 ----
 [1996-11-04 18:00:00, 2003-09-09 12:00:00, 2010-07-14 06:00:00]
 
 query I
-SELECT quantile_cont('00:00:00'::TIME + interval (r/100) second, LIST_VALUE(0.25, 0.5, 0.75)) FROM quantiles
+SELECT quantile_cont('00:00:00'::TIME + interval (r/100) second, [0.25, 0.5, 0.75]) FROM quantiles
 ----
 [00:41:39.75, 01:23:19.5, 02:04:59.25]
 
 statement error
-SELECT quantile_cont(interval (r/100) second, LIST_VALUE(0.25, 0.5, 0.75)) FROM quantiles
+SELECT quantile_cont(interval (r/100) second, [0.25, 0.5, 0.75]) FROM quantiles
 ----
 [00:16:39, 01:23:19, 02:29:59]
 
 # single GROUP
 query R
-SELECT quantile_cont(r, LIST_VALUE(0.25, 0.5, 0.75)) FROM quantiles
+SELECT quantile_cont(r, [0.25, 0.5, 0.75]) FROM quantiles
 ----
 [249975.000000, 499950.000000, 749925.000000]
 
+# Decimals
+foreach type decimal(4,1) decimal(8,1) decimal(12,1) decimal(18,1) decimal(24,1)
+
+query I
+SELECT quantile_cont(d::${type}, [0.25, 0.5, 0.75])
+FROM range(0,100) tbl(d)
+----
+[24.7, 49.5, 74.2]
+
+endloop
+
 # multiple groups
 query RR
-SELECT mod(r,1000) as g, quantile_cont(r, LIST_VALUE(0.25, 0.5, 0.75)) FROM quantiles GROUP BY 1 ORDER BY 1
+SELECT mod(r,1000) as g, quantile_cont(r, [0.25, 0.5, 0.75]) FROM quantiles GROUP BY 1 ORDER BY 1
 ----
 NULL	NULL
 0	[249750.000000, 499500.000000, 749250.000000]
@@ -54,19 +65,19 @@ NULL	NULL
 
 # constant input
 query R
-SELECT quantile_cont(1, LIST_VALUE(0.25, 0.5, 0.75)) FROM quantiles
+SELECT quantile_cont(1, [0.25, 0.5, 0.75]) FROM quantiles
 ----
 [1.000000, 1.000000, 1.000000]
 
 # empty input
 query R
-SELECT quantile_cont(r, LIST_VALUE(0.25, 0.5, 0.75)) FROM quantiles WHERE 1=0
+SELECT quantile_cont(r, [0.25, 0.5, 0.75]) FROM quantiles WHERE 1=0
 ----
 NULL
 
 # empty list
 query R
-SELECT quantile_cont(r, LIST_VALUE()) FROM quantiles
+SELECT quantile_cont(r, []) FROM quantiles
 ----
 []
 
@@ -78,13 +89,13 @@ PRAGMA force_parallelism
 
 # single GROUP
 query R
-SELECT quantile_cont(r, LIST_VALUE(0.25, 0.5, 0.75)) FROM quantiles
+SELECT quantile_cont(r, [0.25, 0.5, 0.75]) FROM quantiles
 ----
 [249975.000000, 499950.000000, 749925.000000]
 
 # multiple groups
 query RR
-SELECT mod(r,1000) as g, quantile_cont(r, LIST_VALUE(0.25, 0.5, 0.75)) FROM quantiles GROUP BY 1 ORDER BY 1
+SELECT mod(r,1000) as g, quantile_cont(r, [0.25, 0.5, 0.75]) FROM quantiles GROUP BY 1 ORDER BY 1
 ----
 NULL	NULL
 0	[249750.000000, 499500.000000, 749250.000000]
@@ -100,36 +111,36 @@ NULL	NULL
 
 # constant input
 query R
-SELECT quantile_cont(1, LIST_VALUE(0.25, 0.5, 0.75)) FROM quantiles
+SELECT quantile_cont(1, [0.25, 0.5, 0.75]) FROM quantiles
 ----
 [1.000000, 1.000000, 1.000000]
 
 # empty input
 query R
-SELECT quantile_cont(r, LIST_VALUE(0.25, 0.5, 0.75)) FROM quantiles WHERE 1=0
+SELECT quantile_cont(r, [0.25, 0.5, 0.75]) FROM quantiles WHERE 1=0
 ----
 NULL
 
 # empty list
 query R
-SELECT quantile_cont(r, LIST_VALUE()) FROM quantiles
+SELECT quantile_cont(r, []) FROM quantiles
 ----
 []
 
 statement error
-SELECT quantile_cont(r, LIST_VALUE(-0.25, 0.5, 0.75)) FROM quantiles
+SELECT quantile_cont(r, [-0.25, 0.5, 0.75]) FROM quantiles
 
 statement error
 SELECT quantile_cont(r, (0.25, 0.5, 1.1)) FROM quantiles
 
 statement error
-SELECT quantile_cont(r, LIST_VALUE(0.25, 0.5, NULL)) FROM quantiles
+SELECT quantile_cont(r, [0.25, 0.5, NULL]) FROM quantiles
 
 statement error
-SELECT quantile_cont(r, LIST_VALUE("0.25", "0.5", "0.75")) FROM quantiles
+SELECT quantile_cont(r, ["0.25", "0.5", "0.75"]) FROM quantiles
 
 statement error
-SELECT quantile_cont(r::string, LIST_VALUE(0.25, 0.5, 0.75)) FROM quantiles
+SELECT quantile_cont(r::string, [0.25, 0.5, 0.75]) FROM quantiles
 
 statement error
-SELECT quantile_cont(r, LIST_VALUE(0.25, 0.5, 0.75), 50) FROM quantiles
+SELECT quantile_cont(r, [0.25, 0.5, 0.75], 50) FROM quantiles

--- a/test/sql/aggregate/aggregates/test_quantile_disc.test
+++ b/test/sql/aggregate/aggregates/test_quantile_disc.test
@@ -6,7 +6,11 @@ statement ok
 PRAGMA enable_verification
 
 statement ok
-create table quantile as select range r, random() from range(10000) union all values (NULL, 0.1), (NULL, 0.5), (NULL, 0.9) order by 2;
+CREATE TABLE quantile as
+SELECT range r, random() AS q
+FROM range(10000)
+UNION ALL VALUES (NULL, 0.1), (NULL, 0.5), (NULL, 0.9)
+ORDER BY 2;
 
 query I
 SELECT quantile_disc(r, 0.5) FROM quantile
@@ -55,6 +59,16 @@ SELECT quantile_disc(r, 0.1), quantile_disc(r, 0.5), quantile_disc(r, 0.9) from 
 999
 4999
 8999
+
+foreach type decimal(4,1) decimal(8,1) decimal(12,1) decimal(18,1) decimal(24,1)
+
+query III
+SELECT quantile_disc(d::${type}, 0.1), quantile_disc(d::${type}, 0.5), quantile_disc(d::${type}, 0.9)
+FROM range(0,100) tbl(d)
+----
+9.0	49.0	89.0
+
+endloop
 
 # multiple groups
 query II
@@ -106,6 +120,7 @@ SELECT quantile_disc(r, 0.1) FROM quantile WHERE 1=0
 ----
 NULL
 
+# Invalid usage
 statement error
 SELECT quantile_disc(r, -0.1) FROM quantile
 
@@ -127,6 +142,8 @@ SELECT quantile_disc(r) FROM quantile
 statement error
 SELECT quantile_disc(r, 0.1, 50) FROM quantile
 
+statement error
+SELECT quantile_cont(r, q) FROM quantile
 
 statement ok
 pragma threads=4
@@ -169,4 +186,3 @@ query I
 SELECT quantile_disc(r, 0.1) FROM quantile WHERE 1=0
 ----
 NULL
-

--- a/test/sql/aggregate/aggregates/test_quantile_disc_list.test
+++ b/test/sql/aggregate/aggregates/test_quantile_disc_list.test
@@ -11,13 +11,23 @@ create table quantiles as select range r, random() FROM range(10000) union all v
 
 # single GROUP
 query I
-SELECT quantile_disc(r, LIST_VALUE(0.1, 0.5, 0.9)) FROM quantiles
+SELECT quantile_disc(r, [0.1, 0.5, 0.9]) FROM quantiles
 ----
 [999, 4999, 8999]
 
+foreach type decimal(4,1) decimal(8,1) decimal(12,1) decimal(18,1) decimal(24,1)
+
+query I
+SELECT quantile_disc(d::${type}, [0.1, 0.5, 0.9])
+FROM range(0,100) tbl(d)
+----
+[9.0, 49.0, 89.0]
+
+endloop
+
 # multiple groups
 query II
-SELECT mod(r,10) as g, quantile_disc(r, LIST_VALUE(0.1, 0.5, 0.9)) FROM quantiles GROUP BY 1 ORDER BY 1
+SELECT mod(r,10) as g, quantile_disc(r, [0.1, 0.5, 0.9]) FROM quantiles GROUP BY 1 ORDER BY 1
 ----
 NULL	NULL
 0	[990, 4990, 8990]
@@ -33,40 +43,40 @@ NULL	NULL
 
 # constant input
 query I
-SELECT quantile_disc(1, LIST_VALUE(0.1, 0.5, 0.9)) FROM quantiles
+SELECT quantile_disc(1, [0.1, 0.5, 0.9]) FROM quantiles
 ----
 [1, 1, 1]
 
 # empty input
 query I
-SELECT quantile_disc(r, LIST_VALUE(0.1, 0.5, 0.9)) FROM quantiles WHERE 1=0
+SELECT quantile_disc(r, [0.1, 0.5, 0.9]) FROM quantiles WHERE 1=0
 ----
 NULL
 
 # empty list
 query I
-SELECT quantile_disc(r, LIST_VALUE()) FROM quantiles
+SELECT quantile_disc(r, []) FROM quantiles
 ----
 []
 
 # temporal types
 query I
-SELECT quantile_disc('2021-01-01'::TIMESTAMP + interval (r) hour, LIST_VALUE(0.1, 0.5, 0.9)) FROM quantiles
+SELECT quantile_disc('2021-01-01'::TIMESTAMP + interval (r) hour, [0.1, 0.5, 0.9]) FROM quantiles
 ----
 [2021-02-11 15:00:00, 2021-07-28 07:00:00, 2022-01-10 23:00:00]
 
 query I
-SELECT quantile_disc('1990-01-01'::DATE + interval (r) day, LIST_VALUE(0.1, 0.5, 0.9)) FROM quantiles
+SELECT quantile_disc('1990-01-01'::DATE + interval (r) day, [0.1, 0.5, 0.9]) FROM quantiles
 ----
 [1992-09-26, 2003-09-09, 2014-08-22]
 
 query I
-SELECT quantile_disc('00:00:00'::TIME + interval (r) second, LIST_VALUE(0.1, 0.5, 0.9)) FROM quantiles
+SELECT quantile_disc('00:00:00'::TIME + interval (r) second, [0.1, 0.5, 0.9]) FROM quantiles
 ----
 [00:16:39, 01:23:19, 02:29:59]
 
 query I
-SELECT quantile_disc(interval (r) second, LIST_VALUE(0.1, 0.5, 0.9)) FROM quantiles
+SELECT quantile_disc(interval (r) second, [0.1, 0.5, 0.9]) FROM quantiles
 ----
 [00:16:39, 01:23:19, 02:29:59]
 
@@ -78,13 +88,13 @@ PRAGMA force_parallelism
 
 # single GROUP
 query I
-SELECT quantile_disc(r, LIST_VALUE(0.1, 0.5, 0.9)) FROM quantiles
+SELECT quantile_disc(r, [0.1, 0.5, 0.9]) FROM quantiles
 ----
 [999, 4999, 8999]
 
 # multiple groups
 query II
-SELECT mod(r,10) as g, quantile_disc(r, LIST_VALUE(0.1, 0.5, 0.9)) FROM quantiles GROUP BY 1 ORDER BY 1
+SELECT mod(r,10) as g, quantile_disc(r, [0.1, 0.5, 0.9]) FROM quantiles GROUP BY 1 ORDER BY 1
 ----
 NULL	NULL
 0	[990, 4990, 8990]
@@ -100,36 +110,36 @@ NULL	NULL
 
 # constant input
 query I
-SELECT quantile_disc(1, LIST_VALUE(0.1, 0.5, 0.9)) FROM quantiles
+SELECT quantile_disc(1, [0.1, 0.5, 0.9]) FROM quantiles
 ----
 [1, 1, 1]
 
 # empty input
 query I
-SELECT quantile_disc(r, LIST_VALUE(0.1, 0.5, 0.9)) FROM quantiles WHERE 1=0
+SELECT quantile_disc(r, [0.1, 0.5, 0.9]) FROM quantiles WHERE 1=0
 ----
 NULL
 
 # empty list
 query I
-SELECT quantile_disc(r, LIST_VALUE()) FROM quantiles
+SELECT quantile_disc(r, []) FROM quantiles
 ----
 []
 
 statement error
-SELECT quantile_disc(r, LIST_VALUE(-0.1, 0.5, 0.9)) FROM quantiles
+SELECT quantile_disc(r, [-0.1, 0.5, 0.9]) FROM quantiles
 
 statement error
 SELECT quantile_disc(r, (0.1, 0.5, 1.1)) FROM quantiles
 
 statement error
-SELECT quantile_disc(r, LIST_VALUE(0.1, 0.5, NULL)) FROM quantiles
+SELECT quantile_disc(r, [0.1, 0.5, NULL]) FROM quantiles
 
 statement error
-SELECT quantile_disc(r, LIST_VALUE("0.1", "0.5", "0.9")) FROM quantiles
+SELECT quantile_disc(r, ["0.1", "0.5", "0.9"]) FROM quantiles
 
 statement error
-SELECT quantile_disc(r::string, LIST_VALUE(0.1, 0.5, 0.9)) FROM quantiles
+SELECT quantile_disc(r::string, [0.1, 0.5, 0.9]) FROM quantiles
 
 statement error
-SELECT quantile_disc(r, LIST_VALUE(0.1, 0.5, 0.9), 50) FROM quantiles
+SELECT quantile_disc(r, [0.1, 0.5, 0.9], 50) FROM quantiles

--- a/test/sql/window/test_quantile_window.test
+++ b/test/sql/window/test_quantile_window.test
@@ -154,3 +154,154 @@ NULL	NULL	4
 7	NULL	4
 8	8	4
 9	NULL	4
+
+#
+# Coverage tests
+#
+
+# ReuseIndexes, backwards moving frame
+query II
+WITH t(i, p, f) AS (VALUES
+	(0, 1, 1),
+	(1, 1, 1),
+	(2, 1, 1),
+	(3, 3, 1),
+	(4, 1, 1),
+	(5, 3, 1)
+)
+SELECT i, MEDIAN(i) OVER (ORDER BY i ROWS BETWEEN p PRECEDING and f FOLLOWING)
+FROM t
+ORDER BY 1
+----
+0	0.500000
+1	1.000000
+2	2.000000
+3	2.000000
+4	4.000000
+5	3.500000
+
+# CanReplace
+query II
+WITH t(r, i, p, f) AS (VALUES
+	(0, 0, 1, 1),
+	(1, 1, 1, 1),
+	(2, 2, 1, 1),
+	(3, 0, 1, 1),
+	(4, 1, 1, 1),
+	(5, 2, 1, 1)
+)
+SELECT r, MEDIAN(i) OVER (ORDER BY r ROWS BETWEEN p PRECEDING and f FOLLOWING)
+FROM t
+ORDER BY 1
+----
+0	0.500000
+1	1.000000
+2	1.000000
+3	1.000000
+4	1.000000
+5	1.500000
+
+# Moving discrete list
+query II
+WITH t(r, i, p, f) AS (VALUES
+	(0, 0, 1, 2),
+	(1, 1, 1, 2),
+	(2, 2, 1, 2),
+	(3, 3, 1, 2),
+	(4, 4, 1, 2),
+	(5, 5, 1, 2)
+)
+SELECT r, QUANTILE_DISC(i, [0.25, 0.5, 0.75]) OVER (ORDER BY r ROWS BETWEEN p PRECEDING and f FOLLOWING)
+FROM t
+ORDER BY 1
+----
+0	[0, 1, 1]
+1	[0, 1, 2]
+2	[1, 2, 3]
+3	[2, 3, 4]
+4	[3, 4, 4]
+5	[4, 4, 4]
+
+# Moving discrete list with NULLs
+query II
+WITH t(r, i, p, f) AS (VALUES
+	(0, NULL, 1, 2),
+	(1, 1, 1, 2),
+	(2, 2, 1, 2),
+	(3, 3, 1, 2),
+	(4, 4, 1, 2),
+	(5, 5, 1, 2)
+)
+SELECT r, QUANTILE_DISC(i, [0.25, 0.5, 0.75]) OVER (ORDER BY r ROWS BETWEEN p PRECEDING and f FOLLOWING)
+FROM t
+ORDER BY 1
+----
+0	[1, 1, 1]
+1	[1, 2, 2]
+2	[1, 2, 3]
+3	[2, 3, 4]
+4	[3, 4, 4]
+5	[4, 4, 4]
+
+# Moving discrete list with all NULLs
+query II
+WITH t(r, i, p, f) AS (VALUES
+	(0, NULL, 1, 2),
+	(1, NULL, 1, 2),
+	(2, NULL, 1, 2),
+	(3, NULL, 1, 2),
+	(4, NULL, 1, 2),
+	(5, NULL, 1, 2)
+)
+SELECT r, QUANTILE_DISC(i, [0.25, 0.5, 0.75]) OVER (ORDER BY r ROWS BETWEEN p PRECEDING and f FOLLOWING)
+FROM t
+ORDER BY 1
+----
+0	NULL
+1	NULL
+2	NULL
+3	NULL
+4	NULL
+5	NULL
+
+# Moving continuous list
+query II
+WITH t(r, i, p, f) AS (VALUES
+	(0, 0, 1, 2),
+	(1, 1, 1, 2),
+	(2, 2, 1, 2),
+	(3, 3, 1, 2),
+	(4, 4, 1, 2),
+	(5, 5, 1, 2)
+)
+SELECT r, QUANTILE_CONT(i, [0.25, 0.5, 0.75]) OVER (ORDER BY r ROWS BETWEEN p PRECEDING and f FOLLOWING)
+FROM t
+ORDER BY 1
+----
+0	[0.500000, 1.000000, 1.500000]
+1	[0.750000, 1.500000, 2.250000]
+2	[1.750000, 2.500000, 3.250000]
+3	[2.750000, 3.500000, 4.250000]
+4	[3.500000, 4.000000, 4.500000]
+5	[4.250000, 4.500000, 4.750000]
+
+# Moving continuous list with replacement
+query II
+WITH t(r, i, p, f) AS (VALUES
+	(0, 0, 1, 2),
+	(1, 1, 1, 2),
+	(2, 2, 1, 2),
+	(3, 0, 1, 2),
+	(4, 1, 1, 2),
+	(5, 2, 1, 2)
+)
+SELECT r, QUANTILE_CONT(i, [0.25, 0.5, 0.75]) OVER (ORDER BY r ROWS BETWEEN p PRECEDING and f FOLLOWING)
+FROM t
+ORDER BY 1
+----
+0	[0.500000, 1.000000, 1.500000]
+1	[0.000000, 0.500000, 1.250000]
+2	[0.750000, 1.000000, 1.250000]
+3	[0.750000, 1.500000, 2.000000]
+4	[0.500000, 1.000000, 1.500000]
+5	[1.250000, 1.500000, 1.750000]


### PR DESCRIPTION
- Missing implementations for LIST<DECIMAL> Instead, we were returning LIST<DOUBLE>
- Incorrect interpolation for HUGEINT
- Parameters were FLOAT instead of DOUBLE, which could cause binding errors.
- Errors in copied and pasted error messages
- Poor testing of the moving quantile algorithm for scalar parameters
- No testing of the moving quantile algorithm for lists of parameters.
- Replace `LIST_VALUE` with compact array syntax.