### PR TITLE
Issue #4134: Mixed Streaming Window

### DIFF
--- a/src/execution/physical_plan/plan_window.cpp
+++ b/src/execution/physical_plan/plan_window.cpp
@@ -44,18 +44,21 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalWindow &op
 	types.resize(output_idx);
 
 	// Identify streaming windows
-	vector<idx_t> window_expressions;
-	bool process_streaming = true;
+	vector<idx_t> blocking_windows;
+	vector<idx_t> streaming_windows;
 	for (idx_t expr_idx = 0; expr_idx < op.expressions.size(); expr_idx++) {
-		window_expressions.push_back(expr_idx);
-		if (!IsStreamingWindow(op.expressions[expr_idx])) {
-			process_streaming = false;
+		if (IsStreamingWindow(op.expressions[expr_idx])) {
+			streaming_windows.push_back(expr_idx);
+		} else {
+			blocking_windows.push_back(expr_idx);
 		}
 	}
+
 	// Process the window functions by sharing the partition/order definitions
 	vector<idx_t> evaluation_order;
-	while (!window_expressions.empty()) {
-		auto &remaining = window_expressions;
+	while (!blocking_windows.empty() || !streaming_windows.empty()) {
+		const bool process_streaming = blocking_windows.empty();
+		auto &remaining = process_streaming ? streaming_windows : blocking_windows;
 
 		// Find all functions that share the partitioning of the first remaining expression
 		const auto over_idx = remaining[0];
@@ -92,7 +95,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalWindow &op
 		plan = move(window);
 
 		// Remember the projection order if we changed it
-		if (!remaining.empty() || !evaluation_order.empty()) {
+		if (!streaming_windows.empty() || !blocking_windows.empty() || !evaluation_order.empty()) {
 			evaluation_order.insert(evaluation_order.end(), matching.begin(), matching.end());
 		}
 	}

--- a/test/sql/window/test_streaming_window.test
+++ b/test/sql/window/test_streaming_window.test
@@ -112,22 +112,22 @@ physical_plan	<!REGEX>:.*STREAMING_WINDOW.*
 query TT
 explain select first_value(i) over (), last_value(i) over () from integers
 ----
-physical_plan	<!REGEX>:.*STREAMING_WINDOW.*
+physical_plan	<REGEX>:.*STREAMING_WINDOW.* WINDOW .*
 
 query TT
 explain select last_value(i) over (), first_value(i) over () from integers
 ----
-physical_plan	<!REGEX>:.*STREAMING_WINDOW.*
+physical_plan	<REGEX>:.*STREAMING_WINDOW.* WINDOW .*
 
 query TT
 explain select first_value(i) over (), last_value(i) over (order by j) from integers
 ----
-physical_plan	<!REGEX>:.*STREAMING_WINDOW.*
+physical_plan	<REGEX>:.*STREAMING_WINDOW.* WINDOW .*
 
 query TT
 explain select last_value(i) over (order by j), first_value(i) over () from integers
 ----
-physical_plan	<!REGEX>:.*STREAMING_WINDOW.*
+physical_plan	<REGEX>:.*STREAMING_WINDOW.* WINDOW .*
 
 #
 # Global state tests from #3275


### PR DESCRIPTION
Re-enable mixing streaming and blocking window operators
by fixing the projection reordering logic.