### PR TITLE
add `INTERVAL` support to node.js

### DIFF
--- a/tools/nodejs/src/statement.cpp
+++ b/tools/nodejs/src/statement.cpp
@@ -138,7 +138,7 @@ static Napi::Value convert_chunk(Napi::Env &env, std::vector<std::string> names,
 			// set up a new Napi::Object for some data types, e.g. INTERVAL
 			Napi::Object object_value;
 
-			bool is_object_value { false };
+			bool is_object_value {false};
 
 			auto dval = chunk.GetValue(col_idx, row_idx);
 			if (dval.is_null) {

--- a/tools/nodejs/src/statement.cpp
+++ b/tools/nodejs/src/statement.cpp
@@ -135,6 +135,10 @@ static Napi::Value convert_chunk(Napi::Env &env, std::vector<std::string> names,
 
 		for (duckdb::idx_t col_idx = 0; col_idx < chunk.ColumnCount(); col_idx++) {
 			Napi::Value value;
+			// set up a new Napi::Object for some data types, e.g. INTERVAL
+			Napi::Object object_value;
+
+			bool is_object_value { false };
 
 			auto dval = chunk.GetValue(col_idx, row_idx);
 			if (dval.is_null) {
@@ -158,6 +162,13 @@ static Napi::Value convert_chunk(Napi::Env &env, std::vector<std::string> names,
 			} break;
 			case duckdb::LogicalTypeId::HUGEINT: {
 				value = Napi::Number::New(env, dval.GetValue<double>());
+			} break;
+			case duckdb::LogicalTypeId::INTERVAL: {
+				is_object_value = true;
+				object_value = Napi::Object::New(env);
+				object_value.Set("months", dval.value_.interval.months);
+				object_value.Set("days", dval.value_.interval.days);
+				object_value.Set("micros", dval.value_.interval.micros);
 			} break;
 #if (NAPI_VERSION > 4)
 			case duckdb::LogicalTypeId::DATE: {
@@ -185,7 +196,11 @@ static Napi::Value convert_chunk(Napi::Env &env, std::vector<std::string> names,
 				    .ThrowAsJavaScriptException();
 				return env.Null();
 			}
-			row_result.Set(node_names[col_idx], value);
+			if (is_object_value == true) {
+				row_result.Set(node_names[col_idx], object_value);
+			} else {
+				row_result.Set(node_names[col_idx], value);
+			}
 		}
 		result.Set(row_idx, row_result);
 	}

--- a/tools/nodejs/test/data_type_support.test.js
+++ b/tools/nodejs/test/data_type_support.test.js
@@ -20,4 +20,18 @@ describe("data type support", function () {
       done();
     });
   });
+  it("supports INTERVAL values", function (done) {
+    db.prepare(`SELECT 
+    INTERVAL 1 MINUTE as minutes,
+    INTERVAL 5 DAY as days,
+    INTERVAL 4 MONTH as months,
+    INTERVAL 4 MONTH + INTERVAL 5 DAY + INTERVAL 1 MINUTE as combined;`).each((err, row) => {
+      assert(err === null);
+      assert.deepEqual(row.minutes, { months: 0, days: 0, micros: 60 * 1000 * 1000});
+      assert.deepEqual(row.days, { months: 0, days: 5, micros: 0});
+      assert.deepEqual(row.months, {months: 4, days: 0, micros: 0});
+      assert.deepEqual(row.combined, {months: 4, days: 5, micros: 60 * 1000 * 1000});
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Closes #2787 based on @hawkfish's suggestion. This PR:

- adds support for `INTERVAL` in node.js by converting the struct to a javascript object
- adds a mocha test to verify this type translation works as expected

Apologies if my c++ is a bit elementary – I welcome feedback on the code quality.