### PR TITLE
More fuzzer fixes

### DIFF
--- a/src/common/operator/string_cast.cpp
+++ b/src/common/operator/string_cast.cpp
@@ -84,6 +84,11 @@ duckdb::string_t StringCast::Operation(hugeint_t input, Vector &vector) {
 
 template <>
 duckdb::string_t StringCast::Operation(date_t input, Vector &vector) {
+	if (input == date_t::infinity()) {
+		return "infinity";
+	} else if (input == date_t::ninfinity()) {
+		return "-infinity";
+	}
 	int32_t date[3];
 	Date::Convert(input, date[0], date[1], date[2]);
 
@@ -119,6 +124,11 @@ duckdb::string_t StringCast::Operation(dtime_t input, Vector &vector) {
 
 template <>
 duckdb::string_t StringCast::Operation(timestamp_t input, Vector &vector) {
+	if (input == timestamp_t::infinity()) {
+		return string_t("infinity");
+	} else if (input == timestamp_t::ninfinity()) {
+		return string_t("-infinity");
+	}
 	date_t date_entry;
 	dtime_t time_entry;
 	Timestamp::Convert(input, date_entry, time_entry);

--- a/src/common/types/interval.cpp
+++ b/src/common/types/interval.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/common/types/cast_helpers.hpp"
 #include "duckdb/common/operator/add.hpp"
 #include "duckdb/common/operator/multiply.hpp"
+#include "duckdb/common/operator/subtract.hpp"
 #include "duckdb/common/string_util.hpp"
 
 namespace duckdb {
@@ -376,7 +377,10 @@ interval_t Interval::GetAge(timestamp_t timestamp_1, timestamp_t timestamp_2) {
 interval_t Interval::GetDifference(timestamp_t timestamp_1, timestamp_t timestamp_2) {
 	const auto us_1 = Timestamp::GetEpochMicroSeconds(timestamp_1);
 	const auto us_2 = Timestamp::GetEpochMicroSeconds(timestamp_2);
-	const auto delta_us = us_1 - us_2;
+	int64_t delta_us;
+	if (!TrySubtractOperator::Operation(us_1, us_2, delta_us)) {
+		throw ConversionException("Timestamp difference is out of bounds");
+	}
 	return FromMicro(delta_us);
 }
 

--- a/src/common/types/interval.cpp
+++ b/src/common/types/interval.cpp
@@ -286,6 +286,7 @@ int64_t Interval::GetNanoseconds(const interval_t &val) {
 }
 
 interval_t Interval::GetAge(timestamp_t timestamp_1, timestamp_t timestamp_2) {
+	D_ASSERT(Timestamp::IsFinite(timestamp_1) && Timestamp::IsFinite(timestamp_2));
 	date_t date1, date2;
 	dtime_t time1, time2;
 
@@ -375,6 +376,9 @@ interval_t Interval::GetAge(timestamp_t timestamp_1, timestamp_t timestamp_2) {
 }
 
 interval_t Interval::GetDifference(timestamp_t timestamp_1, timestamp_t timestamp_2) {
+	if (!Timestamp::IsFinite(timestamp_1) || !Timestamp::IsFinite(timestamp_2)) {
+		throw InvalidInputException("Cannot subtract infinite timestamps");
+	}
 	const auto us_1 = Timestamp::GetEpochMicroSeconds(timestamp_1);
 	const auto us_2 = Timestamp::GetEpochMicroSeconds(timestamp_2);
 	int64_t delta_us;

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1053,7 +1053,7 @@ void Vector::Verify(Vector &vector_p, const SelectionVector &sel_p, idx_t count)
 		D_ASSERT(child_types.size() == children.size());
 		for (idx_t child_idx = 0; child_idx < children.size(); child_idx++) {
 			D_ASSERT(children[child_idx]->GetType() == child_types[child_idx].second);
-			children[child_idx]->Verify(count);
+			Vector::Verify(*children[child_idx], sel_p, count);
 			if (vtype == VectorType::CONSTANT_VECTOR) {
 				D_ASSERT(children[child_idx]->GetVectorType() == VectorType::CONSTANT_VECTOR);
 				if (ConstantVector::IsNull(*vector)) {

--- a/src/include/duckdb/function/scalar/strftime.hpp
+++ b/src/include/duckdb/function/scalar/strftime.hpp
@@ -74,7 +74,7 @@ protected:
 	//! Format is literals[0], specifiers[0], literals[1], ..., specifiers[n - 1], literals[n]
 	vector<string> literals;
 	//! The constant size that appears in the format string
-	idx_t constant_size;
+	idx_t constant_size = 0;
 	//! The max numeric width of the specifier (if it is parsed as a number), or -1 if it is not a number
 	vector<int> numeric_width;
 

--- a/test/fuzzer/sqlsmith/strptime_nullpointer.test
+++ b/test/fuzzer/sqlsmith/strptime_nullpointer.test
@@ -1,0 +1,15 @@
+# name: test/fuzzer/sqlsmith/strptime_nullpointer.test
+# description: Fuzzer #45: nullpointer in strptime call
+# group: [sqlsmith]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t0(c0 BOOLEAN DEFAULT(true), c1 VARCHAR);
+
+statement ok
+INSERT INTO t0(c0, c1) VALUES (534898561, 1156365055), (524523641, '0.46680525959210206');
+
+statement error
+SELECT NULL FROM t0 ORDER BY strptime(NOT(t0.c0 BETWEEN t0.rowid AND t0.rowid), 1407974306)

--- a/test/fuzzer/sqlsmith/struct_verify_crash.test
+++ b/test/fuzzer/sqlsmith/struct_verify_crash.test
@@ -1,0 +1,23 @@
+# name: test/fuzzer/sqlsmith/struct_verify_crash.test
+# description: Fuzzer #52: AddressSanitizer error in duckdb::string_t::VerifyNull() string_type.cpp:30
+# group: [sqlsmith]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE tbl(array_of_structs STRUCT(a INTEGER, b VARCHAR)[]);
+
+statement ok
+INSERT INTO tbl VALUES([]);
+
+statement ok
+INSERT INTO tbl VALUES([{'a': 42, 'b': '🦆🦆🦆🦆🦆🦆'}]);
+
+query I
+SELECT EXISTS(SELECT ref_1.array_of_structs AS c1) FROM tbl AS ref_0, tbl AS ref_1
+----
+true
+true
+true
+true

--- a/test/fuzzer/sqlsmith/timestamp_diff_overflow.test
+++ b/test/fuzzer/sqlsmith/timestamp_diff_overflow.test
@@ -1,5 +1,5 @@
 # name: test/fuzzer/sqlsmith/timestamp_diff_overflow.test
-# description: Test overflow in dayofweek
+# description: Test overflow in timestamp subtract
 # group: [sqlsmith]
 
 statement ok

--- a/test/fuzzer/sqlsmith/timestamp_diff_overflow.test
+++ b/test/fuzzer/sqlsmith/timestamp_diff_overflow.test
@@ -1,0 +1,26 @@
+# name: test/fuzzer/sqlsmith/timestamp_diff_overflow.test
+# description: Test overflow in dayofweek
+# group: [sqlsmith]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE ts("timestamp" TIMESTAMP);;
+
+statement ok
+INSERT INTO ts VALUES('290309-12-22 (BC) 00:00:00');
+
+statement ok
+INSERT INTO ts VALUES('294247-01-10 04:00:54.775806');
+
+statement ok
+INSERT INTO ts VALUES(NULL);
+
+statement error
+select
+  subtract(
+    cast(now() as timestamp),
+    cast(ref_0.timestamp as timestamp)) as c10
+from
+  ts as ref_0

--- a/test/sql/function/timestamp/test_strptime.test
+++ b/test/sql/function/timestamp/test_strptime.test
@@ -180,15 +180,11 @@ WHERE rt <> dt
 ----
 
 # empty specifier and string
-query I
+statement error
 SELECT strptime('', '')
-----
-1900-01-01 00:00:00
 
-query I
+statement error
 SELECT strptime(NULL, '')
-----
-NULL
 
 query I
 SELECT strptime('', NULL)

--- a/test/sql/types/timestamp/test_infinite_time.test
+++ b/test/sql/types/timestamp/test_infinite_time.test
@@ -288,3 +288,35 @@ FROM specials;
 1	1	1
 1	1	1
 0	0	0
+
+query I
+select (timestamp 'infinity')::varchar;
+----
+infinity
+
+query I
+select (timestamp '-infinity')::varchar;
+----
+-infinity
+
+query I
+select (date 'infinity')::varchar;
+----
+infinity
+
+query I
+select (date '-infinity')::varchar;
+----
+-infinity
+
+# infinite subtract
+statement error
+select
+  subtract(
+    cast('infinity' as timestamp), timestamp '1970-01-01')
+
+statement error
+select
+  subtract(
+    timestamp '1970-01-01',
+    cast('-infinity' as timestamp))


### PR DESCRIPTION
* Correctly check that strptime argument is a string
* Detect overflow in timestamp difference
* Fix in `Vector::Verify` to correctly handle vectors of lists of structs