### PR TITLE
R Package License Fix

### DIFF
--- a/tools/rpkg/DESCRIPTION
+++ b/tools/rpkg/DESCRIPTION
@@ -39,7 +39,7 @@ Authors@R:
 Description: The DuckDB project is an embedded analytical data
     management system with support for the Structured Query Language (SQL). This package includes all of
     DuckDB and a R Database Interface (DBI) connector.
-License: MIT
+License: MIT + file LICENSE
 URL: https://duckdb.org/, https://github.com/duckdb/duckdb
 BugReports: https://github.com/duckdb/duckdb/issues
 Depends:

--- a/tools/rpkg/LICENSE
+++ b/tools/rpkg/LICENSE
@@ -1,0 +1,3 @@
+YEAR: 2018
+COPYRIGHT HOLDER: Stichting DuckDB Foundation
+

--- a/tools/rpkg/LICENSE
+++ b/tools/rpkg/LICENSE
@@ -1,3 +1,2 @@
 YEAR: 2018
 COPYRIGHT HOLDER: Stichting DuckDB Foundation
-


### PR DESCRIPTION
As noted in #3473, the MIT license requires an extra LICENSE file (format copied from [ggplot2](https://github.com/tidyverse/ggplot2/blob/main/LICENSE))