### PR TITLE
[Python] Removed mutable default parameters

### DIFF
--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -97,62 +97,58 @@ PYBIND11_MODULE(DUCKDB_PYTHON_LIB_NAME, m) {
 	    .export_values();
 
 	m.def("values", &DuckDBPyRelation::Values, "Create a relation object from the passed values", py::arg("values"),
-	      py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("connection") = py::none());
 	m.def("from_query", &DuckDBPyRelation::FromQuery, "Create a relation object from the given SQL query",
-	      py::arg("query"), py::arg("alias") = "query_relation",
-	      py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("query"), py::arg("alias") = "query_relation", py::arg("connection") = py::none());
 	m.def("query", &DuckDBPyRelation::RunQuery,
 	      "Run a SQL query. If it is a SELECT statement, create a relation object from the given SQL query, otherwise "
 	      "run the query as-is.",
-	      py::arg("query"), py::arg("alias") = "query_relation",
-	      py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("query"), py::arg("alias") = "query_relation", py::arg("connection") = py::none());
 	m.def("from_csv_auto", &DuckDBPyRelation::FromCsvAuto, "Creates a relation object from the CSV file in file_name",
-	      py::arg("file_name"), py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("file_name"), py::arg("connection") = py::none());
 	m.def("from_substrait", &DuckDBPyRelation::FromSubstrait, "Creates a query object from the substrait plan",
-	      py::arg("proto"), py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("proto"), py::arg("connection") = py::none());
 	m.def("get_substrait", &DuckDBPyRelation::GetSubstrait, "Serialize a query object to protobuf", py::arg("query"),
-	      py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("connection") = py::none());
 	m.def("get_substrait_json", &DuckDBPyRelation::GetSubstraitJSON, "Serialize a query object to protobuf",
-	      py::arg("query"), py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("query"), py::arg("connection") = py::none());
 	m.def("from_parquet", &DuckDBPyRelation::FromParquet,
 	      "Creates a relation object from the Parquet file in file_name", py::arg("file_name"),
-	      py::arg("binary_as_string"), py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("binary_as_string"), py::arg("connection") = py::none());
 	m.def("from_parquet", &DuckDBPyRelation::FromParquetDefault,
 	      "Creates a relation object from the Parquet file in file_name", py::arg("file_name"),
-	      py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("connection") = py::none());
 	m.def("df", &DuckDBPyRelation::FromDf, "Create a relation object from the Data.Frame df", py::arg("df"),
-	      py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("connection") = py::none());
 	m.def("from_df", &DuckDBPyRelation::FromDf, "Create a relation object from the Data.Frame df", py::arg("df"),
-	      py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("connection") = py::none());
 	m.def("from_arrow", &DuckDBPyRelation::FromArrow, "Create a relation object from an Arrow object",
-	      py::arg("arrow_object"), py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("arrow_object"), py::arg("connection") = py::none());
 	m.def("arrow", &DuckDBPyRelation::FromArrow, "Create a relation object from an Arrow object",
-	      py::arg("arrow_object"), py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("arrow_object"), py::arg("connection") = py::none());
 	m.def("filter", &DuckDBPyRelation::FilterDf, "Filter the Data.Frame df by the filter in filter_expr", py::arg("df"),
-	      py::arg("filter_expr"), py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("filter_expr"), py::arg("connection") = py::none());
 	m.def("project", &DuckDBPyRelation::ProjectDf, "Project the Data.Frame df by the projection in project_expr",
-	      py::arg("df"), py::arg("project_expr"), py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("df"), py::arg("project_expr"), py::arg("connection") = py::none());
 	m.def("alias", &DuckDBPyRelation::AliasDF, "Create a relation from Data.Frame df with the passed alias",
-	      py::arg("df"), py::arg("alias"), py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("df"), py::arg("alias"), py::arg("connection") = py::none());
 	m.def("order", &DuckDBPyRelation::OrderDf, "Reorder the Data.Frame df by order_expr", py::arg("df"),
-	      py::arg("order_expr"), py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("order_expr"), py::arg("connection") = py::none());
 	m.def("aggregate", &DuckDBPyRelation::AggregateDF,
 	      "Compute the aggregate aggr_expr by the optional groups group_expr on Data.frame df", py::arg("df"),
-	      py::arg("aggr_expr"), py::arg("group_expr") = "",
-	      py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("aggr_expr"), py::arg("group_expr") = "", py::arg("connection") = py::none());
 	m.def("distinct", &DuckDBPyRelation::DistinctDF, "Compute the distinct rows from Data.Frame df ", py::arg("df"),
-	      py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("connection") = py::none());
 	m.def("limit", &DuckDBPyRelation::LimitDF, "Retrieve the first n rows from the Data.Frame df", py::arg("df"),
-	      py::arg("n"), py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("n"), py::arg("connection") = py::none());
 
 	m.def("query_df", &DuckDBPyRelation::QueryDF,
 	      "Run the given SQL query in sql_query on the view named virtual_table_name that contains the content of "
 	      "Data.Frame df",
-	      py::arg("df"), py::arg("virtual_table_name"), py::arg("sql_query"),
-	      py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("df"), py::arg("virtual_table_name"), py::arg("sql_query"), py::arg("connection") = py::none());
 
 	m.def("write_csv", &DuckDBPyRelation::WriteCsvDF, "Write the Data.Frame df to a CSV file in file_name",
-	      py::arg("df"), py::arg("file_name"), py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("df"), py::arg("file_name"), py::arg("connection") = py::none());
 
 	// we need this because otherwise we try to remove registered_dfs on shutdown when python is already dead
 	auto clean_default_connection = []() {

--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -82,7 +82,7 @@ PYBIND11_MODULE(DUCKDB_PYTHON_LIB_NAME, m) {
 	m.def("connect", &DuckDBPyConnection::Connect,
 	      "Create a DuckDB database instance. Can take a database file name to read/write persistent data and a "
 	      "read_only flag if no changes are desired",
-	      py::arg("database") = ":memory:", py::arg("read_only") = false, py::arg("config") = py::dict());
+	      py::arg("database") = ":memory:", py::arg("read_only") = false, py::arg("config") = py::none());
 	m.def("tokenize", PyTokenize,
 	      "Tokenizes a SQL string, returning a list of (position, type) tuples that can be "
 	      "used for e.g. syntax highlighting",
@@ -97,7 +97,7 @@ PYBIND11_MODULE(DUCKDB_PYTHON_LIB_NAME, m) {
 	    .export_values();
 
 	m.def("values", &DuckDBPyRelation::Values, "Create a relation object from the passed values", py::arg("values"),
-	      py::arg("connection") = DuckDBPyConnection::DefaultConnection());
+	      py::arg("connection") = py::none());
 	m.def("from_query", &DuckDBPyRelation::FromQuery, "Create a relation object from the given SQL query",
 	      py::arg("query"), py::arg("alias") = "query_relation",
 	      py::arg("connection") = DuckDBPyConnection::DefaultConnection());

--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -97,7 +97,7 @@ PYBIND11_MODULE(DUCKDB_PYTHON_LIB_NAME, m) {
 	    .export_values();
 
 	m.def("values", &DuckDBPyRelation::Values, "Create a relation object from the passed values", py::arg("values"),
-	      py::arg("connection") = py::none());
+	      py::arg("connection") = DuckDBPyConnection::DefaultConnection());
 	m.def("from_query", &DuckDBPyRelation::FromQuery, "Create a relation object from the given SQL query",
 	      py::arg("query"), py::arg("alias") = "query_relation",
 	      py::arg("connection") = DuckDBPyConnection::DefaultConnection());

--- a/tools/pythonpkg/src/include/duckdb_python/pandas_type.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pandas_type.hpp
@@ -13,7 +13,7 @@ public:
 
 public:
 	static bool check_(const py::handle &object) {
-		return !py::none().is(object);
+		return !object.is_none();
 	}
 };
 

--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
@@ -72,7 +72,7 @@ public:
 
 	unique_ptr<DuckDBPyRelation> Table(const string &tname);
 
-	unique_ptr<DuckDBPyRelation> Values(py::object params = py::list());
+	unique_ptr<DuckDBPyRelation> Values(py::object params = py::none());
 
 	unique_ptr<DuckDBPyRelation> View(const string &vname);
 

--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
@@ -125,7 +125,7 @@ public:
 
 	duckdb::pyarrow::RecordBatchReader FetchRecordBatchReader(const idx_t chunk_size) const;
 
-	static shared_ptr<DuckDBPyConnection> Connect(const string &database, bool read_only, const py::dict &config);
+	static shared_ptr<DuckDBPyConnection> Connect(const string &database, bool read_only, py::object config);
 
 	static vector<Value> TransformPythonParamList(py::handle params);
 

--- a/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
@@ -51,7 +51,7 @@ public:
 	                                           DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
 
 	static unique_ptr<DuckDBPyRelation> Values(py::object values = py::list(),
-	                                           py::object conn = py::none());
+	                                           DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
 
 	static unique_ptr<DuckDBPyRelation> FromQuery(const string &query, const string &alias,
 	                                              DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());

--- a/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
@@ -51,7 +51,7 @@ public:
 	                                           DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
 
 	static unique_ptr<DuckDBPyRelation> Values(py::object values = py::list(),
-	                                           DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	                                           py::object conn = py::none());
 
 	static unique_ptr<DuckDBPyRelation> FromQuery(const string &query, const string &alias,
 	                                              DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -289,6 +289,12 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::Values(py::object params) {
 	if (!connection) {
 		throw ConnectionException("Connection has already been closed");
 	}
+	if (params.is_none()) {
+		params = py::list();
+	}
+	if (!py::hasattr(params, "__len__")) {
+		throw InvalidInputException("Type of object passed to parameter 'values' has to be <list>");
+	}
 	vector<vector<Value>> values {DuckDBPyConnection::TransformPythonParamList(std::move(params))};
 	return make_unique<DuckDBPyRelation>(connection->Values(values));
 }

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -293,7 +293,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::Values(py::object params) {
 		params = py::list();
 	}
 	if (!py::hasattr(params, "__len__")) {
-		throw InvalidInputException("Type of object passed to parameter 'values' has to be <list>");
+		throw InvalidInputException("Type of object passed to parameter 'values' must be iterable");
 	}
 	vector<vector<Value>> values {DuckDBPyConnection::TransformPythonParamList(std::move(params))};
 	return make_unique<DuckDBPyRelation>(connection->Values(values));

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -36,10 +36,10 @@ void DuckDBPyConnection::Initialize(py::handle &m) {
 	    .def("duplicate", &DuckDBPyConnection::Cursor, "Create a duplicate of the current connection")
 	    .def("execute", &DuckDBPyConnection::Execute,
 	         "Execute the given SQL query, optionally using prepared statements with parameters set", py::arg("query"),
-	         py::arg("parameters") = py::list(), py::arg("multiple_parameter_sets") = false)
+	         py::arg("parameters") = py::none(), py::arg("multiple_parameter_sets") = false)
 	    .def("executemany", &DuckDBPyConnection::ExecuteMany,
 	         "Execute the given prepared statement multiple times using the list of parameter sets in parameters",
-	         py::arg("query"), py::arg("parameters") = py::list())
+	         py::arg("query"), py::arg("parameters") = py::none())
 	    .def("close", &DuckDBPyConnection::Close, "Close the connection")
 	    .def("fetchone", &DuckDBPyConnection::FetchOne, "Fetch a single row from a result following execute")
 	    .def("fetchmany", &DuckDBPyConnection::FetchMany, "Fetch the next set of rows from a result following execute",
@@ -74,7 +74,7 @@ void DuckDBPyConnection::Initialize(py::handle &m) {
 	         py::arg("values"))
 	    .def("table_function", &DuckDBPyConnection::TableFunction,
 	         "Create a relation object from the name'd table function with given parameters", py::arg("name"),
-	         py::arg("parameters") = py::list())
+	         py::arg("parameters") = py::none())
 	    .def("from_query", &DuckDBPyConnection::FromQuery, "Create a relation object from the given SQL query",
 	         py::arg("query"), py::arg("alias") = "query_relation")
 	    .def("query", &DuckDBPyConnection::RunQuery,
@@ -112,6 +112,9 @@ void DuckDBPyConnection::Initialize(py::handle &m) {
 }
 
 DuckDBPyConnection *DuckDBPyConnection::ExecuteMany(const string &query, py::object params) {
+	if (params.is_none()) {
+		params = py::list();
+	}
 	Execute(query, std::move(params), true);
 	return this;
 }
@@ -130,6 +133,9 @@ static unique_ptr<QueryResult> CompletePendingQuery(PendingQueryResult &pending_
 DuckDBPyConnection *DuckDBPyConnection::Execute(const string &query, py::object params, bool many) {
 	if (!connection) {
 		throw ConnectionException("Connection has already been closed");
+	}
+	if (params.is_none()) {
+		params = py::list();
 	}
 	result = nullptr;
 	unique_ptr<PreparedStatement> prep;
@@ -299,6 +305,9 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::View(const string &vname) {
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyConnection::TableFunction(const string &fname, py::object params) {
+	if (params.is_none()) {
+		params = py::list();
+	}
 	if (!connection) {
 		throw ConnectionException("Connection has already been closed");
 	}
@@ -600,14 +609,21 @@ static unique_ptr<TableFunctionRef> ScanReplacement(ClientContext &context, cons
 }
 
 shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Connect(const string &database, bool read_only,
-                                                           const py::dict &config_dict) {
+                                                           py::object config_options) {
 	auto res = make_shared<DuckDBPyConnection>();
 
 	DBConfig config;
 
+	if (config_options.is_none()) {
+		config_options = py::dict();
+	}
+	if (!py::isinstance<py::dict>(config_options)) {
+		throw InvalidInputException("Type of object passed to parameter 'config' has to be <dict>");
+	}
 	if (read_only) {
 		config.options.access_mode = AccessMode::READ_ONLY;
 	}
+	py::dict config_dict = config_options;
 	for (auto &kv : config_dict) {
 		string key = py::str(kv.first);
 		string val = py::str(kv.second);

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -145,33 +145,54 @@ DuckDBPyRelation::DuckDBPyRelation(shared_ptr<Relation> rel) : rel(move(rel)) {
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromDf(const DataFrame &df, DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->FromDF(df);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Values(py::object values, DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->Values(std::move(values));
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromQuery(const string &query, const string &alias,
                                                          DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->FromQuery(query, alias);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::RunQuery(const string &query, const string &alias,
                                                         DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->RunQuery(query, alias);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromCsvAuto(const string &filename, DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->FromCsvAuto(filename);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromParquet(const string &filename, bool binary_as_string,
                                                            DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->FromParquet(filename, binary_as_string);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromParquetDefault(const string &filename, DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	bool binary_as_string = false;
 	Value result;
 	if (conn->connection->context->TryGetCurrentSetting("binary_as_string", result)) {
@@ -181,26 +202,44 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromParquetDefault(const string &
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::GetSubstrait(const string &query, DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->GetSubstrait(query);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::GetSubstraitJSON(const string &query, DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->GetSubstraitJSON(query);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromSubstrait(py::bytes &proto, DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->FromSubstrait(proto);
 }
 
 void DuckDBPyRelation::InstallExtension(const string &extension, bool force_install, DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->InstallExtension(extension, force_install);
 }
 
 void DuckDBPyRelation::LoadExtension(const string &extension, DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->LoadExtension(extension);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromArrow(py::object &arrow_object, DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->FromArrow(arrow_object);
 }
 
@@ -212,6 +251,9 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Project(const string &expr) {
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::ProjectDf(const DataFrame &df, const string &expr,
                                                          DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->FromDF(df)->Project(expr);
 }
 
@@ -225,6 +267,9 @@ py::str DuckDBPyRelation::GetAlias() {
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::AliasDF(const DataFrame &df, const string &expr,
                                                        DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->FromDF(df)->SetAlias(expr);
 }
 
@@ -234,6 +279,9 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Filter(const string &expr) {
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FilterDf(const DataFrame &df, const string &expr,
                                                         DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->FromDF(df)->Filter(expr);
 }
 
@@ -242,6 +290,9 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Limit(int64_t n, int64_t offset) 
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::LimitDF(const DataFrame &df, int64_t n, DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->FromDF(df)->Limit(n);
 }
 
@@ -251,6 +302,9 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Order(const string &expr) {
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::OrderDf(const DataFrame &df, const string &expr,
                                                        DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->FromDF(df)->Order(expr);
 }
 
@@ -415,6 +469,9 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::CumMin(const string &aggr_columns
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::AggregateDF(const DataFrame &df, const string &expr,
                                                            const string &groups, DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->FromDF(df)->Aggregate(expr, groups);
 }
 
@@ -423,6 +480,9 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Distinct() {
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::DistinctDF(const DataFrame &df, DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->FromDF(df)->Distinct();
 }
 
@@ -530,6 +590,9 @@ void DuckDBPyRelation::WriteCsv(const string &file) {
 }
 
 void DuckDBPyRelation::WriteCsvDF(const DataFrame &df, const string &file, DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->FromDF(df)->WriteCsv(file);
 }
 
@@ -568,6 +631,9 @@ unique_ptr<DuckDBPyResult> DuckDBPyRelation::Execute() {
 
 unique_ptr<DuckDBPyResult> DuckDBPyRelation::QueryDF(const DataFrame &df, const string &view_name,
                                                      const string &sql_query, DuckDBPyConnection *conn) {
+	if (!conn) {
+		conn = DuckDBPyConnection::DefaultConnection();
+	}
 	return conn->FromDF(df)->Query(view_name, sql_query);
 }
 

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -148,16 +148,8 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromDf(const DataFrame &df, DuckD
 	return conn->FromDF(df);
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Values(py::object values, py::object conn) {
-	static const auto connection_type = py::module::import("duckdb").attr("DuckDBPyConnection");
-	if (conn.is_none()) {
-		conn = py::module::import("duckdb").attr("default_connection");
-	}
-	if (!py::isinstance(conn, connection_type)) {
-		throw InvalidInputException("Type of object passed to parameter 'connection' has to be <DuckDBPyConnection>");
-	}
-	auto conn_p = (DuckDBPyConnection*)conn.ptr();
-	return conn_p->Values(std::move(values));
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Values(py::object values, DuckDBPyConnection *conn) {
+	return conn->Values(std::move(values));
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromQuery(const string &query, const string &alias,


### PR DESCRIPTION
This PR addresses the 'Mutable Objects' portion of issue #4342 

By changing every parameter that takes a mutable object as parameter, where we supplied a default value, this should be fixed now.

The code however did not get prettier from this though.. Everywhere that we accept a `connection` object, we now default to `None` and then assign the default_connection inside the function when the connection is None.

I also came across [this](https://pybind11.readthedocs.io/en/stable/advanced/smart_ptrs.html#std-shared-ptr) post that describes how you shouldn't return a raw pointer of an object that's wrapped in pybind as being a shared_ptr.

Because python/pybind will wrap this raw pointer in a shared_ptr and thus the object gets freed twice.

It sounds like this issue applies to `DuckDBPyConnection::DefaultConnection()`, but since we have yet to experience any issues from this, I'm not sure if I'm missing something.
EDIT: this does not apply to `default_connection` because we store a reference to the object in the `duckdb` module as an attribute, so the object never goes out of scope (we always keep this one reference alive)