### PR TITLE
Fix overflow in generate_series and overflow in abs operator

### DIFF
--- a/src/function/aggregate/holistic/quantile.cpp
+++ b/src/function/aggregate/holistic/quantile.cpp
@@ -896,7 +896,7 @@ struct MadAccessor {
 
 	inline RESULT_TYPE operator()(const INPUT_TYPE &input) const {
 		const auto delta = input - median;
-		return AbsOperator::Operation<RESULT_TYPE, RESULT_TYPE>(delta);
+		return TryAbsOperator::Operation<RESULT_TYPE, RESULT_TYPE>(delta);
 	}
 };
 
@@ -911,7 +911,7 @@ struct MadAccessor<hugeint_t, double, double> {
 	}
 	inline RESULT_TYPE operator()(const INPUT_TYPE &input) const {
 		const auto delta = Hugeint::Cast<double>(input) - median;
-		return AbsOperator::Operation<double, double>(delta);
+		return TryAbsOperator::Operation<double, double>(delta);
 	}
 };
 
@@ -927,7 +927,7 @@ struct MadAccessor<date_t, interval_t, timestamp_t> {
 	inline RESULT_TYPE operator()(const INPUT_TYPE &input) const {
 		const auto dt = Cast::Operation<date_t, timestamp_t>(input);
 		const auto delta = dt - median;
-		return Interval::FromMicro(AbsOperator::Operation<int64_t, int64_t>(delta));
+		return Interval::FromMicro(TryAbsOperator::Operation<int64_t, int64_t>(delta));
 	}
 };
 
@@ -942,7 +942,7 @@ struct MadAccessor<timestamp_t, interval_t, timestamp_t> {
 	}
 	inline RESULT_TYPE operator()(const INPUT_TYPE &input) const {
 		const auto delta = input - median;
-		return Interval::FromMicro(AbsOperator::Operation<int64_t, int64_t>(delta));
+		return Interval::FromMicro(TryAbsOperator::Operation<int64_t, int64_t>(delta));
 	}
 };
 
@@ -957,7 +957,7 @@ struct MadAccessor<dtime_t, interval_t, dtime_t> {
 	}
 	inline RESULT_TYPE operator()(const INPUT_TYPE &input) const {
 		const auto delta = input - median;
-		return Interval::FromMicro(AbsOperator::Operation<int64_t, int64_t>(delta));
+		return Interval::FromMicro(TryAbsOperator::Operation<int64_t, int64_t>(delta));
 	}
 };
 

--- a/src/function/scalar/date/date_part.cpp
+++ b/src/function/scalar/date/date_part.cpp
@@ -227,10 +227,8 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
-			return PropagateDatePartStatistics<T, YearOperator>(child_stats);
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, YearOperator>(input.child_stats);
 		}
 	};
 
@@ -241,11 +239,9 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
 			// min/max of month operator is [1, 12]
-			return PropagateSimpleDatePartStatistics<1, 12>(child_stats);
+			return PropagateSimpleDatePartStatistics<1, 12>(input.child_stats);
 		}
 	};
 
@@ -256,11 +252,9 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
 			// min/max of day operator is [1, 31]
-			return PropagateSimpleDatePartStatistics<1, 31>(child_stats);
+			return PropagateSimpleDatePartStatistics<1, 31>(input.child_stats);
 		}
 	};
 
@@ -277,10 +271,8 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
-			return PropagateDatePartStatistics<T, DecadeOperator>(child_stats);
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, DecadeOperator>(input.child_stats);
 		}
 	};
 
@@ -307,10 +299,8 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
-			return PropagateDatePartStatistics<T, CenturyOperator>(child_stats);
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, CenturyOperator>(input.child_stats);
 		}
 	};
 
@@ -331,10 +321,8 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
-			return PropagateDatePartStatistics<T, MillenniumOperator>(child_stats);
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, MillenniumOperator>(input.child_stats);
 		}
 	};
 
@@ -350,11 +338,9 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
 			// min/max of quarter operator is [1, 4]
-			return PropagateSimpleDatePartStatistics<1, 4>(child_stats);
+			return PropagateSimpleDatePartStatistics<1, 4>(input.child_stats);
 		}
 	};
 
@@ -372,10 +358,8 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
-			return PropagateSimpleDatePartStatistics<0, 6>(child_stats);
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 6>(input.child_stats);
 		}
 	};
 
