### PR TITLE
Change the granularity of SetAllValid/SetAllInvalid of validity_mask to bit, fix #3127

### DIFF
--- a/src/include/duckdb/common/types/validity_mask.hpp
+++ b/src/include/duckdb/common/types/validity_mask.hpp
@@ -247,27 +247,27 @@ public:
 	}
 
 	inline void SetAll(idx_t count, bool valid, V v) {
-        if (count == 0) {
-            return;
-        }
+		if (count == 0) {
+			return;
+		}
 		EnsureWritable();
 		auto entry_count = ValidityBuffer::EntryCount(count);
 		for (idx_t i = 0; i < entry_count - 1; i++) {
 			validity_mask[i] = v;
 		}
 		for (idx_t i = (entry_count - 1) * BITS_PER_VALUE; i < count; i++) {
-		    Set(i, valid);
+			Set(i, valid);
 		}
 	}
 
 	//! Marks exactly "count" bits in the validity mask as invalid (null)
 	inline void SetAllInvalid(idx_t count) {
-	    SetAll(count, false, 0);
+		SetAll(count, false, 0);
 	}
 
 	//! Marks exactly "count" bits in the validity mask as valid (not null)
 	inline void SetAllValid(idx_t count) {
-        SetAll(count, true, ValidityBuffer::MAX_ENTRY);
+		SetAll(count, true, ValidityBuffer::MAX_ENTRY);
 	}
 
 	inline bool IsMaskSet() const {

--- a/src/include/duckdb/common/types/validity_mask.hpp
+++ b/src/include/duckdb/common/types/validity_mask.hpp
@@ -171,6 +171,13 @@ public:
 		entry_idx = row_idx / BITS_PER_VALUE;
 		idx_in_entry = row_idx % BITS_PER_VALUE;
 	}
+	//! Get an entry that has first-n bits set as valid and rest set as invalid
+    static inline V EntryWithValidBits(idx_t n) {
+        if (n == 0) {
+            return V(0);
+        }
+        return ValidityBuffer::MAX_ENTRY >> (BITS_PER_VALUE - n);
+    }
 
 	//! RowIsValidUnsafe should only be used if AllValid() is false: it achieves the same as RowIsValid but skips a
 	//! not-null check
@@ -246,28 +253,33 @@ public:
 		}
 	}
 
-	inline void SetAll(idx_t count, bool valid, V v) {
+	//! Marks exactly "count" bits in the validity mask as invalid (null)
+	inline void SetAllInvalid(idx_t count) {
+		EnsureWritable();
 		if (count == 0) {
 			return;
 		}
-		EnsureWritable();
-		auto entry_count = ValidityBuffer::EntryCount(count);
-		for (idx_t i = 0; i < entry_count - 1; i++) {
-			validity_mask[i] = v;
+		auto last_entry_index = ValidityBuffer::EntryCount(count) - 1;
+		for (idx_t i = 0; i < last_entry_index; i++) {
+			validity_mask[i] = 0;
 		}
-		for (idx_t i = (entry_count - 1) * BITS_PER_VALUE; i < count; i++) {
-			Set(i, valid);
-		}
-	}
-
-	//! Marks exactly "count" bits in the validity mask as invalid (null)
-	inline void SetAllInvalid(idx_t count) {
-		SetAll(count, false, 0);
+		auto last_entry_bits = count % static_cast<idx_t>(BITS_PER_VALUE);
+		validity_mask[last_entry_index] = (last_entry_bits == 0) ? 0 : (ValidityBuffer::MAX_ENTRY << (last_entry_bits));
 	}
 
 	//! Marks exactly "count" bits in the validity mask as valid (not null)
 	inline void SetAllValid(idx_t count) {
-		SetAll(count, true, ValidityBuffer::MAX_ENTRY);
+		EnsureWritable();
+		if (count == 0) {
+			return;
+		}
+		auto last_entry_index = ValidityBuffer::EntryCount(count) - 1;
+		for (idx_t i = 0; i < last_entry_index; i++) {
+			validity_mask[i] = ValidityBuffer::MAX_ENTRY;
+		}
+		auto last_entry_bits = count % static_cast<idx_t>(BITS_PER_VALUE);
+		validity_mask[last_entry_index] |= (last_entry_bits == 0) ?
+		    ValidityBuffer::MAX_ENTRY : ~(ValidityBuffer::MAX_ENTRY << (last_entry_bits));
 	}
 
 	inline bool IsMaskSet() const {

--- a/src/include/duckdb/common/types/validity_mask.hpp
+++ b/src/include/duckdb/common/types/validity_mask.hpp
@@ -172,12 +172,12 @@ public:
 		idx_in_entry = row_idx % BITS_PER_VALUE;
 	}
 	//! Get an entry that has first-n bits set as valid and rest set as invalid
-    static inline V EntryWithValidBits(idx_t n) {
-        if (n == 0) {
-            return V(0);
-        }
-        return ValidityBuffer::MAX_ENTRY >> (BITS_PER_VALUE - n);
-    }
+	static inline V EntryWithValidBits(idx_t n) {
+		if (n == 0) {
+			return V(0);
+		}
+		return ValidityBuffer::MAX_ENTRY >> (BITS_PER_VALUE - n);
+	}
 
 	//! RowIsValidUnsafe should only be used if AllValid() is false: it achieves the same as RowIsValid but skips a
 	//! not-null check
@@ -278,8 +278,8 @@ public:
 			validity_mask[i] = ValidityBuffer::MAX_ENTRY;
 		}
 		auto last_entry_bits = count % static_cast<idx_t>(BITS_PER_VALUE);
-		validity_mask[last_entry_index] |= (last_entry_bits == 0) ?
-		    ValidityBuffer::MAX_ENTRY : ~(ValidityBuffer::MAX_ENTRY << (last_entry_bits));
+		validity_mask[last_entry_index] |=
+		    (last_entry_bits == 0) ? ValidityBuffer::MAX_ENTRY : ~(ValidityBuffer::MAX_ENTRY << (last_entry_bits));
 	}
 
 	inline bool IsMaskSet() const {

--- a/src/include/duckdb/common/types/validity_mask.hpp
+++ b/src/include/duckdb/common/types/validity_mask.hpp
@@ -246,20 +246,28 @@ public:
 		}
 	}
 
