### PR TITLE
Hooold the loooock for Python Strings under Dataframe Object Columns

### DIFF
--- a/tools/pythonpkg/src/vector_conversion.cpp
+++ b/tools/pythonpkg/src/vector_conversion.cpp
@@ -204,9 +204,12 @@ void VectorConversion::NumpyToDuckDB(PandasColumnBindData &bind_data, py::array 
 					out_mask.SetInvalid(row);
 					continue;
 				}
-				py::handle object_handle = val;
-				str_val = py::str(object_handle);
-				val = str_val.ptr();
+				if (!py::isinstance<py::str>(val)) {
+					py::gil_scoped_acquire acquire;
+					py::handle object_handle = val;
+					str_val = py::str(object_handle);
+					val = str_val.ptr();
+				}
 			}
 			// Python 3 string representation:
 			// https://github.com/python/cpython/blob/3a8fdb28794b2f19f6c8464378fb8b46bce1f5f4/Include/cpython/unicodeobject.h#L79

--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_object.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_object.py
@@ -1,7 +1,9 @@
 import pandas as pd
 import duckdb
+import datetime
 
 class TestPandasObject(object):
+
     def test_object_to_string(self, duckdb_cursor):          
         con = duckdb.connect(database=':memory:', read_only=False)
         x = pd.DataFrame([[1, 'a', 2],[1, None, 2], [1, 1.1, 2], [1, 1.1, 2], [1, 1.1, 2]])
@@ -9,3 +11,9 @@ class TestPandasObject(object):
         con.register('view2', x)
         df = con.execute('select * from view2').fetchall()
         assert df == [(1, None, 2),(1, '1.1', 2), (1, '1.1', 2), (1, '1.1', 2)]
+
+    def test_2273(self, duckdb_cursor):          
+        return 
+        
+        df_in = pd.DataFrame([[datetime.date(1992, 7, 30)]])
+        assert duckdb.query("Select * from df_in").fetchall() == [('1992-07-30',)]


### PR DESCRIPTION
Issue #2273 

Basically, we have to hold the lock when creating py::strings if the dataframe column type is "object" and the type of that row is not a string already.