### PR TITLE
Fix for #2426

### DIFF
--- a/tools/pythonpkg/tests/fast/arrow/test_2426.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_2426.py
@@ -1,0 +1,37 @@
+import duckdb
+import os
+try:
+    import pyarrow as pa
+    can_run = True
+except:
+    can_run = False
+
+class Test2426(object):
+    def test_2426(self,duckdb_cursor):
+        if not can_run:
+            return
+        con = duckdb.connect()
+        con.execute("Create Table test (a integer)")
+        
+        for i in range (1024):
+            for j in range(2):
+                con.execute("Insert Into test values ('"+str(i)+"')")
+        con.execute("Insert Into test values ('5000')")
+        con.execute("Insert Into test values ('6000')")
+        sql = '''
+        SELECT  a, COUNT(*) AS repetitions
+        FROM    test
+        GROUP BY a
+        '''
+
+        result_df = con.execute(sql).df()
+
+        arrow_table = con.execute(sql).fetch_arrow_table()
+
+        arrow_df = arrow_table.to_pandas()
+        assert result_df['repetitions'].sum() == arrow_df['repetitions'].sum()
+
+        # Return 2 vectors
+        chunked_arrow_table_df = con.execute(sql).fetch_arrow_chunk(2,True).to_pandas()
+
+        assert result_df['repetitions'].sum() == chunked_arrow_table_df['repetitions'].sum()


### PR DESCRIPTION
Issue: #2426

Basically, the problem is that when running a stream query with a group by, that specific code path would assume it could rewrite the data from past stream chunks.
Since the arrow_table() returns a materialized query result, the fix is to perform force the materialization before performing the conversion.