### PR TITLE
Use templated memcpy/memcmp more

### DIFF
--- a/src/common/sort/comparators.cpp
+++ b/src/common/sort/comparators.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/sort/comparators.hpp"
 
+#include "duckdb/common/fast_mem.hpp"
 #include "duckdb/common/sort/sort.hpp"
 
 namespace duckdb {
@@ -32,7 +33,7 @@ int Comparators::CompareTuple(const SortedBlock &left, const SortedBlock &right,
 	data_ptr_t l_ptr_offset = l_ptr;
 	data_ptr_t r_ptr_offset = r_ptr;
 	for (idx_t col_idx = 0; col_idx < sort_layout.column_count; col_idx++) {
-		comp_res = memcmp(l_ptr_offset, r_ptr_offset, sort_layout.column_sizes[col_idx]);
+		comp_res = FastMemcmp(l_ptr_offset, r_ptr_offset, sort_layout.column_sizes[col_idx]);
 		if (comp_res == 0 && !sort_layout.constant_size[col_idx]) {
 			comp_res =
 			    BreakBlobTie(col_idx, *left.blob_sorting_data, *right.blob_sorting_data, sort_layout, external_sort);

--- a/src/common/sort/sort_state.cpp
+++ b/src/common/sort/sort_state.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/fast_mem.hpp"
 #include "duckdb/common/row_operations/row_operations.hpp"
 #include "duckdb/common/sort/sort.hpp"
 #include "duckdb/common/sort/sorted_block.hpp"
@@ -261,7 +262,7 @@ void LocalSortState::ReOrder(SortedData &sd, data_ptr_t sorting_ptr, RowDataColl
 	const idx_t sorting_entry_size = gstate.sort_layout.entry_size;
 	for (idx_t i = 0; i < count; i++) {
 		auto index = Load<uint32_t>(sorting_ptr);
-		memcpy(ordered_data_ptr, unordered_data_ptr + index * row_width, row_width);
+		FastMemcpy(ordered_data_ptr, unordered_data_ptr + index * row_width, row_width);
 		ordered_data_ptr += row_width;
 		sorting_ptr += sorting_entry_size;
 	}


### PR DESCRIPTION
Forgot to replace `memcpy` with `FastMemcpy` in reordering last time, and forgot to replace `memcpy` with `FastMemcmp` in `comparators.cpp`

Minor speedup mostly noticeable in the single threaded sort, which spends more time reordering the payload. From ~3.95s to ~3.55s for 100M random ints with 1 thread now