### PR TITLE
Turn FileSync into a nop in the PipeFileSystem, and add clear error message when ParquetReader is used to read from a FIFO stream (e.g. /dev/stdin)

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -74,6 +74,7 @@ jobs:
         (cd examples/embedded-c++; make)
         (cd examples/jdbc; make; make maven)
         build/release/benchmark/benchmark_runner benchmark/tpch/sf1/q01.benchmark
+        build/release/duckdb -c "COPY (SELECT 42) TO '/dev/stdout' (FORMAT PARQUET)" | cat
 
     - name: Deploy
       run: |

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -410,6 +410,11 @@ ParquetReader::ParquetReader(ClientContext &context_p, string file_name_p, const
 	file_name = move(file_name_p);
 	file_handle = fs.OpenFile(file_name, FileFlags::FILE_FLAGS_READ, FileSystem::DEFAULT_LOCK,
 	                          FileSystem::DEFAULT_COMPRESSION, file_opener);
+	if (!file_handle->CanSeek()) {
+		throw NotImplementedException(
+		    "Reading parquet files from a FIFO stream is not supported and cannot be efficiently supported since "
+		    "metadata is located at the end of the file. Write the stream to disk first and read from there instead.");
+	}
 	// If object cached is disabled
 	// or if this file has cached metadata
 	// or if the cached version already expired

--- a/src/common/pipe_file_system.cpp
+++ b/src/common/pipe_file_system.cpp
@@ -41,6 +41,9 @@ int64_t PipeFileSystem::GetFileSize(FileHandle &handle) {
 	return 0;
 }
 
+void PipeFileSystem::FileSync(FileHandle &handle) {
+}
+
 unique_ptr<FileHandle> PipeFileSystem::OpenPipe(unique_ptr<FileHandle> handle) {
 	auto path = handle->path;
 	return make_unique<PipeFile>(move(handle), path);

--- a/src/include/duckdb/common/pipe_file_system.hpp
+++ b/src/include/duckdb/common/pipe_file_system.hpp
@@ -27,6 +27,7 @@ public:
 	bool CanSeek() override {
 		return false;
 	}
+	void FileSync(FileHandle &handle) override;
 
 	std::string GetName() const override {
 		return "PipeFileSystem";


### PR DESCRIPTION
Fixes #2826