### PR TITLE
#2187 Renaming Repeated Columns in dataframes

### DIFF
--- a/tools/pythonpkg/src/vector_conversion.cpp
+++ b/tools/pythonpkg/src/vector_conversion.cpp
@@ -313,6 +313,23 @@ void VectorConversion::BindPandas(py::handle df, vector<PandasColumnBindData> &b
 	if (py::len(df_columns) == 0 || py::len(df_types) == 0 || py::len(df_columns) != py::len(df_types)) {
 		throw std::runtime_error("Need a DataFrame with at least one column");
 	}
+
+	// check if names in pandas dataframe are unique
+	unordered_map<string, idx_t> pandas_column_names_map;
+	py::array column_attributes = df.attr("columns").attr("values");
+	for (idx_t col_idx = 0; col_idx < py::len(df_columns); col_idx++) {
+		pandas_column_names_map[py::str(df_columns[col_idx])]++;
+		if (pandas_column_names_map[py::str(df_columns[col_idx])] > 1) {
+			// If the column name is repeated we start adding _x where x is the repetition number
+			string column_name = py::str(df_columns[col_idx]);
+			column_name += "_" + to_string(pandas_column_names_map[py::str(df_columns[col_idx])] - 1);
+			names.emplace_back(py::str(column_name));
+			column_attributes[py::cast(col_idx)] = py::str(column_name);
+		} else {
+			names.emplace_back(py::str(df_columns[col_idx]));
+		}
+	}
+
 	for (idx_t col_idx = 0; col_idx < py::len(df_columns); col_idx++) {
 		LogicalType duckdb_col_type;
 		PandasColumnBindData bind_data;
@@ -345,8 +362,6 @@ void VectorConversion::BindPandas(py::handle df, vector<PandasColumnBindData> &b
 		}
 		D_ASSERT(py::hasattr(bind_data.numpy_col, "strides"));
 		bind_data.numpy_stride = bind_data.numpy_col.attr("strides").attr("__getitem__")(0).cast<idx_t>();
-
-		names.emplace_back(py::str(df_columns[col_idx]));
 		return_types.push_back(duckdb_col_type);
 		bind_columns.push_back(move(bind_data));
 	}

--- a/tools/pythonpkg/src/vector_conversion.cpp
+++ b/tools/pythonpkg/src/vector_conversion.cpp
@@ -318,15 +318,18 @@ void VectorConversion::BindPandas(py::handle df, vector<PandasColumnBindData> &b
 	unordered_map<string, idx_t> pandas_column_names_map;
 	py::array column_attributes = df.attr("columns").attr("values");
 	for (idx_t col_idx = 0; col_idx < py::len(df_columns); col_idx++) {
-		pandas_column_names_map[py::str(df_columns[col_idx])]++;
-		if (pandas_column_names_map[py::str(df_columns[col_idx])] > 1) {
+		auto column_name_py = py::str(df_columns[col_idx]);
+		pandas_column_names_map[column_name_py]++;
+		if (pandas_column_names_map[column_name_py] > 1) {
 			// If the column name is repeated we start adding _x where x is the repetition number
-			string column_name = py::str(df_columns[col_idx]);
-			column_name += "_" + to_string(pandas_column_names_map[py::str(df_columns[col_idx])] - 1);
-			names.emplace_back(py::str(column_name));
-			column_attributes[py::cast(col_idx)] = py::str(column_name);
+			string column_name = column_name_py;
+			column_name += "_" + to_string(pandas_column_names_map[column_name_py] - 1);
+			auto new_column_name_py = py::str(column_name);
+			names.emplace_back(new_column_name_py);
+			column_attributes[py::cast(col_idx)] = new_column_name_py;
+			pandas_column_names_map[new_column_name_py]++;
 		} else {
-			names.emplace_back(py::str(df_columns[col_idx]));
+			names.emplace_back(column_name_py);
 		}
 	}
 

--- a/tools/pythonpkg/tests/pandas/test_same_name.py
+++ b/tools/pythonpkg/tests/pandas/test_same_name.py
@@ -5,7 +5,6 @@ import pandas as pd
 class TestMultipleColumnsSameName(object):
 
     def test_multiple_columns_with_same_name(self, duckdb_cursor):
-
         df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [5, 6, 7, 8], 'd': [9, 10, 11, 12]})
         df = df.rename(columns={ df.columns[1]: "a" })
         con = duckdb.connect()
@@ -16,4 +15,13 @@ class TestMultipleColumnsSameName(object):
 
         assert con.execute("select a_1 from df_view;").fetchall() == [(5,), (6,), (7,), (8,)]
 
+    def test_multiple_columns_with_same_name_2(self, duckdb_cursor):
+        df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [5, 6, 7, 8], 'a_1': [9, 10, 11, 12]})
+        df = df.rename(columns={ df.columns[1]: "a_1" })
+        con = duckdb.connect()
+        con.register('df_view', df)
+        assert con.execute("DESCRIBE df_view;").fetchall() == [('a', 'BIGINT', 'YES', None, None, None), ('a_1', 'BIGINT', 'YES', None, None, None), ('a_1_1', 'BIGINT', 'YES', None, None, None)]
+        assert con.execute("select a_1 from df_view;").fetchall() == [(5,), (6,), (7,), (8,)]
+        assert con.execute("select a from df_view;").fetchall() == [(1,), (2,), (3,), (4,)]
 
