### PR TITLE
Fix issue 3611

### DIFF
--- a/src/storage/compression/dictionary_compression.cpp
+++ b/src/storage/compression/dictionary_compression.cpp
@@ -16,12 +16,6 @@ struct StringHash {
 	}
 };
 
-struct StringCompare {
-	bool operator()(const string &lhs, const string &rhs) const {
-		return lhs == rhs;
-	}
-};
-
 // Abstract class for keeping compression state either for compression or size analysis
 class DictionaryCompressionState : public CompressionState {
 public:
@@ -177,7 +171,7 @@ struct DictionaryCompressionCompressState : public DictionaryCompressionState {
 	data_ptr_t current_end_ptr;
 
 	// Buffers and map for current segment
-	std::unordered_map<string, uint32_t, StringHash, StringCompare> current_string_map;
+	std::unordered_map<string, uint32_t, StringHash> current_string_map;
 	std::vector<uint32_t> index_buffer;
 	std::vector<uint32_t> selection_buffer;
 
@@ -328,7 +322,7 @@ struct DictionaryCompressionAnalyzeState : public AnalyzeState, DictionaryCompre
 	idx_t current_tuple_count;
 	idx_t current_unique_count;
 	size_t current_dict_size;
-	std::unordered_set<string, StringHash, StringCompare> current_set;
+	std::unordered_set<string, StringHash> current_set;
 	bitpacking_width_t current_width;
 	bitpacking_width_t next_width;
 

--- a/src/storage/compression/dictionary_compression.cpp
+++ b/src/storage/compression/dictionary_compression.cpp
@@ -11,14 +11,14 @@
 namespace duckdb {
 
 struct StringHash {
-	std::size_t operator()(const string_t &k) const {
-		return Hash(k.GetDataUnsafe(), k.GetSize());
+	std::size_t operator()(const string &k) const {
+		return Hash(k.c_str(), k.size());
 	}
 };
 
 struct StringCompare {
-	bool operator()(const string_t &lhs, const string_t &rhs) const {
-		return StringComparisonOperators::EqualsOrNot<false>(lhs, rhs);
+	bool operator()(const string &lhs, const string &rhs) const {
+		return lhs == rhs;
 	}
 };
 
@@ -177,7 +177,7 @@ struct DictionaryCompressionCompressState : public DictionaryCompressionState {
 	data_ptr_t current_end_ptr;
 
 	// Buffers and map for current segment
-	std::unordered_map<string_t, uint32_t, StringHash, StringCompare> current_string_map;
+	std::unordered_map<string, uint32_t, StringHash, StringCompare> current_string_map;
 	std::vector<uint32_t> index_buffer;
 	std::vector<uint32_t> selection_buffer;
 
@@ -197,7 +197,7 @@ struct DictionaryCompressionCompressState : public DictionaryCompressionState {
 	}
 
 	bool LookupString(string_t str) override {
-		auto search = current_string_map.find(str);
+		auto search = current_string_map.find(str.GetString());
 		auto has_result = search != current_string_map.end();
 
 		if (has_result) {
@@ -219,7 +219,7 @@ struct DictionaryCompressionCompressState : public DictionaryCompressionState {
 		// Update buffers and map
 		index_buffer.push_back(current_dictionary.size);
 		selection_buffer.push_back(index_buffer.size() - 1);
-		current_string_map.insert({str, index_buffer.size() - 1});
+		current_string_map.insert({str.GetString(), index_buffer.size() - 1});
 		DictionaryCompressionStorage::SetDictionary(*current_segment, *current_handle, current_dictionary);
 
 		current_width = next_width;
@@ -328,19 +328,19 @@ struct DictionaryCompressionAnalyzeState : public AnalyzeState, DictionaryCompre
 	idx_t current_tuple_count;
 	idx_t current_unique_count;
 	size_t current_dict_size;
-	std::unordered_set<string_t, StringHash, StringCompare> current_set;
+	std::unordered_set<string, StringHash, StringCompare> current_set;
 	bitpacking_width_t current_width;
 	bitpacking_width_t next_width;
 
 	bool LookupString(string_t str) override {
-		return current_set.count(str);
+		return current_set.count(str.GetString());
 	}
 
 	void AddNewString(string_t str) override {
 		current_tuple_count++;
 		current_unique_count++;
 		current_dict_size += str.GetSize();
-		current_set.insert(str);
+		current_set.insert(str.GetString());
 		current_width = next_width;
 	}
 

--- a/test/issues/general/test_3611.test
+++ b/test/issues/general/test_3611.test
@@ -1,0 +1,30 @@
+# name: test/issues/general/3611.test
+# description: Issue 3611: Address Sanitiser Failure in Storage Compression
+# group: [general]
+
+# load the DB from disk
+load __TEST_DIR__/issue_3611.db
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+PRAGMA force_compression='dictionary'
+
+statement ok
+CREATE TABLE all_types AS SELECT varchar FROM test_all_types();
+
+loop i 0 12
+
+statement ok
+INSERT INTO all_types SELECT varchar FROM all_types;
+
+endloop
+
+query I nosort r1
+SELECT varchar FROM all_types;
+
+restart
+
+query I nosort r1
+SELECT varchar FROM all_types;

--- a/test/issues/general/test_3611.test
+++ b/test/issues/general/test_3611.test
@@ -1,4 +1,4 @@
-# name: test/issues/general/3611.test
+# name: test/issues/general/test_3611.test
 # description: Issue 3611: Address Sanitiser Failure in Storage Compression
 # group: [general]
 


### PR DESCRIPTION
https://github.com/duckdb/duckdb/issues/3611
reverted string_t keys for dict encoding map/set back to string