### PR TITLE
removed -k param for gzip

### DIFF
--- a/scripts/extension-upload.sh
+++ b/scripts/extension-upload.sh
@@ -7,6 +7,6 @@ for f in $FILES
 do
 	ext=`basename $f .duckdb_extension`
 	echo $ext
-	gzip -k -f $f
+	gzip < $f > "$f.gz"
 	aws s3 cp $f.gz s3://duckdb-extensions/`git log -1 --format=%h`/$1/$ext.duckdb_extension.gz --acl public-read
 done


### PR DESCRIPTION
Apparently Centos 7 Gzip does not have a -k argument causing the extension upload script to fail on master currently. Using shell redirection should fix this