### PR TITLE
Map VARCHAR, JSON, ENUM to Julia String

### DIFF
--- a/tools/juliapkg/src/ctypes.jl
+++ b/tools/juliapkg/src/ctypes.jl
@@ -204,9 +204,9 @@ JULIA_TYPE_MAP = Dict(
     DUCKDB_TYPE_TIMESTAMP_NS => DateTime,
     DUCKDB_TYPE_INTERVAL => Dates.CompoundPeriod,
     DUCKDB_TYPE_UUID => UUID,
-    DUCKDB_TYPE_VARCHAR => AbstractString,
-    DUCKDB_TYPE_JSON => AbstractString,
-    DUCKDB_TYPE_ENUM => AbstractString,
+    DUCKDB_TYPE_VARCHAR => String,
+    DUCKDB_TYPE_JSON => String,
+    DUCKDB_TYPE_ENUM => String,
     DUCKDB_TYPE_BLOB => Base.CodeUnits{UInt8, String},
     DUCKDB_TYPE_MAP => Dict
 )

--- a/tools/juliapkg/test/test_sqlite.jl
+++ b/tools/juliapkg/test/test_sqlite.jl
@@ -220,6 +220,12 @@ end
     r = first(rr)
     @test typeof.(Tuple(r)) ==
           (Missing, Int32, Int32, Float32, Float32, Float64, String, String, String, String, DateTime, DateTime)
+    # Issue #4809: Concrete `String` types.
+    # Want to test exactly the types `execute` returns, so check the schema directly and
+    # avoid calling `Tuple` or anything else that would narrow the types in the result.
+    schema = Tables.schema(rr)
+    @test nonmissingtype.(schema.types) ==
+          (Int32, Int32, Int32, Float32, Float32, Float64, String, String, String, String, DateTime, DateTime)
 end
 
 @testset "Issue #158: Missing DB File" begin


### PR DESCRIPTION
- attempts to fix #4809 
- I couldn't see a reason why we were mapping these to `AbstractString`, but I might well just be missing it - let me know! 😊 
