### PR TITLE
Add httpfs to python conda package

### DIFF
--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, Extension
 
 lib_name = 'duckdb'
 
-extensions = ['parquet', 'icu', 'fts', 'tpch', 'tpcds', 'visualizer', 'excel']
+extensions = ['parquet', 'icu', 'fts', 'tpch', 'tpcds', 'visualizer', 'excel', 'httpfs']
 
 if platform.system() == 'Windows':
     extensions = ['parquet', 'icu', 'fts','tpch', 'excel']


### PR DESCRIPTION
I use this with S3 and on premise Ceph S3.  Having it in Conda would be a help to me.
I do not think this increases the dependency footprint at all.  It is all handled by cmake so hopefully condaforge just works.