### PR TITLE
Add interval to DBAPI description

### DIFF
--- a/tools/pythonpkg/src/pyresult.cpp
+++ b/tools/pythonpkg/src/pyresult.cpp
@@ -2,14 +2,14 @@
 
 #include "datetime.h" // from Python
 #include "duckdb/common/arrow.hpp"
+#include "duckdb/common/arrow_wrapper.hpp"
+#include "duckdb/common/result_arrow_wrapper.hpp"
 #include "duckdb/common/types/date.hpp"
 #include "duckdb/common/types/hugeint.hpp"
 #include "duckdb/common/types/time.hpp"
 #include "duckdb/common/types/timestamp.hpp"
-#include "duckdb_python/array_wrapper.hpp"
 #include "duckdb/common/types/uuid.hpp"
-#include "duckdb/common/arrow_wrapper.hpp"
-#include "duckdb/common/result_arrow_wrapper.hpp"
+#include "duckdb_python/array_wrapper.hpp"
 
 namespace duckdb {
 
@@ -429,23 +429,23 @@ py::str GetTypeToPython(const LogicalType &type) {
 	case LogicalTypeId::LIST: {
 		return py::str("list");
 	}
+	case LogicalTypeId::INTERVAL: {
+		return py::str("TIMEDELTA");
+	}
 	default:
 		throw NotImplementedException("unsupported type: " + type.ToString());
 	}
 }
 
 py::list DuckDBPyResult::Description() {
-	py::list desc(result->names.size());
-	for (idx_t col_idx = 0; col_idx < result->names.size(); col_idx++) {
-		py::tuple col_desc(7);
-		col_desc[0] = py::str(result->names[col_idx]);
-		col_desc[1] = GetTypeToPython(result->types[col_idx]);
-		col_desc[2] = py::none();
-		col_desc[3] = py::none();
-		col_desc[4] = py::none();
-		col_desc[5] = py::none();
-		col_desc[6] = py::none();
-		desc[col_idx] = col_desc;
+	const auto names = result->names;
+
+	py::list desc(names.size());
+
+	for (idx_t col_idx = 0; col_idx < names.size(); col_idx++) {
+		auto py_name = py::str(names[col_idx]);
+		auto py_type = GetTypeToPython(result->types[col_idx]);
+		desc[col_idx] = py::make_tuple(py_name, py_type, py::none(), py::none(), py::none(), py::none(), py::none());
 	}
 	return desc;
 }

--- a/tools/pythonpkg/tests/fast/test_result.py
+++ b/tools/pythonpkg/tests/fast/test_result.py
@@ -40,3 +40,13 @@ class TestPythonResult(object):
         rel = connection.table("timestamps")
         assert rel.execute().fetchall() == [(datetime.datetime(2008, 1, 1, 0, 0, 11), datetime.datetime(2008, 1, 1, 0, 0, 1, 794000), datetime.datetime(2008, 1, 1, 0, 0, 1, 989260), datetime.datetime(2008, 1, 1, 0, 0, 1, 899268))]
 
+    def test_result_interval(self):
+        connection = duckdb.connect()
+        cursor = connection.cursor()
+        cursor.execute('CREATE TABLE IF NOT EXISTS intervals (ivals INTERVAL)')
+        cursor.execute("INSERT INTO intervals VALUES ('1 day'), ('2 second'), ('1 microsecond')")
+
+        rel = connection.table("intervals")
+        res = rel.execute()
+        assert res.description() == [('ivals', 'TIMEDELTA', None, None, None, None, None)]
+        assert res.fetchall() == [(datetime.timedelta(days=1.0),), (datetime.timedelta(seconds=2.0),), (datetime.timedelta(microseconds=1.0),)]


### PR DESCRIPTION
This PR adds interval types to the output of `.description()` and cleans up the
surrounding code a bit. A unit test for the new type in description is included.
