### PR TITLE
Correctly handle NULL values in compound ART keys

### DIFF
--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -92,6 +92,9 @@ bool DataChunk::AllConstant() const {
 }
 
 void DataChunk::Reference(DataChunk &chunk) {
+	if (chunk.ColumnCount() > ColumnCount()) {
+		D_ASSERT(chunk.ColumnCount() <= ColumnCount());
+	}
 	D_ASSERT(chunk.ColumnCount() <= ColumnCount());
 	SetCardinality(chunk);
 	SetCapacity(chunk);

--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -92,9 +92,6 @@ bool DataChunk::AllConstant() const {
 }
 
 void DataChunk::Reference(DataChunk &chunk) {
-	if (chunk.ColumnCount() > ColumnCount()) {
-		D_ASSERT(chunk.ColumnCount() <= ColumnCount());
-	}
 	D_ASSERT(chunk.ColumnCount() <= ColumnCount());
 	SetCardinality(chunk);
 	SetCapacity(chunk);

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -287,19 +287,6 @@ void Construct(vector<Key> &keys, row_t *row_ids, Node *&node, KeySection &key_s
 	}
 }
 
-void FindFirstNotNullKey(vector<Key> &keys, bool &skipped_all_nulls, idx_t &start_idx) {
-
-	if (!skipped_all_nulls) {
-		for (idx_t i = 0; i < keys.size(); i++) {
-			if (!keys[i].Empty()) {
-				start_idx = i;
-				skipped_all_nulls = true;
-				return;
-			}
-		}
-	}
-}
-
 void ART::ConstructAndMerge(IndexLock &lock, PayloadScanner &scanner, Allocator &allocator) {
 
 	auto payload_types = logical_types;
@@ -308,7 +295,6 @@ void ART::ConstructAndMerge(IndexLock &lock, PayloadScanner &scanner, Allocator 
 	ArenaAllocator arena_allocator(allocator);
 	vector<Key> keys(STANDARD_VECTOR_SIZE);
 
-	auto skipped_all_nulls = false;
 	auto temp_art = make_unique<ART>(this->column_ids, this->table_io_manager, this->unbound_expressions,
 	                                 this->constraint_type, this->db);
 
@@ -333,22 +319,6 @@ void ART::ConstructAndMerge(IndexLock &lock, PayloadScanner &scanner, Allocator 
 		arena_allocator.Reset();
 		GenerateKeys(arena_allocator, ordered_chunk, keys);
 
-		// we order NULLS FIRST, so we might have to skip nulls at the start of our sorted data
-		idx_t start_idx = 0;
-		FindFirstNotNullKey(keys, skipped_all_nulls, start_idx);
-
-		if (start_idx != 0 && IsPrimary()) {
-			throw ConstraintException("NULLs in new data violate the primary key constraint of the index");
-		}
-
-		if (!skipped_all_nulls) {
-			if (IsPrimary()) {
-				// chunk consists only of NULLs
-				throw ConstraintException("NULLs in new data violate the primary key constraint of the index");
-			}
-			continue;
-		}
-
 		// prepare the row_identifiers
 		row_identifiers.Flatten(ordered_chunk.size());
 		auto row_ids = FlatVector::GetData<row_t>(row_identifiers);
@@ -356,7 +326,7 @@ void ART::ConstructAndMerge(IndexLock &lock, PayloadScanner &scanner, Allocator 
 		// construct the ART of this chunk
 		auto art = make_unique<ART>(this->column_ids, this->table_io_manager, this->unbound_expressions,
 		                            this->constraint_type, this->db);
-		auto key_section = KeySection(start_idx, ordered_chunk.size() - 1, 0, 0);
+		auto key_section = KeySection(0, ordered_chunk.size() - 1, 0, 0);
 		auto has_constraint = IsUnique();
 		Construct(keys, row_ids, art->tree, key_section, has_constraint);
 

--- a/src/execution/physical_plan/plan_create_index.cpp
+++ b/src/execution/physical_plan/plan_create_index.cpp
@@ -17,18 +17,25 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreateInde
 	// table scan operator for index key columns and row IDs
 	unique_ptr<TableFilterSet> table_filters;
 	op.info->column_ids.emplace_back(COLUMN_IDENTIFIER_ROW_ID);
+
 	auto &bind_data = (TableScanBindData &)*op.bind_data;
 	bind_data.is_create_index = true;
+
 	auto table_scan =
 	    make_unique<PhysicalTableScan>(op.info->scan_types, op.function, move(op.bind_data), op.info->column_ids,
 	                                   op.info->names, move(table_filters), op.estimated_cardinality);
+
 	dependencies.insert(&op.table);
 	op.info->column_ids.pop_back();
+
+	D_ASSERT(op.info->scan_types.size() - 1 == op.info->names.size());
+	D_ASSERT(op.info->scan_types.size() - 1 == op.info->column_ids.size());
 
 	// filter operator for IS_NOT_NULL on each key column
 	vector<LogicalType> filter_types;
 	vector<unique_ptr<Expression>> filter_select_list;
-	for (idx_t i = 0; i < op.info->column_ids.size(); i++) {
+
+	for (idx_t i = 0; i < op.info->scan_types.size() - 1; i++) {
 		filter_types.push_back(op.info->scan_types[i]);
 		auto is_not_null_expr =
 		    make_unique<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NOT_NULL, LogicalType::BOOLEAN);
@@ -36,7 +43,9 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreateInde
 		is_not_null_expr->children.push_back(move(bound_ref));
 		filter_select_list.push_back(move(is_not_null_expr));
 	}
+
 	auto null_filter = make_unique<PhysicalFilter>(move(filter_types), move(filter_select_list), STANDARD_VECTOR_SIZE);
+	null_filter->types.push_back(LogicalType::ROW_TYPE);
 	null_filter->children.push_back(move(table_scan));
 
 	// actual physical create index operator

--- a/src/execution/physical_plan/plan_create_index.cpp
+++ b/src/execution/physical_plan/plan_create_index.cpp
@@ -46,7 +46,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreateInde
 	}
 
 	auto null_filter = make_unique<PhysicalFilter>(move(filter_types), move(filter_select_list), STANDARD_VECTOR_SIZE);
-	null_filter->types.push_back(LogicalType::ROW_TYPE);
+	null_filter->types.emplace_back(LogicalType::ROW_TYPE);
 	null_filter->children.push_back(move(table_scan));
 
 	// actual physical create index operator

--- a/src/execution/physical_plan/plan_create_index.cpp
+++ b/src/execution/physical_plan/plan_create_index.cpp
@@ -1,9 +1,12 @@
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/execution/operator/filter/physical_filter.hpp"
+#include "duckdb/execution/operator/scan/physical_table_scan.hpp"
 #include "duckdb/execution/operator/schema/physical_create_index.hpp"
 #include "duckdb/execution/physical_plan_generator.hpp"
-#include "duckdb/planner/operator/logical_create_index.hpp"
-#include "duckdb/execution/operator/scan/physical_table_scan.hpp"
 #include "duckdb/function/table/table_scan.hpp"
+#include "duckdb/planner/filter/null_filter.hpp"
+#include "duckdb/planner/operator/logical_create_index.hpp"
+#include "duckdb/planner/table_filter.hpp"
 
 namespace duckdb {
 
@@ -11,22 +14,36 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreateInde
 
 	D_ASSERT(op.children.empty());
 
+	// table scan operator for index key columns and row IDs
 	unique_ptr<TableFilterSet> table_filters;
 	op.info->column_ids.emplace_back(COLUMN_IDENTIFIER_ROW_ID);
-
 	auto &bind_data = (TableScanBindData &)*op.bind_data;
 	bind_data.is_create_index = true;
 	auto table_scan =
 	    make_unique<PhysicalTableScan>(op.info->scan_types, op.function, move(op.bind_data), op.info->column_ids,
 	                                   op.info->names, move(table_filters), op.estimated_cardinality);
-
 	dependencies.insert(&op.table);
 	op.info->column_ids.pop_back();
 
+	// filter operator for IS_NOT_NULL on each key column
+	vector<LogicalType> filter_types;
+	vector<unique_ptr<Expression>> filter_select_list;
+	for (idx_t i = 0; i < op.info->scan_types.size(); i++) {
+		filter_types.push_back(op.info->scan_types[i]);
+		auto is_not_null_expr =
+		    make_unique<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NOT_NULL, LogicalType::BOOLEAN);
+		auto bound_ref = make_unique<BoundReferenceExpression>(op.info->names[i], op.info->scan_types[i], i);
+		is_not_null_expr->children.push_back(move(bound_ref));
+		filter_select_list.push_back(move(is_not_null_expr));
+	}
+	auto null_filter = make_unique<PhysicalFilter>(move(filter_types), move(filter_select_list), STANDARD_VECTOR_SIZE);
+	null_filter->children.push_back(move(table_scan));
+
+	// actual physical create index operator
 	auto physical_create_index =
 	    make_unique<PhysicalCreateIndex>(op, op.table, op.info->column_ids, move(op.expressions), move(op.info),
 	                                     move(op.unbound_expressions), op.estimated_cardinality);
-	physical_create_index->children.push_back(move(table_scan));
+	physical_create_index->children.push_back(move(null_filter));
 	return move(physical_create_index);
 }
 

--- a/src/execution/physical_plan/plan_create_index.cpp
+++ b/src/execution/physical_plan/plan_create_index.cpp
@@ -28,8 +28,8 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreateInde
 	dependencies.insert(&op.table);
 	op.info->column_ids.pop_back();
 
-	D_ASSERT(op.info->scan_types.size() - 1 == op.info->names.size());
-	D_ASSERT(op.info->scan_types.size() - 1 == op.info->column_ids.size());
+	D_ASSERT(op.info->scan_types.size() - 1 <= op.info->names.size());
+	D_ASSERT(op.info->scan_types.size() - 1 <= op.info->column_ids.size());
 
 	// filter operator for IS_NOT_NULL on each key column
 	vector<LogicalType> filter_types;
@@ -39,7 +39,8 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreateInde
 		filter_types.push_back(op.info->scan_types[i]);
 		auto is_not_null_expr =
 		    make_unique<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NOT_NULL, LogicalType::BOOLEAN);
-		auto bound_ref = make_unique<BoundReferenceExpression>(op.info->names[i], op.info->scan_types[i], i);
+		auto bound_ref =
+		    make_unique<BoundReferenceExpression>(op.info->names[op.info->column_ids[i]], op.info->scan_types[i], i);
 		is_not_null_expr->children.push_back(move(bound_ref));
 		filter_select_list.push_back(move(is_not_null_expr));
 	}

--- a/src/execution/physical_plan/plan_create_index.cpp
+++ b/src/execution/physical_plan/plan_create_index.cpp
@@ -28,7 +28,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreateInde
 	// filter operator for IS_NOT_NULL on each key column
 	vector<LogicalType> filter_types;
 	vector<unique_ptr<Expression>> filter_select_list;
-	for (idx_t i = 0; i < op.info->scan_types.size(); i++) {
+	for (idx_t i = 0; i < op.info->column_ids.size(); i++) {
 		filter_types.push_back(op.info->scan_types[i]);
 		auto is_not_null_expr =
 		    make_unique<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NOT_NULL, LogicalType::BOOLEAN);

--- a/test/sql/index/art/test_art_create_index.test
+++ b/test/sql/index/art/test_art_create_index.test
@@ -1,0 +1,17 @@
+# name: test/sql/index/art/test_art_create_index.test
+# description: CREATE INDEX
+# group: [art]
+
+# test to reproduce issue #4976
+
+statement ok
+CREATE TABLE t0(c0 DOUBLE, c1 TIMESTAMP DEFAULT(TIMESTAMP '1970-01-04 12:58:32'));
+
+statement ok
+INSERT INTO t0(c1, c0) VALUES (TIMESTAMP '1969-12-28 23:02:08', 1);
+
+statement ok
+INSERT INTO t0(c0) VALUES (DEFAULT);
+
+statement ok
+CREATE INDEX i2 ON t0(c1, c0);


### PR DESCRIPTION
The current implementation of the `CREATE INDEX` operator does not handle `NULL` values in non-first columns of compound ART keys correctly. With this fix, we add another `PhysicalFilter` operator to the pipeline, which filters on 'IS NOT NULL' for each key column.

I also removed the check for `IsPrimary()`, which can never be true in the `CREATE INDEX` statement.