### PR TITLE
ICU Extension Rework: clangd for extensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,6 @@ sqlsmith: debug
 clangd:
 	mkdir -p ./build/clangd && \
 	cd ./build/clangd && \
-	cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ../.. && \
+	cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ${EXTENSIONS} ../.. && \
 	cd ../.. && \
 	ln -sf ./build/clangd/compile_commands.json ./compile_commands.json


### PR DESCRIPTION
Add ${Extensions} to the clangd invocation
to generate the data for editing the developer's extension builds.