### PR TITLE
Fix for #4935: throw internal error if there is no node

### DIFF
--- a/src/optimizer/join_order_optimizer.cpp
+++ b/src/optimizer/join_order_optimizer.cpp
@@ -990,7 +990,6 @@ unique_ptr<LogicalOperator> JoinOrderOptimizer::Optimize(unique_ptr<LogicalOpera
 	for (idx_t i = 0; i < relations.size(); i++) {
 		bindings.insert(i);
 	}
-
 	auto total_relation = set_manager.GetJoinRelation(bindings);
 	auto final_plan = plans.find(total_relation);
 	if (final_plan == plans.end()) {

--- a/src/optimizer/join_order_optimizer.cpp
+++ b/src/optimizer/join_order_optimizer.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/planner/operator/list.hpp"
 
 #include <algorithm>
+#include <iostream>
 
 namespace std {
 
@@ -301,6 +302,10 @@ JoinNode *JoinOrderOptimizer::EmitPair(JoinRelationSet *left, JoinRelationSet *r
 	auto new_plan = CreateJoinTree(new_set, info, left_plan.get(), right_plan.get());
 	// check if this plan is the optimal plan we found for this set of relations
 	auto entry = plans.find(new_set);
+	if (entry != plans.end() && entry->second == nullptr) {
+		entry = plans.end();
+	}
+
 	if (entry == plans.end() || new_plan->GetCost() < entry->second->GetCost()) {
 		// the plan is the optimal plan, move it into the dynamic programming tree
 		auto result = new_plan.get();
@@ -332,6 +337,7 @@ JoinNode *JoinOrderOptimizer::EmitPair(JoinRelationSet *left, JoinRelationSet *r
 		plans[new_set] = move(new_plan);
 		return result;
 	}
+
 	return entry->second.get();
 }
 
@@ -561,10 +567,11 @@ void JoinOrderOptimizer::UpdateDPTree(JoinNode *new_plan) {
 		auto connections = query_graph.GetConnections(new_set, neighbor_relation);
 		// recurse and update up the tree if the combined set produces a plan with a lower cost
 		// only recurse on neighbor relations that have plans.
-		auto &right_plan = plans[neighbor_relation];
-		if (!right_plan) {
+		auto right_plan = plans.find(neighbor_relation);
+		if (right_plan == plans.end()) {
 			continue;
 		}
+
 		auto updated_plan = EmitPair(new_set, neighbor_relation, connections);
 		// <= because the child node has already been replaced. You need to
 		// replace the parent node as well in this case
@@ -597,7 +604,6 @@ void JoinOrderOptimizer::SolveJoinOrderApproximately() {
 				if (!connection.empty()) {
 					// we can check the cost of this connection
 					auto node = EmitPair(left, right, connection);
-
 					// update the DP tree in case a plan created by the DP algorithm uses the node
 					// that was potentially just updated by EmitPair. You will get a use-after-free
 					// error if future plans rely on the old node that was just replaced.
@@ -877,6 +883,7 @@ unique_ptr<LogicalOperator> JoinOrderOptimizer::RewritePlan(unique_ptr<LogicalOp
 	return plan;
 }
 
+
 // the join ordering is pretty much a straight implementation of the paper "Dynamic Programming Strikes Back" by Guido
 // Moerkotte and Thomas Neumannn, see that paper for additional info/documentation bonus slides:
 // https://db.in.tum.de/teaching/ws1415/queryopt/chapter3.pdf?lang=de
@@ -984,12 +991,12 @@ unique_ptr<LogicalOperator> JoinOrderOptimizer::Optimize(unique_ptr<LogicalOpera
 	}
 	// now we perform the actual dynamic programming to compute the final result
 	SolveJoinOrder();
-	// now the optimal join path should have been found
 	// get it from the node
 	unordered_set<idx_t> bindings;
 	for (idx_t i = 0; i < relations.size(); i++) {
 		bindings.insert(i);
 	}
+
 	auto total_relation = set_manager.GetJoinRelation(bindings);
 	auto final_plan = plans.find(total_relation);
 	if (final_plan == plans.end()) {

--- a/test/issues/general/test_4935.test
+++ b/test/issues/general/test_4935.test
@@ -17,4 +17,3 @@ FROM t1 AS v1, t1 AS v2, t1 AS v3, t1 AS v4, t1 AS v5, t1 AS v6, t1 AS v7, t1 AS
 WHERE
 f1.x = v1.a AND f1.y = v3 AND f1.z = v4 AND f1.w = v5 AND
 f2.x = v2.a AND f2.y = v6 AND f2.z = v7 AND f2.w = v8;
-

--- a/test/issues/general/test_4935.test
+++ b/test/issues/general/test_4935.test
@@ -4,8 +4,6 @@
 statement ok
 pragma enable_verification
 
-mode skip
-
 statement ok
 CREATE TABLE t1(a int);
 
@@ -19,3 +17,4 @@ FROM t1 AS v1, t1 AS v2, t1 AS v3, t1 AS v4, t1 AS v5, t1 AS v6, t1 AS v7, t1 AS
 WHERE
 f1.x = v1.a AND f1.y = v3 AND f1.z = v4 AND f1.w = v5 AND
 f2.x = v2.a AND f2.y = v6 AND f2.z = v7 AND f2.w = v8;
+


### PR DESCRIPTION
Apologies for taking so long to fix this, was enjoying some vacation 😅.

Fix for issue https://github.com/duckdb/duckdb/issues/4935. I was using incorrect syntax when attempting to find nodes in the DP table. This lead to an entry being created, but with no actual plan for the value, hence the nullptr errors and so on.

Using the correct syntax prevents this problem. Let me know if the exceptions should also be taken out, but I think to avoid segfaulting they should be left in.
 
