### PR TITLE
Fix for #2304

### DIFF
--- a/tools/pythonpkg/src/pyresult.cpp
+++ b/tools/pythonpkg/src/pyresult.cpp
@@ -223,6 +223,10 @@ py::dict DuckDBPyResult::FetchNumpyInternal(bool stream, idx_t vectors_per_chunk
 			res[result->names[col_idx].c_str()] = conversion.ToArray(col_idx);
 		} else {
 			auto name = result->names[col_idx] + "_" + to_string(names[result->names[col_idx]]);
+			while (names[name] > 0) {
+				// This entry already exists
+				name += "_" + to_string(names[name]);
+			}
 			names[name]++;
 			res[name.c_str()] = conversion.ToArray(col_idx);
 		}

--- a/tools/pythonpkg/src/pyresult.cpp
+++ b/tools/pythonpkg/src/pyresult.cpp
@@ -222,8 +222,9 @@ py::dict DuckDBPyResult::FetchNumpyInternal(bool stream, idx_t vectors_per_chunk
 		if (names[result->names[col_idx]]++ == 0) {
 			res[result->names[col_idx].c_str()] = conversion.ToArray(col_idx);
 		} else {
-			res[(result->names[col_idx] + "_" + to_string(names[result->names[col_idx]])).c_str()] =
-			    conversion.ToArray(col_idx);
+			auto name = result->names[col_idx] + "_" + to_string(names[result->names[col_idx]]);
+			names[name]++;
+			res[name.c_str()] = conversion.ToArray(col_idx);
 		}
 	}
 	return res;

--- a/tools/pythonpkg/src/pyresult.cpp
+++ b/tools/pythonpkg/src/pyresult.cpp
@@ -217,8 +217,14 @@ py::dict DuckDBPyResult::FetchNumpyInternal(bool stream, idx_t vectors_per_chunk
 
 	// now that we have materialized the result in contiguous arrays, construct the actual NumPy arrays
 	py::dict res;
+	unordered_map<string, idx_t> names;
 	for (idx_t col_idx = 0; col_idx < result->types.size(); col_idx++) {
-		res[result->names[col_idx].c_str()] = conversion.ToArray(col_idx);
+		if (names[result->names[col_idx]]++ == 0) {
+			res[result->names[col_idx].c_str()] = conversion.ToArray(col_idx);
+		} else {
+			res[(result->names[col_idx] + "_" + to_string(names[result->names[col_idx]])).c_str()] =
+			    conversion.ToArray(col_idx);
+		}
 	}
 	return res;
 }

