### PR TITLE
[Python(pandas)] Scan multiple chunks worth of values from a 'object' dtype DataFrame

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/python_conversion.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/python_conversion.hpp
@@ -19,6 +19,27 @@
 
 namespace duckdb {
 
+enum class PythonObjectType {
+	Other,
+	None,
+	Integer,
+	Float,
+	Bool,
+	Decimal,
+	Uuid,
+	Datetime,
+	Date,
+	Time,
+	Timedelta,
+	String,
+	ByteArray,
+	MemoryView,
+	Bytes,
+	List,
+	Dict,
+	NdArray,
+};
+
 bool TryTransformPythonNumeric(Value &res, py::handle ele);
 bool DictionaryHasMapFormat(const PyDictionary &dict);
 Value TransformPythonValue(py::handle ele, const LogicalType &target_type = LogicalType::UNKNOWN,

--- a/tools/pythonpkg/src/python_conversion.cpp
+++ b/tools/pythonpkg/src/python_conversion.cpp
@@ -201,59 +201,122 @@ bool TryTransformPythonNumeric(Value &res, py::handle ele) {
 	return true;
 }
 
-Value TransformPythonValue(py::handle ele, const LogicalType &target_type, bool nan_as_null) {
+PythonObjectType GetObjectType(py::handle &ele) {
 	auto &import_cache = *DuckDBPyConnection::ImportCache();
 
 	if (ele.is_none()) {
-		return Value();
+		return PythonObjectType::None;
 	} else if (py::isinstance<py::bool_>(ele)) {
-		return Value::BOOLEAN(ele.cast<bool>());
+		return PythonObjectType::Bool;
 	} else if (py::isinstance<py::int_>(ele)) {
+		return PythonObjectType::Integer;
+	} else if (py::isinstance<py::float_>(ele)) {
+		return PythonObjectType::Float;
+	} else if (py::isinstance(ele, import_cache.decimal.Decimal())) {
+		return PythonObjectType::Decimal;
+	} else if (py::isinstance(ele, import_cache.uuid.UUID())) {
+		return PythonObjectType::Uuid;
+	} else if (py::isinstance(ele, import_cache.datetime.datetime())) {
+		return PythonObjectType::Datetime;
+	} else if (py::isinstance(ele, import_cache.datetime.time())) {
+		return PythonObjectType::Time;
+	} else if (py::isinstance(ele, import_cache.datetime.date())) {
+		return PythonObjectType::Date;
+	} else if (py::isinstance(ele, import_cache.datetime.timedelta())) {
+		return PythonObjectType::Timedelta;
+	} else if (py::isinstance<py::str>(ele)) {
+		return PythonObjectType::String;
+	} else if (py::isinstance<py::bytearray>(ele)) {
+		return PythonObjectType::ByteArray;
+	} else if (py::isinstance<py::memoryview>(ele)) {
+		return PythonObjectType::MemoryView;
+	} else if (py::isinstance<py::bytes>(ele)) {
+		return PythonObjectType::Bytes;
+	} else if (py::isinstance<py::list>(ele)) {
+		return PythonObjectType::List;
+	} else if (py::isinstance<py::dict>(ele)) {
+		return PythonObjectType::Dict;
+	} else if (py::isinstance(ele, import_cache.numpy.ndarray())) {
+		return PythonObjectType::NdArray;
+	} else {
+		return PythonObjectType::Other;
+	}
+}
+
+Value TransformPythonValue(py::handle ele, const LogicalType &target_type, bool nan_as_null) {
+	auto &import_cache = *DuckDBPyConnection::ImportCache();
+
+	auto object_type = GetObjectType(ele);
+	if (object_type != PythonObjectType::Date) {
+		;
+	}
+
+	switch (object_type) {
+	case PythonObjectType::None:
+		return Value();
+	case PythonObjectType::Bool:
+		return Value::BOOLEAN(ele.cast<bool>());
+	case PythonObjectType::Integer: {
 		Value integer;
 		if (!TryTransformPythonNumeric(integer, ele)) {
 			throw InvalidInputException("An error occurred attempting to convert a python integer");
 		}
 		return integer;
-	} else if (py::isinstance<py::float_>(ele)) {
+	}
+	case PythonObjectType::Float:
 		if (nan_as_null && std::isnan(PyFloat_AsDouble(ele.ptr()))) {
 			return Value();
 		}
 		return Value::DOUBLE(ele.cast<double>());
-	} else if (py::isinstance(ele, import_cache.decimal.Decimal())) {
+	case PythonObjectType::Decimal: {
 		PyDecimal decimal(ele);
 		return decimal.ToDuckValue();
-	} else if (py::isinstance(ele, import_cache.uuid.UUID())) {
+	}
+	case PythonObjectType::Uuid: {
 		auto string_val = py::str(ele).cast<string>();
 		return Value::UUID(string_val);
-	} else if (py::isinstance(ele, import_cache.datetime.datetime())) {
+	}
+	case PythonObjectType::Datetime: {
+		auto isnull_result = py::module::import("pandas").attr("isnull")(ele);
+		bool is_nat = string(py::str(isnull_result)) == "True";
+		if (is_nat) {
+			return Value();
+		}
 		auto datetime = PyDateTime(ele);
 		return datetime.ToDuckValue();
-	} else if (py::isinstance(ele, import_cache.datetime.time())) {
+	}
+	case PythonObjectType::Time: {
 		auto time = PyTime(ele);
 		return time.ToDuckValue();
-	} else if (py::isinstance(ele, import_cache.datetime.date())) {
+	}
+	case PythonObjectType::Date: {
 		auto date = PyDate(ele);
 		return date.ToDuckValue();
-	} else if (py::isinstance(ele, import_cache.datetime.timedelta())) {
+	}
+	case PythonObjectType::Timedelta: {
 		auto timedelta = PyTimeDelta(ele);
 		return Value::INTERVAL(timedelta.ToInterval());
-	} else if (py::isinstance<py::str>(ele)) {
+	}
+	case PythonObjectType::String:
 		return ele.cast<string>();
-	} else if (py::isinstance<py::bytearray>(ele)) {
+	case PythonObjectType::ByteArray: {
 		auto byte_array = ele.ptr();
 		auto bytes = PyByteArray_AsString(byte_array);
 		return Value::BLOB_RAW(bytes);
-	} else if (py::isinstance<py::memoryview>(ele)) {
+	}
+	case PythonObjectType::MemoryView: {
 		py::memoryview py_view = ele.cast<py::memoryview>();
 		PyObject *py_view_ptr = py_view.ptr();
 		Py_buffer *py_buf = PyMemoryView_GET_BUFFER(py_view_ptr);
 		return Value::BLOB(const_data_ptr_t(py_buf->buf), idx_t(py_buf->len));
-	} else if (py::isinstance<py::bytes>(ele)) {
+	}
+	case PythonObjectType::Bytes: {
 		const string &ele_string = ele.cast<string>();
 		return Value::BLOB(const_data_ptr_t(ele_string.data()), ele_string.size());
-	} else if (py::isinstance<py::list>(ele)) {
+	}
+	case PythonObjectType::List:
 		return TransformListValue(ele);
-	} else if (py::isinstance<py::dict>(ele)) {
+	case PythonObjectType::Dict: {
 		PyDictionary dict = PyDictionary(py::reinterpret_borrow<py::object>(ele));
 		switch (target_type.id()) {
 		case LogicalTypeId::STRUCT:
@@ -263,9 +326,10 @@ Value TransformPythonValue(py::handle ele, const LogicalType &target_type, bool 
 		default:
 			return TransformDictionary(dict);
 		}
-	} else if (py::isinstance(ele, import_cache.numpy.ndarray())) {
+	}
+	case PythonObjectType::NdArray:
 		return TransformPythonValue(ele.attr("tolist")());
-	} else {
+	case PythonObjectType::Other:
 		throw NotImplementedException("Unable to transform python value of type '%s' to DuckDB LogicalType",
 		                              py::str(ele.get_type()).cast<string>());
 	}

--- a/tools/pythonpkg/src/python_conversion.cpp
+++ b/tools/pythonpkg/src/python_conversion.cpp
@@ -247,9 +247,6 @@ Value TransformPythonValue(py::handle ele, const LogicalType &target_type, bool 
 	auto &import_cache = *DuckDBPyConnection::ImportCache();
 
 	auto object_type = GetObjectType(ele);
-	if (object_type != PythonObjectType::Date) {
-		;
-	}
 
 	switch (object_type) {
 	case PythonObjectType::None:

--- a/tools/pythonpkg/src/vector_conversion.cpp
+++ b/tools/pythonpkg/src/vector_conversion.cpp
@@ -145,7 +145,7 @@ static void SetInvalidRecursive(Vector &out, idx_t index) {
 }
 
 //! 'count' is the amount of rows in the 'out' vector
-//! offset is the current row number within this vector
+//! 'offset' is the current row number within this vector
 void ScanPandasObject(PandasColumnBindData &bind_data, PyObject *object, idx_t offset, Vector &out) {
 
 	// handle None
@@ -192,12 +192,15 @@ void ScanPandasObjectColumn(PandasColumnBindData &bind_data, PyObject **col, idx
 	auto gil = make_unique<PythonGILWrapper>(); // We're creating python objects here, so we need the GIL
 
 	for (idx_t i = 0; i < count; i++) {
-		ScanPandasObject(bind_data, col[i], i, out);
+		idx_t source_idx = offset + i;
+		ScanPandasObject(bind_data, col[source_idx], i, out);
 	}
 	gil.reset();
 	VerifyTypeConstraints(out, count);
 }
 
+//! 'offset' is the offset within the column
+//! 'count' is the amount of values we will convert in this batch
 void VectorConversion::NumpyToDuckDB(PandasColumnBindData &bind_data, py::array &numpy_col, idx_t count, idx_t offset,
                                      Vector &out) {
 	switch (bind_data.pandas_type) {


### PR DESCRIPTION
This PR fixes #4689 

When writing the conversion for object datatypes I seem to have completely disregarded the offset, so if a DataFrame contains more than STANDARD_VECTOR_SIZE (1024) entries, the same 1024 entries would get scanned over and over again.
