### PR TITLE
Move Kahan sum to separate method (fsum, sum_kahan)

### DIFF
--- a/src/function/aggregate/distributive/sum.cpp
+++ b/src/function/aggregate/distributive/sum.cpp
@@ -45,7 +45,7 @@ struct SumToHugeintOperation : public BaseSumOperation<SumSetOperation, HugeintA
 	}
 };
 
-template<class ADD_OPERATOR>
+template <class ADD_OPERATOR>
 struct DoubleSumOperation : public BaseSumOperation<SumSetOperation, ADD_OPERATOR> {
 	template <class T, class STATE>
 	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, ValidityMask &mask, idx_t idx) {

--- a/src/function/aggregate/distributive/sum.cpp
+++ b/src/function/aggregate/distributive/sum.cpp
@@ -45,7 +45,8 @@ struct SumToHugeintOperation : public BaseSumOperation<SumSetOperation, HugeintA
 	}
 };
 
-struct NumericSumOperation : public BaseSumOperation<SumSetOperation, DoubleAdd> {
+template<class ADD_OPERATOR>
+struct DoubleSumOperation : public BaseSumOperation<SumSetOperation, ADD_OPERATOR> {
 	template <class T, class STATE>
 	static void Finalize(Vector &result, FunctionData *, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
 		if (!state->isset) {
@@ -58,6 +59,9 @@ struct NumericSumOperation : public BaseSumOperation<SumSetOperation, DoubleAdd>
 		}
 	}
 };
+
+using NumericSumOperation = DoubleSumOperation<RegularAdd>;
+using KahanSumOperation = DoubleSumOperation<KahanAdd>;
 
 struct HugeintSumOperation : public BaseSumOperation<SumSetOperation, RegularAdd> {
 	template <class T, class STATE>
@@ -167,12 +171,23 @@ void SumFun::RegisterFunction(BuiltinFunctions &set) {
 	sum.AddFunction(GetSumAggregate(PhysicalType::INT32));
 	sum.AddFunction(GetSumAggregate(PhysicalType::INT64));
 	sum.AddFunction(GetSumAggregate(PhysicalType::INT128));
-	// float sums to float
-	// FIXME: implement http://ic.ese.upenn.edu/pdf/parallel_fpaccum_tc2016.pdf for parallel FP sums
 	sum.AddFunction(AggregateFunction::UnaryAggregate<SumState<double>, double, double, NumericSumOperation>(
 	    LogicalType::DOUBLE, LogicalType::DOUBLE));
 
 	set.AddFunction(sum);
+
+	// fsum
+	AggregateFunctionSet fsum("fsum");
+	fsum.AddFunction(AggregateFunction::UnaryAggregate<KahanSumState, double, double, KahanSumOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
+
+	set.AddFunction(fsum);
+
+	fsum.name = "kahan_sum";
+	set.AddFunction(fsum);
+
+	fsum.name = "sumKahan";
+	set.AddFunction(fsum);
 }
 
 } // namespace duckdb

--- a/test/sql/aggregate/aggregates/test_kahan_avg.test
+++ b/test/sql/aggregate/aggregates/test_kahan_avg.test
@@ -10,6 +10,6 @@ INSERT INTO doubles (n) VALUES ('9007199254740992'::DOUBLE), (1::DOUBLE), (1::DO
 
 # this would give the wrong result with a simple sum-and-divide
 query R
-SELECT AVG(n) - '2251799813685248.5'::DOUBLE FROM doubles;
+SELECT FAVG(n) - '2251799813685248.5'::DOUBLE FROM doubles;
 ----
 0

--- a/test/sql/aggregate/aggregates/test_kahan_sum.test
+++ b/test/sql/aggregate/aggregates/test_kahan_sum.test
@@ -10,6 +10,16 @@ INSERT INTO doubles (n) VALUES ('9007199254740992'::DOUBLE), (1::DOUBLE), (1::DO
 
 # this would give the wrong result with a simple sum
 query I
-SELECT SUM(n)::BIGINT FROM doubles;
+SELECT FSUM(n)::BIGINT FROM doubles;
+----
+9007199254740994
+
+query I
+SELECT sumKahan(n)::BIGINT FROM doubles;
+----
+9007199254740994
+
+query I
+SELECT kahan_sum(n)::BIGINT FROM doubles;
 ----
 9007199254740994


### PR DESCRIPTION
After some more discussion and investigation we have opted to move the Kahan sum to a separate function, since the performance impact is much more significant than initially thought  (`SELECT SUM(d) FROM tbl` is slowed down by a factor ~3X, see table below) and most other systems do not perform compensated/accurate floating point summation by default.

The Kahan sum is now available as a separate function as either `fsum` (inspired by [Python](https://docs.python.org/3/library/math.html)), sumKahan (inspired by [ClickHouse](https://clickhouse.com/docs/en/sql-reference/aggregate-functions/reference/sumkahan/)), and kahan_sum.

Usage:

```sql
SELECT fsum(d) FROM table;
```

100M rows:

| Method | Time  |
|--------|------:|
| avg    | 0.18s |
| sum    | 0.18s |
| fsum   | 0.47s |
| favg   | 0.47s |
