### PR TITLE
Add benchmark_runner based regression test, and remove random engine from cycle counter

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -122,3 +122,37 @@ jobs:
 
     - name: Regression Test H2OAI
       run: python scripts/regression_test.py --benchmark=h2oai
+
+ regression-test-benchmark-runner:
+  name: Regression Test (Benchmark Runner)
+  runs-on: ubuntu-20.04
+  needs: regression-test-tpch
+  env:
+    CC: gcc-10
+    CXX: g++-10
+    GEN: ninja
+    BUILD_BENCHMARK: 1
+
+  steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.7'
+
+    - name: Install
+      run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build && pip install requests
+
+    - name: Build
+      run: |
+        make
+        git clone https://github.com/duckdb/duckdb.git
+        cd duckdb
+        make
+        cd ..
+
+    - name: Regression Test
+      run:
+        python scripts/regression_test_runner.py --old=duckdb/build/release/benchmark/benchmark_runner --new=build/release/benchmark/benchmark_runner --benchmarks=.github/workflows/regression_benchmarks.csv --verbose

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -132,6 +132,7 @@ jobs:
     CXX: g++-10
     GEN: ninja
     BUILD_BENCHMARK: 1
+    BUILD_TPCH: 1
 
   steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/regression_benchmarks.csv
+++ b/.github/workflows/regression_benchmarks.csv
@@ -8,4 +8,3 @@ benchmark/micro/cast/cast_int64_int32.benchmark
 benchmark/micro/cast/cast_string_double.benchmark
 benchmark/micro/cast/cast_string_int.benchmark
 benchmark/micro/cast/cast_timestamp_string.benchmark
-benchmark/tpch/csv/read_lineitem_csv.benchmark

--- a/.github/workflows/regression_benchmarks.csv
+++ b/.github/workflows/regression_benchmarks.csv
@@ -1,4 +1,5 @@
 Append100KIntegersINSERT
+Append100KIntegersPREPARED
 benchmark/micro/cast/cast_date_string.benchmark
 benchmark/micro/cast/cast_int_string.benchmark
 benchmark/micro/cast/cast_double_string.benchmark
@@ -7,3 +8,4 @@ benchmark/micro/cast/cast_int64_int32.benchmark
 benchmark/micro/cast/cast_string_double.benchmark
 benchmark/micro/cast/cast_string_int.benchmark
 benchmark/micro/cast/cast_timestamp_string.benchmark
+benchmark/tpch/csv/read_lineitem_csv.benchmark

--- a/.github/workflows/regression_benchmarks.csv
+++ b/.github/workflows/regression_benchmarks.csv
@@ -1,0 +1,9 @@
+Append100KIntegersINSERT
+benchmark/micro/cast/cast_date_string.benchmark
+benchmark/micro/cast/cast_int_string.benchmark
+benchmark/micro/cast/cast_double_string.benchmark
+benchmark/micro/cast/cast_int32_int64.benchmark
+benchmark/micro/cast/cast_int64_int32.benchmark
+benchmark/micro/cast/cast_string_double.benchmark
+benchmark/micro/cast/cast_string_int.benchmark
+benchmark/micro/cast/cast_timestamp_string.benchmark

--- a/benchmark/benchmark_runner.cpp
+++ b/benchmark/benchmark_runner.cpp
@@ -343,4 +343,5 @@ int main(int argc, char **argv) {
 		print_error_message(configuration_error);
 		exit(1);
 	}
+	return 0;
 }

