### PR TITLE
fix: add numpy to setup_requires to fix build from source

### DIFF
--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -286,7 +286,7 @@ setup(
         'duckdb-stubs'
     ],
     include_package_data=True,
-    setup_requires=setup_requires + ["setuptools_scm"] + ['pybind11>=2.6.0'],
+    setup_requires=setup_requires + ["setuptools_scm", 'numpy>=1.14', 'pybind11>=2.6.0'],
     use_scm_version = setuptools_scm_conf,
     tests_require=['google-cloud-storage', 'mypy', 'pytest'],
     classifiers = [


### PR DESCRIPTION
This should fix issues with building from source in an clean virtual env (ie, one that doesn't already have numpy installed)