### PR TITLE
Fix #2315: correctly detect that index joins cannot be used for multi-column indexes, and clean up TPC-DS extension

### DIFF
--- a/extension/tpcds/dsdgen/append_info-c.cpp
+++ b/extension/tpcds/dsdgen/append_info-c.cpp
@@ -32,7 +32,7 @@ void append_row_end(append_info info) {
 void append_varchar(append_info info, const char *value) {
 	auto append_info = (tpcds_append_information *)info;
 	if (!nullCheck(append_info->appender.CurrentColumn())) {
-		append_info->appender.Append<const char *>(value);
+		append_info->appender.Append<duckdb::string_t>(duckdb::string_t(value));
 	} else {
 		append_info->appender.Append(nullptr);
 	}
@@ -41,7 +41,7 @@ void append_varchar(append_info info, const char *value) {
 // TODO: use direct array manipulation for speed, but not now
 static void append_value(append_info info, duckdb::Value v) {
 	auto append_info = (tpcds_append_information *)info;
-	append_info->appender.Append<duckdb::Value>(v);
+	append_info->appender.AppendValue(v);
 }
 
 void append_key(append_info info, int64_t value) {

--- a/extension/tpcds/dsdgen/dsdgen.cpp
+++ b/extension/tpcds/dsdgen/dsdgen.cpp
@@ -19,7 +19,6 @@ void DSDGenWrapper::DSDGen(double scale, ClientContext &context, string schema, 
 	Connection con(*context.db);
 
 	con.Query("BEGIN TRANSACTION");
-	// FIXME: No restart support yet, suspect only fix is init_rand
 	// FIXME: no schema/suffix support yet
 
 	for (int t = 0; t < TPCDS_TABLE_COUNT; t++) {

--- a/extension/tpcds/dsdgen/dsdgen.cpp
+++ b/extension/tpcds/dsdgen/dsdgen.cpp
@@ -29,7 +29,7 @@ static void CreateTPCDSTable(ClientContext &context, string schema, string suffi
 	}
 	if (keys) {
 		vector<string> pk_columns;
-		for(idx_t i = 0; i < T::PrimaryKeyCount; i++) {
+		for (idx_t i = 0; i < T::PrimaryKeyCount; i++) {
 			pk_columns.push_back(T::PrimaryKeyColumns[i]);
 		}
 		info->constraints.push_back(make_unique<UniqueConstraint>(move(pk_columns), true));

--- a/extension/tpcds/dsdgen/dsdgen.cpp
+++ b/extension/tpcds/dsdgen/dsdgen.cpp
@@ -7,6 +7,8 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/storage/data_table.hpp"
 #include "tpcds_constants.hpp"
+#include "dsdgen_schema.hpp"
+#include "duckdb/parser/constraints/unique_constraint.hpp"
 
 #include <cassert>
 
@@ -15,18 +17,58 @@ using namespace std;
 
 namespace tpcds {
 
-void DSDGenWrapper::DSDGen(double scale, ClientContext &context, string schema, string suffix) {
-	Connection con(*context.db);
-
-	con.Query("BEGIN TRANSACTION");
-	// FIXME: no schema/suffix support yet
-
-	for (int t = 0; t < TPCDS_TABLE_COUNT; t++) {
-		con.Query(TPCDS_TABLE_DDL_NOKEYS[t]);
+template <class T>
+static void CreateTPCDSTable(ClientContext &context, string schema, string suffix, bool keys, bool overwrite) {
+	auto info = make_unique<CreateTableInfo>();
+	info->schema = schema;
+	info->table = T::Name + suffix;
+	info->on_conflict = overwrite ? OnCreateConflict::REPLACE_ON_CONFLICT : OnCreateConflict::ERROR_ON_CONFLICT;
+	info->temporary = false;
+	for (idx_t i = 0; i < T::ColumnCount; i++) {
+		info->columns.push_back(ColumnDefinition(T::Columns[i], T::Types[i]));
 	}
+	if (keys) {
+		vector<string> pk_columns;
+		for(idx_t i = 0; i < T::PrimaryKeyCount; i++) {
+			pk_columns.push_back(T::PrimaryKeyColumns[i]);
+		}
+		info->constraints.push_back(make_unique<UniqueConstraint>(move(pk_columns), true));
+	}
+	auto binder = Binder::CreateBinder(context);
+	auto bound_info = binder->BindCreateTableInfo(move(info));
+	auto &catalog = Catalog::GetCatalog(context);
 
-	con.Query("COMMIT");
+	catalog.CreateTable(context, bound_info.get());
+}
 
+void DSDGenWrapper::CreateTPCDSSchema(ClientContext &context, string schema, string suffix, bool keys, bool overwrite) {
+	CreateTPCDSTable<CallCenterInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<CatalogPageInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<CatalogReturnsInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<CatalogSalesInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<CustomerInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<CustomerAddressInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<CustomerDemographicsInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<DateDimInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<HouseholdDemographicsInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<IncomeBandInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<InventoryInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<ItemInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<PromotionInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<ReasonInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<ShipModeInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<StoreInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<StoreReturnsInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<StoreSalesInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<TimeDimInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<WarehouseInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<WebPageInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<WebReturnsInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<WebSalesInfo>(context, schema, suffix, keys, overwrite);
+	CreateTPCDSTable<WebSiteInfo>(context, schema, suffix, keys, overwrite);
+}
+
+void DSDGenWrapper::DSDGen(double scale, ClientContext &context, string schema, string suffix) {
 	if (scale <= 0) {
 		// schema only
 		return;
@@ -37,13 +79,17 @@ void DSDGenWrapper::DSDGen(double scale, ClientContext &context, string schema, 
 	// populate append info
 	vector<unique_ptr<tpcds_append_information>> append_info;
 	append_info.resize(DBGEN_VERSION);
+	auto &catalog = Catalog::GetCatalog(context);
 
 	int tmin = CALL_CENTER, tmax = DBGEN_VERSION;
 
 	for (int table_id = tmin; table_id < tmax; table_id++) {
 		auto table_def = GetTDefByNumber(table_id);
+		auto table_name = table_def.name + suffix;
 		assert(table_def.name);
-		auto append = make_unique<tpcds_append_information>(con, schema, table_def.name);
+		auto table_entry = catalog.GetEntry<TableCatalogEntry>(context, schema, table_name);
+
+		auto append = make_unique<tpcds_append_information>(context, table_entry);
 		append->table_def = table_def;
 		append_info[table_id] = move(append);
 	}

--- a/extension/tpcds/dsdgen/include/append_info-c.hpp
+++ b/extension/tpcds/dsdgen/include/append_info-c.hpp
@@ -2,8 +2,138 @@
 
 #include "duckdb/main/appender.hpp"
 #include "duckdb/main/connection.hpp"
+#include "duckdb/main/client_context.hpp"
+#ifndef DUCKDB_AMALGAMATION
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/date.hpp"
+#include "duckdb/parser/column_definition.hpp"
+#include "duckdb/storage/data_table.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
+#include "duckdb/parser/parsed_data/create_table_info.hpp"
+#include "duckdb/parser/constraints/not_null_constraint.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/common/operator/cast_operators.hpp"
+#include "duckdb/common/operator/string_cast.hpp"
+#endif
 
 #include <memory>
+
+namespace duckdb {
+
+struct DSDGenAppender {
+	DSDGenAppender(ClientContext &context, TableCatalogEntry *tbl) : context(context), tbl(tbl), column(0) {
+		vector<LogicalType> types;
+		for (idx_t i = 0; i < tbl->columns.size(); i++) {
+			types.push_back(tbl->columns[i].type);
+		}
+		chunk.Initialize(types);
+	}
+
+	void BeginRow() {
+		column = 0;
+	}
+
+	void EndRow() {
+		assert(column == chunk.ColumnCount());
+		chunk.SetCardinality(chunk.size() + 1);
+		if (chunk.size() == STANDARD_VECTOR_SIZE) {
+			Flush();
+		}
+	}
+
+	idx_t CurrentColumn() {
+		return column;
+	}
+
+	void Flush() {
+		if (chunk.size() == 0) {
+			return;
+		}
+		tbl->storage->Append(*tbl, context, chunk);
+		chunk.Reset();
+	}
+
+	void Close() {
+		Flush();
+	}
+
+
+	template <class SRC, class DST>
+	void AppendValueInternal(Vector &col, SRC input) {
+		FlatVector::GetData<DST>(col)[chunk.size()] = Cast::Operation<SRC, DST>(input);
+	}
+
+	template <class T>
+	void Append(T input) {
+		if (column >= chunk.data.size()) {
+			throw InvalidInputException("Too many appends for chunk!");
+		}
+		auto &col = chunk.data[column];
+		switch (col.GetType().InternalType()) {
+		case PhysicalType::BOOL:
+			AppendValueInternal<T, bool>(col, input);
+			break;
+		case PhysicalType::UINT8:
+			AppendValueInternal<T, uint8_t>(col, input);
+			break;
+		case PhysicalType::INT8:
+			AppendValueInternal<T, int8_t>(col, input);
+			break;
+		case PhysicalType::UINT16:
+			AppendValueInternal<T, uint16_t>(col, input);
+			break;
+		case PhysicalType::INT16:
+			AppendValueInternal<T, int16_t>(col, input);
+			break;
+		case PhysicalType::UINT32:
+			AppendValueInternal<T, uint32_t>(col, input);
+			break;
+		case PhysicalType::INT32:
+			AppendValueInternal<T, int32_t>(col, input);
+			break;
+		case PhysicalType::UINT64:
+			AppendValueInternal<T, uint64_t>(col, input);
+			break;
+		case PhysicalType::INT64:
+			AppendValueInternal<T, int64_t>(col, input);
+			break;
+		case PhysicalType::INT128:
+			AppendValueInternal<T, hugeint_t>(col, input);
+			break;
+		case PhysicalType::FLOAT:
+			AppendValueInternal<T, float>(col, input);
+			break;
+		case PhysicalType::DOUBLE:
+			AppendValueInternal<T, double>(col, input);
+			break;
+		case PhysicalType::VARCHAR:
+			FlatVector::GetData<string_t>(col)[chunk.size()] = StringCast::Operation<T>(input, col);
+			break;
+		default:
+			AppendValue(Value::CreateValue<T>(input));
+			return;
+		}
+		column++;
+	}
+
+	void AppendValue(const Value &value) {
+		chunk.SetValue(column, chunk.size(), value);
+		column++;
+	}
+	void AppendString(const char *value) {
+		Append<string_t>(StringVector::AddString(chunk.data[column], value));
+	}
+
+private:
+	ClientContext &context;
+	TableCatalogEntry *tbl;
+	DataChunk chunk;
+	idx_t column;
+};
+
+}
 
 namespace tpcds {
 
@@ -17,12 +147,12 @@ struct tpcds_table_def {
 #define DBGEN_VERSION 24
 
 struct tpcds_append_information {
-	tpcds_append_information(duckdb::Connection connection, std::string schema_name, std::string table_name)
-	    : connection(connection), appender(connection, schema_name, table_name) {
+	tpcds_append_information(duckdb::ClientContext &context_p, duckdb::TableCatalogEntry *table)
+	    : context(context_p), appender(context_p, table) {
 	}
 
-	duckdb::Connection connection;
-	duckdb::Appender appender;
+	duckdb::ClientContext &context;
+	duckdb::DSDGenAppender appender;
 
 	tpcds_table_def table_def;
 };

--- a/extension/tpcds/dsdgen/include/append_info-c.hpp
+++ b/extension/tpcds/dsdgen/include/append_info-c.hpp
@@ -60,7 +60,6 @@ struct DSDGenAppender {
 		Flush();
 	}
 
-
 	template <class SRC, class DST>
 	void AppendValueInternal(Vector &col, SRC input) {
 		FlatVector::GetData<DST>(col)[chunk.size()] = Cast::Operation<SRC, DST>(input);
@@ -134,7 +133,7 @@ private:
 	idx_t column;
 };
 
-}
+} // namespace duckdb
 
 namespace tpcds {
 

--- a/extension/tpcds/dsdgen/include/append_info-c.hpp
+++ b/extension/tpcds/dsdgen/include/append_info-c.hpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <memory>
+#include <cassert>
 
 namespace duckdb {
 

--- a/extension/tpcds/dsdgen/include/dsdgen.hpp
+++ b/extension/tpcds/dsdgen/include/dsdgen.hpp
@@ -22,6 +22,8 @@ class ClientContext;
 namespace tpcds {
 
 struct DSDGenWrapper {
+	//! Create the TPC-DS tables in the given schema with the given suffix
+	static void CreateTPCDSSchema(duckdb::ClientContext &context, std::string schema, std::string suffix, bool keys, bool overwrite);
 	//! Generate the TPC-DS data of the given scale factor
 	static void DSDGen(double scale, duckdb::ClientContext &context, std::string schema = DEFAULT_SCHEMA,
 	                   std::string suffix = "");

--- a/extension/tpcds/dsdgen/include/dsdgen.hpp
+++ b/extension/tpcds/dsdgen/include/dsdgen.hpp
@@ -23,7 +23,8 @@ namespace tpcds {
 
 struct DSDGenWrapper {
 	//! Create the TPC-DS tables in the given schema with the given suffix
-	static void CreateTPCDSSchema(duckdb::ClientContext &context, std::string schema, std::string suffix, bool keys, bool overwrite);
+	static void CreateTPCDSSchema(duckdb::ClientContext &context, std::string schema, std::string suffix, bool keys,
+	                              bool overwrite);
 	//! Generate the TPC-DS data of the given scale factor
 	static void DSDGen(double scale, duckdb::ClientContext &context, std::string schema = DEFAULT_SCHEMA,
 	                   std::string suffix = "");

--- a/extension/tpcds/dsdgen/include/dsdgen_schema.hpp
+++ b/extension/tpcds/dsdgen/include/dsdgen_schema.hpp
@@ -1,0 +1,458 @@
+
+#pragma once
+
+#include "duckdb.hpp"
+
+#ifndef DUCKDB_AMALGAMATION
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/date.hpp"
+#include "duckdb/parser/column_definition.hpp"
+#include "duckdb/storage/data_table.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
+#include "duckdb/parser/parsed_data/create_table_info.hpp"
+#include "duckdb/parser/constraints/not_null_constraint.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/planner/binder.hpp"
+#endif
+
+namespace tpcds {
+
+using duckdb::LogicalType;
+using duckdb::idx_t;
+
+
+//===--------------------------------------------------------------------===//
+// call_center
+//===--------------------------------------------------------------------===//
+struct CallCenterInfo {
+	static constexpr char *Name = "call_center";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 31;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 1;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *CallCenterInfo::Columns[] = {"cc_call_center_sk", "cc_call_center_id", "cc_rec_start_date", "cc_rec_end_date", "cc_closed_date_sk", "cc_open_date_sk", "cc_name", "cc_class", "cc_employees", "cc_sq_ft", "cc_hours", "cc_manager", "cc_mkt_id", "cc_mkt_class", "cc_mkt_desc", "cc_market_manager", "cc_division", "cc_division_name", "cc_company", "cc_company_name", "cc_street_number", "cc_street_name", "cc_street_type", "cc_suite_number", "cc_city", "cc_county", "cc_state", "cc_zip", "cc_country", "cc_gmt_offset", "cc_tax_percentage"};
+
+const LogicalType CallCenterInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::DATE, LogicalType::DATE, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DECIMAL(5,2), LogicalType::DECIMAL(5,2)};
+
+const char *CallCenterInfo::PrimaryKeyColumns[] = {"cc_call_center_sk"};
+
+//===--------------------------------------------------------------------===//
+// catalog_page
+//===--------------------------------------------------------------------===//
+struct CatalogPageInfo {
+	static constexpr char *Name = "catalog_page";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 9;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 1;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *CatalogPageInfo::Columns[] = {"cp_catalog_page_sk", "cp_catalog_page_id", "cp_start_date_sk", "cp_end_date_sk", "cp_department", "cp_catalog_number", "cp_catalog_page_number", "cp_description", "cp_type"};
+
+const LogicalType CatalogPageInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR};
+
+const char *CatalogPageInfo::PrimaryKeyColumns[] = {"cp_catalog_page_sk"};
+
+//===--------------------------------------------------------------------===//
+// catalog_returns
+//===--------------------------------------------------------------------===//
+struct CatalogReturnsInfo {
+	static constexpr char *Name = "catalog_returns";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 27;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 2;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *CatalogReturnsInfo::Columns[] = {"cr_returned_date_sk", "cr_returned_time_sk", "cr_item_sk", "cr_refunded_customer_sk", "cr_refunded_cdemo_sk", "cr_refunded_hdemo_sk", "cr_refunded_addr_sk", "cr_returning_customer_sk", "cr_returning_cdemo_sk", "cr_returning_hdemo_sk", "cr_returning_addr_sk", "cr_call_center_sk", "cr_catalog_page_sk", "cr_ship_mode_sk", "cr_warehouse_sk", "cr_reason_sk", "cr_order_number", "cr_return_quantity", "cr_return_amount", "cr_return_tax", "cr_return_amt_inc_tax", "cr_fee", "cr_return_ship_cost", "cr_refunded_cash", "cr_reversed_charge", "cr_store_credit", "cr_net_loss"};
+
+const LogicalType CatalogReturnsInfo::Types[] = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2)};
+
+const char *CatalogReturnsInfo::PrimaryKeyColumns[] = {"cr_item_sk", "cr_order_number"};
+
+//===--------------------------------------------------------------------===//
+// catalog_sales
+//===--------------------------------------------------------------------===//
+struct CatalogSalesInfo {
+	static constexpr char *Name = "catalog_sales";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 34;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 2;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *CatalogSalesInfo::Columns[] = {"cs_sold_date_sk", "cs_sold_time_sk", "cs_ship_date_sk", "cs_bill_customer_sk", "cs_bill_cdemo_sk", "cs_bill_hdemo_sk", "cs_bill_addr_sk", "cs_ship_customer_sk", "cs_ship_cdemo_sk", "cs_ship_hdemo_sk", "cs_ship_addr_sk", "cs_call_center_sk", "cs_catalog_page_sk", "cs_ship_mode_sk", "cs_warehouse_sk", "cs_item_sk", "cs_promo_sk", "cs_order_number", "cs_quantity", "cs_wholesale_cost", "cs_list_price", "cs_sales_price", "cs_ext_discount_amt", "cs_ext_sales_price", "cs_ext_wholesale_cost", "cs_ext_list_price", "cs_ext_tax", "cs_coupon_amt", "cs_ext_ship_cost", "cs_net_paid", "cs_net_paid_inc_tax", "cs_net_paid_inc_ship", "cs_net_paid_inc_ship_tax", "cs_net_profit"};
+
+const LogicalType CatalogSalesInfo::Types[] = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2)};
+
+const char *CatalogSalesInfo::PrimaryKeyColumns[] = {"cs_item_sk", "cs_order_number"};
+
+//===--------------------------------------------------------------------===//
+// customer
+//===--------------------------------------------------------------------===//
+struct CustomerInfo {
+	static constexpr char *Name = "customer";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 18;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 1;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *CustomerInfo::Columns[] = {"c_customer_sk", "c_customer_id", "c_current_cdemo_sk", "c_current_hdemo_sk", "c_current_addr_sk", "c_first_shipto_date_sk", "c_first_sales_date_sk", "c_salutation", "c_first_name", "c_last_name", "c_preferred_cust_flag", "c_birth_day", "c_birth_month", "c_birth_year", "c_birth_country", "c_login", "c_email_address", "c_last_review_date_sk"};
+
+const LogicalType CustomerInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER};
+
+const char *CustomerInfo::PrimaryKeyColumns[] = {"c_customer_sk"};
+
+//===--------------------------------------------------------------------===//
+// customer_address
+//===--------------------------------------------------------------------===//
+struct CustomerAddressInfo {
+	static constexpr char *Name = "customer_address";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 13;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 1;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *CustomerAddressInfo::Columns[] = {"ca_address_sk", "ca_address_id", "ca_street_number", "ca_street_name", "ca_street_type", "ca_suite_number", "ca_city", "ca_county", "ca_state", "ca_zip", "ca_country", "ca_gmt_offset", "ca_location_type"};
+
+const LogicalType CustomerAddressInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DECIMAL(5,2), LogicalType::VARCHAR};
+
+const char *CustomerAddressInfo::PrimaryKeyColumns[] = {"ca_address_sk"};
+
+//===--------------------------------------------------------------------===//
+// customer_demographics
+//===--------------------------------------------------------------------===//
+struct CustomerDemographicsInfo {
+	static constexpr char *Name = "customer_demographics";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 9;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 1;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *CustomerDemographicsInfo::Columns[] = {"cd_demo_sk", "cd_gender", "cd_marital_status", "cd_education_status", "cd_purchase_estimate", "cd_credit_rating", "cd_dep_count", "cd_dep_employed_count", "cd_dep_college_count"};
+
+const LogicalType CustomerDemographicsInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER};
+
+const char *CustomerDemographicsInfo::PrimaryKeyColumns[] = {"cd_demo_sk"};
+
+//===--------------------------------------------------------------------===//
+// date_dim
+//===--------------------------------------------------------------------===//
+struct DateDimInfo {
+	static constexpr char *Name = "date_dim";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 28;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 1;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *DateDimInfo::Columns[] = {"d_date_sk", "d_date_id", "d_date", "d_month_seq", "d_week_seq", "d_quarter_seq", "d_year", "d_dow", "d_moy", "d_dom", "d_qoy", "d_fy_year", "d_fy_quarter_seq", "d_fy_week_seq", "d_day_name", "d_quarter_name", "d_holiday", "d_weekend", "d_following_holiday", "d_first_dom", "d_last_dom", "d_same_day_ly", "d_same_day_lq", "d_current_day", "d_current_week", "d_current_month", "d_current_quarter", "d_current_year"};
+
+const LogicalType DateDimInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::DATE, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+
+const char *DateDimInfo::PrimaryKeyColumns[] = {"d_date_sk"};
+
+//===--------------------------------------------------------------------===//
+// household_demographics
+//===--------------------------------------------------------------------===//
+struct HouseholdDemographicsInfo {
+	static constexpr char *Name = "household_demographics";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 5;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 1;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *HouseholdDemographicsInfo::Columns[] = {"hd_demo_sk", "hd_income_band_sk", "hd_buy_potential", "hd_dep_count", "hd_vehicle_count"};
+
+const LogicalType HouseholdDemographicsInfo::Types[] = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER};
+
+const char *HouseholdDemographicsInfo::PrimaryKeyColumns[] = {"hd_demo_sk"};
+
+//===--------------------------------------------------------------------===//
+// income_band
+//===--------------------------------------------------------------------===//
+struct IncomeBandInfo {
+	static constexpr char *Name = "income_band";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 3;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 1;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *IncomeBandInfo::Columns[] = {"ib_income_band_sk", "ib_lower_bound", "ib_upper_bound"};
+
+const LogicalType IncomeBandInfo::Types[] = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER};
+
+const char *IncomeBandInfo::PrimaryKeyColumns[] = {"ib_income_band_sk"};
+
+//===--------------------------------------------------------------------===//
+// inventory
+//===--------------------------------------------------------------------===//
+struct InventoryInfo {
+	static constexpr char *Name = "inventory";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 4;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 3;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *InventoryInfo::Columns[] = {"inv_date_sk", "inv_item_sk", "inv_warehouse_sk", "inv_quantity_on_hand"};
+
+const LogicalType InventoryInfo::Types[] = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER};
+
+const char *InventoryInfo::PrimaryKeyColumns[] = {"inv_date_sk", "inv_item_sk", "inv_warehouse_sk"};
+
+//===--------------------------------------------------------------------===//
+// item
+//===--------------------------------------------------------------------===//
+struct ItemInfo {
+	static constexpr char *Name = "item";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 22;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 1;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *ItemInfo::Columns[] = {"i_item_sk", "i_item_id", "i_rec_start_date", "i_rec_end_date", "i_item_desc", "i_current_price", "i_wholesale_cost", "i_brand_id", "i_brand", "i_class_id", "i_class", "i_category_id", "i_category", "i_manufact_id", "i_manufact", "i_size", "i_formulation", "i_color", "i_units", "i_container", "i_manager_id", "i_product_name"};
+
+const LogicalType ItemInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::DATE, LogicalType::DATE, LogicalType::VARCHAR, LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR};
+
+const char *ItemInfo::PrimaryKeyColumns[] = {"i_item_sk"};
+
+//===--------------------------------------------------------------------===//
+// promotion
+//===--------------------------------------------------------------------===//
+struct PromotionInfo {
+	static constexpr char *Name = "promotion";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 19;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 1;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *PromotionInfo::Columns[] = {"p_promo_sk", "p_promo_id", "p_start_date_sk", "p_end_date_sk", "p_item_sk", "p_cost", "p_response_target", "p_promo_name", "p_channel_dmail", "p_channel_email", "p_channel_catalog", "p_channel_tv", "p_channel_radio", "p_channel_press", "p_channel_event", "p_channel_demo", "p_channel_details", "p_purpose", "p_discount_active"};
+
+const LogicalType PromotionInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::DECIMAL(15,2), LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+
+const char *PromotionInfo::PrimaryKeyColumns[] = {"p_promo_sk"};
+
+//===--------------------------------------------------------------------===//
+// reason
+//===--------------------------------------------------------------------===//
+struct ReasonInfo {
+	static constexpr char *Name = "reason";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 3;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 1;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *ReasonInfo::Columns[] = {"r_reason_sk", "r_reason_id", "r_reason_desc"};
+
+const LogicalType ReasonInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR};
+
+const char *ReasonInfo::PrimaryKeyColumns[] = {"r_reason_sk"};
+
+//===--------------------------------------------------------------------===//
+// ship_mode
+//===--------------------------------------------------------------------===//
+struct ShipModeInfo {
+	static constexpr char *Name = "ship_mode";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 6;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 1;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *ShipModeInfo::Columns[] = {"sm_ship_mode_sk", "sm_ship_mode_id", "sm_type", "sm_code", "sm_carrier", "sm_contract"};
+
+const LogicalType ShipModeInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+
+const char *ShipModeInfo::PrimaryKeyColumns[] = {"sm_ship_mode_sk"};
+
+//===--------------------------------------------------------------------===//
+// store
+//===--------------------------------------------------------------------===//
+struct StoreInfo {
+	static constexpr char *Name = "store";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 29;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 1;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *StoreInfo::Columns[] = {"s_store_sk", "s_store_id", "s_rec_start_date", "s_rec_end_date", "s_closed_date_sk", "s_store_name", "s_number_employees", "s_floor_space", "s_hours", "s_manager", "s_market_id", "s_geography_class", "s_market_desc", "s_market_manager", "s_division_id", "s_division_name", "s_company_id", "s_company_name", "s_street_number", "s_street_name", "s_street_type", "s_suite_number", "s_city", "s_county", "s_state", "s_zip", "s_country", "s_gmt_offset", "s_tax_precentage"};
+
+const LogicalType StoreInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::DATE, LogicalType::DATE, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DECIMAL(5,2), LogicalType::DECIMAL(5,2)};
+
+const char *StoreInfo::PrimaryKeyColumns[] = {"s_store_sk"};
+
+//===--------------------------------------------------------------------===//
+// store_returns
+//===--------------------------------------------------------------------===//
+struct StoreReturnsInfo {
+	static constexpr char *Name = "store_returns";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 20;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 2;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *StoreReturnsInfo::Columns[] = {"sr_returned_date_sk", "sr_return_time_sk", "sr_item_sk", "sr_customer_sk", "sr_cdemo_sk", "sr_hdemo_sk", "sr_addr_sk", "sr_store_sk", "sr_reason_sk", "sr_ticket_number", "sr_return_quantity", "sr_return_amt", "sr_return_tax", "sr_return_amt_inc_tax", "sr_fee", "sr_return_ship_cost", "sr_refunded_cash", "sr_reversed_charge", "sr_store_credit", "sr_net_loss"};
+
+const LogicalType StoreReturnsInfo::Types[] = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2)};
+
+const char *StoreReturnsInfo::PrimaryKeyColumns[] = {"sr_item_sk", "sr_ticket_number"};
+
+//===--------------------------------------------------------------------===//
+// store_sales
+//===--------------------------------------------------------------------===//
+struct StoreSalesInfo {
+	static constexpr char *Name = "store_sales";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 23;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 2;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *StoreSalesInfo::Columns[] = {"ss_sold_date_sk", "ss_sold_time_sk", "ss_item_sk", "ss_customer_sk", "ss_cdemo_sk", "ss_hdemo_sk", "ss_addr_sk", "ss_store_sk", "ss_promo_sk", "ss_ticket_number", "ss_quantity", "ss_wholesale_cost", "ss_list_price", "ss_sales_price", "ss_ext_discount_amt", "ss_ext_sales_price", "ss_ext_wholesale_cost", "ss_ext_list_price", "ss_ext_tax", "ss_coupon_amt", "ss_net_paid", "ss_net_paid_inc_tax", "ss_net_profit"};
+
+const LogicalType StoreSalesInfo::Types[] = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2)};
+
+const char *StoreSalesInfo::PrimaryKeyColumns[] = {"ss_item_sk", "ss_ticket_number"};
+
+//===--------------------------------------------------------------------===//
+// time_dim
+//===--------------------------------------------------------------------===//
+struct TimeDimInfo {
+	static constexpr char *Name = "time_dim";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 10;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 1;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *TimeDimInfo::Columns[] = {"t_time_sk", "t_time_id", "t_time", "t_hour", "t_minute", "t_second", "t_am_pm", "t_shift", "t_sub_shift", "t_meal_time"};
+
+const LogicalType TimeDimInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+
+const char *TimeDimInfo::PrimaryKeyColumns[] = {"t_time_sk"};
+
+//===--------------------------------------------------------------------===//
+// warehouse
+//===--------------------------------------------------------------------===//
+struct WarehouseInfo {
+	static constexpr char *Name = "warehouse";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 14;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 1;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *WarehouseInfo::Columns[] = {"w_warehouse_sk", "w_warehouse_id", "w_warehouse_name", "w_warehouse_sq_ft", "w_street_number", "w_street_name", "w_street_type", "w_suite_number", "w_city", "w_county", "w_state", "w_zip", "w_country", "w_gmt_offset"};
+
+const LogicalType WarehouseInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DECIMAL(5,2)};
+
+const char *WarehouseInfo::PrimaryKeyColumns[] = {"w_warehouse_sk"};
+
+//===--------------------------------------------------------------------===//
+// web_page
+//===--------------------------------------------------------------------===//
+struct WebPageInfo {
+	static constexpr char *Name = "web_page";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 14;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 1;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *WebPageInfo::Columns[] = {"wp_web_page_sk", "wp_web_page_id", "wp_rec_start_date", "wp_rec_end_date", "wp_creation_date_sk", "wp_access_date_sk", "wp_autogen_flag", "wp_customer_sk", "wp_url", "wp_type", "wp_char_count", "wp_link_count", "wp_image_count", "wp_max_ad_count"};
+
+const LogicalType WebPageInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::DATE, LogicalType::DATE, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER};
+
+const char *WebPageInfo::PrimaryKeyColumns[] = {"wp_web_page_sk"};
+
+//===--------------------------------------------------------------------===//
+// web_returns
+//===--------------------------------------------------------------------===//
+struct WebReturnsInfo {
+	static constexpr char *Name = "web_returns";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 24;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 2;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *WebReturnsInfo::Columns[] = {"wr_returned_date_sk", "wr_returned_time_sk", "wr_item_sk", "wr_refunded_customer_sk", "wr_refunded_cdemo_sk", "wr_refunded_hdemo_sk", "wr_refunded_addr_sk", "wr_returning_customer_sk", "wr_returning_cdemo_sk", "wr_returning_hdemo_sk", "wr_returning_addr_sk", "wr_web_page_sk", "wr_reason_sk", "wr_order_number", "wr_return_quantity", "wr_return_amt", "wr_return_tax", "wr_return_amt_inc_tax", "wr_fee", "wr_return_ship_cost", "wr_refunded_cash", "wr_reversed_charge", "wr_account_credit", "wr_net_loss"};
+
+const LogicalType WebReturnsInfo::Types[] = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2)};
+
+const char *WebReturnsInfo::PrimaryKeyColumns[] = {"wr_item_sk", "wr_order_number"};
+
+//===--------------------------------------------------------------------===//
+// web_sales
+//===--------------------------------------------------------------------===//
+struct WebSalesInfo {
+	static constexpr char *Name = "web_sales";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 34;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 2;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *WebSalesInfo::Columns[] = {"ws_sold_date_sk", "ws_sold_time_sk", "ws_ship_date_sk", "ws_item_sk", "ws_bill_customer_sk", "ws_bill_cdemo_sk", "ws_bill_hdemo_sk", "ws_bill_addr_sk", "ws_ship_customer_sk", "ws_ship_cdemo_sk", "ws_ship_hdemo_sk", "ws_ship_addr_sk", "ws_web_page_sk", "ws_web_site_sk", "ws_ship_mode_sk", "ws_warehouse_sk", "ws_promo_sk", "ws_order_number", "ws_quantity", "ws_wholesale_cost", "ws_list_price", "ws_sales_price", "ws_ext_discount_amt", "ws_ext_sales_price", "ws_ext_wholesale_cost", "ws_ext_list_price", "ws_ext_tax", "ws_coupon_amt", "ws_ext_ship_cost", "ws_net_paid", "ws_net_paid_inc_tax", "ws_net_paid_inc_ship", "ws_net_paid_inc_ship_tax", "ws_net_profit"};
+
+const LogicalType WebSalesInfo::Types[] = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2)};
+
+const char *WebSalesInfo::PrimaryKeyColumns[] = {"ws_item_sk", "ws_order_number"};
+
+//===--------------------------------------------------------------------===//
+// web_site
+//===--------------------------------------------------------------------===//
+struct WebSiteInfo {
+	static constexpr char *Name = "web_site";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = 26;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = 1;
+	static const char *PrimaryKeyColumns[];
+};
+
+const char *WebSiteInfo::Columns[] = {"web_site_sk", "web_site_id", "web_rec_start_date", "web_rec_end_date", "web_name", "web_open_date_sk", "web_close_date_sk", "web_class", "web_manager", "web_mkt_id", "web_mkt_class", "web_mkt_desc", "web_market_manager", "web_company_id", "web_company_name", "web_street_number", "web_street_name", "web_street_type", "web_suite_number", "web_city", "web_county", "web_state", "web_zip", "web_country", "web_gmt_offset", "web_tax_percentage"};
+
+const LogicalType WebSiteInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::DATE, LogicalType::DATE, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DECIMAL(5,2), LogicalType::DECIMAL(5,2)};
+
+const char *WebSiteInfo::PrimaryKeyColumns[] = {"web_site_sk"};
+
+}
+

--- a/extension/tpcds/dsdgen/include/dsdgen_schema.hpp
+++ b/extension/tpcds/dsdgen/include/dsdgen_schema.hpp
@@ -18,9 +18,8 @@
 
 namespace tpcds {
 
-using duckdb::LogicalType;
 using duckdb::idx_t;
-
+using duckdb::LogicalType;
 
 //===--------------------------------------------------------------------===//
 // call_center
@@ -34,9 +33,25 @@ struct CallCenterInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *CallCenterInfo::Columns[] = {"cc_call_center_sk", "cc_call_center_id", "cc_rec_start_date", "cc_rec_end_date", "cc_closed_date_sk", "cc_open_date_sk", "cc_name", "cc_class", "cc_employees", "cc_sq_ft", "cc_hours", "cc_manager", "cc_mkt_id", "cc_mkt_class", "cc_mkt_desc", "cc_market_manager", "cc_division", "cc_division_name", "cc_company", "cc_company_name", "cc_street_number", "cc_street_name", "cc_street_type", "cc_suite_number", "cc_city", "cc_county", "cc_state", "cc_zip", "cc_country", "cc_gmt_offset", "cc_tax_percentage"};
+const char *CallCenterInfo::Columns[] = {
+    "cc_call_center_sk", "cc_call_center_id", "cc_rec_start_date", "cc_rec_end_date",
+    "cc_closed_date_sk", "cc_open_date_sk",   "cc_name",           "cc_class",
+    "cc_employees",      "cc_sq_ft",          "cc_hours",          "cc_manager",
+    "cc_mkt_id",         "cc_mkt_class",      "cc_mkt_desc",       "cc_market_manager",
+    "cc_division",       "cc_division_name",  "cc_company",        "cc_company_name",
+    "cc_street_number",  "cc_street_name",    "cc_street_type",    "cc_suite_number",
+    "cc_city",           "cc_county",         "cc_state",          "cc_zip",
+    "cc_country",        "cc_gmt_offset",     "cc_tax_percentage"};
 
-const LogicalType CallCenterInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::DATE, LogicalType::DATE, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DECIMAL(5,2), LogicalType::DECIMAL(5,2)};
+const LogicalType CallCenterInfo::Types[] = {
+    LogicalType::INTEGER, LogicalType::VARCHAR,       LogicalType::DATE,         LogicalType::DATE,
+    LogicalType::INTEGER, LogicalType::INTEGER,       LogicalType::VARCHAR,      LogicalType::VARCHAR,
+    LogicalType::INTEGER, LogicalType::INTEGER,       LogicalType::VARCHAR,      LogicalType::VARCHAR,
+    LogicalType::INTEGER, LogicalType::VARCHAR,       LogicalType::VARCHAR,      LogicalType::VARCHAR,
+    LogicalType::INTEGER, LogicalType::VARCHAR,       LogicalType::INTEGER,      LogicalType::VARCHAR,
+    LogicalType::VARCHAR, LogicalType::VARCHAR,       LogicalType::VARCHAR,      LogicalType::VARCHAR,
+    LogicalType::VARCHAR, LogicalType::VARCHAR,       LogicalType::VARCHAR,      LogicalType::VARCHAR,
+    LogicalType::VARCHAR, LogicalType::DECIMAL(5, 2), LogicalType::DECIMAL(5, 2)};
 
 const char *CallCenterInfo::PrimaryKeyColumns[] = {"cc_call_center_sk"};
 
@@ -52,9 +67,13 @@ struct CatalogPageInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *CatalogPageInfo::Columns[] = {"cp_catalog_page_sk", "cp_catalog_page_id", "cp_start_date_sk", "cp_end_date_sk", "cp_department", "cp_catalog_number", "cp_catalog_page_number", "cp_description", "cp_type"};
+const char *CatalogPageInfo::Columns[] = {"cp_catalog_page_sk",     "cp_catalog_page_id", "cp_start_date_sk",
+                                          "cp_end_date_sk",         "cp_department",      "cp_catalog_number",
+                                          "cp_catalog_page_number", "cp_description",     "cp_type"};
 
-const LogicalType CatalogPageInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR};
+const LogicalType CatalogPageInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER,
+                                              LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER,
+                                              LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR};
 
 const char *CatalogPageInfo::PrimaryKeyColumns[] = {"cp_catalog_page_sk"};
 
@@ -70,9 +89,42 @@ struct CatalogReturnsInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *CatalogReturnsInfo::Columns[] = {"cr_returned_date_sk", "cr_returned_time_sk", "cr_item_sk", "cr_refunded_customer_sk", "cr_refunded_cdemo_sk", "cr_refunded_hdemo_sk", "cr_refunded_addr_sk", "cr_returning_customer_sk", "cr_returning_cdemo_sk", "cr_returning_hdemo_sk", "cr_returning_addr_sk", "cr_call_center_sk", "cr_catalog_page_sk", "cr_ship_mode_sk", "cr_warehouse_sk", "cr_reason_sk", "cr_order_number", "cr_return_quantity", "cr_return_amount", "cr_return_tax", "cr_return_amt_inc_tax", "cr_fee", "cr_return_ship_cost", "cr_refunded_cash", "cr_reversed_charge", "cr_store_credit", "cr_net_loss"};
+const char *CatalogReturnsInfo::Columns[] = {"cr_returned_date_sk",
+                                             "cr_returned_time_sk",
+                                             "cr_item_sk",
+                                             "cr_refunded_customer_sk",
+                                             "cr_refunded_cdemo_sk",
+                                             "cr_refunded_hdemo_sk",
+                                             "cr_refunded_addr_sk",
+                                             "cr_returning_customer_sk",
+                                             "cr_returning_cdemo_sk",
+                                             "cr_returning_hdemo_sk",
+                                             "cr_returning_addr_sk",
+                                             "cr_call_center_sk",
+                                             "cr_catalog_page_sk",
+                                             "cr_ship_mode_sk",
+                                             "cr_warehouse_sk",
+                                             "cr_reason_sk",
+                                             "cr_order_number",
+                                             "cr_return_quantity",
+                                             "cr_return_amount",
+                                             "cr_return_tax",
+                                             "cr_return_amt_inc_tax",
+                                             "cr_fee",
+                                             "cr_return_ship_cost",
+                                             "cr_refunded_cash",
+                                             "cr_reversed_charge",
+                                             "cr_store_credit",
+                                             "cr_net_loss"};
 
-const LogicalType CatalogReturnsInfo::Types[] = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2)};
+const LogicalType CatalogReturnsInfo::Types[] = {
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2),
+    LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2),
+    LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2)};
 
 const char *CatalogReturnsInfo::PrimaryKeyColumns[] = {"cr_item_sk", "cr_order_number"};
 
@@ -88,9 +140,51 @@ struct CatalogSalesInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *CatalogSalesInfo::Columns[] = {"cs_sold_date_sk", "cs_sold_time_sk", "cs_ship_date_sk", "cs_bill_customer_sk", "cs_bill_cdemo_sk", "cs_bill_hdemo_sk", "cs_bill_addr_sk", "cs_ship_customer_sk", "cs_ship_cdemo_sk", "cs_ship_hdemo_sk", "cs_ship_addr_sk", "cs_call_center_sk", "cs_catalog_page_sk", "cs_ship_mode_sk", "cs_warehouse_sk", "cs_item_sk", "cs_promo_sk", "cs_order_number", "cs_quantity", "cs_wholesale_cost", "cs_list_price", "cs_sales_price", "cs_ext_discount_amt", "cs_ext_sales_price", "cs_ext_wholesale_cost", "cs_ext_list_price", "cs_ext_tax", "cs_coupon_amt", "cs_ext_ship_cost", "cs_net_paid", "cs_net_paid_inc_tax", "cs_net_paid_inc_ship", "cs_net_paid_inc_ship_tax", "cs_net_profit"};
+const char *CatalogSalesInfo::Columns[] = {"cs_sold_date_sk",
+                                           "cs_sold_time_sk",
+                                           "cs_ship_date_sk",
+                                           "cs_bill_customer_sk",
+                                           "cs_bill_cdemo_sk",
+                                           "cs_bill_hdemo_sk",
+                                           "cs_bill_addr_sk",
+                                           "cs_ship_customer_sk",
+                                           "cs_ship_cdemo_sk",
+                                           "cs_ship_hdemo_sk",
+                                           "cs_ship_addr_sk",
+                                           "cs_call_center_sk",
+                                           "cs_catalog_page_sk",
+                                           "cs_ship_mode_sk",
+                                           "cs_warehouse_sk",
+                                           "cs_item_sk",
+                                           "cs_promo_sk",
+                                           "cs_order_number",
+                                           "cs_quantity",
+                                           "cs_wholesale_cost",
+                                           "cs_list_price",
+                                           "cs_sales_price",
+                                           "cs_ext_discount_amt",
+                                           "cs_ext_sales_price",
+                                           "cs_ext_wholesale_cost",
+                                           "cs_ext_list_price",
+                                           "cs_ext_tax",
+                                           "cs_coupon_amt",
+                                           "cs_ext_ship_cost",
+                                           "cs_net_paid",
+                                           "cs_net_paid_inc_tax",
+                                           "cs_net_paid_inc_ship",
+                                           "cs_net_paid_inc_ship_tax",
+                                           "cs_net_profit"};
 
-const LogicalType CatalogSalesInfo::Types[] = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2)};
+const LogicalType CatalogSalesInfo::Types[] = {
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::DECIMAL(7, 2),
+    LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2),
+    LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2),
+    LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2),
+    LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2)};
 
 const char *CatalogSalesInfo::PrimaryKeyColumns[] = {"cs_item_sk", "cs_order_number"};
 
@@ -106,9 +200,21 @@ struct CustomerInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *CustomerInfo::Columns[] = {"c_customer_sk", "c_customer_id", "c_current_cdemo_sk", "c_current_hdemo_sk", "c_current_addr_sk", "c_first_shipto_date_sk", "c_first_sales_date_sk", "c_salutation", "c_first_name", "c_last_name", "c_preferred_cust_flag", "c_birth_day", "c_birth_month", "c_birth_year", "c_birth_country", "c_login", "c_email_address", "c_last_review_date_sk"};
+const char *CustomerInfo::Columns[] = {"c_customer_sk",         "c_customer_id",
+                                       "c_current_cdemo_sk",    "c_current_hdemo_sk",
+                                       "c_current_addr_sk",     "c_first_shipto_date_sk",
+                                       "c_first_sales_date_sk", "c_salutation",
+                                       "c_first_name",          "c_last_name",
+                                       "c_preferred_cust_flag", "c_birth_day",
+                                       "c_birth_month",         "c_birth_year",
+                                       "c_birth_country",       "c_login",
+                                       "c_email_address",       "c_last_review_date_sk"};
 
-const LogicalType CustomerInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER};
+const LogicalType CustomerInfo::Types[] = {
+    LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER,
+    LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
+    LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR,
+    LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER};
 
 const char *CustomerInfo::PrimaryKeyColumns[] = {"c_customer_sk"};
 
@@ -124,9 +230,15 @@ struct CustomerAddressInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *CustomerAddressInfo::Columns[] = {"ca_address_sk", "ca_address_id", "ca_street_number", "ca_street_name", "ca_street_type", "ca_suite_number", "ca_city", "ca_county", "ca_state", "ca_zip", "ca_country", "ca_gmt_offset", "ca_location_type"};
+const char *CustomerAddressInfo::Columns[] = {
+    "ca_address_sk",   "ca_address_id", "ca_street_number", "ca_street_name", "ca_street_type",
+    "ca_suite_number", "ca_city",       "ca_county",        "ca_state",       "ca_zip",
+    "ca_country",      "ca_gmt_offset", "ca_location_type"};
 
-const LogicalType CustomerAddressInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DECIMAL(5,2), LogicalType::VARCHAR};
+const LogicalType CustomerAddressInfo::Types[] = {
+    LogicalType::INTEGER, LogicalType::VARCHAR,       LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
+    LogicalType::VARCHAR, LogicalType::VARCHAR,       LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
+    LogicalType::VARCHAR, LogicalType::DECIMAL(5, 2), LogicalType::VARCHAR};
 
 const char *CustomerAddressInfo::PrimaryKeyColumns[] = {"ca_address_sk"};
 
@@ -142,9 +254,13 @@ struct CustomerDemographicsInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *CustomerDemographicsInfo::Columns[] = {"cd_demo_sk", "cd_gender", "cd_marital_status", "cd_education_status", "cd_purchase_estimate", "cd_credit_rating", "cd_dep_count", "cd_dep_employed_count", "cd_dep_college_count"};
+const char *CustomerDemographicsInfo::Columns[] = {
+    "cd_demo_sk",       "cd_gender",    "cd_marital_status",     "cd_education_status", "cd_purchase_estimate",
+    "cd_credit_rating", "cd_dep_count", "cd_dep_employed_count", "cd_dep_college_count"};
 
-const LogicalType CustomerDemographicsInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER};
+const LogicalType CustomerDemographicsInfo::Types[] = {
+    LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER,
+    LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER};
 
 const char *CustomerDemographicsInfo::PrimaryKeyColumns[] = {"cd_demo_sk"};
 
@@ -160,9 +276,42 @@ struct DateDimInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *DateDimInfo::Columns[] = {"d_date_sk", "d_date_id", "d_date", "d_month_seq", "d_week_seq", "d_quarter_seq", "d_year", "d_dow", "d_moy", "d_dom", "d_qoy", "d_fy_year", "d_fy_quarter_seq", "d_fy_week_seq", "d_day_name", "d_quarter_name", "d_holiday", "d_weekend", "d_following_holiday", "d_first_dom", "d_last_dom", "d_same_day_ly", "d_same_day_lq", "d_current_day", "d_current_week", "d_current_month", "d_current_quarter", "d_current_year"};
+const char *DateDimInfo::Columns[] = {"d_date_sk",
+                                      "d_date_id",
+                                      "d_date",
+                                      "d_month_seq",
+                                      "d_week_seq",
+                                      "d_quarter_seq",
+                                      "d_year",
+                                      "d_dow",
+                                      "d_moy",
+                                      "d_dom",
+                                      "d_qoy",
+                                      "d_fy_year",
+                                      "d_fy_quarter_seq",
+                                      "d_fy_week_seq",
+                                      "d_day_name",
+                                      "d_quarter_name",
+                                      "d_holiday",
+                                      "d_weekend",
+                                      "d_following_holiday",
+                                      "d_first_dom",
+                                      "d_last_dom",
+                                      "d_same_day_ly",
+                                      "d_same_day_lq",
+                                      "d_current_day",
+                                      "d_current_week",
+                                      "d_current_month",
+                                      "d_current_quarter",
+                                      "d_current_year"};
 
-const LogicalType DateDimInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::DATE, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+const LogicalType DateDimInfo::Types[] = {
+    LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::DATE,    LogicalType::INTEGER, LogicalType::INTEGER,
+    LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER,
+    LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR,
+    LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER,
+    LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR,
+    LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
 
 const char *DateDimInfo::PrimaryKeyColumns[] = {"d_date_sk"};
 
@@ -178,9 +327,11 @@ struct HouseholdDemographicsInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *HouseholdDemographicsInfo::Columns[] = {"hd_demo_sk", "hd_income_band_sk", "hd_buy_potential", "hd_dep_count", "hd_vehicle_count"};
+const char *HouseholdDemographicsInfo::Columns[] = {"hd_demo_sk", "hd_income_band_sk", "hd_buy_potential",
+                                                    "hd_dep_count", "hd_vehicle_count"};
 
-const LogicalType HouseholdDemographicsInfo::Types[] = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER};
+const LogicalType HouseholdDemographicsInfo::Types[] = {
+    LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER};
 
 const char *HouseholdDemographicsInfo::PrimaryKeyColumns[] = {"hd_demo_sk"};
 
@@ -216,7 +367,8 @@ struct InventoryInfo {
 
 const char *InventoryInfo::Columns[] = {"inv_date_sk", "inv_item_sk", "inv_warehouse_sk", "inv_quantity_on_hand"};
 
-const LogicalType InventoryInfo::Types[] = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER};
+const LogicalType InventoryInfo::Types[] = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER,
+                                            LogicalType::INTEGER};
 
 const char *InventoryInfo::PrimaryKeyColumns[] = {"inv_date_sk", "inv_item_sk", "inv_warehouse_sk"};
 
@@ -232,9 +384,19 @@ struct ItemInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *ItemInfo::Columns[] = {"i_item_sk", "i_item_id", "i_rec_start_date", "i_rec_end_date", "i_item_desc", "i_current_price", "i_wholesale_cost", "i_brand_id", "i_brand", "i_class_id", "i_class", "i_category_id", "i_category", "i_manufact_id", "i_manufact", "i_size", "i_formulation", "i_color", "i_units", "i_container", "i_manager_id", "i_product_name"};
+const char *ItemInfo::Columns[] = {
+    "i_item_sk",        "i_item_id",     "i_rec_start_date", "i_rec_end_date", "i_item_desc",   "i_current_price",
+    "i_wholesale_cost", "i_brand_id",    "i_brand",          "i_class_id",     "i_class",       "i_category_id",
+    "i_category",       "i_manufact_id", "i_manufact",       "i_size",         "i_formulation", "i_color",
+    "i_units",          "i_container",   "i_manager_id",     "i_product_name"};
 
-const LogicalType ItemInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::DATE, LogicalType::DATE, LogicalType::VARCHAR, LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR};
+const LogicalType ItemInfo::Types[] = {
+    LogicalType::INTEGER, LogicalType::VARCHAR,       LogicalType::DATE,          LogicalType::DATE,
+    LogicalType::VARCHAR, LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::INTEGER,
+    LogicalType::VARCHAR, LogicalType::INTEGER,       LogicalType::VARCHAR,       LogicalType::INTEGER,
+    LogicalType::VARCHAR, LogicalType::INTEGER,       LogicalType::VARCHAR,       LogicalType::VARCHAR,
+    LogicalType::VARCHAR, LogicalType::VARCHAR,       LogicalType::VARCHAR,       LogicalType::VARCHAR,
+    LogicalType::INTEGER, LogicalType::VARCHAR};
 
 const char *ItemInfo::PrimaryKeyColumns[] = {"i_item_sk"};
 
