### PR TITLE
adds `BOOLEAN` support to node.js bindings

### DIFF
--- a/tools/nodejs/package.json
+++ b/tools/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "duckdb",
   "main": "./lib/duckdb.js",
-  "version": "0.2.4",
+  "version": "0.3.2-dev593.0",
   "description": "DuckDB node.js API",
   "gypfile": true,
   "dependencies": {
@@ -25,8 +25,8 @@
     "test": "test"
   },
   "devDependencies": {
-    "mocha": "^8.3.0",
-    "aws-sdk": "^2.790.0"
+    "aws-sdk": "^2.790.0",
+    "mocha": "^8.3.0"
   },
   "repository": {
     "type": "git",

--- a/tools/nodejs/package.json
+++ b/tools/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "duckdb",
   "main": "./lib/duckdb.js",
-  "version": "0.3.2-dev593.0",
+  "version": "0.2.4",
   "description": "DuckDB node.js API",
   "gypfile": true,
   "dependencies": {

--- a/tools/nodejs/src/statement.cpp
+++ b/tools/nodejs/src/statement.cpp
@@ -137,6 +137,7 @@ static Napi::Value convert_chunk(Napi::Env &env, std::vector<std::string> names,
 			Napi::Value value;
 
 			auto dval = chunk.GetValue(col_idx, row_idx);
+
 			if (dval.is_null) {
 				row_result.Set(node_names[col_idx], env.Null());
 				continue;
@@ -170,6 +171,9 @@ static Napi::Value convert_chunk(Napi::Env &env, std::vector<std::string> names,
 #endif
 			case duckdb::LogicalTypeId::VARCHAR: {
 				value = Napi::String::New(env, dval.str_value);
+			} break;
+			case duckdb::LogicalTypeId::BOOLEAN: {
+				value = Napi::Boolean::New(env, dval.value_.boolean);
 			} break;
 			case duckdb::LogicalTypeId::BLOB: {
 				value = Napi::Buffer<char>::Copy(env, dval.str_value.c_str(), dval.str_value.length());

--- a/tools/nodejs/src/statement.cpp
+++ b/tools/nodejs/src/statement.cpp
@@ -137,7 +137,6 @@ static Napi::Value convert_chunk(Napi::Env &env, std::vector<std::string> names,
 			Napi::Value value;
 
 			auto dval = chunk.GetValue(col_idx, row_idx);
-
 			if (dval.is_null) {
 				row_result.Set(node_names[col_idx], env.Null());
 				continue;

--- a/tools/nodejs/test/data_type_support.test.js
+++ b/tools/nodejs/test/data_type_support.test.js
@@ -1,0 +1,23 @@
+var sqlite3 = require("..");
+var assert = require("assert");
+
+describe("data type support", function () {
+  let db;
+  before(function (done) {
+    db = new sqlite3.Database(":memory:", done);
+  });
+
+  it("supports BOOLEAN values", function (done) {
+    db.run("CREATE TABLE boolean_table (i BOOLEAN)");
+    const stmt = db.prepare("INSERT INTO boolean_table VALUES (?)");
+    const values = [true, false];
+    values.forEach((bool) => {
+      stmt.run(bool);
+    });
+    db.prepare("SELECT i from boolean_table;").all((err, res) => {
+      assert(err === null);
+      assert(res.every((v, i) => v.i === values[i]));
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Closes #1342

This PR does the following:

- adds `BOOLEAN` support to the duckdb node bindings. This addition will also incidentally fix the `PRAGMA table_info` problem mentioned in the github issue above.
- contributes a test, `data_type_support.test.js`, which verifies the support. This test file could grow to include more comprehensive support both for existing supported data types and ones that need to be add (e.g. `INTERVAL` as per #2787)