### PR TITLE
Fix issue related to duplicate columns in using clause

### DIFF
--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -28,6 +28,8 @@ class BoundQueryNode;
 
 class StarExpression;
 
+// FIXME: shouldn't this implement a std::hash operator that uses the 'primary_binding'?
+// That way we can confidently place them in an unordered_set without needing to instead put the pointer in it
 struct UsingColumnSet {
 	string primary_binding;
 	unordered_set<string> bindings;

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -51,6 +51,11 @@ vector<string> BindContext::GetSimilarBindings(const string &column_name) {
 }
 
 void BindContext::AddUsingBinding(const string &column_name, UsingColumnSet *set) {
+	auto &using_set = using_columns[column_name];
+	if (!using_set.empty()) {
+		//! No need to add it, the binding on this column_name is already made
+		return;
+	}
 	using_columns[column_name].insert(set);
 }
 
@@ -508,6 +513,7 @@ void BindContext::AddContext(BindContext other) {
 	for (auto &entry : other.using_columns) {
 		for (auto &alias : entry.second) {
 #ifdef DEBUG
+			//! Make sure we don't insert the same alias twice for the same using column
 			for (auto &other_alias : using_columns[entry.first]) {
 				for (auto &col : alias->bindings) {
 					D_ASSERT(other_alias->bindings.find(col) == other_alias->bindings.end());

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -51,11 +51,6 @@ vector<string> BindContext::GetSimilarBindings(const string &column_name) {
 }
 
 void BindContext::AddUsingBinding(const string &column_name, UsingColumnSet *set) {
-	auto &using_set = using_columns[column_name];
-	if (!using_set.empty()) {
-		//! No need to add it, the binding on this column_name is already made
-		return;
-	}
 	using_columns[column_name].insert(set);
 }
 

--- a/test/sql/join/inner/test_duplicate_using_columns_join.test
+++ b/test/sql/join/inner/test_duplicate_using_columns_join.test
@@ -1,0 +1,29 @@
+# name: test/sql/join/inner/test_duplicate_using_columns_join.test
+# group: [inner]
+
+statement ok
+pragma enable_verification
+
+#statement ok
+#CREATE TABLE t1(c0 INT);
+
+## c0 is used twice in the USING clause
+#query II
+#SELECT * FROM (t1 JOIN t1 t2 USING (c0, c0)), (SELECT 2);
+#----
+
+statement ok
+create table tbl as select 42 AS i;
+
+query III
+select * from tbl t1 join tbl t2 using (i, i) join tbl t3 using (i, i, i);
+----
+42	42	42
+
+statement ok
+create or replace table tbl as select 42 AS i, 84 as j;
+
+query III
+select * from tbl t1 join tbl t2 using (i, j, i) join tbl t3 using (i, i, i, j, i);
+----
+42	84


### PR DESCRIPTION
This PR fixes #4561 

We were allowing duplicates in the `using_columns`, this caused an assertion to be triggered.
I changed it to skip duplicates, because logically that makes sense to me (`USING (a,a)` == `USING(a)`)

And this didn't break any tests which surprised me, because there is code that deals with `if (using_bindings->size() > 1) {` in GetUsingBinding.

I hope someone can review this and give me some insight into the inner workings of this clause, because it's a little unclear to me what every component is for.