### PR TITLE
Fix #2588: timestamp -> date cast is not invertible

### DIFF
--- a/src/optimizer/statistics/operator/propagate_filter.cpp
+++ b/src/optimizer/statistics/operator/propagate_filter.cpp
@@ -210,6 +210,10 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalFilt
                                                                      unique_ptr<LogicalOperator> *node_ptr) {
 	// first propagate to the child
 	node_stats = PropagateStatistics(filter.children[0]);
+	if (filter.children[0]->type == LogicalOperatorType::LOGICAL_EMPTY_RESULT) {
+		ReplaceWithEmptyResult(*node_ptr);
+		return make_unique<NodeStatistics>(0, 0);
+	}
 
 	// then propagate to each of the expressions
 	for (idx_t i = 0; i < filter.expressions.size(); i++) {

--- a/src/planner/expression/bound_cast_expression.cpp
+++ b/src/planner/expression/bound_cast_expression.cpp
@@ -57,6 +57,9 @@ bool BoundCastExpression::CastIsInvertible(const LogicalType &source_type, const
 		}
 		return true;
 	}
+	if (source_type.id() == LogicalTypeId::TIMESTAMP || target_type.id() == LogicalTypeId::DATE) {
+		return false;
+	}
 	if (source_type.id() == LogicalTypeId::VARCHAR) {
 		return target_type.id() == LogicalTypeId::DATE || target_type.id() == LogicalTypeId::TIME ||
 		       target_type.id() == LogicalTypeId::TIMESTAMP || target_type.id() == LogicalTypeId::TIMESTAMP_NS ||

--- a/src/planner/expression/bound_cast_expression.cpp
+++ b/src/planner/expression/bound_cast_expression.cpp
@@ -57,7 +57,7 @@ bool BoundCastExpression::CastIsInvertible(const LogicalType &source_type, const
 		}
 		return true;
 	}
-	if (source_type.id() == LogicalTypeId::TIMESTAMP || target_type.id() == LogicalTypeId::DATE) {
+	if (source_type.id() == LogicalTypeId::TIMESTAMP && target_type.id() == LogicalTypeId::DATE) {
 		return false;
 	}
 	if (source_type.id() == LogicalTypeId::VARCHAR) {

--- a/test/sql/cast/timestamp_date_cast.test
+++ b/test/sql/cast/timestamp_date_cast.test
@@ -1,0 +1,24 @@
+# name: test/sql/cast/timestamp_date_cast.test
+# description: Issue #2588: Incorrect result with date conversion
+# group: [cast]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table test as
+select '2021-02-04 19:30:00'::timestamp t;
+
+query I
+select *
+from test
+where (t::date) = '2021-02-04'::date;
+----
+2021-02-04 19:30:00
+
+query I
+select *
+from test
+where (t::date) = '2021-02-04';
+----
+2021-02-04 19:30:00


### PR DESCRIPTION
This was caused by an optimizer misbehaving on the timestamp -> date cast, as it incorrectly assumed timestamp -> date casts were invertible (i.e. when casting `timestamp::date::timestamp` no information is lost). This is incorrect since the timestamp will be truncated in this case (e.g. `2021-02-04 19:30:00`  is turned into `2021-02-04 00:00:00`). Because of that an incorrect rewrite occurred which caused an incorrect result to be emitted.