### PR TITLE
Include PID in test directory name

### DIFF
--- a/test/helpers/CMakeLists.txt
+++ b/test/helpers/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(DUCKDB_TEST_HELPERS_UNITS test_helpers.cpp test_helper_extension.cpp
-                              capi_tester.cpp)
+                              capi_tester.cpp pid.cpp)
 
 add_library(test_helpers STATIC ${DUCKDB_TEST_HELPERS_UNITS})
 

--- a/test/helpers/pid.cpp
+++ b/test/helpers/pid.cpp
@@ -1,0 +1,15 @@
+#if (!defined(_WIN32) && !defined(WIN32)) || defined(__MINGW32__)
+#include <unistd.h>
+#define GETPID ::getpid
+#else
+#include <windows.h>
+#define GETPID (int)GetCurrentProcessId
+#endif
+
+namespace duckdb {
+
+int getpid() {
+	return GETPID();
+}
+
+} // namespace duckdb

--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -9,6 +9,7 @@
 #include "test_helpers.hpp"
 #include "duckdb/parser/parsed_data/copy_info.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "pid.hpp"
 
 #include <cmath>
 #include <fstream>
@@ -64,7 +65,11 @@ string TestDirectoryPath() {
 	if (!fs->DirectoryExists(TESTING_DIRECTORY_NAME)) {
 		fs->CreateDirectory(TESTING_DIRECTORY_NAME);
 	}
-	return TESTING_DIRECTORY_NAME;
+	string path = StringUtil::Format(TESTING_DIRECTORY_NAME "/%d", getpid());
+	if (!fs->DirectoryExists(path)) {
+		fs->CreateDirectory(path);
+	}
+	return path;
 }
 
 string TestCreatePath(string suffix) {

--- a/test/include/pid.hpp
+++ b/test/include/pid.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace duckdb {
+
+int getpid();
+
+} // namespace duckdb

--- a/test/sql/copy/parquet/parquet_filename.test
+++ b/test/sql/copy/parquet/parquet_filename.test
@@ -71,9 +71,9 @@ statement ok
 COPY test_table_large TO '__TEST_DIR__/test_table_large.parquet' (ROW_GROUP_SIZE 1000);
 
 query II
-SELECT sum(i), max(filename) FROM parquet_scan('__TEST_DIR__/test_table_large.parquet', FILENAME=1) where i>5000;
+SELECT sum(i), max(regexp_replace(filename, '^.*/', '')) FROM parquet_scan('__TEST_DIR__/test_table_large.parquet', FILENAME=1) where i>5000;
 ----
-37492500	duckdb_unittest_tempdir/test_table_large.parquet
+37492500	test_table_large.parquet
 
 # Same file twice
 query III


### PR DESCRIPTION
to support parallel execution of `unittest` .