### PR TITLE
Fix #4647

### DIFF
--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -191,11 +191,15 @@ bool CatalogSet::AlterEntry(ClientContext &context, const string &name, AlterInf
 				throw CatalogException(rename_err_msg, original_name, value->name);
 			}
 		}
-		PutMapping(context, value->name, entry_index);
-		DeleteMapping(context, original_name);
 	}
 	//! Check the dependency manager to verify that there are no conflicting dependencies with this alter
 	catalog.dependency_manager->AlterObject(context, entry, value.get());
+
+	if (value->name != original_name) {
+		// Do PutMapping and DeleteMapping after dependency check
+		PutMapping(context, value->name, entry_index);
+		DeleteMapping(context, original_name);
+	}
 
 	value->timestamp = transaction.transaction_id;
 	value->child = move(entries[entry_index]);

--- a/test/sql/alter/rename_table/test_rename_table_with_dependency_check.test
+++ b/test/sql/alter/rename_table/test_rename_table_with_dependency_check.test
@@ -1,0 +1,28 @@
+# name: test/sql/alter/rename_table/test_rename_table_with_dependency_check.test
+# description: Test RENAME TABLE with dependency check
+# group: [rename_table]
+
+statement ok
+CREATE TABLE t0 (c0 INT);
+
+statement ok
+CREATE UNIQUE INDEX i1 ON t0 (c0);
+
+# Cannot alter entry "t0" because there are entries that depend on it
+statement error
+ALTER TABLE t0 RENAME TO t3;
+
+# t3 is not exist
+statement ok
+CREATE TABLE t3 (c0 INT);
+
+# Cannot alter entry "t0" because there are entries that depend on it
+statement error
+ALTER TABLE t0 RENAME TO t4;
+
+statement ok
+DROP TABLE t0;
+
+# t4 is not exist
+statement error
+ANALYZE t4;


### PR DESCRIPTION
### Related Issue
Fix: #4647
### What is the problem?
I executed some SQLs just like the screenshot shows below.
![2022-09-14 01-38-01屏幕截图](https://user-images.githubusercontent.com/81315978/189978167-5e99a5bb-519f-49f3-a1e6-7162d7155a01.png)
I found that although the 'ALTER' was failed, the table 't3' was exist.After I drop table 't0', next operation on 't3' will throw a ‘NULL POINTER‘. It's just like the issue mentioned.
The bug happens on the code in 'src/catalog/catalog_set.cpp', line 194 and 195.
![2022-09-14 02-22-41屏幕截图](https://user-images.githubusercontent.com/81315978/189980673-b3a44bd1-7fa9-47ff-b5b5-9c687d2cfbb6.png)
Though 'ALTER TABLE t0 RENAME TO t3' fails because of dependency check, t3 has been insert into 'map' and there is no related entry in 'entries'. So we need to do dependency check before we do 'PutMapping' and 'DeletMapping'.
I also add some tests for this issue.

Sorry for my bad english.