### PR TITLE
Fix #3351: avoid double-binding functions in subqueries after an initial binding error

### DIFF
--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -94,7 +94,7 @@ unique_ptr<ParsedExpression> ExpressionBinder::CreateStructExtract(unique_ptr<Pa
 	vector<unique_ptr<ParsedExpression>> children;
 	children.push_back(move(base));
 	children.push_back(make_unique_base<ParsedExpression, ConstantExpression>(Value(move(field_name))));
-	auto extract_fun = make_unique<FunctionExpression>("struct_extract", move(children));
+	auto extract_fun = make_unique<OperatorExpression>(ExpressionType::STRUCT_EXTRACT, move(children));
 	return move(extract_fun);
 }
 

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -55,12 +55,13 @@ BindResult ExpressionBinder::BindFunction(FunctionExpression &function, ScalarFu
 	vector<unique_ptr<Expression>> children;
 	for (idx_t i = 0; i < function.children.size(); i++) {
 		auto &child = (BoundExpression &)*function.children[i];
+		D_ASSERT(child.expr);
 		children.push_back(move(child.expr));
 	}
 	unique_ptr<Expression> result =
 	    ScalarFunction::BindScalarFunction(context, *func, move(children), error, function.is_operator);
 	if (!result) {
-		return BindResult(binder.FormatError(function, error));
+		throw BinderException(binder.FormatError(function, error));
 	}
 	return BindResult(move(result));
 }

--- a/src/planner/binder/expression/bind_operator_expression.cpp
+++ b/src/planner/binder/expression/bind_operator_expression.cpp
@@ -86,9 +86,20 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 	case ExpressionType::ARRAY_SLICE:
 		function_name = "array_slice";
 		break;
-	case ExpressionType::STRUCT_EXTRACT:
+	case ExpressionType::STRUCT_EXTRACT: {
+		D_ASSERT(op.children.size() == 2);
+		D_ASSERT(op.children[0]->expression_class == ExpressionClass::BOUND_EXPRESSION);
+		D_ASSERT(op.children[1]->expression_class == ExpressionClass::BOUND_EXPRESSION);
+		auto &extract_exp = (BoundExpression &)*op.children[0];
+		auto &name_exp = (BoundExpression &)*op.children[1];
+		if (extract_exp.expr->return_type.id() != LogicalTypeId::STRUCT) {
+			return BindResult(
+			    StringUtil::Format("Cannot extract field %s from expression \"%s\" because it is not a struct",
+			                       name_exp.ToString(), extract_exp.ToString()));
+		}
 		function_name = "struct_extract";
 		break;
+	}
 	case ExpressionType::ARRAY_CONSTRUCTOR:
 		function_name = "list_value";
 		break;

--- a/src/planner/binder/expression/bind_operator_expression.cpp
+++ b/src/planner/binder/expression/bind_operator_expression.cpp
@@ -92,7 +92,8 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 		D_ASSERT(op.children[1]->expression_class == ExpressionClass::BOUND_EXPRESSION);
 		auto &extract_exp = (BoundExpression &)*op.children[0];
 		auto &name_exp = (BoundExpression &)*op.children[1];
-		if (extract_exp.expr->return_type.id() != LogicalTypeId::STRUCT) {
+		if (extract_exp.expr->return_type.id() != LogicalTypeId::STRUCT &&
+		    extract_exp.expr->return_type.id() != LogicalTypeId::SQLNULL) {
 			return BindResult(
 			    StringUtil::Format("Cannot extract field %s from expression \"%s\" because it is not a struct",
 			                       name_exp.ToString(), extract_exp.ToString()));

--- a/test/issues/fuzz/function_pointer_crash_in_subquery.test
+++ b/test/issues/fuzz/function_pointer_crash_in_subquery.test
@@ -1,0 +1,15 @@
+# name: test/issues/fuzz/function_pointer_crash_in_subquery.test
+# description: Issue 3351: NullPointer at duckdb/src/function/function.cpp:368:29
+# group: [fuzz]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE strings(a INTEGER);
+
+statement ok
+CREATE TABLE c0(test2 tinyint, s1 smallint, s2 integer, test1 bigint, i double, id real, c1 varchar);
+
+statement error
+SELECT * FROM c0 s1 INNER JOIN c0 s2 ON (SELECT s1.s2=s2 FROM c0 WHERE s2.s2=s2) ORDER BY s1.s2;


### PR DESCRIPTION
Fixes #3351