### PR TITLE
R-Dataset: Add flag to enable async scanner

### DIFF
--- a/tools/rpkg/R/register.R
+++ b/tools/rpkg/R/register.R
@@ -66,14 +66,15 @@ duckdb_unregister <- function(conn, name) {
 #' @param conn A DuckDB connection, created by `dbConnect()`.
 #' @param name The name for the virtual table that is registered or unregistered
 #' @param arrow_scannable A scannable Arrow-object
+#' @param use_async Switched to the asynchronous scanner. default FALSE
 #' @return These functions are called for their side effect.
 #' @export
-duckdb_register_arrow <- function(conn, name, arrow_scannable) {
+duckdb_register_arrow <- function(conn, name, arrow_scannable, use_async=FALSE) {
   stopifnot(dbIsValid(conn))
 
     # create some R functions to pass to c-land
     export_fun <- function(arrow_scannable, stream_ptr, projection=NULL, filter=TRUE) {
-        arrow::Scanner$create(arrow_scannable, projection, filter)$ToRecordBatchReader()$export_to_c(stream_ptr)
+        arrow::Scanner$create(arrow_scannable, projection, filter, use_async=use_async)$ToRecordBatchReader()$export_to_c(stream_ptr)
     }
    # pass some functions to c land so we don't have to look them up there
    function_list <- list(export_fun, arrow::Expression$create, arrow::Expression$field_ref, arrow::Expression$scalar)

--- a/tools/rpkg/man/duckdb_register_arrow.Rd
+++ b/tools/rpkg/man/duckdb_register_arrow.Rd
@@ -18,6 +18,8 @@ duckdb_list_arrow(conn)
 \item{name}{The name for the virtual table that is registered or unregistered}
 
 \item{arrow_scannable}{A scannable Arrow-object}
+
+\item{use_async}{Enables the async arrow scanner. Defaults to FALSE}
 }
 \value{
 These functions are called for their side effect.

--- a/tools/rpkg/man/duckdb_register_arrow.Rd
+++ b/tools/rpkg/man/duckdb_register_arrow.Rd
@@ -6,7 +6,7 @@
 \alias{duckdb_list_arrow}
 \title{Register an Arrow data source as a virtual table}
 \usage{
-duckdb_register_arrow(conn, name, arrow_scannable)
+duckdb_register_arrow(conn, name, arrow_scannable, use_async = FALSE)
 
 duckdb_unregister_arrow(conn, name)
 
@@ -19,7 +19,7 @@ duckdb_list_arrow(conn)
 
 \item{arrow_scannable}{A scannable Arrow-object}
 
-\item{use_async}{Enables the async arrow scanner. Defaults to FALSE}
+\item{use_async}{Switched to the asynchronous scanner. default FALSE}
 }
 \value{
 These functions are called for their side effect.


### PR DESCRIPTION
This PR adds the use_async flag
when registering an arrow dataset to duckdb.

This should speed up querying S3 datasets.