@@ -250,9 +412,17 @@ struct PromotionInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *PromotionInfo::Columns[] = {"p_promo_sk", "p_promo_id", "p_start_date_sk", "p_end_date_sk", "p_item_sk", "p_cost", "p_response_target", "p_promo_name", "p_channel_dmail", "p_channel_email", "p_channel_catalog", "p_channel_tv", "p_channel_radio", "p_channel_press", "p_channel_event", "p_channel_demo", "p_channel_details", "p_purpose", "p_discount_active"};
+const char *PromotionInfo::Columns[] = {"p_promo_sk",        "p_promo_id",      "p_start_date_sk",   "p_end_date_sk",
+                                        "p_item_sk",         "p_cost",          "p_response_target", "p_promo_name",
+                                        "p_channel_dmail",   "p_channel_email", "p_channel_catalog", "p_channel_tv",
+                                        "p_channel_radio",   "p_channel_press", "p_channel_event",   "p_channel_demo",
+                                        "p_channel_details", "p_purpose",       "p_discount_active"};
 
-const LogicalType PromotionInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::DECIMAL(15,2), LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+const LogicalType PromotionInfo::Types[] = {
+    LogicalType::INTEGER,        LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER,
+    LogicalType::DECIMAL(15, 2), LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
+    LogicalType::VARCHAR,        LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
+    LogicalType::VARCHAR,        LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
 
 const char *PromotionInfo::PrimaryKeyColumns[] = {"p_promo_sk"};
 
@@ -286,9 +456,11 @@ struct ShipModeInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *ShipModeInfo::Columns[] = {"sm_ship_mode_sk", "sm_ship_mode_id", "sm_type", "sm_code", "sm_carrier", "sm_contract"};
+const char *ShipModeInfo::Columns[] = {"sm_ship_mode_sk", "sm_ship_mode_id", "sm_type",
+                                       "sm_code",         "sm_carrier",      "sm_contract"};
 
-const LogicalType ShipModeInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+const LogicalType ShipModeInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR,
+                                           LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
 
 const char *ShipModeInfo::PrimaryKeyColumns[] = {"sm_ship_mode_sk"};
 
@@ -304,9 +476,23 @@ struct StoreInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *StoreInfo::Columns[] = {"s_store_sk", "s_store_id", "s_rec_start_date", "s_rec_end_date", "s_closed_date_sk", "s_store_name", "s_number_employees", "s_floor_space", "s_hours", "s_manager", "s_market_id", "s_geography_class", "s_market_desc", "s_market_manager", "s_division_id", "s_division_name", "s_company_id", "s_company_name", "s_street_number", "s_street_name", "s_street_type", "s_suite_number", "s_city", "s_county", "s_state", "s_zip", "s_country", "s_gmt_offset", "s_tax_precentage"};
+const char *StoreInfo::Columns[] = {
+    "s_store_sk",      "s_store_id",         "s_rec_start_date", "s_rec_end_date",   "s_closed_date_sk",
+    "s_store_name",    "s_number_employees", "s_floor_space",    "s_hours",          "s_manager",
+    "s_market_id",     "s_geography_class",  "s_market_desc",    "s_market_manager", "s_division_id",
+    "s_division_name", "s_company_id",       "s_company_name",   "s_street_number",  "s_street_name",
+    "s_street_type",   "s_suite_number",     "s_city",           "s_county",         "s_state",
+    "s_zip",           "s_country",          "s_gmt_offset",     "s_tax_precentage"};
 
-const LogicalType StoreInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::DATE, LogicalType::DATE, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DECIMAL(5,2), LogicalType::DECIMAL(5,2)};
+const LogicalType StoreInfo::Types[] = {
+    LogicalType::INTEGER,      LogicalType::VARCHAR, LogicalType::DATE,    LogicalType::DATE,
+    LogicalType::INTEGER,      LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER,
+    LogicalType::VARCHAR,      LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR,
+    LogicalType::VARCHAR,      LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR,
+    LogicalType::INTEGER,      LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
+    LogicalType::VARCHAR,      LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
+    LogicalType::VARCHAR,      LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DECIMAL(5, 2),
+    LogicalType::DECIMAL(5, 2)};
 
 const char *StoreInfo::PrimaryKeyColumns[] = {"s_store_sk"};
 
