### PR TITLE
Expose dbgen text buffer size as a parameter

### DIFF
--- a/extension/tpch/dbgen/dbgen.cpp
+++ b/extension/tpch/dbgen/dbgen.cpp
@@ -568,7 +568,7 @@ void DBGenWrapper::LoadTPCHData(ClientContext &context, double flt_scale, string
 		scale = (long)flt_scale;
 	}
 
-	load_dists();
+	load_dists(300 * 1024 * 1024); // 300MiB
 
 	/* have to do this after init */
 	tdefs[NATION].base = nations.count;

--- a/extension/tpch/dbgen/dbgen_gunk.cpp
+++ b/extension/tpch/dbgen/dbgen_gunk.cpp
@@ -13,7 +13,7 @@
 #include "dbgen/dss.h"
 #include "dbgen/dsstypes.h"
 
-void load_dists(void) {
+void load_dists(long textBufferSize) {
 	read_dist(tpch_env_config(DIST_TAG, DIST_DFLT), "p_cntr", &p_cntr_set);
 	read_dist(tpch_env_config(DIST_TAG, DIST_DFLT), "colors", &colors);
 	read_dist(tpch_env_config(DIST_TAG, DIST_DFLT), "p_types", &p_types_set);
@@ -38,6 +38,9 @@ void load_dists(void) {
 	read_dist(tpch_env_config(DIST_TAG, DIST_DFLT), "grammar", &grammar);
 	read_dist(tpch_env_config(DIST_TAG, DIST_DFLT), "np", &np);
 	read_dist(tpch_env_config(DIST_TAG, DIST_DFLT), "vp", &vp);
+
+  /* populate the text buffer used to generate random text */
+  init_text_pool(textBufferSize);
 }
 
 static void cleanup_dist(distribution *target) {
@@ -77,4 +80,6 @@ void cleanup_dists(void) {
 	cleanup_dist(&grammar);
 	cleanup_dist(&np);
 	cleanup_dist(&vp);
+
+  free_text_pool();
 }

--- a/extension/tpch/dbgen/include/dbgen/dbgen_gunk.hpp
+++ b/extension/tpch/dbgen/include/dbgen/dbgen_gunk.hpp
@@ -10,5 +10,5 @@
  */
 #pragma once
 
-void load_dists(void);
+void load_dists(long textBufferSize);
 void cleanup_dists(void);

--- a/extension/tpch/dbgen/include/dbgen/dss.h
+++ b/extension/tpch/dbgen/include/dbgen/dss.h
@@ -171,6 +171,9 @@ void dump_seeds_ds(int t);
 #define MAX_SENT_LEN 256   /* max length of populated sentence */
 #define RNG_PER_SENT 27    /* max number of RNG calls per sentence */
 
+void init_text_pool PROTO((long bSize));
+void free_text_pool PROTO(());
+
 void dbg_text PROTO((char *t, int min, int max, int s));
 
 #ifdef DECLARER


### PR DESCRIPTION
This is a small re-work from of what was described in #3781, but instead of changing the buffer size in place, it exposes it as a parameter so backward compatibility is maintained. 

In order to that, the text buffer initialization was pulled off and is now part of the general initialization function (the dbgunk stuff).  It now also has the nice property of removing the initialization from dbg_text, and thus making that function thread-safe(r).

Let me know what you guys prefer between the two changes!