### PR TITLE
Convert values whose data types do not have explicit support in NodeJS into strings

### DIFF
--- a/tools/nodejs/src/statement.cpp
+++ b/tools/nodejs/src/statement.cpp
@@ -225,8 +225,7 @@ static Napi::Value convert_col_val(Napi::Env &env, duckdb::Value dval, duckdb::L
 		value = object_value;
 	} break;
 	default:
-		Napi::Error::New(env, "Data type is not supported " + dval.type().ToString()).ThrowAsJavaScriptException();
-		return env.Null();
+		value = Napi::String::New(env, dval.ToString());
 	}
 
 	return value;

--- a/tools/nodejs/test/data_type_support.test.js
+++ b/tools/nodejs/test/data_type_support.test.js
@@ -188,4 +188,10 @@ describe("data type support", function () {
       done();
     });
   });
+  it("converts unsupported data types to strings", function(done) {
+      db.all("SELECT CAST('11:10:10' AS TIME) as time", function(err, rows) {
+          assert.equal(rows[0].time, '11:10:10');
+          done();
+      });
+  });
 });


### PR DESCRIPTION
Fixes #5125

I thought it would be worthwhile to follow what the `node-postgres` project does and convert values for DuckDB data types that do not have corresponding support in Javascript into strings:

https://node-postgres.com/features/types

This PR changes the `default` behavior for type conversion from throwing an exception (that crashes the interpreter) to one where we return a string using `Value.ToString` and tests that this fixes the issue with returning `TIME` types from queries to NodeJS.
