### PR TITLE
R: Check query return type instead of query type in dbFetch()

### DIFF
--- a/src/common/enums/statement_type.cpp
+++ b/src/common/enums/statement_type.cpp
@@ -56,6 +56,18 @@ string StatementTypeToString(StatementType type) {
 	}
 	return "INVALID";
 }
+
+string StatementReturnTypeToString(StatementReturnType type) {
+	switch (type) {
+	case StatementReturnType::QUERY_RESULT:
+		return "QUERY_RESULT";
+	case StatementReturnType::CHANGED_ROWS:
+		return "CHANGED_ROWS";
+	case StatementReturnType::NOTHING:
+		return "NOTHING";
+	}
+	return "INVALID";
+}
 // LCOV_EXCL_STOP
 
 } // namespace duckdb

--- a/src/include/duckdb/common/enums/statement_type.hpp
+++ b/src/include/duckdb/common/enums/statement_type.hpp
@@ -50,6 +50,8 @@ enum class StatementReturnType : uint8_t {
 	NOTHING       // the statement returns nothing
 };
 
+string StatementReturnTypeToString(StatementReturnType type);
+
 //! A struct containing various properties of a SQL statement
 struct StatementProperties {
 	StatementProperties()

--- a/tools/rpkg/R/dbFetch__duckdb_result.R
+++ b/tools/rpkg/R/dbFetch__duckdb_result.R
@@ -35,8 +35,8 @@ dbFetch__duckdb_result <- function(res, n = -1, ...) {
   if (!is_wholenumber(n)) {
     stop("n needs to be not a whole number")
   }
-  if (res@stmt_lst$type != "SELECT") {
-    warning("Should not call dbFetch() on results that do not come from SELECT")
+  if (res@stmt_lst$return_type != "QUERY_RESULT") {
+    warning("Should not call `dbFetch()` on results that do not come from a query that returns rows, e.g. a `SELECT`")
     return(data.frame())
   }
 

--- a/tools/rpkg/src/statement.cpp
+++ b/tools/rpkg/src/statement.cpp
@@ -129,6 +129,8 @@ static void VectorToR(Vector &src_vec, size_t count, void *dest, uint64_t dest_o
 
 	retlist.push_back({"rtypes"_nm = rtypes});
 	retlist.push_back({"n_param"_nm = stmtholder->stmt->n_param});
+	retlist.push_back(
+	    {"return_type"_nm = StatementReturnTypeToString(stmtholder->stmt->GetStatementProperties().return_type)});
 
 	return retlist;
 }

--- a/tools/rpkg/tests/testthat/test_fetch.R
+++ b/tools/rpkg/tests/testthat/test_fetch.R
@@ -1,0 +1,9 @@
+test_that("dbFetch() can fetch RETURNING statements (#3875)", {
+  con <- dbConnect(duckdb())
+  on.exit(dbDisconnect(con, shutdown = TRUE))
+
+  dbCreateTable(con, "x", list(a = "int"))
+
+  expect_silent(out <-dbGetQuery(con, "INSERT INTO x VALUES (1) RETURNING (a)"))
+  expect_equal(out, data.frame(a = 1L))
+})


### PR DESCRIPTION
Closes #3875.