### PR TITLE
PARQUET: Move StringColumnWriter dictionary to use string_t to avoid allocations

### DIFF
--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -16,12 +16,12 @@
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/serializer/buffered_serializer.hpp"
 #include "duckdb/common/operator/comparison_operators.hpp"
+#include "duckdb/common/string_map_set.hpp"
 #endif
 
 #include "snappy.h"
 #include "miniz_wrapper.hpp"
 #include "zstd.h"
-#include "duckdb/common/string_map_set.hpp"
 
 namespace duckdb {
 

--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -63,6 +63,7 @@ if '--extended' in sys.argv:
         "duckdb/planner/filter/constant_filter.hpp",
         "duckdb/execution/operator/persistent/buffered_csv_reader.hpp",
         "duckdb/common/types/vector_cache.hpp",
+        "duckdb/common/string_map_set.hpp",
         "duckdb/planner/filter/null_filter.hpp",
         "duckdb/common/arrow_wrapper.hpp",
         "duckdb/common/hive_partitioning.hpp",

--- a/src/include/duckdb/common/string_map_set.hpp
+++ b/src/include/duckdb/common/string_map_set.hpp
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/string_map_set.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/operator/comparison_operators.hpp"
+#include "duckdb/common/types/hash.hpp"
+#include "duckdb/common/types/string_type.hpp"
+#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/unordered_set.hpp"
+
+namespace duckdb {
+
+struct StringHash {
+	std::size_t operator()(const string_t &k) const {
+		return Hash(k);
+	}
+};
+
+struct StringEquality {
+	bool operator()(const string_t &a, const string_t &b) const {
+		return Equals::Operation(a, b);
+	}
+};
+
+template <typename T>
+using string_map_t = unordered_map<string_t, T, StringHash, StringEquality>;
+
+using string_set_t = unordered_set<string_t, StringHash, StringEquality>;
+
+} // namespace duckdb

--- a/src/storage/compression/dictionary_compression.cpp
+++ b/src/storage/compression/dictionary_compression.cpp
@@ -1,4 +1,6 @@
 #include "duckdb/common/bitpacking.hpp"
+#include "duckdb/common/operator/comparison_operators.hpp"
+#include "duckdb/common/string_map_set.hpp"
 #include "duckdb/common/types/vector_buffer.hpp"
 #include "duckdb/function/compression/compression.hpp"
 #include "duckdb/function/compression_function.hpp"
@@ -7,26 +9,8 @@
 #include "duckdb/storage/string_uncompressed.hpp"
 #include "duckdb/storage/table/append_state.hpp"
 #include "duckdb/storage/table/column_data_checkpointer.hpp"
-#include "duckdb/common/operator/comparison_operators.hpp"
 
 namespace duckdb {
-
-struct StringHash {
-	std::size_t operator()(const string_t &k) const {
-		return Hash(k);
-	}
-};
-
-struct StringEquality {
-	bool operator()(const string_t &a, const string_t &b) const {
-		return Equals::Operation(a, b);
-	}
-};
-
-template <typename T>
-using string_map_t = unordered_map<string_t, T, StringHash, StringEquality>;
-
-using string_set_t = unordered_set<string_t, StringHash, StringEquality>;
 
 // Abstract class for keeping compression state either for compression or size analysis
 class DictionaryCompressionState : public CompressionState {


### PR DESCRIPTION
Note: normally copying `string_t` into an internal map requires cloning the data to avoid someone else releasing it. This is not needed in this case because the dictionary is only maintained while a single chunk is written and ParquetWriter's reference to it is sufficient to guarantee it doesn't change.