### PR TITLE
Python - Test All Types

### DIFF
--- a/src/catalog/catalog_entry/type_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/type_catalog_entry.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/serializer.hpp"
 #include "duckdb/parser/parsed_data/create_sequence_info.hpp"
-
+#include "duckdb/common/types/vector.hpp"
 #include <algorithm>
 #include <sstream>
 

--- a/src/catalog/catalog_entry/type_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/type_catalog_entry.cpp
@@ -34,14 +34,15 @@ string TypeCatalogEntry::ToSQL() {
 	std::stringstream ss;
 	switch (user_type->id()) {
 	case (LogicalTypeId::ENUM): {
-		auto values_insert_order = EnumType::GetValuesInsertOrder(*user_type);
+		Vector values_insert_order(EnumType::GetValuesInsertOrder(*user_type));
+		idx_t size = EnumType::GetSize(*user_type);
 		ss << "CREATE TYPE ";
 		ss << name;
 		ss << " AS ENUM ( ";
 
-		for (idx_t i = 0; i < values_insert_order.size(); i++) {
-			ss << "'" << values_insert_order[i] << "'";
-			if (i != values_insert_order.size() - 1) {
+		for (idx_t i = 0; i < size; i++) {
+			ss << "'" << values_insert_order.GetValue(i).ToString() << "'";
+			if (i != size - 1) {
 				ss << ", ";
 			}
 		}

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -1083,8 +1083,7 @@ struct EnumTypeInfoTemplated : public EnumTypeInfo {
 			values[values_insert_order_p.GetValue(count).ToString()] = count;
 		}
 	}
-	static shared_ptr<EnumTypeInfoTemplated> Deserialize(Deserializer &source) {
-		auto size = source.Read<uint32_t>();
+	static shared_ptr<EnumTypeInfoTemplated> Deserialize(Deserializer &source, uint32_t size) {
 		auto enum_name = source.Read<string>();
 		Vector values_insert_order(LogicalType::VARCHAR);
 		values_insert_order.Deserialize(size, source);
@@ -1224,14 +1223,15 @@ shared_ptr<ExtraTypeInfo> ExtraTypeInfo::Deserialize(Deserializer &source) {
 	case ExtraTypeInfoType::USER_TYPE_INFO:
 		return UserTypeInfo::Deserialize(source);
 	case ExtraTypeInfoType::ENUM_TYPE_INFO: {
-		auto enum_internal_type = EnumType::GetPhysicalType(source.Read<uint32_t>());
+		auto enum_size = source.Read<uint32_t>();
+		auto enum_internal_type = EnumType::GetPhysicalType(enum_size);
 		switch (enum_internal_type) {
 		case PhysicalType::UINT8:
-			return EnumTypeInfoTemplated<uint8_t>::Deserialize(source);
+			return EnumTypeInfoTemplated<uint8_t>::Deserialize(source, enum_size);
 		case PhysicalType::UINT16:
-			return EnumTypeInfoTemplated<uint16_t>::Deserialize(source);
+			return EnumTypeInfoTemplated<uint16_t>::Deserialize(source, enum_size);
 		case PhysicalType::UINT32:
-			return EnumTypeInfoTemplated<uint32_t>::Deserialize(source);
+			return EnumTypeInfoTemplated<uint32_t>::Deserialize(source, enum_size);
 		default:
 			throw InternalException("Invalid Physical Type for ENUMs");
 		}

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -1085,7 +1085,7 @@ struct EnumTypeInfoTemplated : public EnumTypeInfo {
 	}
 	static shared_ptr<EnumTypeInfoTemplated> Deserialize(Deserializer &source, uint32_t size) {
 		auto enum_name = source.Read<string>();
-		Vector values_insert_order(LogicalType::VARCHAR);
+		Vector values_insert_order(LogicalType::VARCHAR, size);
 		values_insert_order.Deserialize(size, source);
 		return make_shared<EnumTypeInfoTemplated>(move(enum_name), values_insert_order, size);
 	}

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -13,6 +13,7 @@
 #include <cmath>
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/catalog/catalog_entry/type_catalog_entry.hpp"
+#include "duckdb/common/types/vector.hpp"
 
 namespace duckdb {
 
@@ -747,7 +748,7 @@ struct ExtraTypeInfo {
 public:
 	virtual bool Equals(ExtraTypeInfo *other) = 0;
 	//! Serializes a ExtraTypeInfo to a stand-alone binary blob
-	virtual void Serialize(Serializer &serializer) const = 0;
+	virtual void Serialize(Serializer &serializer) = 0;
 	//! Serializes a ExtraTypeInfo to a stand-alone binary blob
 	static void Serialize(ExtraTypeInfo *info, Serializer &serializer);
 	//! Deserializes a blob back into an ExtraTypeInfo
@@ -777,7 +778,7 @@ public:
 		return width == other.width && scale == other.scale;
 	}
 
-	void Serialize(Serializer &serializer) const override {
+	void Serialize(Serializer &serializer) override {
 		serializer.Write<uint8_t>(width);
 		serializer.Write<uint8_t>(scale);
 	}
@@ -824,7 +825,7 @@ public:
 		return true;
 	}
 
-	void Serialize(Serializer &serializer) const override {
+	void Serialize(Serializer &serializer) override {
 		serializer.WriteString(collation);
 	}
 
@@ -872,7 +873,7 @@ public:
 		return child_type == other.child_type;
 	}
 
-	void Serialize(Serializer &serializer) const override {
+	void Serialize(Serializer &serializer) override {
 		child_type.Serialize(serializer);
 	}
 
@@ -916,7 +917,7 @@ public:
 		return child_types == other.child_types;
 	}
 
-	void Serialize(Serializer &serializer) const override {
+	void Serialize(Serializer &serializer) override {
 		serializer.Write<uint32_t>(child_types.size());
 		for (idx_t i = 0; i < child_types.size(); i++) {
 			serializer.WriteString(child_types[i].first);
@@ -998,7 +999,7 @@ public:
 		return other.user_type_name == user_type_name;
 	}
 
-	void Serialize(Serializer &serializer) const override {
+	void Serialize(Serializer &serializer) override {
 		serializer.WriteString(user_type_name);
 	}
 
@@ -1024,12 +1025,13 @@ LogicalType LogicalType::USER(const string &user_type_name) {
 // Enum Type
 //===--------------------------------------------------------------------===//
 struct EnumTypeInfo : public ExtraTypeInfo {
-	explicit EnumTypeInfo(string enum_name_p, vector<string> values_insert_order_p)
+	explicit EnumTypeInfo(string enum_name_p, Vector &values_insert_order_p, idx_t size)
 	    : ExtraTypeInfo(ExtraTypeInfoType::ENUM_TYPE_INFO), enum_name(move(enum_name_p)),
-	      values_insert_order(std::move(values_insert_order_p)) {
+	      values_insert_order(values_insert_order_p), size(size) {
 	}
 	string enum_name;
-	vector<string> values_insert_order;
+	Vector values_insert_order;
+	idx_t size;
 	TypeCatalogEntry *catalog_entry = nullptr;
 
 public:
@@ -1042,33 +1044,51 @@ public:
 			return false;
 		}
 		auto &other = (EnumTypeInfo &)*other_p;
-		// We must check if all elements are equal
-		if (other.values_insert_order == values_insert_order) {
-			return true;
+
+		// We must check if both enums have the same size
+		if (other.size != size) {
+			return false;
 		}
-		return false;
+		auto other_vector_ptr = FlatVector::GetData<string_t>(other.values_insert_order);
+		auto this_vector_ptr = FlatVector::GetData<string_t>(values_insert_order);
+
+		// Now we must check if all strings are the same
+		for (idx_t i = 0; i < size; i++) {
+			auto str_size = this_vector_ptr[i].GetSize();
+			if (other_vector_ptr[i].GetSize() != this_vector_ptr[i].GetSize()) {
+				return false;
+			}
+			auto other_str = other_vector_ptr[i].GetDataUnsafe();
+			auto this_str = this_vector_ptr[i].GetDataUnsafe();
+			for (idx_t str_idx = 0; i < str_size; i++) {
+				if (other_str[str_idx] != this_str[str_idx]) {
+					return false;
+				}
+			}
+		}
+		return true;
 	}
-	void Serialize(Serializer &serializer) const override {
-		serializer.Write<uint32_t>(values_insert_order.size());
+	void Serialize(Serializer &serializer) override {
+		serializer.Write<uint32_t>(size);
 		serializer.WriteString(enum_name);
-		serializer.WriteStringVector(values_insert_order);
+		values_insert_order.Serialize(size, serializer);
 	}
 };
 
 template <class T>
 struct EnumTypeInfoTemplated : public EnumTypeInfo {
-	explicit EnumTypeInfoTemplated(const string &enum_name_p, const vector<string> &values_insert_order_p)
-	    : EnumTypeInfo(enum_name_p, values_insert_order_p) {
-		idx_t count = 0;
-		for (auto &value : values_insert_order) {
-			values[value] = count++;
+	explicit EnumTypeInfoTemplated(const string &enum_name_p, Vector &values_insert_order_p, idx_t size_p)
+	    : EnumTypeInfo(enum_name_p, values_insert_order_p, size_p) {
+		for (idx_t count = 0; count < size_p; count++) {
+			values[values_insert_order_p.GetValue(count).ToString()] = count;
 		}
 	}
 	static shared_ptr<EnumTypeInfoTemplated> Deserialize(Deserializer &source) {
+		auto size = source.Read<uint32_t>();
 		auto enum_name = source.Read<string>();
-		vector<string> values_insert_order;
-		source.ReadStringVector(values_insert_order);
-		return make_shared<EnumTypeInfoTemplated>(move(enum_name), move(values_insert_order));
+		Vector values_insert_order(LogicalType::VARCHAR);
+		values_insert_order.Deserialize(size, source);
+		return make_shared<EnumTypeInfoTemplated>(move(enum_name), values_insert_order, size);
 	}
 	unordered_map<string, T> values;
 };
@@ -1080,20 +1100,19 @@ const string &EnumType::GetTypeName(const LogicalType &type) {
 	return ((EnumTypeInfo &)*info).enum_name;
 }
 
-LogicalType LogicalType::ENUM(const string &enum_name, const vector<string> &ordered_data) {
-	auto size = ordered_data.size();
+LogicalType LogicalType::ENUM(const string &enum_name, Vector &ordered_data, idx_t size) {
 	// Generate EnumTypeInfo
 	shared_ptr<ExtraTypeInfo> info;
 	auto enum_internal_type = EnumType::GetPhysicalType(size);
 	switch (enum_internal_type) {
 	case PhysicalType::UINT8:
-		info = make_shared<EnumTypeInfoTemplated<uint8_t>>(enum_name, ordered_data);
+		info = make_shared<EnumTypeInfoTemplated<uint8_t>>(enum_name, ordered_data, size);
 		break;
 	case PhysicalType::UINT16:
-		info = make_shared<EnumTypeInfoTemplated<uint16_t>>(enum_name, ordered_data);
+		info = make_shared<EnumTypeInfoTemplated<uint16_t>>(enum_name, ordered_data, size);
 		break;
 	case PhysicalType::UINT32:
-		info = make_shared<EnumTypeInfoTemplated<uint32_t>>(enum_name, ordered_data);
+		info = make_shared<EnumTypeInfoTemplated<uint32_t>>(enum_name, ordered_data, size);
 		break;
 	default:
 		throw InternalException("Invalid Physical Type for ENUMs");
@@ -1124,22 +1143,22 @@ int64_t EnumType::GetPos(const LogicalType &type, const string &key) {
 	}
 }
 
-const string &EnumType::GetValue(const Value &val) {
+const string EnumType::GetValue(const Value &val) {
 	auto info = val.type().AuxInfo();
-	vector<string> &values_insert_order = ((EnumTypeInfo &)*info).values_insert_order;
+	auto &values_insert_order = ((EnumTypeInfo &)*info).values_insert_order;
 	switch (val.type().InternalType()) {
 	case PhysicalType::UINT8:
-		return values_insert_order[val.value_.utinyint];
+		return values_insert_order.GetValue(val.value_.utinyint).ToString();
 	case PhysicalType::UINT16:
-		return values_insert_order[val.value_.usmallint];
+		return values_insert_order.GetValue(val.value_.usmallint).ToString();
 	case PhysicalType::UINT32:
-		return values_insert_order[val.value_.uinteger];
+		return values_insert_order.GetValue(val.value_.uinteger).ToString();
 	default:
 		throw InternalException("Invalid Internal Type for ENUMs");
 	}
 }
 
-const vector<string> &EnumType::GetValuesInsertOrder(const LogicalType &type) {
+Vector &EnumType::GetValuesInsertOrder(const LogicalType &type) {
 	D_ASSERT(type.id() == LogicalTypeId::ENUM);
 	auto info = type.AuxInfo();
 	D_ASSERT(info);
@@ -1150,7 +1169,7 @@ idx_t EnumType::GetSize(const LogicalType &type) {
 	D_ASSERT(type.id() == LogicalTypeId::ENUM);
 	auto info = type.AuxInfo();
 	D_ASSERT(info);
-	return ((EnumTypeInfo &)*info).values_insert_order.size();
+	return ((EnumTypeInfo &)*info).size;
 }
 
 void EnumType::SetCatalog(LogicalType &type, TypeCatalogEntry *catalog_entry) {

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -14,6 +14,7 @@
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/catalog/catalog_entry/type_catalog_entry.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/operator/comparison_operators.hpp"
 
 namespace duckdb {
 
@@ -1054,16 +1055,8 @@ public:
 
 		// Now we must check if all strings are the same
 		for (idx_t i = 0; i < size; i++) {
-			auto str_size = this_vector_ptr[i].GetSize();
-			if (other_vector_ptr[i].GetSize() != this_vector_ptr[i].GetSize()) {
+			if (!Equals::Operation(other_vector_ptr[i], this_vector_ptr[i])) {
 				return false;
-			}
-			auto other_str = other_vector_ptr[i].GetDataUnsafe();
-			auto this_str = this_vector_ptr[i].GetDataUnsafe();
-			for (idx_t str_idx = 0; i < str_size; i++) {
-				if (other_str[str_idx] != this_str[str_idx]) {
-					return false;
-				}
 			}
 		}
 		return true;

--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -429,7 +429,7 @@ struct ArrowUUIDConversion {
 	}
 
 	static idx_t GetStringLength(uint64_t value) {
-		return UUID::SIZE;
+		return UUID::STRING_SIZE;
 	}
 
 	static string_t ConvertValue(Vector &tgt_vec, string_t *tgt_ptr, internal_type_t *src_ptr, idx_t row) {

--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -421,6 +421,79 @@ void SetStructMap(DuckDBArrowArrayChildHolder &child_holder, const LogicalType &
 	}
 }
 
+struct ArrowUUIDConversion {
+	using internal_type_t = uint64_t;
+
+	static unique_ptr<Vector> InitializeVector(Vector &data, idx_t size) {
+		return make_unique<Vector>(LogicalType::VARCHAR, size);
+	}
+
+	static idx_t GetStringLength(uint64_t value) {
+		return UUID::SIZE;
+	}
+
+	static string_t ConvertValue(Vector &tgt_vec, string_t *tgt_ptr, internal_type_t *src_ptr, idx_t row) {
+		auto str_value = UUID::ToString(src_ptr[row]);
+		// Have to store this string
+		tgt_ptr[row] = StringVector::AddStringOrBlob(tgt_vec, str_value);
+		return tgt_ptr[row];
+	}
+};
+
+struct ArrowVarcharConversion {
+	using internal_type_t = string_t;
+
+	static unique_ptr<Vector> InitializeVector(Vector &data, idx_t size) {
+		return make_unique<Vector>(data);
+	}
+	static idx_t GetStringLength(string_t value) {
+		return value.GetSize();
+	}
+
+	static string_t ConvertValue(Vector &tgt_vec, string_t *tgt_ptr, internal_type_t *src_ptr, idx_t row) {
+		return src_ptr[row];
+	}
+};
+
+template <class CONVERT, class VECTOR_TYPE>
+void SetVarchar(DuckDBArrowArrayChildHolder &child_holder, const LogicalType &type, Vector &data, idx_t size) {
+	auto &child = child_holder.array;
+	child_holder.vector = CONVERT::InitializeVector(data, size);
+	auto target_data_ptr = FlatVector::GetData<string_t>(data);
+	child.n_buffers = 3;
+	child_holder.offsets = unique_ptr<data_t[]>(new data_t[sizeof(uint32_t) * (size + 1)]);
+	child.buffers[1] = child_holder.offsets.get();
+	D_ASSERT(child.buffers[1]);
+	//! step 1: figure out total string length:
+	idx_t total_string_length = 0;
+	auto source_ptr = FlatVector::GetData<VECTOR_TYPE>(data);
+	auto &mask = FlatVector::Validity(data);
+	for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+		if (!mask.RowIsValid(row_idx)) {
+			continue;
+		}
+		total_string_length += CONVERT::GetStringLength(source_ptr[row_idx]);
+	}
+	//! step 2: allocate this much
+	child_holder.data = unique_ptr<data_t[]>(new data_t[total_string_length]);
+	child.buffers[2] = child_holder.data.get();
+	D_ASSERT(child.buffers[2]);
+	//! step 3: assign buffers
+	idx_t current_heap_offset = 0;
+	auto target_ptr = (uint32_t *)child.buffers[1];
+
+	for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+		target_ptr[row_idx] = current_heap_offset;
+		if (!mask.RowIsValid(row_idx)) {
+			continue;
+		}
+		string_t str = CONVERT::ConvertValue(*child_holder.vector, target_data_ptr, source_ptr, row_idx);
+		memcpy((void *)((uint8_t *)child.buffers[2] + current_heap_offset), str.GetDataUnsafe(), str.GetSize());
+		current_heap_offset += str.GetSize();
+	}
+	target_ptr[size] = current_heap_offset; //! need to terminate last string!
+}
+
 void SetArrowChild(DuckDBArrowArrayChildHolder &child_holder, const LogicalType &type, Vector &data, idx_t size) {
 	auto &child = child_holder.array;
 	switch (type.id()) {
@@ -525,52 +598,12 @@ void SetArrowChild(DuckDBArrowArrayChildHolder &child_holder, const LogicalType 
 		break;
 	}
 	case LogicalTypeId::BLOB:
-	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::VARCHAR: {
+		SetVarchar<ArrowVarcharConversion, string_t>(child_holder, type, data, size);
+		break;
+	}
 	case LogicalTypeId::UUID: {
-		child_holder.vector = make_unique<Vector>(data);
-		child.n_buffers = 3;
-		child_holder.offsets = unique_ptr<data_t[]>(new data_t[sizeof(uint32_t) * (size + 1)]);
-		child.buffers[1] = child_holder.offsets.get();
-		D_ASSERT(child.buffers[1]);
-		//! step 1: figure out total string length:
-		idx_t total_string_length = 0;
-		auto string_t_ptr = FlatVector::GetData<string_t>(*child_holder.vector);
-		auto uint64_t_ptr = FlatVector::GetData<uint64_t>(*child_holder.vector);
-
-		auto &mask = FlatVector::Validity(*child_holder.vector);
-		for (idx_t row_idx = 0; row_idx < size; row_idx++) {
-			if (!mask.RowIsValid(row_idx)) {
-				continue;
-			}
-			if (type.id() == LogicalTypeId::UUID) {
-				total_string_length += 36;
-			} else {
-				total_string_length += string_t_ptr[row_idx].GetSize();
-			}
-		}
-		//! step 2: allocate this much
-		child_holder.data = unique_ptr<data_t[]>(new data_t[total_string_length]);
-		child.buffers[2] = child_holder.data.get();
-		D_ASSERT(child.buffers[2]);
-		//! step 3: assign buffers
-		idx_t current_heap_offset = 0;
-		auto target_ptr = (uint32_t *)child.buffers[1];
-
-		for (idx_t row_idx = 0; row_idx < size; row_idx++) {
-			target_ptr[row_idx] = current_heap_offset;
-			if (!mask.RowIsValid(row_idx)) {
-				continue;
-			}
-			string_t str;
-			if (type.id() == LogicalTypeId::UUID) {
-				str = UUID::ToString(uint64_t_ptr[row_idx]);
-			} else {
-				str = string_t_ptr[row_idx];
-			}
-			memcpy((void *)((uint8_t *)child.buffers[2] + current_heap_offset), str.GetDataUnsafe(), str.GetSize());
-			current_heap_offset += str.GetSize();
-		}
-		target_ptr[size] = current_heap_offset; //! need to terminate last string!
+		SetVarchar<ArrowUUIDConversion, uint64_t>(child_holder, type, data, size);
 		break;
 	}
 	case LogicalTypeId::LIST: {

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -1128,7 +1128,7 @@ string Value::ToString() const {
 		default:
 			throw InternalException("ENUM can only have unsigned integers (except UINT64) as physical types");
 		}
-		return values_insert_order[enum_idx];
+		return values_insert_order.GetValue(enum_idx).ToString();
 	}
 	default:
 		throw NotImplementedException("Unimplemented type for printing: %s", type_.ToString());

--- a/src/common/vector_operations/vector_cast.cpp
+++ b/src/common/vector_operations/vector_cast.cpp
@@ -614,7 +614,7 @@ void FillEnum(Vector &source, Vector &result, idx_t count) {
 
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 
-	auto str_vec = EnumType::GetValuesInsertOrder(source.GetType());
+	Vector str_vec(EnumType::GetValuesInsertOrder(source.GetType()));
 	auto res_enum_type = result.GetType();
 
 	VectorData vdata;
@@ -633,7 +633,7 @@ void FillEnum(Vector &source, Vector &result, idx_t count) {
 			result_mask.SetInvalid(i);
 			continue;
 		}
-		auto str = str_vec[source_data[src_idx]];
+		auto str = str_vec.GetValue(source_data[src_idx]).ToString();
 		auto key = EnumType::GetPos(res_enum_type, str);
 		if (key == -1) {
 			// key doesn't exist on result enum
@@ -673,7 +673,7 @@ void EnumToVarchar(Vector &source, Vector &result, idx_t count, PhysicalType enu
 			result.SetValue(i, Value());
 			continue;
 		}
-		auto str_vec = EnumType::GetValuesInsertOrder(source.GetType());
+		Vector str_vec(EnumType::GetValuesInsertOrder(source.GetType()));
 		uint64_t enum_idx;
 		switch (enum_physical_type) {
 		case PhysicalType::UINT8:
@@ -688,7 +688,7 @@ void EnumToVarchar(Vector &source, Vector &result, idx_t count, PhysicalType enu
 		default:
 			throw InternalException("ENUM can only have unsigned integers (except UINT64) as physical types");
 		}
-		result.SetValue(i, Value(str_vec[enum_idx]));
+		result.SetValue(i, str_vec.GetValue(enum_idx));
 	}
 }
 

--- a/src/function/table/system/test_all_types.cpp
+++ b/src/function/table/system/test_all_types.cpp
@@ -11,12 +11,6 @@ struct TestAllTypesData : public FunctionOperatorData {
 	idx_t offset;
 };
 
-void ResizeEnum(Vector &enum_vector, idx_t new_size) {
-	if (new_size > STANDARD_VECTOR_SIZE) {
-		enum_vector.Resize(STANDARD_VECTOR_SIZE, new_size);
-	}
-}
-
 struct TestType {
 	TestType(LogicalType type_p, string name_p)
 	    : type(move(type_p)), name(move(name_p)), min_value(Value::MinimumValue(type)),
@@ -79,14 +73,12 @@ static vector<TestType> GetTestTypes() {
 	                    Value("\\x00\\x00\\x00a"));
 
 	// enums
-	Vector small_enum(LogicalType::VARCHAR);
-	ResizeEnum(small_enum, 2);
+	Vector small_enum(LogicalType::VARCHAR, 2);
 	small_enum.SetValue(0, "DUCK_DUCK_ENUM");
 	small_enum.SetValue(1, "GOOSE");
 	result.emplace_back(LogicalType::ENUM("small_enum", small_enum, 2), "small_enum");
 
-	Vector medium_enum(LogicalType::VARCHAR);
-	ResizeEnum(medium_enum, 300);
+	Vector medium_enum(LogicalType::VARCHAR, 300);
 
 	for (idx_t i = 0; i < 300; i++) {
 		medium_enum.SetValue(i, string("enum_") + to_string(i));
@@ -94,8 +86,7 @@ static vector<TestType> GetTestTypes() {
 	result.emplace_back(LogicalType::ENUM("medium_enum", medium_enum, 300), "medium_enum");
 
 	// this is a big one... not sure if we should push this one here, but it's required for completeness
-	Vector large_enum(LogicalType::VARCHAR);
-	ResizeEnum(large_enum, 700);
+	Vector large_enum(LogicalType::VARCHAR, 70000);
 
 	large_enum.Resize(STANDARD_VECTOR_SIZE, 70000);
 

--- a/src/function/table/system/test_all_types.cpp
+++ b/src/function/table/system/test_all_types.cpp
@@ -74,24 +74,23 @@ static vector<TestType> GetTestTypes() {
 
 	// enums
 	Vector small_enum(LogicalType::VARCHAR, 2);
-	small_enum.SetValue(0, "DUCK_DUCK_ENUM");
-	small_enum.SetValue(1, "GOOSE");
+	auto small_enum_ptr = FlatVector::GetData<string_t>(small_enum);
+	small_enum_ptr[0] = StringVector::AddStringOrBlob(small_enum, "DUCK_DUCK_ENUM");
+	small_enum_ptr[1] = StringVector::AddStringOrBlob(small_enum, "GOOSE");
 	result.emplace_back(LogicalType::ENUM("small_enum", small_enum, 2), "small_enum");
 
 	Vector medium_enum(LogicalType::VARCHAR, 300);
-
+	auto medium_enum_ptr = FlatVector::GetData<string_t>(medium_enum);
 	for (idx_t i = 0; i < 300; i++) {
-		medium_enum.SetValue(i, string("enum_") + to_string(i));
+		medium_enum_ptr[i] = StringVector::AddStringOrBlob(medium_enum, string("enum_") + to_string(i));
 	}
 	result.emplace_back(LogicalType::ENUM("medium_enum", medium_enum, 300), "medium_enum");
 
 	// this is a big one... not sure if we should push this one here, but it's required for completeness
 	Vector large_enum(LogicalType::VARCHAR, 70000);
-
-	large_enum.Resize(STANDARD_VECTOR_SIZE, 70000);
-
+	auto large_enum_ptr = FlatVector::GetData<string_t>(large_enum);
 	for (idx_t i = 0; i < 70000; i++) {
-		large_enum.SetValue(i, string("enum_") + to_string(i));
+		large_enum_ptr[i] = StringVector::AddStringOrBlob(large_enum, string("enum_") + to_string(i));
 	}
 	result.emplace_back(LogicalType::ENUM("large_enum", large_enum, 70000), "large_enum");
 

--- a/src/function/table/system/test_all_types.cpp
+++ b/src/function/table/system/test_all_types.cpp
@@ -11,6 +11,12 @@ struct TestAllTypesData : public FunctionOperatorData {
 	idx_t offset;
 };
 
+void ResizeEnum(Vector &enum_vector, idx_t new_size) {
+	if (new_size > STANDARD_VECTOR_SIZE) {
+		enum_vector.Resize(STANDARD_VECTOR_SIZE, new_size);
+	}
+}
+
 struct TestType {
 	TestType(LogicalType type_p, string name_p)
 	    : type(move(type_p)), name(move(name_p)), min_value(Value::MinimumValue(type)),
@@ -73,21 +79,30 @@ static vector<TestType> GetTestTypes() {
 	                    Value("\\x00\\x00\\x00a"));
 
 	// enums
-	vector<string> small_enum {"DUCK_DUCK_ENUM", "GOOSE"};
-	result.emplace_back(LogicalType::ENUM("small_enum", small_enum), "small_enum");
+	Vector small_enum(LogicalType::VARCHAR);
+	ResizeEnum(small_enum, 2);
+	small_enum.SetValue(0, "DUCK_DUCK_ENUM");
+	small_enum.SetValue(1, "GOOSE");
+	result.emplace_back(LogicalType::ENUM("small_enum", small_enum, 2), "small_enum");
 
-	vector<string> medium_enum;
+	Vector medium_enum(LogicalType::VARCHAR);
+	ResizeEnum(medium_enum, 300);
+
 	for (idx_t i = 0; i < 300; i++) {
-		medium_enum.push_back(string("enum_") + to_string(i));
+		medium_enum.SetValue(i, string("enum_") + to_string(i));
 	}
-	result.emplace_back(LogicalType::ENUM("medium_enum", medium_enum), "medium_enum");
+	result.emplace_back(LogicalType::ENUM("medium_enum", medium_enum, 300), "medium_enum");
 
 	// this is a big one... not sure if we should push this one here, but it's required for completeness
-	vector<string> large_enum;
+	Vector large_enum(LogicalType::VARCHAR);
+	ResizeEnum(large_enum, 700);
+
+	large_enum.Resize(STANDARD_VECTOR_SIZE, 70000);
+
 	for (idx_t i = 0; i < 70000; i++) {
-		large_enum.push_back(string("enum_") + to_string(i));
+		large_enum.SetValue(i, string("enum_") + to_string(i));
 	}
-	result.emplace_back(LogicalType::ENUM("large_enum", large_enum), "large_enum");
+	result.emplace_back(LogicalType::ENUM("large_enum", large_enum, 70000), "large_enum");
 
 	// arrays
 	auto int_list_type = LogicalType::LIST(LogicalType::INTEGER);

--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -20,6 +20,7 @@ class Serializer;
 class Deserializer;
 class Value;
 class TypeCatalogEntry;
+class Vector;
 //! Type used to represent dates (days since 1970-01-01)
 struct date_t {
 	int32_t days;
@@ -474,7 +475,7 @@ public:
 	DUCKDB_API static LogicalType STRUCT( child_list_t<LogicalType> children);    // NOLINT
 	DUCKDB_API static LogicalType MAP( child_list_t<LogicalType> children);       // NOLINT
 	DUCKDB_API static LogicalType MAP(LogicalType key, LogicalType value); // NOLINT
-	DUCKDB_API static LogicalType ENUM(const string &enum_name, const vector<string> &ordered_data); // NOLINT
+	DUCKDB_API static LogicalType ENUM(const string &enum_name, Vector &ordered_data, idx_t size); // NOLINT
 	DUCKDB_API static LogicalType USER(const string &user_type_name); // NOLINT
 	//! A list of all NUMERIC types (integral and floating point types)
 	DUCKDB_API static const vector<LogicalType> NUMERIC;
@@ -504,9 +505,9 @@ struct UserType{
 struct EnumType{
 	DUCKDB_API static const string &GetTypeName(const LogicalType &type);
 	DUCKDB_API static int64_t GetPos(const LogicalType &type, const string& key);
-	DUCKDB_API static const vector<string> &GetValuesInsertOrder(const LogicalType &type);
+	DUCKDB_API static Vector &GetValuesInsertOrder(const LogicalType &type);
 	DUCKDB_API static idx_t GetSize(const LogicalType &type);
-	DUCKDB_API static const string& GetValue(const Value &val);
+	DUCKDB_API static const string GetValue(const Value &val);
 	DUCKDB_API static void SetCatalog(LogicalType &type, TypeCatalogEntry* catalog_entry);
 	DUCKDB_API static TypeCatalogEntry* GetCatalog(const LogicalType &type);
 	DUCKDB_API static PhysicalType GetPhysicalType(idx_t size);

--- a/src/include/duckdb/common/types/uuid.hpp
+++ b/src/include/duckdb/common/types/uuid.hpp
@@ -16,6 +16,7 @@ namespace duckdb {
 //! The UUID class contains static operations for the UUID type
 class UUID {
 public:
+	constexpr static const uint8_t STRING_SIZE = 36;
 	//! Convert a uuid string to a hugeint object
 	static bool FromString(string str, hugeint_t &result);
 	//! Convert a uuid string to a hugeint object
@@ -27,9 +28,9 @@ public:
 
 	//! Convert a hugeint object to a uuid style string
 	static string ToString(hugeint_t input) {
-		char buff[SIZE];
+		char buff[STRING_SIZE];
 		ToString(input, buff);
-		return string(buff, SIZE);
+		return string(buff, STRING_SIZE);
 	}
 
 	static hugeint_t FromString(string str) {
@@ -37,7 +38,6 @@ public:
 		FromString(str, result);
 		return result;
 	}
-	static const uint8_t SIZE = 36;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/types/uuid.hpp
+++ b/src/include/duckdb/common/types/uuid.hpp
@@ -27,9 +27,9 @@ public:
 
 	//! Convert a hugeint object to a uuid style string
 	static string ToString(hugeint_t input) {
-		char buff[36];
+		char buff[SIZE];
 		ToString(input, buff);
-		return string(buff, 36);
+		return string(buff, SIZE);
 	}
 
 	static hugeint_t FromString(string str) {
@@ -37,6 +37,7 @@ public:
 		FromString(str, result);
 		return result;
 	}
+	static const uint8_t SIZE = 36;
 };
 
 } // namespace duckdb

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -292,7 +292,14 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		default:
 			throw InternalException("Unsupported Enum Internal Type");
 		}
+		root_holder.nested_children.emplace_back();
+		root_holder.nested_children.back().resize(1);
+		root_holder.nested_children_ptr.emplace_back();
+		root_holder.nested_children_ptr.back().push_back(&root_holder.nested_children.back()[0]);
+		InitializeChild(root_holder.nested_children.back()[0]);
+		child.dictionary = root_holder.nested_children_ptr.back()[0];
 		child.dictionary->format = "u";
+		break;
 	}
 	default:
 		throw InternalException("Unsupported Arrow type " + type.ToString());

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -278,6 +278,22 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		SetArrowMapFormat(root_holder, child, type);
 		break;
 	}
+	case LogicalTypeId::ENUM: {
+		switch (EnumType::GetPhysicalType(EnumType::GetSize(type))) {
+		case PhysicalType::UINT8:
+			child.format = "C";
+			break;
+		case PhysicalType::UINT16:
+			child.format = "S";
+			break;
+		case PhysicalType::UINT32:
+			child.format = "I";
+			break;
+		default:
+			throw InternalException("Unsupported Enum Internal Type");
+		}
+		child.dictionary->format = "u";
+	}
 	default:
 		throw InternalException("Unsupported Arrow type " + type.ToString());
 	}

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -183,6 +183,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 	case LogicalTypeId::DOUBLE:
 		child.format = "g";
 		break;
+	case LogicalTypeId::UUID:
 	case LogicalTypeId::VARCHAR:
 		child.format = "u";
 		break;

--- a/src/optimizer/rule/enum_comparison.cpp
+++ b/src/optimizer/rule/enum_comparison.cpp
@@ -33,10 +33,11 @@ bool AreMatchesPossible(LogicalType &left, LogicalType &right) {
 		small_enum = &right;
 		big_enum = &left;
 	}
-	Vector string_vec(EnumType::GetValuesInsertOrder(*small_enum));
+	auto &string_vec = EnumType::GetValuesInsertOrder(*small_enum);
+	auto string_vec_ptr = FlatVector::GetData<string_t>(string_vec);
 	auto size = EnumType::GetSize(*small_enum);
 	for (idx_t i = 0; i < size; i++) {
-		auto key = string_vec.GetValue(i).ToString();
+		auto key = string_vec_ptr[i].GetString();
 		if (EnumType::GetPos(*big_enum, key) != -1) {
 			return true;
 		}

--- a/src/optimizer/rule/enum_comparison.cpp
+++ b/src/optimizer/rule/enum_comparison.cpp
@@ -33,8 +33,10 @@ bool AreMatchesPossible(LogicalType &left, LogicalType &right) {
 		small_enum = &right;
 		big_enum = &left;
 	}
-	auto string_vec = EnumType::GetValuesInsertOrder(*small_enum);
-	for (auto &key : string_vec) {
+	Vector string_vec(EnumType::GetValuesInsertOrder(*small_enum));
+	auto size = EnumType::GetSize(*small_enum);
+	for (idx_t i = 0; i < size; i++) {
+		auto key = string_vec.GetValue(i).ToString();
 		if (EnumType::GetPos(*big_enum, key) != -1) {
 			return true;
 		}

--- a/src/parser/transform/statement/transform_create_enum.cpp
+++ b/src/parser/transform/statement/transform_create_enum.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/parser/statement/create_statement.hpp"
 #include "duckdb/parser/transformer.hpp"
 #include "duckdb/common/types.hpp"
+#include "duckdb/common/types/vector.hpp"
 
 namespace duckdb {
 

--- a/src/parser/transform/statement/transform_create_enum.cpp
+++ b/src/parser/transform/statement/transform_create_enum.cpp
@@ -29,11 +29,12 @@ Vector ReadPgListToVector(duckdb_libpgquery::PGList *column_list, idx_t &size) {
 	}
 
 	Vector result(LogicalType::VARCHAR, size);
+	auto result_ptr = FlatVector::GetData<string_t>(result);
 
 	size = 0;
 	for (auto c = column_list->head; c != nullptr; c = lnext(c)) {
 		auto target = (duckdb_libpgquery::PGResTarget *)(c->data.ptr_value);
-		result.SetValue(size++, target->name);
+		result_ptr[size++] = StringVector::AddStringOrBlob(result, target->name);
 	}
 	return result;
 }

--- a/src/parser/transform/statement/transform_create_enum.cpp
+++ b/src/parser/transform/statement/transform_create_enum.cpp
@@ -19,17 +19,17 @@ vector<string> ReadPgListToString(duckdb_libpgquery::PGList *column_list) {
 }
 
 Vector ReadPgListToVector(duckdb_libpgquery::PGList *column_list, idx_t &size) {
-	Vector result(LogicalType::VARCHAR);
 	if (!column_list) {
+		Vector result(LogicalType::VARCHAR);
 		return result;
 	}
 	// First we discover the size of this list
 	for (auto c = column_list->head; c != nullptr; c = lnext(c)) {
 		size++;
 	}
-	if (size > STANDARD_VECTOR_SIZE) {
-		result.Resize(STANDARD_VECTOR_SIZE, size);
-	}
+
+	Vector result(LogicalType::VARCHAR, size);
+
 	size = 0;
 	for (auto c = column_list->head; c != nullptr; c = lnext(c)) {
 		auto target = (duckdb_libpgquery::PGResTarget *)(c->data.ptr_value);

--- a/test/sql/types/enum/test_enum_table.test
+++ b/test/sql/types/enum/test_enum_table.test
@@ -266,3 +266,25 @@ CREATE TABLE midenum_t2 (
 
 statement ok
 INSERT INTO midenum_t2 VALUES ('0')
+
+
+# Test Large Enums
+statement ok
+CREATE TYPE large_enum AS ENUM ('Floccinaucinihilipilification', 'Antidisestablishmentarianism', 'Honorificabilitudinitatibus');
+
+statement ok
+CREATE TABLE large_enum_tbl (
+    big_word large_enum
+);
+
+statement ok
+INSERT INTO large_enum_tbl values ('Floccinaucinihilipilification'), ('Floccinaucinihilipilification'), ('Honorificabilitudinitatibus'), ('Floccinaucinihilipilification'),  ('Antidisestablishmentarianism')
+
+query I
+select * from large_enum_tbl
+----
+Floccinaucinihilipilification
+Floccinaucinihilipilification
+Honorificabilitudinitatibus
+Floccinaucinihilipilification
+Antidisestablishmentarianism

--- a/tools/pythonpkg/src/array_wrapper.cpp
+++ b/tools/pythonpkg/src/array_wrapper.cpp
@@ -741,7 +741,11 @@ void NumpyResultConversion::Append(DataChunk &chunk, unordered_map<idx_t, py::li
 			D_ASSERT(categories);
 			// It's an ENUM type, in addition to converting the codes we must convert the categories
 			if (categories->find(col_idx) == categories->end()) {
-				auto categories_list = EnumType::GetValuesInsertOrder(chunk.data[col_idx].GetType());
+				auto categories_list(EnumType::GetValuesInsertOrder(chunk.data[col_idx].GetType()));
+				auto categories_size = EnumType::GetSize(chunk.data[col_idx].GetType());
+				for (idx_t i = 0; i < categories_size; i++) {
+					(*categories)[col_idx].append(py::cast(categories_list.GetValue(i).ToString()));
+				}
 				(*categories)[col_idx] = py::cast(categories_list);
 			}
 		}

--- a/tools/pythonpkg/src/array_wrapper.cpp
+++ b/tools/pythonpkg/src/array_wrapper.cpp
@@ -746,7 +746,6 @@ void NumpyResultConversion::Append(DataChunk &chunk, unordered_map<idx_t, py::li
 				for (idx_t i = 0; i < categories_size; i++) {
 					(*categories)[col_idx].append(py::cast(categories_list.GetValue(i).ToString()));
 				}
-				(*categories)[col_idx] = py::cast(categories_list);
 			}
 		}
 	}

--- a/tools/pythonpkg/src/pyresult.cpp
+++ b/tools/pythonpkg/src/pyresult.cpp
@@ -408,15 +408,18 @@ py::str GetTypeToPython(const LogicalType &type) {
 	case LogicalTypeId::BLOB:
 		return py::str("BINARY");
 	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
 	case LogicalTypeId::TIMESTAMP_MS:
 	case LogicalTypeId::TIMESTAMP_NS:
 	case LogicalTypeId::TIMESTAMP_SEC: {
 		return py::str("DATETIME");
 	}
-	case LogicalTypeId::TIME: {
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ: {
 		return py::str("Time");
 	}
-	case LogicalTypeId::DATE: {
+	case LogicalTypeId::DATE:
+	case LogicalTypeId::DATE_TZ: {
 		return py::str("Date");
 	}
 	case LogicalTypeId::MAP:

--- a/tools/pythonpkg/src/vector_conversion.cpp
+++ b/tools/pythonpkg/src/vector_conversion.cpp
@@ -397,12 +397,10 @@ void VectorConversion::BindPandas(py::handle original_df, vector<PandasColumnBin
 					auto enum_name = string(py::str(df_columns[col_idx]));
 					vector<string> enum_entries = py::cast<vector<string>>(categories);
 					idx_t size = enum_entries.size();
-					Vector enum_entries_vec(LogicalType::VARCHAR);
-					if (size > STANDARD_VECTOR_SIZE) {
-						enum_entries_vec.Resize(STANDARD_VECTOR_SIZE, size);
-					}
+					Vector enum_entries_vec(LogicalType::VARCHAR, size);
+					auto enum_entries_ptr = FlatVector::GetData<string_t>(enum_entries_vec);
 					for (idx_t i = 0; i < size; i++) {
-						enum_entries_vec.SetValue(i, enum_entries[i]);
+						enum_entries_ptr[i] = StringVector::AddStringOrBlob(enum_entries_vec, enum_entries[i]);
 					}
 					D_ASSERT(py::hasattr(column.attr("cat"), "codes"));
 					duckdb_col_type = LogicalType::ENUM(enum_name, enum_entries_vec, size);

--- a/tools/pythonpkg/src/vector_conversion.cpp
+++ b/tools/pythonpkg/src/vector_conversion.cpp
@@ -397,7 +397,10 @@ void VectorConversion::BindPandas(py::handle original_df, vector<PandasColumnBin
 					auto enum_name = string(py::str(df_columns[col_idx]));
 					vector<string> enum_entries = py::cast<vector<string>>(categories);
 					idx_t size = enum_entries.size();
-					Vector enum_entries_vec(LogicalType::VARCHAR, size);
+					Vector enum_entries_vec(LogicalType::VARCHAR);
+					if (size > STANDARD_VECTOR_SIZE) {
+						enum_entries_vec.Resize(STANDARD_VECTOR_SIZE, size);
+					}
 					for (idx_t i = 0; i < size; i++) {
 						enum_entries_vec.SetValue(i, enum_entries[i]);
 					}

--- a/tools/pythonpkg/src/vector_conversion.cpp
+++ b/tools/pythonpkg/src/vector_conversion.cpp
@@ -396,8 +396,13 @@ void VectorConversion::BindPandas(py::handle original_df, vector<PandasColumnBin
 					bind_data.pandas_type = PandasType::CATEGORY;
 					auto enum_name = string(py::str(df_columns[col_idx]));
 					vector<string> enum_entries = py::cast<vector<string>>(categories);
+					idx_t size = enum_entries.size();
+					Vector enum_entries_vec(LogicalType::VARCHAR, size);
+					for (idx_t i = 0; i < size; i++) {
+						enum_entries_vec.SetValue(i, enum_entries[i]);
+					}
 					D_ASSERT(py::hasattr(column.attr("cat"), "codes"));
-					duckdb_col_type = LogicalType::ENUM(enum_name, enum_entries);
+					duckdb_col_type = LogicalType::ENUM(enum_name, enum_entries_vec, size);
 					bind_data.numpy_col = py::array(column.attr("cat").attr("codes"));
 					bind_data.mask = nullptr;
 					D_ASSERT(py::hasattr(bind_data.numpy_col, "dtype"));

--- a/tools/pythonpkg/tests/coverage/test_pandas_categorical_coverage.py
+++ b/tools/pythonpkg/tests/coverage/test_pandas_categorical_coverage.py
@@ -22,7 +22,8 @@ def check_create_table(category):
     'k': pd.Categorical(category, ordered=True),
     })
 
-    df_out = duckdb.query_df(df_in, "data", "SELECT * FROM data").df()
+    df_out = duckdb.query_df(df_in, "data", "SELECT * FROM data")
+    df_out = df_out.df()
     assert df_in.equals(df_out)
 
     conn.execute("CREATE TABLE t1 AS SELECT * FROM df_in")

--- a/tools/pythonpkg/tests/fast/test_2747.py
+++ b/tools/pythonpkg/tests/fast/test_2747.py
@@ -60,7 +60,6 @@ class Test2747(object):
 			if cur_type not in skip_types:
 				arrow_table = conn.execute("select "+cur_type+" from test_all_types()").arrow()
 				if cur_type in enum_types:
-					arrow_table = conn.execute("select small_enum from test_all_types()").arrow()
 					round_trip_arrow_table = conn.execute("select * from arrow_table").arrow()
 					result_arrow = conn.execute("select * from arrow_table").fetchall()
 					result_roundtrip = conn.execute("select * from round_trip_arrow_table").fetchall()
@@ -69,4 +68,15 @@ class Test2747(object):
 					round_trip_arrow_table = conn.execute("select * from arrow_table").arrow()
 					assert arrow_table.equals(round_trip_arrow_table, check_metadata=True)
 			
-
+	def test_pandas(self, duckdb_cursor):
+		# We skip those since the extreme ranges are not supported in python.
+		skip_types = {'date', 'timestamp', 'timestamp_s', 'timestamp_ns', 'timestamp_ms', 'date_tz', 'timestamp_tz'}
+		conn = duckdb.connect()
+		for cur_type in all_types:
+			print (cur_type)
+			if cur_type not in skip_types:
+					dataframe = conn.execute("select "+cur_type+" from test_all_types()").arrow()
+					round_trip_dataframe = conn.execute("select * from dataframe").arrow()
+					result_dataframe = conn.execute("select * from dataframe").fetchall()
+					result_roundtrip = conn.execute("select * from round_trip_dataframe").fetchall()
+					assert result_dataframe == result_roundtrip

--- a/tools/pythonpkg/tests/fast/test_2747.py
+++ b/tools/pythonpkg/tests/fast/test_2747.py
@@ -1,0 +1,46 @@
+import duckdb
+import pandas as pd
+import numpy as np
+import datetime
+from decimal import Decimal
+from uuid import UUID
+
+def get_all_types():
+	conn = duckdb.connect()		
+	all_types = conn.execute("describe select * from test_all_types()").fetchall()
+	types = []
+	for cur_type in all_types:
+		types.append(cur_type[0])
+	return types
+
+class Test2747(object):
+	def test_fetchall(self, duckdb_cursor):
+		conn = duckdb.connect()	
+		# We skip those since the extreme ranges are not supported in python.
+		skip_types = {'date', 'timestamp', 'timestamp_s', 'timestamp_ns', 'timestamp_ms', 'date_tz', 'timestamp_tz'}
+		correct_answer_map = {'bool':[(False,), (True,), (None,)]
+			, 'tinyint':[(-128,), (127,), (None,)], 'smallint': [(-32768,), (32767,), (None,)]
+			, 'int':[(-2147483648,), (2147483647,), (None,)],'bigint':[(-9223372036854775808,), (9223372036854775807,), (None,)]
+			, 'hugeint':[(-170141183460469231731687303715884105727,), (170141183460469231731687303715884105727,), (None,)]
+			, 'utinyint': [(0,), (255,), (None,)], 'usmallint': [(0,), (65535,), (None,)]
+			, 'uint':[(0,), (4294967295,), (None,)], 'ubigint': [(0,), (18446744073709551615,), (None,)]
+			, 'time':[(datetime.time(0, 0),), (datetime.time(23, 59, 59, 999999),), (None,)]
+			, 'float': [(-3.4028234663852886e+38,), (3.4028234663852886e+38,), (None,)], 'double': [(-1.7976931348623157e+308,), (1.7976931348623157e+308,), (None,)]
+			, 'dec_4_1': [(Decimal('-999.9'),), (Decimal('999.9'),), (None,)], 'dec_9_4': [(Decimal('-99999.9999'),), (Decimal('99999.9999'),), (None,)]
+			, 'dec_18_3': [(Decimal('-999999999999.999999'),), (Decimal('999999999999.999999'),), (None,)], 'dec38_10':[(Decimal('-9999999999999999999999999999.9999999999'),), (Decimal('9999999999999999999999999999.9999999999'),), (None,)]
+			, 'uuid': [(UUID('00000000-0000-0000-0000-000000000001'),), (UUID('ffffffff-ffff-ffff-ffff-ffffffffffff'),), (None,)]
+			, 'varchar': [('🦆🦆🦆🦆🦆🦆',), ('goose',), (None,)], 'blob': [(b'thisisalongblob\x00withnullbytes',), (b'\\x00\\x00\\x00a',), (None,)]
+			, 'small_enum':[('DUCK_DUCK_ENUM',), ('GOOSE',), (None,)], 'medium_enum': [('enum_0',), ('enum_299',), (None,)], 'large_enum': [('enum_0',), ('enum_69999',), (None,)]
+			, 'int_array': [([],), ([42, 999, None, None, -42],), (None,)], 'varchar_array': [([],), (['🦆🦆🦆🦆🦆🦆', 'goose', None, ''],), (None,)]
+			, 'nested_int_array': [([],), ([[], [42, 999, None, None, -42], None, [], [42, 999, None, None, -42]],), (None,)], 'struct': [({'a': None, 'b': None},), ({'a': 42, 'b': '🦆🦆🦆🦆🦆🦆'},), (None,)]
+			, 'struct_of_arrays': [({'a': None, 'b': None},), ({'a': [42, 999, None, None, -42], 'b': ['🦆🦆🦆🦆🦆🦆', 'goose', None, '']},), (None,)]
+			, 'array_of_structs': [([],), ([{'a': None, 'b': None}, {'a': 42, 'b': '🦆🦆🦆🦆🦆🦆'}, None],), (None,)], 'map':[({'key': [], 'value': []},), ({'key': ['key1', 'key2'], 'value': ['🦆🦆🦆🦆🦆🦆', 'goose']},), (None,)] 
+			, 'time_tz':[(datetime.time(0, 0),), (datetime.time(23, 59, 59, 999999),), (None,)], 'interval': [(datetime.timedelta(0),), (datetime.timedelta(days=30969, seconds=999, microseconds=999999),), (None,)]}
+
+		all_types = get_all_types()
+		for cur_type in all_types:
+			if cur_type not in skip_types:
+				result = conn.execute("select "+cur_type+" from test_all_types()").fetchall()
+				print (result)
+				correct_result = correct_answer_map[cur_type]
+				assert result == correct_result

--- a/tools/pythonpkg/tests/fast/test_2747.py
+++ b/tools/pythonpkg/tests/fast/test_2747.py
@@ -13,34 +13,51 @@ def get_all_types():
 		types.append(cur_type[0])
 	return types
 
-class Test2747(object):
-	def test_fetchall(self, duckdb_cursor):
-		conn = duckdb.connect()	
-		# We skip those since the extreme ranges are not supported in python.
-		skip_types = {'date', 'timestamp', 'timestamp_s', 'timestamp_ns', 'timestamp_ms', 'date_tz', 'timestamp_tz'}
-		correct_answer_map = {'bool':[(False,), (True,), (None,)]
-			, 'tinyint':[(-128,), (127,), (None,)], 'smallint': [(-32768,), (32767,), (None,)]
-			, 'int':[(-2147483648,), (2147483647,), (None,)],'bigint':[(-9223372036854775808,), (9223372036854775807,), (None,)]
-			, 'hugeint':[(-170141183460469231731687303715884105727,), (170141183460469231731687303715884105727,), (None,)]
-			, 'utinyint': [(0,), (255,), (None,)], 'usmallint': [(0,), (65535,), (None,)]
-			, 'uint':[(0,), (4294967295,), (None,)], 'ubigint': [(0,), (18446744073709551615,), (None,)]
-			, 'time':[(datetime.time(0, 0),), (datetime.time(23, 59, 59, 999999),), (None,)]
-			, 'float': [(-3.4028234663852886e+38,), (3.4028234663852886e+38,), (None,)], 'double': [(-1.7976931348623157e+308,), (1.7976931348623157e+308,), (None,)]
-			, 'dec_4_1': [(Decimal('-999.9'),), (Decimal('999.9'),), (None,)], 'dec_9_4': [(Decimal('-99999.9999'),), (Decimal('99999.9999'),), (None,)]
-			, 'dec_18_3': [(Decimal('-999999999999.999999'),), (Decimal('999999999999.999999'),), (None,)], 'dec38_10':[(Decimal('-9999999999999999999999999999.9999999999'),), (Decimal('9999999999999999999999999999.9999999999'),), (None,)]
-			, 'uuid': [(UUID('00000000-0000-0000-0000-000000000001'),), (UUID('ffffffff-ffff-ffff-ffff-ffffffffffff'),), (None,)]
-			, 'varchar': [('🦆🦆🦆🦆🦆🦆',), ('goose',), (None,)], 'blob': [(b'thisisalongblob\x00withnullbytes',), (b'\\x00\\x00\\x00a',), (None,)]
-			, 'small_enum':[('DUCK_DUCK_ENUM',), ('GOOSE',), (None,)], 'medium_enum': [('enum_0',), ('enum_299',), (None,)], 'large_enum': [('enum_0',), ('enum_69999',), (None,)]
-			, 'int_array': [([],), ([42, 999, None, None, -42],), (None,)], 'varchar_array': [([],), (['🦆🦆🦆🦆🦆🦆', 'goose', None, ''],), (None,)]
-			, 'nested_int_array': [([],), ([[], [42, 999, None, None, -42], None, [], [42, 999, None, None, -42]],), (None,)], 'struct': [({'a': None, 'b': None},), ({'a': 42, 'b': '🦆🦆🦆🦆🦆🦆'},), (None,)]
-			, 'struct_of_arrays': [({'a': None, 'b': None},), ({'a': [42, 999, None, None, -42], 'b': ['🦆🦆🦆🦆🦆🦆', 'goose', None, '']},), (None,)]
-			, 'array_of_structs': [([],), ([{'a': None, 'b': None}, {'a': 42, 'b': '🦆🦆🦆🦆🦆🦆'}, None],), (None,)], 'map':[({'key': [], 'value': []},), ({'key': ['key1', 'key2'], 'value': ['🦆🦆🦆🦆🦆🦆', 'goose']},), (None,)] 
-			, 'time_tz':[(datetime.time(0, 0),), (datetime.time(23, 59, 59, 999999),), (None,)], 'interval': [(datetime.timedelta(0),), (datetime.timedelta(days=30969, seconds=999, microseconds=999999),), (None,)]}
+all_types = get_all_types()
 
-		all_types = get_all_types()
+class Test2747(object):
+	# def test_fetchall(self, duckdb_cursor):
+	# 	conn = duckdb.connect()	
+	# 	# We skip those since the extreme ranges are not supported in python.
+	# 	skip_types = {'date', 'timestamp', 'timestamp_s', 'timestamp_ns', 'timestamp_ms', 'date_tz', 'timestamp_tz'}
+	# 	correct_answer_map = {'bool':[(False,), (True,), (None,)]
+	# 		, 'tinyint':[(-128,), (127,), (None,)], 'smallint': [(-32768,), (32767,), (None,)]
+	# 		, 'int':[(-2147483648,), (2147483647,), (None,)],'bigint':[(-9223372036854775808,), (9223372036854775807,), (None,)]
+	# 		, 'hugeint':[(-170141183460469231731687303715884105727,), (170141183460469231731687303715884105727,), (None,)]
+	# 		, 'utinyint': [(0,), (255,), (None,)], 'usmallint': [(0,), (65535,), (None,)]
+	# 		, 'uint':[(0,), (4294967295,), (None,)], 'ubigint': [(0,), (18446744073709551615,), (None,)]
+	# 		, 'time':[(datetime.time(0, 0),), (datetime.time(23, 59, 59, 999999),), (None,)]
+	# 		, 'float': [(-3.4028234663852886e+38,), (3.4028234663852886e+38,), (None,)], 'double': [(-1.7976931348623157e+308,), (1.7976931348623157e+308,), (None,)]
+	# 		, 'dec_4_1': [(Decimal('-999.9'),), (Decimal('999.9'),), (None,)], 'dec_9_4': [(Decimal('-99999.9999'),), (Decimal('99999.9999'),), (None,)]
+	# 		, 'dec_18_3': [(Decimal('-999999999999.999999'),), (Decimal('999999999999.999999'),), (None,)], 'dec38_10':[(Decimal('-9999999999999999999999999999.9999999999'),), (Decimal('9999999999999999999999999999.9999999999'),), (None,)]
+	# 		, 'uuid': [(UUID('00000000-0000-0000-0000-000000000001'),), (UUID('ffffffff-ffff-ffff-ffff-ffffffffffff'),), (None,)]
+	# 		, 'varchar': [('🦆🦆🦆🦆🦆🦆',), ('goose',), (None,)], 'blob': [(b'thisisalongblob\x00withnullbytes',), (b'\\x00\\x00\\x00a',), (None,)]
+	# 		, 'small_enum':[('DUCK_DUCK_ENUM',), ('GOOSE',), (None,)], 'medium_enum': [('enum_0',), ('enum_299',), (None,)], 'large_enum': [('enum_0',), ('enum_69999',), (None,)]
+	# 		, 'int_array': [([],), ([42, 999, None, None, -42],), (None,)], 'varchar_array': [([],), (['🦆🦆🦆🦆🦆🦆', 'goose', None, ''],), (None,)]
+	# 		, 'nested_int_array': [([],), ([[], [42, 999, None, None, -42], None, [], [42, 999, None, None, -42]],), (None,)], 'struct': [({'a': None, 'b': None},), ({'a': 42, 'b': '🦆🦆🦆🦆🦆🦆'},), (None,)]
+	# 		, 'struct_of_arrays': [({'a': None, 'b': None},), ({'a': [42, 999, None, None, -42], 'b': ['🦆🦆🦆🦆🦆🦆', 'goose', None, '']},), (None,)]
+	# 		, 'array_of_structs': [([],), ([{'a': None, 'b': None}, {'a': 42, 'b': '🦆🦆🦆🦆🦆🦆'}, None],), (None,)], 'map':[({'key': [], 'value': []},), ({'key': ['key1', 'key2'], 'value': ['🦆🦆🦆🦆🦆🦆', 'goose']},), (None,)] 
+	# 		, 'time_tz':[(datetime.time(0, 0),), (datetime.time(23, 59, 59, 999999),), (None,)], 'interval': [(datetime.timedelta(0),), (datetime.timedelta(days=30969, seconds=999, microseconds=999999),), (None,)]}
+
+	# 	for cur_type in all_types:
+	# 		if cur_type not in skip_types:
+	# 			result = conn.execute("select "+cur_type+" from test_all_types()").fetchall()
+	# 			print (result)
+	# 			correct_result = correct_answer_map[cur_type]
+	# 			assert result == correct_result
+
+	def test_arrow(self, duckdb_cursor):
+		try:
+			import pyarrow as pa
+		except:
+			return
+
+		skip_types = {'small_enum', 'medium_enum', 'large_enum'}
+		all_types = ['uuid']
+		conn = duckdb.connect()	
 		for cur_type in all_types:
 			if cur_type not in skip_types:
-				result = conn.execute("select "+cur_type+" from test_all_types()").fetchall()
-				print (result)
-				correct_result = correct_answer_map[cur_type]
-				assert result == correct_result
+				print(cur_type)
+				arrow_table = conn.execute("select "+cur_type+" from test_all_types()").arrow()
+				round_trip_arrow_table = conn.execute("select * from arrow_table").arrow()
+				assert arrow_table.equals(round_trip_arrow_table, check_metadata=True)

--- a/tools/pythonpkg/tests/fast/test_2747.py
+++ b/tools/pythonpkg/tests/fast/test_2747.py
@@ -16,47 +16,57 @@ def get_all_types():
 all_types = get_all_types()
 
 class Test2747(object):
-	# def test_fetchall(self, duckdb_cursor):
-	# 	conn = duckdb.connect()	
-	# 	# We skip those since the extreme ranges are not supported in python.
-	# 	skip_types = {'date', 'timestamp', 'timestamp_s', 'timestamp_ns', 'timestamp_ms', 'date_tz', 'timestamp_tz'}
-	# 	correct_answer_map = {'bool':[(False,), (True,), (None,)]
-	# 		, 'tinyint':[(-128,), (127,), (None,)], 'smallint': [(-32768,), (32767,), (None,)]
-	# 		, 'int':[(-2147483648,), (2147483647,), (None,)],'bigint':[(-9223372036854775808,), (9223372036854775807,), (None,)]
-	# 		, 'hugeint':[(-170141183460469231731687303715884105727,), (170141183460469231731687303715884105727,), (None,)]
-	# 		, 'utinyint': [(0,), (255,), (None,)], 'usmallint': [(0,), (65535,), (None,)]
-	# 		, 'uint':[(0,), (4294967295,), (None,)], 'ubigint': [(0,), (18446744073709551615,), (None,)]
-	# 		, 'time':[(datetime.time(0, 0),), (datetime.time(23, 59, 59, 999999),), (None,)]
-	# 		, 'float': [(-3.4028234663852886e+38,), (3.4028234663852886e+38,), (None,)], 'double': [(-1.7976931348623157e+308,), (1.7976931348623157e+308,), (None,)]
-	# 		, 'dec_4_1': [(Decimal('-999.9'),), (Decimal('999.9'),), (None,)], 'dec_9_4': [(Decimal('-99999.9999'),), (Decimal('99999.9999'),), (None,)]
-	# 		, 'dec_18_3': [(Decimal('-999999999999.999999'),), (Decimal('999999999999.999999'),), (None,)], 'dec38_10':[(Decimal('-9999999999999999999999999999.9999999999'),), (Decimal('9999999999999999999999999999.9999999999'),), (None,)]
-	# 		, 'uuid': [(UUID('00000000-0000-0000-0000-000000000001'),), (UUID('ffffffff-ffff-ffff-ffff-ffffffffffff'),), (None,)]
-	# 		, 'varchar': [('🦆🦆🦆🦆🦆🦆',), ('goose',), (None,)], 'blob': [(b'thisisalongblob\x00withnullbytes',), (b'\\x00\\x00\\x00a',), (None,)]
-	# 		, 'small_enum':[('DUCK_DUCK_ENUM',), ('GOOSE',), (None,)], 'medium_enum': [('enum_0',), ('enum_299',), (None,)], 'large_enum': [('enum_0',), ('enum_69999',), (None,)]
-	# 		, 'int_array': [([],), ([42, 999, None, None, -42],), (None,)], 'varchar_array': [([],), (['🦆🦆🦆🦆🦆🦆', 'goose', None, ''],), (None,)]
-	# 		, 'nested_int_array': [([],), ([[], [42, 999, None, None, -42], None, [], [42, 999, None, None, -42]],), (None,)], 'struct': [({'a': None, 'b': None},), ({'a': 42, 'b': '🦆🦆🦆🦆🦆🦆'},), (None,)]
-	# 		, 'struct_of_arrays': [({'a': None, 'b': None},), ({'a': [42, 999, None, None, -42], 'b': ['🦆🦆🦆🦆🦆🦆', 'goose', None, '']},), (None,)]
-	# 		, 'array_of_structs': [([],), ([{'a': None, 'b': None}, {'a': 42, 'b': '🦆🦆🦆🦆🦆🦆'}, None],), (None,)], 'map':[({'key': [], 'value': []},), ({'key': ['key1', 'key2'], 'value': ['🦆🦆🦆🦆🦆🦆', 'goose']},), (None,)] 
-	# 		, 'time_tz':[(datetime.time(0, 0),), (datetime.time(23, 59, 59, 999999),), (None,)], 'interval': [(datetime.timedelta(0),), (datetime.timedelta(days=30969, seconds=999, microseconds=999999),), (None,)]}
+	def test_fetchall(self, duckdb_cursor):
+		conn = duckdb.connect()	
+		# We skip those since the extreme ranges are not supported in python.
+		skip_types = {'date', 'timestamp', 'timestamp_s', 'timestamp_ns', 'timestamp_ms', 'date_tz', 'timestamp_tz'}
+		correct_answer_map = {'bool':[(False,), (True,), (None,)]
+			, 'tinyint':[(-128,), (127,), (None,)], 'smallint': [(-32768,), (32767,), (None,)]
+			, 'int':[(-2147483648,), (2147483647,), (None,)],'bigint':[(-9223372036854775808,), (9223372036854775807,), (None,)]
+			, 'hugeint':[(-170141183460469231731687303715884105727,), (170141183460469231731687303715884105727,), (None,)]
+			, 'utinyint': [(0,), (255,), (None,)], 'usmallint': [(0,), (65535,), (None,)]
+			, 'uint':[(0,), (4294967295,), (None,)], 'ubigint': [(0,), (18446744073709551615,), (None,)]
+			, 'time':[(datetime.time(0, 0),), (datetime.time(23, 59, 59, 999999),), (None,)]
+			, 'float': [(-3.4028234663852886e+38,), (3.4028234663852886e+38,), (None,)], 'double': [(-1.7976931348623157e+308,), (1.7976931348623157e+308,), (None,)]
+			, 'dec_4_1': [(Decimal('-999.9'),), (Decimal('999.9'),), (None,)], 'dec_9_4': [(Decimal('-99999.9999'),), (Decimal('99999.9999'),), (None,)]
+			, 'dec_18_3': [(Decimal('-999999999999.999999'),), (Decimal('999999999999.999999'),), (None,)], 'dec38_10':[(Decimal('-9999999999999999999999999999.9999999999'),), (Decimal('9999999999999999999999999999.9999999999'),), (None,)]
+			, 'uuid': [(UUID('00000000-0000-0000-0000-000000000001'),), (UUID('ffffffff-ffff-ffff-ffff-ffffffffffff'),), (None,)]
+			, 'varchar': [('🦆🦆🦆🦆🦆🦆',), ('goose',), (None,)], 'blob': [(b'thisisalongblob\x00withnullbytes',), (b'\\x00\\x00\\x00a',), (None,)]
+			, 'small_enum':[('DUCK_DUCK_ENUM',), ('GOOSE',), (None,)], 'medium_enum': [('enum_0',), ('enum_299',), (None,)], 'large_enum': [('enum_0',), ('enum_69999',), (None,)]
+			, 'int_array': [([],), ([42, 999, None, None, -42],), (None,)], 'varchar_array': [([],), (['🦆🦆🦆🦆🦆🦆', 'goose', None, ''],), (None,)]
+			, 'nested_int_array': [([],), ([[], [42, 999, None, None, -42], None, [], [42, 999, None, None, -42]],), (None,)], 'struct': [({'a': None, 'b': None},), ({'a': 42, 'b': '🦆🦆🦆🦆🦆🦆'},), (None,)]
+			, 'struct_of_arrays': [({'a': None, 'b': None},), ({'a': [42, 999, None, None, -42], 'b': ['🦆🦆🦆🦆🦆🦆', 'goose', None, '']},), (None,)]
+			, 'array_of_structs': [([],), ([{'a': None, 'b': None}, {'a': 42, 'b': '🦆🦆🦆🦆🦆🦆'}, None],), (None,)], 'map':[({'key': [], 'value': []},), ({'key': ['key1', 'key2'], 'value': ['🦆🦆🦆🦆🦆🦆', 'goose']},), (None,)] 
+			, 'time_tz':[(datetime.time(0, 0),), (datetime.time(23, 59, 59, 999999),), (None,)], 'interval': [(datetime.timedelta(0),), (datetime.timedelta(days=30969, seconds=999, microseconds=999999),), (None,)]}
 
-	# 	for cur_type in all_types:
-	# 		if cur_type not in skip_types:
-	# 			result = conn.execute("select "+cur_type+" from test_all_types()").fetchall()
-	# 			print (result)
-	# 			correct_result = correct_answer_map[cur_type]
-	# 			assert result == correct_result
+		for cur_type in all_types:
+			if cur_type not in skip_types:
+				result = conn.execute("select "+cur_type+" from test_all_types()").fetchall()
+				print (result)
+				correct_result = correct_answer_map[cur_type]
+				assert result == correct_result
 
 	def test_arrow(self, duckdb_cursor):
 		try:
 			import pyarrow as pa
 		except:
 			return
-
-		skip_types = {'small_enum', 'medium_enum', 'large_enum', 'interval'}
+		# We skip those since the extreme ranges are not supported in arrow.
+		skip_types = {'interval'}
+		# We do not round trip enum types
+		enum_types = {'small_enum', 'medium_enum', 'large_enum'}
 		conn = duckdb.connect()	
 		for cur_type in all_types:
 			if cur_type not in skip_types:
-				print(cur_type)
 				arrow_table = conn.execute("select "+cur_type+" from test_all_types()").arrow()
-				round_trip_arrow_table = conn.execute("select * from arrow_table").arrow()
-				assert arrow_table.equals(round_trip_arrow_table, check_metadata=True)
+				if cur_type in enum_types:
+					arrow_table = conn.execute("select small_enum from test_all_types()").arrow()
+					round_trip_arrow_table = conn.execute("select * from arrow_table").arrow()
+					result_arrow = conn.execute("select * from arrow_table").fetchall()
+					result_roundtrip = conn.execute("select * from round_trip_arrow_table").fetchall()
+					assert result_arrow == result_roundtrip
+				else:
+					round_trip_arrow_table = conn.execute("select * from arrow_table").arrow()
+					assert arrow_table.equals(round_trip_arrow_table, check_metadata=True)
+			
+

--- a/tools/pythonpkg/tests/fast/test_2747.py
+++ b/tools/pythonpkg/tests/fast/test_2747.py
@@ -52,8 +52,7 @@ class Test2747(object):
 		except:
 			return
 
-		skip_types = {'small_enum', 'medium_enum', 'large_enum'}
-		all_types = ['uuid']
+		skip_types = {'small_enum', 'medium_enum', 'large_enum', 'interval'}
 		conn = duckdb.connect()	
 		for cur_type in all_types:
 			if cur_type not in skip_types:

--- a/tools/rpkg/src/scan.cpp
+++ b/tools/rpkg/src/scan.cpp
@@ -81,10 +81,7 @@ static unique_ptr<FunctionData> dataframe_scan_bind(ClientContext &context, vect
 
 			auto levels = r.Protect(GET_LEVELS(coldata));
 			idx_t size = LENGTH(levels);
-			Vector duckdb_levels(LogicalType::VARCHAR);
-			if (size > STANDARD_VECTOR_SIZE) {
-				duckdb_levels.Resize(STANDARD_VECTOR_SIZE, size);
-			}
+			Vector duckdb_levels(LogicalType::VARCHAR, size);
 			for (idx_t level_idx = 0; level_idx < size; level_idx++) {
 				duckdb_levels.SetValue(level_idx, string(CHAR(STRING_ELT(levels, level_idx))));
 			}

--- a/tools/rpkg/src/statement.cpp
+++ b/tools/rpkg/src/statement.cpp
@@ -447,7 +447,7 @@ static void transform(Vector &src_vec, SEXP &dest, idx_t dest_offset, idx_t n) {
 		}
 
 		RProtector r;
-		Vector str_vec(EnumType::GetValuesInsertOrder(src_vec.GetType()));
+		auto &str_vec = EnumType::GetValuesInsertOrder(src_vec.GetType());
 		auto size = EnumType::GetSize(src_vec.GetType());
 		vector<string> str_c_vec(size);
 		for (idx_t i = 0; i < size; i++) {

--- a/tools/rpkg/src/statement.cpp
+++ b/tools/rpkg/src/statement.cpp
@@ -447,7 +447,14 @@ static void transform(Vector &src_vec, SEXP &dest, idx_t dest_offset, idx_t n) {
 		}
 
 		RProtector r;
-		auto levels_sexp = r.Protect(RApi::StringsToSexp(EnumType::GetValuesInsertOrder(src_vec.GetType())));
+		Vector str_vec(EnumType::GetValuesInsertOrder(src_vec.GetType()));
+		auto size = EnumType::GetSize(src_vec.GetType());
+		vector<string> str_c_vec(size);
+		for (idx_t i = 0; i < size; i++) {
+			str_c_vec[i] = str_vec.GetValue(i).ToString();
+		}
+
+		auto levels_sexp = r.Protect(RApi::StringsToSexp(str_c_vec));
 		SET_LEVELS(dest, levels_sexp);
 		SET_CLASS(dest, RStrings::get().factor_str);
 		break;


### PR DESCRIPTION
This PR presents the all types tests for the python client.

It also includes implementations for some of the missing types.
Python:
* UUID
* Interval

Arrow:
* UUID
* ENUMs

To add support for ENUM -> Arrow, I've changed the enum dictionary from vector<string> -> Vector, hence there is a lot of code to accommodate this change.

cc. @domoritz , I think you recently asked about ENUM -> Arrow. With this PR Enums should be converted to Arrow Dictionaries. However, Arrow Dictionaries will still be treated as our internal vector representation. Hence, if you would round-trip an Arrow Object with a Dictionary column it would be converted to an uncompressed Arrow Column and not an Enum.