### PR TITLE
fix python profile html generator to support updated JSON format.

### DIFF
--- a/tools/pythonpkg/duckdb_query_graph/parse_profiling_output.js
+++ b/tools/pythonpkg/duckdb_query_graph/parse_profiling_output.js
@@ -118,7 +118,7 @@ function parse_profiling_output(graph_json) {
 
 	// assign an impact factor to nodes
 	// this is used for rendering opacity
-	var root_node = graph_data["tree"];
+	var root_node = graph_data;
 	var node_list = []
 	var node_timings = {}
 	var execution_time = gather_nodes(root_node, node_list, node_timings);
@@ -216,7 +216,7 @@ function parse_profiling_output(graph_json) {
 	function convert_json(node, parameters) {
 		var node_name = node["name"];
 		var node_timing = node["timing"];
-		var node_extra_info = node["extra_info"];
+		var node_extra_info = node["extra_info"] || '';
 		var node_impact = node["impact"];
 		var node_children = node["children"];
 		parameters["total_nodes"] += 1
@@ -266,7 +266,7 @@ function parse_profiling_output(graph_json) {
 		return result
 	}
 
-	var new_json = convert_json(graph_data["tree"], parameters);
+	var new_json = convert_json(graph_data, parameters);
 	return [meta_info, new_json];
 }
 


### PR DESCRIPTION
when a profile is generated using

```sql
-- enable profiling in json format
PRAGMA enable_profiling='json';
-- write the profiling output to a specific file on disk
PRAGMA profile_output='/path/to/file.json';
```

and an HTML document is generated using

```python
import duckdb_query_graph
duckdb_query_graph.generate('/path/to/file.json', '/path/to/out.html')
```

as documented at https://duckdb.org/docs/dev/profiling

Two issues occur.

1. graph_data is now the root node of the graph, it is no longer nested
under graph_data.tree
2. extra_info is now option, it is present on some, but all nodes

this addresses both issues, but starting the parsing from the root node
directly, and adding an empty fallback for extra_info so `split()` does
not crash.