### PR TITLE
Benchmark/test format cleanup

### DIFF
--- a/benchmark/micro/aggregate/quantile/quantile.benchmark
+++ b/benchmark/micro/aggregate/quantile/quantile.benchmark
@@ -1,6 +1,6 @@
 # name: benchmark/micro/aggregate/quantile/quantile.benchmark
 # description: Quantile Function
-# group: [aggregate]
+# group: [quantile]
 
 name Quantile
 group quantile

--- a/benchmark/micro/arithmetic/multiplications.benchmark
+++ b/benchmark/micro/arithmetic/multiplications.benchmark
@@ -1,6 +1,6 @@
 # name: benchmark/micro/arithmetic/multiplications.benchmark
 # description: Integer multiplications between 10000000 values
-# group: [micro]
+# group: [arithmetic]
 
 name Integer Multiplication
 group micro

--- a/benchmark/micro/cast/cast_huge_hugeint_string_benchmark.benchmark
+++ b/benchmark/micro/cast/cast_huge_hugeint_string_benchmark.benchmark
@@ -1,4 +1,4 @@
-# name: benchmark/micro/cast/cast_huge_hugeint_string.benchmark
+# name: benchmark/micro/cast/cast_huge_hugeint_string_benchmark.benchmark
 # description: Cast HUYGE HUGEINT to string
 # group: [cast]
 

--- a/benchmark/micro/date/extract_month.benchmark
+++ b/benchmark/micro/date/extract_month.benchmark
@@ -1,4 +1,4 @@
-# name: benchmark/micro/date/extract_year.benchmark
+# name: benchmark/micro/date/extract_month.benchmark
 # description: EXTRACT(month from date)
 # group: [date]
 

--- a/benchmark/micro/groupby-parallel/large_groups.benchmark
+++ b/benchmark/micro/groupby-parallel/large_groups.benchmark
@@ -1,6 +1,6 @@
-# name: benchmark/micro/groupby-parallel/tiny_groups.benchmark
+# name: benchmark/micro/groupby-parallel/large_groups.benchmark
 # description: Aggregation with large group count
-# group: [groupby]
+# group: [groupby-parallel]
 
 name Grouped Aggregate (L, 1000000 groups)
 group aggregate

--- a/benchmark/micro/groupby-parallel/medium_groups.benchmark
+++ b/benchmark/micro/groupby-parallel/medium_groups.benchmark
@@ -1,6 +1,6 @@
-# name: benchmark/micro/groupby-parallel/tiny_groups.benchmark
+# name: benchmark/micro/groupby-parallel/medium_groups.benchmark
 # description: Aggregation with small group count
-# group: [groupby]
+# group: [groupby-parallel]
 
 name Grouped Aggregate (M, 100000 groups)
 group aggregate

--- a/benchmark/micro/groupby-parallel/tiny_groups.benchmark
+++ b/benchmark/micro/groupby-parallel/tiny_groups.benchmark
@@ -1,6 +1,6 @@
 # name: benchmark/micro/groupby-parallel/tiny_groups.benchmark
 # description: Aggregation with small group count
-# group: [groupby]
+# group: [groupby-parallel]
 
 name Grouped Aggregate (S, 100 groups)
 group aggregate

--- a/benchmark/micro/index/range_query_without_index.benchmark
+++ b/benchmark/micro/index/range_query_without_index.benchmark
@@ -1,4 +1,4 @@
-# name: benchmark/micro/index/point_query_without_index.benchmark
+# name: benchmark/micro/index/range_query_without_index.benchmark
 # description: Range query without index
 # group: [index]
 

--- a/benchmark/micro/join/left_outer_join_right_big.benchmark
+++ b/benchmark/micro/join/left_outer_join_right_big.benchmark
@@ -1,4 +1,4 @@
-# name: benchmark/micro/join/left_outer_join_left_big.benchmark
+# name: benchmark/micro/join/left_outer_join_right_big.benchmark
 # description: LEFT OUTER JOIN between two tables, where the right table is significantly bigger than the left table
 # group: [join]
 

--- a/benchmark/micro/join/range_join.benchmark
+++ b/benchmark/micro/join/range_join.benchmark
@@ -1,6 +1,6 @@
 # name: benchmark/micro/join/range_join.benchmark
 # description: Range join between integers
-# group: [micro]
+# group: [join]
 
 name Range Join
 group join

--- a/benchmark/micro/list/unnest.benchmark
+++ b/benchmark/micro/list/unnest.benchmark
@@ -1,6 +1,6 @@
 # name: benchmark/micro/list/unnest.benchmark
 # description: Large unnest
