### PR TITLE
right case for winsock2.h

### DIFF
--- a/third_party/thrift/thrift/protocol/TProtocol.h
+++ b/third_party/thrift/thrift/protocol/TProtocol.h
@@ -22,7 +22,7 @@
 
 #ifdef _WIN32
 // Need to come before any Windows.h includes
-#include <Winsock2.h>
+#include <winsock2.h>
 #endif
 
 #include "thrift/transport/TTransport.h"


### PR DESCRIPTION
You are able to compile this file also in Linux when the case is the correct one.