### PR TITLE
JDBC Change getTimestamp to throw an error for wrong data types

### DIFF
--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
@@ -476,7 +476,9 @@ public class DuckDBResultSet implements ResultSet {
 		if (isType(columnIndex, DuckDBColumnType.TIMESTAMP)) {
 			return DuckDBTimestamp.toSqlTimestamp(getbuf(columnIndex, 8).getLong());
 		}
-		return null;
+
+		Object o = getObject(columnIndex);
+		return Timestamp.valueOf(o.toString());
 	}
 
 	private LocalDateTime getLocalDateTime(int columnIndex) throws SQLException {
@@ -486,7 +488,8 @@ public class DuckDBResultSet implements ResultSet {
 		if (isType(columnIndex, DuckDBColumnType.TIMESTAMP)) {
 			return DuckDBTimestamp.toLocalDateTime(getbuf(columnIndex, 8).getLong());
 		}
-		return null;
+		Object o = getObject(columnIndex);
+		return LocalDateTime.parse(o.toString());
 	}
 
 	private OffsetDateTime getOffsetDateTime(int columnIndex) throws SQLException {
@@ -496,7 +499,9 @@ public class DuckDBResultSet implements ResultSet {
 		if (isType(columnIndex, DuckDBColumnType.TIMESTAMP_WITH_TIME_ZONE)) {
 			return DuckDBTimestamp.toOffsetDateTime(getbuf(columnIndex, 8).getLong());
 		}
-		return null;
+
+		Object o = getObject(columnIndex);
+		return OffsetDateTime.parse(o.toString());
 	}
 
 	static class DuckDBBlobResult implements Blob {

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -398,7 +398,7 @@ public class TestDuckDBJDBC {
 			rs.getTimestamp(2);
 			fail();
 		}
-		catch (SQLException e) {
+		catch (IllegalArgumentException e) {
 		}
 
 		rs.close();

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -383,6 +383,29 @@ public class TestDuckDBJDBC {
 		conn.close();
 	}
 
+	public static void test_throw_wrong_datatype() throws Exception {
+		Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+		Statement stmt = conn.createStatement();
+		ResultSet rs;
+
+		stmt.execute("CREATE TABLE t (id INT, t1 TIMESTAMPTZ, t2 TIMESTAMP)");
+		stmt.execute("INSERT INTO t (id, t1, t2) VALUES (1, '2022-01-01T12:11:10+02', '2022-01-01T12:11:10')");
+
+		rs = stmt.executeQuery("SELECT * FROM t");
+		rs.next();
+
+		try {
+			rs.getTimestamp(2);
+			fail();
+		}
+		catch (SQLException e) {
+		}
+
+		rs.close();
+		stmt.close();
+		conn.close();
+	}
+
 	public static void test_result() throws Exception {
 		Connection conn = DriverManager.getConnection("jdbc:duckdb:");
 		Statement stmt = conn.createStatement();


### PR DESCRIPTION
PR for #4078 to align getTimestamp behavior to the other getXXX methods.

Try to create the Timestamp from the returned object via toString() and throw an error if it is not possible.

