### PR TITLE
Fix #3222: avoid int overflow in RleBpDecoder

### DIFF
--- a/extension/parquet/include/parquet_rle_bp_decoder.hpp
+++ b/extension/parquet/include/parquet_rle_bp_decoder.hpp
@@ -18,7 +18,7 @@ class RleBpDecoder {
 public:
 	/// Create a decoder object. buffer/buffer_len is the decoded data.
 	/// bit_width is the width of each value (before encoding).
-	RleBpDecoder(const uint8_t *buffer, uint32_t buffer_len, uint64_t bit_width)
+	RleBpDecoder(const uint8_t *buffer, uint32_t buffer_len, uint32_t bit_width)
 	    : buffer_((char *)buffer, buffer_len), bit_width_(bit_width), current_value_(0), repeat_count_(0),
 	      literal_count_(0) {
 		if (bit_width >= 64) {
@@ -77,7 +77,7 @@ private:
 	ByteBuffer buffer_;
 
 	/// Number of bits needed to encode the value. Must be between 0 and 64.
-	uint64_t bit_width_;
+	uint32_t bit_width_;
 	uint64_t current_value_;
 	uint32_t repeat_count_;
 	uint32_t literal_count_;

--- a/extension/parquet/include/parquet_rle_bp_decoder.hpp
+++ b/extension/parquet/include/parquet_rle_bp_decoder.hpp
@@ -18,14 +18,14 @@ class RleBpDecoder {
 public:
 	/// Create a decoder object. buffer/buffer_len is the decoded data.
 	/// bit_width is the width of each value (before encoding).
-	RleBpDecoder(const uint8_t *buffer, uint32_t buffer_len, uint32_t bit_width)
+	RleBpDecoder(const uint8_t *buffer, uint32_t buffer_len, uint64_t bit_width)
 	    : buffer_((char *)buffer, buffer_len), bit_width_(bit_width), current_value_(0), repeat_count_(0),
 	      literal_count_(0) {
 		if (bit_width >= 64) {
 			throw std::runtime_error("Decode bit width too large");
 		}
 		byte_encoded_len = ((bit_width_ + 7) / 8);
-		max_val = (1 << bit_width_) - 1;
+		max_val = (uint64_t(1) << bit_width_) - 1;
 	}
 
 	template <typename T>
@@ -77,12 +77,12 @@ private:
 	ByteBuffer buffer_;
 
 	/// Number of bits needed to encode the value. Must be between 0 and 64.
-	int bit_width_;
+	uint64_t bit_width_;
 	uint64_t current_value_;
 	uint32_t repeat_count_;
 	uint32_t literal_count_;
 	uint8_t byte_encoded_len;
-	uint32_t max_val;
+	uint64_t max_val;
 
 	uint8_t bitpack_pos = 0;
 

--- a/test/sql/copy/parquet/test_yellow_cab.test_slow
+++ b/test/sql/copy/parquet/test_yellow_cab.test_slow
@@ -1,0 +1,34 @@
+# name: test/sql/copy/parquet/test_yellow_cab.test_slow
+# description: Test yellow cab parquet file
+# group: [parquet]
+
+require parquet
+
+require httpfs
+
+statement ok
+CREATE TABLE yellow_cab AS SELECT * FROM 'https://github.com/cwida/duckdb-data/releases/download/v1.0/yellowcab.parquet'
+
+statement ok
+PRAGMA enable_verification
+
+query IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
+select min(VendorID::VARCHAR), max(VendorID::VARCHAR), min(tpep_pickup_datetime::VARCHAR), max(tpep_pickup_datetime::VARCHAR), min(tpep_dropoff_datetime::VARCHAR), max(tpep_dropoff_datetime::VARCHAR), min(passenger_count::VARCHAR), max(passenger_count::VARCHAR), min(trip_distance::VARCHAR), max(trip_distance::VARCHAR), min(pickup_longitude::VARCHAR), max(pickup_longitude::VARCHAR), min(pickup_latitude::VARCHAR), max(pickup_latitude::VARCHAR), min(RatecodeID::VARCHAR), max(RatecodeID::VARCHAR), min(store_and_fwd_flag::VARCHAR), max(store_and_fwd_flag::VARCHAR), min(dropoff_longitude::VARCHAR), max(dropoff_longitude::VARCHAR), min(dropoff_latitude::VARCHAR), max(dropoff_latitude::VARCHAR), min(payment_type::VARCHAR), max(payment_type::VARCHAR), min(fare_amount::VARCHAR), max(fare_amount::VARCHAR), min(extra::VARCHAR), max(extra::VARCHAR), min(mta_tax::VARCHAR), max(mta_tax::VARCHAR), min(tip_amount::VARCHAR), max(tip_amount::VARCHAR), min(tolls_amount::VARCHAR), max(tolls_amount::VARCHAR), min(improvement_surcharge::VARCHAR), max(improvement_surcharge::VARCHAR), min(total_amount::VARCHAR), max(total_amount::VARCHAR) from yellow_cab;
+----
+1	2	2016-01-01 00:00:00	2016-01-29 12:08:57	2016-01-01 00:00:00	2016-01-30 12:05:11	0	8	.00	97.40	-0.13990700244903564	0	0	57.269275665283203	1	99	(empty)	Y	-73.210006713867188	0	0	41.317001342773437	1	4	-10	998	-0.5	2.0	-0.5	0.5	0	998.14	-10.5	9.75	-0.3	0.3	-10.8	998.3
+
+
+# writer round-trip
+statement ok
+COPY yellow_cab TO '__TEST_DIR__/yellowcab.parquet' (FORMAT PARQUET);
+
+query IIIIIIIIIIIIIIIIIII nosort yellowcab
+SELECT * FROM yellow_cab
+----
+
+query IIIIIIIIIIIIIIIIIII nosort yellowcab
+SELECT * FROM '__TEST_DIR__/yellowcab.parquet'
+----
+
+
+


### PR DESCRIPTION
Fixes #3222

Avoid an edge case overflow that happens if bit_width=32, in which case `(1 << 32) - 1` overflows a `uint32_t`, because `(1 << 32)` does not fit into a `uint32_t`, which triggers undefined behavior. 