### PR TITLE
Turn the expression depth limit into a configureable parameter

### DIFF
--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -38,6 +38,8 @@ struct ClientConfig {
 	//! Preserve identifier case while parsing.
 	//! If false, all unquoted identifiers are lower-cased (e.g. "MyTable" -> "mytable").
 	bool preserve_identifier_case = true;
+	//! The maximum expression depth limit in the parser
+	idx_t max_expression_depth = 1000;
 
 	// Whether or not aggressive query verification is enabled
 	bool query_verification_enabled = false;

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -169,6 +169,16 @@ struct LogQueryPathSetting {
 	static Value GetSetting(ClientContext &context);
 };
 
+struct MaximumExpressionDepthSetting {
+	static constexpr const char *Name = "max_expression_depth";
+	static constexpr const char *Description =
+	    "The maximum expression depth limit in the parser. WARNING: increasing this setting and using very deep "
+	    "expressions might lead to stack overflow errors.";
+	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT;
+	static void SetLocal(ClientContext &context, const Value &parameter);
+	static Value GetSetting(ClientContext &context);
+};
+
 struct MaximumMemorySetting {
 	static constexpr const char *Name = "max_memory";
 	static constexpr const char *Description = "The maximum memory of the system (e.g. 1GB)";

--- a/src/include/duckdb/parser/parser.hpp
+++ b/src/include/duckdb/parser/parser.hpp
@@ -23,6 +23,7 @@ namespace duckdb {
 
 struct ParserOptions {
 	bool preserve_identifier_case = true;
+	idx_t max_expression_depth = 1000;
 };
 
 //! The parser is responsible for parsing the query and converting it into a set

--- a/src/include/duckdb/parser/transformer.hpp
+++ b/src/include/duckdb/parser/transformer.hpp
@@ -32,12 +32,11 @@ struct GroupingExpressionMap;
 //! The transformer class is responsible for transforming the internal Postgres
 //! parser representation into the DuckDB representation
 class Transformer {
-	static constexpr const idx_t DEFAULT_MAX_EXPRESSION_DEPTH = 1000;
-
 	friend class StackChecker;
 
 public:
-	explicit Transformer(Transformer *parent = nullptr, idx_t max_expression_depth_p = DEFAULT_MAX_EXPRESSION_DEPTH);
+	explicit Transformer(idx_t max_expression_depth_p);
+	explicit Transformer(Transformer *parent);
 
 	//! Transforms a Postgres parse tree into a set of SQL Statements
 	bool TransformParseTree(duckdb_libpgquery::PGList *tree, vector<unique_ptr<SQLStatement>> &statements);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1131,6 +1131,7 @@ bool ClientContext::TryGetCurrentSetting(const std::string &key, Value &result) 
 ParserOptions ClientContext::GetParserOptions() {
 	ParserOptions options;
 	options.preserve_identifier_case = ClientConfig::GetConfig(*this).preserve_identifier_case;
+	options.max_expression_depth = ClientConfig::GetConfig(*this).max_expression_depth;
 	return options;
 }
 

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -40,6 +40,7 @@ static ConfigurationOption internal_options[] = {DUCKDB_GLOBAL(AccessModeSetting
                                                  DUCKDB_GLOBAL(ExternalThreadsSetting),
                                                  DUCKDB_GLOBAL(ForceCompressionSetting),
                                                  DUCKDB_LOCAL(LogQueryPathSetting),
+                                                 DUCKDB_LOCAL(MaximumExpressionDepthSetting),
                                                  DUCKDB_GLOBAL(MaximumMemorySetting),
                                                  DUCKDB_GLOBAL_ALIAS("memory_limit", MaximumMemorySetting),
                                                  DUCKDB_GLOBAL_ALIAS("null_order", DefaultNullOrderSetting),

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -393,6 +393,17 @@ Value LogQueryPathSetting::GetSetting(ClientContext &context) {
 }
 
 //===--------------------------------------------------------------------===//
+// Maximum Expression Depth
+//===--------------------------------------------------------------------===//
+void MaximumExpressionDepthSetting::SetLocal(ClientContext &context, const Value &input) {
+	ClientConfig::GetConfig(context).max_expression_depth = input.GetValue<uint64_t>();
+}
+
+Value MaximumExpressionDepthSetting::GetSetting(ClientContext &context) {
+	return Value::UBIGINT(ClientConfig::GetConfig(context).max_expression_depth);
+}
+
+//===--------------------------------------------------------------------===//
 // Maximum Memory
 //===--------------------------------------------------------------------===//
 void MaximumMemorySetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -18,7 +18,7 @@ Parser::Parser(ParserOptions options_p) : options(options_p) {
 }
 
 void Parser::ParseQuery(const string &query) {
-	Transformer transformer;
+	Transformer transformer(options.max_expression_depth);
 	{
 		PostgresParser::SetPreserveIdentifierCase(options.preserve_identifier_case);
 		PostgresParser parser;

--- a/src/parser/transformer.cpp
+++ b/src/parser/transformer.cpp
@@ -20,9 +20,12 @@ StackChecker::StackChecker(StackChecker &&other) noexcept
 	other.stack_usage = 0;
 }
 
-Transformer::Transformer(Transformer *parent, idx_t max_expression_depth_p)
-    : parent(parent), max_expression_depth(parent ? parent->max_expression_depth : max_expression_depth_p),
-      stack_depth(DConstants::INVALID_INDEX) {
+Transformer::Transformer(idx_t max_expression_depth_p)
+    : parent(nullptr), max_expression_depth(max_expression_depth_p), stack_depth(DConstants::INVALID_INDEX) {
+}
+
+Transformer::Transformer(Transformer *parent)
+    : parent(parent), max_expression_depth(parent->max_expression_depth), stack_depth(DConstants::INVALID_INDEX) {
 }
 
 bool Transformer::TransformParseTree(duckdb_libpgquery::PGList *tree, vector<unique_ptr<SQLStatement>> &statements) {
@@ -48,7 +51,9 @@ StackChecker Transformer::StackCheck(idx_t extra_stack) {
 	}
 	D_ASSERT(node->stack_depth != DConstants::INVALID_INDEX);
 	if (node->stack_depth + extra_stack >= max_expression_depth) {
-		throw ParserException("Max expression depth limit of %lld exceeded", max_expression_depth);
+		throw ParserException("Max expression depth limit of %lld exceeded. Use \"SET max_expression_depth TO x\" to "
+		                      "increase the maximum expression depth.",
+		                      max_expression_depth);
 	}
 	return StackChecker(*node, extra_stack);
 }

--- a/test/sql/parser/expression_depth_limit.test
+++ b/test/sql/parser/expression_depth_limit.test
@@ -1,0 +1,12 @@
+# name: test/sql/parser/expression_depth_limit.test
+# description: Test max expression depth limit
+# group: [parser]
+
+statement ok
+SELECT (1+(1+(1+(1+(1+(1+(1+1)))))));
+
+statement ok
+SET max_expression_depth TO 3;
+
+statement error
+SELECT (1+(1+(1+(1+(1+(1+(1+1)))))));

--- a/test/sql/parser/expression_depth_limit.test
+++ b/test/sql/parser/expression_depth_limit.test
@@ -10,3 +10,9 @@ SET max_expression_depth TO 3;
 
 statement error
 SELECT (1+(1+(1+(1+(1+(1+(1+1)))))));
+
+statement ok
+SET max_expression_depth TO 1000;
+
+statement ok
+SELECT (1+(1+(1+(1+(1+(1+(1+1)))))));


### PR DESCRIPTION
Fixes #3549