### PR TITLE
Support file_search_path with globbing

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -919,7 +919,18 @@ vector<string> LocalFileSystem::Glob(const string &path, FileOpener *opener) {
 	if (absolute_path) {
 		// for absolute paths, we don't start by scanning the current directory
 		previous_directories.push_back(splits[0]);
+	} else {
+		// If file_search_path is set, use those paths as the first glob elements
+		Value value;
+		if (opener->TryGetCurrentSetting("file_search_path", value)) {
+			auto search_paths_str = value.ToString();
+			std::vector<std::string> search_paths = StringUtil::Split(search_paths_str, ',');
+			for (const auto &search_path : search_paths) {
+				previous_directories.push_back(search_path);
+			}
+		}
 	}
+
 	for (idx_t i = absolute_path ? 1 : 0; i < splits.size(); i++) {
 		bool is_last_chunk = i + 1 == splits.size();
 		bool has_glob = HasGlob(splits[i]);

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -853,7 +853,7 @@ vector<string> LocalFileSystem::FetchFileWithoutGlob(const string &path, FileOpe
 		result.push_back(path);
 	} else if (!absolute_path) {
 		Value value;
-		if (opener->TryGetCurrentSetting("file_search_path", value)) {
+		if (opener && opener->TryGetCurrentSetting("file_search_path", value)) {
 			auto search_paths_str = value.ToString();
 			std::vector<std::string> search_paths = StringUtil::Split(search_paths_str, ',');
 			for (const auto &search_path : search_paths) {
@@ -922,7 +922,7 @@ vector<string> LocalFileSystem::Glob(const string &path, FileOpener *opener) {
 	} else {
 		// If file_search_path is set, use those paths as the first glob elements
 		Value value;
-		if (opener->TryGetCurrentSetting("file_search_path", value)) {
+		if (opener && opener->TryGetCurrentSetting("file_search_path", value)) {
 			auto search_paths_str = value.ToString();
 			std::vector<std::string> search_paths = StringUtil::Split(search_paths_str, ',');
 			for (const auto &search_path : search_paths) {

--- a/test/sql/copy/csv/glob/read_csv_glob.test
+++ b/test/sql/copy/csv/glob/read_csv_glob.test
@@ -167,3 +167,45 @@ query I
 select count(*) from glob('~/rewoiarwiouw3rajkawrasdf790273489*.py') limit 10;
 ----
 0
+
+# file_search_path with one path
+statement ok
+set file_search_path='test/sql/copy/csv/data/glob';
+
+query I
+SELECT COUNT(*) FROM glob('*/*.csv');
+----
+5
+
+# file_search_path with multiple paths
+statement ok
+set file_search_path='test/sql/copy/csv/data/glob/a1,test/sql/copy/csv/data/glob/a2';
+
+query I
+SELECT COUNT(*) FROM glob('*.csv');
+----
+2
+
+# file_search_path with a non-existent path
+statement ok
+set file_search_path='test/sql/copy/csv/data/glob,garbage';
+
+query I
+SELECT COUNT(*) FROM glob('*/*.csv');
+----
+5
+
+# Only file_search_path is searched
+query I
+SELECT COUNT(*) FROM glob('test/sql/copy/csv/data/glob/*/*.csv');
+----
+0
+
+# file_search_path can be cleared
+statement ok
+set file_search_path='';
+
+query I
+SELECT COUNT(*) FROM glob('test/sql/copy/csv/data/glob/*/*.csv');
+----
+5

--- a/test/sql/copy/csv/glob/read_csv_glob.test
+++ b/test/sql/copy/csv/glob/read_csv_glob.test
@@ -168,6 +168,8 @@ select count(*) from glob('~/rewoiarwiouw3rajkawrasdf790273489*.py') limit 10;
 ----
 0
 
+require skip_reload
+
 # file_search_path with one path
 statement ok
 set file_search_path='test/sql/copy/csv/data/glob';


### PR DESCRIPTION
People expect to be able to use globbing with Malloy, but `file_search_path` only worked with non-globbed pathnames, this addresses that.