-# group: [micro]
+# group: [list]
 
 name Unnest
 group micro

--- a/benchmark/micro/nulls/no_nulls_addition.benchmark
+++ b/benchmark/micro/nulls/no_nulls_addition.benchmark
@@ -1,6 +1,6 @@
 # name: benchmark/micro/nulls/no_nulls_addition.benchmark
 # description: Benchmark of sum and addition without nulls
-# group: [micro]
+# group: [nulls]
 
 name NULL Addition (no nulls)
 group micro

--- a/benchmark/micro/nulls/null_addition.benchmark
+++ b/benchmark/micro/nulls/null_addition.benchmark
@@ -1,6 +1,6 @@
 # name: benchmark/micro/nulls/null_addition.benchmark
 # description: Benchmark of sum and addition with nulls
-# group: [micro]
+# group: [nulls]
 
 name NULL Addition
 group micro

--- a/benchmark/micro/order/orderby.benchmark
+++ b/benchmark/micro/order/orderby.benchmark
@@ -1,6 +1,6 @@
-# name: benchmark/micro/arithmetic/multiplications.benchmark
+# name: benchmark/micro/order/orderby.benchmark
 # description: Order by integer table with 1000000 values
-# group: [micro]
+# group: [order]
 
 name Order By (Single Integer)
 group micro

--- a/benchmark/micro/window/window_count_star_fixed_100.benchmark
+++ b/benchmark/micro/window/window_count_star_fixed_100.benchmark
@@ -1,6 +1,6 @@
 # name: benchmark/micro/window/window_count_star_fixed_100.benchmark
 # description: Moving COUNT(*) performance, fixed 100 element window
-# group: [micro]
+# group: [window]
 
 name Windowed COUNT(*), Fixed 100
 group window

--- a/benchmark/micro/window/window_count_star_variable_100.benchmark
+++ b/benchmark/micro/window/window_count_star_variable_100.benchmark
@@ -1,6 +1,6 @@
 # name: benchmark/micro/window/window_count_star_variable_100.benchmark
 # description: Moving COUNT(*) performance, variable 100 element window
-# group: [micro]
+# group: [window]
 
 name Windowed COUNT(*), Variable 100
 group window

--- a/benchmark/micro/window/window_iqr_fixed_100.benchmark
+++ b/benchmark/micro/window/window_iqr_fixed_100.benchmark
@@ -1,6 +1,6 @@
 # name: benchmark/micro/window/window_iqr_fixed_100.benchmark
 # description: Moving IQR performance, fixed 100 element window
-# group: [micro]
+# group: [window]
 
 name Windowed IQR, Fixed 100
 group window

--- a/benchmark/micro/window/window_iqr_variable_100.benchmark
+++ b/benchmark/micro/window/window_iqr_variable_100.benchmark
@@ -1,6 +1,6 @@
 # name: benchmark/micro/window/window_iqr_variable_100.benchmark
 # description: Moving IQR performance, variable 100 element window
-# group: [micro]
+# group: [window]
 
 name Windowed IQR, Variable 100
 group window

--- a/benchmark/micro/window/window_mad_fixed_100.benchmark
+++ b/benchmark/micro/window/window_mad_fixed_100.benchmark
@@ -1,6 +1,6 @@
 # name: benchmark/micro/window/window_mad_fixed_100.benchmark
 # description: Moving MAD performance, fixed 100 element frame
-# group: [micro]
+# group: [window]
 
 name Windowed MAD, Fixed 100
 group window

--- a/benchmark/micro/window/window_mad_variable_100.benchmark
+++ b/benchmark/micro/window/window_mad_variable_100.benchmark
@@ -1,6 +1,6 @@
 # name: benchmark/micro/window/window_mad_variable_100.benchmark
 # description: Moving MAD performance, variable 100 element frame
-# group: [micro]
+# group: [window]
 
 name Windowed MAD, Variable 100
 group window

--- a/benchmark/micro/window/window_median_fixed_100.benchmark
+++ b/benchmark/micro/window/window_median_fixed_100.benchmark
@@ -1,6 +1,6 @@
 # name: benchmark/micro/window/window_median_fixed_100.benchmark
 # description: Moving MEDIAN performance, fixed 100 element frame
-# group: [micro]
+# group: [window]
 
 name Windowed MEDIAN, Fixed 100
 group window

--- a/benchmark/micro/window/window_median_variable_100.benchmark
+++ b/benchmark/micro/window/window_median_variable_100.benchmark
@@ -1,6 +1,6 @@
 # name: benchmark/micro/window/window_median_variable_100.benchmark
 # description: Moving MEDIAN performance, varbiable 100 element frame
