### PR TITLE
Infer COPY TO format from file extension

### DIFF
--- a/src/parser/transform/statement/transform_copy.cpp
+++ b/src/parser/transform/statement/transform_copy.cpp
@@ -64,7 +64,11 @@ unique_ptr<CopyStatement> Transformer::TransformCopy(duckdb_libpgquery::PGNode *
 	// get file_path and is_from
 	info.file_path = stmt->filename;
 	info.is_from = stmt->is_from;
-	info.format = "csv";
+	if (StringUtil::EndsWith(info.file_path, ".parquet")) {
+		info.format = "parquet";
+	} else {
+		info.format = "csv";
+	}
 
 	// get select_list
 	if (stmt->attlist) {

--- a/test/sql/copy/parquet/infer_copy_format.test
+++ b/test/sql/copy/parquet/infer_copy_format.test
@@ -1,0 +1,24 @@
+# name: test/sql/copy/parquet/infer_copy_format.test
+# description: Infer COPY TO format test
+# group: [parquet]
+
+require parquet
+
+statement ok
+CREATE TABLE integers AS SELECT * FROM range(6) tbl(i);
+
+statement ok
+COPY integers TO '__TEST_DIR__/integers.parquet';
+
+query I
+SELECT SUM(i) FROM '__TEST_DIR__/integers.parquet';
+----
+15
+
+statement ok
+COPY integers TO '__TEST_DIR__/integers.csv';
+
+query I
+SELECT SUM(i) FROM '__TEST_DIR__/integers.csv' tbl(i);
+----
+15

--- a/test/sql/copy/parquet/infer_copy_format.test
+++ b/test/sql/copy/parquet/infer_copy_format.test
@@ -2,6 +2,8 @@
 # description: Infer COPY TO format test
 # group: [parquet]
 
+require vector_size 512
+
 require parquet
 
 statement ok


### PR DESCRIPTION
Infer COPY TO format from the file extension if none is specified, (see #2715):

```sql
COPY integers TO 'integers.parquet'; -- FORMAT PARQUET
COPY integers TO 'integers.csv'; -- FORMAT CSV
```
