### PR TITLE
Issue #3029: Prevent CURRENT_QUERY folding

### DIFF
--- a/src/function/scalar/system/system_functions.cpp
+++ b/src/function/scalar/system/system_functions.cpp
@@ -71,7 +71,7 @@ void SystemFun::RegisterFunction(BuiltinFunctions &set) {
 	auto varchar_list_type = LogicalType::LIST(LogicalType::VARCHAR);
 
 	set.AddFunction(
-	    ScalarFunction("current_query", {}, LogicalType::VARCHAR, CurrentQueryFunction, false, BindSystemFunction));
+	    ScalarFunction("current_query", {}, LogicalType::VARCHAR, CurrentQueryFunction, true, BindSystemFunction));
 	set.AddFunction(
 	    ScalarFunction("current_schema", {}, LogicalType::VARCHAR, CurrentSchemaFunction, false, BindSystemFunction));
 	set.AddFunction(ScalarFunction("current_schemas", {LogicalType::BOOLEAN}, varchar_list_type, CurrentSchemasFunction,

--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -68,6 +68,9 @@ CREATE TABLE a (i INTEGER);
 SELECT SUM(i) FROM a;
 ''' % datafile, out='126')
 
+# system functions
+test('SELECT 1, current_query() as my_column', out='SELECT 1, current_query() as my_column')
+
 # nested types
 test('select LIST_VALUE(1, 2);', out='[1, 2]')
 test("select STRUCT_PACK(x := 3, y := 3);", out="{'x': 3, 'y': 3}")


### PR DESCRIPTION
Since the value is not always available in some contexts,
marking the function as having side effects
prevents it from being computed during preparation.