### PR TITLE
R: Add rlang as suggested dependency

### DIFF
--- a/tools/rpkg/DESCRIPTION
+++ b/tools/rpkg/DESCRIPTION
@@ -55,6 +55,7 @@ Suggests:
     DBItest,
     dplyr,
     dbplyr,
+    rlang,
     testthat,
     tibble,
     vctrs,


### PR DESCRIPTION
It is already used in test code, and implicitly included via vctrs and by many other packages.