### PR TITLE
Fix #2701: Handle VALUES lists in correlated subqueries

### DIFF
--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -677,7 +677,9 @@ idx_t GroupedAggregateHashTable::Scan(idx_t &scan_position, DataChunk &result) {
 }
 
 void GroupedAggregateHashTable::Finalize() {
-	D_ASSERT(!is_finalized);
+	if (is_finalized) {
+		return;
+	}
 
 	// early release hashes, not needed for partition/scan
 	hashes_hdl.reset();

--- a/src/execution/operator/scan/physical_expression_scan.cpp
+++ b/src/execution/operator/scan/physical_expression_scan.cpp
@@ -6,8 +6,7 @@ namespace duckdb {
 
 class ExpressionScanState : public OperatorState {
 public:
-	explicit ExpressionScanState(const PhysicalExpressionScan &op) :
-		expression_index(0) {
+	explicit ExpressionScanState(const PhysicalExpressionScan &op) : expression_index(0) {
 		temp_chunk.Initialize(op.GetTypes());
 	}
 
@@ -22,8 +21,8 @@ unique_ptr<OperatorState> PhysicalExpressionScan::GetOperatorState(ClientContext
 }
 
 OperatorResultType PhysicalExpressionScan::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
-							OperatorState &state_p) const {
-	auto &state = (ExpressionScanState &) state_p;
+                                                   OperatorState &state_p) const {
+	auto &state = (ExpressionScanState &)state_p;
 
 	for (; chunk.size() + input.size() <= STANDARD_VECTOR_SIZE && state.expression_index < expressions.size();
 	     state.expression_index++) {

--- a/src/execution/operator/scan/physical_expression_scan.cpp
+++ b/src/execution/operator/scan/physical_expression_scan.cpp
@@ -4,9 +4,10 @@
 
 namespace duckdb {
 
-class ExpressionScanState : public GlobalSourceState {
+class ExpressionScanState : public OperatorState {
 public:
-	explicit ExpressionScanState(const PhysicalExpressionScan &op) : expression_index(0) {
+	explicit ExpressionScanState(const PhysicalExpressionScan &op) :
+		expression_index(0) {
 		temp_chunk.Initialize(op.GetTypes());
 	}
 
@@ -16,16 +17,26 @@ public:
 	DataChunk temp_chunk;
 };
 
-class ExpressionSinkState : public GlobalSinkState {
-public:
-	ExpressionSinkState() {
-	}
-
-	DataChunk child_chunk;
-};
-
-unique_ptr<GlobalSourceState> PhysicalExpressionScan::GetGlobalSourceState(ClientContext &context) const {
+unique_ptr<OperatorState> PhysicalExpressionScan::GetOperatorState(ClientContext &context) const {
 	return make_unique<ExpressionScanState>(*this);
+}
+
+OperatorResultType PhysicalExpressionScan::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+							OperatorState &state_p) const {
+	auto &state = (ExpressionScanState &) state_p;
+
+	for (; chunk.size() + input.size() <= STANDARD_VECTOR_SIZE && state.expression_index < expressions.size();
+	     state.expression_index++) {
+		state.temp_chunk.Reset();
+		EvaluateExpression(state.expression_index, &input, state.temp_chunk);
+		chunk.Append(state.temp_chunk);
+	}
+	if (state.expression_index < expressions.size()) {
+		return OperatorResultType::HAVE_MORE_OUTPUT;
+	} else {
+		state.expression_index = 0;
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
 }
 
 void PhysicalExpressionScan::EvaluateExpression(idx_t expression_idx, DataChunk *child_chunk, DataChunk &result) const {
@@ -38,20 +49,6 @@ void PhysicalExpressionScan::EvaluateExpression(idx_t expression_idx, DataChunk 
 	}
 }
 
-void PhysicalExpressionScan::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
-                                     LocalSourceState &lstate) const {
-	D_ASSERT(sink_state);
-	auto &state = (ExpressionScanState &)gstate_p;
-	auto &gstate = (ExpressionSinkState &)*sink_state;
-
-	for (; chunk.size() < STANDARD_VECTOR_SIZE && state.expression_index < expressions.size();
-	     state.expression_index++) {
-		state.temp_chunk.Reset();
-		EvaluateExpression(state.expression_index, &gstate.child_chunk, state.temp_chunk);
-		chunk.Append(state.temp_chunk);
-	}
-}
-
 bool PhysicalExpressionScan::IsFoldable() const {
 	for (auto &expr_list : expressions) {
 		for (auto &expr : expr_list) {
@@ -61,24 +58,6 @@ bool PhysicalExpressionScan::IsFoldable() const {
 		}
 	}
 	return true;
-}
-
-SinkResultType PhysicalExpressionScan::Sink(ExecutionContext &context, GlobalSinkState &gstate_p,
-                                            LocalSinkState &lstate, DataChunk &input) const {
-	auto &gstate = (ExpressionSinkState &)gstate_p;
-
-	D_ASSERT(children.size() == 1);
-	D_ASSERT(gstate.child_chunk.size() == 0);
-	if (input.size() != 1) {
-		throw InternalException("Expected expression scan child to have exactly one element");
-	}
-	gstate.child_chunk.Move(input);
-	gstate.child_chunk.Verify();
-	return SinkResultType::FINISHED;
-}
-
-unique_ptr<GlobalSinkState> PhysicalExpressionScan::GetGlobalSinkState(ClientContext &context) const {
-	return make_unique<ExpressionSinkState>();
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/scan/physical_expression_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_expression_scan.hpp
@@ -27,18 +27,11 @@ public:
 	vector<vector<unique_ptr<Expression>>> expressions;
 
 public:
-	unique_ptr<GlobalSourceState> GetGlobalSourceState(ClientContext &context) const override;
-	void GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
-	             LocalSourceState &lstate) const override;
+	unique_ptr<OperatorState> GetOperatorState(ClientContext &context) const override;
+	OperatorResultType Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+	                           OperatorState &state) const override;
 
-public:
-	// Sink interface
-	SinkResultType Sink(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate,
-	                    DataChunk &input) const override;
-
-	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
-
-	bool IsSink() const override {
+	bool ParallelOperator() const override {
 		return true;
 	}
 

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -410,7 +410,6 @@ void Executor::BuildPipelines(PhysicalOperator *op, Pipeline *current) {
 		case PhysicalOperatorType::TOP_N:
 		case PhysicalOperatorType::COPY_TO_FILE:
 		case PhysicalOperatorType::LIMIT:
-		case PhysicalOperatorType::EXPRESSION_SCAN:
 		case PhysicalOperatorType::EXPLAIN_ANALYZE:
 			D_ASSERT(op->children.size() == 1);
 			// single operator:

--- a/src/planner/expression_iterator.cpp
+++ b/src/planner/expression_iterator.cpp
@@ -148,8 +148,8 @@ void ExpressionIterator::EnumerateTableRefChildren(BoundTableRef &ref,
 	}
 	case TableReferenceType::EXPRESSION_LIST: {
 		auto &bound_expr_list = (BoundExpressionListRef &)ref;
-		for(auto &expr_list : bound_expr_list.values) {
-			for(auto &expr : expr_list) {
+		for (auto &expr_list : bound_expr_list.values) {
+			for (auto &expr : expr_list) {
 				EnumerateExpression(expr, callback);
 			}
 		}

--- a/src/planner/expression_iterator.cpp
+++ b/src/planner/expression_iterator.cpp
@@ -146,6 +146,15 @@ void ExpressionIterator::EnumerateTableRefChildren(BoundTableRef &ref,
 		EnumerateTableRefChildren(*bound_crossproduct.right, callback);
 		break;
 	}
+	case TableReferenceType::EXPRESSION_LIST: {
+		auto &bound_expr_list = (BoundExpressionListRef &)ref;
+		for(auto &expr_list : bound_expr_list.values) {
+			for(auto &expr : expr_list) {
+				EnumerateExpression(expr, callback);
+			}
+		}
+		break;
+	}
 	case TableReferenceType::JOIN: {
 		auto &bound_join = (BoundJoinRef &)ref;
 		EnumerateExpression(bound_join.condition, callback);

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -324,9 +324,9 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 		// now we add all the correlated columns to each of the expressions of the expression scan
 		auto expr_get = (LogicalExpressionGet *)plan.get();
 		for (idx_t i = 0; i < correlated_columns.size(); i++) {
-			for(auto &expr_list : expr_get->expressions) {
+			for (auto &expr_list : expr_get->expressions) {
 				auto colref = make_unique<BoundColumnRefExpression>(
-					correlated_columns[i].type, ColumnBinding(base_binding.table_index, base_binding.column_index + i));
+				    correlated_columns[i].type, ColumnBinding(base_binding.table_index, base_binding.column_index + i));
 				expr_list.push_back(move(colref));
 			}
 			expr_get->expr_types.push_back(correlated_columns[i].type);

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -314,6 +314,29 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 	case LogicalOperatorType::LOGICAL_DISTINCT:
 		plan->children[0] = PushDownDependentJoin(move(plan->children[0]));
 		return plan;
+	case LogicalOperatorType::LOGICAL_EXPRESSION_GET: {
+		// expression get
+		// first we flatten the dependent join in the child
+		plan->children[0] = PushDownDependentJoinInternal(move(plan->children[0]));
+		// then we replace any correlated expressions with the corresponding entry in the correlated_map
+		RewriteCorrelatedExpressions rewriter(base_binding, correlated_map);
+		rewriter.VisitOperator(*plan);
+		// now we add all the correlated columns to each of the expressions of the expression scan
+		auto expr_get = (LogicalExpressionGet *)plan.get();
+		for (idx_t i = 0; i < correlated_columns.size(); i++) {
+			for(auto &expr_list : expr_get->expressions) {
+				auto colref = make_unique<BoundColumnRefExpression>(
+					correlated_columns[i].type, ColumnBinding(base_binding.table_index, base_binding.column_index + i));
+				expr_list.push_back(move(colref));
+			}
+			expr_get->expr_types.push_back(correlated_columns[i].type);
+		}
+
+		base_binding.table_index = expr_get->table_index;
+		this->delim_offset = base_binding.column_index = expr_get->expr_types.size() - correlated_columns.size();
+		this->data_offset = 0;
+		return plan;
+	}
 	case LogicalOperatorType::LOGICAL_ORDER_BY:
 		throw ParserException("ORDER BY not supported in correlated subquery");
 	default:

--- a/test/sql/subquery/scalar/expression_get.test
+++ b/test/sql/subquery/scalar/expression_get.test
@@ -1,0 +1,101 @@
+# name: test/sql/subquery/scalar/expression_get.test
+# description: Issue #2701: Nested selecting max from column values gives dependent join internal error
+# group: [scalar]
+
+statement ok
+PRAGMA enable_verification
+
+# basic correlated VALUES clause in subquery
+statement ok
+CREATE TABLE test AS SELECT CAST((i % 10) AS INTEGER) AS i, CAST(((i * 2) % 10) AS INTEGER) AS j FROM generate_series(0, 9, 1) tbl(i);
+
+query III
+SELECT i, j, (SELECT max(x) FROM (VALUES (i), (j)) AS X(x)) as maxn FROM test;
+----
+0	0	0
+1	2	2
+2	4	4
+3	6	6
+4	8	8
+5	0	5
+6	2	6
+7	4	7
+8	6	8
+9	8	9
+
+# mix of correlated and non-correlated values
+query III
+SELECT i, j, (SELECT max(x) FROM (VALUES (i), (j), (3), (NULL), (5)) AS X(x)) as maxn FROM test;
+----
+0	0	5
+1	2	5
+2	4	5
+3	6	6
+4	8	8
+5	0	5
+6	2	6
+7	4	7
+8	6	8
+9	8	9
+
+# more complex correlated queries involving VALUES lists
+statement ok
+CREATE TABLE integers(i INTEGER);
+
+statement ok
+INSERT INTO integers VALUES (1), (2), (3), (NULL);
+
+# subquery within correlated values list
+query I
+SELECT (SELECT max(x) FROM (VALUES ((SELECT i))) tbl(x)) FROM integers ORDER BY i;
+----
+NULL
+1
+2
+3
+
+# correlated values list within correlated values list
+query I
+SELECT (SELECT max(x) FROM (VALUES ((SELECT * FROM (VALUES (i)) tbl3(x)))) tbl(x)) FROM integers ORDER BY i;
+----
+NULL
+1
+2
+3
+
+# join between correlated values lists
+query I
+SELECT (SELECT max(x) FROM (VALUES (i)) tbl(x) JOIN (VALUES (i)) tbl2(x) USING (x)) FROM integers ORDER BY i;
+----
+NULL
+1
+2
+3
+
+# many rows
+statement ok
+CREATE TABLE test2 AS SELECT (i % 10)::INTEGER AS i, ((i * 2) % 10)::INTEGER AS j FROM generate_series(0, 99999, 1) tbl(i);
+
+query IIII
+SELECT SUM(i), SUM(j), SUM(GREATEST(i, j)), SUM((SELECT max(x) FROM (VALUES (i), (j)) AS X(x))) as maxn FROM test2;
+----
+450000	400000	550000	550000
+
+query IIII
+SELECT SUM(i), SUM(j), SUM(GREATEST(i, j)), SUM((SELECT max(x) FROM (VALUES (i), (j), (i), (j), (i), (j)) AS X(x))) as maxn FROM test2;
+----
+450000	400000	550000	550000
+
+# NULLs
+statement ok
+CREATE TABLE test3 AS SELECT CASE WHEN i%7=2 THEN NULL ELSE (i % 10)::INTEGER END AS i, CASE WHEN i%9=2 THEN NULL ELSE ((i * 2) % 10)::INTEGER END AS j FROM generate_series(0, 99999, 1) tbl(i);
+
+query III
+SELECT SUM(i), SUM(j), SUM((SELECT max(x) FROM (VALUES (i), (j)) AS X(x))) as maxn FROM test3;
+----
+385713	355556	512700
+
+query III
+SELECT SUM(i), SUM(j), SUM((SELECT max(x) FROM (VALUES (i), (j), (NULL), (NULL), (6)) AS X(x))) as maxn FROM test3;
+----
+385713	355556	671748

--- a/test/sql/subquery/scalar/values_list_large.test_slow
+++ b/test/sql/subquery/scalar/values_list_large.test_slow
@@ -1,0 +1,11 @@
+# name: test/sql/subquery/scalar/values_list_large.test_slow
+# description: Test large correlated subquery with VALUES list
+# group: [scalar]
+
+statement ok
+CREATE TABLE test AS SELECT CASE WHEN i%7=2 THEN NULL ELSE i::INTEGER END AS i, CASE WHEN i%9=2 THEN NULL ELSE i::INTEGER+2 END AS j FROM generate_series(0, 9999999, 1) tbl(i);
+
+query III
+SELECT SUM(i), SUM(j), SUM((SELECT max(x) FROM (VALUES (i), (j)) AS X(x))) as maxn FROM test;
+----
+42857134285714	44444461111111	49206358253971


### PR DESCRIPTION
This PR adds support for using VALUES lists in correlated subqueries, fixing #2701.
i.e. the following query now works:

```sql
CREATE TABLE test(i INTEGER, j INTEGER);
SELECT i, j, (SELECT max(x) FROM (VALUES (test.i), (test.j)) AS X(x)) as maxn FROM test;
```