### PR TITLE
Making memory leak sanitizer happy with DuckDB Shell

### DIFF
--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -20759,6 +20759,7 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv){
       bail_on_error = 1;
     }else if( strcmp(z,"-version")==0 ){
       printf("%s %s\n", sqlite3_libversion(), sqlite3_sourceid());
+      free(azCmd);
       return 0;
     }else if( strcmp(z,"-interactive")==0 ){
       stdin_is_interactive = 1;
@@ -20804,16 +20805,26 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv){
       z = cmdline_option_value(argc,argv,++i);
       if( z[0]=='.' ){
         rc = do_meta_command(z, &data);
-        if( rc && bail_on_error ) return rc==2 ? 0 : rc;
+        if( rc && bail_on_error ){
+          free(azCmd);
+          return rc==2 ? 0 : rc;
+        }
       }else{
         open_db(&data, 0);
         rc = shell_exec(&data, z, &zErrMsg);
         if( zErrMsg!=0 ){
           utf8_printf(stderr,"Error: %s\n", zErrMsg);
-          if( bail_on_error ) return rc!=0 ? rc : 1;
+          sqlite3_free(zErrMsg);
+          if( bail_on_error ){
+            free(azCmd);
+            return rc!=0 ? rc : 1;
+          }
         }else if( rc!=0 ){
           utf8_printf(stderr,"Error: unable to process SQL \"%s\"\n", z);
-          if( bail_on_error ) return rc;
+          if( bail_on_error ){
+            free(azCmd);
+            return rc;
+          }
         }
       }
 #if !defined(SQLITE_OMIT_VIRTUALTABLE) && defined(SQLITE_HAVE_ZLIB)
@@ -20821,6 +20832,7 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv){
       if( nCmd>0 ){
         utf8_printf(stderr, "Error: cannot mix regular SQL or dot-commands"
                             " with \"%s\"\n", z);
+        free(azCmd);
         return 1;
       }
       open_db(&data, OPEN_DB_ZIPFILE);
@@ -20836,6 +20848,7 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv){
     }else{
       utf8_printf(stderr,"%s: Error: unknown option: %s\n", Argv0, z);
       raw_printf(stderr,"Use -help for a list of options.\n");
+      free(azCmd);
       return 1;
     }
     data.cMode = data.mode;
@@ -20849,15 +20862,21 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv){
     for(i=0; i<nCmd; i++){
       if( azCmd[i][0]=='.' ){
         rc = do_meta_command(azCmd[i], &data);
-        if( rc ) return rc==2 ? 0 : rc;
+        if( rc ){
+          free(azCmd);
+          return rc==2 ? 0 : rc;
+        }
       }else{
         open_db(&data, 0);
         rc = shell_exec(&data, azCmd[i], &zErrMsg);
         if( zErrMsg!=0 ){
           utf8_printf(stderr,"Error: %s\n", zErrMsg);
+          sqlite3_free(zErrMsg);
+          free(azCmd);
           return rc!=0 ? rc : 1;
         }else if( rc!=0 ){
           utf8_printf(stderr,"Error: unable to process SQL: %s\n", azCmd[i]);
+          free(azCmd);
           return rc;
         }
       }


### PR DESCRIPTION
Hello Duckies! While I was reproducing some fuzzer issues, the memory leak sanitizer was complaining about some allocations not being freed by the shell on error cases.

I am not sure if the shell file is still being generated, if so you can cancel this pull request.