### PR TITLE
Allow duplicate column names in subqueries/CREATE TABLE AS, similar to SQLite

### DIFF
--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -11,13 +11,21 @@
 
 namespace duckdb {
 
-static void CreateColumnMap(BoundCreateTableInfo &info) {
+static void CreateColumnMap(BoundCreateTableInfo &info, bool allow_duplicate_names) {
 	auto &base = (CreateTableInfo &)*info.base;
 
 	for (uint64_t oid = 0; oid < base.columns.size(); oid++) {
 		auto &col = base.columns[oid];
-		if (info.name_map.find(col.name) != info.name_map.end()) {
-			throw CatalogException("Column with name %s already exists!", col.name);
+		if (allow_duplicate_names) {
+			idx_t index = 1;
+			string base_name = col.name;
+			while (info.name_map.find(col.name) != info.name_map.end()) {
+				col.name = base_name + ":" + to_string(index++);
+			}
+		} else {
+			if (info.name_map.find(col.name) != info.name_map.end()) {
+				throw CatalogException("Column with name %s already exists!", col.name);
+			}
 		}
 
 		info.name_map[col.name] = oid;
@@ -143,10 +151,10 @@ unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableInfo(unique_ptr<CreateIn
 			base.columns.emplace_back(names[i], sql_types[i]);
 		}
 		// create the name map for the statement
-		CreateColumnMap(*result);
+		CreateColumnMap(*result, true);
 	} else {
 		// create the name map for the statement
-		CreateColumnMap(*result);
+		CreateColumnMap(*result, false);
 		// bind any constraints
 		BindConstraints(*this, *result);
 		// bind the default values

--- a/test/sql/create/create_table_as_duplicate_names.test
+++ b/test/sql/create/create_table_as_duplicate_names.test
@@ -1,0 +1,96 @@
+# name: test/sql/create/create_table_as_duplicate_names.test
+# description: Test CREATE TABLE AS with duplicate column names
+# group: [create]
+
+query II
+SELECT * FROM range(5) tbl1(i) JOIN range(5) tbl2(i) ON tbl1.i=tbl2.i;
+----
+0	0
+1	1
+2	2
+3	3
+4	4
+
+query II
+SELECT i, i FROM range(5) tbl(i)
+----
+0	0
+1	1
+2	2
+3	3
+4	4
+
+query II
+SELECT * FROM (SELECT i, i FROM range(5) tbl(i)) tbl;
+----
+0	0
+1	1
+2	2
+3	3
+4	4
+
+query IIII
+SELECT * FROM (SELECT i, i, i, i FROM range(5) tbl(i)) tbl;
+----
+0	0	0	0
+1	1	1	1
+2	2	2	2
+3	3	3	3
+4	4	4	4
+
+statement ok
+CREATE TABLE t1 AS SELECT i, i FROM range(5) tbl(i)
+
+query II
+SELECT * FROM t1;
+----
+0	0
+1	1
+2	2
+3	3
+4	4
+
+statement ok
+CREATE TABLE t2 AS SELECT i, i, i, i FROM range(5) tbl(i)
+
+query IIII
+SELECT * FROM (SELECT i, i, i, i FROM range(5) tbl(i)) tbl;
+----
+0	0	0	0
+1	1	1	1
+2	2	2	2
+3	3	3	3
+4	4	4	4
+
+query II
+SELECT * FROM (SELECT * FROM range(5) tbl1(i) JOIN range(5) tbl2(i) ON tbl1.i=tbl2.i) tbl;
+----
+0	0
+1	1
+2	2
+3	3
+4	4
+
+statement ok
+CREATE TABLE t3 AS SELECT tbl1.i, tbl2.i FROM range(5) tbl1(i) JOIN range(5) tbl2(i) ON tbl1.i=tbl2.i;
+
+query II
+SELECT * FROM t3
+----
+0	0
+1	1
+2	2
+3	3
+4	4
+
+statement ok
+CREATE TABLE t4 AS SELECT * FROM range(5) tbl1(i) JOIN range(5) tbl2(i) ON tbl1.i=tbl2.i;
+
+query II
+SELECT * FROM t4
+----
+0	0
+1	1
+2	2
+3	3
+4	4

--- a/test/sql/subquery/scalar/test_scalar_subquery.test
+++ b/test/sql/subquery/scalar/test_scalar_subquery.test
@@ -148,6 +148,7 @@ SELECT * FROM test WHERE EXISTS (SELECT a FROM test ts WHERE ts.a = test.a AND b
 13	22
 
 # duplicate name in subquery
-statement error
+query II
 SELECT * FROM (SELECT 42 AS a, 44 AS a) tbl1
-
+----
+42	44

--- a/test/sql/subquery/scalar/test_scalar_subquery_cte.test
+++ b/test/sql/subquery/scalar/test_scalar_subquery_cte.test
@@ -148,6 +148,7 @@ SELECT * FROM test WHERE EXISTS (WITH cte AS (SELECT * FROM test ts WHERE ts.a =
 13	22
 
 # duplicate name in subquery
-statement error
+query II
 SELECT * FROM (WITH cte AS (SELECT 42 AS a, 44 AS a) SELECT * FROM cte) tbl1
-
+----
+42	44


### PR DESCRIPTION
This PR adds support for handling duplicate column names in subqueries or CREATE TABLE AS statements identically to SQLite, namely duplicate column names get `:1`, `:2`, etc appended to them.

Example:

```sql
D select * from (select 42 i, 44 i, 46 i);
┌────┬─────┬─────┐
│ i  │ i:1 │ i:2 │
├────┼─────┼─────┤
│ 42 │ 44  │ 46  │
└────┴─────┴─────┘

D create table t1 as select 42 i, 44 i, 46 i;
D select * from t1;
┌────┬─────┬─────┐
│ i  │ i:1 │ i:2 │
├────┼─────┼─────┤
│ 42 │ 44  │ 46  │
└────┴─────┴─────┘
```

This is specifically useful for tables where we join identical columns WITHOUT a using clause, since the column will be duplicated, e.g.:

```sql
D select * from range(4) tbl1(i) join range(4) tbl2(i) on tbl1.i=tbl2.i;
┌───┬───┐
│ i │ i │
├───┼───┤
│ 0 │ 0 │
│ 1 │ 1 │
│ 2 │ 2 │
│ 3 │ 3 │
└───┴───┘
```

Now we can also place those queries in subqueries and CREATE TABLE AS statements.