### PR TITLE
Issue #4419: Range Join Swizzling

### DIFF
--- a/src/common/row_operations/row_gather.cpp
+++ b/src/common/row_operations/row_gather.cpp
@@ -15,9 +15,11 @@ using ValidityBytes = RowLayout::ValidityBytes;
 
 template <class T>
 static void TemplatedGatherLoop(Vector &rows, const SelectionVector &row_sel, Vector &col,
-                                const SelectionVector &col_sel, idx_t count, idx_t col_offset, idx_t col_no,
+                                const SelectionVector &col_sel, idx_t count, const RowLayout &layout, idx_t col_no,
                                 idx_t build_size) {
 	// Precompute mask indexes
+	const auto &offsets = layout.GetOffsets();
+	const auto col_offset = offsets[col_no];
 	idx_t entry_idx;
 	idx_t idx_in_entry;
 	ValidityBytes::GetEntryIndex(col_no, entry_idx, idx_in_entry);
@@ -42,8 +44,53 @@ static void TemplatedGatherLoop(Vector &rows, const SelectionVector &row_sel, Ve
 	}
 }
 
+static void GatherVarchar(Vector &rows, const SelectionVector &row_sel, Vector &col, const SelectionVector &col_sel,
+                          idx_t count, const RowLayout &layout, idx_t col_no, idx_t build_size,
+                          data_ptr_t base_heap_ptr) {
+	// Precompute mask indexes
+	const auto &offsets = layout.GetOffsets();
+	const auto col_offset = offsets[col_no];
+	const auto heap_offset = layout.GetHeapOffset();
+	idx_t entry_idx;
+	idx_t idx_in_entry;
+	ValidityBytes::GetEntryIndex(col_no, entry_idx, idx_in_entry);
+
+	auto ptrs = FlatVector::GetData<data_ptr_t>(rows);
+	auto data = FlatVector::GetData<string_t>(col);
+	auto &col_mask = FlatVector::Validity(col);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto row_idx = row_sel.get_index(i);
+		auto row = ptrs[row_idx];
+		auto col_idx = col_sel.get_index(i);
+		auto col_ptr = row + col_offset;
+		data[col_idx] = Load<string_t>(col_ptr);
+		ValidityBytes row_mask(row);
+		if (!row_mask.RowIsValid(row_mask.GetValidityEntry(entry_idx), idx_in_entry)) {
+			if (build_size > STANDARD_VECTOR_SIZE && col_mask.AllValid()) {
+				//! We need to initialize the mask with the vector size.
+				col_mask.Initialize(build_size);
+			}
+			col_mask.SetInvalid(col_idx);
+		} else if (base_heap_ptr && Load<uint32_t>(col_ptr) > string_t::INLINE_LENGTH) {
+			//	Not inline, so unswizzle the copied pointer the pointer
+			auto heap_ptr_ptr = row + heap_offset;
+			auto heap_row_ptr = base_heap_ptr + Load<idx_t>(heap_ptr_ptr);
+			auto string_ptr = data_ptr_t(data + col_idx) + sizeof(uint32_t) + string_t::PREFIX_LENGTH;
+			Store<data_ptr_t>(heap_row_ptr + Load<idx_t>(string_ptr), string_ptr);
+#ifdef DEBUG
+			data[col_idx].Verify();
+#endif
+		}
+	}
+}
+
 static void GatherNestedVector(Vector &rows, const SelectionVector &row_sel, Vector &col,
-                               const SelectionVector &col_sel, idx_t count, idx_t col_offset, idx_t col_no) {
+                               const SelectionVector &col_sel, idx_t count, const RowLayout &layout, idx_t col_no,
+                               data_ptr_t base_heap_ptr) {
+	const auto &offsets = layout.GetOffsets();
+	const auto col_offset = offsets[col_no];
+	const auto heap_offset = layout.GetHeapOffset();
 	auto ptrs = FlatVector::GetData<data_ptr_t>(rows);
 
 	// Build the gather locations
@@ -51,8 +98,16 @@ static void GatherNestedVector(Vector &rows, const SelectionVector &row_sel, Vec
 	auto mask_locations = unique_ptr<data_ptr_t[]>(new data_ptr_t[count]);
 	for (idx_t i = 0; i < count; i++) {
 		auto row_idx = row_sel.get_index(i);
-		mask_locations[i] = ptrs[row_idx];
-		data_locations[i] = Load<data_ptr_t>(ptrs[row_idx] + col_offset);
+		auto row = ptrs[row_idx];
+		mask_locations[i] = row;
+		auto col_ptr = ptrs[row_idx] + col_offset;
+		if (base_heap_ptr) {
+			auto heap_ptr_ptr = row + heap_offset;
+			auto heap_row_ptr = base_heap_ptr + Load<idx_t>(heap_ptr_ptr);
+			data_locations[i] = heap_row_ptr + Load<idx_t>(col_ptr);
+		} else {
+			data_locations[i] = Load<data_ptr_t>(col_ptr);
+		}
 	}
 
 	// Deserialise into the selected locations
@@ -60,56 +115,57 @@ static void GatherNestedVector(Vector &rows, const SelectionVector &row_sel, Vec
 }
 
 void RowOperations::Gather(Vector &rows, const SelectionVector &row_sel, Vector &col, const SelectionVector &col_sel,
-                           const idx_t count, const idx_t col_offset, const idx_t col_no, const idx_t build_size) {
+                           const idx_t count, const RowLayout &layout, const idx_t col_no, const idx_t build_size,
+                           data_ptr_t heap_ptr) {
 	D_ASSERT(rows.GetVectorType() == VectorType::FLAT_VECTOR);
 	D_ASSERT(rows.GetType().id() == LogicalTypeId::POINTER); // "Cannot gather from non-pointer type!"
 
 	col.SetVectorType(VectorType::FLAT_VECTOR);
 	switch (col.GetType().InternalType()) {
 	case PhysicalType::UINT8:
-		TemplatedGatherLoop<uint8_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		TemplatedGatherLoop<uint8_t>(rows, row_sel, col, col_sel, count, layout, col_no, build_size);
 		break;
 	case PhysicalType::UINT16:
-		TemplatedGatherLoop<uint16_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		TemplatedGatherLoop<uint16_t>(rows, row_sel, col, col_sel, count, layout, col_no, build_size);
 		break;
 	case PhysicalType::UINT32:
-		TemplatedGatherLoop<uint32_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		TemplatedGatherLoop<uint32_t>(rows, row_sel, col, col_sel, count, layout, col_no, build_size);
 		break;
 	case PhysicalType::UINT64:
-		TemplatedGatherLoop<uint64_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		TemplatedGatherLoop<uint64_t>(rows, row_sel, col, col_sel, count, layout, col_no, build_size);
 		break;
 	case PhysicalType::BOOL:
 	case PhysicalType::INT8:
-		TemplatedGatherLoop<int8_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		TemplatedGatherLoop<int8_t>(rows, row_sel, col, col_sel, count, layout, col_no, build_size);
 		break;
 	case PhysicalType::INT16:
-		TemplatedGatherLoop<int16_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		TemplatedGatherLoop<int16_t>(rows, row_sel, col, col_sel, count, layout, col_no, build_size);
 		break;
 	case PhysicalType::INT32:
-		TemplatedGatherLoop<int32_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		TemplatedGatherLoop<int32_t>(rows, row_sel, col, col_sel, count, layout, col_no, build_size);
 		break;
 	case PhysicalType::INT64:
-		TemplatedGatherLoop<int64_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		TemplatedGatherLoop<int64_t>(rows, row_sel, col, col_sel, count, layout, col_no, build_size);
 		break;
 	case PhysicalType::INT128:
-		TemplatedGatherLoop<hugeint_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		TemplatedGatherLoop<hugeint_t>(rows, row_sel, col, col_sel, count, layout, col_no, build_size);
 		break;
 	case PhysicalType::FLOAT:
-		TemplatedGatherLoop<float>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		TemplatedGatherLoop<float>(rows, row_sel, col, col_sel, count, layout, col_no, build_size);
 		break;
 	case PhysicalType::DOUBLE:
-		TemplatedGatherLoop<double>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		TemplatedGatherLoop<double>(rows, row_sel, col, col_sel, count, layout, col_no, build_size);
 		break;
 	case PhysicalType::INTERVAL:
-		TemplatedGatherLoop<interval_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		TemplatedGatherLoop<interval_t>(rows, row_sel, col, col_sel, count, layout, col_no, build_size);
 		break;
 	case PhysicalType::VARCHAR:
-		TemplatedGatherLoop<string_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		GatherVarchar(rows, row_sel, col, col_sel, count, layout, col_no, build_size, heap_ptr);
 		break;
 	case PhysicalType::LIST:
 	case PhysicalType::MAP:
 	case PhysicalType::STRUCT:
-		GatherNestedVector(rows, row_sel, col, col_sel, count, col_offset, col_no);
+		GatherNestedVector(rows, row_sel, col, col_sel, count, layout, col_no, heap_ptr);
 		break;
 	default:
 		throw InternalException("Unimplemented type for RowOperations::Gather");

--- a/src/common/row_operations/row_match.cpp
+++ b/src/common/row_operations/row_match.cpp
@@ -119,11 +119,11 @@ static void TemplatedMatchType(UnifiedVectorFormat &col, Vector &rows, Selection
 }
 
 template <class OP, bool NO_MATCH_SEL>
-static void TemplatedMatchNested(Vector &col, Vector &rows, SelectionVector &sel, idx_t &count, const idx_t col_offset,
+static void TemplatedMatchNested(Vector &col, Vector &rows, SelectionVector &sel, idx_t &count, const RowLayout &layout,
                                  const idx_t col_no, SelectionVector *no_match, idx_t &no_match_count) {
 	// Gather a dense Vector containing the column values being matched
 	Vector key(col.GetType());
-	RowOperations::Gather(rows, sel, key, *FlatVector::IncrementalSelectionVector(), count, col_offset, col_no);
+	RowOperations::Gather(rows, sel, key, *FlatVector::IncrementalSelectionVector(), count, layout, col_no);
 
 	// Densify the input column
 	Vector sliced(col, sel, count);
@@ -203,7 +203,7 @@ static void TemplatedMatchOp(Vector &vec, UnifiedVectorFormat &col, const RowLay
 	case PhysicalType::LIST:
 	case PhysicalType::MAP:
 	case PhysicalType::STRUCT:
-		TemplatedMatchNested<OP, NO_MATCH_SEL>(vec, rows, sel, count, col_offset, col_no, no_match, no_match_count);
+		TemplatedMatchNested<OP, NO_MATCH_SEL>(vec, rows, sel, count, layout, col_no, no_match, no_match_count);
 		break;
 	default:
 		throw InternalException("Unsupported column type for RowOperations::Match");

--- a/src/common/sort/sorted_block.cpp
+++ b/src/common/sort/sorted_block.cpp
@@ -355,10 +355,9 @@ void PayloadScanner::Scan(DataChunk &chunk) {
 	}
 	D_ASSERT(scanned == count);
 	// Deserialize the payload data
-	for (idx_t col_idx = 0; col_idx < sorted_data.layout.ColumnCount(); col_idx++) {
-		const auto col_offset = sorted_data.layout.GetOffsets()[col_idx];
-		RowOperations::Gather(addresses, *FlatVector::IncrementalSelectionVector(), chunk.data[col_idx],
-		                      *FlatVector::IncrementalSelectionVector(), count, col_offset, col_idx);
+	for (idx_t col_no = 0; col_no < sorted_data.layout.ColumnCount(); col_no++) {
+		RowOperations::Gather(addresses, *FlatVector::IncrementalSelectionVector(), chunk.data[col_no],
+		                      *FlatVector::IncrementalSelectionVector(), count, sorted_data.layout, col_no);
 	}
 	chunk.SetCardinality(count);
 	chunk.Verify();

--- a/src/common/types/row_data_collection_scanner.cpp
+++ b/src/common/types/row_data_collection_scanner.cpp
@@ -241,10 +241,9 @@ void RowDataCollectionScanner::Scan(DataChunk &chunk) {
 	}
 	D_ASSERT(scanned == count);
 	// Deserialize the payload data
-	for (idx_t col_idx = 0; col_idx < layout.ColumnCount(); col_idx++) {
-		const auto col_offset = layout.GetOffsets()[col_idx];
-		RowOperations::Gather(addresses, *FlatVector::IncrementalSelectionVector(), chunk.data[col_idx],
-		                      *FlatVector::IncrementalSelectionVector(), count, col_offset, col_idx);
+	for (idx_t col_no = 0; col_no < layout.ColumnCount(); col_no++) {
+		RowOperations::Gather(addresses, *FlatVector::IncrementalSelectionVector(), chunk.data[col_no],
+		                      *FlatVector::IncrementalSelectionVector(), count, layout, col_no);
 	}
 	chunk.SetCardinality(count);
 	chunk.Verify();

--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -548,11 +548,10 @@ void GroupedAggregateHashTable::FlushMove(FlushMoveState &state, Vector &source_
 
 	state.groups.Reset();
 	state.groups.SetCardinality(count);
-	for (idx_t i = 0; i < state.groups.ColumnCount(); i++) {
-		auto &column = state.groups.data[i];
-		const auto col_offset = layout.GetOffsets()[i];
+	for (idx_t col_no = 0; col_no < state.groups.ColumnCount(); col_no++) {
+		auto &column = state.groups.data[col_no];
 		RowOperations::Gather(source_addresses, *FlatVector::IncrementalSelectionVector(), column,
-		                      *FlatVector::IncrementalSelectionVector(), count, col_offset, i);
+		                      *FlatVector::IncrementalSelectionVector(), count, layout, col_no);
 	}
 
 	FindOrCreateGroups(state.groups, source_hashes, state.group_addresses, state.new_groups_sel);
@@ -673,11 +672,10 @@ idx_t GroupedAggregateHashTable::Scan(idx_t &scan_position, DataChunk &result) {
 	result.SetCardinality(this_n);
 	// fetch the group columns (ignoring the final hash column
 	const auto group_cols = layout.ColumnCount() - 1;
-	for (idx_t i = 0; i < group_cols; i++) {
-		auto &column = result.data[i];
-		const auto col_offset = layout.GetOffsets()[i];
+	for (idx_t col_no = 0; col_no < group_cols; col_no++) {
+		auto &column = result.data[col_no];
 		RowOperations::Gather(addresses, *FlatVector::IncrementalSelectionVector(), column,
-		                      *FlatVector::IncrementalSelectionVector(), result.size(), col_offset, i);
+		                      *FlatVector::IncrementalSelectionVector(), result.size(), layout, col_no);
 	}
 
 	RowOperations::FinalizeStates(layout, addresses, result, group_cols);

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -520,8 +520,7 @@ void ScanStructure::AdvancePointers() {
 
 void ScanStructure::GatherResult(Vector &result, const SelectionVector &result_vector,
                                  const SelectionVector &sel_vector, const idx_t count, const idx_t col_no) {
-	const auto col_offset = ht.layout.GetOffsets()[col_no];
-	RowOperations::Gather(pointers, sel_vector, result, result_vector, count, col_offset, col_no);
+	RowOperations::Gather(pointers, sel_vector, result, result_vector, count, ht.layout, col_no);
 }
 
 void ScanStructure::GatherResult(Vector &result, const SelectionVector &sel_vector, const idx_t count,
@@ -864,8 +863,7 @@ void JoinHashTable::GatherFullOuter(DataChunk &result, Vector &addresses, idx_t 
 		auto &vector = result.data[left_column_count + i];
 		D_ASSERT(vector.GetType() == build_types[i]);
 		const auto col_no = condition_types.size() + i;
-		const auto col_offset = layout.GetOffsets()[col_no];
-		RowOperations::Gather(addresses, sel_vector, vector, sel_vector, found_entries, col_offset, col_no);
+		RowOperations::Gather(addresses, sel_vector, vector, sel_vector, found_entries, layout, col_no);
 	}
 }
 

--- a/src/execution/operator/join/perfect_hash_join_executor.cpp
+++ b/src/execution/operator/join/perfect_hash_join_executor.cpp
@@ -60,8 +60,7 @@ bool PerfectHashJoinExecutor::FullScanHashTable(JoinHTScanState &state, LogicalT
 		auto &vector = perfect_hash_table[i];
 		D_ASSERT(vector.GetType() == ht.build_types[i]);
 		const auto col_no = ht.condition_types.size() + i;
-		const auto col_offset = ht.layout.GetOffsets()[col_no];
-		RowOperations::Gather(tuples_addresses, sel_tuples, vector, sel_build, keys_count, col_offset, col_no,
+		RowOperations::Gather(tuples_addresses, sel_tuples, vector, sel_build, keys_count, ht.layout, col_no,
 		                      build_size);
 	}
 	return true;

--- a/src/execution/operator/join/physical_piecewise_merge_join.cpp
+++ b/src/execution/operator/join/physical_piecewise_merge_join.cpp
@@ -212,6 +212,7 @@ public:
 	DataChunk rhs_keys;
 	DataChunk rhs_input;
 	ExpressionExecutor rhs_executor;
+	BufferHandle payload_heap_handle;
 
 public:
 	void ResolveJoinKeys(DataChunk &input) {
@@ -561,8 +562,8 @@ OperatorResultType PhysicalPiecewiseMergeJoin::ResolveComplexJoin(ExecutionConte
 			for (idx_t c = 0; c < state.lhs_payload.ColumnCount(); ++c) {
 				chunk.data[c].Slice(state.lhs_payload.data[c], left_info.result, result_count);
 			}
-			SliceSortedPayload(chunk, right_info.state, right_info.block_idx, right_info.result, result_count,
-			                   left_cols);
+			state.payload_heap_handle = SliceSortedPayload(chunk, right_info.state, right_info.block_idx,
+			                                               right_info.result, result_count, left_cols);
 			chunk.SetCardinality(result_count);
 
 			auto sel = FlatVector::IncrementalSelectionVector();

--- a/src/include/duckdb/common/row_operations/row_operations.hpp
+++ b/src/include/duckdb/common/row_operations/row_operations.hpp
@@ -49,8 +49,11 @@ struct RowOperations {
 	static void Scatter(DataChunk &columns, UnifiedVectorFormat col_data[], const RowLayout &layout, Vector &rows,
 	                    RowDataCollection &string_heap, const SelectionVector &sel, idx_t count);
 	//! Gather a single column.
+	//! If heap_ptr is not null, then the data is assumed to contain swizzled pointers,
+	//! which will be unswizzled in memory.
 	static void Gather(Vector &rows, const SelectionVector &row_sel, Vector &col, const SelectionVector &col_sel,
-	                   const idx_t count, const idx_t col_offset, const idx_t col_no, const idx_t build_size = 0);
+	                   const idx_t count, const RowLayout &layout, const idx_t col_no, const idx_t build_size = 0,
+	                   data_ptr_t heap_ptr = nullptr);
 	//! Full Scan an entire columns
 	static void FullScanColumn(const RowLayout &layout, Vector &rows, Vector &col, idx_t count, idx_t col_idx);
 

--- a/src/include/duckdb/execution/operator/join/physical_range_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_range_join.hpp
@@ -95,8 +95,10 @@ public:
 
 public:
 	// Gather the result values and slice the payload columns to those values.
-	static void SliceSortedPayload(DataChunk &payload, GlobalSortState &state, const idx_t block_idx,
-	                               const SelectionVector &result, const idx_t result_count, const idx_t left_cols = 0);
+	// Returns a buffer handle to the pinned heap block (if any)
+	static BufferHandle SliceSortedPayload(DataChunk &payload, GlobalSortState &state, const idx_t block_idx,
+	                                       const SelectionVector &result, const idx_t result_count,
+	                                       const idx_t left_cols = 0);
 	// Apply a tail condition to the current selection
 	static idx_t SelectJoinTail(const ExpressionType &condition, Vector &left, Vector &right,
 	                            const SelectionVector *sel, idx_t count, SelectionVector *true_sel);

--- a/test/sql/join/inner/test_range_join.test
+++ b/test/sql/join/inner/test_range_join.test
@@ -57,3 +57,26 @@ SELECT test.a, test.b, test2.b, test2.c FROM test, test2 WHERE test.a>test2.c AN
 ----
 11	1	1	10
 
+# Forced external
+statement ok
+PRAGMA debug_force_external=true;
+
+# In memory unswizzling
+statement ok
+CREATE TABLE issue4419 (x INT, y VARCHAR);
+
+statement ok
+INSERT INTO issue4419 VALUES (1, 'sssssssssssssssssueufuheuooefef');
+
+statement ok
+INSERT INTO issue4419 VALUES (2, 'sssssssssssssssssueufuheuooefesffff');
+
+statement ok
+INSERT INTO issue4419 VALUES (2, 'sssssssssssssssssueufuheuooefesffffsssssssieiffih');
+
+query IIII
+SELECT * FROM issue4419 t1 INNER JOIN issue4419 t2 ON t1.x < t2.x;
+----
+1	sssssssssssssssssueufuheuooefef	2	sssssssssssssssssueufuheuooefesffff
+1	sssssssssssssssssueufuheuooefef	2	sssssssssssssssssueufuheuooefesffffsssssssieiffih
+


### PR DESCRIPTION
Add an optional heap pointer argument to Gather
so that it can gather from swizzled rows without having
to modify the swizzled data.

This makes it so we can now read paged sorted data in parallel,
without having to worry about swizzling state, mutexes or any other
nasty machinery.