### PR TITLE
R: Remove nycflights13 dependency

### DIFF
--- a/tools/rpkg/DESCRIPTION
+++ b/tools/rpkg/DESCRIPTION
@@ -55,7 +55,6 @@ Suggests:
     DBItest,
     dplyr,
     dbplyr,
-    nycflights13,
     testthat,
     tibble,
     vctrs,

--- a/tools/rpkg/dependencies.R
+++ b/tools/rpkg/dependencies.R
@@ -1,5 +1,5 @@
 local({
-  pkg <- c("DBI", "callr", "DBItest", "dbplyr", "nycflights13", "testthat", "bit64", "cpp11", "arrow", "covr", "pkgbuild", "remotes", "bit64")
+  pkg <- c("DBI", "callr", "DBItest", "dbplyr", "testthat", "bit64", "cpp11", "arrow", "covr", "pkgbuild", "remotes", "bit64")
 
   if (.Platform$OS.type == "unix") {
     options(HTTPUserAgent = sprintf("R/4.1.0 R (4.1.0 %s)", paste(R.version$platform, R.version$arch, R.version$os)))


### PR DESCRIPTION
Not needed, as far as I can tell.