### PR TITLE
Issue #2552: SUBSTR BIGINT

### DIFF
--- a/src/include/duckdb/function/scalar/string_functions.hpp
+++ b/src/include/duckdb/function/scalar/string_functions.hpp
@@ -110,7 +110,7 @@ struct RegexpFun {
 
 struct SubstringFun {
 	static void RegisterFunction(BuiltinFunctions &set);
-	static string_t SubstringScalarFunction(Vector &result, string_t input, int32_t offset, int32_t length);
+	static string_t SubstringScalarFunction(Vector &result, string_t input, int64_t offset, int64_t length);
 };
 
 struct PrintfFun {

--- a/test/sql/function/string/test_substring.test
+++ b/test/sql/function/string/test_substring.test
@@ -220,3 +220,9 @@ SELECT substring(s, -2147483647, -2147483647) FROM strings
 (empty)
 (empty)
 NULL
+
+# Issue #2553 - accept BIGINT arguments
+query I
+SELECT SUBSTR('abc', INSTR('abc', 'b'));
+----
+bc


### PR DESCRIPTION
Change the argument type of SUBSTR to BIGINT.
Fix default length to avoid overflow.