### PR TITLE
Enable EXTENSION_STATIC_BUILD for Mac too

### DIFF
--- a/.github/actions/ubuntu_16_setup/action.yml
+++ b/.github/actions/ubuntu_16_setup/action.yml
@@ -59,7 +59,7 @@ runs:
         wget https://www.openssl.org/source/openssl-1.1.1c.tar.gz
         tar -xf openssl-1.1.1c.tar.gz
         cd openssl-1.1.1c
-        ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl -static zlib
+        ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl no-shared zlib-dynamic
         make
         make install
         echo "/usr/local/ssl/lib" > /etc/ld.so.conf.d/openssl-1.1.1c.conf

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -163,6 +163,7 @@ jobs:
           post_install: rm build/release/src/libduckdb*
           run_tests: 0
           out_of_tree_ext: 1
+          static_link_build: 1
 
       - name: Deploy
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -681,21 +681,25 @@ function(build_loadable_extension_directory NAME OUTPUT_DIRECTORY)
   # Windows:  For windows, delay loading could be used to achieve similar behaviour as MacOS, but since this requires
   #           setting the _declspec header for every function used from an extension, we have also opted for the
   #           EXTENSION_STATIC_BUILD approach
-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    set_target_properties(${TARGET_NAME} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
-  endif()
-
   if (EXTENSION_STATIC_BUILD)
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-      target_link_libraries(${TARGET_NAME} duckdb_static ${DUCKDB_EXTRA_LINK_FLAGS} -Wl,--gc-sections -Wl,--exclude-libs,ALL)
+      # For GNU we rely on fvisibility=hidden to hide the extension symbols and use -exclude-libs to hide the duckdb symbols
+      set_target_properties(${TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
+      target_link_libraries(${TARGET_NAME} PRIVATE duckdb_static ${DUCKDB_EXTRA_LINK_FLAGS} -Wl,--gc-sections -Wl,--exclude-libs,ALL)
     elseif (WIN32)
       target_link_libraries(${TARGET_NAME} duckdb_static ${DUCKDB_EXTRA_LINK_FLAGS})
+    elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+      set_target_properties(${TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
+      # Note that on MacOS we need to use the -exported_symbol whitelist feature due to a lack of -exclude-libs flag in mac's ld variant
+      target_link_libraries(${TARGET_NAME} duckdb_static ${DUCKDB_EXTRA_LINK_FLAGS} -Wl,-dead_strip -Wl,-exported_symbol,_${NAME}_init -Wl,-exported_symbol,_${NAME}_version)
     else()
       error("EXTENSION static build is only intended for Linux and Windows on MVSC")
     endif()
   else()
     if (WIN32)
       target_link_libraries(${TARGET_NAME} duckdb ${DUCKDB_EXTRA_LINK_FLAGS})
+    elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+      set_target_properties(${TARGET_NAME} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
     endif()
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -685,7 +685,7 @@ function(build_loadable_extension_directory NAME OUTPUT_DIRECTORY)
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
       # For GNU we rely on fvisibility=hidden to hide the extension symbols and use -exclude-libs to hide the duckdb symbols
       set_target_properties(${TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
-      target_link_libraries(${TARGET_NAME} PRIVATE duckdb_static ${DUCKDB_EXTRA_LINK_FLAGS} -Wl,--gc-sections -Wl,--exclude-libs,ALL)
+      target_link_libraries(${TARGET_NAME} duckdb_static ${DUCKDB_EXTRA_LINK_FLAGS} -Wl,--gc-sections -Wl,--exclude-libs,ALL)
     elseif (WIN32)
       target_link_libraries(${TARGET_NAME} duckdb_static ${DUCKDB_EXTRA_LINK_FLAGS})
     elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -673,14 +673,15 @@ function(build_loadable_extension_directory NAME OUTPUT_DIRECTORY)
   set_target_properties(${TARGET_NAME} PROPERTIES OUTPUT_NAME ${NAME})
   set_target_properties(${TARGET_NAME} PROPERTIES PREFIX "")
 
-  # Resolution of DuckDB symbols in loadable extensions is done in different ways
-  # MacOS:    The -undefined dynamic_lookup signals CLANG to ignore any missing DuckDB symbols. Because on MacOS dlopen
-  #           is called with the RTLD_GLOBAL flag by default, duckdb symbols are available when the extension is loaded.
-  # Linux:    DuckDB needs to be linked statically to each extension because RTLD_LOCAL is the default on linux. The
-  #           EXTENSION_STATIC_BUILD should be set for this.
-  # Windows:  For windows, delay loading could be used to achieve similar behaviour as MacOS, but since this requires
-  #           setting the _declspec header for every function used from an extension, we have also opted for the
-  #           EXTENSION_STATIC_BUILD approach
+  # loadable extension binaries can be built two ways:
+  # 1. EXTENSION_STATIC_BUILD=1
+  #    DuckDB is statically linked into each extension binary. This increases portability because in several situations
+  #    DuckDB itself may have been loaded with RTLD_LOCAL. This is currently the main way we distribute the lodable
+  #    extension binaries
+  # 2. EXTENSION_STATIC_BUILD=0
+  #    The DuckDB symbols required by the loadable extensions are left unresolved. This will reduce the size of the binaries
+  #    and works well when running the DuckDB cli directly. For windows this uses delay loading. For MacOS and linux the
+  #    dynamic loader will look up the missing symbols when the extension is dlopen-ed.
   if (EXTENSION_STATIC_BUILD)
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
       # For GNU we rely on fvisibility=hidden to hide the extension symbols and use -exclude-libs to hide the duckdb symbols

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -22,6 +22,19 @@
 #endif
 #endif
 
+// duplicate of duckdb/main/winapi.hpp
+#ifndef DUCKDB_EXTENSION_API
+#ifdef _WIN32
+#ifdef DUCKDB_BUILD_LOADABLE_EXTENSION
+#define DUCKDB_EXTENSION_API __declspec(dllexport)
+#else
+#define DUCKDB_EXTENSION_API
+#endif
+#else
+#define DUCKDB_EXTENSION_API __attribute__((visibility("default")))
+#endif
+#endif
+
 // duplicate of duckdb/common/constants.hpp
 #ifndef DUCKDB_API_0_3_1
 #define DUCKDB_API_0_3_1 1

--- a/src/include/duckdb/common/dl.hpp
+++ b/src/include/duckdb/common/dl.hpp
@@ -14,7 +14,7 @@
 #ifndef _WIN32
 #include <dlfcn.h>
 #else
-#define RTLD_NOW  0
+#define RTLD_NOW   0
 #define RTLD_LOCAL 0
 #endif
 

--- a/src/include/duckdb/common/dl.hpp
+++ b/src/include/duckdb/common/dl.hpp
@@ -14,7 +14,7 @@
 #ifndef _WIN32
 #include <dlfcn.h>
 #else
-#define RTLD_LAZY  0
+#define RTLD_NOW  0
 #define RTLD_LOCAL 0
 #endif
 

--- a/src/include/duckdb/common/winapi.hpp
+++ b/src/include/duckdb/common/winapi.hpp
@@ -28,6 +28,6 @@
 #define DUCKDB_EXTENSION_API
 #endif
 #else
-#define DUCKDB_EXTENSION_API
+#define DUCKDB_EXTENSION_API __attribute__((visibility("default")))
 #endif
 #endif

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -39,7 +39,7 @@ void ExtensionHelper::LoadExternalExtension(DatabaseInstance &db, const string &
 	if (!fs.FileExists(filename)) {
 		throw IOException("File \"%s\" not found", filename);
 	}
-	auto lib_hdl = dlopen(filename.c_str(), RTLD_LAZY | RTLD_LOCAL);
+	auto lib_hdl = dlopen(filename.c_str(), RTLD_NOW | RTLD_LOCAL);
 	if (!lib_hdl) {
 		throw IOException("File \"%s\" could not be loaded: %s", filename, GetDLError());
 	}


### PR DESCRIPTION
This PR:
- enables the EXTENSION_STATIC_BUILD flag for the MacOS binaries which seems to fix the persisting R extension loading issues.
- on Linux and MacOS we now use fvisibility=hidden for all symbols in the loadable extension except for the `<modulename>_init` and `<modulename>_version` methods. The benefit is that it should reduce the risk of weird unexpected behaviour because the extension symbols are hidden from the main program.
- switched to RTLD_NOW for extension loading. We don't need the RTLD_LAZY as there are only 2 symbols in the extension anyway and I think we would rather fail immediately on loading the extensions in case of missing symbols (which shouldn't happen with the static builds anyway since extensions should not have any missing duckdb symbols to be resolved by the dynamic linker).