### PR TITLE
Struct Types for Node.js UDFs

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -10,6 +10,10 @@ if(BUILD_REST)
   add_subdirectory(rest)
 endif()
 
+if(BUILD_NODE)
+  add_subdirectory(nodejs)
+endif()
+
 if(BUILD_ODBC_DRIVER)
   add_subdirectory(odbc)
 endif()

--- a/tools/nodejs/CMakeLists.txt
+++ b/tools/nodejs/CMakeLists.txt
@@ -1,27 +1,35 @@
 # ----------------------------------------------------
 # Find Node headers
 
-find_path (NODE_ROOT_DIR
-    NAMES node.h src/node.h
-    PATH_SUFFIXES node node4 node5 node6 node7 node8 nodejs
-    PATHS /usr/include /usr/local/include)
+find_path(
+  NODE_ROOT_DIR
+  NAMES node.h src/node.h
+  PATH_SUFFIXES
+    node
+    node4
+    node5
+    node6
+    node7
+    node8
+    nodejs
+  PATHS /usr/include /usr/local/include)
 
-if (NODE_ROOT_DIR)
-    macro(add_node_include_dir DIR)
-        if (IS_DIRECTORY ${DIR} AND NOT ${DIR} STREQUAL "/usr/include")
-            set(NODE_INCLUDE_DIRS ${NODE_INCLUDE_DIRS} ${DIR})
-        endif()
-    endmacro()
-    add_node_include_dir(${NODE_ROOT_DIR})
-    add_node_include_dir(${NODE_ROOT_DIR}/deps/uv/include)
-    add_node_include_dir(${NODE_ROOT_DIR}/deps/v8/include)
-    add_node_include_dir(${NODE_ROOT_DIR}/include/deps/v8/include)
-    add_node_include_dir(${NODE_ROOT_DIR}/include/node)
-    add_node_include_dir(${NODE_ROOT_DIR}/include/src)
-    add_node_include_dir(${NODE_ROOT_DIR}/src)
+if(NODE_ROOT_DIR)
+  macro(add_node_include_dir DIR)
+    if(IS_DIRECTORY ${DIR} AND NOT ${DIR} STREQUAL "/usr/include")
+      set(NODE_INCLUDE_DIRS ${NODE_INCLUDE_DIRS} ${DIR})
+    endif()
+  endmacro()
+  add_node_include_dir(${NODE_ROOT_DIR})
+  add_node_include_dir(${NODE_ROOT_DIR}/deps/uv/include)
+  add_node_include_dir(${NODE_ROOT_DIR}/deps/v8/include)
+  add_node_include_dir(${NODE_ROOT_DIR}/include/deps/v8/include)
+  add_node_include_dir(${NODE_ROOT_DIR}/include/node)
+  add_node_include_dir(${NODE_ROOT_DIR}/include/src)
+  add_node_include_dir(${NODE_ROOT_DIR}/src)
 else()
-    unset(NODE_INCLUDE_DIRS)
-    message(ERROR "Failed to find node headers")
+  unset(NODE_INCLUDE_DIRS)
+  message(ERROR "Failed to find node headers")
 endif()
 
 # ----------------------------------------------------
@@ -36,7 +44,7 @@ include_directories(./node_modules/node-addon-api/)
 # Build library
 
 set(CMAKE_SHARED_LINKER_FLAGS "-bundle" "-undefined dynamic_lookup")
-add_library(node_duckdb src/duckdb_node.cpp src/database.cpp src/data_chunk.cpp src/connection.cpp
-                        src/statement.cpp src/utils.cpp)
+add_library(node_duckdb src/duckdb_node.cpp src/database.cpp src/data_chunk.cpp
+                        src/connection.cpp src/statement.cpp src/utils.cpp)
 target_link_libraries(node_duckdb duckdb_static)
 link_threads(node_duckdb)

--- a/tools/nodejs/CMakeLists.txt
+++ b/tools/nodejs/CMakeLists.txt
@@ -1,6 +1,38 @@
+# ----------------------------------------------------
+# Find Node headers
+
+find_path (NODE_ROOT_DIR
+    NAMES node.h src/node.h
+    PATH_SUFFIXES node node4 node5 node6 node7 node8 nodejs
+    PATHS /usr/include /usr/local/include)
+
+if (NODE_ROOT_DIR)
+    macro(add_node_include_dir DIR)
+        if (IS_DIRECTORY ${DIR} AND NOT ${DIR} STREQUAL "/usr/include")
+            set(NODE_INCLUDE_DIRS ${NODEJS_INCLUDE_DIRS} ${DIR})
+        endif()
+    endmacro()
+    add_node_include_dir(${NODE_ROOT_DIR})
+    add_node_include_dir(${NODE_ROOT_DIR}/deps/uv/include)
+    add_node_include_dir(${NODE_ROOT_DIR}/deps/v8/include)
+    add_node_include_dir(${NODE_ROOT_DIR}/include/deps/v8/include)
+    add_node_include_dir(${NODE_ROOT_DIR}/include/node)
+    add_node_include_dir(${NODE_ROOT_DIR}/include/src)
+    add_node_include_dir(${NODE_ROOT_DIR}/src)
+else()
+    unset(NODE_INCLUDE_DIRS)
+    message(ERROR " couldn't find node headers")
+endif()
+
+# ----------------------------------------------------
+# Include headers
+
 include_directories(src)
