### PR TITLE
Issue #2908: UTF8 BOM Headers

### DIFF
--- a/src/execution/operator/persistent/buffered_csv_reader.cpp
+++ b/src/execution/operator/persistent/buffered_csv_reader.cpp
@@ -444,11 +444,11 @@ void BufferedCSVReader::InitParseChunk(idx_t num_cols) {
 void BufferedCSVReader::JumpToBeginning(idx_t skip_rows = 0, bool skip_header = false) {
 	ResetBuffer();
 	ResetStream();
-	SkipRowsAndReadHeader(skip_rows, skip_header);
 	sample_chunk_idx = 0;
 	bytes_in_chunk = 0;
 	end_of_file_reached = false;
 	bom_checked = false;
+	SkipRowsAndReadHeader(skip_rows, skip_header);
 }
 
 void BufferedCSVReader::SkipRowsAndReadHeader(idx_t skip_rows, bool skip_header) {

--- a/test/sql/copy/csv/auto/test_header_detection.test
+++ b/test/sql/copy/csv/auto/test_header_detection.test
@@ -114,3 +114,21 @@ SELECT * FROM test;
 statement ok
 DROP TABLE test;
 
+# CSV with UTF-8 BOM marker that could mess up the header line parsing
+statement ok
+CREATE TABLE test AS SELECT * FROM read_csv_auto('test/sql/copy/csv/data/auto/utf8bom.csv');
+
+query II
+SELECT * FROM test;
+----
+1	Mark
+2	Hannes
+
+query I
+SELECT id FROM test;
+----
+1
+2
+
+statement ok
+DROP TABLE test;

--- a/test/sql/copy/csv/data/auto/utf8bom.csv
+++ b/test/sql/copy/csv/data/auto/utf8bom.csv
@@ -1,0 +1,3 @@
+﻿id,name
+1,Mark
+2,Hannes


### PR DESCRIPTION
Don't include BOM in first column name:
Move some state variable resets
to before they get used.