### PR TITLE
Fixing positional reference binding in ORDER BY  clause

### DIFF
--- a/src/planner/expression_binder/order_binder.cpp
+++ b/src/planner/expression_binder/order_binder.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/planner/expression_binder/order_binder.hpp"
 
 #include "duckdb/parser/expression/columnref_expression.hpp"
+#include "duckdb/parser/expression/positional_reference_expression.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/planner/expression_binder.hpp"
@@ -64,6 +65,10 @@ unique_ptr<Expression> OrderBinder::Bind(unique_ptr<ParsedExpression> expr) {
 			return CreateProjectionReference(*expr, entry->second);
 		}
 		break;
+	}
+	case ExpressionClass::POSITIONAL_REFERENCE: {
+		auto &posref = (PositionalReferenceExpression &)*expr;
+		return CreateProjectionReference(*expr, posref.index - 1);
 	}
 	default:
 		break;

--- a/test/sql/binder/test_postitional_ref_order_binding.test
+++ b/test/sql/binder/test_postitional_ref_order_binding.test
@@ -1,0 +1,20 @@
+# name: test/sql/binder/test_postitional_ref_order_binding.test
+# description: Test that we can use string aliases with an AS clause
+# group: [binder]
+
+require tpch
+
+statement ok
+PRAGMA enable_verification
+
+#statement ok
+#call dbgen(sf=0.01)
+
+statement ok
+create table test as select * from (values (42, 43), (44, 45)) v(i, j);
+
+query II
+select i, sum(j) as s from test group by i order by #1;
+----
+42	43
+44	45


### PR DESCRIPTION
This came up in the Substrait experiment, which makes heavy use of positional references.