### PR TITLE
Change SET's default scope from GLOBAL to (PG-compatible) SESSION.

### DIFF
--- a/src/parser/transform/statement/transform_set.cpp
+++ b/src/parser/transform/statement/transform_set.cpp
@@ -15,8 +15,7 @@ SetScope ToSetScope(duckdb_libpgquery::VariableSetScope pg_scope) {
 	case duckdb_libpgquery::VariableSetScope::VAR_SET_SCOPE_GLOBAL:
 		return SetScope::GLOBAL;
 	case duckdb_libpgquery::VariableSetScope::VAR_SET_SCOPE_DEFAULT:
-		// FIXME: This should be SESSION. See https://github.com/duckdb/duckdb/pull/2247
-		return SetScope::GLOBAL;
+		return SetScope::SESSION;
 	default:
 		throw InternalException("Unexpected pg_scope: %d", pg_scope);
 	}

--- a/test/sql/function/generic/test_set_connections.test
+++ b/test/sql/function/generic/test_set_connections.test
@@ -55,12 +55,16 @@ SELECT CURRENT_SETTING('b');
 ----
 43
 
-# Currently the default scope is GLOBAL,
-# but it should be SESSION. See https://github.com/duckdb/duckdb/pull/2247
+# Default (SESSION) scoping
 statement ok con1
 SET c = 42;
 
-query I con2
+query I con1
+SELECT CURRENT_SETTING('c');
+----
+42
+
+statement error
 SELECT CURRENT_SETTING('c');
 ----
 42


### PR DESCRIPTION
This is a follow up of #2284. With it, we no longer have to worry
about the session-scoped SET parameter can break S3FS usage.