@@ -322,9 +508,18 @@ struct StoreReturnsInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *StoreReturnsInfo::Columns[] = {"sr_returned_date_sk", "sr_return_time_sk", "sr_item_sk", "sr_customer_sk", "sr_cdemo_sk", "sr_hdemo_sk", "sr_addr_sk", "sr_store_sk", "sr_reason_sk", "sr_ticket_number", "sr_return_quantity", "sr_return_amt", "sr_return_tax", "sr_return_amt_inc_tax", "sr_fee", "sr_return_ship_cost", "sr_refunded_cash", "sr_reversed_charge", "sr_store_credit", "sr_net_loss"};
+const char *StoreReturnsInfo::Columns[] = {
+    "sr_returned_date_sk", "sr_return_time_sk", "sr_item_sk",         "sr_customer_sk",        "sr_cdemo_sk",
+    "sr_hdemo_sk",         "sr_addr_sk",        "sr_store_sk",        "sr_reason_sk",          "sr_ticket_number",
+    "sr_return_quantity",  "sr_return_amt",     "sr_return_tax",      "sr_return_amt_inc_tax", "sr_fee",
+    "sr_return_ship_cost", "sr_refunded_cash",  "sr_reversed_charge", "sr_store_credit",       "sr_net_loss"};
 
