### PR TITLE
Tests for dataset roundtrip with Arrow

### DIFF
--- a/tools/pythonpkg/tests/fast/arrow/test_dataset.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_dataset.py
@@ -1,6 +1,5 @@
 import duckdb
 import os
-import pytest
 try:
     import pyarrow
     import pyarrow.parquet

--- a/tools/pythonpkg/tests/fast/arrow/test_dataset.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_dataset.py
@@ -1,5 +1,6 @@
 import duckdb
 import os
+import pytest
 try:
     import pyarrow
     import pyarrow.parquet
@@ -52,3 +53,33 @@ class TestArrowDataset(object):
         rel = duckdb_conn.register("dataset",userdata_parquet_dataset)
 
         assert duckdb_conn.execute("Select count(*) from dataset where first_name = 'Jose' and salary > 134708.82").fetchone()[0] == 12
+
+    def test_parallel_dataset_roundtrip(self,duckdb_cursor):
+        if not can_run:
+            return
+
+        duckdb_conn = duckdb.connect()
+        duckdb_conn.execute("PRAGMA threads=4")
+        duckdb_conn.execute("PRAGMA verify_parallelism")
+
+        parquet_filename = os.path.join(os.path.dirname(os.path.realpath(__file__)),'data','userdata1.parquet')
+
+        userdata_parquet_dataset= pyarrow.dataset.dataset([
+            parquet_filename,
+            parquet_filename,
+            parquet_filename,
+        ]
+        , format="parquet")
+
+        rel = duckdb_conn.register("dataset",userdata_parquet_dataset)
+
+        query = duckdb_conn.execute("SELECT * FROM dataset")
+        record_batch_reader = query.fetch_record_batch(2048)
+
+        from_duckdb = record_batch_reader.read_pandas()
+        form_arrow = userdata_parquet_dataset.to_table().to_pandas()
+
+        # reorder since order of rows isn't deterministic
+        df1 = from_duckdb.sort_values('id').reset_index(drop=True)
+        df2 = form_arrow.sort_values('id').reset_index(drop=True)
+        assert df1.equals(df2)


### PR DESCRIPTION
We've been working on enabling true streaming with DuckDB <-> Arrow in R and haven't been able to get it quite right (you can see some of the stuff we're running into at https://github.com/apache/arrow/pull/11730).

As part of that process I tried to write some python tests to see if I can confirm it's an (Arrow or DuckDB) R package issue, or if it is something more widespread. 

I've seen the two following two errors in alternation on this test when running it locally. The IOError: Query Stream is closed is something we've seen on the R side as well.

Any thoughts on what might be causing this?

<details>
```
tests/fast/arrow/test_dataset.py:79: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
pyarrow/ipc.pxi:524: in pyarrow.lib._ReadPandasMixin.read_pandas
    ???
pyarrow/ipc.pxi:587: in pyarrow.lib.RecordBatchReader.read_all
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   OSError: Query Stream is closed

pyarrow/error.pxi:114: OSError
```


```
tests/fast/arrow/test_dataset.py:80: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
pyarrow/ipc.pxi:525: in pyarrow.lib._ReadPandasMixin.read_pandas
    ???
pyarrow/array.pxi:766: in pyarrow.lib._PandasConvertible.to_pandas
    ???
pyarrow/table.pxi:1815: in pyarrow.lib.Table._to_pandas
    ???
../../../../envs/duckdb/lib/python3.9/site-packages/pyarrow/pandas_compat.py:789: in table_to_blockmanager
    blocks = _table_to_blocks(options, table, categories, ext_columns_dtypes)
../../../../envs/duckdb/lib/python3.9/site-packages/pyarrow/pandas_compat.py:1128: in _table_to_blocks
    result = pa.lib.table_to_blocks(options, block_table, categories,
pyarrow/table.pxi:1225: in pyarrow.lib.table_to_blocks
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   pyarrow.lib.ArrowException: Unknown error: Wrapping P�id@com.com failed

pyarrow/error.pxi:137: ArrowException
```
</details>