### PR TITLE
[Fuzzer] Issue #4152 - CatalogEntry dependency on extension

### DIFF
--- a/src/execution/operator/helper/physical_load.cpp
+++ b/src/execution/operator/helper/physical_load.cpp
@@ -6,9 +6,9 @@ namespace duckdb {
 void PhysicalLoad::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
                            LocalSourceState &lstate) const {
 	if (info->load_type == LoadType::INSTALL || info->load_type == LoadType::FORCE_INSTALL) {
-		ExtensionHelper::InstallExtension(context.client, info->filename, info->load_type == LoadType::FORCE_INSTALL);
+		ExtensionHelper::InstallExtension(context.client, info->FileName(), info->load_type == LoadType::FORCE_INSTALL);
 	} else {
-		ExtensionHelper::LoadExternalExtension(context.client, info->filename);
+		ExtensionHelper::LoadExternalExtension(context.client, info->FileName());
 	}
 }
 

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -52,7 +52,7 @@ public:
 	DUCKDB_API bool TryGetCurrentSetting(const std::string &key, Value &result);
 
 private:
-	void Initialize(const char *path, DBConfig *config, DuckDB& db);
+	void Initialize(const char *path, DBConfig *config, DuckDB &db);
 
 	void Configure(DBConfig &config);
 

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -21,6 +21,7 @@ class ConnectionManager;
 class FileSystem;
 class TaskScheduler;
 class ObjectCache;
