### PR TITLE
Add Connection::GetTableNames method to C++ API that allows you to extract the required table names from a query

### DIFF
--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -152,6 +152,9 @@ public:
 	//! Equivalent to CURRENT_SETTING(key) SQL function.
 	DUCKDB_API bool TryGetCurrentSetting(const std::string &key, Value &result);
 
+	//! Fetch a list of table names that are required for a given query
+	DUCKDB_API unordered_set<string> GetTableNames(const string &query);
+
 private:
 	//! Parse statements from a query
 	vector<unique_ptr<SQLStatement>> ParseStatementsInternal(ClientContextLock &lock, const string &query);

--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -128,6 +128,9 @@ public:
 	DUCKDB_API void SetAutoCommit(bool auto_commit);
 	DUCKDB_API bool IsAutoCommit();
 
+	//! Fetch a list of table names that are required for a given query
+	DUCKDB_API unordered_set<string> GetTableNames(const string &query);
+
 	template <typename TR, typename... Args>
 	void CreateScalarFunction(const string &name, TR (*udf_func)(Args...)) {
 		scalar_function_t function = UDFWrapper::CreateScalarFunction<TR, Args...>(name, udf_func);

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -34,6 +34,8 @@ struct BoundCreateTableInfo;
 struct BoundCreateFunctionInfo;
 struct CommonTableExpressionInfo;
 
+enum class BindingMode : uint8_t { STANDARD_BINDING, EXTRACT_NAMES };
+
 struct CorrelatedColumnInfo {
 	ColumnBinding binding;
 	LogicalType type;
@@ -148,6 +150,11 @@ public:
 	bool HasMatchingBinding(const string &schema_name, const string &table_name, const string &column_name,
 	                        string &error_message);
 
+	void SetBindingMode(BindingMode mode);
+	BindingMode GetBindingMode();
+	void AddTableName(string table_name);
+	const unordered_set<string> &GetTableNames();
+
 private:
 	//! The parent binder (if any)
 	shared_ptr<Binder> parent;
@@ -165,6 +172,10 @@ private:
 	bool can_contain_nulls = false;
 	//! The root statement of the query that is currently being parsed
 	SQLStatement *root_statement = nullptr;
+	//! Binding mode
+	BindingMode mode = BindingMode::STANDARD_BINDING;
+	//! Table names extracted for BindingMode::EXTRACT_NAMES
+	unordered_set<string> table_names;
 
 private:
 	//! Bind the default values of the columns of a table

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -880,6 +880,25 @@ void ClientContext::TryBindRelation(Relation &relation, vector<ColumnDefinition>
 	});
 }
 
