### PR TITLE
First cut at TypeScript type declarations for DuckDb

### DIFF
--- a/tools/nodejs/.mocharc.json
+++ b/tools/nodejs/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "extension": ["js", "ts"],
+  "spec": ["test/*.js", "test/*.ts"],
+  "require": "ts-node/register"
+}

--- a/tools/nodejs/lib/duckdb.d.ts
+++ b/tools/nodejs/lib/duckdb.d.ts
@@ -1,0 +1,97 @@
+// declare module "duckdb" {
+export class Connection {
+  constructor(db: Database);
+
+  all(sql: any, ...args: any[]): any;
+
+  each(sql: any, ...args: any[]): any;
+
+  // Native method; no parameter or return type inference available
+  exec(): any;
+
+  // Native method; no parameter or return type inference available
+  prepare(): any;
+
+  register(name: any, return_type: any, fun: any): any;
+
+  // Native method; no parameter or return type inference available
+  register_bulk(): any;
+
+  run(sql: any, ...args: any[]): any;
+
+  stream(sql: any, ...args: any[]): any;
+
+  // Native method; no parameter or return type inference available
+  unregister(): any;
+}
+
+export class Database {
+  constructor(path: string, cb: any);
+
+  all(...args: any[]): any;
+
+  // Native method; no parameter or return type inference available
+  close(): any;
+
+  // Native method; no parameter or return type inference available
+  connect(): any;
+
+  each(...args: any[]): any;
+
+  exec(...args: any[]): any;
+
+  get(): void;
+
+  // Native method; no parameter or return type inference available
+  interrupt(): any;
+
+  // Native method; no parameter or return type inference available
+  parallelize(): any;
+
+  prepare(...args: any[]): any;
+
+  register(...args: any[]): any;
+
+  run(...args: any[]): any;
+
+  // Native method; no parameter or return type inference available
+  serialize(): any;
+
+  unregister(...args: any[]): any;
+
+  // Native method; no parameter or return type inference available
+  wait(): any;
+}
+
+export class Statement {
+  constructor();
+
+  // Native method; no parameter or return type inference available
+  all(): any;
+
+  // Native method; no parameter or return type inference available
+  each(): any;
+
+  // Native method; no parameter or return type inference available
+  finalize(): any;
+
+  get(): void;
+
+  // Native method; no parameter or return type inference available
+  run(): any;
+}
+
+export const ERROR: number;
+
+export const OPEN_CREATE: number;
+
+export const OPEN_FULLMUTEX: number;
+
+export const OPEN_PRIVATECACHE: number;
+
+export const OPEN_READONLY: number;
+
+export const OPEN_READWRITE: number;
+
+export const OPEN_SHAREDCACHE: number;
+// }

--- a/tools/nodejs/lib/duckdb.d.ts
+++ b/tools/nodejs/lib/duckdb.d.ts
@@ -1,84 +1,82 @@
-// declare module "duckdb" {
+/**
+ * TypeScript declarations for Node.JS bindings for DuckDb.
+ * See https://duckdb.org/docs/api/nodejs/overview for details
+ * on Node.JS API
+ */
+export class DuckDbError extends Error {
+  errno: number;
+  code: string;
+}
+
+type Callback<T> = (err: DuckDbError | null, res: T) => void;
+
+export type RowData = {
+  [columnName: string]: any;
+};
+
+export type TableData = RowData[];
+
 export class Connection {
-  constructor(db: Database);
+  constructor(db: Database, callback?: Callback<any>);
 
-  all(sql: any, ...args: any[]): any;
+  all(sql: string, ...args: [...any, Callback<TableData>] | []): void;
+  each(sql: string, ...args: [...any, Callback<RowData>] | []): void;
+  exec(sql: string, ...args: [...any, Callback<void>] | []): void;
 
-  each(sql: any, ...args: any[]): any;
+  prepare(sql: string, ...args: [...any, Callback<Statement>] | []): Statement;
+  run(sql: string, ...args: [...any, Callback<void>] | []): Statement;
 
-  // Native method; no parameter or return type inference available
-  exec(): any;
+  register(
+    name: string,
+    return_type: string,
+    fun: (...args: any[]) => any
+  ): void;
 
-  // Native method; no parameter or return type inference available
-  prepare(): any;
+  register_bulk(
+    name: string,
+    return_type: string,
+    fun: (...args: any[]) => any
+  ): void;
+  unregister(name: string, callback: Callback<any>): void;
 
-  register(name: any, return_type: any, fun: any): any;
+  stream(sql: any, ...args: any[]): QueryResult;
+}
 
