### PR TITLE
Julia API: Add load! to add a DataFrame as a table

### DIFF
--- a/tools/juliapkg/src/old_interface.jl
+++ b/tools/juliapkg/src/old_interface.jl
@@ -28,5 +28,6 @@ Load an input DataFrame `input_df` into a DuckDB table that will be named `table
 function load!(con::Connection, input_df::DataFrame, table::AbstractString, schema::String = "main")
     register_data_frame(con, input_df, "__append_df")
     DBInterface.execute(con, "CREATE TABLE \"$schema\".\"$table\" AS SELECT * FROM __append_df")
-    return unregister_data_frame(con, "__append_df")
+    unregister_data_frame(con, "__append_df")
+    return
 end

--- a/tools/juliapkg/src/old_interface.jl
+++ b/tools/juliapkg/src/old_interface.jl
@@ -19,3 +19,14 @@ end
 
 appendDataFrame(input_df::DataFrame, db::DB, table::AbstractString, schema::String = "main") =
     appendDataFrame(input_df, db.main_connection, table, schema)
+
+"""
+    DuckDB.load!(input_df::DataFrame, con, table)
+
+Load an input DataFrame `input_df` into a DuckDB table that will be named `table`.
+"""
+function load!(con::Connection, input_df::DataFrame, table::AbstractString, schema::String = "main")
+    register_data_frame(con, input_df, "__append_df")
+    DBInterface.execute(con, "CREATE TABLE \"$schema\".\"$table\" AS SELECT * FROM __append_df")
+    return unregister_data_frame(con, "__append_df")
+end


### PR DESCRIPTION
as proposed in [#4641](https://github.com/duckdb/duckdb/issues/4641), this PR adds a function `load!(con, df, table)` to add a DataFrame as a DuckDB table, mimicking the SQLite.jl API.

Compared to the existing `appendDataFrame`, I changed the `INSERT INTO` into the  `CREATE TABLE AS` also proposed in the issue to match the semantics of `load!`. Also, for `load!` I put the connection as the first argument, as the `!` convention usually indicates the first argument being mutated.

I wasn't quite sure where to put the function, so I put it where `appendDataFrame` was for now. Feel free to move things around!