### PR TITLE
Fix #2656: correctly transform DISTINCT with ORDER BY into DISTINCT ON

### DIFF
--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -66,6 +66,11 @@ void Binder::BindModifiers(OrderBinder &order_binder, QueryNode &statement, Boun
 		case ResultModifierType::DISTINCT_MODIFIER: {
 			auto &distinct = (DistinctModifier &)*mod;
 			auto bound_distinct = make_unique<BoundDistinctModifier>();
+			if (distinct.distinct_on_targets.empty()) {
+				for (idx_t i = 0; i < result.names.size(); i++) {
+					distinct.distinct_on_targets.push_back(make_unique<ConstantExpression>(Value::INTEGER(1 + i)));
+				}
+			}
 			for (auto &distinct_on_target : distinct.distinct_on_targets) {
 				auto expr = BindOrderExpression(order_binder, move(distinct_on_target));
 				if (!expr) {

--- a/test/sql/aggregate/distinct/issue2656.test
+++ b/test/sql/aggregate/distinct/issue2656.test
@@ -1,0 +1,43 @@
+# name: test/sql/aggregate/distinct/issue2656.test
+# description: Issue #2656: DISTINCT + ORDER produces incorrect result
+# group: [distinct]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE T (t1 int, t2 int);
+
+statement ok
+INSERT INTO t VALUES (1, 1), (1, 2);
+
+query I
+SELECT DISTINCT t1
+FROM T
+ORDER BY t1, t2;
+----
+1
+
+query II
+SELECT DISTINCT ON (1) t1, t2
+FROM T
+ORDER BY t1, t2;
+----
+1	1
+
+query I
+SELECT DISTINCT t1 FROM T
+UNION
+SELECT DISTINCT t1 FROM T
+ORDER BY t1;
+----
+1
+
+query I
+SELECT DISTINCT t1 FROM T
+UNION ALL
+SELECT DISTINCT t1 FROM T
+ORDER BY t1;
+----
+1
+1


### PR DESCRIPTION
Fixes #2656. We choose to mimick SQLite's behavior here and transform the query into a `DISTINCT ON` with the queries that are mentioned in the SELECT clause, i.e. the following two queries are identical:

```sql
CREATE TABLE T (t1 int, t2 int);
INSERT INTO t VALUES (1, 1), (1, 2);

SELECT DISTINCT t1
FROM T
ORDER BY t1, t2;

SELECT t1 FROM (
  SELECT DISTINCT ON(t1) t1, t2
  FROM T
  ORDER BY t1, t2
) T;
```