### PR TITLE
fix: ignore status message from output of mypy stubs check

### DIFF
--- a/tools/pythonpkg/tests/stubs/test_stubs.py
+++ b/tools/pythonpkg/tests/stubs/test_stubs.py
@@ -18,7 +18,7 @@ def test_stubs():
 			'--mypy-config-file', MYPY_INI_PATH,
 		], stdout=subprocess.PIPE)
 	if (stubs.returncode != 0):
-		errors = stubs.stdout.decode('utf-8').split('error')
+		errors = stubs.stdout.decode('utf-8').split('Found')[0].split('error')
 		broken_stubs = []
 		for error in errors:
 			add_error = True


### PR DESCRIPTION
Newer versions of `mypy` included an additional message in the stubs
output, e.g. `Found 5 error: ...` which breaks the parsing of the output
when all of the test failures are being skipped.

xref: conda-forge/python-duckdb-feedstock#56