### PR TITLE
Missing libffi-dev

### DIFF
--- a/.github/actions/ubuntu_16_setup/action.yml
+++ b/.github/actions/ubuntu_16_setup/action.yml
@@ -14,7 +14,7 @@ runs:
         apt-get install -y -qq software-properties-common
         add-apt-repository ppa:git-core/ppa
         apt-get update -y -qq
-        apt-get install -y -qq ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall
+        apt-get install -y -qq ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev
 
     - name: Install Git 2.18.5
       shell: bash


### PR DESCRIPTION
Accidentally removed in #3422, necessary for the aws client to work