### PR TITLE
Dbplyr-backend SQL translation of is.na() must use only IS NULL

### DIFF
--- a/tools/rpkg/R/backend-dbplyr__duckdb_connection.R
+++ b/tools/rpkg/R/backend-dbplyr__duckdb_connection.R
@@ -112,8 +112,8 @@ sql_translation.duckdb_connection <- function(con) {
     sql_translator(
       .parent = base_scalar,
       as.raw = sql_cast("VARBINARY"),
-      `%%` = function(a, b) sql_expr(FMOD(!!a,!!b)),
-      `%/%` = function(a, b) sql_expr(FDIV(!!a,!!b)),
+      `%%` = function(a, b) sql_expr(FMOD(!!a, !!b)),
+      `%/%` = function(a, b) sql_expr(FDIV(!!a, !!b)),
       `^` = sql_prefix("POW", 2),
       bitwOr = function(a, b) sql_expr((CAST((!!a) %AS% INTEGER)) | (CAST((!!b) %AS% INTEGER))),
       bitwAnd = function(a, b) sql_expr((CAST((!!a) %AS% INTEGER)) & (CAST((!!b) %AS% INTEGER))),
@@ -145,7 +145,7 @@ sql_translation.duckdb_connection <- function(con) {
       # is.nan() 	    FALSE FALSE TRUE 	FALSE
       # is.na() 	    FALSE FALSE TRUE 	TRUE
       # https://github.com/duckdb/duckdb/issues/3019
-      is.na = function(a) build_sql("(", a, " IS NULL OR PRINTF('%f', ", a, ") = 'nan')"),
+      #      is.na = function(a) build_sql("(", a, " IS NULL OR PRINTF('%f', ", a, ") = 'nan')"),
       is.nan = function(a) build_sql("(", a, " IS NOT NULL AND PRINTF('%f', ", a, ") = 'nan')"),
       is.infinite = function(a) build_sql("(", a, " IS NOT NULL AND REGEXP_MATCHES(PRINTF('%f', ", a, "), 'inf'))"),
       is.finite = function(a) build_sql("(NOT (", a, " IS NULL OR REGEXP_MATCHES(PRINTF('%f', ", a, "), 'inf|nan')))"),
@@ -153,7 +153,7 @@ sql_translation.duckdb_connection <- function(con) {
 
       # Return index where the first match starts,-1 if no match
       regexpr = function(p, x) {
-        build_sql("(CASE WHEN REGEXP_MATCHES(", x,", ", p, ") THEN (LENGTH(LIST_EXTRACT(STRING_SPLIT_REGEX(", x, ", ", p,"), 0))+1) ELSE -1 END)")
+        build_sql("(CASE WHEN REGEXP_MATCHES(", x, ", ", p, ") THEN (LENGTH(LIST_EXTRACT(STRING_SPLIT_REGEX(", x, ", ", p, "), 0))+1) ELSE -1 END)")
       },
       round = function(x, digits) sql_expr(ROUND(!!x, CAST(ROUND((!!digits), 0L) %AS% INTEGER))),
       as.Date = sql_cast("DATE"),
@@ -286,9 +286,9 @@ sql_translation.duckdb_connection <- function(con) {
       str_remove_all = function(string, pattern) {
         sql_expr(REGEXP_REPLACE(!!string, !!pattern, "", "g"))
       },
-#      str_to_title = function(string) {
-#        sql_expr(INITCAP(!!string))
-#      },
+      #      str_to_title = function(string) {
+      #        sql_expr(INITCAP(!!string))
+      #      },
       str_to_sentence = function(string) {
         build_sql("(UPPER(", string, "[0]) || ", string, "[1:NULL])")
       },
@@ -393,4 +393,4 @@ dbplyr_fill0.duckdb_connection <- function(.con, .data, cols_to_fill, order_by_c
 }
 
 # Needed to suppress the R CHECK notes (due to the use of sql_expr)
-globalVariables(c("REGEXP_MATCHES", "CAST", "%AS%", "INTEGER", "XOR", "%<<%", "%>>%", "LN", "LOG", "ROUND", "EXTRACT", "%FROM%", "MONTH", "STRFTIME", "QUARTER", "YEAR", "DATE_TRUNC", "DATE", "DOY", "TO_SECONDS", "BIGINT", "TO_MINUTES", "TO_HOURS", "TO_DAYS", "TO_WEEKS", "TO_MONTHS", "TO_YEARS", "STRPOS", "NOT", "REGEXP_REPLACE", "TRIM", "LPAD", "RPAD", "%||%", "REPEAT", "LENGTH", "STRING_AGG", "GREATEST", "LIST_EXTRACT", "LOG10", "LOG2", "STRING_SPLIT_REGEX","FLOOR"))
+globalVariables(c("REGEXP_MATCHES", "CAST", "%AS%", "INTEGER", "XOR", "%<<%", "%>>%", "LN", "LOG", "ROUND", "EXTRACT", "%FROM%", "MONTH", "STRFTIME", "QUARTER", "YEAR", "DATE_TRUNC", "DATE", "DOY", "TO_SECONDS", "BIGINT", "TO_MINUTES", "TO_HOURS", "TO_DAYS", "TO_WEEKS", "TO_MONTHS", "TO_YEARS", "STRPOS", "NOT", "REGEXP_REPLACE", "TRIM", "LPAD", "RPAD", "%||%", "REPEAT", "LENGTH", "STRING_AGG", "GREATEST", "LIST_EXTRACT", "LOG10", "LOG2", "STRING_SPLIT_REGEX", "FLOOR"))

--- a/tools/rpkg/R/backend-dbplyr__duckdb_connection.R
+++ b/tools/rpkg/R/backend-dbplyr__duckdb_connection.R
@@ -90,6 +90,7 @@ duckdb_grepl <- function(pattern, x, ignore.case = FALSE, perl = FALSE, fixed = 
 sql_translation.duckdb_connection <- function(con) {
   sql_variant <- pkg_method("sql_variant", "dbplyr")
   sql_translator <- pkg_method("sql_translator", "dbplyr")
+  sql <- pkg_method("sql", "dbplyr")
   build_sql <- pkg_method("build_sql", "dbplyr")
   sql_expr <- pkg_method("sql_expr", "dbplyr")
   sql_prefix <- pkg_method("sql_prefix", "dbplyr")
@@ -393,4 +394,4 @@ dbplyr_fill0.duckdb_connection <- function(.con, .data, cols_to_fill, order_by_c
 }
 
 # Needed to suppress the R CHECK notes (due to the use of sql_expr)
-globalVariables(c("REGEXP_MATCHES", "CAST", "%AS%", "INTEGER", "XOR", "%<<%", "%>>%", "LN", "LOG", "ROUND", "EXTRACT", "%FROM%", "MONTH", "STRFTIME", "QUARTER", "YEAR", "DATE_TRUNC", "DATE", "DOY", "TO_SECONDS", "BIGINT", "TO_MINUTES", "TO_HOURS", "TO_DAYS", "TO_WEEKS", "TO_MONTHS", "TO_YEARS", "STRPOS", "NOT", "REGEXP_REPLACE", "TRIM", "LPAD", "RPAD", "%||%", "REPEAT", "LENGTH", "STRING_AGG", "GREATEST", "LIST_EXTRACT", "LOG10", "LOG2", "STRING_SPLIT_REGEX", "FLOOR"))
+globalVariables(c("REGEXP_MATCHES", "CAST", "%AS%", "INTEGER", "XOR", "%<<%", "%>>%", "LN", "LOG", "ROUND", "EXTRACT", "%FROM%", "MONTH", "STRFTIME", "QUARTER", "YEAR", "DATE_TRUNC", "DATE", "DOY", "TO_SECONDS", "BIGINT", "TO_MINUTES", "TO_HOURS", "TO_DAYS", "TO_WEEKS", "TO_MONTHS", "TO_YEARS", "STRPOS", "NOT", "REGEXP_REPLACE", "TRIM", "LPAD", "RPAD", "%||%", "REPEAT", "LENGTH", "STRING_AGG", "GREATEST", "LIST_EXTRACT", "LOG10", "LOG2", "STRING_SPLIT_REGEX", "FLOOR", "FMOD", "FIDV"))

--- a/tools/rpkg/tests/testthat/_snaps/backend-dbplyr__duckdb_connection.md
+++ b/tools/rpkg/tests/testthat/_snaps/backend-dbplyr__duckdb_connection.md
@@ -68,6 +68,10 @@
       translate(substr("test", 2, 3))
     Output
       <SQL> SUBSTR('test', 2, 2)
+    Code
+      translate(is.na(var1))
+    Output
+      <SQL> ("var1" IS NULL)
 
 # snapshots of duckdb custom scalars translations
 
@@ -135,10 +139,6 @@
       translate(log2(x))
     Output
       <SQL> LOG2("x")
-    Code
-      translate(is.na(var1))
-    Output
-      <SQL> ("var1" IS NULL OR PRINTF('%f', "var1") = 'nan')
     Code
       translate(is.nan(var1))
     Output

--- a/tools/rpkg/tests/testthat/_snaps/backend-dbplyr__duckdb_connection.md
+++ b/tools/rpkg/tests/testthat/_snaps/backend-dbplyr__duckdb_connection.md
@@ -68,10 +68,6 @@
       translate(substr("test", 2, 3))
     Output
       <SQL> SUBSTR('test', 2, 2)
-    Code
-      translate(is.na(var1))
-    Output
-      <SQL> ("var1" IS NULL)
 
 # snapshots of duckdb custom scalars translations
 

--- a/tools/rpkg/tests/testthat/test_backend-dbplyr__duckdb_connection.R
+++ b/tools/rpkg/tests/testthat/test_backend-dbplyr__duckdb_connection.R
@@ -27,7 +27,6 @@ test_that("dbplyr generic scalars translated correctly", {
   expect_equal(translate(iris[[1]]), sql(r"{"iris"[1]}"))
   expect_equal(translate(cot(x)), sql(r"{COT("x")}"))
   expect_equal(translate(substr("test", 2, 3)), sql(r"{SUBSTR('test', 2, 2)}"))
-  expect_equal(translate(is.na(var1)), sql(r"{("var1" IS NULL)}"))
 })
 
 test_that("duckdb custom scalars translated correctly", {
@@ -209,7 +208,6 @@ test_that("snapshots of dbplyr generic scalar translation", {
     translate(iris[[1]])
     translate(cot(x))
     translate(substr("test", 2, 3))
-    translate(is.na(var1))
   })
 })
 

--- a/tools/rpkg/tests/testthat/test_backend-dbplyr__duckdb_connection.R
+++ b/tools/rpkg/tests/testthat/test_backend-dbplyr__duckdb_connection.R
@@ -27,6 +27,7 @@ test_that("dbplyr generic scalars translated correctly", {
   expect_equal(translate(iris[[1]]), sql(r"{"iris"[1]}"))
   expect_equal(translate(cot(x)), sql(r"{COT("x")}"))
   expect_equal(translate(substr("test", 2, 3)), sql(r"{SUBSTR('test', 2, 2)}"))
+  expect_equal(translate(is.na(var1)), sql(r"{("var1" IS NULL)}"))
 })
 
 test_that("duckdb custom scalars translated correctly", {
@@ -52,7 +53,6 @@ test_that("duckdb custom scalars translated correctly", {
   expect_equal(translate(log(x, base = 2)), sql(r"{LOG2("x")}"))
   expect_equal(translate(log10(x)), sql(r"{LOG10("x")}"))
   expect_equal(translate(log2(x)), sql(r"{LOG2("x")}"))
-  expect_equal(translate(is.na(var1)), sql(r"{("var1" IS NULL OR PRINTF('%f', "var1") = 'nan')}"))
   expect_equal(translate(is.nan(var1)), sql(r"{("var1" IS NOT NULL AND PRINTF('%f', "var1") = 'nan')}"))
   expect_equal(translate(is.infinite(var1)), sql(r"{("var1" IS NOT NULL AND REGEXP_MATCHES(PRINTF('%f', "var1"), 'inf'))}"))
   expect_equal(translate(is.finite(var1)), sql(r"{(NOT ("var1" IS NULL OR REGEXP_MATCHES(PRINTF('%f', "var1"), 'inf|nan')))}"))
@@ -209,6 +209,7 @@ test_that("snapshots of dbplyr generic scalar translation", {
     translate(iris[[1]])
     translate(cot(x))
     translate(substr("test", 2, 3))
+    translate(is.na(var1))
   })
 })
 
@@ -237,7 +238,6 @@ test_that("snapshots of duckdb custom scalars translations", {
     translate(log(x, base = 2))
     translate(log10(x))
     translate(log2(x))
-    translate(is.na(var1))
     translate(is.nan(var1))
     translate(is.infinite(var1))
     translate(is.finite(var1))
@@ -384,10 +384,10 @@ test_that("these should give errors", {
 
   expect_snapshot(error = TRUE, {
     translate(grepl("dummy", txt, perl = TRUE)) # Expected error
-#    translate(paste0(x, collapse = ""), window = FALSE) # Skip because of changing rlang_error (sql_paste())
+    #    translate(paste0(x, collapse = ""), window = FALSE) # Skip because of changing rlang_error (sql_paste())
     translate(quarter(x, type = "other")) # Not supported - error
     translate(quarter(x, fiscal_start = 2)) # Not supported - error
-#    translate(str_c(x, collapse = "")) # Skip because of changing rlang_error (sql_paste())
+    #    translate(str_c(x, collapse = "")) # Skip because of changing rlang_error (sql_paste())
     translate(str_pad(x, width = 10, side = "other")) # Error
   })
 })


### PR DESCRIPTION
In dbplyr-backend `is.na()`-translation is not conditional on column type, so type-specific functions (such as `PRINTF('%f', "col")` that was used to check `NaN`) will throw an error if applied to column with incompatible type. This causes problems in real use cases and must be corrected.

This PR reverts the custom translation of `is.na()` to the default one that uses only `IS NULL`-function and works regardless of the type of the column.

Tests were also updated accordingly.

Styler was also run and it detected a need for some purely styling changes that were not incorporated in the merged version.
