### PR TITLE
Add support for custom bind functions to RegisterCastFunction, and propagate client context to the bind function

### DIFF
--- a/src/common/vector_operations/vector_cast.cpp
+++ b/src/common/vector_operations/vector_cast.cpp
@@ -5,16 +5,17 @@
 
 namespace duckdb {
 
-bool VectorOperations::TryCast(CastFunctionSet &set, Vector &source, Vector &result, idx_t count, string *error_message,
-                               bool strict) {
-	auto cast_function = set.GetCastFunction(source.GetType(), result.GetType());
+bool VectorOperations::TryCast(CastFunctionSet &set, GetCastFunctionInput &input, Vector &source, Vector &result,
+                               idx_t count, string *error_message, bool strict) {
+	auto cast_function = set.GetCastFunction(source.GetType(), result.GetType(), input);
 	CastParameters parameters(cast_function.cast_data.get(), strict, error_message);
 	return cast_function.function(source, result, count, parameters);
 }
 
 bool VectorOperations::DefaultTryCast(Vector &source, Vector &result, idx_t count, string *error_message, bool strict) {
 	CastFunctionSet set;
-	return VectorOperations::TryCast(set, source, result, count, error_message, strict);
+	GetCastFunctionInput input;
+	return VectorOperations::TryCast(set, input, source, result, count, error_message, strict);
 }
 
 void VectorOperations::DefaultCast(Vector &source, Vector &result, idx_t count, bool strict) {
@@ -25,7 +26,8 @@ bool VectorOperations::TryCast(ClientContext &context, Vector &source, Vector &r
                                string *error_message, bool strict) {
 	auto &config = DBConfig::GetConfig(context);
 	auto &set = config.GetCastFunctions();
-	return VectorOperations::TryCast(set, source, result, count, error_message, strict);
+	GetCastFunctionInput get_input(context);
+	return VectorOperations::TryCast(set, get_input, source, result, count, error_message, strict);
 }
 
 void VectorOperations::Cast(ClientContext &context, Vector &source, Vector &result, idx_t count, bool strict) {

--- a/src/function/cast/cast_function_set.cpp
+++ b/src/function/cast/cast_function_set.cpp
@@ -6,6 +6,15 @@
 
 namespace duckdb {
 
+BindCastInput::BindCastInput(CastFunctionSet &function_set, BindCastInfo *info, ClientContext *context)
+    : function_set(function_set), info(info), context(context) {
+}
+
+BoundCastInfo BindCastInput::GetCastFunction(const LogicalType &source, const LogicalType &target) {
+	GetCastFunctionInput input(context);
+	return function_set.GetCastFunction(source, target, input);
+}
+
 BindCastFunction::BindCastFunction(bind_cast_function_t function_p, unique_ptr<BindCastInfo> info_p)
     : function(function_p), info(move(info_p)) {
 }
@@ -22,7 +31,8 @@ CastFunctionSet &CastFunctionSet::Get(DatabaseInstance &db) {
 	return DBConfig::GetConfig(db).GetCastFunctions();
 }
 
-BoundCastInfo CastFunctionSet::GetCastFunction(const LogicalType &source, const LogicalType &target) {
+BoundCastInfo CastFunctionSet::GetCastFunction(const LogicalType &source, const LogicalType &target,
+                                               GetCastFunctionInput &get_input) {
 	if (source == target) {
 		return DefaultCasts::NopCast;
 	}
@@ -30,7 +40,7 @@ BoundCastInfo CastFunctionSet::GetCastFunction(const LogicalType &source, const 
 	// we iterate the set of bind functions backwards
 	for (idx_t i = bind_functions.size(); i > 0; i--) {
 		auto &bind_function = bind_functions[i - 1];
-		BindCastInput input(*this, bind_function.info.get());
+		BindCastInput input(*this, bind_function.info.get(), get_input.context);
 		auto result = bind_function.function(input, source, target);
 		if (result.function) {
 			// found a cast function! return it
@@ -43,10 +53,14 @@ BoundCastInfo CastFunctionSet::GetCastFunction(const LogicalType &source, const 
 
 struct MapCastNode {
 	MapCastNode(BoundCastInfo info, int64_t implicit_cast_cost)
-	    : cast_info(move(info)), implicit_cast_cost(implicit_cast_cost) {
+	    : cast_info(move(info)), bind_function(nullptr), implicit_cast_cost(implicit_cast_cost) {
+	}
+	MapCastNode(bind_cast_function_t func, int64_t implicit_cast_cost)
+	    : cast_info(nullptr), bind_function(func), implicit_cast_cost(implicit_cast_cost) {
 	}
 
 	BoundCastInfo cast_info;
+	bind_cast_function_t bind_function;
 	int64_t implicit_cast_cost;
 };
 
@@ -84,18 +98,30 @@ BoundCastInfo MapCastFunction(BindCastInput &input, const LogicalType &source, c
 		// target type not found
 		return nullptr;
 	}
+	if (target_entry->second.bind_function) {
+		return target_entry->second.bind_function(input, source, target);
+	}
 	return target_entry->second.cast_info.Copy();
 }
 
 void CastFunctionSet::RegisterCastFunction(const LogicalType &source, const LogicalType &target, BoundCastInfo function,
                                            int64_t implicit_cast_cost) {
+	RegisterCastFunction(source, target, MapCastNode(move(function), implicit_cast_cost));
+}
+
+void CastFunctionSet::RegisterCastFunction(const LogicalType &source, const LogicalType &target,
+                                           bind_cast_function_t bind_function, int64_t implicit_cast_cost) {
+	RegisterCastFunction(source, target, MapCastNode(bind_function, implicit_cast_cost));
+}
+
+void CastFunctionSet::RegisterCastFunction(const LogicalType &source, const LogicalType &target, MapCastNode node) {
 	if (!map_info) {
 		// create the cast map and the cast map function
 		auto info = make_unique<MapCastInfo>();
 		map_info = info.get();
 		bind_functions.emplace_back(MapCastFunction, move(info));
 	}
-	map_info->casts[source].insert(make_pair(target, MapCastNode(move(function), implicit_cast_cost)));
+	map_info->casts[source].insert(make_pair(target, move(node)));
 }
 
 } // namespace duckdb

--- a/src/function/cast/enum_casts.cpp
+++ b/src/function/cast/enum_casts.cpp
@@ -104,8 +104,8 @@ public:
 };
 
 unique_ptr<BoundCastData> BindEnumCast(BindCastInput &input, const LogicalType &source, const LogicalType &target) {
-	auto to_varchar_cast = input.function_set.GetCastFunction(source, LogicalType::VARCHAR);
-	auto from_varchar_cast = input.function_set.GetCastFunction(LogicalType::VARCHAR, target);
+	auto to_varchar_cast = input.GetCastFunction(source, LogicalType::VARCHAR);
+	auto from_varchar_cast = input.GetCastFunction(LogicalType::VARCHAR, target);
 	return make_unique<EnumBoundCastData>(move(to_varchar_cast), move(from_varchar_cast));
 }
 

--- a/src/function/cast/list_casts.cpp
+++ b/src/function/cast/list_casts.cpp
@@ -20,7 +20,7 @@ unique_ptr<BoundCastData> BindListToListCast(BindCastInput &input, const Logical
 	vector<BoundCastInfo> child_cast_info;
 	auto &source_child_type = ListType::GetChildType(source);
 	auto &result_child_type = ListType::GetChildType(target);
-	auto child_cast = input.function_set.GetCastFunction(source_child_type, result_child_type);
+	auto child_cast = input.GetCastFunction(source_child_type, result_child_type);
 	return make_unique<ListBoundCastData>(move(child_cast));
 }
 

--- a/src/function/cast/map_cast.cpp
+++ b/src/function/cast/map_cast.cpp
@@ -23,8 +23,8 @@ unique_ptr<BoundCastData> BindMapToMapCast(BindCastInput &input, const LogicalTy
 	auto target_key = LogicalType::LIST(MapType::KeyType(target));
 	auto source_val = LogicalType::LIST(MapType::ValueType(source));
 	auto target_val = LogicalType::LIST(MapType::ValueType(target));
-	auto key_cast = input.function_set.GetCastFunction(source_key, target_key);
-	auto value_cast = input.function_set.GetCastFunction(source_val, target_val);
+	auto key_cast = input.GetCastFunction(source_key, target_key);
+	auto value_cast = input.GetCastFunction(source_val, target_val);
 	return make_unique<MapBoundCastData>(move(key_cast), move(value_cast));
 }
 

--- a/src/function/cast/struct_cast.cpp
+++ b/src/function/cast/struct_cast.cpp
@@ -30,8 +30,7 @@ unique_ptr<BoundCastData> BindStructToStructCast(BindCastInput &input, const Log
 		throw TypeMismatchException(source, target, "Cannot cast STRUCTs of different size");
 	}
 	for (idx_t i = 0; i < source_child_types.size(); i++) {
-		auto child_cast =
-		    input.function_set.GetCastFunction(source_child_types[i].second, result_child_types[i].second);
+		auto child_cast = input.GetCastFunction(source_child_types[i].second, result_child_types[i].second);
 		child_cast_info.push_back(move(child_cast));
 	}
 	return make_unique<StructBoundCastData>(move(child_cast_info), target);

--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -18,6 +18,7 @@ namespace duckdb {
 class CastFunctionSet;
 class Deserializer;
 class Serializer;
+struct GetCastFunctionInput;
 
 //! The Value object holds a single arbitrary value of any type that can be
 //! stored in the database.
@@ -197,18 +198,20 @@ public:
 	DUCKDB_API uintptr_t GetPointer() const;
 
 	//! Cast this value to another type, throws exception if its not possible
-	DUCKDB_API Value CastAs(CastFunctionSet &set, const LogicalType &target_type, bool strict = false) const;
+	DUCKDB_API Value CastAs(CastFunctionSet &set, GetCastFunctionInput &get_input, const LogicalType &target_type,
+	                        bool strict = false) const;
 	DUCKDB_API Value CastAs(ClientContext &context, const LogicalType &target_type, bool strict = false) const;
 	DUCKDB_API Value DefaultCastAs(const LogicalType &target_type, bool strict = false) const;
 	//! Tries to cast this value to another type, and stores the result in "new_value"
-	DUCKDB_API bool TryCastAs(CastFunctionSet &set, const LogicalType &target_type, Value &new_value,
-	                          string *error_message, bool strict = false) const;
+	DUCKDB_API bool TryCastAs(CastFunctionSet &set, GetCastFunctionInput &get_input, const LogicalType &target_type,
+	                          Value &new_value, string *error_message, bool strict = false) const;
 	DUCKDB_API bool TryCastAs(ClientContext &context, const LogicalType &target_type, Value &new_value,
 	                          string *error_message, bool strict = false) const;
 	DUCKDB_API bool DefaultTryCastAs(const LogicalType &target_type, Value &new_value, string *error_message,
 	                                 bool strict = false) const;
 	//! Tries to cast this value to another type, and stores the result in THIS value again
-	DUCKDB_API bool TryCastAs(CastFunctionSet &set, const LogicalType &target_type, bool strict = false);
+	DUCKDB_API bool TryCastAs(CastFunctionSet &set, GetCastFunctionInput &get_input, const LogicalType &target_type,
+	                          bool strict = false);
 	DUCKDB_API bool TryCastAs(ClientContext &context, const LogicalType &target_type, bool strict = false);
 	DUCKDB_API bool DefaultTryCastAs(const LogicalType &target_type, bool strict = false);
 
@@ -251,7 +254,8 @@ public:
 
 	//! Returns true if the values are (approximately) equivalent. Note this is NOT the SQL equivalence. For this
 	//! function, NULL values are equivalent and floating point values that are close are equivalent.
-	DUCKDB_API static bool ValuesAreEqual(CastFunctionSet &set, const Value &result_value, const Value &value);
+	DUCKDB_API static bool ValuesAreEqual(CastFunctionSet &set, GetCastFunctionInput &get_input,
+	                                      const Value &result_value, const Value &value);
 	DUCKDB_API static bool ValuesAreEqual(ClientContext &context, const Value &result_value, const Value &value);
 	DUCKDB_API static bool DefaultValuesAreEqual(const Value &result_value, const Value &value);
 	//! Returns true if the values are not distinct from each other, following SQL semantics for NOT DISTINCT FROM.

--- a/src/include/duckdb/common/vector_operations/vector_operations.hpp
+++ b/src/include/duckdb/common/vector_operations/vector_operations.hpp
@@ -15,6 +15,7 @@
 
 namespace duckdb {
 class CastFunctionSet;
+struct GetCastFunctionInput;
 
 // VectorOperations contains a set of operations that operate on sets of
 // vectors. In general, the operators must all have the same type, otherwise an
@@ -156,8 +157,8 @@ struct VectorOperations {
 	//! Cast the data from the source type to the target type. Any elements that could not be converted are turned into
 	//! NULLs. If any elements cannot be converted, returns false and fills in the error_message. If no error message is
 	//! provided, an exception is thrown instead.
-	DUCKDB_API static bool TryCast(CastFunctionSet &set, Vector &source, Vector &result, idx_t count,
-	                               string *error_message, bool strict = false);
+	DUCKDB_API static bool TryCast(CastFunctionSet &set, GetCastFunctionInput &input, Vector &source, Vector &result,
+	                               idx_t count, string *error_message, bool strict = false);
 	DUCKDB_API static bool DefaultTryCast(Vector &source, Vector &result, idx_t count, string *error_message,
 	                                      bool strict = false);
 	DUCKDB_API static bool TryCast(ClientContext &context, Vector &source, Vector &result, idx_t count,

--- a/src/include/duckdb/function/cast/cast_function_set.hpp
+++ b/src/include/duckdb/function/cast/cast_function_set.hpp
@@ -12,10 +12,20 @@
 
 namespace duckdb {
 struct MapCastInfo;
+struct MapCastNode;
 
 typedef BoundCastInfo (*bind_cast_function_t)(BindCastInput &input, const LogicalType &source,
                                               const LogicalType &target);
 typedef int64_t (*implicit_cast_cost_t)(const LogicalType &from, const LogicalType &to);
+
+struct GetCastFunctionInput {
+	GetCastFunctionInput(ClientContext *context = nullptr) : context(context) {
+	}
+	GetCastFunctionInput(ClientContext &context) : context(&context) {
+	}
+
+	ClientContext *context;
+};
 
 struct BindCastFunction {
 	BindCastFunction(bind_cast_function_t function,
@@ -35,18 +45,24 @@ public:
 
 	//! Returns a cast function (from source -> target)
 	//! Note that this always returns a function - since a cast is ALWAYS possible if the value is NULL
-	DUCKDB_API BoundCastInfo GetCastFunction(const LogicalType &source, const LogicalType &target);
+	DUCKDB_API BoundCastInfo GetCastFunction(const LogicalType &source, const LogicalType &target,
+	                                         GetCastFunctionInput &input);
 	//! Returns the implicit cast cost of casting from source -> target
 	//! -1 means an implicit cast is not possible
 	DUCKDB_API int64_t ImplicitCastCost(const LogicalType &source, const LogicalType &target);
 	//! Register a new cast function from source to target
 	DUCKDB_API void RegisterCastFunction(const LogicalType &source, const LogicalType &target, BoundCastInfo function,
 	                                     int64_t implicit_cast_cost = -1);
+	DUCKDB_API void RegisterCastFunction(const LogicalType &source, const LogicalType &target,
+	                                     bind_cast_function_t bind, int64_t implicit_cast_cost = -1);
 
 private:
 	vector<BindCastFunction> bind_functions;
 	//! If any custom cast functions have been defined using RegisterCastFunction, this holds the map
 	MapCastInfo *map_info;
+
+private:
+	void RegisterCastFunction(const LogicalType &source, const LogicalType &target, MapCastNode node);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/function/cast/default_casts.hpp
+++ b/src/include/duckdb/function/cast/default_casts.hpp
@@ -58,11 +58,14 @@ public:
 };
 
 struct BindCastInput {
-	BindCastInput(CastFunctionSet &function_set, BindCastInfo *info) : function_set(function_set), info(info) {
-	}
+	DUCKDB_API BindCastInput(CastFunctionSet &function_set, BindCastInfo *info, ClientContext *context);
 
 	CastFunctionSet &function_set;
 	BindCastInfo *info;
+	ClientContext *context;
+
+public:
+	DUCKDB_API BoundCastInfo GetCastFunction(const LogicalType &source, const LogicalType &target);
 };
 
 struct DefaultCasts {


### PR DESCRIPTION
This PR adds support for easily registering a custom bind function to casts using the `RegisterCastFunction` API, and propagates the client context to the `BindCastInput` so that this can be referenced in the bind function. For example:

```cpp
BoundCastInfo INetBindCastFunction(BindCastInput &input, const LogicalType &source, const LogicalType &target) {
     // input.context holds the client context
    return INetFunctions::CastVarcharToINET;
}

casts.RegisterCastFunction(LogicalType::VARCHAR, inet_type, INetBindCastFunction, 100);
```

Note that the client context is optional as it is not available when a default cast is performed (e.g. through `Value::DefaultCastAs`). However, for casts defined in extensions, the client context should always be present as `DefaultCastAs` does not consider casts defined in extensions in the first place.

CC @hawkfish 