### PR TITLE
Fix #3272: avoid incorrectly moving LIMIT to before the ORDER clause in certain cases

### DIFF
--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -188,9 +188,10 @@ private:
 private:
 	//! Bind the default values of the columns of a table
 	void BindDefaultValues(vector<ColumnDefinition> &columns, vector<unique_ptr<Expression>> &bound_defaults);
-	//! Bind a delimiter value (LIMIT or OFFSET)
-	unique_ptr<Expression> BindDelimiter(ClientContext &context, unique_ptr<ParsedExpression> delimiter,
-	                                     const LogicalType &type, Value &delimiter_value);
+	//! Bind a limit value (LIMIT or OFFSET)
+	unique_ptr<Expression> BindDelimiter(ClientContext &context, OrderBinder &order_binder,
+	                                     unique_ptr<ParsedExpression> delimiter, const LogicalType &type,
+	                                     Value &delimiter_value);
 
 	//! Move correlated expressions from the child binder to this binder
 	void MoveCorrelatedExpressions(Binder &other);
@@ -251,10 +252,6 @@ private:
 	unique_ptr<LogicalOperator> CreatePlan(BoundExpressionListRef &ref);
 	unique_ptr<LogicalOperator> CreatePlan(BoundCTERef &ref);
 
-	unique_ptr<LogicalOperator> BindTable(TableCatalogEntry &table, BaseTableRef &ref);
-	unique_ptr<LogicalOperator> BindView(ViewCatalogEntry &view, BaseTableRef &ref);
-	unique_ptr<LogicalOperator> BindTableOrView(BaseTableRef &ref);
-
 	BoundStatement BindCopyTo(CopyStatement &stmt);
 	BoundStatement BindCopyFrom(CopyStatement &stmt);
 
@@ -262,8 +259,8 @@ private:
 	void BindModifierTypes(BoundQueryNode &result, const vector<LogicalType> &sql_types, idx_t projection_index);
 
 	BoundStatement BindSummarize(ShowStatement &stmt);
-	unique_ptr<BoundResultModifier> BindLimit(LimitModifier &limit_mod);
-	unique_ptr<BoundResultModifier> BindLimitPercent(LimitPercentModifier &limit_mod);
+	unique_ptr<BoundResultModifier> BindLimit(OrderBinder &order_binder, LimitModifier &limit_mod);
+	unique_ptr<BoundResultModifier> BindLimitPercent(OrderBinder &order_binder, LimitPercentModifier &limit_mod);
 	unique_ptr<Expression> BindOrderExpression(OrderBinder &order_binder, unique_ptr<ParsedExpression> expr);
 
 	unique_ptr<LogicalOperator> PlanFilter(unique_ptr<Expression> condition, unique_ptr<LogicalOperator> root);

--- a/src/include/duckdb/planner/expression_binder/order_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/order_binder.hpp
@@ -33,6 +33,8 @@ public:
 		return max_count;
 	}
 
+	unique_ptr<Expression> CreateExtraReference(unique_ptr<ParsedExpression> expr);
+
 private:
 	unique_ptr<Expression> CreateProjectionReference(ParsedExpression &expr, idx_t index);
 

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -34,9 +34,13 @@ unique_ptr<Expression> Binder::BindOrderExpression(OrderBinder &order_binder, un
 	return bound_expr;
 }
 
