### PR TITLE
[Python] Caching DBInstances and sharing them over multiple connections

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
@@ -141,6 +141,8 @@ public:
 
 private:
 	unique_lock<std::mutex> AcquireConnectionLock();
+	static shared_ptr<DuckDB> GetDBInstance(const string &database, const py::dict &config_dict, bool read_only,
+	                                        bool &new_instance);
 };
 
 } // namespace duckdb

--- a/tools/pythonpkg/tests/fast/test_many_con_same_file.py
+++ b/tools/pythonpkg/tests/fast/test_many_con_same_file.py
@@ -1,0 +1,32 @@
+import duckdb
+import os
+import pytest
+
+class TestManyConnectionSameFile(object):
+
+    def test_multiple_writes(self, duckdb_cursor):
+        con1 = duckdb.connect("test.db")
+        con2 = duckdb.connect("test.db")
+        con1.execute("CREATE TABLE foo1 as SELECT 1 as a, 2 as b")
+        con1.commit()
+        con2.execute("CREATE TABLE bar1 as SELECT 2 as a, 3 as b")
+        con2.commit()
+        con2.close()
+        con1.close()
+        con3 = duckdb.connect("test.db")
+        tbls = con3.execute("select * from information_schema.tables").fetchall()
+        os.remove('test.db') 
+        assert tbls == [(None, 'main', 'foo1', 'BASE TABLE', None, None, None, None, None, 'YES', 'NO', None), (None, 'main', 'bar1', 'BASE TABLE', None, None, None, None, None, 'YES', 'NO', None)]
+
+    def test_diff_config(self, duckdb_cursor):
+        con1 = duckdb.connect("test.db")
+        with pytest.raises(Exception, match="Can't open a connection to same database file with a different configuration than existing connections"):
+            con2 = duckdb.connect("test.db",True)
+        con1.close()
+
+        con1 = duckdb.connect("test.db", config={'default_order': 'desc'})
+
+        with pytest.raises(Exception, match="Can't open a connection to same database file with a different configuration than existing connections"):
+            con2 = duckdb.connect("test.db", config={'default_order': 'asc'})
+            os.remove('test.db') 
+        con2 = duckdb.connect("test.db", config={'default_order': 'desc'})

--- a/tools/pythonpkg/tests/fast/test_many_con_same_file.py
+++ b/tools/pythonpkg/tests/fast/test_many_con_same_file.py
@@ -2,40 +2,39 @@ import duckdb
 import os
 import pytest
 
-class TestManyConnectionSameFile(object):
 
-    def test_multiple_writes(self, duckdb_cursor):
-        con1 = duckdb.connect("test.db")
-        con2 = duckdb.connect("test.db")
-        con1.execute("CREATE TABLE foo1 as SELECT 1 as a, 2 as b")
-        con1.commit()
-        con2.execute("CREATE TABLE bar1 as SELECT 2 as a, 3 as b")
-        con2.commit()
-        con2.close()
-        con1.close()
-        con3 = duckdb.connect("test.db")
-        tbls = con3.execute("select * from information_schema.tables").fetchall()
-        assert tbls == [(None, 'main', 'foo1', 'BASE TABLE', None, None, None, None, None, 'YES', 'NO', None), (None, 'main', 'bar1', 'BASE TABLE', None, None, None, None, None, 'YES', 'NO', None)]
-        con3.close()
-        del con1
-        del con2
-        del con3
-        os.remove('test.db') 
+def test_multiple_writes():
+    con1 = duckdb.connect("test.db")
+    con2 = duckdb.connect("test.db")
+    con1.execute("CREATE TABLE foo1 as SELECT 1 as a, 2 as b")
+    con1.commit()
+    con2.execute("CREATE TABLE bar1 as SELECT 2 as a, 3 as b")
+    con2.commit()
+    con2.close()
+    con1.close()
+    con3 = duckdb.connect("test.db")
+    tbls = con3.execute("select * from information_schema.tables").fetchall()
+    assert tbls == [(None, 'main', 'foo1', 'BASE TABLE', None, None, None, None, None, 'YES', 'NO', None), (None, 'main', 'bar1', 'BASE TABLE', None, None, None, None, None, 'YES', 'NO', None)]
+    con3.close()
+    del con1
+    del con2
+    del con3
+    os.remove('test.db') 
 
-    def test_diff_config(self, duckdb_cursor):
-        con1 = duckdb.connect("test.db")
-        with pytest.raises(Exception, match="Can't open a connection to same database file with a different configuration than existing connections"):
-            con2 = duckdb.connect("test.db",True)
-        con1.close()
-        del con1
+def test_diff_config():
+    con1 = duckdb.connect("test.db")
+    with pytest.raises(Exception, match="Can't open a connection to same database file with a different configuration than existing connections"):
+        con2 = duckdb.connect("test.db",True)
+    con1.close()
+    del con1
 
