### PR TITLE
Add `shell: bash` everywhere

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -13,11 +13,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}
   cancel-in-progress: true
 
-defaults:
-  shell: bash
-  run:
-    shell: bash
-
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -14,6 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 defaults:
+  shell: bash
   run:
     shell: bash
 
@@ -40,9 +41,11 @@ jobs:
           fetch-depth: 0
 
       - name: Install
+        shell: bash
         run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang-format && sudo pip3 install cmake-format
 
       - name: Format Check
+        shell: bash
         run: |
           clang-format --version
           clang-format --dump-config
@@ -66,10 +69,12 @@ jobs:
           fetch-depth: 0
 
       - name: Install
+        shell: bash
         run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang-tidy && sudo pip3 install pybind11[global]
 
       - name: Cache clang-tidy
         id: date
+        shell: bash
         run: echo "::set-output name=now::$(date)"
 
       - name: Cache clang-tidy
@@ -81,6 +86,7 @@ jobs:
             clang-tidy
 
       - name: Download clang-tidy-cache
+        shell: bash
         run: |
           set -e
           curl -Lo /tmp/clang-tidy-cache https://github.com/ejfitzgerald/clang-tidy-cache/releases/download/v0.4.0/clang-tidy-cache-linux-amd64
@@ -88,6 +94,7 @@ jobs:
           chmod +x /tmp/clang-tidy-cache
 
       - name: Tidy Check
+        shell: bash
         run: make tidy-check TIDY_BINARY=/tmp/clang-tidy-cache
 
   codecov:
@@ -102,9 +109,11 @@ jobs:
           fetch-depth: 0
 
       - name: Install
+        shell: bash
         run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build lcov curl
 
       - name: Validate Configuration
+        shell: bash
         run: |
           curl --fail --data-binary @.codecov.yml https://codecov.io/validate
 
@@ -114,16 +123,19 @@ jobs:
           python-version: '3.9'
 
       - name: Before Install
+        shell: bash
         run: |
           pip install --prefer-binary "pandas>=1.2.4" "requests>=2.26" "pyarrow==8.0" "psutil>=5.9.0" pytest
           sudo apt-get install g++
 
       - name: Coverage Reset
+        shell: bash
         run: |
           lcov --config-file .github/workflows/lcovrc --zerocounters --directory .
           lcov --config-file .github/workflows/lcovrc --capture --initial --directory . --base-directory . --no-external --output-file coverage.info
 
       - name: Run Tests
+        shell: bash
         run: |
           mkdir -p build/coverage
           (cd build/coverage && cmake -E env CXXFLAGS="--coverage" cmake -DBUILD_SUBSTRAIT_EXTENSION=1 -DBUILD_PYTHON=1 -DBUILD_PARQUET_EXTENSION=1 -DBUILD_JSON_EXTENSION=1 -DENABLE_SANITIZER=0 -DCMAKE_BUILD_TYPE=Debug ../.. && make)
@@ -140,6 +152,7 @@ jobs:
 
 
       - name: Generate Coverage
+        shell: bash
         run: |
           lcov --config-file .github/workflows/lcovrc --directory . --base-directory . --no-external --capture --output-file coverage.info
           lcov --config-file .github/workflows/lcovrc --remove coverage.info $(< .github/workflows/lcov_exclude) -o lcov.info

--- a/.github/workflows/Julia.yml
+++ b/.github/workflows/Julia.yml
@@ -17,11 +17,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}
   cancel-in-progress: true
 
-defaults:
-  shell: bash
-  run:
-    shell: bash
-
 jobs:
   format_check:
     name: Julia Format Check

--- a/.github/workflows/Julia.yml
+++ b/.github/workflows/Julia.yml
@@ -18,6 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 defaults:
+  shell: bash
   run:
     shell: bash
 
@@ -36,6 +37,7 @@ jobs:
           arch: x64
 
       - name: Format Check
+        shell: bash
         run: |
             cd tools/juliapkg
             julia -e "import Pkg; Pkg.add(\"JuliaFormatter\")"
@@ -71,10 +73,12 @@ jobs:
           key: ${{ github.job }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.version }}
 
       - name: Build DuckDB
+        shell: bash
         run: |
             BUILD_TPCH=1 make
 
       - name: Run Tests
+        shell: bash
         run: |
           export JULIA_DUCKDB_LIBRARY="`pwd`/build/release/src/libduckdb.so"
           export JULIA_NUM_THREADS=2

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -18,6 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 defaults:
+  shell: bash
   run:
     shell: bash
 
@@ -53,18 +54,22 @@ jobs:
     - uses: ./.github/actions/ubuntu_16_setup
 
     - name: Build
+      shell: bash
       run: STATIC_LIBCPP=1 BUILD_ODBC=1 make
 
     - name: Test
+      shell: bash
       run: make allunit
 
     - name: Tools Tests
+      shell: bash
       run: |
         python3.7 tools/shell/shell-test.py build/release/duckdb
         python3.7 tools/rest/test_the_rest.py build/release/tools/rest
         java -cp build/release/tools/jdbc/duckdb_jdbc.jar org.duckdb.test.TestDuckDBJDBC
 
     - name: Examples
+      shell: bash
       run: |
         (cd examples/embedded-c; make)
         (cd examples/embedded-c++; make)
@@ -73,6 +78,7 @@ jobs:
         build/release/duckdb -c "COPY (SELECT 42) TO '/dev/stdout' (FORMAT PARQUET)" | cat
 
     - name: Deploy
