### PR TITLE
[Java] Implement appender support for all? UTF-8 characters 😜

### DIFF
--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -815,16 +815,26 @@ JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1appender_1appe
 
 JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1appender_1append_1string(JNIEnv *env, jclass,
                                                                                            jobject appender_ref_buf,
-                                                                                           jstring value) {
+                                                                                           jbyteArray value) {
 	try {
 		if (env->IsSameObject(value, NULL)) {
 			get_appender(env, appender_ref_buf)->Append<std::nullptr_t>(nullptr);
 			return;
 		}
 
-		auto c_string_value = env->GetStringUTFChars(value, NULL);
-		get_appender(env, appender_ref_buf)->Append(c_string_value);
-		env->ReleaseStringUTFChars(value, c_string_value);
+		auto string_value = byte_array_to_string(env, value);
+		get_appender(env, appender_ref_buf)->Append(string_value.c_str());
+	} catch (exception &e) {
+		env->ThrowNew(J_SQLException, e.what());
+		return;
+	}
+}
+
+JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1appender_1append_1null(JNIEnv *env, jclass,
+                                                                                         jobject appender_ref_buf) {
+	try {
+		get_appender(env, appender_ref_buf)->Append<std::nullptr_t>(nullptr);
+		return;
 	} catch (exception &e) {
 		env->ThrowNew(J_SQLException, e.what());
 		return;

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBAppender.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBAppender.java
@@ -56,7 +56,11 @@ public class DuckDBAppender implements AutoCloseable {
     }
 
     public void append(String value) throws SQLException {
-        DuckDBNative.duckdb_jdbc_appender_append_string(appender_ref, value);
+        if (value == null) {
+            DuckDBNative.duckdb_jdbc_appender_append_null(appender_ref);
+        } else {
+            DuckDBNative.duckdb_jdbc_appender_append_string(appender_ref, value.getBytes(StandardCharsets.UTF_8));
+        }
     }
 
     protected void finalize() throws Throwable {

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBNative.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBNative.java
@@ -113,6 +113,7 @@ public class DuckDBNative {
 
 	protected static native void duckdb_jdbc_appender_append_double(ByteBuffer appender_ref, double value) throws SQLException;
 
-	protected static native void duckdb_jdbc_appender_append_string(ByteBuffer appender_ref, String value) throws SQLException;
+	protected static native void duckdb_jdbc_appender_append_string(ByteBuffer appender_ref, byte[] value) throws SQLException;
 
+	protected static native void duckdb_jdbc_appender_append_null(ByteBuffer appender_ref) throws SQLException;
 }

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -1793,6 +1793,30 @@ public class TestDuckDBJDBC {
 		conn.close();
 	}
 
+	public static void test_appender_string_with_emoji() throws Exception {
+		DuckDBConnection conn = (DuckDBConnection) DriverManager.getConnection("jdbc:duckdb:");
+		Statement stmt = conn.createStatement();
+
+		stmt.execute("CREATE TABLE data (str_value VARCHAR(10))");
+		String expectedValue = "䭔\uD86D\uDF7C🔥\uD83D\uDE1C";
+		try (DuckDBAppender appender = conn.createAppender("main", "data")) {
+			appender.beginRow();
+			appender.append(expectedValue);
+			appender.endRow();
+		}
+
+		ResultSet rs = stmt.executeQuery("SELECT str_value FROM data");
+		assertFalse(rs.isClosed());
+		assertTrue(rs.next());
+
+		String appendedValue = rs.getString(1);
+		assertEquals(appendedValue, expectedValue);
+
+		rs.close();
+		stmt.close();
+		conn.close();
+	}
+
 	public static void test_appender_table_does_not_exist() throws Exception {
 		DuckDBConnection conn = (DuckDBConnection) DriverManager.getConnection("jdbc:duckdb:");
 		Statement stmt = conn.createStatement();


### PR DESCRIPTION
Instead of using the JNI tools to extract the UTF-8 c_string convert the java string to
a byte array (in UTF-8) before crossing the JNI boundary.

Fixes #3956