### PR TITLE
Remove unused move to allow RVO works

### DIFF
--- a/benchmark/include/duckdb_benchmark.hpp
+++ b/benchmark/include/duckdb_benchmark.hpp
@@ -74,7 +74,7 @@ public:
 	unique_ptr<BenchmarkState> Initialize(BenchmarkConfiguration &config) override {
 		auto state = CreateBenchmarkState();
 		Load(state.get());
-		return move(state);
+		return state;
 	}
 
 	void Run(BenchmarkState *state_p) override {

--- a/benchmark/micro/append.cpp
+++ b/benchmark/micro/append.cpp
@@ -65,7 +65,7 @@ struct DuckDBPreparedState : public DuckDBBenchmarkState {
 #define APPEND_BENCHMARK_PREPARED(CREATE_STATEMENT)                                                                    \
 	unique_ptr<DuckDBBenchmarkState> CreateBenchmarkState() override {                                                 \
 		auto result = make_unique<DuckDBPreparedState>(GetDatabasePath());                                             \
-		return move(result);                                                                                           \
+		return result;                                                                                           \
 	}                                                                                                                  \
 	void Load(DuckDBBenchmarkState *state_p) override {                                                                \
 		auto state = (DuckDBPreparedState *)state_p;                                                                   \

--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -280,7 +280,7 @@ unique_ptr<ColumnWriterState> ColumnWriter::InitializeWriteState(duckdb_parquet:
 	column_chunk.meta_data.type = writer.file_meta_data.schema[schema_idx].type;
 	row_group.columns.push_back(move(column_chunk));
 
-	return move(result);
+	return result;
 }
 
 void ColumnWriter::HandleRepeatLevels(ColumnWriterState &state, ColumnWriterState *parent, idx_t count,

--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -1286,7 +1286,7 @@ unique_ptr<ColumnWriterState> StructColumnWriter::InitializeWriteState(duckdb_pa
 	for (auto &child_writer : child_writers) {
 		result->child_states.push_back(child_writer->InitializeWriteState(row_group));
 	}
-	return move(result);
+	return result;
 }
 
 void StructColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterState *parent, Vector &vector, idx_t count) {
@@ -1370,7 +1370,7 @@ public:
 unique_ptr<ColumnWriterState> ListColumnWriter::InitializeWriteState(duckdb_parquet::format::RowGroup &row_group) {
 	auto result = make_unique<ListColumnWriterState>(row_group, row_group.columns.size());
 	result->child_state = child_writer->InitializeWriteState(row_group);
-	return move(result);
+	return result;
 }
 
 void ListColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterState *parent, Vector &vector, idx_t count) {

--- a/extension/parquet/parquet-extension.cpp
+++ b/extension/parquet/parquet-extension.cpp
@@ -106,7 +106,7 @@ public:
 		}
 		ParquetOptions parquet_options(context);
 		result->initial_reader = make_shared<ParquetReader>(context, result->files[0], expected_types, parquet_options);
-		return move(result);
+		return result;
 	}
 
 	static unique_ptr<BaseStatistics> ParquetScanStats(ClientContext &context, const FunctionData *bind_data_p,
@@ -184,7 +184,7 @@ public:
 		return_types = result->initial_reader->return_types;
 
 		names = result->initial_reader->names;
-		return move(result);
+		return result;
 	}
 
 	static vector<string> ParquetGlob(FileSystem &fs, const string &glob) {

--- a/extension/parquet/parquet-extension.cpp
+++ b/extension/parquet/parquet-extension.cpp
@@ -262,7 +262,7 @@ public:
 		}
 		result->reader = bind_data.initial_reader;
 		result->reader->InitializeScan(result->scan_state, column_ids, move(group_ids), filters->table_filters);
-		return move(result);
+		return result;
 	}
 
 	static double ParquetProgress(ClientContext &context, const FunctionData *bind_data_p) {
@@ -286,7 +286,7 @@ public:
 		if (!ParquetParallelStateNext(context, bind_data_p, result.get(), parallel_state_p)) {
 			return nullptr;
 		}
-		return move(result);
+		return result;
 	}
 
 	static void ParquetScanImplementation(ClientContext &context, const FunctionData *bind_data_p,
@@ -344,7 +344,7 @@ public:
 		result->current_reader = bind_data.initial_reader;
 		result->row_group_index = 0;
 		result->file_index = 0;
-		return move(result);
+		return result;
 	}
 
 	static bool ParquetParallelStateNext(ClientContext &context, const FunctionData *bind_data_p,

--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -407,7 +407,7 @@ unique_ptr<FunctionData> ParquetMetaDataBind(ClientContext &context, vector<Valu
 	if (result->files.empty()) {
 		throw IOException("No files found that match the pattern \"%s\"", file_name);
 	}
-	return move(result);
+	return result;
 }
 
 template <bool SCHEMA>
@@ -424,7 +424,7 @@ unique_ptr<FunctionOperatorData> ParquetMetaDataInit(ClientContext &context, con
 		result->LoadFileMetaData(context, bind_data.return_types, bind_data.files[0]);
 	}
 	result->file_index = 0;
-	return move(result);
+	return result;
 }
 
 template <bool SCHEMA>

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -36,7 +36,7 @@ static unique_ptr<BaseStatistics> CreateNumericStats(const LogicalType &type,
 	} else {
 		stats->max.is_null = true;
 	}
-	return move(stats);
+	return stats;
 }
 
 Value ParquetStatisticsUtils::ConvertValue(const LogicalType &type,

--- a/extension/tpcds/tpcds-extension.cpp
+++ b/extension/tpcds/tpcds-extension.cpp
@@ -47,7 +47,7 @@ static unique_ptr<FunctionData> DsdgenBind(ClientContext &context, vector<Value>
 	}
 	return_types.emplace_back(LogicalType::BOOLEAN);
 	names.emplace_back("Success");
-	return move(result);
+	return result;
 }
 
 static void DsdgenFunction(ClientContext &context, const FunctionData *bind_data, FunctionOperatorData *operator_state,
@@ -71,7 +71,7 @@ struct TPCDSData : public FunctionOperatorData {
 unique_ptr<FunctionOperatorData> TPCDSInit(ClientContext &context, const FunctionData *bind_data,
                                            const vector<column_t> &column_ids, TableFilterCollection *filters) {
 	auto result = make_unique<TPCDSData>();
-	return move(result);
+	return result;
 }
 
 static unique_ptr<FunctionData> TPCDSQueryBind(ClientContext &context, vector<Value> &inputs,

--- a/extension/tpch/tpch-extension.cpp
+++ b/extension/tpch/tpch-extension.cpp
@@ -44,7 +44,7 @@ static unique_ptr<FunctionData> DbgenBind(ClientContext &context, vector<Value> 
 	}
 	return_types.emplace_back(LogicalType::BOOLEAN);
 	names.emplace_back("Success");
-	return move(result);
+	return result;
 }
 
 static void DbgenFunction(ClientContext &context, const FunctionData *bind_data, FunctionOperatorData *operator_state,
@@ -68,7 +68,7 @@ struct TPCHData : public FunctionOperatorData {
 unique_ptr<FunctionOperatorData> TPCHInit(ClientContext &context, const FunctionData *bind_data,
                                           const vector<column_t> &column_ids, TableFilterCollection *filters) {
 	auto result = make_unique<TPCHData>();
-	return move(result);
+	return result;
 }
 
 static unique_ptr<FunctionData> TPCHQueryBind(ClientContext &context, vector<Value> &inputs,

--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -112,7 +112,7 @@ static unique_ptr<CreateFunctionInfo> GetDefaultFunction(const string &schema, c
 			bind_info->temporary = true;
 			bind_info->internal = true;
 			bind_info->function = move(result);
-			return move(bind_info);
+			return bind_info;
 		}
 	}
 	return nullptr;

--- a/src/execution/expression_executor/execute_case.cpp
+++ b/src/execution/expression_executor/execute_case.cpp
@@ -23,7 +23,7 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundCaseE
 	}
 	result->AddChild(expr.else_expr.get());
 	result->Finalize();
-	return move(result);
+	return result;
 }
 
 void ExpressionExecutor::Execute(const BoundCaseExpression &expr, ExpressionState *state_p, const SelectionVector *sel,

--- a/src/execution/expression_executor/execute_conjunction.cpp
+++ b/src/execution/expression_executor/execute_conjunction.cpp
@@ -22,7 +22,7 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundConju
 		result->AddChild(child.get());
 	}
 	result->Finalize();
-	return move(result);
+	return result;
 }
 
 void ExpressionExecutor::Execute(const BoundConjunctionExpression &expr, ExpressionState *state,

--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -13,7 +13,7 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundFunct
 	if (expr.function.init_local_state) {
 		result->local_state = expr.function.init_local_state(expr, expr.bind_info.get());
 	}
-	return move(result);
+	return result;
 }
 
 void ExpressionExecutor::Execute(const BoundFunctionExpression &expr, ExpressionState *state,

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -58,7 +58,7 @@ unique_ptr<IndexScanState> ART::InitializeScanSinglePredicate(Transaction &trans
 	auto result = make_unique<ARTIndexScanState>();
 	result->values[0] = value;
 	result->expressions[0] = expression_type;
-	return move(result);
+	return result;
 }
 
 unique_ptr<IndexScanState> ART::InitializeScanTwoPredicates(Transaction &transaction, Value low_value,
@@ -69,7 +69,7 @@ unique_ptr<IndexScanState> ART::InitializeScanTwoPredicates(Transaction &transac
 	result->expressions[0] = low_expression_type;
 	result->values[1] = high_value;
 	result->expressions[1] = high_expression_type;
-	return move(result);
+	return result;
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/join/perfect_hash_join_executor.cpp
+++ b/src/execution/operator/join/perfect_hash_join_executor.cpp
@@ -143,7 +143,7 @@ unique_ptr<OperatorState> PerfectHashJoinExecutor::GetOperatorState(ClientContex
 	state->build_sel_vec.Initialize(STANDARD_VECTOR_SIZE);
 	state->probe_sel_vec.Initialize(STANDARD_VECTOR_SIZE);
 	state->seq_sel_vec.Initialize(STANDARD_VECTOR_SIZE);
-	return move(state);
+	return state;
 }
 
 OperatorResultType PerfectHashJoinExecutor::ProbePerfectHashTable(ExecutionContext &context, DataChunk &input,

--- a/src/execution/operator/join/physical_delim_join.cpp
+++ b/src/execution/operator/join/physical_delim_join.cpp
@@ -60,13 +60,13 @@ unique_ptr<GlobalSinkState> PhysicalDelimJoin::GetGlobalSinkState(ClientContext 
 	if (delim_scans.size() > 1) {
 		PhysicalHashAggregate::SetMultiScan(*distinct->sink_state);
 	}
-	return move(state);
+	return state;
 }
 
 unique_ptr<LocalSinkState> PhysicalDelimJoin::GetLocalSinkState(ExecutionContext &context) const {
 	auto state = make_unique<DelimJoinLocalState>();
 	state->distinct_state = distinct->GetLocalSinkState(context);
-	return move(state);
+	return state;
 }
 
 SinkResultType PhysicalDelimJoin::Sink(ExecutionContext &context, GlobalSinkState &state_p, LocalSinkState &lstate_p,

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -110,7 +110,7 @@ unique_ptr<GlobalSinkState> PhysicalHashJoin::GetGlobalSinkState(ClientContext &
 	// for perfect hash join
 	state->perfect_join_executor =
 	    make_unique<PerfectHashJoinExecutor>(*this, *state->hash_table, perfect_join_statistics);
-	return move(state);
+	return state;
 }
 
 unique_ptr<LocalSinkState> PhysicalHashJoin::GetLocalSinkState(ExecutionContext &context) const {
@@ -122,7 +122,7 @@ unique_ptr<LocalSinkState> PhysicalHashJoin::GetLocalSinkState(ExecutionContext 
 		state->build_executor.AddExpression(*cond.right);
 	}
 	state->join_keys.Initialize(condition_types);
-	return move(state);
+	return state;
 }
 
 SinkResultType PhysicalHashJoin::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate_p,
@@ -212,7 +212,7 @@ unique_ptr<OperatorState> PhysicalHashJoin::GetOperatorState(ClientContext &cont
 			state->probe_executor.AddExpression(*cond.left);
 		}
 	}
-	return move(state);
+	return state;
 }
 
 OperatorResultType PhysicalHashJoin::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,

--- a/src/execution/operator/order/physical_order.cpp
+++ b/src/execution/operator/order/physical_order.cpp
@@ -54,7 +54,7 @@ unique_ptr<GlobalSinkState> PhysicalOrder::GetGlobalSinkState(ClientContext &con
 	idx_t max_memory = BufferManager::GetBufferManager(context).GetMaxMemory();
 	idx_t num_threads = TaskScheduler::GetScheduler(context).NumberOfThreads();
 	state->memory_per_thread = (max_memory / num_threads) / 4;
-	return move(state);
+	return state;
 }
 
 unique_ptr<LocalSinkState> PhysicalOrder::GetLocalSinkState(ExecutionContext &context) const {
@@ -66,7 +66,7 @@ unique_ptr<LocalSinkState> PhysicalOrder::GetLocalSinkState(ExecutionContext &co
 		result->executor.AddExpression(*order.expression);
 	}
 	result->sort.Initialize(types);
-	return move(result);
+	return result;
 }
 
 SinkResultType PhysicalOrder::Sink(ExecutionContext &context, GlobalSinkState &gstate_p, LocalSinkState &lstate_p,

--- a/src/execution/operator/schema/physical_create_table_as.cpp
+++ b/src/execution/operator/schema/physical_create_table_as.cpp
@@ -30,7 +30,7 @@ unique_ptr<GlobalSinkState> PhysicalCreateTableAs::GetGlobalSinkState(ClientCont
 	auto sink = make_unique<CreateTableAsGlobalState>();
 	auto &catalog = Catalog::GetCatalog(context);
 	sink->table = (TableCatalogEntry *)catalog.CreateTable(context, schema, info.get());
-	return move(sink);
+	return sink;
 }
 
 SinkResultType PhysicalCreateTableAs::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate_p,

--- a/src/execution/physical_plan/plan_aggregate.cpp
+++ b/src/execution/physical_plan/plan_aggregate.cpp
@@ -207,7 +207,7 @@ PhysicalPlanGenerator::ExtractAggregateExpressions(unique_ptr<PhysicalOperator> 
 	}
 	auto projection = make_unique<PhysicalProjection>(move(types), move(expressions), child->estimated_cardinality);
 	projection->children.push_back(move(child));
-	return move(projection);
+	return projection;
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_chunk_get.cpp
+++ b/src/execution/physical_plan/plan_chunk_get.cpp
@@ -13,7 +13,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalChunkGet &
 	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN, op.estimated_cardinality);
 	chunk_scan->owned_collection = move(op.collection);
 	chunk_scan->collection = chunk_scan->owned_collection.get();
-	return move(chunk_scan);
+	return chunk_scan;
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_copy_to_file.cpp
+++ b/src/execution/physical_plan/plan_copy_to_file.cpp
@@ -10,7 +10,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile
 	auto copy = make_unique<PhysicalCopyToFile>(op.types, op.function, move(op.bind_data), op.estimated_cardinality);
 
 	copy->children.push_back(move(plan));
-	return move(copy);
+	return copy;
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_delete.cpp
+++ b/src/execution/physical_plan/plan_delete.cpp
@@ -20,7 +20,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelete &op
 	auto del =
 	    make_unique<PhysicalDelete>(op.types, *op.table, *op.table->storage, bound_ref.index, op.estimated_cardinality);
 	del->children.push_back(move(plan));
-	return move(del);
+	return del;
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_delim_get.cpp
+++ b/src/execution/physical_plan/plan_delim_get.cpp
@@ -10,7 +10,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelimGet &
 	// create a PhysicalChunkScan without an owned_collection, the collection will be added later
 	auto chunk_scan =
 	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::DELIM_SCAN, op.estimated_cardinality);
-	return move(chunk_scan);
+	return chunk_scan;
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_explain.cpp
+++ b/src/execution/physical_plan/plan_explain.cpp
@@ -15,7 +15,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExplain &o
 	if (op.explain_type == ExplainType::EXPLAIN_ANALYZE) {
 		auto result = make_unique<PhysicalExplainAnalyze>(op.types);
 		result->children.push_back(move(plan));
-		return move(result);
+		return result;
 	}
 
 	op.physical_plan = plan->ToString();
@@ -56,7 +56,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExplain &o
 	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN, op.estimated_cardinality);
 	chunk_scan->owned_collection = move(collection);
 	chunk_scan->collection = chunk_scan->owned_collection.get();
-	return move(chunk_scan);
+	return chunk_scan;
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_export.cpp
+++ b/src/execution/physical_plan/plan_export.cpp
@@ -17,7 +17,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExport &op
 		auto plan = CreatePlan(*op.children[0]);
 		export_node->children.push_back(move(plan));
 	}
-	return move(export_node);
+	return export_node;
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_expression_get.cpp
+++ b/src/execution/physical_plan/plan_expression_get.cpp
@@ -28,7 +28,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExpression
 		expr_scan->EvaluateExpression(expression_idx, nullptr, chunk);
 		chunk_scan->owned_collection->Append(chunk);
 	}
