### PR TITLE
fix fts/httpfs include directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -517,13 +517,13 @@ function(add_extension_definitions)
   endif()
 
   if(${BUILD_FTS_EXTENSION})
-    include_directories(${CMAKE_SOURCE_DIR}/extension/fts/include)
+    include_directories(${PROJECT_SOURCE_DIR}/extension/fts/include)
     add_definitions(-DBUILD_FTS_EXTENSION=${BUILD_FTS_EXTENSION})
   endif()
 
   if(${BUILD_HTTPFS_EXTENSION})
     find_package(OpenSSL REQUIRED)
-    include_directories(${CMAKE_SOURCE_DIR}/extension/httpfs/include ${OPENSSL_INCLUDE_DIR})
+    include_directories(${PROJECT_SOURCE_DIR}/extension/httpfs/include ${OPENSSL_INCLUDE_DIR})
     add_definitions(-DBUILD_HTTPFS_EXTENSION=${BUILD_HTTPFS_EXTENSION})
   endif()
 


### PR DESCRIPTION
I am trying to write a duckdb conan recipe, but I cannot enable fts and httpfs without a patch.
This is because the `include_directories` paths in CMakeLists.txt are defined differently for fts and httpfs only.

When CMakeLists.txt in duckdb is called from the external CMakeLists.txt, the meaning of CMAKE_SOURCE_DIR and PROJECT_SOURCE_DIR change.

I have created a PR that uses PROJECT_SOURCE_DIR which are used by other extensions.

I know it is not important modification for usual use case.
Please merge it if possible.