### PR TITLE
aarch64 extensions

### DIFF
--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -95,8 +95,8 @@ runs:
         EXTENSION_STATIC_BUILD: ${{ inputs.static_link_build }}
         OPENSSL_ROOT_DIR: ${{ inputs.openssl_path }}
         OSX_BUILD_UNIVERSAL: ${{ inputs.osx_universal }}
-        CC: ${{ inputs.aarch64_cross_compile && 'aarch64-linux-gnu-gcc' || '' }}
-        CXX: ${{ inputs.aarch64_cross_compile && 'aarch64-linux-gnu-g++' || '' }}
+        CC: ${{ inputs.aarch64_cross_compile == 1 && 'aarch64-linux-gnu-gcc' || '' }}
+        CXX: ${{ inputs.aarch64_cross_compile == 1 && 'aarch64-linux-gnu-g++' || '' }}
 
       run: |
         ls -al

--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -110,7 +110,7 @@ runs:
       shell: bash
       run: |
         mkdir -p build/release/extension/out_of_tree
-        ${{ inputs.python_name}} scripts/build_out_of_tree_extensions.py ${{ inputs.aarch64_cross_compile && '--aarch64-cc' || '' }}
+        ${{ inputs.python_name}} scripts/build_out_of_tree_extensions.py ${{ inputs.aarch64_cross_compile == 1 && '--aarch64-cc' || '' }}
 
     - name: Run post-install scripts
       if: ${{ inputs.post_install != '' }}

--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -69,6 +69,10 @@ inputs:
   osx_universal:
     description: 'Build Universal Binary for OSX'
     default: 0
+  aarch64_cross_compile:
+    description: 'Enable Linux aarch64 cross-compiling'
+    default: 0
+
 runs:
   using: "composite"
   steps:
@@ -91,6 +95,8 @@ runs:
         EXTENSION_STATIC_BUILD: ${{ inputs.static_link_build }}
         OPENSSL_ROOT_DIR: ${{ inputs.openssl_path }}
         OSX_BUILD_UNIVERSAL: ${{ inputs.osx_universal }}
+        CC: ${{ inputs.aarch64_cross_compile && 'aarch64-linux-gnu-gcc' || '' }}
+        CXX: ${{ inputs.aarch64_cross_compile && 'aarch64-linux-gnu-g++' || '' }}
 
       run: |
         ls -al
@@ -104,7 +110,7 @@ runs:
       shell: bash
       run: |
         mkdir -p build/release/extension/out_of_tree
-        ${{ inputs.python_name}} scripts/build_out_of_tree_extensions.py
+        ${{ inputs.python_name}} scripts/build_out_of_tree_extensions.py ${{ inputs.aarch64_cross_compile && '--aarch64-cc' || '' }}
 
     - name: Run post-install scripts
       if: ${{ inputs.post_install != '' }}

--- a/.github/actions/ubuntu_16_setup/action.yml
+++ b/.github/actions/ubuntu_16_setup/action.yml
@@ -85,7 +85,7 @@ runs:
         mkdir -p build/openssl
         cd build/openssl
         mkdir sources build
-        curl https://www.openssl.org/source/openssl-3.0.5.tar.gz | tar xv -C sources --strip-components 1
+        curl https://www.openssl.org/source/openssl-3.0.5.tar.gz | tar zxv -C sources --strip-components 1
         export OPENSSL_ROOT_DIR=`pwd`/build
         cd sources
         export CC="aarch64-linux-gnu-gcc"

--- a/.github/actions/ubuntu_16_setup/action.yml
+++ b/.github/actions/ubuntu_16_setup/action.yml
@@ -7,6 +7,9 @@ inputs:
   python:
     description: 'Python'
     default: 1
+  aarch64_cross_compile:
+    description: 'Enable Linux aarch64 cross-compiling'
+    default: 0
 runs:
   using: "composite"
   steps:
@@ -59,6 +62,9 @@ runs:
     - name: Install OpenSSL 1.1.1
       if: ${{ inputs.openssl }} == 1
       shell: bash
