### PR TITLE
Correctly schedule mix of union/child pipelines (again)

### DIFF
--- a/src/execution/operator/set/physical_union.cpp
+++ b/src/execution/operator/set/physical_union.cpp
@@ -23,17 +23,7 @@ void PhysicalUnion::BuildPipelines(Executor &executor, Pipeline &current, Pipeli
 
 	auto union_pipeline = make_shared<Pipeline>(executor);
 	auto pipeline_ptr = union_pipeline.get();
-	auto &child_pipelines = state.GetChildPipelines(executor);
-	auto &child_dependencies = state.GetChildDependencies(executor);
 	auto &union_pipelines = state.GetUnionPipelines(executor);
-	// set up dependencies for any child pipelines to this union pipeline
-	auto child_entry = child_pipelines.find(&current);
-	if (child_entry != child_pipelines.end()) {
-		for (auto &current_child : child_entry->second) {
-			D_ASSERT(child_dependencies.find(current_child.get()) != child_dependencies.end());
-			child_dependencies[current_child.get()].push_back(pipeline_ptr);
-		}
-	}
 	// for the current pipeline, continue building on the LHS
 	state.SetPipelineOperators(*union_pipeline, state.GetPipelineOperators(current));
 	children[0]->BuildPipelines(executor, current, state);

--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -141,8 +141,6 @@ private:
 	//! Unlike union pipelines, child pipelines should be run AFTER their dependencies are completed
 	//! i.e. they should be run after the dependencies are completed, but before finalize is called on the sink
 	unordered_map<Pipeline *, vector<shared_ptr<Pipeline>>> child_pipelines;
-	//! Dependencies of child pipelines
-	unordered_map<Pipeline *, vector<Pipeline *>> child_dependencies;
 
 	//! The last pending execution result (if any)
 	PendingExecutionResult execution_result;

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -43,7 +43,6 @@ public:
 
 	unordered_map<Pipeline *, vector<shared_ptr<Pipeline>>> &GetUnionPipelines(Executor &executor);
 	unordered_map<Pipeline *, vector<shared_ptr<Pipeline>>> &GetChildPipelines(Executor &executor);
-	unordered_map<Pipeline *, vector<Pipeline *>> &GetChildDependencies(Executor &executor);
 
 	PhysicalOperator *GetPipelineSource(Pipeline &pipeline);
 	PhysicalOperator *GetPipelineSink(Pipeline &pipeline);

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -258,10 +258,6 @@ unordered_map<Pipeline *, vector<shared_ptr<Pipeline>>> &PipelineBuildState::Get
 unordered_map<Pipeline *, vector<shared_ptr<Pipeline>>> &PipelineBuildState::GetChildPipelines(Executor &executor) {
 	return executor.child_pipelines;
 }
-unordered_map<Pipeline *, vector<Pipeline *>> &PipelineBuildState::GetChildDependencies(Executor &executor) {
-	return executor.child_dependencies;
-}
-
 vector<PhysicalOperator *> PipelineBuildState::GetPipelineOperators(Pipeline &pipeline) {
 	return pipeline.operators;
 }

--- a/test/sql/join/full_outer/full_outer_join_union.test
+++ b/test/sql/join/full_outer/full_outer_join_union.test
@@ -83,6 +83,8 @@ SELECT i, j, k, l FROM integers FULL OUTER JOIN integers2 ON integers.i=integers
 UNION ALL
 SELECT i, j, k, l FROM integers FULL OUTER JOIN integers2 ON integers.i=integers2.k
 
+loop i 0 10
+
 query IIIIII
 SELECT * FROM v1 FULL OUTER JOIN v1 v2 USING (i, j) ORDER BY 1, 2, 3, 4, 5, 6
 ----
@@ -98,3 +100,5 @@ NULL	NULL	2	20	NULL	NULL
 3	3	NULL	NULL	NULL	NULL
 3	3	NULL	NULL	NULL	NULL
 3	3	NULL	NULL	NULL	NULL
+
+endloop


### PR DESCRIPTION
Follow up from #4340, which caused occasional failures in the CI. We simplify the dependency tracking code more and test in a loop - this time the dependencies appear to be actually correctly set up.