+      shell: bash
       run: |
         python3.7 scripts/amalgamation.py
         zip -j duckdb_cli-linux-amd64.zip build/release/duckdb
@@ -126,14 +132,17 @@ jobs:
     - uses: ./.github/actions/ubuntu_16_setup
 
     - name: Build
+      shell: bash
       run: |
         mkdir -p build/release
         (cd build/release && cmake -DSTATIC_LIBCPP=1 -DJDBC_DRIVER=1 -DBUILD_ICU_EXTENSION=1 -DBUILD_PARQUET_EXTENSION=1 -DBUILD_FTS_EXTENSION=1 -DBUILD_JSON_EXTENSION=1 -DBUILD_EXCEL_EXTENSION=1 -DFORCE_32_BIT=1 -DCMAKE_BUILD_TYPE=Release ../.. && cmake --build .)
 
     - name: Test
+      shell: bash
       run: build/release/test/unittest "*"
 
     - name: Deploy
+      shell: bash
       run: |
         python3.7 scripts/amalgamation.py
         zip -j duckdb_cli-linux-i386.zip build/release/duckdb
@@ -163,6 +172,7 @@ jobs:
         python-version: '3.7'
 
     - name: Install
+      shell: bash
       run: |
         sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
         git clone https://github.com/raspberrypi/tools --depth=1 rpi-tools
@@ -173,6 +183,7 @@ jobs:
         key: ${{ github.job }}
 
     - name: Build
+      shell: bash
       run: |
         export TOOLCHAIN=`pwd`/rpi-tools
         mkdir -p build/release
@@ -182,6 +193,7 @@ jobs:
         file duckdb
 
     - name: Deploy
+      shell: bash
       run: |
         python scripts/amalgamation.py
         zip -j duckdb_cli-linux-rpi.zip build/release/duckdb
@@ -215,6 +227,7 @@ jobs:
         python-version: '3.7'
 
     - name: Install
+      shell: bash
       run: sudo apt-get update -y -qq && sudo apt-get install -y -qq g++-4.8 binutils
 
     - name: Setup Ccache
@@ -223,9 +236,11 @@ jobs:
         key: ${{ github.job }}
 
     - name: Build
+      shell: bash
       run: make release
 
     - name: Test
+      shell: bash
       run: make allunit
 
  release-assert:
@@ -251,6 +266,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install
+      shell: bash
       run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
 
     - name: Setup Ccache
@@ -259,9 +275,11 @@ jobs:
         key: ${{ github.job }}
 
     - name: Build
+      shell: bash
       run: make relassert
 
     - name: Test
+      shell: bash
       run: |
           python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest "*"
 
@@ -289,6 +307,7 @@ jobs:
         key: ${{ github.job }}
 
     - name: Test
+      shell: bash
       run: python scripts/test_vector_sizes.py
 
  linux-wasm-release:
@@ -301,9 +320,11 @@ jobs:
         fetch-depth: 0
 
     - name: Build Amalgamation
+      shell: bash
       run: python scripts/amalgamation.py
 
     - name: Setup
+      shell: bash
       run: ./scripts/wasm_configure.sh
 
     - name: Setup Ccache
@@ -312,15 +333,19 @@ jobs:
         key: ${{ github.job }}
 
     - name: Build Library Module
+      shell: bash
       run: ./scripts/wasm_build_lib.sh Release
 
     - name: Build Test Module
+      shell: bash
       run: ./scripts/wasm_build_test.sh Release
 
     - name: Test WASM Module
+      shell: bash
       run: node ./test/wasm/hello_wasm_test.js
 
     - name: Package
+      shell: bash
       run: |
         zip -j duckdb-wasm32-nothreads.zip ./.wasm/build/duckdb.wasm
         python scripts/asset-upload-gha.py duckdb-wasm32-nothreads.zip
@@ -351,9 +376,11 @@ jobs:
         key: ${{ github.job }}
 
     - name: Build
+      shell: bash
       run: make
 
     - name: Symbol Leakage Test
+      shell: bash
       run: python3.7 scripts/exported_symbols_check.py build/release/src/libduckdb*.so
 
  linux-httpfs:
@@ -376,6 +403,7 @@ jobs:
         python-version: '3.7'
 
     - name: Install Ninja
+      shell: bash
       run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
 
     - name: Setup Ccache
@@ -384,14 +412,17 @@ jobs:
         key: ${{ github.job }}
 
     - name: Build
+      shell: bash
       run: make
 
     - name: Start S3/HTTP test server
+      shell: bash
       run: |
         sudo ./scripts/install_s3_test_server.sh
         ./scripts/run_s3_test_server.sh
 
     - name: Test
+      shell: bash
       run: make allunit
 
  amalgamation-tests:
@@ -417,6 +448,7 @@ jobs:
         version: "10.0"
 
     - name: Generate Amalgamation
+      shell: bash
       run:  |
           python scripts/amalgamation.py --extended
           python scripts/parquet_amalgamation.py

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -17,11 +17,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}
   cancel-in-progress: true
 
-defaults:
-  shell: bash
-  run:
-    shell: bash
-
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -18,6 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 defaults:
+  shell: bash
   run:
     shell: bash
 
@@ -54,6 +55,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install
+      shell: bash
       run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
 
     - name: Setup Ccache
@@ -62,9 +64,11 @@ jobs:
         key: ${{ github.job }}
 
     - name: Build
+      shell: bash
       run:  make debug
 
     - name: Test
+      shell: bash
       run: make unittestci
 
 
