### PR TITLE
Fix #4747: Handle pandas num categories between 128 and 256

### DIFF
--- a/tools/pythonpkg/src/array_wrapper.cpp
+++ b/tools/pythonpkg/src/array_wrapper.cpp
@@ -322,7 +322,7 @@ static bool ConvertColumnCategoricalTemplate(idx_t target_offset, data_ptr_t tar
 			idx_t src_idx = idata.sel->get_index(i);
 			idx_t offset = target_offset + i;
 			if (!idata.validity.RowIsValidUnsafe(src_idx)) {
-				out_ptr[offset] = duckdb_py_convert::RegularConvert::template ConvertValue<DUCKDB_T, NUMPY_T>(-1);
+				out_ptr[offset] = static_cast<NUMPY_T>(-1);
 			} else {
 				out_ptr[offset] =
 				    duckdb_py_convert::RegularConvert::template ConvertValue<DUCKDB_T, NUMPY_T>(src_ptr[src_idx]);

--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_category.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_category.py
@@ -82,6 +82,9 @@ class TestCategory(object):
     def test_category_string_null(self, duckdb_cursor):
         check_category_equal(['foo','bla',None,'zoo', 'foo', 'foo',None, 'bla'])
 
+    def test_category_string_null_bug_4747(self, duckdb_cursor):
+        check_category_equal([str(i) for i in range(160)] + [None])
+
     def test_categorical_fetchall(self, duckdb_cursor):
         df_in = pd.DataFrame({
         'x': pd.Categorical(['foo','bla',None,'zoo', 'foo', 'foo',None, 'bla'], ordered=True),


### PR DESCRIPTION
`NULL` value of `-1` is not compatible with `uint` types used in duckdb enum array while converting to numpy category array with signed `int` dtypes, so we directly assign to `NUMPY_T` instead of casting from `DUCKDB_T` (unsigned) to `NUMPY_T`