### PR TITLE
Parquet globbing: Better support for schema evolution

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -4,6 +4,7 @@
 #include "parquet_reader.hpp"
 
 #include "boolean_column_reader.hpp"
+#include "cast_column_reader.hpp"
 #include "callback_column_reader.hpp"
 #include "parquet_decimal_utils.hpp"
 #include "list_column_reader.hpp"
@@ -51,12 +52,28 @@ ColumnReader::ColumnReader(ParquetReader &reader, LogicalType type_p, const Sche
 ColumnReader::~ColumnReader() {
 }
 
-const LogicalType &ColumnReader::Type() {
+ParquetReader &ColumnReader::Reader() {
+	return reader;
+}
+
+const LogicalType &ColumnReader::Type() const {
 	return type;
 }
 
-const SchemaElement &ColumnReader::Schema() {
+const SchemaElement &ColumnReader::Schema() const {
 	return schema;
+}
+
+idx_t ColumnReader::FileIdx() const {
+	return file_idx;
+}
+
+idx_t ColumnReader::MaxDefine() const {
+	return max_define;
+}
+
+idx_t ColumnReader::MaxRepeat() const {
+	return max_repeat;
 }
 
 idx_t ColumnReader::GroupRowsAvailable() {
@@ -117,9 +134,6 @@ void ColumnReader::PrepareRead(parquet_filter_t &filter) {
 
 	PageHeader page_hdr;
 	page_hdr.read(protocol);
-
-	//		page_hdr.printTo(std::cout);
-	//		std::cout << '\n';
 
 	switch (page_hdr.type) {
 	case PageType::DATA_PAGE_V2:
@@ -618,6 +632,55 @@ ListColumnReader::ListColumnReader(ParquetReader &reader, LogicalType type_p, co
 	child_repeats_ptr = (uint8_t *)child_repeats.ptr;
 
 	child_filter.set();
+}
+
+//===--------------------------------------------------------------------===//
+// Cast Column Reader
+//===--------------------------------------------------------------------===//
+CastColumnReader::CastColumnReader(unique_ptr<ColumnReader> child_reader_p, LogicalType target_type_p)
+    : ColumnReader(child_reader_p->Reader(), move(target_type_p), child_reader_p->Schema(), child_reader_p->FileIdx(),
+                   child_reader_p->MaxDefine(), child_reader_p->MaxRepeat()),
+      child_reader(move(child_reader_p)) {
+	vector<LogicalType> intermediate_types {child_reader->Type()};
+	intermediate_chunk.Initialize(intermediate_types);
+}
+
+unique_ptr<BaseStatistics> CastColumnReader::Stats(const std::vector<ColumnChunk> &columns) {
+	// casting stats is not supported (yet)
+	return nullptr;
+}
+
+void CastColumnReader::InitializeRead(const std::vector<ColumnChunk> &columns, TProtocol &protocol_p) {
+	child_reader->InitializeRead(columns, protocol_p);
+}
+
+idx_t CastColumnReader::Read(uint64_t num_values, parquet_filter_t &filter, uint8_t *define_out, uint8_t *repeat_out,
+                             Vector &result) {
+	intermediate_chunk.Reset();
+	auto &intermediate_vector = intermediate_chunk.data[0];
+
+	auto amount = child_reader->Read(num_values, filter, define_out, repeat_out, intermediate_vector);
+	if (!filter.all()) {
+		// work-around for filters: set all values that are filtered to NULL to prevent the cast from failing on
+		// uninitialized data
+		intermediate_vector.Normalify(amount);
+		auto &validity = FlatVector::Validity(intermediate_vector);
+		for (idx_t i = 0; i < amount; i++) {
+			if (!filter[i]) {
+				validity.SetInvalid(i);
+			}
+		}
+	}
+	VectorOperations::Cast(intermediate_vector, result, amount);
+	return amount;
+}
+
+void CastColumnReader::Skip(idx_t num_values) {
+	child_reader->Skip(num_values);
+}
+
+idx_t CastColumnReader::GroupRowsAvailable() {
+	return child_reader->GroupRowsAvailable();
 }
 
 //===--------------------------------------------------------------------===//

--- a/extension/parquet/include/cast_column_reader.hpp
+++ b/extension/parquet/include/cast_column_reader.hpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// cast_column_reader.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "column_reader.hpp"
+#include "templated_column_reader.hpp"
+
+namespace duckdb {
+
+//! A column reader that represents a cast over a child reader
+class CastColumnReader : public ColumnReader {
+public:
+	CastColumnReader(unique_ptr<ColumnReader> child_reader, LogicalType target_type);
+
+	unique_ptr<ColumnReader> child_reader;
+	DataChunk intermediate_chunk;
+
+public:
+	unique_ptr<BaseStatistics> Stats(const std::vector<ColumnChunk> &columns) override;
+	void InitializeRead(const std::vector<ColumnChunk> &columns, TProtocol &protocol_p) override;
+
+	idx_t Read(uint64_t num_values, parquet_filter_t &filter, uint8_t *define_out, uint8_t *repeat_out,
+	           Vector &result) override;
+
+	void Skip(idx_t num_values) override;
+	idx_t GroupRowsAvailable() override;
+};
+
+} // namespace duckdb

--- a/extension/parquet/include/column_reader.hpp
+++ b/extension/parquet/include/column_reader.hpp
@@ -56,12 +56,16 @@ public:
 
 	virtual void Skip(idx_t num_values);
 
-	const LogicalType &Type();
-	const SchemaElement &Schema();
+	ParquetReader &Reader();
+	const LogicalType &Type() const;
+	const SchemaElement &Schema() const;
+	idx_t FileIdx() const;
+	idx_t MaxDefine() const;
+	idx_t MaxRepeat() const;
 
 	virtual idx_t GroupRowsAvailable();
 
-	unique_ptr<BaseStatistics> Stats(const std::vector<ColumnChunk> &columns);
+	virtual unique_ptr<BaseStatistics> Stats(const std::vector<ColumnChunk> &columns);
 
 protected:
 	// readers that use the default Read() need to implement those

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -4,6 +4,7 @@
 #include "column_reader.hpp"
 
 #include "boolean_column_reader.hpp"
+#include "cast_column_reader.hpp"
 #include "callback_column_reader.hpp"
 #include "list_column_reader.hpp"
 #include "string_column_reader.hpp"
@@ -24,6 +25,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/date.hpp"
 #include "duckdb/common/pair.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
 
 #include "duckdb/storage/object_cache.hpp"
 #endif
@@ -340,10 +342,23 @@ unique_ptr<ColumnReader> ParquetReader::CreateReader(const duckdb_parquet::forma
 	auto ret = CreateReaderRecursive(file_meta_data, 0, 0, 0, next_schema_idx, next_file_idx);
 	D_ASSERT(next_schema_idx == file_meta_data->schema.size() - 1);
 	D_ASSERT(file_meta_data->row_groups.empty() || next_file_idx == file_meta_data->row_groups[0].columns.size());
+
+	// add casts if required
+	for (auto &entry : cast_map) {
+		auto column_idx = entry.first;
+		auto &expected_type = entry.second;
+
+		auto &root_struct_reader = (StructColumnReader &)*ret;
+		auto child_reader = move(root_struct_reader.child_readers[column_idx]);
+		auto cast_reader = make_unique<CastColumnReader>(move(child_reader), expected_type);
+		root_struct_reader.child_readers[column_idx] = move(cast_reader);
+	}
 	return ret;
 }
 
-void ParquetReader::InitializeSchema(const vector<LogicalType> &expected_types_p, const string &initial_filename_p) {
+void ParquetReader::InitializeSchema(const vector<string> &expected_names, const vector<LogicalType> &expected_types,
+                                     const vector<column_t> &column_ids, const string &initial_filename_p) {
+	D_ASSERT(expected_names.size() == expected_types.size() || (expected_names.empty() && column_ids.empty()));
 	auto file_meta_data = GetFileMetadata();
 
 	if (file_meta_data->__isset.encryption_algorithm) {
@@ -354,36 +369,65 @@ void ParquetReader::InitializeSchema(const vector<LogicalType> &expected_types_p
 		throw FormatException("Need at least one non-root column in the file");
 	}
 
-	bool has_expected_types = !expected_types_p.empty();
+	bool has_expected_names = !expected_names.empty();
+	bool has_expected_types = !expected_types.empty();
 	auto root_reader = CreateReader(file_meta_data);
 
 	auto &root_type = root_reader->Type();
 	auto &child_types = StructType::GetChildTypes(root_type);
 	D_ASSERT(root_type.id() == LogicalTypeId::STRUCT);
-	if (has_expected_types && child_types.size() != expected_types_p.size()) {
-		throw FormatException("column count mismatch");
-	}
-	idx_t col_idx = 0;
 	for (auto &type_pair : child_types) {
-		if (has_expected_types && expected_types_p[col_idx] != type_pair.second) {
-			if (initial_filename_p.empty()) {
-				throw FormatException("column \"%d\" in parquet file is of type %s, could not auto cast to "
-				                      "expected type %s for this column",
-				                      col_idx, type_pair.second, expected_types_p[col_idx].ToString());
-			} else {
-				throw FormatException("schema mismatch in Parquet glob: column \"%d\" in parquet file is of type "
-				                      "%s, but in the original file \"%s\" this column is of type \"%s\"",
-				                      col_idx, type_pair.second, initial_filename_p,
-				                      expected_types_p[col_idx].ToString());
-			}
-		} else {
-			names.push_back(type_pair.first);
-			return_types.push_back(type_pair.second);
-		}
-		col_idx++;
+		names.push_back(type_pair.first);
+		return_types.push_back(type_pair.second);
 	}
 	D_ASSERT(!names.empty());
 	D_ASSERT(!return_types.empty());
+	if (!has_expected_types) {
+		return;
+	}
+	if (!has_expected_names && has_expected_types) {
+		// we ONLY have expected types, but no expected names
+		// in this case we need all types to match in-order
+		if (return_types.size() != expected_types.size()) {
+			throw FormatException("column count mismatch: expected %d columns but found %d", expected_types.size(),
+			                      return_types.size());
+		}
+		for (idx_t col_idx = 0; col_idx < return_types.size(); col_idx++) {
+			if (return_types[col_idx] == expected_types[col_idx]) {
+				continue;
+			}
+			// type mismatch: have to add a cast
+			cast_map[col_idx] = expected_types[col_idx];
+		}
+		return;
+	}
+	D_ASSERT(column_ids.size() > 0);
+	// we have expected types: create a map of name -> column index
+	unordered_map<string, idx_t> name_map;
+	for (idx_t col_idx = 0; col_idx < names.size(); col_idx++) {
+		name_map[names[col_idx]] = col_idx;
+	}
+	// now for each of the expected names, look it up in the name map and fill the column_id_map
+	D_ASSERT(column_id_map.empty());
+	for (idx_t i = 0; i < column_ids.size(); i++) {
+		if (column_ids[i] == COLUMN_IDENTIFIER_ROW_ID) {
+			continue;
+		}
+		auto &expected_name = expected_names[column_ids[i]];
+		auto &expected_type = expected_types[column_ids[i]];
+		auto entry = name_map.find(expected_name);
+		if (entry == name_map.end()) {
+			throw FormatException("schema mismatch in Parquet glob: column \"%s\" was read from the original file "
+			                      "\"%s\", but could not be found in file \"%s\"",
+			                      expected_name, initial_filename_p, file_name);
+		}
+		auto column_idx = entry->second;
+		column_id_map.push_back(column_idx);
+		if (expected_type != return_types[column_idx]) {
+			// type mismatch: have to add a cast
+			cast_map[column_idx] = expected_type;
+		}
+	}
 }
 
 ParquetOptions::ParquetOptions(ClientContext &context) {
@@ -399,10 +443,13 @@ ParquetReader::ParquetReader(Allocator &allocator_p, unique_ptr<FileHandle> file
 	file_name = file_handle_p->path;
 	file_handle = move(file_handle_p);
 	metadata = LoadMetadata(allocator, *file_handle);
-	InitializeSchema(expected_types_p, initial_filename_p);
+	vector<string> expected_names;
+	vector<column_t> expected_column_ids;
+	InitializeSchema(expected_names, expected_types_p, expected_column_ids, initial_filename_p);
 }
 
-ParquetReader::ParquetReader(ClientContext &context_p, string file_name_p, const vector<LogicalType> &expected_types_p,
+ParquetReader::ParquetReader(ClientContext &context_p, string file_name_p, const vector<string> &expected_names,
+                             const vector<LogicalType> &expected_types_p, const vector<column_t> &column_ids,
                              ParquetOptions parquet_options_p, const string &initial_filename_p)
     : allocator(Allocator::Get(context_p)), file_opener(FileSystem::GetFileOpener(context_p)),
       parquet_options(parquet_options_p) {
@@ -428,7 +475,7 @@ ParquetReader::ParquetReader(ClientContext &context_p, string file_name_p, const
 			ObjectCache::GetObjectCache(context_p).Put(file_name, metadata);
 		}
 	}
-	InitializeSchema(expected_types_p, initial_filename_p);
+	InitializeSchema(expected_names, expected_types_p, column_ids, initial_filename_p);
 }
 
 ParquetReader::~ParquetReader() {
@@ -487,9 +534,9 @@ void ParquetReader::PrepareRowGroupBuffer(ParquetReaderScanState &state, idx_t o
 				skip_chunk = true;
 			}
 			if (skip_chunk) {
+				// this effectively will skip this chunk
 				state.group_offset = group.num_rows;
 				return;
-				// this effectively will skip this chunk
 			}
 		}
 	}
@@ -509,7 +556,7 @@ void ParquetReader::InitializeScan(ParquetReaderScanState &state, vector<column_
                                    vector<idx_t> groups_to_read, TableFilterSet *filters) {
 	state.current_group = -1;
 	state.finished = false;
-	state.column_ids = move(column_ids);
+	state.column_ids = column_id_map.empty() ? move(column_ids) : column_id_map;
 	state.group_offset = 0;
 	state.group_idx_list = move(groups_to_read);
 	state.filters = filters;

--- a/test/sql/copy/parquet/parquet_schema_evolution.test
+++ b/test/sql/copy/parquet/parquet_schema_evolution.test
@@ -68,7 +68,7 @@ SELECT a FROM '__TEST_DIR__/evolution_*.parquet' ORDER BY 1
 
 # reading either b results in an error, however, since we can't cast from 'hello' to integer
 statement error
-SELECT b FROM '__TEST_DIR__/evolution_*.parquet' ORDER BY 1
+SELECT b FROM parquet_scan(['__TEST_DIR__/evolution_1.parquet', '__TEST_DIR__/evolution_2.parquet']) ORDER BY 1
 
 # if we flip the order of the reads we can read b
 query I
@@ -92,7 +92,7 @@ SELECT a FROM '__TEST_DIR__/evolution_*.parquet' ORDER BY 1
 
 # reading either b results in an error, however, since we can't cast from 'hello' to integer
 statement error
-SELECT b FROM '__TEST_DIR__/evolution_*.parquet' ORDER BY 1
+SELECT b FROM parquet_scan(['__TEST_DIR__/evolution_1.parquet', '__TEST_DIR__/evolution_2.parquet']) ORDER BY 1
 
 # if we flip the order of the reads we can read b
 query I

--- a/test/sql/copy/parquet/parquet_schema_evolution.test
+++ b/test/sql/copy/parquet/parquet_schema_evolution.test
@@ -1,0 +1,140 @@
+# name: test/sql/copy/parquet/parquet_schema_evolution.test
+# description: Test parquet schema evolution
+# group: [parquet]
+
+require parquet
+
+statement ok
+PRAGMA enable_verification
+
+# we run this twice, once with multi threading and once without
+loop i 0 2
+
+# test column names in different orders
+statement ok
+COPY (SELECT 42::INT a, 43::INT c) TO '__TEST_DIR__/evolution_1.parquet' (FORMAT PARQUET);
+
+statement ok
+COPY (SELECT 88::INT b, 84::INT a) TO '__TEST_DIR__/evolution_2.parquet' (FORMAT PARQUET);
+
+query I
+SELECT a FROM '__TEST_DIR__/evolution_*.parquet' ORDER BY a
+----
+42
+84
+
+query I
+SELECT a FROM parquet_scan(['__TEST_DIR__/evolution_2.parquet', '__TEST_DIR__/evolution_1.parquet', '__TEST_DIR__/evolution_*.parquet']) ORDER BY a
+----
+42
+42
+84
+84
+
+# reading either b or c results in an error, since the name is not present in both files
+statement error
+SELECT b FROM '__TEST_DIR__/evolution_*.parquet' ORDER BY 1
+
+statement error
+SELECT c FROM '__TEST_DIR__/evolution_*.parquet' ORDER BY 1
+
+# we can also do this with COPY
+statement ok
+CREATE TABLE copy_test(a INT, b INT);
+
+# if we copy from both files, we run into a schema mismatch in the files themselves (name differences)
+statement error
+COPY copy_test FROM '__TEST_DIR__/evolution_*.parquet'
+
+# copying from one file works, however
+statement ok
+COPY copy_test FROM '__TEST_DIR__/evolution_1.parquet'
+
+statement ok
+DROP TABLE copy_test
+
+# test type promotion
+statement ok
+COPY (SELECT 42::INT a, 43::INT b) TO '__TEST_DIR__/evolution_1.parquet' (FORMAT PARQUET);
+
+statement ok
+COPY (SELECT 'hello'::VARCHAR b, 84::TINYINT a) TO '__TEST_DIR__/evolution_2.parquet' (FORMAT PARQUET);
+
+query I
+SELECT a FROM '__TEST_DIR__/evolution_*.parquet' ORDER BY 1
+----
+42
+84
+
+# reading either b results in an error, however, since we can't cast from 'hello' to integer
+statement error
+SELECT b FROM '__TEST_DIR__/evolution_*.parquet' ORDER BY 1
+
+# if we flip the order of the reads we can read b
+query I
+SELECT b FROM parquet_scan(['__TEST_DIR__/evolution_2.parquet', '__TEST_DIR__/evolution_1.parquet']) ORDER BY 1
+----
+43
+hello
+
+# type promotion, but with lists
+statement ok
+COPY (SELECT [42::INT] a, [43::INT] b) TO '__TEST_DIR__/evolution_1.parquet' (FORMAT PARQUET);
+
+statement ok
+COPY (SELECT ['hello'::VARCHAR] b, [84::TINYINT] a) TO '__TEST_DIR__/evolution_2.parquet' (FORMAT PARQUET);
+
+query I
+SELECT a FROM '__TEST_DIR__/evolution_*.parquet' ORDER BY 1
+----
+[42]
+[84]
+
+# reading either b results in an error, however, since we can't cast from 'hello' to integer
+statement error
+SELECT b FROM '__TEST_DIR__/evolution_*.parquet' ORDER BY 1
+
+# if we flip the order of the reads we can read b
+query I
+SELECT b FROM parquet_scan(['__TEST_DIR__/evolution_2.parquet', '__TEST_DIR__/evolution_1.parquet']) ORDER BY 1
+----
+[43]
+[hello]
+
+# type promotion & skipping
+statement ok
+COPY (SELECT range id, 1::INT a FROM range(10000) UNION ALL SELECT 10000+range id, 2::INT FROM range(10000)) TO '__TEST_DIR__/evolution_1.parquet' (FORMAT PARQUET);
+
+statement ok
+COPY (SELECT (20000+range)::BIGINT id, 'hello'::VARCHAR b, 3::BIGINT a FROM range(10000) UNION ALL SELECT (30000+range)::BIGINT id, 'world'::VARCHAR, 4 FROM range(10000)) TO '__TEST_DIR__/evolution_2.parquet' (FORMAT PARQUET);
+
+query I
+SELECT COUNT(*) FROM '__TEST_DIR__/evolution_*.parquet' WHERE a=2
+----
+10000
+
+query I
+SELECT COUNT(*) FROM '__TEST_DIR__/evolution_*.parquet' WHERE a>=2
+----
+30000
+
+query II
+SELECT id, a FROM '__TEST_DIR__/evolution_*.parquet' WHERE id=2
+----
+2	1
+
+query II
+SELECT id, a FROM '__TEST_DIR__/evolution_*.parquet' WHERE id=27777
+----
+27777	3
+
+query II
+SELECT id, a FROM '__TEST_DIR__/evolution_*.parquet' WHERE id>=39998 ORDER BY id
+----
+39998	4
+39999	4
+
+statement ok
+PRAGMA threads=1
+
+endloop

--- a/test/sql/copy/parquet/tpch_parquet_copy_cast.test_slow
+++ b/test/sql/copy/parquet/tpch_parquet_copy_cast.test_slow
@@ -1,0 +1,50 @@
+# name: test/sql/copy/parquet/tpch_parquet_copy_cast.test_slow
+# description: Test auto-casting to table types in COPY from parquet file
+# group: [parquet]
+
+require parquet
+
+require tpch
+
+statement ok
+CREATE SCHEMA tpch
+
+statement ok
+CALL dbgen(sf=0.01, schema='tpch');
+
+statement ok
+COPY (
+	SELECT
+		l_orderkey::UBIGINT l_orderkey,
+		l_partkey::BIGINT l_partkey,
+		l_suppkey::SMALLINT l_suppkey,
+		l_linenumber::UINTEGER,
+		l_quantity::SMALLINT l_quantity,
+		l_extendedprice::DECIMAL(18,4) l_extendedprice,
+		l_discount::DECIMAL(8,3) l_discount,
+		l_tax::DECIMAL(38,4) l_tax,
+		l_returnflag,
+		l_linestatus,
+		l_shipdate::TIMESTAMP l_shipdate,
+		l_commitdate::TIMESTAMP l_commitdate,
+		l_receiptdate::VARCHAR l_receiptdate,
+		l_shipinstruct,
+		l_shipmode,
+		l_comment FROM tpch.lineitem
+) TO '__TEST_DIR__/lineitem_different_types.parquet' (FORMAT PARQUET);
+
+statement ok
+CREATE TABLE lineitem AS SELECT * FROM tpch.lineitem LIMIT 0;
+
+statement ok
+COPY lineitem FROM '__TEST_DIR__/lineitem_different_types.parquet'
+
+query I
+PRAGMA tpch(1)
+----
+<FILE>:extension/tpch/dbgen/answers/sf0.01/q01.csv
+
+query I
+PRAGMA tpch(6)
+----
+<FILE>:extension/tpch/dbgen/answers/sf0.01/q06.csv

--- a/test/sql/copy/parquet/tpch_parquet_schema_evolution.test_slow
+++ b/test/sql/copy/parquet/tpch_parquet_schema_evolution.test_slow
@@ -1,0 +1,66 @@
+# name: test/sql/copy/parquet/tpch_parquet_schema_evolution.test_slow
+# description: Test more complex type evolution on TPC-H schema
+# group: [parquet]
+
+require parquet
+
+require tpch
+
+statement ok
+CREATE SCHEMA tpch
+
+statement ok
+CALL dbgen(sf=0.01, schema='tpch');
+
+# original schema, minus some unnecessary columns
+statement ok
+COPY (
+	SELECT
+	l_shipdate,
+	l_discount,
+	l_linenumber,
+	l_tax,
+	l_extendedprice,
+	l_shipinstruct,
+	l_commitdate,
+	l_linestatus,
+	l_returnflag,
+	l_quantity,
+	l_orderkey,
+	l_shipmode FROM tpch.lineitem LIMIT 30000
+) TO '__TEST_DIR__/schema_evolution_lineitem1.parquet' (FORMAT PARQUET);
+
+# complete schema, with casts
+statement ok
+COPY (
+	SELECT
+	l_comment,
+	l_shipmode,
+	l_commitdate::TIMESTAMP l_commitdate,
+	l_shipinstruct,
+	l_quantity::SMALLINT l_quantity,
+	l_suppkey::BIGINT l_suppkey,
+	l_linenumber,
+	l_linestatus,
+	l_receiptdate::VARCHAR l_receiptdate,
+	l_returnflag,
+	l_extendedprice::DECIMAL(18,4) l_extendedprice,
+	l_partkey::BIGINT l_partkey,
+	l_orderkey::HUGEINT l_orderkey,
+	l_discount::DECIMAL(8,3) l_discount,
+	l_shipdate::TIMESTAMP l_shipdate,
+	l_tax FROM tpch.lineitem OFFSET 30000
+) TO '__TEST_DIR__/schema_evolution_lineitem2.parquet' (FORMAT PARQUET);
+
+statement ok
+CREATE VIEW lineitem AS SELECT * FROM '__TEST_DIR__/schema_evolution_lineitem*.parquet'
+
+query I
+PRAGMA tpch(1)
+----
+<FILE>:extension/tpch/dbgen/answers/sf0.01/q01.csv
+
+query I
+PRAGMA tpch(6)
+----
+<FILE>:extension/tpch/dbgen/answers/sf0.01/q06.csv


### PR DESCRIPTION
Fixes #3089, #2877 and #3203

This PR adds support for schema evolution when reading multiple Parquet files, usually done using a globbing pattern. To be precise, the following two restrictions are lifted:

* Parquet files no longer need to have an exactly matching schema. Instead, only the columns that are actually *used* by the query are checked. So for example, if we have a query in the form of `SELECT id FROM '*.parquet'`, the system will only check that the `id` column is contained within each of the Parquet files. This also supports re-ordering within the file, so that if the `id` column is the first column in the first file, and the second column in the second file, this will be handled correctly.
* The types of the individual columns no longer need to match exactly. Instead, when there is a type divergence, a cast is added. The type for each column is based on the first Parquet file encountered. So if the first file has a type `INTEGER` for the column `id`, all the other Parquet files will use the `INTEGER` type for this column (and add casts where required).