### PR TITLE
Fix #4356

### DIFF
--- a/src/planner/binder/statement/bind_export.cpp
+++ b/src/planner/binder/statement/bind_export.cpp
@@ -156,6 +156,13 @@ BoundStatement Binder::Bind(ExportStatement &stmt) {
 		info->schema = table->schema->name;
 		info->table = table->name;
 
+		// We can not export generated columns
+		for (auto &col : table->columns) {
+			if (!col.Generated()) {
+				info->select_list.push_back(col.GetName());
+			}
+		}
+
 		exported_data.table_name = info->table;
 		exported_data.schema_name = info->schema;
 		exported_data.file_path = info->file_path;

--- a/test/sql/export/export_generated_columns.test
+++ b/test/sql/export/export_generated_columns.test
@@ -31,6 +31,12 @@ ROLLBACK
 statement ok
 IMPORT DATABASE '__TEST_DIR__/export_generated_columns'
 
+# We can get the data we exported just now
+query II
+SELECT * FROM tbl
+----
+5	10
+
 # Generated columns can not be inserted into directly
 statement error
 INSERT INTO tbl VALUES(2,3)


### PR DESCRIPTION
Fix: #4356

I think maybe we should not export generated columns.

I found there has been a test for exporting generated columns, but it can pass.It seems that though 'IMPORT DATABASE' throws an error, it is regarded as 'statement OK'  and there is no data in the table. So I add a 'SELECT' sql to make sure that we can get the right data we have exported.