### PR TITLE
Split row-group append into Initialize/Append/Finalize and separate append code from version info append

### DIFF
--- a/src/execution/operator/persistent/physical_update.cpp
+++ b/src/execution/operator/persistent/physical_update.cpp
@@ -100,7 +100,7 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, GlobalSinkState &
 		for (idx_t i = 0; i < columns.size(); i++) {
 			mock_chunk.data[columns[i]].Reference(update_chunk.data[i]);
 		}
-		table.Append(tableref, context.client, mock_chunk);
+		table.LocalAppend(tableref, context.client, mock_chunk);
 	} else {
 		if (return_chunk) {
 			mock_chunk.SetCardinality(update_chunk);

--- a/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
@@ -37,10 +37,12 @@ public:
 public:
 	// Sink interface
 	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
-	void Combine(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate) const override;
 	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const override;
 	SinkResultType Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
 	                    DataChunk &input) const override;
+	void Combine(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate) const override;
+	SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+	                          GlobalSinkState &gstate) const override;
 
 	bool IsSink() const override {
 		return true;

--- a/src/include/duckdb/execution/operator/schema/physical_create_table_as.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_table_as.hpp
@@ -32,9 +32,10 @@ public:
 
 public:
 	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
-
 	SinkResultType Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
 	                    DataChunk &input) const override;
+	SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+	                          GlobalSinkState &gstate) const override;
 
 	bool IsSink() const override {
 		return true;

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -65,7 +65,7 @@ private:
 	unique_ptr<ConnectionManager> connection_manager;
 	unordered_set<std::string> loaded_extensions;
 	//! Set to true if a fatal exception has occurred
-	bool is_invalidated = false;
+	atomic<bool> is_invalidated;
 };
 
 //! The database object. This object holds the catalog and all the

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -25,6 +25,7 @@
 
 namespace duckdb {
 class ClientContext;
+class ColumnDataCollection;
 class ColumnDefinition;
 class DataTable;
 class RowGroup;
@@ -83,8 +84,17 @@ public:
 	void Fetch(Transaction &transaction, DataChunk &result, const vector<column_t> &column_ids, Vector &row_ids,
 	           idx_t fetch_count, ColumnFetchState &state);
 
-	//! Append a DataChunk to the table. Throws an exception if the columns don't match the tables' columns.
-	void Append(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk);
+	//! Initializes an append to transaction-local storage
+	void InitializeLocalAppend(LocalAppendState &state, ClientContext &context);
+	//! Append a DataChunk to the transaction-local storage of the table.
+	void LocalAppend(LocalAppendState &state, TableCatalogEntry &table, ClientContext &context, DataChunk &chunk);
+	//! Finalizes a transaction-local append
+	void FinalizeLocalAppend(LocalAppendState &state);
+	//! Append a chunk to the transaction-local storage of this table
+	void LocalAppend(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk);
+	//! Append a column data collection to the transaction-local storage of this table
+	void LocalAppend(TableCatalogEntry &table, ClientContext &context, ColumnDataCollection &collection);
+
 	//! Delete the entries with the specified row identifier from the table
 	idx_t Delete(TableCatalogEntry &table, ClientContext &context, Vector &row_ids, idx_t count);
 	//! Update the entries with the specified row identifier from the table

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -115,11 +115,9 @@ public:
 	//! Fetches an append lock
 	void AppendLock(TableAppendState &state);
 	//! Begin appending structs to this table, obtaining necessary locks, etc
-	void InitializeAppend(TableAppendState &state);
+	void InitializeAppend(Transaction &transaction, TableAppendState &state, idx_t append_count);
 	//! Append a chunk to the table using the AppendState obtained from InitializeAppend
 	void Append(DataChunk &chunk, TableAppendState &state);
-	//! Finalize an append with the given transaction context
-	void FinalizeAppend(Transaction &transaction, TableAppendState &state);
 	//! Commit the append
 	void CommitAppend(transaction_t commit_id, idx_t row_start, idx_t count);
 	//! Write a segment of the table to the WAL

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -105,9 +105,11 @@ public:
 	//! Fetches an append lock
 	void AppendLock(TableAppendState &state);
 	//! Begin appending structs to this table, obtaining necessary locks, etc
-	void InitializeAppend(Transaction &transaction, TableAppendState &state, idx_t append_count);
-	//! Append a chunk to the table using the AppendState obtained from BeginAppend
-	void Append(Transaction &transaction, DataChunk &chunk, TableAppendState &state);
+	void InitializeAppend(TableAppendState &state);
+	//! Append a chunk to the table using the AppendState obtained from InitializeAppend
+	void Append(DataChunk &chunk, TableAppendState &state);
+	//! Finalize an append with the given transaction context
+	void FinalizeAppend(Transaction &transaction, TableAppendState &state);
 	//! Commit the append
 	void CommitAppend(transaction_t commit_id, idx_t row_start, idx_t count);
 	//! Write a segment of the table to the WAL

--- a/src/include/duckdb/storage/string_uncompressed.hpp
+++ b/src/include/duckdb/storage/string_uncompressed.hpp
@@ -74,6 +74,7 @@ public:
 	                              std::unordered_map<string, int32_t> *seen_strings = nullptr) {
 		auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
 		auto handle = buffer_manager.Pin(segment.block);
+		return StringAppendBase(handle, segment, stats, data, offset, count);
 	}
 	template <bool DUPLICATE_ELIMINATE = false>
 	static idx_t StringAppendBase(BufferHandle &handle, ColumnSegment &segment, SegmentStatistics &stats,

--- a/src/include/duckdb/storage/string_uncompressed.hpp
+++ b/src/include/duckdb/storage/string_uncompressed.hpp
@@ -57,9 +57,15 @@ public:
 	                           idx_t result_idx);
 	static unique_ptr<CompressedSegmentState> StringInitSegment(ColumnSegment &segment, block_id_t block_id);
 
