### PR TITLE
fix(jdbc): release results before releasing statements

### DIFF
--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
@@ -281,6 +281,9 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
 	@Override
 	public void close() throws SQLException {
+		if (select_result != null) {
+			select_result.close();
+		}
 		if (stmt_ref != null) {
 			DuckDBNative.duckdb_jdbc_release(stmt_ref);
 			stmt_ref = null;


### PR DESCRIPTION
Fixes #4813

I've tested this locally, not sure if it's possible to write tests for it?