### PR TITLE
Better handling plus encoding in urls

### DIFF
--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -43,7 +43,17 @@ void HTTPFileSystem::ParseUrl(string &url, string &path_out, string &proto_host_
 	}
 	proto_host_port_out = url.substr(0, slash_pos);
 
-	path_out = url.substr(slash_pos);
+	path_out = "";
+
+	// Encode + as %20
+	for (auto& c: url.substr(slash_pos)) {
+		if (c == '+') {
+			path_out += "%20";
+		} else {
+			path_out += c;
+		}
+	}
+
 	if (path_out.empty()) {
 		throw std::runtime_error("URL needs to contain a path");
 	}

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -43,16 +43,7 @@ void HTTPFileSystem::ParseUrl(string &url, string &path_out, string &proto_host_
 	}
 	proto_host_port_out = url.substr(0, slash_pos);
 
-	path_out = "";
-
-	// Encode + as %20
-	for (auto &c : url.substr(slash_pos)) {
-		if (c == '+') {
-			path_out += "%20";
-		} else {
-			path_out += c;
-		}
-	}
+	path_out = url.substr(slash_pos);
 
 	if (path_out.empty()) {
 		throw std::runtime_error("URL needs to contain a path");

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -46,7 +46,7 @@ void HTTPFileSystem::ParseUrl(string &url, string &path_out, string &proto_host_
 	path_out = "";
 
 	// Encode + as %20
-	for (auto& c: url.substr(slash_pos)) {
+	for (auto &c : url.substr(slash_pos)) {
 		if (c == '+') {
 			path_out += "%20";
 		} else {

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -549,7 +549,7 @@ static string get_full_s3_url(S3AuthParams &auth_params, ParsedS3Url parsed_url)
 	string full_url = parsed_url.http_proto + parsed_url.host;
 
 	// Encode + as %2B and plus as space for S3 urls
-	for(auto& c: parsed_url.path) {
+	for (auto &c : parsed_url.path) {
 		if (c == '+') {
 			full_url += "%2B";
 		} else if (c == ' ') {

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -546,7 +546,18 @@ string S3FileSystem::GetPayloadHash(char *buffer, idx_t buffer_len) {
 }
 
 static string get_full_s3_url(S3AuthParams &auth_params, ParsedS3Url parsed_url) {
-	string full_url = parsed_url.http_proto + parsed_url.host + parsed_url.path;
+	string full_url = parsed_url.http_proto + parsed_url.host;
+
+	// Encode + as %2B and plus as space for S3 urls
+	for(auto& c: parsed_url.path) {
+		if (c == '+') {
+			full_url += "%2B";
+		} else if (c == ' ') {
+			full_url += "+";
+		} else {
+			full_url += c;
+		}
+	}
 
 	if (!parsed_url.query_param.empty()) {
 		full_url += "?" + parsed_url.query_param;

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -553,7 +553,7 @@ static string get_full_s3_url(S3AuthParams &auth_params, ParsedS3Url parsed_url)
 		if (c == '+') {
 			full_url += "%2B";
 		} else if (c == ' ') {
-			full_url += "+";
+			full_url += "%20";
 		} else {
 			full_url += c;
 		}

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -546,18 +546,7 @@ string S3FileSystem::GetPayloadHash(char *buffer, idx_t buffer_len) {
 }
 
 static string get_full_s3_url(S3AuthParams &auth_params, ParsedS3Url parsed_url) {
-	string full_url = parsed_url.http_proto + parsed_url.host;
-
-	// Encode + as %2B and plus as space for S3 urls
-	for (auto &c : parsed_url.path) {
-		if (c == '+') {
-			full_url += "%2B";
-		} else if (c == ' ') {
-			full_url += "%20";
-		} else {
-			full_url += c;
-		}
-	}
+	string full_url = parsed_url.http_proto + parsed_url.host + parsed_url.path;
 
 	if (!parsed_url.query_param.empty()) {
 		full_url += "?" + parsed_url.query_param;

--- a/src/include/duckdb/common/field_writer.hpp
+++ b/src/include/duckdb/common/field_writer.hpp
@@ -199,7 +199,7 @@ public:
 	}
 
 	template <class T, class RETURN_TYPE = unique_ptr<T>, typename... ARGS>
-	RETURN_TYPE ReadSerializable(RETURN_TYPE default_value, ARGS &&... args) {
+	RETURN_TYPE ReadSerializable(RETURN_TYPE default_value, ARGS &&...args) {
 		if (field_count >= max_field_count) {
 			// field is not there, read the default value
 			return default_value;
@@ -221,7 +221,7 @@ public:
 	}
 
 	template <class T, class RETURN_TYPE = unique_ptr<T>, typename... ARGS>
-	RETURN_TYPE ReadRequiredSerializable(ARGS &&... args) {
+	RETURN_TYPE ReadRequiredSerializable(ARGS &&...args) {
 		if (field_count >= max_field_count) {
 			// field is not there, read the default value
 			throw SerializationException("Attempting to read mandatory field, but field is missing");

--- a/test/sql/copy/csv/glob/read_csv_glob_s3.test
+++ b/test/sql/copy/csv/glob/read_csv_glob_s3.test
@@ -126,7 +126,7 @@ SELECT * FROM read_csv('s3://test-bucket/read_csv_glob_s3/glob/f*/f\*.csv', auto
 2019-06-15
 2019-06-25
 
-# TODO: for supporting this we need to url combine s3 url encoding with duckdb pattern matching
+# TODO: for supporting this we need to combine s3 url encoding with duckdb pattern matching
 #query I
 #SELECT * FROM read_csv('s3://test-bucket/read_csv_glob_s3/glob/f2/f[a].csv', auto_detect=1) ORDER BY 1
 #----

--- a/test/sql/copy/parquet/test_parquet_remote.test
+++ b/test/sql/copy/parquet/test_parquet_remote.test
@@ -68,9 +68,17 @@ SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://github.com:44
 9	Jose	Foster	jfoster8@yelp.com
 10	Emily	Stewart	estewart9@opensource.org
 
-# with a + in the path
-query IIII
+statement ok
+SELECT * FROM "http://test-bucket-ceiveran.s3.eu-west-1.amazonaws.com/test+folder/actual%2Bsign.csv"
+
+# Plus in url is a bit special:
+# Since we use + to encode a space (it's internally converted to %20), this will not work
+statement error
 SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://github.com/cwida/duckdb-data/releases/download/v1.0/us+er+da+ta.parquet') LIMIT 10;
+
+# a plus symbol needs to be manually converted to %2B
+query IIII
+SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://github.com/cwida/duckdb-data/releases/download/v1.0/us%2Ber%2Bda%2Bta.parquet') LIMIT 10;
 ----
 1	Amanda	Jordan	ajordan0@com.com
 2	Albert	Freeman	afreeman1@is.gd

--- a/test/sql/copy/parquet/test_parquet_remote.test
+++ b/test/sql/copy/parquet/test_parquet_remote.test
@@ -68,25 +68,12 @@ SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://github.com:44
 9	Jose	Foster	jfoster8@yelp.com
 10	Emily	Stewart	estewart9@opensource.org
 
-statement ok
-SELECT * FROM "http://test-bucket-ceiveran.s3.eu-west-1.amazonaws.com/test+folder/actual%2Bsign.csv"
-
-# Plus in url is a bit special:
-# Since we use + to encode a space (it's internally converted to %20), this will not work
-statement error
-SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://github.com/cwida/duckdb-data/releases/download/v1.0/us+er+da+ta.parquet') LIMIT 10;
-
-# a plus symbol needs to be manually converted to %2B
 query IIII
-SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://github.com/cwida/duckdb-data/releases/download/v1.0/us%2Ber%2Bda%2Bta.parquet') LIMIT 10;
+SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://github.com/cwida/duckdb-data/releases/download/v1.0/us+er+da+ta.parquet') LIMIT 1;
 ----
 1	Amanda	Jordan	ajordan0@com.com
-2	Albert	Freeman	afreeman1@is.gd
-3	Evelyn	Morgan	emorgan2@altervista.org
-4	Denise	Riley	driley3@gmpg.org
-5	Carlos	Burns	cburns4@miitbeian.gov.cn
-6	Kathryn	White	kwhite5@google.com
-7	Samuel	Holmes	sholmes6@foxnews.com
-8	Harry	Howell	hhowell7@eepurl.com
-9	Jose	Foster	jfoster8@yelp.com
-10	Emily	Stewart	estewart9@opensource.org
+
+query IIII
+SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://github.com/cwida/duckdb-data/releases/download/v1.0/us%2Ber%2Bda%2Bta.parquet') LIMIT 1;
+----
+1	Amanda	Jordan	ajordan0@com.com

--- a/test/sql/copy/s3/url_encode.test
+++ b/test/sql/copy/s3/url_encode.test
@@ -1,5 +1,5 @@
 # name: test/sql/copy/s3/url_encode.test
-# description: Url encoding in urls
+# description: S3 Url encoding
 # group: [s3]
 
 require parquet
@@ -19,37 +19,38 @@ CREATE TABLE test_1 as (SELECT 1 FROM range(0,5));
 CREATE TABLE test_2 as (SELECT 2 FROM range(0,5));
 CREATE TABLE test_3 as (SELECT 3 FROM range(0,5));
 
-# Upload nasty files
 statement ok
 COPY test_1 TO 's3://test-bucket-public/url_encode/just because you can doesnt mean you should.parquet' (FORMAT 'parquet');
 
 statement ok
 COPY test_2 TO 's3://test-bucket-public/url_encode/just+dont+use+plus+or+spaces+please.parquet' (FORMAT 'parquet');
 
-# For S3 urls spaces are actually allowed
+# For S3 urls spaces are fine
 query I
 SELECT * FROM "s3://test-bucket-public/url_encode/just because you can doesnt mean you should.parquet" LIMIT 1;
 ----
 1
 
+# In S3 urls, + means a plus symbol
 query I
 SELECT * FROM "s3://test-bucket-public/url_encode/just+dont+use+plus+or+spaces+please.parquet" LIMIT 1;
 ----
 2
 
-# For HTTP URLs we convert + to %20 internally
-query I
-SELECT * FROM "http://test-bucket-public.duckdb-minio.com:9000/url_encode/just+because+you+can+doesnt+mean+you+should.parquet" LIMIT 1;
-----
-1
+# NOTE! For HTTP(s) urls, the + symbol is not encoded by duckdb, leaving it up to the server to decide if it should be interpreted
+# as a space or a plus. In the case of AWS S3, they are interpreted as encoded spaces, however Minio does not
+#query I
+#SELECT * FROM "http://test-bucket-public.duckdb-minio.com:9000/url_encode/just+because+you+can+doesnt+mean+you+should.parquet" LIMIT 1;
+#----
+#1
 
+# For HTTP urls, we also allow regular spaces, which will get encoded to %20 by duckdb
 query I
 SELECT * FROM "http://test-bucket-public.duckdb-minio.com:9000/url_encode/just because you can doesnt mean you should.parquet" LIMIT 1;
 ----
 1
 
-# Note that a plus
+# Note that for HTTP urls actual + symbols need to be encoded to %2B
 query I
 SELECT * FROM "http://test-bucket-public.duckdb-minio.com:9000/url_encode/just%2Bdont%2Buse%2Bplus%2Bor%2Bspaces%2Bplease.parquet" LIMIT 1;
 ----
-2

--- a/test/sql/copy/s3/url_encode.test
+++ b/test/sql/copy/s3/url_encode.test
@@ -1,0 +1,55 @@
+# name: test/sql/copy/s3/url_encode.test
+# description: Url encoding in urls
+# group: [s3]
+
+require parquet
+
+require httpfs
+
+require-env S3_TEST_SERVER_AVAILABLE 1
+
+# override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
+set ignore_error_messages
+
+statement ok
+SET s3_secret_access_key='minio_duckdb_user_password';SET s3_access_key_id='minio_duckdb_user';SET s3_region='eu-west-1'; SET s3_endpoint='duckdb-minio.com:9000';SET s3_use_ssl=false;
+
+statement ok
+CREATE TABLE test_1 as (SELECT 1 FROM range(0,5));
+CREATE TABLE test_2 as (SELECT 2 FROM range(0,5));
+CREATE TABLE test_3 as (SELECT 3 FROM range(0,5));
+
+# Upload nasty files
+statement ok
+COPY test_1 TO 's3://test-bucket-public/url_encode/just because you can doesnt mean you should.parquet' (FORMAT 'parquet');
+
+statement ok
+COPY test_2 TO 's3://test-bucket-public/url_encode/just+dont+use+plus+or+spaces+please.parquet' (FORMAT 'parquet');
+
+# For S3 urls spaces are actually allowed
+query I
+SELECT * FROM "s3://test-bucket-public/url_encode/just because you can doesnt mean you should.parquet" LIMIT 1;
+----
+1
+
+query I
+SELECT * FROM "s3://test-bucket-public/url_encode/just+dont+use+plus+or+spaces+please.parquet" LIMIT 1;
+----
+2
+
+# For HTTP URLs we convert + to %20 internally
+query I
+SELECT * FROM "http://test-bucket-public.duckdb-minio.com:9000/url_encode/just+because+you+can+doesnt+mean+you+should.parquet" LIMIT 1;
+----
+1
+
+query I
+SELECT * FROM "http://test-bucket-public.duckdb-minio.com:9000/url_encode/just because you can doesnt mean you should.parquet" LIMIT 1;
+----
+1
+
+# Note that a plus
+query I
+SELECT * FROM "http://test-bucket-public.duckdb-minio.com:9000/url_encode/just%2Bdont%2Buse%2Bplus%2Bor%2Bspaces%2Bplease.parquet" LIMIT 1;
+----
+2

--- a/test/sql/copy/s3/url_encode.test
+++ b/test/sql/copy/s3/url_encode.test
@@ -50,7 +50,14 @@ SELECT * FROM "http://test-bucket-public.duckdb-minio.com:9000/url_encode/just b
 ----
 1
 
-# Note that for HTTP urls actual + symbols need to be encoded to %2B
+# For HTTP urls from AWS with + symbols, encoding them with %2B is required
 query I
 SELECT * FROM "http://test-bucket-public.duckdb-minio.com:9000/url_encode/just%2Bdont%2Buse%2Bplus%2Bor%2Bspaces%2Bplease.parquet" LIMIT 1;
 ----
+2
+
+# However Minio interprets them as spaces so this works too
+query I
+SELECT * FROM "http://test-bucket-public.duckdb-minio.com:9000/url_encode/just+dont+use+plus+or+spaces+please.parquet" LIMIT 1;
+----
+2

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -2050,7 +2050,7 @@ inline std::string encode_url(const std::string &s) {
 	for (size_t i = 0; s[i]; i++) {
 		switch (s[i]) {
 		case ' ': result += "%20"; break;
-		case '+': result += "%2B"; break;
+//		case '+': result += "%2B"; break;
 		case '\r': result += "%0D"; break;
 		case '\n': result += "%0A"; break;
 		case '\'': result += "%27"; break;
@@ -2096,7 +2096,12 @@ inline std::string decode_url(const std::string &s,
 				int val = 0;
 				if (from_hex_to_i(s, i + 1, 2, val)) {
 					// 2 digits hex codes
-					result += static_cast<char>(val);
+					if (static_cast<char>(val) == '+'){
+						// We don't decode +
+						result += "%2B";
+					} else {
+						result += static_cast<char>(val);
+					}
 					i += 2; // '00'
 				} else {
 					result += s[i];

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -2050,7 +2050,7 @@ inline std::string encode_url(const std::string &s) {
 	for (size_t i = 0; s[i]; i++) {
 		switch (s[i]) {
 		case ' ': result += "%20"; break;
-		//case '+': result += "%2B"; break;
+		case '+': result += "%2B"; break;
 		case '\r': result += "%0D"; break;
 		case '\n': result += "%0A"; break;
 		case '\'': result += "%27"; break;
@@ -3695,7 +3695,7 @@ inline void parse_query_text(const std::string &s, Params &params) {
 		});
 
 		if (!key.empty()) {
-			params.emplace(decode_url(key, true), decode_url(val, true));
+			params.emplace(decode_url(key, true), decode_url(val, false));
 		}
 	});
 }
@@ -6072,7 +6072,7 @@ inline bool ClientImpl::redirect(Request &req, Response &res, Error &error) {
 		return false;
 	}
 
-	auto location = detail::decode_url(res.get_header_value("location"), true);
+	auto location = detail::decode_url(res.get_header_value("location"), false);
 	if (location.empty()) { return false; }
 
 	const static Regex re(

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -6072,7 +6072,7 @@ inline bool ClientImpl::redirect(Request &req, Response &res, Error &error) {
 		return false;
 	}
 
-	auto location = detail::decode_url(res.get_header_value("location"), false);
+	auto location = detail::decode_url(res.get_header_value("location"), true);
 	if (location.empty()) { return false; }
 
 	const static Regex re(

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -2050,7 +2050,7 @@ inline std::string encode_url(const std::string &s) {
 	for (size_t i = 0; s[i]; i++) {
 		switch (s[i]) {
 		case ' ': result += "%20"; break;
-		case '+': result += "%2B"; break;
+		//case '+': result += "%2B"; break;
 		case '\r': result += "%0D"; break;
 		case '\n': result += "%0A"; break;
 		case '\'': result += "%27"; break;

--- a/tools/rpkg/src/relational.cpp
+++ b/tools/rpkg/src/relational.cpp
@@ -26,7 +26,7 @@ using namespace duckdb;
 using namespace cpp11;
 
 template <typename T, typename... Args>
-external_pointer<T> make_external(const string &rclass, Args &&... args) {
+external_pointer<T> make_external(const string &rclass, Args &&...args) {
 	auto extptr = external_pointer<T>(new T(std::forward<Args>(args)...));
 	((sexp)extptr).attr("class") = rclass;
 	return (extptr);


### PR DESCRIPTION
This PR fixes #3938 by handling + encoding a bit more nicely. Previously the plus symbol would always get encoded to %2B by httplib, this is problematic because in AWS S3 the plus symbol is used to encode a space to make the urls look nicer.

With these changes, we no longer encode the plus sign at all, basically leaving it to the server to figure out what it should mean. This is preferable over encoding the plus symbol manually in duckdb because not everyone agrees on what the plus should mean.

Now duckdb should properly handle a AWS S3 url such as:
`https://bucket.eu-west-1.amazonaws.com/test+folder+with+spaces/actual%2Bplus%2Bsigns.csv`

Also we can now handle github urls which don't interpret the plus symbol as spaces (the file contains + not space):
`https://github.com/cwida/duckdb-data/releases/download/v1.0/us+er+da+ta.parquet`