### PR TITLE
python extension loading tests

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -51,6 +51,21 @@ jobs:
       with:
         python-version: '3.7'
 
+    - name: Install requirements
+      run: |
+        sudo apt-get update -y -qq
+        sudo apt-get install -y git ninja-build make gcc-multilib g++-multilib wget libssl-dev
+
+    - name: Install CMake
+      run: |
+        wget https://github.com/Kitware/CMake/releases/download/v3.21.3/cmake-3.21.3-linux-x86_64.sh
+        chmod +x cmake-3.21.3-linux-x86_64.sh
+        sudo ./cmake-3.21.3-linux-x86_64.sh --skip-license --prefix=/usr/local
+
+    - name: Build extensions to test
+      run: |
+        GEN=ninja DISABLE_MAIN_DUCKDB_LIBRARY=1 BUILD_HTTPFS=1 STATIC_OPENSSL=1 make
+
     - name: Install
       run: pip install cibuildwheel twine
 

--- a/tools/pythonpkg/tests/fast/test_extensions.py
+++ b/tools/pythonpkg/tests/fast/test_extensions.py
@@ -1,0 +1,38 @@
+import duckdb
+import os
+import glob
+import pandas as pd
+
+class TestExtensions(object):
+    def test_extensions(self, duckdb_cursor):
+        extension_base_path = "../../../../build/release/extension"
+
+        dirname = os.path.dirname(__file__)
+        extension_base_path_abs = os.path.join(dirname, extension_base_path)
+
+        def test_httpfs(duckdb_cursor):
+            try:
+                duckdb_cursor.execute("SELECT id, first_name, last_name FROM PARQUET_SCAN('https://raw.githubusercontent.com/cwida/duckdb/master/data/parquet-testing/userdata1.parquet') LIMIT 3;")
+            except RuntimeError as e:
+                # Test will ignore result if it fails due to networking issues while running the test.
+                if (str(e).startswith("HTTP HEAD error")):
+                    return
+                elif (str(e).startswith("Unable to connect")):
+                    return
+                else:
+                    raise e
+
+            result_df = duckdb_cursor.fetchdf()
+            exp_result = pd.DataFrame({
+                'id': pd.Series([1, 2, 3], dtype="int32"),
+                'first_name': ['Amanda', 'Albert', 'Evelyn'],
+                'last_name': ['Jordan', 'Freeman', 'Morgan']
+            })
+            assert(result_df.equals(exp_result))
+
+        for name in glob.glob(f"{extension_base_path_abs}/*/*.duckdb_extension"):
+            conn = duckdb.connect()
+            conn.execute(f"LOAD '{name}'")
+
+            if (name.endswith("httpfs.duckdb_extension")):
+                test_httpfs(conn)


### PR DESCRIPTION
Test that the httpfs extension can be loaded from Python. We could expand this to more extensions, but most extensions are already included in the python package so there's not really a point i think.

Note that similar to the main httpfs CI, the test do not fail on connectivity issues.