### PR TITLE
Correctly propagate what a statement returns from the binder

### DIFF
--- a/src/common/enums/statement_type.cpp
+++ b/src/common/enums/statement_type.cpp
@@ -58,15 +58,4 @@ string StatementTypeToString(StatementType type) {
 }
 // LCOV_EXCL_STOP
 
-bool StatementTypeReturnChanges(StatementType type) {
-	switch (type) {
-	case StatementType::INSERT_STATEMENT:
-	case StatementType::UPDATE_STATEMENT:
-	case StatementType::DELETE_STATEMENT:
-		return true;
-	default:
-		return false;
-	}
-}
-
 } // namespace duckdb

--- a/src/include/duckdb/common/enums/statement_type.hpp
+++ b/src/include/duckdb/common/enums/statement_type.hpp
@@ -43,6 +43,31 @@ enum class StatementType : uint8_t {
 };
 
 string StatementTypeToString(StatementType type);
-bool StatementTypeReturnChanges(StatementType type);
+
+enum class StatementReturnType : uint8_t {
+	QUERY_RESULT, // the statement returns a query result (e.g. for display to the user)
+	CHANGED_ROWS, // the statement returns a single row containing the number of changed rows (e.g. an insert stmt)
+	NOTHING       // the statement returns nothing
+};
+
+//! A struct containing various properties of a SQL statement
+struct StatementProperties {
+	StatementProperties()
+	    : read_only(true), requires_valid_transaction(true), allow_stream_result(false), bound_all_parameters(true),
+	      return_type(StatementReturnType::QUERY_RESULT) {
+	}
+
+	//! Whether or not the statement is a read-only statement, or whether it can result in changes to the database
+	bool read_only;
+	//! Whether or not the statement requires a valid transaction. Almost all statements require this, with the
+	//! exception of
+	bool requires_valid_transaction;
+	//! Whether or not the result can be streamed to the client
+	bool allow_stream_result;
+	//! Whether or not all parameters have successfully had their types determined
+	bool bound_all_parameters;
+	//! What type of data the statement returns
+	StatementReturnType return_type;
+};
 
 } // namespace duckdb

