### PR TITLE
fsst bugfix

### DIFF
--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -335,7 +335,8 @@ public:
 		Store<uint32_t>(symbol_table_offset, (data_ptr_t)&header_ptr->fsst_symbol_table_offset);
 		Store<uint32_t>((uint32_t)current_width, (data_ptr_t)&header_ptr->bitpacking_width);
 
-		D_ASSERT(symbol_table_offset + fsst_serialized_symbol_table_size <= current_dictionary.end - current_dictionary.size);
+		D_ASSERT(symbol_table_offset + fsst_serialized_symbol_table_size <=
+		         current_dictionary.end - current_dictionary.size);
 
 		if (total_size >= FSSTStorage::COMPACTION_FLUSH_LIMIT) {
 			// the block is full enough, don't bother moving around the dictionary

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -256,6 +256,10 @@ public:
 	}
 
 	void AddNull() {
+		if (!HasEnoughSpace(0)) {
+			Flush();
+			D_ASSERT(HasEnoughSpace(0));
+		}
 		index_buffer.push_back(0);
 		current_segment->count++;
 	}
@@ -330,6 +334,8 @@ public:
 
 		Store<uint32_t>(symbol_table_offset, (data_ptr_t)&header_ptr->fsst_symbol_table_offset);
 		Store<uint32_t>((uint32_t)current_width, (data_ptr_t)&header_ptr->bitpacking_width);
+
+		D_ASSERT(symbol_table_offset + fsst_serialized_symbol_table_size <= current_dictionary.end - current_dictionary.size);
 
 		if (total_size >= FSSTStorage::COMPACTION_FLUSH_LIMIT) {
 			// the block is full enough, don't bother moving around the dictionary

--- a/test/sql/storage/compression/string/null_large.test_slow
+++ b/test/sql/storage/compression/string/null_large.test_slow
@@ -1,0 +1,34 @@
+# name: test/sql/storage/compression/string/null_large.test_slow
+# description: Test storage of string columns with a lot of nulls
+# group: [string]
+
+load __TEST_DIR__/test_string_compression.db
+
+foreach compression fsst dictionary
+
+foreach enable_fsst_vector true false
+
+statement ok
+SET enable_fsst_vectors='${enable_fsst_vector}'
+
+statement ok
+PRAGMA force_compression='${compression}'
+
+# varchars
+statement ok
+CREATE TABLE varchars AS SELECT case when i%2=0 then null else concat('thisismyvarchar-', i/4) end AS v FROM range(1000000) tbl(i);
+
+statement ok
+checkpoint;
+
+query IIIII
+SELECT MIN(v), MAX(v), COUNT(*), COUNT(v), COUNT(DISTINCT v) FROM varchars
+----
+thisismyvarchar-0	thisismyvarchar-99999	1000000	500000	250000
+
+statement ok
+DROP TABLE varchars
+
+endloop
+
+endloop


### PR DESCRIPTION
fixes bug in fsst where for inserting NULL values, the available size in a block would not be checked causing compression to overwrite the dictionary.