### PR TITLE
 Check if replacement scans don't leak memory

### DIFF
--- a/tools/pythonpkg/tests/fast/test_relation_dependency_leak.py
+++ b/tools/pythonpkg/tests/fast/test_relation_dependency_leak.py
@@ -30,11 +30,11 @@ def from_arrow():
 def arrow_replacement():
     data = pa.array(np.random.rand(1_000_000), type=pa.float32())
     arrow_table = pa.Table.from_arrays([data],['a'])
-    duckdb.query("select * from arrow_table")
+    duckdb.query("select sum(a) from arrow_table").fetchall()
 
 def pandas_replacement():
     df = pd.DataFrame({"x": np.random.rand(1_000_000)})
-    duckdb.query("select * from df")
+    duckdb.query("select sum(x) from df").fetchall()
 
 
 class TestRelationDependencyMemoryLeak(object):

--- a/tools/pythonpkg/tests/fast/test_relation_dependency_leak.py
+++ b/tools/pythonpkg/tests/fast/test_relation_dependency_leak.py
@@ -27,6 +27,16 @@ def from_arrow():
     arrow_table = pa.Table.from_arrays([data],['a'])
     duckdb.from_arrow(arrow_table)
 
+def arrow_replacement():
+    data = pa.array(np.random.rand(1_000_000), type=pa.float32())
+    arrow_table = pa.Table.from_arrays([data],['a'])
+    duckdb.query("select * from arrow_table")
+
+def pandas_replacement():
+    df = pd.DataFrame({"x": np.random.rand(1_000_000)})
+    duckdb.query("select * from df")
+
+
 class TestRelationDependencyMemoryLeak(object):
     def test_from_arrow_leak(self, duckdb_cursor):
         if not can_run:
@@ -35,6 +45,14 @@ class TestRelationDependencyMemoryLeak(object):
 
     def test_from_df_leak(self, duckdb_cursor):
         check_memory(from_df)
+
+    def test_arrow_replacement_scan_leak(self, duckdb_cursor):
+        if not can_run:
+            return
+        check_memory(arrow_replacement)
+
+    def test_pandas_replacement_scan_leak(self, duckdb_cursor):
+        check_memory(pandas_replacement)
 
     def test_relation_view_leak(self, duckdb_cursor):
         rel = from_df()


### PR DESCRIPTION
Test case for reopened :
fix: #3144

Hi @cebaa, I've added test cases to check if replacement scans of both Arrow and Pandas objects leak any memory, it seems to be fine.

Can you check how this differs from the case where you experienced memory leaks?