### PR TITLE
Python API - allow duckdb.query to run arbitrary queries

### DIFF
--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -28,6 +28,7 @@ class ClientContext;
 class DatabaseInstance;
 class DuckDB;
 class LogicalOperator;
+class SelectStatement;
 
 typedef void (*warning_callback)(std::string);
 
@@ -127,7 +128,10 @@ public:
 	DUCKDB_API shared_ptr<Relation> ReadCSV(const string &csv_file);
 	DUCKDB_API shared_ptr<Relation> ReadCSV(const string &csv_file, const vector<string> &columns);
 	//! Returns a relation from a query
-	DUCKDB_API shared_ptr<Relation> RelationFromQuery(const string &query, const string &alias = "queryrelation");
+	DUCKDB_API shared_ptr<Relation> RelationFromQuery(string query, string alias = "queryrelation",
+	                                                  string error = "Expected a single SELECT statement");
+	DUCKDB_API shared_ptr<Relation> RelationFromQuery(unique_ptr<SelectStatement> select_stmt,
+	                                                  string alias = "queryrelation");
 
 	DUCKDB_API void BeginTransaction();
 	DUCKDB_API void Commit();

--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -128,8 +128,8 @@ public:
 	DUCKDB_API shared_ptr<Relation> ReadCSV(const string &csv_file);
 	DUCKDB_API shared_ptr<Relation> ReadCSV(const string &csv_file, const vector<string> &columns);
 	//! Returns a relation from a query
-	DUCKDB_API shared_ptr<Relation> RelationFromQuery(string query, string alias = "queryrelation",
-	                                                  string error = "Expected a single SELECT statement");
+	DUCKDB_API shared_ptr<Relation> RelationFromQuery(const string &query, string alias = "queryrelation",
+	                                                  const string &error = "Expected a single SELECT statement");
 	DUCKDB_API shared_ptr<Relation> RelationFromQuery(unique_ptr<SelectStatement> select_stmt,
 	                                                  string alias = "queryrelation");
 

