### PR TITLE
Rename snappy namespace to duckdb_snappy, and enable Parquet extension for the exported symbol checker

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -390,8 +390,6 @@ jobs:
     name: Symbol Leakage
     runs-on: ubuntu-20.04
     needs: linux-release-64
-    env:
-      DISABLE_PARQUET: 1
 
     steps:
     - uses: actions/checkout@v2

--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -216,7 +216,8 @@ void ColumnReader::PreparePage(idx_t compressed_page_size, idx_t uncompressed_pa
 		break;
 	}
 	case CompressionCodec::SNAPPY: {
-		auto res = snappy::RawUncompress((const char *)block->ptr, compressed_page_size, (char *)unpacked_block->ptr);
+		auto res =
+		    duckdb_snappy::RawUncompress((const char *)block->ptr, compressed_page_size, (char *)unpacked_block->ptr);
 		if (!res) {
 			throw std::runtime_error("Decompression failure");
 		}

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -423,10 +423,10 @@ void ParquetWriter::Flush(ChunkCollection &buffer) {
 			compressed_data = temp_writer.blob.data.get();
 			break;
 		case CompressionCodec::SNAPPY: {
-			compressed_size = snappy::MaxCompressedLength(temp_writer.blob.size);
+			compressed_size = duckdb_snappy::MaxCompressedLength(temp_writer.blob.size);
 			compressed_buf = unique_ptr<data_t[]>(new data_t[compressed_size]);
-			snappy::RawCompress((const char *)temp_writer.blob.data.get(), temp_writer.blob.size,
-			                    (char *)compressed_buf.get(), &compressed_size);
+			duckdb_snappy::RawCompress((const char *)temp_writer.blob.data.get(), temp_writer.blob.size,
+			                           (char *)compressed_buf.get(), &compressed_size);
 			compressed_data = compressed_buf.get();
 			break;
 		}

--- a/third_party/snappy/snappy-internal.h
+++ b/third_party/snappy/snappy-internal.h
@@ -244,6 +244,6 @@ static const int kMaxHashTableBits = 14;
 static const size_t kMaxHashTableSize = 1 << kMaxHashTableBits;
 
 
-}  // end namespace snappy
+}  // end namespace duckdb_snappy
 
 #endif  // THIRD_PARTY_SNAPPY_SNAPPY_INTERNAL_H_

--- a/third_party/snappy/snappy-internal.h
+++ b/third_party/snappy/snappy-internal.h
@@ -33,7 +33,7 @@
 
 #include "snappy-stubs-internal.h"
 
