### PR TITLE
Allow strftime arguments to be specified in both orders

### DIFF
--- a/test/sql/function/date/test_strftime.test
+++ b/test/sql/function/date/test_strftime.test
@@ -11,6 +11,17 @@ SELECT strftime(DATE '1992-01-01', '%Y');
 ----
 1992
 
+# flip the order
+query I
+SELECT strftime('%Y', DATE '1992-01-01');
+----
+1992
+
+query I
+SELECT strftime('%Y', TIMESTAMP '1992-01-01');
+----
+1992
+
 # some literals
 query I
 SELECT strftime(DATE '1992-01-01', '(%Y)');
@@ -115,3 +126,7 @@ SELECT strptime('-1', '%g');
 
 statement error
 SELECT strptime('1000', '%g');
+
+# this won't work without explicit casts
+statement error
+SELECT strftime('%Y', '1992-01-01');


### PR DESCRIPTION
i.e. both these queries now work:

```sql
SELECT strftime(DATE '1992-01-01', '%Y');
SELECT strftime('%Y', DATE '1992-01-01');
```

Because of strong typing there is no ambiguity. Trying to use `strftime` with `VARCHAR, VARCHAR` arguments results in the following error:

```sql
D SELECT strftime('%Y', '1992-01-01');
Error: Binder Error: No function matches the given name and argument types 'strftime(VARCHAR, VARCHAR)'. You might need to add explicit type casts.
	Candidate functions:
	strftime(DATE, VARCHAR) -> VARCHAR
	strftime(TIMESTAMP, VARCHAR) -> VARCHAR
	strftime(VARCHAR, DATE) -> VARCHAR
	strftime(VARCHAR, TIMESTAMP) -> VARCHAR

LINE 1: SELECT strftime('%Y', '1992-01-01');
```

This should fix the SQLite compatibility issues described in #3282