### PR TITLE
Julia DataFrame Scan Performance Improvements & TPC-H Tests

### DIFF
--- a/.github/workflows/Julia.yml
+++ b/.github/workflows/Julia.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Build DuckDB
         run: |
-            make
+            BUILD_TPCH=1 make
 
       - name: Run Tests
         run: |

--- a/tools/juliapkg/src/data_frame_scan.jl
+++ b/tools/juliapkg/src/data_frame_scan.jl
@@ -2,16 +2,22 @@ using DataFrames
 
 mutable struct DFBindInfo
     df::DataFrame
+    input_columns::Vector
+    scan_types::Vector{Type}
     result_types::Vector{Type}
     scan_functions::Vector{Function}
 
-    function DFBindInfo(df::DataFrame, result_types::Vector{Type}, scan_functions::Vector{Function})
-        return new(df, result_types, scan_functions)
+    function DFBindInfo(df::DataFrame, input_columns::Vector, scan_types::Vector{Type}, result_types::Vector{Type}, scan_functions::Vector{Function})
+        return new(df, input_columns, scan_types, result_types, scan_functions)
     end
 end
 
+function df_input_type(df, entry)
+    return eltype(df[!, entry])
+end
+
 function df_result_type(df, entry)
-    column_type = eltype(df[!, entry])
+    column_type = df_input_type(df, entry)
     if typeof(column_type) == Union
         # remove Missing type from the union
         column_type = Core.Compiler.typesubtract(column_type, Missing, 1)
@@ -47,19 +53,19 @@ function value_to_duckdb(val::T) where {T}
 end
 
 function df_scan_column(
-    df::DataFrame,
+    input_column::Vector{DF_TYPE},
     df_offset::Int64,
     col_idx::Int64,
     result_idx::Int64,
     scan_count::Int64,
     output::DuckDB.DataChunk,
-    ::Type{T}
-) where {T}
-    vector = DuckDB.get_vector(output, result_idx)
-    result_array::Vector{T} = DuckDB.get_array(vector, T)
-    validity = DuckDB.get_validity(vector)
-    input_column = df[!, col_idx]
-    for i in 1:scan_count
+    ::Type{DUCK_TYPE},
+    ::Type{DF_TYPE}
+) where {DUCK_TYPE, DF_TYPE}
+    vector::Vec = DuckDB.get_vector(output, result_idx)
+    result_array::Vector{DUCK_TYPE} = DuckDB.get_array(vector, DUCK_TYPE)
+    validity::ValidityMask = DuckDB.get_validity(vector)
+    for i::Int64 in 1:scan_count
         if input_column[df_offset + i] === missing
             DuckDB.setinvalid(validity, i)
         else
@@ -69,18 +75,18 @@ function df_scan_column(
 end
 
 function df_scan_string_column(
-    df::DataFrame,
+    input_column::Vector{DF_TYPE},
     df_offset::Int64,
     col_idx::Int64,
     result_idx::Int64,
     scan_count::Int64,
     output::DuckDB.DataChunk,
-    ::Type{T}
-) where {T}
-    vector = DuckDB.get_vector(output, result_idx)
-    validity = DuckDB.get_validity(vector)
-    input_column = df[!, col_idx]
-    for i in 1:scan_count
+    ::Type{DUCK_TYPE},
+    ::Type{DF_TYPE}
+) where {DUCK_TYPE, DF_TYPE}
+    vector::Vec = DuckDB.get_vector(output, result_idx)
+    validity::ValidityMask = DuckDB.get_validity(vector)
+    for i::Int64 in 1:scan_count
         if input_column[df_offset + i] === missing
             DuckDB.setinvalid(validity, i)
         else
@@ -106,17 +112,21 @@ function df_bind_function(info::DuckDB.BindInfo)
     df = extra_data[name]
 
     # register the result columns
+    input_columns = Vector()
+    scan_types::Vector{Type} = Vector()
     result_types::Vector{Type} = Vector()
     scan_functions::Vector{Function} = Vector()
     for entry in names(df)
         result_type = df_result_type(df, entry)
         scan_function = df_scan_function(df, entry)
+        push!(input_columns, df[!, entry])
+        push!(scan_types, df_input_type(df, entry))
         push!(result_types, df_julia_type(result_type))
         push!(scan_functions, scan_function)
 
         DuckDB.add_result_column(info, entry, result_type)
     end
