### PR TITLE
enable out-of-tree extensions for aarch64

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -216,7 +216,7 @@ jobs:
           deploy_as: linux_aarch64
           static_link_build: 1
           treat_warn_as_error: 0
-          out_of_tree_ext: 0 # TODO: currently postgres scanner does not like to be cross compiled
+          out_of_tree_ext: 1
           s3_id: ${{ secrets.S3_ID }}
           s3_key: ${{ secrets.S3_KEY }}
           signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}

--- a/extensions.csv
+++ b/extensions.csv
@@ -9,5 +9,5 @@ tpcds,,,true
 tpch,,,true
 visualizer,,,true
 sqlite_scanner,https://github.com/duckdblabs/sqlite_scanner,ddd342dadf92ecad8a9f4d215a9c56b9731933d2,true
-postgres_scanner,https://github.com/duckdblabs/postgresscanner,37231bf985fb825dccf79aad94ee0630dae2d7c6,true
+postgres_scanner,https://github.com/duckdblabs/postgresscanner,d12c21e2059944b289f0582df18e44f346c251cb,true
 substrait,https://github.com/duckdblabs/substrait,43a77c0c7a1f4da52bfdfc4430f74d495dc59195,false


### PR DESCRIPTION
postgres scanner now detects aarch64 cross compile and should pass correct flag to postgres configure script