### PR TITLE
Fix #2586: correct semantics for extract(second, ...) from intervals

### DIFF
--- a/src/common/types/interval.cpp
+++ b/src/common/types/interval.cpp
@@ -430,4 +430,50 @@ bool Interval::GreaterThanEquals(interval_t left, interval_t right) {
 	return GreaterThan(left, right) || Equals(left, right);
 }
 
+date_t Interval::Add(date_t left, interval_t right) {
+	date_t result;
+	if (right.months != 0) {
+		int32_t year, month, day;
+		Date::Convert(left, year, month, day);
+		int32_t year_diff = right.months / Interval::MONTHS_PER_YEAR;
+		year += year_diff;
+		month += right.months - year_diff * Interval::MONTHS_PER_YEAR;
+		if (month > Interval::MONTHS_PER_YEAR) {
+			year++;
+			month -= Interval::MONTHS_PER_YEAR;
+		} else if (month <= 0) {
+			year--;
+			month += Interval::MONTHS_PER_YEAR;
+		}
+		day = MinValue<int32_t>(day, Date::MonthDays(year, month));
+		result = Date::FromDate(year, month, day);
+	} else {
+		result = left;
+	}
+	if (right.days != 0) {
+		if (!TryAddOperator::Operation(result.days, right.days, result.days)) {
+			throw OutOfRangeException("Date out of range");
+		}
+	}
+	if (right.micros != 0) {
+		if (!TryAddOperator::Operation(result.days, int32_t(right.micros / Interval::MICROS_PER_DAY), result.days)) {
+			throw OutOfRangeException("Date out of range");
+		}
+	}
+	return result;
+}
+
+dtime_t Interval::Add(dtime_t left, interval_t right, date_t &date) {
+	int64_t diff = right.micros - ((right.micros / Interval::MICROS_PER_DAY) * Interval::MICROS_PER_DAY);
+	left += diff;
+	if (left.micros >= Interval::MICROS_PER_DAY) {
+		left.micros -= Interval::MICROS_PER_DAY;
+		date.days++;
+	} else if (left.micros < 0) {
+		left.micros += Interval::MICROS_PER_DAY;
+		date.days--;
+	}
+	return left;
+}
+
 } // namespace duckdb

