### PR TITLE
Support parallel result set materialization of base table scan pipeline

### DIFF
--- a/src/common/enums/physical_operator_type.cpp
+++ b/src/common/enums/physical_operator_type.cpp
@@ -117,6 +117,8 @@ string PhysicalOperatorToString(PhysicalOperatorType type) {
 		return "INOUT_FUNCTION";
 	case PhysicalOperatorType::CREATE_TYPE:
 		return "CREATE_TYPE";
+	case PhysicalOperatorType::MATERIALIZE:
+		return "MATERIALIZE";
 	case PhysicalOperatorType::INVALID:
 		break;
 	}

--- a/src/execution/CMakeLists.txt
+++ b/src/execution/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library_unity(
   perfect_aggregate_hashtable.cpp
   physical_operator.cpp
   physical_plan_generator.cpp
+  physical_materialize.cpp
   radix_partitioned_hashtable.cpp
   reservoir_sample.cpp
   window_segment_tree.cpp)

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -72,6 +72,10 @@ unique_ptr<GlobalSourceState> PhysicalTableScan::GetGlobalSourceState(ClientCont
 	return make_unique<TableScanGlobalState>(context, *this);
 }
 
+bool PhysicalTableScan::OrderedSource() const {
+    return function.ordered_scan_function;
+}
+
 void PhysicalTableScan::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
                                 LocalSourceState &lstate) const {
 	D_ASSERT(!column_ids.empty());

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -107,6 +107,10 @@ void PhysicalTableScan::GetData(ExecutionContext &context, DataChunk &chunk, Glo
 					break;
 				}
 			} else {
+			    lstate.is_ordered = state.operator_data->is_ordered;
+                if (lstate.is_ordered) {
+                    lstate.source_index = ((OrderedFunctionOperatorData*)(state.operator_data.get()))->data_index;
+                }
 				return;
 			}
 		} while (true);

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include "duckdb/execution/operator/scan/physical_table_scan.hpp"
 
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -74,15 +74,15 @@ unique_ptr<GlobalSourceState> PhysicalTableScan::GetGlobalSourceState(ClientCont
 }
 
 bool PhysicalTableScan::OrderedSource() const {
-    return function.ordered_scan_function;
+	return function.ordered_scan_function;
 }
 
 void PhysicalTableScan::SetOrder(TableScanLocalState &lstate) const {
-    if (OrderedSource()) {
-        D_ASSERT(lstate.operator_data->is_ordered);
-        lstate.is_ordered = true;
-        lstate.source_index = ((OrderedFunctionOperatorData*)(lstate.operator_data.get()))->data_index;
-    }
+	if (OrderedSource()) {
+		D_ASSERT(lstate.operator_data->is_ordered);
+		lstate.is_ordered = true;
+		lstate.source_index = ((OrderedFunctionOperatorData *)(lstate.operator_data.get()))->data_index;
+	}
 }
 
 void PhysicalTableScan::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,

--- a/src/execution/physical_materialize.cpp
+++ b/src/execution/physical_materialize.cpp
@@ -1,0 +1,81 @@
+#include <iostream>
+#include "duckdb/execution/physical_materialize.hpp"
+#include "duckdb/common/types/chunk_collection.hpp"
+
+namespace duckdb {
+
+    using collection_map_t = std::map<idx_t, unique_ptr<ChunkCollection>>;
+
+PhysicalMaterialize::PhysicalMaterialize(vector<LogicalType> types, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::MATERIALIZE, move(types), estimated_cardinality) {
+}
+
+class MaterializeGlobalSinkState : public GlobalSinkState {
+public:
+    explicit MaterializeGlobalSinkState() : finished(false) {
+    }
+
+    mutex lock;
+    ChunkCollection result_set;
+    collection_map_t collection_map;
+    bool finished;
+};
+
+unique_ptr<GlobalSinkState> PhysicalMaterialize::GetGlobalSinkState(ClientContext & context) const {
+    return make_unique<MaterializeGlobalSinkState>();
+}
+
+class MaterializeLocalSinkState : public LocalSinkState {
+public:
+    explicit MaterializeLocalSinkState() {}
+    vector<idx_t> data_indexes;
+    vector<unique_ptr<ChunkCollection>> collections;
+};
+
+unique_ptr<LocalSinkState> PhysicalMaterialize::GetLocalSinkState(ExecutionContext &context) const {
+    return make_unique<MaterializeLocalSinkState>();
+}
+
+SinkResultType PhysicalMaterialize::Sink(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate,
+        DataChunk &input) const {
+    D_ASSERT(lstate.is_ordered);
+    D_ASSERT(lstate.source_index != DConstants::INVALID_INDEX);
+
+    auto &local_state = (MaterializeLocalSinkState &)lstate;
+    auto index = lstate.source_index;
+
+    if (local_state.data_indexes.empty() || local_state.data_indexes.back() != index) {
+        local_state.data_indexes.push_back(index);
+        local_state.collections.emplace_back(make_unique<ChunkCollection>());
+    }
+    local_state.collections.back()->Append(input);
+
+    return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalMaterialize::Combine(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate) const {
+    auto &gstate = (MaterializeGlobalSinkState &)state;
+    auto &source = (MaterializeLocalSinkState &)lstate;
+    D_ASSERT(!gstate.finished);
+
+    lock_guard<mutex> glock(gstate.lock);
+    for (idx_t i = 0; i < source.data_indexes.size(); i++) {
+        // TODO: transaction local storage?
+        D_ASSERT(gstate.collection_map.find(source.data_indexes[i]) == gstate.collection_map.end());
+        gstate.collection_map[source.data_indexes[i]] = move(source.collections[i]);
+    }
+}
+
+SinkFinalizeType PhysicalMaterialize::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+        GlobalSinkState &gstate_p) const {
+    auto &gstate = (MaterializeGlobalSinkState &)gstate_p;
+    D_ASSERT(!gstate.finished);
+    for (auto & iter : gstate.collection_map) {
+        gstate.result_set.Append(*iter.second);
+    }
+    gstate.finished = true;
+    return SinkFinalizeType::READY;
+}
+
+
+} // namespace duckdb

