### PR TITLE
ODBC/JDBC Database Instance Cache

### DIFF
--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/catalog/catalog_search_path.hpp"
 #include "duckdb/main/appender.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
+#include "duckdb/main/db_instance_cache.hpp"
 
 using namespace duckdb;
 using namespace std;
@@ -244,6 +245,11 @@ static Connection *get_connection(JNIEnv *env, jobject conn_ref_buf) {
 	return nullptr;
 }
 
+//! The database instance cache, used so that multiple connections to the same file point to the same database object
+duckdb::DBInstanceCache instance_cache;
+//! A map of pointer to shared_ptr, to ensure we keep the DuckDB object alive
+std::unordered_map<duckdb::DuckDB *, shared_ptr<duckdb::DuckDB>> db_map;
+
 JNIEXPORT jobject JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1startup(JNIEnv *env, jclass, jbyteArray database_j,
                                                                              jboolean read_only, jobject props) {
 	auto database = byte_array_to_string(env, database_j);
@@ -275,8 +281,11 @@ JNIEXPORT jobject JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1startup(JNI
 				    StringUtil::CandidatesErrorMessage(DBConfig::GetOptionNames(), key_str, "Did you mean"));
 			}
 		}
+		bool cache_instance = database != ":memory:" && !database.empty();
+		auto shared_db = instance_cache.CreateInstance(database, config, cache_instance);
+		auto db = shared_db.get();
+		db_map[db] = move(shared_db);
 
-		auto db = new DuckDB(database, &config);
 		return env->NewDirectByteBuffer(db, 0);
 	} catch (exception &e) {
 		env->ThrowNew(J_SQLException, e.what());
@@ -288,6 +297,8 @@ JNIEXPORT jobject JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1startup(JNI
 JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1shutdown(JNIEnv *env, jclass, jobject db_ref_buf) {
 	auto db_ref = (DuckDB *)env->GetDirectBufferAddress(db_ref_buf);
 	if (db_ref) {
+		D_ASSERT(db_map.find(db_ref) != db_map.end());
+		db_map.erase(db_ref);
 		delete db_ref;
 	}
 }

--- a/tools/odbc/driver.cpp
+++ b/tools/odbc/driver.cpp
@@ -184,6 +184,7 @@ static void GetDatabaseNameFromDSN(duckdb::OdbcHandleDbc *dbc, SQLCHAR *conn_str
 #endif
 }
 
+//! The database instance cache, used so that multiple connections to the same file point to the same database object
 duckdb::DBInstanceCache instance_cache;
 
 static SQLRETURN SetConnection(SQLHDBC connection_handle, SQLCHAR *conn_str) {

--- a/tools/odbc/driver.cpp
+++ b/tools/odbc/driver.cpp
@@ -6,6 +6,7 @@
 #include "odbc_utils.hpp"
 
 #include "duckdb/main/config.hpp"
+#include "duckdb/main/db_instance_cache.hpp"
 
 #include <odbcinst.h>
 #include <locale>
@@ -183,6 +184,8 @@ static void GetDatabaseNameFromDSN(duckdb::OdbcHandleDbc *dbc, SQLCHAR *conn_str
 #endif
 }
 
+duckdb::DBInstanceCache instance_cache;
+
 static SQLRETURN SetConnection(SQLHDBC connection_handle, SQLCHAR *conn_str) {
 	// TODO actually interpret Database in in_connection_string
 	if (!connection_handle) {
@@ -206,7 +209,8 @@ static SQLRETURN SetConnection(SQLHDBC connection_handle, SQLCHAR *conn_str) {
 		if (dbc->sql_attr_access_mode == SQL_MODE_READ_ONLY) {
 			config.options.access_mode = duckdb::AccessMode::READ_ONLY;
 		}
-		dbc->env->db = duckdb::make_unique<duckdb::DuckDB>(db_name, &config);
+		bool cache_instance = db_name != ":memory:" && !db_name.empty();
+		dbc->env->db = instance_cache.CreateInstance(db_name, config, cache_instance);
 	}
 
 	if (!dbc->conn) {

--- a/tools/odbc/include/duckdb_odbc.hpp
+++ b/tools/odbc/include/duckdb_odbc.hpp
@@ -41,8 +41,9 @@ struct OdbcHandle {
 };
 
 struct OdbcHandleEnv : public OdbcHandle {
-	OdbcHandleEnv() : OdbcHandle(OdbcHandleType::ENV), db(make_unique<DuckDB>(nullptr)) {};
-	unique_ptr<DuckDB> db;
+	OdbcHandleEnv() : OdbcHandle(OdbcHandleType::ENV), db(make_shared<DuckDB>(nullptr)) {};
+
+	shared_ptr<DuckDB> db;
 };
 
 struct OdbcHandleStmt;


### PR DESCRIPTION
Add support for the database connection cache to the ODBC and JDBC clients (see #4414).

The purpose of this cache is for the `connect` method to behave more similarly to a "regular" client-server database. Namely, if multiple connections are made to the same database, the same `DuckDB` object is referenced, and instead only different `duckdb::Connection` objects are made for the different connections.

