### PR TITLE
Issue #3593: avoid duplicate eliminating correlated columns in subqueries when they involve LIST columns

### DIFF
--- a/src/common/types/chunk_collection.cpp
+++ b/src/common/types/chunk_collection.cpp
@@ -454,6 +454,12 @@ bool ChunkCollection::Equals(ChunkCollection &other) {
 	if (compare_equals) {
 		return true;
 	}
+	for (auto &type : types) {
+		// sort not supported
+		if (type.InternalType() == PhysicalType::LIST || type.InternalType() == PhysicalType::STRUCT) {
+			return false;
+		}
+	}
 	// if the results are not equal,
 	// sort both chunk collections to ensure the comparison is not order insensitive
 	vector<OrderType> desc(ColumnCount(), OrderType::DESCENDING);

--- a/src/execution/operator/join/physical_nested_loop_join.cpp
+++ b/src/execution/operator/join/physical_nested_loop_join.cpp
@@ -105,6 +105,16 @@ void PhysicalJoin::ConstructMarkJoinResult(DataChunk &join_keys, DataChunk &left
 	}
 }
 
+bool PhysicalNestedLoopJoin::IsSupported(const vector<JoinCondition> &conditions) {
+	for (auto &cond : conditions) {
+		if (cond.left->return_type.InternalType() == PhysicalType::STRUCT ||
+		    cond.left->return_type.InternalType() == PhysicalType::LIST) {
+			return false;
+		}
+	}
+	return true;
+}
+
 //===--------------------------------------------------------------------===//
 // Sink
 //===--------------------------------------------------------------------===//

--- a/src/execution/physical_plan/plan_comparison_join.cpp
+++ b/src/execution/physical_plan/plan_comparison_join.cpp
@@ -14,6 +14,8 @@
 #include "duckdb/transaction/transaction.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
 #include "duckdb/common/operator/subtract.hpp"
+#include "duckdb/execution/operator/join/physical_blockwise_nl_join.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 
 namespace duckdb {
 
@@ -157,6 +159,14 @@ void TransformIndexJoin(ClientContext &context, LogicalComparisonJoin &op, Index
 	}
 }
 
+static void RewriteJoinCondition(Expression &expr, idx_t offset) {
+	if (expr.type == ExpressionType::BOUND_REF) {
+		auto &ref = (BoundReferenceExpression &)expr;
+		ref.index += offset;
+	}
+	ExpressionIterator::EnumerateChildren(expr, [&](Expression &child) { RewriteJoinCondition(child, offset); });
+}
+
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalComparisonJoin &op) {
 	// now visit the children
 	D_ASSERT(op.children.size() == 2);
@@ -242,10 +252,17 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalComparison
 			// range join: use piecewise merge join
 			plan = make_unique<PhysicalPiecewiseMergeJoin>(op, move(left), move(right), move(op.conditions),
 			                                               op.join_type, op.estimated_cardinality);
-		} else {
+		} else if (PhysicalNestedLoopJoin::IsSupported(op.conditions)) {
 			// inequality join: use nested loop
 			plan = make_unique<PhysicalNestedLoopJoin>(op, move(left), move(right), move(op.conditions), op.join_type,
 			                                           op.estimated_cardinality);
+		} else {
+			for (auto &cond : op.conditions) {
+				RewriteJoinCondition(*cond.right, left->types.size());
+			}
+			auto condition = JoinCondition::CreateExpression(move(op.conditions));
+			plan = make_unique<PhysicalBlockwiseNLJoin>(op, move(left), move(right), move(condition), op.join_type,
+			                                            op.estimated_cardinality);
 		}
 	}
 	return plan;

--- a/src/include/duckdb/execution/operator/join/physical_nested_loop_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_nested_loop_join.hpp
@@ -67,6 +67,8 @@ public:
 		return true;
 	}
 
+	static bool IsSupported(const vector<JoinCondition> &conditions);
+
 private:
 	// resolve joins that output max N elements (SEMI, ANTI, MARK)
 	void ResolveSimpleJoin(ExecutionContext &context, DataChunk &input, DataChunk &chunk, OperatorState &state) const;

--- a/src/include/duckdb/parser/transformer.hpp
+++ b/src/include/duckdb/parser/transformer.hpp
@@ -150,6 +150,7 @@ private:
 	unique_ptr<ConstantExpression> TransformValue(duckdb_libpgquery::PGValue val);
 	//! Transform a Postgres operator into an Expression
 	unique_ptr<ParsedExpression> TransformAExpr(duckdb_libpgquery::PGAExpr *root);