-    return DFBindInfo(df, result_types, scan_functions)
+    return DFBindInfo(df, input_columns, scan_types, result_types, scan_functions)
 end
 
 mutable struct DFInitInfo
@@ -137,25 +147,26 @@ function df_scan_function(info::DuckDB.FunctionInfo, output::DuckDB.DataChunk)
     init_info = DuckDB.get_init_info(info, DFInitInfo)
 
     row_count = size(bind_info.df, 1)
-    scan_count = DuckDB.VECTOR_SIZE
+    scan_count::Int64 = DuckDB.VECTOR_SIZE
     if init_info.pos + scan_count >= row_count
         scan_count = row_count - init_info.pos
     end
 
-    result_idx = 1
+    result_idx::Int64 = 1
     for col_idx in init_info.columns
         if col_idx == 0
             result_idx += 1
             continue
         end
         bind_info.scan_functions[col_idx](
-            bind_info.df,
+            bind_info.input_columns[col_idx],
             init_info.pos,
             col_idx,
             result_idx,
             scan_count,
             output,
-            bind_info.result_types[col_idx]
+            bind_info.result_types[col_idx],
+            bind_info.scan_types[col_idx]
         )
         result_idx += 1
     end

--- a/tools/juliapkg/src/data_frame_scan.jl
+++ b/tools/juliapkg/src/data_frame_scan.jl
@@ -7,7 +7,13 @@ mutable struct DFBindInfo
     result_types::Vector{Type}
     scan_functions::Vector{Function}
 
-    function DFBindInfo(df::DataFrame, input_columns::Vector, scan_types::Vector{Type}, result_types::Vector{Type}, scan_functions::Vector{Function})
+    function DFBindInfo(
+        df::DataFrame,
+        input_columns::Vector,
+        scan_types::Vector{Type},
+        result_types::Vector{Type},
+        scan_functions::Vector{Function}
+    )
         return new(df, input_columns, scan_types, result_types, scan_functions)
     end
 end

--- a/tools/juliapkg/src/table_function.jl
+++ b/tools/juliapkg/src/table_function.jl
@@ -134,8 +134,8 @@ function get_init_info(info::FunctionInfo, ::Type{T})::T where {T}
 end
 
 function _table_main_function(info::duckdb_function_info, chunk::duckdb_data_chunk)
-    main_function = unsafe_pointer_to_objref(duckdb_function_get_extra_info(info))
-    binfo = FunctionInfo(info, main_function)
+    main_function::TableFunction = unsafe_pointer_to_objref(duckdb_function_get_extra_info(info))
+    binfo::FunctionInfo = FunctionInfo(info, main_function)
     try
         main_function.main_func(binfo, DataChunk(chunk, false))
     catch ex

--- a/tools/juliapkg/src/validity_mask.jl
+++ b/tools/juliapkg/src/validity_mask.jl
@@ -1,7 +1,7 @@
 """
 DuckDB validity mask
 """
-mutable struct ValidityMask
+struct ValidityMask
     data::Vector{UInt64}
 
     function ValidityMask(data::Vector{UInt64})

--- a/tools/juliapkg/src/vector.jl
+++ b/tools/juliapkg/src/vector.jl
@@ -1,7 +1,7 @@
 """
 DuckDB vector
 """
-mutable struct Vec
+struct Vec
     handle::duckdb_vector
 
     function Vec(handle::duckdb_vector)
@@ -40,6 +40,10 @@ function struct_child(vector::Vec, index::UInt64)::Vec
     return Vec(duckdb_struct_vector_get_child(vector.handle, index))
 end
 
-function assign_string_element(vector::Vec, index, str::AbstractString)
+function assign_string_element(vector::Vec, index::Int64, str::String)
+    return duckdb_vector_assign_string_element_len(vector.handle, index, str, sizeof(str))
+end
+
+function assign_string_element(vector::Vec, index::Int64, str::AbstractString)
     return duckdb_vector_assign_string_element_len(vector.handle, index, str, sizeof(str))
 end

--- a/tools/juliapkg/test.sh
+++ b/tools/juliapkg/test.sh
@@ -2,8 +2,8 @@ set -e
 
 #julia -e "import Pkg; Pkg.activate(\".\"); Pkg.instantiate(); include(\"test/runtests.jl\")" $1
 
