### PR TITLE
Add automatic version updates for github actions using dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
While checking at the Github Actions jobs of DuckDB I noticed some jobs were showing warnings because they were using older versions of the github actions. This PR addreses this issue by enabling dependabot so github actions are automatically updated, this way we will avoid this issue in the future.

In order to this to work we need to first enable dependabot in the github project settings. Once merged (if the PR is accepted of course). We will be able to tackle each update individually, [for reference you will find the PRs that dependabot opened in my own fork](https://github.com/iemejia/duckdb/pulls).