+        assert con.execute("select a_1_1 from df_view;").fetchall() == [(9,), (10,), (11,), (12,)]

--- a/tools/pythonpkg/tests/pandas/test_same_name.py
+++ b/tools/pythonpkg/tests/pandas/test_same_name.py
@@ -1,6 +1,7 @@
 import pytest
 import duckdb
 import pandas as pd
+import sys
 
 class TestMultipleColumnsSameName(object):
 
@@ -16,6 +17,9 @@ class TestMultipleColumnsSameName(object):
         assert con.execute("select a_1 from df_view;").fetchall() == [(5,), (6,), (7,), (8,)]
 
     def test_multiple_columns_with_same_name_2(self, duckdb_cursor):
+        # Python 2 failure seems to be related to bytes vs strings
+        if sys.version_info.major < 3:
+            return
         df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [5, 6, 7, 8], 'a_1': [9, 10, 11, 12]})
         df = df.rename(columns={ df.columns[1]: "a_1" })
         con = duckdb.connect()

--- a/tools/pythonpkg/tests/pandas/test_same_name.py
+++ b/tools/pythonpkg/tests/pandas/test_same_name.py
@@ -1,0 +1,19 @@
+import pytest
+import duckdb
+import pandas as pd
+
+class TestMultipleColumnsSameName(object):
+
+    def test_multiple_columns_with_same_name(self, duckdb_cursor):
+
+        df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [5, 6, 7, 8], 'd': [9, 10, 11, 12]})
+        df = df.rename(columns={ df.columns[1]: "a" })
+        con = duckdb.connect()
+        con.register('df_view', df)
+        assert con.execute("DESCRIBE df_view;").fetchall() == [('a', 'BIGINT', 'YES', None, None, None), ('a_1', 'BIGINT', 'YES', None, None, None), ('d', 'BIGINT', 'YES', None, None, None)]
+        assert con.execute("select a_1 from df_view;").fetchall() == [(5,), (6,), (7,), (8,)]
+        assert con.execute("select a from df_view;").fetchall() == [(1,), (2,), (3,), (4,)]
+
+        assert con.execute("select a_1 from df_view;").fetchall() == [(5,), (6,), (7,), (8,)]
+
+


### PR DESCRIPTION
In case a dataframe has multiple columns with the same name, subsequent columns are renamed adding _x where x is the repetition number.
