### PR TITLE
feat: aarch64 linux wheels

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -265,6 +265,7 @@ jobs:
          shell: bash
          working-directory: tools/pythonpkg
          run: |
+           . venv/bin/activate
            python3 -m pip install pip -U
            python3 -m sysconfig
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -217,10 +217,10 @@ jobs:
        matrix:
          arch: [aarch64]
          python_build: [
-           {url: 'https://anaconda.org/anaconda/python/3.10.4/download/linux-aarch64/python-3.10.4-hc137634_0.tar.bz2', version: 3.10.4},
-           {url: 'https://anaconda.org/anaconda/python/3.9.12/download/linux-aarch64/python-3.9.12-hc137634_1.tar.bz2', version: 3.9.12},
-           {url: 'https://anaconda.org/anaconda/python/3.8.13/download/linux-aarch64/python-3.8.13-hc137634_0.tar.bz2', version: 3.8.13},
-           {url: 'https://anaconda.org/anaconda/python/3.7.13/download/linux-aarch64/python-3.7.13-hc137634_0.tar.bz2', version: 3.7.13},
+           {url: 'https://anaconda.org/anaconda/python/3.10.4/download/linux-aarch64/python-3.10.4-hc137634_0.tar.bz2', version: 3.10},
+           {url: 'https://anaconda.org/anaconda/python/3.9.12/download/linux-aarch64/python-3.9.12-hc137634_1.tar.bz2', version: 3.9},
+           {url: 'https://anaconda.org/anaconda/python/3.8.13/download/linux-aarch64/python-3.8.13-hc137634_0.tar.bz2', version: 3.8},
+           {url: 'https://anaconda.org/anaconda/python/3.7.13/download/linux-aarch64/python-3.7.13-hc137634_0.tar.bz2', version: 3.7},
          ]
          isRelease:
            - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -271,7 +271,7 @@ jobs:
           python setup.py bdist_wheel
 
        - uses: uraimo/run-on-arch-action@v2
-         name: Run commands
+         name: Tests
          id: runcmd
          with:
           arch: armv7
@@ -283,7 +283,7 @@ jobs:
 
           dockerRunArgs: |
             --volume "${PWD}/dist:/dist"
