### PR TITLE
ODBC: windows installer has to copy and pass program parameters

### DIFF
--- a/tools/odbc/winsetup/install.c
+++ b/tools/odbc/winsetup/install.c
@@ -235,7 +235,7 @@ static BOOL Uninstall(const char *dsn, const char *drivername) {
 	return TRUE;
 }
 
-void ElevateToAdminPrivileges(char **params) {
+void ElevatePrivilegesAsAdmin(char **params) {
 	char szPath[MAX_PATH];
 	if (GetModuleFileName(NULL, szPath, ARRAYSIZE(szPath))) {
 		// Launch itself as admin
@@ -280,7 +280,7 @@ int main(int argc, char **argv) {
 	char *parameters = NULL;
 	if (!IsUserAnAdmin()) {
 		CopyParameters(argc, argv, &parameters);
-		ElevateToAdminPrivileges(&parameters);
+		ElevatePrivilegesAsAdmin(&parameters);
 	}
 
 	char *install_cmd = "/Install";

--- a/tools/odbc/winsetup/install.c
+++ b/tools/odbc/winsetup/install.c
@@ -235,14 +235,14 @@ static BOOL Uninstall(const char *dsn, const char *drivername) {
 	return TRUE;
 }
 
-void ElevatePrivilegesAsAdmin(char **params) {
+void ElevatePrivilegesAsAdmin(char **parameters) {
 	char szPath[MAX_PATH];
 	if (GetModuleFileName(NULL, szPath, ARRAYSIZE(szPath))) {
 		// Launch itself as admin
 		SHELLEXECUTEINFO sei = {sizeof(sei)};
 		sei.lpVerb = "runas";
 		sei.lpFile = szPath;
-		sei.lpParameters = *params;
+		sei.lpParameters = *parameters;
 		sei.hwnd = NULL;
 		sei.nShow = SW_NORMAL;
 		if (!ShellExecuteEx(&sei)) {

--- a/tools/odbc/winsetup/install.c
+++ b/tools/odbc/winsetup/install.c
@@ -259,13 +259,13 @@ void ElevateToAdminPrivileges(char **params) {
 	}
 }
 
-void CopyParameters(int argc, char **argv, char **parameters){
+void CopyParameters(int argc, char **argv, char **parameters) {
 	size_t alloc_size, last_alloc_pos = 0;
-	for (int i=1; i < argc; i++) {
+	for (int i = 1; i < argc; i++) {
 		alloc_size = strlen(argv[i]) + 1;
 		*parameters = (char *)realloc(*parameters, alloc_size);
 		strcat(*parameters, argv[i]);
-		if ((i+1) != argc) {
+		if ((i + 1) != argc) {
 			strcat(*parameters, " ");
 		}
 	}

--- a/tools/odbc/winsetup/install.c
+++ b/tools/odbc/winsetup/install.c
@@ -263,14 +263,11 @@ void CopyParameters(int argc, char **argv, char **parameters){
 	size_t alloc_size, last_alloc_pos = 0;
 	for (int i=1; i < argc; i++) {
 		alloc_size = strlen(argv[i]) + 1;
-		if (i == 0) {
-			*parameters = (char *)malloc(alloc_size * sizeof(char));
-			strcpy(*parameters, argv[i]);
-		} else {
-			*parameters = (char *)realloc(*parameters, alloc_size);
-			strcat(*parameters, argv[i]);
+		*parameters = (char *)realloc(*parameters, alloc_size);
+		strcat(*parameters, argv[i]);
+		if ((i+1) != argc) {
+			strcat(*parameters, " ");
 		}
-		strcat(*parameters, " ");
 	}
 }
 


### PR DESCRIPTION
Hey all,

The Windows installer has a self calling to elevate privileges as Admin, then the program parameters should be passed again to the new call. This PR fixes that.