### PR TITLE
Issue #3056: Null list scatter

### DIFF
--- a/src/common/row_operations/row_scatter.cpp
+++ b/src/common/row_operations/row_scatter.cpp
@@ -93,15 +93,17 @@ static void ScatterNestedVector(Vector &vec, VectorData &col, Vector &rows, data
 	// Store pointers to the data in the row
 	// Do this first because SerializeVector destroys the locations
 	auto ptrs = FlatVector::GetData<data_ptr_t>(rows);
+	data_ptr_t validitymask_locations[STANDARD_VECTOR_SIZE];
 	for (idx_t i = 0; i < count; i++) {
 		auto idx = sel.get_index(i);
 		auto row = ptrs[idx];
+		validitymask_locations[i] = row;
 
 		Store<data_ptr_t>(data_locations[i], row + col_offset);
 	}
 
 	// Serialise the data
-	RowOperations::HeapScatter(vec, vcount, sel, count, col_no, data_locations, ptrs);
+	RowOperations::HeapScatter(vec, vcount, sel, count, col_no, data_locations, validitymask_locations);
 }
 
 void RowOperations::Scatter(DataChunk &columns, VectorData col_data[], const RowLayout &layout, Vector &rows,

--- a/test/sql/aggregate/distinct/test_distinct.test
+++ b/test/sql/aggregate/distinct/test_distinct.test
@@ -53,3 +53,16 @@ SELECT DISTINCT CASE WHEN a > 11 THEN 11 ELSE a END FROM test
 ----
 11
 
+# Distinct LIST<VARCHAR> with NULL in a subsequent position (Issue #3056)
+statement ok
+CREATE TABLE issue3056 AS (SELECT * FROM (VALUES
+	(['TGTA']),
+	(['CGGT']),
+	(['CCTC']),
+	(['TCTA']),
+	(['AGGG']),
+	(NULL))
+tbl(genes));
+
+statement ok
+SELECT DISTINCT genes FROM issue3056;


### PR DESCRIPTION
The validity masks passed to `RowOperations::HeapScatter` are indexed by the output, not the input.