### PR TITLE
Adding check_same_thread option to py connector

### DIFF
--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -81,7 +81,8 @@ PYBIND11_MODULE(DUCKDB_PYTHON_LIB_NAME, m) {
 	m.def("connect", &DuckDBPyConnection::Connect,
 	      "Create a DuckDB database instance. Can take a database file name to read/write persistent data and a "
 	      "read_only flag if no changes are desired",
-	      py::arg("database") = ":memory:", py::arg("read_only") = false, py::arg("config") = py::dict());
+	      py::arg("database") = ":memory:", py::arg("read_only") = false, py::arg("config") = py::dict(),
+	      py::arg("check_same_thread") = true);
 	m.def("tokenize", PyTokenize,
 	      "Tokenizes a SQL string, returning a list of (position, type) tuples that can be "
 	      "used for e.g. syntax highlighting",

--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
@@ -47,6 +47,7 @@ public:
 	unique_ptr<DuckDBPyResult> result;
 	vector<shared_ptr<DuckDBPyConnection>> cursors;
 	std::thread::id thread_id = std::this_thread::get_id();
+	bool check_same_thread = true;
 
 public:
 	explicit DuckDBPyConnection(std::thread::id thread_id_p = std::this_thread::get_id()) : thread_id(thread_id_p) {
@@ -115,7 +116,8 @@ public:
 
 	py::object FetchRecordBatchReader(const idx_t vectors_per_chunk) const;
 
-	static shared_ptr<DuckDBPyConnection> Connect(const string &database, bool read_only, const py::dict &config);
+	static shared_ptr<DuckDBPyConnection> Connect(const string &database, bool read_only, const py::dict &config,
+	                                              bool check_same_thread);
 
 	static vector<Value> TransformPythonParamList(py::handle params);
 

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -102,7 +102,7 @@ DuckDBPyConnection *DuckDBPyConnection::Execute(const string &query, py::object 
 	if (!connection) {
 		throw std::runtime_error("connection closed");
 	}
-	if (std::this_thread::get_id() != thread_id) {
+	if (std::this_thread::get_id() != thread_id && check_same_thread) {
 		throw std::runtime_error("DuckDB objects created in a thread can only be used in that same thread. The object "
 		                         "was created in thread id " +
 		                         to_string(std::hash<std::thread::id> {}(thread_id)) + " and this is thread id " +
@@ -502,7 +502,7 @@ static unique_ptr<TableFunctionRef> ScanReplacement(const string &table_name, vo
 }
 
 shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Connect(const string &database, bool read_only,
-                                                           const py::dict &config_dict) {
+                                                           const py::dict &config_dict, bool check_same_thread) {
 	auto res = make_shared<DuckDBPyConnection>();
 	DBConfig config;
 	if (read_only) {
@@ -523,7 +523,7 @@ shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Connect(const string &databas
 
 	res->database = make_unique<DuckDB>(database, &config);
 	res->connection = make_unique<Connection>(*res->database);
-
+	res->check_same_thread = check_same_thread;
 	PandasScanFunction scan_fun;
 	CreateTableFunctionInfo scan_info(scan_fun);
 
@@ -625,7 +625,7 @@ vector<Value> DuckDBPyConnection::TransformPythonParamList(py::handle params) {
 DuckDBPyConnection *DuckDBPyConnection::DefaultConnection() {
 	if (!default_connection) {
 		py::dict config_dict;
-		default_connection = DuckDBPyConnection::Connect(":memory:", false, config_dict);
+		default_connection = DuckDBPyConnection::Connect(":memory:", false, config_dict, true);
 	}
 	return default_connection.get();
 }

--- a/tools/pythonpkg/tests/fast/test_multithread.py
+++ b/tools/pythonpkg/tests/fast/test_multithread.py
@@ -11,6 +11,10 @@ try:
 except:
     can_run = False
 
+def connect_duck(duckdb_conn):
+    out = duckdb_conn.execute('select i from (values (42), (84), (NULL), (128)) tbl(i)').fetchall()
+    assert out == [(42,), (84,), (None,), (128,)]
+
 class DuckDBThreaded:
     def __init__(self,duckdb_insert_thread_count,thread_function):
         self.duckdb_insert_thread_count = duckdb_insert_thread_count
@@ -41,7 +45,9 @@ class DuckDBThreaded:
 
         assert (return_value)
 
+
 def execute_query_same_connection(duckdb_conn, queue):
+
     try:
         out = duckdb_conn.execute('select i from (values (42), (84), (NULL), (128)) tbl(i)')
         queue.put(False)
@@ -439,6 +445,13 @@ class TestDuckMultithread(object):
 
     def test_cursor(self, duckdb_cursor):
         duck_threads = DuckDBThreaded(10,cursor)
-        duck_threads.multithread_test(False)    
+        duck_threads.multithread_test(False)
+
+    def test_check_same_thread_false(self, duckdb_cursor):
+        con = duckdb.connect(check_same_thread=False)
+
+        x = threading.Thread(target=connect_duck, args=(con,))
+        x.start()
+
 
 


### PR DESCRIPTION
Allow users to explicitly create connections that can be used by different threads.