### PR TITLE
Add CREATE/DROP index to WAL

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -139,6 +139,16 @@ CatalogEntry *Catalog::CreateCollation(ClientContext &context, SchemaCatalogEntr
 	return schema->CreateCollation(context, info);
 }
 
+CatalogEntry *Catalog::CreateIndex(ClientContext &context, CreateIndexInfo *info, TableCatalogEntry *table) {
+	auto schema = GetSchema(context, info->schema);
+	return CreateIndex(context, schema, info, table);
+}
+
+CatalogEntry *Catalog::CreateIndex(ClientContext &context, SchemaCatalogEntry *schema, CreateIndexInfo *info,
+                                   TableCatalogEntry *table) {
+	return schema->CreateIndex(context, info, table);
+}
+
 CatalogEntry *Catalog::CreateSchema(ClientContext &context, CreateSchemaInfo *info) {
 	D_ASSERT(!info->schema.empty());
 	if (info->schema == TEMP_SCHEMA) {

--- a/src/catalog/catalog_entry/index_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/index_catalog_entry.cpp
@@ -27,7 +27,7 @@ string IndexCatalogEntry::ToSQL() {
 	return sql;
 }
 
-void IndexCatalogEntry::Serialize(duckdb::MetaBlockWriter &serializer) {
+void IndexCatalogEntry::Serialize(Serializer &serializer) {
 	// Here we serialize the index metadata in the following order:
 	// schema name, table name, index name, sql, index type, index constraint type, expression list.
 	// column_ids, unbound_expression
@@ -52,7 +52,6 @@ unique_ptr<CreateIndexInfo> IndexCatalogEntry::Deserialize(Deserializer &source,
 	auto create_index_info = make_unique<CreateIndexInfo>();
 
 	FieldReader reader(source);
-
 	create_index_info->schema = reader.ReadRequired<string>();
 	create_index_info->table = make_unique<BaseTableRef>();
 	create_index_info->table->schema_name = create_index_info->schema;
@@ -63,7 +62,6 @@ unique_ptr<CreateIndexInfo> IndexCatalogEntry::Deserialize(Deserializer &source,
 	create_index_info->constraint_type = IndexConstraintType(reader.ReadRequired<uint8_t>());
 	create_index_info->expressions = reader.ReadRequiredSerializableList<ParsedExpression>();
 	create_index_info->parsed_expressions = reader.ReadRequiredSerializableList<ParsedExpression>();
-
 	create_index_info->column_ids = reader.ReadRequiredList<idx_t>();
 	reader.Finalize();
 	return create_index_info;

--- a/src/catalog/catalog_entry/schema_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/schema_catalog_entry.cpp
@@ -279,7 +279,7 @@ void SchemaCatalogEntry::DropEntry(ClientContext &context, DropInfo *info) {
 
 	// remove the foreign key constraint in main key table if main key table's name is valid
 	for (idx_t i = 0; i < fk_arrays.size(); i++) {
-		// alter primary key tablee
+		// alter primary key table
 		Catalog::GetCatalog(context).Alter(context, fk_arrays[i].get());
 	}
 }

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -29,6 +29,7 @@ struct CreateSequenceInfo;
 struct CreateCollationInfo;
 struct CreateTypeInfo;
 struct CreateTableInfo;
+struct CreateIndexInfo;
 
 class ClientContext;
 class Transaction;
@@ -124,6 +125,8 @@ public:
 	DUCKDB_API CatalogEntry *CreateType(ClientContext &context, CreateTypeInfo *info);
 	//! Creates a collation in the catalog
 	DUCKDB_API CatalogEntry *CreateCollation(ClientContext &context, CreateCollationInfo *info);
+	//! Creates an index in the catalog
+	DUCKDB_API CatalogEntry *CreateIndex(ClientContext &context, CreateIndexInfo *info, TableCatalogEntry *table);
 
 	//! Creates a table in the catalog.
 	DUCKDB_API CatalogEntry *CreateTable(ClientContext &context, SchemaCatalogEntry *schema,
@@ -150,6 +153,9 @@ public:
 	//! Creates a collation in the catalog
 	DUCKDB_API CatalogEntry *CreateCollation(ClientContext &context, SchemaCatalogEntry *schema,
 	                                         CreateCollationInfo *info);
+	//! Creates an index in the catalog
+	DUCKDB_API CatalogEntry *CreateIndex(ClientContext &context, SchemaCatalogEntry *schema, CreateIndexInfo *info,
+	                                     TableCatalogEntry *table);
 
 	//! Drops an entry from the catalog
 	DUCKDB_API void DropEntry(ClientContext &context, DropInfo *info);

--- a/src/include/duckdb/catalog/catalog_entry/index_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/index_catalog_entry.hpp
@@ -32,7 +32,7 @@ public:
 
 public:
 	string ToSQL() override;
-	void Serialize(duckdb::MetaBlockWriter &serializer);
+	void Serialize(Serializer &serializer);
 	static unique_ptr<CreateIndexInfo> Deserialize(Deserializer &source, ClientContext &context);
 };
 

--- a/src/include/duckdb/common/enums/wal_type.hpp
+++ b/src/include/duckdb/common/enums/wal_type.hpp
@@ -41,6 +41,9 @@ enum class WALType : uint8_t {
 	CREATE_TABLE_MACRO = 21,
 	DROP_TABLE_MACRO = 22,
 
+	CREATE_INDEX = 23,
+	DROP_INDEX = 24,
+
 	// -----------------------------
 	// Data
 	// -----------------------------

--- a/src/include/duckdb/storage/write_ahead_log.hpp
+++ b/src/include/duckdb/storage/write_ahead_log.hpp
@@ -17,6 +17,7 @@
 
 #include "duckdb/catalog/catalog_entry/scalar_macro_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_macro_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/index_catalog_entry.hpp"
 
 namespace duckdb {
 
@@ -76,6 +77,9 @@ public:
 
 	void WriteCreateTableMacro(TableMacroCatalogEntry *entry);
 	void WriteDropTableMacro(TableMacroCatalogEntry *entry);
+
+	void WriteCreateIndex(IndexCatalogEntry *entry);
+	void WriteDropIndex(IndexCatalogEntry *entry);
 
 	void WriteCreateType(TypeCatalogEntry *entry);
 	void WriteDropType(TypeCatalogEntry *entry);

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -158,6 +158,29 @@ void WriteAheadLog::WriteDropTableMacro(TableMacroCatalogEntry *entry) {
 }
 
 //===--------------------------------------------------------------------===//
+// CREATE INDEX
+//===--------------------------------------------------------------------===//
+void WriteAheadLog::WriteCreateIndex(IndexCatalogEntry *entry) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::CREATE_INDEX);
+	entry->Serialize(*writer);
+}
+
+//===--------------------------------------------------------------------===//
+// DROP INDEX
+//===--------------------------------------------------------------------===//
+void WriteAheadLog::WriteDropIndex(IndexCatalogEntry *entry) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::DROP_INDEX);
+	writer->WriteString(entry->schema->name);
+	writer->WriteString(entry->name);
+}
+
+//===--------------------------------------------------------------------===//
 // Custom Types
 //===--------------------------------------------------------------------===//
 void WriteAheadLog::WriteCreateType(TypeCatalogEntry *entry) {

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -84,7 +84,9 @@ void CommitState::WriteCatalogEntry(CatalogEntry *entry, data_ptr_t dataptr) {
 	case CatalogType::TABLE_MACRO_ENTRY:
 		log->WriteCreateTableMacro((TableMacroCatalogEntry *)parent);
 		break;
-
+	case CatalogType::INDEX_ENTRY:
+		log->WriteCreateIndex((IndexCatalogEntry *)parent);
+		break;
 	case CatalogType::TYPE_ENTRY:
 		log->WriteCreateType((TypeCatalogEntry *)parent);
 		break;
@@ -115,6 +117,8 @@ void CommitState::WriteCatalogEntry(CatalogEntry *entry, data_ptr_t dataptr) {
 			log->WriteDropType((TypeCatalogEntry *)entry);
 			break;
 		case CatalogType::INDEX_ENTRY:
+			log->WriteDropIndex((IndexCatalogEntry *)entry);
+			break;
 		case CatalogType::PREPARED_STATEMENT:
 		case CatalogType::SCALAR_FUNCTION_ENTRY:
 			// do nothing, indexes/prepared statements/functions aren't persisted to disk
@@ -123,7 +127,6 @@ void CommitState::WriteCatalogEntry(CatalogEntry *entry, data_ptr_t dataptr) {
 			throw InternalException("Don't know how to drop this type!");
 		}
 		break;
-	case CatalogType::INDEX_ENTRY:
 	case CatalogType::PREPARED_STATEMENT:
 	case CatalogType::AGGREGATE_FUNCTION_ENTRY:
 	case CatalogType::SCALAR_FUNCTION_ENTRY:

--- a/test/sql/storage/wal/wal_create_index.test
+++ b/test/sql/storage/wal/wal_create_index.test
@@ -1,0 +1,88 @@
+# name: test/sql/storage/wal/wal_create_index.test
+# description: Test serialization of index to WAL
+# group: [wal]
+
+# load the DB from disk
+load __TEST_DIR__/test_wal_create_index.db
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
+statement ok
+CREATE TABLE integers(i INTEGER, j INTEGER)
+
+statement ok
+insert into integers values (1,1), (2,2), (3,3)
+
+# Test single column
+statement ok
+create unique index i_index on integers(i);
+
+#query II
+#EXPLAIN SELECT i FROM integers  where i = 1
+#----
+#logical_opt	<REGEX>:.*INDEX_SCAN.*
+
+restart
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+# this succeeds so I am guessing that it does not find the index for constraint checking
+statement error
+INSERT INTO integers VALUES (1, 1)
+
+# this succeeds, so the index is somewhere?
+statement ok
+DROP INDEX i_index;
+
+query II
+EXPLAIN SELECT i FROM integers  where i = 1
+----
+logical_opt	<REGEX>:.*INDEX_SCAN.*
+
+#restart
+#
+#statement ok
+#PRAGMA disable_checkpoint_on_shutdown
+#
+#statement ok
+#PRAGMA wal_autocheckpoint='1TB';
+#
+#statement ok
+#drop index i_index
+#
+#restart
+#
+#statement ok
+#PRAGMA disable_checkpoint_on_shutdown
+#
+#statement ok
+#PRAGMA wal_autocheckpoint='1TB';
+#
+## Test more complex expression
+#
+#statement ok
+#create index i_index on integers using art((i+j))
+#
+#query II
+#EXPLAIN SELECT i FROM integers  where i+j = 2
+#----
+#logical_opt	<REGEX>:.*INDEX_SCAN.*
+#
+#query I
+#SELECT i FROM integers  where i+j = 2
+#----
+#1
+#
+#statement ok
+#drop index i_index


### PR DESCRIPTION
This PR adds `CREATE INDEX` and `DROP INDEX` functionality to the WAL, as addressed in #4891. 

NOTE: This PR does not pass CI/tests yet, I am missing something somewhere, see the test file @lnkuiper, maybe you can spot something obvious (thanks!). :)