### PR TITLE
Fix #4694: Keep shared pointer to pipelines around in additionally scheduled events

### DIFF
--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -9,7 +9,7 @@
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
-#include "duckdb/parallel/event.hpp"
+#include "duckdb/parallel/base_pipeline_event.hpp"
 #include "duckdb/common/atomic.hpp"
 
 namespace duckdb {
@@ -168,16 +168,15 @@ void PhysicalHashAggregate::Combine(ExecutionContext &context, GlobalSinkState &
 	}
 }
 
-class HashAggregateFinalizeEvent : public Event {
+class HashAggregateFinalizeEvent : public BasePipelineEvent {
 public:
 	HashAggregateFinalizeEvent(const PhysicalHashAggregate &op_p, HashAggregateGlobalState &gstate_p,
 	                           Pipeline *pipeline_p)
-	    : Event(pipeline_p->executor), op(op_p), gstate(gstate_p), pipeline(pipeline_p) {
+	    : BasePipelineEvent(*pipeline_p), op(op_p), gstate(gstate_p) {
 	}
 
 	const PhysicalHashAggregate &op;
 	HashAggregateGlobalState &gstate;
-	Pipeline *pipeline;
 
 public:
 	void Schedule() override {

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -13,7 +13,7 @@
 #include "duckdb/execution/window_segment_tree.hpp"
 #include "duckdb/main/client_config.hpp"
 #include "duckdb/main/config.hpp"
-#include "duckdb/parallel/event.hpp"
+#include "duckdb/parallel/base_pipeline_event.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression/bound_window_expression.hpp"
 
@@ -1502,19 +1502,18 @@ private:
 	WindowGlobalHashGroup &hash_group;
 };
 
-class WindowMergeEvent : public Event {
+class WindowMergeEvent : public BasePipelineEvent {
 public:
 	WindowMergeEvent(WindowGlobalSinkState &gstate_p, Pipeline &pipeline_p, WindowGlobalHashGroup &hash_group_p)
-	    : Event(pipeline_p.executor), gstate(gstate_p), pipeline(pipeline_p), hash_group(hash_group_p) {
+	    : BasePipelineEvent(pipeline_p), gstate(gstate_p), hash_group(hash_group_p) {
 	}
 
 	WindowGlobalSinkState &gstate;
-	Pipeline &pipeline;
 	WindowGlobalHashGroup &hash_group;
 
 public:
 	void Schedule() override {
-		auto &context = pipeline.GetClientContext();
+		auto &context = pipeline->GetClientContext();
 
 		// Schedule tasks equal to the number of threads, which will each merge multiple partitions
 		auto &ts = TaskScheduler::GetScheduler(context);
@@ -1529,7 +1528,7 @@ public:
 
 	void FinishEvent() override {
 		hash_group.global_sort->CompleteMergeRound(true);
-		CreateMergeTasks(pipeline, *this, gstate, hash_group);
+		CreateMergeTasks(*pipeline, *this, gstate, hash_group);
 	}
 
 	static void CreateMergeTasks(Pipeline &pipeline, Event &event, WindowGlobalSinkState &state,

--- a/src/execution/operator/join/physical_range_join.cpp
+++ b/src/execution/operator/join/physical_range_join.cpp
@@ -8,7 +8,7 @@
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/main/client_context.hpp"
-#include "duckdb/parallel/event.hpp"
+#include "duckdb/parallel/base_pipeline_event.hpp"
 #include "duckdb/parallel/thread_context.hpp"
 
 #include <thread>
@@ -104,21 +104,20 @@ private:
 	GlobalSortedTable &table;
 };
 
-class RangeJoinMergeEvent : public Event {
+class RangeJoinMergeEvent : public BasePipelineEvent {
 public:
 	using GlobalSortedTable = PhysicalRangeJoin::GlobalSortedTable;
 
 public:
 	RangeJoinMergeEvent(GlobalSortedTable &table_p, Pipeline &pipeline_p)
-	    : Event(pipeline_p.executor), table(table_p), pipeline(pipeline_p) {
+	    : BasePipelineEvent(pipeline_p), table(table_p) {
 	}
 
 	GlobalSortedTable &table;
-	Pipeline &pipeline;
 
 public:
 	void Schedule() override {
-		auto &context = pipeline.GetClientContext();
+		auto &context = pipeline->GetClientContext();
 
 		// Schedule tasks equal to the number of threads, which will each merge multiple partitions
 		auto &ts = TaskScheduler::GetScheduler(context);
@@ -137,7 +136,7 @@ public:
 		global_sort_state.CompleteMergeRound(true);
 		if (global_sort_state.sorted_blocks.size() > 1) {
 			// Multiple blocks remaining: Schedule the next round
-			table.ScheduleMergeTasks(pipeline, *this);
+			table.ScheduleMergeTasks(*pipeline, *this);
 		}
 	}
 };

--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -132,6 +132,8 @@ private:
 	atomic<idx_t> completed_pipelines;
 	//! The total amount of pipelines in the query
 	idx_t total_pipelines;
+	//! Whether or not execution is cancelled
+	bool cancelled;
 
 	//! The adjacent union pipelines of each pipeline
 	//! Union pipelines have the same sink, but can be run concurrently along with this pipeline

--- a/src/include/duckdb/parallel/base_pipeline_event.hpp
+++ b/src/include/duckdb/parallel/base_pipeline_event.hpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parallel/base_pipeline_event.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/parallel/event.hpp"
+#include "duckdb/parallel/pipeline.hpp"
+
+namespace duckdb {
+
+//! A BasePipelineEvent is used as the basis of any event that belongs to a specific pipeline
+class BasePipelineEvent : public Event {
+public:
+	BasePipelineEvent(shared_ptr<Pipeline> pipeline);
+	BasePipelineEvent(Pipeline &pipeline);
+
+	//! The pipeline that this event belongs to
+	shared_ptr<Pipeline> pipeline;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/parallel/pipeline_event.hpp
+++ b/src/include/duckdb/parallel/pipeline_event.hpp
@@ -8,17 +8,14 @@
 
 #pragma once
 
-#include "duckdb/parallel/event.hpp"
-#include "duckdb/parallel/pipeline.hpp"
+#include "duckdb/parallel/base_pipeline_event.hpp"
 
 namespace duckdb {
 
-class PipelineEvent : public Event {
+//! A PipelineEvent is responsible for scheduling a pipeline
+class PipelineEvent : public BasePipelineEvent {
 public:
 	PipelineEvent(shared_ptr<Pipeline> pipeline);
-
-	//! The pipeline that this event belongs to
-	shared_ptr<Pipeline> pipeline;
 
 public:
 	void Schedule() override;

--- a/src/include/duckdb/parallel/pipeline_finish_event.hpp
+++ b/src/include/duckdb/parallel/pipeline_finish_event.hpp
@@ -8,18 +8,14 @@
 
 #pragma once
 
-#include "duckdb/parallel/event.hpp"
-#include "duckdb/parallel/pipeline.hpp"
+#include "duckdb/parallel/base_pipeline_event.hpp"
 
 namespace duckdb {
 class Executor;
 
-class PipelineFinishEvent : public Event {
+class PipelineFinishEvent : public BasePipelineEvent {
 public:
 	PipelineFinishEvent(shared_ptr<Pipeline> pipeline);
-
-	//! The pipeline that this event belongs to
-	shared_ptr<Pipeline> pipeline;
 
 public:
 	void Schedule() override;

--- a/src/parallel/CMakeLists.txt
+++ b/src/parallel/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library_unity(
   duckdb_parallel
   OBJECT
+  base_pipeline_event.cpp
   executor_task.cpp
   executor.cpp
   event.cpp

--- a/src/parallel/base_pipeline_event.cpp
+++ b/src/parallel/base_pipeline_event.cpp
@@ -1,0 +1,13 @@
+#include "duckdb/parallel/base_pipeline_event.hpp"
+
+namespace duckdb {
+
+BasePipelineEvent::BasePipelineEvent(shared_ptr<Pipeline> pipeline_p)
+    : Event(pipeline_p->executor), pipeline(move(pipeline_p)) {
+}
+
+BasePipelineEvent::BasePipelineEvent(Pipeline &pipeline_p)
+    : Event(pipeline_p.executor), pipeline(pipeline_p.shared_from_this()) {
+}
+
+} // namespace duckdb

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -28,6 +28,9 @@ Executor &Executor::Get(ClientContext &context) {
 
 void Executor::AddEvent(shared_ptr<Event> event) {
 	lock_guard<mutex> elock(executor_lock);
+	if (cancelled) {
+		return;
+	}
 	events.push_back(move(event));
 }
 
@@ -331,6 +334,7 @@ void Executor::CancelTasks() {
 	vector<weak_ptr<Pipeline>> weak_references;
 	{
 		lock_guard<mutex> elock(executor_lock);
+		cancelled = true;
 		weak_references.reserve(pipelines.size());
 		for (auto &pipeline : pipelines) {
 			weak_references.push_back(weak_ptr<Pipeline>(pipeline));
@@ -419,6 +423,7 @@ PendingExecutionResult Executor::ExecuteTask() {
 void Executor::Reset() {
 	lock_guard<mutex> elock(executor_lock);
 	physical_plan = nullptr;
+	cancelled = false;
 	owned_plan.reset();
 	root_executor.reset();
 	root_pipelines.clear();

--- a/src/parallel/pipeline_event.cpp
+++ b/src/parallel/pipeline_event.cpp
@@ -2,8 +2,7 @@
 
 namespace duckdb {
 
-PipelineEvent::PipelineEvent(shared_ptr<Pipeline> pipeline_p)
-    : Event(pipeline_p->executor), pipeline(move(pipeline_p)) {
+PipelineEvent::PipelineEvent(shared_ptr<Pipeline> pipeline_p) : BasePipelineEvent(move(pipeline_p)) {
 }
 
 void PipelineEvent::Schedule() {

--- a/src/parallel/pipeline_finish_event.cpp
+++ b/src/parallel/pipeline_finish_event.cpp
@@ -3,8 +3,7 @@
 
 namespace duckdb {
 
-PipelineFinishEvent::PipelineFinishEvent(shared_ptr<Pipeline> pipeline_p)
-    : Event(pipeline_p->executor), pipeline(move(pipeline_p)) {
+PipelineFinishEvent::PipelineFinishEvent(shared_ptr<Pipeline> pipeline_p) : BasePipelineEvent(move(pipeline_p)) {
 }
 
 void PipelineFinishEvent::Schedule() {

--- a/test/fuzzer/pedro/hash_finalize_race.test
+++ b/test/fuzzer/pedro/hash_finalize_race.test
@@ -1,0 +1,19 @@
+# name: test/fuzzer/pedro/hash_finalize_race.test
+# description: Issue #4694: Race condition at HashJoinFinalizeEvent
+# group: [sqlsmith]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE SEQUENCE t4;
+
+statement ok
+PRAGMA DEBUG_FORCE_EXTERNAL=1;
+
+loop i 0 10
+
+statement error
+SELECT 1 FROM ((SELECT 2) INTERSECT (SELECT 2)) t2(c3) WHERE "currval"('t4') = EXISTS (SELECT 2);
+
+endloop

--- a/test/fuzzer/pedro/hash_finalize_race.test
+++ b/test/fuzzer/pedro/hash_finalize_race.test
@@ -1,6 +1,6 @@
 # name: test/fuzzer/pedro/hash_finalize_race.test
 # description: Issue #4694: Race condition at HashJoinFinalizeEvent
-# group: [sqlsmith]
+# group: [pedro]
 
 statement ok
 PRAGMA enable_verification


### PR DESCRIPTION
Fixes #4694 

The problem was that, upon attempting to terminate a query in case of an error, the executor would try to clean up all remaining tasks prior to destroying all state associated with that query. The manner in which it would check if all tasks were cleaned up was if all pipelines were cleaned up, as all standard tasks would keep shared pointers to pipelines.

Additionally scheduled events generally did not keep shared pointers to pipelines, however, which could spuriously cause the query state to be cleaned up while a task was still running, resulting in a use-after-free. This PR fixes that by ensuring that all additionally scheduled events also correctly keep shared pointers to pipelines around.