-export JULIA_DUCKDB_LIBRARY="`pwd`/../../build/debug/src/libduckdb.dylib"
-#export JULIA_DUCKDB_LIBRARY="/Users/myth/Programs/duckdb-bugfix/build/release/src/libduckdb.dylib"
+#export JULIA_DUCKDB_LIBRARY="`pwd`/../../build/debug/src/libduckdb.dylib"
+export JULIA_DUCKDB_LIBRARY="`pwd`/../../build/release/src/libduckdb.dylib"
 
-export JULIA_NUM_THREADS=4
+export JULIA_NUM_THREADS=1
 julia -e "import Pkg; Pkg.activate(\".\"); include(\"test/runtests.jl\")" $1

--- a/tools/juliapkg/test.sh
+++ b/tools/juliapkg/test.sh
@@ -1,9 +1,9 @@
 set -e
 
-#julia -e "import Pkg; Pkg.activate(\".\"); Pkg.instantiate(); include(\"test/runtests.jl\")" $1
 
-#export JULIA_DUCKDB_LIBRARY="`pwd`/../../build/debug/src/libduckdb.dylib"
-export JULIA_DUCKDB_LIBRARY="`pwd`/../../build/release/src/libduckdb.dylib"
+export JULIA_DUCKDB_LIBRARY="`pwd`/../../build/debug/src/libduckdb.dylib"
+#export JULIA_DUCKDB_LIBRARY="`pwd`/../../build/release/src/libduckdb.dylib"
 
+# memory profiling: --track-allocation=user
 export JULIA_NUM_THREADS=1
 julia -e "import Pkg; Pkg.activate(\".\"); include(\"test/runtests.jl\")" $1

--- a/tools/juliapkg/test/runtests.jl
+++ b/tools/juliapkg/test/runtests.jl
@@ -19,7 +19,8 @@ test_files = [
     "test_old_interface.jl",
     "test_all_types.jl",
     "test_decimals.jl",
-    "test_threading.jl"
+    "test_threading.jl",
+    "test_tpch.jl"
 ]
 
 if size(ARGS)[1] > 0

--- a/tools/juliapkg/test/test_tpch.jl
+++ b/tools/juliapkg/test/test_tpch.jl
@@ -31,20 +31,20 @@
 
     # run all the queries
     for i in 1:22
-#         print("Q$i\n")
+        #         print("Q$i\n")
         # for each query, compare the results of the query ran on the original tables
         # versus the result when run on the Julia DataFrames
         res = DataFrame(DBInterface.execute(df_con, "PRAGMA tpch($i)"))
         res2 = DataFrame(DBInterface.execute(native_con, "PRAGMA tpch($i)"))
         @test isequal(res, res2)
-#         print("Native DuckDB\n")
-#         @time begin
-#             results = DBInterface.execute(native_con, "PRAGMA tpch($i)")
-#         end
-#         print("DataFrame\n")
-#         @time begin
-#             results = DBInterface.execute(df_con, "PRAGMA tpch($i)")
-#         end
+        #         print("Native DuckDB\n")
+        #         @time begin
+        #             results = DBInterface.execute(native_con, "PRAGMA tpch($i)")
+        #         end
+        #         print("DataFrame\n")
+        #         @time begin
+        #             results = DBInterface.execute(df_con, "PRAGMA tpch($i)")
+        #         end
     end
 
     DBInterface.close!(df_con)

--- a/tools/juliapkg/test/test_tpch.jl
+++ b/tools/juliapkg/test/test_tpch.jl
@@ -1,47 +1,52 @@
 # test_tpch.jl
 
 @testset "Test TPC-H" begin
-	sf = "0.01"
+    sf = "0.01"
 
-	# load TPC-H into DuckDB
-    tpch_con = DBInterface.connect(DuckDB.DB)
-	DBInterface.execute(tpch_con, "CALL dbgen(sf=$sf)")
+    # load TPC-H into DuckDB
+    native_con = DBInterface.connect(DuckDB.DB)
+    DBInterface.execute(native_con, "CALL dbgen(sf=$sf)")
 