-	return move(chunk_scan);
+	return chunk_scan;
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -37,7 +37,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 		auto node = make_unique<PhysicalTableInOutFunction>(op.returned_types, op.function, move(op.bind_data),
 		                                                    op.column_ids, op.estimated_cardinality);
 		node->children.push_back(CreatePlan(move(op.children[0])));
-		return move(node);
+		return node;
 	}
 
 	unique_ptr<TableFilterSet> table_filters;
@@ -66,7 +66,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 				// a projection is not necessary if all columns have been requested in-order
 				// in that case we just return the node
 
-				return move(node);
+				return node;
 			}
 		}
 		// push a projection on top that does the projection

--- a/src/execution/physical_plan/plan_recursive_cte.cpp
+++ b/src/execution/physical_plan/plan_recursive_cte.cpp
@@ -38,7 +38,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCTERef &op
 		throw Exception("Referenced recursive CTE does not exist.");
 	}
 	chunk_scan->collection = cte->second.get();
-	return move(chunk_scan);
+	return chunk_scan;
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_show_select.cpp
+++ b/src/execution/physical_plan/plan_show_select.cpp
@@ -41,7 +41,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalShow &op) 
 	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN, op.estimated_cardinality);
 	chunk_scan->owned_collection = move(collection);
 	chunk_scan->collection = chunk_scan->owned_collection.get();
-	return move(chunk_scan);
+	return chunk_scan;
 }
 
 } // namespace duckdb

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -265,7 +265,7 @@ unique_ptr<FunctionData> AggregateFunction::BindSortedAggregate(AggregateFunctio
 	    SortedAggregateFunction::Finalize, SortedAggregateFunction::SimpleUpdate, nullptr,
 	    AggregateFunction::StateDestroy<SortedAggregateState, SortedAggregateFunction>);
 
-	return move(sorted_bind);
+	return sorted_bind;
 }
 
 } // namespace duckdb

--- a/src/function/scalar/date/date_part.cpp
+++ b/src/function/scalar/date/date_part.cpp
@@ -179,7 +179,7 @@ static unique_ptr<BaseStatistics> PropagateDatePartStatistics(vector<unique_ptr<
 	if (child_stats[0]->validity_stats) {
 		result->validity_stats = child_stats[0]->validity_stats->Copy();
 	}
-	return move(result);
+	return result;
 }
 
 template <int64_t MIN, int64_t MAX>
@@ -193,7 +193,7 @@ static unique_ptr<BaseStatistics> PropagateSimpleDatePartStatistics(vector<uniqu
 	} else if (child_stats[0]->validity_stats) {
 		result->validity_stats = child_stats[0]->validity_stats->Copy();
 	}
-	return move(result);
+	return result;
 }
 
 struct DatePart {

--- a/src/function/scalar/list/list_value.cpp
+++ b/src/function/scalar/list/list_value.cpp
@@ -55,10 +55,10 @@ unique_ptr<BaseStatistics> ListValueStats(ClientContext &context, BoundFunctionE
 			list_stats->child_stats->Merge(*child_stats[i]);
 		} else {
 			list_stats->child_stats.reset();
-			return move(list_stats);
+			return list_stats;
 		}
 	}
-	return move(list_stats);
+	return list_stats;
 }
 
 void ListValueFun::RegisterFunction(BuiltinFunctions &set) {

--- a/src/function/scalar/operators/arithmetic.cpp
+++ b/src/function/scalar/operators/arithmetic.cpp
@@ -155,7 +155,7 @@ static unique_ptr<BaseStatistics> PropagateNumericStats(ClientContext &context, 
 	}
 	auto stats = make_unique<NumericStatistics>(expr.return_type, move(new_min), move(new_max));
 	stats->validity_stats = ValidityStatistics::Combine(lstats.validity_stats, rstats.validity_stats);
-	return move(stats);
+	return stats;
 }
 
 template <class OP, class OPOVERFLOWCHECK, bool IS_SUBTRACT = false>
