### PR TITLE
Arrow/Pandas Case Insensitive Columns

### DIFF
--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -174,6 +174,29 @@ LogicalType GetArrowLogicalType(ArrowSchema &schema,
 	}
 }
 
+// Renames repeated columns and case sensitive columns
+void RenameArrowColumns(vector<string> &names) {
+	unordered_map<string, idx_t> name_map;
+	for (auto &column_name : names) {
+		// put it all lower_case
+		column_name = StringUtil::Lower(column_name);
+		if (name_map.find(column_name) == name_map.end()) {
+			// Name does not exist yet
+			name_map[column_name]++;
+		} else {
+			// Name already exists, we add _x where x is the repetition number
+			string new_column_name = column_name + "_" + std::to_string(name_map[column_name]);
+			while (name_map.find(new_column_name) != name_map.end()) {
+				// This name is already here due to a previous definition
+				name_map[column_name]++;
+				new_column_name = column_name + "_" + std::to_string(name_map[column_name]);
+			}
+			column_name = new_column_name;
+			name_map[new_column_name]++;
+		}
+	}
+}
+
 unique_ptr<FunctionData> ArrowTableFunction::ArrowScanBind(ClientContext &context, TableFunctionBindInput &input,
                                                            vector<LogicalType> &return_types, vector<string> &names) {
 	typedef unique_ptr<ArrowArrayStreamWrapper> (*stream_factory_produce_t)(
@@ -217,6 +240,7 @@ unique_ptr<FunctionData> ArrowTableFunction::ArrowScanBind(ClientContext &contex
 		}
 		names.push_back(name);
 	}
+	RenameArrowColumns(names);
 	return move(res);
 }
 

