### PR TITLE
Add support for S3 session token (STS)

### DIFF
--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -64,8 +64,8 @@ static HeaderMap create_s3_get_header(std::string url, std::string query, std::s
 	}
 	auto canonical_request = method + "\n" + uri_encode(url) + "\n" + query + "\nhost:" + host +
 	                         "\nx-amz-content-sha256:" + empty_payload_hash + "\nx-amz-date:" + datetime_now;
-	if (access_token.length() > 0) {
-		canonical_request += "\nx-amz-security-token:" + access_token;
+	if (session_token.length() > 0) {
+		canonical_request += "\nx-amz-security-token:" + session_token;
 	}
 	canonical_request += "\n\n" + signed_headers + "\n" + empty_payload_hash;
 	sha256(canonical_request.c_str(), canonical_request.length(), canonical_request_hash);

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -8,6 +8,7 @@
 
 using namespace duckdb;
 
+<<<<<<< HEAD
 static std::string uri_encode(const std::string &input, bool encode_slash = false) {
 	// https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
 	static const char *hex_digit = "0123456789ABCDEF";
@@ -35,7 +36,14 @@ static std::string uri_encode(const std::string &input, bool encode_slash = fals
 
 static HeaderMap create_s3_get_header(std::string url, std::string host, std::string region, std::string service,
                                       std::string method, std::string access_key_id, std::string secret_access_key,
+                                      std::string access_token, std::string date_now = "",
+                                      std::string datetime_now = "") {
+=======
+static HeaderMap create_s3_get_header(std::string url, std::string query, std::string host, std::string region,
+                                      std::string service, std::string method, std::string access_key_id,
+                                      std::string secret_access_key, std::string session_token,
                                       std::string date_now = "", std::string datetime_now = "") {
+>>>>>>> b431b742d (successful test, renam to session token)
 	// this is the sha256 of the empty string, its useful since we have no payload for GET requests
 	auto empty_payload_hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
@@ -50,18 +58,34 @@ static HeaderMap create_s3_get_header(std::string url, std::string host, std::st
 	res["Host"] = host;
 	res["x-amz-date"] = datetime_now;
 	res["x-amz-content-sha256"] = empty_payload_hash;
+	if (session_token.length() > 0) {
+		res["x-amz-security-token"] = session_token;
+	}
 
 	// construct string to sign
 	hash_bytes canonical_request_hash;
 	hash_str canonical_request_hash_str;
-	auto canonical_request = method + "\n" + uri_encode(url) + "\n\nhost:" + host +
-	                         "\nx-amz-content-sha256:" + empty_payload_hash + "\nx-amz-date:" + datetime_now +
-	                         "\n\nhost;x-amz-content-sha256;x-amz-date\n" + empty_payload_hash;
+	std::string signed_headers = "host;x-amz-content-sha256;x-amz-date";
+	if (session_token.length() > 0) {
+		signed_headers += ";x-amz-security-token";
+	}
+<<<<<<< HEAD
+	auto canonical_request = method + "\n" + uri_encode(url) + "\n\nhost:" + host + "\nx-amz-content-sha256:" + 
+							 empty_payload_hash + "\nx-amz-date:" + datetime_now;
+	if (access_token.length() > 0) {
+		canonical_request += "\nx-amz-security-token:" + access_token;
+=======
+	auto canonical_request = method + "\n" + url + "\n" + query + "\nhost:" + host +
+	                         "\nx-amz-content-sha256:" + empty_payload_hash + "\nx-amz-date:" + datetime_now;
+	if (session_token.length() > 0) {
+		canonical_request += "\nx-amz-security-token:" + session_token;
+>>>>>>> b431b742d (successful test, renam to session token)
+	}
+	canonical_request += "\n\n" + signed_headers + "\n" + empty_payload_hash;
 	sha256(canonical_request.c_str(), canonical_request.length(), canonical_request_hash);
 	hex256(canonical_request_hash, canonical_request_hash_str);
 	auto string_to_sign = "AWS4-HMAC-SHA256\n" + datetime_now + "\n" + date_now + "/" + region + "/" + service +
 	                      "/aws4_request\n" + std::string((char *)canonical_request_hash_str, sizeof(hash_str));
-
 	// compute signature
 	hash_bytes k_date, k_region, k_service, signing_key, signature;
 	hash_str signature_str;
@@ -74,8 +98,8 @@ static HeaderMap create_s3_get_header(std::string url, std::string host, std::st
 	hex256(signature, signature_str);
 
 	res["Authorization"] = "AWS4-HMAC-SHA256 Credential=" + access_key_id + "/" + date_now + "/" + region + "/" +
-	                       service + "/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=" +
-	                       std::string((char *)signature_str, sizeof(hash_str));
+	                       service + "/aws4_request, SignedHeaders=" + signed_headers +
+	                       ", Signature=" + std::string((char *)signature_str, sizeof(hash_str));
 
 	return res;
 }
@@ -110,8 +134,11 @@ HeaderMap S3FileSystem::CreateAuthHeaders(string host, string path, string metho
 	auto region = database_instance.config.set_variables["s3_region"].str_value;
 	auto access_key_id = database_instance.config.set_variables["s3_access_key_id"].str_value;
 	auto secret_access_key = database_instance.config.set_variables["s3_secret_access_key"].str_value;
+	// With STS credentials the session token must be provided
+	//   See: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
+	auto session_token = database_instance.config.set_variables["s3_session_token"].str_value;
 
-	return create_s3_get_header(path, host, region, "s3", method, access_key_id, secret_access_key);
+	return create_s3_get_header(path, "", host, region, "s3", method, access_key_id, secret_access_key, session_token);
 }
 
 std::unique_ptr<FileHandle> S3FileSystem::OpenFile(const string &path, uint8_t flags, FileLockType lock,
@@ -122,13 +149,46 @@ std::unique_ptr<FileHandle> S3FileSystem::OpenFile(const string &path, uint8_t f
 
 // this computes the signature from https://czak.pl/2015/09/15/s3-rest-api-with-curl.html
 void S3FileSystem::Verify() {
-	auto test_header = create_s3_get_header("/", "my-precious-bucket.s3.amazonaws.com", "us-east-1", "s3", "GET",
-	                                        "AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+	auto test_header = create_s3_get_header("/", "", "my-precious-bucket.s3.amazonaws.com", "us-east-1", "s3", "GET",
+	                                        "AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", "",
 	                                        "20150915", "20150915T124500Z");
 	if (test_header["Authorization"] !=
 	    "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20150915/us-east-1/s3/aws4_request, "
 	    "SignedHeaders=host;x-amz-content-sha256;x-amz-date, "
 	    "Signature=182072eb53d85c36b2d791a1fa46a12d23454ec1e921b02075c23aee40166d5a") {
+		throw std::runtime_error("test fail");
+	}
+
+	if (uri_encode("/category=Books/") != "/category%3DBooks/") {
+		throw std::runtime_error("test fail");
+	}
+	if (uri_encode("/?category=Books&title=Ducks Retreat/") != "/%3Fcategory%3DBooks%26title%3DDucks%20Retreat/") {
+		throw std::runtime_error("test fail");
+	}
+	if (uri_encode("/?category=Books&title=Ducks Retreat/", true) !=
+	    "%2F%3Fcategory%3DBooks%26title%3DDucks%20Retreat%2F") {
+		throw std::runtime_error("test fail");
+	}
+
+	auto test_header2 = create_s3_get_header(
+	    "/", "delimiter=%2F&encoding-type=url&list-type=2&prefix=", "my-precious-bucket.s3.eu-west-1.amazonaws.com",
+	    "eu-west-1", "s3", "GET", "ASIAYSPIOYDTHTBIITVC", "vs1BZPxSL2qVARBSg5vCMKJsavCoEPlo/HSHRaVe",
+	    "IQoJb3JpZ2luX2VjENX//////////wEaCWV1LXdlc3QtMSJHMEUCIQDfjzs9BYHrEXDMU/"
+	    "NR+PHV1uSTr7CSVSQdjKSfiPRLdgIgCCztF0VMbi9+"
+	    "uHHAfBVKhV4t9MlUrQg3VAOIsLxrWyoqlAIIHRAAGgw1ODk0MzQ4OTY2MTQiDOGl2DsYxENcKCbh+irxARe91faI+"
+	    "hwUhT60sMGRFg0GWefKnPclH4uRFzczrDOcJlAAaQRJ7KOsT8BrJlrY1jSgjkO7PkVjPp92vi6lJX77bg99MkUTJA"
+	    "ctiOKmd84XvAE5bFc/jFbqechtBjXzopAPkKsGuaqAhCenXnFt6cwq+LZikv/"
+	    "NJGVw7TRphLV+"
+	    "Aq9PSL9XwdzIgsW2qXwe1c3rxDNj53yStRZHVggdxJ0OgHx5v040c98gFphzSULHyg0OY6wmCMTYcswpb4kO2IIi6"
+	    "AiD9cY25TlwPKRKPi5CdBsTPnyTeW62u7PvwK0fTSy4ZuJUuGKQnH2cKmCXquEwoOHEiQY6nQH9fzY/"
+	    "EDGHMRxWWhxu0HiqIfsuFqC7GS0p0ToKQE+pzNsvVwMjZc+KILIDDQpdCWRIwu53I5PZy2Cvk+"
+	    "3y4XLvdZKQCsAKqeOc4c94UAS4NmUT7mCDOuRV0cLBVM8F0JYBGrUxyI+"
+	    "YoIvHhQWmnRLuKgTb5PkF7ZWrXBHFWG5/tZDOvBbbaCWTlRCL9b0Vpg5+BM/81xd8jChP4w83",
+	    "20210904", "20210904T121746Z");
+	if (test_header2["Authorization"] !=
+	    "AWS4-HMAC-SHA256 Credential=ASIAYSPIOYDTHTBIITVC/20210904/eu-west-1/s3/aws4_request, "
+	    "SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token, "
+	    "Signature=4d9d6b59d7836b6485f6ad822de97be40287da30347d83042ea7fbed530dc4c0") {
 		throw std::runtime_error("test fail");
 	}
 

--- a/test/sql/copy/parquet/test_parquet_remote.test
+++ b/test/sql/copy/parquet/test_parquet_remote.test
@@ -78,6 +78,9 @@ SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://github.com:44
 #statement ok
 #SET s3_secret_access_key='NOPE';
 #
+#statement ok
+#SET s3_session_token='EI';
+#
 #query IIII
 #SELECT id, first_name, last_name, email FROM PARQUET_SCAN('s3://cost-report-hannes/userdata1.parquet') LIMIT 10;
 #----


### PR DESCRIPTION
Add support for temporary AWS access credentials (e.g. EC2 instance roles) by adding support for access token parameter and using it if present.

- [x] formatting, linting, etc.
- [x] unit test