### PR TITLE
Fuzzer #55: Remove Normalify Call

### DIFF
--- a/src/common/vector_operations/vector_hash.cpp
+++ b/src/common/vector_operations/vector_hash.cpp
@@ -63,7 +63,6 @@ static inline void TemplatedLoopHash(Vector &input, Vector &result, const Select
 
 template <bool HAS_RSEL, bool FIRST_HASH>
 static inline void StructLoopHash(Vector &input, Vector &hashes, const SelectionVector *rsel, idx_t count) {
-	input.Normalify(count);
 	auto &children = StructVector::GetEntries(input);
 
 	D_ASSERT(!children.empty());


### PR DESCRIPTION
This snuck in somehow and would be bogus because the count is not correct.
It is not needed so I have removed it.