### PR TITLE
Support Parquet's `RLE_DICTIONARY` encoding for string columns

### DIFF
--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -366,16 +366,16 @@ protected:
 	virtual void FlushDictionary(BasicColumnWriterState &state, ColumnWriterStatistics *stats);
 
 	void SetParquetStatistics(BasicColumnWriterState &state, duckdb_parquet::format::ColumnChunk &column);
-	void registerToRowGroup(duckdb_parquet::format::RowGroup &row_group);
+	void RegisterToRowGroup(duckdb_parquet::format::RowGroup &row_group);
 };
 
 unique_ptr<ColumnWriterState> BasicColumnWriter::InitializeWriteState(duckdb_parquet::format::RowGroup &row_group) {
 	auto result = make_unique<BasicColumnWriterState>(row_group, row_group.columns.size());
-	registerToRowGroup(row_group);
+	RegisterToRowGroup(row_group);
 	return move(result);
 }
 
-void BasicColumnWriter::registerToRowGroup(duckdb_parquet::format::RowGroup &row_group) {
+void BasicColumnWriter::RegisterToRowGroup(duckdb_parquet::format::RowGroup &row_group) {
 	format::ColumnChunk column_chunk;
 	column_chunk.__isset.meta_data = true;
 	column_chunk.meta_data.codec = writer.codec;
@@ -1180,7 +1180,7 @@ public:
 
 	unique_ptr<ColumnWriterState> InitializeWriteState(duckdb_parquet::format::RowGroup &row_group) override {
 		auto result = make_unique<StringColumnWriterState>(row_group, row_group.columns.size());
-		registerToRowGroup(row_group);
+		RegisterToRowGroup(row_group);
 		return move(result);
 	}
 

--- a/extension/parquet/include/column_writer.hpp
+++ b/extension/parquet/include/column_writer.hpp
@@ -61,6 +61,21 @@ public:
 	                                                      bool can_have_nulls = true);
 
 	virtual unique_ptr<ColumnWriterState> InitializeWriteState(duckdb_parquet::format::RowGroup &row_group) = 0;
+
+	//! indicates whether the write need to analyse the data before preparing it
+	virtual bool HasAnalyze() {
+		return false;
+	}
+
+	virtual void Analyze(ColumnWriterState &state, ColumnWriterState *parent, Vector &vector, idx_t count) {
+		throw NotImplementedException("Writer does not need analysis");
+	}
+
+	//! Called after all data has been passed to Analyze
+	virtual void FinalizeAnalyze(ColumnWriterState &state) {
+		throw NotImplementedException("Writer does not need analysis");
+	}
+
 	virtual void Prepare(ColumnWriterState &state, ColumnWriterState *parent, Vector &vector, idx_t count) = 0;
 
 	virtual void BeginWrite(ColumnWriterState &state) = 0;

--- a/test/sql/copy/parquet/writer/parquet_write_strings.test
+++ b/test/sql/copy/parquet/writer/parquet_write_strings.test
@@ -18,7 +18,7 @@ INSERT INTO strings VALUES
     ('happy'), ('happy'), ('joy'), ('joy'),
     ('happy'), ('happy'), ('joy'), ('joy'),
     ('happy'), ('happy'), ('joy'), ('joy'),
-    ('happy'), ('happy'), ('joy'), ('joy'), ('joy')
+    ('happy'), ('happy'), ('joy'), ('joy'), ('surprise')
 
 statement ok
 COPY strings TO '__TEST_DIR__/strings.parquet' (FORMAT PARQUET);
@@ -54,7 +54,7 @@ happy
 happy
 joy
 joy
-joy
+surprise
 
 # strings with null values
 statement ok
@@ -94,7 +94,7 @@ happy
 happy
 NULL
 NULL
-NULL
+surprise
 
 # all values are null
 statement ok

--- a/test/sql/copy/parquet/writer/parquet_write_strings.test
+++ b/test/sql/copy/parquet/writer/parquet_write_strings.test
@@ -1,0 +1,137 @@
+# name: test/sql/copy/parquet/writer/parquet_write_strings.test
+# description: Strings tests
+# group: [writer]
+
+require parquet
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE strings(s VARCHAR);
+
+statement ok
+INSERT INTO strings VALUES
+	('happy'), ('happy'), ('joy'), ('joy'),
+	('happy'), ('happy'), ('joy'), ('joy'),
+    ('happy'), ('happy'), ('joy'), ('joy'),
+    ('happy'), ('happy'), ('joy'), ('joy'),
+    ('happy'), ('happy'), ('joy'), ('joy'),
+    ('happy'), ('happy'), ('joy'), ('joy'),
+    ('happy'), ('happy'), ('joy'), ('joy'), ('joy')
+
+statement ok
+COPY strings TO '__TEST_DIR__/strings.parquet' (FORMAT PARQUET);
+
+query I
+SELECT * FROM '__TEST_DIR__/strings.parquet'
+----
+happy
+happy
+joy
+joy
+happy
+happy
+joy
+joy
+happy
+happy
+joy
+joy
+happy
+happy
+joy
+joy
+happy
+happy
+joy
+joy
+happy
+happy
+joy
+joy
+happy
+happy
+joy
+joy
+joy
+
+# strings with null values
+statement ok
+UPDATE strings SET s=NULL WHERE s='joy'
+
+statement ok
+COPY strings TO '__TEST_DIR__/strings.parquet' (FORMAT PARQUET);
+
+query I
+SELECT * FROM '__TEST_DIR__/strings.parquet'
+----
+happy
+happy
+NULL
+NULL
+happy
+happy
+NULL
+NULL
+happy
+happy
+NULL
+NULL
+happy
+happy
+NULL
+NULL
+happy
+happy
+NULL
+NULL
+happy
+happy
+NULL
+NULL
+happy
+happy
+NULL
+NULL
+NULL
+
+# all values are null
+statement ok
+UPDATE strings SET s=NULL
+
+statement ok
+COPY strings TO '__TEST_DIR__/strings.parquet' (FORMAT PARQUET);
+
+query I
+SELECT * FROM '__TEST_DIR__/strings.parquet'
+----
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL

--- a/test/sql/copy/parquet/writer/parquet_write_strings.test
+++ b/test/sql/copy/parquet/writer/parquet_write_strings.test
@@ -135,3 +135,109 @@ NULL
 NULL
 NULL
 NULL
+
+# empty table
+statement ok
+DELETE FROM strings
+
+statement ok
+COPY strings TO '__TEST_DIR__/strings.parquet' (FORMAT PARQUET);
+
+query I
+SELECT * FROM '__TEST_DIR__/strings.parquet'
+----
+
+
+# non-dictionary table
+statement ok
+DELETE FROM strings
+
+statement ok
+INSERT INTO strings VALUES
+	('0'), ('1'), ('2'), ('3'), ('4'), ('5'), ('6'), ('7'), ('8'), ('9'),
+	('10'), ('11'), ('12'), ('13'), ('14'), ('15'), ('16'), ('17'), ('18'), ('19'),
+	('20'), ('21'), ('22'), ('23'), ('24'), ('25'), ('26'), ('27'), ('28'), ('29')
+
+statement ok
+COPY strings TO '__TEST_DIR__/strings.parquet' (FORMAT PARQUET);
+
+query I
+SELECT * FROM '__TEST_DIR__/strings.parquet'
+----
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+17
+18
+19
+20
+21
+22
+23
+24
+25
+26
+27
+28
+29
+
+# non-dictionary table with null
+statement ok
+DELETE FROM strings
+
+statement ok
+INSERT INTO strings VALUES
+	('0'), ('1'), ('2'), (NULL), ('4'), ('5'), ('6'), (NULL), ('8'), ('9'),
+	('10'), ('11'), ('12'), ('13'), ('14'), ('15'), ('16'), ('17'), ('18'), ('19'),
+	('20'), (NULL), ('22'), ('23'), ('24'), ('25'), (NULL), ('27'), ('28'), ('29')
+
+statement ok
+COPY strings TO '__TEST_DIR__/strings.parquet' (FORMAT PARQUET);
+
+query I
+SELECT * FROM '__TEST_DIR__/strings.parquet'
+----
+0
+1
+2
+NULL
+4
+5
+6
+NULL
+8
+9
+10
+11
+12
+13
+14
+15
+16
+17
+18
+19
+20
+NULL
+22
+23
+24
+25
+NULL
+27
+28
+29


### PR DESCRIPTION
Currently, we always write `VARCHAR` columns in `PLAIN` format, i.e., each value is written in sequence. This is highly likely to be inefficient as values repeat themselves. This PR implements Parquet's `RLE_DICTIONARY` encoding, which first writes the distinct values into a dictionary page and then refers to them using a numeric index in the value pages.

In order to build the value dictionary, a pre-flight pass on the data is needed. This is achieved by adding a new "Analyze" phase to the `ColumnWriter` class, which writers can optionally implement. 

Relates to #3316