### PR TITLE
Fix #3366: check for invalid double values in progress bar

### DIFF
--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -84,6 +84,9 @@ bool Pipeline::GetProgressInternal(ClientContext &context, PhysicalOperator *op,
 			if (!GetProgressInternal(context, op_child.get(), child_percentage)) {
 				return false;
 			}
+			if (!Value::DoubleIsFinite(child_percentage)) {
+				return false;
+			}
 			progress.push_back(child_percentage);
 			cardinality.push_back(op_child->estimated_cardinality);
 			total_cardinality += op_child->estimated_cardinality;

--- a/test/issues/fuzz/nan_progress.test
+++ b/test/issues/fuzz/nan_progress.test
@@ -1,0 +1,17 @@
+# name: test/issues/fuzz/nan_progress.test
+# description: Issue 3366: NaN in progress bar
+# group: [fuzz]
+
+statement ok
+SET enable_progress_bar=true;
+
+statement ok
+WITH RECURSIVE t AS
+(
+	SELECT 1 AS x
+UNION
+	SELECT t1.x + t2.x + t3.x AS x
+	FROM t t1, t t2, t t3
+	WHERE t1.x < 100
+)
+SELECT * FROM t ORDER BY 1;


### PR DESCRIPTION
Fixes #3366 