### PR TITLE
Include content of parquet-extension.hpp in parquet-amalgamation.hpp

### DIFF
--- a/scripts/parquet_amalgamation.py
+++ b/scripts/parquet_amalgamation.py
@@ -15,6 +15,7 @@ compile_directories = list(set([x.rsplit(os.path.sep, 1)[0] for x in parquet_con
 
 amalgamation.include_paths += parquet_config.include_directories
 amalgamation.main_header_files = [
+    os.path.sep.join('extension/parquet/include/parquet-extension.hpp'.split('/')),
     os.path.sep.join('extension/parquet/include/parquet_reader.hpp'.split('/')),
     os.path.sep.join('extension/parquet/include/parquet_writer.hpp'.split('/'))]
 amalgamation.skip_duckdb_includes = True


### PR DESCRIPTION
Previously, to get the following code to compile, I had to include `"parquet-amalgamation.cpp"` instead of the header file `"parquet-amalgamation.hpp"`, because `duckdb::ParquetExtension` is included in the source file. I figured it might be cleaner to include the header file in my code instead, which motivated this PR.

```
#include <iostream>

#include "duckdb.hpp"
#include "parquet-amalgamation.hpp"

int main() {
  std::cout << "hello" << std::endl;
  duckdb::DuckDB db(nullptr);
  db.LoadExtension<duckdb::ParquetExtension>();

  duckdb::Connection con(db);

  auto result = con.Query("SELECT * FROM 'data.parquet' limit 10");
  result->Print();
}
```