### PR TITLE
Fix ART

### DIFF
--- a/src/execution/index/art/iterator.cpp
+++ b/src/execution/index/art/iterator.cpp
@@ -151,6 +151,7 @@ void Iterator::PopNode() {
 	auto cur_node = nodes.top();
 	idx_t elements_to_pop = cur_node.node->prefix.Size() + (nodes.size() != 1);
 	cur_key.Pop(elements_to_pop);
+	nodes.pop();
 }
 
 bool Iterator::Next() {

--- a/src/execution/index/art/iterator.cpp
+++ b/src/execution/index/art/iterator.cpp
@@ -241,11 +241,10 @@ bool Iterator::LowerBound(Node *node, Key &key, bool inclusive) {
 			}
 			// Case1: When the ART has only one leaf node, the Next() will return false
 			// Case2: This means the previous node prefix(if any) + a_key(one element of of key array of previous node)
-			//         + leaf prefix(if any) == key[q..=w..=e]
-			// But key[e+1..=z] is not checked.
-			// One fact is key[w] is alawys equal to a_key
-			// and the next element of key array of previous node is always > a_key
-			// So we just call Next() once.
+			// == key[q..=w].
+			// But key[w+1..=z] maybe greater than leaf node prefix.
+			// One fact is key[w] is alawys equal to a_key and the next element
+			// of key array of previous node is always > a_key So we just call Next() once.
 
 			return Next();
 		}

