### PR TITLE
Allow to load extensions through compiler variable definitions

### DIFF
--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -1,7 +1,8 @@
 
-#include "sqllogic_test_runner.hpp"
-
 #include "catch.hpp"
+
+#include "sqllogic_test_runner.hpp"
+#include "test_helpers.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "sqllogic_parser.hpp"
 #ifdef OUT_OF_TREE

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -5,8 +5,8 @@
 #include "test_helpers.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "sqllogic_parser.hpp"
-#ifdef OUT_OF_TREE
-#include EXTENSION_HEADER
+#ifdef DUCKDB_OUT_OF_TREE
+#include DUCKDB_EXTENSION_HEADER
 #endif
 #include "test_helper_extension.hpp"
 
@@ -198,8 +198,8 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 		FAIL("Could not find test script '" + script + "'. Perhaps run `make sqlite`. ");
 	}
 
-#ifdef OUT_OF_TREE
-	db->LoadExtension<duckdb::EXTENSION_CLASS>();
+#ifdef DUCKDB_OUT_OF_TREE
+	db->LoadExtension<duckdb::DUCKDB_EXTENSION_CLASS>();
 #endif
 
 	/* Loop over all records in the file */

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -1,11 +1,12 @@
 
-#include "catch.hpp"
-
 #include "sqllogic_test_runner.hpp"
-#include "test_helpers.hpp"
+
+#include "catch.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "sqllogic_parser.hpp"
-#include "test_helpers.hpp"
+#ifdef OUT_OF_TREE
+#include EXTENSION_HEADER
+#endif
 #include "test_helper_extension.hpp"
 
 namespace duckdb {
@@ -195,6 +196,10 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 	if (!success) {
 		FAIL("Could not find test script '" + script + "'. Perhaps run `make sqlite`. ");
 	}
+
+#ifdef OUT_OF_TREE
+	db->LoadExtension<duckdb::EXTENSION_CLASS>();
+#endif
 
 	/* Loop over all records in the file */
 	while (parser.NextStatement()) {


### PR DESCRIPTION
This facilitates the development of out of tree extensions (mostly it's testing and clion integration), since it allows them to be loaded through variables defined on their root cmake file.