-# group: [micro]
+# group: [window]
 
 name Windowed MEDIAN, Variable 100
 group window

--- a/benchmark/micro/window/window_mode_fixed_100.benchmark
+++ b/benchmark/micro/window/window_mode_fixed_100.benchmark
@@ -1,6 +1,6 @@
 # name: benchmark/micro/window/window_mode_fixed_100.benchmark
 # description: Moving MODE performance, fixed 100 element frame
-# group: [micro]
+# group: [window]
 
 name Windowed MODE, Fixed 100
 group window

--- a/benchmark/micro/window/window_mode_variable_100.benchmark
+++ b/benchmark/micro/window/window_mode_variable_100.benchmark
@@ -1,6 +1,6 @@
-# name: benchmark/micro/window/window_mode_fixed_100.benchmark
+# name: benchmark/micro/window/window_mode_variable_100.benchmark
 # description: Moving mode performance, variable 100 element frame
-# group: [micro]
+# group: [window]
 
 name Windowed MODE, Variable 100
 group window

--- a/benchmark/micro/window/window_sum.benchmark
+++ b/benchmark/micro/window/window_sum.benchmark
@@ -1,6 +1,6 @@
 # name: benchmark/micro/window/window_sum.benchmark
 # description: Window Sum
-# group: [micro]
+# group: [window]
 
 name Window Sum
 group window

--- a/benchmark/tpcds/sf1/q01.benchmark
+++ b/benchmark/tpcds/sf1/q01.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q01.benchmark
 # description: Run query 01 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q02.benchmark
+++ b/benchmark/tpcds/sf1/q02.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q02.benchmark
 # description: Run query 02 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q03.benchmark
+++ b/benchmark/tpcds/sf1/q03.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q03.benchmark
 # description: Run query 03 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q04.benchmark
+++ b/benchmark/tpcds/sf1/q04.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q04.benchmark
 # description: Run query 04 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q05.benchmark
+++ b/benchmark/tpcds/sf1/q05.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q05.benchmark
 # description: Run query 05 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q06.benchmark
+++ b/benchmark/tpcds/sf1/q06.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q06.benchmark
 # description: Run query 06 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q07.benchmark
+++ b/benchmark/tpcds/sf1/q07.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q07.benchmark
 # description: Run query 07 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q08.benchmark
+++ b/benchmark/tpcds/sf1/q08.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q08.benchmark
 # description: Run query 08 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q09.benchmark
+++ b/benchmark/tpcds/sf1/q09.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q09.benchmark
 # description: Run query 09 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q10.benchmark
+++ b/benchmark/tpcds/sf1/q10.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q10.benchmark
 # description: Run query 10 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q11.benchmark
+++ b/benchmark/tpcds/sf1/q11.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q11.benchmark
 # description: Run query 11 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q12.benchmark
+++ b/benchmark/tpcds/sf1/q12.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q12.benchmark
 # description: Run query 12 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q13.benchmark
+++ b/benchmark/tpcds/sf1/q13.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q13.benchmark
 # description: Run query 13 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q14.benchmark
+++ b/benchmark/tpcds/sf1/q14.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q14.benchmark
 # description: Run query 14 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q15.benchmark
+++ b/benchmark/tpcds/sf1/q15.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q15.benchmark
 # description: Run query 15 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q16.benchmark
+++ b/benchmark/tpcds/sf1/q16.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q16.benchmark
 # description: Run query 16 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q17.benchmark
+++ b/benchmark/tpcds/sf1/q17.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q17.benchmark
 # description: Run query 17 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q18.benchmark
+++ b/benchmark/tpcds/sf1/q18.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q18.benchmark
 # description: Run query 18 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q19.benchmark
+++ b/benchmark/tpcds/sf1/q19.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q19.benchmark
 # description: Run query 19 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q20.benchmark
+++ b/benchmark/tpcds/sf1/q20.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q20.benchmark
 # description: Run query 20 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q21.benchmark
+++ b/benchmark/tpcds/sf1/q21.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q21.benchmark
 # description: Run query 21 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q22.benchmark
+++ b/benchmark/tpcds/sf1/q22.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q22.benchmark
 # description: Run query 22 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q23.benchmark
+++ b/benchmark/tpcds/sf1/q23.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q23.benchmark
 # description: Run query 23 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q24.benchmark
+++ b/benchmark/tpcds/sf1/q24.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q24.benchmark
 # description: Run query 24 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q25.benchmark
