### PR TITLE
String functions: count unicode codepoints instead of grapheme clusters

### DIFF
--- a/src/function/scalar/list/array_slice.cpp
+++ b/src/function/scalar/list/array_slice.cpp
@@ -76,7 +76,7 @@ list_entry_t SliceValue(Vector &result, list_entry_t input, int64_t begin, int64
 template <>
 string_t SliceValue(Vector &result, string_t input, int32_t begin, int32_t end) {
 	// one-based - zero has strange semantics
-	return SubstringFun::SubstringScalarFunction(result, input, begin + 1, end - begin);
+	return SubstringFun::SubstringUnicode(result, input, begin + 1, end - begin);
 }
 
 template <typename INPUT_TYPE, typename INDEX_TYPE>

--- a/src/function/scalar/list/list_extract.cpp
+++ b/src/function/scalar/list/list_extract.cpp
@@ -161,7 +161,7 @@ static void ExecuteListExtract(Vector &result, Vector &list, Vector &offsets, co
 static void ExecuteStringExtract(Vector &result, Vector &input_vector, Vector &subscript_vector, const idx_t count) {
 	BinaryExecutor::Execute<string_t, int64_t, string_t>(
 	    input_vector, subscript_vector, result, count, [&](string_t input_string, int64_t subscript) {
-		    return SubstringFun::SubstringScalarFunction(result, input_string, subscript, 1);
+		    return SubstringFun::SubstringUnicode(result, input_string, subscript, 1);
 	    });
 }
 

--- a/src/function/scalar/string/length.cpp
+++ b/src/function/scalar/string/length.cpp
@@ -20,20 +20,7 @@ struct StringLengthOperator {
 struct GraphemeCountOperator {
 	template <class TA, class TR>
 	static inline TR Operation(TA input) {
-		auto input_data = input.GetDataUnsafe();
-		auto input_length = input.GetSize();
-		for (idx_t i = 0; i < input_length; i++) {
-			if (input_data[i] & 0x80) {
-				int64_t length = 0;
-				// non-ascii character: use grapheme iterator on remainder of string
-				utf8proc_grapheme_callback(input_data, input_length, [&](size_t start, size_t end) {
-					length++;
-					return true;
-				});
-				return length;
-			}
-		}
-		return input_length;
+		return LengthFun::GraphemeCount<TA, TR>(input);
 	}
 };
 

--- a/src/function/scalar/string/length.cpp
+++ b/src/function/scalar/string/length.cpp
@@ -94,11 +94,11 @@ void LengthFun::RegisterFunction(BuiltinFunctions &set) {
 	length.name = "len";
 	set.AddFunction(length);
 
-	ScalarFunctionSet grapheme_count("grapheme_count");
-	grapheme_count.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::BIGINT,
-	                                          ScalarFunction::UnaryFunction<string_t, int64_t, GraphemeCountOperator>,
-	                                          nullptr, nullptr, LengthPropagateStats));
-	set.AddFunction(grapheme_count);
+	ScalarFunctionSet length_grapheme("length_grapheme");
+	length_grapheme.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::BIGINT,
+	                                           ScalarFunction::UnaryFunction<string_t, int64_t, GraphemeCountOperator>,
+	                                           nullptr, nullptr, LengthPropagateStats));
+	set.AddFunction(length_grapheme);
 
 	ScalarFunctionSet array_length("array_length");
 	array_length.AddFunction(array_length_unary);

--- a/src/function/scalar/string/substring.cpp
+++ b/src/function/scalar/string/substring.cpp
@@ -145,7 +145,7 @@ string_t SubstringFun::SubstringUnicode(Vector &result, string_t input, int64_t 
 				current_character++;
 			}
 		}
-		if (start_pos == DConstants::INVALID_INDEX || end == 0) {
+		if (start_pos == DConstants::INVALID_INDEX || end == 0 || end <= start) {
 			return SubstringEmptyString(result);
 		}
 	}

--- a/src/include/duckdb/function/scalar/string_functions.hpp
+++ b/src/include/duckdb/function/scalar/string_functions.hpp
@@ -65,6 +65,24 @@ struct LengthFun {
 		}
 		return length;
 	}