-const LogicalType StoreReturnsInfo::Types[] = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2)};
+const LogicalType StoreReturnsInfo::Types[] = {
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::DECIMAL(7, 2),
+    LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2),
+    LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2)};
 
 const char *StoreReturnsInfo::PrimaryKeyColumns[] = {"sr_item_sk", "sr_ticket_number"};
 
@@ -340,9 +535,21 @@ struct StoreSalesInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *StoreSalesInfo::Columns[] = {"ss_sold_date_sk", "ss_sold_time_sk", "ss_item_sk", "ss_customer_sk", "ss_cdemo_sk", "ss_hdemo_sk", "ss_addr_sk", "ss_store_sk", "ss_promo_sk", "ss_ticket_number", "ss_quantity", "ss_wholesale_cost", "ss_list_price", "ss_sales_price", "ss_ext_discount_amt", "ss_ext_sales_price", "ss_ext_wholesale_cost", "ss_ext_list_price", "ss_ext_tax", "ss_coupon_amt", "ss_net_paid", "ss_net_paid_inc_tax", "ss_net_profit"};
+const char *StoreSalesInfo::Columns[] = {
+    "ss_sold_date_sk",       "ss_sold_time_sk",     "ss_item_sk",          "ss_customer_sk",
+    "ss_cdemo_sk",           "ss_hdemo_sk",         "ss_addr_sk",          "ss_store_sk",
+    "ss_promo_sk",           "ss_ticket_number",    "ss_quantity",         "ss_wholesale_cost",
+    "ss_list_price",         "ss_sales_price",      "ss_ext_discount_amt", "ss_ext_sales_price",
+    "ss_ext_wholesale_cost", "ss_ext_list_price",   "ss_ext_tax",          "ss_coupon_amt",
+    "ss_net_paid",           "ss_net_paid_inc_tax", "ss_net_profit"};
 
