### PR TITLE
No longer disable vptr sanitizer on M1 macs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,14 +141,17 @@ elseif(${ENABLE_SANITIZER})
 endif()
 
 
-if(APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
-  if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER 14.0)
-    message(
-      WARNING
-        "Not disabling vptr sanitizer on M1 Macbook - set DISABLE_VPTR_SANITIZER manually if you run into issues with false positives in the sanitizer"
-    )
-  else()
-  set(DISABLE_VPTR_SANITIZER TRUE)
+if (${DISABLE_VPTR_SANITIZER})
+else()
+  if(APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+    if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER 14.0)
+      message(
+        WARNING
+          "Not disabling vptr sanitizer on M1 Macbook - set DISABLE_VPTR_SANITIZER manually if you run into issues with false positives in the sanitizer"
+      )
+    else()
+    set(DISABLE_VPTR_SANITIZER TRUE)
+    endif()
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,14 @@ endif()
 
 
 if(APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+  if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER 14.0)
+    message(
+      WARNING
+        "Not disabling vptr sanitizer on M1 Macbook - set DISABLE_VPTR_SANITIZER manually if you run into issues with false positives in the sanitizer"
+    )
+  else()
   set(DISABLE_VPTR_SANITIZER TRUE)
+  endif()
 endif()
 
 if(${ENABLE_UBSAN})


### PR DESCRIPTION
This was a work-around that was previously necessary as the sanitizer included with the system would trigger loads of false positives, but after upgrading to the latest version of MacOS the false positives no longer seem to occur for me. 