### PR TITLE
Support SET SCHEMA and SET SEARCH_PATH

### DIFF
--- a/src/catalog/CMakeLists.txt
+++ b/src/catalog/CMakeLists.txt
@@ -1,8 +1,14 @@
 add_subdirectory(catalog_entry)
 add_subdirectory(default)
 
-add_library_unity(duckdb_catalog OBJECT catalog_entry.cpp catalog.cpp
-                  catalog_set.cpp dependency_manager.cpp)
+add_library_unity(
+  duckdb_catalog
+  OBJECT
+  catalog_entry.cpp
+  catalog.cpp
+  catalog_search_path.cpp
+  catalog_set.cpp
+  dependency_manager.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_catalog>
     PARENT_SCOPE)

--- a/src/catalog/catalog_entry/schema_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/schema_catalog_entry.cpp
@@ -181,26 +181,6 @@ void SchemaCatalogEntry::Alter(ClientContext &context, AlterInfo *info) {
 	}
 }
 
-CatalogEntry *SchemaCatalogEntry::GetEntry(ClientContext &context, CatalogType type, const string &entry_name,
-                                           bool if_exists, QueryErrorContext error_context) {
-	auto &set = GetCatalogSet(type);
-
-	auto entry = set.GetEntry(context, entry_name);
-	if (!entry) {
-		if (!if_exists) {
-			auto entry = set.SimilarEntry(context, entry_name);
-			string did_you_mean;
-			if (!entry.empty()) {
-				did_you_mean = "\nDid you mean \"" + entry + "\"?";
-			}
-			throw CatalogException(error_context.FormatError("%s with name %s does not exist!%s",
-			                                                 CatalogTypeToString(type), entry_name, did_you_mean));
-		}
-		return nullptr;
-	}
-	return entry;
-}
-
 void SchemaCatalogEntry::Scan(ClientContext &context, CatalogType type,
                               const std::function<void(CatalogEntry *)> &callback) {
 	auto &set = GetCatalogSet(type);

--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -21,6 +21,13 @@ const vector<string> &CatalogSearchPath::Get() {
 	return paths;
 }
 
+const string &CatalogSearchPath::GetDefault() {
+	const auto &paths = Get();
+	D_ASSERT(paths.size() >= 2);
+	D_ASSERT(paths[0] == TEMP_SCHEMA);
+	return paths[1];
+}
+
 vector<string> CatalogSearchPath::ParsePaths(const string &value) {
 	vector<string> paths;
 	paths.emplace_back(TEMP_SCHEMA);

--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -1,0 +1,38 @@
+#include "duckdb/catalog/catalog_search_path.hpp"
+
+#include "duckdb/common/constants.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/main/client_context.hpp"
+
+namespace duckdb {
+
+CatalogSearchPath::CatalogSearchPath(ClientContext &context_p) : context(context_p), paths(ParsePaths("")) {
+}
+
+const vector<string> &CatalogSearchPath::Get() {
+	Value value;
+	context.TryGetCurrentSetting("search_path", value);
+	if (value.str_value != last_value) {
+		paths = ParsePaths(value.str_value);
+		last_value = value.str_value;
+	}
+
+	return paths;
+}
+
+vector<string> CatalogSearchPath::ParsePaths(const string &value) {
+	vector<string> paths;
+	paths.emplace_back(TEMP_SCHEMA);
+
+	auto given_paths = StringUtil::SplitWithQuote(value);
+	for (const auto &p : given_paths) {
+		paths.emplace_back(StringUtil::Lower(p));
+	}
+
+	paths.emplace_back(DEFAULT_SCHEMA);
+	paths.emplace_back("pg_catalog");
+	return paths;
+}
+
+} // namespace duckdb

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -307,7 +307,7 @@ CatalogEntry *CatalogSet::GetCommittedEntry(CatalogEntry *current) {
 	return current;
 }
 
-string CatalogSet::SimilarEntry(ClientContext &context, const string &name) {
+pair<string, idx_t> CatalogSet::SimilarEntry(ClientContext &context, const string &name) {
 	lock_guard<mutex> lock(catalog_lock);
 
 	string result;
@@ -322,7 +322,7 @@ string CatalogSet::SimilarEntry(ClientContext &context, const string &name) {
 			}
 		}
 	}
-	return result;
+	return {result, current_score};
 }
 
 CatalogEntry *CatalogSet::CreateEntryInternal(ClientContext &context, unique_ptr<CatalogEntry> entry) {

--- a/src/execution/operator/helper/physical_set.cpp
+++ b/src/execution/operator/helper/physical_set.cpp
@@ -31,12 +31,10 @@ string PhysicalSet::ValidateInput(ExecutionContext &context) const {
 			throw CatalogException("SET schema can set only 1 schema. This has %d", paths.size());
 		}
 
-		try {
-			for (const auto &path : paths) {
-				context.client.db->GetCatalog().GetSchema(context.client, StringUtil::Lower(path));
+		for (const auto &path : paths) {
+			if (!context.client.db->GetCatalog().GetSchema(context.client, StringUtil::Lower(path), true)) {
+				throw CatalogException("SET %s: No schema named %s found.", name, path);
 			}
-		} catch (const CatalogException &e) {
-			throw CatalogException("SET error: %s", e.what());
 		}
 
 		return "search_path";

--- a/src/execution/operator/helper/physical_set.cpp
+++ b/src/execution/operator/helper/physical_set.cpp
@@ -1,4 +1,6 @@
 #include "duckdb/execution/operator/helper/physical_set.hpp"
+
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/client_context.hpp"
 
@@ -7,13 +9,40 @@ namespace duckdb {
 void PhysicalSet::GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state) const {
 	D_ASSERT(scope == SetScope::GLOBAL || scope == SetScope::SESSION);
 
+	auto normalized_name = ValidateInput(context);
 	if (scope == SetScope::GLOBAL) {
-		context.client.db->config.set_variables[name] = value;
+		context.client.db->config.set_variables[normalized_name] = value;
 	} else {
-		context.client.set_variables[name] = value;
+		context.client.set_variables[normalized_name] = value;
 	}
 
 	state->finished = true;
+}
+
+string PhysicalSet::ValidateInput(ExecutionContext &context) const {
+	CaseInsensitiveStringEquality case_insensitive_streq;
+	if (case_insensitive_streq(name, "search_path") || case_insensitive_streq(name, "schema")) {
+		auto paths = StringUtil::SplitWithQuote(value.str_value, ',');
+
+		// The PG doc says:
+		// >  SET SCHEMA 'value' is an alias for SET search_path TO value.
+		// >  Only one schema can be specified using this syntax.
+		if (case_insensitive_streq(name, "schema") && paths.size() > 1) {
+			throw CatalogException("SET schema can set only 1 schema. This has %d", paths.size());
+		}
+
+		try {
+			for (const auto &path : paths) {
+				context.client.db->GetCatalog().GetSchema(context.client, StringUtil::Lower(path));
+			}
+		} catch (const CatalogException &e) {
+			throw CatalogException("SET error: %s", e.what());
+		}
+
+		return "search_path";
+	}
+
+	return name;
 }
 
 } // namespace duckdb

--- a/src/function/scalar/generic/current_setting.cpp
+++ b/src/function/scalar/generic/current_setting.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/function/scalar/generic_functions.hpp"
+
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -54,6 +54,22 @@ struct CatalogEntryLookup {
 	}
 };
 
+//! Return value of SimilarEntryInSchemas
+struct SimilarCatalogEntry {
+	//! The entry name. Empty if absent
+	string name;
+	//! The distance to the given name.
+	idx_t distance;
+	//! The schema of the entry.
+	SchemaCatalogEntry *schema;
+
+	bool Found() const {
+		return !name.empty();
+	}
+
+	string GetQualifiedName() const;
+};
+
 //! The Catalog object represents the catalog of the database.
 class Catalog {
 public:
@@ -149,6 +165,15 @@ private:
 	//! A variation of GetEntry that returns an associated schema as well.
 	CatalogEntryLookup LookupEntry(ClientContext &context, CatalogType type, const string &schema, const string &name,
 	                               bool if_exists = false, QueryErrorContext error_context = QueryErrorContext());
+
+	//! Return an exception with did-you-mean suggestion.
+	CatalogException CreateMissingEntryException(ClientContext &context, const string &entry_name, CatalogType type,
+	                                             const vector<SchemaCatalogEntry *> &schemas,
+	                                             QueryErrorContext error_context);
+
+	//! Return the close entry name, the distance and the belonging schema.
+	SimilarCatalogEntry SimilarEntryInSchemas(ClientContext &context, const string &entry_name, CatalogType type,
+	                                          const vector<SchemaCatalogEntry *> &schemas);
 
 	void DropSchema(ClientContext &context, DropInfo *info);
 };

--- a/src/include/duckdb/catalog/catalog_entry/schema_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/schema_catalog_entry.hpp
@@ -64,10 +64,6 @@ private:
 	CatalogSet collations;
 
 public:
-	//! Gets a catalog entry from the given catalog set matching the given name
-	CatalogEntry *GetEntry(ClientContext &context, CatalogType type, const string &name, bool if_exists,
-	                       QueryErrorContext error_context = QueryErrorContext());
-
 	//! Scan the specified catalog set, invoking the callback method for every entry
 	void Scan(ClientContext &context, CatalogType type, const std::function<void(CatalogEntry *)> &callback);
 	//! Scan the specified catalog set, invoking the callback method for every committed entry

--- a/src/include/duckdb/catalog/catalog_search_path.hpp
+++ b/src/include/duckdb/catalog/catalog_search_path.hpp
@@ -25,6 +25,7 @@ public:
 	CatalogSearchPath(const CatalogSearchPath &other) = delete;
 
 	const vector<string> &Get();
+	const string &GetDefault();
 
 private:
 	static vector<string> ParsePaths(const string &value);

--- a/src/include/duckdb/catalog/catalog_search_path.hpp
+++ b/src/include/duckdb/catalog/catalog_search_path.hpp
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/catalog/catalog_search_path.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <functional>
+#include "duckdb/common/enums/catalog_type.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/common/types/value.hpp"
+
+namespace duckdb {
+
+class ClientContext;
+
+//! The schema search path, in order by which entries are searched if no schema entry is provided
+class CatalogSearchPath {
+public:
+	explicit CatalogSearchPath(ClientContext &client_p);
+	CatalogSearchPath(const CatalogSearchPath &other) = delete;
+
+	const vector<string> &Get();
+
+private:
+	static vector<string> ParsePaths(const string &value);
+	ClientContext &context;
+	string last_value;
+	vector<string> paths;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/catalog/catalog_set.hpp
+++ b/src/include/duckdb/catalog/catalog_set.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/catalog/default/default_generator.hpp"
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/common/pair.hpp"
 #include "duckdb/common/unordered_set.hpp"
 #include "duckdb/common/mutex.hpp"
 
@@ -58,8 +59,8 @@ public:
 	CatalogEntry *GetEntry(ClientContext &context, const string &name);
 
 	//! Gets the entry that is most similar to the given name (i.e. smallest levenshtein distance), or empty string if
-	//! none is found
-	string SimilarEntry(ClientContext &context, const string &name);
+	//! none is found. The returned pair consists of the entry name and the distance (smaller means closer).
+	pair<string, idx_t> SimilarEntry(ClientContext &context, const string &name);
 
 	//! Rollback <entry> to be the currently valid entry for a certain catalog
 	//! entry

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -52,6 +52,9 @@ public:
 	//! Split the input string based on newline char
 	static vector<string> Split(const string &str, char delimiter);
 
+	//! Split the input string allong a quote. Note that any escaping is NOT supported.
+	static vector<string> SplitWithQuote(const string &str, char delimiter = ',', char quote = '"');
+
 	//! Join multiple strings into one string. Components are concatenated by the given separator
 	static string Join(const vector<string> &input, const string &separator);
 

--- a/src/include/duckdb/execution/operator/helper/physical_set.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_set.hpp
@@ -17,7 +17,7 @@ namespace duckdb {
 //! PhysicalSet represents a SET operation (e.g. SET a = 42)
 class PhysicalSet : public PhysicalOperator {
 public:
-	PhysicalSet(std::string name_p, Value value_p, SetScope scope_p, idx_t estimated_cardinality)
+	PhysicalSet(const std::string &name_p, Value value_p, SetScope scope_p, idx_t estimated_cardinality)
 	    : PhysicalOperator(PhysicalOperatorType::SET, {LogicalType::BOOLEAN}, estimated_cardinality), name(name_p),
 	      value(value_p), scope(scope_p) {
 	}
@@ -26,9 +26,13 @@ public:
 	void GetChunkInternal(ExecutionContext &context, DataChunk &chunk, PhysicalOperatorState *state) const override;
 
 public:
-	std::string name;
-	Value value;
-	SetScope scope;
+	const std::string name;
+	const Value value;
+	const SetScope scope;
+
+private:
+	//! Returns the normalized key name.
+	string ValidateInput(ExecutionContext &context) const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_set.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/deque.hpp"
 #include "duckdb/common/enums/output_type.hpp"
 #include "duckdb/common/pair.hpp"
@@ -76,7 +77,7 @@ public:
 	unique_ptr<SchemaCatalogEntry> temporary_objects;
 	unordered_map<string, shared_ptr<PreparedStatementData>> prepared_statements;
 
-	unordered_map<string, Value> set_variables;
+	case_insensitive_map_t<Value> set_variables;
 
 	// Whether or not aggressive query verification is enabled
 	bool query_verification_enabled = false;

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -28,6 +28,7 @@
 namespace duckdb {
 class Appender;
 class Catalog;
+class CatalogSearchPath;
 class ChunkCollection;
 class DatabaseInstance;
 class FileOpener;
@@ -99,8 +100,7 @@ public:
 	//! The random generator used by random(). Its seed value can be set by setseed().
 	std::mt19937 random_engine;
 
-	//! The schema search path, in order by which entries are searched if no schema entry is provided
-	vector<string> catalog_search_path = {TEMP_SCHEMA, DEFAULT_SCHEMA, "pg_catalog"};
+	const unique_ptr<CatalogSearchPath> catalog_search_path;
 
 	unique_ptr<FileOpener> file_opener;
 

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/allocator.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/order_type.hpp"
 #include "duckdb/common/file_system.hpp"
@@ -93,7 +94,7 @@ public:
 	//! Whether or not object cache is used
 	bool object_cache_enable = false;
 	//! Database configuration variables as controlled by SET
-	unordered_map<std::string, Value> set_variables;
+	case_insensitive_map_t<Value> set_variables;
 	//! Force checkpoint when CHECKPOINT is called or on shutdown, even if no changes have been made
 	bool force_checkpoint = false;
 	//! Run a checkpoint on successful shutdown and delete the WAL, to leave only a single database file behind

--- a/src/include/duckdb/parser/parsed_data/create_function_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_function_info.hpp
@@ -14,7 +14,7 @@
 namespace duckdb {
 
 struct CreateFunctionInfo : public CreateInfo {
-	explicit CreateFunctionInfo(CatalogType type) : CreateInfo(type) {
+	explicit CreateFunctionInfo(CatalogType type, string schema = DEFAULT_SCHEMA) : CreateInfo(type, schema) {
 		D_ASSERT(type == CatalogType::SCALAR_FUNCTION_ENTRY || type == CatalogType::AGGREGATE_FUNCTION_ENTRY ||
 		         type == CatalogType::TABLE_FUNCTION_ENTRY || type == CatalogType::PRAGMA_FUNCTION_ENTRY ||
 		         type == CatalogType::MACRO_ENTRY);

--- a/src/include/duckdb/parser/parsed_data/create_macro_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_macro_info.hpp
@@ -14,7 +14,7 @@
 namespace duckdb {
 
 struct CreateMacroInfo : public CreateFunctionInfo {
-	CreateMacroInfo() : CreateFunctionInfo(CatalogType::MACRO_ENTRY) {
+	CreateMacroInfo() : CreateFunctionInfo(CatalogType::MACRO_ENTRY, INVALID_SCHEMA) {
 	}
 
 	unique_ptr<MacroFunction> function;

--- a/src/include/duckdb/parser/parsed_data/create_sequence_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_sequence_info.hpp
@@ -15,8 +15,8 @@ namespace duckdb {
 
 struct CreateSequenceInfo : public CreateInfo {
 	CreateSequenceInfo()
-	    : CreateInfo(CatalogType::SEQUENCE_ENTRY), name(string()), usage_count(0), increment(1), min_value(1),
-	      max_value(NumericLimits<int64_t>::Maximum()), start_value(1), cycle(false) {
+	    : CreateInfo(CatalogType::SEQUENCE_ENTRY, INVALID_SCHEMA), name(string()), usage_count(0), increment(1),
+	      min_value(1), max_value(NumericLimits<int64_t>::Maximum()), start_value(1), cycle(false) {
 	}
 
 	//! Sequence name to create
@@ -39,6 +39,7 @@ public:
 		auto result = make_unique<CreateSequenceInfo>();
 		CopyProperties(*result);
 		result->name = name;
+		result->schema = schema;
 		result->usage_count = usage_count;
 		result->increment = increment;
 		result->min_value = min_value;

--- a/src/include/duckdb/parser/parsed_data/create_view_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_view_info.hpp
@@ -14,7 +14,7 @@
 namespace duckdb {
 
 struct CreateViewInfo : public CreateInfo {
-	CreateViewInfo() : CreateInfo(CatalogType::VIEW_ENTRY) {
+	CreateViewInfo() : CreateInfo(CatalogType::VIEW_ENTRY, INVALID_SCHEMA) {
 	}
 	CreateViewInfo(string schema, string view_name)
 	    : CreateInfo(CatalogType::VIEW_ENTRY, schema), view_name(view_name) {

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/main/query_profiler.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_search_path.hpp"
 #include "duckdb/common/serializer/buffered_deserializer.hpp"
 #include "duckdb/common/serializer/buffered_serializer.hpp"
 #include "duckdb/execution/physical_plan_generator.hpp"
@@ -53,6 +54,7 @@ ClientContext::ClientContext(shared_ptr<DatabaseInstance> database)
     : profiler(make_unique<QueryProfiler>()), query_profiler_history(make_unique<QueryProfilerHistory>()),
       db(move(database)), transaction(db->GetTransactionManager(), *this), interrupted(false), executor(*this),
       temporary_objects(make_unique<SchemaCatalogEntry>(&db->GetCatalog(), TEMP_SCHEMA, true)),
+      catalog_search_path(make_unique<CatalogSearchPath>(*this)),
       file_opener(make_unique<ClientContextFileOpener>(*this)), open_result(nullptr) {
 	std::random_device rd;
 	random_engine.seed(rd());

--- a/src/parser/transform/statement/transform_set.cpp
+++ b/src/parser/transform/statement/transform_set.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/parser/statement/set_statement.hpp"
+
 #include "duckdb/parser/transformer.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_search_path.hpp"
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/expression/subquery_expression.hpp"
@@ -26,7 +27,7 @@ namespace duckdb {
 
 SchemaCatalogEntry *Binder::BindSchema(CreateInfo &info) {
 	if (info.schema.empty()) {
-		info.schema = info.temporary ? TEMP_SCHEMA : DEFAULT_SCHEMA;
+		info.schema = info.temporary ? TEMP_SCHEMA : context.catalog_search_path->GetDefault();
 	}
 
 	if (!info.temporary) {

--- a/test/common/test_string_util.cpp
+++ b/test/common/test_string_util.cpp
@@ -144,3 +144,87 @@ TEST_CASE("Test join vector items", "[string_util]") {
 		REQUIRE(result == "");
 	}
 }
+
+TEST_CASE("Test split quoted strings", "[string_util]") {
+	SECTION("Empty string") {
+		REQUIRE(StringUtil::SplitWithQuote("") == vector<string> {});
+	}
+
+	SECTION("Empty string with space") {
+		REQUIRE(StringUtil::SplitWithQuote(" ") == vector<string> {});
+	}
+
+	SECTION("One item") {
+		REQUIRE(StringUtil::SplitWithQuote("x") == vector<string> {"x"});
+	}
+
+	SECTION("One item with space") {
+		REQUIRE(StringUtil::SplitWithQuote(" x ") == vector<string> {"x"});
+	}
+
+	SECTION("One item with quote") {
+		REQUIRE(StringUtil::SplitWithQuote("\"x\"") == vector<string> {"x"});
+	}
+
+	SECTION("One empty item with quote") {
+		REQUIRE(StringUtil::SplitWithQuote("\"\"") == vector<string> {""});
+	}
+
+	SECTION("One empty item, followed by non-empty one - Or vise versa") {
+		REQUIRE(StringUtil::SplitWithQuote("\"\",hello") == vector<string> {"", "hello"});
+		REQUIRE(StringUtil::SplitWithQuote(",\"hello\"") == vector<string> {"", "hello"});
+		REQUIRE(StringUtil::SplitWithQuote(",hello") == vector<string> {"", "hello"});
+		REQUIRE(StringUtil::SplitWithQuote("\"\",\"hello\"") == vector<string> {"", "hello"});
+
+		REQUIRE(StringUtil::SplitWithQuote("\"hello\",") == vector<string> {"hello", ""});
+		REQUIRE(StringUtil::SplitWithQuote("hello,\"\"") == vector<string> {"hello", ""});
+		REQUIRE(StringUtil::SplitWithQuote("hello,") == vector<string> {"hello", ""});
+		REQUIRE(StringUtil::SplitWithQuote("\"hello\",\"\"") == vector<string> {"hello", ""});
+	}
+
+	SECTION("One quoted item with spaces") {
+		REQUIRE(StringUtil::SplitWithQuote(" \" x y \" ") == vector<string> {" x y "});
+	}
+
+	SECTION("One quoted item with a delimiter") {
+		REQUIRE(StringUtil::SplitWithQuote("\"x,y\"") == vector<string> {"x,y"});
+	}
+
+	SECTION("Three items") {
+		REQUIRE(StringUtil::SplitWithQuote("x,y,z") == vector<string> {"x", "y", "z"});
+	}
+
+	SECTION("Three items, with and without quote") {
+		REQUIRE(StringUtil::SplitWithQuote("x,\"y\",z") == vector<string> {"x", "y", "z"});
+	}
+
+	SECTION("Even more items, with and without quote") {
+		REQUIRE(StringUtil::SplitWithQuote("a,b,c,d,e,f,g") == vector<string> {"a", "b", "c", "d", "e", "f", "g"});
+	}
+
+	SECTION("Three empty items") {
+		REQUIRE(StringUtil::SplitWithQuote(",,") == vector<string> {"", "", ""});
+	}
+
+	SECTION("Three empty quoted items") {
+		REQUIRE(StringUtil::SplitWithQuote("\"\",\"\",\"\"") == vector<string> {"", "", ""});
+	}
+
+	SECTION("Unclosed quote") {
+		REQUIRE_THROWS_AS(StringUtil::SplitWithQuote("\""), ParserException);
+		REQUIRE_THROWS_AS(StringUtil::SplitWithQuote("\"x"), ParserException);
+		REQUIRE_THROWS_AS(StringUtil::SplitWithQuote("\"x "), ParserException);
+		REQUIRE_THROWS_AS(StringUtil::SplitWithQuote("\","), ParserException);
+		REQUIRE_THROWS_AS(StringUtil::SplitWithQuote("\"x,"), ParserException);
+	}
+
+	SECTION("Unexpected quote") {
+		REQUIRE_THROWS_AS(StringUtil::SplitWithQuote("abc\"def"), ParserException);
+	}
+
+	SECTION("Missing delimiter") {
+		REQUIRE_THROWS_AS(StringUtil::SplitWithQuote("\"x\"\"y\""), ParserException);
+		REQUIRE_THROWS_AS(StringUtil::SplitWithQuote("\"x\" \"y\""), ParserException);
+		REQUIRE_THROWS_AS(StringUtil::SplitWithQuote("x y"), ParserException);
+	}
+}

--- a/test/sql/catalog/did_you_mean.test
+++ b/test/sql/catalog/did_you_mean.test
@@ -1,0 +1,26 @@
+# name: test/sql/catalog/did_you_mean.test
+# Description: The error messages suggest possible alternative
+# group: [catalog]
+ 
+statement ok
+CREATE TABLE hello(i INTEGER);
+
+statement ok
+CREATE SCHEMA test;
+
+statement ok
+CREATE TABLE test.bye(i INTEGER);
+
+statement error
+SELECT * FROM helloo;
+
+# TODO(omo): Test the error message being like this:
+# > Catalog Error: Table with name helloo does not exist!
+# > Did you mean "hello"?
+
+statement error
+SELECT * FROM bye;
+
+# TODO(omo): Test the error message being like this:
+# > Catalog Error: Table with name bye does not exist!
+# > Did you mean "test.bye"?

--- a/test/sql/catalog/test_if_not_exists.test
+++ b/test/sql/catalog/test_if_not_exists.test
@@ -20,3 +20,6 @@ DROP TABLE IF EXISTS integers
 statement ok
 DROP TABLE IF EXISTS integers
 
+statement ok
+DROP TABLE IF EXISTS no_such_scheme.integers
+

--- a/test/sql/catalog/test_set_schema.test
+++ b/test/sql/catalog/test_set_schema.test
@@ -205,8 +205,69 @@ CREATE VIEW bad_test_view AS SELECT * FROM test_table;
 statement ok
 SET SESSION schema = 'test';
 
+# Testing Macros
+
+statement ok
+CREATE MACRO test_macro(a, b) AS a + b;
+
+statement ok
+CREATE MACRO main.main_macro(a, b) AS a - b;
+
+statement ok
+CREATE MACRO out_of_path.oop_macro(a, b) AS a * b;
+
+statement error
+SELECT main.test_macro(1, 2);
+
+statement error
+SELECT oop_macro(1, 2);
+
+statement ok
+SELECT main_macro(1, 2);
+
+statement ok
+SELECT main.main_macro(1, 2);
+
+statement ok
+SELECT test.test_macro(1, 2);
+
+statement ok
+SELECT test_macro(1, 2);
+
+statement ok
+SELECT out_of_path.oop_macro(1, 2);
+
+# Testing sequences.
+
+statement ok
+CREATE SEQUENCE test_sequence;
+
+statement ok
+CREATE SEQUENCE main.main_sequence;
+
+statement ok
+CREATE SEQUENCE out_of_path.oop_sequence;
+
+statement error
+SELECT main.nextval('main.test_sequence');
+
+statement ok
+SELECT main.nextval('test.test_sequence');
+
+statement ok
+SELECT main.nextval('test_sequence');
+
+statement ok
+SELECT main.nextval('main.main_sequence');
+
+statement ok
+SELECT main.nextval('main_sequence');
+
+statement error
+SELECT main.nextval('oop_sequence');
+
+statement ok
+SELECT main.nextval('out_of_path.oop_sequence');
 
 # TODO(omo):
-# - Test MACRO
-# - Test SEQUENCE
 # - Test ALTER and DROP

--- a/test/sql/catalog/test_set_schema.test
+++ b/test/sql/catalog/test_set_schema.test
@@ -157,8 +157,56 @@ SELECT sum(i) FROM test_table;
 ----
 300
 
+# Testing CREATE VIEW
+statement ok
+CREATE VIEW test_view AS SELECT * FROM test_table;
+
+statement ok
+CREATE VIEW main.main_view AS SELECT * FROM main.main_table;
+
+statement ok
+CREATE VIEW out_of_path.oop_view AS SELECT * FROM out_of_path.oop_table;
+
+statement error
+SELECT * FROM main.test_view;
+
+statement ok
+SELECT * FROM test.test_view;
+
+statement ok
+SELECT * FROM test_view;
+
+statement ok
+SELECT * FROM main.main_view;
+
+statement ok
+SELECT * FROM main_view;
+
+statement error
+SELECT * FROM oop_view;
+
+statement ok
+SELECT * FROM out_of_path.oop_view;
+
+statement ok
+SET SESSION schema = 'main';
+
+# Test view's schema being bound on definition.
+statement error
+CREATE VIEW bad_test_view AS SELECT * FROM test_table;
+
 # TODO(omo):
-# - Test VIEW
+#   Currenly this fails because we bind the table name
+#   when the view is actually used vs. defined.
+#   This behavior is incompatible with PG.
+# statement ok
+# SELECT * FROM test.test_view;
+
+statement ok
+SET SESSION schema = 'test';
+
+
+# TODO(omo):
 # - Test MACRO
 # - Test SEQUENCE
 # - Test ALTER and DROP

--- a/test/sql/catalog/test_set_schema.test
+++ b/test/sql/catalog/test_set_schema.test
@@ -157,7 +157,7 @@ SELECT sum(i) FROM test_table;
 ----
 300
 
-# Testing CREATE VIEW
+# Testing Views
 statement ok
 CREATE VIEW test_view AS SELECT * FROM test_table;
 
@@ -205,10 +205,28 @@ CREATE VIEW bad_test_view AS SELECT * FROM test_table;
 statement ok
 SET SESSION schema = 'test';
 
+statement error
+DROP VIEW main.test_view
+
+statement ok
+DROP VIEW test_view
+
+statement ok
+DROP VIEW main_view
+
+statement error
+DROP VIEW oop_view
+
+statement ok
+DROP VIEW out_of_path.oop_view
+
 # Testing Macros
 
 statement ok
 CREATE MACRO test_macro(a, b) AS a + b;
+
+statement ok
+CREATE MACRO test_macro2(c, d) AS c * d;
 
 statement ok
 CREATE MACRO main.main_macro(a, b) AS a - b;
@@ -237,10 +255,31 @@ SELECT test_macro(1, 2);
 statement ok
 SELECT out_of_path.oop_macro(1, 2);
 
+statement error
+DROP MACRO main.test_macro;
+
+statement ok
+DROP MACRO test_macro;
+
+statement ok
+DROP MACRO test.test_macro2;
+
+statement ok
+DROP MACRO main_macro;
+
+statement error
+DROP MACRO oop_macro;
+
+statement ok
+DROP MACRO out_of_path.oop_macro;
+
 # Testing sequences.
 
 statement ok
 CREATE SEQUENCE test_sequence;
+
+statement ok
+CREATE SEQUENCE test_sequence2;
 
 statement ok
 CREATE SEQUENCE main.main_sequence;
@@ -269,5 +308,96 @@ SELECT main.nextval('oop_sequence');
 statement ok
 SELECT main.nextval('out_of_path.oop_sequence');
 
-# TODO(omo):
-# - Test ALTER and DROP
+statement error
+DROP SEQUENCE main.test_sequence;
+
+statement ok
+DROP SEQUENCE test_sequence;
+
+statement ok
+DROP SEQUENCE test.test_sequence2;
+
+statement ok
+DROP SEQUENCE main_sequence;
+
+statement error
+DROP SEQUENCE oop_sequence;
+
+statement ok
+DROP SEQUENCE out_of_path.oop_sequence;
+
+# Testing ALTER TABLE
+
+statement error
+ALTER TABLE main.test_table ADD COLUMN k INTEGER;
+
+statement ok
+ALTER TABLE main.main_table ADD COLUMN k INTEGER;
+
+statement ok
+ALTER TABLE main_table ADD COLUMN l INTEGER;
+
+statement ok
+ALTER TABLE test_table ADD COLUMN m INTEGER;
+
+statement ok
+ALTER TABLE test.test_table ADD COLUMN n INTEGER;
+
+statement error
+ALTER TABLE oop_table ADD COLUMN o INTEGER;
+
+statement ok
+ALTER TABLE out_of_path.oop_table ADD COLUMN p INTEGER;
+
+# Testing DROP TABLE
+
+statement error
+DROP TABLE main.test_table;
+
+statement error
+DROP TABLE test.main_table;
+
+statement ok
+DROP TABLE test_table;
+
+statement ok
+DROP TABLE main_table;
+
+statement error
+DROP TABLE oop_table;
+
+statement ok
+DROP TABLE out_of_path.oop_table;
+
+statement ok
+CREATE TABLE test_table2(i INTEGER);
+
+statement ok
+DROP TABLE test.test_table2;
+
+statement ok
+CREATE TABLE test_table3(i INTEGER);
+
+statement ok
+DROP TABLE IF EXISTS test_table3;
+
+statement ok
+DROP TABLE IF EXISTS test_table3;
+
+statement ok
+CREATE TABLE test_table4(i INTEGER);
+
+statement ok
+DROP TABLE IF EXISTS test.test_table4;
+
+statement ok
+DROP TABLE IF EXISTS test.test_table4;
+
+statement ok
+CREATE TABLE main.main_table2(i INTEGER);
+
+statement ok
+DROP TABLE IF EXISTS main.main_table2;
+
+statement ok
+DROP TABLE IF EXISTS main.main_table2;

--- a/test/sql/catalog/test_set_schema.test
+++ b/test/sql/catalog/test_set_schema.test
@@ -1,0 +1,164 @@
+# name: test/sql/catalog/test_set_schema.test
+# description: Default schema name changes
+# group: [catalog]
+
+# This test focuses on actual name lookup.
+# See also test_set_search_path.test
+
+statement ok
+CREATE SCHEMA test;
+
+statement ok
+CREATE SCHEMA out_of_path;
+
+statement ok
+SET SESSION schema = 'test';
+
+# Testing CREATE TABLE
+
+statement ok
+CREATE TABLE main.main_table(j INTEGER);
+
+statement ok
+CREATE TABLE test_table(i INTEGER);
+
+statement ok
+CREATE TABLE out_of_path.oop_table(k INTEGER);
+
+statement ok
+SELECT * FROM test.test_table;
+
+statement ok
+SELECT * FROM test_table;
+
+statement ok
+SELECT * FROM main_table;
+
+statement ok
+SELECT * FROM out_of_path.oop_table;
+
+statement error
+SELECT * FROM out_of_path.test_table;
+
+statement error
+SELECT * FROM main.test_table;
+
+# Testing INSERT, UPDATE and DELETE
+
+statement error
+INSERT INTO main.test_table (i) VALUES (1);
+
+statement ok
+INSERT INTO test_table (i) VALUES (1);
+
+statement ok
+INSERT INTO test.test_table (i) VALUES (2), (3);
+
+statement ok
+INSERT INTO main_table (j) VALUES (4);
+
+statement ok
+INSERT INTO main.main_table (j) VALUES (5), (6);
+
+statement error
+INSERT INTO oop_table (k) VALUES (7);
+
+statement ok
+INSERT INTO out_of_path.oop_table (k) VALUES (8), (9);
+
+statement error
+DELETE FROM main.test_table WHERE i=3;
+
+statement error
+DELETE FROM test.main_table WHERE i=5;
+
+statement error
+DELETE FROM oop_table WHERE k=8;
+
+statement ok
+DELETE FROM test.test_table WHERE i=1;
+
+statement ok
+DELETE FROM test_table WHERE i=2;
+
+statement ok
+DELETE FROM main.main_table WHERE j=4;
+
+statement ok
+DELETE FROM main_table WHERE j=5;
+
+statement ok
+DELETE FROM out_of_path.oop_table WHERE k=8;
+
+query I
+SELECT i FROM test_table;
+----
+3
+
+query I
+SELECT j FROM main.main_table;
+----
+6
+
+query I
+SELECT k FROM out_of_path.oop_table;
+----
+9
+
+statement error
+UPDATE main.test_table SET i=10 WHERE i=1;
+
+statement ok
+UPDATE test_table SET i=30 WHERE i=3;
+
+statement ok
+UPDATE test.test_table SET i=300 WHERE i=30;
+
+statement ok
+UPDATE main_table SET j=60 WHERE j=6;
+
+statement ok
+UPDATE main.main_table SET j=600 WHERE j=60;
+
+query I
+SELECT i FROM test_table;
+----
+300
+
+query I
+SELECT j FROM main_table;
+----
+600
+
+# Testing temp table.
+# test_temp_table should *not* be created in the test schema, but in the temp schema
+
+statement ok
+CREATE TEMP TABLE test_temp_table(i INTEGER);
+
+statement error
+SELECT * FROM main.test_temp_table;
+
+statement error
+SELECT * FROM test.test_temp_table;
+
+statement ok
+SELECT * FROM test_temp_table;
+
+# Testing functions and aggregates
+query I
+SELECT abs(i) FROM test_table;
+----
+300
+
+# aggregates should work as expected
+query I
+SELECT sum(i) FROM test_table;
+----
+300
+
+# TODO(omo):
+# - Test VIEW
+# - Test MACRO
+# - Test SEQUENCE
+# - Test ALTER and DROP

--- a/test/sql/catalog/test_set_search_path.test
+++ b/test/sql/catalog/test_set_search_path.test
@@ -1,22 +1,42 @@
 # name: test/sql/catalog/test_set_search_path.test
-# description: Default schema name changes
+# description: SET schema and SET search_path
 # group: [catalog]
 
 # create a couple of schemas with a table each
 statement ok
+CREATE TABLE main_table(i INTEGER);
+
+statement ok
 CREATE SCHEMA test;
 
 statement ok
-CREATE TABLE test.hello(i INTEGER);
+CREATE TABLE test.test_table(i INTEGER);
 
 statement ok
 CREATE SCHEMA test2;
 
 statement ok
+CREATE TABLE test2.bye(i INTEGER);
+CREATE TABLE test2.test2_table(i INTEGER);
+
+statement ok
 CREATE SCHEMA test3;
 
 statement ok
-CREATE TABLE test2.bye(i INTEGER);
+CREATE SCHEMA test4;
+
+statement ok
+CREATE SCHEMA test5;
+
+statement ok
+CREATE TABLE test5.test5_table(i INTEGER);
+
+# Reading the config - It should be empty for now.
+statement error
+SELECT CURRENT_SETTING('search_path');
+
+statement error
+SELECT CURRENT_SETTING('schema');
 
 # Setting the default value.
 statement ok
@@ -54,12 +74,12 @@ statement error
 SET SEARCH_PATH = '"invalid quoted string list';
 
 query I
-SELECT CURRENT_SETTING('search_path');
+SELECT MAIN.CURRENT_SETTING('search_path');
 ----
 test,test2
 
 query I
-SELECT CURRENT_SETTING('schema');
+SELECT MAIN.CURRENT_SETTING('schema');
 ----
 test,test2
 
@@ -67,12 +87,12 @@ statement ok
 SET SCHEMA = 'test';
 
 query I
-SELECT CURRENT_SETTING('search_path');
+SELECT MAIN.CURRENT_SETTING('search_path');
 ----
 test
 
 query I
-SELECT CURRENT_SETTING('schema');
+SELECT MAIN.CURRENT_SETTING('schema');
 ----
 test
 
@@ -94,4 +114,91 @@ SELECT CURRENT_SETTING('search_path');
 ----
 test3
 
-# TODO(omo): Test side effects here.
+# Looking up from multiple schemas
+
+statement ok
+SET SEARCH_PATH = 'test,test2';
+
+statement ok
+SELECT i FROM test_table;
+
+statement ok
+SELECT i FROM test2_table;
+
+statement ok
+SELECT i FROM main_table;
+
+statement ok
+CREATE TABLE main.table_with_same_name(in_main INTEGER);
+
+statement ok
+CREATE TABLE test.table_with_same_name(in_test INTEGER);
+
+statement ok
+CREATE TABLE test2.table_with_same_name(in_test2 INTEGER);
+
+statement error
+---
+SELECT in_main FROM table_with_same_name;
+
+statement error
+---
+SELECT in_test2 FROM table_with_same_name;
+
+statement ok
+---
+SELECT in_test FROM table_with_same_name;
+
+
+# Or even more schemas
+
+statement ok
+SET SEARCH_PATH = 'test,test2,test3,test4,test5';
+
+statement ok
+---
+SELECT i FROM test5_table;
+
+statement ok
+SELECT i FROM test_table;
+
+statement ok
+SELECT i FROM test2_table;
+
+statement ok
+SELECT i FROM main_table;
+
+# Duplicate entry in the path (is allowed)
+
+statement ok
+SET SEARCH_PATH = 'test,test,test2';
+
+statement ok
+SELECT i FROM test_table;
+
+statement ok
+SELECT i FROM test2_table;
+
+statement ok
+SELECT i FROM main_table;
+
+# Multiple connections
+
+statement ok con1
+SET schema = 'test';
+
+statement ok con2
+SET schema = 'test2';
+
+statement ok con1
+SELECT i FROM test_table;
+
+statement error con2
+SELECT i FROM test_table;
+
+statement error con1
+SELECT i FROM test2_table;
+
+statement ok con2
+SELECT i FROM test2_table;
+

--- a/test/sql/catalog/test_set_search_path.test
+++ b/test/sql/catalog/test_set_search_path.test
@@ -1,0 +1,97 @@
+# name: test/sql/catalog/test_set_search_path.test
+# description: Default schema name changes
+# group: [catalog]
+
+# create a couple of schemas with a table each
+statement ok
+CREATE SCHEMA test;
+
+statement ok
+CREATE TABLE test.hello(i INTEGER);
+
+statement ok
+CREATE SCHEMA test2;
+
+statement ok
+CREATE SCHEMA test3;
+
+statement ok
+CREATE TABLE test2.bye(i INTEGER);
+
+# Setting the default value.
+statement ok
+SET SEARCH_PATH = 'test';
+
+statement ok
+SET SEARCH_PATH = 'test,test2';
+
+statement ok
+SET SEARCH_PATH = '"test","test2"';
+
+statement ok
+SET SEARCH_PATH = '"test","test2"';
+
+statement error
+SET SEARCH_PATH = 'does_not_exist';
+
+# Setting the default value through 'schema'
+
+statement ok
+SET SCHEMA = 'test';
+
+statement error
+SET SCHEMA = 'test,test2';
+
+statement error
+SET SCHEMA = 'does_not_exist';
+
+# Reading out to see how aliasing works.
+
+statement ok
+SET SEARCH_PATH = 'test,test2';
+
+statement error
+SET SEARCH_PATH = '"invalid quoted string list';
+
+query I
+SELECT CURRENT_SETTING('search_path');
+----
+test,test2
+
+query I
+SELECT CURRENT_SETTING('schema');
+----
+test,test2
+
+statement ok
+SET SCHEMA = 'test';
+
+query I
+SELECT CURRENT_SETTING('search_path');
+----
+test
+
+query I
+SELECT CURRENT_SETTING('schema');
+----
+test
+
+# Case insensitivity
+
+statement ok
+SET schema = 'test2';
+
+query I
+SELECT CURRENT_SETTING('search_path');
+----
+test2
+
+statement ok
+SET search_path = 'test3';
+
+query I
+SELECT CURRENT_SETTING('search_path');
+----
+test3
+
+# TODO(omo): Test side effects here.

--- a/test/sql/function/generic/test_set.test
+++ b/test/sql/function/generic/test_set.test
@@ -76,3 +76,29 @@ query I
 SELECT CURRENT_SETTING('shadowed');
 ----
 42
+
+statement ok
+SET SESSION CASE_IS_LOWERED = 42;
+
+query I
+SELECT CURRENT_SETTING('case_is_lowered');
+----
+42
+
+query I
+SELECT CURRENT_SETTING('CASE_IS_LOWERED');
+----
+42
+
+statement ok
+SET SESSION case_is_lowered = 43;
+
+query I
+SELECT CURRENT_SETTING('case_is_lowered');
+----
+43
+
+query I
+SELECT CURRENT_SETTING('CASE_IS_LOWERED');
+----
+43


### PR DESCRIPTION
Please take a look when you have time?
This series of changes fix #155.

I found some interesting things along the way. These can be addressed in separate PR:

 * The "temp" schema is a bit limiting. We might want to support TEMP tables without using this?
 * Using "main" schema for built-ins can be problematic because since these built-ins become invisible after
   setting the search_path. We might give them their own, like "builtin" or something.
 * The queries in CREATE VIEW can break after the search_path change. We might want to either
   pre-compile these queries somehow or retain the search path for the later resolution.

Anyway, these aren't the main points of this PR. 

Also, I credit #1451 where I borrowed the test. Thanks @rohankumar42!
