### PR TITLE
Adding pragma option for parquet binary as string

### DIFF
--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -54,7 +54,9 @@ struct ParquetReaderScanState {
 };
 
 struct ParquetOptions {
-	bool binary_as_string = false;
+	explicit ParquetOptions(bool binary_as_string_p) : binary_as_string(binary_as_string_p) {
+	}
+	bool binary_as_string;
 };
 
 class ParquetReader {
@@ -78,7 +80,7 @@ public:
 	vector<LogicalType> return_types;
 	vector<string> names;
 	shared_ptr<ParquetFileMetadataCache> metadata;
-	ParquetOptions parquet_options;
+	ParquetOptions parquet_options {false};
 
 public:
 	void InitializeScan(ParquetReaderScanState &state, vector<column_t> column_ids, vector<idx_t> groups_to_read,

--- a/extension/parquet/parquet-extension.cpp
+++ b/extension/parquet/parquet-extension.cpp
@@ -100,7 +100,7 @@ public:
 		if (result->files.empty()) {
 			throw IOException("No files found that match the pattern \"%s\"", info.file_path);
 		}
-		ParquetOptions parquet_options;
+		ParquetOptions parquet_options(context.parquet_binary_as_strings);
 		result->initial_reader = make_shared<ParquetReader>(context, result->files[0], expected_types, parquet_options);
 		return move(result);
 	}
@@ -193,7 +193,7 @@ public:
 	                                                vector<string> &input_table_names,
 	                                                vector<LogicalType> &return_types, vector<string> &names) {
 		auto file_name = inputs[0].GetValue<string>();
-		ParquetOptions parquet_options;
+		ParquetOptions parquet_options {context.parquet_binary_as_strings};
 		for (auto &kv : named_parameters) {
 			if (kv.first == "binary_as_string") {
 				parquet_options.binary_as_string = kv.second.value_.boolean;
@@ -218,7 +218,7 @@ public:
 		if (files.empty()) {
 			throw IOException("Parquet reader needs at least one file to read");
 		}
-		ParquetOptions parquet_options;
+		ParquetOptions parquet_options {context.parquet_binary_as_strings};
 		for (auto &kv : named_parameters) {
 			if (kv.first == "binary_as_string") {
 				parquet_options.binary_as_string = kv.second.value_.boolean;

--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -160,7 +160,7 @@ Value ConvertParquetStats(duckdb_parquet::format::Type::type type, bool stats_is
 void ParquetMetaDataOperatorData::LoadFileMetaData(ClientContext &context, const vector<LogicalType> &return_types,
                                                    const string &file_path) {
 	collection.Reset();
-	ParquetOptions parquet_options;
+	ParquetOptions parquet_options(context.parquet_binary_as_strings);
 	auto reader = make_unique<ParquetReader>(context, file_path, parquet_options);
 	idx_t count = 0;
 	DataChunk current_chunk;
@@ -348,7 +348,7 @@ Value ParquetLogicalTypeToString(const duckdb_parquet::format::LogicalType &type
 void ParquetMetaDataOperatorData::LoadSchemaData(ClientContext &context, const vector<LogicalType> &return_types,
                                                  const string &file_path) {
 	collection.Reset();
-	ParquetOptions parquet_options;
+	ParquetOptions parquet_options(context.parquet_binary_as_strings);
 	auto reader = make_unique<ParquetReader>(context, file_path, parquet_options);
 	idx_t count = 0;
 	DataChunk current_chunk;

--- a/src/function/pragma/pragma_functions.cpp
+++ b/src/function/pragma/pragma_functions.cpp
@@ -171,6 +171,14 @@ static void PragmaDisableForceExternal(ClientContext &context, const FunctionPar
 	context.force_external = false;
 }
 
+static void PragmaEnableParquetBinaryAsString(ClientContext &context, const FunctionParameters &parameters) {
+	context.parquet_binary_as_strings = true;
+}
+
+static void PragmaDisableParquetBinaryAsString(ClientContext &context, const FunctionParameters &parameters) {
+	context.parquet_binary_as_strings = false;
+}
+
 static void PragmaEnableObjectCache(ClientContext &context, const FunctionParameters &parameters) {
 	DBConfig::GetConfig(context).object_cache_enable = true;
 }
@@ -345,6 +353,11 @@ void PragmaFunctions::RegisterFunction(BuiltinFunctions &set) {
 
 	set.AddFunction(PragmaFunction::PragmaStatement("enable_print_progress_bar", PragmaEnablePrintProgressBar));
 	set.AddFunction(PragmaFunction::PragmaStatement("disable_print_progress_bar", PragmaDisablePrintProgressBar));
+
+	set.AddFunction(
+	    PragmaFunction::PragmaStatement("enable_parquet_binary_as_string", PragmaEnableParquetBinaryAsString));
+	set.AddFunction(
+	    PragmaFunction::PragmaStatement("disable_parquet_binary_as_string", PragmaDisableParquetBinaryAsString));
 
 	set.AddFunction(
 	    PragmaFunction::PragmaAssignment("set_progress_bar_time", PragmaSetProgressBarWaitTime, LogicalType::INTEGER));

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -90,6 +90,8 @@ public:
 	bool force_index_join = false;
 	//! Force out-of-core computation for operators that support it, used for testing
 	bool force_external = false;
+	//! If binaries should be converted to strings by default on the parquet reader
+	bool parquet_binary_as_strings = false;
 	//! Maximum bits allowed for using a perfect hash table (i.e. the perfect HT can hold up to 2^perfect_ht_threshold
 	//! elements)
 	idx_t perfect_ht_threshold = 12;

--- a/test/sql/copy/parquet/parquet_blob_string.test
+++ b/test/sql/copy/parquet/parquet_blob_string.test
@@ -31,3 +31,51 @@ SELECT * FROM parquet_scan('data/parquet-testing/binary_string.parquet',binary_a
 foo
 bar
 baz
+
+statement ok
+PRAGMA enable_parquet_binary_as_string
+
+query I
+SELECT typeof(#1) FROM parquet_scan('data/parquet-testing/binary_string.parquet') limit 1
+----
+VARCHAR
+
+
+query I
+SELECT * FROM parquet_scan('data/parquet-testing/binary_string.parquet')
+----
+foo
+bar
+baz
+
+statement ok
+PRAGMA disable_parquet_binary_as_string
+
+query I
+SELECT typeof(#1) FROM parquet_scan('data/parquet-testing/binary_string.parquet') limit 1
+----
+BLOB
+
+query I
+SELECT * FROM parquet_scan('data/parquet-testing/binary_string.parquet')
+----
+foo
+bar
+baz
+
+# Preference goes to variable set in scan
+statement ok
+PRAGMA enable_parquet_binary_as_string
+
+query I
+SELECT typeof(#1) FROM parquet_scan('data/parquet-testing/binary_string.parquet' ,binary_as_string=False) limit 1
+----
+BLOB
+
+
+query I
+SELECT * FROM parquet_scan('data/parquet-testing/binary_string.parquet')
+----
+foo
+bar
+baz

--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -103,7 +103,9 @@ PYBIND11_MODULE(DUCKDB_PYTHON_LIB_NAME, m) {
 	      py::arg("file_name"));
 	m.def("from_parquet", &DuckDBPyRelation::FromParquet,
 	      "Creates a relation object from the Parquet file in file_name", py::arg("file_name"),
-	      py::arg("binary_as_string") = false);
+	      py::arg("binary_as_string"));
+	m.def("from_parquet", &DuckDBPyRelation::FromParquetDefault,
+	      "Creates a relation object from the Parquet file in file_name", py::arg("file_name"));
 	m.def("df", &DuckDBPyRelation::FromDf, "Create a relation object from the Data.Frame df", py::arg("df"));
 	m.def("from_df", &DuckDBPyRelation::FromDf, "Create a relation object from the Data.Frame df", py::arg("df"));
 	m.def("from_arrow_table", &DuckDBPyRelation::FromArrowTable, "Create a relation object from an Arrow table",

--- a/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
@@ -35,6 +35,8 @@ public:
 
 	static unique_ptr<DuckDBPyRelation> FromParquet(const string &filename, bool binary_as_string);
 
+	static unique_ptr<DuckDBPyRelation> FromParquetDefault(const string &filename);
+
 	static unique_ptr<DuckDBPyRelation> FromArrowTable(py::object &table);
 
 	unique_ptr<DuckDBPyRelation> Project(const string &expr);

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -2,6 +2,8 @@
 #include "duckdb_python/pyconnection.hpp"
 #include "duckdb_python/pyresult.hpp"
 #include "duckdb/parser/qualified_name.hpp"
+#include "duckdb/main/client_context.hpp"
+
 namespace duckdb {
 
 void DuckDBPyRelation::Initialize(py::handle &m) {
@@ -82,6 +84,11 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromCsvAuto(const string &filenam
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromParquet(const string &filename, bool binary_as_string) {
 	return DuckDBPyConnection::DefaultConnection()->FromParquet(filename, binary_as_string);
+}
+
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromParquetDefault(const string &filename) {
+	return DuckDBPyConnection::DefaultConnection()->FromParquet(
+	    filename, DuckDBPyConnection::DefaultConnection()->connection->context->parquet_binary_as_strings);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromArrowTable(py::object &table) {

--- a/tools/pythonpkg/tests/fast/test_parquet.py
+++ b/tools/pythonpkg/tests/fast/test_parquet.py
@@ -35,3 +35,33 @@ class TestParquet(object):
 
         res = rel.execute().fetchall()
         assert res[0] == ('foo',) 
+
+    def test__parquet_binary_as_string_pragma(self, duckdb_cursor):
+        conn = duckdb.connect()
+        res = conn.execute("SELECT typeof(#1) FROM parquet_scan('"+filename+"') limit 1").fetchall()
+        assert res[0] == ('BLOB',)
+
+        res = conn.execute("SELECT * FROM parquet_scan('"+filename+"')").fetchall()
+        assert res[0] == (b'foo',)
+
+        conn.execute("PRAGMA enable_parquet_binary_as_string")
+
+        res = conn.execute("SELECT typeof(#1) FROM parquet_scan('"+filename+"') limit 1").fetchall()
+        assert res[0] == ('VARCHAR',)
+
+        res = conn.execute("SELECT * FROM parquet_scan('"+filename+"')").fetchall()
+        assert res[0] == ('foo',)
+
+        res = conn.execute("SELECT typeof(#1) FROM parquet_scan('"+filename+"',binary_as_string=False) limit 1").fetchall()
+        assert res[0] == ('BLOB',)
+
+        res = conn.execute("SELECT * FROM parquet_scan('"+filename+"',binary_as_string=False)").fetchall()
+        assert res[0] == (b'foo',)
+
+        conn.execute("PRAGMA disable_parquet_binary_as_string")
+
+        res = conn.execute("SELECT typeof(#1) FROM parquet_scan('"+filename+"') limit 1").fetchall()
+        assert res[0] == ('BLOB',)
+
+        res = conn.execute("SELECT * FROM parquet_scan('"+filename+"')").fetchall()
+        assert res[0] == (b'foo',)


### PR DESCRIPTION
Binary columns are read from parquet files as strings by default:
```sql 
PRAGMA enable_parquet_binary_as_string
```

To disable it:
```sql 
PRAGMA disable_parquet_binary_as_string
```

If the binary_as_string parameter from the Parquet Function is used, that is used indiferent of the value set in the pragma
```sql
PRAGMA enable_parquet_binary_as_string

-- This will read binaries as binaries
SELECT * FROM parquet_scan('data/parquet-testing/binary_string.parquet',binary_as_string=False)

````
 