### PR TITLE
Fix #2641: correctly handle tab delimiters in COPY TO/FROM

### DIFF
--- a/src/execution/operator/persistent/buffered_csv_reader.cpp
+++ b/src/execution/operator/persistent/buffered_csv_reader.cpp
@@ -25,7 +25,7 @@ namespace duckdb {
 void BufferedCSVReaderOptions::SetDelimiter(const string &input) {
 	this->delimiter = StringUtil::Replace(input, "\\t", "\t");
 	this->has_delimiter = true;
-	if (input.size() == 0) {
+	if (input.empty()) {
 		throw BinderException("DELIM or SEP must not be empty");
 	}
 }

--- a/src/execution/operator/persistent/buffered_csv_reader.cpp
+++ b/src/execution/operator/persistent/buffered_csv_reader.cpp
@@ -22,6 +22,24 @@
 
 namespace duckdb {
 
+void BufferedCSVReaderOptions::SetDelimiter(const string &input) {
+	this->delimiter = StringUtil::Replace(input, "\\t", "\t");
+	this->has_delimiter = true;
+	if (input.size() == 0) {
+		throw BinderException("DELIM or SEP must not be empty");
+	}
+}
+
+std::string BufferedCSVReaderOptions::ToString() const {
+	return "DELIMITER='" + delimiter + (has_delimiter ? "'" : (auto_detect ? "' (auto detected)" : "' (default)")) +
+	       ", QUOTE='" + quote + (has_quote ? "'" : (auto_detect ? "' (auto detected)" : "' (default)")) +
+	       ", ESCAPE='" + escape + (has_escape ? "'" : (auto_detect ? "' (auto detected)" : "' (default)")) +
+	       ", HEADER=" + std::to_string(header) +
+	       (has_header ? "" : (auto_detect ? " (auto detected)" : "' (default)")) +
+	       ", SAMPLE_SIZE=" + std::to_string(sample_chunk_size * sample_chunks) +
+	       ", ALL_VARCHAR=" + std::to_string(all_varchar);
+}
+
 static string GetLineNumberStr(idx_t linenr, bool linenr_estimated) {
 	string estimated = (linenr_estimated ? string(" (estimated)") : string(""));
 	return to_string(linenr + 1) + estimated;
@@ -835,7 +853,7 @@ vector<LogicalType> BufferedCSVReader::RefineTypeDetection(const vector<LogicalT
 		if (requested_types.size() != options.num_cols) {
 			throw InvalidInputException(
 			    "Error while determining column types: found %lld columns but expected %d. (%s)", options.num_cols,
-			    requested_types.size(), options.toString());
+			    requested_types.size(), options.ToString());
 		} else {
 			detected_types = requested_types;
 		}
@@ -1093,7 +1111,7 @@ in_quotes:
 	} while (ReadBuffer(start));
 	// still in quoted state at the end of the file, error:
 	error_message = StringUtil::Format("Error in file \"%s\" on line %s: unterminated quotes. (%s)", options.file_path,
-	                                   GetLineNumberStr(linenr, linenr_estimated).c_str(), options.toString());
+	                                   GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
 	return false;
 unquote:
 	/* state: unquote */
@@ -1123,7 +1141,7 @@ unquote:
 				error_message = StringUtil::Format(
 				    "Error in file \"%s\" on line %s: quote should be followed by end of value, end "
 				    "of row or another quote. (%s)",
-				    options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.toString());
+				    options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
 				return false;
 			}
 			if (delimiter_pos == options.delimiter.size()) {
@@ -1140,7 +1158,7 @@ unquote:
 	} while (ReadBuffer(start));
 	error_message = StringUtil::Format(
 	    "Error in file \"%s\" on line %s: quote should be followed by end of value, end of row or another quote. (%s)",
-	    options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.toString());
+	    options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
 	return false;
 handle_escape:
 	escape_pos = 0;
@@ -1155,7 +1173,7 @@ handle_escape:
 			if (count > escape_pos && count > quote_pos) {
 				error_message = StringUtil::Format(
 				    "Error in file \"%s\" on line %s: neither QUOTE nor ESCAPE is proceeded by ESCAPE. (%s)",
-				    options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.toString());
+				    options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
 				return false;
 			}
 			if (quote_pos == options.quote.size() || escape_pos == options.escape.size()) {
@@ -1166,7 +1184,7 @@ handle_escape:
 	} while (ReadBuffer(start));
 	error_message =
 	    StringUtil::Format("Error in file \"%s\" on line %s: neither QUOTE nor ESCAPE is proceeded by ESCAPE. (%s)",
-	                       options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.toString());
+	                       options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
 	return false;
 carriage_return:
 	/* state: carriage_return */
@@ -1298,7 +1316,7 @@ in_quotes:
 	} while (ReadBuffer(start));
 	// still in quoted state at the end of the file, error:
 	throw InvalidInputException("Error in file \"%s\" on line %s: unterminated quotes. (%s)", options.file_path,
-	                            GetLineNumberStr(linenr, linenr_estimated).c_str(), options.toString());
+	                            GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
 unquote:
 	/* state: unquote */
 	// this state handles the state directly after we unquote
@@ -1325,7 +1343,7 @@ unquote:
 		error_message = StringUtil::Format(
 		    "Error in file \"%s\" on line %s: quote should be followed by end of value, end of "
 		    "row or another quote. (%s)",
-		    options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.toString());
+		    options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
 		return false;
 	}
 handle_escape:
