### PR TITLE
Add duckdb_extensions function

### DIFF
--- a/src/function/table/system/CMakeLists.txt
+++ b/src/function/table/system/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library_unity(
   duckdb_columns.cpp
   duckdb_constraints.cpp
   duckdb_dependencies.cpp
+  duckdb_extensions.cpp
   duckdb_functions.cpp
   duckdb_keywords.cpp
   duckdb_indexes.cpp

--- a/src/function/table/system/duckdb_extensions.cpp
+++ b/src/function/table/system/duckdb_extensions.cpp
@@ -1,0 +1,146 @@
+#include "duckdb/function/table/system_functions.hpp"
+
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/map.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/extension_helper.hpp"
+
+namespace duckdb {
+
+struct ExtensionInformation {
+	string name;
+	bool loaded = false;
+	bool installed = false;
+	string file_path;
+	string description;
+};
+
+struct DuckDBExtensionsData : public GlobalTableFunctionState {
+	DuckDBExtensionsData() : offset(0) {
+	}
+
+	vector<ExtensionInformation> entries;
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> DuckDBExtensionsBind(ClientContext &context, TableFunctionBindInput &input,
+                                                     vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("extension_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("loaded");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("installed");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("install_path");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("description");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> DuckDBExtensionsInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_unique<DuckDBExtensionsData>();
+
+	auto &fs = FileSystem::GetFileSystem(context);
+	auto &db = DatabaseInstance::GetDatabase(context);
+
+	map<string, ExtensionInformation> installed_extensions;
+	auto extension_count = ExtensionHelper::DefaultExtensionCount();
+	for (idx_t i = 0; i < extension_count; i++) {
+		auto extension = ExtensionHelper::GetDefaultExtension(i);
+		ExtensionInformation info;
+		info.name = extension.name;
+		info.installed = extension.statically_loaded;
+		info.loaded = false;
+		info.file_path = extension.statically_loaded ? "(BUILT-IN)" : string();
+		info.description = extension.description;
+		installed_extensions[info.name] = move(info);
+	}
+
+	// scan the install directory for installed extensions
+	auto ext_directory = ExtensionHelper::ExtensionDirectory(fs);
+	fs.ListFiles(ext_directory, [&](const string &path, bool is_directory) {
+		if (!StringUtil::EndsWith(path, ".duckdb_extension")) {
+			return;
+		}
+		ExtensionInformation info;
+		info.name = fs.ExtractBaseName(path);
+		info.loaded = false;
+		info.file_path = fs.JoinPath(ext_directory, path);
+		auto entry = installed_extensions.find(info.name);
+		if (entry == installed_extensions.end()) {
+			installed_extensions[info.name] = move(info);
+		} else {
+			if (!entry->second.loaded) {
+				entry->second.file_path = info.file_path;
+			}
+			entry->second.installed = true;
+		}
+	});
+
+	// now check the list of currently loaded extensions
+	auto &loaded_extensions = db.LoadedExtensions();
+	for (auto &ext_name : loaded_extensions) {
+		auto entry = installed_extensions.find(ext_name);
+		if (entry == installed_extensions.end()) {
+			ExtensionInformation info;
+			info.name = ext_name;
+			info.loaded = true;
+			installed_extensions[ext_name] = move(info);
+		} else {
+			entry->second.loaded = true;
+		}
+	}
+
+	result->entries.reserve(installed_extensions.size());
+	for (auto &kv : installed_extensions) {
+		result->entries.push_back(move(kv.second));
+	}
+	return move(result);
+}
+
+void DuckDBExtensionsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (DuckDBExtensionsData &)*data_p.global_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.entries[data.offset];
+
+		// return values:
+		// extension_name LogicalType::VARCHAR
+		output.SetValue(0, count, Value(entry.name));
+		// loaded LogicalType::BOOLEAN
+		output.SetValue(1, count, Value::BOOLEAN(entry.loaded));
+		// installed LogicalType::BOOLEAN
+		output.SetValue(2, count, !entry.installed && entry.loaded ? Value() : Value::BOOLEAN(entry.installed));
+		// install_path LogicalType::VARCHAR
+		output.SetValue(3, count, Value(entry.file_path));
+		// description LogicalType::VARCHAR
+		output.SetValue(4, count, Value(entry.description));
+
+		data.offset++;
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void DuckDBExtensionsFun::RegisterFunction(BuiltinFunctions &set) {
+	TableFunctionSet functions("duckdb_extensions");
+	functions.AddFunction(TableFunction({}, DuckDBExtensionsFunction, DuckDBExtensionsBind, DuckDBExtensionsInit));
+	set.AddFunction(functions);
+}
+
+} // namespace duckdb

--- a/src/function/table/system_functions.cpp
+++ b/src/function/table/system_functions.cpp
@@ -26,6 +26,7 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 	DuckDBIndexesFun::RegisterFunction(*this);
 	DuckDBSchemasFun::RegisterFunction(*this);
 	DuckDBDependenciesFun::RegisterFunction(*this);
+	DuckDBExtensionsFun::RegisterFunction(*this);
 	DuckDBSequencesFun::RegisterFunction(*this);
 	DuckDBSettingsFun::RegisterFunction(*this);
 	DuckDBTablesFun::RegisterFunction(*this);

--- a/src/include/duckdb/function/table/system_functions.hpp
+++ b/src/include/duckdb/function/table/system_functions.hpp
@@ -64,6 +64,10 @@ struct DuckDBDependenciesFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct DuckDBExtensionsFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct DuckDBFunctionsFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -44,6 +44,8 @@ public:
 
 	DUCKDB_API static DatabaseInstance &GetDatabase(ClientContext &context);
 
+	DUCKDB_API const unordered_set<std::string> &LoadedExtensions();
+
 private:
 	void Initialize(const char *path, DBConfig *config);
 

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -16,6 +16,12 @@ class DuckDB;
 
 enum class ExtensionLoadResult : uint8_t { LOADED_EXTENSION = 0, EXTENSION_UNKNOWN = 1, NOT_LOADED = 2 };
 
+struct DefaultExtension {
+	const char *name;
+	const char *description;
+	bool statically_loaded;
+};
+
 class ExtensionHelper {
 public:
 	static void LoadAllExtensions(DuckDB &db);
@@ -24,6 +30,11 @@ public:
 
 	static void InstallExtension(DatabaseInstance &db, const string &extension, bool force_install);
 	static void LoadExternalExtension(DatabaseInstance &db, const string &extension);
+
+	static string ExtensionDirectory(FileSystem &fs);
+
+	static idx_t DefaultExtensionCount();
+	static DefaultExtension GetDefaultExtension(idx_t index);
 
 private:
 	static const vector<string> PathComponents();

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -240,6 +240,10 @@ idx_t DatabaseInstance::NumberOfThreads() {
 	return scheduler->NumberOfThreads();
 }
 
+const unordered_set<std::string> &DatabaseInstance::LoadedExtensions() {
+	return loaded_extensions;
+}
+
 idx_t DuckDB::NumberOfThreads() {
 	return instance->NumberOfThreads();
 }

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -93,8 +93,8 @@ static DefaultExtension internal_extensions[] = {
 
 idx_t ExtensionHelper::DefaultExtensionCount() {
 	idx_t index;
-	for (index = 0; internal_extensions[index].name != nullptr; index++)
-		;
+	for (index = 0; internal_extensions[index].name != nullptr; index++) {
+	}
 	return index;
 }
 

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -6,31 +6,52 @@
 #include "duckdb/common/string_util.hpp"
 
 #if defined(BUILD_ICU_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#define ICU_STATICALLY_LOADED true
 #include "icu-extension.hpp"
+#else
+#define ICU_STATICALLY_LOADED false
 #endif
 
 #if defined(BUILD_PARQUET_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#define PARQUET_STATICALLY_LOADED true
 #include "parquet-extension.hpp"
+#else
+#define PARQUET_STATICALLY_LOADED false
 #endif
 
 #if defined(BUILD_TPCH_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#define TPCH_STATICALLY_LOADED true
 #include "tpch-extension.hpp"
+#else
+#define TPCH_STATICALLY_LOADED false
 #endif
 
 #if defined(BUILD_TPCDS_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#define TPCDS_STATICALLY_LOADED true
 #include "tpcds-extension.hpp"
+#else
+#define TPCDS_STATICALLY_LOADED false
 #endif
 
 #if defined(BUILD_SUBSTRAIT_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#define SUBSTRAIT_STATICALLY_LOADED true
 #include "substrait-extension.hpp"
+#else
+#define SUBSTRAIT_STATICALLY_LOADED false
 #endif
 
 #if defined(BUILD_FTS_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#define FTS_STATICALLY_LOADED true
 #include "fts-extension.hpp"
+#else
+#define FTS_STATICALLY_LOADED false
 #endif
 
 #if defined(BUILD_HTTPFS_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#define HTTPFS_STATICALLY_LOADED true
 #include "httpfs-extension.hpp"
+#else
+#define HTTPFS_STATICALLY_LOADED false
 #endif
 
 #if defined(BUILD_VISUALIZER_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
@@ -38,7 +59,10 @@
 #endif
 
 #if defined(BUILD_JSON_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#define JSON_STATICALLY_LOADED true
 #include "json-extension.hpp"
+#else
+#define JSON_STATICALLY_LOADED false
 #endif
 
 #if defined(BUILD_EXCEL_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
@@ -51,6 +75,37 @@
 
 namespace duckdb {
 
+//===--------------------------------------------------------------------===//
+// Default Extensions
+//===--------------------------------------------------------------------===//
+static DefaultExtension internal_extensions[] = {
+    {"icu", "Adds support for time zones and collations using the ICU library", ICU_STATICALLY_LOADED},
+    {"parquet", "Adds support for reading and writing parquet files", PARQUET_STATICALLY_LOADED},
+    {"tpch", "Adds TPC-H data generation and query support", TPCH_STATICALLY_LOADED},
+    {"tpcds", "Adds TPC-DS data generation and query support", TPCDS_STATICALLY_LOADED},
+    {"substrait", "Adds support for the Substrait integration", SUBSTRAIT_STATICALLY_LOADED},
+    {"fts", "Adds support for Full-Text Search Indexes", FTS_STATICALLY_LOADED},
+    {"httpfs", "Adds support for reading and writing files over a HTTP(S) connection", HTTPFS_STATICALLY_LOADED},
+    {"json", "Adds support for JSON operations", JSON_STATICALLY_LOADED},
+    {"sqlite_scanner", "Adds support for reading SQLite database files", false},
+    {"postgres_scanner", "Adds support for reading from a Postgres database", false},
+    {nullptr, nullptr, false}};
+
+idx_t ExtensionHelper::DefaultExtensionCount() {
+	idx_t index;
+	for (index = 0; internal_extensions[index].name != nullptr; index++)
+		;
+	return index;
+}
+
+DefaultExtension ExtensionHelper::GetDefaultExtension(idx_t index) {
+	D_ASSERT(index < DefaultExtensionCount());
+	return internal_extensions[index];
+}
+
+//===--------------------------------------------------------------------===//
+// Load Statically Compiled Extension
+//===--------------------------------------------------------------------===//
 void ExtensionHelper::LoadAllExtensions(DuckDB &db) {
 	unordered_set<string> extensions {"parquet",   "icu",        "tpch", "tpcds", "fts",     "httpfs",
 	                                  "substrait", "visualizer", "json", "excel", "sqlsmith"};
@@ -59,9 +114,6 @@ void ExtensionHelper::LoadAllExtensions(DuckDB &db) {
 	}
 }
 
-//===--------------------------------------------------------------------===//
-// Load Statically Compiled Extension
-//===--------------------------------------------------------------------===//
 ExtensionLoadResult ExtensionHelper::LoadExtension(DuckDB &db, const std::string &extension) {
 	return LoadExtensionInternal(db, extension, false);
 }
@@ -85,28 +137,28 @@ ExtensionLoadResult ExtensionHelper::LoadExtensionInternal(DuckDB &db, const std
 	}
 #endif
 	if (extension == "parquet") {
-#if defined(BUILD_PARQUET_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#if PARQUET_STATICALLY_LOADED
 		db.LoadExtension<ParquetExtension>();
 #else
 		// parquet extension required but not build: skip this test
 		return ExtensionLoadResult::NOT_LOADED;
 #endif
 	} else if (extension == "icu") {
-#if defined(BUILD_ICU_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#if ICU_STATICALLY_LOADED
 		db.LoadExtension<ICUExtension>();
 #else
 		// icu extension required but not build: skip this test
 		return ExtensionLoadResult::NOT_LOADED;
 #endif
 	} else if (extension == "tpch") {
-#if defined(BUILD_TPCH_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#if TPCH_STATICALLY_LOADED
 		db.LoadExtension<TPCHExtension>();
 #else
 		// icu extension required but not build: skip this test
 		return ExtensionLoadResult::NOT_LOADED;
 #endif
 	} else if (extension == "substrait") {
-#if defined(BUILD_SUBSTRAIT_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#if SUBSTRAIT_STATICALLY_LOADED
 
 		db.LoadExtension<SubstraitExtension>();
 #else
@@ -114,21 +166,21 @@ ExtensionLoadResult ExtensionHelper::LoadExtensionInternal(DuckDB &db, const std
 		return ExtensionLoadResult::NOT_LOADED;
 #endif
 	} else if (extension == "tpcds") {
-#if defined(BUILD_TPCDS_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#if TPCDS_STATICALLY_LOADED
 		db.LoadExtension<TPCDSExtension>();
 #else
 		// icu extension required but not build: skip this test
 		return ExtensionLoadResult::NOT_LOADED;
 #endif
 	} else if (extension == "fts") {
-#if defined(BUILD_FTS_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#if FTS_STATICALLY_LOADED
 		db.LoadExtension<FTSExtension>();
 #else
 		// fts extension required but not build: skip this test
 		return ExtensionLoadResult::NOT_LOADED;
 #endif
 	} else if (extension == "httpfs") {
-#if defined(BUILD_HTTPFS_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#if HTTPFS_STATICALLY_LOADED
 		db.LoadExtension<HTTPFsExtension>();
 #else
 		return ExtensionLoadResult::NOT_LOADED;
@@ -141,7 +193,7 @@ ExtensionLoadResult ExtensionHelper::LoadExtensionInternal(DuckDB &db, const std
 		return ExtensionLoadResult::NOT_LOADED;
 #endif
 	} else if (extension == "json") {
-#if defined(BUILD_JSON_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#if JSON_STATICALLY_LOADED
 		db.LoadExtension<JSONExtension>();
 #else
 		// json extension required but not build: skip this test

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -17,13 +17,7 @@ const vector<string> ExtensionHelper::PathComponents() {
 	return vector<string> {".duckdb", "extensions", DuckDB::SourceID(), DuckDB::Platform()};
 }
 
-void ExtensionHelper::InstallExtension(DatabaseInstance &db, const string &extension, bool force_install) {
-	auto &config = DBConfig::GetConfig(db);
-	if (!config.enable_external_access) {
-		throw PermissionException("Installing extensions is disabled through configuration");
-	}
-	auto &fs = FileSystem::GetFileSystem(db);
-
+string ExtensionHelper::ExtensionDirectory(FileSystem &fs) {
 	string local_path = fs.GetHomeDirectory();
 	if (!fs.DirectoryExists(local_path)) {
 		throw InternalException("Can't find the home directory at " + local_path);
@@ -35,6 +29,17 @@ void ExtensionHelper::InstallExtension(DatabaseInstance &db, const string &exten
 			fs.CreateDirectory(local_path);
 		}
 	}
+	return local_path;
+}
+
+void ExtensionHelper::InstallExtension(DatabaseInstance &db, const string &extension, bool force_install) {
+	auto &config = DBConfig::GetConfig(db);
+	if (!config.enable_external_access) {
+		throw PermissionException("Installing extensions is disabled through configuration");
+	}
+	auto &fs = FileSystem::GetFileSystem(db);
+
+	string local_path = ExtensionDirectory(fs);
 
 	auto extension_name = fs.ExtractBaseName(extension);
 

--- a/test/sql/table_function/duckdb_extensions.test
+++ b/test/sql/table_function/duckdb_extensions.test
@@ -1,0 +1,13 @@
+# name: test/sql/table_function/duckdb_extensions.test
+# description: Test duckdb_extensions function
+# group: [table_function]
+
+statement ok
+SELECT * FROM duckdb_extensions();
+
+require tpch
+
+query I
+SELECT extension_name FROM duckdb_extensions() WHERE loaded AND extension_name='tpch';
+----
+tpch


### PR DESCRIPTION
Fixes #3885

This PR implements the `duckdb_extensions` table function, that provides information about which extensions are available, which extensions are installed, and which extensions are loaded:

```sql
D select * From duckdb_extensions();
┌──────────────────┬────────┬───────────┬──────────────────────────────────────────────────────────────────────────┬──────────────────────────────────────────────────────────────────────┐
│  extension_name  │ loaded │ installed │                               install_path                               │                             description                              │
├──────────────────┼────────┼───────────┼──────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────┤
│ fts              │ false  │ false     │                                                                          │ Adds support for Full-Text Search Indexes                            │
│ httpfs           │ false  │ false     │                                                                          │ Adds support for reading and writing files over a HTTP(S) connection │
│ icu              │ true   │ true      │ (BUILT-IN)                                                               │ Adds support for time zones and collations using the ICU library     │
│ json             │ false  │ true      │ /Users/myth/.duckdb/extensions/da9ee490d/osx_arm64/json.duckdb_extension │ Adds support for JSON operations                                     │
│ parquet          │ true   │ true      │ (BUILT-IN)                                                               │ Adds support for reading and writing parquet files                   │
│ postgres_scanner │ false  │ false     │                                                                          │ Adds support for reading from a Postgres database                    │
│ sqlite_scanner   │ false  │ false     │                                                                          │ Adds support for reading SQLite database files                       │
│ substrait        │ false  │ false     │                                                                          │ Adds support for the Substrait integration                           │
│ tpcds            │ false  │ false     │                                                                          │ Adds TPC-DS data generation and query support                        │
│ tpch             │ true   │ true      │ (BUILT-IN)                                                               │ Adds TPC-H data generation and query support                         │
└──────────────────┴────────┴───────────┴──────────────────────────────────────────────────────────────────────────┴──────────────────────────────────────────────────────────────────────┘

```

We maintain a list of core extensions in `extension_helper.cpp`, which should also help discoverability of extensions as people can query the available set of extensions with a description of what they do.