### PR TITLE
[Python] `project` now correctly inherits owning references to PyObjects

### DIFF
--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -199,7 +199,9 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromArrow(py::object &arrow_objec
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Project(const string &expr) {
-	return make_unique<DuckDBPyRelation>(rel->Project(expr));
+	auto projected_relation = make_unique<DuckDBPyRelation>(rel->Project(expr));
+	projected_relation->rel->extra_dependencies = this->rel->extra_dependencies;
+	return move(projected_relation);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::ProjectDf(const py::object &df, const string &expr,


### PR DESCRIPTION
This PR fixes the issue addressed in #4025 

Previously we were not inheriting external dependencies in DuckDBPyRelation::Project

Because of this, chaining creation method + project together caused a segmentation fault because we were trying to access pyobjects that had already been destroyed.