--- a/scripts/regression_test_runner.py
+++ b/scripts/regression_test_runner.py
@@ -1,0 +1,141 @@
+import os
+import sys
+import subprocess
+from io import StringIO
+import csv
+import statistics
+
+# how many times we will run the experiment, to be sure of the regression
+number_repetitions = 5
+# the threshold at which we consider something a regression (percentage)
+regression_threshold_percentage = 0.1
+# minimal seconds diff for something to be a regression (for very fast benchmarks)
+regression_threshold_seconds = 0.01
+
+old_runner = None
+new_runner = None
+benchmark_file = None
+verbose = False
+for arg in sys.argv:
+    if arg.startswith("--old="):
+        old_runner = arg.replace("--old=", "")
+    elif arg.startswith("--new="):
+        new_runner = arg.replace("--new=", "")
+    elif arg.startswith("--benchmarks="):
+        benchmark_file = arg.replace("--benchmarks=", "")
+    elif arg == "--verbose":
+        verbose = True
+
+if old_runner is None or new_runner is None or benchmark_file is None:
+    print("Expected usage: python3 scripts/regression_test_runner.py --old=/old/benchmark_runner --new=/new/benchmark_runner --benchmarks=/benchmark/list.csv")
+    exit(1)
+
+if not os.path.isfile(old_runner):
+    print(f"Failed to find old runner {old_runner}")
+    exit(1)
+
+if not os.path.isfile(new_runner):
+    print(f"Failed to find new runner {new_runner}")
+    exit(1)
+
+def run_benchmark(runner, benchmark):
+    proc = subprocess.Popen([runner, benchmark], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out = proc.stdout.read().decode('utf8')
+    err = proc.stderr.read().decode('utf8')
+    proc.wait()
+    if proc.returncode != 0:
+        print("Failed to run benchmark " + benchmark)
+        print('''====================================================
+==============         STDERR          =============
+====================================================
+''')
+        print(err)
+        print('''====================================================
+==============         STDOUT          =============
+====================================================
+''')
+        print(out)
+        exit(1)
+    if verbose:
+        print(err)
+    # read the input CSV
+    f = StringIO(err)
+    csv_reader = csv.reader(f, delimiter='\t')
+    header = True
+    timings = []
+    try:
+        for row in csv_reader:
+            if len(row) == 0:
+                continue
+            if header:
+                header = False
+            else:
+                timings.append(row[2])
+    except:
+        print("Failed to run benchmark " + benchmark)
+        print(err)
+        exit(1)
+    return float(statistics.median(timings))
+
+def run_benchmarks(runner, benchmark_list):
+    results = {}
+    for benchmark in benchmark_list:
+        results[benchmark] = run_benchmark(runner, benchmark)
+    return results
+
+# read the initial benchmark list
+with open(benchmark_file, 'r') as f:
+    benchmark_list = [x.strip() for x in f.read().split('\n') if len(x) > 0]
+
+multiply_percentage = 1.0 + regression_threshold_percentage
+other_results = []
+for i in range(number_repetitions):
+    regression_list = []
+    if len(benchmark_list) == 0:
+        break
+    print(f'''====================================================
+==============      ITERATION {i}        =============
+==============      REMAINING {len(benchmark_list)}        =============
+====================================================
+''')
+
+    old_results = run_benchmarks(old_runner, benchmark_list)
+    new_results = run_benchmarks(new_runner, benchmark_list)
+
+    for benchmark in benchmark_list:
+        old_res = old_results[benchmark]
+        new_res = new_results[benchmark]
+        if (old_res + regression_threshold_seconds) * multiply_percentage < new_res:
+            regression_list.append([benchmark, old_res, new_res])
+        else:
+            other_results.append([benchmark, old_res, new_res])
+    benchmark_list = [x[0] for x in regression_list]
+
+exit_code = 0
+if len(regression_list) > 0:
+    exit_code = 1
+    print('''====================================================
+==============  REGRESSIONS DETECTED   =============
+====================================================
+''')
+    for regression in regression_list:
+        print(f"{regression[0]}")
+        print(f"Old timing: {regression[1]}")
+        print(f"New timing: {regression[2]}")
+        print("")
+    print('''====================================================
+==============     OTHER TIMINGS       =============
+====================================================
+''')
+else:
+    print('''====================================================
+============== NO REGRESSIONS DETECTED  =============
+====================================================
+''')
+
+other_results.sort()
+for res in other_results:
+    print(f"{res[0]}")
+    print(f"Old timing: {res[1]}")
+    print(f"New timing: {res[2]}")
+    print("")

--- a/src/include/duckdb/common/cycle_counter.hpp
+++ b/src/include/duckdb/common/cycle_counter.hpp
@@ -21,10 +21,9 @@ class CycleCounter {
 	friend struct ExpressionInfo;
 	friend struct ExpressionRootInfo;
 	static constexpr int SAMPLING_RATE = 50;
-	static constexpr int SAMPLING_VARIANCE = 100;
 
 public:
-	CycleCounter() : random(-1) {
+	CycleCounter() {
 	}
 	// Next_sample determines if a sample needs to be taken, if so start the profiler
 	void BeginSample() {
@@ -39,7 +38,7 @@ public:
 			time += Tick() - tmp;
 		}
 		if (current_count >= next_sample) {
-			next_sample = SAMPLING_RATE + random.NextRandomInteger() % SAMPLING_VARIANCE;
+			next_sample = SAMPLING_RATE;
 			++sample_count;
 			sample_tuples_count += chunk_size;
 			current_count = 0;
@@ -65,8 +64,6 @@ private:
 	uint64_t sample_tuples_count = 0;
 	//! Count the number of ALL tuples
 	uint64_t tuples_count = 0;
-	//! the random number generator used for sampling
-	RandomEngine random;
 };
 
 } // namespace duckdb


### PR DESCRIPTION
This PR adds regression tests based on the `benchmark_runner` to the CI suite. The benchmarks that are run are defined in `.github/workflows/regression_benchmarks.csv`. Like the other regression tests, they will be run in both the master and the latest commit. 

This PR also removes the `RandomEngine` from the `CycleCounter`. The `RandomEngine` initialization in the `CycleCounter` ended up nearly tripling time taken on executing simple queries (e.g. simple `INSERT INTO` statements).