### PR TITLE
Issue #4454: VARCHAR/DATE Reversibility

### DIFF
--- a/src/planner/expression/bound_cast_expression.cpp
+++ b/src/planner/expression/bound_cast_expression.cpp
@@ -109,7 +109,6 @@ bool BoundCastExpression::CastIsInvertible(const LogicalType &source_type, const
 	}
 	if (source_type.id() == LogicalTypeId::VARCHAR) {
 		switch (target_type.id()) {
-		case LogicalTypeId::DATE:
 		case LogicalTypeId::TIME:
 		case LogicalTypeId::TIMESTAMP:
 		case LogicalTypeId::TIMESTAMP_NS:

--- a/test/sql/types/test_date_cast.test
+++ b/test/sql/types/test_date_cast.test
@@ -1,0 +1,19 @@
+# name: test/sql/types/test_date_cast.test
+# description: Test sequence overflow
+# group: [types]
+
+statement ok
+CREATE TABLE df (x VARCHAR, y BIGINT);
+
+statement ok
+INSERT INTO df VALUES ('2021-01-01 12:00:00', 1);
+
+query IIII
+select
+	CAST(x as DATE) = '2021-01-01' a,
+	IF(CAST(x as DATE) = '2021-01-01', y, 0) b,
+	CASE WHEN CAST(x as DATE) = '2021-01-01' THEN y ELSE 0 END c,
+	IF(CAST(x as DATE) = '2021-01-01', 1, 0) d
+from df
+----
+True	1	1	1


### PR DESCRIPTION
Casting from VARCHAR to DATE is not reversible as it truncates.
Instead, comparison simplification should check whether the constant
in question can be cast reversibly.