### PR TITLE
Issue #3079: When installed system RAM cannot be determined, default to no memory limit

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -95,7 +95,7 @@ idx_t FileSystem::GetAvailableMemory() {
 	mem_state.dwLength = sizeof(MEMORYSTATUSEX);
 
 	if (GlobalMemoryStatusEx(&mem_state)) {
-		return MinValue<idx_t>(statex.ullTotalPhys, UINTPTR_MAX);
+		return MinValue<idx_t>(mem_state.ullTotalPhys, UINTPTR_MAX);
 	}
 	return DConstants::INVALID_INDEX;
 }

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -59,7 +59,7 @@ idx_t FileSystem::GetAvailableMemory() {
 	errno = 0;
 	idx_t max_memory = MinValue<idx_t>((idx_t)sysconf(_SC_PHYS_PAGES) * (idx_t)sysconf(_SC_PAGESIZE), UINTPTR_MAX);
 	if (errno != 0) {
-		throw IOException("Could not fetch available system memory!");
+		return DConstants::INVALID_INDEX;
 	}
 	return max_memory;
 }
@@ -87,7 +87,7 @@ void FileSystem::SetWorkingDirectory(const string &path) {
 idx_t FileSystem::GetAvailableMemory() {
 	ULONGLONG available_memory_kb;
 	if (!GetPhysicallyInstalledSystemMemory(&available_memory_kb)) {
-		throw IOException("Could not fetch available system memory!");
+		return DConstants::INVALID_INDEX;
 	}
 	return MinValue<idx_t>(available_memory_kb * 1024, UINTPTR_MAX);
 }

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -22,6 +22,7 @@
 #include <unistd.h>
 #else
 #include <string>
+#include <sysinfoapi.h>
 
 #ifdef __MINGW32__
 // need to manually define this for mingw
@@ -86,10 +87,17 @@ void FileSystem::SetWorkingDirectory(const string &path) {
 
 idx_t FileSystem::GetAvailableMemory() {
 	ULONGLONG available_memory_kb;
-	if (!GetPhysicallyInstalledSystemMemory(&available_memory_kb)) {
-		return DConstants::INVALID_INDEX;
+	if (GetPhysicallyInstalledSystemMemory(&available_memory_kb)) {
+		return MinValue<idx_t>(available_memory_kb * 1024, UINTPTR_MAX);
 	}
-	return MinValue<idx_t>(available_memory_kb * 1024, UINTPTR_MAX);
+	// fallback: try GlobalMemoryStatusEx
+	MEMORYSTATUSEX mem_state;
+	mem_state.dwLength = sizeof(MEMORYSTATUSEX);
+
+	if (GlobalMemoryStatusEx(&mem_state)) {
+		return MinValue<idx_t>(statex.ullTotalPhys, UINTPTR_MAX);
+	}
+	return DConstants::INVALID_INDEX;
 }
 
 string FileSystem::GetWorkingDirectory() {

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -158,7 +158,7 @@ public:
 	DUCKDB_API static string GetWorkingDirectory();
 	//! Gets the users home directory
 	DUCKDB_API static string GetHomeDirectory();
-	//! Returns the system-available memory in bytes
+	//! Returns the system-available memory in bytes. Returns DConstants::INVALID_INDEX if the system function fails.
 	DUCKDB_API static idx_t GetAvailableMemory();
 	//! Path separator for the current file system
 	DUCKDB_API static string PathSeparator();

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -205,7 +205,10 @@ void DatabaseInstance::Configure(DBConfig &new_config) {
 	}
 	config.maximum_memory = new_config.maximum_memory;
 	if (config.maximum_memory == (idx_t)-1) {
-		config.maximum_memory = FileSystem::GetAvailableMemory() * 8 / 10;
+		auto memory = FileSystem::GetAvailableMemory();
+		if (memory != DConstants::INVALID_INDEX) {
+			config.maximum_memory = memory * 8 / 10;
+		}
 	}
 	if (new_config.maximum_threads == (idx_t)-1) {
 #ifndef DUCKDB_NO_THREADS


### PR DESCRIPTION
Fixes #3079

This is preferable to the current behavior, as the current behavior prevents the database from being started entirely in case these methods fail. By defaulting to infinite memory instead, the user can manually set a memory limit if required.