### PR TITLE
Correctly handle synchronous I/O being returned from Windows API

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -514,25 +514,37 @@ idx_t LocalFileSystem::GetFilePointer(FileHandle &handle) {
 	return ((WindowsFileHandle &)handle).position;
 }
 
-void LocalFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
-	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
+static DWORD FSInternalRead(FileHandle &handle, HANDLE hFile, void *buffer, int64_t nr_bytes, idx_t location) {
 	DWORD bytes_read = 0;
+	bool overlapped_read = false;
 	OVERLAPPED ov = {};
 	ov.Internal = 0;
 	ov.InternalHigh = 0;
 	ov.Offset = location & 0xFFFFFFFF;
 	ov.OffsetHigh = location >> 32;
 	ov.hEvent = 0;
-	auto rc = ReadFile(hFile, buffer, (DWORD)nr_bytes, NULL, &ov);
+	auto rc = ReadFile(hFile, buffer, (DWORD)nr_bytes, &bytes_read, &ov);
 	if (rc == 0) {
-		auto error = GetLastErrorAsString();
-		throw IOException("Could not read file \"%s\" (error in ReadFile): %s", handle.path, error);
+		if (GetLastError() != ERROR_IO_PENDING) {
+			auto error = GetLastErrorAsString();
+			throw IOException("Could not read file \"%s\" (error in ReadFile): %s", handle.path, error);
+		} else {
+			overlapped_read = true;
+		}
 	}
-	rc = GetOverlappedResult(hFile, &ov, &bytes_read, true);
-	if (rc == 0) {
-		auto error = GetLastErrorAsString();
-		throw IOException("Could not read file \"%s\" (error in GetOverlappedResult): %s", handle.path, error);
+	if (overlapped_read) {
+		rc = GetOverlappedResult(hFile, &ov, &bytes_read, true);
+		if (rc == 0) {
+			auto error = GetLastErrorAsString();
+			throw IOException("Could not read file \"%s\" (error in GetOverlappedResult): %s", handle.path, error);
+		}
 	}
+	return bytes_read;
+}
+
+void LocalFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
+	auto bytes_read = FSInternalRead(handle, hFile, buffer, nr_bytes, location);
 	if (bytes_read != nr_bytes) {
 		throw IOException("Could not read all bytes from file \"%s\": wanted=%lld read=%lld", handle.path, nr_bytes,
 		                  bytes_read);
@@ -541,48 +553,45 @@ void LocalFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, i
 
 int64_t LocalFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
 	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
-	DWORD bytes_read;
 	auto &pos = ((WindowsFileHandle &)handle).position;
-	OVERLAPPED ov = {};
-	ov.Internal = 0;
-	ov.InternalHigh = 0;
-	ov.Offset = pos & 0xFFFFFFFF;
-	ov.OffsetHigh = pos >> 32;
-	ov.hEvent = 0;
 	auto n = std::min<idx_t>(std::max<idx_t>(GetFileSize(handle), pos) - pos, nr_bytes);
-	auto rc = ReadFile(hFile, buffer, (DWORD)n, NULL, &ov);
-	if (rc == 0) {
-		auto error = GetLastErrorAsString();
-		throw IOException("Could not read file \"%s\" (error in ReadFile): %s", handle.path, error);
-	}
-	rc = GetOverlappedResult(hFile, &ov, &bytes_read, true);
-	if (rc == 0) {
-		auto error = GetLastErrorAsString();
-		throw IOException("Could not read file \"%s\" (error in GetOverlappedResult): %s", handle.path, error);
-	}
+	auto bytes_read = FSInternalRead(handle, hFile, buffer, n, pos);
 	pos += bytes_read;
 	return bytes_read;
 }
 
-void LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
-	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
-	DWORD bytes_written;
+
+static DWORD FSInternalWrite(FileHandle &handle, HANDLE hFile, void *buffer, int64_t nr_bytes, idx_t location) {
+	DWORD bytes_written = 0;
+	bool overlapped_write = false;
 	OVERLAPPED ov = {};
 	ov.Internal = 0;
 	ov.InternalHigh = 0;
 	ov.Offset = location & 0xFFFFFFFF;
 	ov.OffsetHigh = location >> 32;
 	ov.hEvent = 0;
-	auto rc = WriteFile(hFile, buffer, (DWORD)nr_bytes, NULL, &ov);
+	auto rc = WriteFile(hFile, buffer, (DWORD)nr_bytes, &bytes_written, &ov);
 	if (rc == 0) {
-		auto error = GetLastErrorAsString();
-		throw IOException("Could not write file \"%s\" (error in WriteFile): %s", handle.path, error);
+		if (GetLastError() != ERROR_IO_PENDING) {
+			auto error = GetLastErrorAsString();
+			throw IOException("Could not write file \"%s\" (error in WriteFile): %s", handle.path, error);
+		} else {
+			overlapped_write = true;
+		}
 	}
-	rc = GetOverlappedResult(hFile, &ov, &bytes_written, true);
-	if (rc == 0) {
-		auto error = GetLastErrorAsString();
-		throw IOException("Could not write file \"%s\" (error in GetOverlappedResult): %s", handle.path, error);
+	if (overlapped_write) {
+		rc = GetOverlappedResult(hFile, &ov, &bytes_written, true);
+		if (rc == 0) {
+			auto error = GetLastErrorAsString();
+			throw IOException("Could not write file \"%s\" (error in GetOverlappedResult): %s", handle.path, error);
+		}
 	}
+	return bytes_written;
+}
+
+void LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
+	auto bytes_written = FSInternalWrite(handle, hFile, buffer, nr_bytes, location);
 	if (bytes_written != nr_bytes) {
 		throw IOException("Could not write all bytes from file \"%s\": wanted=%lld wrote=%lld", handle.path, nr_bytes,
 		                  bytes_written);
@@ -591,24 +600,8 @@ void LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, 
 
 int64_t LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
 	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
-	DWORD bytes_written;
 	auto &pos = ((WindowsFileHandle &)handle).position;
-	OVERLAPPED ov = {};
-	ov.Internal = 0;
-	ov.InternalHigh = 0;
-	ov.Offset = pos & 0xFFFFFFFF;
-	ov.OffsetHigh = pos >> 32;
-	ov.hEvent = 0;
-	auto rc = WriteFile(hFile, buffer, (DWORD)nr_bytes, NULL, &ov);
-	if (rc == 0) {
-		auto error = GetLastErrorAsString();
-		throw IOException("Could not write file \"%s\" (error in WriteFile): %s", handle.path, error);
-	}
-	rc = GetOverlappedResult(hFile, &ov, &bytes_written, true);
-	if (rc == 0) {
-		auto error = GetLastErrorAsString();
-		throw IOException("Could not write file \"%s\": %s", handle.path, error);
-	}
+	auto bytes_written = FSInternalWrite(handle, hFile, buffer, nr_bytes, pos);
 	pos += bytes_written;
 	return bytes_written;
 }

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -560,7 +560,6 @@ int64_t LocalFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes
 	return bytes_read;
 }
 
-
 static DWORD FSInternalWrite(FileHandle &handle, HANDLE hFile, void *buffer, int64_t nr_bytes, idx_t location) {
 	DWORD bytes_written = 0;
 	bool overlapped_write = false;


### PR DESCRIPTION
(Hopefully) Fixes #2668, #2661, #2344

This PR fixes an issue that caused the `bytes_read`/`bytes_written` returned from the Windows API calls `ReadFile`/`WriteFile` to be incorrectly set.

The problem was that the ReadFile and WriteFile system calls may switch between doing asynchronous and synchronous I/O. This would not be a problem, except that the interface for doing the I/O changes when this happens. When synchronous I/O happens, the number of bytes are written to the variable passed to the `ReadFile` function. When asynchronous I/O happens, the number of bytes are written to the overlapped result and can be fetched using `GetOverlappedResult`. Previously, we would only use the `GetOverlappedResult` function.

This behavior is hidden away in the manual [here](https://docs.microsoft.com/en-US/troubleshoot/windows/win32/asynchronous-disk-io-synchronous#set-up-asynchronous-io).


    
> Be careful when you code for asynchronous I/O because the system reserves the right to make an operation synchronous if it needs to. So it is best if you write the program to correctly handle an I/O operation that may be completed either synchronously or asynchronously. The sample code demonstrates this consideration.

```cpp
if (!ReadFile(hFile,
               pDataBuf,
               dwSizeOfBuffer,
               &NumberOfBytesRead,
               &osReadOperation )
{
   if (GetLastError() != ERROR_IO_PENDING)
   {
      // Some other error occurred while reading the file.
      ErrorReadingFile();
      ExitProcess(0);
   }
   else
      // Operation has been queued and
      // will complete in the future.
      fOverlapped = TRUE;
}
else
   // Operation has completed immediately.
   fOverlapped = FALSE;

if (fOverlapped)
{
   // Wait for the operation to complete before continuing.
   // You could do some background work if you wanted to.
   if (GetOverlappedResult( hFile,
                           &osReadOperation,
                           &NumberOfBytesTransferred,
                           TRUE))
      ReadHasCompleted(NumberOfBytesTransferred);
   else
      // Operation has completed, but it failed.
      ErrorReadingFile();
}
else
   ReadHasCompleted(NumberOfBytesRead);
```

So the way to detect this scenario is to inspect the error returned from `ReadFile`. If the error returned is `ERROR_IO_PENDING`, the error is not actually an error but a status indicator that indicates asynchronous I/O is taking place and `GetOverlappedResult` should be called. Otherwise, synchronous I/O happens and `GetOverlappedResult` should not be called.

The reason this error is hard to trigger is that the old code mostly worked, until Windows randomly decided to switch to synchronous I/O. My theory here is that there is a limit on the number of asynchronous I/O operations that can happen at once, meaning that once multi-threading is enabled and sufficient reads happen at the same time, the system will switch to synchronous I/O for some requests, which causes this error to spuriously happen.