### PR TITLE
fix openFlags overwriting in shell fixing #4894

### DIFF
--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -18326,7 +18326,7 @@ static int do_meta_command(char *zLine, ShellState *p){
     sqlite3_free(p->zFreeOnClose);
     p->zFreeOnClose = 0;
     p->openMode = SHELL_OPEN_UNSPEC;
-    p->openFlags = 0;
+    p->openFlags = p->openFlags & ~(SQLITE_OPEN_NOFOLLOW); // don't overwrite settings loaded in the command line
     p->szMax = 0;
     /* Check for command-line arguments */
     for(iName=1; iName<nArg && azArg[iName][0]=='-'; iName++){


### PR DESCRIPTION
This pull request fixes the issue where opening a persistent database from the shell would throw away the set command line flags such as `-unsigned`. With this change it only unsets the flag that can be modified by the command (SQLITE_OPEN_NOFOLLOW) and maintains the other bits. This fixes the issue #4894