### PR TITLE
Fix #4152: create base table reference in returning clause so generated columns are correctly resolved

### DIFF
--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -80,10 +80,10 @@ public:
 
 	//! Adds a base table with the given alias to the BindContext.
 	void AddBaseTable(idx_t index, const string &alias, const vector<string> &names, const vector<LogicalType> &types,
-	                  LogicalGet &get);
+	                  vector<column_t> &bound_column_ids, StandardEntry *entry);
 	//! Adds a call to a table function with the given alias to the BindContext.
 	void AddTableFunction(idx_t index, const string &alias, const vector<string> &names,
-	                      const vector<LogicalType> &types, LogicalGet &get);
+	                      const vector<LogicalType> &types, vector<column_t> &bound_column_ids, StandardEntry *entry);
 	//! Adds a table view with a given alias to the BindContext.
 	void AddView(idx_t index, const string &alias, SubqueryRef &ref, BoundQueryNode &subquery, ViewCatalogEntry *view);
 	//! Adds a subquery with a given alias to the BindContext.

--- a/src/include/duckdb/planner/operator/logical_delete.hpp
+++ b/src/include/duckdb/planner/operator/logical_delete.hpp
@@ -31,7 +31,7 @@ public:
 protected:
 	vector<ColumnBinding> GetColumnBindings() override {
 		if (return_chunk) {
-			return GenerateColumnBindings(table_index, table->columns.size());
+			return GenerateColumnBindings(table_index, table->GetTypes().size());
 		}
 		return {ColumnBinding(0, 0)};
 	}

--- a/src/include/duckdb/planner/operator/logical_insert.hpp
+++ b/src/include/duckdb/planner/operator/logical_insert.hpp
@@ -39,7 +39,7 @@ public:
 protected:
 	vector<ColumnBinding> GetColumnBindings() override {
 		if (return_chunk) {
-			return GenerateColumnBindings(table_index, table->columns.size());
+			return GenerateColumnBindings(table_index, table->GetTypes().size());
 		}
 		return {ColumnBinding(0, 0)};
 	}

--- a/src/include/duckdb/planner/operator/logical_update.hpp
+++ b/src/include/duckdb/planner/operator/logical_update.hpp
@@ -36,7 +36,7 @@ public:
 protected:
 	vector<ColumnBinding> GetColumnBindings() override {
 		if (return_chunk) {
-			return GenerateColumnBindings(table_index, table->columns.size());
+			return GenerateColumnBindings(table_index, table->GetTypes().size());
 		}
 		return {ColumnBinding(0, 0)};
 	}

