### PR TITLE
Handling dataframes with repeated names in columns outside the bind. Now when registering df for scan.

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/pandas_scan.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pandas_scan.hpp
@@ -11,6 +11,8 @@
 #include "duckdb.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 
+#include "duckdb_python/pybind_wrapper.hpp"
+
 namespace duckdb {
 
 struct PandasScanFunction : public TableFunction {
@@ -53,6 +55,9 @@ public:
 	                                   ParallelState *parallel_state_p);
 
 	static unique_ptr<NodeStatistics> PandasScanCardinality(ClientContext &context, const FunctionData *bind_data);
+
+	// Helper function that transform pandas df names to make them work with our binder
+	static py::object PandasReplaceCopiedNames(const py::object &original_df);
 };
 
 } // namespace duckdb

--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
@@ -84,7 +84,7 @@ public:
 
 	unique_ptr<DuckDBPyRelation> TableFunction(const string &fname, py::object params = py::list());
 
-	unique_ptr<DuckDBPyRelation> FromDF(py::object value);
+	unique_ptr<DuckDBPyRelation> FromDF(const py::object &value);
 
 	unique_ptr<DuckDBPyRelation> FromCsvAuto(const string &filename);
 

--- a/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
@@ -23,10 +23,17 @@ public:
 	explicit PythonDependencies(py::function map_function)
 	    : ExternalDependency(ExternalDependenciesType::PYTHON_DEPENDENCY), map_function(std::move(map_function)) {};
 	explicit PythonDependencies(unique_ptr<RegisteredObject> py_object)
-	    : ExternalDependency(ExternalDependenciesType::PYTHON_DEPENDENCY), py_object(std::move(py_object)) {};
-
+	    : ExternalDependency(ExternalDependenciesType::PYTHON_DEPENDENCY) {
+		py_object_list.push_back(move(py_object));
+	};
+	explicit PythonDependencies(unique_ptr<RegisteredObject> py_object_original,
+	                            unique_ptr<RegisteredObject> py_object_copy)
+	    : ExternalDependency(ExternalDependenciesType::PYTHON_DEPENDENCY) {
+		py_object_list.push_back(move(py_object_original));
+		py_object_list.push_back(move(py_object_copy));
+	};
 	py::function map_function;
