### PR TITLE
Fix #3414: Correct typo in R license description

### DIFF
--- a/tools/rpkg/DESCRIPTION
+++ b/tools/rpkg/DESCRIPTION
@@ -39,7 +39,7 @@ Authors@R:
 Description: The DuckDB project is an embedded analytical data
     management system with support for the Structured Query Language (SQL). This package includes all of
     DuckDB and a R Database Interface (DBI) connector.
-License: MPL
+License: MIT
 URL: https://duckdb.org/, https://github.com/duckdb/duckdb
 BugReports: https://github.com/duckdb/duckdb/issues
 Depends:


### PR DESCRIPTION
DuckDB is MIT licensed