--- a/src/execution/index/art/iterator.cpp
+++ b/src/execution/index/art/iterator.cpp
@@ -204,7 +204,7 @@ bool Iterator::LowerBound(Node *node, Key &key, bool inclusive) {
 		for (idx_t i = 0; i < top.node->prefix.Size(); i++) {
 			cur_key.Push(top.node->prefix[i]);
 		}
-        // greater case: find leftmost leaf node directly
+		// greater case: find leftmost leaf node directly
 		if (!equal) {
 			while (node->type != NodeType::NLeaf) {
 				auto min_pos = node->GetMin();
@@ -254,7 +254,7 @@ bool Iterator::LowerBound(Node *node, Key &key, bool inclusive) {
 			}
 			return false;
 		}
-        // equal case:
+		// equal case:
 		uint32_t mismatch_pos = node->prefix.KeyMismatchPosition(key, depth);
 		if (mismatch_pos != node->prefix.Size()) {
 			if (node->prefix[mismatch_pos] < key[depth + mismatch_pos]) {
@@ -275,8 +275,8 @@ bool Iterator::LowerBound(Node *node, Key &key, bool inclusive) {
 		depth += node->prefix.Size();
 
 		top.pos = node->GetChildGreaterEqual(key[depth], equal);
-        // The maximum key byte of the current node is less than the key
-        // So fall back to the previous node
+		// The maximum key byte of the current node is less than the key
+		// So fall back to the previous node
 		if (top.pos == DConstants::INVALID_INDEX) {
 			auto cur_node = top.node;
 			idx_t elements_to_pop = cur_node->prefix.Size() + (nodes.size() != 1);

--- a/src/execution/index/art/iterator.cpp
+++ b/src/execution/index/art/iterator.cpp
@@ -240,11 +240,11 @@ bool Iterator::LowerBound(Node *node, Key &key, bool inclusive) {
 				return true;
 			}
 			// Case1: When the ART has only one leaf node, the Next() will return false
-			// Case2: This means the previous node prefix(if any) + a_key(one element of previous node key arrary)
+			// Case2: This means the previous node prefix(if any) + a_key(one element of of key array of previous node)
 			//         + leaf prefix(if any) == key[q..=w..=e]
 			// But key[e+1..=z] is not checked.
 			// One fact is key[w] is alawys equal to a_key
-			// and the next element of previous node key array is always > a_key
+			// and the next element of key array of previous node is always > a_key
 			// So we just call Next() once.
 
 			return Next();

--- a/src/execution/index/art/iterator.cpp
+++ b/src/execution/index/art/iterator.cpp
@@ -239,22 +239,15 @@ bool Iterator::LowerBound(Node *node, Key &key, bool inclusive) {
 			if (cur_key > key) {
 				return true;
 			}
-			// Leaf is lower than key
-			// Check if next leaf is still lower than key
-			while (Next()) {
-				if (cur_key == key) {
-					// if it's not inclusive check if there is a next leaf
-					if (!inclusive && !Next()) {
-						return false;
-					} else {
-						return true;
-					}
-				} else if (cur_key > key) {
-					// if it's not inclusive check if there is a next leaf
-					return true;
-				}
-			}
-			return false;
+			// Case1: When the ART has only one leaf node, the Next() will return false
+			// Case2: This means the previous node prefix(if any) + a_key(one element of previous node key arrary)
+			//         + leaf prefix(if any) == key[q..=w..=e]
+			// But key[e+1..=z] is not checked.
+			// One fact is key[w] is alawys equal to a_key
+			// and the next element of previous node key array is always > a_key
+			// So we just call Next() once.
+
+			return Next();
 		}
 		// equal case:
 		uint32_t mismatch_pos = node->prefix.KeyMismatchPosition(key, depth);

--- a/src/execution/index/art/node16.cpp
+++ b/src/execution/index/art/node16.cpp
@@ -31,7 +31,7 @@ idx_t Node16::GetChildGreaterEqual(uint8_t k, bool &equal) {
 			return pos;
 		}
 	}
-	return Node::GetChildGreaterEqual(k, equal);
+	return DConstants::INVALID_INDEX;
 }
 
 idx_t Node16::GetNextPos(idx_t pos) {

--- a/src/execution/index/art/node4.cpp
+++ b/src/execution/index/art/node4.cpp
@@ -33,7 +33,7 @@ idx_t Node4::GetChildGreaterEqual(uint8_t k, bool &equal) {
 			return pos;
 		}
 	}
-	return Node::GetChildGreaterEqual(k, equal);
+	return DConstants::INVALID_INDEX;
 }
 
 idx_t Node4::GetMin() {

--- a/src/execution/index/art/node48.cpp
+++ b/src/execution/index/art/node48.cpp
@@ -29,7 +29,7 @@ idx_t Node48::GetChildGreaterEqual(uint8_t k, bool &equal) {
 			return pos;
 		}
 	}
-	return Node::GetChildGreaterEqual(k, equal);
+	return DConstants::INVALID_INDEX;
 }
 
 idx_t Node48::GetNextPos(idx_t pos) {

--- a/src/include/duckdb/execution/index/art/iterator.hpp
+++ b/src/include/duckdb/execution/index/art/iterator.hpp
@@ -7,9 +7,9 @@
 //===----------------------------------------------------------------------===//
 #pragma once
 
-#include "duckdb/execution/index/art/node.hpp"
 #include "duckdb/common/stack.hpp"
 #include "duckdb/execution/index/art/leaf.hpp"
+#include "duckdb/execution/index/art/node.hpp"
 
 namespace duckdb {
 
@@ -66,5 +66,7 @@ private:
 	bool Next();
 	//! Push part of the key to cur_key
 	void PushKey(Node *node, uint16_t pos);
+	//! Pop node
+	void PopNode();
 };
 } // namespace duckdb

--- a/src/include/duckdb/execution/index/art/node.hpp
+++ b/src/include/duckdb/execution/index/art/node.hpp
@@ -55,7 +55,7 @@ public:
 	//! Get the position of the first child that is greater or equal to the specific byte, or DConstants::INVALID_INDEX
 	//! if there are no children matching the criteria
 	virtual idx_t GetChildGreaterEqual(uint8_t k, bool &equal) {
-		throw InternalException("Unimplemented GetChildGreaterEqual for ARTNode");
+		return DConstants::INVALID_INDEX;
 	}
 	//! Get the position of the biggest element in node
 	virtual idx_t GetMin();

--- a/src/include/duckdb/execution/index/art/node.hpp
+++ b/src/include/duckdb/execution/index/art/node.hpp
@@ -55,7 +55,7 @@ public:
 	//! Get the position of the first child that is greater or equal to the specific byte, or DConstants::INVALID_INDEX
 	//! if there are no children matching the criteria
 	virtual idx_t GetChildGreaterEqual(uint8_t k, bool &equal) {
-		return DConstants::INVALID_INDEX;
+		throw InternalException("Unimplemented GetChildGreaterEqual for ARTNode");
 	}
 	//! Get the position of the biggest element in node
 	virtual idx_t GetMin();

--- a/test/sql/index/art/test_art_index_range_scan.test
+++ b/test/sql/index/art/test_art_index_range_scan.test
@@ -25,3 +25,65 @@ query I
 SELECT x FROM test WHERE x > 'abce';
 ----
 def
+
+statement ok
+DROP TABLE test;
+
+statement ok
+CREATE TABLE test (x VARCHAR PRIMARY KEY);
+
+statement ok
+INSERT INTO test VALUES ('abcd'), ('abde');
+
+query I
+SELECT x FROM test WHERE x > 'abce';
+----
+abde
+
+statement ok
+DROP TABLE test;
+
+statement ok
+CREATE TABLE test (x USMALLINT PRIMARY KEY);
+
+# node 48
+statement ok
+INSERT INTO test SELECT i FROM range(1, 20) tbl(i);
+
+query I
+SELECT x FROM test WHERE x > 20;
+----
+
+statement ok
+INSERT INTO test VALUES (256);
+
+query I
+SELECT x FROM test WHERE x > 20;
+----
+256
+
+statement ok
+DROP TABLE test;
+
+statement ok
+CREATE TABLE test (x USMALLINT PRIMARY KEY);
+
+# node 256
+statement ok
+INSERT INTO test SELECT i FROM range(1, 135) tbl(i);
+
+query I
+SELECT x FROM test WHERE x > 135;
+----
+
+statement ok
+INSERT INTO test VALUES (256), (257);
+
+query I
+SELECT x FROM test WHERE x > 135;
+----
+256
+257
+
+statement ok
+DROP TABLE test;

--- a/test/sql/index/art/test_art_index_range_scan.test
+++ b/test/sql/index/art/test_art_index_range_scan.test
@@ -1,0 +1,27 @@
+# name: test/sql/index/art/test_art_index_range_scan.test
+# description: Test ART index scan
+# group: [art]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE test (x VARCHAR PRIMARY KEY);
+
+statement ok
+INSERT INTO test VALUES ('abc');
+
+statement ok
+INSERT INTO test VALUES ('def');
+
+query I
+SELECT * FROM test WHERE x > 'z';
+----
+
+statement ok
+INSERT INTO test VALUES ('abcd');
+
+query I
+SELECT x FROM test WHERE x > 'abce';
+----
+def


### PR DESCRIPTION
The previous implementation had parts of the logic that were never executed.

The result is that the leaf node with the smallest key is always found, and `Next()` is called to find the result we expect.