### PR TITLE
Avoid throwing Exception in JDBC Connection.setCatalog()

### DIFF
--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBConnection.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBConnection.java
@@ -173,7 +173,7 @@ public class DuckDBConnection implements java.sql.Connection {
 	}
 
 	public void setCatalog(String catalog) throws SQLException {
-		throw new SQLFeatureNotSupportedException();
+		// not supported => no-op
 	}
 
 	public String getCatalog() throws SQLException {

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -1822,6 +1822,12 @@ public class TestDuckDBJDBC {
 		conn.close();
 	}
 
+	public static void test_set_catalog() throws Exception {
+		Connection conn = (DuckDBConnection) DriverManager.getConnection("jdbc:duckdb:");
+		conn.setCatalog("we do not have this feature yet, sorry"); // Should be no-op until implemented
+		conn.close();
+	}
+
 	public static void test_get_table_types_bug1258() throws Exception {
 		Connection conn = (DuckDBConnection) DriverManager.getConnection("jdbc:duckdb:");
 		Statement stmt = conn.createStatement();


### PR DESCRIPTION
This PR changes the setCatalog() behavior to not throw an exception, but do nothing as described in Java docs: 
https://docs.oracle.com/en/java/javase/17/docs/api/java.sql/java/sql/Connection.html#setCatalog(java.lang.String)

This came up here: #3322