### PR TITLE
Issue #4978: DATE_SUB Subtraction Overflows

### DIFF
--- a/src/function/scalar/date/date_sub.cpp
+++ b/src/function/scalar/date/date_sub.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/function/scalar/date_functions.hpp"
 #include "duckdb/common/enums/date_part_specifier.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/operator/subtract.hpp"
 #include "duckdb/common/types/date.hpp"
 #include "duckdb/common/types/interval.hpp"
 #include "duckdb/common/types/time.hpp"
@@ -13,6 +14,12 @@
 namespace duckdb {
 
 struct DateSub {
+	static int64_t SubtractMicros(timestamp_t startdate, timestamp_t enddate) {
+		const auto start = Timestamp::GetEpochMicroSeconds(startdate);
+		const auto end = Timestamp::GetEpochMicroSeconds(enddate);
+		return SubtractOperatorOverflowCheck::Operation<int64_t, int64_t, int64_t>(end, start);
+	}
+
 	template <class TA, class TB, class TR, class OP>
 	static inline void BinaryExecute(Vector &left, Vector &right, Vector &result, idx_t count) {
 		BinaryExecutor::ExecuteWithNulls<TA, TB, TR>(
@@ -99,55 +106,49 @@ struct DateSub {
 	struct DayOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA startdate, TB enddate) {
-			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate)) /
-			       Interval::MICROS_PER_DAY;
+			return SubtractMicros(startdate, enddate) / Interval::MICROS_PER_DAY;
 		}
 	};
 
 	struct WeekOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA startdate, TB enddate) {
-			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate)) /
-			       Interval::MICROS_PER_WEEK;
+			return SubtractMicros(startdate, enddate) / Interval::MICROS_PER_WEEK;
 		}
 	};
 
 	struct MicrosecondsOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA startdate, TB enddate) {
-			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate));
+			return SubtractMicros(startdate, enddate);
 		}
 	};
 
 	struct MillisecondsOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA startdate, TB enddate) {
-			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate)) /
-			       Interval::MICROS_PER_MSEC;
+			return SubtractMicros(startdate, enddate) / Interval::MICROS_PER_MSEC;
 		}
 	};
 
 	struct SecondsOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA startdate, TB enddate) {
-			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate)) /
-			       Interval::MICROS_PER_SEC;
+			return SubtractMicros(startdate, enddate) / Interval::MICROS_PER_SEC;
 		}
 	};
 
 	struct MinutesOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA startdate, TB enddate) {
-			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate)) /
-			       Interval::MICROS_PER_MINUTE;
+			return SubtractMicros(startdate, enddate) / Interval::MICROS_PER_MINUTE;
 		}
 	};
 
 	struct HoursOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA startdate, TB enddate) {
-			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate)) /
-			       Interval::MICROS_PER_HOUR;
+			return SubtractMicros(startdate, enddate) / Interval::MICROS_PER_HOUR;
 		}
 	};
 };

--- a/test/sql/function/timestamp/date_sub.test_coverage
+++ b/test/sql/function/timestamp/date_sub.test_coverage
@@ -365,6 +365,16 @@ FROM (SELECT '2021-07-30'::TIMESTAMP + INTERVAL (d) DAY AS startdate FROM range(
 
 endloop
 
+# Overflow
+statement error
+SELECT datesub('week',TIMESTAMP '-214169-1-18 21:29:6',TIMESTAMP '93495-11-19 13:3:22');
+
+statement error
+SELECT datesub('dayofyear',TIMESTAMP '-109502-12-4 20:26:13',TIMESTAMP '252823-4-6 9:56:28');
+
+statement error
+SELECT datesub('epoch',TIMESTAMP '153520-4-1 20:33:43',TIMESTAMP '-269898-3-29 12:9:14');
+
 #
 # TIME
 #


### PR DESCRIPTION
Bottleneck all the µs subtractions and check for overflow.