### PR TITLE
R: Support column subsets in dbAppendTable()

### DIFF
--- a/tools/rpkg/R/Connection.R
+++ b/tools/rpkg/R/Connection.R
@@ -204,8 +204,10 @@ setMethod(
       stop("Can't pass `row.names` to `dbAppendTable()`")
     }
 
-    if (!identical(names(value), dbListFields(conn, name))) {
-      stop("Column name mismatch for append")
+    target_names <- dbListFields(conn, name)
+
+    if (!all(names(value) %in% target_names)) {
+      stop("Column `", setdiff(names(value), target_names)[[1]], "` does not exist in target table.")
     }
 
     value <- encode_values(value)
@@ -216,7 +218,14 @@ setMethod(
       view_name <- sprintf("_duckdb_append_view_%s", duckdb_random_string())
       on.exit(duckdb_unregister(conn, view_name))
       duckdb_register(conn, view_name, value)
-      dbExecute(conn, sprintf("INSERT INTO %s SELECT * FROM %s", table_name, view_name))
+
+      sql <- paste0(
+        "INSERT INTO ", table_name, "\n",
+        "(", paste(dbQuoteIdentifier(conn, names(value)), collapse = ", "), ")\n",
+        "SELECT * FROM ", view_name
+      )
+
+      dbExecute(conn, sql)
 
       rs_on_connection_updated(conn, hint=paste0("Updated table'", table_name,"'"))
     }


### PR DESCRIPTION
Currently, columns must match exactly in `dbAppendTable()`. This PR relaxes this requirement by supporting tables with a subset of the columns and in arbitrary order.

Back-compatible with existing behavior. New behavior tested by https://github.com/r-dbi/DBItest/pull/235, works locally.