### PR TITLE
[CPP-API] Comment no longer causes crash

### DIFF
--- a/src/common/types/column_data_collection.cpp
+++ b/src/common/types/column_data_collection.cpp
@@ -42,6 +42,14 @@ struct ColumnDataMetaData {
 	}
 };
 
+//! Explicitly initialized without types
+ColumnDataCollection::ColumnDataCollection(Allocator &allocator_p) {
+	types.clear();
+	count = 0;
+	this->finished_append = false;
+	allocator = make_shared<ColumnDataAllocator>(allocator_p);
+}
+
 ColumnDataCollection::ColumnDataCollection(Allocator &allocator_p, vector<LogicalType> types_p) {
 	Initialize(move(types_p));
 	allocator = make_shared<ColumnDataAllocator>(allocator_p);

--- a/src/include/duckdb/common/types/column_data_collection.hpp
+++ b/src/include/duckdb/common/types/column_data_collection.hpp
@@ -26,6 +26,8 @@ class ColumnDataCollection {
 public:
 	//! Constructs an in-memory column data collection from an allocator
 	DUCKDB_API ColumnDataCollection(Allocator &allocator, vector<LogicalType> types);
+	//! Constructs an empty (but valid) in-memory column data collection from an allocator
+	DUCKDB_API ColumnDataCollection(Allocator &allocator);
 	//! Constructs a buffer-managed column data collection
 	DUCKDB_API ColumnDataCollection(BufferManager &buffer_manager, vector<LogicalType> types);
 	//! Constructs either an in-memory or a buffer-managed column data collection

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -743,9 +743,8 @@ unique_ptr<QueryResult> ClientContext::Query(const string &query, bool allow_str
 	if (statements.empty()) {
 		// no statements, return empty successful result
 		StatementProperties properties;
-		vector<LogicalType> types;
 		vector<string> names;
-		auto collection = make_unique<ColumnDataCollection>(Allocator::DefaultAllocator(), move(types));
+		auto collection = make_unique<ColumnDataCollection>(Allocator::DefaultAllocator());
 		return make_unique<MaterializedQueryResult>(StatementType::INVALID_STATEMENT, properties, move(names),
 		                                            move(collection), GetClientProperties());
 	}

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -10,6 +10,15 @@
 using namespace duckdb;
 using namespace std;
 
+TEST_CASE("Test comment in CPP API", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	con.EnableQueryVerification();
+	con.SendQuery("--ups");
+	//! Should not crash
+	REQUIRE(1);
+}
+
 TEST_CASE("Test using connection after database is gone", "[api]") {
 	auto db = make_unique<DuckDB>(nullptr);
 	auto conn = make_unique<Connection>(*db);


### PR DESCRIPTION
Fixes fuzzer issue mentioned in issue #4152 comment section: [here](https://github.com/duckdb/duckdb/issues/4152#issuecomment-1229962400)

What was happening is that if we parse the query for statements and it's empty, the ColumnDataCollection was getting initialized with an empty types vector, and that should not happen.