### PR TITLE
Allow multiple statements in the R-client

### DIFF
--- a/tools/rpkg/tests/testthat/_snaps/multi_statement.md
+++ b/tools/rpkg/tests/testthat/_snaps/multi_statement.md
@@ -1,0 +1,31 @@
+# empty statement gives an error
+
+    rapi_prepare: No statements to execute
+
+# multiple statements can be used in one call
+
+    Code
+      DBI::dbGetQuery(con, paste("DROP TABLE IF EXISTS integers;", query))
+    Output
+         i
+      1  0
+      2  1
+      3  2
+      4  3
+      5  4
+      6  5
+      7  6
+      8  7
+      9  8
+      10 9
+
+# statements can be splitted apart correctly
+
+    Code
+      DBI::dbGetQuery(con, a <- paste("--Multistatement testing; testing",
+        "/*  test;   ", "--test;", ";test */", "create table temp_test as ", "select",
+        "'testing_temp;' as temp_col", ";", "select * from temp_test;", sep = "\n"))
+    Output
+             temp_col
+      1 testing_temp;
+

--- a/tools/rpkg/tests/testthat/test_multi_statement.R
+++ b/tools/rpkg/tests/testthat/test_multi_statement.R
@@ -1,0 +1,60 @@
+skip_on_cran()
+local_edition(3)
+
+test_that("empty statement gives an error", {
+  con <- DBI::dbConnect(duckdb::duckdb())
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
+  expect_snapshot_error(DBI::dbGetQuery(con, "; ;   ; -- SELECT 1;"))
+})
+
+test_that("multiple statements can be used in one call", {
+  con <- DBI::dbConnect(duckdb::duckdb())
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
+  query <- paste(
+    "CREATE TABLE integers(i integer);",
+    "insert into integers select * from range(10);",
+    "select * from integers;",
+    sep = "\n"
+  )
+  expect_identical(DBI::dbGetQuery(con, query), data.frame(i = 0:9))
+  expect_snapshot(DBI::dbGetQuery(con, paste("DROP TABLE IF EXISTS integers;", query)))
+})
+
+test_that("statements can be splitted apart correctly", {
+  con <- DBI::dbConnect(duckdb::duckdb())
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
+  expect_snapshot(DBI::dbGetQuery(con, a <- paste(
+    "--Multistatement testing; testing",
+    "/*  test;   ",
+    "--test;",
+    ";test */",
+    "create table temp_test as ",
+    "select",
+    "'testing_temp;' as temp_col",
+    ";",
+    "select * from temp_test;",
+    sep = "\n"
+  )))
+})
+
+test_that("export/import database works", {
+  export_location <- file.path(tempdir(), "duckdb_test_export")
+  if (!file.exists(export_location)) dir.create(export_location)
+
+  con <- DBI::dbConnect(duckdb::duckdb())
+  DBI::dbExecute(con, "CREATE TABLE integers(i integer)")
+  DBI::dbExecute(con, "insert into integers select * from range(10)")
+  DBI::dbExecute(con, "CREATE TABLE integers2(i INTEGER)")
+  DBI::dbExecute(con, "INSERT INTO integers2 VALUES (1), (5), (7), (1928)")
+  DBI::dbExecute(con, paste0("EXPORT DATABASE '", export_location, "'"))
+  DBI::dbDisconnect(con, shutdown = TRUE)
+
+  con <- DBI::dbConnect(duckdb::duckdb())
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
+
+  DBI::dbExecute(con, paste0("IMPORT DATABASE '", export_location, "'"))
+  if (file.exists(export_location)) unlink(export_location, recursive = TRUE)
+
+  expect_identical(DBI::dbGetQuery(con, "select * from integers"), data.frame(i = 0:9))
+  expect_identical(DBI::dbGetQuery(con, "select * from integers2"), data.frame(i = c(1L, 5L, 7L, 1928L)))
+})


### PR DESCRIPTION
Implementation of #1102 for the R client. This is needed for the IMPORT DATABASE as well as for the bundling of option setting PRAGMAs with e.g. lazy EXPLAIN queries.