### PR TITLE
Fixed directory separator bug

### DIFF
--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -4,7 +4,7 @@ import re
 import sys
 import shutil
 import subprocess
-from python_helpers import open_utf8
+from python_helpers import open_utf8, normalize_path
 
 amal_dir = os.path.join('src', 'amalgamation')
 header_file = os.path.join(amal_dir, "duckdb.hpp")
@@ -81,13 +81,15 @@ if '--extended' in sys.argv:
     main_header_files += add_include_dir(os.path.join(include_dir, 'duckdb/parser/expression'))
     main_header_files += add_include_dir(os.path.join(include_dir, 'duckdb/parser/parsed_data'))
     main_header_files += add_include_dir(os.path.join(include_dir, 'duckdb/parser/tableref'))
+    main_header_files = normalize_path(main_header_files)
+
 # include paths for where to search for include files during amalgamation
 include_paths = [include_dir, fmt_include_dir, re2_dir, miniz_dir, utf8proc_include_dir, hll_dir, tdigest_dir, utf8proc_dir, pg_query_include_dir, pg_query_dir, moodycamel_include_dir,pcg_include_dir]
 # paths of where to look for files to compile and include to the final amalgamation
 compile_directories = [src_dir, fmt_dir, miniz_dir, re2_dir, hll_dir, utf8proc_dir, pg_query_dir]
 
 # files always excluded
-always_excluded = ['src/amalgamation/duckdb.cpp', 'src/amalgamation/duckdb.hpp', 'src/amalgamation/parquet-amalgamation.cpp', 'src/amalgamation/parquet-amalgamation.hpp']
+always_excluded = normalize_path(['src/amalgamation/duckdb.cpp', 'src/amalgamation/duckdb.hpp', 'src/amalgamation/parquet-amalgamation.cpp', 'src/amalgamation/parquet-amalgamation.hpp'])
 # files excluded from the amalgamation
 excluded_files = ['grammar.cpp', 'grammar.hpp', 'symbols.cpp']
 # files excluded from individual file compilation during test_compile

--- a/scripts/parquet_amalgamation.py
+++ b/scripts/parquet_amalgamation.py
@@ -4,7 +4,7 @@ import os
 import sys
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'extension', 'parquet'))
 import parquet_config
-from python_helpers import open_utf8
+from python_helpers import open_utf8, normalize_path
 
 parquet_amal_base = os.path.join(amalgamation.amal_dir, 'parquet-amalgamation')
 parquet_header_file = parquet_amal_base + '.hpp'
@@ -14,12 +14,14 @@ temp_source = parquet_source_file + '.tmp'
 compile_directories = list(set([x.rsplit(os.path.sep, 1)[0] for x in parquet_config.source_files]))
 
 amalgamation.include_paths += parquet_config.include_directories
-amalgamation.main_header_files = [
-    os.path.sep.join('extension/parquet/include/parquet-extension.hpp'.split('/')),
-    os.path.sep.join('extension/parquet/include/parquet_reader.hpp'.split('/')),
-    os.path.sep.join('extension/parquet/include/parquet_writer.hpp'.split('/'))]
+
+amalgamation.main_header_files = normalize_path([
+    'extension/parquet/include/parquet-extension.hpp',
+    'extension/parquet/include/parquet_reader.hpp',
+    'extension/parquet/include/parquet_writer.hpp'])
+
 amalgamation.skip_duckdb_includes = True
-amalgamation.always_excluded += ['extension/parquet/parquetcli.cpp']
+amalgamation.always_excluded += normalize_path(['extension/parquet/parquetcli.cpp'])
 
 if not os.path.exists(amalgamation.amal_dir):
     os.makedirs(amalgamation.amal_dir)

--- a/scripts/python_helpers.py
+++ b/scripts/python_helpers.py
@@ -1,7 +1,23 @@
-
 def open_utf8(fpath, flags):
     import sys
     if sys.version_info[0] < 3:
         return open(fpath, flags)
     else:
         return open(fpath, flags, encoding="utf8")
+
+def normalize_path(path):
+    import os
+        
+    def normalize(p):
+        return os.path.sep.join(p.split('/'))
+
+    if isinstance(path, list):
+        normed = map(lambda p: normalize(p), path)
+        return list(normed)
+
+    if (isinstance, str):
+        return normalize(path)
+    
+    raise Exception("Can only be called with a str or list argument")
+
+        


### PR DESCRIPTION
Issue on Windows with parquet_amalgamation.py throwing 'Could not find include file "parquet-amalgamation.hpp' exception referenced in #2505. Added helper method in python_helpers to ensure more consistency.