### PR TITLE
[JDBC] Pass through scale and precision for decimal types from DuckDBColumnTypeMetaData

### DIFF
--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSetMetaData.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSetMetaData.java
@@ -217,11 +217,23 @@ public class DuckDBResultSetMetaData implements ResultSetMetaData {
 	}
 
 	public int getPrecision(int column) throws SQLException {
-		return 0;
+		DuckDBColumnTypeMetaData typeMetaData = typeMetadataForColumn(column);
+
+		if (typeMetaData == null) {
+			return 0;
+		}
+
+		return typeMetaData.width;
 	}
 
 	public int getScale(int column) throws SQLException {
-		return 0;
+		DuckDBColumnTypeMetaData typeMetaData = typeMetadataForColumn(column);
+
+		if (typeMetaData == null) {
+			return 0;
+		}
+
+		return typeMetaData.scale;
 	}
 
 	public String getTableName(int column) throws SQLException {
@@ -238,5 +250,12 @@ public class DuckDBResultSetMetaData implements ResultSetMetaData {
 
 	public boolean isWrapperFor(Class<?> iface) throws SQLException {
 		throw new SQLFeatureNotSupportedException();
+	}
+
+	private DuckDBColumnTypeMetaData typeMetadataForColumn(int columnIndex) throws SQLException {
+		if (columnIndex > column_count) {
+			throw new SQLException("Column index out of bounds");
+		}
+		return column_types_meta[columnIndex - 1];
 	}
 }

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -865,6 +865,17 @@ public class TestDuckDBJDBC {
 		assertTrue(BigDecimal.class.toString().equals(meta.getColumnClassName(3)));
 		assertTrue(BigDecimal.class.toString().equals(meta.getColumnClassName(4)));
 
+		assertEquals(3, meta.getPrecision(1));
+		assertEquals(0, meta.getScale(1));
+		assertEquals(4, meta.getPrecision(2));
+		assertEquals(1, meta.getScale(2));
+		assertEquals(9, meta.getPrecision(3));
+		assertEquals(4, meta.getScale(3));
+		assertEquals(18, meta.getPrecision(4));
+		assertEquals(7, meta.getScale(4));
+		assertEquals(38, meta.getPrecision(5));
+		assertEquals(10, meta.getScale(5));
+
 		conn.close();
 	}
 


### PR DESCRIPTION
Fixes #3840