### PR TITLE
Add auto-complete support to the shell

### DIFF
--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -201,8 +201,9 @@ vector<string> StringUtil::TopNStrings(vector<pair<string, idx_t>> scores, idx_t
 	if (scores.empty()) {
 		return vector<string>();
 	}
-	sort(scores.begin(), scores.end(),
-	     [](const pair<string, idx_t> &a, const pair<string, idx_t> &b) -> bool { return a.second < b.second; });
+	sort(scores.begin(), scores.end(), [](const pair<string, idx_t> &a, const pair<string, idx_t> &b) -> bool {
+		return a.second < b.second || (a.second == b.second && a.first.size() < b.first.size());
+	});
 	vector<string> result;
 	result.push_back(scores[0].first);
 	for (idx_t i = 1; i < MinValue<idx_t>(scores.size(), n); i++) {

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -274,7 +274,11 @@ vector<string> StringUtil::TopNLevenshtein(const vector<string> &strings, const 
 	vector<pair<string, idx_t>> scores;
 	scores.reserve(strings.size());
 	for (auto &str : strings) {
-		scores.emplace_back(str, LevenshteinDistance(str, target));
+		if (target.size() < str.size()) {
+			scores.emplace_back(str, LevenshteinDistance(str.substr(0, target.size()), target));
+		} else {
+			scores.emplace_back(str, LevenshteinDistance(str, target));
+		}
 	}
 	return TopNStrings(scores, n, threshold);
 }

--- a/src/include/duckdb/common/file_opener.hpp
+++ b/src/include/duckdb/common/file_opener.hpp
@@ -12,6 +12,7 @@
 
 namespace duckdb {
 
+class ClientContext;
 class Value;
 
 //! Abstract type that provide client-specific context to FileSystem.
@@ -20,6 +21,8 @@ public:
 	virtual ~FileOpener() {};
 
 	virtual bool TryGetCurrentSetting(const string &key, Value &result) = 0;
+
+	static FileOpener *Get(ClientContext &context);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -39,6 +39,24 @@ public:
 	DUCKDB_API static char CharacterIsAlpha(char c) {
 		return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
 	}
+	static bool CharacterIsOperator(char c) {
+		if (c == '_') {
+			return false;
+		}
+		if (c >= '!' && c <= '/') {
+			return true;
+		}
+		if (c >= ':' && c <= '@') {
+			return true;
+		}
+		if (c >= '[' && c <= '`') {
+			return true;
+		}
+		if (c >= '{' && c <= '~') {
+			return true;
+		}
+		return false;
+	}
 
 	//! Returns true if the needle string exists in the haystack
 	DUCKDB_API static bool Contains(const string &haystack, const string &needle);

--- a/src/include/duckdb/parser/keyword_helper.hpp
+++ b/src/include/duckdb/parser/keyword_helper.hpp
@@ -18,10 +18,10 @@ public:
 	static bool IsKeyword(const string &text);
 
 	//! Returns true if the given string needs to be quoted when written as an identifier
-	static bool RequiresQuotes(const string &text);
+	static bool RequiresQuotes(const string &text, bool allow_caps = false);
 
 	//! Writes a string that is optionally quoted + escaped so it can be used as an identifier
-	static string WriteOptionallyQuoted(const string &text, char quote = '"');
+	static string WriteOptionallyQuoted(const string &text, char quote = '"', bool allow_caps = false);
 };
 
 } // namespace duckdb

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -217,6 +217,10 @@ Executor &ClientContext::GetExecutor() {
 	return *active_query->executor;
 }
 
+FileOpener *FileOpener::Get(ClientContext &context) {
+	return ClientData::Get(context).file_opener.get();
+}
+
 const string &ClientContext::GetCurrentQuery() {
 	D_ASSERT(active_query);
 	return active_query->query;

--- a/src/parser/keyword_helper.cpp
+++ b/src/parser/keyword_helper.cpp
@@ -8,13 +8,18 @@ bool KeywordHelper::IsKeyword(const string &text) {
 	return Parser::IsKeyword(text);
 }
 
-bool KeywordHelper::RequiresQuotes(const string &text) {
+bool KeywordHelper::RequiresQuotes(const string &text, bool allow_caps) {
 	for (size_t i = 0; i < text.size(); i++) {
 		if (i > 0 && (text[i] >= '0' && text[i] <= '9')) {
 			continue;
 		}
 		if (text[i] >= 'a' && text[i] <= 'z') {
 			continue;
+		}
+		if (allow_caps) {
+			if (text[i] >= 'A' && text[i] <= 'Z') {
+				continue;
+			}
 		}
 		if (text[i] == '_') {
 			continue;
@@ -24,8 +29,8 @@ bool KeywordHelper::RequiresQuotes(const string &text) {
 	return IsKeyword(text);
 }
 
-string KeywordHelper::WriteOptionallyQuoted(const string &text, char quote) {
-	if (!RequiresQuotes(text)) {
+string KeywordHelper::WriteOptionallyQuoted(const string &text, char quote, bool allow_caps) {
+	if (!RequiresQuotes(text, allow_caps)) {
 		return text;
 	}
 	return string(1, quote) + StringUtil::Replace(text, string(1, quote), string(2, quote)) + string(1, quote);

--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -670,6 +670,12 @@ std::string highlightText(char *buf, size_t len, size_t start_pos, size_t end_po
 	std::string sql(buf, len);
 	auto tokens = duckdb::Parser::Tokenize(sql);
 	std::stringstream ss;
+	if (!tokens.empty() && tokens[0].start > 0) {
+		duckdb::SimplifiedToken new_token;
+		new_token.type = duckdb::SimplifiedTokenType::SIMPLIFIED_TOKEN_IDENTIFIER;
+		new_token.start = 0;
+		tokens.insert(tokens.begin(), new_token);
+	}
 	for (size_t i = 0; i < tokens.size(); i++) {
 		size_t next = i + 1 < tokens.size() ? tokens[i + 1].start : len;
 		if (next < start_pos) {

--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -747,6 +747,43 @@ SELECT * FROM sql_auto_complete('select "Funky Column" FROM f') LIMIT 1;
 """, out="\"Funky Table With Spaces\""
 )
 
+# semicolon
+test("""
+SELECT * FROM sql_auto_complete('SELECT 42; SEL') LIMIT 1;
+""", out="SELECT"
+)
+
+# comments
+test("""
+SELECT * FROM sql_auto_complete('--SELECT * FROM
+SEL') LIMIT 1;
+""", out="SELECT"
+)
+
+# scalar functions
+test("""
+SELECT * FROM sql_auto_complete('SELECT regexp_m') LIMIT 1;
+""", out="regexp_matches"
+)
+
+# aggregate functions
+test("""
+SELECT * FROM sql_auto_complete('SELECT approx_c') LIMIT 1;
+""", out="approx_count_distinct"
+)
+
+# built-in views
+test("""
+SELECT * FROM sql_auto_complete('SELECT * FROM sqlite_ma') LIMIT 1;
+""", out="sqlite_master"
+)
+
+# table functions
+test("""
+SELECT * FROM sql_auto_complete('SELECT * FROM read_csv_a') LIMIT 1;
+""", out="read_csv_auto"
+)
+
 if os.name != 'nt':
      test('''
 create table mytable as select * from

--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -784,6 +784,65 @@ SELECT * FROM sql_auto_complete('SELECT * FROM read_csv_a') LIMIT 1;
 """, out="read_csv_auto"
 )
 
+test("""
+CREATE TABLE partsupp(ps_suppkey int);
+CREATE TABLE supplier(s_suppkey int);
+CREATE TABLE nation(n_nationkey int);
+SELECT * FROM sql_auto_complete('DROP TABLE na') LIMIT 1;
+""", out="nation"
+)
+
+test("""
+CREATE TABLE partsupp(ps_suppkey int);
+CREATE TABLE supplier(s_suppkey int);
+CREATE TABLE nation(n_nationkey int);
+SELECT * FROM sql_auto_complete('SELECT s_supp') LIMIT 1;
+""", out="s_suppkey"
+)
+
+# joins
+test("""
+CREATE TABLE partsupp(ps_suppkey int);
+CREATE TABLE supplier(s_suppkey int);
+CREATE TABLE nation(n_nationkey int);
+SELECT * FROM sql_auto_complete('SELECT * FROM partsupp JOIN supp') LIMIT 1;
+""", out="supplier"
+)
+
+test("""
+CREATE TABLE partsupp(ps_suppkey int);
+CREATE TABLE supplier(s_suppkey int);
+CREATE TABLE nation(n_nationkey int);
+.mode csv
+SELECT l,l FROM sql_auto_complete('SELECT * FROM partsupp JOIN supplier ON (s_supp') t(l) LIMIT 1;
+""", out="s_suppkey,s_suppkey"
+)
+
+test("""
+CREATE TABLE partsupp(ps_suppkey int);
+CREATE TABLE supplier(s_suppkey int);
+CREATE TABLE nation(n_nationkey int);
+SELECT * FROM sql_auto_complete('SELECT * FROM partsupp JOIN supplier USING (ps_') LIMIT 1;
+""", out="ps_suppkey"
+)
+
+test("""
+SELECT * FROM sql_auto_complete('SELECT * FR') LIMIT 1;
+""", out="FROM"
+)
+
+test("""
+CREATE TABLE MyTable(MyColumn Varchar);
+SELECT * FROM sql_auto_complete('SELECT My') LIMIT 1;
+""", out="MyColumn"
+)
+
+test("""
+CREATE TABLE MyTable(MyColumn Varchar);
+SELECT * FROM sql_auto_complete('SELECT MyColumn FROM My') LIMIT 1;
+""", out="MyTable"
+)
+
 if os.name != 'nt':
      test('''
 create table mytable as select * from

--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -631,6 +631,122 @@ test('''
 SELECT lsmode(1) AS lsmode;
 ''', out='lsmode')
 
+
+# test auto-complete
+test("""
+CALL sql_auto_complete('SEL')
+""", out="SELECT"
+)
+
+test("""
+CREATE TABLE my_table(my_column INTEGER);
+SELECT * FROM sql_auto_complete('SELECT my_') LIMIT 1;
+""", out="my_column"
+)
+
+test("""
+CREATE TABLE my_table(my_column INTEGER);
+SELECT * FROM sql_auto_complete('SELECT my_column FROM my_') LIMIT 1;
+""", out="my_table"
+)
+
+test("""
+CREATE TABLE my_table(my_column INTEGER);
+SELECT * FROM sql_auto_complete('SELECT my_column FROM my_table WH') LIMIT 1;
+""", out="WHERE"
+)
+
+test("""
+CREATE TABLE my_table(my_column INTEGER);
+SELECT * FROM sql_auto_complete('INS') LIMIT 1;
+""", out="INSERT"
+)
+
+test("""
+CREATE TABLE my_table(my_column INTEGER);
+SELECT * FROM sql_auto_complete('INSERT IN') LIMIT 1;
+""", out="INTO"
+)
+
+test("""
+CREATE TABLE my_table(my_column INTEGER);
+SELECT * FROM sql_auto_complete('INSERT INTO my_t') LIMIT 1;
+""", out="my_table"
+)
+
+test("""
+CREATE TABLE my_table(my_column INTEGER);
+SELECT * FROM sql_auto_complete('INSERT INTO my_table VAL') LIMIT 1;
+""", out="VALUES"
+)
+
+test("""
+CREATE TABLE my_table(my_column INTEGER);
+SELECT * FROM sql_auto_complete('DEL') LIMIT 1;
+""", out="DELETE"
+)
+
+test("""
+CREATE TABLE my_table(my_column INTEGER);
+SELECT * FROM sql_auto_complete('DELETE F') LIMIT 1;
+""", out="FROM"
+)
+
+test("""
+CREATE TABLE my_table(my_column INTEGER);
+SELECT * FROM sql_auto_complete('DELETE FROM m') LIMIT 1;
+""", out="my_table"
+)
+
+test("""
+CREATE TABLE my_table(my_column INTEGER);
+SELECT * FROM sql_auto_complete('DELETE FROM my_table WHERE m') LIMIT 1;
+""", out="my_column"
+)
+
+test("""
+CREATE TABLE my_table(my_column INTEGER);
+SELECT * FROM sql_auto_complete('U') LIMIT 1;
+""", out="UPDATE"
+)
+
+test("""
+CREATE TABLE my_table(my_column INTEGER);
+SELECT * FROM sql_auto_complete('UPDATE m') LIMIT 1;
+""", out="my_table"
+)
+
+test("""
+CREATE TABLE my_table(my_column INTEGER);
+SELECT * FROM sql_auto_complete('UPDATE "m') LIMIT 1;
+""", out="my_table"
+)
+
+test("""
+CREATE TABLE my_table(my_column INTEGER);
+SELECT * FROM sql_auto_complete('UPDATE my_table SET m') LIMIT 1;
+""", out="my_column"
+)
+
+
+test("""
+CREATE TABLE "Funky Table With Spaces"(my_column INTEGER);
+SELECT * FROM sql_auto_complete('SELECT * FROM F') LIMIT 1;
+""", out="\"Funky Table With Spaces\""
+)
+
+test("""
+CREATE TABLE "Funky Table With Spaces"("Funky Column" int);
+SELECT * FROM sql_auto_complete('select f') LIMIT 1;
+""", out="\"Funky Column\""
+)
+
+test("""
+CREATE TABLE "Funky Table With Spaces"("Funky Column" int);
+SELECT * FROM sql_auto_complete('select "Funky Column" FROM f') LIMIT 1;
+""", out="\"Funky Table With Spaces\""
+)
+
 if os.name != 'nt':
      test('''
 create table mytable as select * from

--- a/tools/sqlite3_api_wrapper/CMakeLists.txt
+++ b/tools/sqlite3_api_wrapper/CMakeLists.txt
@@ -9,14 +9,15 @@ add_definitions(-DSQLITE_SHELL_IS_UTF8)
 
 include_directories(../../third_party/utf8proc/include)
 
-add_library(sqlite3_api_wrapper_static STATIC sqlite3_api_wrapper.cpp
-                                              ${ALL_OBJECT_FILES})
+set(SQLITE_API_WRAPPER_FILES
+    sqlite3_api_wrapper.cpp sql_auto_complete_extension.cpp ${ALL_OBJECT_FILES})
+
+add_library(sqlite3_api_wrapper_static STATIC ${SQLITE_API_WRAPPER_FILES})
 target_link_libraries(sqlite3_api_wrapper_static duckdb_static duckdb_utf8proc)
 link_threads(sqlite3_api_wrapper_static)
 
 if(NOT WIN32)
-  add_library(sqlite3_api_wrapper SHARED sqlite3_api_wrapper.cpp
-                                         ${ALL_OBJECT_FILES})
+  add_library(sqlite3_api_wrapper SHARED ${SQLITE_API_WRAPPER_FILES})
   target_link_libraries(sqlite3_api_wrapper duckdb ${DUCKDB_EXTRA_LINK_FLAGS})
   link_threads(sqlite3_api_wrapper)
 

--- a/tools/sqlite3_api_wrapper/include/sql_auto_complete_extension.hpp
+++ b/tools/sqlite3_api_wrapper/include/sql_auto_complete_extension.hpp
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// sql_auto_complete_extension.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb.hpp"
+
+namespace duckdb {
+
+class SQLAutoCompleteExtension : public Extension {
+public:
+	void Load(DuckDB &db) override;
+	std::string Name() override;
+};
+
+} // namespace duckdb

--- a/tools/sqlite3_api_wrapper/sql_auto_complete_extension.cpp
+++ b/tools/sqlite3_api_wrapper/sql_auto_complete_extension.cpp
@@ -1,0 +1,267 @@
+#include "sql_auto_complete_extension.hpp"
+
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/main/client_data.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
+
+namespace duckdb {
+
+struct SQLAutoCompleteFunctionData : public TableFunctionData {
+	explicit SQLAutoCompleteFunctionData(vector<string> suggestions_p) : suggestions(move(suggestions_p)) {
+	}
+
+	vector<string> suggestions;
+};
+
+struct SQLAutoCompleteData : public GlobalTableFunctionState {
+	SQLAutoCompleteData() : offset(0) {
+	}
+
+	idx_t offset;
+};
+
+static vector<string> ComputeSuggestions(vector<string> available_suggestions, const string &prefix,
+                                         const vector<string> &extra_keywords) {
+	available_suggestions.insert(available_suggestions.end(), extra_keywords.begin(), extra_keywords.end());
+	return StringUtil::TopNLevenshtein(available_suggestions, prefix, 10);
+}
+
+static vector<string> InitialKeywords() {
+	return vector<string> {"WITH",    "SELECT",   "INSERT",     "DELETE", "UPDATE",  "ALTER",
+	                       "CREATE",  "DROP",     "COPY",       "EXPORT", "IMPORT",  "VACUUM",
+	                       "PREPARE", "EXECUTE",  "DEALLOCATE", "SET",    "CALL",    "ANALYZE",
+	                       "EXPLAIN", "DESCRIBE", "SUMMARIZE",  "LOAD",   "INSTALL", "CHECKPOINT"};
+}
+
+static vector<string> SuggestKeyword(ClientContext &context) {
+	return InitialKeywords();
+}
+
+static vector<CatalogEntry *> GetAllTables(ClientContext &context) {
+	vector<CatalogEntry *> result;
+	// scan all the schemas for tables and collect themand collect them
+	auto schemas = Catalog::GetCatalog(context).schemas->GetEntries<SchemaCatalogEntry>(context);
+	for (auto &schema : schemas) {
+		schema->Scan(context, CatalogType::TABLE_ENTRY, [&](CatalogEntry *entry) {
+			if (!entry->internal) {
+				result.push_back(entry);
+			}
+		});
+	};
+
+	// check the temp schema as well
+	ClientData::Get(context).temporary_objects->Scan(context, CatalogType::TABLE_ENTRY, [&](CatalogEntry *entry) {
+		if (!entry->internal) {
+			result.push_back(entry);
+		}
+	});
+	return result;
+}
+
+static vector<string> SuggestTableName(ClientContext &context) {
+	vector<string> suggestions;
+	auto all_entries = GetAllTables(context);
+	for (auto &entry : all_entries) {
+		suggestions.push_back(entry->name);
+	}
+	return suggestions;
+}
+
+static vector<string> SuggestColumnName(ClientContext &context) {
+	vector<string> suggestions;
+	auto all_entries = GetAllTables(context);
+	for (auto &entry : all_entries) {
+		if (entry->type == CatalogType::TABLE_ENTRY) {
+			auto &table = (TableCatalogEntry &)*entry;
+			for (auto &col : table.columns) {
+				suggestions.push_back(col.GetName());
+			}
+		} else if (entry->type == CatalogType::VIEW_ENTRY) {
+			auto &view = (ViewCatalogEntry &)*entry;
+			for (auto &col : view.aliases) {
+				suggestions.push_back(col);
+			}
+		}
+	}
+	return suggestions;
+}
+
+static vector<string> SuggestFileName(ClientContext &context, string &prefix) {
+	auto &fs = FileSystem::GetFileSystem(context);
+	string search_dir;
+	for (idx_t i = prefix.size(); i > 0; i--) {
+		if (prefix[i - 1] == '/' || prefix[i - 1] == '\\') {
+			search_dir = prefix.substr(0, i - 1);
+			prefix = prefix.substr(i);
+			break;
+		}
+	}
+	if (search_dir.empty()) {
+		search_dir = ".";
+	}
+	vector<string> result;
+	fs.ListFiles(search_dir, [&](const string &fname, bool is_dir) {
+		string suggestion;
+		if (is_dir) {
+			suggestion = fname + fs.PathSeparator();
+		} else {
+			suggestion = fname;
+		}
+		result.push_back(move(suggestion));
+	});
+	return result;
+}
+
+enum class SuggestionState : uint8_t { SUGGEST_KEYWORD, SUGGEST_TABLE_NAME, SUGGEST_COLUMN_NAME, SUGGEST_FILE_NAME };
+
+static vector<string> GenerateSuggestions(ClientContext &context, const string &sql) {
+	// for auto-completion, we consider 4 scenarios
+	// * there is nothing in the buffer, or only one word -> suggest a keyword
+	// * the previous keyword is SELECT, WHERE, BY, HAVING, ... -> suggest a column name
+	// * the previous keyword is FROM, INSERT, UPDATE ,... -> select a table name
+	// * we are in a string constant -> suggest a filename
+	// figure out which state we are in by doing a run through the query
+	idx_t pos = 0;
+	idx_t last_pos = 0;
+	vector<string> suggested_keywords;
+	SuggestionState suggest_state = SuggestionState::SUGGEST_KEYWORD;
+	case_insensitive_set_t column_name_keywords = {"SELECT", "WHERE", "BY", "HAVING", "QUALIFY", "LIMIT", "SET"};
+	case_insensitive_set_t table_name_keywords = {"FROM", "JOIN", "INSERT", "UPDATE", "DELETE"};
+	case_insensitive_map_t<vector<string>> next_keyword_map;
+	next_keyword_map["SELECT"] = {"FROM",    "WHERE", "GROUP",  "HAVING", "WINDOW", "ORDER",  "BY",        "LIMIT",
+	                              "QUALIFY", "USING", "SAMPLE", "VALUES", "UNION",  "EXCEPT", "INTERSECT", "DISTINCT"};
+	next_keyword_map["WITH"] = {"RECURSIVE", "SELECT", "AS"};
+	next_keyword_map["INSERT"] = {"INTO", "VALUES", "SELECT", "DEFAULT"};
+	next_keyword_map["DELETE"] = {"FROM", "WHERE", "USING"};
+	next_keyword_map["UPDATE"] = {"SET", "WHERE"};
+	next_keyword_map["CREATE"] = {"TABLE", "SCHEMA", "VIEW", "SEQUENCE", "MACRO", "FUNCTION"};
+	next_keyword_map["DROP"] = next_keyword_map["CREATE"];
+	next_keyword_map["ALTER"] = {"TABLE", "VIEW", "ADD", "DROP", "COLUMN", "SET", "TYPE", "DEFAULT", "DATA", "RENAME"};
+
+regular_scan:
+	for (; pos < sql.size(); pos++) {
+		if (sql[pos] == '\'') {
+			pos++;
+			last_pos = pos;
+			goto in_string_constant;
+		}
+		if (sql[pos] == '"') {
+			pos++;
+			last_pos = pos;
+			goto in_quotes;
+		}
+		if (StringUtil::CharacterIsSpace(sql[pos]) || StringUtil::CharacterIsOperator(sql[pos])) {
+			if (pos > last_pos + 1) {
+				goto process_word;
+			}
+			last_pos++;
+		}
+	}
+	goto standard_suggestion;
+in_quotes:
+	for (; pos < sql.size(); pos++) {
+		if (sql[pos] == '\'') {
+			pos++;
+			goto regular_scan;
+		}
+	}
+	goto standard_suggestion;
+in_string_constant:
+	for (; pos < sql.size(); pos++) {
+		if (sql[pos] == '\'') {
+			pos++;
+			goto regular_scan;
+		}
+	}
+	suggest_state = SuggestionState::SUGGEST_FILE_NAME;
+	goto standard_suggestion;
+process_word : {
+	auto next_word = sql.substr(last_pos, pos - last_pos);
+	StringUtil::Trim(next_word);
+	printf("%s\n", next_word.c_str());
+	if (table_name_keywords.find(next_word) != table_name_keywords.end()) {
+		suggest_state = SuggestionState::SUGGEST_TABLE_NAME;
+	} else if (column_name_keywords.find(next_word) != column_name_keywords.end()) {
+		suggest_state = SuggestionState::SUGGEST_COLUMN_NAME;
+	}
+	auto entry = next_keyword_map.find(next_word);
+	if (entry != next_keyword_map.end()) {
+		suggested_keywords = entry->second;
+	}
+}
+	last_pos = pos - 1;
+	goto regular_scan;
+standard_suggestion:
+	auto last_word = sql.substr(last_pos, pos - last_pos);
+	switch (suggest_state) {
+	case SuggestionState::SUGGEST_KEYWORD:
+		return ComputeSuggestions(SuggestKeyword(context), last_word, suggested_keywords);
+	case SuggestionState::SUGGEST_TABLE_NAME:
+		return ComputeSuggestions(SuggestTableName(context), last_word, suggested_keywords);
+	case SuggestionState::SUGGEST_COLUMN_NAME:
+		return ComputeSuggestions(SuggestColumnName(context), last_word, suggested_keywords);
+	case SuggestionState::SUGGEST_FILE_NAME:
+		return ComputeSuggestions(SuggestFileName(context, last_word), last_word, vector<string>());
+	}
+}
+
+static unique_ptr<FunctionData> SQLAutoCompleteBind(ClientContext &context, TableFunctionBindInput &input,
+                                                    vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("suggestion");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return make_unique<SQLAutoCompleteFunctionData>(GenerateSuggestions(context, StringValue::Get(input.inputs[0])));
+}
+
+unique_ptr<GlobalTableFunctionState> SQLAutoCompleteInit(ClientContext &context, TableFunctionInitInput &input) {
+	return make_unique<SQLAutoCompleteData>();
+}
+
+void SQLAutoCompleteFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = (SQLAutoCompleteFunctionData &)*data_p.bind_data;
+	auto &data = (SQLAutoCompleteData &)*data_p.global_state;
+	if (data.offset >= bind_data.suggestions.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < bind_data.suggestions.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = bind_data.suggestions[data.offset++];
+
+		// suggestion, VARCHAR
+		output.SetValue(0, count, Value(entry));
+
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void SQLAutoCompleteExtension::Load(DuckDB &db) {
+	Connection con(db);
+	con.BeginTransaction();
+
+	auto &context = *con.context;
+
+	Catalog &catalog = Catalog::GetCatalog(context);
+	TableFunction auto_complete_fun("sql_auto_complete", {LogicalType::VARCHAR}, SQLAutoCompleteFunction,
+	                                SQLAutoCompleteBind, SQLAutoCompleteInit);
+	CreateTableFunctionInfo auto_complete_info(auto_complete_fun);
+	catalog.CreateTableFunction(context, &auto_complete_info);
+
+	con.Commit();
+}
+
+std::string SQLAutoCompleteExtension::Name() {
+	return "sql_auto_complete";
+}
+
+} // namespace duckdb

--- a/tools/sqlite3_api_wrapper/sql_auto_complete_extension.cpp
+++ b/tools/sqlite3_api_wrapper/sql_auto_complete_extension.cpp
@@ -145,7 +145,7 @@ static vector<string> GenerateSuggestions(ClientContext &context, const string &
 	unordered_set<string> suggested_keywords;
 	SuggestionState suggest_state = SuggestionState::SUGGEST_KEYWORD;
 	case_insensitive_set_t column_name_keywords = {"SELECT", "WHERE", "BY", "HAVING", "QUALIFY", "LIMIT", "SET"};
-	case_insensitive_set_t table_name_keywords = {"FROM", "JOIN", "INSERT", "UPDATE", "DELETE"};
+	case_insensitive_set_t table_name_keywords = {"FROM", "JOIN", "INSERT", "UPDATE", "DELETE", "ALTER", "DROP"};
 	case_insensitive_map_t<unordered_set<string>> next_keyword_map;
 	next_keyword_map["SELECT"] = {"FROM",    "WHERE",  "GROUP",  "HAVING", "WINDOW", "ORDER",     "LIMIT",
 	                              "QUALIFY", "SAMPLE", "VALUES", "UNION",  "EXCEPT", "INTERSECT", "DISTINCT"};

--- a/tools/sqlite3_api_wrapper/sql_auto_complete_extension.cpp
+++ b/tools/sqlite3_api_wrapper/sql_auto_complete_extension.cpp
@@ -223,6 +223,8 @@ standard_suggestion:
 		return ComputeSuggestions(SuggestColumnName(context), last_word, suggested_keywords, true);
 	case SuggestionState::SUGGEST_FILE_NAME:
 		return ComputeSuggestions(SuggestFileName(context, last_word), last_word, unordered_set<string>());
+	default:
+		throw InternalException("Unrecognized suggestion state");
 	}
 }
 

--- a/tools/sqlite3_api_wrapper/sql_auto_complete_extension.cpp
+++ b/tools/sqlite3_api_wrapper/sql_auto_complete_extension.cpp
@@ -225,7 +225,7 @@ regular_scan:
 			last_pos = pos;
 			goto in_quotes;
 		}
-		if (sql[pos] == '-' && pos + 1 < sql.size() && sql[pos] == '-') {
+		if (sql[pos] == '-' && pos + 1 < sql.size() && sql[pos + 1] == '-') {
 			goto in_comment;
 		}
 		if (sql[pos] == ';') {

--- a/tools/sqlite3_api_wrapper/sql_auto_complete_extension.cpp
+++ b/tools/sqlite3_api_wrapper/sql_auto_complete_extension.cpp
@@ -150,6 +150,9 @@ static vector<AutoCompleteCandidate> SuggestColumnName(ClientContext &context) {
 				suggestions.emplace_back(col, 1);
 			}
 		} else {
+			if (StringUtil::CharacterIsOperator(entry->name[0])) {
+				continue;
+			}
 			suggestions.emplace_back(entry->name);
 		};
 	}

--- a/tools/sqlite3_api_wrapper/sql_auto_complete_extension.cpp
+++ b/tools/sqlite3_api_wrapper/sql_auto_complete_extension.cpp
@@ -147,8 +147,8 @@ static vector<string> GenerateSuggestions(ClientContext &context, const string &
 	case_insensitive_set_t column_name_keywords = {"SELECT", "WHERE", "BY", "HAVING", "QUALIFY", "LIMIT", "SET"};
 	case_insensitive_set_t table_name_keywords = {"FROM", "JOIN", "INSERT", "UPDATE", "DELETE"};
 	case_insensitive_map_t<unordered_set<string>> next_keyword_map;
-	next_keyword_map["SELECT"] = {"FROM",    "WHERE", "GROUP",  "HAVING", "WINDOW", "ORDER",  "BY",        "LIMIT",
-	                              "QUALIFY", "USING", "SAMPLE", "VALUES", "UNION",  "EXCEPT", "INTERSECT", "DISTINCT"};
+	next_keyword_map["SELECT"] = {"FROM",    "WHERE",  "GROUP",  "HAVING", "WINDOW", "ORDER",     "LIMIT",
+	                              "QUALIFY", "SAMPLE", "VALUES", "UNION",  "EXCEPT", "INTERSECT", "DISTINCT"};
 	next_keyword_map["WITH"] = {"RECURSIVE", "SELECT", "AS"};
 	next_keyword_map["INSERT"] = {"INTO", "VALUES", "SELECT", "DEFAULT"};
 	next_keyword_map["DELETE"] = {"FROM", "WHERE", "USING"};
@@ -205,6 +205,8 @@ process_word : {
 	auto entry = next_keyword_map.find(next_word);
 	if (entry != next_keyword_map.end()) {
 		suggested_keywords = entry->second;
+	} else {
+		suggested_keywords.erase(next_word);
 	}
 }
 	last_pos = pos - 1;

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -1,4 +1,5 @@
 #include "sqlite3.h"
+#include "sql_auto_complete_extension.hpp"
 #include "udf_struct_sqlite3.h"
 #include "sqlite3_udf_wrapper.hpp"
 #include "cast_sqlite.hpp"
@@ -99,6 +100,7 @@ int sqlite3_open_v2(const char *filename, /* Database filename (UTF-8) */
 			config.options.allow_unsigned_extensions = true;
 		}
 		pDb->db = make_unique<DuckDB>(filename, &config);
+		pDb->db->LoadExtension<SQLAutoCompleteExtension>();
 		pDb->con = make_unique<Connection>(*pDb->db);
 	} catch (const Exception &ex) {
 		if (pDb) {


### PR DESCRIPTION
This PR adds smart auto-complete powered by AI¹ to the shell.

¹ i.e. a state machine and a bunch of if statements

### Suggestions
Suggestions are triggered in the shell by using the tab key. The tab key will fire off a query `CALL sql_auto_complete('<partial_query>')`, where `<partial_query>` is whatever is currently typed on the current line.

In the function, we scan this partial query and try to come up with suggestions. This process works as follows:

We have four sets of suggestions:
* Initial keywords
* Table names + keywords
* Column names + keywords
* File names

We start out with a list of initial keywords (`SELECT`, `DELETE`, `UPDATE`, etc). When we encounter a new keyword, there is a transition of keywords that are possible starting from that point. For example, after we encounter `SELECT`, subsequent possible keywords are `FROM`, `WHERE`, etc.

Specific keywords trigger a transition between suggesting table names and suggesting column names. After a `SELECT`, for example, we start suggesting column names. After a `FROM`, we start suggesting table names.

The table and column names look at all the column/table names present in the database, and do not analyze the current query. For example, if you have a query `SELECT * FROM tbl WHERE my_`, then the suggested column names will be selected from all tables in the system, not just `tbl`. The auto-complete is also limited in that it will only consider tables and views that are in the DuckDB catalog, i.e. the system will not read a Parquet file to figure out the columns inside of it for the purposes of auto-complete.

In addition to the table/column name auto-complete, there is one special case: if we are in a string-constant, we suggest filenames. This scans the local file system similar to how a regular shell might auto-complete filenames. So if you have a file `my_data.csv` sitting in your current directory, the query `SELECT * FROM 'my_` will autocomplete to `SELECT * FROM 'my_data.csv`.

### Examples

Below are some examples of auto-completions, given the presence of the following tables

```sql
CREATE TABLE students(name varchar, address varchar, phone_number varchar);
CREATE TABLE grades(student_id integer, grade integer);
```

And the presence of the following files:

```
data/students.csv
data/grades.csv
```

The following auto-completions will be provided:

```sql
S -> SELECT

SELECT s -> student_id

SELECT student_id F -> FROM


SELECT student_id FROM g -> grades

SELECT student_id FROM 'd -> data/

SELECT student_id FROM 'data/ -> data/grades.csv
```

The auto-completion will also automatically provide quotes for column/table names that require them. For example:

```sql
CREATE TABLE "Funky Table With Spaces"("Funky Column" int);

SELECT F -> "Funky Column"

SELECT "Funky Column" FROM F -> "Funky Table With Spaces"
```