### PR TITLE
c-api: support decimal and prevent invalid type throws

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -171,7 +171,6 @@ typedef struct {
 	char *__deprecated_name;
 #endif
 	void *internal_data;
-	void *duckdb_logical_type;
 } duckdb_column;
 
 typedef struct {

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -171,6 +171,7 @@ typedef struct {
 	char *__deprecated_name;
 #endif
 	void *internal_data;
+	void *duckdb_logical_type;
 } duckdb_column;
 
 typedef struct {

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -87,7 +87,9 @@ typedef enum DUCKDB_TYPE {
 	// const char*
 	DUCKDB_TYPE_VARCHAR,
 	// duckdb_blob
-	DUCKDB_TYPE_BLOB
+	DUCKDB_TYPE_BLOB,
+	// decimal
+	DUCKDB_TYPE_DECIMAL
 } duckdb_type;
 
 //! Days are stored as days since 1970-01-01
@@ -139,6 +141,13 @@ typedef struct {
 	uint64_t lower;
 	int64_t upper;
 } duckdb_hugeint;
+
+typedef struct {
+	uint8_t width;
+	uint8_t scale;
+
+	duckdb_hugeint value;
+} duckdb_decimal;
 
 typedef struct {
 	void *data;
@@ -475,6 +484,11 @@ DUCKDB_API int64_t duckdb_value_int64(duckdb_result *result, idx_t col, idx_t ro
 DUCKDB_API duckdb_hugeint duckdb_value_hugeint(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+ * returns: The duckdb_decimal value at the specified location, or 0 if the value cannot be converted.
+ */
+DUCKDB_API duckdb_decimal duckdb_value_decimal(duckdb_result *result, idx_t col, idx_t row);
+
+/*!
  * returns: The uint8_t value at the specified location, or 0 if the value cannot be converted.
  */
 DUCKDB_API uint8_t duckdb_value_uint8(duckdb_result *result, idx_t col, idx_t row);
@@ -639,6 +653,17 @@ If the conversion fails because the double value is too big the result will be 0
 * returns: The converted `duckdb_hugeint` element.
 */
 DUCKDB_API duckdb_hugeint duckdb_double_to_hugeint(double val);
+
+//===--------------------------------------------------------------------===//
+// Decimal Helpers
+//===--------------------------------------------------------------------===//
+/*!
+Converts a duckdb_decimal object (as obtained from a `DUCKDB_TYPE_DECIMAL` column) into a double.
+
+* val: The decimal value.
+* returns: The converted `double` element.
+*/
+DUCKDB_API double duckdb_decimal_to_double(duckdb_decimal val);
 
 //===--------------------------------------------------------------------===//
 // Prepared Statements

--- a/src/include/duckdb/main/capi_internal.hpp
+++ b/src/include/duckdb/main/capi_internal.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb.h"
 #include "duckdb.hpp"
+#include "duckdb/common/types.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/main/appender.hpp"
 #include <cstring>
@@ -45,5 +46,9 @@ struct AppenderWrapper {
 duckdb_type ConvertCPPTypeToC(const LogicalType &type);
 idx_t GetCTypeSize(duckdb_type type);
 duckdb_state duckdb_translate_result(MaterializedQueryResult *result, duckdb_result *out);
+
+struct DuckDBColumnData {
+	LogicalType type;
+};
 
 } // namespace duckdb

--- a/src/main/capi/helper-c.cpp
+++ b/src/main/capi/helper-c.cpp
@@ -45,6 +45,8 @@ duckdb_type ConvertCPPTypeToC(const LogicalType &sql_type) {
 		return DUCKDB_TYPE_BLOB;
 	case LogicalTypeId::INTERVAL:
 		return DUCKDB_TYPE_INTERVAL;
+	case LogicalTypeId::DECIMAL:
+		return DUCKDB_TYPE_DECIMAL;
 	default: // LCOV_EXCL_START
 		D_ASSERT(0);
 		return DUCKDB_TYPE_INVALID;
@@ -88,6 +90,8 @@ idx_t GetCTypeSize(duckdb_type type) {
 		return sizeof(duckdb_blob);
 	case DUCKDB_TYPE_INTERVAL:
 		return sizeof(duckdb_interval);
+	case DUCKDB_TYPE_DECIMAL:
+		return sizeof(duckdb_hugeint);
 	default: // LCOV_EXCL_START
 		// unsupported type
 		D_ASSERT(0);

--- a/src/main/capi/hugeint-c.cpp
+++ b/src/main/capi/hugeint-c.cpp
@@ -1,5 +1,7 @@
 #include "duckdb/main/capi_internal.hpp"
 #include "duckdb/common/types/hugeint.hpp"
+#include "duckdb/common/types/decimal.hpp"
+#include "duckdb/common/operator/decimal_cast_operators.hpp"
 
 using duckdb::Hugeint;
 using duckdb::hugeint_t;
@@ -22,5 +24,14 @@ duckdb_hugeint duckdb_double_to_hugeint(double val) {
 	duckdb_hugeint result;
 	result.lower = internal_result.lower;
 	result.upper = internal_result.upper;
+	return result;
+}
+
+double duckdb_decimal_to_double(duckdb_decimal val) {
+	double result;
+	hugeint_t value;
+	value.lower = val.value.lower;
+	value.upper = val.value.upper;
+	duckdb::TryCastFromDecimal::Operation<hugeint_t, double>(value, result, nullptr, val.width, val.scale);
 	return result;
 }

--- a/src/main/capi/result-c.cpp
+++ b/src/main/capi/result-c.cpp
@@ -1,5 +1,4 @@
 #include "duckdb/main/capi_internal.hpp"
-#include "duckdb/common/types.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/serializer/buffered_serializer.hpp"
 #include "duckdb/common/serializer/buffered_deserializer.hpp"
@@ -325,7 +324,7 @@ static void DuckdbDestroyColumn(duckdb_column column, idx_t count) {
 		duckdb_free(column.__deprecated_name);
 	}
 	if (column.duckdb_logical_type) {
-		LogicalType *type = (LogicalType *)column.duckdb_logical_type;
+		duckdb::LogicalType *type = (duckdb::LogicalType *)column.duckdb_logical_type;
 		delete type;
 	}
 }

--- a/src/main/capi/result-c.cpp
+++ b/src/main/capi/result-c.cpp
@@ -58,8 +58,8 @@ duckdb_state duckdb_translate_result(MaterializedQueryResult *result, duckdb_res
 		BufferedSerializer serializer;
 		result->types[i].Serialize(serializer);
 		BufferedDeserializer deserializer(serializer);
-		auto clonedType = new LogicalType(LogicalType::Deserialize(deserializer));
-		out->__deprecated_columns[i].duckdb_logical_type = (void *)clonedType;
+		auto cloned_type = new LogicalType(LogicalType::Deserialize(deserializer));
+		out->__deprecated_columns[i].duckdb_logical_type = (void *)cloned_type;
 		out->__deprecated_columns[i].__deprecated_type = ConvertCPPTypeToC(result->types[i]);
 		out->__deprecated_columns[i].__deprecated_name = strdup(result->names[i].c_str());
 		out->__deprecated_columns[i].__deprecated_nullmask =

--- a/src/main/capi/result-c.cpp
+++ b/src/main/capi/result-c.cpp
@@ -243,6 +243,7 @@ duckdb_state duckdb_translate_result(MaterializedQueryResult *result, duckdb_res
 						row++;
 					}
 				}
+				break;
 			}
 			case PhysicalType::INT32: {
 				for (auto &chunk : result->collection.Chunks()) {

--- a/src/main/capi/value-c.cpp
+++ b/src/main/capi/value-c.cpp
@@ -142,7 +142,11 @@ using duckdb::UnsafeFetch;
 template <class SOURCE_TYPE, class RESULT_TYPE, class OP>
 RESULT_TYPE TryCastCInternal(duckdb_result *result, idx_t col, idx_t row) {
 	RESULT_TYPE result_value;
-	if (!OP::template Operation<SOURCE_TYPE, RESULT_TYPE>(UnsafeFetch<SOURCE_TYPE>(result, col, row), result_value)) {
+	try {
+		if (!OP::template Operation<SOURCE_TYPE, RESULT_TYPE>(UnsafeFetch<SOURCE_TYPE>(result, col, row), result_value)) {
+			return FetchDefaultValue::Operation<RESULT_TYPE>();
+		}
+	} catch (...) {
 		return FetchDefaultValue::Operation<RESULT_TYPE>();
 	}
 	return result_value;

--- a/src/main/capi/value-c.cpp
+++ b/src/main/capi/value-c.cpp
@@ -240,8 +240,8 @@ int64_t duckdb_value_int64(duckdb_result *result, idx_t col, idx_t row) {
 duckdb_decimal duckdb_value_decimal(duckdb_result *result, idx_t col, idx_t row) {
 	duckdb_decimal result_value;
 
-	LogicalType *logical_type = (LogicalType *)result->__deprecated_columns[col].duckdb_logical_type;
-	logical_type->GetDecimalProperties(result_value.width, result_value.scale);
+	auto column_data = (duckdb::DuckDBColumnData *)result->__deprecated_columns[col].internal_data;
+	column_data->type.GetDecimalProperties(result_value.width, result_value.scale);
 
 	auto internal_value = GetInternalCValue<hugeint_t>(result, col, row);
 	result_value.value.lower = internal_value.lower;

--- a/src/main/capi/value-c.cpp
+++ b/src/main/capi/value-c.cpp
@@ -143,7 +143,8 @@ template <class SOURCE_TYPE, class RESULT_TYPE, class OP>
 RESULT_TYPE TryCastCInternal(duckdb_result *result, idx_t col, idx_t row) {
 	RESULT_TYPE result_value;
 	try {
-		if (!OP::template Operation<SOURCE_TYPE, RESULT_TYPE>(UnsafeFetch<SOURCE_TYPE>(result, col, row), result_value)) {
+		if (!OP::template Operation<SOURCE_TYPE, RESULT_TYPE>(UnsafeFetch<SOURCE_TYPE>(result, col, row),
+		                                                      result_value)) {
 			return FetchDefaultValue::Operation<RESULT_TYPE>();
 		}
 	} catch (...) {
@@ -198,6 +199,8 @@ static RESULT_TYPE GetInternalCValue(duckdb_result *result, idx_t col, idx_t row
 		return TryCastCInternal<timestamp_t, RESULT_TYPE, OP>(result, col, row);
 	case DUCKDB_TYPE_HUGEINT:
 		return TryCastCInternal<hugeint_t, RESULT_TYPE, OP>(result, col, row);
+	case DUCKDB_TYPE_DECIMAL:
+		return TryCastCInternal<hugeint_t, RESULT_TYPE, OP>(result, col, row);
 	case DUCKDB_TYPE_INTERVAL:
 		return TryCastCInternal<interval_t, RESULT_TYPE, OP>(result, col, row);
 	case DUCKDB_TYPE_VARCHAR:
@@ -232,6 +235,20 @@ int32_t duckdb_value_int32(duckdb_result *result, idx_t col, idx_t row) {
 
 int64_t duckdb_value_int64(duckdb_result *result, idx_t col, idx_t row) {
 	return GetInternalCValue<int64_t>(result, col, row);
+}
+
+duckdb_decimal duckdb_value_decimal(duckdb_result *result, idx_t col, idx_t row) {
+	duckdb_decimal result_value;
+
+	hugeint_t type_info =
+	    ((hugeint_t *)result->__deprecated_columns[col].__deprecated_data)[result->__deprecated_row_count];
+	result_value.width = (uint8_t)type_info.lower;
+	result_value.scale = (uint8_t)type_info.upper;
+
+	auto internal_value = GetInternalCValue<hugeint_t>(result, col, row);
+	result_value.value.lower = internal_value.lower;
+	result_value.value.upper = internal_value.upper;
+	return result_value;
 }
 
 duckdb_hugeint duckdb_value_hugeint(duckdb_result *result, idx_t col, idx_t row) {

--- a/src/main/capi/value-c.cpp
+++ b/src/main/capi/value-c.cpp
@@ -240,10 +240,8 @@ int64_t duckdb_value_int64(duckdb_result *result, idx_t col, idx_t row) {
 duckdb_decimal duckdb_value_decimal(duckdb_result *result, idx_t col, idx_t row) {
 	duckdb_decimal result_value;
 
-	hugeint_t type_info =
-	    ((hugeint_t *)result->__deprecated_columns[col].__deprecated_data)[result->__deprecated_row_count];
-	result_value.width = (uint8_t)type_info.lower;
-	result_value.scale = (uint8_t)type_info.upper;
+	LogicalType *logical_type = (LogicalType *)result->__deprecated_columns[col].duckdb_logical_type;
+	logical_type->GetDecimalProperties(result_value.width, result_value.scale);
 
 	auto internal_value = GetInternalCValue<hugeint_t>(result, col, row);
 	result_value.value.lower = internal_value.lower;

--- a/test/api/capi/test_capi.cpp
+++ b/test/api/capi/test_capi.cpp
@@ -515,6 +515,15 @@ TEST_CASE("Test different types of C API", "[capi]") {
 	REQUIRE(result->IsNull(0, 0));
 	duckdb_decimal decimal = result->Fetch<duckdb_decimal>(0, 1);
 	REQUIRE(duckdb_decimal_to_double(decimal) == 12.3);
+	// test more decimal physical types
+	result = tester.Query("SELECT 1.2::DECIMAL(4,1), 100.3::DECIMAL(9,1), 320938.4298::DECIMAL(18,4), "
+	                      "49082094824.904820482094::DECIMAL(30,12), NULL::DECIMAL");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(duckdb_decimal_to_double(result->Fetch<duckdb_decimal>(0, 0)) == 1.2);
+	REQUIRE(duckdb_decimal_to_double(result->Fetch<duckdb_decimal>(1, 0)) == 100.3);
+	REQUIRE(duckdb_decimal_to_double(result->Fetch<duckdb_decimal>(2, 0)) == 320938.4298);
+	REQUIRE(duckdb_decimal_to_double(result->Fetch<duckdb_decimal>(3, 0)) == 49082094824.904820482094);
+	REQUIRE(result->IsNull(4, 0));
 }
 
 TEST_CASE("Test errors in C API", "[capi]") {

--- a/test/api/capi/test_capi.cpp
+++ b/test/api/capi/test_capi.cpp
@@ -541,6 +541,22 @@ TEST_CASE("Test errors in C API", "[capi]") {
 	// various edge cases/nullptrs
 	REQUIRE(duckdb_query_arrow_schema(out_arrow, nullptr) == DuckDBSuccess);
 	REQUIRE(duckdb_query_arrow_array(out_arrow, nullptr) == DuckDBSuccess);
+
+	// default duckdb_value_date on invalid date
+	result = tester.Query("SELECT 1, true, 'a'");
+	REQUIRE_NO_FAIL(*result);
+	duckdb_date_struct d = result->Fetch<duckdb_date_struct>(0, 0);
+	REQUIRE(d.year == 1970);
+	REQUIRE(d.month == 1);
+	REQUIRE(d.day == 1);
+	d = result->Fetch<duckdb_date_struct>(1, 0);
+	REQUIRE(d.year == 1970);
+	REQUIRE(d.month == 1);
+	REQUIRE(d.day == 1);
+	d = result->Fetch<duckdb_date_struct>(2, 0);
+	REQUIRE(d.year == 1970);
+	REQUIRE(d.month == 1);
+	REQUIRE(d.day == 1);
 }
 
 TEST_CASE("Test prepared statements in C API", "[capi]") {


### PR DESCRIPTION
Use a trick to store the decimal data in order to save some memory, will allocate an extra row to store the decimal scale and width info so we don't need to have duplication in each row. Not sure if we have a better way to do this.

fix #2853 #2858 