### PR TITLE
Fix #3352: fix several bugs with index selection for verifying foreign key constraints

### DIFF
--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -76,6 +76,8 @@ public:
 		return indexes.size();
 	}
 
+	Index *FindForeignKeyIndex(const vector<idx_t> &fk_keys, ForeignKeyType fk_type);
+
 private:
 	//! Indexes associated with the current table
 	mutex indexes_lock;

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -113,7 +113,7 @@ static void BindConstraints(Binder &binder, BoundCreateTableInfo &info) {
 				for (auto &keyname : fk.pk_columns) {
 					auto entry = info.name_map.find(keyname);
 					if (entry == info.name_map.end()) {
-						throw ParserException("column \"%s\" named in key does not exist", keyname);
+						throw BinderException("column \"%s\" named in key does not exist", keyname);
 					}
 					fk.info.pk_keys.push_back(entry->second);
 				}
@@ -122,7 +122,7 @@ static void BindConstraints(Binder &binder, BoundCreateTableInfo &info) {
 				for (auto &keyname : fk.fk_columns) {
 					auto entry = info.name_map.find(keyname);
 					if (entry == info.name_map.end()) {
-						throw ParserException("column \"%s\" named in key does not exist", keyname);
+						throw BinderException("column \"%s\" named in key does not exist", keyname);
 					}
 					fk.info.fk_keys.push_back(entry->second);
 				}

--- a/test/issues/fuzz/foreign_key_index_selection.test
+++ b/test/issues/fuzz/foreign_key_index_selection.test
@@ -1,0 +1,37 @@
+# name: test/issues/fuzz/foreign_key_index_selection.test
+# description: Issue #3352: String null pointer in foreign key
+# group: [fuzz]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE s1(t0 INTEGER, a TEXT, b TEXT);
+
+# key does not exist
+statement error
+CREATE TABLE c2(c0 INTEGER, c1 INTEgiGER UNIQUE, FOREIGN KEY (c0) REFERENCES s1(tz));
+
+# key does not have an index on it
+statement error
+CREATE TABLE c2(c0 INTEGER, c1 INTEGER UNIQUE, FOREIGN KEY (c0) REFERENCES s1(t0));
+
+statement ok
+CREATE TABLE s2(t0 INTEGER, a TEXT, b TEXT, UNIQUE (t0, a));
+
+# key does not have an index on it
+statement error
+CREATE TABLE c2(c0 INTEGER, c1 INTEGER UNIQUE, FOREIGN KEY (c0) REFERENCES s2(t0));
+
+# this works
+statement ok
+CREATE TABLE s3(t0 INTEGER UNIQUE, a TEXT, b TEXT, UNIQUE (t0, a));
+
+statement ok
+CREATE TABLE c2(c0 INTEGER, c1 INTEGER UNIQUE, FOREIGN KEY (c0) REFERENCES s3(t0));
+
+statement ok
+INSERT INTO s3 VALUES (1, 'a', 'b');
+
+statement ok
+INSERT INTO c2 VALUES (1, 2);


### PR DESCRIPTION
Fixes #3352 

* Indexes were not correctly selected for verification, e.g. for a foreign key referencing `TBL(a)` the index `TBL(a, b)` would also be checked
* Indexes were not correctly checked for existence prior to creating a table with a foreign key constraint, which would lead to no actual constraint verification taking place since there was no index to check