### PR TITLE
Test/add parser error on missing newline

### DIFF
--- a/test/sql/aggregate/aggregates/test_mode.test
+++ b/test/sql/aggregate/aggregates/test_mode.test
@@ -73,6 +73,7 @@ select mode(name) from names;
 pedro
 
 require vector_size 512
+
 query III
 select k, v, mode(v) over (partition by k)
     from aggr

--- a/test/sql/copy/parquet/test_parquet_scan.test
+++ b/test/sql/copy/parquet/test_parquet_scan.test
@@ -3,6 +3,7 @@
 # group: [parquet]
 
 require parquet
+
 require vector_size 512
 
 statement ok

--- a/test/sql/function/timestamp/test_icu_datesub.test
+++ b/test/sql/function/timestamp/test_icu_datesub.test
@@ -130,6 +130,7 @@ select DATESUB('${datepart}', '2004-01-31 13:00:00-08'::TIMESTAMPTZ, '2004-02-28
 3
 
 endloop
+
 query I
 select DATESUB('hour', '2004-01-31 12:00:00-08'::TIMESTAMPTZ, '2004-02-01 13:05:00-08'::TIMESTAMPTZ);
 ----

--- a/test/sql/storage/compression/bitpacking/bitpacking_types.test_coverage
+++ b/test/sql/storage/compression/bitpacking/bitpacking_types.test_coverage
@@ -9,11 +9,9 @@ statement ok
 PRAGMA force_compression = 'bitpacking'
 
 foreach type <numeric> decimal(4,1) decimal(8,1) decimal(12,1) decimal(18,1)
-statement ok
-CREATE TABLE test (a ${type});
 
 statement ok
-CREATE TABLE a AS SELECT MOD(i,3) i FROM range(10000) tbl(i)
+CREATE TABLE a AS SELECT MOD(i,3)::${type} i FROM range(10000) tbl(i)
 
 query IIIII
 SELECT MIN(i), MAX(i), AVG(i), COUNT(*), COUNT(i) FROM a

--- a/test/sql/storage/storage_types.test
+++ b/test/sql/storage/storage_types.test
@@ -67,6 +67,7 @@ SELECT MIN(i), MAX(i), COUNT(*), COUNT(i) FROM a_${type} WHERE i=1
 1	1	1	1
 
 endloop
+
 query IIII
 SELECT MIN(i), MAX(i), COUNT(*), COUNT(i) FROM a_interval
 ----

--- a/test/sql/storage/wal/wal_storage_types.test
+++ b/test/sql/storage/wal/wal_storage_types.test
@@ -98,6 +98,7 @@ SELECT MIN(i), MAX(i), COUNT(*), COUNT(i) FROM a_${type} WHERE i=1
 1	1	1	1
 
 endloop
+
 query IIII
 SELECT MIN(i), MAX(i), COUNT(*), COUNT(i) FROM a_interval
 ----

--- a/test/sqlite/sqllogic_parser.cpp
+++ b/test/sqlite/sqllogic_parser.cpp
@@ -129,8 +129,6 @@ SQLLogicToken SQLLogicParser::Tokenize() {
 // Single line statements should throw a parser error if the next line is not a comment or a newline
 bool SQLLogicParser::IsSingleLineStatement(SQLLogicToken &token) {
 	switch (token.type) {
-	case SQLLogicTokenType::SQLLOGIC_SKIP_IF:
-	case SQLLogicTokenType::SQLLOGIC_ONLY_IF:
 	case SQLLogicTokenType::SQLLOGIC_HASH_THRESHOLD:
 	case SQLLogicTokenType::SQLLOGIC_HALT:
 	case SQLLogicTokenType::SQLLOGIC_MODE:
@@ -142,6 +140,8 @@ bool SQLLogicParser::IsSingleLineStatement(SQLLogicToken &token) {
 	case SQLLogicTokenType::SQLLOGIC_RESTART:
 		return true;
 
+	case SQLLogicTokenType::SQLLOGIC_SKIP_IF:
+	case SQLLogicTokenType::SQLLOGIC_ONLY_IF:
 	case SQLLogicTokenType::SQLLOGIC_INVALID:
 	case SQLLogicTokenType::SQLLOGIC_STATEMENT:
 	case SQLLogicTokenType::SQLLOGIC_QUERY:

--- a/test/sqlite/sqllogic_parser.cpp
+++ b/test/sqlite/sqllogic_parser.cpp
@@ -24,6 +24,14 @@ bool SQLLogicParser::EmptyOrComment(const string &line) {
 	return line.empty() || StringUtil::StartsWith(line, "#");
 }
 
+bool SQLLogicParser::NextLineEmptyOrComment() {
+	if (current_line + 1 >= lines.size()) {
+		return true;
+	} else {
+		return EmptyOrComment(lines[current_line + 1]);
+	}
+}
+
 bool SQLLogicParser::NextStatement() {
 	if (seen_statement) {
 		// skip the current statement
@@ -116,6 +124,42 @@ SQLLogicToken SQLLogicParser::Tokenize() {
 		result.parameters.push_back(move(argument_list[i]));
 	}
 	return result;
+}
+
+// Single line statements should throw a parser error if the next line is not a comment or a newline
+bool SQLLogicParser::IsSingleLineStatement(SQLLogicToken &token) {
+	switch (token.type) {
+	case SQLLogicTokenType::SQLLOGIC_INVALID:
+		return false;
+	case SQLLogicTokenType::SQLLOGIC_SKIP_IF:
+		return true;
+	case SQLLogicTokenType::SQLLOGIC_ONLY_IF:
+		return true;
+	case SQLLogicTokenType::SQLLOGIC_STATEMENT:
+		return false;
+	case SQLLogicTokenType::SQLLOGIC_QUERY:
+		return false;
+	case SQLLogicTokenType::SQLLOGIC_HASH_THRESHOLD:
+		return true;
+	case SQLLogicTokenType::SQLLOGIC_HALT:
+		return true;
+	case SQLLogicTokenType::SQLLOGIC_MODE:
+		return true;
+	case SQLLogicTokenType::SQLLOGIC_LOOP:
+		return true;
+	case SQLLogicTokenType::SQLLOGIC_FOREACH:
+		return true;
+	case SQLLogicTokenType::SQLLOGIC_ENDLOOP:
+		return true;
+	case SQLLogicTokenType::SQLLOGIC_REQUIRE:
+		return true;
+	case SQLLogicTokenType::SQLLOGIC_LOAD:
+		return true;
+	case SQLLogicTokenType::SQLLOGIC_RESTART:
+		return true;
+	default:
+		throw std::runtime_error("Unknown SQLLogic token found!");
+	}
 }
 
 SQLLogicTokenType SQLLogicParser::CommandToToken(const string &token) {

--- a/test/sqlite/sqllogic_parser.cpp
+++ b/test/sqlite/sqllogic_parser.cpp
@@ -129,34 +129,24 @@ SQLLogicToken SQLLogicParser::Tokenize() {
 // Single line statements should throw a parser error if the next line is not a comment or a newline
 bool SQLLogicParser::IsSingleLineStatement(SQLLogicToken &token) {
 	switch (token.type) {
-	case SQLLogicTokenType::SQLLOGIC_INVALID:
-		return false;
 	case SQLLogicTokenType::SQLLOGIC_SKIP_IF:
-		return true;
 	case SQLLogicTokenType::SQLLOGIC_ONLY_IF:
-		return true;
-	case SQLLogicTokenType::SQLLOGIC_STATEMENT:
-		return false;
-	case SQLLogicTokenType::SQLLOGIC_QUERY:
-		return false;
 	case SQLLogicTokenType::SQLLOGIC_HASH_THRESHOLD:
-		return true;
 	case SQLLogicTokenType::SQLLOGIC_HALT:
-		return true;
 	case SQLLogicTokenType::SQLLOGIC_MODE:
-		return true;
 	case SQLLogicTokenType::SQLLOGIC_LOOP:
-		return true;
 	case SQLLogicTokenType::SQLLOGIC_FOREACH:
-		return true;
 	case SQLLogicTokenType::SQLLOGIC_ENDLOOP:
-		return true;
 	case SQLLogicTokenType::SQLLOGIC_REQUIRE:
-		return true;
 	case SQLLogicTokenType::SQLLOGIC_LOAD:
-		return true;
 	case SQLLogicTokenType::SQLLOGIC_RESTART:
 		return true;
+
+	case SQLLogicTokenType::SQLLOGIC_INVALID:
+	case SQLLogicTokenType::SQLLOGIC_STATEMENT:
+	case SQLLogicTokenType::SQLLOGIC_QUERY:
+		return false;
+
 	default:
 		throw std::runtime_error("Unknown SQLLogic token found!");
 	}

--- a/test/sqlite/sqllogic_parser.hpp
+++ b/test/sqlite/sqllogic_parser.hpp
@@ -51,6 +51,10 @@ public:
 
 public:
 	static bool EmptyOrComment(const string &line);
+	static bool IsSingleLineStatement(SQLLogicToken &token);
+
+	//! Does the next line contain a comment, empty line, or is the end of the file
+	bool NextLineEmptyOrComment();
 
 	//! Opens the file, returns whether or not reading was successful
 	bool OpenFile(const string &path);

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -192,6 +192,12 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 	while (parser.NextStatement()) {
 		// tokenize the current line
 		auto token = parser.Tokenize();
+
+		// throw explicit error on single line statements that are not separated by a comment or newline
+		if (parser.IsSingleLineStatement(token) && !parser.NextLineEmptyOrComment()) {
+			parser.Fail("all test statements need to be separated by an empty line");
+		}
+
 		bool skip_statement = false;
 		while (token.type == SQLLogicTokenType::SQLLOGIC_SKIP_IF || token.type == SQLLogicTokenType::SQLLOGIC_ONLY_IF) {
 			// skipif/onlyif


### PR DESCRIPTION
Fixes #3078 by adding a parser error. 

This PR requires a change to the open pr #3069, which introduces 2 new single line commands that should be added to the IsSingleLineStatement. If either PR is merged, I'll update the other with the required change.