### PR TITLE
Add left join type to python relational API

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
@@ -100,7 +100,7 @@ public:
 
 	unique_ptr<DuckDBPyRelation> Map(py::function fun);
 
-	unique_ptr<DuckDBPyRelation> Join(DuckDBPyRelation *other, const string &condition);
+	unique_ptr<DuckDBPyRelation> Join(DuckDBPyRelation *other, const string &condition, const string &type);
 
 	void WriteCsv(const string &file);
 

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -33,7 +33,7 @@ void DuckDBPyRelation::Initialize(py::handle &m) {
 	    .def("join", &DuckDBPyRelation::Join,
 	         "Join the relation object with another relation object in other_rel using the join condition expression "
 	         "in join_condition. Types supported are 'inner' and 'left'",
-	         py::arg("other_rel"), py::arg("condition"), py::arg("type") = "left")
+	         py::arg("other_rel"), py::arg("condition"), py::arg("type") = "inner")
 	    .def("distinct", &DuckDBPyRelation::Distinct, "Retrieve distinct rows from this relation object")
 	    .def("limit", &DuckDBPyRelation::Limit, "Only retrieve the first n rows from this relation object",
 	         py::arg("n"))

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -33,7 +33,7 @@ void DuckDBPyRelation::Initialize(py::handle &m) {
 	    .def("join", &DuckDBPyRelation::Join,
 	         "Join the relation object with another relation object in other_rel using the join condition expression "
 	         "in join_condition. Types supported are 'inner' and 'left'",
-	         py::arg("other_rel"), py::arg("condition"), py::arg("type") = "inner")
+	         py::arg("other_rel"), py::arg("condition"), py::arg("how") = "inner")
 	    .def("distinct", &DuckDBPyRelation::Distinct, "Retrieve distinct rows from this relation object")
 	    .def("limit", &DuckDBPyRelation::Limit, "Only retrieve the first n rows from this relation object",
 	         py::arg("n"))

--- a/tools/pythonpkg/tests/fast/test_relation.py
+++ b/tools/pythonpkg/tests/fast/test_relation.py
@@ -177,4 +177,15 @@ class TestRelation(object):
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         duckdb.write_csv(test_df, temp_file_name)
         csv_rel = duckdb.from_csv_auto(temp_file_name)
-        assert  csv_rel.execute().fetchall() == [(1, 'one'), (2, 'two'), (3, 'three'), (4, 'four')] 
+        assert  csv_rel.execute().fetchall() == [(1, 'one'), (2, 'two'), (3, 'three'), (4, 'four')]
+
+
+    def test_join_types(self, duckdb_cursor):
+        test_df1 = pd.DataFrame.from_dict({"i":[1, 2, 3, 4]})
+        test_df2 = pd.DataFrame.from_dict({"j":[  3, 4, 5, 6]})
+        rel1 = duckdb_cursor.from_df(test_df1)
+        rel2 = duckdb_cursor.from_df(test_df2)
+
+        assert rel1.join(rel2, 'i=j', 'inner').aggregate('count()').fetchone()[0] == 2
+
+        assert rel1.join(rel2, 'i=j', 'left').aggregate('count()').fetchone()[0] == 4


### PR DESCRIPTION
e.g. 
```Python
rel1.join(rel2, 'i=j', 'left')
```