### PR TITLE
ODBC: enabling pyodbc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -847,7 +847,7 @@ jobs:
 
     - name: Dependencies
       run: |
-        sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc-dev python-pip
+        sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc-dev python3-pip
         sudo pip install pyodbc
 
     - name: Install nanodbc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -846,7 +846,9 @@ jobs:
         python-version: '3.7'
 
     - name: Dependencies
-      run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc-dev python3 python3-pyodbc
+      run: |
+        sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc-dev python3 python3-pyodbc python3-pip
+        pip3 install pyodbc
 
     - name: Install nanodbc
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -846,7 +846,7 @@ jobs:
         python-version: '3.7'
 
     - name: Dependencies
-      run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc-dev python3-pyodbc
+      run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc-dev python3 python3-pyodbc
 
     - name: Install nanodbc
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -846,8 +846,9 @@ jobs:
         python-version: '3.7'
 
     - name: Dependencies
-      run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc-dev
-
+      run: |
+        sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc-dev python-pip
+        sudo pip install pyodbc
 
     - name: Install nanodbc
       run: |
@@ -873,6 +874,9 @@ jobs:
 
     - name: Test R ODBC
       run: R -f tools/odbc/test/rodbc.R
+
+    - name: Test Python ODBC
+      run: ./tools/odbc/test/run_pyodbc_tests.sh
 
 
   linux-python3:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -846,9 +846,7 @@ jobs:
         python-version: '3.7'
 
     - name: Dependencies
-      run: |
-        sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc-dev python3-pip
-        sudo pip install pyodbc
+      run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc-dev python3-pyodbc
 
     - name: Install nanodbc
       run: |

