### PR TITLE
[Fuzzer] Issue #4610 - Vacuum table with generated column

### DIFF
--- a/src/planner/binder/statement/bind_vacuum.cpp
+++ b/src/planner/binder/statement/bind_vacuum.cpp
@@ -1,9 +1,9 @@
+#include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/parser/statement/vacuum_statement.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/operator/logical_simple.hpp"
-#include "duckdb/parser/expression/columnref_expression.hpp"
 
 namespace duckdb {
 
@@ -29,7 +29,20 @@ BoundStatement Binder::Bind(VacuumStatement &stmt) {
 			auto &get = (LogicalGet &)*ref->get;
 			columns.insert(columns.end(), get.names.begin(), get.names.end());
 		}
+
+		case_insensitive_set_t column_name_set;
+		vector<string> non_generated_column_names;
 		for (auto &col_name : columns) {
+			if (column_name_set.count(col_name) > 0) {
+				throw BinderException("Vacuum the same column twice(same name in column name list)");
+			}
+			column_name_set.insert(col_name);
+			auto &col = ref->table->GetColumn(col_name);
+			// ignore generated column
+			if (col.Generated()) {
+				continue;
+			}
+			non_generated_column_names.push_back(col_name);
 			ColumnRefExpression colref(col_name, ref->table->name);
 			auto result = bind_context.BindColumn(colref, 0);
 			if (result.HasError()) {
@@ -37,17 +50,29 @@ BoundStatement Binder::Bind(VacuumStatement &stmt) {
 			}
 			select_list.push_back(move(result.expression));
 		}
-		auto table_scan = CreatePlan(*ref);
-		D_ASSERT(table_scan->type == LogicalOperatorType::LOGICAL_GET);
-		auto &get = (LogicalGet &)*table_scan;
-		for (idx_t i = 0; i < get.column_ids.size(); i++) {
-			stmt.info->column_id_map[i] = get.column_ids[i];
+		stmt.info->columns = move(non_generated_column_names);
+		if (!select_list.empty()) {
+			auto table_scan = CreatePlan(*ref);
+			D_ASSERT(table_scan->type == LogicalOperatorType::LOGICAL_GET);
+
+			auto &get = (LogicalGet &)*table_scan;
+
+			D_ASSERT(select_list.size() == get.column_ids.size());
+			D_ASSERT(stmt.info->columns.size() == get.column_ids.size());
+			for (idx_t i = 0; i < get.column_ids.size(); i++) {
+				stmt.info->column_id_map[i] = ref->table->columns[get.column_ids[i]].StorageOid();
+			}
+
+			auto projection = make_unique<LogicalProjection>(GenerateTableIndex(), move(select_list));
+			projection->children.push_back(move(table_scan));
+
+			root = move(projection);
+		} else {
+			// eg. CREATE TABLE test (x AS (1));
+			//     ANALYZE test;
+			// Make it not a SINK so it doesn't have to do anything
+			stmt.info->has_table = false;
 		}
-
-		auto projection = make_unique<LogicalProjection>(GenerateTableIndex(), move(select_list));
-		projection->children.push_back(move(table_scan));
-
-		root = move(projection);
 	}
 	auto vacuum = make_unique<LogicalSimple>(LogicalOperatorType::LOGICAL_VACUUM, move(stmt.info));
 	if (root) {

--- a/test/fuzzer/pedro/vacuum_table_with_generated_column.test
+++ b/test/fuzzer/pedro/vacuum_table_with_generated_column.test
@@ -55,7 +55,6 @@ SELECT stats(x) FROM test LIMIT 1
 ----
 [Min: 0, Max: 4999][Has Null: false, Has No Null: true][Approx Unique: 5080]
 
-# y is not yet accurate
 query T
 SELECT stats(y) FROM test LIMIT 1
 ----

--- a/test/fuzzer/pedro/vacuum_table_with_generated_column.test
+++ b/test/fuzzer/pedro/vacuum_table_with_generated_column.test
@@ -1,0 +1,62 @@
+# name: test/fuzzer/pedro/vacuum_table_with_generated_column.test
+# group: [pedro]
+
+# need this, else the distinct stats sampling is different
+require vector_size 1024
+
+require skip_reload
+
+statement ok
+CREATE TABLE t0(c0 AS (1));
+
+statement ok
+VACUUM t0;
+
+statement ok
+DROP TABLE t0;
+
+statement ok
+CREATE TABLE test (x INT, y AS (x + 100));
+
+# Error: Vacuum the same column twice
+statement error
+ANALYZE test(x, x);
+
+statement ok
+ANALYZE test(y, x);
+
+statement ok
+INSERT INTO test SELECT range % 5000 FROM range(10000);
+
+# inaccurate approx unique due to sampling
+query T
+SELECT stats(x) FROM test LIMIT 1;
+----
+[Min: 0, Max: 4999][Has Null: false, Has No Null: true][Approx Unique: 9809]
+
+query T
+SELECT stats(y) FROM test LIMIT 1;
+----
+[Min: 100, Max: 5099][Has Null: false, Has No Null: true]
+
+# we enable verify_parallelism only for ANALYZE
+statement ok
+PRAGMA verify_parallelism;
+
+statement ok
+ANALYZE test(x)
+
+statement ok
+PRAGMA disable_verify_parallelism;
+
+# x is more accurate now
+query T
+SELECT stats(x) FROM test LIMIT 1
+----
+[Min: 0, Max: 4999][Has Null: false, Has No Null: true][Approx Unique: 5080]
+
+# y is not yet accurate
+query T
+SELECT stats(y) FROM test LIMIT 1
+----
+[Min: 100, Max: 5099][Has Null: false, Has No Null: true]


### PR DESCRIPTION
#4610 

I forbid the same column name to appear. It threw std::unordered_map exception.
Because of the existence of generated columns, sometimes the size of select_list is 0.
`PhysicalVacuum` is no longer a `SINK` by setting has_table = false. It will call `GetData()` and do nothing.
Use `StorageOid`.