### PR TITLE
Fix #2531: in recursive CTE avoid waiting for events to finish if an event has thrown an error

### DIFF
--- a/src/execution/operator/set/physical_recursive_cte.cpp
+++ b/src/execution/operator/set/physical_recursive_cte.cpp
@@ -124,6 +124,9 @@ void PhysicalRecursiveCTE::ExecuteRecursivePipelines(ExecutionContext &context) 
 
 	while (true) {
 		executor.WorkOnTasks();
+		if (executor.HasError()) {
+			executor.ThrowException();
+		}
 		bool finished = true;
 		for (auto &event : events) {
 			if (!event->IsFinished()) {

--- a/test/sql/cte/recursive_cte_error.test
+++ b/test/sql/cte/recursive_cte_error.test
@@ -1,0 +1,30 @@
+# name: test/sql/cte/recursive_cte_error.test
+# description: Recursive CTEs with an error thrown in the pipelines
+# group: [cte]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE tag(id int, name string, subclassof int);
+
+statement ok
+INSERT INTO tag VALUES
+  (7, 'Music',  9),
+  (8, 'Movies', 9),
+  (9, 'Art',    NULL)
+;
+
+statement error
+WITH RECURSIVE tag_hierarchy(id, source, path, target) AS (
+  SELECT id, name, name AS path, NULL AS target -- this should be '' for correct behaviour
+  FROM tag
+  WHERE subclassof IS NULL
+  UNION ALL
+  SELECT tag.id, tag.name, tag_hierarchy.path || ' <- ' || tag.name, tag.name AS target
+  FROM tag, tag_hierarchy
+  WHERE tag.subclassof = tag_hierarchy.id
+)
+SELECT source, path, target
+FROM tag_hierarchy
+;


### PR DESCRIPTION
Fixes #2531. The problem was introduced with the switch to the push-based model. The problem was related to the recursive CTE always waiting until all dependent events had been completed, which would never happen if one of the events threw an error.