### PR TITLE
ODBC: conformance core level of SQLAllocHandle, SQLFreeStmt, SQLGetDiagRec, SQLSetStmtAttr, and descriptors

### DIFF
--- a/tools/odbc/CMakeLists.txt
+++ b/tools/odbc/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(
   empty_stubs.cpp
   descriptor.cpp
   parameter_descriptor.cpp
+  row_descriptor.cpp
   duckdb_odbc.def)
 
 set_target_properties(duckdb_odbc PROPERTIES DEFINE_SYMBOL "DUCKDB_ODBC_API")

--- a/tools/odbc/connection.cpp
+++ b/tools/odbc/connection.cpp
@@ -1,4 +1,5 @@
 #include "duckdb_odbc.hpp"
+#include "driver.hpp"
 
 SQLRETURN SQL_API SQLGetConnectAttr(SQLHDBC connection_handle, SQLINTEGER attribute, SQLPOINTER value_ptr,
                                     SQLINTEGER buffer_length, SQLINTEGER *string_length_ptr) {
@@ -63,15 +64,15 @@ SQLRETURN SQL_API SQLGetInfo(SQLHDBC connection_handle, SQLUSMALLINT info_type, 
 		SQLHDBC stmt;
 
 		if (!SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_STMT, connection_handle, &stmt))) {
-			SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+			duckdb::FreeHandle(SQL_HANDLE_STMT, stmt);
 			return SQL_ERROR;
 		}
 		if (!SQL_SUCCEEDED(SQLExecDirect(stmt, (SQLCHAR *)"SELECT library_version FROM pragma_version()", SQL_NTS))) {
-			SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+			duckdb::FreeHandle(SQL_HANDLE_STMT, stmt);
 			return SQL_ERROR;
 		}
 		if (!SQL_SUCCEEDED(SQLFetch(stmt))) {
-			SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+			duckdb::FreeHandle(SQL_HANDLE_STMT, stmt);
 			return SQL_ERROR;
 		}
 
@@ -84,11 +85,11 @@ SQLRETURN SQL_API SQLGetInfo(SQLHDBC connection_handle, SQLUSMALLINT info_type, 
 			ret = SQLGetData(stmt, 1, SQL_C_CHAR, info_value_ptr, buffer_length, nullptr);
 		}
 		if (!SQL_SUCCEEDED(ret)) {
-			SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+			duckdb::FreeHandle(SQL_HANDLE_STMT, stmt);
 			return SQL_ERROR;
 		}
 
-		SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+		duckdb::FreeHandle(SQL_HANDLE_STMT, stmt);
 		return SQL_SUCCESS;
 	}
 	case SQL_NON_NULLABLE_COLUMNS:

--- a/tools/odbc/descriptor.cpp
+++ b/tools/odbc/descriptor.cpp
@@ -29,7 +29,8 @@ SQLRETURN OdbcHandleDesc::SetDescField(SQLSMALLINT rec_number, SQLSMALLINT field
 	case SQL_DESC_ARRAY_SIZE: {
 		auto size = *((SQLULEN *)value_ptr);
 		if (size <= 0) {
-			stmt->error_messages.emplace_back("Invalid attribute/option identifier.");
+			// TODO throw exception
+			error_messages.emplace_back("Invalid attribute/option identifier.");
 			return SQL_ERROR;
 		}
 		header.sql_desc_array_size = size;
@@ -38,7 +39,7 @@ SQLRETURN OdbcHandleDesc::SetDescField(SQLSMALLINT rec_number, SQLSMALLINT field
 	default:
 		break;
 	}
-	return SQL_SUCCESS;
+	return SQL_ERROR;
 }
 
 void OdbcHandleDesc::Clear() {

--- a/tools/odbc/driver.cpp
+++ b/tools/odbc/driver.cpp
@@ -210,7 +210,8 @@ SQLRETURN SQL_API SQLGetDiagRec(SQLSMALLINT handle_type, SQLHANDLE handle, SQLSM
 	std::function<SQLRETURN(duckdb::OdbcHandle *, duckdb::OdbcHandleType)> func_write_diag =
 	    [&](duckdb::OdbcHandle *hdl, duckdb::OdbcHandleType target_type) {
 		    if (hdl->type != target_type) {
-			    std::string msg_str("Handle type is not an OdbcHandleDesc.");
+			    std::string msg_str("Handle type " + duckdb::OdbcHandleTypeToString(hdl->type) + " mismatch with " +
+			                        duckdb::OdbcHandleTypeToString(target_type));
 			    duckdb::OdbcUtils::WriteString(msg_str, message_text, buffer_length, text_length_ptr);
 			    return SQL_SUCCESS;
 		    }

--- a/tools/odbc/driver.cpp
+++ b/tools/odbc/driver.cpp
@@ -1,37 +1,14 @@
 #include "duckdb_odbc.hpp"
+#include "driver.hpp"
 #include "odbc_fetch.hpp"
+
 #include <odbcinst.h>
 #include <codecvt>
 #include <locale>
+
 using std::string;
 
-SQLRETURN SQL_API SQLAllocHandle(SQLSMALLINT handle_type, SQLHANDLE input_handle, SQLHANDLE *output_handle_ptr) {
-	switch (handle_type) {
-	case SQL_HANDLE_DBC: {
-		D_ASSERT(input_handle);
-		auto *env = (duckdb::OdbcHandleEnv *)input_handle;
-		D_ASSERT(env->type == duckdb::OdbcHandleType::ENV);
-		*output_handle_ptr = new duckdb::OdbcHandleDbc(env);
-		return SQL_SUCCESS;
-	}
-	case SQL_HANDLE_DESC:
-		return SQL_ERROR;
-	case SQL_HANDLE_ENV:
-		*output_handle_ptr = new duckdb::OdbcHandleEnv();
-		return SQL_SUCCESS;
-	case SQL_HANDLE_STMT: {
-		D_ASSERT(input_handle);
-		auto *dbc = (duckdb::OdbcHandleDbc *)input_handle;
-		D_ASSERT(dbc->type == duckdb::OdbcHandleType::DBC);
-		*output_handle_ptr = new duckdb::OdbcHandleStmt(dbc);
-		return SQL_SUCCESS;
-	}
-	default:
-		return SQL_ERROR;
-	}
-}
-
-SQLRETURN SQL_API SQLFreeHandle(SQLSMALLINT handle_type, SQLHANDLE handle) {
+SQLRETURN duckdb::FreeHandle(SQLSMALLINT handle_type, SQLHANDLE handle) {
 	if (!handle) {
 		return SQL_ERROR;
 	}
@@ -44,6 +21,7 @@ SQLRETURN SQL_API SQLFreeHandle(SQLSMALLINT handle_type, SQLHANDLE handle) {
 	}
 	case SQL_HANDLE_DESC: {
 		auto *hdl = (duckdb::OdbcHandleDesc *)handle;
+		hdl->dbc->ResetStmtDescriptors(hdl);
 		delete hdl;
 		return SQL_ERROR;
 	}
@@ -56,6 +34,41 @@ SQLRETURN SQL_API SQLFreeHandle(SQLSMALLINT handle_type, SQLHANDLE handle) {
 		auto *hdl = (duckdb::OdbcHandleStmt *)handle;
 		hdl->dbc->EraseStmtRef(hdl);
 		delete hdl;
+		return SQL_SUCCESS;
+	}
+	default:
+		return SQL_ERROR;
+	}
+}
+
+SQLRETURN SQL_API SQLFreeHandle(SQLSMALLINT handle_type, SQLHANDLE handle) {
+	return duckdb::FreeHandle(handle_type, handle);
+}
+
+SQLRETURN SQL_API SQLAllocHandle(SQLSMALLINT handle_type, SQLHANDLE input_handle, SQLHANDLE *output_handle_ptr) {
+	switch (handle_type) {
+	case SQL_HANDLE_DBC: {
+		D_ASSERT(input_handle);
+		auto *env = (duckdb::OdbcHandleEnv *)input_handle;
+		D_ASSERT(env->type == duckdb::OdbcHandleType::ENV);
+		*output_handle_ptr = new duckdb::OdbcHandleDbc(env);
+		return SQL_SUCCESS;
+	}
+	case SQL_HANDLE_ENV:
+		*output_handle_ptr = new duckdb::OdbcHandleEnv();
+		return SQL_SUCCESS;
+	case SQL_HANDLE_STMT: {
+		D_ASSERT(input_handle);
+		auto *dbc = (duckdb::OdbcHandleDbc *)input_handle;
+		D_ASSERT(dbc->type == duckdb::OdbcHandleType::DBC);
+		*output_handle_ptr = new duckdb::OdbcHandleStmt(dbc);
+		return SQL_SUCCESS;
+	}
+	case SQL_HANDLE_DESC: {
+		D_ASSERT(input_handle);
+		auto *dbc = (duckdb::OdbcHandleDbc *)input_handle;
+		D_ASSERT(dbc->type == duckdb::OdbcHandleType::DBC);
+		*output_handle_ptr = new duckdb::OdbcHandleDesc(dbc);
 		return SQL_SUCCESS;
 	}
 	default:
@@ -193,35 +206,37 @@ SQLRETURN SQL_API SQLGetDiagRec(SQLSMALLINT handle_type, SQLHANDLE handle, SQLSM
 
 	auto *hdl = (duckdb::OdbcHandle *)handle;
 
+	// lambda function that writes the diagnostic messages
+	std::function<SQLRETURN(duckdb::OdbcHandle *, duckdb::OdbcHandleType)> func_write_diag =
+	    [&](duckdb::OdbcHandle *hdl, duckdb::OdbcHandleType target_type) {
+		    if (hdl->type != target_type) {
+			    std::string msg_str("Handle type is not an OdbcHandleDesc.");
+			    duckdb::OdbcUtils::WriteString(msg_str, message_text, buffer_length, text_length_ptr);
+			    return SQL_SUCCESS;
+		    }
+
+		    // Errors should be placed at the error_messages
+		    if ((size_t)rec_number <= hdl->error_messages.size()) {
+			    duckdb::OdbcUtils::WriteString(hdl->error_messages[rec_number - 1], message_text, buffer_length,
+			                                   text_length_ptr);
+			    return SQL_SUCCESS;
+		    } else {
+			    return SQL_NO_DATA;
+		    }
+	    };
+
 	switch (handle_type) {
-	case SQL_HANDLE_DBC: {
-		// TODO return connection errors here
-		return SQL_NO_DATA;
-	}
-	case SQL_HANDLE_DESC: {
-		// throw std::runtime_error("SQL_HANDLE_DESC");
-		return SQL_NO_DATA;
-	}
 	case SQL_HANDLE_ENV: {
-		// dont think we can have errors here
-		return SQL_NO_DATA;
+		return func_write_diag(hdl, duckdb::OdbcHandleType::ENV);
+	}
+	case SQL_HANDLE_DBC: {
+		return func_write_diag(hdl, duckdb::OdbcHandleType::DBC);
 	}
 	case SQL_HANDLE_STMT: {
-		if (hdl->type != duckdb::OdbcHandleType::STMT) {
-			std::string msg_str("Handle type is not a OdbcHandleStmt.");
-			duckdb::OdbcUtils::WriteString(msg_str, message_text, buffer_length, text_length_ptr);
-			return SQL_SUCCESS;
-		}
-
-		auto *stmt = (duckdb::OdbcHandleStmt *)hdl;
-		// Errors should be placed at the stmt->error_messages
-		if ((size_t)rec_number <= stmt->error_messages.size()) {
-			duckdb::OdbcUtils::WriteString(stmt->error_messages[rec_number - 1], message_text, buffer_length,
-			                               text_length_ptr);
-			return SQL_SUCCESS;
-		} else {
-			return SQL_NO_DATA;
-		}
+		return func_write_diag(hdl, duckdb::OdbcHandleType::STMT);
+	}
+	case SQL_HANDLE_DESC: {
+		return func_write_diag(hdl, duckdb::OdbcHandleType::DESC);
 	}
 	default:
 		return SQL_INVALID_HANDLE;

--- a/tools/odbc/duckdb_odbc.cpp
+++ b/tools/odbc/duckdb_odbc.cpp
@@ -10,7 +10,7 @@ using duckdb::OdbcHandleDesc;
 using duckdb::OdbcHandleStmt;
 using duckdb::OdbcHandleType;
 
-std::string OdbcHandleTypeToString(OdbcHandleType type) {
+std::string duckdb::OdbcHandleTypeToString(OdbcHandleType type) {
 	switch (type) {
 	case OdbcHandleType::ENV:
 		return "ENV";

--- a/tools/odbc/duckdb_odbc.cpp
+++ b/tools/odbc/duckdb_odbc.cpp
@@ -8,6 +8,21 @@
 using duckdb::OdbcHandleDbc;
 using duckdb::OdbcHandleDesc;
 using duckdb::OdbcHandleStmt;
+using duckdb::OdbcHandleType;
+
+std::string OdbcHandleTypeToString(OdbcHandleType type) {
+	switch (type) {
+	case OdbcHandleType::ENV:
+		return "ENV";
+	case OdbcHandleType::DBC:
+		return "DBC";
+	case OdbcHandleType::STMT:
+		return "STMT";
+	case OdbcHandleType::DESC:
+		return "DESC";
+	}
+	return "INVALID";
+}
 
 //! OdbcHandleDbc functions ***************************************************
 OdbcHandleDbc::~OdbcHandleDbc() {

--- a/tools/odbc/include/descriptor.hpp
+++ b/tools/odbc/include/descriptor.hpp
@@ -11,7 +11,6 @@
 #include <sqltypes.h>
 
 namespace duckdb {
-enum DescType { APD, IPD, ARD, IRD };
 
 struct DescRecord {
 public:
@@ -64,7 +63,7 @@ public:
 	SQLSMALLINT sql_desc_alloc_type;
 	SQLULEN sql_desc_array_size;
 	SQLUSMALLINT *sql_desc_array_status_ptr;
-	SQLLEN *sql_desc_bind_offset_ptr;
+	SQLLEN *sql_desc_bind_offset_ptr = nullptr;
 	SQLINTEGER sql_desc_bind_type;
 	SQLSMALLINT sql_desc_count;
 	SQLULEN *sql_desc_rows_processed_ptr;

--- a/tools/odbc/include/driver.hpp
+++ b/tools/odbc/include/driver.hpp
@@ -7,6 +7,6 @@ namespace duckdb {
 
 SQLRETURN FreeHandle(SQLSMALLINT handle_type, SQLHANDLE handle);
 
-} // namespace
+} // namespace duckdb
 
 #endif

--- a/tools/odbc/include/driver.hpp
+++ b/tools/odbc/include/driver.hpp
@@ -1,0 +1,12 @@
+#ifndef DRIVER_HPP
+#define DRIVER_HPP
+
+#include "duckdb_odbc.hpp"
+
+namespace duckdb {
+
+SQLRETURN FreeHandle(SQLSMALLINT handle_type, SQLHANDLE handle);
+
+} // namespace
+
+#endif

--- a/tools/odbc/include/duckdb_odbc.hpp
+++ b/tools/odbc/include/duckdb_odbc.hpp
@@ -22,6 +22,8 @@ class ParameterDescriptor;
 class RowDescriptor;
 
 enum OdbcHandleType { ENV, DBC, STMT, DESC };
+std::string OdbcHandleTypeToString(OdbcHandleType type);
+
 struct OdbcHandle {
 	explicit OdbcHandle(OdbcHandleType type_p) : type(type_p) {};
 	OdbcHandleType type;

--- a/tools/odbc/include/odbc_fetch.hpp
+++ b/tools/odbc/include/odbc_fetch.hpp
@@ -78,6 +78,8 @@ public:
 	void SetLastFetchedLength(size_t new_len);
 	size_t GetLastFetchedLength();
 
+	bool IsInExecutionState();
+
 private:
 	SQLRETURN ColumnWise(SQLHSTMT statement_handle, OdbcHandleStmt *stmt);
 

--- a/tools/odbc/include/parameter_descriptor.hpp
+++ b/tools/odbc/include/parameter_descriptor.hpp
@@ -12,8 +12,10 @@ public:
 	OdbcHandleDesc *GetIPD();
 	OdbcHandleDesc *GetAPD();
 	void Clear();
+	void SetCurrentAPD(OdbcHandleDesc *new_apd);
 	void Reset();
 	void ResetParams(SQLSMALLINT count);
+	void ResetCurrentAPD();
 
 	SQLRETURN GetParamValues(std::vector<Value> &values);
 	void SetParamProcessedPtr(SQLPOINTER value_ptr);
@@ -22,6 +24,7 @@ public:
 	bool HasParamSetToProcess();
 
 public:
+	// implicitly allocated descriptors
 	unique_ptr<OdbcHandleDesc> apd;
 	unique_ptr<OdbcHandleDesc> ipd;
 
@@ -38,8 +41,20 @@ private:
 	                              SQLLEN str_len_or_ind_ptr);
 	SQLRETURN ValidateNumeric(int precision, int scale);
 
+	SQLPOINTER GetSQLDescDataPtr(DescRecord &apd_record);
+	void SetSQLDescDataPtr(DescRecord &apd_record, SQLPOINTER data_ptr);
+
+	SQLLEN *GetSQLDescIndicatorPtr(DescRecord &apd_record, idx_t set_idx = 0);
+	void SetSQLDescIndicatorPtr(DescRecord &apd_record, SQLLEN *ind_ptr);
+	void SetSQLDescIndicatorPtr(DescRecord &apd_record, SQLLEN value);
+
+	SQLLEN *GetSQLDescOctetLengthPtr(DescRecord &apd_record, idx_t set_idx = 0);
+	void SetSQLDescOctetLengthPtr(DescRecord &apd_record, SQLLEN *ind_ptr);
+
 private:
 	OdbcHandleStmt *stmt;
+	// pointer to the current APD descriptor
+	OdbcHandleDesc *cur_apd;
 
 	//! a pool of allocated parameters during SQLPutData for character data
 	vector<unique_ptr<char[]>> pool_allocated_ptr;

--- a/tools/odbc/include/row_descriptor.hpp
+++ b/tools/odbc/include/row_descriptor.hpp
@@ -11,7 +11,7 @@ public:
 	}
 	OdbcHandleDesc *GetIRD();
 	OdbcHandleDesc *GetARD();
-    void Clear();
+	void Clear();
 	void SetCurrentARD(OdbcHandleDesc *new_ard);
 	void Reset();
 	void ResetCurrentARD();

--- a/tools/odbc/include/row_descriptor.hpp
+++ b/tools/odbc/include/row_descriptor.hpp
@@ -1,0 +1,31 @@
+#ifndef ROW_DESCRIPTOR_HPP
+#define ROW_DESCRIPTOR_HPP
+
+#include "duckdb_odbc.hpp"
+
+namespace duckdb {
+class RowDescriptor {
+public:
+	RowDescriptor(OdbcHandleStmt *stmt_ptr);
+	~RowDescriptor() {
+	}
+	OdbcHandleDesc *GetIRD();
+	OdbcHandleDesc *GetARD();
+    void Clear();
+	void SetCurrentARD(OdbcHandleDesc *new_ard);
+	void Reset();
+	void ResetCurrentARD();
+
+public:
+	// implicitly allocated descriptors
+	unique_ptr<OdbcHandleDesc> ard;
+	unique_ptr<OdbcHandleDesc> ird;
+
+private:
+	OdbcHandleStmt *stmt;
+	// pointer to the current ARD descriptor
+	OdbcHandleDesc *cur_ard;
+};
+} // namespace duckdb
+
+#endif

--- a/tools/odbc/odbc_fetch.cpp
+++ b/tools/odbc/odbc_fetch.cpp
@@ -431,3 +431,7 @@ void OdbcFetch::SetLastFetchedLength(size_t new_len) {
 size_t OdbcFetch::GetLastFetchedLength() {
 	return last_fetched_variable_val.length;
 }
+
+bool OdbcFetch::IsInExecutionState() {
+	return !chunks.empty() && current_chunk != nullptr;
+}

--- a/tools/odbc/parameter_descriptor.cpp
+++ b/tools/odbc/parameter_descriptor.cpp
@@ -9,8 +9,10 @@ using duckdb::Value;
 ParameterDescriptor::ParameterDescriptor(OdbcHandleStmt *stmt_ptr)
     : stmt(stmt_ptr), paramset_idx(0), cur_paramset_idx(0), cur_param_idx(0) {
 
-	apd = make_unique<OdbcHandleDesc>(DescType::APD, stmt);
-	ipd = make_unique<OdbcHandleDesc>(DescType::IPD, stmt);
+	apd = make_unique<OdbcHandleDesc>(stmt->dbc);
+	ipd = make_unique<OdbcHandleDesc>(stmt->dbc);
+
+	cur_apd = apd.get();
 }
 
 OdbcHandleDesc *ParameterDescriptor::GetIPD() {
@@ -18,19 +20,23 @@ OdbcHandleDesc *ParameterDescriptor::GetIPD() {
 }
 
 OdbcHandleDesc *ParameterDescriptor::GetAPD() {
-	return apd.get();
+	return cur_apd;
 }
 
 void ParameterDescriptor::Clear() {
 	ipd->records.clear();
-	apd->records.clear();
+	cur_apd->records.clear();
 	Reset();
+}
+
+void ParameterDescriptor::SetCurrentAPD(OdbcHandleDesc *new_apd) {
+	cur_apd = new_apd;
 }
 
 void ParameterDescriptor::Reset() {
 	pool_allocated_ptr.clear();
 	ipd->header.sql_desc_count = 0;
-	apd->header.sql_desc_count = 0;
+	cur_apd->header.sql_desc_count = 0;
 	paramset_idx = 0;
 	cur_paramset_idx = 0;
 	cur_param_idx = 0;
@@ -42,8 +48,12 @@ void ParameterDescriptor::ResetParams(SQLSMALLINT count) {
 	ipd->records.resize(count);
 	ipd->header.sql_desc_count = count;
 
-	apd->records.resize(count);
-	apd->header.sql_desc_count = count;
+	cur_apd->records.resize(count);
+	cur_apd->header.sql_desc_count = count;
+}
+
+void ParameterDescriptor::ResetCurrentAPD() {
+	cur_apd = apd.get();
 }
 
 SQLRETURN ParameterDescriptor::GetParamValues(std::vector<Value> &values) {
@@ -51,7 +61,7 @@ SQLRETURN ParameterDescriptor::GetParamValues(std::vector<Value> &values) {
 	if (ipd->records.empty()) {
 		return SQL_SUCCESS;
 	}
-	D_ASSERT((SQLULEN)paramset_idx < apd->header.sql_desc_array_size);
+	D_ASSERT((SQLULEN)paramset_idx < cur_apd->header.sql_desc_array_size);
 	// Fill values
 	for (idx_t rec_idx = 0; rec_idx < ipd->records.size(); ++rec_idx) {
 		auto ret = SetValue(rec_idx);
@@ -82,27 +92,28 @@ void ParameterDescriptor::SetParamProcessedPtr(SQLPOINTER value_ptr) {
 }
 
 SQLRETURN ParameterDescriptor::GetNextParam(SQLPOINTER *param) {
-	if ((SQLSMALLINT)cur_param_idx >= apd->header.sql_desc_count) {
+	if ((SQLSMALLINT)cur_param_idx >= cur_apd->header.sql_desc_count) {
 		return SQL_NO_DATA;
 	}
 
-	auto param_desc = apd->records[cur_param_idx];
-	*param = param_desc.sql_desc_data_ptr;
+	auto apd_record = &cur_apd->records[cur_param_idx];
+	*param = GetSQLDescDataPtr(*apd_record);
 	if (ipd->header.sql_desc_rows_processed_ptr) {
 		*ipd->header.sql_desc_rows_processed_ptr += 1;
 	}
-	if (param_desc.sql_desc_indicator_ptr[cur_paramset_idx] == SQL_DATA_AT_EXEC) {
+	auto sql_desc_ind_ptr = GetSQLDescIndicatorPtr(*apd_record, cur_paramset_idx);
+	if (*sql_desc_ind_ptr == SQL_DATA_AT_EXEC) {
 		return SQL_NEED_DATA;
 	}
 	return SQL_SUCCESS;
 }
 
 SQLRETURN ParameterDescriptor::PutData(SQLPOINTER data_ptr, SQLLEN str_len_or_ind_ptr) {
-	if ((SQLSMALLINT)cur_param_idx >= apd->header.sql_desc_count) {
+	if ((SQLSMALLINT)cur_param_idx >= cur_apd->header.sql_desc_count) {
 		return SQL_ERROR;
 	}
 
-	auto apd_record = &apd->records[cur_param_idx];
+	auto apd_record = &cur_apd->records[cur_param_idx];
 	if (apd_record->sql_desc_type == SQL_C_CHAR || apd_record->sql_desc_type == SQL_C_BINARY) {
 		auto ipd_record = &ipd->records[cur_param_idx];
 		return PutCharData(*apd_record, *ipd_record, data_ptr, str_len_or_ind_ptr);
@@ -111,21 +122,21 @@ SQLRETURN ParameterDescriptor::PutData(SQLPOINTER data_ptr, SQLLEN str_len_or_in
 	// filling the current param, go to the next one
 	++cur_param_idx;
 	if (str_len_or_ind_ptr == SQL_NULL_DATA) {
-		*apd_record->sql_desc_indicator_ptr = SQL_NULL_DATA;
+		SetSQLDescIndicatorPtr(*apd_record, SQL_NULL_DATA);
 		return SQL_SUCCESS;
 	}
 
-	apd_record->sql_desc_data_ptr = data_ptr;
+	SetSQLDescDataPtr(*apd_record, data_ptr);
 	return SQL_SUCCESS;
 }
 
 bool ParameterDescriptor::HasParamSetToProcess() {
-	return (paramset_idx < apd->header.sql_desc_array_size && !ipd->records.empty());
+	return (paramset_idx < cur_apd->header.sql_desc_array_size && !ipd->records.empty());
 }
 
 SQLRETURN ParameterDescriptor::PutCharData(DescRecord &apd_record, DescRecord &ipd_record, SQLPOINTER data_ptr,
                                            SQLLEN str_len_or_ind_ptr) {
-	if (apd->header.sql_desc_array_size == 1) {
+	if (cur_apd->header.sql_desc_array_size == 1) {
 		return FillParamCharDataBuffer(apd_record, ipd_record, data_ptr, str_len_or_ind_ptr);
 	}
 
@@ -135,13 +146,14 @@ SQLRETURN ParameterDescriptor::PutCharData(DescRecord &apd_record, DescRecord &i
 SQLRETURN ParameterDescriptor::FillParamCharDataBuffer(DescRecord &apd_record, DescRecord &ipd_record,
                                                        SQLPOINTER data_ptr, SQLLEN str_len_or_ind_ptr) {
 	size_t offset = 0;
-	if (*apd_record.sql_desc_indicator_ptr == SQL_DATA_AT_EXEC) {
+	auto sql_ind_ptr = GetSQLDescIndicatorPtr(apd_record);
+	if (*sql_ind_ptr == SQL_DATA_AT_EXEC) {
 		pool_allocated_ptr.emplace_back(unique_ptr<char[]>(new char[ipd_record.sql_desc_length]));
-		apd_record.sql_desc_data_ptr = pool_allocated_ptr.back().get();
-		*apd_record.sql_desc_indicator_ptr = 0;
+		SetSQLDescDataPtr(apd_record, pool_allocated_ptr.back().get());
+		*sql_ind_ptr = 0;
 	} else {
 		// appending more data into it
-		offset = *apd_record.sql_desc_indicator_ptr;
+		offset = *sql_ind_ptr;
 	}
 
 	size_t size = str_len_or_ind_ptr;
@@ -151,8 +163,8 @@ SQLRETURN ParameterDescriptor::FillParamCharDataBuffer(DescRecord &apd_record, D
 		++cur_param_idx;
 	}
 
-	memcpy((char *)apd_record.sql_desc_data_ptr + offset, (char *)data_ptr, size);
-	*apd_record.sql_desc_indicator_ptr += size;
+	memcpy((char *)GetSQLDescDataPtr(apd_record) + offset, (char *)data_ptr, size);
+	*sql_ind_ptr += size;
 
 	if (ipd->header.sql_desc_array_status_ptr) {
 		ipd->header.sql_desc_array_status_ptr[cur_param_idx] = SQL_PARAM_SUCCESS;
@@ -163,16 +175,16 @@ SQLRETURN ParameterDescriptor::FillParamCharDataBuffer(DescRecord &apd_record, D
 
 SQLRETURN ParameterDescriptor::FillCurParamCharSet(DescRecord &apd_record, DescRecord &ipd_record, SQLPOINTER data_ptr,
                                                    SQLLEN str_len_or_ind_ptr) {
-	auto len_ptr = &apd_record.sql_desc_indicator_ptr[cur_paramset_idx];
+	auto len_ptr = GetSQLDescIndicatorPtr(apd_record, cur_paramset_idx);
 	auto col_size = (size_t)ipd_record.sql_desc_length;
 
 	if (*len_ptr == SQL_DATA_AT_EXEC && pool_allocated_ptr.empty()) {
-		auto alloc_size = col_size * apd->header.sql_desc_array_size;
+		auto alloc_size = col_size * cur_apd->header.sql_desc_array_size;
 		pool_allocated_ptr.emplace_back(unique_ptr<char[]>(new char[alloc_size]));
-		apd_record.sql_desc_data_ptr = pool_allocated_ptr.back().get();
+		SetSQLDescDataPtr(apd_record, pool_allocated_ptr.back().get());
 	}
 
-	auto value_ptr = (char *)apd_record.sql_desc_data_ptr + (cur_paramset_idx * col_size);
+	auto value_ptr = (char *)GetSQLDescDataPtr(apd_record) + (cur_paramset_idx * col_size);
 
 	size_t size = str_len_or_ind_ptr;
 	if (size >= ((size_t)ipd_record.sql_desc_length)) {
@@ -187,7 +199,7 @@ SQLRETURN ParameterDescriptor::FillCurParamCharSet(DescRecord &apd_record, DescR
 	}
 
 	++cur_paramset_idx;
-	if (cur_paramset_idx >= apd->header.sql_desc_array_size) {
+	if (cur_paramset_idx >= cur_apd->header.sql_desc_array_size) {
 		// got to the next param set
 		cur_paramset_idx = 0;
 		++cur_param_idx;
@@ -198,76 +210,75 @@ SQLRETURN ParameterDescriptor::FillCurParamCharSet(DescRecord &apd_record, DescR
 
 SQLRETURN ParameterDescriptor::SetValue(idx_t rec_idx) {
 	auto val_idx = paramset_idx;
+	auto apd_record = &cur_apd->records[rec_idx];
+	auto sql_data_ptr = GetSQLDescDataPtr(*apd_record);
+	auto sql_ind_ptr = GetSQLDescIndicatorPtr(*apd_record);
 
-	if (apd->records[rec_idx].sql_desc_data_ptr == nullptr && apd->records[rec_idx].sql_desc_indicator_ptr == nullptr) {
+	if (sql_data_ptr == nullptr && sql_ind_ptr == nullptr) {
 		return SQL_ERROR;
 	}
 
-	if (apd->records[rec_idx].sql_desc_data_ptr == nullptr || apd->records[rec_idx].sql_desc_indicator_ptr == nullptr ||
-	    apd->records[rec_idx].sql_desc_indicator_ptr[val_idx] == SQL_NULL_DATA) {
+	auto sql_ind_ptr_val_set = GetSQLDescIndicatorPtr(*apd_record, val_idx);
+	if (sql_data_ptr == nullptr || sql_ind_ptr == nullptr || *sql_ind_ptr_val_set == SQL_NULL_DATA) {
 		Value val_null(nullptr);
 		SetValue(val_null, val_idx);
 		return SQL_SUCCESS;
 	}
 
-	if (apd->records[rec_idx].sql_desc_indicator_ptr[val_idx] == SQL_DATA_AT_EXEC ||
-	    (SQLULEN)apd->records[rec_idx].sql_desc_indicator_ptr[val_idx] ==
-	        SQL_LEN_DATA_AT_EXEC(ipd->records[rec_idx].sql_desc_length)) {
+	if (*sql_ind_ptr_val_set == SQL_DATA_AT_EXEC ||
+	    (SQLULEN)*sql_ind_ptr_val_set == SQL_LEN_DATA_AT_EXEC(ipd->records[rec_idx].sql_desc_length)) {
 		return SQL_NEED_DATA;
 	}
 
 	duckdb::Value value;
 	// TODO need to check it param_value_ptr is an array of parameters
 	// and get the right parameter using the index (now it's working for all supported tests)
-	duckdb::const_data_ptr_t dataptr = (duckdb::const_data_ptr_t)apd->records[rec_idx].sql_desc_data_ptr;
+	duckdb::const_data_ptr_t dataptr = (duckdb::const_data_ptr_t)sql_data_ptr;
 
 	switch (ipd->records[rec_idx].sql_desc_type) {
 	case SQL_CHAR:
 	case SQL_VARCHAR: {
-		auto str_data =
-		    (char *)apd->records[rec_idx].sql_desc_data_ptr + (val_idx * ipd->records[rec_idx].sql_desc_length);
-		auto str_len = apd->records[rec_idx].sql_desc_indicator_ptr[val_idx];
+		auto str_data = (char *)sql_data_ptr + (val_idx * ipd->records[rec_idx].sql_desc_length);
+		auto str_len = *sql_ind_ptr_val_set;
 		value = Value(duckdb::OdbcUtils::ReadString(str_data, str_len));
 		break;
 	}
 	case SQL_WCHAR: {
-		auto str_data =
-		    (wchar_t *)apd->records[rec_idx].sql_desc_data_ptr + (val_idx * ipd->records[rec_idx].sql_desc_length);
-		auto str_len = apd->records[rec_idx].sql_desc_indicator_ptr[val_idx];
+		auto str_data = (wchar_t *)sql_data_ptr + (val_idx * ipd->records[rec_idx].sql_desc_length);
+		auto str_len = *sql_ind_ptr_val_set;
 		value = Value(duckdb::OdbcUtils::ReadString(str_data, str_len));
 		break;
 	}
 	case SQL_VARBINARY:
 	case SQL_BINARY: {
-		auto blob_data = (duckdb::const_data_ptr_t)apd->records[rec_idx].sql_desc_data_ptr +
-		                 (val_idx * ipd->records[rec_idx].sql_desc_length);
-		auto blob_len = apd->records[rec_idx].sql_desc_indicator_ptr[val_idx];
+		auto blob_data = (duckdb::const_data_ptr_t)sql_data_ptr + (val_idx * ipd->records[rec_idx].sql_desc_length);
+		auto blob_len = *sql_ind_ptr_val_set;
 		value = Value::BLOB(blob_data, blob_len);
 		break;
 	}
 	case SQL_TINYINT:
-		if (apd->records[rec_idx].sql_desc_type == SQL_C_UTINYINT) {
+		if (cur_apd->records[rec_idx].sql_desc_type == SQL_C_UTINYINT) {
 			value = Value::UTINYINT(Load<uint8_t>(dataptr));
 		} else {
 			value = Value::TINYINT(Load<int8_t>(dataptr));
 		}
 		break;
 	case SQL_SMALLINT:
-		if (apd->records[rec_idx].sql_desc_type == SQL_C_USHORT) {
+		if (cur_apd->records[rec_idx].sql_desc_type == SQL_C_USHORT) {
 			value = Value::USMALLINT(Load<uint16_t>(dataptr));
 		} else {
 			value = Value::SMALLINT(Load<int16_t>(dataptr));
 		}
 		break;
 	case SQL_INTEGER:
-		if (apd->records[rec_idx].sql_desc_type == SQL_C_ULONG) {
+		if (cur_apd->records[rec_idx].sql_desc_type == SQL_C_ULONG) {
 			value = Value::UINTEGER(Load<uint32_t>(dataptr));
 		} else {
 			value = Value::INTEGER(Load<int32_t>(dataptr));
 		}
 		break;
 	case SQL_BIGINT:
-		if (apd->records[rec_idx].sql_desc_type == SQL_C_UBIGINT) {
+		if (cur_apd->records[rec_idx].sql_desc_type == SQL_C_UBIGINT) {
 			value = Value::UBIGINT(Load<uint64_t>(dataptr));
 		} else {
 			value = Value::BIGINT(Load<int64_t>(dataptr));
@@ -280,7 +291,7 @@ SQLRETURN ParameterDescriptor::SetValue(idx_t rec_idx) {
 		value = Value::DOUBLE(Load<double>(dataptr));
 		break;
 	case SQL_NUMERIC: {
-		auto numeric = (SQL_NUMERIC_STRUCT *)apd->records[rec_idx].sql_desc_data_ptr;
+		auto numeric = (SQL_NUMERIC_STRUCT *)sql_data_ptr;
 		dataptr = numeric->val;
 
 		auto precision = ipd->records[rec_idx].sql_desc_precision;
@@ -323,7 +334,7 @@ Value ParameterDescriptor::GetNextValue() {
 
 SQLRETURN ParameterDescriptor::SetParamIndex() {
 	++paramset_idx;
-	if (paramset_idx == apd->header.sql_desc_array_size) {
+	if (paramset_idx == cur_apd->header.sql_desc_array_size) {
 		return SQL_SUCCESS;
 	}
 	return SQL_STILL_EXECUTING;
@@ -337,4 +348,57 @@ SQLRETURN ParameterDescriptor::ValidateNumeric(int precision, int scale) {
 		return SQL_ERROR;
 	}
 	return SQL_SUCCESS;
+}
+
+SQLPOINTER ParameterDescriptor::GetSQLDescDataPtr(DescRecord &apd_record) {
+	if (cur_apd->header.sql_desc_bind_offset_ptr) {
+		return (uint8_t *)apd_record.sql_desc_data_ptr + *cur_apd->header.sql_desc_bind_offset_ptr;
+	}
+	return apd_record.sql_desc_data_ptr;
+}
+
+void ParameterDescriptor::SetSQLDescDataPtr(DescRecord &apd_record, SQLPOINTER data_ptr) {
+	auto sql_data_ptr = &(apd_record.sql_desc_data_ptr);
+	if (cur_apd->header.sql_desc_bind_offset_ptr) {
+		sql_data_ptr += *cur_apd->header.sql_desc_bind_offset_ptr;
+	}
+	*sql_data_ptr = data_ptr;
+}
+
+SQLLEN *ParameterDescriptor::GetSQLDescIndicatorPtr(DescRecord &apd_record, idx_t set_idx) {
+	if (cur_apd->header.sql_desc_bind_offset_ptr) {
+		return apd_record.sql_desc_indicator_ptr + set_idx + *cur_apd->header.sql_desc_bind_offset_ptr;
+	}
+	return apd_record.sql_desc_indicator_ptr + set_idx;
+}
+
+void ParameterDescriptor::SetSQLDescIndicatorPtr(DescRecord &apd_record, SQLLEN *ind_ptr) {
+	auto sql_ind_ptr = apd_record.sql_desc_indicator_ptr;
+	if (cur_apd->header.sql_desc_bind_offset_ptr) {
+		sql_ind_ptr += *cur_apd->header.sql_desc_bind_offset_ptr;
+	}
+	sql_ind_ptr = ind_ptr;
+}
+
+void ParameterDescriptor::SetSQLDescIndicatorPtr(DescRecord &apd_record, SQLLEN value) {
+	auto sql_ind_ptr = apd_record.sql_desc_indicator_ptr;
+	if (cur_apd->header.sql_desc_bind_offset_ptr) {
+		sql_ind_ptr += *cur_apd->header.sql_desc_bind_offset_ptr;
+	}
+	*sql_ind_ptr = value;
+}
+
+SQLLEN *ParameterDescriptor::GetSQLDescOctetLengthPtr(DescRecord &apd_record, idx_t set_idx) {
+	if (cur_apd->header.sql_desc_bind_offset_ptr) {
+		return apd_record.sql_desc_octet_length_ptr + set_idx + *cur_apd->header.sql_desc_bind_offset_ptr;
+	}
+	return apd_record.sql_desc_octet_length_ptr + set_idx;
+}
+
+void ParameterDescriptor::SetSQLDescOctetLengthPtr(DescRecord &apd_record, SQLLEN *len_ptr) {
+	auto sql_len_ptr = apd_record.sql_desc_octet_length_ptr;
+	if (cur_apd->header.sql_desc_bind_offset_ptr) {
+		sql_len_ptr += *cur_apd->header.sql_desc_bind_offset_ptr;
+	}
+	sql_len_ptr = len_ptr;
 }

--- a/tools/odbc/row_descriptor.cpp
+++ b/tools/odbc/row_descriptor.cpp
@@ -3,7 +3,7 @@
 using duckdb::OdbcHandleDesc;
 using duckdb::RowDescriptor;
 
-RowDescriptor::RowDescriptor(OdbcHandleStmt *stmt_ptr): stmt(stmt_ptr) {
+RowDescriptor::RowDescriptor(OdbcHandleStmt *stmt_ptr) : stmt(stmt_ptr) {
 	ard = make_unique<OdbcHandleDesc>(stmt->dbc);
 	ird = make_unique<OdbcHandleDesc>(stmt->dbc);
 

--- a/tools/odbc/row_descriptor.cpp
+++ b/tools/odbc/row_descriptor.cpp
@@ -1,0 +1,38 @@
+#include "row_descriptor.hpp"
+
+using duckdb::OdbcHandleDesc;
+using duckdb::RowDescriptor;
+
+RowDescriptor::RowDescriptor(OdbcHandleStmt *stmt_ptr): stmt(stmt_ptr) {
+	ard = make_unique<OdbcHandleDesc>(stmt->dbc);
+	ird = make_unique<OdbcHandleDesc>(stmt->dbc);
+
+	cur_ard = ard.get();
+}
+
+OdbcHandleDesc *RowDescriptor::GetIRD() {
+	return ird.get();
+}
+
+OdbcHandleDesc *RowDescriptor::GetARD() {
+	return cur_ard;
+}
+
+void RowDescriptor::Clear() {
+	ird->records.clear();
+	cur_ard->records.clear();
+	Reset();
+}
+
+void RowDescriptor::SetCurrentARD(OdbcHandleDesc *new_ard) {
+	cur_ard = new_ard;
+}
+
+void RowDescriptor::Reset() {
+	ird->header.sql_desc_count = 0;
+	cur_ard->header.sql_desc_count = 0;
+}
+
+void RowDescriptor::ResetCurrentARD() {
+	cur_ard = ard.get();
+}

--- a/tools/odbc/statement.cpp
+++ b/tools/odbc/statement.cpp
@@ -1,8 +1,10 @@
 #include "duckdb_odbc.hpp"
 #include "api_info.hpp"
+#include "driver.hpp"
 #include "odbc_fetch.hpp"
-#include "statement_functions.hpp"
 #include "parameter_descriptor.hpp"
+#include "row_descriptor.hpp"
+#include "statement_functions.hpp"
 
 using duckdb::LogicalTypeId;
 
@@ -64,6 +66,18 @@ SQLRETURN SQL_API SQLSetStmtAttr(SQLHSTMT statement_handle, SQLINTEGER attribute
 		case SQL_ATTR_CONCURRENCY:
 			// needs to be implemented
 			return SQL_SUCCESS;
+		case SQL_ATTR_APP_ROW_DESC: {
+			stmt->SetARD((duckdb::OdbcHandleDesc *)value_ptr);
+			return SQL_SUCCESS;
+		}
+		case SQL_ATTR_APP_PARAM_DESC: {
+			stmt->SetAPD((duckdb::OdbcHandleDesc *)value_ptr);
+			return SQL_SUCCESS;
+		}
+		case SQL_ATTR_PARAM_BIND_OFFSET_PTR: {
+			stmt->param_desc->apd->header.sql_desc_bind_offset_ptr = (SQLLEN *)value_ptr;
+			return SQL_SUCCESS;
+		}
 		default:
 			stmt->error_messages.emplace_back("Unsupported attribute type.");
 			return SQL_ERROR;
@@ -89,10 +103,10 @@ SQLRETURN SQL_API SQLGetStmtAttr(SQLHSTMT statement_handle, SQLINTEGER attribute
 				*((HSTMT *)value_ptr) = stmt->param_desc->GetIPD();
 			}
 			if (attribute == SQL_ATTR_APP_ROW_DESC) {
-				*((HSTMT *)value_ptr) = stmt->ard.get();
+				*((HSTMT *)value_ptr) = stmt->row_desc->GetARD();
 			}
 			if (attribute == SQL_ATTR_IMP_ROW_DESC) {
-				*((HSTMT *)value_ptr) = stmt->ird.get();
+				*((HSTMT *)value_ptr) = stmt->row_desc->GetIRD();
 			}
 			return SQL_SUCCESS;
 		}
@@ -122,8 +136,10 @@ SQLRETURN SQL_API SQLGetStmtAttr(SQLHSTMT statement_handle, SQLINTEGER attribute
 			break;
 		case SQL_ATTR_NOSCAN:
 			break;
-		case SQL_ATTR_PARAM_BIND_OFFSET_PTR:
-			break;
+		case SQL_ATTR_PARAM_BIND_OFFSET_PTR: {
+			*((SQLLEN *)value_ptr) = *stmt->param_desc->apd->header.sql_desc_bind_offset_ptr;
+			return SQL_SUCCESS;
+		}
 		case SQL_ATTR_PARAM_BIND_TYPE:
 			break;
 		case SQL_ATTR_PARAM_OPERATION_PTR:
@@ -347,7 +363,7 @@ SQLRETURN SQL_API SQLFreeStmt(SQLHSTMT statement_handle, SQLUSMALLINT option) {
 	return duckdb::WithStatement(statement_handle, [&](duckdb::OdbcHandleStmt *stmt) -> SQLRETURN {
 		if (option == SQL_DROP) {
 			// mapping FreeStmt with DROP option to SQLFreeHandle
-			return SQLFreeHandle(SQL_HANDLE_STMT, statement_handle);
+			return duckdb::FreeHandle(SQL_HANDLE_STMT, statement_handle);
 		}
 		if (option == SQL_UNBIND) {
 			stmt->bound_cols.clear();


### PR DESCRIPTION
Hey all,

This PR improves the ODBC functions SQLAllocHandle, SQLFreeStmt, SQLGetDiagRec, SQLSetStmtAttr, and also a bunch of descriptor features to meet the ODBC conformance core level.