### PR TITLE
Fix Julia parallelism interleaving with the garbage collector, and expose Pending Query Result in C interface

### DIFF
--- a/extension/tpch/dbgen/dbgen_gunk.cpp
+++ b/extension/tpch/dbgen/dbgen_gunk.cpp
@@ -39,8 +39,8 @@ void load_dists(long textBufferSize, DBGenContext *ctx) {
 	read_dist(tpch_env_config(DIST_TAG, DIST_DFLT), "np", &np);
 	read_dist(tpch_env_config(DIST_TAG, DIST_DFLT), "vp", &vp);
 
-  /* populate the text buffer used to generate random text */
-  init_text_pool(textBufferSize, ctx);
+	/* populate the text buffer used to generate random text */
+	init_text_pool(textBufferSize, ctx);
 }
 
 static void cleanup_dist(distribution *target) {
@@ -81,5 +81,5 @@ void cleanup_dists(void) {
 	cleanup_dist(&np);
 	cleanup_dist(&vp);
 
-  free_text_pool();
+	free_text_pool();
 }

--- a/extension/tpch/dbgen/text.cpp
+++ b/extension/tpch/dbgen/text.cpp
@@ -23,7 +23,7 @@
 
 #include <stdlib.h>
 #ifndef WIN32
-/* Change for Windows NT */
+ /* Change for Windows NT */
 #include <unistd.h>
 #endif /* WIN32 */
 #include <ctype.h>
@@ -64,7 +64,6 @@
 
 #include "dbgen/dss.h"
 #include "dbgen/dsstypes.h"
-#include <new>
 
 /*
  * txt_vp() --
@@ -246,11 +245,11 @@ static char *gen_text(char *dest, seed_t *seed, distribution *s) {
 	return dest + ind + 1;
 }
 
-#define NOUN_MAX_WEIGHT         340
-#define ADJECTIVES_MAX_WEIGHT   289
-#define ADVERBS_MAX_WEIGHT      262
-#define AUXILLARIES_MAX_WEIGHT  18
-#define VERBS_MAX_WEIGHT        174
+#define NOUN_MAX_WEIGHT 340
+#define ADJECTIVES_MAX_WEIGHT 289
+#define ADVERBS_MAX_WEIGHT 262
+#define AUXILLARIES_MAX_WEIGHT 18
+#define VERBS_MAX_WEIGHT 174
 #define PREPOSITIONS_MAX_WEIGHT 456
 
 static char *noun_index[NOUN_MAX_WEIGHT + 1];
@@ -260,7 +259,7 @@ static char *auxillaries_index[AUXILLARIES_MAX_WEIGHT + 1];
 static char *verbs_index[VERBS_MAX_WEIGHT + 1];
 static char *prepositions_index[PREPOSITIONS_MAX_WEIGHT + 1];
 
-static char *szTextPool;
+static char *szTextPool = NULL;
 static long txtBufferSize = 0;
 
 // generate a lookup table for weight -> str
@@ -409,19 +408,9 @@ void init_text_pool(long bSize, DBGenContext *ctx) {
 	gen_index(auxillaries_index, &auxillaries);
 	gen_index(verbs_index, &verbs);
 	gen_index(prepositions_index, &prepositions);
-	if (szTextPool && bSize == txtBufferSize) {
-		return;
-	}
-	if (szTextPool) {
-		free_text_pool();
-	}
 
-	txtBufferSize = bSize;
-	szTextPool = (char *)malloc(bSize + 1 + 100);
-	if (!szTextPool) {
-		txtBufferSize = 0;
-		throw std::bad_alloc();
-	}
+  txtBufferSize = bSize;
+  szTextPool = (char*)malloc(bSize + 1 + 100);
 
 	char *ptr = szTextPool;
 	char *endptr = szTextPool + bSize + 1;
@@ -432,7 +421,7 @@ void init_text_pool(long bSize, DBGenContext *ctx) {
 }
 
 void free_text_pool() {
-	free(szTextPool);
+  free(szTextPool);
 }
 
 /*

--- a/extension/tpch/dbgen/text.cpp
+++ b/extension/tpch/dbgen/text.cpp
@@ -23,7 +23,7 @@
 
 #include <stdlib.h>
 #ifndef WIN32
- /* Change for Windows NT */
+/* Change for Windows NT */
 #include <unistd.h>
 #endif /* WIN32 */
 #include <ctype.h>
@@ -64,6 +64,7 @@
 
 #include "dbgen/dss.h"
 #include "dbgen/dsstypes.h"
+#include <new>
 
 /*
  * txt_vp() --
@@ -245,11 +246,11 @@ static char *gen_text(char *dest, seed_t *seed, distribution *s) {
 	return dest + ind + 1;
 }
 
-#define NOUN_MAX_WEIGHT 340
-#define ADJECTIVES_MAX_WEIGHT 289
-#define ADVERBS_MAX_WEIGHT 262
-#define AUXILLARIES_MAX_WEIGHT 18
-#define VERBS_MAX_WEIGHT 174
+#define NOUN_MAX_WEIGHT         340
+#define ADJECTIVES_MAX_WEIGHT   289
+#define ADVERBS_MAX_WEIGHT      262
+#define AUXILLARIES_MAX_WEIGHT  18
+#define VERBS_MAX_WEIGHT        174
 #define PREPOSITIONS_MAX_WEIGHT 456
 
 static char *noun_index[NOUN_MAX_WEIGHT + 1];
@@ -408,9 +409,19 @@ void init_text_pool(long bSize, DBGenContext *ctx) {
 	gen_index(auxillaries_index, &auxillaries);
 	gen_index(verbs_index, &verbs);
 	gen_index(prepositions_index, &prepositions);
+	if (szTextPool && bSize == txtBufferSize) {
+		return;
+	}
+	if (szTextPool) {
+		free_text_pool();
+	}
 
-  txtBufferSize = bSize;
-  szTextPool = (char*)malloc(bSize + 1 + 100);
+	txtBufferSize = bSize;
+	szTextPool = (char *)malloc(bSize + 1 + 100);
+	if (!szTextPool) {
+		txtBufferSize = 0;
+		throw std::bad_alloc();
+	}
 
 	char *ptr = szTextPool;
 	char *endptr = szTextPool + bSize + 1;
@@ -421,7 +432,7 @@ void init_text_pool(long bSize, DBGenContext *ctx) {
 }
 
 void free_text_pool() {
-  free(szTextPool);
+	free(szTextPool);
 }
 
 /*

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -2032,79 +2032,29 @@ Closes the result and de-allocates all memory allocated for the arrow result.
 DUCKDB_API void duckdb_destroy_arrow(duckdb_arrow *result);
 
 //===--------------------------------------------------------------------===//
-// Threading Information
+// Task Scheduling Information
 //===--------------------------------------------------------------------===//
-typedef void *duckdb_task_state;
+typedef void *duckdb_task;
 
 /*!
-Execute DuckDB tasks on this thread.
+Fetches a task from the task scheduler in the database.
 
-Will return after `max_tasks` have been executed, or if there are no more tasks present.
+duckdb_execute_task must be called on the task, which also frees the task.
 
-* database: The database object to execute tasks for
-* max_tasks: The maximum amount of tasks to execute
+* result: The task, or NULL if no tasks are available.
 */
-DUCKDB_API void duckdb_execute_tasks(duckdb_database database, idx_t max_tasks);
+DUCKDB_API duckdb_task duckdb_get_task(duckdb_database database);
 
 /*!
-Creates a task state that can be used with duckdb_execute_tasks_state to execute tasks until
- duckdb_finish_execution is called on the state.
+Executes a task obtained from duckdb_get_task
 
-duckdb_destroy_state should be called on the result in order to free memory.
+* task: The task to execute
+ */
+DUCKDB_API void duckdb_execute_task(duckdb_task task);
 
-* database: The database object to create the task state for
-* returns: The task state that can be used with duckdb_execute_tasks_state.
-*/
-DUCKDB_API duckdb_task_state duckdb_create_task_state(duckdb_database database);
 
-/*!
-Execute DuckDB tasks on this thread.
 
-The thread will keep on executing tasks forever, until duckdb_finish_execution is called on the state.
-Multiple threads can share the same duckdb_task_state.
 
-* state: The task state of the executor
-*/
-DUCKDB_API void duckdb_execute_tasks_state(duckdb_task_state state);
-
-/*!
-Execute DuckDB tasks on this thread.
-
-The thread will keep on executing tasks until either duckdb_finish_execution is called on the state,
-max_tasks tasks have been executed or there are no more tasks to be executed.
-
-Multiple threads can share the same duckdb_task_state.
-
-* state: The task state of the executor
-* max_tasks: The maximum amount of tasks to execute
-* returns: The amount of tasks that have actually been executed
-*/
-DUCKDB_API idx_t duckdb_execute_n_tasks_state(duckdb_task_state state, idx_t max_tasks);
-
-/*!
-Finish execution on a specific task.
-
-* state: The task state to finish execution
-*/
-DUCKDB_API void duckdb_finish_execution(duckdb_task_state state);
-
-/*!
-Check if the provided duckdb_task_state has finished execution
-
-* state: The task state to inspect
-* returns: Whether or not duckdb_finish_execution has been called on the task state
-*/
-DUCKDB_API bool duckdb_task_state_is_finished(duckdb_task_state state);
-
-/*!
-Destroys the task state returned from duckdb_create_task_state.
-
-Note that this should not be called while there is an active duckdb_execute_tasks_state running
-on the task state.
-
-* state: The task state to clean up
-*/
-DUCKDB_API void duckdb_destroy_task_state(duckdb_task_state state);
 
 #ifdef __cplusplus
 }

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -2032,29 +2032,79 @@ Closes the result and de-allocates all memory allocated for the arrow result.
 DUCKDB_API void duckdb_destroy_arrow(duckdb_arrow *result);
 
 //===--------------------------------------------------------------------===//
