### PR TITLE
Bug fix for segmentation fault in list apply

### DIFF
--- a/src/function/scalar/list/list_lambdas.cpp
+++ b/src/function/scalar/list/list_lambdas.cpp
@@ -119,6 +119,7 @@ static void ExecuteExpression(vector<LogicalType> &types, vector<LogicalType> &r
 	vector<Vector> slices;
 	for (idx_t col_idx = 0; col_idx < args.ColumnCount() - 1; col_idx++) {
 		slices.emplace_back(Vector(args.data[col_idx + 1], sel_vectors[col_idx], elem_cnt));
+		slices[col_idx].Flatten(elem_cnt);
 		input_chunk.data[col_idx + 1].Reference(slices[col_idx]);
 	}
 

--- a/test/sql/function/list/lambdas/transform.test
+++ b/test/sql/function/list/lambdas/transform.test
@@ -242,6 +242,8 @@ SELECT list_transform([1, 2, 3], x -> x + #1) FROM range(10)
 
 # test for issue 4855
 
+require vector_size 512
+
 statement ok
 create table test(a int, b int);
 

--- a/test/sql/function/list/lambdas/transform.test
+++ b/test/sql/function/list/lambdas/transform.test
@@ -239,3 +239,24 @@ SELECT list_transform([1, 2, 3], x -> x + #1) FROM range(10)
 [8, 9, 10]
 [9, 10, 11]
 [10, 11, 12]
+
+# test for issue 4855
+
+statement ok
+create table test(a int, b int);
+
+statement ok
+insert into test values (1, 2), (1, 3), (1, 4), (2, 2), (2, 3), (2, 4), (3, 2), (3, 3), (3, 4);
+
+query III
+select list_transform(bb, x->[x,b]), bb, b
+from (select list(b) over wind as bb, first(b) over wind as b
+    from test window wind as
+        (order by a asc rows between 4 preceding and current row)
+    qualify row_number() over wind >4);
+----
+[[2, 2], [3, 2], [4, 2], [2, 2], [3, 2]]	[2, 3, 4, 2, 3]	2
+[[3, 3], [4, 3], [2, 3], [3, 3], [4, 3]]	[3, 4, 2, 3, 4]	3
+[[4, 4], [2, 4], [3, 4], [4, 4], [2, 4]]	[4, 2, 3, 4, 2]	4
+[[2, 2], [3, 2], [4, 2], [2, 2], [3, 2]]	[2, 3, 4, 2, 3]	2
+[[3, 3], [4, 3], [2, 3], [3, 3], [4, 3]]	[3, 4, 2, 3, 4]	3


### PR DESCRIPTION
Nice find actually, I moved the flatten out of the `ExecuteExpression` and into the `ListLambdaFunction`, should solve the issue (#4855).