+++ b/benchmark/tpcds/sf1/q25.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q25.benchmark
 # description: Run query 25 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q26.benchmark
+++ b/benchmark/tpcds/sf1/q26.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q26.benchmark
 # description: Run query 26 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q27.benchmark
+++ b/benchmark/tpcds/sf1/q27.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q27.benchmark
 # description: Run query 27 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q28.benchmark
+++ b/benchmark/tpcds/sf1/q28.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q28.benchmark
 # description: Run query 28 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q29.benchmark
+++ b/benchmark/tpcds/sf1/q29.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q29.benchmark
 # description: Run query 29 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q30.benchmark
+++ b/benchmark/tpcds/sf1/q30.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q30.benchmark
 # description: Run query 30 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q31.benchmark
+++ b/benchmark/tpcds/sf1/q31.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q31.benchmark
 # description: Run query 31 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q32.benchmark
+++ b/benchmark/tpcds/sf1/q32.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q32.benchmark
 # description: Run query 32 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q33.benchmark
+++ b/benchmark/tpcds/sf1/q33.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q33.benchmark
 # description: Run query 33 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q34.benchmark
+++ b/benchmark/tpcds/sf1/q34.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q34.benchmark
 # description: Run query 34 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q35.benchmark
+++ b/benchmark/tpcds/sf1/q35.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q35.benchmark
 # description: Run query 35 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q36.benchmark
+++ b/benchmark/tpcds/sf1/q36.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q36.benchmark
 # description: Run query 36 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q37.benchmark
+++ b/benchmark/tpcds/sf1/q37.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q37.benchmark
 # description: Run query 37 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q38.benchmark
+++ b/benchmark/tpcds/sf1/q38.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q38.benchmark
 # description: Run query 38 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q39.benchmark
+++ b/benchmark/tpcds/sf1/q39.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q39.benchmark
 # description: Run query 39 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q40.benchmark
+++ b/benchmark/tpcds/sf1/q40.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q40.benchmark
 # description: Run query 40 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q41.benchmark
+++ b/benchmark/tpcds/sf1/q41.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q41.benchmark
 # description: Run query 41 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q42.benchmark
+++ b/benchmark/tpcds/sf1/q42.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q42.benchmark
 # description: Run query 42 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q43.benchmark
+++ b/benchmark/tpcds/sf1/q43.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q43.benchmark
 # description: Run query 43 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q44.benchmark
+++ b/benchmark/tpcds/sf1/q44.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q44.benchmark
 # description: Run query 44 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q45.benchmark
+++ b/benchmark/tpcds/sf1/q45.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q45.benchmark
 # description: Run query 45 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q46.benchmark
+++ b/benchmark/tpcds/sf1/q46.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q46.benchmark
 # description: Run query 46 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q47.benchmark
+++ b/benchmark/tpcds/sf1/q47.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q47.benchmark
 # description: Run query 47 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q48.benchmark
+++ b/benchmark/tpcds/sf1/q48.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q48.benchmark
 # description: Run query 48 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q49.benchmark
+++ b/benchmark/tpcds/sf1/q49.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q49.benchmark
 # description: Run query 49 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q50.benchmark
+++ b/benchmark/tpcds/sf1/q50.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q50.benchmark
 # description: Run query 50 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q51.benchmark
+++ b/benchmark/tpcds/sf1/q51.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q51.benchmark
 # description: Run query 51 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q52.benchmark
+++ b/benchmark/tpcds/sf1/q52.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q52.benchmark
 # description: Run query 52 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q53.benchmark
+++ b/benchmark/tpcds/sf1/q53.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q53.benchmark
 # description: Run query 53 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q54.benchmark
+++ b/benchmark/tpcds/sf1/q54.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q54.benchmark
 # description: Run query 54 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q55.benchmark
+++ b/benchmark/tpcds/sf1/q55.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q55.benchmark
 # description: Run query 55 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q56.benchmark
+++ b/benchmark/tpcds/sf1/q56.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q56.benchmark
 # description: Run query 56 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q57.benchmark
+++ b/benchmark/tpcds/sf1/q57.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q57.benchmark
 # description: Run query 57 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q58.benchmark
+++ b/benchmark/tpcds/sf1/q58.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q58.benchmark
 # description: Run query 58 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q59.benchmark
+++ b/benchmark/tpcds/sf1/q59.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q59.benchmark
 # description: Run query 59 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q60.benchmark
+++ b/benchmark/tpcds/sf1/q60.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q60.benchmark
 # description: Run query 60 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q61.benchmark