@@ -1335,13 +1353,13 @@ handle_escape:
 	if (position >= buffer_size && !ReadBuffer(start)) {
 		error_message = StringUtil::Format(
 		    "Error in file \"%s\" on line %s: neither QUOTE nor ESCAPE is proceeded by ESCAPE. (%s)", options.file_path,
-		    GetLineNumberStr(linenr, linenr_estimated).c_str(), options.toString());
+		    GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
 		return false;
 	}
 	if (buffer[position] != options.quote[0] && buffer[position] != options.escape[0]) {
 		error_message = StringUtil::Format(
 		    "Error in file \"%s\" on line %s: neither QUOTE nor ESCAPE is proceeded by ESCAPE. (%s)", options.file_path,
-		    GetLineNumberStr(linenr, linenr_estimated).c_str(), options.toString());
+		    GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
 		return false;
 	}
 	// escape was followed by quote or escape, go back to quoted state
@@ -1481,7 +1499,7 @@ void BufferedCSVReader::AddValue(char *str_val, idx_t length, idx_t &column, vec
 	if (column >= sql_types.size()) {
 		throw InvalidInputException("Error on line %s: expected %lld values per row, but got more. (%s)",
 		                            GetLineNumberStr(linenr, linenr_estimated).c_str(), sql_types.size(),
-		                            options.toString());
+		                            options.ToString());
 	}
 
 	// insert the line number into the chunk
@@ -1536,7 +1554,7 @@ bool BufferedCSVReader::AddRow(DataChunk &insert_chunk, idx_t &column) {
 	if (column < sql_types.size() && mode != ParserMode::SNIFFING_DIALECT) {
 		throw InvalidInputException("Error on line %s: expected %lld values per row, but got %d. (%s)",
 		                            GetLineNumberStr(linenr, linenr_estimated).c_str(), sql_types.size(), column,
-		                            options.toString());
+		                            options.ToString());
 	}
 
 	if (mode == ParserMode::SNIFFING_DIALECT) {
@@ -1589,7 +1607,7 @@ void BufferedCSVReader::Flush(DataChunk &insert_chunk) {
 						throw InvalidInputException("Error in file \"%s\" between line %llu and %llu in column \"%s\": "
 						                            "file is not valid UTF8. Parser options: %s",
 						                            options.file_path, linenr - parse_chunk.size(), linenr, col_name,
-						                            options.toString());
+						                            options.ToString());
 					}
 				}
 			}
