### PR TITLE
Allow table functions to set cardinality stats through the C API - and utilize this in Julia DataFrame scans

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -1612,6 +1612,14 @@ Sets the user-provided bind data in the bind object. This object can be retrieve
 DUCKDB_API void duckdb_bind_set_bind_data(duckdb_bind_info info, void *bind_data, duckdb_delete_callback_t destroy);
 
 /*!
+Sets the cardinality estimate for the table function, used for optimization.
+
+* info: The bind data object.
+* is_exact: Whether or not the cardinality estimate is exact, or an approximation
+*/
+DUCKDB_API void duckdb_bind_set_cardinality(duckdb_bind_info info, idx_t cardinality, bool is_exact);
+
+/*!
 Report that an error has occurred while calling bind.
 
 * info: The info object

--- a/tools/juliapkg/src/api.jl
+++ b/tools/juliapkg/src/api.jl
@@ -2029,6 +2029,23 @@ function duckdb_bind_set_bind_data(bind_info, bind_data, delete_callback)
 end
 
 """
+Sets the cardinality estimate for the table function, used for optimization.
+
+* info: The bind data object.
+* is_exact: Whether or not the cardinality estimate is exact, or an approximation
+"""
+function duckdb_bind_set_cardinality(bind_info, cardinality, is_exact)
+    return ccall(
+        (:duckdb_bind_set_cardinality, libduckdb),
+        Cvoid,
+        (duckdb_bind_info, UInt64, Bool),
+        bind_info,
+        cardinality,
+        is_exact
+    )
+end
+
+"""
 Report that an error has occurred during bind.
 
 * info: The info object

--- a/tools/juliapkg/src/data_frame_scan.jl
+++ b/tools/juliapkg/src/data_frame_scan.jl
@@ -119,6 +119,10 @@ function df_bind_function(info::DuckDB.BindInfo)
     extra_data = DuckDB.get_extra_data(info)
     df = extra_data[name]
 
+    # set the cardinality
+    row_count::UInt64 = size(df, 1)
+    DuckDB.set_stats_cardinality(info, row_count, true)
+
     # register the result columns
     input_columns = Vector()
     scan_types::Vector{Type} = Vector()

--- a/tools/juliapkg/src/table_function.jl
+++ b/tools/juliapkg/src/table_function.jl
@@ -30,6 +30,11 @@ function get_parameter(bind_info::BindInfo, index::Int64)
     return Value(duckdb_bind_get_parameter(bind_info.handle, index))
 end
 
+function set_stats_cardinality(bind_info::BindInfo, cardinality::UInt64, is_exact::Bool)
+    duckdb_bind_set_cardinality(bind_info.handle, cardinality, is_exact)
+    return
+end
+
 function add_result_column(bind_info::BindInfo, name::AbstractString, type::DataType)
     return add_result_column(bind_info, name, create_logical_type(type))
 end


### PR DESCRIPTION
This mostly equalizes the execution time between the Julia DF Scan and native query execution on TPC-H as the optimizer can now make better decisions for the Julia DF scans as well. There is still a gap remaining in certain queries because of missing min/max stats, and missing HLL stats will cause further gaps after #4274 is merged, but performance is looking very good now.

See below for TPC-H SF10 timings using both the native DuckDB tables and scanning Julia DataFrames.

| Query | Native | Julia DF Scan |
|-------|--------|---------------|
| Q01   | 0.36s  | 0.49s         |
| Q02   | 0.08s  | 0.18s         |
| Q03   | 0.32s  | 0.37s         |
| Q04   | 0.83s  | 0.92s         |
| Q05   | 0.23s  | 0.40s         |
| Q06   | 0.07s  | 0.25s         |
| Q07   | 0.56s  | 0.76s         |
| Q08   | 0.21s  | 0.29s         |
| Q09   | 4.28s  | 4.58s         |
| Q10   | 0.41s  | 0.54s         |
| Q11   | 0.05s  | 0.06s         |
| Q12   | 0.43s  | 0.49s         |
| Q13   | 0.42s  | 0.45s         |
| Q14   | 0.12s  | 0.12s         |
| Q15   | 0.32s  | 0.20s         |
| Q16   | 0.37s  | 0.39s         |
| Q17   | 0.67s  | 0.74s         |
| Q18   | 1.10s  | 1.23s         |
| Q19   | 0.36s  | 0.45s         |
| Q20   | 0.53s  | 0.60s         |
| Q21   | 3.25s  | 4.72s         |
| Q22   | 0.22s  | 0.20s         |