### PR TITLE
Issue #3020: Unify column names of DESCRIBE and SUMMARIZE

### DIFF
--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -33,7 +33,7 @@ string PragmaFunctionsQuery(ClientContext &context, const FunctionParameters &pa
 string PragmaShow(ClientContext &context, const FunctionParameters &parameters) {
 	// PRAGMA table_info but with some aliases
 	return StringUtil::Format(
-	    "SELECT name AS \"colomn_name\", type as \"column_type\", CASE WHEN \"notnull\" THEN 'NO' ELSE 'YES' "
+	    "SELECT name AS \"column_name\", type as \"column_type\", CASE WHEN \"notnull\" THEN 'NO' ELSE 'YES' "
 	    "END AS \"null\", NULL AS \"key\", dflt_value AS \"default\", NULL AS \"extra\" FROM pragma_table_info('%s')",
 	    parameters.values[0].ToString());
 }

--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/main/config.hpp"
+#include "duckdb/common/printer.hpp"
 
 namespace duckdb {
 
@@ -32,9 +33,10 @@ string PragmaFunctionsQuery(ClientContext &context, const FunctionParameters &pa
 
 string PragmaShow(ClientContext &context, const FunctionParameters &parameters) {
 	// PRAGMA table_info but with some aliases
+	Printer::Print("PragmaShow");
 	return StringUtil::Format(
-	    "SELECT name AS \"Field\", type as \"Type\", CASE WHEN \"notnull\" THEN 'NO' ELSE 'YES' END AS \"Null\", "
-	    "NULL AS \"Key\", dflt_value AS \"Default\", NULL AS \"Extra\" FROM pragma_table_info('%s')",
+	    "SELECT name AS \"colomn_name\", type as \"column_type\", CASE WHEN \"notnull\" THEN 'NO' ELSE 'YES' "
+	    "END AS \"null\", NULL AS \"key\", dflt_value AS \"default\", NULL AS \"extra\" FROM pragma_table_info('%s')",
 	    parameters.values[0].ToString());
 }
 

--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -2,7 +2,6 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/main/config.hpp"
-#include "duckdb/common/printer.hpp"
 
 namespace duckdb {
 
@@ -33,7 +32,6 @@ string PragmaFunctionsQuery(ClientContext &context, const FunctionParameters &pa
 
 string PragmaShow(ClientContext &context, const FunctionParameters &parameters) {
 	// PRAGMA table_info but with some aliases
-	Printer::Print("PragmaShow");
 	return StringUtil::Format(
 	    "SELECT name AS \"colomn_name\", type as \"column_type\", CASE WHEN \"notnull\" THEN 'NO' ELSE 'YES' "
 	    "END AS \"null\", NULL AS \"key\", dflt_value AS \"default\", NULL AS \"extra\" FROM pragma_table_info('%s')",

--- a/src/planner/binder/statement/bind_show.cpp
+++ b/src/planner/binder/statement/bind_show.cpp
@@ -20,7 +20,7 @@ BoundStatement Binder::Bind(ShowStatement &stmt) {
 
 	result.plan = move(show);
 
-	result.names = {"Field", "Type", "Null", "Key", "Default", "Extra"};
+	result.names = {"column_name", "column_type", "null", "key", "default", "extra"};
 	result.types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
 	                LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
 	return result;

--- a/test/sql/pragma/test_show_tables.test
+++ b/test/sql/pragma/test_show_tables.test
@@ -34,21 +34,21 @@ integers
 select
 v1
 
-# Field | Type | Null | Key | Default | Extra
+# column_name | column_type | null | key | default | extra
 query TTTITI
 SHOW integers
 ----
 i	INTEGER	YES	NULL	NULL	NULL
 j	INTEGER	YES	NULL	NULL	NULL
 
-# Field | Type | Null | Key | Default | Extra
+# column_name | column_type | null | key | default | extra
 query TTTITI
 SHOW "select";
 ----
 i	INTEGER	YES	NULL	NULL	NULL
 
 # equivalent to PRAGMA SHOW('integers')
-# Field | Type | Null | Key | Default | Extra
+# column_name | column_type | null | key | default | extra
 query TTTITI
 PRAGMA SHOW('integers')
 ----
@@ -56,7 +56,7 @@ i	INTEGER	YES	NULL	NULL	NULL
 j	INTEGER	YES	NULL	NULL	NULL
 
 # we can also describe views
-# Field | Type | Null | Key | Default | Extra
+# column_name | column_type | null | key | default | extra
 query TTTITI
 DESCRIBE v1
 ----

--- a/test/sql/show_select/test_show_select.test
+++ b/test/sql/show_select/test_show_select.test
@@ -17,27 +17,27 @@ INSERT INTO integers VALUES (1, 1), (2, 2), (3, 3), (NULL, NULL)
 statement ok
 INSERT INTO integers2 VALUES (1, 30, 'a', '1992-01-01'), (8, 12, 'b', '1992-01-01'), (3, 24, 'c', '1992-01-01'), (9, 16, 'd', '1992-01-01'), (10, NULL, 'e', '1992-01-01')
 
-# Field | Type | Null | Key | Default | Extra
+# column_name | column_type | null | key | default | extra
 query TTTTTT
 SHOW SELECT * FROM integers
 ----
 i	INTEGER	YES	NULL	NULL	NULL
 j	INTEGER	YES	NULL	NULL	NULL
 
-# Field | Type | Null | Key | Default | Extra
+# column_name | column_type | null | key | default | extra
 query TTTTTT
 DESCRIBE SELECT * FROM integers
 ----
 i	INTEGER	YES	NULL	NULL	NULL
 j	INTEGER	YES	NULL	NULL	NULL
 
-# Field | Type | Null | Key | Default | Extra
+# column_name | column_type | null | key | default | extra
 query TTTTTT
 SHOW SELECT i FROM integers
 ----
 i	INTEGER	YES	NULL	NULL	NULL
 
-# Field | Type | Null | Key | Default | Extra
+# column_name | column_type | null | key | default | extra
 query TTTTTT
 SHOW SELECT integers.i, integers2.st, integers2.d FROM integers, integers2 WHERE integers.i=integers2.i
 ----
@@ -45,7 +45,7 @@ i	INTEGER	YES	NULL	NULL	NULL
 st	VARCHAR	YES	NULL	NULL	NULL
 d	DATE	YES	NULL	NULL	NULL
 
-# Field | Type | Null | Key | Default | Extra
+# column_name | column_type | null | key | default | extra
 query TTTTTT
 SHOW SELECT SUM(i) AS sum1, j FROM integers GROUP BY j HAVING j < 10
 ----

--- a/tools/rpkg/R/dbWriteTable__duckdb_connection_character_data.frame.R
+++ b/tools/rpkg/R/dbWriteTable__duckdb_connection_character_data.frame.R
@@ -67,7 +67,7 @@ dbWriteTable__duckdb_connection_character_data.frame <- function(conn,
 
     col_names <- dbGetQuery(conn, SQL(sprintf(
       "DESCRIBE %s", view_name
-    )))$Field
+    )))$column_name
 
     cols <- character()
     col_idx <- 1


### PR DESCRIPTION
As #3020 mentioned, `DESCRIBE` and `SUMMARIZE` has inconsistent column names.
This PR changes column names of `DESCRIBE` (which is actually `SHOW`) to be consistent with `SUMMARIZE`:
- `Field` -> `column_name`
- `Type` -> `column_type`

And uncapitalize the rest of column names.

Before change:
```
D CREATE TABLE test(i INTEGER);
D SUMMARIZE test;
┌─────────────┬─────────────┬─────┬─────┬───────────────┬─────┬─────┬─────┬─────┬─────┬───────┬─────────────────┐
│ column_name │ column_type │ min │ max │ approx_unique │ avg │ std │ q25 │ q50 │ q75 │ count │ null_percentage │
├─────────────┼─────────────┼─────┼─────┼───────────────┼─────┼─────┼─────┼─────┼─────┼───────┼─────────────────┤
│ i           │ INTEGER     │     │     │ 0             │     │     │     │     │     │ 0     │ %               │
└─────────────┴─────────────┴─────┴─────┴───────────────┴─────┴─────┴─────┴─────┴─────┴───────┴─────────────────┘
D DESCRIBE test;
┌───────┬─────────┬──────┬─────┬─────────┬───────┐
│ Field │  Type   │ Null │ Key │ Default │ Extra │
├───────┼─────────┼──────┼─────┼─────────┼───────┤
│ i     │ INTEGER │ YES  │     │         │       │
└───────┴─────────┴──────┴─────┴─────────┴───────┘
```

After change:
```
D DESCRIBE test;
┌─────────────┬─────────────┬──────┬─────┬─────────┬───────┐
│ colomn_name │ column_type │ null │ key │ default │ extra │
├─────────────┼─────────────┼──────┼─────┼─────────┼───────┤
│ i           │ INTEGER     │ YES  │     │         │       │
└─────────────┴─────────────┴──────┴─────┴─────────┴───────┘
```