### PR TITLE
Add default type generator, move built-in types to default type class and improve error reporting for types

### DIFF
--- a/extension/icu/icu-datesub.cpp
+++ b/extension/icu/icu-datesub.cpp
@@ -122,8 +122,8 @@ struct ICUCalendarSub : public ICUDateFunc {
 
 	template <typename TA>
 	static ScalarFunction GetFunction(const LogicalTypeId &type) {
-		return ScalarFunction({LogicalType::VARCHAR, type, type}, LogicalType::BIGINT, ICUDateSubFunction<TA>, false, false,
-		                      Bind);
+		return ScalarFunction({LogicalType::VARCHAR, type, type}, LogicalType::BIGINT, ICUDateSubFunction<TA>, false,
+		                      false, Bind);
 	}
 
 	static void AddFunctions(const string &name, ClientContext &context) {
@@ -239,8 +239,8 @@ struct ICUCalendarDiff : public ICUDateFunc {
 
 	template <typename TA>
 	static ScalarFunction GetFunction(const LogicalTypeId &type) {
-		return ScalarFunction({LogicalType::VARCHAR, type, type}, LogicalType::BIGINT, ICUDateDiffFunction<TA>, false, false, 
-		                      Bind);
+		return ScalarFunction({LogicalType::VARCHAR, type, type}, LogicalType::BIGINT, ICUDateDiffFunction<TA>, false,
+		                      false, Bind);
 	}
 
 	static void AddFunctions(const string &name, ClientContext &context) {

--- a/extension/icu/icu-datetrunc.cpp
+++ b/extension/icu/icu-datetrunc.cpp
@@ -128,8 +128,8 @@ struct ICUDateTrunc : public ICUDateFunc {
 
 	template <typename TA>
 	static ScalarFunction GetDateTruncFunction(const LogicalTypeId &type) {
-		return ScalarFunction({LogicalType::VARCHAR, type}, LogicalType::TIMESTAMP_TZ, ICUDateTruncFunction<TA>, false, false,
-		                      Bind);
+		return ScalarFunction({LogicalType::VARCHAR, type}, LogicalType::TIMESTAMP_TZ, ICUDateTruncFunction<TA>, false,
+		                      false, Bind);
 	}
 
 	static void AddBinaryTimestampFunction(const string &name, ClientContext &context) {

--- a/src/catalog/catalog_entry/schema_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/schema_catalog_entry.cpp
@@ -34,6 +34,7 @@
 #include "duckdb/planner/constraints/bound_foreign_key_constraint.hpp"
 #include "duckdb/parser/constraints/foreign_key_constraint.hpp"
 #include "duckdb/catalog/catalog_entry/table_macro_catalog_entry.hpp"
+#include "duckdb/catalog/default/default_types.hpp"
 
 #include <algorithm>
 #include <sstream>
@@ -69,7 +70,7 @@ SchemaCatalogEntry::SchemaCatalogEntry(Catalog *catalog, string name_p, bool int
       tables(*catalog, make_unique<DefaultViewGenerator>(*catalog, this)), indexes(*catalog), table_functions(*catalog),
       copy_functions(*catalog), pragma_functions(*catalog),
       functions(*catalog, make_unique<DefaultFunctionGenerator>(*catalog, this)), sequences(*catalog),
-      collations(*catalog), types(*catalog) {
+      collations(*catalog), types(*catalog, make_unique<DefaultTypeGenerator>(*catalog, this)) {
 	this->internal = internal;
 }
 

--- a/src/catalog/catalog_entry/schema_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/schema_catalog_entry.cpp
@@ -123,8 +123,8 @@ CatalogEntry *SchemaCatalogEntry::CreateSequence(ClientContext &context, CreateS
 }
 
 CatalogEntry *SchemaCatalogEntry::CreateType(ClientContext &context, CreateTypeInfo *info) {
-	auto sequence = make_unique<TypeCatalogEntry>(catalog, this, info);
-	return AddEntry(context, move(sequence), info->on_conflict);
+	auto type_entry = make_unique<TypeCatalogEntry>(catalog, this, info);
+	return AddEntry(context, move(type_entry), info->on_conflict);
 }
 
 CatalogEntry *SchemaCatalogEntry::CreateTable(ClientContext &context, BoundCreateTableInfo *info) {

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -382,13 +382,8 @@ unique_ptr<CatalogEntry> TableCatalogEntry::SetDefault(ClientContext &context, S
 
 unique_ptr<CatalogEntry> TableCatalogEntry::ChangeColumnType(ClientContext &context, ChangeColumnTypeInfo &info) {
 	if (info.target_type.id() == LogicalTypeId::USER) {
-		auto &user_type_name = UserType::GetTypeName(info.target_type);
-		auto user_type_catalog = (TypeCatalogEntry *)context.db->GetCatalog().GetEntry(
-		    context, CatalogType::TYPE_ENTRY, schema->name, user_type_name, true);
-		if (!user_type_catalog) {
-			throw NotImplementedException("DataType %s not supported yet...\n", user_type_name);
-		}
-		info.target_type = user_type_catalog->user_type;
+		auto &catalog = Catalog::GetCatalog(context);
+		info.target_type = catalog.GetType(context, schema->name, UserType::GetTypeName(info.target_type));
 	}
 	auto create_info = make_unique<CreateTableInfo>(schema->name, name);
 	idx_t change_idx = GetColumnIndex(info.column_name);

--- a/src/catalog/catalog_entry/type_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/type_catalog_entry.cpp
@@ -14,9 +14,12 @@ namespace duckdb {
 
 TypeCatalogEntry::TypeCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, CreateTypeInfo *info)
     : StandardEntry(CatalogType::TYPE_ENTRY, schema, catalog, info->name), user_type(info->type) {
+	this->temporary = info->temporary;
+	this->internal = info->internal;
 }
 
 void TypeCatalogEntry::Serialize(Serializer &serializer) {
+	D_ASSERT(!internal);
 	FieldWriter writer(serializer);
 	writer.WriteString(schema->name);
 	writer.WriteString(name);

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -51,13 +51,19 @@ bool CatalogSet::CreateEntry(ClientContext &context, const string &name, unique_
 	// lock the catalog for writing
 	lock_guard<mutex> write_lock(catalog.write_lock);
 	// lock this catalog set to disallow reading
-	lock_guard<mutex> read_lock(catalog_lock);
+	unique_lock<mutex> read_lock(catalog_lock);
 
 	// first check if the entry exists in the unordered set
 	idx_t entry_index;
 	auto mapping_value = GetMapping(context, name);
 	if (mapping_value == nullptr || mapping_value->deleted) {
 		// if it does not: entry has never been created
+
+		// check if there is a default entry
+		auto entry = CreateDefaultEntry(context, name, read_lock);
+		if (entry) {
+			return false;
+		}
 
 		// first create a dummy deleted entry for this entry
 		// so transactions started before the commit of this transaction don't
@@ -299,6 +305,7 @@ MappingValue *CatalogSet::GetMapping(ClientContext &context, const string &name,
 	if (entry != mapping.end()) {
 		mapping_value = entry->second.get();
 	} else {
+
 		return nullptr;
 	}
 	if (get_latest) {
@@ -410,20 +417,7 @@ CatalogEntry *CatalogSet::CreateEntryInternal(ClientContext &context, unique_ptr
 	return catalog_entry;
 }
 
-CatalogEntry *CatalogSet::GetEntry(ClientContext &context, const string &name) {
-	unique_lock<mutex> lock(catalog_lock);
-	auto mapping_value = GetMapping(context, name);
-	if (mapping_value != nullptr && !mapping_value->deleted) {
-		// we found an entry for this name
-		// check the version numbers
-
-		auto catalog_entry = entries[mapping_value->index].get();
-		CatalogEntry *current = GetEntryForTransaction(context, catalog_entry);
-		if (current->deleted || (current->name != name && !UseTimestamp(context, mapping_value->timestamp))) {
-			return nullptr;
-		}
-		return current;
-	}
+CatalogEntry *CatalogSet::CreateDefaultEntry(ClientContext &context, const string &name, unique_lock<mutex> &lock) {
 	// no entry found with this name, check for defaults
 	if (!defaults || defaults->created_all_entries) {
 		// no defaults either: return null
@@ -449,6 +443,23 @@ CatalogEntry *CatalogSet::GetEntry(ClientContext &context, const string &name) {
 	// just retry?
 	lock.unlock();
 	return GetEntry(context, name);
+}
+
+CatalogEntry *CatalogSet::GetEntry(ClientContext &context, const string &name) {
+	unique_lock<mutex> lock(catalog_lock);
+	auto mapping_value = GetMapping(context, name);
+	if (mapping_value != nullptr && !mapping_value->deleted) {
+		// we found an entry for this name
+		// check the version numbers
+
+		auto catalog_entry = entries[mapping_value->index].get();
+		CatalogEntry *current = GetEntryForTransaction(context, catalog_entry);
+		if (current->deleted || (current->name != name && !UseTimestamp(context, mapping_value->timestamp))) {
+			return nullptr;
+		}
+		return current;
+	}
+	return CreateDefaultEntry(context, name, lock);
 }
 
 void CatalogSet::UpdateTimestamp(CatalogEntry *entry, transaction_t timestamp) {
@@ -567,6 +578,9 @@ void CatalogSet::CreateDefaultEntries(ClientContext &context, unique_lock<mutex>
 			// specifically for views this can happen since the view will be bound
 			lock.unlock();
 			auto entry = defaults->CreateDefaultEntry(context, default_entry);
+			if (!entry) {
+				throw InternalException("Failed to create default entry for %s", default_entry);
+			}
 
 			lock.lock();
 			CreateEntryInternal(context, move(entry));

--- a/src/catalog/default/CMakeLists.txt
+++ b/src/catalog/default/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library_unity(duckdb_catalog_default_entries OBJECT default_functions.cpp
-                  default_schemas.cpp default_views.cpp)
+                  default_schemas.cpp default_types.cpp default_views.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_catalog_default_entries>
     PARENT_SCOPE)

--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -55,7 +55,7 @@ static DefaultMacro internal_macros[] = {
 	{"pg_catalog", "pg_get_viewdef", {"oid", nullptr}, "(select sql from duckdb_views() v where v.view_oid=oid)"},
 	{"pg_catalog", "pg_get_constraintdef", {"constraint_oid", "pretty_bool", nullptr}, "(select constraint_text from duckdb_constraints() d_constraint where d_constraint.table_oid=constraint_oid/1000000 and d_constraint.constraint_index=constraint_oid%1000000)"},
 	{"pg_catalog", "pg_get_expr", {"pg_node_tree", "relation_oid", nullptr}, "pg_node_tree"},
-	{"pg_catalog", "format_pg_type", {"type_name", nullptr}, "case when type_name='FLOAT' then 'real' when type_name='DOUBLE' then 'double precision' when type_name='DECIMAL' then 'numeric' when type_name='VARCHAR' then 'character varying' when type_name='BLOB' then 'bytea' when type_name='TIMESTAMP' then 'timestamp without time zone' when type_name='TIME' then 'time without time zone' else lower(type_name) end"},
+	{"pg_catalog", "format_pg_type", {"type_name", nullptr}, "case when logical_type='FLOAT' then 'real' when logical_type='DOUBLE' then 'double precision' when logical_type='DECIMAL' then 'numeric' when logical_type='VARCHAR' then 'character varying' when logical_type='BLOB' then 'bytea' when logical_type='TIMESTAMP' then 'timestamp without time zone' when logical_type='TIME' then 'time without time zone' else lower(logical_type) end"},
 	{"pg_catalog", "format_type", {"type_oid", "typemod", nullptr}, "(select format_pg_type(type_name) from duckdb_types() t where t.type_oid=type_oid) || case when typemod>0 then concat('(', typemod/1000, ',', typemod%1000, ')') else '' end"},
 
 	{"pg_catalog", "pg_has_role", {"user", "role", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for role

--- a/src/catalog/default/default_types.cpp
+++ b/src/catalog/default/default_types.cpp
@@ -111,6 +111,9 @@ unique_ptr<CatalogEntry> DefaultTypeGenerator::CreateDefaultEntry(ClientContext 
 
 vector<string> DefaultTypeGenerator::GetDefaultEntries() {
 	vector<string> result;
+	if (schema->name != DEFAULT_SCHEMA) {
+		return result;
+	}
 	for (idx_t index = 0; internal_types[index].name != nullptr; index++) {
 		result.emplace_back(internal_types[index].name);
 	}

--- a/src/catalog/default/default_types.cpp
+++ b/src/catalog/default/default_types.cpp
@@ -1,0 +1,120 @@
+#include "duckdb/catalog/default/default_types.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/type_catalog_entry.hpp"
+#include "duckdb/parser/parsed_data/create_type_info.hpp"
+
+namespace duckdb {
+
+struct DefaultType {
+	const char *name;
+	LogicalTypeId type;
+};
+
+static DefaultType internal_types[] = {{"int", LogicalTypeId::INTEGER},
+                                       {"int4", LogicalTypeId::INTEGER},
+                                       {"signed", LogicalTypeId::INTEGER},
+                                       {"integer", LogicalTypeId::INTEGER},
+                                       {"integral", LogicalTypeId::INTEGER},
+                                       {"int32", LogicalTypeId::INTEGER},
+                                       {"varchar", LogicalTypeId::VARCHAR},
+                                       {"bpchar", LogicalTypeId::VARCHAR},
+                                       {"text", LogicalTypeId::VARCHAR},
+                                       {"string", LogicalTypeId::VARCHAR},
+                                       {"char", LogicalTypeId::VARCHAR},
+                                       {"nvarchar", LogicalTypeId::VARCHAR},
+                                       {"bytea", LogicalTypeId::BLOB},
+                                       {"blob", LogicalTypeId::BLOB},
+                                       {"varbinary", LogicalTypeId::BLOB},
+                                       {"binary", LogicalTypeId::BLOB},
+                                       {"int8", LogicalTypeId::BIGINT},
+                                       {"bigint", LogicalTypeId::BIGINT},
+                                       {"int64", LogicalTypeId::BIGINT},
+                                       {"long", LogicalTypeId::BIGINT},
+                                       {"oid", LogicalTypeId::BIGINT},
+                                       {"int2", LogicalTypeId::SMALLINT},
+                                       {"smallint", LogicalTypeId::SMALLINT},
+                                       {"short", LogicalTypeId::SMALLINT},
+                                       {"int16", LogicalTypeId::SMALLINT},
+                                       {"timestamp", LogicalTypeId::TIMESTAMP},
+                                       {"datetime", LogicalTypeId::TIMESTAMP},
+                                       {"timestamp_us", LogicalTypeId::TIMESTAMP},
+                                       {"timestamp_ms", LogicalTypeId::TIMESTAMP_MS},
+                                       {"timestamp_ns", LogicalTypeId::TIMESTAMP_NS},
+                                       {"timestamp_s", LogicalTypeId::TIMESTAMP_SEC},
+                                       {"bool", LogicalTypeId::BOOLEAN},
+                                       {"boolean", LogicalTypeId::BOOLEAN},
+                                       {"logical", LogicalTypeId::BOOLEAN},
+                                       {"decimal", LogicalTypeId::DECIMAL},
+                                       {"dec", LogicalTypeId::DECIMAL},
+                                       {"numeric", LogicalTypeId::DECIMAL},
+                                       {"real", LogicalTypeId::FLOAT},
+                                       {"float4", LogicalTypeId::FLOAT},
+                                       {"float", LogicalTypeId::FLOAT},
+                                       {"double", LogicalTypeId::DOUBLE},
+                                       {"float8", LogicalTypeId::DOUBLE},
+                                       {"tinyint", LogicalTypeId::TINYINT},
+                                       {"int1", LogicalTypeId::TINYINT},
+                                       {"date", LogicalTypeId::DATE},
+                                       {"time", LogicalTypeId::TIME},
+                                       {"interval", LogicalTypeId::INTERVAL},
+                                       {"hugeint", LogicalTypeId::HUGEINT},
+                                       {"int128", LogicalTypeId::HUGEINT},
+                                       {"uuid", LogicalTypeId::UUID},
+                                       {"guid", LogicalTypeId::UUID},
+                                       {"struct", LogicalTypeId::STRUCT},
+                                       {"row", LogicalTypeId::STRUCT},
+                                       {"map", LogicalTypeId::MAP},
+                                       {"utinyint", LogicalTypeId::UTINYINT},
+                                       {"uint8", LogicalTypeId::UTINYINT},
+                                       {"usmallint", LogicalTypeId::USMALLINT},
+                                       {"uint16", LogicalTypeId::USMALLINT},
+                                       {"uinteger", LogicalTypeId::UINTEGER},
+                                       {"uint32", LogicalTypeId::UINTEGER},
+                                       {"ubigint", LogicalTypeId::UBIGINT},
+                                       {"uint64", LogicalTypeId::UBIGINT},
+                                       {"timestamptz", LogicalTypeId::TIMESTAMP_TZ},
+                                       {"timetz", LogicalTypeId::TIME_TZ},
+                                       {"json", LogicalTypeId::JSON},
+                                       {"null", LogicalTypeId::SQLNULL},
+                                       {nullptr, LogicalTypeId::INVALID}};
+
+LogicalTypeId DefaultTypeGenerator::GetDefaultType(const string &name) {
+	auto lower_str = StringUtil::Lower(name);
+	for (idx_t index = 0; internal_types[index].name != nullptr; index++) {
+		if (internal_types[index].name == lower_str) {
+			return internal_types[index].type;
+		}
+	}
+	return LogicalTypeId::INVALID;
+}
+
+DefaultTypeGenerator::DefaultTypeGenerator(Catalog &catalog, SchemaCatalogEntry *schema)
+    : DefaultGenerator(catalog), schema(schema) {
+}
+
+unique_ptr<CatalogEntry> DefaultTypeGenerator::CreateDefaultEntry(ClientContext &context, const string &entry_name) {
+	if (schema->name != DEFAULT_SCHEMA) {
+		return nullptr;
+	}
+	auto type_id = GetDefaultType(entry_name);
+	if (type_id == LogicalTypeId::INVALID) {
+		return nullptr;
+	}
+	CreateTypeInfo info;
+	info.name = entry_name;
+	info.type = LogicalType(type_id);
+	info.internal = true;
+	info.temporary = true;
+	return make_unique_base<CatalogEntry, TypeCatalogEntry>(&catalog, schema, &info);
+}
+
+vector<string> DefaultTypeGenerator::GetDefaultEntries() {
+	vector<string> result;
+	for (idx_t index = 0; internal_types[index].name != nullptr; index++) {
+		result.emplace_back(internal_types[index].name);
+	}
+	return result;
+}
+
+} // namespace duckdb

--- a/src/catalog/default/default_views.cpp
+++ b/src/catalog/default/default_views.cpp
@@ -94,7 +94,6 @@ vector<string> DefaultViewGenerator::GetDefaultEntries() {
 		}
 	}
 	return result;
-
 }
 
 } // namespace duckdb

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -234,7 +234,9 @@ private:
 };
 
 // adapted from https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Levenshtein_distance#C++
-idx_t StringUtil::LevenshteinDistance(const string &s1, const string &s2) {
+idx_t StringUtil::LevenshteinDistance(const string &s1_p, const string &s2_p) {
+	auto s1 = StringUtil::Lower(s1_p);
+	auto s2 = StringUtil::Lower(s2_p);
 	idx_t len1 = s1.size();
 	idx_t len2 = s2.size();
 	if (len1 == 0) {

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -245,9 +245,9 @@ string TypeIdToString(PhysicalType type) {
 	case PhysicalType::INTERVAL:
 		return "INTERVAL";
 	case PhysicalType::STRUCT:
-		return "STRUCT<?>";
+		return "STRUCT";
 	case PhysicalType::LIST:
-		return "LIST<?>";
+		return "LIST";
 	case PhysicalType::INVALID:
 		return "INVALID";
 	case PhysicalType::BIT:
@@ -415,11 +415,11 @@ string LogicalTypeIdToString(LogicalTypeId id) {
 	case LogicalTypeId::VALIDITY:
 		return "VALIDITY";
 	case LogicalTypeId::STRUCT:
-		return "STRUCT<?>";
+		return "STRUCT";
 	case LogicalTypeId::LIST:
-		return "LIST<?>";
+		return "LIST";
 	case LogicalTypeId::MAP:
-		return "MAP<?>";
+		return "MAP";
 	case LogicalTypeId::HASH:
 		return "HASH";
 	case LogicalTypeId::POINTER:
@@ -433,7 +433,7 @@ string LogicalTypeIdToString(LogicalTypeId id) {
 	case LogicalTypeId::ENUM:
 		return "ENUM";
 	case LogicalTypeId::AGGREGATE_STATE:
-		return "AGGREGATE_STATE<?>";
+		return "AGGREGATE_STATE";
 	case LogicalTypeId::USER:
 		return "USER";
 	case LogicalTypeId::JSON:

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/types.hpp"
 
+#include "duckdb/catalog/default/default_types.hpp"
 #include "duckdb/catalog/catalog_entry/type_catalog_entry.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/field_writer.hpp"
@@ -505,74 +506,13 @@ string LogicalType::ToString() const {
 // LCOV_EXCL_STOP
 
 LogicalTypeId TransformStringToLogicalTypeId(const string &str) {
-	auto lower_str = StringUtil::Lower(str);
-	// Transform column type
-	if (lower_str == "int" || lower_str == "int4" || lower_str == "signed" || lower_str == "integer" ||
-	    lower_str == "integral" || lower_str == "int32") {
-		return LogicalTypeId::INTEGER;
-	} else if (lower_str == "varchar" || lower_str == "bpchar" || lower_str == "text" || lower_str == "string" ||
-	           lower_str == "char" || lower_str == "nvarchar") {
-		return LogicalTypeId::VARCHAR;
-	} else if (lower_str == "bytea" || lower_str == "blob" || lower_str == "varbinary" || lower_str == "binary") {
-		return LogicalTypeId::BLOB;
-	} else if (lower_str == "int8" || lower_str == "bigint" || lower_str == "int64" || lower_str == "long" ||
-	           lower_str == "oid") {
-		return LogicalTypeId::BIGINT;
-	} else if (lower_str == "int2" || lower_str == "smallint" || lower_str == "short" || lower_str == "int16") {
-		return LogicalTypeId::SMALLINT;
-	} else if (lower_str == "timestamp" || lower_str == "datetime" || lower_str == "timestamp_us") {
-		return LogicalTypeId::TIMESTAMP;
-	} else if (lower_str == "timestamp_ms") {
-		return LogicalTypeId::TIMESTAMP_MS;
-	} else if (lower_str == "timestamp_ns") {
-		return LogicalTypeId::TIMESTAMP_NS;
-	} else if (lower_str == "timestamp_s") {
-		return LogicalTypeId::TIMESTAMP_SEC;
-	} else if (lower_str == "bool" || lower_str == "boolean" || lower_str == "logical") {
-		return LogicalTypeId::BOOLEAN;
-	} else if (lower_str == "decimal" || lower_str == "dec" || lower_str == "numeric") {
-		return LogicalTypeId::DECIMAL;
-	} else if (lower_str == "real" || lower_str == "float4" || lower_str == "float") {
-		return LogicalTypeId::FLOAT;
-	} else if (lower_str == "double" || lower_str == "float8") {
-		return LogicalTypeId::DOUBLE;
-	} else if (lower_str == "tinyint" || lower_str == "int1") {
-		return LogicalTypeId::TINYINT;
-	} else if (lower_str == "date") {
-		return LogicalTypeId::DATE;
-	} else if (lower_str == "time") {
-		return LogicalTypeId::TIME;
-	} else if (lower_str == "interval") {
-		return LogicalTypeId::INTERVAL;
-	} else if (lower_str == "hugeint" || lower_str == "int128") {
-		return LogicalTypeId::HUGEINT;
-	} else if (lower_str == "uuid" || lower_str == "guid") {
-		return LogicalTypeId::UUID;
-	} else if (lower_str == "struct" || lower_str == "row") {
-		return LogicalTypeId::STRUCT;
-	} else if (lower_str == "map") {
-		return LogicalTypeId::MAP;
-	} else if (lower_str == "utinyint" || lower_str == "uint8") {
-		return LogicalTypeId::UTINYINT;
-	} else if (lower_str == "usmallint" || lower_str == "uint16") {
-		return LogicalTypeId::USMALLINT;
-	} else if (lower_str == "uinteger" || lower_str == "uint32") {
-		return LogicalTypeId::UINTEGER;
-	} else if (lower_str == "ubigint" || lower_str == "uint64") {
-		return LogicalTypeId::UBIGINT;
-	} else if (lower_str == "timestamptz") {
-		return LogicalTypeId::TIMESTAMP_TZ;
-	} else if (lower_str == "timetz") {
-		return LogicalTypeId::TIME_TZ;
-	} else if (lower_str == "json") {
-		return LogicalTypeId::JSON;
-	} else if (lower_str == "null") {
-		return LogicalTypeId::SQLNULL;
-	} else {
+	auto type = DefaultTypeGenerator::GetDefaultType(str);
+	if (type == LogicalTypeId::INVALID) {
 		// This is a User Type, at this point we don't know if its one of the User Defined Types or an error
 		// It is checked in the binder
-		return LogicalTypeId::USER;
+		type = LogicalTypeId::USER;
 	}
+	return type;
 }
 
 LogicalType TransformStringToLogicalType(const string &str) {

--- a/src/execution/operator/persistent/physical_export.cpp
+++ b/src/execution/operator/persistent/physical_export.cpp
@@ -15,6 +15,9 @@ using std::stringstream;
 
 static void WriteCatalogEntries(stringstream &ss, vector<CatalogEntry *> &entries) {
 	for (auto &entry : entries) {
+		if (entry->internal) {
+			continue;
+		}
 		ss << entry->ToSQL() << std::endl;
 	}
 	ss << std::endl;

--- a/src/function/table/system/duckdb_types.cpp
+++ b/src/function/table/system/duckdb_types.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
-#include "duckdb/catalog/catalog_entry/sequence_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/type_catalog_entry.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/client_context.hpp"
 
@@ -12,7 +12,7 @@ struct DuckDBTypesData : public FunctionOperatorData {
 	DuckDBTypesData() : offset(0) {
 	}
 
-	vector<LogicalType> types;
+	vector<TypeCatalogEntry *> entries;
 	idx_t offset;
 };
 
@@ -33,6 +33,9 @@ static unique_ptr<FunctionData> DuckDBTypesBind(ClientContext &context, TableFun
 	names.emplace_back("type_size");
 	return_types.emplace_back(LogicalType::BIGINT);
 
+	names.emplace_back("logical_type");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
 	// NUMERIC, STRING, DATETIME, BOOLEAN, COMPOSITE, USER
 	names.emplace_back("type_category");
 	return_types.emplace_back(LogicalType::VARCHAR);
@@ -46,37 +49,49 @@ static unique_ptr<FunctionData> DuckDBTypesBind(ClientContext &context, TableFun
 unique_ptr<FunctionOperatorData> DuckDBTypesInit(ClientContext &context, const FunctionData *bind_data,
                                                  const vector<column_t> &column_ids, TableFilterCollection *filters) {
 	auto result = make_unique<DuckDBTypesData>();
-	result->types = LogicalType::AllTypes();
-	// FIXME: add user-defined types here (when we have them)
+	auto schemas = Catalog::GetCatalog(context).schemas->GetEntries<SchemaCatalogEntry>(context);
+	for (auto &schema : schemas) {
+		schema->Scan(context, CatalogType::TYPE_ENTRY,
+		             [&](CatalogEntry *entry) { result->entries.push_back((TypeCatalogEntry *)entry); });
+	};
+
+	// check the temp schema as well
+	ClientData::Get(context).temporary_objects->Scan(context, CatalogType::TYPE_ENTRY, [&](CatalogEntry *entry) {
+		result->entries.push_back((TypeCatalogEntry *)entry);
+	});
 	return move(result);
 }
 
 void DuckDBTypesFunction(ClientContext &context, const FunctionData *bind_data, FunctionOperatorData *operator_state,
                          DataChunk &output) {
 	auto &data = (DuckDBTypesData &)*operator_state;
-	if (data.offset >= data.types.size()) {
+	if (data.offset >= data.entries.size()) {
 		// finished returning values
 		return;
 	}
 	// start returning values
 	// either fill up the chunk or return all the remaining columns
 	idx_t count = 0;
-	while (data.offset < data.types.size() && count < STANDARD_VECTOR_SIZE) {
-		auto &type = data.types[data.offset++];
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &type_entry = data.entries[data.offset++];
+		auto &type = type_entry->user_type;
 
 		// return values:
-		// schema_name, VARCHAR
-		output.SetValue(0, count, Value());
-		// schema_oid, BIGINT
-		output.SetValue(1, count, Value());
+		// schema_name, LogicalType::VARCHAR
+		output.SetValue(0, count, Value(type_entry->schema->name));
+		// schema_oid, LogicalType::BIGINT
+		output.SetValue(1, count, Value::BIGINT(type_entry->schema->oid));
 		// type_oid, BIGINT
-		output.SetValue(2, count, Value::BIGINT(int(type.id())));
+
+		output.SetValue(2, count, Value::BIGINT(type_entry->oid));
 		// type_name, VARCHAR
-		output.SetValue(3, count, Value(type.ToString()));
+		output.SetValue(3, count, Value(type_entry->name));
 		// type_size, BIGINT
 		auto internal_type = type.InternalType();
 		output.SetValue(4, count,
 		                internal_type == PhysicalType::INVALID ? Value() : Value::BIGINT(GetTypeIdSize(internal_type)));
+		// logical_type, VARCHAR
+		output.SetValue(5, count, Value(LogicalTypeIdToString(type.id())));
 		// type_category, VARCHAR
 		string category;
 		switch (type.id()) {
@@ -120,9 +135,9 @@ void DuckDBTypesFunction(ClientContext &context, const FunctionData *bind_data, 
 		default:
 			break;
 		}
-		output.SetValue(5, count, category.empty() ? Value() : Value(category));
+		output.SetValue(6, count, category.empty() ? Value() : Value(category));
 		// internal, BOOLEAN
-		output.SetValue(6, count, Value::BOOLEAN(true));
+		output.SetValue(7, count, Value::BOOLEAN(type_entry->internal));
 
 		count++;
 	}

--- a/src/function/table/system/duckdb_types.cpp
+++ b/src/function/table/system/duckdb_types.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/catalog/catalog_entry/type_catalog_entry.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/client_data.hpp"
 
 namespace duckdb {
 

--- a/src/function/table/system/duckdb_types.cpp
+++ b/src/function/table/system/duckdb_types.cpp
@@ -97,7 +97,7 @@ void DuckDBTypesFunction(ClientContext &context, const FunctionData *bind_data, 
 		} else {
 			oid_val = Value();
 		}
-		output.SetValue(2, count, move(oid_val));
+		output.SetValue(2, count, oid_val);
 		// type_name, VARCHAR
 		output.SetValue(3, count, Value(type_entry->name));
 		// type_size, BIGINT

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -168,6 +168,9 @@ public:
 	//! Gets the "schema.name" entry without a specified type, if entry does not exist an exception is thrown
 	DUCKDB_API CatalogEntry *GetEntry(ClientContext &context, const string &schema, const string &name);
 
+	//! Fetches a logical type from the catalog
+	DUCKDB_API LogicalType GetType(ClientContext &context, const string &schema, const string &name);
+
 	template <class T>
 	T *GetEntry(ClientContext &context, const string &schema_name, const string &name, bool if_exists = false,
 	            QueryErrorContext error_context = QueryErrorContext());
@@ -226,5 +229,8 @@ DUCKDB_API AggregateFunctionCatalogEntry *Catalog::GetEntry(ClientContext &conte
 template <>
 DUCKDB_API CollateCatalogEntry *Catalog::GetEntry(ClientContext &context, const string &schema_name, const string &name,
                                                   bool if_exists, QueryErrorContext error_context);
+template <>
+DUCKDB_API TypeCatalogEntry *Catalog::GetEntry(ClientContext &context, const string &schema_name, const string &name,
+                                               bool if_exists, QueryErrorContext error_context);
 
 } // namespace duckdb

--- a/src/include/duckdb/catalog/catalog_set.hpp
+++ b/src/include/duckdb/catalog/catalog_set.hpp
@@ -110,6 +110,8 @@ private:
 	void DeleteMapping(ClientContext &context, const string &name);
 	void DropEntryDependencies(ClientContext &context, idx_t entry_index, CatalogEntry &entry, bool cascade);
 
+	void CreateDefaultEntries(ClientContext &context, unique_lock<mutex> &lock);
+
 private:
 	Catalog &catalog;
 	//! The catalog lock is used to make changes to the data

--- a/src/include/duckdb/catalog/catalog_set.hpp
+++ b/src/include/duckdb/catalog/catalog_set.hpp
@@ -110,7 +110,10 @@ private:
 	void DeleteMapping(ClientContext &context, const string &name);
 	void DropEntryDependencies(ClientContext &context, idx_t entry_index, CatalogEntry &entry, bool cascade);
 
+	//! Create all default entries
 	void CreateDefaultEntries(ClientContext &context, unique_lock<mutex> &lock);
+	//! Attempt to create a default entry with the specified name. Returns the entry if successful, nullptr otherwise.
+	CatalogEntry *CreateDefaultEntry(ClientContext &context, const string &name, unique_lock<mutex> &lock);
 
 private:
 	Catalog &catalog;

--- a/src/include/duckdb/catalog/default/default_types.hpp
+++ b/src/include/duckdb/catalog/default/default_types.hpp
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/catalog/default/default_types.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/types.hpp"
+#include "duckdb/catalog/default/default_generator.hpp"
+
+namespace duckdb {
+class SchemaCatalogEntry;
+
+class DefaultTypeGenerator : public DefaultGenerator {
+public:
+	DefaultTypeGenerator(Catalog &catalog, SchemaCatalogEntry *schema);
+
+	SchemaCatalogEntry *schema;
+
+public:
+	DUCKDB_API static LogicalTypeId GetDefaultType(const string &name);
+
+	unique_ptr<CatalogEntry> CreateDefaultEntry(ClientContext &context, const string &entry_name) override;
+	vector<string> GetDefaultEntries() override;
+};
+
+} // namespace duckdb

--- a/src/parser/transform/statement/transform_create_enum.cpp
+++ b/src/parser/transform/statement/transform_create_enum.cpp
@@ -44,6 +44,7 @@ unique_ptr<CreateStatement> Transformer::TransformCreateEnum(duckdb_libpgquery::
 	D_ASSERT(stmt);
 	auto result = make_unique<CreateStatement>();
 	auto info = make_unique<CreateTypeInfo>();
+	info->internal = false;
 	info->name = ReadPgListToString(stmt->typeName)[0];
 	idx_t size = 0;
 	auto ordered_array = ReadPgListToVector(stmt->vals, size);

--- a/src/parser/transform/tableref/transform_join.cpp
+++ b/src/parser/transform/tableref/transform_join.cpp
@@ -30,7 +30,7 @@ unique_ptr<TableRef> Transformer::TransformJoin(duckdb_libpgquery::PGJoinExpr *r
 		break;
 	}
 	default: {
-		throw NotImplementedException("Join type %d not supported yet...\n", root->jointype);
+		throw NotImplementedException("Join type %d not supported\n", root->jointype);
 	}
 	}
 

--- a/src/parser/transform/tableref/transform_tableref.cpp
+++ b/src/parser/transform/tableref/transform_tableref.cpp
@@ -17,7 +17,7 @@ unique_ptr<TableRef> Transformer::TransformTableRefNode(duckdb_libpgquery::PGNod
 	case duckdb_libpgquery::T_PGRangeFunction:
 		return TransformRangeFunction(reinterpret_cast<duckdb_libpgquery::PGRangeFunction *>(n));
 	default:
-		throw NotImplementedException("From Type %d not supported yet...", n->type);
+		throw NotImplementedException("From Type %d not supported", n->type);
 	}
 }
 

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -138,14 +138,8 @@ void Binder::BindLogicalType(ClientContext &context, LogicalType &type, const st
 			type = LogicalType::MAP(child_types);
 		}
 	} else if (type.id() == LogicalTypeId::USER) {
-		auto &user_type_name = UserType::GetTypeName(type);
-		auto user_type_catalog = (TypeCatalogEntry *)context.db->GetCatalog().GetEntry(context, CatalogType::TYPE_ENTRY,
-		                                                                               schema, user_type_name, true);
-		if (!user_type_catalog) {
-			throw NotImplementedException("DataType %s not supported yet...\n", user_type_name);
-		}
-		type = user_type_catalog->user_type;
-		EnumType::SetCatalog(type, user_type_catalog);
+		auto &catalog = Catalog::GetCatalog(context);
+		type = catalog.GetType(context, schema, UserType::GetTypeName(type));
 	} else if (type.id() == LogicalTypeId::ENUM) {
 		auto &enum_type_name = EnumType::GetTypeName(type);
 		auto enum_type_catalog = (TypeCatalogEntry *)context.db->GetCatalog().GetEntry(context, CatalogType::TYPE_ENTRY,

--- a/test/sql/types/enum/test_enum_duckdb_types.test
+++ b/test/sql/types/enum/test_enum_duckdb_types.test
@@ -1,0 +1,23 @@
+# name: test/sql/types/enum/test_enum_duckdb_types.test
+# description: ENUM types in duckdb_types() function
+# group: [enum]
+
+statement ok
+PRAGMA enable_verification
+
+query II
+SELECT type_name, logical_type FROM duckdb_types() WHERE NOT internal
+----
+
+statement ok
+CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');
+
+query I
+select 'happy'::mood;
+----
+happy
+
+query II
+SELECT type_name, logical_type FROM duckdb_types() WHERE NOT internal
+----
+mood	ENUM

--- a/test/sql/types/enum/test_enums_and_built_in_types.test
+++ b/test/sql/types/enum/test_enums_and_built_in_types.test
@@ -1,0 +1,18 @@
+# name: test/sql/types/enum/test_enums_and_built_in_types.test
+# description: ENUM types and built-in types
+# group: [enum]
+
+statement ok
+PRAGMA enable_verification
+
+# use a type that is almost a built-in type
+statement error
+SELECT 4::INTEGEE
+
+# cannot drop built-in types
+statement error
+DROP TYPE "INTEGER"
+
+# cannot create built-in type
+statement error
+CREATE TYPE integer AS ENUM ('1', '2', '3');

--- a/test/sql/types/enum/test_enums_and_built_in_types.test
+++ b/test/sql/types/enum/test_enums_and_built_in_types.test
@@ -2,16 +2,30 @@
 # description: ENUM types and built-in types
 # group: [enum]
 
+load :memory:
+
 statement ok
 PRAGMA enable_verification
+
+statement error
+CREATE TYPE "integer" AS ENUM ('1', '2', '3');
+
+restart
 
 # use a type that is almost a built-in type
 statement error
 SELECT 4::INTEGEE
 
+restart
+
 # cannot drop built-in types
 statement error
 DROP TYPE "INTEGER"
+
+statement error
+DROP TYPE "INTEGEE"
+
+restart
 
 # cannot create built-in type
 statement error


### PR DESCRIPTION
This PR cleans up the way built-in/default types are handled by moving them to a default type generator similar to how default views and default macros are handled. This is generally more structured/nicer from a code perspective, and also allows us to throw clearer errors when incorrect types are used, i.e.:

```sql
SELECT '2022-01-01'::timestampz;
-- Error: Catalog Error: Type with name timestampz does not exist!
-- Did you mean "timestamptz"?
```

Previously we would throw the error `DataType ... not supported yet...` which caused some confusion (e.g. #2976), as it indicated we were planning to add such a type in the future.

This also makes the list of types queryable using `duckdb_types()`:

```sql
D select * from duckdb_types() order by type_oid;
┌─────────────┬────────────┬──────────┬──────────────┬───────────┬──────────────────────────┬───────────────┬──────────┐
│ schema_name │ schema_oid │ type_oid │  type_name   │ type_size │       logical_type       │ type_category │ internal │
├─────────────┼────────────┼──────────┼──────────────┼───────────┼──────────────────────────┼───────────────┼──────────┤
│ main        │ 1          │ 1192     │ int          │ 4         │ INTEGER                  │ NUMERIC       │ true     │
│ main        │ 1          │ 1193     │ int4         │ 4         │ INTEGER                  │ NUMERIC       │ true     │
│ main        │ 1          │ 1194     │ signed       │ 4         │ INTEGER                  │ NUMERIC       │ true     │
│ main        │ 1          │ 1195     │ integer      │ 4         │ INTEGER                  │ NUMERIC       │ true     │
│ main        │ 1          │ 1196     │ integral     │ 4         │ INTEGER                  │ NUMERIC       │ true     │
│ main        │ 1          │ 1197     │ int32        │ 4         │ INTEGER                  │ NUMERIC       │ true     │
│ main        │ 1          │ 1198     │ varchar      │ 16        │ VARCHAR                  │ STRING        │ true     │
│ main        │ 1          │ 1199     │ bpchar       │ 16        │ VARCHAR                  │ STRING        │ true     │
│ main        │ 1          │ 1200     │ text         │ 16        │ VARCHAR                  │ STRING        │ true     │
│ main        │ 1          │ 1201     │ string       │ 16        │ VARCHAR                  │ STRING        │ true     │
│ main        │ 1          │ 1202     │ char         │ 16        │ VARCHAR                  │ STRING        │ true     │
│ main        │ 1          │ 1203     │ nvarchar     │ 16        │ VARCHAR                  │ STRING        │ true     │
│ main        │ 1          │ 1204     │ bytea        │ 16        │ BLOB                     │ NULL          │ true     │
│ main        │ 1          │ 1205     │ blob         │ 16        │ BLOB                     │ NULL          │ true     │
│ main        │ 1          │ 1206     │ varbinary    │ 16        │ BLOB                     │ NULL          │ true     │
│ main        │ 1          │ 1207     │ binary       │ 16        │ BLOB                     │ NULL          │ true     │
│ main        │ 1          │ 1208     │ int8         │ 8         │ BIGINT                   │ NUMERIC       │ true     │
│ main        │ 1          │ 1209     │ bigint       │ 8         │ BIGINT                   │ NUMERIC       │ true     │
│ main        │ 1          │ 1210     │ int64        │ 8         │ BIGINT                   │ NUMERIC       │ true     │
│ main        │ 1          │ 1211     │ long         │ 8         │ BIGINT                   │ NUMERIC       │ true     │
│ main        │ 1          │ 1212     │ oid          │ 8         │ BIGINT                   │ NUMERIC       │ true     │
│ main        │ 1          │ 1213     │ int2         │ 2         │ SMALLINT                 │ NUMERIC       │ true     │
│ main        │ 1          │ 1214     │ smallint     │ 2         │ SMALLINT                 │ NUMERIC       │ true     │
│ main        │ 1          │ 1215     │ short        │ 2         │ SMALLINT                 │ NUMERIC       │ true     │
│ main        │ 1          │ 1216     │ int16        │ 2         │ SMALLINT                 │ NUMERIC       │ true     │
│ main        │ 1          │ 1217     │ timestamp    │ 8         │ TIMESTAMP                │ DATETIME      │ true     │
│ main        │ 1          │ 1218     │ datetime     │ 8         │ TIMESTAMP                │ DATETIME      │ true     │
│ main        │ 1          │ 1219     │ timestamp_us │ 8         │ TIMESTAMP                │ DATETIME      │ true     │
│ main        │ 1          │ 1220     │ timestamp_ms │ 8         │ TIMESTAMP_MS             │ DATETIME      │ true     │
│ main        │ 1          │ 1221     │ timestamp_ns │ 8         │ TIMESTAMP_NS             │ DATETIME      │ true     │
│ main        │ 1          │ 1222     │ timestamp_s  │ 8         │ TIMESTAMP_S              │ DATETIME      │ true     │
│ main        │ 1          │ 1223     │ bool         │ 1         │ BOOLEAN                  │ BOOLEAN       │ true     │
│ main        │ 1          │ 1224     │ boolean      │ 1         │ BOOLEAN                  │ BOOLEAN       │ true     │
│ main        │ 1          │ 1225     │ logical      │ 1         │ BOOLEAN                  │ BOOLEAN       │ true     │
│ main        │ 1          │ 1226     │ decimal      │ NULL      │ DECIMAL                  │ NUMERIC       │ true     │
│ main        │ 1          │ 1227     │ dec          │ NULL      │ DECIMAL                  │ NUMERIC       │ true     │
│ main        │ 1          │ 1228     │ numeric      │ NULL      │ DECIMAL                  │ NUMERIC       │ true     │
│ main        │ 1          │ 1229     │ real         │ 4         │ FLOAT                    │ NUMERIC       │ true     │
│ main        │ 1          │ 1230     │ float4       │ 4         │ FLOAT                    │ NUMERIC       │ true     │
│ main        │ 1          │ 1231     │ float        │ 4         │ FLOAT                    │ NUMERIC       │ true     │
│ main        │ 1          │ 1232     │ double       │ 8         │ DOUBLE                   │ NUMERIC       │ true     │
│ main        │ 1          │ 1233     │ float8       │ 8         │ DOUBLE                   │ NUMERIC       │ true     │
│ main        │ 1          │ 1234     │ tinyint      │ 1         │ TINYINT                  │ NUMERIC       │ true     │
│ main        │ 1          │ 1235     │ int1         │ 1         │ TINYINT                  │ NUMERIC       │ true     │
│ main        │ 1          │ 1236     │ date         │ 4         │ DATE                     │ DATETIME      │ true     │
│ main        │ 1          │ 1237     │ time         │ 8         │ TIME                     │ DATETIME      │ true     │
│ main        │ 1          │ 1238     │ interval     │ 16        │ INTERVAL                 │ DATETIME      │ true     │
│ main        │ 1          │ 1239     │ hugeint      │ 16        │ HUGEINT                  │ NUMERIC       │ true     │
│ main        │ 1          │ 1240     │ int128       │ 16        │ HUGEINT                  │ NUMERIC       │ true     │
│ main        │ 1          │ 1241     │ uuid         │ 16        │ UUID                     │ NULL          │ true     │
│ main        │ 1          │ 1242     │ guid         │ 16        │ UUID                     │ NULL          │ true     │
│ main        │ 1          │ 1243     │ struct       │ 0         │ STRUCT                   │ COMPOSITE     │ true     │
│ main        │ 1          │ 1244     │ row          │ 0         │ STRUCT                   │ COMPOSITE     │ true     │
│ main        │ 1          │ 1245     │ map          │ 0         │ MAP                      │ COMPOSITE     │ true     │
│ main        │ 1          │ 1246     │ utinyint     │ 1         │ UTINYINT                 │ NUMERIC       │ true     │
│ main        │ 1          │ 1247     │ uint8        │ 1         │ UTINYINT                 │ NUMERIC       │ true     │
│ main        │ 1          │ 1248     │ usmallint    │ 2         │ USMALLINT                │ NUMERIC       │ true     │
│ main        │ 1          │ 1249     │ uint16       │ 2         │ USMALLINT                │ NUMERIC       │ true     │
│ main        │ 1          │ 1250     │ uinteger     │ 4         │ UINTEGER                 │ NUMERIC       │ true     │
│ main        │ 1          │ 1251     │ uint32       │ 4         │ UINTEGER                 │ NUMERIC       │ true     │
│ main        │ 1          │ 1252     │ ubigint      │ 8         │ UBIGINT                  │ NUMERIC       │ true     │
│ main        │ 1          │ 1253     │ uint64       │ 8         │ UBIGINT                  │ NUMERIC       │ true     │
│ main        │ 1          │ 1254     │ timestamptz  │ 8         │ TIMESTAMP WITH TIME ZONE │ DATETIME      │ true     │
│ main        │ 1          │ 1255     │ timetz       │ 8         │ TIME WITH TIME ZONE      │ DATETIME      │ true     │
│ main        │ 1          │ 1256     │ json         │ 16        │ JSON                     │ NULL          │ true     │
│ main        │ 1          │ 1257     │ null         │ 4         │ NULL                     │ NULL          │ true     │
└─────────────┴────────────┴──────────┴──────────────┴───────────┴──────────────────────────┴───────────────┴──────────┘
```

This also has the added benefit that enums can no longer be created with default type names, which would not behave as you expect as the default type would always shadow the enum.

```sql
D CREATE TYPE "integer" AS ENUM ('1', '2', '3');
Error: Catalog Error: Type with name "integer" already exists!
```

This will likely cause some merge conflicts for #3599
