### PR TITLE
Compatibility with dev dbplyr

### DIFF
--- a/tools/rpkg/tests/testthat/test_arrow.R
+++ b/tools/rpkg/tests/testthat/test_arrow.R
@@ -279,7 +279,7 @@ test_that("to_duckdb passing a connection", {
   table_four <- ds %>%
     select(int, lgl, dbl) %>%
     to_duckdb(con = con_separate, auto_disconnect = FALSE)
-  table_four_name <- table_four$ops$x
+  table_four_name <- dbplyr::remote_name(table_four)
 
   result <- DBI::dbGetQuery(
     con_separate,


### PR DESCRIPTION
The new dbplyr version changes the internal data structure. This breaks one of the tests in the duckdb R package. This PR fixes the test.
We're planning on submitting dbplyr on June 3.