### PR TITLE
Check magic bytes before checksum when opening a DuckDB database file

### DIFF
--- a/src/include/duckdb/storage/storage_info.hpp
+++ b/src/include/duckdb/storage/storage_info.hpp
@@ -29,6 +29,7 @@ using block_id_t = int64_t;
 //! file.
 struct MainHeader {
 	static constexpr idx_t MAGIC_BYTE_SIZE = 4;
+	static constexpr idx_t MAGIC_BYTE_OFFSET = sizeof(uint64_t);
 	static constexpr idx_t FLAG_COUNT = 4;
 	// the magic bytes in front of the file
 	// should be "DUCK"

--- a/src/include/duckdb/storage/storage_info.hpp
+++ b/src/include/duckdb/storage/storage_info.hpp
@@ -13,6 +13,7 @@
 namespace duckdb {
 class Serializer;
 class Deserializer;
+struct FileHandle;
 
 //! The version number of the database storage format
 extern const uint64_t VERSION_NUMBER;
@@ -36,6 +37,8 @@ struct MainHeader {
 	uint64_t version_number;
 	//! The set of flags used by the database
 	uint64_t flags[FLAG_COUNT];
+
+	static void CheckMagicBytes(FileHandle &handle);
 
 	void Serialize(Serializer &ser);
 	static MainHeader Deserialize(Deserializer &source);

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -24,18 +24,23 @@ void MainHeader::Serialize(Serializer &ser) {
 }
 
 void MainHeader::CheckMagicBytes(FileHandle &handle) {
-	char magic_bytes[MAGIC_BYTE_SIZE];
-	if (handle.GetFileSize() < 4) {
+	data_t magic_bytes[MAGIC_BYTE_SIZE];
+	if (handle.GetFileSize() < MainHeader::MAGIC_BYTE_SIZE + MainHeader::MAGIC_BYTE_OFFSET) {
 		throw IOException("The file is not a valid DuckDB database file!");
 	}
-	handle.Read(magic_bytes, 4, 0);
+	handle.Read(magic_bytes, MainHeader::MAGIC_BYTE_SIZE, MainHeader::MAGIC_BYTE_OFFSET);
 	if (memcmp(magic_bytes, MainHeader::MAGIC_BYTES, MainHeader::MAGIC_BYTE_SIZE) != 0) {
 		throw IOException("The file is not a valid DuckDB database file!");
 	}
 }
 
 MainHeader MainHeader::Deserialize(Deserializer &source) {
+	data_t magic_bytes[MAGIC_BYTE_SIZE];
 	MainHeader header;
+	source.ReadData(magic_bytes, MainHeader::MAGIC_BYTE_SIZE);
+	if (memcmp(magic_bytes, MainHeader::MAGIC_BYTES, MainHeader::MAGIC_BYTE_SIZE) != 0) {
+		throw IOException("The file is not a valid DuckDB database file!");
+	}
 	header.version_number = source.Read<uint64_t>();
 	// read the flags
 	for (idx_t i = 0; i < FLAG_COUNT; i++) {

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -477,3 +477,22 @@ TEST_CASE("Test parser tokenize", "[api]") {
 	Parser parser;
 	REQUIRE_NOTHROW(parser.Tokenize("SELECT * FROM table WHERE i+1=3 AND j='hello'; --tokenize example query"));
 }
+
+TEST_CASE("Test opening an invalid database file", "[api]") {
+	unique_ptr<DuckDB> db;
+	bool success = false;
+	try {
+		db = make_unique<DuckDB>("data/parquet-testing/blob.parquet");
+		success = true;
+	} catch (std::exception &ex) {
+		REQUIRE(StringUtil::Contains(ex.what(), "DuckDB"));
+	}
+	REQUIRE(!success);
+	try {
+		db = make_unique<DuckDB>("data/parquet-testing/h2oai/h2oai_group_small.parquet");
+		success = true;
+	} catch (std::exception &ex) {
+		REQUIRE(StringUtil::Contains(ex.what(), "DuckDB"));
+	}
+	REQUIRE(!success);
+}

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -1,5 +1,5 @@
 //
-//  httplib.h
+//  httplib.hpp
 //
 //  Copyright (c) 2020 Yuji Hirose. All rights reserved.
 //  MIT License


### PR DESCRIPTION
This throws a more clear error message when opening files that are not DuckDB files (`The file is not a valid DuckDB database file!`).