+
+	template <class TA, class TR>
+	static inline TR GraphemeCount(TA input) {
+		auto input_data = input.GetDataUnsafe();
+		auto input_length = input.GetSize();
+		for (idx_t i = 0; i < input_length; i++) {
+			if (input_data[i] & 0x80) {
+				int64_t length = 0;
+				// non-ascii character: use grapheme iterator on remainder of string
+				utf8proc_grapheme_callback(input_data, input_length, [&](size_t start, size_t end) {
+					length++;
+					return true;
+				});
+				return length;
+			}
+		}
+		return input_length;
+	}
 };
 
 struct LikeFun {
@@ -103,7 +121,8 @@ struct RegexpFun {
 
 struct SubstringFun {
 	static void RegisterFunction(BuiltinFunctions &set);
-	static string_t SubstringScalarFunction(Vector &result, string_t input, int64_t offset, int64_t length);
+	static string_t SubstringUnicode(Vector &result, string_t input, int64_t offset, int64_t length);
+	static string_t SubstringGrapheme(Vector &result, string_t input, int64_t offset, int64_t length);
 };
 
 struct PrintfFun {

--- a/src/include/duckdb/function/scalar/string_functions.hpp
+++ b/src/include/duckdb/function/scalar/string_functions.hpp
@@ -49,28 +49,21 @@ struct ConcatFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
-struct ConcatWSFun {
-	static void RegisterFunction(BuiltinFunctions &set);
-};
-
 struct LengthFun {
 	static void RegisterFunction(BuiltinFunctions &set);
+	static inline bool IsCharacter(char c) {
+		return (c & 0xc0) != 0x80;
+	}
+
 	template <class TA, class TR>
 	static inline TR Length(TA input) {
 		auto input_data = input.GetDataUnsafe();
 		auto input_length = input.GetSize();
+		TR length = 0;
 		for (idx_t i = 0; i < input_length; i++) {
-			if (input_data[i] & 0x80) {
-				int64_t length = 0;
-				// non-ascii character: use grapheme iterator on remainder of string
-				utf8proc_grapheme_callback(input_data, input_length, [&](size_t start, size_t end) {
-					length++;
-					return true;
-				});
-				return length;
-			}
+			length += IsCharacter(input_data[i]);
 		}
-		return input_length;
+		return length;
 	}
 };
 

--- a/test/sql/function/string/test_array_extract.test
+++ b/test/sql/function/string/test_array_extract.test
@@ -141,7 +141,7 @@ NULL
 query T
 SELECT array_extract(s, -2147483647) FROM strings
 ----
-h
-w
-b
+(empty)
+(empty)
+(empty)
 NULL

--- a/test/sql/function/string/test_complex_unicode.test
+++ b/test/sql/function/string/test_complex_unicode.test
@@ -73,3 +73,29 @@ query T
 SELECT REVERSE('MotörHead')
 ----
 daeHrötoM
+
+# substring with grapheme clusters
+query T
+SELECT substring_grapheme('🤦🏼‍♂️🤦🏼‍♂️🤦🏼‍♂️', 1, 1)
+----
+🤦🏼‍♂️
+
+query T
+SELECT substring_grapheme('S̈a︍', 2, 1)
+----
+a︍
+
+query T
+SELECT substring_grapheme('test: 🤦🏼‍♂️hello🤦🏼‍♂️ world', 7, 7)
+----
+🤦🏼‍♂️hello🤦🏼‍♂️
+
+query T
+SELECT substring_grapheme('S̈a', 1, 1)
+----
+S̈
+
+query T
+SELECT substring_grapheme('S̈a︍', -1, 1)
+----
+a︍

--- a/test/sql/function/string/test_complex_unicode.test
+++ b/test/sql/function/string/test_complex_unicode.test
@@ -5,19 +5,19 @@
 statement ok
 PRAGMA enable_verification
 
-# grapheme_count returns the number of grapheme clusters
+# length_grapheme returns the number of grapheme clusters
 query I
-SELECT grapheme_count('S̈a')
+SELECT length_grapheme('S̈a')
 ----
 2
 
 query I
-SELECT grapheme_count('🤦🏼‍♂️')
+SELECT length_grapheme('🤦🏼‍♂️')
 ----
 1
 
 query I
-SELECT grapheme_count('🤦🏼‍♂️ L🤦🏼‍♂️R 🤦🏼‍♂️')
+SELECT length_grapheme('🤦🏼‍♂️ L🤦🏼‍♂️R 🤦🏼‍♂️')
 ----
 7
 

--- a/test/sql/function/string/test_complex_unicode.test
+++ b/test/sql/function/string/test_complex_unicode.test
@@ -5,21 +5,37 @@
 statement ok
 PRAGMA enable_verification
 
-# length with grapheme clusters
+# grapheme_count returns the number of grapheme clusters
 query I
-SELECT length('S̈a')
+SELECT grapheme_count('S̈a')
 ----
 2
 
 query I
-SELECT length('🤦🏼‍♂️')
+SELECT grapheme_count('🤦🏼‍♂️')
 ----
 1
 
 query I
-SELECT length('🤦🏼‍♂️ L🤦🏼‍♂️R 🤦🏼‍♂️')
+SELECT grapheme_count('🤦🏼‍♂️ L🤦🏼‍♂️R 🤦🏼‍♂️')
 ----
 7
+
+# length returns the number of unicode codepoints
+query I
+SELECT length('S̈a')
+----
+3
+
+query I
+SELECT length('🤦🏼‍♂️')
+----
+5
+
+query I
+SELECT length('🤦🏼‍♂️ L🤦🏼‍♂️R 🤦🏼‍♂️')
+----
+19
 
 # strlen returns size in bytes
 query I
@@ -57,29 +73,3 @@ query T
 SELECT REVERSE('MotörHead')
 ----
 daeHrötoM
-
-# substring with grapheme clusters
-query T
-SELECT substring('🤦🏼‍♂️🤦🏼‍♂️🤦🏼‍♂️', 1, 1)
-----
-🤦🏼‍♂️
-
-query T
-SELECT substring('S̈a︍', 2, 1)
-----
-a︍
-
-query T
-SELECT substring('test: 🤦🏼‍♂️hello🤦🏼‍♂️ world', 7, 7)
-----
-🤦🏼‍♂️hello🤦🏼‍♂️
-
-query T
-SELECT substring('S̈a', 1, 1)
-----
-S̈
-
-query T
-SELECT substring('S̈a︍', -1, 1)
-----
-a︍

--- a/test/sql/function/string/test_left.test
+++ b/test/sql/function/string/test_left.test
@@ -16,6 +16,11 @@ SELECT LEFT('🦆ab', 0), LEFT('🦆ab', 1), LEFT('🦆ab', 2), LEFT('🦆ab', 3
 ----
 (empty)	🦆	🦆a	🦆ab	🦆ab
 
+query TTTT
+SELECT LEFT_GRAPHEME('🦆🤦S̈', 0), LEFT_GRAPHEME('🦆🤦S̈', 1), LEFT_GRAPHEME('🦆🤦S̈', 2), LEFT_GRAPHEME('🦆🤦S̈', 3)
+----
+(empty)	🦆	🦆🤦	🦆🤦S̈
+
 # test LEFT on negative positions
 query TTTTT
 SELECT LEFT('abcd', 0), LEFT('abc', -1), LEFT('abc', -2), LEFT('abc', -3), LEFT('abc', -4)
@@ -26,6 +31,11 @@ query TTTTT
 SELECT LEFT('🦆ab', 0), LEFT('🦆ab', -1), LEFT('🦆ab', -2), LEFT('🦆ab', -3), LEFT('🦆ab', -4)
 ----
 (empty)	🦆a	🦆	(empty)	(empty)
+
+query TTTT
+SELECT LEFT_GRAPHEME('🦆🤦S̈', 0), LEFT_GRAPHEME('🦆🤦S̈', -1), LEFT_GRAPHEME('🦆🤦S̈', -2), LEFT_GRAPHEME('🦆🤦S̈', -3)
+----
+(empty)	🦆🤦	🦆	(empty)
 
 # test LEFT on NULL values
 query TTT

--- a/test/sql/function/string/test_left.test
+++ b/test/sql/function/string/test_left.test
@@ -16,11 +16,6 @@ SELECT LEFT('🦆ab', 0), LEFT('🦆ab', 1), LEFT('🦆ab', 2), LEFT('🦆ab', 3
 ----
 (empty)	🦆	🦆a	🦆ab	🦆ab
 
-query TTTT
-SELECT LEFT('🦆🤦S̈', 0), LEFT('🦆🤦S̈', 1), LEFT('🦆🤦S̈', 2), LEFT('🦆🤦S̈', 3)
-----
-(empty)	🦆	🦆🤦	🦆🤦S̈
-
 # test LEFT on negative positions
 query TTTTT
 SELECT LEFT('abcd', 0), LEFT('abc', -1), LEFT('abc', -2), LEFT('abc', -3), LEFT('abc', -4)
@@ -31,11 +26,6 @@ query TTTTT
 SELECT LEFT('🦆ab', 0), LEFT('🦆ab', -1), LEFT('🦆ab', -2), LEFT('🦆ab', -3), LEFT('🦆ab', -4)
 ----
 (empty)	🦆a	🦆	(empty)	(empty)
-
-query TTTT
-SELECT LEFT('🦆🤦S̈', 0), LEFT('🦆🤦S̈', -1), LEFT('🦆🤦S̈', -2), LEFT('🦆🤦S̈', -3)
-----
-(empty)	🦆🤦	🦆	(empty)
 
 # test LEFT on NULL values
 query TTT

--- a/test/sql/function/string/test_left.test
+++ b/test/sql/function/string/test_left.test
@@ -5,46 +5,38 @@
 statement ok
 PRAGMA enable_verification
 
+foreach FUN LEFT LEFT_GRAPHEME
+
 # test LEFT on positive positions
 query TTTTT
-SELECT LEFT('abcd', 0), LEFT('abc', 1), LEFT('abc', 2), LEFT('abc', 3), LEFT('abc', 4)
+SELECT ${FUN}('abcd', 0), ${FUN}('abc', 1), ${FUN}('abc', 2), ${FUN}('abc', 3), ${FUN}('abc', 4)
 ----
 (empty)	a	ab	abc	abc
 
 query TTTTT
-SELECT LEFT('🦆ab', 0), LEFT('🦆ab', 1), LEFT('🦆ab', 2), LEFT('🦆ab', 3), LEFT('🦆ab', 4)
+SELECT ${FUN}('🦆ab', 0), ${FUN}('🦆ab', 1), ${FUN}('🦆ab', 2), ${FUN}('🦆ab', 3), ${FUN}('🦆ab', 4)
 ----
 (empty)	🦆	🦆a	🦆ab	🦆ab
 
-query TTTT
-SELECT LEFT_GRAPHEME('🦆🤦S̈', 0), LEFT_GRAPHEME('🦆🤦S̈', 1), LEFT_GRAPHEME('🦆🤦S̈', 2), LEFT_GRAPHEME('🦆🤦S̈', 3)
-----
-(empty)	🦆	🦆🤦	🦆🤦S̈
-
 # test LEFT on negative positions
 query TTTTT
-SELECT LEFT('abcd', 0), LEFT('abc', -1), LEFT('abc', -2), LEFT('abc', -3), LEFT('abc', -4)
+SELECT ${FUN}('abcd', 0), ${FUN}('abc', -1), ${FUN}('abc', -2), ${FUN}('abc', -3), ${FUN}('abc', -4)
 ----
 (empty)	ab	a	(empty)	(empty)
 
 query TTTTT
-SELECT LEFT('🦆ab', 0), LEFT('🦆ab', -1), LEFT('🦆ab', -2), LEFT('🦆ab', -3), LEFT('🦆ab', -4)
+SELECT ${FUN}('🦆ab', 0), ${FUN}('🦆ab', -1), ${FUN}('🦆ab', -2), ${FUN}('🦆ab', -3), ${FUN}('🦆ab', -4)
 ----
 (empty)	🦆a	🦆	(empty)	(empty)
 
-query TTTT
-SELECT LEFT_GRAPHEME('🦆🤦S̈', 0), LEFT_GRAPHEME('🦆🤦S̈', -1), LEFT_GRAPHEME('🦆🤦S̈', -2), LEFT_GRAPHEME('🦆🤦S̈', -3)
-----
-(empty)	🦆🤦	🦆	(empty)
-
 # test LEFT on NULL values
 query TTT
-SELECT LEFT(NULL, 0), LEFT('abc', NULL), LEFT(NULL, NULL)
+SELECT ${FUN}(NULL, 0), ${FUN}('abc', NULL), ${FUN}(NULL, NULL)
 ----
 NULL	NULL	NULL
 
 query TTT
-SELECT LEFT(NULL, 0), LEFT('🦆ab', NULL), LEFT(NULL, NULL)
+SELECT ${FUN}(NULL, 0), ${FUN}('🦆ab', NULL), ${FUN}(NULL, NULL)
 ----
 NULL	NULL	NULL
 
@@ -59,7 +51,7 @@ statement ok
 INSERT INTO STRINGS VALUES ('abcd', 0), ('abc', 1), ('abc', 2), ('abc', 3), ('abc', 4)
 
 query T
-SELECT LEFT(a, b) FROM strings
+SELECT ${FUN}(a, b) FROM strings
 ----
 (empty)
 a
@@ -77,7 +69,7 @@ statement ok
 INSERT INTO STRINGS VALUES ('abcd', 0), ('abc', -1), ('abc', -2), ('abc', -3), ('abc', -4)
 
 query T
-SELECT LEFT(a, b) FROM strings
+SELECT ${FUN}(a, b) FROM strings
 ----
 (empty)
 ab
@@ -95,9 +87,21 @@ statement ok
 INSERT INTO STRINGS VALUES (NULL, 0), ('abc', NULL), (NULL, NULL)
 
 query T
-SELECT LEFT(a, b) FROM strings
+SELECT ${FUN}(a, b) FROM strings
 ----
 NULL
 NULL
 NULL
 
+endloop
+
+# grapheme clusters
+query TTTT
+SELECT LEFT_GRAPHEME('🦆🤦S̈', 0), LEFT_GRAPHEME('🦆🤦S̈', 1), LEFT_GRAPHEME('🦆🤦S̈', 2), LEFT_GRAPHEME('🦆🤦S̈', 3)
+----
+(empty)	🦆	🦆🤦	🦆🤦S̈
+
+query TTTT
+SELECT LEFT_GRAPHEME('🦆🤦S̈', 0), LEFT_GRAPHEME('🦆🤦S̈', -1), LEFT_GRAPHEME('🦆🤦S̈', -2), LEFT_GRAPHEME('🦆🤦S̈', -3)
+----
+(empty)	🦆🤦	🦆	(empty)

--- a/test/sql/function/string/test_right.test
+++ b/test/sql/function/string/test_right.test
@@ -16,11 +16,6 @@ SELECT RIGHT('🦆ab', 0), RIGHT('🦆ab', 1), RIGHT('🦆ab', 2), RIGHT('🦆ab
 ----
 (empty)	b	ab	🦆ab	🦆ab
 
-query TTTT
-SELECT RIGHT('🦆🤦S̈', 0), RIGHT('🦆🤦S̈', 1), RIGHT('🦆🤦S̈', 2), RIGHT('🦆🤦S̈', 3)
-----
-(empty)	S̈	🤦S̈	🦆🤦S̈
-
 # test RIGHT on negative positions
 query TTTTT
 SELECT RIGHT('abcd', 0), RIGHT('abc', -1), RIGHT('abc', -2), RIGHT('abc', -3), RIGHT('abc', -4)
@@ -31,11 +26,6 @@ query TTTTT
 SELECT RIGHT('🦆ab', 0), RIGHT('🦆ab', -1), RIGHT('🦆ab', -2), RIGHT('🦆ab', -3), RIGHT('🦆ab', -4)
 ----
 (empty)	ab	b	(empty)	(empty)
-
-query TTTT
-SELECT RIGHT('🦆🤦S̈', 0), RIGHT('🦆🤦S̈', -1), RIGHT('🦆🤦S̈', -2), RIGHT('🦆🤦S̈', -3)
-----
-(empty)	🤦S̈	S̈	(empty)
 
 # test RIGHT on NULL values
 query TTT

--- a/test/sql/function/string/test_right.test
+++ b/test/sql/function/string/test_right.test
@@ -5,46 +5,38 @@
 statement ok
 PRAGMA enable_verification
 
+foreach FUN RIGHT RIGHT_GRAPHEME
+
 # test RIGHT on positive positions
 query TTTTT
-SELECT RIGHT('abcd', 0), RIGHT('abc', 1), RIGHT('abc', 2), RIGHT('abc', 3), RIGHT('abc', 4)
+SELECT ${FUN}('abcd', 0), ${FUN}('abc', 1), ${FUN}('abc', 2), ${FUN}('abc', 3), ${FUN}('abc', 4)
 ----
 (empty)	c	bc	abc	abc
 
 query TTTTT
-SELECT RIGHT('🦆ab', 0), RIGHT('🦆ab', 1), RIGHT('🦆ab', 2), RIGHT('🦆ab', 3), RIGHT('🦆ab', 4)
+SELECT ${FUN}('🦆ab', 0), ${FUN}('🦆ab', 1), ${FUN}('🦆ab', 2), ${FUN}('🦆ab', 3), ${FUN}('🦆ab', 4)
 ----
 (empty)	b	ab	🦆ab	🦆ab
 
-query TTTT
-SELECT RIGHT_GRAPHEME('🦆🤦S̈', 0), RIGHT_GRAPHEME('🦆🤦S̈', 1), RIGHT_GRAPHEME('🦆🤦S̈', 2), RIGHT_GRAPHEME('🦆🤦S̈', 3)
-----
-(empty)	S̈	🤦S̈	🦆🤦S̈
-
 # test RIGHT on negative positions
 query TTTTT
-SELECT RIGHT('abcd', 0), RIGHT('abc', -1), RIGHT('abc', -2), RIGHT('abc', -3), RIGHT('abc', -4)
+SELECT ${FUN}('abcd', 0), ${FUN}('abc', -1), ${FUN}('abc', -2), ${FUN}('abc', -3), ${FUN}('abc', -4)
 ----
 (empty)	bc	c	(empty)	(empty)
 
 query TTTTT
-SELECT RIGHT('🦆ab', 0), RIGHT('🦆ab', -1), RIGHT('🦆ab', -2), RIGHT('🦆ab', -3), RIGHT('🦆ab', -4)
+SELECT ${FUN}('🦆ab', 0), ${FUN}('🦆ab', -1), ${FUN}('🦆ab', -2), ${FUN}('🦆ab', -3), ${FUN}('🦆ab', -4)
 ----
 (empty)	ab	b	(empty)	(empty)
 
-query TTTT
-SELECT RIGHT_GRAPHEME('🦆🤦S̈', 0), RIGHT_GRAPHEME('🦆🤦S̈', -1), RIGHT_GRAPHEME('🦆🤦S̈', -2), RIGHT_GRAPHEME('🦆🤦S̈', -3)
-----
-(empty)	🤦S̈	S̈	(empty)
-
 # test RIGHT on NULL values
 query TTT
-SELECT RIGHT(NULL, 0), RIGHT('abc', NULL), RIGHT(NULL, NULL)
+SELECT ${FUN}(NULL, 0), ${FUN}('abc', NULL), ${FUN}(NULL, NULL)
 ----
 NULL	NULL	NULL
 
 query TTT
-SELECT RIGHT(NULL, 0), RIGHT('🦆ab', NULL), RIGHT(NULL, NULL)
+SELECT ${FUN}(NULL, 0), ${FUN}('🦆ab', NULL), ${FUN}(NULL, NULL)
 ----
 NULL	NULL	NULL
 
@@ -59,7 +51,7 @@ statement ok
 INSERT INTO STRINGS VALUES ('abcd', 0), ('abc', 1), ('abc', 2), ('abc', 3), ('abc', 4)
 
 query T
-SELECT RIGHT(a, b) FROM strings
+SELECT ${FUN}(a, b) FROM strings
 ----
 (empty)
 c
@@ -77,7 +69,7 @@ statement ok
 INSERT INTO STRINGS VALUES ('abcd', 0), ('abc', -1), ('abc', -2), ('abc', -3), ('abc', -4)
 
 query T
-SELECT RIGHT(a, b) FROM strings
+SELECT ${FUN}(a, b) FROM strings
 ----
 (empty)
 bc
@@ -95,9 +87,21 @@ statement ok
 INSERT INTO STRINGS VALUES (NULL, 0), ('abc', NULL), (NULL, NULL)
 
 query T
-SELECT RIGHT(a, b) FROM strings
+SELECT ${FUN}(a, b) FROM strings
 ----
 NULL
 NULL
 NULL
 
+endloop
+
+# grapheme clusters
+query TTTT
+SELECT RIGHT_GRAPHEME('🦆🤦S̈', 0), RIGHT_GRAPHEME('🦆🤦S̈', 1), RIGHT_GRAPHEME('🦆🤦S̈', 2), RIGHT_GRAPHEME('🦆🤦S̈', 3)
+----
+(empty)	S̈	🤦S̈	🦆🤦S̈
+
+query TTTT
+SELECT RIGHT_GRAPHEME('🦆🤦S̈', 0), RIGHT_GRAPHEME('🦆🤦S̈', -1), RIGHT_GRAPHEME('🦆🤦S̈', -2), RIGHT_GRAPHEME('🦆🤦S̈', -3)
+----
+(empty)	🤦S̈	S̈	(empty)

--- a/test/sql/function/string/test_right.test
+++ b/test/sql/function/string/test_right.test
@@ -16,6 +16,11 @@ SELECT RIGHT('🦆ab', 0), RIGHT('🦆ab', 1), RIGHT('🦆ab', 2), RIGHT('🦆ab
 ----
 (empty)	b	ab	🦆ab	🦆ab
 
+query TTTT
+SELECT RIGHT_GRAPHEME('🦆🤦S̈', 0), RIGHT_GRAPHEME('🦆🤦S̈', 1), RIGHT_GRAPHEME('🦆🤦S̈', 2), RIGHT_GRAPHEME('🦆🤦S̈', 3)
+----
+(empty)	S̈	🤦S̈	🦆🤦S̈
+
 # test RIGHT on negative positions
 query TTTTT
 SELECT RIGHT('abcd', 0), RIGHT('abc', -1), RIGHT('abc', -2), RIGHT('abc', -3), RIGHT('abc', -4)
@@ -26,6 +31,11 @@ query TTTTT
 SELECT RIGHT('🦆ab', 0), RIGHT('🦆ab', -1), RIGHT('🦆ab', -2), RIGHT('🦆ab', -3), RIGHT('🦆ab', -4)
 ----
 (empty)	ab	b	(empty)	(empty)
+
+query TTTT
+SELECT RIGHT_GRAPHEME('🦆🤦S̈', 0), RIGHT_GRAPHEME('🦆🤦S̈', -1), RIGHT_GRAPHEME('🦆🤦S̈', -2), RIGHT_GRAPHEME('🦆🤦S̈', -3)
+----
+(empty)	🤦S̈	S̈	(empty)
 
 # test RIGHT on NULL values
 query TTT

--- a/test/sql/function/string/test_string_slice.test
+++ b/test/sql/function/string/test_string_slice.test
@@ -39,31 +39,10 @@ SELECT '🦆ab'[0:0], 'abc'[0:0]
 ----
 (empty)	(empty)
 
-# test grapheme clusters
-query I
-SELECT '🤦🏼‍♂️ L🤦🏼‍♂️R 🤦🏼‍♂️'[2:5]
-----
- L🤦🏼‍♂️R
-
-query I
-SELECT 'S̈a'[1:2]
-----
-S̈a
-
-query I
-SELECT 'S̈a'[2:2]
-----
-a
-
 query I
 SELECT 'MotörHead'[:5]
 ----
 Motör
-
-query I
-SELECT 'Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢'[2:]
-----
-A̴̵̜̰͔ͫ͗͢
 
 # constant offset/length
 # normal slice

--- a/test/sql/function/string/test_subscript.test
+++ b/test/sql/function/string/test_subscript.test
@@ -17,27 +17,6 @@ SELECT '🦆ab'[1], 'abc'[2]
 ----
 🦆	b
 
-# test grapheme clusters
-query I
-SELECT '🤦🏼‍♂️ L🤦🏼‍♂️R 🤦🏼‍♂️'[4]
-----
-🤦🏼‍♂️
-
-query I
-SELECT 'S̈a'[1]
-----
-S̈
-
-query I
-SELECT 'MotörHead'[4]
-----
-ö
-
-query I
-SELECT 'Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢'[2]
-----
-A̴̵̜̰͔ͫ͗͢
-
 # constant offset/length
 # normal array_extract
 query T

--- a/test/sql/function/string/test_subscript.test
+++ b/test/sql/function/string/test_subscript.test
@@ -121,7 +121,12 @@ NULL
 query T
 SELECT s[-2147483647] FROM strings
 ----
-h
-w
-b
+(empty)
+(empty)
+(empty)
+NULL
+
+query T
+SELECT ([1,2,3])[-2147483647]
+----
 NULL

--- a/test/sql/function/string/test_substring.test
+++ b/test/sql/function/string/test_substring.test
@@ -11,9 +11,11 @@ CREATE TABLE strings(s VARCHAR, off INTEGER, length INTEGER);
 statement ok
 INSERT INTO strings VALUES ('hello', 1, 2), ('world', 2, 3), ('b', 1, 1), (NULL, 2, 2)
 
+foreach FUN substring substring_grapheme
+
 # test zero length
 query TT
-SELECT SUBSTRING('🦆ab', 1, 0), SUBSTRING('abc', 1, 0)
+SELECT ${FUN}('🦆ab', 1, 0), ${FUN}('abc', 1, 0)
 ----
 (empty)	(empty)
 
@@ -146,7 +148,7 @@ NULL
 
 # negative length
 query T
-SELECT substring(s, 2, -2) FROM strings
+SELECT ${FUN}(s, 2, -2) FROM strings
 ----
 h
 w
@@ -155,7 +157,7 @@ NULL
 
 # negative offset and negative length
 query T
-SELECT substring(s, -2, -2) FROM strings
+SELECT ${FUN}(s, -2, -2) FROM strings
 ----
 el
 or
@@ -164,7 +166,7 @@ NULL
 
 # length 0
 query T
-SELECT substring(s, 2, 0) FROM strings
+SELECT ${FUN}(s, 2, 0) FROM strings
 ----
 (empty)
 (empty)
@@ -173,7 +175,7 @@ NULL
 
 # no length
 query T
-SELECT substring(s, 2) FROM strings
+SELECT ${FUN}(s, 2) FROM strings
 ----
 ello
 orld
@@ -181,7 +183,7 @@ orld
 NULL
 
 query T
-SELECT substring(substring(s, 2), 2) FROM strings
+SELECT ${FUN}(${FUN}(s, 2), 2) FROM strings
 ----
 llo
 rld
@@ -190,7 +192,7 @@ NULL
 
 # very large offset and length
 query T
-SELECT substring(s, 2147483647, 2147483647) FROM strings
+SELECT ${FUN}(s, 2147483647, 2147483647) FROM strings
 ----
 (empty)
 (empty)
@@ -198,15 +200,7 @@ SELECT substring(s, 2147483647, 2147483647) FROM strings
 NULL
 
 query T
-SELECT substring(s, 2147483647, -2147483647) FROM strings
-----
-hello
-world
-b
-NULL
-
-query T
-SELECT substring(s, -2147483647, 2147483647) FROM strings
+SELECT ${FUN}(s, 2147483647, -2147483647) FROM strings
 ----
 hello
 world
@@ -214,7 +208,15 @@ b
 NULL
 
 query T
-SELECT substring(s, -2147483647, -2147483647) FROM strings
+SELECT ${FUN}(s, -2147483647, 2147483647) FROM strings
+----
+hello
+world
+b
+NULL
+
+query T
+SELECT ${FUN}(s, -2147483647, -2147483647) FROM strings
 ----
 (empty)
 (empty)
@@ -223,6 +225,8 @@ NULL
 
 # Issue #2553 - accept BIGINT arguments
 query I
-SELECT SUBSTR('abc', INSTR('abc', 'b'));
+SELECT ${FUN}('abc', INSTR('abc', 'b'));
 ----
 bc
+
+endloop

--- a/test/sql/function/string/test_substring_utf8.test
+++ b/test/sql/function/string/test_substring_utf8.test
@@ -26,34 +26,38 @@ SELECT substring(s from 15 for 7) FROM strings
 ----
 🦆end
 
+foreach FUN substr substring_grapheme
+
 # negative lengths and offsets
 query T
-SELECT substr(s, -4, 4) FROM strings
+SELECT ${FUN}(s, -4, 4) FROM strings
 ----
 🦆end
 
 query T
-SELECT substr(s, -1, -4) FROM strings
+SELECT ${FUN}(s, -1, -4) FROM strings
 ----
 r🦆en
 
 query T
-SELECT substr(s, 0, -4) FROM strings
+SELECT ${FUN}(s, 0, -4) FROM strings
 ----
 (empty)
 
 query T
-SELECT substr(s, 0, 5) FROM strings
+SELECT ${FUN}(s, 0, 5) FROM strings
 ----
 twoñ
 
 query T
-SELECT substr(s, 5, -5) FROM strings
+SELECT ${FUN}(s, 5, -5) FROM strings
 ----
 twoñ
 
 # length is optional
 query T
-SELECT substr(s, 5) FROM strings
+SELECT ${FUN}(s, 5) FROM strings
 ----
 three₡four🦆end
+
+endloop


### PR DESCRIPTION
This PR moves away from counting grapheme clusters by default and instead switches to counting unicode codepoints. This is similar to what almost all other systems do, such as Postgres and Python. This affects functions such as `length`, but also functions such as `substring`, `left`, `right` and general string slicing. For example:

##### Before this PR

```sql
SELECT LENGTH('오리');
-- 2
SELECT LENGTH('🤦🏼‍♂️');
-- 1
```

##### After this PR

```sql
SELECT LENGTH('오리');
-- 2
SELECT LENGTH('🤦🏼‍♂️');
-- 5
```

##### Python

```py
print(len('오리')) # 2
print(len('🤦🏼‍♂️')) # 5
```

##### Postgres
```sql
SELECT LENGTH('오리');
-- 2
SELECT LENGTH('🤦🏼‍♂️');
-- 5
```

##### Performance

The main benefit to counting unicode codepoints is that it is significantly faster than counting grapheme clusters (on the order of ~10X faster). Counting unicode codepoints is straightforward - whereas counting grapheme clusters is much more computationally expensive. Looking only at the number of bytes is even easier, of course, and we have an optimization for using that (`strlen`) instead when only ASCII characters are stored in a column.

```sql
call dbgen(sf=1);
-- force unicode version to be used by introducing unicode
update lineitem set l_comment=concat(l_comment, 'ä');
select avg(length(l_comment)) from lineitem;
```

```sql
-- ASCII (strlen - number of bytes)
┌─────────────┴─────────────┐
│         PROJECTION        │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│     length(l_comment)     │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│          6001215          │
│          (0.01s)          │
└─────────────┬─────────────┘   
-- Unicode codepoints (this PR)
┌─────────────┴─────────────┐
│         PROJECTION        │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│     length(l_comment)     │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│          6001215          │
│          (0.15s)          │
└─────────────┬─────────────┘  
-- Grapheme clusters (previous LENGTH implementation)
┌─────────────┴─────────────┐
│         PROJECTION        │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│     length(l_comment)     │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│          6001215          │
│          (1.50s)          │
└─────────────┬─────────────┘    

```

##### Grapheme Functions
The previous functionality is still available with functions suffixed with `_grapheme`. For example:


```sql
SELECT LENGTH_GRAPHEME('오리');
-- 2
SELECT LENGTH_GRAPHEME('🤦🏼‍♂️');
-- 1
```

