### PR TITLE
Fix name of environment variable

### DIFF
--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -55,8 +55,8 @@ jobs:
     runs-on: ubuntu-20.04
     needs: r-test-extension
     env:
-      LIBARROW_BINARY : 'false'
-      ARROW_RUNTIME_SIMD_LEVEL : 'AVX2'
+      LIBARROW_BINARY: 'false'
+      ARROW_USER_SIMD_LEVEL: 'AVX2'
       BUILD_SUBSTRAIT_EXTENSION: 1
 
     steps:
@@ -155,8 +155,8 @@ jobs:
     needs: rstats-linux
 
     env:
-      LIBARROW_BINARY : 'false'
-      ARROW_RUNTIME_SIMD_LEVEL : 'AVX2'
+      LIBARROW_BINARY: 'false'
+      ARROW_USER_SIMD_LEVEL: 'AVX2'
       DUCKDB_R_DEBUG: 1
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
to turn off use of AVX512 instruction set in Arrow, not available in valgrind.

Closes #4384.