### PR TITLE
Speedup dbgen initialization time

### DIFF
--- a/extension/tpch/dbgen/text.cpp
+++ b/extension/tpch/dbgen/text.cpp
@@ -62,7 +62,8 @@
 #pragma warning(default : 4214)
 #endif
 
-#define TEXT_POOL_SIZE (300 * 1024 * 1024) /* 300MiB */
+// This was changed from the default (300MiB) to speedup initialization.
+#define TEXT_POOL_SIZE (1 * 1024 * 1024) /* 1MiB */
 
 #include "dbgen/dss.h"
 #include "dbgen/dsstypes.h"


### PR DESCRIPTION
The first call to dbgen functions from a process requires the lazy initialization of a buffer used to generate random texts (`szTextPool`), which currently takes +10 secs on my work server. The long initialization time (despite only being paid once per process) makes it very inconvenient to run tests, slowing down development iteration times. 

This PR reduces this buffer size from 300MB to 1MB, which bring the initialization time from +10 secs to <50ms (which is more reasonable), while still providing a sufficiently large buffer for the generation of random text. 

The only potential issue is that by reducing this buffer we break backwards compatibility, in case this might be an issue. However, this buffer is only used to generate the "comments" columns, which are seldomly used in practice. 