### PR TITLE
Improving CI performance

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -6,9 +6,9 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
-      - 'tools/nodejs'
-      - 'tools/pythonpkg'
-      - 'tools/rpkg'
+      - 'tools/nodejs/**'
+      - 'tools/pythonpkg/**'
+      - 'tools/rpkg/**'
       - '.github/workflows/NodeJS.yml'
       - '.github/workflows/Python.yml'
       - '.github/workflows/R.yml'

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -1,5 +1,17 @@
 name: LinuxRelease
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'tools/nodejs'
+      - 'tools/pythonpkg'
+      - 'tools/rpkg'
+      - '.github/workflows/NodeJS.yml'
+      - '.github/workflows/Python.yml'
+      - '.github/workflows/R.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1,5 +1,17 @@
 name: Main
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'tools/nodejs'
+      - 'tools/pythonpkg'
+      - 'tools/rpkg'
+      - '.github/workflows/NodeJS.yml'
+      - '.github/workflows/Python.yml'
+      - '.github/workflows/R.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -6,9 +6,9 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
-      - 'tools/nodejs'
-      - 'tools/pythonpkg'
-      - 'tools/rpkg'
+      - 'tools/nodejs/**'
+      - 'tools/pythonpkg/**'
+      - 'tools/rpkg/**'
       - '.github/workflows/NodeJS.yml'
       - '.github/workflows/Python.yml'
       - '.github/workflows/R.yml'

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -112,7 +112,7 @@ jobs:
    win-nodejs:
      name: node.js Windows
      runs-on: windows-latest
-#     needs: linux-nodejs
+     needs: linux-nodejs
 
      strategy:
        matrix:

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -73,6 +73,7 @@ jobs:
       run: ./scripts/node_build.sh 17
 
    osx-nodejs:
+      if: github.ref == 'refs/heads/master'
       name: node.js OSX
       runs-on: macos-latest
       needs: linux-nodejs

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -58,12 +58,15 @@ jobs:
       run: ./scripts/node_build.sh 10
 
     - name: Node 12
+      if: github.ref == 'refs/heads/master'
       run: ./scripts/node_build.sh 12
 
     - name: Node 14
+      if: github.ref == 'refs/heads/master'
       run: ./scripts/node_build.sh 14
 
     - name: Node 15
+      if: github.ref == 'refs/heads/master'
       run: ./scripts/node_build.sh 15
 
     - name: Node 17
@@ -92,12 +95,15 @@ jobs:
         run: ./scripts/node_build.sh 10
 
       - name: Node 12
+        if: github.ref == 'refs/heads/master'
         run: ./scripts/node_build.sh 12
 
       - name: Node 14
+        if: github.ref == 'refs/heads/master'
         run: ./scripts/node_build.sh 14
 
       - name: Node 15
+        if: github.ref == 'refs/heads/master'
         run: ./scripts/node_build.sh 15
 
       - name: Node 17

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -1,5 +1,15 @@
 name: NodeJS
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'tools/pythonpkg'
+      - 'tools/rpkg'
+      - '.github/workflows/Python.yml'
+      - '.github/workflows/R.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -6,8 +6,8 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
-      - 'tools/pythonpkg'
-      - 'tools/rpkg'
+      - 'tools/pythonpkg/**'
+      - 'tools/rpkg/**'
       - '.github/workflows/Python.yml'
       - '.github/workflows/R.yml'
 

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -112,11 +112,18 @@ jobs:
    win-nodejs:
      name: node.js Windows
      runs-on: windows-latest
-     needs: linux-nodejs
+#     needs: linux-nodejs
 
      strategy:
        matrix:
          node: [ '10', '12', '14', '15' ]
+         isMaster:
+            - ${{ github.ref == 'refs/heads/master' }}
+         exclude:
+           - isMaster: false
+             node: 12
+           - isMaster: false
+             node: 14
 
      steps:
        - uses: actions/setup-python@v2

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -1,5 +1,17 @@
 name: OSX
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'tools/nodejs'
+      - 'tools/pythonpkg'
+      - 'tools/rpkg'
+      - '.github/workflows/NodeJS.yml'
+      - '.github/workflows/Python.yml'
+      - '.github/workflows/R.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -4,14 +4,8 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'tools/nodejs'
-      - 'tools/pythonpkg'
-      - 'tools/rpkg'
-      - '.github/workflows/NodeJS.yml'
-      - '.github/workflows/Python.yml'
-      - '.github/workflows/R.yml'
+    branches-ignore:
+      - '**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -76,7 +76,7 @@ jobs:
             python_build: 'cp38-*'
           - isMaster: false
             python_build: 'cp39-*'
-#    needs: linux-python3-9
+    needs: linux-python3-9
     env:
       CIBW_BUILD: ${{ matrix.python_build}}
       CIBW_BEFORE_BUILD: 'pip install --prefer-binary "pandas>=0.24" "pytest>=4.3"'
@@ -141,7 +141,7 @@ jobs:
             python_build: 'cp38-*'
           - isMaster: false
             python_build: 'cp39-*'
-#      needs: linux-python3-9
+      needs: linux-python3-9
       env:
         CIBW_BUILD: ${{ matrix.python_build}}
         CIBW_BEFORE_BUILD: 'pip install --prefer-binary "pandas>=0.24" "pytest>=4.3"'
@@ -193,7 +193,7 @@ jobs:
             python_build: 'cp38-*'
           - isMaster: false
             python_build: 'cp39-*'