@@ -91,6 +95,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install
+      shell: bash
       run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
 
     - name: Setup Ccache
@@ -99,9 +104,11 @@ jobs:
         key: ${{ github.job }}
 
     - name: Build
+      shell: bash
       run: make reldebug
 
     - name: Test
+      shell: bash
       run: build/reldebug/test/unittest "*" --force-storage
 
 
@@ -121,6 +128,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install
+        shell: bash
         run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
 
       - name: Setup Ccache
@@ -129,9 +137,11 @@ jobs:
           key: ${{ github.job }}
 
       - name: Build
+        shell: bash
         run: BUILD_ARROW_ABI_TEST=1 make debug
 
       - name: Test
+        shell: bash
         run: make unittestarrow
 
  threadsan:
@@ -157,6 +167,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install
+      shell: bash
       run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
 
     - name: Setup Ccache
@@ -165,9 +176,11 @@ jobs:
         key: ${{ github.job }}
 
     - name: Build
+      shell: bash
       run: THREADSAN=1 make reldebug
 
     - name: Test
+      shell: bash
       run: |
           python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest
           python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest "[intraquery]"
@@ -192,6 +205,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install
+      shell: bash
       run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build valgrind
 
     - name: Setup Ccache
@@ -200,9 +214,11 @@ jobs:
         key: ${{ github.job }}
 
     - name: Build
+      shell: bash
       run: make debug
 
     - name: Test
+      shell: bash
       run: valgrind ./build/debug/test/unittest test/sql/tpch/tpch_sf001.test_slow
 
  docs:
@@ -215,6 +231,7 @@ jobs:
         fetch-depth: 0
 
     - name: Clone Website
+      shell: bash
       run: git clone https://github.com/duckdb/duckdb-web
 
     - name: Set up Python 3.9
@@ -223,6 +240,7 @@ jobs:
         python-version: '3.9'
 
     - name: Package
+      shell: bash
       run: |
         cd duckdb-web
         python3 scripts/generate_docs.py ..
@@ -242,6 +260,7 @@ jobs:
         fetch-depth: 0
 
     - name: Test
+      shell: bash
       run: make sqlite
 
  expanded:
@@ -261,6 +280,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install
+      shell: bash
       run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
 
     - name: Setup Ccache
@@ -269,6 +289,7 @@ jobs:
         key: ${{ github.job }}
 
     - name: Build
+      shell: bash
       run: make debug
 
  sqlancer:
@@ -286,6 +307,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install
+      shell: bash
       run: |
         sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
         git clone https://github.com/hannesmuehleisen/sqlancer
@@ -299,9 +321,11 @@ jobs:
         key: ${{ github.job }}
 
     - name: Build
+      shell: bash
       run: make reldebug
 
     - name: Test
+      shell: bash
       run: |
         cp build/reldebug/tools/jdbc/duckdb_jdbc.jar sqlancer/target/lib/duckdb_jdbc-*.jar
         python3 scripts/run_sqlancer.py
@@ -323,6 +347,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install
+      shell: bash
       run: |
         sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
         git clone https://github.com/hannesmuehleisen/sqlancer
@@ -336,9 +361,11 @@ jobs:
         key: ${{ github.job }}
 
     - name: Build
+      shell: bash
       run: make reldebug
 
     - name: Test
+      shell: bash
       run: |
         cp build/reldebug/tools/jdbc/duckdb_jdbc.jar sqlancer/target/lib/duckdb_jdbc-*.jar
         python3 scripts/run_sqlancer.py --persistent
@@ -361,6 +388,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install
+      shell: bash
       run: |
         sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
         git clone https://github.com/cwida/jdbccts.git
@@ -371,9 +399,11 @@ jobs:
         key: ${{ github.job }}
 
     - name: Build
+      shell: bash
       run: make release
 
     - name: Test
+      shell: bash
       run: (cd jdbccts && make DUCKDB_JAR=../build/release/tools/jdbc/duckdb_jdbc.jar test)
 
  odbc:
@@ -394,16 +424,19 @@ jobs:
         python-version: '3.7'
 
     - name: Dependencies
+      shell: bash
       run: |
         sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc-dev python3 python3-pyodbc python3-pip julia
         pip3 install pyodbc
 
     - name: Install nanodbc
+      shell: bash
       run: |
         wget https://github.com/nanodbc/nanodbc/archive/refs/tags/v2.13.0.tar.gz -O nanodbc.tgz
         (mkdir nanodbc && tar xvf nanodbc.tgz -C nanodbc --strip-components=1 && cd nanodbc && sed -i -e "s/set(test_list/set(test_list odbc/" test/CMakeLists.txt && mkdir build && cd build && cmake -DNANODBC_DISABLE_TESTS=OFF .. && cmake --build .)
 
     - name: Install psqlodbc
+      shell: bash
       run: |
         git clone https://github.com/Mytherin/psqlodbc.git
         (cd psqlodbc && git checkout 89726c417d1ea8b4080e486fe240725a79eca0d6 && make debug)
@@ -414,24 +447,31 @@ jobs:
         key: ${{ github.job }}
 
     - name: Build
+      shell: bash
       run: DISABLE_SANITIZER=1 make debug
 
     - name: Test nanodbc
+      shell: bash
       run: ./tools/odbc/test/run_nanodbc_tests.sh
 
     - name: Test psqlodbc
+      shell: bash
       run: ./tools/odbc/test/run_psqlodbc_tests.sh
 
     - name: Test isql
+      shell: bash
       run: ./tools/odbc/test/run_isql_tests.sh
 
     - name: Test R ODBC
