### PR TITLE
Add duckdb_functions table function

### DIFF
--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -551,6 +551,16 @@ Value Value::LIST(vector<Value> values) {
 	return result;
 }
 
+Value Value::LIST(LogicalType child_type, vector<Value> values) {
+	if (values.empty()) {
+		return Value::EMPTYLIST(move(child_type));
+	}
+	for (auto &val : values) {
+		val = val.CastAs(child_type);
+	}
+	return Value::LIST(move(values));
+}
+
 Value Value::EMPTYLIST(LogicalType child_type) {
 	Value result;
 	result.type_ = LogicalType::LIST(move(child_type));

--- a/src/function/table/system/CMakeLists.txt
+++ b/src/function/table/system/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library_unity(
   duckdb_columns.cpp
   duckdb_constraints.cpp
   duckdb_dependencies.cpp
+  duckdb_functions.cpp
   duckdb_indexes.cpp
   duckdb_schemas.cpp
   duckdb_sequences.cpp

--- a/src/function/table/system/duckdb_functions.cpp
+++ b/src/function/table/system/duckdb_functions.cpp
@@ -1,0 +1,411 @@
+#include "duckdb/function/table/system_functions.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/macro_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/pragma_function_catalog_entry.hpp"
+#include "duckdb/parser/expression/columnref_expression.hpp"
+
+namespace duckdb {
+
+struct DuckDBFunctionsData : public FunctionOperatorData {
+	DuckDBFunctionsData() : offset(0), offset_in_entry(0) {
+	}
+
+	vector<CatalogEntry *> entries;
+	idx_t offset;
+	idx_t offset_in_entry;
+};
+
+static unique_ptr<FunctionData> DuckDBFunctionsBind(ClientContext &context, vector<Value> &inputs,
+                                                    unordered_map<string, Value> &named_parameters,
+                                                    vector<LogicalType> &input_table_types,
+                                                    vector<string> &input_table_names,
+                                                    vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("schema_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("function_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("function_type");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("description");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("return_type");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("parameters");
+	return_types.push_back(LogicalType::LIST(LogicalType::VARCHAR));
+
+	names.emplace_back("parameter_types");
+	return_types.push_back(LogicalType::LIST(LogicalType::VARCHAR));
+
+	names.emplace_back("varargs");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("macro_definition");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+static void ExtractFunctionsFromSchema(ClientContext &context, SchemaCatalogEntry &schema,
+                                       DuckDBFunctionsData &result) {
+	schema.Scan(context, CatalogType::SCALAR_FUNCTION_ENTRY,
+	            [&](CatalogEntry *entry) { result.entries.push_back(entry); });
+	schema.Scan(context, CatalogType::TABLE_FUNCTION_ENTRY,
+	            [&](CatalogEntry *entry) { result.entries.push_back(entry); });
+	schema.Scan(context, CatalogType::PRAGMA_FUNCTION_ENTRY,
+	            [&](CatalogEntry *entry) { result.entries.push_back(entry); });
+}
+
+unique_ptr<FunctionOperatorData> DuckDBFunctionsInit(ClientContext &context, const FunctionData *bind_data,
+                                                     const vector<column_t> &column_ids,
+                                                     TableFilterCollection *filters) {
+	auto result = make_unique<DuckDBFunctionsData>();
+
+	// scan all the schemas for tables and collect themand collect them
+	auto schemas = Catalog::GetCatalog(context).schemas->GetEntries<SchemaCatalogEntry>(context);
+	for (auto &schema : schemas) {
+		ExtractFunctionsFromSchema(context, *schema, *result);
+	};
+	ExtractFunctionsFromSchema(context, *context.temporary_objects, *result);
+
+	return move(result);
+}
+
+struct ScalarFunctionExtractor {
+	static idx_t FunctionCount(ScalarFunctionCatalogEntry &entry) {
+		return entry.functions.size();
+	}
+
+	static Value GetFunctionType() {
+		return Value("scalar");
+	}
+
+	static Value GetFunctionDescription(ScalarFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetReturnType(ScalarFunctionCatalogEntry &entry, idx_t offset) {
+		return Value(entry.functions[offset].return_type.ToString());
+	}
+
+	static Value GetParameters(ScalarFunctionCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
+			results.push_back(Value("col" + to_string(i)));
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetParameterTypes(ScalarFunctionCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
+			results.push_back(entry.functions[offset].arguments[i].ToString());
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetVarArgs(ScalarFunctionCatalogEntry &entry, idx_t offset) {
+		return entry.functions[offset].varargs.id() == LogicalTypeId::INVALID
+		           ? Value()
+		           : Value(entry.functions[offset].varargs.ToString());
+	}
+
+	static Value GetMacroDefinition(ScalarFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+};
+
+struct AggregateFunctionExtractor {
+	static idx_t FunctionCount(AggregateFunctionCatalogEntry &entry) {
+		return entry.functions.size();
+	}
+
+	static Value GetFunctionType() {
+		return Value("aggregate");
+	}
+
+	static Value GetFunctionDescription(AggregateFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetReturnType(AggregateFunctionCatalogEntry &entry, idx_t offset) {
+		return Value(entry.functions[offset].return_type.ToString());
+	}
+
+	static Value GetParameters(AggregateFunctionCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
+			results.push_back(Value("col" + to_string(i)));
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetParameterTypes(AggregateFunctionCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
+			results.push_back(entry.functions[offset].arguments[i].ToString());
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetVarArgs(AggregateFunctionCatalogEntry &entry, idx_t offset) {
+		return entry.functions[offset].varargs.id() == LogicalTypeId::INVALID
+		           ? Value()
+		           : Value(entry.functions[offset].varargs.ToString());
+	}
+
+	static Value GetMacroDefinition(AggregateFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+};
+
+struct MacroExtractor {
+	static idx_t FunctionCount(MacroCatalogEntry &entry) {
+		return 1;
+	}
+
+	static Value GetFunctionType() {
+		return Value("macro");
+	}
+
+	static Value GetFunctionDescription(MacroCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetReturnType(MacroCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetParameters(MacroCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (auto &param : entry.function->parameters) {
+			D_ASSERT(param->type == ExpressionType::COLUMN_REF);
+			auto &colref = (ColumnRefExpression &)*param;
+			results.push_back(Value(colref.GetColumnName()));
+		}
+		for (auto &param_entry : entry.function->default_parameters) {
+			results.push_back(Value(param_entry.first));
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetParameterTypes(MacroCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (idx_t i = 0; i < entry.function->parameters.size(); i++) {
+			results.push_back(Value(LogicalType::VARCHAR));
+		}
+		for (idx_t i = 0; i < entry.function->default_parameters.size(); i++) {
+			results.push_back(Value(LogicalType::VARCHAR));
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetVarArgs(MacroCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetMacroDefinition(MacroCatalogEntry &entry, idx_t offset) {
+		return entry.function->expression->ToString();
+	}
+};
+
+struct TableFunctionExtractor {
+	static idx_t FunctionCount(TableFunctionCatalogEntry &entry) {
+		return entry.functions.size();
+	}
+
+	static Value GetFunctionType() {
+		return Value("table");
+	}
+
+	static Value GetFunctionDescription(TableFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetReturnType(TableFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetParameters(TableFunctionCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
+			results.push_back(Value("col" + to_string(i)));
+		}
+		for (auto &param : entry.functions[offset].named_parameters) {
+			results.push_back(Value(param.first));
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetParameterTypes(TableFunctionCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
+			results.push_back(entry.functions[offset].arguments[i].ToString());
+		}
+		for (auto &param : entry.functions[offset].named_parameters) {
+			results.push_back(Value(param.second.ToString()));
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetVarArgs(TableFunctionCatalogEntry &entry, idx_t offset) {
+		return entry.functions[offset].varargs.id() == LogicalTypeId::INVALID
+		           ? Value()
+		           : Value(entry.functions[offset].varargs.ToString());
+	}
+
+	static Value GetMacroDefinition(TableFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+};
+
+struct PragmaFunctionExtractor {
+	static idx_t FunctionCount(PragmaFunctionCatalogEntry &entry) {
+		return entry.functions.size();
+	}
+
+	static Value GetFunctionType() {
+		return Value("pragma");
+	}
+
+	static Value GetFunctionDescription(PragmaFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetReturnType(PragmaFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetParameters(PragmaFunctionCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
+			results.push_back(Value("col" + to_string(i)));
+		}
+		for (auto &param : entry.functions[offset].named_parameters) {
+			results.push_back(Value(param.first));
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetParameterTypes(PragmaFunctionCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
+			results.push_back(entry.functions[offset].arguments[i].ToString());
+		}
+		for (auto &param : entry.functions[offset].named_parameters) {
+			results.push_back(Value(param.second.ToString()));
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetVarArgs(PragmaFunctionCatalogEntry &entry, idx_t offset) {
+		return entry.functions[offset].varargs.id() == LogicalTypeId::INVALID
+		           ? Value()
+		           : Value(entry.functions[offset].varargs.ToString());
+	}
+
+	static Value GetMacroDefinition(PragmaFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+};
+
+template <class T, class OP>
+bool ExtractFunctionData(StandardEntry *entry, idx_t function_idx, DataChunk &output, idx_t output_offset) {
+	auto &function = (T &)*entry;
+	// schema_name, LogicalType::VARCHAR
+	output.SetValue(0, output_offset, Value(entry->schema->name));
+
+	// function_name, LogicalType::VARCHAR
+	output.SetValue(1, output_offset, Value(entry->name));
+
+	// function_type, LogicalType::VARCHAR
+	output.SetValue(2, output_offset, Value(OP::GetFunctionType()));
+
+	// function_description, LogicalType::VARCHAR
+	output.SetValue(3, output_offset, OP::GetFunctionDescription(function, function_idx));
+
+	// return_type, LogicalType::VARCHAR
+	output.SetValue(4, output_offset, OP::GetReturnType(function, function_idx));
+
+	// parameters, LogicalType::LIST(LogicalType::VARCHAR)
+	output.SetValue(5, output_offset, OP::GetParameters(function, function_idx));
+
+	// parameter_types, LogicalType::LIST(LogicalType::VARCHAR)
+	output.SetValue(6, output_offset, OP::GetParameterTypes(function, function_idx));
+
+	// varargs, LogicalType::VARCHAR
+	output.SetValue(7, output_offset, OP::GetVarArgs(function, function_idx));
+
+	// macro_definition, LogicalType::VARCHAR
+	output.SetValue(8, output_offset, OP::GetMacroDefinition(function, function_idx));
+
+	return function_idx + 1 == OP::FunctionCount(function);
+}
+
+void DuckDBFunctionsFunction(ClientContext &context, const FunctionData *bind_data,
+                             FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
+	auto &data = (DuckDBFunctionsData &)*operator_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.entries[data.offset];
+		auto standard_entry = (StandardEntry *)entry;
+		bool finished = false;
+
+		switch (entry->type) {
+		case CatalogType::SCALAR_FUNCTION_ENTRY:
+			finished = ExtractFunctionData<ScalarFunctionCatalogEntry, ScalarFunctionExtractor>(
+			    standard_entry, data.offset_in_entry, output, count);
+			break;
+		case CatalogType::AGGREGATE_FUNCTION_ENTRY:
+			finished = ExtractFunctionData<AggregateFunctionCatalogEntry, AggregateFunctionExtractor>(
+			    standard_entry, data.offset_in_entry, output, count);
+			break;
+		case CatalogType::MACRO_ENTRY:
+			finished = ExtractFunctionData<MacroCatalogEntry, MacroExtractor>(standard_entry, data.offset_in_entry,
+			                                                                  output, count);
+			break;
+		case CatalogType::TABLE_FUNCTION_ENTRY:
+			finished = ExtractFunctionData<TableFunctionCatalogEntry, TableFunctionExtractor>(
+			    standard_entry, data.offset_in_entry, output, count);
+			break;
+		case CatalogType::PRAGMA_FUNCTION_ENTRY:
+			finished = ExtractFunctionData<PragmaFunctionCatalogEntry, PragmaFunctionExtractor>(
+			    standard_entry, data.offset_in_entry, output, count);
+			break;
+		default:
+			throw InternalException("FIXME: unrecognized function type in duckdb_functions");
+		}
+		if (finished) {
+			// finished with this function, move to the next function
+			data.offset++;
+			data.offset_in_entry = 0;
+		} else {
+			// more functions remain
+			data.offset_in_entry++;
+		}
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void DuckDBFunctionsFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    TableFunction("duckdb_functions", {}, DuckDBFunctionsFunction, DuckDBFunctionsBind, DuckDBFunctionsInit));
+}
+
+} // namespace duckdb

--- a/src/function/table/system/duckdb_functions.cpp
+++ b/src/function/table/system/duckdb_functions.cpp
@@ -103,7 +103,7 @@ struct ScalarFunctionExtractor {
 	static Value GetParameters(ScalarFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
 		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
-			results.push_back(Value("col" + to_string(i)));
+			results.emplace_back("col" + to_string(i));
 		}
 		return Value::LIST(LogicalType::VARCHAR, move(results));
 	}
@@ -111,7 +111,7 @@ struct ScalarFunctionExtractor {
 	static Value GetParameterTypes(ScalarFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
 		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
-			results.push_back(entry.functions[offset].arguments[i].ToString());
+			results.emplace_back(entry.functions[offset].arguments[i].ToString());
 		}
 		return Value::LIST(LogicalType::VARCHAR, move(results));
 	}
@@ -147,7 +147,7 @@ struct AggregateFunctionExtractor {
 	static Value GetParameters(AggregateFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
 		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
-			results.push_back(Value("col" + to_string(i)));
+			results.emplace_back("col" + to_string(i));
 		}
 		return Value::LIST(LogicalType::VARCHAR, move(results));
 	}
@@ -155,7 +155,7 @@ struct AggregateFunctionExtractor {
 	static Value GetParameterTypes(AggregateFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
 		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
-			results.push_back(entry.functions[offset].arguments[i].ToString());
+			results.emplace_back(entry.functions[offset].arguments[i].ToString());
 		}
 		return Value::LIST(LogicalType::VARCHAR, move(results));
 	}
@@ -193,10 +193,10 @@ struct MacroExtractor {
 		for (auto &param : entry.function->parameters) {
 			D_ASSERT(param->type == ExpressionType::COLUMN_REF);
 			auto &colref = (ColumnRefExpression &)*param;
-			results.push_back(Value(colref.GetColumnName()));
+			results.emplace_back(colref.GetColumnName());
 		}
 		for (auto &param_entry : entry.function->default_parameters) {
-			results.push_back(Value(param_entry.first));
+			results.emplace_back(param_entry.first);
 		}
 		return Value::LIST(LogicalType::VARCHAR, move(results));
 	}
@@ -204,10 +204,10 @@ struct MacroExtractor {
 	static Value GetParameterTypes(MacroCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
 		for (idx_t i = 0; i < entry.function->parameters.size(); i++) {
-			results.push_back(Value(LogicalType::VARCHAR));
+			results.emplace_back(LogicalType::VARCHAR);
 		}
 		for (idx_t i = 0; i < entry.function->default_parameters.size(); i++) {
-			results.push_back(Value(LogicalType::VARCHAR));
+			results.emplace_back(LogicalType::VARCHAR);
 		}
 		return Value::LIST(LogicalType::VARCHAR, move(results));
 	}
@@ -241,10 +241,10 @@ struct TableFunctionExtractor {
 	static Value GetParameters(TableFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
 		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
-			results.push_back(Value("col" + to_string(i)));
+			results.emplace_back("col" + to_string(i));
 		}
 		for (auto &param : entry.functions[offset].named_parameters) {
-			results.push_back(Value(param.first));
+			results.emplace_back(param.first);
 		}
 		return Value::LIST(LogicalType::VARCHAR, move(results));
 	}
@@ -252,10 +252,10 @@ struct TableFunctionExtractor {
 	static Value GetParameterTypes(TableFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
 		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
-			results.push_back(entry.functions[offset].arguments[i].ToString());
+			results.emplace_back(entry.functions[offset].arguments[i].ToString());
 		}
 		for (auto &param : entry.functions[offset].named_parameters) {
-			results.push_back(Value(param.second.ToString()));
+			results.emplace_back(param.second.ToString());
 		}
 		return Value::LIST(LogicalType::VARCHAR, move(results));
 	}
@@ -291,10 +291,10 @@ struct PragmaFunctionExtractor {
 	static Value GetParameters(PragmaFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
 		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
-			results.push_back(Value("col" + to_string(i)));
+			results.emplace_back("col" + to_string(i));
 		}
 		for (auto &param : entry.functions[offset].named_parameters) {
-			results.push_back(Value(param.first));
+			results.emplace_back(param.first);
 		}
 		return Value::LIST(LogicalType::VARCHAR, move(results));
 	}
@@ -302,10 +302,10 @@ struct PragmaFunctionExtractor {
 	static Value GetParameterTypes(PragmaFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
 		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
-			results.push_back(entry.functions[offset].arguments[i].ToString());
+			results.emplace_back(entry.functions[offset].arguments[i].ToString());
 		}
 		for (auto &param : entry.functions[offset].named_parameters) {
-			results.push_back(Value(param.second.ToString()));
+			results.emplace_back(param.second.ToString());
 		}
 		return Value::LIST(LogicalType::VARCHAR, move(results));
 	}

--- a/src/function/table/system/duckdb_functions.cpp
+++ b/src/function/table/system/duckdb_functions.cpp
@@ -79,7 +79,7 @@ unique_ptr<FunctionOperatorData> DuckDBFunctionsInit(ClientContext &context, con
 	ExtractFunctionsFromSchema(context, *context.temporary_objects, *result);
 
 	std::sort(result->entries.begin(), result->entries.end(),
-	          [](CatalogEntry *&a, CatalogEntry *&b) -> bool { return (int)a->type < (int)b->type; });
+	          [&](CatalogEntry *a, CatalogEntry *b) { return (int)a->type < (int)b->type; });
 	return move(result);
 }
 

--- a/src/function/table/system/duckdb_functions.cpp
+++ b/src/function/table/system/duckdb_functions.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/pragma_function_catalog_entry.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
+#include "duckdb/common/algorithm.hpp"
 
 namespace duckdb {
 
@@ -77,6 +78,8 @@ unique_ptr<FunctionOperatorData> DuckDBFunctionsInit(ClientContext &context, con
 	};
 	ExtractFunctionsFromSchema(context, *context.temporary_objects, *result);
 
+	std::sort(result->entries.begin(), result->entries.end(),
+	          [](CatalogEntry *&a, CatalogEntry *&b) -> bool { return (int)a->type < (int)b->type; });
 	return move(result);
 }
 

--- a/src/function/table/system_functions.cpp
+++ b/src/function/table/system_functions.cpp
@@ -21,6 +21,7 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 
 	DuckDBColumnsFun::RegisterFunction(*this);
 	DuckDBConstraintsFun::RegisterFunction(*this);
+	DuckDBFunctionsFun::RegisterFunction(*this);
 	DuckDBIndexesFun::RegisterFunction(*this);
 	DuckDBSchemasFun::RegisterFunction(*this);
 	DuckDBDependenciesFun::RegisterFunction(*this);

--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -121,8 +121,11 @@ public:
 	DUCKDB_API static Value DOUBLE(double value);
 	//! Create a struct value with given list of entries
 	DUCKDB_API static Value STRUCT(child_list_t<Value> values);
-	//! Create a list value with the given entries
+	//! Create a list value with the given entries, list type is inferred from children
+	//! Cannot be called with an empty list, use either EMPTYLIST or LIST with a type instead
 	DUCKDB_API static Value LIST(vector<Value> values);
+	//! Create a list value with the given entries
+	DUCKDB_API static Value LIST(LogicalType child_type, vector<Value> values);
 	//! Create an empty list with the specified type
 	DUCKDB_API static Value EMPTYLIST(LogicalType child_type);
 	//! Creat a map value from a (key, value) pair

--- a/src/include/duckdb/function/table/system_functions.hpp
+++ b/src/include/duckdb/function/table/system_functions.hpp
@@ -64,6 +64,10 @@ struct DuckDBDependenciesFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct DuckDBFunctionsFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct DuckDBIndexesFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/test/sql/table_function/duckdb_functions.test
+++ b/test/sql/table_function/duckdb_functions.test
@@ -1,0 +1,26 @@
+# name: test/sql/table_function/duckdb_functions.test
+# description: Test duckdb_functions function
+# group: [table_function]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+SELECT * FROM duckdb_functions();
+
+statement ok
+CREATE MACRO add_default1(a := 3, b := 5) AS a + b
+
+statement ok
+CREATE MACRO add_default2(a, b := 5) AS a + b
+
+statement ok
+SELECT * FROM duckdb_functions();
+
+statement ok
+SELECT * FROM duckdb_functions() WHERE function_type='table';
+
+query I
+select distinct function_name from duckdb_functions() where function_name='sqrt';
+----
+sqrt


### PR DESCRIPTION
This PR adds the `duckdb_functions` table function, that shows the list of functions currently built into the system, e.g.:

```sql
D select distinct on(function_name) function_name, function_type, return_type, parameters, parameter_types from duckdb_functions() where function_type='scalar' limit 10;
┌────────────────┬───────────────┬─────────────┬──────────────────────────┬──────────────────────────────────────┐
│ function_name  │ function_type │ return_type │        parameters        │           parameter_types            │
├────────────────┼───────────────┼─────────────┼──────────────────────────┼──────────────────────────────────────┤
│ log10          │ scalar        │ DOUBLE      │ [col0]                   │ [DOUBLE]                             │
│ mod            │ scalar        │ TINYINT     │ [col0, col1]             │ [TINYINT, TINYINT]                   │
│ date_diff      │ scalar        │ BIGINT      │ [col0, col1, col2]       │ [VARCHAR, DATE, DATE]                │
│ writefile      │ scalar        │ VARCHAR     │ []                       │ []                                   │
│ regexp_replace │ scalar        │ VARCHAR     │ [col0, col1, col2, col3] │ [VARCHAR, VARCHAR, VARCHAR, VARCHAR] │
│ age            │ scalar        │ INTERVAL    │ [col0]                   │ [TIMESTAMP]                          │
│ age            │ scalar        │ INTERVAL    │ [col0, col1]             │ [TIMESTAMP, TIMESTAMP]               │
│ datediff       │ scalar        │ BIGINT      │ [col0, col1, col2]       │ [VARCHAR, DATE, DATE]                │
│ map            │ scalar        │ MAP         │ []                       │ []                                   │
│ year           │ scalar        │ BIGINT      │ [col0]                   │ [TIMESTAMP WITH TIME ZONE]           │
└────────────────┴───────────────┴─────────────┴──────────────────────────┴──────────────────────────────────────┘

D select distinct on(function_type) * from duckdb_functions();
┌─────────────┬─────────────────────┬───────────────┬─────────────┬─────────────┬────────────────────┬─────────────────┬─────────┬────────────────────┐
│ schema_name │    function_name    │ function_type │ description │ return_type │     parameters     │ parameter_types │ varargs │  macro_definition  │
├─────────────┼─────────────────────┼───────────────┼─────────────┼─────────────┼────────────────────┼─────────────────┼─────────┼────────────────────┤
│ main        │ parquet_schema      │ table         │ NULL        │ NULL        │ [col0]             │ [VARCHAR]       │ NULL    │ NULL               │
│ main        │ log10               │ scalar        │ NULL        │ DOUBLE      │ [col0]             │ [DOUBLE]        │ NULL    │ NULL               │
│ main        │ count_star          │ aggregate     │ NULL        │ BIGINT      │ []                 │ []              │ NULL    │ NULL               │
│ main        │ table_info          │ pragma        │ NULL        │ NULL        │ [col0]             │ [VARCHAR]       │ NULL    │ NULL               │
│ pg_catalog  │ has_table_privilege │ macro         │ NULL        │ NULL        │ [table, privilege] │ [NULL, NULL]    │ NULL    │ CAST(t AS BOOLEAN) │
└─────────────┴─────────────────────┴───────────────┴─────────────┴─────────────┴────────────────────┴─────────────────┴─────────┴────────────────────┘
```

Currently the description and parameter names of functions are still missing. The idea is to add those to the system in a later refactor of the system. 

The purpose of this function is to help with auto-generating of documentation (CC @Alex-Monahan) and to add support for displaying available functions of the system (e.g. using `SHOW FUNCTIONS` or similar).