### PR TITLE
Fix #2823: Correctly alter cardinality estimation in LIMIT/SAMPLE clauses

### DIFF
--- a/src/include/duckdb/planner/operator/logical_limit.hpp
+++ b/src/include/duckdb/planner/operator/logical_limit.hpp
@@ -15,10 +15,7 @@ namespace duckdb {
 //! LogicalLimit represents a LIMIT clause
 class LogicalLimit : public LogicalOperator {
 public:
-	LogicalLimit(int64_t limit_val, int64_t offset_val, unique_ptr<Expression> limit, unique_ptr<Expression> offset)
-	    : LogicalOperator(LogicalOperatorType::LOGICAL_LIMIT), limit_val(limit_val), offset_val(offset_val),
-	      limit(move(limit)), offset(move(offset)) {
-	}
+	LogicalLimit(int64_t limit_val, int64_t offset_val, unique_ptr<Expression> limit, unique_ptr<Expression> offset);
 
 	//! Limit and offset values in case they are constants, used in optimizations.
 	int64_t limit_val;
@@ -29,13 +26,11 @@ public:
 	unique_ptr<Expression> offset;
 
 public:
-	vector<ColumnBinding> GetColumnBindings() override {
-		return children[0]->GetColumnBindings();
-	}
+	vector<ColumnBinding> GetColumnBindings() override;
+
+	idx_t EstimateCardinality(ClientContext &context) override;
 
 protected:
-	void ResolveTypes() override {
-		types = children[0]->types;
-	}
+	void ResolveTypes() override;
 };
 } // namespace duckdb

--- a/src/include/duckdb/planner/operator/logical_sample.hpp
+++ b/src/include/duckdb/planner/operator/logical_sample.hpp
@@ -16,23 +16,18 @@ namespace duckdb {
 //! LogicalSample represents a SAMPLE clause
 class LogicalSample : public LogicalOperator {
 public:
-	LogicalSample(unique_ptr<SampleOptions> sample_options_p, unique_ptr<LogicalOperator> child)
-	    : LogicalOperator(LogicalOperatorType::LOGICAL_SAMPLE), sample_options(move(sample_options_p)) {
-		children.push_back(move(child));
-	}
+	LogicalSample(unique_ptr<SampleOptions> sample_options_p, unique_ptr<LogicalOperator> child);
 
 	//! The sample options
 	unique_ptr<SampleOptions> sample_options;
 
 public:
-	vector<ColumnBinding> GetColumnBindings() override {
-		return children[0]->GetColumnBindings();
-	}
+	vector<ColumnBinding> GetColumnBindings() override;
+
+	idx_t EstimateCardinality(ClientContext &context) override;
 
 protected:
-	void ResolveTypes() override {
-		types = children[0]->types;
-	}
+	void ResolveTypes() override;
 };
 
 } // namespace duckdb

--- a/src/planner/operator/CMakeLists.txt
+++ b/src/planner/operator/CMakeLists.txt
@@ -8,8 +8,10 @@ add_library_unity(
   logical_cross_product.cpp
   logical_filter.cpp
   logical_get.cpp
+  logical_limit.cpp
   logical_join.cpp
   logical_projection.cpp
+  logical_sample.cpp
   logical_unnest.cpp
   logical_window.cpp
   logical_distinct.cpp)

