### PR TITLE
Undefined behavior sanitizer error fix

### DIFF
--- a/src/execution/operator/join/physical_comparison_join.cpp
+++ b/src/execution/operator/join/physical_comparison_join.cpp
@@ -29,7 +29,7 @@ string PhysicalComparisonJoin::ParamsToString() const {
 		string op = ExpressionTypeToOperator(it.comparison);
 		extra_info += it.left->GetName() + " " + op + " " + it.right->GetName() + "\n";
 	}
-	extra_info += "\nEC = " + std::to_string(estimated_props->GetCardinality()) + "\n";
+	extra_info += "\nEC = " + std::to_string(estimated_props->GetCardinality<double>()) + "\n";
 	extra_info += "COST = " + std::to_string(estimated_props->GetCost()) + "\n";
 	return extra_info;
 }

--- a/src/execution/physical_plan_generator.cpp
+++ b/src/execution/physical_plan_generator.cpp
@@ -197,7 +197,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalOperator &
 	}
 
 	if (op.estimated_props) {
-		plan->estimated_cardinality = op.estimated_props->GetCardinality();
+		plan->estimated_cardinality = op.estimated_props->GetCardinality<idx_t>();
 		plan->estimated_props = op.estimated_props->Copy();
 	} else {
 		plan->estimated_props = make_unique<EstimatedProperties>();

--- a/src/include/duckdb/optimizer/estimated_properties.hpp
+++ b/src/include/duckdb/optimizer/estimated_properties.hpp
@@ -24,8 +24,11 @@ public:
 	EstimatedProperties(double cardinality, double cost) : cardinality(cardinality), cost(cost) {};
 	EstimatedProperties() : cardinality(0), cost(0) {};
 
-	double GetCardinality();
-	double GetCost();
+	template <class T>
+	T GetCardinality() const {
+		throw NotImplementedException("Unsupported type for GetCardinality");
+	}
+	double GetCost() const;
 	void SetCost(double new_cost);
 	void SetCardinality(double cardinality);
 
@@ -36,4 +39,11 @@ private:
 public:
 	unique_ptr<EstimatedProperties> Copy();
 };
+
+template <>
+double EstimatedProperties::GetCardinality() const;
+
+template <>
+idx_t EstimatedProperties::GetCardinality() const;
+
 } // namespace duckdb

--- a/src/include/duckdb/optimizer/join_node.hpp
+++ b/src/include/duckdb/optimizer/join_node.hpp
@@ -53,7 +53,10 @@ private:
 	double base_cardinality;
 
 public:
-	double GetCardinality() const;
+	template <class CARDINALITY_TYPE>
+	CARDINALITY_TYPE GetCardinality() const {
+		return estimated_props->GetCardinality<CARDINALITY_TYPE>();
+	}
 	double GetCost();
 	void SetCost(double cost);
 	double GetBaseTableCardinality();

--- a/src/optimizer/estimated_properties.cpp
+++ b/src/optimizer/estimated_properties.cpp
@@ -3,10 +3,18 @@
 
 namespace duckdb {
 
-double EstimatedProperties::GetCardinality() {
+template <>
+double EstimatedProperties::GetCardinality() const {
 	return cardinality;
 }
-double EstimatedProperties::GetCost() {
+
+template <>
+idx_t EstimatedProperties::GetCardinality() const {
+	auto max_idx_t = NumericLimits<idx_t>::Maximum() - 10000;
+	return MinValue<double>(cardinality, max_idx_t);
+}
+
+double EstimatedProperties::GetCost() const {
 	return cost;
 }
 

--- a/src/optimizer/join_node.cpp
+++ b/src/optimizer/join_node.cpp
@@ -21,10 +21,6 @@ unique_ptr<EstimatedProperties> EstimatedProperties::Copy() {
 	return result;
 }
 
-double JoinNode::GetCardinality() const {
-	return estimated_props->GetCardinality();
-}
-
 double JoinNode::GetCost() {
 	return estimated_props->GetCost();
 }
@@ -54,10 +50,10 @@ string JoinNode::ToString() {
 	}
 	string result = "-------------------------------\n";
 	result += set->ToString() + "\n";
-	result += "card = " + to_string(GetCardinality()) + "\n";
+	result += "card = " + to_string(GetCardinality<double>()) + "\n";
 	bool is_cartesian = false;
 	if (left && right) {
-		is_cartesian = (GetCardinality() == left->GetCardinality() * right->GetCardinality());
+		is_cartesian = (GetCardinality<double>() == left->GetCardinality<double>() * right->GetCardinality<double>());
 	}
 	result += "cartesian = " + to_string(is_cartesian) + "\n";
 	result += "cost = " + to_string(estimated_props->GetCost()) + "\n";

--- a/src/optimizer/join_order_optimizer.cpp
+++ b/src/optimizer/join_order_optimizer.cpp
@@ -250,14 +250,14 @@ unique_ptr<JoinNode> JoinOrderOptimizer::CreateJoinTree(JoinRelationSet *set,
 	auto plan = plans.find(set);
 	// if we have already calculated an expected cardinality for this set,
 	// just re-use that cardinality
-	if (left->GetCardinality() < right->GetCardinality()) {
+	if (left->GetCardinality<double>() < right->GetCardinality<double>()) {
 		return CreateJoinTree(set, possible_connections, right, left);
 	}
 	if (plan != plans.end()) {
 		if (!plan->second) {
 			throw InternalException("No plan: internal error in join order optimizer");
 		}
-		expected_cardinality = plan->second->GetCardinality();
+		expected_cardinality = plan->second->GetCardinality<double>();
 		best_connection = possible_connections.back();
 	} else if (possible_connections.empty()) {
 		// cross product
@@ -622,7 +622,8 @@ void JoinOrderOptimizer::SolveJoinOrderApproximately() {
 				auto current_plan = plans[join_relations[i]].get();
 				// check if the cardinality is smaller than the smallest two found so far
 				for (idx_t j = 0; j < 2; j++) {
-					if (!smallest_plans[j] || smallest_plans[j]->GetCardinality() > current_plan->GetCardinality()) {
+					if (!smallest_plans[j] ||
+					    smallest_plans[j]->GetCardinality<double>() > current_plan->GetCardinality<double>()) {
 						smallest_plans[j] = current_plan;
 						smallest_index[j] = i;
 						break;
@@ -757,8 +758,7 @@ JoinOrderOptimizer::GenerateJoins(vector<unique_ptr<LogicalOperator>> &extracted
 		result_relation = node->set;
 		result_operator = move(extracted_relations[node->set->relations[0]]);
 	}
-	auto max_idx_t = NumericLimits<idx_t>::Maximum() - 10000;
-	result_operator->estimated_cardinality = MinValue<idx_t>(node->GetCardinality(), max_idx_t);
+	result_operator->estimated_cardinality = node->GetCardinality<idx_t>();
 	result_operator->has_estimated_cardinality = true;
 	result_operator->estimated_props = node->estimated_props->Copy();
 	// check if we should do a pushdown on this node


### PR DESCRIPTION
This PR fixes an issue that triggers the undefined behavior sanitizer.

```
join_order_optimizer.cpp:761:59: runtime error: 2.38979e+19 is outside the range of representable values of type 'unsigned long long'
```

The fix might be a little too verbose, after writing this I realized maybe creating a GetRoundedCardinality() function would have been better, avoids touching all the other calls and doesn't make them as verbose (and error-prone if we decide to change the underlying type of `cardinality`)