### PR TITLE
Print NOT operator correctly

### DIFF
--- a/src/include/duckdb/parser/expression/operator_expression.hpp
+++ b/src/include/duckdb/parser/expression/operator_expression.hpp
@@ -57,7 +57,15 @@ public:
 			child_list += ")";
 			return "(" + in_child + op_type + child_list + ")";
 		}
-		case ExpressionType::OPERATOR_NOT:
+		case ExpressionType::OPERATOR_NOT: {
+			string result = "(";
+			result += ExpressionTypeToString(entry.type);
+			result += " ";
+			result += StringUtil::Join(entry.children, entry.children.size(), ", ",
+			                           [](const unique_ptr<BASE> &child) { return child->ToString(); });
+			result += ")";
+			return result;
+		}
 		case ExpressionType::GROUPING_FUNCTION:
 		case ExpressionType::OPERATOR_COALESCE: {
 			string result = ExpressionTypeToString(entry.type);

--- a/src/planner/expression_binder/constant_binder.cpp
+++ b/src/planner/expression_binder/constant_binder.cpp
@@ -23,7 +23,7 @@ BindResult ConstantBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr
 }
 
 string ConstantBinder::UnsupportedAggregateMessage() {
-	return clause + "cannot contain aggregates!";
+	return clause + " cannot contain aggregates!";
 }
 
 } // namespace duckdb


### PR DESCRIPTION
Hi Duckies! Just a small fix for my testing setup. Printing the NOT operator outside the parentheses could give issues reconstructing queries due to operator precedence.