### PR TITLE
Julia Table Functions: add stack trace to errors reported 

### DIFF
--- a/tools/juliapkg/src/table_function.jl
+++ b/tools/juliapkg/src/table_function.jl
@@ -64,8 +64,14 @@ end
 
 function get_exception_info()
     error = ""
-    for (exc, bt) in current_exceptions()
-        error = string(error, sprint(showerror, exc, bt))
+    if VERSION < v"1.7"
+        for (exc, bt) in catch_stack()
+            error = string(error, sprint(showerror, exc, bt))
+        end
+    else
+        for (exc, bt) in current_exceptions()
+            error = string(error, sprint(showerror, exc, bt))
+        end
     end
     return error
 end

--- a/tools/juliapkg/src/table_function.jl
+++ b/tools/juliapkg/src/table_function.jl
@@ -65,7 +65,7 @@ end
 function get_exception_info()
     error = ""
     if VERSION < v"1.7"
-        for (exc, bt) in catch_stack()
+        for (exc, bt) in Base.catch_stack()
             error = string(error, sprint(showerror, exc, bt))
         end
     else


### PR DESCRIPTION
This should make it easier to debug Julia table functions, e.g.:

```julia
test_table_function.jl
Test table function errors: Error During Test at /Users/myth/Programs/duckdb-bugfix/tools/juliapkg/test/test_table_function.jl:135
  Got exception outside of a @test
  Execute of query "SELECT * FROM main_error_function(3)" failed: "runtime error"
  Stacktrace:
    [1] my_main_error_function(info::DuckDB.FunctionInfo, output::DuckDB.DataChunk)
      @ Main ~/Programs/duckdb-bugfix/tools/juliapkg/test/test_table_function.jl:132
    [2] _table_main_function(info::Ptr{Nothing}, chunk::Ptr{Nothing})
      @ DuckDB ~/Programs/duckdb-bugfix/tools/juliapkg/src/table_function.jl:184
    [3] duckdb_execute_prepared
      @ ~/Programs/duckdb-bugfix/tools/juliapkg/src/api.jl:1183 [inlined]
    [4] execute(stmt::DuckDB.Stmt, params::NamedTuple{(), Tuple{}})
      @ DuckDB ~/Programs/duckdb-bugfix/tools/juliapkg/src/result.jl:523
    [5] execute
      @ ~/Programs/duckdb-bugfix/tools/juliapkg/src/result.jl:615 [inlined]
    [6] execute
      @ ~/.julia/packages/DBInterface/1Gmxx/src/DBInterface.jl:130 [inlined]
    [7] #execute#2
      @ ~/.julia/packages/DBInterface/1Gmxx/src/DBInterface.jl:152 [inlined]
    [8] execute(conn::DuckDB.DB, sql::String)
      @ DBInterface ~/.julia/packages/DBInterface/1Gmxx/src/DBInterface.jl:152
    [9] macro expansion
      @ ~/Programs/duckdb-bugfix/tools/juliapkg/test/test_table_function.jl:163 [inlined]
   [10] macro expansion
      @ /Applications/Julia-1.7.app/Contents/Resources/julia/share/julia/stdlib/v1.7/Test/src/Test.jl:1283 [inlined]
   [11] top-level scope
      @ ~/Programs/duckdb-bugfix/tools/juliapkg/test/test_table_function.jl:136
   [12] include(fname::String)
      @ Base.MainInclude ./client.jl:451
   [13] top-level scope
      @ ~/Programs/duckdb-bugfix/tools/juliapkg/test/runtests.jl:38
   [14] include(fname::String)
      @ Base.MainInclude ./client.jl:451
   [15] top-level scope
      @ none:1
   [16] eval
      @ ./boot.jl:373 [inlined]
   [17] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:268
   [18] _start()
      @ Base ./client.jl:495
```