### PR TITLE
Add LIST_CONCAT and LIST_APPEND functions

### DIFF
--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -88,7 +88,9 @@ static DefaultMacro internal_macros[] = {
 	{DEFAULT_SCHEMA, "nullif", {"a", "b", nullptr}, "CASE WHEN a=b THEN NULL ELSE a END"},
 	{DEFAULT_SCHEMA, "list_append", {"l", "e", nullptr}, "list_concat(l, list_value(e))"},
 	{DEFAULT_SCHEMA, "array_append", {"arr", "el", nullptr}, "list_append(arr, el)"},
-    {nullptr, nullptr, {nullptr}, nullptr}};
+	{DEFAULT_SCHEMA, "list_prepend", {"e", "l", nullptr}, "list_concat(list_value(e), l)"},
+	{DEFAULT_SCHEMA, "array_prepend", {"el", "arr", nullptr}, "list_prepend(el, arr)"},
+	{nullptr, nullptr, {nullptr}, nullptr}};
 
 static unique_ptr<CreateFunctionInfo> GetDefaultFunction(const string &schema, const string &name) {
 	for (idx_t index = 0; internal_macros[index].name != nullptr; index++) {

--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -86,6 +86,8 @@ static DefaultMacro internal_macros[] = {
 	{DEFAULT_SCHEMA, "round_even", {"x", "n", nullptr}, "CASE ((abs(x) * power(10, n+1)) % 10) WHEN 5 THEN round(x/2, n) * 2 ELSE round(x, n) END"},
 	{DEFAULT_SCHEMA, "roundbankers", {"x", "n", nullptr}, "round_even(x, n)"},
 	{DEFAULT_SCHEMA, "nullif", {"a", "b", nullptr}, "CASE WHEN a=b THEN NULL ELSE a END"},
+    {DEFAULT_SCHEMA, "list_append", {"l", "e", nullptr}, "list_concat(l, list_value(e))"},
+    {DEFAULT_SCHEMA, "array_append", {"arr", "el", nullptr}, "list_append(arr, el)"},
     {nullptr, nullptr, {nullptr}, nullptr}};
 
 static unique_ptr<CreateFunctionInfo> GetDefaultFunction(const string &schema, const string &name) {

--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -86,8 +86,8 @@ static DefaultMacro internal_macros[] = {
 	{DEFAULT_SCHEMA, "round_even", {"x", "n", nullptr}, "CASE ((abs(x) * power(10, n+1)) % 10) WHEN 5 THEN round(x/2, n) * 2 ELSE round(x, n) END"},
 	{DEFAULT_SCHEMA, "roundbankers", {"x", "n", nullptr}, "round_even(x, n)"},
 	{DEFAULT_SCHEMA, "nullif", {"a", "b", nullptr}, "CASE WHEN a=b THEN NULL ELSE a END"},
-    {DEFAULT_SCHEMA, "list_append", {"l", "e", nullptr}, "list_concat(l, list_value(e))"},
-    {DEFAULT_SCHEMA, "array_append", {"arr", "el", nullptr}, "list_append(arr, el)"},
+	{DEFAULT_SCHEMA, "list_append", {"l", "e", nullptr}, "list_concat(l, list_value(e))"},
+	{DEFAULT_SCHEMA, "array_append", {"arr", "el", nullptr}, "list_append(arr, el)"},
     {nullptr, nullptr, {nullptr}, nullptr}};
 
 static unique_ptr<CreateFunctionInfo> GetDefaultFunction(const string &schema, const string &name) {

--- a/src/function/scalar/list/CMakeLists.txt
+++ b/src/function/scalar/list/CMakeLists.txt
@@ -1,5 +1,11 @@
-add_library_unity(duckdb_func_list OBJECT array_slice.cpp list_extract.cpp
-                  list_value.cpp range.cpp)
+add_library_unity(
+  duckdb_func_list
+  OBJECT
+  list_concat.cpp
+  array_slice.cpp
+  list_extract.cpp
+  list_value.cpp
+  range.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_list>
     PARENT_SCOPE)

--- a/src/function/scalar/list/list_concat.cpp
+++ b/src/function/scalar/list/list_concat.cpp
@@ -1,0 +1,132 @@
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/function/scalar/nested_functions.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/storage/statistics/list_statistics.hpp"
+#include "duckdb/storage/statistics/validity_statistics.hpp"
+
+namespace duckdb {
+
+static void ListConcatFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 2);
+	auto count = args.size();
+
+	Vector &lhs = args.data[0];
+	Vector &rhs = args.data[1];
+	if (lhs.GetType().id() == LogicalTypeId::SQLNULL || rhs.GetType().id() == LogicalTypeId::SQLNULL) {
+		// If either side is NULL the result is NULL
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		return;
+	}
+
+	VectorData lhs_data;
+	VectorData rhs_data;
+	lhs.Orrify(count, lhs_data);
+	rhs.Orrify(count, rhs_data);
+	auto lhs_entries = (list_entry_t *)lhs_data.data;
+	auto rhs_entries = (list_entry_t *)rhs_data.data;
+
+	auto lhs_list_size = ListVector::GetListSize(lhs);
+	auto rhs_list_size = ListVector::GetListSize(rhs);
+	auto &lhs_child = ListVector::GetEntry(lhs);
+	auto &rhs_child = ListVector::GetEntry(rhs);
+	VectorData lhs_child_data;
+	VectorData rhs_child_data;
+	lhs_child.Orrify(lhs_list_size, lhs_child_data);
+	rhs_child.Orrify(rhs_list_size, rhs_child_data);
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_entries = FlatVector::GetData<list_entry_t>(result);
+	auto &result_validity = FlatVector::Validity(result);
+
+	idx_t offset = 0;
+	for (idx_t i = 0; i < count; i++) {
+		auto lhs_list_index = lhs_data.sel->get_index(i);
+		auto rhs_list_index = rhs_data.sel->get_index(i);
+		if (!lhs_data.validity.RowIsValid(lhs_list_index) || !rhs_data.validity.RowIsValid(rhs_list_index)) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+		const auto &lhs_entry = lhs_entries[lhs_list_index];
+		const auto &rhs_entry = rhs_entries[rhs_list_index];
+
+		result_entries[i].offset = offset;
+		result_entries[i].length = lhs_entry.length + rhs_entry.length;
+		offset += result_entries[i].length;
+
+		ListVector::Append(result, lhs_child, *lhs_child_data.sel, lhs_entry.offset + lhs_entry.length,
+		                   lhs_entry.offset);
+		ListVector::Append(result, rhs_child, *rhs_child_data.sel, rhs_entry.offset + rhs_entry.length,
+		                   rhs_entry.offset);
+	}
+	D_ASSERT(ListVector::GetListSize(result) == offset);
+
+	if (lhs.GetVectorType() == VectorType::CONSTANT_VECTOR && rhs.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+}
+
+static unique_ptr<FunctionData> ListConcatBind(ClientContext &context, ScalarFunction &bound_function,
+                                               vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(bound_function.arguments.size() == 2);
+
+	auto &lhs = arguments[0]->return_type;
+	auto &rhs = arguments[1]->return_type;
+	if (lhs.id() == LogicalTypeId::SQLNULL) {
+		bound_function.arguments[0] = LogicalType::SQLNULL;
+	}
+	if (rhs.id() == LogicalTypeId::SQLNULL) {
+		bound_function.arguments[1] = LogicalType::SQLNULL;
+	}
+	if (lhs.id() == LogicalTypeId::SQLNULL || rhs.id() == LogicalTypeId::SQLNULL) {
+		bound_function.return_type = LogicalType::SQLNULL;
+	} else {
+		D_ASSERT(lhs.id() == LogicalTypeId::LIST);
+		D_ASSERT(rhs.id() == LogicalTypeId::LIST);
+
+		auto &lhs_child_type = ListType::GetChildType(lhs);
+		auto &rhs_child_type = ListType::GetChildType(rhs);
+		if (lhs_child_type.id() == LogicalTypeId::SQLNULL) {
+			bound_function.arguments[0] = rhs;
+			bound_function.arguments[1] = rhs;
+			bound_function.return_type = rhs;
+		} else if (rhs_child_type.id() == LogicalTypeId::SQLNULL) {
+			bound_function.arguments[0] = lhs;
+			bound_function.arguments[1] = lhs;
+			bound_function.return_type = lhs;
+		} else if (lhs_child_type.id() != rhs_child_type.id()) {
+			throw TypeMismatchException(lhs, rhs, "Cannot concatenate lists with different child types");
+		} else {
+			bound_function.arguments[0] = lhs;
+			bound_function.arguments[1] = lhs;
+			bound_function.return_type = lhs;
+		}
+	}
+	return make_unique<VariableReturnBindData>(bound_function.return_type);
+}
+
+static unique_ptr<BaseStatistics> ListConcatStats(ClientContext &context, BoundFunctionExpression &expr,
+                                                  FunctionData *bind_data,
+                                                  vector<unique_ptr<BaseStatistics>> &child_stats) {
+	D_ASSERT(child_stats.size() == 2);
+	if (!child_stats[0] || !child_stats[1]) {
+		return nullptr;
+	}
+
+	auto &left_stats = (ListStatistics &)*child_stats[0];
+	auto &right_stats = (ListStatistics &)*child_stats[1];
+
+	auto stats = left_stats.Copy();
+	stats->Merge(right_stats);
+
+	return stats;
+}
+
+void ListConcatFun::RegisterFunction(BuiltinFunctions &set) {
+	// the arguments and return types are actually set in the binder function
+	ScalarFunction lfun({LogicalType::LIST(LogicalType::ANY), LogicalType::LIST(LogicalType::ANY)},
+	                    LogicalType::LIST(LogicalType::ANY), ListConcatFunction, false, ListConcatBind, nullptr,
+	                    ListConcatStats);
+	set.AddFunction({"list_concat", "list_cat", "array_concat", "array_cat"}, lfun);
+}
+
+} // namespace duckdb

--- a/src/function/scalar/list/list_extract.cpp
+++ b/src/function/scalar/list/list_extract.cpp
@@ -1,12 +1,12 @@
-#include "duckdb/common/pair.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/common/string_util.hpp"
-#include "duckdb/common/types/chunk_collection.hpp"
-#include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/vector_operations/binary_executor.hpp"
+#include "duckdb/parser/expression/bound_expression.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
-#include "duckdb/parser/expression/bound_expression.hpp"
-#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/common/types/chunk_collection.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/pair.hpp"
 #include "duckdb/storage/statistics/list_statistics.hpp"
 #include "duckdb/storage/statistics/validity_statistics.hpp"
 
@@ -210,10 +210,26 @@ static unique_ptr<FunctionData> ListExtractBind(ClientContext &context, ScalarFu
 	return make_unique<VariableReturnBindData>(bound_function.return_type);
 }
 
+static unique_ptr<BaseStatistics> ListExtractStats(ClientContext &context, BoundFunctionExpression &expr,
+                                                   FunctionData *bind_data,
+                                                   vector<unique_ptr<BaseStatistics>> &child_stats) {
+	if (!child_stats[0]) {
+		return nullptr;
+	}
+	auto &list_stats = (ListStatistics &)*child_stats[0];
+	if (!list_stats.child_stats) {
+		return nullptr;
+	}
+	auto child_copy = list_stats.child_stats->Copy();
+	// list_extract always pushes a NULL, since if the offset is out of range for a list it inserts a null
+	child_copy->validity_stats = make_unique<ValidityStatistics>(true);
+	return child_copy;
+}
+
 void ListExtractFun::RegisterFunction(BuiltinFunctions &set) {
 	// the arguments and return types are actually set in the binder function
 	ScalarFunction lfun({LogicalType::LIST(LogicalType::ANY), LogicalType::BIGINT}, LogicalType::ANY,
-	                    ListExtractFunction, false, ListExtractBind, nullptr, nullptr);
+	                    ListExtractFunction, false, ListExtractBind, nullptr, ListExtractStats);
 
 	ScalarFunction sfun({LogicalType::VARCHAR, LogicalType::INTEGER}, LogicalType::VARCHAR, ListExtractFunction, false,
 	                    nullptr);

--- a/src/function/scalar/list/list_extract.cpp
+++ b/src/function/scalar/list/list_extract.cpp
@@ -1,12 +1,12 @@
-#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/common/pair.hpp"
 #include "duckdb/common/string_util.hpp"
-#include "duckdb/common/vector_operations/binary_executor.hpp"
-#include "duckdb/parser/expression/bound_expression.hpp"
-#include "duckdb/function/scalar/nested_functions.hpp"
-#include "duckdb/function/scalar/string_functions.hpp"
 #include "duckdb/common/types/chunk_collection.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
-#include "duckdb/common/pair.hpp"
+#include "duckdb/common/vector_operations/binary_executor.hpp"
+#include "duckdb/function/scalar/nested_functions.hpp"
+#include "duckdb/function/scalar/string_functions.hpp"
+#include "duckdb/parser/expression/bound_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/storage/statistics/list_statistics.hpp"
 #include "duckdb/storage/statistics/validity_statistics.hpp"
 
@@ -210,26 +210,10 @@ static unique_ptr<FunctionData> ListExtractBind(ClientContext &context, ScalarFu
 	return make_unique<VariableReturnBindData>(bound_function.return_type);
 }
 
-static unique_ptr<BaseStatistics> ListExtractStats(ClientContext &context, BoundFunctionExpression &expr,
-                                                   FunctionData *bind_data,
-                                                   vector<unique_ptr<BaseStatistics>> &child_stats) {
-	if (!child_stats[0]) {
-		return nullptr;
-	}
-	auto &list_stats = (ListStatistics &)*child_stats[0];
-	if (!list_stats.child_stats) {
-		return nullptr;
-	}
-	auto child_copy = list_stats.child_stats->Copy();
-	// list_extract always pushes a NULL, since if the offset is out of range for a list it inserts a null
-	child_copy->validity_stats = make_unique<ValidityStatistics>(true);
-	return child_copy;
-}
-
 void ListExtractFun::RegisterFunction(BuiltinFunctions &set) {
 	// the arguments and return types are actually set in the binder function
 	ScalarFunction lfun({LogicalType::LIST(LogicalType::ANY), LogicalType::BIGINT}, LogicalType::ANY,
-	                    ListExtractFunction, false, ListExtractBind, nullptr, ListExtractStats);
+	                    ListExtractFunction, false, ListExtractBind, nullptr, nullptr);
 
 	ScalarFunction sfun({LogicalType::VARCHAR, LogicalType::INTEGER}, LogicalType::VARCHAR, ListExtractFunction, false,
 	                    nullptr);

--- a/src/function/scalar/nested_functions.cpp
+++ b/src/function/scalar/nested_functions.cpp
@@ -6,6 +6,7 @@ void BuiltinFunctions::RegisterNestedFunctions() {
 	Register<ArraySliceFun>();
 	Register<StructPackFun>();
 	Register<StructExtractFun>();
+	Register<ListConcatFun>();
 	Register<ListValueFun>();
 	Register<ListExtractFun>();
 	Register<ListRangeFun>();

--- a/src/function/scalar/operators/arithmetic.cpp
+++ b/src/function/scalar/operators/arithmetic.cpp
@@ -335,7 +335,7 @@ void AddFun::RegisterFunction(BuiltinFunctions &set) {
 	functions.AddFunction(GetFunction(LogicalType::TIMESTAMP, LogicalType::INTERVAL));
 	functions.AddFunction(GetFunction(LogicalType::INTERVAL, LogicalType::TIMESTAMP));
 	// we can add lists together
-	functions.AddFunction(GetFunction(LogicalType::LIST(LogicalType::ANY), LogicalType::LIST(LogicalType::ANY)));
+	functions.AddFunction(ListConcatFun::GetFunction());
 
 	set.AddFunction(functions);
 }

--- a/src/function/scalar/operators/arithmetic.cpp
+++ b/src/function/scalar/operators/arithmetic.cpp
@@ -286,11 +286,6 @@ ScalarFunction AddFun::GetFunction(const LogicalType &left_type, const LogicalTy
 			                      ScalarFunction::BinaryFunction<interval_t, timestamp_t, timestamp_t, AddOperator>);
 		}
 		break;
-	case LogicalTypeId::LIST:
-		if (right_type.id() == LogicalTypeId::LIST) {
-			return ListConcatFun::GetFunction();
-		}
-		break;
 	case LogicalTypeId::TIME:
 		if (right_type.id() == LogicalTypeId::INTERVAL) {
 			return ScalarFunction("+", {left_type, right_type}, LogicalType::TIME,

--- a/src/function/scalar/operators/arithmetic.cpp
+++ b/src/function/scalar/operators/arithmetic.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/function/scalar/operators.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/storage/statistics/numeric_statistics.hpp"
+#include "duckdb/function/scalar/nested_functions.hpp"
 
 #include <limits>
 
@@ -285,6 +286,11 @@ ScalarFunction AddFun::GetFunction(const LogicalType &left_type, const LogicalTy
 			                      ScalarFunction::BinaryFunction<interval_t, timestamp_t, timestamp_t, AddOperator>);
 		}
 		break;
+	case LogicalTypeId::LIST:
+		if (right_type.id() == LogicalTypeId::LIST) {
+			return ListConcatFun::GetFunction();
+		}
+		break;
 	case LogicalTypeId::TIME:
 		if (right_type.id() == LogicalTypeId::INTERVAL) {
 			return ScalarFunction("+", {left_type, right_type}, LogicalType::TIME,
@@ -328,6 +334,8 @@ void AddFun::RegisterFunction(BuiltinFunctions &set) {
 
 	functions.AddFunction(GetFunction(LogicalType::TIMESTAMP, LogicalType::INTERVAL));
 	functions.AddFunction(GetFunction(LogicalType::INTERVAL, LogicalType::TIMESTAMP));
+	// we can add lists together
+	functions.AddFunction(GetFunction(LogicalType::LIST(LogicalType::ANY), LogicalType::LIST(LogicalType::ANY)));
 
 	set.AddFunction(functions);
 }

--- a/src/function/scalar/string/concat.cpp
+++ b/src/function/scalar/string/concat.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/date.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/common/vector_operations/binary_executor.hpp"
+#include "duckdb/function/scalar/nested_functions.hpp"
 
 #include <string.h>
 
@@ -250,6 +251,7 @@ void ConcatFun::RegisterFunction(BuiltinFunctions &set) {
 	concat_op.AddFunction(
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR, ConcatOperator));
 	concat_op.AddFunction(ScalarFunction({LogicalType::BLOB, LogicalType::BLOB}, LogicalType::BLOB, ConcatOperator));
+	concat_op.AddFunction(ListConcatFun::GetFunction());
 	set.AddFunction(concat_op);
 
 	ScalarFunction concat_ws = ScalarFunction("concat_ws", {LogicalType::VARCHAR, LogicalType::VARCHAR},

--- a/src/include/duckdb/function/scalar/nested_functions.hpp
+++ b/src/include/duckdb/function/scalar/nested_functions.hpp
@@ -53,6 +53,7 @@ struct ListExtractFun {
 };
 
 struct ListConcatFun {
+	static ScalarFunction GetFunction();
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 

--- a/src/include/duckdb/function/scalar/nested_functions.hpp
+++ b/src/include/duckdb/function/scalar/nested_functions.hpp
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include "duckdb/function/scalar_function.hpp"
 #include "duckdb/function/function_set.hpp"
+#include "duckdb/function/scalar_function.hpp"
 
 namespace duckdb {
 
@@ -47,9 +47,15 @@ struct MapFun {
 struct MapExtractFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
+
 struct ListExtractFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
+
+struct ListConcatFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct CardinalityFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/test/sql/function/list/list_concat.test
+++ b/test/sql/function/list/list_concat.test
@@ -5,6 +5,7 @@
 statement ok
 PRAGMA enable_verification
 
+# basic functionality
 query T
 SELECT list_concat([1, 2], [3, 4])
 ----
@@ -18,12 +19,12 @@ SELECT array_cat([1, 2], [3, 4])
 query T
 SELECT list_concat(NULL, [3, 4])
 ----
-NULL
+[3, 4]
 
 query T
 SELECT list_concat([1, 2], NULL)
 ----
-NULL
+[1, 2]
 
 query T
 SELECT list_concat([], [])
@@ -41,11 +42,44 @@ SELECT list_concat([1, 2], [])
 [1, 2]
 
 statement error
-SELECT list_concat(['a', 'b'], [3, 4])
+SELECT list_concat([1, 2], 3)
 
-statement error
-SELECT list_concat([1, 2], ['c', 'd'])
+# operators
+query T
+SELECT [1, 2] || [3, 4]
+----
+[1, 2, 3, 4]
 
+query T
+SELECT [1, 2] + [3, 4]
+----
+[1, 2, 3, 4]
+
+# type casting
+foreach type_a <integral> varchar
+
+foreach type_b <integral> varchar
+
+query T
+SELECT list_concat([1, 2]::${type_a}[], [3, 4]::${type_b}[])
+----
+[1, 2, 3, 4]
+
+endloop
+
+endloop
+
+query T
+SELECT list_concat([1.000000, 2.000000]::float[], [3.000000, 4.000000]::double[])
+----
+[1.000000, 2.000000, 3.000000, 4.000000]
+
+query T
+SELECT list_concat([1.000000, 2.000000]::double[], [3.000000, 4.000000]::float[])
+----
+[1.000000, 2.000000, 3.000000, 4.000000]
+
+# nulls
 query T
 SELECT list_concat([NULL], [NULL])
 ----
@@ -66,10 +100,16 @@ SELECT list_concat([[1, 2]], [[3, 4]])
 ----
 [[1, 2], [3, 4]]
 
+# nested types
 query T
 SELECT list_concat([{a: 1}, {a: 2}], [{a: 3}, {a: 4}])
 ----
 [{'a': 1}, {'a': 2}, {'a': 3}, {'a': 4}]
+
+query T
+SELECT list_concat([[[1], [2]], [[3], [4]]], [[[5], [6]], [[7], [8]]])
+----
+[[[1], [2]], [[3], [4]], [[5], [6]], [[7], [8]]]
 
 statement ok
 CREATE TABLE test AS SELECT range % 4 i, range j, range k FROM range(16)
@@ -102,7 +142,7 @@ SELECT list_append([1, 2], NULL)
 query T
 SELECT list_append(NULL, 3)
 ----
-NULL
+[3]
 
 query II
 SELECT i, list_append(list_concat(j, k), i) FROM lists

--- a/test/sql/function/list/list_concat.test
+++ b/test/sql/function/list/list_concat.test
@@ -151,3 +151,14 @@ SELECT i, list_append(list_concat(j, k), i) FROM lists
 1	[1, 5, 9, 13, 1, 5, 9, 13, 1]
 2	[2, 6, 10, 14, 2, 6, 10, 14, 2]
 3	[3, 7, 11, 15, 3, 7, 11, 15, 3]
+
+# prepend macro
+query T
+SELECT list_prepend(1, [2, 3])
+----
+[1, 2, 3]
+
+query T
+SELECT array_prepend(1, [2, 3])
+----
+[1, 2, 3]

--- a/test/sql/function/list/list_concat.test
+++ b/test/sql/function/list/list_concat.test
@@ -1,0 +1,113 @@
+# name: test/sql/function/list/list_concat.test
+# description: Test list_concat function
+# group: [list]
+
+statement ok
+PRAGMA enable_verification
+
+query T
+SELECT list_concat([1, 2], [3, 4])
+----
+[1, 2, 3, 4]
+
+query T
+SELECT array_cat([1, 2], [3, 4])
+----
+[1, 2, 3, 4]
+
+query T
+SELECT list_concat(NULL, [3, 4])
+----
+NULL
+
+query T
+SELECT list_concat([1, 2], NULL)
+----
+NULL
+
+query T
+SELECT list_concat([], [])
+----
+[]
+
+query T
+SELECT list_concat([], [3, 4])
+----
+[3, 4]
+
+query T
+SELECT list_concat([1, 2], [])
+----
+[1, 2]
+
+statement error
+SELECT list_concat(['a', 'b'], [3, 4])
+
+statement error
+SELECT list_concat([1, 2], ['c', 'd'])
+
+query T
+SELECT list_concat([NULL], [NULL])
+----
+[NULL, NULL]
+
+query T
+SELECT list_concat([1, 2], [NULL])
+----
+[1, 2, NULL]
+
+query T
+SELECT list_concat([NULL], [3, 4])
+----
+[NULL, 3, 4]
+
+query T
+SELECT list_concat([[1, 2]], [[3, 4]])
+----
+[[1, 2], [3, 4]]
+
+query T
+SELECT list_concat([{a: 1}, {a: 2}], [{a: 3}, {a: 4}])
+----
+[{'a': 1}, {'a': 2}, {'a': 3}, {'a': 4}]
+
+statement ok
+CREATE TABLE test AS SELECT range % 4 i, range j, range k FROM range(16)
+
+statement ok
+CREATE TABLE lists AS SELECT i, list(j) j, list(k) k FROM test GROUP BY i
+
+query II
+SELECT i, list_concat(j, k) FROM lists
+----
+0	[0, 4, 8, 12, 0, 4, 8, 12]
+1	[1, 5, 9, 13, 1, 5, 9, 13]
+2	[2, 6, 10, 14, 2, 6, 10, 14]
+3	[3, 7, 11, 15, 3, 7, 11, 15]
+
+statement error
+SELECT i, list_concat(j, cast(k AS VARCHAR)) FROM lists
+
+# list_append(l, e) is an alias for list_concat(l, list_value(e))
+query T
+SELECT list_append([1, 2], 3)
+----
+[1, 2, 3]
+
+query T
+SELECT list_append([1, 2], NULL)
+----
+[1, 2, NULL]
+
+query T
+SELECT list_append(NULL, 3)
+----
+NULL
+
+query II
+SELECT i, list_append(list_concat(j, k), i) FROM lists
+----
+0	[0, 4, 8, 12, 0, 4, 8, 12, 0]
+1	[1, 5, 9, 13, 1, 5, 9, 13, 1]
+2	[2, 6, 10, 14, 2, 6, 10, 14, 2]
+3	[3, 7, 11, 15, 3, 7, 11, 15, 3]


### PR DESCRIPTION
This PR implements `list_concat(listA, listB)` that appends lists to each other.
```sql
SELECT list_concat([1, 2], [3, 4])
--- [1, 2, 3, 4]
```
It has 3 aliases: `list_cat`, `array_concat` and `array_cat`.

I've added the macro `list_append(list, element)` that appends a value to a list (`list_append(l, e)` gets rewritten to `list_append(l, list_value(e))`. This has one alias: `array_append`.

@szarnyasg 