### PR TITLE
Atomic extension installation

### DIFF
--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -64,9 +64,10 @@ void ExtensionHelper::InstallExtension(DatabaseInstance &db, const string &exten
 		if (out.bad()) {
 			throw IOException("Failed to write extension to \"%s\"", temp_path);
 		}
-		fs.MoveFile(temp_path, local_extension_path);
 		in.close();
 		out.close();
+
+		fs.MoveFile(temp_path, local_extension_path);
 		return;
 	} else if (StringUtil::Contains(extension, "/") && !is_http_url) {
 		throw IOException("Failed to read extension from \"%s\": no such file", extension);
@@ -113,6 +114,7 @@ void ExtensionHelper::InstallExtension(DatabaseInstance &db, const string &exten
 	if (out.bad()) {
 		throw IOException("Failed to write extension to %s", temp_path);
 	}
+	out.close();
 	fs.MoveFile(temp_path, local_extension_path);
 #endif
 }

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -48,17 +48,23 @@ void ExtensionHelper::InstallExtension(DatabaseInstance &db, const string &exten
 		return;
 	}
 
+	string temp_path = local_extension_path + ".tmp";
+	if (fs.FileExists(temp_path)) {
+		fs.RemoveFile(temp_path);
+	}
 	auto is_http_url = StringUtil::Contains(extension, "http://");
 	if (fs.FileExists(extension)) {
+
 		std::ifstream in(extension, std::ios::binary);
 		if (in.bad()) {
 			throw IOException("Failed to read extension from \"%s\"", extension);
 		}
-		std::ofstream out(local_extension_path, std::ios::binary);
+		std::ofstream out(temp_path, std::ios::binary);
 		out << in.rdbuf();
 		if (out.bad()) {
-			throw IOException("Failed to write extension to \"%s\"", local_extension_path);
+			throw IOException("Failed to write extension to \"%s\"", temp_path);
 		}
+		fs.MoveFile(temp_path, local_extension_path);
 		in.close();
 		out.close();
 		return;
@@ -102,11 +108,12 @@ void ExtensionHelper::InstallExtension(DatabaseInstance &db, const string &exten
 		throw IOException("Failed to download extension %s%s", url_base, url_local_part);
 	}
 	auto decompressed_body = GZipFileSystem::UncompressGZIPString(res->body);
-	std::ofstream out(local_extension_path, std::ios::binary);
+	std::ofstream out(temp_path, std::ios::binary);
 	out.write(decompressed_body.data(), decompressed_body.size());
 	if (out.bad()) {
-		throw IOException("Failed to write extension to %s", local_extension_path);
+		throw IOException("Failed to write extension to %s", temp_path);
 	}
+	fs.MoveFile(temp_path, local_extension_path);
 #endif
 }
 


### PR DESCRIPTION
Fixes #3947

This PR installs extensions to a temporary file first (e.g. `tpch.duckdb_extension.tmp`) and only moves them to the final destination when installation is successful. This prevents partial extensions from being used while they are still being downloaded, and prevents partial extensions from being counted as installed (so that subsequent `INSTALL` commands will not do anything without the `FORCE` flag).