### PR TITLE
src/include/duckdb/common/assert.hpp: Added winapi

### DIFF
--- a/src/include/duckdb/common/assert.hpp
+++ b/src/include/duckdb/common/assert.hpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "duckdb/common/winapi.hpp"
+
 #pragma once
 
 #if (defined(DUCKDB_USE_STANDARD_ASSERT) || !defined(DEBUG)) && !defined(DUCKDB_FORCE_ASSERT)
@@ -14,7 +16,7 @@
 #define D_ASSERT assert
 #else
 namespace duckdb {
-void DuckDBAssertInternal(bool condition, const char *condition_name, const char *file, int linenr);
+DUCKDB_API void DuckDBAssertInternal(bool condition, const char *condition_name, const char *file, int linenr);
 }
 
 #define D_ASSERT(condition) duckdb::DuckDBAssertInternal(bool(condition), #condition, __FILE__, __LINE__)


### PR DESCRIPTION
When building duckdb with the LLVM ClangCl compiler frontend 13.0.0 in front of Visual Studio 2019 v16.11 and using ninja, I get an error about an undefined symbol:
```
lld-link: error: undefined symbol: void __cdecl duckdb::DuckDBAssertInternal(bool, char const *, char const *, int)
>>> referenced by C:\BDA\bld\XTJyb_7r\0\duckdb\src\include\duckdb\common\types\string_type.hpp:32
>>>               test\extension\CMakeFiles\loadable_extension_demo.dir\loadable_extension_demo.cpp.obj:(public: __cdecl duckdb::string_t::string_t(char const *, unsigned int))
>>> referenced by C:\BDA\bld\XTJyb_7r\0\duckdb\src\include\duckdb\common\types\vector.hpp:217
>>>               test\extension\CMakeFiles\loadable_extension_demo.dir\loadable_extension_demo.cpp.obj:(public: static bool __cdecl duckdb::ConstantVector::IsNull(class duckdb::Vector const &))
>>> referenced by C:\BDA\bld\XTJyb_7r\0\duckdb\src\include\duckdb\common\types\vector.hpp:222
>>>               test\extension\CMakeFiles\loadable_extension_demo.dir\loadable_extension_demo.cpp.obj:(public: static struct duckdb::ValidityMask & __cdecl duckdb::ConstantVector::Validity(class duckdb::Vector &))
>>> referenced 8 more times
```

To resolve this error, I have to add the DLL export for `DuckDBAssertInternal`.