### PR TITLE
Add python module constants from PEP249

### DIFF
--- a/tools/pythonpkg/duckdb-stubs/__init__.pyi
+++ b/tools/pythonpkg/duckdb-stubs/__init__.pyi
@@ -11,13 +11,16 @@ import pandas
 import sys
 # stubgen override - This should probably not be exposed
 #_clean_default_connection: Any
+apilevel: str
 comment: token_type
 default_connection: DuckDBPyConnection
 identifier: token_type
 keyword: token_type
 numeric_const: token_type
 operator: token_type
+paramstyle: str
 string_const: token_type
+threadsafety: int
 
 class DuckDBPyConnection:
     def __init__(self, *args, **kwargs) -> None: ...

--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -77,6 +77,9 @@ PYBIND11_MODULE(DUCKDB_PYTHON_LIB_NAME, m) {
 	m.attr("__version__") = DuckDB::LibraryVersion();
 	m.attr("__git_revision__") = DuckDB::SourceID();
 	m.attr("default_connection") = DuckDBPyConnection::DefaultConnection();
+	m.attr("apilevel") = "1.0";
+	m.attr("threadsafety") = 1;
+	m.attr("paramstyle") = "qmark";
 
 	m.def("connect", &DuckDBPyConnection::Connect,
 	      "Create a DuckDB database instance. Can take a database file name to read/write persistent data and a "

--- a/tools/pythonpkg/tests/fast/test_module.py
+++ b/tools/pythonpkg/tests/fast/test_module.py
@@ -1,0 +1,12 @@
+import duckdb
+
+
+class TestModule:
+    def test_paramstyle(self):
+        assert duckdb.paramstyle == "qmark"
+
+    def test_threadsafety(self):
+        assert duckdb.threadsafety == 1
+
+    def test_apilevel(self):
+        assert duckdb.apilevel == "1.0"


### PR DESCRIPTION
Add the python module level constants `apilevel`, `threadsafety` and `paramstyle` from PEP249, which describes the python database API.

These constants were added into 2.0 of the DB API but are useful for all users.

References:
https://peps.python.org/pep-0249/#major-changes-from-version-1-0-to-version-2-0

Notes:
Changes initially included in a large PR #916 that was not merged.