+class DuckDB;
 
 class DatabaseInstance : public std::enable_shared_from_this<DatabaseInstance> {
 	friend class DuckDB;
@@ -51,7 +52,7 @@ public:
 	DUCKDB_API bool TryGetCurrentSetting(const std::string &key, Value &result);
 
 private:
-	void Initialize(const char *path, DBConfig *config);
+	void Initialize(const char *path, DBConfig *config, DuckDB& db);
 
 	void Configure(DBConfig &config);
 

--- a/src/include/duckdb/parser/parsed_data/load_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/load_info.hpp
@@ -9,22 +9,31 @@
 #pragma once
 
 #include "duckdb/parser/parsed_data/parse_info.hpp"
+#include "duckdb/common/string.hpp"
 
 namespace duckdb {
 
 enum class LoadType { LOAD, INSTALL, FORCE_INSTALL };
 
 struct LoadInfo : public ParseInfo {
-	std::string filename;
-	LoadType load_type;
-
 public:
+	LoadInfo() {}
+	LoadType load_type;
+public:
+	const string& FileName() {
+		return filename;
+	}
+	void SetFileName(const string& file_name) {
+		filename = file_name;
+	}
 	unique_ptr<LoadInfo> Copy() const {
 		auto result = make_unique<LoadInfo>();
 		result->filename = filename;
 		result->load_type = load_type;
 		return result;
 	}
+private:
+	string filename;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/parsed_data/load_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/load_info.hpp
@@ -17,13 +17,15 @@ enum class LoadType { LOAD, INSTALL, FORCE_INSTALL };
 
 struct LoadInfo : public ParseInfo {
 public:
-	LoadInfo() {}
+	LoadInfo() {
+	}
 	LoadType load_type;
+
 public:
-	const string& FileName() {
+	const string &FileName() {
 		return filename;
 	}
-	void SetFileName(const string& file_name) {
+	void SetFileName(const string &file_name) {
 		filename = file_name;
 	}
 	unique_ptr<LoadInfo> Copy() const {
@@ -32,6 +34,7 @@ public:
 		result->load_type = load_type;
 		return result;
 	}
+
 private:
 	string filename;
 };

--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -38,6 +38,8 @@ public:
 	static StorageManager &GetStorageManager(ClientContext &context);
 	static StorageManager &GetStorageManager(DatabaseInstance &db);
 
+	//! Load the database from disk or create the block_manager
+	void InitializeDatabase();
 	//! Initialize a database or load an existing database from the given path
 	void Initialize();
 	//! Get the WAL of the StorageManager, returns nullptr if in-memory

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -107,7 +107,7 @@ ConnectionManager &ConnectionManager::Get(ClientContext &context) {
 	return ConnectionManager::Get(DatabaseInstance::GetDatabase(context));
 }
 
-void DatabaseInstance::Initialize(const char *path, DBConfig *new_config, DuckDB& db) {
+void DatabaseInstance::Initialize(const char *path, DBConfig *new_config, DuckDB &db) {
 	if (new_config) {
 		// user-supplied configuration
 		Configure(*new_config);

--- a/src/parser/transform/statement/transform_load.cpp
+++ b/src/parser/transform/statement/transform_load.cpp
@@ -9,7 +9,7 @@ unique_ptr<LoadStatement> Transformer::TransformLoad(duckdb_libpgquery::PGNode *
 
 	auto load_stmt = make_unique<LoadStatement>();
 	auto load_info = make_unique<LoadInfo>();
-	load_info->filename = std::string(stmt->filename);
+	load_info->SetFileName(std::string(stmt->filename));
 	switch (stmt->load_type) {
 	case duckdb_libpgquery::PG_LOAD_TYPE_LOAD:
 		load_info->load_type = LoadType::LOAD;

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -43,6 +43,15 @@ bool StorageManager::InMemory() {
 	return path.empty() || path == ":memory:";
 }
 
+void StorageManager::InitializeDatabase() {
+	if (!InMemory()) {
+		// create or load the database from disk, if not in-memory mode
+		LoadDatabase();
+	} else {
+		block_manager = make_unique<InMemoryBlockManager>();
+	}
+}
+
 void StorageManager::Initialize() {
 	bool in_memory = InMemory();
 	if (in_memory && read_only) {
@@ -71,13 +80,6 @@ void StorageManager::Initialize() {
 
 	// commit transactions
 	con.Commit();
-
-	if (!in_memory) {
-		// create or load the database from disk, if not in-memory mode
-		LoadDatabase();
-	} else {
-		block_manager = make_unique<InMemoryBlockManager>();
-	}
 }
 
 void StorageManager::LoadDatabase() {

--- a/test/fuzzer/pedro/collate_reload_issue.test
+++ b/test/fuzzer/pedro/collate_reload_issue.test
@@ -1,0 +1,15 @@
+# name: test/fuzzer/pedro/collate_reload_issue.test
+# group: [pedro]
+
+# make this use a (temporary) persisted db
+require icu
+
+load __TEST_DIR__/collate_reload_issue.db
+
+statement ok
+CREATE TABLE t0 (c0 VARCHAR(0) COLLATE AF);
+
+restart
+
+statement ok
+SELECT * FROM t0;

--- a/test/fuzzer/pedro/collate_reload_issue.test
+++ b/test/fuzzer/pedro/collate_reload_issue.test
@@ -2,9 +2,9 @@
 # group: [pedro]
 
 # make this use a (temporary) persisted db
-require icu
-
 load __TEST_DIR__/collate_reload_issue.db
+
+require icu
 
 statement ok
 CREATE TABLE t0 (c0 VARCHAR(0) COLLATE AF);

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -331,7 +331,9 @@ void TestResultHelper::CheckStatementResult() {
 		// even in the case of "statement error", we do not accept ALL errors
 		// internal errors are never expected
 		// neither are "unoptimized result differs from original result" errors
-		bool internal_error = TestIsInternalError(runner.always_fail_error_messages, result.GetError());
+
+		bool internal_error =
+		    result.HasError() ? TestIsInternalError(runner.always_fail_error_messages, result.GetError()) : false;
 		if (!internal_error) {
 			error = !error;
 		} else {

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -74,6 +74,11 @@ void SQLLogicTestRunner::LoadDatabase(string dbpath) {
 	named_connection_map.clear();
 	// now re-open the current database
 
+	//! If the database depends on extensions, we have to make sure those extensions are loaded at startup
+	if (!extensions.empty()) {
+		config->options.load_extensions = true;
+	}
+
 	db = make_unique<DuckDB>(dbpath, config.get());
 	con = make_unique<Connection>(*db);
 	if (enable_verification) {


### PR DESCRIPTION
This PR attempts to fix the issue in #4152 entitled `Database collation not reloaded?`

The problem is that a CollateCatalogEntry is created by the ICU extension, and when it's used in a table this is serialized to disk.
When deserializing the database, the extensions are loaded last.
This results in a CatalogException being thrown when trying to load the CollateCatalogEntry, because it doesn't exist yet.

The ICU extension loading depends on quite a large portion of the database to be loaded, but I was able to squeeze the extension loading in between one of the load steps.

One last problem that's left to deal with though is related to the unittester
```c++
SQLLogicTestRunner::SQLLogicTestRunner(string dbpath) : dbpath(move(dbpath)) {
	config = GetTestConfig();
	config->options.load_extensions = false;
}
```
This causes the exception to be thrown still.