-  // Native method; no parameter or return type inference available
-  register_bulk(): any;
-
-  run(sql: any, ...args: any[]): any;
-
-  stream(sql: any, ...args: any[]): any;
-
-  // Native method; no parameter or return type inference available
-  unregister(): any;
+export class QueryResult {
+  [Symbol.asyncIterator](): AsyncIterator<RowData>;
 }
 
 export class Database {
-  constructor(path: string, cb: any);
+  constructor(path: string, callback?: Callback<any>);
 
-  all(...args: any[]): any;
+  close(callback: Callback<void>): void;
 
-  // Native method; no parameter or return type inference available
-  close(): any;
+  connect(): Connection;
 
-  // Native method; no parameter or return type inference available
-  connect(): any;
+  all(sql: string, ...args: [...any, Callback<TableData>] | []): void;
+  each(sql: string, ...args: [...any, Callback<RowData>] | []): void;
+  exec(sql: string, ...args: [...any, Callback<void>] | []): void;
 
-  each(...args: any[]): any;
+  prepare(sql: string, ...args: [...any, Callback<Statement>] | []): Statement;
+  run(sql: string, ...args: [...any, Callback<void>] | []): Statement;
 
-  exec(...args: any[]): any;
-
-  get(): void;
-
-  // Native method; no parameter or return type inference available
-  interrupt(): any;
-
-  // Native method; no parameter or return type inference available
-  parallelize(): any;
-
-  prepare(...args: any[]): any;
-
-  register(...args: any[]): any;
-
-  run(...args: any[]): any;
-
-  // Native method; no parameter or return type inference available
-  serialize(): any;
-
-  unregister(...args: any[]): any;
-
-  // Native method; no parameter or return type inference available
-  wait(): any;
+  register(
+    name: string,
+    return_type: string,
+    fun: (...args: any[]) => any
+  ): void;
+  unregister(name: string, callback: Callback<any>): void;
 }
 
 export class Statement {
   constructor();
 
-  // Native method; no parameter or return type inference available
-  all(): any;
+  all(...args: [...any, Callback<TableData>] | []): void;
+  each(...args: [...any, Callback<RowData>] | []): void;
 
-  // Native method; no parameter or return type inference available
-  each(): any;
+  finalize(callback?: Callback<void>): void;
 
-  // Native method; no parameter or return type inference available
-  finalize(): any;
-
-  get(): void;
-
-  // Native method; no parameter or return type inference available
-  run(): any;
+  run(...args: [...any, Callback<void>] | []): Statement;
 }
 
 export const ERROR: number;
@@ -94,4 +92,3 @@ export const OPEN_READONLY: number;
 export const OPEN_READWRITE: number;
 
 export const OPEN_SHAREDCACHE: number;
-// }

--- a/tools/nodejs/package.json
+++ b/tools/nodejs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "duckdb",
   "main": "./lib/duckdb.js",
+  "types": "./lib/duckdb.d.ts",
   "version": "0.2.4",
   "description": "DuckDB node.js API",
   "gypfile": true,
