### PR TITLE
Fix several update issues

### DIFF
--- a/src/storage/compression/numeric_constant.cpp
+++ b/src/storage/compression/numeric_constant.cpp
@@ -61,6 +61,7 @@ void ConstantScanFunctionValidity(ColumnSegment &segment, ColumnScanState &state
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
 			ConstantVector::SetNull(result, true);
 		} else {
+			result.Flatten(scan_count);
 			ConstantFillFunctionValidity(segment, result, 0, scan_count);
 		}
 	}

--- a/src/storage/compression/numeric_constant.cpp
+++ b/src/storage/compression/numeric_constant.cpp
@@ -17,26 +17,6 @@ unique_ptr<SegmentScanState> ConstantInitScan(ColumnSegment &segment) {
 }
 
 //===--------------------------------------------------------------------===//
-// Scan base data
-//===--------------------------------------------------------------------===//
-void ConstantScanFunctionValidity(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result) {
-	auto &validity = (ValidityStatistics &)*segment.stats.statistics;
-	if (validity.has_null) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(result, true);
-	}
-}
-
-template <class T>
-void ConstantScanFunction(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result) {
-	auto &nstats = (NumericStatistics &)*segment.stats.statistics;
-
-	auto data = FlatVector::GetData<T>(result);
-	data[0] = nstats.min.GetValueUnsafe<T>();
-	result.SetVectorType(VectorType::CONSTANT_VECTOR);
-}
-
-//===--------------------------------------------------------------------===//
 // Scan Partial
 //===--------------------------------------------------------------------===//
 void ConstantFillFunctionValidity(ColumnSegment &segment, Vector &result, idx_t start_idx, idx_t count) {
@@ -69,6 +49,30 @@ template <class T>
 void ConstantScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result,
                          idx_t result_offset) {
 	ConstantFillFunction<T>(segment, result, result_offset, scan_count);
+}
+
+//===--------------------------------------------------------------------===//
+// Scan base data
+//===--------------------------------------------------------------------===//
+void ConstantScanFunctionValidity(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result) {
+	auto &validity = (ValidityStatistics &)*segment.stats.statistics;
+	if (validity.has_null) {
+		if (result.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(result, true);
+		} else {
+			ConstantFillFunctionValidity(segment, result, 0, scan_count);
+		}
+	}
+}
+
+template <class T>
+void ConstantScanFunction(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result) {
+	auto &nstats = (NumericStatistics &)*segment.stats.statistics;
+
+	auto data = FlatVector::GetData<T>(result);
+	data[0] = nstats.min.GetValueUnsafe<T>();
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1038,8 +1038,7 @@ void DataTable::RemoveFromIndexes(Vector &row_identifiers, idx_t count) {
 	result.Initialize(Allocator::Get(db), types);
 
 	row_group->InitializeScanWithOffset(state.row_group_scan_state, row_group_vector_idx);
-	row_group->ScanCommitted(state.row_group_scan_state, result,
-	                         TableScanType::TABLE_SCAN_COMMITTED_ROWS_DISALLOW_UPDATES);
+	row_group->ScanCommitted(state.row_group_scan_state, result, TableScanType::TABLE_SCAN_COMMITTED_ROWS);
 	result.Slice(sel, count);
 
 	info->indexes.Scan([&](Index &index) {

--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -630,10 +630,14 @@ static void InitializeUpdateData(UpdateInfo *base_info, Vector &base_data, Updat
 	}
 
 	auto base_array_data = FlatVector::GetData<T>(base_data);
+	auto &base_validity = FlatVector::Validity(base_data);
 	auto base_tuple_data = (T *)base_info->tuple_data;
 	for (idx_t i = 0; i < base_info->N; i++) {
-		base_tuple_data[i] =
-		    UpdateSelectElement::Operation<T>(base_info->segment, base_array_data[base_info->tuples[i]]);
+		auto base_idx = base_info->tuples[i];
+		if (!base_validity.RowIsValid(base_idx)) {
+			continue;
+		}
+		base_tuple_data[i] = UpdateSelectElement::Operation<T>(base_info->segment, base_array_data[base_idx]);
 	}
 }
 

--- a/test/sql/update/large_string_null_update.test
+++ b/test/sql/update/large_string_null_update.test
@@ -1,0 +1,33 @@
+# name: test/sql/update/large_string_null_update.test
+# description: Test back and forth update of string NULL values with many strings
+# group: [update]
+
+load __TEST_DIR__/string_null_update.db
+
+statement ok
+create table t (id int, col varchar);
+
+statement ok
+insert into t (id) select range as id from range(0, 1000000);
+
+
+query III
+SELECT COUNT(*), COUNT(id), COUNT(col) FROM t
+----
+1000000	1000000	0
+
+statement ok
+update t set col = 'x';
+
+query III
+SELECT COUNT(*), COUNT(id), COUNT(col) FROM t
+----
+1000000	1000000	1000000
+
+statement ok
+update t set col = NULL;
+
+query III
+SELECT COUNT(*), COUNT(id), COUNT(col) FROM t
+----
+1000000	1000000	0

--- a/test/sql/update/update_delete_wal.test
+++ b/test/sql/update/update_delete_wal.test
@@ -1,0 +1,41 @@
+# name: test/sql/update/update_delete_wal.test
+# description: Integer null update checkpoint
+# group: [update]
+
+load __TEST_DIR__/update_delete_wal.db
+
+statement ok
+SET wal_autocheckpoint='1TB';
+
+statement ok
+create table test (id bigint primary key, c1 text);
+
+statement ok
+insert into test (id, c1) values (1, 'foo');
+
+statement ok
+insert into test (id, c1) values (2, 'bar');
+
+statement ok
+begin transaction;
+
+statement ok
+delete from test where id = 1;
+
+statement ok
+update test set c1='baz' where id=2;
+
+statement ok
+commit;
+
+query II
+SELECT * FROM test ORDER BY id
+----
+2	baz
+
+restart
+
+query II
+SELECT * FROM test ORDER BY id
+----
+2	baz

--- a/test/sql/update/update_null_integers.test
+++ b/test/sql/update/update_null_integers.test
@@ -2,7 +2,7 @@
 # description: Integer null update checkpoint
 # group: [update]
 
-load __TEST_DIR__/string_null_update.db
+load __TEST_DIR__/update_null_integers.db
 
 statement ok
 SET wal_autocheckpoint='1TB';

--- a/test/sql/update/update_null_integers.test
+++ b/test/sql/update/update_null_integers.test
@@ -1,0 +1,37 @@
+# name: test/sql/update/update_null_integers.test
+# description: Integer null update checkpoint
+# group: [update]
+
+load __TEST_DIR__/string_null_update.db
+
+statement ok
+SET wal_autocheckpoint='1TB';
+
+statement ok
+CREATE TABLE t(i int, j int);
+
+# Insert >= 1024 NULLs
+statement ok
+INSERT INTO t SELECT ii, NULL FROM range(1024) tbl(ii);
+
+query III
+select COUNT(j), MIN(j), MAX(j) from t;
+----
+0	NULL	NULL
+
+# checkpoint to trigger the issue
+statement ok
+CHECKPOINT;
+
+query III
+select COUNT(j), MIN(j), MAX(j) from t;
+----
+0	NULL	NULL
+
+statement ok
+UPDATE t SET j = 1;
+
+query III
+select COUNT(j), MIN(j), MAX(j) from t;
+----
+1024	1	1


### PR DESCRIPTION
Fixes #4401, #4173, #4406

* Fix #4173: constant validity segment can only output constant NULL vectors if the input vector is a constant as well, otherwise we might end up overriding previously set values in case of an update that changes NULL-ness
* Fix #4401: correctly skip NULL values in update of string values to avoid reading garbage data
* Fix #4406: do not disallow updates when removing committed data from indexes
