### PR TITLE
Fixing ascii bug in histogram strings

### DIFF
--- a/src/function/scalar/list/list_aggregates.cpp
+++ b/src/function/scalar/list/list_aggregates.cpp
@@ -54,14 +54,29 @@ struct StateVector {
 	Vector state_vector;
 };
 
+struct FinalizeValueFunctor {
+	template <class T>
+	static Value FinalizeValue(T first) {
+		return Value::CreateValue(first);
+	}
+};
+
+struct FinalizeStringValueFunctor {
+	template <class T>
+	static Value FinalizeValue(T first) {
+		string_t value = first;
+		return Value::CreateValue(value);
+	}
+};
+
 struct AggregateFunctor {
-	template <class T, class MAP_TYPE = unordered_map<T, idx_t>>
+	template <class OP, class T, class MAP_TYPE = unordered_map<T, idx_t>>
 	static void ListExecuteFunction(Vector &result, Vector &state_vector, idx_t count) {
 	}
 };
 
 struct DistinctFunctor {
-	template <class T, class MAP_TYPE = unordered_map<T, idx_t>>
+	template <class OP, class T, class MAP_TYPE = unordered_map<T, idx_t>>
 	static void ListExecuteFunction(Vector &result, Vector &state_vector, idx_t count) {
 
 		VectorData sdata;
@@ -85,7 +100,7 @@ struct DistinctFunctor {
 			offset += state->hist->size();
 
 			for (auto &entry : *state->hist) {
-				auto bucket_value = Value::CreateValue(entry.first);
+				Value bucket_value = OP::template FinalizeValue<T>(entry.first);
 				ListVector::PushBack(result, bucket_value);
 			}
 		}
@@ -94,7 +109,7 @@ struct DistinctFunctor {
 };
 
 struct UniqueFunctor {
-	template <class T, class MAP_TYPE = unordered_map<T, idx_t>>
+	template <class OP, class T, class MAP_TYPE = unordered_map<T, idx_t>>
 	static void ListExecuteFunction(Vector &result, Vector &state_vector, idx_t count) {
 
 		VectorData sdata;
@@ -118,7 +133,7 @@ struct UniqueFunctor {
 	}
 };
 
-template <class OP, bool IS_AGGR = false>
+template <class FUNCTION_FUNCTOR, bool IS_AGGR = false>
 static void ListAggregatesFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 
 	auto count = args.size();
@@ -224,61 +239,80 @@ static void ListAggregatesFunction(DataChunk &args, ExpressionState &state, Vect
 
 		switch (key_type.InternalType()) {
 		case PhysicalType::BOOL:
-			OP::template ListExecuteFunction<bool>(result, state_vector.state_vector, count);
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, bool>(
+			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::UINT8:
-			OP::template ListExecuteFunction<uint8_t>(result, state_vector.state_vector, count);
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, uint8_t>(
+			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::UINT16:
-			OP::template ListExecuteFunction<uint16_t>(result, state_vector.state_vector, count);
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, uint16_t>(
+			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::UINT32:
-			OP::template ListExecuteFunction<uint32_t>(result, state_vector.state_vector, count);
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, uint32_t>(
+			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::UINT64:
-			OP::template ListExecuteFunction<uint64_t>(result, state_vector.state_vector, count);
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, uint64_t>(
+			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::INT8:
-			OP::template ListExecuteFunction<int8_t>(result, state_vector.state_vector, count);
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int8_t>(
+			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::INT16:
-			OP::template ListExecuteFunction<int16_t>(result, state_vector.state_vector, count);
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int16_t>(
+			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::INT32:
-			OP::template ListExecuteFunction<int32_t>(result, state_vector.state_vector, count);
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int32_t>(
+			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::INT64:
-			OP::template ListExecuteFunction<int64_t>(result, state_vector.state_vector, count);
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int64_t>(
+			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::FLOAT:
-			OP::template ListExecuteFunction<float>(result, state_vector.state_vector, count);
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, float>(
+			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::DOUBLE:
-			OP::template ListExecuteFunction<double>(result, state_vector.state_vector, count);
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, double>(
+			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::DATE32:
-			OP::template ListExecuteFunction<int32_t>(result, state_vector.state_vector, count);
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int32_t>(
+			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::DATE64:
-			OP::template ListExecuteFunction<int64_t>(result, state_vector.state_vector, count);
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int64_t>(
+			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::TIMESTAMP:
-			OP::template ListExecuteFunction<int64_t>(result, state_vector.state_vector, count);
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int64_t>(
+			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::TIME32:
-			OP::template ListExecuteFunction<int32_t>(result, state_vector.state_vector, count);
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int32_t>(
+			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::TIME64:
-			OP::template ListExecuteFunction<int64_t>(result, state_vector.state_vector, count);
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int64_t>(
+			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::STRING:
-			OP::template ListExecuteFunction<string>(result, state_vector.state_vector, count);
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeStringValueFunctor, string>(
+			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::LARGE_STRING:
-			OP::template ListExecuteFunction<string>(result, state_vector.state_vector, count);
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeStringValueFunctor, string>(
+			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::VARCHAR:
-			OP::template ListExecuteFunction<string>(result, state_vector.state_vector, count);
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeStringValueFunctor, string>(
+			    result, state_vector.state_vector, count);
 			break;
 		default:
 			throw InternalException("Unimplemented histogram aggregate");

--- a/test/sql/aggregate/aggregates/test_histogram.test
+++ b/test/sql/aggregate/aggregates/test_histogram.test
@@ -21,6 +21,12 @@ select histogram(1)
 ----
 {1=1}
 
+# Allow ascii characters in strings
+query I
+SELECT histogram('、')
+----
+{、=1}
+
 query I
 SELECT histogram(2) FROM range(100);
 ----
@@ -120,3 +126,18 @@ select histogram()
 
 statement error
 select histogram(*)
+
+# enums
+statement ok
+CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')
+
+statement ok
+CREATE TABLE enums (e mood)
+
+statement ok
+INSERT INTO enums VALUES ('happy'), ('ok')
+
+query I
+SELECT histogram(e) FROM enums
+----
+{happy=1, ok=1}

--- a/test/sql/function/list/aggregates/histogram.test
+++ b/test/sql/function/list/aggregates/histogram.test
@@ -98,5 +98,7 @@ SELECT list_histogram(['15:00:07'::TIMETZ])
 {15:00:07+00=1}
 
 # interval
-statement error
+query I
 SELECT list_histogram([INTERVAL 1 YEAR])
+----
+{1 year=1}

--- a/test/sql/function/list/aggregates/types.test
+++ b/test/sql/function/list/aggregates/types.test
@@ -172,8 +172,7 @@ endloop
 endloop
 
 # TEMPORAL types
-# exceptions: 
-# histogram (works with everything except interval)
+# exceptions:
 # mad (works with everything except interval)
 
 # specific result
@@ -249,7 +248,7 @@ endloop
 endloop
 
 # any other result
-foreach func_name approx_count_distinct count entropy median array_agg list
+foreach func_name approx_count_distinct count entropy median array_agg list histogram
 
 foreach type date time timestamp timestamp_s timestamp_ms timestamp_ns timetz timestamptz
 
@@ -378,7 +377,7 @@ happy
 endloop
 
 # any other result
-foreach func_name approx_count_distinct count entropy array_agg list
+foreach func_name approx_count_distinct count entropy array_agg list histogram
 
 statement ok
 SELECT list_aggr(e, '${func_name}') FROM enums
@@ -387,7 +386,7 @@ endloop
 
 # statement error for ENUMS
 
-foreach func_name avg favg bit_and bit_or bit_xor bool_and bool_or histogram kurtosis mad product sem skewness sum fsum sumKahan kahan_sum var_samp var_pop stddev stddev_pop variance stddev_samp
+foreach func_name avg favg bit_and bit_or bit_xor bool_and bool_or kurtosis mad product sem skewness sum fsum sumKahan kahan_sum var_samp var_pop stddev stddev_pop variance stddev_samp
 
 statement error
 SELECT list_aggr(e, '${func_name}') FROM enums

--- a/test/sql/function/list/list_distinct.test
+++ b/test/sql/function/list/list_distinct.test
@@ -203,6 +203,12 @@ SELECT list_distinct(['2021-08-20'::TIMESTAMPTZ])
 ----
 [2021-08-20 00:00:00+00]
 
+# interval
+query I
+SELECT list_distinct([INTERVAL 1 YEAR])
+----
+[1 year]
+
 foreach type date time timestamp timestamp_s timestamp_ms timestamp_ns timetz timestamptz
 
 query I
@@ -224,6 +230,21 @@ SELECT list_distinct([NULL::JSON])
 ----
 []
 
+# enums
+statement ok
+CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')
+
+statement ok
+CREATE TABLE enums (e mood[])
+
+statement ok
+INSERT INTO enums VALUES (['happy', 'ok'])
+
+query I
+SELECT list_sort(list_distinct(e)) FROM enums
+----
+[ok, happy]
+
 # test WHERE
 
 statement ok
@@ -243,3 +264,9 @@ query I
 SELECT name FROM wheretest WHERE name ILIKE 'two%' AND list_unique(list_distinct(l)) > 3;
 ----
 two1
+
+# bug in #3481
+query I
+SELECT list_sort(list_distinct(['a', 'b、c', 'a']))
+----
+[a, b、c]

--- a/test/sql/function/list/list_unique.test
+++ b/test/sql/function/list/list_unique.test
@@ -188,6 +188,12 @@ SELECT list_unique(['2021-08-20'::TIMESTAMPTZ])
 ----
 1
 
+# interval
+query I
+SELECT list_unique([INTERVAL 1 YEAR])
+----
+1
+
 foreach type date time timestamp timestamp_s timestamp_ms timestamp_ns timetz timestamptz
 
 query I
@@ -208,3 +214,24 @@ query I
 SELECT list_unique([NULL::JSON])
 ----
 0
+
+# enums
+statement ok
+CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')
+
+statement ok
+CREATE TABLE enums (e mood[])
+
+statement ok
+INSERT INTO enums VALUES (['happy', 'ok'])
+
+query I
+SELECT list_unique(e) FROM enums
+----
+2
+
+# bug in #3481
+query I
+SELECT list_unique(['a', 'b、c', 'a'])
+----
+2


### PR DESCRIPTION
This PR fixes a type conversion bug related to ascii characters in histogram values. These queries should now work and no longer return `Error: Conversion Error: Invalid byte encountered in STRING -> BLOB conversion. All non-ascii characters must be escaped with hex codes (e.g. \xAA)`.

```sql
SELECT list_distinct(['a', 'b、c', 'a'])
SELECT histogram('、')
```

Coincidentally, this also fixes a bug preventing enums and intervals from being usable with histogram.

@pdet I am a bit unhappy with basically using the same functions to return the `Value` in `histogram.cpp` and `list_aggregates.cpp`. Should I put them in a location accessible by both, and if yes, where would that be?

@ruanjf I hope this fixes your issue in #3481.