### PR TITLE
Fix #4702. Correctly use index when generated column is involved

### DIFF
--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -629,19 +629,19 @@ unique_ptr<CatalogEntry> TableCatalogEntry::ChangeColumnType(ClientContext &cont
 	auto expression = info.expression->Copy();
 	auto bound_expression = expr_binder.Bind(expression);
 	auto bound_create_info = binder->BindCreateTableInfo(move(create_info));
-	vector<column_t> storage_cids;
+	vector<column_t> storage_oids;
 	if (bound_columns.empty()) {
-		storage_cids.push_back(COLUMN_IDENTIFIER_ROW_ID);
+		storage_oids.push_back(COLUMN_IDENTIFIER_ROW_ID);
 	}
-	// transform to storage_id
+	// transform to storage_oid
 	else {
 		for (idx_t i = 0; i < bound_columns.size(); i++) {
-			storage_cids.push_back(columns[bound_columns[i]].StorageOid());
+			storage_oids.push_back(columns[bound_columns[i]].StorageOid());
 		}
 	}
 
 	auto new_storage = make_shared<DataTable>(context, *storage, columns[change_idx].StorageOid(), info.target_type,
-	                                          move(storage_cids), *bound_expression);
+	                                          move(storage_oids), *bound_expression);
 	auto result =
 	    make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(), new_storage);
 	return move(result);

--- a/test/sql/alter/alter_type/test_alter_type_with_generated_column.test
+++ b/test/sql/alter/alter_type/test_alter_type_with_generated_column.test
@@ -1,0 +1,27 @@
+# name: test/sql/alter/alter_type/test_alter_type_with_generated_column.test
+# description: Test ALTER TABLE ALTER TYPE with Generated Column
+# group: [alter_type]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE test(i AS (1), j INTEGER)
+
+statement ok
+INSERT INTO test VALUES (1), (2)
+
+# Alter generated column
+statement error
+ALTER TABLE test ALTER i TYPE VARCHAR
+
+# Alter normal column
+statement ok
+ALTER TABLE test ALTER j TYPE VARCHAR
+
+query IT
+SELECT * FROM test
+----
+1	1
+1	2
+


### PR DESCRIPTION
Symptom
===============
Issue #4702. heap-buffer-overflow when alter column type against table with generated column presented.

	
Root Cause
===============
TableCatalogEntry::columns contains all columns include the generated columns, while DataTable::column_definitions contains the real columns only. 
The changed and bound index should be StorageOid, otherwise the DataTable::column_definitions might be overflowed.


Fix
===============
Use column's StorageOid for changed and bound columns.


Test 
===============
Tests has been added to alter_type group with generated column being presented.