### PR TITLE
Improve binding errors for mix of aggregates/non-aggregates, window functions and subqueries 

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -201,7 +201,7 @@ TableCatalogEntry *Catalog::GetEntry(ClientContext &context, string schema_name,
 		return nullptr;
 	}
 	if (entry->type != CatalogType::TABLE_ENTRY) {
-		throw CatalogException("%s is not a table", name);
+		throw CatalogException(error_context.FormatError("%s is not a table", name));
 	}
 	return (TableCatalogEntry *)entry;
 }
@@ -240,7 +240,7 @@ AggregateFunctionCatalogEntry *Catalog::GetEntry(ClientContext &context, string 
 	auto entry =
 	    GetEntry(context, CatalogType::AGGREGATE_FUNCTION_ENTRY, move(schema_name), name, if_exists, error_context);
 	if (entry->type != CatalogType::AGGREGATE_FUNCTION_ENTRY) {
-		throw CatalogException("%s is not an aggregate function", name);
+		throw CatalogException(error_context.FormatError("%s is not an aggregate function", name));
 	}
 	return (AggregateFunctionCatalogEntry *)entry;
 }

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -54,6 +54,7 @@ struct CorrelatedColumnInfo {
 */
 class Binder : public std::enable_shared_from_this<Binder> {
 	friend class ExpressionBinder;
+	friend class SelectBinder;
 	friend class RecursiveSubqueryPlanner;
 
 public:

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -29,6 +29,11 @@ class SimpleFunction;
 
 struct MacroBinding;
 
+struct BoundColumnReferenceInfo {
+	string name;
+	idx_t query_location;
+};
+
 struct BindResult {
 	explicit BindResult(string error) : error(error) {
 	}
@@ -57,7 +62,10 @@ public:
 	                            bool root_expression = true);
 
 	//! Returns whether or not any columns have been bound by the expression binder
-	bool BoundColumns() {
+	bool HasBoundColumns() {
+		return !bound_columns.empty();
+	}
+	const vector<BoundColumnReferenceInfo> &GetBoundColumns() {
 		return bound_columns;
 	}
 
@@ -121,7 +129,7 @@ protected:
 	ClientContext &context;
 	ExpressionBinder *stored_binder;
 	MacroBinding *macro_binding;
-	bool bound_columns = false;
+	vector<BoundColumnReferenceInfo> bound_columns;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -33,7 +33,7 @@ public:
 	}
 	void ResetBindings() {
 		this->bound_aggregate = false;
-		this->bound_columns = false;
+		this->bound_columns.clear();
 	}
 
 protected:

--- a/src/parser/transform/expression/transform_function.cpp
+++ b/src/parser/transform/expression/transform_function.cpp
@@ -183,7 +183,7 @@ unique_ptr<ParsedExpression> Transformer::TransformFuncCall(duckdb_libpgquery::P
 		}
 		TransformWindowDef(window_ref, expr.get(), depth);
 		TransformWindowFrame(window_spec, expr.get(), depth);
-
+		expr->query_location = root->location;
 		return move(expr);
 	}
 

--- a/src/parser/transform/expression/transform_operator.cpp
+++ b/src/parser/transform/expression/transform_operator.cpp
@@ -99,6 +99,7 @@ unique_ptr<ParsedExpression> Transformer::TransformAExpr(duckdb_libpgquery::PGAE
 		subquery_expr->subquery_type = SubqueryType::ANY;
 		subquery_expr->child = move(left_expr);
 		subquery_expr->comparison_type = OperatorToExpressionType(name);
+		subquery_expr->query_location = root->location;
 
 		if (root->kind == duckdb_libpgquery::PG_AEXPR_OP_ALL) {
 			// ALL sublink is equivalent to NOT(ANY) with inverted comparison
@@ -121,6 +122,7 @@ unique_ptr<ParsedExpression> Transformer::TransformAExpr(duckdb_libpgquery::PGAE
 			operator_type = ExpressionType::COMPARE_IN;
 		}
 		auto result = make_unique<OperatorExpression>(operator_type, move(left_expr));
+		result->query_location = root->location;
 		TransformExpressionList(*((duckdb_libpgquery::PGList *)root->rexpr), result->children, depth);
 		return move(result);
 	}

--- a/src/parser/transform/expression/transform_subquery.cpp
+++ b/src/parser/transform/expression/transform_subquery.cpp
@@ -55,6 +55,7 @@ unique_ptr<ParsedExpression> Transformer::TransformSubquery(duckdb_libpgquery::P
 	default:
 		throw NotImplementedException("Subquery of type %d not implemented\n", (int)root->subLinkType);
 	}
+	subquery_expr->query_location = root->location;
 	return move(subquery_expr);
 }
 

--- a/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -36,7 +36,7 @@ BindResult SelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFuncti
 
 	if (!error.empty()) {
 		// failed to bind child
-		if (aggregate_binder.BoundColumns()) {
+		if (aggregate_binder.HasBoundColumns()) {
 			for (idx_t i = 0; i < aggr.children.size(); i++) {
 				// however, we bound columns!
 				// that means this aggregation belongs to this node

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -50,7 +50,10 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref, idx_t d
 	                        ? binder.macro_binding->Bind(colref, depth)
 	                        : binder.bind_context.BindColumn(colref, depth);
 	if (!result.HasError()) {
-		bound_columns = true;
+		BoundColumnReferenceInfo ref;
+		ref.name = colref.column_name;
+		ref.query_location = colref.query_location;
+		bound_columns.push_back(move(ref));
 	} else {
 		result.error = binder.FormatError(colref, result.error);
 	}

--- a/src/planner/binder/expression/bind_subquery_expression.cpp
+++ b/src/planner/binder/expression/bind_subquery_expression.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_subquery_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
+#include "duckdb/common/string_util.hpp"
 
 namespace duckdb {
 
@@ -45,7 +46,7 @@ BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t dept
 			}
 		}
 		if (expr.subquery_type != SubqueryType::EXISTS && bound_node->types.size() > 1) {
-			throw BinderException("Subquery returns %zu columns - expected 1", bound_node->types.size());
+			throw BinderException(binder.FormatError(expr, StringUtil::Format("Subquery returns %zu columns - expected 1", bound_node->types.size())));
 		}
 		auto prior_subquery = move(expr.subquery);
 		expr.subquery = make_unique<SelectStatement>();

--- a/src/planner/binder/expression/bind_subquery_expression.cpp
+++ b/src/planner/binder/expression/bind_subquery_expression.cpp
@@ -46,7 +46,8 @@ BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t dept
 			}
 		}
 		if (expr.subquery_type != SubqueryType::EXISTS && bound_node->types.size() > 1) {
-			throw BinderException(binder.FormatError(expr, StringUtil::Format("Subquery returns %zu columns - expected 1", bound_node->types.size())));
+			throw BinderException(binder.FormatError(
+			    expr, StringUtil::Format("Subquery returns %zu columns - expected 1", bound_node->types.size())));
 		}
 		auto prior_subquery = move(expr.subquery);
 		expr.subquery = make_unique<SelectStatement>();

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -308,7 +308,10 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SelectNode &statement) {
 		} else if (statement.aggregate_handling == AggregateHandling::STANDARD_HANDLING) {
 			if (select_binder.HasBoundColumns()) {
 				auto &bound_columns = select_binder.GetBoundColumns();
-				throw BinderException(FormatError(bound_columns[0].query_location, "column \"%s\" must appear in the GROUP BY clause or be used in an aggregate function", bound_columns[0].name));
+				throw BinderException(
+				    FormatError(bound_columns[0].query_location,
+				                "column \"%s\" must appear in the GROUP BY clause or be used in an aggregate function",
+				                bound_columns[0].name));
 			}
 		}
 	}

