### PR TITLE
Fix for #3417

### DIFF
--- a/src/parser/transform/helpers/transform_cte.cpp
+++ b/src/parser/transform/helpers/transform_cte.cpp
@@ -36,7 +36,7 @@ void Transformer::TransformCTE(duckdb_libpgquery::PGWithClause *de_with_clause, 
 		}
 		// we need a query
 		if (!cte->ctequery || cte->ctequery->type != duckdb_libpgquery::T_PGSelectStmt) {
-			throw InternalException("A CTE needs a SELECT");
+			throw NotImplementedException("A CTE needs a SELECT");
 		}
 
 		// CTE transformation can either result in inlining for non recursive CTEs, or in recursive CTE bindings

--- a/test/sql/cte/insert_cte_bug_3417.test
+++ b/test/sql/cte/insert_cte_bug_3417.test
@@ -1,0 +1,15 @@
+# name: test/sql/cte/insert_cte_bug_3417.test
+# description: Test for a crash reported in issue #3417
+# group: [cte]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE table1 (id INTEGER, a INTEGER);
+
+statement ok
+CREATE TABLE table2 (table1_id INTEGER);
+
+statement error
+INSERT INTO table2 WITH cte AS (INSERT INTO table1 SELECT 1, 2 RETURNING id) SELECT id FROM cte;


### PR DESCRIPTION
While checking the fuzzing script I also found this crash. At the moment the exception can become a not implemented one. DML inside CTEs doesn't look good to me to ever be implemented.