### PR TITLE
Fix #4562: generate table index for dummy scan generated from VALUES clause

### DIFF
--- a/src/planner/binder/tableref/plan_expressionlistref.cpp
+++ b/src/planner/binder/tableref/plan_expressionlistref.cpp
@@ -6,7 +6,7 @@
 namespace duckdb {
 
 unique_ptr<LogicalOperator> Binder::CreatePlan(BoundExpressionListRef &ref) {
-	auto root = make_unique_base<LogicalOperator, LogicalDummyScan>(0);
+	auto root = make_unique_base<LogicalOperator, LogicalDummyScan>(GenerateTableIndex());
 	// values list, first plan any subqueries in the list
 	for (auto &expr_list : ref.values) {
 		for (auto &expr : expr_list) {

--- a/test/fuzzer/pedro/subquery_assertion_error.test
+++ b/test/fuzzer/pedro/subquery_assertion_error.test
@@ -1,0 +1,11 @@
+# name: test/fuzzer/pedro/subquery_assertion_error.test
+# description: Issue #4562: Subquery error
+# group: [pedro]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT (VALUES(1 != ALL(SELECT 2)));
+----
+true


### PR DESCRIPTION
Fixes #4562

The problem was that the `VALUES` clause would generate a `LogicalDummyScan` with a hard-coded table-index of 0. This would normally not cause any problems. However, in case a subquery was present inside the first `VALUES` clause of a query it could lead to two tables being present with a table-index of 0. This lead to strange behavior where columns were not bound correctly, causing the incorrect column to be referenced, which would ultimately lead to the assertion we see in the issue.