### PR TITLE
No longer fail CI on project codecov, and only run patch codecov on pull requests

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,7 +12,7 @@ coverage:
           - "src"
        # advanced settings
         if_not_found: failure
-        if_ci_failed: error #success, failure, error, ignore
+        if_ci_failed: success #success, failure, error, ignore
         informational: false
         only_pulls: false
     patch:
@@ -25,6 +25,6 @@ coverage:
         branches:
           - master
         if_ci_failed: error #success, failure, error, ignore
-        only_pulls: false
+        only_pulls: true
         paths:
           - "src"


### PR DESCRIPTION
* Project codecov has minor fluctuations because of multi-threading and we generally only care about patch codecov anyway.
* Patch codecov only makes sense on PRs.