@@ -421,7 +421,7 @@ static unique_ptr<BaseStatistics> NegateBindStatistics(ClientContext &context, B
 	if (istats.validity_stats) {
 		stats->validity_stats = istats.validity_stats->Copy();
 	}
-	return move(stats);
+	return stats;
 }
 
 ScalarFunction SubtractFun::GetFunction(const LogicalType &type) {

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -188,7 +188,7 @@ unique_ptr<FunctionData> RegexpReplaceBindData::Copy() {
 	auto copy = make_unique<RegexpReplaceBindData>();
 	copy->options = options;
 	copy->global_replace = global_replace;
-	return move(copy);
+	return copy;
 }
 
 static unique_ptr<FunctionData> RegexReplaceBind(ClientContext &context, ScalarFunction &bound_function,

--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -242,7 +242,7 @@ unique_ptr<FunctionOperatorData> ArrowTableFunction::ArrowScanInit(ClientContext
 	result->column_ids = column_ids;
 	auto &data = (const ArrowScanFunctionData &)*bind_data;
 	result->stream = ProduceArrowScan(data, column_ids, filters);
-	return move(result);
+	return result;
 }
 
 void ShiftRight(unsigned char *ar, int size, int shift) {
@@ -1063,7 +1063,7 @@ unique_ptr<ParallelState> ArrowTableFunction::ArrowScanInitParallelState(ClientC
 	auto &bind_data = (const ArrowScanFunctionData &)*bind_data_p;
 	auto result = make_unique<ParallelArrowScanState>();
 	result->stream = ProduceArrowScan(bind_data, column_ids, filters);
-	return move(result);
+	return result;
 }
 
 bool ArrowTableFunction::ArrowScanParallelStateNext(ClientContext &context, const FunctionData *bind_data_p,
@@ -1095,7 +1095,7 @@ ArrowTableFunction::ArrowScanParallelInit(ClientContext &context, const Function
 	result->column_ids = column_ids;
 	result->filters = filters;
 	ArrowScanParallelStateNext(context, bind_data_p, result.get(), state);
-	return move(result);
+	return result;
 }
 
 unique_ptr<NodeStatistics> ArrowTableFunction::ArrowScanCardinality(ClientContext &context, const FunctionData *data) {

--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -177,7 +177,7 @@ static unique_ptr<FunctionData> WriteCSVBind(ClientContext &context, CopyInfo &i
 	bind_data->Finalize();
 	bind_data->is_simple = bind_data->options.delimiter.size() == 1 && bind_data->options.escape.size() == 1 &&
 	                       bind_data->options.quote.size() == 1;
-	return move(bind_data);
+	return bind_data;
 }
 
 static unique_ptr<FunctionData> ReadCSVBind(ClientContext &context, CopyInfo &info, vector<string> &expected_names,
@@ -263,7 +263,7 @@ static unique_ptr<FunctionData> ReadCSVBind(ClientContext &context, CopyInfo &in
 		options.force_not_null.resize(expected_types.size(), false);
 	}
 	bind_data->Finalize();
-	return move(bind_data);
+	return bind_data;
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/function/table/glob.cpp
+++ b/src/function/table/glob.cpp
@@ -24,7 +24,7 @@ static unique_ptr<FunctionData> GlobFunctionBind(ClientContext &context, vector<
 	result->files = fs.Glob(inputs[0].str_value);
 	return_types.emplace_back(LogicalType::VARCHAR);
 	names.emplace_back("file");
-	return move(result);
+	return result;
 }
 
 struct GlobFunctionState : public FunctionOperatorData {

--- a/src/function/table/range.cpp
+++ b/src/function/table/range.cpp
@@ -56,7 +56,7 @@ RangeFunctionBind(ClientContext &context, vector<Value> &inputs, unordered_map<s
 	} else {
 		names.emplace_back("range");
 	}
-	return move(result);
+	return result;
 }
 
 struct RangeFunctionState : public FunctionOperatorData {
@@ -167,7 +167,7 @@ RangeDateTimeBind(ClientContext &context, vector<Value> &inputs, unordered_map<s
 		result->inclusive_bound = false;
 		names.emplace_back("range");
 	}
-	return move(result);
+	return result;
 }
 
 struct RangeDateTimeState : public FunctionOperatorData {

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -147,7 +147,7 @@ static unique_ptr<FunctionData> ReadCSVBind(ClientContext &context, vector<Value
 		return_types.emplace_back(LogicalType::VARCHAR);
 		names.emplace_back("filename");
 	}
-	return move(result);
+	return result;
 }
 
 struct ReadCSVOperatorData : public FunctionOperatorData {
@@ -171,7 +171,7 @@ static unique_ptr<FunctionOperatorData> ReadCSVInit(ClientContext &context, cons
 	bind_data.bytes_read = 0;
 	bind_data.file_size = result->csv_reader->GetFileSize();
 	result->file_index = 1;
-	return move(result);
+	return result;
 }
 
 static unique_ptr<FunctionData> ReadCSVAutoBind(ClientContext &context, vector<Value> &inputs,

--- a/src/function/table/system/duckdb_columns.cpp
+++ b/src/function/table/system/duckdb_columns.cpp
@@ -86,7 +86,7 @@ unique_ptr<FunctionOperatorData> DuckDBColumnsInit(ClientContext &context, const
 	// check the temp schema as well
 	context.temporary_objects->Scan(context, CatalogType::TABLE_ENTRY,
 	                                [&](CatalogEntry *entry) { result->entries.push_back(entry); });
-	return move(result);
+	return result;
 }
 
 namespace { // anonymous namespace for the ColumnHelper classes for working with tables/views

--- a/src/function/table/system/duckdb_constraints.cpp
+++ b/src/function/table/system/duckdb_constraints.cpp
@@ -78,7 +78,7 @@ unique_ptr<FunctionOperatorData> DuckDBConstraintsInit(ClientContext &context, c
 	// check the temp schema as well
 	context.temporary_objects->Scan(context, CatalogType::TABLE_ENTRY,
 	                                [&](CatalogEntry *entry) { result->entries.push_back(entry); });
-	return move(result);
+	return result;
 }
 
 void DuckDBConstraintsFunction(ClientContext &context, const FunctionData *bind_data,

--- a/src/function/table/system/duckdb_dependencies.cpp
+++ b/src/function/table/system/duckdb_dependencies.cpp
@@ -66,7 +66,7 @@ unique_ptr<FunctionOperatorData> DuckDBDependenciesInit(ClientContext &context, 
 		result->entries.push_back(info);
 	});
 
-	return move(result);
+	return result;
 }
 
 void DuckDBDependenciesFunction(ClientContext &context, const FunctionData *bind_data,

--- a/src/function/table/system/duckdb_functions.cpp
+++ b/src/function/table/system/duckdb_functions.cpp
@@ -80,7 +80,7 @@ unique_ptr<FunctionOperatorData> DuckDBFunctionsInit(ClientContext &context, con
 
 	std::sort(result->entries.begin(), result->entries.end(),
 	          [&](CatalogEntry *a, CatalogEntry *b) { return (int)a->type < (int)b->type; });
-	return move(result);
+	return result;
 }
 
 struct ScalarFunctionExtractor {

--- a/src/function/table/system/duckdb_indexes.cpp
+++ b/src/function/table/system/duckdb_indexes.cpp
@@ -69,7 +69,7 @@ unique_ptr<FunctionOperatorData> DuckDBIndexesInit(ClientContext &context, const
 	// check the temp schema as well
 	context.temporary_objects->Scan(context, CatalogType::INDEX_ENTRY,
 	                                [&](CatalogEntry *entry) { result->entries.push_back(entry); });
-	return move(result);
+	return result;
 }
 
 void DuckDBIndexesFunction(ClientContext &context, const FunctionData *bind_data, FunctionOperatorData *operator_state,

--- a/src/function/table/system/duckdb_schemas.cpp
+++ b/src/function/table/system/duckdb_schemas.cpp
@@ -45,7 +45,7 @@ unique_ptr<FunctionOperatorData> DuckDBSchemasInit(ClientContext &context, const
 	// get the temp schema as well
 	result->entries.push_back(context.temporary_objects.get());
 
-	return move(result);
+	return result;
 }
 
 void DuckDBSchemasFunction(ClientContext &context, const FunctionData *bind_data, FunctionOperatorData *operator_state,

--- a/src/function/table/system/duckdb_sequences.cpp
+++ b/src/function/table/system/duckdb_sequences.cpp
@@ -75,7 +75,7 @@ unique_ptr<FunctionOperatorData> DuckDBSequencesInit(ClientContext &context, con
 	// check the temp schema as well
 	context.temporary_objects->Scan(context, CatalogType::SEQUENCE_ENTRY,
 	                                [&](CatalogEntry *entry) { result->entries.push_back(entry); });
-	return move(result);
+	return result;
 }
 
 void DuckDBSequencesFunction(ClientContext &context, const FunctionData *bind_data,

--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -72,7 +72,7 @@ unique_ptr<FunctionOperatorData> DuckDBSettingsInit(ClientContext &context, cons
 
 		result->settings.push_back(move(value));
 	}
-	return move(result);
+	return result;
 }
 
 void DuckDBSettingsFunction(ClientContext &context, const FunctionData *bind_data, FunctionOperatorData *operator_state,

--- a/src/function/table/system/duckdb_tables.cpp
+++ b/src/function/table/system/duckdb_tables.cpp
@@ -76,7 +76,7 @@ unique_ptr<FunctionOperatorData> DuckDBTablesInit(ClientContext &context, const 
 	// check the temp schema as well
 	context.temporary_objects->Scan(context, CatalogType::TABLE_ENTRY,
 	                                [&](CatalogEntry *entry) { result->entries.push_back(entry); });
-	return move(result);
+	return result;
 }
 
 static bool TableHasPrimaryKey(TableCatalogEntry &table) {

--- a/src/function/table/system/duckdb_types.cpp
+++ b/src/function/table/system/duckdb_types.cpp
@@ -51,7 +51,7 @@ unique_ptr<FunctionOperatorData> DuckDBTypesInit(ClientContext &context, const F
 	auto result = make_unique<DuckDBTypesData>();
 	result->types = LogicalType::AllTypes();
 	// FIXME: add user-defined types here (when we have them)
-	return move(result);
+	return result;
 }
 
 void DuckDBTypesFunction(ClientContext &context, const FunctionData *bind_data, FunctionOperatorData *operator_state,

--- a/src/function/table/system/duckdb_views.cpp
+++ b/src/function/table/system/duckdb_views.cpp
@@ -61,7 +61,7 @@ unique_ptr<FunctionOperatorData> DuckDBViewsInit(ClientContext &context, const F
 	// check the temp schema as well
 	context.temporary_objects->Scan(context, CatalogType::VIEW_ENTRY,
 	                                [&](CatalogEntry *entry) { result->entries.push_back(entry); });
-	return move(result);
+	return result;
 }
 
 void DuckDBViewsFunction(ClientContext &context, const FunctionData *bind_data, FunctionOperatorData *operator_state,

--- a/src/function/table/system/pragma_collations.cpp
+++ b/src/function/table/system/pragma_collations.cpp
@@ -36,7 +36,7 @@ unique_ptr<FunctionOperatorData> PragmaCollateInit(ClientContext &context, const
 		             [&](CatalogEntry *entry) { result->entries.push_back(entry->name); });
 	});
 
-	return move(result);
+	return result;
 }
 
 static void PragmaCollateFunction(ClientContext &context, const FunctionData *bind_data,

--- a/src/function/table/system/pragma_functions.cpp
+++ b/src/function/table/system/pragma_functions.cpp
@@ -55,7 +55,7 @@ unique_ptr<FunctionOperatorData> PragmaFunctionsInit(ClientContext &context, con
 		             [&](CatalogEntry *entry) { result->entries.push_back(entry); });
 	});
 
-	return move(result);
+	return result;
 }
 
 void AddFunction(BaseScalarFunction &f, idx_t &count, DataChunk &output, bool is_aggregate) {

--- a/src/function/table/system/pragma_storage_info.cpp
+++ b/src/function/table/system/pragma_storage_info.cpp
@@ -89,7 +89,7 @@ static unique_ptr<FunctionData> PragmaStorageInfoBind(ClientContext &context, ve
 
 	auto result = make_unique<PragmaStorageFunctionData>(table_entry);
 	result->storage_info = table_entry->storage->GetStorageInfo();
-	return move(result);
+	return result;
 }
 
 unique_ptr<FunctionOperatorData> PragmaStorageInfoInit(ClientContext &context, const FunctionData *bind_data,

--- a/src/function/table/system/test_all_types.cpp
+++ b/src/function/table/system/test_all_types.cpp
@@ -190,7 +190,7 @@ unique_ptr<FunctionOperatorData> TestAllTypesInit(ClientContext &context, const 
 		result->entries[1].push_back(move(test_type.max_value));
 		result->entries[2].emplace_back(move(test_type.type));
 	}
-	return move(result);
+	return result;
 }
 
 void TestAllTypesFunction(ClientContext &context, const FunctionData *bind_data, FunctionOperatorData *operator_state,

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -38,7 +38,7 @@ static unique_ptr<FunctionOperatorData> TableScanInit(ClientContext &context, co
 	result->scan_state.table_filters = filters->table_filters;
 	bind_data.table->storage->InitializeScan(transaction, result->scan_state, result->column_ids,
 	                                         filters->table_filters);
-	return move(result);
+	return result;
 }
 
 static unique_ptr<BaseStatistics> TableScanStatistics(ClientContext &context, const FunctionData *bind_data_p,
@@ -59,7 +59,7 @@ static unique_ptr<FunctionOperatorData> TableScanParallelInit(ClientContext &con
 	result->column_ids = column_ids;
 	result->scan_state.table_filters = filters->table_filters;
 	TableScanParallelStateNext(context, bind_data_p, result.get(), state);
-	return move(result);
+	return result;
 }
 
 static void TableScanFunc(ClientContext &context, const FunctionData *bind_data_p, FunctionOperatorData *operator_state,
@@ -91,7 +91,7 @@ unique_ptr<ParallelState> TableScanInitParallelState(ClientContext &context, con
 	auto &bind_data = (const TableScanBindData &)*bind_data_p;
 	auto result = make_unique<ParallelTableFunctionScanState>();
 	bind_data.table->storage->InitializeParallelScan(context, result->state);
-	return move(result);
+	return result;
 }
 
 bool TableScanParallelStateNext(ClientContext &context, const FunctionData *bind_data_p,
@@ -166,7 +166,7 @@ static unique_ptr<FunctionOperatorData> IndexScanInit(ClientContext &context, co
 	                                   filters->table_filters);
 
 	result->finished = false;
-	return move(result);
+	return result;
 }
 
 static void IndexScanFunction(ClientContext &context, const FunctionData *bind_data_p,

--- a/src/include/duckdb/optimizer/filter_combiner.hpp
+++ b/src/include/duckdb/optimizer/filter_combiner.hpp
@@ -83,7 +83,7 @@ private:
 			auto const_filter = make_unique<ConstantFilter>(comp_expr->type, const_value);
 			conj_filter->child_filters.push_back(move(const_filter));
 		}
-		return move(conj_filter);
+		return conj_filter;
 	}
 
 private:

--- a/src/include/duckdb/parser/parsed_data/create_aggregate_function_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_aggregate_function_info.hpp
@@ -34,7 +34,7 @@ public:
 	unique_ptr<CreateInfo> Copy() const override {
 		auto result = make_unique<CreateAggregateFunctionInfo>(functions);
 		CopyProperties(*result);
-		return move(result);
+		return result;
 	}
 };
 

--- a/src/include/duckdb/parser/parsed_data/create_collation_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_collation_info.hpp
@@ -35,7 +35,7 @@ public:
 	unique_ptr<CreateInfo> Copy() const override {
 		auto result = make_unique<CreateCollationInfo>(name, function, combinable, not_required_for_equality);
 		CopyProperties(*result);
-		return move(result);
+		return result;
 	}
 };
 

--- a/src/include/duckdb/parser/parsed_data/create_copy_function_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_copy_function_info.hpp
@@ -28,7 +28,7 @@ public:
 	unique_ptr<CreateInfo> Copy() const override {
 		auto result = make_unique<CreateCopyFunctionInfo>(function);
 		CopyProperties(*result);
-		return move(result);
+		return result;
 	}
 };
 

--- a/src/include/duckdb/parser/parsed_data/create_index_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_index_info.hpp
@@ -42,7 +42,7 @@ public:
 		for (auto &expr : expressions) {
 			result->expressions.push_back(expr->Copy());
 		}
-		return move(result);
+		return result;
 	}
 };
 

--- a/src/include/duckdb/parser/parsed_data/create_macro_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_macro_info.hpp
@@ -25,7 +25,7 @@ public:
 		result->function = function->Copy();
 		result->name = name;
 		CopyProperties(*result);
-		return move(result);
+		return result;
 	}
 };
 

--- a/src/include/duckdb/parser/parsed_data/create_pragma_function_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_pragma_function_info.hpp
@@ -33,7 +33,7 @@ public:
 	unique_ptr<CreateInfo> Copy() const override {
 		auto result = make_unique<CreatePragmaFunctionInfo>(functions[0].name, functions);
 		CopyProperties(*result);
-		return move(result);
+		return result;
 	}
 };
 

--- a/src/include/duckdb/parser/parsed_data/create_scalar_function_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_scalar_function_info.hpp
@@ -36,7 +36,7 @@ public:
 		set.functions = functions;
 		auto result = make_unique<CreateScalarFunctionInfo>(move(set));
 		CopyProperties(*result);
-		return move(result);
+		return result;
 	}
 };
 

--- a/src/include/duckdb/parser/parsed_data/create_schema_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_schema_info.hpp
@@ -20,7 +20,7 @@ public:
 	unique_ptr<CreateInfo> Copy() const override {
 		auto result = make_unique<CreateSchemaInfo>();
 		CopyProperties(*result);
-		return move(result);
+		return result;
 	}
 };
 

--- a/src/include/duckdb/parser/parsed_data/create_sequence_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_sequence_info.hpp
@@ -46,7 +46,7 @@ public:
 		result->max_value = max_value;
 		result->start_value = start_value;
 		result->cycle = cycle;
-		return move(result);
+		return result;
 	}
 };
 

--- a/src/include/duckdb/parser/parsed_data/create_table_function_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_table_function_info.hpp
@@ -32,7 +32,7 @@ public:
 		set.functions = functions;
 		auto result = make_unique<CreateTableFunctionInfo>(move(set));
 		CopyProperties(*result);
-		return move(result);
+		return result;
 	}
 };
 

--- a/src/include/duckdb/parser/parsed_data/create_table_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_table_info.hpp
@@ -44,7 +44,7 @@ public:
 		if (query) {
 			result->query = unique_ptr_cast<SQLStatement, SelectStatement>(query->Copy());
 		}
-		return move(result);
+		return result;
 	}
 };
 

--- a/src/include/duckdb/parser/parsed_data/create_type_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_type_info.hpp
@@ -31,7 +31,7 @@ public:
 		CopyProperties(*result);
 		result->name = name;
 		result->type = make_unique<LogicalType>(*type);
-		return move(result);
+		return result;
 	}
 };
 

--- a/src/include/duckdb/parser/parsed_data/create_view_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_view_info.hpp
@@ -36,7 +36,7 @@ public:
 		result->aliases = aliases;
 		result->types = types;
 		result->query = unique_ptr_cast<SQLStatement, SelectStatement>(query->Copy());
-		return move(result);
+		return result;
 	}
 };
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -222,7 +222,7 @@ unique_ptr<QueryResult> ClientContext::FetchResultInternal(ClientContextLock &lo
 		auto stream_result =
 		    make_unique<StreamQueryResult>(pending.statement_type, shared_from_this(), pending.types, pending.names);
 		active_query->open_result = stream_result.get();
-		return move(stream_result);
+		return stream_result;
 	}
 	// create a materialized result by continuously fetching
 	auto result = make_unique<MaterializedQueryResult>(pending.statement_type, pending.types, pending.names);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -240,7 +240,7 @@ unique_ptr<QueryResult> ClientContext::FetchResultInternal(ClientContextLock &lo
 #endif
 		result->collection.Append(*chunk);
 	}
