### PR TITLE
Fix #2406: Handle aliases in expressions in the ORDER BY clause

### DIFF
--- a/src/include/duckdb/planner/expression_binder/order_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/order_binder.hpp
@@ -30,7 +30,10 @@ public:
 
 private:
 	unique_ptr<Expression> CreateProjectionReference(ParsedExpression &expr, idx_t index);
+	void ReplaceAliases(unique_ptr<ParsedExpression> &expr);
 
+private:
+	SelectNode *node;
 	vector<Binder *> binders;
 	idx_t projection_index;
 	idx_t max_count;

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -209,7 +209,9 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SelectNode &statement) {
 		result->names.push_back(expr->GetName());
 		ExpressionBinder::BindTableNames(*this, *expr);
 		if (!expr->alias.empty()) {
-			alias_map[expr->alias] = i;
+			if (alias_map.find(expr->alias) == alias_map.end()) {
+				alias_map[expr->alias] = i;
+			}
 			result->names[i] = expr->alias;
 		}
 		projection_map[expr.get()] = i;

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -206,9 +206,10 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SelectNode &statement) {
 	expression_map_t<idx_t> projection_map;
 	for (idx_t i = 0; i < statement.select_list.size(); i++) {
 		auto &expr = statement.select_list[i];
+		bool has_alias = !expr->alias.empty();
 		result->names.push_back(expr->GetName());
 		ExpressionBinder::BindTableNames(*this, *expr);
-		if (!expr->alias.empty()) {
+		if (has_alias) {
 			if (alias_map.find(expr->alias) == alias_map.end()) {
 				alias_map[expr->alias] = i;
 			}

--- a/src/planner/expression_binder/order_binder.cpp
+++ b/src/planner/expression_binder/order_binder.cpp
@@ -10,12 +10,13 @@ namespace duckdb {
 
 OrderBinder::OrderBinder(vector<Binder *> binders, idx_t projection_index, unordered_map<string, idx_t> &alias_map,
                          expression_map_t<idx_t> &projection_map, idx_t max_count)
-    : node(nullptr), binders(move(binders)), projection_index(projection_index), max_count(max_count), extra_list(nullptr),
-      alias_map(alias_map), projection_map(projection_map) {
+    : node(nullptr), binders(move(binders)), projection_index(projection_index), max_count(max_count),
+      extra_list(nullptr), alias_map(alias_map), projection_map(projection_map) {
 }
 OrderBinder::OrderBinder(vector<Binder *> binders, idx_t projection_index, SelectNode &node,
                          unordered_map<string, idx_t> &alias_map, expression_map_t<idx_t> &projection_map)
-    : node(&node), binders(move(binders)), projection_index(projection_index), alias_map(alias_map), projection_map(projection_map) {
+    : node(&node), binders(move(binders)), projection_index(projection_index), alias_map(alias_map),
+      projection_map(projection_map) {
 	this->max_count = node.select_list.size();
 	this->extra_list = &node.select_list;
 }
@@ -45,9 +46,8 @@ void OrderBinder::ReplaceAliases(unique_ptr<ParsedExpression> &expr) {
 		}
 		return;
 	}
-	ParsedExpressionIterator::EnumerateChildren(*expr, [&](unique_ptr<ParsedExpression> &child) {
-		ReplaceAliases(child);
-	});
+	ParsedExpressionIterator::EnumerateChildren(*expr,
+	                                            [&](unique_ptr<ParsedExpression> &child) { ReplaceAliases(child); });
 }
 
 unique_ptr<Expression> OrderBinder::Bind(unique_ptr<ParsedExpression> expr) {

--- a/test/sql/aggregate/group/test_group_by_alias.test
+++ b/test/sql/aggregate/group/test_group_by_alias.test
@@ -6,10 +6,10 @@ statement ok
 PRAGMA enable_verification
 
 statement ok
-CREATE TABLE integers(i INTEGER)
+CREATE TABLE integers(i INTEGER);
 
 statement ok
-INSERT INTO integers VALUES (1), (2), (3), (NULL)
+INSERT INTO integers VALUES (1), (2), (3), (NULL);
 
 # use alias in HAVING clause
 # CONTROVERSIAL: this query DOES NOT work in PostgreSQL
@@ -46,6 +46,14 @@ NULL	NULL	NULL
 2	0	2.000000
 1	1	1.000000
 3	1	3.000000
+
+query IIR
+SELECT i % 2 AS i, i, SUM(i) FROM integers GROUP BY i ORDER BY i, 3;
+----
+NULL	NULL	NULL
+0	2	2.000000
+1	1	1.000000
+1	3	3.000000
 
 # changing the name of the alias makes it more explicit what should happen
 query IIR

--- a/test/sql/order/order_alias.test
+++ b/test/sql/order/order_alias.test
@@ -1,4 +1,4 @@
-# name: test/sql/order/test_limit_parameter.test
+# name: test/sql/order/order_alias.test
 # description: Test LIMIT with a parameter (issue 1866)
 # group: [order]
 
@@ -21,6 +21,11 @@ SELECT foo AS bar FROM (SELECT 1 AS foo) t ORDER BY bar + 1;
 1
 
 query I
+SELECT bar+bar AS bar FROM (SELECT 1 AS bar) t ORDER BY bar;
+----
+2
+
+query I
 SELECT foo AS bar FROM (SELECT i%2 foo FROM generate_series(0, 3, 1) t(i)) t ORDER BY bar + 1;
 ----
 0
@@ -38,6 +43,25 @@ SELECT foo AS bar FROM (SELECT i%2 foo FROM generate_series(0, 3, 1) t(i)) t ORD
 
 query I
 SELECT foo AS bar FROM (SELECT i%2 foo FROM generate_series(0, 3, 1) t(i)) t ORDER BY 1 - bar + bar + bar;
+----
+0
+0
+1
+1
+
+query I
+SELECT 1-i AS i FROM (SELECT i%2 foo FROM generate_series(0, 3, 1) t(i)) t(i) ORDER BY i;
+----
+0
+0
+1
+1
+
+# CONTROVERSIAL: sqlite reverses the order here
+# it seems that there is a different code path in SQLite
+# for binding the alias as root of the order by vs binding the alias as part of an expression
+query I
+SELECT 1-i AS i FROM (SELECT i%2 foo FROM generate_series(0, 3, 1) t(i)) t(i) ORDER BY i+1;
 ----
 0
 0

--- a/test/sql/order/order_alias.test
+++ b/test/sql/order/order_alias.test
@@ -1,0 +1,75 @@
+# name: test/sql/order/test_limit_parameter.test
+# description: Test LIMIT with a parameter (issue 1866)
+# group: [order]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT foo AS bar FROM (SELECT 1 AS foo) t ORDER BY foo + 1;
+----
+1
+
+query I
+SELECT foo AS bar FROM (SELECT 1 AS foo) t ORDER BY bar;
+----
+1
+
+query I
+SELECT foo AS bar FROM (SELECT 1 AS foo) t ORDER BY bar + 1;
+----
+1
+
+query I
+SELECT foo AS bar FROM (SELECT i%2 foo FROM generate_series(0, 3, 1) t(i)) t ORDER BY bar + 1;
+----
+0
+0
+1
+1
+
+query I
+SELECT foo AS bar FROM (SELECT i%2 foo FROM generate_series(0, 3, 1) t(i)) t ORDER BY 1 - bar;
+----
+1
+1
+0
+0
+
+query I
+SELECT foo AS bar FROM (SELECT i%2 foo FROM generate_series(0, 3, 1) t(i)) t ORDER BY 1 - bar + bar + bar;
+----
+0
+0
+1
+1
+
+# duplicate alias
+# we match SQLite's behavior here and use the first
+# CONTROVERSIAL: Postgres reports an error
+query II
+SELECT foo AS bar, 1-foo AS bar FROM (SELECT i%2 foo FROM generate_series(0, 3, 1) t(i)) t ORDER BY bar + 1;
+----
+0	1
+0	1
+1	0
+1	0
+
+query II
+SELECT foo AS bar, 1-foo AS bar FROM (SELECT i%2 foo FROM generate_series(0, 3, 1) t(i)) t ORDER BY bar;
+----
+0	1
+0	1
+1	0
+1	0
+
+# DISTINCT ON binds in the same manner as ORDER BY
+query I
+SELECT DISTINCT ON(bar) foo AS bar FROM (SELECT 1 AS foo) t;
+----
+1
+
+query I
+SELECT DISTINCT ON(bar + 1) foo AS bar FROM (SELECT 1 AS foo) t;
+----
+1


### PR DESCRIPTION
Fixes #2406
