### PR TITLE
Let FTS index creation respect the current schema.

### DIFF
--- a/extension/fts/fts_indexing.cpp
+++ b/extension/fts/fts_indexing.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/main/connection.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_search_path.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/parser/qualified_name.hpp"
@@ -14,7 +15,7 @@ static string fts_schema_name(const string &schema, const string &table) {
 
 string drop_fts_index_query(ClientContext &context, const FunctionParameters &parameters) {
 	auto qname = QualifiedName::Parse(parameters.values[0].str_value);
-	qname.schema = qname.schema == INVALID_SCHEMA ? DEFAULT_SCHEMA : qname.schema;
+	qname.schema = context.catalog_search_path->GetOrDefault(qname.schema);
 	string fts_schema = fts_schema_name(qname.schema, qname.name);
 
 	auto &catalog = Catalog::GetCatalog(context);
@@ -236,7 +237,7 @@ void check_exists(ClientContext &context, QualifiedName &qname) {
 
 string create_fts_index_query(ClientContext &context, const FunctionParameters &parameters) {
 	auto qname = QualifiedName::Parse(parameters.values[0].str_value);
-	qname.schema = qname.schema == INVALID_SCHEMA ? DEFAULT_SCHEMA : qname.schema;
+	qname.schema = context.catalog_search_path->GetOrDefault(qname.schema);
 	check_exists(context, qname);
 	string fts_schema = fts_schema_name(qname.schema, qname.name);
 
@@ -253,7 +254,7 @@ string create_fts_index_query(ClientContext &context, const FunctionParameters &
 		stopwords = stopword_entry->second.str_value;
 		if (stopwords != "english" && stopwords != "none") {
 			auto stopwords_qname = QualifiedName::Parse(stopwords);
-			stopwords_qname.schema = stopwords_qname.schema == INVALID_SCHEMA ? DEFAULT_SCHEMA : stopwords_qname.schema;
+			stopwords_qname.schema = context.catalog_search_path->GetOrDefault(stopwords_qname.schema);
 			check_exists(context, stopwords_qname);
 		}
 	}

--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -21,6 +21,10 @@ const vector<string> &CatalogSearchPath::Get() {
 	return paths;
 }
 
+const string &CatalogSearchPath::GetOrDefault(const string &name) {
+	return name == INVALID_SCHEMA ? GetDefault() : name;
+}
+
 const string &CatalogSearchPath::GetDefault() {
 	const auto &paths = Get();
 	D_ASSERT(paths.size() >= 2);

--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -22,7 +22,7 @@ const vector<string> &CatalogSearchPath::Get() {
 }
 
 const string &CatalogSearchPath::GetOrDefault(const string &name) {
-	return name == INVALID_SCHEMA ? GetDefault() : name;
+	return name == INVALID_SCHEMA ? GetDefault() : name; // NOLINT
 }
 
 const string &CatalogSearchPath::GetDefault() {

--- a/src/include/duckdb/catalog/catalog_search_path.hpp
+++ b/src/include/duckdb/catalog/catalog_search_path.hpp
@@ -26,6 +26,7 @@ public:
 
 	const vector<string> &Get();
 	const string &GetDefault();
+	const string &GetOrDefault(const string &name);
 
 private:
 	static vector<string> ParsePaths(const string &value);

--- a/test/sql/fts/test_indexing_and_schema.test
+++ b/test/sql/fts/test_indexing_and_schema.test
@@ -1,0 +1,35 @@
+# name: test/sql/fts/test_indexing_and_schema.test
+# Description: Refer default schema when the table name doesn't have a qualifier.
+# group: [fts]
+
+require fts
+
+statement ok
+CREATE SCHEMA test
+
+statement ok
+CREATE TABLE test.documents(id VARCHAR, body VARCHAR)
+
+statement ok
+INSERT INTO test.documents VALUES ('doc1', ' QUÁCKING+QUÁCKING+QUÁCKING'), ('doc2', ' BÁRKING+BÁRKING+BÁRKING+BÁRKING'), ('doc3', ' MÉOWING+MÉOWING+MÉOWING+MÉOWING+MÉOWING+999')
+
+statement error
+PRAGMA create_fts_index('documents', 'id', 'body')
+
+statement ok
+SET SCHEMA='test'
+
+statement ok
+PRAGMA create_fts_index('documents', 'id', 'body')
+
+statement ok
+SET SCHEMA='main'
+
+statement error
+PRAGMA drop_fts_index('documents')
+
+statement ok
+SET SCHEMA='test'
+
+statement ok
+PRAGMA drop_fts_index('documents')


### PR DESCRIPTION
Yet another follow up for #2317.
It used DEFAULT_SCHEMA if the qualifier is missing.