### PR TITLE
Fix #2745: correctly detect when a RECURSIVE CTE does not contain a reference to itself (i.e. is not a recursive CTE at all)

### DIFF
--- a/src/planner/binder/query_node/plan_recursive_cte_node.cpp
+++ b/src/planner/binder/query_node/plan_recursive_cte_node.cpp
@@ -24,7 +24,8 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundRecursiveCTENode &node) {
 	left_node = CastLogicalOperatorToTypes(node.left->types, node.types, move(left_node));
 	right_node = CastLogicalOperatorToTypes(node.right->types, node.types, move(right_node));
 
-	if (node.right_binder->bind_context.cte_references[node.ctename] == nullptr) {
+	if (!node.right_binder->bind_context.cte_references[node.ctename] ||
+	    *node.right_binder->bind_context.cte_references[node.ctename] == 0) {
 		auto root = make_unique<LogicalSetOperation>(node.setop_index, node.types.size(), move(left_node),
 		                                             move(right_node), LogicalOperatorType::LOGICAL_UNION);
 		return VisitQueryNode(node, move(root));

--- a/test/sql/cte/recursive_hang_2745.test
+++ b/test/sql/cte/recursive_hang_2745.test
@@ -1,0 +1,120 @@
+# name: test/sql/cte/recursive_hang_2745.test
+# description: Issue #2745: sql with RECURSIVE keyword but does not RECURSIVE hang
+# group: [cte]
+
+statement ok
+PRAGMA enable_verification
+
+query III
+with RECURSIVE parents_tab (id , value , parent )
+as (values (1, 1, 2), (2, 2, 4), (3, 1, 4), (4, 2, -1), (5, 1, 2), (6, 2, 7), (7, 1, -1)
+),
+parents_tab2(id , value , parent )
+as (values (1, 1, 2), (2, 2, 4), (3, 1, 4), (4, 2, -1), (5, 1, 2), (6, 2, 7), (7, 1, -1)
+),
+parents as (
+    select * from parents_tab
+    union all
+    select id, value+2, parent from parents_tab2
+)
+select * from parents;
+----
+1	1	2
+2	2	4
+3	1	4
+4	2	-1
+5	1	2
+6	2	7
+7	1	-1
+1	3	2
+2	4	4
+3	3	4
+4	4	-1
+5	3	2
+6	4	7
+7	3	-1
+
+query III
+with RECURSIVE parents_tab (id , value , parent )
+as (values (1, 1, 2), (2, 2, 4), (3, 1, 4), (4, 2, -1), (5, 1, 2), (6, 2, 7), (7, 1, -1)
+),
+parents_tab2(id , value , parent )
+as (values (1, 1, 2), (2, 2, 4), (3, 1, 4), (4, 2, -1), (5, 1, 2), (6, 2, 7), (7, 1, -1)
+)
+select * from parents_tab
+union all
+select id, value+2, parent from parents_tab2;
+----
+1	1	2
+2	2	4
+3	1	4
+4	2	-1
+5	1	2
+6	2	7
+7	1	-1
+1	3	2
+2	4	4
+3	3	4
+4	4	-1
+5	3	2
+6	4	7
+7	3	-1
+
+query III
+with parents_tab (id , value , parent )
+as (values (1, 1, 2), (2, 2, 4), (3, 1, 4), (4, 2, -1), (5, 1, 2), (6, 2, 7), (7, 1, -1)
+),
+parents_tab2(id , value , parent )
+as (values (1, 1, 2), (2, 2, 4), (3, 1, 4), (4, 2, -1), (5, 1, 2), (6, 2, 7), (7, 1, -1)
+),
+parents as (
+    select * from parents_tab
+    union all
+    select id, value+2, parent from parents_tab2
+)
+select * from parents;
+----
+1	1	2
+2	2	4
+3	1	4
+4	2	-1
+5	1	2
+6	2	7
+7	1	-1
+1	3	2
+2	4	4
+3	3	4
+4	4	-1
+5	3	2
+6	4	7
+7	3	-1
+
+statement ok
+create view vparents as
+with RECURSIVE parents_tab (id , value , parent )
+as (values (1, 1, 2), (2, 2, 4), (3, 1, 4), (4, 2, -1), (5, 1, 2), (6, 2, 7), (7, 1, -1)
+),
+parents_tab2(id , value , parent )
+as (values (1, 1, 2), (2, 2, 4), (3, 1, 4), (4, 2, -1), (5, 1, 2), (6, 2, 7), (7, 1, -1)
+)
+select * from parents_tab
+union all
+select id, value+2, parent from parents_tab2;
+
+query III
+select * from vparents;
+----
+1	1	2
+2	2	4
+3	1	4
+4	2	-1
+5	1	2
+6	2	7
+7	1	-1
+1	3	2
+2	4	4
+3	3	4
+4	4	-1
+5	3	2
+6	4	7
+7	3	-1


### PR DESCRIPTION
Fixes #2745