-unique_ptr<Expression> Binder::BindDelimiter(ClientContext &context, unique_ptr<ParsedExpression> delimiter,
-                                             const LogicalType &type, Value &delimiter_value) {
+unique_ptr<Expression> Binder::BindDelimiter(ClientContext &context, OrderBinder &order_binder,
+                                             unique_ptr<ParsedExpression> delimiter, const LogicalType &type,
+                                             Value &delimiter_value) {
 	auto new_binder = Binder::CreateBinder(context, this, true);
+	if (delimiter->HasSubquery()) {
+		return order_binder.CreateExtraReference(move(delimiter));
+	}
 	ExpressionBinder expr_binder(*new_binder, context);
 	expr_binder.target_type = type;
 	auto expr = expr_binder.Bind(delimiter);
@@ -48,18 +52,18 @@ unique_ptr<Expression> Binder::BindDelimiter(ClientContext &context, unique_ptr<
 	return expr;
 }
 
-unique_ptr<BoundResultModifier> Binder::BindLimit(LimitModifier &limit_mod) {
+unique_ptr<BoundResultModifier> Binder::BindLimit(OrderBinder &order_binder, LimitModifier &limit_mod) {
 	auto result = make_unique<BoundLimitModifier>();
 	if (limit_mod.limit) {
 		Value val;
-		result->limit = BindDelimiter(context, move(limit_mod.limit), LogicalType::BIGINT, val);
+		result->limit = BindDelimiter(context, order_binder, move(limit_mod.limit), LogicalType::BIGINT, val);
 		if (!result->limit) {
 			result->limit_val = val.GetValue<int64_t>();
 		}
 	}
 	if (limit_mod.offset) {
 		Value val;
-		result->offset = BindDelimiter(context, move(limit_mod.offset), LogicalType::BIGINT, val);
+		result->offset = BindDelimiter(context, order_binder, move(limit_mod.offset), LogicalType::BIGINT, val);
 		if (!result->offset) {
 			result->offset_val = val.GetValue<int64_t>();
 		}
@@ -67,11 +71,11 @@ unique_ptr<BoundResultModifier> Binder::BindLimit(LimitModifier &limit_mod) {
 	return move(result);
 }
 
-unique_ptr<BoundResultModifier> Binder::BindLimitPercent(LimitPercentModifier &limit_mod) {
+unique_ptr<BoundResultModifier> Binder::BindLimitPercent(OrderBinder &order_binder, LimitPercentModifier &limit_mod) {
 	auto result = make_unique<BoundLimitPercentModifier>();
 	if (limit_mod.limit) {
 		Value val;
-		result->limit = BindDelimiter(context, move(limit_mod.limit), LogicalType::DOUBLE, val);
+		result->limit = BindDelimiter(context, order_binder, move(limit_mod.limit), LogicalType::DOUBLE, val);
 		if (!result->limit) {
 			result->limit_percent = val.GetValue<double>();
 			if (result->limit_percent < 0.0) {
@@ -81,7 +85,7 @@ unique_ptr<BoundResultModifier> Binder::BindLimitPercent(LimitPercentModifier &l
 	}
 	if (limit_mod.offset) {
 		Value val;
-		result->offset = BindDelimiter(context, move(limit_mod.offset), LogicalType::BIGINT, val);
+		result->offset = BindDelimiter(context, order_binder, move(limit_mod.offset), LogicalType::BIGINT, val);
 		if (!result->offset) {
 			result->offset_val = val.GetValue<int64_t>();
 		}
@@ -146,10 +150,10 @@ void Binder::BindModifiers(OrderBinder &order_binder, QueryNode &statement, Boun
 			break;
 		}
 		case ResultModifierType::LIMIT_MODIFIER:
-			bound_modifier = BindLimit((LimitModifier &)*mod);
+			bound_modifier = BindLimit(order_binder, (LimitModifier &)*mod);
 			break;
 		case ResultModifierType::LIMIT_PERCENT_MODIFIER:
-			bound_modifier = BindLimitPercent((LimitPercentModifier &)*mod);
+			bound_modifier = BindLimitPercent(order_binder, (LimitPercentModifier &)*mod);
 			break;
 		default:
 			throw Exception("Unsupported result modifier");
@@ -158,6 +162,18 @@ void Binder::BindModifiers(OrderBinder &order_binder, QueryNode &statement, Boun
 			result.modifiers.push_back(move(bound_modifier));
 		}
 	}
+}
+
+static void AssignReturnType(unique_ptr<Expression> &expr, const vector<LogicalType> &sql_types,
+                             idx_t projection_index) {
+	if (!expr) {
+		return;
+	}
+	if (expr->type != ExpressionType::BOUND_COLUMN_REF) {
+		return;
+	}
+	auto &bound_colref = (BoundColumnRefExpression &)*expr;
+	bound_colref.return_type = sql_types[bound_colref.binding.column_index];
 }
 
 void Binder::BindModifierTypes(BoundQueryNode &result, const vector<LogicalType> &sql_types, idx_t projection_index) {
@@ -191,6 +207,18 @@ void Binder::BindModifierTypes(BoundQueryNode &result, const vector<LogicalType>
 					                                                  StringType::GetCollation(sql_type), true);
 				}
 			}
+			break;
+		}
+		case ResultModifierType::LIMIT_MODIFIER: {
+			auto &limit = (BoundLimitModifier &)*bound_mod;
+			AssignReturnType(limit.limit, sql_types, projection_index);
+			AssignReturnType(limit.offset, sql_types, projection_index);
+			break;
+		}
+		case ResultModifierType::LIMIT_PERCENT_MODIFIER: {
+			auto &limit = (BoundLimitPercentModifier &)*bound_mod;
+			AssignReturnType(limit.limit, sql_types, projection_index);
+			AssignReturnType(limit.offset, sql_types, projection_index);
 			break;
 		}
 		case ResultModifierType::ORDER_MODIFIER: {

--- a/src/planner/expression_binder/order_binder.cpp
+++ b/src/planner/expression_binder/order_binder.cpp
@@ -32,6 +32,12 @@ unique_ptr<Expression> OrderBinder::CreateProjectionReference(ParsedExpression &
 	                                             ColumnBinding(projection_index, index));
 }
 
+unique_ptr<Expression> OrderBinder::CreateExtraReference(unique_ptr<ParsedExpression> expr) {
+	auto result = CreateProjectionReference(*expr, extra_list->size());
+	extra_list->push_back(move(expr));
+	return result;
+}
+
 unique_ptr<Expression> OrderBinder::Bind(unique_ptr<ParsedExpression> expr) {
 	// in the ORDER BY clause we do not bind children
 	// we bind ONLY to the select list
@@ -102,9 +108,7 @@ unique_ptr<Expression> OrderBinder::Bind(unique_ptr<ParsedExpression> expr) {
 		                      expr->ToString());
 	}
 	// otherwise we need to push the ORDER BY entry into the select list
-	auto result = CreateProjectionReference(*expr, extra_list->size());
-	extra_list->push_back(move(expr));
-	return result;
+	return CreateExtraReference(move(expr));
 }
 
 } // namespace duckdb

--- a/test/sql/order/limit_parameter.test
+++ b/test/sql/order/limit_parameter.test
@@ -1,0 +1,51 @@
+# name: test/sql/order/limit_parameter.test
+# description: Test LIMIT with a parameter
+# group: [order]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT * FROM generate_series(0, 10000, 1) tbl(i) ORDER BY i DESC LIMIT 5
+----
+10000
+9999
+9998
+9997
+9996
+
+statement ok
+CREATE TABLE integers AS SELECT 5 k
+
+query I
+SELECT * FROM generate_series(0, 10000, 1) tbl(i) ORDER BY i DESC LIMIT (SELECT k FROM integers)
+----
+10000
+9999
+9998
+9997
+9996
+
+statement ok
+CREATE TABLE strings AS SELECT '5'::VARCHAR k
+
+query I
+SELECT * FROM generate_series(0, 10000, 1) tbl(i) ORDER BY i DESC LIMIT (SELECT k FROM strings)
+----
+10000
+9999
+9998
+9997
+9996
+
+statement ok
+PREPARE v1 AS SELECT * FROM generate_series(0, 10000, 1) tbl(i) ORDER BY i DESC LIMIT ?::VARCHAR
+
+query I
+EXECUTE v1(5)
+----
+10000
+9999
+9998
+9997
+9996

--- a/test/sql/order/limit_parameter.test
+++ b/test/sql/order/limit_parameter.test
@@ -49,3 +49,27 @@ EXECUTE v1(5)
 9998
 9997
 9996
+
+statement ok
+PREPARE v1 AS SELECT * FROM generate_series(0, 10000, 1) tbl(i) ORDER BY i DESC LIMIT ?::VARCHAR %
+
+query I
+EXECUTE v1('0.05')
+----
+10000
+9999
+9998
+9997
+9996
+
+statement ok
+CREATE TABLE doubles AS SELECT 0.05 d
+
+query I
+SELECT * FROM generate_series(0, 10000, 1) tbl(i) ORDER BY i DESC LIMIT (SELECT d FROM doubles) %
+----
+10000
+9999
+9998
+9997
+9996


### PR DESCRIPTION
Fixes #3272