### PR TITLE
Use difftime_str instead of hms class

### DIFF
--- a/tools/rpkg/src/utils.cpp
+++ b/tools/rpkg/src/utils.cpp
@@ -242,13 +242,9 @@ SEXP RApiTypes::ValueToSexp(Value &val) {
 		dest_ptr[0] = ((double)val.GetValue<dtime_t>().micros) / 1000;
 		NUMERIC_POINTER(res)[0] = val.GetValue<dtime_t>().micros;
 		// some dresssup for R
-		RProtector r_time;
-		SEXP cl = r_time.Protect(NEW_STRING(2));
-		SET_STRING_ELT(cl, 0, r_time.Protect(Rf_mkChar("hms")));
-		SET_STRING_ELT(cl, 1, r_time.Protect(Rf_mkChar("difftime")));
-		SET_CLASS(res, cl);
-		// hms difftime is always stored as "seconds"
-		Rf_setAttrib(res, Rf_install("units"), r_time.Protect(Rf_mkString("secs")));
+		SET_CLASS(res, RStrings::get().difftime_str);
+		// we always return difftime as "seconds"
+		Rf_setAttrib(res, RStrings::get().units_sym, RStrings::get().secs_str);
 		return res;
 	}
 


### PR DESCRIPTION
@Mytherin: I wonder why #2150 introduced use of the hms class here, it's not even a suggested dependency of duckdb.