### PR TITLE
[Verification] add `verify_generated_columns`

### DIFF
--- a/src/include/duckdb/parser/parser.hpp
+++ b/src/include/duckdb/parser/parser.hpp
@@ -26,6 +26,7 @@ struct ParserOptions {
 	bool preserve_identifier_case = true;
 	idx_t max_expression_depth = 1000;
 	const vector<ParserExtension> *extensions = nullptr;
+	bool verify_generated_columns = false;
 };
 
 //! The parser is responsible for parsing the query and converting it into a set

--- a/src/include/duckdb/parser/transformer.hpp
+++ b/src/include/duckdb/parser/transformer.hpp
@@ -17,6 +17,7 @@
 #include "duckdb/parser/parsed_data/create_info.hpp"
 #include "duckdb/parser/group_by_node.hpp"
 #include "duckdb/parser/query_node.hpp"
+#include "duckdb/parser/parser.hpp"
 
 #include "pg_definitions.hpp"
 #include "nodes/parsenodes.hpp"
@@ -36,7 +37,7 @@ class Transformer {
 	friend class StackChecker;
 
 public:
-	explicit Transformer(idx_t max_expression_depth_p);
+	explicit Transformer(ParserOptions &options);
 	explicit Transformer(Transformer *parent);
 
 	//! Transforms a Postgres parse tree into a set of SQL Statements
@@ -50,6 +51,7 @@ public:
 private:
 	Transformer *parent;
 	idx_t max_expression_depth;
+	bool verify_generated_columns;
 	//! The current prepared statement parameter index
 	idx_t prepared_statement_parameter_index = 0;
 	//! Holds window expressions defined by name. We need those when transforming the expressions referring to them.
@@ -248,6 +250,9 @@ private:
 	void TransformWindowFrame(duckdb_libpgquery::PGWindowDef *window_spec, WindowExpression *expr);
 
 	unique_ptr<SampleOptions> TransformSampleOptions(duckdb_libpgquery::PGNode *options);
+
+private:
+	void AddRandomGeneratedColumn(unordered_set<string> &columns, data_ptr_t info_p);
 
 private:
 	//! Current stack depth

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1064,6 +1064,7 @@ ParserOptions ClientContext::GetParserOptions() const {
 	options.preserve_identifier_case = ClientConfig::GetConfig(*this).preserve_identifier_case;
 	options.max_expression_depth = ClientConfig::GetConfig(*this).max_expression_depth;
 	options.extensions = &DBConfig::GetConfig(*this).parser_extensions;
+	options.verify_generated_columns = ClientConfig::GetConfig(*this).query_verification_enabled;
 	return options;
 }
 

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -20,7 +20,7 @@ Parser::Parser(ParserOptions options_p) : options(options_p) {
 }
 
 void Parser::ParseQuery(const string &query) {
-	Transformer transformer(options.max_expression_depth);
+	Transformer transformer(options);
 	{
 		PostgresParser::SetPreserveIdentifierCase(options.preserve_identifier_case);
 		PostgresParser parser;

--- a/src/parser/transform/statement/transform_create_table.cpp
+++ b/src/parser/transform/statement/transform_create_table.cpp
@@ -6,6 +6,9 @@
 #include "duckdb/catalog/catalog_entry/table_column_type.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
 
+#include <random>
+#include <iterator>
+
 namespace duckdb {
 
 string Transformer::TransformCollation(duckdb_libpgquery::PGCollateClause *collate) {
@@ -67,6 +70,52 @@ ColumnDefinition Transformer::TransformColumnDefinition(duckdb_libpgquery::PGCol
 	return ColumnDefinition(colname, target_type);
 }
 
+static std::string GenerateRandomName(idx_t size) {
+	std::random_device rd;
+	std::mt19937 gen(rd());
+	std::uniform_int_distribution<> dis(0, 15);
+
+	std::stringstream ss;
+	idx_t i;
+	ss << std::hex;
+	for (i = 0; i < size; i++) {
+		ss << dis(gen);
+	}
+	return ss.str();
+}
+
+void Transformer::AddRandomGeneratedColumn(unordered_set<string> &columns, data_ptr_t info_p) {
+	// Get the minimum size for the random column, as to not collide with any existing column
+	idx_t size = 10;
+	for (auto &column : columns) {
+		if (column.size() > size) {
+			size = column.size() + 1;
+		}
+	}
+	// Random name for the generated column ('a' to make it start with a letter)
+	auto random_name = "a" + GenerateRandomName(size);
+	auto info = (CreateTableInfo *)info_p;
+
+	std::random_device rd;
+	std::mt19937 gen(rd());
+	std::uniform_int_distribution<> dis(0, columns.size() - 1);
+
+	// The column it will reference
+	auto chosen_column = columns.begin();
+	std::advance(chosen_column, (int)dis(gen));
+
+	duckdb_libpgquery::PGColumnDef cdef;
+	cdef.colname = (char *)random_name.c_str();
+	cdef.category = duckdb_libpgquery::COL_GENERATED;
+	cdef.typeName = NULL;
+	cdef.collClause = NULL;
+
+	auto gcol_reference = make_unique_base<ParsedExpression, ColumnRefExpression>(*chosen_column);
+	auto centry = TransformColumnDefinition(&cdef);
+	centry.SetGeneratedExpression(move(gcol_reference));
+	info->columns.insert(info->columns.begin(), move(centry));
+}
+
 unique_ptr<CreateStatement> Transformer::TransformCreateTable(duckdb_libpgquery::PGNode *node) {
 	auto stmt = reinterpret_cast<duckdb_libpgquery::PGCreateStmt *>(node);
 	D_ASSERT(stmt);
@@ -96,6 +145,7 @@ unique_ptr<CreateStatement> Transformer::TransformCreateTable(duckdb_libpgquery:
 	}
 
 	idx_t column_count = 0;
+	std::unordered_set<string> column_names;
 	for (auto c = stmt->tableElts->head; c != nullptr; c = lnext(c)) {
 		auto node = reinterpret_cast<duckdb_libpgquery::PGNode *>(c->data.ptr_value);
 		switch (node->type) {
@@ -104,12 +154,15 @@ unique_ptr<CreateStatement> Transformer::TransformCreateTable(duckdb_libpgquery:
 			auto centry = TransformColumnDefinition(cdef);
 			if (cdef->constraints) {
 				for (auto constr = cdef->constraints->head; constr != nullptr; constr = constr->next) {
-					auto constraint = TransformConstraint(constr, centry, info->columns.size());
+					// Verify generated columns adds a GENERATED COLUMN at index 0, so we offset everything by 1
+					auto constraint =
+					    TransformConstraint(constr, centry, verify_generated_columns + info->columns.size());
 					if (constraint) {
 						info->constraints.push_back(move(constraint));
 					}
 				}
 			}
+			column_names.insert(centry.GetName());
 			info->columns.push_back(move(centry));
 			column_count++;
 			break;
@@ -125,6 +178,10 @@ unique_ptr<CreateStatement> Transformer::TransformCreateTable(duckdb_libpgquery:
 
 	if (!column_count) {
 		throw ParserException("Table must have at least one column!");
+	}
+	if (verify_generated_columns) {
+		// Add a single generated column to the front to test if generated columns are properly supported
+		AddRandomGeneratedColumn(column_names, (data_ptr_t)info.get());
 	}
 
 	result->info = move(info);

--- a/src/parser/transformer.cpp
+++ b/src/parser/transformer.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/parser/expression/list.hpp"
 #include "duckdb/parser/statement/list.hpp"
 #include "duckdb/parser/tableref/emptytableref.hpp"
+#include "duckdb/parser/parser.hpp"
 
 namespace duckdb {
 
@@ -20,8 +21,9 @@ StackChecker::StackChecker(StackChecker &&other) noexcept
 	other.stack_usage = 0;
 }
 
-Transformer::Transformer(idx_t max_expression_depth_p)
-    : parent(nullptr), max_expression_depth(max_expression_depth_p), stack_depth(DConstants::INVALID_INDEX) {
+Transformer::Transformer(ParserOptions &options)
+    : parent(nullptr), max_expression_depth(options.max_expression_depth),
+      verify_generated_columns(options.verify_generated_columns), stack_depth(DConstants::INVALID_INDEX) {
 }
 
 Transformer::Transformer(Transformer *parent)


### PR DESCRIPTION
This PR aims to aid in finding issues caused by the addition of generated columns.

Generated columns caused the storage index and the column index to become disjointed.
```c++
// The storage_oid is used to index columns that are physically stored, excluding generated columns.
// a INTEGER, b BOOLEAN, c GENERATED ALWAYS AS a, d VARCHAR
// 0          1          -                        2
```

Since this only becomes apparent when generated columns are involved, this causes numerous issues that are hard to spot.
So when `verify_generated_columns` is enabled (currently tied to `enable_verification`) every `CREATE TABLE` statement will add a generated column on index 0.

This is not really meant to be merged in the state it's in, but it is meant to be used.
Running the test runner (`unittest`) on this branch highlights **a lot** of issues caused by this change.

EDIT:
Maybe scrap this, there's possibly a better and much more effective solution to this