### PR TITLE
Fix #3690: correctly assign catalog set to default objects to avoid crash when used as dependency

### DIFF
--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -409,6 +409,7 @@ CatalogEntry *CatalogSet::CreateEntryInternal(ClientContext &context, unique_ptr
 	auto entry_index = current_entry++;
 	auto catalog_entry = entry.get();
 
+	entry->set = this;
 	entry->timestamp = 0;
 
 	PutMapping(context, name, entry_index);

--- a/src/catalog/dependency_manager.cpp
+++ b/src/catalog/dependency_manager.cpp
@@ -18,6 +18,9 @@ void DependencyManager::AddObject(ClientContext &context, CatalogEntry *object,
 	for (auto &dependency : dependencies) {
 		idx_t entry_index;
 		CatalogEntry *catalog_entry;
+		if (!dependency->set) {
+			throw InternalException("Dependency has no set");
+		}
 		if (!dependency->set->GetEntryInternal(context, dependency->name, entry_index, catalog_entry)) {
 			throw InternalException("Dependency has already been deleted?");
 		}

--- a/test/sql/catalog/function/information_schema_macro.test
+++ b/test/sql/catalog/function/information_schema_macro.test
@@ -1,0 +1,20 @@
+# name: test/sql/catalog/function/information_schema_macro.test
+# description: Issue #3690: Creating a MACRO in pg_catalog or information_schema causes duckdb to crash
+# group: [function]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create macro information_schema.foo(a) as a;
+
+statement ok
+create table information_schema.integers(i int);
+
+query I
+select information_schema.foo(42)
+----
+42
+
+statement ok
+select * from information_schema.integers


### PR DESCRIPTION
Fixes #3690