### PR TITLE
Use Python 3 for configuring R

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,7 +140,7 @@ if(BUILD_PYTHON
       COMMAND
         DUCKDB_R_BINDIR=${CMAKE_BINARY_DIR}
         DUCKDB_R_CFLAGS=\"${ALL_COMPILE_FLAGS}\"
-        DUCKDB_R_LIBS=\"${duckdb_libs}\" python rconfigure.py
+        DUCKDB_R_LIBS=\"${duckdb_libs}\" python3 rconfigure.py
       DEPENDS duckdb
       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tools/rpkg
       COMMENT Configure

--- a/tools/rpkg/configure
+++ b/tools/rpkg/configure
@@ -8,7 +8,7 @@ cd `dirname $0`
 echo "R: configure"
 
 if [ -z "${DUCKDB_R_DEBUG}" ]; then
-  python rconfigure.py
+  python3 rconfigure.py
 else
   cd ../..
   GEN=ninja CONFIGURE_R=1 nice ${MAKE:-make} debug


### PR DESCRIPTION
Recent changes to the configuration scripts make this move necessary.

Should our CMake system use `python3` everywhere, or perhaps detect the correct Python 3 executable and use that everywhere?