+      env:
+        CC: ${{ inputs.aarch64_cross_compile == 1 && 'aarch64-linux-gnu-gcc' || '' }}
+        CXX: ${{ inputs.aarch64_cross_compile == 1 && 'aarch64-linux-gnu-g++' || '' }}
       run: |
         wget https://www.openssl.org/source/openssl-1.1.1c.tar.gz
         tar -xf openssl-1.1.1c.tar.gz

--- a/.github/actions/ubuntu_16_setup/action.yml
+++ b/.github/actions/ubuntu_16_setup/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: 'Python'
     default: 1
   aarch64_cross_compile:
-    description: 'Enable Linux aarch64 cross-compiling'
+    description: 'Install dependencies for aarch64 cross-compiling'
     default: 0
 runs:
   using: "composite"
@@ -21,6 +21,12 @@ runs:
         add-apt-repository ppa:git-core/ppa
         apt-get update -y -qq
         apt-get install -y -qq ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev
+
+    - name: Install
+      shell: bash
+      if: ${{ inputs.aarch64_cross_compile == 1 }}
+      run: |
+        apt-get install -y -qq gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
     - name: Install Git 2.18.5
       shell: bash
@@ -60,11 +66,8 @@ runs:
         cmake --version
 
     - name: Install OpenSSL 1.1.1
-      if: ${{ inputs.openssl }} == 1
+      if: ${{ inputs.openssl == 1 && inputs.aarch64_cross_compile == 0}}
       shell: bash
-      env:
-        CC: ${{ inputs.aarch64_cross_compile == 1 && 'aarch64-linux-gnu-gcc' || '' }}
-        CXX: ${{ inputs.aarch64_cross_compile == 1 && 'aarch64-linux-gnu-g++' || '' }}
       run: |
         wget https://www.openssl.org/source/openssl-1.1.1c.tar.gz
         tar -xf openssl-1.1.1c.tar.gz
@@ -75,6 +78,21 @@ runs:
         echo "/usr/local/ssl/lib" > /etc/ld.so.conf.d/openssl-1.1.1c.conf
         ldconfig -v
 
+    - name: Install OpenSSL for Cross compiling
+      if: ${{ inputs.openssl == 1 && inputs.aarch64_cross_compile == 1}}
+      shell: bash
+      run: |
+        mkdir -p build/openssl
+        cd build/openssl
+        mkdir sources build
+        curl https://www.openssl.org/source/openssl-3.0.5.tar.gz | tar xv -C sources --strip-components 1
+        export OPENSSL_ROOT_DIR=`pwd`/build
+        cd sources
+        export CC="aarch64-linux-gnu-gcc"
+        perl ./Configure --prefix=$OPENSSL_ROOT_DIR linux-aarch64 no-asm
+        make -j
+        make install_sw
+
     - name: Version Check
       shell: bash
       run: |
@@ -82,4 +100,3 @@ runs:
         python3.7 --version
         git --version
         git log -1 --format=%h
-

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -191,7 +191,7 @@ jobs:
     name: Linux Extensions (AARCH64)
     runs-on: ubuntu-latest
     container: ubuntu:18.04 # cross compiler not available in 16
-    needs: linux-release-64
+#    needs: linux-release-64
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -201,19 +201,14 @@ jobs:
       - uses: ./.github/actions/ubuntu_16_setup
         with:
           openssl: 1
-
-      - name: Install Stuff
-        shell: bash
-        run: |
-          apt-get update -y -qq
-          apt-get install -y -qq gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          aarch64_cross_compile: 1
 
       - uses: ./.github/actions/build_extensions
         with:
           post_install: rm build/release/src/libduckdb*
           deploy_as: linux_aarch64
           static_link_build: 1
-          out_of_tree_ext: 1
+          out_of_tree_ext: 0 # TODO: currently postgres scanner does not like to be cross compiled
           s3_id: ${{ secrets.S3_ID }}
           s3_key: ${{ secrets.S3_KEY }}
           signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -95,7 +95,6 @@ jobs:
    name: Linux (AARCH64)
    runs-on: ubuntu-latest
    needs: linux-release-64
