### PR TITLE
Fix #3756: fix issue when running blockwise NL join on dictionary vectors of structs

### DIFF
--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1131,7 +1131,6 @@ const SelectionVector *ConstantVector::ZeroSelectionVector(idx_t count, Selectio
 }
 
 void ConstantVector::Reference(Vector &vector, Vector &source, idx_t position, idx_t count) {
-	D_ASSERT(position < count);
 	auto &source_type = source.GetType();
 	switch (source_type.InternalType()) {
 	case PhysicalType::LIST: {
@@ -1179,7 +1178,7 @@ void ConstantVector::Reference(Vector &vector, Vector &source, idx_t position, i
 		auto &source_entries = StructVector::GetEntries(source);
 		auto &target_entries = StructVector::GetEntries(vector);
 		for (idx_t i = 0; i < source_entries.size(); i++) {
-			ConstantVector::Reference(*target_entries[i], *source_entries[i], position, count);
+			ConstantVector::Reference(*target_entries[i], *source_entries[i], struct_index, count);
 		}
 		vector.SetVectorType(VectorType::CONSTANT_VECTOR);
 		break;

--- a/src/common/vector_operations/vector_hash.cpp
+++ b/src/common/vector_operations/vector_hash.cpp
@@ -63,6 +63,7 @@ static inline void TemplatedLoopHash(Vector &input, Vector &result, const Select
 
 template <bool HAS_RSEL, bool FIRST_HASH>
 static inline void StructLoopHash(Vector &input, Vector &hashes, const SelectionVector *rsel, idx_t count) {
+	input.Normalify(count);
 	auto &children = StructVector::GetEntries(input);
 
 	D_ASSERT(!children.empty());

--- a/test/sql/join/test_complex_join_structs.test
+++ b/test/sql/join/test_complex_join_structs.test
@@ -1,0 +1,149 @@
+# name: test/sql/join/test_complex_join_structs.test
+# description: Test complex joins and count distincts with structs
+# group: [join]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE structs AS SELECT i id, {'i': i} s, i%3 j FROM generate_series(0,99,1) tbl(i), generate_series(0,1,1);
+
+statement ok
+CREATE TABLE other_table AS SELECT i id, i%3 j FROM generate_series(0,99,1) tbl(i) WHERE i%2=0;
+
+# count distinct
+query IIII
+SELECT COUNT(*), COUNT(s), COUNT(DISTINCT s), COUNT(DISTINCT structs.id) FROM structs;
+----
+200	200	100	100
+
+#count distinct with a filter
+query IIII
+SELECT COUNT(*), COUNT(s), COUNT(DISTINCT s), COUNT(DISTINCT structs.id) FROM structs WHERE id%2<>0;
+----
+100	100	50	50
+
+# count distinct with a join
+query IIII
+SELECT COUNT(*), COUNT(s), COUNT(DISTINCT s), COUNT(DISTINCT structs.id) FROM structs JOIN other_table USING (id);
+----
+100	100	50	50
+
+query IIII
+SELECT COUNT(*), COUNT(s), COUNT(DISTINCT s), COUNT(DISTINCT structs.id) FROM structs LEFT JOIN other_table USING (id);
+----
+200	200	100	100
+
+# count distinct with a complex join condition
+query IIIII
+SELECT structs.j, COUNT(*), COUNT(s), COUNT(DISTINCT s), COUNT(DISTINCT structs.id)
+FROM structs
+LEFT JOIN other_table o1 USING (id)
+CROSS JOIN other_table
+WHERE ((structs.j IN (0, 1) AND (structs.id=other_table.id)) OR (structs.j=2 AND structs.id+1=other_table.id))
+GROUP BY ALL
+ORDER BY ALL
+----
+0	34	34	17	17
+1	32	32	16	16
+2	32	32	16	16
+
+# now with lists
+statement ok
+DROP TABLE structs;
+
+statement ok
+DROP TABLE other_table
+
+statement ok
+CREATE TABLE structs AS SELECT i id, {'i': [i, i + 1, i + 2], 'j': CASE WHEN i%4=1 THEN NULL ELSE [i, i] END} s, i%3 j FROM generate_series(0,99,1) tbl(i), generate_series(0,1,1);
+
+statement ok
+CREATE TABLE other_table AS SELECT i id, i%3 j FROM generate_series(0,99,1) tbl(i) WHERE i%2=0;
+
+# count distinct
+query IIII
+SELECT COUNT(*), COUNT(s), COUNT(DISTINCT s), COUNT(DISTINCT structs.id) FROM structs;
+----
+200	200	100	100
+
+#count distinct with a filter
+query IIII
+SELECT COUNT(*), COUNT(s), COUNT(DISTINCT s), COUNT(DISTINCT structs.id) FROM structs WHERE id%2<>0;
+----
+100	100	50	50
+
+# count distinct with a join
+query IIII
+SELECT COUNT(*), COUNT(s), COUNT(DISTINCT s), COUNT(DISTINCT structs.id) FROM structs JOIN other_table USING (id);
+----
+100	100	50	50
+
+query IIII
+SELECT COUNT(*), COUNT(s), COUNT(DISTINCT s), COUNT(DISTINCT structs.id) FROM structs LEFT JOIN other_table USING (id);
+----
+200	200	100	100
+
+# count distinct with a complex join condition
+query IIIII
+SELECT structs.j, COUNT(*), COUNT(s), COUNT(DISTINCT s), COUNT(DISTINCT structs.id)
+FROM structs
+LEFT JOIN other_table o1 USING (id)
+CROSS JOIN other_table
+WHERE ((structs.j IN (0, 1) AND (structs.id=other_table.id)) OR (structs.j=2 AND structs.id+1=other_table.id))
+GROUP BY ALL
+ORDER BY ALL
+----
+0	34	34	17	17
+1	32	32	16	16
+2	32	32	16	16
+
+# more complex nested structs
+statement ok
+DROP TABLE structs;
+
+statement ok
+DROP TABLE other_table
+
+statement ok
+CREATE TABLE structs AS SELECT i id, {'i': {'j': [i + 1, i + 2, i + 3], 'k': i}, 'l': NULL} s, i%3 j FROM generate_series(0,99,1) tbl(i), generate_series(0,1,1);
+
+statement ok
+CREATE TABLE other_table AS SELECT i id, i%3 j FROM generate_series(0,99,1) tbl(i) WHERE i%2=0;
+
+# count distinct
+query IIII
+SELECT COUNT(*), COUNT(s), COUNT(DISTINCT s), COUNT(DISTINCT structs.id) FROM structs;
+----
+200	200	100	100
+
+#count distinct with a filter
+query IIII
+SELECT COUNT(*), COUNT(s), COUNT(DISTINCT s), COUNT(DISTINCT structs.id) FROM structs WHERE id%2<>0;
+----
+100	100	50	50
+
+# count distinct with a join
+query IIII
+SELECT COUNT(*), COUNT(s), COUNT(DISTINCT s), COUNT(DISTINCT structs.id) FROM structs JOIN other_table USING (id);
+----
+100	100	50	50
+
+query IIII
+SELECT COUNT(*), COUNT(s), COUNT(DISTINCT s), COUNT(DISTINCT structs.id) FROM structs LEFT JOIN other_table USING (id);
+----
+200	200	100	100
+
+# count distinct with a complex join condition
+query IIIII
+SELECT structs.j, COUNT(*), COUNT(s), COUNT(DISTINCT s), COUNT(DISTINCT structs.id)
+FROM structs
+LEFT JOIN other_table o1 USING (id)
+CROSS JOIN other_table
+WHERE ((structs.j IN (0, 1) AND (structs.id=other_table.id)) OR (structs.j=2 AND structs.id+1=other_table.id))
+GROUP BY ALL
+ORDER BY ALL
+----
+0	34	34	17	17
+1	32	32	16	16
+2	32	32	16	16


### PR DESCRIPTION
Fixes #3756 

The problem was caused by an incorrect index being used in the `ConstantVector::Reference` method when used with a struct type. This method was called in the `Blockwise NL join`, which is the join type that is used when there are no straightforward comparison join expressions available, and a complex join expressions has to be used (e.g. an `OR` clause or other complex expressions).