### PR TITLE
Avoid running approx quantile with vsize=2

### DIFF
--- a/test/sql/aggregate/aggregates/test_approx_quantile.test
+++ b/test/sql/aggregate/aggregates/test_approx_quantile.test
@@ -2,6 +2,8 @@
 # description: Test approx quantile operator
 # group: [aggregates]
 
+require vector_size 512
+
 statement ok
 PRAGMA enable_verification
 


### PR DESCRIPTION
This test randomly fails the CI when run with vector size = 2

@hawkfish perhaps you can have a look at why this happens when you have time