### PR TITLE
Zero-copy scans for non-list uncompressed segments

### DIFF
--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -82,6 +82,7 @@ idx_t ListColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t co
 	D_ASSERT(!updates);
 
 	idx_t scan_count = ScanVector(state, result, count);
+	D_ASSERT(scan_count > 0);
 	validity.ScanCount(state.child_states[0], result, count);
 
 	auto data = FlatVector::GetData<list_entry_t>(result);


### PR DESCRIPTION
This PR adds support for zero-copy scans of uncompressed segments, which is possible now that we no longer do in-place updates in the storage. There is a minor edge case in the case of lists, as our list scans do in-place modifications to correct offsets, which would result in changes in the storage if we did not make a copy. 