### PR TITLE
Add support for DATEFORMAT and TIMESTAMPFORMAT to COPY TO

### DIFF
--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -314,6 +314,15 @@ static void WriteCSVSink(ClientContext &context, FunctionData &bind_data, Global
 		if (csv_data.sql_types[col_idx].id() == LogicalTypeId::VARCHAR) {
 			// VARCHAR, just create a reference
 			cast_chunk.data[col_idx].Reference(input.data[col_idx]);
+		} else if (options.has_format[LogicalTypeId::DATE] && csv_data.sql_types[col_idx].id() == LogicalTypeId::DATE) {
+			// use the date format to cast the chunk
+			csv_data.options.write_date_format[LogicalTypeId::DATE].ConvertDateVector(
+			    input.data[col_idx], cast_chunk.data[col_idx], input.size());
+		} else if (options.has_format[LogicalTypeId::TIMESTAMP] &&
+		           csv_data.sql_types[col_idx].id() == LogicalTypeId::TIMESTAMP) {
+			// use the timestamp format to cast the chunk
+			csv_data.options.write_date_format[LogicalTypeId::TIMESTAMP].ConvertTimestampVector(
+			    input.data[col_idx], cast_chunk.data[col_idx], input.size());
 		} else {
 			// non varchar column, perform the cast
 			VectorOperations::Cast(input.data[col_idx], cast_chunk.data[col_idx], input.size());

--- a/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
@@ -123,6 +123,9 @@ struct BufferedCSVReaderOptions {
 
 	//! The date format to use (if any is specified)
 	std::map<LogicalTypeId, StrpTimeFormat> date_format = {{LogicalTypeId::DATE, {}}, {LogicalTypeId::TIMESTAMP, {}}};
+	//! The date format to use for writing (if any is specified)
+	std::map<LogicalTypeId, StrfTimeFormat> write_date_format = {{LogicalTypeId::DATE, {}},
+	                                                             {LogicalTypeId::TIMESTAMP, {}}};
 	//! Whether or not a type format is specified
 	std::map<LogicalTypeId, bool> has_format = {{LogicalTypeId::DATE, false}, {LogicalTypeId::TIMESTAMP, false}};
 
@@ -137,6 +140,7 @@ struct BufferedCSVReaderOptions {
 	void SetReadOption(const string &loption, const Value &value, vector<string> &expected_names);
 
 	void SetWriteOption(const string &loption, const Value &value);
+	void SetDateFormat(LogicalTypeId type, const string &format, bool read_format);
 
 	std::string ToString() const;
 };

--- a/src/include/duckdb/function/scalar/strftime.hpp
+++ b/src/include/duckdb/function/scalar/strftime.hpp
@@ -91,6 +91,9 @@ struct StrfTimeFormat : public StrTimeFormat {
 
 	DUCKDB_API static string Format(timestamp_t timestamp, const string &format);
 
+	DUCKDB_API void ConvertDateVector(Vector &input, Vector &result, idx_t count);
+	DUCKDB_API void ConvertTimestampVector(Vector &input, Vector &result, idx_t count);
+
 protected:
 	//! The variable-length specifiers. To determine total string size, these need to be checked.
 	vector<StrTimeSpecifier> var_length_specifiers;

--- a/test/sql/copy/csv/test_dateformat.test
+++ b/test/sql/copy/csv/test_dateformat.test
@@ -27,6 +27,22 @@ SELECT * FROM dates ORDER BY d
 2019-05-06
 2019-06-05
 
+# test dateformat on COPY TO
+statement ok
+CREATE TABLE new_dates (d DATE);
+
+statement ok
+COPY dates TO '__TEST_DIR__/dateformat.csv' (HEADER 0, DATEFORMAT '%d/%m/%Y')
+
+statement ok
+COPY new_dates FROM '__TEST_DIR__/dateformat.csv' (HEADER 0, DATEFORMAT '%d/%m/%Y')
+
+query I
+SELECT * FROM new_dates ORDER BY 1
+----
+2019-05-06
+2019-06-05
+
 # timestamp format
 statement ok
 CREATE TABLE timestamps(t TIMESTAMP);
@@ -37,6 +53,36 @@ COPY timestamps FROM 'test/sql/copy/csv/data/test/timestampformat.csv' (HEADER 0
 
 query I
 SELECT * FROM timestamps
+----
+2003-06-30 12:03:10
+
+# test timestamp format on COPY TO
+statement ok
+CREATE TABLE new_timestamps (t TIMESTAMP);
+
+statement ok
+COPY timestamps TO '__TEST_DIR__/timestampformat.csv' (HEADER 0, TIMESTAMPFORMAT '%a %d, %B %Y, %I:%M:%S %p')
+
+statement ok
+COPY new_timestamps FROM '__TEST_DIR__/timestampformat.csv' (HEADER 0, TIMESTAMPFORMAT '%a %d, %B %Y, %I:%M:%S %p')
+
+query I
+SELECT * FROM new_timestamps ORDER BY 1
+----
+2003-06-30 12:03:10
+
+statement ok
+DELETE FROM new_timestamps
+
+# test iso format in copy
+statement ok
+COPY timestamps TO '__TEST_DIR__/timestampformat.csv' (HEADER 0, TIMESTAMPFORMAT ISO)
+
+statement ok
+COPY new_timestamps FROM '__TEST_DIR__/timestampformat.csv' (HEADER 0)
+
+query I
+SELECT * FROM new_timestamps ORDER BY 1
 ----
 2003-06-30 12:03:10
 


### PR DESCRIPTION
Fixes #3942

The following now works:

```sql
COPY tbl TO 'tbl.csv' (TIMESTAMPFORMAT '%a %d, %B %Y, %I:%M:%S %p');
```

There is also an `ISO` short-hand:

```sql
COPY tbl TO 'tbl.csv' (TIMESTAMPFORMAT ISO);
-- short hand for:
COPY tbl TO 'tbl.csv' (TIMESTAMPFORMAT '%Y-%m-%dT%H:%M:%S.%fZ');
```

The [documentation has a list of all format specifiers here](https://duckdb.org/docs/sql/functions/dateformat).