--- a/src/execution/physical_materialize.cpp
+++ b/src/execution/physical_materialize.cpp
@@ -4,7 +4,7 @@
 
 namespace duckdb {
 
-    using collection_map_t = std::map<idx_t, unique_ptr<ChunkCollection>>;
+using collection_map_t = std::map<idx_t, unique_ptr<ChunkCollection>>;
 
 PhysicalMaterialize::PhysicalMaterialize(vector<LogicalType> types, idx_t estimated_cardinality)
     : PhysicalOperator(PhysicalOperatorType::MATERIALIZE, move(types), estimated_cardinality) {
@@ -12,74 +12,75 @@ PhysicalMaterialize::PhysicalMaterialize(vector<LogicalType> types, idx_t estima
 
 class MaterializeGlobalSinkState : public GlobalSinkState {
 public:
-    explicit MaterializeGlobalSinkState() : finished(false) {
-    }
+	explicit MaterializeGlobalSinkState() : finished(false) {
+	}
 
-    mutex lock;
-    ChunkCollection result_set;
-    collection_map_t collection_map;
-    bool finished;
+	mutex lock;
+	ChunkCollection result_set;
+	collection_map_t collection_map;
+	bool finished;
 };
 
-unique_ptr<GlobalSinkState> PhysicalMaterialize::GetGlobalSinkState(ClientContext & context) const {
-    return make_unique<MaterializeGlobalSinkState>();
+unique_ptr<GlobalSinkState> PhysicalMaterialize::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<MaterializeGlobalSinkState>();
 }
 
 class MaterializeLocalSinkState : public LocalSinkState {
 public:
-    explicit MaterializeLocalSinkState() {}
-    vector<idx_t> data_indexes;
-    vector<unique_ptr<ChunkCollection>> collections;
+	explicit MaterializeLocalSinkState() {
+	}
+	vector<idx_t> data_indexes;
+	vector<unique_ptr<ChunkCollection>> collections;
 };
 
 unique_ptr<LocalSinkState> PhysicalMaterialize::GetLocalSinkState(ExecutionContext &context) const {
-    return make_unique<MaterializeLocalSinkState>();
+	return make_unique<MaterializeLocalSinkState>();
 }
 
 SinkResultType PhysicalMaterialize::Sink(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate,
-        DataChunk &input) const {
-    D_ASSERT(lstate.is_ordered);
-    D_ASSERT(lstate.source_index != DConstants::INVALID_INDEX);
+                                         DataChunk &input) const {
+	D_ASSERT(lstate.is_ordered);
+	D_ASSERT(lstate.source_index != DConstants::INVALID_INDEX);
 
-    auto &local_state = (MaterializeLocalSinkState &)lstate;
-    auto index = lstate.source_index;
+	auto &local_state = (MaterializeLocalSinkState &)lstate;
+	auto index = lstate.source_index;
 
-    if (local_state.data_indexes.empty() || local_state.data_indexes.back() != index) {
-        local_state.data_indexes.push_back(index);
-        local_state.collections.emplace_back(make_unique<ChunkCollection>());
-    }
-    local_state.collections.back()->Append(input);
+	if (local_state.data_indexes.empty() || local_state.data_indexes.back() != index) {
+		local_state.data_indexes.push_back(index);
+		local_state.collections.emplace_back(make_unique<ChunkCollection>());
+	}
+	local_state.collections.back()->Append(input);
 
-    return SinkResultType::NEED_MORE_INPUT;
+	return SinkResultType::NEED_MORE_INPUT;
 }
 
 void PhysicalMaterialize::Combine(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate) const {
-    auto &gstate = (MaterializeGlobalSinkState &)state;
-    auto &source = (MaterializeLocalSinkState &)lstate;
-    D_ASSERT(!gstate.finished);
+	auto &gstate = (MaterializeGlobalSinkState &)state;
+	auto &source = (MaterializeLocalSinkState &)lstate;
+	D_ASSERT(!gstate.finished);
 
-    lock_guard<mutex> glock(gstate.lock);
-    for (idx_t i = 0; i < source.data_indexes.size(); i++) {
-        // TODO: transaction local storage?
-        D_ASSERT(gstate.collection_map.find(source.data_indexes[i]) == gstate.collection_map.end());
-        gstate.collection_map[source.data_indexes[i]] = move(source.collections[i]);
-    }
+	lock_guard<mutex> glock(gstate.lock);
+	for (idx_t i = 0; i < source.data_indexes.size(); i++) {
+		// TODO: transaction local storage?
+		D_ASSERT(gstate.collection_map.find(source.data_indexes[i]) == gstate.collection_map.end());
+		gstate.collection_map[source.data_indexes[i]] = move(source.collections[i]);
+	}
 }
 
 SinkFinalizeType PhysicalMaterialize::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
-        GlobalSinkState &gstate_p) const {
-    auto &gstate = (MaterializeGlobalSinkState &)gstate_p;
-    D_ASSERT(!gstate.finished);
-    for (auto & iter : gstate.collection_map) {
-        gstate.result_set.Append(*iter.second);
-    }
-    gstate.finished = true;
-    return SinkFinalizeType::READY;
+                                               GlobalSinkState &gstate_p) const {
+	auto &gstate = (MaterializeGlobalSinkState &)gstate_p;
+	D_ASSERT(!gstate.finished);
+	for (auto &iter : gstate.collection_map) {
+		gstate.result_set.Append(*iter.second);
+	}
+	gstate.finished = true;
+	return SinkFinalizeType::READY;
 }
 
 ChunkCollection PhysicalMaterialize::GetResult() {
-    D_ASSERT(sink_state != nullptr);
-    return move(reinterpret_cast<MaterializeGlobalSinkState*>(sink_state.get())->result_set);
+	D_ASSERT(sink_state != nullptr);
+	return move(reinterpret_cast<MaterializeGlobalSinkState *>(sink_state.get())->result_set);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_materialize.cpp
+++ b/src/execution/physical_materialize.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include "duckdb/execution/physical_materialize.hpp"
 #include "duckdb/common/types/chunk_collection.hpp"
 
@@ -61,7 +60,6 @@ void PhysicalMaterialize::Combine(ExecutionContext &context, GlobalSinkState &st
 
 	lock_guard<mutex> glock(gstate.lock);
 	for (idx_t i = 0; i < source.data_indexes.size(); i++) {
-		// TODO: transaction local storage?
 		D_ASSERT(gstate.collection_map.find(source.data_indexes[i]) == gstate.collection_map.end());
 		gstate.collection_map[source.data_indexes[i]] = move(source.collections[i]);
 	}

--- a/src/execution/physical_materialize.cpp
+++ b/src/execution/physical_materialize.cpp
@@ -77,5 +77,9 @@ SinkFinalizeType PhysicalMaterialize::Finalize(Pipeline &pipeline, Event &event,
     return SinkFinalizeType::READY;
 }
 
+ChunkCollection PhysicalMaterialize::GetResult() {
+    D_ASSERT(sink_state != nullptr);
+    return move(reinterpret_cast<MaterializeGlobalSinkState*>(sink_state.get())->result_set);
+}
 
 } // namespace duckdb

--- a/src/function/pragma/pragma_functions.cpp
+++ b/src/function/pragma/pragma_functions.cpp
@@ -137,10 +137,10 @@ void PragmaFunctions::RegisterFunction(BuiltinFunctions &set) {
 	set.AddFunction(
 	    PragmaFunction::PragmaStatement("disable_checkpoint_on_shutdown", PragmaDisableCheckpointOnShutdown));
 
-    set.AddFunction(PragmaFunction::PragmaStatement("force_result_set_materialization",
-        PragmaEnableForceResultSetMaterialization));
+	set.AddFunction(
+	    PragmaFunction::PragmaStatement("force_result_set_materialization", PragmaEnableForceResultSetMaterialization));
 	set.AddFunction(PragmaFunction::PragmaStatement("disable_force_result_set_materialization",
-        PragmaDisableForceResultSetMaterialization));
+	                                                PragmaDisableForceResultSetMaterialization));
 }
 
 } // namespace duckdb