--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -179,20 +179,22 @@ void RenameArrowColumns(vector<string> &names) {
 	unordered_map<string, idx_t> name_map;
 	for (auto &column_name : names) {
 		// put it all lower_case
-		column_name = StringUtil::Lower(column_name);
-		if (name_map.find(column_name) == name_map.end()) {
+		auto low_column_name = StringUtil::Lower(column_name);
+		if (name_map.find(low_column_name) == name_map.end()) {
 			// Name does not exist yet
-			name_map[column_name]++;
+			name_map[low_column_name]++;
 		} else {
 			// Name already exists, we add _x where x is the repetition number
-			string new_column_name = column_name + "_" + std::to_string(name_map[column_name]);
-			while (name_map.find(new_column_name) != name_map.end()) {
+			string new_column_name = column_name + "_" + std::to_string(name_map[low_column_name]);
+			auto new_column_name_low = StringUtil::Lower(new_column_name);
+			while (name_map.find(new_column_name_low) != name_map.end()) {
 				// This name is already here due to a previous definition
-				name_map[column_name]++;
-				new_column_name = column_name + "_" + std::to_string(name_map[column_name]);
+				name_map[low_column_name]++;
+				new_column_name = column_name + "_" + std::to_string(name_map[low_column_name]);
+				new_column_name_low = StringUtil::Lower(new_column_name);
 			}
 			column_name = new_column_name;
-			name_map[new_column_name]++;
+			name_map[new_column_name_low]++;
 		}
 	}
 }

--- a/tools/pythonpkg/src/pandas_scan.cpp
+++ b/tools/pythonpkg/src/pandas_scan.cpp
@@ -182,7 +182,9 @@ py::object PandasScanFunction::PandasReplaceCopiedNames(const py::object &origin
 	auto df_columns = py::list(original_df.attr("columns"));
 
 	for (auto &column_name_py : df_columns) {
-		const string column_name = py::str(column_name_py);
+		string column_name = py::str(column_name_py);
+		// put it all lower_case
+		column_name = StringUtil::Lower(column_name);
 		if (name_map.find(column_name) == name_map.end()) {
 			// Name does not exist yet
 			column_name_list.append(column_name);

--- a/tools/pythonpkg/src/pandas_scan.cpp
+++ b/tools/pythonpkg/src/pandas_scan.cpp
@@ -197,27 +197,30 @@ py::object PandasScanFunction::PandasReplaceCopiedNames(const py::object &origin
 	for (auto &column_name_py : df_columns) {
 		string column_name = py::str(column_name_py);
 		// put it all lower_case
-		column_name = StringUtil::Lower(column_name);
-		name_map[column_name] = 1;
+		auto column_name_low = StringUtil::Lower(column_name);
+		name_map[column_name_low] = 1;
 	}
 	for (auto &column_name_py : df_columns) {
 		const string column_name = py::str(column_name_py);
-		if (columns_seen.find(column_name) == columns_seen.end()) {
+		auto column_name_low = StringUtil::Lower(column_name);
+		if (columns_seen.find(column_name_low) == columns_seen.end()) {
 			// `column_name` has not been seen before -> It isn't a duplicate
 			column_name_list.append(column_name);
-			columns_seen.insert(column_name);
+			columns_seen.insert(column_name_low);
 		} else {
 			// `column_name` already seen. Deduplicate by with suffix _{x} where x starts at the repetition number of
 			// `column_name` If `column_name_{x}` already exists in `name_map`, increment x and try again.
-			string new_column_name = column_name + "_" + std::to_string(name_map[column_name]);
-			while (name_map.find(new_column_name) != name_map.end()) {
+			string new_column_name = column_name + "_" + std::to_string(name_map[column_name_low]);
+			auto new_column_name_low = StringUtil::Lower(new_column_name);
+			while (name_map.find(new_column_name_low) != name_map.end()) {
 				// This name is already here due to a previous definition
-				name_map[column_name]++;
-				new_column_name = column_name + "_" + std::to_string(name_map[column_name]);
+				name_map[column_name_low]++;
+				new_column_name = column_name + "_" + std::to_string(name_map[column_name_low]);
+				new_column_name_low = StringUtil::Lower(new_column_name);
 			}
 			column_name_list.append(new_column_name);
-			columns_seen.insert(new_column_name);
-			name_map[new_column_name]++;
+			columns_seen.insert(new_column_name_low);
+			name_map[column_name_low]++;
 		}
 	}
 

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_case_sensitive.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_case_sensitive.py
@@ -15,8 +15,20 @@ class TestArrowCaseSensitive(object):
 
         con = duckdb.connect()
         con.register('arrow_tbl', arrow_table)
-
-        assert con.execute("DESCRIBE arrow_tbl;").fetchall() == [('a1', 'INTEGER', 'YES', None, None, None), ('a1_1', 'INTEGER', 'YES', None, None, None)]
-        assert con.execute("select a1 from arrow_tbl;").fetchall() == [(1,)]
+        print (con.execute("DESCRIBE arrow_tbl;").fetchall())
+        assert con.execute("DESCRIBE arrow_tbl;").fetchall() == [('A1', 'INTEGER', 'YES', None, None, None), ('a1_1', 'INTEGER', 'YES', None, None, None)]
+        assert con.execute("select A1 from arrow_tbl;").fetchall() == [(1,)]
         assert con.execute("select a1_1 from arrow_tbl;").fetchall() == [(1000,)]
         assert arrow_table.column_names == ['A1', 'a1']
+
+    def test_arrow_case_sensitive_repeated(self, duckdb_cursor):
+        if not can_run:
+            return
+        data = (pa.array([1], type=pa.int32()),pa.array([1000], type=pa.int32()))
+        arrow_table = pa.Table.from_arrays([data[0],data[1],data[1]],['A1','a1_1','a1'])
+
+        con = duckdb.connect()
+        con.register('arrow_tbl', arrow_table)
+        print (con.execute("DESCRIBE arrow_tbl;").fetchall())
+        assert con.execute("DESCRIBE arrow_tbl;").fetchall() == [('A1', 'INTEGER', 'YES', None, None, None), ('a1_1', 'INTEGER', 'YES', None, None, None), ('a1_2', 'INTEGER', 'YES', None, None, None)]
+        assert arrow_table.column_names == ['A1','a1_1','a1']

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_case_sensitive.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_case_sensitive.py
@@ -1,0 +1,22 @@
+import duckdb
+import pytest
+try:
+    import pyarrow as pa
+    can_run = True
+except:
+    can_run = False
+
+class TestArrowCaseSensitive(object):
+    def test_arrow_case_sensitive(self, duckdb_cursor):
+        if not can_run:
+            return
+        data = (pa.array([1], type=pa.int32()),pa.array([1000], type=pa.int32()))
+        arrow_table = pa.Table.from_arrays([data[0],data[1]],['A1','a1'])
+
+        con = duckdb.connect()
+        con.register('arrow_tbl', arrow_table)
+
+        assert con.execute("DESCRIBE arrow_tbl;").fetchall() == [('a1', 'INTEGER', 'YES', None, None, None), ('a1_1', 'INTEGER', 'YES', None, None, None)]
+        assert con.execute("select a1 from arrow_tbl;").fetchall() == [(1,)]
+        assert con.execute("select a1_1 from arrow_tbl;").fetchall() == [(1000,)]
+        assert arrow_table.column_names == ['A1', 'a1']

--- a/tools/pythonpkg/tests/fast/pandas/test_same_name.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_same_name.py
@@ -3,7 +3,6 @@ import duckdb
 import pandas as pd
 
 class TestMultipleColumnsSameName(object):
-
     def test_multiple_columns_with_same_name(self, duckdb_cursor):
         df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [5, 6, 7, 8], 'd': [9, 10, 11, 12]})
         df = df.rename(columns={ df.columns[1]: "a" })
@@ -64,3 +63,10 @@ class TestMultipleColumnsSameName(object):
 
         assert con.execute("select a_1_1 from df_view;").fetchall() == [(9,), (10,), (11,), (12,)]
 
+    def test_case_insensitive(self, duckdb_cursor):
+        df = pd.DataFrame({'A_1': [1, 2, 3, 4],  'a_1': [9, 10, 11, 12]})
+        con = duckdb.connect()
+        con.register('df_view', df)
+        assert con.execute("DESCRIBE df_view;").fetchall() == [('a_1', 'BIGINT', 'YES', None, None, None), ('a_1_1', 'BIGINT', 'YES', None, None, None)]
+        assert con.execute("select a_1 from df_view;").fetchall() == [(1,), (2,), (3,), (4,)]
+        assert con.execute("select a_1_1 from df_view;").fetchall() == [(9,), (10,), (11,), (12,)]

--- a/tools/pythonpkg/tests/fast/pandas/test_same_name.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_same_name.py
@@ -86,6 +86,6 @@ class TestMultipleColumnsSameName(object):
         df = pd.DataFrame({'A_1': [1, 2, 3, 4],  'a_1': [9, 10, 11, 12]})
         con = duckdb.connect()
         con.register('df_view', df)
-        assert con.execute("DESCRIBE df_view;").fetchall() == [('a_1', 'BIGINT', 'YES', None, None, None), ('a_1_1', 'BIGINT', 'YES', None, None, None)]
+        assert con.execute("DESCRIBE df_view;").fetchall() == [('A_1', 'BIGINT', 'YES', None, None, None), ('a_1_1', 'BIGINT', 'YES', None, None, None)]
         assert con.execute("select a_1 from df_view;").fetchall() == [(1,), (2,), (3,), (4,)]
         assert con.execute("select a_1_1 from df_view;").fetchall() == [(9,), (10,), (11,), (12,)]


### PR DESCRIPTION
Arrow and Pandas both accept case-sensitive column names but duckdb doesn't, hence we rename columns as they were repeated.

Fix: #3686 