### PR TITLE
node: report memory usage to the node GC

### DIFF
--- a/tools/nodejs/src/database.cpp
+++ b/tools/nodejs/src/database.cpp
@@ -1,4 +1,5 @@
 #include "duckdb_node.hpp"
+#include "napi.h"
 #include "parquet-amalgamation.hpp"
 
 namespace node_duckdb {
@@ -86,7 +87,8 @@ struct OpenTask : public Task {
 	bool success = false;
 };
 
-Database::Database(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Database>(info), task_inflight(false) {
+Database::Database(const Napi::CallbackInfo &info)
+    : Napi::ObjectWrap<Database>(info), task_inflight(false), env(info.Env()) {
 	auto env = info.Env();
 
 	if (info.Length() < 1 || !info[0].IsString()) {
@@ -119,6 +121,10 @@ Database::Database(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Database>(
 	Schedule(env, duckdb::make_unique<OpenTask>(*this, filename, access_mode, config, callback));
 }
 
+Database::~Database() {
+	Napi::MemoryManagement::AdjustExternalMemory(env, -bytes_allocated);
+}
+
 void Database::Schedule(Napi::Env env, std::unique_ptr<Task> task) {
 	{
 		std::lock_guard<std::mutex> lock(task_mutex);
@@ -146,6 +152,16 @@ void Database::TaskComplete(Napi::Env env) {
 		task_inflight = false;
 	}
 	Process(env);
+
+	if (database) {
+		// Bookkeeping: tell node (and the node GC in particular) how much
+		// memory we're using, such that it can make better decisions on when to
+		// trigger collections.
+		auto &buffer_manager = duckdb::BufferManager::GetBufferManager(*database->instance);
+		auto current_bytes = buffer_manager.GetUsedMemory();
+		Napi::MemoryManagement::AdjustExternalMemory(env, current_bytes - bytes_allocated);
+		bytes_allocated = current_bytes;
+	}
 }
 
 void Database::Process(Napi::Env env) {

--- a/tools/nodejs/src/duckdb_node.hpp
+++ b/tools/nodejs/src/duckdb_node.hpp
@@ -41,6 +41,7 @@ class Connection;
 class Database : public Napi::ObjectWrap<Database> {
 public:
 	explicit Database(const Napi::CallbackInfo &info);
+	~Database() override;
 	static Napi::Object Init(Napi::Env env, Napi::Object exports);
 	void Process(Napi::Env env);
 	void TaskComplete(Napi::Env env);
@@ -76,6 +77,8 @@ private:
 	std::mutex task_mutex;
 	bool task_inflight;
 	static Napi::FunctionReference constructor;
+	Napi::Env env;
+	int64_t bytes_allocated = 0;
 };
 
 struct JSArgs;


### PR DESCRIPTION
Previously, the node garbage collector had no sense of how much memory
would be freed by freeing duckdb's C++ / napi objects, and therefore did
so extremely infrequently. This caused memory usage to balloon and
shrink in an extreme sawtooth pattern.

With this change, we track how much memory is used by each database
object, and publish diffs of that usage to the node GC. This gives it a
better sense of when to GC, keeping memory usage consistently much
lower.