### PR TITLE
Install covr from main development branch

### DIFF
--- a/tools/rpkg/dependencies.R
+++ b/tools/rpkg/dependencies.R
@@ -5,7 +5,7 @@ local({
     options(HTTPUserAgent = sprintf("R/4.1.0 R (4.1.0 %s)", paste(R.version$platform, R.version$arch, R.version$os)))
     install.packages(pkg, repos = "https://packagemanager.rstudio.com/all/__linux__/focal/latest")
     # https://github.com/r-lib/covr/pull/499
-    remotes::install_github("r-lib/covr@f-497-relative-path")
+    remotes::install_github("r-lib/covr")
   } else {
     install.packages(pkg, repos = "https://cloud.r-project.org", pkgType = "binary")
   }


### PR DESCRIPTION
because https://github.com/r-lib/covr/pull/499 has been merged.

This code is run only as part of the GitHub Actions workflows. It's important to merge it soon to keep CI stable and avoid relying on a branch that might go away.