### PR TITLE
Fix home directory setter

### DIFF
--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -417,7 +417,7 @@ Value ForceCompressionSetting::GetSetting(ClientContext &context) {
 //===--------------------------------------------------------------------===//
 void HomeDirectorySetting::SetLocal(ClientContext &context, const Value &input) {
 	auto &config = ClientConfig::GetConfig(context);
-	config.home_directory = input.ToString();
+	config.home_directory = input.IsNull() ? string() : input.ToString();
 }
 
 Value HomeDirectorySetting::GetSetting(ClientContext &context) {

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -417,7 +417,7 @@ Value ForceCompressionSetting::GetSetting(ClientContext &context) {
 //===--------------------------------------------------------------------===//
 void HomeDirectorySetting::SetLocal(ClientContext &context, const Value &input) {
 	auto &config = ClientConfig::GetConfig(context);
-	config.home_directory = input.IsNull() ? input.ToString() : string();
+	config.home_directory = input.ToString();
 }
 
 Value HomeDirectorySetting::GetSetting(ClientContext &context) {

--- a/test/sql/copy/csv/csv_home_directory.test
+++ b/test/sql/copy/csv/csv_home_directory.test
@@ -12,7 +12,7 @@ statement ok
 CREATE TABLE integers AS SELECT * FROM range(10)
 
 statement ok
-COPY integers TO '~/integers.csv' (FORMAT CSV);
+COPY integers TO '__TEST_DIR__/integers.csv' (FORMAT CSV);
 
 query I
 SELECT * FROM '~/integers.csv'
@@ -50,10 +50,10 @@ SELECT * FROM integers_load
 
 # glob from home directory
 statement ok
-COPY integers TO '~/homedir_integers1.csv'
+COPY integers TO '__TEST_DIR__/homedir_integers1.csv'
 
 statement ok
-COPY integers TO '~/homedir_integers2.csv'
+COPY integers TO '__TEST_DIR__/homedir_integers2.csv'
 
 query I
 SELECT COUNT(*) FROM '~/homedir_integers*.csv'

--- a/test/sql/copy/parquet/writer/parquet_write_home_directory.test
+++ b/test/sql/copy/parquet/writer/parquet_write_home_directory.test
@@ -14,7 +14,7 @@ statement ok
 CREATE TABLE integers AS SELECT * FROM range(10)
 
 statement ok
-COPY integers TO '~/integers.parquet' (FORMAT PARQUET);
+COPY integers TO '__TEST_DIR__/integers.parquet' (FORMAT PARQUET);
 
 query I
 SELECT * FROM '~/integers.parquet'
@@ -52,10 +52,10 @@ SELECT * FROM integers_load
 
 # glob from home directory
 statement ok
-COPY integers TO '~/homedir_integers1.parquet'
+COPY integers TO '__TEST_DIR__/homedir_integers1.parquet'
 
 statement ok
-COPY integers TO '~/homedir_integers2.parquet'
+COPY integers TO '__TEST_DIR__/homedir_integers2.parquet'
 
 query I
 SELECT COUNT(*) FROM '~/homedir_integers*.parquet'


### PR DESCRIPTION
The new `home_directory` setting from #4328 doesn't actually get applied because the ternary operator is backwards in the setter, only setting the variable to the `input` value when it's `NULL` anyway.

This is easily reproducible e.g.  through the 0.5.0 CLI:

```bash
$ ./duckdb
v0.5.0 109f932c4
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
D SET home_directory = '/tmp';
D SELECT current_setting('home_directory');
┌───────────────────────────────────┐
│ current_setting('home_directory') │
├───────────────────────────────────┤
│                                   │
└───────────────────────────────────┘
```

According to my tests, everything works as expected by simply calling `input.ToString()`, so I've changed it to that accordingly here.

I'm not familiar with the testing framework used in this project so I haven't added any tests for this yet but I can come back to it when I have some more time.