@@ -387,10 +371,8 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
-			return PropagateSimpleDatePartStatistics<1, 7>(child_stats);
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<1, 7>(input.child_stats);
 		}
 	};
 
@@ -401,10 +383,8 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
-			return PropagateSimpleDatePartStatistics<1, 366>(child_stats);
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<1, 366>(input.child_stats);
 		}
 	};
 
@@ -415,10 +395,8 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
-			return PropagateSimpleDatePartStatistics<1, 54>(child_stats);
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<1, 54>(input.child_stats);
 		}
 	};
 
@@ -429,10 +407,8 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
-			return PropagateDatePartStatistics<T, ISOYearOperator>(child_stats);
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, ISOYearOperator>(input.child_stats);
 		}
 	};
 
@@ -450,10 +426,8 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
-			return PropagateDatePartStatistics<T, YearWeekOperator>(child_stats);
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, YearWeekOperator>(input.child_stats);
 		}
 	};
 
@@ -464,10 +438,8 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
-			return PropagateSimpleDatePartStatistics<0, 60000000>(child_stats);
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 60000000>(input.child_stats);
 		}
 	};
 
@@ -478,10 +450,8 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
-			return PropagateSimpleDatePartStatistics<0, 60000>(child_stats);
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 60000>(input.child_stats);
 		}
 	};
 
@@ -492,10 +462,8 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
-			return PropagateSimpleDatePartStatistics<0, 60>(child_stats);
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 60>(input.child_stats);
 		}
 	};
 
@@ -506,10 +474,8 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
-			return PropagateSimpleDatePartStatistics<0, 60>(child_stats);
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 60>(input.child_stats);
 		}
 	};
 
@@ -520,10 +486,8 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
-			return PropagateSimpleDatePartStatistics<0, 24>(child_stats);
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 24>(input.child_stats);
 		}
 	};
 
@@ -534,10 +498,8 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
-			return PropagateDatePartStatistics<T, EpochOperator>(child_stats);
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, EpochOperator>(input.child_stats);
 		}
 	};
 
@@ -553,10 +515,8 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
-			return PropagateSimpleDatePartStatistics<0, 1>(child_stats);
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 1>(input.child_stats);
 		}
 	};
 
@@ -568,10 +528,8 @@ struct DatePart {
 		}
 
 		template <class T>
-		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, BoundFunctionExpression &expr,
-		                                                      FunctionData *bind_data,
-		                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
-			return PropagateSimpleDatePartStatistics<0, 0>(child_stats);
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 0>(input.child_stats);
 		}
 	};
 
@@ -1025,12 +983,10 @@ int64_t DatePart::EpochOperator::Operation(dtime_t input) {
 }
 
 template <>
