### PR TITLE
Reduce memory footprint of Python/R compilation by default by disabling unity builds unless DUCKDB_BUILD_UNITY flag is enabled

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -65,6 +65,7 @@ jobs:
       SETUPTOOLS_SCM_NO_LOCAL: 'yes'
       TWINE_USERNAME: 'hfmuehleisen'
       PYTEST_TIMEOUT: '600'
+      DUCKDB_BUILD_UNITY: 1
 
     steps:
     - uses: actions/checkout@v2
@@ -120,6 +121,7 @@ jobs:
         CIBW_ARCHS_MACOS: 'x86_64 universal2 arm64'
         SETUPTOOLS_SCM_NO_LOCAL: 'yes'
         TWINE_USERNAME: 'hfmuehleisen'
+        DUCKDB_BUILD_UNITY: 1
 
       steps:
       - uses: actions/checkout@v2
@@ -162,6 +164,7 @@ jobs:
         CIBW_TEST_COMMAND: 'python -m pytest {project}/tests/fast'
         SETUPTOOLS_SCM_NO_LOCAL: 'yes'
         TWINE_USERNAME: 'hfmuehleisen'
+        DUCKDB_BUILD_UNITY: 1
 
       steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -19,6 +19,7 @@ jobs:
 
     env:
       LIBARROW_BINARY : 'true'
+      DUCKDB_BUILD_UNITY: 1
 
     steps:
     - uses: actions/checkout@v2
@@ -78,6 +79,9 @@ jobs:
       runs-on: windows-latest
       needs: rstats-linux
 
+      env:
+        DUCKDB_BUILD_UNITY: 1
+
       steps:
       - uses: actions/checkout@v2
         with:
@@ -105,13 +109,11 @@ jobs:
           R CMD check --as-cran --no-manual -o /tmp duckdb_*.tar.gz
           if grep WARNING /tmp/duckdb.Rcheck/00check.log ; then exit 1; fi
 
-
-
-
    rubsan:
       name: R UBSAN
       runs-on: ubuntu-latest
       needs: rstats-linux
+
       steps:
       - uses: actions/checkout@v2
         with:

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -113,7 +113,7 @@ def include_package(pkg_name, pkg_dir, include_files, include_list, source_list)
 
     sys.path = original_path
 
-def build_package(target_dir, extensions, linenumbers = False):
+def build_package(target_dir, extensions, linenumbers = False, unity_count = 32):
     if not os.path.isdir(target_dir):
         os.mkdir(target_dir)
 
@@ -225,7 +225,10 @@ def build_package(target_dir, extensions, linenumbers = False):
         return new_source_files
 
     original_sources = source_list
-    source_list = generate_unity_builds(source_list, 8, linenumbers)
+    if unity_count > 0:
+        source_list = generate_unity_builds(source_list, unity_count, linenumbers)
+    else:
+        source_list = [os.path.join('duckdb', source) for source in source_list]
 
     os.chdir(prev_wd)
     return ([convert_backslashes(x) for x in source_list if not file_is_excluded(x)],

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -15,6 +15,9 @@ extensions = ['parquet', 'icu', 'fts', 'tpch', 'tpcds', 'visualizer']
 if platform.system() == 'Windows':
     extensions = ['parquet', 'icu', 'fts','tpch']
 
+unity_build = 0
+if 'DUCKDB_BUILD_UNITY' in os.environ:
+    unity_build = 16
 
 def parallel_cpp_compile(self, sources, output_dir=None, macros=None, include_dirs=None, debug=0,
                          extra_preargs=None, extra_postargs=None, depends=None):
@@ -39,7 +42,6 @@ def parallel_cpp_compile(self, sources, output_dir=None, macros=None, include_di
 if os.name != 'nt':
     import distutils.ccompiler
     distutils.ccompiler.CCompiler.compile = parallel_cpp_compile
-
 
 def open_utf8(fpath, flags):
     import sys
@@ -125,7 +127,7 @@ if len(existing_duckdb_dir) == 0:
         sys.path.append(os.path.join(script_path, '..', '..', 'scripts'))
         import package_build
 
-        (source_list, include_list, original_sources) = package_build.build_package(os.path.join(script_path, 'duckdb'), extensions)
+        (source_list, include_list, original_sources) = package_build.build_package(os.path.join(script_path, 'duckdb'), extensions, False, unity_build)
 
         duckdb_sources = [os.path.sep.join(package_build.get_relative_path(script_path, x).split('/')) for x in source_list]
         duckdb_sources.sort()

--- a/tools/rpkg/rconfigure.py
+++ b/tools/rpkg/rconfigure.py
@@ -10,6 +10,10 @@ extensions = ['parquet']
 if 'DUCKDB_R_EXTENSIONS' in os.environ:
     extensions = extensions + os.environ['DUCKDB_R_EXTENSIONS'].split(",")
 
+unity_build = 0
+if 'DUCKDB_BUILD_UNITY' in os.environ:
+    unity_build = 16
+
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', 'scripts'))
 import package_build
 
@@ -74,7 +78,7 @@ target_dir = os.path.join(os.getcwd(), 'src', 'duckdb')
 
 linenr = bool(os.getenv("DUCKDB_R_LINENR", ""))
 
-(source_list, include_list, original_sources) = package_build.build_package(target_dir, extensions, linenr)
+(source_list, include_list, original_sources) = package_build.build_package(target_dir, extensions, linenr, unity_build)
 
 # object list, relative paths
 script_path = os.path.dirname(os.path.abspath(__file__)).replace('\\','/')


### PR DESCRIPTION
Fixes #2688