### PR TITLE
Modify LEAST/GREATEST to ignore NULL values

### DIFF
--- a/src/function/scalar/generic/least.cpp
+++ b/src/function/scalar/generic/least.cpp
@@ -38,7 +38,7 @@ static void LeastGreatestFunction(DataChunk &args, ExpressionState &state, Vecto
 		VectorData vdata;
 		args.data[0].Orrify(args.size(), vdata);
 		auto input_data = (T *)vdata.data;
-		for(idx_t i = 0; i < args.size(); i++) {
+		for (idx_t i = 0; i < args.size(); i++) {
 			auto vindex = vdata.sel->get_index(i);
 			if (vdata.validity.RowIsValid(vindex)) {
 				result_data[i] = input_data[vindex];
@@ -50,7 +50,8 @@ static void LeastGreatestFunction(DataChunk &args, ExpressionState &state, Vecto
 	}
 	// now handle the remainder of the columns
 	for (idx_t col_idx = 1; col_idx < args.ColumnCount(); col_idx++) {
-		if (args.data[col_idx].GetVectorType() == VectorType::CONSTANT_VECTOR && ConstantVector::IsNull(args.data[col_idx])) {
+		if (args.data[col_idx].GetVectorType() == VectorType::CONSTANT_VECTOR &&
+		    ConstantVector::IsNull(args.data[col_idx])) {
 			// ignore null vector
 			continue;
 		}
@@ -85,7 +86,7 @@ static void LeastGreatestFunction(DataChunk &args, ExpressionState &state, Vecto
 			}
 		}
 	}
-	for(idx_t i = 0; i < args.size(); i++) {
+	for (idx_t i = 0; i < args.size(); i++) {
 		if (!result_has_value[i]) {
 			result_mask.SetInvalid(i);
 		}

--- a/src/function/scalar/generic/least.cpp
+++ b/src/function/scalar/generic/least.cpp
@@ -20,14 +20,7 @@ static void LeastGreatestFunction(DataChunk &args, ExpressionState &state, Vecto
 	}
 	auto result_type = VectorType::CONSTANT_VECTOR;
 	for (idx_t col_idx = 0; col_idx < args.ColumnCount(); col_idx++) {
-		if (args.data[col_idx].GetVectorType() == VectorType::CONSTANT_VECTOR) {
-			if (ConstantVector::IsNull(args.data[col_idx])) {
-				// constant NULL: result is constant NULL
-				result.SetVectorType(VectorType::CONSTANT_VECTOR);
-				ConstantVector::SetNull(result, true);
-				return;
-			}
-		} else {
+		if (args.data[col_idx].GetVectorType() != VectorType::CONSTANT_VECTOR) {
 			// non-constant input: result is not a constant vector
 			result_type = VectorType::FLAT_VECTOR;
 		}
@@ -37,58 +30,64 @@ static void LeastGreatestFunction(DataChunk &args, ExpressionState &state, Vecto
 		}
 	}
 
-	// we start off performing a binary operation between the first two inputs, where we store the lowest (or highest)
-	// directly in the result
-	BinaryExecutor::ExecuteGeneric<T, T, T, BinarySingleArgumentOperatorWrapper, LeastOperator<OP>, bool>(
-	    args.data[0], args.data[1], result, args.size(), false);
-
-	// now we loop over the other columns and compare it to the stored result
 	auto result_data = FlatVector::GetData<T>(result);
 	auto &result_mask = FlatVector::Validity(result);
-	SelectionVector rsel;
-	idx_t rcount = 0;
-	// create a selection vector from the mask
-	rsel.Initialize();
-	for (idx_t i = 0; i < args.size(); i++) {
-		if (result_mask.RowIsValid(i)) {
-			rsel.set_index(rcount++, i);
+	// copy over the first column
+	bool result_has_value[STANDARD_VECTOR_SIZE];
+	{
+		VectorData vdata;
+		args.data[0].Orrify(args.size(), vdata);
+		auto input_data = (T *)vdata.data;
+		for(idx_t i = 0; i < args.size(); i++) {
+			auto vindex = vdata.sel->get_index(i);
+			if (vdata.validity.RowIsValid(vindex)) {
+				result_data[i] = input_data[vindex];
+				result_has_value[i] = true;
+			} else {
+				result_has_value[i] = false;
+			}
 		}
 	}
-	for (idx_t col_idx = 2; col_idx < args.ColumnCount(); col_idx++) {
+	// now handle the remainder of the columns
+	for (idx_t col_idx = 1; col_idx < args.ColumnCount(); col_idx++) {
+		if (args.data[col_idx].GetVectorType() == VectorType::CONSTANT_VECTOR && ConstantVector::IsNull(args.data[col_idx])) {
+			// ignore null vector
+			continue;
+		}
+
 		VectorData vdata;
 		args.data[col_idx].Orrify(args.size(), vdata);
 
 		auto input_data = (T *)vdata.data;
 		if (!vdata.validity.AllValid()) {
 			// potential new null entries: have to check the null mask
-			idx_t new_count = 0;
-			for (idx_t i = 0; i < rcount; i++) {
-				auto rindex = rsel.get_index(i);
-				auto vindex = vdata.sel->get_index(rindex);
-				if (!vdata.validity.RowIsValid(vindex)) {
-					// new null entry: set nullmask
-					result_mask.SetInvalid(rindex);
-				} else {
+			for (idx_t i = 0; i < args.size(); i++) {
+				auto vindex = vdata.sel->get_index(i);
+				if (vdata.validity.RowIsValid(vindex)) {
 					// not a null entry: perform the operation and add to new set
 					auto ivalue = input_data[vindex];
-					if (OP::template Operation<T>(ivalue, result_data[rindex])) {
-						result_data[rindex] = ivalue;
+					if (!result_has_value[i] || OP::template Operation<T>(ivalue, result_data[i])) {
+						result_has_value[i] = true;
+						result_data[i] = ivalue;
 					}
-					rsel.set_index(new_count++, rindex);
 				}
 			}
-			rcount = new_count;
 		} else {
 			// no new null entries: only need to perform the operation
-			for (idx_t i = 0; i < rcount; i++) {
-				auto rindex = rsel.get_index(i);
-				auto vindex = vdata.sel->get_index(rindex);
+			for (idx_t i = 0; i < args.size(); i++) {
+				auto vindex = vdata.sel->get_index(i);
 
 				auto ivalue = input_data[vindex];
-				if (OP::template Operation<T>(ivalue, result_data[rindex])) {
-					result_data[rindex] = ivalue;
+				if (!result_has_value[i] || OP::template Operation<T>(ivalue, result_data[i])) {
+					result_has_value[i] = true;
+					result_data[i] = ivalue;
 				}
 			}
+		}
+	}
+	for(idx_t i = 0; i < args.size(); i++) {
+		if (!result_has_value[i]) {
+			result_mask.SetInvalid(i);
 		}
 	}
 	result.SetVectorType(result_type);

--- a/test/sql/aggregate/group/test_group_by_nested.test
+++ b/test/sql/aggregate/group/test_group_by_nested.test
@@ -33,7 +33,7 @@ SELECT k, SUM(v) FROM intlists GROUP BY k ORDER BY 2
 query III
 SELECT k, LEAST(v, 21) as c, SUM(v) FROM intlists GROUP BY k, c ORDER BY 2, 3
 ----
-[13]	NULL	NULL
+[13]	21	NULL
 [1]	21	21
 []	21	23
 [NULL]	21	54
@@ -65,7 +65,7 @@ SELECT k, SUM(v) FROM strlists GROUP BY k ORDER BY 2
 query III
 SELECT k, LEAST(v, 21) as c, SUM(v) FROM strlists GROUP BY k, c ORDER BY 2, 3
 ----
-[Somateria mollissima]	NULL	NULL
+[Somateria mollissima]	21	NULL
 [a]	21	21
 []	21	23
 [NULL]	21	54
@@ -97,7 +97,7 @@ SELECT k, SUM(v) FROM structs GROUP BY k ORDER BY 2
 query III
 SELECT k, LEAST(v, 21) as c, SUM(v) FROM structs GROUP BY k, c ORDER BY 2, 3
 ----
-{'x': 13, 'y': Somateria mollissima}	NULL	NULL
+{'x': 13, 'y': Somateria mollissima}	21	NULL
 {'x': 1, 'y': a}	21	21
 {'x': 0, 'y': }	21	23
 {'x': NULL, 'y': NULL}	21	54
@@ -133,7 +133,7 @@ SELECT k, LEAST(v, 21) as c, SUM(v) FROM struct_lint_lstr
 GROUP BY k, c
 ORDER BY 2, 3
 ----
-{'x': [13], 'y': [Somateria mollissima]}	NULL	NULL
+{'x': [13], 'y': [Somateria mollissima]}	21	NULL
 {'x': [1], 'y': [a]}	21	21
 {'x': [], 'y': []}	21	23
 {'x': [NULL], 'y': [NULL]}	21	54
@@ -169,7 +169,7 @@ SELECT k, LEAST(v, 21) as c, SUM(v) FROM r2l3r4l5i4i2l3v
 GROUP BY k, c
 ORDER BY 2, 3
 ----
-{'x': [{'l4': [62], 'i4': 47}], 'y': [Somateria mollissima]}	NULL	NULL
+{'x': [{'l4': [62], 'i4': 47}], 'y': [Somateria mollissima]}	21	NULL
 {'x': [{'l4': [51], 'i4': 41}], 'y': [a]}	21	21
 {'x': [], 'y': []}	21	23
 {'x': [NULL], 'y': [NULL]}	21	54
@@ -208,7 +208,7 @@ SELECT k, LEAST(v, 21) as c, SUM(v) FROM longlists
 GROUP BY k, c
 ORDER BY 2, 3
 ----
-15 values hashing to 84a00080363dc8d5f8adbf6cc769a55d
+15 values hashing to 221ccf64a566554dde15e57c459708c8
 
 # Multiple constant keys
 query II

--- a/test/sql/function/generic/test_least_greatest.test
+++ b/test/sql/function/generic/test_least_greatest.test
@@ -29,12 +29,12 @@ SELECT LEAST(1, 3, 0, 2, 7, 8, 10, 11, -100, 30)
 query I
 SELECT LEAST(1, 3, 0, 2, 7, 8, 10, 11, -100, 30, NULL)
 ----
-NULL
+-100
 
 query I
 SELECT LEAST(NULL, 3, 0, 2, 7, 8, 10, 11, -100, 30, 1)
 ----
-NULL
+-100
 
 # double
 query R
@@ -67,7 +67,7 @@ SELECT LEAST(DATE '1992-01-01', DATE '1994-02-02', DATE '1991-01-01')
 query T
 SELECT LEAST(DATE '1992-01-01', DATE '1994-02-02', DATE '1991-01-01', NULL)
 ----
-NULL
+1991-01-01
 
 # test mix of types
 query T
@@ -77,58 +77,58 @@ SELECT LEAST(DATE '1992-01-01', 'hello', 123)
 
 # tables
 statement ok
-CREATE TABLE t1(i INTEGER, j INTEGER)
+CREATE TABLE t1(i INTEGER, j INTEGER);
 
 statement ok
-INSERT INTO t1 VALUES (1, NULL), (2, 1), (3, 7)
+INSERT INTO t1 VALUES (1, NULL), (2, 1), (3, 7);
 
 query II
-SELECT LEAST(i, j), GREATEST(i, j) FROM t1 ORDER BY i
+SELECT LEAST(i, j), GREATEST(i, j) FROM t1 ORDER BY i;
 ----
-NULL	NULL
+1	1
 1	2
 3	7
 
 query II
-SELECT LEAST(i, i + 1, j), GREATEST(i, i - 1, j) FROM t1 ORDER BY i
+SELECT LEAST(i, i + 1, j), GREATEST(i, i - 1, j) FROM t1 ORDER BY i;
 ----
-NULL	NULL
+1	1
 1	2
 3	7
 
 query II
-SELECT LEAST(i, 800, i + 1, 1000, j), GREATEST(i, -1000, i - 1, -700, j, -800) FROM t1 ORDER BY i
+SELECT LEAST(i, 800, i + 1, 1000, j), GREATEST(i, -1000, i - 1, -700, j, -800) FROM t1 ORDER BY i;
 ----
-NULL	NULL
+1	1
 1	2
 3	7
 
 query II
-SELECT LEAST(i, 800, i + 1, 1000, j, NULL), GREATEST(i, -1000, i - 1, -700, j, -800) FROM t1 ORDER BY i
+SELECT LEAST(i, 800, i + 1, 1000, j, NULL), GREATEST(i, -1000, i - 1, -700, j, -800) FROM t1 ORDER BY i;
 ----
-NULL	NULL
-NULL	2
-NULL	7
+1	1
+1	2
+3	7
 
 # selection vectors
 query II
-SELECT LEAST(i, j), GREATEST(i, j) FROM t1 WHERE j IS NOT NULL ORDER BY i
+SELECT LEAST(i, j), GREATEST(i, j) FROM t1 WHERE j IS NOT NULL ORDER BY i;
 ----
 1	2
 3	7
 
 # row ids
 query II
-SELECT LEAST(rowid + 10, i, j), GREATEST(i, rowid + 4, j) FROM t1 WHERE j IS NOT NULL ORDER BY i
+SELECT LEAST(rowid + 10, i, j), GREATEST(i, rowid + 4, j) FROM t1 WHERE j IS NOT NULL ORDER BY i;
 ----
 1	5
 3	7
 
 # generated strings
 query T
-SELECT LEAST(REPEAT(i::VARCHAR, 20), j::VARCHAR) FROM t1
+SELECT LEAST(REPEAT(i::VARCHAR, 20), j::VARCHAR) FROM t1;
 ----
-NULL
+11111111111111111111
 1
 33333333333333333333
 


### PR DESCRIPTION
Postgres ignores NULL values (i.e. LEAST/GREATEST is evaluated similar to an aggregate):

```sql
SELECT LEAST(3, NULL); -- 3
```

This PR patches the functions in DuckDB to have the same behavior.