--- a/test/sql/error/mix_aggregate_and_non_aggregate.test
+++ b/test/sql/error/mix_aggregate_and_non_aggregate.test
@@ -1,0 +1,16 @@
+# name: test/sql/error/mix_aggregate_and_non_aggregate.test
+# description: Test mix of aggregate and non-aggregate
+# group: [error]
+
+statement ok
+CREATE TABLE tbl(name VARCHAR, style VARCHAR, brewery_id INTEGER, abv DOUBLE, ibu INTEGER);
+
+statement error
+SELECT FIRST(name), FIRST(abv)
+FROM tbl
+GROUP BY style
+ORDER BY abv DESC;
+
+statement error
+SELECT FIRST(name)||abv
+FROM tbl

--- a/test/sql/error/subquery_single_column.test
+++ b/test/sql/error/subquery_single_column.test
@@ -1,0 +1,7 @@
+# name: test/sql/error/subquery_single_column.test
+# description: Subqueries can only return a single column
+# group: [error]
+
+# subqueries can only return a single column
+statement error
+SELECT (SELECT 42, 84)

--- a/test/sql/error/unknown_window_function.test
+++ b/test/sql/error/unknown_window_function.test
@@ -1,0 +1,6 @@
+# name: test/sql/error/unknown_window_function.test
+# description: Test unknown window function
+# group: [error]
+
+statement error
+SELECT substr('hello', 3, 2) OVER ();

