### PR TITLE
Support all basic integer types in node API

### DIFF
--- a/tools/nodejs/src/statement.cpp
+++ b/tools/nodejs/src/statement.cpp
@@ -139,17 +139,35 @@ static Napi::Value convert_col_val(Napi::Env &env, duckdb::Value dval, duckdb::L
 	case duckdb::LogicalTypeId::BOOLEAN: {
 		value = Napi::Boolean::New(env, duckdb::BooleanValue::Get(dval));
 	} break;
+	case duckdb::LogicalTypeId::TINYINT: {
+		value = Napi::Number::New(env, duckdb::TinyIntValue::Get(dval));
+	} break;
+	case duckdb::LogicalTypeId::SMALLINT: {
+		value = Napi::Number::New(env, duckdb::SmallIntValue::Get(dval));
+	} break;
 	case duckdb::LogicalTypeId::INTEGER: {
 		value = Napi::Number::New(env, duckdb::IntegerValue::Get(dval));
+	} break;
+	case duckdb::LogicalTypeId::BIGINT: {
+		value = Napi::Number::New(env, duckdb::BigIntValue::Get(dval));
+	} break;
+	case duckdb::LogicalTypeId::UTINYINT: {
+		value = Napi::Number::New(env, duckdb::UTinyIntValue::Get(dval));
+	} break;
+	case duckdb::LogicalTypeId::USMALLINT: {
+		value = Napi::Number::New(env, duckdb::USmallIntValue::Get(dval));
+	} break;
+	case duckdb::LogicalTypeId::UINTEGER: {
+		value = Napi::Number::New(env, duckdb::UIntegerValue::Get(dval));
+	} break;
+	case duckdb::LogicalTypeId::UBIGINT: {
+		value = Napi::Number::New(env, duckdb::UBigIntValue::Get(dval));
 	} break;
 	case duckdb::LogicalTypeId::FLOAT: {
 		value = Napi::Number::New(env, duckdb::FloatValue::Get(dval));
 	} break;
 	case duckdb::LogicalTypeId::DOUBLE: {
 		value = Napi::Number::New(env, duckdb::DoubleValue::Get(dval));
-	} break;
-	case duckdb::LogicalTypeId::BIGINT: {
-		value = Napi::Number::New(env, duckdb::BigIntValue::Get(dval));
 	} break;
 	case duckdb::LogicalTypeId::HUGEINT: {
 		value = Napi::Number::New(env, dval.GetValue<double>());

--- a/tools/nodejs/test/data_type_support.test.js
+++ b/tools/nodejs/test/data_type_support.test.js
@@ -41,8 +41,8 @@ describe("data type support", function () {
       assert(res.length === 2);
       assert(Object.entries(res[0]).length === 8);
       assert(Object.entries(res[1]).length === 8);
-      assert(Object.entries(res[0]).every((v, i) => v[1] == minValues[i]))
-      assert(Object.entries(res[1]).every((v, i) => v[1] == maxValues[i]))
+      assert.deepEqual(Object.entries(res[0]).map(v => v[1]), minValues);
+      assert.deepEqual(Object.entries(res[1]).map(v => v[1]), maxValues);
       done();
     });
   });

--- a/tools/nodejs/test/data_type_support.test.js
+++ b/tools/nodejs/test/data_type_support.test.js
@@ -26,9 +26,9 @@ describe("data type support", function () {
     const stmt = db.prepare("INSERT INTO integer_table VALUES (?, ?, ?, ?, ?, ?, ?, ?)");
 
     // Numerical limits
-    signedMinValue = (bitWidth) => -(2**(bitWidth-1)-1)-1;
-    signedMaxValue = (bitWidth) => 2**(bitWidth-1)-1;
-    unsignedMaxValue = (bitWidth) => 2**(bitWidth)-1;
+    signedMinValue = (bitWidth) => Math.max(-(2**(bitWidth-1)-1)-1, Number.MIN_SAFE_INTEGER);
+    signedMaxValue = (bitWidth) => Math.min(2**(bitWidth-1)-1, Number.MAX_SAFE_INTEGER);
+    unsignedMaxValue = (bitWidth) => Math.min(2**(bitWidth)-1, Number.MAX_SAFE_INTEGER);
     let minValues = [signedMinValue(8), signedMinValue(16), signedMinValue(32), signedMinValue(64), 0, 0, 0, 0];
     let maxValues = [signedMinValue(8), signedMinValue(16), signedMinValue(32), signedMinValue(64), unsignedMaxValue(8), unsignedMaxValue(16), unsignedMaxValue(32), unsignedMaxValue(64)];
 


### PR DESCRIPTION
Fixes #4537. Some integer types were missing in the Node client.