+unordered_set<string> ClientContext::GetTableNames(const string &query) {
+	auto lock = LockContext();
+
+	auto statements = ParseStatementsInternal(*lock, query);
+	if (statements.size() != 1) {
+		throw InvalidInputException("Expected a single statement");
+	}
+
+	unordered_set<string> result;
+	RunFunctionInTransactionInternal(*lock, [&]() {
+		// bind the expressions
+		auto binder = Binder::CreateBinder(*this);
+		binder->SetBindingMode(BindingMode::EXTRACT_NAMES);
+		binder->Bind(*statements[0]);
+		result = binder->GetTableNames();
+	});
+	return result;
+}
+
 unique_ptr<QueryResult> ClientContext::Execute(const shared_ptr<Relation> &relation) {
 	auto lock = LockContext();
 	InitialCleanup(*lock);

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -195,6 +195,10 @@ shared_ptr<Relation> Connection::ReadCSV(const string &csv_file, const vector<st
 	return make_shared<ReadCSVRelation>(*context, csv_file, move(column_list));
 }
 
+unordered_set<string> Connection::GetTableNames(const string &query) {
+	return context->GetTableNames(query);
+}
+
 shared_ptr<Relation> Connection::RelationFromQuery(const string &query, const string &alias) {
 	return make_shared<QueryRelation>(*context, query, alias);
 }

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -320,6 +320,35 @@ bool Binder::HasMatchingBinding(const string &schema_name, const string &table_n
 	return true;
 }
 
+void Binder::SetBindingMode(BindingMode mode) {
+	if (parent) {
+		parent->SetBindingMode(mode);
+	}
+	this->mode = mode;
+}
+
+BindingMode Binder::GetBindingMode() {
+	if (parent) {
+		return parent->GetBindingMode();
+	}
+	return mode;
+}
+
+void Binder::AddTableName(string table_name) {
+	if (parent) {
+		parent->AddTableName(move(table_name));
+		return;
+	}
+	table_names.insert(move(table_name));
+}
+
+const unordered_set<string> &Binder::GetTableNames() {
+	if (parent) {
+		return parent->GetTableNames();
+	}
+	return table_names;
+}
+
 string Binder::FormatError(ParsedExpression &expr_context, const string &message) {
 	return FormatError(expr_context.query_location, message);
 }

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/parser/expression/subquery_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
 
 namespace duckdb {
 
@@ -175,6 +176,9 @@ unique_ptr<ParsedExpression> ExpressionBinder::QualifyColumnName(ColumnRefExpres
 }
 
 BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref_p, idx_t depth) {
+	if (binder.GetBindingMode() == BindingMode::EXTRACT_NAMES) {
+		return BindResult(make_unique<BoundConstantExpression>(Value(LogicalType::SQLNULL)));
+	}
 	string error_message;
 	auto expr = QualifyColumnName(colref_p, error_message);
 	if (!expr) {

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -46,6 +46,10 @@ BindResult ExpressionBinder::BindFunction(FunctionExpression &function, ScalarFu
 	if (!error.empty()) {
 		return BindResult(error);
 	}
+	if (binder.GetBindingMode() == BindingMode::EXTRACT_NAMES) {
+		return BindResult(make_unique<BoundConstantExpression>(Value(LogicalType::SQLNULL)));
+	}
+
 	// all children bound successfully
 	// extract the children and types
 	vector<unique_ptr<Expression>> children;

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
 #include "duckdb/main/config.hpp"
+#include "duckdb/planner/tableref/bound_dummytableref.hpp"
 
 namespace duckdb {
 

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -75,6 +75,19 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 				return Bind(*replacement_function);
 			}
 		}
+		// we still didn't find the table
+		if (GetBindingMode() == BindingMode::EXTRACT_NAMES) {
+			// if we are in EXTRACT_NAMES, we create a dummy table ref
+			AddTableName(ref.table_name);
+
+			// add a bind context entry
+			auto table_index = GenerateTableIndex();
+			auto alias = ref.alias.empty() ? ref.table_name : ref.alias;
+			vector<LogicalType> types {LogicalType::INTEGER};
+			vector<string> names {"__dummy_col" + to_string(table_index)};
+			bind_context.AddGenericBinding(table_index, alias, names, types);
+			return make_unique_base<BoundTableRef, BoundEmptyTableRef>(table_index);
+		}
 		// could not find an alternative: bind again to get the error
 		table_or_view = Catalog::GetCatalog(context).GetEntry(context, CatalogType::TABLE_ENTRY, ref.schema_name,
 		                                                      ref.table_name, false, error_context);

--- a/src/planner/expression_binder/group_binder.cpp
+++ b/src/planner/expression_binder/group_binder.cpp
@@ -47,7 +47,7 @@ BindResult GroupBinder::BindSelectRef(idx_t entry) {
 		// e.g. GROUP BY k, k or GROUP BY 1, 1
 		// in this case, we can just replace the grouping with a constant since the second grouping has no effect
 		// (the constant grouping will be optimized out later)
-		return BindResult(make_unique<BoundConstantExpression>(Value(LogicalType::SQLNULL)));
+		return BindResult(make_unique<BoundConstantExpression>(Value::INTEGER(42)));
 	}
 	if (entry >= node.select_list.size()) {
 		throw BinderException("GROUP BY term out of range - should be between 1 and %d", (int)node.select_list.size());

--- a/src/planner/expression_binder/group_binder.cpp
+++ b/src/planner/expression_binder/group_binder.cpp
@@ -47,7 +47,7 @@ BindResult GroupBinder::BindSelectRef(idx_t entry) {
 		// e.g. GROUP BY k, k or GROUP BY 1, 1
 		// in this case, we can just replace the grouping with a constant since the second grouping has no effect
 		// (the constant grouping will be optimized out later)
-		return BindResult(make_unique<BoundConstantExpression>(Value::INTEGER(42)));
+		return BindResult(make_unique<BoundConstantExpression>(Value(LogicalType::SQLNULL)));
 	}
 	if (entry >= node.select_list.size()) {
 		throw BinderException("GROUP BY term out of range - should be between 1 and %d", (int)node.select_list.size());

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_API_OBJECTS
     test_config.cpp
     test_custom_allocator.cpp
     test_results.cpp
+    test_get_table_names.cpp
     test_prepared_api.cpp
     test_table_info.cpp
     test_appender_api.cpp

--- a/test/api/test_get_table_names.cpp
+++ b/test/api/test_get_table_names.cpp
@@ -1,0 +1,216 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/planner/logical_operator.hpp"
+
+#include <chrono>
+#include <thread>
+
+using namespace duckdb;
+using namespace std;
+
+TEST_CASE("Test GetTableNames", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	unordered_set<string> table_names;
+
+	// standard
+	table_names = con.GetTableNames("SELECT * FROM my_table");
+	REQUIRE(table_names.size() == 1);
+	REQUIRE(table_names.count("my_table"));
+
+	// fetch a specific column
+	table_names = con.GetTableNames("SELECT col_a FROM my_table");
+	REQUIRE(table_names.size() == 1);
+	REQUIRE(table_names.count("my_table"));
+
+	// multiple tables
+	table_names = con.GetTableNames("SELECT * FROM my_table1, my_table2, my_table3");
+	REQUIRE(table_names.size() == 3);
+	REQUIRE(table_names.count("my_table1"));
+	REQUIRE(table_names.count("my_table2"));
+	REQUIRE(table_names.count("my_table3"));
+
+	// same table is mentioned multiple times
+	table_names = con.GetTableNames("SELECT col_a FROM my_table, my_table m2, my_table m3");
+	REQUIRE(table_names.size() == 1);
+	REQUIRE(table_names.count("my_table"));
+
+	// cte
+	table_names = con.GetTableNames("WITH cte AS (SELECT * FROM my_table) SELECT * FROM cte");
+	REQUIRE(table_names.size() == 1);
+	REQUIRE(table_names.count("my_table"));
+
+	// subqueries
+	table_names = con.GetTableNames("SELECT * FROM (SELECT * FROM (SELECT * FROM my_table) bla) bla3");
+	REQUIRE(table_names.size() == 1);
+	REQUIRE(table_names.count("my_table"));
+
+	// join
+	table_names = con.GetTableNames("SELECT col_a FROM my_table JOIN my_table2 ON (my_table.col_b=my_table2.col_d)");
+	REQUIRE(table_names.size() == 2);
+	REQUIRE(table_names.count("my_table"));
+	REQUIRE(table_names.count("my_table2"));
+
+	// scalar subquery
+	table_names = con.GetTableNames("SELECT (SELECT COUNT(*) FROM my_table)");
+	REQUIRE(table_names.size() == 1);
+	REQUIRE(table_names.count("my_table"));
+
+	// set operations
+	table_names =
+	    con.GetTableNames("SELECT * FROM my_table UNION ALL SELECT * FROM my_table2 INTERSECT SELECT * FROM my_table3");
+	REQUIRE(table_names.size() == 3);
+	REQUIRE(table_names.count("my_table"));
+	REQUIRE(table_names.count("my_table2"));
+	REQUIRE(table_names.count("my_table3"));
+
+	// window functions
+	table_names = con.GetTableNames("SELECT row_number() OVER (ORDER BY (SELECT i+j FROM my_table2)) FROM my_table");
+	REQUIRE(table_names.size() == 2);
+	REQUIRE(table_names.count("my_table"));
+	REQUIRE(table_names.count("my_table2"));
+
+	if (!db.ExtensionIsLoaded("tpch")) {
+		return;
+	}
+
+	// TPCH
+	table_names = con.GetTableNames("PRAGMA tpch(1)");
+	REQUIRE(table_names.size() == 1);
+	REQUIRE(table_names.count("lineitem"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(2)");
+	REQUIRE(table_names.size() == 5);
+	REQUIRE(table_names.count("part"));
+	REQUIRE(table_names.count("supplier"));
+	REQUIRE(table_names.count("partsupp"));
+	REQUIRE(table_names.count("nation"));
+	REQUIRE(table_names.count("region"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(3)");
+	REQUIRE(table_names.size() == 3);
+	REQUIRE(table_names.count("customer"));
+	REQUIRE(table_names.count("orders"));
+	REQUIRE(table_names.count("lineitem"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(4)");
+	REQUIRE(table_names.size() == 2);
+	REQUIRE(table_names.count("orders"));
+	REQUIRE(table_names.count("lineitem"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(5)");
+	REQUIRE(table_names.size() == 6);
+	REQUIRE(table_names.count("customer"));
+	REQUIRE(table_names.count("orders"));
+	REQUIRE(table_names.count("lineitem"));
+	REQUIRE(table_names.count("supplier"));
+	REQUIRE(table_names.count("nation"));
+	REQUIRE(table_names.count("region"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(6)");
+	REQUIRE(table_names.size() == 1);
+	REQUIRE(table_names.count("lineitem"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(7)");
+	REQUIRE(table_names.size() == 5);
+	REQUIRE(table_names.count("supplier"));
+	REQUIRE(table_names.count("lineitem"));
+	REQUIRE(table_names.count("orders"));
+	REQUIRE(table_names.count("customer"));
+	REQUIRE(table_names.count("nation"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(8)");
+	REQUIRE(table_names.size() == 7);
+	REQUIRE(table_names.count("part"));
+	REQUIRE(table_names.count("supplier"));
+	REQUIRE(table_names.count("lineitem"));
+	REQUIRE(table_names.count("orders"));
+	REQUIRE(table_names.count("customer"));
+	REQUIRE(table_names.count("nation"));
+	REQUIRE(table_names.count("region"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(9)");
+	REQUIRE(table_names.size() == 6);
+	REQUIRE(table_names.count("part"));
+	REQUIRE(table_names.count("supplier"));
+	REQUIRE(table_names.count("lineitem"));
+	REQUIRE(table_names.count("partsupp"));
+	REQUIRE(table_names.count("orders"));
+	REQUIRE(table_names.count("nation"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(10)");
+	REQUIRE(table_names.size() == 4);
+	REQUIRE(table_names.count("customer"));
+	REQUIRE(table_names.count("orders"));
+	REQUIRE(table_names.count("lineitem"));
+	REQUIRE(table_names.count("nation"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(11)");
+	REQUIRE(table_names.size() == 3);
+	REQUIRE(table_names.count("partsupp"));
+	REQUIRE(table_names.count("supplier"));
+	REQUIRE(table_names.count("nation"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(12)");
+	REQUIRE(table_names.size() == 2);
+	REQUIRE(table_names.count("orders"));
+	REQUIRE(table_names.count("lineitem"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(13)");
+	REQUIRE(table_names.size() == 2);
+	REQUIRE(table_names.count("customer"));
+	REQUIRE(table_names.count("orders"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(14)");
+	REQUIRE(table_names.size() == 2);
+	REQUIRE(table_names.count("part"));
+	REQUIRE(table_names.count("lineitem"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(15)");
+	REQUIRE(table_names.size() == 2);
+	REQUIRE(table_names.count("supplier"));
+	REQUIRE(table_names.count("lineitem"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(16)");
+	REQUIRE(table_names.size() == 3);
+	REQUIRE(table_names.count("partsupp"));
+	REQUIRE(table_names.count("part"));
+	REQUIRE(table_names.count("supplier"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(17)");
+	REQUIRE(table_names.size() == 2);
+	REQUIRE(table_names.count("lineitem"));
+	REQUIRE(table_names.count("part"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(18)");
+	REQUIRE(table_names.size() == 3);
+	REQUIRE(table_names.count("customer"));
+	REQUIRE(table_names.count("orders"));
+	REQUIRE(table_names.count("lineitem"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(19)");
+	REQUIRE(table_names.size() == 2);
+	REQUIRE(table_names.count("lineitem"));
+	REQUIRE(table_names.count("part"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(20)");
+	REQUIRE(table_names.size() == 5);
+	REQUIRE(table_names.count("supplier"));
+	REQUIRE(table_names.count("nation"));
+	REQUIRE(table_names.count("partsupp"));
+	REQUIRE(table_names.count("part"));
+	REQUIRE(table_names.count("lineitem"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(21)");
+	REQUIRE(table_names.size() == 4);
+	REQUIRE(table_names.count("supplier"));
+	REQUIRE(table_names.count("lineitem"));
+	REQUIRE(table_names.count("orders"));
+	REQUIRE(table_names.count("nation"));
+
+	table_names = con.GetTableNames("PRAGMA tpch(22)");
+	REQUIRE(table_names.size() == 2);
+	REQUIRE(table_names.count("customer"));
+	REQUIRE(table_names.count("orders"));
+}


### PR DESCRIPTION
Usage:

```cpp
unordered_set<string> table_names = con.GetTableNames("SELECT * FROM my_table");
// my_table
table_names = con.GetTableNames("WITH cte AS (SELECT * FROM my_table) SELECT * FROM cte");
// my_table
```

The tables don't need to exist in the catalog, and this should work on arbitrary queries.

CC @ankoh 