### PR TITLE
Use filesystem from database config

### DIFF
--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -54,8 +54,7 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 	auto copy = make_unique<LogicalCopyToFile>(copy_function->function, move(function_data));
 	copy->file_path = stmt.info->file_path;
 	copy->use_tmp_file = use_tmp_file;
-	LocalFileSystem fs;
-	copy->is_file_and_exists = fs.FileExists(copy->file_path);
+	copy->is_file_and_exists = config.file_system->FileExists(copy->file_path);
 
 	copy->AddChild(move(select_node.plan));
 


### PR DESCRIPTION
This reference to the local filesystem bypasses the filesystem of the database config.