### PR TITLE
Implement nest(), unnest(), pack() and unpack()

### DIFF
--- a/tools/rpkg/DESCRIPTION
+++ b/tools/rpkg/DESCRIPTION
@@ -57,6 +57,8 @@ Suggests:
     nycflights13,
     testthat,
     tibble,
+    tidyr,
+    tidyselect,
     vctrs,
     withr
 Encoding: UTF-8

--- a/tools/rpkg/DESCRIPTION
+++ b/tools/rpkg/DESCRIPTION
@@ -55,6 +55,7 @@ Suggests:
     dplyr,
     dbplyr,
     nycflights13,
+    rlang,
     testthat,
     tibble,
     tidyr,

--- a/tools/rpkg/R/nest.R
+++ b/tools/rpkg/R/nest.R
@@ -1,0 +1,86 @@
+# Registered in .onLoad()
+nest.tbl_duckdb_connection <- function(.data, ..., .names_sep = NULL) {
+  # Import
+  group_by <- pkg_method("group_by", "dplyr", "nest")
+  summarise <- pkg_method("summarise", "dplyr", "nest", version = "1.0.0")
+
+  # Build spec
+  spec <- build_nest_pack_spec(.data, .names_sep, ...)
+
+  # Plan
+  groups <- lapply(unname(spec$unpacked), as.name)
+
+  list_calls <- lapply(stats::setNames(nm = names(spec$packed)), function(.x) {
+    call("LIST", as.name(.x))
+  })
+
+  # Apply plan
+  packed_tbl <- pack_impl(.data, spec$unpacked, spec$packed)
+  grouped_tbl <- group_by(packed_tbl, !!!groups)
+  summarised_tbl <- summarise(grouped_tbl, !!!list_calls, .groups = "drop")
+  summarised_tbl
+}
+
+# Registered in .onLoad()
+pack.tbl_duckdb_connection <- function(.data, ..., .names_sep = NULL) {
+  # Build spec
+  spec <- build_nest_pack_spec(.data, .names_sep, ...)
+
+  # Apply plan
+  pack_impl(.data, spec$unpacked, spec$packed)
+}
+
+build_nest_pack_spec <- function(.data, .names_sep, ...) {
+  if (!is.null(.names_sep)) {
+    stop("`.names_sep` unsupported.")
+  }
+
+  enquos <- pkg_method("enquos", "rlang", "pack")
+  names2 <- pkg_method("names2", "rlang", "pack")
+  eval_select <- pkg_method("eval_select", "tidyselect", "pack")
+
+  named_names <- stats::setNames(nm = colnames(.data))
+
+  cols <- enquos(...)
+  if (any(names2(cols) == "")) {
+    stop("All elements of `...` must be named")
+  }
+
+  cols <- lapply(cols, function(.x) eval_select(.x, named_names))
+
+  unpacked <- setdiff(named_names, unlist(lapply(cols, names)))
+
+  packed <- lapply(cols, function(.x) named_names[.x])
+
+  # if (!is.null(.names_sep)) {
+  #   packed <- imap(packed, strip_names, names_sep = .names_sep)
+  # }
+
+  list(named_names = named_names, packed = packed, unpacked = unpacked)
+}
+
+pack_impl <- function(.data, unpacked, packed) {
+  transmute <- pkg_method("transmute", "dplyr", "pack")
+
+  stopifnot(identical(unname(unlist(lapply(packed, names))), unname(unlist(packed))))
+
+  row_calls <- lapply(packed, function(.x) {
+    fun_args <- lapply(c("ROW", unname(.x)), as.name)
+    as.call(fun_args)
+  })
+
+  transmute(.data, !!!lapply(unpacked, as.name), !!!row_calls)
+}
+
+untibble <- function(x) {
+  if (!is.data.frame(x)) {
+    return(x)
+  }
+  class(x) <- "data.frame"
+  dfs <- vapply(x, is.data.frame, logical(1))
+  lists <- vapply(x[!dfs], is.list, logical(1))
+
+  x[dfs] <- lapply(x[dfs], untibble)
+  x[!dfs][lists] <- lapply(x[!dfs][lists], lapply, untibble)
+  x
+}

