### PR TITLE
R: Avoid `translate_duckdb()` in tests

### DIFF
--- a/tools/rpkg/tests/testthat/_snaps/backend-dbplyr__duckdb_connection.md
+++ b/tools/rpkg/tests/testthat/_snaps/backend-dbplyr__duckdb_connection.md
@@ -373,29 +373,29 @@
 
     Code
       test_date <- as.Date("2020-01-01")
-      escape(test_date, con = con)
+      escape(test_date)
     Output
       <SQL> '2020-01-01'::date
     Code
-      escape("2020-01-01", con = con)
+      escape("2020-01-01")
     Output
       <SQL> '2020-01-01'
     Code
       test_datetime <- as.POSIXct("2020-01-01 01:23:45 UTC", tz = "UTC")
-      escape(test_datetime, con = con)
+      escape(test_datetime)
     Output
       <SQL> '2020-01-01 01:23:45'::timestamp
     Code
-      escape("2020-01-01 01:23:45 UTC", con = con)
+      escape("2020-01-01 01:23:45 UTC")
     Output
       <SQL> '2020-01-01 01:23:45 UTC'
     Code
       test_datetime_tz <- as.POSIXct("2020-01-01 18:23:45 UTC", tz = "America/Los_Angeles")
-      escape(test_datetime_tz, con = con)
+      escape(test_datetime_tz)
     Output
       <SQL> '2020-01-02 02:23:45'::timestamp
     Code
-      escape("2020-01-01 18:23:45 PST", con = con)
+      escape("2020-01-01 18:23:45 PST")
     Output
       <SQL> '2020-01-01 18:23:45 PST'
 


### PR DESCRIPTION
After #4266, it leads to a new connection for every call to `dbQuoteIdentifier()` .