### PR TITLE
Simplify `clangd` target

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: build/clangd

--- a/Makefile
+++ b/Makefile
@@ -258,8 +258,4 @@ sqlsmith: debug
 	./build/debug/third_party/sqlsmith/sqlsmith --duckdb=:memory:
 
 clangd:
-	mkdir -p ./build/clangd && \
-	cd ./build/clangd && \
-	cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ${EXTENSIONS} ../.. && \
-	cd ../.. && \
-	ln -sf ./build/clangd/compile_commands.json ./compile_commands.json
+	cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ${EXTENSIONS} -B build/clangd .


### PR DESCRIPTION
The current `Makefile` can be simplified with additional [`CMake`](https://clangd.llvm.org/config#files) [flags](https://cmake.org/cmake/help/v3.13/manual/cmake.1.html#options). This PR will only change `clangd` target as a POC.

Additionally, this PR adds a [.clangd](https://clangd.llvm.org/config#files) file that points to the generated [compile_commands.json](https://clangd.llvm.org/config#compilationdatabase) file to replace the functionality of the removed symbolic link command.