### PR TITLE
ODBC driver assets

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -83,7 +83,8 @@ jobs:
         zip -j libduckdb-linux-amd64.zip build/release/src/libduckdb*.so src/amalgamation/duckdb.hpp src/include/duckdb.h
         zip -j libduckdb-src.zip src/amalgamation/duckdb.hpp src/amalgamation/duckdb.cpp src/include/duckdb.h
         zip -j duckdb_rest-linux-amd64.zip build/release/tools/rest/duckdb_rest_server
-        python3.7 scripts/asset-upload-gha.py libduckdb-src.zip libduckdb-linux-amd64.zip duckdb_cli-linux-amd64.zip duckdb_rest-linux-amd64.zip duckdb_jdbc-linux-amd64.jar=build/release/tools/jdbc/duckdb_jdbc.jar
+        zip -j duckdb_odbc-linux-amd64.zip build/release/tools/odbc/bin/Release/*
+        python3.7 scripts/asset-upload-gha.py libduckdb-src.zip libduckdb-linux-amd64.zip duckdb_cli-linux-amd64.zip duckdb_rest-linux-amd64.zip duckdb_jdbc-linux-amd64.jar=build/release/tools/jdbc/duckdb_jdbc.jar duckdb_odbc-linux-amd64.zip
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -57,7 +57,7 @@ jobs:
         ./cmake-3.21.3-linux-x86_64.sh --skip-license --prefix=/usr/local
 
     - name: Build
-      run: STATIC_LIBCPP=1 make
+      run: STATIC_LIBCPP=1 BUILD_ODBC=1 make
 
     - name: Test
       run: make allunit

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -83,6 +83,7 @@ jobs:
         zip -j libduckdb-linux-amd64.zip build/release/src/libduckdb*.so src/amalgamation/duckdb.hpp src/include/duckdb.h
         zip -j libduckdb-src.zip src/amalgamation/duckdb.hpp src/amalgamation/duckdb.cpp src/include/duckdb.h
         zip -j duckdb_rest-linux-amd64.zip build/release/tools/rest/duckdb_rest_server
+        ls -R build/release/tools && echo "##########################################"
         zip -j duckdb_odbc-linux-amd64.zip build/release/tools/odbc/libduckdb_odbc.so
         python3.7 scripts/asset-upload-gha.py libduckdb-src.zip libduckdb-linux-amd64.zip duckdb_cli-linux-amd64.zip duckdb_rest-linux-amd64.zip duckdb_jdbc-linux-amd64.jar=build/release/tools/jdbc/duckdb_jdbc.jar duckdb_odbc-linux-amd64.zip
 

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -83,7 +83,7 @@ jobs:
         zip -j libduckdb-linux-amd64.zip build/release/src/libduckdb*.so src/amalgamation/duckdb.hpp src/include/duckdb.h
         zip -j libduckdb-src.zip src/amalgamation/duckdb.hpp src/amalgamation/duckdb.cpp src/include/duckdb.h
         zip -j duckdb_rest-linux-amd64.zip build/release/tools/rest/duckdb_rest_server
-        zip -j duckdb_odbc-linux-amd64.zip build/release/tools/odbc/bin/Release/*
+        zip -j duckdb_odbc-linux-amd64.zip build/release/tools/odbc/libduckdb_odbc.so
         python3.7 scripts/asset-upload-gha.py libduckdb-src.zip libduckdb-linux-amd64.zip duckdb_cli-linux-amd64.zip duckdb_rest-linux-amd64.zip duckdb_jdbc-linux-amd64.jar=build/release/tools/jdbc/duckdb_jdbc.jar duckdb_odbc-linux-amd64.zip
 
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -36,7 +36,7 @@ jobs:
         add-apt-repository ppa:deadsnakes/ppa
         add-apt-repository ppa:git-core/ppa
         apt-get update -y -qq
-        apt-get install -y -qq git ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk python3.7 zip python3-pip maven
+        apt-get install -y -qq git ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk python3.7 zip python3-pip maven unixodbc-dev
         python3.7 -m pip install pip
         python3.7 -m pip install requests
 
@@ -83,7 +83,6 @@ jobs:
         zip -j libduckdb-linux-amd64.zip build/release/src/libduckdb*.so src/amalgamation/duckdb.hpp src/include/duckdb.h
         zip -j libduckdb-src.zip src/amalgamation/duckdb.hpp src/amalgamation/duckdb.cpp src/include/duckdb.h
         zip -j duckdb_rest-linux-amd64.zip build/release/tools/rest/duckdb_rest_server
-        ls -R build/release/tools && echo "##########################################"
         zip -j duckdb_odbc-linux-amd64.zip build/release/tools/odbc/libduckdb_odbc.so
         python3.7 scripts/asset-upload-gha.py libduckdb-src.zip libduckdb-linux-amd64.zip duckdb_cli-linux-amd64.zip duckdb_rest-linux-amd64.zip duckdb_jdbc-linux-amd64.jar=build/release/tools/jdbc/duckdb_jdbc.jar duckdb_odbc-linux-amd64.zip
 

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -45,7 +45,8 @@ jobs:
         choco install zip -y --force
         zip -j duckdb_cli-windows-amd64.zip Release/duckdb.exe
         zip -j libduckdb-windows-amd64.zip src/Release/duckdb.dll src/amalgamation/duckdb.hpp src/include/duckdb.h
-        python scripts/asset-upload-gha.py libduckdb-windows-amd64.zip duckdb_cli-windows-amd64.zip duckdb_jdbc-windows-amd64.jar=tools/jdbc/duckdb_jdbc.jar
+        zip -j duckdb_odbc-windows-amd64.zip tools/odbc/bin/Release/*
+        python scripts/asset-upload-gha.py libduckdb-windows-amd64.zip duckdb_cli-windows-amd64.zip duckdb_jdbc-windows-amd64.jar=tools/jdbc/duckdb_jdbc.jar duckdb_odbc-windows-amd64.zip
 
     - uses: actions/upload-artifact@v2
       with:

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ doxygen: docs
 release:
 	mkdir -p build/release && \
 	cd build/release && \
-	cmake $(GENERATOR) $(FORCE_COLOR) ${WARNINGS_AS_ERRORS} ${FORCE_WARN_UNUSED_FLAG} ${DISABLE_UNITY_FLAG} ${DISABLE_SANITIZER_FLAG} ${STATIC_LIBCPP} ${EXTENSIONS} -DBUILD_ODBC_DRIVER=1 -DCMAKE_BUILD_TYPE=Release ../.. && \
+	cmake $(GENERATOR) $(FORCE_COLOR) ${WARNINGS_AS_ERRORS} ${FORCE_WARN_UNUSED_FLAG} ${DISABLE_UNITY_FLAG} ${DISABLE_SANITIZER_FLAG} ${STATIC_LIBCPP} ${EXTENSIONS} -DCMAKE_BUILD_TYPE=Release ../.. && \
 	cmake --build . --config Release
 
 reldebug:

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ doxygen: docs
 release:
 	mkdir -p build/release && \
 	cd build/release && \
-	cmake $(GENERATOR) $(FORCE_COLOR) ${WARNINGS_AS_ERRORS} ${FORCE_WARN_UNUSED_FLAG} ${DISABLE_UNITY_FLAG} ${DISABLE_SANITIZER_FLAG} ${STATIC_LIBCPP} ${EXTENSIONS} -DCMAKE_BUILD_TYPE=Release ../.. && \
+	cmake $(GENERATOR) $(FORCE_COLOR) ${WARNINGS_AS_ERRORS} ${FORCE_WARN_UNUSED_FLAG} ${DISABLE_UNITY_FLAG} ${DISABLE_SANITIZER_FLAG} ${STATIC_LIBCPP} ${EXTENSIONS} -DBUILD_ODBC_DRIVER=1 -DCMAKE_BUILD_TYPE=Release ../.. && \
 	cmake --build . --config Release
 
 reldebug:

--- a/tools/odbc/connection.cpp
+++ b/tools/odbc/connection.cpp
@@ -1,6 +1,8 @@
 #include "duckdb_odbc.hpp"
 #include "driver.hpp"
 
+using std::ptrdiff_t;
+
 SQLRETURN SQL_API SQLGetConnectAttr(SQLHDBC connection_handle, SQLINTEGER attribute, SQLPOINTER value_ptr,
                                     SQLINTEGER buffer_length, SQLINTEGER *string_length_ptr) {
 

--- a/tools/odbc/driver.cpp
+++ b/tools/odbc/driver.cpp
@@ -3,7 +3,6 @@
 #include "odbc_fetch.hpp"
 
 #include <odbcinst.h>
-#include <codecvt>
 #include <locale>
 
 using std::string;

--- a/tools/odbc/statement.cpp
+++ b/tools/odbc/statement.cpp
@@ -5,7 +5,6 @@
 #include "parameter_descriptor.hpp"
 #include "row_descriptor.hpp"
 #include "statement_functions.hpp"
-#include <sqlext.h>
 
 using duckdb::LogicalTypeId;
 
@@ -113,8 +112,8 @@ SQLRETURN SQL_API SQLGetStmtAttr(SQLHSTMT statement_handle, SQLINTEGER attribute
 		}
 		case SQL_ATTR_ASYNC_ENABLE:
 			break;
-		case SQL_ATTR_ASYNC_STMT_EVENT:
-			break;
+		// case SQL_ATTR_ASYNC_STMT_EVENT:
+		//	break;
 		case SQL_ATTR_CONCURRENCY:
 			break;
 		case SQL_ATTR_CURSOR_SCROLLABLE:

--- a/tools/odbc/statement.cpp
+++ b/tools/odbc/statement.cpp
@@ -112,8 +112,10 @@ SQLRETURN SQL_API SQLGetStmtAttr(SQLHSTMT statement_handle, SQLINTEGER attribute
 		}
 		case SQL_ATTR_ASYNC_ENABLE:
 			break;
+#if (ODBCVER >= 0x0380)
 		case SQL_ATTR_ASYNC_STMT_EVENT:
 			break;
+#endif
 		case SQL_ATTR_CONCURRENCY:
 			break;
 		case SQL_ATTR_CURSOR_SCROLLABLE:

--- a/tools/odbc/statement.cpp
+++ b/tools/odbc/statement.cpp
@@ -5,6 +5,7 @@
 #include "parameter_descriptor.hpp"
 #include "row_descriptor.hpp"
 #include "statement_functions.hpp"
+#include <sqlext.h>
 
 using duckdb::LogicalTypeId;
 
@@ -112,10 +113,8 @@ SQLRETURN SQL_API SQLGetStmtAttr(SQLHSTMT statement_handle, SQLINTEGER attribute
 		}
 		case SQL_ATTR_ASYNC_ENABLE:
 			break;
-#if (ODBCVER >= 0x0380)
 		case SQL_ATTR_ASYNC_STMT_EVENT:
 			break;
-#endif
 		case SQL_ATTR_CONCURRENCY:
 			break;
 		case SQL_ATTR_CURSOR_SCROLLABLE:


### PR DESCRIPTION
Hey all,

This PR releases the ODBC driver as an asset of DuckDB, creating an asset for Windows-64 (duckdb_odbc-windows-amd64.zip) and another for Linux-64 (duckdb_odbc-linux-amd64.zip).

P.S. I couldn't test if the zip files were properly released in my fork, let me know if I need to do something else. As we do not test 32-bit SO versions, these assets still need to be created (if we plan to release them).