### PR TITLE
Fix #3505: Correctly handle Foreign Key syntax for when primary-key columns are not specified

### DIFF
--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -899,7 +899,7 @@ void ART::VerifyExistence(DataChunk &chunk, VerifyExistenceType verify_type, str
 		case VerifyExistenceType::APPEND_FK: {
 			// found node no exists in tree
 			exception_msg =
-			    "violates foreign key constraint because key \"" + key_name + "\" no exist in referenced table";
+			    "violates foreign key constraint because key \"" + key_name + "\" does not exist in referenced table";
 			break;
 		}
 		case VerifyExistenceType::DELETE_FK: {

--- a/src/parser/transform/constraint/transform_constraint.cpp
+++ b/src/parser/transform/constraint/transform_constraint.cpp
@@ -37,10 +37,12 @@ unique_ptr<Constraint> Transformer::TransformConstraint(duckdb_libpgquery::PGLis
 		for (auto kc = constraint->fk_attrs->head; kc; kc = kc->next) {
 			fk_columns.emplace_back(reinterpret_cast<duckdb_libpgquery::PGValue *>(kc->data.ptr_value)->val.str);
 		}
-		for (auto kc = constraint->pk_attrs->head; kc; kc = kc->next) {
-			pk_columns.emplace_back(reinterpret_cast<duckdb_libpgquery::PGValue *>(kc->data.ptr_value)->val.str);
+		if (constraint->pk_attrs) {
+			for (auto kc = constraint->pk_attrs->head; kc; kc = kc->next) {
+				pk_columns.emplace_back(reinterpret_cast<duckdb_libpgquery::PGValue *>(kc->data.ptr_value)->val.str);
+			}
 		}
-		if (pk_columns.size() != fk_columns.size()) {
+		if (!pk_columns.empty() && pk_columns.size() != fk_columns.size()) {
 			throw ParserException("The number of referencing and referenced columns for foreign keys must be the same");
 		}
 		if (fk_columns.empty()) {

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -27,6 +27,7 @@
 #include "duckdb/parser/constraints/foreign_key_constraint.hpp"
 #include "duckdb/function/scalar_macro_function.hpp"
 #include "duckdb/storage/data_table.hpp"
+#include "duckdb/parser/constraints/unique_constraint.hpp"
 
 namespace duckdb {
 
@@ -152,6 +153,35 @@ void Binder::BindLogicalType(ClientContext &context, LogicalType &type, const st
 	}
 }
 
+static void FindMatchingPrimaryKeyColumns(vector<unique_ptr<Constraint>> &constraints, ForeignKeyConstraint &fk) {
+	if (!fk.pk_columns.empty()) {
+		return;
+	}
+	// find the matching primary key constraint
+	for (auto &constr : constraints) {
+		if (constr->type != ConstraintType::UNIQUE) {
+			continue;
+		}
+		auto &unique = (UniqueConstraint &)*constr;
+		if (!unique.is_primary_key) {
+			continue;
+		}
+		idx_t column_count;
+		if (unique.index != DConstants::INVALID_INDEX) {
+			fk.info.pk_keys.push_back(unique.index);
+			column_count = 1;
+		} else {
+			fk.pk_columns = unique.columns;
+			column_count = unique.columns.size();
+		}
+		if (column_count != fk.fk_columns.size()) {
+			throw BinderException("The number of referencing and referenced columns for foreign keys must be the same");
+		}
+		return;
+	}
+	throw BinderException("there is no primary key for referenced table \"%s\"", fk.info.table);
+}
+
 BoundStatement Binder::Bind(CreateStatement &stmt) {
 	BoundStatement result;
 	result.names = {"Count"};
@@ -232,13 +262,15 @@ BoundStatement Binder::Bind(CreateStatement &stmt) {
 			if (fk.info.type != ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE) {
 				continue;
 			}
-			D_ASSERT(fk.info.pk_keys.empty() && !fk.pk_columns.empty());
+			D_ASSERT(fk.info.pk_keys.empty());
 			if (create_info.table == fk.info.table) {
 				fk.info.type = ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE;
+				FindMatchingPrimaryKeyColumns(create_info.constraints, fk);
 			} else {
 				// have to resolve referenced table
 				auto pk_table_entry_ptr = catalog.GetEntry<TableCatalogEntry>(context, fk.info.schema, fk.info.table);
-				D_ASSERT(!fk.pk_columns.empty() && fk.info.pk_keys.empty());
+				D_ASSERT(fk.info.pk_keys.empty());
+				FindMatchingPrimaryKeyColumns(pk_table_entry_ptr->constraints, fk);
 				for (auto &keyname : fk.pk_columns) {
 					auto entry = pk_table_entry_ptr->name_map.find(keyname);
 					if (entry == pk_table_entry_ptr->name_map.end()) {

--- a/test/sql/constraints/foreignkey/foreign_key_matching_columns.test
+++ b/test/sql/constraints/foreignkey/foreign_key_matching_columns.test
@@ -16,7 +16,7 @@ CREATE TABLE routes (
 statement ok
 CREATE TABLE agency (
 	agency_id TEXT PRIMARY KEY,
-	agency_name TEXT NOT NULL
+	agency_name TEXT UNIQUE NOT NULL
 );
 
 # column count mismatch
@@ -83,3 +83,25 @@ INSERT INTO routes VALUES (2, 2);
 
 statement ok
 INSERT INTO routes VALUES (2, 1);
+
+# multi-column primary key constraint
+statement ok
+DROP TABLE routes;
+
+statement ok
+DROP TABLE agency;
+
+statement ok
+CREATE TABLE agency (
+	agency_id TEXT,
+	agency_id_2 TEXT,
+	agency_name TEXT NOT NULL,
+	PRIMARY KEY (agency_id, agency_id_2)
+);
+
+statement ok
+CREATE TABLE routes (
+	route_id TEXT PRIMARY KEY,
+	agency_id TEXT,
+	FOREIGN KEY (route_id, agency_id) REFERENCES agency
+);

--- a/test/sql/constraints/foreignkey/foreign_key_matching_columns.test
+++ b/test/sql/constraints/foreignkey/foreign_key_matching_columns.test
@@ -1,0 +1,85 @@
+# name: test/sql/constraints/foreignkey/foreign_key_matching_columns.test
+# description: Issue #3505: foreign key support without an explicit column name
+# group: [foreignkey]
+
+statement ok
+PRAGMA enable_verification
+
+# non-existant reference
+statement error
+CREATE TABLE routes (
+	route_id TEXT PRIMARY KEY,
+	agency_id TEXT,
+	FOREIGN KEY (agency_id) REFERENCES agency
+);
+
+statement ok
+CREATE TABLE agency (
+	agency_id TEXT PRIMARY KEY,
+	agency_name TEXT NOT NULL
+);
+
+# column count mismatch
+statement error
+CREATE TABLE routes (
+	route_id TEXT PRIMARY KEY,
+	agency_id TEXT,
+	FOREIGN KEY (route_id, agency_id) REFERENCES agency
+);
+
+statement ok
+CREATE TABLE routes (
+	route_id TEXT PRIMARY KEY,
+	agency_id TEXT,
+	FOREIGN KEY (agency_id) REFERENCES agency
+);
+
+# verify foreign key functionality
+statement error
+INSERT INTO routes VALUES (1, 1);
+
+statement ok
+INSERT INTO agency VALUES (1, 1);
+
+statement ok
+INSERT INTO routes VALUES (1, 1);
+
+# now without a primary key
+statement error
+DROP TABLE agency;
+
+statement ok
+DROP TABLE routes;
+
+statement ok
+DROP TABLE agency;
+
+statement ok
+CREATE TABLE agency (
+	agency_id TEXT,
+	agency_name TEXT NOT NULL
+);
+
+statement error
+CREATE TABLE routes (
+	route_id TEXT PRIMARY KEY,
+	agency_id TEXT,
+	FOREIGN KEY (agency_id) REFERENCES agency
+);
+
+# self-referential primary key
+statement ok
+CREATE TABLE routes (
+	route_id TEXT PRIMARY KEY,
+	agency_id TEXT,
+	FOREIGN KEY (agency_id) REFERENCES routes
+);
+
+statement ok
+INSERT INTO routes VALUES (1, NULL);
+
+statement error
+INSERT INTO routes VALUES (2, 2);
+
+statement ok
+INSERT INTO routes VALUES (2, 1);


### PR DESCRIPTION
Fixes #3505