### PR TITLE
Tear down connections

### DIFF
--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -39,7 +39,9 @@ class Connection {
 public:
 	DUCKDB_API explicit Connection(DuckDB &database);
 	DUCKDB_API explicit Connection(DatabaseInstance &database);
+	DUCKDB_API ~Connection();
 
+	shared_ptr<DatabaseInstance> database;
 	shared_ptr<ClientContext> context;
 	warning_callback warning_cb;
 

--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -41,7 +41,6 @@ public:
 	DUCKDB_API explicit Connection(DatabaseInstance &database);
 	DUCKDB_API ~Connection();
 
-	shared_ptr<DatabaseInstance> database;
 	shared_ptr<ClientContext> context;
 	warning_callback warning_cb;
 

--- a/src/include/duckdb/main/connection_manager.hpp
+++ b/src/include/duckdb/main/connection_manager.hpp
@@ -24,32 +24,26 @@ public:
 
 	void AddConnection(ClientContext &context) {
 		lock_guard<mutex> lock(connections_lock);
-		connections.push_back(weak_ptr<ClientContext>(context.shared_from_this()));
+		connections.insert(make_pair(&context, weak_ptr<ClientContext>(context.shared_from_this())));
 	}
 
 	void RemoveConnection(ClientContext &context) {
 		lock_guard<mutex> lock(connections_lock);
-		for (size_t i = 0; i < connections.size(); i++) {
-			auto connection = connections[i].lock();
-			if (connection == context.shared_from_this()) {
-				connections.erase(connections.begin() + i);
-				return;
-			}
-		}
+		connections.erase(&context);
 	}
 
 	vector<shared_ptr<ClientContext>> GetConnectionList() {
 		vector<shared_ptr<ClientContext>> result;
-		for (size_t i = 0; i < connections.size(); i++) {
-			auto connection = connections[i].lock();
+		for (auto &it : connections) {
+			auto connection = it.second.lock();
 			if (!connection) {
-				connections.erase(connections.begin() + i);
-				i--;
+				connections.erase(it.first);
 				continue;
 			} else {
 				result.push_back(move(connection));
 			}
 		}
+
 		return result;
 	}
 
@@ -58,7 +52,7 @@ public:
 
 public:
 	mutex connections_lock;
-	vector<weak_ptr<ClientContext>> connections;
+	unordered_map<ClientContext *, weak_ptr<ClientContext>> connections;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/connection_manager.hpp
+++ b/src/include/duckdb/main/connection_manager.hpp
@@ -27,6 +27,17 @@ public:
 		connections.push_back(weak_ptr<ClientContext>(context.shared_from_this()));
 	}
 
+	void RemoveConnection(ClientContext &context) {
+		lock_guard<mutex> lock(connections_lock);
+		for (size_t i = 0; i < connections.size(); i++) {
+			auto connection = connections[i].lock();
+			if (connection == context.shared_from_this()) {
+				connections.erase(connections.begin() + i);
+				return;
+			}
+		}
+	}
+
 	vector<shared_ptr<ClientContext>> GetConnectionList() {
 		vector<shared_ptr<ClientContext>> result;
 		for (size_t i = 0; i < connections.size(); i++) {

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -16,7 +16,7 @@
 
 namespace duckdb {
 
-Connection::Connection(DatabaseInstance &database) : context(make_shared<ClientContext>(database.shared_from_this())) {
+Connection::Connection(DatabaseInstance &database) : database(database.shared_from_this()), context(make_shared<ClientContext>(database.shared_from_this())) {
 	ConnectionManager::Get(database).AddConnection(*context);
 #ifdef DEBUG
 	EnableProfiling();
@@ -24,6 +24,10 @@ Connection::Connection(DatabaseInstance &database) : context(make_shared<ClientC
 }
 
 Connection::Connection(DuckDB &database) : Connection(*database.instance) {
+}
+
+Connection::~Connection() {
+	ConnectionManager::Get(*database).RemoveConnection(*context);
 }
 
 string Connection::GetProfilingInformation(ProfilerPrintFormat format) {

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -16,7 +16,7 @@
 
 namespace duckdb {
 
-Connection::Connection(DatabaseInstance &database) : database(database.shared_from_this()), context(make_shared<ClientContext>(database.shared_from_this())) {
+Connection::Connection(DatabaseInstance &database) : context(make_shared<ClientContext>(database.shared_from_this())) {
 	ConnectionManager::Get(database).AddConnection(*context);
 #ifdef DEBUG
 	EnableProfiling();
@@ -27,7 +27,7 @@ Connection::Connection(DuckDB &database) : Connection(*database.instance) {
 }
 
 Connection::~Connection() {
-	ConnectionManager::Get(*database).RemoveConnection(*context);
+	ConnectionManager::Get(*context->db).RemoveConnection(*context);
 }
 
 string Connection::GetProfilingInformation(ProfilerPrintFormat format) {

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -504,8 +504,8 @@ TEST_CASE("Test opening an invalid database file", "[api]") {
 
 TEST_CASE("Test large number of connections to a single database", "[api]") {
 	auto db = make_unique<DuckDB>(nullptr);
-	auto &clientContext = ClientContext((*db).instance);
-	auto &connection_manager = ConnectionManager::Get(clientContext);
+	auto context = make_unique<ClientContext>((*db).instance);
+	auto &connection_manager = ConnectionManager::Get(*context);
 
 	vector<unique_ptr<Connection>> connections;
 	int numCon = 5000;

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -508,20 +508,21 @@ TEST_CASE("Test large number of connections to a single database", "[api]") {
 	auto &connection_manager = ConnectionManager::Get(*context);
 
 	vector<unique_ptr<Connection>> connections;
-	int numCon = 5000;
+	size_t createdConnections = 5000;
+	size_t remainingConnections = 500;
+	size_t toRemove = createdConnections - remainingConnections;
 
-	for (size_t i = 0; i < numCon; i++) {
+	for (size_t i = 0; i < createdConnections; i++) {
 		auto conn = make_unique<Connection>(*db);
 		connections.push_back(move(conn));
 	}
 
-	REQUIRE(connection_manager.connections.size() == numCon);
+	REQUIRE(connection_manager.connections.size() == createdConnections);
 
-	for (size_t i = 0; i < connections.size(); i++) {
-		auto conn = *connections[i];
-		connections.erase(connections.begin() + i);
-		i--;
+	for (size_t i = 0; i < toRemove; i++) {
+		auto conn = *connections[0];
+		connections.erase(connections.begin());
 	}
 
-	REQUIRE(connection_manager.connections.size() == 0);
+	REQUIRE(connection_manager.connections.size() == remainingConnections);
 }


### PR DESCRIPTION
This PR addresses a memory leak in the duckdb connection manager (this is more prevalent when using an in memory database). 

Whenever a connection is created a reference to it is stored by the `ConnectionManager` in the `connections` vector. When a connection is closed the `ConnectionManager` still keeps a reference to the connection and this is not cleared*, this PR adds a deconstruction to remove the entry in the `connections` vector.

The memory leak can be seen by opening an in memory database and connecting / disconnecting to this many times, you will see the memory of your application increase and it will not be freed up. 

* calling `GetConnectionList()` will erase any disposed pointers but this is called `Checkpoint` which doesn't run for in memory database via `LockClients`. 