+      shell: bash
       run: R -f tools/odbc/test/rodbc.R
 
     - name: Test Python ODBC
+      shell: bash
       run: ./tools/odbc/test/run_pyodbc_tests.sh
 
     - name: Test Julia ODBC
+      shell: bash
       run: |
         export ASAN_OPTIONS=verify_asan_link_order=0
         julia tools/odbc/test/julia-test.jl

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -17,11 +17,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}
   cancel-in-progress: true
 
-defaults:
-  shell: bash
-  run:
-    shell: bash
-
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -20,6 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 defaults:
+  shell: bash
   run:
     shell: bash
 
@@ -41,11 +42,13 @@ jobs:
         fetch-depth: 0
 
     - name: Install requirements
+      shell: bash
       run: |
         sudo apt-get update -y -qq
         sudo apt-get install -y git ninja-build make gcc-multilib g++-multilib wget libssl-dev
 
     - name: Install CMake
+      shell: bash
       run: |
         wget https://github.com/Kitware/CMake/releases/download/v3.21.3/cmake-3.21.3-linux-x86_64.sh
         chmod +x cmake-3.21.3-linux-x86_64.sh
@@ -57,31 +60,39 @@ jobs:
         key: ${{ github.job }}
 
     - name: Build extensions
+      shell: bash
       run: |
         GEN=ninja EXTENSION_STATIC_BUILD=1 BUILD_TPCH=1 BUILD_HTTPFS=1 STATIC_OPENSSL=1 make
 
     - name: Setup
+      shell: bash
       run: ./scripts/node_version.sh upload
 
     - name: Node 10
+      shell: bash
       run: ./scripts/node_build.sh 10
 
     - name: Node 12
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
+      shell: bash
       run: ./scripts/node_build.sh 12
 
     - name: Node 14
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
+      shell: bash
       run: ./scripts/node_build.sh 14
 
     - name: Node 15
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
+      shell: bash
       run: ./scripts/node_build.sh 15
 
     - name: Node 16
+      shell: bash
       run: ./scripts/node_build.sh 16
 
     - name: Node 17
+      shell: bash
       run: ./scripts/node_build.sh 17
 
    osx-nodejs:
@@ -100,6 +111,7 @@ jobs:
           key: ${{ github.job }}
 
       - name: Build extensions
+        shell: bash
         run: |
           brew install openssl ninja
           export OPENSSL_ROOT_DIR=`brew --prefix openssl`
@@ -107,27 +119,34 @@ jobs:
           GEN=ninja BUILD_TPCH=1 BUILD_HTTPFS=1 STATIC_OPENSSL=1 make
 
       - name: Setup
+        shell: bash
         run: ./scripts/node_version.sh
 
       - name: Node 10
+        shell: bash
         run: ./scripts/node_build.sh 10
 
       - name: Node 12
         if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
+        shell: bash
         run: ./scripts/node_build.sh 12
 
       - name: Node 14
         if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
+        shell: bash
         run: ./scripts/node_build.sh 14
 
       - name: Node 15
         if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
+        shell: bash
         run: ./scripts/node_build.sh 15
 
       - name: Node 16
+        shell: bash
         run: ./scripts/node_build.sh 16
 
       - name: Node 17
+        shell: bash
         run: ./scripts/node_build.sh 17
 
    win-nodejs:
@@ -161,17 +180,20 @@ jobs:
            node-version: ${{ matrix.node }}
 
        - name: Versions
+         shell: bash
          run: |
            systeminfo
            node -v
            npm -v
 
        - name: Windows Build Tools
+         shell: bash
          run: |
            choco install python visualstudio2019-workload-vctools -y
            npm config set msvs_version 2019
 
        - name: Node Version
+         shell: bash
          run: ./scripts/node_version.sh
 
        - name: Setup Ccache
@@ -181,4 +203,5 @@ jobs:
            variant: sccache
 
        - name: Node
+         shell: bash
          run: ./scripts/node_build_win.sh

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -19,11 +19,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}
   cancel-in-progress: true
 
-defaults:
-  shell: bash
-  run:
-    shell: bash
-
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -11,11 +11,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}
   cancel-in-progress: true
 
-defaults:
-  shell: bash
-  run:
-    shell: bash
-
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -12,6 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 defaults:
+  shell: bash
   run:
     shell: bash
 
@@ -40,12 +41,15 @@ jobs:
         python-version: '3.7'
 
     - name: Build
+      shell: bash
       run: make debug
 
     - name: Test
+      shell: bash
       run: make unittestci
 
     - name: Amalgamation
+      shell: bash
       run: |
         python scripts/amalgamation.py --extended
         python scripts/parquet_amalgamation.py
@@ -83,23 +87,28 @@ jobs:
         key: ${{ github.job }}
 
     - name: Build
+      shell: bash
       run: make
 
     - name: Unit Test
+      shell: bash
       run: make allunit
 
     - name: Tools Tests
+      shell: bash
       run: |
         python tools/shell/shell-test.py build/release/duckdb
         java -cp build/release/tools/jdbc/duckdb_jdbc.jar org.duckdb.test.TestDuckDBJDBC
 
     - name: Examples
+      shell: bash
       run: |
         (cd examples/embedded-c; make)
         (cd examples/embedded-c++; make)
         (cd examples/jdbc; make; make maven)
 
     - name: Deploy
+      shell: bash
       run: |
         python scripts/amalgamation.py
         zip -j duckdb_cli-osx-amd64.zip build/release/duckdb
