### PR TITLE
Issue #2180: handle case ambiguity in USING clause correctly

### DIFF
--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -81,7 +81,9 @@ public:
 	void AddCTEBinding(idx_t index, const string &alias, const vector<string> &names, const vector<LogicalType> &types);
 
 	//! Add an implicit join condition (e.g. USING (x))
-	void AddUsingBinding(const string &column_name, UsingColumnSet set);
+	void AddUsingBinding(const string &column_name, UsingColumnSet *set);
+
+	void AddUsingBindingSet(unique_ptr<UsingColumnSet> set);
 
 	//! Returns any using column set for the given column name, or nullptr if there is none. On conflict (multiple using
 	//! column sets with the same name) throw an exception.
@@ -90,6 +92,13 @@ public:
 	UsingColumnSet *GetUsingBinding(const string &column_name, const string &binding_name);
 	//! Erase a using binding from the set of using bindings
 	void RemoveUsingBinding(const string &column_name, UsingColumnSet *set);
+	//! Finds the using bindings for a given column. Returns true if any exists, false otherwise.
+	bool FindUsingBinding(const string &column_name, vector<UsingColumnSet *> **using_columns);
+
+	//! Fetch the actual column name from the given binding, or throws if none exists
+	//! This can be different from "column_name" because of case insensitivity
+	//! (e.g. "column_name" might return "COLUMN_NAME")
+	string GetActualColumnName(const string &binding, const string &column_name);
 
 	unordered_map<string, std::shared_ptr<Binding>> GetCTEBindings() {
 		return cte_bindings;
@@ -118,7 +127,9 @@ private:
 	//! The list of bindings in insertion order
 	vector<std::pair<string, Binding *>> bindings_list;
 	//! The set of columns used in USING join conditions
-	unordered_map<string, vector<UsingColumnSet>> using_columns;
+	unordered_map<string, vector<UsingColumnSet *>> using_columns;
+	//! Using column sets
+	vector<unique_ptr<UsingColumnSet>> using_column_sets;
 
 	//! The set of CTE bindings
 	unordered_map<string, std::shared_ptr<Binding>> cte_bindings;

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -122,6 +122,8 @@ public:
 	//! Add a correlated column to this binder (if it does not exist)
 	void AddCorrelatedColumn(const CorrelatedColumnInfo &info);
 
+	void AddUsingBindingSet(unique_ptr<UsingColumnSet> set);
+
 	string FormatError(ParsedExpression &expr_context, const string &message);
 	string FormatError(TableRef &ref_context, const string &message);
 

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -260,6 +260,14 @@ vector<ExpressionBinder *> &Binder::GetActiveBinders() {
 	return active_binders;
 }
 
+void Binder::AddUsingBindingSet(unique_ptr<UsingColumnSet> set) {
+	if (parent) {
+		parent->AddUsingBindingSet(move(set));
+		return;
+	}
+	bind_context.AddUsingBindingSet(move(set));
+}
+
 void Binder::MoveCorrelatedExpressions(Binder &other) {
 	MergeCorrelatedColumns(other.correlated_columns);
 	other.correlated_columns.clear();

--- a/src/planner/binder/tableref/bind_joinref.cpp
+++ b/src/planner/binder/tableref/bind_joinref.cpp
@@ -156,7 +156,7 @@ unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
 			left_binder.bind_context.RemoveUsingBinding(column_name, left_using_binding);
 			right_binder.bind_context.RemoveUsingBinding(column_name, right_using_binding);
 			bind_context.AddUsingBinding(column_name, set.get());
-			bind_context.AddUsingBindingSet(move(set));
+			AddUsingBindingSet(move(set));
 		}
 		if (extra_conditions.empty()) {
 			// no matching bindings found in natural join: throw an exception
@@ -226,7 +226,7 @@ unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
 			if (left_column_name != right_column_name) {
 				bind_context.AddUsingBinding(right_column_name, set.get());
 			}
-			bind_context.AddUsingBindingSet(move(set));
+			AddUsingBindingSet(move(set));
 		}
 	}
 	bind_context.AddContext(move(left_binder.bind_context));

--- a/test/sql/catalog/issue_2180.test
+++ b/test/sql/catalog/issue_2180.test
@@ -1,0 +1,146 @@
+# name: test/sql/catalog/issue_2180.test
+# description: Issue #2180: Duplicate Join Column Names with USING Statements
+# group: [catalog]
+
+statement ok
+create table A as select 1 as "X", 2 as "Y";
+
+statement ok
+create table B as select 1 as "X", 3 as "Z";
+
+query III
+select * from A join B using(X);
+----
+1	2	3
+
+query III
+select * from A join B using("X");
+----
+1	2	3
+
+# case mismatch in using clause
+statement ok
+DROP TABLE "A"
+
+statement ok
+DROP TABLE "B"
+
+statement ok
+create table A as select 1 as "X", 2 as "Y";
+
+statement ok
+create table B as select 1 as X, 3 as "Z";
+
+query III
+select * from A join B using(X);
+----
+1	2	3
+
+query III
+select * from A join B using(X);
+----
+1	2	3
+
+# case mismatch with ambiguity in using clause
+statement ok
+DROP TABLE "A"
+
+statement ok
+DROP TABLE "B"
+
+statement ok
+create table A as select 1 as "X", 2 as x;
+
+statement ok
+create table B as select 1 as "X", 2 as x;
+
+query III
+select * from A join B using(x);
+----
+1	2	1
+
+query III
+select * from A join B using("X");
+----
+1	2	2
+
+query II
+select * from A natural join B;
+----
+1	2
+
+# multi-way using
+statement ok
+create table C as select 1 as "X", 2 as x;
+
+query IIII
+select * from A join B using(x) join C using(x);
+----
+1	2	1	1
+
+query IIII
+select * from A join B using("X") join C using ("X");
+----
+1	2	2	2
+
+query II
+select * from A natural join B natural join C;
+----
+1	2
+
+# complete ambiguity
+statement ok
+DROP TABLE "A"
+
+statement ok
+DROP TABLE "B"
+
+statement ok
+DROP TABLE "C"
+
+statement ok
+create table A as select 1 as "HELLO", 2 as hello;
+
+statement ok
+create table B as select 1 as "HELLO", 2 as hello;
+
+query III
+select * from A join B using(hello);
+----
+1	2	1
+
+query III
+select * from A join B using("HELLO");
+----
+1	2	2
+
+query III
+select * from A join B using(hello);
+----
+1	2	1
+
+# complete ambiguity with multi-way tables
+statement ok
+create table C as select 1 as "HELLO", 2 as hello;
+
+query IIII
+select * from A join B using(hello) join C using(hello);
+----
+1	2	1	1
+
+query IIII
+select * from A join B using("HELLO") join C using("HELLO");
+----
+1	2	2	2
+
+query II
+select * from A natural join B natural join C;
+----
+1	2
+
+# like this doesn't work - ambiguity
+statement error
+select * from A join B using(hello) join C using("HELLO");
+
+statement error
+select * from A join B using("HELLO") join C using(hello);


### PR DESCRIPTION
This should fix #2180.

Now this works correctly:

```sql
create table A as select 1 as "X", 2 as "Y";
create table B as select 1 as "X", 3 as "Z";
select * from A join B using(X);
┌───┬───┬───┐
│ X │ Y │ Z │
├───┼───┼───┤
│ 1 │ 2 │ 3 │
└───┴───┴───┘
```