### PR TITLE
Add support for EXPLAIN ANALYZE

### DIFF
--- a/src/common/enums/physical_operator_type.cpp
+++ b/src/common/enums/physical_operator_type.cpp
@@ -71,6 +71,8 @@ string PhysicalOperatorToString(PhysicalOperatorType type) {
 		return "CREATE_INDEX";
 	case PhysicalOperatorType::EXPLAIN:
 		return "EXPLAIN";
+	case PhysicalOperatorType::EXPLAIN_ANALYZE:
+		return "EXPLAIN_ANALYZE";
 	case PhysicalOperatorType::EXECUTE:
 		return "EXECUTE";
 	case PhysicalOperatorType::VACUUM:

--- a/src/execution/operator/helper/CMakeLists.txt
+++ b/src/execution/operator/helper/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library_unity(
   duckdb_operator_helper
   OBJECT
   physical_execute.cpp
+  physical_explain_analyze.cpp
   physical_limit.cpp
   physical_load.cpp
   physical_pragma.cpp

--- a/src/execution/operator/helper/physical_explain_analyze.cpp
+++ b/src/execution/operator/helper/physical_explain_analyze.cpp
@@ -16,8 +16,9 @@ unique_ptr<GlobalSourceState> PhysicalExplainAnalyze::GetGlobalSourceState(Clien
 	return make_unique<ExplainAnalyzeState>();
 }
 
-void PhysicalExplainAnalyze::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate, LocalSourceState &lstate) const {
-	auto &state = (ExplainAnalyzeState &) gstate;
+void PhysicalExplainAnalyze::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                     LocalSourceState &lstate) const {
+	auto &state = (ExplainAnalyzeState &)gstate;
 	if (state.finished) {
 		return;
 	}
@@ -29,10 +30,9 @@ void PhysicalExplainAnalyze::GetData(ExecutionContext &context, DataChunk &chunk
 	state.finished = true;
 }
 
-
 SinkResultType PhysicalExplainAnalyze::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
-					DataChunk &input) const {
+                                            DataChunk &input) const {
 	return SinkResultType::NEED_MORE_INPUT;
 }
 
-}
+} // namespace duckdb

--- a/src/execution/operator/helper/physical_explain_analyze.cpp
+++ b/src/execution/operator/helper/physical_explain_analyze.cpp
@@ -1,0 +1,38 @@
+#include "duckdb/execution/operator/helper/physical_explain_analyze.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/query_profiler.hpp"
+
+namespace duckdb {
+
+class ExplainAnalyzeState : public GlobalSourceState {
+public:
+	ExplainAnalyzeState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalExplainAnalyze::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<ExplainAnalyzeState>();
+}
+
+void PhysicalExplainAnalyze::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate, LocalSourceState &lstate) const {
+	auto &state = (ExplainAnalyzeState &) gstate;
+	if (state.finished) {
+		return;
+	}
+	string analyzed_plan = context.client.profiler->ToString();
+	chunk.SetValue(0, 0, Value("analyzed_plan"));
+	chunk.SetValue(1, 0, Value(move(analyzed_plan)));
+	chunk.SetCardinality(1);
+
+	state.finished = true;
+}
+
+
+SinkResultType PhysicalExplainAnalyze::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+					DataChunk &input) const {
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+}

--- a/src/include/duckdb/common/enums/physical_operator_type.hpp
+++ b/src/include/duckdb/common/enums/physical_operator_type.hpp
@@ -82,6 +82,7 @@ enum class PhysicalOperatorType : uint8_t {
 	// Helpers
 	// -----------------------------
 	EXPLAIN,
+	EXPLAIN_ANALYZE,
 	EMPTY_RESULT,
 	EXECUTE,
 	PREPARE,

--- a/src/include/duckdb/execution/operator/aggregate/physical_simple_aggregate.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_simple_aggregate.hpp
@@ -47,7 +47,6 @@ public:
 	}
 
 	bool ParallelSink() const override {
-		// we can only parallelize if all aggregates are combinable
 		return true;
 	}
 };

