### PR TITLE
Fix for #3997

### DIFF
--- a/extension/sqlsmith/include/statement_simplifier.hpp
+++ b/extension/sqlsmith/include/statement_simplifier.hpp
@@ -67,6 +67,7 @@ private:
 	void Simplify(OrderModifier &modifier);
 
 	void SimplifyExpression(unique_ptr<ParsedExpression> &expr);
+	void Simplify(unordered_map<string, unique_ptr<CommonTableExpressionInfo>> &cte_map);
 };
 
 } // namespace duckdb

--- a/extension/sqlsmith/include/statement_simplifier.hpp
+++ b/extension/sqlsmith/include/statement_simplifier.hpp
@@ -67,7 +67,7 @@ private:
 	void Simplify(OrderModifier &modifier);
 
 	void SimplifyExpression(unique_ptr<ParsedExpression> &expr);
-	void Simplify(unordered_map<string, unique_ptr<CommonTableExpressionInfo>> &cte_map);
+	void Simplify(CommonTableExpressionMap &cte_map);
 };
 
 } // namespace duckdb

--- a/extension/sqlsmith/statement_simplifier.cpp
+++ b/extension/sqlsmith/statement_simplifier.cpp
@@ -123,21 +123,25 @@ void StatementSimplifier::Simplify(SetOperationNode &node) {
 	Simplify(*node.right);
 }
 
