### PR TITLE
Fix #2997: allow maximum CSV line size to be configurable

### DIFF
--- a/src/execution/operator/persistent/buffered_csv_reader.cpp
+++ b/src/execution/operator/persistent/buffered_csv_reader.cpp
@@ -1532,8 +1532,8 @@ bool BufferedCSVReader::ReadBuffer(idx_t &start) {
 	while (remaining > buffer_read_size) {
 		buffer_read_size *= 2;
 	}
-	if (remaining + buffer_read_size > MAXIMUM_CSV_LINE_SIZE) {
-		throw InvalidInputException("Maximum line size of %llu bytes exceeded!", MAXIMUM_CSV_LINE_SIZE);
+	if (remaining + buffer_read_size > options.maximum_line_size) {
+		throw InvalidInputException("Maximum line size of %llu bytes exceeded!", options.maximum_line_size);
 	}
 	buffer = unique_ptr<char[]>(new char[buffer_read_size + remaining + 1]);
 	buffer_size = remaining + buffer_read_size;

--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -81,7 +81,7 @@ static bool ParseBaseOption(BufferedCSVReaderOptions &options, string &loption, 
 	} else if (loption == "compression") {
 		options.compression = FileCompressionTypeFromString(ParseString(set));
 	} else if (loption == "skip") {
-		options.skip_rows = ParseInteger(set);;
+		options.skip_rows = ParseInteger(set);
 	} else if (loption == "max_line_size" || loption == "maximum_line_size") {
 		options.maximum_line_size = ParseInteger(set);
 	} else {

--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -81,7 +81,9 @@ static bool ParseBaseOption(BufferedCSVReaderOptions &options, string &loption, 
 	} else if (loption == "compression") {
 		options.compression = FileCompressionTypeFromString(ParseString(set));
 	} else if (loption == "skip") {
-		options.skip_rows = ParseInteger(set);
+		options.skip_rows = ParseInteger(set);;
+	} else if (loption == "max_line_size" || loption == "maximum_line_size") {
+		options.maximum_line_size = ParseInteger(set);
 	} else {
 		// unrecognized option in base CSV
 		return false;

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -124,6 +124,8 @@ static unique_ptr<FunctionData> ReadCSVBind(ClientContext &context, vector<Value
 			result->include_file_name = BooleanValue::Get(kv.second);
 		} else if (loption == "skip") {
 			options.skip_rows = kv.second.GetValue<int64_t>();
+		} else if (loption == "max_line_size" || loption == "maximum_line_size") {
+			options.maximum_line_size = kv.second.GetValue<int64_t>();
 		} else {
 			throw InternalException("Unrecognized parameter %s", kv.first);
 		}
@@ -230,6 +232,8 @@ static void ReadCSVAddNamedParameters(TableFunction &table_function) {
 	table_function.named_parameters["compression"] = LogicalType::VARCHAR;
 	table_function.named_parameters["filename"] = LogicalType::BOOLEAN;
 	table_function.named_parameters["skip"] = LogicalType::BIGINT;
+	table_function.named_parameters["max_line_size"] = LogicalType::VARCHAR;
+	table_function.named_parameters["maximum_line_size"] = LogicalType::VARCHAR;
 }
 
 double CSVReaderProgress(ClientContext &context, const FunctionData *bind_data_p) {

--- a/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
@@ -95,6 +95,9 @@ struct BufferedCSVReaderOptions {
 	idx_t buffer_size = STANDARD_VECTOR_SIZE * 100;
 	//! Consider all columns to be of type varchar
 	bool all_varchar = false;
+	//! Maximum CSV line size: specified because if we reach this amount, we likely have the wrong delimiters (default: 2MB)
+	idx_t maximum_line_size = 2097152;
+
 	//! The date format to use (if any is specified)
 	std::map<LogicalTypeId, StrpTimeFormat> date_format = {{LogicalTypeId::DATE, {}}, {LogicalTypeId::TIMESTAMP, {}}};
 	//! Whether or not a type format is specified
@@ -111,8 +114,6 @@ enum class ParserMode : uint8_t { PARSING = 0, SNIFFING_DIALECT = 1, SNIFFING_DA
 class BufferedCSVReader {
 	//! Initial buffer read size; can be extended for long lines
 	static constexpr idx_t INITIAL_BUFFER_SIZE = 16384;
-	//! Maximum CSV line size: specified because if we reach this amount, we likely have the wrong delimiters
-	static constexpr idx_t MAXIMUM_CSV_LINE_SIZE = 1048576;
 	ParserMode mode;
 
 public:

--- a/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
@@ -95,7 +95,7 @@ struct BufferedCSVReaderOptions {
 	idx_t buffer_size = STANDARD_VECTOR_SIZE * 100;
 	//! Consider all columns to be of type varchar
 	bool all_varchar = false;
-	//! Maximum CSV line size: specified because if we reach this amount, we likely have the wrong delimiters (default: 2MB)
+	//! Maximum CSV line size: specified because if we reach this amount, we likely have wrong delimiters (default: 2MB)
 	idx_t maximum_line_size = 2097152;
 
 	//! The date format to use (if any is specified)

--- a/test/sql/copy/csv/test_max_line_size.test_slow
+++ b/test/sql/copy/csv/test_max_line_size.test_slow
@@ -2,9 +2,9 @@
 # description: Test lines that exceed the maximum line size
 # group: [csv]
 
-# generate CSV file with 20 MB string
+# generate CSV file with 4 MB string
 statement ok
-COPY (SELECT 10, REPEAT('a', 2048576), 20) TO '__TEST_DIR__/test.csv'
+COPY (SELECT 10, REPEAT('a', 4048576), 20) TO '__TEST_DIR__/test.csv'
 
 # value is too big for loading
 statement ok

--- a/test/sql/copy/csv/test_max_line_size.test_slow
+++ b/test/sql/copy/csv/test_max_line_size.test_slow
@@ -13,3 +13,10 @@ CREATE TABLE test (a INTEGER, b VARCHAR, c INTEGER);
 statement error
 COPY test FROM '__TEST_DIR__/test.csv';
 
+# we can override the max line size
+statement ok
+COPY test FROM '__TEST_DIR__/test.csv' (max_line_size 204857600);
+
+# also in the read_csv call
+statement ok
+INSERT INTO test SELECT * FROM read_csv_auto('__TEST_DIR__/test.csv', max_line_size=204857600);


### PR DESCRIPTION
Fixes #2997

Usage:

```sql
SELECT * FROM read_csv_auto('file.csv', max_line_size=9999); -- size in bytes
COPY test FROM 'file.csv' (max_line_size 9999); -- size in bytes
```

This PR also changes the default max line size to 2MB.