### PR TITLE
Fix #3942: avoid converting + to space in httplib::decode_url

### DIFF
--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -311,7 +311,7 @@ bool HTTPFileSystem::FileExists(const string &filename) {
 		auto handle = OpenFile(filename.c_str(), FileFlags::FILE_FLAGS_READ);
 		auto &sfh = (HTTPFileHandle &)handle;
 		if (sfh.length == 0) {
-			throw std::runtime_error("not there this file");
+			return false;
 		}
 		return true;
 	} catch (...) {

--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -73,9 +73,9 @@ class S3FileHandle : public HTTPFileHandle {
 	friend class S3FileSystem;
 
 public:
-	S3FileHandle(FileSystem &fs, std::string path, uint8_t flags, const HTTPParams &http_params,
+	S3FileHandle(FileSystem &fs, std::string path_p, uint8_t flags, const HTTPParams &http_params,
 	             const S3AuthParams &auth_params_p, const S3ConfigParams &config_params_p)
-	    : HTTPFileHandle(fs, std::move(path), flags, http_params), auth_params(auth_params_p),
+	    : HTTPFileHandle(fs, std::move(path_p), flags, http_params), auth_params(auth_params_p),
 	      config_params(config_params_p) {
 
 		if (flags & FileFlags::FILE_FLAGS_WRITE && flags & FileFlags::FILE_FLAGS_READ) {

--- a/test/sql/copy/parquet/test_parquet_remote.test
+++ b/test/sql/copy/parquet/test_parquet_remote.test
@@ -67,3 +67,18 @@ SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://github.com:44
 8	Harry	Howell	hhowell7@eepurl.com
 9	Jose	Foster	jfoster8@yelp.com
 10	Emily	Stewart	estewart9@opensource.org
+
+# with a + in the path
+query IIII
+SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://github.com/cwida/duckdb-data/releases/download/v1.0/us+er+da+ta.parquet') LIMIT 10;
+----
+1	Amanda	Jordan	ajordan0@com.com
+2	Albert	Freeman	afreeman1@is.gd
+3	Evelyn	Morgan	emorgan2@altervista.org
+4	Denise	Riley	driley3@gmpg.org
+5	Carlos	Burns	cburns4@miitbeian.gov.cn
+6	Kathryn	White	kwhite5@google.com
+7	Samuel	Holmes	sholmes6@foxnews.com
+8	Harry	Howell	hhowell7@eepurl.com
+9	Jose	Foster	jfoster8@yelp.com
+10	Emily	Stewart	estewart9@opensource.org

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -6072,7 +6072,7 @@ inline bool ClientImpl::redirect(Request &req, Response &res, Error &error) {
 		return false;
 	}
 
-	auto location = detail::decode_url(res.get_header_value("location"), true);
+	auto location = detail::decode_url(res.get_header_value("location"), false);
 	if (location.empty()) { return false; }
 
 	const static Regex re(


### PR DESCRIPTION
Fixes #3942 

The problem is that on redirect, httplib would convert any `+` symbol in the URL to a space, which would cause incorrect behavior. I am not sure if disabling this behavior will cause other problems, however.  