-// Task Scheduling Information
+// Threading Information
 //===--------------------------------------------------------------------===//
-typedef void *duckdb_task;
+typedef void *duckdb_task_state;
 
 /*!
-Fetches a task from the task scheduler in the database.
+Execute DuckDB tasks on this thread.
 
-duckdb_execute_task must be called on the task, which also frees the task.
+Will return after `max_tasks` have been executed, or if there are no more tasks present.
 
-* result: The task, or NULL if no tasks are available.
+* database: The database object to execute tasks for
+* max_tasks: The maximum amount of tasks to execute
 */
-DUCKDB_API duckdb_task duckdb_get_task(duckdb_database database);
+DUCKDB_API void duckdb_execute_tasks(duckdb_database database, idx_t max_tasks);
 
 /*!
-Executes a task obtained from duckdb_get_task
+Creates a task state that can be used with duckdb_execute_tasks_state to execute tasks until
+ duckdb_finish_execution is called on the state.
 
-* task: The task to execute
- */
-DUCKDB_API void duckdb_execute_task(duckdb_task task);
+duckdb_destroy_state should be called on the result in order to free memory.
 
+* database: The database object to create the task state for
+* returns: The task state that can be used with duckdb_execute_tasks_state.
+*/
+DUCKDB_API duckdb_task_state duckdb_create_task_state(duckdb_database database);
 
+/*!
+Execute DuckDB tasks on this thread.
 
+The thread will keep on executing tasks forever, until duckdb_finish_execution is called on the state.
+Multiple threads can share the same duckdb_task_state.
 
+* state: The task state of the executor
+*/
+DUCKDB_API void duckdb_execute_tasks_state(duckdb_task_state state);
+
+/*!
+Execute DuckDB tasks on this thread.
+
+The thread will keep on executing tasks until either duckdb_finish_execution is called on the state,
+max_tasks tasks have been executed or there are no more tasks to be executed.
+
+Multiple threads can share the same duckdb_task_state.
+
+* state: The task state of the executor
+* max_tasks: The maximum amount of tasks to execute
+* returns: The amount of tasks that have actually been executed
+*/
+DUCKDB_API idx_t duckdb_execute_n_tasks_state(duckdb_task_state state, idx_t max_tasks);
+
+/*!
+Finish execution on a specific task.
+
+* state: The task state to finish execution
+*/
+DUCKDB_API void duckdb_finish_execution(duckdb_task_state state);
+
+/*!
+Check if the provided duckdb_task_state has finished execution
+
+* state: The task state to inspect
+* returns: Whether or not duckdb_finish_execution has been called on the task state
+*/
+DUCKDB_API bool duckdb_task_state_is_finished(duckdb_task_state state);
+
+/*!
+Destroys the task state returned from duckdb_create_task_state.
+
+Note that this should not be called while there is an active duckdb_execute_tasks_state running
+on the task state.
+
+* state: The task state to clean up
+*/
+DUCKDB_API void duckdb_destroy_task_state(duckdb_task_state state);
 
 #ifdef __cplusplus
 }

--- a/src/include/duckdb/main/capi_internal.hpp
+++ b/src/include/duckdb/main/capi_internal.hpp
@@ -33,6 +33,10 @@ struct PreparedStatementWrapper {
 	vector<Value> values;
 };
 
