### PR TITLE
Fix #2612: Correctly check that default is set on copy of SetDefaultInfo

### DIFF
--- a/src/parser/parsed_data/alter_table_info.cpp
+++ b/src/parser/parsed_data/alter_table_info.cpp
@@ -148,7 +148,8 @@ unique_ptr<AlterInfo> ChangeColumnTypeInfo::Deserialize(Deserializer &source, st
 // SetDefaultInfo
 //===--------------------------------------------------------------------===//
 unique_ptr<AlterInfo> SetDefaultInfo::Copy() const {
-	return make_unique_base<AlterInfo, SetDefaultInfo>(schema, name, column_name, expression->Copy());
+	return make_unique_base<AlterInfo, SetDefaultInfo>(schema, name, column_name,
+	                                                   expression ? expression->Copy() : nullptr);
 }
 
 void SetDefaultInfo::Serialize(Serializer &serializer) {

--- a/test/sql/alter/default/drop_default.test
+++ b/test/sql/alter/default/drop_default.test
@@ -1,0 +1,30 @@
+# name: test/sql/alter/default/drop_default.test
+# description: Test ALTER TABLE DROP DEFAULT
+# group: [default]
+
+statement ok
+PRAGMA enable_verification;
+
+statement ok
+CREATE TABLE data(id INTEGER, x INTEGER);
+
+statement ok
+ALTER TABLE data ALTER COLUMN id DROP DEFAULT;
+
+statement ok
+INSERT INTO data VALUES (1, 0), (2, 1);
+
+statement ok
+ALTER TABLE data ALTER COLUMN id DROP DEFAULT;
+
+statement ok
+ALTER TABLE data ALTER COLUMN id DROP DEFAULT;
+
+statement ok
+ALTER TABLE data ALTER COLUMN x DROP DEFAULT;
+
+statement ok
+ALTER TABLE data ALTER COLUMN x DROP DEFAULT;
+
+statement error
+ALTER TABLE data ALTER COLUMN j DROP DEFAULT;

--- a/test/sql/alter/default/test_set_default.test
+++ b/test/sql/alter/default/test_set_default.test
@@ -1,6 +1,6 @@
-# name: test/sql/alter/test_set_default.test
+# name: test/sql/alter/default/test_set_default.test
 # description: Test ALTER TABLE SET DEFAULT
-# group: [alter]
+# group: [default]
 
 statement ok
 CREATE TABLE test(i INTEGER, j INTEGER)


### PR DESCRIPTION
Correctly check that the expression field is set before copying it.

Fixes #2612.