### PR TITLE
SQLite UDF fixes for writefile and friends

### DIFF
--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -541,6 +541,32 @@ select 42;
 
 test('/* ;;;;;; */ select 42;', out='42')
 
+
+# sqlite udfs
+test('''
+SELECT writefile();
+''', err='wrong number of arguments to function writefile')
+
+test('''
+SELECT writefile('hello');
+''', err='wrong number of arguments to function writefile')
+
+test('''
+SELECT writefile('duckdbtest_writefile', 'hello');
+''')
+test_writefile = 'duckdbtest_writefile'
+if not os.path.exists(test_writefile):
+     raise Exception(f"Failed to write file {test_writefile}");
+with open(test_writefile, 'r') as f:
+     text = f.read()
+if text != 'hello':
+     raise Exception("Incorrect contents for test writefile")
+os.remove(test_writefile)
+
+test('''
+SELECT lsmode(1) AS lsmode;
+''', out='lsmode')
+
 if os.name != 'nt':
      test('''
 create table mytable as select * from

--- a/tools/sqlite3_api_wrapper/sqlite3_udf_api/include/cast_sqlite.hpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_udf_api/include/cast_sqlite.hpp
@@ -76,8 +76,7 @@ struct CastToSQLiteValue {
 		static sqlite3_value Operation(SRC blob) {
 			sqlite3_value sqlite_blob;
 			sqlite_blob.type = SQLiteTypeValue::BLOB;
-			sqlite_blob.n = blob.GetSize();
-			sqlite_blob.str_t = blob;
+			sqlite_blob.str = blob.GetString();
 			return sqlite_blob;
 		}
 	};

--- a/tools/sqlite3_api_wrapper/sqlite3_udf_api/include/udf_struct_sqlite3.h
+++ b/tools/sqlite3_api_wrapper/sqlite3_udf_api/include/udf_struct_sqlite3.h
@@ -26,15 +26,11 @@ struct sqlite3_value {
 		double r;  /* Real value used when MEM_Real is set in flags */
 		int64_t i; /* Integer value used when MEM_Int is set in flags */
 		           // int nZero;          /* Extra zero bytes when MEM_Zero and MEM_Blob set */
-		           // const char *zPType; /* Pointer type when MEM_Term|MEM_Subtype|MEM_Null */
 	} u;
 	duckdb::SQLiteTypeValue type;
 
-	int n;                  /* Number of characters in string value, excluding '\0' */
-	duckdb::string_t str_t; /* String or BLOB value */
-	char *zMalloc;          /* Space to hold MEM_Str or MEM_Blob if szMalloc>0 */
-	int szMalloc = 0;       /* Size of the zMalloc allocation */
-	sqlite3 *db;            /* The associated database connection */
+	std::string str;
+	sqlite3 *db; /* The associated database connection */
 };
 
 struct FuncDef {

--- a/tools/sqlite3_api_wrapper/sqlite3_udf_api/sqlite3_udf_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_udf_api/sqlite3_udf_wrapper.cpp
@@ -40,7 +40,6 @@ duckdb::scalar_function_t duckdb::SQLiteUDFWrapper::CreateSQLiteScalarFunction(d
 				db_sqlite3->errCode = SQLITE_OK;
 			}
 			// call the UDF on that tuple
-			memset(&context.result, 0, sizeof(sqlite3_value));
 			context.isError = SQLITE_OK;
 			sqlite_udf(&context, argc, argv.get());
 

--- a/tools/sqlite3_api_wrapper/sqlite3_udf_api/sqlite3_udf_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_udf_api/sqlite3_udf_wrapper.cpp
@@ -40,19 +40,19 @@ duckdb::scalar_function_t duckdb::SQLiteUDFWrapper::CreateSQLiteScalarFunction(d
 				db_sqlite3->errCode = SQLITE_OK;
 			}
 			// call the UDF on that tuple
+			memset(&context.result, 0, sizeof(sqlite3_value));
+			context.isError = SQLITE_OK;
 			sqlite_udf(&context, argc, argv.get());
 
 			// check memory allocatated by the sqlite_values
-			for (idx_t col_idx = 0; col_idx < argc; ++col_idx) {
-				if (argv[col_idx]->szMalloc > 0) {
-					vec_values_to_free.push_back(*argv[col_idx]);
-				}
-			}
-
 			// error set by the UDF
-			if (context.isError == SQLITE_ERROR) {
-				char *error_msg = context.result.str_t.GetDataWriteable();
-				string str_msg(error_msg, context.result.n);
+			if (context.isError != SQLITE_OK) {
+				string str_msg;
+				if (context.result.type == SQLiteTypeValue::TEXT) {
+					str_msg = context.result.str;
+				} else {
+					str_msg = "Error in SQLite UDF, but no error message was provided";
+				}
 				throw std::runtime_error(str_msg.c_str());
 			}
 
@@ -72,11 +72,6 @@ duckdb::scalar_function_t duckdb::SQLiteUDFWrapper::CreateSQLiteScalarFunction(d
 		}
 
 		CastSQLite::ToVectorString(res_sqlite_value_type, res_sqlite_values, result);
-
-		// free memory allocated by sqlite_values
-		for (idx_t i = 0; i < vec_values_to_free.size(); ++i) {
-			free(vec_values_to_free[i].zMalloc);
-		}
 	};
 	return udf_function;
 }


### PR DESCRIPTION
* Fixes crash in SQLite UDFs when called without parameters
* Fixes bugs in string management with non-inlined strings and generally simplifies string management for `sqlite3_value`
* Add tests to SQLite UDFs that are registered in the shell