### PR TITLE
ci: restructure to run format/tidy/codecov for python

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -1,0 +1,132 @@
+name: CodeQuality
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '.github/workflows/**'
+      - '!.github/workflows/CodeQuality.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+  AWS_ACCESS_KEY_ID: AKIAVBLKPL2ZW2T7TYFQ
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.NODE_PRE_GYP_SECRETACCESSKEY }}
+  NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}
+
+jobs:
+  format-check:
+    name: Format Check
+    runs-on: ubuntu-20.04
+
+    env:
+      CC: gcc-10
+      CXX: g++-10
+      GEN: ninja
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang-format && sudo pip3 install cmake-format
+
+      - name: Format Check
+        run: |
+          clang-format --version
+          clang-format --dump-config
+          make format-check-silent
+
+
+  tidy-check:
+    name: Tidy Check
+    runs-on: ubuntu-20.04
+    needs: format-check
+
+    env:
+      CC: gcc-10
+      CXX: g++-10
+      GEN: ninja
+      TIDY_THREADS: 4
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang-tidy && sudo pip3 install pybind11[global]
+
+      - name: Tidy Check
+        run: make tidy-check
+
+  codecov:
+    name: CodeCov
+    runs-on: ubuntu-20.04
+    needs: tidy-check
+    env:
+      GEN: ninja
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build lcov curl
+
+      - name: Validate Configuration
+        run: |
+          curl --fail --data-binary @.codecov.yml https://codecov.io/validate
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Before Install
+        run: |
+          pip install --prefer-binary "pandas>=1.2.4" "requests>=2.26" "pyarrow==6.0" pytest
+          sudo apt-get install g++
+
+      - name: Coverage Reset
+        run: |
+          lcov --config-file .github/workflows/lcovrc --zerocounters --directory .
+          lcov --config-file .github/workflows/lcovrc --capture --initial --directory . --base-directory . --no-external --output-file coverage.info
+
+      - name: Run Tests
+        run: |
+          mkdir -p build/coverage
+          (cd build/coverage && cmake -E env CXXFLAGS="--coverage" cmake -DBUILD_SUBSTRAIT_EXTENSION=1 -DBUILD_PYTHON=1 -DBUILD_PARQUET_EXTENSION=1 -DBUILD_JSON_EXTENSION=1 -DENABLE_SANITIZER=0 -DCMAKE_BUILD_TYPE=Debug ../.. && make)
+          (cd tools/pythonpkg/tests/fast && python3 -m pytest)
+          (cd tools/pythonpkg/tests/coverage && python3 -m pytest)
+          build/coverage/test/unittest
+          build/coverage/test/unittest "[intraquery]"
+          build/coverage/test/unittest "[interquery]"
+          python3 scripts/try_timeout.py --timeout=1200 --retry=3 build/coverage/test/unittest "[coverage]"
+          build/coverage/test/unittest "[detailed_profiler]"
+          build/coverage/test/unittest test/sql/tpch/tpch_sf01.test_slow
+          build/coverage/tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper
+          python tools/shell/shell-test.py build/coverage/duckdb
+
+
+      - name: Generate Coverage
+        run: |
+          lcov --config-file .github/workflows/lcovrc --directory . --base-directory . --no-external --capture --output-file coverage.info
+          lcov --config-file .github/workflows/lcovrc --remove coverage.info $(< .github/workflows/lcov_exclude) -o lcov.info
+
+      - name: CodeCov Upload
+        uses: codecov/codecov-action@v2
+        with:
+          files: lcov.info
+          fail_ci_if_error: true

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -62,50 +62,6 @@ jobs:
     - name: Test
       run: make unittestci
 
- format-check:
-    name: Format Check
-    runs-on: ubuntu-20.04
-
-    env:
-      CC: gcc-10
-      CXX: g++-10
-      GEN: ninja
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-
-    - name: Install
-      run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang-format && sudo pip3 install cmake-format
-
-    - name: Format Check
-      run: |
-        clang-format --version
-        clang-format --dump-config
-        make format-check-silent
-
-
- tidy-check:
-    name: Tidy Check
-    runs-on: ubuntu-20.04
-
-    env:
-      CC: gcc-10
-      CXX: g++-10
-      GEN: ninja
-      TIDY_THREADS: 4
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-
-    - name: Install
-      run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang-tidy && sudo pip3 install pybind11[global]
-
-    - name: Tidy Check
-      run: make tidy-check
 
  force-storage:
     name: Force Storage
@@ -223,67 +179,6 @@ jobs:
 
     - name: Test
       run: valgrind ./build/debug/test/unittest test/sql/tpch/tpch_sf001.test_slow
-
-
- codecov:
-    name: CodeCov
-    runs-on: ubuntu-20.04
-    needs: linux-debug
-    env:
-      GEN: ninja
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Install
-        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build lcov curl
-
-      - name: Validate Configuration
-        run: |
-          curl --fail --data-binary @.codecov.yml https://codecov.io/validate
-
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-
-      - name: Before Install
-        run: |
-          pip install --prefer-binary "pandas>=1.2.4" "requests>=2.26" "pyarrow==6.0" pytest
-          sudo apt-get install g++
-
-      - name: Coverage Reset
-        run: |
-          lcov --config-file .github/workflows/lcovrc --zerocounters --directory .
-          lcov --config-file .github/workflows/lcovrc --capture --initial --directory . --base-directory . --no-external --output-file coverage.info
-
-      - name: Run Tests
-        run: |
-          mkdir -p build/coverage
-          (cd build/coverage && cmake -E env CXXFLAGS="--coverage" cmake -DBUILD_SUBSTRAIT_EXTENSION=1 -DBUILD_PYTHON=1 -DBUILD_PARQUET_EXTENSION=1 -DBUILD_JSON_EXTENSION=1 -DENABLE_SANITIZER=0 -DCMAKE_BUILD_TYPE=Debug ../.. && make)
-          (cd tools/pythonpkg/tests/fast && python3 -m pytest)
-          (cd tools/pythonpkg/tests/coverage && python3 -m pytest)
-          build/coverage/test/unittest
-          build/coverage/test/unittest "[intraquery]"
-          build/coverage/test/unittest "[interquery]"
-          python3 scripts/try_timeout.py --timeout=1200 --retry=3 build/coverage/test/unittest "[coverage]"
-          build/coverage/test/unittest "[detailed_profiler]"
-          build/coverage/test/unittest test/sql/tpch/tpch_sf01.test_slow
-          build/coverage/tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper
-          python tools/shell/shell-test.py build/coverage/duckdb
-
-
-      - name: Generate Coverage
-        run: |
-          lcov --config-file .github/workflows/lcovrc --directory . --base-directory . --no-external --capture --output-file coverage.info
-          lcov --config-file .github/workflows/lcovrc --remove coverage.info $(< .github/workflows/lcov_exclude) -o lcov.info
-
-      - name: CodeCov Upload
-        uses: codecov/codecov-action@v2
-        with:
-          files: lcov.info
-          fail_ci_if_error: true
 
  docs:
     name: Website Docs


### PR DESCRIPTION
https://github.com/duckdb/duckdb/pull/3251 was a bit too ambitious in optimizing CI. This PR re-enables the format, tidy and CodeCov Ci for PRs that only touch python code.

There is one problem with this: before this PR codecov depended on the linux-debug job. This prevented codecov from running if the tests fail. After the optimization however, this job will not run so this dependency is not really possible, without super hacky solutions. To mitigate the a little, the codecov, tidy and format are now chained to reduce the chance of codecov running.