### PR TITLE
Return errors from RecordBatchReader

### DIFF
--- a/src/common/arrow_wrapper.cpp
+++ b/src/common/arrow_wrapper.cpp
@@ -83,7 +83,7 @@ int ResultArrowArrayStreamWrapper::MyStreamGetSchema(struct ArrowArrayStream *st
 
 	auto &result = *my_stream->result;
 	if (!result.success) {
-		my_stream->last_error = "Query Failed";
+		my_stream->last_error = result.GetError();
 		return -1;
 	}
 	if (result.type == QueryResultType::STREAM_RESULT) {
@@ -108,7 +108,7 @@ int ResultArrowArrayStreamWrapper::MyStreamGetNext(struct ArrowArrayStream *stre
 	auto my_stream = (ResultArrowArrayStreamWrapper *)stream->private_data;
 	auto &result = *my_stream->result;
 	if (!result.success) {
-		my_stream->last_error = "Query Failed";
+		my_stream->last_error = result.GetError();
 		return -1;
 	}
 	if (result.type == QueryResultType::STREAM_RESULT) {
@@ -125,6 +125,10 @@ int ResultArrowArrayStreamWrapper::MyStreamGetNext(struct ArrowArrayStream *stre
 	}
 	unique_ptr<DataChunk> chunk_result = result.Fetch();
 	if (!chunk_result) {
+		if (!result.success) {
+			my_stream->last_error = result.GetError();
+			return -1;
+		}
 		// Nothing to output
 		out->release = nullptr;
 		return 0;
@@ -186,7 +190,6 @@ unique_ptr<DataChunk> ArrowUtil::FetchNext(QueryResult &result) {
 }
 
 unique_ptr<DataChunk> ArrowUtil::FetchChunk(QueryResult *result, idx_t chunk_size) {
-
 	auto data_chunk = FetchNext(*result);
 	if (!data_chunk) {
 		return data_chunk;

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_fetch_recordbatch.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_fetch_recordbatch.py
@@ -106,15 +106,12 @@ class TestArrowFetchRecordBatch(object):
         chunk = record_batch_reader.read_all()
         assert(len(chunk) == 2048)
 
-    def test_record_batch_query_error(self, duckdb_cursor):
+    def test_record_batch_query_error(self):
         if not can_run:
             return
         duckdb_cursor = duckdb.connect()
         duckdb_cursor.execute("CREATE table t as select 'foo' as a;")
         query = duckdb_cursor.execute("SELECT cast(a as double) FROM t")
         record_batch_reader = query.fetch_record_batch(1024)
-        try:
-            chunk = record_batch_reader.read_next_batch()
-            assert(False)
-        except Exception as e:
-            assert('Conversion Error' in str(e))
+        with pytest.raises(RuntimeError, match='Conversion Error'):
+            record_batch_reader.read_next_batch()

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_fetch_recordbatch.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_fetch_recordbatch.py
@@ -106,3 +106,15 @@ class TestArrowFetchRecordBatch(object):
         chunk = record_batch_reader.read_all()
         assert(len(chunk) == 2048)
 
+    def test_record_batch_query_error(self, duckdb_cursor):
+        if not can_run:
+            return
+        duckdb_cursor = duckdb.connect()
+        duckdb_cursor.execute("CREATE table t as select 'foo' as a;")
+        query = duckdb_cursor.execute("SELECT cast(a as double) FROM t")
+        record_batch_reader = query.fetch_record_batch(1024)
+        try:
+            chunk = record_batch_reader.read_next_batch()
+            assert(False)
+        except Exception as e:
+            assert('Conversion Error' in str(e))

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_fetch_recordbatch.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_fetch_recordbatch.py
@@ -113,5 +113,5 @@ class TestArrowFetchRecordBatch(object):
         duckdb_cursor.execute("CREATE table t as select 'foo' as a;")
         query = duckdb_cursor.execute("SELECT cast(a as double) FROM t")
         record_batch_reader = query.fetch_record_batch(1024)
-        with pytest.raises(RuntimeError, match='Conversion Error'):
+        with pytest.raises(OSError, match='Conversion Error'):
             record_batch_reader.read_next_batch()


### PR DESCRIPTION
Attempt to fix https://github.com/duckdb/duckdb/issues/4282
- Add a success check after `result.Fetch()` so that errors are detected
- Use `QueryResult.GetError()` to set last error for the arrow stream
