### PR TITLE
Preserve Identifier Case by default, rather than lower-casing all unquoted identifiers

### DIFF
--- a/examples/standalone-plan/main.cpp
+++ b/examples/standalone-plan/main.cpp
@@ -201,7 +201,7 @@ struct MyBindData : public FunctionData {
 // k: 1, 10, 20
 // (see MyScanNode)
 static unique_ptr<FunctionData> MyScanBind(ClientContext &context, vector<Value> &inputs,
-                                           unordered_map<string, Value> &named_parameters,
+                                           named_parameter_map_t &named_parameters,
                                            vector<LogicalType> &input_table_types, vector<string> &input_table_names,
                                            vector<LogicalType> &return_types, vector<string> &names) {
 	auto table_name = inputs[0].ToString();

--- a/extension/icu/icu-extension.cpp
+++ b/extension/icu/icu-extension.cpp
@@ -150,7 +150,7 @@ struct ICUTimeZoneData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> ICUTimeZoneBind(ClientContext &context, vector<Value> &inputs,
-                                                unordered_map<string, Value> &named_parameters,
+                                                named_parameter_map_t &named_parameters,
                                                 vector<LogicalType> &input_table_types,
                                                 vector<string> &input_table_names, vector<LogicalType> &return_types,
                                                 vector<string> &names) {
@@ -236,7 +236,7 @@ struct ICUCalendarData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> ICUCalendarBind(ClientContext &context, vector<Value> &inputs,
-                                                unordered_map<string, Value> &named_parameters,
+                                                named_parameter_map_t &named_parameters,
                                                 vector<LogicalType> &input_table_types,
                                                 vector<string> &input_table_names, vector<LogicalType> &return_types,
                                                 vector<string> &names) {

--- a/extension/parquet/parquet-extension.cpp
+++ b/extension/parquet/parquet-extension.cpp
@@ -196,7 +196,7 @@ public:
 	}
 
 	static unique_ptr<FunctionData> ParquetScanBind(ClientContext &context, vector<Value> &inputs,
-	                                                unordered_map<string, Value> &named_parameters,
+	                                                named_parameter_map_t &named_parameters,
 	                                                vector<LogicalType> &input_table_types,
 	                                                vector<string> &input_table_names,
 	                                                vector<LogicalType> &return_types, vector<string> &names) {
@@ -217,7 +217,7 @@ public:
 	}
 
 	static unique_ptr<FunctionData> ParquetScanBindList(ClientContext &context, vector<Value> &inputs,
-	                                                    unordered_map<string, Value> &named_parameters,
+	                                                    named_parameter_map_t &named_parameters,
 	                                                    vector<LogicalType> &input_table_types,
 	                                                    vector<string> &input_table_names,
 	                                                    vector<LogicalType> &return_types, vector<string> &names) {

--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -385,7 +385,7 @@ void ParquetMetaDataOperatorData::LoadSchemaData(ClientContext &context, const v
 
 template <bool SCHEMA>
 unique_ptr<FunctionData> ParquetMetaDataBind(ClientContext &context, vector<Value> &inputs,
-                                             unordered_map<string, Value> &named_parameters,
+                                             named_parameter_map_t &named_parameters,
                                              vector<LogicalType> &input_table_types, vector<string> &input_table_names,
                                              vector<LogicalType> &return_types, vector<string> &names) {
 	auto &config = DBConfig::GetConfig(context);

--- a/extension/tpcds/tpcds-extension.cpp
+++ b/extension/tpcds/tpcds-extension.cpp
@@ -28,7 +28,7 @@ struct DSDGenFunctionData : public TableFunctionData {
 };
 
 static unique_ptr<FunctionData> DsdgenBind(ClientContext &context, vector<Value> &inputs,
-                                           unordered_map<string, Value> &named_parameters,
+                                           named_parameter_map_t &named_parameters,
                                            vector<LogicalType> &input_table_types, vector<string> &input_table_names,
                                            vector<LogicalType> &return_types, vector<string> &names) {
 	auto result = make_unique<DSDGenFunctionData>();
@@ -75,7 +75,7 @@ unique_ptr<FunctionOperatorData> TPCDSInit(ClientContext &context, const Functio
 }
 
 static unique_ptr<FunctionData> TPCDSQueryBind(ClientContext &context, vector<Value> &inputs,
-                                               unordered_map<string, Value> &named_parameters,
+                                               named_parameter_map_t &named_parameters,
                                                vector<LogicalType> &input_table_types,
                                                vector<string> &input_table_names, vector<LogicalType> &return_types,
                                                vector<string> &names) {
@@ -110,7 +110,7 @@ static void TPCDSQueryFunction(ClientContext &context, const FunctionData *bind_
 }
 
 static unique_ptr<FunctionData> TPCDSQueryAnswerBind(ClientContext &context, vector<Value> &inputs,
-                                                     unordered_map<string, Value> &named_parameters,
+                                                     named_parameter_map_t &named_parameters,
                                                      vector<LogicalType> &input_table_types,
                                                      vector<string> &input_table_names,
                                                      vector<LogicalType> &return_types, vector<string> &names) {

--- a/extension/tpch/tpch-extension.cpp
+++ b/extension/tpch/tpch-extension.cpp
@@ -27,7 +27,7 @@ struct DBGenFunctionData : public TableFunctionData {
 };
 
 static unique_ptr<FunctionData> DbgenBind(ClientContext &context, vector<Value> &inputs,
-                                          unordered_map<string, Value> &named_parameters,
+                                          named_parameter_map_t &named_parameters,
                                           vector<LogicalType> &input_table_types, vector<string> &input_table_names,
                                           vector<LogicalType> &return_types, vector<string> &names) {
 	auto result = make_unique<DBGenFunctionData>();
@@ -72,7 +72,7 @@ unique_ptr<FunctionOperatorData> TPCHInit(ClientContext &context, const Function
 }
 
 static unique_ptr<FunctionData> TPCHQueryBind(ClientContext &context, vector<Value> &inputs,
-                                              unordered_map<string, Value> &named_parameters,
+                                              named_parameter_map_t &named_parameters,
                                               vector<LogicalType> &input_table_types, vector<string> &input_table_names,
                                               vector<LogicalType> &return_types, vector<string> &names) {
 	names.emplace_back("query_nr");
@@ -106,7 +106,7 @@ static void TPCHQueryFunction(ClientContext &context, const FunctionData *bind_d
 }
 
 static unique_ptr<FunctionData> TPCHQueryAnswerBind(ClientContext &context, vector<Value> &inputs,
-                                                    unordered_map<string, Value> &named_parameters,
+                                                    named_parameter_map_t &named_parameters,
                                                     vector<LogicalType> &input_table_types,
                                                     vector<string> &input_table_names,
                                                     vector<LogicalType> &return_types, vector<string> &names) {

--- a/src/execution/operator/persistent/buffered_csv_reader.cpp
+++ b/src/execution/operator/persistent/buffered_csv_reader.cpp
@@ -921,7 +921,7 @@ void BufferedCSVReader::DetectHeader(const vector<vector<LogicalType>> &best_sql
 	// update parser info, and read, generate & set col_names based on previous findings
 	if (((!first_row_consistent || first_row_nulls) && !options.has_header) || (options.has_header && options.header)) {
 		options.header = true;
-		unordered_map<string, idx_t> name_collision_count;
+		case_insensitive_map_t<idx_t> name_collision_count;
 		// get header names from CSV
 		for (idx_t col = 0; col < options.num_cols; col++) {
 			const auto &val = best_header_row.GetValue(col, 0);

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -208,7 +208,7 @@ string Function::CallToString(const string &name, const vector<LogicalType> &arg
 }
 
 string Function::CallToString(const string &name, const vector<LogicalType> &arguments,
-                              const unordered_map<string, LogicalType> &named_parameters) {
+                              const named_parameter_type_map_t &named_parameters) {
 	vector<string> input_arguments;
 	input_arguments.reserve(arguments.size() + named_parameters.size());
 	for (auto &arg : arguments) {

--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -161,7 +161,7 @@ LogicalType GetArrowLogicalType(ArrowSchema &schema,
 }
 
 unique_ptr<FunctionData> ArrowTableFunction::ArrowScanBind(ClientContext &context, vector<Value> &inputs,
-                                                           unordered_map<string, Value> &named_parameters,
+                                                           named_parameter_map_t &named_parameters,
                                                            vector<LogicalType> &input_table_types,
                                                            vector<string> &input_table_names,
                                                            vector<LogicalType> &return_types, vector<string> &names) {

--- a/src/function/table/checkpoint.cpp
+++ b/src/function/table/checkpoint.cpp
@@ -6,7 +6,7 @@
 namespace duckdb {
 
 static unique_ptr<FunctionData> CheckpointBind(ClientContext &context, vector<Value> &inputs,
-                                               unordered_map<string, Value> &named_parameters,
+                                               named_parameter_map_t &named_parameters,
                                                vector<LogicalType> &input_table_types,
                                                vector<string> &input_table_names, vector<LogicalType> &return_types,
                                                vector<string> &names) {

--- a/src/function/table/glob.cpp
+++ b/src/function/table/glob.cpp
@@ -11,7 +11,7 @@ struct GlobFunctionBindData : public TableFunctionData {
 };
 
 static unique_ptr<FunctionData> GlobFunctionBind(ClientContext &context, vector<Value> &inputs,
-                                                 unordered_map<string, Value> &named_parameters,
+                                                 named_parameter_map_t &named_parameters,
                                                  vector<LogicalType> &input_table_types,
                                                  vector<string> &input_table_names, vector<LogicalType> &return_types,
                                                  vector<string> &names) {

--- a/src/function/table/pragma_detailed_profiling_output.cpp
+++ b/src/function/table/pragma_detailed_profiling_output.cpp
@@ -22,7 +22,7 @@ struct PragmaDetailedProfilingOutputData : public TableFunctionData {
 };
 
 static unique_ptr<FunctionData> PragmaDetailedProfilingOutputBind(ClientContext &context, vector<Value> &inputs,
-                                                                  unordered_map<string, Value> &named_parameters,
+                                                                  named_parameter_map_t &named_parameters,
                                                                   vector<LogicalType> &input_table_types,
                                                                   vector<string> &input_table_names,
                                                                   vector<LogicalType> &return_types,

--- a/src/function/table/pragma_last_profiling_output.cpp
+++ b/src/function/table/pragma_last_profiling_output.cpp
@@ -22,12 +22,10 @@ struct PragmaLastProfilingOutputData : public TableFunctionData {
 	vector<LogicalType> types;
 };
 
-static unique_ptr<FunctionData> PragmaLastProfilingOutputBind(ClientContext &context, vector<Value> &inputs,
-                                                              named_parameter_map_t &named_parameters,
-                                                              vector<LogicalType> &input_table_types,
-                                                              vector<string> &input_table_names,
-                                                              vector<LogicalType> &return_types,
-                                                              vector<string> &names) {
+static unique_ptr<FunctionData>
+PragmaLastProfilingOutputBind(ClientContext &context, vector<Value> &inputs, named_parameter_map_t &named_parameters,
+                              vector<LogicalType> &input_table_types, vector<string> &input_table_names,
+                              vector<LogicalType> &return_types, vector<string> &names) {
 	names.emplace_back("OPERATOR_ID");
 	return_types.emplace_back(LogicalType::INTEGER);
 

--- a/src/function/table/pragma_last_profiling_output.cpp
+++ b/src/function/table/pragma_last_profiling_output.cpp
@@ -23,7 +23,7 @@ struct PragmaLastProfilingOutputData : public TableFunctionData {
 };
 
 static unique_ptr<FunctionData> PragmaLastProfilingOutputBind(ClientContext &context, vector<Value> &inputs,
-                                                              unordered_map<string, Value> &named_parameters,
+                                                              named_parameter_map_t &named_parameters,
                                                               vector<LogicalType> &input_table_types,
                                                               vector<string> &input_table_names,
                                                               vector<LogicalType> &return_types,

--- a/src/function/table/range.cpp
+++ b/src/function/table/range.cpp
@@ -18,7 +18,7 @@ struct RangeFunctionBindData : public TableFunctionData {
 
 template <bool GENERATE_SERIES>
 static unique_ptr<FunctionData>
-RangeFunctionBind(ClientContext &context, vector<Value> &inputs, unordered_map<string, Value> &named_parameters,
+RangeFunctionBind(ClientContext &context, vector<Value> &inputs, named_parameter_map_t &named_parameters,
                   vector<LogicalType> &input_table_types, vector<string> &input_table_names,
                   vector<LogicalType> &return_types, vector<string> &names) {
 	auto result = make_unique<RangeFunctionBindData>();
@@ -129,7 +129,7 @@ struct RangeDateTimeBindData : public TableFunctionData {
 
 template <bool GENERATE_SERIES>
 static unique_ptr<FunctionData>
-RangeDateTimeBind(ClientContext &context, vector<Value> &inputs, unordered_map<string, Value> &named_parameters,
+RangeDateTimeBind(ClientContext &context, vector<Value> &inputs, named_parameter_map_t &named_parameters,
                   vector<LogicalType> &input_table_types, vector<string> &input_table_names,
                   vector<LogicalType> &return_types, vector<string> &names) {
 	auto result = make_unique<RangeDateTimeBindData>();

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -15,7 +15,7 @@
 namespace duckdb {
 
 static unique_ptr<FunctionData> ReadCSVBind(ClientContext &context, vector<Value> &inputs,
-                                            unordered_map<string, Value> &named_parameters,
+                                            named_parameter_map_t &named_parameters,
                                             vector<LogicalType> &input_table_types, vector<string> &input_table_names,
                                             vector<LogicalType> &return_types, vector<string> &names) {
 	auto &config = DBConfig::GetConfig(context);
@@ -176,7 +176,7 @@ static unique_ptr<FunctionOperatorData> ReadCSVInit(ClientContext &context, cons
 }
 
 static unique_ptr<FunctionData> ReadCSVAutoBind(ClientContext &context, vector<Value> &inputs,
-                                                unordered_map<string, Value> &named_parameters,
+                                                named_parameter_map_t &named_parameters,
                                                 vector<LogicalType> &input_table_types,
                                                 vector<string> &input_table_names, vector<LogicalType> &return_types,
                                                 vector<string> &names) {

--- a/src/function/table/repeat.cpp
+++ b/src/function/table/repeat.cpp
@@ -18,7 +18,7 @@ struct RepeatOperatorData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> RepeatBind(ClientContext &context, vector<Value> &inputs,
-                                           unordered_map<string, Value> &named_parameters,
+                                           named_parameter_map_t &named_parameters,
                                            vector<LogicalType> &input_table_types, vector<string> &input_table_names,
                                            vector<LogicalType> &return_types, vector<string> &names) {
 	// the repeat function returns the type of the first argument

--- a/src/function/table/summary.cpp
+++ b/src/function/table/summary.cpp
@@ -8,7 +8,7 @@
 namespace duckdb {
 
 static unique_ptr<FunctionData> SummaryFunctionBind(ClientContext &context, vector<Value> &inputs,
-                                                    unordered_map<string, Value> &named_parameters,
+                                                    named_parameter_map_t &named_parameters,
                                                     vector<LogicalType> &input_table_types,
                                                     vector<string> &input_table_names,
                                                     vector<LogicalType> &return_types, vector<string> &names) {

--- a/src/function/table/system/duckdb_columns.cpp
+++ b/src/function/table/system/duckdb_columns.cpp
@@ -21,7 +21,7 @@ struct DuckDBColumnsData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> DuckDBColumnsBind(ClientContext &context, vector<Value> &inputs,
-                                                  unordered_map<string, Value> &named_parameters,
+                                                  named_parameter_map_t &named_parameters,
                                                   vector<LogicalType> &input_table_types,
                                                   vector<string> &input_table_names, vector<LogicalType> &return_types,
                                                   vector<string> &names) {

--- a/src/function/table/system/duckdb_constraints.cpp
+++ b/src/function/table/system/duckdb_constraints.cpp
@@ -25,7 +25,7 @@ struct DuckDBConstraintsData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> DuckDBConstraintsBind(ClientContext &context, vector<Value> &inputs,
-                                                      unordered_map<string, Value> &named_parameters,
+                                                      named_parameter_map_t &named_parameters,
                                                       vector<LogicalType> &input_table_types,
                                                       vector<string> &input_table_names,
                                                       vector<LogicalType> &return_types, vector<string> &names) {

--- a/src/function/table/system/duckdb_dependencies.cpp
+++ b/src/function/table/system/duckdb_dependencies.cpp
@@ -22,7 +22,7 @@ struct DuckDBDependenciesData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> DuckDBDependenciesBind(ClientContext &context, vector<Value> &inputs,
-                                                       unordered_map<string, Value> &named_parameters,
+                                                       named_parameter_map_t &named_parameters,
                                                        vector<LogicalType> &input_table_types,
                                                        vector<string> &input_table_names,
                                                        vector<LogicalType> &return_types, vector<string> &names) {

--- a/src/function/table/system/duckdb_functions.cpp
+++ b/src/function/table/system/duckdb_functions.cpp
@@ -22,7 +22,7 @@ struct DuckDBFunctionsData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> DuckDBFunctionsBind(ClientContext &context, vector<Value> &inputs,
-                                                    unordered_map<string, Value> &named_parameters,
+                                                    named_parameter_map_t &named_parameters,
                                                     vector<LogicalType> &input_table_types,
                                                     vector<string> &input_table_names,
                                                     vector<LogicalType> &return_types, vector<string> &names) {

--- a/src/function/table/system/duckdb_indexes.cpp
+++ b/src/function/table/system/duckdb_indexes.cpp
@@ -19,7 +19,7 @@ struct DuckDBIndexesData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> DuckDBIndexesBind(ClientContext &context, vector<Value> &inputs,
-                                                  unordered_map<string, Value> &named_parameters,
+                                                  named_parameter_map_t &named_parameters,
                                                   vector<LogicalType> &input_table_types,
                                                   vector<string> &input_table_names, vector<LogicalType> &return_types,
                                                   vector<string> &names) {

--- a/src/function/table/system/duckdb_keywords.cpp
+++ b/src/function/table/system/duckdb_keywords.cpp
@@ -15,7 +15,7 @@ struct DuckDBKeywordsData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> DuckDBKeywordsBind(ClientContext &context, vector<Value> &inputs,
-                                                   unordered_map<string, Value> &named_parameters,
+                                                   named_parameter_map_t &named_parameters,
                                                    vector<LogicalType> &input_table_types,
                                                    vector<string> &input_table_names, vector<LogicalType> &return_types,
                                                    vector<string> &names) {

--- a/src/function/table/system/duckdb_schemas.cpp
+++ b/src/function/table/system/duckdb_schemas.cpp
@@ -16,7 +16,7 @@ struct DuckDBSchemasData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> DuckDBSchemasBind(ClientContext &context, vector<Value> &inputs,
-                                                  unordered_map<string, Value> &named_parameters,
+                                                  named_parameter_map_t &named_parameters,
                                                   vector<LogicalType> &input_table_types,
                                                   vector<string> &input_table_names, vector<LogicalType> &return_types,
                                                   vector<string> &names) {

--- a/src/function/table/system/duckdb_sequences.cpp
+++ b/src/function/table/system/duckdb_sequences.cpp
@@ -17,7 +17,7 @@ struct DuckDBSequencesData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> DuckDBSequencesBind(ClientContext &context, vector<Value> &inputs,
-                                                    unordered_map<string, Value> &named_parameters,
+                                                    named_parameter_map_t &named_parameters,
                                                     vector<LogicalType> &input_table_types,
                                                     vector<string> &input_table_names,
                                                     vector<LogicalType> &return_types, vector<string> &names) {

--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -21,7 +21,7 @@ struct DuckDBSettingsData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> DuckDBSettingsBind(ClientContext &context, vector<Value> &inputs,
-                                                   unordered_map<string, Value> &named_parameters,
+                                                   named_parameter_map_t &named_parameters,
                                                    vector<LogicalType> &input_table_types,
                                                    vector<string> &input_table_names, vector<LogicalType> &return_types,
                                                    vector<string> &names) {

--- a/src/function/table/system/duckdb_tables.cpp
+++ b/src/function/table/system/duckdb_tables.cpp
@@ -20,7 +20,7 @@ struct DuckDBTablesData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> DuckDBTablesBind(ClientContext &context, vector<Value> &inputs,
-                                                 unordered_map<string, Value> &named_parameters,
+                                                 named_parameter_map_t &named_parameters,
                                                  vector<LogicalType> &input_table_types,
                                                  vector<string> &input_table_names, vector<LogicalType> &return_types,
                                                  vector<string> &names) {

--- a/src/function/table/system/duckdb_types.cpp
+++ b/src/function/table/system/duckdb_types.cpp
@@ -17,7 +17,7 @@ struct DuckDBTypesData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> DuckDBTypesBind(ClientContext &context, vector<Value> &inputs,
-                                                unordered_map<string, Value> &named_parameters,
+                                                named_parameter_map_t &named_parameters,
                                                 vector<LogicalType> &input_table_types,
                                                 vector<string> &input_table_names, vector<LogicalType> &return_types,
                                                 vector<string> &names) {

--- a/src/function/table/system/duckdb_views.cpp
+++ b/src/function/table/system/duckdb_views.cpp
@@ -17,7 +17,7 @@ struct DuckDBViewsData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> DuckDBViewsBind(ClientContext &context, vector<Value> &inputs,
-                                                unordered_map<string, Value> &named_parameters,
+                                                named_parameter_map_t &named_parameters,
                                                 vector<LogicalType> &input_table_types,
                                                 vector<string> &input_table_names, vector<LogicalType> &return_types,
                                                 vector<string> &names) {

--- a/src/function/table/system/pragma_collations.cpp
+++ b/src/function/table/system/pragma_collations.cpp
@@ -16,7 +16,7 @@ struct PragmaCollateData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> PragmaCollateBind(ClientContext &context, vector<Value> &inputs,
-                                                  unordered_map<string, Value> &named_parameters,
+                                                  named_parameter_map_t &named_parameters,
                                                   vector<LogicalType> &input_table_types,
                                                   vector<string> &input_table_names, vector<LogicalType> &return_types,
                                                   vector<string> &names) {

--- a/src/function/table/system/pragma_database_list.cpp
+++ b/src/function/table/system/pragma_database_list.cpp
@@ -12,7 +12,7 @@ struct PragmaDatabaseListData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> PragmaDatabaseListBind(ClientContext &context, vector<Value> &inputs,
-                                                       unordered_map<string, Value> &named_parameters,
+                                                       named_parameter_map_t &named_parameters,
                                                        vector<LogicalType> &input_table_types,
                                                        vector<string> &input_table_names,
                                                        vector<LogicalType> &return_types, vector<string> &names) {

--- a/src/function/table/system/pragma_database_size.cpp
+++ b/src/function/table/system/pragma_database_size.cpp
@@ -16,7 +16,7 @@ struct PragmaDatabaseSizeData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> PragmaDatabaseSizeBind(ClientContext &context, vector<Value> &inputs,
-                                                       unordered_map<string, Value> &named_parameters,
+                                                       named_parameter_map_t &named_parameters,
                                                        vector<LogicalType> &input_table_types,
                                                        vector<string> &input_table_names,
                                                        vector<LogicalType> &return_types, vector<string> &names) {

--- a/src/function/table/system/pragma_functions.cpp
+++ b/src/function/table/system/pragma_functions.cpp
@@ -19,7 +19,7 @@ struct PragmaFunctionsData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> PragmaFunctionsBind(ClientContext &context, vector<Value> &inputs,
-                                                    unordered_map<string, Value> &named_parameters,
+                                                    named_parameter_map_t &named_parameters,
                                                     vector<LogicalType> &input_table_types,
                                                     vector<string> &input_table_names,
                                                     vector<LogicalType> &return_types, vector<string> &names) {

--- a/src/function/table/system/pragma_storage_info.cpp
+++ b/src/function/table/system/pragma_storage_info.cpp
@@ -31,7 +31,7 @@ struct PragmaStorageOperatorData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> PragmaStorageInfoBind(ClientContext &context, vector<Value> &inputs,
-                                                      unordered_map<string, Value> &named_parameters,
+                                                      named_parameter_map_t &named_parameters,
                                                       vector<LogicalType> &input_table_types,
                                                       vector<string> &input_table_names,
                                                       vector<LogicalType> &return_types, vector<string> &names) {

--- a/src/function/table/system/pragma_table_info.cpp
+++ b/src/function/table/system/pragma_table_info.cpp
@@ -28,7 +28,7 @@ struct PragmaTableOperatorData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> PragmaTableInfoBind(ClientContext &context, vector<Value> &inputs,
-                                                    unordered_map<string, Value> &named_parameters,
+                                                    named_parameter_map_t &named_parameters,
                                                     vector<LogicalType> &input_table_types,
                                                     vector<string> &input_table_names,
                                                     vector<LogicalType> &return_types, vector<string> &names) {

--- a/src/function/table/system/test_all_types.cpp
+++ b/src/function/table/system/test_all_types.cpp
@@ -166,7 +166,7 @@ static vector<TestType> GetTestTypes() {
 }
 
 static unique_ptr<FunctionData> TestAllTypesBind(ClientContext &context, vector<Value> &inputs,
-                                                 unordered_map<string, Value> &named_parameters,
+                                                 named_parameter_map_t &named_parameters,
                                                  vector<LogicalType> &input_table_types,
                                                  vector<string> &input_table_names, vector<LogicalType> &return_types,
                                                  vector<string> &names) {

--- a/src/function/table/unnest.cpp
+++ b/src/function/table/unnest.cpp
@@ -18,7 +18,7 @@ struct UnnestOperatorData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> UnnestBind(ClientContext &context, vector<Value> &inputs,
-                                           unordered_map<string, Value> &named_parameters,
+                                           named_parameter_map_t &named_parameters,
                                            vector<LogicalType> &input_table_types, vector<string> &input_table_names,
                                            vector<LogicalType> &return_types, vector<string> &names) {
 	return_types.push_back(ListType::GetChildType(inputs[0].type()));

--- a/src/function/table/version/pragma_version.cpp
+++ b/src/function/table/version/pragma_version.cpp
@@ -10,7 +10,7 @@ struct PragmaVersionData : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> PragmaVersionBind(ClientContext &context, vector<Value> &inputs,
-                                                  unordered_map<string, Value> &named_parameters,
+                                                  named_parameter_map_t &named_parameters,
                                                   vector<LogicalType> &input_table_types,
                                                   vector<string> &input_table_names, vector<LogicalType> &return_types,
                                                   vector<string> &names) {

--- a/src/include/duckdb/common/named_parameter_map.hpp
+++ b/src/include/duckdb/common/named_parameter_map.hpp
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/named_parameter_map.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/common/types.hpp"
+namespace duckdb {
+
+using named_parameter_type_map_t = case_insensitive_map_t<LogicalType>;
+using named_parameter_map_t = case_insensitive_map_t<Value>;
+
+} // namespace duckdb

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "duckdb/common/types/data_chunk.hpp"
-#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/named_parameter_map.hpp"
 #include "duckdb/common/unordered_set.hpp"
 #include "duckdb/parser/column_definition.hpp"
 
@@ -47,7 +47,7 @@ struct TableFunctionData : public FunctionData {
 
 struct FunctionParameters {
 	vector<Value> values;
-	unordered_map<string, Value> named_parameters;
+	named_parameter_map_t named_parameters;
 };
 
 //! Function is the base class used for any type of function (scalar, aggregate or simple function)
@@ -67,7 +67,7 @@ public:
 	                                      const LogicalType &return_type);
 	//! Returns the formatted string name(arg1, arg2.., np1=a, np2=b, ...)
 	DUCKDB_API static string CallToString(const string &name, const vector<LogicalType> &arguments,
-	                                      const unordered_map<string, LogicalType> &named_parameters);
+	                                      const named_parameter_type_map_t &named_parameters);
 
 	//! Bind a scalar function from the set of functions and input arguments. Returns the index of the chosen function,
 	//! returns DConstants::INVALID_INDEX and sets error if none could be found
@@ -117,14 +117,14 @@ public:
 	DUCKDB_API ~SimpleNamedParameterFunction() override;
 
 	//! The named parameters of the function
-	unordered_map<string, LogicalType> named_parameters;
+	named_parameter_type_map_t named_parameters;
 
 public:
 	DUCKDB_API string ToString() override;
 	DUCKDB_API bool HasNamedParameters();
 
 	DUCKDB_API void EvaluateInputParameters(vector<LogicalType> &arguments, vector<Value> &parameters,
-	                                        unordered_map<string, Value> &named_parameters,
+	                                        named_parameter_map_t &named_parameters,
 	                                        vector<unique_ptr<ParsedExpression>> &children);
 };
 

--- a/src/include/duckdb/function/pragma_function.hpp
+++ b/src/include/duckdb/function/pragma_function.hpp
@@ -47,7 +47,7 @@ public:
 
 	pragma_query_t query;
 	pragma_function_t function;
-	unordered_map<string, LogicalType> named_parameters;
+	named_parameter_type_map_t named_parameters;
 
 private:
 	PragmaFunction(string name, PragmaType pragma_type, pragma_query_t query, pragma_function_t function,

--- a/src/include/duckdb/function/table/arrow.hpp
+++ b/src/include/duckdb/function/table/arrow.hpp
@@ -115,7 +115,7 @@ public:
 private:
 	//! Binds an arrow table
 	static unique_ptr<FunctionData> ArrowScanBind(ClientContext &context, vector<Value> &inputs,
-	                                              unordered_map<string, Value> &named_parameters,
+	                                              named_parameter_map_t &named_parameters,
 	                                              vector<LogicalType> &input_table_types,
 	                                              vector<string> &input_table_names, vector<LogicalType> &return_types,
 	                                              vector<string> &names);

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
-
-#include "duckdb/common/unordered_map.hpp"
 #include "duckdb/function/function.hpp"
 #include "duckdb/storage/statistics/node_statistics.hpp"
 
@@ -31,7 +29,7 @@ struct TableFilterCollection {
 };
 
 typedef unique_ptr<FunctionData> (*table_function_bind_t)(ClientContext &context, vector<Value> &inputs,
-                                                          unordered_map<string, Value> &named_parameters,
+                                                          named_parameter_map_t &named_parameters,
                                                           vector<LogicalType> &input_table_types,
                                                           vector<string> &input_table_names,
                                                           vector<LogicalType> &return_types, vector<string> &names);

--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -35,6 +35,10 @@ struct ClientConfig {
 	//! The wait time before showing the progress bar
 	int wait_time = 2000;
 
+	//! Preserve identifier case while parsing.
+	//! If false, all unquoted identifiers are lower-cased (e.g. "MyTable" -> "mytable").
+	bool preserve_identifier_case = true;
+
 	// Whether or not aggressive query verification is enabled
 	bool query_verification_enabled = false;
 	//! Enable the running of optimizers

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -42,6 +42,7 @@ class ClientContextLock;
 struct CreateScalarFunctionInfo;
 class ScalarFunctionCatalogEntry;
 struct ActiveQueryContext;
+struct ParserOptions;
 
 //! The ClientContext holds information relevant to the current client session
 //! during execution
@@ -158,6 +159,9 @@ public:
 
 	//! Equivalent to CURRENT_SETTING(key) SQL function.
 	DUCKDB_API bool TryGetCurrentSetting(const std::string &key, Value &result);
+
+	//! Returns the parser options for this client context
+	DUCKDB_API ParserOptions GetParserOptions();
 
 	DUCKDB_API unique_ptr<DataChunk> Fetch(ClientContextLock &lock, StreamQueryResult &result);
 

--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -114,7 +114,7 @@ public:
 	//! Returns a relation that calls a specified table function
 	DUCKDB_API shared_ptr<Relation> TableFunction(const string &tname);
 	DUCKDB_API shared_ptr<Relation> TableFunction(const string &tname, const vector<Value> &values,
-	                                              const unordered_map<string, Value> &named_parameters);
+	                                              const named_parameter_map_t &named_parameters);
 	DUCKDB_API shared_ptr<Relation> TableFunction(const string &tname, const vector<Value> &values);
 	//! Returns a relation that produces values
 	DUCKDB_API shared_ptr<Relation> Values(const vector<vector<Value>> &values);

--- a/src/include/duckdb/main/relation.hpp
+++ b/src/include/duckdb/main/relation.hpp
@@ -14,7 +14,7 @@
 #include "duckdb/common/winapi.hpp"
 #include "duckdb/main/query_result.hpp"
 #include "duckdb/parser/column_definition.hpp"
-#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/named_parameter_map.hpp"
 
 #include <memory>
 
@@ -122,7 +122,7 @@ public:
 	//! Create a relation from calling a table in/out function on the input relation
 	DUCKDB_API shared_ptr<Relation> TableFunction(const std::string &fname, const vector<Value> &values);
 	DUCKDB_API shared_ptr<Relation> TableFunction(const std::string &fname, const vector<Value> &values,
-	                                              const unordered_map<string, Value> &named_parameters);
+	                                              const named_parameter_map_t &named_parameters);
 
 public:
 	//! Whether or not the relation inherits column bindings from its child or not, only relevant for binding

--- a/src/include/duckdb/main/relation/table_function_relation.hpp
+++ b/src/include/duckdb/main/relation/table_function_relation.hpp
@@ -15,8 +15,7 @@ namespace duckdb {
 class TableFunctionRelation : public Relation {
 public:
 	TableFunctionRelation(ClientContext &context, string name, vector<Value> parameters,
-	                      named_parameter_map_t named_parameters,
-	                      shared_ptr<Relation> input_relation_p = nullptr);
+	                      named_parameter_map_t named_parameters, shared_ptr<Relation> input_relation_p = nullptr);
 
 	TableFunctionRelation(ClientContext &context, string name, vector<Value> parameters,
 	                      shared_ptr<Relation> input_relation_p = nullptr);

--- a/src/include/duckdb/main/relation/table_function_relation.hpp
+++ b/src/include/duckdb/main/relation/table_function_relation.hpp
@@ -15,7 +15,7 @@ namespace duckdb {
 class TableFunctionRelation : public Relation {
 public:
 	TableFunctionRelation(ClientContext &context, string name, vector<Value> parameters,
-	                      unordered_map<string, Value> named_parameters,
+	                      named_parameter_map_t named_parameters,
 	                      shared_ptr<Relation> input_relation_p = nullptr);
 
 	TableFunctionRelation(ClientContext &context, string name, vector<Value> parameters,
@@ -23,7 +23,7 @@ public:
 
 	string name;
 	vector<Value> parameters;
-	unordered_map<string, Value> named_parameters;
+	named_parameter_map_t named_parameters;
 	vector<ColumnDefinition> columns;
 	shared_ptr<Relation> input_relation;
 

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -177,6 +177,14 @@ struct PerfectHashThresholdSetting {
 	static Value GetSetting(ClientContext &context);
 };
 
+struct PreserveIdentifierCase {
+	static constexpr const char *Name = "preserve_identifier_case";
+	static constexpr const char *Description = "Whether or not to preserve the identifier case, instead of always lowercasing all non-quoted identifiers";
+	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static Value GetSetting(ClientContext &context);
+};
+
 struct ProfilerHistorySize {
 	static constexpr const char *Name = "profiler_history_size";
 	static constexpr const char *Description = "Sets the profiler history size";

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -179,7 +179,8 @@ struct PerfectHashThresholdSetting {
 
 struct PreserveIdentifierCase {
 	static constexpr const char *Name = "preserve_identifier_case";
-	static constexpr const char *Description = "Whether or not to preserve the identifier case, instead of always lowercasing all non-quoted identifiers";
+	static constexpr const char *Description =
+	    "Whether or not to preserve the identifier case, instead of always lowercasing all non-quoted identifiers";
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static Value GetSetting(ClientContext &context);

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -182,7 +182,7 @@ struct PreserveIdentifierCase {
 	static constexpr const char *Description =
 	    "Whether or not to preserve the identifier case, instead of always lowercasing all non-quoted identifiers";
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void SetLocal(ClientContext &context, const Value &parameter);
 	static Value GetSetting(ClientContext &context);
 };
 

--- a/src/include/duckdb/parser/parsed_data/pragma_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/pragma_info.hpp
@@ -10,7 +10,7 @@
 
 #include "duckdb/parser/parsed_data/parse_info.hpp"
 #include "duckdb/common/types/value.hpp"
-#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/named_parameter_map.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
 
 namespace duckdb {
@@ -23,7 +23,7 @@ struct PragmaInfo : public ParseInfo {
 	//! Parameter list (if any)
 	vector<Value> parameters;
 	//! Named parameter list (if any)
-	unordered_map<string, Value> named_parameters;
+	named_parameter_map_t named_parameters;
 
 public:
 	unique_ptr<PragmaInfo> Copy() const {

--- a/src/include/duckdb/parser/parser.hpp
+++ b/src/include/duckdb/parser/parser.hpp
@@ -46,6 +46,11 @@ public:
 	//! Returns a list of all keywords in the parser
 	static vector<ParserKeyword> KeywordList();
 
+	//! Set whether or not to convert unquoted identifiers to lower case
+	static void SetDowncaseIdentifier(bool downcase);
+	//! Returns whether or not unquoted identifiers are converted to lower case
+	static bool GetDowncaseIdentifier();
+
 	//! Parses a list of expressions (i.e. the list found in a SELECT clause)
 	static vector<unique_ptr<ParsedExpression>> ParseExpressionList(const string &select_list);
 	//! Parses a list as found in an ORDER BY expression (i.e. including optional ASCENDING/DESCENDING modifiers)

--- a/src/include/duckdb/parser/parser.hpp
+++ b/src/include/duckdb/parser/parser.hpp
@@ -21,12 +21,16 @@ struct PGList;
 
 namespace duckdb {
 
+struct ParserOptions {
+	bool preserve_identifier_case = true;
+};
+
 //! The parser is responsible for parsing the query and converting it into a set
 //! of parsed statements. The parsed statements can then be converted into a
 //! plan and executed.
 class Parser {
 public:
-	Parser();
+	Parser(ParserOptions options = ParserOptions());
 
 	//! The parsed SQL statements from an invocation to ParseQuery.
 	vector<unique_ptr<SQLStatement>> statements;
@@ -46,21 +50,22 @@ public:
 	//! Returns a list of all keywords in the parser
 	static vector<ParserKeyword> KeywordList();
 
-	//! Set whether or not to convert unquoted identifiers to lower case
-	static void SetDowncaseIdentifier(bool downcase);
-	//! Returns whether or not unquoted identifiers are converted to lower case
-	static bool GetDowncaseIdentifier();
-
 	//! Parses a list of expressions (i.e. the list found in a SELECT clause)
-	static vector<unique_ptr<ParsedExpression>> ParseExpressionList(const string &select_list);
+	static vector<unique_ptr<ParsedExpression>> ParseExpressionList(const string &select_list,
+	                                                                ParserOptions options = ParserOptions());
 	//! Parses a list as found in an ORDER BY expression (i.e. including optional ASCENDING/DESCENDING modifiers)
-	static vector<OrderByNode> ParseOrderList(const string &select_list);
+	static vector<OrderByNode> ParseOrderList(const string &select_list, ParserOptions options = ParserOptions());
 	//! Parses an update list (i.e. the list found in the SET clause of an UPDATE statement)
 	static void ParseUpdateList(const string &update_list, vector<string> &update_columns,
-	                            vector<unique_ptr<ParsedExpression>> &expressions);
+	                            vector<unique_ptr<ParsedExpression>> &expressions,
+	                            ParserOptions options = ParserOptions());
 	//! Parses a VALUES list (i.e. the list of expressions after a VALUES clause)
-	static vector<vector<unique_ptr<ParsedExpression>>> ParseValuesList(const string &value_list);
+	static vector<vector<unique_ptr<ParsedExpression>>> ParseValuesList(const string &value_list,
+	                                                                    ParserOptions options = ParserOptions());
 	//! Parses a column list (i.e. as found in a CREATE TABLE statement)
-	static vector<ColumnDefinition> ParseColumnList(const string &column_list);
+	static vector<ColumnDefinition> ParseColumnList(const string &column_list, ParserOptions options = ParserOptions());
+
+private:
+	ParserOptions options;
 };
 } // namespace duckdb

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -99,7 +99,7 @@ public:
 	SchemaCatalogEntry *BindCreateFunctionInfo(CreateInfo &info);
 
 	//! Check usage, and cast named parameters to their types
-	static void BindNamedParameters(unordered_map<string, LogicalType> &types, unordered_map<string, Value> &values,
+	static void BindNamedParameters(named_parameter_type_map_t &types, named_parameter_map_t &values,
 	                                QueryErrorContext &error_context, string &func_name);
 
 	unique_ptr<BoundTableRef> Bind(TableRef &ref);
@@ -226,7 +226,7 @@ private:
 	unique_ptr<BoundTableRef> Bind(ExpressionListRef &ref);
 
 	bool BindFunctionParameters(vector<unique_ptr<ParsedExpression>> &expressions, vector<LogicalType> &arguments,
-	                            vector<Value> &parameters, unordered_map<string, Value> &named_parameters,
+	                            vector<Value> &parameters, named_parameter_map_t &named_parameters,
 	                            unique_ptr<BoundSubqueryRef> &subquery, string &error);
 
 	unique_ptr<LogicalOperator> CreatePlan(BoundBaseTableRef &ref);

--- a/src/include/duckdb/planner/expression_binder/column_alias_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/column_alias_binder.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 
 namespace duckdb {
@@ -19,14 +19,14 @@ class ColumnRefExpression;
 //! A helper binder for WhereBinder and HavingBinder which support alias as a columnref.
 class ColumnAliasBinder {
 public:
-	ColumnAliasBinder(BoundSelectNode &node, const unordered_map<string, idx_t> &alias_map);
+	ColumnAliasBinder(BoundSelectNode &node, const case_insensitive_map_t<idx_t> &alias_map);
 
 	BindResult BindAlias(ExpressionBinder &enclosing_binder, ColumnRefExpression &expr, idx_t depth,
 	                     bool root_expression);
 
 private:
 	BoundSelectNode &node;
-	const unordered_map<string, idx_t> &alias_map;
+	const case_insensitive_map_t<idx_t> &alias_map;
 	bool in_alias;
 };
 

--- a/src/include/duckdb/planner/expression_binder/group_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/group_binder.hpp
@@ -8,8 +8,7 @@
 
 #pragma once
 
-#include "duckdb/common/unordered_map.hpp"
-#include "duckdb/common/unordered_set.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 
 namespace duckdb {
@@ -20,7 +19,7 @@ class ColumnRefExpression;
 class GroupBinder : public ExpressionBinder {
 public:
 	GroupBinder(Binder &binder, ClientContext &context, SelectNode &node, idx_t group_index,
-	            unordered_map<string, idx_t> &alias_map, unordered_map<string, idx_t> &group_alias_map);
+	            case_insensitive_map_t<idx_t> &alias_map, case_insensitive_map_t<idx_t> &group_alias_map);
 
 	//! The unbound root expression
 	unique_ptr<ParsedExpression> unbound_expression;
@@ -37,8 +36,8 @@ protected:
 	BindResult BindConstant(ConstantExpression &expr);
 
 	SelectNode &node;
-	unordered_map<string, idx_t> &alias_map;
-	unordered_map<string, idx_t> &group_alias_map;
+	case_insensitive_map_t<idx_t> &alias_map;
+	case_insensitive_map_t<idx_t> &group_alias_map;
 	unordered_set<idx_t> used_aliases;
 
 	idx_t group_index;

--- a/src/include/duckdb/planner/expression_binder/having_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/having_binder.hpp
@@ -17,7 +17,7 @@ namespace duckdb {
 class HavingBinder : public SelectBinder {
 public:
 	HavingBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
-	             unordered_map<string, idx_t> &alias_map);
+	             case_insensitive_map_t<idx_t> &alias_map);
 
 protected:
 	BindResult BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth,

--- a/src/include/duckdb/planner/expression_binder/order_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/order_binder.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/parser/expression_map.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"

--- a/src/include/duckdb/planner/expression_binder/order_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/order_binder.hpp
@@ -21,10 +21,10 @@ class SelectNode;
 //! The ORDER binder is responsible for binding an expression within the ORDER BY clause of a SQL statement
 class OrderBinder {
 public:
-	OrderBinder(vector<Binder *> binders, idx_t projection_index, unordered_map<string, idx_t> &alias_map,
+	OrderBinder(vector<Binder *> binders, idx_t projection_index, case_insensitive_map_t<idx_t> &alias_map,
 	            expression_map_t<idx_t> &projection_map, idx_t max_count);
 	OrderBinder(vector<Binder *> binders, idx_t projection_index, SelectNode &node,
-	            unordered_map<string, idx_t> &alias_map, expression_map_t<idx_t> &projection_map);
+	            case_insensitive_map_t<idx_t> &alias_map, expression_map_t<idx_t> &projection_map);
 
 public:
 	unique_ptr<Expression> Bind(unique_ptr<ParsedExpression> expr);
@@ -41,7 +41,7 @@ private:
 	idx_t projection_index;
 	idx_t max_count;
 	vector<unique_ptr<ParsedExpression>> *extra_list;
-	unordered_map<string, idx_t> &alias_map;
+	case_insensitive_map_t<idx_t> &alias_map;
 	expression_map_t<idx_t> &projection_map;
 };
 

--- a/src/include/duckdb/planner/expression_binder/qualify_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/qualify_binder.hpp
@@ -17,7 +17,7 @@ namespace duckdb {
 class QualifyBinder : public SelectBinder {
 public:
 	QualifyBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
-	              unordered_map<string, idx_t> &alias_map);
+	              case_insensitive_map_t<idx_t> &alias_map);
 
 protected:
 	BindResult BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth,

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/parser/expression_map.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 
@@ -20,7 +20,7 @@ class BoundSelectNode;
 
 struct BoundGroupInformation {
 	expression_map_t<idx_t> map;
-	unordered_map<string, idx_t> alias_map;
+	case_insensitive_map_t<idx_t> alias_map;
 };
 
 //! The SELECT binder is responsible for binding an expression within the SELECT clause of a SQL statement

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -364,7 +364,7 @@ vector<unique_ptr<SQLStatement>> ClientContext::ParseStatements(const string &qu
 }
 
 vector<unique_ptr<SQLStatement>> ClientContext::ParseStatementsInternal(ClientContextLock &lock, const string &query) {
-	Parser parser;
+	Parser parser(GetParserOptions());
 	parser.ParseQuery(query);
 
 	PragmaHandler handler(*this);
@@ -1099,6 +1099,12 @@ bool ClientContext::TryGetCurrentSetting(const std::string &key, Value &result) 
 
 	result = found_session_value ? session_value->second : global_value->second;
 	return true;
+}
+
+ParserOptions ClientContext::GetParserOptions() {
+	ParserOptions options;
+	options.preserve_identifier_case = ClientConfig::GetConfig(*this).preserve_identifier_case;
+	return options;
 }
 
 } // namespace duckdb

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -43,7 +43,7 @@ static ConfigurationOption internal_options[] = {DUCKDB_GLOBAL(AccessModeSetting
                                                  DUCKDB_GLOBAL_ALIAS("memory_limit", MaximumMemorySetting),
                                                  DUCKDB_GLOBAL_ALIAS("null_order", DefaultNullOrderSetting),
                                                  DUCKDB_LOCAL(PerfectHashThresholdSetting),
-                                                 DUCKDB_GLOBAL(PreserveIdentifierCase),
+                                                 DUCKDB_LOCAL(PreserveIdentifierCase),
                                                  DUCKDB_LOCAL(ProfilerHistorySize),
                                                  DUCKDB_LOCAL(ProfileOutputSetting),
                                                  DUCKDB_LOCAL(ProfilingModeSetting),

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -83,8 +83,10 @@ ConfigurationOption *DBConfig::GetOptionByIndex(idx_t target_index) {
 }
 
 ConfigurationOption *DBConfig::GetOptionByName(const string &name) {
+	auto lname = StringUtil::Lower(name);
 	for (idx_t index = 0; internal_options[index].name; index++) {
-		if (internal_options[index].name == name) {
+		D_ASSERT(StringUtil::Lower(internal_options[index].name) == string(internal_options[index].name));
+		if (internal_options[index].name == lname) {
 			return internal_options + index;
 		}
 	}

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -43,6 +43,7 @@ static ConfigurationOption internal_options[] = {DUCKDB_GLOBAL(AccessModeSetting
                                                  DUCKDB_GLOBAL_ALIAS("memory_limit", MaximumMemorySetting),
                                                  DUCKDB_GLOBAL_ALIAS("null_order", DefaultNullOrderSetting),
                                                  DUCKDB_LOCAL(PerfectHashThresholdSetting),
+                                                 DUCKDB_GLOBAL(PreserveIdentifierCase),
                                                  DUCKDB_LOCAL(ProfilerHistorySize),
                                                  DUCKDB_LOCAL(ProfileOutputSetting),
                                                  DUCKDB_LOCAL(ProfilingModeSetting),

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -147,12 +147,12 @@ shared_ptr<Relation> Connection::View(const string &schema_name, const string &t
 
 shared_ptr<Relation> Connection::TableFunction(const string &fname) {
 	vector<Value> values;
-	unordered_map<string, Value> named_parameters;
+	named_parameter_map_t named_parameters;
 	return TableFunction(fname, values, named_parameters);
 }
 
 shared_ptr<Relation> Connection::TableFunction(const string &fname, const vector<Value> &values,
-                                               const unordered_map<string, Value> &named_parameters) {
+                                               const named_parameter_map_t &named_parameters) {
 	return make_shared<TableFunctionRelation>(*context, fname, values, named_parameters);
 }
 

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -195,7 +195,7 @@ shared_ptr<Relation> Connection::ReadCSV(const string &csv_file, const vector<st
 	// parse columns
 	vector<ColumnDefinition> column_list;
 	for (auto &column : columns) {
-		auto col_list = Parser::ParseColumnList(column);
+		auto col_list = Parser::ParseColumnList(column, context->GetParserOptions());
 		if (col_list.size() != 1) {
 			throw ParserException("Expected a single column definition");
 		}

--- a/src/main/relation.cpp
+++ b/src/main/relation.cpp
@@ -265,7 +265,7 @@ void Relation::Delete(const string &condition) {
 }
 
 shared_ptr<Relation> Relation::TableFunction(const std::string &fname, const vector<Value> &values,
-                                             const unordered_map<string, Value> &named_parameters) {
+                                             const named_parameter_map_t &named_parameters) {
 	return make_shared<TableFunctionRelation>(context, fname, values, named_parameters, shared_from_this());
 }
 

--- a/src/main/relation.cpp
+++ b/src/main/relation.cpp
@@ -35,7 +35,7 @@ shared_ptr<Relation> Relation::Project(const string &expression, const string &a
 }
 
 shared_ptr<Relation> Relation::Project(const string &select_list, const vector<string> &aliases) {
-	auto expressions = Parser::ParseExpressionList(select_list);
+	auto expressions = Parser::ParseExpressionList(select_list, context.GetParserOptions());
 	return make_shared<ProjectionRelation>(shared_from_this(), move(expressions), aliases);
 }
 
@@ -44,13 +44,14 @@ shared_ptr<Relation> Relation::Project(const vector<string> &expressions) {
 	return Project(expressions, aliases);
 }
 
-static vector<unique_ptr<ParsedExpression>> StringListToExpressionList(const vector<string> &expressions) {
+static vector<unique_ptr<ParsedExpression>> StringListToExpressionList(ClientContext &context,
+                                                                       const vector<string> &expressions) {
 	if (expressions.empty()) {
 		throw ParserException("Zero expressions provided");
 	}
 	vector<unique_ptr<ParsedExpression>> result_list;
 	for (auto &expr : expressions) {
-		auto expression_list = Parser::ParseExpressionList(expr);
+		auto expression_list = Parser::ParseExpressionList(expr, context.GetParserOptions());
 		if (expression_list.size() != 1) {
 			throw ParserException("Expected a single expression in the expression list");
 		}
@@ -60,12 +61,12 @@ static vector<unique_ptr<ParsedExpression>> StringListToExpressionList(const vec
 }
 
 shared_ptr<Relation> Relation::Project(const vector<string> &expressions, const vector<string> &aliases) {
-	auto result_list = StringListToExpressionList(expressions);
+	auto result_list = StringListToExpressionList(context, expressions);
 	return make_shared<ProjectionRelation>(shared_from_this(), move(result_list), aliases);
 }
 
 shared_ptr<Relation> Relation::Filter(const string &expression) {
-	auto expression_list = Parser::ParseExpressionList(expression);
+	auto expression_list = Parser::ParseExpressionList(expression, context.GetParserOptions());
 	if (expression_list.size() != 1) {
 		throw ParserException("Expected a single expression as filter condition");
 	}
@@ -74,7 +75,7 @@ shared_ptr<Relation> Relation::Filter(const string &expression) {
 
 shared_ptr<Relation> Relation::Filter(const vector<string> &expressions) {
 	// if there are multiple expressions, we AND them together
-	auto expression_list = StringListToExpressionList(expressions);
+	auto expression_list = StringListToExpressionList(context, expressions);
 	D_ASSERT(!expression_list.empty());
 
 	auto expr = move(expression_list[0]);
@@ -90,7 +91,7 @@ shared_ptr<Relation> Relation::Limit(int64_t limit, int64_t offset) {
 }
 
 shared_ptr<Relation> Relation::Order(const string &expression) {
-	auto order_list = Parser::ParseOrderList(expression);
+	auto order_list = Parser::ParseOrderList(expression, context.GetParserOptions());
 	return make_shared<OrderRelation>(shared_from_this(), move(order_list));
 }
 
@@ -100,7 +101,7 @@ shared_ptr<Relation> Relation::Order(const vector<string> &expressions) {
 	}
 	vector<OrderByNode> order_list;
 	for (auto &expression : expressions) {
-		auto inner_list = Parser::ParseOrderList(expression);
+		auto inner_list = Parser::ParseOrderList(expression, context.GetParserOptions());
 		if (inner_list.size() != 1) {
 			throw ParserException("Expected a single ORDER BY expression in the expression list");
 		}
@@ -110,7 +111,7 @@ shared_ptr<Relation> Relation::Order(const vector<string> &expressions) {
 }
 
 shared_ptr<Relation> Relation::Join(const shared_ptr<Relation> &other, const string &condition, JoinType type) {
-	auto expression_list = Parser::ParseExpressionList(condition);
+	auto expression_list = Parser::ParseExpressionList(condition, context.GetParserOptions());
 	D_ASSERT(!expression_list.empty());
 
 	if (expression_list.size() > 1 || expression_list[0]->type == ExpressionType::COLUMN_REF) {
@@ -154,24 +155,24 @@ shared_ptr<Relation> Relation::Alias(const string &alias) {
 }
 
 shared_ptr<Relation> Relation::Aggregate(const string &aggregate_list) {
-	auto expression_list = Parser::ParseExpressionList(aggregate_list);
+	auto expression_list = Parser::ParseExpressionList(aggregate_list, context.GetParserOptions());
 	return make_shared<AggregateRelation>(shared_from_this(), move(expression_list));
 }
 
 shared_ptr<Relation> Relation::Aggregate(const string &aggregate_list, const string &group_list) {
-	auto expression_list = Parser::ParseExpressionList(aggregate_list);
-	auto groups = Parser::ParseExpressionList(group_list);
+	auto expression_list = Parser::ParseExpressionList(aggregate_list, context.GetParserOptions());
+	auto groups = Parser::ParseExpressionList(group_list, context.GetParserOptions());
 	return make_shared<AggregateRelation>(shared_from_this(), move(expression_list), move(groups));
 }
 
 shared_ptr<Relation> Relation::Aggregate(const vector<string> &aggregates) {
-	auto aggregate_list = StringListToExpressionList(aggregates);
+	auto aggregate_list = StringListToExpressionList(context, aggregates);
 	return make_shared<AggregateRelation>(shared_from_this(), move(aggregate_list));
 }
 
 shared_ptr<Relation> Relation::Aggregate(const vector<string> &aggregates, const vector<string> &groups) {
-	auto aggregate_list = StringListToExpressionList(aggregates);
-	auto group_list = StringListToExpressionList(groups);
+	auto aggregate_list = StringListToExpressionList(context, aggregates);
+	auto group_list = StringListToExpressionList(context, groups);
 	return make_shared<AggregateRelation>(shared_from_this(), move(aggregate_list), move(group_list));
 }
 

--- a/src/main/relation/query_relation.cpp
+++ b/src/main/relation/query_relation.cpp
@@ -12,7 +12,7 @@ QueryRelation::QueryRelation(ClientContext &context, string query, string alias)
 }
 
 unique_ptr<SelectStatement> QueryRelation::GetSelectStatement() {
-	Parser parser;
+	Parser parser(context.GetParserOptions());
 	parser.ParseQuery(query);
 	if (parser.statements.size() != 1) {
 		throw ParserException("Expected a single SELECT statement");

--- a/src/main/relation/table_function_relation.cpp
+++ b/src/main/relation/table_function_relation.cpp
@@ -13,7 +13,7 @@
 namespace duckdb {
 
 TableFunctionRelation::TableFunctionRelation(ClientContext &context, string name_p, vector<Value> parameters_p,
-                                             unordered_map<string, Value> named_parameters,
+                                             named_parameter_map_t named_parameters,
                                              shared_ptr<Relation> input_relation_p)
     : Relation(context, RelationType::TABLE_FUNCTION_RELATION), name(move(name_p)), parameters(move(parameters_p)),
       named_parameters(move(named_parameters)), input_relation(move(input_relation_p)) {

--- a/src/main/relation/table_relation.cpp
+++ b/src/main/relation/table_relation.cpp
@@ -38,9 +38,9 @@ string TableRelation::ToString(idx_t depth) {
 	return RenderWhitespace(depth) + "Scan Table [" + description->table + "]";
 }
 
-static unique_ptr<ParsedExpression> ParseCondition(const string &condition) {
+static unique_ptr<ParsedExpression> ParseCondition(ClientContext &context, const string &condition) {
 	if (!condition.empty()) {
-		auto expression_list = Parser::ParseExpressionList(condition);
+		auto expression_list = Parser::ParseExpressionList(condition, context.GetParserOptions());
 		if (expression_list.size() != 1) {
 			throw ParserException("Expected a single expression as filter condition");
 		}
@@ -53,15 +53,15 @@ static unique_ptr<ParsedExpression> ParseCondition(const string &condition) {
 void TableRelation::Update(const string &update_list, const string &condition) {
 	vector<string> update_columns;
 	vector<unique_ptr<ParsedExpression>> expressions;
-	auto cond = ParseCondition(condition);
-	Parser::ParseUpdateList(update_list, update_columns, expressions);
+	auto cond = ParseCondition(context, condition);
+	Parser::ParseUpdateList(update_list, update_columns, expressions, context.GetParserOptions());
 	auto update = make_shared<UpdateRelation>(context, move(cond), description->schema, description->table,
 	                                          move(update_columns), move(expressions));
 	update->Execute();
 }
 
 void TableRelation::Delete(const string &condition) {
-	auto cond = ParseCondition(condition);
+	auto cond = ParseCondition(context, condition);
 	auto del = make_shared<DeleteRelation>(context, move(cond), description->schema, description->table);
 	del->Execute();
 }

--- a/src/main/relation/table_relation.cpp
+++ b/src/main/relation/table_relation.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/main/relation/delete_relation.hpp"
 #include "duckdb/main/relation/update_relation.hpp"
 #include "duckdb/parser/parser.hpp"
+#include "duckdb/main/client_context.hpp"
 
 namespace duckdb {
 

--- a/src/main/relation/value_relation.cpp
+++ b/src/main/relation/value_relation.cpp
@@ -25,7 +25,7 @@ ValueRelation::ValueRelation(ClientContext &context, const vector<vector<Value>>
 
 ValueRelation::ValueRelation(ClientContext &context, const string &values_list, vector<string> names_p, string alias_p)
     : Relation(context, RelationType::VALUE_LIST_RELATION), names(move(names_p)), alias(move(alias_p)) {
-	this->expressions = Parser::ParseValuesList(values_list);
+	this->expressions = Parser::ParseValuesList(values_list, context.GetParserOptions());
 	context.TryBindRelation(*this, this->columns);
 }
 

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -410,12 +410,12 @@ Value PerfectHashThresholdSetting::GetSetting(ClientContext &context) {
 //===--------------------------------------------------------------------===//
 // PreserveIdentifierCase
 //===--------------------------------------------------------------------===//
-void PreserveIdentifierCase::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
-	Parser::SetDowncaseIdentifier(!input.GetValue<bool>());
+void PreserveIdentifierCase::SetLocal(ClientContext &context, const Value &input) {
+	ClientConfig::GetConfig(context).preserve_identifier_case = input.GetValue<bool>();
 }
 
 Value PreserveIdentifierCase::GetSetting(ClientContext &context) {
-	return Value::BOOLEAN(!Parser::GetDowncaseIdentifier());
+	return Value::BOOLEAN(ClientConfig::GetConfig(context).preserve_identifier_case);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/main/query_profiler.hpp"
 #include "duckdb/storage/storage_manager.hpp"
+#include "duckdb/parser/parser.hpp"
 
 namespace duckdb {
 
@@ -404,6 +405,17 @@ void PerfectHashThresholdSetting::SetLocal(ClientContext &context, const Value &
 
 Value PerfectHashThresholdSetting::GetSetting(ClientContext &context) {
 	return Value::BIGINT(ClientConfig::GetConfig(context).perfect_ht_threshold);
+}
+
+//===--------------------------------------------------------------------===//
+// PreserveIdentifierCase
+//===--------------------------------------------------------------------===//
+void PreserveIdentifierCase::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	Parser::SetDowncaseIdentifier(!input.GetValue<bool>());
+}
+
+Value PreserveIdentifierCase::GetSetting(ClientContext &context) {
+	return Value::BOOLEAN(!Parser::GetDowncaseIdentifier());
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/parser/expression/columnref_expression.cpp
+++ b/src/parser/expression/columnref_expression.cpp
@@ -57,7 +57,7 @@ bool ColumnRefExpression::Equals(const ColumnRefExpression *a, const ColumnRefEx
 	if (a->column_names.size() != b->column_names.size()) {
 		return false;
 	}
-	for(idx_t i = 0; i < a->column_names.size(); i++) {
+	for (idx_t i = 0; i < a->column_names.size(); i++) {
 		auto lcase_a = StringUtil::Lower(a->column_names[i]);
 		auto lcase_b = StringUtil::Lower(b->column_names[i]);
 		if (lcase_a != lcase_b) {

--- a/src/parser/expression/columnref_expression.cpp
+++ b/src/parser/expression/columnref_expression.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/serializer.hpp"
 #include "duckdb/common/types/hash.hpp"
+#include "duckdb/common/string_util.hpp"
 
 namespace duckdb {
 
@@ -53,13 +54,24 @@ string ColumnRefExpression::ToString() const {
 }
 
 bool ColumnRefExpression::Equals(const ColumnRefExpression *a, const ColumnRefExpression *b) {
-	return a->column_names == b->column_names;
+	if (a->column_names.size() != b->column_names.size()) {
+		return false;
+	}
+	for(idx_t i = 0; i < a->column_names.size(); i++) {
+		auto lcase_a = StringUtil::Lower(a->column_names[i]);
+		auto lcase_b = StringUtil::Lower(b->column_names[i]);
+		if (lcase_a != lcase_b) {
+			return false;
+		}
+	}
+	return true;
 }
 
 hash_t ColumnRefExpression::Hash() const {
 	hash_t result = ParsedExpression::Hash();
 	for (auto &column_name : column_names) {
-		result = CombineHash(result, duckdb::Hash<const char *>(column_name.c_str()));
+		auto lcase = StringUtil::Lower(column_name);
+		result = CombineHash(result, duckdb::Hash<const char *>(lcase.c_str()));
 	}
 	return result;
 }

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -14,7 +14,7 @@
 
 namespace duckdb {
 
-Parser::Parser(ParserOptions options_p) : options(move(options_p)) {
+Parser::Parser(ParserOptions options_p) : options(options_p) {
 }
 
 void Parser::ParseQuery(const string &query) {

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -14,12 +14,13 @@
 
 namespace duckdb {
 
-Parser::Parser() {
+Parser::Parser(ParserOptions options_p) : options(move(options_p)) {
 }
 
 void Parser::ParseQuery(const string &query) {
 	Transformer transformer;
 	{
+		PostgresParser::SetPreserveIdentifierCase(options.preserve_identifier_case);
 		PostgresParser parser;
 		parser.Parse(query);
 
@@ -115,19 +116,11 @@ vector<ParserKeyword> Parser::KeywordList() {
 	return result;
 }
 
-void Parser::SetDowncaseIdentifier(bool downcase) {
-	PostgresParser::SetDowncaseIdentifier(downcase);
-}
-
-bool Parser::GetDowncaseIdentifier() {
-	return PostgresParser::GetDowncaseIdentifier();
-}
-
-vector<unique_ptr<ParsedExpression>> Parser::ParseExpressionList(const string &select_list) {
+vector<unique_ptr<ParsedExpression>> Parser::ParseExpressionList(const string &select_list, ParserOptions options) {
 	// construct a mock query prefixed with SELECT
 	string mock_query = "SELECT " + select_list;
 	// parse the query
-	Parser parser;
+	Parser parser(options);
 	parser.ParseQuery(mock_query);
 	// check the statements
 	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::SELECT_STATEMENT) {
@@ -141,11 +134,11 @@ vector<unique_ptr<ParsedExpression>> Parser::ParseExpressionList(const string &s
 	return move(select_node.select_list);
 }
 
-vector<OrderByNode> Parser::ParseOrderList(const string &select_list) {
+vector<OrderByNode> Parser::ParseOrderList(const string &select_list, ParserOptions options) {
 	// construct a mock query
 	string mock_query = "SELECT * FROM tbl ORDER BY " + select_list;
 	// parse the query
-	Parser parser;
+	Parser parser(options);
 	parser.ParseQuery(mock_query);
 	// check the statements
 	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::SELECT_STATEMENT) {
@@ -165,11 +158,11 @@ vector<OrderByNode> Parser::ParseOrderList(const string &select_list) {
 }
 
 void Parser::ParseUpdateList(const string &update_list, vector<string> &update_columns,
-                             vector<unique_ptr<ParsedExpression>> &expressions) {
+                             vector<unique_ptr<ParsedExpression>> &expressions, ParserOptions options) {
 	// construct a mock query
 	string mock_query = "UPDATE tbl SET " + update_list;
 	// parse the query
-	Parser parser;
+	Parser parser(options);
 	parser.ParseQuery(mock_query);
 	// check the statements
 	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::UPDATE_STATEMENT) {
@@ -180,11 +173,11 @@ void Parser::ParseUpdateList(const string &update_list, vector<string> &update_c
 	expressions = move(update.expressions);
 }
 
-vector<vector<unique_ptr<ParsedExpression>>> Parser::ParseValuesList(const string &value_list) {
+vector<vector<unique_ptr<ParsedExpression>>> Parser::ParseValuesList(const string &value_list, ParserOptions options) {
 	// construct a mock query
 	string mock_query = "VALUES " + value_list;
 	// parse the query
-	Parser parser;
+	Parser parser(options);
 	parser.ParseQuery(mock_query);
 	// check the statements
 	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::SELECT_STATEMENT) {
@@ -202,9 +195,9 @@ vector<vector<unique_ptr<ParsedExpression>>> Parser::ParseValuesList(const strin
 	return move(values_list.values);
 }
 
-vector<ColumnDefinition> Parser::ParseColumnList(const string &column_list) {
+vector<ColumnDefinition> Parser::ParseColumnList(const string &column_list, ParserOptions options) {
 	string mock_query = "CREATE TABLE blabla (" + column_list + ")";
-	Parser parser;
+	Parser parser(options);
 	parser.ParseQuery(mock_query);
 	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::CREATE_STATEMENT) {
 		throw ParserException("Expected a single CREATE statement");

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -115,6 +115,14 @@ vector<ParserKeyword> Parser::KeywordList() {
 	return result;
 }
 
+void Parser::SetDowncaseIdentifier(bool downcase) {
+	PostgresParser::SetDowncaseIdentifier(downcase);
+}
+
+bool Parser::GetDowncaseIdentifier() {
+	return PostgresParser::GetDowncaseIdentifier();
+}
+
 vector<unique_ptr<ParsedExpression>> Parser::ParseExpressionList(const string &select_list) {
 	// construct a mock query prefixed with SELECT
 	string mock_query = "SELECT " + select_list;

--- a/src/planner/binder/expression/bind_comparison_expression.cpp
+++ b/src/planner/binder/expression/bind_comparison_expression.cpp
@@ -25,6 +25,7 @@ unique_ptr<Expression> ExpressionBinder::PushCollation(ClientContext &context, u
 	} else {
 		collation = collation_p;
 	}
+	collation = StringUtil::Lower(collation);
 	// bind the collation
 	if (collation.empty() || collation == "binary" || collation == "c" || collation == "posix") {
 		// binary collation: just skip

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -253,7 +253,7 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SelectNode &statement) {
 	statement.select_list = move(new_select_list);
 
 	// create a mapping of (alias -> index) and a mapping of (Expression -> index) for the SELECT list
-	unordered_map<string, idx_t> alias_map;
+	case_insensitive_map_t<idx_t> alias_map;
 	expression_map_t<idx_t> projection_map;
 	for (idx_t i = 0; i < statement.select_list.size(); i++) {
 		auto &expr = statement.select_list[i];

--- a/src/planner/binder/query_node/bind_setop_node.cpp
+++ b/src/planner/binder/query_node/bind_setop_node.cpp
@@ -11,7 +11,7 @@
 
 namespace duckdb {
 
-static void GatherAliases(BoundQueryNode &node, unordered_map<string, idx_t> &aliases,
+static void GatherAliases(BoundQueryNode &node, case_insensitive_map_t<idx_t> &aliases,
                           expression_map_t<idx_t> &expressions) {
 	if (node.type == QueryNodeType::SET_OPERATION_NODE) {
 		// setop, recurse
@@ -81,7 +81,7 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SetOperationNode &statement) {
 
 		// we recursively visit the children of this node to extract aliases and expressions that can be referenced in
 		// the ORDER BY
-		unordered_map<string, idx_t> alias_map;
+		case_insensitive_map_t<idx_t> alias_map;
 		expression_map_t<idx_t> expression_map;
 		GatherAliases(*result, alias_map, expression_map);
 

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -40,7 +40,7 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 		// insertion statement specifies column list
 
 		// create a mapping of (list index) -> (column index)
-		unordered_map<string, idx_t> column_name_map;
+		case_insensitive_map_t<idx_t> column_name_map;
 		for (idx_t i = 0; i < stmt.columns.size(); i++) {
 			column_name_map[stmt.columns[i]] = i;
 			auto entry = table->name_map.find(stmt.columns[i]);

--- a/src/planner/binder/tableref/bind_named_parameters.cpp
+++ b/src/planner/binder/tableref/bind_named_parameters.cpp
@@ -2,7 +2,7 @@
 
 namespace duckdb {
 
-void Binder::BindNamedParameters(unordered_map<string, LogicalType> &types, unordered_map<string, Value> &values,
+void Binder::BindNamedParameters(named_parameter_type_map_t &types, named_parameter_map_t &values,
                                  QueryErrorContext &error_context, string &func_name) {
 	for (auto &kv : values) {
 		auto entry = types.find(kv.first);

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -17,7 +17,7 @@
 namespace duckdb {
 
 bool Binder::BindFunctionParameters(vector<unique_ptr<ParsedExpression>> &expressions, vector<LogicalType> &arguments,
-                                    vector<Value> &parameters, unordered_map<string, Value> &named_parameters,
+                                    vector<Value> &parameters, named_parameter_map_t &named_parameters,
                                     unique_ptr<BoundSubqueryRef> &subquery, string &error) {
 	bool seen_subquery = false;
 	for (auto &child : expressions) {
@@ -81,7 +81,7 @@ unique_ptr<BoundTableRef> Binder::Bind(TableFunctionRef &ref) {
 	// evaluate the input parameters to the function
 	vector<LogicalType> arguments;
 	vector<Value> parameters;
-	unordered_map<string, Value> named_parameters;
+	named_parameter_map_t named_parameters;
 	unique_ptr<BoundSubqueryRef> subquery;
 	string error;
 	if (!BindFunctionParameters(fexpr->children, arguments, parameters, named_parameters, subquery, error)) {

--- a/src/planner/expression_binder/column_alias_binder.cpp
+++ b/src/planner/expression_binder/column_alias_binder.cpp
@@ -6,7 +6,7 @@
 
 namespace duckdb {
 
-ColumnAliasBinder::ColumnAliasBinder(BoundSelectNode &node, const unordered_map<string, idx_t> &alias_map)
+ColumnAliasBinder::ColumnAliasBinder(BoundSelectNode &node, const case_insensitive_map_t<idx_t> &alias_map)
     : node(node), alias_map(alias_map), in_alias(false) {
 }
 

--- a/src/planner/expression_binder/group_binder.cpp
+++ b/src/planner/expression_binder/group_binder.cpp
@@ -9,7 +9,7 @@
 namespace duckdb {
 
 GroupBinder::GroupBinder(Binder &binder, ClientContext &context, SelectNode &node, idx_t group_index,
-                         unordered_map<string, idx_t> &alias_map, unordered_map<string, idx_t> &group_alias_map)
+                         case_insensitive_map_t<idx_t> &alias_map, case_insensitive_map_t<idx_t> &group_alias_map)
     : ExpressionBinder(binder, context), node(node), alias_map(alias_map), group_alias_map(group_alias_map),
       group_index(group_index) {
 }

--- a/src/planner/expression_binder/having_binder.cpp
+++ b/src/planner/expression_binder/having_binder.cpp
@@ -9,7 +9,7 @@
 namespace duckdb {
 
 HavingBinder::HavingBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
-                           unordered_map<string, idx_t> &alias_map)
+                           case_insensitive_map_t<idx_t> &alias_map)
     : SelectBinder(binder, context, node, info), column_alias_binder(node, alias_map) {
 	target_type = LogicalType(LogicalTypeId::BOOLEAN);
 }

--- a/src/planner/expression_binder/order_binder.cpp
+++ b/src/planner/expression_binder/order_binder.cpp
@@ -9,13 +9,13 @@
 
 namespace duckdb {
 
-OrderBinder::OrderBinder(vector<Binder *> binders, idx_t projection_index, unordered_map<string, idx_t> &alias_map,
+OrderBinder::OrderBinder(vector<Binder *> binders, idx_t projection_index, case_insensitive_map_t<idx_t> &alias_map,
                          expression_map_t<idx_t> &projection_map, idx_t max_count)
     : binders(move(binders)), projection_index(projection_index), max_count(max_count), extra_list(nullptr),
       alias_map(alias_map), projection_map(projection_map) {
 }
 OrderBinder::OrderBinder(vector<Binder *> binders, idx_t projection_index, SelectNode &node,
-                         unordered_map<string, idx_t> &alias_map, expression_map_t<idx_t> &projection_map)
+                         case_insensitive_map_t<idx_t> &alias_map, expression_map_t<idx_t> &projection_map)
     : binders(move(binders)), projection_index(projection_index), alias_map(alias_map), projection_map(projection_map) {
 	this->max_count = node.select_list.size();
 	this->extra_list = &node.select_list;

--- a/src/planner/expression_binder/qualify_binder.cpp
+++ b/src/planner/expression_binder/qualify_binder.cpp
@@ -9,7 +9,7 @@
 namespace duckdb {
 
 QualifyBinder::QualifyBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
-                             unordered_map<string, idx_t> &alias_map)
+                             case_insensitive_map_t<idx_t> &alias_map)
     : SelectBinder(binder, context, node, info), column_alias_binder(node, alias_map) {
 	target_type = LogicalType(LogicalTypeId::BOOLEAN);
 }

--- a/src/planner/pragma_handler.cpp
+++ b/src/planner/pragma_handler.cpp
@@ -28,7 +28,7 @@ void PragmaHandler::HandlePragmaStatementsInternal(vector<unique_ptr<SQLStatemen
 			if (!new_query.empty()) {
 				// this PRAGMA statement gets replaced by a new query string
 				// push the new query string through the parser again and add it to the transformer
-				Parser parser;
+				Parser parser(context.GetParserOptions());
 				parser.ParseQuery(new_query);
 				// insert the new statements and remove the old statement
 				// FIXME: off by one here maybe?

--- a/test/optimizer/pushdown/table_or_pushdown.test
+++ b/test/optimizer/pushdown/table_or_pushdown.test
@@ -6,7 +6,7 @@ statement ok
 PRAGMA enable_verification
 
 statement ok
-CREATE TABLE integers AS SELECT a as A, a as B FROM generate_series(1, 5, 1) tbl(a)
+CREATE TABLE integers AS SELECT a as a, a as b FROM generate_series(1, 5, 1) tbl(a)
 
 #### test OR filters with multiple columns in the root OR, e.g., a=1 OR b=2
 query II

--- a/test/sql/catalog/case_insensitive_operations.test
+++ b/test/sql/catalog/case_insensitive_operations.test
@@ -1,0 +1,87 @@
+# name: test/sql/catalog/case_insensitive_operations.test
+# description: Test case insensitive operations
+# group: [catalog]
+
+statement ok
+PRAGMA enable_verification
+
+loop i 0 2
+
+statement ok
+CREATE TABLE INTEGERS(I INTEGER);
+
+statement ok
+INSERT INTO integers (i) VALUES (1), (2), (3), (NULL);
+
+query I
+SELECT integers.i FROM integers ORDER BY i;
+----
+NULL
+1
+2
+3
+
+query I
+UPDATE integers SET i=integers.i+1
+----
+4
+
+query I
+SELECT i FROM integers ORDER BY integers.i;
+----
+NULL
+2
+3
+4
+
+query I
+DELETE FROM integers WHERE i IS NULL;
+----
+1
+
+query I
+SELECT i FROM integers ORDER BY integers.i;
+----
+2
+3
+4
+
+statement ok
+ALTER TABLE integers ADD COLUMN J INTEGER;
+
+query II
+SELECT i, j FROM integers ORDER BY integers.i;
+----
+2	NULL
+3	NULL
+4	NULL
+
+query I
+UPDATE integers SET j=integers.i;
+----
+3
+
+statement ok
+ALTER TABLE integers DROP COLUMN i;
+
+query I
+SELECT j FROM integers ORDER BY integers.j;
+----
+2
+3
+4
+
+query I
+SELECT tbl.k FROM (SELECT j FROM integers) TBL(K) ORDER BY K;
+----
+2
+3
+4
+
+statement ok
+DROP TABLE integers;
+
+statement ok
+PRAGMA preserve_identifier_case=false;
+
+endloop

--- a/test/sql/catalog/case_insensitive_operations.test
+++ b/test/sql/catalog/case_insensitive_operations.test
@@ -30,7 +30,19 @@ NULL
 3
 
 query I
-SELECT integers.i AS "i" FROM integers GROUP BY "I" ORDER BY "INTEGERS"."i";
+SELECT integers.i AS "ZZZ" FROM integers GROUP BY "zzz" ORDER BY "INTEGERS"."i";
+----
+NULL
+1
+2
+3
+
+
+query I
+WITH "CTE"("ZZZ") AS (
+	SELECT integers.i AS "ZZZ" FROM integers GROUP BY "zzz"
+)
+SELECT * FROM cte ORDER BY zZz;
 ----
 NULL
 1

--- a/test/sql/catalog/case_insensitive_operations.test
+++ b/test/sql/catalog/case_insensitive_operations.test
@@ -49,6 +49,12 @@ NULL
 2
 3
 
+statement error
+WITH "CTE"("ZZZ") AS (
+	SELECT integers.i AS "ZZZ" FROM integers GROUP BY "zzz"
+),
+	"cte" AS (SELECT 42)
+
 query I
 UPDATE integers SET i=integers.i+1
 ----

--- a/test/sql/catalog/case_insensitive_operations.test
+++ b/test/sql/catalog/case_insensitive_operations.test
@@ -22,6 +22,22 @@ NULL
 3
 
 query I
+SELECT integers.i AS i FROM integers GROUP BY I ORDER BY "integers"."I";
+----
+NULL
+1
+2
+3
+
+query I
+SELECT integers.i AS "i" FROM integers GROUP BY "I" ORDER BY "INTEGERS"."i";
+----
+NULL
+1
+2
+3
+
+query I
 UPDATE integers SET i=integers.i+1
 ----
 4
@@ -80,6 +96,31 @@ SELECT tbl.k FROM (SELECT j FROM integers) TBL(K) ORDER BY K;
 
 statement ok
 DROP TABLE integers;
+
+# structs
+statement ok
+CREATE TABLE STRUCTS(S ROW(I ROW(K INTEGER)));
+
+statement ok
+INSERT INTO structs VALUES ({'i': {'k': 42}});
+
+query III
+SELECT structs.S.i.K, "STRUCTS"."S"."I"."K", "structs"."s"."i"."k" FROM structs
+----
+42	42	42
+
+query I
+SELECT "STRUCTS"."S"."I"."K" FROM structs GROUP BY "STRUCTS"."S"."I"."K"
+----
+42
+
+query I
+SELECT structs.S.i.K FROM structs GROUP BY structs.S.i.K
+----
+42
+
+statement ok
+DROP TABLE structs;
 
 statement ok
 PRAGMA preserve_identifier_case=false;

--- a/test/sql/collate/test_collate_expression.test
+++ b/test/sql/collate/test_collate_expression.test
@@ -13,6 +13,16 @@ SELECT 'hëllo' COLLATE NOACCENT='hello'
 ----
 1
 
+query T
+SELECT 'hëllo' COLLATE POSIX='hello'
+----
+0
+
+query T
+SELECT 'hëllo' COLLATE C='hello'
+----
+0
+
 statement ok
 SELECT * FROM collate_test WHERE s='hello'
 

--- a/test/sql/copy/csv/test_read_csv.test
+++ b/test/sql/copy/csv/test_read_csv.test
@@ -10,7 +10,7 @@ statement ok
 CREATE TABLE abac_tbl (a VARCHAR, b VARCHAR, c VARCHAR);
 
 query I
-INSERT INTO abac_tbl SELECT * FROM read_csv('test/sql/copy/csv/data/abac/abac.csv', columns=STRUCT_PACK(a := 'VARCHAR', b := 'VARCHAR', c := 'VARCHAR'), sep='ABAC', auto_detect='false')
+INSERT INTO abac_tbl SELECT * FROM read_csv('test/sql/copy/csv/data/abac/abac.csv', COLUMNS=STRUCT_PACK(a := 'VARCHAR', b := 'VARCHAR', c := 'VARCHAR'), sep='ABAC', auto_detect='false')
 ----
 1
 

--- a/test/sql/settings/setting_preserve_identifier_case.test
+++ b/test/sql/settings/setting_preserve_identifier_case.test
@@ -1,0 +1,31 @@
+# name: test/sql/settings/setting_preserve_identifier_case.test
+# description: Test preserve_identifier_case setting
+# group: [settings]
+
+statement ok
+CREATE SCHEMA MYSCHEMA;
+
+statement ok
+CREATE TABLE MYSCHEMA.INTEGERS(I INTEGER);
+
+query III
+SELECT duckdb_tables.schema_name, duckdb_tables.table_name, column_name FROM duckdb_tables JOIN duckdb_columns USING (table_oid);
+----
+MYSCHEMA	INTEGERS	I
+
+statement ok
+DROP SCHEMA MYSCHEMA CASCADE
+
+statement ok
+SET preserve_identifier_case TO false;
+
+statement ok
+CREATE SCHEMA MYSCHEMA;
+
+statement ok
+CREATE TABLE MYSCHEMA.INTEGERS(I INTEGER);
+
+query III
+SELECT duckdb_tables.schema_name, duckdb_tables.table_name, column_name FROM duckdb_tables JOIN duckdb_columns USING (table_oid);
+----
+myschema	integers	i

--- a/test/sql/settings/setting_preserve_identifier_case.test
+++ b/test/sql/settings/setting_preserve_identifier_case.test
@@ -2,6 +2,11 @@
 # description: Test preserve_identifier_case setting
 # group: [settings]
 
+query I
+SELECT value FROM duckdb_settings() WHERE name='preserve_identifier_case'
+----
+True
+
 statement ok
 CREATE SCHEMA MYSCHEMA;
 
@@ -18,6 +23,11 @@ DROP SCHEMA MYSCHEMA CASCADE
 
 statement ok
 SET preserve_identifier_case TO false;
+
+query I
+SELECT value FROM duckdb_settings() WHERE name='preserve_identifier_case'
+----
+False
 
 statement ok
 CREATE SCHEMA MYSCHEMA;

--- a/third_party/libpg_query/include/parser/scansup.hpp
+++ b/third_party/libpg_query/include/parser/scansup.hpp
@@ -24,4 +24,7 @@ char *downcase_identifier(const char *ident, int len, bool warn, bool truncate);
 
 bool scanner_isspace(char ch);
 
+void set_downcase_identifier(bool downcase);
+bool get_downcase_identifier();
+
 }

--- a/third_party/libpg_query/include/parser/scansup.hpp
+++ b/third_party/libpg_query/include/parser/scansup.hpp
@@ -24,7 +24,7 @@ char *downcase_identifier(const char *ident, int len, bool warn, bool truncate);
 
 bool scanner_isspace(char ch);
 
-void set_downcase_identifier(bool downcase);
-bool get_downcase_identifier();
+void set_preserve_identifier_case(bool downcase);
+bool get_preserve_identifier_case();
 
 }

--- a/third_party/libpg_query/include/postgres_parser.hpp
+++ b/third_party/libpg_query/include/postgres_parser.hpp
@@ -30,8 +30,7 @@ public:
 	static bool IsKeyword(const std::string &text);
 	static std::vector<duckdb_libpgquery::PGKeyword> KeywordList();
 
-	static void SetDowncaseIdentifier(bool downcase);
-	static bool GetDowncaseIdentifier();
+	static void SetPreserveIdentifierCase(bool downcase);
 };
 
 }

--- a/third_party/libpg_query/include/postgres_parser.hpp
+++ b/third_party/libpg_query/include/postgres_parser.hpp
@@ -29,5 +29,9 @@ public:
 
 	static bool IsKeyword(const std::string &text);
 	static std::vector<duckdb_libpgquery::PGKeyword> KeywordList();
+
+	static void SetDowncaseIdentifier(bool downcase);
+	static bool GetDowncaseIdentifier();
 };
+
 }

--- a/third_party/libpg_query/postgres_parser.cpp
+++ b/third_party/libpg_query/postgres_parser.cpp
@@ -2,6 +2,7 @@
 
 #include "pg_functions.hpp"
 #include "parser/parser.hpp"
+#include "parser/scansup.hpp"
 #include "common/keywords.hpp"
 
 using namespace std;
@@ -41,6 +42,14 @@ bool PostgresParser::IsKeyword(const std::string &text) {
 
 vector<duckdb_libpgquery::PGKeyword> PostgresParser::KeywordList() {
 	return duckdb_libpgquery::keyword_list();
+}
+
+void PostgresParser::SetDowncaseIdentifier(bool downcase) {
+	duckdb_libpgquery::set_downcase_identifier(downcase);
+}
+
+bool PostgresParser::GetDowncaseIdentifier() {
+	return duckdb_libpgquery::get_downcase_identifier();
 }
 
 }

--- a/third_party/libpg_query/postgres_parser.cpp
+++ b/third_party/libpg_query/postgres_parser.cpp
@@ -44,12 +44,8 @@ vector<duckdb_libpgquery::PGKeyword> PostgresParser::KeywordList() {
 	return duckdb_libpgquery::keyword_list();
 }
 
-void PostgresParser::SetDowncaseIdentifier(bool downcase) {
-	duckdb_libpgquery::set_downcase_identifier(downcase);
-}
-
-bool PostgresParser::GetDowncaseIdentifier() {
-	return duckdb_libpgquery::get_downcase_identifier();
+void PostgresParser::SetPreserveIdentifierCase(bool preserve) {
+	duckdb_libpgquery::set_preserve_identifier_case(preserve);
 }
 
 }

--- a/third_party/libpg_query/src_backend_parser_scansup.cpp
+++ b/third_party/libpg_query/src_backend_parser_scansup.cpp
@@ -60,14 +60,18 @@ char *downcase_truncate_identifier(const char *ident, int len, bool warn) {
 	return downcase_identifier(ident, len, warn, true);
 }
 
-static bool pg_downcase_identifier = false;
+
+bool *pg_downcase_identifier() {
+	static bool downcase_identifier = false;
+	return &downcase_identifier;
+}
 
 void set_downcase_identifier(bool downcase) {
-	pg_downcase_identifier = downcase;
+	*pg_downcase_identifier() = downcase;
 }
 
 bool get_downcase_identifier() {
-	return pg_downcase_identifier;
+	return *pg_downcase_identifier();
 }
 
 /*
@@ -93,7 +97,7 @@ char *downcase_identifier(const char *ident, int len, bool warn, bool truncate) 
 	for (i = 0; i < len; i++) {
 		unsigned char ch = (unsigned char)ident[i];
 
-		if (pg_downcase_identifier) {
+		if (get_downcase_identifier()) {
 			if (ch >= 'A' && ch <= 'Z')
 				ch += 'a' - 'A';
 			else if (enc_is_single_byte && IS_HIGHBIT_SET(ch) && isupper(ch))

--- a/third_party/libpg_query/src_backend_parser_scansup.cpp
+++ b/third_party/libpg_query/src_backend_parser_scansup.cpp
@@ -60,18 +60,14 @@ char *downcase_truncate_identifier(const char *ident, int len, bool warn) {
 	return downcase_identifier(ident, len, warn, true);
 }
 
+static __thread bool pg_preserve_identifier_case = false;
 
-bool *pg_downcase_identifier() {
-	static bool downcase_identifier = false;
-	return &downcase_identifier;
+void set_preserve_identifier_case(bool preserve) {
+	pg_preserve_identifier_case = preserve;
 }
 
-void set_downcase_identifier(bool downcase) {
-	*pg_downcase_identifier() = downcase;
-}
-
-bool get_downcase_identifier() {
-	return *pg_downcase_identifier();
+bool get_preserve_identifier_case() {
+	return pg_preserve_identifier_case;
 }
 
 /*
@@ -97,7 +93,7 @@ char *downcase_identifier(const char *ident, int len, bool warn, bool truncate) 
 	for (i = 0; i < len; i++) {
 		unsigned char ch = (unsigned char)ident[i];
 
-		if (get_downcase_identifier()) {
+		if (!get_preserve_identifier_case()) {
 			if (ch >= 'A' && ch <= 'Z')
 				ch += 'a' - 'A';
 			else if (enc_is_single_byte && IS_HIGHBIT_SET(ch) && isupper(ch))

--- a/third_party/libpg_query/src_backend_parser_scansup.cpp
+++ b/third_party/libpg_query/src_backend_parser_scansup.cpp
@@ -60,6 +60,16 @@ char *downcase_truncate_identifier(const char *ident, int len, bool warn) {
 	return downcase_identifier(ident, len, warn, true);
 }
 
+static bool pg_downcase_identifier = false;
+
+void set_downcase_identifier(bool downcase) {
+	pg_downcase_identifier = downcase;
+}
+
+bool get_downcase_identifier() {
+	return pg_downcase_identifier;
+}
+
 /*
  * a workhorse for downcase_truncate_identifier
  */
@@ -83,10 +93,12 @@ char *downcase_identifier(const char *ident, int len, bool warn, bool truncate) 
 	for (i = 0; i < len; i++) {
 		unsigned char ch = (unsigned char)ident[i];
 
-		if (ch >= 'A' && ch <= 'Z')
-			ch += 'a' - 'A';
-		else if (enc_is_single_byte && IS_HIGHBIT_SET(ch) && isupper(ch))
-			ch = tolower(ch);
+		if (pg_downcase_identifier) {
+			if (ch >= 'A' && ch <= 'Z')
+				ch += 'a' - 'A';
+			else if (enc_is_single_byte && IS_HIGHBIT_SET(ch) && isupper(ch))
+				ch = tolower(ch);
+		}
 		result[i] = (char)ch;
 	}
 	result[i] = '\0';

--- a/tools/pythonpkg/src/include/duckdb_python/map.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/map.hpp
@@ -20,7 +20,7 @@ public:
 	MapFunction();
 
 	static unique_ptr<FunctionData> MapFunctionBind(ClientContext &context, vector<Value> &inputs,
-	                                                unordered_map<string, Value> &named_parameters,
+	                                                named_parameter_map_t &named_parameters,
 	                                                vector<LogicalType> &input_table_types,
 	                                                vector<string> &input_table_names,
 	                                                vector<LogicalType> &return_types, vector<string> &names);

--- a/tools/pythonpkg/src/include/duckdb_python/pandas_scan.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pandas_scan.hpp
@@ -21,7 +21,7 @@ public:
 	PandasScanFunction();
 
 	static unique_ptr<FunctionData> PandasScanBind(ClientContext &context, vector<Value> &inputs,
-	                                               unordered_map<string, Value> &named_parameters,
+	                                               named_parameter_map_t &named_parameters,
 	                                               vector<LogicalType> &input_table_types,
 	                                               vector<string> &input_table_names, vector<LogicalType> &return_types,
 	                                               vector<string> &names);

--- a/tools/pythonpkg/src/map.cpp
+++ b/tools/pythonpkg/src/map.cpp
@@ -44,7 +44,7 @@ static py::handle FunctionCall(NumpyResultConversion &conversion, vector<string>
 // we call the passed function with a zero-row data frame to infer the output columns and their names.
 // they better not change in the actual execution ^^
 unique_ptr<FunctionData> MapFunction::MapFunctionBind(ClientContext &context, vector<Value> &inputs,
-                                                      unordered_map<string, Value> &named_parameters,
+                                                      named_parameter_map_t &named_parameters,
                                                       vector<LogicalType> &input_table_types,
                                                       vector<string> &input_table_names,
                                                       vector<LogicalType> &return_types, vector<string> &names) {

--- a/tools/pythonpkg/src/pandas_scan.cpp
+++ b/tools/pythonpkg/src/pandas_scan.cpp
@@ -53,7 +53,7 @@ PandasScanFunction::PandasScanFunction()
 }
 
 unique_ptr<FunctionData> PandasScanFunction::PandasScanBind(ClientContext &context, vector<Value> &inputs,
-                                                            unordered_map<string, Value> &named_parameters,
+                                                            named_parameter_map_t &named_parameters,
                                                             vector<LogicalType> &input_table_types,
                                                             vector<string> &input_table_names,
                                                             vector<LogicalType> &return_types, vector<string> &names) {

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -280,7 +280,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromParquet(const string &filen
 	}
 	vector<Value> params;
 	params.emplace_back(filename);
-	unordered_map<string, Value> named_parameters({{"binary_as_string", Value::BOOLEAN(binary_as_string)}});
+	named_parameter_map_t named_parameters({{"binary_as_string", Value::BOOLEAN(binary_as_string)}});
 	return make_unique<DuckDBPyRelation>(
 	    connection->TableFunction("parquet_scan", params, named_parameters)->Alias(filename));
 }

--- a/tools/rpkg/src/scan.cpp
+++ b/tools/rpkg/src/scan.cpp
@@ -50,7 +50,7 @@ struct DataFrameScanState : public FunctionOperatorData {
 };
 
 static unique_ptr<FunctionData> dataframe_scan_bind(ClientContext &context, vector<Value> &inputs,
-                                                    unordered_map<string, Value> &named_parameters,
+                                                    named_parameter_map_t &named_parameters,
                                                     vector<LogicalType> &input_table_types,
                                                     vector<string> &input_table_names,
                                                     vector<LogicalType> &return_types, vector<string> &names) {

--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -413,14 +413,14 @@ test('.databases', out='main:')
 
 # .dump test
 test('''
-CREATE TABLE a (I INTEGER);
+CREATE TABLE a (i INTEGER);
 .changes off
 INSERT INTO a VALUES (42);
 .dump
 ''', 'CREATE TABLE a(i INTEGER)')
 
 test('''
-CREATE TABLE a (I INTEGER);
+CREATE TABLE a (i INTEGER);
 .changes off
 INSERT INTO a VALUES (42);
 .dump
@@ -428,7 +428,7 @@ INSERT INTO a VALUES (42);
 
 # .dump a specific table
 test('''
-CREATE TABLE a (I INTEGER);
+CREATE TABLE a (i INTEGER);
 .changes off
 INSERT INTO a VALUES (42);
 .dump a
@@ -436,7 +436,7 @@ INSERT INTO a VALUES (42);
 
 # .dump LIKE
 test('''
-CREATE TABLE a (I INTEGER);
+CREATE TABLE a (i INTEGER);
 .changes off
 INSERT INTO a VALUES (42);
 .dump a%

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -135,7 +135,7 @@ int sqlite3_prepare_v2(sqlite3 *db,           /* Database handle */
 		*pzTail = zSql + query.size();
 	}
 	try {
-		Parser parser;
+		Parser parser(db->con->context->GetParserOptions());
 		parser.ParseQuery(query);
 		if (parser.statements.size() == 0) {
 			return SQLITE_OK;


### PR DESCRIPTION
Fixes #2075

With this PR we no longer automatically lower-case unquoted identifiers, and instead preserve them as-is. This should in general not change anything in the SQL layer, as our entire binding engine is case insensitive (e.g. the names "MyTable" and "mytable" can always be used interchangeably). However, this makes a difference when exporting columns to e.g. Pandas DataFrames, Parquet files or CSV files, since the column name will now be preserved as it has been typed by the user in the SQL statement.

```sql
D create table MyTable(MyColumn INTEGER);
D select * from sqlite_master;
┌───────┬─────────┬──────────┬──────────┬─────────────────────────────────────────────┐
│ type  │  name   │ tbl_name │ rootpage │                     sql                     │
├───────┼─────────┼──────────┼──────────┼─────────────────────────────────────────────┤
│ table │ MyTable │ MyTable  │ 0        │ CREATE TABLE "MyTable"("MyColumn" INTEGER); │
└───────┴─────────┴──────────┴──────────┴─────────────────────────────────────────────┘
```

You can revert to the old behavior using the `preserve_identifier_case` setting (defaults to true).

```sql
D SET preserve_identifier_case=false;
D create table MyTable(MyColumn INTEGER);
D select * from sqlite_master;
┌───────┬─────────┬──────────┬──────────┬─────────────────────────────────────────┐
│ type  │  name   │ tbl_name │ rootpage │                   sql                   │
├───────┼─────────┼──────────┼──────────┼─────────────────────────────────────────┤
│ table │ mytable │ mytable  │ 0        │ CREATE TABLE mytable(mycolumn INTEGER); │
└───────┴─────────┴──────────┴──────────┴─────────────────────────────────────────┘
```