### PR TITLE
Add URI encoding to S3 fs

### DIFF
--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -136,7 +136,8 @@ void S3FileSystem::Verify() {
 	if (uri_encode("/?category=Books&title=Ducks Retreat/") != "/%3Fcategory%3DBooks%26title%3DDucks+Retreat/") {
 		throw std::runtime_error("test fail");
 	}
-	if (uri_encode("/?category=Books&title=Ducks Retreat/", true) != "%2F%3Fcategory%3DBooks%26title%3DDucks+Retreat%2F") {
+	if (uri_encode("/?category=Books&title=Ducks Retreat/", true) !=
+	    "%2F%3Fcategory%3DBooks%26title%3DDucks+Retreat%2F") {
 		throw std::runtime_error("test fail");
 	}
 }

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -129,6 +129,16 @@ void S3FileSystem::Verify() {
 	    "Signature=182072eb53d85c36b2d791a1fa46a12d23454ec1e921b02075c23aee40166d5a") {
 		throw std::runtime_error("test fail");
 	}
+
+	if (uri_encode("/category=Books/") != "/category%3DBooks/") {
+		throw std::runtime_error("test fail");
+	}
+	if (uri_encode("/?category=Books&title=Ducks Retreat/") != "%2F%3Fcategory%3DBooks%26title%3DDucks+Retreat%2F") {
+		throw std::runtime_error("test fail");
+	}
+	if (uri_encode("/?category=Books&title=Ducks Retreat/", false) != "/%3Fcategory%3DBooks%26title%3DDucks+Retreat/") {
+		throw std::runtime_error("test fail");
+	}
 }
 
 bool S3FileSystem::CanHandleFile(const string &fpath) {

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -133,10 +133,10 @@ void S3FileSystem::Verify() {
 	if (uri_encode("/category=Books/") != "/category%3DBooks/") {
 		throw std::runtime_error("test fail");
 	}
-	if (uri_encode("/?category=Books&title=Ducks Retreat/") != "%2F%3Fcategory%3DBooks%26title%3DDucks+Retreat%2F") {
+	if (uri_encode("/?category=Books&title=Ducks Retreat/") != "/%3Fcategory%3DBooks%26title%3DDucks+Retreat/") {
 		throw std::runtime_error("test fail");
 	}
-	if (uri_encode("/?category=Books&title=Ducks Retreat/", false) != "/%3Fcategory%3DBooks%26title%3DDucks+Retreat/") {
+	if (uri_encode("/?category=Books&title=Ducks Retreat/", true) != "%2F%3Fcategory%3DBooks%26title%3DDucks+Retreat%2F") {
 		throw std::runtime_error("test fail");
 	}
 }

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -8,24 +8,26 @@
 
 using namespace duckdb;
 
-static std::string uri_encode(std::string input, bool encodeSlash = false) {
+static std::string uri_encode(const std::string &input, bool encode_slash = false) {
 	// https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
-	static auto hex_digt = "0123456789ABCDEF";
-	std::string result = "";
-	for (int i = 0; i < input.length(); i++) {
+	static const char *hex_digit = "0123456789ABCDEF";
+	std::string result;
+	result.reserve(input.size());
+	for (idx_t i = 0; i < input.length(); i++) {
 		char ch = input[i];
 		if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '_' ||
 		    ch == '-' || ch == '~' || ch == '.') {
 			result += ch;
 		} else if (ch == '/') {
-			if (encodeSlash) {
+			if (encode_slash) {
 				result += std::string("%2F");
 			} else {
 				result += ch;
 			}
 		} else {
-			result += std::string("%") + hex_digt[static_cast<unsigned char>(ch) >> 4] +
-			          hex_digt[static_cast<unsigned char>(ch) & 15];
+			result += std::string("%");
+			result += hex_digit[static_cast<unsigned char>(ch) >> 4];
+			result += hex_digit[static_cast<unsigned char>(ch) & 15];
 		}
 	}
 	return result;

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -133,11 +133,11 @@ void S3FileSystem::Verify() {
 	if (uri_encode("/category=Books/") != "/category%3DBooks/") {
 		throw std::runtime_error("test fail");
 	}
-	if (uri_encode("/?category=Books&title=Ducks Retreat/") != "/%3Fcategory%3DBooks%26title%3DDucks+Retreat/") {
+	if (uri_encode("/?category=Books&title=Ducks Retreat/") != "/%3Fcategory%3DBooks%26title%3DDucks%20Retreat/") {
 		throw std::runtime_error("test fail");
 	}
 	if (uri_encode("/?category=Books&title=Ducks Retreat/", true) !=
-	    "%2F%3Fcategory%3DBooks%26title%3DDucks+Retreat%2F") {
+	    "%2F%3Fcategory%3DBooks%26title%3DDucks%20Retreat%2F") {
 		throw std::runtime_error("test fail");
 	}
 }

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -10,11 +10,12 @@ using namespace duckdb;
 
 static std::string uri_encode(std::string  input, bool encodeSlash = false) {
 	// https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
-    static auto hex_digt = "0123456789ABCDEF";
+	static auto hex_digt = "0123456789ABCDEF";
 	std::string result = "";
 	for (int i = 0; i < input.length(); i++) {
 		char ch = input[i];
-		if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '-' || ch == '~' || ch == '.') {
+		if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '_' ||
+		    ch == '-' || ch == '~' || ch == '.') {
 			result += ch;
 		} else if (ch == '/') {
 			if (encodeSlash) {
@@ -23,7 +24,8 @@ static std::string uri_encode(std::string  input, bool encodeSlash = false) {
 				result += ch;
 			}
 		} else {
-			result += std::string("%") + hex_digt[static_cast<unsigned char>(ch) >> 4] + hex_digt[static_cast<unsigned char>(ch) & 15];
+			result += std::string("%") + hex_digt[static_cast<unsigned char>(ch) >> 4] +
+			          hex_digt[static_cast<unsigned char>(ch) & 15];
 		}
 	}
 	return result;
@@ -50,9 +52,9 @@ static HeaderMap create_s3_get_header(std::string url, std::string host, std::st
 	// construct string to sign
 	hash_bytes canonical_request_hash;
 	hash_str canonical_request_hash_str;
-	auto canonical_request = method + "\n" + uri_encode(url) + "\n\nhost:" + host + "\nx-amz-content-sha256:" + empty_payload_hash +
-	                         "\nx-amz-date:" + datetime_now + "\n\nhost;x-amz-content-sha256;x-amz-date\n" +
-	                         empty_payload_hash;
+	auto canonical_request = method + "\n" + uri_encode(url) + "\n\nhost:" + host +
+	                         "\nx-amz-content-sha256:" + empty_payload_hash + "\nx-amz-date:" + datetime_now +
+	                         "\n\nhost;x-amz-content-sha256;x-amz-date\n" + empty_payload_hash;
 	sha256(canonical_request.c_str(), canonical_request.length(), canonical_request_hash);
 	hex256(canonical_request_hash, canonical_request_hash_str);
 	auto string_to_sign = "AWS4-HMAC-SHA256\n" + datetime_now + "\n" + date_now + "/" + region + "/" + service +

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -8,7 +8,7 @@
 
 using namespace duckdb;
 
-static std::string uri_encode(std::string  input, bool encodeSlash = false) {
+static std::string uri_encode(std::string input, bool encodeSlash = false) {
 	// https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
 	static auto hex_digt = "0123456789ABCDEF";
 	std::string result = "";


### PR DESCRIPTION
The httpfs extension supports S3 URLs, however, the URL is not encoded and thus e.g. paths with `category=Books` do not work as the equal sign is not URI encoded for the canonical URL formation (sigv4). This PR adds URI encoding as per https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html. 

- [x] formatting, linting, etc.
- [x] unit test