### PR TITLE
Correctly call SetFilePointerEx on Windows so the truncate works as expected

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -556,6 +556,7 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path, uint8_t fla
 
 void LocalFileSystem::SetFilePointer(FileHandle &handle, idx_t location) {
 	auto &whandle = (WindowsFileHandle &)handle;
+	whandle.position = location;
 	LARGE_INTEGER wlocation;
 	wlocation.QuadPart = location;
 	SetFilePointerEx(whandle.fd, wlocation, NULL, FILE_BEGIN);

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -555,7 +555,10 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path, uint8_t fla
 }
 
 void LocalFileSystem::SetFilePointer(FileHandle &handle, idx_t location) {
-	((WindowsFileHandle &)handle).position = location;
+	auto &whandle = (WindowsFileHandle &)handle;
+	LARGE_INTEGER wlocation;
+	wlocation.QuadPart = location;
+	SetFilePointerEx(whandle.fd, wlocation, NULL, FILE_BEGIN);
 }
 
 idx_t LocalFileSystem::GetFilePointer(FileHandle &handle) {
@@ -573,7 +576,7 @@ static DWORD FSInternalRead(FileHandle &handle, HANDLE hFile, void *buffer, int6
 	auto rc = ReadFile(hFile, buffer, (DWORD)nr_bytes, &bytes_read, &ov);
 	if (!rc) {
 		auto error = LocalFileSystem::GetLastErrorAsString();
-		throw IOException("Could not read file \"%s\" (error in ReadFile): %s", handle.path, error);
+		throw IOException("Could not read file \"%s\" (error in ReadFile(location: %llu, nr_bytes: %lld)): %s", handle.path, location, nr_bytes, error);
 	}
 	return bytes_read;
 }

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -577,7 +577,8 @@ static DWORD FSInternalRead(FileHandle &handle, HANDLE hFile, void *buffer, int6
 	auto rc = ReadFile(hFile, buffer, (DWORD)nr_bytes, &bytes_read, &ov);
 	if (!rc) {
 		auto error = LocalFileSystem::GetLastErrorAsString();
-		throw IOException("Could not read file \"%s\" (error in ReadFile(location: %llu, nr_bytes: %lld)): %s", handle.path, location, nr_bytes, error);
+		throw IOException("Could not read file \"%s\" (error in ReadFile(location: %llu, nr_bytes: %lld)): %s",
+		                  handle.path, location, nr_bytes, error);
 	}
 	return bytes_read;
 }


### PR DESCRIPTION
This fixes the secondary issue mentioned by @djouallah in #4170

Closes #4170