### PR TITLE
Use right template for smallint

### DIFF
--- a/src/function/scalar/string/printf.cpp
+++ b/src/function/scalar/string/printf.cpp
@@ -111,7 +111,7 @@ static void PrintfFunction(DataChunk &args, ExpressionState &state, Vector &resu
 				break;
 			}
 			case LogicalTypeId::SMALLINT: {
-				auto arg_data = FlatVector::GetData<int8_t>(col);
+				auto arg_data = FlatVector::GetData<int16_t>(col);
 				format_args.emplace_back(duckdb_fmt::internal::make_arg<CTX>(arg_data[arg_idx]));
 				break;
 			}

--- a/test/sql/function/string/test_printf.test
+++ b/test/sql/function/string/test_printf.test
@@ -183,3 +183,9 @@ SELECT printf('%s: %s', pstring, pstring) FROM strings WHERE idx <> 2 ORDER BY i
 ----
 hello: hello
 abcde: abcde
+
+# cast integers correctly
+query T
+SELECT printf('%d %d %d %d', 100::tinyint, 1000::smallint, 1000::int, 1000::bigint);
+----
+100 1000 1000 1000


### PR DESCRIPTION
Just fixing a small typo at printf function.

I am considering if it's worth fuzzing it. I see the unsigned and huge types are missing there, but maybe some format identifiers are not available for them.