+++ b/benchmark/tpcds/sf1/q61.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q61.benchmark
 # description: Run query 61 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q62.benchmark
+++ b/benchmark/tpcds/sf1/q62.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q62.benchmark
 # description: Run query 62 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q63.benchmark
+++ b/benchmark/tpcds/sf1/q63.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q63.benchmark
 # description: Run query 63 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q64.benchmark
+++ b/benchmark/tpcds/sf1/q64.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q64.benchmark
 # description: Run query 64 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q65.benchmark
+++ b/benchmark/tpcds/sf1/q65.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q65.benchmark
 # description: Run query 65 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q66.benchmark
+++ b/benchmark/tpcds/sf1/q66.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q66.benchmark
 # description: Run query 66 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q67.benchmark
+++ b/benchmark/tpcds/sf1/q67.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q67.benchmark
 # description: Run query 67 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q68.benchmark
+++ b/benchmark/tpcds/sf1/q68.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q68.benchmark
 # description: Run query 68 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q69.benchmark
+++ b/benchmark/tpcds/sf1/q69.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q69.benchmark
 # description: Run query 69 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q70.benchmark
+++ b/benchmark/tpcds/sf1/q70.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q70.benchmark
 # description: Run query 70 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q71.benchmark
+++ b/benchmark/tpcds/sf1/q71.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q71.benchmark
 # description: Run query 71 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q72.benchmark
+++ b/benchmark/tpcds/sf1/q72.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q72.benchmark
 # description: Run query 72 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q73.benchmark
+++ b/benchmark/tpcds/sf1/q73.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q73.benchmark
 # description: Run query 73 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q74.benchmark
+++ b/benchmark/tpcds/sf1/q74.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q74.benchmark
 # description: Run query 74 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q75.benchmark
+++ b/benchmark/tpcds/sf1/q75.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q75.benchmark
 # description: Run query 75 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q76.benchmark
+++ b/benchmark/tpcds/sf1/q76.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q76.benchmark
 # description: Run query 76 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q77.benchmark
+++ b/benchmark/tpcds/sf1/q77.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q77.benchmark
 # description: Run query 77 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q78.benchmark
+++ b/benchmark/tpcds/sf1/q78.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q78.benchmark
 # description: Run query 78 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q79.benchmark
+++ b/benchmark/tpcds/sf1/q79.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q79.benchmark
 # description: Run query 79 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q80.benchmark
+++ b/benchmark/tpcds/sf1/q80.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q80.benchmark
 # description: Run query 80 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q81.benchmark
+++ b/benchmark/tpcds/sf1/q81.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q81.benchmark
 # description: Run query 81 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q82.benchmark
+++ b/benchmark/tpcds/sf1/q82.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q82.benchmark
 # description: Run query 82 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q83.benchmark
+++ b/benchmark/tpcds/sf1/q83.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q83.benchmark
 # description: Run query 83 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q84.benchmark
+++ b/benchmark/tpcds/sf1/q84.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q84.benchmark
 # description: Run query 84 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q85.benchmark
+++ b/benchmark/tpcds/sf1/q85.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q85.benchmark
 # description: Run query 85 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q86.benchmark
+++ b/benchmark/tpcds/sf1/q86.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q86.benchmark
 # description: Run query 86 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q87.benchmark
+++ b/benchmark/tpcds/sf1/q87.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q87.benchmark
 # description: Run query 87 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q88.benchmark
+++ b/benchmark/tpcds/sf1/q88.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q88.benchmark
 # description: Run query 88 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q89.benchmark
+++ b/benchmark/tpcds/sf1/q89.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q89.benchmark
 # description: Run query 89 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q90.benchmark
+++ b/benchmark/tpcds/sf1/q90.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q90.benchmark
 # description: Run query 90 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q91.benchmark
+++ b/benchmark/tpcds/sf1/q91.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q91.benchmark
 # description: Run query 91 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q92.benchmark
+++ b/benchmark/tpcds/sf1/q92.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q92.benchmark
 # description: Run query 92 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q93.benchmark
+++ b/benchmark/tpcds/sf1/q93.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q93.benchmark
 # description: Run query 93 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q94.benchmark
+++ b/benchmark/tpcds/sf1/q94.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q94.benchmark
 # description: Run query 94 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q95.benchmark
+++ b/benchmark/tpcds/sf1/q95.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q95.benchmark
 # description: Run query 95 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q96.benchmark
+++ b/benchmark/tpcds/sf1/q96.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q96.benchmark
 # description: Run query 96 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q97.benchmark
