### PR TITLE
R: support structs

### DIFF
--- a/tools/rpkg/DESCRIPTION
+++ b/tools/rpkg/DESCRIPTION
@@ -56,6 +56,8 @@ Suggests:
     dbplyr,
     nycflights13,
     testthat,
+    tibble,
+    vctrs,
     withr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/tools/rpkg/R/Result.R
+++ b/tools/rpkg/R/Result.R
@@ -46,7 +46,7 @@ duckdb_execute <- function(res) {
 
 duckdb_post_execute <- function(res, out) {
   if (!res@arrow) {
-    out <- list_to_df(out)
+    stopifnot(is.data.frame(out))
 
     if (!res@stmt_lst$type %in% c("SELECT", "EXPLAIN")) {
       res@env$rows_affected <- sum(as.numeric(out[[1]]))
@@ -56,15 +56,6 @@ duckdb_post_execute <- function(res, out) {
   }
 
   out
-}
-
-list_to_df <- function(x) {
-  if (is.data.frame(x)) {
-    return(x)
-  }
-  attr(x, "row.names") <- c(NA_integer_, -length(x[[1]]))
-  class(x) <- c( "data.frame")
-  x
 }
 
 # as per is.integer documentation

--- a/tools/rpkg/R/dbBind__duckdb_result.R
+++ b/tools/rpkg/R/dbBind__duckdb_result.R
@@ -30,3 +30,12 @@ dbBind__duckdb_result <- function(res, params, ...) {
 #' @rdname duckdb_result-class
 #' @export
 setMethod("dbBind", "duckdb_result", dbBind__duckdb_result)
+
+list_to_df <- function(x) {
+  if (is.data.frame(x)) {
+    return(x)
+  }
+  attr(x, "row.names") <- c(NA_integer_, -NROW(x[[1]]))
+  class(x) <- "data.frame"
+  x
+}

--- a/tools/rpkg/R/dbFetch__duckdb_result.R
+++ b/tools/rpkg/R/dbFetch__duckdb_result.R
@@ -6,6 +6,14 @@ dbFetch__duckdb_result <- function(res, n = -1, ...) {
   if (!res@env$open) {
     stop("result set was closed")
   }
+
+  if (res@arrow) {
+    if (n != -1) {
+      stop("Cannot dbFetch() an Arrow result unless n = -1")
+    }
+    return(as.data.frame(duckdb::duckdb_fetch_arrow(res)))
+  }
+
   if (is.null(res@env$resultset)) {
     stop("Need to call `dbBind()` before `dbFetch()`")
   }
@@ -30,10 +38,6 @@ dbFetch__duckdb_result <- function(res, n = -1, ...) {
   if (res@stmt_lst$type != "SELECT") {
     warning("Should not call dbFetch() on results that do not come from SELECT")
     return(data.frame())
-  }
-
-  if (res@arrow) {
-    stop("Cannot dbFetch() an Arrow result")
   }
 
   timezone_out <- res@connection@timezone_out

--- a/tools/rpkg/src/include/rapi.hpp
+++ b/tools/rpkg/src/include/rapi.hpp
@@ -99,6 +99,7 @@ struct RStrings {
 	SEXP UTC_str; // Rf_mkString
 	SEXP Date_str;
 	SEXP factor_str;
+	SEXP dataframe_str;
 	SEXP difftime_str;
 	SEXP secs_str;
 	SEXP arrow_str; // StringsToSexp

--- a/tools/rpkg/src/utils.cpp
+++ b/tools/rpkg/src/utils.cpp
@@ -54,7 +54,7 @@ RStrings::RStrings() {
 	R_PreserveObject(strings);
 	MARK_NOT_MUTABLE(strings);
 
-	SEXP chars = r.Protect(Rf_allocVector(VECSXP, 7));
+	SEXP chars = r.Protect(Rf_allocVector(VECSXP, 8));
 	SET_VECTOR_ELT(chars, 0, UTC_str = Rf_mkString("UTC"));
 	SET_VECTOR_ELT(chars, 1, Date_str = Rf_mkString("Date"));
 	SET_VECTOR_ELT(chars, 2, difftime_str = Rf_mkString("difftime"));
@@ -62,6 +62,7 @@ RStrings::RStrings() {
 	SET_VECTOR_ELT(chars, 4, arrow_str = Rf_mkString("arrow"));
 	SET_VECTOR_ELT(chars, 5, POSIXct_POSIXt_str = StringsToSexp({"POSIXct", "POSIXt"}));
 	SET_VECTOR_ELT(chars, 6, factor_str = Rf_mkString("factor"));
+	SET_VECTOR_ELT(chars, 7, dataframe_str = Rf_mkString("data.frame"));
 
 	R_PreserveObject(chars);
 	MARK_NOT_MUTABLE(chars);

--- a/tools/rpkg/tests/testthat/test_struct.R
+++ b/tools/rpkg/tests/testthat/test_struct.R
@@ -1,0 +1,110 @@
+test_that("structs can be read", {
+  skip_if_not_installed("vctrs")
+
+  con <- dbConnect(duckdb::duckdb())
+  on.exit(dbDisconnect(con, shutdown = TRUE))
+
+  res <- dbGetQuery(con, "SELECT {'x': 100, 'y': 'hello', 'z': 3.14} AS s")
+  expect_equal(res, vctrs::data_frame(
+    s = vctrs::data_frame(x = 100L, y = "hello", z = 3.14)
+  ))
+
+  res <- dbGetQuery(con, "SELECT 1 AS n, {'x': 100, 'y': 'hello', 'z': 3.14} AS s")
+  expect_equal(res, vctrs::data_frame(
+    n = 1L,
+    s = vctrs::data_frame(x = 100L, y = "hello", z = 3.14)
+  ))
+
+  res <- dbGetQuery(con, "values (100, {'x': 100}), (200, {'x': 200}), (300, NULL)")
+  expect_equal(res, vctrs::data_frame(
+    col0 = c(100L, 200L, 300L),
+    col1 = vctrs::data_frame(x = c(100L, 200L, NA))
+  ))
+
+  res <- dbGetQuery(con, "values ('a', {'x': 100, 'y': {'a': 1, 'b': 2}}), ('b', {'x': 200, y: NULL}), ('c', NULL)")
+  expect_equal(res, vctrs::data_frame(
+    col0 = c("a", "b", "c"),
+    col1 = vctrs::data_frame(
+      x = c(100L, 200L, NA),
+      y = vctrs::data_frame(a = c(1L, NA, NA), b = c(2L, NA, NA))
+    )
+  ))
+
+  res <- dbGetQuery(con, "select 100 AS other, [{'x': 1, 'y': 'a'}, {'x': 2, 'y': 'b'}] AS s")
+  expect_equal(res, vctrs::data_frame(
+    other = 100L,
+    s = list(
+      vctrs::data_frame(x = c(1L, 2L), y = c("a", "b"))
+    )
+  ))
+
+  res <- dbGetQuery(con, "values ([{'x': 1, 'y': 'a'}, {'x': 2, 'y': 'b'}]), ([]), ([{'x': 1, 'y': 'a'}])")
+  expect_equal(res, vctrs::data_frame(
+    col0 = list(
+      vctrs::data_frame(x = c(1L, 2L), y = c("a", "b")),
+      vctrs::data_frame(x = integer(0), y = character(0)),
+      vctrs::data_frame(x = 1L, y = "a")
+    )
+  ))
+})
+
+test_that("structs give the same results via Arrow", {
+  skip_if_not_installed("vctrs")
+  skip_if_not_installed("tibble")
+  skip_if_not_installed("arrow")
+
+  con <- dbConnect(duckdb::duckdb())
+  on.exit(dbDisconnect(con, shutdown = TRUE))
+
+  res <- dbGetQuery(con, "SELECT {'x': 100, 'y': 'hello', 'z': 3.14} AS s", arrow = TRUE)
+  expect_equal(res, tibble::tibble(
+    s = tibble::tibble(x = 100L, y = "hello", z = 3.14)
+  ))
+
+  res <- dbGetQuery(con, "SELECT 1 AS n, {'x': 100, 'y': 'hello', 'z': 3.14} AS s", arrow = TRUE)
+  expect_equal(res, tibble::tibble(
+    n = 1L,
+    s = tibble::tibble(x = 100L, y = "hello", z = 3.14)
+  ))
+
+  res <- dbGetQuery(con, "values (100, {'x': 100}), (200, {'x': 200}), (300, NULL)", arrow = TRUE)
+  expect_equal(res, tibble::tibble(
+    col0 = c(100L, 200L, 300L),
+    col1 = tibble::tibble(x = c(100L, 200L, NA))
+  ))
+
+  res <- dbGetQuery(con, "values ('a', {'x': 100, 'y': {'a': 1, 'b': 2}}), ('b', {'x': 200, y: NULL}), ('c', NULL)", arrow = TRUE)
+  expect_equal(res, tibble::tibble(
+    col0 = c("a", "b", "c"),
+    col1 = tibble::tibble(
+      x = c(100L, 200L, NA),
+      y = tibble::tibble(a = c(1L, NA, NA), b = c(2L, NA, NA))
+    )
+  ))
+
+  res <- dbGetQuery(con, "select 100 AS other, [{'x': 1, 'y': 'a'}, {'x': 2, 'y': 'b'}] AS s", arrow = TRUE)
+  expect_equal(res, tibble::tibble(
+    other = 100L,
+    s = vctrs::new_list_of(
+      list(
+        tibble::tibble(x = c(1L, 2L), y = c("a", "b"))
+      ),
+      ptype = tibble::tibble(x = integer(), y = character()),
+      class = "arrow_list"
+    )
+  ))
+
+  res <- dbGetQuery(con, "values ([{'x': 1, 'y': 'a'}, {'x': 2, 'y': 'b'}]), ([]), ([{'x': 1, 'y': 'a'}])", arrow = TRUE)
+  expect_equal(res, tibble::tibble(
+    col0 = vctrs::new_list_of(
+      list(
+        tibble::tibble(x = c(1L, 2L), y = c("a", "b")),
+        tibble::tibble(x = integer(0), y = character(0)),
+        tibble::tibble(x = 1L, y = "a")
+      ),
+      ptype = tibble::tibble(x = integer(), y = character()),
+      class = "arrow_list"
+    )
+  ))
+})
+


### PR DESCRIPTION
This PR allows structs to be returned when running queries from R. Resolves #3334.

C++ side is pretty easy: I recursively build an R list by deferring to the allocate/transform methods of a struct column's children.

~~The R side is trickier... I convert a duckdb struct column to an R data frame which I think is the most intuitive thing to do. However base R data frames really struggle with nested data whereas tibbles support it well. So I've added an option to dbConnect (defaults to false) allowing output to be returned as tibbles rather than data frames. (Personally I favour tibbles everywhere but this [upsets](https://github.com/r-dbi/odbc/issues/3) some people and is an extra dependency.)~~

The R output is now a just a plain old data frame, not a tibble. If the C++ code sets the necessary attributes, then nested and packed columns seem to be supported okay in base R (but for some reason they are difficult to *construct* in base R; `as.data.frame` in particular chokes).


