### PR TITLE
RAII for SortedBlock

### DIFF
--- a/src/common/sort/comparators.cpp
+++ b/src/common/sort/comparators.cpp
@@ -26,7 +26,7 @@ bool Comparators::TieIsBreakable(const idx_t &col_idx, const data_ptr_t row_ptr,
 	return true;
 }
 
-int Comparators::CompareTuple(const SortedBlock &left, const SortedBlock &right, const data_ptr_t &l_ptr,
+int Comparators::CompareTuple(const SBScanState &left, const SBScanState &right, const data_ptr_t &l_ptr,
                               const data_ptr_t &r_ptr, const SortLayout &sort_layout, const bool &external_sort) {
 	// Compare the sorting columns one by one
 	int comp_res = 0;
@@ -35,8 +35,7 @@ int Comparators::CompareTuple(const SortedBlock &left, const SortedBlock &right,
 	for (idx_t col_idx = 0; col_idx < sort_layout.column_count; col_idx++) {
 		comp_res = FastMemcmp(l_ptr_offset, r_ptr_offset, sort_layout.column_sizes[col_idx]);
 		if (comp_res == 0 && !sort_layout.constant_size[col_idx]) {
-			comp_res =
-			    BreakBlobTie(col_idx, *left.blob_sorting_data, *right.blob_sorting_data, sort_layout, external_sort);
+			comp_res = BreakBlobTie(col_idx, left, right, sort_layout, external_sort);
 		}
 		if (comp_res != 0) {
 			break;
@@ -62,11 +61,11 @@ int Comparators::CompareVal(const data_ptr_t l_ptr, const data_ptr_t r_ptr, cons
 	}
 }
 
-int Comparators::BreakBlobTie(const idx_t &tie_col, const SortedData &left, const SortedData &right,
+int Comparators::BreakBlobTie(const idx_t &tie_col, const SBScanState &left, const SBScanState &right,
                               const SortLayout &sort_layout, const bool &external) {
 	const idx_t &col_idx = sort_layout.sorting_to_blob_col.at(tie_col);
-	data_ptr_t l_data_ptr = left.DataPtr();
-	data_ptr_t r_data_ptr = right.DataPtr();
+	data_ptr_t l_data_ptr = left.DataPtr(*left.sb->blob_sorting_data);
+	data_ptr_t r_data_ptr = right.DataPtr(*right.sb->blob_sorting_data);
 	if (!TieIsBreakable(col_idx, l_data_ptr, sort_layout.blob_layout)) {
 		// Quick check to see if ties can be broken
 		return 0;
@@ -77,12 +76,12 @@ int Comparators::BreakBlobTie(const idx_t &tie_col, const SortedData &left, cons
 	r_data_ptr += tie_col_offset;
 	// Do the comparison
 	const int order = sort_layout.order_types[tie_col] == OrderType::DESCENDING ? -1 : 1;
-	const auto &type = left.layout.GetTypes()[col_idx];
+	const auto &type = sort_layout.blob_layout.GetTypes()[col_idx];
 	int result;
 	if (external) {
 		// Store heap pointers
-		data_ptr_t l_heap_ptr = left.HeapPtr();
-		data_ptr_t r_heap_ptr = right.HeapPtr();
+		data_ptr_t l_heap_ptr = left.HeapPtr(*left.sb->blob_sorting_data);
+		data_ptr_t r_heap_ptr = right.HeapPtr(*right.sb->blob_sorting_data);
 		// Unswizzle offset to pointer
 		UnswizzleSingleValue(l_data_ptr, l_heap_ptr, type);
 		UnswizzleSingleValue(r_data_ptr, r_heap_ptr, type);

--- a/src/common/sort/merge_sorter.cpp
+++ b/src/common/sort/merge_sorter.cpp
@@ -91,8 +91,8 @@ void MergeSorter::GetNextPartition() {
 	const idx_t l_count = left_block.Count();
 	const idx_t r_count = right_block.Count();
 	// Initialize left and right reader
-	left = make_unique<SortedBlockReadState>(buffer_manager, state);
-	right = make_unique<SortedBlockReadState>(buffer_manager, state);
+	left = make_unique<SBScanState>(buffer_manager, state);
+	right = make_unique<SBScanState>(buffer_manager, state);
 	// Compute the work that this thread must do using Merge Path
 	idx_t l_end;
 	idx_t r_end;
@@ -109,8 +109,8 @@ void MergeSorter::GetNextPartition() {
 		r_end = r_count;
 	}
 	// Create slices of the data that this thread must merge
-	left->ResetIndices(0, 0);
-	right->ResetIndices(0, 0);
+	left->SetIndices(0, 0);
+	right->SetIndices(0, 0);
 	left_input = left_block.CreateSlice(state.l_start, l_end, left->entry_idx);
 	right_input = right_block.CreateSlice(state.r_start, r_end, right->entry_idx);
 	left->sb = left_input.get();
@@ -130,8 +130,7 @@ void MergeSorter::GetNextPartition() {
 	}
 }
 
-int MergeSorter::CompareUsingGlobalIndex(SortedBlockReadState &l, SortedBlockReadState &r, const idx_t l_idx,
-                                         const idx_t r_idx) {
+int MergeSorter::CompareUsingGlobalIndex(SBScanState &l, SBScanState &r, const idx_t l_idx, const idx_t r_idx) {
 	D_ASSERT(l_idx < l.sb->Count());
 	D_ASSERT(r_idx < r.sb->Count());
 
@@ -320,8 +319,8 @@ void MergeSorter::ComputeMerge(const idx_t &count, bool left_smaller[]) {
 		}
 	}
 	// Reset block indices
-	left->ResetIndices(l_block_idx_before, l_entry_idx_before);
-	right->ResetIndices(r_block_idx_before, r_entry_idx_before);
+	left->SetIndices(l_block_idx_before, l_entry_idx_before);
+	right->SetIndices(r_block_idx_before, r_entry_idx_before);
 }
 
 void MergeSorter::MergeRadix(const idx_t &count, const bool left_smaller[]) {
@@ -391,8 +390,8 @@ void MergeSorter::MergeRadix(const idx_t &count, const bool left_smaller[]) {
 		}
 	}
 	// Reset block indices
-	left->ResetIndices(l_block_idx_before, l_entry_idx_before);
-	right->ResetIndices(r_block_idx_before, r_entry_idx_before);
+	left->SetIndices(l_block_idx_before, l_entry_idx_before);
+	right->SetIndices(r_block_idx_before, r_entry_idx_before);
 }
 
 void MergeSorter::MergeData(SortedData &result_data, SortedData &l_data, SortedData &r_data, const idx_t &count,
@@ -565,8 +564,8 @@ void MergeSorter::MergeData(SortedData &result_data, SortedData &l_data, SortedD
 		}
 	}
 	if (reset_indices) {
-		left->ResetIndices(l_block_idx_before, l_entry_idx_before);
-		right->ResetIndices(r_block_idx_before, r_entry_idx_before);
+		left->SetIndices(l_block_idx_before, l_entry_idx_before);
+		right->SetIndices(r_block_idx_before, r_entry_idx_before);
 	}
 }
 

--- a/src/common/sort/merge_sorter.cpp
+++ b/src/common/sort/merge_sorter.cpp
@@ -22,21 +22,23 @@ void MergeSorter::PerformInMergeRound() {
 }
 
 void MergeSorter::MergePartition() {
-	auto &left = *left_block;
-	auto &right = *right_block;
+	auto &left_block = *left->sb;
+	auto &right_block = *right->sb;
 #ifdef DEBUG
-	D_ASSERT(left.radix_sorting_data.size() == left.payload_data->data_blocks.size());
-	D_ASSERT(right.radix_sorting_data.size() == right.payload_data->data_blocks.size());
+	D_ASSERT(left_block.radix_sorting_data.size() == left_block.payload_data->data_blocks.size());
+	D_ASSERT(right_block.radix_sorting_data.size() == right_block.payload_data->data_blocks.size());
 	if (!state.payload_layout.AllConstant() && state.external) {
-		D_ASSERT(left.payload_data->data_blocks.size() == left.payload_data->heap_blocks.size());
-		D_ASSERT(right.payload_data->data_blocks.size() == right.payload_data->heap_blocks.size());
+		D_ASSERT(left_block.payload_data->data_blocks.size() == left_block.payload_data->heap_blocks.size());
+		D_ASSERT(right_block.payload_data->data_blocks.size() == right_block.payload_data->heap_blocks.size());
 	}
 	if (!sort_layout.all_constant) {
-		D_ASSERT(left.radix_sorting_data.size() == left.blob_sorting_data->data_blocks.size());
-		D_ASSERT(right.radix_sorting_data.size() == right.blob_sorting_data->data_blocks.size());
+		D_ASSERT(left_block.radix_sorting_data.size() == left_block.blob_sorting_data->data_blocks.size());
+		D_ASSERT(right_block.radix_sorting_data.size() == right_block.blob_sorting_data->data_blocks.size());
 		if (state.external) {
-			D_ASSERT(left.blob_sorting_data->data_blocks.size() == left.blob_sorting_data->heap_blocks.size());
-			D_ASSERT(right.blob_sorting_data->data_blocks.size() == right.blob_sorting_data->heap_blocks.size());
+			D_ASSERT(left_block.blob_sorting_data->data_blocks.size() ==
+			         left_block.blob_sorting_data->heap_blocks.size());
+			D_ASSERT(right_block.blob_sorting_data->data_blocks.size() ==
+			         right_block.blob_sorting_data->heap_blocks.size());
 		}
 	}
 #endif
@@ -48,12 +50,12 @@ void MergeSorter::MergePartition() {
 	idx_t next_entry_sizes[STANDARD_VECTOR_SIZE];
 	// Merge loop
 #ifdef DEBUG
-	auto l_count = left.Remaining();
-	auto r_count = right.Remaining();
+	auto l_count = left->Remaining();
+	auto r_count = right->Remaining();
 #endif
 	while (true) {
-		auto l_remaining = left.Remaining();
-		auto r_remaining = right.Remaining();
+		auto l_remaining = left->Remaining();
+		auto r_remaining = right->Remaining();
 		if (l_remaining + r_remaining == 0) {
 			// Done
 			break;
@@ -66,17 +68,12 @@ void MergeSorter::MergePartition() {
 		// Actually merge the data (radix, blob, and payload)
 		MergeRadix(next, left_smaller);
 		if (!sort_layout.all_constant) {
-			MergeData(*result->blob_sorting_data, *left.blob_sorting_data, *right.blob_sorting_data, next, left_smaller,
-			          next_entry_sizes);
-			D_ASSERT(left.block_idx == left.blob_sorting_data->block_idx &&
-			         left.entry_idx == left.blob_sorting_data->entry_idx);
-			D_ASSERT(right.block_idx == right.blob_sorting_data->block_idx &&
-			         right.entry_idx == right.blob_sorting_data->entry_idx);
+			MergeData(*result->blob_sorting_data, *left_block.blob_sorting_data, *right_block.blob_sorting_data, next,
+			          left_smaller, next_entry_sizes, true);
 			D_ASSERT(result->radix_sorting_data.size() == result->blob_sorting_data->data_blocks.size());
 		}
-		MergeData(*result->payload_data, *left.payload_data, *right.payload_data, next, left_smaller, next_entry_sizes);
-		D_ASSERT(left.block_idx == left.payload_data->block_idx && left.entry_idx == left.payload_data->entry_idx);
-		D_ASSERT(right.block_idx == right.payload_data->block_idx && right.entry_idx == right.payload_data->entry_idx);
+		MergeData(*result->payload_data, *left_block.payload_data, *right_block.payload_data, next, left_smaller,
+		          next_entry_sizes, false);
 		D_ASSERT(result->radix_sorting_data.size() == result->payload_data->data_blocks.size());
 	}
 #ifdef DEBUG
@@ -89,34 +86,39 @@ void MergeSorter::GetNextPartition() {
 	state.sorted_blocks_temp[state.pair_idx].push_back(make_unique<SortedBlock>(buffer_manager, state));
 	result = state.sorted_blocks_temp[state.pair_idx].back().get();
 	// Determine which blocks must be merged
-	auto &left = *state.sorted_blocks[state.pair_idx * 2];
-	auto &right = *state.sorted_blocks[state.pair_idx * 2 + 1];
-	const idx_t l_count = left.Count();
-	const idx_t r_count = right.Count();
+	auto &left_block = *state.sorted_blocks[state.pair_idx * 2];
+	auto &right_block = *state.sorted_blocks[state.pair_idx * 2 + 1];
+	const idx_t l_count = left_block.Count();
+	const idx_t r_count = right_block.Count();
+	// Initialize left and right reader
+	left = make_unique<SortedBlockReadState>(buffer_manager, state);
+	right = make_unique<SortedBlockReadState>(buffer_manager, state);
 	// Compute the work that this thread must do using Merge Path
 	idx_t l_end;
 	idx_t r_end;
 	if (state.l_start + state.r_start + state.block_capacity < l_count + r_count) {
+		left->sb = state.sorted_blocks[state.pair_idx * 2].get();
+		right->sb = state.sorted_blocks[state.pair_idx * 2 + 1].get();
 		const idx_t intersection = state.l_start + state.r_start + state.block_capacity;
-		GetIntersection(left, right, intersection, l_end, r_end);
+		GetIntersection(intersection, l_end, r_end);
 		D_ASSERT(l_end <= l_count);
 		D_ASSERT(r_end <= r_count);
 		D_ASSERT(intersection == l_end + r_end);
-		// Unpin after finding the intersection
-		if (!sort_layout.blob_layout.AllConstant()) {
-			left.blob_sorting_data->ResetIndices(0, 0);
-			right.blob_sorting_data->ResetIndices(0, 0);
-		}
 	} else {
 		l_end = l_count;
 		r_end = r_count;
 	}
 	// Create slices of the data that this thread must merge
-	left_block = left.CreateSlice(state.l_start, l_end);
-	right_block = right.CreateSlice(state.r_start, r_end);
-	// Update global state
+	left->ResetIndices(0, 0);
+	right->ResetIndices(0, 0);
+	left_input = left_block.CreateSlice(state.l_start, l_end, left->entry_idx);
+	right_input = right_block.CreateSlice(state.r_start, r_end, right->entry_idx);
+	left->sb = left_input.get();
+	right->sb = right_input.get();
 	state.l_start = l_end;
 	state.r_start = r_end;
+	D_ASSERT(left->Remaining() + right->Remaining() == state.block_capacity || (l_end == l_count && r_end == r_count));
+	// Update global state
 	if (state.l_start == l_count && state.r_start == r_count) {
 		// Delete references to previous pair
 		state.sorted_blocks[state.pair_idx * 2] = nullptr;
@@ -128,9 +130,10 @@ void MergeSorter::GetNextPartition() {
 	}
 }
 
-int MergeSorter::CompareUsingGlobalIndex(SortedBlock &l, SortedBlock &r, const idx_t l_idx, const idx_t r_idx) {
-	D_ASSERT(l_idx < l.Count());
-	D_ASSERT(r_idx < r.Count());
+int MergeSorter::CompareUsingGlobalIndex(SortedBlockReadState &l, SortedBlockReadState &r, const idx_t l_idx,
+                                         const idx_t r_idx) {
+	D_ASSERT(l_idx < l.sb->Count());
+	D_ASSERT(r_idx < r.sb->Count());
 
 	// Easy comparison using the previous result (intersections must increase monotonically)
 	if (l_idx < state.l_start) {
@@ -140,37 +143,28 @@ int MergeSorter::CompareUsingGlobalIndex(SortedBlock &l, SortedBlock &r, const i
 		return 1;
 	}
 
-	idx_t l_block_idx;
-	idx_t l_entry_idx;
-	l.GlobalToLocalIndex(l_idx, l_block_idx, l_entry_idx);
+	l.sb->GlobalToLocalIndex(l_idx, l.block_idx, l.entry_idx);
+	r.sb->GlobalToLocalIndex(r_idx, r.block_idx, r.entry_idx);
 
-	idx_t r_block_idx;
-	idx_t r_entry_idx;
-	r.GlobalToLocalIndex(r_idx, r_block_idx, r_entry_idx);
-
-	l.PinRadix(l_block_idx);
-	r.PinRadix(r_block_idx);
-	data_ptr_t l_ptr = l.radix_handle->Ptr() + l_entry_idx * sort_layout.entry_size;
-	data_ptr_t r_ptr = r.radix_handle->Ptr() + r_entry_idx * sort_layout.entry_size;
+	l.PinRadix(l.block_idx);
+	r.PinRadix(r.block_idx);
+	data_ptr_t l_ptr = l.radix_handle->Ptr() + l.entry_idx * sort_layout.entry_size;
+	data_ptr_t r_ptr = r.radix_handle->Ptr() + r.entry_idx * sort_layout.entry_size;
 
 	int comp_res;
 	if (sort_layout.all_constant) {
 		comp_res = FastMemcmp(l_ptr, r_ptr, sort_layout.comparison_size);
 	} else {
-		l.blob_sorting_data->block_idx = l_block_idx;
-		l.blob_sorting_data->entry_idx = l_entry_idx;
-		l.blob_sorting_data->Pin();
-		r.blob_sorting_data->block_idx = r_block_idx;
-		r.blob_sorting_data->entry_idx = r_entry_idx;
-		r.blob_sorting_data->Pin();
+		l.PinData(*l.sb->blob_sorting_data);
+		r.PinData(*r.sb->blob_sorting_data);
 		comp_res = Comparators::CompareTuple(l, r, l_ptr, r_ptr, sort_layout, state.external);
 	}
 	return comp_res;
 }
 
-void MergeSorter::GetIntersection(SortedBlock &l, SortedBlock &r, const idx_t diagonal, idx_t &l_idx, idx_t &r_idx) {
-	const idx_t l_count = l.Count();
-	const idx_t r_count = r.Count();
+void MergeSorter::GetIntersection(const idx_t diagonal, idx_t &l_idx, idx_t &r_idx) {
+	const idx_t l_count = left->sb->Count();
+	const idx_t r_count = right->sb->Count();
 	// Cover some edge cases
 	// Code coverage off because these edge cases cannot happen unless other code changes
 	// Edge cases have been tested extensively while developing Merge Path in a script
@@ -200,16 +194,16 @@ void MergeSorter::GetIntersection(SortedBlock &l, SortedBlock &r, const idx_t di
 	const idx_t search_space = diagonal > MaxValue(l_count, r_count) ? l_count + r_count - diagonal
 	                                                                 : MinValue(diagonal, MinValue(l_count, r_count));
 	// Double binary search
-	idx_t left = 0;
-	idx_t right = search_space - 1;
+	idx_t li = 0;
+	idx_t ri = search_space - 1;
 	idx_t middle;
 	int comp_res;
-	while (left <= right) {
-		middle = (left + right) / 2;
+	while (li <= ri) {
+		middle = (li + ri) / 2;
 		l_idx = l_offset - middle;
 		r_idx = r_offset + middle;
 		if (l_idx == l_count || r_idx == 0) {
-			comp_res = CompareUsingGlobalIndex(l, r, l_idx - 1, r_idx);
+			comp_res = CompareUsingGlobalIndex(*left, *right, l_idx - 1, r_idx);
 			if (comp_res > 0) {
 				l_idx--;
 				r_idx++;
@@ -226,15 +220,15 @@ void MergeSorter::GetIntersection(SortedBlock &l, SortedBlock &r, const idx_t di
 				break;
 			}
 		}
-		comp_res = CompareUsingGlobalIndex(l, r, l_idx, r_idx);
+		comp_res = CompareUsingGlobalIndex(*left, *right, l_idx, r_idx);
 		if (comp_res > 0) {
-			left = middle + 1;
+			li = middle + 1;
 		} else {
-			right = middle - 1;
+			ri = middle - 1;
 		}
 	}
-	int l_r_min1 = CompareUsingGlobalIndex(l, r, l_idx, r_idx - 1);
-	int l_min1_r = CompareUsingGlobalIndex(l, r, l_idx - 1, r_idx);
+	int l_r_min1 = CompareUsingGlobalIndex(*left, *right, l_idx, r_idx - 1);
+	int l_min1_r = CompareUsingGlobalIndex(*left, *right, l_idx - 1, r_idx);
 	if (l_r_min1 > 0 && l_min1_r < 0) {
 		return;
 	} else if (l_r_min1 > 0) {
@@ -247,13 +241,15 @@ void MergeSorter::GetIntersection(SortedBlock &l, SortedBlock &r, const idx_t di
 }
 
 void MergeSorter::ComputeMerge(const idx_t &count, bool left_smaller[]) {
-	auto &left = *left_block;
-	auto &right = *right_block;
-	// Store indices to restore after computing the merge
-	idx_t l_block_idx = left.block_idx;
-	idx_t r_block_idx = right.block_idx;
-	idx_t l_entry_idx = left.entry_idx;
-	idx_t r_entry_idx = right.entry_idx;
+	auto &l = *left;
+	auto &r = *right;
+	auto &l_sorted_block = *l.sb;
+	auto &r_sorted_block = *r.sb;
+	// Save indices to restore afterwards
+	idx_t l_block_idx_before = l.block_idx;
+	idx_t l_entry_idx_before = l.entry_idx;
+	idx_t r_block_idx_before = r.block_idx;
+	idx_t r_entry_idx_before = r.entry_idx;
 	// Data pointers for both sides
 	data_ptr_t l_radix_ptr;
 	data_ptr_t r_radix_ptr;
@@ -261,91 +257,84 @@ void MergeSorter::ComputeMerge(const idx_t &count, bool left_smaller[]) {
 	idx_t compared = 0;
 	while (compared < count) {
 		// Move to the next block (if needed)
-		if (l_block_idx < left.radix_sorting_data.size() && l_entry_idx == left.radix_sorting_data[l_block_idx].count) {
-			l_block_idx++;
-			l_entry_idx = 0;
-			if (!sort_layout.all_constant) {
-				left.blob_sorting_data->block_idx = l_block_idx;
-				left.blob_sorting_data->entry_idx = l_entry_idx;
-			}
+		if (l.block_idx < l_sorted_block.radix_sorting_data.size() &&
+		    l.entry_idx == l_sorted_block.radix_sorting_data[l.block_idx].count) {
+			l.block_idx++;
+			l.entry_idx = 0;
 		}
-		if (r_block_idx < right.radix_sorting_data.size() &&
-		    r_entry_idx == right.radix_sorting_data[r_block_idx].count) {
-			r_block_idx++;
-			r_entry_idx = 0;
-			if (!sort_layout.all_constant) {
-				right.blob_sorting_data->block_idx = r_block_idx;
-				right.blob_sorting_data->entry_idx = r_entry_idx;
-			}
+		if (r.block_idx < r_sorted_block.radix_sorting_data.size() &&
+		    r.entry_idx == r_sorted_block.radix_sorting_data[r.block_idx].count) {
+			r.block_idx++;
+			r.entry_idx = 0;
 		}
-		const bool l_done = l_block_idx == left.radix_sorting_data.size();
-		const bool r_done = r_block_idx == right.radix_sorting_data.size();
+		const bool l_done = l.block_idx == l_sorted_block.radix_sorting_data.size();
+		const bool r_done = r.block_idx == r_sorted_block.radix_sorting_data.size();
 		if (l_done || r_done) {
 			// One of the sides is exhausted, no need to compare
 			break;
 		}
 		// Pin the radix sorting data
 		if (!l_done) {
-			left.PinRadix(l_block_idx);
-			l_radix_ptr = left.radix_handle->Ptr() + l_entry_idx * sort_layout.entry_size;
+			left->PinRadix(l.block_idx);
+			l_radix_ptr = left->RadixPtr();
 		}
 		if (!r_done) {
-			right.PinRadix(r_block_idx);
-			r_radix_ptr = right.radix_handle->Ptr() + r_entry_idx * sort_layout.entry_size;
+			right->PinRadix(r.block_idx);
+			r_radix_ptr = right->RadixPtr();
 		}
-		const idx_t &l_count = !l_done ? left.radix_sorting_data[l_block_idx].count : 0;
-		const idx_t &r_count = !r_done ? right.radix_sorting_data[r_block_idx].count : 0;
+		const idx_t &l_count = !l_done ? l_sorted_block.radix_sorting_data[l.block_idx].count : 0;
+		const idx_t &r_count = !r_done ? r_sorted_block.radix_sorting_data[r.block_idx].count : 0;
 		// Compute the merge
 		if (sort_layout.all_constant) {
 			// All sorting columns are constant size
-			for (; compared < count && l_entry_idx < l_count && r_entry_idx < r_count; compared++) {
+			for (; compared < count && l.entry_idx < l_count && r.entry_idx < r_count; compared++) {
 				left_smaller[compared] = FastMemcmp(l_radix_ptr, r_radix_ptr, sort_layout.comparison_size) < 0;
 				const bool &l_smaller = left_smaller[compared];
 				const bool r_smaller = !l_smaller;
 				// Use comparison bool (0 or 1) to increment entries and pointers
-				l_entry_idx += l_smaller;
-				r_entry_idx += r_smaller;
+				l.entry_idx += l_smaller;
+				r.entry_idx += r_smaller;
 				l_radix_ptr += l_smaller * sort_layout.entry_size;
 				r_radix_ptr += r_smaller * sort_layout.entry_size;
 			}
 		} else {
 			// Pin the blob data
 			if (!l_done) {
-				left.blob_sorting_data->Pin();
+				left->PinData(*l_sorted_block.blob_sorting_data);
 			}
 			if (!r_done) {
-				right.blob_sorting_data->Pin();
+				right->PinData(*r_sorted_block.blob_sorting_data);
 			}
 			// Merge with variable size sorting columns
-			for (; compared < count && l_entry_idx < l_count && r_entry_idx < r_count; compared++) {
-				D_ASSERT(l_block_idx == left.blob_sorting_data->block_idx &&
-				         l_entry_idx == left.blob_sorting_data->entry_idx);
-				D_ASSERT(r_block_idx == right.blob_sorting_data->block_idx &&
-				         r_entry_idx == right.blob_sorting_data->entry_idx);
+			for (; compared < count && l.entry_idx < l_count && r.entry_idx < r_count; compared++) {
 				left_smaller[compared] =
-				    Comparators::CompareTuple(left, right, l_radix_ptr, r_radix_ptr, sort_layout, state.external) < 0;
+				    Comparators::CompareTuple(*left, *right, l_radix_ptr, r_radix_ptr, sort_layout, state.external) < 0;
 				const bool &l_smaller = left_smaller[compared];
 				const bool r_smaller = !l_smaller;
 				// Use comparison bool (0 or 1) to increment entries and pointers
-				l_entry_idx += l_smaller;
-				r_entry_idx += r_smaller;
+				l.entry_idx += l_smaller;
+				r.entry_idx += r_smaller;
 				l_radix_ptr += l_smaller * sort_layout.entry_size;
 				r_radix_ptr += r_smaller * sort_layout.entry_size;
-				left.blob_sorting_data->Advance(l_smaller);
-				right.blob_sorting_data->Advance(r_smaller);
 			}
 		}
 	}
-	// Reset block indices before the actual merge
-	if (!sort_layout.all_constant) {
-		left.blob_sorting_data->ResetIndices(left.block_idx, left.entry_idx);
-		right.blob_sorting_data->ResetIndices(right.block_idx, right.entry_idx);
-	}
+	// Reset block indices
+	left->ResetIndices(l_block_idx_before, l_entry_idx_before);
+	right->ResetIndices(r_block_idx_before, r_entry_idx_before);
 }
 
 void MergeSorter::MergeRadix(const idx_t &count, const bool left_smaller[]) {
-	auto &left = *left_block;
-	auto &right = *right_block;
+	auto &l = *left;
+	auto &r = *right;
+	// Save indices to restore afterwards
+	idx_t l_block_idx_before = l.block_idx;
+	idx_t l_entry_idx_before = l.entry_idx;
+	idx_t r_block_idx_before = r.block_idx;
+	idx_t r_entry_idx_before = r.entry_idx;
+
+	auto &l_blocks = l.sb->radix_sorting_data;
+	auto &r_blocks = r.sb->radix_sorting_data;
 	RowDataBlock *l_block;
 	RowDataBlock *r_block;
 
@@ -359,54 +348,63 @@ void MergeSorter::MergeRadix(const idx_t &count, const bool left_smaller[]) {
 	idx_t copied = 0;
 	while (copied < count) {
 		// Move to the next block (if needed)
-		if (left.block_idx < left.radix_sorting_data.size() &&
-		    left.entry_idx == left.radix_sorting_data[left.block_idx].count) {
+		if (l.block_idx < l_blocks.size() && l.entry_idx == l_blocks[l.block_idx].count) {
 			// Delete reference to previous block
-			left.radix_sorting_data[left.block_idx].block = nullptr;
+			l_blocks[l.block_idx].block = nullptr;
 			// Advance block
-			left.block_idx++;
-			left.entry_idx = 0;
+			l.block_idx++;
+			l.entry_idx = 0;
 		}
-		if (right.block_idx < right.radix_sorting_data.size() &&
-		    right.entry_idx == right.radix_sorting_data[right.block_idx].count) {
+		if (r.block_idx < r_blocks.size() && r.entry_idx == r_blocks[r.block_idx].count) {
 			// Delete reference to previous block
-			right.radix_sorting_data[right.block_idx].block = nullptr;
+			r_blocks[r.block_idx].block = nullptr;
 			// Advance block
-			right.block_idx++;
-			right.entry_idx = 0;
+			r.block_idx++;
+			r.entry_idx = 0;
 		}
-		const bool l_done = left.block_idx == left.radix_sorting_data.size();
-		const bool r_done = right.block_idx == right.radix_sorting_data.size();
+		const bool l_done = l.block_idx == l_blocks.size();
+		const bool r_done = r.block_idx == r_blocks.size();
 		// Pin the radix sortable blocks
 		if (!l_done) {
-			l_block = &left.radix_sorting_data[left.block_idx];
-			left.PinRadix(left.block_idx);
-			l_ptr = left.radix_handle->Ptr() + left.entry_idx * sort_layout.entry_size;
+			l_block = &l_blocks[l.block_idx];
+			left->PinRadix(l.block_idx);
+			l_ptr = l.RadixPtr();
 		}
 		if (!r_done) {
-			r_block = &right.radix_sorting_data[right.block_idx];
-			right.PinRadix(right.block_idx);
-			r_ptr = right.radix_handle->Ptr() + right.entry_idx * sort_layout.entry_size;
+			r_block = &r_blocks[r.block_idx];
+			r.PinRadix(r.block_idx);
+			r_ptr = r.RadixPtr();
 		}
 		const idx_t &l_count = !l_done ? l_block->count : 0;
 		const idx_t &r_count = !r_done ? r_block->count : 0;
 		// Copy using computed merge
 		if (!l_done && !r_done) {
 			// Both sides have data - merge
-			MergeRows(l_ptr, left.entry_idx, l_count, r_ptr, right.entry_idx, r_count, result_block, result_ptr,
+			MergeRows(l_ptr, l.entry_idx, l_count, r_ptr, r.entry_idx, r_count, result_block, result_ptr,
 			          sort_layout.entry_size, left_smaller, copied, count);
 		} else if (r_done) {
 			// Right side is exhausted
-			FlushRows(l_ptr, left.entry_idx, l_count, result_block, result_ptr, sort_layout.entry_size, copied, count);
+			FlushRows(l_ptr, l.entry_idx, l_count, result_block, result_ptr, sort_layout.entry_size, copied, count);
 		} else {
 			// Left side is exhausted
-			FlushRows(r_ptr, right.entry_idx, r_count, result_block, result_ptr, sort_layout.entry_size, copied, count);
+			FlushRows(r_ptr, r.entry_idx, r_count, result_block, result_ptr, sort_layout.entry_size, copied, count);
 		}
 	}
+	// Reset block indices
+	left->ResetIndices(l_block_idx_before, l_entry_idx_before);
+	right->ResetIndices(r_block_idx_before, r_entry_idx_before);
 }
 
 void MergeSorter::MergeData(SortedData &result_data, SortedData &l_data, SortedData &r_data, const idx_t &count,
-                            const bool left_smaller[], idx_t next_entry_sizes[]) {
+                            const bool left_smaller[], idx_t next_entry_sizes[], bool reset_indices) {
+	auto &l = *left;
+	auto &r = *right;
+	// Save indices to restore afterwards
+	idx_t l_block_idx_before = l.block_idx;
+	idx_t l_entry_idx_before = l.entry_idx;
+	idx_t r_block_idx_before = r.block_idx;
+	idx_t r_entry_idx_before = r.entry_idx;
+
 	const auto &layout = result_data.layout;
 	const idx_t row_width = layout.GetRowWidth();
 	const idx_t heap_pointer_offset = layout.GetHeapPointerOffset();
@@ -435,76 +433,70 @@ void MergeSorter::MergeData(SortedData &result_data, SortedData &l_data, SortedD
 	idx_t copied = 0;
 	while (copied < count) {
 		// Move to new data blocks (if needed)
-		if (l_data.block_idx < l_data.data_blocks.size() &&
-		    l_data.entry_idx == l_data.data_blocks[l_data.block_idx].count) {
+		if (l.block_idx < l_data.data_blocks.size() && l.entry_idx == l_data.data_blocks[l.block_idx].count) {
 			// Delete reference to previous block
-			l_data.data_blocks[l_data.block_idx].block = nullptr;
+			l_data.data_blocks[l.block_idx].block = nullptr;
 			if (!layout.AllConstant() && state.external) {
-				l_data.heap_blocks[l_data.block_idx].block = nullptr;
+				l_data.heap_blocks[l.block_idx].block = nullptr;
 			}
 			// Advance block
-			l_data.block_idx++;
-			l_data.entry_idx = 0;
+			l.block_idx++;
+			l.entry_idx = 0;
 		}
-		if (r_data.block_idx < r_data.data_blocks.size() &&
-		    r_data.entry_idx == r_data.data_blocks[r_data.block_idx].count) {
+		if (r.block_idx < r_data.data_blocks.size() && r.entry_idx == r_data.data_blocks[r.block_idx].count) {
 			// Delete reference to previous block
-			r_data.data_blocks[r_data.block_idx].block = nullptr;
+			r_data.data_blocks[r.block_idx].block = nullptr;
 			if (!layout.AllConstant() && state.external) {
-				r_data.heap_blocks[r_data.block_idx].block = nullptr;
+				r_data.heap_blocks[r.block_idx].block = nullptr;
 			}
 			// Advance block
-			r_data.block_idx++;
-			r_data.entry_idx = 0;
+			r.block_idx++;
+			r.entry_idx = 0;
 		}
-		const bool l_done = l_data.block_idx == l_data.data_blocks.size();
-		const bool r_done = r_data.block_idx == r_data.data_blocks.size();
+		const bool l_done = l.block_idx == l_data.data_blocks.size();
+		const bool r_done = r.block_idx == r_data.data_blocks.size();
 		// Pin the row data blocks
 		if (!l_done) {
-			l_data.Pin();
-			l_ptr = l_data.data_handle->Ptr() + l_data.entry_idx * row_width;
+			l.PinData(l_data);
+			l_ptr = l.DataPtr(l_data);
 		}
 		if (!r_done) {
-			r_data.Pin();
-			r_ptr = r_data.data_handle->Ptr() + r_data.entry_idx * row_width;
+			r.PinData(r_data);
+			r_ptr = r.DataPtr(r_data);
 		}
-		const idx_t &l_count = !l_done ? l_data.data_blocks[l_data.block_idx].count : 0;
-		const idx_t &r_count = !r_done ? r_data.data_blocks[r_data.block_idx].count : 0;
+		const idx_t &l_count = !l_done ? l_data.data_blocks[l.block_idx].count : 0;
+		const idx_t &r_count = !r_done ? r_data.data_blocks[r.block_idx].count : 0;
 		// Perform the merge
 		if (layout.AllConstant() || !state.external) {
 			// If all constant size, or if we are doing an in-memory sort, we do not need to touch the heap
 			if (!l_done && !r_done) {
 				// Both sides have data - merge
-				MergeRows(l_ptr, l_data.entry_idx, l_count, r_ptr, r_data.entry_idx, r_count, result_data_block,
-				          result_data_ptr, row_width, left_smaller, copied, count);
+				MergeRows(l_ptr, l.entry_idx, l_count, r_ptr, r.entry_idx, r_count, result_data_block, result_data_ptr,
+				          row_width, left_smaller, copied, count);
 			} else if (r_done) {
 				// Right side is exhausted
-				FlushRows(l_ptr, l_data.entry_idx, l_count, result_data_block, result_data_ptr, row_width, copied,
-				          count);
+				FlushRows(l_ptr, l.entry_idx, l_count, result_data_block, result_data_ptr, row_width, copied, count);
 			} else {
 				// Left side is exhausted
-				FlushRows(r_ptr, r_data.entry_idx, r_count, result_data_block, result_data_ptr, row_width, copied,
-				          count);
+				FlushRows(r_ptr, r.entry_idx, r_count, result_data_block, result_data_ptr, row_width, copied, count);
 			}
 		} else {
 			// External sorting with variable size data. Pin the heap blocks too
 			if (!l_done) {
-				l_heap_ptr = l_data.heap_handle->Ptr() + Load<idx_t>(l_ptr + heap_pointer_offset);
-				D_ASSERT(l_heap_ptr - l_data.heap_handle->Ptr() >= 0);
-				D_ASSERT((idx_t)(l_heap_ptr - l_data.heap_handle->Ptr()) <
-				         l_data.heap_blocks[l_data.block_idx].byte_offset);
+				l_heap_ptr = l.BaseHeapPtr(l_data) + Load<idx_t>(l_ptr + heap_pointer_offset);
+				D_ASSERT(l_heap_ptr - l.BaseHeapPtr(l_data) >= 0);
+				D_ASSERT((idx_t)(l_heap_ptr - l.BaseHeapPtr(l_data)) < l_data.heap_blocks[l.block_idx].byte_offset);
 			}
 			if (!r_done) {
-				r_heap_ptr = r_data.heap_handle->Ptr() + Load<idx_t>(r_ptr + heap_pointer_offset);
-				D_ASSERT(r_heap_ptr - r_data.heap_handle->Ptr() >= 0);
-				D_ASSERT((idx_t)(r_heap_ptr - r_data.heap_handle->Ptr()) <
-				         r_data.heap_blocks[r_data.block_idx].byte_offset);
+				r_heap_ptr = r.BaseHeapPtr(r_data) + Load<idx_t>(r_ptr + heap_pointer_offset);
+				D_ASSERT(r_heap_ptr - r.BaseHeapPtr(r_data) >= 0);
+				D_ASSERT((idx_t)(r_heap_ptr - r.BaseHeapPtr(r_data)) < r_data.heap_blocks[r.block_idx].byte_offset);
 			}
 			// Both the row and heap data need to be dealt with
 			if (!l_done && !r_done) {
 				// Both sides have data - merge
-				idx_t l_idx_copy = l_data.entry_idx;
-				idx_t r_idx_copy = r_data.entry_idx;
+				idx_t l_idx_copy = l.entry_idx;
+				idx_t r_idx_copy = r.entry_idx;
 				data_ptr_t result_data_ptr_copy = result_data_ptr;
 				idx_t copied_copy = copied;
 				// Merge row data
@@ -526,10 +518,10 @@ void MergeSorter::MergeData(SortedData &result_data, SortedData &l_data, SortedD
 					entry_size =
 					    l_smaller * Load<uint32_t>(l_heap_ptr_copy) + r_smaller * Load<uint32_t>(r_heap_ptr_copy);
 					D_ASSERT(entry_size >= sizeof(uint32_t));
-					D_ASSERT(l_heap_ptr_copy - l_data.heap_handle->Ptr() + l_smaller * entry_size <=
-					         l_data.heap_blocks[l_data.block_idx].byte_offset);
-					D_ASSERT(r_heap_ptr_copy - r_data.heap_handle->Ptr() + r_smaller * entry_size <=
-					         r_data.heap_blocks[r_data.block_idx].byte_offset);
+					D_ASSERT(l_heap_ptr_copy - l.BaseHeapPtr(l_data) + l_smaller * entry_size <=
+					         l_data.heap_blocks[l.block_idx].byte_offset);
+					D_ASSERT(r_heap_ptr_copy - r.BaseHeapPtr(r_data) + r_smaller * entry_size <=
+					         r_data.heap_blocks[r.block_idx].byte_offset);
 					l_heap_ptr_copy += l_smaller * entry_size;
 					r_heap_ptr_copy += r_smaller * entry_size;
 					copy_bytes += entry_size;
@@ -553,8 +545,8 @@ void MergeSorter::MergeData(SortedData &result_data, SortedData &l_data, SortedD
 					result_heap_ptr += entry_size;
 					l_heap_ptr += l_smaller * entry_size;
 					r_heap_ptr += r_smaller * entry_size;
-					l_data.entry_idx += l_smaller;
-					r_data.entry_idx += r_smaller;
+					l.entry_idx += l_smaller;
+					r.entry_idx += r_smaller;
 				}
 				// Update result indices and pointers
 				result_heap_block->count += merged;
@@ -562,15 +554,19 @@ void MergeSorter::MergeData(SortedData &result_data, SortedData &l_data, SortedD
 				copied += merged;
 			} else if (r_done) {
 				// Right side is exhausted - flush left
-				FlushBlobs(layout, l_count, l_ptr, l_data.entry_idx, l_heap_ptr, result_data_block, result_data_ptr,
+				FlushBlobs(layout, l_count, l_ptr, l.entry_idx, l_heap_ptr, result_data_block, result_data_ptr,
 				           result_heap_block, *result_heap_handle, result_heap_ptr, copied, count);
 			} else {
 				// Left side is exhausted - flush right
-				FlushBlobs(layout, r_count, r_ptr, r_data.entry_idx, r_heap_ptr, result_data_block, result_data_ptr,
+				FlushBlobs(layout, r_count, r_ptr, r.entry_idx, r_heap_ptr, result_data_block, result_data_ptr,
 				           result_heap_block, *result_heap_handle, result_heap_ptr, copied, count);
 			}
 			D_ASSERT(result_data_block->count == result_heap_block->count);
 		}
+	}
+	if (reset_indices) {
+		left->ResetIndices(l_block_idx_before, l_entry_idx_before);
+		right->ResetIndices(r_block_idx_before, r_entry_idx_before);
 	}
 }
 

--- a/src/common/sort/sorted_block.cpp
+++ b/src/common/sort/sorted_block.cpp
@@ -8,8 +8,9 @@
 
 namespace duckdb {
 
-SortedData::SortedData(const RowLayout &layout, BufferManager &buffer_manager, GlobalSortState &state)
-    : layout(layout), block_idx(0), entry_idx(0), swizzled(false), buffer_manager(buffer_manager), state(state) {
+SortedData::SortedData(SortedDataType type, const RowLayout &layout, BufferManager &buffer_manager,
+                       GlobalSortState &state)
+    : type(type), layout(layout), swizzled(false), buffer_manager(buffer_manager), state(state) {
 }
 
 idx_t SortedData::Count() {
@@ -22,37 +23,6 @@ idx_t SortedData::Count() {
 	return count;
 }
 
-void SortedData::Pin() {
-	PinData();
-	if (!layout.AllConstant() && state.external) {
-		PinHeap();
-	}
-}
-
-data_ptr_t SortedData::DataPtr() const {
-	D_ASSERT(data_blocks[block_idx].block->Readers() != 0 &&
-	         data_handle->handle->BlockId() == data_blocks[block_idx].block->BlockId());
-	return data_ptr + entry_idx * layout.GetRowWidth();
-}
-
-data_ptr_t SortedData::HeapPtr() const {
-	D_ASSERT(!layout.AllConstant() && state.external);
-	D_ASSERT(heap_blocks[block_idx].block->Readers() != 0 &&
-	         heap_handle->handle->BlockId() == heap_blocks[block_idx].block->BlockId());
-	return heap_ptr + Load<idx_t>(DataPtr() + layout.GetHeapPointerOffset());
-}
-
-void SortedData::Advance(const bool &adv) {
-	entry_idx += adv;
-	if (entry_idx == data_blocks[block_idx].count) {
-		block_idx++;
-		entry_idx = 0;
-		if (block_idx < data_blocks.size()) {
-			Pin();
-		}
-	}
-}
-
 void SortedData::CreateBlock() {
 	auto capacity =
 	    MaxValue(((idx_t)Storage::BLOCK_SIZE + layout.GetRowWidth() - 1) / layout.GetRowWidth(), state.block_capacity);
@@ -63,15 +33,9 @@ void SortedData::CreateBlock() {
 	}
 }
 
-void SortedData::ResetIndices(idx_t block_idx_to, idx_t entry_idx_to) {
-	block_idx = block_idx_to;
-	entry_idx = entry_idx_to;
-}
-
-unique_ptr<SortedData> SortedData::CreateSlice(idx_t start_block_index, idx_t start_entry_index, idx_t end_block_index,
-                                               idx_t end_entry_index) {
+unique_ptr<SortedData> SortedData::CreateSlice(idx_t start_block_index, idx_t end_block_index, idx_t end_entry_index) {
 	// Add the corresponding blocks to the result
-	auto result = make_unique<SortedData>(layout, buffer_manager, state);
+	auto result = make_unique<SortedData>(type, layout, buffer_manager, state);
 	for (idx_t i = start_block_index; i <= end_block_index; i++) {
 		result->data_blocks.push_back(data_blocks[i]);
 		if (!layout.AllConstant() && state.external) {
@@ -86,11 +50,21 @@ unique_ptr<SortedData> SortedData::CreateSlice(idx_t start_block_index, idx_t st
 		}
 	}
 	// Use start and end entry indices to set the boundaries
-	result->entry_idx = start_entry_index;
 	D_ASSERT(end_entry_index <= result->data_blocks.back().count);
 	result->data_blocks.back().count = end_entry_index;
 	if (!layout.AllConstant() && state.external) {
 		result->heap_blocks.back().count = end_entry_index;
+	}
+	return result;
+}
+
+unique_ptr<SortedData> SortedData::Copy() {
+	auto result = make_unique<SortedData>(type, layout, buffer_manager, state);
+	for (idx_t i = 0; i < data_blocks.size(); i++) {
+		result->data_blocks.push_back(data_blocks[i]);
+	}
+	for (idx_t i = 0; i < heap_blocks.size(); i++) {
+		result->heap_blocks.push_back(heap_blocks[i]);
 	}
 	return result;
 }
@@ -112,29 +86,11 @@ void SortedData::Unswizzle() {
 	heap_blocks.clear();
 }
 
-void SortedData::PinData() {
-	D_ASSERT(block_idx < data_blocks.size());
-	auto &block = data_blocks[block_idx];
-	if (!data_handle || data_handle->handle->BlockId() != block.block->BlockId()) {
-		data_handle = buffer_manager.Pin(data_blocks[block_idx].block);
-	}
-	data_ptr = data_handle->Ptr();
-}
-
-void SortedData::PinHeap() {
-	D_ASSERT(!layout.AllConstant() && state.external);
-	auto &block = heap_blocks[block_idx];
-	if (!heap_handle || heap_handle->handle->BlockId() != block.block->BlockId()) {
-		heap_handle = buffer_manager.Pin(heap_blocks[block_idx].block);
-	}
-	heap_ptr = heap_handle->Ptr();
-}
-
 SortedBlock::SortedBlock(BufferManager &buffer_manager, GlobalSortState &state)
-    : block_idx(0), entry_idx(0), buffer_manager(buffer_manager), state(state), sort_layout(state.sort_layout),
+    : buffer_manager(buffer_manager), state(state), sort_layout(state.sort_layout),
       payload_layout(state.payload_layout) {
-	blob_sorting_data = make_unique<SortedData>(sort_layout.blob_layout, buffer_manager, state);
-	payload_data = make_unique<SortedData>(payload_layout, buffer_manager, state);
+	blob_sorting_data = make_unique<SortedData>(SortedDataType::BLOB, sort_layout.blob_layout, buffer_manager, state);
+	payload_data = make_unique<SortedData>(SortedDataType::PAYLOAD, payload_layout, buffer_manager, state);
 }
 
 idx_t SortedBlock::Count() const {
@@ -145,17 +101,6 @@ idx_t SortedBlock::Count() const {
 	}
 	D_ASSERT(count == payload_data->Count());
 	return count;
-}
-
-idx_t SortedBlock::Remaining() const {
-	idx_t remaining = 0;
-	if (block_idx < radix_sorting_data.size()) {
-		remaining += radix_sorting_data[block_idx].count - entry_idx;
-		for (idx_t i = block_idx + 1; i < radix_sorting_data.size(); i++) {
-			remaining += radix_sorting_data[i].count;
-		}
-	}
-	return remaining;
 }
 
 void SortedBlock::InitializeWrite() {
@@ -170,14 +115,6 @@ void SortedBlock::CreateBlock() {
 	auto capacity = MaxValue(((idx_t)Storage::BLOCK_SIZE + sort_layout.entry_size - 1) / sort_layout.entry_size,
 	                         state.block_capacity);
 	radix_sorting_data.emplace_back(buffer_manager, capacity, sort_layout.entry_size);
-}
-
-void SortedBlock::PinRadix(idx_t pin_block_idx) {
-	D_ASSERT(pin_block_idx < radix_sorting_data.size());
-	auto &block = radix_sorting_data[pin_block_idx];
-	if (!radix_handle || radix_handle->handle->BlockId() != block.block->BlockId()) {
-		radix_handle = buffer_manager.Pin(block.block);
-	}
 }
 
 void SortedBlock::AppendSortedBlocks(vector<unique_ptr<SortedBlock>> &sorted_blocks) {
@@ -224,7 +161,7 @@ void SortedBlock::GlobalToLocalIndex(const idx_t &global_idx, idx_t &local_block
 	D_ASSERT(local_entry_index < radix_sorting_data[local_block_index].count);
 }
 
-unique_ptr<SortedBlock> SortedBlock::CreateSlice(const idx_t start, const idx_t end) {
+unique_ptr<SortedBlock> SortedBlock::CreateSlice(const idx_t start, const idx_t end, idx_t &entry_idx) {
 	// Identify blocks/entry indices of this slice
 	idx_t start_block_index;
 	idx_t start_entry_index;
@@ -242,18 +179,25 @@ unique_ptr<SortedBlock> SortedBlock::CreateSlice(const idx_t start, const idx_t 
 		radix_sorting_data[i].block = nullptr;
 	}
 	// Use start and end entry indices to set the boundaries
-	result->entry_idx = start_entry_index;
+	entry_idx = start_entry_index;
 	D_ASSERT(end_entry_index <= result->radix_sorting_data.back().count);
 	result->radix_sorting_data.back().count = end_entry_index;
 	// Same for the var size sorting data
 	if (!sort_layout.all_constant) {
-		result->blob_sorting_data =
-		    blob_sorting_data->CreateSlice(start_block_index, start_entry_index, end_block_index, end_entry_index);
+		result->blob_sorting_data = blob_sorting_data->CreateSlice(start_block_index, end_block_index, end_entry_index);
 	}
 	// And the payload data
-	result->payload_data =
-	    payload_data->CreateSlice(start_block_index, start_entry_index, end_block_index, end_entry_index);
-	D_ASSERT(result->Remaining() == end - start);
+	result->payload_data = payload_data->CreateSlice(start_block_index, end_block_index, end_entry_index);
+	return result;
+}
+
+unique_ptr<SortedBlock> SortedBlock::Copy() {
+	auto result = make_unique<SortedBlock>(buffer_manager, state);
+	for (idx_t i = 0; i < radix_sorting_data.size(); i++) {
+		result->radix_sorting_data.push_back(radix_sorting_data[i]);
+	}
+	result->blob_sorting_data = blob_sorting_data->Copy();
+	result->payload_data = payload_data->Copy();
 	return result;
 }
 
@@ -288,19 +232,90 @@ idx_t SortedBlock::SizeInBytes() const {
 	return bytes;
 }
 
-SortedDataScanner::SortedDataScanner(SortedData &sorted_data, GlobalSortState &global_sort_state)
-    : sorted_data(sorted_data), total_count(sorted_data.Count()), global_sort_state(global_sort_state),
-      total_scanned(0) {
+SBScanState::SBScanState(BufferManager &buffer_manager, GlobalSortState &state)
+    : buffer_manager(buffer_manager), sort_layout(state.sort_layout), state(state), block_idx(0), entry_idx(0) {
 }
 
-void SortedDataScanner::Scan(DataChunk &chunk) {
+void SBScanState::PinRadix(idx_t block_idx_to) {
+	auto &radix_sorting_data = sb->radix_sorting_data;
+	D_ASSERT(block_idx_to < radix_sorting_data.size());
+	auto &block = radix_sorting_data[block_idx_to];
+	if (!radix_handle || radix_handle->handle->BlockId() != block.block->BlockId()) {
+		radix_handle = buffer_manager.Pin(block.block);
+	}
+}
+
+void SBScanState::PinData(SortedData &sd) {
+	D_ASSERT(block_idx < sd.data_blocks.size());
+	auto &data_handle = sd.type == SortedDataType::BLOB ? blob_sorting_data_handle : payload_data_handle;
+	auto &heap_handle = sd.type == SortedDataType::BLOB ? blob_sorting_heap_handle : payload_heap_handle;
+
+	auto &data_block = sd.data_blocks[block_idx];
+	if (!data_handle || data_handle->handle->BlockId() != data_block.block->BlockId()) {
+		data_handle = buffer_manager.Pin(data_block.block);
+	}
+	if (sd.layout.AllConstant() || !state.external) {
+		return;
+	}
+	auto &heap_block = sd.heap_blocks[block_idx];
+	if (!heap_handle || heap_handle->handle->BlockId() != heap_block.block->BlockId()) {
+		heap_handle = buffer_manager.Pin(heap_block.block);
+	}
+}
+
+data_ptr_t SBScanState::RadixPtr() const {
+	return radix_handle->Ptr() + entry_idx * sort_layout.entry_size;
+}
+
+data_ptr_t SBScanState::DataPtr(SortedData &sd) const {
+	auto &data_handle = sd.type == SortedDataType::BLOB ? *blob_sorting_data_handle : *payload_data_handle;
+	D_ASSERT(sd.data_blocks[block_idx].block->Readers() != 0 &&
+	         data_handle.handle->BlockId() == sd.data_blocks[block_idx].block->BlockId());
+	return data_handle.Ptr() + entry_idx * sd.layout.GetRowWidth();
+}
+
+data_ptr_t SBScanState::HeapPtr(SortedData &sd) const {
+	return BaseHeapPtr(sd) + Load<idx_t>(DataPtr(sd) + sd.layout.GetHeapPointerOffset());
+}
+
+data_ptr_t SBScanState::BaseHeapPtr(SortedData &sd) const {
+	auto &heap_handle = sd.type == SortedDataType::BLOB ? *blob_sorting_heap_handle : *payload_heap_handle;
+	D_ASSERT(!sd.layout.AllConstant() && state.external);
+	D_ASSERT(sd.heap_blocks[block_idx].block->Readers() != 0 &&
+	         heap_handle.handle->BlockId() == sd.heap_blocks[block_idx].block->BlockId());
+	return heap_handle.Ptr();
+}
+
+idx_t SBScanState::Remaining() const {
+	const auto &blocks = sb->radix_sorting_data;
+	idx_t remaining = 0;
+	if (block_idx < blocks.size()) {
+		remaining += blocks[block_idx].count - entry_idx;
+		for (idx_t i = block_idx + 1; i < blocks.size(); i++) {
+			remaining += blocks[i].count;
+		}
+	}
+	return remaining;
+}
+
+void SBScanState::SetIndices(idx_t block_idx_to, idx_t entry_idx_to) {
+	block_idx = block_idx_to;
+	entry_idx = entry_idx_to;
+}
+
+PayloadScanner::PayloadScanner(SortedData &sorted_data, GlobalSortState &global_sort_state)
+    : sorted_data(sorted_data), read_state(global_sort_state.buffer_manager, global_sort_state),
+      total_count(sorted_data.Count()), global_sort_state(global_sort_state), total_scanned(0) {
+}
+
+void PayloadScanner::Scan(DataChunk &chunk) {
 	auto count = MinValue((idx_t)STANDARD_VECTOR_SIZE, total_count - total_scanned);
 	if (count == 0) {
-		D_ASSERT(sorted_data.block_idx == sorted_data.data_blocks.size());
+		D_ASSERT(read_state.block_idx == sorted_data.data_blocks.size());
 		return;
 	}
 	// Eagerly delete references to blocks that we've passed
-	for (idx_t i = 0; i < sorted_data.block_idx; i++) {
+	for (idx_t i = 0; i < read_state.block_idx; i++) {
 		sorted_data.data_blocks[i].block = nullptr;
 	}
 	const idx_t &row_width = sorted_data.layout.GetRowWidth();
@@ -308,10 +323,10 @@ void SortedDataScanner::Scan(DataChunk &chunk) {
 	idx_t scanned = 0;
 	auto data_pointers = FlatVector::GetData<data_ptr_t>(addresses);
 	while (scanned < count) {
-		sorted_data.Pin();
-		auto &data_block = sorted_data.data_blocks[sorted_data.block_idx];
-		idx_t next = MinValue(data_block.count - sorted_data.entry_idx, count - scanned);
-		const data_ptr_t data_ptr = sorted_data.data_handle->Ptr() + sorted_data.entry_idx * row_width;
+		read_state.PinData(sorted_data);
+		auto &data_block = sorted_data.data_blocks[read_state.block_idx];
+		idx_t next = MinValue(data_block.count - read_state.entry_idx, count - scanned);
+		const data_ptr_t data_ptr = read_state.payload_data_handle->Ptr() + read_state.entry_idx * row_width;
 		// Set up the next pointers
 		data_ptr_t row_ptr = data_ptr;
 		for (idx_t i = 0; i < next; i++) {
@@ -320,14 +335,15 @@ void SortedDataScanner::Scan(DataChunk &chunk) {
 		}
 		// Unswizzle the offsets back to pointers (if needed)
 		if (!sorted_data.layout.AllConstant() && global_sort_state.external) {
-			RowOperations::UnswizzleHeapPointer(sorted_data.layout, data_ptr, sorted_data.heap_handle->Ptr(), next);
+			RowOperations::UnswizzleHeapPointer(sorted_data.layout, data_ptr, read_state.payload_heap_handle->Ptr(),
+			                                    next);
 			RowOperations::UnswizzleColumns(sorted_data.layout, data_ptr, next);
 		}
 		// Update state indices
-		sorted_data.entry_idx += next;
-		if (sorted_data.entry_idx == data_block.count) {
-			sorted_data.block_idx++;
-			sorted_data.entry_idx = 0;
+		read_state.entry_idx += next;
+		if (read_state.entry_idx == data_block.count) {
+			read_state.block_idx++;
+			read_state.entry_idx = 0;
 		}
 		scanned += next;
 	}

--- a/src/common/sort/sorted_block.cpp
+++ b/src/common/sort/sorted_block.cpp
@@ -58,17 +58,6 @@ unique_ptr<SortedData> SortedData::CreateSlice(idx_t start_block_index, idx_t en
 	return result;
 }
 
-unique_ptr<SortedData> SortedData::Copy() {
-	auto result = make_unique<SortedData>(type, layout, buffer_manager, state);
-	for (idx_t i = 0; i < data_blocks.size(); i++) {
-		result->data_blocks.push_back(data_blocks[i]);
-	}
-	for (idx_t i = 0; i < heap_blocks.size(); i++) {
-		result->heap_blocks.push_back(heap_blocks[i]);
-	}
-	return result;
-}
-
 void SortedData::Unswizzle() {
 	if (layout.AllConstant() || !swizzled) {
 		return;
@@ -188,16 +177,6 @@ unique_ptr<SortedBlock> SortedBlock::CreateSlice(const idx_t start, const idx_t 
 	}
 	// And the payload data
 	result->payload_data = payload_data->CreateSlice(start_block_index, end_block_index, end_entry_index);
-	return result;
-}
-
-unique_ptr<SortedBlock> SortedBlock::Copy() {
-	auto result = make_unique<SortedBlock>(buffer_manager, state);
-	for (idx_t i = 0; i < radix_sorting_data.size(); i++) {
-		result->radix_sorting_data.push_back(radix_sorting_data[i]);
-	}
-	result->blob_sorting_data = blob_sorting_data->Copy();
-	result->payload_data = payload_data->Copy();
 	return result;
 }
 

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -426,7 +426,7 @@ static void ScanSortedPartition(WindowOperatorState &state, ChunkCollection &inp
 	payload_types.insert(payload_types.end(), over_types.begin(), over_types.end());
 
 	// scan the sorted row data
-	SortedDataScanner scanner(*global_sort_state.sorted_blocks[0]->payload_data, global_sort_state);
+	PayloadScanner scanner(*global_sort_state.sorted_blocks[0]->payload_data, global_sort_state);
 	for (;;) {
 		DataChunk payload_chunk;
 		payload_chunk.Initialize(payload_types);

--- a/src/execution/operator/order/physical_order.cpp
+++ b/src/execution/operator/order/physical_order.cpp
@@ -191,7 +191,7 @@ void PhysicalOrder::ScheduleMergeTasks(Pipeline &pipeline, Event &event, OrderGl
 class PhysicalOrderOperatorState : public GlobalSourceState {
 public:
 	//! Payload scanner
-	unique_ptr<SortedDataScanner> scanner;
+	unique_ptr<PayloadScanner> scanner;
 };
 
 unique_ptr<GlobalSourceState> PhysicalOrder::GetGlobalSourceState(ClientContext &context) const {
@@ -210,7 +210,7 @@ void PhysicalOrder::GetData(ExecutionContext &context, DataChunk &chunk, GlobalS
 			return;
 		}
 		state.scanner =
-		    make_unique<SortedDataScanner>(*global_sort_state.sorted_blocks[0]->payload_data, global_sort_state);
+		    make_unique<PayloadScanner>(*global_sort_state.sorted_blocks[0]->payload_data, global_sort_state);
 	}
 
 	// Scan the next data chunk

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -22,7 +22,7 @@ PhysicalTopN::PhysicalTopN(vector<LogicalType> types, vector<BoundOrderByNode> o
 class TopNHeap;
 
 struct TopNScanState {
-	unique_ptr<SortedDataScanner> scanner;
+	unique_ptr<PayloadScanner> scanner;
 	idx_t pos;
 	bool exclude_offset;
 };
@@ -152,7 +152,7 @@ void TopNSortState::InitializeScan(TopNScanState &state, bool exclude_offset) {
 		state.scanner = nullptr;
 	} else {
 		D_ASSERT(global_state->sorted_blocks.size() == 1);
-		state.scanner = make_unique<SortedDataScanner>(*global_state->sorted_blocks[0]->payload_data, *global_state);
+		state.scanner = make_unique<PayloadScanner>(*global_state->sorted_blocks[0]->payload_data, *global_state);
 	}
 	state.pos = 0;
 	state.exclude_offset = exclude_offset && heap.offset > 0;

--- a/src/include/duckdb/common/sort/comparators.hpp
+++ b/src/include/duckdb/common/sort/comparators.hpp
@@ -14,8 +14,7 @@
 namespace duckdb {
 
 struct SortLayout;
-struct SortedBlock;
-struct SortedData;
+struct SBScanState;
 
 using ValidityBytes = RowLayout::ValidityBytes;
 
@@ -25,14 +24,14 @@ public:
 	static bool TieIsBreakable(const idx_t &col_idx, const data_ptr_t row_ptr, const RowLayout &row_layout);
 	//! Compares the tuples that a being read from in the 'left' and 'right blocks during merge sort
 	//! (only in case we cannot simply 'memcmp' - if there are blob columns)
-	static int CompareTuple(const SortedBlock &left, const SortedBlock &right, const data_ptr_t &l_ptr,
+	static int CompareTuple(const SBScanState &left, const SBScanState &right, const data_ptr_t &l_ptr,
 	                        const data_ptr_t &r_ptr, const SortLayout &sort_layout, const bool &external_sort);
 	//! Compare two blob values
 	static int CompareVal(const data_ptr_t l_ptr, const data_ptr_t r_ptr, const LogicalType &type);
 
 private:
 	//! Compares two blob values that were initially tied by their prefix
-	static int BreakBlobTie(const idx_t &tie_col, const SortedData &left, const SortedData &right,
+	static int BreakBlobTie(const idx_t &tie_col, const SBScanState &left, const SBScanState &right,
 	                        const SortLayout &sort_layout, const bool &external);
 	//! Compare two fixed-size values
 	template <class T>

--- a/src/include/duckdb/common/sort/sort.hpp
+++ b/src/include/duckdb/common/sort/sort.hpp
@@ -149,12 +149,28 @@ public:
 	void PerformInMergeRound();
 
 private:
+	//! The global sorting state
+	GlobalSortState &state;
+	//! The sorting and payload layouts
+	BufferManager &buffer_manager;
+	const SortLayout &sort_layout;
+
+	//! The left and right reader
+	unique_ptr<SBScanState> left;
+	unique_ptr<SBScanState> right;
+
+	//! Input and output blocks
+	unique_ptr<SortedBlock> left_input;
+	unique_ptr<SortedBlock> right_input;
+	SortedBlock *result;
+
+private:
 	//! Computes the left and right block that will be merged next (Merge Path partition)
 	void GetNextPartition();
 	//! Finds the boundary of the next partition using binary search
-	void GetIntersection(SortedBlock &l, SortedBlock &r, const idx_t diagonal, idx_t &l_idx, idx_t &r_idx);
+	void GetIntersection(const idx_t diagonal, idx_t &l_idx, idx_t &r_idx);
 	//! Compare values within SortedBlocks using a global index
-	int CompareUsingGlobalIndex(SortedBlock &l, SortedBlock &r, const idx_t l_idx, const idx_t r_idx);
+	int CompareUsingGlobalIndex(SBScanState &l, SBScanState &r, const idx_t l_idx, const idx_t r_idx);
 
 	//! Finds the next partition and merges it
 	void MergePartition();
@@ -166,7 +182,7 @@ private:
 	void MergeRadix(const idx_t &count, const bool left_smaller[]);
 	//! Merges SortedData according to the 'left_smaller' array
 	void MergeData(SortedData &result_data, SortedData &l_data, SortedData &r_data, const idx_t &count,
-	               const bool left_smaller[], idx_t next_entry_sizes[]);
+	               const bool left_smaller[], idx_t next_entry_sizes[], bool reset_indices);
 	//! Merges constant size rows according to the 'left_smaller' array
 	void MergeRows(data_ptr_t &l_ptr, idx_t &l_entry_idx, const idx_t &l_count, data_ptr_t &r_ptr, idx_t &r_entry_idx,
 	               const idx_t &r_count, RowDataBlock *target_block, data_ptr_t &target_ptr, const idx_t &entry_size,
@@ -180,18 +196,6 @@ private:
 	                idx_t &source_entry_idx, data_ptr_t &source_heap_ptr, RowDataBlock *target_data_block,
 	                data_ptr_t &target_data_ptr, RowDataBlock *target_heap_block, BufferHandle &target_heap_handle,
 	                data_ptr_t &target_heap_ptr, idx_t &copied, const idx_t &count);
-
-private:
-	//! The global sorting state
-	GlobalSortState &state;
-	//! The sorting and payload layouts
-	BufferManager &buffer_manager;
-	const SortLayout &sort_layout;
-
-	//! The left, right and result blocks of the current partition
-	unique_ptr<SortedBlock> left_block;
-	unique_ptr<SortedBlock> right_block;
-	SortedBlock *result;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/sort/sorted_block.hpp
+++ b/src/include/duckdb/common/sort/sorted_block.hpp
@@ -28,8 +28,6 @@ public:
 	void CreateBlock();
 	//! Create a slice that holds the rows between the start and end indices
 	unique_ptr<SortedData> CreateSlice(idx_t start_block_index, idx_t end_block_index, idx_t end_entry_index);
-	//! Copy the SortedData
-	unique_ptr<SortedData> Copy();
 	//! Unswizzles all
 	void Unswizzle();
 
@@ -67,8 +65,6 @@ public:
 	void GlobalToLocalIndex(const idx_t &global_idx, idx_t &local_block_index, idx_t &local_entry_index);
 	//! Create a slice that holds the rows between the start and end indices
 	unique_ptr<SortedBlock> CreateSlice(const idx_t start, const idx_t end, idx_t &entry_idx);
-	//! Copy the SortedBlock
-	unique_ptr<SortedBlock> Copy();
 
 	//! Size (in bytes) of the heap of this block
 	idx_t HeapSize() const;

--- a/src/include/duckdb/common/sort/sorted_block.hpp
+++ b/src/include/duckdb/common/sort/sorted_block.hpp
@@ -16,59 +16,38 @@ struct RowDataBlock;
 struct SortLayout;
 struct GlobalSortState;
 
+enum class SortedDataType { BLOB, PAYLOAD };
+
 //! Object that holds sorted rows, and an accompanying heap if there are blobs
 struct SortedData {
 public:
-	SortedData(const RowLayout &layout, BufferManager &buffer_manager, GlobalSortState &state);
+	SortedData(SortedDataType type, const RowLayout &layout, BufferManager &buffer_manager, GlobalSortState &state);
 	//! Number of rows that this object holds
 	idx_t Count();
-	//! Pin the current block so it can be read
-	void Pin();
-	//! Pointer to the row that is currently being read from
-	data_ptr_t DataPtr() const;
-	//! Pointer to the heap row that corresponds to the current row
-	data_ptr_t HeapPtr() const;
-	//! Advance one row
-	void Advance(const bool &adv);
 	//! Initialize new block to write to
 	void CreateBlock();
-	//! Reset read indices to the given indices
-	void ResetIndices(idx_t block_idx_to, idx_t entry_idx_to);
 	//! Create a slice that holds the rows between the start and end indices
-	unique_ptr<SortedData> CreateSlice(idx_t start_block_index, idx_t start_entry_index, idx_t end_block_index,
-	                                   idx_t end_entry_index);
+	unique_ptr<SortedData> CreateSlice(idx_t start_block_index, idx_t end_block_index, idx_t end_entry_index);
+	//! Copy the SortedData
+	unique_ptr<SortedData> Copy();
 	//! Unswizzles all
 	void Unswizzle();
 
 public:
+	const SortedDataType type;
 	//! Layout of this data
 	const RowLayout layout;
 	//! Data and heap blocks
 	vector<RowDataBlock> data_blocks;
 	vector<RowDataBlock> heap_blocks;
-	//! Buffer handles to the data being currently read
-	unique_ptr<BufferHandle> data_handle;
-	unique_ptr<BufferHandle> heap_handle;
-	//! Read indices
-	idx_t block_idx;
-	idx_t entry_idx;
 	//! Whether the pointers in this sorted data are swizzled
 	bool swizzled;
-
-private:
-	//! Pin fixed-size row data
-	void PinData();
-	//! Pin the accompanying heap data (if any)
-	void PinHeap();
 
 private:
 	//! The buffer manager
 	BufferManager &buffer_manager;
 	//! The global state
 	GlobalSortState &state;
-	//! Pointers into the buffers being currently read
-	data_ptr_t data_ptr;
-	data_ptr_t heap_ptr;
 };
 
 //! Block that holds sorted rows: radix, blob and payload data
@@ -77,21 +56,19 @@ public:
 	SortedBlock(BufferManager &buffer_manager, GlobalSortState &gstate);
 	//! Number of rows that this object holds
 	idx_t Count() const;
-	//! The remaining number of rows to be read from this object
-	idx_t Remaining() const;
 	//! Initialize this block to write data to
 	void InitializeWrite();
 	//! Init new block to write to
 	void CreateBlock();
-	//! Pins radix block with given index
-	void PinRadix(idx_t pin_block_idx);
 	//! Fill this sorted block by appending the blocks held by a vector of sorted blocks
 	void AppendSortedBlocks(vector<unique_ptr<SortedBlock>> &sorted_blocks);
 	//! Locate the block and entry index of a row in this block,
 	//! given an index between 0 and the total number of rows in this block
 	void GlobalToLocalIndex(const idx_t &global_idx, idx_t &local_block_index, idx_t &local_entry_index);
 	//! Create a slice that holds the rows between the start and end indices
-	unique_ptr<SortedBlock> CreateSlice(const idx_t start, const idx_t end);
+	unique_ptr<SortedBlock> CreateSlice(const idx_t start, const idx_t end, idx_t &entry_idx);
+	//! Copy the SortedBlock
+	unique_ptr<SortedBlock> Copy();
 
 	//! Size (in bytes) of the heap of this block
 	idx_t HeapSize() const;
@@ -101,25 +78,59 @@ public:
 public:
 	//! Radix/memcmp sortable data
 	vector<RowDataBlock> radix_sorting_data;
-	unique_ptr<BufferHandle> radix_handle;
-	idx_t block_idx;
-	idx_t entry_idx;
 	//! Variable sized sorting data
 	unique_ptr<SortedData> blob_sorting_data;
 	//! Payload data
 	unique_ptr<SortedData> payload_data;
 
 private:
-	//! Buffer manager, and sorting layout constants
+	//! Buffer manager, global state, and sorting layout constants
 	BufferManager &buffer_manager;
 	GlobalSortState &state;
 	const SortLayout &sort_layout;
 	const RowLayout &payload_layout;
 };
 
-struct SortedDataScanner {
+//! State used to scan a SortedBlock e.g. during merge sort
+struct SBScanState {
 public:
-	SortedDataScanner(SortedData &sorted_data, GlobalSortState &global_sort_state);
+	SBScanState(BufferManager &buffer_manager, GlobalSortState &state);
+
+	void PinRadix(idx_t block_idx_to);
+	void PinData(SortedData &sd);
+
+	data_ptr_t RadixPtr() const;
+	data_ptr_t DataPtr(SortedData &sd) const;
+	data_ptr_t HeapPtr(SortedData &sd) const;
+	data_ptr_t BaseHeapPtr(SortedData &sd) const;
+
+	idx_t Remaining() const;
+
+	void SetIndices(idx_t block_idx_to, idx_t entry_idx_to);
+
+public:
+	BufferManager &buffer_manager;
+	const SortLayout &sort_layout;
+	GlobalSortState &state;
+
+	SortedBlock *sb;
+
+	idx_t block_idx;
+	idx_t entry_idx;
+
+	unique_ptr<BufferHandle> radix_handle = nullptr;
+
+	unique_ptr<BufferHandle> blob_sorting_data_handle = nullptr;
+	unique_ptr<BufferHandle> blob_sorting_heap_handle = nullptr;
+
+	unique_ptr<BufferHandle> payload_data_handle = nullptr;
+	unique_ptr<BufferHandle> payload_heap_handle = nullptr;
+};
+
+//! Used to scan the data into DataChunks after sorting
+struct PayloadScanner {
+public:
+	PayloadScanner(SortedData &sorted_data, GlobalSortState &global_sort_state);
 
 	//! Scans the next data chunk from the sorted data
 	void Scan(DataChunk &chunk);
@@ -127,6 +138,8 @@ public:
 private:
 	//! The sorted data being scanned
 	SortedData &sorted_data;
+	//! Read state
+	SBScanState read_state;
 	//! The total count of sorted_data
 	const idx_t total_count;
 	//! The global sort state


### PR DESCRIPTION
This PR moves `block_idx`, `entry_idx` and `BufferHandle` away from `SortedBlock`, and into `SBScanState`. This allows multiple threads to scan the scan the same `SortedBlock`, each using their own `SBScanState`.

Sorry for the delay @hawkfish ! Please let me know if this was what you had in mind, and if anything needs changing.