-include_directories(/opt/homebrew/lib/node_modules/node-addon-api)
-include_directories(/opt/homebrew/Cellar/node/17.4.0/include/node)
+include_directories(${NODE_INCLUDE_DIRS})
+include_directories(./node_modules/node-addon-api/)
+
+# ----------------------------------------------------
+# Build library
 
 set(CMAKE_SHARED_LINKER_FLAGS "-bundle" "-undefined dynamic_lookup")
 add_library(node_duckdb src/duckdb_node.cpp src/database.cpp src/connection.cpp

--- a/tools/nodejs/CMakeLists.txt
+++ b/tools/nodejs/CMakeLists.txt
@@ -14,6 +14,11 @@ find_path(
     nodejs
   PATHS /usr/include /usr/local/include)
 
+find_path(
+  NAPI_INCLUDE_DIR
+  NAMES napi.h
+  PATHS ${CMAKE_CURRENT_SOURCE_DIR}/node_modules/node-addon-api)
+
 if(NODE_ROOT_DIR)
   macro(add_node_include_dir DIR)
     if(IS_DIRECTORY ${DIR} AND NOT ${DIR} STREQUAL "/usr/include")
@@ -27,6 +32,7 @@ if(NODE_ROOT_DIR)
   add_node_include_dir(${NODE_ROOT_DIR}/include/node)
   add_node_include_dir(${NODE_ROOT_DIR}/include/src)
   add_node_include_dir(${NODE_ROOT_DIR}/src)
+  add_node_include_dir(${NAPI_INCLUDE_DIR})
 else()
   unset(NODE_INCLUDE_DIRS)
   message(ERROR "Failed to find node headers")
@@ -38,7 +44,6 @@ endif()
 message(STATUS "NODE_INCLUDE_DIRS=${NODE_INCLUDE_DIRS}")
 include_directories(src)
 include_directories(${NODE_INCLUDE_DIRS})
-include_directories(./node_modules/node-addon-api/)
 
 # ----------------------------------------------------
 # Build library

--- a/tools/nodejs/CMakeLists.txt
+++ b/tools/nodejs/CMakeLists.txt
@@ -14,11 +14,6 @@ find_path(
     nodejs
   PATHS /usr/include /usr/local/include)
 
-find_path(
-  NAPI_INCLUDE_DIR
-  NAMES napi.h
-  PATHS ${CMAKE_CURRENT_SOURCE_DIR}/node_modules/node-addon-api)
-
 if(NODE_ROOT_DIR)
   macro(add_node_include_dir DIR)
     if(IS_DIRECTORY ${DIR} AND NOT ${DIR} STREQUAL "/usr/include")
@@ -32,11 +27,25 @@ if(NODE_ROOT_DIR)
   add_node_include_dir(${NODE_ROOT_DIR}/include/node)
   add_node_include_dir(${NODE_ROOT_DIR}/include/src)
   add_node_include_dir(${NODE_ROOT_DIR}/src)
-  add_node_include_dir(${NAPI_INCLUDE_DIR})
 else()
   unset(NODE_INCLUDE_DIRS)
   message(ERROR "Failed to find node headers")
 endif()
+
+find_path(
+  NAPI_INCLUDE_DIR
+  NAMES napi.h
+  PATHS ${CMAKE_CURRENT_SOURCE_DIR}/node_modules/node-addon-api)
+
+if(NAPI_INCLUDE_DIR)
+  add_node_include_dir(${NAPI_INCLUDE_DIR})
+else()
+  unset(NAPI_INCLUDE_DIR)
+  message(ERROR "Failed to find node api headers")
+endif()
+
+add_library(napi INTERFACE)
+target_include_directories(napi INTERFACE ${NODE_INCLUDE_DIRS})
 
 # ----------------------------------------------------
 # Include headers
@@ -51,5 +60,5 @@ include_directories(${NODE_INCLUDE_DIRS})
 set(CMAKE_SHARED_LINKER_FLAGS "-bundle" "-undefined dynamic_lookup")
 add_library(node_duckdb src/duckdb_node.cpp src/database.cpp src/data_chunk.cpp
                         src/connection.cpp src/statement.cpp src/utils.cpp)
-target_link_libraries(node_duckdb duckdb_static)
+target_link_libraries(node_duckdb duckdb_static napi)
 link_threads(node_duckdb)

--- a/tools/nodejs/CMakeLists.txt
+++ b/tools/nodejs/CMakeLists.txt
@@ -9,7 +9,7 @@ find_path (NODE_ROOT_DIR
 if (NODE_ROOT_DIR)
     macro(add_node_include_dir DIR)
         if (IS_DIRECTORY ${DIR} AND NOT ${DIR} STREQUAL "/usr/include")
-            set(NODE_INCLUDE_DIRS ${NODEJS_INCLUDE_DIRS} ${DIR})
+            set(NODE_INCLUDE_DIRS ${NODE_INCLUDE_DIRS} ${DIR})
         endif()
     endmacro()
     add_node_include_dir(${NODE_ROOT_DIR})
@@ -21,12 +21,13 @@ if (NODE_ROOT_DIR)
     add_node_include_dir(${NODE_ROOT_DIR}/src)
 else()
     unset(NODE_INCLUDE_DIRS)
-    message(ERROR " couldn't find node headers")
+    message(ERROR "Failed to find node headers")
 endif()
 
 # ----------------------------------------------------
 # Include headers
 
+message(STATUS "NODE_INCLUDE_DIRS=${NODE_INCLUDE_DIRS}")
 include_directories(src)
 include_directories(${NODE_INCLUDE_DIRS})
 include_directories(./node_modules/node-addon-api/)
@@ -35,7 +36,7 @@ include_directories(./node_modules/node-addon-api/)
 # Build library
 
 set(CMAKE_SHARED_LINKER_FLAGS "-bundle" "-undefined dynamic_lookup")
-add_library(node_duckdb src/duckdb_node.cpp src/database.cpp src/connection.cpp
+add_library(node_duckdb src/duckdb_node.cpp src/database.cpp src/data_chunk.cpp src/connection.cpp
                         src/statement.cpp src/utils.cpp)
 target_link_libraries(node_duckdb duckdb_static)
 link_threads(node_duckdb)

--- a/tools/nodejs/Makefile
+++ b/tools/nodejs/Makefile
@@ -7,10 +7,10 @@ src/duckdb.cpp:
 	npm install --build-from-source
 
 build: ./node_modules src/duckdb.cpp
-	./node_modules/.bin/node-pre-gyp build --loglevel=silent
+	./node_modules/.bin/node-pre-gyp build -j max --loglevel=silent
 
 debug: ./node_modules src/duckdb.cpp
-	./node_modules/.bin/node-pre-gyp build --debug --verbose
+	./node_modules/.bin/node-pre-gyp build -j max --debug --verbose
 
 clean:
 	@rm -rf ./build

--- a/tools/nodejs/binding.gyp
+++ b/tools/nodejs/binding.gyp
@@ -5,6 +5,7 @@
             "sources": [
                 "src/duckdb_node.cpp",
                 "src/database.cpp",
+                "src/data_chunk.cpp",
                 "src/connection.cpp",
                 "src/statement.cpp",
                 "src/utils.cpp",

--- a/tools/nodejs/binding.gyp
+++ b/tools/nodejs/binding.gyp
@@ -20,18 +20,20 @@
             ],
             "cflags_cc": [
                 "-frtti",
-                "-fexceptions"
+                "-fexceptions",
+                "-Wno-redundant-move",
             ],
             "cflags_cc!": [
-                "-fno-rrti"
+                "-fno-rrti",
                 "-fno-exceptions",
             ],
             "cflags": [
                 "-frtti",
-                "-fexceptions"
+                "-fexceptions",
+                "-Wno-redundant-move",
             ],
             "cflags!": [
-                "-fno-rrti"
+                "-fno-rrti",
                 "-fno-exceptions",
             ],
             "xcode_settings": {
@@ -40,7 +42,7 @@
                 "CLANG_CXX_LIBRARY": "libc++",
                 "MACOSX_DEPLOYMENT_TARGET": "10.15",
                 'CLANG_CXX_LANGUAGE_STANDARD':'c++11',
-                'OTHER_CFLAGS' : ['-fexceptions', '-frtti']
+                'OTHER_CFLAGS' : ['-fexceptions', '-frtti', '-Wno-redundant-move']
 
             },
             "msvs_settings": {

--- a/tools/nodejs/lib/duckdb.js
+++ b/tools/nodejs/lib/duckdb.js
@@ -23,83 +23,117 @@ Connection.prototype.each = function(sql) {
     return statement.each.apply(statement, arguments);
 }
 
-function ptr_to_arr(buffer, ptype, n) {
-    // TODO can we create those on the C++ side of things already?
-    switch(ptype) {
-        case 'BOOL':
+function getTypeSize(ptype) {
+    switch (ptype) {
         case 'UINT8':
-            return new Uint8Array(buffer.buffer, 0, n);
         case 'INT8':
-            return new Int8Array(buffer.buffer, 0, n);
-        case 'INT16':
-            return new Int16Array(buffer.buffer, 0, n);
-        case 'UINT16':
-            return new UInt16Array(buffer.buffer, 0, n);
+            return 1;
         case 'INT32':
-            return new Int32Array(buffer.buffer, 0, n);
-        case 'UINT32':
-            return new UInt32Array(buffer.buffer, 0, n);
         case 'FLOAT':
-            return new Float32Array(buffer.buffer, 0, n);
+            return 4;
+        case 'INT64':
+        case 'UINT64':
         case 'DOUBLE':
-            return new Float64Array(buffer.buffer, 0, n);
-        case 'VARCHAR':  // we already have created a string array on the C++ side for this
-            return buffer;
+        case 'VARCHAR':
+            return 8;
         default:
-            return new Array<string>(0); // cough
+            return 0;
     }
 }
 
 // this follows the wasm udfs somewhat but is simpler because we can pass data much more cleanly
 Connection.prototype.register = function(name, return_type, fun) {
     // TODO what if this throws an error somewhere? do we need a try/catch?
-    return this.register_bulk(name, return_type, function(descr) {
+    return this.register_bulk(name, return_type, function(desc) {
         try {
-            const data_arr = [];
-            const validity_arr = [];
+            // Build an argument resolver
+            const buildResolver = (arg) => {
+                let validity = null;
+                if (arg.validityBuffer !== undefined) {
+                    validity = ptrToUint8Array(mod, ptrs[arg.validityBuffer], desc.rows);
+                }
+                switch (arg.physicalType) {
+                    case 'STRUCT<?>': {
+                        const tmp = {};
+                        const children = [];
+                        for (let j = 0; j < (arg.children?.length || 0); ++j) {
+                            const attr = arg.children[j];
+                            const child = buildResolver(attr);
+                            children.push((row) => {
+                                tmp[attr.name] = child(row);
+                            });
+                        }
+                        if (validity != null) {
+                            return (row) => {
+                                if (!validity[row]) {
+                                    return null;
+                                }
+                                for (const resolver of children) {
+                                    resolver(row);
+                                }
+                                return tmp;
+                            };
+                        } else {
+                            return (row) => {
+                                for (const resolver of children) {
+                                    resolver(row);
+                                }
+                                return tmp;
+                            };
+                        }
+                    }
+                    default: {
+                        if (arg.data === undefined) {
+                            throw new Error(
+                                'malformed data view, expected data buffer for argument of type: ' + arg.physicalType,
+                            );
+                        }
+                        const data = arg.data;
+                        if (validity != null) {
+                            return (row) => (!validity[row] ? null : data[row]);
+                        } else {
+                            return (row) => data[row];
+                        }
+                    }
+                }
+            };
 
-            for (const idx in descr.args) {
-                const arg = descr.args[idx];
-                validity_arr.push(arg.data_buffers[arg.validity_buffer]);
-                data_arr.push(ptr_to_arr(arg.data_buffers[arg.data_buffer], arg.physical_type, descr.rows));
+            // Translate argument data
+            const argResolvers = [];
+            for (let i = 0; i < desc.args.length; ++i) {
+                argResolvers.push(buildResolver(desc.args[i]));
+            }
+            const args = [];
+            for (let i = 0; i < desc.args.length; ++i) {
+                args.push(null);
             }
 
-            const out_data = ptr_to_arr(descr.ret.data_buffers[descr.ret.data_buffer], descr.ret.physical_type, descr.rows);
-            const out_validity = descr.ret.data_buffers[descr.ret.validity_buffer];
+            // Return type
+            desc.ret.validity = new Uint8Array(desc.rows);
+            switch (desc.ret.physicalType) {
+                case 'INT32':
+                case 'INTEGER':
+                    desc.ret.data = new Uint32Array(desc.rows);
+                    break;
+                case 'DOUBLE':
+                    desc.ret.data = new Float64Array(desc.rows);
+                    break;
+                case 'VARCHAR':
+                    desc.ret.data = new Array(desc.rows);
+                    break;
+            }
 
-            switch (descr.args.length) {
-                case 0:
-                    for (let i = 0; i < descr.rows; ++i) {
-                        const res = fun();
-                        out_data[i] = res;
-                        out_validity[i] = res == undefined || res == null ? 0 : 1;
-                    }
-                    break;
-                case 1:
-                    for (let i = 0; i < descr.rows; ++i) {
-                        const res = fun(validity_arr[0][i] ? data_arr[0][i] : undefined);
-                        out_data[i] = res;
-                        out_validity[i] = res == undefined || res == null ? 0 : 1;
-                    }
-                    break;
-                case 2:
-                    for (let i = 0; i < descr.rows; ++i) {
-                        const res = fun(validity_arr[0][i] ? data_arr[0][i] : undefined, validity_arr[1][i] ? data_arr[1][i] : undefined);
-                        out_data[i] = res;
-                        out_validity[i] = res == undefined || res == null ? 0 : 1;
-                    }
-                    break;
-                case 3:
-                    for (let i = 0; i < descr.rows; ++i) {
-                        const res = fun(validity_arr[0][i] ? data_arr[0][i] : undefined, validity_arr[1][i] ? data_arr[1][i] : undefined, validity_arr[2][i] ? data_arr[2][i] : undefined);
-                        out_data[i] = res;
-                        out_validity[i] = res == undefined || res == null ? 0 : 1;
-                    }
-                    break;
-                default:
-                    throw "Unsupported argument count";
+            // Call the function
+            for (let i = 0; i < desc.rows; ++i) {
+                for (let j = 0; j < desc.args.length; ++j) {
+                    args[j] = argResolvers[j](i);
+                }
+                const res = fun(...args);
+                desc.ret.data[i] = res;
+                desc.ret.validity[i] = res === undefined || res === null ? 0 : 1;
             }
         } catch(error) { // work around recently fixed napi bug https://github.com/nodejs/node-addon-api/issues/912
+            console.log(desc.ret);
             msg = error;
             if (typeof error == 'object' && 'message' in error) {
                 msg = error.message

--- a/tools/nodejs/lib/duckdb.js
+++ b/tools/nodejs/lib/duckdb.js
@@ -48,10 +48,7 @@ Connection.prototype.register = function(name, return_type, fun) {
         try {
             // Build an argument resolver
             const buildResolver = (arg) => {
-                let validity = null;
-                if (arg.validityBuffer !== undefined) {
-                    validity = ptrToUint8Array(mod, ptrs[arg.validityBuffer], desc.rows);
-                }
+                let validity = arg.validity || null;
                 switch (arg.physicalType) {
                     case 'STRUCT<?>': {
                         const tmp = {};

--- a/tools/nodejs/lib/duckdb.js
+++ b/tools/nodejs/lib/duckdb.js
@@ -90,13 +90,28 @@ Connection.prototype.register = function(name, return_type, fun) {
             // Return type
             desc.ret.validity = new Uint8Array(desc.rows);
             switch (desc.ret.physicalType) {
+                case 'INT8':
+                    desc.ret.data = new Int8Array(desc.rows);
+                    break;
+                case 'INT16':
+                    desc.ret.data = new Int16Array(desc.rows);
+                    break;
                 case 'INT32':
-                case 'INTEGER':
-                    desc.ret.data = new Uint32Array(desc.rows);
+                    desc.ret.data = new Int32Array(desc.rows);
                     break;
                 case 'DOUBLE':
                     desc.ret.data = new Float64Array(desc.rows);
                     break;
+                case 'DATE64':
+                case 'TIME64':
+                case 'TIMESTAMP':
+                case 'INT64':
+                    desc.ret.data = new BigInt64Array(desc.rows);
+                    break;
+                case 'UINT64':
+                    desc.ret.data = new BigUint64Array(desc.rows);
+                    break;
+                case 'BLOB':
                 case 'VARCHAR':
                     desc.ret.data = new Array(desc.rows);
                     break;

--- a/tools/nodejs/lib/duckdb.js
+++ b/tools/nodejs/lib/duckdb.js
@@ -53,7 +53,7 @@ Connection.prototype.register = function(name, return_type, fun) {
                     case 'STRUCT<?>': {
                         const tmp = {};
                         const children = [];
-                        for (let j = 0; j < (arg.children?.length || 0); ++j) {
+                        for (let j = 0; j < (arg.children.length || 0); ++j) {
                             const attr = arg.children[j];
                             const child = buildResolver(attr);
                             children.push((row) => {

--- a/tools/nodejs/lib/duckdb.js
+++ b/tools/nodejs/lib/duckdb.js
@@ -23,24 +23,6 @@ Connection.prototype.each = function(sql) {
     return statement.each.apply(statement, arguments);
 }
 
-function getTypeSize(ptype) {
-    switch (ptype) {
-        case 'UINT8':
-        case 'INT8':
-            return 1;
-        case 'INT32':
-        case 'FLOAT':
-            return 4;
-        case 'INT64':
-        case 'UINT64':
-        case 'DOUBLE':
-        case 'VARCHAR':
-            return 8;
-        default:
-            return 0;
-    }
-}
-
 // this follows the wasm udfs somewhat but is simpler because we can pass data much more cleanly
 Connection.prototype.register = function(name, return_type, fun) {
     // TODO what if this throws an error somewhere? do we need a try/catch?
@@ -50,7 +32,7 @@ Connection.prototype.register = function(name, return_type, fun) {
             const buildResolver = (arg) => {
                 let validity = arg.validity || null;
                 switch (arg.physicalType) {
-                    case 'STRUCT<?>': {
+                    case 'STRUCT': {
                         const tmp = {};
                         const children = [];
                         for (let j = 0; j < (arg.children.length || 0); ++j) {

--- a/tools/nodejs/src/connection.cpp
+++ b/tools/nodejs/src/connection.cpp
@@ -1,4 +1,6 @@
+#include "duckdb.hpp"
 #include "duckdb_node.hpp"
+#include "napi.h"
 
 #include <thread>
 

--- a/tools/nodejs/src/connection.cpp
+++ b/tools/nodejs/src/connection.cpp
@@ -94,7 +94,7 @@ void DuckDBNodeUDFLauncher(Napi::Env env, Napi::Function jsudf, std::nullptr_t *
 		ret.Set("sqlType", jsargs->result->GetType().ToString());
 		auto ret_type = jsargs->result->GetType().InternalType();
 #if NAPI_VERSION <= 5
-        if (ret_type == duckdb::PhysicalType::INT64 || ret_type == duckdb::PhysicalType::UINT64) {
+		if (ret_type == duckdb::PhysicalType::INT64 || ret_type == duckdb::PhysicalType::UINT64) {
 			ret_type = duckdb::PhysicalType::DOUBLE;
 		}
 #endif

--- a/tools/nodejs/src/data_chunk.cpp
+++ b/tools/nodejs/src/data_chunk.cpp
@@ -1,4 +1,3 @@
-
 #include "duckdb.hpp"
 #include "duckdb_node.hpp"
 #include "napi.h"
@@ -64,6 +63,28 @@ Napi::Array EncodeDataChunk(Napi::Env env, duckdb::DataChunk &chunk, bool with_t
 
 			// Create data buffer
 			switch (vec_type.id()) {
+			case duckdb::LogicalTypeId::TINYINT: {
+				if (with_data) {
+					auto array = Napi::Int8Array::New(env, chunk.size());
+					auto data = duckdb::FlatVector::GetData<int8_t>(*vec);
+					for (size_t i = 0; i < chunk.size(); ++i) {
+						array[i] = data[i];
+					}
+					desc.Set("data", array);
+				}
+				break;
+			}
+			case duckdb::LogicalTypeId::SMALLINT: {
+				if (with_data) {
+					auto array = Napi::Int16Array::New(env, chunk.size());
+					auto data = duckdb::FlatVector::GetData<int16_t>(*vec);
+					for (size_t i = 0; i < chunk.size(); ++i) {
+						array[i] = data[i];
+					}
+					desc.Set("data", array);
+				}
+				break;
+			}
 			case duckdb::LogicalTypeId::INTEGER: {
 				if (with_data) {
 					auto array = Napi::Int32Array::New(env, chunk.size());
@@ -79,6 +100,44 @@ Napi::Array EncodeDataChunk(Napi::Env env, duckdb::DataChunk &chunk, bool with_t
 				if (with_data) {
 					auto array = Napi::Float64Array::New(env, chunk.size());
 					auto data = duckdb::FlatVector::GetData<double>(*vec);
+					for (size_t i = 0; i < chunk.size(); ++i) {
+						array[i] = data[i];
+					}
+					desc.Set("data", array);
+				}
+				break;
+			}
+			case duckdb::LogicalTypeId::BIGINT:
+			case duckdb::LogicalTypeId::TIME:
+			case duckdb::LogicalTypeId::TIME_TZ:
+			case duckdb::LogicalTypeId::TIMESTAMP_MS:
+			case duckdb::LogicalTypeId::TIMESTAMP_NS:
+			case duckdb::LogicalTypeId::TIMESTAMP_SEC:
+			case duckdb::LogicalTypeId::TIMESTAMP: {
+				if (with_data) {
+#if NAPI_VERSION > 5
+					auto array = Napi::BigInt64Array::New(env, chunk.size());
+					auto data = duckdb::FlatVector::GetData<int64_t>(*vec);
+#else
+					auto array = Napi::Float64Array::New(env, chunk.size());
+					auto data = duckdb::FlatVector::GetData<int64_t>(*vec);
+#endif
+					for (size_t i = 0; i < chunk.size(); ++i) {
+						array[i] = data[i];
+					}
+					desc.Set("data", array);
+				}
+				break;
+			}
+			case duckdb::LogicalTypeId::UBIGINT: {
+				if (with_data) {
+#if NAPI_VERSION > 5
+					auto array = Napi::BigUint64Array::New(env, chunk.size());
+					auto data = duckdb::FlatVector::GetData<uint64_t>(*vec);
+#else
+					auto array = Napi::Float64Array::New(env, chunk.size());
+					auto data = duckdb::FlatVector::GetData<int64_t>(*vec);
+#endif
 					for (size_t i = 0; i < chunk.size(); ++i) {
 						array[i] = data[i];
 					}

--- a/tools/nodejs/src/data_chunk.cpp
+++ b/tools/nodejs/src/data_chunk.cpp
@@ -1,0 +1,125 @@
+
+#include "duckdb.hpp"
+#include "duckdb_node.hpp"
+#include "napi.h"
+
+#include <thread>
+
+namespace node_duckdb {
+
+Napi::Object BuildDataChunk(Napi::Env env, duckdb::DataChunk& chunk, bool with_types, bool with_data) {
+    Napi::Array col_descs(Napi::Array::New(env, chunk.ColumnCount()));
+    for (idx_t col_idx = 0; col_idx < chunk.ColumnCount(); col_idx++) {
+    	Napi::Object col_desc(Napi::Object::New(env));
+
+        // Make sure we only have flat vectors hereafter (for now)
+        auto& chunk_vec = chunk.data[col_idx];
+        if (with_data) {
+            chunk_vec.Normalify(chunk.size());
+        }
+
+        // Do a post-order DFS traversal
+        std::vector<std::tuple<bool, duckdb::Vector*, Napi::Object, size_t, size_t>> pending;
+        pending.emplace_back(false, &chunk_vec, Napi::Object(Napi::Object::New(env)), 0, 0);
+
+        while (!pending.empty()) {
+            // Unpack DFS node
+    		auto& back = pending.back();
+    		auto& visited = std::get<0>(back);
+    		auto& vec = std::get<1>(back);
+    		auto& desc = std::get<2>(back);
+    		auto& parent_idx = std::get<3>(back);
+    		auto& idx_in_parent = std::get<4>(back);
+
+            // Already visited?
+            if (visited) {
+                if (pending.size() == 1) {
+                    col_desc = desc;
+                    break;
+                }
+                std::get<2>(pending[parent_idx]).Get("children").As<Napi::Array>().Set(idx_in_parent, desc);
+                pending.pop_back();
+                continue;
+            }
+            visited = true;
+            auto current_idx = pending.size() - 1;
+
+            // Store types
+            auto& vec_type = vec->GetType();
+            if (with_types) {
+                desc.Set("sqlType", vec_type.ToString());
+                desc.Set("physicalType", TypeIdToString(vec_type.InternalType()));
+            }
+
+            // Create validity vector
+            if (with_data) {
+                vec->Normalify(chunk.size());
+                auto& validity = duckdb::FlatVector::Validity(*vec);
+                auto validity_buffer = Napi::Uint8Array::New(env, chunk.size());
+                for (idx_t row_idx = 0; row_idx < chunk.size(); row_idx++) {
+                    validity_buffer[row_idx] = validity.RowIsValid(row_idx);
+                }
+                desc.Set("validity", validity_buffer);
+            }
+
+            // Create data buffer
+            switch (vec_type.id()) {
+                case duckdb::LogicalTypeId::INTEGER: {
+                    if (with_data) {
+                        auto array = Napi::Int32Array::New(env, chunk.size());
+                        auto data = duckdb::FlatVector::GetData<int32_t>(*vec);
+                        for (size_t i = 0; i < chunk.size(); ++i) {
+                            array[i] = data[i];
+                        }
+                        desc.Set("data", array);
+                    }
+                    break;
+    			}
+                case duckdb::LogicalTypeId::DOUBLE: {
+                    if (with_data) {
+                        auto array = Napi::Float64Array::New(env, chunk.size());
+                        auto data = duckdb::FlatVector::GetData<double>(*vec);
+                        for (size_t i = 0; i < chunk.size(); ++i) {
+                            array[i] = data[i];
+                        }
+                        desc.Set("data", array);
+                    }
+                    break;
+    			}
+                case duckdb::LogicalTypeId::BLOB:
+                case duckdb::LogicalTypeId::VARCHAR: {
+                    if (with_data) {
+                        auto array = Napi::Array::New(env, chunk.size());
+                        auto data = duckdb::FlatVector::GetData<duckdb::string_t>(*vec);
+                        for (size_t i = 0; i < chunk.size(); ++i) {
+                            array.Set(i, data[i].GetString());
+                        }
+                        desc.Set("data", array);
+                    }
+                    break;
+                }
+                case duckdb::LogicalTypeId::STRUCT: {
+                    auto child_count = duckdb::StructType::GetChildCount(vec_type);
+                    auto& entries = duckdb::StructVector::GetEntries(*vec);
+                    desc.Set("children", Napi::Array::New(env, child_count));
+                    for (size_t i = 0; i < child_count; ++i) {
+                        auto c = child_count - 1 - i;
+                        auto& entry = entries[c];
+    					auto desc = Napi::Object::New(env);
+                        auto name = duckdb::StructType::GetChildName(vec_type, c);
+                        desc.Set("name", name);
+                        pending.emplace_back(false, entry.get(), desc, current_idx, i);
+                    }
+                    break;
+                }
+                default:
+    				Napi::TypeError::New(env, "Unsupported UDF argument type " + vec->GetType().ToString()).ThrowAsJavaScriptException();
+    				break;
+            }
+        }
+        col_descs.Set(col_idx, col_desc);
+    }
+    return col_descs;
+}
+
+} // namespace node_duckdb

--- a/tools/nodejs/src/data_chunk.cpp
+++ b/tools/nodejs/src/data_chunk.cpp
@@ -7,10 +7,10 @@
 
 namespace node_duckdb {
 
-Napi::Object BuildDataChunk(Napi::Env env, duckdb::DataChunk& chunk, bool with_types, bool with_data) {
+Napi::Array EncodeDataChunk(Napi::Env env, duckdb::DataChunk& chunk, bool with_types, bool with_data) {
     Napi::Array col_descs(Napi::Array::New(env, chunk.ColumnCount()));
     for (idx_t col_idx = 0; col_idx < chunk.ColumnCount(); col_idx++) {
-    	Napi::Object col_desc(Napi::Object::New(env));
+    	auto col_desc = Napi::Object::New(env);
 
         // Make sure we only have flat vectors hereafter (for now)
         auto& chunk_vec = chunk.data[col_idx];
@@ -20,7 +20,7 @@ Napi::Object BuildDataChunk(Napi::Env env, duckdb::DataChunk& chunk, bool with_t
 
         // Do a post-order DFS traversal
         std::vector<std::tuple<bool, duckdb::Vector*, Napi::Object, size_t, size_t>> pending;
-        pending.emplace_back(false, &chunk_vec, Napi::Object(Napi::Object::New(env)), 0, 0);
+        pending.emplace_back(false, &chunk_vec, Napi::Object::New(env), 0, 0);
 
         while (!pending.empty()) {
             // Unpack DFS node

--- a/tools/nodejs/src/data_chunk.cpp
+++ b/tools/nodejs/src/data_chunk.cpp
@@ -7,119 +7,120 @@
 
 namespace node_duckdb {
 
-Napi::Array EncodeDataChunk(Napi::Env env, duckdb::DataChunk& chunk, bool with_types, bool with_data) {
-    Napi::Array col_descs(Napi::Array::New(env, chunk.ColumnCount()));
-    for (idx_t col_idx = 0; col_idx < chunk.ColumnCount(); col_idx++) {
-    	auto col_desc = Napi::Object::New(env);
+Napi::Array EncodeDataChunk(Napi::Env env, duckdb::DataChunk &chunk, bool with_types, bool with_data) {
+	Napi::Array col_descs(Napi::Array::New(env, chunk.ColumnCount()));
+	for (idx_t col_idx = 0; col_idx < chunk.ColumnCount(); col_idx++) {
+		auto col_desc = Napi::Object::New(env);
 
-        // Make sure we only have flat vectors hereafter (for now)
-        auto& chunk_vec = chunk.data[col_idx];
-        if (with_data) {
-            chunk_vec.Normalify(chunk.size());
-        }
+		// Make sure we only have flat vectors hereafter (for now)
+		auto &chunk_vec = chunk.data[col_idx];
+		if (with_data) {
+			chunk_vec.Normalify(chunk.size());
+		}
 
-        // Do a post-order DFS traversal
-        std::vector<std::tuple<bool, duckdb::Vector*, Napi::Object, size_t, size_t>> pending;
-        pending.emplace_back(false, &chunk_vec, Napi::Object::New(env), 0, 0);
+		// Do a post-order DFS traversal
+		std::vector<std::tuple<bool, duckdb::Vector *, Napi::Object, size_t, size_t>> pending;
+		pending.emplace_back(false, &chunk_vec, Napi::Object::New(env), 0, 0);
 
-        while (!pending.empty()) {
-            // Unpack DFS node
-    		auto& back = pending.back();
-    		auto& visited = std::get<0>(back);
-    		auto& vec = std::get<1>(back);
-    		auto& desc = std::get<2>(back);
-    		auto& parent_idx = std::get<3>(back);
-    		auto& idx_in_parent = std::get<4>(back);
+		while (!pending.empty()) {
+			// Unpack DFS node
+			auto &back = pending.back();
+			auto &visited = std::get<0>(back);
+			auto &vec = std::get<1>(back);
+			auto &desc = std::get<2>(back);
+			auto &parent_idx = std::get<3>(back);
+			auto &idx_in_parent = std::get<4>(back);
 
-            // Already visited?
-            if (visited) {
-                if (pending.size() == 1) {
-                    col_desc = desc;
-                    break;
-                }
-                std::get<2>(pending[parent_idx]).Get("children").As<Napi::Array>().Set(idx_in_parent, desc);
-                pending.pop_back();
-                continue;
-            }
-            visited = true;
-            auto current_idx = pending.size() - 1;
+			// Already visited?
+			if (visited) {
+				if (pending.size() == 1) {
+					col_desc = desc;
+					break;
+				}
+				std::get<2>(pending[parent_idx]).Get("children").As<Napi::Array>().Set(idx_in_parent, desc);
+				pending.pop_back();
+				continue;
+			}
+			visited = true;
+			auto current_idx = pending.size() - 1;
 
-            // Store types
-            auto& vec_type = vec->GetType();
-            if (with_types) {
-                desc.Set("sqlType", vec_type.ToString());
-                desc.Set("physicalType", TypeIdToString(vec_type.InternalType()));
-            }
+			// Store types
+			auto &vec_type = vec->GetType();
+			if (with_types) {
+				desc.Set("sqlType", vec_type.ToString());
+				desc.Set("physicalType", TypeIdToString(vec_type.InternalType()));
+			}
 
-            // Create validity vector
-            if (with_data) {
-                vec->Normalify(chunk.size());
-                auto& validity = duckdb::FlatVector::Validity(*vec);
-                auto validity_buffer = Napi::Uint8Array::New(env, chunk.size());
-                for (idx_t row_idx = 0; row_idx < chunk.size(); row_idx++) {
-                    validity_buffer[row_idx] = validity.RowIsValid(row_idx);
-                }
-                desc.Set("validity", validity_buffer);
-            }
+			// Create validity vector
+			if (with_data) {
+				vec->Normalify(chunk.size());
+				auto &validity = duckdb::FlatVector::Validity(*vec);
+				auto validity_buffer = Napi::Uint8Array::New(env, chunk.size());
+				for (idx_t row_idx = 0; row_idx < chunk.size(); row_idx++) {
+					validity_buffer[row_idx] = validity.RowIsValid(row_idx);
+				}
+				desc.Set("validity", validity_buffer);
+			}
 
-            // Create data buffer
-            switch (vec_type.id()) {
-                case duckdb::LogicalTypeId::INTEGER: {
-                    if (with_data) {
-                        auto array = Napi::Int32Array::New(env, chunk.size());
-                        auto data = duckdb::FlatVector::GetData<int32_t>(*vec);
-                        for (size_t i = 0; i < chunk.size(); ++i) {
-                            array[i] = data[i];
-                        }
-                        desc.Set("data", array);
-                    }
-                    break;
-    			}
-                case duckdb::LogicalTypeId::DOUBLE: {
-                    if (with_data) {
-                        auto array = Napi::Float64Array::New(env, chunk.size());
-                        auto data = duckdb::FlatVector::GetData<double>(*vec);
-                        for (size_t i = 0; i < chunk.size(); ++i) {
-                            array[i] = data[i];
-                        }
-                        desc.Set("data", array);
-                    }
-                    break;
-    			}
-                case duckdb::LogicalTypeId::BLOB:
-                case duckdb::LogicalTypeId::VARCHAR: {
-                    if (with_data) {
-                        auto array = Napi::Array::New(env, chunk.size());
-                        auto data = duckdb::FlatVector::GetData<duckdb::string_t>(*vec);
-                        for (size_t i = 0; i < chunk.size(); ++i) {
-                            array.Set(i, data[i].GetString());
-                        }
-                        desc.Set("data", array);
-                    }
-                    break;
-                }
-                case duckdb::LogicalTypeId::STRUCT: {
-                    auto child_count = duckdb::StructType::GetChildCount(vec_type);
-                    auto& entries = duckdb::StructVector::GetEntries(*vec);
-                    desc.Set("children", Napi::Array::New(env, child_count));
-                    for (size_t i = 0; i < child_count; ++i) {
-                        auto c = child_count - 1 - i;
-                        auto& entry = entries[c];
-    					auto desc = Napi::Object::New(env);
-                        auto name = duckdb::StructType::GetChildName(vec_type, c);
-                        desc.Set("name", name);
-                        pending.emplace_back(false, entry.get(), desc, current_idx, i);
-                    }
-                    break;
-                }
-                default:
-    				Napi::TypeError::New(env, "Unsupported UDF argument type " + vec->GetType().ToString()).ThrowAsJavaScriptException();
-    				break;
-            }
-        }
-        col_descs.Set(col_idx, col_desc);
-    }
-    return col_descs;
+			// Create data buffer
+			switch (vec_type.id()) {
+			case duckdb::LogicalTypeId::INTEGER: {
+				if (with_data) {
+					auto array = Napi::Int32Array::New(env, chunk.size());
+					auto data = duckdb::FlatVector::GetData<int32_t>(*vec);
+					for (size_t i = 0; i < chunk.size(); ++i) {
+						array[i] = data[i];
+					}
+					desc.Set("data", array);
+				}
+				break;
+			}
+			case duckdb::LogicalTypeId::DOUBLE: {
+				if (with_data) {
+					auto array = Napi::Float64Array::New(env, chunk.size());
+					auto data = duckdb::FlatVector::GetData<double>(*vec);
+					for (size_t i = 0; i < chunk.size(); ++i) {
+						array[i] = data[i];
+					}
+					desc.Set("data", array);
+				}
+				break;
+			}
+			case duckdb::LogicalTypeId::BLOB:
+			case duckdb::LogicalTypeId::VARCHAR: {
+				if (with_data) {
+					auto array = Napi::Array::New(env, chunk.size());
+					auto data = duckdb::FlatVector::GetData<duckdb::string_t>(*vec);
+					for (size_t i = 0; i < chunk.size(); ++i) {
+						array.Set(i, data[i].GetString());
+					}
+					desc.Set("data", array);
+				}
+				break;
+			}
+			case duckdb::LogicalTypeId::STRUCT: {
+				auto child_count = duckdb::StructType::GetChildCount(vec_type);
+				auto &entries = duckdb::StructVector::GetEntries(*vec);
+				desc.Set("children", Napi::Array::New(env, child_count));
+				for (size_t i = 0; i < child_count; ++i) {
+					auto c = child_count - 1 - i;
+					auto &entry = entries[c];
+					auto desc = Napi::Object::New(env);
+					auto name = duckdb::StructType::GetChildName(vec_type, c);
+					desc.Set("name", name);
+					pending.emplace_back(false, entry.get(), desc, current_idx, i);
+				}
+				break;
+			}
+			default:
+				Napi::TypeError::New(env, "Unsupported UDF argument type " + vec->GetType().ToString())
+				    .ThrowAsJavaScriptException();
+				break;
+			}
+		}
+		col_descs.Set(col_idx, col_desc);
+	}
+	return col_descs;
 }
 
 } // namespace node_duckdb

--- a/tools/nodejs/src/database.cpp
+++ b/tools/nodejs/src/database.cpp
@@ -77,9 +77,6 @@ Database::Database(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Database>(
 		mode = info[pos++].As<Napi::Number>().Int32Value();
 	}
 
-	// TODO check read only flag
-	(void)mode;
-
 	Napi::Function callback;
 	if (info.Length() >= pos && info[pos].IsFunction()) {
 		callback = info[pos++].As<Napi::Function>();

--- a/tools/nodejs/src/duckdb_node.hpp
+++ b/tools/nodejs/src/duckdb_node.hpp
@@ -1,17 +1,17 @@
 #pragma once
 #define NODE_ADDON_API_DISABLE_DEPRECATED
+#include "duckdb.hpp"
+
 #include <napi.h>
 #include <queue>
 #include <unordered_map>
 
-#include "duckdb.hpp"
-
 namespace node_duckdb {
 
 struct Task {
-	Task(Napi::Reference<Napi::Object> &object_, Napi::Function cb_) : object(object_) {
-		if (!cb_.IsUndefined() && cb_.IsFunction()) {
-			callback = Persistent(cb_); // TODO not sure what this does
+	Task(Napi::Reference<Napi::Object> &object, Napi::Function cb) : object(object) {
+		if (!cb.IsUndefined() && cb.IsFunction()) {
+			callback = Persistent(cb); // TODO not sure what this does
 		}
 		object.Ref();
 	}
@@ -40,7 +40,7 @@ class Connection;
 
 class Database : public Napi::ObjectWrap<Database> {
 public:
-	Database(const Napi::CallbackInfo &info);
+	explicit Database(const Napi::CallbackInfo &info);
 	static Napi::Object Init(Napi::Env env, Napi::Object exports);
 	void Process(Napi::Env env);
 	void TaskComplete(Napi::Env env);
@@ -50,8 +50,9 @@ public:
 	static bool HasInstance(Napi::Value val) {
 		Napi::Env env = val.Env();
 		Napi::HandleScope scope(env);
-		if (!val.IsObject())
+		if (!val.IsObject()) {
 			return false;
+		}
 		Napi::Object obj = val.As<Napi::Object>();
 		return obj.InstanceOf(constructor.Value());
 	}
@@ -78,14 +79,14 @@ private:
 };
 
 struct JSArgs;
-void DuckDBNodeUDFLauncher(Napi::Env env, Napi::Function jsudf, nullptr_t *, JSArgs *data);
+void DuckDBNodeUDFLauncher(Napi::Env env, Napi::Function jsudf, std::nullptr_t *, JSArgs *data);
 
-typedef Napi::TypedThreadSafeFunction<nullptr_t, JSArgs, DuckDBNodeUDFLauncher> DuckDBNodeUDFFUnction;
+typedef Napi::TypedThreadSafeFunction<std::nullptr_t, JSArgs, DuckDBNodeUDFLauncher> duckdb_node_udf_function_t;
 
 class Connection : public Napi::ObjectWrap<Connection> {
 public:
-	Connection(const Napi::CallbackInfo &info);
-	~Connection();
+	explicit Connection(const Napi::CallbackInfo &info);
+	~Connection() override;
 	static Napi::Object Init(Napi::Env env, Napi::Object exports);
 
 public:
@@ -97,8 +98,9 @@ public:
 	static bool HasInstance(Napi::Value val) {
 		Napi::Env env = val.Env();
 		Napi::HandleScope scope(env);
-		if (!val.IsObject())
+		if (!val.IsObject()) {
 			return false;
+		}
 		Napi::Object obj = val.As<Napi::Object>();
 		return obj.InstanceOf(constructor.Value());
 	}
@@ -107,15 +109,15 @@ public:
 	static Napi::FunctionReference constructor;
 	std::unique_ptr<duckdb::Connection> connection;
 	Database *database_ref;
-	std::unordered_map<std::string, DuckDBNodeUDFFUnction> udfs;
+	std::unordered_map<std::string, duckdb_node_udf_function_t> udfs;
 };
 
 struct StatementParam;
 
 class Statement : public Napi::ObjectWrap<Statement> {
 public:
-	Statement(const Napi::CallbackInfo &info);
-	~Statement();
+	explicit Statement(const Napi::CallbackInfo &info);
+	~Statement() override;
 	static Napi::Object Init(Napi::Env env, Napi::Object exports);
 	void SetProcessFirstParam() {
 		ignore_first_param = false;
@@ -126,8 +128,7 @@ public:
 	Napi::Value Each(const Napi::CallbackInfo &info);
 	Napi::Value Run(const Napi::CallbackInfo &info);
 	Napi::Value Bind(const Napi::CallbackInfo &info);
-
-	Napi::Value Finalize_(const Napi::CallbackInfo &info);
+	Napi::Value Finish(const Napi::CallbackInfo &info);
 
 public:
 	static Napi::FunctionReference constructor;

--- a/tools/nodejs/src/duckdb_node.hpp
+++ b/tools/nodejs/src/duckdb_node.hpp
@@ -159,4 +159,6 @@ public:
 	}
 };
 
+Napi::Array EncodeDataChunk(Napi::Env env, duckdb::DataChunk& chunk, bool with_types, bool with_data);
+
 } // namespace node_duckdb

--- a/tools/nodejs/src/duckdb_node.hpp
+++ b/tools/nodejs/src/duckdb_node.hpp
@@ -159,6 +159,6 @@ public:
 	}
 };
 
-Napi::Array EncodeDataChunk(Napi::Env env, duckdb::DataChunk& chunk, bool with_types, bool with_data);
+Napi::Array EncodeDataChunk(Napi::Env env, duckdb::DataChunk &chunk, bool with_types, bool with_data);
 
 } // namespace node_duckdb

--- a/tools/nodejs/src/statement.cpp
+++ b/tools/nodejs/src/statement.cpp
@@ -1,4 +1,5 @@
 #include "duckdb_node.hpp"
+
 #include <cassert>
 
 namespace node_duckdb {

--- a/tools/nodejs/test/udf.test.js
+++ b/tools/nodejs/test/udf.test.js
@@ -2,170 +2,213 @@ var duckdb = require('..');
 var assert = require('assert');
 
 describe('UDFs', function() {
-    var db;
+    describe('arity', function() {
+        var db;
+        before(function(done) {
+            db = new duckdb.Database(':memory:', done);
+        });
 
-    before(function(done) {
-        db = new duckdb.Database(':memory:', done);
+        it('0ary int', function(done) {
+            db.register("udf", "integer", () => 42);
+            db.all("select udf() v", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].v, 42);
+            });
+            db.unregister("udf", done);
+        });
+
+        it('0ary double', function(done) {
+            db.register("udf", "double", () => 4.2);
+            db.all("select udf() v", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].v, 4.2);
+            });
+            db.unregister("udf", done);
+        });
+
+        it('0ary string', function(done) {
+            db.register("udf", "varchar", () => 'hello');
+            db.all("select udf() v", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].v, 'hello');
+            });
+            db.unregister("udf", done);
+        });
+
+        it('0ary int null', function(done) {
+            db.register("udf", "integer", () => undefined);
+            db.all("select udf() v", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].v, undefined);
+            });
+            db.unregister("udf", done);
+        });
+
+
+        it('0ary string null', function(done) {
+            db.register("udf", "varchar", () => undefined);
+            db.all("select udf() v", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].v, undefined);
+            });
+            db.unregister("udf", done);
+        });
+
+
+        it('unary int', function(done) {
+            db.register("udf", "integer", (x) => x+1);
+            db.all("select udf(42) v", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].v, 43);
+            });
+            db.unregister("udf", done);
+        });
+
+        it('unary double', function(done) {
+            db.register("udf", "double", (x) => x);
+            db.all("select udf(4.2::double) v", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].v, 4.2);
+            });
+            db.unregister("udf", done);
+        });
+
+        it('unary int null', function(done) {
+            db.register("udf", "integer", (x) => undefined);
+            db.all("select udf(42) v", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].v, undefined);
+            });
+            db.unregister("udf", done);
+        });
+
+
+        it('unary double null', function(done) {
+            db.register("udf", "double", (x) => undefined);
+            db.all("select udf(4.2::double) v", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].v, undefined);
+            });
+            db.unregister("udf", done);
+        });
+
+
+        it('unary string', function(done) {
+            db.register("udf", "varchar", (x) => 'hello ' + x);
+            db.all("select udf('world') v", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].v, 'hello world');
+            });
+            db.unregister("udf", done);
+        });
+
+        it('unary string null', function(done) {
+            db.register("udf", "varchar", (x) => undefined);
+            db.all("select udf('world') v", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].v, undefined);
+            });
+            db.unregister("udf", done);
+        });
+
+        it('binary int', function(done) {
+            db.register("udf", "integer", (x, y) => x + y);
+            db.all("select udf(40, 2) v", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].v, 42);
+            });
+            db.unregister("udf", done);
+        });
+
+        it('binary string', function(done) {
+            db.register("udf", "varchar", (x, y) => x + ' ' + y);
+            db.all("select udf('hello', 'world') v", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].v, 'hello world');
+            });
+            db.unregister("udf", done);
+        });
+
+        it('ternary int', function(done) {
+            db.register("udf", "integer", (x, y, z) => x + y + z);
+            db.all("select udf(21, 20, 1) v", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].v, 42);
+            });
+            db.unregister("udf", done);
+        });
+
+        it('unary larger series', function(done) {
+            db.register("udf", "integer", (x) => 1);
+            db.all("select sum(udf(range::double)) v from range(10000)", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].v, 10000);
+            });
+            db.unregister("udf", done);
+        });
     });
 
-    it('0ary int', function(done) {
-        db.register("udf", "integer", () => 42);
-        db.all("select udf() v", function(err, rows) {
-            if (err) throw err;
-            assert.equal(rows[0].v, 42);
+    describe('types', function() {
+        var db;
+        before(function(done) {
+            db = new duckdb.Database(':memory:', done);
         });
-        db.unregister("udf", done);
-    });
 
-    it('0ary double', function(done) {
-        db.register("udf", "double", () => 4.2);
-        db.all("select udf() v", function(err, rows) {
-            if (err) throw err;
-            assert.equal(rows[0].v, 4.2);
+        it('tinyint', function(done) {
+            db.register("udf", "integer", (x) => x+1);
+            db.all("select udf(42::tinyint) v", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].v, 43);
+            });
+            db.unregister("udf", done);
         });
-        db.unregister("udf", done);
-    });
 
-    it('0ary string', function(done) {
-        db.register("udf", "varchar", () => 'hello');
-        db.all("select udf() v", function(err, rows) {
-            if (err) throw err;
-            assert.equal(rows[0].v, 'hello');
+        it('smallint', function(done) {
+            db.register("udf", "integer", (x) => x+1);
+            db.all("select udf(42::smallint) v", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].v, 43);
+            });
+            db.unregister("udf", done);
         });
-        db.unregister("udf", done);
-    });
 
-    it('0ary int null', function(done) {
-        db.register("udf", "integer", () => undefined);
-        db.all("select udf() v", function(err, rows) {
-            if (err) throw err;
-            assert.equal(rows[0].v, undefined);
+        it('int', function(done) {
+            db.register("udf", "integer", (x) => x+1);
+            db.all("select udf(42::integer) v", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].v, 43);
+            });
+            db.unregister("udf", done);
         });
-        db.unregister("udf", done);
-    });
 
-
-    it('0ary string null', function(done) {
-        db.register("udf", "varchar", () => undefined);
-        db.all("select udf() v", function(err, rows) {
-            if (err) throw err;
-            assert.equal(rows[0].v, undefined);
+        it('timestamp', function(done) {
+            db.register("udf", "timestamp", (x) => x);
+            db.all("select udf(timestamp '1992-09-20 11:30:00') v", function(err, rows) {
+                if (err) throw err;
+            });
+            db.unregister("udf", done);
         });
-        db.unregister("udf", done);
-    });
 
-
-    it('unary int', function(done) {
-        db.register("udf", "integer", (x) => x+1);
-        db.all("select udf(42) v", function(err, rows) {
-            if (err) throw err;
-            assert.equal(rows[0].v, 43);
+        it('struct', function(done) {
+            db.register("udf", "integer", a => {
+                return (a.x == null ? -100 : a.x);
+            });
+            db.all("SELECT min(udf({'x': (case when v % 2 = 0 then v else null end)::INTEGER, 'y': 42}))::INTEGER as foo FROM generate_series(1, 10000) as t(v)", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].foo, -100);
+            });
+            db.unregister("udf", done);
         });
-        db.unregister("udf", done);
-    });
 
-    it('unary double', function(done) {
-        db.register("udf", "double", (x) => x);
-        db.all("select udf(4.2::double) v", function(err, rows) {
-            if (err) throw err;
-            assert.equal(rows[0].v, 4.2);
+        it('structnestednull', function(done) {
+            db.register("udf", "integer", a => {
+                return (a.x == null ? -100 : a.x.y);
+            });
+            db.all("SELECT min(udf({'x': (case when v % 2 = 0 then {'y': v::INTEGER } else null end), 'z': 42}))::INTEGER as foo FROM generate_series(1, 10000) as t(v)", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].foo, -100);
+            });
+            db.unregister("udf", done);
         });
-        db.unregister("udf", done);
-    });
-
-    it('unary int null', function(done) {
-        db.register("udf", "integer", (x) => undefined);
-        db.all("select udf(42) v", function(err, rows) {
-            if (err) throw err;
-            assert.equal(rows[0].v, undefined);
-        });
-        db.unregister("udf", done);
-    });
-
-
-    it('unary double null', function(done) {
-        db.register("udf", "double", (x) => undefined);
-        db.all("select udf(4.2::double) v", function(err, rows) {
-            if (err) throw err;
-            assert.equal(rows[0].v, undefined);
-        });
-        db.unregister("udf", done);
-    });
-
-
-    it('unary string', function(done) {
-        db.register("udf", "varchar", (x) => 'hello ' + x);
-        db.all("select udf('world') v", function(err, rows) {
-            if (err) throw err;
-            assert.equal(rows[0].v, 'hello world');
-        });
-        db.unregister("udf", done);
-    });
-
-    it('unary string null', function(done) {
-        db.register("udf", "varchar", (x) => undefined);
-        db.all("select udf('world') v", function(err, rows) {
-            if (err) throw err;
-            assert.equal(rows[0].v, undefined);
-        });
-        db.unregister("udf", done);
-    });
-
-    it('binary int', function(done) {
-        db.register("udf", "integer", (x, y) => x + y);
-        db.all("select udf(40, 2) v", function(err, rows) {
-            if (err) throw err;
-            assert.equal(rows[0].v, 42);
-        });
-        db.unregister("udf", done);
-    });
-
-    it('binary string', function(done) {
-        db.register("udf", "varchar", (x, y) => x + ' ' + y);
-        db.all("select udf('hello', 'world') v", function(err, rows) {
-            if (err) throw err;
-            assert.equal(rows[0].v, 'hello world');
-        });
-        db.unregister("udf", done);
-    });
-
-    it('ternary int', function(done) {
-        db.register("udf", "integer", (x, y, z) => x + y + z);
-        db.all("select udf(21, 20, 1) v", function(err, rows) {
-            if (err) throw err;
-            assert.equal(rows[0].v, 42);
-        });
-        db.unregister("udf", done);
-    });
-
-    it('unary larger series', function(done) {
-        db.register("udf", "integer", (x) => 1);
-        db.all("select sum(udf(range::double)) v from range(10000)", function(err, rows) {
-            if (err) throw err;
-            assert.equal(rows[0].v, 10000);
-        });
-        db.unregister("udf", done);
-    });
-
-    it('struct', function(done) {
-        db.register("udf", "integer", a => {
-            return (a.x == null ? -100 : a.x);
-        });
-        db.all("SELECT min(udf({'x': (case when v % 2 = 0 then v else null end)::INTEGER, 'y': 42}))::INTEGER as foo FROM generate_series(1, 10000) as t(v)", function(err, rows) {
-            if (err) throw err;
-            assert.equal(rows[0].foo, -100);
-        });
-        db.unregister("udf", done);
-    });
-
-    it('structnestednull', function(done) {
-        db.register("udf", "integer", a => {
-            return (a.x == null ? -100 : a.x.y);
-        });
-        db.all("SELECT min(udf({'x': (case when v % 2 = 0 then {'y': v::INTEGER } else null end), 'z': 42}))::INTEGER as foo FROM generate_series(1, 10000) as t(v)", function(err, rows) {
-            if (err) throw err;
-            assert.equal(rows[0].foo, -100);
-        });
-        db.unregister("udf", done);
     });
 });

--- a/tools/nodejs/test/udf.test.js
+++ b/tools/nodejs/test/udf.test.js
@@ -146,4 +146,26 @@ describe('UDFs', function() {
         });
         db.unregister("udf", done);
     });
+
+    it('struct', function(done) {
+        db.register("udf", "integer", a => {
+            return (a.x == null ? -100 : a.x);
+        });
+        db.all("SELECT min(udf({'x': (case when v % 2 = 0 then v else null end)::INTEGER, 'y': 42}))::INTEGER as foo FROM generate_series(1, 10000) as t(v)", function(err, rows) {
+            if (err) throw err;
+            assert.equal(rows[0].foo, -100);
+        });
+        db.unregister("udf", done);
+    });
+
+    it('structnestednull', function(done) {
+        db.register("udf", "integer", a => {
+            return (a.x?.y == null ? -100 : a.x.y);
+        });
+        db.all("SELECT min(udf({'x': (case when v % 2 = 0 then {'y': v::INTEGER } else null end), 'z': 42}))::INTEGER as foo FROM generate_series(1, 10000) as t(v)", function(err, rows) {
+            if (err) throw err;
+            assert.equal(rows[0].foo, -100);
+        });
+        db.unregister("udf", done);
+    });
 });

--- a/tools/nodejs/test/udf.test.js
+++ b/tools/nodejs/test/udf.test.js
@@ -160,7 +160,7 @@ describe('UDFs', function() {
 
     it('structnestednull', function(done) {
         db.register("udf", "integer", a => {
-            return (a.x?.y == null ? -100 : a.x.y);
+            return (a.x == null ? -100 : a.x.y);
         });
         db.all("SELECT min(udf({'x': (case when v % 2 = 0 then {'y': v::INTEGER } else null end), 'z': 42}))::INTEGER as foo FROM generate_series(1, 10000) as t(v)", function(err, rows) {
             if (err) throw err;


### PR DESCRIPTION
In this PR:
* Node UDFs now support struct types.
* Node UDFs now support arbitrary argument counts.
* Resolve node api headers with CMake and add Node.js to global CMakeLists behind BUILD_NODE flag.
* Fixed clang-tidy warnings
* Reduce gyp build warnings, we can probably get this to zero later.

We pass the UDF arguments very similar to the Wasm UDFs by constructing native arrays.
https://github.com/ankoh/duckdb/blob/master/tools/nodejs/src/data_chunk.cpp

This PR is a draft because we need more udf tests and need to map more primitive types to native arrays.
(Atm, it's only integer, doubles, varchars and structs).

Further, we should use the data chunk mapping for the query results themselves in the future.
We would just stream the data chunks chunk-by-chunk with native arrays which should be faster than the current approach of materializing individual Napi row objects in C++.
In order for this to not break existing node.js users, we would need to glue Arrow-js style proxy objects on top of the native arrays.
The user would then still see the object which is effectively just a fat pointer into the column arrays.