### PR TITLE
Fix #2313: No Out of Range Error in Index Benchmark

### DIFF
--- a/benchmark/micro/index/point_query_with_index.benchmark
+++ b/benchmark/micro/index/point_query_with_index.benchmark
@@ -6,7 +6,7 @@ name Point Query (Index)
 group index
 
 load
-CREATE TABLE integers AS SELECT (i * 9876983769044 % 100000000) AS i, i + 2 AS j FROM range(0, 100000000) t(i);
+CREATE TABLE integers AS SELECT (i * 9876983769044::INT128 % 100000000)::INT64 AS i, i + 2 AS j FROM range(0, 100000000) t(i);
 CREATE INDEX i_index ON integers using art(i);
 
 run

--- a/benchmark/micro/index/point_query_without_index.benchmark
+++ b/benchmark/micro/index/point_query_without_index.benchmark
@@ -6,7 +6,7 @@ name Point Query (No Index, Random Data)
 group index
 
 load
-CREATE TABLE integers AS SELECT (i * 9876983769044 % 100000000) AS i, i + 2 AS j FROM range(0, 100000000) t(i);
+CREATE TABLE integers AS SELECT (i * 9876983769044::INT128 % 100000000)::INT64 AS i, i + 2 AS j FROM range(0, 100000000) t(i);
 
 run
 SELECT i FROM integers WHERE i=50000 LIMIT 1


### PR DESCRIPTION
simple fix: cast to int128 to avoid Out of Range Error.

Issue #2313 #2310 are similar.
This PR is similar to PR #2311, which fixed Issue #2310.

Signed-off-by: Jigao Luo <luojigao@outlook.com>