### PR TITLE
Moving CreateViewInfo::Copy() out of header 

### DIFF
--- a/src/include/duckdb/parser/parsed_data/create_view_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_view_info.hpp
@@ -30,14 +30,7 @@ struct CreateViewInfo : public CreateInfo {
 	unique_ptr<SelectStatement> query;
 
 public:
-	unique_ptr<CreateInfo> Copy() const override {
-		auto result = make_unique<CreateViewInfo>(schema, view_name);
-		CopyProperties(*result);
-		result->aliases = aliases;
-		result->types = types;
-		result->query = unique_ptr_cast<SQLStatement, SelectStatement>(query->Copy());
-		return move(result);
-	}
+	unique_ptr<CreateInfo> Copy() const override;
 };
 
 } // namespace duckdb

--- a/src/parser/parsed_data/CMakeLists.txt
+++ b/src/parser/parsed_data/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library_unity(duckdb_parsed_data OBJECT alter_table_info.cpp
-                  sample_options.cpp)
+                  create_view_info.cpp sample_options.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_parsed_data>
     PARENT_SCOPE)

--- a/src/parser/parsed_data/create_view_info.cpp
+++ b/src/parser/parsed_data/create_view_info.cpp
@@ -1,0 +1,12 @@
+#include "duckdb/parser/parsed_data/create_view_info.hpp"
+
+namespace duckdb {
+unique_ptr<CreateInfo> CreateViewInfo::Copy() const {
+	auto result = make_unique<CreateViewInfo>(schema, view_name);
+	CopyProperties(*result);
+	result->aliases = aliases;
+	result->types = types;
+	result->query = unique_ptr_cast<SQLStatement, SelectStatement>(query->Copy());
+	return move(result);
+}
+} // namespace duckdb


### PR DESCRIPTION
so we can avoid exporting `SelectStatement::Copy()`