### PR TITLE
Avoid installing git for ODBC Windows CI Run

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -167,11 +167,6 @@ jobs:
       with:
         python-version: '3.7'
 
-    - name: Install Git
-      shell: bash
-      run: |
-        choco install git -y --force
-
     - name: Build
       shell: bash
       run: |

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -157,7 +157,6 @@ jobs:
  odbc-win-64:
     name: ODBC Windows
     runs-on: windows-latest
-    needs: win-release-64
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -157,6 +157,7 @@ jobs:
  odbc-win-64:
     name: ODBC Windows
     runs-on: windows-latest
+    needs: win-release-64
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
choco has been letting us down here with several CI failures - but it turns out this install is unnecessary to begin with.