+	unique_ptr<ParsedExpression> TransformAExprInternal(duckdb_libpgquery::PGAExpr *root);
 	//! Transform a Postgres abstract expression into an Expression
 	unique_ptr<ParsedExpression> TransformExpression(duckdb_libpgquery::PGNode *node);
 	//! Transform a Postgres function call into an Expression

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -45,8 +45,11 @@ struct CorrelatedColumnInfo {
 	string name;
 	idx_t depth;
 
+	CorrelatedColumnInfo(ColumnBinding binding, LogicalType type_p, string name_p, idx_t depth)
+	    : binding(binding), type(move(type_p)), name(move(name_p)), depth(depth) {
+	}
 	explicit CorrelatedColumnInfo(BoundColumnRefExpression &expr)
-	    : binding(expr.binding), type(expr.return_type), name(expr.GetName()), depth(expr.depth) {
+	    : CorrelatedColumnInfo(expr.binding, expr.return_type, expr.GetName(), expr.depth) {
 	}
 
 	bool operator==(const CorrelatedColumnInfo &rhs) const {

--- a/src/include/duckdb/planner/joinside.hpp
+++ b/src/include/duckdb/planner/joinside.hpp
@@ -22,6 +22,7 @@ public:
 	//! Turns the JoinCondition into an expression; note that this destroys the JoinCondition as the expression inherits
 	//! the left/right expressions
 	static unique_ptr<Expression> CreateExpression(JoinCondition cond);
+	static unique_ptr<Expression> CreateExpression(vector<JoinCondition> conditions);
 
 public:
 	unique_ptr<Expression> left;

--- a/src/include/duckdb/planner/logical_operator.hpp
+++ b/src/include/duckdb/planner/logical_operator.hpp
@@ -24,13 +24,9 @@ namespace duckdb {
 //! logical query tree
 class LogicalOperator {
 public:
-	explicit LogicalOperator(LogicalOperatorType type) : type(type) {
-	}
-	LogicalOperator(LogicalOperatorType type, vector<unique_ptr<Expression>> expressions)
-	    : type(type), expressions(move(expressions)) {
-	}
-	virtual ~LogicalOperator() {
-	}
+	explicit LogicalOperator(LogicalOperatorType type);
+	LogicalOperator(LogicalOperatorType type, vector<unique_ptr<Expression>> expressions);
+	virtual ~LogicalOperator();
 
 	//! The type of the logical operator
 	LogicalOperatorType type;
@@ -44,9 +40,7 @@ public:
 	idx_t estimated_cardinality = 0;
 
 public:
-	virtual vector<ColumnBinding> GetColumnBindings() {
-		return {ColumnBinding(0, 0)};
-	}
+	virtual vector<ColumnBinding> GetColumnBindings();
 	static vector<ColumnBinding> GenerateColumnBindings(idx_t table_idx, idx_t column_count);
 	static vector<LogicalType> MapTypes(const vector<LogicalType> &types, const vector<idx_t> &projection_map);
 	static vector<ColumnBinding> MapBindings(const vector<ColumnBinding> &types, const vector<idx_t> &projection_map);
@@ -61,18 +55,9 @@ public:
 	//! Debug method: verify that the integrity of expressions & child nodes are maintained
 	virtual void Verify();
 
-	void AddChild(unique_ptr<LogicalOperator> child) {
-		children.push_back(move(child));
-	}
+	void AddChild(unique_ptr<LogicalOperator> child);
 
-	virtual idx_t EstimateCardinality(ClientContext &context) {
-		// simple estimator, just take the max of the children
-		idx_t max_cardinality = 0;
-		for (auto &child : children) {
-			max_cardinality = MaxValue(child->EstimateCardinality(context), max_cardinality);
-		}
-		return max_cardinality;
-	}
+	virtual idx_t EstimateCardinality(ClientContext &context);
 
 protected:
 	//! Resolve types for this specific operator

--- a/src/include/duckdb/planner/subquery/flatten_dependent_join.hpp
+++ b/src/include/duckdb/planner/subquery/flatten_dependent_join.hpp
@@ -18,7 +18,8 @@ namespace duckdb {
 //! The FlattenDependentJoins class is responsible for pushing the dependent join down into the plan to create a
 //! flattened subquery
 struct FlattenDependentJoins {
-	FlattenDependentJoins(Binder &binder, const vector<CorrelatedColumnInfo> &correlated, bool any_join = false);
+	FlattenDependentJoins(Binder &binder, const vector<CorrelatedColumnInfo> &correlated, bool perform_delim = true,
+	                      bool any_join = false);
 
 	//! Detects which Logical Operators have correlated expressions that they are dependent upon, filling the
 	//! has_correlated_expressions map.
@@ -37,6 +38,7 @@ struct FlattenDependentJoins {
 	const vector<CorrelatedColumnInfo> &correlated_columns;
 	vector<LogicalType> delim_types;
 
+	bool perform_delim;
 	bool any_join;
 
 private:

--- a/src/parser/transform/expression/transform_operator.cpp
+++ b/src/parser/transform/expression/transform_operator.cpp
@@ -57,7 +57,7 @@ unique_ptr<ParsedExpression> Transformer::TransformBinaryOperator(const string &
 	}
 }
 
-unique_ptr<ParsedExpression> Transformer::TransformAExpr(duckdb_libpgquery::PGAExpr *root) {
+unique_ptr<ParsedExpression> Transformer::TransformAExprInternal(duckdb_libpgquery::PGAExpr *root) {
 	D_ASSERT(root);
 	auto name = string((reinterpret_cast<duckdb_libpgquery::PGValue *>(root->name->head->data.ptr_value))->val.str);
 
@@ -203,6 +203,14 @@ unique_ptr<ParsedExpression> Transformer::TransformAExpr(duckdb_libpgquery::PGAE
 	} else {
 		return TransformBinaryOperator(name, move(left_expr), move(right_expr));
 	}
+}
+
+unique_ptr<ParsedExpression> Transformer::TransformAExpr(duckdb_libpgquery::PGAExpr *root) {
+	auto result = TransformAExprInternal(root);
+	if (result) {
+		result->query_location = root->location;
+	}
+	return result;
 }
 
 } // namespace duckdb

--- a/src/planner/binder/query_node/plan_subquery.cpp
+++ b/src/planner/binder/query_node/plan_subquery.cpp
@@ -209,7 +209,7 @@ static bool PerformDuplicateElimination(Binder &binder, vector<CorrelatedColumnI
 	auto binding = ColumnBinding(binder.GenerateTableIndex(), 0);
 	auto type = LogicalType::BIGINT;
 	auto name = "delim_index";
-	CorrelatedColumnInfo info(binding, move(type), move(name), 0);
+	CorrelatedColumnInfo info(binding, type, name, 0);
 	correlated_columns.insert(correlated_columns.begin(), move(info));
 	return false;
 }

--- a/src/planner/binder/query_node/plan_subquery.cpp
+++ b/src/planner/binder/query_node/plan_subquery.cpp
@@ -11,6 +11,9 @@
 #include "duckdb/planner/operator/list.hpp"
 #include "duckdb/planner/subquery/flatten_dependent_join.hpp"
 #include "duckdb/function/aggregate/distributive_functions.hpp"
+#include "duckdb/planner/operator/logical_window.hpp"
+#include "duckdb/planner/expression/bound_window_expression.hpp"
+#include "duckdb/main/client_config.hpp"
 
 namespace duckdb {
 
@@ -133,8 +136,25 @@ static unique_ptr<Expression> PlanUncorrelatedSubquery(Binder &binder, BoundSubq
 }
 
 static unique_ptr<LogicalDelimJoin> CreateDuplicateEliminatedJoin(vector<CorrelatedColumnInfo> &correlated_columns,
-                                                                  JoinType join_type) {
+                                                                  JoinType join_type,
+                                                                  unique_ptr<LogicalOperator> original_plan,
+                                                                  bool perform_delim) {
 	auto delim_join = make_unique<LogicalDelimJoin>(join_type);
+	if (!perform_delim) {
+		// if we are not performing a delim join, we push a row_number() OVER() window operator on the LHS
+		// and perform all duplicate elimination on that row number instead
+		D_ASSERT(correlated_columns[0].type.id() == LogicalTypeId::BIGINT);
+		auto window = make_unique<LogicalWindow>(correlated_columns[0].binding.table_index);
+		auto row_number = make_unique<BoundWindowExpression>(ExpressionType::WINDOW_ROW_NUMBER, LogicalType::BIGINT,
+		                                                     nullptr, nullptr);
+		row_number->start = WindowBoundary::UNBOUNDED_PRECEDING;
+		row_number->end = WindowBoundary::CURRENT_ROW_ROWS;
+		row_number->alias = "delim_index";
+		window->expressions.push_back(move(row_number));
+		window->AddChild(move(original_plan));
+		original_plan = move(window);
+	}
+	delim_join->AddChild(move(original_plan));
 	for (idx_t i = 0; i < correlated_columns.size(); i++) {
 		auto &col = correlated_columns[i];
 		delim_join->duplicate_eliminated_columns.push_back(
@@ -145,8 +165,9 @@ static unique_ptr<LogicalDelimJoin> CreateDuplicateEliminatedJoin(vector<Correla
 }
 
 static void CreateDelimJoinConditions(LogicalDelimJoin &delim_join, vector<CorrelatedColumnInfo> &correlated_columns,
-                                      vector<ColumnBinding> bindings, idx_t base_offset) {
-	for (idx_t i = 0; i < correlated_columns.size(); i++) {
+                                      vector<ColumnBinding> bindings, idx_t base_offset, bool perform_delim) {
+	auto col_count = perform_delim ? correlated_columns.size() : 1;
+	for (idx_t i = 0; i < col_count; i++) {
 		auto &col = correlated_columns[i];
 		JoinCondition cond;
 		cond.left = make_unique<BoundColumnRefExpression>(col.name, col.type, col.binding);
@@ -156,10 +177,50 @@ static void CreateDelimJoinConditions(LogicalDelimJoin &delim_join, vector<Corre
 	}
 }
 
+static bool PerformDelimOnType(const LogicalType &type) {
+	if (type.InternalType() == PhysicalType::LIST) {
+		return false;
+	}
+	if (type.InternalType() == PhysicalType::STRUCT) {
+		for (auto &entry : StructType::GetChildTypes(type)) {
+			if (!PerformDelimOnType(entry.second)) {
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
+static bool PerformDuplicateElimination(Binder &binder, vector<CorrelatedColumnInfo> &correlated_columns) {
+	if (!ClientConfig::GetConfig(binder.context).enable_optimizer) {
+		// if optimizations are disabled we always do a delim join
+		return true;
+	}
+	bool perform_delim = true;
+	for (auto &col : correlated_columns) {
+		if (!PerformDelimOnType(col.type)) {
+			perform_delim = false;
+			break;
+		}
+	}
+	if (perform_delim) {
+		return true;
+	}
+	auto binding = ColumnBinding(binder.GenerateTableIndex(), 0);
+	auto type = LogicalType::BIGINT;
+	auto name = "delim_index";
+	CorrelatedColumnInfo info(binding, move(type), move(name), 0);
+	correlated_columns.insert(correlated_columns.begin(), move(info));
+	return false;
+}
+
 static unique_ptr<Expression> PlanCorrelatedSubquery(Binder &binder, BoundSubqueryExpression &expr,
                                                      unique_ptr<LogicalOperator> &root,
                                                      unique_ptr<LogicalOperator> plan) {
 	auto &correlated_columns = expr.binder->correlated_columns;
+	// FIXME: there should be a way of disabling decorrelation for ANY queries as well, but not for now...
+	bool perform_delim =
+	    expr.subquery_type == SubqueryType::ANY ? true : PerformDuplicateElimination(binder, correlated_columns);
 	D_ASSERT(expr.IsCorrelated());
 	// correlated subquery
 	// for a more in-depth explanation of this code, read the paper "Unnesting Arbitrary Subqueries"
@@ -176,15 +237,15 @@ static unique_ptr<Expression> PlanCorrelatedSubquery(Binder &binder, BoundSubque
 		// NULL values are equal in this join because we join on the correlated columns ONLY
 		// and e.g. in the query: SELECT (SELECT 42 FROM integers WHERE i1.i IS NULL LIMIT 1) FROM integers i1;
 		// the input value NULL will generate the value 42, and we need to join NULL on the LHS with NULL on the RHS
-		auto delim_join = CreateDuplicateEliminatedJoin(correlated_columns, JoinType::SINGLE);
-
 		// the left side is the original plan
 		// this is the side that will be duplicate eliminated and pushed into the RHS
-		delim_join->AddChild(move(root));
+		auto delim_join =
+		    CreateDuplicateEliminatedJoin(correlated_columns, JoinType::SINGLE, move(root), perform_delim);
+
 		// the right side initially is a DEPENDENT join between the duplicate eliminated scan and the subquery
 		// HOWEVER: we do not explicitly create the dependent join
 		// instead, we eliminate the dependent join by pushing it down into the right side of the plan
-		FlattenDependentJoins flatten(binder, correlated_columns);
+		FlattenDependentJoins flatten(binder, correlated_columns, perform_delim);
 
 		// first we check which logical operators have correlated expressions in the first place
 		flatten.DetectCorrelatedExpressions(plan.get());
@@ -197,7 +258,7 @@ static unique_ptr<Expression> PlanCorrelatedSubquery(Binder &binder, BoundSubque
 		auto plan_columns = dependent_join->GetColumnBindings();
 
 		// now create the join conditions
-		CreateDelimJoinConditions(*delim_join, correlated_columns, plan_columns, flatten.delim_offset);
+		CreateDelimJoinConditions(*delim_join, correlated_columns, plan_columns, flatten.delim_offset, perform_delim);
 		delim_join->AddChild(move(dependent_join));
 		root = move(delim_join);
 		// finally push the BoundColumnRefExpression referring to the data element returned by the join
@@ -208,12 +269,10 @@ static unique_ptr<Expression> PlanCorrelatedSubquery(Binder &binder, BoundSubque
 		// correlated EXISTS query
 		// this query is similar to the correlated SCALAR query, except we use a MARK join here
 		idx_t mark_index = binder.GenerateTableIndex();
-		auto delim_join = CreateDuplicateEliminatedJoin(correlated_columns, JoinType::MARK);
+		auto delim_join = CreateDuplicateEliminatedJoin(correlated_columns, JoinType::MARK, move(root), perform_delim);
 		delim_join->mark_index = mark_index;
-		// LHS
-		delim_join->AddChild(move(root));
 		// RHS
-		FlattenDependentJoins flatten(binder, correlated_columns);
+		FlattenDependentJoins flatten(binder, correlated_columns, perform_delim);
 		flatten.DetectCorrelatedExpressions(plan.get());
 		auto dependent_join = flatten.PushDownDependentJoin(move(plan));
 
@@ -221,7 +280,7 @@ static unique_ptr<Expression> PlanCorrelatedSubquery(Binder &binder, BoundSubque
 		auto plan_columns = dependent_join->GetColumnBindings();
 
 		// now we create the join conditions between the dependent join and the original table
-		CreateDelimJoinConditions(*delim_join, correlated_columns, plan_columns, flatten.delim_offset);
+		CreateDelimJoinConditions(*delim_join, correlated_columns, plan_columns, flatten.delim_offset, perform_delim);
 		delim_join->AddChild(move(dependent_join));
 		root = move(delim_join);
 		// finally push the BoundColumnRefExpression referring to the marker
@@ -237,10 +296,8 @@ static unique_ptr<Expression> PlanCorrelatedSubquery(Binder &binder, BoundSubque
 		// as the MARK join has one extra join condition (the original condition, of the ANY expression, e.g.
 		// [i=ANY(...)])
 		idx_t mark_index = binder.GenerateTableIndex();
-		auto delim_join = CreateDuplicateEliminatedJoin(correlated_columns, JoinType::MARK);
+		auto delim_join = CreateDuplicateEliminatedJoin(correlated_columns, JoinType::MARK, move(root), perform_delim);
 		delim_join->mark_index = mark_index;
-		// LHS
-		delim_join->AddChild(move(root));
 		// RHS
 		FlattenDependentJoins flatten(binder, correlated_columns, true);
 		flatten.DetectCorrelatedExpressions(plan.get());
@@ -250,7 +307,7 @@ static unique_ptr<Expression> PlanCorrelatedSubquery(Binder &binder, BoundSubque
 		auto plan_columns = dependent_join->GetColumnBindings();
 
 		// now we create the join conditions between the dependent join and the original table
-		CreateDelimJoinConditions(*delim_join, correlated_columns, plan_columns, flatten.delim_offset);
+		CreateDelimJoinConditions(*delim_join, correlated_columns, plan_columns, flatten.delim_offset, perform_delim);
 		// add the actual condition based on the ANY/ALL predicate
 		JoinCondition compare_cond;
 		compare_cond.left = move(expr.child);
@@ -274,9 +331,11 @@ public:
 	void VisitOperator(LogicalOperator &op) override {
 		if (!op.children.empty()) {
 			root = move(op.children[0]);
+			D_ASSERT(root);
 			VisitOperatorExpressions(op);
 			op.children[0] = move(root);
 			for (idx_t i = 0; i < op.children.size(); i++) {
+				D_ASSERT(op.children[i]);
 				VisitOperator(*op.children[i]);
 			}
 		}

--- a/test/sql/subquery/complex/correlated_list_aggregate.test
+++ b/test/sql/subquery/complex/correlated_list_aggregate.test
@@ -1,0 +1,273 @@
+# name: test/sql/subquery/complex/correlated_list_aggregate.test
+# description: Test correlated aggregate subqueries
+# group: [complex]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE lists(l INTEGER[]);
+
+statement ok
+INSERT INTO lists VALUES (ARRAY[1]), (ARRAY[2]), (ARRAY[3]), (NULL), (ARRAY[NULL]::INT[]);
+
+# aggregate with correlation in final projection
+query II
+SELECT l, (SELECT MIN(l[1])+i1.l[1] FROM lists) FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	2
+[2]	3
+[3]	4
+[NULL]	NULL
+
+# aggregate with correlation inside aggregation
+query II
+SELECT l, (SELECT MIN(l[1]+2*i1.l[1]) FROM lists) FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	3
+[2]	5
+[3]	7
+[NULL]	NULL
+
+query IRR
+SELECT l, SUM(l[1]), (SELECT SUM(l[1])+SUM(i1.l[1]) FROM lists) FROM lists i1 GROUP BY l ORDER BY l;
+----
+NULL	NULL	NULL
+[1]	1.000000	7.000000
+[2]	2.000000	8.000000
+[3]	3.000000	9.000000
+[NULL]	NULL	NULL
+
+query IRR
+SELECT l, SUM(l[1]), (SELECT SUM(l[1])+COUNT(i1.l[1]) FROM lists) FROM lists i1 GROUP BY l ORDER BY l;
+----
+NULL	NULL	6.000000
+[1]	1.000000	7.000000
+[2]	2.000000	7.000000
+[3]	3.000000	7.000000
+[NULL]	NULL	6.000000
+
+# correlated COUNT(*)
+query II
+SELECT l, (SELECT COUNT(*) FROM lists i2 WHERE i2.l[1]>i1.l[1]) FROM lists i1 ORDER BY l;
+----
+NULL	0
+[1]	2
+[2]	1
+[3]	0
+[NULL]	0
+
+# aggregate with correlation inside aggregation
+query II
+SELECT l, (SELECT MIN(l[1]+2*i1.l[1]) FROM lists) FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	3
+[2]	5
+[3]	7
+[NULL]	NULL
+
+# aggregate ONLY inside subquery
+query R
+SELECT (SELECT SUM(i1.l[1])) FROM lists i1;
+----
+6.000000
+
+# aggregate ONLY inside subquery, with column reference outside of subquery
+query IR
+SELECT MIN(l[1]), (SELECT SUM(i1.l[1])) FROM lists i1;
+----
+1	6.000000
+
+# this will fail, because "l[1]" is not an aggregate but the SUM(i1.l[1]) turns this query into an aggregate
+statement error
+SELECT l, (SELECT SUM(i1.l[1])) FROM lists i1;
+
+statement error
+SELECT l[1]+1, (SELECT SUM(i1.l[1])) FROM lists i1;
+
+query IR
+SELECT MIN(l[1]), (SELECT SUM(i1.l[1])) FROM lists i1;
+----
+1	6.000000
+
+query RR
+SELECT (SELECT SUM(i1.l[1])), (SELECT SUM(i1.l[1])) FROM lists i1;
+----
+6.000000	6.000000
+
+# subquery inside aggregation
+query RR
+SELECT SUM(l[1]), SUM((SELECT l[1] FROM lists WHERE l[1]=i1.l[1])) FROM lists i1;
+----
+6.000000	6.000000
+
+query RR
+SELECT SUM(l[1]), (SELECT SUM(l[1]) FROM lists WHERE l[1]>SUM(i1.l[1])) FROM lists i1;
+----
+6.000000	NULL
+
+# subquery with aggregation inside aggregation should fail
+statement error
+SELECT SUM((SELECT SUM(l[1]))) FROM lists
+
+# aggregate with correlation in filter
+query II
+SELECT l, (SELECT MIN(l[1]) FROM lists WHERE l[1]>i1.l[1]) FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	2
+[2]	3
+[3]	NULL
+[NULL]	NULL
+
+# aggregate with correlation in both filter and projection
+query II
+SELECT l, (SELECT MIN(l[1])+i1.l[1] FROM lists WHERE l[1]>i1.l[1]) FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	3
+[2]	5
+[3]	NULL
+[NULL]	NULL
+
+# aggregate with correlation in GROUP BY
+query II
+SELECT l, (SELECT MIN(l[1]) FROM lists GROUP BY i1.l[1]) AS j FROM lists i1 ORDER BY l;
+----
+NULL	1
+[1]	1
+[2]	1
+[3]	1
+[NULL]	1
+
+# aggregate with correlation in HAVING clause
+query II
+SELECT l, (SELECT l[1] FROM lists GROUP BY l[1] HAVING l[1]=i1.l[1]) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	1
+[2]	2
+[3]	3
+[NULL]	NULL
+
+# correlated subquery in HAVING
+query IR
+SELECT i1.l, SUM(l[1]) FROM lists i1 GROUP BY i1.l HAVING SUM(l[1])=(SELECT MIN(l[1]) FROM lists WHERE l[1]<>i1.l[1]+1) ORDER BY 1;
+----
+[1]	1.000000
+
+query IR
+SELECT l[1] % 2 AS j, SUM(l[1]) FROM lists i1 GROUP BY j HAVING SUM(l[1])=(SELECT SUM(l[1]) FROM lists WHERE l[1]<>j+1) ORDER BY 1;
+----
+1	4.000000
+
+# aggregate query with non-aggregate subquery without group by
+query R
+SELECT (SELECT l[1]+SUM(i1.l[1]) FROM lists WHERE l[1]=1 LIMIT 1) FROM lists i1;
+----
+7.000000
+
+query R
+SELECT (SELECT SUM(l[1])+SUM(i1.l[1]) FROM lists) FROM lists i1 ORDER BY 1;
+----
+12.000000
+
+# aggregate query with non-aggregate subquery with group by
+query IR
+SELECT l, (SELECT l[1]+SUM(i1.l[1]) FROM lists WHERE l[1]=1) FROM lists i1 GROUP BY l ORDER BY l;
+----
+NULL	NULL
+[1]	2.000000
+[2]	3.000000
+[3]	4.000000
+[NULL]	NULL
+
+# subquery inside aggregate
+query R
+SELECT SUM((SELECT l[1]+i1.l[1] FROM lists WHERE l[1]=1)) FROM lists i1;
+----
+9.000000
+
+query IRR
+SELECT l, SUM(i1.l[1]), (SELECT SUM(i1.l[1]) FROM lists) AS k FROM lists i1 GROUP BY l ORDER BY l;
+----
+NULL	NULL	NULL
+[1]	1.000000	1.000000
+[2]	2.000000	2.000000
+[3]	3.000000	3.000000
+[NULL]	NULL	NULL
+
+# aggregation of both entries inside subquery
+# aggregate on group inside subquery
+query IR
+SELECT i1.l AS j, (SELECT SUM(j[1]+l[1]) FROM lists) AS k FROM lists i1 GROUP BY j ORDER BY j;
+----
+NULL	NULL
+[1]	9.000000
+[2]	12.000000
+[3]	15.000000
+[NULL]	NULL
+
+query R
+SELECT (SELECT SUM(i1.l[1]*l[1]) FROM lists) FROM lists i1 ORDER BY l;
+----
+NULL
+6.000000
+12.000000
+18.000000
+NULL
+
+# ORDER BY correlated subquery
+query IR
+SELECT l, SUM(i1.l[1]) FROM lists i1 GROUP BY l ORDER BY (SELECT SUM(i1.l[1]) FROM lists);
+----
+NULL	NULL
+[NULL]	NULL
+[1]	1.000000
+[2]	2.000000
+[3]	3.000000
+
+# LIMIT 0 on correlated subquery
+query IR
+SELECT l, SUM((SELECT SUM(l[1])*i1.l[1] FROM lists LIMIT 0)) AS k FROM lists i1 GROUP BY l ORDER BY l;
+----
+NULL	NULL
+[1]	NULL
+[2]	NULL
+[3]	NULL
+[NULL]	NULL
+
+# GROUP BY correlated subquery
+query IR
+SELECT (SELECT l[1]+i1.l[1] FROM lists WHERE l[1]=1) AS k, SUM(l[1]) AS j FROM lists i1 GROUP BY k ORDER BY 1;
+----
+NULL	NULL
+2	1.000000
+3	2.000000
+4	3.000000
+
+# correlated subquery in WHERE
+query R
+SELECT SUM(l[1]) FROM lists i1 WHERE l[1]>(SELECT (l[1]+i1.l[1])/2 FROM lists WHERE l[1]=1);
+----
+5.000000
+
+# correlated aggregate in WHERE
+query R
+SELECT SUM(l[1]) FROM lists i1 WHERE l[1]>(SELECT (SUM(l[1])+i1.l[1])/2 FROM lists WHERE l[1]=1);
+----
+5.000000
+
+# use scalar subquery as argument to ALL/ANY
+query IT
+SELECT l, (SELECT MIN(l[1]) FROM lists WHERE l[1]=i1.l[1]) >= ALL(SELECT l[1] FROM lists WHERE l[1] IS NOT NULL) FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	0
+[2]	0
+[3]	1
+[NULL]	NULL
+

--- a/test/sql/subquery/complex/correlated_list_any_join.test
+++ b/test/sql/subquery/complex/correlated_list_any_join.test
@@ -1,0 +1,79 @@
+# name: test/sql/subquery/complex/correlated_list_any_join.test
+# description: Test subqueries on ANY join with correlated lists
+# group: [complex]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE lists(l INTEGER[]);
+
+statement ok
+INSERT INTO lists VALUES (ARRAY[1]), (ARRAY[2]), (ARRAY[3]), (NULL);
+
+# correlated expressions in inner/left/right joins
+query II
+SELECT l, l IN (SELECT i1.l FROM (SELECT * FROM lists i1 WHERE i1.l=lists.l) i1 JOIN generate_series(1, 2, 1) tbl(s) ON i1.l=ARRAY[tbl.s]) FROM lists ORDER BY l NULLS LAST;
+----
+[1]	True
+[2]	True
+[3]	False
+NULL	False
+
+query I
+SELECT l IN (SELECT i1.l FROM (SELECT * FROM lists i1 WHERE i1.l=lists.l) i1 LEFT JOIN generate_series(1, 2, 1) tbl(s) ON i1.l=ARRAY[tbl.s]) FROM lists ORDER BY l NULLS LAST;
+----
+true
+true
+true
+false
+
+query I
+SELECT l IN (SELECT i1.l FROM (SELECT * FROM lists i1 WHERE i1.l=lists.l) i1 RIGHT JOIN generate_series(1, 2, 1) tbl(s) ON i1.l=ARRAY[tbl.s]) FROM lists ORDER BY l NULLS LAST;
+----
+true
+true
+NULL
+NULL
+
+# other way around
+query I
+SELECT l IN (SELECT i1.l FROM generate_series(1, 2, 1) tbl(s) LEFT JOIN (SELECT * FROM lists i1 WHERE i1.l=lists.l) i1 ON i1.l=ARRAY[tbl.s]) FROM lists ORDER BY l NULLS LAST;
+----
+true
+true
+NULL
+NULL
+
+query I
+SELECT l IN (SELECT i1.l FROM generate_series(1, 2, 1) tbl(s) RIGHT JOIN (SELECT * FROM lists i1 WHERE i1.l=lists.l) i1 ON i1.l=ARRAY[tbl.s]) FROM lists ORDER BY l NULLS LAST;
+----
+true
+true
+true
+false
+
+# complex join condition
+query I
+SELECT l IN (SELECT i1.l FROM (SELECT * FROM lists i1 WHERE i1.l IS NOT DISTINCT FROM lists.l) i1 JOIN generate_series(1, 2, 1) tbl(s) ON i1.l=ARRAY[tbl.s] OR (i1.l IS NULL AND tbl.s IS NULL)) FROM lists ORDER BY l NULLS LAST;
+----
+true
+true
+false
+false
+
+query I
+SELECT l IN (SELECT i1.l FROM (SELECT * FROM lists i1 WHERE i1.l IS NOT DISTINCT FROM lists.l) i1 LEFT JOIN generate_series(1, 2, 1) tbl(s) ON i1.l=ARRAY[tbl.s] OR (i1.l IS NULL AND tbl.s IS NULL)) FROM lists ORDER BY l NULLS LAST;
+----
+true
+true
+true
+NULL
+
+query I
+SELECT l IN (SELECT i1.l FROM (SELECT * FROM lists i1 WHERE i1.l IS NOT DISTINCT FROM lists.l) i1 RIGHT JOIN generate_series(1, 2, 1) tbl(s) ON i1.l=ARRAY[tbl.s] OR (i1.l IS NULL AND tbl.s IS NULL)) FROM lists ORDER BY l NULLS LAST;
+----
+true
+true
+NULL
+NULL

--- a/test/sql/subquery/complex/expensive_deduplication_3593.test
+++ b/test/sql/subquery/complex/expensive_deduplication_3593.test
@@ -20,6 +20,25 @@ SELECT gen_random_uuid() id, 1 as val FROM generate_series(0, 160)
 ----
 161
 
+query II
+SELECT
+z%2 AS k,
+(
+  select count(*) as value
+  FROM (
+    SELECT UNNEST(array_agg(distinct id))
+  ) a
+)
+  as total_seats
+FROM (
+SELECT row_number() over () AS z, gen_random_uuid() id, 1 as val FROM generate_series(0, 160)
+) as m
+GROUP BY k
+ORDER BY k;
+----
+0	80
+1	81
+
 # disable verification for these queries, they are too slow to run without the deduplication
 statement ok
 PRAGMA disable_verification

--- a/test/sql/subquery/complex/expensive_deduplication_3593.test
+++ b/test/sql/subquery/complex/expensive_deduplication_3593.test
@@ -1,0 +1,56 @@
+# name: test/sql/subquery/complex/expensive_deduplication_3593.test
+# description: Issue #3593: Macros causes crash: memory consumption or recursion or something
+# group: [complex]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT
+(
+  select count(*) as value
+  FROM (
+    SELECT UNNEST(array_agg(distinct id))
+  ) a
+)
+  as total_seats
+FROM (
+SELECT gen_random_uuid() id, 1 as val FROM generate_series(0, 160)
+) as m;
+----
+161
+
+# disable verification for these queries, they are too slow to run without the deduplication
+statement ok
+PRAGMA disable_verification
+
+query I
+SELECT
+(
+  select count(*) as value
+  FROM (
+    SELECT UNNEST(array_agg(distinct id))
+  ) a
+)
+  as total_seats
+FROM (
+SELECT gen_random_uuid() id, 1 as val FROM generate_series(0, 100000)
+) as m;
+----
+100001
+
+query I
+SELECT
+(
+  select sum(a.val) as value
+  FROM (
+    SELECT UNNEST(list(distinct {key:m.id, val: m.val})) a
+  ) x
+)
+  as total_seats
+FROM (
+SELECT gen_random_uuid() id, 1 as val FROM range(0, 100000)
+) as m
+cross join (select * FROM range(0,3)) as r
+----
+100000

--- a/test/sql/subquery/complex/nested_correlated_list.test
+++ b/test/sql/subquery/complex/nested_correlated_list.test
@@ -1,0 +1,329 @@
+# name: test/sql/subquery/complex/nested_correlated_list.test
+# description: Test nested correlated list subqueries
+# group: [complex]
+
+#statement ok
+#PRAGMA enable_verification
+
+statement ok
+CREATE TABLE lists(l INTEGER[]);
+
+statement ok
+INSERT INTO lists VALUES (ARRAY[1]), (ARRAY[2]), (ARRAY[3]), (NULL);
+
+# nested correlated queries
+query II
+SELECT l, (SELECT (SELECT 42+i1.l[1])+42+i1.l[1]) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	86
+[2]	88
+[3]	90
+
+query II
+SELECT l, (SELECT (SELECT (SELECT (SELECT 42+i1.l[1])++i1.l[1])+42+i1.l[1])+42+i1.l[1]) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	130
+[2]	134
+[3]	138
+
+query IR
+SELECT l, (SELECT (SELECT i1.l[1]+SUM(i2.l[1])) FROM lists i2) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	7.000000
+[2]	8.000000
+[3]	9.000000
+
+# correlated query inside uncorrelated query
+query II
+SELECT l, (SELECT (SELECT (SELECT (SELECT i1.l[1]+i1.l[1]+i1.l[1]+i1.l[1]+i1.l[1])))) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	5
+[2]	10
+[3]	15
+
+query IR
+SELECT l, (SELECT SUM(l[1])+(SELECT 42+i1.l[1]) FROM lists) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	49.000000
+[2]	50.000000
+[3]	51.000000
+
+query IR
+SELECT l, (SELECT ((SELECT ((SELECT ((SELECT SUM(l[1])+SUM(i4.l[1])+SUM(i3.l[1])+SUM(i2.l[1])+SUM(i1.l[1]) FROM lists i5)) FROM lists i4)) FROM lists i3)) FROM lists i2) AS j FROM lists i1 GROUP BY l ORDER BY l;
+----
+NULL	NULL
+[1]	25.000000
+[2]	26.000000
+[3]	27.000000
+
+query II
+SELECT l, (SELECT (SELECT (SELECT (SELECT i1.l[1]+i1.l[1]+i1.l[1]+i1.l[1]+i1.l[1]+i2.l[1]) FROM lists i2 WHERE i2.l=i1.l))) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	6
+[2]	12
+[3]	18
+
+query R
+SELECT (SELECT (SELECT SUM(i1.l[1])+SUM(i2.l[1])+SUM(i3.l[1]) FROM lists i3) FROM lists i2) FROM lists i1 ORDER BY 1
+----
+18.000000
+
+# explicit join on subquery
+query IR
+SELECT l, (SELECT SUM(s1.l[1]) FROM lists s1 INNER JOIN lists s2 ON (SELECT i1.l[1]+s1.l[1])=(SELECT i1.l[1]+s2.l[1])) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	6.000000
+[2]	6.000000
+[3]	6.000000
+
+# nested aggregate queries
+query IRR
+SELECT l, SUM(l[1]), (SELECT (SELECT SUM(l[1])+SUM(i1.l[1])+SUM(i2.l[1]) FROM lists) FROM lists i2) FROM lists i1 GROUP BY l ORDER BY l;
+----
+NULL	NULL	NULL
+[1]	1.000000	13.000000
+[2]	2.000000	14.000000
+[3]	3.000000	15.000000
+
+# correlated ANY inside subquery
+query IR
+SELECT l, (SELECT SUM(ss1.l[1]) FROM (SELECT l FROM lists s1 WHERE l[1]>ANY(SELECT l[1] FROM lists WHERE l<>s1.l)) ss1) AS j FROM lists i1 ORDER BY l;
+----
+NULL	5.000000
+[1]	5.000000
+[2]	5.000000
+[3]	5.000000
+
+query IR
+SELECT l, (SELECT SUM(ss2.l[1]) FROM (SELECT l FROM lists s1 WHERE l=i1.l AND l=ANY(SELECT l FROM lists WHERE l=s1.l)) ss2) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	1.000000
+[2]	2.000000
+[3]	3.000000
+
+# left outer join on correlated subquery within subquery
+# not supported yet: left outer join on JoinSide::BOTH
+statement error
+SELECT l, (SELECT SUM(s1.l[1]) FROM lists s1 LEFT OUTER JOIN lists s2 ON (SELECT i1.l[1]+s1.l[1])=(SELECT i1.l[1]+s2.l[1])) AS j FROM lists i1 ORDER BY l;
+
+# REQUIRE(CHECK_COLUMN(result, 0, {Value(), 1, 2, 3}));
+# REQUIRE(CHECK_COLUMN(result, 1, {6, 6, 6, 6}));
+query IR
+SELECT l, (SELECT SUM(ss1.l[1])+SUM(ss2.l[1]) FROM (SELECT l FROM lists s1 WHERE l>ANY(SELECT l FROM lists WHERE l<>s1.l)) ss1 LEFT OUTER JOIN (SELECT l FROM lists s1 WHERE l=ANY(SELECT l FROM lists WHERE l=s1.l)) ss2 ON ss1.l=ss2.l) AS j FROM lists i1 ORDER BY l;
+----
+NULL	10.000000
+[1]	10.000000
+[2]	10.000000
+[3]	10.000000
+
+# left outer join with correlation on LHS
+query IR
+SELECT l, (SELECT SUM(s1.l[1]) FROM (SELECT l FROM lists WHERE l=i1.l) s1 LEFT OUTER JOIN lists s2 ON s1.l=s2.l) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	1.000000
+[2]	2.000000
+[3]	3.000000
+
+query IR
+SELECT l, (SELECT SUM(s1.l[1]) FROM (SELECT l FROM lists WHERE l<>i1.l) s1 LEFT OUTER JOIN lists s2 ON s1.l=s2.l) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	5.000000
+[2]	4.000000
+[3]	3.000000
+
+# left outer join with correlation on RHS
+query IR
+SELECT l, (SELECT SUM(s2.l[1]) FROM lists s1 LEFT OUTER JOIN (SELECT l FROM lists WHERE l=i1.l) s2 ON s1.l=s2.l) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	1.000000
+[2]	2.000000
+[3]	3.000000
+
+query IR
+SELECT l, (SELECT SUM(s2.l[1]) FROM lists s1 LEFT OUTER JOIN (SELECT l FROM lists WHERE l<>i1.l) s2 ON s1.l=s2.l) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	5.000000
+[2]	4.000000
+[3]	3.000000
+
+query IR
+SELECT l, (SELECT SUM(ss2.l[1]) FROM (SELECT l FROM lists s1 WHERE CASE WHEN (l=i1.l AND l=ANY(SELECT l FROM lists WHERE l=s1.l)) THEN true ELSE false END) ss2) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	1.000000
+[2]	2.000000
+[3]	3.000000
+
+query IR
+SELECT l, (SELECT SUM(ss2.l[1]) FROM (SELECT l FROM lists s1 WHERE l=i1.l AND l=ANY(SELECT l FROM lists WHERE l=s1.l)) ss2) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	1.000000
+[2]	2.000000
+[3]	3.000000
+
+query IR
+SELECT l, (SELECT SUM(ss2.l[1]) FROM (SELECT l FROM lists s1 WHERE l=i1.l) ss2) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	1.000000
+[2]	2.000000
+[3]	3.000000
+
+query IR
+SELECT l, (SELECT SUM(ss2.l[1]) FROM (SELECT l FROM lists s1 WHERE l=ANY(SELECT l FROM lists WHERE l=s1.l)) ss2) AS j FROM lists i1 ORDER BY l;
+----
+NULL	6.000000
+[1]	6.000000
+[2]	6.000000
+[3]	6.000000
+
+query IT
+SELECT l, (SELECT l=ANY(SELECT l FROM lists WHERE l=s1.l) FROM lists s1 WHERE l=i1.l) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	1
+[2]	1
+[3]	1
+
+query IR
+SELECT l, (SELECT SUM(ss2.l[1]) FROM (SELECT l FROM lists s1 WHERE l=i1.l OR l=ANY(SELECT l FROM lists WHERE l=s1.l)) ss2) AS j FROM lists i1 ORDER BY l;
+----
+NULL	6.000000
+[1]	6.000000
+[2]	6.000000
+[3]	6.000000
+
+query IR
+SELECT l, (SELECT SUM(ss2.l[1]) FROM (SELECT l FROM lists s1 WHERE CASE WHEN (l=i1.l AND l=ANY(SELECT l FROM lists WHERE l=s1.l)) THEN true ELSE false END) ss2) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	1.000000
+[2]	2.000000
+[3]	3.000000
+
+query IR
+SELECT l, (SELECT SUM(ss2.l[1]) FROM (SELECT l FROM lists s1 WHERE l=i1.l AND EXISTS(SELECT l FROM lists WHERE l=s1.l)) ss2) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	1.000000
+[2]	2.000000
+[3]	3.000000
+
+# complex left outer join with correlation on RHS
+query IR
+SELECT l, (SELECT SUM(ss1.l[1]) FROM (SELECT l FROM lists s1 WHERE l>ANY(SELECT l FROM lists WHERE l<>s1.l)) ss1) AS j FROM lists i1 ORDER BY l;
+----
+NULL	5.000000
+[1]	5.000000
+[2]	5.000000
+[3]	5.000000
+
+query IR
+SELECT l, (SELECT SUM(ss1.l[1]) FROM (SELECT l FROM lists s1 WHERE l>ANY(SELECT l FROM lists WHERE l<>s1.l)) ss1 LEFT OUTER JOIN (SELECT l FROM lists s1 WHERE l=i1.l AND l=ANY(SELECT l FROM lists WHERE l=s1.l)) ss2 ON ss1.l=ss2.l) AS j FROM lists i1 ORDER BY l;
+----
+NULL	5.000000
+[1]	5.000000
+[2]	5.000000
+[3]	5.000000
+
+query IR
+SELECT l, (SELECT SUM(ss2.l[1]) FROM (SELECT l FROM lists s1 WHERE l>ANY(SELECT l FROM lists WHERE l<>s1.l)) ss1 LEFT OUTER JOIN (SELECT l FROM lists s1 WHERE l=i1.l AND l=ANY(SELECT l FROM lists WHERE l=s1.l)) ss2 ON ss1.l=ss2.l) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	NULL
+[2]	2.000000
+[3]	3.000000
+
+query IR
+SELECT l, (SELECT SUM(ss1.l[1])+SUM(ss2.l[1]) FROM (SELECT l FROM lists s1 WHERE l>ANY(SELECT l FROM lists WHERE l<>s1.l)) ss1 LEFT OUTER JOIN (SELECT l FROM lists s1 WHERE l=i1.l AND l=ANY(SELECT l FROM lists WHERE l=s1.l)) ss2 ON ss1.l=ss2.l) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	NULL
+[2]	7.000000
+[3]	8.000000
+
+# complex left outer join with correlation on LHS
+query IR
+SELECT l, (SELECT SUM(ss1.l[1])+SUM(ss2.l[1]) FROM (SELECT l FROM lists s1 WHERE l=i1.l AND l>ANY(SELECT l FROM lists WHERE l<>s1.l)) ss1 LEFT OUTER JOIN (SELECT l FROM lists s1 WHERE l=ANY(SELECT l FROM lists WHERE l=s1.l)) ss2 ON ss1.l=ss2.l) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	NULL
+[2]	4.000000
+[3]	6.000000
+
+# complex left outer join with correlation on both sides
+query IR
+SELECT l, (SELECT SUM(ss1.l[1])+SUM(ss2.l[1]) FROM (SELECT l FROM lists s1 WHERE l=i1.l AND l>ANY(SELECT l FROM lists WHERE l<>s1.l)) ss1 LEFT OUTER JOIN (SELECT l FROM lists s1 WHERE l<>i1.l OR l=ANY(SELECT l FROM lists WHERE l=s1.l)) ss2 ON ss1.l=ss2.l) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	NULL
+[2]	4.000000
+[3]	6.000000
+
+# test correlated queries with correlated expressions inside FROM clause
+# subquery
+query II
+SELECT l, (SELECT * FROM (SELECT (SELECT 42+i1.l[1])) s1) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	43
+[2]	44
+[3]	45
+
+# cross product
+query II
+SELECT l, (SELECT s1.k+s2.k FROM (SELECT (SELECT 42+i1.l[1]) AS k) s1, (SELECT (SELECT 42+i1.l[1]) AS k) s2) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	86
+[2]	88
+[3]	90
+
+# join
+query II
+SELECT l, (SELECT s1.k+s2.k FROM (SELECT (SELECT 42+i1.l[1]) AS k) s1 LEFT OUTER JOIN (SELECT (SELECT 42+i1.l[1]) AS k) s2 ON s1.k=s2.k) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	86
+[2]	88
+[3]	90
+
+# IN list inside correlated subquery
+query IT
+SELECT l, (SELECT i1.l[1] IN (1, 2, 3, 4, 5, 6, 7, 8)) AS j FROM lists i1 ORDER BY l;
+----
+NULL	NULL
+[1]	1
+[2]	1
+[3]	1
+
+# nested correlated subqueries with multiple aggregate parameters
+query R
+SELECT (SELECT (SELECT COVAR_POP(i1.l[1], i3.l[1]) FROM lists i3) FROM lists i2 LIMIT 1) FROM lists i1 ORDER BY 1
+----
+NULL
+0.000000
+0.000000
+0.000000
+
+query R
+SELECT (SELECT (SELECT COVAR_POP(i2.l[1], i3.l[1]) FROM lists i3) FROM lists i2 LIMIT 1) FROM lists i1 ORDER BY 1
+----
+0.000000
+0.000000
+0.000000
+0.000000
+

--- a/test/sql/subquery/complex/nested_correlated_list.test
+++ b/test/sql/subquery/complex/nested_correlated_list.test
@@ -2,8 +2,8 @@
 # description: Test nested correlated list subqueries
 # group: [complex]
 
-#statement ok
-#PRAGMA enable_verification
+statement ok
+PRAGMA enable_verification
 
 statement ok
 CREATE TABLE lists(l INTEGER[]);

--- a/test/sql/subquery/complex/nested_unnest_subquery.test
+++ b/test/sql/subquery/complex/nested_unnest_subquery.test
@@ -1,0 +1,34 @@
+# name: test/sql/subquery/complex/nested_unnest_subquery.test
+# description: Test nested correlated unnest subqueries
+# group: [complex]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE nested_lists(l INTEGER[][]);
+
+statement ok
+INSERT INTO nested_lists VALUES (ARRAY[ARRAY[0], ARRAY[1]]), (ARRAY[ARRAY[2], ARRAY[NULL, 3]]), (ARRAY[ARRAY[4, 5], ARRAY[6, 7], ARRAY[], ARRAY[8]]), (NULL), (ARRAY[NULL]::INT[][]);
+
+query I
+SELECT UNNEST(l) FROM nested_lists
+----
+[0]
+[1]
+[2]
+[NULL, 3]
+[4, 5]
+[6, 7]
+[]
+[8]
+NULL
+
+query II
+SELECT l, (SELECT SUM(a) FROM (SELECT UNNEST(b) AS a FROM (SELECT UNNEST(l) AS b))) FROM nested_lists ORDER BY l
+----
+NULL	NULL
+[[0], [1]]	1
+[[2], [NULL, 3]]	5
+[[4, 5], [6, 7], [], [8]]	30
+[NULL]	NULL

--- a/test/sql/subquery/scalar/test_correlated_side_effects.test
+++ b/test/sql/subquery/scalar/test_correlated_side_effects.test
@@ -1,0 +1,18 @@
+# name: test/sql/subquery/scalar/test_correlated_side_effects.test
+# description: Test correlated subqueries with side effects
+# group: [scalar]
+
+statement ok
+PRAGMA enable_verification
+
+# FIXME: we should not perform duplicate elimination for subqueries that have side-effects
+
+mode skip
+
+query I
+SELECT COUNT(DISTINCT
+	(SELECT concat(gen_random_uuid()::VARCHAR, r::VARCHAR))
+  ) as total_seats
+FROM (SELECT 1 FROM generate_series(1, 100, 1)) AS t(r)
+----
+100


### PR DESCRIPTION
Fixes #3593

This PR modifies the subquery flattening to avoid the duplicate elimination of correlated columns when they are LIST columns. That is because the duplicate elimination can turn out to be extremely expensive and can lead to quadratic performance (as illustrated in #3593). In this PR we instead opt to add a `row_number() OVER ()` clause to the left-hand side, and use the unique row number of each row to identify the subquery result for each row. This allows us to still perform batch-processing/de-correlation, without resorting to (expensive!) grouping and de-correlation on large lists.

Below are some performance numbers for the query from the issue:

```sql
SELECT
(
  select count(*) as value
  FROM (
    SELECT UNNEST(list(distinct id)) a
  )
)
  as total_seats
FROM (
SELECT gen_random_uuid() id, 1 as val FROM range(0, 1000000)
) as m;

┌──────┬───────┬────────┐
│ Rows │  Old  │  New   │
├──────┼───────┼────────┤
│ 1K   │ 0.02s │ 0.002s │
│ 10K  │ 1.25s │ 0.01s  │
│ 100K │ 124s  │ 0.02s  │
│ 1M   │ T     │ 0.2s   │
│ 10M  │ T     │ 2.3s   │
└──────┴───────┴────────┘
```

As you can see linear performance has been achieved, and the bottleneck has actually been moved to the `LIST(DISTINCT)` computation.
