### PR TITLE
Implementation of list_contains

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,7 +67,7 @@ else()
       duckdb_hyperloglog
       duckdb_fastpforlib)
 
-  add_library(duckdb SHARED ${ALL_OBJECT_FILES})
+  add_library(duckdb SHARED ${ALL_OBJECT_FILES} function/scalar/list/list_contains.cpp)
   target_link_libraries(duckdb ${DUCKDB_LINK_LIBS})
   link_threads(duckdb)
   link_extension_libraries(duckdb)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,7 +67,7 @@ else()
       duckdb_hyperloglog
       duckdb_fastpforlib)
 
-  add_library(duckdb SHARED ${ALL_OBJECT_FILES} function/scalar/list/list_contains.cpp)
+  add_library(duckdb SHARED ${ALL_OBJECT_FILES})
   target_link_libraries(duckdb ${DUCKDB_LINK_LIBS})
   link_threads(duckdb)
   link_extension_libraries(duckdb)

--- a/src/function/scalar/list/CMakeLists.txt
+++ b/src/function/scalar/list/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library_unity(
   duckdb_func_list
   OBJECT
   list_concat.cpp
+  list_contains.cpp
   array_slice.cpp
   list_extract.cpp
   list_value.cpp

--- a/src/function/scalar/list/list_contains.cpp
+++ b/src/function/scalar/list/list_contains.cpp
@@ -1,0 +1,131 @@
+//
+// Created by daniel on 24-01-22.
+//
+
+#include <iostream>
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/function/scalar/nested_functions.hpp"
+#include "duckdb/planner/expression_binder.hpp"
+
+
+namespace duckdb {
+
+template <class T>
+static void TemplatedListContainsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 2);
+	auto count = args.size();
+
+	Vector &list = args.data[0];
+	auto   value = args.data[1].GetValue(0);
+
+	if (list.GetType().id() == LogicalTypeId::SQLNULL) {
+		result.Reference(false);
+	}
+	auto &key_type = ListType::GetChildType(list.GetType());
+	if (key_type != LogicalTypeId::SQLNULL) {
+		value = value.CastAs(key_type);
+	}
+
+	VectorData list_data;
+	list.Orrify(count, list_data);
+	auto array_entries = (list_entry_t*)list_data.data;
+
+	auto list_size = ListVector::GetListSize(list);
+	auto &list_child = ListVector::GetEntry(list);
+	VectorData list_child_data;
+
+	for (idx_t i = 0; i < list_size; i++) {
+		auto list_index = list_child_data.sel->get_index(i);
+		if (list_data.validity.RowIsValid(list_index)) {
+			list_child.Orrify(list_size, list_child_data);
+			const auto &child_entry = list_child_data.data[list_index];
+
+		}
+	}
+}
+
+static void ListContainsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	switch (args.data[1].GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedListContainsFunction<int8_t>(args, state, result);
+		break;
+	case PhysicalType::INT16:
+		TemplatedListContainsFunction<int16_t>(args, state, result);
+		break;
+	case PhysicalType::INT32:
+		TemplatedListContainsFunction<int32_t>(args, state, result);
+		break;
+	case PhysicalType::INT64:
+		TemplatedListContainsFunction<int64_t>(args, state, result);
+		break;
+	case PhysicalType::INT128:
+		TemplatedListContainsFunction<hugeint_t>(args, state, result);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedListContainsFunction<uint8_t>(args, state, result);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedListContainsFunction<uint16_t>(args, state, result);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedListContainsFunction<uint32_t>(args, state, result);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedListContainsFunction<uint64_t>(args, state, result);
+		break;
+		//	case PhysicalType::FLOAT:
+		//		TemplatedListContainsFunction<float>(args, state, result);
+		//		break;
+		//	case PhysicalType::DOUBLE:
+		//		TemplatedListContainsFunction<double>(args, state, result);
+		//		break;
+		//		case PhysicalType::VARCHAR:
+		//		    TemplatedListContainsFunction(list, StringValue::Get(key), offsets, key.IsNull(), entry.offset, entry.length); 			break;
+	default:
+		throw InvalidTypeException(args.data[1].GetType().id(), "Invalid type for List Vector Search");
+	}
+}
+
+
+
+static unique_ptr<FunctionData> ListContainsBind(ClientContext &context, ScalarFunction &bound_function,
+                                                 vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(bound_function.arguments.size() == 2);
+
+	auto &array = arguments[0]->return_type; // change to list
+	auto &value = arguments[1]->return_type;
+	if (array.id() == LogicalTypeId::SQLNULL && value.id() == LogicalTypeId::SQLNULL) {
+		bound_function.return_type = LogicalType::SQLNULL;
+	} else if (array.id() == LogicalTypeId::SQLNULL || value.id() == LogicalTypeId::SQLNULL) {
+		bound_function.arguments[0] = array;
+		bound_function.arguments[1] = value;
+		bound_function.return_type = value.id() == LogicalTypeId::SQLNULL ? array : value;
+	} else {
+		auto child_type =ListType::GetChildType(arguments[0]->return_type);
+		D_ASSERT(array.id() == LogicalTypeId::LIST);
+		D_ASSERT(value.id() == child_type.id()); // LogicalTypeId::ANY?
+
+		//		LogicalType child_type = LogicalType::SQLNULL;
+		//		child_type = LogicalType::MaxLogicalType(child_type, ListType::GetChildType(arguments[0]->return_type));
+		//		ExpressionBinder::ResolveParameterType(child_type);
+
+		bound_function.arguments[0] = LogicalType::LIST(move(child_type));
+		bound_function.arguments[1] = value; // LogicalType::ANY What should be here. The second argument can be of type any.
+		bound_function.return_type = LogicalType::BOOLEAN; // What should be here. Boolean
+	}
+
+	return make_unique<VariableReturnBindData>(bound_function.return_type);
+}
+
+
+ScalarFunction ListContainsFun::GetFunction() {
+	return ScalarFunction({LogicalType::LIST(LogicalType::ANY), LogicalType::ANY}, // argument list
+	                      LogicalType::BOOLEAN,                         // return type
+	                      ListContainsFunction, false, ListContainsBind, nullptr);
+}
+
+void ListContainsFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction({"list_contains", "array_contains"},GetFunction());
+}
+}