-        con1 = duckdb.connect("test.db", config={'default_order': 'desc'})
+    con1 = duckdb.connect("test.db", config={'default_order': 'desc'})
 
-        with pytest.raises(Exception, match="Can't open a connection to same database file with a different configuration than existing connections"):
-            con2 = duckdb.connect("test.db", config={'default_order': 'asc'})
-        
-        con2 = duckdb.connect("test.db", config={'default_order': 'desc'})
-        con1.close()
-        con2.close()
-        del con1
-        del con2
+    with pytest.raises(Exception, match="Can't open a connection to same database file with a different configuration than existing connections"):
+        con2 = duckdb.connect("test.db", config={'default_order': 'asc'})
+    
+    con2 = duckdb.connect("test.db", config={'default_order': 'desc'})
+    con1.close()
+    con2.close()
+    del con1
+    del con2

--- a/tools/pythonpkg/tests/fast/test_many_con_same_file.py
+++ b/tools/pythonpkg/tests/fast/test_many_con_same_file.py
@@ -15,18 +15,27 @@ class TestManyConnectionSameFile(object):
         con1.close()
         con3 = duckdb.connect("test.db")
         tbls = con3.execute("select * from information_schema.tables").fetchall()
-        os.remove('test.db') 
         assert tbls == [(None, 'main', 'foo1', 'BASE TABLE', None, None, None, None, None, 'YES', 'NO', None), (None, 'main', 'bar1', 'BASE TABLE', None, None, None, None, None, 'YES', 'NO', None)]
+        con3.close()
+        del con1
+        del con2
+        del con3
+        os.remove('test.db') 
 
     def test_diff_config(self, duckdb_cursor):
         con1 = duckdb.connect("test.db")
         with pytest.raises(Exception, match="Can't open a connection to same database file with a different configuration than existing connections"):
             con2 = duckdb.connect("test.db",True)
         con1.close()
+        del con1
 
         con1 = duckdb.connect("test.db", config={'default_order': 'desc'})
 
         with pytest.raises(Exception, match="Can't open a connection to same database file with a different configuration than existing connections"):
             con2 = duckdb.connect("test.db", config={'default_order': 'asc'})
-            os.remove('test.db') 
+        
         con2 = duckdb.connect("test.db", config={'default_order': 'desc'})
+        con1.close()
+        con2.close()
+        del con1
+        del con2

--- a/tools/pythonpkg/tests/fast/test_many_con_same_file.py
+++ b/tools/pythonpkg/tests/fast/test_many_con_same_file.py
@@ -8,19 +8,18 @@ class TestManyConnectionSameFile(object):
         con1 = duckdb.connect("test.db")
         con2 = duckdb.connect("test.db")
         con1.execute("CREATE TABLE foo1 as SELECT 1 as a, 2 as b")
-        con1.commit()
         con2.execute("CREATE TABLE bar1 as SELECT 2 as a, 3 as b")
-        con2.commit()
         con2.close()
         con1.close()
         con3 = duckdb.connect("test.db")
         tbls = con3.execute("select * from information_schema.tables").fetchall()
-        assert tbls == [(None, 'main', 'foo1', 'BASE TABLE', None, None, None, None, None, 'YES', 'NO', None), (None, 'main', 'bar1', 'BASE TABLE', None, None, None, None, None, 'YES', 'NO', None)]
-        con3.close()
+        assert tbls == [(None, 'main', 'foo1', 'BASE TABLE', None, None, None, None, None, 'YES', 'NO', None), (None, 'main', 'bar1', 'BASE TABLE', None, None, None, None, None, 'YES', 'NO', None)] or tbls == [(None, 'main', 'bar1', 'BASE TABLE', None, None, None, None, None, 'YES', 'NO', None), (None, 'main', 'foo1', 'BASE TABLE', None, None, None, None, None, 'YES', 'NO', None)]
         del con1
         del con2
         del con3
+
         os.remove('test.db') 
+
 
     def test_diff_config(self, duckdb_cursor):
         con1 = duckdb.connect("test.db")


### PR DESCRIPTION
The idea is to cache database instances for connections created over the same db file.
That means that different write connections should be able to connect to a file, with the MVCC taking care of any updates underneath.
The only downside of sharing a database instance is that both connections must have the same configuration, if they have different configurations, then I throw an error.

Fix: #4017 