+struct PendingStatementWrapper {
+	unique_ptr<PendingQueryResult> statement;
+};
+
 struct ArrowResultWrapper {
 	unique_ptr<MaterializedQueryResult> result;
 	unique_ptr<DataChunk> current_chunk;

--- a/src/include/duckdb/parallel/task_scheduler.hpp
+++ b/src/include/duckdb/parallel/task_scheduler.hpp
@@ -52,6 +52,9 @@ public:
 	bool GetTaskFromProducer(ProducerToken &token, unique_ptr<Task> &task);
 	//! Run tasks forever until "marker" is set to false, "marker" must remain valid until the thread is joined
 	void ExecuteForever(atomic<bool> *marker);
+	//! Run tasks until `marker` is set to false, `max_tasks` have been completed, or until there are no more tasks
+	//! available. Returns the number of tasks that were completed.
+	idx_t ExecuteTasks(atomic<bool> *marker, idx_t max_tasks);
 	//! Run tasks until `max_tasks` have been completed, or until there are no more tasks available
 	void ExecuteTasks(idx_t max_tasks);
 

--- a/src/include/duckdb/parallel/task_scheduler.hpp
+++ b/src/include/duckdb/parallel/task_scheduler.hpp
@@ -52,11 +52,8 @@ public:
 	bool GetTaskFromProducer(ProducerToken &token, unique_ptr<Task> &task);
 	//! Run tasks forever until "marker" is set to false, "marker" must remain valid until the thread is joined
 	void ExecuteForever(atomic<bool> *marker);
-	//! Run tasks until `marker` is set to false, `max_tasks` have been completed, or until there are no more tasks
-	//! available. Returns the number of tasks that were completed.
-	idx_t ExecuteTasks(atomic<bool> *marker, idx_t max_tasks);
-	//! Run tasks until `max_tasks` have been completed, or until there are no more tasks available
-	void ExecuteTasks(idx_t max_tasks);
+	//! Obtains a task from the task scheduler to execute later
+	unique_ptr<Task> GetTask();
 
 	//! Sets the amount of active threads executing tasks for the system; n-1 background threads will be launched.
 	//! The main thread will also be used for execution

--- a/src/include/duckdb/parallel/task_scheduler.hpp
+++ b/src/include/duckdb/parallel/task_scheduler.hpp
@@ -52,8 +52,11 @@ public:
 	bool GetTaskFromProducer(ProducerToken &token, unique_ptr<Task> &task);
 	//! Run tasks forever until "marker" is set to false, "marker" must remain valid until the thread is joined
 	void ExecuteForever(atomic<bool> *marker);
-	//! Obtains a task from the task scheduler to execute later
-	unique_ptr<Task> GetTask();
+	//! Run tasks until `marker` is set to false, `max_tasks` have been completed, or until there are no more tasks
+	//! available. Returns the number of tasks that were completed.
+	idx_t ExecuteTasks(atomic<bool> *marker, idx_t max_tasks);
+	//! Run tasks until `max_tasks` have been completed, or until there are no more tasks available
+	void ExecuteTasks(idx_t max_tasks);
 
 	//! Sets the amount of active threads executing tasks for the system; n-1 background threads will be launched.
 	//! The main thread will also be used for execution

--- a/src/main/capi/CMakeLists.txt
+++ b/src/main/capi/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library_unity(
   helper-c.cpp
   hugeint-c.cpp
   logical_types-c.cpp
+  pending-c.cpp
   prepared-c.cpp
   replacement_scan-c.cpp
   result-c.cpp

--- a/src/main/capi/pending-c.cpp
+++ b/src/main/capi/pending-c.cpp
@@ -1,0 +1,84 @@
+#include "duckdb/main/capi_internal.hpp"
+#include "duckdb/main/query_result.hpp"
+#include "duckdb/main/pending_query_result.hpp"
+
+using duckdb::make_unique;
+using duckdb::PendingExecutionResult;
+using duckdb::PendingQueryResult;
+using duckdb::PendingStatementWrapper;
+using duckdb::PreparedStatementWrapper;
+
+duckdb_state duckdb_pending_prepared(duckdb_prepared_statement prepared_statement, duckdb_pending_result *out_result) {
+	if (!prepared_statement || !out_result) {
+		return DuckDBError;
+	}
+	auto wrapper = (PreparedStatementWrapper *)prepared_statement;
+	auto result = new PendingStatementWrapper();
+	try {
+		result->statement = wrapper->statement->PendingQuery(wrapper->values, false);
+	} catch (std::exception &ex) {
+		result->statement = make_unique<PendingQueryResult>(ex.what());
+	}
+	duckdb_state return_value = result->statement->success ? DuckDBSuccess : DuckDBError;
+	*out_result = (duckdb_pending_result)result;
+
+	return return_value;
+}
+
+void duckdb_destroy_pending(duckdb_pending_result *pending_result) {
+	if (!pending_result || !*pending_result) {
+		return;
+	}
+	auto wrapper = (PendingStatementWrapper *)*pending_result;
+	if (wrapper->statement) {
+		wrapper->statement->Close();
+	}
+	delete wrapper;
+	*pending_result = nullptr;
+}
+
+const char *duckdb_pending_error(duckdb_pending_result pending_result) {
+	if (!pending_result) {
+		return nullptr;
+	}
+	auto wrapper = (PendingStatementWrapper *)pending_result;
+	if (!wrapper->statement) {
+		return nullptr;
+	}
+	return wrapper->statement->error.c_str();
+}
+
+duckdb_pending_state duckdb_pending_execute_task(duckdb_pending_result pending_result) {
+	if (!pending_result) {
+		return DUCKDB_PENDING_ERROR;
+	}
+	auto wrapper = (PendingStatementWrapper *)pending_result;
+	if (!wrapper->statement) {
+		return DUCKDB_PENDING_ERROR;
+	}
+	if (!wrapper->statement->success) {
+		return DUCKDB_PENDING_ERROR;
+	}
+	auto return_value = wrapper->statement->ExecuteTask();
+	switch (return_value) {
+	case PendingExecutionResult::RESULT_READY:
+		return DUCKDB_PENDING_RESULT_READY;
+	case PendingExecutionResult::RESULT_NOT_READY:
+		return DUCKDB_PENDING_RESULT_NOT_READY;
+	default:
+		return DUCKDB_PENDING_ERROR;
+	}
+}
+
+duckdb_state duckdb_execute_pending(duckdb_pending_result pending_result, duckdb_result *out_result) {
+	if (!pending_result || !out_result) {
+		return DuckDBError;
+	}
+	auto wrapper = (PendingStatementWrapper *)pending_result;
+	if (!wrapper->statement) {
+		return DuckDBError;
+	}
+	auto result = wrapper->statement->Execute();
+	wrapper->statement.reset();
+	return duckdb_translate_result(move(result), out_result);
+}

--- a/src/main/capi/pending-c.cpp
+++ b/src/main/capi/pending-c.cpp
@@ -59,7 +59,14 @@ duckdb_pending_state duckdb_pending_execute_task(duckdb_pending_result pending_r
 	if (!wrapper->statement->success) {
 		return DUCKDB_PENDING_ERROR;
 	}
-	auto return_value = wrapper->statement->ExecuteTask();
+	PendingExecutionResult return_value;
+	try {
+		return_value = wrapper->statement->ExecuteTask();
+	} catch (std::exception &ex) {
+		wrapper->statement->success = false;
+		wrapper->statement->error = ex.what();
+		return DUCKDB_PENDING_ERROR;
+	}
 	switch (return_value) {
 	case PendingExecutionResult::RESULT_READY:
 		return DUCKDB_PENDING_RESULT_READY;

--- a/src/main/capi/threading-c.cpp
+++ b/src/main/capi/threading-c.cpp
@@ -3,78 +3,21 @@
 
 using duckdb::DatabaseData;
 
-struct CAPITaskState {
-	CAPITaskState(duckdb::DatabaseInstance &db)
-	    : db(db), marker(duckdb::make_unique<duckdb::atomic<bool>>(true)), execute_count(0) {
-	}
-
-	duckdb::DatabaseInstance &db;
-	duckdb::unique_ptr<duckdb::atomic<bool>> marker;
-	duckdb::atomic<idx_t> execute_count;
-};
-
-void duckdb_execute_tasks(duckdb_database database, idx_t max_tasks) {
-	if (!database) {
-		return;
-	}
-	auto wrapper = (DatabaseData *)database;
-	auto &scheduler = duckdb::TaskScheduler::GetScheduler(*wrapper->database->instance);
-	scheduler.ExecuteTasks(max_tasks);
-}
-
-duckdb_task_state duckdb_create_task_state(duckdb_database database) {
+duckdb_task duckdb_get_task(duckdb_database database) {
 	if (!database) {
 		return nullptr;
 	}
 	auto wrapper = (DatabaseData *)database;
-	auto state = new CAPITaskState(*wrapper->database->instance);
-	return state;
+	auto &scheduler = duckdb::TaskScheduler::GetScheduler(*wrapper->database->instance);
+	auto task = scheduler.GetTask();
+	return task.release();
 }
 
-void duckdb_execute_tasks_state(duckdb_task_state state_p) {
-	if (!state_p) {
+void duckdb_execute_task(duckdb_task task_p) {
+	if (!task_p) {
 		return;
 	}
-	auto state = (CAPITaskState *)state_p;
-	auto &scheduler = duckdb::TaskScheduler::GetScheduler(state->db);
-	state->execute_count++;
-	scheduler.ExecuteForever(state->marker.get());
-}
-
-idx_t duckdb_execute_n_tasks_state(duckdb_task_state state_p, idx_t max_tasks) {
-	if (!state_p) {
-		return 0;
-	}
-	auto state = (CAPITaskState *)state_p;
-	auto &scheduler = duckdb::TaskScheduler::GetScheduler(state->db);
-	return scheduler.ExecuteTasks(state->marker.get(), max_tasks);
-}
-
-void duckdb_finish_execution(duckdb_task_state state_p) {
-	if (!state_p) {
-		return;
-	}
-	auto state = (CAPITaskState *)state_p;
-	*state->marker = false;
-	if (state->execute_count > 0) {
-		// signal to the threads to wake up
-		auto &scheduler = duckdb::TaskScheduler::GetScheduler(state->db);
-		scheduler.Signal(state->execute_count);
-	}
-}
-
-bool duckdb_task_state_is_finished(duckdb_task_state state_p) {
-	if (!state_p) {
-		return false;
-	}
-	auto state = (CAPITaskState *)state_p;
-	return !*state->marker;
-}
-
-void duckdb_destroy_task_state(duckdb_task_state state_p) {
-	if (!state_p) {
-		return;
-	}
-	auto state = (CAPITaskState *)state_p;
-	delete state;
+	auto task = (duckdb::Task *) task_p;
+	task->Execute(duckdb::TaskExecutionMode::PROCESS_ALL);
+	delete task;
 }

--- a/src/main/capi/threading-c.cpp
+++ b/src/main/capi/threading-c.cpp
@@ -68,7 +68,7 @@ bool duckdb_task_state_is_finished(duckdb_task_state state_p) {
 		return false;
 	}
 	auto state = (CAPITaskState *)state_p;
-	return !*state->marker;
+	return !(*state->marker);
 }
 
 void duckdb_destroy_task_state(duckdb_task_state state_p) {

--- a/src/main/capi/threading-c.cpp
+++ b/src/main/capi/threading-c.cpp
@@ -41,6 +41,15 @@ void duckdb_execute_tasks_state(duckdb_task_state state_p) {
 	scheduler.ExecuteForever(state->marker.get());
 }
 
+idx_t duckdb_execute_n_tasks_state(duckdb_task_state state_p, idx_t max_tasks) {
+	if (!state_p) {
+		return 0;
+	}
+	auto state = (CAPITaskState *)state_p;
+	auto &scheduler = duckdb::TaskScheduler::GetScheduler(state->db);
+	return scheduler.ExecuteTasks(state->marker.get(), max_tasks);
+}
+
 void duckdb_finish_execution(duckdb_task_state state_p) {
 	if (!state_p) {
 		return;
@@ -52,6 +61,14 @@ void duckdb_finish_execution(duckdb_task_state state_p) {
 		auto &scheduler = duckdb::TaskScheduler::GetScheduler(state->db);
 		scheduler.Signal(state->execute_count);
 	}
+}
+
+bool duckdb_task_state_is_finished(duckdb_task_state state_p) {
+	if (!state_p) {
+		return false;
+	}
+	auto state = (CAPITaskState *)state_p;
+	return !*state->marker;
 }
 
 void duckdb_destroy_task_state(duckdb_task_state state_p) {

--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -141,6 +141,25 @@ void TaskScheduler::ExecuteForever(atomic<bool> *marker) {
 #endif
 }
 
+idx_t TaskScheduler::ExecuteTasks(atomic<bool> *marker, idx_t max_tasks) {
+#ifndef DUCKDB_NO_THREADS
+	idx_t completed_tasks = 0;
+	// loop until the marker is set to false
+	while (*marker && completed_tasks < max_tasks) {
+		unique_ptr<Task> task;
+		if (!queue->q.try_dequeue(task)) {
+			return completed_tasks;
+		}
+		task->Execute(TaskExecutionMode::PROCESS_ALL);
+		task.reset();
+		completed_tasks++;
+	}
+	return completed_tasks;
+#else
+	throw NotImplementedException("DuckDB was compiled without threads! Background thread loop is not allowed.");
+#endif
+}
+
 void TaskScheduler::ExecuteTasks(idx_t max_tasks) {
 #ifndef DUCKDB_NO_THREADS
 	unique_ptr<Task> task;

--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -141,43 +141,12 @@ void TaskScheduler::ExecuteForever(atomic<bool> *marker) {
 #endif
 }
 
-idx_t TaskScheduler::ExecuteTasks(atomic<bool> *marker, idx_t max_tasks) {
-#ifndef DUCKDB_NO_THREADS
-	idx_t completed_tasks = 0;
-	// loop until the marker is set to false
-	while (*marker && completed_tasks < max_tasks) {
-		unique_ptr<Task> task;
-		if (!queue->q.try_dequeue(task)) {
-			return completed_tasks;
-		}
-		task->Execute(TaskExecutionMode::PROCESS_ALL);
-		task.reset();
-		completed_tasks++;
-	}
-	return completed_tasks;
-#else
-	throw NotImplementedException("DuckDB was compiled without threads! Background thread loop is not allowed.");
-#endif
-}
-
-void TaskScheduler::ExecuteTasks(idx_t max_tasks) {
-#ifndef DUCKDB_NO_THREADS
+unique_ptr<Task> TaskScheduler::GetTask() {
 	unique_ptr<Task> task;
-	for (idx_t i = 0; i < max_tasks; i++) {
-		queue->semaphore.wait(TASK_TIMEOUT_USECS);
-		if (!queue->q.try_dequeue(task)) {
-			return;
-		}
-		try {
-			task->Execute(TaskExecutionMode::PROCESS_ALL);
-			task.reset();
-		} catch (...) {
-			return;
-		}
+	if (queue->q.try_dequeue(task)) {
+		return task;
 	}
-#else
-	throw NotImplementedException("DuckDB was compiled without threads! Background thread loop is not allowed.");
-#endif
+	return nullptr;
 }
 
 #ifndef DUCKDB_NO_THREADS

--- a/test/api/capi/CMakeLists.txt
+++ b/test/api/capi/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library_unity(
   test_capi_appender.cpp
   test_capi_arrow.cpp
   test_capi_data_chunk.cpp
+  test_capi_pending.cpp
   test_capi_prepared.cpp
   test_capi_website.cpp
   test_capi_complex_types.cpp

--- a/test/api/capi/test_capi_pending.cpp
+++ b/test/api/capi/test_capi_pending.cpp
@@ -1,0 +1,77 @@
+#include "capi_tester.hpp"
+#include "duckdb.h"
+
+using namespace duckdb;
+using namespace std;
+
+struct CAPIPrepared {
+	CAPIPrepared() {
+	}
+	~CAPIPrepared() {
+		if (!prepared) {
+			return;
+		}
+		duckdb_destroy_prepare(&prepared);
+	}
+
+	bool Prepare(CAPITester &tester, const string &query) {
+		auto state = duckdb_prepare(tester.connection, query.c_str(), &prepared);
+		return state == DuckDBSuccess;
+	}
+
+	duckdb_prepared_statement prepared = nullptr;
+};
+
+struct CAPIPending {
+	CAPIPending() {
+	}
+	~CAPIPending() {
+		if (!pending) {
+			return;
+		}
+		duckdb_destroy_pending(&pending);
+	}
+
+	bool Pending(CAPIPrepared &prepared) {
+		auto state = duckdb_pending_prepared(prepared.prepared, &pending);
+		return state == DuckDBSuccess;
+	}
+
+	duckdb_pending_state ExecuteTask() {
+		REQUIRE(pending);
+		return duckdb_pending_execute_task(pending);
+	}
+
+	unique_ptr<CAPIResult> Execute() {
+		duckdb_result result;
+		auto success = duckdb_execute_pending(pending, &result) == DuckDBSuccess;
+		return make_unique<CAPIResult>(result, success);
+	}
+
+	duckdb_pending_result pending = nullptr;
+};
+
+TEST_CASE("Test pending statements in C API", "[capi]") {
+	CAPITester tester;
+	CAPIPrepared prepared;
+	CAPIPending pending;
+	unique_ptr<CAPIResult> result;
+
+	// open the database in in-memory mode
+	REQUIRE(tester.OpenDatabase(nullptr));
+	REQUIRE(prepared.Prepare(tester, "SELECT SUM(i) FROM range(1000000) tbl(i)"));
+	REQUIRE(pending.Pending(prepared));
+
+	while (true) {
+		auto state = pending.ExecuteTask();
+		REQUIRE(state != DUCKDB_PENDING_ERROR);
+		if (state == DUCKDB_PENDING_RESULT_READY) {
+			break;
+		}
+	}
+
+	result = pending.Execute();
+	REQUIRE(result);
+	REQUIRE(result->success);
+	REQUIRE(result->Fetch<int64_t>(0, 0) == 499999500000LL);
+}

--- a/test/include/capi_tester.hpp
+++ b/test/include/capi_tester.hpp
@@ -41,6 +41,10 @@ private:
 
 class CAPIResult {
 public:
+	CAPIResult() {
+	}
+	CAPIResult(duckdb_result result, bool success) : success(success), result(result) {
+	}
 	~CAPIResult() {
 		duckdb_destroy_result(&result);
 	}

--- a/tools/juliapkg/src/api.jl
+++ b/tools/juliapkg/src/api.jl
@@ -2643,86 +2643,24 @@ end
 // Threading Interface
 //===--------------------------------------------------------------------===//
 =#
-"""
-Execute DuckDB tasks on this thread.
 
-Will return after `max_tasks` have been executed, or if there are no more tasks present.
 
-* database: The database object to execute tasks for
-* max_tasks: The maximum amount of tasks to execute
 """
-function duckdb_execute_tasks(handle, max_tasks)
-    return ccall((:duckdb_execute_tasks, libduckdb), Cvoid, (duckdb_database, UInt64), handle, max_tasks)
+Fetches a task from the task scheduler in the database.
+
+duckdb_execute_task must be called on the task, which also frees the task.
+
+* result: The task, or NULL if no tasks are available.
+"""
+function duckdb_get_task(database)
+    return ccall((:duckdb_get_task, libduckdb), duckdb_task, (duckdb_database, ), database)
 end
 
 """
-Creates a task state that can be used with duckdb_execute_tasks_state to execute tasks until
- duckdb_finish_execution is called on the state.
+Executes a task obtained from duckdb_get_task
 
-duckdb_destroy_state should be called on the result in order to free memory.
-
-* returns: The task state that can be used with duckdb_execute_tasks_state.
+* task: The task to execute
 """
-function duckdb_create_task_state(database)
-    return ccall((:duckdb_create_task_state, libduckdb), duckdb_task_state, (duckdb_database,), database)
-end
-
-"""
-Execute DuckDB tasks on this thread.
-
-The thread will keep on executing tasks forever, until duckdb_finish_execution is called on the state.
-Multiple threads can share the same duckdb_task_state.
-
-* database: The database object to execute tasks for
-* state: The task state of the executor
-"""
-function duckdb_execute_tasks_state(state)
-    return ccall((:duckdb_execute_tasks_state, libduckdb), Cvoid, (duckdb_task_state,), state)
-end
-
-"""
-Execute DuckDB tasks on this thread.
-
-The thread will keep on executing tasks until either duckdb_finish_execution is called on the state,
-max_tasks tasks have been executed or there are no more tasks to be executed.
-
-Multiple threads can share the same duckdb_task_state.
-
-* state: The task state of the executor
-* max_tasks: The maximum amount of tasks to execute
-* returns: The amount of tasks that have actually been executed
-"""
-function duckdb_execute_n_tasks_state(state, max_tasks)
-    return ccall((:duckdb_execute_n_tasks_state, libduckdb), UInt64, (duckdb_task_state, UInt64), state, max_tasks)
-end
-
-"""
-Finish execution on a specific task.
-
-* state: The task state to finish execution
-"""
-function duckdb_finish_execution(state)
-    return ccall((:duckdb_finish_execution, libduckdb), Cvoid, (duckdb_task_state,), state)
-end
-
-"""
-Check if the provided duckdb_task_state has finished execution
-
-* state: The task state to inspect
-* returns: Whether or not duckdb_finish_execution has been called on the task state
-"""
-function duckdb_task_state_is_finished(state)
-    return ccall((:duckdb_task_state_is_finished, libduckdb), Bool, (duckdb_task_state,), state)
-end
-
-"""
-Destroys the task state returned from duckdb_create_task_state.
-
-Note that this should not be called while there is an active duckdb_execute_tasks_state running
-on the task state.
-
-* state: The task state to clean up
-"""
-function duckdb_destroy_task_state(state)
-    return ccall((:duckdb_destroy_task_state, libduckdb), Cvoid, (duckdb_task_state,), state)
+function duckdb_execute_task(task)
+    return ccall((:duckdb_execute_task, libduckdb), Cvoid, (duckdb_task, ), task)
 end

--- a/tools/juliapkg/src/api.jl
+++ b/tools/juliapkg/src/api.jl
@@ -1207,6 +1207,94 @@ end
 #     )
 # end
 
+#=
+//===--------------------------------------------------------------------===//
+// Pending Result Interface
+//===--------------------------------------------------------------------===//
+=#
+"""
+Executes the prepared statement with the given bound parameters, and returns a pending result.
+The pending result represents an intermediate structure for a query that is not yet fully executed.
+The pending result can be used to incrementally execute a query, returning control to the client between tasks.
+
+Note that after calling `duckdb_pending_prepared`, the pending result should always be destroyed using
+`duckdb_destroy_pending`, even if this function returns DuckDBError.
+
+* prepared_statement: The prepared statement to execute.
+* out_result: The pending query result.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+"""
+function duckdb_pending_prepared(prepared_statement, out_pending)
+    return ccall(
+        (:duckdb_pending_prepared, libduckdb),
+        duckdb_state,
+        (duckdb_prepared_statement, Ref{duckdb_pending_result}),
+        prepared_statement,
+        out_pending
+    )
+end
+
+"""
+Closes the pending result and de-allocates all memory allocated for the result.
+
+* pending_result: The pending result to destroy.
+"""
+function duckdb_destroy_pending(pending_result)
+    return ccall((:duckdb_destroy_pending, libduckdb), Cvoid, (Ref{duckdb_pending_result},), pending_result)
+end
+
+"""
+Returns the error message contained within the pending result.
+
+The result of this function must not be freed. It will be cleaned up when `duckdb_destroy_pending` is called.
+
+* result: The pending result to fetch the error from.
+* returns: The error of the pending result.
+"""
+function duckdb_pending_error(pending_result)
+    return ccall((:duckdb_pending_error, libduckdb), Ptr{UInt8}, (duckdb_pending_result,), pending_result)
+end
+
+"""
+Executes a single task within the query, returning whether or not the query is ready.
+
+If this returns DUCKDB_PENDING_RESULT_READY, the duckdb_execute_pending function can be called to obtain the result.
+If this returns DUCKDB_PENDING_RESULT_NOT_READY, the duckdb_pending_execute_task function should be called again.
+If this returns DUCKDB_PENDING_ERROR, an error occurred during execution.
+
+The error message can be obtained by calling duckdb_pending_error on the pending_result.
+
+* pending_result: The pending result to execute a task within.
+* returns: The state of the pending result after the execution.
+"""
+function duckdb_pending_execute_task(pending_result)
+    return ccall(
+        (:duckdb_pending_execute_task, libduckdb),
+        duckdb_pending_state,
+        (duckdb_pending_result,),
+        pending_result
+    )
+end
+
+"""
+Fully execute a pending query result, returning the final query result.
+
+If duckdb_pending_execute_task has been called until DUCKDB_PENDING_RESULT_READY was returned, this will return fast.
+Otherwise, all remaining tasks must be executed first.
+
+* pending_result: The pending result to execute.
+* out_result: The result object.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+"""
+function duckdb_execute_pending(pending_result, out_result)
+    return ccall(
+        (:duckdb_execute_pending, libduckdb),
+        duckdb_state,
+        (duckdb_pending_result, Ref{duckdb_result}),
+        pending_result,
+        out_result
+    )
+end
 
 #=
 //===--------------------------------------------------------------------===//
@@ -2555,50 +2643,86 @@ end
 // Threading Interface
 //===--------------------------------------------------------------------===//
 =#
-# Execute DuckDB tasks on this thread.
-#
-# Will return after `max_tasks` have been executed, or if there are no more tasks present.
-#
-# * database: The database object to execute tasks for
-# * max_tasks: The maximum amount of tasks to execute
+"""
+Execute DuckDB tasks on this thread.
+
+Will return after `max_tasks` have been executed, or if there are no more tasks present.
+
+* database: The database object to execute tasks for
+* max_tasks: The maximum amount of tasks to execute
+"""
 function duckdb_execute_tasks(handle, max_tasks)
     return ccall((:duckdb_execute_tasks, libduckdb), Cvoid, (duckdb_database, UInt64), handle, max_tasks)
 end
 
-# Creates a task state that can be used with duckdb_execute_tasks_state to execute tasks until
-#  duckdb_finish_execution is called on the state.
-#
-# duckdb_destroy_state should be called on the result in order to free memory.
-#
-# * returns: The task state that can be used with duckdb_execute_tasks_state.
+"""
+Creates a task state that can be used with duckdb_execute_tasks_state to execute tasks until
+ duckdb_finish_execution is called on the state.
+
+duckdb_destroy_state should be called on the result in order to free memory.
+
+* returns: The task state that can be used with duckdb_execute_tasks_state.
+"""
 function duckdb_create_task_state(database)
     return ccall((:duckdb_create_task_state, libduckdb), duckdb_task_state, (duckdb_database,), database)
 end
 
-# Execute DuckDB tasks on this thread.
-#
-# The thread will keep on executing tasks forever, until duckdb_finish_execution is called on the state.
-# Multiple threads can share the same duckdb_task_state.
-#
-# * database: The database object to execute tasks for
-# * state: The task state of the executor
+"""
+Execute DuckDB tasks on this thread.
+
+The thread will keep on executing tasks forever, until duckdb_finish_execution is called on the state.
+Multiple threads can share the same duckdb_task_state.
+
+* database: The database object to execute tasks for
+* state: The task state of the executor
+"""
 function duckdb_execute_tasks_state(state)
     return ccall((:duckdb_execute_tasks_state, libduckdb), Cvoid, (duckdb_task_state,), state)
 end
 
-# Finish execution on a specific task.
-#
-# * state: The task state to finish execution
+"""
+Execute DuckDB tasks on this thread.
+
+The thread will keep on executing tasks until either duckdb_finish_execution is called on the state,
+max_tasks tasks have been executed or there are no more tasks to be executed.
+
+Multiple threads can share the same duckdb_task_state.
+
+* state: The task state of the executor
+* max_tasks: The maximum amount of tasks to execute
+* returns: The amount of tasks that have actually been executed
+"""
+function duckdb_execute_n_tasks_state(state, max_tasks)
+    return ccall((:duckdb_execute_n_tasks_state, libduckdb), UInt64, (duckdb_task_state, UInt64), state, max_tasks)
+end
+
+"""
+Finish execution on a specific task.
+
+* state: The task state to finish execution
+"""
 function duckdb_finish_execution(state)
     return ccall((:duckdb_finish_execution, libduckdb), Cvoid, (duckdb_task_state,), state)
 end
 
-# Destroys the task state returned from duckdb_create_task_state.
-#
-# Note that this should not be called while there is an active duckdb_execute_tasks_state running
-# on the task state.
-#
-# * state: The task state to clean up
+"""
+Check if the provided duckdb_task_state has finished execution
+
+* state: The task state to inspect
+* returns: Whether or not duckdb_finish_execution has been called on the task state
+"""
+function duckdb_task_state_is_finished(state)
+    return ccall((:duckdb_task_state_is_finished, libduckdb), Bool, (duckdb_task_state,), state)
+end
+
+"""
+Destroys the task state returned from duckdb_create_task_state.
+
+Note that this should not be called while there is an active duckdb_execute_tasks_state running
+on the task state.
+
+* state: The task state to clean up
+"""
 function duckdb_destroy_task_state(state)
     return ccall((:duckdb_destroy_task_state, libduckdb), Cvoid, (duckdb_task_state,), state)
 end

--- a/tools/juliapkg/src/ctypes.jl
+++ b/tools/juliapkg/src/ctypes.jl
@@ -3,6 +3,7 @@ const duckdb_database = Ptr{Cvoid}
 const duckdb_config = Ptr{Cvoid}
 const duckdb_connection = Ptr{Cvoid}
 const duckdb_prepared_statement = Ptr{Cvoid}
+const duckdb_pending_result = Ptr{Cvoid}
 const duckdb_logical_type = Ptr{Cvoid}
 const duckdb_data_chunk = Ptr{Cvoid}
 const duckdb_vector = Ptr{Cvoid}
@@ -15,9 +16,16 @@ const duckdb_init_info = Ptr{Cvoid}
 const duckdb_function_info = Ptr{Cvoid}
 const duckdb_replacement_scan_info = Ptr{Cvoid}
 const duckdb_task_state = Ptr{Cvoid}
+
+const duckdb_state = Int32;
 const DuckDBSuccess = 0;
 const DuckDBError = 1;
-const duckdb_state = Int32;
+
+const duckdb_pending_state = Int32;
+const DUCKDB_PENDING_RESULT_READY = 0;
+const DUCKDB_PENDING_RESULT_NOT_READY = 1;
+const DUCKDB_PENDING_ERROR = 2;
+
 
 @enum DUCKDB_TYPE_::UInt32 begin
     DUCKDB_TYPE_INVALID = 0

--- a/tools/juliapkg/src/ctypes.jl
+++ b/tools/juliapkg/src/ctypes.jl
@@ -15,7 +15,7 @@ const duckdb_bind_info = Ptr{Cvoid}
 const duckdb_init_info = Ptr{Cvoid}
 const duckdb_function_info = Ptr{Cvoid}
 const duckdb_replacement_scan_info = Ptr{Cvoid}
-const duckdb_task = Ptr{Cvoid}
+const duckdb_task_state = Ptr{Cvoid}
 
 const duckdb_state = Int32;
 const DuckDBSuccess = 0;

--- a/tools/juliapkg/src/ctypes.jl
+++ b/tools/juliapkg/src/ctypes.jl
@@ -15,7 +15,7 @@ const duckdb_bind_info = Ptr{Cvoid}
 const duckdb_init_info = Ptr{Cvoid}
 const duckdb_function_info = Ptr{Cvoid}
 const duckdb_replacement_scan_info = Ptr{Cvoid}
-const duckdb_task_state = Ptr{Cvoid}
+const duckdb_task = Ptr{Cvoid}
 
 const duckdb_state = Int32;
 const DuckDBSuccess = 0;

--- a/tools/juliapkg/src/result.jl
+++ b/tools/juliapkg/src/result.jl
@@ -535,35 +535,16 @@ function get_error(stmt::Stmt, pending::PendingQueryResult)
     return error_message
 end
 
-# execute tasks from a pending query result in a loop
-# function pending_execute_tasks(pending::PendingQueryResult)::Bool
-#     ret = DUCKDB_PENDING_RESULT_NOT_READY
-#     while ret == DUCKDB_PENDING_RESULT_NOT_READY
-#     	GC.safepoint()
-#         ret = duckdb_pending_execute_task(pending.handle)
-#     end
-#     return ret != DUCKDB_PENDING_ERROR
-# end
-
 # execute background tasks, until task execution is finished
-function execute_tasks(state::duckdb_task_state)
-	while !duckdb_task_state_is_finished(state)
-		GC.safepoint()
-		count = duckdb_execute_n_tasks_state(state, 1)
-		if count == 0
-			break
-		end
-	end
-	return
+function execute_task(task::duckdb_task)
+	duckdb_execute_task(task)
 end
 
 # cleanup background tasks
-function cleanup_tasks(tasks, state)
-    duckdb_finish_execution(state)
+function cleanup_tasks(tasks)
     for task in tasks
         Base.wait(task)
     end
-    duckdb_destroy_task_state(state)
     return
 end
 
@@ -576,22 +557,26 @@ function execute(stmt::Stmt, params::DBInterface.StatementParams = ())
     if !pending.success
         throw(QueryException(get_error(stmt, pending)))
     end
-    # if multi-threading is enabled, launch background tasks
-    task_state = duckdb_create_task_state(stmt.con.db.handle)
-    tasks = []
-    for i in 2:Threads.nthreads()
-        task_val = @spawn execute_tasks(task_state)
-        push!(tasks, task_val)
-    end
+    multi_threading = Threads.nthreads() > 1
     # now start executing tasks of the pending result in a loop
+    tasks = []
     ret = DUCKDB_PENDING_RESULT_NOT_READY
     while ret == DUCKDB_PENDING_RESULT_NOT_READY
+    	# if multi-threading is enabled, launch background tasks
     	GC.safepoint()
+    	while true
+    		task = duckdb_get_task(stmt.con.db.handle)
+    		if task == C_NULL
+    			break
+    		end
+    		task_thread = @spawn execute_task(task)
+    		push!(tasks, task_thread)
+    	end
         ret = duckdb_pending_execute_task(pending.handle)
     end
     success = ret != DUCKDB_PENDING_ERROR
     # we finished execution of all tasks, cleanup the tasks
-    cleanup_tasks(tasks, task_state)
+    cleanup_tasks(tasks)
     # check if an error was thrown
     if !success
         throw(QueryException(get_error(stmt, pending)))

--- a/tools/juliapkg/src/result.jl
+++ b/tools/juliapkg/src/result.jl
@@ -580,8 +580,15 @@ function execute(stmt::Stmt, params::DBInterface.StatementParams = ())
         task_val = @spawn execute_tasks(task_state)
         push!(tasks, task_val)
     end
-    # now start executing tasks of the pending result in a loop
-    success = pending_execute_tasks(pending)
+    success = true
+    try
+        # now start executing tasks of the pending result in a loop
+        success = pending_execute_tasks(pending)
+    catch ex
+        cleanup_tasks(tasks, task_state)
+        throw(ex)
+    end
+
     # we finished execution of all tasks, cleanup the tasks
     cleanup_tasks(tasks, task_state)
     # check if an error was thrown

--- a/tools/juliapkg/src/result.jl
+++ b/tools/juliapkg/src/result.jl
@@ -536,22 +536,25 @@ function get_error(stmt::Stmt, pending::PendingQueryResult)
 end
 
 # execute tasks from a pending query result in a loop
-function pending_execute_tasks(pending::PendingQueryResult)::Bool
-    ret = DUCKDB_PENDING_RESULT_NOT_READY
-    while ret == DUCKDB_PENDING_RESULT_NOT_READY
-        GC.safepoint()
-        ret = duckdb_pending_execute_task(pending.handle)
-    end
-    return ret != DUCKDB_PENDING_ERROR
-end
+# function pending_execute_tasks(pending::PendingQueryResult)::Bool
+#     ret = DUCKDB_PENDING_RESULT_NOT_READY
+#     while ret == DUCKDB_PENDING_RESULT_NOT_READY
+#     	GC.safepoint()
+#         ret = duckdb_pending_execute_task(pending.handle)
+#     end
+#     return ret != DUCKDB_PENDING_ERROR
+# end
 
-# execute background tasks in a loop, until task execution is finished
+# execute background tasks, until task execution is finished
 function execute_tasks(state::duckdb_task_state)
-    while !duckdb_task_state_is_finished(state)
-        GC.safepoint()
-        duckdb_execute_n_tasks_state(state, 1)
-    end
-    return
+	while !duckdb_task_state_is_finished(state)
+		GC.safepoint()
+		count = duckdb_execute_n_tasks_state(state, 1)
+		if count == 0
+			break
+		end
+	end
+	return
 end
 
 # cleanup background tasks
@@ -581,7 +584,12 @@ function execute(stmt::Stmt, params::DBInterface.StatementParams = ())
         push!(tasks, task_val)
     end
     # now start executing tasks of the pending result in a loop
-    success = pending_execute_tasks(pending)
+    ret = DUCKDB_PENDING_RESULT_NOT_READY
+    while ret == DUCKDB_PENDING_RESULT_NOT_READY
+    	GC.safepoint()
+        ret = duckdb_pending_execute_task(pending.handle)
+    end
+    success = ret != DUCKDB_PENDING_ERROR
     # we finished execution of all tasks, cleanup the tasks
     cleanup_tasks(tasks, task_state)
     # check if an error was thrown

--- a/tools/juliapkg/test/test_tpch.jl
+++ b/tools/juliapkg/test/test_tpch.jl
@@ -1,54 +1,52 @@
 # test_tpch.jl
 
 @testset "Test TPC-H" begin
-    sf = "0.1"
+    sf = "0.01"
 
-	while true
-		# load TPC-H into DuckDB
-		native_con = DBInterface.connect(DuckDB.DB)
-		DBInterface.execute(native_con, "CALL dbgen(sf=$sf)")
+    # load TPC-H into DuckDB
+    native_con = DBInterface.connect(DuckDB.DB)
+    DBInterface.execute(native_con, "CALL dbgen(sf=$sf)")
 
-		# convert all tables to Julia DataFrames
-		customer = DataFrame(DBInterface.execute(native_con, "SELECT * FROM customer"))
-		lineitem = DataFrame(DBInterface.execute(native_con, "SELECT * FROM lineitem"))
-		nation = DataFrame(DBInterface.execute(native_con, "SELECT * FROM nation"))
-		orders = DataFrame(DBInterface.execute(native_con, "SELECT * FROM orders"))
-		part = DataFrame(DBInterface.execute(native_con, "SELECT * FROM part"))
-		partsupp = DataFrame(DBInterface.execute(native_con, "SELECT * FROM partsupp"))
-		region = DataFrame(DBInterface.execute(native_con, "SELECT * FROM region"))
-		supplier = DataFrame(DBInterface.execute(native_con, "SELECT * FROM supplier"))
+    # convert all tables to Julia DataFrames
+    customer = DataFrame(DBInterface.execute(native_con, "SELECT * FROM customer"))
+    lineitem = DataFrame(DBInterface.execute(native_con, "SELECT * FROM lineitem"))
+    nation = DataFrame(DBInterface.execute(native_con, "SELECT * FROM nation"))
+    orders = DataFrame(DBInterface.execute(native_con, "SELECT * FROM orders"))
+    part = DataFrame(DBInterface.execute(native_con, "SELECT * FROM part"))
+    partsupp = DataFrame(DBInterface.execute(native_con, "SELECT * FROM partsupp"))
+    region = DataFrame(DBInterface.execute(native_con, "SELECT * FROM region"))
+    supplier = DataFrame(DBInterface.execute(native_con, "SELECT * FROM supplier"))
 
-		# now open a new in-memory database, and register the dataframes there
-		df_con = DBInterface.connect(DuckDB.DB)
-		DuckDB.register_data_frame(df_con, customer, "customer")
-		DuckDB.register_data_frame(df_con, lineitem, "lineitem")
-		DuckDB.register_data_frame(df_con, nation, "nation")
-		DuckDB.register_data_frame(df_con, orders, "orders")
-		DuckDB.register_data_frame(df_con, part, "part")
-		DuckDB.register_data_frame(df_con, partsupp, "partsupp")
-		DuckDB.register_data_frame(df_con, region, "region")
-		DuckDB.register_data_frame(df_con, supplier, "supplier")
-		GC.gc()
+    # now open a new in-memory database, and register the dataframes there
+    df_con = DBInterface.connect(DuckDB.DB)
+    DuckDB.register_data_frame(df_con, customer, "customer")
+    DuckDB.register_data_frame(df_con, lineitem, "lineitem")
+    DuckDB.register_data_frame(df_con, nation, "nation")
+    DuckDB.register_data_frame(df_con, orders, "orders")
+    DuckDB.register_data_frame(df_con, part, "part")
+    DuckDB.register_data_frame(df_con, partsupp, "partsupp")
+    DuckDB.register_data_frame(df_con, region, "region")
+    DuckDB.register_data_frame(df_con, supplier, "supplier")
+    GC.gc()
 
-		# run all the queries
-		for i in 1:22
-					print("Q$i\n")
-			# for each query, compare the results of the query ran on the original tables
-			# versus the result when run on the Julia DataFrames
-			res = DataFrame(DBInterface.execute(df_con, "PRAGMA tpch($i)"))
-			res2 = DataFrame(DBInterface.execute(native_con, "PRAGMA tpch($i)"))
-			@test isequal(res, res2)
-					print("Native DuckDB\n")
-					@time begin
-						results = DBInterface.execute(native_con, "PRAGMA tpch($i)")
-					end
-					print("DataFrame\n")
-					@time begin
-						results = DBInterface.execute(df_con, "PRAGMA tpch($i)")
-					end
-		end
+    # run all the queries
+    for i in 1:22
+        #         print("Q$i\n")
+        # for each query, compare the results of the query ran on the original tables
+        # versus the result when run on the Julia DataFrames
+        res = DataFrame(DBInterface.execute(df_con, "PRAGMA tpch($i)"))
+        res2 = DataFrame(DBInterface.execute(native_con, "PRAGMA tpch($i)"))
+        @test isequal(res, res2)
+        #         print("Native DuckDB\n")
+        #         @time begin
+        #             results = DBInterface.execute(native_con, "PRAGMA tpch($i)")
+        #         end
+        #         print("DataFrame\n")
+        #         @time begin
+        #             results = DBInterface.execute(df_con, "PRAGMA tpch($i)")
+        #         end
+    end
 
-		DBInterface.close!(df_con)
-		DBInterface.close!(native_con)
-	end
+    DBInterface.close!(df_con)
+    DBInterface.close!(native_con)
 end

--- a/tools/juliapkg/test/test_tpch.jl
+++ b/tools/juliapkg/test/test_tpch.jl
@@ -1,52 +1,54 @@
 # test_tpch.jl
 
 @testset "Test TPC-H" begin
-    sf = "0.01"
+    sf = "0.1"
 
-    # load TPC-H into DuckDB
-    native_con = DBInterface.connect(DuckDB.DB)
-    DBInterface.execute(native_con, "CALL dbgen(sf=$sf)")
+	while true
+		# load TPC-H into DuckDB
+		native_con = DBInterface.connect(DuckDB.DB)
+		DBInterface.execute(native_con, "CALL dbgen(sf=$sf)")
 
-    # convert all tables to Julia DataFrames
-    customer = DataFrame(DBInterface.execute(native_con, "SELECT * FROM customer"))
-    lineitem = DataFrame(DBInterface.execute(native_con, "SELECT * FROM lineitem"))
-    nation = DataFrame(DBInterface.execute(native_con, "SELECT * FROM nation"))
-    orders = DataFrame(DBInterface.execute(native_con, "SELECT * FROM orders"))
-    part = DataFrame(DBInterface.execute(native_con, "SELECT * FROM part"))
-    partsupp = DataFrame(DBInterface.execute(native_con, "SELECT * FROM partsupp"))
-    region = DataFrame(DBInterface.execute(native_con, "SELECT * FROM region"))
-    supplier = DataFrame(DBInterface.execute(native_con, "SELECT * FROM supplier"))
+		# convert all tables to Julia DataFrames
+		customer = DataFrame(DBInterface.execute(native_con, "SELECT * FROM customer"))
+		lineitem = DataFrame(DBInterface.execute(native_con, "SELECT * FROM lineitem"))
+		nation = DataFrame(DBInterface.execute(native_con, "SELECT * FROM nation"))
+		orders = DataFrame(DBInterface.execute(native_con, "SELECT * FROM orders"))
+		part = DataFrame(DBInterface.execute(native_con, "SELECT * FROM part"))
+		partsupp = DataFrame(DBInterface.execute(native_con, "SELECT * FROM partsupp"))
+		region = DataFrame(DBInterface.execute(native_con, "SELECT * FROM region"))
+		supplier = DataFrame(DBInterface.execute(native_con, "SELECT * FROM supplier"))
 
-    # now open a new in-memory database, and register the dataframes there
-    df_con = DBInterface.connect(DuckDB.DB)
-    DuckDB.register_data_frame(df_con, customer, "customer")
-    DuckDB.register_data_frame(df_con, lineitem, "lineitem")
-    DuckDB.register_data_frame(df_con, nation, "nation")
-    DuckDB.register_data_frame(df_con, orders, "orders")
-    DuckDB.register_data_frame(df_con, part, "part")
-    DuckDB.register_data_frame(df_con, partsupp, "partsupp")
-    DuckDB.register_data_frame(df_con, region, "region")
-    DuckDB.register_data_frame(df_con, supplier, "supplier")
-    GC.gc()
+		# now open a new in-memory database, and register the dataframes there
+		df_con = DBInterface.connect(DuckDB.DB)
+		DuckDB.register_data_frame(df_con, customer, "customer")
+		DuckDB.register_data_frame(df_con, lineitem, "lineitem")
+		DuckDB.register_data_frame(df_con, nation, "nation")
+		DuckDB.register_data_frame(df_con, orders, "orders")
+		DuckDB.register_data_frame(df_con, part, "part")
+		DuckDB.register_data_frame(df_con, partsupp, "partsupp")
+		DuckDB.register_data_frame(df_con, region, "region")
+		DuckDB.register_data_frame(df_con, supplier, "supplier")
+		GC.gc()
 
-    # run all the queries
-    for i in 1:22
-        #         print("Q$i\n")
-        # for each query, compare the results of the query ran on the original tables
-        # versus the result when run on the Julia DataFrames
-        res = DataFrame(DBInterface.execute(df_con, "PRAGMA tpch($i)"))
-        res2 = DataFrame(DBInterface.execute(native_con, "PRAGMA tpch($i)"))
-        @test isequal(res, res2)
-        #         print("Native DuckDB\n")
-        #         @time begin
-        #             results = DBInterface.execute(native_con, "PRAGMA tpch($i)")
-        #         end
-        #         print("DataFrame\n")
-        #         @time begin
-        #             results = DBInterface.execute(df_con, "PRAGMA tpch($i)")
-        #         end
-    end
+		# run all the queries
+		for i in 1:22
+					print("Q$i\n")
+			# for each query, compare the results of the query ran on the original tables
+			# versus the result when run on the Julia DataFrames
+			res = DataFrame(DBInterface.execute(df_con, "PRAGMA tpch($i)"))
+			res2 = DataFrame(DBInterface.execute(native_con, "PRAGMA tpch($i)"))
+			@test isequal(res, res2)
+					print("Native DuckDB\n")
+					@time begin
+						results = DBInterface.execute(native_con, "PRAGMA tpch($i)")
+					end
+					print("DataFrame\n")
+					@time begin
+						results = DBInterface.execute(df_con, "PRAGMA tpch($i)")
+					end
+		end
 
-    DBInterface.close!(df_con)
-    DBInterface.close!(native_con)
+		DBInterface.close!(df_con)
+		DBInterface.close!(native_con)
+	end
 end


### PR DESCRIPTION
This PR fixes the GC disabling in the Julia connector - which used to be required because of the way the Julia tasks interacted with the garbage collector. We fix this issue by pulling the task execution loop into Julia, so that `GC.safepoint` can be called in between tasks, which allows the garbage collector to run in the middle of executing (long-running) queries.

Code snippet:

```julia
function execute_tasks(state::duckdb_task_state)
     while !duckdb_task_state_is_finished(state)
         GC.safepoint()
         duckdb_execute_n_tasks_state(state, 1)
     end
     return
 end
```

As part of this rework, we also add support for pending query results to the C API and use them in the Julia client. 

CC @nantiamak 