### PR TITLE
Allow WHERE clause referring aliases defined in SELECT clause.

### DIFF
--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -20,6 +20,7 @@
 
 namespace duckdb {
 class BoundResultModifier;
+class BoundSelectNode;
 class ClientContext;
 class ExpressionBinder;
 class LimitModifier;
@@ -233,7 +234,6 @@ private:
 
 	BoundStatement BindSummarize(ShowStatement &stmt);
 	unique_ptr<BoundResultModifier> BindLimit(LimitModifier &limit_mod);
-	unique_ptr<Expression> BindFilter(unique_ptr<ParsedExpression> condition);
 	unique_ptr<Expression> BindOrderExpression(OrderBinder &order_binder, unique_ptr<ParsedExpression> expr);
 
 	unique_ptr<LogicalOperator> PlanFilter(unique_ptr<Expression> condition, unique_ptr<LogicalOperator> root);

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -91,10 +91,12 @@ public:
 	static void ResolveParameterType(LogicalType &type);
 	static void ResolveParameterType(unique_ptr<Expression> &expr);
 
-protected:
+	//! Bind the given expresion. Unlike Bind(), this does *not* mute the given ParsedExpression.
+	//! Exposed to be used from sub-binders that aren't subclasses of ExpressionBinder.
 	virtual BindResult BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth,
 	                                  bool root_expression = false);
 
+protected:
 	BindResult BindExpression(BetweenExpression &expr, idx_t depth);
 	BindResult BindExpression(CaseExpression &expr, idx_t depth);
 	BindResult BindExpression(CollateExpression &expr, idx_t depth);

--- a/src/include/duckdb/planner/expression_binder/column_alias_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/column_alias_binder.hpp
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/planner/expression_binder/column_alias_binder.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/planner/expression_binder.hpp"
+
+namespace duckdb {
+
+class BoundSelectNode;
+class ColumnRefExpression;
+
+//! A helper binder for WhereBinder and HavingBinder which support alias as a columnref.
+class ColumnAliasBinder {
+public:
+	ColumnAliasBinder(BoundSelectNode &node, const unordered_map<string, idx_t> &alias_map);
+
+	BindResult BindAlias(ExpressionBinder &enclosing_binder, ColumnRefExpression &expr, idx_t depth,
+	                     bool root_expression);
+
+	bool HadUnrecoverableError() const {
+		return detected_unrecoverable;
+	}
+
+private:
+	BoundSelectNode &node;
+	const unordered_map<string, idx_t> &alias_map;
+	bool in_alias;
+	bool detected_unrecoverable;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder/column_alias_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/column_alias_binder.hpp
@@ -24,15 +24,10 @@ public:
 	BindResult BindAlias(ExpressionBinder &enclosing_binder, ColumnRefExpression &expr, idx_t depth,
 	                     bool root_expression);
 
-	bool HadUnrecoverableError() const {
-		return detected_unrecoverable;
-	}
-
 private:
 	BoundSelectNode &node;
 	const unordered_map<string, idx_t> &alias_map;
 	bool in_alias;
-	bool detected_unrecoverable;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder/having_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/having_binder.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/planner/expression_binder/select_binder.hpp"
+#include "duckdb/planner/expression_binder/column_alias_binder.hpp"
 
 namespace duckdb {
 
@@ -18,12 +19,14 @@ public:
 	HavingBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
 	             unordered_map<string, idx_t> &alias_map);
 
-	unordered_map<string, idx_t> &alias_map;
-	bool in_alias;
-
 protected:
 	BindResult BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth,
 	                          bool root_expression = false) override;
+
+private:
+	BindResult BindColumnRef(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression);
+
+	ColumnAliasBinder column_alias_binder;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder/where_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/where_binder.hpp
@@ -12,16 +12,23 @@
 
 namespace duckdb {
 
+class ColumnAliasBinder;
+
 //! The WHERE binder is responsible for binding an expression within the WHERE clause of a SQL statement
 class WhereBinder : public ExpressionBinder {
 public:
-	WhereBinder(Binder &binder, ClientContext &context);
+	WhereBinder(Binder &binder, ClientContext &context, ColumnAliasBinder *column_alias_binder = nullptr);
 
 protected:
 	BindResult BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth,
 	                          bool root_expression = false) override;
 
 	string UnsupportedAggregateMessage() override;
+
+private:
+	BindResult BindColumnRef(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression);
+
+	ColumnAliasBinder *column_alias_binder;
 };
 
 } // namespace duckdb

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/tableref/joinref.hpp"
 #include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression_binder/column_alias_binder.hpp"
 #include "duckdb/planner/expression_binder/constant_binder.hpp"
 #include "duckdb/planner/expression_binder/group_binder.hpp"
 #include "duckdb/planner/expression_binder/having_binder.hpp"
