### PR TITLE
fix: correct mislabelling of amd64 libs in jars

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -259,6 +259,10 @@ jobs:
         path: |
           libduckdb-linux-i386.zip
           duckdb_cli-linux-i386.zip
+    - uses: actions/upload-artifact@v2
+      with:
+        name: duckdb-binaries-linux-32bit
+        path: |
           build/release/tools/jdbc/duckdb_jdbc.jar
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,6 +375,8 @@ set(OS_ARCH "amd64")
 string(REGEX MATCH "(arm64|aarch64)" IS_ARM "${CMAKE_SYSTEM_PROCESSOR}")
 if(IS_ARM)
   set(OS_ARCH "arm64")
+elseif(FORCE_32_BIT)
+  set(OS_ARCH "i386")
 endif()
 
 if(APPLE)

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBNative.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBNative.java
@@ -13,16 +13,24 @@ public class DuckDBNative {
 	static {
 		try {
 			String os_name = "";
-			String os_arch = "";
+			String os_arch;
 			String os_name_detect = System.getProperty("os.name").toLowerCase().trim();
 			String os_arch_detect = System.getProperty("os.arch").toLowerCase().trim();
-			if (os_arch_detect.equals("x86_64") || os_arch_detect.equals("amd64")) {
-				os_arch = "amd64";
+			switch (os_arch_detect) {
+				case "x86_64":
+				case "amd64":
+					os_arch = "amd64";
+					break;
+				case "aarch64":
+				case "arm64":
+					os_arch = "arm64";
+					break;
+				case "i386":
+					os_arch = "i386";
+					break;
+				default:
+					throw new IllegalStateException("Unsupported system architecture");
 			}
-			if (os_arch_detect.equals("aarch64") || os_arch_detect.equals("arm64")) {
-				os_arch = "arm64";
-			}
-			// TODO 32 bit gunk
 
 			if (os_name_detect.startsWith("windows")) {
 				os_name = "windows";


### PR DESCRIPTION
This also fixes up a name collision in the generated zip files, and completes support for jdbc on 32bit systems