-unique_ptr<BaseStatistics>
-DatePart::EpochOperator::PropagateStatistics<dtime_t>(ClientContext &context, BoundFunctionExpression &expr,
-                                                      FunctionData *bind_data,
-                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
+unique_ptr<BaseStatistics> DatePart::EpochOperator::PropagateStatistics<dtime_t>(ClientContext &context,
+                                                                                 FunctionStatisticsInput &input) {
 	// time seconds range over a single day
-	return PropagateSimpleDatePartStatistics<0, 86400>(child_stats);
+	return PropagateSimpleDatePartStatistics<0, 86400>(input.child_stats);
 }
 
 template <>

--- a/src/function/scalar/generic/stats.cpp
+++ b/src/function/scalar/generic/stats.cpp
@@ -35,9 +35,9 @@ unique_ptr<FunctionData> StatsBind(ClientContext &context, ScalarFunction &bound
 	return make_unique<StatsBindData>();
 }
 
-static unique_ptr<BaseStatistics> StatsPropagateStats(ClientContext &context, BoundFunctionExpression &expr,
-                                                      FunctionData *bind_data,
-                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
+static unique_ptr<BaseStatistics> StatsPropagateStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &bind_data = input.bind_data;
 	if (child_stats[0]) {
 		auto &info = (StatsBindData &)*bind_data;
 		info.stats = child_stats[0]->ToString();

--- a/src/function/scalar/list/flatten.cpp
+++ b/src/function/scalar/list/flatten.cpp
@@ -115,9 +115,8 @@ static unique_ptr<FunctionData> ListFlattenBind(ClientContext &context, ScalarFu
 	return make_unique<VariableReturnBindData>(bound_function.return_type);
 }
 
-static unique_ptr<BaseStatistics> ListFlattenStats(ClientContext &context, BoundFunctionExpression &expr,
-                                                   FunctionData *bind_data,
-                                                   vector<unique_ptr<BaseStatistics>> &child_stats) {
+static unique_ptr<BaseStatistics> ListFlattenStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
 	if (!child_stats[0]) {
 		return nullptr;
 	}

--- a/src/function/scalar/list/list_concat.cpp
+++ b/src/function/scalar/list/list_concat.cpp
@@ -104,9 +104,8 @@ static unique_ptr<FunctionData> ListConcatBind(ClientContext &context, ScalarFun
 	return make_unique<VariableReturnBindData>(bound_function.return_type);
 }
 
-static unique_ptr<BaseStatistics> ListConcatStats(ClientContext &context, BoundFunctionExpression &expr,
-                                                  FunctionData *bind_data,
-                                                  vector<unique_ptr<BaseStatistics>> &child_stats) {
+static unique_ptr<BaseStatistics> ListConcatStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
 	D_ASSERT(child_stats.size() == 2);
 	if (!child_stats[0] || !child_stats[1]) {
 		return nullptr;

--- a/src/function/scalar/list/list_extract.cpp
+++ b/src/function/scalar/list/list_extract.cpp
@@ -209,9 +209,8 @@ static unique_ptr<FunctionData> ListExtractBind(ClientContext &context, ScalarFu
 	return make_unique<VariableReturnBindData>(bound_function.return_type);
 }
 
-static unique_ptr<BaseStatistics> ListExtractStats(ClientContext &context, BoundFunctionExpression &expr,
-                                                   FunctionData *bind_data,
-                                                   vector<unique_ptr<BaseStatistics>> &child_stats) {
+static unique_ptr<BaseStatistics> ListExtractStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
 	if (!child_stats[0]) {
 		return nullptr;
 	}

--- a/src/function/scalar/list/list_value.cpp
+++ b/src/function/scalar/list/list_value.cpp
@@ -46,8 +46,9 @@ static unique_ptr<FunctionData> ListValueBind(ClientContext &context, ScalarFunc
 	return make_unique<VariableReturnBindData>(bound_function.return_type);
 }
 
-unique_ptr<BaseStatistics> ListValueStats(ClientContext &context, BoundFunctionExpression &expr,
-                                          FunctionData *bind_data, vector<unique_ptr<BaseStatistics>> &child_stats) {
+unique_ptr<BaseStatistics> ListValueStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
 	auto list_stats = make_unique<ListStatistics>(expr.return_type);
 	for (idx_t i = 0; i < child_stats.size(); i++) {
 		if (child_stats[i]) {

--- a/src/function/scalar/operators/arithmetic.cpp
+++ b/src/function/scalar/operators/arithmetic.cpp
@@ -112,9 +112,9 @@ struct SubtractPropagateStatistics {
 };
 
 template <class OP, class PROPAGATE, class BASEOP>
-static unique_ptr<BaseStatistics> PropagateNumericStats(ClientContext &context, BoundFunctionExpression &expr,
-                                                        FunctionData *bind_data,
-                                                        vector<unique_ptr<BaseStatistics>> &child_stats) {
+static unique_ptr<BaseStatistics> PropagateNumericStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
 	D_ASSERT(child_stats.size() == 2);
 	// can only propagate stats if the children have stats
 	if (!child_stats[0] || !child_stats[1]) {
@@ -425,9 +425,9 @@ struct NegatePropagateStatistics {
 	}
 };
 
-static unique_ptr<BaseStatistics> NegateBindStatistics(ClientContext &context, BoundFunctionExpression &expr,
-                                                       FunctionData *bind_data,
-                                                       vector<unique_ptr<BaseStatistics>> &child_stats) {
+static unique_ptr<BaseStatistics> NegateBindStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
 	D_ASSERT(child_stats.size() == 1);
 	// can only propagate stats if the children have stats
 	if (!child_stats[0]) {

--- a/src/function/scalar/string/caseconvert.cpp
+++ b/src/function/scalar/string/caseconvert.cpp
@@ -148,9 +148,9 @@ static void CaseConvertFunctionASCII(DataChunk &args, ExpressionState &state, Ve
 }
 
 template <bool IS_UPPER>
-static unique_ptr<BaseStatistics> CaseConvertPropagateStats(ClientContext &context, BoundFunctionExpression &expr,
-                                                            FunctionData *bind_data,
-                                                            vector<unique_ptr<BaseStatistics>> &child_stats) {
+static unique_ptr<BaseStatistics> CaseConvertPropagateStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
 	D_ASSERT(child_stats.size() == 1);
 	// can only propagate stats if the children have stats
 	if (!child_stats[0]) {

--- a/src/function/scalar/string/instr.cpp
+++ b/src/function/scalar/string/instr.cpp
@@ -37,9 +37,9 @@ struct InstrAsciiOperator {
 	}
 };
 
-static unique_ptr<BaseStatistics> InStrPropagateStats(ClientContext &context, BoundFunctionExpression &expr,
-                                                      FunctionData *bind_data,
-                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
+static unique_ptr<BaseStatistics> InStrPropagateStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
 	D_ASSERT(child_stats.size() == 2);
 	// can only propagate stats if the children have stats
 	if (!child_stats[0]) {

--- a/src/function/scalar/string/length.cpp
+++ b/src/function/scalar/string/length.cpp
@@ -49,9 +49,9 @@ struct BitLenOperator {
 	}
 };
 
-static unique_ptr<BaseStatistics> LengthPropagateStats(ClientContext &context, BoundFunctionExpression &expr,
-                                                       FunctionData *bind_data,
-                                                       vector<unique_ptr<BaseStatistics>> &child_stats) {
+static unique_ptr<BaseStatistics> LengthPropagateStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
 	D_ASSERT(child_stats.size() == 1);
 	// can only propagate stats if the children have stats
 	if (!child_stats[0]) {

--- a/src/function/scalar/string/like.cpp
+++ b/src/function/scalar/string/like.cpp
@@ -462,9 +462,9 @@ static void LikeEscapeFunction(DataChunk &args, ExpressionState &state, Vector &
 }
 
 template <class ASCII_OP>
-static unique_ptr<BaseStatistics> ILikePropagateStats(ClientContext &context, BoundFunctionExpression &expr,
-                                                      FunctionData *bind_data,
-                                                      vector<unique_ptr<BaseStatistics>> &child_stats) {
+static unique_ptr<BaseStatistics> ILikePropagateStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
 	D_ASSERT(child_stats.size() >= 1);
 	// can only propagate stats if the children have stats
 	if (!child_stats[0]) {

--- a/src/function/scalar/string/substring.cpp
+++ b/src/function/scalar/string/substring.cpp
@@ -169,9 +169,9 @@ static void SubstringFunctionASCII(DataChunk &args, ExpressionState &state, Vect
 	}
 }
 
-static unique_ptr<BaseStatistics> SubstringPropagateStats(ClientContext &context, BoundFunctionExpression &expr,
-                                                          FunctionData *bind_data,
-                                                          vector<unique_ptr<BaseStatistics>> &child_stats) {
+static unique_ptr<BaseStatistics> SubstringPropagateStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
 	// can only propagate stats if the children have stats
 	if (!child_stats[0]) {
 		return nullptr;

--- a/src/function/scalar/struct/struct_extract.cpp
+++ b/src/function/scalar/struct/struct_extract.cpp
@@ -108,9 +108,9 @@ static unique_ptr<FunctionData> StructExtractBind(ClientContext &context, Scalar
 	return make_unique<StructExtractBindData>(key, key_index, return_type);
 }
 
-static unique_ptr<BaseStatistics> PropagateStructExtractStats(ClientContext &context, BoundFunctionExpression &expr,
-                                                              FunctionData *bind_data,
-                                                              vector<unique_ptr<BaseStatistics>> &child_stats) {
+static unique_ptr<BaseStatistics> PropagateStructExtractStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &bind_data = input.bind_data;
 	if (!child_stats[0]) {
 		return nullptr;
 	}

--- a/src/function/scalar/struct/struct_pack.cpp
+++ b/src/function/scalar/struct/struct_pack.cpp
@@ -58,8 +58,9 @@ static unique_ptr<FunctionData> StructPackBind(ClientContext &context, ScalarFun
 	return make_unique<VariableReturnBindData>(bound_function.return_type);
 }
 
-unique_ptr<BaseStatistics> StructPackStats(ClientContext &context, BoundFunctionExpression &expr,
-                                           FunctionData *bind_data, vector<unique_ptr<BaseStatistics>> &child_stats) {
+unique_ptr<BaseStatistics> StructPackStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
 	auto struct_stats = make_unique<StructStatistics>(expr.return_type);
 	D_ASSERT(child_stats.size() == struct_stats->child_stats.size());
 	for (idx_t i = 0; i < struct_stats->child_stats.size(); i++) {

--- a/src/include/duckdb/common/operator/abs.hpp
+++ b/src/include/duckdb/common/operator/abs.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/limits.hpp"
 
 namespace duckdb {
 
@@ -21,21 +22,60 @@ struct AbsOperator {
 };
 
 template <>
-inline hugeint_t AbsOperator::Operation(const hugeint_t &input) {
+inline hugeint_t AbsOperator::Operation(hugeint_t input) {
 	const hugeint_t zero(0);
-	return (input < zero) ? (zero - input) : input;
+	return (input < zero) ? -input : input;
+}
+
+struct TryAbsOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return AbsOperator::Operation<TA, TR>(input);
+	}
+};
+
+template <>
+inline int8_t TryAbsOperator::Operation(int8_t input) {
+	if (input == NumericLimits<int8_t>::Minimum()) {
+		throw OutOfRangeException("Overflow on abs(%d)", input);
+	}
+	return input < 0 ? -input : input;
 }
 
 template <>
-inline dtime_t AbsOperator::Operation(const dtime_t &input) {
-	return dtime_t(AbsOperator::Operation<int64_t, int64_t>(input.micros));
+inline int16_t TryAbsOperator::Operation(int16_t input) {
+	if (input == NumericLimits<int16_t>::Minimum()) {
+		throw OutOfRangeException("Overflow on abs(%d)", input);
+	}
+	return input < 0 ? -input : input;
 }
 
 template <>
-inline interval_t AbsOperator::Operation(const interval_t &input) {
-	return {AbsOperator::Operation<int32_t, int32_t>(input.months),
-	        AbsOperator::Operation<int32_t, int32_t>(input.days),
-	        AbsOperator::Operation<int64_t, int64_t>(input.micros)};
+inline int32_t TryAbsOperator::Operation(int32_t input) {
+	if (input == NumericLimits<int32_t>::Minimum()) {
+		throw OutOfRangeException("Overflow on abs(%d)", input);
+	}
+	return input < 0 ? -input : input;
+}
+
+template <>
+inline int64_t TryAbsOperator::Operation(int64_t input) {
+	if (input == NumericLimits<int64_t>::Minimum()) {
+		throw OutOfRangeException("Overflow on abs(%d)", input);
+	}
+	return input < 0 ? -input : input;
+}
+
+template <>
+inline dtime_t TryAbsOperator::Operation(dtime_t input) {
+	return dtime_t(TryAbsOperator::Operation<int64_t, int64_t>(input.micros));
+}
+
+template <>
+inline interval_t TryAbsOperator::Operation(interval_t input) {
+	return {TryAbsOperator::Operation<int32_t, int32_t>(input.months),
+	        TryAbsOperator::Operation<int32_t, int32_t>(input.days),
+	        TryAbsOperator::Operation<int64_t, int64_t>(input.micros)};
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -25,6 +25,18 @@ struct FunctionLocalState {
 class BoundFunctionExpression;
 class ScalarFunctionCatalogEntry;
 
+struct FunctionStatisticsInput {
+	FunctionStatisticsInput(BoundFunctionExpression &expr_p, FunctionData *bind_data_p,
+	                        vector<unique_ptr<BaseStatistics>> &child_stats_p, unique_ptr<Expression> *expr_ptr_p)
+	    : expr(expr_p), bind_data(bind_data_p), child_stats(child_stats_p), expr_ptr(expr_ptr_p) {
+	}
+
+	BoundFunctionExpression &expr;
+	FunctionData *bind_data;
+	vector<unique_ptr<BaseStatistics>> &child_stats;
+	unique_ptr<Expression> *expr_ptr;
+};
+
 //! The type used for scalar functions
 typedef std::function<void(DataChunk &, ExpressionState &, Vector &)> scalar_function_t;
 //! Binds the scalar function and creates the function data
@@ -32,9 +44,7 @@ typedef unique_ptr<FunctionData> (*bind_scalar_function_t)(ClientContext &contex
                                                            vector<unique_ptr<Expression>> &arguments);
 typedef unique_ptr<FunctionLocalState> (*init_local_state_t)(const BoundFunctionExpression &expr,
                                                              FunctionData *bind_data);
-typedef unique_ptr<BaseStatistics> (*function_statistics_t)(ClientContext &context, BoundFunctionExpression &expr,
-                                                            FunctionData *bind_data,
-                                                            vector<unique_ptr<BaseStatistics>> &child_stats);
+typedef unique_ptr<BaseStatistics> (*function_statistics_t)(ClientContext &context, FunctionStatisticsInput &input);
 //! Adds the dependencies of this BoundFunctionExpression to the set of dependencies
 typedef void (*dependency_function_t)(BoundFunctionExpression &expr, unordered_set<CatalogEntry *> &dependencies);
 

--- a/src/optimizer/statistics/expression/propagate_function.cpp
+++ b/src/optimizer/statistics/expression/propagate_function.cpp
@@ -13,7 +13,8 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundFuncti
 	if (!func.function.statistics) {
 		return nullptr;
 	}
-	return func.function.statistics(context, func, func.bind_info.get(), stats);
+	FunctionStatisticsInput input(func, func.bind_info.get(), stats, expr_ptr);
+	return func.function.statistics(context, input);
 }
 
 } // namespace duckdb

--- a/test/fuzzer/sqlsmith/generate_series_overflow.test
+++ b/test/fuzzer/sqlsmith/generate_series_overflow.test
@@ -1,0 +1,34 @@
+# name: test/fuzzer/sqlsmith/generate_series_overflow.test
+# description: Fuzzer #26: overflow in generate series
+# group: [sqlsmith]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE tbl(bigint BIGINT);
+
+statement ok
+INSERT INTO tbl VALUES(-9223372036854775808);
+
+statement ok
+INSERT INTO tbl VALUES(9223372036854775807);
+
+statement ok
+INSERT INTO tbl VALUES(NULL);
+
+statement error
+SELECT generate_series(CAST(ref_0."bigint" AS BIGINT)) AS c1 FROM tbl AS ref_0
+
+statement error
+SELECT generate_series(-9223372036854775808, 9223372036854775807, 1) AS c1
+
+query I
+SELECT generate_series(9223372036854775805, 9223372036854775807, 1) AS c1
+----
+[9223372036854775805, 9223372036854775806, 9223372036854775807]
+
+query I
+SELECT generate_series(-9223372036854775806, -9223372036854775808, -1) AS c1
+----
+[-9223372036854775806, -9223372036854775807, -9223372036854775808]

--- a/test/fuzzer/sqlsmith/test_abs_overflow.test
+++ b/test/fuzzer/sqlsmith/test_abs_overflow.test
@@ -1,0 +1,22 @@
+# name: test/fuzzer/sqlsmith/test_abs_overflow.test
+# description: Fuzzer #29: test abs overflow
+# group: [sqlsmith]
+
+statement ok
+PRAGMA enable_verification
+
+# test abs function on extremes
+
+statement ok
+CREATE TABLE numerics AS SELECT tinyint, smallint, int, bigint FROM test_all_types();
+
+foreach type tinyint smallint int bigint
+
+statement error
+SELECT abs(${type}) FROM numerics;
+
+statement ok
+SELECT abs(${type}) FROM numerics WHERE ${type} > 0;
+
+endloop
+

--- a/test/optimizer/statistics/statistics_numeric.test
+++ b/test/optimizer/statistics/statistics_numeric.test
@@ -1,0 +1,102 @@
+# name: test/optimizer/statistics/statistics_numeric.test
+# description: Statistics propagation of numeric functions
+# group: [statistics]
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
+statement ok
+CREATE TABLE integers(i INTEGER);
+
+statement ok
+INSERT INTO integers VALUES (1), (10);
+
+# abs with only positive values
+query I
+SELECT ABS(i) FROM integers ORDER BY i
+----
+1
+10
+
+query I
+SELECT STATS(ABS(i)) FROM integers LIMIT 1
+----
+<REGEX>:.*1.*10.*
+
+# verify that the call to abs gets removed by the optimizer out
+query II
+EXPLAIN SELECT ABS(i) FROM integers ORDER BY i;
+----
+logical_opt	<!REGEX>:.*abs.*
+
+
+# mix of positive and negative values
+statement ok
+INSERT INTO integers VALUES (-5)
+
+query I
+SELECT STATS(ABS(i)) FROM integers LIMIT 1
+----
+<REGEX>:.*0.*10.*
+
+query I
+SELECT ABS(i) FROM integers ORDER BY i
+----
+5
+1
+10
+
+# the call to abs can no longer be removed
+query II
+EXPLAIN SELECT ABS(i) FROM integers ORDER BY i;
+----
+logical_opt	<REGEX>:.*abs.*
+
+
+statement ok
+INSERT INTO integers VALUES (-15)
+
+query I
+SELECT STATS(ABS(i)) FROM integers LIMIT 1
+----
+<REGEX>:.*0.*15.*
+
+query I
+SELECT ABS(i) FROM integers ORDER BY i
+----
+15
+5
+1
+10
+
+statement ok
+INSERT INTO integers VALUES (0)
+
+query I
+SELECT STATS(ABS(i)) FROM integers LIMIT 1
+----
+<REGEX>:.*0.*15.*
+
+query I
+SELECT ABS(i) FROM integers ORDER BY i
+----
+15
+5
+0
+1
+10
+
+# only negative values
+statement ok
+DROP TABLE integers
+
+statement ok
+CREATE TABLE integers(i INTEGER);
+
+statement ok
+INSERT INTO integers VALUES (-1), (-10);
+
+query I
+SELECT STATS(ABS(i)) FROM integers LIMIT 1
+----
+<REGEX>:.*1.*10.*

--- a/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
@@ -133,7 +133,7 @@ public:
 
 	unique_ptr<DuckDBPyRelation> Mode(const string &aggr_columns, const string &groups = "");
 
-	unique_ptr<DuckDBPyRelation> Abs(const string &aggr_columns, const string &groups = "");
+	unique_ptr<DuckDBPyRelation> Abs(const string &aggr_columns);
 	unique_ptr<DuckDBPyRelation> Prod(const string &aggr_columns, const string &groups = "");
 
 	unique_ptr<DuckDBPyRelation> Skew(const string &aggr_columns, const string &groups = "");

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -69,9 +69,8 @@ void DuckDBPyRelation::Initialize(py::handle &m) {
 	    .def("mode", &DuckDBPyRelation::Mode,
 	         "Returns the most frequent value for the aggregate columns. NULL values are ignored.",
 	         py::arg("aggregation_columns"), py::arg("group_columns") = "")
-	    .def("abs", &DuckDBPyRelation::Abs,
-	         "Returns the most absolute value for the  aggregate columns. NULL values are ignored.",
-	         py::arg("aggregation_columns"), py::arg("group_columns") = "")
+	    .def("abs", &DuckDBPyRelation::Abs, "Returns the absolute value for the specified columns.",
+	         py::arg("aggregation_columns"))
 	    .def("prod", &DuckDBPyRelation::Prod, "Calculates the product of the aggregate column.",
 	         py::arg("aggregation_columns"), py::arg("group_columns") = "")
 	    .def("skew", &DuckDBPyRelation::Skew, "Returns the skewness of the aggregate column.",
@@ -340,8 +339,9 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Mode(const string &aggr_columns, 
 	return GenericAggregator("mode", aggr_columns, groups);
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Abs(const string &aggr_columns, const string &groups) {
-	return GenericAggregator("abs", aggr_columns, groups);
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Abs(const string &columns) {
+	auto expr = GenerateExpressionList("abs", columns);
+	return Project(expr);
 }
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Prod(const string &aggr_columns, const string &groups) {
 	return GenericAggregator("product", aggr_columns, groups);


### PR DESCRIPTION
* Fix a signed integer overflow in the `generate_series` function
* Fix a signed integer overflow in the `abs` operator
* Add statistics propagation to the `abs` operator
* Slight clean-up of statistics propagation by adding a `FunctionStatisticsInput` struct as input to the function