-	//! Marks "count" entries in the validity mask as invalid (null)
-	inline void SetAllInvalid(idx_t count) {
+	inline void SetAll(idx_t count, bool valid, V v) {
+        if (count == 0) {
+            return;
+        }
 		EnsureWritable();
-		for (idx_t i = 0; i < ValidityBuffer::EntryCount(count); i++) {
-			validity_mask[i] = 0;
+		auto entry_count = ValidityBuffer::EntryCount(count);
+		for (idx_t i = 0; i < entry_count - 1; i++) {
+			validity_mask[i] = v;
+		}
+		for (idx_t i = (entry_count - 1) * BITS_PER_VALUE; i < count; i++) {
+		    Set(i, valid);
 		}
 	}
 
-	//! Marks "count" entries in the validity mask as valid (not null)
+	//! Marks exactly "count" bits in the validity mask as invalid (null)
+	inline void SetAllInvalid(idx_t count) {
+	    SetAll(count, false, 0);
+	}
+
+	//! Marks exactly "count" bits in the validity mask as valid (not null)
 	inline void SetAllValid(idx_t count) {
-		EnsureWritable();
-		for (idx_t i = 0; i < ValidityBuffer::EntryCount(count); i++) {
-			validity_mask[i] = ValidityBuffer::MAX_ENTRY;
-		}
+        SetAll(count, true, ValidityBuffer::MAX_ENTRY);
 	}
 
 	inline bool IsMaskSet() const {

--- a/test/issues/general/test_3127.test
+++ b/test/issues/general/test_3127.test
@@ -1,0 +1,25 @@
+# name: test/issues/general/test_3127.test
+# description: Issue 3127: Transactional INSERT + ALTER TABLE ADD COLUMN + INSERT erases data values written to new column
+# group: [general]
+
+statement ok
+CREATE TABLE test(i INTEGER, j INTEGER)
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+INSERT INTO test VALUES (1, 1), (2, 2)
+
+statement ok
+ALTER TABLE test ADD COLUMN k INTEGER
+
+statement ok
+INSERT INTO test VALUES (3, 3, 3)
+
+query III
+SELECT * FROM test
+----
+1	1	NULL
+2	2	NULL
+3	3	3


### PR DESCRIPTION
Currently `ValidityMask::SetAllInvalid(count)` sets all entries through the entry in which the `count`th bit is located to `invalid`, this becomes the cause of #3127. 

More specifically, what happens in #3127 is as follow:
1. `CREATE TABLE test(col1 bigint)`
2. `BEGIN TRANSACTION`
3. `INSERT INTO test VALUES (111)` --> `LocalStorage` creates `LocalTableStorage` corresponding to `test` and insert row of `111`
4. `ALTER TABLE test ADD COLUMN col2 bigint` --> `LocalStorage::AddColumn` is called to add `Vector` of `col2` to each chunk of `ChunkCollection`. The `Vector` is the result of `default_value` expression, which is `Null`. It then got `Normalify`, in this call, the **whole validity entry** that contains `111` row inserted in step `3` is set to invalid, making all bits in that entry following the bit to invalid.
4. `INSERT INTO test VALUES (222, 123)` --> the value `123` did get inserted, but since the validity is invalid, it can't be read.

This PR changes `ValidityMask::SetAllInvalid(count)` and `ValidityMask::SetAllValid(count)` to work on exactly `count` bits instead of `entry`, it also contains the [test](https://github.com/duckdb/duckdb/pull/3131) that [@aarashy](https://github.com/aarashy) pushed to reproduce the issue.