### PR TITLE
avoid double-writing the index data

### DIFF
--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -20,6 +20,7 @@ ART::ART(const vector<column_t> &column_ids, TableIOManager &table_io_manager,
 	} else {
 		tree = nullptr;
 	}
+	serialized_data_pointer = BlockPointer(block_id, block_offset);
 	for (idx_t i = 0; i < types.size(); i++) {
 		switch (types[i]) {
 		case PhysicalType::BOOL:
@@ -883,9 +884,11 @@ void ART::VerifyExistence(DataChunk &chunk, VerifyExistenceType verify_type, str
 BlockPointer ART::Serialize(duckdb::MetaBlockWriter &writer) {
 	lock_guard<mutex> l(lock);
 	if (tree) {
-		return tree->Serialize(*this, writer);
+		serialized_data_pointer = tree->Serialize(*this, writer);
+	} else {
+		serialized_data_pointer = {(block_id_t)DConstants::INVALID_INDEX, (uint32_t)DConstants::INVALID_INDEX};
 	}
-	return {(block_id_t)DConstants::INVALID_INDEX, (uint32_t)DConstants::INVALID_INDEX};
+	return serialized_data_pointer;
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/storage/checkpoint_manager.hpp
+++ b/src/include/duckdb/storage/checkpoint_manager.hpp
@@ -34,7 +34,6 @@ public:
 
 	virtual MetaBlockWriter &GetMetaBlockWriter() = 0;
 	virtual unique_ptr<TableDataWriter> GetTableDataWriter(TableCatalogEntry &table) = 0;
-	virtual BlockPointer WriteIndexData(IndexCatalogEntry &index_catalog) = 0;
 
 protected:
 	virtual void WriteSchema(SchemaCatalogEntry &schema);
@@ -96,7 +95,6 @@ public:
 
 	virtual MetaBlockWriter &GetMetaBlockWriter() override;
 	virtual unique_ptr<TableDataWriter> GetTableDataWriter(TableCatalogEntry &table) override;
-	virtual BlockPointer WriteIndexData(IndexCatalogEntry &index_catalog) override;
 
 	BlockManager &GetBlockManager();
 

--- a/src/include/duckdb/storage/index.hpp
+++ b/src/include/duckdb/storage/index.hpp
@@ -106,11 +106,19 @@ public:
 	//! Serializes the index and returns the pair of block_id offset positions
 	virtual BlockPointer Serialize(duckdb::MetaBlockWriter &writer);
 
+	//! Returns block/offset of where index was most recently serialized.
+	BlockPointer GetSerializedDataPointer() const {
+		return serialized_data_pointer;
+	}
+
 protected:
 	void ExecuteExpressions(DataChunk &input, DataChunk &result);
 
 	//! Lock used for updating the index
 	mutex lock;
+
+	//! Pointer to most recently checkpointed index data.
+	BlockPointer serialized_data_pointer;
 
 private:
 	//! Bound expressions used by the index

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -40,10 +40,6 @@ BlockManager &SingleFileCheckpointWriter::GetBlockManager() {
 	return *storage_manager.block_manager;
 }
 
-BlockPointer SingleFileCheckpointWriter::WriteIndexData(IndexCatalogEntry &index_catalog) {
-	return index_catalog.index->Serialize(*table_metadata_writer);
-}
-
 MetaBlockWriter &SingleFileCheckpointWriter::GetMetaBlockWriter() {
 	return *metadata_writer;
 }
@@ -329,9 +325,9 @@ void CheckpointReader::ReadSequence(ClientContext &context, MetaBlockReader &rea
 // Indexes
 //===--------------------------------------------------------------------===//
 void CheckpointWriter::WriteIndex(IndexCatalogEntry &index_catalog) {
-	// Write the index data and metadata
-	// Serialize the necessary meta data for index catalog construction.
-	auto root_offset = WriteIndexData(index_catalog);
+	// The index data should already have been written as part of WriteTableData.
+	// Here, we need only serialize the pointer to that data.
+	auto root_offset = index_catalog.index->GetSerializedDataPointer();
 	auto &metadata_writer = GetMetaBlockWriter();
 	index_catalog.Serialize(metadata_writer);
 	// Serialize the Block id and offset of root node

--- a/test/sql/storage/test_index_checkpoint.test
+++ b/test/sql/storage/test_index_checkpoint.test
@@ -9,7 +9,8 @@ statement ok
 PRAGMA wal_autocheckpoint='1TB';
 
 statement ok
-create table t2 (i integer,  uid varchar, PRIMARY KEY (i,uid));
+create table t2 (i integer,  uid varchar);
+create unique index iu on t2(uid);
 
 statement ok
 insert into t2 select i.range as i, gen_random_uuid() as uid FROM range(10000) as i;
@@ -21,9 +22,9 @@ statement ok
 select * from pragma_database_size();
 
 # A prior version of index checkpoint caused index data to be written twice,
-# which results in a database size of 1.8MB (7 blocks). When the data is not
-# duplicated, the size is just under 1.6MB (6 blocks). This verifies we do not regress.
+# which results in a database size of 2.8MB (11 blocks). When the data is not
+# duplicated, the size is just under 1.8MB (7 blocks). This verifies we do not regress.
 query I
-select total_blocks * block_size < 1600000 from pragma_database_size();
+select total_blocks * block_size < 2100000 from pragma_database_size();
 ----
 true

--- a/test/sql/storage/test_index_checkpoint.test
+++ b/test/sql/storage/test_index_checkpoint.test
@@ -1,0 +1,29 @@
+# name: test/sql/storage/test_index_checkpoint.test
+# description: Verify that database footprint remains within expected bounds when writing index data.
+# group: [storage]
+
+load __TEST_DIR__/test_index_checkpoint.db
+
+# Ensure we do not checkpoint early (which would throw off the total_blocks stat)
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+statement ok
+create table t2 (i integer,  uid varchar, PRIMARY KEY (i,uid));
+
+statement ok
+insert into t2 select i.range as i, gen_random_uuid() as uid FROM range(10000) as i;
+
+statement ok
+CHECKPOINT;
+
+statement ok
+select * from pragma_database_size();
+
+# A prior version of index checkpoint caused index data to be written twice,
+# which results in a database size of 1.8MB (7 blocks). When the data is not
+# duplicated, the size is just under 1.6MB (6 blocks). This verifies we do not regress.
+query I
+select total_blocks * block_size < 1600000 from pragma_database_size();
+----
+true

--- a/test/sql/storage/test_index_checkpoint.test
+++ b/test/sql/storage/test_index_checkpoint.test
@@ -2,6 +2,8 @@
 # description: Verify that database footprint remains within expected bounds when writing index data.
 # group: [storage]
 
+require skip_reload
+
 load __TEST_DIR__/test_index_checkpoint.db
 
 # Ensure we do not checkpoint early (which would throw off the total_blocks stat)


### PR DESCRIPTION
It seems that index data is getting written twice. Once via WriteTableData, and then again in WriteIndexData.

With this change, the data is written only once (via WriteTableData, which is guaranteed to get invoked first), and WriteIndexData only rewrites the pointer.

There should be no detectable change in file-format, in either direction.