### PR TITLE
Fix #5124: correctly deal with DICTIONARY vectors inside LIST vectors for various functions

### DIFF
--- a/src/common/row_operations/row_radix_scatter.cpp
+++ b/src/common/row_operations/row_radix_scatter.cpp
@@ -102,6 +102,7 @@ void RadixScatterListVector(Vector &v, UnifiedVectorFormat &vdata, const Selecti
 	auto list_data = ListVector::GetData(v);
 	auto &child_vector = ListVector::GetEntry(v);
 	auto list_size = ListVector::GetListSize(v);
+	child_vector.Flatten(list_size);
 
 	// serialize null values
 	if (has_null) {

--- a/src/common/vector_operations/is_distinct_from.cpp
+++ b/src/common/vector_operations/is_distinct_from.cpp
@@ -564,8 +564,8 @@ static idx_t DistinctSelectList(Vector &left, Vector &right, idx_t count, const 
 	SelectionVector lcursor(count);
 	SelectionVector rcursor(count);
 
-	ListVector::GetEntry(left).Flatten(count);
-	ListVector::GetEntry(right).Flatten(count);
+	ListVector::GetEntry(left).Flatten(ListVector::GetListSize(left));
+	ListVector::GetEntry(right).Flatten(ListVector::GetListSize(right));
 	Vector lchild(ListVector::GetEntry(left), lcursor, count);
 	Vector rchild(ListVector::GetEntry(right), rcursor, count);
 

--- a/src/function/scalar/list/contains_or_position.cpp
+++ b/src/function/scalar/list/contains_or_position.cpp
@@ -55,8 +55,8 @@ static void TemplatedContainsOrPosition(DataChunk &args, ExpressionState &state,
 	value_vector.ToUnifiedFormat(count, value_data);
 
 	// not required for a comparison of nested types
-	auto child_value = FlatVector::GetData<CHILD_TYPE>(child_vector);
-	auto values = FlatVector::GetData<CHILD_TYPE>(value_vector);
+	auto child_value = (CHILD_TYPE *)child_data.data;
+	auto values = (CHILD_TYPE *)value_data.data;
 
 	for (idx_t i = 0; i < count; i++) {
 		auto list_index = list_data.sel->get_index(i);

--- a/src/function/scalar/list/list_lambdas.cpp
+++ b/src/function/scalar/list/list_lambdas.cpp
@@ -167,6 +167,7 @@ static void ListLambdaFunction(DataChunk &args, ExpressionState &state, Vector &
 	// get the child vector and child data
 	auto lists_size = ListVector::GetListSize(lists);
 	auto &child_vector = ListVector::GetEntry(lists);
+	child_vector.Flatten(lists_size);
 	UnifiedVectorFormat child_data;
 	child_vector.ToUnifiedFormat(lists_size, child_data);
 
@@ -251,10 +252,8 @@ static void ListLambdaFunction(DataChunk &args, ExpressionState &state, Vector &
 
 		// iterate list elements and create transformed expression columns
 		for (idx_t child_idx = 0; child_idx < list_entry.length; child_idx++) {
-
 			// reached STANDARD_VECTOR_SIZE elements
 			if (elem_cnt == STANDARD_VECTOR_SIZE) {
-
 				lambda_chunk.Reset();
 				ExecuteExpression(types, result_types, elem_cnt, sel, sel_vectors, input_chunk, lambda_chunk,
 				                  child_vector, args, expr_executor);

--- a/test/sql/storage/list_dictionary.test
+++ b/test/sql/storage/list_dictionary.test
@@ -1,0 +1,93 @@
+# name: test/sql/storage/list_dictionary.test
+# description: Test list functions on a list with a child with dictionary encoding
+# group: [storage]
+
+# load the DB from disk
+load __TEST_DIR__/list_dictionary.db
+
+statement ok
+PRAGMA force_compression='dictionary'
+
+statement ok
+CREATE TABLE test (a VARCHAR[]);
+
+statement ok
+INSERT INTO test SELECT CASE WHEN i%2=0 THEN [] ELSE ['Hello', 'World'] END FROM range(10000) t(i);
+
+query III
+SELECT MIN(t), MAX(t), COUNT(t) FROM (SELECT a[2] FROM test) t(t)
+----
+World	World	5000
+
+query I
+SELECT SUM(CASE WHEN a IS DISTINCT FROM ['Hello', 'World'] THEN 1 ELSE 0 END) FROM test
+----
+5000
+
+query I
+SELECT COUNT(*) FROM test WHERE a=['Hello', 'World']
+----
+5000
+
+query I
+SELECT DISTINCT a FROM test ORDER BY ALL
+----
+[]
+[Hello, World]
+
+query III
+SELECT MIN(t), MAX(t), COUNT(t) FROM (SELECT a[2:2] FROM test) t(t)
+----
+[]	[World]	10000
+
+statement ok
+CREATE TABLE test2 AS SELECT * FROM test ORDER BY a
+
+query I
+SELECT * FROM test2 LIMIT 3
+----
+[]
+[]
+[]
+
+query I
+SELECT * FROM test2 LIMIT 3 OFFSET 5000
+----
+[Hello, World]
+[Hello, World]
+[Hello, World]
+
+query II
+SELECT MIN(t), MAX(t) FROM (SELECT UNNEST(a) AS t FROM test) t(t)
+----
+Hello	World
+
+query I
+SELECT COUNT(*) FROM test WHERE a IN (SELECT * FROM test)
+----
+10000
+
+query IIIIII
+SELECT MIN(t), MAX(t), MIN(t[1]), MAX(t[1]), MIN(t[2]), MAX(t[2]) FROM (SELECT [lower(x) for x in a] FROM test) t(t)
+----
+[]	[hello, world]	hello	hello	world	world
+
+query II
+SELECT MIN(t), MAX(t) FROM (SELECT [lower(x) for x in a if x!='Hello'] FROM test) t(t)
+----
+[]	[world]
+
+query IIII
+SELECT MIN(a), MAX(a), MIN(b), MAX(b) FROM (SELECT list_min(a), list_max(a) FROM test) t(a, b)
+----
+Hello	Hello	World	World
+
+query I
+SELECT MIN(list_sort(a)[2]) FROM test
+----
+World
+
+query I
+SELECT COUNT(*) FROM test WHERE array_contains(a, 'World')
+----
+5000


### PR DESCRIPTION
Fixes #5124 

This PR fixes several issues with list functions and operations that did not correctly deal with dictionary vectors. These vectors would be emitted when the underlying list column was dictionary compressed and exactly vector size aligned (as the dictionary compression only emits dictionary vectors when scanning multiples of the `STANDARD_VECTOR_SIZE`). 