@@ -25,14 +26,24 @@
     "test": "test"
   },
   "devDependencies": {
+    "@types/mocha": "^10.0.0",
+    "@types/node": "^18.11.0",
     "aws-sdk": "^2.790.0",
     "chai": "^4.3.6",
     "jsdoc3-parser": "^2.0.0",
-    "mocha": "^8.3.0"
+    "mocha": "^8.3.0",
+    "ts-node": "^10.9.1",
+    "tsconfig-paths": "^4.0.0",
+    "typescript": "^4.8.4"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cwida/duckdb.git"
+  },
+  "ts-node": {
+    "require": [
+      "tsconfig-paths/register"
+    ]
   },
   "keywords": [
     "database",

--- a/tools/nodejs/test/typescript_decls.test.ts
+++ b/tools/nodejs/test/typescript_decls.test.ts
@@ -1,33 +1,57 @@
 import * as duckdb from "..";
-var assert = require("assert");
-var fs = require("fs");
+import assert from "assert";
+import fs from "fs";
 
 describe("TypeScript declarataions", function () {
-  var db;
+  var db: duckdb.Database;
   before(function (done) {
     db = new duckdb.Database(":memory:", done);
   });
 
-  it("Database#exec", function (done) {
+  it("typescript: Database constructor no callback", (done) => {
+    const tdb0 = new duckdb.Database(":memory:"); // no callback argument
+    done();
+  });
+
+  it("typescript: Database constructor path error", (done) => {
+    const tdb0 = new duckdb.Database("./bogusPath.db", (err, res) => {
+      // Issue: I'm a little surprised that specifying an invalid file path
+      // doesn't seem to immediately signal an error here, but it doesn't.
+      tdb0.all(
+        "PRAGMA show_tables",
+        (err: duckdb.DuckDbError | null, res: any) => {
+          done();
+        }
+      );
+    });
+  });
+
+  it("typescript: query with error", (done) => {
+    // query with an error:
+    db.all(
+      "SELECT * FROM sometable",
+      (err: duckdb.DuckDbError | null, res: any) => {
+        assert.equal(err?.code, "DUCKDB_NODEJS_ERROR");
+        assert.equal(err?.errno, -1);
+        done();
+      }
+    );
+  });
+
+  it("typescript: Database#exec", function (done) {
     var sql = fs.readFileSync("test/support/script.sql", "utf8");
-    db.exec(sql, function (err) {
+    db.exec(sql, function (err: duckdb.DuckDbError | null) {
       if (err) throw err;
       done();
     });
   });
 
-  it("retrieve database structure", function (done) {
+  it("typescript: retrieve database structure", function (done) {
     db.all(
       "SELECT type, name FROM sqlite_master ORDER BY type, name",
-      function (err, rows) {
+      function (err: duckdb.DuckDbError | null, rows: duckdb.TableData) {
         if (err) throw err;
         assert.deepEqual(rows, [
-          // { type: 'index', name: 'grid_key_lookup' },
-          // { type: 'index', name: 'grid_utfgrid_lookup' },
-          // { type: 'index', name: 'images_id' },
-          // { type: 'index', name: 'keymap_lookup' },
-          //  { type: 'index', name: 'map_index' },
-          // { type: 'index', name: 'name' },
           { type: "table", name: "grid_key" },
           { type: "table", name: "grid_utfgrid" },
           { type: "table", name: "images" },
@@ -41,5 +65,167 @@ describe("TypeScript declarataions", function () {
         done();
       }
     );
+  });
+
+  it("typescript: database#all with no callback", (done) => {
+    db.all("select 42 as x");
+    done();
+  });
+
+  it("typescript: database#connect", (done) => {
+    const conn = db.connect();
+    assert(conn instanceof duckdb.Connection);
+    done();
+  });
+
+  it("typescript: ensure empty results work ok", (done) => {
+    db.all(
+      "create table test_table as select 42 as x",
+      (err: duckdb.DuckDbError | null, res: duckdb.TableData) => {
+        db.all(
+          "drop table test_table",
+          (err: duckdb.DuckDbError | null, res: duckdb.TableData) => {
+            console.log("drop table results: ", err, res);
+            assert.deepEqual(res, []);
+            done();
+          }
+        );
+      }
+    );
+  });
+
+  it("typescript: ternary int udf", function (done) {
+    db.register(
+      "udf",
+      "integer",
+      (x: number, y: number, z: number) => x + y + z
+    );
+    db.all(
+      "select udf(21, 20, 1) v",
+      function (err: duckdb.DuckDbError | null, rows: duckdb.TableData) {
+        if (err) throw err;
+        assert.equal(rows[0].v, 42);
+      }
+    );
+    db.unregister("udf", done);
+  });
+});
+
+describe("typescript: each", function () {
+  var db: duckdb.Database;
+  before(function (done) {
+    db = new duckdb.Database("test/support/big.db", done);
+  });
+
+  it("typescript: retrieve 100,000 rows with Statement#each", function (done) {
+    var total = 100000;
+    var retrieved = 0;
+
+    db.each(
+      "SELECT id, txt FROM foo WHERE ROWID < ?",
+      total,
+      function (err: duckdb.DuckDbError | null, row: any) {
+        if (err) throw err;
+        retrieved++;
+
+        if (retrieved === total) {
+          assert.equal(
+            retrieved,
+            total,
+            "Only retrieved " + retrieved + " out of " + total + " rows."
+          );
+          done();
+        }
+      }
+    );
+  });
+
+  /**
+   * This seems to always hang indefinitely, which is probably a bug:
+
+  it("typescript: each with no results", (done) => {
+    db.each(
+      "SELECT id, txt FROM foo WHERE 1=0",
+      function (err: duckdb.DuckDbError | null, row: any) {
+        console.log("each with empty results: ", err, row);
+        done();
+      }
+    );
+  });
+  */
+});
+
+describe("typescript: simple prepared statement", function () {
+  var db: duckdb.Database;
+  before(function (done) {
+    db = new duckdb.Database(":memory:", done);
+  });
+
+  it("should prepare, run and finalize the statement", function (done) {
+    db.prepare("CREATE TABLE foo (bar text)").run().finalize(done);
+  });
+
+  after(function (done) {
+    db.close(done);
+  });
+});
+
+describe("typescript: prepared statements", function () {
+  var db: duckdb.Database;
+  before(function (done) {
+    db = new duckdb.Database(":memory:", done);
+  });
+
+  var inserted = 0;
+  var retrieved = 0;
+
+  // We insert and retrieve that many rows.
+  var count = 1000;
+
+  it("typescript: should create the table", function (done) {
+    db.prepare("CREATE TABLE foo (txt text, num int, flt double, blb blob)")
+      .run()
+      .finalize(done);
+  });
+
+  it("typescript: should insert " + count + " rows", function (done) {
+    for (var i = 0; i < count; i++) {
+      db.prepare("INSERT INTO foo VALUES(?, ?, ?, ?)")
+        .run(
+          "String " + i,
+          i,
+          i * Math.PI,
+          null,
+          function (err: duckdb.DuckDbError | null) {
+            if (err) throw err;
+            inserted++;
+          }
+        )
+        .finalize(function (err) {
+          if (err) throw err;
+          if (inserted == count) done();
+        });
+    }
+  });
+});
+
+describe("typescript: stream and QueryResult", function () {
+  const total = 1000;
+
+  let db: duckdb.Database;
+  let conn: duckdb.Connection;
+  before((done) => {
+    db = new duckdb.Database(":memory:", () => {
+      conn = new duckdb.Connection(db, done);
+    });
+  });
+
+  it("streams results", async () => {
+    let retrieved = 0;
+    const stream = conn.stream("SELECT * FROM range(0, ?)", total);
+    for await (const row of stream) {
+      retrieved++;
+    }
+    assert.equal(total, retrieved);
   });
 });

--- a/tools/nodejs/test/typescript_decls.test.ts
+++ b/tools/nodejs/test/typescript_decls.test.ts
@@ -109,20 +109,12 @@ describe("TypeScript declarataions", function () {
     );
     db.unregister("udf", done);
   });
-});
-
-describe("typescript: each", function () {
-  var db: duckdb.Database;
-  before(function (done) {
-    db = new duckdb.Database("test/support/big.db", done);
-  });
-
   it("typescript: retrieve 100,000 rows with Statement#each", function (done) {
     var total = 100000;
     var retrieved = 0;
 
     db.each(
-      "SELECT id, txt FROM foo WHERE ROWID < ?",
+      "SELECT * FROM range(0, ?)",
       total,
       function (err: duckdb.DuckDbError | null, row: any) {
         if (err) throw err;
@@ -139,20 +131,6 @@ describe("typescript: each", function () {
       }
     );
   });
-
-  /**
-   * This seems to always hang indefinitely, which is probably a bug:
-
-  it("typescript: each with no results", (done) => {
-    db.each(
-      "SELECT id, txt FROM foo WHERE 1=0",
-      function (err: duckdb.DuckDbError | null, row: any) {
-        console.log("each with empty results: ", err, row);
-        done();
-      }
-    );
-  });
-  */
 });
 
 describe("typescript: simple prepared statement", function () {

--- a/tools/nodejs/test/typescript_decls.test.ts
+++ b/tools/nodejs/test/typescript_decls.test.ts
@@ -1,0 +1,45 @@
+import * as duckdb from "..";
+var assert = require("assert");
+var fs = require("fs");
+
+describe("TypeScript declarataions", function () {
+  var db;
+  before(function (done) {
+    db = new duckdb.Database(":memory:", done);
+  });
+
+  it("Database#exec", function (done) {
+    var sql = fs.readFileSync("test/support/script.sql", "utf8");
+    db.exec(sql, function (err) {
+      if (err) throw err;
+      done();
+    });
+  });
+
+  it("retrieve database structure", function (done) {
+    db.all(
+      "SELECT type, name FROM sqlite_master ORDER BY type, name",
+      function (err, rows) {
+        if (err) throw err;
+        assert.deepEqual(rows, [
+          // { type: 'index', name: 'grid_key_lookup' },
+          // { type: 'index', name: 'grid_utfgrid_lookup' },
+          // { type: 'index', name: 'images_id' },
+          // { type: 'index', name: 'keymap_lookup' },
+          //  { type: 'index', name: 'map_index' },
+          // { type: 'index', name: 'name' },
+          { type: "table", name: "grid_key" },
+          { type: "table", name: "grid_utfgrid" },
+          { type: "table", name: "images" },
+          { type: "table", name: "keymap" },
+          { type: "table", name: "map" },
+          { type: "table", name: "metadata" },
+          { type: "view", name: "grid_data" },
+          { type: "view", name: "grids" },
+          { type: "view", name: "tiles" },
+        ]);
+        done();
+      }
+    );
+  });
+});

--- a/tools/nodejs/tsconfig.json
+++ b/tools/nodejs/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "compilerOptions": {
     "allowJs": false,
+    "esModuleInterop": true,
+    "noImplicitAny": true,
+    "strict": true,
     "outDir": "./dist",
-    "rootDir": "./lib",
     "types": ["node", "mocha"]
   },
   "include": ["test/**/*"],

--- a/tools/nodejs/tsconfig.json
+++ b/tools/nodejs/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowJs": false,
+    "outDir": "./dist",
+    "rootDir": "./lib",
+    "types": ["node", "mocha"]
+  },
+  "include": ["test/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR includes a first cut at adding TypeScript type declarations for the Node.JS API to DuckDb that can be shipped with the duckdb npm module. 

The type declarations are defined in a single module, `duckdb.d.ts` that lives in the same `lib` directory as the NodeJS API, this is linked to the npm module via the `types` field of `package.json` so that TypeScript users of the NodeJS API should be able to just do

```typescript
import * as duckdb from "duckdb"
```
and be able to use all of the same NodeJS API, just with strict static type checks.

I've included a unit test in `test/typescript_decls.ts` to exercise a significant fraction of the API from TypeScript. It was pieced together from parts of the existing NodeJS tests. I also added a `.mocharc.json` and `tsconfig.json` to enable Mocha to run unit tests written in TypeScript.  Because the `tsconfig.json` has `allowJs` set to false, all existing JS tests continue to be run by Mocha directly, without first being transpiled by the TypeScript compiler.