### PR TITLE
Fix for build error of R package on Windows

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -56,7 +56,7 @@ bool LocalFileSystem::FileExists(const string &filename) {
 	const wchar_t *wpath = unicode_path.c_str();
 	if (_waccess(wpath, 0) == 0) {
 		struct _stat64i32 status;
-		_wstat(wpath, &status);
+		_wstat64i32(wpath, &status);
 		if (status.st_size > 0) {
 			return true;
 		}
@@ -68,7 +68,7 @@ bool LocalFileSystem::IsPipe(const string &filename) {
 	const wchar_t *wpath = unicode_path.c_str();
 	if (_waccess(wpath, 0) == 0) {
 		struct _stat64i32 status;
-		_wstat(wpath, &status);
+		_wstat64i32(wpath, &status);
 		if (status.st_size == 0) {
 			return true;
 		}


### PR DESCRIPTION
It is currently impossible to build i386 (32-bit) R package on Windows using rtools40 (used with R 4.0 (oldrel) and R 4.1 (currel) but not with R 4.2 (devrel)) as building stops on two errors:
 
```
In file included from duckdb/amalgamation-1.cpp:87:
duckdb/src/common/local_file_system.cpp: In member function 'virtual bool duckdb::LocalFileSystem::FileExists(const string&)':
duckdb/src/common/local_file_system.cpp:59:17: error: cannot convert '_stat64i32*' to '_stat*'
   _wstat(wpath, &status);
```

```
In file included from duckdb/amalgamation-1.cpp:87:
duckdb/src/common/local_file_system.cpp: In member function 'virtual bool duckdb::LocalFileSystem::IsPipe(const string&)':
duckdb/src/common/local_file_system.cpp:71:17: error: cannot convert '_stat64i32*' to '_stat*'
   _wstat(wpath, &status);
```

Probably the problem was introduced in commit 664d1f25defd3392ce2deeb28f55d0d672e40c00. Unclear why this was not detected in the CI checks.

If the type `_stat64i32` is correct, this seems to be easy to fix by changing `_wstat` to `_wstat64i32`.