### PR TITLE
Issue #1998: Exact Timestamp Subtraction

### DIFF
--- a/src/common/types/interval.cpp
+++ b/src/common/types/interval.cpp
@@ -277,7 +277,7 @@ int64_t Interval::GetNanoseconds(interval_t val) {
 
 	return nano;
 }
-interval_t Interval::GetDifference(timestamp_t timestamp_1, timestamp_t timestamp_2) {
+interval_t Interval::GetAge(timestamp_t timestamp_1, timestamp_t timestamp_2) {
 	date_t date1, date2;
 	dtime_t time1, time2;
 
@@ -364,6 +364,18 @@ interval_t Interval::GetDifference(timestamp_t timestamp_1, timestamp_t timestam
 	interval.micros = Time::FromTime(hour_diff, min_diff, sec_diff, micros_diff).micros;
 
 	return interval;
+}
+interval_t Interval::GetDifference(timestamp_t timestamp_1, timestamp_t timestamp_2) {
+	const auto us_1 = Timestamp::GetEpochMicroSeconds(timestamp_1);
+	const auto us_2 = Timestamp::GetEpochMicroSeconds(timestamp_2);
+	const auto delta_us = us_1 - us_2;
+
+	interval_t result;
+	result.months = 0;
+	result.days = delta_us / Interval::MICROS_PER_DAY;
+	result.micros = delta_us % Interval::MICROS_PER_DAY;
+
+	return result;
 }
 
 static void NormalizeIntervalEntries(interval_t input, int64_t &months, int64_t &days, int64_t &micros) {

--- a/src/function/scalar/date/age.cpp
+++ b/src/function/scalar/date/age.cpp
@@ -13,7 +13,7 @@ static void AgeFunctionStandard(DataChunk &input, ExpressionState &state, Vector
 	auto current_timestamp = Timestamp::GetCurrentTimestamp();
 
 	UnaryExecutor::Execute<timestamp_t, interval_t>(input.data[0], result, input.size(), [&](timestamp_t input) {
-		return Interval::GetDifference(current_timestamp, input);
+		return Interval::GetAge(current_timestamp, input);
 	});
 }
 
@@ -22,7 +22,7 @@ static void AgeFunction(DataChunk &input, ExpressionState &state, Vector &result
 
 	BinaryExecutor::Execute<timestamp_t, timestamp_t, interval_t>(
 	    input.data[0], input.data[1], result, input.size(),
-	    [&](timestamp_t input1, timestamp_t input2) { return Interval::GetDifference(input1, input2); });
+	    [&](timestamp_t input1, timestamp_t input2) { return Interval::GetAge(input1, input2); });
 }
 
 void AgeFun::RegisterFunction(BuiltinFunctions &set) {

--- a/src/function/scalar/date/date_sub.cpp
+++ b/src/function/scalar/date/date_sub.cpp
@@ -44,7 +44,7 @@ struct DateSub {
 			// Our interval difference will now give the correct result.
 			// Note that PG gives different interval subtraction results,
 			// so if we change this we will have to reimplement.
-			return Interval::GetDifference(end_ts, start_ts).months;
+			return Interval::GetAge(end_ts, start_ts).months;
 		}
 	};
 

--- a/src/include/duckdb/common/types/interval.hpp
+++ b/src/include/duckdb/common/types/interval.hpp
@@ -62,7 +62,10 @@ public:
 	//! Get Interval in Nanoseconds
 	static int64_t GetNanoseconds(interval_t val);
 
-	//! Returns the difference between two timestamps
+	//! Returns the age between two timestamps (including 30 day months)
+	static interval_t GetAge(timestamp_t timestamp_1, timestamp_t timestamp_2);
+
+	//! Returns the exact difference between two timestamps (days and seconds)
 	static interval_t GetDifference(timestamp_t timestamp_1, timestamp_t timestamp_2);
 
 	//! Comparison operators

--- a/test/sql/function/timestamp/age.test
+++ b/test/sql/function/timestamp/age.test
@@ -96,9 +96,9 @@ NULL
 query T
 SELECT t1 - t2 FROM timestamp;
 ----
-43 years 9 months 27 days
+16007 days
 8 days
-3 months 24 days
+114 days
 00:00:00
 NULL
 NULL

--- a/test/sql/types/interval/test_interval_addition.test
+++ b/test/sql/types/interval/test_interval_addition.test
@@ -251,5 +251,25 @@ SELECT TIMESTAMP '1992-01-01 10:00:00' - INTERVAL '1' DAY
 query T
 select timestamp '1993-01-01 00:00:00' - timestamp '1991-01-01 01:00:30';
 ----
-1 year 11 months 30 days 22:59:30
+730 days 22:59:30
 
+statement ok
+CREATE TABLE issue1998(id INTEGER, lhs TIMESTAMP, rhs TIMESTAMP);
+
+statement ok
+INSERT INTO issue1998 VALUES
+	(0, '2020-07-07 02:01:01', '2020-08-05 07:51:47'),
+	(1, '2020-02-08 19:26:38', '2020-09-21 10:02:28'),
+	(2, '2020-06-19 20:45:41', '2020-01-04 05:44:42'),
+	(3, '2020-11-18 18:22:26', '2020-06-14 02:46:55'),
+	(4, '2020-08-24 03:31:52', '2020-07-05 19:04:34')
+
+
+query II
+SELECT id, lhs - rhs FROM issue1998 ORDER BY 1
+----
+0	-29 days -05:50:46
+1	-225 days -14:35:50
+2	167 days 15:00:59
+3	157 days 15:35:31
+4	49 days 08:27:18


### PR DESCRIPTION
Match Postgres' TIMESTAMP semantics by returning
only day and microsecond parts.