### PR TITLE
Expose dbgen speed_seed functions on header file and add missing ones

### DIFF
--- a/extension/tpch/dbgen/include/dbgen/dsstypes.h
+++ b/extension/tpch/dbgen/include/dbgen/dsstypes.h
@@ -152,3 +152,13 @@ int ld_nation PROTO((code_t * c, int mode));
 int mk_region PROTO((DSS_HUGE i, code_t *c));
 int pr_region PROTO((code_t * c, int mode));
 int ld_region PROTO((code_t * c, int mode));
+
+/* speed seed - advances seeds `skip_count` times */
+long sd_nation(int child, DSS_HUGE skip_count);
+long sd_region(int child, DSS_HUGE skip_coun);
+long sd_order(int child, DSS_HUGE skip_count);
+long sd_line(int child, DSS_HUGE skip_count);
+long sd_supp(int child, DSS_HUGE skip_count);
+long sd_part(int child, DSS_HUGE skip_count);
+long sd_psupp(int child, DSS_HUGE skip_count);
+long sd_cust(int child, DSS_HUGE skip_count);

--- a/extension/tpch/dbgen/speed_seed.cpp
+++ b/extension/tpch/dbgen/speed_seed.cpp
@@ -200,3 +200,20 @@ long sd_supp(int child, DSS_HUGE skip_count) {
 
 	return (0L);
 }
+
+long sd_nation(int child, DSS_HUGE skip_count) {
+  (void)child;
+
+  ADVANCE_STREAM(N_CMNT_SD, skip_count * 2);
+
+  return (0L);
+}
+
+long sd_region(int child, DSS_HUGE skip_count) {
+  (void)child;
+
+  ADVANCE_STREAM(R_CMNT_SD, skip_count * 2);
+
+  return (0L);
+}
+


### PR DESCRIPTION
This PR addresses the second issue described in #3657: in order to deterministically generate TPC-H datasets using dbgen given a certain offset, a library client would need to advance the seed to the correct state (controlled by the offset). This is done using the speed_seed() functions available in dbgen.

This PR makes tow changes: (a) it exposes the speed seed functions in the header file (so that library clients can use them explicitly), and (b) adds two speed functions missing in dbgen for the region and nation tables (this would affect the `comment` column and make it non-deterministic if given an offset).

Regarding testing: I couldn't find an easy way to add tests for this in duckdb as tests are built in a much higher-level API which doesn't support generation given an offset. I built an extensive test suite from the Velox side, which validates this works as intended though. Open to feedback here. 