### PR TITLE
Fix #2713: correctly bind multi-part column references in correlated subqueries

### DIFF
--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -56,7 +56,7 @@ BindResult ExpressionBinder::BindFunction(FunctionExpression &function, ScalarFu
 	unique_ptr<Expression> result =
 	    ScalarFunction::BindScalarFunction(context, *func, move(children), error, function.is_operator);
 	if (!result) {
-		throw BinderException(binder.FormatError(function, error));
+		return BindResult(binder.FormatError(function, error));
 	}
 	return BindResult(move(result));
 }

--- a/test/sql/cte/recursive_cte_correlated_subquery.test_slow
+++ b/test/sql/cte/recursive_cte_correlated_subquery.test_slow
@@ -1,0 +1,33 @@
+# name: test/sql/cte/recursive_cte_correlated_subquery.test_slow
+# description: Issue #2713: reports struct_extract error when run a sql
+# group: [cte]
+
+query I
+WITH RECURSIVE
+input(sud) AS (
+VALUES('53..7....6..195....98....6.8...6...34..8.3..17...2...6.6....28....419..5....8..79')
+),
+digits(z, lp) AS (
+SELECT CAST(lp+1 AS TEXT), lp::int+1 FROM generate_series(0,8,1) t(lp)
+),
+x(s, ind) AS (
+SELECT sud, instr(sud, '.') FROM input
+UNION ALL
+SELECT
+substr(s, 1, ind::int-1) || z || substr(s, ind::int+1),
+instr(substr(s, 1, ind::int-1) || z || substr(s, ind::int+1), '.' )
+FROM x, digits AS z
+WHERE ind::int>0
+AND NOT EXISTS (
+SELECT 1
+FROM digits AS lp
+WHERE z.z = substr(s, ((ind::int-1)/9)*9 + lp, 1)
+OR z.z = substr(s, ((ind::int-1)%9) + (lp-1)*9 + 1, 1)
+OR z.z = substr(s, (((ind::int-1)/3) % 3) * 3
++ ((ind::int-1)/27) * 27 + lp
++ ((lp-1) / 3) * 6, 1)
+)
+)
+SELECT s FROM x WHERE ind::int=0;
+----
+534678912672195348198342567859761423426853791713924856961537284287419635345286179


### PR DESCRIPTION
Fixes #2713 

This was a regression introduced by #2578. The problem was when a multi-dot column reference occurred in a subquery, we would try to bind `z.z` as `struct_extract(z, 'z')`. That would throw an exception directly instead of propagating the error correctly, which caused the bind to abort early and not find the correct binding of `z.z` later in the outer query. 