### PR TITLE
s3fs decode keys correctly

### DIFF
--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -153,6 +153,7 @@ public:
 	static ParsedS3Url S3UrlParse(string url, const S3AuthParams &params);
 
 	static std::string UrlEncode(const std::string &input, bool encode_slash = false);
+	static std::string UrlDecode(std::string input);
 
 	// Uploads the contents of write_buffer to S3.
 	// Note: caller is responsible to not call this method twice on the same buffer

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -101,6 +101,25 @@ static unique_ptr<duckdb_httplib_openssl::Headers> initialize_http_headers(Heade
 	return headers;
 }
 
+std::string S3FileSystem::UrlDecode(std::string input) {
+	std::string result;
+	result.reserve(input.size());
+	char ch;
+	std::replace(input.begin(), input.end(), '+', ' ');
+	for (idx_t i = 0; i < input.length(); i++) {
+		if (int(input[i]) == 37) {
+			int ii;
+			sscanf(input.substr(i + 1, 2).c_str(), "%x", &ii);
+			ch = static_cast<char>(ii);
+			result += ch;
+			i += 2;
+		} else {
+			result += input[i];
+		}
+	}
+	return result;
+}
+
 std::string S3FileSystem::UrlEncode(const std::string &input, bool encode_slash) {
 	// https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
 	static const char *hex_digit = "0123456789ABCDEF";
@@ -895,7 +914,8 @@ void AWSListObjectV2::ParseKey(string &aws_response, vector<string> &result) {
 			if (next_close_tag_pos == string::npos) {
 				throw InternalException("Failed to parse S3 result");
 			}
-			auto parsed_path = aws_response.substr(next_open_tag_pos + 5, next_close_tag_pos - next_open_tag_pos - 5);
+			auto parsed_path = S3FileSystem::UrlDecode(
+			    aws_response.substr(next_open_tag_pos + 5, next_close_tag_pos - next_open_tag_pos - 5));
 			if (parsed_path.back() != '/') {
 				result.push_back(parsed_path);
 			}

--- a/scripts/run_s3_test_server.sh
+++ b/scripts/run_s3_test_server.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker-compose -f scripts/minio_s3.yml -p duckdb-minio up -d
+docker compose -f scripts/minio_s3.yml -p duckdb-minio up -d

--- a/test/sql/copy/parquet/parquet_glob_s3.test
+++ b/test/sql/copy/parquet/parquet_glob_s3.test
@@ -19,6 +19,8 @@ statement ok
 COPY (select * from 'data/parquet-testing/glob/t1.parquet') to 's3://test-bucket/parquet_glob_s3/glob/t1.parquet';
 COPY (select * from 'data/parquet-testing/glob/t2.parquet') to 's3://test-bucket/parquet_glob_s3/glob/t2.parquet';
 COPY (select * from 'data/parquet-testing/glob2/t1.parquet') to 's3://test-bucket/parquet_glob_s3/glob2/t1.parquet';
+COPY (select * from 'data/parquet-testing/glob/t1.parquet') to 's3://test-bucket/parquet_glob_s3/with+plus/t1.parquet';
+COPY (select * from 'data/parquet-testing/glob/t1.parquet') to 's3://test-bucket/parquet_glob_s3/with space/t1.parquet';
 
 # parquet glob with COPY FROM
 statement ok
@@ -74,6 +76,11 @@ select count(*) from parquet_scan('s3://test-bucket/parquet_glob_s3/g*/*.parquet
 
 query I
 select count(*) from parquet_scan('s3://test-bucket/parquet_glob_s3/g*/t1.parquet')
+----
+2
+
+query I
+select count(*) from parquet_scan('s3://test-bucket/parquet_glob_s3/with*/*.parquet')
 ----
 2
 


### PR DESCRIPTION
This adds s3 prefix ("Key") decoding so that prefixes with spaces and other interesting characters (e.g. +, =) are handled correctly.
There are also new test cases that fail before this fix, and pass with it.

This addresses #3830 