### PR TITLE
Fuzzer: fix sanitization of address sanitizer error

### DIFF
--- a/scripts/reduce_sql.py
+++ b/scripts/reduce_sql.py
@@ -15,6 +15,9 @@ def sanitize_error(err):
     err = re.sub('Error: near line \d+: ', '', err)
     err = err.replace(os.getcwd() + '/', '')
     err = err.replace(os.getcwd(), '')
+    if 'AddressSanitizer' in err:
+        match = re.search(r'[ \t]+[#]0 ([A-Za-z0-9]+) ([^\n]+)', err).groups()[1]
+        err = 'AddressSanitizer error ' + match
     return err
 
 def run_shell_command(shell, cmd):

--- a/scripts/run_fuzzer.py
+++ b/scripts/run_fuzzer.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import reduce_sql
 import fuzzer_helper
+import random
 
 seed = -1
 
@@ -20,6 +21,8 @@ for param in sys.argv:
         db = 'tpch'
     elif param.startswith('--shell='):
         shell = param.replace('--shell=', '')
+    elif param.startswith('--seed='):
+        seed = int(param.replace('--seed=', ''))
 
 if fuzzer is None:
     print("Unrecognized fuzzer to run, expected e.g. --sqlsmith")
@@ -32,6 +35,11 @@ if db is None:
 if shell is None:
     print("Unrecognized path to shell, expected e.g. --shell=build/debug/duckdb")
     exit(1)
+
+if seed < 0:
+    seed = random.randint(0, 2**30)
+
+git_hash = fuzzer_helper.get_github_hash()
 
 def create_db_script(db):
     if db == 'alltypes':
@@ -139,4 +147,4 @@ print("=========================================")
 last_query = reduce_sql.reduce(last_query, load_script, shell, error_msg)
 cmd = load_script + '\n' + last_query + "\n"
 
-fuzzer_helper.file_issue(cmd, error_msg)
+fuzzer_helper.file_issue(cmd, error_msg, "SQLSmith", seed, git_hash)

--- a/scripts/run_sqlancer.py
+++ b/scripts/run_sqlancer.py
@@ -1,4 +1,5 @@
 import os
+import random
 import subprocess
 import sys
 import reduce_sql
@@ -36,6 +37,11 @@ if shell is None:
 if not os.path.isfile(shell):
 	print(f"Could not find shell \"{shell}\"")
 	exit(1)
+
+if seed < 0:
+	seed = random.randint(0, 2 ** 30)
+
+git_hash = fuzzer_helper.get_github_hash()
 
 targetdir = os.path.join(sqlancer_dir, 'target')
 filenames = os.listdir(targetdir)
@@ -144,4 +150,4 @@ if error_msg in current_errors:
     print("Issue already exists: https://github.com/duckdb/duckdb-fuzzer/issues/" + str(current_errors[error_msg]['number']))
     exit(0)
 
-fuzzer_helper.file_issue(reduced_test_case, error_msg)
+fuzzer_helper.file_issue(reduced_test_case, error_msg, "SQLancer", seed, git_hash)


### PR DESCRIPTION
This prevents address sanitizer errors from always being unique, by instead of using the entire asan message (which contains memory addresses) using only the top-level frame of the stack-trace. This prevents the fuzzer from filing many duplicate bugs and allows for correct functioning of the SQL reduction.