### PR TITLE
Fix current_schema() and current_schemas()

### DIFF
--- a/test/sql/catalog/test_set_search_path.test
+++ b/test/sql/catalog/test_set_search_path.test
@@ -96,6 +96,16 @@ SELECT MAIN.CURRENT_SETTING('schema');
 ----
 test
 
+query I
+SELECT current_schema();
+----
+test
+
+query I
+SELECT current_schemas(false);
+----
+[temp, test, main, pg_catalog]
+
 # Case insensitivity
 
 statement ok

--- a/test/sql/pg_catalog/system_functions.test
+++ b/test/sql/pg_catalog/system_functions.test
@@ -48,7 +48,7 @@ main
 query I
 SELECT current_schemas(false);
 ----
-[main]
+[temp, main, pg_catalog]
 
 query IIII
 SELECT inet_client_addr(), inet_client_port(), inet_server_addr(), inet_server_port();


### PR DESCRIPTION
These values were hard-coded but #2317 made it configurable.
This CL let these functions return the configured values.