### PR TITLE
replace gcc version check with cxx abi check

### DIFF
--- a/src/function/table/version/pragma_version.cpp
+++ b/src/function/table/version/pragma_version.cpp
@@ -71,7 +71,7 @@ string DuckDB::Platform() {
 	arch = "arm64";
 #endif
 
-#if defined(__GNUC__) && __GNUC__ == 4
+#if !defined(_GLIBCXX_USE_CXX11_ABI) || _GLIBCXX_USE_CXX11_ABI == 0
 	if (os == "linux") {
 		postfix = "_gcc4";
 	}


### PR DESCRIPTION
This PR aims to make the python builds load the correct extension binaries. We need to add a test to the CI for this still

@Mytherin 