### PR TITLE
MSD Radix Sort

### DIFF
--- a/src/common/sort/radix_sort.cpp
+++ b/src/common/sort/radix_sort.cpp
@@ -269,11 +269,10 @@ void LocalSortState::SortInMemory() {
 	idx_t sorting_size = 0;
 	idx_t col_offset = 0;
 	unique_ptr<bool[]> ties_ptr;
-	unique_ptr<BufferHandle> ties_handle;
 	bool *ties = nullptr;
 	for (idx_t i = 0; i < sort_layout->column_count; i++) {
 		sorting_size += sort_layout->column_sizes[i];
-		if (sort_layout->constant_size[i] && i < sort_layout->column_count - 1 && sorting_size < 32) {
+		if (sort_layout->constant_size[i] && i < sort_layout->column_count - 1) {
 			// Add columns to the sorting size until we reach a variable size column, or the last column
 			continue;
 		}

--- a/src/include/duckdb/common/sort/sort.hpp
+++ b/src/include/duckdb/common/sort/sort.hpp
@@ -17,6 +17,13 @@ namespace duckdb {
 class RowLayout;
 struct LocalSortState;
 
+struct SortConstants {
+	static constexpr idx_t VALUES_PER_RADIX = 256;
+	static constexpr idx_t MSD_RADIX_LOCATIONS = VALUES_PER_RADIX + 1;
+	static constexpr idx_t INSERTION_SORT_THRESHOLD = 24;
+	static constexpr idx_t MSD_RADIX_SORT_SIZE_THRESHOLD = 4;
+};
+
 struct SortLayout {
 public:
 	explicit SortLayout(const vector<BoundOrderByNode> &orders);


### PR DESCRIPTION
This PR implements MSD radix sort.

We already used LSD radix sort, which is better for smaller sorting key sizes, and fixed-size types. I've implemented MSD radix sort now, which recurses into insertion sort when bucket sizes are small. This should perform better on strings. The sorting algorithm is chosen at runtime 

I've added a minor optimisation to both radix sorts: if all values are in the same bucket after counting, the data is not distributed, because this is pointless. This optimisation should help especially when there are string ties, because we encode a prefix and pad with `'\0'`. This caused a lot of pointless `memcpy`'s.

I've ran a quick benchmark sorting strings on TPC-DS SF300:
```sql
.timer on
.mode trash
SELECT c_customer_sk FROM customer ORDER BY c_first_name, c_last_name;
```
And here are the results:
| Old | New |
| :- | :- |
| 0.572 | 0.391 |