### PR TITLE
Add duckdb_keywords function

### DIFF
--- a/src/function/table/system/CMakeLists.txt
+++ b/src/function/table/system/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library_unity(
   duckdb_constraints.cpp
   duckdb_dependencies.cpp
   duckdb_functions.cpp
+  duckdb_keywords.cpp
   duckdb_indexes.cpp
   duckdb_schemas.cpp
   duckdb_sequences.cpp

--- a/src/function/table/system/duckdb_keywords.cpp
+++ b/src/function/table/system/duckdb_keywords.cpp
@@ -1,0 +1,84 @@
+#include "duckdb/function/table/system_functions.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/parser/parser.hpp"
+
+namespace duckdb {
+
+struct DuckDBKeywordsData : public FunctionOperatorData {
+	DuckDBKeywordsData() : offset(0) {
+	}
+
+	vector<ParserKeyword> entries;
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> DuckDBKeywordsBind(ClientContext &context, vector<Value> &inputs,
+                                                   unordered_map<string, Value> &named_parameters,
+                                                   vector<LogicalType> &input_table_types,
+                                                   vector<string> &input_table_names, vector<LogicalType> &return_types,
+                                                   vector<string> &names) {
+	names.emplace_back("keyword_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("keyword_category");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+unique_ptr<FunctionOperatorData> DuckDBKeywordsInit(ClientContext &context, const FunctionData *bind_data,
+                                                    const vector<column_t> &column_ids,
+                                                    TableFilterCollection *filters) {
+	auto result = make_unique<DuckDBKeywordsData>();
+	result->entries = Parser::KeywordList();
+	return move(result);
+}
+
+void DuckDBKeywordsFunction(ClientContext &context, const FunctionData *bind_data, FunctionOperatorData *operator_state,
+                            DataChunk *input, DataChunk &output) {
+	auto &data = (DuckDBKeywordsData &)*operator_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.entries[data.offset++];
+
+		// keyword_name, VARCHAR
+		output.SetValue(0, count, Value(entry.name));
+		// keyword_category, VARCHAR
+		string category_name;
+		switch (entry.category) {
+		case KeywordCategory::KEYWORD_RESERVED:
+			category_name = "reserved";
+			break;
+		case KeywordCategory::KEYWORD_UNRESERVED:
+			category_name = "unreserved";
+			break;
+		case KeywordCategory::KEYWORD_TYPE_FUNC:
+			category_name = "type_function";
+			break;
+		case KeywordCategory::KEYWORD_COL_NAME:
+			category_name = "column_name";
+			break;
+		default:
+			throw InternalException("Unrecognized keyword category");
+		}
+		output.SetValue(1, count, Value(move(category_name)));
+
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void DuckDBKeywordsFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    TableFunction("duckdb_keywords", {}, DuckDBKeywordsFunction, DuckDBKeywordsBind, DuckDBKeywordsInit));
+}
+
+} // namespace duckdb

--- a/src/function/table/system_functions.cpp
+++ b/src/function/table/system_functions.cpp
@@ -22,6 +22,7 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 	DuckDBColumnsFun::RegisterFunction(*this);
 	DuckDBConstraintsFun::RegisterFunction(*this);
 	DuckDBFunctionsFun::RegisterFunction(*this);
+	DuckDBKeywordsFun::RegisterFunction(*this);
 	DuckDBIndexesFun::RegisterFunction(*this);
 	DuckDBSchemasFun::RegisterFunction(*this);
 	DuckDBDependenciesFun::RegisterFunction(*this);

--- a/src/include/duckdb/function/table/system_functions.hpp
+++ b/src/include/duckdb/function/table/system_functions.hpp
@@ -68,6 +68,10 @@ struct DuckDBFunctionsFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct DuckDBKeywordsFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct DuckDBIndexesFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/src/include/duckdb/parser/parser.hpp
+++ b/src/include/duckdb/parser/parser.hpp
@@ -28,6 +28,10 @@ class Parser {
 public:
 	Parser();
 
+	//! The parsed SQL statements from an invocation to ParseQuery.
+	vector<unique_ptr<SQLStatement>> statements;
+
+public:
 	//! Attempts to parse a query into a series of SQL statements. Returns
 	//! whether or not the parsing was successful. If the parsing was
 	//! successful, the parsed statements will be stored in the statements
@@ -39,6 +43,8 @@ public:
 
 	//! Returns true if the given text matches a keyword of the parser
 	static bool IsKeyword(const string &text);
+	//! Returns a list of all keywords in the parser
+	static vector<ParserKeyword> KeywordList();
 
 	//! Parses a list of expressions (i.e. the list found in a SELECT clause)
 	static vector<unique_ptr<ParsedExpression>> ParseExpressionList(const string &select_list);
@@ -51,14 +57,5 @@ public:
 	static vector<vector<unique_ptr<ParsedExpression>>> ParseValuesList(const string &value_list);
 	//! Parses a column list (i.e. as found in a CREATE TABLE statement)
 	static vector<ColumnDefinition> ParseColumnList(const string &column_list);
-
-	//! The parsed SQL statements from an invocation to ParseQuery.
-	vector<unique_ptr<SQLStatement>> statements;
-
-private:
-	//! Transform a Postgres parse tree into a set of SQL Statements
-	bool TransformList(duckdb_libpgquery::PGList *tree);
-	//! Transform a single Postgres parse node into a SQL Statement.
-	unique_ptr<SQLStatement> TransformNode(duckdb_libpgquery::PGNode *stmt);
 };
 } // namespace duckdb

--- a/src/include/duckdb/parser/simplified_token.hpp
+++ b/src/include/duckdb/parser/simplified_token.hpp
@@ -28,4 +28,11 @@ struct SimplifiedToken {
 	idx_t start;
 };
 
+enum class KeywordCategory : uint8_t { KEYWORD_RESERVED, KEYWORD_UNRESERVED, KEYWORD_TYPE_FUNC, KEYWORD_COL_NAME };
+
+struct ParserKeyword {
+	string name;
+	KeywordCategory category;
+};
+
 } // namespace duckdb