--- a/src/include/duckdb/planner/table_binding.hpp
+++ b/src/include/duckdb/planner/table_binding.hpp
@@ -68,11 +68,13 @@ public:
 //! TableBinding is exactly like the Binding, except it keeps track of which columns were bound in the linked LogicalGet
 //! node for projection pushdown purposes.
 struct TableBinding : public Binding {
-	TableBinding(const string &alias, vector<LogicalType> types, vector<string> names, LogicalGet &get, idx_t index,
-	             bool add_row_id = false);
+	TableBinding(const string &alias, vector<LogicalType> types, vector<string> names,
+	             vector<column_t> &bound_column_ids, StandardEntry *entry, idx_t index, bool add_row_id = false);
 
-	//! the underlying LogicalGet
-	LogicalGet &get;
+	//! A reference to the set of bound column ids
+	vector<column_t> &bound_column_ids;
+	//! The underlying catalog entry (if any)
+	StandardEntry *entry;
 
 public:
 	unique_ptr<ParsedExpression> ExpandGeneratedColumn(const string &column_name);

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -167,7 +167,9 @@ unique_ptr<ParsedExpression> BindContext::ExpandGeneratedColumn(const string &ta
 	auto binding = GetBinding(table_name, error_message);
 	D_ASSERT(binding);
 	auto &table_binding = *(TableBinding *)binding;
-	return table_binding.ExpandGeneratedColumn(column_name);
+	auto result = table_binding.ExpandGeneratedColumn(column_name);
+	result->alias = column_name;
+	return result;
 }
 
 unique_ptr<ParsedExpression> BindContext::CreateColumnReference(const string &table_name, const string &column_name) {
@@ -419,13 +421,15 @@ void BindContext::AddBinding(const string &alias, unique_ptr<Binding> binding) {
 }
 
 void BindContext::AddBaseTable(idx_t index, const string &alias, const vector<string> &names,
-                               const vector<LogicalType> &types, LogicalGet &get) {
-	AddBinding(alias, make_unique<TableBinding>(alias, types, names, get, index, true));
+                               const vector<LogicalType> &types, vector<column_t> &bound_column_ids,
+                               StandardEntry *entry) {
+	AddBinding(alias, make_unique<TableBinding>(alias, types, names, bound_column_ids, entry, index, true));
 }
 
 void BindContext::AddTableFunction(idx_t index, const string &alias, const vector<string> &names,
-                                   const vector<LogicalType> &types, LogicalGet &get) {
-	AddBinding(alias, make_unique<TableBinding>(alias, types, names, get, index));
+                                   const vector<LogicalType> &types, vector<column_t> &bound_column_ids,
+                                   StandardEntry *entry) {
+	AddBinding(alias, make_unique<TableBinding>(alias, types, names, bound_column_ids, entry, index));
 }
 
 static string AddColumnNameToBinding(const string &base_name, case_insensitive_set_t &current_names) {

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -409,12 +409,18 @@ BoundStatement Binder::BindReturning(vector<unique_ptr<ParsedExpression>> return
 
 	auto binder = Binder::CreateBinder(context);
 
+	vector<column_t> bound_columns;
+	idx_t column_count = 0;
 	for (auto &col : table->columns) {
 		names.push_back(col.Name());
 		types.push_back(col.Type());
+		if (!col.Generated()) {
+			bound_columns.push_back(column_count);
+		}
+		column_count++;
 	}
 
-	binder->bind_context.AddGenericBinding(update_table_index, table->name, names, types);
+	binder->bind_context.AddBaseTable(update_table_index, table->name, names, types, bound_columns, table);
 	ReturningBinder returning_binder(*binder, context);
 
 	vector<unique_ptr<Expression>> projection_expressions;

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -245,7 +245,12 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref_p, idx_t
 	}
 	//! Generated column returns generated expression
 	if (expr->type != ExpressionType::COLUMN_REF) {
-		return BindExpression(&expr, depth);
+		auto alias = expr->alias;
+		auto result = BindExpression(&expr, depth);
+		if (result.expression) {
+			result.expression->alias = move(alias);
+		}
+		return result;
 	}
 	auto &colref = (ColumnRefExpression &)*expr;
 	D_ASSERT(colref.IsQualified());

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -120,7 +120,8 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 
 		auto logical_get = make_unique<LogicalGet>(table_index, scan_function, move(bind_data), move(return_types),
 		                                           move(return_names));
-		bind_context.AddBaseTable(table_index, alias, table_names, table_types, *logical_get);
+		bind_context.AddBaseTable(table_index, alias, table_names, table_types, logical_get->column_ids,
+		                          logical_get->GetTable());
 		return make_unique_base<BoundTableRef, BoundBaseTableRef>(table, move(logical_get));
 	}
 	case CatalogType::VIEW_ENTRY: {

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -154,7 +154,8 @@ Binder::BindTableFunctionInternal(TableFunction &table_function, const string &f
 	get->input_table_types = input_table_types;
 	get->input_table_names = input_table_names;
 	// now add the table function to the bind context so its columns can be bound
-	bind_context.AddTableFunction(bind_index, function_name, return_names, return_types, *get);
+	bind_context.AddTableFunction(bind_index, function_name, return_names, return_types, get->column_ids,
+	                              get->GetTable());
 	return move(get);
 }
 

--- a/test/fuzzer/pedro/returning_clause_sizes_not_match.test
+++ b/test/fuzzer/pedro/returning_clause_sizes_not_match.test
@@ -1,0 +1,61 @@
+# name: test/fuzzer/pedro/returning_clause_sizes_not_match.test
+# group: [pedro]
+
+statement ok
+PRAGMA enable_verification;
+
+statement ok
+CREATE TABLE test (x INT, y AS(x + 100));
+
+query II
+INSERT INTO test VALUES (1), (2) RETURNING *;
+----
+1	101
+2	102
+
+query I
+SELECT test FROM test
+----
+{'x': 1, 'y': 101}
+{'x': 2, 'y': 102}
+
+query IIII
+INSERT INTO test VALUES (1), (2) RETURNING *, *;
+----
+1	101	1	101
+2	102	2	102
+
+query II
+DELETE FROM test WHERE x=2 RETURNING *;
+----
+2	102
+2	102
+
+query II
+UPDATE test SET x=0 WHERE x = 1 RETURNING *;
+----
+0	100
+0	100
+
+# Error: Binder Error: Referenced table "y" not found!
+statement error
+INSERT INTO test VALUES(1) RETURNING y.y;
+
+# Error: Binder Error: Referenced table "y" not found!
+statement error
+INSERT INTO test VALUES(1) RETURNING y.*;
+
+query I
+INSERT INTO test VALUES(1) RETURNING test;
+----
+{'x': 1, 'y': 101}
+
+query I
+INSERT INTO test VALUES(1) RETURNING test.y;
+----
+101
+
+query I
+INSERT INTO test VALUES(1) RETURNING {'i' : x, 'j' : y};
+----
+{'i': 1, 'j': 101}

--- a/test/fuzzer/pedro/returning_clause_sizes_not_match.test
+++ b/test/fuzzer/pedro/returning_clause_sizes_not_match.test
@@ -59,3 +59,21 @@ query I
 INSERT INTO test VALUES(1) RETURNING {'i' : x, 'j' : y};
 ----
 {'i': 1, 'j': 101}
+
+query I
+INSERT INTO test VALUES (1), (2) RETURNING y;
+----
+101
+102
+
+query IIII
+INSERT INTO test VALUES (1), (2) RETURNING y, y, y, x;
+----
+101	101	101	1
+102	102	102	2
+
+query II
+INSERT INTO test VALUES (1), (2) RETURNING y + y, x + y;
+----
+202	102
+204	104


### PR DESCRIPTION
Supersedes #4551