-const LogicalType StoreSalesInfo::Types[] = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2)};
+const LogicalType StoreSalesInfo::Types[] = {
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::DECIMAL(7, 2),
+    LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2),
+    LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2),
+    LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2)};
 
 const char *StoreSalesInfo::PrimaryKeyColumns[] = {"ss_item_sk", "ss_ticket_number"};
 
@@ -358,9 +565,12 @@ struct TimeDimInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *TimeDimInfo::Columns[] = {"t_time_sk", "t_time_id", "t_time", "t_hour", "t_minute", "t_second", "t_am_pm", "t_shift", "t_sub_shift", "t_meal_time"};
+const char *TimeDimInfo::Columns[] = {"t_time_sk", "t_time_id", "t_time",  "t_hour",      "t_minute",
+                                      "t_second",  "t_am_pm",   "t_shift", "t_sub_shift", "t_meal_time"};
 
-const LogicalType TimeDimInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+const LogicalType TimeDimInfo::Types[] = {
+    LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER,
+    LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
 
 const char *TimeDimInfo::PrimaryKeyColumns[] = {"t_time_sk"};
 
@@ -376,9 +586,15 @@ struct WarehouseInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *WarehouseInfo::Columns[] = {"w_warehouse_sk", "w_warehouse_id", "w_warehouse_name", "w_warehouse_sq_ft", "w_street_number", "w_street_name", "w_street_type", "w_suite_number", "w_city", "w_county", "w_state", "w_zip", "w_country", "w_gmt_offset"};
+const char *WarehouseInfo::Columns[] = {"w_warehouse_sk",  "w_warehouse_id", "w_warehouse_name", "w_warehouse_sq_ft",
+                                        "w_street_number", "w_street_name",  "w_street_type",    "w_suite_number",
+                                        "w_city",          "w_county",       "w_state",          "w_zip",
+                                        "w_country",       "w_gmt_offset"};
 
-const LogicalType WarehouseInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DECIMAL(5,2)};
+const LogicalType WarehouseInfo::Types[] = {
+    LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER,      LogicalType::VARCHAR,
+    LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,      LogicalType::VARCHAR,
+    LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DECIMAL(5, 2)};
 
 const char *WarehouseInfo::PrimaryKeyColumns[] = {"w_warehouse_sk"};
 
