### PR TITLE
nodejs: use less memory in each

### DIFF
--- a/tools/nodejs/src/statement.cpp
+++ b/tools/nodejs/src/statement.cpp
@@ -288,6 +288,8 @@ struct RunPreparedTask : public Task {
 		case RunType::EACH: {
 			duckdb::idx_t count = 0;
 			while (true) {
+				Napi::HandleScope scope(env);
+
 				auto chunk = result->Fetch();
 				if (!chunk || chunk->size() == 0) {
 					break;


### PR DESCRIPTION
Based on my read of the [node-api documentation](https://github.com/nodejs/node-addon-api/blob/main/doc/object_lifetime_management.md), the previous
implementation of `each` suffered from an issue where the lifetime of
every javascript object created by duckdb was the entire duration of the
call to `each`. This meant that, despite `each`'s supposed streaming
nature, it was not more memory efficient than materializing the entire
result set at once.

This change adds a Napi Scope within the chunk-reading loop, allowing
the javascript objects corresponding to each chunk to be garbage
collected as soon as the next chunk is requested. In a test derived from
`tools/nodejs/test/each.test.js`, iterating over 1,000,000 records
required only 73MB of additional RSS after making this change, down from
230MB.