### PR TITLE
Escape column names in dbWriteTable() Fixes #2622

### DIFF
--- a/tools/rpkg/R/Connection.R
+++ b/tools/rpkg/R/Connection.R
@@ -181,7 +181,7 @@ setMethod(
         col_idx <- 1
         for (name in col_names) {
             if (name %in% names(field.types)) {
-                cols <- c(cols, sprintf("#%d::%s %s", col_idx, field.types[name], name))
+                cols <- c(cols, sprintf("#%d::%s %s", col_idx, field.types[name], dbQuoteIdentifier(conn, name)))
             }
             else {
                 cols <- c(cols, sprintf("#%d", col_idx))

--- a/tools/rpkg/tests/testthat/test_dbwritetable.R
+++ b/tools/rpkg/tests/testthat/test_dbwritetable.R
@@ -1,0 +1,11 @@
+test_that("dbWriteTable can write tables with keyword column names", {
+  con <- dbConnect(duckdb())
+  on.exit(dbDisconnect(con, shutdown = TRUE))
+
+  # NB: name is a reserved word, will need to be escaped as part of writing operation
+  sample_data <- data.frame(id = 1:3, name = c("cuthbert", "dibble", "grubb"))
+  dbWriteTable(con, "sample_data", sample_data, field.types = c(id = "INTEGER", name = "VARCHAR"))
+
+  # Can read the data we wrote back again
+  expect_identical(dbReadTable(con, "sample_data"), sample_data)
+})


### PR DESCRIPTION
Field names can't be used in SQL directly as column names, at best they may be
keywords. Escape before use.

MFDB isn't out the woods yet, there's another DuckDB error occurring in it's integration tests, but will figure that out separately.