### PR TITLE
Fix #686: remove hard-coded memory limit in parser and fix error message propagation from exceptions thrown in parser

### DIFF
--- a/third_party/libpg_query/pg_functions.cpp
+++ b/third_party/libpg_query/pg_functions.cpp
@@ -11,7 +11,6 @@
 
 // max parse tree size approx 100 MB, should be enough
 #define PG_MALLOC_SIZE 10240
-#define PG_MALLOC_LIMIT 1000
 
 namespace duckdb_libpgquery {
 
@@ -23,7 +22,8 @@ struct pg_parser_state_str {
 
 	size_t malloc_pos;
 	size_t malloc_ptr_idx;
-	char *malloc_ptrs[PG_MALLOC_LIMIT];
+	char **malloc_ptrs;
+	size_t malloc_ptr_size;
 };
 
 static __thread parser_state pg_parser_state;
@@ -33,8 +33,13 @@ __thread PGNode *duckdb_newNodeMacroHolder;
 #endif
 
 static void allocate_new(parser_state *state, size_t n) {
-	if (state->malloc_ptr_idx + 1 >= PG_MALLOC_LIMIT) {
-		throw std::runtime_error("Memory allocation failure");
+	if (state->malloc_ptr_idx >= state->malloc_ptr_size) {
+		size_t new_size = state->malloc_ptr_size * 2;
+		auto new_malloc_ptrs = (char **) malloc(sizeof(char *) * new_size);
+		memcpy(new_malloc_ptrs, state->malloc_ptrs, state->malloc_ptr_size * sizeof(char*));
+		free(state->malloc_ptrs);
+		state->malloc_ptr_size = new_size;
+		state->malloc_ptrs = new_malloc_ptrs;
 	}
 	if (n < PG_MALLOC_SIZE) {
 		n = PG_MALLOC_SIZE;
@@ -65,6 +70,8 @@ void pg_parser_init() {
 	pg_parser_state.pg_err_code = PGUNDEFINED;
 	pg_parser_state.pg_err_msg[0] = '\0';
 
+	pg_parser_state.malloc_ptr_size = 4;
+	pg_parser_state.malloc_ptrs = (char **) malloc(sizeof(char *) * pg_parser_state.malloc_ptr_size);
 	pg_parser_state.malloc_ptr_idx = 0;
 	allocate_new(&pg_parser_state, 1);
 }
@@ -74,8 +81,16 @@ void pg_parser_parse(const char *query, parse_result *res) {
 	try {
 		res->parse_tree = duckdb_libpgquery::raw_parser(query);
 		res->success = pg_parser_state.pg_err_code == PGUNDEFINED;
-	} catch (...) {
+	} catch (std::exception &ex) {
 		res->success = false;
+		// copy the error message of the exception
+		auto error_message = ex.what();
+		uint32_t pos = 0;
+		while(pos < 1023 && error_message[pos]) {
+			pg_parser_state.pg_err_msg[pos] = error_message[pos];
+			pos++;
+		}
+		pg_parser_state.pg_err_msg[pos] = '\0';
 	}
 	res->error_message = pg_parser_state.pg_err_msg;
 	res->error_location = pg_parser_state.pg_err_pos;
@@ -89,6 +104,7 @@ void pg_parser_cleanup() {
 			pg_parser_state.malloc_ptrs[ptr_idx] = nullptr;
 		}
 	}
+	free(pg_parser_state.malloc_ptrs);
 }
 
 int ereport(int code, ...) {


### PR DESCRIPTION
Fixes #686