@@ -394,9 +610,15 @@ struct WebPageInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *WebPageInfo::Columns[] = {"wp_web_page_sk", "wp_web_page_id", "wp_rec_start_date", "wp_rec_end_date", "wp_creation_date_sk", "wp_access_date_sk", "wp_autogen_flag", "wp_customer_sk", "wp_url", "wp_type", "wp_char_count", "wp_link_count", "wp_image_count", "wp_max_ad_count"};
+const char *WebPageInfo::Columns[] = {
+    "wp_web_page_sk",    "wp_web_page_id",  "wp_rec_start_date", "wp_rec_end_date", "wp_creation_date_sk",
+    "wp_access_date_sk", "wp_autogen_flag", "wp_customer_sk",    "wp_url",          "wp_type",
+    "wp_char_count",     "wp_link_count",   "wp_image_count",    "wp_max_ad_count"};
 
-const LogicalType WebPageInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::DATE, LogicalType::DATE, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER};
+const LogicalType WebPageInfo::Types[] = {
+    LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::DATE,    LogicalType::DATE,    LogicalType::INTEGER,
+    LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR,
+    LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER};
 
 const char *WebPageInfo::PrimaryKeyColumns[] = {"wp_web_page_sk"};
 
@@ -412,9 +634,38 @@ struct WebReturnsInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *WebReturnsInfo::Columns[] = {"wr_returned_date_sk", "wr_returned_time_sk", "wr_item_sk", "wr_refunded_customer_sk", "wr_refunded_cdemo_sk", "wr_refunded_hdemo_sk", "wr_refunded_addr_sk", "wr_returning_customer_sk", "wr_returning_cdemo_sk", "wr_returning_hdemo_sk", "wr_returning_addr_sk", "wr_web_page_sk", "wr_reason_sk", "wr_order_number", "wr_return_quantity", "wr_return_amt", "wr_return_tax", "wr_return_amt_inc_tax", "wr_fee", "wr_return_ship_cost", "wr_refunded_cash", "wr_reversed_charge", "wr_account_credit", "wr_net_loss"};
+const char *WebReturnsInfo::Columns[] = {"wr_returned_date_sk",
+                                         "wr_returned_time_sk",
+                                         "wr_item_sk",
+                                         "wr_refunded_customer_sk",
+                                         "wr_refunded_cdemo_sk",
+                                         "wr_refunded_hdemo_sk",
+                                         "wr_refunded_addr_sk",
+                                         "wr_returning_customer_sk",
+                                         "wr_returning_cdemo_sk",
+                                         "wr_returning_hdemo_sk",
+                                         "wr_returning_addr_sk",
+                                         "wr_web_page_sk",
+                                         "wr_reason_sk",
+                                         "wr_order_number",
+                                         "wr_return_quantity",
+                                         "wr_return_amt",
+                                         "wr_return_tax",
+                                         "wr_return_amt_inc_tax",
+                                         "wr_fee",
+                                         "wr_return_ship_cost",
+                                         "wr_refunded_cash",
+                                         "wr_reversed_charge",
+                                         "wr_account_credit",
+                                         "wr_net_loss"};
 
