### PR TITLE
Fix #2975: fix off-by-one in transform of string constant to decimal in case of large negative numbers

### DIFF
--- a/src/parser/transform/expression/transform_constant.cpp
+++ b/src/parser/transform/expression/transform_constant.cpp
@@ -45,7 +45,9 @@ unique_ptr<ConstantExpression> Transformer::TransformValue(duckdb_libpgquery::PG
 				return make_unique<ConstantExpression>(Value::HUGEINT(hugeint_value));
 			}
 		}
-		if (try_cast_as_decimal && decimal_position >= 0 && str_val.GetSize() < Decimal::MAX_WIDTH_DECIMAL + 2) {
+		idx_t decimal_offset = val.val.str[0] == '-' ? 3 : 2;
+		if (try_cast_as_decimal && decimal_position >= 0 &&
+		    str_val.GetSize() < Decimal::MAX_WIDTH_DECIMAL + decimal_offset) {
 			// figure out the width/scale based on the decimal position
 			auto width = uint8_t(str_val.GetSize() - 1);
 			auto scale = uint8_t(width - decimal_position);

--- a/test/sql/types/decimal/test_decimal_2975.test
+++ b/test/sql/types/decimal/test_decimal_2975.test
@@ -1,0 +1,21 @@
+# name: test/sql/types/decimal/test_decimal_2975.test
+# description: Test #2975: Insert with large decimal fails
+# group: [decimal]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table q (big decimal (38,10))
+
+statement ok
+insert into q (big ) values (9999999999999999899999999999.9999999999);
+
+statement ok
+insert into q (big ) values (-9999999999999999899999999999.9999999999);
+
+query I
+SELECT * FROM q
+----
+9999999999999999899999999999.9999999999
+-9999999999999999899999999999.9999999999


### PR DESCRIPTION
Fixes #2975