### PR TITLE
Python 3.10 builds

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         arch: [auto, aarch64]
-        python_build: [cp37-*, cp38-*,cp39-*]
+        python_build: [cp37-*, cp38-*,cp39-*,cp310-*]
     needs: linux-python3-9
     env:
       CIBW_BUILD: ${{ matrix.python_build}}
@@ -109,7 +109,7 @@ jobs:
       runs-on: macos-latest
       strategy:
        matrix:
-        python_build: [cp36-*, cp37-*, cp38-*, cp39-*]
+        python_build: [cp36-*, cp37-*, cp38-*, cp39-*, cp310-*]
       needs: linux-python3-9
       env:
         CIBW_BUILD: ${{ matrix.python_build}}
@@ -151,7 +151,7 @@ jobs:
       runs-on: windows-latest
       strategy:
        matrix:
-        python_build: [cp36-*, cp37-*, cp38-*, cp39-*]
+        python_build: [cp36-*, cp37-*, cp38-*, cp39-*, cp310-*]
       needs: linux-python3-9
 
       env:

--- a/tools/pythonpkg/src/array_wrapper.cpp
+++ b/tools/pythonpkg/src/array_wrapper.cpp
@@ -492,7 +492,7 @@ void RawArrayWrapper::Initialize(idx_t capacity) {
 }
 
 void RawArrayWrapper::Resize(idx_t new_capacity) {
-	vector<ssize_t> new_shape {ssize_t(new_capacity)};
+	vector<py::ssize_t> new_shape {py::ssize_t(new_capacity)};
 	array.resize(new_shape, false);
 	data = (data_ptr_t)array.mutable_data();
 }


### PR DESCRIPTION
Supersedes #2379

Seems to work now as the NumPy issues have been resolved.