### PR TITLE
Fix #4703

### DIFF
--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -863,7 +863,7 @@ void TableCatalogEntry::CommitAlter(AlterInfo &info) {
 		}
 	}
 	D_ASSERT(removed_index != DConstants::INVALID_INDEX);
-	storage->CommitDropColumn(removed_index);
+	storage->CommitDropColumn(columns[removed_index].StorageOid());
 }
 
 void TableCatalogEntry::CommitDrop() {

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -441,16 +441,7 @@ unique_ptr<CatalogEntry> TableCatalogEntry::RemoveColumn(ClientContext &context,
 		return make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(),
 		                                      storage);
 	}
-
-	// We need to skip generated columns because they are not in 'storage'
-	column_t storage_index = removed_index;
-	for (column_t i = 0; i < removed_index; i++) {
-		if (columns[i].Generated()) {
-			storage_index--;
-		}
-	}
-
-	auto new_storage = make_shared<DataTable>(context, *storage, storage_index);
+	auto new_storage = make_shared<DataTable>(context, *storage, columns[removed_index].StorageOid());
 	return make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(),
 	                                      new_storage);
 }

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -441,7 +441,16 @@ unique_ptr<CatalogEntry> TableCatalogEntry::RemoveColumn(ClientContext &context,
 		return make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(),
 		                                      storage);
 	}
-	auto new_storage = make_shared<DataTable>(context, *storage, removed_index);
+
+	// We need to skip generated columns because they are not in 'storage'
+	column_t storage_index = removed_index;
+	for (column_t i = 0; i < removed_index; i++) {
+		if (columns[i].Generated()) {
+			storage_index--;
+		}
+	}
+
+	auto new_storage = make_shared<DataTable>(context, *storage, storage_index);
 	return make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(),
 	                                      new_storage);
 }

--- a/test/sql/alter/drop_col/test_drop_col_with_generated_cols.test
+++ b/test/sql/alter/drop_col/test_drop_col_with_generated_cols.test
@@ -1,0 +1,18 @@
+# name: test/sql/alter/drop_col/test_drop_col_with_generated_cols.test
+# description: Test ALTER TABLE DROP COLUMN with generated cols in the table
+# group: [drop_col]
+
+statement ok
+create table t(i int, j as (2), k int, m as (3), n int);
+
+statement ok
+alter table t drop column n;
+
+statement ok
+alter table t drop column m;
+
+statement ok
+alter table t drop column k;
+
+statement ok
+alter table t drop column j;


### PR DESCRIPTION
Fix #4703

It seems that generated columns are not inserted into DataTable and we use wrong index to delete common columns from DataTable.
I think I can't fix this issue just by inserting generated columns into DataTable because duckdb only support virtual generated columns now.So I skip the generated columns when passing argument 'removed_column' to DataTable.

I also add a test for this issue.