### PR TITLE
Issue #561: Implement ICU AGE

### DIFF
--- a/extension/icu/icu-dateadd.cpp
+++ b/extension/icu/icu-dateadd.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/common/operator/add.hpp"
 #include "duckdb/common/operator/multiply.hpp"
+#include "duckdb/common/types/time.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 
 namespace duckdb {
@@ -16,10 +17,17 @@ struct ICUCalendarAdd {
 	}
 };
 
-struct ICUCalendarSub {
+struct ICUCalendarSub : public ICUDateFunc {
 	template <class TA, class TB, class TR>
 	static inline TR Operation(TA left, TB right, icu::Calendar *calendar) {
 		throw InternalException("Unimplemented type for ICUCalendarSub");
+	}
+};
+
+struct ICUCalendarAge : public ICUDateFunc {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA left, TB right, icu::Calendar *calendar) {
+		throw InternalException("Unimplemented type for ICUCalendarAge");
 	}
 };
 
@@ -81,7 +89,91 @@ timestamp_t ICUCalendarSub::Operation(timestamp_t timestamp, interval_t interval
 	return ICUCalendarAdd::template Operation<timestamp_t, interval_t, timestamp_t>(timestamp, negated, calendar);
 }
 
+template <>
+interval_t ICUCalendarSub::Operation(timestamp_t end_date, timestamp_t start_date, icu::Calendar *calendar) {
+	if (start_date > end_date) {
+		auto negated = Operation<timestamp_t, timestamp_t, interval_t>(start_date, end_date, calendar);
+		return {-negated.months, -negated.days, -negated.micros};
+	}
+
+	auto start_micros = ICUDateFunc::SetTime(calendar, start_date);
+	auto end_micros = end_date.value % Interval::MICROS_PER_MSEC;
+
+	// Borrow 1ms from end_date if we wrap. This works because start_date <= end_date
+	// and if the µs are out of order, then there must be an extra ms.
+	if (start_micros > end_micros) {
+		end_date.value -= Interval::MICROS_PER_MSEC;
+		end_micros += Interval::MICROS_PER_MSEC;
+	}
+
+	//	Timestamp differences do not use months, so start with days
+	interval_t result;
+	result.months = 0;
+	result.days = SubtractField(calendar, UCAL_DATE, end_date);
+
+	auto hour_diff = SubtractField(calendar, UCAL_HOUR_OF_DAY, end_date);
+	auto min_diff = SubtractField(calendar, UCAL_MINUTE, end_date);
+	auto sec_diff = SubtractField(calendar, UCAL_SECOND, end_date);
+	auto ms_diff = SubtractField(calendar, UCAL_MILLISECOND, end_date);
+	auto micros_diff = ms_diff * Interval::MICROS_PER_MSEC + (end_micros - start_micros);
+	result.micros = Time::FromTime(hour_diff, min_diff, sec_diff, micros_diff).micros;
+
+	return result;
+}
+
+template <>
+interval_t ICUCalendarAge::Operation(timestamp_t end_date, timestamp_t start_date, icu::Calendar *calendar) {
+	if (start_date > end_date) {
+		auto negated = Operation<timestamp_t, timestamp_t, interval_t>(start_date, end_date, calendar);
+		return {-negated.months, -negated.days, -negated.micros};
+	}
+
+	auto start_micros = ICUDateFunc::SetTime(calendar, start_date);
+	auto end_micros = end_date.value % Interval::MICROS_PER_MSEC;
+
+	// Borrow 1ms from end_date if we wrap. This works because start_date <= end_date
+	// and if the µs are out of order, then there must be an extra ms.
+	if (start_micros > end_micros) {
+		end_date.value -= Interval::MICROS_PER_MSEC;
+		end_micros += Interval::MICROS_PER_MSEC;
+	}
+
+	//	Lunar calendars have uneven numbers of months, so we just diff months, not years
+	interval_t result;
+	result.months = SubtractField(calendar, UCAL_MONTH, end_date);
+	result.days = SubtractField(calendar, UCAL_DATE, end_date);
+
+	auto hour_diff = SubtractField(calendar, UCAL_HOUR_OF_DAY, end_date);
+	auto min_diff = SubtractField(calendar, UCAL_MINUTE, end_date);
+	auto sec_diff = SubtractField(calendar, UCAL_SECOND, end_date);
+	auto ms_diff = SubtractField(calendar, UCAL_MILLISECOND, end_date);
+	auto micros_diff = ms_diff * Interval::MICROS_PER_MSEC + (end_micros - start_micros);
+	result.micros = Time::FromTime(hour_diff, min_diff, sec_diff, micros_diff).micros;
+
+	return result;
+}
+
 struct ICUDateAdd : public ICUDateFunc {
+
+	template <typename TA, typename TR, typename OP>
+	static void ExecuteUnary(DataChunk &args, ExpressionState &state, Vector &result) {
+		D_ASSERT(args.ColumnCount() == 1);
+
+		auto &func_expr = (BoundFunctionExpression &)state.expr;
+		auto &info = (BindData &)*func_expr.bind_info;
+		CalendarPtr calendar(info.calendar->clone());
+
+		auto end_date = Timestamp::GetCurrentTimestamp();
+		UnaryExecutor::Execute<TA, TR>(args.data[0], result, args.size(), [&](TA start_date) {
+			return OP::template Operation<timestamp_t, TA, TR>(end_date, start_date, calendar.get());
+		});
+	}
+
+	template <typename TA, typename TR, typename OP>
+	inline static ScalarFunction GetUnaryDateFunction(const LogicalTypeId &left_type,
+	                                                  const LogicalTypeId &result_type) {
+		return ScalarFunction({left_type}, result_type, ExecuteUnary<TA, TR, OP>, false, Bind);
+	}
 
 	template <typename TA, typename TB, typename TR, typename OP>
 	static void ExecuteBinary(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -99,8 +191,7 @@ struct ICUDateAdd : public ICUDateFunc {
 	template <typename TA, typename TB, typename TR, typename OP>
 	inline static ScalarFunction GetBinaryDateFunction(const LogicalTypeId &left_type, const LogicalTypeId &right_type,
 	                                                   const LogicalTypeId &result_type) {
-		return ScalarFunction({left_type, right_type}, result_type, ExecuteBinary<TA, TB, timestamp_t, OP>, false,
-		                      Bind);
+		return ScalarFunction({left_type, right_type}, result_type, ExecuteBinary<TA, TB, TR, OP>, false, Bind);
 	}
 
 	template <typename TA, typename TB, typename OP>
@@ -121,11 +212,37 @@ struct ICUDateAdd : public ICUDateFunc {
 		catalog.AddFunction(context, &func_info);
 	}
 
+	template <typename TA, typename OP>
+	static ScalarFunction GetUnaryAgeFunction(const LogicalTypeId &left_type) {
+		return GetUnaryDateFunction<TA, interval_t, OP>(left_type, LogicalType::INTERVAL);
+	}
+
+	template <typename TA, typename TB, typename OP>
+	static ScalarFunction GetBinaryAgeFunction(const LogicalTypeId &left_type, const LogicalTypeId &right_type) {
+		return GetBinaryDateFunction<TA, TB, interval_t, OP>(left_type, right_type, LogicalType::INTERVAL);
+	}
+
 	static void AddDateSubOperators(const string &name, ClientContext &context) {
 		//	temporal - interval
 		ScalarFunctionSet set(name);
 		set.AddFunction(GetDateAddFunction<timestamp_t, interval_t, ICUCalendarSub>(LogicalType::TIMESTAMP_TZ,
 		                                                                            LogicalType::INTERVAL));
+
+		//	temporal - temporal
+		set.AddFunction(GetBinaryAgeFunction<timestamp_t, timestamp_t, ICUCalendarSub>(LogicalType::TIMESTAMP_TZ,
+		                                                                               LogicalType::TIMESTAMP_TZ));
+
+		CreateScalarFunctionInfo func_info(set);
+		auto &catalog = Catalog::GetCatalog(context);
+		catalog.AddFunction(context, &func_info);
+	}
+
+	static void AddDateAgeFunctions(const string &name, ClientContext &context) {
+		//	age(temporal, temporal)
+		ScalarFunctionSet set(name);
+		set.AddFunction(GetBinaryAgeFunction<timestamp_t, timestamp_t, ICUCalendarAge>(LogicalType::TIMESTAMP_TZ,
+		                                                                               LogicalType::TIMESTAMP_TZ));
+		set.AddFunction(GetUnaryAgeFunction<timestamp_t, ICUCalendarAge>(LogicalType::TIMESTAMP_TZ));
 
 		CreateScalarFunctionInfo func_info(set);
 		auto &catalog = Catalog::GetCatalog(context);
@@ -136,6 +253,7 @@ struct ICUDateAdd : public ICUDateFunc {
 void RegisterICUDateAddFunctions(ClientContext &context) {
 	ICUDateAdd::AddDateAddOperators("+", context);
 	ICUDateAdd::AddDateSubOperators("-", context);
+	ICUDateAdd::AddDateAgeFunctions("age", context);
 }
 
 } // namespace duckdb

--- a/test/sql/function/timestamp/test_icu_age.test
+++ b/test/sql/function/timestamp/test_icu_age.test
@@ -1,0 +1,144 @@
+# name: test/sql/function/timestamp/test_icu_age.test
+# description: Test ICU age functionality
+# group: [timestamp]
+
+require icu
+
+statement ok
+SET TimeZone = 'America/Los_Angeles';
+
+# age without second timestamp compares to NOW()
+statement ok
+SELECT AGE(TIMESTAMPTZ '1957-06-13') t;
+
+query T
+SELECT AGE(TIMESTAMP '2001-04-10 00:00:00-07', TIMESTAMP '1957-06-13 00:00:00-07');
+----
+43 years 9 months 27 days
+
+query T
+SELECT age(TIMESTAMP '2014-04-25 00:00:00-07', TIMESTAMP '2014-04-17 00:00:00-07');
+----
+8 days
+
+# Daylight savings time
+query T
+SELECT age(TIMESTAMPTZ '2014-04-25', TIMESTAMPTZ '2014-01-01');
+----
+3 months 24 days 01:00:00
+
+query T
+SELECT age(TIMESTAMPTZ '2019-06-11', TIMESTAMPTZ '2019-06-11');
+----
+00:00:00
+
+query T
+SELECT age(TIMESTAMPTZ '2019-06-11', TIMESTAMPTZ '2019-06-11')::VARCHAR;
+----
+00:00:00
+
+query T
+SELECT age(TIMESTAMPTZ '2019-06-11 12:00:00-07', TIMESTAMPTZ '2019-07-11 11:00:00-07');
+----
+-29 days -23:00:00
+
+statement ok
+CREATE TABLE timestamps(t1 TIMESTAMPTZ, t2 TIMESTAMPTZ);
+
+statement ok
+INSERT INTO timestamps VALUES
+	('2001-04-10', '1957-06-13'),
+	('2014-04-25', '2014-04-17'),
+	('2014-04-25','2014-01-01'),
+	('2019-06-11', '2019-06-11'),
+	(NULL, '2019-06-11'),
+	('2019-06-11', NULL),
+	(NULL, NULL)
+
+# Differences from the built in AGE function are due to ICU
+# computing month lengths from the originating month
+# instead of assuming a constant month size of 30 days
+query T
+SELECT AGE(t1, TIMESTAMPTZ '1957-06-13') FROM timestamps;
+----
+43 years 9 months 28 days
+56 years 10 months 12 days
+56 years 10 months 12 days
+61 years 11 months 29 days
+NULL
+61 years 11 months 29 days
+NULL
+
+# Time fields caused by DST
+query T
+SELECT AGE(TIMESTAMPTZ '2001-04-10', t2) FROM timestamps;
+----
+43 years 9 months 28 days
+-13 years -7 days
+-12 years -8 months -21 days -23:00:00
+-18 years -2 months -1 days
+-18 years -2 months -1 days
+NULL
+NULL
+
+query T
+SELECT AGE(t1, t2) FROM timestamps;
+----
+43 years 9 months 28 days
+8 days
+3 months 24 days 01:00:00
+00:00:00
+NULL
+NULL
+NULL
+
+query T
+SELECT t1 - t2 FROM timestamps;
+----
+16007 days
+8 days
+114 days 01:00:00
+00:00:00
+NULL
+NULL
+NULL
+
+query T
+SELECT AGE(t1, t2) FROM timestamps WHERE t1 > '2001-12-12';
+----
+8 days
+3 months 24 days 01:00:00
+00:00:00
+NULL
+
+query T
+SELECT AGE(NULL, NULL);
+----
+NULL
+
+query T
+SELECT AGE(TIMESTAMPTZ '1957-06-13', NULL);
+----
+NULL
+
+query T
+SELECT AGE(NULL, TIMESTAMPTZ '1957-06-13');
+----
+NULL
+
+# Subsecond tests
+query I
+SELECT AGE(TIMESTAMPTZ '1992-01-01 01:01:02.400', TIMESTAMPTZ '1992-01-01 01:01:02.200');
+----
+00:00:00.2
+
+query I
+SELECT AGE(TIMESTAMPTZ '1992-01-01 01:01:02.200', TIMESTAMPTZ '1992-01-01 01:01:02.400');
+----
+-00:00:00.2
+
+query I
+SELECT AGE(TIMESTAMPTZ '1992-01-01 01:01:01.400', TIMESTAMPTZ '1992-01-01 01:01:02.200');
+----
+-00:00:00.8
+


### PR DESCRIPTION
ICU's AGE computations are slightly different from the built in ones
* Daylight savings time is accounted for
* Month lengths are not fixed.

Also implement the timestamptz subtraction operator.