### PR TITLE
Julia multi-threading fix: avoid using a time-out to cancel threads in case there are no tasks

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -1962,6 +1962,8 @@ DUCKDB_API void duckdb_destroy_arrow(duckdb_arrow *result);
 //===--------------------------------------------------------------------===//
 // Threading Information
 //===--------------------------------------------------------------------===//
+typedef void *duckdb_task_state;
+
 /*!
 Execute DuckDB tasks on this thread.
 
@@ -1971,6 +1973,44 @@ Will return after `max_tasks` have been executed, or if there are no more tasks 
 * max_tasks: The maximum amount of tasks to execute
 */
 DUCKDB_API void duckdb_execute_tasks(duckdb_database database, idx_t max_tasks);
+
+/*!
+Creates a task state that can be used with duckdb_execute_tasks_state to execute tasks until
+ duckdb_finish_execution is called on the state.
+
+duckdb_destroy_state should be called on the result in order to free memory.
+
+* database: The database object to create the task state for
+* returns: The task state that can be used with duckdb_execute_tasks_state.
+*/
+DUCKDB_API duckdb_task_state duckdb_create_task_state(duckdb_database database);
+
+/*!
+Execute DuckDB tasks on this thread.
+
+The thread will keep on executing tasks forever, until duckdb_finish_execution is called on the state.
+Multiple threads can share the same duckdb_task_state.
+
+* state: The task state of the executor
+*/
+DUCKDB_API void duckdb_execute_tasks_state(duckdb_task_state state);
+
+/*!
+Finish execution on a specific task.
+
+* state: The task state to finish execution
+*/
+DUCKDB_API void duckdb_finish_execution(duckdb_task_state state);
+
+/*!
+Destroys the task state returned from duckdb_create_task_state.
+
+Note that this should not be called while there is an active duckdb_execute_tasks_state running
+on the task state.
+
+* state: The task state to clean up
+*/
+DUCKDB_API void duckdb_destroy_task_state(duckdb_task_state state);
 
 #ifdef __cplusplus
 }

--- a/src/include/duckdb/parallel/task_scheduler.hpp
+++ b/src/include/duckdb/parallel/task_scheduler.hpp
@@ -61,6 +61,9 @@ public:
 	//! Returns the number of threads
 	int32_t NumberOfThreads();
 
+	//! Send signals to n threads, signalling for them to wake up and attempt to execute a task
+	void Signal(idx_t n);
+
 private:
 	void SetThreadsInternal(int32_t n);
 

--- a/src/main/capi/threading-c.cpp
+++ b/src/main/capi/threading-c.cpp
@@ -3,6 +3,16 @@
 
 using duckdb::DatabaseData;
 
