### PR TITLE
Move LocalStorage row groups directly to DataTable instead of re-appending

### DIFF
--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -140,6 +140,7 @@ public:
 
 	void ScanTableSegment(idx_t start_row, idx_t count, const std::function<void(DataChunk &chunk)> &function);
 
+	//! Merge a row group collection directly into this table - appending it to the end of the table without copying
 	void MergeStorage(RowGroupCollection &data, TableIndexList &indexes, TableStatistics &stats);
 
 	//! Append a chunk with the row ids [row_start, ..., row_start + chunk.size()] to all indexes of the table, returns

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -123,6 +123,8 @@ public:
 	void UpdateColumn(TableCatalogEntry &table, ClientContext &context, Vector &row_ids,
 	                  const vector<column_t> &column_path, DataChunk &updates);
 
+	//! Fetches an append lock
+	void AppendLock(TableAppendState &state);
 	//! Begin appending structs to this table, obtaining necessary locks, etc
 	void InitializeAppend(Transaction &transaction, TableAppendState &state, idx_t append_count);
 	//! Append a chunk to the table using the AppendState obtained from BeginAppend
@@ -137,6 +139,8 @@ public:
 	void RevertAppendInternal(idx_t start_row, idx_t count);
 
 	void ScanTableSegment(idx_t start_row, idx_t count, const std::function<void(DataChunk &chunk)> &function);
+
+	void MergeStorage(RowGroupCollection &data, TableIndexList &indexes, TableStatistics &stats);
 
 	//! Append a chunk with the row ids [row_start, ..., row_start + chunk.size()] to all indexes of the table, returns
 	//! whether or not the append succeeded

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -38,6 +38,8 @@ class ColumnData {
 
 public:
 	ColumnData(DataTableInfo &info, idx_t column_index, idx_t start_row, LogicalType type, ColumnData *parent);
+	ColumnData(ColumnData &other, idx_t start, ColumnData *parent);
+
 	virtual ~ColumnData();
 
 	//! Table info for the column
@@ -119,6 +121,7 @@ public:
 
 	static shared_ptr<ColumnData> CreateColumn(DataTableInfo &info, idx_t column_index, idx_t start_row,
 	                                           const LogicalType &type, ColumnData *parent = nullptr);
+	static shared_ptr<ColumnData> CreateColumn(ColumnData &other, idx_t start_row, ColumnData *parent = nullptr);
 	static unique_ptr<ColumnData> CreateColumnUnique(DataTableInfo &info, idx_t column_index, idx_t start_row,
 	                                                 const LogicalType &type, ColumnData *parent = nullptr);
 

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -124,6 +124,7 @@ public:
 	static shared_ptr<ColumnData> CreateColumn(ColumnData &other, idx_t start_row, ColumnData *parent = nullptr);
 	static unique_ptr<ColumnData> CreateColumnUnique(DataTableInfo &info, idx_t column_index, idx_t start_row,
 	                                                 const LogicalType &type, ColumnData *parent = nullptr);
+	static unique_ptr<ColumnData> CreateColumnUnique(ColumnData &other, idx_t start_row, ColumnData *parent = nullptr);
 
 protected:
 	//! Append a transient segment

--- a/src/include/duckdb/storage/table/column_segment.hpp
+++ b/src/include/duckdb/storage/table/column_segment.hpp
@@ -59,6 +59,7 @@ public:
 	                                                         CompressionType compression_type,
 	                                                         unique_ptr<BaseStatistics> statistics);
 	static unique_ptr<ColumnSegment> CreateTransientSegment(DatabaseInstance &db, const LogicalType &type, idx_t start);
+	static unique_ptr<ColumnSegment> CreateSegment(ColumnSegment &other, idx_t start);
 
 public:
 	void InitializeScan(ColumnScanState &state);
@@ -114,6 +115,7 @@ public:
 	ColumnSegment(DatabaseInstance &db, LogicalType type, ColumnSegmentType segment_type, idx_t start, idx_t count,
 	              CompressionFunction *function, unique_ptr<BaseStatistics> statistics, block_id_t block_id,
 	              idx_t offset);
+	ColumnSegment(ColumnSegment &other, idx_t start);
 
 private:
 	void Scan(ColumnScanState &state, idx_t scan_count, Vector &result);

