### PR TITLE
When using Replace, keep the alias of the original column

### DIFF
--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -260,8 +260,10 @@ bool BindContext::CheckExclusionList(StarExpression &expr, Binding *binding, con
 	}
 	auto entry = expr.replace_list.find(column_name);
 	if (entry != expr.replace_list.end()) {
+		auto new_entry = entry->second->Copy();
+		new_entry->alias = entry->first;
 		excluded_columns.insert(entry->first);
-		new_select_list.push_back(entry->second->Copy());
+		new_select_list.push_back(move(new_entry));
 		return true;
 	}
 	return false;


### PR DESCRIPTION
e.g. if we have a query like this

```sql
SELECT * REPLACE (1+1 AS i) FROM range(10) tbl(i);
```

We want the result to be this:

```sql
┌───┐
│ i │
├───┤
│ 2 │
│ 2 │
│ 2 │
│ 2 │
└───┘
```

i.e. the replaced expression has the same name as the original expression.