-
+          install: apt install python3.10-full
           run: |
             pip install /artifacts/*.whl
             python -c "print(__import__('duckdb').__version__)"

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -258,11 +258,13 @@ jobs:
            ls
 
            python3 -m crossenv usr/bin/python3.10 venv
+           . venv/bin/activate
+           echo "VIRTUAL ENV:" $VIRTUAL_ENV
 
            export DISTUTILS_C_COMPILER_LAUNCHER=ccache
            # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
 
-           ./venv/bin/activate/python3 setup.py bdist_wheel
+           python setup.py bdist_wheel
 
    osx-python3:
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -255,7 +255,7 @@ jobs:
            dpkg-deb -xv python_3.10.6_aarch64.deb python-aarch64
            ls
 
-           python3 -m crossenv data/data/com.termux/files/usr/bin/python3 venv
+           python3 -m crossenv python-aarch64/data/data/com.termux/files/usr/bin/python3 venv
            . venv/bin/activate
            pip install numpy
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -277,9 +277,8 @@ jobs:
            . venv/bin/activate
            echo "VIRTUAL ENV:" $VIRTUAL_ENV
 
-           wget https://files.pythonhosted.org/packages/15/aa/f831165eefc6e0f10082db7b314871490f30791f9e6a2ddc404828c77e67/numpy-1.23.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
            pip install wheel
-           pip install numpy-1.23.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+           pip install numpy
 
            export DISTUTILS_C_COMPILER_LAUNCHER=ccache
            # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -253,8 +253,8 @@ jobs:
            cd tools/pythonpkg
            wget https://grimler.se/termux-packages-24/pool/main/p/python/python_3.10.6_aarch64.deb
            ar vx python_3.10.6_aarch64.deb
-           tar xvf control.tar.gz
-           tar data.tar.gz
+           tar xvf control.tar.xz
+           tar data.tar.xz
            ls
 
            python3 -m crossenv python3 venv

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -281,7 +281,7 @@ jobs:
        - uses: addnab/docker-run-action@v3
          with:
             image: 'quay.io/pypa/manylinux2014_aarch64:latest'
-            options: --volume ${{ github.workspace }}:/duckdb
+            options: --volume ${{ github.workspace }}:/duckdb --platform linux/arm64/v8
             run: |
               uname -m
               python3 -V

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -259,7 +259,7 @@ jobs:
            # TODO: need to find source for older aarch64 python binaries
            wget ${{ matrix.python_build.url }}
            tar -xvjf *.tar.bz2
-           ls lib/python${{matrix.python_build.version}}/_sysconfigdata_*.py | grep -v sysconfigdata_aarch64_conda_linux_gnu | xargs rm
+           ls lib/python${{matrix.python_build.version}}/_sysconfigdata_* | grep -v sysconfigdata_aarch64_conda_linux_gnu | xargs rm
 
            # if cibuildwheel starts supporting cross compiling for aarch64 at some point we should switch to that
            # as using emulation is far too slow (6+ hours)

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -285,7 +285,7 @@ jobs:
             --volume "${PWD}/dist:/dist"
           install: |
             apt update
-            apt install python3.10-full -y
+            apt install python3.10-full python3-pip -y
           run: |
             python3.10 -m pip install /artifacts/*.whl
             python3.10 -c "print(__import__('duckdb').__version__)"

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -252,7 +252,9 @@ jobs:
          run: |
            cd tools/pythonpkg
            wget https://grimler.se/termux-packages-24/pool/main/p/python/python_3.10.6_aarch64.deb
-           ar x python_3.10.6_aarch64.deb
+           ar vx python_3.10.6_aarch64.deb
+           tar xvf control.tar.gz
+           tar data.tar.gz
            ls
 
            python3 -m crossenv python3 venv

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -259,15 +259,19 @@ jobs:
 
            python3 -m crossenv usr/bin/python3.10 venv --cc $(which aarch64-linux-gnu-gcc) --cxx $(which aarch64-linux-gnu-g++) --ar $(which aarch64-linux-gnu-ar)
 
+       - name: Debug pip
+         shell: bash
+         working-directory: tools/pythonpkg
+         run: |
+           python3 -m pip install pip -U
+           python3 -m pip debug --verbose
+
        - name: Build
          shell: bash
          working-directory: tools/pythonpkg
          run: |
            . venv/bin/activate
            echo "VIRTUAL ENV:" $VIRTUAL_ENV
-           python3 -m pip install pip -U
-           python3 -c "print(__import__('platform').architecture())"
-           python3 -c "import packaging.tags; print(list(packaging.tags.sys_tags()))"
 
            wget https://files.pythonhosted.org/packages/15/aa/f831165eefc6e0f10082db7b314871490f30791f9e6a2ddc404828c77e67/numpy-1.23.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
            pip install wheel

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -222,7 +222,7 @@ jobs:
      strategy:
        matrix:
          arch: [aarch64]
-         python_build: [cp37-*, cp38-*, cp39-*, cp310-*]
+         python_build: [3.10.6]
          isRelease:
            - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}
          exclude:
@@ -238,7 +238,7 @@ jobs:
 
        - uses: actions/setup-python@v2
          with:
-           python-version: 3.10.6
+           python-version: ${{ matrix.python_build }}
 
        - name: Install
          shell: bash
@@ -256,35 +256,27 @@ jobs:
          working-directory: tools/pythonpkg
          run: |
            python3 -m pip install pip -U
-           wget http://mirror.archlinuxarm.org/aarch64/core/python-3.10.6-1-aarch64.pkg.tar.xz
+           wget http://mirror.archlinuxarm.org/aarch64/core/python-${{ matrix.python_build }}-1-aarch64.pkg.tar.xz
            tar xf python-3.10.6-1-aarch64.pkg.tar.xz
 
            python3 -m crossenv usr/bin/python3.10 venv --cc $(which aarch64-linux-gnu-gcc) --cxx $(which aarch64-linux-gnu-g++) --ar $(which aarch64-linux-gnu-ar) --manylinux manylinux_2_17 --manylinux manylinux2014
-
-       - name: Debug pip
-         shell: bash
-         working-directory: tools/pythonpkg
-         run: |
-           . venv/bin/activate
-           python3 -m pip install pip -U
-           python3 -m sysconfig
-           python3 -m pip debug --verbose
 
        - name: Build
          shell: bash
          working-directory: tools/pythonpkg
          run: |
           . venv/bin/activate
-          echo "VIRTUAL ENV:" $VIRTUAL_ENV
-          
-          build-python -m pip install wheel numpy
+
+          build-python -m pip install numpy
           pip install wheel
-          # pip install numpy
-          
+
           export DISTUTILS_C_COMPILER_LAUNCHER=ccache
-          # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
-          
+
           python setup.py bdist_wheel
+
+       - uses: actions/upload-artifact@v2
+         with:
+           path: dist/
 
    osx-python3:
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -295,7 +295,7 @@ jobs:
             apt update
             apt install software-properties-common --yes
             add-apt-repository ppa:deadsnakes --yes
-            apt install python${{matrix.python_build.version}}-full --yes
+            apt install python${{matrix.python_build.version}}-full python3-pip --yes
 
             # # Download, build and install python
             # apt install wget
@@ -305,7 +305,7 @@ jobs:
             # ./configure --enable-optimizations --enable-shared --enable-unicode=ucs4 --enable-ssl
             # make altinstall
             # cd ..
-            python${{matrix.python_build.version}} -m ensurepip
+            # python${{matrix.python_build.version}} -m ensurepip
 
           run: |
             cd /duckdb/tools/pythonpkg

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -252,9 +252,7 @@ jobs:
          run: |
            cd tools/pythonpkg
            wget https://grimler.se/termux-packages-24/pool/main/p/python/python_3.10.6_aarch64.deb
-           ar vx python_3.10.6_aarch64.deb
-           tar xvf control.tar.xz
-           tar data.tar.xz
+           dpkg-deb -xv python_3.10.6_aarch64.deb python-aarch64
            ls
 
            python3 -m crossenv python3 venv
@@ -264,7 +262,7 @@ jobs:
            export DISTUTILS_C_COMPILER_LAUNCHER=ccache
            # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
 
-           pyproject-build
+           python3 setup.py bdist_wheel
 
    osx-python3:
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -272,11 +272,13 @@ jobs:
 
           export DISTUTILS_C_COMPILER_LAUNCHER=ccache
 
+          python -m pip install .
           python setup.py bdist_wheel
+          ls
 
        - uses: actions/upload-artifact@v2
          with:
-           path: dist/
+           path: tools/pythonpkg/venv/cross/lib/python3.10/site-packages/duckdb
 
    osx-python3:
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -217,6 +217,7 @@ jobs:
        matrix:
          arch: [aarch64]
          python_build: [
+           # urls from https://anaconda.org/anaconda/python/files
            {url: 'https://anaconda.org/anaconda/python/3.10.4/download/linux-aarch64/python-3.10.4-hc137634_0.tar.bz2', version: '3.10'},
            {url: 'https://anaconda.org/anaconda/python/3.9.12/download/linux-aarch64/python-3.9.12-hc137634_1.tar.bz2', version: '3.9'},
            {url: 'https://anaconda.org/anaconda/python/3.8.13/download/linux-aarch64/python-3.8.13-hc137634_0.tar.bz2', version: '3.8'},

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -259,7 +259,9 @@ jobs:
            # TODO: need to find source for older aarch64 python binaries
            wget ${{ matrix.python_build.url }}
            tar -xvjf *.tar.bz2
-           ls
+           rm lib/python${{matrix.python_build.version}}/_sysconfigdata_i686_conda_linux_gnu.py
+           rm lib/python${{matrix.python_build.version}}/_sysconfigdata_s390x_conda_linux_gnu.py
+           ls lib/python${{matrix.python_build.version}}/_sysconfigdata_*.py
 
            # if cibuildwheel starts supporting cross compiling for aarch64 at some point we should switch to that
            # as using emulation is far too slow (6+ hours)

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -275,10 +275,15 @@ jobs:
           python -m pip install .
           python setup.py bdist_wheel
           ls
+          tree dist
+          tree build
 
        - uses: actions/upload-artifact@v2
          with:
-           path: tools/pythonpkg/venv/cross/lib/python3.10/site-packages/duckdb
+           path: |
+             tools/pythonpkg/venv/cross/lib/python3.10/site-packages/duckdb
+             tools/pythonpkg/build
+             tools/pythonpkg/dist
 
    osx-python3:
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -256,10 +256,11 @@ jobs:
            wget http://mirror.archlinuxarm.org/aarch64/core/python-3.10.6-1-aarch64.pkg.tar.xz
            tar xf python-3.10.6-1-aarch64.pkg.tar.xz
 
-           CC=$(which aarch64-unknown-linux-gnu)
-           echo $CC
+           CC=$(which aarch64-linux-gnu-gcc)
+           CXX=$(which aarch64-linux-gnu-g++)
+           echo $CC $CXX
 
-           python3 -m crossenv usr/bin/python3.10 venv --cc $(CC)
+           python3 -m crossenv usr/bin/python3.10 venv --cc $CC --cxx $CXX
            . venv/bin/activate
            echo "VIRTUAL ENV:" $VIRTUAL_ENV
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -285,7 +285,7 @@ jobs:
             --volume "${PWD}/dist:/dist"
           install: |
             apt update
-            apt install python3.10-full
+            apt install python3.10-full -y
           run: |
             pip install /artifacts/*.whl
             python -c "print(__import__('duckdb').__version__)"

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -256,7 +256,10 @@ jobs:
            wget http://mirror.archlinuxarm.org/aarch64/core/python-3.10.6-1-aarch64.pkg.tar.xz
            tar xf python-3.10.6-1-aarch64.pkg.tar.xz
 
-           python3 -m crossenv usr/bin/python3.10 venv
+           CC=$(which aarch64-unknown-linux-gnu)
+           echo $CC
+
+           python3 -m crossenv usr/bin/python3.10 venv --cc $(CC)
            . venv/bin/activate
            echo "VIRTUAL ENV:" $VIRTUAL_ENV
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -280,8 +280,7 @@ jobs:
 
        - uses: addnab/docker-run-action@v3
          with:
-            registry: quay.io
-            image: manylinux2014_aarch64:latest
+            image: 'quay.io/pypa/manylinux2014_aarch64:latest'
             options: --volume "${{ github.workspace }}:/duckdb"
             run: |
               cd /duckdb/tools/pythonpkg

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -251,7 +251,7 @@ jobs:
          shell: bash
          run: |
            cd tools/pythonpkg
-           wget https://grimler.se/termux-packages-24/pool/main/p/python/python_3.10.6_aarch64.deb
+           wget https://packages.termux.dev/apt/termux-main/pool/main/p/python/python_3.10.6_aarch64.deb
            dpkg-deb -xv python_3.10.6_aarch64.deb python-aarch64
            ls
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -281,7 +281,7 @@ jobs:
        - uses: addnab/docker-run-action@v3
          with:
             image: 'quay.io/pypa/manylinux2014_aarch64:latest'
-            options: --volume "${{ github.workspace }}:/duckdb"
+            options: --volume ${{ github.workspace }}:/duckdb
             run: |
               cd /duckdb/tools/pythonpkg
               ./bin/python${{matrix.python_build.version}} -m ensurepip

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -235,9 +235,9 @@ jobs:
          with:
            fetch-depth: 0
 
-       - uses: actions/setup-python@v4
-         with:
-           python-version: ${{ matrix.python_build.version }}
+      #  - uses: actions/setup-python@v4
+      #    with:
+      #      python-version: ${{ matrix.python_build.version }}
 
        - name: Install
          shell: bash
@@ -262,7 +262,7 @@ jobs:
 
            # if cibuildwheel starts supporting cross compiling for aarch64 at some point we should switch to that
            # as using emulation is far too slow (6+ hours)
-           python3 -m crossenv usr/bin/python3.10 venv --cc $(which aarch64-linux-gnu-gcc) --cxx $(which aarch64-linux-gnu-g++) --ar $(which aarch64-linux-gnu-ar) --manylinux manylinux_2_17 --manylinux manylinux2014
+           python${{matrix.python_build.version}} -m crossenv usr/bin/python3.10 venv --cc $(which aarch64-linux-gnu-gcc) --cxx $(which aarch64-linux-gnu-g++) --ar $(which aarch64-linux-gnu-ar) --manylinux manylinux_2_17 --manylinux manylinux2014
 
        - name: Build
          shell: bash

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -264,7 +264,7 @@ jobs:
          working-directory: tools/pythonpkg
          run: |
            python3 -m pip install pip -U
-           build-pip debug --verbose
+           python3 -m sysconfig
 
        - name: Build
          shell: bash

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -20,10 +20,14 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  TWINE_USERNAME: 'hfmuehleisen'
   TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
   AWS_ACCESS_KEY_ID: AKIAVBLKPL2ZW2T7TYFQ
   AWS_SECRET_ACCESS_KEY: ${{ secrets.NODE_PRE_GYP_SECRETACCESSKEY }}
   NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}
+  DUCKDB_BUILD_UNITY: 1
+  SETUPTOOLS_SCM_NO_LOCAL: 'yes'
+  PYTEST_TIMEOUT: '600'
 
 jobs:
 #  This is just a sanity check of Python 3.9 running with Arrow
@@ -34,9 +38,6 @@ jobs:
     env:
       CIBW_BUILD: 'cp39-manylinux_x86_64'
       CIBW_TEST_COMMAND: 'python -m pytest {project}/tests'
-      SETUPTOOLS_SCM_NO_LOCAL: 'yes'
-      TWINE_USERNAME: 'hfmuehleisen'
-      PYTEST_TIMEOUT: '600'
 
     steps:
     - uses: actions/checkout@v3
@@ -158,10 +159,6 @@ jobs:
     env:
       CIBW_BUILD: ${{ matrix.python_build}}
       CIBW_ARCHS: ${{ matrix.arch == 'i686' && 'auto32' || 'auto64' }}
-      SETUPTOOLS_SCM_NO_LOCAL: 'yes'
-      TWINE_USERNAME: 'hfmuehleisen'
-      PYTEST_TIMEOUT: '600'
-      DUCKDB_BUILD_UNITY: 1
 
     steps:
     - uses: actions/checkout@v3
@@ -302,6 +299,13 @@ jobs:
            path: |
              tools/pythonpkg/dist
 
+       - name: Deploy
+         shell: bash
+         run: |
+           if [[ "$GITHUB_REF" =~ ^(refs/heads/master|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
+             twine upload --non-interactive --disable-progress-bar --skip-existing tools/pythonpkg/dist/*.whl
+           fi
+
    osx-python3:
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
       name: Python 3 OSX
@@ -314,9 +318,6 @@ jobs:
         CIBW_BUILD: ${{ matrix.python_build}}
         CIBW_ARCHS: 'x86_64 universal2 arm64'
         CIBW_TEST_COMMAND: 'python -m pytest {project}/tests/fast'
-        SETUPTOOLS_SCM_NO_LOCAL: 'yes'
-        TWINE_USERNAME: 'hfmuehleisen'
-        DUCKDB_BUILD_UNITY: 1
 
       steps:
       - uses: actions/checkout@v3
@@ -372,10 +373,7 @@ jobs:
 
       env:
         CIBW_BUILD: ${{ matrix.python_build}}
-        SETUPTOOLS_SCM_NO_LOCAL: 'yes'
         SETUPTOOLS_USE_DISTUTILS: 'stdlib'
-        TWINE_USERNAME: 'hfmuehleisen'
-        DUCKDB_BUILD_UNITY: 1
 
       steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -253,11 +253,11 @@ jobs:
          shell: bash
          run: |
            cd tools/pythonpkg
-           wget https://packages.termux.dev/apt/termux-main/pool/main/p/python/python_3.10.6_aarch64.deb
-           dpkg-deb -xv python_3.10.6_aarch64.deb python-aarch64
+           wget wget http://mirror.archlinuxarm.org/aarch64/core/python-3.10.6-1-aarch64.pkg.tar.xz
+           tar -xf python-3.10.6-1-aarch64.pkg.tar.xz
            ls
 
-           python3 -m crossenv python-aarch64/data/data/com.termux/files/usr/bin/python3 venv
+           python3 -m crossenv usr/bin/python3.10 venv
            . venv/bin/activate
            pip install numpy
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -292,6 +292,7 @@ jobs:
           dockerRunArgs: |
             --volume "${PWD}:/duckdb"
           install: |
+            apt update
             apt install software-properties-common --yes
             add-apt-repository ppa:deadsnakes --yes
             apt install python${{matrix.python_build.version}}-full

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -243,7 +243,7 @@ jobs:
          shell: bash
          run: |
           python${{matrix.python_build.version}} -m pip install crossenv twine build
-          sudo apt install binutils-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross crossbuild-essential-arm64
+          apt install binutils-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross crossbuild-essential-arm64
 
        - name: Setup Ccache
          uses: hendrikmuhs/ccache-action@main

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -259,7 +259,7 @@ jobs:
            # TODO: need to find source for older aarch64 python binaries
            wget ${{ matrix.python_build.url }}
            tar -xvjf *.tar.bz2
-           ls lib/python${{matrix.python_build.version}}/_sysconfigdata_* | grep -v sysconfigdata_aarch64_conda_linux_gnu | xargs rm
+           ls lib/python${{matrix.python_build.version}}/**/_sysconfigdata_* | grep -v sysconfigdata_aarch64_conda_linux_gnu | xargs rm
 
            # if cibuildwheel starts supporting cross compiling for aarch64 at some point we should switch to that
            # as using emulation is far too slow (6+ hours)

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -255,7 +255,6 @@ jobs:
            cd tools/pythonpkg
            wget http://mirror.archlinuxarm.org/aarch64/core/python-3.10.6-1-aarch64.pkg.tar.xz
            tar xf python-3.10.6-1-aarch64.pkg.tar.xz