--- a/src/planner/operator/logical_limit.cpp
+++ b/src/planner/operator/logical_limit.cpp
@@ -2,9 +2,10 @@
 
 namespace duckdb {
 
-LogicalLimit::LogicalLimit(int64_t limit_val, int64_t offset_val, unique_ptr<Expression> limit, unique_ptr<Expression> offset)
-	: LogicalOperator(LogicalOperatorType::LOGICAL_LIMIT), limit_val(limit_val), offset_val(offset_val),
-		limit(move(limit)), offset(move(offset)) {
+LogicalLimit::LogicalLimit(int64_t limit_val, int64_t offset_val, unique_ptr<Expression> limit,
+                           unique_ptr<Expression> offset)
+    : LogicalOperator(LogicalOperatorType::LOGICAL_LIMIT), limit_val(limit_val), offset_val(offset_val),
+      limit(move(limit)), offset(move(offset)) {
 }
 
 vector<ColumnBinding> LogicalLimit::GetColumnBindings() {
@@ -23,5 +24,4 @@ void LogicalLimit::ResolveTypes() {
 	types = children[0]->types;
 }
 
-}
-
+} // namespace duckdb

--- a/src/planner/operator/logical_limit.cpp
+++ b/src/planner/operator/logical_limit.cpp
@@ -1,0 +1,27 @@
+#include "duckdb/planner/operator/logical_limit.hpp"
+
+namespace duckdb {
+
+LogicalLimit::LogicalLimit(int64_t limit_val, int64_t offset_val, unique_ptr<Expression> limit, unique_ptr<Expression> offset)
+	: LogicalOperator(LogicalOperatorType::LOGICAL_LIMIT), limit_val(limit_val), offset_val(offset_val),
+		limit(move(limit)), offset(move(offset)) {
+}
+
+vector<ColumnBinding> LogicalLimit::GetColumnBindings() {
+	return children[0]->GetColumnBindings();
+}
+
+idx_t LogicalLimit::EstimateCardinality(ClientContext &context) {
+	auto child_cardinality = children[0]->EstimateCardinality(context);
+	if (limit_val < child_cardinality) {
+		child_cardinality = limit_val;
+	}
+	return child_cardinality;
+}
+
+void LogicalLimit::ResolveTypes() {
+	types = children[0]->types;
+}
+
+}
+

--- a/src/planner/operator/logical_limit.cpp
+++ b/src/planner/operator/logical_limit.cpp
@@ -14,7 +14,7 @@ vector<ColumnBinding> LogicalLimit::GetColumnBindings() {
 
 idx_t LogicalLimit::EstimateCardinality(ClientContext &context) {
 	auto child_cardinality = children[0]->EstimateCardinality(context);
-	if (limit_val < child_cardinality) {
+	if (limit_val >= 0 && idx_t(limit_val) < child_cardinality) {
 		child_cardinality = limit_val;
 	}
 	return child_cardinality;

--- a/src/planner/operator/logical_sample.cpp
+++ b/src/planner/operator/logical_sample.cpp
@@ -1,0 +1,31 @@
+#include "duckdb/planner/operator/logical_sample.hpp"
+
+namespace duckdb {
+
+LogicalSample::LogicalSample(unique_ptr<SampleOptions> sample_options_p, unique_ptr<LogicalOperator> child)
+	: LogicalOperator(LogicalOperatorType::LOGICAL_SAMPLE), sample_options(move(sample_options_p)) {
+	children.push_back(move(child));
+}
+
+vector<ColumnBinding> LogicalSample::GetColumnBindings() {
+	return children[0]->GetColumnBindings();
+}
+
+idx_t LogicalSample::EstimateCardinality(ClientContext &context) {
+	auto child_cardinality = children[0]->EstimateCardinality(context);
+	if (sample_options->is_percentage) {
+		return idx_t(child_cardinality * sample_options->sample_size.GetValue<double>());
+	} else {
+		auto sample_size = sample_options->sample_size.GetValue<uint64_t>();
+		if (sample_size < child_cardinality) {
+			return sample_size;
+		}
+	}
+	return child_cardinality;
+}
+
+void LogicalSample::ResolveTypes() {
+	types = children[0]->types;
+}
+
+}

--- a/src/planner/operator/logical_sample.cpp
+++ b/src/planner/operator/logical_sample.cpp
@@ -3,7 +3,7 @@
 namespace duckdb {
 
 LogicalSample::LogicalSample(unique_ptr<SampleOptions> sample_options_p, unique_ptr<LogicalOperator> child)
-	: LogicalOperator(LogicalOperatorType::LOGICAL_SAMPLE), sample_options(move(sample_options_p)) {
+    : LogicalOperator(LogicalOperatorType::LOGICAL_SAMPLE), sample_options(move(sample_options_p)) {
 	children.push_back(move(child));
 }
 
@@ -28,4 +28,4 @@ void LogicalSample::ResolveTypes() {
 	types = children[0]->types;
 }
 
-}
+} // namespace duckdb


### PR DESCRIPTION
This should fix #2823 by correctly selecting the build side of the hash table to be the (much) smaller side.