### PR TITLE
Directly merge row groups from local storage into table even if the table has indexes

### DIFF
--- a/src/include/duckdb/storage/table/table_index_list.hpp
+++ b/src/include/duckdb/storage/table/table_index_list.hpp
@@ -42,6 +42,8 @@ public:
 	//! Serialize all indexes owned by this table, returns a vector of block info of all indexes
 	vector<BlockPointer> SerializeIndexes(duckdb::MetaBlockWriter &writer);
 
+	vector<column_t> GetRequiredColumns();
+
 private:
 	//! Indexes associated with the current table
 	mutex indexes_lock;

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -60,6 +60,13 @@ public:
 	bool HasWrittenBlocks();
 	void Rollback();
 	idx_t EstimatedSize();
+
+	void AppendToIndexes(Transaction &transaction, TableAppendState &append_state, idx_t append_count,
+	                     bool append_to_table);
+
+private:
+	template <class T>
+	bool ScanTableStorage(Transaction &transaction, T &&fun);
 };
 
 //! The LocalStorage class holds appends that have not been committed yet
@@ -124,9 +131,6 @@ public:
 
 private:
 	LocalTableStorage *GetStorage(DataTable *table);
-
-	template <class T>
-	bool ScanTableStorage(DataTable &table, LocalTableStorage &storage, T &&fun);
 
 private:
 	Transaction &transaction;

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -27,12 +27,12 @@ public:
 	                  const vector<column_t> &bound_columns, Expression &cast_expr);
 	// Create a LocalTableStorage from a DROP COLUMN
 	LocalTableStorage(DataTable &table, LocalTableStorage &parent, idx_t drop_idx);
-	// Create a LocalTableStorage from a ADD COLUMN
+	// Create a LocalTableStorage from an ADD COLUMN
 	LocalTableStorage(DataTable &table, LocalTableStorage &parent, ColumnDefinition &new_column,
 	                  Expression *default_value);
 	~LocalTableStorage();
 
-	DataTable &table;
+	DataTable *table;
 
 	Allocator &allocator;
 	//! The main chunk collection holding the data

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -67,6 +67,8 @@ public:
 private:
 	template <class T>
 	bool ScanTableStorage(Transaction &transaction, T &&fun);
+	template <class T>
+	bool ScanTableStorage(Transaction &transaction, const vector<column_t> &column_ids, T &&fun);
 };
 
 //! The LocalStorage class holds appends that have not been committed yet

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -531,6 +531,7 @@ void DataTable::AppendLock(TableAppendState &state) {
 		throw TransactionException("Transaction conflict: adding entries to a table that has been altered!");
 	}
 	state.row_start = row_groups->GetTotalRows();
