### PR TITLE
Fix RTTI issue across extension boundaries on OSX

### DIFF
--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -44,8 +44,8 @@ void Planner::CreatePlan(SQLStatement &statement) {
 
 		auto max_tree_depth = ClientConfig::GetConfig(context).max_expression_depth;
 		CheckTreeDepth(*plan, max_tree_depth);
-	} catch (Exception &ex) {
-		if (ex.type != ExceptionType::PARAMETER_NOT_RESOLVED) {
+	} catch (std::exception &ex) {
+		if (ex.what() != string("Parameter Not Resolved Error: Parameter types could not be resolved")) {
 			throw;
 		}
 		// parameter types could not be resolved

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -46,7 +46,7 @@ void Planner::CreatePlan(SQLStatement &statement) {
 		CheckTreeDepth(*plan, max_tree_depth);
 	} catch (Exception &ex) {
 		if (ex.type != ExceptionType::PARAMETER_NOT_RESOLVED) {
-			throw ex;
+			throw;
 		}
 		// parameter types could not be resolved
 		this->names = {"unknown"};

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -44,7 +44,10 @@ void Planner::CreatePlan(SQLStatement &statement) {
 
 		auto max_tree_depth = ClientConfig::GetConfig(context).max_expression_depth;
 		CheckTreeDepth(*plan, max_tree_depth);
-	} catch (ParameterNotResolvedException &ex) {
+	} catch (Exception &ex) {
+		if (ex.type != ExceptionType::PARAMETER_NOT_RESOLVED) {
+			throw ex;
+		}
 		// parameter types could not be resolved
 		this->names = {"unknown"};
 		this->types = {LogicalTypeId::UNKNOWN};


### PR DESCRIPTION
Apparently detecting exception type with RTTI fails across extension boundaries on OSX, which causes the tests to fail on master currently