### PR TITLE
Build extensions for R debug builds

### DIFF
--- a/tools/rpkg/configure
+++ b/tools/rpkg/configure
@@ -11,5 +11,5 @@ if [ -z "${DUCKDB_R_DEBUG}" ]; then
   python3 rconfigure.py
 else
   cd ../..
-  GEN=ninja CONFIGURE_R=1 nice ${MAKE:-make} debug
+  GEN=ninja CONFIGURE_R=1 BUILD_EXCEL=1 BUILD_JSON=1 BUILD_FTS=1 BUILD_VISUALIZER=1 nice ${MAKE:-make} debug
 fi


### PR DESCRIPTION
Follow-up to #3859.

This seems to be actually necessary to support the following workflow:

- clone duckdb
- change to tools/rpkg
- run `DUCKDB_R_DEBUG=1 R CMD INSTALL .`

Without this change, the package is not installed. This happened on my local machine, I wonder why the corresponding GitHub Actions run doesn't detect the failure here. Debugging.