### PR TITLE
node: don't crash on syntax errors

### DIFF
--- a/tools/nodejs/src/connection.cpp
+++ b/tools/nodejs/src/connection.cpp
@@ -321,19 +321,25 @@ struct ExecTask : public Task {
 		auto &connection = Get<Connection>();
 
 		success = true;
-		auto statements = connection.connection->ExtractStatements(sql);
-		if (statements.empty()) {
-			return;
-		}
-
-		// thanks Mark
-		for (duckdb::idx_t i = 0; i < statements.size(); i++) {
-			auto res = connection.connection->Query(move(statements[i]));
-			if (!res->success) {
-				success = false;
-				error = res->error;
-				break;
+		try {
+			auto statements = connection.connection->ExtractStatements(sql);
+			if (statements.empty()) {
+				return;
 			}
+
+			// thanks Mark
+			for (duckdb::idx_t i = 0; i < statements.size(); i++) {
+				auto res = connection.connection->Query(move(statements[i]));
+				if (!res->success) {
+					success = false;
+					error = res->error;
+					break;
+				}
+			}
+		} catch (duckdb::ParserException &e) {
+			success = false;
+			error = e.what();
+			return;
 		}
 	}
 

--- a/tools/nodejs/test/syntax_error.test.js
+++ b/tools/nodejs/test/syntax_error.test.js
@@ -1,0 +1,16 @@
+var duckdb = require('..');
+var assert = require('assert');
+
+describe('exec', function() {
+    var db;
+    before(function(done) {
+        db = new duckdb.Database(':memory:', done);
+    });
+
+    it("doesn't crash on a syntax error", function(done) {
+        db.exec("syntax error", function(err) {
+            assert.notEqual(err, null, "Expected an error")
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Fixes #3979 