### PR TITLE
Add "position" as an alias to the "instr" function

### DIFF
--- a/src/function/scalar/string/instr.cpp
+++ b/src/function/scalar/string/instr.cpp
@@ -62,6 +62,8 @@ void InstrFun::RegisterFunction(BuiltinFunctions &set) {
 	set.AddFunction(instr);
 	instr.name = "strpos";
 	set.AddFunction(instr);
+	instr.name = "position";
+	set.AddFunction(instr);
 }
 
 } // namespace duckdb

--- a/test/sql/function/string/test_instr.test
+++ b/test/sql/function/string/test_instr.test
@@ -20,6 +20,15 @@ SELECT instr(s,'h') FROM strings
 0
 NULL
 
+# position is an alias for instr
+query I
+SELECT position('h' in s) FROM strings
+----
+1
+0
+0
+NULL
+
 # Test second letter
 query I
 SELECT instr(s,'e') FROM strings
@@ -41,6 +50,14 @@ NULL
 # Test multiple letters
 query I
 SELECT instr(s,'he') FROM strings
+----
+1
+0
+0
+NULL
+
+query I
+SELECT position('he' in s) FROM strings
 ----
 1
 0

--- a/test/sql/function/string/test_instr_utf8.test
+++ b/test/sql/function/string/test_instr_utf8.test
@@ -29,6 +29,14 @@ SELECT INSTR(s,'á') FROM strings
 0
 0
 
+query I
+SELECT POSITION('á' in s) FROM strings
+----
+1
+3
+0
+0
+
 # Test a sentence with UTF-8
 query I
 SELECT INSTR(s,'olá mundo') FROM strings


### PR DESCRIPTION
This allows you to use the `position` function similar to Postgres, e.g.:

```sql
select position('.' in 'hello.world'); -- 6
```