### PR TITLE
not export deletes to allow crosscompile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,8 @@ __nvm
 *.vcxproj*
 *.cmake
 *.sln
+
+# Zig files
+zig-out/*
+zig-cache/*
+*.zig

--- a/src/include/duckdb/catalog/catalog_search_path.hpp
+++ b/src/include/duckdb/catalog/catalog_search_path.hpp
@@ -22,7 +22,7 @@ class ClientContext;
 class CatalogSearchPath {
 public:
 	DUCKDB_API explicit CatalogSearchPath(ClientContext &client_p);
-	DUCKDB_API CatalogSearchPath(const CatalogSearchPath &other) = delete;
+//	DUCKDB_API CatalogSearchPath(const CatalogSearchPath &other) = delete;
 
 	DUCKDB_API void Set(const string &new_value, bool is_set_schema);
 	DUCKDB_API const vector<string> &Get();

--- a/src/include/duckdb/catalog/catalog_search_path.hpp
+++ b/src/include/duckdb/catalog/catalog_search_path.hpp
@@ -22,7 +22,7 @@ class ClientContext;
 class CatalogSearchPath {
 public:
 	DUCKDB_API explicit CatalogSearchPath(ClientContext &client_p);
-//	DUCKDB_API CatalogSearchPath(const CatalogSearchPath &other) = delete;
+	CatalogSearchPath(const CatalogSearchPath &other) = delete;
 
 	DUCKDB_API void Set(const string &new_value, bool is_set_schema);
 	DUCKDB_API const vector<string> &Get();

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -69,7 +69,7 @@ public:
 	*/
 	DUCKDB_API Vector(LogicalType type, bool create_data, bool zero_data, idx_t capacity = STANDARD_VECTOR_SIZE);
 	// implicit copying of Vectors is not allowed
-//	DUCKDB_API Vector(const Vector &) = delete;
+	Vector(const Vector &) = delete;
 	// but moving of vectors is allowed
 	DUCKDB_API Vector(Vector &&other) noexcept;
 

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -69,7 +69,7 @@ public:
 	*/
 	DUCKDB_API Vector(LogicalType type, bool create_data, bool zero_data, idx_t capacity = STANDARD_VECTOR_SIZE);
 	// implicit copying of Vectors is not allowed
-	DUCKDB_API Vector(const Vector &) = delete;
+//	DUCKDB_API Vector(const Vector &) = delete;
 	// but moving of vectors is allowed
 	DUCKDB_API Vector(Vector &&other) noexcept;
 


### PR DESCRIPTION
I have to comment these two lines to allow crosscompile from WSL2/Ubuntu to Windows with Zig. After this `zig build`is working for Ubuntu and `zig build -Dtarget=x86_64-windows-gnu` is working for Windows.