### PR TITLE
make wal impl more reusable

### DIFF
--- a/src/include/duckdb/storage/write_ahead_log.hpp
+++ b/src/include/duckdb/storage/write_ahead_log.hpp
@@ -34,6 +34,54 @@ class TableCatalogEntry;
 class Transaction;
 class TransactionManager;
 
+class ReplayState {
+public:
+	ReplayState(DatabaseInstance &db, ClientContext &context, Deserializer &source)
+	    : db(db), context(context), source(source), current_table(nullptr), deserialize_only(false),
+	      checkpoint_id(INVALID_BLOCK) {
+	}
+
+	DatabaseInstance &db;
+	ClientContext &context;
+	Deserializer &source;
+	TableCatalogEntry *current_table;
+	bool deserialize_only;
+	block_id_t checkpoint_id;
+
+public:
+	void ReplayEntry(WALType entry_type);
+
+protected:
+	virtual void ReplayCreateTable();
+	void ReplayDropTable();
+	void ReplayAlter();
+
+	void ReplayCreateView();
+	void ReplayDropView();
+
+	void ReplayCreateSchema();
+	void ReplayDropSchema();
+
+	void ReplayCreateType();
+	void ReplayDropType();
+
+	void ReplayCreateSequence();
+	void ReplayDropSequence();
+	void ReplaySequenceValue();
+
+	void ReplayCreateMacro();
+	void ReplayDropMacro();
+
+	void ReplayCreateTableMacro();
+	void ReplayDropTableMacro();
+
+	void ReplayUseTable();
+	void ReplayInsert();
+	void ReplayDelete();
+	void ReplayUpdate();
+	void ReplayCheckpoint();
+};
+
 //! The WriteAheadLog (WAL) is a log that is used to provide durability. Prior
 //! to committing a transaction it writes the changes the transaction made to
 //! the database to the log, which can then be replayed upon startup in case the

--- a/src/include/duckdb/transaction/transaction_manager.hpp
+++ b/src/include/duckdb/transaction/transaction_manager.hpp
@@ -61,6 +61,11 @@ public:
 	static TransactionManager &Get(ClientContext &context);
 	static TransactionManager &Get(DatabaseInstance &db);
 
+	void SetBaseCommitId(transaction_t base) {
+		D_ASSERT(base >= TRANSACTION_ID_START);
+		current_transaction_id = base;
+	}
+
 private:
 	bool CanCheckpoint(Transaction *current = nullptr);
 	//! Remove the given transaction from the list of active transactions

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -20,54 +20,6 @@
 
 namespace duckdb {
 
-class ReplayState {
-public:
-	ReplayState(DatabaseInstance &db, ClientContext &context, Deserializer &source)
-	    : db(db), context(context), source(source), current_table(nullptr), deserialize_only(false),
-	      checkpoint_id(INVALID_BLOCK) {
-	}
-
-	DatabaseInstance &db;
-	ClientContext &context;
-	Deserializer &source;
-	TableCatalogEntry *current_table;
-	bool deserialize_only;
-	block_id_t checkpoint_id;
-
-public:
-	void ReplayEntry(WALType entry_type);
-
-private:
-	void ReplayCreateTable();
-	void ReplayDropTable();
-	void ReplayAlter();
-
-	void ReplayCreateView();
-	void ReplayDropView();
-
-	void ReplayCreateSchema();
-	void ReplayDropSchema();
-
-	void ReplayCreateType();
-	void ReplayDropType();
-
-	void ReplayCreateSequence();
-	void ReplayDropSequence();
-	void ReplaySequenceValue();
-
-	void ReplayCreateMacro();
-	void ReplayDropMacro();
-
-	void ReplayCreateTableMacro();
-	void ReplayDropTableMacro();
-
-	void ReplayUseTable();
-	void ReplayInsert();
-	void ReplayDelete();
-	void ReplayUpdate();
-	void ReplayCheckpoint();
-};
-
 bool WriteAheadLog::Replay(DatabaseInstance &database, string &path) {
 	auto initial_reader = make_unique<BufferedFileReader>(database.GetFileSystem(), path.c_str());
 	if (initial_reader->Finished()) {
@@ -222,7 +174,6 @@ void ReplayState::ReplayEntry(WALType entry_type) {
 	case WALType::DROP_TYPE:
 		ReplayDropType();
 		break;
-
 	default:
 		throw InternalException("Invalid WAL entry type!");
 	}


### PR DESCRIPTION
Very simple change. Move some definitions around so that a custom storage engine can more easily reuse bits of the existing WAL logging/replay functionality. Related, enable WAL replay to reset the TM's base transaction ID.