-           ls
 
            python3 -m crossenv usr/bin/python3.10 venv
            . venv/bin/activate

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -283,6 +283,8 @@ jobs:
             image: 'quay.io/pypa/manylinux2014_aarch64:latest'
             options: --volume ${{ github.workspace }}:/duckdb
             run: |
+              uname -m
+              python3 -V
               cd /duckdb/tools/pythonpkg
               ./bin/python${{matrix.python_build.version}} -m ensurepip
               ./bin/python${{matrix.python_build.version}} -m pip install dist/*.whl pytest pandas pyarrow psutil

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -255,7 +255,7 @@ jobs:
            dpkg-deb -xv python_3.10.6_aarch64.deb python-aarch64
            ls
 
-           python3 -m crossenv python3 venv
+           python3 -m crossenv data/data/com.termux/files/usr/bin/python3 venv
            . venv/bin/activate
            pip install numpy
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -264,7 +264,7 @@ jobs:
          working-directory: tools/pythonpkg
          run: |
            python3 -m pip install pip -U
-           python3 -m pip debug --verbose
+           build-pip debug --verbose
 
        - name: Build
          shell: bash
@@ -274,8 +274,8 @@ jobs:
            echo "VIRTUAL ENV:" $VIRTUAL_ENV
 
            wget https://files.pythonhosted.org/packages/15/aa/f831165eefc6e0f10082db7b314871490f30791f9e6a2ddc404828c77e67/numpy-1.23.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-           pip install wheel
-           pip install numpy-1.23.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+           build-pip install wheel
+           build-pip install numpy-1.23.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
 
            export DISTUTILS_C_COMPILER_LAUNCHER=ccache
            # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -277,8 +277,9 @@ jobs:
            . venv/bin/activate
            echo "VIRTUAL ENV:" $VIRTUAL_ENV
 
-           pip install wheel
-           pip install numpy
+           build-python -m pip install wheel numpy
+#           pip install wheel
+#           pip install numpy
 
            export DISTUTILS_C_COMPILER_LAUNCHER=ccache
            # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -265,6 +265,7 @@ jobs:
          run: |
            . venv/bin/activate
            echo "VIRTUAL ENV:" $VIRTUAL_ENV
+           python3 -m pip install pip -U
            python3 -c "print(__import__('platform').architecture())"
            python3 -c "import packaging.tags; print(list(packaging.tags.sys_tags()))"
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -212,7 +212,6 @@ jobs:
    linux-python3-aarch64:
      name: Python 3 Linux aarch64
      runs-on: ubuntu-20.04
-     #  container: quay.io/pypa/manylinux2014_x86_64
      strategy:
        matrix:
          arch: [aarch64]
@@ -227,9 +226,9 @@ jobs:
            - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}
          exclude:
            - isRelease: false
-             python_build: 'cp38-*'
+             python_build: {url: 'https://anaconda.org/anaconda/python/3.8.13/download/linux-aarch64/python-3.8.13-hc137634_0.tar.bz2', version: '3.8'}
            - isRelease: false
-             python_build: 'cp39-*'
+             python_build: {url: 'https://anaconda.org/anaconda/python/3.9.12/download/linux-aarch64/python-3.9.12-hc137634_1.tar.bz2', version: '3.9'}
 
      steps:
        - uses: actions/checkout@v3
@@ -256,7 +255,6 @@ jobs:
          working-directory: tools/pythonpkg
          run: |
            python${{matrix.python_build.version}} -m pip install pip -U
-           # TODO: need to find source for older aarch64 python binaries
            wget ${{ matrix.python_build.url }}
            tar -xvjf *.tar.bz2
            ls lib/python${{matrix.python_build.version}}/_sysconfigdata_* | grep -v sysconfigdata_aarch64_conda_linux_gnu | xargs rm

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -253,6 +253,7 @@ jobs:
          shell: bash
          working-directory: tools/pythonpkg
          run: |
+           python3 -m pip install pip -U
            wget http://mirror.archlinuxarm.org/aarch64/core/python-3.10.6-1-aarch64.pkg.tar.xz
            tar xf python-3.10.6-1-aarch64.pkg.tar.xz
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -265,6 +265,7 @@ jobs:
          run: |
            . venv/bin/activate
            echo "VIRTUAL ENV:" $VIRTUAL_ENV
+           python3 -c "print(__import__('platform').architecture())"
 
            wget https://files.pythonhosted.org/packages/15/aa/f831165eefc6e0f10082db7b314871490f30791f9e6a2ddc404828c77e67/numpy-1.23.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
            pip install wheel

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -240,7 +240,9 @@ jobs:
 
        - name: Install
          shell: bash
-         run: pip install crossenv twine build
+         run: |
+          pip install crossenv twine build
+          sudo apt install binutils-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross crossbuild-essential-arm64
 
        - name: Setup Ccache
          uses: hendrikmuhs/ccache-action@main

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        arch: [i686, x86_64, aarch64]
+        arch: [i686, x86_64]
         python_build: [cp37-*, cp38-*, cp39-*,cp310-*]
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}
@@ -157,7 +157,7 @@ jobs:
     needs: manylinux-extensions
     env:
       CIBW_BUILD: ${{ matrix.python_build}}
-      CIBW_ARCHS: ${{ matrix.arch == 'i686' && 'auto32' || (matrix.arch == 'x86_64' && 'auto64' || 'aarch64') }}
+      CIBW_ARCHS: ${{ matrix.arch == 'i686' && 'auto32' || 'auto64' }}
       SETUPTOOLS_SCM_NO_LOCAL: 'yes'
       TWINE_USERNAME: 'hfmuehleisen'
       PYTEST_TIMEOUT: '600'
@@ -171,11 +171,7 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: '3.7'
-    - name: Set up QEMU
-      if: matrix.arch == 'aarch64'
-      uses: docker/setup-qemu-action@v2
-      with:
-        platforms: all
+
     - name: Install
       shell: bash
       run: pip install cibuildwheel twine
@@ -280,9 +276,8 @@ jobs:
 
        - uses: actions/upload-artifact@v2
          with:
+           name: linux-python-aarch64
            path: |
-             tools/pythonpkg/venv/cross/lib/python3.10/site-packages/duckdb
-             tools/pythonpkg/build
              tools/pythonpkg/dist
 
    osx-python3:

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -291,15 +291,18 @@ jobs:
 
           dockerRunArgs: |
             --volume "${PWD}:/duckdb"
-          install:
-            # Download, build and install python
-            apt install wget
-            wget https://www.python.org/ftp/python/3.10.4/Python-3.10.4.tgz
-            tar -xzf Python-3.10.4.tgz
-            cd Python-3.10.4
-            ./configure --enable-optimizations --enable-shared --enable-unicode=ucs4 --enable-ssl
-            make altinstall
-            cd ..
+          install: |
+            add-apt-repository ppa:deadsnakes --yes
+            apt install python${{matrix.python_build.version}}-full
+
+            # # Download, build and install python
+            # apt install wget
+            # wget https://www.python.org/ftp/python/3.10.4/Python-3.10.4.tgz
+            # tar xzf Python-3.10.4.tgz
+            # cd Python-3.10.4
+            # ./configure --enable-optimizations --enable-shared --enable-unicode=ucs4 --enable-ssl
+            # make altinstall
+            # cd ..
             python3.10 -m ensurepip
 
           run: |

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -268,11 +268,25 @@ jobs:
 
           export DISTUTILS_C_COMPILER_LAUNCHER=ccache
 
-          python -m pip install .
           python setup.py bdist_wheel
-          ls
-          tree dist
-          tree build
+
+       - uses: uraimo/run-on-arch-action@v2
+         name: Run commands
+         id: runcmd
+         with:
+          arch: armv7
+          distro: ubuntu18.04
+
+          # Not required, but speeds up builds by storing container images in
+          # a GitHub package registry.
+          githubToken: ${{ github.token }}
+
+          dockerRunArgs: |
+            --volume "${PWD}/dist:/dist"
+
+          run: |
+            pip install /artifacts/*.whl
+            python -c "print(__import__('duckdb').__version__)"
 
        - uses: actions/upload-artifact@v2
          with:

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -235,7 +235,7 @@ jobs:
          with:
            fetch-depth: 0
 
-       - uses: actions/setup-python@v2
+       - uses: actions/setup-python@v4
          with:
            python-version: ${{ matrix.python_build.version }}
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -282,12 +282,13 @@ jobs:
           githubToken: ${{ github.token }}
 
           dockerRunArgs: |
-            --volume "${PWD}/dist:/dist"
+            --volume "${PWD}:/duckdb"
           install: |
             apt update
             apt install python3.10-full python3-pip -y
           run: |
-            python3.10 -m pip install /artifacts/*.whl
+            ls /duckdb
+            python3.10 -m pip install /duckdb/tools/pythonpkg/dist/*.whl
             python3.10 -c "print(__import__('duckdb').__version__)"
 
        - uses: actions/upload-artifact@v2

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -288,8 +288,8 @@ jobs:
             apt install python3.10-full python3-pip -y
           run: |
             cd /duckdb/tools/pythonpkg
-            python3 -m pip install -r requirements-dev.txt
             python3.10 -m pip install dist/*.whl -U
+            python3 -m pip install -r requirements-dev.txt
             python3.10 -c "print(__import__('duckdb').__version__)"
             python3.10 -m pytest tests/fast
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -257,8 +257,9 @@ jobs:
            python${{matrix.python_build.version}} -m pip install pip -U
            wget ${{ matrix.python_build.url }}
            tar -xvjf *.tar.bz2
-           ls lib/python${{matrix.python_build.version}}/_sysconfigdata_* | grep -v sysconfigdata_aarch64_conda_linux_gnu | xargs rm
-           rm -rf ls lib/python${{matrix.python_build.version}}/__pycache__
+           ls lib/python${{matrix.python_build.version}}/_sysconfigdata_* | grep -v aarch64 | xargs rm
+           ls lib/python${{matrix.python_build.version}}/_sysconfigdata_*
+           rm -rf lib/python${{matrix.python_build.version}}/__pycache__
 
            # if cibuildwheel starts supporting cross compiling for aarch64 at some point we should switch to that
            # as using emulation is far too slow (6+ hours)

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -290,14 +290,11 @@ jobs:
 
           dockerRunArgs: |
             --volume "${PWD}:/duckdb"
-          install: |
-            apt update
-            apt install python${{matrix.python_build.version}}-full python3-pip -y
           run: |
             cd /duckdb/tools/pythonpkg
-            python${{matrix.python_build.version}} -m pip install dist/*.whl pytest pandas pyarrow psutil
-            python${{matrix.python_build.version}} -c "print(__import__('duckdb').__version__)"
-            python${{matrix.python_build.version}} -m pytest tests/fast
+            ./bin/python${{matrix.python_build.version}} -m pip install dist/*.whl pytest pandas pyarrow psutil
+            ./bin/python${{matrix.python_build.version}} -c "print(__import__('duckdb').__version__)"
+            ./bin/python${{matrix.python_build.version}} -m pytest tests/fast
 
        - uses: actions/upload-artifact@v2
          with:

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -254,7 +254,7 @@ jobs:
          shell: bash
          working-directory: tools/pythonpkg
          run: |
-           python3 -m pip install pip -U
+           python${{matrix.python_build.version}} -m pip install pip -U
            # TODO: need to find source for older aarch64 python binaries
            wget ${{ matrix.python_build.url }}
            tar -xvjf *.tar.bz2

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        arch: [i686, x86_64]
+        arch: [i686, x86_64, aarch64]
         python_build: [cp37-*, cp38-*, cp39-*,cp310-*]
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}
@@ -157,7 +157,7 @@ jobs:
     needs: manylinux-extensions
     env:
       CIBW_BUILD: ${{ matrix.python_build}}
-      CIBW_ARCHS: ${{ matrix.arch == 'i686' && 'auto32' || 'auto64'}}
+      CIBW_ARCHS: ${{ matrix.arch == 'i686' && 'auto32' || (matrix.arch == 'x86_64' && 'auto64' || 'aarch64') }}
       SETUPTOOLS_SCM_NO_LOCAL: 'yes'
       TWINE_USERNAME: 'hfmuehleisen'
       PYTEST_TIMEOUT: '600'
@@ -171,7 +171,11 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: '3.7'
-
+    - name: Set up QEMU
+      if: matrix.arch == 'aarch64'
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: all
     - name: Install
       shell: bash
       run: pip install cibuildwheel twine

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -215,6 +215,7 @@ jobs:
    linux-python3-aarch64:
      name: Python 3 Linux aarch64
      runs-on: ubuntu-20.04
+     container: quay.io/pypa/manylinux2014_x86_64
      strategy:
        matrix:
          arch: [aarch64]

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -242,7 +242,7 @@ jobs:
        - name: Install
          shell: bash
          run: |
-          pip install crossenv twine build
+          python3 -m pip install crossenv twine build
           sudo apt install binutils-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross crossbuild-essential-arm64
 
        - name: Setup Ccache

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -257,8 +257,8 @@ jobs:
            python${{matrix.python_build.version}} -m pip install pip -U
            wget ${{ matrix.python_build.url }}
            tar -xvjf *.tar.bz2
-           ls lib/python${{matrix.python_build.version}}/_sysconfigdata_* | grep -v _sysconfigdata_m_linux_aarch64-linux-gnu | xargs rm
            ls lib/python${{matrix.python_build.version}}/_sysconfigdata_*
+           ls lib/python${{matrix.python_build.version}}/_sysconfigdata_* | grep -v "_sysconfigdata_m_linux_aarch64-linux-gnu" | xargs rm
            rm -rf lib/python${{matrix.python_build.version}}/__pycache__
 
            # if cibuildwheel starts supporting cross compiling for aarch64 at some point we should switch to that

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -259,7 +259,7 @@ jobs:
            wget http://mirror.archlinuxarm.org/aarch64/core/python-3.10.6-1-aarch64.pkg.tar.xz
            tar xf python-3.10.6-1-aarch64.pkg.tar.xz
 
-           python3 -m crossenv usr/bin/python3.10 venv --cc $(which aarch64-linux-gnu-gcc) --cxx $(which aarch64-linux-gnu-g++) --ar $(which aarch64-linux-gnu-ar)
+           python3 -m crossenv usr/bin/python3.10 venv --cc $(which aarch64-linux-gnu-gcc) --cxx $(which aarch64-linux-gnu-g++) --ar $(which aarch64-linux-gnu-ar) --manylinux manylinux_2_17 --manylinux manylinux2014
 
        - name: Debug pip
          shell: bash

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -217,10 +217,10 @@ jobs:
        matrix:
          arch: [aarch64]
          python_build: [
-           {url: 'https://anaconda.org/anaconda/python/3.10.4/download/linux-aarch64/python-3.10.4-hc137634_0.tar.bz2', version: 3.10},
-           {url: 'https://anaconda.org/anaconda/python/3.9.12/download/linux-aarch64/python-3.9.12-hc137634_1.tar.bz2', version: 3.9},
-           {url: 'https://anaconda.org/anaconda/python/3.8.13/download/linux-aarch64/python-3.8.13-hc137634_0.tar.bz2', version: 3.8},
-           {url: 'https://anaconda.org/anaconda/python/3.7.13/download/linux-aarch64/python-3.7.13-hc137634_0.tar.bz2', version: 3.7},
+           {url: 'https://anaconda.org/anaconda/python/3.10.4/download/linux-aarch64/python-3.10.4-hc137634_0.tar.bz2', version: '3.10'},
+           {url: 'https://anaconda.org/anaconda/python/3.9.12/download/linux-aarch64/python-3.9.12-hc137634_1.tar.bz2', version: '3.9'},
+           {url: 'https://anaconda.org/anaconda/python/3.8.13/download/linux-aarch64/python-3.8.13-hc137634_0.tar.bz2', version: '3.8'},
+           {url: 'https://anaconda.org/anaconda/python/3.7.13/download/linux-aarch64/python-3.7.13-hc137634_0.tar.bz2', version: '3.7'},
          ]
          isRelease:
            - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -274,8 +274,8 @@ jobs:
          name: Tests
          id: runcmd
          with:
-          arch: armv7
-          distro: ubuntu18.04
+          arch: aarch64
+          distro: ubuntu22.04
 
           # Not required, but speeds up builds by storing container images in
           # a GitHub package registry.

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -216,6 +216,50 @@ jobs:
           twine upload --non-interactive --disable-progress-bar --skip-existing tools/pythonpkg/wheelhouse/*.whl tools/pythonpkg/dist/duckdb-*.tar.gz
         fi
 
+   linux-python3-aarch64:
+     name: Python 3 Linux aarch64
+     runs-on: ubuntu-20.04
+     strategy:
+       matrix:
+         arch: [aarch64]
+         python_build: [cp37-*, cp38-*, cp39-*, cp310-*]
+         isRelease:
+           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}
+         exclude:
+           - isRelease: false
+             python_build: 'cp38-*'
+           - isRelease: false
+             python_build: 'cp39-*'
+
+     steps:
+       - uses: actions/checkout@v3
+         with:
+           fetch-depth: 0
+
+       - uses: actions/setup-python@v2
+
+       - name: Install
+         shell: bash
+         run: pip install crossenv twine build
+
+       - name: Setup Ccache
+         uses: hendrikmuhs/ccache-action@main
+         with:
+           key: ${{ github.job }}-${{ matrix.arch }}-${{ matrix.python_build }}
+
+       - name: Build
+         shell: bash
+         run: |
+           cd tools/pythonpkg
+           python3 -m crossenv python3 venv
+           . venv/bin/activate
+           pip install numpy
+
+           export DISTUTILS_C_COMPILER_LAUNCHER=ccache
+           # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
+
+           pyproject-build
+
    osx-python3:
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
       name: Python 3 OSX

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -243,7 +243,7 @@ jobs:
          shell: bash
          run: |
           python${{matrix.python_build.version}} -m pip install crossenv twine build
-          apt install binutils-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross crossbuild-essential-arm64
+          # apt install binutils-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross crossbuild-essential-arm64
 
        - name: Setup Ccache
          uses: hendrikmuhs/ccache-action@main

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -293,7 +293,7 @@ jobs:
             --volume "${PWD}:/duckdb"
           install:
             # Download, build and install python
-            yum add wget
+            apt install wget
             wget https://www.python.org/ftp/python/3.10.4/Python-3.10.4.tgz
             tar -xzf Python-3.10.4.tgz
             cd Python-3.10.4

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -287,8 +287,8 @@ jobs:
             apt update
             apt install python3.10-full -y
           run: |
-            pip install /artifacts/*.whl
-            python -c "print(__import__('duckdb').__version__)"
+            python3 -m pip install /artifacts/*.whl
+            python3 -c "print(__import__('duckdb').__version__)"
 
        - uses: actions/upload-artifact@v2
          with:

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -242,7 +242,7 @@ jobs:
        - name: Install
          shell: bash
          run: |
-          python3 -m pip install crossenv twine build
+          python${{matrix.python_build.version}} -m pip install crossenv twine build
           sudo apt install binutils-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross crossbuild-essential-arm64
 
        - name: Setup Ccache

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -265,7 +265,9 @@ jobs:
            . venv/bin/activate
            echo "VIRTUAL ENV:" $VIRTUAL_ENV
 
-           pip install wheel numpy
+           wget https://files.pythonhosted.org/packages/15/aa/f831165eefc6e0f10082db7b314871490f30791f9e6a2ddc404828c77e67/numpy-1.23.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+           pip install wheel
+           pip install numpy-1.23.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
 
            export DISTUTILS_C_COMPILER_LAUNCHER=ccache
            # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -266,6 +266,7 @@ jobs:
            . venv/bin/activate
            echo "VIRTUAL ENV:" $VIRTUAL_ENV
            python3 -c "print(__import__('platform').architecture())"
+           python3 -c "import packaging.tags; print(list(packaging.tags.sys_tags()))"
 
            wget https://files.pythonhosted.org/packages/15/aa/f831165eefc6e0f10082db7b314871490f30791f9e6a2ddc404828c77e67/numpy-1.23.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
            pip install wheel

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -258,7 +258,7 @@ jobs:
            wget ${{ matrix.python_build.url }}
            tar -xvjf *.tar.bz2
            ls lib/python${{matrix.python_build.version}}/_sysconfigdata_*
-           ls lib/python${{matrix.python_build.version}}/_sysconfigdata_* | grep -v "_sysconfigdata_m_linux_aarch64-linux-gnu" | xargs rm
+           ls lib/python${{matrix.python_build.version}}/_sysconfigdata_* | grep -v "linux_aarch64-linux-gnu" | xargs rm
            rm -rf lib/python${{matrix.python_build.version}}/__pycache__
 
            # if cibuildwheel starts supporting cross compiling for aarch64 at some point we should switch to that

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -293,6 +293,7 @@ jobs:
             --volume "${PWD}:/duckdb"
           install:
             # Download, build and install python
+            yum add wget
             wget https://www.python.org/ftp/python/3.10.4/Python-3.10.4.tgz
             tar -xzf Python-3.10.4.tgz
             cd Python-3.10.4

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -292,7 +292,8 @@ jobs:
           dockerRunArgs: |
             --volume "${PWD}:/duckdb"
           install: |
-            apt-add-repository ppa:deadsnakes --yes
+            apt install software-properties-common --yes
+            add-apt-repository ppa:deadsnakes --yes
             apt install python${{matrix.python_build.version}}-full
 
             # # Download, build and install python

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -212,7 +212,7 @@ jobs:
    linux-python3-aarch64:
      name: Python 3 Linux aarch64
      runs-on: ubuntu-20.04
-     container: quay.io/pypa/manylinux2014_x86_64
+     #  container: quay.io/pypa/manylinux2014_x86_64
      strategy:
        matrix:
          arch: [aarch64]
@@ -235,15 +235,15 @@ jobs:
          with:
            fetch-depth: 0
 
-      #  - uses: actions/setup-python@v4
-      #    with:
-      #      python-version: ${{ matrix.python_build.version }}
+       - uses: actions/setup-python@v4
+         with:
+           python-version: ${{ matrix.python_build.version }}
 
        - name: Install
          shell: bash
          run: |
           python${{matrix.python_build.version}} -m pip install crossenv twine build
-          # apt install binutils-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross crossbuild-essential-arm64
+          sudo apt install binutils-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross crossbuild-essential-arm64
 
        - name: Setup Ccache
          uses: hendrikmuhs/ccache-action@main

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -287,9 +287,11 @@ jobs:
             apt update
             apt install python3.10-full python3-pip -y
           run: |
-            ls /duckdb
-            python3.10 -m pip install /duckdb/tools/pythonpkg/dist/*.whl
+            cd /duckdb/tools/pythonpkg
+            python3 -m pip install -r requirements-dev.txt
+            python3.10 -m pip install dist/*.whl -U
             python3.10 -c "print(__import__('duckdb').__version__)"
+            python3.10 -m pytest tests/fast
 
        - uses: actions/upload-artifact@v2
          with:

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -274,17 +274,17 @@ jobs:
          shell: bash
          working-directory: tools/pythonpkg
          run: |
-           . venv/bin/activate
-           echo "VIRTUAL ENV:" $VIRTUAL_ENV
-
-           build-python -m pip install wheel numpy
-#           pip install wheel
-#           pip install numpy
-
-           export DISTUTILS_C_COMPILER_LAUNCHER=ccache
-           # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
-
-           python setup.py bdist_wheel
+          . venv/bin/activate
+          echo "VIRTUAL ENV:" $VIRTUAL_ENV
+          
+          build-python -m pip install wheel numpy
+          # pip install wheel
+          # pip install numpy
+          
+          export DISTUTILS_C_COMPILER_LAUNCHER=ccache
+          # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
+          
+          python setup.py bdist_wheel
 
    osx-python3:
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -253,8 +253,8 @@ jobs:
          shell: bash
          run: |
            cd tools/pythonpkg
-           wget wget http://mirror.archlinuxarm.org/aarch64/core/python-3.10.6-1-aarch64.pkg.tar.xz
-           tar -xf python-3.10.6-1-aarch64.pkg.tar.xz
+           wget http://mirror.archlinuxarm.org/aarch64/core/python-3.10.6-1-aarch64.pkg.tar.xz
+           tar xf python-3.10.6-1-aarch64.pkg.tar.xz
            ls
 
            python3 -m crossenv usr/bin/python3.10 venv

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -287,8 +287,8 @@ jobs:
             apt update
             apt install python3.10-full -y
           run: |
-            python3 -m pip install /artifacts/*.whl
-            python3 -c "print(__import__('duckdb').__version__)"
+            python3.10 -m pip install /artifacts/*.whl
+            python3.10 -c "print(__import__('duckdb').__version__)"
 
        - uses: actions/upload-artifact@v2
          with:

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -278,18 +278,34 @@ jobs:
 
           python setup.py bdist_wheel
 
-       - uses: addnab/docker-run-action@v3
+       - uses: uraimo/run-on-arch-action@v2
+         name: Tests
+         id: runcmd
          with:
-            image: 'quay.io/pypa/manylinux2014_aarch64:latest'
-            options: --volume ${{ github.workspace }}:/duckdb --platform linux/arm64/v8
-            run: |
-              uname -m
-              python3 -V
-              cd /duckdb/tools/pythonpkg
-              ./bin/python${{matrix.python_build.version}} -m ensurepip
-              ./bin/python${{matrix.python_build.version}} -m pip install dist/*.whl pytest pandas pyarrow psutil
-              ./bin/python${{matrix.python_build.version}} -c "print(__import__('duckdb').__version__)"
-              ./bin/python${{matrix.python_build.version}} -m pytest tests/fast
+          arch: aarch64
+          distro: ubuntu22.04
+
+          # Not required, but speeds up builds by storing container images in
+          # a GitHub package registry.
+          githubToken: ${{ github.token }}
+
+          dockerRunArgs: |
+            --volume "${PWD}:/duckdb"
+          install:
+            # Download, build and install python
+            wget https://www.python.org/ftp/python/3.10.4/Python-3.10.4.tgz
+            tar -xzf Python-3.10.4.tgz
+            cd Python-3.10.4
+            ./configure --enable-optimizations --enable-shared --enable-unicode=ucs4 --enable-ssl
+            make altinstall
+            cd ..
+            python3.10 -m ensurepip
+
+          run: |
+            cd /duckdb/tools/pythonpkg
+            python3.10 -m pip install dist/*.whl pytest pandas pyarrow psutil
+            python3.10 -c "print(__import__('duckdb').__version__)"
+            python3.10 -m pytest tests/fast
 
        - uses: actions/upload-artifact@v2
          with:

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -249,18 +249,19 @@ jobs:
          with:
            key: ${{ github.job }}-${{ matrix.arch }}-${{ matrix.python_build }}
 
-       - name: Build
+       - name: Setup build env
          shell: bash
+         working-directory: tools/pythonpkg
          run: |
-           cd tools/pythonpkg
            wget http://mirror.archlinuxarm.org/aarch64/core/python-3.10.6-1-aarch64.pkg.tar.xz
            tar xf python-3.10.6-1-aarch64.pkg.tar.xz
 
-           CC=$(which aarch64-linux-gnu-gcc)
-           CXX=$(which aarch64-linux-gnu-g++)
-           echo $CC $CXX
+           python3 -m crossenv usr/bin/python3.10 venv --$(which aarch64-linux-gnu-gcc) --cxx $(which aarch64-linux-gnu-g++) --ar $(which aarch64-linux-gnu-ar)
 
-           python3 -m crossenv usr/bin/python3.10 venv --cc $CC --cxx $CXX
+       - name: Build
+         shell: bash
+         working-directory: tools/pythonpkg
+         run: |
            . venv/bin/activate
            echo "VIRTUAL ENV:" $VIRTUAL_ENV
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -258,13 +258,11 @@ jobs:
            ls
 
            python3 -m crossenv usr/bin/python3.10 venv
-           . venv/bin/activate
-           pip install numpy
 
            export DISTUTILS_C_COMPILER_LAUNCHER=ccache
            # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
 
-           python3 setup.py bdist_wheel
+           ./venv/bin/activate/python3 setup.py bdist_wheel
 
    osx-python3:
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -259,7 +259,8 @@ jobs:
            # TODO: need to find source for older aarch64 python binaries
            wget ${{ matrix.python_build.url }}
            tar -xvjf *.tar.bz2
-           ls lib/python${{matrix.python_build.version}}/**/_sysconfigdata_* | grep -v sysconfigdata_aarch64_conda_linux_gnu | xargs rm
+           ls lib/python${{matrix.python_build.version}}/_sysconfigdata_* | grep -v sysconfigdata_aarch64_conda_linux_gnu | xargs rm
+           rm -rf ls lib/python${{matrix.python_build.version}}/__pycache__
 
            # if cibuildwheel starts supporting cross compiling for aarch64 at some point we should switch to that
            # as using emulation is far too slow (6+ hours)

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -292,12 +292,12 @@ jobs:
             --volume "${PWD}:/duckdb"
           install: |
             apt update