--- a/tools/pythonpkg/tests/pandas/test_2304.py
+++ b/tools/pythonpkg/tests/pandas/test_2304.py
@@ -22,12 +22,12 @@ class TestPandasMergeSameName(object):
         con.register('df2', df2)
         query = """SELECT * from df1
         LEFT  OUTER JOIN df2
-        ON (df1.id_1=df2.id_1 and df1.agedate=df2.agedate)  order by df1.id_1, df1.agedate"""
+        ON (df1.id_1=df2.id_1 and df1.agedate=df2.agedate)  order by df1.id_1, df1.agedate, df1.age, df1.v, df2.id_1,df2.agedate,df2.v2"""
 
         result_df = con.execute(query).fetchdf()
         expected_result = con.execute(query).fetchall()
         con.register('result_df', result_df)
-        result = con.execute('select * from result_df').fetchall()
+        result = con.execute('select * from result_df order by id_1, agedate, age, v, id_1_2, agedate_2,v2').fetchall()
 
         assert result == expected_result
 
@@ -49,8 +49,9 @@ class TestPandasMergeSameName(object):
             'id': [1, 1, 2, 1, 1],
             'id_1': [1, 1, 2, 1, 1],
             'id_3': [1, 1, 2, 1, 1],
-            'id_2': [1, 1, 1, 1, 1],
-            'id_1_2': [1, 1, 2, 1, 1]
+            'id_2': [1, 1, 2, 1, 1],
+            'id_1_2': [1, 1, 2, 1, 1],
+            'id_2_2': [1, 1, 1, 1, 1]
         })
 
         con = duckdb.connect()

--- a/tools/pythonpkg/tests/pandas/test_2304.py
+++ b/tools/pythonpkg/tests/pandas/test_2304.py
@@ -1,9 +1,12 @@
 import duckdb
 import pandas as pd
 import numpy as np
+import sys 
 
 class TestPandasMergeSameName(object):
     def test_2304(self, duckdb_cursor):
+        if sys.version_info.major < 3:
+            return
         df1 = pd.DataFrame({
             'id_1': [1, 1, 1, 2, 2],
             'agedate': np.array(['2010-01-01','2010-02-01','2010-03-01','2020-02-01', '2020-03-01']).astype('datetime64[D]'),
@@ -32,6 +35,8 @@ class TestPandasMergeSameName(object):
         assert result == expected_result
 
     def test_pd_names(self, duckdb_cursor):
+        if sys.version_info.major < 3:
+            return
 
         df1 = pd.DataFrame({
             'id': [1, 1, 2],

--- a/tools/pythonpkg/tests/pandas/test_2304.py
+++ b/tools/pythonpkg/tests/pandas/test_2304.py
@@ -63,3 +63,33 @@ class TestPandasMergeSameName(object):
 
         result_df = con.execute(query).fetchdf()
         assert(exp_result.equals(result_df))
+
+    def test_repeat_name(self, duckdb_cursor):
+
+        df1 = pd.DataFrame({
+            'id': [1],
+            'id_1': [1],
+            'id_2': [1],
+        })
+
+        df2 = pd.DataFrame({
+            'id': [1]
+        })
+
+        exp_result = pd.DataFrame({
+            'id': [1],
+            'id_1': [1],
+            'id_2': [1],
+            'id_2_1': [1],
+        })
+
+        con = duckdb.connect()
+        con.register('df1', df1)
+        con.register('df2', df2)
+        query = """SELECT * from df1
+        LEFT OUTER JOIN df2
+        ON (df1.id=df2.id)"""
+
+        result_df = con.execute(query).fetchdf()
+        print(result_df)
+        assert(exp_result.equals(result_df))

--- a/tools/pythonpkg/tests/pandas/test_2304.py
+++ b/tools/pythonpkg/tests/pandas/test_2304.py
@@ -1,0 +1,64 @@
+import duckdb
+import pandas as pd
+import numpy as np
+
+class TestPandasMergeSameName(object):
+    def test_2304(self, duckdb_cursor):
+        df1 = pd.DataFrame({
+            'id_1': [1, 1, 1, 2, 2],
+            'agedate': np.array(['2010-01-01','2010-02-01','2010-03-01','2020-02-01', '2020-03-01']).astype('datetime64[D]'),
+            'age': [1, 2, 3, 1, 2],
+            'v': [1.1, 1.2, 1.3, 2.1, 2.2]
+        })
+
+        df2 = pd.DataFrame({
+            'id_1': [1, 1, 2],
+            'agedate': np.array(['2010-01-01','2010-02-01', '2020-03-01']).astype('datetime64[D]'),
+            'v2': [11.1, 11.2, 21.2]
+        })
+
+        con = duckdb.connect()
+        con.register('df1', df1)
+        con.register('df2', df2)
+        query = """SELECT * from df1
+        LEFT  OUTER JOIN df2
+        ON (df1.id_1=df2.id_1 and df1.agedate=df2.agedate)  order by df1.id_1, df1.agedate"""
+
+        result_df = con.execute(query).fetchdf()
+        expected_result = con.execute(query).fetchall()
+        con.register('result_df', result_df)
+        result = con.execute('select * from result_df').fetchall()
+
+        assert result == expected_result
+
+    def test_pd_names(self, duckdb_cursor):
+
+        df1 = pd.DataFrame({
+            'id': [1, 1, 2],
+            'id_1': [1, 1, 2],
+            'id_3': [1, 1, 2],
+        })
+
+        df2 = pd.DataFrame({
+            'id': [1, 1, 2],
+            'id_1': [1, 1, 2],
+            'id_2': [1, 1, 1]
+        })
+
+        exp_result = pd.DataFrame({
+            'id': [1, 1, 2, 1, 1],
+            'id_1': [1, 1, 2, 1, 1],
+            'id_3': [1, 1, 2, 1, 1],
+            'id_2': [1, 1, 1, 1, 1],
+            'id_1_2': [1, 1, 2, 1, 1]
+        })
+
+        con = duckdb.connect()
+        con.register('df1', df1)
+        con.register('df2', df2)
+        query = """SELECT * from df1
+        LEFT OUTER JOIN df2
+        ON (df1.id_1=df2.id_1)"""
+
+        result_df = con.execute(query).fetchdf()
+        assert(exp_result.equals(result_df))


### PR DESCRIPTION
Adding a suffix to columns when multiple columns from the query result have the same name and are being fetched to a pandas df.