### PR TITLE
Fix #2591: avoid using ungrouped aggregate for non-combineable aggregates

### DIFF
--- a/src/execution/physical_plan/plan_aggregate.cpp
+++ b/src/execution/physical_plan/plan_aggregate.cpp
@@ -147,9 +147,9 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAggregate 
 				break;
 			}
 		}
-		if (use_simple_aggregation) {
+		if (use_simple_aggregation && all_combinable) {
 			groupby = make_unique_base<PhysicalOperator, PhysicalSimpleAggregate>(
-			    op.types, move(op.expressions), all_combinable, op.estimated_cardinality);
+			    op.types, move(op.expressions), op.estimated_cardinality);
 		} else {
 			groupby = make_unique_base<PhysicalOperator, PhysicalHashAggregate>(context, op.types, move(op.expressions),
 			                                                                    op.estimated_cardinality);

--- a/src/execution/physical_plan/plan_aggregate.cpp
+++ b/src/execution/physical_plan/plan_aggregate.cpp
@@ -148,8 +148,8 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAggregate 
 			}
 		}
 		if (use_simple_aggregation && all_combinable) {
-			groupby = make_unique_base<PhysicalOperator, PhysicalSimpleAggregate>(
-			    op.types, move(op.expressions), op.estimated_cardinality);
+			groupby = make_unique_base<PhysicalOperator, PhysicalSimpleAggregate>(op.types, move(op.expressions),
+			                                                                      op.estimated_cardinality);
 		} else {
 			groupby = make_unique_base<PhysicalOperator, PhysicalHashAggregate>(context, op.types, move(op.expressions),
 			                                                                    op.estimated_cardinality);

--- a/src/include/duckdb/execution/operator/aggregate/physical_simple_aggregate.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_simple_aggregate.hpp
@@ -22,6 +22,7 @@ public:
 
 	//! The aggregates that have to be computed
 	vector<unique_ptr<Expression>> aggregates;
+
 public:
 	// Source interface
 	unique_ptr<GlobalSourceState> GetGlobalSourceState(ClientContext &context) const override;

--- a/src/include/duckdb/execution/operator/aggregate/physical_simple_aggregate.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_simple_aggregate.hpp
@@ -13,19 +13,15 @@
 
 namespace duckdb {
 
-//! PhysicalSimpleAggregate is an aggregate operator that can only perform aggregates (1) without any groups, and (2)
-//! without any DISTINCT aggregates
+//! PhysicalSimpleAggregate is an aggregate operator that can only perform aggregates (1) without any groups, (2)
+//! without any DISTINCT aggregates, and (3) when all aggregates are combineable
 class PhysicalSimpleAggregate : public PhysicalOperator {
 public:
-	PhysicalSimpleAggregate(vector<LogicalType> types, vector<unique_ptr<Expression>> expressions, bool all_combinable,
+	PhysicalSimpleAggregate(vector<LogicalType> types, vector<unique_ptr<Expression>> expressions,
 	                        idx_t estimated_cardinality);
 
 	//! The aggregates that have to be computed
 	vector<unique_ptr<Expression>> aggregates;
-	//! Whether or not all aggregates are trivially combinable. Aggregates that are trivially combinable can be
-	//! parallelized.
-	bool all_combinable;
-
 public:
 	// Source interface
 	unique_ptr<GlobalSourceState> GetGlobalSourceState(ClientContext &context) const override;
@@ -51,7 +47,7 @@ public:
 
 	bool ParallelSink() const override {
 		// we can only parallelize if all aggregates are combinable
-		return all_combinable;
+		return true;
 	}
 };
 

--- a/test/sql/aggregate/aggregates/string_agg_union.test
+++ b/test/sql/aggregate/aggregates/string_agg_union.test
@@ -1,0 +1,30 @@
+# name: test/sql/aggregate/aggregates/string_agg_union.test
+# description: Issue #2591: string_agg only returns final row if there is no Group By clause
+# group: [aggregates]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+WITH my_data as (
+        SELECT 'text1'::varchar(1000) as my_column union all
+        SELECT 'text1'::varchar(1000) as my_column union all
+        SELECT 'text1'::varchar(1000) as my_column
+    )
+        SELECT string_agg(my_column,', ') as my_string_agg
+        FROM my_data
+----
+text1, text1, text1
+
+query I
+WITH my_data as (
+        SELECT 1 as dummy,  'text1'::varchar(1000) as my_column union all
+        SELECT 1 as dummy,  'text1'::varchar(1000) as my_column union all
+        SELECT 1 as dummy,  'text1'::varchar(1000) as my_column
+    )
+        SELECT string_agg(my_column,', ') as my_string_agg
+        FROM my_data
+        GROUP BY
+            dummy
+----
+text1, text1, text1


### PR DESCRIPTION
This fixes #2591. The problem was that the ungrouped aggregate would not correctly handle multiple pipelines when used with non-combineable aggregates (like `string_aggr`). Previously this would work correctly because parallelism would be disabled for these aggregates, which would avoid the use of multiple pipelines. However, since the introduction of the push-based model UNION nodes will create multiple pipelines regardless, which caused the result of only one of the pipelines to be used.