--- a/src/function/scalar/list/list_contains.cpp
+++ b/src/function/scalar/list/list_contains.cpp
@@ -187,19 +187,15 @@ static unique_ptr<FunctionData> ListContainsBind(ClientContext &context, ScalarF
 		bound_function.return_type = LogicalTypeId::SQLNULL;
 	} else {
 		D_ASSERT(list.id() == LogicalTypeId::LIST);
+
 		auto child_type = ListType::GetChildType(arguments[0]->return_type);
-//		if (child_type.id() == LogicalTypeId::SQLNULL) { // list_contains([NULL],1) -> returns NULL
-//			bound_function.arguments[0] = list;
-//			bound_function.arguments[1] = value;
-//			bound_function.return_type = LogicalTypeId::SQLNULL;
-//		} else {
 		auto max_child_type = LogicalType::MaxLogicalType(child_type, value);
 		ExpressionBinder::ResolveParameterType(max_child_type);
 		auto list_type = LogicalType::LIST(max_child_type);
+
 		bound_function.arguments[0] = list_type;
 		bound_function.arguments[1] = value == max_child_type ? value : max_child_type;
 		bound_function.return_type = LogicalType::BOOLEAN;
-//		}
 	}
 	return make_unique<VariableReturnBindData>(bound_function.return_type);
 }

