### PR TITLE
Allow GitHub Actions run on manual requests.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 defaults:
   run:


### PR DESCRIPTION
By having `workflow_dispatch` in the `on` clause, the CI
is allowed to be run manually from Web or CLI.

This allows the contributors to make sure the build status
on their fork before sending out a PR, can reduce the
churn on the PR request. Will be especially helpful when
working on a platform-specfic code.

See:
 * https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
 * https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch