### PR TITLE
Fix for #3200

### DIFF
--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -69,12 +69,30 @@ bool Pipeline::GetProgressInternal(ClientContext &context, PhysicalOperator *op,
 			current_percentage = get.function.table_scan_progress(context, get.bind_data.get());
 			return true;
 		}
-		//! If the table_scan_progress is not implemented it means we don't support this function yet in the progress
-		//! bar
+		// If the table_scan_progress is not implemented it means we don't support this function yet in the progress
+		// bar
 		return false;
 	}
-	default:
-		return false;
+		// If it is not a table scan we go down on all children until we reach the leaf operators
+	default: {
+		vector<idx_t> progress;
+		vector<idx_t> cardinality;
+		double total_cardinality = 0;
+		current_percentage = 0;
+		for (auto &op_child : op->children) {
+			double child_percentage = 0;
+			if (!GetProgressInternal(context, op_child.get(), child_percentage)) {
+				return false;
+			}
+			progress.push_back(child_percentage);
+			cardinality.push_back(op_child->estimated_cardinality);
+			total_cardinality += op_child->estimated_cardinality;
+		}
+		for (size_t i = 0; i < progress.size(); i++) {
+			current_percentage += progress[i] * cardinality[i] / total_cardinality;
+		}
+		return true;
+	}
 	}
 }
 // LCOV_EXCL_STOP


### PR DESCRIPTION
Iterate over other children in the pipeline root operator for progressive bars.
Fix #3200