--- a/tools/rpkg/R/s3_register.R
+++ b/tools/rpkg/R/s3_register.R
@@ -64,12 +64,24 @@ s3_register <- function(generic, class, method = NULL) {
 
 # From: https://github.com/DyfanJones/noctua/blob/b82113098df6b3a7981cf8ca0c1ae9f2ff408756/R/utils.R#L168-L175
 # get parent pkg function and method
-pkg_method <- function(fun, pkg) {
+pkg_method <- function(fun, pkg, caller_fun = fun, version = NULL) {
   if (!requireNamespace(pkg, quietly = TRUE)) {
-    stop(fun, " requires the ", pkg, " package, please install it first and try again",
+    stop(caller_fun, " requires the ", pkg, " package, please install it first and try again",
       call. = FALSE
     )
   }
+
+  if (!is.null(version)) {
+    spec <- get(".__NAMESPACE__.", asNamespace(pkg))$spec
+    pkg_version <- base::package_version(spec[["version"]])
+    if (pkg_version < version) {
+      stop(caller_fun, " requires the ", pkg, " package in version ", version,
+        ", you have version ", pkg_version, ". Please update it first and try again",
+        call. = FALSE
+      )
+    }
+  }
+
   fun_name <- utils::getFromNamespace(fun, pkg)
   return(fun_name)
 }

--- a/tools/rpkg/R/unnest.R
+++ b/tools/rpkg/R/unnest.R
@@ -1,0 +1,79 @@
+# Registered in .onLoad()
+unnest.tbl_duckdb_connection <- function(data,
+                                         cols,
+                                         ...,
+                                         keep_empty = FALSE,
+                                         ptype = NULL,
+                                         names_sep = NULL,
+                                         names_repair = "check_unique") {
+
+  if (keep_empty) {
+    stop("`keep_empty` unsupported.")
+  }
+  if (!is.null(ptype)) {
+    stop("`ptype` unsupported.")
+  }
+
+  # Side effect: check that tidyr is loaded, brings in rlang, vctrs, tidyselect
+  # and dplyr
+  pkg_method("unnest", "tidyr")
+  rlang::check_required(cols)
+
+  named_names <- rlang::set_names(colnames(data))
+
+  cols_q <- rlang::enquo(cols)
+  select_cols <- tidyselect::eval_select(cols_q, named_names)
+
+  plan <- lapply(rlang::set_names(names(select_cols)), function(.x) {
+    call("UNNEST", as.name(.x))
+  })
+
+  unnested <- dplyr::mutate(data, !!!plan)
+
+  unpack.tbl_duckdb_connection(
+    unnested, !!cols_q,
+    names_sep = names_sep,
+    names_repair = names_repair
+  )
+}
+
+# Registered in .onLoad()
+unpack.tbl_duckdb_connection <- function(data, cols, ..., names_sep = NULL, names_repair = "check_unique") {
+  if (!is.null(names_sep)) {
+    stop("`names_sep` unsupported.")
+  }
+
+  # Side effect: check that tidyr is loaded, brings in rlang, vctrs, tidyselect
+  # and dplyr
+  pkg_method("unpack", "tidyr")
+  rlang::check_required(cols)
+
+  named_names <- rlang::set_names(colnames(data))
+
+  cols <- tidyselect::eval_select(rlang::enquo(cols), named_names)
+
+  ptype <- dplyr::collect(utils::head(dplyr::select(data, !!!cols), 0))
+  ptype <- ptype[vapply(ptype, is.data.frame, logical(1))]
+
+  plan <- lapply(named_names, function(.x) list(as.name(.x)))
+  plan[names(ptype)] <- mapply(ptype, names(ptype), FUN = function (.x, .y) {
+    out <- lapply(rlang::set_names(names(.x)), function(...) {
+      list(call("STRUCT_EXTRACT", as.name(.y), ..1))
+    })
+    list(vctrs::new_data_frame(out, n = 1L))
+  })
+
+  names(plan)[names(plan) %in% names(ptype)] <- ""
+
+  # Logic from tidyr
+  df_plan <- vctrs::df_list(!!!plan, .size = 1, .name_repair = "minimal")
+  names(df_plan) <- vctrs::vec_as_names(
+    names = names(df_plan),
+    repair = names_repair,
+    repair_arg = "names_repair"
+  )
+
+  unpacked_plan <- lapply(df_plan, function(.x) .x[[1]])
+
+  dplyr::transmute(data, !!!unpacked_plan)
+}

--- a/tools/rpkg/R/zzz.R
+++ b/tools/rpkg/R/zzz.R
@@ -7,4 +7,7 @@
   s3_register("dbplyr::sql_escape_date", "duckdb_connection")
   s3_register("dbplyr::sql_escape_datetime", "duckdb_connection")
   s3_register("dplyr::tbl", "duckdb_connection")
+  s3_register("tidyr::nest", "tbl_duckdb_connection")
+  # https://github.com/tidyverse/tidyr/pull/1372
+  # s3_register("tidyr::pack", "tbl_duckdb_connection")
 }

--- a/tools/rpkg/R/zzz.R
+++ b/tools/rpkg/R/zzz.R
@@ -8,6 +8,8 @@
   s3_register("dbplyr::sql_escape_datetime", "duckdb_connection")
   s3_register("dplyr::tbl", "duckdb_connection")
   s3_register("tidyr::nest", "tbl_duckdb_connection")
+  s3_register("tidyr::unnest", "tbl_duckdb_connection")
   # https://github.com/tidyverse/tidyr/pull/1372
   # s3_register("tidyr::pack", "tbl_duckdb_connection")
+  # s3_register("tidyr::unpack", "tbl_duckdb_connection")
 }

--- a/tools/rpkg/R/zzz.R
+++ b/tools/rpkg/R/zzz.R
@@ -10,6 +10,6 @@
   s3_register("tidyr::nest", "tbl_duckdb_connection")
   s3_register("tidyr::unnest", "tbl_duckdb_connection")
   # https://github.com/tidyverse/tidyr/pull/1372
-  # s3_register("tidyr::pack", "tbl_duckdb_connection")
-  # s3_register("tidyr::unpack", "tbl_duckdb_connection")
+  try(s3_register("tidyr::pack", "tbl_duckdb_connection"), silent = TRUE)
+  try(s3_register("tidyr::unpack", "tbl_duckdb_connection"), silent = TRUE)
 }

