### PR TITLE
Add support for extensions to the parser, and add an example of this to the loadable extension demo

### DIFF
--- a/src/common/enums/statement_type.cpp
+++ b/src/common/enums/statement_type.cpp
@@ -51,6 +51,8 @@ string StatementTypeToString(StatementType type) {
 		return "SET";
 	case StatementType::LOAD_STATEMENT:
 		return "LOAD";
+	case StatementType::EXTENSION_STATEMENT:
+		return "EXTENSION";
 	case StatementType::INVALID_STATEMENT:
 		break;
 	}

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -25,7 +25,11 @@ TableFunction::TableFunction(const vector<LogicalType> &arguments, table_functio
                              table_function_init_local_t init_local)
     : TableFunction(string(), arguments, function, bind, init_global, init_local) {
 }
-TableFunction::TableFunction() : SimpleNamedParameterFunction("", {}) {
+TableFunction::TableFunction()
+    : SimpleNamedParameterFunction("", {}), bind(nullptr), init_global(nullptr), init_local(nullptr), function(nullptr),
+      in_out_function(nullptr), statistics(nullptr), dependency(nullptr), cardinality(nullptr),
+      pushdown_complex_filter(nullptr), to_string(nullptr), table_scan_progress(nullptr), get_batch_index(nullptr),
+      projection_pushdown(false), filter_pushdown(false) {
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/common/enums/statement_type.hpp
+++ b/src/include/duckdb/common/enums/statement_type.hpp
@@ -39,7 +39,8 @@ enum class StatementType : uint8_t {
 	CALL_STATEMENT,         // CALL statement type
 	SET_STATEMENT,          // SET statement type
 	LOAD_STATEMENT,         // LOAD statement type
-	RELATION_STATEMENT
+	RELATION_STATEMENT,
+	EXTENSION_STATEMENT
 };
 
 string StatementTypeToString(StatementType type);

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -22,6 +22,7 @@
 #include "duckdb/common/enums/optimizer_type.hpp"
 #include "duckdb/common/enums/window_aggregation_mode.hpp"
 #include "duckdb/common/enums/set_scope.hpp"
+#include "duckdb/parser/parser_extension.hpp"
 
 namespace duckdb {
 class ClientContext;
@@ -127,6 +128,8 @@ public:
 	WindowAggregationMode window_mode = WindowAggregationMode::WINDOW;
 	//! Whether or not preserving insertion order should be preserved
 	bool preserve_insertion_order = true;
+	//! Extensions made to the parser
+	vector<ParserExtension> parser_extensions;
 
 	//! Extra parameters that can be SET for loaded extensions
 	case_insensitive_map_t<ExtensionOption> extension_parameters;

--- a/src/include/duckdb/parser/parser.hpp
+++ b/src/include/duckdb/parser/parser.hpp
@@ -20,10 +20,12 @@ struct PGList;
 } // namespace duckdb_libpgquery
 
 namespace duckdb {
+class ParserExtension;
 
 struct ParserOptions {
 	bool preserve_identifier_case = true;
 	idx_t max_expression_depth = 1000;
+	vector<ParserExtension> *extensions = nullptr;
 };
 
 //! The parser is responsible for parsing the query and converting it into a set

--- a/src/include/duckdb/parser/parser_extension.hpp
+++ b/src/include/duckdb/parser/parser_extension.hpp
@@ -17,33 +17,33 @@ namespace duckdb {
 //! The ParserExtensionInfo holds static information relevant to the parser extension
 //! It is made available in the parse_function, and will be kept alive as long as the database system is kept alive
 struct ParserExtensionInfo {
-	DUCKDB_API virtual ~ParserExtensionInfo() {}
+	DUCKDB_API virtual ~ParserExtensionInfo() {
+	}
 };
 
 //===--------------------------------------------------------------------===//
 // Parse
 //===--------------------------------------------------------------------===//
-enum class ParserExtensionResultType : uint8_t {
-	PARSE_SUCCESSFUL,
-	DISPLAY_ORIGINAL_ERROR,
-	DISPLAY_EXTENSION_ERROR
-};
+enum class ParserExtensionResultType : uint8_t { PARSE_SUCCESSFUL, DISPLAY_ORIGINAL_ERROR, DISPLAY_EXTENSION_ERROR };
 
 //! The ParserExtensionParseData holds the result of a successful parse step
 //! It will be passed along to the subsequent plan function
 struct ParserExtensionParseData {
-	DUCKDB_API virtual ~ParserExtensionParseData() {}
+	DUCKDB_API virtual ~ParserExtensionParseData() {
+	}
 
 	virtual unique_ptr<ParserExtensionParseData> Copy() const = 0;
 };
 
 struct ParserExtensionParseResult {
-	ParserExtensionParseResult() :
-		type(ParserExtensionResultType::DISPLAY_ORIGINAL_ERROR) {}
-	ParserExtensionParseResult(string error_p) :
-		type(ParserExtensionResultType::DISPLAY_EXTENSION_ERROR), error(move(error_p)) {}
-	ParserExtensionParseResult(unique_ptr<ParserExtensionParseData> parse_data_p) :
-		type(ParserExtensionResultType::PARSE_SUCCESSFUL), parse_data(move(parse_data_p)) {}
+	ParserExtensionParseResult() : type(ParserExtensionResultType::DISPLAY_ORIGINAL_ERROR) {
+	}
+	ParserExtensionParseResult(string error_p)
+	    : type(ParserExtensionResultType::DISPLAY_EXTENSION_ERROR), error(move(error_p)) {
+	}
+	ParserExtensionParseResult(unique_ptr<ParserExtensionParseData> parse_data_p)
+	    : type(ParserExtensionResultType::PARSE_SUCCESSFUL), parse_data(move(parse_data_p)) {
+	}
 
 	//! Whether or not parsing was successful
 	ParserExtensionResultType type;
@@ -70,7 +70,8 @@ struct ParserExtensionPlanResult {
 	StatementReturnType return_type = StatementReturnType::NOTHING;
 };
 
-typedef ParserExtensionPlanResult (*plan_function_t)(ParserExtensionInfo *info, ClientContext &context, unique_ptr<ParserExtensionParseData> parse_data);
+typedef ParserExtensionPlanResult (*plan_function_t)(ParserExtensionInfo *info, ClientContext &context,
+                                                     unique_ptr<ParserExtensionParseData> parse_data);
 
 //===--------------------------------------------------------------------===//
 // ParserExtension
@@ -89,4 +90,4 @@ public:
 	shared_ptr<ParserExtensionInfo> parser_info;
 };
 
-}
+} // namespace duckdb

--- a/src/include/duckdb/parser/parser_extension.hpp
+++ b/src/include/duckdb/parser/parser_extension.hpp
@@ -1,0 +1,97 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/parser_extension.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/enums/statement_type.hpp"
+#include "duckdb/function/table_function.hpp"
+
+namespace duckdb {
+
+//! The ParserExtensionInfo holds static information relevant to the parser extension
+//! It is made available in the parse_function, and will be kept alive as long as the database system is kept alive
+struct ParserExtensionInfo {
+	DUCKDB_API virtual ~ParserExtensionInfo() {}
+};
+
+//===--------------------------------------------------------------------===//
+// Parse
+//===--------------------------------------------------------------------===//
+enum class ParserExtensionResultType : uint8_t {
+	PARSE_SUCCESSFUL,
+	DISPLAY_ORIGINAL_ERROR,
+	DISPLAY_EXTENSION_ERROR
+};
+
+//! The ParserExtensionParseData holds the result of a successful parse step
+//! It will be passed along to the subsequent plan function
+struct ParserExtensionParseData {
+	DUCKDB_API virtual ~ParserExtensionParseData() {}
+
+	virtual unique_ptr<ParserExtensionParseData> Copy() const = 0;
+};
+
+struct ParserExtensionParseResult {
+	ParserExtensionParseResult() :
+		type(ParserExtensionResultType::DISPLAY_ORIGINAL_ERROR) {}
+	ParserExtensionParseResult(string error_p) :
+		type(ParserExtensionResultType::DISPLAY_EXTENSION_ERROR), error(move(error_p)) {}
+	ParserExtensionParseResult(unique_ptr<ParserExtensionParseData> parse_data_p) :
+		type(ParserExtensionResultType::PARSE_SUCCESSFUL), parse_data(move(parse_data_p)) {}
+
+	//! Whether or not parsing was successful
+	ParserExtensionResultType type;
+	//! The parse data (if successful)
+	unique_ptr<ParserExtensionParseData> parse_data;
+	//! The error message (if unsuccessful)
+	string error;
+};
+
+typedef ParserExtensionParseResult (*parse_function_t)(ParserExtensionInfo *info, const string &query);
+//===--------------------------------------------------------------------===//
+// Plan
+//===--------------------------------------------------------------------===//
+struct ParserExtensionPlanData {
+	DUCKDB_API virtual ~ParserExtensionPlanData() {}
+};
+
+//! Input to plan_function_t
+struct ParserExtensionPlanResult {
+	//! The table function to execute
+	TableFunction function;
+	//! Parameters to the function
+	vector<Value> parameters;
+	//! Whether or not the statement is read_only (i.e. can be executed in a read_only database)
+	bool read_only = false;
+	//! Whether or not the statement requires a valid transaction to be executed
+	bool requires_valid_transaction = true;
+	//! What type of result set the statement returns
+	StatementReturnType return_type = StatementReturnType::NOTHING;
+};
+
+typedef ParserExtensionPlanResult (*plan_function_t)(ParserExtensionInfo *info, ClientContext &context, unique_ptr<ParserExtensionParseData> parse_data);
+
+//===--------------------------------------------------------------------===//
+// ParserExtension
+//===--------------------------------------------------------------------===//
+class ParserExtension {
+public:
+	//! The parse function of the parser extension.
+	//! Takes a query string as input and returns ParserExtensionParseData (on success) or an error
+	parse_function_t parse_function;
+
+	//! The plan function of the parser extension
+	//! Takes as input the result of the parse_function, and outputs various properties of the resulting plan
+	plan_function_t plan_function;
+
+	//! Additional parser info passed to the parse function
+	shared_ptr<ParserExtensionInfo> parser_info;
+};
+
+}

--- a/src/include/duckdb/parser/parser_extension.hpp
+++ b/src/include/duckdb/parser/parser_extension.hpp
@@ -57,11 +57,6 @@ typedef ParserExtensionParseResult (*parse_function_t)(ParserExtensionInfo *info
 //===--------------------------------------------------------------------===//
 // Plan
 //===--------------------------------------------------------------------===//
-struct ParserExtensionPlanData {
-	DUCKDB_API virtual ~ParserExtensionPlanData() {}
-};
-
-//! Input to plan_function_t
 struct ParserExtensionPlanResult {
 	//! The table function to execute
 	TableFunction function;

--- a/src/include/duckdb/parser/statement/extension_statement.hpp
+++ b/src/include/duckdb/parser/statement/extension_statement.hpp
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/statement/extension_statement.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/parser/sql_statement.hpp"
+#include "duckdb/parser/parser_extension.hpp"
+
+namespace duckdb {
+
+class ExtensionStatement : public SQLStatement {
+public:
+	ExtensionStatement(ParserExtension extension, unique_ptr<ParserExtensionParseData> parse_data);
+
+	//! The ParserExtension this statement was generated from
+	ParserExtension extension;
+	//! The parse data for this specific statement
+	unique_ptr<ParserExtensionParseData> parse_data;
+
+public:
+	unique_ptr<SQLStatement> Copy() const override;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/parser/tokens.hpp
+++ b/src/include/duckdb/parser/tokens.hpp
@@ -21,6 +21,7 @@ class CopyStatement;
 class CreateStatement;
 class DeleteStatement;
 class DropStatement;
+class ExtensionStatement;
 class InsertStatement;
 class SelectStatement;
 class TransactionStatement;

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -211,6 +211,7 @@ private:
 	BoundStatement Bind(ShowStatement &stmt);
 	BoundStatement Bind(CallStatement &stmt);
 	BoundStatement Bind(ExportStatement &stmt);
+	BoundStatement Bind(ExtensionStatement &stmt);
 	BoundStatement Bind(SetStatement &stmt);
 	BoundStatement Bind(LoadStatement &stmt);
 	BoundStatement BindReturning(vector<unique_ptr<ParsedExpression>> returning_list, TableCatalogEntry *table,
@@ -244,6 +245,12 @@ private:
 	                                 unique_ptr<BoundSubqueryRef> &subquery, string &error);
 	bool BindTableInTableOutFunction(vector<unique_ptr<ParsedExpression>> &expressions,
 	                                 unique_ptr<BoundSubqueryRef> &subquery, string &error);
+	unique_ptr<LogicalOperator> BindTableFunction(TableFunction &function, vector<Value> parameters);
+	unique_ptr<LogicalOperator>
+	BindTableFunctionInternal(TableFunction &table_function, const string &function_name, vector<Value> parameters,
+	                          named_parameter_map_t named_parameters, vector<LogicalType> input_table_types,
+	                          vector<string> input_table_names, const vector<string> &column_name_alias,
+	                          unique_ptr<ExternalDependency> external_dependency);
 
 	unique_ptr<LogicalOperator> CreatePlan(BoundBaseTableRef &ref);
 	unique_ptr<LogicalOperator> CreatePlan(BoundCrossProductRef &ref);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1183,6 +1183,7 @@ ParserOptions ClientContext::GetParserOptions() {
 	ParserOptions options;
 	options.preserve_identifier_case = ClientConfig::GetConfig(*this).preserve_identifier_case;
 	options.max_expression_depth = ClientConfig::GetConfig(*this).max_expression_depth;
+	options.extensions = &DBConfig::GetConfig(*this).parser_extensions;
 	return options;
 }
 

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -233,6 +233,7 @@ void DatabaseInstance::Configure(DBConfig &new_config) {
 	config.replacement_scans = move(new_config.replacement_scans);
 	config.initialize_default_database = new_config.initialize_default_database;
 	config.disabled_optimizers = move(new_config.disabled_optimizers);
+	config.parser_extensions = move(new_config.parser_extensions);
 }
 
 DBConfig &DBConfig::GetConfig(ClientContext &context) {

--- a/src/parser/statement/CMakeLists.txt
+++ b/src/parser/statement/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library_unity(
   execute_statement.cpp
   explain_statement.cpp
   export_statement.cpp
+  extension_statement.cpp
   insert_statement.cpp
   load_statement.cpp
   pragma_statement.cpp

--- a/src/parser/statement/extension_statement.cpp
+++ b/src/parser/statement/extension_statement.cpp
@@ -1,0 +1,13 @@
+#include "duckdb/parser/statement/extension_statement.hpp"
+
+namespace duckdb {
+
+ExtensionStatement::ExtensionStatement(ParserExtension extension_p, unique_ptr<ParserExtensionParseData> parse_data_p)
+    : SQLStatement(StatementType::EXTENSION_STATEMENT), extension(extension_p), parse_data(move(parse_data_p)) {
+}
+
+unique_ptr<SQLStatement> ExtensionStatement::Copy() const {
+	return make_unique<ExtensionStatement>(extension, parse_data->Copy());
+}
+
+} // namespace duckdb

--- a/src/parser/statement/extension_statement.cpp
+++ b/src/parser/statement/extension_statement.cpp
@@ -3,7 +3,7 @@
 namespace duckdb {
 
 ExtensionStatement::ExtensionStatement(ParserExtension extension_p, unique_ptr<ParserExtensionParseData> parse_data_p)
-    : SQLStatement(StatementType::EXTENSION_STATEMENT), extension(extension_p), parse_data(move(parse_data_p)) {
+    : SQLStatement(StatementType::EXTENSION_STATEMENT), extension(move(extension_p)), parse_data(move(parse_data_p)) {
 }
 
 unique_ptr<SQLStatement> ExtensionStatement::Copy() const {

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -77,6 +77,8 @@ BoundStatement Binder::Bind(SQLStatement &statement) {
 		return Bind((SetStatement &)statement);
 	case StatementType::LOAD_STATEMENT:
 		return Bind((LoadStatement &)statement);
+	case StatementType::EXTENSION_STATEMENT:
+		return Bind((ExtensionStatement &)statement);
 	default: // LCOV_EXCL_START
 		throw NotImplementedException("Unimplemented statement type \"%s\" for Bind",
 		                              StatementTypeToString(statement.type));

--- a/src/planner/binder/statement/CMakeLists.txt
+++ b/src/planner/binder/statement/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library_unity(
   bind_drop.cpp
   bind_explain.cpp
   bind_export.cpp
+  bind_extension.cpp
   bind_insert.cpp
   bind_load.cpp
   bind_pragma.cpp

--- a/src/planner/binder/statement/bind_extension.cpp
+++ b/src/planner/binder/statement/bind_extension.cpp
@@ -1,0 +1,31 @@
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/parser/statement/extension_statement.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+
+namespace duckdb {
+
+BoundStatement Binder::Bind(ExtensionStatement &stmt) {
+	BoundStatement result;
+
+	// perform the planning of the function
+	D_ASSERT(stmt.extension.plan_function);
+	auto parse_result = stmt.extension.plan_function(stmt.extension.parser_info.get(), context, move(stmt.parse_data));
+
+	properties.read_only = parse_result.read_only;
+	properties.requires_valid_transaction = parse_result.requires_valid_transaction;
+	properties.return_type = parse_result.return_type;
+
+	// create the plan as a scan of the given table function
+	result.plan = BindTableFunction(parse_result.function, move(parse_result.parameters));
+	D_ASSERT(result.plan->type == LogicalOperatorType::LOGICAL_GET);
+	auto &get = (LogicalGet &)*result.plan;
+	result.names = get.names;
+	result.types = get.returned_types;
+	get.column_ids.clear();
+	for (idx_t i = 0; i < get.returned_types.size(); i++) {
+		get.column_ids.push_back(i);
+	}
+	return result;
+}
+
+} // namespace duckdb

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -107,9 +107,60 @@ bool Binder::BindTableFunctionParameters(TableFunctionCatalogEntry &table_functi
 	return true;
 }
 
+unique_ptr<LogicalOperator>
+Binder::BindTableFunctionInternal(TableFunction &table_function, const string &function_name, vector<Value> parameters,
+                                  named_parameter_map_t named_parameters, vector<LogicalType> input_table_types,
+                                  vector<string> input_table_names, const vector<string> &column_name_alias,
+                                  unique_ptr<ExternalDependency> external_dependency) {
+	auto bind_index = GenerateTableIndex();
+	// perform the binding
+	unique_ptr<FunctionData> bind_data;
+	vector<LogicalType> return_types;
+	vector<string> return_names;
+	if (table_function.bind) {
+		TableFunctionBindInput bind_input(parameters, named_parameters, input_table_types, input_table_names,
+		                                  table_function.function_info.get());
+		bind_data = table_function.bind(context, bind_input, return_types, return_names);
+		if (table_function.name == "pandas_scan" || table_function.name == "arrow_scan") {
+			auto arrow_bind = (PyTableFunctionData *)bind_data.get();
+			arrow_bind->external_dependency = move(external_dependency);
+		}
+	}
+	if (return_types.size() != return_names.size()) {
+		throw InternalException(
+		    "Failed to bind \"%s\": Table function return_types and return_names must be of the same size",
+		    table_function.name);
+	}
+	if (return_types.empty()) {
+		throw InternalException("Failed to bind \"%s\": Table function must return at least one column",
+		                        table_function.name);
+	}
+	// overwrite the names with any supplied aliases
+	for (idx_t i = 0; i < column_name_alias.size() && i < return_names.size(); i++) {
+		return_names[i] = column_name_alias[i];
+	}
+	for (idx_t i = 0; i < return_names.size(); i++) {
+		if (return_names[i].empty()) {
+			return_names[i] = "C" + to_string(i);
+		}
+	}
+	auto get = make_unique<LogicalGet>(bind_index, table_function, move(bind_data), return_types, return_names);
+	// now add the table function to the bind context so its columns can be bound
+	bind_context.AddTableFunction(bind_index, function_name, return_names, return_types, *get);
+	return move(get);
+}
+
+unique_ptr<LogicalOperator> Binder::BindTableFunction(TableFunction &function, vector<Value> parameters) {
+	named_parameter_map_t named_parameters;
+	vector<LogicalType> input_table_types;
+	vector<string> input_table_names;
+	vector<string> column_name_aliases;
+	return BindTableFunctionInternal(function, function.name, move(parameters), move(named_parameters),
+	                                 move(input_table_types), move(input_table_names), column_name_aliases, nullptr);
+}
+
 unique_ptr<BoundTableRef> Binder::Bind(TableFunctionRef &ref) {
 	QueryErrorContext error_context(root_statement, ref.query_location);
-	auto bind_index = GenerateTableIndex();
 
 	D_ASSERT(ref.function->type == ExpressionType::FUNCTION);
 	auto fexpr = (FunctionExpression *)ref.function.get();
@@ -183,42 +234,9 @@ unique_ptr<BoundTableRef> Binder::Bind(TableFunctionRef &ref) {
 		input_table_types = subquery->subquery->types;
 		input_table_names = subquery->subquery->names;
 	}
-
-	// perform the binding
-	unique_ptr<FunctionData> bind_data;
-	vector<LogicalType> return_types;
-	vector<string> return_names;
-	if (table_function.bind) {
-		TableFunctionBindInput bind_input(parameters, named_parameters, input_table_types, input_table_names,
-		                                  table_function.function_info.get());
-		bind_data = table_function.bind(context, bind_input, return_types, return_names);
-		if (table_function.name == "pandas_scan" || table_function.name == "arrow_scan") {
-			auto arrow_bind = (PyTableFunctionData *)bind_data.get();
-			arrow_bind->external_dependency = move(ref.external_dependency);
-		}
-	}
-	if (return_types.size() != return_names.size()) {
-		throw InternalException(
-		    "Failed to bind \"%s\": Table function return_types and return_names must be of the same size",
-		    table_function.name);
-	}
-	if (return_types.empty()) {
-		throw InternalException("Failed to bind \"%s\": Table function must return at least one column",
-		                        table_function.name);
-	}
-	// overwrite the names with any supplied aliases
-	for (idx_t i = 0; i < ref.column_name_alias.size() && i < return_names.size(); i++) {
-		return_names[i] = ref.column_name_alias[i];
-	}
-	for (idx_t i = 0; i < return_names.size(); i++) {
-		if (return_names[i].empty()) {
-			return_names[i] = "C" + to_string(i);
-		}
-	}
-	auto get = make_unique<LogicalGet>(bind_index, table_function, move(bind_data), return_types, return_names);
-	// now add the table function to the bind context so its columns can be bound
-	bind_context.AddTableFunction(bind_index, ref.alias.empty() ? fexpr->function_name : ref.alias, return_names,
-	                              return_types, *get);
+	auto get = BindTableFunctionInternal(table_function, ref.alias.empty() ? fexpr->function_name : ref.alias,
+	                                     move(parameters), move(named_parameters), move(input_table_types),
+	                                     move(input_table_names), ref.column_name_alias, move(ref.external_dependency));
 	if (subquery) {
 		get->children.push_back(Binder::CreatePlan(*subquery));
 	}

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -186,6 +186,7 @@ void Planner::CreatePlan(unique_ptr<SQLStatement> statement) {
 	case StatementType::SHOW_STATEMENT:
 	case StatementType::SET_STATEMENT:
 	case StatementType::LOAD_STATEMENT:
+	case StatementType::EXTENSION_STATEMENT:
 		CreatePlan(*statement);
 		break;
 	case StatementType::EXECUTE_STATEMENT:

--- a/test/extension/load_extension.test
+++ b/test/extension/load_extension.test
@@ -17,7 +17,7 @@ statement error
 LOAD NULL;
 
 statement ok
-LOAD 'build/debug/test/extension/loadable_extension_demo.duckdb_extension';
+LOAD '__BUILD_DIRECTORY__/test/extension/loadable_extension_demo.duckdb_extension';
 
 query I
 SELECT hello('World');

--- a/test/extension/load_extension.test
+++ b/test/extension/load_extension.test
@@ -17,9 +17,28 @@ statement error
 LOAD NULL;
 
 statement ok
-LOAD '__BUILD_DIRECTORY__/test/extension/loadable_extension_demo.duckdb_extension';
+LOAD 'build/debug/test/extension/loadable_extension_demo.duckdb_extension';
 
 query I
 SELECT hello('World');
 ----
 Hello, World
+
+query I
+QUACK QUACK QUACK
+----
+QUACK
+QUACK
+QUACK
+
+query I
+quACk QUaCk
+----
+QUACK
+QUACK
+
+statement error
+QUAC
+
+statement error
+QUACK NOT QUACK

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -1,19 +1,146 @@
 #define DUCKDB_EXTENSION_MAIN
 #include "duckdb.hpp"
-
+#include "duckdb/parser/parser_extension.hpp"
+#include "duckdb/common/string_util.hpp"
 using namespace duckdb;
 
+//===--------------------------------------------------------------------===//
+// Scalar function
+//===--------------------------------------------------------------------===//
 inline string_t hello_fun(string_t what) {
 	return "Hello, " + what.GetString();
 }
 
+//===--------------------------------------------------------------------===//
+// Quack Table Function
+//===--------------------------------------------------------------------===//
+class QuackFunction : public TableFunction {
+public:
+	QuackFunction() {
+		name = "quack";
+		arguments.push_back(LogicalType::BIGINT);
+		bind = QuackBind;
+		init_global = QuackInit;
+		function = QuackFunc;
+	}
+
+	struct QuackBindData : public TableFunctionData {
+		QuackBindData(idx_t number_of_quacks) : number_of_quacks(number_of_quacks) {
+		}
+
+		idx_t number_of_quacks;
+	};
+
+	struct QuackGlobalData : public GlobalTableFunctionState {
+		QuackGlobalData() : offset(0) {
+		}
+
+		idx_t offset;
+	};
+
+	static unique_ptr<FunctionData> QuackBind(ClientContext &context, TableFunctionBindInput &input,
+	                                          vector<LogicalType> &return_types, vector<string> &names) {
+		names.emplace_back("quack");
+		return_types.emplace_back(LogicalType::VARCHAR);
+		return make_unique<QuackBindData>(BigIntValue::Get(input.inputs[0]));
+	}
+
+	static unique_ptr<GlobalTableFunctionState> QuackInit(ClientContext &context, TableFunctionInitInput &input) {
+		return make_unique<QuackGlobalData>();
+	}
+
+	static void QuackFunc(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+		auto &bind_data = (QuackBindData &)*data_p.bind_data;
+		auto &data = (QuackGlobalData &)*data_p.global_state;
+		if (data.offset >= bind_data.number_of_quacks) {
+			// finished returning values
+			return;
+		}
+		// start returning values
+		// either fill up the chunk or return all the remaining columns
+		idx_t count = 0;
+		while (data.offset < bind_data.number_of_quacks && count < STANDARD_VECTOR_SIZE) {
+			output.SetValue(0, count, Value("QUACK"));
+			data.offset++;
+			count++;
+		}
+		output.SetCardinality(count);
+	}
+};
+
+//===--------------------------------------------------------------------===//
+// Parser extension
+//===--------------------------------------------------------------------===//
+struct QuackExtensionData : public ParserExtensionParseData {
+	QuackExtensionData(idx_t number_of_quacks) : number_of_quacks(number_of_quacks) {
+	}
+
+	idx_t number_of_quacks;
+
+	unique_ptr<ParserExtensionParseData> Copy() const override {
+		return make_unique<QuackExtensionData>(number_of_quacks);
+	}
+};
+
+class QuackExtension : public ParserExtension {
+public:
+	QuackExtension() {
+		parse_function = QuackParseFunction;
+		plan_function = QuackPlanFunction;
+	}
+
+	static ParserExtensionParseResult QuackParseFunction(ParserExtensionInfo *info, const string &query) {
+		auto lcase = StringUtil::Lower(StringUtil::Replace(query, ";", ""));
+		if (!StringUtil::Contains(lcase, "quack")) {
+			// quack not found!?
+			if (StringUtil::Contains(lcase, "quac")) {
+				// use our error
+				return ParserExtensionParseResult("Did you mean... QUACK!?");
+			}
+			// use original error
+			return ParserExtensionParseResult();
+		}
+		auto splits = StringUtil::Split(lcase, "quack");
+		for (auto &split : splits) {
+			StringUtil::Trim(split);
+			if (!split.empty()) {
+				// we only accept quacks here
+				return ParserExtensionParseResult("This is not a quack: " + split);
+			}
+		}
+		// QUACK
+		return ParserExtensionParseResult(make_unique<QuackExtensionData>(splits.size() + 1));
+	}
+
+	static ParserExtensionPlanResult QuackPlanFunction(ParserExtensionInfo *info, ClientContext &context,
+	                                                   unique_ptr<ParserExtensionParseData> parse_data) {
+		auto &quack_data = (QuackExtensionData &)*parse_data;
+
+		ParserExtensionPlanResult result;
+		result.function = QuackFunction();
+		result.parameters.push_back(Value::BIGINT(quack_data.number_of_quacks));
+		result.read_only = true;
+		result.requires_valid_transaction = false;
+		result.return_type = StatementReturnType::QUERY_RESULT;
+		return result;
+	}
+};
+
+//===--------------------------------------------------------------------===//
+// Extension load + setup
+//===--------------------------------------------------------------------===//
 extern "C" {
 DUCKDB_EXTENSION_API void loadable_extension_demo_init(duckdb::DatabaseInstance &db) {
+	// create a scalar function
 	Connection con(db);
 	con.BeginTransaction();
 	con.CreateScalarFunction<string_t, string_t>("hello", {LogicalType(LogicalTypeId::VARCHAR)},
 	                                             LogicalType(LogicalTypeId::VARCHAR), &hello_fun);
 	con.Commit();
+
+	// add a parser extension
+	auto &config = DBConfig::GetConfig(db);
+	config.parser_extensions.push_back(QuackExtension());
 }
 
 DUCKDB_EXTENSION_API const char *loadable_extension_demo_version() {


### PR DESCRIPTION
This PR adds support for ParserExtensions, which allow the installation of "fallback parsers" as part of extensions. When the regular parser throws a parsing error, any available `ParserExtensions` are executed instead. This allows for extensions to the grammar to be made. ParserExtensions are installed at the database level, meaning all connections will have access to the extensions. 

The ParserExtension interface requires the implementation of two methods, `parse` and `plan`:

#### Parse
The Parse function takes as input the query string, together with the `ParserExtensionInfo` (which is a generic object that can be attached to the `ParserExtension` to hold any state required by the parser extension). 

```cpp
ParserExtensionParseResult ParseFunction(ParserExtensionInfo *info, const string &query);
```

It returns a `ParserExtensionParseResult`, which contains a generic parse_data object if successful (`ParserExtensionParseData`). If unsuccessful, it contains an error message, or an instruction to the system to display the original error.

```cpp
enum class ParserExtensionResultType : uint8_t {
	PARSE_SUCCESSFUL,
	DISPLAY_ORIGINAL_ERROR,
	DISPLAY_EXTENSION_ERROR
};

struct ParserExtensionParseResult {
	//! Whether or not parsing was successful
	ParserExtensionResultType type;
	//! The parse data (if successful)
	unique_ptr<ParserExtensionParseData> parse_data;
	//! The error message (if unsuccessful)
	string error;
};
```

#### Plan
After the parsing stage, the planning occurs. In the planning stage, the function has access to the client context, which transitively gives access to the system catalogs and database system in general. In addition, the function receives the `ParserExtensionInfo` again, and the `ParserExtensionParseData` that came out of the `ParseFunction`.

```cpp
ParserExtensionPlanResult PlanFunction(ParserExtensionInfo *info, ClientContext &context, unique_ptr<ParserExtensionParseData> parse_data);
```

The plan function returns the following struct, with information on the return value of the statement, whether or not the statement is read_only, and the table function to execute together with parameters to the table function.

```cpp
struct ParserExtensionPlanResult {
	//! The table function to execute
	TableFunction function;
	//! Parameters to the function
	vector<Value> parameters;
	//! Whether or not the statement is read_only (i.e. can be executed in a read_only database)
	bool read_only = false;
	//! Whether or not the statement requires a valid transaction to be executed
	bool requires_valid_transaction = true;
	//! What type of result set the statement returns
	StatementReturnType return_type = StatementReturnType::NOTHING;
};
```

The TableFunction interface itself is used to handle subsequent execution of the plan, and contains a [flexible interface](https://github.com/duckdb/duckdb/blob/master/src/include/duckdb/function/table_function.hpp) that can be used in various manners. For example, the function could return nothing, and only execute a DDL statement (or similar). It can also operate in parallel using the global and local states. 

An example of the parser extension is provided [in the loadable extension demo](https://github.com/Mytherin/duckdb/blob/4de11f39b02da83700a68cfaee737f4da1c0a906/test/extension/loadable_extension_demo.cpp#L17).