### PR TITLE
Extension dashes to underscores

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -148,7 +148,7 @@ jobs:
     - name: Deploy
       run: |
         if [[ "$GITHUB_REF" =~ ^(refs/heads/master|refs/tags/v.+)$ ]] ; then
-          ./scripts/extension-upload.sh linux-amd64
+          ./scripts/extension-upload.sh linux_amd64
         fi
 
 

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -119,6 +119,5 @@ jobs:
       run: |
           if [[ "$GITHUB_REF" =~ ^(refs/heads/master|refs/tags/v.+)$ ]] ; then
             pip install awscli
-            ./scripts/extension-upload.sh osx-amd64
+            ./scripts/extension-upload.sh osx_amd64
           fi
-

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -214,5 +214,5 @@ jobs:
       run: |
         if [[ "$GITHUB_REF" =~ ^(refs/heads/master|refs/tags/v.+)$ ]] ; then
           pip install awscli
-          ./scripts/extension-upload.sh windows-amd64
+          ./scripts/extension-upload.sh windows_amd64
         fi


### PR DESCRIPTION
I'm super excited by [the new support for installing extensions after building](https://github.com/duckdb/duckdb/pull/2569)

I tried this with a recent install on macos and I got:
```
dbExecute(con, "INSTALL tpch;")
Error in duckdb_execute(res) : duckdb_execute_R: Failed to run query
Error: IO Error: Failed to download extension http://extensions.duckdb.org/498775f6c/osx_amd64/tpch.duckdb_extension.gz
```

It appears that the URL should actually be http://extensions.duckdb.org/498775f6c/osx-amd64/tpch.duckdb_extension.gz

If I'm [reading this](https://github.com/duckdb/duckdb/blob/01bdd7ce8930a960ad4e9ded58f29efa8fb65cda/src/function/table/version/pragma_version.cpp#L66) correctly, the platform should have underscores instead of dashes like are used in the upload script. Or maybe that line in `DuckDB::Platform()` should have a dash instead of an underscore?