### PR TITLE
R bug-fixes: Pipes in tests and silence R NOTE

### DIFF
--- a/tools/rpkg/R/register.R
+++ b/tools/rpkg/R/register.R
@@ -81,22 +81,23 @@ duckdb_register_arrow <- function(conn, name, arrow_scannable, use_async = NULL)
   # create some R functions to pass to c-land
   export_fun <- function(arrow_scannable, stream_ptr, projection = NULL, filter = TRUE) {
     # If we get a scanner we must transform it to a record batch reader first
-    if(class(arrow_scannable)[1] == "Scanner"){
-      arrow_scannable<-arrow_scannable$ToRecordBatchReader()
+    if (class(arrow_scannable)[1] == "Scanner") {
+      arrow_scannable <- arrow_scannable$ToRecordBatchReader()
     }
     arrow::Scanner$create(arrow_scannable, projection, filter)$ToRecordBatchReader()$export_to_c(stream_ptr)
   }
 
   get_schema_fun <- function(arrow_scannable, stream_ptr) {
-    if(class(arrow_scannable)[1] == "arrow_dplyr_query"){
+    if (class(arrow_scannable)[1] == "arrow_dplyr_query") {
+      collapse <- pkg_method("collapse", "dplyr")
       collapse(arrow_scannable)$.data$schema$export_to_c(stream_ptr)
-    } else{
+    } else {
       schema <- arrow_scannable$schema$export_to_c(stream_ptr)
     }
   }
 
   # pass some functions to c land so we don't have to look them up there
-  function_list <- list(export_fun, arrow::Expression$create, arrow::Expression$field_ref, arrow::Expression$scalar,get_schema_fun)
+  function_list <- list(export_fun, arrow::Expression$create, arrow::Expression$field_ref, arrow::Expression$scalar, get_schema_fun)
   rapi_register_arrow(conn@conn_ref, enc2utf8(as.character(name)), function_list, arrow_scannable)
   invisible(TRUE)
 }

--- a/tools/rpkg/tests/testthat/test_tbl__duckdb_connection.R
+++ b/tools/rpkg/tests/testthat/test_tbl__duckdb_connection.R
@@ -1,9 +1,5 @@
 skip_on_cran()
-skip_if_no_R4 <- function() {
-  if (R.Version()$major < 4) {
-    skip("R 4.0.0 or newer not available for testing")
-  }
-}
+`%>%` <- dplyr::`%>%`
 
 test_that("Parquet files can be registered with dplyr::tbl()", {
   con <- DBI::dbConnect(duckdb::duckdb())
@@ -11,19 +7,19 @@ test_that("Parquet files can be registered with dplyr::tbl()", {
 
   tab0 <- dplyr::tbl(con, "data/userdata1.parquet")
   expect_true(inherits(tab0, "tbl_duckdb_connection"))
-  expect_true(tab0 |> dplyr::count() |> dplyr::collect() == 1000)
+  expect_true(tab0 %>% dplyr::count() %>% dplyr::collect() == 1000)
 
   tab1 <- dplyr::tbl(con, "read_parquet(['data/userdata1.parquet'])")
   expect_true(inherits(tab1, "tbl_duckdb_connection"))
-  expect_true(tab1 |> dplyr::count() |> dplyr::collect() == 1000)
+  expect_true(tab1 %>% dplyr::count() %>% dplyr::collect() == 1000)
 
   tab2 <- dplyr::tbl(con, "'data/userdata1.parquet'")
   expect_true(inherits(tab2, "tbl_duckdb_connection"))
-  expect_true(tab2 |> dplyr::count() |> dplyr::collect() == 1000)
+  expect_true(tab2 %>% dplyr::count() %>% dplyr::collect() == 1000)
 
   tab3 <- dplyr::tbl(con, "parquet_scan(['data/userdata1.parquet'])")
   expect_true(inherits(tab3, "tbl_duckdb_connection"))
-  expect_true(tab3 |> dplyr::count() |> dplyr::collect() == 1000)
+  expect_true(tab3 %>% dplyr::count() %>% dplyr::collect() == 1000)
 })
 
 
@@ -51,11 +47,11 @@ test_that("CSV files can be registered with dplyr::tbl()", {
 
   tab1 <- dplyr::tbl(con, path)
   expect_true(inherits(tab1, "tbl_duckdb_connection"))
-  expect_true(tab1 |> dplyr::count() |> dplyr::collect() == 150)
+  expect_true(tab1 %>% dplyr::count() %>% dplyr::collect() == 150)
 
   tab2 <- dplyr::tbl(con, paste0("read_csv_auto('", path, "')"))
   expect_true(inherits(tab2, "tbl_duckdb_connection"))
-  expect_true(tab2 |> dplyr::count() |> dplyr::collect() == 150)
+  expect_true(tab2 %>% dplyr::count() %>% dplyr::collect() == 150)
 })
 
 test_that("Other replacement scans or functions can be registered with dplyr::tbl()", {
@@ -64,5 +60,7 @@ test_that("Other replacement scans or functions can be registered with dplyr::tb
 
   obj <- dplyr::tbl(con, "duckdb_keywords()")
   expect_true(inherits(obj, "tbl_duckdb_connection"))
-  expect_true(obj |> dplyr::filter(keyword_name == "all") |> dplyr::count() |> dplyr::collect() == 1)
+  expect_true(obj %>% dplyr::filter(keyword_name == "all") %>% dplyr::count() %>% dplyr::collect() == 1)
 })
+
+rm(`%>%`)


### PR DESCRIPTION
Native pipes in R require R 4.1.0 or higher, but tests in #3264 condition only for R 4.0 as pointed out by @eitsupi [here](https://github.com/duckdb/duckdb/pull/3264#discussion_r837267003). As it is better that tests work also in earlier versions, this PR fixes the pipe-issue.

I also noticed that there was a new **NOTE** in the `R CHECK` results, that was introduced in #3299:
```
* checking R code for possible problems ... NOTE
duckdb_register_arrow : get_schema_fun: no visible global function
  definition for ‘collapse’
Undefined global functions or variables:
  collapse
```
That **NOTE** can be easily silenced by conditioning on namespace, so only minimal change required (one call to `pkg_method`). Running `styler::style_file()` on the file `register.R` suggested some other non-essential changes. 