### PR TITLE
Consistent struct definitions

### DIFF
--- a/third_party/mbedtls/mbedtls_wrapper.cpp
+++ b/third_party/mbedtls/mbedtls_wrapper.cpp
@@ -1,4 +1,6 @@
 #include "mbedtls_wrapper.hpp"
+// otherwise we have different definitions for mbedtls_pk_context / mbedtls_sha256_context
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS
 
 #include "mbedtls/sha256.h"
 #include "mbedtls/pk.h"


### PR DESCRIPTION
CRAN flagged different definitions of `mbedtls_sha256_context` and `mbedtls_pk_context` due to a C-level attempt of information hiding in mbedtls (bless their heart). We set a define to disable this and thus make the definitions consistent.