+struct CAPITaskState {
+	CAPITaskState(duckdb::DatabaseInstance &db)
+	    : db(db), marker(duckdb::make_unique<duckdb::atomic<bool>>(true)), execute_count(0) {
+	}
+
+	duckdb::DatabaseInstance &db;
+	duckdb::unique_ptr<duckdb::atomic<bool>> marker;
+	duckdb::atomic<idx_t> execute_count;
+};
+
 void duckdb_execute_tasks(duckdb_database database, idx_t max_tasks) {
 	if (!database) {
 		return;
@@ -10,4 +20,44 @@ void duckdb_execute_tasks(duckdb_database database, idx_t max_tasks) {
 	auto wrapper = (DatabaseData *)database;
 	auto &scheduler = duckdb::TaskScheduler::GetScheduler(*wrapper->database->instance);
 	scheduler.ExecuteTasks(max_tasks);
+}
+
+duckdb_task_state duckdb_create_task_state(duckdb_database database) {
+	if (!database) {
+		return nullptr;
+	}
+	auto wrapper = (DatabaseData *)database;
+	auto state = new CAPITaskState(*wrapper->database->instance);
+	return state;
+}
+
+void duckdb_execute_tasks_state(duckdb_task_state state_p) {
+	if (!state_p) {
+		return;
+	}
+	auto state = (CAPITaskState *)state_p;
+	auto &scheduler = duckdb::TaskScheduler::GetScheduler(state->db);
+	state->execute_count++;
+	scheduler.ExecuteForever(state->marker.get());
+}
+
+void duckdb_finish_execution(duckdb_task_state state_p) {
+	if (!state_p) {
+		return;
+	}
+	auto state = (CAPITaskState *)state_p;
+	*state->marker = false;
+	if (state->execute_count > 0) {
+		// signal to the threads to wake up
+		auto &scheduler = duckdb::TaskScheduler::GetScheduler(state->db);
+		scheduler.Signal(state->execute_count);
+	}
+}
+
+void duckdb_destroy_task_state(duckdb_task_state state_p) {
+	if (!state_p) {
+		return;
+	}
+	auto state = (CAPITaskState *)state_p;
+	delete state;
 }

--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -186,7 +186,9 @@ void TaskScheduler::SetThreads(int32_t n) {
 }
 
 void TaskScheduler::Signal(idx_t n) {
+#ifndef DUCKDB_NO_THREADS
 	queue->semaphore.signal(n);
+#endif
 }
 
 void TaskScheduler::SetThreadsInternal(int32_t n) {

--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -129,7 +129,7 @@ void TaskScheduler::ExecuteForever(atomic<bool> *marker) {
 	unique_ptr<Task> task;
 	// loop until the marker is set to false
 	while (*marker) {
-		// wait for a signal with a timeout; the timeout allows us to periodically check
+		// wait for a signal with a timeout
 		queue->semaphore.wait();
 		if (queue->q.try_dequeue(task)) {
 			task->Execute(TaskExecutionMode::PROCESS_ALL);
@@ -185,6 +185,10 @@ void TaskScheduler::SetThreads(int32_t n) {
 #endif
 }
 
+void TaskScheduler::Signal(idx_t n) {
+	queue->semaphore.signal(n);
+}
+
 void TaskScheduler::SetThreadsInternal(int32_t n) {
 #ifndef DUCKDB_NO_THREADS
 	if (threads.size() == idx_t(n - 1)) {
@@ -196,7 +200,7 @@ void TaskScheduler::SetThreadsInternal(int32_t n) {
 		for (idx_t i = 0; i < threads.size(); i++) {
 			*markers[i] = false;
 		}
-		queue->semaphore.signal(threads.size());
+		Signal(threads.size());
 		// now join the threads to ensure they are fully stopped before erasing them
 		for (idx_t i = 0; i < threads.size(); i++) {
 			threads[i]->internal_thread->join();

--- a/tools/juliapkg/src/api.jl
+++ b/tools/juliapkg/src/api.jl
@@ -2564,3 +2564,41 @@ end
 function duckdb_execute_tasks(handle, max_tasks)
     return ccall((:duckdb_execute_tasks, libduckdb), Cvoid, (duckdb_database, UInt64), handle, max_tasks)
 end
+
+# Creates a task state that can be used with duckdb_execute_tasks_state to execute tasks until
+#  duckdb_finish_execution is called on the state.
+#
+# duckdb_destroy_state should be called on the result in order to free memory.
+#
+# * returns: The task state that can be used with duckdb_execute_tasks_state.
+function duckdb_create_task_state(database)
+    return ccall((:duckdb_create_task_state, libduckdb), duckdb_task_state, (duckdb_database,), database)
+end
+
+# Execute DuckDB tasks on this thread.
+#
+# The thread will keep on executing tasks forever, until duckdb_finish_execution is called on the state.
+# Multiple threads can share the same duckdb_task_state.
+#
+# * database: The database object to execute tasks for
+# * state: The task state of the executor
+function duckdb_execute_tasks_state(state)
+    return ccall((:duckdb_execute_tasks_state, libduckdb), Cvoid, (duckdb_task_state,), state)
+end
+
+# Finish execution on a specific task.
+#
+# * state: The task state to finish execution
+function duckdb_finish_execution(state)
+    return ccall((:duckdb_finish_execution, libduckdb), Cvoid, (duckdb_task_state,), state)
+end
+
+# Destroys the task state returned from duckdb_create_task_state.
+#
+# Note that this should not be called while there is an active duckdb_execute_tasks_state running
+# on the task state.
+#
+# * state: The task state to clean up
+function duckdb_destroy_task_state(state)
+    return ccall((:duckdb_destroy_task_state, libduckdb), Cvoid, (duckdb_task_state,), state)
+end

--- a/tools/juliapkg/src/ctypes.jl
+++ b/tools/juliapkg/src/ctypes.jl
@@ -14,6 +14,7 @@ const duckdb_bind_info = Ptr{Cvoid}
 const duckdb_init_info = Ptr{Cvoid}
 const duckdb_function_info = Ptr{Cvoid}
 const duckdb_replacement_scan_info = Ptr{Cvoid}
+const duckdb_task_state = Ptr{Cvoid}
 const DuckDBSuccess = 0;
 const DuckDBError = 1;
 const duckdb_state = Int32;

--- a/tools/juliapkg/src/result.jl
+++ b/tools/juliapkg/src/result.jl
@@ -497,15 +497,17 @@ function toDataFrame(result::Ref{duckdb_result})::DataFrame
     return df
 end
 
-function execute_tasks(db::DuckDBHandle)
-    duckdb_execute_tasks(db.handle, typemax(UInt64))
+function execute_tasks(state::duckdb_task_state)
+    duckdb_execute_tasks_state(state)
     return
 end
 
-function cleanup_tasks(tasks)
+function cleanup_tasks(tasks, state)
+    duckdb_finish_execution(state)
     for task in tasks
         Base.wait(task)
     end
+    return duckdb_destroy_task_state(state)
 end
 
 function execute(stmt::Stmt, params::DBInterface.StatementParams = ())
@@ -513,19 +515,20 @@ function execute(stmt::Stmt, params::DBInterface.StatementParams = ())
 
     handle = Ref{duckdb_result}()
     # if multi-threading is enabled, launch tasks
+    task_state = duckdb_create_task_state(stmt.con.db.handle)
     tasks = []
     for i in 2:Threads.nthreads()
-        task_val = @spawn execute_tasks(stmt.con.db)
+        task_val = @spawn execute_tasks(task_state)
         push!(tasks, task_val)
     end
     ret = DuckDBSuccess
     try
         ret = duckdb_execute_prepared(stmt.handle, handle)
     catch ex
-        cleanup_tasks(tasks)
+        cleanup_tasks(tasks, task_state)
         throw(ex)
     end
-    cleanup_tasks(tasks)
+    cleanup_tasks(tasks, task_state)
     if ret != DuckDBSuccess
         error_ptr = duckdb_result_error(handle)
         if error_ptr == C_NULL


### PR DESCRIPTION
This PR fixes an issue with multi-threading in the Julia client that occasionally caused worker threads to exit early due to a race condition. Essentially, the threads would launch and wait for tasks to appear from the main query. However, this wait came together with a time-out, and if no tasks appeared during the time-out the thread would exit early. This would sporadically happen when the query was complex and took a long time to plan/optimize, or when there were other slowdowns during query planning (e.g. Julia plan compilation).

Instead, we extend the task execution C API to allow the creation of a task context that allows fine-grained control over when the worker threads exit. This is used in the Julia API to avoid cleaning up worker threads early. Instead, worker threads now exist until the query execution is finished, which allows the multi-threading to work as expected.