+++ b/benchmark/tpcds/sf1/q97.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q97.benchmark
 # description: Run query 97 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q98.benchmark
+++ b/benchmark/tpcds/sf1/q98.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q98.benchmark
 # description: Run query 98 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpcds/sf1/q99.benchmark
+++ b/benchmark/tpcds/sf1/q99.benchmark
@@ -1,5 +1,4 @@
-
-# name: benchmark/tpcds/sf1/qpadded.benchmark
+# name: benchmark/tpcds/sf1/q99.benchmark
 # description: Run query 99 from the TPC-DS benchmark
 # group: [sf1]
 

--- a/benchmark/tpch/csv/read_lineitem_csv_unicode.benchmark
+++ b/benchmark/tpch/csv/read_lineitem_csv_unicode.benchmark
@@ -1,4 +1,4 @@
-# name: benchmark/tpch/csv/read_lineitem_csv.benchmark
+# name: benchmark/tpch/csv/read_lineitem_csv_unicode.benchmark
 # description: Read the lineitem of TPC-H SF0.1 from a CSV file with a unicode delimiter
 # group: [csv]
 

--- a/benchmark/tpch/expression_reordering/adaptive_mixed_reordering_and.benchmark
+++ b/benchmark/tpch/expression_reordering/adaptive_mixed_reordering_and.benchmark
@@ -1,4 +1,4 @@
-# name: benchmark/tpch/expression_reordering/adaptive_numeric_reordering_or.benchmark
+# name: benchmark/tpch/expression_reordering/adaptive_mixed_reordering_and.benchmark
 # description: Re-order mixed comparisons adaptively
 # group: [expression_reordering]
 

--- a/benchmark/tpch/expression_reordering/adaptive_mixed_reordering_or.benchmark
+++ b/benchmark/tpch/expression_reordering/adaptive_mixed_reordering_or.benchmark
@@ -1,4 +1,4 @@
-# name: benchmark/tpch/expression_reordering/adaptive_numeric_reordering_or.benchmark
+# name: benchmark/tpch/expression_reordering/adaptive_mixed_reordering_or.benchmark
 # description: Re-order mixed comparisons adaptively
 # group: [expression_reordering]
 

--- a/benchmark/tpch/expression_reordering/adaptive_numeric_reordering_or.benchmark
+++ b/benchmark/tpch/expression_reordering/adaptive_numeric_reordering_or.benchmark
@@ -1,4 +1,4 @@
-# name: benchmark/tpch/expression_reordering/adaptive_numeric_reordering_and.benchmark
+# name: benchmark/tpch/expression_reordering/adaptive_numeric_reordering_or.benchmark
 # description: Re-order numeric comparisons adaptively
 # group: [expression_reordering]
 

--- a/benchmark/tpch/topn/lineitem_date_topn_large_payload.benchmark
+++ b/benchmark/tpch/topn/lineitem_date_topn_large_payload.benchmark
@@ -1,4 +1,4 @@
-# name: benchmark/tpch/topn/lineitem_topn.benchmark
+# name: benchmark/tpch/topn/lineitem_date_topn_large_payload.benchmark
 # description: Top-N over lineitem (over a single date)
 # group: [topn]
 

--- a/benchmark/tpch/topn/lineitem_date_topn_small_payload.benchmark
+++ b/benchmark/tpch/topn/lineitem_date_topn_small_payload.benchmark
@@ -1,4 +1,4 @@
-# name: benchmark/tpch/topn/lineitem_topn.benchmark
+# name: benchmark/tpch/topn/lineitem_date_topn_small_payload.benchmark
 # description: Top-N over lineitem (over a single date)
 # group: [topn]
 

--- a/benchmark/tpch/union/q01_union.benchmark
+++ b/benchmark/tpch/union/q01_union.benchmark
@@ -1,4 +1,4 @@
-# name: benchmark/tpch/union/union_into_aggregate.benchmark
+# name: benchmark/tpch/union/q01_union.benchmark
 # description: Union of separate tables into a single aggregate
 # group: [union]
 

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -189,27 +189,27 @@ def get_formatted_text(f, full_path, directory, ext):
         new_path_line = '# name: ' + full_path + '\n'
         new_group_line =  '# group: [' + group_name + ']' + '\n'
         found_diff = False
-        for i in range(0, len(lines)):
-            line = lines[i]
-            if line.startswith('# name: ') or line.startswith('#name: '):
-                if found_name:
-                    print("Error formatting file " + full_path + ", multiple lines starting with # name found")
+        # Find description.
+        found_description = False
+        for line in lines:
+            if line.lower().startswith('# description:') or line.lower().startswith('#description:'):
+                if found_description:
+                    print("Error formatting file " + full_path + ", multiple lines starting with # description found")
                     exit(1)
