### PR TITLE
Missing json_contains in extension list

### DIFF
--- a/src/include/extension_functions.hpp
+++ b/src/include/extension_functions.hpp
@@ -35,6 +35,7 @@ static constexpr ExtensionFunction EXTENSION_FUNCTIONS[] = {
     {"json", "json"},
     {"json_array", "json"},
     {"json_array_length", "json"},
+    {"json_contains", "json"},
     {"json_extract", "json"},
     {"json_extract_path", "json"},
     {"json_extract_path_text", "json"},


### PR DESCRIPTION
Fixes a CI failure in "Checks extension functions"