### PR TITLE
buffermanager accounting

### DIFF
--- a/src/include/duckdb/common/file_buffer.hpp
+++ b/src/include/duckdb/common/file_buffer.hpp
@@ -52,11 +52,18 @@ public:
 
 	// Same rules as the constructor. We will add room for a header, in additio to
 	// the requested user bytes. We will then sector-align the result.
-	virtual void Resize(uint64_t user_size);
+	void Resize(uint64_t user_size);
 
 	uint64_t AllocSize() const {
 		return internal_size;
 	}
+
+	struct MemoryRequirement {
+		idx_t alloc_size;
+		idx_t header_size;
+	};
+
+	MemoryRequirement CalculateMemory(uint64_t user_size);
 
 protected:
 	//! The pointer to the internal buffer that will be read or written, including the buffer header

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -22,6 +22,34 @@ class FileBuffer;
 
 enum class BlockState : uint8_t { BLOCK_UNLOADED = 0, BLOCK_LOADED = 1 };
 
+struct BufferPoolReservation {
+	idx_t size {0};
+
+	BufferPoolReservation() {
+	}
+	BufferPoolReservation(const BufferPoolReservation &) = delete;
+	BufferPoolReservation &operator=(const BufferPoolReservation &) = delete;
+
+	BufferPoolReservation(BufferPoolReservation &&);
+	BufferPoolReservation &operator=(BufferPoolReservation &&);
+
+	~BufferPoolReservation();
+
+	void Resize(atomic<idx_t> &counter, idx_t new_size);
+	void Merge(BufferPoolReservation &&src);
+};
+
+struct TempBufferPoolReservation : BufferPoolReservation {
+	atomic<idx_t> &counter;
+	TempBufferPoolReservation(atomic<idx_t> &counter, idx_t size) : counter(counter) {
+		Resize(counter, size);
+	}
+	TempBufferPoolReservation(TempBufferPoolReservation &&) = default;
+	~TempBufferPoolReservation() {
+		Resize(counter, 0);
+	}
+};
+
 class BlockHandle {
 	friend class BlockManager;
 	friend struct BufferEvictionNode;
@@ -31,7 +59,7 @@ class BlockHandle {
 public:
 	BlockHandle(BlockManager &block_manager, block_id_t block_id);
 	BlockHandle(BlockManager &block_manager, block_id_t block_id, unique_ptr<FileBuffer> buffer, bool can_destroy,
-	            idx_t block_size);
+	            idx_t block_size, BufferPoolReservation &&reservation);
 	~BlockHandle();
 
 	BlockManager &block_manager;
@@ -73,8 +101,11 @@ private:
 	atomic<idx_t> eviction_timestamp;
 	//! Whether or not the buffer can be destroyed (only used for temporary buffers)
 	const bool can_destroy;
-	//! The memory usage of the block
+	//! The memory usage of the block (when loaded). If we are pinning/loading
+	//! an unloaded block, this tells us how much memory to reserve.
 	idx_t memory_usage;
+	//! Current memory reservation / usage
+	BufferPoolReservation memory_charge;
 	//! Does the block contain any memory pointers?
 	const char *unswizzled;
 };

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -30,8 +30,8 @@ struct BufferPoolReservation {
 	BufferPoolReservation(const BufferPoolReservation &) = delete;
 	BufferPoolReservation &operator=(const BufferPoolReservation &) = delete;
 
-	BufferPoolReservation(BufferPoolReservation &&);
-	BufferPoolReservation &operator=(BufferPoolReservation &&);
+	BufferPoolReservation(BufferPoolReservation &&) noexcept;
+	BufferPoolReservation &operator=(BufferPoolReservation &&) noexcept;
 
 	~BufferPoolReservation();
 

--- a/src/include/duckdb/storage/buffer_manager.hpp
+++ b/src/include/duckdb/storage/buffer_manager.hpp
@@ -95,8 +95,11 @@ private:
 	//! "buffer" will be made to point to the re-usable memory. Note that this is not guaranteed.
 	//! Returns a pair. result.first indicates if eviction was successful. result.second contains the
 	//! reservation handle, which can be moved to the BlockHandle that will own the reservation.
-	std::pair<bool, TempBufferPoolReservation> EvictBlocks(idx_t extra_memory, idx_t memory_limit,
-	                                                       unique_ptr<FileBuffer> *buffer = nullptr);
+	struct EvictionResult {
+		bool success;
+		TempBufferPoolReservation reservation;
+	};
+	EvictionResult EvictBlocks(idx_t extra_memory, idx_t memory_limit, unique_ptr<FileBuffer> *buffer = nullptr);
 
 	//! Helper
 	template <typename... ARGS>

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -9,12 +9,12 @@
 
 namespace duckdb {
 
-BufferPoolReservation::BufferPoolReservation(BufferPoolReservation &&src) {
+BufferPoolReservation::BufferPoolReservation(BufferPoolReservation &&src) noexcept {
 	size = src.size;
 	src.size = 0;
 }
 
-BufferPoolReservation &BufferPoolReservation::operator=(BufferPoolReservation &&src) {
+BufferPoolReservation &BufferPoolReservation::operator=(BufferPoolReservation &&src) noexcept {
 	size = src.size;
 	src.size = 0;
 	return *this;

--- a/test/sql/storage/test_buffer_manager.cpp
+++ b/test/sql/storage/test_buffer_manager.cpp
@@ -239,6 +239,10 @@ TEST_CASE("Test buffer reallocation", "[storage][.]") {
 	DeleteDatabase(storage_database);
 	DuckDB db(storage_database, config.get());
 
+	auto align = [](idx_t requested_size) {
+		return AlignValue<idx_t, Storage::SECTOR_SIZE>(requested_size);
+	};
+
 	// 1GB limit
 	Connection con(db);
 	const idx_t limit = 1000000000;
@@ -250,12 +254,11 @@ TEST_CASE("Test buffer reallocation", "[storage][.]") {
 	idx_t requested_size = Storage::BLOCK_SIZE;
 	auto block = buffer_manager.RegisterMemory(requested_size, false);
 	auto handle = buffer_manager.Pin(block);
-	D_ASSERT(buffer_manager.GetUsedMemory() == requested_size + Storage::BLOCK_HEADER_SIZE);
-
+	D_ASSERT(buffer_manager.GetUsedMemory() == align(requested_size + Storage::BLOCK_HEADER_SIZE));
 	for (; requested_size < limit; requested_size *= 2) {
 		// increase size
 		buffer_manager.ReAllocate(block, requested_size);
-		D_ASSERT(buffer_manager.GetUsedMemory() == requested_size + Storage::BLOCK_HEADER_SIZE);
+		D_ASSERT(buffer_manager.GetUsedMemory() == align(requested_size + Storage::BLOCK_HEADER_SIZE));
 		// unpin and make sure it's evicted
 		handle.Destroy();
 		REQUIRE_NO_FAIL(con.Query(StringUtil::Format("PRAGMA memory_limit='%lldB'", requested_size)));
@@ -263,13 +266,13 @@ TEST_CASE("Test buffer reallocation", "[storage][.]") {
 		// re-pin
 		REQUIRE_NO_FAIL(con.Query(StringUtil::Format("PRAGMA memory_limit='%lldB'", limit)));
 		handle = buffer_manager.Pin(block);
-		D_ASSERT(buffer_manager.GetUsedMemory() == requested_size + Storage::BLOCK_HEADER_SIZE);
+		D_ASSERT(buffer_manager.GetUsedMemory() == align(requested_size + Storage::BLOCK_HEADER_SIZE));
 	}
 	requested_size /= 2;
 	for (; requested_size > Storage::BLOCK_SIZE; requested_size /= 2) {
 		// decrease size
 		buffer_manager.ReAllocate(block, requested_size);
-		D_ASSERT(buffer_manager.GetUsedMemory() == requested_size + Storage::BLOCK_HEADER_SIZE);
+		D_ASSERT(buffer_manager.GetUsedMemory() == align(requested_size + Storage::BLOCK_HEADER_SIZE));
 		// unpin and make sure it's evicted
 		handle.Destroy();
 		REQUIRE_NO_FAIL(con.Query(StringUtil::Format("PRAGMA memory_limit='%lldB'", requested_size)));
@@ -277,6 +280,6 @@ TEST_CASE("Test buffer reallocation", "[storage][.]") {
 		// re-pin
 		REQUIRE_NO_FAIL(con.Query(StringUtil::Format("PRAGMA memory_limit='%lldB'", limit)));
 		handle = buffer_manager.Pin(block);
-		D_ASSERT(buffer_manager.GetUsedMemory() == requested_size + Storage::BLOCK_HEADER_SIZE);
+		D_ASSERT(buffer_manager.GetUsedMemory() == align(requested_size + Storage::BLOCK_HEADER_SIZE));
 	}
 }

--- a/test/sql/storage/test_buffer_manager.cpp
+++ b/test/sql/storage/test_buffer_manager.cpp
@@ -232,16 +232,18 @@ TEST_CASE("Modifying the buffer manager limit at runtime for an in-memory databa
 	REQUIRE_NO_FAIL(con.Query("PRAGMA memory_limit='1MB'"));
 }
 
-static idx_t AlignPage(idx_t requested_size) {
-	return AlignValue<idx_t, Storage::SECTOR_SIZE>(requested_size);
-}
-
 TEST_CASE("Test buffer reallocation", "[storage][.]") {
 	auto storage_database = TestCreatePath("storage_test");
 	auto config = GetTestConfig();
 	// make sure the database does not exist
 	DeleteDatabase(storage_database);
 	DuckDB db(storage_database, config.get());
+
+#if defined(DEBUG) || defined(DUCKDB_FORCE_ASSERT)
+	auto align = [](idx_t requested_size) {
+		return AlignValue<idx_t, Storage::SECTOR_SIZE>(requested_size);
+	};
+#endif
 
 	// 1GB limit
 	Connection con(db);
@@ -254,11 +256,11 @@ TEST_CASE("Test buffer reallocation", "[storage][.]") {
 	idx_t requested_size = Storage::BLOCK_SIZE;
 	auto block = buffer_manager.RegisterMemory(requested_size, false);
 	auto handle = buffer_manager.Pin(block);
-	D_ASSERT(buffer_manager.GetUsedMemory() == AlignPage(requested_size + Storage::BLOCK_HEADER_SIZE));
+	D_ASSERT(buffer_manager.GetUsedMemory() == align(requested_size + Storage::BLOCK_HEADER_SIZE));
 	for (; requested_size < limit; requested_size *= 2) {
 		// increase size
 		buffer_manager.ReAllocate(block, requested_size);
-		D_ASSERT(buffer_manager.GetUsedMemory() == AlignPage(requested_size + Storage::BLOCK_HEADER_SIZE));
+		D_ASSERT(buffer_manager.GetUsedMemory() == align(requested_size + Storage::BLOCK_HEADER_SIZE));
 		// unpin and make sure it's evicted
 		handle.Destroy();
 		REQUIRE_NO_FAIL(con.Query(StringUtil::Format("PRAGMA memory_limit='%lldB'", requested_size)));
@@ -266,13 +268,13 @@ TEST_CASE("Test buffer reallocation", "[storage][.]") {
 		// re-pin
 		REQUIRE_NO_FAIL(con.Query(StringUtil::Format("PRAGMA memory_limit='%lldB'", limit)));
 		handle = buffer_manager.Pin(block);
-		D_ASSERT(buffer_manager.GetUsedMemory() == AlignPage(requested_size + Storage::BLOCK_HEADER_SIZE));
+		D_ASSERT(buffer_manager.GetUsedMemory() == align(requested_size + Storage::BLOCK_HEADER_SIZE));
 	}
 	requested_size /= 2;
 	for (; requested_size > Storage::BLOCK_SIZE; requested_size /= 2) {
 		// decrease size
 		buffer_manager.ReAllocate(block, requested_size);
-		D_ASSERT(buffer_manager.GetUsedMemory() == AlignPage(requested_size + Storage::BLOCK_HEADER_SIZE));
+		D_ASSERT(buffer_manager.GetUsedMemory() == align(requested_size + Storage::BLOCK_HEADER_SIZE));
 		// unpin and make sure it's evicted
 		handle.Destroy();
 		REQUIRE_NO_FAIL(con.Query(StringUtil::Format("PRAGMA memory_limit='%lldB'", requested_size)));
@@ -280,6 +282,6 @@ TEST_CASE("Test buffer reallocation", "[storage][.]") {
 		// re-pin
 		REQUIRE_NO_FAIL(con.Query(StringUtil::Format("PRAGMA memory_limit='%lldB'", limit)));
 		handle = buffer_manager.Pin(block);
-		D_ASSERT(buffer_manager.GetUsedMemory() == AlignPage(requested_size + Storage::BLOCK_HEADER_SIZE));
+		D_ASSERT(buffer_manager.GetUsedMemory() == align(requested_size + Storage::BLOCK_HEADER_SIZE));
 	}
 }


### PR DESCRIPTION
Some refactoring of buffer management.

- Remove some asserts and add update BlockHandle::memory_usage in a few places, to account for variable-sized blocks.
- Introduce [Temp]BufferPoolReservation to make maintenance of BufferManager::current_memory less error-prone.
- Move size calculations out of FileBuffer::Resize to their own method.
- Extra asserts to ensure we aren't doing IO on tinybuffers
- Introduce EvictBlocksOrThrow, to replace the common pattern where the caller of EvictBlocks would throw manually.
- Greatly reduce frequency of calls to PurgeQueue. This method can be expensive, and needs only to be called very infrequently. We now call only on every 1024th invocation of AddToEvictionQueue.