### PR TITLE
Fix #2815: split single row group into multiple pages if pages exceed INT32_MAX uncompressed size

### DIFF
--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -197,9 +197,9 @@ struct ParquetHugeintOperator {
 };
 
 template <class SRC, class TGT, class OP = ParquetCastOperator>
-static void TemplatedWritePlain(Vector &col, idx_t length, ValidityMask &mask, Serializer &ser) {
+static void TemplatedWritePlain(Vector &col, idx_t chunk_start, idx_t chunk_end, ValidityMask &mask, Serializer &ser) {
 	auto *ptr = FlatVector::GetData<SRC>(col);
-	for (idx_t r = 0; r < length; r++) {
+	for (idx_t r = chunk_start; r < chunk_end; r++) {
 		if (mask.RowIsValid(r)) {
 			ser.Write<TGT>(OP::template Operation<SRC, TGT>(ptr[r]));
 		}
@@ -209,10 +209,6 @@ static void TemplatedWritePlain(Vector &col, idx_t length, ValidityMask &mask, S
 ParquetWriter::ParquetWriter(FileSystem &fs, string file_name_p, FileOpener *file_opener_p, vector<LogicalType> types_p,
                              vector<string> names_p, CompressionCodec::type codec)
     : file_name(move(file_name_p)), sql_types(move(types_p)), column_names(move(names_p)), codec(codec) {
-#if STANDARD_VECTOR_SIZE < 64
-	throw NotImplementedException("Parquet writer is not supported for vector sizes < 64");
-#endif
-
 	// initialize the file writer
 	writer = make_unique<BufferedFileWriter>(
 	    fs, file_name.c_str(), FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW, file_opener_p);
@@ -248,6 +244,264 @@ ParquetWriter::ParquetWriter(FileSystem &fs, string file_name_p, FileOpener *fil
 	}
 }
 
+idx_t ParquetWriter::MaxWriteCount(ChunkCollection &buffer, idx_t col_idx, idx_t chunk_idx, idx_t index_in_chunk,
+                                   idx_t &out_max_chunk, idx_t &out_max_index_in_chunk) {
+	D_ASSERT(buffer.ChunkCount() > 0);
+	if (buffer.Types()[col_idx].InternalType() != PhysicalType::VARCHAR) {
+		// for non-variable length types we know 100K rows will fit within 2GB (the max page size in Parquet)
+		// so checking this is unnecessary
+		out_max_chunk = buffer.ChunkCount();
+		out_max_index_in_chunk = 0;
+		return buffer.Count();
+	}
+	idx_t current_size = 0;
+	idx_t write_count = 0;
+	auto &chunks = buffer.Chunks();
+	for (; chunk_idx < chunks.size();) {
+		auto &input = *chunks[chunk_idx];
+		auto &input_column = input.data[col_idx];
+		auto &mask = FlatVector::Validity(input_column);
+		auto *ptr = FlatVector::GetData<string_t>(input_column);
+		for (; index_in_chunk < input.size(); index_in_chunk++) {
+			if (mask.RowIsValid(index_in_chunk)) {
+				current_size += ptr[index_in_chunk].GetSize() + sizeof(uint32_t);
+				if (current_size >= MAX_UNCOMPRESSED_PAGE_SIZE) {
+					index_in_chunk++;
+					break;
+				}
+			}
+			write_count++;
+		}
+		if (index_in_chunk >= input.size()) {
+			index_in_chunk = 0;
+			chunk_idx++;
+		}
+		if (current_size >= MAX_UNCOMPRESSED_PAGE_SIZE) {
+			break;
+		}
+	}
+	out_max_chunk = chunk_idx;
+	out_max_index_in_chunk = index_in_chunk;
+	return write_count;
+}
+
+void ParquetWriter::WriteVector(Serializer &temp_writer, DataChunk &input, idx_t col_idx, idx_t chunk_start,
+                                idx_t chunk_end) {
+	auto &input_column = input.data[col_idx];
+	auto &mask = FlatVector::Validity(input_column);
+
+	// write actual payload data
+	switch (sql_types[col_idx].id()) {
+	case LogicalTypeId::BOOLEAN: {
+#if STANDARD_VECTOR_SIZE < 64
+		throw InternalException("Writing booleans to Parquet not supported for vsize < 64");
+#endif
+		auto *ptr = FlatVector::GetData<bool>(input_column);
+		uint8_t byte = 0;
+		uint8_t byte_pos = 0;
+		for (idx_t r = chunk_start; r < chunk_end; r++) {
+			if (mask.RowIsValid(r)) { // only encode if non-null
+				byte |= (ptr[r] & 1) << byte_pos;
+				byte_pos++;
+
+				if (byte_pos == 8) {
+					temp_writer.Write<uint8_t>(byte);
+					byte = 0;
+					byte_pos = 0;
+				}
+			}
+		}
+		// flush last byte if req
+		if (byte_pos > 0) {
+			temp_writer.Write<uint8_t>(byte);
+		}
+		break;
+	}
+	case LogicalTypeId::TINYINT:
+		TemplatedWritePlain<int8_t, int32_t>(input_column, chunk_start, chunk_end, mask, temp_writer);
+		break;
+	case LogicalTypeId::SMALLINT:
+		TemplatedWritePlain<int16_t, int32_t>(input_column, chunk_start, chunk_end, mask, temp_writer);
+		break;
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::DATE:
+		TemplatedWritePlain<int32_t, int32_t>(input_column, chunk_start, chunk_end, mask, temp_writer);
+		break;
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_MS:
+		TemplatedWritePlain<int64_t, int64_t>(input_column, chunk_start, chunk_end, mask, temp_writer);
+		break;
+	case LogicalTypeId::HUGEINT:
+		TemplatedWritePlain<hugeint_t, double, ParquetHugeintOperator>(input_column, chunk_start, chunk_end, mask,
+		                                                               temp_writer);
+		break;
+	case LogicalTypeId::TIMESTAMP_NS:
+		TemplatedWritePlain<int64_t, int64_t, ParquetTimestampNSOperator>(input_column, chunk_start, chunk_end, mask,
+		                                                                  temp_writer);
+		break;
+	case LogicalTypeId::TIMESTAMP_SEC:
+		TemplatedWritePlain<int64_t, int64_t, ParquetTimestampSOperator>(input_column, chunk_start, chunk_end, mask,
+		                                                                 temp_writer);
+		break;
+	case LogicalTypeId::UTINYINT:
+		TemplatedWritePlain<uint8_t, int32_t>(input_column, chunk_start, chunk_end, mask, temp_writer);
+		break;
+	case LogicalTypeId::USMALLINT:
+		TemplatedWritePlain<uint16_t, int32_t>(input_column, chunk_start, chunk_end, mask, temp_writer);
+		break;
+	case LogicalTypeId::UINTEGER:
+		TemplatedWritePlain<uint32_t, uint32_t>(input_column, chunk_start, chunk_end, mask, temp_writer);
+		break;
+	case LogicalTypeId::UBIGINT:
+		TemplatedWritePlain<uint64_t, uint64_t>(input_column, chunk_start, chunk_end, mask, temp_writer);
+		break;
+	case LogicalTypeId::FLOAT:
+		TemplatedWritePlain<float, float>(input_column, chunk_start, chunk_end, mask, temp_writer);
+		break;
+	case LogicalTypeId::DECIMAL: {
+		// FIXME: fixed length byte array...
+		Vector double_vec(LogicalType::DOUBLE);
+		VectorOperations::Cast(input_column, double_vec, input.size());
+		TemplatedWritePlain<double, double>(double_vec, chunk_start, chunk_end, mask, temp_writer);
+		break;
+	}
+	case LogicalTypeId::DOUBLE:
+		TemplatedWritePlain<double, double>(input_column, chunk_start, chunk_end, mask, temp_writer);
+		break;
+	case LogicalTypeId::BLOB:
+	case LogicalTypeId::VARCHAR: {
+		auto *ptr = FlatVector::GetData<string_t>(input_column);
+		for (idx_t r = chunk_start; r < chunk_end; r++) {
+			if (mask.RowIsValid(r)) {
+				temp_writer.Write<uint32_t>(ptr[r].GetSize());
+				temp_writer.WriteData((const_data_ptr_t)ptr[r].GetDataUnsafe(), ptr[r].GetSize());
+			}
+		}
+		break;
+	}
+	default:
+		throw NotImplementedException((sql_types[col_idx].ToString()));
+	}
+}
+
+void ParquetWriter::WriteColumn(ChunkCollection &buffer, idx_t col_idx, idx_t chunk_idx, idx_t index_in_chunk,
+                                idx_t max_chunk, idx_t max_index_in_chunk, idx_t write_count) {
+	// we start off by writing everything into a temporary buffer
+	// this is necessary to (1) know the total written size, and (2) to compress it afterwards
+	BufferedSerializer temp_writer;
+
+	// set up some metadata
+	PageHeader hdr;
+	hdr.compressed_page_size = 0;
+	hdr.uncompressed_page_size = 0;
+	hdr.type = PageType::DATA_PAGE;
+	hdr.__isset.data_page_header = true;
+
+	hdr.data_page_header.num_values = write_count;
+	hdr.data_page_header.encoding = Encoding::PLAIN;
+	hdr.data_page_header.definition_level_encoding = Encoding::RLE;
+	hdr.data_page_header.repetition_level_encoding = Encoding::BIT_PACKED;
+
+	// write the definition levels (i.e. the inverse of the nullmask)
+	// we always bit pack everything
+
+	// first figure out how many bytes we need (1 byte per 8 rows, rounded up)
+	auto define_byte_count = (write_count + 7) / 8;
+	// we need to set up the count as a varint, plus an added marker for the RLE scheme
+	// for this marker we shift the count left 1 and set low bit to 1 to indicate bit packed literals
+	uint32_t define_header = (define_byte_count << 1) | 1;
+	uint32_t define_size = GetVarintSize(define_header) + define_byte_count;
+
+	// write the number of defines as a varint
+	temp_writer.Write<uint32_t>(define_size);
+	VarintEncode(define_header, temp_writer);
+
+	auto &chunks = buffer.Chunks();
+	if (max_index_in_chunk == 0) {
+		max_chunk--;
+		max_index_in_chunk = chunks[max_chunk]->size();
+	}
+	// construct a large validity mask holding all the validity bits we need to write
+	ValidityMask result_mask(write_count);
+	idx_t current_index = 0;
+	for (idx_t i = chunk_idx; i <= max_chunk; i++) {
+		auto &input = *chunks[i];
+		auto start_row = i == chunk_idx ? index_in_chunk : 0;
+		auto end_row = i == max_chunk ? max_index_in_chunk : input.size();
+		auto &validity = FlatVector::Validity(input.data[col_idx]);
+		for (idx_t i = start_row; i < end_row; i++) {
+			result_mask.Set(current_index++, validity.RowIsValid(i));
+		}
+	}
+	// actually write out the validity bits
+	temp_writer.WriteData((const_data_ptr_t)result_mask.GetData(), define_byte_count);
+
+	// now write the actual payload: we always write this as PLAIN values for now
+	for (idx_t i = chunk_idx; i <= max_chunk; i++) {
+		auto &input = *chunks[i];
+		auto start_row = i == chunk_idx ? index_in_chunk : 0;
+		auto end_row = i == max_chunk ? max_index_in_chunk : input.size();
+		WriteVector(temp_writer, input, col_idx, start_row, end_row);
+	}
+
+	// now that we have finished writing the data we know the uncompressed size
+	if (temp_writer.blob.size > NumericLimits<int32_t>::Maximum()) {
+		throw InternalException("Parquet writer: %d uncompressed page size out of range for type integer",
+		                        temp_writer.blob.size);
+	}
+	hdr.uncompressed_page_size = temp_writer.blob.size;
+
+	// compress the data based
+	size_t compressed_size;
+	data_ptr_t compressed_data;
+	unique_ptr<data_t[]> compressed_buf;
+	switch (codec) {
+	case CompressionCodec::UNCOMPRESSED:
+		compressed_size = temp_writer.blob.size;
+		compressed_data = temp_writer.blob.data.get();
+		break;
+	case CompressionCodec::SNAPPY: {
+		compressed_size = duckdb_snappy::MaxCompressedLength(temp_writer.blob.size);
+		compressed_buf = unique_ptr<data_t[]>(new data_t[compressed_size]);
+		duckdb_snappy::RawCompress((const char *)temp_writer.blob.data.get(), temp_writer.blob.size,
+		                           (char *)compressed_buf.get(), &compressed_size);
+		compressed_data = compressed_buf.get();
+		D_ASSERT(compressed_size <= duckdb_snappy::MaxCompressedLength(temp_writer.blob.size));
+		break;
+	}
+	case CompressionCodec::GZIP: {
+		MiniZStream s;
+		compressed_size = s.MaxCompressedLength(temp_writer.blob.size);
+		compressed_buf = unique_ptr<data_t[]>(new data_t[compressed_size]);
+		s.Compress((const char *)temp_writer.blob.data.get(), temp_writer.blob.size, (char *)compressed_buf.get(),
+		           &compressed_size);
+		compressed_data = compressed_buf.get();
+		break;
+	}
+	case CompressionCodec::ZSTD: {
+		compressed_size = duckdb_zstd::ZSTD_compressBound(temp_writer.blob.size);
+		compressed_buf = unique_ptr<data_t[]>(new data_t[compressed_size]);
+		compressed_size = duckdb_zstd::ZSTD_compress((void *)compressed_buf.get(), compressed_size,
+		                                             (const void *)temp_writer.blob.data.get(), temp_writer.blob.size,
+		                                             ZSTD_CLEVEL_DEFAULT);
+		compressed_data = compressed_buf.get();
+		break;
+	}
+	default:
+		throw InternalException("Unsupported codec for Parquet Writer");
+	}
+
+	if (compressed_size > NumericLimits<int32_t>::Maximum()) {
+		throw InternalException("Parquet writer: %d compressed page size out of range for type integer",
+		                        temp_writer.blob.size);
+	}
+	hdr.compressed_page_size = compressed_size;
+	// now finally write the data to the actual file
+	hdr.write(protocol.get());
+	writer->WriteData(compressed_data, compressed_size);
+}
+
 void ParquetWriter::Flush(ChunkCollection &buffer) {
 	if (buffer.Count() == 0) {
 		return;
@@ -262,209 +516,37 @@ void ParquetWriter::Flush(ChunkCollection &buffer) {
 	row_group.columns.resize(buffer.ColumnCount());
 
 	// iterate over each of the columns of the chunk collection and write them
-	for (idx_t i = 0; i < buffer.ColumnCount(); i++) {
-		// we start off by writing everything into a temporary buffer
-		// this is necessary to (1) know the total written size, and (2) to compress it afterwards
-		BufferedSerializer temp_writer;
-
-		// set up some metadata
-		PageHeader hdr;
-		hdr.compressed_page_size = 0;
-		hdr.uncompressed_page_size = 0;
-		hdr.type = PageType::DATA_PAGE;
-		hdr.__isset.data_page_header = true;
-
-		hdr.data_page_header.num_values = buffer.Count();
-		hdr.data_page_header.encoding = Encoding::PLAIN;
-		hdr.data_page_header.definition_level_encoding = Encoding::RLE;
-		hdr.data_page_header.repetition_level_encoding = Encoding::BIT_PACKED;
-		// hdr.data_page_header.statistics.__isset.max
-		// hdr.data_page_header.statistics.max
-
+	for (idx_t col_idx = 0; col_idx < buffer.ColumnCount(); col_idx++) {
 		// record the current offset of the writer into the file
-		// this is the starting position of the current page
+		// this is the starting position of the current column
 		auto start_offset = writer->GetTotalWritten();
 
-		// write the definition levels (i.e. the inverse of the nullmask)
-		// we always bit pack everything
+		idx_t chunk_idx = 0;
+		idx_t index_in_chunk = 0;
+		while (chunk_idx < buffer.ChunkCount()) {
+			idx_t max_chunk_idx;
+			idx_t max_index_in_chunk;
+			// check how many rows we can write in a single page
+			idx_t write_count =
+			    MaxWriteCount(buffer, col_idx, chunk_idx, index_in_chunk, max_chunk_idx, max_index_in_chunk);
+			D_ASSERT(write_count > 0);
+			D_ASSERT(max_chunk_idx >= chunk_idx);
+			D_ASSERT(max_chunk_idx > chunk_idx || max_index_in_chunk > index_in_chunk);
 
-		// first figure out how many bytes we need (1 byte per 8 rows, rounded up)
-		auto define_byte_count = (buffer.Count() + 7) / 8;
-		// we need to set up the count as a varint, plus an added marker for the RLE scheme
-		// for this marker we shift the count left 1 and set low bit to 1 to indicate bit packed literals
-		uint32_t define_header = (define_byte_count << 1) | 1;
-		uint32_t define_size = GetVarintSize(define_header) + define_byte_count;
-
-		// we write the actual definitions into the temp_writer for now
-		temp_writer.Write<uint32_t>(define_size);
-		VarintEncode(define_header, temp_writer);
-
-		for (auto &chunk : buffer.Chunks()) {
-			auto &validity = FlatVector::Validity(chunk->data[i]);
-			auto validity_data = validity.GetData();
-			auto chunk_define_byte_count = (chunk->size() + 7) / 8;
-			if (!validity_data) {
-				ValidityMask nop_mask(chunk->size());
-				temp_writer.WriteData((const_data_ptr_t)nop_mask.GetData(), chunk_define_byte_count);
-			} else {
-				// write the bits of the nullmask
-				temp_writer.WriteData((const_data_ptr_t)validity_data, chunk_define_byte_count);
-			}
+			// now write that many rows to the file as a single page
+			WriteColumn(buffer, col_idx, chunk_idx, index_in_chunk, max_chunk_idx, max_index_in_chunk, write_count);
+			chunk_idx = max_chunk_idx;
+			index_in_chunk = max_index_in_chunk;
 		}
 
-		// now write the actual payload: we write this as PLAIN values (for now? possibly for ever?)
-		for (auto &chunk : buffer.Chunks()) {
-			auto &input = *chunk;
-			auto &input_column = input.data[i];
-			auto &mask = FlatVector::Validity(input_column);
-
-			// write actual payload data
-			switch (sql_types[i].id()) {
-			case LogicalTypeId::BOOLEAN: {
-				auto *ptr = FlatVector::GetData<bool>(input_column);
-				uint8_t byte = 0;
-				uint8_t byte_pos = 0;
-				for (idx_t r = 0; r < input.size(); r++) {
-					if (mask.RowIsValid(r)) { // only encode if non-null
-						byte |= (ptr[r] & 1) << byte_pos;
-						byte_pos++;
-
-						if (byte_pos == 8) {
-							temp_writer.Write<uint8_t>(byte);
-							byte = 0;
-							byte_pos = 0;
-						}
-					}
-				}
-				// flush last byte if req
-				if (byte_pos > 0) {
-					temp_writer.Write<uint8_t>(byte);
-				}
-				break;
-			}
-			case LogicalTypeId::TINYINT:
-				TemplatedWritePlain<int8_t, int32_t>(input_column, input.size(), mask, temp_writer);
-				break;
-			case LogicalTypeId::SMALLINT:
-				TemplatedWritePlain<int16_t, int32_t>(input_column, input.size(), mask, temp_writer);
-				break;
-			case LogicalTypeId::INTEGER:
-			case LogicalTypeId::DATE:
-				TemplatedWritePlain<int32_t, int32_t>(input_column, input.size(), mask, temp_writer);
-				break;
-			case LogicalTypeId::BIGINT:
-			case LogicalTypeId::TIMESTAMP:
-			case LogicalTypeId::TIMESTAMP_MS:
-				TemplatedWritePlain<int64_t, int64_t>(input_column, input.size(), mask, temp_writer);
-				break;
-			case LogicalTypeId::HUGEINT:
-				TemplatedWritePlain<hugeint_t, double, ParquetHugeintOperator>(input_column, input.size(), mask,
-				                                                               temp_writer);
-				break;
-			case LogicalTypeId::TIMESTAMP_NS:
-				TemplatedWritePlain<int64_t, int64_t, ParquetTimestampNSOperator>(input_column, input.size(), mask,
-				                                                                  temp_writer);
-				break;
-			case LogicalTypeId::TIMESTAMP_SEC:
-				TemplatedWritePlain<int64_t, int64_t, ParquetTimestampSOperator>(input_column, input.size(), mask,
-				                                                                 temp_writer);
-				break;
-			case LogicalTypeId::UTINYINT:
-				TemplatedWritePlain<uint8_t, int32_t>(input_column, input.size(), mask, temp_writer);
-				break;
-			case LogicalTypeId::USMALLINT:
-				TemplatedWritePlain<uint16_t, int32_t>(input_column, input.size(), mask, temp_writer);
-				break;
-			case LogicalTypeId::UINTEGER:
-				TemplatedWritePlain<uint32_t, uint32_t>(input_column, input.size(), mask, temp_writer);
-				break;
-			case LogicalTypeId::UBIGINT:
-				TemplatedWritePlain<uint64_t, uint64_t>(input_column, input.size(), mask, temp_writer);
-				break;
-			case LogicalTypeId::FLOAT:
-				TemplatedWritePlain<float, float>(input_column, input.size(), mask, temp_writer);
-				break;
-			case LogicalTypeId::DECIMAL: {
-				// FIXME: fixed length byte array...
-				Vector double_vec(LogicalType::DOUBLE);
-				VectorOperations::Cast(input_column, double_vec, input.size());
-				TemplatedWritePlain<double, double>(double_vec, input.size(), mask, temp_writer);
-				break;
-			}
-			case LogicalTypeId::DOUBLE:
-				TemplatedWritePlain<double, double>(input_column, input.size(), mask, temp_writer);
-				break;
-			case LogicalTypeId::BLOB:
-			case LogicalTypeId::VARCHAR: {
-				auto *ptr = FlatVector::GetData<string_t>(input_column);
-				for (idx_t r = 0; r < input.size(); r++) {
-					if (mask.RowIsValid(r)) {
-						temp_writer.Write<uint32_t>(ptr[r].GetSize());
-						temp_writer.WriteData((const_data_ptr_t)ptr[r].GetDataUnsafe(), ptr[r].GetSize());
-					}
-				}
-				break;
-			}
-			default:
-				throw NotImplementedException((sql_types[i].ToString()));
-			}
-		}
-
-		// now that we have finished writing the data we know the uncompressed size
-		hdr.uncompressed_page_size = temp_writer.blob.size;
-
-		// compress the data based
-		size_t compressed_size;
-		data_ptr_t compressed_data;
-		unique_ptr<data_t[]> compressed_buf;
-		switch (codec) {
-		case CompressionCodec::UNCOMPRESSED:
-			compressed_size = temp_writer.blob.size;
-			compressed_data = temp_writer.blob.data.get();
-			break;
-		case CompressionCodec::SNAPPY: {
-			compressed_size = duckdb_snappy::MaxCompressedLength(temp_writer.blob.size);
-			compressed_buf = unique_ptr<data_t[]>(new data_t[compressed_size]);
-			duckdb_snappy::RawCompress((const char *)temp_writer.blob.data.get(), temp_writer.blob.size,
-			                           (char *)compressed_buf.get(), &compressed_size);
-			compressed_data = compressed_buf.get();
-			break;
-		}
-		case CompressionCodec::GZIP: {
-			MiniZStream s;
-			compressed_size = s.MaxCompressedLength(temp_writer.blob.size);
-			compressed_buf = unique_ptr<data_t[]>(new data_t[compressed_size]);
-			s.Compress((const char *)temp_writer.blob.data.get(), temp_writer.blob.size, (char *)compressed_buf.get(),
-			           &compressed_size);
-			compressed_data = compressed_buf.get();
-			break;
-		}
-		case CompressionCodec::ZSTD: {
-			compressed_size = duckdb_zstd::ZSTD_compressBound(temp_writer.blob.size);
-			compressed_buf = unique_ptr<data_t[]>(new data_t[compressed_size]);
-			compressed_size = duckdb_zstd::ZSTD_compress((void *)compressed_buf.get(), compressed_size,
-			                                             (const void *)temp_writer.blob.data.get(),
-			                                             temp_writer.blob.size, ZSTD_CLEVEL_DEFAULT);
-			compressed_data = compressed_buf.get();
-			break;
-		}
-		default:
-			throw InternalException("Unsupported codec for Parquet Writer");
-		}
-
-		hdr.compressed_page_size = compressed_size;
-		// now finally write the data to the actual file
-		hdr.write(protocol.get());
-		writer->WriteData(compressed_data, compressed_size);
-
-		auto &column_chunk = row_group.columns[i];
+		auto &column_chunk = row_group.columns[col_idx];
 		column_chunk.__isset.meta_data = true;
 		column_chunk.meta_data.data_page_offset = start_offset;
 		column_chunk.meta_data.total_compressed_size = writer->GetTotalWritten() - start_offset;
 		column_chunk.meta_data.codec = codec;
-		column_chunk.meta_data.path_in_schema.push_back(file_meta_data.schema[i + 1].name);
+		column_chunk.meta_data.path_in_schema.push_back(file_meta_data.schema[col_idx + 1].name);
 		column_chunk.meta_data.num_values = buffer.Count();
-		column_chunk.meta_data.type = file_meta_data.schema[i + 1].type;
+		column_chunk.meta_data.type = file_meta_data.schema[col_idx + 1].type;
 	}
 	row_group.num_rows += buffer.Count();
 

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -263,6 +263,7 @@ idx_t ParquetWriter::MaxWriteCount(ChunkCollection &buffer, idx_t col_idx, idx_t
 		auto &mask = FlatVector::Validity(input_column);
 		auto *ptr = FlatVector::GetData<string_t>(input_column);
 		for (; index_in_chunk < input.size(); index_in_chunk++) {
+			write_count++;
 			if (mask.RowIsValid(index_in_chunk)) {
 				current_size += ptr[index_in_chunk].GetSize() + sizeof(uint32_t);
 				if (current_size >= MAX_UNCOMPRESSED_PAGE_SIZE) {
@@ -270,7 +271,6 @@ idx_t ParquetWriter::MaxWriteCount(ChunkCollection &buffer, idx_t col_idx, idx_t
 					break;
 				}
 			}
-			write_count++;
 		}
 		if (index_in_chunk >= input.size()) {
 			index_in_chunk = 0;

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -446,7 +446,7 @@ void ParquetWriter::WriteColumn(ChunkCollection &buffer, idx_t col_idx, idx_t ch
 	}
 
 	// now that we have finished writing the data we know the uncompressed size
-	if (temp_writer.blob.size > NumericLimits<int32_t>::Maximum()) {
+	if (temp_writer.blob.size > idx_t(NumericLimits<int32_t>::Maximum())) {
 		throw InternalException("Parquet writer: %d uncompressed page size out of range for type integer",
 		                        temp_writer.blob.size);
 	}
@@ -492,7 +492,7 @@ void ParquetWriter::WriteColumn(ChunkCollection &buffer, idx_t col_idx, idx_t ch
 		throw InternalException("Unsupported codec for Parquet Writer");
 	}
 
-	if (compressed_size > NumericLimits<int32_t>::Maximum()) {
+	if (compressed_size > idx_t(NumericLimits<int32_t>::Maximum())) {
 		throw InternalException("Parquet writer: %d compressed page size out of range for type integer",
 		                        temp_writer.blob.size);
 	}

--- a/test/sql/copy/parquet/parquet_1589.test
+++ b/test/sql/copy/parquet/parquet_1589.test
@@ -4,8 +4,8 @@
 
 require parquet
 
-# statement ok
-# pragma enable_verification
+statement ok
+pragma enable_verification
 
 query I
 SELECT backlink_count FROM parquet_scan('data/parquet-testing/bug1589.parquet') LIMIT 1

--- a/test/sql/copy/parquet/parquet_filter_bug1391.test
+++ b/test/sql/copy/parquet/parquet_filter_bug1391.test
@@ -3,32 +3,31 @@
 # group: [parquet]
 
 require parquet
-require vector_size 512
 
 statement ok
 PRAGMA enable_verification
 
 statement ok
 CREATE VIEW tbl AS SELECT * FROM PARQUET_SCAN('data/parquet-testing/filter_bug1391.parquet');
-#
-#query I
-#SELECT ORGUNITID FROM tbl LIMIT 10
-#----
-#98
-#13
-#175
-#200
-#262
-#206
-#204
-#131
-#181
-#269
-#
-#query I
-#SELECT COUNT(*) FROM tbl;
-#----
-#9789
+
+query I
+SELECT ORGUNITID FROM tbl LIMIT 10
+----
+98
+13
+175
+200
+262
+206
+204
+131
+181
+269
+
+query I
+SELECT COUNT(*) FROM tbl;
+----
+9789
 
 query I
 SELECT COUNT(*) FROM tbl

--- a/test/sql/copy/parquet/parquet_write_codecs.test
+++ b/test/sql/copy/parquet/parquet_write_codecs.test
@@ -4,8 +4,6 @@
 
 require parquet
 
-require vector_size 64
-
 # codec uncompressed
 statement ok
 COPY (SELECT 42, 'hello') TO '__TEST_DIR__/uncompressed.parquet' (FORMAT 'parquet', CODEC 'UNCOMPRESSED');

--- a/test/sql/copy/parquet/test_aws_files.test
+++ b/test/sql/copy/parquet/test_aws_files.test
@@ -3,7 +3,6 @@
 # group: [parquet]
 
 require parquet
-require vector_size 512
 
 statement ok
 PRAGMA enable_verification

--- a/test/sql/copy/parquet/test_parquet_filter_pushdown.test
+++ b/test/sql/copy/parquet/test_parquet_filter_pushdown.test
@@ -3,7 +3,6 @@
 # group: [parquet]
 
 require parquet
-require vector_size 512
 
 statement ok
 pragma enable_verification

--- a/test/sql/copy/parquet/test_parquet_stats.test
+++ b/test/sql/copy/parquet/test_parquet_stats.test
@@ -3,7 +3,6 @@
 # group: [parquet]
 
 require parquet
-require vector_size 512
 
 statement ok
 PRAGMA explain_output = PHYSICAL_ONLY

--- a/test/sql/copy/parquet/writer/parquet_large_blobs.test_coverage
+++ b/test/sql/copy/parquet/writer/parquet_large_blobs.test_coverage
@@ -1,0 +1,20 @@
+# name: test/sql/copy/parquet/writer/parquet_large_blobs.test_coverage
+# description: Test writing of large blobs into parquet files
+# group: [writer]
+
+require parquet
+
+statement ok
+CREATE TABLE large_strings AS SELECT repeat('duckduck', 10000+i) i FROM range(4000) tbl(i);
+
+query III nosort minmaxstrlen
+SELECT MIN(strlen(i)), MAX(strlen(i)), AVG(strlen(i)) FROM large_strings;
+
+statement ok
+COPY large_strings TO '__TEST_DIR__/largestrings.parquet' (FORMAT PARQUET);
+
+statement ok
+SELECT * FROM parquet_metadata('__TEST_DIR__/largestrings.parquet');
+
+query III nosort minmaxstrlen
+SELECT MIN(strlen(i)), MAX(strlen(i)), AVG(strlen(i)) FROM large_strings;

--- a/test/sql/copy/parquet/writer/parquet_write_booleans.test
+++ b/test/sql/copy/parquet/writer/parquet_write_booleans.test
@@ -1,0 +1,36 @@
+# name: test/sql/copy/parquet/writer/parquet_write_booleans.test
+# description: Parquet bools round trip
+# group: [writer]
+
+require parquet
+
+require vector_size 512
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE bools(b BOOL)
+
+statement ok
+INSERT INTO bools SELECT CASE WHEN i%2=0 THEN NULL ELSE i%7=0 OR i%3=0 END b FROM range(10000) tbl(i);
+
+query IIIIII
+SELECT COUNT(*), COUNT(b), BOOL_AND(b), BOOL_OR(b), SUM(CASE WHEN b THEN 1 ELSE 0 END) true_count, SUM(CASE WHEN b THEN 0 ELSE 1 END) false_count
+FROM bools
+----
+10000	5000	False	True	2143	7857
+
+statement ok
+COPY bools TO '__TEST_DIR__/bools.parquet' (FORMAT 'parquet');
+
+query IIIIII
+SELECT COUNT(*), COUNT(b), BOOL_AND(b), BOOL_OR(b), SUM(CASE WHEN b THEN 1 ELSE 0 END) true_count, SUM(CASE WHEN b THEN 0 ELSE 1 END) false_count
+FROM '__TEST_DIR__/bools.parquet'
+----
+10000	5000	False	True	2143	7857
+
+query I
+SELECT typeof(b) FROM '__TEST_DIR__/bools.parquet' LIMIT 1
+----
+BOOLEAN

--- a/test/sql/copy/parquet/writer/parquet_write_date.test
+++ b/test/sql/copy/parquet/writer/parquet_write_date.test
@@ -4,8 +4,6 @@
 
 require parquet
 
-require vector_size 64
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/copy/parquet/writer/parquet_write_hugeint.test
+++ b/test/sql/copy/parquet/writer/parquet_write_hugeint.test
@@ -4,8 +4,6 @@
 
 require parquet
 
-require vector_size 64
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/copy/parquet/writer/parquet_write_signed.test
+++ b/test/sql/copy/parquet/writer/parquet_write_signed.test
@@ -4,8 +4,6 @@
 
 require parquet
 
-require vector_size 64
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/copy/parquet/writer/parquet_write_timestamp.test
+++ b/test/sql/copy/parquet/writer/parquet_write_timestamp.test
@@ -4,8 +4,6 @@
 
 require parquet
 
-require vector_size 64
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/copy/parquet/writer/parquet_write_unsigned.test
+++ b/test/sql/copy/parquet/writer/parquet_write_unsigned.test
@@ -4,8 +4,6 @@
 
 require parquet
 
-require vector_size 64
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/copy/parquet/writer/parquet_zstd_sequence.test_coverage
+++ b/test/sql/copy/parquet/writer/parquet_zstd_sequence.test_coverage
@@ -4,6 +4,8 @@
 
 require parquet
 
+require 64bit
+
 statement ok
 CREATE TABLE tbl AS SELECT * FROM read_csv_auto('data/csv/sequences.csv.gz', delim=',', header=True);
 

--- a/test/sql/copy/parquet/writer/parquet_zstd_sequence.test_coverage
+++ b/test/sql/copy/parquet/writer/parquet_zstd_sequence.test_coverage
@@ -1,0 +1,19 @@
+# name: test/sql/copy/parquet/writer/parquet_zstd_sequence.test_coverage
+# description: Test writing of large blobs into parquet files
+# group: [writer]
+
+require parquet
+
+statement ok
+CREATE TABLE tbl AS SELECT * FROM read_csv_auto('data/csv/sequences.csv.gz', delim=',', header=True);
+
+query IIIIII nosort querylabel
+select count(*), min(strain), max(strain), min(strlen(sequence)), max(strlen(sequence)), avg(strlen(sequence))
+from tbl;
+
+statement ok
+COPY tbl TO '__TEST_DIR__/duckseq.parquet' (FORMAT 'PARQUET', CODEC 'ZSTD');
+
+query IIIIII nosort querylabel
+select count(*), min(strain), max(strain), min(strlen(sequence)), max(strlen(sequence)), avg(strlen(sequence))
+from '__TEST_DIR__/duckseq.parquet';

--- a/test/sql/copy/parquet/writer/test_parquet_write.test
+++ b/test/sql/copy/parquet/writer/test_parquet_write.test
@@ -4,9 +4,6 @@
 
 require parquet
 
-# single scalar value
-require vector_size 64
-
 statement ok
 COPY (SELECT 42) TO '__TEST_DIR__/scalar.parquet' (FORMAT 'parquet');
 

--- a/test/sql/copy/parquet/writer/test_parquet_write_complex.test
+++ b/test/sql/copy/parquet/writer/test_parquet_write_complex.test
@@ -4,8 +4,7 @@
 
 require parquet
 
-# writer requires vector_size >= 64
-require vector_size 64
+require vector_size 512
 
 # alltypes_dictionary: scan as parquet
 query I nosort alltypes_dictionary

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -387,7 +387,7 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 				return;
 #endif
 			} else if (param == "64bit") {
-				if (sizeof(void*) != 8) {
+				if (sizeof(void *) != 8) {
 					return;
 				}
 			} else if (param == "noforcestorage") {

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -386,6 +386,10 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 #if LDBL_MANT_DIG < 54
 				return;
 #endif
+			} else if (param == "64bit") {
+				if (sizeof(void*) != 8) {
+					return;
+				}
 			} else if (param == "noforcestorage") {
 				if (TestForceStorage()) {
 					return;


### PR DESCRIPTION
Fixes #2815

The Parquet format page headers are encoded as INT32 internally (for some reason), which can be hit when we are writing many large strings, as is the case in #2815. In this case, we need to split up the column in the row group into separate pages. 