### PR TITLE
Fix #3260: if a schema name is provided, pass along the schema name and table name to the replacement scan

### DIFF
--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -63,14 +63,10 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 	// not a CTE
 	// extract a table or view from the catalog
 	auto &catalog = Catalog::GetCatalog(context);
-	auto schema = catalog.GetSchema(context, ref.schema_name, true, error_context);
-	CatalogEntry *table_or_view = nullptr;
-	if (!schema) {
-		table_or_view =
-		    catalog.GetEntry(context, CatalogType::TABLE_ENTRY, ref.schema_name, ref.table_name, true, error_context);
-	}
+	auto table_or_view =
+	    catalog.GetEntry(context, CatalogType::TABLE_ENTRY, ref.schema_name, ref.table_name, true, error_context);
 	if (!table_or_view) {
-		auto table_name = schema ? ref.table_name : ref.schema_name + "." + ref.table_name;
+		auto table_name = ref.schema_name.empty() ? ref.table_name : (ref.schema_name + "." + ref.table_name);
 		// table could not be found: try to bind a replacement scan
 		auto &config = DBConfig::GetConfig(context);
 		for (auto &scan : config.replacement_scans) {

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -62,14 +62,19 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 	}
 	// not a CTE
 	// extract a table or view from the catalog
-	auto table_or_view =
-	    Catalog::GetCatalog(context).GetEntry(context, CatalogType::TABLE_ENTRY, ref.schema_name, ref.table_name,
-	                                          ref.schema_name.empty() ? true : false, error_context);
+	auto &catalog = Catalog::GetCatalog(context);
+	auto schema = catalog.GetSchema(context, ref.schema_name, true, error_context);
+	CatalogEntry *table_or_view = nullptr;
+	if (!schema) {
+		table_or_view =
+		    catalog.GetEntry(context, CatalogType::TABLE_ENTRY, ref.schema_name, ref.table_name, true, error_context);
+	}
 	if (!table_or_view) {
+		auto table_name = schema ? ref.table_name : ref.schema_name + "." + ref.table_name;
 		// table could not be found: try to bind a replacement scan
 		auto &config = DBConfig::GetConfig(context);
 		for (auto &scan : config.replacement_scans) {
-			auto replacement_function = scan.function(context, ref.table_name, scan.data.get());
+			auto replacement_function = scan.function(context, table_name, scan.data.get());
 			if (replacement_function) {
 				replacement_function->alias = ref.alias.empty() ? ref.table_name : ref.alias;
 				replacement_function->column_name_alias = ref.column_name_alias;
@@ -79,11 +84,11 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		// we still didn't find the table
 		if (GetBindingMode() == BindingMode::EXTRACT_NAMES) {
 			// if we are in EXTRACT_NAMES, we create a dummy table ref
-			AddTableName(ref.table_name);
+			AddTableName(table_name);
 
 			// add a bind context entry
 			auto table_index = GenerateTableIndex();
-			auto alias = ref.alias.empty() ? ref.table_name : ref.alias;
+			auto alias = ref.alias.empty() ? table_name : ref.alias;
 			vector<LogicalType> types {LogicalType::INTEGER};
 			vector<string> names {"__dummy_col" + to_string(table_index)};
 			bind_context.AddGenericBinding(table_index, alias, names, types);


### PR DESCRIPTION
Fixes #3260 

This allows queries like this to work without quotes:

```sql
SELECT * FROM test.parquet
```

Note that this will usually not work without quotes, since path separators (`/`, `\`, etc) will always need to be quoted. It's only useful when DuckDB is run inside the same directory as the parquet files. 