--- a/src/function/scalar/date/date_part.cpp
+++ b/src/function/scalar/date/date_part.cpp
@@ -540,7 +540,7 @@ int64_t DatePart::MicrosecondsOperator::Operation(timestamp_t input) {
 template <>
 int64_t DatePart::MicrosecondsOperator::Operation(interval_t input) {
 	// remove everything but the second & microsecond part
-	return input.micros;
+	return input.micros % Interval::MICROS_PER_MINUTE;
 }
 
 template <>
@@ -620,8 +620,17 @@ int64_t DatePart::EpochOperator::Operation(timestamp_t input) {
 
 template <>
 int64_t DatePart::EpochOperator::Operation(interval_t input) {
-	auto secs = SecondsOperator::Operation<interval_t, int64_t>(input);
-	return (input.months * Interval::DAYS_PER_MONTH + input.days) * Interval::SECS_PER_DAY + secs;
+	int64_t interval_years = input.months / Interval::MONTHS_PER_YEAR;
+	int64_t interval_days;
+	interval_days = Interval::DAYS_PER_YEAR * interval_years;
+	interval_days += Interval::DAYS_PER_MONTH * (input.months % Interval::MONTHS_PER_YEAR);
+	interval_days += input.days;
+	int64_t interval_epoch;
+	interval_epoch = interval_days * Interval::SECS_PER_DAY;
+	// we add 0.25 days per year to sort of account for leap days
+	interval_epoch += interval_years * (Interval::SECS_PER_DAY / 4);
+	interval_epoch += input.micros / Interval::MICROS_PER_SEC;
+	return interval_epoch;
 }
 
 template <>

--- a/src/include/duckdb/common/types/interval.hpp
+++ b/src/include/duckdb/common/types/interval.hpp
@@ -22,8 +22,9 @@ public:
 	static constexpr const int32_t MONTHS_PER_YEAR = 12;
 	static constexpr const int32_t MONTHS_PER_QUARTER = 3;
 	static constexpr const int32_t DAYS_PER_WEEK = 7;
-	static constexpr const int64_t DAYS_PER_MONTH =
-	    30; // only used for interval comparison/ordering purposes, in which case a month counts as 30 days
+	//! only used for interval comparison/ordering purposes, in which case a month counts as 30 days
+	static constexpr const int64_t DAYS_PER_MONTH = 30;
+	static constexpr const int64_t DAYS_PER_YEAR = 365;
 	static constexpr const int64_t MSECS_PER_SEC = 1000;
 	static constexpr const int32_t SECS_PER_MINUTE = 60;
 	static constexpr const int32_t MINS_PER_HOUR = 60;
@@ -73,6 +74,12 @@ public:
 
 	//! Returns the exact difference between two timestamps (days and seconds)
 	static interval_t GetDifference(timestamp_t timestamp_1, timestamp_t timestamp_2);
+
+	//! Add an interval to a date
+	static date_t Add(date_t left, interval_t right);
+	//! Add an interval to a time. In case the time overflows or underflows, modify the date by the overflow.
+	//! For example if we go from 23:00 to 02:00, we add a day to the date
+	static dtime_t Add(dtime_t left, interval_t right, date_t &date);
 
 	//! Comparison operators
 	static bool Equals(interval_t left, interval_t right);

--- a/test/sql/function/interval/test_date_part.test
+++ b/test/sql/function/interval/test_date_part.test
@@ -6,10 +6,10 @@ statement ok
 PRAGMA enable_verification
 
 statement ok
-CREATE TABLE intervals(i INTERVAL, s VARCHAR)
+CREATE TABLE intervals(i INTERVAL, s VARCHAR);
 
 statement ok
-INSERT INTO intervals VALUES ('2 years', 'year'), ('16 months', 'quarter'), ('42 days', 'day'), ('2066343400 microseconds', 'minute')
+INSERT INTO intervals VALUES ('2 years', 'year'), ('16 months', 'quarter'), ('42 days', 'day'), ('2066343400 microseconds', 'minute');
 
 # test date_part with different combinations of constant/non-constant columns
 query I
@@ -51,6 +51,14 @@ SELECT date_part('seconds', i) FROM intervals;
 0
 0
 0
+26
+
+query I
+SELECT date_part('epoch', i) FROM intervals;
+----
+63115200
+41925600
+3628800
 2066
 
 query I

--- a/test/sql/function/interval/test_extract.test
+++ b/test/sql/function/interval/test_extract.test
@@ -6,10 +6,10 @@ statement ok
 PRAGMA enable_verification
 
 statement ok
-CREATE TABLE intervals(i INTERVAL)
+CREATE TABLE intervals(i INTERVAL);
 
 statement ok
-INSERT INTO intervals VALUES ('2 years'), ('16 months'), ('42 days'), ('2066343400 microseconds'), (NULL)
+INSERT INTO intervals VALUES ('2 years'), ('16 months'), ('42 days'), ('2066343400 microseconds'), (NULL);
 
 # extract various parts of the intervals
 query I
@@ -93,8 +93,8 @@ SELECT EXTRACT(yearweek FROM i) FROM intervals
 query I
 SELECT EXTRACT(epoch FROM i) FROM intervals
 ----
-62208000
-41472000
+63115200
+41925600
 3628800
 2066
 NULL
@@ -105,7 +105,7 @@ SELECT EXTRACT(microsecond FROM i) FROM intervals
 0
 0
 0
-2066343400
+26343400
 NULL
 
 query I
@@ -114,7 +114,7 @@ SELECT EXTRACT(millisecond FROM i) FROM intervals
 0
 0
 0
-2066343
+26343
 NULL
 
 query I
@@ -123,7 +123,7 @@ SELECT EXTRACT(second FROM i) FROM intervals
 0
 0
 0
-2066
+26
 NULL
 
 query I


### PR DESCRIPTION
Fixes #2586, this now works correctly:

```sql
D select extract( second from interval '2 hours 2 minutes 10 seconds' ) as value_should_be_10;
┌────────────────────┐
│ value_should_be_10 │
├────────────────────┤
│ 10                 │
└────────────────────┘
D select extract( epoch from interval '2 hours 2 minutes 10 seconds' ) as value_should_be_7330;
┌──────────────────────┐
│ value_should_be_7330 │
├──────────────────────┤
│ 7330                 │
└──────────────────────┘
```

Also try to follow Postgres in date_part for epoch. Unfortunately Postgres is internally inconsistent there:

```sql
postgres=# select extract(epoch from interval '2 years');
     extract     
-----------------
 63072000.000000
(1 row)

postgres=# select date_part('epoch', interval '2 years');
 date_part 
-----------
  63115200
(1 row)
```

This is because `date_part` counts years as 365.25 days, whereas `extract` counts days as 365 days. Why this follows a different code-path is a mystery, but well. For now I have settled on 365.25 days. 