### PR TITLE
More node types

### DIFF
--- a/tools/nodejs/src/statement.cpp
+++ b/tools/nodejs/src/statement.cpp
@@ -148,6 +148,9 @@ static Napi::Value convert_col_val(Napi::Env &env, duckdb::Value dval, duckdb::L
 	case duckdb::LogicalTypeId::HUGEINT: {
 		value = Napi::Number::New(env, dval.GetValue<double>());
 	} break;
+	case duckdb::LogicalTypeId::DECIMAL: {
+		value = Napi::Number::New(env, dval.GetValue<double>());
+	} break;
 	case duckdb::LogicalTypeId::INTERVAL: {
 		auto interval = duckdb::IntervalValue::Get(dval);
 		is_object_value = true;

--- a/tools/nodejs/test/data_type_support.test.js
+++ b/tools/nodejs/test/data_type_support.test.js
@@ -51,20 +51,9 @@ describe("data type support", function () {
       }
     );
   });
-
   it("supports LIST values", function (done) {
     db.prepare(`SELECT ['duck', 'duck', 'goose'] as list`).each((err, row) => {
       assert.deepEqual(row.list, ["duck", "duck", "goose"]);
-      done();
-    });
-  });
-
-  it("supports MAP values", function (done) {
-    db.prepare(`SELECT [[100, 200], ['a', 'b']] as map`).each((err, row) => {
-      assert.deepEqual(row.map, [
-        [100, 200],
-        ["a", "b"],
-      ]);
       done();
     });
   });

--- a/tools/nodejs/test/data_type_support.test.js
+++ b/tools/nodejs/test/data_type_support.test.js
@@ -89,4 +89,17 @@ describe("data type support", function () {
       done();
     });
   });
+  it("supports DECIMAL values", function (done) {
+    db.run("CREATE TABLE decimal_table (d DECIMAL(24, 6))");
+    const stmt = db.prepare("INSERT INTO decimal_table VALUES (?)");
+    const values = [0, -1, 23534642362547.543463];
+    values.forEach((d) => {
+      stmt.run(d);
+    });
+    db.prepare("SELECT d from decimal_table;").all((err, res) => {
+      assert(err === null);
+      assert(res.every((v, i) => v.d === values[i]));
+      done();
+    });
+  });
 });

--- a/tools/nodejs/test/data_type_support.test.js
+++ b/tools/nodejs/test/data_type_support.test.js
@@ -25,12 +25,46 @@ describe("data type support", function () {
     INTERVAL 1 MINUTE as minutes,
     INTERVAL 5 DAY as days,
     INTERVAL 4 MONTH as months,
-    INTERVAL 4 MONTH + INTERVAL 5 DAY + INTERVAL 1 MINUTE as combined;`).each((err, row) => {
+    INTERVAL 4 MONTH + INTERVAL 5 DAY + INTERVAL 1 MINUTE as combined;`
+    ).each((err, row) => {
       assert(err === null);
-      assert.deepEqual(row.minutes, { months: 0, days: 0, micros: 60 * 1000 * 1000});
-      assert.deepEqual(row.days, { months: 0, days: 5, micros: 0});
-      assert.deepEqual(row.months, {months: 4, days: 0, micros: 0});
-      assert.deepEqual(row.combined, {months: 4, days: 5, micros: 60 * 1000 * 1000});
+      assert.deepEqual(row.minutes, {
+        months: 0,
+        days: 0,
+        micros: 60 * 1000 * 1000,
+      });
+      assert.deepEqual(row.days, { months: 0, days: 5, micros: 0 });
+      assert.deepEqual(row.months, { months: 4, days: 0, micros: 0 });
+      assert.deepEqual(row.combined, {
+        months: 4,
+        days: 5,
+        micros: 60 * 1000 * 1000,
+      });
+      done();
+    });
+  });
+  it("supports STRUCT values", function (done) {
+    db.prepare(`SELECT {'x': 1, 'y': 2, 'z': {'a': 'b'}} as struct`).each(
+      (err, row) => {
+        assert.deepEqual(row.struct, { x: 1, y: 2, z: { a: "b" } });
+        done();
+      }
+    );
+  });
+
+  it("supports LIST values", function (done) {
+    db.prepare(`SELECT ['duck', 'duck', 'goose'] as list`).each((err, row) => {
+      assert.deepEqual(row.list, ["duck", "duck", "goose"]);
+      done();
+    });
+  });
+
+  it("supports MAP values", function (done) {
+    db.prepare(`SELECT [[100, 200], ['a', 'b']] as map`).each((err, row) => {
+      assert.deepEqual(row.map, [
+        [100, 200],
+        ["a", "b"],
+      ]);
       done();
     });
   });


### PR DESCRIPTION
Support for LIST, STRUCT and DECIMAL. Required refactoring conversion into `convert_col_val()` to allow recursive invocation.