### PR TITLE
Equal or null optimization

### DIFF
--- a/src/include/duckdb/optimizer/rule/equal_or_null_simplification.hpp
+++ b/src/include/duckdb/optimizer/rule/equal_or_null_simplification.hpp
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/rule/equal_or_null_simplification.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/optimizer/rule.hpp"
+
+namespace duckdb {
+
+// Rewrite
+// a=b OR (a IS NULL AND b IS NULL) to a IS NOT DISTINCT FROM b
+class EqualOrNullSimplification : public Rule {
+public:
+	explicit EqualOrNullSimplification(ExpressionRewriter &rewriter);
+
+	unique_ptr<Expression> Apply(LogicalOperator &op, vector<Expression *> &bindings, bool &changes_made,
+	                             bool is_root) override;
+};
+
+} // namespace duckdb

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -19,6 +19,7 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/main/config.hpp"
 
+#include "duckdb/optimizer/rule/equal_or_null_simplification.hpp"
 #include "duckdb/optimizer/rule/in_clause_simplification.hpp"
 
 namespace duckdb {
@@ -32,6 +33,7 @@ Optimizer::Optimizer(Binder &binder, ClientContext &context) : context(context),
 	rewriter.rules.push_back(make_unique<DatePartSimplificationRule>(rewriter));
 	rewriter.rules.push_back(make_unique<ComparisonSimplificationRule>(rewriter));
 	rewriter.rules.push_back(make_unique<InClauseSimplificationRule>(rewriter));
+	rewriter.rules.push_back(make_unique<EqualOrNullSimplification>(rewriter));
 	rewriter.rules.push_back(make_unique<MoveConstantsRule>(rewriter));
 	rewriter.rules.push_back(make_unique<LikeOptimizationRule>(rewriter));
 	rewriter.rules.push_back(make_unique<EmptyNeedleRemovalRule>(rewriter));

--- a/src/optimizer/rule/CMakeLists.txt
+++ b/src/optimizer/rule/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library_unity(
   distributivity.cpp
   empty_needle_removal.cpp
   enum_comparison.cpp
+  equal_or_null_simplification.cpp
   move_constants.cpp
   like_optimizations.cpp
   in_clause_simplification_rule.cpp)

--- a/src/optimizer/rule/equal_or_null_simplification.cpp
+++ b/src/optimizer/rule/equal_or_null_simplification.cpp
@@ -8,61 +8,105 @@ namespace duckdb {
 
 EqualOrNullSimplification::EqualOrNullSimplification(ExpressionRewriter &rewriter) : Rule(rewriter) {
 	// match on OR conjunction
-	root = make_unique<ExpressionMatcher>();
-	root->expr_type = make_unique<SpecificExpressionTypeMatcher>(ExpressionType::CONJUNCTION_OR);
+	auto op = make_unique<ConjunctionExpressionMatcher>();
+	op->expr_type = make_unique<SpecificExpressionTypeMatcher>(ExpressionType::CONJUNCTION_OR);
+	op->policy = SetMatcher::Policy::SOME;
+
+	// equi comparison on one side
+	auto equal_child = make_unique<ComparisonExpressionMatcher>();
+	equal_child->expr_type = make_unique<SpecificExpressionTypeMatcher>(ExpressionType::COMPARE_EQUAL);
+	equal_child->policy = SetMatcher::Policy::SOME;
+	op->matchers.push_back(move(equal_child));
+
+	// AND conjuction on the other
+	auto and_child = make_unique<ConjunctionExpressionMatcher>();
+	and_child->expr_type = make_unique<SpecificExpressionTypeMatcher>(ExpressionType::CONJUNCTION_AND);
+	and_child->policy = SetMatcher::Policy::SOME;
+
+	// IS NULL tests inside AND
+	auto isnull_child = make_unique<ExpressionMatcher>();
+	isnull_child->expr_type = make_unique<SpecificExpressionTypeMatcher>(ExpressionType::OPERATOR_IS_NULL);
+	// I could try to use std::make_unique for a copy, but it's available from C++14 only
+	auto isnull_child2 = make_unique<ExpressionMatcher>();
+	isnull_child2->expr_type = make_unique<SpecificExpressionTypeMatcher>(ExpressionType::OPERATOR_IS_NULL);
+	and_child->matchers.push_back(move(isnull_child));
+	and_child->matchers.push_back(move(isnull_child2));
+
+	op->matchers.push_back(move(and_child));
+	root = move(op);
 }
 
 // a=b OR (a IS NULL AND b IS NULL) to a IS NOT DISTINCT FROM b
-static unique_ptr<Expression> TryRewriteEqualOrIsNull(const Expression *e1, const Expression *e2) {
-	if (e1->type == ExpressionType::COMPARE_EQUAL && e2->type == ExpressionType::CONJUNCTION_AND &&
-	    ((BoundConjunctionExpression *)e2)->children.size() == 2) {
-		const auto equal_comp = (BoundComparisonExpression *)e1;
-		const auto a_exp = equal_comp->left.get(), b_exp = equal_comp->right.get();
-		bool valid = true, a_is_null_found = false, b_is_null_found = false;
+static unique_ptr<Expression> TryRewriteEqualOrIsNull(const Expression *equal_expr, const Expression *and_expr) {
+	if (equal_expr->type != ExpressionType::COMPARE_EQUAL || and_expr->type != ExpressionType::CONJUNCTION_AND) {
+		return nullptr;
+	}
 
-		// Make sure on the AND conjuction the relevant conditions appear
-		for (const auto &item : ((BoundConjunctionExpression *)e2)->children) {
-			const auto next_exp = item.get();
+	const auto equal_cast = (BoundComparisonExpression *)equal_expr;
+	const auto and_cast = (BoundConjunctionExpression *)and_expr;
 
-			if (next_exp->type == ExpressionType::OPERATOR_IS_NULL) {
-				const auto child = ((BoundOperatorExpression *)next_exp)->children[0].get();
-				if (Expression::Equals(child, a_exp)) {
-					a_is_null_found = true;
-				} else if (Expression::Equals(child, b_exp)) {
-					b_is_null_found = true;
-				} else {
-					valid = false;
-					break;
-				}
+	if (and_cast->children.size() != 2) {
+		return nullptr;
+	}
+
+	// Make sure on the AND conjuction the relevant conditions appear
+	const auto a_exp = equal_cast->left.get();
+	const auto b_exp = equal_cast->right.get();
+	bool valid = true;
+	bool a_is_null_found = false;
+	bool b_is_null_found = false;
+
+	for (const auto &item : and_cast->children) {
+		const auto next_exp = item.get();
+
+		if (next_exp->type == ExpressionType::OPERATOR_IS_NULL) {
+			const auto next_exp_cast = (BoundOperatorExpression *)next_exp;
+			const auto child = next_exp_cast->children[0].get();
+
+			// Test for equality on both 'a' and 'b' expressions
+			if (Expression::Equals(child, a_exp)) {
+				a_is_null_found = true;
+			} else if (Expression::Equals(child, b_exp)) {
+				b_is_null_found = true;
 			} else {
 				valid = false;
 				break;
 			}
+		} else {
+			valid = false;
+			break;
 		}
-		if (valid && a_is_null_found && b_is_null_found) {
-			return make_unique<BoundComparisonExpression>(ExpressionType::COMPARE_NOT_DISTINCT_FROM,
-			                                              move(equal_comp->left), move(equal_comp->right));
-		}
+	}
+	if (valid && a_is_null_found && b_is_null_found) {
+		return make_unique<BoundComparisonExpression>(ExpressionType::COMPARE_NOT_DISTINCT_FROM, move(equal_cast->left),
+		                                              move(equal_cast->right));
 	}
 	return nullptr;
 }
 
 unique_ptr<Expression> EqualOrNullSimplification::Apply(LogicalOperator &op, vector<Expression *> &bindings,
                                                         bool &changes_made, bool is_root) {
-	const auto or_exp = bindings[0];
+	const Expression *or_exp = bindings[0];
 
-	if (((BoundConjunctionExpression *)or_exp)->children.size() == 2) {
-		const auto or_cast = (BoundConjunctionExpression *)or_exp;
-		const auto left_exp = or_cast->children[0].get(), right_exp = or_cast->children[1].get();
-		// Test for: a=b OR (a IS NULL AND b IS NULL)
-		auto one_try = TryRewriteEqualOrIsNull(left_exp, right_exp);
-		if (one_try != nullptr) {
-			return one_try;
-		}
-		// Test for: (a IS NULL AND b IS NULL) OR a=b
-		return TryRewriteEqualOrIsNull(right_exp, left_exp);
+	if (or_exp->type != ExpressionType::CONJUNCTION_OR) {
+		return nullptr;
 	}
-	return nullptr;
+
+	const auto or_exp_cast = (BoundConjunctionExpression *)or_exp;
+
+	if (or_exp_cast->children.size() != 2) {
+		return nullptr;
+	}
+
+	const auto left_exp = or_exp_cast->children[0].get();
+	const auto right_exp = or_exp_cast->children[1].get();
+	// Test for: a=b OR (a IS NULL AND b IS NULL)
+	auto first_try = TryRewriteEqualOrIsNull(left_exp, right_exp);
+	if (first_try) {
+		return first_try;
+	}
+	// Test for: (a IS NULL AND b IS NULL) OR a=b
+	return TryRewriteEqualOrIsNull(right_exp, left_exp);
 }
 
 } // namespace duckdb

--- a/src/optimizer/rule/equal_or_null_simplification.cpp
+++ b/src/optimizer/rule/equal_or_null_simplification.cpp
@@ -1,0 +1,68 @@
+#include "duckdb/optimizer/rule/equal_or_null_simplification.hpp"
+
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/planner/expression/bound_operator_expression.hpp"
+
+namespace duckdb {
+
+EqualOrNullSimplification::EqualOrNullSimplification(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	// match on OR conjunction
+	root = make_unique<ExpressionMatcher>();
+	root->expr_type = make_unique<SpecificExpressionTypeMatcher>(ExpressionType::CONJUNCTION_OR);
+}
+
+// a=b OR (a IS NULL AND b IS NULL) to a IS NOT DISTINCT FROM b
+static unique_ptr<Expression> TryRewriteEqualOrIsNull(const Expression *e1, const Expression *e2) {
+	if (e1->type == ExpressionType::COMPARE_EQUAL && e2->type == ExpressionType::CONJUNCTION_AND &&
+	    ((BoundConjunctionExpression *)e2)->children.size() == 2) {
+		const auto equal_comp = (BoundComparisonExpression *)e1;
+		const auto a_exp = equal_comp->left.get(), b_exp = equal_comp->right.get();
+		bool valid = true, a_is_null_found = false, b_is_null_found = false;
+
+		// Make sure on the AND conjuction the relevant conditions appear
+		for (const auto &item : ((BoundConjunctionExpression *)e2)->children) {
+			const auto next_exp = item.get();
+
+			if (next_exp->type == ExpressionType::OPERATOR_IS_NULL) {
+				const auto child = ((BoundOperatorExpression *)next_exp)->children[0].get();
+				if (Expression::Equals(child, a_exp)) {
+					a_is_null_found = true;
+				} else if (Expression::Equals(child, b_exp)) {
+					b_is_null_found = true;
+				} else {
+					valid = false;
+					break;
+				}
+			} else {
+				valid = false;
+				break;
+			}
+		}
+		if (valid && a_is_null_found && b_is_null_found) {
+			return make_unique<BoundComparisonExpression>(ExpressionType::COMPARE_NOT_DISTINCT_FROM,
+			                                              move(equal_comp->left), move(equal_comp->right));
+		}
+	}
+	return nullptr;
+}
+
+unique_ptr<Expression> EqualOrNullSimplification::Apply(LogicalOperator &op, vector<Expression *> &bindings,
+                                                        bool &changes_made, bool is_root) {
+	const auto or_exp = bindings[0];
+
+	if (((BoundConjunctionExpression *)or_exp)->children.size() == 2) {
+		const auto or_cast = (BoundConjunctionExpression *)or_exp;
+		const auto left_exp = or_cast->children[0].get(), right_exp = or_cast->children[1].get();
+		// Test for: a=b OR (a IS NULL AND b IS NULL)
+		auto one_try = TryRewriteEqualOrIsNull(left_exp, right_exp);
+		if (one_try != nullptr) {
+			return one_try;
+		}
+		// Test for: (a IS NULL AND b IS NULL) OR a=b
+		return TryRewriteEqualOrIsNull(right_exp, left_exp);
+	}
+	return nullptr;
+}
+
+} // namespace duckdb

--- a/test/sql/optimizer/expression/test_equal_or_null_optimization.test
+++ b/test/sql/optimizer/expression/test_equal_or_null_optimization.test
@@ -1,0 +1,35 @@
+# name: test/sql/optimizer/expression/test_equal_or_null_optimization.test
+# description: Test a=b OR (a IS NULL AND b IS NULL) to a IS NOT DISTINCT FROM b
+# group: [expression]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+START TRANSACTION;
+
+statement ok
+CREATE TABLE test(i INTEGER, j INTEGER);
+
+statement ok
+INSERT INTO test VALUES (1,1), (2,2), (NULL,NULL)
+
+statement ok
+PRAGMA explain_output = 'OPTIMIZED_ONLY';
+
+query I rowsort
+SELECT i FROM test WHERE (i=j) OR (i IS NULL AND j IS NULL);
+----
+1
+2
+NULL
+
+query I rowsort
+SELECT i FROM test WHERE (i IS NULL AND j IS NULL) OR (i=j);
+----
+1
+2
+NULL
+
+statement ok
+ROLLBACK;

--- a/test/sql/optimizer/expression/test_equal_or_null_optimization.test
+++ b/test/sql/optimizer/expression/test_equal_or_null_optimization.test
@@ -6,13 +6,10 @@ statement ok
 PRAGMA enable_verification
 
 statement ok
-CREATE TABLE test(i INTEGER, j INTEGER);
+CREATE TABLE test(i INTEGER, j INTEGER, k integer);
 
 statement ok
-INSERT INTO test VALUES (1,1), (2,2), (NULL,NULL)
-
-statement ok
-PRAGMA explain_output = 'OPTIMIZED_ONLY';
+INSERT INTO test VALUES (1,1,3), (2,2,4), (NULL,NULL,NULL);
 
 query I rowsort
 SELECT i FROM test WHERE (i=j) OR (i IS NULL AND j IS NULL);
@@ -21,9 +18,38 @@ SELECT i FROM test WHERE (i=j) OR (i IS NULL AND j IS NULL);
 2
 NULL
 
+query I nosort distinctrewrite1
+EXPLAIN SELECT (i=j) OR (i IS NULL AND j IS NULL) FROM test;
+----
+
+query I nosort distinctrewrite1
+EXPLAIN SELECT i IS NOT DISTINCT FROM j FROM test;
+----
+
 query I rowsort
 SELECT i FROM test WHERE (i IS NULL AND j IS NULL) OR (i=j);
 ----
 1
 2
 NULL
+
+query I nosort distinctrewrite2
+EXPLAIN SELECT (i IS NULL AND j IS NULL) OR (i=j) FROM test;
+----
+
+query I nosort distinctrewrite2
+EXPLAIN SELECT i IS NOT DISTINCT FROM j FROM test;
+----
+
+# this one cannot be rewritten
+query I nosort
+SELECT i FROM test WHERE (i=k) OR (i IS NULL AND j IS NULL);
+----
+NULL
+
+# neither this one
+query I nosort
+SELECT i FROM test WHERE (i=j) OR (i IS NULL AND j = 1);
+----
+1
+2

--- a/test/sql/optimizer/expression/test_equal_or_null_optimization.test
+++ b/test/sql/optimizer/expression/test_equal_or_null_optimization.test
@@ -6,6 +6,9 @@ statement ok
 PRAGMA enable_verification
 
 statement ok
+PRAGMA explain_output = 'PHYSICAL_ONLY'
+
+statement ok
 CREATE TABLE test(i INTEGER, j INTEGER, k integer);
 
 statement ok
@@ -18,13 +21,22 @@ SELECT i FROM test WHERE (i=j) OR (i IS NULL AND j IS NULL);
 2
 NULL
 
-query I nosort distinctrewrite1
+query II nosort distinctrewrite1
 EXPLAIN SELECT (i=j) OR (i IS NULL AND j IS NULL) FROM test;
 ----
+physical_plan	<REGEX>:.*DISTINCT.*
 
-query I nosort distinctrewrite1
+query I rowsort
+SELECT i FROM test WHERE i IS NOT DISTINCT FROM j;
+----
+1
+2
+NULL
+
+query II nosort distinctrewrite1
 EXPLAIN SELECT i IS NOT DISTINCT FROM j FROM test;
 ----
+physical_plan	<REGEX>:.*DISTINCT.*
 
 query I rowsort
 SELECT i FROM test WHERE (i IS NULL AND j IS NULL) OR (i=j);
@@ -33,13 +45,28 @@ SELECT i FROM test WHERE (i IS NULL AND j IS NULL) OR (i=j);
 2
 NULL
 
-query I nosort distinctrewrite2
+query II nosort distinctrewrite1
 EXPLAIN SELECT (i IS NULL AND j IS NULL) OR (i=j) FROM test;
 ----
+physical_plan	<REGEX>:.*DISTINCT.*
 
-query I nosort distinctrewrite2
-EXPLAIN SELECT i IS NOT DISTINCT FROM j FROM test;
+# do a hash join
+query I rowsort
+SELECT test1.i FROM test AS test1, test AS test2 WHERE (test1.i=test2.j) OR (test1.i IS NULL AND test2.j IS NULL);
 ----
+1
+2
+NULL
+
+query II nosort distinctrewrite2
+EXPLAIN SELECT test1.i FROM test AS test1, test AS test2 WHERE (test1.i=test2.j) OR (test1.i IS NULL AND test2.j IS NULL);
+----
+physical_plan	<REGEX>:.*DISTINCT.*
+
+query II nosort distinctrewrite2
+EXPLAIN SELECT test1.i FROM test AS test1, test AS test2 WHERE (test1.i IS NULL AND test2.j IS NULL) OR (test1.i=test2.j);
+----
+physical_plan	<REGEX>:.*DISTINCT.*
 
 # this one cannot be rewritten
 query I nosort
@@ -47,9 +74,45 @@ SELECT i FROM test WHERE (i=k) OR (i IS NULL AND j IS NULL);
 ----
 NULL
 
+query II nosort nodistinctrewrite1
+EXPLAIN SELECT i FROM test WHERE (i=k) OR (i IS NULL AND j IS NULL);
+----
+physical_plan	<REGEX>:.*OR.*
+
 # neither this one
 query I nosort
 SELECT i FROM test WHERE (i=j) OR (i IS NULL AND j = 1);
 ----
 1
 2
+
+query II nosort nodistinctrewrite2
+EXPLAIN SELECT i FROM test WHERE (i=j) OR (i IS NULL AND j = 1);
+----
+physical_plan	<REGEX>:.*OR.*
+
+# do a nested loop join because the OR cannot be rewritten here
+query I rowsort
+SELECT test1.i FROM test AS test1, test AS test2 WHERE (test1.i=test2.j) OR (test2.i IS NULL AND test1.j IS NULL);
+----
+1
+2
+NULL
+
+query II nosort distinctrewrite3
+EXPLAIN SELECT test1.i FROM test AS test1, test AS test2 WHERE (test1.i=test2.j) OR (test2.i IS NULL AND test1.j IS NULL);
+----
+physical_plan	<REGEX>:.*OR.*
+
+# same issue as the previous one
+query I rowsort
+SELECT test1.i FROM test AS test1, test AS test2 WHERE (test1.i=test2.k) OR (test2.i IS NULL AND test2.j IS NULL);
+----
+1
+2
+NULL
+
+query II nosort distinctrewrite4
+EXPLAIN SELECT test1.i FROM test AS test1, test AS test2 WHERE (test1.i=test2.k) OR (test2.i IS NULL AND test2.j IS NULL);
+----
+physical_plan	<REGEX>:.*OR.*

--- a/test/sql/optimizer/expression/test_equal_or_null_optimization.test
+++ b/test/sql/optimizer/expression/test_equal_or_null_optimization.test
@@ -6,9 +6,6 @@ statement ok
 PRAGMA enable_verification
 
 statement ok
-START TRANSACTION;
-
-statement ok
 CREATE TABLE test(i INTEGER, j INTEGER);
 
 statement ok
@@ -30,6 +27,3 @@ SELECT i FROM test WHERE (i IS NULL AND j IS NULL) OR (i=j);
 1
 2
 NULL
-
-statement ok
-ROLLBACK;


### PR DESCRIPTION
Hello, Duckies! Here is my very first contribution to the Duck! However, I have some questions before the reviews.

This pull request implements the a=b OR (a IS NULL AND b IS NULL) to a IS NOT DISTINCT FROM b rewrite as part of issue #3509.

1. From writing SQL optimizers in the past I found some corner cases such as equality between two different types, (eg INT and BIGINT), and an upcast is needed. This creates corner cases for optimizers such as this one where the expressions won't match between both sides of the OR due to the upcast under the equality. I wonder if such cases have been handled before because I didn't spot it from other optimizers.
2. Is there any documentation about writing optimizers? That's because it's not clear to me what is the role of the "Rule". I see some optimizers with rule clauses, but later during the optimization phase, they apply other conditions, which makes it confusing for me :(
3.  I see a new expression is always returned when the expression optimizer makes changes. but could we just overwrite the input expression to avoid allocations, or a single expression can have more than one reference?
4. In MonetDB there was a performance issue because there were multiple optimizers present, so we had to pack them together in single calls. I see many here: https://github.com/PedroTadim/duckdb/blob/master/src/optimizer/optimizer.cpp#L27 It would be desirable to pack them in the future? Same here: https://github.com/PedroTadim/duckdb/blob/master/src/optimizer/optimizer.cpp#L66

Thanks for your support!