### PR TITLE
Fix #4165: correctly fill in false_sel when performing comparison with constant null value

### DIFF
--- a/src/include/duckdb/common/vector_operations/binary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/binary_executor.hpp
@@ -387,9 +387,19 @@ public:
 		auto rdata = FlatVector::GetData<RIGHT_TYPE>(right);
 
 		if (LEFT_CONSTANT && ConstantVector::IsNull(left)) {
+			if (false_sel) {
+				for (idx_t i = 0; i < count; i++) {
+					false_sel->set_index(i, sel->get_index(i));
+				}
+			}
 			return 0;
 		}
 		if (RIGHT_CONSTANT && ConstantVector::IsNull(right)) {
+			if (false_sel) {
+				for (idx_t i = 0; i < count; i++) {
+					false_sel->set_index(i, sel->get_index(i));
+				}
+			}
 			return 0;
 		}
 

--- a/test/issues/general/test_4165.test
+++ b/test/issues/general/test_4165.test
@@ -3,13 +3,16 @@
 # group: [general]
 
 statement ok
+SELECT setseed(0.42);
+
+statement ok
 CREATE TABLE df_a AS
 SELECT
     (100000 + (899999 * RANDOM()))::BIGINT AS ID,
     (4000 * RANDOM())::BIGINT AS C,
     (4000 * RANDOM())::BIGINT AS P,
     substring('abc', 1+(RANDOM() * 2)::BIGINT, 1) AS S
-FROM range(80000)
+FROM range(20000)
 
 statement ok
 CREATE TABLE df_b AS

--- a/test/issues/general/test_4165.test
+++ b/test/issues/general/test_4165.test
@@ -1,0 +1,31 @@
+# name: test/issues/general/test_4165.test
+# description: Issue 4165: SIGSEGV on Debian Buster amd64
+# group: [general]
+
+statement ok
+CREATE TABLE df_a AS
+SELECT
+    (100000 + (899999 * RANDOM()))::BIGINT AS ID,
+    (4000 * RANDOM())::BIGINT AS C,
+    (4000 * RANDOM())::BIGINT AS P,
+    substring('abc', 1+(RANDOM() * 2)::BIGINT, 1) AS S
+FROM range(80000)
+
+statement ok
+CREATE TABLE df_b AS
+SELECT * FROM df_a WHERE S='a'
+
+statement ok
+select
+       Case
+           when try_cast(b.c as real) is null
+                and a.s = 'b' then a.p
+           when try_cast(b.c as real) is not null
+                and a.s = 'b'
+                and try_cast(b.c as real) < try_cast(a.p as real)
+                then try_cast(a.p as real)
+           else 0
+       END
+from df_a a
+left join df_b b on Cast(a.ID as real) = cast(b.ID as real)
+left join df_b c on a.ID = c.ID;


### PR DESCRIPTION
Fixes #4165

This issue pops up in the query because there are constant null values generated by the left join. The `false_sel` used to not be filled in which leads to accessing uninitialized memory in the false_sel, which results in potential out-of-bounds accesses.