### PR TITLE
Making date_trunc statistics handling consistent with date_part

### DIFF
--- a/src/function/scalar/date/date_trunc.cpp
+++ b/src/function/scalar/date/date_trunc.cpp
@@ -601,7 +601,7 @@ static unique_ptr<BaseStatistics> DateTruncStatistics(vector<unique_ptr<BaseStat
 	auto min = nstats.min.GetValueUnsafe<TA>();
 	auto max = nstats.max.GetValueUnsafe<TA>();
 	if (min > max) {
-		throw InternalException("Invalid DATETRUNC child statistics");
+		return nullptr;
 	}
 
 	// Infinite values are unmodified

--- a/test/sql/function/date/date_trunc_stats.test
+++ b/test/sql/function/date/date_trunc_stats.test
@@ -1,0 +1,12 @@
+# name: test/sql/function/date/date_trunc_stats.test
+# description: Test date part stats on empty table
+# group: [date]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE table T1(A0 TIMESTAMP)
+
+statement ok
+SELECT date_trunc('DAY', A0) FROM T1


### PR DESCRIPTION
Should fix https://github.com/duckdb/duckdb/issues/4128, this time for real