--- a/src/function/pragma/pragma_functions.cpp
+++ b/src/function/pragma/pragma_functions.cpp
@@ -98,6 +98,14 @@ static void PragmaDisableOptimizer(ClientContext &context, const FunctionParamet
 	ClientConfig::GetConfig(context).enable_optimizer = false;
 }
 
+static void PragmaEnableForceResultSetMaterialization(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).force_result_set_materialization = true;
+}
+
+static void PragmaDisableForceResultSetMaterialization(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).force_result_set_materialization = false;
+}
+
 void PragmaFunctions::RegisterFunction(BuiltinFunctions &set) {
 	RegisterEnableProfiling(set);
 
@@ -128,6 +136,11 @@ void PragmaFunctions::RegisterFunction(BuiltinFunctions &set) {
 	set.AddFunction(PragmaFunction::PragmaStatement("enable_checkpoint_on_shutdown", PragmaEnableCheckpointOnShutdown));
 	set.AddFunction(
 	    PragmaFunction::PragmaStatement("disable_checkpoint_on_shutdown", PragmaDisableCheckpointOnShutdown));
+
+    set.AddFunction(PragmaFunction::PragmaStatement("force_result_set_materialization",
+        PragmaEnableForceResultSetMaterialization));
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_force_result_set_materialization",
+        PragmaDisableForceResultSetMaterialization));
 }
 
 } // namespace duckdb

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -329,6 +329,7 @@ void TableScanPushdownComplexFilter(ClientContext &context, LogicalGet &get, Fun
 				get.function.parallel_state_next = nullptr;
 				get.function.table_scan_progress = nullptr;
 				get.function.filter_pushdown = false;
+				get.function.ordered_scan_function = false;
 			} else {
 				bind_data.result_ids.clear();
 			}

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -22,7 +22,7 @@ namespace duckdb {
 bool TableScanParallelStateNext(ClientContext &context, const FunctionData *bind_data,
                                 FunctionOperatorData *operator_state, ParallelState *parallel_state_p);
 
-struct TableScanOperatorData : public FunctionOperatorData {
+struct TableScanOperatorData : public OrderedFunctionOperatorData {
 	//! The current position in the scan
 	TableScanState scan_state;
 	vector<column_t> column_ids;
@@ -69,7 +69,7 @@ static void TableScanFunc(ClientContext &context, const FunctionData *bind_data_
 	auto &bind_data = (TableScanBindData &)*bind_data_p;
 	auto &state = (TableScanOperatorData &)*operator_state;
 	auto &transaction = Transaction::GetTransaction(context);
-	bind_data.table->storage->Scan(transaction, output, state.scan_state, state.column_ids);
+	bind_data.table->storage->Scan(transaction, output, state.scan_state, state.column_ids, state.data_index);
 	bind_data.chunk_count++;
 }
 

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -359,6 +359,7 @@ TableFunction TableScanFunction::GetFunction() {
 	scan_function.table_scan_progress = TableScanProgress;
 	scan_function.projection_pushdown = true;
 	scan_function.filter_pushdown = true;
+	scan_function.ordered_scan_function = true;
 	return scan_function;
 }
 

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -21,13 +21,13 @@ TableFunction::TableFunction(string name, vector<LogicalType> arguments, table_f
                              table_function_parallel_t parallel_function, table_function_init_parallel_t parallel_init,
                              table_function_parallel_state_next_t parallel_state_next, bool projection_pushdown,
                              bool filter_pushdown, table_function_progress_t query_progress,
-                             table_in_out_function_t in_out_function)
+                             table_in_out_function_t in_out_function, bool ordered_scan_function)
     : SimpleNamedParameterFunction(move(name), move(arguments)), bind(bind), init(init), function(function),
       in_out_function(in_out_function), statistics(statistics), cleanup(cleanup), dependency(dependency),
       cardinality(cardinality), pushdown_complex_filter(pushdown_complex_filter), to_string(to_string),
       max_threads(max_threads), init_parallel_state(init_parallel_state), parallel_function(parallel_function),
       parallel_init(parallel_init), parallel_state_next(parallel_state_next), table_scan_progress(query_progress),
-      projection_pushdown(projection_pushdown), filter_pushdown(filter_pushdown) {
+      projection_pushdown(projection_pushdown), filter_pushdown(filter_pushdown), ordered_scan_function(ordered_scan_function) {
 }
 
 TableFunction::TableFunction(const vector<LogicalType> &arguments, table_function_t function,

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -5,6 +5,9 @@ namespace duckdb {
 FunctionOperatorData::~FunctionOperatorData() {
 }
 
+OrderedFunctionOperatorData::~OrderedFunctionOperatorData() {
+}
+
 TableFunctionInfo::~TableFunctionInfo() {
 }
 

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -30,7 +30,8 @@ TableFunction::TableFunction(string name, vector<LogicalType> arguments, table_f
       cardinality(cardinality), pushdown_complex_filter(pushdown_complex_filter), to_string(to_string),
       max_threads(max_threads), init_parallel_state(init_parallel_state), parallel_function(parallel_function),
       parallel_init(parallel_init), parallel_state_next(parallel_state_next), table_scan_progress(query_progress),
-      projection_pushdown(projection_pushdown), filter_pushdown(filter_pushdown), ordered_scan_function(ordered_scan_function) {
+      projection_pushdown(projection_pushdown), filter_pushdown(filter_pushdown),
+      ordered_scan_function(ordered_scan_function) {
 }
 
 TableFunction::TableFunction(const vector<LogicalType> &arguments, table_function_t function,

--- a/src/include/duckdb/common/enums/physical_operator_type.hpp
+++ b/src/include/duckdb/common/enums/physical_operator_type.hpp
@@ -93,7 +93,8 @@ enum class PhysicalOperatorType : uint8_t {
 	EXPORT,
 	SET,
 	LOAD,
-	INOUT_FUNCTION
+	INOUT_FUNCTION,
+    MATERIALIZE
 };
 
 string PhysicalOperatorToString(PhysicalOperatorType type);

--- a/src/include/duckdb/common/enums/physical_operator_type.hpp
+++ b/src/include/duckdb/common/enums/physical_operator_type.hpp
@@ -94,7 +94,7 @@ enum class PhysicalOperatorType : uint8_t {
 	SET,
 	LOAD,
 	INOUT_FUNCTION,
-    MATERIALIZE
+	MATERIALIZE
 };
 
 string PhysicalOperatorToString(PhysicalOperatorType type);

--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/enums/pending_execution_result.hpp"
+#include "duckdb/execution/physical_materialize.hpp"
 
 namespace duckdb {
 class ClientContext;
@@ -82,6 +83,9 @@ public:
 
 	void ReschedulePipelines(const vector<shared_ptr<Pipeline>> &pipelines, vector<shared_ptr<Event>> &events);
 
+public:
+	unique_ptr<PhysicalMaterialize> materialized_sink;
+
 private:
 	void ScheduleEvents();
 	void ScheduleEventsInternal(const vector<shared_ptr<Pipeline>> &pipelines,
@@ -102,6 +106,8 @@ private:
 	void VerifyPipeline(Pipeline &pipeline);
 	void VerifyPipelines();
 	void ThrowExceptionInternal();
+
+	bool MaybeMaterializeResult(Pipeline *root_pipeline);
 
 private:
 	PhysicalOperator *physical_plan;

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -49,6 +49,8 @@ public:
 	bool ParallelSource() const override {
 		return true;
 	}
+
+    bool OrderedSource() const override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -15,7 +15,7 @@
 
 namespace duckdb {
 
-    class TableScanLocalState;
+class TableScanLocalState;
 
 //! Represents a scan of a base table
 class PhysicalTableScan : public PhysicalOperator {
@@ -52,10 +52,10 @@ public:
 		return true;
 	}
 
-    bool OrderedSource() const override;
+	bool OrderedSource() const override;
 
 private:
-    void SetOrder(TableScanLocalState &lstate) const;
+	void SetOrder(TableScanLocalState &lstate) const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -15,6 +15,8 @@
 
 namespace duckdb {
 
+    class TableScanLocalState;
+
 //! Represents a scan of a base table
 class PhysicalTableScan : public PhysicalOperator {
 public:
@@ -51,6 +53,9 @@ public:
 	}
 
     bool OrderedSource() const override;
+
+private:
+    void SetOrder(TableScanLocalState &lstate) const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/physical_materialize.hpp
+++ b/src/include/duckdb/execution/physical_materialize.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "duckdb/execution/physical_operator.hpp"
+#include "duckdb/common/types/chunk_collection.hpp"
+
+#include <map>
+
+namespace duckdb {
+
+class PhysicalMaterialize : public PhysicalOperator {
+public:
+    PhysicalMaterialize(vector<LogicalType> types, idx_t estimated_cardinality);
+
+public:
+	// Sink interface
+	SinkResultType Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+	                    DataChunk &input) const override;
+	void Combine(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate) const override;
+	SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+	        GlobalSinkState &gstate) const override;
+
+	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const override;
+	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
+
+	bool IsSink() const override {
+		return true;
+	}
+
+	bool ParallelSink() const override {
+		return true;
+	}
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/execution/physical_materialize.hpp
+++ b/src/include/duckdb/execution/physical_materialize.hpp
@@ -30,6 +30,10 @@ public:
 		return true;
 	}
 
+	virtual bool SinkOrderMatters() const {
+		return false;
+	}
+
 	ChunkCollection GetResult();
 };
 

--- a/src/include/duckdb/execution/physical_materialize.hpp
+++ b/src/include/duckdb/execution/physical_materialize.hpp
@@ -9,7 +9,7 @@ namespace duckdb {
 
 class PhysicalMaterialize : public PhysicalOperator {
 public:
-    PhysicalMaterialize(vector<LogicalType> types, idx_t estimated_cardinality);
+	PhysicalMaterialize(vector<LogicalType> types, idx_t estimated_cardinality);
 
 public:
 	// Sink interface
@@ -17,7 +17,7 @@ public:
 	                    DataChunk &input) const override;
 	void Combine(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate) const override;
 	SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
-	        GlobalSinkState &gstate) const override;
+	                          GlobalSinkState &gstate) const override;
 
 	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const override;
 	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;

--- a/src/include/duckdb/execution/physical_materialize.hpp
+++ b/src/include/duckdb/execution/physical_materialize.hpp
@@ -29,6 +29,8 @@ public:
 	bool ParallelSink() const override {
 		return true;
 	}
+
+	ChunkCollection GetResult();
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/physical_materialize.hpp
+++ b/src/include/duckdb/execution/physical_materialize.hpp
@@ -30,8 +30,8 @@ public:
 		return true;
 	}
 
-	virtual bool SinkOrderMatters() const {
-		return false;
+	virtual bool SinkOrderMatters() const override {
+		return true;
 	}
 
 	ChunkCollection GetResult();

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -48,6 +48,8 @@ public:
 
 class LocalSinkState {
 public:
+    bool is_ordered = false;
+    idx_t source_index = DConstants::INVALID_INDEX;
 	virtual ~LocalSinkState() {
 	}
 };
@@ -64,6 +66,8 @@ public:
 
 class LocalSourceState {
 public:
+    bool is_ordered = false;
+    idx_t source_index = DConstants::INVALID_INDEX;
 	virtual ~LocalSourceState() {
 	}
 };

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -48,8 +48,8 @@ public:
 
 class LocalSinkState {
 public:
-    bool is_ordered = false;
-    idx_t source_index = DConstants::INVALID_INDEX;
+	bool is_ordered = false;
+	idx_t source_index = DConstants::INVALID_INDEX;
 	virtual ~LocalSinkState() {
 	}
 };
@@ -66,8 +66,8 @@ public:
 
 class LocalSourceState {
 public:
-    bool is_ordered = false;
-    idx_t source_index = DConstants::INVALID_INDEX;
+	bool is_ordered = false;
+	idx_t source_index = DConstants::INVALID_INDEX;
 	virtual ~LocalSourceState() {
 	}
 };
@@ -144,9 +144,9 @@ public:
 		return false;
 	}
 
-    virtual bool OrderedSource() const {
-        return false;
-    }
+	virtual bool OrderedSource() const {
+		return false;
+	}
 
 public:
 	// Sink interface

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -140,6 +140,10 @@ public:
 		return false;
 	}
 
+    virtual bool OrderedSource() const {
+        return false;
+    }
+
 public:
 	// Sink interface
 

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -22,7 +22,16 @@ struct ParallelState;
 class TableFilterSet;
 
 struct FunctionOperatorData {
+    bool is_ordered = false;
 	DUCKDB_API virtual ~FunctionOperatorData();
+};
+
+struct OrderedFunctionOperatorData : FunctionOperatorData {
+    OrderedFunctionOperatorData() {
+        is_ordered = true;
+    }
+	idx_t data_index = DConstants::INVALID_INDEX;
+	DUCKDB_API virtual ~OrderedFunctionOperatorData();
 };
 
 struct TableFunctionInfo {

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -105,7 +105,7 @@ public:
 	              table_function_init_parallel_t parallel_init = nullptr,
 	              table_function_parallel_state_next_t parallel_state_next = nullptr, bool projection_pushdown = false,
 	              bool filter_pushdown = false, table_function_progress_t query_progress = nullptr,
-	              table_in_out_function_t in_out_function = nullptr);
+	              table_in_out_function_t in_out_function = nullptr, bool ordered_scan_function = false);
 	DUCKDB_API
 	TableFunction(const vector<LogicalType> &arguments, table_function_t function, table_function_bind_t bind = nullptr,
 	              table_function_init_t init = nullptr, table_statistics_t statistics = nullptr,
@@ -169,6 +169,8 @@ public:
 	//! Whether or not the table function supports filter pushdown. If not supported a filter will be added
 	//! that applies the table filter directly.
 	bool filter_pushdown;
+	//! Whether or not the table funtion is a scan function that generates data with order
+	bool ordered_scan_function;
 	//! Additional function info, passed to the bind
 	shared_ptr<TableFunctionInfo> function_info;
 };

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -22,13 +22,15 @@ struct ParallelState;
 class TableFilterSet;
 
 struct FunctionOperatorData {
-	FunctionOperatorData(bool is_ordered = false) : is_ordered(is_ordered) {}
-    bool is_ordered;
+	FunctionOperatorData(bool is_ordered = false) : is_ordered(is_ordered) {
+	}
+	bool is_ordered;
 	DUCKDB_API virtual ~FunctionOperatorData();
 };
 
 struct OrderedFunctionOperatorData : FunctionOperatorData {
-    OrderedFunctionOperatorData() : FunctionOperatorData(true) {}
+	OrderedFunctionOperatorData() : FunctionOperatorData(true) {
+	}
 	idx_t data_index = DConstants::INVALID_INDEX;
 	DUCKDB_API virtual ~OrderedFunctionOperatorData();
 };

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -22,14 +22,13 @@ struct ParallelState;
 class TableFilterSet;
 
 struct FunctionOperatorData {
-    bool is_ordered = false;
+	FunctionOperatorData(bool is_ordered = false) : is_ordered(is_ordered) {}
+    bool is_ordered;
 	DUCKDB_API virtual ~FunctionOperatorData();
 };
 
 struct OrderedFunctionOperatorData : FunctionOperatorData {
-    OrderedFunctionOperatorData() {
-        is_ordered = true;
-    }
+    OrderedFunctionOperatorData() : FunctionOperatorData(true) {}
 	idx_t data_index = DConstants::INVALID_INDEX;
 	DUCKDB_API virtual ~OrderedFunctionOperatorData();
 };

--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -50,7 +50,7 @@ struct ClientConfig {
 	//! Force out-of-core computation for operators that support it, used for testing
 	bool force_external = false;
 	//! Force result set materialization
-	bool force_result_set_materialization = true;
+	bool force_result_set_materialization = false;
 	//! Maximum bits allowed for using a perfect hash table (i.e. the perfect HT can hold up to 2^perfect_ht_threshold
 	//! elements)
 	idx_t perfect_ht_threshold = 12;

--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -49,8 +49,8 @@ struct ClientConfig {
 	bool force_index_join = false;
 	//! Force out-of-core computation for operators that support it, used for testing
 	bool force_external = false;
-    //! Force result set materialization
-	bool force_result_set_materialization = false;
+	//! Force result set materialization
+	bool force_result_set_materialization = true;
 	//! Maximum bits allowed for using a perfect hash table (i.e. the perfect HT can hold up to 2^perfect_ht_threshold
 	//! elements)
 	idx_t perfect_ht_threshold = 12;

--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -49,6 +49,8 @@ struct ClientConfig {
 	bool force_index_join = false;
 	//! Force out-of-core computation for operators that support it, used for testing
 	bool force_external = false;
+    //! Force result set materialization
+	bool force_result_set_materialization = false;
 	//! Maximum bits allowed for using a perfect hash table (i.e. the perfect HT can hold up to 2^perfect_ht_threshold
 	//! elements)
 	idx_t perfect_ht_threshold = 12;

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/unordered_set.hpp"
 #include "duckdb/execution/physical_operator.hpp"
+#include "duckdb/execution/physical_materialize.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/parallel/parallel_state.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
@@ -58,6 +59,10 @@ public:
 	}
 
 	bool OrderedParallelPipeline() const;
+
+	unique_ptr<PhysicalMaterialize> AddMaterializedSink();
+
+	bool IsMaterializedSinkPipeline() const;
 
 private:
 	//! Whether or not the pipeline has been readied

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -57,6 +57,8 @@ public:
 		return sink;
 	}
 
+	bool OrderedParallelPipeline() const;
+
 private:
 	//! Whether or not the pipeline has been readied
 	bool ready;
@@ -81,6 +83,7 @@ private:
 	bool LaunchScanTasks(shared_ptr<Event> &event, idx_t max_threads);
 
 	bool ScheduleParallel(shared_ptr<Event> &event);
+	bool Parallel(bool check_sink = false) const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parallel/pipeline_executor.hpp
+++ b/src/include/duckdb/parallel/pipeline_executor.hpp
@@ -82,6 +82,8 @@ private:
 	//! Cached chunks for any operators that require caching
 	vector<unique_ptr<DataChunk>> cached_chunks;
 
+	bool is_pipeline_order_preserving;
+
 private:
 	void StartOperator(PhysicalOperator *op);
 	void EndOperator(PhysicalOperator *op, DataChunk *chunk);
@@ -97,6 +99,7 @@ private:
 
 	static bool CanCacheType(const LogicalType &type);
 	void CacheChunk(DataChunk &input, idx_t operator_idx);
+	void FlushCache();
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -154,7 +154,7 @@ public:
 	//! from offset and store them in result. Offset is incremented with how many
 	//! elements were returned.
 	//! Returns true if all pushed down filters were executed during data fetching
-	void Scan(Transaction &transaction, DataChunk &result, TableScanState &state, vector<column_t> &column_ids);
+	void Scan(Transaction &transaction, DataChunk &result, TableScanState &state, vector<column_t> &column_ids, idx_t &row_group_idx);
 
 	//! Fetch data from the specific row identifiers from the base table
 	void Fetch(Transaction &transaction, DataChunk &result, const vector<column_t> &column_ids, Vector &row_ids,

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -154,7 +154,8 @@ public:
 	//! from offset and store them in result. Offset is incremented with how many
 	//! elements were returned.
 	//! Returns true if all pushed down filters were executed during data fetching
-	void Scan(Transaction &transaction, DataChunk &result, TableScanState &state, vector<column_t> &column_ids, idx_t &row_group_idx);
+	void Scan(Transaction &transaction, DataChunk &result, TableScanState &state, vector<column_t> &column_ids,
+	          idx_t &row_group_idx);
 
 	//! Fetch data from the specific row identifiers from the base table
 	void Fetch(Transaction &transaction, DataChunk &result, const vector<column_t> &column_ids, Vector &row_ids,

--- a/src/include/duckdb/storage/table/segment_base.hpp
+++ b/src/include/duckdb/storage/table/segment_base.hpp
@@ -15,7 +15,7 @@ namespace duckdb {
 
 class SegmentBase {
 public:
-	SegmentBase(idx_t start, idx_t count) : start(start), count(count) {
+	SegmentBase(idx_t start, idx_t count) : start(start), index(0), count(count) {
 	}
 	virtual ~SegmentBase() {
 		// destroy the chain of segments iteratively (rather than recursively)
@@ -26,6 +26,8 @@ public:
 
 	//! The start row id of this chunk
 	const idx_t start;
+	//! The index of node in SegmentTree
+	idx_t index;
 	//! The amount of entries in this storage chunk
 	atomic<idx_t> count;
 	//! The next segment after this one

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -206,8 +206,8 @@ unique_ptr<QueryResult> ClientContext::FetchResultInternal(ClientContextLock &lo
 	D_ASSERT(active_query->prepared);
 	auto &prepared = *active_query->prepared;
 	auto &executor = GetExecutor();
-	bool create_stream_result = prepared.allow_stream_result && allow_stream_result
-	    && (executor.materialized_sink == nullptr);
+	bool create_stream_result =
+	    prepared.allow_stream_result && allow_stream_result && (executor.materialized_sink == nullptr);
 	if (create_stream_result) {
 		active_query->progress_bar.reset();
 		query_progress = -1;
@@ -222,25 +222,25 @@ unique_ptr<QueryResult> ClientContext::FetchResultInternal(ClientContextLock &lo
 	// create a materialized result by continuously fetching
 	auto result = make_unique<MaterializedQueryResult>(pending.statement_type, pending.types, pending.names);
 	if (executor.materialized_sink == nullptr) {
-        while (true) {
-            auto chunk = FetchInternal(lock, GetExecutor(), *result);
-            if (!chunk || chunk->size() == 0) {
-                break;
-            }
+		while (true) {
+			auto chunk = FetchInternal(lock, GetExecutor(), *result);
+			if (!chunk || chunk->size() == 0) {
+				break;
+			}
 #ifdef DEBUG
-            for (idx_t i = 0; i < chunk->ColumnCount(); i++) {
-                if (pending.types[i].id() == LogicalTypeId::VARCHAR) {
-                    chunk->data[i].UTFVerify(chunk->size());
-                }
-            }
+			for (idx_t i = 0; i < chunk->ColumnCount(); i++) {
+				if (pending.types[i].id() == LogicalTypeId::VARCHAR) {
+					chunk->data[i].UTFVerify(chunk->size());
+				}
+			}
 #endif
-            result->collection.Append(*chunk);
-        }
-    } else {
-        result->collection = move(executor.materialized_sink->GetResult());
-        executor.materialized_sink.reset();
-        CleanupInternal(lock, result.get());
-    }
+			result->collection.Append(*chunk);
+		}
+	} else {
+		result->collection = move(executor.materialized_sink->GetResult());
+		executor.materialized_sink.reset();
+		CleanupInternal(lock, result.get());
+	}
 	return move(result);
 }
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -239,6 +239,7 @@ unique_ptr<QueryResult> ClientContext::FetchResultInternal(ClientContextLock &lo
     } else {
         result->collection = move(executor.materialized_sink->GetResult());
         executor.materialized_sink.reset();
+        CleanupInternal(lock, result.get());
     }
 	return move(result);
 }

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -275,7 +275,7 @@ void QueryProfiler::Flush(OperatorProfiler &profiler) {
 		auto entry = tree_map.find(node.first);
 		// TODO: for now, PhysicalMaterialize is not intialized
 		// thus does not exist in tree_map
-		if (entry == tree_map.end()) {
+		if (entry == tree_map.end() && node.first->type == PhysicalOperatorType::MATERIALIZE) {
 			continue;
 		}
 		D_ASSERT(entry != tree_map.end());

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -275,9 +275,9 @@ void QueryProfiler::Flush(OperatorProfiler &profiler) {
 		auto entry = tree_map.find(node.first);
 		// TODO: for now, PhysicalMaterialize is not intialized
 		// thus does not exist in tree_map
-        if (entry == tree_map.end()) {
-            continue;
-        }
+		if (entry == tree_map.end()) {
+			continue;
+		}
 		D_ASSERT(entry != tree_map.end());
 
 		entry->second->info.time += node.second.time;

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -273,6 +273,11 @@ void QueryProfiler::Flush(OperatorProfiler &profiler) {
 	}
 	for (auto &node : profiler.timings) {
 		auto entry = tree_map.find(node.first);
+		// TODO: for now, PhysicalMaterialize is not intialized
+		// thus does not exist in tree_map
+        if (entry == tree_map.end()) {
+            continue;
+        }
 		D_ASSERT(entry != tree_map.end());
 
 		entry->second->info.time += node.second.time;

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -755,12 +755,13 @@ bool Executor::MaybeMaterializeResult(Pipeline *root_pipeline) {
         return false;
     }
     // Don't support UNION ALL and RIGHT OUTER JOIN for now
-    if (union_pipelines.find(root_pipeline.get()) != union_pipelines.end()
+    if (union_pipelines.find(root_pipeline) != union_pipelines.end()
             || child_pipelines.find(root_pipeline) != child_pipelines.end()) {
         return false;
     }
 
     materialized_sink = root_pipeline->AddMaterializedSink();
+    return true;
 }
 
 } // namespace duckdb

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -274,12 +274,12 @@ void Executor::Initialize(PhysicalOperator *plan) {
 		BuildPipelines(physical_plan, root_pipeline.get());
 
 		auto materialize_result = MaybeMaterializeResult(root_pipeline.get());
-        if (materialize_result) {
-            pipelines.push_back(root_pipeline);
-        } else {
-            root_pipeline_idx = 0;
-            ExtractPipelines(root_pipeline, root_pipelines);
-        }
+		if (materialize_result) {
+			pipelines.push_back(root_pipeline);
+		} else {
+			root_pipeline_idx = 0;
+			ExtractPipelines(root_pipeline, root_pipelines);
+		}
 		this->total_pipelines = pipelines.size();
 
 		VerifyPipelines();
@@ -746,22 +746,22 @@ unique_ptr<DataChunk> Executor::FetchChunk() {
 }
 
 bool Executor::MaybeMaterializeResult(Pipeline *root_pipeline) {
-    D_ASSERT(materialized_sink == nullptr);
+	D_ASSERT(materialized_sink == nullptr);
 
-    if (!context.config.force_result_set_materialization) {
-        return false;
-    }
-    if (!root_pipeline->OrderedParallelPipeline()) {
-        return false;
-    }
-    // Don't support UNION ALL and RIGHT OUTER JOIN for now
-    if (union_pipelines.find(root_pipeline) != union_pipelines.end()
-            || child_pipelines.find(root_pipeline) != child_pipelines.end()) {
-        return false;
-    }
+	if (!context.config.force_result_set_materialization) {
+		return false;
+	}
+	if (!root_pipeline->OrderedParallelPipeline()) {
+		return false;
+	}
+	// Don't support UNION ALL and RIGHT OUTER JOIN for now
+	if (union_pipelines.find(root_pipeline) != union_pipelines.end() ||
+	    child_pipelines.find(root_pipeline) != child_pipelines.end()) {
+		return false;
+	}
 
-    materialized_sink = root_pipeline->AddMaterializedSink();
-    return true;
+	materialized_sink = root_pipeline->AddMaterializedSink();
+	return true;
 }
 
 } // namespace duckdb

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -237,4 +237,16 @@ bool Pipeline::OrderedParallelPipeline() const {
     return source->OrderedSource() && Parallel();
 }
 
+unique_ptr<PhysicalMaterialize> Pipeline::AddMaterializedSink() {
+    D_ASSERT(sink == nullptr);
+    auto last_op = operators.empty() ? source : operators.back();
+    auto materialized_sink = make_unique<PhysicalMaterialize>(last_op->types, last_op->estimated_cardinality);
+    sink = materialized_sink.get();
+    return materialized_sink;
+}
+
+bool Pipeline::IsMaterializedSinkPipeline() const {
+    return sink != nullptr && sink->type == PhysicalOperatorType::MATERIALIZE;
+}
+
 } // namespace duckdb

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -113,10 +113,10 @@ void Pipeline::ScheduleSequentialTask(shared_ptr<Event> &event) {
 
 bool Pipeline::Parallel(bool check_sink) const {
 	if (check_sink) {
-        if (!sink->ParallelSink()) {
-            return false;
-        }
-    }
+		if (!sink->ParallelSink()) {
+			return false;
+		}
+	}
 	if (!source->ParallelSource()) {
 		return false;
 	}
@@ -125,13 +125,13 @@ bool Pipeline::Parallel(bool check_sink) const {
 			return false;
 		}
 	}
-    return true;
+	return true;
 }
 
 bool Pipeline::ScheduleParallel(shared_ptr<Event> &event) {
-    if (!Parallel(true)) {
-        return false;
-    }
+	if (!Parallel(true)) {
+		return false;
+	}
 	idx_t max_threads = source_state->MaxThreads();
 	return LaunchScanTasks(event, max_threads);
 }
@@ -234,19 +234,19 @@ vector<PhysicalOperator *> Pipeline::GetOperators() const {
 }
 
 bool Pipeline::OrderedParallelPipeline() const {
-    return source->OrderedSource() && Parallel();
+	return source->OrderedSource() && Parallel();
 }
 
 unique_ptr<PhysicalMaterialize> Pipeline::AddMaterializedSink() {
-    D_ASSERT(sink == nullptr);
-    auto last_op = operators.empty() ? source : operators.back();
-    auto materialized_sink = make_unique<PhysicalMaterialize>(last_op->types, last_op->estimated_cardinality);
-    sink = materialized_sink.get();
-    return materialized_sink;
+	D_ASSERT(sink == nullptr);
+	auto last_op = operators.empty() ? source : operators.back();
+	auto materialized_sink = make_unique<PhysicalMaterialize>(last_op->types, last_op->estimated_cardinality);
+	sink = materialized_sink.get();
+	return materialized_sink;
 }
 
 bool Pipeline::IsMaterializedSinkPipeline() const {
-    return sink != nullptr && sink->type == PhysicalOperatorType::MATERIALIZE;
+	return sink != nullptr && sink->type == PhysicalOperatorType::MATERIALIZE;
 }
 
 } // namespace duckdb

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -100,6 +100,13 @@ OperatorResultType PipelineExecutor::ExecutePushInternal(DataChunk &input, idx_t
 			StartOperator(pipeline.sink);
 			D_ASSERT(pipeline.sink);
 			D_ASSERT(pipeline.sink->sink_state);
+
+            if (local_source_state->is_ordered) {
+                D_ASSERT(local_source_state->source_index != DConstants::INVALID_INDEX);
+                local_sink_state->is_ordered = true;
+                local_sink_state->source_index = local_source_state->source_index;
+            }
+
 			auto sink_result = pipeline.sink->Sink(context, *pipeline.sink->sink_state, *local_sink_state, sink_chunk);
 			EndOperator(pipeline.sink, nullptr);
 			if (sink_result == SinkResultType::FINISHED) {

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -59,21 +59,21 @@ bool PipelineExecutor::Execute(idx_t max_chunks) {
 			exhausted_source = true;
 			break;
 		}
-        if (is_pipeline_order_preserving) {
-            D_ASSERT(local_source_state->is_ordered);
-            D_ASSERT(local_source_state->source_index != DConstants::INVALID_INDEX);
-            if (!local_sink_state->is_ordered) {
-                D_ASSERT(local_sink_state->source_index == DConstants::INVALID_INDEX);
-                local_sink_state->is_ordered = true;
-                local_sink_state->source_index = local_source_state->source_index;
-            } else {
-                D_ASSERT(local_sink_state->source_index != DConstants::INVALID_INDEX);
-                if (local_sink_state->source_index != local_source_state->source_index) {
-                    FlushCache();
-                    local_sink_state->source_index = local_source_state->source_index;
-                }
-            }
-        }
+		if (is_pipeline_order_preserving) {
+			D_ASSERT(local_source_state->is_ordered);
+			D_ASSERT(local_source_state->source_index != DConstants::INVALID_INDEX);
+			if (!local_sink_state->is_ordered) {
+				D_ASSERT(local_sink_state->source_index == DConstants::INVALID_INDEX);
+				local_sink_state->is_ordered = true;
+				local_sink_state->source_index = local_source_state->source_index;
+			} else {
+				D_ASSERT(local_sink_state->source_index != DConstants::INVALID_INDEX);
+				if (local_sink_state->source_index != local_source_state->source_index) {
+					FlushCache();
+					local_sink_state->source_index = local_source_state->source_index;
+				}
+			}
+		}
 		auto result = ExecutePushInternal(source_chunk);
 		if (result == OperatorResultType::FINISHED) {
 			finished_processing = true;
@@ -136,7 +136,7 @@ void PipelineExecutor::PushFinalize() {
 	finalized = true;
 	// flush all caches
 	if (!finished_processing) {
-	    FlushCache();
+		FlushCache();
 	}
 	D_ASSERT(local_sink_state);
 	// run the combine for the sink
@@ -348,13 +348,13 @@ void PipelineExecutor::EndOperator(PhysicalOperator *op, DataChunk *chunk) {
 }
 
 void PipelineExecutor::FlushCache() {
-    D_ASSERT(in_process_operators.empty());
-    for (idx_t i = 0; i < cached_chunks.size(); i++) {
-        if (cached_chunks[i] && cached_chunks[i]->size() > 0) {
-            ExecutePushInternal(*cached_chunks[i], i + 1);
-            cached_chunks[i].reset();
-        }
-    }
+	D_ASSERT(in_process_operators.empty());
+	for (idx_t i = 0; i < cached_chunks.size(); i++) {
+		if (cached_chunks[i] && cached_chunks[i]->size() > 0) {
+			ExecutePushInternal(*cached_chunks[i], i + 1);
+			cached_chunks[i].reset();
+		}
+	}
 }
 
 } // namespace duckdb

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -185,13 +185,7 @@ void PipelineExecutor::CacheChunk(DataChunk &current_chunk, idx_t operator_idx) 
 				// chunk cache not full: probe again
 				current_chunk.Reset();
 			}
-        } else if (is_pipeline_order_preserving && cached_chunks[operator_idx]->size() > 0) {
-            DataChunk tmp_chunk;
-			auto &chunk_cache = *cached_chunks[operator_idx];
-            tmp_chunk.Move(current_chunk);
-            current_chunk.Move(chunk_cache);
-            chunk_cache.Move(tmp_chunk);
-        }
+		}
 	}
 #endif
 }

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -358,7 +358,7 @@ bool DataTable::NextParallelScan(ClientContext &context, ParallelTableScanState 
 }
 
 void DataTable::Scan(Transaction &transaction, DataChunk &result, TableScanState &state, vector<column_t> &column_ids,
-        idx_t &row_group_idx) {
+                     idx_t &row_group_idx) {
 	// scan the persistent segments
 	if (ScanBaseTable(transaction, result, state)) {
 		D_ASSERT(result.size() > 0);

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -357,15 +357,18 @@ bool DataTable::NextParallelScan(ClientContext &context, ParallelTableScanState 
 	}
 }
 
-void DataTable::Scan(Transaction &transaction, DataChunk &result, TableScanState &state, vector<column_t> &column_ids) {
+void DataTable::Scan(Transaction &transaction, DataChunk &result, TableScanState &state, vector<column_t> &column_ids,
+        idx_t &row_group_idx) {
 	// scan the persistent segments
 	if (ScanBaseTable(transaction, result, state)) {
 		D_ASSERT(result.size() > 0);
+		row_group_idx = state.row_group_scan_state.row_group->index;
 		return;
 	}
 
 	// scan the transaction-local segments
 	transaction.storage.Scan(state.local_state, column_ids, result);
+	row_group_idx = transaction.transaction_id;
 }
 
 bool DataTable::ScanBaseTable(Transaction &transaction, DataChunk &result, TableScanState &state) {

--- a/src/storage/table/segment_tree.cpp
+++ b/src/storage/table/segment_tree.cpp
@@ -54,6 +54,7 @@ void SegmentTree::AppendSegment(unique_ptr<SegmentBase> segment) {
 	} else {
 		root_node = move(segment);
 	}
+	node.node->index = nodes.size() - 1;
 }
 
 void SegmentTree::Replace(SegmentTree &other) {

--- a/test/sql/parallelism/intraquery/test_parallel_materialization_order.test
+++ b/test/sql/parallelism/intraquery/test_parallel_materialization_order.test
@@ -17,7 +17,7 @@ CREATE TABLE test(i BIGINT)
 statement ok
 INSERT INTO test SELECT range FROM range(1024*120*20)
 
-query R
+query I
 SELECT * FROM test WHERE i % (1024*60) = 0;
 ----
 0
@@ -60,3 +60,26 @@ SELECT * FROM test WHERE i % (1024*60) = 0;
 2273280
 2334720
 2396160
+
+statement ok
+CREATE TABLE test1(i BIGINT)
+
+statement ok
+INSERT INTO test1 SELECT range FROM range(1024*120*4)
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+INSERT INTO test1 SELECT range FROM range(1024*120*3)
+
+query I
+SELECT * FROM test1 WHERE i % (1024*120) = 0;
+----
+0
+122880
+245760
+368640
+0
+122880
+245760

--- a/test/sql/parallelism/intraquery/test_parallel_materialization_order.test
+++ b/test/sql/parallelism/intraquery/test_parallel_materialization_order.test
@@ -1,0 +1,62 @@
+# name: test/sql/parallelism/intraquery/test_parallel_materialization_order.test
+# description: Test the order gurantee of parallel result set materialization
+# group: [intraquery]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+PRAGMA threads=4
+
+statement ok
+PRAGMA force_result_set_materialization
+
+statement ok
+CREATE TABLE test(i BIGINT)
+
+statement ok
+INSERT INTO test SELECT range FROM range(1024*120*20)
+
+query R
+SELECT * FROM test WHERE i % (1024*60) = 0;
+----
+0
+61440
+122880
+184320
+245760
+307200
+368640
+430080
+491520
+552960
+614400
+675840
+737280
+798720
+860160
+921600
+983040
+1044480
+1105920
+1167360
+1228800
+1290240
+1351680
+1413120
+1474560
+1536000
+1597440
+1658880
+1720320
+1781760
+1843200
+1904640
+1966080
+2027520
+2088960
+2150400
+2211840
+2273280
+2334720
+2396160


### PR DESCRIPTION
This PR tries to implement parallel result set materialization mentioned in #2260.

### Background
Currently, the root pipeline of the query plan with non-aggregate root operator is executed with pull-based method and is not parallelized, unlike the rest of pipelines, which are executed with push-based method and can be parallelized. The reason is to keep the order of the output.
As a result, if the query is non-aggregate and contains expensive computation in the root pipeline, it'd be slow due to the lack of parallelism, #2245, #2653 have mentioned this issue.

### Ideas
To parallelize the root pipeline while keeping the order:
1. The source of the pipeline needs to emit the the data with order
2. A sink can be added to sort the data between different pipeline execution with the order
3. Within the pipeline execution, data from different row group should not be mixed.

In this case, the pipeline can be scheduled to run parallel like other pipelines.

### Proposed Change
This PR implements ordered base table scan which uses row group id as the order, and adds `PhysicalMaterialize` to the target root pipeline as the sink that sorts the data. The pipeline is then scheduled like the normal pipelines to be execute with push-based method. The result is sorted into a `ChunkCollection` by `PhysicalMaterialize` and output to `MaterializeQueryResult `.

### 
This feature is disabled by default and can be toggled by `ClientConfig.force_result_set_materialization`, to enable:
```
PRAGMA force_result_set_materialization
```
This will force query like `SELECT * FROM TEST;` to use `MaterializeQueryResult` instead of `StreamQueryResult` and parallelize the execution.

### Future Work
This PR only enables the end-to-end of non-index base table scan pipeline, queries that involves child/union pipelines are not supported yet. there are more works to be done in the future:

- [ ] Support index scan
- [ ] Support queries that involves child pipelines / union pipeline of root pipeline (e.g. RIGHT OUTER JOIN, UNION)
- [ ] Support more scan types (e.g. Parquet, CSV, httpfs etc)
- [ ] (Maybe) Introduce a order-preserving caching mechanism in `PipelieExecutor` that can speed-up the execution