### PR TITLE
R: Remove duckdb:: qualifier

### DIFF
--- a/tools/rpkg/R/backend-dbplyr__duckdb_connection.R
+++ b/tools/rpkg/R/backend-dbplyr__duckdb_connection.R
@@ -9,7 +9,7 @@
 #' @aliases NULL
 #' @examples
 #' library(dplyr, warn.conflicts = FALSE)
-#' con <- DBI::dbConnect(duckdb::duckdb(), path = ":memory:")
+#' con <- DBI::dbConnect(duckdb(), path = ":memory:")
 #'
 #' dbiris <- copy_to(con, iris, overwrite = TRUE)
 #'

--- a/tools/rpkg/R/dbFetch__duckdb_result.R
+++ b/tools/rpkg/R/dbFetch__duckdb_result.R
@@ -11,7 +11,7 @@ dbFetch__duckdb_result <- function(res, n = -1, ...) {
     if (n != -1) {
       stop("Cannot dbFetch() an Arrow result unless n = -1")
     }
-    return(as.data.frame(duckdb::duckdb_fetch_arrow(res)))
+    return(as.data.frame(duckdb_fetch_arrow(res)))
   }
 
   if (is.null(res@env$resultset)) {

--- a/tools/rpkg/R/relational.R
+++ b/tools/rpkg/R/relational.R
@@ -54,7 +54,7 @@ expr_set_alias <- rapi_expr_set_alias
 
 #' @export
 print.duckdb_expr <- function(x, ...) {
-    message("DuckDB Expression: ", duckdb::expr_tostring(x))
+    message("DuckDB Expression: ", expr_tostring(x))
     invisible(NULL)
 }
 
@@ -66,7 +66,7 @@ print.duckdb_expr <- function(x, ...) {
 #' @return the `duckdb_relation` object wrapping the data.frame
 #' @export
 #' @examples
-#' con <- DBI::dbConnect(duckdb::duckdb())
+#' con <- DBI::dbConnect(duckdb())
 #' rel <- rel_from_df(con, mtcars)
 rel_from_df <- function(con, df) {
     rapi_rel_from_df(con@conn_ref, as.data.frame(df))

--- a/tools/rpkg/man/backend-duckdb.Rd
+++ b/tools/rpkg/man/backend-duckdb.Rd
@@ -19,7 +19,7 @@ contains more mapped functions.
 }
 \examples{
 library(dplyr, warn.conflicts = FALSE)
-con <- DBI::dbConnect(duckdb::duckdb(), path = ":memory:")
+con <- DBI::dbConnect(duckdb(), path = ":memory:")
 
 dbiris <- copy_to(con, iris, overwrite = TRUE)
 

--- a/tools/rpkg/man/rel_from_df.Rd
+++ b/tools/rpkg/man/rel_from_df.Rd
@@ -18,6 +18,6 @@ the \code{duckdb_relation} object wrapping the data.frame
 Convert a R data.frame to a DuckDB relation object
 }
 \examples{
-con <- DBI::dbConnect(duckdb::duckdb())
+con <- DBI::dbConnect(duckdb())
 rel <- rel_from_df(con, mtcars)
 }

--- a/tools/rpkg/tests/regression/perf_regression.R
+++ b/tools/rpkg/tests/regression/perf_regression.R
@@ -27,7 +27,7 @@ res <- bench_mark(
   reps = 50,
   grid = list(nrow = c(1e3, 1e5, 1e7)),
   setup = {
-    con <- dbConnect(duckdb::duckdb(), dbdir = ":memory:")
+    con <- dbConnect(duckdb(), dbdir = ":memory:")
     dat <- setup_data(nrow)
     arw <- InMemoryDataset$create(dat)
 

--- a/tools/rpkg/tests/testthat/helper-DBItest.R
+++ b/tools/rpkg/tests/testthat/helper-DBItest.R
@@ -1,5 +1,5 @@
-drv <- duckdb::duckdb()
-reg.finalizer(drv@database_ref, function(x) duckdb:::rapi_shutdown(x))
+drv <- duckdb()
+reg.finalizer(drv@database_ref, function(x) rapi_shutdown(x))
 
 # remotes::install_github("r-dbi/dblog")
 # Then, use DBItest::test_some() to see the DBI calls emitted by the tests

--- a/tools/rpkg/tests/testthat/test_arrow.R
+++ b/tools/rpkg/tests/testthat/test_arrow.R
@@ -40,7 +40,7 @@ example_data <- dplyr::tibble(
 
 test_that("to_duckdb", {
   ds <- InMemoryDataset$create(example_data)
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   dbExecute(con, "PRAGMA threads=1")
@@ -200,7 +200,7 @@ test_that("to_arrow roundtrip, with dataset", {
 # persistence and querying against the table without using the `tbl` itself, so
 # we need to create a connection separate from the ephemeral one that is made
 # with arrow_duck_connection()
-con <- dbConnect(duckdb::duckdb())
+con <- dbConnect(duckdb())
 dbExecute(con, "PRAGMA threads=1")
 on.exit(dbDisconnect(con, shutdown = TRUE), add = TRUE)
 
@@ -223,10 +223,10 @@ test_that("Joining, auto-cleanup enabled", {
   expect_identical(dim(res), c(9L, 14L))
 
   # clean up cleans up the tables
-  expect_true(all(c(table_one_name, table_two_name) %in% duckdb::duckdb_list_arrow(con)))
+  expect_true(all(c(table_one_name, table_two_name) %in% duckdb_list_arrow(con)))
   rm(table_one, table_two)
   gc()
-  expect_false(any(c(table_one_name,     table_two_name) %in% duckdb::duckdb_list_arrow(con)))
+  expect_false(any(c(table_one_name,     table_two_name) %in% duckdb_list_arrow(con)))
 })
 
 test_that("Joining, auto-cleanup disabled", {
@@ -236,11 +236,11 @@ test_that("Joining, auto-cleanup disabled", {
   table_three <- to_duckdb(ds, con = con, table_name = table_three_name, auto_disconnect = FALSE)
 
   # clean up does *not* clean these tables
-  expect_true(table_three_name %in% duckdb::duckdb_list_arrow(con))
+  expect_true(table_three_name %in% duckdb_list_arrow(con))
   rm(table_three)
   gc()
   # but because we aren't auto_disconnecting then we still have this table.
-  expect_true(table_three_name %in% duckdb::duckdb_list_arrow(con))
+  expect_true(table_three_name %in% duckdb_list_arrow(con))
 })
 
 test_that("to_duckdb with a table", {
@@ -266,7 +266,7 @@ test_that("to_duckdb with a table", {
 test_that("to_duckdb passing a connection", {
   ds <- InMemoryDataset$create(example_data)
 
-  con_separate <- dbConnect(duckdb::duckdb())
+  con_separate <- dbConnect(duckdb())
   # we always want to test in parallel
   dbExecute(con_separate, "PRAGMA threads=2")
   on.exit(dbDisconnect(con_separate, shutdown = TRUE), add = TRUE)

--- a/tools/rpkg/tests/testthat/test_backend-dbplyr__duckdb_connection.R
+++ b/tools/rpkg/tests/testthat/test_backend-dbplyr__duckdb_connection.R
@@ -7,7 +7,7 @@ skip_if_no_R4 <- function() {
 test_that("dbplyr generic scalars translated correctly", {
   skip_if_no_R4()
   skip_if_not_installed("dbplyr")
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
   translate <- function(...) dbplyr::translate_sql(..., con = con)
   sql <- function(...) dbplyr::sql(...)
@@ -34,7 +34,7 @@ test_that("dbplyr generic scalars translated correctly", {
 test_that("duckdb custom scalars translated correctly", {
   skip_if_no_R4()
   skip_if_not_installed("dbplyr")
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
   translate <- function(...) dbplyr::translate_sql(..., con = con)
   sql <- function(...) dbplyr::sql(...)
@@ -73,7 +73,7 @@ test_that("duckdb custom scalars translated correctly", {
 test_that("pasting translated correctly", {
   skip_if_no_R4()
   skip_if_not_installed("dbplyr")
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
   translate <- function(...) dbplyr::translate_sql(..., con = con)
   sql <- function(...) dbplyr::sql(...)
@@ -94,7 +94,7 @@ test_that("pasting translated correctly", {
 test_that("custom lubridate functions translated correctly", {
   skip_if_no_R4()
   skip_if_not_installed("dbplyr")
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
   translate <- function(...) dbplyr::translate_sql(..., con = con)
   sql <- function(...) dbplyr::sql(...)
@@ -136,7 +136,7 @@ test_that("custom lubridate functions translated correctly", {
 test_that("custom stringr functions translated correctly", {
   skip_if_no_R4()
   skip_if_not_installed("dbplyr")
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
   translate <- function(...) dbplyr::translate_sql(..., con = con)
   sql <- function(...) dbplyr::sql(...)
@@ -162,7 +162,7 @@ test_that("custom stringr functions translated correctly", {
 test_that("datetime escaping working as in DBI", {
   skip_if_no_R4()
   skip_if_not_installed("dbplyr")
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
   escape <- function(...) dbplyr::escape(..., con = con)
   sql <- function(...) dbplyr::sql(...)
@@ -183,7 +183,7 @@ test_that("datetime escaping working as in DBI", {
 test_that("two variable aggregates are translated correctly", {
   skip_if_no_R4()
   skip_if_not_installed("dbplyr")
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
   translate <- function(...) dbplyr::translate_sql(..., con = con)
   sql <- function(...) dbplyr::sql(...)
@@ -200,7 +200,7 @@ test_that("two variable aggregates are translated correctly", {
 test_that("snapshots of dbplyr generic scalar translation", {
   skip_on_cran()
   skip_if_not_installed("dbplyr")
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
   local_edition(3)
   translate <- function(...) dbplyr::translate_sql(..., con = con)
@@ -230,7 +230,7 @@ test_that("snapshots of dbplyr generic scalar translation", {
 test_that("snapshots of duckdb custom scalars translations", {
   skip_on_cran()
   skip_if_not_installed("dbplyr")
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
   local_edition(3)
   translate <- function(...) dbplyr::translate_sql(..., con = con)
@@ -271,7 +271,7 @@ test_that("snapshots of duckdb custom scalars translations", {
 test_that("snapshot tests for pasting translate", {
   skip_on_cran()
   skip_if_not_installed("dbplyr")
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
   local_edition(3)
   translate <- function(...) dbplyr::translate_sql(..., con = con)
@@ -294,7 +294,7 @@ test_that("snapshot tests for pasting translate", {
 test_that("snapshots for custom lubridate functions translated correctly", {
   skip_on_cran()
   skip_if_not_installed("dbplyr")
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
   local_edition(3)
   translate <- function(...) dbplyr::translate_sql(..., con = con)
@@ -338,7 +338,7 @@ test_that("snapshots for custom lubridate functions translated correctly", {
 test_that("snapshots for custom stringr functions translated correctly", {
   skip_on_cran()
   skip_if_not_installed("dbplyr")
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
   local_edition(3)
   translate <- function(...) dbplyr::translate_sql(..., con = con)
@@ -366,7 +366,7 @@ test_that("snapshots for custom stringr functions translated correctly", {
 test_that("snapshots datetime escaping working as in DBI", {
   skip_on_cran()
   skip_if_not_installed("dbplyr")
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
   local_edition(3)
   escape <- function(...) dbplyr::escape(..., con = con)
@@ -389,7 +389,7 @@ test_that("snapshots datetime escaping working as in DBI", {
 test_that("two variable aggregates are translated correctly", {
   skip_on_cran()
   skip_if_not_installed("dbplyr")
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
   local_edition(3)
   translate <- function(...) dbplyr::translate_sql(..., con = con)
@@ -403,7 +403,7 @@ test_that("two variable aggregates are translated correctly", {
 test_that("these should give errors", {
   skip_on_cran()
   skip_if_not_installed("dbplyr")
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
   local_edition(3)
   translate <- function(...) dbplyr::translate_sql(..., con = con)

--- a/tools/rpkg/tests/testthat/test_bind.R
+++ b/tools/rpkg/tests/testthat/test_bind.R
@@ -26,7 +26,7 @@ test_convert <- function(con, type, val) {
 }
 
 test_that("dbBind() works as expected for all types", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   test_convert(con, "BOOLEAN", TRUE)
@@ -48,7 +48,7 @@ test_that("dbBind() works as expected for all types", {
 })
 
 test_that("dbBind() is called from dbGetQuery and dbExecute", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   res <- dbGetQuery(con, "SELECT CAST (? AS INTEGER), CAST(? AS STRING)", params = list(42, "Hello"))
@@ -83,7 +83,7 @@ test_that("dbBind() is called from dbGetQuery and dbExecute", {
 })
 
 test_that("test blobs", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   res <- dbGetQuery(con, "SELECT BLOB 'hello'")
@@ -91,7 +91,7 @@ test_that("test blobs", {
 })
 
 test_that("various error cases for dbBind()", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   q <- dbSendQuery(con, "SELECT CAST (? AS INTEGER)")

--- a/tools/rpkg/tests/testthat/test_config_keyvalue.R
+++ b/tools/rpkg/tests/testthat/test_config_keyvalue.R
@@ -1,17 +1,17 @@
 test_that("configuration key value pairs work as expected", {
 
   # setting nothing or empty list should work
-  drv <- duckdb::duckdb()
-  duckdb::duckdb_shutdown(drv)
+  drv <- duckdb()
+  duckdb_shutdown(drv)
 
-  drv <- duckdb::duckdb(config = list())
-  duckdb::duckdb_shutdown(drv)
+  drv <- duckdb(config = list())
+  duckdb_shutdown(drv)
 
   # but we should throw an error on non-existent options
-  expect_error(duckdb::duckdb(config = list(a = "a")))
+  expect_error(duckdb(config = list(a = "a")))
 
   # but setting a legal option is fine
-  drv <- duckdb::duckdb(config = list("default_order" = "DESC"))
+  drv <- duckdb(config = list("default_order" = "DESC"))
 
   # the option actually does something
   con <- dbConnect(drv)
@@ -20,12 +20,12 @@ test_that("configuration key value pairs work as expected", {
   res <- dbGetQuery(con, "select i from a order by i")
   dbDisconnect(con)
   expect_equal(res$i, c(44, 42))
-  duckdb::duckdb_shutdown(drv)
+  duckdb_shutdown(drv)
 
   # setting a configuration option to a non-string is an error
-  expect_error(duckdb::duckdb(config = list("default_order" = 42)))
-  expect_error(duckdb::duckdb(config = list("default_order" = c("a", "b"))))
+  expect_error(duckdb(config = list("default_order" = 42)))
+  expect_error(duckdb(config = list("default_order" = c("a", "b"))))
 
   # setting a configuration option to an unrecognized value
-  expect_error(duckdb::duckdb(config = list("default_order" = "asdf")))
+  expect_error(duckdb(config = list("default_order" = "asdf")))
 })

--- a/tools/rpkg/tests/testthat/test_dbinfo.R
+++ b/tools/rpkg/tests/testthat/test_dbinfo.R
@@ -1,6 +1,6 @@
 test_that("dbGetInfo returns something meaningful", {
   dbdir <- tempfile()
-  drv <- duckdb::duckdb(dbdir)
+  drv <- duckdb(dbdir)
 
   info_drv <- dbGetInfo(drv)
   expect_equal(info_drv$dbname, dbdir)

--- a/tools/rpkg/tests/testthat/test_explain.R
+++ b/tools/rpkg/tests/testthat/test_explain.R
@@ -3,7 +3,7 @@ skip_on_os(c("windows"))
 local_edition(3)
 
 test_that("EXPLAIN gives reasonable output", {
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- DBI::dbConnect(duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
   expect_snapshot({
     DBI::dbGetQuery(con, "EXPLAIN SELECT 1;")
@@ -11,7 +11,7 @@ test_that("EXPLAIN gives reasonable output", {
 })
 
 test_that("EXPLAIN shows logical, optimized and physical plan", {
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- DBI::dbConnect(duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
   expect_snapshot({
     DBI::dbExecute(con, "PRAGMA explain_output='all';")
@@ -20,7 +20,7 @@ test_that("EXPLAIN shows logical, optimized and physical plan", {
 })
 
 test_that("EXPLAIN ANALYZE outputs query tree", {
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- DBI::dbConnect(duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
   rs <- DBI::dbGetQuery(con, "EXPLAIN ANALYZE SELECT 1;")
   expect_true(is(rs, c("duckdb_explain")))
@@ -29,7 +29,7 @@ test_that("EXPLAIN ANALYZE outputs query tree", {
 })
 
 test_that("zero length input is smoothly skipped", {
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- DBI::dbConnect(duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
   expect_snapshot({
     rs <- DBI::dbGetQuery(con, "SELECT 1;")
@@ -38,7 +38,7 @@ test_that("zero length input is smoothly skipped", {
 })
 
 test_that("wrong type of input forwards handling to the next method", {
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- DBI::dbConnect(duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
   expect_snapshot({
     rs <- DBI::dbGetQuery(con, "SELECT 1;")

--- a/tools/rpkg/tests/testthat/test_extensions.R
+++ b/tools/rpkg/tests/testthat/test_extensions.R
@@ -4,7 +4,7 @@ library("DBI")
 library("testthat")
 
 load_extension <- function(extension_name) {
-  con <- dbConnect(duckdb::duckdb(config=list("allow_unsigned_extensions"="true")))
+  con <- dbConnect(duckdb(config=list("allow_unsigned_extensions"="true")))
   matches <- list.files(pattern='*.duckdb_extension', recursive=FALSE, full.names=TRUE)
   matches <- c(matches, list.files(path='/tmp/duckdb_extensions', pattern='*.duckdb_extension', recursive=TRUE, full.names=TRUE))
   matches <- c(matches, list.files(path=system.file(package = 'duckdb'), pattern='*.duckdb_extension', recursive=TRUE, full.names=TRUE))

--- a/tools/rpkg/tests/testthat/test_factor.R
+++ b/tools/rpkg/tests/testthat/test_factor.R
@@ -1,5 +1,5 @@
 test_that("factors can be round tripped", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   df0 <- data.frame(
@@ -9,7 +9,7 @@ test_that("factors can be round tripped", {
     stringsAsFactors = FALSE
   )
 
-  duckdb::duckdb_register(con, "df0", df0)
+  duckdb_register(con, "df0", df0)
   df1 <- dbReadTable(con, "df0")
   expect_equal(df0, df1)
 
@@ -20,10 +20,10 @@ test_that("factors can be round tripped", {
 
 
 test_that("iris can be round-tripped", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
-  duckdb::duckdb_register(con, "iris", iris)
+  duckdb_register(con, "iris", iris)
   df1 <- dbReadTable(con, "iris")
   expect_identical(iris, df1)
 
@@ -33,7 +33,7 @@ test_that("iris can be round-tripped", {
 })
 
 test_that("non-utf things can be read", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   horrid_string <- iconv("Mühleisen", "utf8", "latin1")
@@ -43,7 +43,7 @@ test_that("non-utf things can be read", {
   df <- data.frame(a = factor(horrid_string), b = horrid_string, stringsAsFactors = FALSE)
   names(df) <- c(horrid_string, "less_horrid")
 
-  duckdb::duckdb_register(con, "df", df)
+  duckdb_register(con, "df", df)
   df1 <- dbReadTable(con, "df")
 
   dbWriteTable(con, "df2", df)
@@ -60,7 +60,7 @@ test_that("non-utf things can be read", {
 
 
 test_that("single value factors round trip correctly, issue 2627", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   df1 <- data.frame(year = as.factor(rep("1998", 5)))
@@ -72,7 +72,7 @@ test_that("single value factors round trip correctly, issue 2627", {
 
 
 test_that("huge-cardinality factors do not cause strange crashes, issue 3639", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   set.seed(123)

--- a/tools/rpkg/tests/testthat/test_fetch_arrow.R
+++ b/tools/rpkg/tests/testthat/test_fetch_arrow.R
@@ -5,50 +5,50 @@ skip_if_not_installed("arrow", "5.0.0")
 skip_if_not(arrow::arrow_with_parquet(), message = "The installed Arrow is not fully featured, skipping Arrow integration tests")
 
 test_that("duckdb_fetch_arrow() test table over vector size", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   dbExecute(con, paste0("CREATE table test as select range a from range(10000);"))
   dbExecute(con, "INSERT INTO  test VALUES(NULL);")
-  arrow_table <- duckdb::duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE))
-  duckdb::duckdb_register_arrow(con, "testarrow", arrow_table)
+  arrow_table <- duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE))
+  duckdb_register_arrow(con, "testarrow", arrow_table)
 
   expect_equal(dbGetQuery(con, "SELECT * from testarrow"), dbGetQuery(con, "SELECT * from test"))
 
-  duckdb::duckdb_unregister_arrow(con, "testarrow")
+  duckdb_unregister_arrow(con, "testarrow")
 })
 
 test_that("duckdb_fetch_arrow() empty table", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   dbExecute(con, paste0("CREATE TABLE test (a  INTEGER)"))
 
-  arrow_table <- duckdb::duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE))
-  duckdb::duckdb_register_arrow(con, "testarrow", arrow_table)
+  arrow_table <- duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE))
+  duckdb_register_arrow(con, "testarrow", arrow_table)
 
   expect_equal(dbGetQuery(con, "SELECT * from testarrow"), dbGetQuery(con, "SELECT * from test"))
 
-  duckdb::duckdb_unregister_arrow(con, "testarrow")
+  duckdb_unregister_arrow(con, "testarrow")
 })
 
 test_that("duckdb_fetch_arrow() table with only nulls", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   dbExecute(con, paste0("CREATE TABLE test (a  INTEGER)"))
 
   dbExecute(con, "INSERT INTO  test VALUES(NULL);")
-  arrow_table <- duckdb::duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE))
-  duckdb::duckdb_register_arrow(con, "testarrow", arrow_table)
+  arrow_table <- duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE))
+  duckdb_register_arrow(con, "testarrow", arrow_table)
 
   expect_equal(dbGetQuery(con, "SELECT * from testarrow"), dbGetQuery(con, "SELECT * from test"))
 
-  duckdb::duckdb_unregister_arrow(con, "testarrow")
+  duckdb_unregister_arrow(con, "testarrow")
 })
 
 test_that("duckdb_fetch_arrow() table with prepared statement", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   dbExecute(con, paste0("CREATE TABLE test (a  INTEGER)"))
@@ -56,23 +56,23 @@ test_that("duckdb_fetch_arrow() table with prepared statement", {
   for (value in 1:1500) {
     dbExecute(con, sprintf("EXECUTE s1 (%d, %d);", value, value * 2))
   }
-  arrow_table <- duckdb::duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE))
-  duckdb::duckdb_register_arrow(con, "testarrow", arrow_table)
+  arrow_table <- duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE))
+  duckdb_register_arrow(con, "testarrow", arrow_table)
 
   expect_equal(dbGetQuery(con, "SELECT * from testarrow"), dbGetQuery(con, "SELECT * from test"))
 
-  duckdb::duckdb_unregister_arrow(con, "testarrow")
+  duckdb_unregister_arrow(con, "testarrow")
 })
 
 
 test_that("duckdb_fetch_arrow() record_batch_reader ", {
   skip_if_not_installed("arrow", "4.0.1")
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   dbExecute(con, paste0("CREATE table t as select range a from range(3000);"))
   res <- dbSendQuery(con, "SELECT * FROM t", arrow = TRUE)
-  record_batch_reader <- duckdb::duckdb_fetch_record_batch(res,1024)
+  record_batch_reader <- duckdb_fetch_record_batch(res,1024)
   cur_batch <- record_batch_reader$read_next_batch()
   expect_equal(1024, cur_batch$num_rows)
 
@@ -88,10 +88,10 @@ test_that("duckdb_fetch_arrow() record_batch_reader ", {
 
 test_that("duckdb_fetch_arrow() record_batch_reader multiple vectors per chunk", {
   skip_if_not_installed("arrow", "4.0.1")
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   dbExecute(con, paste0("CREATE table t as select range a from range(5000);"))
   res <- dbSendQuery(con, "SELECT * FROM t", arrow = TRUE)
-  record_batch_reader <- duckdb::duckdb_fetch_record_batch(res, 2048)
+  record_batch_reader <- duckdb_fetch_record_batch(res, 2048)
   cur_batch <- record_batch_reader$read_next_batch()
   expect_equal(2048, cur_batch$num_rows)
 
@@ -108,11 +108,11 @@ test_that("duckdb_fetch_arrow() record_batch_reader multiple vectors per chunk",
 
 test_that("record_batch_reader and table error", {
   skip_if_not_installed("arrow", "4.0.1")
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   dbExecute(con, paste0("CREATE table t as select range a from range(5000);"))
   res <- dbSendQuery(con, "SELECT * FROM t", arrow = TRUE)
-  expect_error(duckdb::duckdb_fetch_record_batch(res, 0))
-  expect_error(duckdb::duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE),0))
+  expect_error(duckdb_fetch_record_batch(res, 0))
+  expect_error(duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE),0))
 
   dbDisconnect(con, shutdown = T)
 })
@@ -120,10 +120,10 @@ test_that("record_batch_reader and table error", {
 
 test_that("duckdb_fetch_arrow() record_batch_reader defaultparamenter", {
   skip_if_not_installed("arrow", "4.0.1")
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   dbExecute(con, paste0("CREATE table t as select range a from range(5000);"))
   res <- dbSendQuery(con, "SELECT * FROM t", arrow = TRUE)
-  record_batch_reader <- duckdb::duckdb_fetch_record_batch(res)
+  record_batch_reader <- duckdb_fetch_record_batch(res)
   cur_batch <- record_batch_reader$read_next_batch()
   expect_equal(5000, cur_batch$num_rows)
 
@@ -134,12 +134,12 @@ test_that("duckdb_fetch_arrow() record_batch_reader defaultparamenter", {
 
 test_that("duckdb_fetch_arrow() record_batch_reader Read Table", {
   skip_if_not_installed("arrow", "4.0.1")
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   dbExecute(con, paste0("CREATE table t as select range a from range(3000);"))
   res <- dbSendQuery(con, "SELECT * FROM t", arrow = TRUE)
-  record_batch_reader <- duckdb::duckdb_fetch_record_batch(res)
+  record_batch_reader <- duckdb_fetch_record_batch(res)
   arrow_table <- record_batch_reader$read_table()
   expect_equal(3000, arrow_table$num_rows)
 })

--- a/tools/rpkg/tests/testthat/test_integer64.R
+++ b/tools/rpkg/tests/testthat/test_integer64.R
@@ -2,11 +2,11 @@
 test_that("we can roundtrip an integer64", {
   skip_if_not_installed("bit64")
 
-  con <- dbConnect(duckdb::duckdb(bigint="integer64"))
+  con <- dbConnect(duckdb(bigint="integer64"))
   on.exit(dbDisconnect(con, shutdown = TRUE))
   df <- data.frame(a = bit64::as.integer64(42), b = bit64::as.integer64(-42), c = bit64::as.integer64(NA))
 
-  duckdb::duckdb_register(con, "df", df)
+  duckdb_register(con, "df", df)
 
   res <- dbReadTable(con, "df")
   expect_identical(df, res)

--- a/tools/rpkg/tests/testthat/test_interval.R
+++ b/tools/rpkg/tests/testthat/test_interval.R
@@ -2,7 +2,7 @@ expect_equal_difftime <- function (a, b)
     expect_equal(as.numeric(a, units = "secs"), as.numeric(b, units = "secs"))
 
 test_that("we can retrieve an interval", {
-    con <- dbConnect(duckdb::duckdb())
+    con <- dbConnect(duckdb())
     on.exit(dbDisconnect(con, shutdown = TRUE))
 
     res <- dbGetQuery(con, "SELECT '2021-11-26'::TIMESTAMP-'1984-04-24'::TIMESTAMP i")

--- a/tools/rpkg/tests/testthat/test_list.R
+++ b/tools/rpkg/tests/testthat/test_list.R
@@ -1,5 +1,5 @@
 test_that("one-level lists can be read", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   res <- dbGetQuery(con, "SELECT [] a")$a

--- a/tools/rpkg/tests/testthat/test_multi_statement.R
+++ b/tools/rpkg/tests/testthat/test_multi_statement.R
@@ -2,13 +2,13 @@ skip_on_cran()
 local_edition(3)
 
 test_that("empty statement gives an error", {
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- DBI::dbConnect(duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
   expect_snapshot_error(DBI::dbGetQuery(con, "; ;   ; -- SELECT 1;"))
 })
 
 test_that("multiple statements can be used in one call", {
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- DBI::dbConnect(duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
   query <- paste(
     "CREATE TABLE integers(i integer);",
@@ -21,7 +21,7 @@ test_that("multiple statements can be used in one call", {
 })
 
 test_that("statements can be splitted apart correctly", {
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- DBI::dbConnect(duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
   expect_snapshot(DBI::dbGetQuery(con, a <- paste(
     "--Multistatement testing; testing",
@@ -41,7 +41,7 @@ test_that("export/import database works", {
   export_location <- file.path(tempdir(), "duckdb_test_export")
   if (!file.exists(export_location)) dir.create(export_location)
 
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- DBI::dbConnect(duckdb())
   DBI::dbExecute(con, "CREATE TABLE integers(i integer)")
   DBI::dbExecute(con, "insert into integers select * from range(10)")
   DBI::dbExecute(con, "CREATE TABLE integers2(i INTEGER)")
@@ -49,7 +49,7 @@ test_that("export/import database works", {
   DBI::dbExecute(con, paste0("EXPORT DATABASE '", export_location, "'"))
   DBI::dbDisconnect(con, shutdown = TRUE)
 
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- DBI::dbConnect(duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
 
   DBI::dbExecute(con, paste0("IMPORT DATABASE '", export_location, "'"))

--- a/tools/rpkg/tests/testthat/test_parquet.R
+++ b/tools/rpkg/tests/testthat/test_parquet.R
@@ -1,12 +1,12 @@
 test_that("parquet reader works on the notorious userdata1 file", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   res <- dbGetQuery(con, "SELECT * FROM parquet_scan('data/userdata1.parquet')")
   dbDisconnect(con, shutdown = TRUE)
   expect_true(TRUE)
 })
 
 test_that("parquet reader works with the binary as string flag", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   res <- dbGetQuery(con, "SELECT typeof(#1) FROM parquet_scan('data/binary_string.parquet',binary_as_string=true) limit 1")
   expect_true(res[1] == "VARCHAR")
   dbDisconnect(con, shutdown = TRUE)

--- a/tools/rpkg/tests/testthat/test_read.R
+++ b/tools/rpkg/tests/testthat/test_read.R
@@ -1,5 +1,5 @@
 test_that("duckdb_read_csv() works as expected", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
 
   tf <- tempfile()
 

--- a/tools/rpkg/tests/testthat/test_readonly.R
+++ b/tools/rpkg/tests/testthat/test_readonly.R
@@ -13,7 +13,7 @@ test_that("read_only flag and shutdown works as expected", {
 
 
   # 2nd: start two parallel read-only references
-  drv <- duckdb::duckdb(dbdir, read_only = TRUE)
+  drv <- duckdb(dbdir, read_only = TRUE)
   con <- dbConnect(drv)
 
   res <- dbReadTable(con, "iris")

--- a/tools/rpkg/tests/testthat/test_register.R
+++ b/tools/rpkg/tests/testthat/test_register.R
@@ -1,36 +1,36 @@
 test_that("duckdb_register() works", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   # most basic case
-  duckdb::duckdb_register(con, "my_df1", iris)
+  duckdb_register(con, "my_df1", iris)
   res <- dbReadTable(con, "my_df1")
   res$Species <- as.factor(res$Species)
   expect_true(identical(res, iris))
-  duckdb::duckdb_unregister(con, "my_df1")
+  duckdb_unregister(con, "my_df1")
 
-  duckdb::duckdb_register(con, "my_df2", mtcars)
+  duckdb_register(con, "my_df2", mtcars)
   res <- dbReadTable(con, "my_df2")
   row.names(res) <- row.names(mtcars)
   expect_true(identical(res, mtcars))
-  duckdb::duckdb_unregister(con, "my_df2")
+  duckdb_unregister(con, "my_df2")
 
-  duckdb::duckdb_register(con, "my_df1", mtcars)
+  duckdb_register(con, "my_df1", mtcars)
   res <- dbReadTable(con, "my_df1")
   row.names(res) <- row.names(mtcars)
   expect_true(identical(res, mtcars))
 
   # re-registering under same name is an error by default, see issue #967
-  expect_error(duckdb::duckdb_register(con, "my_df1", iris))
+  expect_error(duckdb_register(con, "my_df1", iris))
   # can force an overwrite
-  duckdb::duckdb_register(con, "my_df1", iris, overwrite=TRUE)
+  duckdb_register(con, "my_df1", iris, overwrite=TRUE)
   res <- dbReadTable(con, "my_df1")
   res$Species <- as.factor(res$Species)
   expect_true(identical(res, iris))
 
-  duckdb::duckdb_unregister(con, "my_df1")
-  duckdb::duckdb_unregister(con, "my_df2")
-  duckdb::duckdb_unregister(con, "xxx")
+  duckdb_unregister(con, "my_df1")
+  duckdb_unregister(con, "my_df2")
+  duckdb_unregister(con, "xxx")
 
   # this needs to be empty now
   expect_true(length(attributes(con@conn_ref)) == 0)
@@ -38,31 +38,31 @@ test_that("duckdb_register() works", {
 
 
 test_that("various error cases for duckdb_register()", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
 
-  duckdb::duckdb_register(con, "my_df1", iris)
-  duckdb::duckdb_unregister(con, "my_df1")
+  duckdb_register(con, "my_df1", iris)
+  duckdb_unregister(con, "my_df1")
   expect_error(dbReadTable(con, "my_df1"))
 
-  expect_error(duckdb::duckdb_register(1, "my_df1", iris))
-  expect_error(duckdb::duckdb_register(con, "", iris))
-  expect_error(duckdb::duckdb_unregister(1, "my_df1"))
-  expect_error(duckdb::duckdb_unregister(con, ""))
+  expect_error(duckdb_register(1, "my_df1", iris))
+  expect_error(duckdb_register(con, "", iris))
+  expect_error(duckdb_unregister(1, "my_df1"))
+  expect_error(duckdb_unregister(con, ""))
   dbDisconnect(con, shutdown = TRUE)
   # this is fine
-  duckdb::duckdb_unregister(con, "my_df1")
+  duckdb_unregister(con, "my_df1")
 })
 
 
 test_that("uppercase data frames are queryable", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
-  duckdb::duckdb_register(con, "My_Mtcars", mtcars)
+  duckdb_register(con, "My_Mtcars", mtcars)
   dbGetQuery(con, "SELECT * FROM \"My_Mtcars\"")
 
   res <- dbReadTable(con, "My_Mtcars")
   row.names(res) <- row.names(mtcars)
   expect_true(identical(res, mtcars))
-  duckdb::duckdb_unregister(con, "My_Mtcars")
+  duckdb_unregister(con, "My_Mtcars")
 })

--- a/tools/rpkg/tests/testthat/test_register_arrow.R
+++ b/tools/rpkg/tests/testthat/test_register_arrow.R
@@ -7,18 +7,18 @@ skip_if_not(arrow::arrow_with_parquet(), message = "The installed Arrow is not f
 library("arrow")
 
 test_that("duckdb_register_arrow() works", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   res <- arrow::read_parquet("data/userdata1.parquet", as_data_frame = FALSE)
-  duckdb::duckdb_register_arrow(con, "myreader", res)
+  duckdb_register_arrow(con, "myreader", res)
   res1 <- dbGetQuery(con, "SELECT first_name, last_name FROM myreader LIMIT 10")
   res2 <- dbGetQuery(con, "SELECT first_name, last_name FROM parquet_scan('data/userdata1.parquet') LIMIT 10")
   expect_true(identical(res1, res2))
   # we can re-read
   res3 <- dbGetQuery(con, "SELECT first_name, last_name FROM myreader LIMIT 10")
   expect_true(identical(res2, res3))
-  duckdb::duckdb_unregister_arrow(con, "myreader")
+  duckdb_unregister_arrow(con, "myreader")
   # cant read after unregister
   expect_error(dbGetQuery(con, "SELECT first_name, last_name FROM myreader LIMIT 100"))
 
@@ -27,49 +27,49 @@ test_that("duckdb_register_arrow() works", {
 })
 
 test_that("duckdb_register_arrow() works with record_batch_readers", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   res <- arrow::read_parquet("data/userdata1.parquet", as_data_frame = TRUE)
   res <- arrow::record_batch(res)
-  duckdb::duckdb_register_arrow(con, "myreader", res)
+  duckdb_register_arrow(con, "myreader", res)
   res1 <- dbGetQuery(con, "SELECT first_name, last_name FROM myreader LIMIT 10")
   res2 <- dbGetQuery(con, "SELECT first_name, last_name FROM parquet_scan('data/userdata1.parquet') LIMIT 10")
   expect_true(identical(res1, res2))
   # we can re-read
   res3 <- dbGetQuery(con, "SELECT first_name, last_name FROM myreader LIMIT 10")
   expect_true(identical(res2, res3))
-  duckdb::duckdb_unregister_arrow(con, "myreader")
+  duckdb_unregister_arrow(con, "myreader")
   # cant read after unregister
   expect_error(dbGetQuery(con, "SELECT first_name, last_name FROM myreader LIMIT 100"))
 })
 
 test_that("duckdb_register_arrow() works with scanner", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   res <- arrow::read_parquet("data/userdata1.parquet", as_data_frame = FALSE)
   res <- arrow::Scanner$create(res)
-  duckdb::duckdb_register_arrow(con, "myreader", res)
+  duckdb_register_arrow(con, "myreader", res)
   res1 <- dbGetQuery(con, "SELECT first_name, last_name FROM myreader LIMIT 10")
   res2 <- dbGetQuery(con, "SELECT first_name, last_name FROM parquet_scan('data/userdata1.parquet') LIMIT 10")
   expect_true(identical(res1, res2))
   # we can re-read
   res3 <- dbGetQuery(con, "SELECT first_name, last_name FROM myreader LIMIT 10")
   expect_true(identical(res2, res3))
-  duckdb::duckdb_unregister_arrow(con, "myreader")
+  duckdb_unregister_arrow(con, "myreader")
   # cant read after unregister
   expect_error(dbGetQuery(con, "SELECT first_name, last_name FROM myreader LIMIT 100"))
 })
 
 
 test_that("duckdb_register_arrow() works with datasets", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   # Registering a dataset + aggregation
   ds <- arrow::open_dataset("data/userdata1.parquet")
-  duckdb::duckdb_register_arrow(con, "mydatasetreader", ds)
+  duckdb_register_arrow(con, "mydatasetreader", ds)
   res1 <- dbGetQuery(con, "SELECT count(*) FROM mydatasetreader")
   res2 <- dbGetQuery(con, "SELECT count(*) FROM parquet_scan('data/userdata1.parquet')")
   expect_true(identical(res1, res2))
@@ -77,17 +77,17 @@ test_that("duckdb_register_arrow() works with datasets", {
   dbExecute(con, "PRAGMA threads=4")
   res3 <- dbGetQuery(con, "SELECT count(*) FROM mydatasetreader")
   expect_true(identical(res2, res3))
-  duckdb::duckdb_unregister_arrow(con, "mydatasetreader")
+  duckdb_unregister_arrow(con, "mydatasetreader")
 })
 
 
 test_that("duckdb_register_arrow() works with datasets and async arrow scanner", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   # Registering a dataset + aggregation
   ds <- arrow::open_dataset("data/userdata1.parquet")
-  duckdb::duckdb_register_arrow(con, "mydatasetreader", ds)
+  duckdb_register_arrow(con, "mydatasetreader", ds)
   res1 <- dbGetQuery(con, "SELECT count(*) FROM mydatasetreader")
   res2 <- dbGetQuery(con, "SELECT count(*) FROM parquet_scan('data/userdata1.parquet')")
   expect_true(identical(res1, res2))
@@ -95,17 +95,17 @@ test_that("duckdb_register_arrow() works with datasets and async arrow scanner",
   dbExecute(con, "PRAGMA threads=4")
   res3 <- dbGetQuery(con, "SELECT count(*) FROM mydatasetreader")
   expect_true(identical(res2, res3))
-  duckdb::duckdb_unregister_arrow(con, "mydatasetreader")
+  duckdb_unregister_arrow(con, "mydatasetreader")
 })
 
 
 test_that("duckdb_register_arrow() performs projection pushdown", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   # Registering a dataset + aggregation
   ds <- arrow::open_dataset("data/userdata1.parquet")
-  duckdb::duckdb_register_arrow(con, "mydatasetreader", ds)
+  duckdb_register_arrow(con, "mydatasetreader", ds)
 
   res1 <- dbGetQuery(con, "SELECT last_name, salary, first_name FROM mydatasetreader")
   res2 <- dbGetQuery(con, "SELECT last_name, salary, first_name FROM parquet_scan('data/userdata1.parquet')")
@@ -114,16 +114,16 @@ test_that("duckdb_register_arrow() performs projection pushdown", {
   dbExecute(con, "PRAGMA threads=4")
   res3 <- dbGetQuery(con, "SELECT last_name, salary, first_name FROM mydatasetreader")
   expect_true(identical(res2, res3))
-  duckdb::duckdb_unregister_arrow(con, "mydatasetreader")
+  duckdb_unregister_arrow(con, "mydatasetreader")
 })
 
 test_that("duckdb_register_arrow() performs selection pushdown", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   # Registering a dataset + aggregation
   ds <- arrow::open_dataset("data/userdata1.parquet")
-  duckdb::duckdb_register_arrow(con, "mydatasetreader", ds)
+  duckdb_register_arrow(con, "mydatasetreader", ds)
 
   res1 <- dbGetQuery(con, "SELECT last_name, first_name FROM mydatasetreader where salary > 130000")
   res2 <- dbGetQuery(con, "SELECT last_name, first_name FROM parquet_scan('data/userdata1.parquet')  where salary > 130000")
@@ -132,18 +132,18 @@ test_that("duckdb_register_arrow() performs selection pushdown", {
   dbExecute(con, "PRAGMA threads=4")
   res3 <- dbGetQuery(con, "SELECT last_name, first_name FROM mydatasetreader where salary > 130000")
   expect_true(identical(res2, res3))
-  duckdb::duckdb_unregister_arrow(con, "mydatasetreader")
+  duckdb_unregister_arrow(con, "mydatasetreader")
 })
 
 
 numeric_operators <- function(data_type) {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   dbExecute(con, paste0("CREATE TABLE test (a ", data_type, ", b ", data_type, ", c ", data_type, ")"))
   dbExecute(con, "INSERT INTO  test VALUES (1,1,1),(10,10,10),(100,10,100),(NULL,NULL,NULL)")
-  arrow_table <- duckdb::duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE))
-  duckdb::duckdb_register_arrow(con, "testarrow", arrow_table)
+  arrow_table <- duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE))
+  duckdb_register_arrow(con, "testarrow", arrow_table)
 
   # Try ==
   expect_equal(dbGetQuery(con, "SELECT count(*) from testarrow where a =1")[[1]], 1)
@@ -167,7 +167,7 @@ numeric_operators <- function(data_type) {
   # Try Or
   expect_equal(dbGetQuery(con, "SELECT count(*) from testarrow where a = 100 or b =1")[[1]], 2)
 
-  duckdb::duckdb_unregister_arrow(con, "testarrow")
+  duckdb_unregister_arrow(con, "testarrow")
 }
 
 
@@ -191,13 +191,13 @@ test_that("duckdb_register_arrow() performs selection pushdown decimal types", {
 })
 
 test_that("duckdb_register_arrow() performs selection pushdown varchar type", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   dbExecute(con, paste0("CREATE TABLE test (a  VARCHAR, b VARCHAR, c VARCHAR)"))
   dbExecute(con, "INSERT INTO  test VALUES ('1','1','1'),('10','10','10'),('100','10','100'),(NULL,NULL,NULL)")
-  arrow_table <- duckdb::duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE))
-  duckdb::duckdb_register_arrow(con, "testarrow", arrow_table)
+  arrow_table <- duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE))
+  duckdb_register_arrow(con, "testarrow", arrow_table)
 
   # Try ==
   expect_equal(dbGetQuery(con, "SELECT count(*) from testarrow where a ='1'")[[1]], 1)
@@ -221,17 +221,17 @@ test_that("duckdb_register_arrow() performs selection pushdown varchar type", {
   # Try Or
   expect_equal(dbGetQuery(con, "SELECT count(*) from testarrow where a = '100' or b ='1'")[[1]], 2)
 
-  duckdb::duckdb_unregister_arrow(con, "testarrow")
+  duckdb_unregister_arrow(con, "testarrow")
 })
 
 test_that("duckdb_register_arrow() performs selection pushdown bool type", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   dbExecute(con, paste0("CREATE TABLE test (a  BOOL, b BOOL)"))
   dbExecute(con, "INSERT INTO  test VALUES (TRUE,TRUE),(TRUE,FALSE),(FALSE,TRUE),(NULL,NULL)")
-  arrow_table <- duckdb::duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE))
-  duckdb::duckdb_register_arrow(con, "testarrow", arrow_table)
+  arrow_table <- duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE))
+  duckdb_register_arrow(con, "testarrow", arrow_table)
 
   # Try ==
   expect_equal(dbGetQuery(con, "SELECT count(*) from testarrow where a =True")[[1]], 2)
@@ -246,18 +246,18 @@ test_that("duckdb_register_arrow() performs selection pushdown bool type", {
   # Try Or
   expect_equal(dbGetQuery(con, "SELECT count(*) from testarrow where a = True or b =True")[[1]], 3)
 
-  duckdb::duckdb_unregister_arrow(con, "testarrow")
+  duckdb_unregister_arrow(con, "testarrow")
 })
 
 test_that("duckdb_register_arrow() performs selection pushdown time type", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   dbExecute(con, paste0("CREATE TABLE test (a  TIME, b TIME, c TIME)"))
 
   time <- structure(c(60, 600, 3600, NA), class = "difftime", units = "secs")
   arrow_table <- arrow::arrow_table(a = time, b = time, c = time)
-  duckdb::duckdb_register_arrow(con, "testarrow", arrow_table)
+  duckdb_register_arrow(con, "testarrow", arrow_table)
 
   # Try ==
   expect_equal(dbGetQuery(con, "SELECT count(*) from testarrow where a ='00:01:00'")[[1]], 1)
@@ -282,17 +282,17 @@ test_that("duckdb_register_arrow() performs selection pushdown time type", {
   # # Try Or
   expect_equal(dbGetQuery(con, "SELECT count(*) from testarrow where a = '01:00:00' or b ='00:01:00'")[[1]], 2)
 
-  duckdb::duckdb_unregister_arrow(con, "testarrow")
+  duckdb_unregister_arrow(con, "testarrow")
 })
 
 test_that("duckdb_register_arrow() performs selection pushdown timestamp type", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   dbExecute(con, paste0("CREATE TABLE test (a  TIMESTAMP, b TIMESTAMP, c TIMESTAMP)"))
   dbExecute(con, "INSERT INTO  test VALUES ('2008-01-01 00:00:01','2008-01-01 00:00:01','2008-01-01 00:00:01'),('2010-01-01 10:00:01','2010-01-01 10:00:01','2010-01-01 10:00:01'),('2020-03-01 10:00:01','2010-01-01 10:00:01','2020-03-01 10:00:01'),(NULL,NULL,NULL)")
-  arrow_table <- duckdb::duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE))
-  duckdb::duckdb_register_arrow(con, "testarrow", arrow_table)
+  arrow_table <- duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE))
+  duckdb_register_arrow(con, "testarrow", arrow_table)
 
   # Try ==
   expect_equal(dbGetQuery(con, "SELECT count(*) from testarrow where a ='2008-01-01 00:00:01'")[[1]], 1)
@@ -316,17 +316,17 @@ test_that("duckdb_register_arrow() performs selection pushdown timestamp type", 
   # Try Or
   expect_equal(dbGetQuery(con, "SELECT count(*) from testarrow where a = '2020-03-01 10:00:01' or b ='2008-01-01 00:00:01'")[[1]], 2)
 
-  duckdb::duckdb_unregister_arrow(con, "testarrow")
+  duckdb_unregister_arrow(con, "testarrow")
 })
 
 test_that("duckdb_register_arrow() performs selection pushdown timestamptz type", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   dbExecute(con, paste0("CREATE TABLE test (a  TIMESTAMPTZ, b TIMESTAMPTZ, c TIMESTAMPTZ)"))
   dbExecute(con, "INSERT INTO  test VALUES ('2008-01-01 00:00:01','2008-01-01 00:00:01','2008-01-01 00:00:01'),('2010-01-01 10:00:01','2010-01-01 10:00:01','2010-01-01 10:00:01'),('2020-03-01 10:00:01','2010-01-01 10:00:01','2020-03-01 10:00:01'),(NULL,NULL,NULL)")
-  arrow_table <- duckdb::duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE))
-  duckdb::duckdb_register_arrow(con, "testarrow", arrow_table)
+  arrow_table <- duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE))
+  duckdb_register_arrow(con, "testarrow", arrow_table)
 
   # Try ==
   expect_equal(dbGetQuery(con, "SELECT count(*) from testarrow where a ='2008-01-01 00:00:01'")[[1]], 1)
@@ -350,17 +350,17 @@ test_that("duckdb_register_arrow() performs selection pushdown timestamptz type"
   # Try Or
   expect_equal(dbGetQuery(con, "SELECT count(*) from testarrow where a = '2020-03-01 10:00:01' or b ='2008-01-01 00:00:01'")[[1]], 2)
 
-  duckdb::duckdb_unregister_arrow(con, "testarrow")
+  duckdb_unregister_arrow(con, "testarrow")
 })
 
 test_that("duckdb_register_arrow() performs selection pushdown date type", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   dbExecute(con, paste0("CREATE TABLE test (a  DATE, b DATE, c DATE)"))
   dbExecute(con, "INSERT INTO  test VALUES ('2000-01-01','2000-01-01','2000-01-01'),('2000-10-01','2000-10-01','2000-10-01'),('2010-01-01','2000-10-01','2010-01-01'),(NULL,NULL,NULL)")
-  arrow_table <- duckdb::duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE))
-  duckdb::duckdb_register_arrow(con, "testarrow", arrow_table)
+  arrow_table <- duckdb_fetch_arrow(dbSendQuery(con, "SELECT * FROM test", arrow = TRUE))
+  duckdb_register_arrow(con, "testarrow", arrow_table)
 
   # Try ==
   expect_equal(dbGetQuery(con, "SELECT count(*) from testarrow where a ='2000-01-01'")[[1]], 1)
@@ -384,15 +384,15 @@ test_that("duckdb_register_arrow() performs selection pushdown date type", {
   # Try Or
   expect_equal(dbGetQuery(con, "SELECT count(*) from testarrow where a = '2010-01-01' or b ='2000-01-01'")[[1]], 2)
 
-  duckdb::duckdb_unregister_arrow(con, "testarrow")
+  duckdb_unregister_arrow(con, "testarrow")
 })
 
 test_that("duckdb_register_arrow() under many threads", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   ds <- arrow::InMemoryDataset$create(mtcars)
-  duckdb::duckdb_register_arrow(con, "mtcars_arrow", ds)
+  duckdb_register_arrow(con, "mtcars_arrow", ds)
   dbExecute(con, "PRAGMA threads=32")
   dbExecute(con, "PRAGMA verify_parallelism")
   expect_error(dbGetQuery(con, "SELECT cyl, COUNT(mpg) FROM mtcars_arrow GROUP BY cyl"), NA)
@@ -401,7 +401,7 @@ test_that("duckdb_register_arrow() under many threads", {
 })
 
 test_that("we can unregister in finalizers yay", {
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- DBI::dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
   ds <- arrow::InMemoryDataset$create(mtcars)
 
@@ -410,53 +410,53 @@ test_that("we can unregister in finalizers yay", {
     # we need to force the name here
     table_name_forced <- force(table_name)
     reg.finalizer(environment(), function(...) {
-      duckdb::duckdb_unregister_arrow(con, table_name_forced)
+      duckdb_unregister_arrow(con, table_name_forced)
     })
     environment()
   }
 
   for (i in 1:100) {
     table_name <- paste0("mtcars_", i)
-    duckdb::duckdb_register_arrow(con, table_name, ds)
+    duckdb_register_arrow(con, table_name, ds)
     object_to_clean <- duckdb_disconnector(con, table_name)
   }
   object_to_clean <- NULL # otherwise we leak one
   # force a gc run, now they should all be gone
   gc()
 
-  expect_equal(length(duckdb::duckdb_list_arrow(con)), 0)
+  expect_equal(length(duckdb_list_arrow(con)), 0)
 })
 
 
 test_that("we can list registered arrow tables", {
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- DBI::dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
   ds <- arrow::InMemoryDataset$create(mtcars)
 
-  expect_equal(length(duckdb::duckdb_list_arrow(con)), 0)
+  expect_equal(length(duckdb_list_arrow(con)), 0)
 
-  duckdb::duckdb_register_arrow(con, "t1", ds)
-  duckdb::duckdb_register_arrow(con, "t2", ds)
+  duckdb_register_arrow(con, "t1", ds)
+  duckdb_register_arrow(con, "t2", ds)
 
-  expect_equal(duckdb::duckdb_list_arrow(con), c("t1", "t2"))
+  expect_equal(duckdb_list_arrow(con), c("t1", "t2"))
 
-  duckdb::duckdb_unregister_arrow(con, "t1")
-  expect_equal(duckdb::duckdb_list_arrow(con), c("t2"))
-  duckdb::duckdb_unregister_arrow(con, "t2")
+  duckdb_unregister_arrow(con, "t1")
+  expect_equal(duckdb_list_arrow(con), c("t2"))
+  duckdb_unregister_arrow(con, "t2")
 
-  expect_equal(length(duckdb::duckdb_list_arrow(con)), 0)
+  expect_equal(length(duckdb_list_arrow(con)), 0)
 })
 
 
 test_that("duckdb can read arrow timestamps", {
-  con <- DBI::dbConnect(duckdb::duckdb(), timezone_out = "UTC")
+  con <- DBI::dbConnect(duckdb(), timezone_out = "UTC")
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   timestamp <- as.POSIXct("2022-01-30 11:59:29", tz = "UTC")
 
   for (unit in c("s", "ms", "us", "ns")) {
     tbl <- arrow::arrow_table(t = arrow::Array$create(timestamp, type = arrow::timestamp(unit)))
-    duckdb::duckdb_register_arrow(con, "timestamps", tbl)
+    duckdb_register_arrow(con, "timestamps", tbl)
 
     if (unit == "ns") {
       # warning when precision loss
@@ -475,20 +475,20 @@ test_that("duckdb can read arrow timestamps", {
     expect_equal(res[[5]], 59)
     expect_equal(res[[6]], 29)
 
-    duckdb::duckdb_unregister_arrow(con, "timestamps")
+    duckdb_unregister_arrow(con, "timestamps")
   }
 })
 
 test_that("duckdb can read arrow timestamptz", {
   skip("ICU not loaded")
-  con <- DBI::dbConnect(duckdb::duckdb(), timezone_out = "UTC")
+  con <- DBI::dbConnect(duckdb(), timezone_out = "UTC")
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   timestamp <- as.POSIXct("2022-01-30 11:59:29")
 
   for (unit in c("s", "ms", "us", "ns")) {
     tbl <- arrow::arrow_table(t = arrow::Array$create(timestamp, type = arrow::timestamp(unit, "UTC")))
-    duckdb::duckdb_register_arrow(con, "timestamps", tbl)
+    duckdb_register_arrow(con, "timestamps", tbl)
 
     if (unit == "ns") {
       # warning when precision loss
@@ -507,7 +507,7 @@ test_that("duckdb can read arrow timestamptz", {
     expect_equal(res[[5]], 59)
     expect_equal(res[[6]], 29)
 
-    duckdb::duckdb_unregister_arrow(con, "timestamps")
+    duckdb_unregister_arrow(con, "timestamps")
   }
 })
 

--- a/tools/rpkg/tests/testthat/test_register_readonly.R
+++ b/tools/rpkg/tests/testthat/test_register_readonly.R
@@ -1,11 +1,11 @@
 test_that("we can register a data frame on a read only connection", {
   path <- tempfile()
   # create empty database
-  con <- dbConnect(duckdb::duckdb(), dbdir = path, read_only = FALSE)
+  con <- dbConnect(duckdb(), dbdir = path, read_only = FALSE)
   dbDisconnect(con, shutdown = TRUE)
 
   # reopen database read-only, try to write temp table
-  con <- dbConnect(duckdb::duckdb(), dbdir = path, read_only = TRUE)
+  con <- dbConnect(duckdb(), dbdir = path, read_only = TRUE)
   expect_true(duckdb_register(con, "mtcars", mtcars))
   dbDisconnect(con, shutdown = TRUE)
 })

--- a/tools/rpkg/tests/testthat/test_relational.R
+++ b/tools/rpkg/tests/testthat/test_relational.R
@@ -1,56 +1,56 @@
 library("DBI")
 library("testthat")
 
-con <- dbConnect(duckdb::duckdb())
+con <- dbConnect(duckdb())
 on.exit(dbDisconnect(con, shutdown = TRUE))
 
 test_that("we can create a relation from a df", {
-  duckdb::rel_from_df(con, mtcars)
+  rel_from_df(con, mtcars)
   expect_true(TRUE)
 })
 
 test_that("we won't crash when creating a relation from odd things", {
   # na seems to be fine, single col data frame with a single row with NA in it
-  duckdb::rel_from_df(con, NA)
+  rel_from_df(con, NA)
 
-  expect_error(duckdb::rel_from_df(NULL, NULL))
-  expect_error(duckdb::rel_from_df(con, NULL))
+  expect_error(rel_from_df(NULL, NULL))
+  expect_error(rel_from_df(con, NULL))
 
   expect_true(TRUE)
 })
 
 test_that("we can round-trip a data frame", {
-  expect_equivalent(mtcars, as.data.frame(duckdb::rel_from_df(con, mtcars)))
-  expect_equivalent(iris, as.data.frame(duckdb::rel_from_df(con, iris)))
+  expect_equivalent(mtcars, as.data.frame(rel_from_df(con, mtcars)))
+  expect_equivalent(iris, as.data.frame(rel_from_df(con, iris)))
 })
 
 
 test_that("we can create various expressions and don't crash", {
-  ref <- duckdb::expr_reference('asdf')
+  ref <- expr_reference('asdf')
   print(ref)
-  expect_error(duckdb::expr_reference(NA))
-#  expect_error(duckdb::expr_reference(as.character(NA)))
-  expect_error(duckdb::expr_reference(''))
-  expect_error(duckdb::expr_reference(NULL))
+  expect_error(expr_reference(NA))
+#  expect_error(expr_reference(as.character(NA)))
+  expect_error(expr_reference(''))
+  expect_error(expr_reference(NULL))
 
-  duckdb::expr_constant(TRUE)
-  duckdb::expr_constant(FALSE)
-  duckdb::expr_constant(NA)
-  duckdb::expr_constant(42L)
-  duckdb::expr_constant(42)
-  const <- duckdb::expr_constant("asdf")
+  expr_constant(TRUE)
+  expr_constant(FALSE)
+  expr_constant(NA)
+  expr_constant(42L)
+  expr_constant(42)
+  const <- expr_constant("asdf")
   print(const)
 
-  expect_error(duckdb::expr_constant(NULL))
-  expect_error(duckdb::expr_constant())
+  expect_error(expr_constant(NULL))
+  expect_error(expr_constant())
 
 
-  duckdb::expr_function("asdf", list())
+  expr_function("asdf", list())
 
-  expect_error(duckdb::expr_function("", list()))
-#  expect_error(duckdb::expr_function(as.character(NA), list()))
-  expect_error(duckdb::expr_function(NULL, list()))
-  expect_error(duckdb::expr_function("asdf"))
+  expect_error(expr_function("", list()))
+#  expect_error(expr_function(as.character(NA), list()))
+  expect_error(expr_function(NULL, list()))
+  expect_error(expr_function("asdf"))
 
   expect_true(TRUE)
 })
@@ -69,24 +69,24 @@ test_that("we can cast R strings to DuckDB strings", {
     test_string_vec <- c(vapply(1:n, gen_rand_string, "character", max_len), NA, NA, NA, NA, NA, NA, NA, NA) # batman
 
     df <- data.frame(s=test_string_vec, stringsAsFactors=FALSE)
-    expect_equivalent(df, as.data.frame(duckdb::rel_from_df(con, df)))
+    expect_equivalent(df, as.data.frame(rel_from_df(con, df)))
 
-    res <- duckdb::rel_from_df(con, df) |> duckdb::rel_sql("SELECT s::string FROM _")
+    res <- rel_from_df(con, df) |> rel_sql("SELECT s::string FROM _")
     expect_equivalent(df, res)
 
-    res <- duckdb::rel_from_df(con, df) |> duckdb::rel_sql("SELECT COUNT(*) c FROM _")
+    res <- rel_from_df(con, df) |> rel_sql("SELECT COUNT(*) c FROM _")
     expect_equal(nrow(df), res$c)
 
     # many rounds yay
     df2 <- df
     for (i in 1:10) {
-        df2 <- as.data.frame(duckdb::rel_from_df(con, df2))
+        df2 <- as.data.frame(rel_from_df(con, df2))
         expect_equivalent(df, df2)
     }
 
     df2 <- df
     for (i in 1:10) {
-        df2 <- as.data.frame(duckdb::rel_from_df(con, df2) |> duckdb::rel_sql("SELECT s::string s FROM _"))
+        df2 <- as.data.frame(rel_from_df(con, df2) |> rel_sql("SELECT s::string s FROM _"))
         expect_equivalent(df, df2)
     }
 })

--- a/tools/rpkg/tests/testthat/test_struct.R
+++ b/tools/rpkg/tests/testthat/test_struct.R
@@ -1,7 +1,7 @@
 test_that("structs can be read", {
   skip_if_not_installed("vctrs")
 
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   res <- dbGetQuery(con, "SELECT {'x': 100, 'y': 'hello', 'z': 3.14} AS s")
@@ -53,7 +53,7 @@ test_that("structs give the same results via Arrow", {
   skip_if_not_installed("tibble")
   skip_if_not_installed("arrow")
 
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   res <- dbGetQuery(con, "SELECT {'x': 100, 'y': 'hello', 'z': 3.14} AS s", arrow = TRUE)

--- a/tools/rpkg/tests/testthat/test_tbl__duckdb_connection.R
+++ b/tools/rpkg/tests/testthat/test_tbl__duckdb_connection.R
@@ -2,7 +2,7 @@ skip_on_cran()
 `%>%` <- dplyr::`%>%`
 
 test_that("Parquet files can be registered with dplyr::tbl()", {
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- DBI::dbConnect(duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
 
   tab0 <- dplyr::tbl(con, "data/userdata1.parquet")
@@ -24,7 +24,7 @@ test_that("Parquet files can be registered with dplyr::tbl()", {
 
 
 test_that("Object cache can be enabled for parquet files with dplyr::tbl()", {
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- DBI::dbConnect(duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
 
   DBI::dbExecute(con, "SET enable_object_cache=False;")
@@ -42,7 +42,7 @@ test_that("CSV files can be registered with dplyr::tbl()", {
   write.csv(iris, file = path)
   on.exit(unlink(path))
 
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- DBI::dbConnect(duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
 
   tab1 <- dplyr::tbl(con, path)
@@ -55,7 +55,7 @@ test_that("CSV files can be registered with dplyr::tbl()", {
 })
 
 test_that("Other replacement scans or functions can be registered with dplyr::tbl()", {
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- DBI::dbConnect(duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
 
   obj <- dplyr::tbl(con, "duckdb_keywords()")

--- a/tools/rpkg/tests/testthat/test_timezone.R
+++ b/tools/rpkg/tests/testthat/test_timezone.R
@@ -1,5 +1,5 @@
 test_that("timezone_out works with default", {
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   query <- "SELECT '1970-01-01 12:00:00'::TIMESTAMP AS ts"
@@ -8,7 +8,7 @@ test_that("timezone_out works with default", {
 })
 
 test_that("timezone_out works with UTC specified", {
-  con <- dbConnect(duckdb::duckdb(), timezone_out = "UTC")
+  con <- dbConnect(duckdb(), timezone_out = "UTC")
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   query <- "SELECT '1970-01-01 12:00:00'::TIMESTAMP AS ts"
@@ -17,7 +17,7 @@ test_that("timezone_out works with UTC specified", {
 })
 
 test_that("timezone_out works with a specified timezone", {
-  con <- dbConnect(duckdb::duckdb(), timezone_out = "Pacific/Tahiti")
+  con <- dbConnect(duckdb(), timezone_out = "Pacific/Tahiti")
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   query <- "SELECT '1970-01-01 12:00:00'::TIMESTAMP AS ts"
@@ -28,7 +28,7 @@ test_that("timezone_out works with a specified timezone", {
 test_that("timezone_out works with '' and converts to local timezime", {
   unlockBinding(".sys.timezone", baseenv())
   withr::local_timezone("Pacific/Tahiti")
-  con <- dbConnect(duckdb::duckdb(), timezone_out = "")
+  con <- dbConnect(duckdb(), timezone_out = "")
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   query <- "SELECT '1970-01-01 12:00:00'::TIMESTAMP AS ts"
@@ -39,7 +39,7 @@ test_that("timezone_out works with '' and converts to local timezime", {
 test_that("timezone_out works with Sys.timezone", {
   unlockBinding(".sys.timezone", baseenv())
   withr::local_timezone("Pacific/Tahiti")
-  con <- dbConnect(duckdb::duckdb(), timezone_out = Sys.timezone())
+  con <- dbConnect(duckdb(), timezone_out = Sys.timezone())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   query <- "SELECT '1970-01-01 12:00:00'::TIMESTAMP AS ts"
@@ -48,7 +48,7 @@ test_that("timezone_out works with Sys.timezone", {
 })
 
 test_that("timezone_out works with UTC and tz_out_convert = 'force'", {
-  con <- dbConnect(duckdb::duckdb(), timezone_out = "UTC", tz_out_convert = "force")
+  con <- dbConnect(duckdb(), timezone_out = "UTC", tz_out_convert = "force")
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   query <- "SELECT '1970-01-01 12:00:00'::TIMESTAMP AS ts"
@@ -57,7 +57,7 @@ test_that("timezone_out works with UTC and tz_out_convert = 'force'", {
 })
 
 test_that("timezone_out works with a specified timezone and tz_out_convert = 'force'", {
-  con <- dbConnect(duckdb::duckdb(), timezone_out = "Pacific/Tahiti", tz_out_convert = "force")
+  con <- dbConnect(duckdb(), timezone_out = "Pacific/Tahiti", tz_out_convert = "force")
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   query <- "SELECT '1970-01-01 12:00:00'::TIMESTAMP AS ts"
@@ -68,7 +68,7 @@ test_that("timezone_out works with a specified timezone and tz_out_convert = 'fo
 test_that("timezone_out works with '' and tz_out_convert = 'force': forces local timezime", {
   unlockBinding(".sys.timezone", baseenv())
   withr::local_timezone("Pacific/Tahiti")
-  con <- dbConnect(duckdb::duckdb(), timezone_out = "", tz_out_convert = "force")
+  con <- dbConnect(duckdb(), timezone_out = "", tz_out_convert = "force")
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   query <- "SELECT '1970-01-01 12:00:00'::TIMESTAMP AS ts"
@@ -79,7 +79,7 @@ test_that("timezone_out works with '' and tz_out_convert = 'force': forces local
 test_that("timezone_out works with a specified local timezone and tz_out_convert = 'force': forces local timezime", {
   unlockBinding(".sys.timezone", baseenv())
   withr::local_timezone("Pacific/Tahiti")
-  con <- dbConnect(duckdb::duckdb(), timezone_out = Sys.timezone(), tz_out_convert = "force")
+  con <- dbConnect(duckdb(), timezone_out = Sys.timezone(), tz_out_convert = "force")
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   query <- "SELECT '1970-01-01 12:00:00'::TIMESTAMP AS ts"
@@ -88,20 +88,20 @@ test_that("timezone_out works with a specified local timezone and tz_out_convert
 })
 
 test_that("timezone_out gives a warning with invalid timezone, and converts to UTC", {
-  expect_warning(con <- dbConnect(duckdb::duckdb(), timezone_out = "not_a_timezone"))
+  expect_warning(con <- dbConnect(duckdb(), timezone_out = "not_a_timezone"))
   on.exit(dbDisconnect(con, shutdown = TRUE))
   expect_equal(con@timezone_out, "UTC")
 })
 
 test_that("timezone_out gives a warning with NULL timezone, and converts to UTC", {
-  expect_warning(con <- dbConnect(duckdb::duckdb(), timezone_out = NULL))
+  expect_warning(con <- dbConnect(duckdb(), timezone_out = NULL))
   on.exit(dbDisconnect(con, shutdown = TRUE))
   expect_equal(con@timezone_out, "UTC")
 })
 
 test_that("dbConnect fails when tz_out_convert is misspecified", {
-  drv <- duckdb::duckdb()
-  on.exit(duckdb::duckdb_shutdown(drv))
+  drv <- duckdb()
+  on.exit(duckdb_shutdown(drv))
 
   expect_error(dbConnect(drv, tz_out_convert = "nope"))
 })

--- a/tools/rpkg/tests/testthat/test_types.R
+++ b/tools/rpkg/tests/testthat/test_types.R
@@ -1,7 +1,7 @@
 test_that("test_all_types() output", {
   skip_on_os("windows")
 
-  con <- dbConnect(duckdb::duckdb())
+  con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   local_edition(3)

--- a/tools/rpkg/tests/testthat/test_viewer.R
+++ b/tools/rpkg/tests/testthat/test_viewer.R
@@ -2,12 +2,12 @@ test_that("rs_list_object_types", {
   con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
-  object_types <- duckdb:::rs_list_object_types(con)
+  object_types <- rs_list_object_types(con)
   expect_true(length(object_types) == 1)
 
   dbExecute(con, "CREATE VIEW foo as SELECT 42")
 
-  object_types <- duckdb:::rs_list_object_types(con)
+  object_types <- rs_list_object_types(con)
   expect_true(length(object_types$schema$contains) == 2)
 })
 
@@ -15,39 +15,39 @@ test_that("rs_list_objects", {
   con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
-  objects <- duckdb:::rs_list_objects(con)
+  objects <- rs_list_objects(con)
   expect_equal(nrow(objects), 0)
 
   dbExecute(con, "CREATE TABLE a (j integer)")
   dbExecute(con, "CREATE VIEW b as SELECT 42")
 
-  expect_equal(duckdb:::rs_list_objects(con), data.frame(name = c("a", "b"), type = c("table", "view"), stringsAsFactors = FALSE))
+  expect_equal(rs_list_objects(con), data.frame(name = c("a", "b"), type = c("table", "view"), stringsAsFactors = FALSE))
 
   dbExecute(con, "CREATE schema fuu ;")
   dbExecute(con, "CREATE TABLE fuu.x (j integer)")
 
-  expect_equal(duckdb:::rs_list_objects(con, schema = "fuu"), data.frame(name = c("x"), type = c("table"), stringsAsFactors = FALSE))
+  expect_equal(rs_list_objects(con, schema = "fuu"), data.frame(name = c("x"), type = c("table"), stringsAsFactors = FALSE))
 })
 
 test_that("rs_list_columns", {
   con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
-  objects <- duckdb:::rs_list_objects(con)
+  objects <- rs_list_objects(con)
   expect_equal(nrow(objects), 0)
 
   dbExecute(con, "CREATE TABLE t (a integer, b string, c timestamp)")
 
   cmp <- data.frame(name = c("a", "b", "c"), field.type = c("INTEGER", "VARCHAR", "TIMESTAMP"), stringsAsFactors = FALSE)
 
-  expect_equal(duckdb:::rs_list_columns(con, "t"), cmp)
-  expect_equal(duckdb:::rs_list_columns(con, "t", schema = "main"), cmp)
+  expect_equal(rs_list_columns(con, "t"), cmp)
+  expect_equal(rs_list_columns(con, "t", schema = "main"), cmp)
 
   dbExecute(con, "CREATE schema fuu ;")
   dbExecute(con, "CREATE TABLE fuu.t (x integer, y string, z timestamp)")
 
   cmp <- data.frame(name = c("x", "y", "z"), field.type = c("INTEGER", "VARCHAR", "TIMESTAMP"), stringsAsFactors = FALSE)
-  expect_equal(duckdb:::rs_list_columns(con, "t", schema = "fuu"), cmp)
+  expect_equal(rs_list_columns(con, "t", schema = "fuu"), cmp)
 })
 
 test_that("rs_viewer", {
@@ -57,14 +57,14 @@ test_that("rs_viewer", {
   dbWriteTable(con, "mtcars", mtcars)
 
   row.names(mtcars) <- seq(1, nrow(mtcars))
-  expect_equal(head(mtcars, 5), duckdb:::rs_preview(con, 5, table = "mtcars"))
+  expect_equal(head(mtcars, 5), rs_preview(con, 5, table = "mtcars"))
 })
 
 test_that("rs_actions", {
   con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
-  duckdb:::rs_actions(con)
+  rs_actions(con)
   expect_true(TRUE)
 })
 


### PR DESCRIPTION
They are noisy in the best case, and avoid easy package renames. Use case: https://github.com/r-dbi/duckadbc .