### PR TITLE
Flag special result sets

### DIFF
--- a/src/include/duckdb/planner/bound_statement.hpp
+++ b/src/include/duckdb/planner/bound_statement.hpp
@@ -16,6 +16,10 @@ struct BoundStatement {
 	unique_ptr<LogicalOperator> plan;
 	vector<LogicalType> types;
 	vector<string> names;
+	bool special;
+
+	BoundStatement() : special(false) {
+	}
 };
 
 } // namespace duckdb

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -29,6 +29,7 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 	BoundStatement result;
 	result.types = {LogicalType::BIGINT};
 	result.names = {"Count"};
+	result.special = true;
 
 	// bind the select statement
 	auto select_node = Bind(*stmt.select_statement);
@@ -71,6 +72,7 @@ BoundStatement Binder::BindCopyFrom(CopyStatement &stmt) {
 	BoundStatement result;
 	result.types = {LogicalType::BIGINT};
 	result.names = {"Count"};
+	result.special = true;
 
 	D_ASSERT(!stmt.info->table.empty());
 	// COPY FROM a file

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -259,6 +259,8 @@ BoundStatement Binder::Bind(CreateStatement &stmt) {
 	BoundStatement result;
 	result.names = {"Count"};
 	result.types = {LogicalType::BIGINT};
+	result.special = true;
+
 	properties.return_type = StatementReturnType::NOTHING;
 
 	auto catalog_type = stmt.info->type;

--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -89,6 +89,8 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 		result.plan = move(del);
 		result.names = {"Count"};
 		result.types = {LogicalType::BIGINT};
+		result.special = true;
+
 		properties.allow_stream_result = false;
 		properties.return_type = StatementReturnType::CHANGED_ROWS;
 	}

--- a/src/planner/binder/statement/bind_drop.cpp
+++ b/src/planner/binder/statement/bind_drop.cpp
@@ -45,6 +45,8 @@ BoundStatement Binder::Bind(DropStatement &stmt) {
 	result.plan = make_unique<LogicalSimple>(LogicalOperatorType::LOGICAL_DROP, move(stmt.info));
 	result.names = {"Success"};
 	result.types = {LogicalType::BOOLEAN};
+	result.special = true;
+
 	properties.allow_stream_result = false;
 	properties.return_type = StatementReturnType::NOTHING;
 	return result;

--- a/src/planner/binder/statement/bind_explain.cpp
+++ b/src/planner/binder/statement/bind_explain.cpp
@@ -17,6 +17,8 @@ BoundStatement Binder::Bind(ExplainStatement &stmt) {
 	result.plan = move(explain);
 	result.names = {"explain_key", "explain_value"};
 	result.types = {LogicalType::VARCHAR, LogicalType::VARCHAR};
+	result.special = true;
+
 	properties.return_type = StatementReturnType::QUERY_RESULT;
 	return result;
 }

--- a/src/planner/binder/statement/bind_export.cpp
+++ b/src/planner/binder/statement/bind_export.cpp
@@ -94,6 +94,7 @@ BoundStatement Binder::Bind(ExportStatement &stmt) {
 	BoundStatement result;
 	result.types = {LogicalType::BOOLEAN};
 	result.names = {"Success"};
+	result.special = true;
 
 	// lookup the format in the catalog
 	auto &catalog = Catalog::GetCatalog(context);

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -29,6 +29,7 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 	BoundStatement result;
 	result.names = {"Count"};
 	result.types = {LogicalType::BIGINT};
+	result.special = true;
 
 	auto table = Catalog::GetCatalog(context).GetEntry<TableCatalogEntry>(context, stmt.schema, stmt.table);
 	D_ASSERT(table);

--- a/src/planner/binder/statement/bind_load.cpp
+++ b/src/planner/binder/statement/bind_load.cpp
@@ -9,6 +9,7 @@ BoundStatement Binder::Bind(LoadStatement &stmt) {
 	BoundStatement result;
 	result.types = {LogicalType::BOOLEAN};
 	result.names = {"Success"};
+	result.special = true;
 
 	result.plan = make_unique<LogicalSimple>(LogicalOperatorType::LOGICAL_LOAD, move(stmt.info));
 	properties.allow_stream_result = false;

--- a/src/planner/binder/statement/bind_pragma.cpp
+++ b/src/planner/binder/statement/bind_pragma.cpp
@@ -28,6 +28,7 @@ BoundStatement Binder::Bind(PragmaStatement &stmt) {
 	BoundStatement result;
 	result.names = {"Success"};
 	result.types = {LogicalType::BOOLEAN};
+	result.special = true;
 	result.plan = make_unique<LogicalPragma>(bound_function, *stmt.info);
 	properties.return_type = StatementReturnType::QUERY_RESULT;
 	return result;

--- a/src/planner/binder/statement/bind_set.cpp
+++ b/src/planner/binder/statement/bind_set.cpp
@@ -9,7 +9,7 @@ BoundStatement Binder::Bind(SetStatement &stmt) {
 	BoundStatement result;
 	result.types = {LogicalType::BOOLEAN};
 	result.names = {"Success"};
-
+	result.special = true;
 	result.plan = make_unique<LogicalSet>(stmt.name, stmt.value, stmt.scope);
 	properties.return_type = StatementReturnType::NOTHING;
 	return result;

--- a/src/planner/binder/statement/bind_show.cpp
+++ b/src/planner/binder/statement/bind_show.cpp
@@ -23,6 +23,8 @@ BoundStatement Binder::Bind(ShowStatement &stmt) {
 	result.names = {"column_name", "column_type", "null", "key", "default", "extra"};
 	result.types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
 	                LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+	result.special = true;
+
 	properties.return_type = StatementReturnType::QUERY_RESULT;
 	return result;
 }

--- a/src/planner/binder/statement/bind_simple.cpp
+++ b/src/planner/binder/statement/bind_simple.cpp
@@ -15,6 +15,8 @@ BoundStatement Binder::Bind(AlterStatement &stmt) {
 	BoundStatement result;
 	result.names = {"Success"};
 	result.types = {LogicalType::BOOLEAN};
+	result.special = true;
+
 	Catalog &catalog = Catalog::GetCatalog(context);
 	auto entry = catalog.GetEntry(context, stmt.info->GetCatalogType(), stmt.info->schema, stmt.info->name, true);
 	if (entry && !entry->temporary) {
@@ -33,6 +35,7 @@ BoundStatement Binder::Bind(TransactionStatement &stmt) {
 	BoundStatement result;
 	result.names = {"Success"};
 	result.types = {LogicalType::BOOLEAN};
+	result.special = true;
 	result.plan = make_unique<LogicalSimple>(LogicalOperatorType::LOGICAL_TRANSACTION, move(stmt.info));
 	properties.return_type = StatementReturnType::NOTHING;
 	return result;

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -227,6 +227,7 @@ BoundStatement Binder::Bind(UpdateStatement &stmt) {
 		update->table_index = 0;
 		result.names = {"Count"};
 		result.types = {LogicalType::BIGINT};
+		result.special = true;
 		result.plan = move(update);
 		properties.allow_stream_result = false;
 		properties.return_type = StatementReturnType::CHANGED_ROWS;

--- a/src/planner/binder/statement/bind_vacuum.cpp
+++ b/src/planner/binder/statement/bind_vacuum.cpp
@@ -8,6 +8,7 @@ BoundStatement Binder::Bind(VacuumStatement &stmt) {
 	BoundStatement result;
 	result.names = {"Success"};
 	result.types = {LogicalType::BOOLEAN};
+	result.special = true;
 	result.plan = make_unique<LogicalSimple>(LogicalOperatorType::LOGICAL_VACUUM, move(stmt.info));
 	properties.return_type = StatementReturnType::NOTHING;
 	return result;


### PR DESCRIPTION
For #3875. We would forward the new `special` flag to the R client so that it can decide cleanly if it's a statement or a "proper" query.

We might want to think about how to do this better with adbc. I like the idea of returning "count" and "success" tables.