### PR TITLE
(Hopefully) fix signing extension signing on master

### DIFF
--- a/scripts/extension-upload.sh
+++ b/scripts/extension-upload.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo $DUCKDB_EXTENSION_SIGNING_PK > private.pem
+echo "$DUCKDB_EXTENSION_SIGNING_PK" > private.pem
 
 FILES="build/release/extension/*/*.duckdb_extension"
 for f in $FILES


### PR DESCRIPTION
@hannes I think we need quotes here because without them, the scripts removes the newlines and openssl really wants its newlines. Also: the variables in GH secrets should contain these newlines so you may want to double check that before merging this