### PR TITLE
Avoid reading past the end of the string when parsing a time as part of an interval

### DIFF
--- a/src/common/types/interval.cpp
+++ b/src/common/types/interval.cpp
@@ -110,7 +110,7 @@ interval_parse_time : {
 	// parse the remainder of the time as a Time type
 	dtime_t time;
 	idx_t pos;
-	if (!Time::TryConvertTime(str + start_pos, len, pos, time)) {
+	if (!Time::TryConvertTime(str + start_pos, len - start_pos, pos, time)) {
 		return false;
 	}
 	result.micros += time.micros;


### PR DESCRIPTION
@hawkfish this fixes the sporadic failure of the test_all_types with Parquet.