### PR TITLE
Arrow use_async argument deprecation

### DIFF
--- a/tools/rpkg/R/register.R
+++ b/tools/rpkg/R/register.R
@@ -65,15 +65,22 @@ duckdb_unregister <- function(conn, name) {
 #' @param conn A DuckDB connection, created by `dbConnect()`.
 #' @param name The name for the virtual table that is registered or unregistered
 #' @param arrow_scannable A scannable Arrow-object
-#' @param use_async Switched to the asynchronous scanner. default FALSE
+#' @param use_async Switched to the asynchronous scanner. (deprecated)
 #' @return These functions are called for their side effect.
 #' @export
-duckdb_register_arrow <- function(conn, name, arrow_scannable, use_async = FALSE) {
+duckdb_register_arrow <- function(conn, name, arrow_scannable, use_async = NULL) {
   stopifnot(dbIsValid(conn))
+
+  if (!is.null(use_async)) {
+    .Deprecated(msg = paste(
+      "The parameter 'use_async' is deprecated",
+      "and will be removed in a future release."
+    ))
+  }
 
   # create some R functions to pass to c-land
   export_fun <- function(arrow_scannable, stream_ptr, projection = NULL, filter = TRUE) {
-    arrow::Scanner$create(arrow_scannable, projection, filter, use_async = use_async)$ToRecordBatchReader()$export_to_c(stream_ptr)
+    arrow::Scanner$create(arrow_scannable, projection, filter)$ToRecordBatchReader()$export_to_c(stream_ptr)
   }
   # pass some functions to c land so we don't have to look them up there
   function_list <- list(export_fun, arrow::Expression$create, arrow::Expression$field_ref, arrow::Expression$scalar)

--- a/tools/rpkg/man/duckdb_register_arrow.Rd
+++ b/tools/rpkg/man/duckdb_register_arrow.Rd
@@ -6,7 +6,7 @@
 \alias{duckdb_list_arrow}
 \title{Register an Arrow data source as a virtual table}
 \usage{
-duckdb_register_arrow(conn, name, arrow_scannable, use_async = FALSE)
+duckdb_register_arrow(conn, name, arrow_scannable, use_async = NULL)
 
 duckdb_unregister_arrow(conn, name)
 
@@ -19,7 +19,7 @@ duckdb_list_arrow(conn)
 
 \item{arrow_scannable}{A scannable Arrow-object}
 
-\item{use_async}{Switched to the asynchronous scanner. default FALSE}
+\item{use_async}{Switched to the asynchronous scanner. (deprecated)}
 }
 \value{
 These functions are called for their side effect.

--- a/tools/rpkg/tests/testthat/test_register_arrow.R
+++ b/tools/rpkg/tests/testthat/test_register_arrow.R
@@ -51,7 +51,7 @@ test_that("duckdb_register_arrow() works with datasets and async arrow scanner",
 
   # Registering a dataset + aggregation
   ds <- arrow::open_dataset("data/userdata1.parquet")
-  duckdb::duckdb_register_arrow(con, "mydatasetreader", ds, use_async = TRUE)
+  duckdb::duckdb_register_arrow(con, "mydatasetreader", ds)
   res1 <- dbGetQuery(con, "SELECT count(*) FROM mydatasetreader")
   res2 <- dbGetQuery(con, "SELECT count(*) FROM parquet_scan('data/userdata1.parquet')")
   expect_true(identical(res1, res2))


### PR DESCRIPTION
As part of some cleanups and deprecations in Arrow (specifically: https://issues.apache.org/jira/browse/ARROW-13554), we've deprecated the use of `use_async` argument in the scanner builder. This PR also deprecates this in DuckDB so that people have some warning that the argument is going away.