-namespace snappy {
+namespace duckdb_snappy {
 namespace internal {
 
 // Working memory performs a single allocation to hold all scratch space

--- a/third_party/snappy/snappy-sinksource.cc
+++ b/third_party/snappy/snappy-sinksource.cc
@@ -101,4 +101,4 @@ char* UncheckedByteArraySink::GetAppendBufferVariable(
   return dest_;
 }
 
-}  // namespace snappy
+}  // namespace duckdb_snappy

--- a/third_party/snappy/snappy-sinksource.cc
+++ b/third_party/snappy/snappy-sinksource.cc
@@ -30,7 +30,7 @@
 
 #include "snappy-sinksource.h"
 
-namespace snappy {
+namespace duckdb_snappy {
 
 Source::~Source() { }
 

--- a/third_party/snappy/snappy-sinksource.h
+++ b/third_party/snappy/snappy-sinksource.h
@@ -31,7 +31,7 @@
 
 #include <stddef.h>
 
-namespace snappy {
+namespace duckdb_snappy {
 
 // A Sink is an interface that consumes a sequence of bytes.
 class Sink {

--- a/third_party/snappy/snappy-sinksource.h
+++ b/third_party/snappy/snappy-sinksource.h
@@ -177,6 +177,6 @@ class UncheckedByteArraySink : public Sink {
   char* dest_;
 };
 
-}  // namespace snappy
+}  // namespace duckdb_snappy
 
 #endif  // THIRD_PARTY_SNAPPY_SNAPPY_SINKSOURCE_H_

--- a/third_party/snappy/snappy-stubs-internal.cc
+++ b/third_party/snappy/snappy-stubs-internal.cc
@@ -39,4 +39,4 @@ void Varint::Append32(string* s, uint32 value) {
   s->append(buf, p - buf);
 }
 
-}  // namespace snappy
+}  // namespace duckdb_snappy

--- a/third_party/snappy/snappy-stubs-internal.cc
+++ b/third_party/snappy/snappy-stubs-internal.cc
@@ -31,7 +31,7 @@
 
 #include "snappy-stubs-internal.h"
 
-namespace snappy {
+namespace duckdb_snappy {
 
 void Varint::Append32(string* s, uint32 value) {
   char buf[Varint::kMax32];

--- a/third_party/snappy/snappy-stubs-internal.h
+++ b/third_party/snappy/snappy-stubs-internal.h
@@ -113,7 +113,7 @@
 #define DECLARE_bool(flag_name) \
   extern bool FLAGS_ ## flag_name
 
-namespace snappy {
+namespace duckdb_snappy {
 
 //static const uint32 kuint32max = static_cast<uint32>(0xFFFFFFFF);
 //static const int64 kint64max = static_cast<int64>(0x7FFFFFFFFFFFFFFFLL);

--- a/third_party/snappy/snappy-stubs-internal.h
+++ b/third_party/snappy/snappy-stubs-internal.h
@@ -503,6 +503,6 @@ inline char* string_as_array(string* str) {
   return str->empty() ? NULL : &*str->begin();
 }
 
-}  // namespace snappy
+}  // namespace duckdb_snappy
 
 #endif  // THIRD_PARTY_SNAPPY_OPENSOURCE_SNAPPY_STUBS_INTERNAL_H_

--- a/third_party/snappy/snappy-stubs-public.h
+++ b/third_party/snappy/snappy-stubs-public.h
@@ -71,6 +71,6 @@ struct iovec {
 };
 #endif  // !HAVE_SYS_UIO_H
 
-}  // namespace snappy
+}  // namespace duckdb_snappy
 
 #endif  // THIRD_PARTY_SNAPPY_OPENSOURCE_SNAPPY_STUBS_PUBLIC_H_

--- a/third_party/snappy/snappy-stubs-public.h
+++ b/third_party/snappy/snappy-stubs-public.h
@@ -49,7 +49,7 @@
 #define SNAPPY_VERSION \
     ((SNAPPY_MAJOR << 16) | (SNAPPY_MINOR << 8) | SNAPPY_PATCHLEVEL)
 
-namespace snappy {
+namespace duckdb_snappy {
 
 using int8 = std::int8_t;
 using uint8 = std::uint8_t;

--- a/third_party/snappy/snappy.cc
+++ b/third_party/snappy/snappy.cc
@@ -74,7 +74,7 @@
 #include <string>
 #include <vector>
 
-namespace snappy {
+namespace duckdb_snappy {
 
 using internal::COPY_1_BYTE_OFFSET;
 using internal::COPY_2_BYTE_OFFSET;

--- a/third_party/snappy/snappy.cc
+++ b/third_party/snappy/snappy.cc
@@ -1659,4 +1659,4 @@ bool Uncompress(Source* compressed, Sink* uncompressed) {
   }
 }
 
-}  // namespace snappy
+}  // namespace duckdb_snappy

--- a/third_party/snappy/snappy.h
+++ b/third_party/snappy/snappy.h
@@ -184,6 +184,6 @@ namespace duckdb_snappy {
   // unspecified prefix of *compressed.
   bool IsValidCompressed(Source* compressed);
 
-}  // end namespace snappy
+}  // end namespace duckdb_snappy
 
 #endif  // THIRD_PARTY_SNAPPY_SNAPPY_H__

--- a/third_party/snappy/snappy.h
+++ b/third_party/snappy/snappy.h
@@ -44,7 +44,7 @@
 
 #include "snappy-stubs-public.h"
 
-namespace snappy {
+namespace duckdb_snappy {
   class Source;
   class Sink;
 


### PR DESCRIPTION
See facebookincubator/velox#678, CC @mbasmanova