### PR TITLE
[capi] impl clear bindings for prepared stmt

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -816,6 +816,11 @@ Returns `DUCKDB_TYPE_INVALID` if the parameter index is out of range or the stat
 DUCKDB_API duckdb_type duckdb_param_type(duckdb_prepared_statement prepared_statement, idx_t param_idx);
 
 /*!
+Clear the params bind to the prepared statement.
+*/
+DUCKDB_API duckdb_state duckdb_clear_bindings(duckdb_prepared_statement prepared_statement);
+
+/*!
 Binds a bool value to the prepared statement at the specified index.
 */
 DUCKDB_API duckdb_state duckdb_bind_boolean(duckdb_prepared_statement prepared_statement, idx_t param_idx, bool val);

--- a/src/main/capi/prepared-c.cpp
+++ b/src/main/capi/prepared-c.cpp
@@ -52,6 +52,15 @@ duckdb_type duckdb_param_type(duckdb_prepared_statement prepared_statement, idx_
 	return ConvertCPPTypeToC(entry->second->return_type);
 }
 
+duckdb_state duckdb_clear_bindings(duckdb_prepared_statement prepared_statement) {
+	auto wrapper = (PreparedStatementWrapper *)prepared_statement;
+	if (!wrapper || !wrapper->statement || !wrapper->statement->success) {
+		return DuckDBError;
+	}
+	wrapper->values.clear();
+	return DuckDBSuccess;
+}
+
 static duckdb_state duckdb_bind_value(duckdb_prepared_statement prepared_statement, idx_t param_idx, Value val) {
 	auto wrapper = (PreparedStatementWrapper *)prepared_statement;
 	if (!wrapper || !wrapper->statement || !wrapper->statement->success) {

--- a/test/api/capi/test_capi_prepared.cpp
+++ b/test/api/capi/test_capi_prepared.cpp
@@ -221,9 +221,13 @@ TEST_CASE("Test prepared statements in C API", "[capi]") {
 	status = duckdb_prepare(tester.connection, "SELECT SUM(i)*$1-$2 FROM a", &stmt);
 	REQUIRE(status == DuckDBSuccess);
 	REQUIRE(stmt != nullptr);
+	// clear bindings
+	duckdb_bind_int32(stmt, 1, 2);
+	REQUIRE(duckdb_clear_bindings(stmt) == DuckDBSuccess);
+
+	// bind again will succeed
 	duckdb_bind_int32(stmt, 1, 2);
 	duckdb_bind_int32(stmt, 2, 1000);
-
 	status = duckdb_execute_prepared(stmt, &res);
 	REQUIRE(status == DuckDBSuccess);
 	REQUIRE(duckdb_value_int32(&res, 0, 0) == 1000000);


### PR DESCRIPTION
When we implement a cached stmt return the stmt back to cache, we can call this function to make sure there is no binding params with this stmt.

[example](https://github.com/wangfenjin/duckdb-rs/pull/67/files#diff-5caf3cc5d3186459b336694e55ad1898aaf48294956d7886e318cde96bb9eb99R157)