-                found_name = True
-                if lines[i] != new_path_line:
-                    lines[i] = new_path_line
-            if line.startswith('# group: ') or line.startswith('#group: '):
-                if found_group:
-                    print("Error formatting file " + full_path + ", multiple lines starting with # group found")
-                    exit(1)
-                found_group = True
-                if lines[i] != new_group_line:
-                    lines[i] = new_group_line
-        if not found_group:
-            lines = [new_group_line] + lines
-        if not found_name:
-            lines = [new_path_line] + lines
-        return ''.join(lines)
+                found_description = True
+                new_description_line = '# description: ' + line.split(':', 1)[1].strip() + '\n'
+        # Filter old meta.
+        meta = ['#name:', '# name:', '#description:', '# description:', '#group:', '# group:']
+        lines = [line for line in lines if not any(line.lower().startswith(m) for m in meta)]
+        # Clean up empty leading lines.
+        while lines and not lines[0].strip():
+            lines.pop(0)
+        # Ensure header is prepended.
+        header = [new_path_line]
+        if found_description: header.append(new_description_line)
+        header.append(new_group_line)
+        header.append('\n')
+        return ''.join(header + lines)
     proc_command = format_commands[ext].split(' ') + [full_path]
     proc = subprocess.Popen(proc_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     new_text = proc.stdout.read().decode('utf8')

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -12,7 +12,7 @@ from python_helpers import open_utf8
 
 cpp_format_command = 'clang-format --sort-includes=0 -style=file'
 cmake_format_command = 'cmake-format'
-extensions = ['.cpp', '.c', '.hpp', '.h', '.cc', '.hh', 'CMakeLists.txt', '.test', '.test_slow', '.test_coverage']
+extensions = ['.cpp', '.c', '.hpp', '.h', '.cc', '.hh', 'CMakeLists.txt', '.test', '.test_slow', '.test_coverage', '.benchmark']
 formatted_directories = ['src', 'benchmark', 'test', 'tools', 'examples', 'extension']
 ignored_files = ['tpch_constants.hpp', 'tpcds_constants.hpp', '_generated', 'tpce_flat_input.hpp',
                  'test_csv_header.hpp', 'duckdb.cpp', 'duckdb.hpp', 'json.hpp', 'sqlite3.h', 'shell.c',
@@ -178,7 +178,7 @@ def get_formatted_text(f, full_path, directory, ext):
             if not is_old_header:
                 text += line
 
-    if ext == '.test' or ext == '.test_slow' or ext == '.test_coverage':
+    if ext == '.test' or ext == '.test_slow' or ext == '.test_coverage' or ext == '.benchmark':
         f = open_utf8(full_path, 'r')
         lines = f.readlines()
         f.close()

--- a/test/sql/aggregate/aggregates/test_last.test
+++ b/test/sql/aggregate/aggregates/test_last.test
@@ -1,7 +1,6 @@
-# group: [aggregates]
 # name: test/sql/aggregate/aggregates/test_last.test
 # description: Test the LAST function
-# GROUP: [aggregates]
+# group: [aggregates]
 
 statement ok
 PRAGMA enable_verification

--- a/test/sql/catalog/did_you_mean.test
+++ b/test/sql/catalog/did_you_mean.test
@@ -1,6 +1,7 @@
 # name: test/sql/catalog/did_you_mean.test
-# Description: The error messages suggest possible alternative
+# description: The error messages suggest possible alternative
 # group: [catalog]
+
 require test_helper
 
 statement ok

--- a/test/sql/copy/csv/tsv_copy.test
+++ b/test/sql/copy/csv/tsv_copy.test
@@ -2,7 +2,6 @@
 # description: Test TSV Copy round-trip
 # group: [csv]
 
-
 statement ok
 CREATE TABLE people(id INTEGER, name VARCHAR);
 

--- a/test/sql/fts/test_indexing.test_slow
+++ b/test/sql/fts/test_indexing.test_slow
@@ -1,5 +1,5 @@
 # name: test/sql/fts/test_indexing.test_slow
-# DESCription: Full text search indexing
+# description: Full text search indexing
 # group: [fts]
 
 require fts

--- a/test/sql/fts/test_indexing_and_schema.test
+++ b/test/sql/fts/test_indexing_and_schema.test
@@ -1,5 +1,5 @@
 # name: test/sql/fts/test_indexing_and_schema.test
-# Description: Refer default schema when the table name doesn't have a qualifier.
+# description: Refer default schema when the table name doesn't have a qualifier.
 # group: [fts]
 
 require fts

--- a/test/sql/function/numeric/test_factorial.test
+++ b/test/sql/function/numeric/test_factorial.test
@@ -2,7 +2,6 @@
 # description: Mod test
 # group: [numeric]
 
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/function/string/test_ascii.test
+++ b/test/sql/function/string/test_ascii.test
@@ -1,5 +1,5 @@
 # name: test/sql/function/string/test_ascii.test
-# description:  test ascii() and chr() functions
+# description: test ascii() and chr() functions
 # group: [string]
 
 #statement ok

--- a/test/sql/function/string/test_concat.test
+++ b/test/sql/function/string/test_concat.test
@@ -2,7 +2,6 @@
 # description: Test concat function
 # group: [string]
 
-
 # Test Case disclaimer
 
 # Assertions built using the Domain Testing technique

--- a/test/sql/index/art/test_art_join.test_slow
+++ b/test/sql/index/art/test_art_join.test_slow
@@ -2,7 +2,6 @@
 # description: Test Joins using art indexes
 # group: [art]
 
-
 statement ok
 PRAGMA explain_output = PHYSICAL_ONLY;
 PRAGMA force_index_join

--- a/test/sql/storage/test_large_interleaved_transactions.test_slow
+++ b/test/sql/storage/test_large_interleaved_transactions.test_slow
@@ -2,7 +2,6 @@
 # description: Test large interleaved transactions
 # group: [storage]
 
-
 # this is a temporary restriction: we currently do not allow committing commits when deletes/updates have been made to the non-committed data
 # this is because with interleaved transactions we get incorrect row ids in the deletes/updates in the WAL which leads to errors on reload
 # for this reason this test is currently skipped

--- a/test/sql/storage_version/storage_version.test_slow
+++ b/test/sql/storage_version/storage_version.test_slow
@@ -1,10 +1,11 @@
 # name: test/sql/storage_version/storage_version.test_slow
 # description: Storage version test checks whether or not the storage version needs to be incremented.
+# group: [storage_version]
+
 # If this test fails, re-generate the database file by following the steps listed below:
 # 1) Increment the version number in src/storage/storage_info.cpp and recompile (make debug)
 # 2) Run the script in scripts/generate_storage_version.py,
 # 3) Commit the newly generated database file in test/sql/storage_version/storage_version.db
-# group: [storage_version]
 
 statement ok
 PRAGMA enable_verification

--- a/test/sql/types/nested/nested_nested_types.test
+++ b/test/sql/types/nested/nested_nested_types.test
@@ -2,7 +2,6 @@
 # description: Test Nested Types Nested on other Nested types
 # group: [nested]
 
-
 query T
 SELECT [{'i':1,'j':[2,3]},NULL]
 ----

--- a/test/sql/visualizer/visualizer_tpch_sf001.test_slow
+++ b/test/sql/visualizer/visualizer_tpch_sf001.test_slow
@@ -2,7 +2,6 @@
 # description: Test Visualizer for TPC-H SF0.1
 # group: [visualizer]
 
-
 require visualizer
 
 require tpch

--- a/test/sqlite/select1.test
+++ b/test/sqlite/select1.test
@@ -1,5 +1,6 @@
 # name: test/sqlite/select1.test
 # group: [sqlite]
+
 statement ok
 CREATE TABLE t1(a INTEGER, b INTEGER, c INTEGER, d INTEGER, e INTEGER)
 

--- a/test/sqlite/select2.test
+++ b/test/sqlite/select2.test
@@ -1,5 +1,6 @@
 # name: test/sqlite/select2.test
 # group: [sqlite]
+
 hash-threshold 8
 
 statement ok

--- a/test/sqlite/select3.test_slow
+++ b/test/sqlite/select3.test_slow
@@ -1,5 +1,6 @@
 # name: test/sqlite/select3.test_slow
 # group: [sqlite]
+
 hash-threshold 8
 
 statement ok

--- a/test/sqlite/select4.test_slow
+++ b/test/sqlite/select4.test_slow
@@ -1,5 +1,6 @@
 # name: test/sqlite/select4.test_slow
 # group: [sqlite]
+
 statement ok
 CREATE TABLE t1(
   a1 INTEGER,


### PR DESCRIPTION
The `format.py` did not ensure consistency on filenames/groups for benchmarks. I fixed that, and made sure capitalization/whitespace is consistent such that the first three lines of every benchmark/test consist of name, description (if any), group, in that order, followed by a single blank line.