### PR TITLE
Avoid re-using RE2 regex between threads, since RE2 regex objects have locks internally

### DIFF
--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -5,12 +5,15 @@ namespace duckdb {
 
 unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundFunctionExpression &expr,
                                                                 ExpressionExecutorState &root) {
-	auto result = make_unique<ExpressionState>(expr, root);
+	auto result = make_unique<ExecuteFunctionState>(expr, root);
 	for (auto &child : expr.children) {
 		result->AddChild(child.get());
 	}
 	result->Finalize();
-	return result;
+	if (expr.function.init_local_state) {
+		result->local_state = expr.function.init_local_state(expr, expr.bind_info.get());
+	}
+	return move(result);
 }
 
 void ExpressionExecutor::Execute(const BoundFunctionExpression &expr, ExpressionState *state,

--- a/src/function/scalar/generic/least.cpp
+++ b/src/function/scalar/generic/least.cpp
@@ -98,20 +98,20 @@ template <class OP>
 static void RegisterLeastGreatest(BuiltinFunctions &set, const string &fun_name) {
 	ScalarFunctionSet fun_set(fun_name);
 	fun_set.AddFunction(ScalarFunction({LogicalType::DATE}, LogicalType::DATE, LeastGreatestFunction<date_t, OP>, false,
-	                                   nullptr, nullptr, nullptr, LogicalType::DATE));
+	                                   nullptr, nullptr, nullptr, nullptr, LogicalType::DATE));
 	fun_set.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::TIMESTAMP,
 	                                   LeastGreatestFunction<timestamp_t, OP>, false, nullptr, nullptr, nullptr,
-	                                   LogicalType::TIMESTAMP));
+	                                   nullptr, LogicalType::TIMESTAMP));
 	fun_set.AddFunction(ScalarFunction({LogicalType::BIGINT}, LogicalType::BIGINT, LeastGreatestFunction<int64_t, OP>,
-	                                   false, nullptr, nullptr, nullptr, LogicalType::BIGINT));
+	                                   false, nullptr, nullptr, nullptr, nullptr, LogicalType::BIGINT));
 	fun_set.AddFunction(ScalarFunction({LogicalType::HUGEINT}, LogicalType::HUGEINT,
-	                                   LeastGreatestFunction<hugeint_t, OP>, false, nullptr, nullptr, nullptr,
+	                                   LeastGreatestFunction<hugeint_t, OP>, false, nullptr, nullptr, nullptr, nullptr,
 	                                   LogicalType::HUGEINT));
 	fun_set.AddFunction(ScalarFunction({LogicalType::DOUBLE}, LogicalType::DOUBLE, LeastGreatestFunction<double, OP>,
-	                                   false, nullptr, nullptr, nullptr, LogicalType::DOUBLE));
+	                                   false, nullptr, nullptr, nullptr, nullptr, LogicalType::DOUBLE));
 	fun_set.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR,
 	                                   LeastGreatestFunction<string_t, OP, true>, false, nullptr, nullptr, nullptr,
-	                                   LogicalType::VARCHAR));
+	                                   nullptr, LogicalType::VARCHAR));
 	set.AddFunction(fun_set);
 }
 

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -91,7 +91,7 @@ struct RegexFullMatch {
 };
 
 struct RegexLocalState : public FunctionData {
-	RegexLocalState(RegexpMatchesBindData &info)
+	explicit RegexLocalState(RegexpMatchesBindData &info)
 	    : constant_pattern(duckdb_re2::StringPiece(info.constant_string.c_str(), info.constant_string.size()),
 	                       info.options) {
 		D_ASSERT(info.constant_pattern);

--- a/src/include/duckdb/execution/expression_executor_state.hpp
+++ b/src/include/duckdb/execution/expression_executor_state.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/cycle_counter.hpp"
 #include "duckdb/common/random_engine.hpp"
+#include "duckdb/function/function.hpp"
 
 namespace duckdb {
 class Expression;
@@ -34,6 +35,18 @@ struct ExpressionState {
 public:
 	void AddChild(Expression *expr);
 	void Finalize();
+};
+
+struct ExecuteFunctionState : public ExpressionState {
+	ExecuteFunctionState(const Expression &expr, ExpressionExecutorState &root) : ExpressionState(expr, root) {
+	}
+
+	unique_ptr<FunctionData> local_state;
+
+public:
+	static FunctionData *GetFunctionState(ExpressionState &state) {
+		return ((ExecuteFunctionState &)state).local_state.get();
+	}
 };
 
 struct ExpressionExecutorState {

--- a/src/include/duckdb/function/scalar/regexp.hpp
+++ b/src/include/duckdb/function/scalar/regexp.hpp
@@ -19,7 +19,7 @@ struct RegexpMatchesBindData : public FunctionData {
 
 	duckdb_re2::RE2::Options options;
 	string constant_string;
-	std::unique_ptr<duckdb_re2::RE2> constant_pattern;
+	bool constant_pattern;
 	string range_min;
 	string range_max;
 	bool range_success;


### PR DESCRIPTION
This greatly improves performance of regex functions in the presence of multiple threads:


```sql
select count(*) from lineitem where l_shipinstruct SIMILAR TO '.*DE.*I.*ER.*';
```

| Branch | 1 Thread | 4 Threads |
|--------|----------|-----------|
| Old    | 0.64s    | 1.26s     |
| New    | 0.64s    | 0.2s     |