### PR TITLE
Add C API functions to build list/map types and read map types

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -1000,6 +1000,10 @@ This should not be used with `DUCKDB_TYPE_DECIMAL`.
 */
 DUCKDB_API duckdb_logical_type duckdb_create_logical_type(duckdb_type type);
 
+DUCKDB_API duckdb_logical_type duckdb_create_list_logical_type(duckdb_logical_type type);
+DUCKDB_API duckdb_logical_type duckdb_create_map_logical_type(duckdb_logical_type key_type,
+                                                              duckdb_logical_type value_type);
+
 /*!
 Creates a `duckdb_logical_type` of type decimal with the specified width and scale
 The resulting type should be destroyed with `duckdb_destroy_logical_type`.
@@ -1078,6 +1082,9 @@ The result must be freed with `duckdb_destroy_logical_type`
 * returns: The child type of the list type. Must be destroyed with `duckdb_destroy_logical_type`.
 */
 DUCKDB_API duckdb_logical_type duckdb_list_type_child_type(duckdb_logical_type type);
+
+DUCKDB_API duckdb_logical_type duckdb_map_type_key_type(duckdb_logical_type type);
+DUCKDB_API duckdb_logical_type duckdb_map_type_value_type(duckdb_logical_type type);
 
 /*!
 Returns the number of children of a struct type.

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -1000,9 +1000,23 @@ This should not be used with `DUCKDB_TYPE_DECIMAL`.
 */
 DUCKDB_API duckdb_logical_type duckdb_create_logical_type(duckdb_type type);
 
-DUCKDB_API duckdb_logical_type duckdb_create_list_logical_type(duckdb_logical_type type);
-DUCKDB_API duckdb_logical_type duckdb_create_map_logical_type(duckdb_logical_type key_type,
-                                                              duckdb_logical_type value_type);
+/*!
+Creates a list type from its child type.
+The resulting type should be destroyed with `duckdb_destroy_logical_type`.
+
+* type: The child type of list type to create.
+* returns: The logical type.
+*/
+DUCKDB_API duckdb_logical_type duckdb_create_list_type(duckdb_logical_type type);
+
+/*!
+Creates a map type from its key type and value type.
+The resulting type should be destroyed with `duckdb_destroy_logical_type`.
+
+* type: The key type and value type of map type to create.
+* returns: The logical type.
+*/
+DUCKDB_API duckdb_logical_type duckdb_create_map_type(duckdb_logical_type key_type, duckdb_logical_type value_type);
 
 /*!
 Creates a `duckdb_logical_type` of type decimal with the specified width and scale
@@ -1083,7 +1097,24 @@ The result must be freed with `duckdb_destroy_logical_type`
 */
 DUCKDB_API duckdb_logical_type duckdb_list_type_child_type(duckdb_logical_type type);
 
+/*!
+Retrieves the key type of the given map type.
+
+The result must be freed with `duckdb_destroy_logical_type`
+
+* type: The logical type object
+* returns: The key type of the map type. Must be destroyed with `duckdb_destroy_logical_type`.
+*/
 DUCKDB_API duckdb_logical_type duckdb_map_type_key_type(duckdb_logical_type type);
