### PR TITLE
Fix use after free bug in local storage

### DIFF
--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -72,9 +72,9 @@ struct ColumnFetchState {
 struct LocalScanState {
 	~LocalScanState();
 
-	void SetStorage(LocalTableStorage *storage);
+	void SetStorage(shared_ptr<LocalTableStorage> storage);
 	LocalTableStorage *GetStorage() {
-		return storage;
+		return storage.get();
 	}
 
 	idx_t chunk_index;
@@ -83,7 +83,7 @@ struct LocalScanState {
 	TableFilterSet *table_filters;
 
 private:
-	LocalTableStorage *storage = nullptr;
+	shared_ptr<LocalTableStorage> storage;
 };
 
 class RowGroupScanState {

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -16,7 +16,7 @@ class DataTable;
 class WriteAheadLog;
 struct TableAppendState;
 
-class LocalTableStorage {
+class LocalTableStorage : public std::enable_shared_from_this<LocalTableStorage> {
 public:
 	explicit LocalTableStorage(DataTable &table);
 	~LocalTableStorage();
@@ -99,7 +99,7 @@ private:
 
 private:
 	Transaction &transaction;
-	unordered_map<DataTable *, unique_ptr<LocalTableStorage>> table_storage;
+	unordered_map<DataTable *, shared_ptr<LocalTableStorage>> table_storage;
 
 	void Flush(DataTable &table, LocalTableStorage &storage);
 };

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -23,7 +23,7 @@ void LocalTableStorage::InitializeScan(LocalScanState &state, TableFilterSet *ta
 		// nothing to scan
 		return;
 	}
-	state.SetStorage(this);
+	state.SetStorage(shared_from_this());
 
 	state.chunk_index = 0;
 	state.max_index = collection.ChunkCount() - 1;
@@ -47,12 +47,12 @@ LocalScanState::~LocalScanState() {
 	SetStorage(nullptr);
 }
 
-void LocalScanState::SetStorage(LocalTableStorage *new_storage) {
-	if (storage != nullptr) {
+void LocalScanState::SetStorage(shared_ptr<LocalTableStorage> new_storage) {
+	if (storage) {
 		D_ASSERT(storage->active_scans > 0);
 		storage->active_scans--;
 	}
-	storage = new_storage;
+	storage = move(new_storage);
 	if (storage) {
 		storage->active_scans++;
 	}
@@ -166,7 +166,7 @@ void LocalStorage::Append(DataTable *table, DataChunk &chunk) {
 	auto entry = table_storage.find(table);
 	LocalTableStorage *storage;
 	if (entry == table_storage.end()) {
-		auto new_storage = make_unique<LocalTableStorage>(*table);
+		auto new_storage = make_shared<LocalTableStorage>(*table);
 		storage = new_storage.get();
 		table_storage.insert(make_pair(table, move(new_storage)));
 	} else {


### PR DESCRIPTION
This occasionally crashed the CI by triggering a use-after-free in a destructor.