### PR TITLE
[Python] Making new connections to cursors and adding lock on queries over sampe connection

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
@@ -139,6 +139,9 @@ public:
 	static shared_ptr<DuckDBPyConnection> default_connection;
 
 	static bool IsAcceptedArrowObject(string &py_object_type);
+
+private:
+	unique_lock<std::mutex> AcquireConnectionLock();
 };
 
 } // namespace duckdb

--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
@@ -42,12 +42,13 @@ public:
 struct DuckDBPyConnection {
 public:
 	shared_ptr<DuckDB> database;
-	shared_ptr<Connection> connection;
+	unique_ptr<Connection> connection;
 	unique_ptr<DuckDBPyResult> result;
 	vector<shared_ptr<DuckDBPyConnection>> cursors;
 	unordered_map<string, shared_ptr<Relation>> temporary_views;
 	std::thread::id thread_id = std::this_thread::get_id();
 	bool check_same_thread = true;
+	std::mutex py_connection_lock;
 
 public:
 	explicit DuckDBPyConnection(std::thread::id thread_id_p = std::this_thread::get_id()) : thread_id(thread_id_p) {

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -139,8 +139,10 @@ DuckDBPyConnection *DuckDBPyConnection::Execute(const string &query, py::object 
 	{
 		// we first release the gil and then acquire the connection lock
 		unique_lock<std::mutex> lock(py_connection_lock, std::defer_lock);
-		py::gil_scoped_release release;
-		lock.lock();
+		{
+			py::gil_scoped_release release;
+			lock.lock();
+		}
 
 		auto statements = connection->ExtractStatements(query);
 		if (statements.empty()) {

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -137,6 +137,7 @@ DuckDBPyConnection *DuckDBPyConnection::Execute(const string &query, py::object 
 	result = nullptr;
 	unique_ptr<PreparedStatement> prep;
 	{
+		const std::lock_guard<std::mutex> lock(py_connection_lock);
 		auto statements = connection->ExtractStatements(query);
 		if (statements.empty()) {
 			// no statements to execute
@@ -460,7 +461,7 @@ void DuckDBPyConnection::Close() {
 shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Cursor() {
 	auto res = make_shared<DuckDBPyConnection>(thread_id);
 	res->database = database;
-	res->connection = connection;
+	res->connection = make_unique<Connection>(*res->database);
 	res->check_same_thread = check_same_thread;
 	cursors.push_back(res);
 	return res;


### PR DESCRIPTION
Hopefully fixes the issues on the CI Introduced with the multithreaded tests.