### PR TITLE
Use version tag as dir for extensions for releases

### DIFF
--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -121,8 +121,12 @@ runs:
         DUCKDB_EXTENSION_SIGNING_PK: ${{ inputs.signing_pk }}
         AWS_DEFAULT_REGION: us-east-1
       run: |
-        if [[ "$GITHUB_REF" =~ ^(refs/heads/master|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
-          ./scripts/extension-upload.sh ${{ inputs.deploy_as }}
+        if [[ "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
+          if [[ "$GITHUB_REF" =~ ^(refs/tags/v.+)$ ]] ; then
+            ./scripts/extension-upload.sh ${{ inputs.deploy_as }} ${{ github.ref_name }}
+          elif [[ "$GITHUB_REF" =~ ^(refs/heads/master)$ ]] ; then
+            ./scripts/extension-upload.sh ${{ inputs.deploy_as }} `git log -1 --format=%h`
+          fi
         fi
 
     - name: Test

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -180,18 +180,16 @@ jobs:
       - name: Deploy
         shell: bash
         run: |
-          zip -j httpfs.duckdb_extension.zip build/release/extension/httpfs/httpfs.duckdb_extension
-          if [[ "$GITHUB_REF" =~ ^(refs/heads/master|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
+          if [[ "$GITHUB_REF" =~ ^(refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
             pip install awscli
-            ./scripts/extension-upload.sh osx_amd64
-            ./scripts/extension-upload.sh osx_arm64
+            ./scripts/extension-upload.sh osx_amd64 ${{ github.ref_name }}
+            ./scripts/extension-upload.sh osx_arm64 ${{ github.ref_name }}
+            ./scripts/extension-upload-test.sh
+          elif [[ "$GITHUB_REF" =~ ^(refs/heads/master)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
+            pip install awscli
+            ./scripts/extension-upload.sh osx_amd64 `git log -1 --format=%h`
+            ./scripts/extension-upload.sh osx_arm64 `git log -1 --format=%h`
             ./scripts/extension-upload-test.sh
           else
             ./scripts/extension-upload-test.sh local
           fi
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: duckdb-binaries-osx
-          path: |
-            httpfs.duckdb_extension.zip

--- a/scripts/extension-upload.sh
+++ b/scripts/extension-upload.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Usage: ./extension-upload.sh <architecture> <commithash or version_tag>
+
 set -e
 
 echo "$DUCKDB_EXTENSION_SIGNING_PK" > private.pem
@@ -18,7 +20,7 @@ do
   # compress extension binary
 	gzip < $f > "$f.gz"
 	# upload compressed extension binary to S3
-	aws s3 cp $f.gz s3://duckdb-extensions/`git log -1 --format=%h`/$1/$ext.duckdb_extension.gz --acl public-read
+	aws s3 cp $f.gz s3://duckdb-extensions/$2/$1/$ext.duckdb_extension.gz --acl public-read
 done
 
 rm private.pem

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -40,6 +40,11 @@ public:
 
 private:
 	static const vector<string> PathComponents();
+	//! For tagged releases we use the tag, else we use the git commit hash
+	static const string GetVersionDirectoryName();
+	//! Version tags occur with and without 'v', tag in extension path is always with 'v'
+	static const string NormalizeVersionTag(const string &version_tag);
+	static const bool IsRelease(const string& version_tag);
 
 private:
 	static ExtensionLoadResult LoadExtensionInternal(DuckDB &db, const std::string &extension, bool initial_load);

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -44,7 +44,7 @@ private:
 	static const string GetVersionDirectoryName();
 	//! Version tags occur with and without 'v', tag in extension path is always with 'v'
 	static const string NormalizeVersionTag(const string &version_tag);
-	static const bool IsRelease(const string& version_tag);
+	static bool IsRelease(const string &version_tag);
 
 private:
 	static ExtensionLoadResult LoadExtensionInternal(DuckDB &db, const std::string &extension, bool initial_load);

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -22,7 +22,7 @@ const string ExtensionHelper::NormalizeVersionTag(const string &version_tag) {
 	return version_tag;
 }
 
-const bool ExtensionHelper::IsRelease(const string& version_tag) {
+bool ExtensionHelper::IsRelease(const string &version_tag) {
 	return !StringUtil::Contains(version_tag, "-dev");
 }
 

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -15,8 +15,27 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // Install Extension
 //===--------------------------------------------------------------------===//
+const string ExtensionHelper::NormalizeVersionTag(const string &version_tag) {
+	if (version_tag.length() > 0 && version_tag[0] != 'v') {
+		return "v" + version_tag;
+	}
+	return version_tag;
+}
+
+const bool ExtensionHelper::IsRelease(const string& version_tag) {
+	return !StringUtil::Contains(version_tag, "-dev");
+}
+
+const string ExtensionHelper::GetVersionDirectoryName() {
+	if (IsRelease(DuckDB::LibraryVersion())) {
+		return NormalizeVersionTag(DuckDB::LibraryVersion());
+	} else {
+		return DuckDB::SourceID();
+	}
+}
+
 const vector<string> ExtensionHelper::PathComponents() {
-	return vector<string> {".duckdb", "extensions", DuckDB::SourceID(), DuckDB::Platform()};
+	return vector<string> {".duckdb", "extensions", GetVersionDirectoryName(), DuckDB::Platform()};
 }
 
 string ExtensionHelper::ExtensionDirectory(ClientContext &context) {
@@ -89,7 +108,7 @@ void ExtensionHelper::InstallExtension(ClientContext &context, const string &ext
 		extension_name = "";
 	}
 
-	auto url = StringUtil::Replace(url_template, "${REVISION}", DuckDB::SourceID());
+	auto url = StringUtil::Replace(url_template, "${REVISION}", GetVersionDirectoryName());
 	url = StringUtil::Replace(url, "${PLATFORM}", DuckDB::Platform());
 	url = StringUtil::Replace(url, "${NAME}", extension_name);
 


### PR DESCRIPTION
fixes #4620

Tested the extension loading manually by overriding the Version in the CMakefile. The extension loading for dev builds should be tested in CI as soon as this is merged, but the the CI for testing release tagged extensions will only run as soon as we do the actually 0.5.1 release. 

@Mytherin do we just merge this after thorough review or should I setup a fork with a separate S3 bucket to doublecheck the release?