### PR TITLE
Remove the DLLEXPORT from deleted API methods

### DIFF
--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -37,8 +37,8 @@ public:
 	DUCKDB_API AllocatedData(Allocator &allocator, data_ptr_t pointer, idx_t allocated_size);
 	DUCKDB_API ~AllocatedData();
 	// disable copy constructors
-	DUCKDB_API AllocatedData(const AllocatedData &other) = delete;
-	DUCKDB_API AllocatedData &operator=(const AllocatedData &) = delete;
+	AllocatedData(const AllocatedData &other) = delete;
+	AllocatedData &operator=(const AllocatedData &) = delete;
 	//! enable move constructors
 	DUCKDB_API AllocatedData(AllocatedData &&other) noexcept;
 	DUCKDB_API AllocatedData &operator=(AllocatedData &&) noexcept;


### PR DESCRIPTION
This PR fixes the build on Windows 11 with Visual Studio 2022 using ClangCl as a compiler frontend. Most likely this fix is required by all versions of Visual Studio.

Without this fix, the error is:
```
FAILED: src/optimizer/pullup/CMakeFiles/duckdb_optimizer_pullup.dir/ub_duckdb_optimizer_pullup.cpp.obj 
C:\BDA\ci\LLVM-14.0.6\bin\clang-cl.exe   -TP -DDUCKDB -DDUCKDB_BUILD_LIBRARY -DDUCKDB_MAIN_LIBRARY -IC:\BDA\bld\XTJyb_7r\0\duckdb\src\include -IC:\BDA\bld\XTJyb_7r\0\duckdb\third_party\fmt\include -IC:\BDA\bld\XTJyb_7r\0\duckdb\third_party\hyperloglog -IC:\BDA\bld\XTJyb_7r\0\duckdb\third_party\fastpforlib -IC:\BDA\bld\XTJyb_7r\0\duckdb\third_party\fast_float -IC:\BDA\bld\XTJyb_7r\0\duckdb\third_party\re2 -IC:\BDA\bld\XTJyb_7r\0\duckdb\third_party\miniz -IC:\BDA\bld\XTJyb_7r\0\duckdb\third_party\utf8proc\include -IC:\BDA\bld\XTJyb_7r\0\duckdb\third_party\miniparquet -IC:\BDA\bld\XTJyb_7r\0\duckdb\third_party\concurrentqueue -IC:\BDA\bld\XTJyb_7r\0\duckdb\third_party\pcg -IC:\BDA\bld\XTJyb_7r\0\duckdb\third_party\tdigest -IC:\BDA\bld\XTJyb_7r\0\duckdb\third_party\mbedtls\include -IC:\BDA\bld\XTJyb_7r\0\duckdb\third_party\jaro_winkler /D_ITERATOR_DEBUG_LEVEL=0     /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DDEBUG     /D_CRT_SECURE_NO_DEPRECATE /D_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS  -DQT_DISABLE_DEPRECATED_BEFORE=0x050F00 -Wextra -Werror=return-type -Werror=uninitialized -Werror=unknown-pragmas -Werror=shadow -Werror=undef -Werror=pointer-arith -Werror=shift-count-overflow -Werror=string-plus-int -Werror=nonportable-include-path -Werror=inconsistent-missing-override -Werror=self-assign -Werror=self-assign-field -Werror=self-move -Werror=braced-scalar-init -Werror=many-braces-around-scalar-init -Werror=deprecated-enum-enum-conversion -Werror=infinite-recursion -Werror=exceptions -Werror=excess-initializers -Werror=return-stack-address -Werror=delete-non-abstract-non-virtual-dtor  -Wno-error=undef -Wno-undef -Wno-error=shadow -Wno-shadow  -march=skylake  /MDd /Z7  -Werror=pessimizing-move -Werror=redundant-move -Werror=range-loop-construct  /DWIN32 /D_WINDOWS  /GR /EHsc /wd4244 /wd4267 /wd4200 /wd26451 /wd26495 /D_CRT_SECURE_NO_WARNINGS /utf-8 /Zi /Ob0 /Od /RTC1 -Wexit-time-destructors -MDd -fcolor-diagnostics -std:c++14 /showIncludes /Fosrc\optimizer\pullup\CMakeFiles\duckdb_optimizer_pullup.dir\ub_duckdb_optimizer_pullup.cpp.obj /Fdsrc\optimizer\pullup\CMakeFiles\duckdb_optimizer_pullup.dir\ -c -- C:\data\ci-tmp-C10Sk32c193231332c1406\Debug\duckdb\src\optimizer\pullup\ub_duckdb_optimizer_pullup.cpp
In file included from C:\data\ci-tmp-C10Sk32c193231332c1406\Debug\duckdb\src\optimizer\pullup\ub_duckdb_optimizer_pullup.cpp:2:
In file included from C:/BDA/bld/XTJyb_7r/0/duckdb/src/optimizer/pullup/pullup_filter.cpp:1:
In file included from C:\BDA\bld\XTJyb_7r\0\duckdb\src\include\duckdb/optimizer/filter_pullup.hpp:12:
In file included from C:\BDA\bld\XTJyb_7r\0\duckdb\src\include\duckdb/planner/logical_operator.hpp:12:
In file included from C:\BDA\bld\XTJyb_7r\0\duckdb\src\include\duckdb/optimizer/estimated_properties.hpp:16:
In file included from C:\BDA\bld\XTJyb_7r\0\duckdb\src\include\duckdb/storage/statistics/distinct_statistics.hpp:12:
In file included from C:\BDA\bld\XTJyb_7r\0\duckdb\src\include\duckdb/common/types/hyperloglog.hpp:12:
In file included from C:\BDA\bld\XTJyb_7r\0\duckdb\src\include\duckdb/common/types/vector.hpp:17:
In file included from C:\BDA\bld\XTJyb_7r\0\duckdb\src\include\duckdb/common/types/vector_buffer.hpp:13:
In file included from C:\BDA\bld\XTJyb_7r\0\duckdb\src\include\duckdb/common/types/string_heap.hpp:13:
In file included from C:\BDA\bld\XTJyb_7r\0\duckdb\src\include\duckdb/storage/arena_allocator.hpp:12:
C:\BDA\bld\XTJyb_7r\0\duckdb\src\include\duckdb/common/allocator.hpp(40,13): error: attribute 'dllexport' cannot be applied to a deleted function
        DUCKDB_API AllocatedData(const AllocatedData &other) = delete;
                   ^
C:\BDA\bld\XTJyb_7r\0\duckdb\src\include\duckdb/common/allocator.hpp(41,28): error: attribute 'dllexport' cannot be applied to a deleted function
        DUCKDB_API AllocatedData &operator=(const AllocatedData &) = delete;
                                  ^
```