### PR TITLE
Prefetch Parquet Meta Data

### DIFF
--- a/extension/parquet/include/thrift_tools.hpp
+++ b/extension/parquet/include/thrift_tools.hpp
@@ -13,12 +13,13 @@ namespace duckdb {
 
 class ThriftFileTransport : public duckdb_apache::thrift::transport::TVirtualTransport<ThriftFileTransport> {
 public:
-	ThriftFileTransport(Allocator &allocator, FileHandle &handle_p) :
-	    allocator(allocator), handle(handle_p), location(0) {
+	ThriftFileTransport(Allocator &allocator, FileHandle &handle_p)
+	    : allocator(allocator), handle(handle_p), location(0) {
 	}
 
 	uint32_t read(uint8_t *buf, uint32_t len) {
-		if (prefetched_data && location >= prefetch_location && location + len < prefetch_location + prefetched_data->GetSize()) {
+		if (prefetched_data && location >= prefetch_location &&
+		    location + len < prefetch_location + prefetched_data->GetSize()) {
 			memcpy(buf, prefetched_data->get() + location - prefetch_location, len);
 		} else {
 			handle.Read(buf, len, location);

--- a/extension/parquet/include/thrift_tools.hpp
+++ b/extension/parquet/include/thrift_tools.hpp
@@ -6,19 +6,35 @@
 #include "duckdb.hpp"
 #ifndef DUCKDB_AMALGAMATION
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/allocator.hpp"
 #endif
 
 namespace duckdb {
 
 class ThriftFileTransport : public duckdb_apache::thrift::transport::TVirtualTransport<ThriftFileTransport> {
 public:
-	ThriftFileTransport(FileHandle &handle_p) : handle(handle_p), location(0) {
+	ThriftFileTransport(Allocator &allocator, FileHandle &handle_p) :
+	    allocator(allocator), handle(handle_p), location(0) {
 	}
 
 	uint32_t read(uint8_t *buf, uint32_t len) {
-		handle.Read(buf, len, location);
+		if (prefetched_data && location >= prefetch_location && location + len < prefetch_location + prefetched_data->GetSize()) {
+			memcpy(buf, prefetched_data->get() + location - prefetch_location, len);
+		} else {
+			handle.Read(buf, len, location);
+		}
 		location += len;
 		return len;
+	}
+
+	void Prefetch(idx_t pos, idx_t len) {
+		prefetch_location = pos;
+		prefetched_data = allocator.Allocate(len);
+		handle.Read(prefetched_data->get(), len, prefetch_location);
+	}
+
+	void ClearPrefetch() {
+		prefetched_data.reset();
 	}
 
 	void SetLocation(idx_t location_p) {
@@ -33,8 +49,12 @@ public:
 	}
 
 private:
-	duckdb::FileHandle &handle;
-	duckdb::idx_t location;
+	Allocator &allocator;
+	FileHandle &handle;
+	idx_t location;
+
+	unique_ptr<AllocatedData> prefetched_data;
+	idx_t prefetch_location;
 };
 
 } // namespace duckdb

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -46,7 +46,8 @@ using duckdb_parquet::format::SchemaElement;
 using duckdb_parquet::format::Statistics;
 using duckdb_parquet::format::Type;
 
-static unique_ptr<duckdb_apache::thrift::protocol::TProtocol> CreateThriftProtocol(Allocator &allocator, FileHandle &file_handle) {
+static unique_ptr<duckdb_apache::thrift::protocol::TProtocol> CreateThriftProtocol(Allocator &allocator,
+                                                                                   FileHandle &file_handle) {
 	auto transport = make_shared<ThriftFileTransport>(allocator, file_handle);
 	return make_unique<duckdb_apache::thrift::protocol::TCompactProtocolT<ThriftFileTransport>>(move(transport));
 }

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -46,15 +46,15 @@ using duckdb_parquet::format::SchemaElement;
 using duckdb_parquet::format::Statistics;
 using duckdb_parquet::format::Type;
 
-static unique_ptr<duckdb_apache::thrift::protocol::TProtocol> CreateThriftProtocol(FileHandle &file_handle) {
-	shared_ptr<ThriftFileTransport> trans(new ThriftFileTransport(file_handle));
-	return make_unique<duckdb_apache::thrift::protocol::TCompactProtocolT<ThriftFileTransport>>(trans);
+static unique_ptr<duckdb_apache::thrift::protocol::TProtocol> CreateThriftProtocol(Allocator &allocator, FileHandle &file_handle) {
+	auto transport = make_shared<ThriftFileTransport>(allocator, file_handle);
+	return make_unique<duckdb_apache::thrift::protocol::TCompactProtocolT<ThriftFileTransport>>(move(transport));
 }
 
 static shared_ptr<ParquetFileMetadataCache> LoadMetadata(Allocator &allocator, FileHandle &file_handle) {
 	auto current_time = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 
-	auto proto = CreateThriftProtocol(file_handle);
+	auto proto = CreateThriftProtocol(allocator, file_handle);
 	auto &transport = ((ThriftFileTransport &)*proto->getTransport());
 	auto file_size = transport.GetSize();
 	if (file_size < 12) {
@@ -78,6 +78,7 @@ static shared_ptr<ParquetFileMetadataCache> LoadMetadata(Allocator &allocator, F
 	}
 	auto metadata_pos = file_size - (footer_len + 8);
 	transport.SetLocation(metadata_pos);
+	transport.Prefetch(metadata_pos, footer_len);
 
 	auto metadata = make_unique<FileMetaData>();
 	metadata->read(proto.get());
@@ -386,7 +387,7 @@ void ParquetReader::InitializeScan(ParquetReaderScanState &state, vector<column_
 	state.filters = filters;
 	state.sel.Initialize(STANDARD_VECTOR_SIZE);
 	state.file_handle = file_handle->file_system.OpenFile(file_handle->path, FileFlags::FILE_FLAGS_READ);
-	state.thrift_file_proto = CreateThriftProtocol(*state.file_handle);
+	state.thrift_file_proto = CreateThriftProtocol(allocator, *state.file_handle);
 	state.root_reader = CreateReader(*this, GetFileMetadata());
 
 	state.define_buf.resize(allocator, STANDARD_VECTOR_SIZE);

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -35,6 +35,9 @@ public:
 	const_data_ptr_t get() const {
 		return pointer;
 	}
+	idx_t GetSize() const {
+		return allocated_size;
+	}
 	void Reset();
 
 private:


### PR DESCRIPTION
Prefetch the Parquet meta data prior to reading. This should avoid many small calls to `pread` at the beginning of a Parquet file which should significantly speed up Parquet metadata reading. This is probably fixing #2051.

This gets the metadata read for the giant Parquet file in #2193 down to 15 seconds, from several minutes.