-const LogicalType WebReturnsInfo::Types[] = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2)};
+const LogicalType WebReturnsInfo::Types[] = {
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::DECIMAL(7, 2),
+    LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2),
+    LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2)};
 
 const char *WebReturnsInfo::PrimaryKeyColumns[] = {"wr_item_sk", "wr_order_number"};
 
@@ -430,9 +681,51 @@ struct WebSalesInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *WebSalesInfo::Columns[] = {"ws_sold_date_sk", "ws_sold_time_sk", "ws_ship_date_sk", "ws_item_sk", "ws_bill_customer_sk", "ws_bill_cdemo_sk", "ws_bill_hdemo_sk", "ws_bill_addr_sk", "ws_ship_customer_sk", "ws_ship_cdemo_sk", "ws_ship_hdemo_sk", "ws_ship_addr_sk", "ws_web_page_sk", "ws_web_site_sk", "ws_ship_mode_sk", "ws_warehouse_sk", "ws_promo_sk", "ws_order_number", "ws_quantity", "ws_wholesale_cost", "ws_list_price", "ws_sales_price", "ws_ext_discount_amt", "ws_ext_sales_price", "ws_ext_wholesale_cost", "ws_ext_list_price", "ws_ext_tax", "ws_coupon_amt", "ws_ext_ship_cost", "ws_net_paid", "ws_net_paid_inc_tax", "ws_net_paid_inc_ship", "ws_net_paid_inc_ship_tax", "ws_net_profit"};
+const char *WebSalesInfo::Columns[] = {"ws_sold_date_sk",
+                                       "ws_sold_time_sk",
+                                       "ws_ship_date_sk",
+                                       "ws_item_sk",
+                                       "ws_bill_customer_sk",
+                                       "ws_bill_cdemo_sk",
+                                       "ws_bill_hdemo_sk",
+                                       "ws_bill_addr_sk",
+                                       "ws_ship_customer_sk",
+                                       "ws_ship_cdemo_sk",
+                                       "ws_ship_hdemo_sk",
+                                       "ws_ship_addr_sk",
+                                       "ws_web_page_sk",
+                                       "ws_web_site_sk",
+                                       "ws_ship_mode_sk",
+                                       "ws_warehouse_sk",
+                                       "ws_promo_sk",
+                                       "ws_order_number",
+                                       "ws_quantity",
+                                       "ws_wholesale_cost",
+                                       "ws_list_price",
+                                       "ws_sales_price",
+                                       "ws_ext_discount_amt",
+                                       "ws_ext_sales_price",
+                                       "ws_ext_wholesale_cost",
+                                       "ws_ext_list_price",
+                                       "ws_ext_tax",
+                                       "ws_coupon_amt",
+                                       "ws_ext_ship_cost",
+                                       "ws_net_paid",
+                                       "ws_net_paid_inc_tax",
+                                       "ws_net_paid_inc_ship",
+                                       "ws_net_paid_inc_ship_tax",
+                                       "ws_net_profit"};
 
-const LogicalType WebSalesInfo::Types[] = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2), LogicalType::DECIMAL(7,2)};
+const LogicalType WebSalesInfo::Types[] = {
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,
+    LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::INTEGER,       LogicalType::DECIMAL(7, 2),
+    LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2),
+    LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2),
+    LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2),
+    LogicalType::DECIMAL(7, 2), LogicalType::DECIMAL(7, 2)};
 
 const char *WebSalesInfo::PrimaryKeyColumns[] = {"ws_item_sk", "ws_order_number"};
 
@@ -448,11 +741,25 @@ struct WebSiteInfo {
 	static const char *PrimaryKeyColumns[];
 };
 
-const char *WebSiteInfo::Columns[] = {"web_site_sk", "web_site_id", "web_rec_start_date", "web_rec_end_date", "web_name", "web_open_date_sk", "web_close_date_sk", "web_class", "web_manager", "web_mkt_id", "web_mkt_class", "web_mkt_desc", "web_market_manager", "web_company_id", "web_company_name", "web_street_number", "web_street_name", "web_street_type", "web_suite_number", "web_city", "web_county", "web_state", "web_zip", "web_country", "web_gmt_offset", "web_tax_percentage"};
+const char *WebSiteInfo::Columns[] = {"web_site_sk",        "web_site_id",       "web_rec_start_date",
+                                      "web_rec_end_date",   "web_name",          "web_open_date_sk",
+                                      "web_close_date_sk",  "web_class",         "web_manager",
+                                      "web_mkt_id",         "web_mkt_class",     "web_mkt_desc",
+                                      "web_market_manager", "web_company_id",    "web_company_name",
+                                      "web_street_number",  "web_street_name",   "web_street_type",
+                                      "web_suite_number",   "web_city",          "web_county",
+                                      "web_state",          "web_zip",           "web_country",
+                                      "web_gmt_offset",     "web_tax_percentage"};
 
-const LogicalType WebSiteInfo::Types[] = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::DATE, LogicalType::DATE, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DECIMAL(5,2), LogicalType::DECIMAL(5,2)};
+const LogicalType WebSiteInfo::Types[] = {
+    LogicalType::INTEGER,       LogicalType::VARCHAR,      LogicalType::DATE,    LogicalType::DATE,
+    LogicalType::VARCHAR,       LogicalType::INTEGER,      LogicalType::INTEGER, LogicalType::VARCHAR,
+    LogicalType::VARCHAR,       LogicalType::INTEGER,      LogicalType::VARCHAR, LogicalType::VARCHAR,
+    LogicalType::VARCHAR,       LogicalType::INTEGER,      LogicalType::VARCHAR, LogicalType::VARCHAR,
+    LogicalType::VARCHAR,       LogicalType::VARCHAR,      LogicalType::VARCHAR, LogicalType::VARCHAR,
+    LogicalType::VARCHAR,       LogicalType::VARCHAR,      LogicalType::VARCHAR, LogicalType::VARCHAR,
+    LogicalType::DECIMAL(5, 2), LogicalType::DECIMAL(5, 2)};
 
 const char *WebSiteInfo::PrimaryKeyColumns[] = {"web_site_sk"};
 
-}
-
+} // namespace tpcds

--- a/scripts/generate_csv_header.py
+++ b/scripts/generate_csv_header.py
@@ -67,7 +67,6 @@ create_tpch_header(tpch_dir)
 # ------------------------------------------- #
 tpcds_dir = 'extension/tpcds/dsdgen'
 tpcds_queries = os.path.join(tpcds_dir, 'queries')
-tpcds_schema = os.path.join(tpcds_dir, 'schema')
 tpcds_answers_sf001 = os.path.join(tpcds_dir, 'answers', 'sf0.01')
 tpcds_answers_sf1 = os.path.join(tpcds_dir, 'answers', 'sf1')
 tpcds_header = os.path.join(tpcds_dir, 'include', 'tpcds_constants.hpp')
@@ -84,7 +83,6 @@ const int TPCDS_TABLE_COUNT = 24;
 	result += write_dir(tpcds_queries, "TPCDS_QUERIES")
 	result += write_dir(tpcds_answers_sf001, "TPCDS_ANSWERS_SF0_01")
 	result += write_dir(tpcds_answers_sf1, "TPCDS_ANSWERS_SF1")
-	result += write_dir(tpcds_schema, "TPCDS_TABLE_DDL_NOKEYS")
 
 	with open_utf8(tpcds_header, 'w+') as f:
 		f.write(result)