-            apt install python3.10-full python3-pip -y
+            apt install python${{matrix.python_build.version}}-full python3-pip -y
           run: |
             cd /duckdb/tools/pythonpkg
-            python3.10 -m pip install dist/*.whl pytest pandas pyarrow psutil
-            python3.10 -c "print(__import__('duckdb').__version__)"
-            python3.10 -m pytest tests/fast
+            python${{matrix.python_build.version}} -m pip install dist/*.whl pytest pandas pyarrow psutil
+            python${{matrix.python_build.version}} -c "print(__import__('duckdb').__version__)"
+            python${{matrix.python_build.version}} -m pytest tests/fast
 
        - uses: actions/upload-artifact@v2
          with:

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -260,7 +260,7 @@ jobs:
            . venv/bin/activate
            echo "VIRTUAL ENV:" $VIRTUAL_ENV
 
-           pip install wheel
+           pip install wheel numpy
 
            export DISTUTILS_C_COMPILER_LAUNCHER=ccache
            # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -278,25 +278,17 @@ jobs:
 
           python setup.py bdist_wheel
 
-       - uses: uraimo/run-on-arch-action@v2
-         name: Tests
-         id: runcmd
+       - uses: addnab/docker-run-action@v3
          with:
-          arch: aarch64
-          distro: ubuntu22.04
-
-          # Not required, but speeds up builds by storing container images in
-          # a GitHub package registry.
-          githubToken: ${{ github.token }}
-
-          dockerRunArgs: |
-            --volume "${PWD}:/duckdb"
-          run: |
-            cd /duckdb/tools/pythonpkg
-            ./bin/python${{matrix.python_build.version}} -m ensurepip
-            ./bin/python${{matrix.python_build.version}} -m pip install dist/*.whl pytest pandas pyarrow psutil
-            ./bin/python${{matrix.python_build.version}} -c "print(__import__('duckdb').__version__)"
-            ./bin/python${{matrix.python_build.version}} -m pytest tests/fast
+            registry: quay.io
+            image: manylinux2014_aarch64:latest
+            options: --volume "${{ github.workspace }}:/duckdb"
+            run: |
+              cd /duckdb/tools/pythonpkg
+              ./bin/python${{matrix.python_build.version}} -m ensurepip
+              ./bin/python${{matrix.python_build.version}} -m pip install dist/*.whl pytest pandas pyarrow psutil
+              ./bin/python${{matrix.python_build.version}} -c "print(__import__('duckdb').__version__)"
+              ./bin/python${{matrix.python_build.version}} -m pytest tests/fast
 
        - uses: actions/upload-artifact@v2
          with:

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -257,7 +257,7 @@ jobs:
            python${{matrix.python_build.version}} -m pip install pip -U
            wget ${{ matrix.python_build.url }}
            tar -xvjf *.tar.bz2
-           ls lib/python${{matrix.python_build.version}}/_sysconfigdata_* | grep -v aarch64 | xargs rm
+           ls lib/python${{matrix.python_build.version}}/_sysconfigdata_* | grep -v _sysconfigdata_m_linux_aarch64-linux-gnu | xargs rm
            ls lib/python${{matrix.python_build.version}}/_sysconfigdata_*
            rm -rf lib/python${{matrix.python_build.version}}/__pycache__
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -278,7 +278,7 @@ jobs:
           echo "VIRTUAL ENV:" $VIRTUAL_ENV
           
           build-python -m pip install wheel numpy
-          # pip install wheel
+          pip install wheel
           # pip install numpy
           
           export DISTUTILS_C_COMPILER_LAUNCHER=ccache

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -295,7 +295,7 @@ jobs:
             apt update
             apt install software-properties-common --yes
             add-apt-repository ppa:deadsnakes --yes
-            apt install python${{matrix.python_build.version}}-full python3-pip --yes
+            apt install python${{matrix.python_build.version}}-full python${{matrix.python_build.version}}-dev python3-pip --yes
 
             # # Download, build and install python
             # apt install wget

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -297,16 +297,6 @@ jobs:
             add-apt-repository ppa:deadsnakes --yes
             apt install python${{matrix.python_build.version}}-full python${{matrix.python_build.version}}-dev python3-pip --yes
 
-            # # Download, build and install python
-            # apt install wget
-            # wget https://www.python.org/ftp/python/3.10.4/Python-3.10.4.tgz
-            # tar xzf Python-3.10.4.tgz
-            # cd Python-3.10.4
-            # ./configure --enable-optimizations --enable-shared --enable-unicode=ucs4 --enable-ssl
-            # make altinstall
-            # cd ..
-            # python${{matrix.python_build.version}} -m ensurepip
-
           run: |
             cd /duckdb/tools/pythonpkg
             python${{matrix.python_build.version}} -m pip install dist/*.whl pytest pandas pyarrow psutil

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -268,6 +268,7 @@ jobs:
            . venv/bin/activate
            python3 -m pip install pip -U
            python3 -m sysconfig
+           python3 -m pip debug --verbose
 
        - name: Build
          shell: bash
@@ -277,8 +278,8 @@ jobs:
            echo "VIRTUAL ENV:" $VIRTUAL_ENV
 
            wget https://files.pythonhosted.org/packages/15/aa/f831165eefc6e0f10082db7b314871490f30791f9e6a2ddc404828c77e67/numpy-1.23.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-           build-pip install wheel
-           build-pip install numpy-1.23.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+           pip install wheel
+           pip install numpy-1.23.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
 
            export DISTUTILS_C_COMPILER_LAUNCHER=ccache
            # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -259,9 +259,7 @@ jobs:
            # TODO: need to find source for older aarch64 python binaries
            wget ${{ matrix.python_build.url }}
            tar -xvjf *.tar.bz2
-           rm lib/python${{matrix.python_build.version}}/_sysconfigdata_i686_conda_linux_gnu.py
-           rm lib/python${{matrix.python_build.version}}/_sysconfigdata_s390x_conda_linux_gnu.py
-           ls lib/python${{matrix.python_build.version}}/_sysconfigdata_*.py
+           ls lib/python${{matrix.python_build.version}}/_sysconfigdata_*.py | grep -v sysconfigdata_aarch64_conda_linux_gnu | xargs rm
 
            # if cibuildwheel starts supporting cross compiling for aarch64 at some point we should switch to that
            # as using emulation is far too slow (6+ hours)

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -283,7 +283,9 @@ jobs:
 
           dockerRunArgs: |
             --volume "${PWD}/dist:/dist"
-          install: apt install python3.10-full
+          install: |
+            apt update
+            apt install python3.10-full
           run: |
             pip install /artifacts/*.whl
             python -c "print(__import__('duckdb').__version__)"

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -216,7 +216,12 @@ jobs:
      strategy:
        matrix:
          arch: [aarch64]
-         python_build: [3.10.6]
+         python_build: [
+           {url: 'https://anaconda.org/anaconda/python/3.10.4/download/linux-aarch64/python-3.10.4-hc137634_0.tar.bz2', version: 3.10.4},
+           {url: 'https://anaconda.org/anaconda/python/3.9.12/download/linux-aarch64/python-3.9.12-hc137634_1.tar.bz2', version: 3.9.12},
+           {url: 'https://anaconda.org/anaconda/python/3.8.13/download/linux-aarch64/python-3.8.13-hc137634_0.tar.bz2', version: 3.8.13},
+           {url: 'https://anaconda.org/anaconda/python/3.7.13/download/linux-aarch64/python-3.7.13-hc137634_0.tar.bz2', version: 3.7.13},
+         ]
          isRelease:
            - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}
          exclude:
@@ -232,7 +237,7 @@ jobs:
 
        - uses: actions/setup-python@v2
          with:
-           python-version: ${{ matrix.python_build }}
+           python-version: ${{ matrix.python_build.version }}
 
        - name: Install
          shell: bash
@@ -251,8 +256,9 @@ jobs:
          run: |
            python3 -m pip install pip -U
            # TODO: need to find source for older aarch64 python binaries
-           wget http://mirror.archlinuxarm.org/aarch64/core/python-${{ matrix.python_build }}-1-aarch64.pkg.tar.xz
-           tar xf python-3.10.6-1-aarch64.pkg.tar.xz
+           wget ${{ matrix.python_build.url }}
+           tar -xvjf *.tar.bz2
+           ls
 
            # if cibuildwheel starts supporting cross compiling for aarch64 at some point we should switch to that
            # as using emulation is far too slow (6+ hours)

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -288,8 +288,7 @@ jobs:
             apt install python3.10-full python3-pip -y
           run: |
             cd /duckdb/tools/pythonpkg
-            python3.10 -m pip install dist/*.whl -U
-            python3 -m pip install -r requirements-dev.txt
+            python3.10 -m pip install dist/*.whl pytest
             python3.10 -c "print(__import__('duckdb').__version__)"
             python3.10 -m pytest tests/fast
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -237,6 +237,8 @@ jobs:
            fetch-depth: 0
 
        - uses: actions/setup-python@v2
+         with:
+           python-version: 3.10.6
 
        - name: Install
          shell: bash

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -288,7 +288,7 @@ jobs:
             apt install python3.10-full python3-pip -y
           run: |
             cd /duckdb/tools/pythonpkg
-            python3.10 -m pip install dist/*.whl pytest
+            python3.10 -m pip install dist/*.whl pytest pandas pyarrow
             python3.10 -c "print(__import__('duckdb').__version__)"
             python3.10 -m pytest tests/fast
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -292,6 +292,7 @@ jobs:
             --volume "${PWD}:/duckdb"
           run: |
             cd /duckdb/tools/pythonpkg
+            ./bin/python${{matrix.python_build.version}} -m ensurepip
             ./bin/python${{matrix.python_build.version}} -m pip install dist/*.whl pytest pandas pyarrow psutil
             ./bin/python${{matrix.python_build.version}} -c "print(__import__('duckdb').__version__)"
             ./bin/python${{matrix.python_build.version}} -m pytest tests/fast

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -260,6 +260,8 @@ jobs:
            . venv/bin/activate
            echo "VIRTUAL ENV:" $VIRTUAL_ENV
 
+           pip install wheel
+
            export DISTUTILS_C_COMPILER_LAUNCHER=ccache
            # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -256,7 +256,7 @@ jobs:
            wget http://mirror.archlinuxarm.org/aarch64/core/python-3.10.6-1-aarch64.pkg.tar.xz
            tar xf python-3.10.6-1-aarch64.pkg.tar.xz
 
-           python3 -m crossenv usr/bin/python3.10 venv --$(which aarch64-linux-gnu-gcc) --cxx $(which aarch64-linux-gnu-g++) --ar $(which aarch64-linux-gnu-ar)
+           python3 -m crossenv usr/bin/python3.10 venv --cc $(which aarch64-linux-gnu-gcc) --cxx $(which aarch64-linux-gnu-g++) --ar $(which aarch64-linux-gnu-ar)
 
        - name: Build
          shell: bash

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -288,7 +288,7 @@ jobs:
             apt install python3.10-full python3-pip -y
           run: |
             cd /duckdb/tools/pythonpkg
-            python3.10 -m pip install dist/*.whl pytest pandas pyarrow
+            python3.10 -m pip install dist/*.whl pytest pandas pyarrow psutil
             python3.10 -c "print(__import__('duckdb').__version__)"
             python3.10 -m pytest tests/fast
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -262,7 +262,7 @@ jobs:
 
            # if cibuildwheel starts supporting cross compiling for aarch64 at some point we should switch to that
            # as using emulation is far too slow (6+ hours)
-           python${{matrix.python_build.version}} -m crossenv usr/bin/python3.10 venv --cc $(which aarch64-linux-gnu-gcc) --cxx $(which aarch64-linux-gnu-g++) --ar $(which aarch64-linux-gnu-ar) --manylinux manylinux_2_17 --manylinux manylinux2014
+           python${{matrix.python_build.version}} -m crossenv bin/python${{matrix.python_build.version}} venv --cc $(which aarch64-linux-gnu-gcc) --cxx $(which aarch64-linux-gnu-g++) --ar $(which aarch64-linux-gnu-ar) --manylinux manylinux_2_17 --manylinux manylinux2014
 
        - name: Build
          shell: bash

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -251,6 +251,10 @@ jobs:
          shell: bash
          run: |
            cd tools/pythonpkg
+           wget https://grimler.se/termux-packages-24/pool/main/p/python/python_3.10.6_aarch64.deb
+           ar x python_3.10.6_aarch64.deb
+           ls
+
            python3 -m crossenv python3 venv
            . venv/bin/activate
            pip install numpy

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -253,9 +253,12 @@ jobs:
          working-directory: tools/pythonpkg
          run: |
            python3 -m pip install pip -U
+           # TODO: need to find source for older aarch64 python binaries
            wget http://mirror.archlinuxarm.org/aarch64/core/python-${{ matrix.python_build }}-1-aarch64.pkg.tar.xz
            tar xf python-3.10.6-1-aarch64.pkg.tar.xz
 
+           # if cibuildwheel starts supporting cross compiling for aarch64 at some point we should switch to that
+           # as using emulation is far too slow (6+ hours)
            python3 -m crossenv usr/bin/python3.10 venv --cc $(which aarch64-linux-gnu-gcc) --cxx $(which aarch64-linux-gnu-g++) --ar $(which aarch64-linux-gnu-ar) --manylinux manylinux_2_17 --manylinux manylinux2014
 
        - name: Build

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -305,13 +305,13 @@ jobs:
             # ./configure --enable-optimizations --enable-shared --enable-unicode=ucs4 --enable-ssl
             # make altinstall
             # cd ..
-            python3.10 -m ensurepip
+            python${{matrix.python_build.version}} -m ensurepip
 
           run: |
             cd /duckdb/tools/pythonpkg
-            python3.10 -m pip install dist/*.whl pytest pandas pyarrow psutil
-            python3.10 -c "print(__import__('duckdb').__version__)"
-            python3.10 -m pytest tests/fast
+            python${{matrix.python_build.version}} -m pip install dist/*.whl pytest pandas pyarrow psutil
+            python${{matrix.python_build.version}} -c "print(__import__('duckdb').__version__)"
+            python${{matrix.python_build.version}} -m pytest tests/fast
 
        - uses: actions/upload-artifact@v2
          with:

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -295,7 +295,7 @@ jobs:
             apt update
             apt install software-properties-common --yes
             add-apt-repository ppa:deadsnakes --yes
-            apt install python${{matrix.python_build.version}}-full
+            apt install python${{matrix.python_build.version}}-full --yes
 
             # # Download, build and install python
             # apt install wget

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -292,7 +292,7 @@ jobs:
           dockerRunArgs: |
             --volume "${PWD}:/duckdb"
           install: |
-            add-apt-repository ppa:deadsnakes --yes
+            apt-add-repository ppa:deadsnakes --yes
             apt install python${{matrix.python_build.version}}-full
 
             # # Download, build and install python

--- a/tools/pythonpkg/cibw.toml
+++ b/tools/pythonpkg/cibw.toml
@@ -8,12 +8,15 @@ before-test = 'pip install --prefer-binary "pandas>=0.24" pytest-timeout mypy "p
 test-requires = 'pytest'
 test-command = 'DUCKDB_PYTHON_TEST_EXTENSION_PATH={project} DUCKDB_PYTHON_TEST_EXTENSION_REQUIRED=1 python -m pytest {project}/tests'
 
-# For musllinux we currently don't build extensions yet
+# For musllinux, 32 bit, windows, or aarch64, we currently don't build extensions yet
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
 test-command = "python -m pytest {project}/tests/fast"
 
-# For 32 bit we don't build extensions
+[[tool.cibuildwheel.overrides]]
+select = "*aarch64*"
+test-command = "python -m pytest {project}/tests/fast"
+
 [[tool.cibuildwheel.overrides]]
 select = "*i686*"
 test-command = "python -m pytest {project}/tests/fast"


### PR DESCRIPTION
It looks like we had these at some point in the past, but I assume compile times with emulation blew out too much?

Might still need some tweaking WRT manylinux compatibility, but this is a good start

(cibuildwheel might also add support for cross compiling at some point, in which case we can just switch to that)