### PR TITLE
Name and affiliation should not be required by the form validation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,14 +44,10 @@ body:
     attributes:
       label: "Full Name:"
       placeholder: e.g. John Doe
-    validations:
-      required: true
   - type: input
     attributes:
       label: "Affiliation:"
       placeholder: e.g. Oracle
-    validations:
-      required: true
 
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,10 +14,15 @@ body:
       description: Steps to reproduce the behavior. Bonus points if those are only SQL queries.
     validations:
       required: true
+      
+  - type: textarea
+    attributes:
+      label: Anything else
+      description: Anything else you want to add to this issue? Use this input to disclose your identity and affiliation if they are not obvious from your GitHub profile page.
 
   - type: markdown
     attributes:
-      value: "# Environment (please complete the following information):"
+      value: "# Environment:"
   - type: input
     attributes:
       label: "OS:"
@@ -39,22 +44,7 @@ body:
 
   - type: markdown
     attributes:
-      value: "# Identity Disclosure:"
-  - type: input
-    attributes:
-      label: "Full Name:"
-      placeholder: e.g. John Doe
-  - type: input
-    attributes:
-      label: "Affiliation:"
-      placeholder: e.g. Oracle
-
-  - type: markdown
-    attributes:
-      value: |
-        If the above is not given and is not obvious from your GitHub profile page, we might close your issue without further review. Please refer to the [reasoning behind this rule](https://berthub.eu/articles/posts/anonymous-help/) if you have questions.
-
-        # Before Submitting
+      value: "# Before Submitting"
 
   - type: checkboxes
     attributes:
@@ -65,12 +55,25 @@ body:
         * **Other Platforms**: You can find links to binaries [here](https://duckdb.org/docs/installation/) or compile from source.
 
       options:
-        - label: I agree
+        - label: Yes, I tried master.
           required: true
 
   - type: checkboxes
     attributes:
       label: Have you tried the steps to reproduce? Do they include all relevant data and configuration? Does the issue you report still appear there?
       options:
-        - label: I agree
+        - label: Yes, I have tried to reproduce the issue.
+          required: true
+          
+  - type: checkboxes
+    attributes:
+      label: Are your identity and affiliation disclosed?
+
+      description: |
+        We expect every issue reporter to disclose their identity (full name) and affiliation. If they are not obvious from your GitHub profile page,
+        please use the extra textarea above. If your identity is not disclosed, we might close your issue without further review.
+        Please refer to the [reasoning behind this rule](https://berthub.eu/articles/posts/anonymous-help/) if you have questions.
+
+      options:
+        - label: Yes, my identiy and affiliation are disclosed.
           required: true


### PR DESCRIPTION
The comment even says that the issue will be closed if they are not given but I have to give them even if my affiliation is obvious.