### PR TITLE
Declare all variables for nodejs.

### DIFF
--- a/tools/nodejs/lib/duckdb.js
+++ b/tools/nodejs/lib/duckdb.js
@@ -296,7 +296,7 @@ Connection.prototype.register_bulk;
  */
 Connection.prototype.unregister;
 
-default_connection = function (o) {
+var default_connection = function (o) {
     if (o.default_connection == undefined) {
         o.default_connection = new duckdb.Connection(o);
     }


### PR DESCRIPTION
Minor thing that was a head scratcher for us updating esbuild - under strict mode assigning to an undeclared variable is an error.