--- a/tools/rpkg/dependencies.R
+++ b/tools/rpkg/dependencies.R
@@ -1,5 +1,5 @@
 local({
-  pkg <- c("DBI", "callr", "DBItest", "dbplyr", "nycflights13", "testthat", "bit64", "cpp11", "arrow", "covr", "pkgbuild", "remotes")
+  pkg <- c("DBI", "callr", "DBItest", "dbplyr", "tidyr", "nycflights13", "testthat", "bit64", "cpp11", "arrow", "covr", "pkgbuild", "remotes")
 
   if (.Platform$OS.type == "unix") {
     options(HTTPUserAgent = sprintf("R/4.1.0 R (4.1.0 %s)", paste(R.version$platform, R.version$arch, R.version$os)))

--- a/tools/rpkg/tests/testthat/_snaps/nest.md
+++ b/tools/rpkg/tests/testthat/_snaps/nest.md
@@ -1,0 +1,20 @@
+# nest() is consistent with data frames
+
+    Code
+      dbplyr::sql_render(tidyr::nest(tbl, data = -groups))
+    Output
+      <SQL> SELECT "groups", LIST("data") AS "data"
+      FROM (
+        SELECT "groups", ROW("num", "char") AS "data"
+        FROM "data"
+      ) "q01"
+      GROUP BY "groups"
+
+# pack() is consistent with data frames
+
+    Code
+      dbplyr::sql_render(pack.tbl_duckdb_connection(tbl, data = -groups))
+    Output
+      <SQL> SELECT "groups", ROW("num", "char") AS "data"
+      FROM "data"
+

--- a/tools/rpkg/tests/testthat/_snaps/unnest.md
+++ b/tools/rpkg/tests/testthat/_snaps/unnest.md
@@ -1,0 +1,25 @@
+# unnest() is consistent with data frames
+
+    Code
+      dbplyr::sql_render(tidyr::unnest(tbl_nested, data))
+    Output
+      <SQL> SELECT
+        "groups",
+        STRUCT_EXTRACT("data", 'num') AS "num",
+        STRUCT_EXTRACT("data", 'char') AS "char"
+      FROM (
+        SELECT "groups", UNNEST("data") AS "data"
+        FROM "dbplyr_001"
+      ) "q01"
+
+# unpack() is consistent with data frames
+
+    Code
+      dbplyr::sql_render(unpack.tbl_duckdb_connection(tbl_packed, data))
+    Output
+      <SQL> SELECT
+        "groups",
+        STRUCT_EXTRACT("data", 'num') AS "num",
+        STRUCT_EXTRACT("data", 'char') AS "char"
+      FROM "dbplyr_002"
+

--- a/tools/rpkg/tests/testthat/test-nest.R
+++ b/tools/rpkg/tests/testthat/test-nest.R
@@ -1,0 +1,43 @@
+test_that("nest() is consistent with data frames", {
+  local_edition(3)
+
+  skip_if_not_installed("tidyr")
+  skip_if_not_installed("dbplyr")
+
+  con <- DBI::dbConnect(duckdb::duckdb())
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
+
+  data <- data.frame(groups = 1:2, num = 1:6, char = letters[1:6])
+  tbl <- dplyr::copy_to(con, data)
+
+  expect_snapshot({
+    dbplyr::sql_render(tidyr::nest(tbl, data = -groups))
+  })
+
+  expect_equal(
+    untibble(tidyr::nest(data, data = -groups)),
+    untibble(dplyr::collect(tidyr::nest(tbl, data = -groups)))
+  )
+})
+
+test_that("pack() is consistent with data frames", {
+  local_edition(3)
+
+  skip_if_not_installed("tidyr")
+  skip_if_not_installed("dbplyr")
+
+  con <- DBI::dbConnect(duckdb::duckdb())
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
+
+  data <- data.frame(groups = 1:2, num = 1:6, char = letters[1:6])
+  tbl <- dplyr::copy_to(con, data)
+
+  expect_snapshot({
+    dbplyr::sql_render(pack.tbl_duckdb_connection(tbl, data = -groups))
+  })
+
+  expect_equal(
+    untibble(tidyr::pack(data, data = -groups)),
+    untibble(dplyr::collect(pack.tbl_duckdb_connection(tbl, data = -groups)))
+  )
+})

--- a/tools/rpkg/tests/testthat/test-unnest.R
+++ b/tools/rpkg/tests/testthat/test-unnest.R
@@ -1,0 +1,47 @@
+test_that("unnest() is consistent with data frames", {
+  local_edition(3)
+
+  skip_if_not_installed("tidyr")
+  skip_if_not_installed("dbplyr")
+
+  con <- DBI::dbConnect(duckdb::duckdb())
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
+
+  data <- data.frame(groups = 1:2, num = 1:6, char = letters[1:6])
+  tbl <- dplyr::copy_to(con, data)
+  data_nested <- tidyr::nest(data, data = -groups)
+  tbl_nested <- dplyr::compute(tidyr::nest(tbl, data = -groups))
+
+  expect_snapshot({
+    dbplyr::sql_render(tidyr::unnest(tbl_nested, data))
+  })
+
+  expect_equal(
+    untibble(tidyr::unnest(data_nested, data)),
+    untibble(dplyr::collect(tidyr::unnest(tbl_nested, data)))
+  )
+})
+
+test_that("unpack() is consistent with data frames", {
+  local_edition(3)
+
+  skip_if_not_installed("tidyr")
+  skip_if_not_installed("dbplyr")
+
+  con <- DBI::dbConnect(duckdb::duckdb())
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
+
+  data <- data.frame(groups = 1:2, num = 1:6, char = letters[1:6])
+  tbl <- dplyr::copy_to(con, data)
+  data_packed <- tidyr::pack(data, data = -groups)
+  tbl_packed <- dplyr::compute(pack.tbl_duckdb_connection(tbl, data = -groups))
+
+  expect_snapshot({
+    dbplyr::sql_render(unpack.tbl_duckdb_connection(tbl_packed, data))
+  })
+
+  expect_equal(
+    untibble(tidyr::unpack(data_packed, data)),
+    untibble(dplyr::collect(unpack.tbl_duckdb_connection(tbl_packed, data)))
+  )
+})


### PR DESCRIPTION
Thanks to #3495, CC @james-atkins @rsund.

DuckDB's `UNNEST()` is the equivalent of `tidyr::unchop()`. Our `unnest()` implementation is using it under the hood.