### PR TITLE
Force aggregates to have a Combine method, expose bind data in combine & general bind data clean up

### DIFF
--- a/examples/standalone-plan/main.cpp
+++ b/examples/standalone-plan/main.cpp
@@ -187,7 +187,7 @@ void CreateAggregateFunction(Connection &con, string name, vector<LogicalType> a
 //===--------------------------------------------------------------------===//
 // Custom Table Scan Function
 //===--------------------------------------------------------------------===//
-struct MyBindData : public FunctionData {
+struct MyBindData : public TableFunctionData {
 	MyBindData(string name_p) : table_name(move(name_p)) {
 	}
 

--- a/extension/icu/icu-datefunc.cpp
+++ b/extension/icu/icu-datefunc.cpp
@@ -35,12 +35,12 @@ ICUDateFunc::BindData::BindData(ClientContext &context) {
 	}
 }
 
-bool ICUDateFunc::BindData::Equals(FunctionData &other_p) {
-	auto &other = (BindData &)other_p;
-	return FunctionData::Equals(other_p) && *calendar == *other.calendar;
+bool ICUDateFunc::BindData::Equals(const FunctionData &other_p) const {
+	auto &other = (const ICUDateFunc::BindData &)other_p;
+	return *calendar == *other.calendar;
 }
 
-unique_ptr<FunctionData> ICUDateFunc::BindData::Copy() {
+unique_ptr<FunctionData> ICUDateFunc::BindData::Copy() const {
 	return make_unique<BindData>(*this);
 }
 

--- a/extension/icu/icu-datepart.cpp
+++ b/extension/icu/icu-datepart.cpp
@@ -217,12 +217,12 @@ struct ICUDatePart : public ICUDateFunc {
 
 		adapters_t adapters;
 
-		bool Equals(FunctionData &other_p) override {
+		bool Equals(const FunctionData &other_p) const override {
 			const auto &other = (BindAdapterData &)other_p;
 			return BindData::Equals(other_p) && adapters == other.adapters;
 		}
 
-		unique_ptr<FunctionData> Copy() override {
+		unique_ptr<FunctionData> Copy() const override {
 			return make_unique<BindAdapterData>(*this);
 		}
 	};
@@ -414,7 +414,8 @@ struct ICUDatePart : public ICUDateFunc {
 	static ScalarFunction GetStructFunction(const LogicalType &temporal_type) {
 		auto part_type = LogicalType::LIST(LogicalType::VARCHAR);
 		auto result_type = LogicalType::STRUCT({});
-		return ScalarFunction({part_type, temporal_type}, result_type, StructFunction<INPUT_TYPE>, false, false, BindStruct);
+		return ScalarFunction({part_type, temporal_type}, result_type, StructFunction<INPUT_TYPE>, false, false,
+		                      BindStruct);
 	}
 
 	static void AddDatePartFunctions(const string &name, ClientContext &context) {
@@ -434,8 +435,8 @@ struct ICUDatePart : public ICUDateFunc {
 
 	template <typename INPUT_TYPE>
 	static ScalarFunction GetLastDayFunction(const LogicalType &temporal_type) {
-		return ScalarFunction({temporal_type}, LogicalType::DATE, UnaryTimestampFunction<INPUT_TYPE, date_t>, false, false,
-		                      BindLastDate);
+		return ScalarFunction({temporal_type}, LogicalType::DATE, UnaryTimestampFunction<INPUT_TYPE, date_t>, false,
+		                      false, BindLastDate);
 	}
 	static void AddLastDayFunctions(const string &name, ClientContext &context) {
 		auto &catalog = Catalog::GetCatalog(context);

--- a/extension/icu/icu-extension.cpp
+++ b/extension/icu/icu-extension.cpp
@@ -45,8 +45,13 @@ struct IcuBindData : public FunctionData {
 		}
 	}
 
-	unique_ptr<FunctionData> Copy() override {
+	unique_ptr<FunctionData> Copy() const override {
 		return make_unique<IcuBindData>(language, country);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (IcuBindData &)other_p;
+		return language == other.language && country == other.country;
 	}
 };
 

--- a/extension/icu/include/icu-datefunc.hpp
+++ b/extension/icu/include/icu-datefunc.hpp
@@ -25,8 +25,8 @@ struct ICUDateFunc {
 
 		CalendarPtr calendar;
 
-		bool Equals(FunctionData &other_p) override;
-		unique_ptr<FunctionData> Copy() override;
+		bool Equals(const FunctionData &other_p) const override;
+		unique_ptr<FunctionData> Copy() const override;
 	};
 
 	//! Binds a default calendar object for use by the function

--- a/extension/json/include/json_common.hpp
+++ b/extension/json/include/json_common.hpp
@@ -20,7 +20,8 @@ namespace duckdb {
 struct JSONReadFunctionData : public FunctionData {
 public:
 	JSONReadFunctionData(bool constant, string path_p, idx_t len);
-	unique_ptr<FunctionData> Copy() override;
+	unique_ptr<FunctionData> Copy() const override;
+	bool Equals(const FunctionData &other_p) const override;
 	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
 	                                     vector<unique_ptr<Expression>> &arguments);
 
@@ -34,7 +35,8 @@ public:
 struct JSONReadManyFunctionData : public FunctionData {
 public:
 	JSONReadManyFunctionData(vector<string> paths_p, vector<size_t> lens_p);
-	unique_ptr<FunctionData> Copy() override;
+	unique_ptr<FunctionData> Copy() const override;
+	bool Equals(const FunctionData &other_p) const override;
 	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
 	                                     vector<unique_ptr<Expression>> &arguments);
 

--- a/extension/json/json_common.cpp
+++ b/extension/json/json_common.cpp
@@ -37,7 +37,7 @@ unique_ptr<FunctionData> JSONReadFunctionData::Copy() const {
 
 bool JSONReadFunctionData::Equals(const FunctionData &other_p) const {
 	auto &other = (const JSONReadFunctionData &)other_p;
-	return constant == other.constant && path == other.path && ptr == other.ptr && len == other.len;
+	return constant == other.constant && path == other.path && len == other.len;
 }
 
 unique_ptr<FunctionData> JSONReadFunctionData::Bind(ClientContext &context, ScalarFunction &bound_function,
@@ -67,7 +67,7 @@ unique_ptr<FunctionData> JSONReadManyFunctionData::Copy() const {
 
 bool JSONReadManyFunctionData::Equals(const FunctionData &other_p) const {
 	auto &other = (const JSONReadManyFunctionData &)other_p;
-	return paths == other.paths && ptrs == other.ptrs && lens == other.lens;
+	return paths == other.paths && lens == other.lens;
 }
 
 unique_ptr<FunctionData> JSONReadManyFunctionData::Bind(ClientContext &context, ScalarFunction &bound_function,

--- a/extension/json/json_common.cpp
+++ b/extension/json/json_common.cpp
@@ -31,8 +31,13 @@ JSONReadFunctionData::JSONReadFunctionData(bool constant, string path_p, idx_t l
     : constant(constant), path(move(path_p)), ptr(path.c_str()), len(len) {
 }
 
-unique_ptr<FunctionData> JSONReadFunctionData::Copy() {
+unique_ptr<FunctionData> JSONReadFunctionData::Copy() const {
 	return make_unique<JSONReadFunctionData>(constant, path, len);
+}
+
+bool JSONReadFunctionData::Equals(const FunctionData &other_p) const {
+	auto &other = (const JSONReadFunctionData &)other_p;
+	return constant == other.constant && path == other.path && ptr == other.ptr && len == other.len;
 }
 
 unique_ptr<FunctionData> JSONReadFunctionData::Bind(ClientContext &context, ScalarFunction &bound_function,
@@ -56,8 +61,13 @@ JSONReadManyFunctionData::JSONReadManyFunctionData(vector<string> paths_p, vecto
 	}
 }
 
-unique_ptr<FunctionData> JSONReadManyFunctionData::Copy() {
+unique_ptr<FunctionData> JSONReadManyFunctionData::Copy() const {
 	return make_unique<JSONReadManyFunctionData>(paths, lens);
+}
+
+bool JSONReadManyFunctionData::Equals(const FunctionData &other_p) const {
+	auto &other = (const JSONReadManyFunctionData &)other_p;
+	return paths == other.paths && ptrs == other.ptrs && lens == other.lens;
 }
 
 unique_ptr<FunctionData> JSONReadManyFunctionData::Bind(ClientContext &context, ScalarFunction &bound_function,

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -8,7 +8,7 @@ public:
 	JSONCreateFunctionData(unordered_map<string, unique_ptr<Vector>> const_struct_names)
 	    : const_struct_names(move(const_struct_names)) {
 	}
-	unique_ptr<FunctionData> Copy() override {
+	unique_ptr<FunctionData> Copy() const override {
 		// Have to do this because we can't implicitly copy Vector
 		unordered_map<string, unique_ptr<Vector>> map_copy;
 		for (const auto &kv : const_struct_names) {
@@ -16,6 +16,9 @@ public:
 			map_copy[kv.first] = make_unique<Vector>(Value(kv.first));
 		}
 		return make_unique<JSONCreateFunctionData>(move(map_copy));
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		return false;
 	}
 
 public:

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -18,7 +18,7 @@ public:
 		return make_unique<JSONCreateFunctionData>(move(map_copy));
 	}
 	bool Equals(const FunctionData &other_p) const override {
-		return false;
+		return true;
 	}
 
 public:

--- a/extension/parquet/parquet-extension.cpp
+++ b/extension/parquet/parquet-extension.cpp
@@ -36,7 +36,7 @@
 
 namespace duckdb {
 
-struct ParquetReadBindData : public FunctionData {
+struct ParquetReadBindData : public TableFunctionData {
 	shared_ptr<ParquetReader> initial_reader;
 	vector<string> files;
 	vector<column_t> column_ids;
@@ -389,7 +389,7 @@ public:
 	}
 };
 
-struct ParquetWriteBindData : public FunctionData {
+struct ParquetWriteBindData : public TableFunctionData {
 	vector<LogicalType> sql_types;
 	string file_name;
 	vector<string> column_names;

--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -10,7 +10,7 @@
 
 namespace duckdb {
 
-struct ParquetMetaDataBindData : public FunctionData {
+struct ParquetMetaDataBindData : public TableFunctionData {
 	vector<LogicalType> return_types;
 	vector<string> files;
 };

--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -13,6 +13,12 @@ namespace duckdb {
 struct ParquetMetaDataBindData : public TableFunctionData {
 	vector<LogicalType> return_types;
 	vector<string> files;
+
+public:
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const ParquetMetaDataBindData &)other_p;
+		return other.return_types == return_types && files == other.files;
+	}
 };
 
 struct ParquetMetaDataOperatorData : public FunctionOperatorData {

--- a/src/common/row_operations/row_aggregate.cpp
+++ b/src/common/row_operations/row_aggregate.cpp
@@ -78,7 +78,7 @@ void RowOperations::CombineStates(RowLayout &layout, Vector &sources, Vector &ta
 	VectorOperations::AddInPlace(targets, layout.GetAggrOffset(), count);
 	for (auto &aggr : layout.GetAggregates()) {
 		D_ASSERT(aggr.function.combine);
-		aggr.function.combine(sources, targets, count);
+		aggr.function.combine(sources, targets, aggr.bind_data, count);
 
 		// Move to the next aggregate states
 		VectorOperations::AddInPlace(sources, aggr.payload_size, count);

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -1764,6 +1764,10 @@ void Value::Print() const {
 	Printer::Print(ToString());
 }
 
+bool Value::NotDistinctFrom(const Value &lvalue, const Value &rvalue) {
+	return ValueOperations::NotDistinctFrom(lvalue, rvalue);
+}
+
 bool Value::ValuesAreEqual(const Value &result_value, const Value &value) {
 	if (result_value.IsNull() != value.IsNull()) {
 		return false;

--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -3,6 +3,13 @@
 
 namespace duckdb {
 
+ExecuteFunctionState::ExecuteFunctionState(const Expression &expr, ExpressionExecutorState &root)
+    : ExpressionState(expr, root) {
+}
+
+ExecuteFunctionState::~ExecuteFunctionState() {
+}
+
 unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundFunctionExpression &expr,
                                                                 ExpressionExecutorState &root) {
 	auto result = make_unique<ExecuteFunctionState>(expr, root);

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -66,7 +66,7 @@ PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<Logi
 			payload_types_filters.push_back(aggr.filter->return_type);
 		}
 		if (!aggr.function.combine) {
-			throw InternalException("Hash function %s is missing a combine method", aggr.function.name);
+			throw InternalException("Aggregate function %s is missing a combine method", aggr.function.name);
 		}
 		aggregates.push_back(move(expr));
 	}

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -35,8 +35,7 @@ PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<Logi
                                              vector<vector<idx_t>> grouping_functions_p, idx_t estimated_cardinality,
                                              PhysicalOperatorType type)
     : PhysicalOperator(type, move(types), estimated_cardinality), groups(move(groups_p)),
-      grouping_sets(move(grouping_sets_p)), grouping_functions(move(grouping_functions_p)), all_combinable(true),
-      any_distinct(false) {
+      grouping_sets(move(grouping_sets_p)), grouping_functions(move(grouping_functions_p)), any_distinct(false) {
 	// get a list of all aggregates to be computed
 	for (auto &expr : groups) {
 		group_types.push_back(expr->return_type);
@@ -67,7 +66,7 @@ PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<Logi
 			payload_types_filters.push_back(aggr.filter->return_type);
 		}
 		if (!aggr.function.combine) {
-			all_combinable = false;
+			throw InternalException("Hash function %s is missing a combine method", aggr.function.name);
 		}
 		aggregates.push_back(move(expr));
 	}

--- a/src/execution/operator/aggregate/physical_simple_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_simple_aggregate.cpp
@@ -165,7 +165,7 @@ void PhysicalSimpleAggregate::Combine(ExecutionContext &context, GlobalSinkState
 		Vector source_state(Value::POINTER((uintptr_t)source.state.aggregates[aggr_idx].get()));
 		Vector dest_state(Value::POINTER((uintptr_t)gstate.state.aggregates[aggr_idx].get()));
 
-		aggregate.function.combine(source_state, dest_state, 1);
+		aggregate.function.combine(source_state, dest_state, aggregate.bind_info.get(), 1);
 	}
 
 	auto &client_profiler = QueryProfiler::Get(context.client);

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -133,7 +133,6 @@ void RadixPartitionedHashTable::Sink(ExecutionContext &context, GlobalSinkState 
 		return;
 	}
 
-	D_ASSERT(op.all_combinable);
 	D_ASSERT(!op.any_distinct);
 
 	if (group_chunk.size() > 0) {
@@ -174,7 +173,6 @@ void RadixPartitionedHashTable::Combine(ExecutionContext &context, GlobalSinkSta
 	}
 
 	lock_guard<mutex> glock(gstate.lock);
-	D_ASSERT(op.all_combinable);
 	D_ASSERT(!op.any_distinct);
 
 	if (!llstate.is_empty) {
@@ -299,7 +297,7 @@ void RadixPartitionedHashTable::ScheduleTasks(Executor &executor, const shared_p
 
 bool RadixPartitionedHashTable::ForceSingleHT(GlobalSinkState &state) const {
 	auto &gstate = (RadixHTGlobalState &)state;
-	return !op.all_combinable || op.any_distinct || gstate.partition_info.n_partitions < 2;
+	return op.any_distinct || gstate.partition_info.n_partitions < 2;
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/window_segment_tree.cpp
+++ b/src/execution/window_segment_tree.cpp
@@ -127,7 +127,7 @@ void WindowSegmentTree::WindowSegmentValue(idx_t l_idx, idx_t begin, idx_t end) 
 			pdata[i] = begin_ptr + i * state.size();
 		}
 		v.Verify(inputs.size());
-		aggregate.combine(v, s, inputs.size());
+		aggregate.combine(v, s, bind_info, inputs.size());
 	}
 }
 

--- a/src/function/aggregate/algebraic/avg.cpp
+++ b/src/function/aggregate/algebraic/avg.cpp
@@ -46,9 +46,14 @@ struct AverageDecimalBindData : public FunctionData {
 	double scale;
 
 public:
-	unique_ptr<FunctionData> Copy() override {
+	unique_ptr<FunctionData> Copy() const override {
 		return make_unique<AverageDecimalBindData>(scale);
 	};
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (AverageDecimalBindData &)other_p;
+		return scale == other.scale;
+	}
 };
 
 struct AverageSetOperation {

--- a/src/function/aggregate/algebraic/avg.cpp
+++ b/src/function/aggregate/algebraic/avg.cpp
@@ -57,7 +57,7 @@ struct AverageSetOperation {
 		state->Initialize();
 	}
 	template <class STATE>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		target->Combine(source);
 	}
 	template <class STATE>

--- a/src/function/aggregate/distributive/approx_count.cpp
+++ b/src/function/aggregate/distributive/approx_count.cpp
@@ -19,7 +19,7 @@ struct ApproxCountDistinctFunctionBase {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (!source.log) {
 			return;
 		}

--- a/src/function/aggregate/distributive/arg_min_max.cpp
+++ b/src/function/aggregate/distributive/arg_min_max.cpp
@@ -83,7 +83,7 @@ struct ArgMinMaxBase {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (!source.is_initialized) {
 			return;
 		}

--- a/src/function/aggregate/distributive/bitagg.cpp
+++ b/src/function/aggregate/distributive/bitagg.cpp
@@ -72,7 +72,7 @@ struct BitAndOperation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (!source.is_set) {
 			// source is NULL, nothing to do.
 			return;
@@ -132,7 +132,7 @@ struct BitOrOperation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (!source.is_set) {
 			// source is NULL, nothing to do.
 			return;
@@ -192,7 +192,7 @@ struct BitXorOperation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (!source.is_set) {
 			// source is NULL, nothing to do.
 			return;

--- a/src/function/aggregate/distributive/bool.cpp
+++ b/src/function/aggregate/distributive/bool.cpp
@@ -19,7 +19,7 @@ struct BoolAndFunFunction {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		target->val = target->val && source.val;
 		target->empty = target->empty && source.empty;
 	}
@@ -59,7 +59,7 @@ struct BoolOrFunFunction {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		target->val = target->val || source.val;
 		target->empty = target->empty && source.empty;
 	}

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -13,7 +13,7 @@ struct BaseCountFunction {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		*target += source;
 	}
 

--- a/src/function/aggregate/distributive/entropy.cpp
+++ b/src/function/aggregate/distributive/entropy.cpp
@@ -32,7 +32,7 @@ struct EntropyFunctionBase {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (!source.distinct) {
 			return;
 		}

--- a/src/function/aggregate/distributive/first.cpp
+++ b/src/function/aggregate/distributive/first.cpp
@@ -46,7 +46,7 @@ struct FirstFunction : public FirstFunctionBase {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (!target->is_set) {
 			*target = source;
 		}
@@ -97,7 +97,7 @@ struct FirstFunctionString : public FirstFunctionBase {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (source.is_set && (LAST || !target->is_set)) {
 			SetValue(target, source.value, source.is_null);
 		}
@@ -167,7 +167,7 @@ struct FirstVectorFunction {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (source.value && (LAST || !target->value)) {
 			SetValue(target, *source.value, 0);
 		}

--- a/src/function/aggregate/distributive/kurtosis.cpp
+++ b/src/function/aggregate/distributive/kurtosis.cpp
@@ -38,7 +38,7 @@ struct KurtosisOperation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (source.n == 0) {
 			return;
 		}

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -112,7 +112,7 @@ struct MinOperation : public NumericMinMaxBase {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (!source.isset) {
 			// source is NULL, nothing to do
 			return;
@@ -135,7 +135,7 @@ struct MaxOperation : public NumericMinMaxBase {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (!source.isset) {
 			// source is NULL, nothing to do
 			return;
@@ -182,7 +182,7 @@ struct StringMinMaxBase : public MinMaxBase {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (!source.isset) {
 			// source is NULL, nothing to do
 			return;
@@ -442,7 +442,7 @@ struct VectorMinMaxBase {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (!source.value) {
 			return;
 		} else if (!target->value) {

--- a/src/function/aggregate/distributive/product.cpp
+++ b/src/function/aggregate/distributive/product.cpp
@@ -19,7 +19,7 @@ struct ProductFunction {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		target->val *= source.val;
 		target->empty = target->empty && source.empty;
 	}

--- a/src/function/aggregate/distributive/skew.cpp
+++ b/src/function/aggregate/distributive/skew.cpp
@@ -36,7 +36,7 @@ struct SkewnessOperation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (source.n == 0) {
 			return;
 		}

--- a/src/function/aggregate/distributive/string_agg.cpp
+++ b/src/function/aggregate/distributive/string_agg.cpp
@@ -15,7 +15,7 @@ struct StringAggState {
 };
 
 struct StringAggBindData : public FunctionData {
-	StringAggBindData(string sep_p) : sep(move(sep_p)) {
+	explicit StringAggBindData(string sep_p) : sep(move(sep_p)) {
 	}
 
 	string sep;

--- a/src/function/aggregate/distributive/string_agg.cpp
+++ b/src/function/aggregate/distributive/string_agg.cpp
@@ -20,10 +20,10 @@ struct StringAggBindData : public FunctionData {
 
 	string sep;
 
-	unique_ptr<FunctionData> Copy() override {
+	unique_ptr<FunctionData> Copy() const override {
 		return make_unique<StringAggBindData>(sep);
 	}
-	bool Equals(FunctionData &other_p) override {
+	bool Equals(const FunctionData &other_p) const override {
 		auto &other = (StringAggBindData &)other_p;
 		return sep == other.sep;
 	}

--- a/src/function/aggregate/distributive/string_agg.cpp
+++ b/src/function/aggregate/distributive/string_agg.cpp
@@ -3,6 +3,8 @@
 #include "duckdb/common/types/null_value.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/common/algorithm.hpp"
+#include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
 
 namespace duckdb {
 
@@ -12,7 +14,22 @@ struct StringAggState {
 	char *dataptr;
 };
 
-struct StringAggBaseFunction {
+struct StringAggBindData : public FunctionData {
+	StringAggBindData(string sep_p) : sep(move(sep_p)) {
+	}
+
+	string sep;
+
+	unique_ptr<FunctionData> Copy() override {
+		return make_unique<StringAggBindData>(sep);
+	}
+	bool Equals(FunctionData &other_p) override {
+		auto &other = (StringAggBindData &)other_p;
+		return sep == other.sep;
+	}
+};
+
+struct StringAggFunction {
 	template <class STATE>
 	static void Initialize(STATE *state) {
 		state->dataptr = nullptr;
@@ -70,28 +87,15 @@ struct StringAggBaseFunction {
 		}
 	}
 
-	static inline void PerformOperation(StringAggState *state, string_t str, string_t sep) {
-		PerformOperation(state, str.GetDataUnsafe(), sep.GetDataUnsafe(), str.GetSize(), sep.GetSize());
+	static inline void PerformOperation(StringAggState *state, string_t str, FunctionData *data_p) {
+		auto &data = (StringAggBindData &)*data_p;
+		PerformOperation(state, str.GetDataUnsafe(), data.sep.c_str(), str.GetSize(), data.sep.size());
 	}
 
-	static inline void PerformOperation(StringAggState *state, string_t str) {
-		PerformOperation(state, str.GetDataUnsafe(), ",", str.GetSize(), 1);
-	}
-};
-
-struct StringAggFunction : public StringAggBaseFunction {
-	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, FunctionData *bind_data, A_TYPE *str_data, B_TYPE *sep_data,
-	                      ValidityMask &str_mask, ValidityMask &sep_mask, idx_t str_idx, idx_t sep_idx) {
-		PerformOperation(state, str_data[str_idx], sep_data[sep_idx]);
-	}
-};
-
-struct StringAggSingleFunction : public StringAggBaseFunction {
 	template <class INPUT_TYPE, class STATE, class OP>
 	static void Operation(STATE *state, FunctionData *bind_data, INPUT_TYPE *str_data, ValidityMask &str_mask,
 	                      idx_t str_idx) {
-		PerformOperation(state, str_data[str_idx]);
+		PerformOperation(state, str_data[str_idx], bind_data);
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
@@ -103,33 +107,52 @@ struct StringAggSingleFunction : public StringAggBaseFunction {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (!source.dataptr) {
 			// source is not set: skip combining
 			return;
 		}
-		PerformOperation(target, string_t(source.dataptr, source.size));
+		PerformOperation(target, string_t(source.dataptr, source.size), bind_data);
 	}
 };
 
+unique_ptr<FunctionData> StringAggBind(ClientContext &context, AggregateFunction &function,
+                                       vector<unique_ptr<Expression>> &arguments) {
+	if (arguments.size() == 1) {
+		// single argument: default to comma
+		return make_unique<StringAggBindData>(",");
+	}
+	D_ASSERT(arguments.size() == 2);
+	if (!arguments[1]->IsFoldable()) {
+		throw BinderException("Separator argument to StringAgg must be a constant");
+	}
+	auto separator_val = ExpressionExecutor::EvaluateScalar(*arguments[1]);
+	if (separator_val.IsNull()) {
+		arguments[0] = make_unique<BoundConstantExpression>(Value(LogicalType::VARCHAR));
+	}
+	function.arguments.erase(function.arguments.begin() + 1);
+	return make_unique<StringAggBindData>(separator_val.ToString());
+}
+
 void StringAggFun::RegisterFunction(BuiltinFunctions &set) {
 	AggregateFunctionSet string_agg("string_agg");
-	string_agg.AddFunction(AggregateFunction(
-	    {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
-	    AggregateFunction::StateSize<StringAggState>,
-	    AggregateFunction::StateInitialize<StringAggState, StringAggFunction>,
-	    AggregateFunction::BinaryScatterUpdate<StringAggState, string_t, string_t, StringAggFunction>, nullptr,
-	    AggregateFunction::StateFinalize<StringAggState, string_t, StringAggFunction>,
-	    AggregateFunction::BinaryUpdate<StringAggState, string_t, string_t, StringAggFunction>, nullptr,
-	    AggregateFunction::StateDestroy<StringAggState, StringAggFunction>, nullptr, nullptr));
+	string_agg.AddFunction(
+	    AggregateFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                      AggregateFunction::StateSize<StringAggState>,
+	                      AggregateFunction::StateInitialize<StringAggState, StringAggFunction>,
+	                      AggregateFunction::UnaryScatterUpdate<StringAggState, string_t, StringAggFunction>,
+	                      AggregateFunction::StateCombine<StringAggState, StringAggFunction>,
+	                      AggregateFunction::StateFinalize<StringAggState, string_t, StringAggFunction>,
+	                      AggregateFunction::UnaryUpdate<StringAggState, string_t, StringAggFunction>, StringAggBind,
+	                      AggregateFunction::StateDestroy<StringAggState, StringAggFunction>));
 	string_agg.AddFunction(
 	    AggregateFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, AggregateFunction::StateSize<StringAggState>,
-	                      AggregateFunction::StateInitialize<StringAggState, StringAggSingleFunction>,
-	                      AggregateFunction::UnaryScatterUpdate<StringAggState, string_t, StringAggSingleFunction>,
-	                      AggregateFunction::StateCombine<StringAggState, StringAggSingleFunction>,
-	                      AggregateFunction::StateFinalize<StringAggState, string_t, StringAggSingleFunction>,
-	                      AggregateFunction::UnaryUpdate<StringAggState, string_t, StringAggSingleFunction>, nullptr,
-	                      AggregateFunction::StateDestroy<StringAggState, StringAggSingleFunction>, nullptr, nullptr));
+	                      AggregateFunction::StateInitialize<StringAggState, StringAggFunction>,
+	                      AggregateFunction::UnaryScatterUpdate<StringAggState, string_t, StringAggFunction>,
+	                      AggregateFunction::StateCombine<StringAggState, StringAggFunction>,
+	                      AggregateFunction::StateFinalize<StringAggState, string_t, StringAggFunction>,
+	                      AggregateFunction::UnaryUpdate<StringAggState, string_t, StringAggFunction>, StringAggBind,
+	                      AggregateFunction::StateDestroy<StringAggState, StringAggFunction>));
 	set.AddFunction(string_agg);
 	string_agg.name = "group_concat";
 	set.AddFunction(string_agg);

--- a/src/function/aggregate/distributive/sum.cpp
+++ b/src/function/aggregate/distributive/sum.cpp
@@ -14,7 +14,7 @@ struct SumSetOperation {
 		state->Initialize();
 	}
 	template <class STATE>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		target->Combine(source);
 	}
 	template <class STATE>

--- a/src/function/aggregate/holistic/approximate_quantile.cpp
+++ b/src/function/aggregate/holistic/approximate_quantile.cpp
@@ -18,11 +18,11 @@ struct ApproximateQuantileBindData : public FunctionData {
 	explicit ApproximateQuantileBindData(float quantile_p) : quantile(quantile_p) {
 	}
 
-	unique_ptr<FunctionData> Copy() override {
+	unique_ptr<FunctionData> Copy() const override {
 		return make_unique<ApproximateQuantileBindData>(quantile);
 	}
 
-	bool Equals(FunctionData &other_p) override {
+	bool Equals(const FunctionData &other_p) const override {
 		auto &other = (ApproximateQuantileBindData &)other_p;
 		return quantile == other.quantile;
 	}

--- a/src/function/aggregate/holistic/approximate_quantile.cpp
+++ b/src/function/aggregate/holistic/approximate_quantile.cpp
@@ -57,7 +57,7 @@ struct ApproxQuantileOperation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (source.pos == 0) {
 			return;
 		}

--- a/src/function/aggregate/holistic/mode.cpp
+++ b/src/function/aggregate/holistic/mode.cpp
@@ -126,7 +126,7 @@ struct ModeFunction {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (!source.frequency_map) {
 			return;
 		}

--- a/src/function/aggregate/holistic/quantile.cpp
+++ b/src/function/aggregate/holistic/quantile.cpp
@@ -351,13 +351,13 @@ struct QuantileBindData : public FunctionData {
 		std::sort(order.begin(), order.end(), lt);
 	}
 
-	unique_ptr<FunctionData> Copy() override {
+	unique_ptr<FunctionData> Copy() const override {
 		return make_unique<QuantileBindData>(quantiles);
 	}
 
-	bool Equals(FunctionData &other_p) override {
+	bool Equals(const FunctionData &other_p) const override {
 		auto &other = (QuantileBindData &)other_p;
-		return quantiles == other.quantiles;
+		return quantiles == other.quantiles && order == other.order;
 	}
 
 	vector<double> quantiles;

--- a/src/function/aggregate/holistic/quantile.cpp
+++ b/src/function/aggregate/holistic/quantile.cpp
@@ -384,7 +384,7 @@ struct QuantileOperation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (source.v.empty()) {
 			return;
 		}

--- a/src/function/aggregate/holistic/reservoir_quantile.cpp
+++ b/src/function/aggregate/holistic/reservoir_quantile.cpp
@@ -97,7 +97,7 @@ struct ReservoirQuantileOperation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (source.pos == 0) {
 			return;
 		}

--- a/src/function/aggregate/holistic/reservoir_quantile.cpp
+++ b/src/function/aggregate/holistic/reservoir_quantile.cpp
@@ -40,13 +40,13 @@ struct ReservoirQuantileBindData : public FunctionData {
 	    : quantile(quantile_p), sample_size(sample_size_p) {
 	}
 
-	unique_ptr<FunctionData> Copy() override {
+	unique_ptr<FunctionData> Copy() const override {
 		return make_unique<ReservoirQuantileBindData>(quantile, sample_size);
 	}
 
-	bool Equals(FunctionData &other_p) override {
+	bool Equals(const FunctionData &other_p) const override {
 		auto &other = (ReservoirQuantileBindData &)other_p;
-		return quantile == other.quantile;
+		return quantile == other.quantile && sample_size == other.sample_size;
 	}
 
 	double quantile;

--- a/src/function/aggregate/nested/histogram.cpp
+++ b/src/function/aggregate/nested/histogram.cpp
@@ -78,7 +78,7 @@ static void HistogramUpdateFunctionString(Vector inputs[], FunctionData *, idx_t
 }
 
 template <class T>
-static void HistogramCombineFunction(Vector &state, Vector &combined, idx_t count) {
+static void HistogramCombineFunction(Vector &state, Vector &combined, FunctionData *bind_data, idx_t count) {
 	VectorData sdata;
 	state.Orrify(count, sdata);
 	auto states_ptr = (HistogramAggState<T> **)sdata.data;

--- a/src/function/aggregate/nested/list.cpp
+++ b/src/function/aggregate/nested/list.cpp
@@ -48,7 +48,7 @@ static void ListUpdateFunction(Vector inputs[], FunctionData *, idx_t input_coun
 	}
 }
 
-static void ListCombineFunction(Vector &state, Vector &combined, idx_t count) {
+static void ListCombineFunction(Vector &state, Vector &combined, FunctionData *bind_data, idx_t count) {
 	VectorData sdata;
 	state.Orrify(count, sdata);
 	auto states_ptr = (ListAggState **)sdata.data;

--- a/src/function/aggregate/nested/list.cpp
+++ b/src/function/aggregate/nested/list.cpp
@@ -109,8 +109,7 @@ unique_ptr<FunctionData> ListBindFunction(ClientContext &context, AggregateFunct
                                           vector<unique_ptr<Expression>> &arguments) {
 	D_ASSERT(arguments.size() == 1);
 	function.return_type = LogicalType::LIST(arguments[0]->return_type);
-	return make_unique<ListBindData>(); // TODO atm this is not used anywhere but it might not be required after all
-	                                    // except for sanity checking
+	return nullptr;
 }
 
 void ListFun::RegisterFunction(BuiltinFunctions &set) {

--- a/src/function/aggregate/regression/regr_avg.cpp
+++ b/src/function/aggregate/regression/regr_avg.cpp
@@ -18,7 +18,7 @@ struct RegrAvgFunction {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		target->sum += source.sum;
 		target->count += source.count;
 	}

--- a/src/function/aggregate/regression/regr_intercept.cpp
+++ b/src/function/aggregate/regression/regr_intercept.cpp
@@ -33,11 +33,11 @@ struct RegrInterceptOperation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		target->count += source.count;
 		target->sum_x += source.sum_x;
 		target->sum_y += source.sum_y;
-		RegrSlopeOperation::Combine<RegrSlopeState, OP>(source.slope, &target->slope);
+		RegrSlopeOperation::Combine<RegrSlopeState, OP>(source.slope, &target->slope, bind_data);
 	}
 
 	template <class T, class STATE>

--- a/src/function/aggregate/regression/regr_r2.cpp
+++ b/src/function/aggregate/regression/regr_r2.cpp
@@ -33,10 +33,10 @@ struct RegrR2Operation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
-		CorrOperation::Combine<CorrState, OP>(source.corr, &target->corr);
-		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop_x, &target->var_pop_x);
-		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop_y, &target->var_pop_y);
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
+		CorrOperation::Combine<CorrState, OP>(source.corr, &target->corr, bind_data);
+		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop_x, &target->var_pop_x, bind_data);
+		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop_y, &target->var_pop_y, bind_data);
 	}
 
 	template <class T, class STATE>

--- a/src/function/aggregate/regression/regr_sxx_syy.cpp
+++ b/src/function/aggregate/regression/regr_sxx_syy.cpp
@@ -22,9 +22,9 @@ struct RegrBaseOperation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
-		RegrCountFunction::Combine<size_t, OP>(source.count, &target->count);
-		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop, &target->var_pop);
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
+		RegrCountFunction::Combine<size_t, OP>(source.count, &target->count, bind_data);
+		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop, &target->var_pop, bind_data);
 	}
 
 	template <class T, class STATE>

--- a/src/function/aggregate/regression/regr_sxy.cpp
+++ b/src/function/aggregate/regression/regr_sxy.cpp
@@ -29,9 +29,9 @@ struct RegrSXYOperation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
-		CovarOperation::Combine<CovarState, OP>(source.cov_pop, &target->cov_pop);
-		RegrCountFunction::Combine<size_t, OP>(source.count, &target->count);
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
+		CovarOperation::Combine<CovarState, OP>(source.cov_pop, &target->cov_pop, bind_data);
+		RegrCountFunction::Combine<size_t, OP>(source.count, &target->count, bind_data);
 	}
 
 	template <class T, class STATE>

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -174,7 +174,7 @@ struct SortedAggregateFunction {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (source.arguments.Count() == 0) {
 			return;
 		}

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -44,12 +44,12 @@ struct SortedAggregateBindData : public FunctionData {
 		}
 	}
 
-	unique_ptr<FunctionData> Copy() override {
+	unique_ptr<FunctionData> Copy() const override {
 		return make_unique<SortedAggregateBindData>(*this);
 	}
 
-	bool Equals(FunctionData &other_p) override {
-		auto &other = (SortedAggregateBindData &)other_p;
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const SortedAggregateBindData &)other_p;
 		if (bind_info && other.bind_info) {
 			if (!bind_info->Equals(*other.bind_info)) {
 				return false;

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -26,15 +26,7 @@ namespace duckdb {
 FunctionData::~FunctionData() {
 }
 
-unique_ptr<FunctionData> FunctionData::Copy() {
-	throw InternalException("Unimplemented copy for FunctionData");
-}
-
-bool FunctionData::Equals(FunctionData &other) {
-	return true;
-}
-
-bool FunctionData::Equals(FunctionData *left, FunctionData *right) {
+bool FunctionData::Equals(const FunctionData *left, const FunctionData *right) {
 	if (left == right) {
 		return true;
 	}
@@ -42,6 +34,17 @@ bool FunctionData::Equals(FunctionData *left, FunctionData *right) {
 		return false;
 	}
 	return left->Equals(*right);
+}
+
+TableFunctionData::~TableFunctionData() {
+}
+
+unique_ptr<FunctionData> TableFunctionData::Copy() const {
+	throw InternalException("Copy not supported for TableFunctionData");
+}
+
+bool TableFunctionData::Equals(const FunctionData &other) const {
+	throw InternalException("Equals not supported for TableFunctionData");
 }
 
 Function::Function(string name_p) : name(move(name_p)) {

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -44,7 +44,7 @@ unique_ptr<FunctionData> TableFunctionData::Copy() const {
 }
 
 bool TableFunctionData::Equals(const FunctionData &other) const {
-	throw InternalException("Equals not supported for TableFunctionData");
+	return false;
 }
 
 Function::Function(string name_p) : name(move(name_p)) {

--- a/src/function/scalar/date/current.cpp
+++ b/src/function/scalar/date/current.cpp
@@ -15,8 +15,12 @@ struct CurrentBindData : public FunctionData {
 	explicit CurrentBindData(ClientContext &context) : context(context) {
 	}
 
-	unique_ptr<FunctionData> Copy() override {
+	unique_ptr<FunctionData> Copy() const override {
 		return make_unique<CurrentBindData>(context);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		return true;
 	}
 };
 

--- a/src/function/scalar/date/date_part.cpp
+++ b/src/function/scalar/date/date_part.cpp
@@ -1302,7 +1302,7 @@ struct StructDatePart {
 		    : VariableReturnBindData(stype), part_codes(part_codes_p) {
 		}
 
-		unique_ptr<FunctionData> Copy() override {
+		unique_ptr<FunctionData> Copy() const override {
 			return make_unique<BindData>(stype, part_codes);
 		}
 	};

--- a/src/function/scalar/date/strftime.cpp
+++ b/src/function/scalar/date/strftime.cpp
@@ -572,13 +572,20 @@ string StrTimeFormat::ParseFormatSpecifier(const string &format_string, StrTimeF
 }
 
 struct StrfTimeBindData : public FunctionData {
-	explicit StrfTimeBindData(StrfTimeFormat format) : format(move(format)) {
+	explicit StrfTimeBindData(StrfTimeFormat format_p, string format_string_p)
+	    : format(move(format_p)), format_string(move(format_string_p)) {
 	}
 
 	StrfTimeFormat format;
+	string format_string;
 
-	unique_ptr<FunctionData> Copy() override {
-		return make_unique<StrfTimeBindData>(format);
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<StrfTimeBindData>(format, format_string);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const StrfTimeBindData &)other_p;
+		return format_string == other.format_string;
 	}
 };
 
@@ -589,15 +596,15 @@ static unique_ptr<FunctionData> StrfTimeBindFunction(ClientContext &context, Sca
 		throw InvalidInputException("strftime format must be a constant");
 	}
 	Value options_str = ExpressionExecutor::EvaluateScalar(*arguments[REVERSED ? 0 : 1]);
+	auto format_string = options_str.GetValue<string>();
 	StrfTimeFormat format;
 	if (!options_str.IsNull()) {
-		auto format_string = options_str.GetValue<string>();
 		string error = StrTimeFormat::ParseFormatSpecifier(format_string, format);
 		if (!error.empty()) {
 			throw InvalidInputException("Failed to parse format specifier %s: %s", format_string, error);
 		}
 	}
-	return make_unique<StrfTimeBindData>(format);
+	return make_unique<StrfTimeBindData>(format, format_string);
 }
 
 template <bool REVERSED>
@@ -1102,13 +1109,20 @@ bool StrpTimeFormat::Parse(string_t str, ParseResult &result) {
 }
 
 struct StrpTimeBindData : public FunctionData {
-	explicit StrpTimeBindData(StrpTimeFormat format) : format(move(format)) {
+	explicit StrpTimeBindData(StrpTimeFormat format_p, string format_string_p)
+	    : format(move(format_p)), format_string(move(format_string_p)) {
 	}
 
 	StrpTimeFormat format;
+	string format_string;
 
-	unique_ptr<FunctionData> Copy() override {
-		return make_unique<StrpTimeBindData>(format);
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<StrpTimeBindData>(format, format_string);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const StrpTimeBindData &)other_p;
+		return format_string == other.format_string;
 	}
 };
 
@@ -1118,16 +1132,16 @@ static unique_ptr<FunctionData> StrpTimeBindFunction(ClientContext &context, Sca
 		throw InvalidInputException("strptime format must be a constant");
 	}
 	Value options_str = ExpressionExecutor::EvaluateScalar(*arguments[1]);
+	string format_string = options_str.ToString();
 	StrpTimeFormat format;
 	if (!options_str.IsNull() && options_str.type().id() == LogicalTypeId::VARCHAR) {
-		string format_string = options_str.ToString();
 		format.format_specifier = format_string;
 		string error = StrTimeFormat::ParseFormatSpecifier(format_string, format);
 		if (!error.empty()) {
 			throw InvalidInputException("Failed to parse format specifier %s: %s", format_string, error);
 		}
 	}
-	return make_unique<StrpTimeBindData>(format);
+	return make_unique<StrpTimeBindData>(format, format_string);
 }
 
 StrpTimeFormat::ParseResult StrpTimeFormat::Parse(const string &format_string, const string &text) {

--- a/src/function/scalar/generic/constant_or_null.cpp
+++ b/src/function/scalar/generic/constant_or_null.cpp
@@ -12,8 +12,13 @@ struct ConstantOrNullBindData : public FunctionData {
 	Value value;
 
 public:
-	unique_ptr<FunctionData> Copy() override {
+	unique_ptr<FunctionData> Copy() const override {
 		return make_unique<ConstantOrNullBindData>(value);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const ConstantOrNullBindData &)other_p;
+		return value == other.value;
 	}
 };
 

--- a/src/function/scalar/generic/current_setting.cpp
+++ b/src/function/scalar/generic/current_setting.cpp
@@ -14,8 +14,13 @@ struct CurrentSettingBindData : public FunctionData {
 	Value value;
 
 public:
-	unique_ptr<FunctionData> Copy() override {
+	unique_ptr<FunctionData> Copy() const override {
 		return make_unique<CurrentSettingBindData>(value);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const CurrentSettingBindData &)other_p;
+		return value == other.value;
 	}
 };
 

--- a/src/function/scalar/generic/current_setting.cpp
+++ b/src/function/scalar/generic/current_setting.cpp
@@ -20,7 +20,7 @@ public:
 
 	bool Equals(const FunctionData &other_p) const override {
 		auto &other = (const CurrentSettingBindData &)other_p;
-		return value == other.value;
+		return Value::NotDistinctFrom(value, other.value);
 	}
 };
 

--- a/src/function/scalar/generic/stats.cpp
+++ b/src/function/scalar/generic/stats.cpp
@@ -10,8 +10,13 @@ struct StatsBindData : public FunctionData {
 	string stats;
 
 public:
-	unique_ptr<FunctionData> Copy() override {
+	unique_ptr<FunctionData> Copy() const override {
 		return make_unique<StatsBindData>(stats);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const StatsBindData &)other_p;
+		return stats == other.stats;
 	}
 };
 

--- a/src/function/scalar/list/list_aggregates.cpp
+++ b/src/function/scalar/list/list_aggregates.cpp
@@ -18,15 +18,18 @@ struct ListAggregatesBindData : public FunctionData {
 	LogicalType stype;
 	unique_ptr<Expression> aggr_expr;
 
-	unique_ptr<FunctionData> Copy() override;
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<ListAggregatesBindData>(stype, aggr_expr->Copy());
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const ListAggregatesBindData &)other_p;
+		return stype == other.stype && aggr_expr->Equals(other.aggr_expr.get());
+	}
 };
 
 ListAggregatesBindData::ListAggregatesBindData(const LogicalType &stype_p, unique_ptr<Expression> aggr_expr_p)
     : stype(stype_p), aggr_expr(move(aggr_expr_p)) {
-}
-
-unique_ptr<FunctionData> ListAggregatesBindData::Copy() {
-	return make_unique<ListAggregatesBindData>(stype, aggr_expr->Copy());
 }
 
 ListAggregatesBindData::~ListAggregatesBindData() {

--- a/src/function/scalar/math/numeric.cpp
+++ b/src/function/scalar/math/numeric.cpp
@@ -398,8 +398,13 @@ struct RoundPrecisionFunctionData : public FunctionData {
 
 	int32_t target_scale;
 
-	unique_ptr<FunctionData> Copy() override {
+	unique_ptr<FunctionData> Copy() const override {
 		return make_unique<RoundPrecisionFunctionData>(target_scale);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const RoundPrecisionFunctionData &)other_p;
+		return other.target_scale;
 	}
 };
 

--- a/src/function/scalar/math/numeric.cpp
+++ b/src/function/scalar/math/numeric.cpp
@@ -404,7 +404,7 @@ struct RoundPrecisionFunctionData : public FunctionData {
 
 	bool Equals(const FunctionData &other_p) const override {
 		auto &other = (const RoundPrecisionFunctionData &)other_p;
-		return other.target_scale;
+		return target_scale == other.target_scale;
 	}
 };
 

--- a/src/function/scalar/math/random.cpp
+++ b/src/function/scalar/math/random.cpp
@@ -19,7 +19,7 @@ struct RandomBindData : public FunctionData {
 	}
 
 	bool Equals(const FunctionData &other_p) const override {
-		return false;
+		return true;
 	}
 };
 

--- a/src/function/scalar/math/random.cpp
+++ b/src/function/scalar/math/random.cpp
@@ -14,8 +14,12 @@ struct RandomBindData : public FunctionData {
 	RandomBindData(ClientContext &context, std::uniform_real_distribution<double> dist) : context(context), dist(dist) {
 	}
 
-	unique_ptr<FunctionData> Copy() override {
+	unique_ptr<FunctionData> Copy() const override {
 		return make_unique<RandomBindData>(context, dist);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		return false;
 	}
 };
 

--- a/src/function/scalar/math/setseed.cpp
+++ b/src/function/scalar/math/setseed.cpp
@@ -15,8 +15,12 @@ struct SetseedBindData : public FunctionData {
 	explicit SetseedBindData(ClientContext &context) : context(context) {
 	}
 
-	unique_ptr<FunctionData> Copy() override {
+	unique_ptr<FunctionData> Copy() const override {
 		return make_unique<SetseedBindData>(context);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		return true;
 	}
 };
 

--- a/src/function/scalar/sequence/nextval.cpp
+++ b/src/function/scalar/sequence/nextval.cpp
@@ -27,7 +27,8 @@ struct NextvalBindData : public FunctionData {
 	}
 
 	bool Equals(const FunctionData &other_p) const override {
-		return false;
+		auto &other = (NextvalBindData &)other_p;
+		return sequence == other.sequence;
 	}
 };
 

--- a/src/function/scalar/sequence/nextval.cpp
+++ b/src/function/scalar/sequence/nextval.cpp
@@ -22,8 +22,12 @@ struct NextvalBindData : public FunctionData {
 	NextvalBindData(ClientContext &context, SequenceCatalogEntry *sequence) : context(context), sequence(sequence) {
 	}
 
-	unique_ptr<FunctionData> Copy() override {
+	unique_ptr<FunctionData> Copy() const override {
 		return make_unique<NextvalBindData>(context, sequence);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		return false;
 	}
 };
 

--- a/src/function/scalar/string/like.cpp
+++ b/src/function/scalar/string/like.cpp
@@ -72,8 +72,9 @@ struct LikeSegment {
 };
 
 struct LikeMatcher : public FunctionData {
-	LikeMatcher(vector<LikeSegment> segments, bool has_start_percentage, bool has_end_percentage)
-	    : segments(move(segments)), has_start_percentage(has_start_percentage), has_end_percentage(has_end_percentage) {
+	LikeMatcher(string like_pattern_p, vector<LikeSegment> segments, bool has_start_percentage, bool has_end_percentage)
+	    : like_pattern(move(like_pattern_p)), segments(move(segments)), has_start_percentage(has_start_percentage),
+	      has_end_percentage(has_end_percentage) {
 	}
 
 	bool Match(string_t &str) {
@@ -169,14 +170,20 @@ struct LikeMatcher : public FunctionData {
 		if (segments.empty()) {
 			return nullptr;
 		}
-		return make_unique<LikeMatcher>(move(segments), has_start_percentage, has_end_percentage);
+		return make_unique<LikeMatcher>(move(like_pattern), move(segments), has_start_percentage, has_end_percentage);
 	}
 
-	unique_ptr<FunctionData> Copy() override {
-		return make_unique<LikeMatcher>(segments, has_start_percentage, has_end_percentage);
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<LikeMatcher>(like_pattern, segments, has_start_percentage, has_end_percentage);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const LikeMatcher &)other_p;
+		return like_pattern == other.like_pattern;
 	}
 
 private:
+	string like_pattern;
 	vector<LikeSegment> segments;
 	bool has_start_percentage;
 	bool has_end_percentage;

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -30,8 +30,12 @@ RegexpMatchesBindData::RegexpMatchesBindData(duckdb_re2::RE2::Options options, s
 RegexpMatchesBindData::~RegexpMatchesBindData() {
 }
 
-unique_ptr<FunctionData> RegexpMatchesBindData::Copy() {
+unique_ptr<FunctionData> RegexpMatchesBindData::Copy() const {
 	return make_unique<RegexpMatchesBindData>(options, constant_string);
+}
+
+bool RegexpMatchesBindData::Equals(const FunctionData &other_p) const {
+	return false;
 }
 
 static inline duckdb_re2::StringPiece CreateStringPiece(string_t &input) {
@@ -94,7 +98,7 @@ struct RegexFullMatch {
 	}
 };
 
-struct RegexLocalState : public FunctionData {
+struct RegexLocalState : public FunctionLocalState {
 	explicit RegexLocalState(RegexpMatchesBindData &info)
 	    : constant_pattern(duckdb_re2::StringPiece(info.constant_string.c_str(), info.constant_string.size()),
 	                       info.options) {
@@ -109,7 +113,8 @@ struct RegexLocalState : public FunctionData {
 	RE2 constant_pattern;
 };
 
-static unique_ptr<FunctionData> RegexInitLocalState(const BoundFunctionExpression &expr, FunctionData *bind_data) {
+static unique_ptr<FunctionLocalState> RegexInitLocalState(const BoundFunctionExpression &expr,
+                                                          FunctionData *bind_data) {
 	auto &info = (RegexpMatchesBindData &)*bind_data;
 	if (info.constant_pattern) {
 		return make_unique<RegexLocalState>(info);
@@ -188,11 +193,15 @@ static void RegexReplaceFunction(DataChunk &args, ExpressionState &state, Vector
 	    });
 }
 
-unique_ptr<FunctionData> RegexpReplaceBindData::Copy() {
+unique_ptr<FunctionData> RegexpReplaceBindData::Copy() const {
 	auto copy = make_unique<RegexpReplaceBindData>();
 	copy->options = options;
 	copy->global_replace = global_replace;
 	return move(copy);
+}
+
+bool RegexpReplaceBindData::Equals(const FunctionData &other_p) const {
+	return false;
 }
 
 static unique_ptr<FunctionData> RegexReplaceBind(ClientContext &context, ScalarFunction &bound_function,
@@ -239,8 +248,8 @@ static void RegexExtractFunction(DataChunk &args, ExpressionState &state, Vector
 	}
 }
 
-static unique_ptr<FunctionData> RegexExtractInitLocalState(const BoundFunctionExpression &expr,
-                                                           FunctionData *bind_data) {
+static unique_ptr<FunctionLocalState> RegexExtractInitLocalState(const BoundFunctionExpression &expr,
+                                                                 FunctionData *bind_data) {
 	auto &info = (RegexpExtractBindData &)*bind_data;
 	if (info.constant_pattern) {
 		return make_unique<RegexLocalState>(info);
@@ -254,8 +263,12 @@ RegexpExtractBindData::RegexpExtractBindData(bool constant_pattern, const string
       rewrite(group_string) {
 }
 
-unique_ptr<FunctionData> RegexpExtractBindData::Copy() {
+unique_ptr<FunctionData> RegexpExtractBindData::Copy() const {
 	return make_unique<RegexpExtractBindData>(constant_pattern, constant_string, group_string);
+}
+
+bool RegexpExtractBindData::Equals(const FunctionData &other_p) const {
+	return false;
 }
 
 static unique_ptr<FunctionData> RegexExtractBind(ClientContext &context, ScalarFunction &bound_function,

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -27,6 +27,10 @@ RegexpMatchesBindData::RegexpMatchesBindData(duckdb_re2::RE2::Options options, s
 	}
 }
 
+static bool RegexOptionsEquals(const duckdb_re2::RE2::Options &opt_a, const duckdb_re2::RE2::Options &opt_b) {
+	return opt_a.case_sensitive() == opt_b.case_sensitive();
+}
+
 RegexpMatchesBindData::~RegexpMatchesBindData() {
 }
 
@@ -35,7 +39,8 @@ unique_ptr<FunctionData> RegexpMatchesBindData::Copy() const {
 }
 
 bool RegexpMatchesBindData::Equals(const FunctionData &other_p) const {
-	return false;
+	auto &other = (const RegexpMatchesBindData &)other_p;
+	return constant_string == other.constant_string && RegexOptionsEquals(options, other.options);
 }
 
 static inline duckdb_re2::StringPiece CreateStringPiece(string_t &input) {
@@ -201,7 +206,8 @@ unique_ptr<FunctionData> RegexpReplaceBindData::Copy() const {
 }
 
 bool RegexpReplaceBindData::Equals(const FunctionData &other_p) const {
-	return false;
+	auto &other = (const RegexpReplaceBindData &)other_p;
+	return global_replace == other.global_replace && RegexOptionsEquals(options, other.options);
 }
 
 static unique_ptr<FunctionData> RegexReplaceBind(ClientContext &context, ScalarFunction &bound_function,
@@ -268,7 +274,8 @@ unique_ptr<FunctionData> RegexpExtractBindData::Copy() const {
 }
 
 bool RegexpExtractBindData::Equals(const FunctionData &other_p) const {
-	return false;
+	auto &other = (const RegexpExtractBindData &)other_p;
+	return constant_string == other.constant_string && group_string == other.group_string;
 }
 
 static unique_ptr<FunctionData> RegexExtractBind(ClientContext &context, ScalarFunction &bound_function,

--- a/src/function/scalar/struct/struct_extract.cpp
+++ b/src/function/scalar/struct/struct_extract.cpp
@@ -16,11 +16,11 @@ struct StructExtractBindData : public FunctionData {
 	LogicalType type;
 
 public:
-	unique_ptr<FunctionData> Copy() override {
+	unique_ptr<FunctionData> Copy() const override {
 		return make_unique<StructExtractBindData>(key, index, type);
 	}
-	bool Equals(FunctionData &other_p) override {
-		auto &other = (StructExtractBindData &)other_p;
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const StructExtractBindData &)other_p;
 		return key == other.key && index == other.index && type == other.type;
 	}
 };

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -163,7 +163,7 @@ static void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Ve
 		memcpy(local_state.state_buffer0.get(), state0.GetDataUnsafe(), bind_data.state_size);
 		memcpy(local_state.state_buffer1.get(), state1.GetDataUnsafe(), bind_data.state_size);
 
-		bind_data.aggr.combine(local_state.state_vector0, local_state.state_vector1, 1);
+		bind_data.aggr.combine(local_state.state_vector0, local_state.state_vector1, nullptr, 1);
 
 		result_ptr[i] =
 		    StringVector::AddStringOrBlob(result, (const char *)local_state.state_buffer1.get(), bind_data.state_size);

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -7,7 +7,6 @@
 namespace duckdb {
 
 // aggregate state export
-
 struct ExportAggregateBindData : public FunctionData {
 	AggregateFunction &aggr;
 	idx_t state_size;
@@ -16,9 +15,13 @@ struct ExportAggregateBindData : public FunctionData {
 	    : aggr(aggr_p), state_size(state_size_p) {
 	}
 
-	unique_ptr<FunctionData> Copy() override {
-
+	unique_ptr<FunctionData> Copy() const override {
 		return make_unique<ExportAggregateBindData>(aggr, state_size);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const ExportAggregateBindData &)other_p;
+		return aggr == other.aggr && state_size == other.state_size;
 	}
 
 	static ExportAggregateBindData &GetFrom(ExpressionState &state) {
@@ -27,7 +30,7 @@ struct ExportAggregateBindData : public FunctionData {
 	}
 };
 
-struct CombineState : public FunctionData {
+struct CombineState : public FunctionLocalState {
 	idx_t state_size;
 
 	unique_ptr<data_t[]> state_buffer0, state_buffer1;
@@ -39,18 +42,14 @@ struct CombineState : public FunctionData {
 	      state_vector0(Value::POINTER((uintptr_t)state_buffer0.get())),
 	      state_vector1(Value::POINTER((uintptr_t)state_buffer1.get())) {
 	}
-
-	unique_ptr<FunctionData> Copy() override {
-		return make_unique<CombineState>(state_size);
-	}
 };
 
-static unique_ptr<FunctionData> InitCombineState(const BoundFunctionExpression &expr, FunctionData *bind_data_p) {
+static unique_ptr<FunctionLocalState> InitCombineState(const BoundFunctionExpression &expr, FunctionData *bind_data_p) {
 	auto &bind_data = *(ExportAggregateBindData *)bind_data_p;
 	return make_unique<CombineState>(bind_data.state_size);
 }
 
-struct FinalizeState : public FunctionData {
+struct FinalizeState : public FunctionLocalState {
 	idx_t state_size;
 	unique_ptr<data_t[]> state_buffer;
 	Vector addresses;
@@ -60,13 +59,10 @@ struct FinalizeState : public FunctionData {
 	      state_buffer(unique_ptr<data_t[]>(new data_t[STANDARD_VECTOR_SIZE * AlignValue(state_size_p)])),
 	      addresses(LogicalType::POINTER) {
 	}
-
-	unique_ptr<FunctionData> Copy() override {
-		return make_unique<FinalizeState>(state_size);
-	}
 };
 
-static unique_ptr<FunctionData> InitFinalizeState(const BoundFunctionExpression &expr, FunctionData *bind_data_p) {
+static unique_ptr<FunctionLocalState> InitFinalizeState(const BoundFunctionExpression &expr,
+                                                        FunctionData *bind_data_p) {
 	auto &bind_data = *(ExportAggregateBindData *)bind_data_p;
 	return make_unique<FinalizeState>(bind_data.state_size);
 }
@@ -242,8 +238,13 @@ ExportAggregateFunctionBindData::ExportAggregateFunctionBindData(unique_ptr<Expr
 	aggregate = unique_ptr<BoundAggregateExpression>((BoundAggregateExpression *)aggregate_p.release());
 }
 
-unique_ptr<FunctionData> ExportAggregateFunctionBindData::Copy() {
+unique_ptr<FunctionData> ExportAggregateFunctionBindData::Copy() const {
 	return make_unique<ExportAggregateFunctionBindData>(aggregate->Copy());
+}
+
+bool ExportAggregateFunctionBindData::Equals(const FunctionData &other_p) const {
+	auto &other = (const ExportAggregateFunctionBindData &)other_p;
+	return aggregate->Equals(other.aggregate.get());
 }
 
 unique_ptr<BoundAggregateExpression>

--- a/src/function/scalar/system/system_functions.cpp
+++ b/src/function/scalar/system/system_functions.cpp
@@ -15,8 +15,11 @@ struct SystemBindData : public FunctionData {
 	explicit SystemBindData(ClientContext &context) : context(context) {
 	}
 
-	unique_ptr<FunctionData> Copy() override {
+	unique_ptr<FunctionData> Copy() const override {
 		return make_unique<SystemBindData>(context);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		return true;
 	}
 
 	static SystemBindData &GetFrom(ExpressionState &state) {

--- a/src/function/scalar/uuid/gen_random.cpp
+++ b/src/function/scalar/uuid/gen_random.cpp
@@ -13,8 +13,11 @@ struct UUIDRandomBindData : public FunctionData {
 	    : context(context), dist(dist) {
 	}
 
-	unique_ptr<FunctionData> Copy() override {
+	unique_ptr<FunctionData> Copy() const override {
 		return make_unique<UUIDRandomBindData>(context, dist);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		return false;
 	}
 };
 

--- a/src/function/scalar/uuid/gen_random.cpp
+++ b/src/function/scalar/uuid/gen_random.cpp
@@ -17,7 +17,7 @@ struct UUIDRandomBindData : public FunctionData {
 		return make_unique<UUIDRandomBindData>(context, dist);
 	}
 	bool Equals(const FunctionData &other_p) const override {
-		return false;
+		return true;
 	}
 };
 

--- a/src/function/scalar_function.cpp
+++ b/src/function/scalar_function.cpp
@@ -2,6 +2,9 @@
 
 namespace duckdb {
 
+FunctionLocalState::~FunctionLocalState() {
+}
+
 ScalarFunction::ScalarFunction(string name, vector<LogicalType> arguments, LogicalType return_type,
                                scalar_function_t function, bool has_side_effects, bind_scalar_function_t bind,
                                dependency_function_t dependency, function_statistics_t statistics,

--- a/src/function/table/range.cpp
+++ b/src/function/table/range.cpp
@@ -14,6 +14,12 @@ struct RangeFunctionBindData : public TableFunctionData {
 	hugeint_t start;
 	hugeint_t end;
 	hugeint_t increment;
+
+public:
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const RangeFunctionBindData &)other_p;
+		return other.start == start && other.end == end && other.increment == increment;
+	}
 };
 
 template <bool GENERATE_SERIES>
@@ -108,6 +114,13 @@ struct RangeDateTimeBindData : public TableFunctionData {
 	interval_t increment;
 	bool inclusive_bound;
 	bool greater_than_check;
+
+public:
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const RangeDateTimeBindData &)other_p;
+		return other.start == start && other.end == end && other.increment == increment &&
+		       other.inclusive_bound == inclusive_bound && other.greater_than_check == greater_than_check;
+	}
 
 	bool Finished(timestamp_t current_value) {
 		if (greater_than_check) {

--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -240,6 +240,8 @@ public:
 	//! Returns true if the values are (approximately) equivalent. Note this is NOT the SQL equivalence. For this
 	//! function, NULL values are equivalent and floating point values that are close are equivalent.
 	DUCKDB_API static bool ValuesAreEqual(const Value &result_value, const Value &value);
+	//! Returns true if the values are not distinct from each other, following SQL semantics for NOT DISTINCT FROM.
+	DUCKDB_API static bool NotDistinctFrom(const Value &lvalue, const Value &rvalue);
 
 	friend std::ostream &operator<<(std::ostream &out, const Value &val) {
 		out << val.ToString();

--- a/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
@@ -301,13 +301,13 @@ public:
 	}
 
 	template <class STATE_TYPE, class OP>
-	static void Combine(Vector &source, Vector &target, idx_t count) {
+	static void Combine(Vector &source, Vector &target, FunctionData *bind_data, idx_t count) {
 		D_ASSERT(source.GetType().id() == LogicalTypeId::POINTER && target.GetType().id() == LogicalTypeId::POINTER);
 		auto sdata = FlatVector::GetData<const STATE_TYPE *>(source);
 		auto tdata = FlatVector::GetData<STATE_TYPE *>(target);
 
 		for (idx_t i = 0; i < count; i++) {
-			OP::template Combine<STATE_TYPE, OP>(*sdata[i], tdata[i]);
+			OP::template Combine<STATE_TYPE, OP>(*sdata[i], tdata[i], bind_data);
 		}
 	}
 

--- a/src/include/duckdb/execution/expression_executor_state.hpp
+++ b/src/include/duckdb/execution/expression_executor_state.hpp
@@ -18,6 +18,7 @@ namespace duckdb {
 class Expression;
 class ExpressionExecutor;
 struct ExpressionExecutorState;
+struct FunctionLocalState;
 
 struct ExpressionState {
 	ExpressionState(const Expression &expr, ExpressionExecutorState &root);
@@ -38,13 +39,13 @@ public:
 };
 
 struct ExecuteFunctionState : public ExpressionState {
-	ExecuteFunctionState(const Expression &expr, ExpressionExecutorState &root) : ExpressionState(expr, root) {
-	}
+	ExecuteFunctionState(const Expression &expr, ExpressionExecutorState &root);
+	~ExecuteFunctionState();
 
-	unique_ptr<FunctionData> local_state;
+	unique_ptr<FunctionLocalState> local_state;
 
 public:
-	static FunctionData *GetFunctionState(ExpressionState &state) {
+	static FunctionLocalState *GetFunctionState(ExpressionState &state) {
 		return ((ExecuteFunctionState &)state).local_state.get();
 	}
 };

--- a/src/include/duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp
@@ -40,8 +40,6 @@ public:
 	vector<unique_ptr<Expression>> aggregates;
 	//! The set of GROUPING functions
 	vector<vector<idx_t>> grouping_functions;
-	//! Whether or not all aggregates are combinable
-	bool all_combinable;
 
 	//! Whether or not any aggregation is DISTINCT
 	bool any_distinct;
@@ -83,7 +81,7 @@ public:
 	}
 
 	bool ParallelSink() const override {
-		return all_combinable;
+		return true;
 	}
 
 public:

--- a/src/include/duckdb/function/aggregate/algebraic/corr.hpp
+++ b/src/include/duckdb/function/aggregate/algebraic/corr.hpp
@@ -41,10 +41,10 @@ struct CorrOperation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
-		CovarOperation::Combine<CovarState, OP>(source.cov_pop, &target->cov_pop);
-		STDDevBaseOperation::Combine<StddevState, OP>(source.dev_pop_x, &target->dev_pop_x);
-		STDDevBaseOperation::Combine<StddevState, OP>(source.dev_pop_y, &target->dev_pop_y);
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
+		CovarOperation::Combine<CovarState, OP>(source.cov_pop, &target->cov_pop, bind_data);
+		STDDevBaseOperation::Combine<StddevState, OP>(source.dev_pop_x, &target->dev_pop_x, bind_data);
+		STDDevBaseOperation::Combine<StddevState, OP>(source.dev_pop_y, &target->dev_pop_y, bind_data);
 	}
 
 	template <class T, class STATE>

--- a/src/include/duckdb/function/aggregate/algebraic/covar.hpp
+++ b/src/include/duckdb/function/aggregate/algebraic/covar.hpp
@@ -50,7 +50,7 @@ struct CovarOperation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (target->count == 0) {
 			*target = source;
 		} else if (source.count > 0) {

--- a/src/include/duckdb/function/aggregate/algebraic/stddev.hpp
+++ b/src/include/duckdb/function/aggregate/algebraic/stddev.hpp
@@ -53,7 +53,7 @@ struct STDDevBaseOperation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (target->count == 0) {
 			*target = source;
 		} else if (source.count > 0) {

--- a/src/include/duckdb/function/aggregate/nested_functions.hpp
+++ b/src/include/duckdb/function/aggregate/nested_functions.hpp
@@ -13,15 +13,6 @@
 
 namespace duckdb {
 
-struct ListBindData : public FunctionData {
-	ListBindData() {
-	}
-
-	unique_ptr<FunctionData> Copy() override {
-		return make_unique<ListBindData>();
-	}
-};
-
 struct ListFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/src/include/duckdb/function/aggregate/regression/regr_count.hpp
+++ b/src/include/duckdb/function/aggregate/regression/regr_count.hpp
@@ -22,7 +22,7 @@ struct RegrCountFunction {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		*target += source;
 	}
 

--- a/src/include/duckdb/function/aggregate/regression/regr_slope.hpp
+++ b/src/include/duckdb/function/aggregate/regression/regr_slope.hpp
@@ -33,9 +33,9 @@ struct RegrSlopeOperation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
-		CovarOperation::Combine<CovarState, OP>(source.cov_pop, &target->cov_pop);
-		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop, &target->var_pop);
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
+		CovarOperation::Combine<CovarState, OP>(source.cov_pop, &target->cov_pop, bind_data);
+		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop, &target->var_pop, bind_data);
 	}
 
 	template <class T, class STATE>

--- a/src/include/duckdb/function/aggregate/sum_helpers.hpp
+++ b/src/include/duckdb/function/aggregate/sum_helpers.hpp
@@ -139,8 +139,8 @@ struct BaseSumOperation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
-		STATEOP::template Combine<STATE>(source, target);
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
+		STATEOP::template Combine<STATE>(source, target, bind_data);
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -26,8 +26,8 @@ typedef void (*aggregate_initialize_t)(data_ptr_t state);
 //! The type used for updating hashed aggregate functions
 typedef void (*aggregate_update_t)(Vector inputs[], FunctionData *bind_data, idx_t input_count, Vector &state,
                                    idx_t count);
-//! The type used for combining hashed aggregate states (optional)
-typedef void (*aggregate_combine_t)(Vector &state, Vector &combined, idx_t count);
+//! The type used for combining hashed aggregate states
+typedef void (*aggregate_combine_t)(Vector &state, Vector &combined, FunctionData *bind_data, idx_t count);
 //! The type used for finalizing hashed aggregate function payloads
 typedef void (*aggregate_finalize_t)(Vector &state, FunctionData *bind_data, Vector &result, idx_t count, idx_t offset);
 //! The type used for propagating statistics in aggregate functions (optional)
@@ -237,8 +237,8 @@ public:
 	}
 
 	template <class STATE, class OP>
-	static void StateCombine(Vector &source, Vector &target, idx_t count) {
-		AggregateExecutor::Combine<STATE, OP>(source, target, count);
+	static void StateCombine(Vector &source, Vector &target, FunctionData *bind_data, idx_t count) {
+		AggregateExecutor::Combine<STATE, OP>(source, target, bind_data, count);
 	}
 
 	template <class STATE, class RESULT_TYPE, class OP>

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -35,14 +35,19 @@ struct PragmaInfo;
 struct FunctionData {
 	DUCKDB_API virtual ~FunctionData();
 
-	DUCKDB_API virtual unique_ptr<FunctionData> Copy();
-	DUCKDB_API virtual bool Equals(FunctionData &other);
-	DUCKDB_API static bool Equals(FunctionData *left, FunctionData *right);
+	DUCKDB_API virtual unique_ptr<FunctionData> Copy() const = 0;
+	DUCKDB_API virtual bool Equals(const FunctionData &other) const = 0;
+	DUCKDB_API static bool Equals(const FunctionData *left, const FunctionData *right);
 };
 
 struct TableFunctionData : public FunctionData {
 	// used to pass on projections to table functions that support them. NB, can contain COLUMN_IDENTIFIER_ROW_ID
 	vector<idx_t> column_ids;
+
+	DUCKDB_API virtual ~TableFunctionData();
+
+	DUCKDB_API unique_ptr<FunctionData> Copy() const override;
+	DUCKDB_API bool Equals(const FunctionData &other) const override;
 };
 
 struct FunctionParameters {
@@ -122,10 +127,6 @@ public:
 public:
 	DUCKDB_API string ToString() override;
 	DUCKDB_API bool HasNamedParameters();
-
-	DUCKDB_API void EvaluateInputParameters(vector<LogicalType> &arguments, vector<Value> &parameters,
-	                                        named_parameter_map_t &named_parameters,
-	                                        vector<unique_ptr<ParsedExpression>> &children);
 };
 
 class BaseScalarFunction : public SimpleFunction {

--- a/src/include/duckdb/function/scalar/generic_functions.hpp
+++ b/src/include/duckdb/function/scalar/generic_functions.hpp
@@ -55,7 +55,8 @@ struct SystemFun {
 struct ExportAggregateFunctionBindData : public FunctionData {
 	unique_ptr<BoundAggregateExpression> aggregate;
 	explicit ExportAggregateFunctionBindData(unique_ptr<Expression> aggregate_p);
-	unique_ptr<FunctionData> Copy() override;
+	unique_ptr<FunctionData> Copy() const override;
+	bool Equals(const FunctionData &other_p) const override;
 };
 
 struct ExportAggregateFunction {

--- a/src/include/duckdb/function/scalar/nested_functions.hpp
+++ b/src/include/duckdb/function/scalar/nested_functions.hpp
@@ -19,8 +19,12 @@ struct VariableReturnBindData : public FunctionData {
 	explicit VariableReturnBindData(const LogicalType &stype_p) : stype(stype_p) {
 	}
 
-	unique_ptr<FunctionData> Copy() override {
+	unique_ptr<FunctionData> Copy() const override {
 		return make_unique<VariableReturnBindData>(stype);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const VariableReturnBindData &)other_p;
+		return stype == other.stype;
 	}
 };
 
@@ -63,7 +67,6 @@ struct ListContainsFun {
 };
 
 struct ListFlattenFun {
-	static ScalarFunction GetFunction();
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 

--- a/src/include/duckdb/function/scalar/regexp.hpp
+++ b/src/include/duckdb/function/scalar/regexp.hpp
@@ -24,14 +24,16 @@ struct RegexpMatchesBindData : public FunctionData {
 	string range_max;
 	bool range_success;
 
-	unique_ptr<FunctionData> Copy() override;
+	unique_ptr<FunctionData> Copy() const override;
+	bool Equals(const FunctionData &other_p) const override;
 };
 
 struct RegexpReplaceBindData : public FunctionData {
 	duckdb_re2::RE2::Options options;
 	bool global_replace;
 
-	unique_ptr<FunctionData> Copy() override;
+	unique_ptr<FunctionData> Copy() const override;
+	bool Equals(const FunctionData &other_p) const override;
 };
 
 struct RegexpExtractBindData : public FunctionData {
@@ -43,7 +45,8 @@ struct RegexpExtractBindData : public FunctionData {
 	const string group_string;
 	const duckdb_re2::StringPiece rewrite;
 
-	unique_ptr<FunctionData> Copy() override;
+	unique_ptr<FunctionData> Copy() const override;
+	bool Equals(const FunctionData &other_p) const override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -17,6 +17,11 @@
 #include "duckdb/storage/statistics/base_statistics.hpp"
 
 namespace duckdb {
+
+struct FunctionLocalState {
+	DUCKDB_API virtual ~FunctionLocalState();
+};
+
 class BoundFunctionExpression;
 class ScalarFunctionCatalogEntry;
 
@@ -25,7 +30,8 @@ typedef std::function<void(DataChunk &, ExpressionState &, Vector &)> scalar_fun
 //! Binds the scalar function and creates the function data
 typedef unique_ptr<FunctionData> (*bind_scalar_function_t)(ClientContext &context, ScalarFunction &bound_function,
                                                            vector<unique_ptr<Expression>> &arguments);
-typedef unique_ptr<FunctionData> (*init_local_state_t)(const BoundFunctionExpression &expr, FunctionData *bind_data);
+typedef unique_ptr<FunctionLocalState> (*init_local_state_t)(const BoundFunctionExpression &expr,
+                                                             FunctionData *bind_data);
 typedef unique_ptr<BaseStatistics> (*function_statistics_t)(ClientContext &context, BoundFunctionExpression &expr,
                                                             FunctionData *bind_data,
                                                             vector<unique_ptr<BaseStatistics>> &child_stats);

--- a/src/include/duckdb/function/table/table_scan.hpp
+++ b/src/include/duckdb/function/table/table_scan.hpp
@@ -14,7 +14,7 @@
 namespace duckdb {
 class TableCatalogEntry;
 
-struct TableScanBindData : public FunctionData {
+struct TableScanBindData : public TableFunctionData {
 	explicit TableScanBindData(TableCatalogEntry *table) : table(table), is_index_scan(false), chunk_count(0) {
 	}
 

--- a/src/include/duckdb/function/table/table_scan.hpp
+++ b/src/include/duckdb/function/table/table_scan.hpp
@@ -28,6 +28,12 @@ struct TableScanBindData : public TableFunctionData {
 
 	//! How many chunks we already scanned
 	atomic<idx_t> chunk_count;
+
+public:
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const TableScanBindData &)other_p;
+		return other.table == table && result_ids == other.result_ids;
+	}
 };
 
 //! The table scan function represents a sequential scan over one of DuckDB's base tables.

--- a/src/main/capi/table_function-c.cpp
+++ b/src/main/capi/table_function-c.cpp
@@ -22,7 +22,7 @@ struct CTableFunctionInfo : public TableFunctionInfo {
 	duckdb_delete_callback_t delete_callback = nullptr;
 };
 
-struct CTableBindData : public FunctionData {
+struct CTableBindData : public TableFunctionData {
 	~CTableBindData() {
 		if (bind_data && delete_callback) {
 			delete_callback(bind_data);

--- a/test/api/udf_function/udf_functions_to_test.hpp
+++ b/test/api/udf_function/udf_functions_to_test.hpp
@@ -337,7 +337,7 @@ struct UDFAverageFunction {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		target->count += source.count;
 		target->sum += source.sum;
 	}
@@ -400,7 +400,7 @@ struct UDFCovarOperation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target) {
+	static void Combine(const STATE &source, STATE *target, FunctionData *bind_data) {
 		if (target->count == 0) {
 			*target = source;
 		} else if (source.count > 0) {
@@ -543,7 +543,7 @@ struct UDFSum {
 	}
 
 	template <class STATE_TYPE>
-	static void Combine(Vector &source, Vector &target, idx_t count) {
+	static void Combine(Vector &source, Vector &target, FunctionData *bind_data, idx_t count) {
 		D_ASSERT(source.GetType().id() == LogicalTypeId::POINTER && target.GetType().id() == LogicalTypeId::POINTER);
 		auto sdata = FlatVector::GetData<const STATE_TYPE *>(source);
 		auto tdata = FlatVector::GetData<STATE_TYPE *>(target);

--- a/test/sql/aggregate/aggregates/test_string_agg.test
+++ b/test/sql/aggregate/aggregates/test_string_agg.test
@@ -24,7 +24,7 @@ a
 
 # test string aggregation on scalar values
 query TTTT
-SELECT STRING_AGG('a',','), STRING_AGG(NULL,','), STRING_AGG('a',NULL), STRING_AGG(NULL,NULL)
+SELECT STRING_AGG('a',','), STRING_AGG(NULL,','), STRING_AGG('a', NULL), STRING_AGG(NULL,NULL)
 ----
 a
 NULL
@@ -38,33 +38,22 @@ CREATE TABLE strings(g INTEGER, x VARCHAR, y VARCHAR);
 statement ok
 INSERT INTO strings VALUES (1,'a','/'), (1,'b','-'), (2,'i','/'), (2,NULL,'-'), (2,'j','+'), (3,'p','/'), (4,'x','/'), (4,'y','-'), (4,'z','+')
 
-query TT
+# string agg separator must be a constant
+statement error
 SELECT STRING_AGG(x,','), STRING_AGG(x,y) FROM strings
-----
-a,b,i,j,p,x,y,z
-a-b/i+j/p/x-y+z
 
-query ITT
-SELECT g, STRING_AGG(x,','), STRING_AGG(x,y) FROM strings GROUP BY g ORDER BY g
+query II
+SELECT g, STRING_AGG(x,'|') FROM strings GROUP BY g ORDER BY g
 ----
-1
-a,b
-a-b
-2
-i,j
-i+j
-3
-p
-p
-4
-x,y,z
-x-y+z
+1	a|b
+2	i|j
+3	p
+4	x|y|z
 
 # test agg on empty set
-query TT
-SELECT STRING_AGG(x,','), STRING_AGG(x,y) FROM strings WHERE g > 100
+query T
+SELECT STRING_AGG(x,',') FROM strings WHERE g > 100
 ----
-NULL
 NULL
 
 # numerics are auto cast to strings
@@ -102,50 +91,40 @@ PRAGMA verify_parallelism
 
 # Single group
 query TT
-SELECT STRING_AGG(x,',' ORDER BY x ASC), STRING_AGG(x,y ORDER BY x ASC) FROM strings
+SELECT STRING_AGG(x ORDER BY x ASC), STRING_AGG(x, '|' ORDER BY x ASC) FROM strings
 ----
 a,b,i,j,p,x,y,z
-a-b/i+j/p/x-y+z
+a|b|i|j|p|x|y|z
 
 query TT
-SELECT STRING_AGG(x,',' ORDER BY x DESC), STRING_AGG(x,y ORDER BY x DESC) FROM strings
+SELECT STRING_AGG(x ORDER BY x DESC), STRING_AGG(x,'|' ORDER BY x DESC) FROM strings
 ----
 z,y,x,p,j,i,b,a
-z-y/x/p+j/i-b/a
+z|y|x|p|j|i|b|a
 
 # Constant separator
-query II
-SELECT g, STRING_AGG(x, ',' ORDER BY x ASC) FROM strings GROUP BY g ORDER BY 1
+query III
+SELECT g, STRING_AGG(x ORDER BY x ASC), STRING_AGG(x, '|' ORDER BY x ASC) FROM strings GROUP BY g ORDER BY 1
 ----
-1	a,b
-2	i,j
-3	p
-4	x,y,z
+1	a,b	a|b
+2	i,j	i|j
+3	p	p
+4	x,y,z	x|y|z
 
-query II
-SELECT g, STRING_AGG(x, ',' ORDER BY x DESC) FROM strings GROUP BY g ORDER BY 1
+query III
+SELECT g, STRING_AGG(x ORDER BY x DESC), STRING_AGG(x, '|' ORDER BY x DESC) FROM strings GROUP BY g ORDER BY 1
 ----
-1	b,a
-2	j,i
-3	p
-4	z,y,x
+1	b,a	b|a
+2	j,i	j|i
+3	p	p
+4	z,y,x	z|y|x
 
 # Variable separator
-query II
+statement error
 SELECT g, STRING_AGG(x, y ORDER BY x ASC) FROM strings GROUP BY g ORDER BY 1
-----
-1	a-b
-2	i+j
-3	p
-4	x-y+z
 
-query II
+statement error
 SELECT g, STRING_AGG(x, y ORDER BY x DESC) FROM strings GROUP BY g ORDER BY 1
-----
-1	b/a
-2	j/i
-3	p
-4	z-y/x
 
 # A more complex ORDER BY expression
 # Ordering [NULL a b i j p x y z]

--- a/test/sql/aggregate/aggregates/test_string_agg_big.test
+++ b/test/sql/aggregate/aggregates/test_string_agg_big.test
@@ -3,6 +3,9 @@
 # group: [aggregates]
 
 statement ok
+PRAGMA enable_verification
+
+statement ok
 PRAGMA verify_parallelism
 
 statement ok
@@ -14,9 +17,10 @@ SELECT COUNT(*) FROM (SELECT g, STRING_AGG(x,',') FROM strings GROUP BY g) t1
 100
 
 query I
-SELECT g, STRING_AGG(x,',') FROM strings GROUP BY g ORDER BY 1, 2
+SELECT g, STRING_AGG(x ORDER BY x DESC) FROM strings GROUP BY g ORDER BY 1, 2
 ----
-200 values hashing to b8126ea73f21372cdb3f2dc483106a12
+200 values hashing to d9069f92649cccb595d30934b2c25cbc
+
 
 query I
 SELECT g, STRING_AGG(x,',' ORDER BY x DESC) FROM strings GROUP BY g ORDER BY 1, 2

--- a/test/sql/aggregate/aggregates/test_string_agg_many_groups.test_slow
+++ b/test/sql/aggregate/aggregates/test_string_agg_many_groups.test_slow
@@ -3,6 +3,9 @@
 # group: [aggregates]
 
 statement ok
+PRAGMA enable_Verification
+
+statement ok
 PRAGMA verify_parallelism
 
 # generate a table

--- a/test/sql/window/test_window_string_agg.test
+++ b/test/sql/window/test_window_string_agg.test
@@ -33,12 +33,5 @@ select j, s, string_agg(s, '|') over (partition by j order by s) from a order by
 2	5	2|5
 
 # different separator per group
-query III
+statement error
 select j, s, string_agg(s, sep) over (partition by j order by s) from a order by j, s;
-----
-0	3	3
-0	6	3-6
-1	1	1
-1	4	1|4
-2	2	2
-2	5	2|5


### PR DESCRIPTION
This PR does some clean-up surrounding bind data, and forces aggregate functions to have a combine method defined (i.e. the combine is no longer optional).

* Aggregate functions must have a combine now.

Previously the only aggregate function that did not have a combine was `string_agg` with two arguments, where the second argument was a non-constant string (e.g. `string_agg(a, b)`). Since this is likely not useful anyway we now force the second argument of `string_agg` to be a constant.
* As part of the change to `string_agg`, we expose the function bind data to the `combine` method of an aggregate. This is so that the `combine` of `string_agg` can access the separator that is used.
* We now force the FunctionData to define `Copy` and `Equals` methods.

Previously `Equals` defaulted to `true` for the bind data, which is dangerous in some edge cases since this could cause common subexpression elimination to introduce bugs, particularly when child-expressions get removed. For example, `STRING_AGG(a, '|')` and `STRING_AGG(a, ',')` both become `STRING_AGG(a)` with a different bind-data. If the equality for the bind data is incorrect, the system will incorrectly assume the two expressions are identical.

* Make `Copy` and `Equals` `const` methods.