@@ -133,6 +142,7 @@ jobs:
           python-version: '3.7'
 
       - name: Install OpenSSL
+        shell: bash
         run: |
           mkdir -p build/openssl
           cd build/openssl
@@ -146,6 +156,7 @@ jobs:
           make install_sw
 
       - name: Get OpenSSL path
+        shell: bash
         run: |
           export OPENSSL_ROOT_DIR=`pwd`/build/openssl/build
           echo "OPENSSL_ROOT_DIR=$OPENSSL_ROOT_DIR" >> $GITHUB_ENV
@@ -158,6 +169,7 @@ jobs:
           run_tests: 0
 
       - name: Deploy
+        shell: bash
         run: |
           zip -j httpfs.duckdb_extension.zip build/release/extension/httpfs/httpfs.duckdb_extension
           if [[ "$GITHUB_REF" =~ ^(refs/heads/master|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -19,6 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 defaults:
+  shell: bash
   run:
     shell: bash
 
@@ -52,6 +53,7 @@ jobs:
         python-version: '3.7'
 
     - name: Install
+      shell: bash
       run: pip install cibuildwheel twine
 
     - name: Setup Ccache
@@ -60,6 +62,7 @@ jobs:
         key: ${{ github.job }}
 
     - name: Build
+      shell: bash
       run: |
         cd tools/pythonpkg
         python setup.py sdist
@@ -76,6 +79,7 @@ jobs:
 
     steps:
     - name: Install dependencies
+      shell: bash
       run: |
         yum install -y gcc gcc-c++ cmake make
         yum install -y epel-release
@@ -85,12 +89,14 @@ jobs:
         yum install -y curl-devel expat-devel gettext-devel zlib-devel perl-ExtUtils-MakeMaker
 
     - name: Install AWS CLI
+      shell: bash
       run: |
         python3 -m pip install awscli
         aws --version
 
       # the weird openssl findreplace fix with version numbers is from: https://github.com/h2o/h2o/issues/213
     - name: Download OpenSSL 1.1.1k
+      shell: bash
       run: |
         wget https://ftp.openssl.org/source/openssl-1.1.1k.tar.gz --no-check-certificate
         tar -xzvf openssl-1.1.1k.tar.gz
@@ -98,11 +104,13 @@ jobs:
         find ./ -type f -exec sed -i -e 's/\#\ define\ OPENSSL\_VERSION\_NUMBER/\#define\ OPENSSL\_VERSION\_NUMBER/g' {} \;
 
     - name: Configure OpenSSL
+      shell: bash
       run: |
         cd openssl-1.1.1k
         ./config --prefix=/usr --openssldir=/etc/ssl --libdir=lib no-shared zlib-dynamic
 
     - name: Build OpenSSL
+      shell: bash
       run: |
         cd openssl-1.1.1k
         make
@@ -113,6 +121,7 @@ jobs:
         fetch-depth: 0
 
     - name: Version Check
+      shell: bash
       run: |
         cmake --version
         ldd --version ldd
@@ -167,6 +176,7 @@ jobs:
         python-version: '3.7'
 
     - name: Install
+      shell: bash
       run: pip install cibuildwheel twine
 
     - uses: actions/download-artifact@v3
@@ -176,6 +186,7 @@ jobs:
         path: tools/pythonpkg
 
     - name: List extensions to be tested
+      shell: bash
       run: |
         find tools/pythonpkg -maxdepth 2 -type f -name "*.duckdb_extension"
 
@@ -185,6 +196,7 @@ jobs:
         key: ${{ github.job }}-${{ matrix.arch }}-${{ matrix.python_build }}
 
     - name: Build
+      shell: bash
       run: |
         cd tools/pythonpkg
         python setup.py sdist
@@ -196,6 +208,7 @@ jobs:
         ls wheelhouse
 
     - name: Deploy
+      shell: bash
       run: |
         python scripts/asset-upload-gha.py duckdb_python_src.tar.gz=tools/pythonpkg/dist/duckdb-*.tar.gz
         if [[ "$GITHUB_REF" =~ ^(refs/heads/master|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
@@ -228,6 +241,7 @@ jobs:
           python-version: '3.7'
 
       - name: Install
+        shell: bash
         run: pip install cibuildwheel twine
 
       - name: Setup Ccache
@@ -236,6 +250,7 @@ jobs:
           key: ${{ github.job }}-${{ matrix.python_build }}
 
       - name: Build
+        shell: bash
         run: |
           cd tools/pythonpkg
           python setup.py sdist
@@ -245,6 +260,7 @@ jobs:
           cibuildwheel --output-dir wheelhouse --config-file cibw.toml duckdb_tarball
 
       - name: Deploy
+        shell: bash
         run: |
           if [[ "$GITHUB_REF" =~ ^(refs/heads/master|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
             twine upload --non-interactive --disable-progress-bar --skip-existing tools/pythonpkg/wheelhouse/*.whl
@@ -288,6 +304,7 @@ jobs:
           python-version: '3.7'
 
       - name: Install
+        shell: bash
         run: pip install cibuildwheel twine
 
       - name: Setup Ccache
@@ -296,6 +313,7 @@ jobs:
           key: ${{ github.job }}-${{ matrix.python_build }}
 
       - name: Build
+        shell: bash
         run: |
           cd tools/pythonpkg
           python setup.py sdist
@@ -305,6 +323,7 @@ jobs:
           cibuildwheel --output-dir wheelhouse duckdb_tarball
 
       - name: Deploy
+        shell: bash
         run: |
           if [[ "$GITHUB_REF" =~ ^(refs/heads/master|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
             twine upload --non-interactive --disable-progress-bar --skip-existing tools/pythonpkg/wheelhouse/*.whl
@@ -325,6 +344,7 @@ jobs:
           python-version: '3.7'
 
       - name: Install
+        shell: bash
         run: pip install numpy pytest pandas mypy psutil
 
       - name: Setup Ccache
@@ -333,6 +353,7 @@ jobs:
           key: ${{ github.job }}
 
       - name: Build
+        shell: bash
         run: |
           python --version
           git archive --format zip --output test-tarball.zip HEAD
@@ -364,4 +385,5 @@ jobs:
           python-version: '3.7'
 
       - name: Cleanup Releases
+        shell: bash
         run: python3 scripts/pypi_cleanup.py

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -18,11 +18,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}
   cancel-in-progress: true
 
-defaults:
-  shell: bash
-  run:
-    shell: bash
-
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -18,11 +18,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}
   cancel-in-progress: true
 
-defaults:
-  shell: bash
-  run:
-    shell: bash
-
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -121,11 +121,10 @@ jobs:
     - name: Coverage
       env:
         DUCKDB_R_DEBUG: 1
-      shell: bash
+      shell: Rscript {0}
       run: |
         pkgload::load_all("tools/rpkg")
         cov <- covr::codecov("tools/rpkg", relative_path = ".")
-      shell: Rscript {0}
 
     - name: Print R log on failure
       if: ${{ failure() }}

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -19,6 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 defaults:
+  shell: bash
   run:
     shell: bash
 
@@ -76,12 +77,14 @@ jobs:
     - name: Install
       env:
         GITHUB_PAT: ${{ github.token }}
+      shell: bash
       run: |
         sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build texlive-latex-base texlive-fonts-extra libcurl4-openssl-dev valgrind pandoc
         mkdir -p $HOME/.R
         R -f tools/rpkg/dependencies.R
 
     - name: Prepare
+      shell: bash
       run: |
         mkdir -p /tmp/duckdb_extensions
         cd tools/rpkg
@@ -94,6 +97,7 @@ jobs:
         path: /tmp/duckdb_extensions
 
     - name: Tests
+      shell: bash
       run: |
         ls /tmp/duckdb_extensions
         cd tools/rpkg
@@ -101,12 +105,14 @@ jobs:
         (cd tests && DUCKDB_R_TEST_EXTENSION_REQUIRED=1 R -f testthat.R)
 
     - name: R CMD check
+      shell: bash
       run: |
         cd tools/rpkg
         R CMD check --as-cran -o /tmp duckdb_*.tar.gz
         if grep WARNING /tmp/duckdb.Rcheck/00check.log ; then exit 1; fi
 
     - name: Valgrind
+      shell: bash
       run: |
         cd tools/rpkg
         export NOT_CRAN='false'
@@ -115,6 +121,7 @@ jobs:
     - name: Coverage
       env:
         DUCKDB_R_DEBUG: 1
+      shell: bash
       run: |
         pkgload::load_all("tools/rpkg")
         cov <- covr::codecov("tools/rpkg", relative_path = ".")
@@ -122,12 +129,14 @@ jobs:
 
     - name: Print R log on failure
       if: ${{ failure() }}
+      shell: bash
       run: |
         ls -R /tmp/duckdb.Rcheck
         cat /tmp/duckdb.Rcheck/00check.log
         cat /tmp/duckdb.Rcheck/tests/testthat.Rout.fail
 
     - name: Deploy
+      shell: bash
       run: python scripts/asset-upload-gha.py duckdb_r_src.tar.gz=tools/rpkg/duckdb_*.tar.gz
 
   rstats-windows:
@@ -149,10 +158,12 @@ jobs:
         r-version: 'devel'
 
     - name: Install
+      shell: bash
       run: |
         R -f tools/rpkg/dependencies.R
 
     - name: Build
+      shell: bash
       run: |
         cd tools/rpkg
         ./configure
@@ -173,12 +184,14 @@ jobs:
         fetch-depth: 0
 
     - name: Run
+      shell: bash
       run: |
         (cd tools/rpkg && ./configure && R CMD build .)
         docker run -v `pwd`:/duckdb --cap-add SYS_PTRACE wch1/r-debug:latest bash -c "mkdir -p ~/.R && echo -e \"PKG_CFLAGS=-fno-sanitize-recover=all\\nPKG_CXXFLAGS=-fno-sanitize-recover=all\" > ~/.R/Makevars && export CMAKE_UNITY_BUILD=OFF ARROW_R_DEV=TRUE LIBARROW_BINARY=true && cd /duckdb/tools/rpkg/ && RDsan -f dependencies.R && RDsan CMD INSTALL duckdb_*.tar.gz && cd tests && UBSAN_OPTIONS=print_stacktrace=1 RDsan -f testthat.R"
 
     - name: Print R log on failure
       if: ${{ failure() }}
+      shell: bash
       run: |
         cat duckdb.Rcheck/00check.log
         cat duckdb.Rcheck/tests/testthat.Rout.fail

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -16,11 +16,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}
   cancel-in-progress: true
 
-defaults:
-  shell: bash
-  run:
-    shell: bash
-
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -17,6 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 defaults:
+  shell: bash
   run:
     shell: bash
 
@@ -58,6 +59,7 @@ jobs:
         python-version: '3.7'
 
     - name: Install
+      shell: bash
       run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build && pip install requests
 
     - name: Setup Ccache
@@ -66,6 +68,7 @@ jobs:
         key: ${{ github.job }}
 
     - name: Build
+      shell: bash
       run: |
         make
         git clone https://github.com/duckdb/duckdb.git --depth=1
@@ -74,6 +77,7 @@ jobs:
         cd ..
 
     - name: Regression Test
+      shell: bash
       run: |
         cp -r benchmark duckdb/
         python scripts/regression_test_runner.py --old=duckdb/build/release/benchmark/benchmark_runner --new=build/release/benchmark/benchmark_runner --benchmarks=.github/regression/${{ matrix.benchmark }}.csv --verbose --threads=2
@@ -96,27 +100,32 @@ jobs:
         python-version: '3.7'
 
     - name: Install
+      shell: bash
       run: |
         sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
         pip install numpy pytest pandas mypy psutil pyarrow
 
     - name: Build Current Version
+      shell: bash
       run: |
         cd tools/pythonpkg
         python setup.py install --user
         cd ../..
 
     - name: Run New Version
+      shell: bash
       run: |
         python scripts/regression_test_python.py --threads=2 --out-file=new.csv
 
     - name: Cleanup New Version
+      shell: bash
       run: |
         cd tools/pythonpkg
         ./clean.sh
         cd ../..
 
     - name: Build Current
+      shell: bash
       run: |
         git clone https://github.com/duckdb/duckdb.git --depth=1
         cd duckdb/tools/pythonpkg
@@ -124,9 +133,11 @@ jobs:
         cd ../../..
 
     - name: Run Current Version
+      shell: bash
       run: |
         python scripts/regression_test_python.py --threads=2 --out-file=current.csv
 
     - name: Regression Test
+      shell: bash
       run: |
         python scripts/regression_check.py --old=current.csv --new=new.csv

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -129,10 +129,6 @@ jobs:
      name: MingW (64 Bit)
      runs-on: windows-latest
      needs: win-release-64
-     defaults:
-       shell: bash
-       run:
-         shell: msys2 {0}
      steps:
        - uses: actions/checkout@v3
        - uses: msys2/setup-msys2@v2
@@ -143,17 +139,17 @@ jobs:
        # see here: https://gist.github.com/scivision/1de4fd6abea9ba6b2d87dc1e86b5d2ce
        - name: Put MSYS2_MinGW64 on PATH
          # there is not yet an environment variable for this path from msys2/setup-msys2
-         shell: bash
+         shell: msys2 {0}
          run: export PATH=D:/a/_temp/msys/msys64/mingw64/bin:$PATH
 
        - name: Build
-         shell: bash
+         shell: msys2 {0}
          run: |
            cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DBUILD_PARQUET_EXTENSION=1
            cmake --build . --config Release
 
        - name: Test
-         shell: bash
+         shell: msys2 {0}
          run: |
            cp src/libduckdb.dll .
            test/unittest.exe

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -17,11 +17,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}
   cancel-in-progress: true
 
-defaults:
-  shell: bash
-  run:
-    shell: bash
-
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -18,6 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 defaults:
+  shell: bash
   run:
     shell: bash
 
@@ -42,20 +43,24 @@ jobs:
         python-version: '3.7'
 
     - name: Build
+      shell: bash
       run: |
         python scripts/windows_ci.py
         cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR_PLATFORM=x64 -DBUILD_ICU_EXTENSION=1 -DBUILD_PARQUET_EXTENSION=1 -DBUILD_TPCH_EXTENSION=1 -DBUILD_TPCDS_EXTENSION=1 -DBUILD_FTS_EXTENSION=1 -DBUILD_JSON_EXTENSION=1 -DBUILD_EXCEL_EXTENSION=1 -DBUILD_REST=1 -DJDBC_DRIVER=1 -DBUILD_VISUALIZER_EXTENSION=1 -DBUILD_ODBC_DRIVER=1 -DDISABLE_UNITY=1
         cmake --build . --config Release
 
     - name: Test
+      shell: bash
       run: test/Release/unittest.exe
 
     - name: Tools Test
+      shell: bash
       run: |
         python tools/shell/shell-test.py Release/duckdb.exe
         java -cp tools/jdbc/duckdb_jdbc.jar org.duckdb.test.TestDuckDBJDBC
 
     - name: Deploy
+      shell: bash
       run: |
         python scripts/amalgamation.py
         choco install zip -y --force
@@ -75,6 +80,7 @@ jobs:
 
     - uses: ilammy/msvc-dev-cmd@v1
     - name: Duckdb.dll export symbols with C++ on Windows
+      shell: bash
       run: cl -I src/include examples/embedded-c++-windows/cppintegration.cpp -link src/Release/duckdb.lib
 
  win-release-32:
@@ -92,18 +98,22 @@ jobs:
         python-version: '3.7'
 
     - name: Build
+      shell: bash
       run: |
         cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR_PLATFORM=Win32 -DBUILD_ICU_EXTENSION=1 -DBUILD_PARQUET_EXTENSION=1 -DBUILD_TPCH_EXTENSION=1 -DBUILD_TPCDS_EXTENSION=1 -DBUILD_FTS_EXTENSION=1 -DBUILD_JSON_EXTENSION=1 -DBUILD_EXCEL_EXTENSION=1 -DJDBC_DRIVER=1 -DBUILD_VISUALIZER_EXTENSION=1
         cmake --build . --config Release
 
     - name: Test
+      shell: bash
       run: test/Release/unittest.exe
 
     - name: Tools Test
+      shell: bash
       run: |
         python tools/shell/shell-test.py Release/duckdb.exe
 
     - name: Deploy
+      shell: bash
       run: |
         python scripts/amalgamation.py
         choco install zip -y --force
@@ -125,6 +135,7 @@ jobs:
      runs-on: windows-latest
      needs: win-release-64
      defaults:
+       shell: bash
        run:
          shell: msys2 {0}
      steps:
@@ -137,14 +148,17 @@ jobs:
        # see here: https://gist.github.com/scivision/1de4fd6abea9ba6b2d87dc1e86b5d2ce
        - name: Put MSYS2_MinGW64 on PATH
          # there is not yet an environment variable for this path from msys2/setup-msys2
+         shell: bash
          run: export PATH=D:/a/_temp/msys/msys64/mingw64/bin:$PATH
 
        - name: Build
+         shell: bash
          run: |
            cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DBUILD_PARQUET_EXTENSION=1
            cmake --build . --config Release
 
        - name: Test
+         shell: bash
          run: |
            cp src/libduckdb.dll .
            test/unittest.exe
@@ -163,15 +177,18 @@ jobs:
         python-version: '3.7'
 
     - name: Install Git
+      shell: bash
       run: |
         choco install git -y --force
 
     - name: Build
+      shell: bash
       run: |
         cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR_PLATFORM=x64 -DBUILD_ICU_EXTENSION=1 -DBUILD_PARQUET_EXTENSION=1 -DBUILD_TPCH_EXTENSION=1 -DBUILD_TPCDS_EXTENSION=1 -DBUILD_FTS_EXTENSION=1 -DBUILD_JSON_EXTENSION=1 -DBUILD_EXCEL_EXTENSION=1 -DBUILD_REST=1 -DJDBC_DRIVER=1 -DBUILD_VISUALIZER_EXTENSION=1 -DBUILD_ODBC_DRIVER=1 -DDISABLE_UNITY=1
         cmake --build . --config Release
 
     - name: Install ODBC Driver
+      shell: bash
       run:  |
         tools/odbc/bin/Release/odbc_install.exe //CI //Install
         Reg Query "HKLM\SOFTWARE\ODBC\ODBC.INI\ODBC Data Sources"
@@ -179,6 +196,7 @@ jobs:
         Reg Query "HKLM\SOFTWARE\ODBC\ODBCINST.INI\DuckDB Driver"
 
     - name: Enable ODBC Trace HKCU
+      shell: bash
       run: |
         REG ADD "HKCU\SOFTWARE\ODBC\ODBC.INI\ODBC" //f
         REG ADD "HKCU\SOFTWARE\ODBC\ODBC.INI\ODBC" //v Trace //t REG_SZ //d 1
@@ -188,11 +206,13 @@ jobs:
         Reg Query "HKCU\SOFTWARE\ODBC\ODBC.INI\ODBC"
 
     - name: Install psqlodbc
+      shell: bash
       run: |
         git clone https://github.com/Mytherin/psqlodbc.git
         (cd psqlodbc && git checkout 89726c417d1ea8b4080e486fe240725a79eca0d6 && make release)
 
     - name: Test psqlodbc
+      shell: bash
       run: |
         cd psqlodbc
         export PSQLODBC_TEST_DSN=DuckDB
@@ -200,6 +220,7 @@ jobs:
 
     - name: Print ODBC trace on failure
       if: ${{ failure() }}
+      shell: bash
       run: cat ODBC_TRACE.log
 
  win-extensions-64:
@@ -216,6 +237,7 @@ jobs:
          python-version: '3.7'
 
      - name: Install OpenSSL
+       shell: bash
        run: |
          choco install openssl -y --force
 

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -44,6 +44,7 @@ jobs:
 
     steps:
       - name: Dependencies
+        shell: bash
         run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build ccache
 
       - uses: actions/checkout@v2
@@ -51,9 +52,11 @@ jobs:
           fetch-depth: 0
 
       - name: Build
+        shell: bash
         run: |
             make debug
 
       - name: Fuzz
+        shell: bash
         run: |
             python3 scripts/run_fuzzer.py  --sqlsmith --alltypes --shell=build/debug/duckdb


### PR DESCRIPTION
TL;DR: Should we move the details of each job to its dedicated composite action, so that we can revert to using one workflow file which allows reuse of build artifacts across different ecosystems?

This is an attempt to flee the CI/CD hell we're currently in.

If we had one single big workflow file per OS (as opposed to the current situation), we could eventually have just a few early build steps and then have the various ecosystems (NodeJS, Python, R, ...) use artifacts from those build steps to dramatically shorten check times. This would mean:

- Less resource consumption
- More parallel builds in the duckdb org
- Overall reduced turnaround time for pull requests

A big workflow file is clunky, and can be made prettier if it only calls a few actions (or perhaps just one) in each job.

GHA now has composite actions, see `.github/actions/build_extensions` for an example. A technical requirements for the steps in such actions are that each step with a `run:` block has a `shell:` block. This PR does precisely that (and gets rid of the `defaults:` sections to avoid confusion).

Once we agree on the specifics, I'm happy to proceed with extracting actions from the individual jobs, so that we can go back to using a single small workflow file per target platform. Then we should be able to figure out how to create one comprehensive build that prepares for checking on all target ecosystems, and use that build instead of building anew every time.

Script to do the replacement: `gsed 's/^( *)(run:)/\1shell: bash\n\1\2/'` and `gsed '/defaults:/ ,+4d'` .