### PR TITLE
Support parallel unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,9 @@ unittest: debug
 	build/debug/test/unittest
 	build/debug/tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper
 
+unittest-parallel: debug
+	build/debug/test/unittest -t "[fast]" | sed -n -r '/^.*([[].*[]])/ s//\1/p' | egrep -v '[[]fast[]]' | xargs -P $$(nproc) -n 1 build/debug/test/unittest "[fast]"
+
 unittestci:
 	python3 scripts/run_tests_one_by_one.py build/debug/test/unittest
 	build/debug/tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper

--- a/test/sqlite/test_sqllogictest.cpp
+++ b/test/sqlite/test_sqllogictest.cpp
@@ -53,7 +53,7 @@ static void testRunner() {
 }
 
 static string ParseGroupFromPath(string file) {
-	string extension = "";
+	string extension = "[fast]";
 	if (file.find(".test_slow") != std::string::npos) {
 		// "slow" in the name indicates a slow test (i.e. only run as part of allunit)
 		extension = "[.]";


### PR DESCRIPTION
The rule in the `Makefile` does the following:

- it lists all the test tags with at least one test that is tagged "fast"
- for each such tag, a `unittest` process is started in parallel that runs all tests under that tag and also the "fast" tag

The same strategy could be applied to slow tests or to other tags.

The new tag is necessary because `unittest` accepts only one test name for each run, but multiple tags.