### PR TITLE
Fix #2652: Make struct fields case insensitive

### DIFF
--- a/src/function/scalar/struct/struct_pack.cpp
+++ b/src/function/scalar/struct/struct_pack.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/parser/expression/bound_expression.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
-#include "duckdb/common/unordered_set.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/storage/statistics/struct_statistics.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 
@@ -31,7 +31,7 @@ static void StructPackFunction(DataChunk &args, ExpressionState &state, Vector &
 
 static unique_ptr<FunctionData> StructPackBind(ClientContext &context, ScalarFunction &bound_function,
                                                vector<unique_ptr<Expression>> &arguments) {
-	unordered_set<string> name_collision_set;
+	case_insensitive_set_t name_collision_set;
 
 	// collect names and deconflict, construct return type
 	if (arguments.empty()) {

--- a/test/sql/types/struct/struct_case_insensitivity.test
+++ b/test/sql/types/struct/struct_case_insensitivity.test
@@ -1,0 +1,41 @@
+# name: test/sql/types/struct/struct_case_insensitivity.test
+# description: Test struct case insensitivity
+# group: [struct]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE tbl AS SELECT ({'HELLO': 3}) col;
+
+query I
+SELECT col['HELLO'] FROM tbl
+----
+3
+
+query I
+SELECT col['hello'] FROM tbl
+----
+3
+
+query I
+SELECT col.hello FROM tbl
+----
+3
+
+query I
+SELECT "COL"."HELLO" FROM tbl
+----
+3
+
+statement error
+SELECT ({'hello': 3, 'hello': 4}) col;
+
+statement error
+SELECT ({'HELLO': 3, 'HELLO': 4}) col;
+
+statement error
+SELECT ({'HELLO': 3, 'hello': 4}) col;
+
+statement error
+SELECT col['HELL'] FROM tbl


### PR DESCRIPTION
Fixes #2652 and improves the error message of struct extract when an entry is not found:

```sql
D select ({'hello': 3})['hey'];
Error: Binder Error: Could not find key "hey" in struct

Candidate Entries: "hello"
```