### PR TITLE
Use FieldWriter/FieldReader in Checkpoint Manager

### DIFF
--- a/src/storage/storage_info.cpp
+++ b/src/storage/storage_info.cpp
@@ -2,6 +2,6 @@
 
 namespace duckdb {
 
-const uint64_t VERSION_NUMBER = 32;
+const uint64_t VERSION_NUMBER = 33;
 
 } // namespace duckdb


### PR DESCRIPTION
This PR switches the CheckpointManager to also use the FieldWriter and FieldReader for writing the catalog entry counts. This will allow new types of catalog entries to be added without requiring the storage version to be incremented (which was the only event which required an increase in storage version this release).