### PR TITLE
Make S3 credentials session scoped

### DIFF
--- a/extension/httpfs/httpfs-extension.cpp
+++ b/extension/httpfs/httpfs-extension.cpp
@@ -8,7 +8,7 @@ void HTTPFsExtension::Load(DuckDB &db) {
 	S3FileSystem::Verify(); // run some tests to see if all the hashes work out
 	auto &fs = db.instance->GetFileSystem();
 	fs.RegisterSubSystem(make_unique<HTTPFileSystem>());
-	fs.RegisterSubSystem(make_unique<S3FileSystem>(*db.instance));
+	fs.RegisterSubSystem(make_unique<S3FileSystem>());
 }
 
 } // namespace duckdb

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -80,7 +80,7 @@ HTTPFileHandle::HTTPFileHandle(FileSystem &fs, std::string path)
 }
 
 std::unique_ptr<FileHandle> HTTPFileSystem::OpenFile(const string &path, uint8_t flags, FileLockType lock,
-                                                     FileCompressionType compression) {
+                                                     FileCompressionType compression, FileOpener *opener) {
 	D_ASSERT(compression == FileCompressionType::UNCOMPRESSED);
 	return duckdb::make_unique<HTTPFileHandle>(*this, path);
 }

--- a/extension/httpfs/include/httpfs.hpp
+++ b/extension/httpfs/include/httpfs.hpp
@@ -46,8 +46,9 @@ public:
 
 class HTTPFileSystem : public FileSystem {
 public:
-	std::unique_ptr<FileHandle> OpenFile(const string &path, uint8_t flags, FileLockType lock = FileLockType::NO_LOCK,
-	                                     FileCompressionType compression = FileCompressionType::UNCOMPRESSED) override;
+	std::unique_ptr<FileHandle> OpenFile(const string &path, uint8_t flags, FileLockType lock = DEFAULT_LOCK,
+	                                     FileCompressionType compression = DEFAULT_COMPRESSION,
+	                                     FileOpener *opener = nullptr) override;
 
 	std::vector<std::string> Glob(const std::string &path) override {
 		return {path}; // FIXME

--- a/extension/httpfs/include/httpfs.hpp
+++ b/extension/httpfs/include/httpfs.hpp
@@ -23,14 +23,14 @@ public:
 class HTTPFileHandle : public FileHandle {
 public:
 	HTTPFileHandle(FileSystem &fs, std::string path);
+	// This two-phase construction allows subclasses more flexible setup.
+	virtual void InitializeMetadata();
 
 protected:
 	void Close() override {
 	}
 
 private:
-	virtual void IntializeMetadata();
-
 public:
 	idx_t length;
 	time_t last_modified;
@@ -48,7 +48,7 @@ class HTTPFileSystem : public FileSystem {
 public:
 	std::unique_ptr<FileHandle> OpenFile(const string &path, uint8_t flags, FileLockType lock = DEFAULT_LOCK,
 	                                     FileCompressionType compression = DEFAULT_COMPRESSION,
-	                                     FileOpener *opener = nullptr) override;
+	                                     FileOpener *opener = nullptr) override final;
 
 	std::vector<std::string> Glob(const std::string &path) override {
 		return {path}; // FIXME
@@ -84,6 +84,10 @@ public:
 	std::string GetName() const override {
 		return "HTTPFileSystem";
 	}
+
+protected:
+	virtual std::unique_ptr<HTTPFileHandle> CreateHandle(const string &path, uint8_t flags, FileLockType lock,
+	                                                     FileCompressionType compression, FileOpener *opener);
 };
 
 } // namespace duckdb

--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -9,8 +9,9 @@ class S3FileSystem : public HTTPFileSystem {
 public:
 	S3FileSystem(DatabaseInstance &instance_p) : database_instance(instance_p) {
 	}
-	std::unique_ptr<FileHandle> OpenFile(const string &path, uint8_t flags, FileLockType lock = FileLockType::NO_LOCK,
-	                                     FileCompressionType compression = FileCompressionType::UNCOMPRESSED) override;
+	std::unique_ptr<FileHandle> OpenFile(const string &path, uint8_t flags, FileLockType lock = DEFAULT_LOCK,
+	                                     FileCompressionType compression = DEFAULT_COMPRESSION,
+	                                     FileOpener *opener = nullptr) override;
 
 	unique_ptr<ResponseWrapper> Request(FileHandle &handle, string url, string method, HeaderMap header_map = {},
 	                                    idx_t file_offset = 0, char *buffer_out = nullptr,

--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -1,17 +1,14 @@
 #pragma once
 
 #include "httpfs.hpp"
-#include "duckdb/main/database.hpp"
+#include "duckdb/common/file_opener.hpp"
 
 namespace duckdb {
 
 class S3FileSystem : public HTTPFileSystem {
 public:
-	S3FileSystem(DatabaseInstance &instance_p) : database_instance(instance_p) {
+	S3FileSystem() {
 	}
-	std::unique_ptr<FileHandle> OpenFile(const string &path, uint8_t flags, FileLockType lock = DEFAULT_LOCK,
-	                                     FileCompressionType compression = DEFAULT_COMPRESSION,
-	                                     FileOpener *opener = nullptr) override;
 
 	unique_ptr<ResponseWrapper> Request(FileHandle &handle, string url, string method, HeaderMap header_map = {},
 	                                    idx_t file_offset = 0, char *buffer_out = nullptr,
@@ -23,11 +20,9 @@ public:
 		return false;
 	}
 
-public:
-	DatabaseInstance &database_instance;
-
-private:
-	HeaderMap CreateAuthHeaders(string host, string path, string method);
+protected:
+	std::unique_ptr<HTTPFileHandle> CreateHandle(const string &path, uint8_t flags, FileLockType lock,
+	                                             FileCompressionType compression, FileOpener *opener) override;
 };
 
 } // namespace duckdb

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -128,7 +128,7 @@ HeaderMap S3FileSystem::CreateAuthHeaders(string host, string path, string metho
 }
 
 std::unique_ptr<FileHandle> S3FileSystem::OpenFile(const string &path, uint8_t flags, FileLockType lock,
-                                                   FileCompressionType compression) {
+                                                   FileCompressionType compression, FileOpener *opener) {
 	D_ASSERT(compression == FileCompressionType::UNCOMPRESSED);
 	return duckdb::make_unique<HTTPFileHandle>(*this, path);
 }

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -71,6 +71,7 @@ public:
 
 	Allocator &allocator;
 	string file_name;
+	FileOpener *file_opener;
 	vector<LogicalType> return_types;
 	vector<string> names;
 	shared_ptr<ParquetFileMetadataCache> metadata;

--- a/extension/parquet/include/parquet_writer.hpp
+++ b/extension/parquet/include/parquet_writer.hpp
@@ -22,11 +22,12 @@
 
 namespace duckdb {
 class FileSystem;
+class FileOpener;
 
 class ParquetWriter {
 public:
-	ParquetWriter(FileSystem &fs, string file_name, vector<LogicalType> types, vector<string> names,
-	              duckdb_parquet::format::CompressionCodec::type codec);
+	ParquetWriter(FileSystem &fs, string file_name, FileOpener *file_opener, vector<LogicalType> types,
+	              vector<string> names, duckdb_parquet::format::CompressionCodec::type codec);
 
 public:
 	void Flush(ChunkCollection &buffer);

--- a/extension/parquet/parquet-extension.cpp
+++ b/extension/parquet/parquet-extension.cpp
@@ -130,7 +130,8 @@ public:
 			for (idx_t file_idx = 1; file_idx < bind_data.files.size(); file_idx++) {
 				auto &file_name = bind_data.files[file_idx];
 				auto metadata = std::dynamic_pointer_cast<ParquetFileMetadataCache>(cache.Get(file_name));
-				auto handle = fs.OpenFile(file_name, FileFlags::FILE_FLAGS_READ);
+				auto handle = fs.OpenFile(file_name, FileFlags::FILE_FLAGS_READ, FileSystem::DEFAULT_LOCK,
+				                          FileSystem::DEFAULT_COMPRESSION, FileSystem::GetFileOpener(context));
 				// but we need to check if the metadata cache entries are current
 				if (!metadata || (fs.GetLastModifiedTime(*handle) >= metadata->read_time)) {
 					// missing or invalid metadata entry in cache, no usable stats overall
@@ -403,8 +404,9 @@ unique_ptr<GlobalFunctionData> ParquetWriteInitializeGlobal(ClientContext &conte
 	auto &parquet_bind = (ParquetWriteBindData &)bind_data;
 
 	auto &fs = FileSystem::GetFileSystem(context);
-	global_state->writer = make_unique<ParquetWriter>(fs, parquet_bind.file_name, parquet_bind.sql_types,
-	                                                  parquet_bind.column_names, parquet_bind.codec);
+	global_state->writer =
+	    make_unique<ParquetWriter>(fs, parquet_bind.file_name, FileSystem::GetFileOpener(context),
+	                               parquet_bind.sql_types, parquet_bind.column_names, parquet_bind.codec);
 	return move(global_state);
 }
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -281,10 +281,11 @@ ParquetReader::ParquetReader(Allocator &allocator_p, unique_ptr<FileHandle> file
 
 ParquetReader::ParquetReader(ClientContext &context_p, string file_name_p, const vector<LogicalType> &expected_types_p,
                              const string &initial_filename_p)
-    : allocator(Allocator::Get(context_p)) {
+    : allocator(Allocator::Get(context_p)), file_opener(FileSystem::GetFileOpener(context_p)) {
 	auto &fs = FileSystem::GetFileSystem(context_p);
 	file_name = move(file_name_p);
-	file_handle = fs.OpenFile(file_name, FileFlags::FILE_FLAGS_READ);
+	file_handle = fs.OpenFile(file_name, FileFlags::FILE_FLAGS_READ, FileSystem::DEFAULT_LOCK,
+	                          FileSystem::DEFAULT_COMPRESSION, file_opener);
 	// If object cached is disabled
 	// or if this file has cached metadata
 	// or if the cached version already expired
@@ -387,7 +388,9 @@ void ParquetReader::InitializeScan(ParquetReaderScanState &state, vector<column_
 	state.group_idx_list = move(groups_to_read);
 	state.filters = filters;
 	state.sel.Initialize(STANDARD_VECTOR_SIZE);
-	state.file_handle = file_handle->file_system.OpenFile(file_handle->path, FileFlags::FILE_FLAGS_READ);
+	state.file_handle =
+	    file_handle->file_system.OpenFile(file_handle->path, FileFlags::FILE_FLAGS_READ, FileSystem::DEFAULT_LOCK,
+	                                      FileSystem::DEFAULT_COMPRESSION, file_opener);
 	state.thrift_file_proto = CreateThriftProtocol(allocator, *state.file_handle);
 	state.root_reader = CreateReader(*this, GetFileMetadata());
 

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -132,16 +132,16 @@ static void TemplatedWritePlain(Vector &col, idx_t length, ValidityMask &mask, S
 	}
 }
 
-ParquetWriter::ParquetWriter(FileSystem &fs, string file_name_p, vector<LogicalType> types_p, vector<string> names_p,
-                             CompressionCodec::type codec)
+ParquetWriter::ParquetWriter(FileSystem &fs, string file_name_p, FileOpener *file_opener_p, vector<LogicalType> types_p,
+                             vector<string> names_p, CompressionCodec::type codec)
     : file_name(move(file_name_p)), sql_types(move(types_p)), column_names(move(names_p)), codec(codec) {
 #if STANDARD_VECTOR_SIZE < 64
 	throw NotImplementedException("Parquet writer is not supported for vector sizes < 64");
 #endif
 
 	// initialize the file writer
-	writer = make_unique<BufferedFileWriter>(fs, file_name.c_str(),
-	                                         FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	writer = make_unique<BufferedFileWriter>(
+	    fs, file_name.c_str(), FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW, file_opener_p);
 	// parquet files start with the string "PAR1"
 	writer->WriteData((const_data_ptr_t) "PAR1", 4);
 	TCompactProtocolFactoryT<MyTransport> tproto_factory;

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -36,6 +36,10 @@ FileSystem &FileSystem::GetFileSystem(ClientContext &context) {
 	return *context.db->config.file_system;
 }
 
+FileOpener *FileSystem::GetFileOpener(ClientContext &context) {
+	return context.file_opener.get();
+}
+
 #ifndef _WIN32
 string FileSystem::PathSeparator() {
 	return "/";

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -137,7 +137,7 @@ string FileSystem::GetHomeDirectory() {
 
 // LCOV_EXCL_START
 unique_ptr<FileHandle> FileSystem::OpenFile(const string &path, uint8_t flags, FileLockType lock,
-                                            FileCompressionType compression) {
+                                            FileCompressionType compression, FileOpener *opener) {
 	throw NotImplementedException("%s: OpenFile is not implemented!", GetName());
 }
 

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -74,7 +74,7 @@ public:
 };
 
 unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path, uint8_t flags, FileLockType lock_type,
-                                                 FileCompressionType compression) {
+                                                 FileCompressionType compression, FileOpener *opener) {
 	if (compression != FileCompressionType::UNCOMPRESSED) {
 		throw NotImplementedException("Unsupported compression type for default file system");
 	}
@@ -432,7 +432,7 @@ public:
 };
 
 unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path, uint8_t flags, FileLockType lock_type,
-                                                 FileCompressionType compression) {
+                                                 FileCompressionType compression, FileOpener *opener) {
 	if (compression != FileCompressionType::UNCOMPRESSED) {
 		throw NotImplementedException("Unsupported compression type for default file system");
 	}

--- a/src/common/serializer/buffered_file_reader.cpp
+++ b/src/common/serializer/buffered_file_reader.cpp
@@ -7,9 +7,10 @@
 
 namespace duckdb {
 
-BufferedFileReader::BufferedFileReader(FileSystem &fs, const char *path)
+BufferedFileReader::BufferedFileReader(FileSystem &fs, const char *path, FileOpener *opener)
     : fs(fs), data(unique_ptr<data_t[]>(new data_t[FILE_BUFFER_SIZE])), offset(0), read_data(0), total_read(0) {
-	handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ, FileLockType::READ_LOCK);
+	handle =
+	    fs.OpenFile(path, FileFlags::FILE_FLAGS_READ, FileLockType::READ_LOCK, FileSystem::DEFAULT_COMPRESSION, opener);
 	file_size = fs.GetFileSize(*handle);
 }
 

--- a/src/common/serializer/buffered_file_writer.cpp
+++ b/src/common/serializer/buffered_file_writer.cpp
@@ -5,9 +5,12 @@
 
 namespace duckdb {
 
-BufferedFileWriter::BufferedFileWriter(FileSystem &fs, const string &path, uint8_t open_flags)
+// Remove this when we switch C++17: https://stackoverflow.com/a/53350948
+constexpr uint8_t BufferedFileWriter::DEFAULT_OPEN_FLAGS;
+
+BufferedFileWriter::BufferedFileWriter(FileSystem &fs, const string &path, uint8_t open_flags, FileOpener *opener)
     : fs(fs), data(unique_ptr<data_t[]>(new data_t[FILE_BUFFER_SIZE])), offset(0), total_written(0) {
-	handle = fs.OpenFile(path, open_flags, FileLockType::WRITE_LOCK);
+	handle = fs.OpenFile(path, open_flags, FileLockType::WRITE_LOCK, FileSystem::DEFAULT_COMPRESSION, opener);
 }
 
 int64_t BufferedFileWriter::GetFileSize() {

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -10,7 +10,7 @@ VirtualFileSystem::VirtualFileSystem() : default_fs(FileSystem::CreateLocal()) {
 }
 
 unique_ptr<FileHandle> VirtualFileSystem::OpenFile(const string &path, uint8_t flags, FileLockType lock,
-                                                   FileCompressionType compression) {
+                                                   FileCompressionType compression, FileOpener *opener) {
 	if (compression == FileCompressionType::AUTO_DETECT) {
 		// auto detect compression settings based on file name
 		auto lower_path = StringUtil::Lower(path);
@@ -21,7 +21,7 @@ unique_ptr<FileHandle> VirtualFileSystem::OpenFile(const string &path, uint8_t f
 		}
 	}
 	// open the base file handle
-	auto file_handle = FindFileSystem(path)->OpenFile(path, flags, lock, FileCompressionType::UNCOMPRESSED);
+	auto file_handle = FindFileSystem(path)->OpenFile(path, flags, lock, FileCompressionType::UNCOMPRESSED, opener);
 	if (file_handle->GetType() == FileType::FILE_TYPE_FIFO) {
 		file_handle = PipeFileSystem::OpenPipe(move(file_handle));
 	} else if (compression != FileCompressionType::UNCOMPRESSED) {

--- a/src/function/pragma/pragma_functions.cpp
+++ b/src/function/pragma/pragma_functions.cpp
@@ -193,7 +193,9 @@ static void PragmaLogQueryPath(ClientContext &context, const FunctionParameters 
 		// empty path: clean up query writer
 		context.log_query_writer = nullptr;
 	} else {
-		context.log_query_writer = make_unique<BufferedFileWriter>(FileSystem::GetFileSystem(context), str_val);
+		context.log_query_writer =
+		    make_unique<BufferedFileWriter>(FileSystem::GetFileSystem(context), str_val,
+		                                    BufferedFileWriter::DEFAULT_OPEN_FLAGS, context.file_opener.get());
 	}
 }
 

--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -43,12 +43,15 @@ string PragmaVersion(ClientContext &context, const FunctionParameters &parameter
 
 string PragmaImportDatabase(ClientContext &context, const FunctionParameters &parameters) {
 	auto &fs = FileSystem::GetFileSystem(context);
+	auto *opener = FileSystem::GetFileOpener(context);
+
 	string query;
 	// read the "shema.sql" and "load.sql" files
 	vector<string> files = {"schema.sql", "load.sql"};
 	for (auto &file : files) {
 		auto file_path = fs.JoinPath(parameters.values[0].ToString(), file);
-		auto handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ);
+		auto handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ, FileSystem::DEFAULT_LOCK,
+		                          FileSystem::DEFAULT_COMPRESSION, opener);
 		auto fsize = fs.GetFileSize(*handle);
 		auto buffer = unique_ptr<char[]>(new char[fsize]);
 		fs.Read(*handle, buffer.get(), fsize);

--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -403,9 +403,9 @@ struct LocalReadCSVData : public LocalFunctionData {
 };
 
 struct GlobalWriteCSVData : public GlobalFunctionData {
-	GlobalWriteCSVData(FileSystem &fs, const string &file_path) : fs(fs) {
+	GlobalWriteCSVData(FileSystem &fs, const string &file_path, FileOpener *opener) : fs(fs) {
 		handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW,
-		                     FileLockType::WRITE_LOCK);
+		                     FileLockType::WRITE_LOCK, FileSystem::DEFAULT_COMPRESSION, opener);
 	}
 
 	void WriteData(const_data_ptr_t data, idx_t size) {
@@ -435,7 +435,8 @@ static unique_ptr<LocalFunctionData> WriteCSVInitializeLocal(ClientContext &cont
 static unique_ptr<GlobalFunctionData> WriteCSVInitializeGlobal(ClientContext &context, FunctionData &bind_data) {
 	auto &csv_data = (WriteCSVData &)bind_data;
 	auto &options = csv_data.options;
-	auto global_data = make_unique<GlobalWriteCSVData>(FileSystem::GetFileSystem(context), csv_data.files[0]);
+	auto global_data = make_unique<GlobalWriteCSVData>(FileSystem::GetFileSystem(context), csv_data.files[0],
+	                                                   FileSystem::GetFileOpener(context));
 
 	if (options.header) {
 		BufferedSerializer serializer;

--- a/src/include/duckdb/common/file_opener.hpp
+++ b/src/include/duckdb/common/file_opener.hpp
@@ -8,12 +8,18 @@
 
 #pragma once
 
+#include "duckdb/common/string.hpp"
+
 namespace duckdb {
+
+class Value;
 
 //! Abstact type that provide client-spcific context to FileSystem.
 class FileOpener {
 public:
 	virtual ~FileOpener() {};
+
+	virtual bool TryGetCurrentSetting(const string &key, Value &result) = 0;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/file_opener.hpp
+++ b/src/include/duckdb/common/file_opener.hpp
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/file_opener.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+namespace duckdb {
+
+//! Abstact type that provide client-spcific context to FileSystem.
+class FileOpener {
+public:
+	virtual ~FileOpener() {};
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -106,6 +106,7 @@ public:
 	static constexpr FileCompressionType DEFAULT_COMPRESSION = FileCompressionType::UNCOMPRESSED;
 	static FileSystem &GetFileSystem(ClientContext &context);
 	static FileSystem &GetFileSystem(DatabaseInstance &db);
+	static FileOpener *GetFileOpener(ClientContext &context);
 
 	virtual unique_ptr<FileHandle> OpenFile(const string &path, uint8_t flags, FileLockType lock = DEFAULT_LOCK,
 	                                        FileCompressionType compression = DEFAULT_COMPRESSION,

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -24,6 +24,7 @@
 namespace duckdb {
 class ClientContext;
 class DatabaseInstance;
+class FileOpener;
 class FileSystem;
 
 enum class FileType {
@@ -101,12 +102,14 @@ public:
 	}
 
 public:
+	static constexpr FileLockType DEFAULT_LOCK = FileLockType::NO_LOCK;
+	static constexpr FileCompressionType DEFAULT_COMPRESSION = FileCompressionType::UNCOMPRESSED;
 	static FileSystem &GetFileSystem(ClientContext &context);
 	static FileSystem &GetFileSystem(DatabaseInstance &db);
 
-	virtual unique_ptr<FileHandle> OpenFile(const string &path, uint8_t flags,
-	                                        FileLockType lock = FileLockType::NO_LOCK,
-	                                        FileCompressionType compression = FileCompressionType::UNCOMPRESSED);
+	virtual unique_ptr<FileHandle> OpenFile(const string &path, uint8_t flags, FileLockType lock = DEFAULT_LOCK,
+	                                        FileCompressionType compression = DEFAULT_COMPRESSION,
+	                                        FileOpener *opener = nullptr);
 
 	//! Read exactly nr_bytes from the specified location in the file. Fails if nr_bytes could not be read. This is
 	//! equivalent to calling SetFilePointer(location) followed by calling Read().

--- a/src/include/duckdb/common/local_file_system.hpp
+++ b/src/include/duckdb/common/local_file_system.hpp
@@ -15,7 +15,8 @@ namespace duckdb {
 class LocalFileSystem : public FileSystem {
 public:
 	unique_ptr<FileHandle> OpenFile(const string &path, uint8_t flags, FileLockType lock = FileLockType::NO_LOCK,
-	                                FileCompressionType compression = FileCompressionType::UNCOMPRESSED) override;
+	                                FileCompressionType compression = FileCompressionType::UNCOMPRESSED,
+	                                FileOpener *opener = nullptr) override;
 
 	//! Read exactly nr_bytes from the specified location in the file. Fails if nr_bytes could not be read. This is
 	//! equivalent to calling SetFilePointer(location) followed by calling Read().

--- a/src/include/duckdb/common/serializer/buffered_file_reader.hpp
+++ b/src/include/duckdb/common/serializer/buffered_file_reader.hpp
@@ -14,7 +14,7 @@ namespace duckdb {
 
 class BufferedFileReader : public Deserializer {
 public:
-	BufferedFileReader(FileSystem &fs, const char *path);
+	BufferedFileReader(FileSystem &fs, const char *path, FileOpener *opener = nullptr);
 
 	FileSystem &fs;
 	unique_ptr<data_t[]> data;

--- a/src/include/duckdb/common/serializer/buffered_file_writer.hpp
+++ b/src/include/duckdb/common/serializer/buffered_file_writer.hpp
@@ -17,10 +17,12 @@ namespace duckdb {
 
 class BufferedFileWriter : public Serializer {
 public:
+	static constexpr uint8_t DEFAULT_OPEN_FLAGS = FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE;
+
 	//! Serializes to a buffer allocated by the serializer, will expand when
 	//! writing past the initial threshold
-	BufferedFileWriter(FileSystem &fs, const string &path,
-	                   uint8_t open_flags = FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE);
+	BufferedFileWriter(FileSystem &fs, const string &path, uint8_t open_flags = DEFAULT_OPEN_FLAGS,
+	                   FileOpener *opener = nullptr);
 
 	FileSystem &fs;
 	unique_ptr<data_t[]> data;

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -18,7 +18,8 @@ public:
 	VirtualFileSystem();
 
 	unique_ptr<FileHandle> OpenFile(const string &path, uint8_t flags, FileLockType lock = FileLockType::NO_LOCK,
-	                                FileCompressionType compression = FileCompressionType::UNCOMPRESSED) override;
+	                                FileCompressionType compression = FileCompressionType::UNCOMPRESSED,
+	                                FileOpener *opener = nullptr) override;
 
 	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {
 		handle.file_system.Read(handle, buffer, nr_bytes, location);

--- a/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
@@ -23,6 +23,7 @@ struct CopyInfo;
 struct FileHandle;
 struct StrpTimeFormat;
 
+class FileOpener;
 class FileSystem;
 
 //! The shifts array allows for linear searching of multi-byte values. For each position, it determines the next
@@ -123,10 +124,11 @@ public:
 	BufferedCSVReader(ClientContext &context, BufferedCSVReaderOptions options,
 	                  const vector<LogicalType> &requested_types = vector<LogicalType>());
 
-	BufferedCSVReader(FileSystem &fs, BufferedCSVReaderOptions options,
+	BufferedCSVReader(FileSystem &fs, FileOpener *opener, BufferedCSVReaderOptions options,
 	                  const vector<LogicalType> &requested_types = vector<LogicalType>());
 
 	FileSystem &fs;
+	FileOpener *opener;
 	BufferedCSVReaderOptions options;
 	vector<LogicalType> sql_types;
 	vector<string> col_names;

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -29,6 +29,7 @@ class Appender;
 class Catalog;
 class ChunkCollection;
 class DatabaseInstance;
+class FileOpener;
 class LogicalOperator;
 class PreparedStatementData;
 class Relation;
@@ -99,6 +100,8 @@ public:
 
 	//! The schema search path, in order by which entries are searched if no schema entry is provided
 	vector<string> catalog_search_path = {TEMP_SCHEMA, DEFAULT_SCHEMA, "pg_catalog"};
+
+	unique_ptr<FileOpener> file_opener;
 
 public:
 	DUCKDB_API Transaction &ActiveTransaction() {

--- a/src/include/duckdb/main/client_context_file_opener.hpp
+++ b/src/include/duckdb/main/client_context_file_opener.hpp
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/main/client_context_file_opener.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/file_opener.hpp"
+
+namespace duckdb {
+
+class ClientContext;
+
+//! ClientContext-specific FileOpener implemenation.
+//! This object is owned by ClientContext and never outlives it.
+class ClientContextFileOpener : public FileOpener {
+public:
+	explicit ClientContextFileOpener(ClientContext &context_p) : context(context_p) {
+	}
+
+	bool TryGetCurrentSetting(const string &key, Value &result) override;
+
+private:
+	ClientContext &context;
+};
+
+} // namespace duckdb

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library_unity(
   duckdb_main
   OBJECT
   appender.cpp
+  client_context_file_opener.cpp
   client_context.cpp
   config.cpp
   connection.cpp

--- a/src/main/client_context_file_opener.cpp
+++ b/src/main/client_context_file_opener.cpp
@@ -1,0 +1,11 @@
+#include "duckdb/main/client_context_file_opener.hpp"
+
+#include "duckdb/main/client_context.hpp"
+
+namespace duckdb {
+
+bool ClientContextFileOpener::TryGetCurrentSetting(const string &key, Value &result) {
+	return context.TryGetCurrentSetting(key, result);
+}
+
+} // namespace duckdb

--- a/test/sql/storage/test_readonly.cpp
+++ b/test/sql/storage/test_readonly.cpp
@@ -8,11 +8,11 @@ namespace duckdb {
 
 class ReadOnlyFileSystem : public LocalFileSystem {
 	unique_ptr<FileHandle> OpenFile(const string &path, uint8_t flags, FileLockType lock_type,
-	                                FileCompressionType compression) override {
+	                                FileCompressionType compression, FileOpener *opener) override {
 		if (flags & FileFlags::FILE_FLAGS_WRITE) {
 			throw Exception("RO file system");
 		}
-		return LocalFileSystem::OpenFile(path, flags, lock_type, compression);
+		return LocalFileSystem::OpenFile(path, flags, lock_type, compression, opener);
 	}
 
 	std::string GetName() const override {


### PR DESCRIPTION
This is a follow up for #2247.

With this change, S3FS reads the credentials from ClientContext instead of Database.
Once this is in, we can change SET's default scope to SESSION from GLOBAL.
