### PR TITLE
Fix a bug in the sqlite3_api_wrapper that resulted in not correctly reporting why a database could not be opened

### DIFF
--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -369,7 +369,7 @@ SELECT * FROM t1;
 duckdb_nonsense_db = 'duckdbtest_nonsensedb.db'
 with open(duckdb_nonsense_db, 'w+') as f:
      f.write('blablabla')
-test('', err='unable to open', extra_commands=[duckdb_nonsense_db])
+test('', err='The file is not a valid DuckDB database file', extra_commands=[duckdb_nonsense_db])
 os.remove(duckdb_nonsense_db)
 
 # enable_profiling doesn't result in any output

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -84,6 +84,7 @@ int sqlite3_open_v2(const char *filename, /* Database filename (UTF-8) */
 	if (zVfs) { /* unsupported so if set we complain */
 		return SQLITE_ERROR;
 	}
+	int rc = SQLITE_OK;
 	sqlite3 *pDb = nullptr;
 	try {
 		pDb = new sqlite3();
@@ -99,10 +100,10 @@ int sqlite3_open_v2(const char *filename, /* Database filename (UTF-8) */
 			pDb->last_error = ex.what();
 			pDb->errCode = SQLITE_ERROR;
 		}
-		return SQLITE_ERROR;
+		rc = SQLITE_ERROR;
 	}
 	*ppDb = pDb;
-	return SQLITE_OK;
+	return rc;
 }
 
 int sqlite3_close(sqlite3 *db) {


### PR DESCRIPTION
Now the shell actually reports why a database file could not be opened:

```
build/debug/duckdb zstd.parquet                    
Error: unable to open database "zstd.parquet": IO Error: The file is not a valid DuckDB database file!
```