-	# convert all tables to Julia DataFrames
-	customer = DataFrame(DBInterface.execute(tpch_con, "SELECT * FROM customer"))
-	lineitem = DataFrame(DBInterface.execute(tpch_con, "SELECT * FROM lineitem"))
-	nation   = DataFrame(DBInterface.execute(tpch_con, "SELECT * FROM nation"))
-	orders   = DataFrame(DBInterface.execute(tpch_con, "SELECT * FROM orders"))
-	part     = DataFrame(DBInterface.execute(tpch_con, "SELECT * FROM part"))
-	partsupp = DataFrame(DBInterface.execute(tpch_con, "SELECT * FROM partsupp"))
-	region   = DataFrame(DBInterface.execute(tpch_con, "SELECT * FROM region"))
-	supplier = DataFrame(DBInterface.execute(tpch_con, "SELECT * FROM supplier"))
+    # convert all tables to Julia DataFrames
+    customer = DataFrame(DBInterface.execute(native_con, "SELECT * FROM customer"))
+    lineitem = DataFrame(DBInterface.execute(native_con, "SELECT * FROM lineitem"))
+    nation = DataFrame(DBInterface.execute(native_con, "SELECT * FROM nation"))
+    orders = DataFrame(DBInterface.execute(native_con, "SELECT * FROM orders"))
+    part = DataFrame(DBInterface.execute(native_con, "SELECT * FROM part"))
+    partsupp = DataFrame(DBInterface.execute(native_con, "SELECT * FROM partsupp"))
+    region = DataFrame(DBInterface.execute(native_con, "SELECT * FROM region"))
+    supplier = DataFrame(DBInterface.execute(native_con, "SELECT * FROM supplier"))
 
-	# now open a new in-memory database, and register the dataframes there
-    con = DBInterface.connect(DuckDB.DB)
-	DuckDB.register_data_frame(con, customer, "customer")
-	DuckDB.register_data_frame(con, lineitem, "lineitem")
-	DuckDB.register_data_frame(con, nation, "nation")
-	DuckDB.register_data_frame(con, orders, "orders")
-	DuckDB.register_data_frame(con, part, "part")
-	DuckDB.register_data_frame(con, partsupp, "partsupp")
-	DuckDB.register_data_frame(con, region, "region")
-	DuckDB.register_data_frame(con, supplier, "supplier")
+    # now open a new in-memory database, and register the dataframes there
+    df_con = DBInterface.connect(DuckDB.DB)
+    DuckDB.register_data_frame(df_con, customer, "customer")
+    DuckDB.register_data_frame(df_con, lineitem, "lineitem")
+    DuckDB.register_data_frame(df_con, nation, "nation")
+    DuckDB.register_data_frame(df_con, orders, "orders")
+    DuckDB.register_data_frame(df_con, part, "part")
+    DuckDB.register_data_frame(df_con, partsupp, "partsupp")
+    DuckDB.register_data_frame(df_con, region, "region")
+    DuckDB.register_data_frame(df_con, supplier, "supplier")
     GC.gc()
 
-	# run all the queries
-	for i in 1:22
-		# print("Q$i\n")
-		# for each query, compare the results of the query ran on the original tables
-		# versus the result when run on the Julia DataFrames
-		res = DataFrame(DBInterface.execute(con, "PRAGMA tpch($i)"))
-		res2 = DataFrame(DBInterface.execute(tpch_con, "PRAGMA tpch($i)"))
-		@test isequal(res, res2)
-# 		@time begin
-# 			results = DBInterface.execute(con, "PRAGMA tpch($i)")
-# 		end
-	end
+    # run all the queries
+    for i in 1:22
+#         print("Q$i\n")
+        # for each query, compare the results of the query ran on the original tables
+        # versus the result when run on the Julia DataFrames
+        res = DataFrame(DBInterface.execute(df_con, "PRAGMA tpch($i)"))
+        res2 = DataFrame(DBInterface.execute(native_con, "PRAGMA tpch($i)"))
+        @test isequal(res, res2)
+#         print("Native DuckDB\n")
+#         @time begin
+#             results = DBInterface.execute(native_con, "PRAGMA tpch($i)")
+#         end
+#         print("DataFrame\n")
+#         @time begin
+#             results = DBInterface.execute(df_con, "PRAGMA tpch($i)")
+#         end
+    end
 
-    DBInterface.close!(con)
-    DBInterface.close!(tpch_con)
+    DBInterface.close!(df_con)
+    DBInterface.close!(native_con)
 end

