### PR TITLE
Fix #4202: in the comparison simplification optimizer, we can only shift the cast to the constant if both casts are invertible

### DIFF
--- a/src/optimizer/rule/comparison_simplification.cpp
+++ b/src/optimizer/rule/comparison_simplification.cpp
@@ -37,7 +37,8 @@ unique_ptr<Expression> ComparisonSimplificationRule::Apply(LogicalOperator &op, 
 		//! Here we check if we can apply the expression on the constant side
 		auto cast_expression = (BoundCastExpression *)column_ref_expr;
 		auto target_type = cast_expression->source_type();
-		if (!BoundCastExpression::CastIsInvertible(target_type, cast_expression->return_type)) {
+		if (!BoundCastExpression::CastIsInvertible(target_type, cast_expression->return_type) ||
+		    !BoundCastExpression::CastIsInvertible(cast_expression->return_type, target_type)) {
 			return nullptr;
 		}
 		auto new_constant = constant_value.TryCastAs(target_type);

--- a/test/sql/function/date/date_trunc_4202.test
+++ b/test/sql/function/date/date_trunc_4202.test
@@ -1,0 +1,28 @@
+# name: test/sql/function/date/date_trunc_4202.test
+# description: Issue #4202: Suspect behavior when comparing dates and timestamps
+# group: [date]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table t1 (date timestamp);
+
+statement ok
+insert into t1 values ('2016-12-16T00:00:00.000Z');
+
+statement ok
+insert into t1 values ('2020-02-17T23:59:59.998Z');
+
+statement ok
+insert into t1 values ('2020-02-17T23:59:59.999Z');
+
+statement ok
+insert into t1 values ('2020-02-18T00:00:00.000Z');
+
+query I
+select * from t1 WHERE (date_trunc('DAY', T1.date) < ('2020-02-17T23:59:59.999Z'::timestamp)) ORDER BY 1;
+----
+2016-12-16 00:00:00
+2020-02-17 23:59:59.998
+2020-02-17 23:59:59.999


### PR DESCRIPTION
Fixes #4202

The problem was that an optimizer would try to shift the cast from the non-constant side to the constant, i.e. it would transform this:

```sql
select * from t1 WHERE (date_trunc('DAY', T1.date)::TIMESTAMP <  TIMESTAMP '2020-02-17T23:59:59.999Z') 
```

Into this:

```sql
select * from t1 WHERE (date_trunc('DAY', T1.date) <  (TIMESTAMP '2020-02-17T23:59:59.999Z')::DATE) 
```

This is incorrect since the cast of a timestamp to date is lossy and truncates the timestamp, which causes results on the boundary to be incorrectly excluded.