### PR TITLE
Fix #3595: avoid using system hash for floating point values

### DIFF
--- a/benchmark/tpch/join/floating_point_join.benchmark
+++ b/benchmark/tpch/join/floating_point_join.benchmark
@@ -1,0 +1,20 @@
+# name: benchmark/tpch/join/floating_point_join.benchmark
+# description: COUNT aggregate over join on double keys
+# group: [join]
+
+name Join Double Keys
+group join
+subgroup tpch
+
+require tpch
+
+load
+CALL dbgen(sf=1, suffix='_normal');
+CREATE TABLE lineitem AS SELECT * REPLACE (l_orderkey::DOUBLE AS l_orderkey) FROM lineitem_normal;
+CREATE TABLE orders AS SELECT * REPLACE (o_orderkey::DOUBLE AS o_orderkey) FROM orders_normal;
+
+run
+SELECT COUNT(*) from lineitem join orders on (l_orderkey=o_orderkey);
+
+result I
+6001215

--- a/benchmark/tpch/join/integer_join.benchmark
+++ b/benchmark/tpch/join/integer_join.benchmark
@@ -1,0 +1,20 @@
+# name: benchmark/tpch/join/integer_join.benchmark
+# description: COUNT aggregate over join on integer keys
+# group: [join]
+
+name Join Integer Keys
+group join
+subgroup tpch
+
+require tpch
+
+cache tpch_sf1
+
+load
+CALL dbgen(sf=1);
+
+run
+SELECT COUNT(*) from lineitem join orders on (l_orderkey=o_orderkey);
+
+result I
+6001215

--- a/src/common/types/hash.cpp
+++ b/src/common/types/hash.cpp
@@ -24,12 +24,16 @@ hash_t Hash(hugeint_t val) {
 
 template <>
 hash_t Hash(float val) {
-	return std::hash<float> {}(val);
+	static_assert(sizeof(float) == sizeof(uint32_t), "");
+	uint32_t uval = *((uint32_t *)&val);
+	return murmurhash64(uval);
 }
 
 template <>
 hash_t Hash(double val) {
-	return std::hash<double> {}(val);
+	static_assert(sizeof(double) == sizeof(uint64_t), "");
+	uint64_t uval = *((uint64_t *)&val);
+	return murmurhash64(uval);
 }
 
 template <>

--- a/test/sql/tpch/tpch_floating_point_join.test_slow
+++ b/test/sql/tpch/tpch_floating_point_join.test_slow
@@ -1,0 +1,35 @@
+# name: test/sql/tpch/tpch_floating_point_join.test_slow
+# description: Join using floating point keys
+# group: [tpch]
+
+require tpch
+
+statement ok
+CALL dbgen(sf=0.1, suffix='_normal');
+
+statement ok
+CREATE TABLE lineitem_flt AS SELECT * REPLACE (l_orderkey::DOUBLE AS l_orderkey) FROM lineitem_normal;
+
+statement ok
+CREATE TABLE orders_flt AS SELECT * REPLACE (o_orderkey::DOUBLE AS o_orderkey) FROM orders_normal;
+
+statement ok
+CREATE TABLE lineitem_dbl AS SELECT * REPLACE (l_orderkey::DOUBLE AS l_orderkey) FROM lineitem_normal;
+
+statement ok
+CREATE TABLE orders_dbl AS SELECT * REPLACE (o_orderkey::DOUBLE AS o_orderkey) FROM orders_normal;
+
+query I
+SELECT COUNT(*) from lineitem_normal join orders_normal on (l_orderkey=o_orderkey);
+----
+600572
+
+query I
+SELECT COUNT(*) from lineitem_dbl join orders_dbl on (l_orderkey=o_orderkey);
+----
+600572
+
+query I
+SELECT COUNT(*) from lineitem_flt join orders_flt on (l_orderkey=o_orderkey);
+----
+600572


### PR DESCRIPTION
Fixes #3595

After investigating more, it turns out that the default `std::hash` that ships on M1 macbooks results in many unnecessary hash collisions, which causes joins on floating point values to become very slow.

This PR moves away from using the systems' floating point hash to using our own floating point hash by reinterpreting the bytes of floats and doubles as uint32 and uint64 values respectively, which fixes the issue at least on my M1 Macbook.