### PR TITLE
Fix #3294: initialize validity mask to correct size in placeholder code

### DIFF
--- a/src/storage/compression/validity_uncompressed.cpp
+++ b/src/storage/compression/validity_uncompressed.cpp
@@ -237,7 +237,12 @@ void ValidityScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t s
 	// the bitwise ops we use below don't work if the vector size is too small
 	ValidityMask source_mask(input_data);
 	for (idx_t i = 0; i < scan_count; i++) {
-		result_mask.Set(result_offset + i, source_mask.RowIsValid(start + i));
+		if (!source_mask.RowIsValid(start + i)) {
+			if (result_mask.AllValid()) {
+				result_mask.Initialize(MaxValue<idx_t>(STANDARD_VECTOR_SIZE, result_offset + scan_count));
+			}
+			result_mask.SetInvalid(result_offset + i);
+		}
 	}
 #else
 	// the code below does what the fallback code above states, but using bitwise ops:

--- a/test/sql/delete/list_delete.test
+++ b/test/sql/delete/list_delete.test
@@ -1,0 +1,28 @@
+# name: test/sql/delete/list_delete.test
+# description: Test list deletions
+# group: [delete]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE aggr (k int[]);
+
+statement ok
+INSERT INTO aggr VALUES ([0, 1, 1, 1, 4, 0, 3, 3, 2, 2, 4, 4, 2, 4, 0, 0, 0, 1, 2, 3, 4, 2, 3, 3, 1]);
+
+statement ok
+INSERT INTO aggr VALUES ([]), ([NULL]), (NULL), ([0, 1, 1, 1, 4, NULL, 0, 3, 3, 2, NULL, 2, 4, 4, 2, 4, 0, 0, 0, 1, NULL, 2, 3, 4, 2, 3, 3, 1]);
+
+query I
+SELECT COUNT(k) FROM aggr
+----
+4
+
+statement ok
+DELETE FROM aggr;
+
+query I
+SELECT COUNT(k) FROM aggr
+----
+0


### PR DESCRIPTION
Fixes #3294 

Note that this bug is only triggered in placeholder code that is used only for low vector sizes.