### PR TITLE
Document installation of dependencies in Python package README

### DIFF
--- a/tools/pythonpkg/README.md
+++ b/tools/pythonpkg/README.md
@@ -2,12 +2,17 @@ This is the DuckDB Python package
 
 ## Default installation
 
-You would normally install the DuckDB released version using `pip` as follows:
-    pip install duckdb
+You would normally install the DuckDB released version using pip as follows:
+
+    pip3 install duckdb
 
 ## Installing locally for development
 
-For development, you may need a DuckDB python package that is installed from source. In order to install from source, the simplest way is by cloning the git repo, and running the make command with `BUILD_PYTHON` set:
+For development, you may need a DuckDB Python package that is installed from source. Make sure you have the dependencies installed:
+
+    pip3 install -r requirements-dev.txt
+
+ In order to install from source, the simplest way is to install by cloning the git repo, and running the make command with `BUILD_PYTHON` set:
 
     BUILD_PYTHON=1 make debug
 


### PR DESCRIPTION
I amended the README of the Python package.

A remark: the [`requirements-dev.txt`](https://github.com/duckdb/duckdb/blob/d0670872fe61b5d581bb3a28c7f05c60dc086a3b/tools/pythonpkg/requirements-dev.txt) seems a bit excessive. For me, installing `numpy` was enough to get the `duckdb` Python package working.
