### PR TITLE
Fix unsafe index overwrites

### DIFF
--- a/tools/pythonpkg/src/vector_conversion.cpp
+++ b/tools/pythonpkg/src/vector_conversion.cpp
@@ -302,7 +302,7 @@ static void ConvertPandasType(const string &col_type, LogicalType &duckdb_col_ty
 
 void VectorConversion::BindPandas(py::handle df, vector<PandasColumnBindData> &bind_columns,
                                   vector<LogicalType> &return_types, vector<string> &names) {
-	auto df_columns = py::list(df.attr("columns"));
+	auto df_columns = py::array(df.attr("columns"));
 	auto df_types = py::list(df.attr("dtypes"));
 	auto get_fun = df.attr("__getitem__");
 	// TODO support masked arrays as well

--- a/tools/pythonpkg/src/vector_conversion.cpp
+++ b/tools/pythonpkg/src/vector_conversion.cpp
@@ -313,7 +313,6 @@ void VectorConversion::BindPandas(py::handle df, vector<PandasColumnBindData> &b
 
 	// check if names in pandas dataframe are unique
 	unordered_map<string, idx_t> pandas_column_names_map;
-	py::array column_attributes = df.attr("columns").attr("values");
 	for (idx_t col_idx = 0; col_idx < py::len(df_columns); col_idx++) {
 		auto column_name_py = py::str(df_columns[col_idx]);
 		pandas_column_names_map[column_name_py]++;
@@ -323,12 +322,13 @@ void VectorConversion::BindPandas(py::handle df, vector<PandasColumnBindData> &b
 			column_name += "_" + to_string(pandas_column_names_map[column_name_py] - 1);
 			auto new_column_name_py = py::str(column_name);
 			names.emplace_back(new_column_name_py);
-			column_attributes[py::cast(col_idx)] = new_column_name_py;
+			df_columns[py::cast(col_idx)] = column_name;
 			pandas_column_names_map[new_column_name_py]++;
 		} else {
 			names.emplace_back(column_name_py);
 		}
 	}
+	df.attr("columns") = df_columns;
 
 	for (idx_t col_idx = 0; col_idx < py::len(df_columns); col_idx++) {
 		LogicalType duckdb_col_type;

--- a/tools/pythonpkg/src/vector_conversion.cpp
+++ b/tools/pythonpkg/src/vector_conversion.cpp
@@ -322,7 +322,7 @@ void VectorConversion::BindPandas(py::handle df, vector<PandasColumnBindData> &b
 			column_name += "_" + to_string(pandas_column_names_map[column_name_py] - 1);
 			auto new_column_name_py = py::str(column_name);
 			names.emplace_back(new_column_name_py);
-			df_columns[py::cast(col_idx)] = column_name;
+			df_columns[py::cast(col_idx)] = new_column_name_py;
 			pandas_column_names_map[new_column_name_py]++;
 		} else {
 			names.emplace_back(column_name_py);


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/2363

The issue in #2363 occurred because of unsafe overwriting of individual indices in `df.columns.values`. By manually overwriting columns in that array, it would bypass many pandas helper functions such as `set_axis` which do validation, cache clearing, and other state manipulation.

The Dataframe cache is lazily computed, so if no call to `df` is made before running `con.register`, there are no stale caches that get corrupted when columns are automatically renamed to `a_1`, etc. If these caches are computed ahead of time, the calls to `get_loc` in parts of the pandas code will return incorrect values.