### PR TITLE
Fix #2678: Fix undefined behavior for sequences close to INT64 min/INT64 max

### DIFF
--- a/src/function/scalar/sequence/nextval.cpp
+++ b/src/function/scalar/sequence/nextval.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/transaction/transaction.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
+#include "duckdb/common/operator/add.hpp"
 
 namespace duckdb {
 
@@ -42,9 +43,12 @@ struct NextSequenceValueOperator {
 	static int64_t Operation(Transaction &transaction, SequenceCatalogEntry *seq) {
 		lock_guard<mutex> seqlock(seq->lock);
 		int64_t result;
+		result = seq->counter;
+		bool overflow = TryAddOperator::Operation(seq->counter, seq->increment, seq->counter);
 		if (seq->cycle) {
-			result = seq->counter;
-			seq->counter += seq->increment;
+			if (overflow) {
+				throw SequenceException("overflow in sequence");
+			}
 			if (result < seq->min_value) {
 				result = seq->max_value;
 				seq->counter = seq->max_value + seq->increment;
@@ -53,13 +57,11 @@ struct NextSequenceValueOperator {
 				seq->counter = seq->min_value + seq->increment;
 			}
 		} else {
-			result = seq->counter;
-			seq->counter += seq->increment;
-			if (result < seq->min_value) {
+			if (result < seq->min_value || (overflow && seq->increment < 0)) {
 				throw SequenceException("nextval: reached minimum value of sequence \"%s\" (%lld)", seq->name,
 				                        seq->min_value);
 			}
-			if (result > seq->max_value) {
+			if (result > seq->max_value || overflow) {
 				throw SequenceException("nextval: reached maximum value of sequence \"%s\" (%lld)", seq->name,
 				                        seq->max_value);
 			}

--- a/src/function/scalar/sequence/nextval.cpp
+++ b/src/function/scalar/sequence/nextval.cpp
@@ -44,7 +44,7 @@ struct NextSequenceValueOperator {
 		lock_guard<mutex> seqlock(seq->lock);
 		int64_t result;
 		result = seq->counter;
-		bool overflow = TryAddOperator::Operation(seq->counter, seq->increment, seq->counter);
+		bool overflow = !TryAddOperator::Operation(seq->counter, seq->increment, seq->counter);
 		if (seq->cycle) {
 			if (overflow) {
 				throw SequenceException("overflow in sequence");

--- a/test/sql/catalog/sequence/sequence_overflow.test
+++ b/test/sql/catalog/sequence/sequence_overflow.test
@@ -1,0 +1,27 @@
+# name: test/sql/catalog/sequence/sequence_overflow.test
+# description: Issue #2678: overflow in sequences
+# group: [sequence]
+
+statement ok
+create sequence seq1 INCREMENT BY 1 MINVALUE 9223372036854775800 MAXVALUE 9223372036854775807 CYCLE;
+
+statement error
+SELECT nextval('seq1') from generate_series(0,20);
+
+statement ok
+create sequence seq2 INCREMENT BY -1 MINVALUE -9223372036854775808 MAXVALUE -9223372036854775800 CYCLE;
+
+statement error
+SELECT nextval('seq2') from generate_series(0,20);
+
+statement ok
+create sequence seq3 INCREMENT BY 1 MINVALUE 9223372036854775800 MAXVALUE 9223372036854775807;
+
+statement error
+SELECT nextval('seq3') from generate_series(0,20);
+
+statement ok
+create sequence seq4 INCREMENT BY -1 MINVALUE -9223372036854775808 MAXVALUE -9223372036854775800;
+
+statement error
+SELECT nextval('seq4') from generate_series(0,20);

--- a/test/sql/catalog/sequence/sequence_overflow.test
+++ b/test/sql/catalog/sequence/sequence_overflow.test
@@ -25,3 +25,21 @@ create sequence seq4 INCREMENT BY -1 MINVALUE -9223372036854775808 MAXVALUE -922
 
 statement error
 SELECT nextval('seq4') from generate_series(0,20);
+
+statement ok
+create sequence seq5 INCREMENT BY 9223372036854775807 MINVALUE 9223372036854775800 MAXVALUE 9223372036854775807 CYCLE;
+
+statement error
+SELECT nextval('seq5') from generate_series(0,20);
+
+statement ok
+create sequence seq6 INCREMENT BY 9223372036854775807 MINVALUE 9223372036854775800 MAXVALUE 9223372036854775807;
+
+statement error
+SELECT nextval('seq6') from generate_series(0,20);
+
+statement ok
+create sequence seq7 INCREMENT BY -9223372036854775808 MINVALUE -9223372036854775808 MAXVALUE -9223372036854775800;
+
+statement error
+SELECT nextval('seq7') from generate_series(0,20);


### PR DESCRIPTION
Fixes #2678

An overflow without `CYCLE` is always an exception. We can handle the overflow with `CYCLE` in theory, but for now we just throw an exception in this case since it likely doesn't matter.