### PR TITLE
Issue #3625: Adding canonical guards around Arrow CData Interface

### DIFF
--- a/src/include/duckdb/common/arrow.hpp
+++ b/src/include/duckdb/common/arrow.hpp
@@ -10,7 +10,6 @@
 
 #include <stdint.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/include/duckdb/common/arrow.hpp
+++ b/src/include/duckdb/common/arrow.hpp
@@ -15,12 +15,13 @@
 extern "C" {
 #endif
 
+#ifndef ARROW_C_DATA_INTERFACE
+#define ARROW_C_DATA_INTERFACE
+
 #define ARROW_FLAG_DICTIONARY_ORDERED 1
 #define ARROW_FLAG_NULLABLE           2
 #define ARROW_FLAG_MAP_KEYS_SORTED    4
 
-#ifndef ARROW_C_DATA_H
-#define ARROW_C_DATA_H
 struct ArrowSchema {
 	// Array type description
 	const char *format;

--- a/src/include/duckdb/common/arrow.hpp
+++ b/src/include/duckdb/common/arrow.hpp
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -18,6 +19,7 @@ extern "C" {
 #define ARROW_FLAG_NULLABLE           2
 #define ARROW_FLAG_MAP_KEYS_SORTED    4
 
+#ifndef ARROW_C_DATA_H
 struct ArrowSchema {
 	// Array type description
 	const char *format;
@@ -75,6 +77,7 @@ struct ArrowArrayStream {
 	// Opaque producer-specific data
 	void *private_data;
 };
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/include/duckdb/common/arrow.hpp
+++ b/src/include/duckdb/common/arrow.hpp
@@ -20,6 +20,7 @@ extern "C" {
 #define ARROW_FLAG_MAP_KEYS_SORTED    4
 
 #ifndef ARROW_C_DATA_H
+#define ARROW_C_DATA_H
 struct ArrowSchema {
 	// Array type description
 	const char *format;
@@ -52,7 +53,10 @@ struct ArrowArray {
 	// Opaque producer-specific data
 	void *private_data;
 };
+#endif
 
+#ifndef ARROW_C_STREAM_INTERFACE
+#define ARROW_C_STREAM_INTERFACE
 // EXPERIMENTAL
 struct ArrowArrayStream {
 	// Callback to get the stream type


### PR DESCRIPTION
This PR adds canonical guards around Arrow's CData intefrace, preventing collisions when someone does `#include <arrow/c/bridge.h>`.

This PR builds in conjunction with https://github.com/apache/arrow/pull/13115.