### PR TITLE
Issue #2782: Non-Gregorian Calendars

### DIFF
--- a/extension/icu/icu-datefunc.cpp
+++ b/extension/icu/icu-datefunc.cpp
@@ -18,8 +18,18 @@ ICUDateFunc::BindData::BindData(ClientContext &context) {
 	}
 	auto tz = icu::TimeZone::createTimeZone(icu::UnicodeString::fromUTF8(icu::StringPiece(tz_id)));
 
+	string cal_id("@calendar=");
+	Value cal_value;
+	if (context.TryGetCurrentSetting("Calendar", cal_value)) {
+		cal_id += cal_value.ToString();
+	} else {
+		cal_id += "gregorian";
+	}
+
+	icu::Locale locale(cal_id.c_str());
+
 	UErrorCode success = U_ZERO_ERROR;
-	calendar.reset(icu::Calendar::createInstance(tz, success));
+	calendar.reset(icu::Calendar::createInstance(tz, locale, success));
 	if (U_FAILURE(success)) {
 		throw Exception("Unable to create ICU calendar.");
 	}

--- a/extension/icu/icu-extension.cpp
+++ b/extension/icu/icu-extension.cpp
@@ -220,6 +220,76 @@ static void ICUTimeZoneFunction(ClientContext &context, const FunctionData *bind
 	output.SetCardinality(index);
 }
 
