### PR TITLE
Fix #3353: check if any results are returned in sqlite api wrapper before looking at the chunk

### DIFF
--- a/test/issues/fuzz/sqlite_wrapper_crash.test
+++ b/test/issues/fuzz/sqlite_wrapper_crash.test
@@ -1,0 +1,14 @@
+# name: test/issues/fuzz/sqlite_wrapper_crash.test
+# description: Issue #3353: NullPointer at sqlite3_api_wrapper.cpp:237:75
+# group: [fuzz]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE strings (a INTEGER DEFAULT -1, b INTEGER DEFAULT -2, t0 INTEGER DEFAULT -3);
+
+statement ok
+DELETE FROM strings
+WHERE b IN (SELECT sum(a) FROM strings GROUP BY b)
+RETURNING *;

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -234,7 +234,7 @@ int sqlite3_step(sqlite3_stmt *pStmt) {
 		pStmt->current_row = -1;
 
 		auto statement_type = pStmt->prepared->GetStatementType();
-		if (StatementTypeReturnChanges(statement_type) && pStmt->current_chunk->size() > 0) {
+		if (StatementTypeReturnChanges(statement_type) && pStmt->current_chunk && pStmt->current_chunk->size() > 0) {
 			// update total changes
 			auto row_changes = pStmt->current_chunk->GetValue(0, 0);
 			if (!row_changes.IsNull() && row_changes.TryCastAs(LogicalType::BIGINT)) {


### PR DESCRIPTION
Fixes #3353