@@ -19,10 +20,6 @@
 #include "duckdb/planner/expression_binder/aggregate_binder.hpp"
 
 namespace duckdb {
-unique_ptr<Expression> Binder::BindFilter(unique_ptr<ParsedExpression> condition) {
-	WhereBinder where_binder(*this, context);
-	return where_binder.Bind(condition);
-}
 
 unique_ptr<Expression> Binder::BindOrderExpression(OrderBinder &order_binder, unique_ptr<ParsedExpression> expr) {
 	// we treat the Distinct list as a order by
@@ -220,7 +217,10 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SelectNode &statement) {
 	// first visit the WHERE clause
 	// the WHERE clause happens before the GROUP BY, PROJECTION or HAVING clauses
 	if (statement.where_clause) {
-		result->where_clause = BindFilter(move(statement.where_clause));
+		ColumnAliasBinder alias_binder(*result, alias_map);
+		WhereBinder where_binder(*this, context, &alias_binder);
+		unique_ptr<ParsedExpression> condition = move(statement.where_clause);
+		result->where_clause = where_binder.Bind(condition);
 	}
 
 	// now bind all the result modifiers; including DISTINCT and ORDER BY targets

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -249,8 +249,6 @@ void ExpressionBinder::BindTableNames(Binder &binder, ParsedExpression &expr, un
 			if (binder.macro_binding != nullptr && binder.macro_binding->HasMatchingBinding(colref.column_name)) {
 				// macro parameters get priority
 				colref.table_name = binder.macro_binding->alias;
-			} else if (alias_map && alias_map->find(colref.column_name) != alias_map->end()) {
-				// alias: leave unqualified
 			} else {
 				colref.table_name = binder.bind_context.GetMatchingBinding(colref.column_name);
 			}

--- a/src/planner/expression_binder/CMakeLists.txt
+++ b/src/planner/expression_binder/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library_unity(
   aggregate_binder.cpp
   alter_binder.cpp
   check_binder.cpp
+  column_alias_binder.cpp
   constant_binder.cpp
   group_binder.cpp
   having_binder.cpp

--- a/src/planner/expression_binder/column_alias_binder.cpp
+++ b/src/planner/expression_binder/column_alias_binder.cpp
@@ -1,0 +1,37 @@
+#include "duckdb/planner/expression_binder/column_alias_binder.hpp"
+
+#include "duckdb/parser/expression/columnref_expression.hpp"
+#include "duckdb/planner/query_node/bound_select_node.hpp"
+#include "duckdb/common/string_util.hpp"
+
+namespace duckdb {
+
+ColumnAliasBinder::ColumnAliasBinder(BoundSelectNode &node, const unordered_map<string, idx_t> &alias_map)
+    : node(node), alias_map(alias_map), in_alias(false), detected_unrecoverable(false) {
+}
+
+BindResult ColumnAliasBinder::BindAlias(ExpressionBinder &enclosing_binder, ColumnRefExpression &expr, idx_t depth,
+                                        bool root_expression) {
+	if (!expr.table_name.empty()) {
+		return BindResult(StringUtil::Format("Alias %s cannot be qualified.", expr.ToString()));
+	}
+
+	auto alias_entry = alias_map.find(expr.column_name);
+	if (alias_entry == alias_map.end()) {
+		return BindResult(StringUtil::Format("Alias %s is not found.", expr.ToString()));
+	}
+
+	if (in_alias) {
+		detected_unrecoverable = true;
+		return BindResult(StringUtil::Format("Alias %s is recursively used.", expr.ToString()));
+	}
+
+	// found an alias: bind the alias expression
+	auto expression = node.original_expressions[alias_entry->second]->Copy();
+	in_alias = true;
+	auto result = enclosing_binder.BindExpression(&expression, depth, root_expression);
+	in_alias = false;
+	return result;
+}
+
+} // namespace duckdb

--- a/src/planner/expression_binder/column_alias_binder.cpp
+++ b/src/planner/expression_binder/column_alias_binder.cpp
@@ -7,7 +7,7 @@
 namespace duckdb {
 
 ColumnAliasBinder::ColumnAliasBinder(BoundSelectNode &node, const unordered_map<string, idx_t> &alias_map)
-    : node(node), alias_map(alias_map), in_alias(false), detected_unrecoverable(false) {
+    : node(node), alias_map(alias_map), in_alias(false) {
 }
 
 BindResult ColumnAliasBinder::BindAlias(ExpressionBinder &enclosing_binder, ColumnRefExpression &expr, idx_t depth,
@@ -21,12 +21,8 @@ BindResult ColumnAliasBinder::BindAlias(ExpressionBinder &enclosing_binder, Colu
 		return BindResult(StringUtil::Format("Alias %s is not found.", expr.ToString()));
 	}
 
-	if (in_alias) {
-		detected_unrecoverable = true;
-		return BindResult(StringUtil::Format("Alias %s is recursively used.", expr.ToString()));
-	}
-
 	// found an alias: bind the alias expression
+	D_ASSERT(!in_alias);
 	auto expression = node.original_expressions[alias_entry->second]->Copy();
 	in_alias = true;
 	auto result = enclosing_binder.BindExpression(&expression, depth, root_expression);

--- a/src/planner/expression_binder/having_binder.cpp
+++ b/src/planner/expression_binder/having_binder.cpp
@@ -10,8 +10,19 @@ namespace duckdb {
 
 HavingBinder::HavingBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
                            unordered_map<string, idx_t> &alias_map)
-    : SelectBinder(binder, context, node, info), alias_map(alias_map), in_alias(false) {
+    : SelectBinder(binder, context, node, info), column_alias_binder(node, alias_map) {
 	target_type = LogicalType(LogicalTypeId::BOOLEAN);
+}
+
+BindResult HavingBinder::BindColumnRef(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
+	auto &expr = (ColumnRefExpression &)**expr_ptr;
+	auto alias_result = column_alias_binder.BindAlias(*this, expr, depth, root_expression);
+	if (!alias_result.HasError()) {
+		return alias_result;
+	}
+
+	return BindResult(StringUtil::Format(
+	    "column %s must appear in the GROUP BY clause or be used in an aggregate function", expr.ToString()));
 }
 
 BindResult HavingBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
@@ -25,22 +36,7 @@ BindResult HavingBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, 
 	case ExpressionClass::WINDOW:
 		return BindResult("HAVING clause cannot contain window functions!");
 	case ExpressionClass::COLUMN_REF:
-		if (!in_alias) {
-			auto &colref = (ColumnRefExpression &)expr;
-			if (colref.table_name.empty()) {
-				auto alias_entry = alias_map.find(colref.column_name);
-				if (alias_entry != alias_map.end()) {
-					// found an alias: bind the alias expression
-					auto expression = node.original_expressions[alias_entry->second]->Copy();
-					in_alias = true;
-					auto result = BindExpression(&expression, depth, root_expression);
-					in_alias = false;
-					return result;
-				}
-			}
-		}
-		return BindResult(StringUtil::Format(
-		    "column %s must appear in the GROUP BY clause or be used in an aggregate function", expr.ToString()));
+		return BindColumnRef(expr_ptr, depth, root_expression);
 	default:
 		return duckdb::SelectBinder::BindExpression(expr_ptr, depth);
 	}

--- a/src/planner/expression_binder/where_binder.cpp
+++ b/src/planner/expression_binder/where_binder.cpp
@@ -17,7 +17,6 @@ BindResult WhereBinder::BindColumnRef(unique_ptr<ParsedExpression> *expr_ptr, id
 
 	BindResult alias_result = column_alias_binder->BindAlias(*this, expr, depth, root_expression);
 	// This code path cannot be exercised at thispoint. #1547 might change that.
-	D_ASSERT(!column_alias_binder->HadUnrecoverableError());
 	if (!alias_result.HasError()) {
 		return alias_result;
 	}

--- a/src/planner/expression_binder/where_binder.cpp
+++ b/src/planner/expression_binder/where_binder.cpp
@@ -1,9 +1,28 @@
 #include "duckdb/planner/expression_binder/where_binder.hpp"
+#include "duckdb/planner/expression_binder/column_alias_binder.hpp"
 
 namespace duckdb {
 
-WhereBinder::WhereBinder(Binder &binder, ClientContext &context) : ExpressionBinder(binder, context) {
+WhereBinder::WhereBinder(Binder &binder, ClientContext &context, ColumnAliasBinder *column_alias_binder)
+    : ExpressionBinder(binder, context), column_alias_binder(column_alias_binder) {
 	target_type = LogicalType(LogicalTypeId::BOOLEAN);
+}
+
+BindResult WhereBinder::BindColumnRef(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
+	auto &expr = (ColumnRefExpression &)**expr_ptr;
+	auto result = ExpressionBinder::BindExpression(expr_ptr, depth);
+	if (!result.HasError() || !column_alias_binder) {
+		return result;
+	}
+
+	BindResult alias_result = column_alias_binder->BindAlias(*this, expr, depth, root_expression);
+	// This code path cannot be exercised at thispoint. #1547 might change that.
+	D_ASSERT(!column_alias_binder->HadUnrecoverableError());
+	if (!alias_result.HasError()) {
+		return alias_result;
+	}
+
+	return result;
 }
 
 BindResult WhereBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
@@ -13,6 +32,8 @@ BindResult WhereBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, i
 		return BindResult("WHERE clause cannot contain DEFAULT clause");
 	case ExpressionClass::WINDOW:
 		return BindResult("WHERE clause cannot contain window functions!");
+	case ExpressionClass::COLUMN_REF:
+		return BindColumnRef(expr_ptr, depth, root_expression);
 	default:
 		return ExpressionBinder::BindExpression(expr_ptr, depth);
 	}

--- a/test/sql/binder/test_having_alias.test
+++ b/test/sql/binder/test_having_alias.test
@@ -22,17 +22,13 @@ SELECT i, COUNT(*) AS k FROM integers GROUP BY i HAVING k=1 ORDER BY i;
 statement error
 SELECT i, COUNT(*) AS k FROM integers GROUP BY i HAVING integers.k=1 ORDER BY i;
 
-# aliases take priority
+# column name wins over the alias
 query II
-SELECT i AS j, COUNT(*) AS i FROM integers GROUP BY j HAVING i=1 ORDER BY 1;
+SELECT 1 AS i, COUNT(*) FROM integers GROUP BY i HAVING i=2;
 ----
-0	1
 1	1
-2	1
-3	1
-4	1
 
-# unless qualified
+# as if qualified
 query II
 SELECT i AS j, COUNT(*) AS i FROM integers GROUP BY j HAVING integers.i=1 ORDER BY i;
 ----
@@ -49,20 +45,19 @@ SELECT COUNT(i) AS j FROM integers HAVING j=5;
 ----
 5
 
-# potentially recursive alias
-query I
+# These don't work since i in HAVING refers the column instead of the alias
+# (SQLite says: 'Error: a GROUP BY clause is required before HAVING')
+statement error
 SELECT COUNT(i) AS i FROM integers HAVING i=5;
-----
-5
 
-query I
+statement error
 SELECT COUNT(i) AS i FROM integers HAVING i=5 ORDER BY i;
 ----
 5
 
 # use the same alias multiple times
 query I
-SELECT COUNT(i) AS i FROM integers HAVING i=i;
+SELECT COUNT(i) AS j FROM integers HAVING j=j;
 ----
 5
 

--- a/test/sql/filter/test_alias_filter.test
+++ b/test/sql/filter/test_alias_filter.test
@@ -12,9 +12,43 @@ statement ok
 INSERT INTO integers VALUES (1), (2), (3), (NULL)
 
 # this fails in postgres and monetdb, but succeeds in sqlite
-# for now, we have this fail as well because it simplifies our life
-# the filter occurs before the projection, hence "j" is not computed until AFTER the filter normally
-# we probably want to change this to succeed
-statement error
-SELECT i % 2 AS j FROM integers WHERE j<>0;
+query I
+SELECT i % 2 AS k FROM integers WHERE k<>0;
+----
+1
+1
 
+# These cases roughly follows what HAVING does.
+# See test/sql/binder/test_having_alias.test.
+
+# alias cannot be qualified
+statement error
+SELECT i % 2 AS k FROM integers WHERE integers.k<>0;
+
+# columns take priority
+query I
+SELECT i % 2 AS i FROM integers WHERE i<>0;
+----
+1
+0
+1
+
+# columns with qualified name
+query I
+SELECT i % 2 AS k FROM integers WHERE integers.i<>0;
+----
+1
+0
+1
+
+# use the same alias multiple times
+query I
+SELECT i % 2 AS k FROM integers WHERE k=k;
+----
+1
+0
+1
+
+# alias to an aggregate doesn't work.
+statement error
+SELECT i % 2 AS o, COUNT(i) AS c FROM integers WHERE c = 0 GROUP BY o;


### PR DESCRIPTION
This adds alias handling to WhereBinder. The logic is extracted from
HavingBinder as ColumnAliasBinder and shared between them.

Note that what it does is to expand the aliased expression inline,
so the computation isn't shared between these two clauses.

This fixes #699.