### PR TITLE
Faster hive part filters

### DIFF
--- a/extension/parquet/parquet-extension.cpp
+++ b/extension/parquet/parquet-extension.cpp
@@ -491,21 +491,23 @@ public:
 	static void ParquetComplexFilterPushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data_p,
 	                                         vector<unique_ptr<Expression>> &filters) {
 		auto data = (ParquetReadBindData *)bind_data_p;
-		auto initial_filename = data->files[0];
+		if (!data->files.empty()) {
+			auto initial_filename = data->files[0];
 
-		if (data->parquet_options.hive_partitioning || data->parquet_options.filename) {
-			unordered_map<string, column_t> column_map;
-			for (idx_t i = 0; i < get.column_ids.size(); i++) {
-				column_map.insert({get.names[get.column_ids[i]], i});
-			}
+			if (data->parquet_options.hive_partitioning || data->parquet_options.filename) {
+				unordered_map<string, column_t> column_map;
+				for (idx_t i = 0; i < get.column_ids.size(); i++) {
+					column_map.insert({get.names[get.column_ids[i]], i});
+				}
 
-			HivePartitioning::ApplyFiltersToFileList(data->files, filters, column_map, get.table_index,
-			                                         data->parquet_options.hive_partitioning,
-			                                         data->parquet_options.filename);
+				HivePartitioning::ApplyFiltersToFileList(data->files, filters, column_map, get.table_index,
+				                                         data->parquet_options.hive_partitioning,
+				                                         data->parquet_options.filename);
 
-			if (data->files.empty() || initial_filename != data->files[0]) {
-				// Remove initial reader in case the first file gets filtered out
-				data->initial_reader.reset();
+				if (data->files.empty() || initial_filename != data->files[0]) {
+					// Remove initial reader in case the first file gets filtered out
+					data->initial_reader.reset();
+				}
 			}
 		}
 	}

--- a/src/common/hive_partitioning.cpp
+++ b/src/common/hive_partitioning.cpp
@@ -10,12 +10,10 @@
 
 namespace duckdb {
 
-// use precompiled pattern
-const duckdb_re2::RE2 HivePartitioning::compiled_regex(("[\\/\\\\]([^\\/\\?\\\\]+)=([^\\/\\n\\?\\\\]+)"));
-
 static unordered_map<column_t, string> GetKnownColumnValues(string &filename,
                                                             unordered_map<string, column_t> &column_map,
-                                                            bool filename_col, bool hive_partition_cols) {
+                                                            duckdb_re2::RE2 &compiled_regex, bool filename_col,
+                                                            bool hive_partition_cols) {
 	unordered_map<column_t, string> result;
 
 	if (filename_col) {
@@ -26,7 +24,7 @@ static unordered_map<column_t, string> GetKnownColumnValues(string &filename,
 	}
 
 	if (hive_partition_cols) {
-		auto partitions = HivePartitioning::Parse(filename);
+		auto partitions = HivePartitioning::Parse(filename, compiled_regex);
 		for (auto &partition : partitions) {
 			auto lookup_column_id = column_map.find(partition.first);
 			if (lookup_column_id != column_map.end()) {
@@ -64,16 +62,23 @@ static void ConvertKnownColRefToConstants(unique_ptr<Expression> &expr,
 // 	- s3://bucket/var1=value1/bla/bla/var2=value2
 //  - http(s)://domain(:port)/lala/kasdl/var1=value1/?not-a-var=not-a-value
 //  - folder/folder/folder/../var1=value1/etc/.//var2=value2
-std::map<string, string> HivePartitioning::Parse(string &filename) {
+const string HivePartitioning::REGEX_STRING = "[\\/\\\\]([^\\/\\?\\\\]+)=([^\\/\\n\\?\\\\]+)";
+
+std::map<string, string> HivePartitioning::Parse(string &filename, duckdb_re2::RE2 &regex) {
 	std::map<string, string> result;
 	duckdb_re2::StringPiece input(filename); // Wrap a StringPiece around it
 
 	string var;
 	string value;
-	while (RE2::FindAndConsume(&input, compiled_regex, &var, &value)) {
+	while (RE2::FindAndConsume(&input, regex, &var, &value)) {
 		result.insert(std::pair<string, string>(var, value));
 	}
 	return result;
+}
+
+std::map<string, string> HivePartitioning::Parse(string &filename) {
+	duckdb_re2::RE2 regex(REGEX_STRING);
+	return Parse(filename, regex);
 }
 
 // TODO: this can still be improved by removing the parts of filter expressions that are true for all remaining files.
@@ -83,6 +88,7 @@ void HivePartitioning::ApplyFiltersToFileList(vector<string> &files, vector<uniq
                                               bool hive_enabled, bool filename_enabled) {
 	vector<string> pruned_files;
 	vector<unique_ptr<Expression>> pruned_filters;
+	duckdb_re2::RE2 regex(REGEX_STRING);
 
 	if ((!filename_enabled && !hive_enabled) || filters.empty()) {
 		return;
@@ -91,7 +97,7 @@ void HivePartitioning::ApplyFiltersToFileList(vector<string> &files, vector<uniq
 	for (idx_t i = 0; i < files.size(); i++) {
 		auto &file = files[i];
 		bool should_prune_file = false;
-		auto known_values = GetKnownColumnValues(file, column_map, filename_enabled, hive_enabled);
+		auto known_values = GetKnownColumnValues(file, column_map, regex, filename_enabled, hive_enabled);
 
 		FilterCombiner combiner;
 		for (auto &filter : filters) {

--- a/src/common/hive_partitioning.cpp
+++ b/src/common/hive_partitioning.cpp
@@ -10,6 +10,9 @@
 
 namespace duckdb {
 
+// use precompiled pattern
+const duckdb_re2::RE2 HivePartitioning::compiled_regex(("[\\/\\\\]([^\\/\\?\\\\]+)=([^\\/\\n\\?\\\\]+)"));
+
 static unordered_map<column_t, string> GetKnownColumnValues(string &filename,
                                                             unordered_map<string, column_t> &column_map,
                                                             bool filename_col, bool hive_partition_cols) {
@@ -63,13 +66,11 @@ static void ConvertKnownColRefToConstants(unique_ptr<Expression> &expr,
 //  - folder/folder/folder/../var1=value1/etc/.//var2=value2
 std::map<string, string> HivePartitioning::Parse(string &filename) {
 	std::map<string, string> result;
-
-	string regex = "[\\/\\\\]([^\\/\\?\\\\]+)=([^\\/\\n\\?\\\\]+)";
 	duckdb_re2::StringPiece input(filename); // Wrap a StringPiece around it
 
 	string var;
 	string value;
-	while (RE2::FindAndConsume(&input, regex, &var, &value)) {
+	while (RE2::FindAndConsume(&input, compiled_regex, &var, &value)) {
 		result.insert(std::pair<string, string>(var, value));
 	}
 	return result;

--- a/src/include/duckdb/common/hive_partitioning.hpp
+++ b/src/include/duckdb/common/hive_partitioning.hpp
@@ -21,6 +21,7 @@ class HivePartitioning {
 public:
 	//! Parse a filename that follows the hive partitioning scheme
 	DUCKDB_API static std::map<string, string> Parse(string &filename);
+	DUCKDB_API static std::map<string, string> Parse(string &filename, duckdb_re2::RE2 &regex);
 	//! Prunes a list of filenames based on a set of filters, can be used by TableFunctions in the
 	//! pushdown_complex_filter function to skip files with filename-based filters. Also removes the filters that always
 	//! evaluate to true.
@@ -28,7 +29,8 @@ public:
 	                                              unordered_map<string, column_t> &column_map, idx_t table_index,
 	                                              bool hive_enabled, bool filename_enabled);
 
-	static const duckdb_re2::RE2 compiled_regex;
+	//! Returns the compiled regex pattern to match hive partitions
+	DUCKDB_API static const string REGEX_STRING;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/hive_partitioning.hpp
+++ b/src/include/duckdb/common/hive_partitioning.hpp
@@ -27,6 +27,8 @@ public:
 	DUCKDB_API static void ApplyFiltersToFileList(vector<string> &files, vector<unique_ptr<Expression>> &filters,
 	                                              unordered_map<string, column_t> &column_map, idx_t table_index,
 	                                              bool hive_enabled, bool filename_enabled);
+
+	static const duckdb_re2::RE2 compiled_regex;
 };
 
 } // namespace duckdb


### PR DESCRIPTION
Did some profiling and found that compiling the regex was done for every file and is actually quite expensive. Precompiling the regex gains quite a big speedup. To benchmark this i replicated the use case in issue https://github.com/duckdb/duckdb/issues/4339, with 120 x 30 partitions using the tpch sf0.1 lineitem table in each folder. 

Original:
```
SELECT COUNT(*) FROM parquet_scan('./hive_test_data/*/*/*.parquet', HIVE_PARTITIONING=1) WHERE country='belize' AND date='2106-01-01';
Run Time (s): real 0.315 user 0.233535 sys 0.081209
```

This PR
```
SELECT COUNT(*) FROM parquet_scan('./hive_test_data/*/*/*.parquet', HIVE_PARTITIONING=1) WHERE country='belize' AND date='2106-01-01';
Run Time (s): real 0.109 user 0.034185 sys 0.075329
```

Baseline with single file queried
```
SELECT COUNT(*) FROM parquet_scan('./hive_test_data2/country=belize/date=2106-01-01/*.parquet', HIVE_PARTITIONING=1);
Run Time (s): real 0.002 user 0.001802 sys 0.000728
```

Note that there's still quite a bit of overhead, most of which is due to the fact that using the hive partition filters does require to get a full listing from the filesystem. This may be improved further though, will look at it tomorrow.

