### PR TITLE
Fix #2828: setup.py BUILD_HTTPFS does not work

### DIFF
--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -87,6 +87,10 @@ if platform.system() == 'Darwin':
 if platform.system() == 'Windows':
     toolchain_args.extend(['-DDUCKDB_BUILD_LIBRARY','-DWIN32'])
 
+if 'BUILD_HTTPFS' in os.environ:
+    libraries += ['crypto', 'ssl']
+    extensions += ['httpfs']
+
 for ext in extensions:
     toolchain_args.extend(['-DBUILD_{}_EXTENSION'.format(ext.upper())])
 
@@ -102,12 +106,6 @@ class get_numpy_include(object):
     def __str__(self):
         import numpy
         return numpy.get_include()
-
-
-if 'BUILD_HTTPFS' in os.environ:
-    libraries += ['crypto', 'ssl']
-    extensions += ['httpfs']
-
 
 
 extra_files = []


### PR DESCRIPTION
Move BUILD_HTTPFS check before extensions are added to toolchain.