### PR TITLE
Issue #2910: Support pandas boolean datatype

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/vector_conversion.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/vector_conversion.hpp
@@ -15,6 +15,7 @@
 namespace duckdb {
 
 enum class PandasType : uint8_t {
+	BOOL,
 	BOOLEAN,
 	TINYINT,
 	SMALLINT,

--- a/tools/pythonpkg/src/vector_conversion.cpp
+++ b/tools/pythonpkg/src/vector_conversion.cpp
@@ -376,7 +376,8 @@ void VectorConversion::BindPandas(py::handle original_df, vector<PandasColumnBin
 		LogicalType duckdb_col_type;
 		PandasColumnBindData bind_data;
 		auto col_type = string(py::str(df_types[col_idx]));
-		if (col_type == "Int8" || col_type == "Int16" || col_type == "Int32" || col_type == "Int64" || col_type == "boolean") {
+		if (col_type == "Int8" || col_type == "Int16" || col_type == "Int32" || col_type == "Int64" ||
+		    col_type == "boolean") {
 			// masked object
 			// fetch the internal data and mask array
 			bind_data.numpy_col = get_fun(df_columns[col_idx]).attr("array").attr("_data");

--- a/tools/pythonpkg/src/vector_conversion.cpp
+++ b/tools/pythonpkg/src/vector_conversion.cpp
@@ -47,7 +47,7 @@ void ScanPandasCategory(py::array &column, idx_t count, idx_t offset, Vector &ou
 }
 
 template <class T>
-void ScanPandasNumeric(PandasColumnBindData &bind_data, idx_t count, idx_t offset, Vector &out) {
+void ScanPandasMasked(PandasColumnBindData &bind_data, idx_t count, idx_t offset, Vector &out) {
 	ScanPandasColumn<T>(bind_data.numpy_col, bind_data.numpy_stride, offset, out, count);
 	auto &result_mask = FlatVector::Validity(out);
 	if (bind_data.mask) {
@@ -113,31 +113,34 @@ void VectorConversion::NumpyToDuckDB(PandasColumnBindData &bind_data, py::array 
                                      Vector &out) {
 	switch (bind_data.pandas_type) {
 	case PandasType::BOOLEAN:
+		ScanPandasMasked<bool>(bind_data, count, offset, out);
+		break;
+	case PandasType::BOOL:
 		ScanPandasColumn<bool>(numpy_col, bind_data.numpy_stride, offset, out, count);
 		break;
 	case PandasType::UTINYINT:
-		ScanPandasNumeric<uint8_t>(bind_data, count, offset, out);
+		ScanPandasMasked<uint8_t>(bind_data, count, offset, out);
 		break;
 	case PandasType::USMALLINT:
-		ScanPandasNumeric<uint16_t>(bind_data, count, offset, out);
+		ScanPandasMasked<uint16_t>(bind_data, count, offset, out);
 		break;
 	case PandasType::UINTEGER:
-		ScanPandasNumeric<uint32_t>(bind_data, count, offset, out);
+		ScanPandasMasked<uint32_t>(bind_data, count, offset, out);
 		break;
 	case PandasType::UBIGINT:
-		ScanPandasNumeric<uint64_t>(bind_data, count, offset, out);
+		ScanPandasMasked<uint64_t>(bind_data, count, offset, out);
 		break;
 	case PandasType::TINYINT:
-		ScanPandasNumeric<int8_t>(bind_data, count, offset, out);
+		ScanPandasMasked<int8_t>(bind_data, count, offset, out);
 		break;
 	case PandasType::SMALLINT:
-		ScanPandasNumeric<int16_t>(bind_data, count, offset, out);
+		ScanPandasMasked<int16_t>(bind_data, count, offset, out);
 		break;
 	case PandasType::INTEGER:
-		ScanPandasNumeric<int32_t>(bind_data, count, offset, out);
+		ScanPandasMasked<int32_t>(bind_data, count, offset, out);
 		break;
 	case PandasType::BIGINT:
-		ScanPandasNumeric<int64_t>(bind_data, count, offset, out);
+		ScanPandasMasked<int64_t>(bind_data, count, offset, out);
 		break;
 	case PandasType::FLOAT:
 		ScanPandasFpColumn<float>((float *)numpy_col.data(), count, offset, out);
@@ -288,6 +291,9 @@ void VectorConversion::NumpyToDuckDB(PandasColumnBindData &bind_data, py::array 
 static void ConvertPandasType(const string &col_type, LogicalType &duckdb_col_type, PandasType &pandas_type) {
 	if (col_type == "bool") {
 		duckdb_col_type = LogicalType::BOOLEAN;
+		pandas_type = PandasType::BOOL;
+	} else if (col_type == "boolean") {
+		duckdb_col_type = LogicalType::BOOLEAN;
 		pandas_type = PandasType::BOOLEAN;
 	} else if (col_type == "uint8" || col_type == "Uint8") {
 		duckdb_col_type = LogicalType::UTINYINT;
@@ -370,8 +376,8 @@ void VectorConversion::BindPandas(py::handle original_df, vector<PandasColumnBin
 		LogicalType duckdb_col_type;
 		PandasColumnBindData bind_data;
 		auto col_type = string(py::str(df_types[col_idx]));
-		if (col_type == "Int8" || col_type == "Int16" || col_type == "Int32" || col_type == "Int64") {
-			// numeric object
+		if (col_type == "Int8" || col_type == "Int16" || col_type == "Int32" || col_type == "Int64" || col_type == "boolean") {
+			// masked object
 			// fetch the internal data and mask array
 			bind_data.numpy_col = get_fun(df_columns[col_idx]).attr("array").attr("_data");
 			bind_data.mask = make_unique<NumPyArrayWrapper>(get_fun(df_columns[col_idx]).attr("array").attr("_mask"));

--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_types.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_types.py
@@ -22,7 +22,20 @@ class TestPandasTypes(object):
     def test_pandas_bool(self, duckdb_cursor):
         data = numpy.array([True,False,False,True])
         round_trip(data,'bool')
-        
+    
+    def test_pandas_boolean(self, duckdb_cursor):
+        data = numpy.array([True,None,pd.NA,numpy.nan,True])
+        df_in = pd.DataFrame({
+            'object': pd.Series(data, dtype='boolean'),
+        })
+
+        df_out = duckdb.query_df(df_in, "data", "SELECT * FROM data").df()
+        assert df_out['object'][0] == df_in['object'][0]
+        assert numpy.isnan(df_out['object'][1])
+        assert numpy.isnan(df_out['object'][2])
+        assert numpy.isnan(df_out['object'][3])
+        assert df_out['object'][4] == df_in['object'][4]
+
     def test_pandas_float32(self, duckdb_cursor):
         data = numpy.array([0.1,0.32,0.78, numpy.nan])
         df_in = pd.DataFrame({


### PR DESCRIPTION
Support Pandas experimental boolean datatype and Boolean Array and Fixes #2910.
[https://pandas.pydata.org/docs/reference/api/pandas.arrays.BooleanArray.html#pandas.arrays.BooleanArray](https://pandas.pydata.org/docs/reference/api/pandas.arrays.BooleanArray.html#pandas.arrays.BooleanArray)