--- a/tools/odbc/api_info.cpp
+++ b/tools/odbc/api_info.cpp
@@ -33,37 +33,37 @@ const std::unordered_set<SQLUSMALLINT> ApiInfo::BASE_SUPPORTED_FUNCTIONS = {
 
 const std::unordered_set<SQLUSMALLINT> ApiInfo::ODBC3_EXTRA_SUPPORTED_FUNCTIONS = {};
 
-const std::vector<SQLSMALLINT> ApiInfo::ODBC_SUPPORTED_SQL_TYPES = {SQL_CHAR,
-                                                                    SQL_TINYINT,
-                                                                    SQL_SMALLINT,
-                                                                    SQL_INTEGER,
-                                                                    SQL_BIGINT,
-                                                                    SQL_DATE,
-                                                                    SQL_TYPE_DATE,
-                                                                    SQL_TIME,
-                                                                    SQL_TYPE_TIME,
-                                                                    SQL_TIMESTAMP,
-                                                                    SQL_TYPE_TIMESTAMP,
-                                                                    SQL_DECIMAL,
-                                                                    SQL_NUMERIC,
-                                                                    SQL_FLOAT,
-                                                                    SQL_DOUBLE,
-                                                                    SQL_VARCHAR,
-                                                                    SQL_BINARY,
-                                                                    SQL_VARBINARY,
-                                                                    SQL_INTERVAL_MONTH,
-                                                                    SQL_INTERVAL_YEAR,
-                                                                    SQL_INTERVAL_YEAR_TO_MONTH,
-                                                                    SQL_INTERVAL_DAY,
-                                                                    SQL_INTERVAL_HOUR,
-                                                                    SQL_INTERVAL_MINUTE,
-                                                                    SQL_INTERVAL_SECOND,
-                                                                    SQL_INTERVAL_DAY_TO_HOUR,
-                                                                    SQL_INTERVAL_DAY_TO_MINUTE,
-                                                                    SQL_INTERVAL_DAY_TO_SECOND,
-                                                                    SQL_INTERVAL_HOUR_TO_MINUTE,
-                                                                    SQL_INTERVAL_HOUR_TO_SECOND,
-                                                                    SQL_INTERVAL_MINUTE_TO_SECOND};
+const std::unordered_set<SQLSMALLINT> ApiInfo::ODBC_SUPPORTED_SQL_TYPES = {SQL_CHAR,
+                                                                           SQL_TINYINT,
+                                                                           SQL_SMALLINT,
+                                                                           SQL_INTEGER,
+                                                                           SQL_BIGINT,
+                                                                           SQL_DATE,
+                                                                           SQL_TYPE_DATE,
+                                                                           SQL_TIME,
+                                                                           SQL_TYPE_TIME,
+                                                                           SQL_TIMESTAMP,
+                                                                           SQL_TYPE_TIMESTAMP,
+                                                                           SQL_DECIMAL,
+                                                                           SQL_NUMERIC,
+                                                                           SQL_FLOAT,
+                                                                           SQL_DOUBLE,
+                                                                           SQL_VARCHAR,
+                                                                           SQL_BINARY,
+                                                                           SQL_VARBINARY,
+                                                                           SQL_INTERVAL_MONTH,
+                                                                           SQL_INTERVAL_YEAR,
+                                                                           SQL_INTERVAL_YEAR_TO_MONTH,
+                                                                           SQL_INTERVAL_DAY,
+                                                                           SQL_INTERVAL_HOUR,
+                                                                           SQL_INTERVAL_MINUTE,
+                                                                           SQL_INTERVAL_SECOND,
+                                                                           SQL_INTERVAL_DAY_TO_HOUR,
+                                                                           SQL_INTERVAL_DAY_TO_MINUTE,
+                                                                           SQL_INTERVAL_DAY_TO_SECOND,
+                                                                           SQL_INTERVAL_HOUR_TO_MINUTE,
+                                                                           SQL_INTERVAL_HOUR_TO_SECOND,
+                                                                           SQL_INTERVAL_MINUTE_TO_SECOND};
 
 void ApiInfo::SetFunctionSupported(SQLUSMALLINT *flags, int function_id) {
 	flags[function_id >> 4] |= (1 << (function_id & 0xF));
@@ -145,10 +145,8 @@ SQLSMALLINT ApiInfo::FindRelatedSQLType(duckdb::LogicalTypeId type_id) {
 }
 
 SQLRETURN ApiInfo::CheckDataType(SQLSMALLINT data_type) {
-	for (idx_t i = 0; i < ODBC_SUPPORTED_SQL_TYPES.size(); ++i) {
-		if (ODBC_SUPPORTED_SQL_TYPES[i] == data_type) {
-			return SQL_SUCCESS;
-		}
+	if (ODBC_SUPPORTED_SQL_TYPES.find(data_type) != ODBC_SUPPORTED_SQL_TYPES.end()) {
+		return SQL_SUCCESS;
 	}
 	return SQL_ERROR;
 }

--- a/tools/odbc/connection.cpp
+++ b/tools/odbc/connection.cpp
@@ -108,12 +108,10 @@ SQLRETURN SQLEndTran(SQLSMALLINT handle_type, SQLHANDLE handle, SQLSMALLINT comp
 	return duckdb::WithConnection(handle, [&](duckdb::OdbcHandleDbc *dbc) {
 		switch (completion_type) {
 		case SQL_COMMIT:
-			if (dbc->stmt_handle) {
-				// it needs to materialize the result set because ODBC can still fetch after a commit
-				if (dbc->stmt_handle->MaterializeResult() != SQL_SUCCESS) {
-					// for some reason we couldn't materialize the result set
-					return SQL_ERROR;
-				}
+			// it needs to materialize the result set because ODBC can still fetch after a commit
+			if (dbc->MaterializeResult() != SQL_SUCCESS) {
+				// for some reason we couldn't materialize the result set
+				return SQL_ERROR;
 			}
 			if (dbc->conn->IsAutoCommit()) {
 				return SQL_SUCCESS;

--- a/tools/odbc/driver.cpp
+++ b/tools/odbc/driver.cpp
@@ -1,5 +1,6 @@
 #include "duckdb_odbc.hpp"
 #include "parameter_wrapper.hpp"
+#include "odbc_fetch.hpp"
 #include <odbcinst.h>
 
 using std::string;
@@ -50,10 +51,7 @@ SQLRETURN SQLFreeHandle(SQLSMALLINT handle_type, SQLHANDLE handle) {
 	}
 	case SQL_HANDLE_STMT: {
 		auto *hdl = (duckdb::OdbcHandleStmt *)handle;
-		if (hdl == hdl->dbc->stmt_handle) {
-			hdl->param_wrapper->Clear();
-			hdl->dbc->stmt_handle = nullptr;
-		}
+		hdl->dbc->EraseStmtRef(hdl);
 		delete hdl;
 		return SQL_SUCCESS;
 	}

--- a/tools/odbc/duckdb_odbc.cpp
+++ b/tools/odbc/duckdb_odbc.cpp
@@ -2,8 +2,36 @@
 #include "odbc_fetch.hpp"
 #include "parameter_wrapper.hpp"
 
+using duckdb::OdbcHandleDbc;
 using duckdb::OdbcHandleStmt;
 
+//! OdbcHandleDbc functions ***************************************************
+OdbcHandleDbc::~OdbcHandleDbc() {
+	// this is needed because some applications may not call SQLFreeHandle
+	for (auto stmt : vec_stmt_ref) {
+		delete stmt;
+	}
+}
+
+void OdbcHandleDbc::EraseStmtRef(OdbcHandleStmt *stmt) {
+	// erase the reference from vec_stmt_ref
+	for (duckdb::idx_t v_idx = 0; v_idx < vec_stmt_ref.size(); ++v_idx) {
+		if (vec_stmt_ref[v_idx] == stmt) {
+			vec_stmt_ref.erase(vec_stmt_ref.begin() + v_idx);
+			break;
+		}
+	}
+}
+
+SQLRETURN OdbcHandleDbc::MaterializeResult() {
+	if (vec_stmt_ref.empty()) {
+		return SQL_SUCCESS;
+	}
+	// only materializing the result set from the last statement
+	return vec_stmt_ref.back()->MaterializeResult();
+}
+
+//! OdbcHandleStmt functions **************************************************
 OdbcHandleStmt::OdbcHandleStmt(OdbcHandleDbc *dbc_p)
     : OdbcHandle(OdbcHandleType::STMT), dbc(dbc_p), rows_fetched_ptr(nullptr) {
 	D_ASSERT(dbc_p);
@@ -11,10 +39,21 @@ OdbcHandleStmt::OdbcHandleStmt(OdbcHandleDbc *dbc_p)
 
 	param_wrapper = make_unique<ParameterWrapper>(&error_messages);
 	odbc_fetcher = make_unique<OdbcFetch>();
-	dbc->stmt_handle = this;
+	dbc->vec_stmt_ref.emplace_back(this);
 }
 
 OdbcHandleStmt::~OdbcHandleStmt() {
+}
+
+void OdbcHandleStmt::Close() {
+	open = false;
+	res.reset();
+	odbc_fetcher->ClearChunks();
+	param_wrapper->Reset();
+	// stmt->stmt.reset(); // the statment can be reuse in prepared statement
+	bound_cols.clear();
+	// stmt->param_wrapper->Clear(); // the parameter values can be reused after
+	error_messages.clear();
 }
 
 SQLRETURN OdbcHandleStmt::MaterializeResult() {

--- a/tools/odbc/include/api_info.hpp
+++ b/tools/odbc/include/api_info.hpp
@@ -6,7 +6,6 @@
 #include <sql.h>
 #include <sqltypes.h>
 #include <sqlext.h>
-#include <vector>
 #include <unordered_set>
 
 #define NUM_FUNC_SUPPORTED 4000
@@ -22,7 +21,7 @@ private:
 	// fill ODBC3 supported functions in this array
 	static const std::unordered_set<SQLUSMALLINT> ODBC3_EXTRA_SUPPORTED_FUNCTIONS;
 
-	static const std::vector<SQLSMALLINT> ODBC_SUPPORTED_SQL_TYPES;
+	static const std::unordered_set<SQLSMALLINT> ODBC_SUPPORTED_SQL_TYPES;
 
 	static void SetFunctionSupported(SQLUSMALLINT *flags, int function_id);
 

--- a/tools/odbc/include/duckdb_odbc.hpp
+++ b/tools/odbc/include/duckdb_odbc.hpp
@@ -108,11 +108,15 @@ struct OdbcHandleDbc : public OdbcHandle {
 		D_ASSERT(env_p);
 		D_ASSERT(env_p->db);
 	};
+	~OdbcHandleDbc();
+	void EraseStmtRef(OdbcHandleStmt *stmt);
+	SQLRETURN MaterializeResult();
+
 	OdbcHandleEnv *env;
 	unique_ptr<Connection> conn;
 	bool autocommit;
 	// reference to an open statement handled by this connection
-	OdbcHandleStmt *stmt_handle;
+	std::vector<OdbcHandleStmt *> vec_stmt_ref;
 };
 
 inline bool IsSQLVarcharType(SQLSMALLINT type) {
@@ -145,6 +149,7 @@ struct OdbcBoundCol {
 struct OdbcHandleStmt : public OdbcHandle {
 	explicit OdbcHandleStmt(OdbcHandleDbc *dbc_p);
 	~OdbcHandleStmt();
+	void Close();
 	SQLRETURN MaterializeResult();
 
 	OdbcHandleDbc *dbc;
@@ -203,7 +208,6 @@ SQLRETURN WithStatement(SQLHANDLE &statement_handle, T &&lambda) {
 	if (!hdl->dbc || !hdl->dbc->conn) {
 		return SQL_ERROR;
 	}
-
 	return lambda(hdl);
 }
 

--- a/tools/odbc/odbc_fetch.cpp
+++ b/tools/odbc/odbc_fetch.cpp
@@ -11,6 +11,7 @@ using duckdb::OdbcFetch;
 using duckdb::OdbcHandleStmt;
 
 OdbcFetch::~OdbcFetch() {
+	chunks.clear();
 }
 
 void OdbcFetch::IncreaseRowCount() {

--- a/tools/odbc/parameter_wrapper.cpp
+++ b/tools/odbc/parameter_wrapper.cpp
@@ -230,6 +230,12 @@ SQLRETURN ParameterDescriptor::SetValue(idx_t val_idx) {
 		value = Value(duckdb::OdbcUtils::ReadString(str_data, str_len));
 		break;
 	}
+	case SQL_WCHAR: {
+		auto str_data = (wchar_t *)apd.param_value_ptr + (val_idx * ipd.col_size);
+		auto str_len = apd.str_len_or_ind_ptr[val_idx];
+		value = Value(duckdb::OdbcUtils::ReadString(str_data, str_len));
+		break;
+	}
 	case SQL_VARBINARY:
 	case SQL_BINARY: {
 		auto blob_data = (duckdb::const_data_ptr_t)apd.param_value_ptr + (val_idx * ipd.col_size);

--- a/tools/odbc/parameter_wrapper.cpp
+++ b/tools/odbc/parameter_wrapper.cpp
@@ -11,6 +11,7 @@ using duckdb::ParameterWrapper;
 //! ParameterWrapper methods *****************************************
 
 ParameterWrapper::~ParameterWrapper() {
+	Clear();
 }
 
 void ParameterWrapper::Clear() {

--- a/tools/odbc/statement_functions.cpp
+++ b/tools/odbc/statement_functions.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <codecvt>
+#include <locale>
 
 using std::string;
 

--- a/tools/odbc/statement_functions.cpp
+++ b/tools/odbc/statement_functions.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/types/timestamp.hpp"
 
 #include <algorithm>
+#include <codecvt>
 
 using std::string;
 
@@ -232,31 +233,54 @@ SQLRETURN duckdb::GetDataStmtResult(SQLHSTMT statement_handle, SQLUSMALLINT col_
 				return SetStringValueLength(str, str_len_or_ind_ptr);
 			}
 
-			std::wstring w_str = std::wstring(str.begin(), str.end());
-			auto out_len = swprintf((wchar_t *)target_value_ptr, buffer_length, L"%ls", w_str.c_str());
+			SQLRETURN ret = SQL_SUCCESS;
+
+			std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> converter_utf16;
+			std::u16string utf16_str = converter_utf16.from_bytes(str.data());
+			auto out_len = duckdb::MinValue(utf16_str.size(), (size_t)buffer_length);
+			// reserving two bytes for each char
+			out_len *= 2;
+			// check space for 2 null terminator char
+			if (out_len > (size_t)(buffer_length - 2)) {
+				out_len = buffer_length - 2;
+				// check odd length
+				if ((out_len % 2) != 0) {
+					out_len -= 1;
+				}
+				ret = SQL_SUCCESS_WITH_INFO;
+				stmt->error_messages.emplace_back("SQLGetData returned with info.");
+			}
+			memcpy((char *)target_value_ptr, (char *)utf16_str.c_str(), out_len);
+
+			// null terminator char
+			((char *)target_value_ptr)[out_len] = '\0';
+			((char *)target_value_ptr)[out_len + 1] = '\0';
 
 			if (str_len_or_ind_ptr) {
 				*str_len_or_ind_ptr = out_len;
 			}
-			return SQL_SUCCESS;
+			return ret;
 		}
 		// case SQL_C_VARBOOKMARK: // same ODBC type (\\TODO we don't support bookmark types)
 		case SQL_C_BINARY: {
+			SQLRETURN ret = SQL_SUCCESS;
+
 			// threating binary values as BLOB type
 			string blob = duckdb::Blob::ToBlob(duckdb::string_t(val.GetValue<string>().c_str()));
 			auto out_len = duckdb::MinValue(blob.size(), (size_t)buffer_length);
 			memcpy((char *)target_value_ptr, blob.c_str(), out_len);
-			// terminating null character
-			if (blob.size() < (size_t)buffer_length) {
-				((char *)target_value_ptr)[blob.size()] = '\0';
-			} else {
-				((char *)target_value_ptr)[buffer_length - 1] = '\0';
+			if (out_len == (size_t)buffer_length) {
+				out_len = buffer_length - 1;
+				ret = SQL_SUCCESS_WITH_INFO;
+				stmt->error_messages.emplace_back("SQLGetData returned with info.");
 			}
+			// null terminator char
+			((char *)target_value_ptr)[out_len] = '\0';
 
 			if (str_len_or_ind_ptr) {
 				*str_len_or_ind_ptr = out_len;
 			}
-			return SQL_SUCCESS;
+			return ret;
 		}
 		case SQL_C_CHAR: {
 			std::string val_str = val.GetValue<std::string>();
@@ -264,19 +288,22 @@ SQLRETURN duckdb::GetDataStmtResult(SQLHSTMT statement_handle, SQLUSMALLINT col_
 				return SetStringValueLength(val_str, str_len_or_ind_ptr);
 			}
 
+			SQLRETURN ret = SQL_SUCCESS;
+
 			auto out_len = duckdb::MinValue(val_str.size(), (size_t)buffer_length);
 			memcpy((char *)target_value_ptr, val_str.c_str(), out_len);
-			// terminating null character
-			if (val_str.size() < (size_t)buffer_length) {
-				((char *)target_value_ptr)[val_str.size()] = '\0';
-			} else {
-				((char *)target_value_ptr)[buffer_length - 1] = '\0';
+			if (out_len == (size_t)buffer_length) {
+				out_len = buffer_length - 1;
+				ret = SQL_SUCCESS_WITH_INFO;
+				stmt->error_messages.emplace_back("SQLGetData returned with info.");
 			}
+			// null terminator char
+			((char *)target_value_ptr)[out_len] = '\0';
 
 			if (str_len_or_ind_ptr) {
 				*str_len_or_ind_ptr = out_len;
 			}
-			return SQL_SUCCESS;
+			return ret;
 		}
 		case SQL_C_NUMERIC: {
 			if (!ValidateType(val.type().id(), LogicalTypeId::DECIMAL, stmt)) {

--- a/tools/odbc/test/pyodbc-test.py
+++ b/tools/odbc/test/pyodbc-test.py
@@ -1,0 +1,8 @@
+import pyodbc
+import glob
+
+cnxn = pyodbc.connect('DSN={DuckDB}')
+cursor = cnxn.cursor()
+
+cursor.execute("CREATE TABLE fuu (i INTEGER, j STRING)")
+cursor.execute("INSERT INTO fuu VALUES (42, 'Hello'), (43, 'World'), (NULL, NULL)")

--- a/tools/odbc/test/pyodbc-test.py
+++ b/tools/odbc/test/pyodbc-test.py
@@ -6,3 +6,6 @@ cursor = cnxn.cursor()
 
 cursor.execute("CREATE TABLE fuu (i INTEGER, j STRING)")
 cursor.execute("INSERT INTO fuu VALUES (42, 'Hello'), (43, 'World'), (NULL, NULL)")
+cursor.execute("SELECT * FROM fuu")
+result = cursor.fetchall()
+print(result)

--- a/tools/odbc/test/run_pyodbc_tests.sh
+++ b/tools/odbc/test/run_pyodbc_tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo -e "[ODBC]\nTrace = yes\nTraceFile = /tmp/odbctrace\n\n[DuckDB Driver]\nDriver = "$(pwd)"/build/debug/tools/odbc/libduckdb_odbc.so" > ~/.odbcinst.ini
+echo -e "[DuckDB]\nDriver = DuckDB Driver\nDatabase=:memory:\n" > ~/.odbc.ini
+
+export ASAN_OPTIONS=verify_asan_link_order=0
+
+python3 tools/odbc/test/pyodbc-test.py
+if [[ $? != 0 ]]; then
+    exit 1;
+fi


### PR DESCRIPTION
This PR enables the pyodbc that has a quite different behavior than the other odbc clients.
Pyodbc doesn't deallocate handle_statment, it only close them calling SQLFreeStmt.
The  handle_connect have to hold statement references that were allocated and release them properly.

P.S. There is a minor problem related to UNICODE and ANSII chars returned because the pyodbc uses unicode functions (with the 'W' termination, like SQLExecuteDirectW.c)