### PR TITLE
Issue #3290: Histogram Temporal Bindings

### DIFF
--- a/src/function/aggregate/nested/histogram.cpp
+++ b/src/function/aggregate/nested/histogram.cpp
@@ -248,6 +248,9 @@ void HistogramFun::RegisterFunction(BuiltinFunctions &set) {
 	fun.AddFunction(GetHistogramFunction(PhysicalType::VARCHAR));
 	fun.AddFunction(GetHistogramFunction<int64_t>(LogicalType::TIMESTAMP));
 	fun.AddFunction(GetHistogramFunction<int64_t>(LogicalType::TIMESTAMP_TZ));
+	fun.AddFunction(GetHistogramFunction<int64_t>(LogicalType::TIMESTAMP_S));
+	fun.AddFunction(GetHistogramFunction<int64_t>(LogicalType::TIMESTAMP_MS));
+	fun.AddFunction(GetHistogramFunction<int64_t>(LogicalType::TIMESTAMP_NS));
 	set.AddFunction(fun);
 }
 

--- a/test/sql/aggregate/aggregates/test_histogram.test
+++ b/test/sql/aggregate/aggregates/test_histogram.test
@@ -69,6 +69,22 @@ select histogram(name) from names;
 ----
 {Hubert Blaine Wolfeschlegelsteinhausenbergerdorff Sr.=1, hannes=2, mark=1, pedro=3}
 
+# Variant time type binding (Issue #3290)
+query I
+SELECT histogram(CAST('2021-08-20' AS TIMESTAMP_S));
+----
+{2021-08-20 00:00:00=1}
+
+query I
+SELECT histogram(CAST('2021-08-20' AS TIMESTAMP_MS));
+----
+{2021-08-20 00:00:00=1}
+
+query I
+SELECT histogram(CAST('2021-08-20' AS TIMESTAMP_NS));
+----
+{2021-08-20 00:00:00=1}
+
 require vector_size 512
 
 query II rowsort


### PR DESCRIPTION
Add bindings for the `histogram` aggregate so it
returns correctly scaled results for variant temporal types.