@@ -1623,11 +1641,11 @@ void BufferedCSVReader::Flush(DataChunk &insert_chunk) {
 					                            "(SAMPLE_SIZE=X [X rows] or SAMPLE_SIZE=-1 [all rows]), "
 					                            "or skipping column conversion (ALL_VARCHAR=1)",
 					                            error_message, col_name, linenr - parse_chunk.size() + 1, linenr,
-					                            options.toString());
+					                            options.ToString());
 				} else {
 					throw InvalidInputException("%s between line %llu and %llu in column %s. Parser options: %s ",
 					                            error_message, linenr - parse_chunk.size(), linenr, col_name,
-					                            options.toString());
+					                            options.ToString());
 				}
 			}
 		}

--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -61,11 +61,7 @@ static int64_t ParseInteger(vector<Value> &set) {
 //===--------------------------------------------------------------------===//
 static bool ParseBaseOption(BufferedCSVReaderOptions &options, string &loption, vector<Value> &set) {
 	if (StringUtil::StartsWith(loption, "delim") || StringUtil::StartsWith(loption, "sep")) {
-		options.delimiter = ParseString(set);
-		options.has_delimiter = true;
-		if (options.delimiter.length() == 0) {
-			throw BinderException("DELIM or SEP must not be empty");
-		}
+		options.SetDelimiter(ParseString(set));
 	} else if (loption == "quote") {
 		options.quote = ParseString(set);
 		options.has_quote = true;

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -33,8 +33,7 @@ static unique_ptr<FunctionData> ReadCSVBind(ClientContext &context, vector<Value
 		if (kv.first == "auto_detect") {
 			options.auto_detect = kv.second.value_.boolean;
 		} else if (kv.first == "sep" || kv.first == "delim") {
-			options.delimiter = kv.second.str_value;
-			options.has_delimiter = true;
+			options.SetDelimiter(kv.second.str_value);
 		} else if (kv.first == "header") {
 			options.header = kv.second.value_.boolean;
 			options.has_header = true;

--- a/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
@@ -99,15 +99,9 @@ struct BufferedCSVReaderOptions {
 	//! Whether or not a type format is specified
 	std::map<LogicalTypeId, bool> has_format = {{LogicalTypeId::DATE, false}, {LogicalTypeId::TIMESTAMP, false}};
 
-	std::string toString() const {
-		return "DELIMITER='" + delimiter + (has_delimiter ? "'" : (auto_detect ? "' (auto detected)" : "' (default)")) +
-		       ", QUOTE='" + quote + (has_quote ? "'" : (auto_detect ? "' (auto detected)" : "' (default)")) +
-		       ", ESCAPE='" + escape + (has_escape ? "'" : (auto_detect ? "' (auto detected)" : "' (default)")) +
-		       ", HEADER=" + std::to_string(header) +
-		       (has_header ? "" : (auto_detect ? " (auto detected)" : "' (default)")) +
-		       ", SAMPLE_SIZE=" + std::to_string(sample_chunk_size * sample_chunks) +
-		       ", ALL_VARCHAR=" + std::to_string(all_varchar);
-	}
+	void SetDelimiter(const string &delimiter);
+
+	std::string ToString() const;
 };
 
 enum class ParserMode : uint8_t { PARSING = 0, SNIFFING_DIALECT = 1, SNIFFING_DATATYPES = 2, PARSING_HEADER = 3 };

--- a/test/sql/copy/csv/tsv_copy.test
+++ b/test/sql/copy/csv/tsv_copy.test
@@ -1,0 +1,25 @@
+# name: test/sql/copy/csv/tsv_copy.test
+# description: Test TSV Copy round-trip
+# group: [csv]
+
+
+statement ok
+CREATE TABLE people(id INTEGER, name VARCHAR);
+
+statement ok
+INSERT INTO people VALUES (1, 'Mark'), (2, 'Hannes');
+
+statement ok
+COPY people TO '__TEST_DIR__/test.tsv' WITH (HEADER 1, DELIMITER '\t');
+
+query II
+SELECT * FROM '__TEST_DIR__/test.tsv'
+----
+1	Mark
+2	Hannes
+
+query II
+SELECT * FROM read_csv('__TEST_DIR__/test.tsv', sep='\t', columns={'id': 'INTEGER', 'name': 'VARCHAR'}, header=1)
+----
+1	Mark
+2	Hannes


### PR DESCRIPTION
Fixes #2641