### PR TITLE
Retire `LogicalTypeId::HASH` and replace it with `LogicalTypeId::UBIGINT`

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -108,9 +108,6 @@ PhysicalType LogicalType::GetInternalType() {
 		return PhysicalType::STRUCT;
 	case LogicalTypeId::LIST:
 		return PhysicalType::LIST;
-	case LogicalTypeId::HASH:
-		static_assert(sizeof(hash_t) == sizeof(uint64_t), "Hash must be uint64_t");
-		return PhysicalType::UINT64;
 	case LogicalTypeId::POINTER:
 		// LCOV_EXCL_START
 		if (sizeof(uintptr_t) == sizeof(uint32_t)) {
@@ -419,8 +416,6 @@ string LogicalTypeIdToString(LogicalTypeId id) {
 		return "LIST";
 	case LogicalTypeId::MAP:
 		return "MAP";
-	case LogicalTypeId::HASH:
-		return "HASH";
 	case LogicalTypeId::POINTER:
 		return "POINTER";
 	case LogicalTypeId::TABLE:

--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -259,7 +259,7 @@ unique_ptr<VectorData[]> DataChunk::Orrify() {
 }
 
 void DataChunk::Hash(Vector &result) {
-	D_ASSERT(result.GetType().id() == LogicalTypeId::HASH);
+	D_ASSERT(result.GetType().id() == LogicalType::HASH);
 	VectorOperations::Hash(data[0], result, size());
 	for (idx_t i = 1; i < ColumnCount(); i++) {
 		VectorOperations::CombineHash(result, data[i], size());

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -943,8 +943,6 @@ Value Value::Numeric(const LogicalType &type, int64_t value) {
 		return Value((float)value);
 	case LogicalTypeId::DOUBLE:
 		return Value((double)value);
-	case LogicalTypeId::HASH:
-		return Value::HASH(value);
 	case LogicalTypeId::POINTER:
 		return Value::POINTER(value);
 	case LogicalTypeId::DATE:
@@ -1335,8 +1333,6 @@ string Value::ToString() const {
 		return Blob::ToString(string_t(str_value));
 	case LogicalTypeId::POINTER:
 		return to_string(value_.pointer);
-	case LogicalTypeId::HASH:
-		return to_string(value_.hash);
 	case LogicalTypeId::STRUCT: {
 		string ret = "{";
 		auto &child_types = StructType::GetChildTypes(type_);

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -496,8 +496,6 @@ Value Vector::GetValue(const Vector &v_p, idx_t index_p) {
 			throw InternalException("ENUM can only have unsigned integers as physical types");
 		}
 	}
-	case LogicalTypeId::HASH:
-		return Value::HASH(((hash_t *)data)[index]);
 	case LogicalTypeId::POINTER:
 		return Value::POINTER(((uintptr_t *)data)[index]);
 	case LogicalTypeId::FLOAT:

--- a/src/common/vector_operations/vector_hash.cpp
+++ b/src/common/vector_operations/vector_hash.cpp
@@ -177,7 +177,7 @@ static inline void ListLoopHash(Vector &input, Vector &hashes, const SelectionVe
 
 template <bool HAS_RSEL>
 static inline void HashTypeSwitch(Vector &input, Vector &result, const SelectionVector *rsel, idx_t count) {
-	D_ASSERT(result.GetType().id() == LogicalTypeId::HASH);
+	D_ASSERT(result.GetType().id() == LogicalType::HASH);
 	switch (input.GetType().InternalType()) {
 	case PhysicalType::BOOL:
 	case PhysicalType::INT8:
@@ -309,7 +309,7 @@ void TemplatedLoopCombineHash(Vector &input, Vector &hashes, const SelectionVect
 
 template <bool HAS_RSEL>
 static inline void CombineHashTypeSwitch(Vector &hashes, Vector &input, const SelectionVector *rsel, idx_t count) {
-	D_ASSERT(hashes.GetType().id() == LogicalTypeId::HASH);
+	D_ASSERT(hashes.GetType().id() == LogicalType::HASH);
 	switch (input.GetType().InternalType()) {
 	case PhysicalType::BOOL:
 	case PhysicalType::INT8:

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -234,7 +234,7 @@ void JoinHashTable::Build(DataChunk &keys, DataChunk &payload) {
 }
 
 void JoinHashTable::InsertHashes(Vector &hashes, idx_t count, data_ptr_t key_locations[]) {
-	D_ASSERT(hashes.GetType().id() == LogicalTypeId::HASH);
+	D_ASSERT(hashes.GetType().id() == LogicalType::HASH);
 
 	// use bitmask to get position in array
 	ApplyBitmask(hashes, count);

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -454,7 +454,7 @@ static void ScanSortedPartition(WindowOperatorState &state, ChunkCollection &inp
 }
 
 static void HashChunk(counts_t &counts, DataChunk &hash_chunk, DataChunk &sort_chunk, const idx_t partition_cols) {
-	const vector<LogicalType> hash_types(1, LogicalTypeId::HASH);
+	const vector<LogicalType> hash_types(1, LogicalType::HASH);
 	hash_chunk.Initialize(hash_types);
 	hash_chunk.SetCardinality(sort_chunk);
 	auto &hash_vector = hash_chunk.data[0];

--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -371,7 +371,7 @@ enum class LogicalTypeId : uint8_t {
 
 	HUGEINT = 50,
 	POINTER = 51,
-	DEPRECATED_HASH = 52, // deprecated, uses UBIGINT instead
+	// HASH = 52, // deprecated, uses UBIGINT instead
 	VALIDITY = 53,
 	UUID = 54,
 

--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -371,7 +371,7 @@ enum class LogicalTypeId : uint8_t {
 
 	HUGEINT = 50,
 	POINTER = 51,
-	HASH = 52,
+	DEPRECATED_HASH = 52, // deprecated, uses UBIGINT instead
 	VALIDITY = 53,
 	UUID = 54,
 
@@ -483,7 +483,7 @@ public:
 	static constexpr const LogicalTypeId INTERVAL = LogicalTypeId::INTERVAL;
 	static constexpr const LogicalTypeId HUGEINT = LogicalTypeId::HUGEINT;
 	static constexpr const LogicalTypeId UUID = LogicalTypeId::UUID;
-	static constexpr const LogicalTypeId HASH = LogicalTypeId::HASH;
+	static constexpr const LogicalTypeId HASH = LogicalTypeId::UBIGINT;
 	static constexpr const LogicalTypeId POINTER = LogicalTypeId::POINTER;
 	static constexpr const LogicalTypeId TABLE = LogicalTypeId::TABLE;
 	static constexpr const LogicalTypeId INVALID = LogicalTypeId::INVALID;


### PR DESCRIPTION
Fixes #3920.

This change replaces `LogicalTypeId::HASH` with a `LogicalTypeId::DEPRECATED_HASH` value (to preserve the enum value of 52, but this may be unnecessary) and switches all uses of `LogicalTypeId::HASH` in the codebase to reference `LogicalType::HASH` which is now set to be equal to the `LogicalTypeId::UBIGINT` since the current `hash_t` used by DuckDB is equal to `uint8_t` on each platform it runs on.

Note that this is an internal only change, the only user-visible impact of it is that the (currently undocumented) `hash` UDF will now return an unsigned bigint value that can be operated on normally using the rest of the functions/operators provided by DuckDB-- I'm happy to add unit tests and/or docs for this function as part of this PR!