### PR TITLE
fix: use selection vector to ensure ids are ordered

### DIFF
--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -521,8 +521,8 @@ void UpdateSegment::CleanupUpdate(UpdateInfo *info) {
 //===--------------------------------------------------------------------===//
 // Check for conflicts in update
 //===--------------------------------------------------------------------===//
-static void CheckForConflicts(UpdateInfo *info, Transaction &transaction, row_t *ids, idx_t count, row_t offset,
-                              UpdateInfo *&node) {
+static void CheckForConflicts(UpdateInfo *info, Transaction &transaction, row_t *ids, const SelectionVector &sel,
+                              idx_t count, row_t offset, UpdateInfo *&node) {
 	if (!info) {
 		return;
 	}
@@ -534,7 +534,7 @@ static void CheckForConflicts(UpdateInfo *info, Transaction &transaction, row_t 
 		// as both ids and info->tuples are sorted, this is similar to a merge join
 		idx_t i = 0, j = 0;
 		while (true) {
-			auto id = ids[i] - offset;
+			auto id = ids[sel.get_index(i)] - offset;
 			if (id == info->tuples[j]) {
 				throw TransactionException("Conflict on update!");
 			} else if (id < info->tuples[j]) {
@@ -552,7 +552,7 @@ static void CheckForConflicts(UpdateInfo *info, Transaction &transaction, row_t 
 			}
 		}
 	}
-	CheckForConflicts(info->next, transaction, ids, count, offset, node);
+	CheckForConflicts(info->next, transaction, ids, sel, count, offset, node);
 }
 
 //===--------------------------------------------------------------------===//
@@ -1085,7 +1085,7 @@ void UpdateSegment::Update(Transaction &transaction, idx_t column_index, Vector 
 		// there is already a version here, check if there are any conflicts and search for the node that belongs to
 		// this transaction in the version chain
 		auto base_info = root->info[vector_index]->info.get();
-		CheckForConflicts(base_info->next, transaction, ids, count, vector_offset, node);
+		CheckForConflicts(base_info->next, transaction, ids, sel, count, vector_offset, node);
 
 		// there are no conflicts
 		// first, check if this thread has already done any updates

--- a/test/sql/transactions/test_from_update_conflict.test
+++ b/test/sql/transactions/test_from_update_conflict.test
@@ -1,0 +1,43 @@
+# name: test/sql/transactions/test_from_update_conflict.test
+# description: Test correct checking for out-of-order row id updates
+# group: [transactions]
+statement ok con1
+CREATE TABLE test AS SELECT i AS a FROM range (2048, 5000, 1) t1(i)
+
+statement ok con1
+INSERT INTO test VALUES (1), (2), (3)
+
+statement ok con1
+CREATE TABLE src(b INTEGER)
+
+statement ok con1
+INSERT INTO src VALUES (3), (2), (1), (4)
+
+
+query IIII con1
+SELECT src.rowid sr, b, test.rowid tr, a FROM src, test WHERE src.b = test.a;
+----
+2	1	2952	1
+1	2	2953	2
+0	3	2954	3   
+
+statement ok con1
+BEGIN TRANSACTION
+
+statement ok con1 
+UPDATE src SET b = 10000 WHERE src.rowid = 0 OR src.rowid = 1 OR src.rowid = 3
+
+query I con1
+SELECT b FROM src
+----
+10000
+10000
+1
+10000
+
+
+statement ok con2
+BEGIN TRANSACTION
+
+statement error con2
+UPDATE src SET b = 20000 FROM test WHERE src.b = test.a;

--- a/test/sql/transactions/test_from_update_conflict.test
+++ b/test/sql/transactions/test_from_update_conflict.test
@@ -1,6 +1,7 @@
 # name: test/sql/transactions/test_from_update_conflict.test
 # description: Test correct checking for out-of-order row id updates
 # group: [transactions]
+
 statement ok con1
 CREATE TABLE test AS SELECT i AS a FROM range (2048, 5000, 1) t1(i)
 


### PR DESCRIPTION
`static idx_t SortSelectionVector(SelectionVector &sel, idx_t count, row_t *ids)`
**SortSelectionVector** does not actually sort ids, but ensures that ids are ordered through SelectionVector

The algorithm in **CheckForConflicts** needs to traverse the ids in order, which requires a SelectionVector to guarantee.