### PR TITLE
Atomic extension install: use UUID in temp file

### DIFF
--- a/src/common/types/uuid.cpp
+++ b/src/common/types/uuid.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/types/uuid.hpp"
+#include "duckdb/common/random_engine.hpp"
 
 namespace duckdb {
 
@@ -82,6 +83,45 @@ void UUID::ToString(hugeint_t input, char *buf) {
 	byte_to_hex(input.lower >> 16 & 0xFF, buf, pos);
 	byte_to_hex(input.lower >> 8 & 0xFF, buf, pos);
 	byte_to_hex(input.lower & 0xFF, buf, pos);
+}
+
+hugeint_t UUID::GenerateRandomUUID(RandomEngine &engine) {
+	uint8_t bytes[16];
+	for (int i = 0; i < 16; i += 4) {
+		*reinterpret_cast<uint32_t *>(bytes + i) = engine.NextRandomInteger();
+	}
+	// variant must be 10xxxxxx
+	bytes[8] &= 0xBF;
+	bytes[8] |= 0x80;
+	// version must be 0100xxxx
+	bytes[6] &= 0x4F;
+	bytes[6] |= 0x40;
+
+	hugeint_t result;
+	result.upper = 0;
+	result.upper |= ((int64_t)bytes[0] << 56);
+	result.upper |= ((int64_t)bytes[1] << 48);
+	result.upper |= ((int64_t)bytes[3] << 40);
+	result.upper |= ((int64_t)bytes[4] << 32);
+	result.upper |= ((int64_t)bytes[5] << 24);
+	result.upper |= ((int64_t)bytes[6] << 16);
+	result.upper |= ((int64_t)bytes[7] << 8);
+	result.upper |= bytes[8];
+	result.lower = 0;
+	result.lower |= ((uint64_t)bytes[8] << 56);
+	result.lower |= ((uint64_t)bytes[9] << 48);
+	result.lower |= ((uint64_t)bytes[10] << 40);
+	result.lower |= ((uint64_t)bytes[11] << 32);
+	result.lower |= ((uint64_t)bytes[12] << 24);
+	result.lower |= ((uint64_t)bytes[13] << 16);
+	result.lower |= ((uint64_t)bytes[14] << 8);
+	result.lower |= bytes[15];
+	return result;
+}
+
+hugeint_t UUID::GenerateRandomUUID() {
+	RandomEngine engine;
+	return GenerateRandomUUID(engine);
 }
 
 } // namespace duckdb

--- a/src/function/scalar/math/random.cpp
+++ b/src/function/scalar/math/random.cpp
@@ -67,35 +67,7 @@ static void GenerateUUIDFunction(DataChunk &args, ExpressionState &state, Vector
 	auto result_data = FlatVector::GetData<hugeint_t>(result);
 
 	for (idx_t i = 0; i < args.size(); i++) {
-		uint8_t bytes[16];
-		for (int i = 0; i < 16; i += 4) {
-			*reinterpret_cast<uint32_t *>(bytes + i) = lstate.random_engine.NextRandomInteger();
-		}
-		// variant must be 10xxxxxx
-		bytes[8] &= 0xBF;
-		bytes[8] |= 0x80;
-		// version must be 0100xxxx
-		bytes[6] &= 0x4F;
-		bytes[6] |= 0x40;
-
-		result_data[i].upper = 0;
-		result_data[i].upper |= ((int64_t)bytes[0] << 56);
-		result_data[i].upper |= ((int64_t)bytes[1] << 48);
-		result_data[i].upper |= ((int64_t)bytes[3] << 40);
-		result_data[i].upper |= ((int64_t)bytes[4] << 32);
-		result_data[i].upper |= ((int64_t)bytes[5] << 24);
-		result_data[i].upper |= ((int64_t)bytes[6] << 16);
-		result_data[i].upper |= ((int64_t)bytes[7] << 8);
-		result_data[i].upper |= bytes[8];
-		result_data[i].lower = 0;
-		result_data[i].lower |= ((uint64_t)bytes[8] << 56);
-		result_data[i].lower |= ((uint64_t)bytes[9] << 48);
-		result_data[i].lower |= ((uint64_t)bytes[10] << 40);
-		result_data[i].lower |= ((uint64_t)bytes[11] << 32);
-		result_data[i].lower |= ((uint64_t)bytes[12] << 24);
-		result_data[i].lower |= ((uint64_t)bytes[13] << 16);
-		result_data[i].lower |= ((uint64_t)bytes[14] << 8);
-		result_data[i].lower |= bytes[15];
+		result_data[i] = UUID::GenerateRandomUUID(lstate.random_engine);
 	}
 }
 

--- a/src/include/duckdb/common/types/uuid.hpp
+++ b/src/include/duckdb/common/types/uuid.hpp
@@ -12,6 +12,8 @@
 #include "duckdb/common/types/string_type.hpp"
 
 namespace duckdb {
+class ClientContext;
+struct RandomEngine;
 
 //! The UUID class contains static operations for the UUID type
 class UUID {
@@ -25,6 +27,10 @@ public:
 	}
 	//! Convert a hugeint object to a uuid style string
 	static void ToString(hugeint_t input, char *buf);
+
+	//! Convert a hugeint object to a uuid style string
+	static hugeint_t GenerateRandomUUID(RandomEngine &engine);
+	static hugeint_t GenerateRandomUUID();
 
 	//! Convert a hugeint object to a uuid style string
 	static string ToString(hugeint_t input) {

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/common/gzip_file_system.hpp"
+#include "duckdb/common/types/uuid.hpp"
 
 #ifndef DISABLE_DUCKDB_REMOTE_INSTALL
 #include "httplib.hpp"
@@ -48,7 +49,8 @@ void ExtensionHelper::InstallExtension(DatabaseInstance &db, const string &exten
 		return;
 	}
 
-	string temp_path = local_extension_path + ".tmp";
+	auto uuid = UUID::ToString(UUID::GenerateRandomUUID());
+	string temp_path = local_extension_path + ".tmp-" + uuid;
 	if (fs.FileExists(temp_path)) {
 		fs.RemoveFile(temp_path);
 	}


### PR DESCRIPTION
Follow up from #3950, fixes a problem when multiple DuckDB processes install the same extension at the same time.