### PR TITLE
Test query profiler shouldn't output profiling info to the console

### DIFF
--- a/test/api/test_query_profiler.cpp
+++ b/test/api/test_query_profiler.cpp
@@ -15,7 +15,7 @@ TEST_CASE("Test query profiler", "[api]") {
 	con.EnableQueryVerification();
 	con.EnableProfiling();
 	// don't pollute the console with profiler info.
-	con.context -> config.emit_profiler_output = false;
+	con.context->config.emit_profiler_output = false;
 
 	REQUIRE_NO_FAIL(con.Query("SELECT * FROM (SELECT 42) tbl1, (SELECT 33) tbl2"));
 

--- a/test/api/test_query_profiler.cpp
+++ b/test/api/test_query_profiler.cpp
@@ -14,6 +14,8 @@ TEST_CASE("Test query profiler", "[api]") {
 
 	con.EnableQueryVerification();
 	con.EnableProfiling();
+	// don't pollute the console with profiler info.
+	con.context -> config.emit_profiler_output = false;
 
 	REQUIRE_NO_FAIL(con.Query("SELECT * FROM (SELECT 42) tbl1, (SELECT 33) tbl2"));
 


### PR DESCRIPTION
This is a result of the change made in #4009 , where enabling profiling through the connection was made to output to the console by default (making it consistent with the PRAGMA command).