### PR TITLE
Dropping support to Python 2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1223,39 +1223,6 @@ jobs:
         cat duckdb.Rcheck/00check.log
         cat duckdb.Rcheck/tests/testthat.Rout.fail
 
-
- linux-tarball-v2:
-    name: Python 2 Tarball
-    runs-on: ubuntu-20.04
-    needs: linux-debug
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: '2.7'
-
-    - name: Install
-      run: |
-        pip install setuptools-scm==5.0.2
-        pip install numpy pytest pandas
-
-    - name: Build
-      run: |
-        python --version
-        git archive --format zip --output test-tarball.zip HEAD
-        mkdir duckdb-test-tarball
-        mv test-tarball.zip duckdb-test-tarball
-        cd duckdb-test-tarball
-        unzip test-tarball.zip
-        cd tools/pythonpkg
-        export SETUPTOOLS_SCM_PRETEND_VERSION=0.2.2
-        python setup.py install --user
-        (cd tests/ && python -m pytest)
-
  linux-tarball:
     name: Python 3 Tarball
     runs-on: ubuntu-20.04

--- a/tools/pythonpkg/src/array_wrapper.cpp
+++ b/tools/pythonpkg/src/array_wrapper.cpp
@@ -108,7 +108,6 @@ struct TimeConvert {
 };
 
 struct StringConvert {
-#if PY_MAJOR_VERSION >= 3
 	template <class T>
 	static void ConvertUnicodeValueTemplated(T *result, int32_t *codepoints, idx_t codepoint_count, const char *data,
 	                                         idx_t ascii_count) {
@@ -198,13 +197,6 @@ struct StringConvert {
 		memcpy(target_data, data, len);
 		return result;
 	}
-#else
-	template <class DUCKDB_T, class NUMPY_T>
-	static PyObject *ConvertValue(string_t val) {
-		return py::str(val.GetString()).release().ptr();
-	}
-#endif
-
 	template <class NUMPY_T>
 	static NUMPY_T NullValue() {
 		return nullptr;

--- a/tools/pythonpkg/tests/api/test_dbapi05.py
+++ b/tools/pythonpkg/tests/api/test_dbapi05.py
@@ -1,11 +1,7 @@
 #simple DB API testcase
 
-import sys
-
 class TestSimpleDBAPI(object):
     def test_prepare(self, duckdb_cursor):
-        if sys.version_info.major < 3:
-            return
         result = duckdb_cursor.execute('SELECT CAST(? AS INTEGER), CAST(? AS INTEGER)', ['42', '84']).fetchall()
         assert result == [(42, 84, )], "Incorrect result returned"
 

--- a/tools/pythonpkg/tests/api/test_dbapi12.py
+++ b/tools/pythonpkg/tests/api/test_dbapi12.py
@@ -2,13 +2,9 @@ import duckdb
 import tempfile
 import os
 import pandas as pd
-import sys
 
 class TestRelationApi(object):
     def test_readonly(self, duckdb_cursor):
-        if sys.version_info.major < 3:
-            return
-
         test_df = pd.DataFrame.from_dict({"i":[1, 2, 3], "j":["one", "two", "three"]})
 
         def test_rel(rel, duckdb_cursor):

--- a/tools/pythonpkg/tests/arrow/test_binary_type.py
+++ b/tools/pythonpkg/tests/arrow/test_binary_type.py
@@ -1,6 +1,5 @@
 import duckdb
 import os
-import sys
 try:
     import pyarrow as pa
     from pyarrow import parquet as pq

--- a/tools/pythonpkg/tests/arrow/test_dataset.py
+++ b/tools/pythonpkg/tests/arrow/test_dataset.py
@@ -1,6 +1,5 @@
 import duckdb
 import os
-import sys
 try:
     import pyarrow
     import pyarrow.parquet

--- a/tools/pythonpkg/tests/arrow/test_date.py
+++ b/tools/pythonpkg/tests/arrow/test_date.py
@@ -1,6 +1,5 @@
 import duckdb
 import os
-import sys
 import datetime
 import pytest
 try:

--- a/tools/pythonpkg/tests/arrow/test_filter_pushdown.py
+++ b/tools/pythonpkg/tests/arrow/test_filter_pushdown.py
@@ -1,6 +1,5 @@
 import duckdb
 import os
-import sys
 import pytest
 import tempfile
 try:

--- a/tools/pythonpkg/tests/arrow/test_integration.py
+++ b/tools/pythonpkg/tests/arrow/test_integration.py
@@ -1,6 +1,5 @@
 import duckdb
 import os
-import sys
 try:
     import pyarrow
     import pyarrow.parquet

--- a/tools/pythonpkg/tests/arrow/test_interval.py
+++ b/tools/pythonpkg/tests/arrow/test_interval.py
@@ -1,6 +1,5 @@
 import duckdb
 import os
-import sys
 import datetime
 import pytest
 try:

--- a/tools/pythonpkg/tests/arrow/test_large_string.py
+++ b/tools/pythonpkg/tests/arrow/test_large_string.py
@@ -1,6 +1,5 @@
 import duckdb
 import os
-import sys
 try:
     import pyarrow as pa
     from pyarrow import parquet as pq
@@ -12,8 +11,8 @@ except:
 class TestArrowLargeString(object):
     def test_large_string_type(self,duckdb_cursor):
         if not can_run:
-
             return
+            
         schema = pa.schema([("data", pa.large_string())])
         inputs = [pa.array(["foo", "baaaar", "b"], type=pa.large_string())]
         arrow_table = pa.Table.from_arrays(inputs, schema=schema)

--- a/tools/pythonpkg/tests/arrow/test_multiple_reads.py
+++ b/tools/pythonpkg/tests/arrow/test_multiple_reads.py
@@ -1,6 +1,5 @@
 import duckdb
 import os
-import sys
 try:
     import pyarrow
     import pyarrow.parquet

--- a/tools/pythonpkg/tests/arrow/test_parallel.py
+++ b/tools/pythonpkg/tests/arrow/test_parallel.py
@@ -1,6 +1,5 @@
 import duckdb
 import os
-import sys
 try:
     import pyarrow
     import pyarrow.parquet

--- a/tools/pythonpkg/tests/arrow/test_progress.py
+++ b/tools/pythonpkg/tests/arrow/test_progress.py
@@ -1,6 +1,5 @@
 import duckdb
 import os
-import sys
 try:
     import pyarrow
     import pyarrow.parquet

--- a/tools/pythonpkg/tests/arrow/test_projection_pushdown.py
+++ b/tools/pythonpkg/tests/arrow/test_projection_pushdown.py
@@ -1,6 +1,5 @@
 import duckdb
 import os
-import sys
 import pytest
 try:
     import pyarrow as pa

--- a/tools/pythonpkg/tests/arrow/test_time.py
+++ b/tools/pythonpkg/tests/arrow/test_time.py
@@ -1,6 +1,5 @@
 import duckdb
 import os
-import sys
 import datetime
 import pytest
 try:

--- a/tools/pythonpkg/tests/arrow/test_timestamps.py
+++ b/tools/pythonpkg/tests/arrow/test_timestamps.py
@@ -1,6 +1,5 @@
 import duckdb
 import os
-import sys
 import datetime
 import pytest
 try:

--- a/tools/pythonpkg/tests/arrow/test_unregister.py
+++ b/tools/pythonpkg/tests/arrow/test_unregister.py
@@ -3,7 +3,6 @@ import tempfile
 import gc
 import duckdb
 import os
-import sys
 try:
     import pyarrow
     import pyarrow.parquet

--- a/tools/pythonpkg/tests/arrow/test_view.py
+++ b/tools/pythonpkg/tests/arrow/test_view.py
@@ -1,6 +1,5 @@
 import duckdb
 import os
-import sys
 try:
     import pyarrow
     import pyarrow.parquet

--- a/tools/pythonpkg/tests/pandas/test_2304.py
+++ b/tools/pythonpkg/tests/pandas/test_2304.py
@@ -1,12 +1,9 @@
 import duckdb
 import pandas as pd
 import numpy as np
-import sys 
 
 class TestPandasMergeSameName(object):
     def test_2304(self, duckdb_cursor):
-        if sys.version_info.major < 3:
-            return
         df1 = pd.DataFrame({
             'id_1': [1, 1, 1, 2, 2],
             'agedate': np.array(['2010-01-01','2010-02-01','2010-03-01','2020-02-01', '2020-03-01']).astype('datetime64[D]'),
@@ -35,9 +32,6 @@ class TestPandasMergeSameName(object):
         assert result == expected_result
 
     def test_pd_names(self, duckdb_cursor):
-        if sys.version_info.major < 3:
-            return
-
         df1 = pd.DataFrame({
             'id': [1, 1, 2],
             'id_1': [1, 1, 2],
@@ -70,7 +64,6 @@ class TestPandasMergeSameName(object):
         assert(exp_result.equals(result_df))
 
     def test_repeat_name(self, duckdb_cursor):
-
         df1 = pd.DataFrame({
             'id': [1],
             'id_1': [1],

--- a/tools/pythonpkg/tests/pandas/test_bug2281.py
+++ b/tools/pythonpkg/tests/pandas/test_bug2281.py
@@ -1,6 +1,5 @@
 import duckdb
 import os
-import sys
 import datetime
 import pytest
 import pandas as pd

--- a/tools/pythonpkg/tests/pandas/test_issue_1767.py
+++ b/tools/pythonpkg/tests/pandas/test_issue_1767.py
@@ -4,13 +4,10 @@
 import duckdb
 import pandas as pd
 import numpy
-import sys
 
 # Join from pandas not matching identical strings #1767
 class TestIssue1767(object):
     def test_unicode_join_pandas(self, duckdb_cursor):
-        if sys.version_info.major < 3:
-            return
         A = pd.DataFrame({"key": ["a", "п"]})
         B = pd.DataFrame({"key": ["a", "п"]})
         con = duckdb.connect(":memory:")

--- a/tools/pythonpkg/tests/pandas/test_pandas_object.py
+++ b/tools/pythonpkg/tests/pandas/test_pandas_object.py
@@ -1,12 +1,8 @@
 import pandas as pd
 import duckdb
-import sys
 
 class TestPandasObject(object):
-    def test_object_to_string(self, duckdb_cursor):
-        if sys.version_info.major < 3:
-            return
-            
+    def test_object_to_string(self, duckdb_cursor):          
         con = duckdb.connect(database=':memory:', read_only=False)
         x = pd.DataFrame([[1, 'a', 2],[1, None, 2], [1, 1.1, 2], [1, 1.1, 2], [1, 1.1, 2]])
         x = x.iloc[1:].copy()       # middle col now entirely native float items

--- a/tools/pythonpkg/tests/pandas/test_parallel_pandas_scan.py
+++ b/tools/pythonpkg/tests/pandas/test_parallel_pandas_scan.py
@@ -4,7 +4,6 @@ import duckdb
 import pandas as pd
 import numpy
 import datetime
-import sys
 
 def run_parallel_queries(main_table, left_join_table, expected_df, iteration_count = 5):
     for i in range(0, iteration_count):
@@ -50,15 +49,11 @@ class TestParallelPandasScan(object):
         run_parallel_queries(main_table, left_join_table, left_join_table)
 
     def test_parallel_complex_unicode_text(self, duckdb_cursor):
-        if sys.version_info.major < 3:
-            return
         main_table = pd.DataFrame([{"join_column":u"鴨"}])
         left_join_table = pd.DataFrame([{"join_column": u"鴨","other_column":u"數據庫"}])
         run_parallel_queries(main_table, left_join_table, left_join_table)
 
     def test_parallel_emojis(self, duckdb_cursor):
-        if sys.version_info.major < 3:
-            return
         main_table = pd.DataFrame([{"join_column":u"🤦🏼‍♂️ L🤦🏼‍♂️R 🤦🏼‍♂️"}])
         left_join_table = pd.DataFrame([{"join_column": u"🤦🏼‍♂️ L🤦🏼‍♂️R 🤦🏼‍♂️","other_column":u"🦆🍞🦆"}])
         run_parallel_queries(main_table, left_join_table, left_join_table)

--- a/tools/pythonpkg/tests/pandas/test_same_name.py
+++ b/tools/pythonpkg/tests/pandas/test_same_name.py
@@ -1,7 +1,6 @@
 import pytest
 import duckdb
 import pandas as pd
-import sys
 
 class TestMultipleColumnsSameName(object):
 
@@ -17,9 +16,6 @@ class TestMultipleColumnsSameName(object):
         assert con.execute("select a_1 from df_view;").fetchall() == [(5,), (6,), (7,), (8,)]
 
     def test_multiple_columns_with_same_name_2(self, duckdb_cursor):
-        # Python 2 failure seems to be related to bytes vs strings
-        if sys.version_info.major < 3:
-            return
         df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [5, 6, 7, 8], 'a_1': [9, 10, 11, 12]})
         df = df.rename(columns={ df.columns[1]: "a_1" })
         con = duckdb.connect()

--- a/tools/pythonpkg/tests/pandas/test_timestamp.py
+++ b/tools/pythonpkg/tests/pandas/test_timestamp.py
@@ -1,6 +1,5 @@
 import duckdb
 import os
-import sys
 import datetime
 import pytest
 import pandas as pd

--- a/tools/pythonpkg/tests/sqlite/test_types.py
+++ b/tools/pythonpkg/tests/sqlite/test_types.py
@@ -28,7 +28,6 @@ import datetime
 import decimal
 import unittest
 import duckdb
-import sys
 
 
 class DuckDBTypeTests(unittest.TestCase):
@@ -98,8 +97,6 @@ class DuckDBTypeTests(unittest.TestCase):
         self.assertEqual(row[0], sample)
 
     def test_CheckMemoryviewFromhexBlob(self):
-        if sys.version_info.major < 3:
-            return
         sample = bytes.fromhex('00FF0F2E3D4C5B6A798800FF00')
         val = memoryview(sample)
         self.cur.execute("insert into test(b) values (?)", (val,))

--- a/tools/pythonpkg/tests/test_unicode.py
+++ b/tools/pythonpkg/tests/test_unicode.py
@@ -3,12 +3,9 @@
 
 import duckdb
 import pandas as pd
-import sys
 
 class TestUnicode(object):
     def test_unicode_pandas_scan(self, duckdb_cursor):
-        if sys.version_info.major < 3:
-            return
         con = duckdb.connect(database=':memory:', read_only=False)
         test_df = pd.DataFrame.from_dict({"i":[1, 2, 3], "j":["a", "c", u"ë"]})
         con.register('test_df_view', test_df)


### PR DESCRIPTION
Mainly removing:

- From CI: Python 2 Tarball
- From Main Library: PY_MAJOR_VERSION
- From Python Tests: sys.version_info.major checks.

Did I miss something?