### PR TITLE
[Map] Fix map_extract from multiple rows

### DIFF
--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1464,7 +1464,7 @@ vector<idx_t> ListVector::Search(Vector &list, const Value &key, idx_t row) {
 	vector<idx_t> offsets;
 
 	auto &list_vector = ListVector::GetEntry(list);
-	auto &entry = ((list_entry_t *)list.GetData())[row];
+	auto &entry = ListVector::GetData(list)[row];
 
 	switch (list_vector.GetType().InternalType()) {
 	case PhysicalType::BOOL:

--- a/test/sql/types/nested/map/test_map_subscript.test
+++ b/test/sql/types/nested/map/test_map_subscript.test
@@ -195,5 +195,3 @@ from (SELECT a%4 as grp, list(a) as lsta, list(a) as lstb FROM range(7) tbl(a) g
 1	{1=1, 5=5}	[NULL]
 2	{2=2, 6=6}	[]
 3	{3=3}	[]
-
-

--- a/test/sql/types/nested/map/test_map_subscript_from_column.test
+++ b/test/sql/types/nested/map/test_map_subscript_from_column.test
@@ -1,0 +1,44 @@
+# name: test/sql/types/nested/map/test_map_subscript_from_column.test
+# group: [map]
+
+statement ok
+create table t1 (
+	id int,
+	k integer[],
+	v decimal[]
+);
+
+statement ok
+insert into t1 
+SELECT * FROM (VALUES
+	(0, [1,2,3,4], [1.0, 2.0, 3.0, 4.0]),
+	(1, [5,6,7,8], [5.0, 6.0, 7.0, 8.0]),
+	(2, [9,10,11,12], [9.0, 10.0, 11.0, 12.0]),
+	(3, [13,14,15,16], [13.0, 14.0, 15.0, 16.0]),
+	(4, [17,18,19,20], [17.0, 18.0, 19.0, 20.0]),
+	(5, [21,22,23,24], [21.0, 22.0, 23.0, 24.0]),
+	(6, [25,26,27,28], [25.0, 26.0, 27.0, 28.0]),
+	(7, [29,30,31,32], [29.0, 30.0, 31.0, 32.0]),
+	(8, [33,34,35,36], [33.0, 34.0, 35.0, 36.0]),
+	(9, [37,38,39,40], [37.0, 38.0, 39.0, 40.0])
+)
+
+statement ok
+create table t2 (id int, v_map map(integer, decimal), k integer[]);
+
+statement ok
+insert into t2 select id, map(k,v), k from t1;
+
+query I
+select v_map[array_sort(k, 'DESC', 'NULLS LAST')[1]] from t2 limit 10;
+----
+[4.000]
+[8.000]
+[12.000]
+[16.000]
+[20.000]
+[24.000]
+[28.000]
+[32.000]
+[36.000]
+[40.000]


### PR DESCRIPTION
This PR closes #4590 

`map_extract(map, key)`
What was happening is that map_extract did not use the `key` of the row it's searching, instead it was always using index 0.
