### PR TITLE
WIP/RFC: Allow refering to aliased columns in SELECT

### DIFF
--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -78,12 +78,15 @@ public:
 	unique_ptr<ParsedExpression> CreateStructExtract(unique_ptr<ParsedExpression> base, string field_name);
 	BindResult BindQualifiedColumnName(ColumnRefExpression &colref, const string &table_name);
 
-	unique_ptr<ParsedExpression> QualifyColumnName(const string &column_name, string &error_message);
-	unique_ptr<ParsedExpression> QualifyColumnName(ColumnRefExpression &colref, string &error_message);
+	unique_ptr<ParsedExpression> QualifyColumnName(const string &column_name, string &error_message,
+	                                               bool prioritise_current_aliases);
+	unique_ptr<ParsedExpression> QualifyColumnName(ColumnRefExpression &colref, string &error_message,
+	                                               bool prioritise_current_aliases);
 
 	// Bind table names to ColumnRefExpressions
-	void QualifyColumnNames(unique_ptr<ParsedExpression> &expr);
-	static void QualifyColumnNames(Binder &binder, unique_ptr<ParsedExpression> &expr);
+	void QualifyColumnNames(unique_ptr<ParsedExpression> &expr, bool prioritise_current_aliases);
+	static void QualifyColumnNames(Binder &binder, unique_ptr<ParsedExpression> &expr,
+	                               bool prioritise_current_aliases = false);
 
 	static unique_ptr<Expression> PushCollation(ClientContext &context, unique_ptr<Expression> source,
 	                                            const string &collation, bool equality_only = false);