+struct ICUCalendarData : public FunctionOperatorData {
+	ICUCalendarData() {
+		// All calendars are available in all locales
+		UErrorCode status = U_ZERO_ERROR;
+		calendars.reset(icu::Calendar::getKeywordValuesForLocale("calendar", icu::Locale::getDefault(), false, status));
+	}
+
+	std::unique_ptr<icu::StringEnumeration> calendars;
+};
+
+static unique_ptr<FunctionData> ICUCalendarBind(ClientContext &context, vector<Value> &inputs,
+                                                unordered_map<string, Value> &named_parameters,
+                                                vector<LogicalType> &input_table_types,
+                                                vector<string> &input_table_names, vector<LogicalType> &return_types,
+                                                vector<string> &names) {
+	names.emplace_back("name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+static unique_ptr<FunctionOperatorData> ICUCalendarInit(ClientContext &context, const FunctionData *bind_data,
+                                                        const vector<column_t> &column_ids,
+                                                        TableFilterCollection *filters) {
+	return make_unique<ICUCalendarData>();
+}
+
+static void ICUCalendarFunction(ClientContext &context, const FunctionData *bind_data,
+                                FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
+	auto &data = (ICUCalendarData &)*operator_state;
+	idx_t index = 0;
+	while (index < STANDARD_VECTOR_SIZE) {
+		if (!data.calendars) {
+			break;
+		}
+
+		UErrorCode status = U_ZERO_ERROR;
+		auto calendar = data.calendars->snext(status);
+		if (U_FAILURE(status) || !calendar) {
+			break;
+		}
+
+		//	The calendar name is all we have
+		std::string utf8;
+		calendar->toUTF8String(utf8);
+		output.SetValue(0, index, Value(utf8));
+
+		++index;
+	}
+	output.SetCardinality(index);
+}
+
+static void ICUCalendarCleanup(ClientContext &context, const FunctionData *bind_data,
+                               FunctionOperatorData *operator_state) {
+	auto &data = (ICUCalendarData &)*operator_state;
+	(void)data.calendars.release();
+}
+
+static void SetICUCalendar(ClientContext &context, SetScope scope, Value &parameter) {
+	const auto name = parameter.Value::GetValueUnsafe<string>();
+	string locale_key = "@calendar=" + name;
+	icu::Locale locale(locale_key.c_str());
+
+	UErrorCode status = U_ZERO_ERROR;
+	std::unique_ptr<icu::Calendar> cal(icu::Calendar::createInstance(locale, status));
+	if (U_FAILURE(status) || name != cal->getType()) {
+		throw NotImplementedException("Unknown Calendar setting");
+	}
+}
+
 void ICUExtension::Load(DuckDB &db) {
 	Connection con(db);
 	con.BeginTransaction();
@@ -269,6 +339,17 @@ void ICUExtension::Load(DuckDB &db) {
 	RegisterICUDateSubFunctions(*con.context);
 	RegisterICUDateTruncFunctions(*con.context);
 	RegisterICUMakeDateFunctions(*con.context);
+
+	// Calendars
+	config.AddExtensionOption("Calendar", "The current calendar", LogicalType::VARCHAR, SetICUCalendar);
+	UErrorCode status = U_ZERO_ERROR;
+	std::unique_ptr<icu::Calendar> cal(icu::Calendar::createInstance(status));
+	config.set_variables["Calendar"] = Value(cal->getType());
+
+	TableFunction cal_names("icu_calendar_names", {}, ICUCalendarFunction, ICUCalendarBind, ICUCalendarInit, nullptr,
+	                        ICUCalendarCleanup);
+	CreateTableFunctionInfo cal_names_info(move(cal_names));
+	catalog.CreateTableFunction(*con.context, &cal_names_info);
 
 	con.Commit();
 }

--- a/test/sql/timezone/test_icu_calendar.test
+++ b/test/sql/timezone/test_icu_calendar.test
@@ -1,0 +1,92 @@
+# name: test/sql/timezone/test_icu_calendar.test
+# description: Test the ICU calendar interface
+# group: [timezone]
+
+require icu
+
+query I
+SELECT name FROM icu_calendar_names()
+GROUP BY 1
+ORDER BY 1;
+----
+buddhist
+chinese
+coptic
+dangi
+ethiopic
+ethiopic-amete-alem
+gregorian
+hebrew
+indian
+islamic
+islamic-civil
+islamic-rgsa
+islamic-tbla
+islamic-umalqura
+iso8601
+japanese
+persian
+roc
+
+query IIII
+SELECT * FROM duckdb_settings() WHERE name = 'Calendar';
+----
+Calendar	gregorian	The current calendar	VARCHAR
+
+statement error
+SET Calendar = 'fnord';
+
+#
+# Japanese calendar testing
+#
+statement ok
+SET Calendar = 'japanese';
+
+query IIII
+SELECT * FROM duckdb_settings() WHERE name = 'Calendar';
+----
+Calendar	japanese	The current calendar	VARCHAR
+
+statement ok
+SET TimeZone = 'Asia/Tokyo';
+
+statement ok
+CREATE TABLE timestamps AS SELECT ts::TIMESTAMPTZ AS ts, era FROM (VALUES
+	('0645-06-30 00:00:00+00', 'Taika'),
+	('1867-01-01 00:00:00+00', 'Keiou'),
+	('1868-09-07 00:00:00+00', 'Keiou'),
+	('1868-09-08 00:00:00+00', 'Meiji'),
+	('1912-07-29 00:00:00+00', 'Meiji'),
+	('1912-07-30 00:00:00+00', 'Taisho'),
+	('1926-12-24 00:00:00+00', 'Taisho'),
+	('1926-12-25 00:00:00+00', 'Showa'),
+	('1989-01-06 00:00:00+00', 'Showa'),
+	('1989-01-08 00:00:00+00', 'Heisei'),
+	('2019-05-01 00:00:00+00', 'Reiwa'),
+	('2022-01-01 00:00:00+00', 'Reiwa')
+) tbl(ts, era);
+
+# ICU appears to have the start of the Meiji era incorrect with regard to:
+#	* the accession of Mutsuhito (1867-02-03)
+#	* the resignation of the Shogun (1867-11-09)
+#	* the imperial restoration (1868-01-03)
+#	* their own comments (1868-01-09)
+#	* the fall of Edo (1868-07)
+# and a bunch of other dates in that period.
+query III
+SELECT era, ts, DATE_PART(['era', 'year', 'month', 'day'], ts)
+FROM timestamps
+ORDER BY 2
+----
+Taika	0645-06-30 00:00:00+00	{'era': 0, 'year': 1, 'month': 6, 'day': 27}
+Keiou	1867-01-01 00:00:00+00	{'era': 231, 'year': 3, 'month': 1, 'day': 1}
+Keiou	1868-09-07 00:00:00+00	{'era': 231, 'year': 4, 'month': 9, 'day': 7}
+Meiji	1868-09-08 00:00:00+00	{'era': 232, 'year': 1, 'month': 9, 'day': 8}
+Meiji	1912-07-29 00:00:00+00	{'era': 232, 'year': 45, 'month': 7, 'day': 29}
+Taisho	1912-07-30 00:00:00+00	{'era': 233, 'year': 1, 'month': 7, 'day': 30}
+Taisho	1926-12-24 00:00:00+00	{'era': 233, 'year': 15, 'month': 12, 'day': 24}
+Showa	1926-12-25 00:00:00+00	{'era': 234, 'year': 1, 'month': 12, 'day': 25}
+Showa	1989-01-06 00:00:00+00	{'era': 234, 'year': 64, 'month': 1, 'day': 6}
+Heisei	1989-01-08 00:00:00+00	{'era': 235, 'year': 1, 'month': 1, 'day': 8}
+Reiwa	2019-05-01 00:00:00+00	{'era': 236, 'year': 1, 'month': 5, 'day': 1}
+Reiwa	2022-01-01 00:00:00+00	{'era': 236, 'year': 4, 'month': 1, 'day': 1}

--- a/test/sql/timezone/test_icu_calendar.test
+++ b/test/sql/timezone/test_icu_calendar.test
@@ -66,13 +66,7 @@ CREATE TABLE timestamps AS SELECT ts::TIMESTAMPTZ AS ts, era FROM (VALUES
 	('2022-01-01 00:00:00+00', 'Reiwa')
 ) tbl(ts, era);
 
-# ICU appears to have the start of the Meiji era incorrect with regard to:
-#	* the accession of Mutsuhito (1867-02-03)
-#	* the resignation of the Shogun (1867-11-09)
-#	* the imperial restoration (1868-01-03)
-#	* their own comments (1868-01-09)
-#	* the fall of Edo (1868-07)
-# and a bunch of other dates in that period.
+# See http://www.meijigakuin.ac.jp/~watson/ref/mtsh.html for details on recent era boundaries.
 query III
 SELECT era, ts, DATE_PART(['era', 'year', 'month', 'day'], ts)
 FROM timestamps


### PR DESCRIPTION
Allow the user to change the current calendar used by ICU via

```sql
Set Calendar='<name>';
```

Test it using the Japanese imperial eras.