### PR TITLE
Exit with the correct exit code in the regression test runner

### DIFF
--- a/scripts/regression_test_runner.py
+++ b/scripts/regression_test_runner.py
@@ -145,3 +145,5 @@ for res in other_results:
     print(f"Old timing: {res[1]}")
     print(f"New timing: {res[2]}")
     print("")
+
+exit(exit_code)


### PR DESCRIPTION
This got lost at some point and now the regression tests (incorrectly) pass even if a regression is detected