### PR TITLE
Fixing Arrow Stream Output Error

### DIFF
--- a/src/common/arrow_wrapper.cpp
+++ b/src/common/arrow_wrapper.cpp
@@ -101,8 +101,9 @@ int ResultArrowArrayStreamWrapper::MyStreamGetNext(struct ArrowArrayStream *stre
 	if (result.type == QueryResultType::STREAM_RESULT) {
 		auto &stream_result = (StreamQueryResult &)result;
 		if (!stream_result.IsOpen()) {
-			my_stream->last_error = "Query Stream is closed";
-			return -1;
+			// Nothing to output
+			out->release = nullptr;
+			return 0;
 		}
 	}
 	unique_ptr<DataChunk> chunk_result = result.Fetch();

--- a/tools/pythonpkg/tests/fast/arrow/test_dataset.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_dataset.py
@@ -75,7 +75,10 @@ class TestArrowDataset(object):
         query = duckdb_conn.execute("SELECT * FROM dataset order by id" )
         record_batch_reader = query.fetch_record_batch(2048)
 
-        df1 = record_batch_reader.read_pandas()
+        arrow_table = record_batch_reader.read_all()
         # reorder since order of rows isn't deterministic
-        df2 = userdata_parquet_dataset.to_table().to_pandas().sort_values('id').reset_index(drop=True)
-        assert df1.equals(df2)
+        df = userdata_parquet_dataset.to_table().to_pandas().sort_values('id').reset_index(drop=True)
+        # turn it into an arrow table
+        arrow_table_2 = pyarrow.Table.from_pandas(df)
+
+        assert arrow_table.equals(arrow_table_2)

--- a/tools/rpkg/tests/testthat/test_fetch_arrow.R
+++ b/tools/rpkg/tests/testthat/test_fetch_arrow.R
@@ -208,7 +208,7 @@ test_that("duckdb_fetch_arrow() record_batch_reader multiple vectors per chunk",
     cur_batch <- record_batch_reader$read_next_batch()
     expect_equal(904,cur_batch$num_rows)
 
-    expect_error(record_batch_reader$read_next_batch())
+    record_batch_reader$read_next_batch()
     
     dbDisconnect(con, shutdown = T)
 })


### PR DESCRIPTION
This should fix #2911 

Basically instead of outputting an error there, we should just output an empty chunk to signal that we are done with the stream to Arrow.

@jonkeane let me know if this also fixes the problems from the R side, since they both use the same code path here it should be fine!