### PR TITLE
NodeJS search paths

### DIFF
--- a/tools/nodejs/src/duckdb_node.hpp
+++ b/tools/nodejs/src/duckdb_node.hpp
@@ -150,6 +150,7 @@ class Utils {
 public:
 	static Napi::Value CreateError(Napi::Env env, std::string msg);
 	static bool OtherIsInt(Napi::Number source);
+	static bool IsStringArray(Napi::Value source);
 
 	template <class T>
 	static T *NewUnwrap(std::vector<napi_value> args) {

--- a/tools/nodejs/src/utils.cpp
+++ b/tools/nodejs/src/utils.cpp
@@ -12,6 +12,20 @@ bool Utils::OtherIsInt(Napi::Number source) {
 	}
 }
 
+bool Utils::IsStringArray(Napi::Value source) {
+	if (source.IsArray()) {
+		auto array = source.As<Napi::Array>();
+		for (uint32_t index = 0; index < array.Length(); index++) {
+			auto value = array.Get(index);
+			if (!value.IsString()) {
+				return false;
+			}
+		}
+		return true;
+	}
+	return false;
+}
+
 Napi::Value Utils::CreateError(Napi::Env env, std::string msg) {
 	auto err = Napi::Error::New(env, Napi::String::New(env, msg).Utf8Value()).Value();
 	Napi::Object obj = err.As<Napi::Object>();

--- a/tools/nodejs/test/pathnames.test.js
+++ b/tools/nodejs/test/pathnames.test.js
@@ -1,0 +1,25 @@
+var sqlite3 = require('..');
+var assert = require("assert");
+
+describe("pathname search support", function () {
+    let db;
+    it("supports full paths", function (done) {
+        db = new sqlite3.Database(":memory:", () => {
+            db.prepare('select * from "test/support/prepare.csv"').all((err, result) => {
+                assert(err === null);
+                assert(result.length === 5000);
+                done();
+            });
+        });
+    });
+
+    it("supports search paths", function (done) {
+        db = new sqlite3.Database(":memory:", ["test/support/"], () => {
+            db.prepare('select * from "prepare.csv"').all((err, result) => {
+                assert(err === null);
+                assert(result.length === 5000);
+                done();
+            });
+        });
+    });
+});

--- a/tools/nodejs/test/pathnames.test.js
+++ b/tools/nodejs/test/pathnames.test.js
@@ -3,9 +3,44 @@ var assert = require("assert");
 
 describe("pathname search support", function () {
     let db;
-    it("supports full paths", function (done) {
-        db = new sqlite3.Database(":memory:", () => {
+    describe('without search paths', () => {
+        before((done) => {
+            db = new sqlite3.Database(":memory:", done)
+        });
+
+        it("supports a full path", function (done) {
             db.prepare('select * from "test/support/prepare.csv"').all((err, result) => {
+                assert(err === null);
+                assert(result.length === 5000);
+                done();
+            });
+        });
+
+        it("don't not support a partial path", function (done) {
+            db.prepare('select * from "prepare.csv"').all((err, result) => {
+                assert(err.code === 'DUCKDB_NODEJS_ERROR');
+                assert(err.errno === -1);
+                assert(result == null);
+                done();
+            });
+        });
+    })
+
+    describe('with search paths', () => {
+        before((done) => {
+            db = new sqlite3.Database(":memory:", ["test/support/"], done)
+        });
+
+        it("supports a full path", function (done) {
+            db.prepare('select * from "test/support/prepare.csv"').all((err, result) => {
+                assert(err === null);
+                assert(result.length === 5000);
+                done();
+            });
+        });
+
+        it("supports a partial path", function (done) {
+            db.prepare('select * from "prepare.csv"').all((err, result) => {
                 assert(err === null);
                 assert(result.length === 5000);
                 done();
@@ -13,8 +48,20 @@ describe("pathname search support", function () {
         });
     });
 
-    it("supports search paths", function (done) {
-        db = new sqlite3.Database(":memory:", ["test/support/"], () => {
+    describe('with multiple search paths', () => {
+        before((done) => {
+            db = new sqlite3.Database(":memory:", ["test/", "test/support/"], done)
+        });
+
+        it("supports a full path", function (done) {
+            db.prepare('select * from "test/support/prepare.csv"').all((err, result) => {
+                assert(err === null);
+                assert(result.length === 5000);
+                done();
+            });
+        });
+
+        it("supports a partial path", function (done) {
             db.prepare('select * from "prepare.csv"').all((err, result) => {
                 assert(err === null);
                 assert(result.length === 5000);


### PR DESCRIPTION
Allows an array of strings argument that can be used to prefix table names so that files can be accessed with relative paths that are not relative to the current working directory. Part of https://github.com/looker-open-source/malloy/issues/555.