### PR TITLE
C API: Deprecate direct access into duckdb_result and duckdb_column structs

### DIFF
--- a/examples/embedded-c/main.c
+++ b/examples/embedded-c/main.c
@@ -27,13 +27,15 @@ int main() {
 		goto cleanup;
 	}
 	// print the names of the result
-	for (size_t i = 0; i < result.column_count; i++) {
-		printf("%s ", result.columns[i].name);
+	idx_t row_count = duckdb_row_count(&result);
+	idx_t column_count = duckdb_column_count(&result);
+	for (size_t i = 0; i < column_count; i++) {
+		printf("%s ", duckdb_column_name(&result, i));
 	}
 	printf("\n");
 	// print the data of the result
-	for (size_t row_idx = 0; row_idx < result.row_count; row_idx++) {
-		for (size_t col_idx = 0; col_idx < result.column_count; col_idx++) {
+	for (size_t row_idx = 0; row_idx < row_count; row_idx++) {
+		for (size_t col_idx = 0; col_idx < column_count; col_idx++) {
 			char *val = duckdb_value_varchar(&result, col_idx, row_idx);
 			printf("%s ", val);
 			duckdb_free(val);

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+// duplicate of duckdb/main/winapi.hpp
 #ifndef DUCKDB_API
 #ifdef _WIN32
 #if defined(DUCKDB_BUILD_LIBRARY) && !defined(DUCKDB_BUILD_LOADABLE_EXTENSION)
@@ -19,6 +20,21 @@
 #else
 #define DUCKDB_API
 #endif
+#endif
+
+// duplicate of duckdb/common/constants.hpp
+#ifndef DUCKDB_API_0_3_1
+#define DUCKDB_API_0_3_1 1
+#endif
+#ifndef DUCKDB_API_0_3_2
+#define DUCKDB_API_0_3_2 2
+#endif
+#ifndef DUCKDB_API_LATEST
+#define DUCKDB_API_LATEST DUCKDB_API_0_3_2
+#endif
+
+#ifndef DUCKDB_API_VERSION
+#define DUCKDB_API_VERSION DUCKDB_API_LATEST
 #endif
 
 #include <stdbool.h>
@@ -130,19 +146,43 @@ typedef struct {
 } duckdb_blob;
 
 typedef struct {
+#if DUCKDB_API_VERSION < DUCKDB_API_0_3_2
 	void *data;
 	bool *nullmask;
 	duckdb_type type;
 	char *name;
+#else
+	// deprecated, use duckdb_column_data
+	void *__deprecated_data;
+	// deprecated, use duckdb_nullmask_data
+	bool *__deprecated_nullmask;
+	// deprecated, use duckdb_column_type
+	duckdb_type __deprecated_type;
+	// deprecated, use duckdb_column_name
+	char *__deprecated_name;
+#endif
 	void *internal_data;
 } duckdb_column;
 
 typedef struct {
+#if DUCKDB_API_VERSION < DUCKDB_API_0_3_2
 	idx_t column_count;
 	idx_t row_count;
 	idx_t rows_changed;
 	duckdb_column *columns;
 	char *error_message;
+#else
+	// deprecated, use duckdb_column_count
+	idx_t __deprecated_column_count;
+	// deprecated, use duckdb_row_count
+	idx_t __deprecated_row_count;
+	// deprecated, use duckdb_rows_changed
+	idx_t __deprecated_rows_changed;
+	// deprecated, use duckdb_column_ family of functions
+	duckdb_column *__deprecated_columns;
+	// deprecated, use duckdb_result_error
+	char *__deprecated_error_message;
+#endif
 	void *internal_data;
 } duckdb_result;
 

--- a/src/main/capi/result-c.cpp
+++ b/src/main/capi/result-c.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 template <class T>
 void WriteData(duckdb_result *out, ChunkCollection &source, idx_t col) {
 	idx_t row = 0;
-	auto target = (T *)out->columns[col].data;
+	auto target = (T *)out->__deprecated_columns[col].__deprecated_data;
 	for (auto &chunk : source.Chunks()) {
 		auto source = FlatVector::GetData<T>(chunk->data[col]);
 		auto &mask = FlatVector::Validity(chunk->data[col]);
@@ -29,46 +29,49 @@ duckdb_state duckdb_translate_result(MaterializedQueryResult *result, duckdb_res
 	memset(out, 0, sizeof(duckdb_result));
 	if (!result->success) {
 		// write the error message
-		out->error_message = strdup(result->error.c_str());
+		out->__deprecated_error_message = strdup(result->error.c_str());
 		return DuckDBError;
 	}
 	// copy the data
 	// first write the meta data
-	out->column_count = result->types.size();
-	out->row_count = result->collection.Count();
-	out->rows_changed = 0;
-	if (out->row_count > 0 && StatementTypeReturnChanges(result->statement_type)) {
+	out->__deprecated_column_count = result->types.size();
+	out->__deprecated_row_count = result->collection.Count();
+	out->__deprecated_rows_changed = 0;
+	if (out->__deprecated_row_count > 0 && StatementTypeReturnChanges(result->statement_type)) {
 		// update total changes
 		auto row_changes = result->GetValue(0, 0);
 		if (!row_changes.is_null && row_changes.TryCastAs(LogicalType::BIGINT)) {
-			out->rows_changed = row_changes.GetValue<int64_t>();
+			out->__deprecated_rows_changed = row_changes.GetValue<int64_t>();
 		}
 	}
-	out->columns = (duckdb_column *)duckdb_malloc(sizeof(duckdb_column) * out->column_count);
-	if (!out->columns) { // LCOV_EXCL_START
+	out->__deprecated_columns = (duckdb_column *)duckdb_malloc(sizeof(duckdb_column) * out->__deprecated_column_count);
+	if (!out->__deprecated_columns) { // LCOV_EXCL_START
 		// malloc failure
 		return DuckDBError;
 	} // LCOV_EXCL_STOP
 
 	// zero initialize the columns (so we can cleanly delete it in case a malloc fails)
-	memset(out->columns, 0, sizeof(duckdb_column) * out->column_count);
-	for (idx_t i = 0; i < out->column_count; i++) {
-		out->columns[i].type = ConvertCPPTypeToC(result->types[i]);
-		out->columns[i].name = strdup(result->names[i].c_str());
-		out->columns[i].nullmask = (bool *)duckdb_malloc(sizeof(bool) * out->row_count);
-		out->columns[i].data = duckdb_malloc(GetCTypeSize(out->columns[i].type) * out->row_count);
-		if (!out->columns[i].nullmask || !out->columns[i].name || !out->columns[i].data) { // LCOV_EXCL_START
+	memset(out->__deprecated_columns, 0, sizeof(duckdb_column) * out->__deprecated_column_count);
+	for (idx_t i = 0; i < out->__deprecated_column_count; i++) {
+		out->__deprecated_columns[i].__deprecated_type = ConvertCPPTypeToC(result->types[i]);
+		out->__deprecated_columns[i].__deprecated_name = strdup(result->names[i].c_str());
+		out->__deprecated_columns[i].__deprecated_nullmask =
+		    (bool *)duckdb_malloc(sizeof(bool) * out->__deprecated_row_count);
+		out->__deprecated_columns[i].__deprecated_data =
+		    duckdb_malloc(GetCTypeSize(out->__deprecated_columns[i].__deprecated_type) * out->__deprecated_row_count);
+		if (!out->__deprecated_columns[i].__deprecated_nullmask || !out->__deprecated_columns[i].__deprecated_name ||
+		    !out->__deprecated_columns[i].__deprecated_data) { // LCOV_EXCL_START
 			// malloc failure
 			return DuckDBError;
 		} // LCOV_EXCL_STOP
 	}
 	// now write the data
-	for (idx_t col = 0; col < out->column_count; col++) {
+	for (idx_t col = 0; col < out->__deprecated_column_count; col++) {
 		// first set the nullmask
 		idx_t row = 0;
 		for (auto &chunk : result->collection.Chunks()) {
 			for (idx_t k = 0; k < chunk->size(); k++) {
-				out->columns[col].nullmask[row++] = FlatVector::IsNull(chunk->data[col], k);
+				out->__deprecated_columns[col].__deprecated_nullmask[row++] = FlatVector::IsNull(chunk->data[col], k);
 			}
 		}
 		// then write the data
@@ -119,7 +122,7 @@ duckdb_state duckdb_translate_result(MaterializedQueryResult *result, duckdb_res
 			break;
 		case LogicalTypeId::VARCHAR: {
 			idx_t row = 0;
-			auto target = (const char **)out->columns[col].data;
+			auto target = (const char **)out->__deprecated_columns[col].__deprecated_data;
 			for (auto &chunk : result->collection.Chunks()) {
 				auto source = FlatVector::GetData<string_t>(chunk->data[col]);
 				for (idx_t k = 0; k < chunk->size(); k++) {
@@ -139,7 +142,7 @@ duckdb_state duckdb_translate_result(MaterializedQueryResult *result, duckdb_res
 		}
 		case LogicalTypeId::BLOB: {
 			idx_t row = 0;
-			auto target = (duckdb_blob *)out->columns[col].data;
+			auto target = (duckdb_blob *)out->__deprecated_columns[col].__deprecated_data;
 			for (auto &chunk : result->collection.Chunks()) {
 				auto source = FlatVector::GetData<string_t>(chunk->data[col]);
 				for (idx_t k = 0; k < chunk->size(); k++) {
@@ -161,7 +164,7 @@ duckdb_state duckdb_translate_result(MaterializedQueryResult *result, duckdb_res
 		case LogicalTypeId::TIMESTAMP_MS:
 		case LogicalTypeId::TIMESTAMP_SEC: {
 			idx_t row = 0;
-			auto target = (timestamp_t *)out->columns[col].data;
+			auto target = (timestamp_t *)out->__deprecated_columns[col].__deprecated_data;
 			for (auto &chunk : result->collection.Chunks()) {
 				auto source = FlatVector::GetData<timestamp_t>(chunk->data[col]);
 
@@ -183,7 +186,7 @@ duckdb_state duckdb_translate_result(MaterializedQueryResult *result, duckdb_res
 		}
 		case LogicalTypeId::HUGEINT: {
 			idx_t row = 0;
-			auto target = (duckdb_hugeint *)out->columns[col].data;
+			auto target = (duckdb_hugeint *)out->__deprecated_columns[col].__deprecated_data;
 			for (auto &chunk : result->collection.Chunks()) {
 				auto source = FlatVector::GetData<hugeint_t>(chunk->data[col]);
 				for (idx_t k = 0; k < chunk->size(); k++) {
@@ -198,7 +201,7 @@ duckdb_state duckdb_translate_result(MaterializedQueryResult *result, duckdb_res
 		}
 		case LogicalTypeId::INTERVAL: {
 			idx_t row = 0;
-			auto target = (duckdb_interval *)out->columns[col].data;
+			auto target = (duckdb_interval *)out->__deprecated_columns[col].__deprecated_data;
 			for (auto &chunk : result->collection.Chunks()) {
 				auto source = FlatVector::GetData<interval_t>(chunk->data[col]);
 				for (idx_t k = 0; k < chunk->size(); k++) {
@@ -224,99 +227,99 @@ duckdb_state duckdb_translate_result(MaterializedQueryResult *result, duckdb_res
 } // namespace duckdb
 
 static void DuckdbDestroyColumn(duckdb_column column, idx_t count) {
-	if (column.data) {
-		if (column.type == DUCKDB_TYPE_VARCHAR) {
+	if (column.__deprecated_data) {
+		if (column.__deprecated_type == DUCKDB_TYPE_VARCHAR) {
 			// varchar, delete individual strings
-			auto data = (char **)column.data;
+			auto data = (char **)column.__deprecated_data;
 			for (idx_t i = 0; i < count; i++) {
 				if (data[i]) {
 					duckdb_free(data[i]);
 				}
 			}
-		} else if (column.type == DUCKDB_TYPE_BLOB) {
+		} else if (column.__deprecated_type == DUCKDB_TYPE_BLOB) {
 			// blob, delete individual blobs
-			auto data = (duckdb_blob *)column.data;
+			auto data = (duckdb_blob *)column.__deprecated_data;
 			for (idx_t i = 0; i < count; i++) {
 				if (data[i].data) {
 					duckdb_free((void *)data[i].data);
 				}
 			}
 		}
-		duckdb_free(column.data);
+		duckdb_free(column.__deprecated_data);
 	}
-	if (column.nullmask) {
-		duckdb_free(column.nullmask);
+	if (column.__deprecated_nullmask) {
+		duckdb_free(column.__deprecated_nullmask);
 	}
-	if (column.name) {
-		duckdb_free(column.name);
+	if (column.__deprecated_name) {
+		duckdb_free(column.__deprecated_name);
 	}
 }
 
 void duckdb_destroy_result(duckdb_result *result) {
-	if (result->error_message) {
-		duckdb_free(result->error_message);
+	if (result->__deprecated_error_message) {
+		duckdb_free(result->__deprecated_error_message);
 	}
-	if (result->columns) {
-		for (idx_t i = 0; i < result->column_count; i++) {
-			DuckdbDestroyColumn(result->columns[i], result->row_count);
+	if (result->__deprecated_columns) {
+		for (idx_t i = 0; i < result->__deprecated_column_count; i++) {
+			DuckdbDestroyColumn(result->__deprecated_columns[i], result->__deprecated_row_count);
 		}
-		duckdb_free(result->columns);
+		duckdb_free(result->__deprecated_columns);
 	}
 	memset(result, 0, sizeof(duckdb_result));
 }
 
 const char *duckdb_column_name(duckdb_result *result, idx_t col) {
-	if (!result || col >= result->column_count) {
+	if (!result || col >= result->__deprecated_column_count) {
 		return nullptr;
 	}
-	return result->columns[col].name;
+	return result->__deprecated_columns[col].__deprecated_name;
 }
 
 duckdb_type duckdb_column_type(duckdb_result *result, idx_t col) {
-	if (!result || col >= result->column_count) {
+	if (!result || col >= result->__deprecated_column_count) {
 		return DUCKDB_TYPE_INVALID;
 	}
-	return result->columns[col].type;
+	return result->__deprecated_columns[col].__deprecated_type;
 }
 
 idx_t duckdb_column_count(duckdb_result *result) {
 	if (!result) {
 		return 0;
 	}
-	return result->column_count;
+	return result->__deprecated_column_count;
 }
 
 idx_t duckdb_row_count(duckdb_result *result) {
 	if (!result) {
 		return 0;
 	}
-	return result->row_count;
+	return result->__deprecated_row_count;
 }
 
 idx_t duckdb_rows_changed(duckdb_result *result) {
 	if (!result) {
 		return 0;
 	}
-	return result->rows_changed;
+	return result->__deprecated_rows_changed;
 }
 
 void *duckdb_column_data(duckdb_result *result, idx_t col) {
-	if (!result || col >= result->column_count) {
+	if (!result || col >= result->__deprecated_column_count) {
 		return nullptr;
 	}
-	return result->columns[col].data;
+	return result->__deprecated_columns[col].__deprecated_data;
 }
 
 bool *duckdb_nullmask_data(duckdb_result *result, idx_t col) {
-	if (!result || col >= result->column_count) {
+	if (!result || col >= result->__deprecated_column_count) {
 		return nullptr;
 	}
-	return result->columns[col].nullmask;
+	return result->__deprecated_columns[col].__deprecated_nullmask;
 }
 
 char *duckdb_result_error(duckdb_result *result) {
 	if (!result) {
 		return nullptr;
 	}
-	return result->error_message;
+	return result->__deprecated_error_message;
 }

--- a/src/main/capi/value-c.cpp
+++ b/src/main/capi/value-c.cpp
@@ -27,8 +27,8 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 template <class T>
 T UnsafeFetch(duckdb_result *result, idx_t col, idx_t row) {
-	D_ASSERT(row < result->row_count);
-	return ((T *)result->columns[col].data)[row];
+	D_ASSERT(row < result->__deprecated_row_count);
+	return ((T *)result->__deprecated_columns[col].__deprecated_data)[row];
 }
 
 //===--------------------------------------------------------------------===//
@@ -149,10 +149,10 @@ RESULT_TYPE TryCastCInternal(duckdb_result *result, idx_t col, idx_t row) {
 }
 
 static bool CanFetchValue(duckdb_result *result, idx_t col, idx_t row) {
-	if (!result || col >= result->column_count || row >= result->row_count) {
+	if (!result || col >= result->__deprecated_column_count || row >= result->__deprecated_row_count) {
 		return false;
 	}
-	if (result->columns[col].nullmask[row]) {
+	if (result->__deprecated_columns[col].__deprecated_nullmask[row]) {
 		return false;
 	}
 	return true;
@@ -163,7 +163,7 @@ static RESULT_TYPE GetInternalCValue(duckdb_result *result, idx_t col, idx_t row
 	if (!CanFetchValue(result, col, row)) {
 		return FetchDefaultValue::Operation<RESULT_TYPE>();
 	}
-	switch (result->columns[col].type) {
+	switch (result->__deprecated_columns[col].__deprecated_type) {
 	case DUCKDB_TYPE_BOOLEAN:
 		return TryCastCInternal<bool, RESULT_TYPE, OP>(result, col, row);
 	case DUCKDB_TYPE_TINYINT:
@@ -304,7 +304,7 @@ char *duckdb_value_varchar_internal(duckdb_result *result, idx_t col, idx_t row)
 }
 
 duckdb_blob duckdb_value_blob(duckdb_result *result, idx_t col, idx_t row) {
-	if (CanFetchValue(result, col, row) && result->columns[col].type == DUCKDB_TYPE_BLOB) {
+	if (CanFetchValue(result, col, row) && result->__deprecated_columns[col].__deprecated_type == DUCKDB_TYPE_BLOB) {
 		auto internal_result = UnsafeFetch<duckdb_blob>(result, col, row);
 
 		duckdb_blob result_blob;
@@ -317,8 +317,8 @@ duckdb_blob duckdb_value_blob(duckdb_result *result, idx_t col, idx_t row) {
 }
 
 bool duckdb_value_is_null(duckdb_result *result, idx_t col, idx_t row) {
-	if (!result || col >= result->column_count || row >= result->row_count) {
+	if (!result || col >= result->__deprecated_column_count || row >= result->__deprecated_row_count) {
 		return false;
 	}
-	return result->columns[col].nullmask[row];
+	return result->__deprecated_columns[col].__deprecated_nullmask[row];
 }

--- a/test/api/capi/test_capi.cpp
+++ b/test/api/capi/test_capi.cpp
@@ -136,19 +136,19 @@ double CAPIResult::Fetch(idx_t col, idx_t row) {
 
 template <>
 duckdb_date CAPIResult::Fetch(idx_t col, idx_t row) {
-	auto data = (duckdb_date *)result.columns[col].data;
+	auto data = (duckdb_date *)duckdb_column_data(&result, col);
 	return data[row];
 }
 
 template <>
 duckdb_time CAPIResult::Fetch(idx_t col, idx_t row) {
-	auto data = (duckdb_time *)result.columns[col].data;
+	auto data = (duckdb_time *)duckdb_column_data(&result, col);
 	return data[row];
 }
 
 template <>
 duckdb_timestamp CAPIResult::Fetch(idx_t col, idx_t row) {
-	auto data = (duckdb_timestamp *)result.columns[col].data;
+	auto data = (duckdb_timestamp *)duckdb_column_data(&result, col);
 	return data[row];
 }
 
@@ -159,7 +159,7 @@ duckdb_interval CAPIResult::Fetch(idx_t col, idx_t row) {
 
 template <>
 duckdb_blob CAPIResult::Fetch(idx_t col, idx_t row) {
-	auto data = (duckdb_blob *)result.columns[col].data;
+	auto data = (duckdb_blob *)duckdb_column_data(&result, col);
 	return data[row];
 }
 
@@ -645,7 +645,7 @@ TEST_CASE("Test prepared statements in C API", "[capi]") {
 	duckdb_bind_null(stmt, 1);
 	status = duckdb_execute_prepared(stmt, &res);
 	REQUIRE(status == DuckDBSuccess);
-	REQUIRE(res.columns[0].nullmask[0] == true);
+	REQUIRE(duckdb_nullmask_data(&res, 0)[0] == true);
 	duckdb_destroy_result(&res);
 
 	duckdb_destroy_prepare(&stmt);


### PR DESCRIPTION
In the C API, direct access into the `duckdb_result` and `duckdb_column` structs is not required, as we have various helper functions that allow accessing each of these components. The direct access is problematic, since it requires us to up-front convert all the results from our internal C++ format to the C format, which is an unnecessary performance hit.

In this PR we deprecate the direct result access. We will do this in two stages. First, we rename the variables to `__deprecated_` unless `DUCKDB_API_VERSION` is defined to be lower than `2` (the current API version):

```cpp
typedef struct {
#if DUCKDB_API_VERSION < DUCKDB_API_0_3_2
	idx_t column_count;
	idx_t row_count;
	idx_t rows_changed;
	duckdb_column *columns;
	char *error_message;
#else
	// deprecated, use duckdb_column_count
	idx_t __deprecated_column_count;
	// deprecated, use duckdb_row_count
	idx_t __deprecated_row_count;
	// deprecated, use duckdb_rows_changed
	idx_t __deprecated_rows_changed;
	// deprecated, use duckdb_column_ family of functions
	duckdb_column *__deprecated_columns;
	// deprecated, use duckdb_result_error
	char *__deprecated_error_message;
#endif
	void *internal_data;
} duckdb_result;
```

This way, it is temporarily still possible to use old code that relies on this by adding a `#define DUCKDB_API_VERSION 1` before the include:

```cpp
#define DUCKDB_API_VERSION 1
#include "duckdb.h"

...
// result.columns[col_idx].data;
...
```

In a future version we will deprecate these fields entirely and remove them, so this work-around will only work temporarily.