-	unique_ptr<RegisteredObject> py_object;
+	vector<unique_ptr<RegisteredObject>> py_object_list;
 };
 
 struct DuckDBPyRelation {

--- a/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
@@ -46,7 +46,7 @@ public:
 public:
 	static void Initialize(py::handle &m);
 
-	static unique_ptr<DuckDBPyRelation> FromDf(py::object df,
+	static unique_ptr<DuckDBPyRelation> FromDf(const py::object &df,
 	                                           DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
 
 	static unique_ptr<DuckDBPyRelation> Values(py::object values = py::list(),
@@ -78,29 +78,29 @@ public:
 
 	unique_ptr<DuckDBPyRelation> Project(const string &expr);
 
-	static unique_ptr<DuckDBPyRelation> ProjectDf(py::object df, const string &expr,
+	static unique_ptr<DuckDBPyRelation> ProjectDf(const py::object &df, const string &expr,
 	                                              DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
 
 	py::str GetAlias();
 
 	unique_ptr<DuckDBPyRelation> SetAlias(const string &expr);
 
-	static unique_ptr<DuckDBPyRelation> AliasDF(py::object df, const string &expr,
+	static unique_ptr<DuckDBPyRelation> AliasDF(const py::object &df, const string &expr,
 	                                            DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
 
 	unique_ptr<DuckDBPyRelation> Filter(const string &expr);
 
-	static unique_ptr<DuckDBPyRelation> FilterDf(py::object df, const string &expr,
+	static unique_ptr<DuckDBPyRelation> FilterDf(const py::object &df, const string &expr,
 	                                             DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
 
 	unique_ptr<DuckDBPyRelation> Limit(int64_t n);
 
-	static unique_ptr<DuckDBPyRelation> LimitDF(py::object df, int64_t n,
+	static unique_ptr<DuckDBPyRelation> LimitDF(const py::object &df, int64_t n,
 	                                            DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
 
 	unique_ptr<DuckDBPyRelation> Order(const string &expr);
 
-	static unique_ptr<DuckDBPyRelation> OrderDf(py::object df, const string &expr,
+	static unique_ptr<DuckDBPyRelation> OrderDf(const py::object &df, const string &expr,
 	                                            DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
 
 	unique_ptr<DuckDBPyRelation> Aggregate(const string &expr, const string &groups = "");
@@ -156,12 +156,12 @@ public:
 	unique_ptr<DuckDBPyRelation> CumMax(const string &aggr_columns);
 	unique_ptr<DuckDBPyRelation> CumMin(const string &aggr_columns);
 
-	static unique_ptr<DuckDBPyRelation> AggregateDF(py::object df, const string &expr, const string &groups = "",
+	static unique_ptr<DuckDBPyRelation> AggregateDF(const py::object &df, const string &expr, const string &groups = "",
 	                                                DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
 
 	unique_ptr<DuckDBPyRelation> Distinct();
 
-	static unique_ptr<DuckDBPyRelation> DistinctDF(py::object df,
+	static unique_ptr<DuckDBPyRelation> DistinctDF(const py::object &df,
 	                                               DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
 
 	py::object ToDF();
@@ -186,7 +186,7 @@ public:
 
 	void WriteCsv(const string &file);
 
-	static void WriteCsvDF(py::object df, const string &file,
+	static void WriteCsvDF(const py::object &df, const string &file,
 	                       DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
 
 	// should this return a rel with the new view?
@@ -196,7 +196,7 @@ public:
 
 	unique_ptr<DuckDBPyResult> Execute();
 
-	static unique_ptr<DuckDBPyResult> QueryDF(py::object df, const string &view_name, const string &sql_query,
+	static unique_ptr<DuckDBPyResult> QueryDF(const py::object &df, const string &view_name, const string &sql_query,
 	                                          DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
 
 	void InsertInto(const string &table);

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -183,16 +183,17 @@ DuckDBPyConnection *DuckDBPyConnection::RegisterPythonObject(const string &name,
 	auto py_object_type = string(py::str(python_object.get_type().attr("__name__")));
 
 	if (py_object_type == "DataFrame") {
+		auto new_df = PandasScanFunction::PandasReplaceCopiedNames(python_object);
 		{
 			py::gil_scoped_release release;
-			temporary_views[name] =
-			    connection->TableFunction("pandas_scan", {Value::POINTER((uintptr_t)python_object.ptr())})
-			        ->CreateView(name, true, true);
+			temporary_views[name] = connection->TableFunction("pandas_scan", {Value::POINTER((uintptr_t)new_df.ptr())})
+			                            ->CreateView(name, true, true);
 		}
 
 		// keep a reference
 		vector<shared_ptr<ExternalDependency>> dependencies;
-		dependencies.push_back(make_shared<PythonDependencies>(make_unique<RegisteredObject>(python_object)));
+		dependencies.push_back(make_shared<PythonDependencies>(make_unique<RegisteredObject>(python_object),
+		                                                       make_unique<RegisteredObject>(new_df)));
 		connection->context->external_dependencies[name] = move(dependencies);
 	} else if (IsAcceptedArrowObject(py_object_type)) {
 		auto stream_factory =
@@ -302,10 +303,12 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromDF(py::object value) {
 		throw std::runtime_error("connection closed");
 	}
 	string name = "df_" + GenerateRandomName();
+	auto new_df = PandasScanFunction::PandasReplaceCopiedNames(value);
 	vector<Value> params;
-	params.emplace_back(Value::POINTER((uintptr_t)value.ptr()));
+	params.emplace_back(Value::POINTER((uintptr_t)new_df.ptr()));
 	auto rel = make_unique<DuckDBPyRelation>(connection->TableFunction("pandas_scan", params)->Alias(name));
-	rel->rel->extra_dependencies = make_unique<PythonDependencies>(make_unique<RegisteredObject>(value));
+	rel->rel->extra_dependencies =
+	    make_unique<PythonDependencies>(make_unique<RegisteredObject>(value), make_unique<RegisteredObject>(new_df));
 	return rel;
 }
 
@@ -499,11 +502,13 @@ TryReplacement(py::dict &dict, py::str &table_name,
 	vector<unique_ptr<ParsedExpression>> children;
 	if (py_object_type == "DataFrame") {
 		string name = "df_" + GenerateRandomName();
-		children.push_back(make_unique<ConstantExpression>(Value::POINTER((uintptr_t)entry.ptr())));
+		auto new_df = PandasScanFunction::PandasReplaceCopiedNames(entry);
+		children.push_back(make_unique<ConstantExpression>(Value::POINTER((uintptr_t)new_df.ptr())));
 		table_function->function = make_unique<FunctionExpression>("pandas_scan", move(children));
 		// keep a reference
 		vector<shared_ptr<ExternalDependency>> external_dependency;
-		auto object = make_shared<PythonDependencies>(make_unique<RegisteredObject>(entry));
+		auto object = make_shared<PythonDependencies>(make_unique<RegisteredObject>(entry),
+		                                              make_unique<RegisteredObject>(new_df));
 		external_dependency.push_back(move(object));
 		registered_objects[name] = move(external_dependency);
 	} else if (DuckDBPyConnection::IsAcceptedArrowObject(py_object_type)) {

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -298,7 +298,7 @@ static std::string GenerateRandomName() {
 	return ss.str();
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromDF(py::object value) {
+unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromDF(const py::object &value) {
 	if (!connection) {
 		throw std::runtime_error("connection closed");
 	}

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -141,8 +141,8 @@ void DuckDBPyRelation::Initialize(py::handle &m) {
 DuckDBPyRelation::DuckDBPyRelation(shared_ptr<Relation> rel) : rel(move(rel)) {
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromDf(py::object df, DuckDBPyConnection *conn) {
-	return conn->FromDF(std::move(df));
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromDf(const py::object &df, DuckDBPyConnection *conn) {
+	return conn->FromDF(df);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Values(py::object values, DuckDBPyConnection *conn) {
@@ -193,8 +193,9 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Project(const string &expr) {
 	return make_unique<DuckDBPyRelation>(rel->Project(expr));
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::ProjectDf(py::object df, const string &expr, DuckDBPyConnection *conn) {
-	return conn->FromDF(std::move(df))->Project(expr);
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::ProjectDf(const py::object &df, const string &expr,
+                                                         DuckDBPyConnection *conn) {
+	return conn->FromDF(df)->Project(expr);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::SetAlias(const string &expr) {
@@ -205,32 +206,35 @@ py::str DuckDBPyRelation::GetAlias() {
 	return py::str(string(rel->GetAlias()));
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::AliasDF(py::object df, const string &expr, DuckDBPyConnection *conn) {
-	return conn->FromDF(std::move(df))->SetAlias(expr);
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::AliasDF(const py::object &df, const string &expr,
+                                                       DuckDBPyConnection *conn) {
+	return conn->FromDF(df)->SetAlias(expr);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Filter(const string &expr) {
 	return make_unique<DuckDBPyRelation>(rel->Filter(expr));
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FilterDf(py::object df, const string &expr, DuckDBPyConnection *conn) {
-	return conn->FromDF(std::move(df))->Filter(expr);
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FilterDf(const py::object &df, const string &expr,
+                                                        DuckDBPyConnection *conn) {
+	return conn->FromDF(df)->Filter(expr);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Limit(int64_t n) {
 	return make_unique<DuckDBPyRelation>(rel->Limit(n));
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::LimitDF(py::object df, int64_t n, DuckDBPyConnection *conn) {
-	return conn->FromDF(std::move(df))->Limit(n);
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::LimitDF(const py::object &df, int64_t n, DuckDBPyConnection *conn) {
+	return conn->FromDF(df)->Limit(n);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Order(const string &expr) {
 	return make_unique<DuckDBPyRelation>(rel->Order(expr));
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::OrderDf(py::object df, const string &expr, DuckDBPyConnection *conn) {
-	return conn->FromDF(std::move(df))->Order(expr);
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::OrderDf(const py::object &df, const string &expr,
+                                                       DuckDBPyConnection *conn) {
+	return conn->FromDF(df)->Order(expr);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Aggregate(const string &expr, const string &groups) {
@@ -391,17 +395,17 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::CumMin(const string &aggr_columns
 	return GenericWindowFunction("min", aggr_columns);
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::AggregateDF(py::object df, const string &expr, const string &groups,
-                                                           DuckDBPyConnection *conn) {
-	return conn->FromDF(std::move(df))->Aggregate(expr, groups);
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::AggregateDF(const py::object &df, const string &expr,
+                                                           const string &groups, DuckDBPyConnection *conn) {
+	return conn->FromDF(df)->Aggregate(expr, groups);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Distinct() {
 	return make_unique<DuckDBPyRelation>(rel->Distinct());
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::DistinctDF(py::object df, DuckDBPyConnection *conn) {
-	return conn->FromDF(std::move(df))->Distinct();
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::DistinctDF(const py::object &df, DuckDBPyConnection *conn) {
+	return conn->FromDF(df)->Distinct();
 }
 
 py::object DuckDBPyRelation::ToDF() {
@@ -495,8 +499,8 @@ void DuckDBPyRelation::WriteCsv(const string &file) {
 	rel->WriteCSV(file);
 }
 
-void DuckDBPyRelation::WriteCsvDF(py::object df, const string &file, DuckDBPyConnection *conn) {
-	return conn->FromDF(std::move(df))->WriteCsv(file);
+void DuckDBPyRelation::WriteCsvDF(const py::object &df, const string &file, DuckDBPyConnection *conn) {
+	return conn->FromDF(df)->WriteCsv(file);
 }
 
 // should this return a rel with the new view?
@@ -529,9 +533,9 @@ unique_ptr<DuckDBPyResult> DuckDBPyRelation::Execute() {
 	return res;
 }
 
-unique_ptr<DuckDBPyResult> DuckDBPyRelation::QueryDF(py::object df, const string &view_name, const string &sql_query,
-                                                     DuckDBPyConnection *conn) {
-	return conn->FromDF(std::move(df))->Query(view_name, sql_query);
+unique_ptr<DuckDBPyResult> DuckDBPyRelation::QueryDF(const py::object &df, const string &view_name,
+                                                     const string &sql_query, DuckDBPyConnection *conn) {
+	return conn->FromDF(df)->Query(view_name, sql_query);
 }
 
 void DuckDBPyRelation::InsertInto(const string &table) {

--- a/tools/pythonpkg/src/vector_conversion.cpp
+++ b/tools/pythonpkg/src/vector_conversion.cpp
@@ -340,10 +340,9 @@ static void ConvertPandasType(const string &col_type, LogicalType &duckdb_col_ty
 	}
 }
 
-void VectorConversion::BindPandas(py::handle original_df, vector<PandasColumnBindData> &bind_columns,
+void VectorConversion::BindPandas(py::handle df, vector<PandasColumnBindData> &bind_columns,
                                   vector<LogicalType> &return_types, vector<string> &names) {
 	// This performs a shallow copy that allows us to rename the dataframe
-	auto df = original_df.attr("copy")(false);
 	auto df_columns = py::list(df.attr("columns"));
 	auto df_types = py::list(df.attr("dtypes"));
 	auto get_fun = df.attr("__getitem__");
@@ -352,29 +351,12 @@ void VectorConversion::BindPandas(py::handle original_df, vector<PandasColumnBin
 	if (py::len(df_columns) == 0 || py::len(df_types) == 0 || py::len(df_columns) != py::len(df_types)) {
 		throw std::runtime_error("Need a DataFrame with at least one column");
 	}
-
-	// check if names in pandas dataframe are unique
-	unordered_map<string, idx_t> pandas_column_names_map;
 	py::array column_attributes = df.attr("columns").attr("values");
-	for (idx_t col_idx = 0; col_idx < py::len(df_columns); col_idx++) {
-		auto column_name_py = py::str(df_columns[col_idx]);
-		pandas_column_names_map[column_name_py]++;
-		if (pandas_column_names_map[column_name_py] > 1) {
-			// If the column name is repeated we start adding _x where x is the repetition number
-			string column_name = column_name_py;
-			column_name += "_" + to_string(pandas_column_names_map[column_name_py] - 1);
-			auto new_column_name_py = py::str(column_name);
-			names.emplace_back(new_column_name_py);
-			column_attributes[py::cast(col_idx)] = new_column_name_py;
-			pandas_column_names_map[new_column_name_py]++;
-		} else {
-			names.emplace_back(column_name_py);
-		}
-	}
 
 	for (idx_t col_idx = 0; col_idx < py::len(df_columns); col_idx++) {
 		LogicalType duckdb_col_type;
 		PandasColumnBindData bind_data;
+		names.emplace_back(py::str(df_columns[col_idx]));
 		auto col_type = string(py::str(df_types[col_idx]));
 		if (col_type == "Int8" || col_type == "Int16" || col_type == "Int32" || col_type == "Int64" ||
 		    col_type == "boolean") {

--- a/tools/pythonpkg/tests/fast/pandas/test_same_name.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_same_name.py
@@ -7,7 +7,6 @@ class TestMultipleColumnsSameName(object):
     def test_multiple_columns_with_same_name(self, duckdb_cursor):
         df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [5, 6, 7, 8], 'd': [9, 10, 11, 12]})
         df = df.rename(columns={ df.columns[1]: "a" })
-        df_original = df.copy(True)
         con = duckdb.connect()
         con.register('df_view', df)
 
@@ -15,7 +14,29 @@ class TestMultipleColumnsSameName(object):
         assert con.execute("select a_1 from df_view;").fetchall() == [(5,), (6,), (7,), (8,)]
         assert con.execute("select a from df_view;").fetchall() == [(1,), (2,), (3,), (4,)]
         # Verify we are not changing original dataframe
-        assert df_original.equals(df)
+        assert all(df.columns == ['a', 'a', 'd']), df.columns
+
+    def test_multiple_columns_with_same_name_relation(self, duckdb_cursor):
+        df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [5, 6, 7, 8], 'd': [9, 10, 11, 12]})
+        df = df.rename(columns={ df.columns[1]: "a" })
+        con = duckdb.connect()
+        rel = con.from_df(df)
+        assert rel.query("df_view","DESCRIBE df_view;").fetchall() == [('a', 'BIGINT', 'YES', None, None, None), ('a_1', 'BIGINT', 'YES', None, None, None), ('d', 'BIGINT', 'YES', None, None, None)]
+
+        assert rel.query("df_view","select a_1 from df_view;").fetchall() == [(5,), (6,), (7,), (8,)]
+        assert rel.query("df_view","select a from df_view;").fetchall() == [(1,), (2,), (3,), (4,)]
+        
+        # Verify we are not changing original dataframe
+        assert all(df.columns == ['a', 'a', 'd']), df.columns
+
+    def test_multiple_columns_with_same_name_replacement_scans(self, duckdb_cursor):
+        df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [5, 6, 7, 8], 'd': [9, 10, 11, 12]})
+        df = df.rename(columns={ df.columns[1]: "a" })
+        con = duckdb.connect()
+        assert con.execute("select a_1 from df;").fetchall() == [(5,), (6,), (7,), (8,)]
+        assert con.execute("select a from df;").fetchall() == [(1,), (2,), (3,), (4,)]
+        # Verify we are not changing original dataframe
+        assert all(df.columns == ['a', 'a', 'd']), df.columns
 
     def test_multiple_columns_with_same_name_2(self, duckdb_cursor):
         df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [5, 6, 7, 8], 'a_1': [9, 10, 11, 12]})
@@ -27,3 +48,4 @@ class TestMultipleColumnsSameName(object):
         assert con.execute("select a from df_view;").fetchall() == [(1,), (2,), (3,), (4,)]
 
         assert con.execute("select a_1_1 from df_view;").fetchall() == [(9,), (10,), (11,), (12,)]
+

--- a/tools/pythonpkg/tests/fast/pandas/test_same_name.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_same_name.py
@@ -38,6 +38,21 @@ class TestMultipleColumnsSameName(object):
         # Verify we are not changing original dataframe
         assert all(df.columns == ['a', 'a', 'd']), df.columns
 
+
+    def test_3669(self, duckdb_cursor):
+        df = pd.DataFrame([(1, 5, 9),
+                    (2, 6, 10),
+                    (3, 7, 11), 
+                    (4, 8, 12)],
+                    columns=['a_1', 'a', 'a'])
+        con = duckdb.connect()
+        con.register('df_view', df)
+        assert con.execute("DESCRIBE df_view;").fetchall() == [('a_1', 'BIGINT', 'YES', None, None, None), ('a', 'BIGINT', 'YES', None, None, None), ('a_2', 'BIGINT', 'YES', None, None, None)]
+        assert con.execute("select a_1 from df_view;").fetchall() == [(1,), (2,), (3,), (4,)] 
+        assert con.execute("select a from df_view;").fetchall() == [(5,), (6,), (7,), (8,)]
+        # Verify we are not changing original dataframe
+        assert all(df.columns == ['a_1', 'a', 'a']), df.columns
+
     def test_multiple_columns_with_same_name_2(self, duckdb_cursor):
         df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [5, 6, 7, 8], 'a_1': [9, 10, 11, 12]})
         df = df.rename(columns={ df.columns[1]: "a_1" })


### PR DESCRIPTION
FIx: #2365
Fix: #3669

@TNonet , you were right thanks for reopening the issue and pointing out a suitable solution.
If possible, double-check the tests are testing what they should be testing now :-).