### PR TITLE
More fixes for #2416

### DIFF
--- a/src/function/scalar/struct/struct_extract.cpp
+++ b/src/function/scalar/struct/struct_extract.cpp
@@ -51,8 +51,8 @@ static void StructExtractFunction(DataChunk &args, ExpressionState &state, Vecto
 static unique_ptr<FunctionData> StructExtractBind(ClientContext &context, ScalarFunction &bound_function,
                                                   vector<unique_ptr<Expression>> &arguments) {
 	D_ASSERT(bound_function.arguments.size() == 2);
-	if (arguments[0]->return_type.id() == LogicalTypeId::SQLNULL) {
-		// this should only happen when list extract occurs in a macro function
+	if (arguments[0]->return_type.id() == LogicalTypeId::SQLNULL ||
+	    arguments[1]->return_type.id() == LogicalTypeId::SQLNULL) {
 		bound_function.return_type = LogicalType::SQLNULL;
 		bound_function.arguments[0] = LogicalType::SQLNULL;
 		return make_unique<StructExtractBindData>("", 0, LogicalType::SQLNULL);

--- a/src/function/scalar/struct/struct_extract.cpp
+++ b/src/function/scalar/struct/struct_extract.cpp
@@ -1,7 +1,7 @@
-#include "duckdb/function/scalar/nested_functions.hpp"
-#include "duckdb/execution/expression_executor.hpp"
-#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/function/scalar/nested_functions.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/storage/statistics/struct_statistics.hpp"
 
 namespace duckdb {
@@ -50,6 +50,14 @@ static void StructExtractFunction(DataChunk &args, ExpressionState &state, Vecto
 
 static unique_ptr<FunctionData> StructExtractBind(ClientContext &context, ScalarFunction &bound_function,
                                                   vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(bound_function.arguments.size() == 2);
+	if (arguments[0]->return_type.id() == LogicalTypeId::SQLNULL) {
+		// this should only happen when list extract occurs in a macro function
+		bound_function.return_type = LogicalType::SQLNULL;
+		bound_function.arguments[0] = LogicalType::SQLNULL;
+		return make_unique<StructExtractBindData>("", 0, LogicalType::SQLNULL);
+	}
+	D_ASSERT(LogicalTypeId::STRUCT == arguments[0]->return_type.id());
 	auto &struct_children = StructType::GetChildTypes(arguments[0]->return_type);
 	if (struct_children.empty()) {
 		throw InternalException("Can't extract something from an empty struct");

--- a/test/issues/general/test_2416.test
+++ b/test/issues/general/test_2416.test
@@ -88,3 +88,91 @@ query I
 SELECT array_l([1, 2, 3])
 ----
 3
+
+statement ok
+CREATE MACRO my_extract(my_nested_type, index_or_field) AS my_nested_type[index_or_field]
+
+query T
+SELECT my_extract('1234', 1)
+----
+2
+
+query T
+SELECT my_extract([1, 2, 3, 4], 2)
+----
+3
+
+query T
+SELECT my_extract({a: 1, b: 2, c: 3, d: 4}, 'd')
+----
+4
+
+statement ok
+CREATE MACRO my_list_or_string_extract_2(my_list_or_string) AS my_list_or_string[2]
+
+query T
+SELECT my_list_or_string_extract_2('1234')
+----
+3
+
+query T
+SELECT my_list_or_string_extract_2('12')
+----
+(empty)
+
+query T
+SELECT my_list_or_string_extract_2([1, 2, 3, 4])
+----
+3
+
+query T
+SELECT my_list_or_string_extract_2([1, 2])
+----
+NULL
+
+statement error
+SELECT my_list_or_string_extract_2({a: 1, b: 2, c: 3, d: 4})
+
+statement ok
+CREATE MACRO my_struct_extract_c(my_struct) AS my_struct['c']
+
+query T
+SELECT my_struct_extract_c({a: 1, b: 2, c: 3, d: 4})
+----
+3
+
+statement error
+SELECT my_struct_extract_c({a: 1, b: 2, d: 4})
+
+statement ok
+CREATE MACRO my_specific_struct_extract(field) AS struct_pack(a:= 1, b:= 2, c:= 3, d:= 4)[field]
+
+query T
+SELECT my_specific_struct_extract('c')
+----
+3
+
+statement error
+SELECT my_specific_struct_extract(2)
+
+statement ok
+CREATE MACRO my_specific_list_extract(index) AS list_value(1, 2, 3, 4)[index]
+
+query T
+SELECT my_specific_list_extract(2)
+----
+3
+
+statement error
+SELECT my_specific_list_extract('c')
+
+statement ok
+CREATE MACRO my_specific_string_extract(index) AS '1234'[index]
+
+query T
+SELECT my_specific_string_extract(2)
+----
+3
+
+statement error
+SELECT my_specific_string_extract('c')


### PR DESCRIPTION
#2423 fixed this:
```sql
create macro agg_extracted_field(my_struct, my_field) as sum(my_struct[my_field]);
```

But the following macro creations still segfaulted:
```sql
create macro agg_extracted_field(my_struct) as my_struct['my_field'];
create macro agg_extracted_field(my_struct, my_field:='my_field') as my_struct[my_field];
```

This PR fixes these macro creations as well.