### PR TITLE
Issue #2432: PERCENTILE_XXXX ignores DESC

### DIFF
--- a/src/function/aggregate/holistic/quantile.cpp
+++ b/src/function/aggregate/holistic/quantile.cpp
@@ -158,6 +158,11 @@ string_t CastInterpolation::Cast(const std::string &src, Vector &result) {
 	return StringVector::AddString(result, src);
 }
 
+template <>
+string_t CastInterpolation::Cast(const string_t &src, Vector &result) {
+	return StringVector::AddString(result, src);
+}
+
 template <class INPUT_TYPE, class TARGET_TYPE, bool DISCRETE>
 struct Interpolator {
 	Interpolator(const double q, const idx_t n_p) : n(n_p), RN((double)(n_p - 1) * q), FRN(floor(RN)), CRN(ceil(RN)) {

--- a/src/parser/transform/expression/transform_function.cpp
+++ b/src/parser/transform/expression/transform_function.cpp
@@ -212,16 +212,23 @@ unique_ptr<ParsedExpression> Transformer::TransformFuncCall(duckdb_libpgquery::P
 			throw ParserException("Cannot use multiple ORDER BY clauses with WITHIN GROUP");
 		}
 		if (lowercase_name == "percentile_cont") {
+			if (children.size() != 1) {
+				throw ParserException("Wrong number of arguments for PERCENTILE_CONT");
+			}
 			lowercase_name = "quantile_cont";
 		} else if (lowercase_name == "percentile_disc") {
+			if (children.size() != 1) {
+				throw ParserException("Wrong number of arguments for PERCENTILE_DISC");
+			}
 			lowercase_name = "quantile_disc";
 		} else if (lowercase_name == "mode") {
+			if (!children.empty()) {
+				throw ParserException("Wrong number of arguments for MODE");
+			}
 			lowercase_name = "mode";
 		} else {
 			throw ParserException("Unknown ordered aggregate \"%s\".", function_name);
 		}
-		children.insert(children.begin(), move(order_bys->orders[0].expression));
-		order_bys->orders.clear();
 	}
 
 	// star gets eaten in the parser

--- a/test/sql/aggregate/aggregates/test_ordered_aggregates.test
+++ b/test/sql/aggregate/aggregates/test_ordered_aggregates.test
@@ -52,6 +52,32 @@ SELECT "dest", percentile_disc([0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY "arr_de
 FROM "flights"
 GROUP BY "dest"
 
+# ORDER BY DESC
+
+query I
+select percentile_disc(0.25) within group(order by i desc) from generate_series(0,100) tbl(i);
+----
+75
+
+query I
+select percentile_disc([0.25, 0.5, 0.75]) within group(order by i desc) from generate_series(0,100) tbl(i);
+----
+[75, 50, 25]
+
+query I
+select percentile_cont(0.25) within group(order by i desc) from generate_series(0,100) tbl(i);
+----
+75.000000
+
+query I
+select percentile_cont([0.25, 0.5, 0.75]) within group(order by i desc) from generate_series(0,100) tbl(i);
+----
+[75.000000, 50.000000, 25.000000]
+
+#
+# Error checking
+#
+
 # Cannot use multiple ORDER BY clauses with WITHIN GROUP
 statement error
 SELECT "dest", mode() WITHIN GROUP (ORDER BY "arr_delay", "arr_time") AS "median_delay"
@@ -63,3 +89,29 @@ statement error
 SELECT "dest", duck(0.5) WITHIN GROUP (ORDER BY "arr_delay") AS "duck_delay"
 FROM "flights"
 GROUP BY "dest"
+
+# Wrong number of arguments for PERCENTILE_DISC
+statement error
+select percentile_disc() within group(order by i) from generate_series(0,100) tbl(i);
+
+statement error
+select percentile_disc(0.25, 0.5) within group(order by i) from generate_series(0,100) tbl(i);
+
+# Wrong number of arguments for PERCENTILE_CONT
+statement error
+select percentile_cont() within group(order by i) from generate_series(0,100) tbl(i);
+
+statement error
+select percentile_cont(0.25, 0.5) within group(order by i) from generate_series(0,100) tbl(i);
+
+# Wrong number of arguments for MODE
+statement error
+select mode(0.25) within group(order by i) from generate_series(0,100) tbl(i);
+
+# No function matches the given name and argument types 'quantile_disc(BIGINT, VARCHAR)'
+statement error
+select percentile_disc('duck') within group(order by i) from generate_series(0,100) tbl(i);
+
+# No function matches the given name and argument types 'quantile_cont(BIGINT, VARCHAR)'
+statement error
+select percentile_cont('duck') within group(order by i) from generate_series(0,100) tbl(i);

--- a/test/sql/window/test_quantile_window.test
+++ b/test/sql/window/test_quantile_window.test
@@ -78,6 +78,79 @@ NULL	1
 8	8
 9	8
 
+#
+#  VARCHAR
+#
+query III
+SELECT r % 2, r, median(r::VARCHAR) over (partition by r % 2 order by r) FROM quantiles ORDER BY 1, 2
+----
+NULL	NULL	NULL
+NULL	NULL	NULL
+NULL	NULL	NULL
+0	0	0
+0	2	0
+0	4	2
+0	6	2
+0	8	4
+1	1	1
+1	3	1
+1	5	3
+1	7	3
+1	9	5
+
+
+query II
+SELECT r, median(r::VARCHAR) over (order by r rows between 1 preceding and 1 following) FROM quantiles ORDER BY 1, 2
+----
+NULL	NULL
+NULL	NULL
+NULL	0
+0	0
+1	1
+2	2
+3	3
+4	4
+5	5
+6	6
+7	7
+8	8
+9	8
+
+query II
+SELECT r, quantile(r::VARCHAR, 0.5) over (order by r rows between 1 preceding and 3 following) FROM quantiles ORDER BY 1, 2
+----
+NULL	0
+NULL	0
+NULL	1
+0	1
+1	2
+2	3
+3	4
+4	5
+5	6
+6	7
+7	7
+8	8
+9	8
+
+# Non-inlined
+query II
+SELECT r, median('prefix-' || r::VARCHAR || '-suffix') over (order by r rows between 1 preceding and 1 following) FROM quantiles ORDER BY 1, 2
+----
+NULL	NULL
+NULL	NULL
+NULL	prefix-0-suffix
+0	prefix-0-suffix
+1	prefix-1-suffix
+2	prefix-2-suffix
+3	prefix-3-suffix
+4	prefix-4-suffix
+5	prefix-5-suffix
+6	prefix-6-suffix
+7	prefix-7-suffix
+8	prefix-8-suffix
+9	prefix-8-suffix
+
 # Scattered NULLs
 query IIII
 SELECT r % 3, r, n, median(n) over (partition by r % 3 order by r)


### PR DESCRIPTION
Move the ordered set rewrites to the binder
where we have access to the default ordering from the context.
Correct the fractions for the QUANTILE_XXXX functions
by evaluating the constants and inverting them when ordering DESC.