-void StatementSimplifier::Simplify(QueryNode &node) {
+void StatementSimplifier::Simplify(unordered_map<string, unique_ptr<CommonTableExpressionInfo>> &cte_map) {
 	// remove individual CTEs
 	vector<string> cte_keys;
-	for (auto &kv : node.cte_map) {
+	for (auto &kv : cte_map) {
 		cte_keys.push_back(kv.first);
 	}
 	for (idx_t i = 0; i < cte_keys.size(); i++) {
-		auto n = move(node.cte_map[cte_keys[i]]);
-		node.cte_map.erase(cte_keys[i]);
+		auto n = move(cte_map[cte_keys[i]]);
+		cte_map.erase(cte_keys[i]);
 		Simplification();
-		node.cte_map[cte_keys[i]] = move(n);
+		cte_map[cte_keys[i]] = move(n);
 
 		// simplify individual ctes
-		Simplify(*node.cte_map[cte_keys[i]]->query->node);
+		Simplify(*cte_map[cte_keys[i]]->query->node);
 	}
+}
+
+void StatementSimplifier::Simplify(QueryNode &node) {
+	Simplify(node.cte_map);
 	switch (node.type) {
 	case QueryNodeType::SELECT_NODE:
 		Simplify((SelectNode &)node);
@@ -234,17 +238,21 @@ void StatementSimplifier::Simplify(SelectStatement &stmt) {
 }
 
 void StatementSimplifier::Simplify(InsertStatement &stmt) {
+	Simplify(stmt.cte_map);
 	Simplify(*stmt.select_statement);
 	SimplifyList(stmt.returning_list);
 }
 
 void StatementSimplifier::Simplify(DeleteStatement &stmt) {
+	Simplify(stmt.cte_map);
 	SimplifyOptional(stmt.condition);
 	SimplifyExpression(stmt.condition);
 	SimplifyList(stmt.using_clauses);
+	SimplifyList(stmt.returning_list);
 }
 
 void StatementSimplifier::Simplify(UpdateStatement &stmt) {
+	Simplify(stmt.cte_map);
 	if (stmt.from_table) {
 		Simplify(*stmt.from_table);
 	}

--- a/extension/sqlsmith/statement_simplifier.cpp
+++ b/extension/sqlsmith/statement_simplifier.cpp
@@ -123,20 +123,20 @@ void StatementSimplifier::Simplify(SetOperationNode &node) {
 	Simplify(*node.right);
 }
 
-void StatementSimplifier::Simplify(unordered_map<string, unique_ptr<CommonTableExpressionInfo>> &cte_map) {
+void StatementSimplifier::Simplify(CommonTableExpressionMap &cte) {
 	// remove individual CTEs
 	vector<string> cte_keys;
-	for (auto &kv : cte_map) {
+	for (auto &kv : cte.map) {
 		cte_keys.push_back(kv.first);
 	}
 	for (idx_t i = 0; i < cte_keys.size(); i++) {
-		auto n = move(cte_map[cte_keys[i]]);
-		cte_map.erase(cte_keys[i]);
+		auto n = move(cte.map[cte_keys[i]]);
+		cte.map.erase(cte_keys[i]);
 		Simplification();
-		cte_map[cte_keys[i]] = move(n);
+		cte.map[cte_keys[i]] = move(n);
 
 		// simplify individual ctes
-		Simplify(*cte_map[cte_keys[i]]->query->node);
+		Simplify(*cte.map[cte_keys[i]]->query->node);
 	}
 }
 

--- a/src/include/duckdb/common/field_writer.hpp
+++ b/src/include/duckdb/common/field_writer.hpp
@@ -199,7 +199,7 @@ public:
 	}
 
 	template <class T, class RETURN_TYPE = unique_ptr<T>, typename... ARGS>
-	RETURN_TYPE ReadSerializable(RETURN_TYPE default_value, ARGS &&...args) {
+	RETURN_TYPE ReadSerializable(RETURN_TYPE default_value, ARGS &&... args) {
 		if (field_count >= max_field_count) {
 			// field is not there, read the default value
 			return default_value;
@@ -221,7 +221,7 @@ public:
 	}
 
 	template <class T, class RETURN_TYPE = unique_ptr<T>, typename... ARGS>
-	RETURN_TYPE ReadRequiredSerializable(ARGS &&...args) {
+	RETURN_TYPE ReadRequiredSerializable(ARGS &&... args) {
 		if (field_count >= max_field_count) {
 			// field is not there, read the default value
 			throw SerializationException("Attempting to read mandatory field, but field is missing");

--- a/src/include/duckdb/parser/query_node.hpp
+++ b/src/include/duckdb/parser/query_node.hpp
@@ -25,6 +25,17 @@ enum QueryNodeType : uint8_t {
 
 struct CommonTableExpressionInfo;
 
+class CommonTableExpressionMap {
+public:
+	CommonTableExpressionMap();
+	CommonTableExpressionMap(const CommonTableExpressionMap &other);
+
+	unordered_map<string, unique_ptr<CommonTableExpressionInfo>> map;
+
+public:
+	string CTEToString() const;
+};
+
 class QueryNode {
 public:
 	explicit QueryNode(QueryNodeType type) : type(type) {
@@ -37,7 +48,7 @@ public:
 	//! The set of result modifiers associated with this query node
 	vector<unique_ptr<ResultModifier>> modifiers;
 	//! CTEs (used by SelectNode and SetOperationNode)
-	unordered_map<string, unique_ptr<CommonTableExpressionInfo>> cte_map;
+	CommonTableExpressionMap cte_map;
 
 	virtual const vector<unique_ptr<ParsedExpression>> &GetSelectList() const = 0;
 
@@ -56,7 +67,6 @@ public:
 	//! Deserializes a blob back into a QueryNode
 	DUCKDB_API static unique_ptr<QueryNode> Deserialize(Deserializer &source);
 
-	static string CTEToString(const unordered_map<string, unique_ptr<CommonTableExpressionInfo>> &cte_map);
 	string ResultModifiersToString() const;
 
 protected:

--- a/src/include/duckdb/parser/query_node.hpp
+++ b/src/include/duckdb/parser/query_node.hpp
@@ -33,7 +33,7 @@ public:
 	unordered_map<string, unique_ptr<CommonTableExpressionInfo>> map;
 
 public:
-	string CTEToString() const;
+	string ToString() const;
 };
 
 class QueryNode {

--- a/src/include/duckdb/parser/query_node.hpp
+++ b/src/include/duckdb/parser/query_node.hpp
@@ -54,7 +54,7 @@ public:
 	//! Deserializes a blob back into a QueryNode
 	DUCKDB_API static unique_ptr<QueryNode> Deserialize(Deserializer &source);
 
-	string CTEToString() const;
+	static string CTEToString(const unordered_map<string, unique_ptr<CommonTableExpressionInfo>> &cte_map);
 	string ResultModifiersToString() const;
 
 protected:

--- a/src/include/duckdb/parser/query_node.hpp
+++ b/src/include/duckdb/parser/query_node.hpp
@@ -23,6 +23,8 @@ enum QueryNodeType : uint8_t {
 	RECURSIVE_CTE_NODE = 4
 };
 
+struct CommonTableExpressionInfo;
+
 class QueryNode {
 public:
 	explicit QueryNode(QueryNodeType type) : type(type) {

--- a/src/include/duckdb/parser/query_node.hpp
+++ b/src/include/duckdb/parser/query_node.hpp
@@ -28,12 +28,12 @@ struct CommonTableExpressionInfo;
 class CommonTableExpressionMap {
 public:
 	CommonTableExpressionMap();
-	CommonTableExpressionMap(const CommonTableExpressionMap &other);
 
 	unordered_map<string, unique_ptr<CommonTableExpressionInfo>> map;
 
 public:
 	string ToString() const;
+	CommonTableExpressionMap Copy() const;
 };
 
 class QueryNode {

--- a/src/include/duckdb/parser/statement/delete_statement.hpp
+++ b/src/include/duckdb/parser/statement/delete_statement.hpp
@@ -22,6 +22,8 @@ public:
 	unique_ptr<TableRef> table;
 	vector<unique_ptr<TableRef>> using_clauses;
 	vector<unique_ptr<ParsedExpression>> returning_list;
+	//! CTEs
+	unordered_map<string, unique_ptr<CommonTableExpressionInfo>> cte_map;
 
 protected:
 	DeleteStatement(const DeleteStatement &other);

--- a/src/include/duckdb/parser/statement/delete_statement.hpp
+++ b/src/include/duckdb/parser/statement/delete_statement.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "duckdb/common/common.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/parser/sql_statement.hpp"
 #include "duckdb/parser/tableref.hpp"

--- a/src/include/duckdb/parser/statement/delete_statement.hpp
+++ b/src/include/duckdb/parser/statement/delete_statement.hpp
@@ -11,7 +11,7 @@
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/parser/sql_statement.hpp"
 #include "duckdb/parser/tableref.hpp"
-#include "duckdb/parser/common_table_expression_info.hpp"
+#include "duckdb/parser/query_node.hpp"
 
 namespace duckdb {
 
@@ -24,7 +24,7 @@ public:
 	vector<unique_ptr<TableRef>> using_clauses;
 	vector<unique_ptr<ParsedExpression>> returning_list;
 	//! CTEs
-	unordered_map<string, unique_ptr<CommonTableExpressionInfo>> cte_map;
+	CommonTableExpressionMap cte_map;
 
 protected:
 	DeleteStatement(const DeleteStatement &other);

--- a/src/include/duckdb/parser/statement/delete_statement.hpp
+++ b/src/include/duckdb/parser/statement/delete_statement.hpp
@@ -8,9 +8,11 @@
 
 #pragma once
 
+#include "duckdb/common/common.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/parser/sql_statement.hpp"
 #include "duckdb/parser/tableref.hpp"
+#include "duckdb/parser/common_table_expression_info.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/parser/statement/insert_statement.hpp
+++ b/src/include/duckdb/parser/statement/insert_statement.hpp
@@ -31,6 +31,9 @@ public:
 	//! keep track of optional returningList if statement contains a RETURNING keyword
 	vector<unique_ptr<ParsedExpression>> returning_list;
 
+	//! CTEs
+	unordered_map<string, unique_ptr<CommonTableExpressionInfo>> cte_map;
+
 protected:
 	InsertStatement(const InsertStatement &other);
 

--- a/src/include/duckdb/parser/statement/insert_statement.hpp
+++ b/src/include/duckdb/parser/statement/insert_statement.hpp
@@ -10,7 +10,7 @@
 
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
-#include "duckdb/parser/common_table_expression_info.hpp"
+#include "duckdb/parser/query_node.hpp"
 
 namespace duckdb {
 class ExpressionListRef;
@@ -33,7 +33,7 @@ public:
 	vector<unique_ptr<ParsedExpression>> returning_list;
 
 	//! CTEs
-	unordered_map<string, unique_ptr<CommonTableExpressionInfo>> cte_map;
+	CommonTableExpressionMap cte_map;
 
 protected:
 	InsertStatement(const InsertStatement &other);

--- a/src/include/duckdb/parser/statement/insert_statement.hpp
+++ b/src/include/duckdb/parser/statement/insert_statement.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "duckdb/common/common.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/common_table_expression_info.hpp"

--- a/src/include/duckdb/parser/statement/insert_statement.hpp
+++ b/src/include/duckdb/parser/statement/insert_statement.hpp
@@ -8,8 +8,10 @@
 
 #pragma once
 
+#include "duckdb/common/common.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
+#include "duckdb/parser/common_table_expression_info.hpp"
 
 namespace duckdb {
 class ExpressionListRef;

--- a/src/include/duckdb/parser/statement/update_statement.hpp
+++ b/src/include/duckdb/parser/statement/update_statement.hpp
@@ -8,10 +8,12 @@
 
 #pragma once
 
+#include "duckdb/common/common.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/parser/sql_statement.hpp"
 #include "duckdb/parser/tableref.hpp"
 #include "duckdb/common/vector.hpp"
+#include "duckdb/parser/common_table_expression_info.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/parser/statement/update_statement.hpp
+++ b/src/include/duckdb/parser/statement/update_statement.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "duckdb/common/common.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/parser/sql_statement.hpp"
 #include "duckdb/parser/tableref.hpp"

--- a/src/include/duckdb/parser/statement/update_statement.hpp
+++ b/src/include/duckdb/parser/statement/update_statement.hpp
@@ -26,6 +26,8 @@ public:
 	vector<unique_ptr<ParsedExpression>> expressions;
 	//! keep track of optional returningList if statement contains a RETURNING keyword
 	vector<unique_ptr<ParsedExpression>> returning_list;
+	//! CTEs
+	unordered_map<string, unique_ptr<CommonTableExpressionInfo>> cte_map;
 
 protected:
 	UpdateStatement(const UpdateStatement &other);

--- a/src/include/duckdb/parser/statement/update_statement.hpp
+++ b/src/include/duckdb/parser/statement/update_statement.hpp
@@ -12,7 +12,7 @@
 #include "duckdb/parser/sql_statement.hpp"
 #include "duckdb/parser/tableref.hpp"
 #include "duckdb/common/vector.hpp"
-#include "duckdb/parser/common_table_expression_info.hpp"
+#include "duckdb/parser/query_node.hpp"
 
 namespace duckdb {
 
@@ -28,7 +28,7 @@ public:
 	//! keep track of optional returningList if statement contains a RETURNING keyword
 	vector<unique_ptr<ParsedExpression>> returning_list;
 	//! CTEs
-	unordered_map<string, unique_ptr<CommonTableExpressionInfo>> cte_map;
+	CommonTableExpressionMap cte_map;
 
 protected:
 	UpdateStatement(const UpdateStatement &other);

--- a/src/include/duckdb/parser/transformer.hpp
+++ b/src/include/duckdb/parser/transformer.hpp
@@ -195,7 +195,8 @@ private:
 	//===--------------------------------------------------------------------===//
 	OnCreateConflict TransformOnConflict(duckdb_libpgquery::PGOnCreateConflict conflict);
 	string TransformAlias(duckdb_libpgquery::PGAlias *root, vector<string> &column_name_alias);
-	void TransformCTE(duckdb_libpgquery::PGWithClause *de_with_clause, QueryNode &select);
+	void TransformCTE(duckdb_libpgquery::PGWithClause *de_with_clause,
+	                  unordered_map<string, unique_ptr<CommonTableExpressionInfo>> &cte_map);
 	unique_ptr<SelectStatement> TransformRecursiveCTE(duckdb_libpgquery::PGCommonTableExpr *node,
 	                                                  CommonTableExpressionInfo &info);
 

--- a/src/include/duckdb/parser/transformer.hpp
+++ b/src/include/duckdb/parser/transformer.hpp
@@ -16,6 +16,7 @@
 #include "duckdb/parser/tokens.hpp"
 #include "duckdb/parser/parsed_data/create_info.hpp"
 #include "duckdb/parser/group_by_node.hpp"
+#include "duckdb/parser/query_node.hpp"
 
 #include "pg_definitions.hpp"
 #include "nodes/parsenodes.hpp"
@@ -195,8 +196,7 @@ private:
 	//===--------------------------------------------------------------------===//
 	OnCreateConflict TransformOnConflict(duckdb_libpgquery::PGOnCreateConflict conflict);
 	string TransformAlias(duckdb_libpgquery::PGAlias *root, vector<string> &column_name_alias);
-	void TransformCTE(duckdb_libpgquery::PGWithClause *de_with_clause,
-	                  unordered_map<string, unique_ptr<CommonTableExpressionInfo>> &cte_map);
+	void TransformCTE(duckdb_libpgquery::PGWithClause *de_with_clause, CommonTableExpressionMap &cte_map);
 	unique_ptr<SelectStatement> TransformRecursiveCTE(duckdb_libpgquery::PGCommonTableExpr *node,
 	                                                  CommonTableExpressionInfo &info);
 

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -290,6 +290,7 @@ private:
 	                            const string &join_side, UsingColumnSet *new_set);
 
 	void AddCTEMap(CommonTableExpressionMap &cte_map);
+
 public:
 	// This should really be a private constructor, but make_shared does not allow it...
 	// If you are thinking about calling this, you should probably call Binder::CreateBinder

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -17,6 +17,7 @@
 #include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/planner/bound_statement.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/parser/query_node.hpp"
 #include "duckdb/parser/result_modifier.hpp"
 #include "duckdb/common/enums/statement_type.hpp"
 
@@ -288,6 +289,7 @@ private:
 	string RetrieveUsingBinding(Binder &current_binder, UsingColumnSet *current_set, const string &column_name,
 	                            const string &join_side, UsingColumnSet *new_set);
 
+	void AddCTEMap(CommonTableExpressionMap &cte_map);
 public:
 	// This should really be a private constructor, but make_shared does not allow it...
 	// If you are thinking about calling this, you should probably call Binder::CreateBinder

--- a/src/parser/parsed_expression_iterator.cpp
+++ b/src/parser/parsed_expression_iterator.cpp
@@ -280,7 +280,7 @@ void ParsedExpressionIterator::EnumerateQueryNodeChildren(
 		EnumerateQueryNodeModifiers(node, callback);
 	}
 
-	for (auto &kv : node.cte_map) {
+	for (auto &kv : node.cte_map.map) {
 		EnumerateQueryNodeChildren(*kv.second->query->node, callback);
 	}
 }

--- a/src/parser/query_node.cpp
+++ b/src/parser/query_node.cpp
@@ -11,15 +11,17 @@ namespace duckdb {
 CommonTableExpressionMap::CommonTableExpressionMap() {
 }
 
-CommonTableExpressionMap::CommonTableExpressionMap(const CommonTableExpressionMap &other) {
-	for (auto &kv : other.map) {
+CommonTableExpressionMap CommonTableExpressionMap::Copy() const {
+	CommonTableExpressionMap res;
+	for (auto &kv : this->map) {
 		auto kv_info = make_unique<CommonTableExpressionInfo>();
 		for (auto &al : kv.second->aliases) {
 			kv_info->aliases.push_back(al);
 		}
 		kv_info->query = unique_ptr_cast<SQLStatement, SelectStatement>(kv.second->query->Copy());
-		map[kv.first] = move(kv_info);
+		res.map[kv.first] = move(kv_info);
 	}
+	return res;
 }
 
 string CommonTableExpressionMap::ToString() const {

--- a/src/parser/query_node.cpp
+++ b/src/parser/query_node.cpp
@@ -8,7 +8,7 @@
 
 namespace duckdb {
 
-string QueryNode::CTEToString() const {
+string QueryNode::CTEToString(const unordered_map<string, unique_ptr<CommonTableExpressionInfo>> &cte_map) {
 	if (cte_map.empty()) {
 		return string();
 	}

--- a/src/parser/query_node.cpp
+++ b/src/parser/query_node.cpp
@@ -22,7 +22,7 @@ CommonTableExpressionMap::CommonTableExpressionMap(const CommonTableExpressionMa
 	}
 }
 
-string CommonTableExpressionMap::CTEToString() const {
+string CommonTableExpressionMap::ToString() const {
 	if (map.empty()) {
 		return string();
 	}

--- a/src/parser/query_node/select_node.cpp
+++ b/src/parser/query_node/select_node.cpp
@@ -11,7 +11,7 @@ SelectNode::SelectNode()
 
 string SelectNode::ToString() const {
 	string result;
-	result = QueryNode::CTEToString(cte_map);
+	result = cte_map.CTEToString();
 	result += "SELECT ";
 
 	// search for a distinct modifier

--- a/src/parser/query_node/select_node.cpp
+++ b/src/parser/query_node/select_node.cpp
@@ -11,7 +11,7 @@ SelectNode::SelectNode()
 
 string SelectNode::ToString() const {
 	string result;
-	result = cte_map.CTEToString();
+	result = cte_map.ToString();
 	result += "SELECT ";
 
 	// search for a distinct modifier

--- a/src/parser/query_node/select_node.cpp
+++ b/src/parser/query_node/select_node.cpp
@@ -11,7 +11,7 @@ SelectNode::SelectNode()
 
 string SelectNode::ToString() const {
 	string result;
-	result = CTEToString();
+	result = QueryNode::CTEToString(cte_map);
 	result += "SELECT ";
 
 	// search for a distinct modifier

--- a/src/parser/query_node/set_operation_node.cpp
+++ b/src/parser/query_node/set_operation_node.cpp
@@ -5,7 +5,7 @@ namespace duckdb {
 
 string SetOperationNode::ToString() const {
 	string result;
-	result = CTEToString();
+	result = QueryNode::CTEToString(cte_map);
 	result += "(" + left->ToString() + ") ";
 	bool is_distinct = false;
 	for (idx_t modifier_idx = 0; modifier_idx < modifiers.size(); modifier_idx++) {

--- a/src/parser/query_node/set_operation_node.cpp
+++ b/src/parser/query_node/set_operation_node.cpp
@@ -5,7 +5,7 @@ namespace duckdb {
 
 string SetOperationNode::ToString() const {
 	string result;
-	result = cte_map.CTEToString();
+	result = cte_map.ToString();
 	result += "(" + left->ToString() + ") ";
 	bool is_distinct = false;
 	for (idx_t modifier_idx = 0; modifier_idx < modifiers.size(); modifier_idx++) {

--- a/src/parser/query_node/set_operation_node.cpp
+++ b/src/parser/query_node/set_operation_node.cpp
@@ -5,7 +5,7 @@ namespace duckdb {
 
 string SetOperationNode::ToString() const {
 	string result;
-	result = QueryNode::CTEToString(cte_map);
+	result = cte_map.CTEToString();
 	result += "(" + left->ToString() + ") ";
 	bool is_distinct = false;
 	for (idx_t modifier_idx = 0; modifier_idx < modifiers.size(); modifier_idx++) {

--- a/src/parser/statement/delete_statement.cpp
+++ b/src/parser/statement/delete_statement.cpp
@@ -7,13 +7,14 @@ DeleteStatement::DeleteStatement() : SQLStatement(StatementType::DELETE_STATEMEN
 }
 
 DeleteStatement::DeleteStatement(const DeleteStatement &other)
-    : SQLStatement(other), table(other.table->Copy()), cte_map(other.cte_map) {
+    : SQLStatement(other), table(other.table->Copy()) {
 	if (other.condition) {
 		condition = other.condition->Copy();
 	}
 	for (const auto &using_clause : other.using_clauses) {
 		using_clauses.push_back(using_clause->Copy());
 	}
+	cte_map = other.cte_map.Copy();
 }
 
 string DeleteStatement::ToString() const {

--- a/src/parser/statement/delete_statement.cpp
+++ b/src/parser/statement/delete_statement.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/parser/statement/delete_statement.hpp"
+#include "duckdb/parser/query_node/select_node.hpp"
 
 namespace duckdb {
 
@@ -12,10 +13,19 @@ DeleteStatement::DeleteStatement(const DeleteStatement &other) : SQLStatement(ot
 	for (const auto &using_clause : other.using_clauses) {
 		using_clauses.push_back(using_clause->Copy());
 	}
+	for (auto &kv : other.cte_map) {
+		auto kv_info = make_unique<CommonTableExpressionInfo>();
+		for (auto &al : kv.second->aliases) {
+			kv_info->aliases.push_back(al);
+		}
+		kv_info->query = unique_ptr_cast<SQLStatement, SelectStatement>(kv.second->query->Copy());
+		cte_map[kv.first] = move(kv_info);
+	}
 }
 
 string DeleteStatement::ToString() const {
 	string result;
+	result = QueryNode::CTEToString(cte_map);
 	result += "DELETE FROM ";
 	result += table->ToString();
 	if (!using_clauses.empty()) {

--- a/src/parser/statement/delete_statement.cpp
+++ b/src/parser/statement/delete_statement.cpp
@@ -6,26 +6,19 @@ namespace duckdb {
 DeleteStatement::DeleteStatement() : SQLStatement(StatementType::DELETE_STATEMENT) {
 }
 
-DeleteStatement::DeleteStatement(const DeleteStatement &other) : SQLStatement(other), table(other.table->Copy()) {
+DeleteStatement::DeleteStatement(const DeleteStatement &other)
+    : SQLStatement(other), table(other.table->Copy()), cte_map(other.cte_map) {
 	if (other.condition) {
 		condition = other.condition->Copy();
 	}
 	for (const auto &using_clause : other.using_clauses) {
 		using_clauses.push_back(using_clause->Copy());
 	}
-	for (auto &kv : other.cte_map) {
-		auto kv_info = make_unique<CommonTableExpressionInfo>();
-		for (auto &al : kv.second->aliases) {
-			kv_info->aliases.push_back(al);
-		}
-		kv_info->query = unique_ptr_cast<SQLStatement, SelectStatement>(kv.second->query->Copy());
-		cte_map[kv.first] = move(kv_info);
-	}
 }
 
 string DeleteStatement::ToString() const {
 	string result;
-	result = QueryNode::CTEToString(cte_map);
+	result = cte_map.CTEToString();
 	result += "DELETE FROM ";
 	result += table->ToString();
 	if (!using_clauses.empty()) {

--- a/src/parser/statement/delete_statement.cpp
+++ b/src/parser/statement/delete_statement.cpp
@@ -18,7 +18,7 @@ DeleteStatement::DeleteStatement(const DeleteStatement &other)
 
 string DeleteStatement::ToString() const {
 	string result;
-	result = cte_map.CTEToString();
+	result = cte_map.ToString();
 	result += "DELETE FROM ";
 	result += table->ToString();
 	if (!using_clauses.empty()) {

--- a/src/parser/statement/delete_statement.cpp
+++ b/src/parser/statement/delete_statement.cpp
@@ -6,8 +6,7 @@ namespace duckdb {
 DeleteStatement::DeleteStatement() : SQLStatement(StatementType::DELETE_STATEMENT) {
 }
 
-DeleteStatement::DeleteStatement(const DeleteStatement &other)
-    : SQLStatement(other), table(other.table->Copy()) {
+DeleteStatement::DeleteStatement(const DeleteStatement &other) : SQLStatement(other), table(other.table->Copy()) {
 	if (other.condition) {
 		condition = other.condition->Copy();
 	}

--- a/src/parser/statement/insert_statement.cpp
+++ b/src/parser/statement/insert_statement.cpp
@@ -15,7 +15,7 @@ InsertStatement::InsertStatement(const InsertStatement &other)
 
 string InsertStatement::ToString() const {
 	string result;
-	result = cte_map.CTEToString();
+	result = cte_map.ToString();
 	result += "INSERT INTO ";
 	if (!schema.empty()) {
 		result += KeywordHelper::WriteOptionallyQuoted(schema) + ".";

--- a/src/parser/statement/insert_statement.cpp
+++ b/src/parser/statement/insert_statement.cpp
@@ -10,7 +10,8 @@ InsertStatement::InsertStatement() : SQLStatement(StatementType::INSERT_STATEMEN
 InsertStatement::InsertStatement(const InsertStatement &other)
     : SQLStatement(other),
       select_statement(unique_ptr_cast<SQLStatement, SelectStatement>(other.select_statement->Copy())),
-      columns(other.columns), table(other.table), schema(other.schema), cte_map(other.cte_map) {
+      columns(other.columns), table(other.table), schema(other.schema) {
+	cte_map = other.cte_map.Copy();
 }
 
 string InsertStatement::ToString() const {

--- a/src/parser/statement/update_statement.cpp
+++ b/src/parser/statement/update_statement.cpp
@@ -7,7 +7,7 @@ UpdateStatement::UpdateStatement() : SQLStatement(StatementType::UPDATE_STATEMEN
 }
 
 UpdateStatement::UpdateStatement(const UpdateStatement &other)
-    : SQLStatement(other), table(other.table->Copy()), columns(other.columns) {
+    : SQLStatement(other), table(other.table->Copy()), columns(other.columns), cte_map(other.cte_map) {
 	if (other.condition) {
 		condition = other.condition->Copy();
 	}
@@ -17,19 +17,11 @@ UpdateStatement::UpdateStatement(const UpdateStatement &other)
 	for (auto &expr : other.expressions) {
 		expressions.emplace_back(expr->Copy());
 	}
-	for (auto &kv : other.cte_map) {
-		auto kv_info = make_unique<CommonTableExpressionInfo>();
-		for (auto &al : kv.second->aliases) {
-			kv_info->aliases.push_back(al);
-		}
-		kv_info->query = unique_ptr_cast<SQLStatement, SelectStatement>(kv.second->query->Copy());
-		cte_map[kv.first] = move(kv_info);
-	}
 }
 
 string UpdateStatement::ToString() const {
 	string result;
-	result = QueryNode::CTEToString(cte_map);
+	result = cte_map.CTEToString();
 	result += "UPDATE ";
 	result += table->ToString();
 	result += " SET ";

--- a/src/parser/statement/update_statement.cpp
+++ b/src/parser/statement/update_statement.cpp
@@ -21,7 +21,7 @@ UpdateStatement::UpdateStatement(const UpdateStatement &other)
 
 string UpdateStatement::ToString() const {
 	string result;
-	result = cte_map.CTEToString();
+	result = cte_map.ToString();
 	result += "UPDATE ";
 	result += table->ToString();
 	result += " SET ";

--- a/src/parser/statement/update_statement.cpp
+++ b/src/parser/statement/update_statement.cpp
@@ -7,7 +7,7 @@ UpdateStatement::UpdateStatement() : SQLStatement(StatementType::UPDATE_STATEMEN
 }
 
 UpdateStatement::UpdateStatement(const UpdateStatement &other)
-    : SQLStatement(other), table(other.table->Copy()), columns(other.columns), cte_map(other.cte_map) {
+    : SQLStatement(other), table(other.table->Copy()), columns(other.columns) {
 	if (other.condition) {
 		condition = other.condition->Copy();
 	}
@@ -17,6 +17,7 @@ UpdateStatement::UpdateStatement(const UpdateStatement &other)
 	for (auto &expr : other.expressions) {
 		expressions.emplace_back(expr->Copy());
 	}
+	cte_map = other.cte_map.Copy();
 }
 
 string UpdateStatement::ToString() const {

--- a/src/parser/transform/expression/transform_subquery.cpp
+++ b/src/parser/transform/expression/transform_subquery.cpp
@@ -31,12 +31,14 @@ unique_ptr<ParsedExpression> Transformer::TransformSubquery(duckdb_libpgquery::P
 			    string((reinterpret_cast<duckdb_libpgquery::PGValue *>(root->operName->head->data.ptr_value))->val.str);
 			subquery_expr->comparison_type = OperatorToExpressionType(operator_name);
 		}
-		D_ASSERT(subquery_expr->comparison_type == ExpressionType::COMPARE_EQUAL ||
-		         subquery_expr->comparison_type == ExpressionType::COMPARE_NOTEQUAL ||
-		         subquery_expr->comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
-		         subquery_expr->comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO ||
-		         subquery_expr->comparison_type == ExpressionType::COMPARE_LESSTHAN ||
-		         subquery_expr->comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO);
+		if (subquery_expr->comparison_type != ExpressionType::COMPARE_EQUAL &&
+		    subquery_expr->comparison_type != ExpressionType::COMPARE_NOTEQUAL &&
+		    subquery_expr->comparison_type != ExpressionType::COMPARE_GREATERTHAN &&
+		    subquery_expr->comparison_type != ExpressionType::COMPARE_GREATERTHANOREQUALTO &&
+		    subquery_expr->comparison_type != ExpressionType::COMPARE_LESSTHAN &&
+		    subquery_expr->comparison_type != ExpressionType::COMPARE_LESSTHANOREQUALTO) {
+			throw ParserException("ANY and ALL operators require one of =,<>,>,<,>=,<= comparisons!");
+		}
 		if (root->subLinkType == duckdb_libpgquery::PG_ALL_SUBLINK) {
 			// ALL sublink is equivalent to NOT(ANY) with inverted comparison
 			// e.g. [= ALL()] is equivalent to [NOT(<> ANY())]

--- a/src/parser/transform/helpers/transform_cte.cpp
+++ b/src/parser/transform/helpers/transform_cte.cpp
@@ -6,7 +6,7 @@
 
 namespace duckdb {
 
-void Transformer::TransformCTE(duckdb_libpgquery::PGWithClause *de_with_clause, QueryNode &select) {
+void Transformer::TransformCTE(duckdb_libpgquery::PGWithClause *de_with_clause, unordered_map<string, unique_ptr<CommonTableExpressionInfo>> &cte_map) {
 	// TODO: might need to update in case of future lawsuit
 	D_ASSERT(de_with_clause);
 
@@ -49,12 +49,12 @@ void Transformer::TransformCTE(duckdb_libpgquery::PGWithClause *de_with_clause, 
 		D_ASSERT(info->query);
 		auto cte_name = string(cte->ctename);
 
-		auto it = select.cte_map.find(cte_name);
-		if (it != select.cte_map.end()) {
+		auto it = cte_map.find(cte_name);
+		if (it != cte_map.end()) {
 			// can't have two CTEs with same name
 			throw ParserException("Duplicate CTE name \"%s\"", cte_name);
 		}
-		select.cte_map[cte_name] = move(info);
+		cte_map[cte_name] = move(info);
 	}
 }
 

--- a/src/parser/transform/helpers/transform_cte.cpp
+++ b/src/parser/transform/helpers/transform_cte.cpp
@@ -6,8 +6,7 @@
 
 namespace duckdb {
 
-void Transformer::TransformCTE(duckdb_libpgquery::PGWithClause *de_with_clause,
-                               unordered_map<string, unique_ptr<CommonTableExpressionInfo>> &cte_map) {
+void Transformer::TransformCTE(duckdb_libpgquery::PGWithClause *de_with_clause, CommonTableExpressionMap &cte_map) {
 	// TODO: might need to update in case of future lawsuit
 	D_ASSERT(de_with_clause);
 
@@ -50,12 +49,12 @@ void Transformer::TransformCTE(duckdb_libpgquery::PGWithClause *de_with_clause,
 		D_ASSERT(info->query);
 		auto cte_name = string(cte->ctename);
 
-		auto it = cte_map.find(cte_name);
-		if (it != cte_map.end()) {
+		auto it = cte_map.map.find(cte_name);
+		if (it != cte_map.map.end()) {
 			// can't have two CTEs with same name
 			throw ParserException("Duplicate CTE name \"%s\"", cte_name);
 		}
-		cte_map[cte_name] = move(info);
+		cte_map.map[cte_name] = move(info);
 	}
 }
 

--- a/src/parser/transform/helpers/transform_cte.cpp
+++ b/src/parser/transform/helpers/transform_cte.cpp
@@ -6,7 +6,8 @@
 
 namespace duckdb {
 
-void Transformer::TransformCTE(duckdb_libpgquery::PGWithClause *de_with_clause, unordered_map<string, unique_ptr<CommonTableExpressionInfo>> &cte_map) {
+void Transformer::TransformCTE(duckdb_libpgquery::PGWithClause *de_with_clause,
+                               unordered_map<string, unique_ptr<CommonTableExpressionInfo>> &cte_map) {
 	// TODO: might need to update in case of future lawsuit
 	D_ASSERT(de_with_clause);
 

--- a/src/parser/transform/statement/transform_delete.cpp
+++ b/src/parser/transform/statement/transform_delete.cpp
@@ -8,6 +8,9 @@ unique_ptr<DeleteStatement> Transformer::TransformDelete(duckdb_libpgquery::PGNo
 	auto stmt = reinterpret_cast<duckdb_libpgquery::PGDeleteStmt *>(node);
 	D_ASSERT(stmt);
 	auto result = make_unique<DeleteStatement>();
+	if (stmt->withClause) {
+		TransformCTE(reinterpret_cast<duckdb_libpgquery::PGWithClause *>(stmt->withClause), result->cte_map);
+	}
 
 	result->condition = TransformExpression(stmt->whereClause);
 	result->table = TransformRangeVar(stmt->relation);

--- a/src/parser/transform/statement/transform_insert.cpp
+++ b/src/parser/transform/statement/transform_insert.cpp
@@ -28,8 +28,14 @@ unique_ptr<InsertStatement> Transformer::TransformInsert(duckdb_libpgquery::PGNo
 	if (stmt->onConflictClause && stmt->onConflictClause->action != duckdb_libpgquery::PG_ONCONFLICT_NONE) {
 		throw ParserException("ON CONFLICT IGNORE/UPDATE clauses are not supported");
 	}
+	if (!stmt->selectStmt) {
+		throw ParserException("DEFAULT VALUES clause is not supported!");
+	}
 
 	auto result = make_unique<InsertStatement>();
+	if (stmt->withClause) {
+		TransformCTE(reinterpret_cast<duckdb_libpgquery::PGWithClause *>(stmt->withClause), result->cte_map);
+	}
 
 	// first check if there are any columns specified
 	if (stmt->cols) {

--- a/src/parser/transform/statement/transform_select_node.cpp
+++ b/src/parser/transform/statement/transform_select_node.cpp
@@ -19,7 +19,7 @@ unique_ptr<QueryNode> Transformer::TransformSelectNode(duckdb_libpgquery::PGSele
 		node = make_unique<SelectNode>();
 		auto result = (SelectNode *)node.get();
 		if (stmt->withClause) {
-			TransformCTE(reinterpret_cast<duckdb_libpgquery::PGWithClause *>(stmt->withClause), *node);
+			TransformCTE(reinterpret_cast<duckdb_libpgquery::PGWithClause *>(stmt->withClause), node->cte_map);
 		}
 		if (stmt->windowClause) {
 			for (auto window_ele = stmt->windowClause->head; window_ele != nullptr; window_ele = window_ele->next) {
@@ -81,7 +81,7 @@ unique_ptr<QueryNode> Transformer::TransformSelectNode(duckdb_libpgquery::PGSele
 		node = make_unique<SetOperationNode>();
 		auto result = (SetOperationNode *)node.get();
 		if (stmt->withClause) {
-			TransformCTE(reinterpret_cast<duckdb_libpgquery::PGWithClause *>(stmt->withClause), *node);
+			TransformCTE(reinterpret_cast<duckdb_libpgquery::PGWithClause *>(stmt->withClause), node->cte_map);
 		}
 		result->left = TransformSelectNode(stmt->larg);
 		result->right = TransformSelectNode(stmt->rarg);

--- a/src/parser/transform/statement/transform_update.cpp
+++ b/src/parser/transform/statement/transform_update.cpp
@@ -8,6 +8,9 @@ unique_ptr<UpdateStatement> Transformer::TransformUpdate(duckdb_libpgquery::PGNo
 	D_ASSERT(stmt);
 
 	auto result = make_unique<UpdateStatement>();
+	if (stmt->withClause) {
+		TransformCTE(reinterpret_cast<duckdb_libpgquery::PGWithClause *>(stmt->withClause), result->cte_map);
+	}
 
 	result->table = TransformRangeVar(stmt->relation);
 	if (stmt->fromClause) {

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -85,7 +85,7 @@ BoundStatement Binder::Bind(SQLStatement &statement) {
 
 unique_ptr<BoundQueryNode> Binder::BindNode(QueryNode &node) {
 	// first we visit the set of CTEs and add them to the bind context
-	for (auto &cte_it : node.cte_map) {
+	for (auto &cte_it : node.cte_map.map) {
 		AddCTE(cte_it.first, cte_it.second.get());
 	}
 	// now we bind the node

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -85,11 +85,15 @@ BoundStatement Binder::Bind(SQLStatement &statement) {
 	} // LCOV_EXCL_STOP
 }
 
-unique_ptr<BoundQueryNode> Binder::BindNode(QueryNode &node) {
-	// first we visit the set of CTEs and add them to the bind context
-	for (auto &cte_it : node.cte_map.map) {
+void Binder::AddCTEMap(CommonTableExpressionMap &cte_map) {
+	for (auto &cte_it : cte_map.map) {
 		AddCTE(cte_it.first, cte_it.second.get());
 	}
+}
+
+unique_ptr<BoundQueryNode> Binder::BindNode(QueryNode &node) {
+	// first we visit the set of CTEs and add them to the bind context
+	AddCTEMap(node.cte_map);
 	// now we bind the node
 	unique_ptr<BoundQueryNode> result;
 	switch (node.type) {

--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -32,7 +32,7 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 	}
 
 	// Add CTEs as bindable
-	for (auto &cte_it : stmt.cte_map) {
+	for (auto &cte_it : stmt.cte_map.map) {
 		AddCTE(cte_it.first, cte_it.second.get());
 	}
 

--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -31,6 +31,11 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 		properties.read_only = false;
 	}
 
+	// Add CTEs as bindable
+	for (auto &cte_it : stmt.cte_map) {
+		AddCTE(cte_it.first, cte_it.second.get());
+	}
+
 	// plan any tables from the various using clauses
 	if (!stmt.using_clauses.empty()) {
 		unique_ptr<LogicalOperator> child_operator;

--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -32,9 +32,7 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 	}
 
 	// Add CTEs as bindable
-	for (auto &cte_it : stmt.cte_map.map) {
-		AddCTE(cte_it.first, cte_it.second.get());
-	}
+	AddCTEMap(stmt.cte_map);
 
 	// plan any tables from the various using clauses
 	if (!stmt.using_clauses.empty()) {

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -40,9 +40,7 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 	auto insert = make_unique<LogicalInsert>(table);
 
 	// Add CTEs as bindable
-	for (auto &cte_it : stmt.cte_map.map) {
-		AddCTE(cte_it.first, cte_it.second.get());
-	}
+	AddCTEMap(stmt.cte_map);
 
 	idx_t generated_column_count = 0;
 	vector<idx_t> named_column_map;

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -39,6 +39,11 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 
 	auto insert = make_unique<LogicalInsert>(table);
 
+	// Add CTEs as bindable
+	for (auto &cte_it : stmt.cte_map) {
+		AddCTE(cte_it.first, cte_it.second.get());
+	}
+
 	idx_t generated_column_count = 0;
 	vector<idx_t> named_column_map;
 	if (!stmt.columns.empty()) {

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -40,7 +40,7 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 	auto insert = make_unique<LogicalInsert>(table);
 
 	// Add CTEs as bindable
-	for (auto &cte_it : stmt.cte_map) {
+	for (auto &cte_it : stmt.cte_map.map) {
 		AddCTE(cte_it.first, cte_it.second.get());
 	}
 

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -132,7 +132,7 @@ BoundStatement Binder::Bind(UpdateStatement &stmt) {
 	auto table = table_binding.table;
 
 	// Add CTEs as bindable
-	for (auto &cte_it : stmt.cte_map) {
+	for (auto &cte_it : stmt.cte_map.map) {
 		AddCTE(cte_it.first, cte_it.second.get());
 	}
 

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -132,9 +132,7 @@ BoundStatement Binder::Bind(UpdateStatement &stmt) {
 	auto table = table_binding.table;
 
 	// Add CTEs as bindable
-	for (auto &cte_it : stmt.cte_map.map) {
-		AddCTE(cte_it.first, cte_it.second.get());
-	}
+	AddCTEMap(stmt.cte_map);
 
 	if (stmt.from_table) {
 		BoundCrossProductRef bound_crossproduct;

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -131,6 +131,11 @@ BoundStatement Binder::Bind(UpdateStatement &stmt) {
 	auto &table_binding = (BoundBaseTableRef &)*bound_table;
 	auto table = table_binding.table;
 
+	// Add CTEs as bindable
+	for (auto &cte_it : stmt.cte_map) {
+		AddCTE(cte_it.first, cte_it.second.get());
+	}
+
 	if (stmt.from_table) {
 		BoundCrossProductRef bound_crossproduct;
 		bound_crossproduct.left = move(bound_table);

--- a/test/issues/general/test_3997.test
+++ b/test/issues/general/test_3997.test
@@ -1,0 +1,60 @@
+# name: test/issues/general/test_3997.test
+# description: Issue 3997: CTEs on Insert/update/delete statements
+# group: [general]
+
+statement ok
+PRAGMA enable_verification;
+
+statement ok
+create table x (x int);
+
+statement ok
+with y(y) as (select 1) insert into x (select y from y);
+
+query I
+select x from x;
+----
+1
+
+statement ok
+with y(y) as (select 1) update x set x = 2 from y where x = y;
+
+query I
+select x from x;
+----
+2
+
+statement ok
+with y(y) as (select 2) delete from x using y where x = y;
+
+query I
+select x from x;
+----
+
+statement ok
+with y(y) as (select 1), z(z) as (select 2) insert into x (select (select y + z + 7) from y, z);
+
+statement ok
+with recursive t as (select 1 as x union all select x+1 from t where x < 3) insert into x (select * from t);
+
+query I
+select x from x;
+----
+10
+1
+2
+3
+
+statement ok
+with y(y) as (with z(z) as (select 20) select * from z) delete from x using y where x < y;
+
+query I
+select x from x;
+----
+
+statement error
+with y(y) as (select 2) delete from x using (select y) z(z) where x = z;
+
+# at the moment keep this as an error
+statement error
+insert into x default values;

--- a/test/issues/general/test_4008.test
+++ b/test/issues/general/test_4008.test
@@ -1,0 +1,21 @@
+# name: test/issues/general/test_4008.test
+# description: Issue 4008: ANY/ALL without comparison operators
+# group: [general]
+
+statement ok
+PRAGMA enable_verification;
+
+statement error
+select 1 - any(select 1);
+
+query I
+select 1 = all(select 1);
+----
+1
+
+statement error
+select 1 where 2 + all(select 2);
+
+query I
+select 1 where 2 > any(select 2);
+----

--- a/tools/rpkg/src/relational.cpp
+++ b/tools/rpkg/src/relational.cpp
@@ -26,7 +26,7 @@ using namespace duckdb;
 using namespace cpp11;
 
 template <typename T, typename... Args>
-external_pointer<T> make_external(const string &rclass, Args &&...args) {
+external_pointer<T> make_external(const string &rclass, Args &&... args) {
 	auto extptr = external_pointer<T>(new T(std::forward<Args>(args)...));
 	((sexp)extptr).attr("class") = rclass;
 	return (extptr);


### PR DESCRIPTION
Hello duckies! On this pull request I add support for CTEs on insert/update/delete statements. This pairs the implementation with PostgreSQL.

I had to make the QueryNode::CTEToString method static, so the class hierarchy is still stable, but we can discuss another solution while the codebase keeps clean?

This pull request also disables INSERT INTO x DEFAULT VALUES . Later this can be converted to a value list statement.

Also includes a fix for issue #4008.
Thanks for your feedback!