### PR TITLE
Fix #2599: maintain correct dependencies between UNION ALL nodes so that output is deterministic/in-line with what a sequential execution would produce

### DIFF
--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -26,6 +26,8 @@ class Task;
 struct PipelineEventStack;
 struct ProducerToken;
 
+using event_map_t = unordered_map<const Pipeline *, PipelineEventStack>;
+
 class Executor {
 	friend class Pipeline;
 	friend class PipelineTask;
@@ -81,14 +83,11 @@ private:
 	                            unordered_map<Pipeline *, vector<shared_ptr<Pipeline>>> &child_pipelines,
 	                            vector<shared_ptr<Event>> &events, bool main_schedule = true);
 
-	void SchedulePipeline(const shared_ptr<Pipeline> &pipeline,
-	                      unordered_map<Pipeline *, PipelineEventStack> &event_map, vector<shared_ptr<Event>> &events,
-	                      bool complete_pipeline);
-	void ScheduleUnionPipeline(const shared_ptr<Pipeline> &pipeline, PipelineEventStack &stack,
-	                           unordered_map<Pipeline *, PipelineEventStack> &event_map,
-	                           vector<shared_ptr<Event>> &events);
-	void ScheduleChildPipeline(Pipeline *parent, const shared_ptr<Pipeline> &pipeline,
-	                           unordered_map<Pipeline *, PipelineEventStack> &event_map,
+	void SchedulePipeline(const shared_ptr<Pipeline> &pipeline, event_map_t &event_map,
+	                      vector<shared_ptr<Event>> &events, bool complete_pipeline);
+	Pipeline *ScheduleUnionPipeline(const shared_ptr<Pipeline> &pipeline, const Pipeline *parent,
+	                                event_map_t &event_map, vector<shared_ptr<Event>> &events);
+	void ScheduleChildPipeline(Pipeline *parent, const shared_ptr<Pipeline> &pipeline, event_map_t &event_map,
 	                           vector<shared_ptr<Event>> &events);
 	void ExtractPipelines(shared_ptr<Pipeline> &pipeline, vector<shared_ptr<Pipeline>> &result);
 	bool NextExecutor();

--- a/test/sql/setops/union_limit.test
+++ b/test/sql/setops/union_limit.test
@@ -1,0 +1,194 @@
+# name: test/sql/setops/union_limit.test
+# description: Test union limit
+# group: [setops]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT 1 UNION ALL SELECT * FROM range(2, 100) UNION ALL SELECT 999 LIMIT 5;
+----
+1
+2
+3
+4
+5
+
+query I
+SELECT 'select count(case'a union all select 'when a='||range||' then 1' from range(100) LIMIT 5;
+----
+select count(case
+when a=0 then 1
+when a=1 then 1
+when a=2 then 1
+when a=3 then 1
+
+query I
+SELECT STRING_AGG(a, ' ') FROM (SELECT 'select count(case'a union all select 'when a='||range||' then 1' from range(2) union all select 'end) from t') tbl;
+----
+select count(case when a=0 then 1 when a=1 then 1 end) from t
+
+query I
+SELECT 'select count(case'a union all select 'when a='||range||' then 1' from range(2) union all select 'end) from t' LIMIT 5;
+----
+select count(case
+when a=0 then 1
+when a=1 then 1
+end) from t
+
+query I
+SELECT 'select count(case'a union all select 'when a='||range||' then 1' from range(100) union all select 'end) from t' LIMIT 5;
+----
+select count(case
+when a=0 then 1
+when a=1 then 1
+when a=2 then 1
+when a=3 then 1
+
+
+query I
+SELECT 1
+UNION ALL
+(
+	SELECT * FROM generate_series(10, 12, 1)
+	UNION ALL
+	(
+		SELECT * FROM generate_series(100, 103, 1)
+	)
+	UNION ALL
+	SELECT * FROM generate_series(1000, 1002, 1)
+)
+UNION ALL
+SELECT * FROM generate_series(10000, 10002, 1)
+UNION ALL
+(
+	SELECT * FROM generate_series(100000, 100002, 1)
+	UNION ALL
+	SELECT * FROM generate_series(1000000, 1000003, 1)
+);
+----
+1
+10
+11
+12
+100
+101
+102
+103
+1000
+1001
+1002
+10000
+10001
+10002
+100000
+100001
+100002
+1000000
+1000001
+1000002
+1000003
+
+query I
+SELECT ARRAY_AGG(1)
+UNION ALL
+(
+	SELECT ARRAY_AGG(i) FROM generate_series(10, 12, 1) tbl(i)
+	UNION ALL
+	(
+		SELECT ARRAY_AGG(i) FROM generate_series(100, 103, 1) tbl(i)
+	)
+	UNION ALL
+	SELECT ARRAY_AGG(i) FROM generate_series(1000, 1002, 1) tbl(i)
+)
+UNION ALL
+SELECT ARRAY_AGG(i) FROM generate_series(10000, 10002, 1) tbl(i)
+UNION ALL
+(
+	SELECT ARRAY_AGG(i) FROM generate_series(100000, 100002, 1) tbl(i)
+	UNION ALL
+	SELECT ARRAY_AGG(i) FROM generate_series(1000000, 1000003, 1) tbl(i)
+);
+----
+[1]
+[10, 11, 12]
+[100, 101, 102, 103]
+[1000, 1001, 1002]
+[10000, 10001, 10002]
+[100000, 100001, 100002]
+[1000000, 1000001, 1000002, 1000003]
+
+
+query I
+SELECT 1
+UNION ALL
+(
+	SELECT * FROM generate_series(10, 12, 1)
+	UNION ALL
+	(
+		SELECT * FROM generate_series(100, 103, 1)
+	)
+	UNION ALL
+	SELECT * FROM generate_series(1000, 1002, 1)
+)
+UNION ALL
+SELECT * FROM generate_series(10000, 10002, 1)
+UNION ALL
+(
+	SELECT * FROM generate_series(100000, 100002, 1)
+	UNION ALL
+	SELECT * FROM generate_series(1000000, 1000003, 1)
+)
+LIMIT 1000;
+----
+1
+10
+11
+12
+100
+101
+102
+103
+1000
+1001
+1002
+10000
+10001
+10002
+100000
+100001
+100002
+1000000
+1000001
+1000002
+1000003
+
+query I
+SELECT ARRAY_AGG(1)
+UNION ALL
+(
+	SELECT ARRAY_AGG(i) FROM generate_series(10, 12, 1) tbl(i)
+	UNION ALL
+	(
+		SELECT ARRAY_AGG(i) FROM generate_series(100, 103, 1) tbl(i)
+	)
+	UNION ALL
+	SELECT ARRAY_AGG(i) FROM generate_series(1000, 1002, 1) tbl(i)
+)
+UNION ALL
+SELECT ARRAY_AGG(i) FROM generate_series(10000, 10002, 1) tbl(i)
+UNION ALL
+(
+	SELECT ARRAY_AGG(i) FROM generate_series(100000, 100002, 1) tbl(i)
+	UNION ALL
+	SELECT ARRAY_AGG(i) FROM generate_series(1000000, 1000003, 1) tbl(i)
+)
+LIMIT 1000;
+----
+[1]
+[10, 11, 12]
+[100, 101, 102, 103]
+[1000, 1001, 1002]
+[10000, 10001, 10002]
+[100000, 100001, 100002]
+[1000000, 1000001, 1000002, 1000003]


### PR DESCRIPTION
Fixes #2599