### PR TITLE
fix: pass absolute path to `System.load()` in Java

### DIFF
--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBNative.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBNative.java
@@ -39,7 +39,7 @@ public class DuckDBNative {
 			}
 			Files.copy(lib_res.openStream(), lib_file, StandardCopyOption.REPLACE_EXISTING);
 			new File(lib_file.toString()).deleteOnExit();
-			System.load(lib_file.toString());
+			System.load(lib_file.toAbsolutePath().toString());
 		} catch (IOException e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
JDK `System.load()` requires an absolute path. If provided a relative path, it fails. The path returned by `Files.createTempFile()` may not be absolute.

See e.g. jdk8:
http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/lang/System.java#l1045

jdk17: https://github.com/openjdk/jdk/blob/jdk-17-ga/src/java.base/share/classes/java/lang/System.java#L1915-L1954