### PR TITLE
Don't leak memory in duckdb.query_df

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
@@ -22,6 +22,7 @@ public:
 
 	shared_ptr<Relation> rel;
 	unique_ptr<PythonTableArrowArrayStreamFactory> arrow_stream_factory;
+	unique_ptr<RegisteredObject> backing_object;
 
 public:
 	static void Initialize(py::handle &m);

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -165,6 +165,7 @@ DuckDBPyConnection *DuckDBPyConnection::Execute(const string &query, py::object 
 DuckDBPyConnection *DuckDBPyConnection::Append(const string &name, py::object value) {
 	RegisterPythonObject("__append_df", std::move(value));
 	return Execute("INSERT INTO \"" + name + "\" SELECT * FROM __append_df");
+	UnregisterPythonObject("__append_df");
 }
 
 DuckDBPyConnection *DuckDBPyConnection::RegisterPythonObject(const string &name, py::object python_object,

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -283,10 +283,12 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromDF(py::object value) {
 		throw std::runtime_error("connection closed");
 	}
 	string name = "df_" + GenerateRandomName();
-	registered_objects[name] = make_unique<RegisteredObject>(value);
+	auto obj = make_unique<RegisteredObject>(value);
 	vector<Value> params;
 	params.emplace_back(Value::POINTER((uintptr_t)value.ptr()));
-	return make_unique<DuckDBPyRelation>(connection->TableFunction("pandas_scan", params)->Alias(name));
+	auto rel = make_unique<DuckDBPyRelation>(connection->TableFunction("pandas_scan", params)->Alias(name));
+	rel->backing_object = std::move(obj);
+	return rel;
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromCsvAuto(const string &filename) {

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -404,7 +404,10 @@ unique_ptr<DuckDBPyResult> DuckDBPyRelation::Execute() {
 
 unique_ptr<DuckDBPyResult> DuckDBPyRelation::QueryDF(py::object df, const string &view_name, const string &sql_query,
                                                      DuckDBPyConnection *conn) {
-	return conn->FromDF(std::move(df))->Query(view_name, sql_query);
+	auto relation = conn->FromDF(std::move(df));
+	auto result = relation->Query(view_name, sql_query);
+	conn->UnregisterPythonObject(relation->GetAlias());
+	return result;
 }
 
 void DuckDBPyRelation::InsertInto(const string &table) {

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -404,10 +404,7 @@ unique_ptr<DuckDBPyResult> DuckDBPyRelation::Execute() {
 
 unique_ptr<DuckDBPyResult> DuckDBPyRelation::QueryDF(py::object df, const string &view_name, const string &sql_query,
                                                      DuckDBPyConnection *conn) {
-	auto relation = conn->FromDF(std::move(df));
-	auto result = relation->Query(view_name, sql_query);
-	conn->UnregisterPythonObject(relation->GetAlias());
-	return result;
+	return conn->FromDF(std::move(df))->Query(view_name, sql_query);
 }
 
 void DuckDBPyRelation::InsertInto(const string &table) {


### PR DESCRIPTION
My C++ is not the best, but I think this should solve the surface-level problem from https://github.com/duckdb/duckdb/issues/3144 around `query_df`-- in this particular case, we know that no one can have called `SetAlias` on the `DuckDBPyRelation`, so we can use it to unregistered the Python object when we're done. This, of course, does not address the underlying problem with this `conn->FromDF` API.

My main concern is whether `DuckDBPyResult` somehow relies on the memory of the registered object or not -- I don't quite understand the `QueryResult`/`DataChunk` code to be fully confident, but at the very least all tests pass locally for me and 

```python
import pandas as pd
import duckdb
import numpy as np

from tqdm import tqdm

for __ in tqdm(range(10_000_000)):
    df = pd.DataFrame({"x": np.random.rand(1_000_000)})
    duckdb.query_df(df, "df", "SELECT * FROM df")
```

no longer seems to leak memory.