### PR TITLE
Implements __enter__ and __exit__ functions on pyconnection to allow the use of context managers

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
@@ -53,6 +53,13 @@ public:
 	static void Initialize(py::handle &m);
 	static void Cleanup();
 
+	static shared_ptr<DuckDBPyConnection> Enter(DuckDBPyConnection &self,
+	                                            const string &database = ":memory:", bool read_only = false,
+	                                            const py::dict &config = py::dict(), bool check_same_thread = true);
+
+	static bool Exit(DuckDBPyConnection &self, const py::object &exc_type, const py::object &exc,
+	                 const py::object &traceback);
+
 	static DuckDBPyConnection *DefaultConnection();
 
 	DuckDBPyConnection *ExecuteMany(const string &query, py::object params = py::list());

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -91,17 +91,9 @@ void DuckDBPyConnection::Initialize(py::handle &m) {
 	    .def("get_substrait", &DuckDBPyConnection::GetSubstrait, "Serialize a query to protobuf", py::arg("query"))
 	    .def("get_table_names", &DuckDBPyConnection::GetTableNames, "Extract the required table names from a query",
 	         py::arg("query"))
-	    .def("__enter__", [](DuckDBPyConnection &self, string database = ":memory:", bool read_only = false, py::dict config = py::dict(),
-	                                              bool check_same_thread = true) {
-				return DuckDBPyConnection::Connect(database,read_only,config, check_same_thread); // uses placement-new
-			})
-	    .def("__exit__", [](DuckDBPyConnection &self, const py::object& exc_type, const py::object& exc, const py::object& traceback) {
-		    if (!exc.is_none() || !exc_type.is_none() || !traceback.is_none()){
-			    throw NotImplementedException("Can't handle this");
-		    }
-				self.Close();
-		        return true;
-			})
+	    .def("__enter__", &DuckDBPyConnection::Enter, py::arg("database") = ":memory:", py::arg("read_only") = false,
+	         py::arg("config") = py::dict(), py::arg("check_same_thread") = true)
+	    .def("__exit__", &DuckDBPyConnection::Exit, py::arg("exc_type"), py::arg("exc"), py::arg("traceback"))
 	    .def_property_readonly("description", &DuckDBPyConnection::GetDescription,
 	                           "Get result set attributes, mainly column names");
 
@@ -691,6 +683,18 @@ DuckDBPyConnection *DuckDBPyConnection::DefaultConnection() {
 		default_connection = DuckDBPyConnection::Connect(":memory:", false, config_dict, true);
 	}
 	return default_connection.get();
+}
+
+shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Enter(DuckDBPyConnection &self, const string &database,
+                                                         bool read_only, const py::dict &config,
+                                                         bool check_same_thread) {
+	return self.Connect(database, read_only, config, check_same_thread);
+}
+
+bool DuckDBPyConnection::Exit(DuckDBPyConnection &self, const py::object &exc_type, const py::object &exc,
+                              const py::object &traceback) {
+	self.Close();
+	return true;
 }
 
 void DuckDBPyConnection::Cleanup() {

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -91,6 +91,17 @@ void DuckDBPyConnection::Initialize(py::handle &m) {
 	    .def("get_substrait", &DuckDBPyConnection::GetSubstrait, "Serialize a query to protobuf", py::arg("query"))
 	    .def("get_table_names", &DuckDBPyConnection::GetTableNames, "Extract the required table names from a query",
 	         py::arg("query"))
+	    .def("__enter__", [](DuckDBPyConnection &self, string database = ":memory:", bool read_only = false, py::dict config = py::dict(),
+	                                              bool check_same_thread = true) {
+				return DuckDBPyConnection::Connect(database,read_only,config, check_same_thread); // uses placement-new
+			})
+	    .def("__exit__", [](DuckDBPyConnection &self, const py::object& exc_type, const py::object& exc, const py::object& traceback) {
+		    if (!exc.is_none() || !exc_type.is_none() || !traceback.is_none()){
+			    throw NotImplementedException("Can't handle this");
+		    }
+				self.Close();
+		        return true;
+			})
 	    .def_property_readonly("description", &DuckDBPyConnection::GetDescription,
 	                           "Get result set attributes, mainly column names");
 

--- a/tools/pythonpkg/tests/fast/test_context_manager.py
+++ b/tools/pythonpkg/tests/fast/test_context_manager.py
@@ -1,0 +1,5 @@
+import duckdb
+
+with duckdb.connect() as con:
+    res = con.execute("select 1").fetchall()
+    print (res)

--- a/tools/pythonpkg/tests/fast/test_context_manager.py
+++ b/tools/pythonpkg/tests/fast/test_context_manager.py
@@ -1,5 +1,6 @@
 import duckdb
 
-with duckdb.connect() as con:
-    res = con.execute("select 1").fetchall()
-    print (res)
+class TestContextManager(object):
+    def test_context_manager(self, duckdb_cursor):
+        with duckdb.connect(database=':memory:', read_only=False) as con:
+            assert con.execute("select 1").fetchall() == [(1,)]


### PR DESCRIPTION
Fix: #3573 