### PR TITLE
Fix #4475: allow ignore_errors in read_csv and read_csv_auto

### DIFF
--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -210,6 +210,7 @@ static void ReadCSVAddNamedParameters(TableFunction &table_function) {
 	table_function.named_parameters["skip"] = LogicalType::BIGINT;
 	table_function.named_parameters["max_line_size"] = LogicalType::VARCHAR;
 	table_function.named_parameters["maximum_line_size"] = LogicalType::VARCHAR;
+	table_function.named_parameters["ignore_errors"] = LogicalType::BOOLEAN;
 }
 
 double CSVReaderProgress(ClientContext &context, const FunctionData *bind_data_p,

--- a/test/sql/copy/csv/test_ignore_errors.test
+++ b/test/sql/copy/csv/test_ignore_errors.test
@@ -25,6 +25,25 @@ statement ok
 DELETE FROM integers;
 
 statement ok
+INSERT INTO integers SELECT * FROM read_csv('test/sql/copy/csv/data/test/error_too_little.csv', columns={'i': 'INTEGER', 'j': 'INTEGER'}, header=1, ignore_errors=1)
+
+statement error
+INSERT INTO integers SELECT * FROM read_csv('test/sql/copy/csv/data/test/error_too_little.csv', columns={'i': 'INTEGER'}, header=1)
+
+# not enough columns provided
+query II
+SELECT * FROM integers AS too_little_columns
+----
+1	1
+2	2
+3	3
+4	4
+5	5
+
+statement ok
+DELETE FROM integers;
+
+statement ok
 COPY integers FROM 'test/sql/copy/csv/data/test/error_too_little_single.csv' (HEADER, IGNORE_ERRORS)
 
 statement error


### PR DESCRIPTION
Fixes #4475

Calling this a bug-fix as it was a simple oversight in the named parameter list