### PR TITLE
Update Java DuckDBAppender to allow appending null values - fixes issue 3035

### DIFF
--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -534,10 +534,16 @@ JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1appender_1appe
 
 JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1appender_1append_1string(JNIEnv *env, jclass,
                                                                                            jobject appender_ref_buf,
-                                                                                           jbyteArray value) {
+                                                                                           jstring value) {
 	try {
-		auto string_value = byte_array_to_string(env, value);
-		get_appender(env, appender_ref_buf)->Append(string_value.c_str());
+	    if (env->IsSameObject(value, NULL)) {
+	        get_appender(env, appender_ref_buf)->Append<std::nullptr_t>(nullptr);
+	        return;
+	    }
+
+		auto c_string_value = env->GetStringUTFChars(value, NULL);
+		get_appender(env, appender_ref_buf)->Append(c_string_value);
+		env->ReleaseStringUTFChars(value, c_string_value);
 	} catch (exception &e) {
 		env->ThrowNew(env->FindClass("java/sql/SQLException"), e.what());
 	}

--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -536,10 +536,10 @@ JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1appender_1appe
                                                                                            jobject appender_ref_buf,
                                                                                            jstring value) {
 	try {
-	    if (env->IsSameObject(value, NULL)) {
-	        get_appender(env, appender_ref_buf)->Append<std::nullptr_t>(nullptr);
-	        return;
-	    }
+		if (env->IsSameObject(value, NULL)) {
+			get_appender(env, appender_ref_buf)->Append<std::nullptr_t>(nullptr);
+			return;
+		}
 
 		auto c_string_value = env->GetStringUTFChars(value, NULL);
 		get_appender(env, appender_ref_buf)->Append(c_string_value);

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBAppender.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBAppender.java
@@ -56,7 +56,7 @@ public class DuckDBAppender implements AutoCloseable {
     }
 
     public void append(String value) throws SQLException {
-        DuckDBNative.duckdb_jdbc_appender_append_string(appender_ref, value.getBytes(StandardCharsets.UTF_8));
+        DuckDBNative.duckdb_jdbc_appender_append_string(appender_ref, value);
     }
 
     protected void finalize() throws Throwable {

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBNative.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBNative.java
@@ -111,6 +111,6 @@ public class DuckDBNative {
 
 	protected static native void duckdb_jdbc_appender_append_double(ByteBuffer appender_ref, double value);
 
-	protected static native void duckdb_jdbc_appender_append_string(ByteBuffer appender_ref, byte[] value);
+	protected static native void duckdb_jdbc_appender_append_string(ByteBuffer appender_ref, String value);
 
 }

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -1316,6 +1316,55 @@ public static void test_duckdb_timestamp() throws Exception {
 		conn.close();
 	}
 
+	public static void test_appender_null_integer() throws Exception {
+		DuckDBConnection conn = (DuckDBConnection) DriverManager.getConnection("jdbc:duckdb:");
+		Statement stmt = conn.createStatement();
+
+		stmt.execute("CREATE TABLE data (a INTEGER)");
+
+		DuckDBAppender appender = conn.createAppender("main", "data");
+
+		appender.beginRow();
+		appender.append(null);
+		appender.endRow();
+		appender.flush();
+		appender.close();
+
+		ResultSet results = stmt.executeQuery("SELECT * FROM data");
+		assertTrue(results.next());
+		// java.sql.ResultSet.getInt(int) returns 0 if the value is NULL
+		assertEquals(0, results.getInt(1));
+		assertTrue(results.wasNull());
+
+		results.close();
+		stmt.close();
+		conn.close();
+	}
+
+	public static void test_appender_null_varchar() throws Exception {
+		DuckDBConnection conn = (DuckDBConnection) DriverManager.getConnection("jdbc:duckdb:");
+		Statement stmt = conn.createStatement();
+
+		stmt.execute("CREATE TABLE data (a VARCHAR)");
+
+		DuckDBAppender appender = conn.createAppender("main", "data");
+
+		appender.beginRow();
+		appender.append(null);
+		appender.endRow();
+		appender.flush();
+		appender.close();
+
+		ResultSet results = stmt.executeQuery("SELECT * FROM data");
+		assertTrue(results.next());
+		assertNull(results.getString(1));
+		assertTrue(results.wasNull());
+
+		results.close();
+		stmt.close();
+		conn.close();
+	}
+
 	public static void test_get_catalog() throws Exception {
 		Connection conn = (DuckDBConnection) DriverManager.getConnection("jdbc:duckdb:");
 		ResultSet rs = conn.getMetaData().getCatalogs();


### PR DESCRIPTION
Updates Java DuckDBAppender to allow appending null values. The version of the append method that takes a java.lang.String now properly handles being passed null by invoking the corresponding version of the C++ Appender class to append a null value, regardless of column type.

Includes additional unit tests to verify that null values can now be appended in integer and varchar columns.

Closes https://github.com/duckdb/duckdb/issues/3035.