-	return move(result);
+	return result;
 }
 
 shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatement(ClientContextLock &lock, const string &query,

--- a/src/main/relation/filter_relation.cpp
+++ b/src/main/relation/filter_relation.cpp
@@ -35,7 +35,7 @@ unique_ptr<QueryNode> FilterRelation::GetQueryNode() {
 		result->select_list.push_back(make_unique<StarExpression>());
 		result->from_table = child->GetTableRef();
 		result->where_clause = condition->Copy();
-		return move(result);
+		return result;
 	}
 }
 

--- a/src/main/relation/join_relation.cpp
+++ b/src/main/relation/join_relation.cpp
@@ -30,7 +30,7 @@ unique_ptr<QueryNode> JoinRelation::GetQueryNode() {
 	auto result = make_unique<SelectNode>();
 	result->select_list.push_back(make_unique<StarExpression>());
 	result->from_table = GetTableRef();
-	return move(result);
+	return result;
 }
 
 unique_ptr<TableRef> JoinRelation::GetTableRef() {
@@ -42,7 +42,7 @@ unique_ptr<TableRef> JoinRelation::GetTableRef() {
 	}
 	join_ref->using_columns = using_columns;
 	join_ref->type = join_type;
-	return move(join_ref);
+	return join_ref;
 }
 
 const vector<ColumnDefinition> &JoinRelation::Columns() {

--- a/src/main/relation/read_csv_relation.cpp
+++ b/src/main/relation/read_csv_relation.cpp
@@ -24,7 +24,7 @@ unique_ptr<QueryNode> ReadCSVRelation::GetQueryNode() {
 	auto result = make_unique<SelectNode>();
 	result->select_list.push_back(make_unique<StarExpression>());
 	result->from_table = GetTableRef();
-	return move(result);
+	return result;
 }
 
 unique_ptr<TableRef> ReadCSVRelation::GetTableRef() {
@@ -48,7 +48,7 @@ unique_ptr<TableRef> ReadCSVRelation::GetTableRef() {
 		                                                     make_unique<ConstantExpression>(Value::BOOLEAN(true))));
 	}
 	table_ref->function = make_unique<FunctionExpression>("read_csv", move(children));
-	return move(table_ref);
+	return table_ref;
 }
 
 string ReadCSVRelation::GetAlias() {

--- a/src/main/relation/setop_relation.cpp
+++ b/src/main/relation/setop_relation.cpp
@@ -19,7 +19,7 @@ unique_ptr<QueryNode> SetOpRelation::GetQueryNode() {
 	result->left = left->GetQueryNode();
 	result->right = right->GetQueryNode();
 	result->setop_type = setop_type;
-	return move(result);
+	return result;
 }
 
 string SetOpRelation::GetAlias() {

--- a/src/main/relation/table_function_relation.cpp
+++ b/src/main/relation/table_function_relation.cpp
@@ -31,7 +31,7 @@ unique_ptr<QueryNode> TableFunctionRelation::GetQueryNode() {
 	auto result = make_unique<SelectNode>();
 	result->select_list.push_back(make_unique<StarExpression>());
 	result->from_table = GetTableRef();
-	return move(result);
+	return result;
 }
 
 unique_ptr<TableRef> TableFunctionRelation::GetTableRef() {

--- a/src/main/relation/table_relation.cpp
+++ b/src/main/relation/table_relation.cpp
@@ -16,14 +16,14 @@ unique_ptr<QueryNode> TableRelation::GetQueryNode() {
 	auto result = make_unique<SelectNode>();
 	result->select_list.push_back(make_unique<StarExpression>());
 	result->from_table = GetTableRef();
-	return move(result);
+	return result;
 }
 
 unique_ptr<TableRef> TableRelation::GetTableRef() {
 	auto table_ref = make_unique<BaseTableRef>();
 	table_ref->schema_name = description->schema;
 	table_ref->table_name = description->table;
-	return move(table_ref);
+	return table_ref;
 }
 
 string TableRelation::GetAlias() {

--- a/src/main/relation/value_relation.cpp
+++ b/src/main/relation/value_relation.cpp
@@ -33,7 +33,7 @@ unique_ptr<QueryNode> ValueRelation::GetQueryNode() {
 	auto result = make_unique<SelectNode>();
 	result->select_list.push_back(make_unique<StarExpression>());
 	result->from_table = GetTableRef();
-	return move(result);
+	return result;
 }
 
 unique_ptr<TableRef> ValueRelation::GetTableRef() {
@@ -61,7 +61,7 @@ unique_ptr<TableRef> ValueRelation::GetTableRef() {
 		table_ref->values.push_back(move(copied_list));
 	}
 	table_ref->alias = GetAlias();
-	return move(table_ref);
+	return table_ref;
 }
 
 string ValueRelation::GetAlias() {

--- a/src/main/relation/view_relation.cpp
+++ b/src/main/relation/view_relation.cpp
@@ -16,14 +16,14 @@ unique_ptr<QueryNode> ViewRelation::GetQueryNode() {
 	auto result = make_unique<SelectNode>();
 	result->select_list.push_back(make_unique<StarExpression>());
 	result->from_table = GetTableRef();
-	return move(result);
+	return result;
 }
 
 unique_ptr<TableRef> ViewRelation::GetTableRef() {
 	auto table_ref = make_unique<BaseTableRef>();
 	table_ref->schema_name = schema_name;
 	table_ref->table_name = view_name;
-	return move(table_ref);
+	return table_ref;
 }
 
 string ViewRelation::GetAlias() {

--- a/src/optimizer/statistics/expression/propagate_cast.cpp
+++ b/src/optimizer/statistics/expression/propagate_cast.cpp
@@ -17,7 +17,7 @@ static unique_ptr<BaseStatistics> StatisticsOperationsNumericNumericCast(const B
 	if (input.validity_stats) {
 		stats->validity_stats = input.validity_stats->Copy();
 	}
-	return move(stats);
+	return stats;
 }
 
 static unique_ptr<BaseStatistics> StatisticsNumericCastSwitch(const BaseStatistics *input, const LogicalType &target) {

--- a/src/optimizer/statistics/expression/propagate_constant.cpp
+++ b/src/optimizer/statistics/expression/propagate_constant.cpp
@@ -23,7 +23,7 @@ unique_ptr<BaseStatistics> StatisticsPropagator::StatisticsFromValue(const Value
 	case PhysicalType::DOUBLE: {
 		auto result = make_unique<NumericStatistics>(input.type(), input, input);
 		result->validity_stats = make_unique<ValidityStatistics>(input.is_null, !input.is_null);
-		return move(result);
+		return result;
 	}
 	case PhysicalType::VARCHAR: {
 		auto result = make_unique<StringStatistics>(input.type());
@@ -32,7 +32,7 @@ unique_ptr<BaseStatistics> StatisticsPropagator::StatisticsFromValue(const Value
 			string_t str(input.str_value.c_str(), input.str_value.size());
 			result->Update(str);
 		}
-		return move(result);
+		return result;
 	}
 	case PhysicalType::STRUCT: {
 		auto result = make_unique<StructStatistics>(input.type());
@@ -47,7 +47,7 @@ unique_ptr<BaseStatistics> StatisticsPropagator::StatisticsFromValue(const Value
 				result->child_stats[i] = StatisticsFromValue(input.struct_value[i]);
 			}
 		}
-		return move(result);
+		return result;
 	}
 	case PhysicalType::LIST: {
 		auto result = make_unique<ListStatistics>(input.type());
@@ -64,7 +64,7 @@ unique_ptr<BaseStatistics> StatisticsPropagator::StatisticsFromValue(const Value
 				}
 			}
 		}
-		return move(result);
+		return result;
 	}
 	default:
 		return nullptr;

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -36,7 +36,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalAggr
 		statistics_map[aggregate_binding] = move(stats);
 	}
 	// the max cardinality of an aggregate is the max cardinality of the input (i.e. when every row is a unique group)
-	return move(node_stats);
+	return node_stats;
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -36,7 +36,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalAggr
 		statistics_map[aggregate_binding] = move(stats);
 	}
 	// the max cardinality of an aggregate is the max cardinality of the input (i.e. when every row is a unique group)
-	return node_stats;
+	return move(node_stats);
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/operator/propagate_filter.cpp
+++ b/src/optimizer/statistics/operator/propagate_filter.cpp
@@ -241,7 +241,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalFilt
 		}
 	}
 	// the max cardinality of a filter is the cardinality of the input (i.e. no tuples get filtered)
-	return node_stats;
+	return move(node_stats);
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/operator/propagate_filter.cpp
+++ b/src/optimizer/statistics/operator/propagate_filter.cpp
@@ -241,7 +241,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalFilt
 		}
 	}
 	// the max cardinality of a filter is the cardinality of the input (i.e. no tuples get filtered)
-	return move(node_stats);
+	return node_stats;
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/operator/propagate_get.cpp
+++ b/src/optimizer/statistics/operator/propagate_get.cpp
@@ -37,7 +37,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalGet 
 	}
 	if (!get.function.statistics) {
 		// no column statistics to get
-		return node_stats;
+		return move(node_stats);
 	}
 	for (idx_t i = 0; i < get.column_ids.size(); i++) {
 		auto stats = get.function.statistics(context, get.bind_data.get(), get.column_ids[i]);
@@ -93,7 +93,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalGet 
 			break;
 		}
 	}
-	return node_stats;
+	return move(node_stats);
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/operator/propagate_get.cpp
+++ b/src/optimizer/statistics/operator/propagate_get.cpp
@@ -37,7 +37,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalGet 
 	}
 	if (!get.function.statistics) {
 		// no column statistics to get
-		return move(node_stats);
+		return node_stats;
 	}
 	for (idx_t i = 0; i < get.column_ids.size(); i++) {
 		auto stats = get.function.statistics(context, get.bind_data.get(), get.column_ids[i]);
@@ -93,7 +93,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalGet 
 			break;
 		}
 	}
-	return move(node_stats);
+	return node_stats;
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/operator/propagate_join.cpp
+++ b/src/optimizer/statistics/operator/propagate_join.cpp
@@ -206,7 +206,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalJoin
 			}
 		}
 	}
-	return node_stats;
+	return move(node_stats);
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/operator/propagate_join.cpp
+++ b/src/optimizer/statistics/operator/propagate_join.cpp
@@ -206,7 +206,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalJoin
 			}
 		}
 	}
-	return move(node_stats);
+	return node_stats;
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/operator/propagate_order.cpp
+++ b/src/optimizer/statistics/operator/propagate_order.cpp
@@ -13,7 +13,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalOrde
 	for (auto &bound_order : order.orders) {
 		PropagateAndCompress(bound_order.expression, bound_order.stats);
 	}
-	return node_stats;
+	return move(node_stats);
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/operator/propagate_order.cpp
+++ b/src/optimizer/statistics/operator/propagate_order.cpp
@@ -13,7 +13,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalOrde
 	for (auto &bound_order : order.orders) {
 		PropagateAndCompress(bound_order.expression, bound_order.stats);
 	}
-	return move(node_stats);
+	return node_stats;
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/operator/propagate_projection.cpp
+++ b/src/optimizer/statistics/operator/propagate_projection.cpp
@@ -9,7 +9,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalProj
 	node_stats = PropagateStatistics(proj.children[0]);
 	if (proj.children[0]->type == LogicalOperatorType::LOGICAL_EMPTY_RESULT) {
 		ReplaceWithEmptyResult(*node_ptr);
-		return node_stats;
+		return move(node_stats);
 	}
 
 	// then propagate to each of the expressions
@@ -20,7 +20,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalProj
 			statistics_map.insert(make_pair(binding, move(stats)));
 		}
 	}
-	return node_stats;
+	return move(node_stats);
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/operator/propagate_projection.cpp
+++ b/src/optimizer/statistics/operator/propagate_projection.cpp
@@ -9,7 +9,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalProj
 	node_stats = PropagateStatistics(proj.children[0]);
 	if (proj.children[0]->type == LogicalOperatorType::LOGICAL_EMPTY_RESULT) {
 		ReplaceWithEmptyResult(*node_ptr);
-		return move(node_stats);
+		return node_stats;
 	}
 
 	// then propagate to each of the expressions
@@ -20,7 +20,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalProj
 			statistics_map.insert(make_pair(binding, move(stats)));
 		}
 	}
-	return move(node_stats);
+	return node_stats;
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/operator/propagate_window.cpp
+++ b/src/optimizer/statistics/operator/propagate_window.cpp
@@ -19,7 +19,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalWind
 			bound_order.stats = PropagateExpression(bound_order.expression);
 		}
 	}
-	return move(node_stats);
+	return node_stats;
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/operator/propagate_window.cpp
+++ b/src/optimizer/statistics/operator/propagate_window.cpp
@@ -19,7 +19,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalWind
 			bound_order.stats = PropagateExpression(bound_order.expression);
 		}
 	}
-	return node_stats;
+	return move(node_stats);
 }
 
 } // namespace duckdb

--- a/src/parser/constraints/unique_constraint.cpp
+++ b/src/parser/constraints/unique_constraint.cpp
@@ -31,7 +31,7 @@ unique_ptr<Constraint> UniqueConstraint::Copy() {
 	} else {
 		auto result = make_unique<UniqueConstraint>(index, is_primary_key);
 		result->columns = columns;
-		return move(result);
+		return result;
 	}
 }
 
