### PR TITLE
Fix lambda bug for struct extract

### DIFF
--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -117,6 +117,21 @@ void ExpressionBinder::QualifyColumnNames(Binder &binder, unique_ptr<ParsedExpre
 
 unique_ptr<ParsedExpression> ExpressionBinder::CreateStructExtract(unique_ptr<ParsedExpression> base,
                                                                    string field_name) {
+
+	// we need to transform the struct extract if it is inside a lambda expression
+	// because we cannot bind to an existing table, so we remove the dummy table also
+	if (lambda_bindings && base->type == ExpressionType::COLUMN_REF) {
+		auto &lambda_column_ref = (ColumnRefExpression &)*base;
+		D_ASSERT(!lambda_column_ref.column_names.empty());
+
+		if (lambda_column_ref.column_names[0].find("0_macro_parameters") != string::npos) {
+			D_ASSERT(lambda_column_ref.column_names.size() == 2);
+			auto lambda_param_name = lambda_column_ref.column_names.back();
+			lambda_column_ref.column_names.clear();
+			lambda_column_ref.column_names.push_back(lambda_param_name);
+		}
+	}
+
 	vector<unique_ptr<ParsedExpression>> children;
 	children.push_back(move(base));
 	children.push_back(make_unique_base<ParsedExpression, ConstantExpression>(Value(move(field_name))));
@@ -243,7 +258,8 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref_p, idx_t
 	if (!expr) {
 		return BindResult(binder.FormatError(colref_p, error_message));
 	}
-	//! Generated column returns generated expression
+
+	// a generated column returns a generated expression, a struct on a column returns a struct extract
 	if (expr->type != ExpressionType::COLUMN_REF) {
 		auto alias = expr->alias;
 		auto result = BindExpression(&expr, depth);
@@ -252,6 +268,7 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref_p, idx_t
 		}
 		return result;
 	}
+
 	auto &colref = (ColumnRefExpression &)*expr;
 	D_ASSERT(colref.IsQualified());
 	auto &table_name = colref.GetTableName();

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -124,7 +124,7 @@ unique_ptr<ParsedExpression> ExpressionBinder::CreateStructExtract(unique_ptr<Pa
 		auto &lambda_column_ref = (ColumnRefExpression &)*base;
 		D_ASSERT(!lambda_column_ref.column_names.empty());
 
-		if (lambda_column_ref.column_names[0].find("0_macro_parameters") != string::npos) {
+		if (lambda_column_ref.column_names[0].find(DummyBinding::DUMMY_NAME) != string::npos) {
 			D_ASSERT(lambda_column_ref.column_names.size() == 2);
 			auto lambda_param_name = lambda_column_ref.column_names.back();
 			lambda_column_ref.column_names.clear();

--- a/test/sql/function/list/lambdas/transform.test
+++ b/test/sql/function/list/lambdas/transform.test
@@ -179,6 +179,33 @@ True
 True
 True
 
+# test structs (issue #5005)
+
+query I
+SELECT list_transform([{'a': 1}], x -> x.a);
+----
+[1]
+
+query I
+SELECT list_transform([{'a': [1, 2, 3]}], x -> x.a[2]);
+----
+[2]
+
+query I
+SELECT list_transform([{'b' : {'a': 1}}], x -> x.b.a);
+----
+[1]
+
+query I
+SELECT list_transform([{'b' : {'a': 42, 'b': 43}}], x -> x.b.b);
+----
+[43]
+
+query I
+SELECT list_transform([{'b' : {'a': [{'c': 77}], 'b': 43}}], x -> x.b.a[1].c);
+----
+[77]
+
 # test correlated subqueries
 
 statement ok


### PR DESCRIPTION
We were trying to bind the temporary dummy table for lambdas and macros. I am now removing that table from the column names before trying to bind them.