### PR TITLE
ALTER SEQUENCE IF EXISTS fix

### DIFF
--- a/src/parser/transform/statement/transform_alter_sequence.cpp
+++ b/src/parser/transform/statement/transform_alter_sequence.cpp
@@ -66,6 +66,7 @@ unique_ptr<AlterStatement> Transformer::TransformAlterSequence(duckdb_libpgquery
 			throw NotImplementedException("ALTER SEQUENCE option not supported yet!");
 		}
 	}
+	result->info->if_exists = stmt->missing_ok;
 	return result;
 }
 } // namespace duckdb

--- a/test/sql/alter/test_alter_if_exists.test
+++ b/test/sql/alter/test_alter_if_exists.test
@@ -1,0 +1,7 @@
+# name: test/sql/alter/rename_col/test_alter_if_exists.test
+# description: Test ALTER SEQUENCE IF EXISTS
+# group: [alter]
+
+# sequence does not exist
+statement ok
+ALTER SEQUENCE IF EXISTS seq OWNED BY x;

--- a/test/sql/alter/test_alter_if_exists.test
+++ b/test/sql/alter/test_alter_if_exists.test
@@ -1,4 +1,4 @@
-# name: test/sql/alter/rename_col/test_alter_if_exists.test
+# name: test/sql/alter/test_alter_if_exists.test
 # description: Test ALTER SEQUENCE IF EXISTS
 # group: [alter]
 


### PR DESCRIPTION
This fixes one of the issues addressed in #4152

`transform_alter_sequence.cpp` wasn't setting `if_exists`

Added a test to make sure this doesn't break again.