### PR TITLE
[Python] Add MSVC `/utf-8` flag

### DIFF
--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -102,7 +102,7 @@ os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
 if os.name == 'nt':
     # windows:
-    toolchain_args = ['/wd4244', '/wd4267', '/wd4200', '/wd26451', '/wd26495', '/D_CRT_SECURE_NO_WARNINGS']
+    toolchain_args = ['/wd4244', '/wd4267', '/wd4200', '/wd26451', '/wd26495', '/D_CRT_SECURE_NO_WARNINGS', '/utf-8']
 else:
     # macos/linux
     toolchain_args = ['-std=c++11', '-g0']


### PR DESCRIPTION
The `/utf-8` flag for MSVC is set in [CMakeLists.txt](https://github.com/duckdb/duckdb/blob/d3db91ffbf9b8555d0d9b42087a6f05be04a41b9/CMakeLists.txt#L365), so we should add them to `setup.py`, too.