### PR TITLE
Add generate_subscripts macro

### DIFF
--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -90,6 +90,7 @@ static DefaultMacro internal_macros[] = {
 	{DEFAULT_SCHEMA, "array_append", {"arr", "el", nullptr}, "list_append(arr, el)"},
 	{DEFAULT_SCHEMA, "list_prepend", {"e", "l", nullptr}, "list_concat(list_value(e), l)"},
 	{DEFAULT_SCHEMA, "array_prepend", {"el", "arr", nullptr}, "list_prepend(el, arr)"},
+	{DEFAULT_SCHEMA, "generate_subscripts", {"arr", "dim", nullptr}, "unnest(generate_series(1, array_length(arr, dim)))"},
 	{nullptr, nullptr, {nullptr}, nullptr}};
 
 static unique_ptr<CreateFunctionInfo> GetDefaultFunction(const string &schema, const string &name) {

--- a/test/sql/function/list/generate_subscripts.test
+++ b/test/sql/function/list/generate_subscripts.test
@@ -1,0 +1,24 @@
+# name: test/sql/function/list/generate_subscripts.test
+# description: Test generate_subscripts function
+# group: [list]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT generate_subscripts([4,5,6], 1)
+----
+1
+2
+3
+
+query I
+SELECT generate_subscripts([], 1)
+----
+
+query I
+SELECT generate_subscripts(NULL, 1)
+----
+
+statement error
+SELECT generate_subscripts([[1,2],[3,4],[5,6]], 2)


### PR DESCRIPTION
Implement the [`generate_subscripts`](https://www.postgresql.org/docs/14/arrays.html) [function](https://pgpedia.info/g/generate_subscripts.html) as a macro.
The exact nature of indexing (0-based vs. 1-based) is pending on #2575. It is currently 1-based which does not play well with the rest of DuckDB arrays which are 0-based.