### PR TITLE
Fix #3730: avoid modifying the payload in-place in aggregate hash table, because it might be used multiple times in case of grouping sets

### DIFF
--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -304,29 +304,24 @@ idx_t GroupedAggregateHashTable::AddChunk(DataChunk &groups, Vector &group_hashe
 			// value have not been seen yet
 			idx_t new_group_count =
 			    distinct_hashes[aggr_idx]->FindOrCreateGroups(probe_chunk, dummy_addresses, new_groups);
-
+			if (new_group_count == 0) {
+				continue;
+			}
 			// now fix up the payload and addresses accordingly by creating
 			// a selection vector
-			if (new_group_count > 0) {
-				if (aggr.filter) {
-					Vector distinct_addresses(addresses, new_groups, new_group_count);
-					DataChunk distinct_payload;
-					auto pay_types = payload.GetTypes();
-					distinct_payload.Initialize(pay_types);
-					distinct_payload.Slice(payload, new_groups, new_group_count);
-					distinct_addresses.Verify(new_group_count);
-					distinct_addresses.Normalify(new_group_count);
-					RowOperations::UpdateFilteredStates(aggr, distinct_addresses, distinct_payload, payload_idx);
-				} else {
-					Vector distinct_addresses(addresses, new_groups, new_group_count);
-					for (idx_t i = 0; i < aggr.child_count; i++) {
-						payload.data[payload_idx + i].Slice(new_groups, new_group_count);
-						payload.data[payload_idx + i].Verify(new_group_count);
-					}
-					distinct_addresses.Verify(new_group_count);
+			DataChunk distinct_payload;
+			distinct_payload.Initialize(payload.GetTypes());
+			distinct_payload.Slice(payload, new_groups, new_group_count);
+			distinct_payload.Verify();
 
-					RowOperations::UpdateStates(aggr, distinct_addresses, payload, payload_idx, new_group_count);
-				}
+			Vector distinct_addresses(addresses, new_groups, new_group_count);
+			distinct_addresses.Verify(new_group_count);
+
+			if (aggr.filter) {
+				distinct_addresses.Normalify(new_group_count);
+				RowOperations::UpdateFilteredStates(aggr, distinct_addresses, distinct_payload, payload_idx);
+			} else {
+				RowOperations::UpdateStates(aggr, distinct_addresses, distinct_payload, payload_idx, new_group_count);
 			}
 		} else if (aggr.filter) {
 			RowOperations::UpdateFilteredStates(aggr, addresses, payload, payload_idx);

--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -304,24 +304,24 @@ idx_t GroupedAggregateHashTable::AddChunk(DataChunk &groups, Vector &group_hashe
 			// value have not been seen yet
 			idx_t new_group_count =
 			    distinct_hashes[aggr_idx]->FindOrCreateGroups(probe_chunk, dummy_addresses, new_groups);
-			if (new_group_count == 0) {
-				continue;
-			}
-			// now fix up the payload and addresses accordingly by creating
-			// a selection vector
-			DataChunk distinct_payload;
-			distinct_payload.Initialize(payload.GetTypes());
-			distinct_payload.Slice(payload, new_groups, new_group_count);
-			distinct_payload.Verify();
+			if (new_group_count > 0) {
+				// now fix up the payload and addresses accordingly by creating
+				// a selection vector
+				DataChunk distinct_payload;
+				distinct_payload.Initialize(payload.GetTypes());
+				distinct_payload.Slice(payload, new_groups, new_group_count);
+				distinct_payload.Verify();
 
-			Vector distinct_addresses(addresses, new_groups, new_group_count);
-			distinct_addresses.Verify(new_group_count);
+				Vector distinct_addresses(addresses, new_groups, new_group_count);
+				distinct_addresses.Verify(new_group_count);
 
-			if (aggr.filter) {
-				distinct_addresses.Normalify(new_group_count);
-				RowOperations::UpdateFilteredStates(aggr, distinct_addresses, distinct_payload, payload_idx);
-			} else {
-				RowOperations::UpdateStates(aggr, distinct_addresses, distinct_payload, payload_idx, new_group_count);
+				if (aggr.filter) {
+					distinct_addresses.Normalify(new_group_count);
+					RowOperations::UpdateFilteredStates(aggr, distinct_addresses, distinct_payload, payload_idx);
+				} else {
+					RowOperations::UpdateStates(aggr, distinct_addresses, distinct_payload, payload_idx,
+					                            new_group_count);
+				}
 			}
 		} else if (aggr.filter) {
 			RowOperations::UpdateFilteredStates(aggr, addresses, payload, payload_idx);

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -161,6 +161,7 @@ SinkResultType PhysicalHashAggregate::Sink(ExecutionContext &context, GlobalSink
 		for (auto &child_expr : aggr.children) {
 			D_ASSERT(child_expr->type == ExpressionType::BOUND_REF);
 			auto &bound_ref_expr = (BoundReferenceExpression &)*child_expr;
+			D_ASSERT(bound_ref_expr.index < input.data.size());
 			aggregate_input_chunk.data[aggregate_input_idx++].Reference(input.data[bound_ref_expr.index]);
 		}
 	}
@@ -169,6 +170,7 @@ SinkResultType PhysicalHashAggregate::Sink(ExecutionContext &context, GlobalSink
 		if (aggr.filter) {
 			auto it = filter_indexes.find(aggr.filter.get());
 			D_ASSERT(it != filter_indexes.end());
+			D_ASSERT(it->second < input.data.size());
 			aggregate_input_chunk.data[aggregate_input_idx++].Reference(input.data[it->second]);
 		}
 	}

--- a/test/sql/aggregate/grouping_sets/issue_3730.test
+++ b/test/sql/aggregate/grouping_sets/issue_3730.test
@@ -1,0 +1,50 @@
+# name: test/sql/aggregate/grouping_sets/issue_3730.test
+# description: Issue #3730: Segmentation fault on GROUP BY when using ROLLUP/CUBE + COUNT DISTINCT on Parquet
+# group: [grouping_sets]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE response(id BIGINT, response VARCHAR);;
+
+statement ok
+INSERT INTO response VALUES(1,'yes');
+
+statement ok
+INSERT INTO response VALUES(1,'no');
+
+statement ok
+INSERT INTO response VALUES(1,'yes');
+
+statement ok
+INSERT INTO response VALUES(2,'no');
+
+statement ok
+INSERT INTO response VALUES(2,'no');
+
+
+statement ok
+CREATE TABLE user_pq(id BIGINT, "name" VARCHAR);;
+
+statement ok
+INSERT INTO user_pq VALUES(1,'alice');
+
+statement ok
+INSERT INTO user_pq VALUES(2,'bob');
+
+query III
+SELECT id, response, COUNT(DISTINCT id)
+FROM user_pq
+JOIN response USING (id)
+GROUP BY CUBE (id, response)
+ORDER BY 1 NULLS LAST, 2 NULLS LAST, 3 NULLS LAST
+----
+1	no	1
+1	yes	1
+1	NULL	1
+2	no	1
+2	NULL	1
+NULL	no	2
+NULL	yes	1
+NULL	NULL	2


### PR DESCRIPTION
Fixes #3730 