### PR TITLE
Fix #5149: better tracking of query location in column reference, and improve error message

### DIFF
--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -32,6 +32,7 @@ struct DummyBinding;
 struct BoundColumnReferenceInfo {
 	string name;
 	idx_t query_location;
+	idx_t select_index;
 };
 
 struct BindResult {
@@ -70,7 +71,7 @@ public:
 	bool HasBoundColumns() {
 		return !bound_columns.empty();
 	}
-	const vector<BoundColumnReferenceInfo> &GetBoundColumns() {
+	vector<BoundColumnReferenceInfo> &GetBoundColumns() {
 		return bound_columns;
 	}
 

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -32,7 +32,6 @@ struct DummyBinding;
 struct BoundColumnReferenceInfo {
 	string name;
 	idx_t query_location;
-	idx_t select_index;
 };
 
 struct BindResult {
@@ -71,7 +70,7 @@ public:
 	bool HasBoundColumns() {
 		return !bound_columns.empty();
 	}
-	vector<BoundColumnReferenceInfo> &GetBoundColumns() {
+	const vector<BoundColumnReferenceInfo> &GetBoundColumns() {
 		return bound_columns;
 	}
 

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -88,6 +88,7 @@ void ExpressionBinder::QualifyColumnNames(unique_ptr<ParsedExpression> &expr) {
 			if (!expr->alias.empty()) {
 				new_expr->alias = expr->alias;
 			}
+			new_expr->query_location = colref.query_location;
 			expr = move(new_expr);
 		}
 		break;
@@ -258,6 +259,7 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref_p, idx_t
 	if (!expr) {
 		return BindResult(binder.FormatError(colref_p, error_message));
 	}
+	expr->query_location = colref_p.query_location;
 
 	// a generated column returns a generated expression, a struct on a column returns a struct extract
 	if (expr->type != ExpressionType::COLUMN_REF) {

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -476,7 +476,8 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SelectNode &statement) {
 				auto &bound_columns = select_binder.GetBoundColumns();
 				string error;
 				error = "column \"%s\" must appear in the GROUP BY clause or must be part of an aggregate function.";
-				error += "\nUse \"ANY_VALUE(%s)\" if you do not care about which value of \"%s\" you are selecting";
+				error += "\nEither add it to the GROUP BY list, or use \"ANY_VALUE(%s)\" if the exact value of \"%s\" "
+				         "is not important.";
 				throw BinderException(FormatError(bound_columns[0].query_location, error, bound_columns[0].name,
 				                                  bound_columns[0].name, bound_columns[0].name));
 			}

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -474,10 +474,11 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SelectNode &statement) {
 		} else if (statement.aggregate_handling == AggregateHandling::STANDARD_HANDLING) {
 			if (select_binder.HasBoundColumns()) {
 				auto &bound_columns = select_binder.GetBoundColumns();
-				throw BinderException(
-				    FormatError(bound_columns[0].query_location,
-				                "column \"%s\" must appear in the GROUP BY clause or be used in an aggregate function",
-				                bound_columns[0].name));
+				string error;
+				error = "column \"%s\" must appear in the GROUP BY clause or must be part of an aggregate function.";
+				error += "\nUse \"ANY_VALUE(%s)\" if you do not care about which value of \"%s\" you are selecting";
+				throw BinderException(FormatError(bound_columns[0].query_location, error, bound_columns[0].name,
+				                                  bound_columns[0].name, bound_columns[0].name));
 			}
 		}
 	}

--- a/test/sql/error/aggregate_order_by.test
+++ b/test/sql/error/aggregate_order_by.test
@@ -1,0 +1,16 @@
+# name: test/sql/error/aggregate_order_by.test
+# description: Use non-aggregated column in the ORDER BY clause
+# group: [error]
+
+statement ok
+CREATE TABLE lists_tbl AS SELECT i%20 as groups, [x + i for x in range(5)] AS l FROM range(1000) tmp(i);
+
+statement error
+SELECT COUNT(DISTINCT l) FROM lists_tbl group by groups order by l limit 10;
+----
+GROUP BY clause
+
+statement error
+SELECT DISTINCT ON(l) COUNT(DISTINCT l) FROM lists_tbl group by groups;
+----
+GROUP BY clause

--- a/test/sql/error/aggregate_order_by.test
+++ b/test/sql/error/aggregate_order_by.test
@@ -3,7 +3,7 @@
 # group: [error]
 
 statement ok
-CREATE TABLE lists_tbl AS SELECT i%20 as groups, [x + i for x in range(5)] AS l FROM range(1000) tmp(i);
+CREATE TABLE lists_tbl AS SELECT i%20 as groups, i AS l FROM range(1000) tmp(i);
 
 statement error
 SELECT COUNT(DISTINCT l) FROM lists_tbl group by groups order by l limit 10;


### PR DESCRIPTION
Fix #5149 

The error message now points to where the error is, which should clear up the ambiguity:


```sql
D CREATE TABLE lists_tbl AS SELECT i%20 as groups, i AS l FROM range(1000) tmp(i);
D SELECT COUNT(DISTINCT l) FROM lists_tbl group by groups order by l limit 10;
```
```
Binder Error: column "l" must appear in the GROUP BY clause or must be part of an aggregate function.
Either add it to the GROUP BY list, or use "ANY_VALUE(l)" if the exact value of "l" is not important.
LINE 1: ...ROM lists_tbl group by groups order by l limit 10;
                                                  ^
```

The actual error message is correct and clear in my opinion, adding an aggregate around `l` solves the problem, as does adding `l` to the `GROUP BY` list. 