### PR TITLE
[Arrow] Guarantee threads don't call get_next after stream is done.

### DIFF
--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -258,9 +258,9 @@ bool ArrowScanParallelStateNext(ClientContext &context, const FunctionData *bind
 	state.chunk = move(current_chunk);
 	//! have we run out of chunks? we are done
 	if (!state.chunk->arrow_array.release) {
-		return false;
+		parallel_state.done = true;
 	}
-	return true;
+	return !parallel_state.done;
 }
 
 unique_ptr<GlobalTableFunctionState> ArrowTableFunction::ArrowScanInitGlobal(ClientContext &context,

--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -249,6 +249,9 @@ idx_t ArrowTableFunction::ArrowScanMaxThreads(ClientContext &context, const Func
 bool ArrowScanParallelStateNext(ClientContext &context, const FunctionData *bind_data_p, ArrowScanLocalState &state,
                                 ArrowScanGlobalState &parallel_state) {
 	lock_guard<mutex> parallel_lock(parallel_state.main_mutex);
+	if (parallel_state.done) {
+		return false;
+	}
 	state.chunk_offset = 0;
 
 	auto current_chunk = parallel_state.stream->GetNextChunk();
@@ -259,8 +262,9 @@ bool ArrowScanParallelStateNext(ClientContext &context, const FunctionData *bind
 	//! have we run out of chunks? we are done
 	if (!state.chunk->arrow_array.release) {
 		parallel_state.done = true;
+		return false;
 	}
-	return !parallel_state.done;
+	return true;
 }
 
 unique_ptr<GlobalTableFunctionState> ArrowTableFunction::ArrowScanInitGlobal(ClientContext &context,

--- a/src/include/duckdb/function/table/arrow.hpp
+++ b/src/include/duckdb/function/table/arrow.hpp
@@ -91,8 +91,8 @@ struct ArrowScanLocalState : public LocalTableFunctionState {
 struct ArrowScanGlobalState : public GlobalTableFunctionState {
 	unique_ptr<ArrowArrayStreamWrapper> stream;
 	mutex main_mutex;
-	bool ready = false;
 	idx_t max_threads = 1;
+	bool done = false;
 
 	idx_t MaxThreads() const override {
 		return max_threads;


### PR DESCRIPTION
@paleolimbot can you try the Arrow CI on this PR?

Potentially fixes: #4656 