### PR TITLE
Fix breaking CI on unused variable errors

### DIFF
--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -642,6 +642,7 @@ void GroupedAggregateHashTable::Partition(vector<GroupedAggregateHashTable *> &p
 		partition_entry->Verify();
 		total_count += partition_entry->Size();
 	}
+	(void)total_count;
 	D_ASSERT(total_count == entries);
 }
 

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -534,6 +534,7 @@ void WindowLocalSinkState::Combine(WindowGlobalSinkState &gstate) {
 		}
 	}
 
+	(void)check;
 	D_ASSERT(check == count);
 }
 

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -191,6 +191,7 @@ void SingleFileStorageCommitState::FlushCommit() {
 	if (log) {
 		// flush the WAL if any changes were made
 		if (log->GetTotalWritten() > initial_written) {
+			(void)checkpoint;
 			D_ASSERT(!checkpoint);
 			D_ASSERT(!log->skip_writing);
 			log->Flush();


### PR DESCRIPTION
This PR fixes a small issue that caused the CI to fail.

on OSX Debug, when writing the amalgamation, this error occurred:
```
-- Writing src/amalgamation/parquet-amalgamation.cpp --
------------------------
duckdb.cpp:206030:7: error: private field 'checkpoint' is not used [-Werror,-Wunused-private-field]
        bool checkpoint;
             ^
```

It's marked as unused because the D_ASSERT turns into a no-op, and the variable is not used for anything other than the D_ASSERT check.

Not sure it's preferred to just ignore this warning with the amalgamation create script rather than "fixing" them?