--- a/src/include/duckdb/main/relation/query_relation.hpp
+++ b/src/include/duckdb/main/relation/query_relation.hpp
@@ -16,13 +16,15 @@ class SelectStatement;
 
 class QueryRelation : public Relation {
 public:
-	QueryRelation(ClientContext &context, string query, string alias = "query_relation");
+	QueryRelation(ClientContext &context, unique_ptr<SelectStatement> select_stmt, string alias);
+	~QueryRelation();
 
-	string query;
+	unique_ptr<SelectStatement> select_stmt;
 	string alias;
 	vector<ColumnDefinition> columns;
 
 public:
+	static unique_ptr<SelectStatement> ParseStatement(ClientContext &context, const string &query, const string &error);
 	unique_ptr<QueryNode> GetQueryNode() override;
 	unique_ptr<TableRef> GetTableRef() override;
 

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -208,8 +208,12 @@ unordered_set<string> Connection::GetTableNames(const string &query) {
 	return context->GetTableNames(query);
 }
 
-shared_ptr<Relation> Connection::RelationFromQuery(const string &query, const string &alias) {
-	return make_shared<QueryRelation>(*context, query, alias);
+shared_ptr<Relation> Connection::RelationFromQuery(string query, string alias, string error) {
+	return RelationFromQuery(QueryRelation::ParseStatement(*context, query, error), move(alias));
+}
+
+shared_ptr<Relation> Connection::RelationFromQuery(unique_ptr<SelectStatement> select_stmt, string alias) {
+	return make_shared<QueryRelation>(*context, move(select_stmt), move(alias));
 }
 
 void Connection::BeginTransaction() {

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -208,7 +208,7 @@ unordered_set<string> Connection::GetTableNames(const string &query) {
 	return context->GetTableNames(query);
 }
 
-shared_ptr<Relation> Connection::RelationFromQuery(string query, string alias, string error) {
+shared_ptr<Relation> Connection::RelationFromQuery(const string &query, string alias, const string &error) {
 	return RelationFromQuery(QueryRelation::ParseStatement(*context, query, error), move(alias));
 }
 

--- a/src/main/relation/query_relation.cpp
+++ b/src/main/relation/query_relation.cpp
@@ -1,26 +1,34 @@
 #include "duckdb/main/relation/query_relation.hpp"
 #include "duckdb/main/client_context.hpp"
-#include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
+#include "duckdb/parser/parser.hpp"
 
 namespace duckdb {
 
-QueryRelation::QueryRelation(ClientContext &context, string query, string alias)
-    : Relation(context, RelationType::QUERY_RELATION), query(move(query)), alias(move(alias)) {
+QueryRelation::QueryRelation(ClientContext &context, unique_ptr<SelectStatement> select_stmt_p, string alias_p)
+    : Relation(context, RelationType::QUERY_RELATION), select_stmt(move(select_stmt_p)), alias(move(alias_p)) {
 	context.TryBindRelation(*this, this->columns);
 }
 
-unique_ptr<SelectStatement> QueryRelation::GetSelectStatement() {
+QueryRelation::~QueryRelation() {
+}
+
+unique_ptr<SelectStatement> QueryRelation::ParseStatement(ClientContext &context, const string &query,
+                                                          const string &error) {
 	Parser parser(context.GetParserOptions());
 	parser.ParseQuery(query);
 	if (parser.statements.size() != 1) {
-		throw ParserException("Expected a single SELECT statement");
+		throw ParserException(error);
 	}
 	if (parser.statements[0]->type != StatementType::SELECT_STATEMENT) {
-		throw ParserException("Expected a single SELECT statement");
+		throw ParserException(error);
 	}
 	return unique_ptr_cast<SQLStatement, SelectStatement>(move(parser.statements[0]));
+}
+
+unique_ptr<SelectStatement> QueryRelation::GetSelectStatement() {
+	return unique_ptr_cast<SQLStatement, SelectStatement>(select_stmt->Copy());
 }
 
 unique_ptr<QueryNode> QueryRelation::GetQueryNode() {
@@ -42,7 +50,7 @@ const vector<ColumnDefinition> &QueryRelation::Columns() {
 }
 
 string QueryRelation::ToString(idx_t depth) {
-	return RenderWhitespace(depth) + "Subquery [" + query + "]";
+	return RenderWhitespace(depth) + "Subquery";
 }
 
 } // namespace duckdb

--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -100,8 +100,11 @@ PYBIND11_MODULE(DUCKDB_PYTHON_LIB_NAME, m) {
 	m.def("from_query", &DuckDBPyRelation::FromQuery, "Create a relation object from the given SQL query",
 	      py::arg("query"), py::arg("alias") = "query_relation",
 	      py::arg("connection") = DuckDBPyConnection::DefaultConnection());
-	m.def("query", &DuckDBPyRelation::FromQuery, "Create a relation object from the given SQL query", py::arg("query"),
-	      py::arg("alias") = "query_relation", py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	m.def("query", &DuckDBPyRelation::RunQuery,
+	      "Run a SQL query. If it is a SELECT statement, create a relation object from the given SQL query, otherwise "
+	      "run the query as-is.",
+	      py::arg("query"), py::arg("alias") = "query_relation",
+	      py::arg("connection") = DuckDBPyConnection::DefaultConnection());
 	m.def("from_csv_auto", &DuckDBPyRelation::FromCsvAuto, "Creates a relation object from the CSV file in file_name",
 	      py::arg("file_name"), py::arg("connection") = DuckDBPyConnection::DefaultConnection());
 	m.def("from_parquet", &DuckDBPyRelation::FromParquet,

--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
@@ -64,6 +64,7 @@ public:
 	                                         const idx_t rows_per_tuple = 100000);
 
 	unique_ptr<DuckDBPyRelation> FromQuery(const string &query, const string &alias = "query_relation");
+	unique_ptr<DuckDBPyRelation> RunQuery(const string &query, const string &alias = "query_relation");
 
 	unique_ptr<DuckDBPyRelation> Table(const string &tname);
 

--- a/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
@@ -35,6 +35,9 @@ public:
 	static unique_ptr<DuckDBPyRelation> FromQuery(const string &query, const string &alias,
 	                                              DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
 
+	static unique_ptr<DuckDBPyRelation> RunQuery(const string &query, const string &alias,
+	                                             DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+
 	static unique_ptr<DuckDBPyRelation> FromCsvAuto(const string &filename,
 	                                                DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
 

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -15,6 +15,7 @@
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
+#include "duckdb/parser/parser.hpp"
 
 #include "datetime.h" // from Python
 
@@ -70,7 +71,9 @@ void DuckDBPyConnection::Initialize(py::handle &m) {
 	         py::arg("parameters") = py::list())
 	    .def("from_query", &DuckDBPyConnection::FromQuery, "Create a relation object from the given SQL query",
 	         py::arg("query"), py::arg("alias") = "query_relation")
-	    .def("query", &DuckDBPyConnection::FromQuery, "Create a relation object from the given SQL query",
+	    .def("query", &DuckDBPyConnection::RunQuery,
+	         "Run a SQL query. If it is a SELECT statement, create a relation object from the given SQL query, "
+	         "otherwise run the query as-is.",
 	         py::arg("query"), py::arg("alias") = "query_relation")
 	    .def("from_df", &DuckDBPyConnection::FromDF, "Create a relation object from the Data.Frame in df",
 	         py::arg("df") = py::none())
@@ -206,7 +209,28 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromQuery(const string &query, 
 	if (!connection) {
 		throw std::runtime_error("connection closed");
 	}
-	return make_unique<DuckDBPyRelation>(connection->RelationFromQuery(query, alias));
+	const char *duckdb_query_error = R"(duckdb.from_query cannot be used to run arbitrary SQL queries.
+It can only be used to run individual SELECT statements, and converts the result of that SELECT
+statement into a Relation object.
+Use duckdb.query to run arbitrary SQL queries.)";
+	return make_unique<DuckDBPyRelation>(connection->RelationFromQuery(query, alias, duckdb_query_error));
+}
+
+unique_ptr<DuckDBPyRelation> DuckDBPyConnection::RunQuery(const string &query, const string &alias) {
+	if (!connection) {
+		throw std::runtime_error("connection closed");
+	}
+	Parser parser(connection->context->GetParserOptions());
+	parser.ParseQuery(query);
+	if (parser.statements.size() == 1 && parser.statements[0]->type == StatementType::SELECT_STATEMENT) {
+		return make_unique<DuckDBPyRelation>(connection->RelationFromQuery(
+		    unique_ptr_cast<SQLStatement, SelectStatement>(move(parser.statements[0])), alias));
+	}
+	Execute(query);
+	if (result) {
+		FetchAll();
+	}
+	return nullptr;
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyConnection::Table(const string &tname) {

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -79,6 +79,11 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromQuery(const string &query, co
 	return conn->FromQuery(query, alias);
 }
 
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::RunQuery(const string &query, const string &alias,
+                                                        DuckDBPyConnection *conn) {
+	return conn->RunQuery(query, alias);
+}
+
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromCsvAuto(const string &filename, DuckDBPyConnection *conn) {
 	return conn->FromCsvAuto(filename);
 }

--- a/tools/pythonpkg/tests/fast/api/duckdb_query.py
+++ b/tools/pythonpkg/tests/fast/api/duckdb_query.py
@@ -1,0 +1,27 @@
+
+import duckdb
+import pytest
+
+class TestDuckDBQuery(object):
+    def test_duckdb_query(self, duckdb_cursor):
+        # we can use duckdb.query to run both DDL statements and select statements
+        duckdb.query('create view v1 as select 42 i')
+        rel = duckdb.query('select * from v1')
+        assert rel.fetchall()[0][0] == 42;
+
+        # also multiple statements
+        duckdb.query('create view v2 as select i*2 j from v1; create view v3 as select j * 2 from v2;')
+        rel = duckdb.query('select * from v3')
+        assert rel.fetchall()[0][0] == 168;
+
+        # we can run multiple select statements, but we get no result
+        res = duckdb.query('select 42; select 84;');
+        assert res is None
+
+    def test_duckdb_from_query(self, duckdb_cursor):
+        # duckdb.from_query cannot be used to run arbitrary queries
+        with pytest.raises(Exception) as e_info:
+            duckdb.from_query('create view v1 as select 42 i')
+        # ... or multiple select statements
+        with pytest.raises(Exception) as e_info:
+            duckdb.from_query('select 42; select 84;')

--- a/tools/pythonpkg/tests/fast/api/duckdb_query.py
+++ b/tools/pythonpkg/tests/fast/api/duckdb_query.py
@@ -22,6 +22,8 @@ class TestDuckDBQuery(object):
         # duckdb.from_query cannot be used to run arbitrary queries
         with pytest.raises(Exception) as e_info:
             duckdb.from_query('create view v1 as select 42 i')
+        assert 'duckdb.query' in str(e_info.value)
         # ... or multiple select statements
         with pytest.raises(Exception) as e_info:
             duckdb.from_query('select 42; select 84;')
+        assert 'duckdb.query' in str(e_info.value)


### PR DESCRIPTION
`duckdb.query` is a bit of a misnomer - it was originally added to allow the creation of relation objects from select statements, but it has since been the source of confusion for several newcomers. In this PR we make the change so that `duckdb.query` can be used to run arbitrary queries, but will still return a relation object if (and only if) the query is a single `SELECT` statement. So the following now works:

```py
duckdb.query('create view v1 as select 42 i')
print(duckdb.query('select  * from v1'))
```

The `duckdb.from_query` remains unchanged and will throw a (now more clear) error if it is used to do anything besides run a single select statement:

```
duckdb.from_query cannot be used to run arbitrary SQL queries.
It can only be used to run individual SELECT statements, and converts the result of that SELECT
statement into a Relation object.
Use duckdb.query to run arbitrary SQL queries.

```