### PR TITLE
Fix potential use after move detected by linter, and add DISABLE_DUCKDB_REMOTE_INSTALL define

### DIFF
--- a/src/function/macro_function.cpp
+++ b/src/function/macro_function.cpp
@@ -25,7 +25,8 @@ string MacroFunction::ValidateArguments(MacroCatalogEntry &macro_func, FunctionE
 			} else if (defaults.find(arg->alias) != defaults.end()) {
 				return StringUtil::Format("Duplicate default parameters %s!", arg->alias);
 			}
-			defaults[arg->alias] = move(arg);
+			auto alias = arg->alias;
+			defaults[alias] = move(arg);
 		} else if (!defaults.empty()) {
 			return "Positional parameters cannot come after parameters with a default value!";
 		} else {

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -1,7 +1,9 @@
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/common/gzip_file_system.hpp"
 
+#ifndef DISABLE_DUCKDB_REMOTE_INSTALL
 #include "httplib.hpp"
+#endif
 #include "duckdb/common/windows_undefs.hpp"
 
 #include <fstream>
@@ -59,6 +61,9 @@ void ExtensionHelper::InstallExtension(DatabaseInstance &db, const string &exten
 		throw IOException("Failed to read extension from \"%s\": no such file", extension);
 	}
 
+#ifdef DISABLE_DUCKDB_REMOTE_INSTALL
+	throw BinderException("Remote extension installation is disabled through configuration");
+#else
 	string url_template = "http://extensions.duckdb.org/${REVISION}/${PLATFORM}/${NAME}.duckdb_extension.gz";
 
 	if (is_http_url) {
@@ -97,6 +102,7 @@ void ExtensionHelper::InstallExtension(DatabaseInstance &db, const string &exten
 	if (out.bad()) {
 		throw IOException("Failed to write extension to %s", local_extension_path);
 	}
+#endif
 }
 
 } // namespace duckdb

--- a/src/parser/transform/statement/transform_create_function.cpp
+++ b/src/parser/transform/statement/transform_create_function.cpp
@@ -36,7 +36,8 @@ unique_ptr<CreateStatement> Transformer::TransformCreateFunction(duckdb_libpgque
 				if (macro_func->default_parameters.find(param->alias) != macro_func->default_parameters.end()) {
 					throw ParserException("Duplicate default parameter: '%s'", param->alias);
 				}
-				macro_func->default_parameters[param->alias] = move(param);
+				auto alias = param->alias;
+				macro_func->default_parameters[alias] = move(param);
 			} else if (param->GetExpressionClass() == ExpressionClass::COLUMN_REF) {
 				// positional parameters
 				if (!macro_func->default_parameters.empty()) {


### PR DESCRIPTION
This adds support for the `DISABLE_DUCKDB_REMOTE_INSTALL` define, which disables loading of `httplib`,  which should remove any usage of `std::regex`.

CC @mbasmanova  @majetideepak