@@ -60,7 +60,7 @@ unique_ptr<Constraint> UniqueConstraint::Deserialize(Deserializer &source) {
 		// single column parsed constraint
 		auto result = make_unique<UniqueConstraint>(index, is_primary_key);
 		result->columns = move(columns);
-		return move(result);
+		return result;
 	} else {
 		// column list parsed constraint
 		return make_unique<UniqueConstraint>(move(columns), is_primary_key);

--- a/src/parser/expression/between_expression.cpp
+++ b/src/parser/expression/between_expression.cpp
@@ -28,7 +28,7 @@ bool BetweenExpression::Equals(const BetweenExpression *a, const BetweenExpressi
 unique_ptr<ParsedExpression> BetweenExpression::Copy() const {
 	auto copy = make_unique<BetweenExpression>(input->Copy(), lower->Copy(), upper->Copy());
 	copy->CopyProperties(*this);
-	return move(copy);
+	return copy;
 }
 
 void BetweenExpression::Serialize(Serializer &serializer) {

--- a/src/parser/expression/case_expression.cpp
+++ b/src/parser/expression/case_expression.cpp
@@ -46,7 +46,7 @@ unique_ptr<ParsedExpression> CaseExpression::Copy() const {
 		copy->case_checks.push_back(move(new_check));
 	}
 	copy->else_expr = else_expr->Copy();
-	return move(copy);
+	return copy;
 }
 
 void CaseExpression::Serialize(Serializer &serializer) {
@@ -69,7 +69,7 @@ unique_ptr<ParsedExpression> CaseExpression::Deserialize(ExpressionType type, De
 		result->case_checks.push_back(move(new_check));
 	}
 	result->else_expr = ParsedExpression::Deserialize(source);
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/expression/cast_expression.cpp
+++ b/src/parser/expression/cast_expression.cpp
@@ -32,7 +32,7 @@ bool CastExpression::Equals(const CastExpression *a, const CastExpression *b) {
 unique_ptr<ParsedExpression> CastExpression::Copy() const {
 	auto copy = make_unique<CastExpression>(cast_type, child->Copy(), try_cast);
 	copy->CopyProperties(*this);
-	return move(copy);
+	return copy;
 }
 
 void CastExpression::Serialize(Serializer &serializer) {

--- a/src/parser/expression/collate_expression.cpp
+++ b/src/parser/expression/collate_expression.cpp
@@ -28,7 +28,7 @@ bool CollateExpression::Equals(const CollateExpression *a, const CollateExpressi
 unique_ptr<ParsedExpression> CollateExpression::Copy() const {
 	auto copy = make_unique<CollateExpression>(collation, child->Copy());
 	copy->CopyProperties(*this);
-	return move(copy);
+	return copy;
 }
 
 void CollateExpression::Serialize(Serializer &serializer) {

--- a/src/parser/expression/columnref_expression.cpp
+++ b/src/parser/expression/columnref_expression.cpp
@@ -85,7 +85,7 @@ unique_ptr<ParsedExpression> ColumnRefExpression::Deserialize(ExpressionType typ
 		column_names.push_back(source.Read<string>());
 	}
 	auto expression = make_unique<ColumnRefExpression>(move(column_names));
-	return move(expression);
+	return expression;
 }
 
 } // namespace duckdb

--- a/src/parser/expression/columnref_expression.cpp
+++ b/src/parser/expression/columnref_expression.cpp
@@ -67,7 +67,7 @@ hash_t ColumnRefExpression::Hash() const {
 unique_ptr<ParsedExpression> ColumnRefExpression::Copy() const {
 	auto copy = make_unique<ColumnRefExpression>(column_names);
 	copy->CopyProperties(*this);
-	return move(copy);
+	return copy;
 }
 
 void ColumnRefExpression::Serialize(Serializer &serializer) {

--- a/src/parser/expression/comparison_expression.cpp
+++ b/src/parser/expression/comparison_expression.cpp
@@ -30,7 +30,7 @@ bool ComparisonExpression::Equals(const ComparisonExpression *a, const Compariso
 unique_ptr<ParsedExpression> ComparisonExpression::Copy() const {
 	auto copy = make_unique<ComparisonExpression>(type, left->Copy(), right->Copy());
 	copy->CopyProperties(*this);
-	return move(copy);
+	return copy;
 }
 
 void ComparisonExpression::Serialize(Serializer &serializer) {

--- a/src/parser/expression/conjunction_expression.cpp
+++ b/src/parser/expression/conjunction_expression.cpp
@@ -54,7 +54,7 @@ unique_ptr<ParsedExpression> ConjunctionExpression::Copy() const {
 	}
 	auto copy = make_unique<ConjunctionExpression>(type, move(copy_children));
 	copy->CopyProperties(*this);
-	return move(copy);
+	return copy;
 }
 
 void ConjunctionExpression::Serialize(Serializer &serializer) {
@@ -65,7 +65,7 @@ void ConjunctionExpression::Serialize(Serializer &serializer) {
 unique_ptr<ParsedExpression> ConjunctionExpression::Deserialize(ExpressionType type, Deserializer &source) {
 	auto result = make_unique<ConjunctionExpression>(type);
 	source.ReadList<ParsedExpression>(result->children);
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/expression/constant_expression.cpp
+++ b/src/parser/expression/constant_expression.cpp
@@ -25,7 +25,7 @@ hash_t ConstantExpression::Hash() const {
 unique_ptr<ParsedExpression> ConstantExpression::Copy() const {
 	auto copy = make_unique<ConstantExpression>(value);
 	copy->CopyProperties(*this);
-	return move(copy);
+	return copy;
 }
 
 void ConstantExpression::Serialize(Serializer &serializer) {

--- a/src/parser/expression/default_expression.cpp
+++ b/src/parser/expression/default_expression.cpp
@@ -14,7 +14,7 @@ string DefaultExpression::ToString() const {
 unique_ptr<ParsedExpression> DefaultExpression::Copy() const {
 	auto copy = make_unique<DefaultExpression>();
 	copy->CopyProperties(*this);
-	return move(copy);
+	return copy;
 }
 
 unique_ptr<ParsedExpression> DefaultExpression::Deserialize(ExpressionType type, Deserializer &source) {

--- a/src/parser/expression/function_expression.cpp
+++ b/src/parser/expression/function_expression.cpp
@@ -104,7 +104,7 @@ unique_ptr<ParsedExpression> FunctionExpression::Copy() const {
 	                                            distinct, is_operator);
 	copy->schema = schema;
 	copy->CopyProperties(*this);
-	return move(copy);
+	return copy;
 }
 
 void FunctionExpression::Serialize(Serializer &serializer) {

--- a/src/parser/expression/operator_expression.cpp
+++ b/src/parser/expression/operator_expression.cpp
@@ -57,7 +57,7 @@ unique_ptr<ParsedExpression> OperatorExpression::Copy() const {
 	for (auto &it : children) {
 		copy->children.push_back(it->Copy());
 	}
-	return move(copy);
+	return copy;
 }
 
 void OperatorExpression::Serialize(Serializer &serializer) {

--- a/src/parser/expression/operator_expression.cpp
+++ b/src/parser/expression/operator_expression.cpp
@@ -68,7 +68,7 @@ void OperatorExpression::Serialize(Serializer &serializer) {
 unique_ptr<ParsedExpression> OperatorExpression::Deserialize(ExpressionType type, Deserializer &source) {
 	auto expression = make_unique<OperatorExpression>(type);
 	source.ReadList<ParsedExpression>(expression->children);
-	return move(expression);
+	return expression;
 }
 
 } // namespace duckdb

--- a/src/parser/expression/parameter_expression.cpp
+++ b/src/parser/expression/parameter_expression.cpp
@@ -19,7 +19,7 @@ unique_ptr<ParsedExpression> ParameterExpression::Copy() const {
 	auto copy = make_unique<ParameterExpression>();
 	copy->parameter_nr = parameter_nr;
 	copy->CopyProperties(*this);
-	return move(copy);
+	return copy;
 }
 
 hash_t ParameterExpression::Hash() const {

--- a/src/parser/expression/parameter_expression.cpp
+++ b/src/parser/expression/parameter_expression.cpp
@@ -35,7 +35,7 @@ void ParameterExpression::Serialize(Serializer &serializer) {
 unique_ptr<ParsedExpression> ParameterExpression::Deserialize(ExpressionType type, Deserializer &source) {
 	auto expression = make_unique<ParameterExpression>();
 	expression->parameter_nr = source.Read<idx_t>();
-	return move(expression);
+	return expression;
 }
 
 } // namespace duckdb

--- a/src/parser/expression/positional_reference_expression.cpp
+++ b/src/parser/expression/positional_reference_expression.cpp
@@ -38,7 +38,7 @@ void PositionalReferenceExpression::Serialize(Serializer &serializer) {
 
 unique_ptr<ParsedExpression> PositionalReferenceExpression::Deserialize(ExpressionType type, Deserializer &source) {
 	auto expression = make_unique<PositionalReferenceExpression>(source.Read<idx_t>());
-	return move(expression);
+	return expression;
 }
 
 } // namespace duckdb

--- a/src/parser/expression/positional_reference_expression.cpp
+++ b/src/parser/expression/positional_reference_expression.cpp
@@ -23,7 +23,7 @@ bool PositionalReferenceExpression::Equals(const PositionalReferenceExpression *
 unique_ptr<ParsedExpression> PositionalReferenceExpression::Copy() const {
 	auto copy = make_unique<PositionalReferenceExpression>(index);
 	copy->CopyProperties(*this);
-	return move(copy);
+	return copy;
 }
 
 hash_t PositionalReferenceExpression::Hash() const {

--- a/src/parser/expression/star_expression.cpp
+++ b/src/parser/expression/star_expression.cpp
@@ -86,7 +86,7 @@ unique_ptr<ParsedExpression> StarExpression::Deserialize(ExpressionType type, De
 		auto expr = ParsedExpression::Deserialize(source);
 		result->replace_list.insert(make_pair(name, move(expr)));
 	}
-	return move(result);
+	return result;
 }
 
 unique_ptr<ParsedExpression> StarExpression::Copy() const {
@@ -96,7 +96,7 @@ unique_ptr<ParsedExpression> StarExpression::Copy() const {
 		copy->replace_list[entry.first] = entry.second->Copy();
 	}
 	copy->CopyProperties(*this);
-	return move(copy);
+	return copy;
 }
 
 } // namespace duckdb

--- a/src/parser/expression/subquery_expression.cpp
+++ b/src/parser/expression/subquery_expression.cpp
@@ -32,7 +32,7 @@ unique_ptr<ParsedExpression> SubqueryExpression::Copy() const {
 	copy->subquery_type = subquery_type;
 	copy->child = child ? child->Copy() : nullptr;
 	copy->comparison_type = comparison_type;
-	return move(copy);
+	return copy;
 }
 
 void SubqueryExpression::Serialize(Serializer &serializer) {

--- a/src/parser/expression/subquery_expression.cpp
+++ b/src/parser/expression/subquery_expression.cpp
@@ -52,7 +52,7 @@ unique_ptr<ParsedExpression> SubqueryExpression::Deserialize(ExpressionType type
 	expression->subquery = move(subquery);
 	expression->child = source.ReadOptional<ParsedExpression>();
 	expression->comparison_type = source.Read<ExpressionType>();
-	return move(expression);
+	return expression;
 }
 
 } // namespace duckdb

--- a/src/parser/expression/window_expression.cpp
+++ b/src/parser/expression/window_expression.cpp
@@ -264,7 +264,7 @@ unique_ptr<ParsedExpression> WindowExpression::Deserialize(ExpressionType type, 
 	expr->offset_expr = source.ReadOptional<ParsedExpression>();
 	expr->default_expr = source.ReadOptional<ParsedExpression>();
 	expr->ignore_nulls = source.Read<bool>();
-	return move(expr);
+	return expr;
 }
 
 } // namespace duckdb

--- a/src/parser/query_node/recursive_cte_node.cpp
+++ b/src/parser/query_node/recursive_cte_node.cpp
@@ -31,7 +31,7 @@ unique_ptr<QueryNode> RecursiveCTENode::Copy() {
 	result->right = right->Copy();
 	result->aliases = aliases;
 	this->CopyProperties(*result);
-	return move(result);
+	return result;
 }
 
 void RecursiveCTENode::Serialize(Serializer &serializer) {
@@ -50,7 +50,7 @@ unique_ptr<QueryNode> RecursiveCTENode::Deserialize(Deserializer &source) {
 	result->left = QueryNode::Deserialize(source);
 	result->right = QueryNode::Deserialize(source);
 	source.ReadStringVector(result->aliases);
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/query_node/select_node.cpp
+++ b/src/parser/query_node/select_node.cpp
@@ -68,7 +68,7 @@ unique_ptr<QueryNode> SelectNode::Copy() {
 	result->qualify = qualify ? qualify->Copy() : nullptr;
 	result->sample = sample ? sample->Copy() : nullptr;
 	this->CopyProperties(*result);
-	return move(result);
+	return result;
 }
 
 void SelectNode::Serialize(Serializer &serializer) {
@@ -119,7 +119,7 @@ unique_ptr<QueryNode> SelectNode::Deserialize(Deserializer &source) {
 	result->sample = source.ReadOptional<SampleOptions>();
 	// qualify
 	result->qualify = source.ReadOptional<ParsedExpression>();
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/query_node/set_operation_node.cpp
+++ b/src/parser/query_node/set_operation_node.cpp
@@ -28,7 +28,7 @@ unique_ptr<QueryNode> SetOperationNode::Copy() {
 	result->left = left->Copy();
 	result->right = right->Copy();
 	this->CopyProperties(*result);
-	return move(result);
+	return result;
 }
 
 void SetOperationNode::Serialize(Serializer &serializer) {
@@ -43,7 +43,7 @@ unique_ptr<QueryNode> SetOperationNode::Deserialize(Deserializer &source) {
 	result->setop_type = source.Read<SetOperationType>();
 	result->left = QueryNode::Deserialize(source);
 	result->right = QueryNode::Deserialize(source);
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/result_modifier.cpp
+++ b/src/parser/result_modifier.cpp
@@ -53,7 +53,7 @@ unique_ptr<ResultModifier> LimitModifier::Copy() {
 	if (offset) {
 		copy->offset = offset->Copy();
 	}
-	return move(copy);
+	return copy;
 }
 
 void LimitModifier::Serialize(Serializer &serializer) {
@@ -66,7 +66,7 @@ unique_ptr<ResultModifier> LimitModifier::Deserialize(Deserializer &source) {
 	auto mod = make_unique<LimitModifier>();
 	mod->limit = source.ReadOptional<ParsedExpression>();
 	mod->offset = source.ReadOptional<ParsedExpression>();
-	return move(mod);
+	return mod;
 }
 
 bool DistinctModifier::Equals(const ResultModifier *other_p) const {
@@ -85,7 +85,7 @@ unique_ptr<ResultModifier> DistinctModifier::Copy() {
 	for (auto &expr : distinct_on_targets) {
 		copy->distinct_on_targets.push_back(expr->Copy());
 	}
-	return move(copy);
+	return copy;
 }
 
 void DistinctModifier::Serialize(Serializer &serializer) {
@@ -96,7 +96,7 @@ void DistinctModifier::Serialize(Serializer &serializer) {
 unique_ptr<ResultModifier> DistinctModifier::Deserialize(Deserializer &source) {
 	auto mod = make_unique<DistinctModifier>();
 	source.ReadList<ParsedExpression>(mod->distinct_on_targets);
-	return move(mod);
+	return mod;
 }
 
 bool OrderModifier::Equals(const ResultModifier *other_p) const {
@@ -123,7 +123,7 @@ unique_ptr<ResultModifier> OrderModifier::Copy() {
 	for (auto &order : orders) {
 		copy->orders.emplace_back(order.type, order.null_order, order.expression->Copy());
 	}
-	return move(copy);
+	return copy;
 }
 
 string OrderByNode::ToString() const {
@@ -169,7 +169,7 @@ unique_ptr<ResultModifier> OrderModifier::Deserialize(Deserializer &source) {
 	for (int64_t i = 0; i < order_count; i++) {
 		mod->orders.push_back(OrderByNode::Deserialize((source)));
 	}
-	return move(mod);
+	return mod;
 }
 
 bool LimitPercentModifier::Equals(const ResultModifier *other_p) const {
@@ -194,7 +194,7 @@ unique_ptr<ResultModifier> LimitPercentModifier::Copy() {
 	if (offset) {
 		copy->offset = offset->Copy();
 	}
-	return move(copy);
+	return copy;
 }
 
 void LimitPercentModifier::Serialize(Serializer &serializer) {
@@ -207,7 +207,7 @@ unique_ptr<ResultModifier> LimitPercentModifier::Deserialize(Deserializer &sourc
 	auto mod = make_unique<LimitPercentModifier>();
 	mod->limit = source.ReadOptional<ParsedExpression>();
 	mod->offset = source.ReadOptional<ParsedExpression>();
-	return move(mod);
+	return mod;
 }
 
 } // namespace duckdb

--- a/src/parser/statement/alter_statement.cpp
+++ b/src/parser/statement/alter_statement.cpp
@@ -10,7 +10,7 @@ AlterStatement::AlterStatement(unique_ptr<AlterInfo> info)
 
 unique_ptr<SQLStatement> AlterStatement::Copy() const {
 	auto result = make_unique<AlterStatement>(info->Copy());
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/statement/call_statement.cpp
+++ b/src/parser/statement/call_statement.cpp
@@ -8,7 +8,7 @@ CallStatement::CallStatement() : SQLStatement(StatementType::CALL_STATEMENT) {
 unique_ptr<SQLStatement> CallStatement::Copy() const {
 	auto result = make_unique<CallStatement>();
 	result->function = function->Copy();
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/statement/copy_statement.cpp
+++ b/src/parser/statement/copy_statement.cpp
@@ -11,7 +11,7 @@ unique_ptr<SQLStatement> CopyStatement::Copy() const {
 	if (select_statement) {
 		result->select_statement = select_statement->Copy();
 	}
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/statement/create_statement.cpp
+++ b/src/parser/statement/create_statement.cpp
@@ -8,7 +8,7 @@ CreateStatement::CreateStatement() : SQLStatement(StatementType::CREATE_STATEMEN
 unique_ptr<SQLStatement> CreateStatement::Copy() const {
 	auto result = make_unique<CreateStatement>();
 	result->info = info->Copy();
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/statement/delete_statement.cpp
+++ b/src/parser/statement/delete_statement.cpp
@@ -14,7 +14,7 @@ unique_ptr<SQLStatement> DeleteStatement::Copy() const {
 	for (auto &using_clause : using_clauses) {
 		result->using_clauses.push_back(using_clause->Copy());
 	}
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/statement/drop_statement.cpp
+++ b/src/parser/statement/drop_statement.cpp
@@ -8,7 +8,7 @@ DropStatement::DropStatement() : SQLStatement(StatementType::DROP_STATEMENT), in
 unique_ptr<SQLStatement> DropStatement::Copy() const {
 	auto result = make_unique<DropStatement>();
 	result->info = info->Copy();
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/statement/execute_statement.cpp
+++ b/src/parser/statement/execute_statement.cpp
@@ -11,7 +11,7 @@ unique_ptr<SQLStatement> ExecuteStatement::Copy() const {
 	for (auto &value : values) {
 		result->values.push_back(value->Copy());
 	}
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/statement/explain_statement.cpp
+++ b/src/parser/statement/explain_statement.cpp
@@ -8,7 +8,7 @@ ExplainStatement::ExplainStatement(unique_ptr<SQLStatement> stmt, ExplainType ex
 
 unique_ptr<SQLStatement> ExplainStatement::Copy() const {
 	auto result = make_unique<ExplainStatement>(stmt->Copy(), explain_type);
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/statement/insert_statement.cpp
+++ b/src/parser/statement/insert_statement.cpp
@@ -11,7 +11,7 @@ unique_ptr<SQLStatement> InsertStatement::Copy() const {
 	result->columns = columns;
 	result->table = table;
 	result->schema = schema;
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/statement/load_statement.cpp
+++ b/src/parser/statement/load_statement.cpp
@@ -8,7 +8,7 @@ LoadStatement::LoadStatement() : SQLStatement(StatementType::LOAD_STATEMENT) {
 unique_ptr<SQLStatement> LoadStatement::Copy() const {
 	auto result = make_unique<LoadStatement>();
 	result->info = info->Copy();
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/statement/pragma_statement.cpp
+++ b/src/parser/statement/pragma_statement.cpp
@@ -8,7 +8,7 @@ PragmaStatement::PragmaStatement() : SQLStatement(StatementType::PRAGMA_STATEMEN
 unique_ptr<SQLStatement> PragmaStatement::Copy() const {
 	auto result = make_unique<PragmaStatement>();
 	result->info = info->Copy();
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/statement/prepare_statement.cpp
+++ b/src/parser/statement/prepare_statement.cpp
@@ -9,7 +9,7 @@ unique_ptr<SQLStatement> PrepareStatement::Copy() const {
 	auto result = make_unique<PrepareStatement>();
 	result->statement = statement->Copy();
 	result->name = name;
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/statement/relation_statement.cpp
+++ b/src/parser/statement/relation_statement.cpp
@@ -8,7 +8,7 @@ RelationStatement::RelationStatement(shared_ptr<Relation> relation)
 
 unique_ptr<SQLStatement> RelationStatement::Copy() const {
 	auto result = make_unique<RelationStatement>(relation);
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/statement/select_statement.cpp
+++ b/src/parser/statement/select_statement.cpp
@@ -7,7 +7,7 @@ namespace duckdb {
 unique_ptr<SQLStatement> SelectStatement::Copy() const {
 	auto result = make_unique<SelectStatement>();
 	result->node = node->Copy();
-	return move(result);
+	return result;
 }
 
 void SelectStatement::Serialize(Serializer &serializer) {

--- a/src/parser/statement/show_statement.cpp
+++ b/src/parser/statement/show_statement.cpp
@@ -8,7 +8,7 @@ ShowStatement::ShowStatement() : SQLStatement(StatementType::SHOW_STATEMENT), in
 unique_ptr<SQLStatement> ShowStatement::Copy() const {
 	auto result = make_unique<ShowStatement>();
 	result->info = info->Copy();
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/statement/update_statement.cpp
+++ b/src/parser/statement/update_statement.cpp
@@ -18,7 +18,7 @@ unique_ptr<SQLStatement> UpdateStatement::Copy() const {
 	for (auto &expr : expressions) {
 		result->expressions.push_back(expr->Copy());
 	}
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/tableref/basetableref.cpp
+++ b/src/parser/tableref/basetableref.cpp
@@ -32,7 +32,7 @@ unique_ptr<TableRef> BaseTableRef::Deserialize(Deserializer &source) {
 	result->table_name = source.Read<string>();
 	source.ReadStringVector(result->column_name_alias);
 
-	return move(result);
+	return result;
 }
 
 unique_ptr<TableRef> BaseTableRef::Copy() {
@@ -43,6 +43,6 @@ unique_ptr<TableRef> BaseTableRef::Copy() {
 	copy->column_name_alias = column_name_alias;
 	CopyProperties(*copy);
 
-	return move(copy);
+	return copy;
 }
 } // namespace duckdb

--- a/src/parser/tableref/crossproductref.cpp
+++ b/src/parser/tableref/crossproductref.cpp
@@ -17,7 +17,7 @@ unique_ptr<TableRef> CrossProductRef::Copy() {
 	copy->left = left->Copy();
 	copy->right = right->Copy();
 	copy->alias = alias;
-	return move(copy);
+	return copy;
 }
 
 void CrossProductRef::Serialize(Serializer &serializer) {
@@ -37,7 +37,7 @@ unique_ptr<TableRef> CrossProductRef::Deserialize(Deserializer &source) {
 		return nullptr;
 	}
 
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/tableref/expressionlistref.cpp
+++ b/src/parser/tableref/expressionlistref.cpp
@@ -39,7 +39,7 @@ unique_ptr<TableRef> ExpressionListRef::Copy() {
 	result->expected_names = expected_names;
 	result->expected_types = expected_types;
 	CopyProperties(*result);
-	return move(result);
+	return result;
 }
 
 void ExpressionListRef::Serialize(Serializer &serializer) {
@@ -75,7 +75,7 @@ unique_ptr<TableRef> ExpressionListRef::Deserialize(Deserializer &source) {
 		source.ReadList<ParsedExpression>(value_list);
 		result->values.push_back(move(value_list));
 	}
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/tableref/joinref.cpp
+++ b/src/parser/tableref/joinref.cpp
@@ -33,7 +33,7 @@ unique_ptr<TableRef> JoinRef::Copy() {
 	copy->is_natural = is_natural;
 	copy->alias = alias;
 	copy->using_columns = using_columns;
-	return move(copy);
+	return copy;
 }
 
 void JoinRef::Serialize(Serializer &serializer) {
@@ -63,7 +63,7 @@ unique_ptr<TableRef> JoinRef::Deserialize(Deserializer &source) {
 	for (idx_t i = 0; i < count; i++) {
 		result->using_columns.push_back(source.Read<string>());
 	}
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/tableref/subqueryref.cpp
+++ b/src/parser/tableref/subqueryref.cpp
@@ -22,7 +22,7 @@ unique_ptr<TableRef> SubqueryRef::Copy() {
 	auto copy = make_unique<SubqueryRef>(unique_ptr_cast<SQLStatement, SelectStatement>(subquery->Copy()), alias);
 	copy->column_name_alias = column_name_alias;
 	CopyProperties(*copy);
-	return move(copy);
+	return copy;
 }
 
 void SubqueryRef::Serialize(Serializer &serializer) {
@@ -38,7 +38,7 @@ unique_ptr<TableRef> SubqueryRef::Deserialize(Deserializer &source) {
 	}
 	auto result = make_unique<SubqueryRef>(move(subquery));
 	source.ReadStringVector(result->column_name_alias);
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/tableref/table_function.cpp
+++ b/src/parser/tableref/table_function.cpp
@@ -30,7 +30,7 @@ unique_ptr<TableRef> TableFunctionRef::Deserialize(Deserializer &source) {
 	result->alias = source.Read<string>();
 	source.ReadStringVector(result->column_name_alias);
 
-	return move(result);
+	return result;
 }
 
 unique_ptr<TableRef> TableFunctionRef::Copy() {
@@ -40,7 +40,7 @@ unique_ptr<TableRef> TableFunctionRef::Copy() {
 	copy->column_name_alias = column_name_alias;
 	CopyProperties(*copy);
 
-	return move(copy);
+	return copy;
 }
 
 } // namespace duckdb

--- a/src/parser/transform/expression/transform_coalesce.cpp
+++ b/src/parser/transform/expression/transform_coalesce.cpp
@@ -17,7 +17,7 @@ unique_ptr<ParsedExpression> Transformer::TransformCoalesce(duckdb_libpgquery::P
 		auto value_expr = TransformExpression(reinterpret_cast<duckdb_libpgquery::PGNode *>(cell->data.ptr_value));
 		coalesce_op->children.push_back(move(value_expr));
 	}
-	return move(coalesce_op);
+	return coalesce_op;
 }
 
 } // namespace duckdb

--- a/src/parser/transform/expression/transform_columnref.cpp
+++ b/src/parser/transform/expression/transform_columnref.cpp
@@ -36,7 +36,7 @@ unique_ptr<ParsedExpression> Transformer::TransformStarExpression(duckdb_libpgqu
 			result->replace_list.insert(make_pair(move(exclude_entry), move(replace_expression)));
 		}
 	}
-	return move(result);
+	return result;
 }
 
 unique_ptr<ParsedExpression> Transformer::TransformColumnRef(duckdb_libpgquery::PGColumnRef *root) {

--- a/src/parser/transform/expression/transform_function.cpp
+++ b/src/parser/transform/expression/transform_function.cpp
@@ -192,7 +192,7 @@ unique_ptr<ParsedExpression> Transformer::TransformFuncCall(duckdb_libpgquery::P
 		TransformWindowDef(window_ref, expr.get());
 		TransformWindowFrame(window_spec, expr.get());
 		expr->query_location = root->location;
-		return move(expr);
+		return expr;
 	}
 
 	if (root->agg_ignore_nulls) {
@@ -258,7 +258,7 @@ unique_ptr<ParsedExpression> Transformer::TransformFuncCall(duckdb_libpgquery::P
 		check.then_expr = move(children[1]);
 		expr->case_checks.push_back(move(check));
 		expr->else_expr = move(children[2]);
-		return move(expr);
+		return expr;
 	} else if (lowercase_name == "construct_array") {
 		auto construct_array = make_unique<OperatorExpression>(ExpressionType::ARRAY_CONSTRUCTOR);
 		construct_array->children = move(children);

--- a/src/parser/transform/expression/transform_operator.cpp
+++ b/src/parser/transform/expression/transform_operator.cpp
@@ -40,7 +40,7 @@ unique_ptr<ParsedExpression> Transformer::TransformUnaryOperator(const string &o
 	// built-in operator function
 	auto result = make_unique<FunctionExpression>(schema, op, move(children));
 	result->is_operator = true;
-	return move(result);
+	return result;
 }
 
 unique_ptr<ParsedExpression> Transformer::TransformBinaryOperator(const string &op, unique_ptr<ParsedExpression> left,
@@ -59,7 +59,7 @@ unique_ptr<ParsedExpression> Transformer::TransformBinaryOperator(const string &
 		if (invert_similar) {
 			return make_unique<OperatorExpression>(ExpressionType::OPERATOR_NOT, move(result));
 		} else {
-			return move(result);
+			return result;
 		}
 	} else {
 		auto target_type = OperatorToExpressionType(op);
@@ -70,7 +70,7 @@ unique_ptr<ParsedExpression> Transformer::TransformBinaryOperator(const string &
 		// not a special operator: convert to a function expression
 		auto result = make_unique<FunctionExpression>(schema, op, move(children));
 		result->is_operator = true;
-		return move(result);
+		return result;
 	}
 }
 
@@ -124,7 +124,7 @@ unique_ptr<ParsedExpression> Transformer::TransformAExpr(duckdb_libpgquery::PGAE
 		auto result = make_unique<OperatorExpression>(operator_type, move(left_expr));
 		result->query_location = root->location;
 		TransformExpressionList(*((duckdb_libpgquery::PGList *)root->rexpr), result->children);
-		return move(result);
+		return result;
 	}
 	// rewrite NULLIF(a, b) into CASE WHEN a=b THEN NULL ELSE a END
 	case duckdb_libpgquery::PG_AEXPR_NULLIF: {
@@ -189,7 +189,7 @@ unique_ptr<ParsedExpression> Transformer::TransformAExpr(duckdb_libpgquery::PGAE
 		if (invert_similar) {
 			return make_unique<OperatorExpression>(ExpressionType::OPERATOR_NOT, move(result));
 		} else {
-			return move(result);
+			return result;
 		}
 	}
 	case duckdb_libpgquery::PG_AEXPR_NOT_DISTINCT: {

--- a/src/parser/transform/expression/transform_param_ref.cpp
+++ b/src/parser/transform/expression/transform_param_ref.cpp
@@ -13,7 +13,7 @@ unique_ptr<ParsedExpression> Transformer::TransformParamRef(duckdb_libpgquery::P
 		expr->parameter_nr = node->number;
 	}
 	SetParamCount(MaxValue<idx_t>(ParamCount(), expr->parameter_nr));
-	return move(expr);
+	return expr;
 }
 
 } // namespace duckdb

--- a/src/parser/transform/expression/transform_positional_reference.cpp
+++ b/src/parser/transform/expression/transform_positional_reference.cpp
@@ -10,7 +10,7 @@ unique_ptr<ParsedExpression> Transformer::TransformPositionalReference(duckdb_li
 	}
 	auto result = make_unique<PositionalReferenceExpression>(node->position);
 	result->query_location = node->location;
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/transform/statement/transform_checkpoint.cpp
+++ b/src/parser/transform/statement/transform_checkpoint.cpp
@@ -12,7 +12,7 @@ unique_ptr<SQLStatement> Transformer::TransformCheckpoint(duckdb_libpgquery::PGN
 	auto result = make_unique<CallStatement>();
 	result->function =
 	    make_unique<FunctionExpression>(checkpoint->force ? "force_checkpoint" : "checkpoint", move(children));
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/transform/statement/transform_drop.cpp
+++ b/src/parser/transform/statement/transform_drop.cpp
@@ -60,7 +60,7 @@ unique_ptr<SQLStatement> Transformer::TransformDrop(duckdb_libpgquery::PGNode *n
 	}
 	info.cascade = stmt->behavior == duckdb_libpgquery::PGDropBehavior::PG_DROP_CASCADE;
 	info.if_exists = stmt->missing_ok;
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/transform/statement/transform_insert.cpp
+++ b/src/parser/transform/statement/transform_insert.cpp
@@ -19,7 +19,7 @@ unique_ptr<TableRef> Transformer::TransformValuesList(duckdb_libpgquery::PGList 
 		result->values.push_back(move(insert_values));
 	}
 	result->alias = "valueslist";
-	return move(result);
+	return result;
 }
 
 unique_ptr<InsertStatement> Transformer::TransformInsert(duckdb_libpgquery::PGNode *node) {

--- a/src/parser/transform/statement/transform_pragma.cpp
+++ b/src/parser/transform/statement/transform_pragma.cpp
@@ -63,7 +63,7 @@ unique_ptr<SQLStatement> Transformer::TransformPragma(duckdb_libpgquery::PGNode 
 		throw InternalException("Unknown pragma type");
 	}
 
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/transform/statement/transform_show.cpp
+++ b/src/parser/transform/statement/transform_show.cpp
@@ -23,7 +23,7 @@ unique_ptr<SQLStatement> Transformer::TransformShow(duckdb_libpgquery::PGNode *n
 		select->from_table = move(basetable);
 
 		info.query = move(select);
-		return move(result);
+		return result;
 	}
 
 	auto result = make_unique<PragmaStatement>();
@@ -38,7 +38,7 @@ unique_ptr<SQLStatement> Transformer::TransformShow(duckdb_libpgquery::PGNode *n
 		info.parameters.emplace_back(stmt->name);
 	}
 
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/transform/tableref/transform_base_tableref.cpp
+++ b/src/parser/transform/tableref/transform_base_tableref.cpp
@@ -17,7 +17,7 @@ unique_ptr<TableRef> Transformer::TransformRangeVar(duckdb_libpgquery::PGRangeVa
 		result->sample = TransformSampleOptions(root->sample);
 	}
 	result->query_location = root->location;
-	return move(result);
+	return result;
 }
 
 QualifiedName Transformer::TransformQualifiedName(duckdb_libpgquery::PGRangeVar *root) {

--- a/src/parser/transform/tableref/transform_from.cpp
+++ b/src/parser/transform/tableref/transform_from.cpp
@@ -31,7 +31,7 @@ unique_ptr<TableRef> Transformer::TransformFrom(duckdb_libpgquery::PGList *root)
 			list_size++;
 			StackCheck(list_size);
 		}
-		return move(result);
+		return result;
 	}
 
 	auto n = reinterpret_cast<duckdb_libpgquery::PGNode *>(root->head->data.ptr_value);

--- a/src/parser/transform/tableref/transform_join.cpp
+++ b/src/parser/transform/tableref/transform_join.cpp
@@ -48,17 +48,17 @@ unique_ptr<TableRef> Transformer::TransformJoin(duckdb_libpgquery::PGJoinExpr *r
 			auto column_name = string(reinterpret_cast<duckdb_libpgquery::PGValue *>(target)->val.str);
 			result->using_columns.push_back(column_name);
 		}
-		return move(result);
+		return result;
 	}
 
 	if (!root->quals && result->using_columns.empty() && !result->is_natural) { // CROSS PRODUCT
 		auto cross = make_unique<CrossProductRef>();
 		cross->left = move(result->left);
 		cross->right = move(result->right);
-		return move(cross);
+		return cross;
 	}
 	result->condition = TransformExpression(root->quals);
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/transform/tableref/transform_subquery.cpp
+++ b/src/parser/transform/tableref/transform_subquery.cpp
@@ -14,7 +14,7 @@ unique_ptr<TableRef> Transformer::TransformRangeSubselect(duckdb_libpgquery::PGR
 	if (root->sample) {
 		result->sample = TransformSampleOptions(root->sample);
 	}
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/parser/transform/tableref/transform_table_function.cpp
+++ b/src/parser/transform/tableref/transform_table_function.cpp
@@ -44,7 +44,7 @@ unique_ptr<TableRef> Transformer::TransformRangeFunction(duckdb_libpgquery::PGRa
 	if (root->sample) {
 		result->sample = TransformSampleOptions(root->sample);
 	}
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -183,7 +183,7 @@ unique_ptr<ParsedExpression> BindContext::CreateColumnReference(const string &sc
 			result->alias = binding->names[column_index];
 		}
 	}
-	return move(result);
+	return result;
 }
 
 Binding *BindContext::GetCTEBinding(const string &ctename) {

--- a/src/planner/binder/query_node/bind_recursive_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_recursive_cte_node.cpp
@@ -55,7 +55,7 @@ unique_ptr<BoundQueryNode> Binder::BindNode(RecursiveCTENode &statement) {
 		throw NotImplementedException("FIXME: bind modifiers in recursive CTE");
 	}
 
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -64,7 +64,7 @@ unique_ptr<BoundResultModifier> Binder::BindLimit(LimitModifier &limit_mod) {
 			result->offset_val = val.GetValue<int64_t>();
 		}
 	}
-	return move(result);
+	return result;
 }
 
 unique_ptr<BoundResultModifier> Binder::BindLimitPercent(LimitPercentModifier &limit_mod) {
@@ -86,7 +86,7 @@ unique_ptr<BoundResultModifier> Binder::BindLimitPercent(LimitPercentModifier &l
 			result->offset_val = val.GetValue<int64_t>();
 		}
 	}
-	return move(result);
+	return result;
 }
 
 void Binder::BindModifiers(OrderBinder &order_binder, QueryNode &statement, BoundQueryNode &result) {
@@ -372,7 +372,7 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SelectNode &statement) {
 
 	// now that the SELECT list is bound, we set the types of DISTINCT/ORDER BY expressions
 	BindModifierTypes(*result, internal_sql_types, result->projection_index);
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/planner/binder/query_node/bind_setop_node.cpp
+++ b/src/planner/binder/query_node/bind_setop_node.cpp
@@ -116,7 +116,7 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SetOperationNode &statement) {
 
 	// finally bind the types of the ORDER/DISTINCT clause expressions
 	BindModifierTypes(*result, result->types, result->setop_index);
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -57,7 +57,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 
 			result->types = b->types;
 			result->bound_columns = move(names);
-			return move(result);
+			return result;
 		}
 	}
 	// not a CTE

--- a/src/planner/binder/tableref/bind_crossproductref.cpp
+++ b/src/planner/binder/tableref/bind_crossproductref.cpp
@@ -18,7 +18,7 @@ unique_ptr<BoundTableRef> Binder::Bind(CrossProductRef &ref) {
 	bind_context.AddContext(move(right_binder.bind_context));
 	MoveCorrelatedExpressions(left_binder);
 	MoveCorrelatedExpressions(right_binder);
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/planner/binder/tableref/bind_expressionlistref.cpp
+++ b/src/planner/binder/tableref/bind_expressionlistref.cpp
@@ -58,7 +58,7 @@ unique_ptr<BoundTableRef> Binder::Bind(ExpressionListRef &expr) {
 	}
 	result->bind_index = GenerateTableIndex();
 	bind_context.AddGenericBinding(result->bind_index, expr.alias, result->names, result->types);
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/planner/binder/tableref/bind_joinref.cpp
+++ b/src/planner/binder/tableref/bind_joinref.cpp
@@ -234,7 +234,7 @@ unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
 		result->condition = binder.Bind(ref.condition);
 	}
 	D_ASSERT(result->condition);
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/planner/binder/tableref/bind_subqueryref.cpp
+++ b/src/planner/binder/tableref/bind_subqueryref.cpp
@@ -22,7 +22,7 @@ unique_ptr<BoundTableRef> Binder::Bind(SubqueryRef &ref, CommonTableExpressionIn
 	auto result = make_unique<BoundSubqueryRef>(move(binder), move(subquery));
 	bind_context.AddSubquery(bind_index, alias, ref, *result->subquery);
 	MoveCorrelatedExpressions(*result->binder);
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/planner/binder/tableref/plan_joinref.cpp
+++ b/src/planner/binder/tableref/plan_joinref.cpp
@@ -110,7 +110,7 @@ unique_ptr<LogicalOperator> LogicalComparisonJoin::CreateJoin(JoinType type, uni
 			any_join->condition = make_unique<BoundConjunctionExpression>(
 			    ExpressionType::CONJUNCTION_AND, move(any_join->condition), move(arbitrary_expressions[i]));
 		}
-		return move(any_join);
+		return any_join;
 	} else {
 		// we successfully converted expressions into JoinConditions
 		// create a LogicalComparisonJoin
@@ -127,9 +127,9 @@ unique_ptr<LogicalOperator> LogicalComparisonJoin::CreateJoin(JoinType type, uni
 			}
 			LogicalFilter::SplitPredicates(filter->expressions);
 			filter->children.push_back(move(comp_join));
-			return move(filter);
+			return filter;
 		}
-		return move(comp_join);
+		return comp_join;
 	}
 }
 
@@ -174,7 +174,7 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundJoinRef &ref) {
 			PlanSubqueries(&expression, &root);
 		}
 		filter->AddChild(move(root));
-		return move(filter);
+		return filter;
 	}
 
 	// split the expressions by the AND clause

--- a/src/planner/expression/bound_aggregate_expression.cpp
+++ b/src/planner/expression/bound_aggregate_expression.cpp
@@ -74,7 +74,7 @@ unique_ptr<Expression> BoundAggregateExpression::Copy() {
 	auto copy = make_unique<BoundAggregateExpression>(function, move(new_children), move(new_filter),
 	                                                  move(new_bind_info), distinct);
 	copy->CopyProperties(*this);
-	return move(copy);
+	return copy;
 }
 
 } // namespace duckdb

--- a/src/planner/expression/bound_between_expression.cpp
+++ b/src/planner/expression/bound_between_expression.cpp
@@ -34,7 +34,7 @@ unique_ptr<Expression> BoundBetweenExpression::Copy() {
 	auto copy = make_unique<BoundBetweenExpression>(input->Copy(), lower->Copy(), upper->Copy(), lower_inclusive,
 	                                                upper_inclusive);
 	copy->CopyProperties(*this);
-	return move(copy);
+	return copy;
 }
 
 } // namespace duckdb

--- a/src/planner/expression/bound_cast_expression.cpp
+++ b/src/planner/expression/bound_cast_expression.cpp
@@ -121,7 +121,7 @@ bool BoundCastExpression::Equals(const BaseExpression *other_p) const {
 unique_ptr<Expression> BoundCastExpression::Copy() {
 	auto copy = make_unique<BoundCastExpression>(child->Copy(), return_type, try_cast);
 	copy->CopyProperties(*this);
-	return move(copy);
+	return copy;
 }
 
 } // namespace duckdb

--- a/src/planner/expression/bound_comparison_expression.cpp
+++ b/src/planner/expression/bound_comparison_expression.cpp
@@ -28,7 +28,7 @@ bool BoundComparisonExpression::Equals(const BaseExpression *other_p) const {
 unique_ptr<Expression> BoundComparisonExpression::Copy() {
 	auto copy = make_unique<BoundComparisonExpression>(type, left->Copy(), right->Copy());
 	copy->CopyProperties(*this);
-	return move(copy);
+	return copy;
 }
 
 } // namespace duckdb

--- a/src/planner/expression/bound_conjunction_expression.cpp
+++ b/src/planner/expression/bound_conjunction_expression.cpp
@@ -36,7 +36,7 @@ unique_ptr<Expression> BoundConjunctionExpression::Copy() {
 		copy->children.push_back(expr->Copy());
 	}
 	copy->CopyProperties(*this);
-	return move(copy);
+	return copy;
 }
 
 } // namespace duckdb

--- a/src/planner/expression/bound_constant_expression.cpp
+++ b/src/planner/expression/bound_constant_expression.cpp
@@ -30,7 +30,7 @@ hash_t BoundConstantExpression::Hash() const {
 unique_ptr<Expression> BoundConstantExpression::Copy() {
 	auto copy = make_unique<BoundConstantExpression>(value);
 	copy->CopyProperties(*this);
-	return move(copy);
+	return copy;
 }
 
 } // namespace duckdb

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -63,7 +63,7 @@ unique_ptr<Expression> BoundFunctionExpression::Copy() {
 	auto copy = make_unique<BoundFunctionExpression>(return_type, function, move(new_children), move(new_bind_info),
 	                                                 is_operator);
 	copy->CopyProperties(*this);
-	return move(copy);
+	return copy;
 }
 
 } // namespace duckdb

--- a/src/planner/expression/bound_operator_expression.cpp
+++ b/src/planner/expression/bound_operator_expression.cpp
@@ -43,7 +43,7 @@ unique_ptr<Expression> BoundOperatorExpression::Copy() {
 	for (auto &child : children) {
 		copy->children.push_back(child->Copy());
 	}
-	return move(copy);
+	return copy;
 }
 
 } // namespace duckdb

--- a/src/planner/expression/bound_parameter_expression.cpp
+++ b/src/planner/expression/bound_parameter_expression.cpp
@@ -43,7 +43,7 @@ unique_ptr<Expression> BoundParameterExpression::Copy() {
 	result->value = value;
 	result->return_type = return_type;
 	result->CopyProperties(*this);
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/planner/expression/bound_unnest_expression.cpp
+++ b/src/planner/expression/bound_unnest_expression.cpp
@@ -36,7 +36,7 @@ bool BoundUnnestExpression::Equals(const BaseExpression *other_p) const {
 unique_ptr<Expression> BoundUnnestExpression::Copy() {
 	auto copy = make_unique<BoundUnnestExpression>(return_type);
 	copy->child = child->Copy();
-	return move(copy);
+	return copy;
 }
 
 } // namespace duckdb

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -66,7 +66,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 		auto delim_scan = make_unique<LogicalDelimGet>(delim_index, delim_types);
 		cross_product->children.push_back(move(delim_scan));
 		cross_product->children.push_back(move(plan));
-		return move(cross_product);
+		return cross_product;
 	}
 	switch (plan->type) {
 	case LogicalOperatorType::LOGICAL_UNNEST:
@@ -152,7 +152,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 			base_binding.table_index = left_index;
 			this->delim_offset = base_binding.column_index = 0;
 			this->data_offset = 0;
-			return move(left_outer_join);
+			return left_outer_join;
 		} else {
 			// update the delim_index
 			base_binding.table_index = aggr.group_index;
@@ -195,7 +195,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 		}
 		join->children.push_back(move(plan->children[0]));
 		join->children.push_back(move(plan->children[1]));
-		return move(join);
+		return join;
 	}
 	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN: {
 		auto &join = (LogicalComparisonJoin &)*plan;

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -441,7 +441,7 @@ unique_ptr<FileBuffer> BufferManager::ReadTemporaryBuffer(block_id_t id) {
 
 	handle.reset();
 	DeleteTemporaryFile(id);
-	return move(buffer);
+	return buffer;
 }
 
 void BufferManager::DeleteTemporaryFile(block_id_t id) {

--- a/src/storage/compression/bitpacking.cpp
+++ b/src/storage/compression/bitpacking.cpp
@@ -467,7 +467,7 @@ public:
 template <class T>
 unique_ptr<SegmentScanState> BitpackingInitScan(ColumnSegment &segment) {
 	auto result = make_unique<BitpackingScanState<T>>(segment);
-	return move(result);
+	return result;
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/compression/fixed_size_uncompressed.cpp
+++ b/src/storage/compression/fixed_size_uncompressed.cpp
@@ -116,7 +116,7 @@ unique_ptr<SegmentScanState> FixedSizeInitScan(ColumnSegment &segment) {
 	auto result = make_unique<FixedSizeScanState>();
 	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
 	result->handle = buffer_manager.Pin(segment.block);
-	return move(result);
+	return result;
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -281,7 +281,7 @@ struct RLEScanState : public SegmentScanState {
 template <class T>
 unique_ptr<SegmentScanState> RLEInitScan(ColumnSegment &segment) {
 	auto result = make_unique<RLEScanState<T>>(segment);
-	return move(result);
+	return result;
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/compression/string_uncompressed.cpp
+++ b/src/storage/compression/string_uncompressed.cpp
@@ -139,7 +139,7 @@ unique_ptr<SegmentScanState> UncompressedStringStorage::StringInitScan(ColumnSeg
 	auto result = make_unique<StringScanState>();
 	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
 	result->handle = buffer_manager.Pin(segment.block);
-	return move(result);
+	return result;
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/compression/validity_uncompressed.cpp
+++ b/src/storage/compression/validity_uncompressed.cpp
@@ -209,7 +209,7 @@ unique_ptr<SegmentScanState> ValidityInitScan(ColumnSegment &segment) {
 	auto result = make_unique<ValidityScanState>();
 	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
 	result->handle = buffer_manager.Pin(segment.block);
-	return move(result);
+	return result;
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/statistics/list_statistics.cpp
+++ b/src/storage/statistics/list_statistics.cpp
@@ -32,7 +32,7 @@ unique_ptr<BaseStatistics> ListStatistics::Copy() {
 	auto copy = make_unique<ListStatistics>(type);
 	copy->validity_stats = validity_stats ? validity_stats->Copy() : nullptr;
 	copy->child_stats = child_stats ? child_stats->Copy() : nullptr;
-	return move(copy);
+	return copy;
 }
 
 void ListStatistics::Serialize(Serializer &serializer) {
@@ -45,7 +45,7 @@ unique_ptr<BaseStatistics> ListStatistics::Deserialize(Deserializer &source, Log
 	auto result = make_unique<ListStatistics>(move(type));
 	auto &child_type = ListType::GetChildType(result->type);
 	result->child_stats = BaseStatistics::Deserialize(source, child_type);
-	return move(result);
+	return result;
 }
 
 string ListStatistics::ToString() {

--- a/src/storage/statistics/numeric_statistics.cpp
+++ b/src/storage/statistics/numeric_statistics.cpp
@@ -181,7 +181,7 @@ unique_ptr<BaseStatistics> NumericStatistics::Copy() {
 	if (validity_stats) {
 		stats->validity_stats = validity_stats->Copy();
 	}
-	return move(stats);
+	return stats;
 }
 
 bool NumericStatistics::IsConstant() {

--- a/src/storage/statistics/string_statistics.cpp
+++ b/src/storage/statistics/string_statistics.cpp
@@ -26,7 +26,7 @@ unique_ptr<BaseStatistics> StringStatistics::Copy() {
 	if (validity_stats) {
 		stats->validity_stats = validity_stats->Copy();
 	}
-	return move(stats);
+	return stats;
 }
 
 void StringStatistics::Serialize(Serializer &serializer) {
@@ -45,7 +45,7 @@ unique_ptr<BaseStatistics> StringStatistics::Deserialize(Deserializer &source, L
 	stats->has_unicode = source.Read<bool>();
 	stats->max_string_length = source.Read<uint32_t>();
 	stats->has_overflow_strings = source.Read<bool>();
-	return move(stats);
+	return stats;
 }
 
 static int StringValueComparison(const_data_ptr_t data, idx_t len, const_data_ptr_t comparison) {

--- a/src/storage/statistics/struct_statistics.cpp
+++ b/src/storage/statistics/struct_statistics.cpp
@@ -43,7 +43,7 @@ unique_ptr<BaseStatistics> StructStatistics::Copy() {
 	for (idx_t i = 0; i < child_stats.size(); i++) {
 		copy->child_stats[i] = child_stats[i] ? child_stats[i]->Copy() : nullptr;
 	}
-	return move(copy);
+	return copy;
 }
 
 void StructStatistics::Serialize(Serializer &serializer) {
@@ -68,7 +68,7 @@ unique_ptr<BaseStatistics> StructStatistics::Deserialize(Deserializer &source, L
 			result->child_stats[i].reset();
 		}
 	}
-	return move(result);
+	return result;
 }
 
 string StructStatistics::ToString() {

--- a/src/storage/table/chunk_info.cpp
+++ b/src/storage/table/chunk_info.cpp
@@ -95,7 +95,7 @@ unique_ptr<ChunkInfo> ChunkConstantInfo::Deserialize(Deserializer &source) {
 	auto info = make_unique<ChunkConstantInfo>(start);
 	info->insert_id = 0;
 	info->delete_id = 0;
-	return move(info);
+	return info;
 }
 
 //===--------------------------------------------------------------------===//
@@ -258,7 +258,7 @@ unique_ptr<ChunkInfo> ChunkVectorInfo::Deserialize(Deserializer &source) {
 			result->deleted[i] = 0;
 		}
 	}
-	return move(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -235,7 +235,7 @@ public:
 			stats->child_stats[i] = child_states[i]->GetStatistics();
 			D_ASSERT(stats->child_stats[i]);
 		}
-		return move(stats);
+		return stats;
 	}
 
 	void FlushToDisk() override {

--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -62,7 +62,7 @@ static py::object PyTokenize(const string &query) {
 		}
 		result.append(tuple);
 	}
-	return move(result);
+	return result;
 }
 
 PYBIND11_MODULE(DUCKDB_PYTHON_LIB_NAME, m) {

--- a/tools/pythonpkg/src/pandas_scan.cpp
+++ b/tools/pythonpkg/src/pandas_scan.cpp
@@ -77,7 +77,7 @@ unique_ptr<FunctionOperatorData> PandasScanFunction::PandasScanInit(ClientContex
 	auto &bind_data = (const PandasScanFunctionData &)*bind_data_p;
 	auto result = make_unique<PandasScanState>(0, bind_data.row_count);
 	result->column_ids = column_ids;
-	return move(result);
+	return result;
 }
 
 idx_t PandasScanFunction::PandasScanMaxThreads(ClientContext &context, const FunctionData *bind_data_p) {
@@ -105,7 +105,7 @@ unique_ptr<FunctionOperatorData> PandasScanFunction::PandasScanParallelInit(Clie
 	if (!PandasScanParallelStateNext(context, bind_data_p, result.get(), state)) {
 		return nullptr;
 	}
-	return move(result);
+	return result;
 }
 
 bool PandasScanFunction::PandasScanParallelStateNext(ClientContext &context, const FunctionData *bind_data_p,


### PR DESCRIPTION
We don't need to `return move(unique_ptr)`, if the pointer is created inside the function. It will disallow the compiler using copy elision to optimize functions.