### PR TITLE
Switching the JDBC API over to streaming results. 

### DIFF
--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -199,7 +199,7 @@ JNIEXPORT jobject JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1execute(JNI
 		}
 	}
 
-	res_ref->res = stmt_ref->stmt->Execute(duckdb_params, false);
+	res_ref->res = stmt_ref->stmt->Execute(duckdb_params, true);
 	if (!res_ref->res->success) {
 		string error_msg = string(res_ref->res->error);
 		res_ref->res = nullptr;

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -1387,6 +1387,29 @@ public class TestDuckDBJDBC {
 		conn.close();
 	}
 
+	// we can't have multiple open result sets at the same time, so fetching from an old one while a new one is open throws an error
+	public static void test_multiple_open_results() throws Exception {
+		DuckDBConnection conn = (DuckDBConnection) DriverManager.getConnection("jdbc:duckdb:");
+		Statement stmt = conn.createStatement();
+
+		ResultSet rs = stmt.executeQuery("SELECT * FROM range(100000)");
+		assertTrue(rs.next());
+
+		ResultSet rs2 = stmt.executeQuery("SELECT * FROM range(100000)");
+		assertTrue(rs2.next());
+
+		try {
+			rs.next();
+			fail();
+		} catch (Exception e) {
+		}
+
+		rs.close();
+		rs2.close();
+		stmt.close();
+		conn.close();
+	}
+
 	public static void main(String[] args) throws Exception {
 		// Woo I can do reflection too, take this, JUnit!
 		Method[] methods = TestDuckDBJDBC.class.getMethods();


### PR DESCRIPTION
restriction is that there cannot be two open result sets on a single connection any more

Should fix #2457