--- a/src/function/scalar/list/list_contains.cpp
+++ b/src/function/scalar/list/list_contains.cpp
@@ -39,17 +39,19 @@ static void TemplatedListContainsFunction(DataChunk &args, ExpressionState &stat
 
 	VectorData child_data;
 	child_vector.Orrify(list_size, child_data);
+
 	for (idx_t i = 0; i < count; i++) {
 		auto list_index = list_data.sel->get_index(i);
 		if (list_data.validity.RowIsValid(list_index)) {
-			auto list_entry = ((list_entry_t *)list_data.data)[list_index];
-			idx_t child_offset = list_entry.offset;
-		   	if (child_data.validity.RowIsValid(child_offset)) {
-				auto child_value = ((T *)child_data.data)[child_offset];
-				if (child_value == ((T *)value_data.data)[0]) {
-					auto result_data = ConstantVector::GetData<bool>(result);
-					result_data[0] = true;
-					return;
+//			auto list_entry = ((list_entry_t *)list_data.data)[list_index];
+			for (idx_t j = 0; j < list_size; j++) {
+				if (child_data.validity.RowIsValid(j)) {
+					auto child_value = ((T *)child_data.data)[j];
+					if (child_value == ((T *)value_data.data)[0]) {
+						auto result_data = ConstantVector::GetData<bool>(result);
+						result_data[0] = true;
+						return;
+					}
 				}
 			}
 		}

--- a/src/function/scalar/list/list_contains.cpp
+++ b/src/function/scalar/list/list_contains.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/planner/expression_binder.hpp"
@@ -53,7 +52,7 @@ static void TemplatedListContainsFunction(DataChunk &args, ExpressionState &stat
 		auto list_index = list_data.sel->get_index(i);
 		auto value_index = value_data.sel->get_index(i);
 
-		if (!list_data.validity.RowIsValid(list_index) or !value_data.validity.RowIsValid(value_index)) {
+		if (!list_data.validity.RowIsValid(list_index) || !value_data.validity.RowIsValid(value_index)) {
 			result_validity.SetInvalid(i);
 			continue;
 		}
@@ -76,7 +75,6 @@ static void TemplatedListContainsFunction(DataChunk &args, ExpressionState &stat
 			}
 		}
 	}
-	return;
 }
 
 static void NestedListContainsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -111,7 +109,7 @@ static void NestedListContainsFunction(DataChunk &args, ExpressionState &state, 
 		auto list_index = list_data.sel->get_index(i);
 		auto value_index = value_data.sel->get_index(i);
 
-		if (!list_data.validity.RowIsValid(list_index) or !value_data.validity.RowIsValid(value_index)) {
+		if (!list_data.validity.RowIsValid(list_index) || !value_data.validity.RowIsValid(value_index)) {
 			result_validity.SetInvalid(i);
 			continue;
 		}
@@ -131,7 +129,6 @@ static void NestedListContainsFunction(DataChunk &args, ExpressionState &state, 
 			}
 		}
 	}
-	return;
 }
 
 static void ListContainsFunction(DataChunk &args, ExpressionState &state, Vector &result) {

--- a/src/function/scalar/list/list_contains.cpp
+++ b/src/function/scalar/list/list_contains.cpp
@@ -70,7 +70,7 @@ static void TemplatedListContainsFunction(DataChunk &args, ExpressionState &stat
 			if (!child_data.validity.RowIsValid(child_value_idx)) {
 				continue;
 			}
-			if (ValueCompare(child_value[child_value_idx], values[value_index])) {
+			if (ValueCompare<T>(child_value[child_value_idx], values[value_index])) {
 				result_entries[list_index] = true;
 				break; // Found value in list, no need to look further
 			}
@@ -79,8 +79,7 @@ static void TemplatedListContainsFunction(DataChunk &args, ExpressionState &stat
 	return;
 }
 
-template <class T>
-static void NestedTemplatedListContainsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+static void NestedListContainsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	D_ASSERT(args.ColumnCount() == 2);
 	auto count = args.size();
 	Vector &list = args.data[0];
@@ -126,7 +125,7 @@ static void NestedTemplatedListContainsFunction(DataChunk &args, ExpressionState
 			if (!child_data.validity.RowIsValid(child_value_idx)) {
 				continue;
 			}
-			if (ValueCompare(child_vector.GetValue(child_value_idx), value_vector.GetValue(value_index))) {
+			if (ValueCompare<Value>(child_vector.GetValue(child_value_idx), value_vector.GetValue(value_index))) {
 				result_entries[list_index] = true;
 				break; // Found value in list, no need to look further
 			}
@@ -177,7 +176,7 @@ static void ListContainsFunction(DataChunk &args, ExpressionState &state, Vector
 	case PhysicalType::MAP:
 	case PhysicalType::STRUCT:
 	case PhysicalType::LIST:
-		NestedTemplatedListContainsFunction<list_entry_t>(args, state, result);
+		NestedListContainsFunction(args, state, result);
 		break;
 	default:
 		throw NotImplementedException("This function has not been implemented for this type");

--- a/src/function/scalar/list/list_contains.cpp
+++ b/src/function/scalar/list/list_contains.cpp
@@ -5,12 +5,6 @@
 
 namespace duckdb {
 
-static void SetResultFalse(Vector &result) {
-	auto result_data = FlatVector::GetData<bool>(result);
-	result_data[0] = false;
-	return;
-}
-
 template <class T>
 static inline bool ValueCompare(const T &left, const T &right) {
 	return left == right;
@@ -21,6 +15,11 @@ inline bool ValueCompare(const string_t &left, const string_t &right) {
 	return StringComparisonOperators::EqualsOrNot<false>(left, right);
 }
 
+template <>
+inline bool ValueCompare(const Value &left, const Value &right) {
+	return left == right;
+}
+
 template <class T>
 static void TemplatedListContainsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	D_ASSERT(args.ColumnCount() == 2);
@@ -28,22 +27,18 @@ static void TemplatedListContainsFunction(DataChunk &args, ExpressionState &stat
 	Vector &list = args.data[0];
 	Vector &value_vector = args.data[1];
 
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_entries = FlatVector::GetData<bool>(result); // Create a vector of bool
+	auto &result_validity = FlatVector::Validity(result);
 
 	if (list.GetType().id() == LogicalTypeId::SQLNULL) {
-		SetResultFalse(result);
+		result_validity.SetInvalid(0);
 		return;
 	}
 
 	auto list_size = ListVector::GetListSize(list);
-	if (list_size == 0) { // empty list will never contain a value
-		SetResultFalse(result);
-		return;
-	}
 	auto &child_vector = ListVector::GetEntry(list);
-	if (child_vector.GetType().id() == LogicalTypeId::SQLNULL) {
-		SetResultFalse(result);
-		return;
-	}
+
 	VectorData child_data;
 	child_vector.Orrify(list_size, child_data);
 
@@ -54,20 +49,11 @@ static void TemplatedListContainsFunction(DataChunk &args, ExpressionState &stat
 	VectorData value_data;
 	value_vector.Orrify(count, value_data);
 
-	result.SetVectorType(VectorType::FLAT_VECTOR);
-	auto result_entries = FlatVector::GetData<bool>(result); // Create a vector of bool
-	auto &result_validity = FlatVector::Validity(result);
-
 	for (idx_t i = 0; i < count; i++) {
 		auto list_index = list_data.sel->get_index(i);
 		auto value_index = value_data.sel->get_index(i);
 
-		if (!list_data.validity.RowIsValid(list_index)) {
-			result_validity.SetInvalid(i);
-			continue;
-		}
-
-		if (!value_data.validity.RowIsValid(value_index)) {
+		if (!list_data.validity.RowIsValid(list_index) or !value_data.validity.RowIsValid(value_index)) {
 			result_validity.SetInvalid(i);
 			continue;
 		}
@@ -93,6 +79,61 @@ static void TemplatedListContainsFunction(DataChunk &args, ExpressionState &stat
 	return;
 }
 
+template <class T>
+static void NestedTemplatedListContainsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 2);
+	auto count = args.size();
+	Vector &list = args.data[0];
+	Vector &value_vector = args.data[1];
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_entries = FlatVector::GetData<bool>(result); // Create a vector of bool
+	auto &result_validity = FlatVector::Validity(result);
+
+	if (list.GetType().id() == LogicalTypeId::SQLNULL) {
+		result_validity.SetInvalid(0);
+		return;
+	}
+
+	auto list_size = ListVector::GetListSize(list);
+	auto &child_vector = ListVector::GetEntry(list);
+
+	VectorData child_data;
+	child_vector.Orrify(list_size, child_data);
+
+	VectorData list_data;
+	list.Orrify(count, list_data);
+	auto list_entries = (list_entry_t *)list_data.data;
+
+	VectorData value_data;
+	value_vector.Orrify(count, value_data);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto list_index = list_data.sel->get_index(i);
+		auto value_index = value_data.sel->get_index(i);
+
+		if (!list_data.validity.RowIsValid(list_index) or !value_data.validity.RowIsValid(value_index)) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+
+		const auto &list_entry = list_entries[list_index];
+		auto source_idx = child_data.sel->get_index(list_entry.offset);
+
+		result_entries[list_index] = false;
+		for (idx_t child_idx = 0; child_idx < list_entry.length; child_idx++) {
+			auto child_value_idx = source_idx + child_idx;
+			if (!child_data.validity.RowIsValid(child_value_idx)) {
+				continue;
+			}
+			if (ValueCompare(child_vector.GetValue(child_value_idx), value_vector.GetValue(value_index))) {
+				result_entries[list_index] = true;
+				break; // Found value in list, no need to look further
+			}
+		}
+	}
+	return;
+}
 
 static void ListContainsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	switch (args.data[1].GetType().InternalType()) {
@@ -133,7 +174,11 @@ static void ListContainsFunction(DataChunk &args, ExpressionState &state, Vector
 	case PhysicalType::VARCHAR:
 		TemplatedListContainsFunction<string_t>(args, state, result);
 		break;
-
+	case PhysicalType::MAP:
+	case PhysicalType::STRUCT:
+	case PhysicalType::LIST:
+		NestedTemplatedListContainsFunction<list_entry_t>(args, state, result);
+		break;
 	default:
 		throw NotImplementedException("This function has not been implemented for this type");
 	}
@@ -156,12 +201,7 @@ static unique_ptr<FunctionData> ListContainsBind(ClientContext &context, ScalarF
 		bound_function.arguments[1] = value;
 		bound_function.return_type = LogicalTypeId::SQLNULL;
 	} else {
-		D_ASSERT(list.id() == LogicalTypeId::LIST);
-
 		auto const &child_type = ListType::GetChildType(arguments[0]->return_type);
-		if (child_type.id() == LogicalTypeId::LIST or value.id() == LogicalTypeId::LIST) {
-			throw NotImplementedException("This function has not yet been implemented for nested types");
-		}
 		auto max_child_type = LogicalType::MaxLogicalType(child_type, value);
 		ExpressionBinder::ResolveParameterType(max_child_type);
 		auto list_type = LogicalType::LIST(max_child_type);

--- a/src/function/scalar/nested_functions.cpp
+++ b/src/function/scalar/nested_functions.cpp
@@ -7,6 +7,7 @@ void BuiltinFunctions::RegisterNestedFunctions() {
 	Register<StructPackFun>();
 	Register<StructExtractFun>();
 	Register<ListConcatFun>();
+	Register<ListContainsFun>();
 	Register<ListValueFun>();
 	Register<ListExtractFun>();
 	Register<ListRangeFun>();

--- a/src/include/duckdb/function/scalar/nested_functions.hpp
+++ b/src/include/duckdb/function/scalar/nested_functions.hpp
@@ -57,6 +57,11 @@ struct ListConcatFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct ListContainsFun {
+	static ScalarFunction GetFunction();
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct CardinalityFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/test/sql/function/list/list_contains.test
+++ b/test/sql/function/list/list_contains.test
@@ -7,6 +7,41 @@ PRAGMA enable_verification
 
 # basic functionality
 query T
-SELECT list_contains([5], 7)
+SELECT list_contains([7], 7)
+----
+1
+
+query T
+SELECT list_contains([7], 5)
 ----
 0
+
+query T
+SELECT list_contains([1,2,3,4],4)
+----
+1
+
+query T
+SELECT list_contains([1,2,3,4],5)
+----
+0
+
+query T
+SELECT list_contains([true, false],true)
+----
+1
+
+query T
+SELECT list_contains([true, true],false)
+----
+0
+
+query T
+SELECT list_contains(["test", "notest"],"notest")
+----
+1
+
+query T
+SELECT list_contains(["test", "notest"],"a")
+----
+1

--- a/test/sql/function/list/list_contains.test
+++ b/test/sql/function/list/list_contains.test
@@ -6,6 +6,27 @@ statement ok
 PRAGMA enable_verification
 
 query T
+SELECT list_contains([], 7)
+----
+0
+
+
+query T
+SELECT list_contains([1,2,3],1.0)
+----
+1
+
+query T
+SELECT list_contains([1.0,2.0,3.0,4.0],1)
+----
+1
+
+query T
+SELECT list_contains(NULL,NULL)
+----
+NULL
+
+query T
 SELECT list_contains([NULL,7], 7)
 ----
 1
@@ -16,10 +37,6 @@ SELECT list_contains([7], 7)
 ----
 1
 
-query T
-SELECT list_contains([], 7)
-----
-0
 
 query T
 SELECT list_contains([7], 5)
@@ -45,6 +62,8 @@ query T
 SELECT list_contains([1.0,2.0,3.0,4.0],4.0)
 ----
 1
+
+
 
 query T
 SELECT list_contains([true, false],true)
@@ -72,14 +91,30 @@ SELECT list_contains(NULL,1)
 NULL
 
 
+
 query T
-SELECT list_contains(NULL,NULL)
+SELECT list_contains([NULL],NULL)
 ----
 NULL
 
 
 query T
 SELECT list_contains([NULL, 1],NULL)
+----
+NULL
+
+query T
+SELECT list_contains([NULL, 1],1)
+----
+1
+
+query T
+SELECT list_contains([NULL, 0],1)
+----
+0
+
+query T
+SELECT list_contains([],NULL)
 ----
 NULL
 

--- a/test/sql/function/list/list_contains.test
+++ b/test/sql/function/list/list_contains.test
@@ -1,0 +1,12 @@
+# name: test/sql/function/list/list_contains.test
+# description: Test list_ccontains function
+# group: [list]
+
+statement ok
+PRAGMA enable_verification
+
+# basic functionality
+query T
+SELECT list_contains([5, 6, 7, 1], 1)
+----
+1

--- a/test/sql/function/list/list_contains.test
+++ b/test/sql/function/list/list_contains.test
@@ -7,6 +7,6 @@ PRAGMA enable_verification
 
 # basic functionality
 query T
-SELECT list_contains([5, 6, 7, 1], 1)
+SELECT list_contains([5], 7)
 ----
-1
+0

--- a/test/sql/function/list/list_contains.test
+++ b/test/sql/function/list/list_contains.test
@@ -5,12 +5,13 @@
 statement ok
 PRAGMA enable_verification
 
+# Empty list
 query T
 SELECT list_contains([], 7)
 ----
 0
 
-
+# Mixed data types
 query T
 SELECT list_contains([1,2,3],1.0)
 ----
@@ -20,6 +21,26 @@ query T
 SELECT list_contains([1.0,2.0,3.0,4.0],1)
 ----
 1
+
+query T
+SELECT list_contains([1,2,3],4.0)
+----
+0
+
+query T
+SELECT list_contains([1.0,2.0,3.0],4)
+----
+0
+
+
+query T
+SELECT list_contains([1.0,2.0,3.0], 'a')
+----
+0
+
+# Not a list as input
+statement error
+SELECT list_contains('a', 'a')
 
 query T
 SELECT list_contains(NULL,NULL)
@@ -36,7 +57,6 @@ query T
 SELECT list_contains([7], 7)
 ----
 1
-
 
 query T
 SELECT list_contains([7], 5)
@@ -63,8 +83,6 @@ SELECT list_contains([1.0,2.0,3.0,4.0],4.0)
 ----
 1
 
-
-
 query T
 SELECT list_contains([true, false],true)
 ----
@@ -85,18 +103,16 @@ SELECT list_contains(['test', 'notest'],'a')
 ----
 0
 
+# Null types
 query T
 SELECT list_contains(NULL,1)
 ----
 NULL
 
-
-
 query T
 SELECT list_contains([NULL],NULL)
 ----
 NULL
-
 
 query T
 SELECT list_contains([NULL, 1],NULL)

--- a/test/sql/function/list/list_contains.test
+++ b/test/sql/function/list/list_contains.test
@@ -5,11 +5,21 @@
 statement ok
 PRAGMA enable_verification
 
+query T
+SELECT list_contains([NULL,7], 7)
+----
+1
+
 # basic functionality
 query T
 SELECT list_contains([7], 7)
 ----
 1
+
+query T
+SELECT list_contains([], 7)
+----
+0
 
 query T
 SELECT list_contains([7], 5)
@@ -27,6 +37,16 @@ SELECT list_contains([1,2,3,4],5)
 0
 
 query T
+SELECT list_contains([1.0,2.0,3.0,4.0],5.0)
+----
+0
+
+query T
+SELECT list_contains([1.0,2.0,3.0,4.0],4.0)
+----
+1
+
+query T
 SELECT list_contains([true, false],true)
 ----
 1
@@ -37,11 +57,29 @@ SELECT list_contains([true, true],false)
 0
 
 query T
-SELECT list_contains(["test", "notest"],"notest")
+SELECT list_contains(['test', 'notest'],'notest')
 ----
 1
 
 query T
-SELECT list_contains(["test", "notest"],"a")
+SELECT list_contains(['test', 'notest'],'a')
 ----
-1
+0
+
+query T
+SELECT list_contains(NULL,1)
+----
+NULL
+
+
+query T
+SELECT list_contains(NULL,NULL)
+----
+NULL
+
+
+query T
+SELECT list_contains([NULL, 1],NULL)
+----
+NULL
+

--- a/test/sql/function/list/list_contains.test
+++ b/test/sql/function/list/list_contains.test
@@ -45,7 +45,7 @@ statement ok
 create table STR_TEST (i string[]);
 
 statement ok
-insert into STR_TEST values (['a','b','c']), (['d','a','e']), (['b']);
+insert into STR_TEST values (['a','b','c']), (['d','a','e']), (['b']), (['aaaaaaaaaaaaaaaaaaaaaaaa']);
 
 query TT
 SELECT i, list_contains(i,'a') from STR_TEST;
@@ -53,6 +53,15 @@ SELECT i, list_contains(i,'a') from STR_TEST;
 [a, b, c]	1
 [d, a, e]	1
 [b]	0
+[aaaaaaaaaaaaaaaaaaaaaaaa]	0
+
+query TT
+SELECT i, list_contains(i,'aaaaaaaaaaaaaaaaaaaaaaaa') from STR_TEST;
+----
+[a, b, c]	0
+[d, a, e]	0
+[b]	0
+[aaaaaaaaaaaaaaaaaaaaaaaa]	1
 
 query TT
 SELECT i, list_contains(i,0) from STR_TEST;
@@ -60,6 +69,7 @@ SELECT i, list_contains(i,0) from STR_TEST;
 [a, b, c]	0
 [d, a, e]	0
 [b]	0
+[aaaaaaaaaaaaaaaaaaaaaaaa]	0
 
 
 query TT
@@ -68,6 +78,7 @@ SELECT i, list_contains(i,NULL) from STR_TEST;
 [a, b, c]	NULL
 [d, a, e]	NULL
 [b]	NULL
+[aaaaaaaaaaaaaaaaaaaaaaaa]	NULL
 
 statement ok
 DROP table STR_TEST;

--- a/test/sql/function/list/list_contains.test
+++ b/test/sql/function/list/list_contains.test
@@ -5,6 +5,25 @@
 statement ok
 PRAGMA enable_verification
 
+statement ok
+create table TEST (i int[]);
+
+statement ok
+insert into TEST values ([1,2,3]), ([2,3,1]), ([3,2,4]);
+
+query TT
+SELECT i, list_contains(i,1) from TEST;
+----
+[1, 2, 3]	1
+[2, 3, 1]	1
+[3, 2, 4]	0
+
+# basic functionality
+query T
+SELECT list_contains([7,2,5], 7)
+----
+1
+
 # Empty list
 query T
 SELECT list_contains([], 7)
@@ -47,16 +66,6 @@ SELECT list_contains(NULL,NULL)
 ----
 NULL
 
-query T
-SELECT list_contains([NULL,7], 7)
-----
-1
-
-# basic functionality
-query T
-SELECT list_contains([7], 7)
-----
-1
 
 query T
 SELECT list_contains([7], 5)
@@ -133,4 +142,16 @@ query T
 SELECT list_contains([],NULL)
 ----
 NULL
+
+
+query T
+SELECT list_contains([NULL,7], 7)
+----
+1
+
+statement error
+SELECT list_contains([[1,2,3],[1],[1,2,3])
+
+
+
 

--- a/test/sql/function/list/list_contains.test
+++ b/test/sql/function/list/list_contains.test
@@ -6,6 +6,19 @@ statement ok
 PRAGMA enable_verification
 
 statement ok
+create table TEST2 (i int[], j int);
+
+statement ok
+insert into TEST2 values ([2,1,3], 2), ([2,3,4], 5), ([1], NULL);
+
+query T
+select list_contains(i, j) from TEST2
+----
+1
+0
+NULL
+
+statement ok
 create table TEST (i int[]);
 
 statement ok
@@ -24,6 +37,9 @@ SELECT i, list_contains(i,4.0) from TEST;
 [2, 1, 3]	0
 [2, 3, 4]	1
 [1]	0
+
+statement ok
+DROP table TEST;
 
 statement ok
 create table STR_TEST (i string[]);
@@ -52,6 +68,9 @@ SELECT i, list_contains(i,NULL) from STR_TEST;
 [a, b, c]	NULL
 [d, a, e]	NULL
 [b]	NULL
+
+statement ok
+DROP table STR_TEST;
 
 
 # basic functionality
@@ -154,6 +173,12 @@ SELECT list_contains(NULL,1)
 ----
 NULL
 
+# Null types
+query T
+SELECT list_contains([1],NULL)
+----
+NULL
+
 query T
 SELECT list_contains([NULL],NULL)
 ----
@@ -187,4 +212,47 @@ SELECT list_contains([NULL,7], 7)
 
 statement error
 SELECT list_contains([[1,2,3],[1],[1,2,3])
+
+statement error
+SELECT list_contains([[1,2,3],[1],[1,2,3]])
+
+statement error
+SELECT list_contains(1)
+
+statement ok
+PRAGMA debug_force_external=true
+
+loop i 0 2
+
+foreach type <integral> varchar
+
+# list tests
+statement ok
+CREATE TABLE test0 (i ${type}[])
+
+statement ok
+INSERT INTO test0 VALUES ([2]), ([1]), ([1, 2]), ([]), ([2, 2]), ([NULL]), ([2, 3])
+
+query T
+SELECT list_contains(i,1) from test0
+----
+0
+1
+1
+0
+0
+0
+0
+
+statement ok
+DROP TABLE test0
+
+statement ok
+PRAGMA debug_force_external=false
+
+endloop
+
+endloop
+
+
 

--- a/test/sql/function/list/list_contains.test
+++ b/test/sql/function/list/list_contains.test
@@ -9,14 +9,50 @@ statement ok
 create table TEST (i int[]);
 
 statement ok
-insert into TEST values ([1,2,3]), ([2,3,1]), ([3,2,4]);
+insert into TEST values ([2,1,3]), ([2,3,4]), ([1]);
 
 query TT
 SELECT i, list_contains(i,1) from TEST;
 ----
-[1, 2, 3]	1
-[2, 3, 1]	1
-[3, 2, 4]	0
+[2, 1, 3]	1
+[2, 3, 4]	0
+[1]	1
+
+query TT
+SELECT i, list_contains(i,4.0) from TEST;
+----
+[2, 1, 3]	0
+[2, 3, 4]	1
+[1]	0
+
+statement ok
+create table STR_TEST (i string[]);
+
+statement ok
+insert into STR_TEST values (['a','b','c']), (['d','a','e']), (['b']);
+
+query TT
+SELECT i, list_contains(i,'a') from STR_TEST;
+----
+[a, b, c]	1
+[d, a, e]	1
+[b]	0
+
+query TT
+SELECT i, list_contains(i,0) from STR_TEST;
+----
+[a, b, c]	0
+[d, a, e]	0
+[b]	0
+
+
+query TT
+SELECT i, list_contains(i,NULL) from STR_TEST;
+----
+[a, b, c]	NULL
+[d, a, e]	NULL
+[b]	NULL
+
 
 # basic functionality
 query T

--- a/test/sql/function/list/list_contains.test
+++ b/test/sql/function/list/list_contains.test
@@ -204,7 +204,6 @@ SELECT list_contains([],NULL)
 ----
 NULL
 
-
 query T
 SELECT list_contains([NULL,7], 7)
 ----
@@ -218,6 +217,9 @@ SELECT list_contains([[1,2,3],[1],[1,2,3]])
 
 statement error
 SELECT list_contains(1)
+
+statement error
+SELECT list_contains(1,1)
 
 statement ok
 PRAGMA debug_force_external=true
@@ -254,5 +256,69 @@ endloop
 
 endloop
 
+query T
+SELECT list_contains([[1,2,3],[1]],[1])
+----
+1
 
+query T
+SELECT list_contains([[1,2,3],[1]],[2])
+----
+0
+
+query T
+SELECT list_contains([[1,2,3],[1]],[1,2,3])
+----
+1
+
+query T
+SELECT list_contains([[1,3],[1]],[1,2,3])
+----
+0
+
+query T
+SELECT list_contains([[1,3],[1], [1,2,3]],[1,2,3])
+----
+1
+
+query T
+SELECT list_contains([[NULL],[1], [1,2,3]],NULL)
+----
+NULL
+
+query T
+SELECT list_contains([[NULL],[1], [1,2,3]],[NULL])
+----
+1
+
+query T
+SELECT list_contains([[1,NULL],[1], [1,2,3]],[1,NULL])
+----
+1
+
+query T
+SELECT list_contains([[1,NULL],[1], [1,2,3]],[0,NULL])
+----
+0
+
+# nested types
+query T
+SELECT list_contains([{a: 1}, {a: 2}], {a: 2})
+----
+1
+
+query T
+SELECT list_contains([{a: 1}, {a: 2}], {a: 3})
+----
+0
+
+query T
+SELECT list_contains([MAP([1], [2])], MAP([1], [2]))
+----
+1
+
+query T
+SELECT list_contains([MAP([1], [2])], MAP([1], [3]))
+----
+0
 

--- a/test/sql/function/list/list_contains.test
+++ b/test/sql/function/list/list_contains.test
@@ -188,6 +188,3 @@ SELECT list_contains([NULL,7], 7)
 statement error
 SELECT list_contains([[1,2,3],[1],[1,2,3])
 
-
-
-

--- a/test/sql/function/list/list_contains.test
+++ b/test/sql/function/list/list_contains.test
@@ -322,3 +322,37 @@ SELECT list_contains([MAP([1], [2])], MAP([1], [3]))
 ----
 0
 
+statement ok
+PRAGMA debug_force_external=true
+
+loop i 0 2
+
+foreach type float double
+
+# list tests
+statement ok
+CREATE TABLE test0 (i ${type}[])
+
+statement ok
+INSERT INTO test0 VALUES ([2.0]), ([1.0]), ([1.0, 2.0]), ([]), ([2.0, 2.0]), ([NULL]), ([2.0, 3.0])
+
+query T
+SELECT list_contains(i,1.0) from test0
+----
+0
+1
+1
+0
+0
+0
+0
+
+statement ok
+DROP TABLE test0
+
+statement ok
+PRAGMA debug_force_external=false
+
+endloop
+
+endloop


### PR DESCRIPTION
As mentioned [here](https://github.com/duckdb/duckdb/issues/1940#issuecomment-871655466), one of the features yet to be implemented was the list_contains (or array_contains) function for arrays. This PR implements it for integers, floats and strings. Nested types are not supported at this moment. Behaviour is similar to PrestoDB. Happy to hear feedback @lnkuiper :slightly_smiling_face: 
