### PR TITLE
Added support for generated columns to TableCatalogEntry->ToSQL()

### DIFF
--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -671,6 +671,9 @@ string TableCatalogEntry::ToSQL() {
 		if (column.DefaultValue()) {
 			ss << " DEFAULT(" << column.DefaultValue()->ToString() << ")";
 		}
+		if (column.Generated()) {
+			ss << " GENERATED ALWAYS AS(" << column.GeneratedExpression().ToString() << ")";
+		}
 	}
 	// print any extra constraints that still need to be printed
 	for (auto &extra_constraint : extra_constraints) {

--- a/test/sql/export/export_generated_columns.test
+++ b/test/sql/export/export_generated_columns.test
@@ -1,0 +1,32 @@
+# name: test/sql/export/export_generated_columns.test
+# description: Test export of generated columns
+# group: [export]
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+CREATE TABLE tbl (
+	x INTEGER,
+	gen_x AS (x + 5)
+);
+
+statement ok
+INSERT INTO tbl VALUES(5);
+
+statement ok
+EXPORT DATABASE '__TEST_DIR__/export_generated_columns' (FORMAT CSV);
+
+statement ok
+ROLLBACK
+
+statement ok
+IMPORT DATABASE '__TEST_DIR__/export_generated_columns'
+
+# Generated columns can not be inserted into directly
+statement error
+INSERT INTO tbl VALUES(2,3)
+
+# 'x' can not be removed, as 'gen_x' depends on it
+statement error
+ALTER TABLE tbl DROP COLUMN x;

--- a/test/sql/export/export_generated_columns.test
+++ b/test/sql/export/export_generated_columns.test
@@ -14,6 +14,14 @@ CREATE TABLE tbl (
 statement ok
 INSERT INTO tbl VALUES(5);
 
+# Generated columns can not be inserted into directly
+statement error
+INSERT INTO tbl VALUES(2,3)
+
+# 'x' can not be removed, as 'gen_x' depends on it
+statement error
+ALTER TABLE tbl DROP COLUMN x;
+
 statement ok
 EXPORT DATABASE '__TEST_DIR__/export_generated_columns' (FORMAT CSV);
 


### PR DESCRIPTION
This PR fixes #3851 

Previously generated expressions weren't added when exporting a table to SQL, this causes the generated column to turn into a regular column on re-import.
I've also added a test to the 'export' tests that tests two situations that should (still) error after re-importing the database.