### PR TITLE
to issue#3475 optimize CSG & CMP enumeration of join order optimizer

### DIFF
--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -8,11 +8,11 @@
 
 #pragma once
 
-#include "duckdb/common/common.hpp"
-#include "duckdb/common/types/value.hpp"
-#include "duckdb/common/enums/output_type.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/enums/output_type.hpp"
 #include "duckdb/common/enums/profiler_format.hpp"
+#include "duckdb/common/types/value.hpp"
 
 namespace duckdb {
 class ClientContext;
@@ -51,6 +51,8 @@ struct ClientConfig {
 	bool force_index_join = false;
 	//! Force out-of-core computation for operators that support it, used for testing
 	bool force_external = false;
+	//! Force disable cross product generation when hyper graph isn't connected, used for testing
+	bool force_no_cross_product = false;
 	//! Maximum bits allowed for using a perfect hash table (i.e. the perfect HT can hold up to 2^perfect_ht_threshold
 	//! elements)
 	idx_t perfect_ht_threshold = 12;

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -51,6 +51,15 @@ struct DebugForceExternal {
 	static Value GetSetting(ClientContext &context);
 };
 
+struct DebugForceNoCrossProduct {
+	static constexpr const char *Name = "debug_force_no_cross_product";
+	static constexpr const char *Description =
+	    "DEBUG SETTING: Force disable cross product generation when hyper graph isn't connected, used for testing";
+	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static void SetLocal(ClientContext &context, const Value &parameter);
+	static Value GetSetting(ClientContext &context);
+};
+
 struct DebugManyFreeListBlocks {
 	static constexpr const char *Name = "debug_many_free_list_blocks";
 	static constexpr const char *Description = "DEBUG SETTING: add additional blocks to the free list";

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -26,6 +26,7 @@ static ConfigurationOption internal_options[] = {DUCKDB_GLOBAL(AccessModeSetting
                                                  DUCKDB_GLOBAL(CheckpointThresholdSetting),
                                                  DUCKDB_GLOBAL(DebugCheckpointAbort),
                                                  DUCKDB_LOCAL(DebugForceExternal),
+                                                 DUCKDB_LOCAL(DebugForceNoCrossProduct),
                                                  DUCKDB_GLOBAL(DebugManyFreeListBlocks),
                                                  DUCKDB_GLOBAL(DebugWindowMode),
                                                  DUCKDB_GLOBAL_LOCAL(DefaultCollationSetting),

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -1,15 +1,16 @@
 #include "duckdb/main/settings.hpp"
+
+#include "duckdb/catalog/catalog_search_path.hpp"
 #include "duckdb/common/string_util.hpp"
-#include "duckdb/main/config.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/client_data.hpp"
-#include "duckdb/catalog/catalog_search_path.hpp"
-#include "duckdb/storage/buffer_manager.hpp"
-#include "duckdb/parallel/task_scheduler.hpp"
-#include "duckdb/planner/expression_binder.hpp"
+#include "duckdb/main/config.hpp"
 #include "duckdb/main/query_profiler.hpp"
-#include "duckdb/storage/storage_manager.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/parser/parser.hpp"
+#include "duckdb/planner/expression_binder.hpp"
+#include "duckdb/storage/buffer_manager.hpp"
+#include "duckdb/storage/storage_manager.hpp"
 
 namespace duckdb {
 
@@ -89,6 +90,17 @@ void DebugForceExternal::SetLocal(ClientContext &context, const Value &input) {
 
 Value DebugForceExternal::GetSetting(ClientContext &context) {
 	return Value::BOOLEAN(ClientConfig::GetConfig(context).force_external);
+}
+
+//===--------------------------------------------------------------------===//
+// Debug Force NoCrossProduct
+//===--------------------------------------------------------------------===//
+void DebugForceNoCrossProduct::SetLocal(ClientContext &context, const Value &input) {
+	ClientConfig::GetConfig(context).force_no_cross_product = input.GetValue<bool>();
+}
+
+Value DebugForceNoCrossProduct::GetSetting(ClientContext &context) {
+	return Value::BOOLEAN(ClientConfig::GetConfig(context).force_no_cross_product);
 }
 
 //===--------------------------------------------------------------------===//

--- a/test/optimizer/join_reorder_optimizer.test
+++ b/test/optimizer/join_reorder_optimizer.test
@@ -1,0 +1,67 @@
+# name: test/optimizer/join_reorder_optimizer.test
+# description: Make sure we can emit a vaild join order by DPhyp if hypergraph is connected
+# group: [optimizer]
+
+statement ok
+CREATE TABLE t1(c1 int, c2 int, c3 int, c4 int)
+
+statement ok
+INSERT INTO t1 VALUES (1, 1, 1, 1)
+
+statement ok
+INSERT INTO t1 VALUES (1, 1, 1, 1)
+
+statement ok
+CREATE TABLE t2 AS SELECT * FROM t1
+
+statement ok
+INSERT INTO t2 VALUES (1, 1, 1, 1)
+
+statement ok
+CREATE TABLE t3 AS SELECT * FROM t2
+
+statement ok
+INSERT INTO t2 VALUES (1, 1, 1, 1)
+
+statement ok
+CREATE TABLE t4 AS SELECT * FROM t3
+
+statement ok
+INSERT INTO t2 VALUES (1, 1, 1, 1)
+
+statement ok
+PRAGMA debug_force_no_cross_product=true
+
+statement ok
+EXPLAIN 
+SELECT 
+  COUNT(*) 
+FROM 
+  t1, t2, t3, t4 
+WHERE 
+  t1.c1 = t2.c1 AND 
+  t2.c2 = t3.c2 AND 
+  t3.c3 = t4.c3
+
+statement ok
+EXPLAIN 
+SELECT 
+  COUNT(*) 
+FROM 
+  t1, t2, t3, t4 
+WHERE 
+  t1.c1 = t2.c1 AND 
+  t2.c2 = t3.c2 AND 
+  t3.c3 = t4.c3 AND 
+  t4.c4 = t1.c4
+
+statement ok
+EXPLAIN 
+SELECT 
+  COUNT(*) 
+FROM 
+  t1, t2, t3, t4 
+WHERE 
+  t1.c1 = t2.c1 AND 
+  t2.c2 = t3.c2 AND 
+  t1.c1 + t2.c2 + t3.c3= 3 * t4.c4


### PR DESCRIPTION
In the current implementation of DPhyp, there is some way to optimize join
enumeration:
  1. GetNeighbors(S1, X) function might return some vertex that belongs
     to S1.
  2. exclusion_set only union current neighbor in EnumCsg(Cmp)Rec, for
     example: the neighbors of V1 is V2 and V4, when we try to call
     EnumCsgRec({V1, V2}, {V2}),  we will enum {V1, V2, V4}, but then
     when we call EnumCsgRec({v1, v4}, {v4}), we will enum {V1, V2, V4}
     again.
  3. if S1.count == relations.size(), EmitCsg can return immediately
     because there isn't any available Cmp to connect.

Some include file order is changed by formatter