### PR TITLE
Fix #3960: avoid returning an error when a blob contains a NULL character in duckdb_append_blob

### DIFF
--- a/src/main/capi/appender-c.cpp
+++ b/src/main/capi/appender-c.cpp
@@ -184,7 +184,8 @@ duckdb_state duckdb_append_varchar_length(duckdb_appender appender, const char *
 	return duckdb_append_internal<string_t>(appender, string_t(val, length));
 }
 duckdb_state duckdb_append_blob(duckdb_appender appender, const void *data, idx_t length) {
-	return duckdb_append_internal<string_t>(appender, string_t((const char *)data, length));
+	auto value = duckdb::Value::BLOB((duckdb::const_data_ptr_t)data, length);
+	return duckdb_append_internal<duckdb::Value>(appender, value);
 }
 
 duckdb_state duckdb_appender_flush(duckdb_appender appender) {

--- a/test/api/capi/test_capi_appender.cpp
+++ b/test/api/capi/test_capi_appender.cpp
@@ -179,9 +179,9 @@ TEST_CASE("Test appender statements in C API", "[capi]") {
 	date_struct.month = 9;
 	date_struct.day = 3;
 
-	auto str = strdup("hello world this is my long string");
-	status = duckdb_append_blob(tappender, str, strlen(str));
-	free(str);
+	char blob_data[] = "hello world this\0is my long string";
+	idx_t blob_len = 34;
+	status = duckdb_append_blob(tappender, blob_data, blob_len);
 	REQUIRE(status == DuckDBSuccess);
 
 	status = duckdb_append_date(tappender, duckdb_to_date(date_struct));
@@ -298,8 +298,8 @@ TEST_CASE("Test appender statements in C API", "[capi]") {
 	REQUIRE(result->Fetch<string>(10, 0) == "hello");
 
 	auto blob = duckdb_value_blob(&result->InternalResult(), 11, 0);
-	REQUIRE(blob.size == 34);
-	REQUIRE(memcmp(blob.data, "hello world this is my long string", 34) == 0);
+	REQUIRE(blob.size == blob_len);
+	REQUIRE(memcmp(blob.data, blob_data, blob_len) == 0);
 	duckdb_free(blob.data);
 	REQUIRE(duckdb_value_int32(&result->InternalResult(), 11, 0) == 0);
 


### PR DESCRIPTION
Fixes #3960 