### PR TITLE
Fix #3367: correctly detect overflow in statistics propagation for ORDER BY

### DIFF
--- a/test/issues/fuzz/stats_propagation_overflow.test
+++ b/test/issues/fuzz/stats_propagation_overflow.test
@@ -1,0 +1,21 @@
+# name: test/issues/fuzz/stats_propagation_overflow.test
+# description: Issue #3367: signed integer overflow at propagate_and_compress.cpp:79:37
+# group: [fuzz]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE test(a BIGINT);
+
+statement ok
+INSERT INTO test VALUES(-5361272612100082873);
+
+statement ok
+INSERT INTO test VALUES(3877673001272535186);
+
+query I
+SELECT a FROM test ORDER BY 1;
+----
+-5361272612100082873
+3877673001272535186


### PR DESCRIPTION
Fixes #3367