### PR TITLE
Fix levenshtein(s1, s2) for empty strings

### DIFF
--- a/src/function/scalar/string/levenshtein.cpp
+++ b/src/function/scalar/string/levenshtein.cpp
@@ -16,12 +16,11 @@ static idx_t LevenshteinDistance(const string_t &txt, const string_t &tgt) {
 	auto txt_len = txt.GetSize();
 	auto tgt_len = tgt.GetSize();
 
-	if (txt_len < 1) {
-		throw InvalidInputException("Levenshtein Function: 1st argument too short");
-	}
-
-	if (tgt_len < 1) {
-		throw InvalidInputException("Levenshtein Function: 2nd argument too short");
+	// If one string is empty, the distance equals the length of the other string
+	if (txt_len == 0) {
+		return tgt_len;
+	} else if (tgt_len == 0) {
+		return txt_len;
 	}
 
 	auto txt_str = txt.GetDataUnsafe();

--- a/test/sql/function/string/test_levenshtein.test
+++ b/test/sql/function/string/test_levenshtein.test
@@ -67,23 +67,30 @@ SELECT levenshtein(NULL, NULL)
 ----
 NULL
 
-statement ok
-SELECT mismatches('', NULL) 
+query I
+SELECT levenshtein('', NULL)
+----
+NULL
 
-statement ok
-SELECT mismatches(NULL, '') 
+query I
+SELECT levenshtein(NULL, '')
+----
+NULL
 
+query I
+SELECT levenshtein('', 'hi')
+----
+2
 
-# incorrect usage
-statement error
-SELECT mismatches('', 'hi') 
+query I
+SELECT levenshtein('hi', '')
+----
+2
 
-statement error
-SELECT mismatches('hi', '') 
-
-statement error
-SELECT mismatches('', '') 
-
+query I
+SELECT levenshtein('', '')
+----
+0
 
 
 statement ok
@@ -113,7 +120,7 @@ SELECT levenshtein('hallo', s) FROM strings ORDER BY s
 1
 
 query I
-SELECT levenshtein(NULL, s) FROM strings 
+SELECT levenshtein(NULL, s) FROM strings
 ----
 NULL
 NULL
@@ -123,7 +130,7 @@ NULL
 NULL
 
 query I
-SELECT levenshtein(NULL, s) FROM strings 
+SELECT levenshtein(NULL, s) FROM strings
 ----
 NULL
 NULL
@@ -132,11 +139,25 @@ NULL
 NULL
 NULL
 
-statement error
-SELECT mismatches('', s) FROM strings
+query I
+SELECT levenshtein('', s) FROM strings ORDER BY s
+----
+5
+5
+5
+6
+5
+5
 
-statement error
-SELECT mismatches(s, '')  FROM strings
+query I
+SELECT levenshtein(s, '') FROM strings ORDER BY s
+----
+5
+5
+5
+6
+5
+5
 
 
 statement ok
@@ -169,12 +190,12 @@ SELECT levenshtein(s, 'hi') from strings
 NULL
 
 query I
-SELECT mismatches('', s)  FROM strings
+SELECT levenshtein('', s)  FROM strings
 ----
 NULL
 
 query I
-SELECT mismatches(s, '')  FROM strings
+SELECT levenshtein(s, '')  FROM strings
 ----
 NULL
 
@@ -189,27 +210,34 @@ statement ok
 INSERT INTO strings VALUES ('')
 
 query I
-SELECT mismatches(NULL, s)  FROM strings
+SELECT levenshtein(NULL, s)  FROM strings
 ----
 NULL
 
 query I
-SELECT mismatches(s, NULL)  FROM strings
+SELECT levenshtein(s, NULL)  FROM strings
 ----
 NULL
 
-statement error
-SELECT mismatches(s, '')  FROM strings
+query I
+SELECT levenshtein(s, '')  FROM strings
+----
+0
 
-statement error
-SELECT mismatches('', s)  FROM strings
+query I
+SELECT levenshtein('', s)  FROM strings
+----
+0
 
-statement error
-SELECT mismatches(s, 'hi')  FROM strings
+query I
+SELECT levenshtein(s, 'hi')  FROM strings
+----
+2
 
-statement error
-SELECT mismatches('hi', s)  FROM strings
-
+query I
+SELECT levenshtein('hi', s)  FROM strings
+----
+2
 
 
 # editdist3
@@ -218,9 +246,10 @@ SELECT editdist3('hallo', 'hello')
 ----
 1
 
-statement error
+query I
 SELECT editdist3(s, 'hello') FROM strings
-
+----
+5
 
 # Comparing fields from two columns row wise
 
@@ -232,15 +261,15 @@ CREATE TABLE strings(s VARCHAR, t VARCHAR)
 
 statement ok
 INSERT INTO strings VALUES 	('hello', 'hello'), ('hello', 'hallo'), ('flaw', 'lawn'),
-							('sitting', 'kitten'), ('hallo', 'aloha'), ('hello', 'aloha'), 
-							(NULL, NULL), ('', ''), 
-							(NULL, 'bora'), ('bora', NULL), 
-							('hi', ''), ('', 'hi'), 
+							('sitting', 'kitten'), ('hallo', 'aloha'), ('hello', 'aloha'),
+							(NULL, NULL), ('', ''),
+							(NULL, 'bora'), ('bora', NULL),
+							('hi', ''), ('', 'hi'),
 							(NULL, ''), ('', NULL)
 
 
 query I
-SELECT levenshtein(s, t) ld FROM strings WHERE length(s) > 1 AND length(t) > 0 AND s is not NULL and t is not NULL
+SELECT levenshtein(s, t) ld FROM strings
 ----
 0
 1
@@ -248,26 +277,11 @@ SELECT levenshtein(s, t) ld FROM strings WHERE length(s) > 1 AND length(t) > 0 A
 3
 4
 5
-
-# NULL inserts result in empty string
-
-statement error
-SELECT levenshtein(s, t)  FROM strings
-
-statement error
-SELECT s, t, levenshtein(s, t) ld FROM strings WHERE length(s) > 1 AND s is not NULL and t is not NULL
-
-statement error
-SELECT levenshtein(s, t)  FROM strings WHERE length(s) < 1
-
-statement error
-SELECT levenshtein(t, s)  FROM strings WHERE length(s) < 1
-
-statement error
-SELECT levenshtein(s, t)  FROM strings WHERE length(t) < 1
-
-statement error
-SELECT levenshtein(t, s)  FROM strings WHERE length(t) < 1
-
-statement error
-SELECT levenshtein(s, t)  FROM strings WHERE rowid > 5
+NULL
+0
+NULL
+NULL
+2
+2
+NULL
+NULL


### PR DESCRIPTION
As explained in [this discussion](https://github.com/duckdb/duckdb/discussions/5061), the function `levenshtein(s1, s2)` should return the proper value when `s1` or `s2` are empty strings (i.e., the length of the other string), however it currently throws an exception.

I also updated the corresponding test case (which contained some leftover checks from the `mismatches()` function test case).