-
    container: ubuntu:18.04 # cross compiler not available in 16
    env:
      GEN: ninja
@@ -187,6 +186,45 @@ jobs:
         name: linux-extensions-64
         path: |
           build/release/extension/*/*.duckdb_extension
+
+ linux-extensions-64-aarch64:
+    name: Linux Extensions (AARCH64)
+    runs-on: ubuntu-latest
+    container: ubuntu:18.04 # cross compiler not available in 16
+    needs: linux-release-64
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/ubuntu_16_setup
+        with:
+          openssl: 1
+
+      - name: Install Stuff
+        shell: bash
+        run: |
+          apt-get update -y -qq
+          apt-get install -y -qq gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      - uses: ./.github/actions/build_extensions
+        with:
+          post_install: rm build/release/src/libduckdb*
+          deploy_as: linux_aarch64
+          static_link_build: 1
+          out_of_tree_ext: 1
+          s3_id: ${{ secrets.S3_ID }}
+          s3_key: ${{ secrets.S3_KEY }}
+          signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
+          aarch64_cross_compile: 1
+          run_tests: 0 # Cannot run tests here due to cross-compiling
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: linux-extensions-64-aarch64
+          path: |
+            build/release/extension/*/*.duckdb_extension
 
  check-load-install-extensions:
     name: Checks extension functions

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -203,11 +203,19 @@ jobs:
           openssl: 1
           aarch64_cross_compile: 1
 
+      - name: Configure OpenSSL path
+        shell: bash
+        run: |
+          export OPENSSL_ROOT_DIR=`pwd`/build/openssl/build
+          echo "OPENSSL_ROOT_DIR=$OPENSSL_ROOT_DIR" >> $GITHUB_ENV
+
       - uses: ./.github/actions/build_extensions
         with:
+          openssl_path: ${{ env.OPENSSL_ROOT_DIR }}
           post_install: rm build/release/src/libduckdb*
           deploy_as: linux_aarch64
           static_link_build: 1
+          treat_warn_as_error: 0
           out_of_tree_ext: 0 # TODO: currently postgres scanner does not like to be cross compiled
           s3_id: ${{ secrets.S3_ID }}
           s3_key: ${{ secrets.S3_KEY }}

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -191,7 +191,7 @@ jobs:
     name: Linux Extensions (AARCH64)
     runs-on: ubuntu-latest
     container: ubuntu:18.04 # cross compiler not available in 16
-#    needs: linux-release-64
+    needs: linux-release-64
 
     steps:
       - uses: actions/checkout@v3

--- a/scripts/build_out_of_tree_extensions.py
+++ b/scripts/build_out_of_tree_extensions.py
@@ -12,7 +12,7 @@ parser = argparse.ArgumentParser(description='Builds out-of-tree extensions for 
 
 parser.add_argument('--extensions', action='store',
                     help='CSV file with DuckDB extensions to build', default="extensions.csv")
-
+parser.add_argument('--aarch64-cc', help='Enables Linux aarch64 crosscompile build', action='store_true')
 
 args = parser.parse_args()
 
@@ -62,5 +62,8 @@ for task in tasks:
         os.chdir(basedir)
         os.environ['BUILD_OUT_OF_TREE_EXTENSION'] = clonedir
         print(f"Building extension \"{task['name']}\" from URL \"{task['url']}\" at commit \"{task['commit']}\" at clonedir \"{clonedir}\"")
+        if (args.aarch64_cc):
+            os.environ['CC'] = "aarch64-linux-gnu-gcc"
+            os.environ['CXX'] = "aarch64-linux-gnu-g++"
         exec('make')
 print("done")


### PR DESCRIPTION
This pr adds a build step to CI for cross compiling the extensions for linux aarch64. Out of tree extensions are not yet included, will look at those tomorrow.