### PR TITLE
[CSV] Fixed bug related to invalidated iterators

### DIFF
--- a/src/execution/operator/persistent/buffered_csv_reader.cpp
+++ b/src/execution/operator/persistent/buffered_csv_reader.cpp
@@ -451,14 +451,28 @@ static bool StartsWithNumericDate(string &separator, const string &value) {
 
 string GenerateDateFormat(const string &separator, const char *format_template) {
 	string format_specifier = format_template;
-
-	//	replace all dashes with the separator
-	for (auto pos = std::find(format_specifier.begin(), format_specifier.end(), '-'); pos != format_specifier.end();
-	     pos = std::find(pos + separator.size(), format_specifier.end(), '-')) {
-		format_specifier.replace(pos, pos + 1, separator);
+	auto amount_of_dashes = std::count(format_specifier.begin(), format_specifier.end(), '-');
+	if (!amount_of_dashes) {
+		return format_specifier;
 	}
+	string result;
+	result.reserve(format_specifier.size() - amount_of_dashes + (amount_of_dashes * separator.size()));
+	for (auto &character : format_specifier) {
+		if (character == '-') {
+			result += separator;
+		} else {
+			result += character;
+		}
+	}
+	return result;
+	////	replace all dashes with the separator
+	// for (auto pos = std::find(format_specifier.begin(), format_specifier.end(), '-');
+	//      pos != format_specifier.end() && DoesNotExceedValidRange(format_specifier, pos, separator);
+	//      pos = std::find(pos + separator.size(), format_specifier.end(), '-')) {
+	//	format_specifier.replace(pos, pos + 1, separator);
+	// }
 
-	return format_specifier;
+	// return format_specifier;
 }
 
 TextSearchShiftArray::TextSearchShiftArray() {

--- a/src/execution/operator/persistent/buffered_csv_reader.cpp
+++ b/src/execution/operator/persistent/buffered_csv_reader.cpp
@@ -465,14 +465,6 @@ string GenerateDateFormat(const string &separator, const char *format_template) 
 		}
 	}
 	return result;
-	////	replace all dashes with the separator
-	// for (auto pos = std::find(format_specifier.begin(), format_specifier.end(), '-');
-	//      pos != format_specifier.end() && DoesNotExceedValidRange(format_specifier, pos, separator);
-	//      pos = std::find(pos + separator.size(), format_specifier.end(), '-')) {
-	//	format_specifier.replace(pos, pos + 1, separator);
-	// }
-
-	// return format_specifier;
 }
 
 TextSearchShiftArray::TextSearchShiftArray() {

--- a/test/sql/copy/csv/auto/test_date_format_bug_linux.test
+++ b/test/sql/copy/csv/auto/test_date_format_bug_linux.test
@@ -1,0 +1,10 @@
+# name: test/sql/copy/csv/auto/test_date_format_bug_linux.test
+# group: [auto]
+
+query I
+SELECT *  FROM read_csv_auto('test/sql/copy/csv/data/auto/date_format_bug_linux.csv')
+----
+test
+8cb123cb8
+34fd321
+fg5391jn4

--- a/test/sql/copy/csv/data/auto/date_format_bug_linux.csv
+++ b/test/sql/copy/csv/data/auto/date_format_bug_linux.csv
@@ -1,0 +1,4 @@
+test
+8cb123cb8
+34fd321
+fg5391jn4


### PR DESCRIPTION
This PR fixes #4503 

The old code was relying on an iterator after a `replace` operation had been called on the string where the iterator originated from. Because replace might cause a reallocation, all iterators are considered invalidated after this operation has been called.

This caused undefined behavior that was masked on MacOS and was only highlighted by running said code on Linux