### PR TITLE
node: add async-iterator-based streaming

### DIFF
--- a/tools/nodejs/src/database.cpp
+++ b/tools/nodejs/src/database.cpp
@@ -135,9 +135,7 @@ static void TaskExecuteCallback(napi_env e, void *data) {
 static void TaskCompleteCallback(napi_env e, napi_status status, void *data) {
 	std::unique_ptr<TaskHolder> holder((TaskHolder *)data);
 	holder->db->TaskComplete(e);
-	if (holder->task->callback.Value().IsFunction()) {
-		holder->task->Callback();
-	}
+	holder->task->DoCallback();
 }
 
 void Database::TaskComplete(Napi::Env env) {

--- a/tools/nodejs/src/duckdb_node.cpp
+++ b/tools/nodejs/src/duckdb_node.cpp
@@ -12,6 +12,7 @@ Napi::Object RegisterModule(Napi::Env env, Napi::Object exports) {
 	node_duckdb::Database::Init(env, exports);
 	node_duckdb::Connection::Init(env, exports);
 	node_duckdb::Statement::Init(env, exports);
+	node_duckdb::QueryResult::Init(env, exports);
 
 	exports.DefineProperties({
 	    DEFINE_CONSTANT_INTEGER(exports, node_duckdb::Database::DUCKDB_NODEJS_ERROR, ERROR) DEFINE_CONSTANT_INTEGER(

--- a/tools/nodejs/src/duckdb_node.hpp
+++ b/tools/nodejs/src/duckdb_node.hpp
@@ -15,8 +15,26 @@ struct Task {
 		}
 		object.Ref();
 	}
+	explicit Task(Napi::Reference<Napi::Object> &object) : object(object) {
+		object.Ref();
+	}
+
+	// Called on a worker thread (i.e., not the main event loop thread)
 	virtual void DoWork() = 0;
 
+	// Called on the event loop thread after the work has been completed. By
+	// default, call the associated callback, if defined. If you're writing
+	// a Task that uses promises, override this method instead of Callback.
+	virtual void DoCallback() {
+		auto env = object.Env();
+		Napi::HandleScope scope(env);
+
+		if (!callback.Value().IsUndefined()) {
+			Callback();
+		}
+	}
+
+	// Called on the event loop thread by DoCallback (see above)
 	virtual void Callback() {
 		auto env = object.Env();
 		Napi::HandleScope scope(env);
@@ -127,8 +145,8 @@ public:
 	Napi::Value All(const Napi::CallbackInfo &info);
 	Napi::Value Each(const Napi::CallbackInfo &info);
 	Napi::Value Run(const Napi::CallbackInfo &info);
-	Napi::Value Bind(const Napi::CallbackInfo &info);
 	Napi::Value Finish(const Napi::CallbackInfo &info);
+	Napi::Value Stream(const Napi::CallbackInfo &info);
 
 public:
 	static Napi::FunctionReference constructor;
@@ -139,6 +157,21 @@ public:
 
 private:
 	std::unique_ptr<StatementParam> HandleArgs(const Napi::CallbackInfo &info);
+};
+
+class QueryResult : public Napi::ObjectWrap<QueryResult> {
+public:
+	explicit QueryResult(const Napi::CallbackInfo &info);
+	~QueryResult() override;
+	static Napi::Object Init(Napi::Env env, Napi::Object exports);
+	std::unique_ptr<duckdb::QueryResult> result;
+
+public:
+	static Napi::FunctionReference constructor;
+	Napi::Value NextChunk(const Napi::CallbackInfo &info);
+
+private:
+	Database *database_ref;
 };
 
 struct TaskHolder {

--- a/tools/nodejs/src/statement.cpp
+++ b/tools/nodejs/src/statement.cpp
@@ -1,5 +1,8 @@
+#include "duckdb.hpp"
 #include "duckdb_node.hpp"
+#include "napi.h"
 
+#include <algorithm>
 #include <cassert>
 
 namespace node_duckdb {
@@ -12,7 +15,8 @@ Napi::Object Statement::Init(Napi::Env env, Napi::Object exports) {
 	Napi::Function t =
 	    DefineClass(env, "Statement",
 	                {InstanceMethod("run", &Statement::Run), InstanceMethod("all", &Statement::All),
-	                 InstanceMethod("each", &Statement::Each), InstanceMethod("finalize", &Statement::Finish)});
+	                 InstanceMethod("each", &Statement::Each), InstanceMethod("finalize", &Statement::Finish),
+	                 InstanceMethod("stream", &Statement::Stream)});
 
 	constructor = Napi::Persistent(t);
 	constructor.SuppressDestruct();
@@ -272,10 +276,6 @@ struct RunPreparedTask : public Task {
 			cb.MakeCallback(statement.Value(), {Utils::CreateError(env, statement.statement->error)});
 			return;
 		}
-		if (!statement.statement->success) {
-			cb.MakeCallback(statement.Value(), {Utils::CreateError(env, statement.statement->error)});
-			return;
-		}
 		if (!result->success) {
 			cb.MakeCallback(statement.Value(), {Utils::CreateError(env, result->error)});
 			return;
@@ -340,6 +340,45 @@ struct RunPreparedTask : public Task {
 	RunType run_type;
 };
 
+struct RunQueryTask : public Task {
+	RunQueryTask(Statement &statement, duckdb::unique_ptr<StatementParam> params, Napi::Promise::Deferred deferred)
+	    : Task(statement), deferred(deferred), params(move(params)) {
+	}
+
+	void DoWork() override {
+		auto &statement = Get<Statement>();
+		if (!statement.statement || !statement.statement->success) {
+			return;
+		}
+
+		result = statement.statement->Execute(params->params, true);
+	}
+
+	void DoCallback() override {
+		auto &statement = Get<Statement>();
+		Napi::Env env = statement.Env();
+		Napi::HandleScope scope(env);
+
+		if (!statement.statement) {
+			deferred.Reject(Utils::CreateError(env, "statement was finalized"));
+		} else if (!statement.statement->success) {
+			deferred.Reject(Utils::CreateError(env, statement.statement->error));
+		} else if (!result->success) {
+			deferred.Reject(Utils::CreateError(env, result->error));
+		} else {
+			auto db = statement.connection_ref->database_ref->Value();
+			auto query_result = QueryResult::constructor.New({db});
+			auto unwrapped = Napi::ObjectWrap<QueryResult>::Unwrap(query_result);
+			unwrapped->result = move(result);
+			deferred.Resolve(query_result);
+		}
+	}
+
+	Napi::Promise::Deferred deferred;
+	std::unique_ptr<duckdb::QueryResult> result;
+	duckdb::unique_ptr<StatementParam> params;
+};
+
 duckdb::unique_ptr<StatementParam> Statement::HandleArgs(const Napi::CallbackInfo &info) {
 	size_t start_idx = ignore_first_param ? 1 : 0;
 	auto params = duckdb::make_unique<StatementParam>();
@@ -369,17 +408,22 @@ Napi::Value Statement::All(const Napi::CallbackInfo &info) {
 }
 
 Napi::Value Statement::Run(const Napi::CallbackInfo &info) {
-	auto params = HandleArgs(info);
 	connection_ref->database_ref->Schedule(info.Env(),
 	                                       duckdb::make_unique<RunPreparedTask>(*this, HandleArgs(info), RunType::RUN));
 	return info.This();
 }
 
 Napi::Value Statement::Each(const Napi::CallbackInfo &info) {
-	auto params = HandleArgs(info);
 	connection_ref->database_ref->Schedule(
 	    info.Env(), duckdb::make_unique<RunPreparedTask>(*this, HandleArgs(info), RunType::EACH));
 	return info.This();
+}
+
+Napi::Value Statement::Stream(const Napi::CallbackInfo &info) {
+	auto deferred = Napi::Promise::Deferred::New(info.Env());
+	connection_ref->database_ref->Schedule(info.Env(),
+	                                       duckdb::make_unique<RunQueryTask>(*this, HandleArgs(info), deferred));
+	return deferred.Promise();
 }
 
 struct FinishTask : public Task {
@@ -404,6 +448,69 @@ Napi::Value Statement::Finish(const Napi::CallbackInfo &info) {
 
 	connection_ref->database_ref->Schedule(env, duckdb::make_unique<FinishTask>(*this, callback));
 	return env.Null();
+}
+
+Napi::FunctionReference QueryResult::constructor;
+
+Napi::Object QueryResult::Init(Napi::Env env, Napi::Object exports) {
+	Napi::HandleScope scope(env);
+
+	Napi::Function t = DefineClass(env, "QueryResult", {InstanceMethod("nextChunk", &QueryResult::NextChunk)});
+
+	constructor = Napi::Persistent(t);
+	constructor.SuppressDestruct();
+
+	exports.Set("QueryResult", t);
+	return exports;
+}
+
+QueryResult::QueryResult(const Napi::CallbackInfo &info) : Napi::ObjectWrap<QueryResult>(info) {
+	database_ref = Napi::ObjectWrap<Database>::Unwrap(info[0].As<Napi::Object>());
+	database_ref->Ref();
+}
+
+QueryResult::~QueryResult() {
+	database_ref->Unref();
+	database_ref = nullptr;
+}
+
+struct GetChunkTask : public Task {
+	GetChunkTask(QueryResult &query_result, Napi::Promise::Deferred deferred) : Task(query_result), deferred(deferred) {
+	}
+
+	void DoWork() override {
+		auto &query_result = Get<QueryResult>();
+		chunk = query_result.result->Fetch();
+	}
+
+	void DoCallback() override {
+		auto &query_result = Get<QueryResult>();
+		Napi::Env env = query_result.Env();
+		Napi::HandleScope scope(env);
+
+		if (chunk == nullptr || chunk->size() == 0) {
+			deferred.Resolve(env.Null());
+			return;
+		}
+
+		auto chunk_converted = convert_chunk(env, query_result.result->names, *chunk).ToObject();
+		if (!chunk_converted.IsArray()) {
+			deferred.Reject(Utils::CreateError(env, "internal error: chunk is not array"));
+		} else {
+			deferred.Resolve(chunk_converted);
+		}
+	}
+
+	Napi::Promise::Deferred deferred;
+	std::unique_ptr<duckdb::DataChunk> chunk;
+};
+
+Napi::Value QueryResult::NextChunk(const Napi::CallbackInfo &info) {
+	auto env = info.Env();
+	auto deferred = Napi::Promise::Deferred::New(env);
+	database_ref->Schedule(env, duckdb::make_unique<GetChunkTask>(*this, deferred));
+
+	return deferred.Promise();
 }
 
 } // namespace node_duckdb

--- a/tools/nodejs/test/query_result.test.js
+++ b/tools/nodejs/test/query_result.test.js
@@ -1,0 +1,23 @@
+var duckdb = require('..');
+var assert = require('assert');
+
+describe('QueryResult', () => {
+    const total = 1000;
+
+    let db;
+    let conn;
+    before((done) => {
+        db = new duckdb.Database(':memory:', () => {
+            conn = new duckdb.Connection(db, done);
+        });
+    });
+
+    it('streams results', async () => {
+        let retrieved = 0;
+        const stream = conn.stream('SELECT * FROM range(0, ?)', total);
+        for await (const row of stream) {
+            retrieved++;
+        }
+        assert.equal(total, retrieved)
+    })
+})


### PR DESCRIPTION
Narrowly, add support for [async-iterator-based](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) streaming results.
This has a couple of benefits over the current `each` approach:
- It allows callers to stop iterating through results if they've gotten
  the information they need (#3755)
- It allows callers to know when they've seen all of the rows (#3754)
- It aligns better with the no-longer-so-recent trend in the Node
  ecosystem to move from callbacks to [Promises and async/await](https://nodejs.dev/learn/modern-asynchronous-javascript-with-async-and-await)

More broadly, this implies some potential changes to the node bindings
that I'd be eager to discuss with the broader community:
- It introduces the idea of a Promise-based Task. Not only is this a
  better programming model for the user-facing API, but it also
  simplifies the C++ code, especially as it relates to error handling.
  Based on the number of error handling bugs we've fixed recently, I
  wonder if this would be a useful programming style to deploy more
  broadly.
- It moves more of the logic of the bindings from C++ into javascript.
  An example way to continue this trend is to reimplement `all` and
  `each` on top of the `stream` function I added in this PR, which would
  allow us to delete a lot of C++ code. I personally view this as a good
  change--it lowers the barrier to entry for contributors coming from
  the node community--but understand it might be a trickier tradeoff for
  the maintainers of the duckdb core
- I'm curious if there's appetite for Promise variants of the existing
  functions. We could either make minor breaking changes to the existing
  functions, or we could have a second parallel javascript API, with one
  of the two being a thin veneer over the other.