### PR TITLE
Improve error messages of extension install

### DIFF
--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/common/gzip_file_system.hpp"
 #include "duckdb/common/types/uuid.hpp"
+#include "duckdb/common/string_util.hpp"
 
 #ifndef DISABLE_DUCKDB_REMOTE_INSTALL
 #include "httplib.hpp"
@@ -107,8 +108,24 @@ void ExtensionHelper::InstallExtension(DatabaseInstance &db, const string &exten
 	                                                                     DuckDB::SourceID(), DuckDB::Platform())}};
 
 	auto res = cli.Get(url_local_part.c_str(), headers);
+	//	const vector<string> &strings, const string &target
 	if (!res || res->status != 200) {
-		throw IOException("Failed to download extension %s%s", url_base, url_local_part);
+		// create suggestions
+		vector<string> candidates;
+		for (idx_t ext_count = ExtensionHelper::DefaultExtensionCount(), i = 0; i < ext_count; i++) {
+			candidates.push_back(ExtensionHelper::GetDefaultExtension(i).name);
+		}
+		auto closest_extensions = StringUtil::TopNLevenshtein(candidates, extension_name);
+		auto message = StringUtil::CandidatesMessage(closest_extensions, "Candidate extensions");
+		for (auto &closest : closest_extensions) {
+			if (closest == extension_name) {
+				message = "Extension \"" + extension_name + "\" is an existing extension.\n";
+				message += "Are you using a development build? In this case, libraries might not (yet) be uploaded.";
+				break;
+			}
+		}
+		throw IOException("Failed to download extension \"%s\" at URL \"%s%s\"\n%s", extension_name, url_base,
+		                  url_local_part, message);
 	}
 	auto decompressed_body = GZipFileSystem::UncompressGZIPString(res->body);
 	std::ofstream out(temp_path, std::ios::binary);

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -120,7 +120,7 @@ void ExtensionHelper::InstallExtension(DatabaseInstance &db, const string &exten
 		for (auto &closest : closest_extensions) {
 			if (closest == extension_name) {
 				message = "Extension \"" + extension_name + "\" is an existing extension.\n";
-				message += "Are you using a development build? In this case, libraries might not (yet) be uploaded.";
+				message += "Are you using a development build? In this case, extensions might not (yet) be uploaded.";
 				break;
 			}
 		}

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -108,7 +108,7 @@ void ExtensionHelper::InstallExtension(DatabaseInstance &db, const string &exten
 	                                                                     DuckDB::SourceID(), DuckDB::Platform())}};
 
 	auto res = cli.Get(url_local_part.c_str(), headers);
-	//	const vector<string> &strings, const string &target
+
 	if (!res || res->status != 200) {
 		// create suggestions
 		vector<string> candidates;

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -113,7 +113,7 @@ void ExtensionHelper::InstallExtension(DatabaseInstance &db, const string &exten
 		// create suggestions
 		vector<string> candidates;
 		for (idx_t ext_count = ExtensionHelper::DefaultExtensionCount(), i = 0; i < ext_count; i++) {
-			candidates.push_back(ExtensionHelper::GetDefaultExtension(i).name);
+			candidates.emplace_back(ExtensionHelper::GetDefaultExtension(i).name);
 		}
 		auto closest_extensions = StringUtil::TopNLevenshtein(candidates, extension_name);
 		auto message = StringUtil::CandidatesMessage(closest_extensions, "Candidate extensions");


### PR DESCRIPTION
e.g.:

```sql
D install https;
Error: IO Error: Failed to download extension "https" at URL "http://extensions.duckdb.org/cdbc688c1/osx_arm64/https.duckdb_extension.gz"

Candidate extensions: "httpfs", "fts", "tpch", "tpcds", "icu"
```

```sql
D install httpfs;
Error: IO Error: Failed to download extension "httpfs" at URL "http://extensions.duckdb.org/cdbc688c1/osx_arm64/httpfs.duckdb_extension.gz"
Extension "httpfs" is an existing extension.
Are you using a development build? In this case, libraries might not (yet) be uploaded.
```