### PR TITLE
Bug fixes for ENUMs

### DIFF
--- a/src/optimizer/rule/enum_comparison.cpp
+++ b/src/optimizer/rule/enum_comparison.cpp
@@ -63,7 +63,7 @@ unique_ptr<Expression> EnumComparisonRule::Apply(LogicalOperator &op, vector<Exp
 	}
 
 	auto cast_left_to_right =
-	    make_unique<BoundCastExpression>(move(left_child->child), right_child->child->return_type);
+	    make_unique<BoundCastExpression>(move(left_child->child), right_child->child->return_type, true);
 
 	return make_unique<BoundComparisonExpression>(root->type, move(cast_left_to_right), move(right_child->child));
 }

--- a/test/sql/types/enum/test_3479.test
+++ b/test/sql/types/enum/test_3479.test
@@ -1,0 +1,28 @@
+# name: test/sql/types/enum/test_3479.test
+# description: Test Enum -> Enum invalid conversion
+# group: [enum]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');
+
+statement ok
+CREATE TYPE mood_2 AS ENUM ('1', '2', '3');
+
+statement ok
+CREATE TABLE m (
+    m mood
+);
+
+statement ok
+CREATE TABLE m_2 (
+    m mood_2
+);
+
+statement ok
+insert into m_2 values ('1')
+
+statement error
+insert into m SELECT * FROM m_2

--- a/test/sql/types/enum/test_enum_comparisons.test
+++ b/test/sql/types/enum/test_enum_comparisons.test
@@ -170,13 +170,9 @@ SELECT * FROM person_pet_den WHERE (person_mood == pet_mood) IS NULL
 Tim	Chorizo	ok	NULL
 
 # Explicit casts from one enum to another
-query I
+statement error
 SELECT person_mood::pet_mood FROM person_pet_den
-----
-happy
-quackity-quack
-NULL
-NULL
+
 
 # Use enums as normal strings (testing e.g. substr, LIKE, REGEXP_MATCHES).
 query T

--- a/tools/pythonpkg/src/array_wrapper.cpp
+++ b/tools/pythonpkg/src/array_wrapper.cpp
@@ -761,24 +761,13 @@ void NumpyResultConversion::Resize(idx_t new_capacity) {
 	capacity = new_capacity;
 }
 
-void NumpyResultConversion::Append(DataChunk &chunk, unordered_map<idx_t, py::list> *categories) {
+void NumpyResultConversion::Append(DataChunk &chunk) {
 	if (count + chunk.size() > capacity) {
 		Resize(capacity * 2);
 	}
 	auto chunk_types = chunk.GetTypes();
 	for (idx_t col_idx = 0; col_idx < owned_data.size(); col_idx++) {
 		owned_data[col_idx].Append(count, chunk.data[col_idx], chunk.size());
-		if (chunk_types[col_idx].id() == LogicalTypeId::ENUM) {
-			D_ASSERT(categories);
-			// It's an ENUM type, in addition to converting the codes we must convert the categories
-			if (categories->find(col_idx) == categories->end()) {
-				auto &categories_list = EnumType::GetValuesInsertOrder(chunk.data[col_idx].GetType());
-				auto categories_size = EnumType::GetSize(chunk.data[col_idx].GetType());
-				for (idx_t i = 0; i < categories_size; i++) {
-					(*categories)[col_idx].append(py::cast(categories_list.GetValue(i).ToString()));
-				}
-			}
-		}
 	}
 	count += chunk.size();
 #ifdef DEBUG

--- a/tools/pythonpkg/src/include/duckdb_python/array_wrapper.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/array_wrapper.hpp
@@ -44,7 +44,7 @@ class NumpyResultConversion {
 public:
 	NumpyResultConversion(vector<LogicalType> &types, idx_t initial_capacity);
 
-	void Append(DataChunk &chunk, unordered_map<idx_t, py::list> *categories = nullptr);
+	void Append(DataChunk &chunk);
 
 	py::object ToArray(idx_t col_idx) {
 		return owned_data[col_idx].ToArray(count);

--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_enum.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_enum.py
@@ -1,0 +1,18 @@
+import duckdb
+import pandas as pd
+
+class TestPandasEnum(object):
+    def test_3480(self, duckdb_cursor):
+        duckdb_cursor.execute(
+        """
+        create type cat as enum ('marie', 'duchess', 'toulouse');
+        create table tab (
+            cat cat,
+            amt int
+        );
+        """
+        )
+        df = duckdb_cursor.query(f"SELECT * FROM tab LIMIT 0;").to_df()
+        assert df["cat"].cat.categories.equals(pd.Index(['marie', 'duchess', 'toulouse']))
+
+

--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_enum.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_enum.py
@@ -1,5 +1,5 @@
-import duckdb
 import pandas as pd
+import pytest
 
 class TestPandasEnum(object):
     def test_3480(self, duckdb_cursor):
@@ -15,4 +15,21 @@ class TestPandasEnum(object):
         df = duckdb_cursor.query(f"SELECT * FROM tab LIMIT 0;").to_df()
         assert df["cat"].cat.categories.equals(pd.Index(['marie', 'duchess', 'toulouse']))
 
+    def test_3479(self, duckdb_cursor):
+        duckdb_cursor.execute(
+        """
+        create type cat as enum ('marie', 'duchess', 'toulouse');
+        create table tab (
+            cat cat,
+            amt int
+        );
+        """
+        )
+
+        df = pd.DataFrame({"cat2": pd.Series(['duchess', 'toulouse', 'marie', None, "berlioz", "o_malley"], dtype="category"), "amt": [1, 2, 3, 4, 5, 6]})
+        duckdb_cursor.register('df', df)
+        with pytest.raises(Exception):
+            duckdb_cursor.execute(f"INSERT INTO tab SELECT * FROM df;")
+
+        assert duckdb_cursor.execute("select * from tab").fetchall() == []
 


### PR DESCRIPTION
Fix: #3479 and #3480 

We make sure to properly throw errors with ENUM to ENUM ```cast``` and to transform the categories on empty ENUMs.