--- a/src/include/duckdb/execution/operator/helper/physical_explain_analyze.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_explain_analyze.hpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/operator/helper/physical_explain_analyze.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/execution/physical_operator.hpp"
+#include "duckdb/planner/expression.hpp"
+
+namespace duckdb {
+
+class PhysicalExplainAnalyze : public PhysicalOperator {
+public:
+	PhysicalExplainAnalyze(vector<LogicalType> types)
+	    : PhysicalOperator(PhysicalOperatorType::EXPLAIN_ANALYZE, move(types), 1) {
+	}
+
+public:
+	// Source interface
+	unique_ptr<GlobalSourceState> GetGlobalSourceState(ClientContext &context) const override;
+	void GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+	             LocalSourceState &lstate) const override;
+
+public:
+	// Sink Interface
+	SinkResultType Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+	                    DataChunk &input) const override;
+
+	bool IsSink() const override {
+		return true;
+	}
+
+	bool ParallelSink() const override {
+		return true;
+	}
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/execution/operator/helper/physical_explain_analyze.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_explain_analyze.hpp
@@ -29,6 +29,10 @@ public:
 	// Sink Interface
 	SinkResultType Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
 	                    DataChunk &input) const override;
+	SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+	                          GlobalSinkState &gstate) const override;
+
+	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
 
 	bool IsSink() const override {
 		return true;

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -34,6 +34,7 @@ struct ExpressionInfo {
 	vector<unique_ptr<ExpressionInfo>> children;
 	// Extract ExpressionInformation from a given expression state
 	void ExtractExpressionsRecursive(unique_ptr<ExpressionState> &state);
+
 	//! Whether or not expression has function
 	bool hasfunction;
 	//! The function Name
@@ -49,6 +50,7 @@ struct ExpressionInfo {
 //! The ExpressionRootInfo keeps information related to the root of an expression tree
 struct ExpressionRootInfo {
 	ExpressionRootInfo(ExpressionExecutorState &executor, string name);
+
 	//! Count the number of time the executor called
 	uint64_t total_count = 0;
 	//! Count the number of time the executor called since last sampling
@@ -72,6 +74,7 @@ struct ExpressionRootInfo {
 struct ExpressionExecutorInfo {
 	explicit ExpressionExecutorInfo() {};
 	explicit ExpressionExecutorInfo(ExpressionExecutor &executor, const string &name, int id);
+
 	//! A vector which contain the pointer to all ExpressionRootInfo
 	vector<unique_ptr<ExpressionRootInfo>> roots;
 	//! Id, it will be used as index for executors_info vector
@@ -79,11 +82,12 @@ struct ExpressionExecutorInfo {
 };
 
 struct OperatorInformation {
+	explicit OperatorInformation(double time_ = 0, idx_t elements_ = 0) : time(time_), elements(elements_) {
+	}
+
 	double time = 0;
 	idx_t elements = 0;
 	string name;
-	explicit OperatorInformation(double time_ = 0, idx_t elements_ = 0) : time(time_), elements(elements_) {
-	}
 	//! A vector of Expression Executor Info
 	vector<unique_ptr<ExpressionExecutorInfo>> executors_info;
 };
@@ -124,6 +128,11 @@ public:
 	      query_requires_profiling(false) {
 	}
 
+	//! The format to automatically print query profiling information in (default: disabled)
+	ProfilerPrintFormat automatic_print_format;
+	//! The file to save query profiling information to, instead of printing it to the console (empty = print to
+	//! console)
+	string save_location;
 public:
 	struct TreeNode {
 		PhysicalOperatorType type;
@@ -167,8 +176,10 @@ public:
 		return detailed_enabled;
 	}
 
-	DUCKDB_API void StartQuery(string query);
+	DUCKDB_API void StartQuery(string query, bool is_explain_analyze = false);
 	DUCKDB_API void EndQuery();
+
+	DUCKDB_API void StartExplainAnalyze();
 
 	//! Adds the timings gathered by an OperatorProfiler to this query profiler
 	DUCKDB_API void Flush(OperatorProfiler &profiler);
@@ -184,12 +195,6 @@ public:
 
 	DUCKDB_API string ToJSON() const;
 	DUCKDB_API void WriteToFile(const char *path, string &info) const;
-
-	//! The format to automatically print query profiling information in (default: disabled)
-	ProfilerPrintFormat automatic_print_format;
-	//! The file to save query profiling information to, instead of printing it to the console (empty = print to
-	//! console)
-	string save_location;
 
 	idx_t OperatorSize() {
 		return tree_map.size();
@@ -215,6 +220,11 @@ private:
 	Profiler<system_clock> main_query;
 	//! A map of a Physical Operator pointer to a tree node
 	TreeMap tree_map;
+
+	bool is_explain_analyze = false;
+	bool stored_enabled;
+	ProfilerPrintFormat stored_automatic_print_format;
+	string stored_save_location;
 
 public:
 	const TreeMap &GetTreeMap() const {

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -133,6 +133,7 @@ public:
 	//! The file to save query profiling information to, instead of printing it to the console (empty = print to
 	//! console)
 	string save_location;
+
 public:
 	struct TreeNode {
 		PhysicalOperatorType type;

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -125,7 +125,8 @@ class QueryProfiler {
 public:
 	DUCKDB_API QueryProfiler()
 	    : automatic_print_format(ProfilerPrintFormat::NONE), enabled(false), detailed_enabled(false), running(false),
-	      query_requires_profiling(false) {
+	      query_requires_profiling(false), is_explain_analyze(false), stored_enabled(false),
+	      stored_automatic_print_format(ProfilerPrintFormat::NONE) {
 	}
 
 	//! The format to automatically print query profiling information in (default: disabled)
@@ -222,7 +223,7 @@ private:
 	//! A map of a Physical Operator pointer to a tree node
 	TreeMap tree_map;
 
-	bool is_explain_analyze = false;
+	bool is_explain_analyze;
 	bool stored_enabled;
 	ProfilerPrintFormat stored_automatic_print_format;
 	string stored_save_location;

--- a/src/include/duckdb/parser/statement/explain_statement.hpp
+++ b/src/include/duckdb/parser/statement/explain_statement.hpp
@@ -13,11 +13,17 @@
 
 namespace duckdb {
 
+enum class ExplainType : uint8_t {
+	EXPLAIN_STANDARD,
+	EXPLAIN_ANALYZE
+};
+
 class ExplainStatement : public SQLStatement {
 public:
-	explicit ExplainStatement(unique_ptr<SQLStatement> stmt);
+	ExplainStatement(unique_ptr<SQLStatement> stmt, ExplainType explain_type = ExplainType::EXPLAIN_STANDARD);
 
 	unique_ptr<SQLStatement> stmt;
+	ExplainType explain_type;
 
 public:
 	unique_ptr<SQLStatement> Copy() const override;

--- a/src/include/duckdb/parser/statement/explain_statement.hpp
+++ b/src/include/duckdb/parser/statement/explain_statement.hpp
@@ -13,10 +13,7 @@
 
 namespace duckdb {
 
-enum class ExplainType : uint8_t {
-	EXPLAIN_STANDARD,
-	EXPLAIN_ANALYZE
-};
+enum class ExplainType : uint8_t { EXPLAIN_STANDARD, EXPLAIN_ANALYZE };
 
 class ExplainStatement : public SQLStatement {
 public:

--- a/src/include/duckdb/planner/operator/logical_explain.hpp
+++ b/src/include/duckdb/planner/operator/logical_explain.hpp
@@ -15,8 +15,8 @@ namespace duckdb {
 
 class LogicalExplain : public LogicalOperator {
 public:
-	LogicalExplain(unique_ptr<LogicalOperator> plan, ExplainType explain_type) :
-	   LogicalOperator(LogicalOperatorType::LOGICAL_EXPLAIN), explain_type(explain_type) {
+	LogicalExplain(unique_ptr<LogicalOperator> plan, ExplainType explain_type)
+	    : LogicalOperator(LogicalOperatorType::LOGICAL_EXPLAIN), explain_type(explain_type) {
 		children.push_back(move(plan));
 	}
 

--- a/src/include/duckdb/planner/operator/logical_explain.hpp
+++ b/src/include/duckdb/planner/operator/logical_explain.hpp
@@ -9,15 +9,18 @@
 #pragma once
 
 #include "duckdb/planner/logical_operator.hpp"
+#include "duckdb/parser/statement/explain_statement.hpp"
 
 namespace duckdb {
 
 class LogicalExplain : public LogicalOperator {
 public:
-	explicit LogicalExplain(unique_ptr<LogicalOperator> plan) : LogicalOperator(LogicalOperatorType::LOGICAL_EXPLAIN) {
+	LogicalExplain(unique_ptr<LogicalOperator> plan, ExplainType explain_type) :
+	   LogicalOperator(LogicalOperatorType::LOGICAL_EXPLAIN), explain_type(explain_type) {
 		children.push_back(move(plan));
 	}
 
+	ExplainType explain_type;
 	string physical_plan;
 	string logical_plan_unopt;
 	string logical_plan_opt;

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -447,7 +447,7 @@ unique_ptr<QueryResult> ClientContext::RunStatementOrPreparedStatement(ClientCon
 		statement = move(copied_statement);
 	}
 	// start the profiler
-	profiler->StartQuery(query, IsExplainAnalyze(statement.get()));
+	profiler->StartQuery(query, IsExplainAnalyze(statement ? statement.get() : prepared->unbound_statement.get()));
 	try {
 		if (statement) {
 			result = RunStatementInternal(lock, query, move(statement), allow_stream_result);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -405,6 +405,17 @@ unique_ptr<QueryResult> ClientContext::RunStatementInternal(ClientContextLock &l
 	return ExecutePreparedStatement(lock, query, move(prepared), move(bound_values), allow_stream_result);
 }
 
+static bool IsExplainAnalyze(SQLStatement *statement) {
+	if (!statement) {
+		return false;
+	}
+	if (statement->type != StatementType::EXPLAIN_STATEMENT) {
+		return false;
+	}
+	auto &explain = (ExplainStatement &) *statement;
+	return explain.explain_type == ExplainType::EXPLAIN_ANALYZE;
+}
+
 unique_ptr<QueryResult> ClientContext::RunStatementOrPreparedStatement(ClientContextLock &lock, const string &query,
                                                                        unique_ptr<SQLStatement> statement,
                                                                        shared_ptr<PreparedStatementData> &prepared,
@@ -436,7 +447,7 @@ unique_ptr<QueryResult> ClientContext::RunStatementOrPreparedStatement(ClientCon
 		statement = move(copied_statement);
 	}
 	// start the profiler
-	profiler->StartQuery(query);
+	profiler->StartQuery(query, IsExplainAnalyze(statement.get()));
 	try {
 		if (statement) {
 			result = RunStatementInternal(lock, query, move(statement), allow_stream_result);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -412,7 +412,7 @@ static bool IsExplainAnalyze(SQLStatement *statement) {
 	if (statement->type != StatementType::EXPLAIN_STATEMENT) {
 		return false;
 	}
-	auto &explain = (ExplainStatement &) *statement;
+	auto &explain = (ExplainStatement &)*statement;
 	return explain.explain_type == ExplainType::EXPLAIN_ANALYZE;
 }
 

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -16,7 +16,10 @@
 
 namespace duckdb {
 
-void QueryProfiler::StartQuery(string query) {
+void QueryProfiler::StartQuery(string query, bool is_explain_analyze) {
+	if (is_explain_analyze) {
+		StartExplainAnalyze();
+	}
 	if (!enabled) {
 		return;
 	}
@@ -72,6 +75,17 @@ void QueryProfiler::Finalize(TreeNode &node) {
 	}
 }
 
+void QueryProfiler::StartExplainAnalyze() {
+	this->is_explain_analyze = true;
+	this->stored_enabled = enabled;
+	this->stored_automatic_print_format = automatic_print_format;
+	this->stored_save_location = save_location;
+
+	this->enabled = true;
+	this->save_location = string();
+	this->automatic_print_format = ProfilerPrintFormat::NONE;
+}
+
 void QueryProfiler::EndQuery() {
 	if (!enabled || !running) {
 		return;
@@ -100,6 +114,12 @@ void QueryProfiler::EndQuery() {
 		} else {
 			WriteToFile(save_location.c_str(), query_info);
 		}
+	}
+	if (is_explain_analyze) {
+		this->is_explain_analyze = false;
+		this->enabled = stored_enabled;
+		this->automatic_print_format = stored_automatic_print_format;
+		this->save_location = stored_save_location;
 	}
 }
 

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -411,6 +411,7 @@ void Executor::BuildPipelines(PhysicalOperator *op, Pipeline *current) {
 		case PhysicalOperatorType::COPY_TO_FILE:
 		case PhysicalOperatorType::LIMIT:
 		case PhysicalOperatorType::EXPRESSION_SCAN:
+		case PhysicalOperatorType::EXPLAIN_ANALYZE:
 			D_ASSERT(op->children.size() == 1);
 			// single operator:
 			// the operator becomes the data source of the current pipeline

--- a/src/parser/statement/explain_statement.cpp
+++ b/src/parser/statement/explain_statement.cpp
@@ -2,12 +2,12 @@
 
 namespace duckdb {
 
-ExplainStatement::ExplainStatement(unique_ptr<SQLStatement> stmt)
-    : SQLStatement(StatementType::EXPLAIN_STATEMENT), stmt(move(stmt)) {
+ExplainStatement::ExplainStatement(unique_ptr<SQLStatement> stmt, ExplainType explain_type)
+    : SQLStatement(StatementType::EXPLAIN_STATEMENT), stmt(move(stmt)), explain_type(explain_type) {
 }
 
 unique_ptr<SQLStatement> ExplainStatement::Copy() const {
-	auto result = make_unique<ExplainStatement>(stmt->Copy());
+	auto result = make_unique<ExplainStatement>(stmt->Copy(), explain_type);
 	return move(result);
 }
 

--- a/src/parser/transform/statement/transform_explain.cpp
+++ b/src/parser/transform/statement/transform_explain.cpp
@@ -6,7 +6,19 @@ namespace duckdb {
 unique_ptr<ExplainStatement> Transformer::TransformExplain(duckdb_libpgquery::PGNode *node) {
 	auto stmt = reinterpret_cast<duckdb_libpgquery::PGExplainStmt *>(node);
 	D_ASSERT(stmt);
-	return make_unique<ExplainStatement>(TransformStatement(stmt->query));
+	auto explain_type = ExplainType::EXPLAIN_STANDARD;
+	if (stmt->options) {
+		for(auto n = stmt->options->head; n; n = n->next) {
+			auto def_elem = ((duckdb_libpgquery::PGDefElem*)n->data.ptr_value)->defname;
+			string elem(def_elem);
+			if (elem == "analyze") {
+				explain_type = ExplainType::EXPLAIN_ANALYZE;
+			} else {
+				throw NotImplementedException("Unimplemented explain type: %s", elem);
+			}
+		}
+	}
+	return make_unique<ExplainStatement>(TransformStatement(stmt->query), explain_type);
 }
 
 } // namespace duckdb

--- a/src/parser/transform/statement/transform_explain.cpp
+++ b/src/parser/transform/statement/transform_explain.cpp
@@ -8,8 +8,8 @@ unique_ptr<ExplainStatement> Transformer::TransformExplain(duckdb_libpgquery::PG
 	D_ASSERT(stmt);
 	auto explain_type = ExplainType::EXPLAIN_STANDARD;
 	if (stmt->options) {
-		for(auto n = stmt->options->head; n; n = n->next) {
-			auto def_elem = ((duckdb_libpgquery::PGDefElem*)n->data.ptr_value)->defname;
+		for (auto n = stmt->options->head; n; n = n->next) {
+			auto def_elem = ((duckdb_libpgquery::PGDefElem *)n->data.ptr_value)->defname;
 			string elem(def_elem);
 			if (elem == "analyze") {
 				explain_type = ExplainType::EXPLAIN_ANALYZE;

--- a/src/planner/binder/statement/bind_explain.cpp
+++ b/src/planner/binder/statement/bind_explain.cpp
@@ -11,7 +11,7 @@ BoundStatement Binder::Bind(ExplainStatement &stmt) {
 	auto plan = Bind(*stmt.stmt);
 	// get the unoptimized logical plan, and create the explain statement
 	auto logical_plan_unopt = plan.plan->ToString();
-	auto explain = make_unique<LogicalExplain>(move(plan.plan));
+	auto explain = make_unique<LogicalExplain>(move(plan.plan), stmt.explain_type);
 	explain->logical_plan_unopt = logical_plan_unopt;
 
 	result.plan = move(explain);

--- a/test/sql/explain/test_explain_analyze.test
+++ b/test/sql/explain/test_explain_analyze.test
@@ -1,0 +1,35 @@
+# name: test/sql/explain/test_explain_analyze.test
+# description: Test explain analyze
+# group: [explain]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE integers AS SELECT * FROM range(100) tbl(i);
+
+query II
+EXPLAIN ANALYZE SELECT SUM(i) FROM integers
+----
+analyzed_plan	<REGEX>:.*integers.*
+
+query II
+EXPLAIN ANALYZE SELECT SUM(i) FROM (SELECT * FROM integers i1, integers i2 UNION ALL SELECT * FROM integers i1, integers i2);
+----
+analyzed_plan	<REGEX>:.*CROSS_PRODUCT.*
+
+statement ok
+PRAGMA enable_profiling
+
+query II
+EXPLAIN ANALYZE SELECT SUM(i) FROM (SELECT * FROM integers i1, integers i2 UNION ALL SELECT * FROM integers i1, integers i2);
+----
+analyzed_plan	<REGEX>:.*CROSS_PRODUCT.*
+
+statement ok
+PRAGMA disable_profiling
+
+query II
+EXPLAIN ANALYZE SELECT SUM(i) FROM (SELECT * FROM integers i1, integers i2 UNION ALL SELECT * FROM integers i1, integers i2);
+----
+analyzed_plan	<REGEX>:.*CROSS_PRODUCT.*

--- a/test/sql/explain/test_explain_analyze.test
+++ b/test/sql/explain/test_explain_analyze.test
@@ -33,3 +33,34 @@ query II
 EXPLAIN ANALYZE SELECT SUM(i) FROM (SELECT * FROM integers i1, integers i2 UNION ALL SELECT * FROM integers i1, integers i2);
 ----
 analyzed_plan	<REGEX>:.*CROSS_PRODUCT.*
+
+statement ok
+PRAGMA profiling_output='__TEST_DIR__/test.json'
+
+statement ok
+PRAGMA enable_profiling='json'
+
+statement ok
+SELECT 42
+
+statement ok
+PRAGMA disable_profiling
+
+query I nosort json_output
+SELECT * FROM read_csv('__TEST_DIR__/test.json', columns={'json': 'VARCHAR'}, sep='🦆');
+----
+
+statement ok
+PRAGMA enable_profiling='json'
+
+query II
+EXPLAIN ANALYZE SELECT SUM(i) FROM integers
+----
+analyzed_plan	<REGEX>:.*integers.*
+
+statement ok
+PRAGMA disable_profiling
+
+query I nosort json_output
+SELECT * FROM read_csv('__TEST_DIR__/test.json', columns={'json': 'VARCHAR'}, sep='🦆');
+----

--- a/test/sql/explain/test_explain_analyze_tpch.test_slow
+++ b/test/sql/explain/test_explain_analyze_tpch.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/explain/test_explain_analyze_tpch.test
+# name: test/sql/explain/test_explain_analyze_tpch.test_slow
 # description: Test explain analyze TPC-H
 # group: [explain]
 

--- a/test/sql/explain/test_explain_analyze_tpch.test_slow
+++ b/test/sql/explain/test_explain_analyze_tpch.test_slow
@@ -1,0 +1,43 @@
+# name: test/sql/explain/test_explain_analyze_tpch.test
+# description: Test explain analyze TPC-H
+# group: [explain]
+
+require tpch
+
+statement ok
+CALL dbgen(sf=0.01);
+
+statement ok
+PRAGMA enable_profiling
+
+loop i 0 2
+
+query II
+EXPLAIN ANALYZE SELECT
+    l_returnflag,
+    l_linestatus,
+    sum(l_quantity) AS sum_qty,
+    sum(l_extendedprice) AS sum_base_price,
+    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
+    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+    avg(l_quantity) AS avg_qty,
+    avg(l_extendedprice) AS avg_price,
+    avg(l_discount) AS avg_disc,
+    count(*) AS count_order
+FROM
+    lineitem
+WHERE
+    l_shipdate <= CAST('1998-09-02' AS date)
+GROUP BY
+    l_returnflag,
+    l_linestatus
+ORDER BY
+    l_returnflag,
+    l_linestatus;
+----
+analyzed_plan	<REGEX>:.*lineitem.*
+
+statement ok
+PRAGMA disable_profiling
+
+endloop

--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -166,6 +166,11 @@ test('''
 SELECT x::INT FROM (SELECT x::VARCHAR x FROM range(10) tbl(x) UNION ALL SELECT 'hello' x) tbl(x);
 ''', err='Could not convert string')
 
+# test explain
+test('explain select sum(i) from range(1000) tbl(i)', out='RANGE')
+test('explain analyze select sum(i) from range(1000) tbl(i)', out='RANGE')
+
+
 # this should be fixed
 test('.selftest', err='sqlite3_table_column_metadata')
 


### PR DESCRIPTION
Fixes #2401.

EXPLAIN ANALYZE output is similar to running our regular query profiler, but has two crucial differences:

* The EXPLAIN ANALYZE only runs for a single query, rather than needing to enable the setting connection-wide, and can easily be prepended to any query.
* EXPLAIN ANALYZE is returned as a regular result rather than being printed to the terminal or a file, which makes it more suitable to use from other clients (e.g. the Python/R clients, JDBC, etc).

```sql
D explain analyze select sum(i) from range(1000000) tbl(i);

┌─────────────────────────────────────┐
│┌───────────────────────────────────┐│
││    Query Profiling Information    ││
│└───────────────────────────────────┘│
└─────────────────────────────────────┘
explain analyze select sum(i) from range(1000000) tbl(i);
┌─────────────────────────────────────┐
│┌───────────────────────────────────┐│
││        Total Time: 0.0437s        ││
│└───────────────────────────────────┘│
└─────────────────────────────────────┘
┌───────────────────────────┐
│      EXPLAIN_ANALYZE      │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│             0             │
│          (0.00s)          │
└─────────────┬─────────────┘                             
┌─────────────┴─────────────┐
│      SIMPLE_AGGREGATE     │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│          sum(#0)          │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│             1             │
│          (0.03s)          │
└─────────────┬─────────────┘                             
┌─────────────┴─────────────┐
│         PROJECTION        │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│             i             │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│          1000000          │
│          (0.00s)          │
└─────────────┬─────────────┘                             
┌─────────────┴─────────────┐
│           RANGE           │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│          1000000          │
│          (0.01s)          │
└───────────────────────────┘             
```