### PR TITLE
Correctly scan unaligned row groups in DataTable::ScanTableSegment

### DIFF
--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -568,14 +568,22 @@ void DataTable::ScanTableSegment(idx_t row_start, idx_t count, const std::functi
 			break;
 		}
 		idx_t end_row = current_row + chunk.size();
+		// start of chunk is current_row
+		// end of chunk is end_row
 		// figure out if we need to write the entire chunk or just part of it
 		idx_t chunk_start = MaxValue<idx_t>(current_row, row_start);
 		idx_t chunk_end = MinValue<idx_t>(end_row, end);
 		D_ASSERT(chunk_start < chunk_end);
 		idx_t chunk_count = chunk_end - chunk_start;
 		if (chunk_count != chunk.size()) {
+			D_ASSERT(chunk_count <= chunk.size());
 			// need to slice the chunk before insert
-			auto start_in_chunk = chunk_start % STANDARD_VECTOR_SIZE;
+			idx_t start_in_chunk;
+			if (current_row >= row_start) {
+				start_in_chunk = 0;
+			} else {
+				start_in_chunk = row_start - current_row;
+			}
 			SelectionVector sel(start_in_chunk, chunk_count);
 			chunk.Slice(sel, chunk_count);
 			chunk.Verify();

--- a/test/sql/storage/wal/wal_unaligned_row_groups.test_slow
+++ b/test/sql/storage/wal/wal_unaligned_row_groups.test_slow
@@ -1,0 +1,48 @@
+# name: test/sql/storage/wal/wal_unaligned_row_groups.test_slow
+# description: Test loading of unaligned row groups
+# group: [wal]
+
+# load the DB from disk
+load __TEST_DIR__/unaligned_row_groups.db
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+# create a table with a check constraint
+statement ok
+CREATE TABLE test(a VARCHAR);
+
+loop i 0 2
+
+statement ok
+INSERT INTO test SELECT concat('helloworldxxx', i) from range(150000) tbl(i);
+
+statement ok
+INSERT INTO test SELECT concat('helloworldxxx', i) from range(16534) tbl(i);
+
+statement ok
+INSERT INTO test SELECT concat('helloworldxxx', i) from range(999) tbl(i);
+
+statement ok
+INSERT INTO test SELECT concat('helloworldxxx', i) from range(31) tbl(i);
+
+statement ok
+INSERT INTO test SELECT concat('helloworldxxx', i) from range(34569) tbl(i);
+
+endloop
+
+query IIII
+SELECT MIN(a), MAX(a), COUNT(*), AVG(REPLACE(a, 'helloworldxxx', '')::INT) FROM test
+----
+helloworldxxx0	helloworldxxx99999	404266	59290.629798202174
+
+# reload the database
+restart
+
+query IIII
+SELECT MIN(a), MAX(a), COUNT(*), AVG(REPLACE(a, 'helloworldxxx', '')::INT) FROM test
+----
+helloworldxxx0	helloworldxxx99999	404266	59290.629798202174


### PR DESCRIPTION
Found by @szarnyasg 

With the recent changes to loading row groups are no longer guaranteed to be entirely filled, so we need to correctly take that into account in `DataTable::ScanTableSegment` instead of just being able to divide by the vector size.