-#      needs: linux-python3-9
+      needs: linux-python3-9
 
       env:
         CIBW_BUILD: ${{ matrix.python_build}}

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -127,6 +127,7 @@ jobs:
         fi
 
    osx-python3:
+      if: github.ref == 'refs/heads/master'
       name: Python 3 OSX
       runs-on: macos-latest
       strategy:

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -68,8 +68,15 @@ jobs:
     strategy:
       matrix:
         arch: [auto, aarch64]
-        python_build: [cp37-*, cp38-*,cp39-*,cp310-*]
-    needs: linux-python3-9
+        python_build: [cp37-*, cp38-*, cp39-*,cp310-*]
+        isMaster:
+          - ${{ github.ref == 'refs/heads/master' }}
+        exclude:
+          - isMaster: false
+            python_build: 'cp38-*'
+          - isMaster: false
+            python_build: 'cp39-*'
+#    needs: linux-python3-9
     env:
       CIBW_BUILD: ${{ matrix.python_build}}
       CIBW_BEFORE_BUILD: 'pip install --prefer-binary "pandas>=0.24" "pytest>=4.3"'
@@ -125,7 +132,16 @@ jobs:
       strategy:
        matrix:
         python_build: [cp36-*, cp37-*, cp38-*, cp39-*, cp310-*]
-      needs: linux-python3-9
+        isMaster:
+          - ${{ github.ref == 'refs/heads/master' }}
+        exclude:
+          - isMaster: false
+            python_build: 'cp37-*'
+          - isMaster: false
+            python_build: 'cp38-*'
+          - isMaster: false
+            python_build: 'cp39-*'
+#      needs: linux-python3-9
       env:
         CIBW_BUILD: ${{ matrix.python_build}}
         CIBW_BEFORE_BUILD: 'pip install --prefer-binary "pandas>=0.24" "pytest>=4.3"'
@@ -168,7 +184,16 @@ jobs:
       strategy:
        matrix:
         python_build: [cp36-*, cp37-*, cp38-*, cp39-*, cp310-*]
-      needs: linux-python3-9
+        isMaster:
+          - ${{ github.ref == 'refs/heads/master' }}
+        exclude:
+          - isMaster: false
+            python_build: 'cp37-*'
+          - isMaster: false
+            python_build: 'cp38-*'
+          - isMaster: false
+            python_build: 'cp39-*'
+#      needs: linux-python3-9
 
       env:
         CIBW_BUILD: ${{ matrix.python_build}}

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -6,8 +6,8 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
-      - 'tools/nodejs'
-      - 'tools/rpkg'
+      - 'tools/nodejs/**'
+      - 'tools/rpkg/**'
       - '.github/workflows/NodeJS.yml'
       - '.github/workflows/R.yml'
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -1,5 +1,15 @@
 name: Python
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'tools/nodejs'
+      - 'tools/rpkg'
+      - '.github/workflows/NodeJS.yml'
+      - '.github/workflows/R.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -6,8 +6,8 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
-      - 'tools/nodejs'
-      - 'tools/pythonpkg'
+      - 'tools/nodejs/**'
+      - 'tools/pythonpkg/**'
       - '.github/workflows/NodeJS.yml'
       - '.github/workflows/Python.yml'
 

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -1,5 +1,15 @@
 name: R
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'tools/nodejs'
+      - 'tools/pythonpkg'
+      - '.github/workflows/NodeJS.yml'
+      - '.github/workflows/Python.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -1,5 +1,16 @@
 name: Regression
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'tools/nodejs/**'
+      - 'tools/rpkg/**'
+      - '.github/workflows/NodeJS.yml'
+      - '.github/workflows/Python.yml'
+      - '.github/workflows/R.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -6,9 +6,9 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
-      - 'tools/nodejs'
-      - 'tools/pythonpkg'
-      - 'tools/rpkg'
+      - 'tools/nodejs/**'
+      - 'tools/pythonpkg/**'
+      - 'tools/rpkg/**'
       - '.github/workflows/NodeJS.yml'
       - '.github/workflows/Python.yml'
       - '.github/workflows/R.yml'

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -1,5 +1,17 @@
 name: Windows
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'tools/nodejs'
+      - 'tools/pythonpkg'
+      - 'tools/rpkg'
+      - '.github/workflows/NodeJS.yml'
+      - '.github/workflows/Python.yml'
+      - '.github/workflows/R.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}


### PR DESCRIPTION
This pr contains a few changes to the CI that should bring a decent reduction in overal CI runner load.

1.  For Node and Python, we only run the latest and oldest versions if the branch != master
2. When a PR only touches files for node/python/R or their respective yml files, we only run the CI thats actually relevant.
3.  OSX CI is never run for PRs, only after merging on the push event of master. Reasoning behind this is that if a test passes linux CI it will almost certainly also pass OSX ci and the OSX runners tend to be a bottleneck.

**Potential further improvements**
I could move tools/odbc and tools/jdbc into separate yml files and add similar optimization to only run the relevant ci for those directories. I could also add this to this PR?

For more drastic changes in CI runner load we could consider running the CI only on a specific subset pull_request events. For example we could only run the CI on the pull_request.opened and and pull_request.review_requested events (see [github docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request)), which would mean that CI will run automatically on the initial pr open, but for the ci to be rerun when the author has made changes, the author has to explicitly request a review, which will then trigger the CI. However, whether this is a development workflow we want is up for discussion. I'd say it makes sense to wait out this pr and see if CI queue/run times improve enough to leave it as is.