### PR TITLE
Fixes #2240: Support in-place updates of varchar

### DIFF
--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -294,8 +294,11 @@ static void UpdateChunk(Vector &data, Vector &updates, Vector &row_ids, idx_t co
 	case PhysicalType::DOUBLE:
 		TemplatedUpdateLoop<double>(data, updates, row_ids, count, base_index);
 		break;
+	case PhysicalType::VARCHAR:
+		TemplatedUpdateLoop<string_t>(data, updates, row_ids, count, base_index);
+		break;
 	default:
-		throw Exception("Unsupported type for in-place update");
+		throw Exception("Unsupported type for in-place update: " + TypeIdToString(data.GetType().InternalType()));
 	}
 }
 

--- a/test/issues/general/test_2240.test
+++ b/test/issues/general/test_2240.test
@@ -1,0 +1,23 @@
+# name: test/issues/general/test_2240.test
+# description: Issue 2240: Exception thrown when inserting and updating a text column in the same row in a transaction
+# group: [general]
+
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
+CREATE TABLE test (id INTEGER, name TEXT);
+
+statement ok
+INSERT INTO test VALUES (1, 'Bob');
+
+statement ok
+UPDATE test SET name = 'Alice' Where id = 1;
+
+statement ok
+COMMIT;
+
+query T
+select name from test where id = 1;
+----
+Alice


### PR DESCRIPTION
This adds support for updating a column of type VARCHAR in-place during a transaction.