### PR TITLE
Issue #2834: ICU BindAdapterData::Equals

### DIFF
--- a/extension/icu/icu-datefunc.cpp
+++ b/extension/icu/icu-datefunc.cpp
@@ -22,6 +22,11 @@ ICUDateFunc::BindData::BindData(ClientContext &context) {
 	}
 }
 
+bool ICUDateFunc::BindData::Equals(FunctionData &other_p) {
+	auto &other = (BindData &)other_p;
+	return FunctionData::Equals(other_p) && *calendar == *other.calendar;
+}
+
 unique_ptr<FunctionData> ICUDateFunc::BindData::Copy() {
 	return make_unique<BindData>(*this);
 }

--- a/extension/icu/icu-datepart.cpp
+++ b/extension/icu/icu-datepart.cpp
@@ -184,6 +184,11 @@ struct ICUDatePart : public ICUDateFunc {
 
 		adapter_t adapter;
 
+		bool Equals(FunctionData &other_p) override {
+			const auto &other = (BindAdapterData &)other_p;
+			return BindData::Equals(other_p) && adapter == other.adapter;
+		}
+
 		unique_ptr<FunctionData> Copy() override {
 			return make_unique<BindAdapterData>(*this);
 		}

--- a/extension/icu/include/icu-datefunc.hpp
+++ b/extension/icu/include/icu-datefunc.hpp
@@ -25,6 +25,7 @@ struct ICUDateFunc {
 
 		CalendarPtr calendar;
 
+		bool Equals(FunctionData &other_p) override;
 		unique_ptr<FunctionData> Copy() override;
 	};
 

--- a/test/sql/function/timestamp/test_icu_datepart.test
+++ b/test/sql/function/timestamp/test_icu_datepart.test
@@ -249,6 +249,17 @@ SELECT DATE_PART('offset', '2021-07-31 00:00:00-07'::TIMESTAMPTZ) / (60::BIGINT 
 ----
 -7
 
+# Multiple extractions
+query IIIII
+SELECT MAX(EXTRACT(YEAR FROM ts))
+	, MAX(EXTRACT(MONTH FROM ts))
+	, MAX(EXTRACT(DAY FROM ts))
+	, MAX(EXTRACT(DECADE FROM ts))
+	, MAX(EXTRACT(CENTURY FROM ts))
+FROM timestamps
+----
+2021	12	31	202	21
+
 # Aliases
 query III
 SELECT datepart(part, ts), datepart(part, ts::TIMESTAMP), part FROM timestamps;


### PR DESCRIPTION
Add Equals method to prevent aliasing of ICU part functions.