### PR TITLE
parquet: correctly encode booleans on write

### DIFF
--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -253,7 +253,6 @@ void ParquetWriter::Flush(ChunkCollection &buffer) {
 						byte |= (ptr[r] & 1) << byte_pos;
 						byte_pos++;
 
-						temp_writer.Write<uint8_t>(byte);
 						if (byte_pos == 8) {
 							temp_writer.Write<uint8_t>(byte);
 							byte = 0;

--- a/test/sql/copy/parquet/test_parquet_write_complex.test
+++ b/test/sql/copy/parquet/test_parquet_write_complex.test
@@ -33,6 +33,16 @@ query I nosort bug687_nulls
 SELECT * FROM parquet_scan('__TEST_DIR__/bug687_nulls.parquet') LIMIT 10;
 ----
 
+# Issue #1637: booleans encoded incorrectly
+statement ok
+COPY (SELECT true as x UNION ALL SELECT true) TO '__TEST_DIR__/bug1637_booleans.parquet' (FORMAT 'PARQUET');
+
+# Prior to the #1637 fix, duckdb wrote a parquet file containing true, false
+query I
+SELECT COUNT(*) FROM parquet_scan('__TEST_DIR__/bug1637_booleans.parquet') WHERE x;
+----
+2
+
 # userdata1.parquet
 query I nosort userdata1.parquet
 SELECT * FROM parquet_scan('data/parquet-testing/userdata1.parquet') ORDER BY 1 LIMIT 10;


### PR DESCRIPTION
Closes #1637

I'm unable to build duckdb locally, so can't test this fix. I've tested the query as best I can in a shell, and have verified the queries in the test currently fail, although just looking at them they really shouldn't. Hopefully one of the maintainers (or your CI system!) can test this change for me!