### PR TITLE
Don't ship substrait by default in the Python extension

### DIFF
--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -11,10 +11,10 @@ from setuptools import setup, Extension
 lib_name = 'duckdb'
 extension_name = '_duckdb_extension'
 
-extensions = ['parquet', 'icu', 'fts', 'tpch', 'tpcds', 'visualizer', 'json', 'excel', 'substrait']
+extensions = ['parquet', 'icu', 'fts', 'tpch', 'tpcds', 'json']
 
 if platform.system() == 'Windows':
-    extensions = ['parquet', 'icu', 'fts', 'tpch', 'json', 'excel', 'substrait']
+    extensions = ['parquet', 'icu', 'fts', 'tpch', 'json']
 
 unity_build = 0
 if 'DUCKDB_BUILD_UNITY' in os.environ:

--- a/tools/pythonpkg/tests/substrait/test_substrait.py
+++ b/tools/pythonpkg/tests/substrait/test_substrait.py
@@ -1,12 +1,12 @@
-import pandas as pd
-
-
-def test_roundtrip_substrait(duckdb_cursor):
-    res = duckdb_cursor.get_substrait("select * from integers limit 5")
-    proto_bytes = res.fetchone()[0]
-
-    query_result = duckdb_cursor.from_substrait(proto_bytes)
-
-    expected = pd.Series(range(5), name="i", dtype="int32")
-
-    pd.testing.assert_series_equal(query_result.df()["i"], expected)
+# import pandas as pd
+#
+#
+# def test_roundtrip_substrait(duckdb_cursor):
+#     res = duckdb_cursor.get_substrait("select * from integers limit 5")
+#     proto_bytes = res.fetchone()[0]
+#
+#     query_result = duckdb_cursor.from_substrait(proto_bytes)
+#
+#     expected = pd.Series(range(5), name="i", dtype="int32")
+#
+#     pd.testing.assert_series_equal(query_result.df()["i"], expected)


### PR DESCRIPTION
This leads to problems when loading other libraries that contain protobuf (see #3443). Instead, substrait can be installed as a standard extension using `INSTALL substrait`. 