### PR TITLE
Remove CCache from the OSX Extensions Release build

### DIFF
--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -144,11 +144,6 @@ jobs:
         with:
           python-version: '3.7'
 
-      - name: Setup Ccache
-        uses: hendrikmuhs/ccache-action@main
-        with:
-          key: ${{ github.job }}
-
       - name: Install OpenSSL
         run: |
           mkdir -p build/openssl


### PR DESCRIPTION
This seems to bork the [OpenSSL installation](https://github.com/duckdb/duckdb/runs/6467897543?check_suite_focus=true)