### PR TITLE
Allow to use custom memory allocator through DuckDB API on Windows

### DIFF
--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -28,10 +28,8 @@ Allocator::Allocator(allocate_function_ptr_t allocate_function_p, free_function_
       reallocate_function(reallocate_function_p), private_data(move(private_data)) {
 }
 
-Allocator& Allocator::operator=(Allocator &&allocator)
-{
-	if (this != &allocator)
-	{
+Allocator &Allocator::operator=(Allocator &&allocator) {
+	if (this != &allocator) {
 		allocate_function = allocator.allocate_function;
 		free_function = allocator.free_function;
 		reallocate_function = allocator.reallocate_function;

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -28,16 +28,6 @@ Allocator::Allocator(allocate_function_ptr_t allocate_function_p, free_function_
       reallocate_function(reallocate_function_p), private_data(move(private_data)) {
 }
 
-Allocator &Allocator::operator=(Allocator &&allocator) noexcept {
-	if (this != &allocator) {
-		allocate_function = allocator.allocate_function;
-		free_function = allocator.free_function;
-		reallocate_function = allocator.reallocate_function;
-		private_data = move(allocator.private_data);
-	}
-	return *this;
-}
-
 data_ptr_t Allocator::AllocateData(idx_t size) {
 	return allocate_function(private_data.get(), size);
 }

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -28,14 +28,14 @@ Allocator::Allocator(allocate_function_ptr_t allocate_function_p, free_function_
       reallocate_function(reallocate_function_p), private_data(move(private_data)) {
 }
 
-Allocator& Allocator::operator=( Allocator &&allocator )
+Allocator& Allocator::operator=(Allocator &&allocator)
 {
-	if ( this != &allocator )
+	if (this != &allocator)
 	{
 		allocate_function = allocator.allocate_function;
 		free_function = allocator.free_function;
 		reallocate_function = allocator.reallocate_function;
-		private_data = move( allocator.private_data );
+		private_data = move(allocator.private_data);
 	}
 	return *this;
 }

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -38,7 +38,6 @@ Allocator &Allocator::operator=(Allocator &&allocator) {
 	return *this;
 }
 
-
 data_ptr_t Allocator::AllocateData(idx_t size) {
 	return allocate_function(private_data.get(), size);
 }

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -28,7 +28,7 @@ Allocator::Allocator(allocate_function_ptr_t allocate_function_p, free_function_
       reallocate_function(reallocate_function_p), private_data(move(private_data)) {
 }
 
-Allocator &Allocator::operator=(Allocator &&allocator) {
+Allocator &Allocator::operator=(Allocator &&allocator) noexcept {
 	if (this != &allocator) {
 		allocate_function = allocator.allocate_function;
 		free_function = allocator.free_function;

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -28,6 +28,19 @@ Allocator::Allocator(allocate_function_ptr_t allocate_function_p, free_function_
       reallocate_function(reallocate_function_p), private_data(move(private_data)) {
 }
 
+Allocator& Allocator::operator=( Allocator &&allocator )
+{
+	if ( this != &allocator )
+	{
+		allocate_function = allocator.allocate_function;
+		free_function = allocator.free_function;
+		reallocate_function = allocator.reallocate_function;
+		private_data = move( allocator.private_data );
+	}
+	return *this;
+}
+
+
 data_ptr_t Allocator::AllocateData(idx_t size) {
 	return allocate_function(private_data.get(), size);
 }

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -53,7 +53,7 @@ public:
 	                     reallocate_function_ptr_t reallocate_function_p,
 	                     unique_ptr<PrivateAllocatorData> private_data);
 
-	DUCKDB_API Allocator &operator=(Allocator &&allocator);
+	DUCKDB_API Allocator &operator=(Allocator &&allocator) noexcept;
 
 	data_ptr_t AllocateData(idx_t size);
 	void FreeData(data_ptr_t pointer, idx_t size);

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -53,7 +53,7 @@ public:
 	                     reallocate_function_ptr_t reallocate_function_p,
 	                     unique_ptr<PrivateAllocatorData> private_data);
 
-	DUCKDB_API Allocator &operator=(Allocator &&allocator) noexcept;
+	DUCKDB_API Allocator &operator=(Allocator &&allocator) noexcept = default;
 
 	data_ptr_t AllocateData(idx_t size);
 	void FreeData(data_ptr_t pointer, idx_t size);

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -50,9 +50,10 @@ class Allocator {
 public:
 	DUCKDB_API Allocator();
 	DUCKDB_API Allocator(allocate_function_ptr_t allocate_function_p, free_function_ptr_t free_function_p,
-	          reallocate_function_ptr_t reallocate_function_p, unique_ptr<PrivateAllocatorData> private_data);
+	                     reallocate_function_ptr_t reallocate_function_p,
+						 unique_ptr<PrivateAllocatorData> private_data);
 
-	DUCKDB_API Allocator& operator=( Allocator &&allocator );
+	DUCKDB_API Allocator& operator=(Allocator &&allocator);
 
 	data_ptr_t AllocateData(idx_t size);
 	void FreeData(data_ptr_t pointer, idx_t size);

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -51,9 +51,9 @@ public:
 	DUCKDB_API Allocator();
 	DUCKDB_API Allocator(allocate_function_ptr_t allocate_function_p, free_function_ptr_t free_function_p,
 	                     reallocate_function_ptr_t reallocate_function_p,
-						 unique_ptr<PrivateAllocatorData> private_data);
+	                     unique_ptr<PrivateAllocatorData> private_data);
 
-	DUCKDB_API Allocator& operator=(Allocator &&allocator);
+	DUCKDB_API Allocator &operator=(Allocator &&allocator);
 
 	data_ptr_t AllocateData(idx_t size);
 	void FreeData(data_ptr_t pointer, idx_t size);

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -48,9 +48,11 @@ private:
 
 class Allocator {
 public:
-	Allocator();
-	Allocator(allocate_function_ptr_t allocate_function_p, free_function_ptr_t free_function_p,
+	DUCKDB_API Allocator();
+	DUCKDB_API Allocator(allocate_function_ptr_t allocate_function_p, free_function_ptr_t free_function_p,
 	          reallocate_function_ptr_t reallocate_function_p, unique_ptr<PrivateAllocatorData> private_data);
+
+	DUCKDB_API Allocator& operator=( Allocator &&allocator );
 
 	data_ptr_t AllocateData(idx_t size);
 	void FreeData(data_ptr_t pointer, idx_t size);


### PR DESCRIPTION
I tried to use more than 50 DuckDB databases simultaneously, but I found a quick process memory heap degradation (fragmentation), it slows down all operations with databases (Windows 10). Closing and opening of databases didn't help (the process heap was already fragmented). Only the process restart can help. A simplest solution is the assigning to each database its-own memory heap using a custom memory allocator.

Currently there is no way to use a custom memory allocator through API because duckdb::Allocator and duckdb::Allocator ::operator= isn't exported in DLL.
This path adds exporting of missed functions.

Sample:
class MyAllocator : public duckdb::PrivateAllocatorData
{
....
}

std::unique_ptr<duckdb::PrivateAllocatorData> my_allocator( new MyAllocator() );

duckdb::Allocator duckdb_allocator( &MyAllocator::Allocate, &MyAllocator::Free, &MyAllocator::Reallocate, std::move( my_allocator ) );

DBConfig config;
config.allocator = std::move( duckdb_allocator );
...
