### PR TITLE
fix for issue 4533

### DIFF
--- a/src/include/duckdb/optimizer/join_order_optimizer.hpp
+++ b/src/include/duckdb/optimizer/join_order_optimizer.hpp
@@ -62,8 +62,7 @@ private:
 
 	bool full_plan_found;
 	bool must_update_full_plan;
-	unordered_set<JoinNode *> join_nodes_in_full_plan;
-	unordered_set<std::string> join_nodes_in_full_plan_str;
+	unordered_set<std::string> join_nodes_in_full_plan;
 
 	//! Extract the bindings referred to by an Expression
 	bool ExtractBindings(Expression &expression, unordered_set<idx_t> &bindings);
@@ -103,7 +102,6 @@ private:
 	void UpdateDPTree(JoinNode *new_plan);
 
 	void UpdateJoinNodesInFullPlan(JoinNode *node);
-	void UpdateJoinNodesInFullPlanSTR(JoinNode *node);
 
 	std::pair<JoinRelationSet *, unique_ptr<LogicalOperator>>
 	GenerateJoins(vector<unique_ptr<LogicalOperator>> &extracted_relations, JoinNode *node);

--- a/src/include/duckdb/optimizer/join_order_optimizer.hpp
+++ b/src/include/duckdb/optimizer/join_order_optimizer.hpp
@@ -63,6 +63,7 @@ private:
 	bool full_plan_found;
 	bool must_update_full_plan;
 	unordered_set<JoinNode *> join_nodes_in_full_plan;
+	unordered_set<std::string> join_nodes_in_full_plan_str;
 
 	//! Extract the bindings referred to by an Expression
 	bool ExtractBindings(Expression &expression, unordered_set<idx_t> &bindings);
@@ -102,6 +103,7 @@ private:
 	void UpdateDPTree(JoinNode *new_plan);
 
 	void UpdateJoinNodesInFullPlan(JoinNode *node);
+	void UpdateJoinNodesInFullPlanSTR(JoinNode *node);
 
 	std::pair<JoinRelationSet *, unique_ptr<LogicalOperator>>
 	GenerateJoins(vector<unique_ptr<LogicalOperator>> &extracted_relations, JoinNode *node);

--- a/src/optimizer/cardinality_estimator.cpp
+++ b/src/optimizer/cardinality_estimator.cpp
@@ -265,6 +265,8 @@ double CardinalityEstimator::EstimateCardinalityWithSet(JoinRelationSet *new_set
 		}
 	}
 	double denom = 1;
+	// TODO: It's possible cross-products were added and are not present in the filters in the relation_2_tdom
+	//       structures. When that's the case, multiply the denom structures that have no intersection
 	for (auto &match : subgraphs) {
 		// It's possible that in production, one of the D_ASSERTS above will fail and not all subgraphs
 		// were connected. When this happens, just use the largest denominator of all the subgraphs.

--- a/src/optimizer/join_order_optimizer.cpp
+++ b/src/optimizer/join_order_optimizer.cpp
@@ -5,7 +5,6 @@
 #include "duckdb/planner/expression/list.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/list.hpp"
-#include "iostream"
 
 #include <algorithm>
 

--- a/src/optimizer/join_order_optimizer.cpp
+++ b/src/optimizer/join_order_optimizer.cpp
@@ -271,6 +271,21 @@ unique_ptr<JoinNode> JoinOrderOptimizer::CreateJoinTree(JoinRelationSet *set,
 	return result;
 }
 
+
+void JoinOrderOptimizer::UpdateJoinNodesInFullPlanSTR(JoinNode *node) {
+	if (!node) {
+		return;
+	}
+	if (node->set->count == relations.size()) {
+		join_nodes_in_full_plan_str.clear();
+	}
+	if (node->set->count < relations.size()) {
+		join_nodes_in_full_plan_str.insert(node->set->ToString());
+	}
+	UpdateJoinNodesInFullPlanSTR(node->left);
+	UpdateJoinNodesInFullPlanSTR(node->right);
+}
+
 void JoinOrderOptimizer::UpdateJoinNodesInFullPlan(JoinNode *node) {
 	if (!node) {
 		return;
@@ -295,7 +310,7 @@ JoinNode *JoinOrderOptimizer::EmitPair(JoinRelationSet *left, JoinRelationSet *r
 	auto new_plan = CreateJoinTree(new_set, info, left_plan.get(), right_plan.get());
 	// check if this plan is the optimal plan we found for this set of relations
 	auto entry = plans.find(new_set);
-	if (entry == plans.end() || new_plan->GetCost() < entry->second->GetCost()) {
+	if (entry == plans.end() ||  new_plan->GetCost() < entry->second->GetCost()) {
 		// the plan is the optimal plan, move it into the dynamic programming tree
 		auto result = new_plan.get();
 
@@ -303,8 +318,7 @@ JoinNode *JoinOrderOptimizer::EmitPair(JoinRelationSet *left, JoinRelationSet *r
 		if (entry != plans.end()) {
 			cardinality_estimator.VerifySymmetry(result, entry->second.get());
 		}
-
-		if (full_plan_found && join_nodes_in_full_plan.count(new_plan.get()) > 0) {
+		if (full_plan_found && join_nodes_in_full_plan_str.count(new_plan->set->ToString()) > 0) {
 			must_update_full_plan = true;
 		}
 		if (new_set->count == relations.size()) {
@@ -317,6 +331,7 @@ JoinNode *JoinOrderOptimizer::EmitPair(JoinRelationSet *left, JoinRelationSet *r
 			// If we know a node in the full plan is updated, we can prevent ourselves from exiting the
 			// DP algorithm until the last plan updated is a full plan
 			UpdateJoinNodesInFullPlan(result);
+			UpdateJoinNodesInFullPlanSTR(result);
 			if (must_update_full_plan) {
 				must_update_full_plan = false;
 			}
@@ -656,6 +671,7 @@ void JoinOrderOptimizer::SolveJoinOrderApproximately() {
 		join_relations.push_back(best_connection->set);
 	}
 }
+
 
 void JoinOrderOptimizer::SolveJoinOrder() {
 	// first try to solve the join order exactly


### PR DESCRIPTION
Fix for https://github.com/duckdb/duckdb/issues/4533

When running the DP plan enumeration algorithm, we can't exit unless we are sure that a full plan exists in the table where all references are valid (or no plan at all). If a full plan is found, and we update children in the plan, then we need to stay in the DP algorithm until we find a new full plan. We are guaranteed a new full plan will be produced because our cost model has optimal substructure. 

We run this check by storing all hashes of `JoinNodes` in a set and when an entry in the DP table is updated, we check if it is in the set of hashes for the full plan. If this is the case, we stay in the DP algorithm.

This bug was caused because the check was failing. For some reason, the template to hash the `JoinNode` structure wasn't working quite right or the way that the code checks for the existence of the hash wasn't working quite right. By just storing the strings of the relations of the `JoinNode` we can fix this issue. Might be worth it to go back and investigate, but since this issue is a blocker, this is a good fix for now.