--- a/scripts/generate_tpcds_schema.py
+++ b/scripts/generate_tpcds_schema.py
@@ -1,0 +1,105 @@
+import os
+import subprocess
+
+duckdb_program = '/Users/myth/Programs/duckdb-bugfix/build/release/duckdb'
+
+struct_def = '''struct $STRUCT_NAME {
+	static constexpr char *Name = "$NAME";
+	static const char *Columns[];
+	static constexpr idx_t ColumnCount = $COLUMN_COUNT;
+	static const LogicalType Types[];
+	static constexpr idx_t PrimaryKeyCount = $PK_COLUMN_COUNT;
+	static const char *PrimaryKeyColumns[];
+};
+'''
+
+initcode = '''
+call dsdgen(sf=0);
+.mode csv
+.header 0
+'''
+
+column_count_query = '''
+select count(*) from pragma_table_info('$NAME');
+'''
+
+pk_column_count_query = '''
+select count(*) from pragma_table_info('$NAME') where pk=true;
+'''
+
+gen_names = '''
+select concat('const char *', '$STRUCT_NAME', '::Columns[] = {', STRING_AGG('"' || name || '"', ', ') || '};') from pragma_table_info('$NAME');
+'''
+
+gen_types = '''
+select concat('const LogicalType ', '$STRUCT_NAME', '::Types[] = {', STRING_AGG('LogicalType::' || type, ', ') || '};') from pragma_table_info('$NAME');
+'''
+
+pk_columns = '''
+select concat('const char *', '$STRUCT_NAME', '::PrimaryKeyColumns[] = {', STRING_AGG('"' || name || '"', ', ') || '};') from pragma_table_info('$NAME') where pk=true;
+'''
+
+def run_query(sql):
+	input_sql = initcode + '\n' + sql
+	res = subprocess.run(duckdb_program, input=input_sql.encode('utf8'), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+	stdout = res.stdout.decode('utf8').strip()
+	stderr = res.stderr.decode('utf8').strip()
+	if res.returncode != 0:
+		print("FAILED TO RUN QUERY")
+		print(stderr)
+		exit(1)
+	return stdout
+
+def prepare_query(sql, table_name, struct_name):
+	return sql.replace('$NAME', table_name).replace('$STRUCT_NAME', struct_name)
+
+header = '''
+#pragma once
+
+#include "duckdb.hpp"
+
+#ifndef DUCKDB_AMALGAMATION
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/date.hpp"
+#include "duckdb/parser/column_definition.hpp"
+#include "duckdb/storage/data_table.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
+#include "duckdb/parser/parsed_data/create_table_info.hpp"
+#include "duckdb/parser/constraints/not_null_constraint.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/planner/binder.hpp"
+#endif
+
+namespace tpcds {
+
+using duckdb::LogicalType;
+using duckdb::idx_t;
+'''
+
+footer = '''
+}
+'''
+
+print(header)
+
+table_list = run_query('show tables')
+for table_name in table_list.split('\n'):
+	table_name = table_name.strip()
+	print('''
+//===--------------------------------------------------------------------===//
+// $NAME
+//===--------------------------------------------------------------------===//'''.replace('$NAME', table_name))
+	struct_name = str(table_name.title().replace('_', '')) + 'Info'
+	column_count = int(run_query(prepare_query(column_count_query, table_name, struct_name)).strip())
+	pk_column_count = int(run_query(prepare_query(pk_column_count_query, table_name, struct_name)).strip())
+	print(prepare_query(struct_def, table_name, struct_name).replace('$COLUMN_COUNT', str(column_count)).replace('$PK_COLUMN_COUNT', str(pk_column_count)))
+
+	print(run_query(prepare_query(gen_names, table_name, struct_name)).replace('""', '"').strip('"'))
+	print("")
+	print(run_query(prepare_query(gen_types, table_name, struct_name)).strip('"'))
+	print("")
+	print(run_query(prepare_query(pk_columns, table_name, struct_name)).replace('""', '"').strip('"'))
+
+print(footer)

--- a/src/execution/physical_plan/plan_comparison_join.cpp
+++ b/src/execution/physical_plan/plan_comparison_join.cpp
@@ -122,6 +122,9 @@ void TransformIndexJoin(ClientContext &context, LogicalComparisonJoin &op, Index
 			auto tbl = dynamic_cast<TableScanBindData *>(tbl_scan.bind_data.get());
 			if (CanPlanIndexJoin(transaction, tbl, tbl_scan)) {
 				tbl->table->storage->info->indexes.Scan([&](Index &index) {
+					if (index.unbound_expressions.size() > 1) {
+						return false;
+					}
 					if (index.unbound_expressions[0]->alias == op.conditions[0].left->alias) {
 						*left_index = &index;
 						return true;
@@ -135,6 +138,9 @@ void TransformIndexJoin(ClientContext &context, LogicalComparisonJoin &op, Index
 			auto tbl = dynamic_cast<TableScanBindData *>(tbl_scan.bind_data.get());
 			if (CanPlanIndexJoin(transaction, tbl, tbl_scan)) {
 				tbl->table->storage->info->indexes.Scan([&](Index &index) {
+					if (index.unbound_expressions.size() > 1) {
+						return false;
+					}
 					if (index.unbound_expressions[0]->alias == op.conditions[0].right->alias) {
 						*right_index = &index;
 						return true;

--- a/src/execution/physical_plan/plan_comparison_join.cpp
+++ b/src/execution/physical_plan/plan_comparison_join.cpp
@@ -115,7 +115,7 @@ static void CanUseIndexJoin(TableScanBindData *tbl, Expression &expr, Index **re
 		if (index.unbound_expressions.size() != 1) {
 			return false;
 		}
-		if (expr.Equals(index.unbound_expressions[0].get())) {
+		if (expr.alias == index.unbound_expressions[0]->alias) {
 			*result_index = &index;
 			return true;
 		}

--- a/test/sql/index/art/test_multi_dimensional_index_join.test
+++ b/test/sql/index/art/test_multi_dimensional_index_join.test
@@ -1,4 +1,4 @@
-# name: test/sql/index/art/test_art_index_join.test
+# name: test/sql/index/art/test_multi_dimensional_index_join.test
 # description: ART Join
 # group: [art]
 

--- a/test/sql/index/art/test_multi_dimensional_index_join.test
+++ b/test/sql/index/art/test_multi_dimensional_index_join.test
@@ -1,0 +1,54 @@
+# name: test/sql/index/art/test_art_index_join.test
+# description: ART Join
+# group: [art]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE Person (id bigint, k int, PRIMARY KEY (id, k));
+
+statement ok
+CREATE TABLE Person_knows_Person (Person1id bigint, Person2id bigint);
+
+statement ok
+INSERT INTO Person VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5);
+
+statement ok
+INSERT INTO Person_knows_Person VALUES (1, 2), (1, 3), (1, 4), (2, 3), (3, 4), (4, 5);
+
+statement ok
+PRAGMA force_index_join;
+
+query II
+SELECT p1.id,p2.id
+FROM Person_knows_Person pkp
+JOIN Person p1
+  ON p1.id = pkp.Person1id
+JOIN Person p2
+  ON p2.id = pkp.Person2id
+ORDER BY 1, 2;
+----
+1	2
+1	3
+1	4
+2	3
+3	4
+4	5
+
+
+query II
+SELECT p1.id,p2.id
+FROM Person p1
+JOIN Person_knows_Person pkp
+  ON p1.id = pkp.Person1id
+JOIN Person p2
+  ON p2.id = pkp.Person2id
+ORDER BY 1, 2;
+----
+1	2
+1	3
+1	4
+2	3
+3	4
+4	5

--- a/test/sql/tpcds/tpcds_options.test_slow
+++ b/test/sql/tpcds/tpcds_options.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/tpcds/tpcds_options.test
+# name: test/sql/tpcds/tpcds_options.test_slow
 # description: Test TPC-DS data generation options
 # group: [tpcds]
 

--- a/test/sql/tpcds/tpcds_options.test_slow
+++ b/test/sql/tpcds/tpcds_options.test_slow
@@ -1,0 +1,32 @@
+# name: test/sql/tpcds/tpcds_options.test
+# description: Test TPC-DS data generation options
+# group: [tpcds]
+
+require tpcds
+
+statement ok
+CALL dsdgen(sf=0)
+
+# tables already exist
+statement error
+CALL dsdgen(sf=0)
+
+# overwrite should work
+statement ok
+CALL dsdgen(sf=0, overwrite=true)
+
+# suffix
+statement ok
+CALL dsdgen(sf=0.01, suffix='_bla')
+
+statement ok
+SELECT COUNT(*) FROM call_center_bla
+
+statement ok
+create schema tpcds
+
+statement ok
+CALL dsdgen(sf=0.01, schema='tpcds')
+
+statement ok
+SELECT COUNT(*) FROM tpcds.call_center

--- a/test/sql/tpcds/tpcds_sf001_keys.test_slow
+++ b/test/sql/tpcds/tpcds_sf001_keys.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/tpcds/tpcds_sf001.test_slow
+# name: test/sql/tpcds/tpcds_sf001_keys.test_slow
 # description: Test TPC-DS SF0.001
 # group: [tpcds]
 

--- a/test/sql/tpcds/tpcds_sf001_keys.test_slow
+++ b/test/sql/tpcds/tpcds_sf001_keys.test_slow
@@ -1,0 +1,152 @@
+# name: test/sql/tpcds/tpcds_sf001.test_slow
+# description: Test TPC-DS SF0.001
+# group: [tpcds]
+
+require tpcds
+
+# answers are generated from postgres
+# hence check with NULLS LAST flag
+statement ok
+PRAGMA default_null_order='NULLS LAST'
+
+statement ok
+CALL dsdgen(sf=0.01, keys=true)
+
+query T
+SELECT COUNT(*) FROM call_center
+----
+1
+
+query T
+SELECT COUNT(*) FROM catalog_page
+----
+11718
+
+query T
+SELECT COUNT(*) FROM catalog_returns
+----
+1358
+
+query T
+SELECT COUNT(*) FROM catalog_sales
+----
+14313
+
+query T
+SELECT COUNT(*) FROM customer
+----
+1000
+
+query T
+SELECT COUNT(*) FROM customer_demographics
+----
+19208
+
+query T
+SELECT COUNT(*) FROM customer_address
+----
+500
+
+query T
+SELECT COUNT(*) FROM date_dim
+----
+73049
+
+query T
+SELECT COUNT(*) FROM household_demographics
+----
+7200
+
+query T
+SELECT COUNT(*) FROM inventory
+----
+23490
+
+query T
+SELECT COUNT(*) FROM income_band
+----
+20
+
+query T
+SELECT COUNT(*) FROM item
+----
+180
+
+query T
+SELECT COUNT(*) FROM promotion
+----
+3
+
+query T
+SELECT COUNT(*) FROM reason
+----
+1
+
+query T
+SELECT COUNT(*) FROM ship_mode
+----
+20
+
+query T
+SELECT COUNT(*) FROM store
+----
+1
+
+query T
+SELECT COUNT(*) FROM store_returns
+----
+2810
+
+query T
+SELECT COUNT(*) FROM store_sales
+----
+28810
+
+query T
+SELECT COUNT(*) FROM time_dim
+----
+86400
+
+query T
+SELECT COUNT(*) FROM warehouse
+----
+1
+
+query T
+SELECT COUNT(*) FROM web_page
+----
+1
+
+query T
+SELECT COUNT(*) FROM web_returns
+----
+679
+
+query T
+SELECT COUNT(*) FROM web_sales
+----
+7212
+
+query T
+SELECT COUNT(*) FROM web_site
+----
+1
+
+loop i 1 9
+
+query I
+PRAGMA tpcds(${i})
+----
+<FILE>:extension/tpcds/dsdgen/answers/sf0.01/0${i}.csv
+
+endloop
+
+loop i 10 99
+
+query I
+PRAGMA tpcds(${i})
+----
+<FILE>:extension/tpcds/dsdgen/answers/sf0.01/${i}.csv
+
+endloop
+


### PR DESCRIPTION
This PR cleans up the TPC-DS extension so `dsdgen` is implemented in a similar manner to `dbgen`. The extension now correctly executes within the transaction of the client calling `dsdgen`, and dsdgen has been extended to support the following additional options:

```
suffix VARCHAR
schema VARCHAR
keys BOOLEAN
overwrite BOOLEAN
```

Setting `keys=true` generates the extension with primary key constraints, which lead to issue #2315 as the optimizer incorrectly chose to use an index join when the index did not permit this (as the index was a multi-column index, and the index join only handles single-column indexes currently).