### PR TITLE
[Python] Exceptions encountered in 'with' body are now properly propagated

### DIFF
--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -717,6 +717,9 @@ DuckDBPyConnection *DuckDBPyConnection::Enter() {
 bool DuckDBPyConnection::Exit(DuckDBPyConnection &self, const py::object &exc_type, const py::object &exc,
                               const py::object &traceback) {
 	self.Close();
+	if (exc_type.ptr() != Py_None) {
+		return false;
+	}
 	return true;
 }
 

--- a/tools/pythonpkg/tests/fast/api/test_with_propagating_exceptions.py
+++ b/tools/pythonpkg/tests/fast/api/test_with_propagating_exceptions.py
@@ -1,0 +1,18 @@
+import pytest
+import duckdb
+
+class TestWithPropagatingExceptions(object):
+
+    def test_with(self):
+        # Should propagate exception raised in the 'with duckdb.connect() ..'
+        with pytest.raises(duckdb.ParserException, match="syntax error at or near *"):
+            with duckdb.connect() as con:
+                print('before')
+                con.execute('invalid')
+                print('after')
+
+        # Does not raise an exception
+        with duckdb.connect() as con:
+            print('before')
+            con.execute('select 1')
+            print('after')


### PR DESCRIPTION
This PR fixes #5104 

@Mause was of course 100% correct and the issue was always returning `true` from our `__exit__` function 👍 