### PR TITLE
Add mechanism to ingest Arrow data via the JDBC driver.

### DIFF
--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBArrayStreamWrapper.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBArrayStreamWrapper.java
@@ -1,0 +1,6 @@
+package org.duckdb;
+
+public interface DuckDBArrayStreamWrapper {
+  void exportArrayStream(long arrowArrayStreamPointer);
+  void exportSchema(long arrowSchemaPointer);
+}

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBConnection.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBConnection.java
@@ -1,6 +1,7 @@
 package org.duckdb;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.sql.Array;
 import java.sql.Blob;
 import java.sql.CallableStatement;
@@ -339,5 +340,12 @@ public class DuckDBConnection implements java.sql.Connection {
 
 	public DuckDBAppender createAppender(String schemaName, String tableName) throws SQLException {
 		return new DuckDBAppender(this, schemaName, tableName);
+	}
+
+	public void ingestArrowTable(String schemaName, String tableName, DuckDBArrayStreamWrapper arrayStreamWrapper) throws SQLException {
+		byte[] schemaNameBytes = schemaName.getBytes(StandardCharsets.UTF_8);
+		byte[] tableNameBytes = tableName.getBytes(StandardCharsets.UTF_8);
+
+		DuckDBNative.duckdb_jdbc_ingest_arrow_table(conn_ref, schemaNameBytes, tableNameBytes, arrayStreamWrapper);
 	}
 }

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBNative.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBNative.java
@@ -118,4 +118,6 @@ public class DuckDBNative {
 	protected static native void duckdb_jdbc_appender_append_string(ByteBuffer appender_ref, byte[] value) throws SQLException;
 
 	protected static native void duckdb_jdbc_appender_append_null(ByteBuffer appender_ref) throws SQLException;
+
+	protected static native void duckdb_jdbc_ingest_arrow_table(ByteBuffer conn_ref, byte[] schema_name, byte[] table_name, DuckDBArrayStreamWrapper array_stream_wrapper) throws SQLException;
 }


### PR DESCRIPTION
Arrow's next release should include the ability to export an ArrowReader as a C data interface
ArrowArrayStream.  [PR](https://github.com/apache/arrow/pull/13465) / [JIRA](https://issues.apache.org/jira/browse/ARROW-16913)


With this it should be possible to implement the DuckDBArrayStreamWrapper interface
to ingest arrow data from java. 

This approach does not rely on any external dependencies and therefore a client will theoretically have
to implement the DuckDBArrayStreamInterface to use this.

The implementation is trivial, but might be nicer to support ingesting an ArrowReader instead.

Otherwise, this implementation tries to mirror the WASM / Python implementation.

Few TODOS: 
- [x] arrow actually has to release the updated ArrowArrayStream importer / exporter for java this for it to be useful. (though because duckdb-jdbc doesn't actually depend on it, it doesn't matter). 
- [ ] determine if it is worth figuring out how to include the arrow IPC pieces in the JDBC driver
- [ ] testing (somewhat challenging given a lack of bundled arrow c-data interface, but anything that fills an ArrowArrayStream could do)
- [ ] finding a home for JavaArrowStreamFactory that isn't just in the JNI/duckdb_java.cpp file. 
- [ ] determine what batch size makes sense (I copied what the python one was doing -- I think)
- [x] not all timestamp vectors are supported. After ingesting a TimestampMilis Vector extracting data via JDBC fails to deserialize the timestamp vector. 


Maybe you could say that this would solve https://github.com/duckdb/duckdb/issues/3489, but its currently closed 🙂 