### PR TITLE
Allow optional extensions when building the R package

### DIFF
--- a/tools/rpkg/README.md
+++ b/tools/rpkg/README.md
@@ -17,6 +17,12 @@ cd tools/rpkg
 R CMD INSTALL .
 ```
 
+Optional extensions can be enabled by passing them (comma-separated, if there is more than one) to the environment variable `DUCKDB_R_EXTENSIONS`:
+
+```sh
+DUCKDB_R_EXTENSIONS=tpch R CMD INSTALL .
+```
+
 ## Development
 
 For development, setting the `DUCKDB_R_DEBUG` environment variable enables incremental debugging builds for the R package.

--- a/tools/rpkg/rconfigure.py
+++ b/tools/rpkg/rconfigure.py
@@ -4,6 +4,11 @@ import shutil
 import subprocess
 
 extensions = ['parquet']
+
+# check if there are any additional extensions being requested
+if 'DUCKDB_R_EXTENSIONS' in os.environ:
+    extensions = extensions + os.environ['DUCKDB_R_EXTENSIONS'].split(",")
+
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', 'scripts'))
 import package_build
 


### PR DESCRIPTION
This adds an envvar `DUCKDB_R_EXTENSIONS` where one can specify the optional extensions to build with. I've also added a (brief) description to the readme.

There isn't any checking that the extension is valid (one could look in `extension/`, makes sure the names match, and if not error but I'm not sure that's necessary since this is a more advanced-user feature).

Resolves #2264