### PR TITLE
Fix .import not creating missing table in CLI

### DIFF
--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -51,6 +51,16 @@ test('select \'asdf\' as a;', out='asdf')
 
 test('select * from range(10000);', out='9999')
 
+import_basic_csv_table = tf()
+print("col_1,col_2\n1,2\n10,20",  file=open(import_basic_csv_table, 'w'))
+# test create missing table with import
+test("""
+.mode csv
+.import "%s" test_table
+SELECT * FROM test_table;
+""" % import_basic_csv_table, out="col_1,col_2\n1,2\n10,20"
+)
+
 # test pragma
 test("""
 .mode csv

--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -17853,7 +17853,7 @@ static int do_meta_command(char *zLine, ShellState *p){
     nByte = strlen30(zSql);
     rc = sqlite3_prepare_v2(p->db, zSql, -1, &pStmt, 0);
     import_append_char(&sCtx, 0);    /* To ensure sCtx.z is allocated */
-    if( rc && sqlite3_strglob("no such table: *", sqlite3_errmsg(p->db))==0 ){
+    if( rc && sqlite3_strglob("Catalog Error: Table with name *", sqlite3_errmsg(p->db))==0 ){
       char *zCreate = sqlite3_mprintf("CREATE TABLE %s", zTable);
       char cSep = '(';
       while( xRead(&sCtx) ){


### PR DESCRIPTION
This PR fixes the issue described in #3713 

The problem was that it's looking for a specific error message to detect this issue, and it now looks for the "correct" error message, for now.

I could see this breaking with a change in the future, probably needs a better solution than this one.