### PR TITLE
JDBC: Add public getter for statement return type

### DIFF
--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSetMetaData.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSetMetaData.java
@@ -62,6 +62,10 @@ public class DuckDBResultSetMetaData implements ResultSetMetaData {
 	protected DuckDBColumnTypeMetaData[] column_types_meta;
 	protected final StatementReturnType return_type;
 
+	public StatementReturnType getReturnType() {
+		return return_type;
+	}
+
 	public int getColumnCount() throws SQLException {
 		return column_count;
 	}


### PR DESCRIPTION
This PR just adds a public getter to access the statement return type via the meta data object.