### PR TITLE
Support in-place updates for unsigned integers

### DIFF
--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -302,14 +302,26 @@ static void UpdateChunk(Vector &data, Vector &updates, Vector &row_ids, idx_t co
 	case PhysicalType::INT8:
 		TemplatedUpdateLoop<int8_t>(data, updates, row_ids, count, base_index);
 		break;
+	case PhysicalType::UINT8:
+		TemplatedUpdateLoop<uint8_t>(data, updates, row_ids, count, base_index);
+		break;
 	case PhysicalType::INT16:
 		TemplatedUpdateLoop<int16_t>(data, updates, row_ids, count, base_index);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedUpdateLoop<uint16_t>(data, updates, row_ids, count, base_index);
 		break;
 	case PhysicalType::INT32:
 		TemplatedUpdateLoop<int32_t>(data, updates, row_ids, count, base_index);
 		break;
+	case PhysicalType::UINT32:
+		TemplatedUpdateLoop<uint32_t>(data, updates, row_ids, count, base_index);
+		break;
 	case PhysicalType::INT64:
 		TemplatedUpdateLoop<int64_t>(data, updates, row_ids, count, base_index);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedUpdateLoop<uint64_t>(data, updates, row_ids, count, base_index);
 		break;
 	case PhysicalType::FLOAT:
 		TemplatedUpdateLoop<float>(data, updates, row_ids, count, base_index);

--- a/test/issues/general/test_3518.test
+++ b/test/issues/general/test_3518.test
@@ -1,0 +1,23 @@
+# name: test/issues/general/test_3518.test
+# description: Issue 3518: Exception thrown when inserting and updating an unsigned integer column in the same row in a transaction
+# group: [general]
+
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
+CREATE TABLE test (c1 UTINYINT, c2 USMALLINT, c3 UINTEGER, c4 UBIGINT);
+
+statement ok
+INSERT INTO test VALUES (1, 1, 1, 1);
+
+statement ok
+UPDATE test SET c1 = 2, c2 = 2, c3 = 2, c4 = 2;
+
+statement ok
+COMMIT;
+
+query IIII
+SELECT c1, c2, c3, c4 FROM test;
+----
+2	2	2	2


### PR DESCRIPTION
Fixes #https://github.com/duckdb/duckdb/issues/3518

@Mytherin / @hannes , there are other `PhysicalType` variants which are of fixed size that aren't caught by the match arms here. I'm talking about HUGEINT / i128, DATE32, DATE64, etc. All of those should be in the match arms here, right? 

Judging by the fact that VARCHAR is on this list, even variable-size data types can be updated in place. 
If that is the case, why are any `PhysicalType` variants missing from the match arms here? Shouldn't all `PhysicalType`s be added to the match arms?