+	state.current_row = state.row_start;
 }
 
 void DataTable::InitializeAppend(Transaction &transaction, TableAppendState &state, idx_t append_count) {
@@ -594,9 +595,6 @@ void DataTable::MergeStorage(RowGroupCollection &data, TableIndexList &indexes, 
 	row_groups->MergeStorage(data);
 	stats.MergeStats(other_stats);
 	row_groups->Verify();
-	if (!indexes.Empty()) {
-		throw InternalException("FIXME: merge indexes");
-	}
 }
 
 void DataTable::WriteToLog(WriteAheadLog &log, idx_t row_start, idx_t count) {

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -18,7 +18,7 @@ namespace duckdb {
 // Local Table Storage
 //===--------------------------------------------------------------------===//
 LocalTableStorage::LocalTableStorage(DataTable &table)
-    : table(table), allocator(Allocator::Get(table.db)), deleted_rows(0) {
+    : table(&table), allocator(Allocator::Get(table.db)), deleted_rows(0) {
 	auto types = table.GetTypes();
 	row_groups = make_shared<RowGroupCollection>(table.info, TableIOManager::Get(table).GetBlockManagerForRowData(),
 	                                             types, MAX_ROW_ID, 0);
@@ -43,7 +43,7 @@ LocalTableStorage::LocalTableStorage(DataTable &table)
 LocalTableStorage::LocalTableStorage(DataTable &new_dt, LocalTableStorage &parent, idx_t changed_idx,
                                      const LogicalType &target_type, const vector<column_t> &bound_columns,
                                      Expression &cast_expr)
-    : table(new_dt), allocator(Allocator::Get(table.db)), deleted_rows(parent.deleted_rows),
+    : table(&new_dt), allocator(Allocator::Get(table->db)), deleted_rows(parent.deleted_rows),
       partial_manager(move(parent.partial_manager)), written_blocks(move(parent.written_blocks)) {
 	if (partial_manager) {
 		partial_manager->FlushPartialBlocks();
@@ -56,7 +56,7 @@ LocalTableStorage::LocalTableStorage(DataTable &new_dt, LocalTableStorage &paren
 }
 
 LocalTableStorage::LocalTableStorage(DataTable &new_dt, LocalTableStorage &parent, idx_t drop_idx)
-    : table(new_dt), allocator(Allocator::Get(table.db)), deleted_rows(parent.deleted_rows),
+    : table(&new_dt), allocator(Allocator::Get(table->db)), deleted_rows(parent.deleted_rows),
       partial_manager(move(parent.partial_manager)), written_blocks(move(parent.written_blocks)) {
 	if (partial_manager) {
 		partial_manager->FlushPartialBlocks();
@@ -69,9 +69,9 @@ LocalTableStorage::LocalTableStorage(DataTable &new_dt, LocalTableStorage &paren
 
 LocalTableStorage::LocalTableStorage(DataTable &new_dt, LocalTableStorage &parent, ColumnDefinition &new_column,
                                      Expression *default_value)
-    : table(new_dt), allocator(Allocator::Get(table.db)), deleted_rows(parent.deleted_rows),
+    : table(&new_dt), allocator(Allocator::Get(table->db)), deleted_rows(parent.deleted_rows),
       partial_manager(move(parent.partial_manager)), written_blocks(move(parent.written_blocks)) {
-	idx_t new_column_idx = parent.table.column_definitions.size();
+	idx_t new_column_idx = parent.table->column_definitions.size();
 	stats.InitializeAddColumn(parent.stats, new_column.GetType());
 	row_groups = parent.row_groups->AddColumn(new_column, default_value, stats.GetStats(new_column_idx));
 	parent.row_groups.reset();
@@ -181,7 +181,7 @@ void LocalStorage::Append(LocalAppendState &state, DataChunk &chunk) {
 void LocalTableStorage::CheckFlushToDisk() {
 	// we finished writing a complete row group
 	// check if we should pre-emptively write it to disk
-	if (table.info->IsTemporary() || StorageManager::GetStorageManager(table.db).InMemory()) {
+	if (table->info->IsTemporary() || StorageManager::GetStorageManager(table->db).InMemory()) {
 		return;
 	}
 	if (deleted_rows != 0) {
@@ -191,7 +191,7 @@ void LocalTableStorage::CheckFlushToDisk() {
 	// we should! write the second-to-last row group to disk
 	// allocate the partial block-manager if none is allocated yet
 	if (!partial_manager) {
-		auto &block_manager = table.info->table_io_manager->GetBlockManagerForRowData();
+		auto &block_manager = table->info->table_io_manager->GetBlockManagerForRowData();
 		partial_manager = make_unique<PartialBlockManager>(block_manager);
 	}
 	// flush second-to-last row group
@@ -207,7 +207,7 @@ void LocalTableStorage::FlushToDisk(RowGroup *row_group) {
 	//! The set of column compression types (if any)
 	vector<CompressionType> compression_types;
 	D_ASSERT(compression_types.empty());
-	for (auto &column : table.column_definitions) {
+	for (auto &column : table->column_definitions) {
 		compression_types.push_back(column.CompressionType());
 	}
 	auto row_group_pointer = row_group->WriteToDisk(*partial_manager, compression_types);
@@ -276,13 +276,13 @@ void LocalStorage::Update(DataTable *table, Vector &row_ids, const vector<column
 template <class T>
 bool LocalTableStorage::ScanTableStorage(Transaction &transaction, T &&fun) {
 	vector<column_t> column_ids;
-	column_ids.reserve(table.column_definitions.size());
-	for (idx_t i = 0; i < table.column_definitions.size(); i++) {
+	column_ids.reserve(table->column_definitions.size());
+	for (idx_t i = 0; i < table->column_definitions.size(); i++) {
 		column_ids.push_back(i);
 	}
 
 	DataChunk chunk;
-	chunk.Initialize(allocator, table.GetTypes());
+	chunk.Initialize(allocator, table->GetTypes());
 
 	// initialize the scan
 	TableScanState state;
@@ -305,17 +305,17 @@ void LocalTableStorage::AppendToIndexes(Transaction &transaction, TableAppendSta
                                         bool append_to_table) {
 	bool constraint_violated = false;
 	if (append_to_table) {
-		table.InitializeAppend(transaction, append_state, append_count);
+		table->InitializeAppend(transaction, append_state, append_count);
 	}
 	ScanTableStorage(transaction, [&](DataChunk &chunk) -> bool {
 		// append this chunk to the indexes of the table
-		if (!table.AppendToIndexes(chunk, append_state.current_row)) {
+		if (!table->AppendToIndexes(chunk, append_state.current_row)) {
 			constraint_violated = true;
 			return false;
 		}
 		// append to base table
 		if (append_to_table) {
-			table.Append(chunk, append_state);
+			table->Append(chunk, append_state);
 		} else {
 			append_state.current_row += chunk.size();
 		}
@@ -327,7 +327,7 @@ void LocalTableStorage::AppendToIndexes(Transaction &transaction, TableAppendSta
 		// remove the data from the indexes, if there are any indexes
 		ScanTableStorage(transaction, [&](DataChunk &chunk) -> bool {
 			// append this chunk to the indexes of the table
-			table.RemoveFromIndexes(append_state, chunk, current_row);
+			table->RemoveFromIndexes(append_state, chunk, current_row);
 
 			current_row += chunk.size();
 			if (current_row >= append_state.current_row) {
@@ -337,7 +337,7 @@ void LocalTableStorage::AppendToIndexes(Transaction &transaction, TableAppendSta
 			return true;
 		});
 		if (append_to_table) {
-			table.RevertAppendInternal(append_state.row_start, append_count);
+			table->RevertAppendInternal(append_state.row_start, append_count);
 		}
 		throw ConstraintException("PRIMARY KEY or UNIQUE constraint violated: duplicated key");
 	}
@@ -408,7 +408,7 @@ void LocalTableStorage::Rollback() {
 		partial_manager->Clear();
 		partial_manager.reset();
 	}
-	auto &block_manager = table.info->table_io_manager->GetBlockManagerForRowData();
+	auto &block_manager = table->info->table_io_manager->GetBlockManagerForRowData();
 	for (auto block_id : written_blocks) {
 		block_manager.MarkBlockAsModified(block_id);
 	}
@@ -430,6 +430,7 @@ void LocalStorage::MoveStorage(DataTable *old_dt, DataTable *new_dt) {
 	}
 	// take over the storage from the old entry
 	auto new_storage = move(entry->second);
+	new_storage->table = new_dt;
 	table_storage.erase(entry);
 	table_storage[new_dt] = move(new_storage);
 }
@@ -481,7 +482,7 @@ void LocalStorage::FetchChunk(DataTable *table, Vector &row_ids, idx_t count, Da
 
 	ColumnFetchState fetch_state;
 	vector<column_t> col_ids;
-	vector<LogicalType> types = storage->table.GetTypes();
+	vector<LogicalType> types = storage->table->GetTypes();
 	for (idx_t i = 0; i < types.size(); i++) {
 		col_ids.push_back(i);
 	}

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -337,11 +337,12 @@ void LocalTableStorage::AppendToIndexes(Transaction &transaction, TableAppendSta
 		mock_chunk.InitializeEmpty(table->GetTypes());
 		ScanTableStorage(transaction, columns, [&](DataChunk &chunk) -> bool {
 			// construct the mock chunk by referencing the required columns
-			for (idx_t i = 0; i < chunk.size(); i++) {
+			for (idx_t i = 0; i < columns.size(); i++) {
 				mock_chunk.data[columns[i]].Reference(chunk.data[i]);
 			}
+			mock_chunk.SetCardinality(chunk);
 			// append this chunk to the indexes of the table
-			if (!table->AppendToIndexes(chunk, append_state.current_row)) {
+			if (!table->AppendToIndexes(mock_chunk, append_state.current_row)) {
 				constraint_violated = true;
 				return false;
 			}

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -71,8 +71,9 @@ vector<column_t> TableIndexList::GetRequiredColumns() {
 		}
 	}
 	vector<column_t> result;
+	result.reserve(unique_indexes.size());
 	for (auto column_index : unique_indexes) {
-		result.push_back(column_index);
+		result.emplace_back(column_index);
 	}
 	return result;
 }

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -62,6 +62,21 @@ void TableIndexList::VerifyForeignKey(const vector<idx_t> &fk_keys, bool is_appe
 	}
 }
 
+vector<column_t> TableIndexList::GetRequiredColumns() {
+	lock_guard<mutex> lock(indexes_lock);
+	set<column_t> unique_indexes;
+	for (auto &index : indexes) {
+		for (auto col_index : index->column_ids) {
+			unique_indexes.insert(col_index);
+		}
+	}
+	vector<column_t> result;
+	for (auto column_index : unique_indexes) {
+		result.push_back(column_index);
+	}
+	return result;
+}
+
 vector<BlockPointer> TableIndexList::SerializeIndexes(duckdb::MetaBlockWriter &writer) {
 	vector<BlockPointer> blocks_info;
 	for (auto &index : indexes) {

--- a/test/sql/alter/alter_col/test_not_null_in_tran.test
+++ b/test/sql/alter/alter_col/test_not_null_in_tran.test
@@ -48,10 +48,10 @@ INSERT INTO t SELECT i, i FROM RANGE(2048) tbl(i)
 statement ok
 BEGIN TRANSACTION
 
-statement ok 
+statement ok
 INSERT INTO t values(8888, 8888)
 
-statement ok 
+statement ok
 ALTER TABLE t ALTER COLUMN j SET NOT NULL
 
 statement ok

--- a/test/sql/parallelism/interquery/concurrent_batch_append_pk.test
+++ b/test/sql/parallelism/interquery/concurrent_batch_append_pk.test
@@ -1,0 +1,27 @@
+# name: test/sql/parallelism/interquery/concurrent_batch_append_pk.test
+# description: Test concurrent batch appends on persistent storage with primary key
+# group: [interquery]
+
+load __TEST_DIR__/concurrent_batch_append.db
+
+statement ok
+CREATE TABLE test(a INTEGER PRIMARY KEY)
+
+concurrentloop threadid 0 10
+
+statement ok
+INSERT INTO test SELECT * FROM range(250000 * ${threadid}, 250000 * (${threadid} + 1))
+
+endloop
+
+query II
+SELECT COUNT(*), SUM(a) FROM test
+----
+2500000	3124998750000
+
+concurrentloop threadid 0 10
+
+statement error
+INSERT INTO test VALUES ({${threadid} * 17171)
+
+endloop

--- a/test/sql/storage/optimistic_write/optimistic_write_primary_key.test
+++ b/test/sql/storage/optimistic_write/optimistic_write_primary_key.test
@@ -32,6 +32,9 @@ SELECT SUM(a) FROM test
 ----
 499999500000
 
+statement error
+INSERT INTO test VALUES (42)
+
 restart
 
 query I
@@ -43,3 +46,6 @@ query I
 SELECT SUM(a) FROM test
 ----
 499999500000
+
+statement error
+INSERT INTO test VALUES (42)


### PR DESCRIPTION
This PR alleviates one of the previous restrictions on the local-storage merge: if the table has indexes we enable merging now as well. We do still perform a scan of the local storage to append to the indexes. However, there are still two performance improvements: we can flush the data to disk as we load it, and on the final append to the indexes we only need to read back the columns that are required to construct the indexes. Therefore this can still offer a large performance boost.

 In the future, this could be further optimized by merging the indexes from the local storage directly into the indexes of the table (CC @taniabogatsch).