### PR TITLE
Fix amalgamated build with multiple .cpp

### DIFF
--- a/src/include/duckdb/common/dl.hpp
+++ b/src/include/duckdb/common/dl.hpp
@@ -22,23 +22,23 @@ namespace duckdb {
 
 #ifdef _WIN32
 
-void *dlopen(const char *file, int mode) {
+inline void *dlopen(const char *file, int mode) {
 	D_ASSERT(file);
 	return (void *)LoadLibrary(file);
 }
 
-void *dlsym(void *handle, const char *name) {
+inline void *dlsym(void *handle, const char *name) {
 	D_ASSERT(handle);
 	return (void *)GetProcAddress((HINSTANCE)handle, name);
 }
 
-std::string GetDLError(void) {
+inline std::string GetDLError(void) {
 	return LocalFileSystem::GetLastErrorAsString();
 }
 
 #else
 
-std::string GetDLError(void) {
+inline std::string GetDLError(void) {
 	return dlerror();
 }
 


### PR DESCRIPTION
When building split amalgamated files, this function ends up being defined in duckdb-internal.hpp, and when included by multiple compilation units, fails linkage due to multiple symbol definition. Marking it as inline to fix build. 