### PR TITLE
Get rid of polymorphism from FileSystem::GetFileType().

### DIFF
--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -67,7 +67,6 @@ public:
 	bool CanSeek();
 	bool OnDiskFile();
 	idx_t GetFileSize();
-	FileType GetType();
 
 protected:
 	virtual void Close() = 0;
@@ -124,8 +123,6 @@ public:
 	virtual int64_t GetFileSize(FileHandle &handle);
 	//! Returns the file last modified time of a file handle, returns timespec with zero on all attributes on error
 	virtual time_t GetLastModifiedTime(FileHandle &handle);
-	//! Returns the file last modified time of a file handle, returns timespec with zero on all attributes on error
-	virtual FileType GetFileType(FileHandle &handle);
 	//! Truncate a file to a maximum size of new_size, new_size should be smaller than or equal to the current size of
 	//! the file
 	virtual void Truncate(FileHandle &handle, int64_t new_size);
@@ -192,6 +189,11 @@ public:
 	virtual bool OnDiskFile(FileHandle &handle);
 
 private:
+	//! Returns the file last modified time of a file handle, returns timespec with zero on all attributes on error
+	FileType GetOsFileType(FileHandle &handle);
+	//! Opens the raw OS file handle.
+	unique_ptr<FileHandle> OpenOsFile(const string &path, uint8_t flags, FileLockType lock);
+
 	//! Set the file pointer of a file handle to a specified location. Reads and writes will happen from this location
 	void SetFilePointer(FileHandle &handle, idx_t location);
 	virtual idx_t GetFilePointer(FileHandle &handle);
@@ -224,9 +226,6 @@ public:
 	}
 	time_t GetLastModifiedTime(FileHandle &handle) override {
 		return handle.file_system.GetLastModifiedTime(handle);
-	}
-	FileType GetFileType(FileHandle &handle) override {
-		return handle.file_system.GetFileType(handle);
 	}
 
 	void Truncate(FileHandle &handle, int64_t new_size) override {


### PR DESCRIPTION
This fixes an ASAN error like following:

```
/home/morrita/w/duckdb/src/common/file_system.cpp:226:38: runtime error: member access within address 0x60b000035d00 which does not point to an object of type 'UnixFileHandle'
0x60b000035d00: note: object is of type 'duckdb::HTTPFileHandle'
 4e 00 80 77  08 f4 a8 53 10 56 00 00  50 7b 00 00 20 60 00 00  20 41 01 00 60 60 00 00  3b 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'duckdb::HTTPFileHandle'
```

This is hit when HTTPFS is used.

The problematic function, FileSystem::GetFileType(), is not
implemented in non-local FileSystem implementations and causes
this problem, and this is tricky to implement since the semantics
is tied to the local filesystem.

This change narrows the usage of this function to (local) FileSystem
implementation and gets rid of the polymorphism, as well as the
public visibility.