### PR TITLE
Use double to store scale factor in TPC-H answers

### DIFF
--- a/extension/tpch/tpch-extension.cpp
+++ b/extension/tpch/tpch-extension.cpp
@@ -114,7 +114,7 @@ static unique_ptr<FunctionData> TPCHQueryAnswerBind(ClientContext &context, vect
 	return_types.emplace_back(LogicalType::INTEGER);
 
 	names.emplace_back("scale_factor");
-	return_types.emplace_back(LogicalType::INTEGER);
+	return_types.emplace_back(LogicalType::DOUBLE);
 
 	names.emplace_back("answer");
 	return_types.emplace_back(LogicalType::VARCHAR);

--- a/tools/pythonpkg/tests/fast/arrow/test_tpch.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_tpch.py
@@ -7,14 +7,7 @@ try:
 except:
     can_run = False
 
-def answer_munge(cell):
-    try:
-        cell = round(float(cell), 2)
-    except ValueError:
-        cell = str(cell)
-    return cell
-
-def result_munge(cell):
+def munge(cell):
     try:
         cell = round(float(cell), 2)
     except (ValueError, TypeError):
@@ -28,8 +21,8 @@ def check_result(result,answers):
         # The end of the rows, continue
         if cq_results == [''] and str(db_result) == 'None' or str(db_result[0]) == 'None':
             continue
-        ans_result = [answer_munge(cell) for cell in cq_results]
-        db_result = [result_munge(cell) for cell in db_result]
+        ans_result = [munge(cell) for cell in cq_results]
+        db_result = [munge(cell) for cell in db_result]
 
         assert ans_result == db_result
     return True

--- a/tools/pythonpkg/tests/fast/arrow/test_tpch.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_tpch.py
@@ -7,20 +7,31 @@ try:
 except:
     can_run = False
 
+def answer_munge(cell):
+    try:
+        cell = round(float(cell), 2)
+    except ValueError:
+        cell = str(cell)
+    return cell
+
+def result_munge(cell):
+    try:
+        cell = round(float(cell), 2)
+    except (ValueError, TypeError):
+        cell = str(cell)
+    return cell
 
 def check_result(result,answers):
     for q_res in answers:
         db_result = result.fetchone()
         cq_results = q_res.split("|")
-        i = 0
-        for cq_res in cq_results:
-            if cq_res != str(db_result[i]):
-                if cq_res == '' and str(db_result[i]) == 'None':
-                    continue
-                #AVG does floating point division, check only first 6 values
-                if (float(cq_res[0:6]) != float(str(db_result[i])[0:6])):
-                    return False
-            i = i+1
+        # The end of the rows, continue
+        if cq_results == [''] and str(db_result) == 'None' or str(db_result[0]) == 'None':
+            continue
+        ans_result = [answer_munge(cell) for cell in cq_results]
+        db_result = [result_munge(cell) for cell in db_result]
+
+        assert ans_result == db_result
     return True
 
 class TestTPCHArrow(object):
@@ -44,7 +55,7 @@ class TestTPCHArrow(object):
 
         for i in range (1,23):
             query = duckdb_conn.execute("select query from tpch_queries() where query_nr="+str(i)).fetchone()[0]
-            answers = duckdb_conn.execute("select answer from tpch_answers() where scale_factor = 0.01 and query_nr="+str(i)).fetchone()[1:]
+            answers = duckdb_conn.execute("select answer from tpch_answers() where scale_factor = 0.01 and query_nr="+str(i)).fetchone()[0].split("\n")[1:]
             result = duckdb_conn.execute(query)
             assert(check_result(result,answers))
             print ("Query " + str(i) + " works")
@@ -68,7 +79,7 @@ class TestTPCHArrow(object):
 
         for i in range (1,23):
             query = duckdb_conn.execute("select query from tpch_queries() where query_nr="+str(i)).fetchone()[0]
-            answers = duckdb_conn.execute("select answer from tpch_answers() where scale_factor = 0.01 and query_nr="+str(i)).fetchone()[1:]
+            answers = duckdb_conn.execute("select answer from tpch_answers() where scale_factor = 0.01 and query_nr="+str(i)).fetchone()[0].split("\n")[1:]
             result = duckdb_conn.execute(query)
             assert(check_result(result,answers))
             print ("Query " + str(i) + " works")
@@ -78,7 +89,7 @@ class TestTPCHArrow(object):
 
         for i in range (1,23):
             query = duckdb_conn.execute("select query from tpch_queries() where query_nr="+str(i)).fetchone()[0]
-            answers = duckdb_conn.execute("select answer from tpch_answers() where scale_factor = 0.01 and query_nr="+str(i)).fetchone()[1:]
+            answers = duckdb_conn.execute("select answer from tpch_answers() where scale_factor = 0.01 and query_nr="+str(i)).fetchone()[0].split("\n")[1:]
             result = duckdb_conn.execute(query)
             assert(check_result(result,answers))
             print ("Query " + str(i) + " works (Parallel)")

--- a/tools/pythonpkg/tests/fast/arrow/test_tpch.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_tpch.py
@@ -60,6 +60,30 @@ class TestTPCHArrow(object):
             assert(check_result(result,answers))
             print ("Query " + str(i) + " works")
 
+    def test_tpch_arrow_01(self,duckdb_cursor):
+        if not can_run:
+            return
+
+        tpch_tables = ['part', 'partsupp', 'supplier', 'customer', 'lineitem', 'orders', 'nation', 'region']
+        arrow_tables = []
+
+        duckdb_conn = duckdb.connect()
+        duckdb_conn.execute("CALL dbgen(sf=0.1);")
+
+        for tpch_table in tpch_tables:
+            duck_tbl = duckdb_conn.table(tpch_table)
+            arrow_tables.append(duck_tbl.arrow())
+            duck_arrow_table = duckdb_conn.from_arrow_table(arrow_tables[-1])
+            duckdb_conn.execute("DROP TABLE "+tpch_table)
+            duck_arrow_table.create(tpch_table)
+
+        for i in range (1,23):
+            query = duckdb_conn.execute("select query from tpch_queries() where query_nr="+str(i)).fetchone()[0]
+            answers = duckdb_conn.execute("select answer from tpch_answers() where scale_factor = 0.1 and query_nr="+str(i)).fetchone()[0].split("\n")[1:]
+            result = duckdb_conn.execute(query)
+            assert(check_result(result,answers))
+            print ("Query " + str(i) + " works")
+
     def test_tpch_arrow_batch(self,duckdb_cursor):
         if not can_run:
             return


### PR DESCRIPTION
I noticed that the `scale_factor` column in TPC-H answers is stored as an integer, meaning that both 0.01 and 0.1 end up both being stored as 0. Therefore when querying answers for either 0.01 or 0.1, you get both:

```
>>> import duckdb
>>> conn = duckdb.connect()
# Get the answer for query 1, scale factor 0.01
>>> q1_sf001 = conn.execute(f"select answer from tpch_answers() where scale_factor=0.01 and query_nr=1").fetchall()
>>> len(q1_sf001)
2
# Get the answer for query 1, scale factor 0.1
>>> q1_sf01 = conn.execute(f"select answer from tpch_answers() where scale_factor=0.1 and query_nr=1").fetchall()
>>> len(q1_sf01)
2
# They are identical!
>>> q1_sf001 == q1_sf01
True
>>> q1_sf001
[('l_returnflag|l_linestatus|sum_qty|sum_base_price|sum_disc_price|sum_charge|avg_qty|avg_price|avg_disc|count_order\nA|F|380456|532348211.65|505822441.4861|526165934.000839|25.5751546114546921|35785.709306937349|0.05008133906964237698|14876\nN|F|8971|12384801.37|11798257.2080|12282485.056933|25.7787356321839080|35588.509683908046|0.04775862068965517241|348\nN|O|742802|1041502841.45|989737518.6346|1029418531.523350|25.4549878345498783|35691.129209074398|0.04993111956409992804|29181\nR|F|381449|534594445.35|507996454.4067|528524219.358903|25.5971681653469333|35874.006532680177|0.04982753992752650651|14902\n',), ('l_returnflag|l_linestatus|sum_qty|sum_base_price|sum_disc_price|sum_charge|avg_qty|avg_price|avg_disc|count_order\nA|F|3774200|5320753880.69|5054096266.6828|5256751331.449234|25.5375871168549970|36002.123829014142|0.05014459706340077136|147790\nN|F|95257|133737795.84|127132372.6512|132286291.229445|25.3006640106241700|35521.326916334661|0.04939442231075697211|3765\nN|O|7459297|10512270008.90|9986238338.3847|10385578376.585467|25.5455376712328767|36000.924688013699|0.05009595890410958904|292000\nR|F|3785523|5337950526.47|5071818532.9420|5274405503.049367|25.5259438574251017|35994.029214030924|0.04998927856184381764|148301\n',)]
```

This PR changes that storage to be a double (and adds a test for 0.1 that fails with these stored as integers, but passes as double).

As part of this process I realized the tests in `tools/pythonpkg/tests/fast/arrow/test_tpch.py` weren't actually comparing results (i.e. I could use mismatched scale factors and the tests would still pass).

It might be easiest to review by commit:

1. Alters the `check_results` function to actually check results ([this build passes CI on its own](https://github.com/jonkeane/duckdb/actions/runs/1669609277))
2. Adds the scale factor 0.1 which fails (since the answer it's comparing to is accidentally 0.01) ([this build fails CI](https://github.com/jonkeane/duckdb/actions/runs/1670013040))
3. Changes the type from integer to double