### PR TITLE
Issue #4942: Check DESC Errors

### DIFF
--- a/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -67,7 +67,7 @@ BindResult SelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFuncti
 	for (auto &child : aggr.children) {
 		aggregate_binder.BindChild(child, 0, error);
 		// We have to invert the fractions for PERCENTILE_XXXX DESC
-		if (invert_fractions) {
+		if (error.empty() && invert_fractions) {
 			InvertPercentileFractions(child);
 		}
 	}

--- a/test/sql/aggregate/aggregates/test_ordered_aggregates.test
+++ b/test/sql/aggregate/aggregates/test_ordered_aggregates.test
@@ -115,3 +115,7 @@ select percentile_disc('duck') within group(order by i) from generate_series(0,1
 # No function matches the given name and argument types 'quantile_cont(BIGINT, VARCHAR)'
 statement error
 select percentile_cont('duck') within group(order by i) from generate_series(0,100) tbl(i);
+
+# aggregate function calls cannot be nested
+statement error
+SELECT percentile_disc(sum(1)) WITHIN GROUP (ORDER BY 1 DESC);


### PR DESCRIPTION
We were not checking for binding errors when inverting ordered aggregate children when the ORDER BY was DESC.