### PR TITLE
Fixes minor flag comment

### DIFF
--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -84,7 +84,7 @@ class FileFlags {
 public:
 	//! Open file with read access
 	static constexpr uint8_t FILE_FLAGS_READ = 1 << 0;
-	//! Open file with read/write access
+	//! Open file with write access
 	static constexpr uint8_t FILE_FLAGS_WRITE = 1 << 1;
 	//! Use direct IO when reading/writing to the file
 	static constexpr uint8_t FILE_FLAGS_DIRECT_IO = 1 << 2;


### PR DESCRIPTION
`FILE_FLAGS_WRITE` is no longer read/write since 2548dce98b5d309064597d64b285de5faf2acc53.