### PR TITLE
Add unit of measurement in timer function

### DIFF
--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -309,7 +309,7 @@ SELECT 42,43;
 test('''
 .timer on
 SELECT NULL;
-''', out="Run Time:")
+''', out="Run Time (s):")
 
 test('''
 .scanstats on

--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -295,7 +295,7 @@ static void endTimer(void){
     sqlite3_int64 iEnd = timeOfDay();
     struct rusage sEnd;
     getrusage(RUSAGE_SELF, &sEnd);
-    printf("Run Time: real %.3f user %f sys %f\n",
+    printf("Run Time (s): real %.3f user %f sys %f\n",
        (iEnd - iBegin)*0.001,
        timeDiff(&sBegin.ru_utime, &sEnd.ru_utime),
        timeDiff(&sBegin.ru_stime, &sEnd.ru_stime));
@@ -374,7 +374,7 @@ static void endTimer(void){
     FILETIME ftCreation, ftExit, ftKernelEnd, ftUserEnd;
     sqlite3_int64 ftWallEnd = timeOfDay();
     getProcessTimesAddr(hProcess,&ftCreation,&ftExit,&ftKernelEnd,&ftUserEnd);
-    printf("Run Time: real %.3f user %f sys %f\n",
+    printf("Run Time (s): real %.3f user %f sys %f\n",
        (ftWallEnd - ftWallBegin)*0.001,
        timeDiff(&ftUserBegin, &ftUserEnd),
        timeDiff(&ftKernelBegin, &ftKernelEnd));


### PR DESCRIPTION
Hi, was not expecting this to be my first pull request here, but I got annoyed by not knowing if my timer was in seconds or milliseconds so I fixed it :laughing: 