--- a/tools/juliapkg/test/test_tpch.jl
+++ b/tools/juliapkg/test/test_tpch.jl
@@ -1,0 +1,47 @@
+# test_tpch.jl
+
+@testset "Test TPC-H" begin
+	sf = "0.01"
+
+	# load TPC-H into DuckDB
+    tpch_con = DBInterface.connect(DuckDB.DB)
+	DBInterface.execute(tpch_con, "CALL dbgen(sf=$sf)")
+
+	# convert all tables to Julia DataFrames
+	customer = DataFrame(DBInterface.execute(tpch_con, "SELECT * FROM customer"))
+	lineitem = DataFrame(DBInterface.execute(tpch_con, "SELECT * FROM lineitem"))
+	nation   = DataFrame(DBInterface.execute(tpch_con, "SELECT * FROM nation"))
+	orders   = DataFrame(DBInterface.execute(tpch_con, "SELECT * FROM orders"))
+	part     = DataFrame(DBInterface.execute(tpch_con, "SELECT * FROM part"))
+	partsupp = DataFrame(DBInterface.execute(tpch_con, "SELECT * FROM partsupp"))
+	region   = DataFrame(DBInterface.execute(tpch_con, "SELECT * FROM region"))
+	supplier = DataFrame(DBInterface.execute(tpch_con, "SELECT * FROM supplier"))
+
+	# now open a new in-memory database, and register the dataframes there
+    con = DBInterface.connect(DuckDB.DB)
+	DuckDB.register_data_frame(con, customer, "customer")
+	DuckDB.register_data_frame(con, lineitem, "lineitem")
+	DuckDB.register_data_frame(con, nation, "nation")
+	DuckDB.register_data_frame(con, orders, "orders")
+	DuckDB.register_data_frame(con, part, "part")
+	DuckDB.register_data_frame(con, partsupp, "partsupp")
+	DuckDB.register_data_frame(con, region, "region")
+	DuckDB.register_data_frame(con, supplier, "supplier")
+    GC.gc()
+
+	# run all the queries
+	for i in 1:22
+		# print("Q$i\n")
+		# for each query, compare the results of the query ran on the original tables
+		# versus the result when run on the Julia DataFrames
+		res = DataFrame(DBInterface.execute(con, "PRAGMA tpch($i)"))
+		res2 = DataFrame(DBInterface.execute(tpch_con, "PRAGMA tpch($i)"))
+		@test isequal(res, res2)
+# 		@time begin
+# 			results = DBInterface.execute(con, "PRAGMA tpch($i)")
+# 		end
+	end
+
+    DBInterface.close!(con)
+    DBInterface.close!(tpch_con)
+end


### PR DESCRIPTION
This PR improves the performance of the Julia DataFrame scan by adding a number of extra type annotations to improve type stability.  We also add a test that runs the full TPC-H benchmark using both regular DuckDB versus running the benchmark over Julia DataFrames.

As we can see the type stability improvements drastically improve performance. There is still a small performance penalty over using regular DuckDB tables (and Julia DF scans don't support parallelism yet) - but the performance penalty is not extremely significant (i.e. on the order of 10-30% slower, rather than orders of magnitude).

| Query | Native (1T) | Julia DF (New) | Julia DF (Old) |
|-------|--------|----------------|----------------|
| Q01   | 0.23s  | 0.32s          | 2.35s          |
| Q02   | 0.02s  | 0.06s          | 0.34s          |
| Q03   | 0.09s  | 0.13s          | 1.80s          |
| Q04   | 0.08s  | 0.11s          | 1.34s          |
| Q05   | 0.08s  | 0.15s          | 1.72s          |
| Q06   | 0.04s  | 0.04s          | 1.27s          |
| Q07   | 0.13s  | 0.26s          | 2.14s          |
| Q08   | 0.09s  | 0.15s          | 2.15s          |
| Q09   | 1.22s  | 0.98s          | 3.16s          |
| Q10   | 0.13s  | 0.15s          | 1.62s          |
| Q11   | 0.01s  | 0.01s          | 0.30s          |
| Q12   | 0.16s  | 0.19s          | 1.98s          |
| Q13   | 0.12s  | 0.16s          | 0.46s          |
| Q14   | 0.04s  | 0.05s          | 1.45s          |
| Q15   | 0.06s  | 0.09s          | 2.74s          |
| Q16   | 0.03s  | 0.04s          | 0.15s          |
| Q17   | 0.10s  | 0.14s          | 1.78s          |
| Q18   | 0.24s  | 0.60s          | 2.23s          |
| Q19   | 0.19s  | 0.27s          | 1.91s          |
| Q20   | 0.09s  | 0.11s          | 1.52s          |
| Q21   | 0.32s  | 0.44s          | 4.00s          |
| Q22   | 0.02s  | 0.03s          | 0.15s          |