### PR TITLE
Fix #2663: correctly implement EXTRACT(EPOCH from TIME) as seconds since midnight

### DIFF
--- a/src/function/scalar/date/date_part.cpp
+++ b/src/function/scalar/date/date_part.cpp
@@ -635,7 +635,7 @@ int64_t DatePart::EpochOperator::Operation(interval_t input) {
 
 template <>
 int64_t DatePart::EpochOperator::Operation(dtime_t input) {
-	return SecondsOperator::Operation<dtime_t, int64_t>(input);
+	return input.micros / Interval::MICROS_PER_SEC;
 }
 
 template <>

--- a/test/sql/function/time/epoch.test
+++ b/test/sql/function/time/epoch.test
@@ -1,4 +1,4 @@
-# name: test/sql/function/time/test_extract.test
+# name: test/sql/function/time/epoch.test
 # description: Extract function
 # group: [time]
 

--- a/test/sql/function/time/epoch.test
+++ b/test/sql/function/time/epoch.test
@@ -1,0 +1,21 @@
+# name: test/sql/function/time/test_extract.test
+# description: Extract function
+# group: [time]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+select epoch(TIME '14:21:13')
+----
+51673
+
+query I
+select extract(epoch from TIME '14:21:13')
+----
+51673
+
+query I
+select extract(seconds from TIME '14:21:13')
+----
+13

--- a/test/sql/function/time/test_extract.test
+++ b/test/sql/function/time/test_extract.test
@@ -60,10 +60,10 @@ NULL
 query I
 SELECT EXTRACT(epoch FROM i) FROM times
 ----
-20
-10
-10
-10
+80
+72490
+72490
+72490
 NULL
 
 # time gives errors for date-only parts


### PR DESCRIPTION
Fixes #2663