### PR TITLE
Fix #3860: add support for creating foreign keys on temporary tables, and for now disable support for cross-schema foreign keys

### DIFF
--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -437,6 +437,7 @@ unique_ptr<CatalogEntry> TableCatalogEntry::ChangeColumnType(ClientContext &cont
 	}
 	auto change_idx = GetColumnIndex(info.column_name);
 	auto create_info = make_unique<CreateTableInfo>(schema->name, name);
+	create_info->temporary = temporary;
 
 	for (idx_t i = 0; i < columns.size(); i++) {
 		auto copy = columns[i].Copy();
@@ -518,6 +519,7 @@ unique_ptr<CatalogEntry> TableCatalogEntry::ChangeColumnType(ClientContext &cont
 
 unique_ptr<CatalogEntry> TableCatalogEntry::SetForeignKeyConstraint(ClientContext &context, AlterForeignKeyInfo &info) {
 	auto create_info = make_unique<CreateTableInfo>(schema->name, name);
+	create_info->temporary = temporary;
 
 	for (idx_t i = 0; i < columns.size(); i++) {
 		create_info->columns.push_back(columns[i].Copy());

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -326,6 +326,8 @@ BoundStatement Binder::Bind(CreateStatement &stmt) {
 		// If there is a foreign key constraint, resolve primary key column's index from primary key column's name
 		auto &create_info = (CreateTableInfo &)*stmt.info;
 		auto &catalog = Catalog::GetCatalog(context);
+		// We first check if there are any user types, if yes we check to which custom types they refer.
+		unordered_set<SchemaCatalogEntry *> fk_schemas;
 		for (idx_t i = 0; i < create_info.constraints.size(); i++) {
 			auto &cond = create_info.constraints[i];
 			if (cond->type != ConstraintType::FOREIGN_KEY) {
@@ -342,6 +344,7 @@ BoundStatement Binder::Bind(CreateStatement &stmt) {
 			} else {
 				// have to resolve referenced table
 				auto pk_table_entry_ptr = catalog.GetEntry<TableCatalogEntry>(context, fk.info.schema, fk.info.table);
+				fk_schemas.insert(pk_table_entry_ptr->schema);
 				D_ASSERT(fk.info.pk_keys.empty());
 				FindMatchingPrimaryKeyColumns(pk_table_entry_ptr->constraints, fk);
 				for (auto &keyname : fk.pk_columns) {
@@ -366,9 +369,14 @@ BoundStatement Binder::Bind(CreateStatement &stmt) {
 		if (AnyConstraintReferencesGeneratedColumn(create_info)) {
 			throw BinderException("Constraints on generated columns are not supported yet");
 		}
-		// We first check if there are any user types, if yes we check to which custom types they refer.
 		auto bound_info = BindCreateTableInfo(move(stmt.info));
 		auto root = move(bound_info->query);
+
+		for (auto &fk_schema : fk_schemas) {
+			if (fk_schema != bound_info->schema) {
+				throw BinderException("Creating foreign keys across different schemas is not supported");
+			}
+		}
 
 		// create the logical operator
 		auto &schema = bound_info->schema;

--- a/test/sql/constraints/foreignkey/test_fk_cross_schema.test
+++ b/test/sql/constraints/foreignkey/test_fk_cross_schema.test
@@ -1,0 +1,18 @@
+# name: test/sql/constraints/foreignkey/test_fk_cross_schema.test
+# description: Test foreign key constraint across different schemas
+# group: [foreignkey]
+
+statement ok
+CREATE SCHEMA s1
+
+statement ok
+CREATE SCHEMA s2
+
+statement ok
+CREATE TABLE s1.pk_integers(i INTEGER PRIMARY KEY)
+
+statement ok
+INSERT INTO s1.pk_integers VALUES (1), (2), (3)
+
+statement error
+CREATE TABLE s2.fk_integers(j INTEGER, FOREIGN KEY (j) REFERENCES s1.pk_intexgers(i))

--- a/test/sql/constraints/foreignkey/test_fk_temporary.test
+++ b/test/sql/constraints/foreignkey/test_fk_temporary.test
@@ -1,0 +1,247 @@
+# name: test/sql/constraints/foreignkey/test_fk_temporary.test
+# description: Test foreign key constraint
+# group: [foreignkey]
+
+statement ok
+CREATE TEMPORARY TABLE album(artistid INTEGER, albumname TEXT, albumcover TEXT, UNIQUE (artistid, albumname));
+
+statement ok
+INSERT INTO album VALUES (1, 'A', 'A_cover'), (2, 'B', 'B_cover'), (3, 'C', 'C_cover'), (4, 'D', 'D_cover');
+
+statement ok
+CREATE TEMPORARY TABLE song(songid INTEGER, songartist INTEGER, songalbum TEXT, songname TEXT, FOREIGN KEY(songartist, songalbum) REFERENCES album(artistid, albumname));
+
+# Any row that is inserted into the table with the foreign key must exist in the table with the primary key (constraint)
+statement error
+INSERT INTO song VALUES (11, 1, 'A', 'A_song'), (12, 2, 'E', 'B_song'), (13, 3, 'C', 'C_song');
+
+statement error
+INSERT INTO song VALUES (11, 1, 'A', 'A_song'), (12, 5, 'D', 'B_song'), (13, 3, 'C', 'C_song');
+
+statement ok
+INSERT INTO song VALUES (11, 1, 'A', 'A_song'), (12, 2, 'B', 'B_song'), (13, 3, 'C', 'C_song');
+
+# Any row that is deleted from the table with the primary key must not exist in the table with the foreign key (constraint)
+statement error
+DELETE FROM album WHERE albumname='C';
+
+statement ok
+DELETE FROM album WHERE albumname='D';
+
+query ITT
+SELECT * FROM album;
+----
+1	A	A_cover
+2	B	B_cover
+3	C	C_cover
+
+# Any row that is updated from the table has foreign key must exist in the table with the primary key (constraint)
+statement error
+UPDATE song SET songartist=5, songalbum='A' WHERE songname='B_song';
+
+statement ok
+UPDATE song SET songartist=1, songalbum='A' WHERE songname='B_song';
+
+query ITT
+SELECT * FROM album;
+----
+1	A	A_cover
+2	B	B_cover
+3	C	C_cover
+
+query IITT
+SELECT * FROM song;
+----
+11	1	A	A_song
+13	3	C	C_song
+12	1	A	B_song
+
+# Any row that is updated from the table with primary key must not exist in the table has foreign key (constraint)
+statement error
+UPDATE album SET albumname='B' WHERE albumcover='C_cover';
+
+statement error
+UPDATE song SET songalbum='E' WHERE albumcover='C_song';
+
+statement ok
+UPDATE album SET artistid=5, albumname='D' WHERE albumcover='B_cover';
+
+query ITT
+SELECT * FROM album;
+----
+1	A	A_cover
+3	C	C_cover
+5	D	B_cover
+
+# perform an update on a column that is NOT part of the primary key in the main table
+statement ok
+UPDATE album SET albumcover='C_cover_new' WHERE artistid=3;
+
+# perform an update on a column that is NOT part of the foreign key in the referencing table
+statement ok
+UPDATE song SET songname='C_song_new' WHERE songartist=3;
+
+query ITT
+SELECT * FROM album;
+----
+1	A	A_cover
+3	C	C_cover_new
+5	D	B_cover
+
+query IITT
+SELECT * FROM song;
+----
+11	1	A	A_song
+13	3	C	C_song_new
+12	1	A	B_song
+
+# Cannot rename the columns that are involved in the foreign key constraint
+statement error
+ALTER TABLE album RENAME COLUMN albumname TO albumname_new;
+
+statement error
+ALTER TABLE song RENAME COLUMN songalbum TO songalbum_new;
+
+statement ok
+ALTER TABLE song RENAME COLUMN songname TO songname_new;
+
+# Cannot change type of the columns that are involved in the foreign key constraint
+statement error
+ALTER TABLE song ALTER COLUMN songartist SET DATA TYPE TEXT;
+
+statement error
+ALTER TABLE album ALTER COLUMN artistid SET DATA TYPE TEXT;
+
+statement ok
+ALTER TABLE song ALTER COLUMN songname_new SET DATA TYPE VARCHAR;
+
+# Cannot drop the columns that are involved in the foreign key constraint because of dependency
+statement error
+ALTER TABLE album DROP COLUMN artistid;
+
+statement ok
+ALTER TABLE song DROP COLUMN songname_new;
+
+# Can't drop the table with primary key corresponding with foreign key until exists the table has foreign key
+statement error
+DROP TABLE album;
+
+statement ok
+DROP TABLE song;
+
+statement ok
+ALTER TABLE album RENAME COLUMN albumname TO albumname_new;
+
+statement ok
+ALTER TABLE album ALTER COLUMN albumcover SET DATA TYPE VARCHAR;
+
+statement ok
+ALTER TABLE album DROP COLUMN albumcover;
+
+statement ok
+DROP TABLE album;
+
+# multiple columns and indices
+statement ok
+CREATE TABLE pkt(i INTEGER UNIQUE, k INTEGER UNIQUE)
+
+statement ok
+INSERT INTO pkt VALUES (1, 11), (2, 12), (3, 13)
+
+statement ok
+CREATE TABLE fkt(j INTEGER, l INTEGER UNIQUE, FOREIGN KEY (j) REFERENCES pkt(i))
+
+statement ok
+CREATE INDEX k_index ON pkt(k)
+
+statement ok
+CREATE INDEX l_index ON fkt(l)
+
+statement ok
+INSERT INTO fkt VALUES (1, 101), (2, 102)
+
+statement error
+INSERT INTO fkt VALUES (4, 104)
+
+statement ok
+INSERT INTO fkt VALUES (3, 103)
+
+statement error
+DELETE FROM pkt WHERE k=13
+
+statement ok
+DELETE FROM fkt WHERE l=103
+
+statement ok
+DELETE FROM pkt WHERE k=13
+
+statement error
+UPDATE pkt SET i=5 WHERE k=12
+
+statement error
+UPDATE fkt SET i=4 WHERE l=102
+
+statement error
+UPDATE fkt SET i=4 WHERE l=102
+
+statement ok
+DROP INDEX k_index
+
+statement ok
+DROP INDEX l_index
+
+statement error
+DROP TABLE pkt;
+
+statement ok
+DROP TABLE fkt;
+
+statement ok
+DROP TABLE pkt;
+
+# for tables that do not live in the current schema search path
+statement ok
+CREATE SCHEMA s1
+
+statement ok
+CREATE TABLE s1.pkt(i INTEGER PRIMARY KEY)
+
+statement ok
+CREATE TABLE s1.fkt(j INTEGER, FOREIGN KEY (j) REFERENCES s1.pkt(i))
+
+statement ok
+INSERT INTO s1.pkt VALUES (1), (2), (3), (4), (5)
+
+statement ok
+INSERT INTO s1.fkt VALUES (2), (3)
+
+statement error
+INSERT INTO s1.fkt VALUES (6)
+
+statement ok
+INSERT INTO s1.fkt VALUES (1)
+
+statement error
+DELETE FROM s1.pkt WHERE i=2
+
+statement ok
+DELETE FROM s1.pkt WHERE i=5
+
+statement error
+DROP TABLE s1.pkt;
+
+statement ok
+DROP TABLE s1.fkt;
+
+statement ok
+DROP TABLE s1.pkt;
+
+# insert NULL into the foreign key column
+statement ok
+CREATE TABLE pkt(i INTEGER UNIQUE)
+
+statement ok
+CREATE TABLE fkt(j INTEGER, FOREIGN KEY (j) REFERENCES pkt(i))
+
+statement ok
+INSERT INTO fkt VALUES (NULL)

--- a/test/sql/storage/constraints/foreignkey/foreign_key_persistent.test
+++ b/test/sql/storage/constraints/foreignkey/foreign_key_persistent.test
@@ -1,6 +1,6 @@
-# name: test/sql/storage/test_foreign_key_persistent_storage.test
+# name: test/sql/storage/constraints/foreignkey/foreign_key_persistent.test
 # description: persistent storage tests with foreign key tables
-# group: [storage]
+# group: [foreignkey]
 
 # load the DB from disk
 load __TEST_DIR__/test_fk_persistent.db


### PR DESCRIPTION
Fixes #3860