### PR TITLE
Guarantee same thread calls R in binder and scans (Arrow)

### DIFF
--- a/src/include/duckdb/function/table/arrow.hpp
+++ b/src/include/duckdb/function/table/arrow.hpp
@@ -16,7 +16,7 @@
 #include "duckdb/common/thread.hpp"
 #include <map>
 #include <condition_variable>
-#define DUCKDB_NO_THREADS
+
 namespace duckdb {
 //===--------------------------------------------------------------------===//
 // Arrow Variable Size Types

--- a/src/include/duckdb/function/table/arrow.hpp
+++ b/src/include/duckdb/function/table/arrow.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/thread.hpp"
 #include <map>
+#include <condition_variable>
 
 namespace duckdb {
 //===--------------------------------------------------------------------===//

--- a/tools/rpkg/src/register.cpp
+++ b/tools/rpkg/src/register.cpp
@@ -6,11 +6,6 @@
 #include "duckdb/planner/filter/constant_filter.hpp"
 #include "duckdb/planner/filter/conjunction_filter.hpp"
 
-#ifndef _WIN32
-#define CSTACK_DEFNS
-#include "Rinterface.h"
-#endif
-
 using namespace duckdb;
 
 SEXP RApi::RegisterDataFrame(SEXP connsexp, SEXP namesexp, SEXP valuesexp) {
@@ -92,10 +87,6 @@ public:
 			export_call = r.Protect(
 			    Rf_lang5(export_fun, factory->arrow_scannable, stream_ptr_sexp, projection_sexp, filters_sexp));
 		}
-//! Otherwise, if different threads call R methods we get a stack error
-#ifndef _WIN32
-		R_CStackLimit = (uintptr_t)-1;
-#endif
 		RApi::REvalThrows(export_call);
 		return res;
 	}

--- a/tools/rpkg/tests/testthat/test_register_arrow.R
+++ b/tools/rpkg/tests/testthat/test_register_arrow.R
@@ -321,3 +321,19 @@ test_that("duckdb_register_arrow() performs selection pushdown date type", {
     dbDisconnect(con, shutdown = T)
 })
 
+test_that("duckdb_register_arrow() under many threads", {
+    con <- DBI::dbConnect(duckdb::duckdb())
+    ds <- arrow::InMemoryDataset$create(mtcars)
+    duckdb::duckdb_register_arrow(con, "mtcars_arrow", ds)
+    DBI::dbExecute(con, "PRAGMA threads=32")
+    DBI::dbExecute(con, "PRAGMA force_parallelism")
+    expect_error(DBI::dbGetQuery(con, "SELECT cyl, COUNT(mpg) FROM mtcars_arrow GROUP BY cyl"),NA)
+
+    expect_error(DBI::dbGetQuery(con, "SELECT cyl, SUM(mpg) FROM mtcars_arrow GROUP BY cyl"),NA)
+
+
+    expect_error(DBI::dbGetQuery(con, "SELECT cyl, AVG(mpg) FROM mtcars_arrow GROUP BY cyl"),NA)
+
+})
+
+


### PR DESCRIPTION
This PR implements a workaround to the multithread R problem.
The best solution would actually be to have a global initialize for the parallel state that is called in the main thread. I'm postponing it due to @Mytherin rework of the push-based model.

Here I capture the thread id in the binding phase and guarantee that the same thread makes the call when creating the stream for the scans (i.e., if it is not the same thread, they wait until the correct thread starts it off).