### PR TITLE
list_slice test fix

### DIFF
--- a/test/sql/function/string/test_string_array_slice.test
+++ b/test/sql/function/string/test_string_array_slice.test
@@ -43,7 +43,7 @@ SELECT list_slice(s, 0, 2) FROM strings
 ----
 he
 wo
-NULL
+b
 NULL
 
 # index out of range


### PR DESCRIPTION
Fix a problem caused by #2917 adding a test case, that was broken by #2921 through changing the semantics of the array_slice function.