+
+/*!
+Retrieves the value type of the given map type.
+
+The result must be freed with `duckdb_destroy_logical_type`
+
+* type: The logical type object
+* returns: The value type of the map type. Must be destroyed with `duckdb_destroy_logical_type`.
+*/
 DUCKDB_API duckdb_logical_type duckdb_map_type_value_type(duckdb_logical_type type);
 
 /*!

--- a/src/main/capi/logical_types-c.cpp
+++ b/src/main/capi/logical_types-c.cpp
@@ -4,7 +4,7 @@ duckdb_logical_type duckdb_create_logical_type(duckdb_type type) {
 	return new duckdb::LogicalType(duckdb::ConvertCTypeToCPP(type));
 }
 
-duckdb_logical_type duckdb_create_list_logical_type(duckdb_logical_type type) {
+duckdb_logical_type duckdb_create_list_type(duckdb_logical_type type) {
 	if (!type) {
 		return nullptr;
 	}
@@ -13,7 +13,7 @@ duckdb_logical_type duckdb_create_list_logical_type(duckdb_logical_type type) {
 	return ltype;
 }
 
-duckdb_logical_type duckdb_create_map_logical_type(duckdb_logical_type key_type, duckdb_logical_type value_type) {
+duckdb_logical_type duckdb_create_map_type(duckdb_logical_type key_type, duckdb_logical_type value_type) {
 	if (!key_type || !value_type) {
 		return nullptr;
 	}

--- a/src/main/capi/logical_types-c.cpp
+++ b/src/main/capi/logical_types-c.cpp
@@ -4,6 +4,24 @@ duckdb_logical_type duckdb_create_logical_type(duckdb_type type) {
 	return new duckdb::LogicalType(duckdb::ConvertCTypeToCPP(type));
 }
 
+duckdb_logical_type duckdb_create_list_logical_type(duckdb_logical_type type) {
+	if (!type) {
+		return nullptr;
+	}
+	duckdb::LogicalType *ltype = new duckdb::LogicalType;
+	*ltype = duckdb::LogicalType::LIST(*(duckdb::LogicalType *)type);
+	return ltype;
+}
+
+duckdb_logical_type duckdb_create_map_logical_type(duckdb_logical_type key_type, duckdb_logical_type value_type) {
+	if (!key_type || !value_type) {
+		return nullptr;
+	}
+	duckdb::LogicalType *mtype = new duckdb::LogicalType;
+	*mtype = duckdb::LogicalType::MAP(*(duckdb::LogicalType *)key_type, *(duckdb::LogicalType *)value_type);
+	return mtype;
+}
+
 duckdb_logical_type duckdb_create_decimal_type(uint8_t width, uint8_t scale) {
 	return new duckdb::LogicalType(duckdb::LogicalType::DECIMAL(width, scale));
 }
@@ -121,6 +139,28 @@ duckdb_logical_type duckdb_list_type_child_type(duckdb_logical_type type) {
 		return nullptr;
 	}
 	return new duckdb::LogicalType(duckdb::ListType::GetChildType(ltype));
+}
+
+duckdb_logical_type duckdb_map_type_key_type(duckdb_logical_type type) {
+	if (!type) {
+		return nullptr;
+	}
+	auto &mtype = *((duckdb::LogicalType *)type);
+	if (mtype.id() != duckdb::LogicalTypeId::MAP) {
+		return nullptr;
+	}
+	return new duckdb::LogicalType(duckdb::MapType::KeyType(mtype));
+}
+
+duckdb_logical_type duckdb_map_type_value_type(duckdb_logical_type type) {
+	if (!type) {
+		return nullptr;
+	}
+	auto &mtype = *((duckdb::LogicalType *)type);
+	if (mtype.id() != duckdb::LogicalTypeId::MAP) {
+		return nullptr;
+	}
+	return new duckdb::LogicalType(duckdb::MapType::ValueType(mtype));
 }
 
 idx_t duckdb_struct_type_child_count(duckdb_logical_type type) {

--- a/test/api/capi/test_capi_data_chunk.cpp
+++ b/test/api/capi/test_capi_data_chunk.cpp
@@ -15,6 +15,7 @@ TEST_CASE("Test Logical Types C API", "[capi]") {
 	duckdb_logical_type list_type = duckdb_create_list_type(elem_type);
 	REQUIRE(duckdb_get_type_id(list_type) == DUCKDB_TYPE_LIST);
 	duckdb_logical_type elem_type_dup = duckdb_list_type_child_type(list_type);
+	REQUIRE(elem_type_dup != elem_type);
 	REQUIRE(duckdb_get_type_id(elem_type_dup) == duckdb_get_type_id(elem_type));
 	duckdb_destroy_logical_type(&elem_type);
 	duckdb_destroy_logical_type(&list_type);
@@ -27,6 +28,8 @@ TEST_CASE("Test Logical Types C API", "[capi]") {
 	REQUIRE(duckdb_get_type_id(map_type) == DUCKDB_TYPE_MAP);
 	duckdb_logical_type key_type_dup = duckdb_map_type_key_type(map_type);
 	duckdb_logical_type value_type_dup = duckdb_map_type_value_type(map_type);
+	REQUIRE(key_type_dup != key_type);
+	REQUIRE(value_type_dup != value_type);
 	REQUIRE(duckdb_get_type_id(key_type_dup) == duckdb_get_type_id(key_type));
 	REQUIRE(duckdb_get_type_id(value_type_dup) == duckdb_get_type_id(value_type));
 	duckdb_destroy_logical_type(&key_type);

--- a/test/api/capi/test_capi_data_chunk.cpp
+++ b/test/api/capi/test_capi_data_chunk.cpp
@@ -12,7 +12,7 @@ TEST_CASE("Test Logical Types C API", "[capi]") {
 
 	// list type
 	duckdb_logical_type elem_type = duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
-	duckdb_logical_type list_type = duckdb_create_list_logical_type(elem_type);
+	duckdb_logical_type list_type = duckdb_create_list_type(elem_type);
 	REQUIRE(duckdb_get_type_id(list_type) == DUCKDB_TYPE_LIST);
 	duckdb_logical_type elem_type_dup = duckdb_list_type_child_type(list_type);
 	REQUIRE(duckdb_get_type_id(elem_type_dup) == duckdb_get_type_id(elem_type));
@@ -23,7 +23,7 @@ TEST_CASE("Test Logical Types C API", "[capi]") {
 	// map type
 	duckdb_logical_type key_type = duckdb_create_logical_type(DUCKDB_TYPE_SMALLINT);
 	duckdb_logical_type value_type = duckdb_create_logical_type(DUCKDB_TYPE_DOUBLE);
-	duckdb_logical_type map_type = duckdb_create_map_logical_type(key_type, value_type);
+	duckdb_logical_type map_type = duckdb_create_map_type(key_type, value_type);
 	REQUIRE(duckdb_get_type_id(map_type) == DUCKDB_TYPE_MAP);
 	duckdb_logical_type key_type_dup = duckdb_map_type_key_type(map_type);
 	duckdb_logical_type value_type_dup = duckdb_map_type_value_type(map_type);

--- a/test/api/capi/test_capi_data_chunk.cpp
+++ b/test/api/capi/test_capi_data_chunk.cpp
@@ -10,6 +10,31 @@ TEST_CASE("Test Logical Types C API", "[capi]") {
 	duckdb_destroy_logical_type(&type);
 	duckdb_destroy_logical_type(&type);
 
+	// list type
+	duckdb_logical_type elem_type = duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
+	duckdb_logical_type list_type = duckdb_create_list_logical_type(elem_type);
+	REQUIRE(duckdb_get_type_id(list_type) == DUCKDB_TYPE_LIST);
+	duckdb_logical_type elem_type_dup = duckdb_list_type_child_type(list_type);
+	REQUIRE(duckdb_get_type_id(elem_type_dup) == duckdb_get_type_id(elem_type));
+	duckdb_destroy_logical_type(&elem_type);
+	duckdb_destroy_logical_type(&list_type);
+	duckdb_destroy_logical_type(&elem_type_dup);
+
+	// map type
+	duckdb_logical_type key_type = duckdb_create_logical_type(DUCKDB_TYPE_SMALLINT);
+	duckdb_logical_type value_type = duckdb_create_logical_type(DUCKDB_TYPE_DOUBLE);
+	duckdb_logical_type map_type = duckdb_create_map_logical_type(key_type, value_type);
+	REQUIRE(duckdb_get_type_id(map_type) == DUCKDB_TYPE_MAP);
+	duckdb_logical_type key_type_dup = duckdb_map_type_key_type(map_type);
+	duckdb_logical_type value_type_dup = duckdb_map_type_value_type(map_type);
+	REQUIRE(duckdb_get_type_id(key_type_dup) == duckdb_get_type_id(key_type));
+	REQUIRE(duckdb_get_type_id(value_type_dup) == duckdb_get_type_id(value_type));
+	duckdb_destroy_logical_type(&key_type);
+	duckdb_destroy_logical_type(&value_type);
+	duckdb_destroy_logical_type(&map_type);
+	duckdb_destroy_logical_type(&key_type_dup);
+	duckdb_destroy_logical_type(&value_type_dup);
+
 	duckdb_destroy_logical_type(nullptr);
 }
 


### PR DESCRIPTION
Add several C API functions to build list/map types and read map types.

If the naming and implementation are approved, I will add docstrings to these API functions in `duckdb.h`.