-	static idx_t StringAppend(ColumnSegment &segment, SegmentStatistics &stats, UnifiedVectorFormat &data, idx_t offset,
-	                          idx_t count) {
-		return StringAppendBase(segment, stats, data, offset, count);
+	static unique_ptr<CompressionAppendState> StringInitAppend(ColumnSegment &segment) {
+		auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+		auto handle = buffer_manager.Pin(segment.block);
+		return make_unique<CompressionAppendState>(move(handle));
+	}
+
+	static idx_t StringAppend(CompressionAppendState &append_state, ColumnSegment &segment, SegmentStatistics &stats,
+	                          UnifiedVectorFormat &data, idx_t offset, idx_t count) {
+		return StringAppendBase(append_state.handle, segment, stats, data, offset, count);
 	}
 
 	template <bool DUPLICATE_ELIMINATE = false>
@@ -68,7 +74,11 @@ public:
 	                              std::unordered_map<string, int32_t> *seen_strings = nullptr) {
 		auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
 		auto handle = buffer_manager.Pin(segment.block);
-
+	}
+	template <bool DUPLICATE_ELIMINATE = false>
+	static idx_t StringAppendBase(BufferHandle &handle, ColumnSegment &segment, SegmentStatistics &stats,
+	                              UnifiedVectorFormat &data, idx_t offset, idx_t count,
+	                              std::unordered_map<string, int32_t> *seen_strings = nullptr) {
 		D_ASSERT(segment.GetBlockOffset() == 0);
 		auto source_data = (string_t *)data.data;
 		auto result_data = (int32_t *)(handle.Ptr() + DICTIONARY_HEADER_SIZE);

--- a/src/include/duckdb/storage/table/append_state.hpp
+++ b/src/include/duckdb/storage/table/append_state.hpp
@@ -16,9 +16,9 @@
 namespace duckdb {
 class ColumnSegment;
 class DataTable;
+class LocalTableStorage;
 class RowGroup;
 class UpdateSegment;
-class ValiditySegment;
 
 struct TableAppendState;
 
@@ -52,7 +52,6 @@ struct IndexLock {
 struct TableAppendState {
 	TableAppendState() : row_group_append_state(*this), total_append_count(0), start_row_group(nullptr) {
 	}
-	~TableAppendState();
 
 	RowGroupAppendState row_group_append_state;
 	unique_lock<mutex> append_lock;
@@ -62,6 +61,11 @@ struct TableAppendState {
 	idx_t total_append_count;
 	//! The first row-group that has been appended to
 	RowGroup *start_row_group;
+};
+
+struct LocalAppendState {
+	TableAppendState append_state;
+	LocalTableStorage *storage;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/append_state.hpp
+++ b/src/include/duckdb/storage/table/append_state.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/storage/buffer/buffer_handle.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/function/compression_function.hpp"
+#include "duckdb/transaction/transaction_data.hpp"
 
 namespace duckdb {
 class ColumnSegment;
@@ -53,8 +54,8 @@ struct IndexLock {
 };
 
 struct TableAppendState {
-	TableAppendState() : row_group_append_state(*this), total_append_count(0), start_row_group(nullptr) {
-	}
+	TableAppendState();
+	~TableAppendState();
 
 	RowGroupAppendState row_group_append_state;
 	unique_lock<mutex> append_lock;
@@ -64,6 +65,10 @@ struct TableAppendState {
 	idx_t total_append_count;
 	//! The first row-group that has been appended to
 	RowGroup *start_row_group;
+	//! The transaction data
+	TransactionData transaction;
+	//! The remaining append count, only if the append count is known beforehand
+	idx_t remaining;
 };
 
 struct LocalAppendState {

--- a/src/include/duckdb/storage/table/append_state.hpp
+++ b/src/include/duckdb/storage/table/append_state.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/storage/storage_lock.hpp"
 #include "duckdb/storage/buffer/buffer_handle.hpp"
 #include "duckdb/common/vector.hpp"
+#include "duckdb/function/compression_function.hpp"
 
 namespace duckdb {
 class ColumnSegment;
@@ -29,6 +30,8 @@ struct ColumnAppendState {
 	vector<ColumnAppendState> child_appends;
 	//! The write lock that is held by the append
 	unique_ptr<StorageLockKey> lock;
+	//! The compression append state
+	unique_ptr<CompressionAppendState> append_state;
 };
 
 struct RowGroupAppendState {

--- a/src/include/duckdb/storage/table/append_state.hpp
+++ b/src/include/duckdb/storage/table/append_state.hpp
@@ -50,14 +50,18 @@ struct IndexLock {
 };
 
 struct TableAppendState {
-	TableAppendState() : row_group_append_state(*this) {
+	TableAppendState() : row_group_append_state(*this), total_append_count(0), start_row_group(nullptr) {
 	}
+	~TableAppendState();
 
 	RowGroupAppendState row_group_append_state;
 	unique_lock<mutex> append_lock;
 	row_t row_start;
 	row_t current_row;
-	idx_t remaining_append_count;
+	//! The total number of rows appended by the append operation
+	idx_t total_append_count;
+	//! The first row-group that has been appended to
+	RowGroup *start_row_group;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/column_segment.hpp
+++ b/src/include/duckdb/storage/table/column_segment.hpp
@@ -81,7 +81,7 @@ public:
 	//! Finalize the segment for appending - no more appends can follow on this segment
 	//! The segment should be compacted as much as possible
 	//! Returns the number of bytes occupied within the segment
-	idx_t FinalizeAppend();
+	idx_t FinalizeAppend(ColumnAppendState &state);
 	//! Revert an append made to this segment
 	void RevertAppend(idx_t start_row);
 

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -114,7 +114,7 @@ public:
 	              row_t row_id, DataChunk &result, idx_t result_idx);
 
 	//! Append count rows to the version info
-	void AppendVersionInfo(TransactionData transaction, idx_t start, idx_t count, transaction_t commit_id);
+	void AppendVersionInfo(TransactionData transaction, idx_t count);
 	//! Commit a previous append made by RowGroup::AppendVersionInfo
 	void CommitAppend(transaction_t commit_id, idx_t start, idx_t count);
 	//! Revert a previous append made by RowGroup::AppendVersionInfo
@@ -127,7 +127,7 @@ public:
 	static void Serialize(RowGroupPointer &pointer, Serializer &serializer);
 	static RowGroupPointer Deserialize(Deserializer &source, const vector<ColumnDefinition> &columns);
 
-	void InitializeAppend(TransactionData transaction, RowGroupAppendState &append_state, idx_t remaining_append_count);
+	void InitializeAppend(RowGroupAppendState &append_state);
 	void Append(RowGroupAppendState &append_state, DataChunk &chunk, idx_t append_count);
 
 	void Update(TransactionData transaction, DataChunk &updates, row_t *ids, idx_t offset, idx_t count,

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -48,8 +48,9 @@ public:
 	void Fetch(TransactionData transaction, DataChunk &result, const vector<column_t> &column_ids,
 	           Vector &row_identifiers, idx_t fetch_count, ColumnFetchState &state);
 
-	void InitializeAppend(TransactionData transaction, TableAppendState &state, idx_t append_count);
-	void Append(TransactionData transaction, DataChunk &chunk, TableAppendState &state, TableStatistics &stats);
+	void InitializeAppend(TableAppendState &state);
+	void Append(DataChunk &chunk, TableAppendState &state, TableStatistics &stats);
+	void FinalizeAppend(TransactionData transaction, TableAppendState &state);
 	void CommitAppend(transaction_t commit_id, idx_t row_start, idx_t count);
 	void RevertAppendInternal(idx_t start_row, idx_t count);
 

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -48,8 +48,13 @@ public:
 	void Fetch(TransactionData transaction, DataChunk &result, const vector<column_t> &column_ids,
 	           Vector &row_identifiers, idx_t fetch_count, ColumnFetchState &state);
 
+	//! Initialize an append of a variable number of rows. FinalizeAppend must be called after appending is done.
 	void InitializeAppend(TableAppendState &state);
+	//! Initialize an append with a known number of rows. FinalizeAppend should not be called after appending is done.
+	void InitializeAppend(TransactionData transaction, TableAppendState &state, idx_t append_count);
+	//! Append a chunk to a table.
 	void Append(DataChunk &chunk, TableAppendState &state, TableStatistics &stats);
+	//! FinalizeAppend flushes an append with a variable number of rows.
 	void FinalizeAppend(TransactionData transaction, TableAppendState &state);
 	void CommitAppend(transaction_t commit_id, idx_t row_start, idx_t count);
 	void RevertAppendInternal(idx_t start_row, idx_t count);

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -70,16 +70,19 @@ public:
 	bool NextParallelScan(ClientContext &context, DataTable *table, ParallelCollectionScanState &state,
 	                      CollectionScanState &scan_state);
 
+	//! Begin appending to the local storage
+	void InitializeAppend(LocalAppendState &state, DataTable *table);
 	//! Append a chunk to the local storage
-	void Append(DataTable *table, DataChunk &chunk);
+	static void Append(LocalAppendState &state, DataChunk &chunk);
+	//! Finish appending to the local storage
+	static void FinalizeAppend(LocalAppendState &state);
 	//! Delete a set of rows from the local storage
 	idx_t Delete(DataTable *table, Vector &row_ids, idx_t count);
 	//! Update a set of rows in the local storage
 	void Update(DataTable *table, Vector &row_ids, const vector<column_t> &column_ids, DataChunk &data);
 
 	//! Commits the local storage, writing it to the WAL and completing the commit
-	void Commit(LocalStorage::CommitState &commit_state, Transaction &transaction, WriteAheadLog *log,
-	            transaction_t commit_id);
+	void Commit(LocalStorage::CommitState &commit_state, Transaction &transaction);
 
 	bool ChangesMade() noexcept {
 		return table_storage.size() > 0;

--- a/src/include/duckdb/transaction/transaction.hpp
+++ b/src/include/duckdb/transaction/transaction.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/transaction/undo_buffer.hpp"
 #include "duckdb/transaction/local_storage.hpp"
 #include "duckdb/common/atomic.hpp"
+#include "duckdb/transaction/transaction_data.hpp"
 
 namespace duckdb {
 class SequenceCatalogEntry;
@@ -103,20 +104,6 @@ private:
 	UndoBuffer undo_buffer;
 
 	Transaction(const Transaction &) = delete;
-};
-
-struct TransactionData {
-	TransactionData(Transaction &transaction_p) // NOLINT
-	    : transaction(&transaction_p), transaction_id(transaction_p.transaction_id),
-	      start_time(transaction_p.start_time) {
-	}
-	TransactionData(transaction_t transaction_id_p, transaction_t start_time_p)
-	    : transaction(nullptr), transaction_id(transaction_id_p), start_time(start_time_p) {
-	}
-
-	Transaction *transaction;
-	transaction_t transaction_id;
-	transaction_t start_time;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/transaction/transaction_data.hpp
+++ b/src/include/duckdb/transaction/transaction_data.hpp
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/transaction/transaction_data.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+
+namespace duckdb {
+class Transaction;
+
+struct TransactionData {
+	TransactionData(Transaction &transaction_p);
+	TransactionData(transaction_t transaction_id_p, transaction_t start_time_p);
+
+	Transaction *transaction;
+	transaction_t transaction_id;
+	transaction_t start_time;
+};
+
+} // namespace duckdb

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -331,9 +331,7 @@ void Appender::FlushInternal(ColumnDataCollection &collection) {
 }
 
 void InternalAppender::FlushInternal(ColumnDataCollection &collection) {
-	for (auto &chunk : collection.Chunks()) {
-		table.storage->Append(table, context, chunk);
-	}
+	table.storage->LocalAppend(table, context, collection);
 }
 
 void BaseAppender::Close() {

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -960,9 +960,7 @@ void ClientContext::Append(TableDescription &description, ColumnDataCollection &
 				throw Exception("Failed to append: table entry has different number of columns!");
 			}
 		}
-		for (auto &chunk : collection.Chunks()) {
-			table_entry->storage->Append(*table_entry, *this, chunk);
-		}
+		table_entry->storage->LocalAppend(*table_entry, *this, collection);
 	});
 }
 

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -28,7 +28,7 @@ DBConfig::DBConfig() {
 DBConfig::~DBConfig() {
 }
 
-DatabaseInstance::DatabaseInstance() {
+DatabaseInstance::DatabaseInstance() : is_invalidated(false) {
 }
 
 DatabaseInstance::~DatabaseInstance() {

--- a/src/storage/compression/fixed_size_uncompressed.cpp
+++ b/src/storage/compression/fixed_size_uncompressed.cpp
@@ -41,6 +41,18 @@ idx_t FixedSizeFinalAnalyze(AnalyzeState &state_p) {
 //===--------------------------------------------------------------------===//
 // Compress
 //===--------------------------------------------------------------------===//
+struct UncompressedCompressState : public CompressionState {
+	explicit UncompressedCompressState(ColumnDataCheckpointer &checkpointer);
+
+	ColumnDataCheckpointer &checkpointer;
+	unique_ptr<ColumnSegment> current_segment;
+	ColumnAppendState append_state;
+
+	virtual void CreateEmptySegment(idx_t row_start);
+	void FlushSegment(idx_t segment_size);
+	void Finalize(idx_t segment_size);
+};
+
 UncompressedCompressState::UncompressedCompressState(ColumnDataCheckpointer &checkpointer)
     : checkpointer(checkpointer) {
 	CreateEmptySegment(checkpointer.GetRowGroup().start);
@@ -55,6 +67,7 @@ void UncompressedCompressState::CreateEmptySegment(idx_t row_start) {
 		state.overflow_writer = make_unique<WriteOverflowStringsToDisk>(checkpointer.GetColumnData().block_manager);
 	}
 	current_segment = move(compressed_segment);
+	current_segment->InitializeAppend(append_state);
 }
 
 void UncompressedCompressState::FlushSegment(idx_t segment_size) {
@@ -77,17 +90,16 @@ void UncompressedFunctions::Compress(CompressionState &state_p, Vector &data, id
 	UnifiedVectorFormat vdata;
 	data.ToUnifiedFormat(count, vdata);
 
-	ColumnAppendState append_state;
 	idx_t offset = 0;
 	while (count > 0) {
-		idx_t appended = state.current_segment->Append(append_state, vdata, offset, count);
+		idx_t appended = state.current_segment->Append(state.append_state, vdata, offset, count);
 		if (appended == count) {
 			// appended everything: finished
 			return;
 		}
 		auto next_start = state.current_segment->start + state.current_segment->count;
 		// the segment is full: flush it to disk
-		state.FlushSegment(state.current_segment->FinalizeAppend());
+		state.FlushSegment(state.current_segment->FinalizeAppend(state.append_state));
 
 		// now create a new segment and continue appending
 		state.CreateEmptySegment(next_start);
@@ -98,7 +110,7 @@ void UncompressedFunctions::Compress(CompressionState &state_p, Vector &data, id
 
 void UncompressedFunctions::FinalizeCompress(CompressionState &state_p) {
 	auto &state = (UncompressedCompressState &)state_p;
-	state.Finalize(state.current_segment->FinalizeAppend());
+	state.Finalize(state.current_segment->FinalizeAppend(state.append_state));
 }
 
 //===--------------------------------------------------------------------===//
@@ -168,6 +180,12 @@ void FixedSizeFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t ro
 //===--------------------------------------------------------------------===//
 // Append
 //===--------------------------------------------------------------------===//
+static unique_ptr<CompressionAppendState> FixedSizeInitAppend(ColumnSegment &segment) {
+	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+	auto handle = buffer_manager.Pin(segment.block);
+	return make_unique<CompressionAppendState>(move(handle));
+}
+
 template <class T>
 static void AppendLoop(SegmentStatistics &stats, data_ptr_t target, idx_t target_offset, UnifiedVectorFormat &adata,
                        idx_t offset, idx_t count) {
@@ -210,13 +228,11 @@ void AppendLoop<list_entry_t>(SegmentStatistics &stats, data_ptr_t target, idx_t
 }
 
 template <class T>
-idx_t FixedSizeAppend(ColumnSegment &segment, SegmentStatistics &stats, UnifiedVectorFormat &data, idx_t offset,
-                      idx_t count) {
-	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
-	auto handle = buffer_manager.Pin(segment.block);
+idx_t FixedSizeAppend(CompressionAppendState &append_state, ColumnSegment &segment, SegmentStatistics &stats,
+                      UnifiedVectorFormat &data, idx_t offset, idx_t count) {
 	D_ASSERT(segment.GetBlockOffset() == 0);
 
-	auto target_ptr = handle.Ptr();
+	auto target_ptr = append_state.handle.Ptr();
 	idx_t max_tuple_count = Storage::BLOCK_SIZE / sizeof(T);
 	idx_t copy_count = MinValue<idx_t>(count, max_tuple_count - segment.count);
 
@@ -239,7 +255,7 @@ CompressionFunction FixedSizeGetFunction(PhysicalType data_type) {
 	                           FixedSizeAnalyze, FixedSizeFinalAnalyze<T>, UncompressedFunctions::InitCompression,
 	                           UncompressedFunctions::Compress, UncompressedFunctions::FinalizeCompress,
 	                           FixedSizeInitScan, FixedSizeScan<T>, FixedSizeScanPartial<T>, FixedSizeFetchRow<T>,
-	                           UncompressedFunctions::EmptySkip, nullptr, FixedSizeAppend<T>,
+	                           UncompressedFunctions::EmptySkip, nullptr, FixedSizeInitAppend, FixedSizeAppend<T>,
 	                           FixedSizeFinalizeAppend<T>, nullptr);
 }
 

--- a/src/storage/compression/string_uncompressed.cpp
+++ b/src/storage/compression/string_uncompressed.cpp
@@ -191,7 +191,8 @@ CompressionFunction StringUncompressed::GetFunction(PhysicalType data_type) {
 	                           UncompressedStringStorage::StringInitScan, UncompressedStringStorage::StringScan,
 	                           UncompressedStringStorage::StringScanPartial, UncompressedStringStorage::StringFetchRow,
 	                           UncompressedFunctions::EmptySkip, UncompressedStringStorage::StringInitSegment,
-	                           UncompressedStringStorage::StringAppend, UncompressedStringStorage::FinalizeAppend);
+	                           UncompressedStringStorage::StringInitAppend, UncompressedStringStorage::StringAppend,
+	                           UncompressedStringStorage::FinalizeAppend);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -530,22 +530,17 @@ void DataTable::AppendLock(TableAppendState &state) {
 	state.row_start = row_groups->GetTotalRows();
 }
 
-void DataTable::InitializeAppend(TableAppendState &state) {
+void DataTable::InitializeAppend(Transaction &transaction, TableAppendState &state, idx_t append_count) {
 	// obtain the append lock for this table
 	if (!state.append_lock) {
 		throw InternalException("DataTable::AppendLock should be called before DataTable::InitializeAppend");
 	}
-	row_groups->InitializeAppend(state);
+	row_groups->InitializeAppend(transaction, state, append_count);
 }
 
 void DataTable::Append(DataChunk &chunk, TableAppendState &state) {
 	D_ASSERT(is_root);
 	row_groups->Append(chunk, state, stats);
-}
-
-void DataTable::FinalizeAppend(Transaction &transaction, TableAppendState &state) {
-	D_ASSERT(is_root);
-	row_groups->FinalizeAppend(transaction, state);
 }
 
 void DataTable::ScanTableSegment(idx_t row_start, idx_t count, const std::function<void(DataChunk &chunk)> &function) {

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -505,17 +505,22 @@ void DataTable::AppendLock(TableAppendState &state) {
 	state.row_start = row_groups->GetTotalRows();
 }
 
-void DataTable::InitializeAppend(Transaction &transaction, TableAppendState &state, idx_t append_count) {
+void DataTable::InitializeAppend(TableAppendState &state) {
 	// obtain the append lock for this table
 	if (!state.append_lock) {
 		throw InternalException("DataTable::AppendLock should be called before DataTable::InitializeAppend");
 	}
-	row_groups->InitializeAppend(transaction, state, append_count);
+	row_groups->InitializeAppend(state);
 }
 
-void DataTable::Append(Transaction &transaction, DataChunk &chunk, TableAppendState &state) {
+void DataTable::Append(DataChunk &chunk, TableAppendState &state) {
 	D_ASSERT(is_root);
-	row_groups->Append(transaction, chunk, state, stats);
+	row_groups->Append(chunk, state, stats);
+}
+
+void DataTable::FinalizeAppend(Transaction &transaction, TableAppendState &state) {
+	D_ASSERT(is_root);
+	row_groups->FinalizeAppend(transaction, state);
 }
 
 void DataTable::ScanTableSegment(idx_t row_start, idx_t count, const std::function<void(DataChunk &chunk)> &function) {

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -475,14 +475,20 @@ void DataTable::VerifyAppendConstraints(TableCatalogEntry &table, ClientContext 
 	}
 }
 
-void DataTable::Append(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk) {
+void DataTable::InitializeLocalAppend(LocalAppendState &state, ClientContext &context) {
+	if (!is_root) {
+		throw TransactionException("Transaction conflict: adding entries to a table that has been altered!");
+	}
+	auto &transaction = Transaction::GetTransaction(context);
+	transaction.storage.InitializeAppend(state, this);
+}
+
+void DataTable::LocalAppend(LocalAppendState &state, TableCatalogEntry &table, ClientContext &context,
+                            DataChunk &chunk) {
 	if (chunk.size() == 0) {
 		return;
 	}
-	// FIXME: could be an assertion instead?
-	if (chunk.ColumnCount() != table.StandardColumnCount()) {
-		throw InternalException("Mismatch in column count for append");
-	}
+	D_ASSERT(chunk.ColumnCount() == table.StandardColumnCount());
 	if (!is_root) {
 		throw TransactionException("Transaction conflict: adding entries to a table that has been altered!");
 	}
@@ -493,8 +499,27 @@ void DataTable::Append(TableCatalogEntry &table, ClientContext &context, DataChu
 	VerifyAppendConstraints(table, context, chunk);
 
 	// append to the transaction local data
-	auto &transaction = Transaction::GetTransaction(context);
-	transaction.storage.Append(this, chunk);
+	LocalStorage::Append(state, chunk);
+}
+
+void DataTable::FinalizeLocalAppend(LocalAppendState &state) {
+	LocalStorage::FinalizeAppend(state);
+}
+
+void DataTable::LocalAppend(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk) {
+	LocalAppendState append_state;
+	table.storage->InitializeLocalAppend(append_state, context);
+	table.storage->LocalAppend(append_state, table, context, chunk);
+	table.storage->FinalizeLocalAppend(append_state);
+}
+
+void DataTable::LocalAppend(TableCatalogEntry &table, ClientContext &context, ColumnDataCollection &collection) {
+	LocalAppendState append_state;
+	table.storage->InitializeLocalAppend(append_state, context);
+	for (auto &chunk : collection.Chunks()) {
+		table.storage->LocalAppend(append_state, table, context, chunk);
+	}
+	table.storage->FinalizeLocalAppend(append_state);
 }
 
 void DataTable::AppendLock(TableAppendState &state) {

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -235,7 +235,7 @@ void LocalStorage::Flush(DataTable &table, LocalTableStorage &storage) {
 		table.MergeStorage(*storage.row_groups, storage.indexes, storage.stats);
 	} else {
 		bool constraint_violated = false;
-		table.InitializeAppend(append_state);
+		table.InitializeAppend(transaction, append_state, append_count);
 		ScanTableStorage(table, storage, [&](DataChunk &chunk) -> bool {
 			// append this chunk to the indexes of the table
 			if (!table.AppendToIndexes(chunk, append_state.current_row)) {
@@ -246,7 +246,6 @@ void LocalStorage::Flush(DataTable &table, LocalTableStorage &storage) {
 			table.Append(chunk, append_state);
 			return true;
 		});
-		table.FinalizeAppend(transaction, append_state);
 		if (constraint_violated) {
 			// need to revert the append
 			row_t current_row = append_state.row_start;

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -121,28 +121,33 @@ bool LocalStorage::NextParallelScan(ClientContext &context, DataTable *table, Pa
 	return storage->row_groups->NextParallelScan(context, state, scan_state);
 }
 
-void LocalStorage::Append(DataTable *table, DataChunk &chunk) {
+void LocalStorage::InitializeAppend(LocalAppendState &state, DataTable *table) {
 	auto entry = table_storage.find(table);
-	LocalTableStorage *storage;
 	if (entry == table_storage.end()) {
 		auto new_storage = make_shared<LocalTableStorage>(*table);
-		storage = new_storage.get();
+		state.storage = new_storage.get();
 		table_storage.insert(make_pair(table, move(new_storage)));
 	} else {
-		storage = entry->second.get();
+		state.storage = entry->second.get();
 	}
+	state.storage->row_groups->InitializeAppend(state.append_state);
+}
+
+void LocalStorage::Append(LocalAppendState &state, DataChunk &chunk) {
 	// append to unique indices (if any)
+	auto storage = state.storage;
 	idx_t base_id = MAX_ROW_ID + storage->row_groups->GetTotalRows();
 	if (!DataTable::AppendToIndexes(storage->indexes, chunk, base_id)) {
 		throw ConstraintException("PRIMARY KEY or UNIQUE constraint violated: duplicated key");
 	}
 
 	//! Append to the chunk
-	TableAppendState state;
+	storage->row_groups->Append(chunk, state.append_state, storage->stats);
+}
+
+void LocalStorage::FinalizeAppend(LocalAppendState &state) {
 	TransactionData transaction_data(0, 0);
-	storage->row_groups->InitializeAppend(state);
-	storage->row_groups->Append(chunk, state, storage->stats);
-	storage->row_groups->FinalizeAppend(transaction_data, state);
+	state.storage->row_groups->FinalizeAppend(transaction_data, state.append_state);
 }
 
 LocalTableStorage *LocalStorage::GetStorage(DataTable *table) {
@@ -264,8 +269,7 @@ void LocalStorage::Flush(DataTable &table, LocalTableStorage &storage) {
 	transaction.PushAppend(&table, append_state.row_start, append_count);
 }
 
-void LocalStorage::Commit(LocalStorage::CommitState &commit_state, Transaction &transaction, WriteAheadLog *log,
-                          transaction_t commit_id) {
+void LocalStorage::Commit(LocalStorage::CommitState &commit_state, Transaction &transaction) {
 	// commit local storage, iterate over all entries in the table storage map
 	for (auto &entry : table_storage) {
 		auto table = entry.first;

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -539,8 +539,6 @@ void RowGroup::AppendVersionInfo(TransactionData transaction, idx_t count) {
 	}
 	lock_guard<mutex> lock(row_group_lock);
 
-	this->count = row_group_end;
-
 	// create the version_info if it doesn't exist yet
 	if (!version_info) {
 		version_info = make_unique<VersionNode>();
@@ -573,6 +571,7 @@ void RowGroup::AppendVersionInfo(TransactionData transaction, idx_t count) {
 			info->Append(start, end, transaction.transaction_id);
 		}
 	}
+	this->count = row_group_end;
 }
 
 void RowGroup::CommitAppend(transaction_t commit_id, idx_t row_group_start, idx_t count) {

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -531,13 +531,15 @@ void RowGroup::FetchRow(TransactionData transaction, ColumnFetchState &state, co
 	}
 }
 
-void RowGroup::AppendVersionInfo(TransactionData transaction, idx_t row_group_start, idx_t count,
-                                 transaction_t commit_id) {
+void RowGroup::AppendVersionInfo(TransactionData transaction, idx_t count) {
+	idx_t row_group_start = this->count.load();
 	idx_t row_group_end = row_group_start + count;
+	if (row_group_end > RowGroup::ROW_GROUP_SIZE) {
+		row_group_end = RowGroup::ROW_GROUP_SIZE;
+	}
 	lock_guard<mutex> lock(row_group_lock);
 
-	this->count += count;
-	D_ASSERT(this->count <= RowGroup::ROW_GROUP_SIZE);
+	this->count = row_group_end;
 
 	// create the version_info if it doesn't exist yet
 	if (!version_info) {
@@ -552,7 +554,7 @@ void RowGroup::AppendVersionInfo(TransactionData transaction, idx_t row_group_st
 		if (start == 0 && end == STANDARD_VECTOR_SIZE) {
 			// entire vector is encapsulated by append: append a single constant
 			auto constant_info = make_unique<ChunkConstantInfo>(this->start + vector_idx * STANDARD_VECTOR_SIZE);
-			constant_info->insert_id = commit_id;
+			constant_info->insert_id = transaction.transaction_id;
 			constant_info->delete_id = NOT_DELETED_ID;
 			version_info->info[vector_idx] = move(constant_info);
 		} else {
@@ -568,7 +570,7 @@ void RowGroup::AppendVersionInfo(TransactionData transaction, idx_t row_group_st
 				// use existing vector
 				info = (ChunkVectorInfo *)version_info->info[vector_idx].get();
 			}
-			info->Append(start, end, commit_id);
+			info->Append(start, end, transaction.transaction_id);
 		}
 	}
 }
@@ -606,8 +608,7 @@ void RowGroup::RevertAppend(idx_t row_group_start) {
 	Verify();
 }
 
-void RowGroup::InitializeAppend(TransactionData transaction, RowGroupAppendState &append_state,
-                                idx_t remaining_append_count) {
+void RowGroup::InitializeAppend(RowGroupAppendState &append_state) {
 	append_state.row_group = this;
 	append_state.offset_in_row_group = this->count;
 	// for each column, initialize the append state
@@ -615,9 +616,6 @@ void RowGroup::InitializeAppend(TransactionData transaction, RowGroupAppendState
 	for (idx_t i = 0; i < columns.size(); i++) {
 		columns[i]->InitializeAppend(append_state.states[i]);
 	}
-	// append the version info for this row_group
-	idx_t append_count = MinValue<idx_t>(remaining_append_count, RowGroup::ROW_GROUP_SIZE - this->count);
-	AppendVersionInfo(transaction, this->count, append_count, transaction.transaction_id);
 }
 
 void RowGroup::Append(RowGroupAppendState &state, DataChunk &chunk, idx_t append_count) {

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -165,15 +165,6 @@ bool RowGroupCollection::IsEmpty() const {
 	return row_groups->GetRootSegment() == nullptr;
 }
 
-TableAppendState::~TableAppendState() {
-	if (Exception::UncaughtException()) {
-		return;
-	}
-	// if these assertions get triggered FinalizeAppend was not called correctly
-	D_ASSERT(!start_row_group);
-	D_ASSERT(total_append_count == 0);
-}
-
 void RowGroupCollection::InitializeAppend(TableAppendState &state) {
 	state.row_start = total_rows;
 	state.current_row = state.row_start;

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -161,11 +161,19 @@ void RowGroupCollection::Fetch(TransactionData transaction, DataChunk &result, c
 //===--------------------------------------------------------------------===//
 // Append
 //===--------------------------------------------------------------------===//
+TableAppendState::TableAppendState()
+    : row_group_append_state(*this), total_append_count(0), start_row_group(nullptr), transaction(0, 0), remaining(0) {
+}
+
+TableAppendState::~TableAppendState() {
+	D_ASSERT(Exception::UncaughtException() || remaining == 0);
+}
+
 bool RowGroupCollection::IsEmpty() const {
 	return row_groups->GetRootSegment() == nullptr;
 }
 
-void RowGroupCollection::InitializeAppend(TableAppendState &state) {
+void RowGroupCollection::InitializeAppend(TransactionData transaction, TableAppendState &state, idx_t append_count) {
 	state.row_start = total_rows;
 	state.current_row = state.row_start;
 	state.total_append_count = 0;
@@ -179,6 +187,17 @@ void RowGroupCollection::InitializeAppend(TableAppendState &state) {
 	state.start_row_group = (RowGroup *)row_groups->GetLastSegment();
 	D_ASSERT(this->row_start + total_rows == state.start_row_group->start + state.start_row_group->count);
 	state.start_row_group->InitializeAppend(state.row_group_append_state);
+	state.remaining = append_count;
+	if (state.remaining > 0) {
+		state.transaction = transaction;
+		state.start_row_group->AppendVersionInfo(transaction, state.remaining);
+		total_rows += state.remaining;
+	}
+}
+
+void RowGroupCollection::InitializeAppend(TableAppendState &state) {
+	TransactionData tdata(0, 0);
+	InitializeAppend(tdata, state, 0);
 }
 
 void RowGroupCollection::Append(DataChunk &chunk, TableAppendState &state, TableStatistics &stats) {
@@ -202,6 +221,9 @@ void RowGroupCollection::Append(DataChunk &chunk, TableAppendState &state, Table
 			}
 		}
 		remaining -= append_count;
+		if (state.remaining > 0) {
+			state.remaining -= append_count;
+		}
 		if (remaining > 0) {
 			// we expect max 1 iteration of this loop (i.e. a single chunk should never overflow more than one
 			// row_group)
@@ -221,6 +243,9 @@ void RowGroupCollection::Append(DataChunk &chunk, TableAppendState &state, Table
 			lock_guard<mutex> row_group_lock(row_groups->node_lock);
 			auto last_row_group = (RowGroup *)row_groups->GetLastSegment();
 			last_row_group->InitializeAppend(state.row_group_append_state);
+			if (state.remaining > 0) {
+				last_row_group->AppendVersionInfo(state.transaction, state.remaining);
+			}
 			continue;
 		} else {
 			break;
@@ -238,6 +263,7 @@ void RowGroupCollection::Append(DataChunk &chunk, TableAppendState &state, Table
 }
 
 void RowGroupCollection::FinalizeAppend(TransactionData transaction, TableAppendState &state) {
+	D_ASSERT(state.transaction.transaction_id == 0);
 	auto remaining = state.total_append_count;
 	auto row_group = state.start_row_group;
 	while (remaining > 0) {

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -467,7 +467,7 @@ void ReplayState::ReplayInsert() {
 	}
 
 	// append to the current table
-	current_table->storage->Append(*current_table, context, chunk);
+	current_table->storage->LocalAppend(*current_table, context, chunk);
 }
 
 void ReplayState::ReplayDelete() {

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -97,7 +97,7 @@ string Transaction::Commit(DatabaseInstance &db, transaction_t commit_id, bool c
 	LocalStorage::CommitState commit_state;
 	auto storage_commit_state = storage_manager.GenStorageCommitState(*this, checkpoint);
 	try {
-		storage.Commit(commit_state, *this, log, commit_id);
+		storage.Commit(commit_state, *this);
 		undo_buffer.Commit(iterator_state, log, commit_id);
 		if (log) {
 			// commit any sequences that were used to the WAL

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -18,6 +18,13 @@
 
 namespace duckdb {
 
+TransactionData::TransactionData(Transaction &transaction_p) // NOLINT
+    : transaction(&transaction_p), transaction_id(transaction_p.transaction_id), start_time(transaction_p.start_time) {
+}
+TransactionData::TransactionData(transaction_t transaction_id_p, transaction_t start_time_p)
+    : transaction(nullptr), transaction_id(transaction_id_p), start_time(start_time_p) {
+}
+
 Transaction::Transaction(weak_ptr<ClientContext> context_p, transaction_t start_time, transaction_t transaction_id,
                          timestamp_t start_timestamp, idx_t catalog_version)
     : context(move(context_p)), start_time(start_time), transaction_id(transaction_id), commit_id(0),


### PR DESCRIPTION
This is a minor clean-up that allows us to keep state around during the append process - which means we no longer need to `Pin`/`Unpin` blocks as often while batch appending. Splitting up the version info append from the actual append also means we no longer need to know how many blocks we are going to append when calling `Initialize`, which simplifies a bunch of code as well and causes more efficient version info nodes to be able to be made in the local storage case.