### PR TITLE
Issue #4764: Window Ignore Nulls

### DIFF
--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -1133,7 +1133,7 @@ void WindowBoundariesState::Update(const idx_t row_idx, WindowInputColumn &range
 struct WindowExecutor {
 	WindowExecutor(BoundWindowExpression *wexpr, Allocator &allocator, const idx_t count);
 
-	void Sink(DataChunk &input_chunk, const idx_t input_idx);
+	void Sink(DataChunk &input_chunk, const idx_t input_idx, const idx_t total_count);
 	void Finalize(WindowAggregationMode mode);
 
 	void Evaluate(idx_t row_idx, DataChunk &input_chunk, Vector &result, const ValidityMask &partition_mask,
@@ -1207,7 +1207,7 @@ WindowExecutor::WindowExecutor(BoundWindowExpression *wexpr, Allocator &allocato
 	PrepareInputExpressions(exprs.data(), exprs.size(), payload_executor, payload_chunk);
 }
 
-void WindowExecutor::Sink(DataChunk &input_chunk, const idx_t input_idx) {
+void WindowExecutor::Sink(DataChunk &input_chunk, const idx_t input_idx, const idx_t total_count) {
 	// Single pass over the input to produce the global data.
 	// Vectorisation for the win...
 
@@ -1242,7 +1242,7 @@ void WindowExecutor::Sink(DataChunk &input_chunk, const idx_t input_idx) {
 			if (!vdata.validity.AllValid()) {
 				//	Lazily materialise the contents when we find the first NULL
 				if (ignore_nulls.AllValid()) {
-					ignore_nulls.Initialize(payload_collection.Count());
+					ignore_nulls.Initialize(total_count);
 				}
 				// Write to the current position
 				// Chunks in a collection are full, so we don't have to worry about raggedness
@@ -1771,7 +1771,7 @@ void WindowLocalSourceState::GeneratePartition(WindowGlobalSinkState &gstate, co
 
 		//	TODO: Parallelization opportunity
 		for (auto &wexec : window_execs) {
-			wexec->Sink(input_chunk, input_idx);
+			wexec->Sink(input_chunk, input_idx, scanner->Count());
 		}
 		input_idx += input_chunk.size();
 	}

--- a/src/include/duckdb/common/types/row_data_collection_scanner.hpp
+++ b/src/include/duckdb/common/types/row_data_collection_scanner.hpp
@@ -55,6 +55,11 @@ public:
 		return layout.GetTypes();
 	}
 
+	//! The number of rows in the collection
+	inline idx_t Count() const {
+		return total_count;
+	}
+
 	//! The number of rows scanned so far
 	inline idx_t Scanned() const {
 		return total_scanned;

--- a/test/sql/window/test_ignore_nulls.test
+++ b/test/sql/window/test_ignore_nulls.test
@@ -232,6 +232,30 @@ FROM issue2549
 3	1	639	639
 4	1	2027	2027
 
+# Multiple blocks for ignore nulls
+query IIII
+WITH gen AS (
+    SELECT *,
+        ((id * 1327) % 9973) / 10000.0 AS rnd
+    FROM generate_series(1, 10000) tbl(id)
+),
+lvl AS (
+    SELECT id,
+        rnd,
+        CASE
+            WHEN rnd <= 0.1 THEN 'shallow'
+            WHEN rnd >= 0.9 THEN 'high'
+        END AS water_level
+    FROM gen
+)
+SELECT *,
+    LAST_VALUE(water_level IGNORE NULLS) OVER (
+        ORDER BY id
+    ) AS grade
+FROM lvl
+----
+40000 values hashing to c302c8b0f3c10c1e5cc7211c4af7a8d6
+
 #
 # Unsupported
 #


### PR DESCRIPTION
Fix a problem with allocating the IGNORE NULLS bitmap where it was using the intermediate count for allocation instead of the final count.