--- a/src/include/duckdb/planner/expression_binder/group_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/group_binder.hpp
@@ -10,16 +10,19 @@
 
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/planner/expression_binder.hpp"
+#include "duckdb/planner/expression_binder.hpp"
+#include "duckdb/planner/expression_binder/column_alias_binder.hpp"
 
 namespace duckdb {
 class ConstantExpression;
 class ColumnRefExpression;
+class BoundSelectNode;
 
 //! The GROUP binder is responsible for binding expressions in the GROUP BY clause
 class GroupBinder : public ExpressionBinder {
 public:
-	GroupBinder(Binder &binder, ClientContext &context, SelectNode &node, idx_t group_index,
-	            case_insensitive_map_t<idx_t> &alias_map, case_insensitive_map_t<idx_t> &group_alias_map);
+	GroupBinder(Binder &binder, ClientContext &context, SelectNode &node, BoundSelectNode &bound_node,
+	            const case_insensitive_map_t<idx_t> &alias_map, idx_t group_index);
 
 	//! The unbound root expression
 	unique_ptr<ParsedExpression> unbound_expression;
@@ -36,11 +39,13 @@ protected:
 	BindResult BindConstant(ConstantExpression &expr);
 
 	SelectNode &node;
-	case_insensitive_map_t<idx_t> &alias_map;
-	case_insensitive_map_t<idx_t> &group_alias_map;
 	unordered_set<idx_t> used_aliases;
 
 	idx_t group_index;
+
+private:
+	ColumnAliasLookup column_alias_lookup;
+	ColumnAliasBinder column_alias_binder;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder/having_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/having_binder.hpp
@@ -23,6 +23,9 @@ protected:
 	BindResult BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth,
 	                          bool root_expression = false) override;
 	BindResult BindColumnRef(ColumnRefExpression &expr, idx_t depth, bool root_expression) override;
+
+protected:
+	ColumnAliasProjectionBinder column_alias_projection_binder;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder/having_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/having_binder.hpp
@@ -16,17 +16,13 @@ namespace duckdb {
 //! The HAVING binder is responsible for binding an expression within the HAVING clause of a SQL statement
 class HavingBinder : public SelectBinder {
 public:
-	HavingBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
-	             case_insensitive_map_t<idx_t> &alias_map);
+	HavingBinder(Binder &binder, ClientContext &context, BoundSelectNode &node,
+	             const case_insensitive_map_t<idx_t> &alias_map, BoundGroupInformation &info);
 
 protected:
 	BindResult BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth,
 	                          bool root_expression = false) override;
-
-private:
-	BindResult BindColumnRef(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression);
-
-	ColumnAliasBinder column_alias_binder;
+	BindResult BindColumnRef(ColumnRefExpression &expr, idx_t depth, bool root_expression) override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder/order_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/order_binder.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/parser/expression_map.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression_binder/column_alias_binder.hpp"
 
 namespace duckdb {
 class Binder;
@@ -40,11 +41,14 @@ private:
 
 private:
 	vector<Binder *> binders;
-	idx_t projection_index;
+	// idx_t projection_index;
 	idx_t max_count;
 	vector<unique_ptr<ParsedExpression>> *extra_list;
-	case_insensitive_map_t<idx_t> &alias_map;
+	// case_insensitive_map_t<idx_t> &alias_map;
 	expression_map_t<idx_t> &projection_map;
+
+	ColumnAliasLookup column_alias_lookup;
+	ColumnAliasProjectionBinder column_alias_projection_binder;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder/qualify_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/qualify_binder.hpp
@@ -16,17 +16,13 @@ namespace duckdb {
 //! The QUALIFY binder is responsible for binding an expression within the QUALIFY clause of a SQL statement
 class QualifyBinder : public SelectBinder {
 public:
-	QualifyBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
-	              case_insensitive_map_t<idx_t> &alias_map);
+	QualifyBinder(Binder &binder, ClientContext &context, BoundSelectNode &node,
+	              const case_insensitive_map_t<idx_t> &alias_map, BoundGroupInformation &info);
 
 protected:
+	BindResult BindColumnRef(ColumnRefExpression &expr, idx_t depth, bool root_expression);
 	BindResult BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth,
 	                          bool root_expression = false) override;
-
-private:
-	BindResult BindColumnRef(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression);
-
-	ColumnAliasBinder column_alias_binder;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder/qualify_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/qualify_binder.hpp
@@ -23,6 +23,8 @@ protected:
 	BindResult BindColumnRef(ColumnRefExpression &expr, idx_t depth, bool root_expression);
 	BindResult BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth,
 	                          bool root_expression = false) override;
+protected:
+	ColumnAliasProjectionBinder column_alias_projection_binder;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder/where_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/where_binder.hpp
@@ -9,26 +9,36 @@
 #pragma once
 
 #include "duckdb/planner/expression_binder.hpp"
+#include "duckdb/planner/expression_binder/column_alias_binder.hpp"
 
 namespace duckdb {
 
+class ColumnAliasLookup;
 class ColumnAliasBinder;
 
 //! The WHERE binder is responsible for binding an expression within the WHERE clause of a SQL statement
 class WhereBinder : public ExpressionBinder {
 public:
-	WhereBinder(Binder &binder, ClientContext &context, ColumnAliasBinder *column_alias_binder = nullptr);
+	WhereBinder(Binder &binder, ClientContext &context);
+	WhereBinder(Binder &binder, ClientContext &context, const case_insensitive_map_t<idx_t> &alias_map,
+	            const BoundSelectNode &node);
 
 protected:
+	WhereBinder(Binder &binder, ClientContext &context, unique_ptr<ColumnAliasLookup> column_alias_lookup,
+	            unique_ptr<ColumnAliasBinder> column_alias_binder);
+
 	BindResult BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth,
 	                          bool root_expression = false) override;
+
+	BindResult BindColumnRef(ColumnRefExpression &expr, idx_t depth, bool root_expression);
 
 	string UnsupportedAggregateMessage() override;
 
 private:
-	BindResult BindColumnRef(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression);
-
-	ColumnAliasBinder *column_alias_binder;
+	//! filled for SELECT, null for DROP, UPDATE, etc.
+	unique_ptr<ColumnAliasLookup> column_alias_lookup;
+	//! filled for SELECT, null for DROP, UPDATE, etc.
+	unique_ptr<ColumnAliasBinder> column_alias_binder;
 };
 
 } // namespace duckdb

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -360,7 +360,7 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SelectNode &statement) {
 
 	// bind the QUALIFY clause, if any
 	if (statement.qualify) {
-		ExpressionBinder::QualifyColumnNames(*this, statement.qualify);
+		ExpressionBinder::QualifyColumnNames(*this, statement.qualify, true);
 		QualifyBinder qualify_binder(*this, context, *result, alias_map, info);
 		result->qualify = qualify_binder.Bind(statement.qualify);
 	}

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -108,7 +108,8 @@ SchemaCatalogEntry *Binder::BindCreateFunctionInfo(CreateInfo &info) {
 	string error;
 	auto sel_node = make_unique<BoundSelectNode>();
 	auto group_info = make_unique<BoundGroupInformation>();
-	SelectBinder binder(*this, context, *sel_node, *group_info);
+	case_insensitive_map_t<idx_t> alias_map;
+	SelectBinder binder(*this, context, *sel_node, alias_map, *group_info);
 	error = binder.Bind(&expression, 0, false);
 
 	if (!error.empty()) {

--- a/src/planner/expression_binder/column_alias_binder.cpp
+++ b/src/planner/expression_binder/column_alias_binder.cpp
@@ -6,28 +6,73 @@
 
 namespace duckdb {
 
-ColumnAliasBinder::ColumnAliasBinder(BoundSelectNode &node, const case_insensitive_map_t<idx_t> &alias_map)
-    : node(node), alias_map(alias_map), in_alias(false) {
+// alias map will be modified during initial select column list binding.
+ColumnAliasLookup::ColumnAliasLookup(const case_insensitive_map_t<idx_t> &alias_map) : alias_map(alias_map) {
 }
 
-BindResult ColumnAliasBinder::BindAlias(ExpressionBinder &enclosing_binder, ColumnRefExpression &expr, idx_t depth,
-                                        bool root_expression) {
-	if (expr.IsQualified()) {
-		return BindResult(StringUtil::Format("Alias %s cannot be qualified.", expr.ToString()));
+idx_t ColumnAliasLookup::TryBindAlias(const ParsedExpression &expr) {
+	if (expr.expression_class != ExpressionClass::COLUMN_REF) {
+		return DConstants::INVALID_INDEX;
+	}
+	auto &colref = (ColumnRefExpression &)expr;
+
+	if (colref.IsQualified()) {
+		return DConstants::INVALID_INDEX;
+	}
+	auto alias_name = colref.column_names[0];
+
+	auto index = alias_map.find(alias_name);
+	if (index == alias_map.end()) {
+		return DConstants::INVALID_INDEX;
+	};
+
+	// TODO, this is for order by
+	if (index->second == DConstants::INVALID_INDEX) {
+		throw BinderException(
+		    StringUtil::Format("Tried to reference alias \"%s\", which has been poisoned.", alias_name));
 	}
 
-	auto alias_entry = alias_map.find(expr.column_names[0]);
-	if (alias_entry == alias_map.end()) {
-		return BindResult(StringUtil::Format("Alias %s is not found.", expr.ToString()));
-	}
+	return index->second;
+}
 
-	// found an alias: bind the alias expression
-	D_ASSERT(!in_alias);
-	auto expression = node.original_expressions[alias_entry->second]->Copy();
-	in_alias = true;
-	auto result = enclosing_binder.BindExpression(&expression, depth, root_expression);
-	in_alias = false;
+ColumnAliasBinder::ColumnAliasBinder(const BoundSelectNode &node) : node(node) {
+}
+
+unique_ptr<ParsedExpression> ColumnAliasBinder::ResolveAliasByDuplicatingParsedTarget(idx_t index) {
+	auto select_length = node.original_expressions.size();
+	if (index >= select_length) {
+		throw InternalException(StringUtil::Format("Tried to duplicate index %lld of a select list with %lld items.",
+		                                           index, select_length));
+	}
+	auto resolved_select_item = node.original_expressions[index]->Copy();
+	return resolved_select_item;
+}
+
+BindResult ColumnAliasBinder::BindAliasByDuplicatingParsedTarget(ExpressionBinder *binder, const ParsedExpression &expr,
+                                                                 idx_t index, idx_t depth, bool root_expression) {
+	auto resolved_select_item = ResolveAliasByDuplicatingParsedTarget(index);
+	auto result = binder->BindExpression(&resolved_select_item, depth, root_expression);
+	if (!result.HasError() && result.expression->HasSideEffects()) {
+		throw BinderException(
+		    StringUtil::Format("Alias \"%s\" tried to reference \"%s\", but this has side effects so is not allowed.",
+		                       expr.alias, resolved_select_item->ToString()));
+	}
 	return result;
+}
+
+ColumnAliasProjectionBinder::ColumnAliasProjectionBinder(idx_t projection_idx) : projection_index(projection_idx) {
+}
+
+unique_ptr<Expression> ColumnAliasProjectionBinder::ResolveAliasWithProjection(const ParsedExpression &expr,
+                                                                               idx_t index) {
+	if (projection_index == DConstants::INVALID_INDEX) {
+		throw InternalException(StringUtil::Format(
+		    "Tried to bind %s with a projection to this query, but projection_index has not yet been set.",
+		    expr.ToString()));
+	}
+	string alias = expr.GetName();
+	return make_unique<BoundColumnRefExpression>(move(alias), LogicalType::INVALID,
+	                                             ColumnBinding(projection_index, index));
 }
 
 } // namespace duckdb

--- a/src/planner/expression_binder/group_binder.cpp
+++ b/src/planner/expression_binder/group_binder.cpp
@@ -8,9 +8,9 @@
 
 namespace duckdb {
 
-GroupBinder::GroupBinder(Binder &binder, ClientContext &context, SelectNode &node, idx_t group_index,
-                         case_insensitive_map_t<idx_t> &alias_map, case_insensitive_map_t<idx_t> &group_alias_map)
-    : ExpressionBinder(binder, context), node(node), alias_map(alias_map), group_alias_map(group_alias_map),
+GroupBinder::GroupBinder(Binder &binder, ClientContext &context, SelectNode &node, BoundSelectNode &bound_node,
+                         const case_insensitive_map_t<idx_t> &alias_map, idx_t group_index)
+    : ExpressionBinder(binder, context), column_alias_lookup(alias_map), column_alias_binder(bound_node), node(node),
       group_index(group_index) {
 }
 
@@ -52,14 +52,11 @@ BindResult GroupBinder::BindSelectRef(idx_t entry) {
 	if (entry >= node.select_list.size()) {
 		throw BinderException("GROUP BY term out of range - should be between 1 and %d", (int)node.select_list.size());
 	}
+	auto select_entry = column_alias_binder.ResolveAliasByDuplicatingParsedTarget(entry);
 	// we replace the root expression, also replace the unbound expression
-	unbound_expression = node.select_list[entry]->Copy();
-	// move the expression that this refers to here and bind it
-	auto select_entry = move(node.select_list[entry]);
+	unbound_expression = select_entry->Copy();
+	// bind the expression that this refers to
 	auto binding = Bind(select_entry, nullptr, false);
-	// now replace the original expression in the select list with a reference to this group
-	group_alias_map[to_string(entry)] = bind_index;
-	node.select_list[entry] = make_unique<ColumnRefExpression>(to_string(entry));
 	// insert into the set of used aliases
 	used_aliases.insert(entry);
 	return BindResult(move(binding));
@@ -77,32 +74,24 @@ BindResult GroupBinder::BindConstant(ConstantExpression &constant) {
 }
 
 BindResult GroupBinder::BindColumnRef(ColumnRefExpression &colref) {
-	// columns in GROUP BY clauses:
-	// FIRST refer to the original tables, and
-	// THEN if no match is found refer to aliases in the SELECT list
-	// THEN if no match is found, refer to outer queries
-
-	// first try to bind to the base columns (original tables)
+	// first fall through to an underlying table
 	auto result = ExpressionBinder::BindExpression(colref, 0);
-	if (result.HasError()) {
-		if (colref.IsQualified()) {
-			// explicit table name: not an alias reference
-			return result;
-		}
-		// failed to bind the column and the node is the root expression with depth = 0
-		// check if refers to an alias in the select clause
-		auto alias_name = colref.column_names[0];
-		auto entry = alias_map.find(alias_name);
-		if (entry == alias_map.end()) {
-			// no matching alias found
-			return result;
-		}
-		result = BindResult(BindSelectRef(entry->second));
-		if (!result.HasError()) {
-			group_alias_map[alias_name] = bind_index;
-		}
+	if (!result.HasError()) {
+		return result;
 	}
-	return result;
+
+	// no luck? try an alias
+	auto alias_index = column_alias_lookup.TryBindAlias(colref);
+	if (alias_index == DConstants::INVALID_INDEX) {
+		// no alias, abort
+		return BindResult(StringUtil::Format("%s, and GROUP BY \"%s\" couldn\'t be found in the FROM clause!",
+		                                     result.error, colref.ToString()));
+	}
+
+	// TODO - check group_alias_map in master
+
+	// found the alias, off we go
+	return BindResult(BindSelectRef(alias_index));
 }
 
 } // namespace duckdb

--- a/src/planner/expression_binder/qualify_binder.cpp
+++ b/src/planner/expression_binder/qualify_binder.cpp
@@ -10,7 +10,7 @@ namespace duckdb {
 
 QualifyBinder::QualifyBinder(Binder &binder, ClientContext &context, BoundSelectNode &node,
                              const case_insensitive_map_t<idx_t> &alias_map, BoundGroupInformation &info)
-    : SelectBinder(binder, context, node, alias_map, info) {
+    : SelectBinder(binder, context, node, alias_map, info), column_alias_projection_binder(node.projection_index) {
 	target_type = LogicalType(LogicalTypeId::BOOLEAN);
 }
 
@@ -20,8 +20,7 @@ BindResult QualifyBinder::BindColumnRef(ColumnRefExpression &expr, idx_t depth, 
 
 	auto alias_index = column_alias_lookup.TryBindAlias(expr);
 	if (alias_index != DConstants::INVALID_INDEX) {
-		return column_alias_binder.BindAliasByDuplicatingParsedTarget(this, (ParsedExpression &)expr, alias_index,
-		                                                              depth, root_expression);
+		return BindResult(column_alias_projection_binder.ResolveAliasWithProjection((ParsedExpression &)expr, alias_index));
 	}
 
 	auto non_alias_result = ExpressionBinder::BindExpression(expr, depth);

--- a/src/planner/expression_binder/where_binder.cpp
+++ b/src/planner/expression_binder/where_binder.cpp
@@ -3,25 +3,37 @@
 
 namespace duckdb {
 
-WhereBinder::WhereBinder(Binder &binder, ClientContext &context, ColumnAliasBinder *column_alias_binder)
-    : ExpressionBinder(binder, context), column_alias_binder(column_alias_binder) {
+WhereBinder::WhereBinder(Binder &binder, ClientContext &context, unique_ptr<ColumnAliasLookup> column_alias_lookup,
+                         unique_ptr<ColumnAliasBinder> column_alias_binder)
+    : ExpressionBinder(binder, context), column_alias_lookup {move(column_alias_lookup)}, column_alias_binder {move(
+                                                                                              column_alias_binder)} {
 	target_type = LogicalType(LogicalTypeId::BOOLEAN);
 }
 
-BindResult WhereBinder::BindColumnRef(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
-	auto &expr = (ColumnRefExpression &)**expr_ptr;
-	auto result = ExpressionBinder::BindExpression(expr_ptr, depth);
-	if (!result.HasError() || !column_alias_binder) {
+WhereBinder::WhereBinder(Binder &binder, ClientContext &context) : WhereBinder(binder, context, nullptr, nullptr) {
+}
+
+WhereBinder::WhereBinder(Binder &binder, ClientContext &context, const case_insensitive_map_t<idx_t> &alias_map,
+                         const BoundSelectNode &node)
+    : WhereBinder(binder, context, make_unique<ColumnAliasLookup>(alias_map), make_unique<ColumnAliasBinder>(node)) {
+}
+
+BindResult WhereBinder::BindColumnRef(ColumnRefExpression &expr, idx_t depth, bool root_expression) {
+	auto result = ExpressionBinder::BindExpression(expr, depth);
+	if (!result.HasError()) {
 		return result;
 	}
 
-	BindResult alias_result = column_alias_binder->BindAlias(*this, expr, depth, root_expression);
-	// This code path cannot be exercised at thispoint. #1547 might change that.
-	if (!alias_result.HasError()) {
-		return alias_result;
+	if (!column_alias_lookup || !column_alias_binder) {
+		return result;
 	}
 
-	return result;
+	auto alias_index = column_alias_lookup->TryBindAlias(expr);
+	if (alias_index != DConstants::INVALID_INDEX) {
+		return column_alias_binder->BindAliasByDuplicatingParsedTarget(this, (ParsedExpression &)expr, alias_index,
+		                                                               depth, root_expression);
+	}
+	return BindResult(StringUtil::Format("%s, and no existing column for \"%s\" found", result.error, expr.ToString()));
 }
 
 BindResult WhereBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
@@ -32,7 +44,7 @@ BindResult WhereBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, i
 	case ExpressionClass::WINDOW:
 		return BindResult("WHERE clause cannot contain window functions!");
 	case ExpressionClass::COLUMN_REF:
-		return BindColumnRef(expr_ptr, depth, root_expression);
+		return BindColumnRef((ColumnRefExpression &)expr, depth, root_expression);
 	default:
 		return ExpressionBinder::BindExpression(expr_ptr, depth);
 	}

--- a/test/sql/aggregate/qualify/test_qualify.test
+++ b/test/sql/aggregate/qualify/test_qualify.test
@@ -208,7 +208,7 @@ SELECT b, SUM(a) FROM test GROUP BY b QUALIFY row_number() OVER (PARTITION BY b)
 
 # alias conflicts with underlying column
 query TI
-SELECT b, a*10 as aa from qt qualify aa >= 10 and count(*) over () > 0
+SELECT b, a*10 as a from qt qualify a >= 10 and count(*) over () > 0
 ----
 A	10
 A	20

--- a/test/sql/aggregate/qualify/test_qualify.test
+++ b/test/sql/aggregate/qualify/test_qualify.test
@@ -205,3 +205,12 @@ SELECT b FROM test QUALIFY avga() > 10
 # column not found in from clause and can't find in alias map
 statement error
 SELECT b, SUM(a) FROM test GROUP BY b QUALIFY row_number() OVER (PARTITION BY b) > sum;
+
+# alias conflicts with underlying column
+query TI
+SELECT b, a*10 as aa from qt qualify aa >= 10 and count(*) over () > 0
+----
+A	10
+A	20
+B	30
+B	40

--- a/test/sql/binder/test_select_alias.test
+++ b/test/sql/binder/test_select_alias.test
@@ -1,0 +1,52 @@
+# name: test/sql/binder/test_select_alias.test
+# description: Test filter on alias
+# group: [binder]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE integers(i INTEGER)
+
+statement ok
+INSERT INTO integers VALUES (1), (2), (3), (NULL)
+
+# simple refer to a previous alias
+query II
+SELECT i % 2 as k, k*2 FROM integers;
+----
+1	2
+0	0
+1	2
+NULL	NULL
+
+# refer to an aliased aggregate
+query II
+select sum(i+1) as ii, ii+1 from integers group by null
+----
+9	10
+
+# refer to an aliased aggregate in a window function
+query IIR
+select
+    (i % 2 = 0) as is_even,
+	sum(i) as subtotal,
+	subtotal::double/(sum(subtotal) over ()) as proportion
+from integers group by is_even order by is_even
+----
+NULL	NULL	NULL
+0	4	0.666667
+1	2	0.333333
+
+# refer to an alias in a window
+query III
+select
+    (i % 2 = 0) as is_even,
+	i,
+	sum(i) over (partition by is_even),
+from integers order by i
+----
+NULL	NULL	NULL
+0	1	4
+1	2	2
+0	3	4

--- a/test/sql/filter/test_alias_filter.test
+++ b/test/sql/filter/test_alias_filter.test
@@ -52,3 +52,7 @@ SELECT i % 2 AS k FROM integers WHERE k=k;
 # alias to an aggregate doesn't work.
 statement error
 SELECT i % 2 AS o, COUNT(i) AS c FROM integers WHERE c = 0 GROUP BY o;
+
+# alias to an expression with side effects doesn't work.
+statement error
+SELECT random() as r FROM integers WHERE r = 42;

--- a/test/sql/projection/test_scalar_projection.test
+++ b/test/sql/projection/test_scalar_projection.test
@@ -40,9 +40,11 @@ SELECT CASE WHEN 43 > 33 THEN 43 ELSE 33 END;
 ----
 43
 
-# cannot reference columns like this
-statement error
+# allow referencing column alias
+query II
 SELECT 1 AS a, a * 2
+----
+1	2
 
 # query without selection list
 statement error


### PR DESCRIPTION
This is an initial pass at #1547.

Coming work is
 - use same code path in WHERE and HAVING - I think they can now be simplified
 - (pending direction) error if a referenced col is ambiguously either underlying table or alias
 - (pending direction) provide a way to disambiguate in favour of an alias above

There are also a couple of things I want to ask about current work, will do in comments.

Thanks!

===

Take 2:

This looks a fair bit nicer, hope you agree. I've split out alias lookup and resolution into separate helper classes - I've left them separate for now but you may want to organize them in a different way (e.g. maybe mixins for the clause binders instead? and maybe combine lookups and the binders into a hierarchy?).

QualifyColumnNames is now untouched but I still want to come back to this in future work - the current situation is an implicit "unqualified column names must be an alias" which isn't great, and it also precludes ever letting the user explicitly refer to an alias.

In the first refactor commit, which contains most of the work, I've resolved aliases by duplicating bound expressions everywhere but ORDER and TryBindGroup in SELECT. This works and allows for the side effects check, but you weren't super keen on this for QUALIFY and HAVING.

In a middle commit I have a first attempt at getting QUALIFY to preference an alias over a column, as this is how it works in other databases. This will probably get pulled out of this PR but I did want to see if the current design would make this possible (it doesn't, see first note above...)

In the final commit, I've attempted to resolve with projections for QUALIFY and HAVING. This doesn't actually work yet - before spending a lot of time on getting this working, I wanted to check if this is really what you want? I think there is some existing de-duping logic against the select list when planning these filters later, unless I misunderstood something? Replacing them with projections now might need to be rolled back if the optimizer is ever able to pushdown filters in these clauses, right? I know HAVING and QUALIFY are "meant to" only be used for agg funcs and window funcs, but it is possible to refer to base columns in there as well, and in future work I was going to try and convince you to remove the "must contain a window function" restriction from QUALIFY as well :)