--- a/test/sql/function/generic/case_varchar.test
+++ b/test/sql/function/generic/case_varchar.test
@@ -1,0 +1,37 @@
+# name: testtest/sql/function/generic/case_varchar.test
+# description: Test case statement with VARCHAR columns
+# group: [generic]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE tbl AS SELECT i, 'thisisalongstring' || i::VARCHAR s FROM range(10) tbl(i)
+
+query III
+SELECT i, s, CASE WHEN i%2=0 THEN s ELSE s END FROM tbl
+----
+0	thisisalongstring0	thisisalongstring0
+1	thisisalongstring1	thisisalongstring1
+2	thisisalongstring2	thisisalongstring2
+3	thisisalongstring3	thisisalongstring3
+4	thisisalongstring4	thisisalongstring4
+5	thisisalongstring5	thisisalongstring5
+6	thisisalongstring6	thisisalongstring6
+7	thisisalongstring7	thisisalongstring7
+8	thisisalongstring8	thisisalongstring8
+9	thisisalongstring9	thisisalongstring9
+
+query III
+SELECT i, s, CASE WHEN i%2=0 THEN s ELSE s END FROM (SELECT i, s||'_suffix' FROM tbl) tbl(i, s)
+----
+0	thisisalongstring0_suffix	thisisalongstring0_suffix
+1	thisisalongstring1_suffix	thisisalongstring1_suffix
+2	thisisalongstring2_suffix	thisisalongstring2_suffix
+3	thisisalongstring3_suffix	thisisalongstring3_suffix
+4	thisisalongstring4_suffix	thisisalongstring4_suffix
+5	thisisalongstring5_suffix	thisisalongstring5_suffix
+6	thisisalongstring6_suffix	thisisalongstring6_suffix
+7	thisisalongstring7_suffix	thisisalongstring7_suffix
+8	thisisalongstring8_suffix	thisisalongstring8_suffix
+9	thisisalongstring9_suffix	thisisalongstring9_suffix

--- a/test/sql/function/generic/case_varchar.test
+++ b/test/sql/function/generic/case_varchar.test
@@ -1,4 +1,4 @@
-# name: testtest/sql/function/generic/case_varchar.test
+# name: test/sql/function/generic/case_varchar.test
 # description: Test case statement with VARCHAR columns
 # group: [generic]
 


### PR DESCRIPTION
Now the actual column name & query location are also reported, e.g.:

```sql
SELECT FIRST(name), FIRST(abv)
FROM tbl
GROUP BY style
ORDER BY abv DESC;
-- Binder Error: column "abv" must appear in the GROUP BY clause or be used in an aggregate function
-- LINE 4: ORDER BY abv DESC;
```