--- a/src/include/duckdb/main/materialized_query_result.hpp
+++ b/src/include/duckdb/main/materialized_query_result.hpp
@@ -16,10 +16,9 @@ namespace duckdb {
 
 class MaterializedQueryResult : public QueryResult {
 public:
-	//! Creates an empty successful query result
-	DUCKDB_API explicit MaterializedQueryResult(StatementType statement_type);
 	//! Creates a successful query result with the specified names and types
-	DUCKDB_API MaterializedQueryResult(StatementType statement_type, vector<LogicalType> types, vector<string> names);
+	DUCKDB_API MaterializedQueryResult(StatementType statement_type, StatementProperties properties,
+	                                   vector<LogicalType> types, vector<string> names);
 	//! Creates an unsuccessful query result with error condition
 	DUCKDB_API explicit MaterializedQueryResult(string error);
 

--- a/src/include/duckdb/main/prepared_statement.hpp
+++ b/src/include/duckdb/main/prepared_statement.hpp
@@ -46,6 +46,8 @@ public:
 	idx_t ColumnCount();
 	//! Returns the statement type of the underlying prepared statement object
 	StatementType GetStatementType();
+	//! Returns the underlying statement properties
+	StatementProperties GetStatementProperties();
 	//! Returns the result SQL types of the prepared statement
 	const vector<LogicalType> &GetTypes();
 	//! Returns the result names of the prepared statement

--- a/src/include/duckdb/main/prepared_statement_data.hpp
+++ b/src/include/duckdb/main/prepared_statement_data.hpp
@@ -37,15 +37,8 @@ public:
 	//! The result types of the transaction
 	vector<LogicalType> types;
 
-	//! Whether or not the statement is a read-only statement, or whether it can result in changes to the database
-	bool read_only;
-	//! Whether or not the statement requires a valid transaction. Almost all statements require this, with the
-	//! exception of
-	bool requires_valid_transaction;
-	//! Whether or not the result can be streamed to the client
-	bool allow_stream_result;
-	//! Whether or not all parameters have successfully had their types determined
-	bool bound_all_parameters;
+	//! The statement properties
+	StatementProperties properties;
 
 	//! The catalog version of when the prepared statement was bound
 	//! If this version is lower than the current catalog version, we have to rebind the prepared statement

--- a/src/include/duckdb/main/query_result.hpp
+++ b/src/include/duckdb/main/query_result.hpp
@@ -20,11 +20,9 @@ enum class QueryResultType : uint8_t { MATERIALIZED_RESULT, STREAM_RESULT, PENDI
 
 class BaseQueryResult {
 public:
-	//! Creates a successful empty query result
-	DUCKDB_API BaseQueryResult(QueryResultType type, StatementType statement_type);
 	//! Creates a successful query result with the specified names and types
-	DUCKDB_API BaseQueryResult(QueryResultType type, StatementType statement_type, vector<LogicalType> types,
-	                           vector<string> names);
+	DUCKDB_API BaseQueryResult(QueryResultType type, StatementType statement_type, StatementProperties properties,
+	                           vector<LogicalType> types, vector<string> names);
 	//! Creates an unsuccessful query result with error condition
 	DUCKDB_API BaseQueryResult(QueryResultType type, string error);
 	DUCKDB_API virtual ~BaseQueryResult();
@@ -55,11 +53,9 @@ public:
 //! incrementally fetch data from the database.
 class QueryResult : public BaseQueryResult {
 public:
-	//! Creates a successful empty query result
-	DUCKDB_API QueryResult(QueryResultType type, StatementType statement_type);
 	//! Creates a successful query result with the specified names and types
-	DUCKDB_API QueryResult(QueryResultType type, StatementType statement_type, vector<LogicalType> types,
-	                       vector<string> names);
+	DUCKDB_API QueryResult(QueryResultType type, StatementType statement_type, StatementProperties properties,
+	                       vector<LogicalType> types, vector<string> names);
 	//! Creates an unsuccessful query result with error condition
 	DUCKDB_API QueryResult(QueryResultType type, string error);
 	DUCKDB_API virtual ~QueryResult() override;

--- a/src/include/duckdb/main/query_result.hpp
+++ b/src/include/duckdb/main/query_result.hpp
@@ -33,6 +33,8 @@ public:
 	QueryResultType type;
 	//! The type of the statement that created this result
 	StatementType statement_type;
+	//! Properties of the statement
+	StatementProperties properties;
 	//! The SQL types of the result
 	vector<LogicalType> types;
 	//! The names of the result

--- a/src/include/duckdb/main/stream_query_result.hpp
+++ b/src/include/duckdb/main/stream_query_result.hpp
@@ -25,8 +25,8 @@ class StreamQueryResult : public QueryResult {
 public:
 	//! Create a successful StreamQueryResult. StreamQueryResults should always be successful initially (it makes no
 	//! sense to stream an error).
-	DUCKDB_API StreamQueryResult(StatementType statement_type, shared_ptr<ClientContext> context,
-	                             vector<LogicalType> types, vector<string> names);
+	DUCKDB_API StreamQueryResult(StatementType statement_type, StatementProperties properties,
+	                             shared_ptr<ClientContext> context, vector<LogicalType> types, vector<string> names);
 	DUCKDB_API ~StreamQueryResult() override;
 
 public:

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -18,8 +18,7 @@
 #include "duckdb/planner/bound_statement.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/parser/result_modifier.hpp"
-
-//#include "duckdb/catalog/catalog_entry/table_macro_catalog_entry.hpp"
+#include "duckdb/common/enums/statement_type.hpp"
 
 namespace duckdb {
 class BoundResultModifier;
@@ -83,12 +82,8 @@ public:
 	vector<BoundParameterExpression *> *parameters;
 	//! The types of the prepared statement parameters, if any
 	vector<LogicalType> *parameter_types;
-	//! Whether or not the bound statement is read-only
-	bool read_only;
-	//! Whether or not the statement requires a valid transaction to run
-	bool requires_valid_transaction;
-	//! Whether or not the statement can be streamed to the client
-	bool allow_stream_result;
+	//! Statement properties
+	StatementProperties properties;
 	//! The alias for the currently processing subquery, if it exists
 	string alias;
 	//! Macro parameter bindings (if any)

--- a/src/include/duckdb/planner/planner.hpp
+++ b/src/include/duckdb/planner/planner.hpp
@@ -33,10 +33,7 @@ public:
 	shared_ptr<Binder> binder;
 	ClientContext &context;
 
-	bool read_only;
-	bool requires_valid_transaction;
-	bool allow_stream_result;
-	bool bound_all_parameters;
+	StatementProperties properties;
 
 private:
 	void CreatePlan(SQLStatement &statement);

--- a/src/main/capi/arrow-c.cpp
+++ b/src/main/capi/arrow-c.cpp
@@ -56,7 +56,7 @@ idx_t duckdb_arrow_rows_changed(duckdb_arrow result) {
 	auto wrapper = (ArrowResultWrapper *)result;
 	idx_t rows_changed = 0;
 	idx_t row_count = wrapper->result->collection.Count();
-	if (row_count > 0 && StatementTypeReturnChanges(wrapper->result->statement_type)) {
+	if (row_count > 0 && wrapper->result->properties.return_type == duckdb::StatementReturnType::CHANGED_ROWS) {
 		auto row_changes = wrapper->result->GetValue(0, 0);
 		if (!row_changes.IsNull() && row_changes.TryCastAs(LogicalType::BIGINT)) {
 			rows_changed = row_changes.GetValue<int64_t>();

--- a/src/main/capi/result-c.cpp
+++ b/src/main/capi/result-c.cpp
@@ -314,7 +314,8 @@ bool deprecated_materialize_result(duckdb_result *result) {
 		result->__deprecated_columns[i].__deprecated_name = (char *)result_data->result->names[i].c_str();
 	}
 	result->__deprecated_row_count = materialized.collection.Count();
-	if (result->__deprecated_row_count > 0 && StatementTypeReturnChanges(materialized.statement_type)) {
+	if (result->__deprecated_row_count > 0 &&
+	    materialized.properties.return_type == StatementReturnType::CHANGED_ROWS) {
 		// update total changes
 		auto row_changes = materialized.GetValue(0, 0);
 		if (!row_changes.IsNull() && row_changes.TryCastAs(LogicalType::BIGINT)) {

--- a/src/main/materialized_query_result.cpp
+++ b/src/main/materialized_query_result.cpp
@@ -3,13 +3,9 @@
 
 namespace duckdb {
 
-MaterializedQueryResult::MaterializedQueryResult(StatementType statement_type)
-    : QueryResult(QueryResultType::MATERIALIZED_RESULT, statement_type) {
-}
-
-MaterializedQueryResult::MaterializedQueryResult(StatementType statement_type, vector<LogicalType> types,
-                                                 vector<string> names)
-    : QueryResult(QueryResultType::MATERIALIZED_RESULT, statement_type, move(types), move(names)) {
+MaterializedQueryResult::MaterializedQueryResult(StatementType statement_type, StatementProperties properties,
+                                                 vector<LogicalType> types, vector<string> names)
+    : QueryResult(QueryResultType::MATERIALIZED_RESULT, statement_type, properties, move(types), move(names)) {
 }
 
 MaterializedQueryResult::MaterializedQueryResult(string error)

--- a/src/main/pending_query_result.cpp
+++ b/src/main/pending_query_result.cpp
@@ -6,7 +6,8 @@ namespace duckdb {
 
 PendingQueryResult::PendingQueryResult(shared_ptr<ClientContext> context_p, PreparedStatementData &statement,
                                        vector<LogicalType> types_p)
-    : BaseQueryResult(QueryResultType::PENDING_RESULT, statement.statement_type, move(types_p), statement.names),
+    : BaseQueryResult(QueryResultType::PENDING_RESULT, statement.statement_type, statement.properties, move(types_p),
+                      statement.names),
       context(move(context_p)) {
 }
 

--- a/src/main/prepared_statement.cpp
+++ b/src/main/prepared_statement.cpp
@@ -27,6 +27,11 @@ StatementType PreparedStatement::GetStatementType() {
 	return data->statement_type;
 }
 
+StatementProperties PreparedStatement::GetStatementProperties() {
+	D_ASSERT(data);
+	return data->properties;
+}
+
 const vector<LogicalType> &PreparedStatement::GetTypes() {
 	D_ASSERT(data);
 	return data->types;
@@ -42,7 +47,7 @@ unique_ptr<QueryResult> PreparedStatement::Execute(vector<Value> &values, bool a
 	if (!pending->success) {
 		return make_unique<MaterializedQueryResult>(pending->error);
 	}
-	return pending->Execute(allow_stream_result && data->allow_stream_result);
+	return pending->Execute(allow_stream_result && data->properties.allow_stream_result);
 }
 
 unique_ptr<PendingQueryResult> PreparedStatement::PendingQuery(vector<Value> &values) {

--- a/src/main/prepared_statement_data.cpp
+++ b/src/main/prepared_statement_data.cpp
@@ -4,9 +4,7 @@
 
 namespace duckdb {
 
-PreparedStatementData::PreparedStatementData(StatementType type)
-    : statement_type(type), read_only(true), requires_valid_transaction(true), allow_stream_result(false),
-      bound_all_parameters(true) {
+PreparedStatementData::PreparedStatementData(StatementType type) : statement_type(type) {
 }
 
 PreparedStatementData::~PreparedStatementData() {

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -6,13 +6,10 @@
 
 namespace duckdb {
 
-BaseQueryResult::BaseQueryResult(QueryResultType type, StatementType statement_type)
-    : type(type), statement_type(statement_type), success(true) {
-}
-
-BaseQueryResult::BaseQueryResult(QueryResultType type, StatementType statement_type, vector<LogicalType> types_p,
-                                 vector<string> names_p)
-    : type(type), statement_type(statement_type), types(move(types_p)), names(move(names_p)), success(true) {
+BaseQueryResult::BaseQueryResult(QueryResultType type, StatementType statement_type, StatementProperties properties,
+                                 vector<LogicalType> types_p, vector<string> names_p)
+    : type(type), statement_type(statement_type), properties(properties), types(move(types_p)), names(move(names_p)),
+      success(true) {
 	D_ASSERT(types.size() == names.size());
 }
 
@@ -32,12 +29,9 @@ idx_t BaseQueryResult::ColumnCount() {
 	return types.size();
 }
 
-QueryResult::QueryResult(QueryResultType type, StatementType statement_type) : BaseQueryResult(type, statement_type) {
-}
-
-QueryResult::QueryResult(QueryResultType type, StatementType statement_type, vector<LogicalType> types_p,
-                         vector<string> names_p)
-    : BaseQueryResult(type, statement_type, move(types_p), move(names_p)) {
+QueryResult::QueryResult(QueryResultType type, StatementType statement_type, StatementProperties properties,
+                         vector<LogicalType> types_p, vector<string> names_p)
+    : BaseQueryResult(type, statement_type, properties, move(types_p), move(names_p)) {
 }
 
 QueryResult::QueryResult(QueryResultType type, string error) : BaseQueryResult(type, move(error)) {

--- a/src/main/stream_query_result.cpp
+++ b/src/main/stream_query_result.cpp
@@ -5,9 +5,10 @@
 
 namespace duckdb {
 
-StreamQueryResult::StreamQueryResult(StatementType statement_type, shared_ptr<ClientContext> context,
-                                     vector<LogicalType> types, vector<string> names)
-    : QueryResult(QueryResultType::STREAM_RESULT, statement_type, move(types), move(names)), context(move(context)) {
+StreamQueryResult::StreamQueryResult(StatementType statement_type, StatementProperties properties,
+                                     shared_ptr<ClientContext> context, vector<LogicalType> types, vector<string> names)
+    : QueryResult(QueryResultType::STREAM_RESULT, statement_type, properties, move(types), move(names)),
+      context(move(context)) {
 }
 
 StreamQueryResult::~StreamQueryResult() {
@@ -57,7 +58,7 @@ unique_ptr<MaterializedQueryResult> StreamQueryResult::Materialize() {
 	if (!success) {
 		return make_unique<MaterializedQueryResult>(error);
 	}
-	auto result = make_unique<MaterializedQueryResult>(statement_type, types, names);
+	auto result = make_unique<MaterializedQueryResult>(statement_type, properties, types, names);
 	while (true) {
 		auto chunk = Fetch();
 		if (!chunk || chunk->size() == 0) {

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -22,8 +22,7 @@ shared_ptr<Binder> Binder::CreateBinder(ClientContext &context, Binder *parent, 
 }
 
 Binder::Binder(bool, ClientContext &context, shared_ptr<Binder> parent_p, bool inherit_ctes_p)
-    : context(context), read_only(true), requires_valid_transaction(true), allow_stream_result(false),
-      parent(move(parent_p)), bound_tables(0), inherit_ctes(inherit_ctes_p) {
+    : context(context), parent(move(parent_p)), bound_tables(0), inherit_ctes(inherit_ctes_p) {
 	parameters = nullptr;
 	parameter_types = nullptr;
 	if (parent) {
@@ -424,7 +423,8 @@ BoundStatement Binder::BindReturning(vector<unique_ptr<ParsedExpression>> return
 	projection->AddChild(move(child_operator));
 	D_ASSERT(result.types.size() == result.names.size());
 	result.plan = move(projection);
-	this->allow_stream_result = true;
+	properties.allow_stream_result = true;
+	properties.return_type = StatementReturnType::QUERY_RESULT;
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_call.cpp
+++ b/src/planner/binder/statement/bind_call.cpp
@@ -23,6 +23,7 @@ BoundStatement Binder::Bind(CallStatement &stmt) {
 	result.types = get.returned_types;
 	result.names = get.names;
 	result.plan = CreatePlan(*bound_func);
+	properties.return_type = StatementReturnType::QUERY_RESULT;
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -140,7 +140,8 @@ BoundStatement Binder::Bind(CopyStatement &stmt) {
 		}
 		stmt.select_statement = move(statement);
 	}
-	this->allow_stream_result = false;
+	properties.allow_stream_result = false;
+	properties.return_type = StatementReturnType::CHANGED_ROWS;
 	if (stmt.info->is_from) {
 		return BindCopyFrom(stmt);
 	} else {

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -208,7 +208,7 @@ unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableInfo(unique_ptr<CreateIn
 			}
 		}
 	}
-	this->allow_stream_result = false;
+	properties.allow_stream_result = false;
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -28,7 +28,7 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 
 	if (!table->temporary) {
 		// delete from persistent table: not read only!
-		this->read_only = false;
+		properties.read_only = false;
 	}
 
 	// plan any tables from the various using clauses
@@ -89,7 +89,8 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 		result.plan = move(del);
 		result.names = {"Count"};
 		result.types = {LogicalType::BIGINT};
-		this->allow_stream_result = false;
+		properties.allow_stream_result = false;
+		properties.return_type = StatementReturnType::CHANGED_ROWS;
 	}
 	return result;
 }

--- a/src/planner/binder/statement/bind_drop.cpp
+++ b/src/planner/binder/statement/bind_drop.cpp
@@ -14,11 +14,11 @@ BoundStatement Binder::Bind(DropStatement &stmt) {
 	case CatalogType::PREPARED_STATEMENT:
 		// dropping prepared statements is always possible
 		// it also does not require a valid transaction
-		this->requires_valid_transaction = false;
+		properties.requires_valid_transaction = false;
 		break;
 	case CatalogType::SCHEMA_ENTRY:
 		// dropping a schema is never read-only because there are no temporary schemas
-		this->read_only = false;
+		properties.read_only = false;
 		break;
 	case CatalogType::VIEW_ENTRY:
 	case CatalogType::SEQUENCE_ENTRY:
@@ -34,7 +34,7 @@ BoundStatement Binder::Bind(DropStatement &stmt) {
 		}
 		if (!entry->temporary) {
 			// we can only drop temporary tables in read-only mode
-			this->read_only = false;
+			properties.read_only = false;
 		}
 		stmt.info->schema = entry->schema->name;
 		break;
@@ -45,7 +45,8 @@ BoundStatement Binder::Bind(DropStatement &stmt) {
 	result.plan = make_unique<LogicalSimple>(LogicalOperatorType::LOGICAL_DROP, move(stmt.info));
 	result.names = {"Success"};
 	result.types = {LogicalType::BOOLEAN};
-	this->allow_stream_result = false;
+	properties.allow_stream_result = false;
+	properties.return_type = StatementReturnType::NOTHING;
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_explain.cpp
+++ b/src/planner/binder/statement/bind_explain.cpp
@@ -17,6 +17,7 @@ BoundStatement Binder::Bind(ExplainStatement &stmt) {
 	result.plan = move(explain);
 	result.names = {"explain_key", "explain_value"};
 	result.types = {LogicalType::VARCHAR, LogicalType::VARCHAR};
+	properties.return_type = StatementReturnType::QUERY_RESULT;
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_export.cpp
+++ b/src/planner/binder/statement/bind_export.cpp
@@ -197,7 +197,8 @@ BoundStatement Binder::Bind(ExportStatement &stmt) {
 	}
 
 	result.plan = move(export_node);
-	this->allow_stream_result = false;
+	properties.allow_stream_result = false;
+	properties.return_type = StatementReturnType::NOTHING;
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -34,7 +34,7 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 	D_ASSERT(table);
 	if (!table->temporary) {
 		// inserting into a non-temporary table: alters underlying database
-		this->read_only = false;
+		properties.read_only = false;
 	}
 
 	auto insert = make_unique<LogicalInsert>(table);
@@ -140,7 +140,8 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 	} else {
 		D_ASSERT(result.types.size() == result.names.size());
 		result.plan = move(insert);
-		this->allow_stream_result = false;
+		properties.allow_stream_result = false;
+		properties.return_type = StatementReturnType::CHANGED_ROWS;
 		return result;
 	}
 }

--- a/src/planner/binder/statement/bind_load.cpp
+++ b/src/planner/binder/statement/bind_load.cpp
@@ -11,7 +11,8 @@ BoundStatement Binder::Bind(LoadStatement &stmt) {
 	result.names = {"Success"};
 
 	result.plan = make_unique<LogicalSimple>(LogicalOperatorType::LOGICAL_LOAD, move(stmt.info));
-	this->allow_stream_result = false;
+	properties.allow_stream_result = false;
+	properties.return_type = StatementReturnType::NOTHING;
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_pragma.cpp
+++ b/src/planner/binder/statement/bind_pragma.cpp
@@ -29,6 +29,7 @@ BoundStatement Binder::Bind(PragmaStatement &stmt) {
 	result.names = {"Success"};
 	result.types = {LogicalType::BOOLEAN};
 	result.plan = make_unique<LogicalPragma>(bound_function, *stmt.info);
+	properties.return_type = StatementReturnType::QUERY_RESULT;
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_select.cpp
+++ b/src/planner/binder/statement/bind_select.cpp
@@ -5,7 +5,8 @@
 namespace duckdb {
 
 BoundStatement Binder::Bind(SelectStatement &stmt) {
-	this->allow_stream_result = true;
+	properties.allow_stream_result = true;
+	properties.return_type = StatementReturnType::QUERY_RESULT;
 	return Bind(*stmt.node);
 }
 

--- a/src/planner/binder/statement/bind_set.cpp
+++ b/src/planner/binder/statement/bind_set.cpp
@@ -11,6 +11,7 @@ BoundStatement Binder::Bind(SetStatement &stmt) {
 	result.names = {"Success"};
 
 	result.plan = make_unique<LogicalSet>(stmt.name, stmt.value, stmt.scope);
+	properties.return_type = StatementReturnType::NOTHING;
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_show.cpp
+++ b/src/planner/binder/statement/bind_show.cpp
@@ -23,6 +23,7 @@ BoundStatement Binder::Bind(ShowStatement &stmt) {
 	result.names = {"column_name", "column_type", "null", "key", "default", "extra"};
 	result.types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
 	                LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+	properties.return_type = StatementReturnType::QUERY_RESULT;
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_simple.cpp
+++ b/src/planner/binder/statement/bind_simple.cpp
@@ -19,20 +19,22 @@ BoundStatement Binder::Bind(AlterStatement &stmt) {
 	auto entry = catalog.GetEntry(context, stmt.info->GetCatalogType(), stmt.info->schema, stmt.info->name, true);
 	if (entry && !entry->temporary) {
 		// we can only alter temporary tables/views in read-only mode
-		this->read_only = false;
+		properties.read_only = false;
 	}
 	result.plan = make_unique<LogicalSimple>(LogicalOperatorType::LOGICAL_ALTER, move(stmt.info));
+	properties.return_type = StatementReturnType::NOTHING;
 	return result;
 }
 
 BoundStatement Binder::Bind(TransactionStatement &stmt) {
 	// transaction statements do not require a valid transaction
-	this->requires_valid_transaction = false;
+	properties.requires_valid_transaction = false;
 
 	BoundStatement result;
 	result.names = {"Success"};
 	result.types = {LogicalType::BOOLEAN};
 	result.plan = make_unique<LogicalSimple>(LogicalOperatorType::LOGICAL_TRANSACTION, move(stmt.info));
+	properties.return_type = StatementReturnType::NOTHING;
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_summarize.cpp
+++ b/src/planner/binder/statement/bind_summarize.cpp
@@ -128,6 +128,7 @@ BoundStatement Binder::BindSummarize(ShowStatement &stmt) {
 	select_node->select_list.push_back(SummarizeWrapUnnest(null_percentage_children, "null_percentage"));
 	select_node->from_table = move(subquery_ref);
 
+	properties.return_type = StatementReturnType::QUERY_RESULT;
 	return Bind(*select_node);
 }
 

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -144,7 +144,7 @@ BoundStatement Binder::Bind(UpdateStatement &stmt) {
 
 	if (!table->temporary) {
 		// update of persistent table: not read only!
-		this->read_only = false;
+		properties.read_only = false;
 	}
 	auto update = make_unique<LogicalUpdate>(table);
 
@@ -225,7 +225,8 @@ BoundStatement Binder::Bind(UpdateStatement &stmt) {
 		result.names = {"Count"};
 		result.types = {LogicalType::BIGINT};
 		result.plan = move(update);
-		this->allow_stream_result = false;
+		properties.allow_stream_result = false;
+		properties.return_type = StatementReturnType::CHANGED_ROWS;
 	}
 	return result;
 }

--- a/src/planner/binder/statement/bind_vacuum.cpp
+++ b/src/planner/binder/statement/bind_vacuum.cpp
@@ -9,6 +9,7 @@ BoundStatement Binder::Bind(VacuumStatement &stmt) {
 	result.names = {"Success"};
 	result.types = {LogicalType::BOOLEAN};
 	result.plan = make_unique<LogicalSimple>(LogicalOperatorType::LOGICAL_VACUUM, move(stmt.info));
+	properties.return_type = StatementReturnType::NOTHING;
 	return result;
 }
 

--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -195,17 +195,13 @@ show table1;
 # test display of call
 test('''
 CALL range(4);
-''', out='4')
+''', out='3')
 
 # test display of prepare/execute
 test('''
-PREPARE v1 AS SELECT 42
-CALL range(4);
-''', out='4')
-
-
-
-
+PREPARE v1 AS SELECT ?::INT;
+EXECUTE v1(42);
+''', out='42')
 
 
 # this should be fixed

--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -173,6 +173,40 @@ SELECT x::INT FROM (SELECT x::VARCHAR x FROM range(10) tbl(x) UNION ALL SELECT '
 test('explain select sum(i) from range(1000) tbl(i)', out='RANGE')
 test('explain analyze select sum(i) from range(1000) tbl(i)', out='RANGE')
 
+# test returning insert
+test('''
+CREATE TABLE table1 (a INTEGER DEFAULT -1, b INTEGER DEFAULT -2, c INTEGER DEFAULT -3);
+INSERT INTO table1 VALUES (1, 2, 3) RETURNING *;
+SELECT COUNT(*) FROM table1;
+''', out='1')
+
+# test display of pragmas
+test('''
+CREATE TABLE table1 (mylittlecolumn INTEGER);
+pragma table_info('table1');
+''', out='mylittlecolumn')
+
+# test display of show
+test('''
+CREATE TABLE table1 (mylittlecolumn INTEGER);
+show table1;
+''', out='mylittlecolumn')
+
+# test display of call
+test('''
+CALL range(4);
+''', out='4')
+
+# test display of prepare/execute
+test('''
+PREPARE v1 AS SELECT 42
+CALL range(4);
+''', out='4')
+
+
+
+
+
 
 # this should be fixed
 test('.selftest', err='sqlite3_table_column_metadata')


### PR DESCRIPTION
Fixes #3548 

Previously, we would use only the statement type to determine if a statement returned (a) a query result, (b) the number of rows changed, or (c) nothing. Certain clients handled different return types in different manners, e.g. in the shell we would only print out query results, and would avoid printing out anything in case the number of rows changed or nothing was returned.

However, with the introduction of the `RETURNING` statement, the statement type itself is not sufficient anymore to determine what a statement returns. Instead, we need to propagate this information from the binder to the query result/prepared statement so that the client can correctly see what a statement returns.

In this PR we do so by introducing a `StatementProperties` struct that holds this information. The flags are set in the binder, and the information is propagated to the prepared statements/query results which allows the clients (shell and C APIs) to handle the statements correctly.