### PR TITLE
Issue #4944: Negative Unpadded Centuries

### DIFF
--- a/src/function/scalar/date/strftime.cpp
+++ b/src/function/scalar/date/strftime.cpp
@@ -134,7 +134,7 @@ idx_t StrfTimeFormat::GetSpecifierLength(StrTimeSpecifier specifier, date_t date
 	case StrTimeSpecifier::DAY_OF_YEAR_DECIMAL:
 		return NumericHelper::UnsignedLength<uint32_t>(Date::ExtractDayOfTheYear(date));
 	case StrTimeSpecifier::YEAR_WITHOUT_CENTURY:
-		return NumericHelper::UnsignedLength<uint32_t>(Date::ExtractYear(date) % 100);
+		return NumericHelper::UnsignedLength<uint32_t>(AbsValue(Date::ExtractYear(date)) % 100);
 	default:
 		throw InternalException("Unimplemented specifier for GetSpecifierLength");
 	}
@@ -351,7 +351,7 @@ char *StrfTimeFormat::WriteStandardSpecifier(StrTimeSpecifier specifier, int32_t
 		break;
 	}
 	case StrTimeSpecifier::YEAR_WITHOUT_CENTURY: {
-		target = Write2(target, data[0] % 100);
+		target = Write2(target, AbsValue(data[0]) % 100);
 		break;
 	}
 	case StrTimeSpecifier::HOUR_24_DECIMAL: {

--- a/test/sql/function/date/test_strftime_exhaustive.test
+++ b/test/sql/function/date/test_strftime_exhaustive.test
@@ -373,6 +373,11 @@ SELECT strftime(date '-99999-01-01', '%y')
 ----
 99
 
+query I
+SELECT strftime(DATE '-4869706-10-11','%-yi');
+----
+6i
+
 statement error
 SELECT strftime(date '-99999-01-01', random()::varchar)
 


### PR DESCRIPTION
Add some missing absolute value conversions
when formatting unpadded negative years
without the century.