### PR TITLE
[Python] Accept 'schema' in table reference

### DIFF
--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -282,7 +282,11 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::Table(const string &tname) {
 	if (!connection) {
 		throw ConnectionException("Connection has already been closed");
 	}
-	return make_unique<DuckDBPyRelation>(connection->Table(tname));
+	auto qualified_name = QualifiedName::Parse(tname);
+	if (qualified_name.schema.empty()) {
+		qualified_name.schema = DEFAULT_SCHEMA;
+	}
+	return make_unique<DuckDBPyRelation>(connection->Table(qualified_name.schema, qualified_name.name));
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyConnection::Values(py::object params) {

--- a/tools/pythonpkg/tests/fast/relational_api/test_rapi_query.py
+++ b/tools/pythonpkg/tests/fast/relational_api/test_rapi_query.py
@@ -42,6 +42,14 @@ class TestRAPIQuery(object):
         result = rel.execute()
         assert(result.fetchall() == [(5,)])
 
+    def test_query_table_qualified(self):
+        con = duckdb.default_connection
+        con.execute("create schema fff")
+
+        # Create table in fff schema
+        con.execute("create table fff.t2 as select 1 as t")
+        assert(con.table("fff.t2").fetchall() == [(1,)])
+
     def test_query_insert_into_relation(self, tbl_table):
         con = duckdb.default_connection
         rel = con.query("select i from range(1000) tbl(i)")


### PR DESCRIPTION
This PR fixes #5038

We were not separating the schema from the table, and then calling a method that always uses the DEFAULT_SCHEMA.
Which caused `con.table('fff.t2')` to look for `main.fff.t2`