### PR TITLE
clean.py deleting correct directory and asks confirmation

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -117,6 +117,7 @@ jobs:
       run: |
         cd tools/pythonpkg
         ./clean.sh
+        y
         cd ../..
 
     - name: Build Current

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -116,7 +116,7 @@ jobs:
       shell: bash
       run: |
         cd tools/pythonpkg
-        ./clean.sh -f
+        ./clean.sh
         cd ../..
 
     - name: Build Current

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -116,7 +116,7 @@ jobs:
       shell: bash
       run: |
         cd tools/pythonpkg
-        ./clean.sh -f    
+        ./clean.sh -f
         cd ../..
 
     - name: Build Current

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -116,8 +116,7 @@ jobs:
       shell: bash
       run: |
         cd tools/pythonpkg
-        ./clean.sh
-        y
+        ./clean.sh -f    
         cd ../..
 
     - name: Build Current

--- a/tools/pythonpkg/clean.py
+++ b/tools/pythonpkg/clean.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 import shutil
 import sys
+import argparse
 
 # avoid importing from the current directory
 sys.path = sys.path[1:]
@@ -18,15 +19,23 @@ while 'duckdb' in pathlib.PurePath(next_dir).name:
 if 'duckdb' not in base_dir:
     raise Exception("Failed to find DuckDB path to delete")
 
-answer = ""
-while answer not in ["y", "yes", "n", "no"]:
-    print("The following directory and all files in it will be deleted:")
-    print(base_dir)
-    answer = input(f"Delete directory and all files in it? (y/n): ")
-    if answer.lower() in ["y", "yes"]:
-        shutil.rmtree(base_dir)
-    elif answer.lower() in ["n", "no"]:
-        print("Aborting clean.py")
-        quit()
-    else:
-        print("Please indicate if you wish to continue deletion (y) or abort (n)")
+parser = argparse.ArgumentParser()
+parser.add_argument('-f', '--force', help="force deletion of folders", action='store_true')
+args = parser.parse_args()
+
+if args.force:
+    print(f"Deleting {base_dir}")
+    shutil.rmtree(base_dir)
+else:
+    answer = ""
+    while answer not in ["y", "yes", "n", "no"]:
+        print("The following directory and all files in it will be deleted:")
+        print(base_dir)
+        answer = input(f"Delete directory and all files in it? (y/n): ")
+        if answer.lower() in ["y", "yes"]:
+            shutil.rmtree(base_dir)
+        elif answer.lower() in ["n", "no"]:
+            print("Aborting clean.py")
+            quit()
+        else:
+            print("Please indicate if you wish to continue deletion (y) or abort (n)")

--- a/tools/pythonpkg/clean.py
+++ b/tools/pythonpkg/clean.py
@@ -1,15 +1,31 @@
-import os, sys, shutil
+import os
+import pathlib
+import shutil
+import sys
+
 # avoid importing from the current directory
 sys.path = sys.path[1:]
 
 try:
     import duckdb
 except:
+    print("Failed to import duckdb")
     exit(0)
 next_dir = duckdb.__file__
-while 'duckdb' in next_dir:
+while 'duckdb' in pathlib.PurePath(next_dir).name:
     base_dir = next_dir
     next_dir = next_dir.rsplit(os.path.sep, 1)[0]
 if 'duckdb' not in base_dir:
-    raise Exception("Failed to find DuckDB path to delete")
-shutil.rmtree(base_dir)
+    print(Exception("Failed to find DuckDB path to delete"))
+answer = ""
+while answer not in ["y", "yes", "n", "no"]:
+    print("The following directory and all files in it will be deleted:")
+    print(base_dir)
+    answer = input(f"Delete directory and all files in it? (y/n): ")
+    if answer.lower() in ["y", "yes"]:
+        shutil.rmtree(base_dir)
+    elif answer.lower() in ["n", "no"]:
+        print("Aborting clean.py")
+        quit()
+    else:
+        print("Please indicate if you wish to continue deletion (y) or abort (n)")

--- a/tools/pythonpkg/clean.py
+++ b/tools/pythonpkg/clean.py
@@ -16,7 +16,8 @@ while 'duckdb' in pathlib.PurePath(next_dir).name:
     base_dir = next_dir
     next_dir = next_dir.rsplit(os.path.sep, 1)[0]
 if 'duckdb' not in base_dir:
-    print(Exception("Failed to find DuckDB path to delete"))
+    raise Exception("Failed to find DuckDB path to delete")
+
 answer = ""
 while answer not in ["y", "yes", "n", "no"]:
     print("The following directory and all files in it will be deleted:")

--- a/tools/pythonpkg/clean.sh
+++ b/tools/pythonpkg/clean.sh
@@ -3,7 +3,7 @@
 rm -rf .eggs .pytest_cache build dist duckdb.egg-info duckdb.cpp duckdb.hpp parquet-extension.cpp parquet-extension.hpp duckdb duckdb_tarball
 rm -f sources.list includes.list githash.list
 
-while [[ $# -ge 1 ]]
+while [ $# -ge 1 ]
 do
 key="$1"
   case $key in

--- a/tools/pythonpkg/clean.sh
+++ b/tools/pythonpkg/clean.sh
@@ -9,7 +9,7 @@ key="$1"
   case $key in
     -f | --force)
     python3 clean.py -f
-        exit 1
+        exit 0
         ;;
   esac
 shift

--- a/tools/pythonpkg/clean.sh
+++ b/tools/pythonpkg/clean.sh
@@ -2,4 +2,16 @@
 
 rm -rf .eggs .pytest_cache build dist duckdb.egg-info duckdb.cpp duckdb.hpp parquet-extension.cpp parquet-extension.hpp duckdb duckdb_tarball
 rm -f sources.list includes.list githash.list
+
+while [[ $# -ge 1 ]]
+do
+key="$1"
+  case $key in
+    -f | --force)
+    python3 clean.py -f
+        exit 1
+        ;;
+  esac
+shift
+done
 python3 clean.py

--- a/tools/pythonpkg/clean.sh
+++ b/tools/pythonpkg/clean.sh
@@ -3,15 +3,4 @@
 rm -rf .eggs .pytest_cache build dist duckdb.egg-info duckdb.cpp duckdb.hpp parquet-extension.cpp parquet-extension.hpp duckdb duckdb_tarball
 rm -f sources.list includes.list githash.list
 
-while [ $# -ge 1 ]
-do
-key="$1"
-  case $key in
-    -f | --force)
-    python3 clean.py -f
-        exit 0
-        ;;
-  esac
-shift
-done
-python3 clean.py
+python3 -m pip uninstall duckdb


### PR DESCRIPTION
The clean.py, which cleans artifacts of Python builds, now deletes a higher level directory than it should. This pull request addresses this. Only the folder where the Python package exists is now deleted. The deletion first has to be confirmed by the user.