### PR TITLE
Fixed empty list aggregates

### DIFF
--- a/test/sql/aggregate/aggregates/test_list_aggregate.test
+++ b/test/sql/aggregate/aggregates/test_list_aggregate.test
@@ -89,3 +89,24 @@ SELECT g, LIST(i ORDER BY i DESC NULLS LAST) FROM list_extract_test GROUP BY g;
 1	[2, 1]
 2	[3]
 3	[42, NULL]
+
+query II
+SELECT g, LIST(i ORDER BY i ASC) FILTER (WHERE i <> 3) FROM list_extract_test GROUP BY g;
+----
+1	[1, 2]
+2	NULL
+3	[42]
+
+query II
+SELECT g, LIST(i ORDER BY i ASC) FILTER (WHERE i IS NULL) FROM list_extract_test GROUP BY g;
+----
+1	NULL
+2	NULL
+3	[NULL]
+
+query II
+SELECT g, LIST(i ORDER BY i ASC) FILTER (WHERE i = 1337) FROM list_extract_test GROUP BY g;
+----
+1	NULL
+2	NULL
+3	NULL


### PR DESCRIPTION
I wasted a bunch of time because I was trying to generate empty lists rather than NULL, and only afterwards when another test case started failing I realised list aggregates must return `NULL` rather than the empty list when no results were found. Even trickier was that I trusted the original code which sets `mask.SetInvalid(i)`, which should have been `mask.SetInvalid(rid)` all along. Anyway... this should fix https://github.com/duckdb/duckdb/issues/3216.