--- a/src/include/duckdb/storage/table/list_column_data.hpp
+++ b/src/include/duckdb/storage/table/list_column_data.hpp
@@ -18,6 +18,7 @@ class ListColumnData : public ColumnData {
 public:
 	ListColumnData(DataTableInfo &info, idx_t column_index, idx_t start_row, LogicalType type,
 	               ColumnData *parent = nullptr);
+	ListColumnData(ColumnData &original, idx_t start_row, ColumnData *parent = nullptr);
 
 	//! The child-column of the list
 	unique_ptr<ColumnData> child_column;

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -43,6 +43,7 @@ public:
 	RowGroup(DatabaseInstance &db, DataTableInfo &table_info, idx_t start, idx_t count);
 	RowGroup(DatabaseInstance &db, DataTableInfo &table_info, const vector<LogicalType> &types,
 	         RowGroupPointer &pointer);
+	RowGroup(RowGroup &row_group, idx_t start);
 	~RowGroup();
 
 private:

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -157,6 +157,8 @@ private:
 
 struct VersionNode {
 	unique_ptr<ChunkInfo> info[RowGroup::ROW_GROUP_VECTOR_COUNT];
+
+	void SetStart(idx_t start);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -31,6 +31,8 @@ public:
 	void Initialize(PersistentTableData &data);
 	void InitializeEmpty();
 
+	bool IsEmpty() const;
+
 	void AppendRowGroup(idx_t start_row);
 	void Verify();
 
@@ -50,6 +52,8 @@ public:
 	void Append(TransactionData transaction, DataChunk &chunk, TableAppendState &state, TableStatistics &stats);
 	void CommitAppend(transaction_t commit_id, idx_t row_start, idx_t count);
 	void RevertAppendInternal(idx_t start_row, idx_t count);
+
+	void MergeStorage(RowGroupCollection &data);
 
 	void RemoveFromIndexes(TableIndexList &indexes, Vector &row_identifiers, idx_t count);
 

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -29,7 +29,6 @@ public:
 	Allocator &GetAllocator() const;
 
 	void Initialize(PersistentTableData &data);
-	void InitializeEmpty();
 
 	bool IsEmpty() const;
 

--- a/src/include/duckdb/storage/table/standard_column_data.hpp
+++ b/src/include/duckdb/storage/table/standard_column_data.hpp
@@ -18,6 +18,7 @@ class StandardColumnData : public ColumnData {
 public:
 	StandardColumnData(DataTableInfo &info, idx_t column_index, idx_t start_row, LogicalType type,
 	                   ColumnData *parent = nullptr);
+	StandardColumnData(ColumnData &original, idx_t start_row, ColumnData *parent = nullptr);
 
 	//! The validity column data
 	ValidityColumnData validity;

--- a/src/include/duckdb/storage/table/struct_column_data.hpp
+++ b/src/include/duckdb/storage/table/struct_column_data.hpp
@@ -18,6 +18,7 @@ class StructColumnData : public ColumnData {
 public:
 	StructColumnData(DataTableInfo &info, idx_t column_index, idx_t start_row, LogicalType type,
 	                 ColumnData *parent = nullptr);
+	StructColumnData(ColumnData &original, idx_t start_row, ColumnData *parent = nullptr);
 
 	//! The sub-columns of the struct
 	vector<unique_ptr<ColumnData>> sub_columns;

--- a/src/include/duckdb/storage/table/table_statistics.hpp
+++ b/src/include/duckdb/storage/table/table_statistics.hpp
@@ -34,6 +34,7 @@ public:
 	void InitializeAlterType(TableStatistics &parent, idx_t changed_idx, const LogicalType &new_type);
 	void InitializeAddConstraint(TableStatistics &parent);
 
+	void MergeStats(TableStatistics &other);
 	void MergeStats(idx_t i, BaseStatistics &stats);
 	void MergeStats(TableStatisticsLock &lock, idx_t i, BaseStatistics &stats);
 

--- a/src/include/duckdb/storage/table/validity_column_data.hpp
+++ b/src/include/duckdb/storage/table/validity_column_data.hpp
@@ -16,6 +16,7 @@ namespace duckdb {
 class ValidityColumnData : public ColumnData {
 public:
 	ValidityColumnData(DataTableInfo &info, idx_t column_index, idx_t start_row, ColumnData *parent);
+	ValidityColumnData(ColumnData &original, idx_t start_row, ColumnData *parent = nullptr);
 
 public:
 	bool CheckZonemap(ColumnScanState &state, TableFilter &filter) override;

--- a/src/main/client_verify.cpp
+++ b/src/main/client_verify.cpp
@@ -56,7 +56,6 @@ PreservedError ClientContext::VerifyQuery(ClientContextLock &lock, const string 
 	bool any_failed = original->Run(*this, query, [&](const string &q, unique_ptr<SQLStatement> s) {
 		return RunStatementInternal(lock, q, move(s), false, false);
 	});
-
 	// Execute the verifiers
 	for (auto &verifier : statement_verifiers) {
 		bool failed = verifier->Run(*this, query, [&](const string &q, unique_ptr<SQLStatement> s) {
@@ -76,11 +75,7 @@ PreservedError ClientContext::VerifyQuery(ClientContextLock &lock, const string 
 		}
 	} else {
 		if (db->IsInvalidated()) {
-			for (auto &verifier : statement_verifiers) {
-				if (verifier->materialized_result->HasError()) {
-					return verifier->materialized_result->GetErrorObject();
-				}
-			}
+			return original->materialized_result->GetErrorObject();
 		}
 	}
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -492,11 +492,18 @@ void DataTable::Append(TableCatalogEntry &table, ClientContext &context, DataChu
 	transaction.storage.Append(this, chunk);
 }
 
-void DataTable::InitializeAppend(Transaction &transaction, TableAppendState &state, idx_t append_count) {
-	// obtain the append lock for this table
+void DataTable::AppendLock(TableAppendState &state) {
 	state.append_lock = unique_lock<mutex>(append_lock);
 	if (!is_root) {
 		throw TransactionException("Transaction conflict: adding entries to a table that has been altered!");
+	}
+	state.row_start = row_groups->GetTotalRows();
+}
+
+void DataTable::InitializeAppend(Transaction &transaction, TableAppendState &state, idx_t append_count) {
+	// obtain the append lock for this table
+	if (!state.append_lock) {
+		throw InternalException("DataTable::AppendLock should be called before DataTable::InitializeAppend");
 	}
 	row_groups->InitializeAppend(transaction, state, append_count);
 }
@@ -546,6 +553,15 @@ void DataTable::ScanTableSegment(idx_t row_start, idx_t count, const std::functi
 		function(chunk);
 		chunk.Reset();
 		current_row = end_row;
+	}
+}
+
+void DataTable::MergeStorage(RowGroupCollection &data, TableIndexList &indexes, TableStatistics &other_stats) {
+	row_groups->MergeStorage(data);
+	stats.MergeStats(other_stats);
+	row_groups->Verify();
+	if (!indexes.Empty()) {
+		throw InternalException("FIXME: merge indexes");
 	}
 }
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -36,7 +36,6 @@ DataTable::DataTable(DatabaseInstance &db, const string &schema, const string &t
 	if (stats.Empty()) {
 		D_ASSERT(row_groups->GetTotalRows() == 0);
 
-		row_groups->InitializeEmpty();
 		stats.InitializeEmpty(types);
 	}
 	row_groups->Verify();

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -216,7 +216,7 @@ void LocalStorage::Flush(DataTable &table, LocalTableStorage &storage) {
 
 	TableAppendState append_state;
 	table.AppendLock(append_state);
-	if (append_state.row_start == 0 && storage.indexes.Empty()) {
+	if (append_state.row_start == 0 && storage.table.info->indexes.Empty()) {
 		// table is currently empty: move over the storage directly
 		table.MergeStorage(*storage.row_groups, storage.indexes, storage.stats);
 	} else {

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -15,7 +15,6 @@ LocalTableStorage::LocalTableStorage(DataTable &table)
     : table(table), allocator(Allocator::Get(table.db)), deleted_rows(0) {
 	auto types = table.GetTypes();
 	row_groups = make_shared<RowGroupCollection>(table.info, types, MAX_ROW_ID, 0);
-	row_groups->InitializeEmpty();
 	stats.InitializeEmpty(types);
 	table.info->indexes.Scan([&](Index &index) {
 		D_ASSERT(index.type == IndexType::ART);

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -206,44 +206,51 @@ bool LocalStorage::ScanTableStorage(DataTable &table, LocalTableStorage &storage
 }
 
 void LocalStorage::Flush(DataTable &table, LocalTableStorage &storage) {
+	auto storage_entry = move(table_storage[&table]);
+	table_storage[&table].reset();
+
 	if (storage.row_groups->GetTotalRows() <= storage.deleted_rows) {
 		return;
 	}
 	idx_t append_count = storage.row_groups->GetTotalRows() - storage.deleted_rows;
-	TableAppendState append_state;
-	table.InitializeAppend(transaction, append_state, append_count);
 
-	bool constraint_violated = false;
-	ScanTableStorage(table, storage, [&](DataChunk &chunk) -> bool {
-		// append this chunk to the indexes of the table
-		if (!table.AppendToIndexes(chunk, append_state.current_row)) {
-			constraint_violated = true;
-			return false;
-		}
-		// append to base table
-		table.Append(transaction, chunk, append_state);
-		return true;
-	});
-	if (constraint_violated) {
-		// need to revert the append
-		row_t current_row = append_state.row_start;
-		// remove the data from the indexes, if there are any indexes
+	TableAppendState append_state;
+	table.AppendLock(append_state);
+	if (append_state.row_start == 0) {
+		// table is currently empty: move over the storage directly
+		table.MergeStorage(*storage.row_groups, storage.indexes, storage.stats);
+	} else {
+		bool constraint_violated = false;
+		table.InitializeAppend(transaction, append_state, append_count);
 		ScanTableStorage(table, storage, [&](DataChunk &chunk) -> bool {
 			// append this chunk to the indexes of the table
-			table.RemoveFromIndexes(append_state, chunk, current_row);
-
-			current_row += chunk.size();
-			if (current_row >= append_state.current_row) {
-				// finished deleting all rows from the index: abort now
+			if (!table.AppendToIndexes(chunk, append_state.current_row)) {
+				constraint_violated = true;
 				return false;
 			}
+			// append to base table
+			table.Append(transaction, chunk, append_state);
 			return true;
 		});
-		table.RevertAppendInternal(append_state.row_start, append_count);
-		table_storage[&table].reset();
-		throw ConstraintException("PRIMARY KEY or UNIQUE constraint violated: duplicated key");
+		if (constraint_violated) {
+			// need to revert the append
+			row_t current_row = append_state.row_start;
+			// remove the data from the indexes, if there are any indexes
+			ScanTableStorage(table, storage, [&](DataChunk &chunk) -> bool {
+				// append this chunk to the indexes of the table
+				table.RemoveFromIndexes(append_state, chunk, current_row);
+
+				current_row += chunk.size();
+				if (current_row >= append_state.current_row) {
+					// finished deleting all rows from the index: abort now
+					return false;
+				}
+				return true;
+			});
+			table.RevertAppendInternal(append_state.row_start, append_count);
+			throw ConstraintException("PRIMARY KEY or UNIQUE constraint violated: duplicated key");
+		}
 	}
-	table_storage[&table].reset();
 	transaction.PushAppend(&table, append_state.row_start, append_count);
 }
 

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -216,7 +216,7 @@ void LocalStorage::Flush(DataTable &table, LocalTableStorage &storage) {
 
 	TableAppendState append_state;
 	table.AppendLock(append_state);
-	if (append_state.row_start == 0) {
+	if (append_state.row_start == 0 && storage.indexes.Empty()) {
 		// table is currently empty: move over the storage directly
 		table.MergeStorage(*storage.row_groups, storage.indexes, storage.stats);
 	} else {

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -216,7 +216,7 @@ void LocalStorage::Flush(DataTable &table, LocalTableStorage &storage) {
 
 	TableAppendState append_state;
 	table.AppendLock(append_state);
-	if (append_state.row_start == 0 && storage.table.info->indexes.Empty()) {
+	if (append_state.row_start == 0 && storage.table.info->indexes.Empty() && storage.deleted_rows == 0) {
 		// table is currently empty: move over the storage directly
 		table.MergeStorage(*storage.row_groups, storage.indexes, storage.stats);
 	} else {

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -483,25 +483,34 @@ static RET CreateColumnInternal(DataTableInfo &info, idx_t column_index, idx_t s
 	return OP::template Create<StandardColumnData>(info, column_index, start_row, type, parent);
 }
 
+template <class RET, class OP>
+static RET CreateColumnInternal(ColumnData &other, idx_t start_row, ColumnData *parent) {
+	if (other.type.InternalType() == PhysicalType::STRUCT) {
+		return OP::template Create<StructColumnData>(other, start_row, parent);
+	} else if (other.type.InternalType() == PhysicalType::LIST) {
+		return OP::template Create<ListColumnData>(other, start_row, parent);
+	} else if (other.type.id() == LogicalTypeId::VALIDITY) {
+		return OP::template Create<ValidityColumnData>(other, start_row, parent);
+	}
+	return OP::template Create<StandardColumnData>(other, start_row, parent);
+}
+
 shared_ptr<ColumnData> ColumnData::CreateColumn(DataTableInfo &info, idx_t column_index, idx_t start_row,
                                                 const LogicalType &type, ColumnData *parent) {
 	return CreateColumnInternal<shared_ptr<ColumnData>, SharedConstructor>(info, column_index, start_row, type, parent);
 }
 
 shared_ptr<ColumnData> ColumnData::CreateColumn(ColumnData &other, idx_t start_row, ColumnData *parent) {
-	if (other.type.InternalType() == PhysicalType::STRUCT) {
-		return make_shared<StructColumnData>(other, start_row, parent);
-	} else if (other.type.InternalType() == PhysicalType::LIST) {
-		return make_shared<ListColumnData>(other, start_row, parent);
-	} else if (other.type.id() == LogicalTypeId::VALIDITY) {
-		return make_shared<ValidityColumnData>(other, start_row, parent);
-	}
-	return make_shared<StandardColumnData>(other, start_row, parent);
+	return CreateColumnInternal<shared_ptr<ColumnData>, SharedConstructor>(other, start_row, parent);
 }
 
 unique_ptr<ColumnData> ColumnData::CreateColumnUnique(DataTableInfo &info, idx_t column_index, idx_t start_row,
                                                       const LogicalType &type, ColumnData *parent) {
 	return CreateColumnInternal<unique_ptr<ColumnData>, UniqueConstructor>(info, column_index, start_row, type, parent);
+}
+
+unique_ptr<ColumnData> ColumnData::CreateColumnUnique(ColumnData &other, idx_t start_row, ColumnData *parent) {
+	return CreateColumnInternal<unique_ptr<ColumnData>, UniqueConstructor>(other, start_row, parent);
 }
 
 } // namespace duckdb

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -51,8 +51,15 @@ const LogicalType &ColumnData::RootType() const {
 }
 
 idx_t ColumnData::GetMaxEntry() {
+	auto first_segment = data.GetRootSegment();
 	auto last_segment = data.GetLastSegment();
-	return last_segment ? last_segment->start + last_segment->count : start;
+	if (!first_segment) {
+		D_ASSERT(!last_segment);
+		return 0;
+	} else {
+		D_ASSERT(last_segment->start >= first_segment->start);
+		return last_segment->start + last_segment->count - first_segment->start;
+	}
 }
 
 void ColumnData::InitializeScan(ColumnScanState &state) {

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -38,6 +38,10 @@ unique_ptr<ColumnSegment> ColumnSegment::CreateTransientSegment(DatabaseInstance
 	                                  INVALID_BLOCK, 0);
 }
 
+unique_ptr<ColumnSegment> ColumnSegment::CreateSegment(ColumnSegment &other, idx_t start) {
+	return make_unique<ColumnSegment>(other, start);
+}
+
 ColumnSegment::ColumnSegment(DatabaseInstance &db, LogicalType type_p, ColumnSegmentType segment_type, idx_t start,
                              idx_t count, CompressionFunction *function_p, unique_ptr<BaseStatistics> statistics,
                              block_id_t block_id_p, idx_t offset_p)
@@ -61,6 +65,12 @@ ColumnSegment::ColumnSegment(DatabaseInstance &db, LogicalType type_p, ColumnSeg
 	if (function->init_segment) {
 		segment_state = function->init_segment(*this, block_id);
 	}
+}
+
+ColumnSegment::ColumnSegment(ColumnSegment &other, idx_t start)
+    : SegmentBase(start, other.count), db(other.db), type(move(other.type)), type_size(other.type_size),
+      segment_type(other.segment_type), function(other.function), stats(move(other.stats)), block(move(other.block)),
+      block_id(other.block_id), offset(other.offset), segment_state(move(other.segment_state)) {
 }
 
 ColumnSegment::~ColumnSegment() {

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -13,6 +13,11 @@ ListColumnData::ListColumnData(DataTableInfo &info, idx_t column_index, idx_t st
 	child_column = ColumnData::CreateColumnUnique(info, 1, start_row, child_type, this);
 }
 
+ListColumnData::ListColumnData(ColumnData &original, idx_t start_row, ColumnData *parent)
+    : ColumnData(original, start_row, parent), validity(((ListColumnData &)original).validity, start_row, this) {
+	throw InternalException("FIXME: ListColumnData constructor");
+}
+
 bool ListColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
 	// table filters are not supported yet for list columns
 	return false;

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -303,7 +303,7 @@ void ListColumnData::FetchRow(TransactionData transaction, ColumnFetchState &sta
 		auto &child_type = ListType::GetChildType(result.GetType());
 		Vector child_scan(child_type, child_scan_count);
 		// seek the scan towards the specified position and read [length] entries
-		child_column->InitializeScanWithOffset(*child_state, original_offset);
+		child_column->InitializeScanWithOffset(*child_state, start + original_offset);
 		D_ASSERT(child_type.InternalType() == PhysicalType::STRUCT ||
 		         child_state->row_index + child_scan_count <= child_column->GetMaxEntry());
 		child_column->ScanCount(*child_state, child_scan, child_scan_count);

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -305,7 +305,7 @@ void ListColumnData::FetchRow(TransactionData transaction, ColumnFetchState &sta
 		// seek the scan towards the specified position and read [length] entries
 		child_column->InitializeScanWithOffset(*child_state, start + original_offset);
 		D_ASSERT(child_type.InternalType() == PhysicalType::STRUCT ||
-		         child_state->row_index + child_scan_count <= child_column->GetMaxEntry());
+		         child_state->row_index + child_scan_count - this->start <= child_column->GetMaxEntry());
 		child_column->ScanCount(*child_state, child_scan, child_scan_count);
 
 		ListVector::Append(result, child_scan, child_scan_count);

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -113,7 +113,8 @@ idx_t ListColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t co
 	if (child_scan_count > 0) {
 		auto &child_entry = ListVector::GetEntry(result);
 		D_ASSERT(child_entry.GetType().InternalType() == PhysicalType::STRUCT ||
-		         state.child_states[1].row_index + child_scan_count <= child_column->GetMaxEntry());
+		         state.child_states[1].row_index + child_scan_count <=
+		             child_column->start + child_column->GetMaxEntry());
 		child_column->ScanCount(state.child_states[1], child_entry, child_scan_count);
 	}
 

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -15,7 +15,8 @@ ListColumnData::ListColumnData(DataTableInfo &info, idx_t column_index, idx_t st
 
 ListColumnData::ListColumnData(ColumnData &original, idx_t start_row, ColumnData *parent)
     : ColumnData(original, start_row, parent), validity(((ListColumnData &)original).validity, start_row, this) {
-	throw InternalException("FIXME: ListColumnData constructor");
+	auto &list_data = (ListColumnData &)original;
+	child_column = ColumnData::CreateColumnUnique(*list_data.child_column, start_row, this);
 }
 
 bool ListColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -68,7 +68,7 @@ void ListColumnData::InitializeScanWithOffset(ColumnScanState &state, idx_t row_
 	D_ASSERT(child_offset <= child_column->GetMaxEntry());
 	ColumnScanState child_state;
 	if (child_offset < child_column->GetMaxEntry()) {
-		child_column->InitializeScanWithOffset(child_state, child_offset);
+		child_column->InitializeScanWithOffset(child_state, start + child_offset);
 	}
 	state.child_states.push_back(move(child_state));
 }

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -49,6 +49,15 @@ RowGroup::RowGroup(DatabaseInstance &db, DataTableInfo &table_info, const vector
 	Verify();
 }
 
+RowGroup::RowGroup(RowGroup &row_group, idx_t start)
+    : SegmentBase(start, row_group.count), db(row_group.db), table_info(row_group.table_info),
+      version_info(move(row_group.version_info)), stats(move(row_group.stats)) {
+	for (auto &column : row_group.columns) {
+		this->columns.push_back(ColumnData::CreateColumn(*column, start));
+	}
+	Verify();
+}
+
 RowGroup::~RowGroup() {
 }
 

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -55,7 +55,20 @@ RowGroup::RowGroup(RowGroup &row_group, idx_t start)
 	for (auto &column : row_group.columns) {
 		this->columns.push_back(ColumnData::CreateColumn(*column, start));
 	}
+	if (version_info) {
+		version_info->SetStart(start);
+	}
 	Verify();
+}
+
+void VersionNode::SetStart(idx_t start) {
+	idx_t current_start = start;
+	for (idx_t i = 0; i < RowGroup::ROW_GROUP_VECTOR_COUNT; i++) {
+		if (info[i]) {
+			info[i]->start = current_start;
+		}
+		current_start += STANDARD_VECTOR_SIZE;
+	}
 }
 
 RowGroup::~RowGroup() {

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -551,6 +551,9 @@ shared_ptr<RowGroupCollection> RowGroupCollection::AlterType(idx_t changed_idx, 
 }
 
 void RowGroupCollection::VerifyNewConstraint(DataTable &parent, const BoundConstraint &constraint) {
+	if (total_rows == 0) {
+		return;
+	}
 	// scan the original table, check if there's any null value
 	auto &not_null_constraint = (BoundNotNullConstraint &)constraint;
 	vector<LogicalType> scan_types;

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -42,7 +42,7 @@ void RowGroupCollection::Initialize(PersistentTableData &data) {
 }
 
 void RowGroupCollection::InitializeEmpty() {
-	AppendRowGroup(row_start);
+	//	AppendRowGroup(row_start);
 }
 
 void RowGroupCollection::AppendRowGroup(idx_t start_row) {
@@ -54,7 +54,10 @@ void RowGroupCollection::AppendRowGroup(idx_t start_row) {
 
 void RowGroupCollection::Verify() {
 #ifdef DEBUG
-	D_ASSERT(row_groups->GetRootSegment() != nullptr);
+	for (auto segment = row_groups->GetRootSegment(); segment; segment = segment->next.get()) {
+		auto &row_group = (RowGroup &)*segment;
+		row_group.Verify();
+	}
 #endif
 }
 
@@ -64,6 +67,7 @@ void RowGroupCollection::Verify() {
 void RowGroupCollection::InitializeScan(CollectionScanState &state, const vector<column_t> &column_ids,
                                         TableFilterSet *table_filters) {
 	auto row_group = (RowGroup *)row_groups->GetRootSegment();
+	D_ASSERT(row_group);
 	state.max_row = row_start + total_rows;
 	while (row_group && !row_group->InitializeScan(state.row_group_state)) {
 		row_group = (RowGroup *)row_group->next.get();
@@ -77,6 +81,7 @@ void RowGroupCollection::InitializeCreateIndexScan(CreateIndexScanState &state) 
 void RowGroupCollection::InitializeScanWithOffset(CollectionScanState &state, const vector<column_t> &column_ids,
                                                   idx_t start_row, idx_t end_row) {
 	auto row_group = (RowGroup *)row_groups->GetSegment(start_row);
+	D_ASSERT(row_group);
 	state.max_row = end_row;
 	idx_t start_vector = (start_row - row_group->start) / STANDARD_VECTOR_SIZE;
 	if (!row_group->InitializeScanWithOffset(state.row_group_state, start_vector)) {
@@ -154,6 +159,10 @@ void RowGroupCollection::Fetch(TransactionData transaction, DataChunk &result, c
 //===--------------------------------------------------------------------===//
 // Append
 //===--------------------------------------------------------------------===//
+bool RowGroupCollection::IsEmpty() const {
+	return row_groups->GetRootSegment() == nullptr;
+}
+
 void RowGroupCollection::InitializeAppend(TransactionData transaction, TableAppendState &state, idx_t append_count) {
 	state.remaining_append_count = append_count;
 	state.row_start = total_rows;
@@ -161,6 +170,10 @@ void RowGroupCollection::InitializeAppend(TransactionData transaction, TableAppe
 
 	// start writing to the row_groups
 	lock_guard<mutex> row_group_lock(row_groups->node_lock);
+	if (IsEmpty()) {
+		// empty row group collection: empty first row group
+		AppendRowGroup(row_start);
+	}
 	auto last_row_group = (RowGroup *)row_groups->GetLastSegment();
 	D_ASSERT(this->row_start + total_rows == last_row_group->start + last_row_group->count);
 	last_row_group->InitializeAppend(transaction, state.row_group_append_state, state.remaining_append_count);
@@ -225,6 +238,7 @@ void RowGroupCollection::Append(TransactionData transaction, DataChunk &chunk, T
 
 void RowGroupCollection::CommitAppend(transaction_t commit_id, idx_t row_start, idx_t count) {
 	auto row_group = (RowGroup *)row_groups->GetSegment(row_start);
+	D_ASSERT(row_group);
 	idx_t current_row = row_start;
 	idx_t remaining = count;
 	while (true) {
@@ -265,6 +279,18 @@ void RowGroupCollection::RevertAppendInternal(idx_t start_row, idx_t count) {
 	}
 	info.next = nullptr;
 	info.RevertAppend(start_row);
+}
+
+void RowGroupCollection::MergeStorage(RowGroupCollection &data) {
+	D_ASSERT(data.types == types);
+	auto index = row_start;
+	for (auto segment = data.row_groups->GetRootSegment(); segment; segment = segment->next.get()) {
+		auto &row_group = (RowGroup &)*segment;
+		auto new_group = make_unique<RowGroup>(row_group, index);
+		index += new_group->count;
+		row_groups->AppendSegment(move(new_group));
+	}
+	total_rows += data.total_rows.load();
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -41,10 +41,6 @@ void RowGroupCollection::Initialize(PersistentTableData &data) {
 	}
 }
 
-void RowGroupCollection::InitializeEmpty() {
-	//	AppendRowGroup(row_start);
-}
-
 void RowGroupCollection::AppendRowGroup(idx_t start_row) {
 	D_ASSERT(start_row >= row_start);
 	auto new_row_group = make_unique<RowGroup>(info->db, *info, start_row, 0);

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -13,6 +13,10 @@ StandardColumnData::StandardColumnData(DataTableInfo &info, idx_t column_index, 
     : ColumnData(info, column_index, start_row, move(type), parent), validity(info, 0, start_row, this) {
 }
 
+StandardColumnData::StandardColumnData(ColumnData &original, idx_t start_row, ColumnData *parent)
+    : ColumnData(original, start_row, parent), validity(((StandardColumnData &)original).validity, start_row, this) {
+}
+
 bool StandardColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
 	if (!state.segment_checked) {
 		if (!state.current) {

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -19,6 +19,11 @@ StructColumnData::StructColumnData(DataTableInfo &info, idx_t column_index, idx_
 	}
 }
 
+StructColumnData::StructColumnData(ColumnData &original, idx_t start_row, ColumnData *parent)
+    : ColumnData(original, start_row, parent), validity(((StructColumnData &)original).validity, start_row, this) {
+	throw InternalException("FIXME: StructColumnData constructor");
+}
+
 bool StructColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
 	// table filters are not supported yet for struct columns
 	return false;

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -21,7 +21,10 @@ StructColumnData::StructColumnData(DataTableInfo &info, idx_t column_index, idx_
 
 StructColumnData::StructColumnData(ColumnData &original, idx_t start_row, ColumnData *parent)
     : ColumnData(original, start_row, parent), validity(((StructColumnData &)original).validity, start_row, this) {
-	throw InternalException("FIXME: StructColumnData constructor");
+	auto &struct_data = (StructColumnData &)original;
+	for (auto &child_col : struct_data.sub_columns) {
+		sub_columns.push_back(ColumnData::CreateColumnUnique(*child_col, start_row, this));
+	}
 }
 
 bool StructColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {

--- a/src/storage/table/table_statistics.cpp
+++ b/src/storage/table/table_statistics.cpp
@@ -66,6 +66,14 @@ void TableStatistics::InitializeAddConstraint(TableStatistics &parent) {
 	}
 }
 
+void TableStatistics::MergeStats(TableStatistics &other) {
+	auto l = GetLock();
+	D_ASSERT(column_stats.size() == other.column_stats.size());
+	for (idx_t i = 0; i < column_stats.size(); i++) {
+		column_stats[i]->stats->Merge(*other.column_stats[i]->stats);
+	}
+}
+
 void TableStatistics::MergeStats(idx_t i, BaseStatistics &stats) {
 	auto l = GetLock();
 	MergeStats(*l, i, stats);

--- a/src/storage/table/validity_column_data.cpp
+++ b/src/storage/table/validity_column_data.cpp
@@ -8,6 +8,10 @@ ValidityColumnData::ValidityColumnData(DataTableInfo &info, idx_t column_index, 
     : ColumnData(info, column_index, start_row, LogicalType(LogicalTypeId::VALIDITY), parent) {
 }
 
+ValidityColumnData::ValidityColumnData(ColumnData &original, idx_t start_row, ColumnData *parent)
+    : ColumnData(original, start_row, parent) {
+}
+
 bool ValidityColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
 	return true;
 }


### PR DESCRIPTION
This PR adds the `MergeStorage` feature, that merges one set of row groups into another set. This allows data appended to the `LocalStorage` to be moved to the main `DataTable` without needing go through another scan -> append phase. This improves performance and fixes the regressions introduced by #4798 (and speeds up table insertion in general).

There are some restrictions on this behavior that should be relaxed/removed in future PRs. We only do the zero-cost merging if:

* The table is empty
* The table has no indexes
* The thread-local storage has no deletes