### PR TITLE
CMakeLists.txt: Add 'delayimp.lib' to delay-loaded DLL on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -587,7 +587,10 @@ function(build_loadable_extension_directory NAME OUTPUT_DIRECTORY)
             PROPERTIES LINK_FLAGS_RELEASE "/DELAYLOAD:duckdb.dll")
     set(CMAKE_EXE_LINKER_FLAGS_RELEASE
             "${CMAKE_EXE_LINKER_FLAGS_RELEASE}  /DELAYLOAD:duckdb.dll")
-  endif()
+    # This is only strictly required in non-Visual-Studio builds like Ninja:
+    target_link_libraries(${TARGET_NAME}
+            delayimp)
+endif()
 
 endfunction()
 


### PR DESCRIPTION
When building DuckDB with cmake and Ninja, the MSVC dependency `delayimp.lib` is not automatically added to dela-loaded DLLs. Therefore its better to add this dependency manually and explicitly.

See https://discourse.cmake.org/t/delayload-inconsistency-between-visual-studio-and-ninja-generators/2719/2 for the same suggestion from upstream cmake.