### PR TITLE
Allow literal option for regex

### DIFF
--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -50,9 +50,9 @@ static void ParseRegexOptions(const string &options, duckdb_re2::RE2::Options &r
 			result.set_case_sensitive(false);
 			break;
 		case 'l':
-		  // literal matching
-		  result.set_literal(true);
-		  break;		
+			// literal matching
+			result.set_literal(true);
+			break;
 		case 'm':
 		case 'n':
 		case 'p':

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -49,6 +49,10 @@ static void ParseRegexOptions(const string &options, duckdb_re2::RE2::Options &r
 			// case-insensitive matching
 			result.set_case_sensitive(false);
 			break;
+		case 'l':
+		  // literal matching
+		  result.set_literal(true);
+		  break;		
 		case 'm':
 		case 'n':
 		case 'p':

--- a/test/sql/function/string/regex_replace.test
+++ b/test/sql/function/string/regex_replace.test
@@ -33,6 +33,17 @@ SELECT regexp_replace('ANA', 'ana', 'banana', 'i')
 ----
 banana
 
+# literal match
+query T
+SELECT regexp_replace('as^/$df', '^/$', '', 'l')
+----
+asdf
+
+query T
+SELECT regexp_replace('as^/$df', '^/$', '')
+----
+as^/$df
+
 # dot matches newline
 query T
 SELECT regexp_replace('hello

--- a/test/sql/function/string/regex_search.test
+++ b/test/sql/function/string/regex_search.test
@@ -112,6 +112,17 @@ SELECT regexp_matches('asdf', '.*SD.*', 'c')
 ----
 0
 
+# literal match
+query T
+SELECT regexp_matches('as^/$df', '^/$', 'l')
+----
+1
+
+query T
+SELECT regexp_matches('as^/$df', '^/$')
+----
+0
+
 # dot matches newline
 query T
 SELECT regexp_matches('hello


### PR DESCRIPTION
Adds a modifier 'l' for the RE2 build-in option for literal matching.