### PR TITLE
Fix #2750: check enable_external_access flag in more locations

### DIFF
--- a/extension/parquet/parquet-extension.cpp
+++ b/extension/parquet/parquet-extension.cpp
@@ -194,6 +194,10 @@ public:
 	                                                vector<LogicalType> &input_table_types,
 	                                                vector<string> &input_table_names,
 	                                                vector<LogicalType> &return_types, vector<string> &names) {
+		auto &config = DBConfig::GetConfig(context);
+		if (!config.enable_external_access) {
+			throw PermissionException("Scanning Parquet files is disabled through configuration");
+		}
 		auto file_name = inputs[0].GetValue<string>();
 		ParquetOptions parquet_options(context);
 		for (auto &kv : named_parameters) {
@@ -211,6 +215,10 @@ public:
 	                                                    vector<LogicalType> &input_table_types,
 	                                                    vector<string> &input_table_names,
 	                                                    vector<LogicalType> &return_types, vector<string> &names) {
+		auto &config = DBConfig::GetConfig(context);
+		if (!config.enable_external_access) {
+			throw PermissionException("Scanning Parquet files is disabled through configuration");
+		}
 		FileSystem &fs = FileSystem::GetFileSystem(context);
 		vector<string> files;
 		for (auto &val : inputs[0].list_value) {

--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -3,6 +3,7 @@
 
 #ifndef DUCKDB_AMALGAMATION
 #include "duckdb/common/types/blob.hpp"
+#include "duckdb/main/config.hpp"
 #endif
 
 namespace duckdb {
@@ -408,6 +409,10 @@ unique_ptr<FunctionData> ParquetMetaDataBind(ClientContext &context, vector<Valu
                                              unordered_map<string, Value> &named_parameters,
                                              vector<LogicalType> &input_table_types, vector<string> &input_table_names,
                                              vector<LogicalType> &return_types, vector<string> &names) {
+	auto &config = DBConfig::GetConfig(context);
+	if (!config.enable_external_access) {
+		throw PermissionException("Scanning Parquet files is disabled through configuration");
+	}
 	if (SCHEMA) {
 		ParquetMetaDataOperatorData::BindSchema(return_types, names);
 	} else {

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -98,6 +98,8 @@ string Exception::ExceptionTypeToString(ExceptionType type) {
 		return "Invalid Input";
 	case ExceptionType::OUT_OF_MEMORY:
 		return "Out of Memory";
+	case ExceptionType::PERMISSION:
+		return "Permission";
 	default:
 		return "Unknown";
 	}
@@ -181,6 +183,9 @@ CatalogException::CatalogException(const string &msg) : StandardException(Except
 }
 
 ParserException::ParserException(const string &msg) : StandardException(ExceptionType::PARSER, msg) {
+}
+
+PermissionException::PermissionException(const string &msg) : StandardException(ExceptionType::PERMISSION, msg) {
 }
 
 SyntaxException::SyntaxException(const string &msg) : Exception(ExceptionType::SYNTAX, msg) {

--- a/src/execution/physical_plan/plan_export.cpp
+++ b/src/execution/physical_plan/plan_export.cpp
@@ -1,10 +1,15 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/execution/operator/persistent/physical_export.hpp"
 #include "duckdb/planner/operator/logical_export.hpp"
+#include "duckdb/main/config.hpp"
 
 namespace duckdb {
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExport &op) {
+	auto &config = DBConfig::GetConfig(context);
+	if (!config.enable_external_access) {
+		throw PermissionException("Export is disabled through configuration");
+	}
 	auto export_node = make_unique<PhysicalExport>(op.types, op.function, move(op.copy_info), op.estimated_cardinality,
 	                                               op.exported_tables);
 	// plan the underlying copy statements, if any

--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/function/pragma/pragma_functions.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/main/config.hpp"
 
 namespace duckdb {
 
@@ -42,6 +43,10 @@ string PragmaVersion(ClientContext &context, const FunctionParameters &parameter
 }
 
 string PragmaImportDatabase(ClientContext &context, const FunctionParameters &parameters) {
+	auto &config = DBConfig::GetConfig(context);
+	if (!config.enable_external_access) {
+		throw PermissionException("Import is disabled through configuration");
+	}
 	auto &fs = FileSystem::GetFileSystem(context);
 	auto *opener = FileSystem::GetFileOpener(context);
 

--- a/src/function/table/glob.cpp
+++ b/src/function/table/glob.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/function/function_set.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/main/config.hpp"
 
 namespace duckdb {
 
@@ -14,6 +15,10 @@ static unique_ptr<FunctionData> GlobFunctionBind(ClientContext &context, vector<
                                                  vector<LogicalType> &input_table_types,
                                                  vector<string> &input_table_names, vector<LogicalType> &return_types,
                                                  vector<string> &names) {
+	auto &config = DBConfig::GetConfig(context);
+	if (!config.enable_external_access) {
+		throw PermissionException("Globbing is disabled through configuration");
+	}
 	auto result = make_unique<GlobFunctionBindData>();
 	auto &fs = FileSystem::GetFileSystem(context);
 	result->files = fs.Glob(inputs[0].str_value);

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -18,6 +18,10 @@ static unique_ptr<FunctionData> ReadCSVBind(ClientContext &context, vector<Value
                                             unordered_map<string, Value> &named_parameters,
                                             vector<LogicalType> &input_table_types, vector<string> &input_table_names,
                                             vector<LogicalType> &return_types, vector<string> &names) {
+	auto &config = DBConfig::GetConfig(context);
+	if (!config.enable_external_access) {
+		throw PermissionException("Scanning CSV files is disabled through configuration");
+	}
 	auto result = make_unique<ReadCSVData>();
 	auto &options = result->options;
 

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -73,7 +73,8 @@ enum class ExceptionType {
 	INTERNAL =
 	    31, // Internal exception: exception that indicates something went wrong internally (i.e. bug in the code base)
 	INVALID_INPUT = 32, // Input or arguments error
-	OUT_OF_MEMORY = 33  // out of memory
+	OUT_OF_MEMORY = 33, // out of memory
+	PERMISSION = 34     // insufficient permissions
 };
 
 class Exception : public std::exception {
@@ -134,6 +135,16 @@ public:
 
 	template <typename... Args>
 	explicit ParserException(const string &msg, Args... params) : ParserException(ConstructMessage(msg, params...)) {
+	}
+};
+
+class PermissionException : public StandardException {
+public:
+	DUCKDB_API explicit PermissionException(const string &msg);
+
+	template <typename... Args>
+	explicit PermissionException(const string &msg, Args... params)
+	    : PermissionException(ConstructMessage(msg, params...)) {
 	}
 };
 

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -17,7 +17,7 @@ const vector<string> ExtensionHelper::PATH_COMPONENTS = {".duckdb", "extensions"
 void ExtensionHelper::InstallExtension(DatabaseInstance &db, const string &extension, bool force_install) {
 	auto &config = DBConfig::GetConfig(db);
 	if (!config.enable_external_access) {
-		throw Exception("Installing extensions is disabled");
+		throw PermissionException("Installing extensions is disabled through configuration");
 	}
 	auto &fs = FileSystem::GetFileSystem(db);
 

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -21,7 +21,7 @@ static T LoadFunctionFromDLL(void *dll, const string &function_name, const strin
 void ExtensionHelper::LoadExternalExtension(DatabaseInstance &db, const string &extension) {
 	auto &config = DBConfig::GetConfig(db);
 	if (!config.enable_external_access) {
-		throw Exception("Loading external extensions is disabled");
+		throw PermissionException("Loading external extensions is disabled through configuration");
 	}
 	auto &fs = FileSystem::GetFileSystem(db);
 	auto filename = fs.ConvertSeparators(extension);

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -232,10 +232,11 @@ Value DisabledOptimizersSetting::GetSetting(ClientContext &context) {
 // Enable External Access
 //===--------------------------------------------------------------------===//
 void EnableExternalAccessSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
-	if (db) {
+	auto new_value = input.GetValue<bool>();
+	if (db && new_value) {
 		throw InvalidInputException("Cannot change enable_external_access setting while database is running");
 	}
-	config.enable_external_access = input.GetValue<bool>();
+	config.enable_external_access = new_value;
 }
 
 Value EnableExternalAccessSetting::GetSetting(ClientContext &context) {

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -22,7 +22,7 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 	// COPY TO a file
 	auto &config = DBConfig::GetConfig(context);
 	if (!config.enable_external_access) {
-		throw Exception("COPY TO is disabled by configuration");
+		throw PermissionException("COPY TO is disabled by configuration");
 	}
 	BoundStatement result;
 	result.types = {LogicalType::BIGINT};
@@ -52,7 +52,7 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 BoundStatement Binder::BindCopyFrom(CopyStatement &stmt) {
 	auto &config = DBConfig::GetConfig(context);
 	if (!config.enable_external_access) {
-		throw Exception("COPY FROM is disabled by configuration");
+		throw PermissionException("COPY FROM is disabled by configuration");
 	}
 	BoundStatement result;
 	result.types = {LogicalType::BIGINT};

--- a/src/planner/binder/statement/bind_export.cpp
+++ b/src/planner/binder/statement/bind_export.cpp
@@ -43,7 +43,7 @@ BoundStatement Binder::Bind(ExportStatement &stmt) {
 	// COPY TO a file
 	auto &config = DBConfig::GetConfig(context);
 	if (!config.enable_external_access) {
-		throw Exception("COPY TO is disabled by configuration");
+		throw PermissionException("COPY TO is disabled through configuration");
 	}
 	BoundStatement result;
 	result.types = {LogicalType::BOOLEAN};

--- a/test/sql/copy/csv/csv_external_access.test
+++ b/test/sql/copy/csv/csv_external_access.test
@@ -1,0 +1,28 @@
+# name: test/sql/copy/csv/csv_external_access.test
+# description: Test that enable_external_access blocks CSV readers
+# group: [csv]
+
+statement ok
+CREATE TABLE date_test(d date);
+
+statement ok
+COPY date_test FROM 'test/sql/copy/csv/data/test/date.csv';
+
+statement ok
+SET enable_external_access=false;
+
+statement error
+SELECT * FROM read_csv('test/sql/copy/csv/data/test/date.csv', columns = {'d': 'DATE'});
+
+statement error
+SELECT * FROM read_csv_auto('test/sql/copy/csv/data/test/date.csv');
+
+statement error
+COPY date_test FROM 'test/sql/copy/csv/data/test/date.csv';
+
+statement error
+COPY date_test TO '__TEST_DIR__/date.csv'
+
+# we also can't just enable external access again
+statement error
+SET enable_external_access=true;

--- a/test/sql/copy/parquet/parquet_external_access.test
+++ b/test/sql/copy/parquet/parquet_external_access.test
@@ -1,0 +1,42 @@
+# name: test/sql/copy/parquet/parquet_external_access.test
+# description: Test that enable_external_access blocks Parquet reads
+# group: [parquet]
+
+require parquet
+
+# we cannot read parquet files
+statement ok
+CREATE TABLE lineitem AS SELECT * FROM 'data/parquet-testing/arrow/lineitem-arrow.parquet'
+
+statement ok
+SET enable_external_access=false;
+
+# we cannot read parquet files
+statement error
+SELECT * FROM 'data/parquet-testing/arrow/lineitem-arrow.parquet'
+
+# or their metadata
+statement error
+SELECT * FROM parquet_metadata('data/parquet-testing/arrow/lineitem-arrow.parquet')
+
+statement error
+SELECT * FROM parquet_schema('data/parquet-testing/arrow/lineitem-arrow.parquet')
+
+# also not in a list
+statement error
+SELECT * FROM parquet_scan(['data/parquet-testing/arrow/lineitem-arrow.parquet', 'data/parquet-testing/arrow/lineitem-arrow.parquet'])
+
+# neither can we glob
+statement error
+SELECT * FROM glob('data/parquet-testing/arrow/lineitem-arrow.parquet')
+
+# or copy to/from...
+statement error
+COPY lineitem FROM 'data/parquet-testing/arrow/lineitem-arrow.parquet'
+
+statement error
+COPY lineitem TO '__TEST_DIR__/lineitem.parquet'
+
+# we also can't just enable external access again
+statement error
+SET enable_external_access=true;

--- a/test/sql/export/export_external_access.test
+++ b/test/sql/export/export_external_access.test
@@ -1,0 +1,24 @@
+# name: test/sql/export/export_external_access.test
+# description: Test export database
+# group: [export]
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+CREATE TABLE integers(i INTEGER, j INTEGER, CHECK(i+j<10))
+
+statement ok
+EXPORT DATABASE '__TEST_DIR__/export_permissions_test' (FORMAT CSV)
+
+statement ok
+ROLLBACK
+
+statement ok
+SET enable_external_access=false
+
+statement error
+IMPORT DATABASE '__TEST_DIR__/export_permissions_test'
+
+statement error
+EXPORT DATABASE '__TEST_DIR__/export_permissions_test2' (FORMAT CSV)


### PR DESCRIPTION
Fixes #2750 

This PR correctly checks the `enable_external_access` flag in several more locations that were missing this check before, including the Parquet reader, CSV reader, Parquet metadata reader, the EXPORT/IMPORT functions and the glob function.