### PR TITLE
[Python] Fix unwanted conversion from NaN -> NULL in param list

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/python_conversion.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/python_conversion.hpp
@@ -21,6 +21,7 @@ namespace duckdb {
 
 bool TryTransformPythonNumeric(Value &res, py::handle ele);
 bool DictionaryHasMapFormat(const PyDictionary &dict);
-Value TransformPythonValue(py::handle ele, const LogicalType &target_type = LogicalType::UNKNOWN);
+Value TransformPythonValue(py::handle ele, const LogicalType &target_type = LogicalType::UNKNOWN,
+                           bool from_pandas = true);
 
 } // namespace duckdb

--- a/tools/pythonpkg/src/include/duckdb_python/python_conversion.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/python_conversion.hpp
@@ -22,6 +22,6 @@ namespace duckdb {
 bool TryTransformPythonNumeric(Value &res, py::handle ele);
 bool DictionaryHasMapFormat(const PyDictionary &dict);
 Value TransformPythonValue(py::handle ele, const LogicalType &target_type = LogicalType::UNKNOWN,
-                           bool from_pandas = true);
+                           bool nan_as_null = true);
 
 } // namespace duckdb

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -669,7 +669,7 @@ vector<Value> DuckDBPyConnection::TransformPythonParamList(py::handle params) {
 	args.reserve(py::len(params));
 
 	for (auto param : params) {
-		args.emplace_back(TransformPythonValue(param));
+		args.emplace_back(TransformPythonValue(param, LogicalType::UNKNOWN, false));
 	}
 	return args;
 }

--- a/tools/pythonpkg/src/python_conversion.cpp
+++ b/tools/pythonpkg/src/python_conversion.cpp
@@ -201,7 +201,7 @@ bool TryTransformPythonNumeric(Value &res, py::handle ele) {
 	return true;
 }
 
-Value TransformPythonValue(py::handle ele, const LogicalType &target_type, bool from_pandas) {
+Value TransformPythonValue(py::handle ele, const LogicalType &target_type, bool nan_as_null) {
 	auto &import_cache = *DuckDBPyConnection::ImportCache();
 
 	if (ele.is_none()) {
@@ -215,7 +215,7 @@ Value TransformPythonValue(py::handle ele, const LogicalType &target_type, bool 
 		}
 		return integer;
 	} else if (py::isinstance<py::float_>(ele)) {
-		if (from_pandas && std::isnan(PyFloat_AsDouble(ele.ptr()))) {
+		if (nan_as_null && std::isnan(PyFloat_AsDouble(ele.ptr()))) {
 			return Value();
 		}
 		return Value::DOUBLE(ele.cast<double>());

--- a/tools/pythonpkg/src/python_conversion.cpp
+++ b/tools/pythonpkg/src/python_conversion.cpp
@@ -201,7 +201,7 @@ bool TryTransformPythonNumeric(Value &res, py::handle ele) {
 	return true;
 }
 
-Value TransformPythonValue(py::handle ele, const LogicalType &target_type) {
+Value TransformPythonValue(py::handle ele, const LogicalType &target_type, bool from_pandas) {
 	auto &import_cache = *DuckDBPyConnection::ImportCache();
 
 	if (ele.is_none()) {
@@ -215,7 +215,7 @@ Value TransformPythonValue(py::handle ele, const LogicalType &target_type) {
 		}
 		return integer;
 	} else if (py::isinstance<py::float_>(ele)) {
-		if (std::isnan(PyFloat_AsDouble(ele.ptr()))) {
+		if (from_pandas && std::isnan(PyFloat_AsDouble(ele.ptr()))) {
 			return Value();
 		}
 		return Value::DOUBLE(ele.cast<double>());

--- a/tools/pythonpkg/tests/fast/test_all_types.py
+++ b/tools/pythonpkg/tests/fast/test_all_types.py
@@ -356,7 +356,7 @@ class TestAllTypes(object):
                 round_trip_arrow_table = conn.execute("select * from arrow_table").arrow()
                 assert arrow_table.equals(round_trip_arrow_table, check_metadata=True)
 
-    def test_pandas(self, duckdb_cursor):
+    def test_pandas(self):
         # We skip those since the extreme ranges are not supported in python.
         replacement_values = { 'timestamp': "'1990-01-01 00:00:00'::TIMESTAMP",
             'timestamp_s': "'1990-01-01 00:00:00'::TIMESTAMP_S",
@@ -378,5 +378,6 @@ class TestAllTypes(object):
             print(cur_type)
             round_trip_dataframe = conn.execute("select * from dataframe").df()
             result_dataframe = conn.execute("select * from dataframe").fetchall()
+            print(round_trip_dataframe)
             result_roundtrip = conn.execute("select * from round_trip_dataframe").fetchall()
             assert recursive_equality(result_dataframe, result_roundtrip)

--- a/tools/pythonpkg/tests/fast/test_parameter_list.py
+++ b/tools/pythonpkg/tests/fast/test_parameter_list.py
@@ -17,3 +17,8 @@ class TestParameterList(object):
         conn.execute("insert into bool_table values (TRUE)")
         with pytest.raises(duckdb.NotImplementedException, match='Unable to transform'):
             res = conn.execute("select count(*) from bool_table where a =?",[df_in])
+
+    def test_explicit_nan_param(self):
+        con = duckdb.default_connection
+        res = con.execute('select isnan(cast(? as double))', (float("nan"),))
+        assert(res.fetchone()[0] == True)


### PR DESCRIPTION
This PR fixes #4623 

As the title states, logic added to be able to roundtrip from pandas <-> duckdb caused a regression in explicit NaN's in param lists (as they use the same code path)