--- a/test/sql/table_function/duckdb_keywords.test
+++ b/test/sql/table_function/duckdb_keywords.test
@@ -1,0 +1,9 @@
+# name: test/sql/table_function/duckdb_keywords.test
+# description: Test duckdb_keywords function
+# group: [table_function]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+SELECT * FROM duckdb_keywords();

--- a/third_party/libpg_query/include/parser/parser.hpp
+++ b/third_party/libpg_query/include/parser/parser.hpp
@@ -30,6 +30,7 @@ typedef enum PGBackslashQuoteType {
 PGList *raw_parser(const char *str);
 
 bool is_keyword(const char *str);
+std::vector<PGKeyword> keyword_list();
 
 std::vector<PGSimplifiedToken> tokenize(const char *str);
 

--- a/third_party/libpg_query/include/pg_simplified_token.hpp
+++ b/third_party/libpg_query/include/pg_simplified_token.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 namespace duckdb_libpgquery {
 
@@ -16,6 +17,18 @@ enum class PGSimplifiedTokenType : uint8_t {
 struct PGSimplifiedToken {
 	PGSimplifiedTokenType type;
 	int32_t start;
+};
+
+enum class PGKeywordCategory : uint8_t {
+	PG_KEYWORD_RESERVED,
+	PG_KEYWORD_UNRESERVED,
+	PG_KEYWORD_TYPE_FUNC,
+	PG_KEYWORD_COL_NAME
+};
+
+struct PGKeyword {
+	std::string text;
+	PGKeywordCategory category;
 };
 
 }

--- a/third_party/libpg_query/include/postgres_parser.hpp
+++ b/third_party/libpg_query/include/postgres_parser.hpp
@@ -28,5 +28,6 @@ public:
 	static std::vector<duckdb_libpgquery::PGSimplifiedToken> Tokenize(const std::string &query);
 
 	static bool IsKeyword(const std::string &text);
+	static std::vector<duckdb_libpgquery::PGKeyword> KeywordList();
 };
 }

--- a/third_party/libpg_query/postgres_parser.cpp
+++ b/third_party/libpg_query/postgres_parser.cpp
@@ -39,4 +39,8 @@ bool PostgresParser::IsKeyword(const std::string &text) {
 	return duckdb_libpgquery::is_keyword(text.c_str());
 }
 
+vector<duckdb_libpgquery::PGKeyword> PostgresParser::KeywordList() {
+	return duckdb_libpgquery::keyword_list();
+}
+
 }

--- a/third_party/libpg_query/src_backend_parser_parser.cpp
+++ b/third_party/libpg_query/src_backend_parser_parser.cpp
@@ -72,6 +72,30 @@ bool is_keyword(const char *text) {
 	return ScanKeywordLookup(text, ScanKeywords, NumScanKeywords) != NULL;
 }
 
+std::vector<PGKeyword> keyword_list() {
+    std::vector<PGKeyword> result;
+	for(size_t i = 0; i < NumScanKeywords; i++) {
+		PGKeyword keyword;
+		keyword.text = ScanKeywords[i].name;
+		switch(ScanKeywords[i].category) {
+		case UNRESERVED_KEYWORD:
+			keyword.category = PGKeywordCategory::PG_KEYWORD_UNRESERVED;
+			break;
+		case RESERVED_KEYWORD:
+			keyword.category = PGKeywordCategory::PG_KEYWORD_RESERVED;
+			break;
+		case TYPE_FUNC_NAME_KEYWORD:
+			keyword.category = PGKeywordCategory::PG_KEYWORD_TYPE_FUNC;
+			break;
+		case COL_NAME_KEYWORD:
+			keyword.category = PGKeywordCategory::PG_KEYWORD_COL_NAME;
+			break;
+		}
+		result.push_back(keyword);
+	}
+	return result;
+}
+
 std::vector<PGSimplifiedToken> tokenize(const char *str) {
 	core_yyscan_t yyscanner;
 	base_yy_extra_type yyextra;


### PR DESCRIPTION
Fixes #2891 and #989

This PR implements the `duckdb_keywords` table-producing function that can be used to query all keywords in the system together with their category, e.g.:

```sql
D select * from duckdb_keywords() using sample 20;
┌──────────────┬──────────────────┐
│ keyword_name │ keyword_category │
├──────────────┼──────────────────┤
│ outer        │ type_function    │
│ off          │ unreserved       │
│ qualify      │ reserved         │
│ share        │ unreserved       │
│ char         │ column_name      │
│ ordinality   │ unreserved       │
│ validate     │ unreserved       │
│ relative     │ unreserved       │
│ reset        │ unreserved       │
│ leakproof    │ unreserved       │
│ indexes      │ unreserved       │
│ into         │ reserved         │
│ strict       │ unreserved       │
│ localtime    │ reserved         │
│ xmlforest    │ column_name      │
│ insert       │ unreserved       │
│ similar      │ type_function    │
│ install      │ unreserved       │
│ stdin        │ unreserved       │
│ none         │ column_name      │
└──────────────┴──────────────────┘
```

There are four types of keywords:

* **reserved** keywords can generally not be used anywhere (besides as the keyword, or when quoted).
* **column_name** keywords can be used as column or table names, but not as functions or types.
* **type_function** keywords can be used as types or functions, but not as column or table names.
* **unreserved** keywords can be used anywhere without quotes.