### PR TITLE
[Python] Arrow Dataset type requirement is now less strict

### DIFF
--- a/tools/pythonpkg/src/arrow_array_stream.cpp
+++ b/tools/pythonpkg/src/arrow_array_stream.cpp
@@ -20,8 +20,7 @@ PyArrowObjectType GetArrowType(const py::handle &obj) {
 	auto scanner_class = import_cache.arrow.dataset.Scanner();
 	auto table_class = import_cache.arrow.lib.Table();
 	auto record_batch_reader_class = import_cache.arrow.lib.RecordBatchReader();
-	auto in_memory_dataset_class = import_cache.arrow.dataset.InMemoryDataset();
-	auto filesystem_dataset_class = import_cache.arrow.dataset.FileSystemDataset();
+	auto dataset_class = import_cache.arrow.dataset.Dataset();
 
 	if (py::isinstance(obj, scanner_class)) {
 		return PyArrowObjectType::Scanner;
@@ -29,10 +28,8 @@ PyArrowObjectType GetArrowType(const py::handle &obj) {
 		return PyArrowObjectType::Table;
 	} else if (py::isinstance(obj, record_batch_reader_class)) {
 		return PyArrowObjectType::RecordBatchReader;
-	} else if (py::isinstance(obj, in_memory_dataset_class)) {
-		return PyArrowObjectType::InMemoryDataset;
-	} else if (py::isinstance(obj, filesystem_dataset_class)) {
-		return PyArrowObjectType::FileSystemDataset;
+	} else if (py::isinstance(obj, dataset_class)) {
+		return PyArrowObjectType::Dataset;
 	}
 	return PyArrowObjectType::Invalid;
 }
@@ -88,8 +85,7 @@ unique_ptr<ArrowArrayStreamWrapper> PythonTableArrowArrayStreamFactory::Produce(
 		scanner = ProduceScanner(arrow_batch_scanner, record_batches, parameters, factory->config);
 		break;
 	}
-	case PyArrowObjectType::InMemoryDataset:
-	case PyArrowObjectType::FileSystemDataset: {
+	case PyArrowObjectType::Dataset: {
 		scanner = ProduceScanner(arrow_scanner, arrow_obj_handle, parameters, factory->config);
 		break;
 	}

--- a/tools/pythonpkg/src/include/duckdb_python/arrow_array_stream.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/arrow_array_stream.hpp
@@ -48,7 +48,7 @@ public:
 };
 } // namespace pyarrow
 
-enum class PyArrowObjectType { Invalid, Table, RecordBatchReader, Scanner, InMemoryDataset, FileSystemDataset };
+enum class PyArrowObjectType { Invalid, Table, RecordBatchReader, Scanner, Dataset };
 
 PyArrowObjectType GetArrowType(const py::handle &obj);
 

--- a/tools/pythonpkg/src/include/duckdb_python/python_import_cache.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/python_import_cache.hpp
@@ -86,14 +86,12 @@ public:
 	~ArrowDatasetCacheItem() override {
 	}
 	virtual void LoadSubtypes(PythonImportCache &cache) override {
-		FileSystemDataset.LoadAttribute("FileSystemDataset", cache, *this);
-		InMemoryDataset.LoadAttribute("InMemoryDataset", cache, *this);
+		Dataset.LoadAttribute("Dataset", cache, *this);
 		Scanner.LoadAttribute("Scanner", cache, *this);
 	}
 
 public:
-	PythonImportCacheItem FileSystemDataset;
-	PythonImportCacheItem InMemoryDataset;
+	PythonImportCacheItem Dataset;
 	PythonImportCacheItem Scanner;
 };
 

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -591,7 +591,7 @@ static unique_ptr<TableFunctionRef> TryReplacement(py::dict &dict, py::str &tabl
 
 		throw InvalidInputException(
 		    "Python Object \"%s\" of type \"%s\" found on line \"%s\" not suitable for replacement scans.\nMake sure "
-		    "that \"%s\" is either a pandas.DataFrame, or pyarrow Table, FileSystemDataset, InMemoryDataset, "
+		    "that \"%s\" is either a pandas.DataFrame, or pyarrow Table, Dataset, "
 		    "RecordBatchReader, or Scanner",
 		    cpp_table_name, py_object_type, location, cpp_table_name);
 	}
@@ -737,8 +737,7 @@ bool DuckDBPyConnection::IsAcceptedArrowObject(const py::object &object) {
 	auto &import_cache = *DuckDBPyConnection::ImportCache();
 	return import_cache.arrow.lib.Table.IsInstance(object) ||
 	       import_cache.arrow.lib.RecordBatchReader.IsInstance(object) ||
-	       import_cache.arrow.dataset.FileSystemDataset.IsInstance(object) ||
-	       import_cache.arrow.dataset.InMemoryDataset.IsInstance(object) ||
+	       import_cache.arrow.dataset.Dataset.IsInstance(object) ||
 	       import_cache.arrow.dataset.Scanner.IsInstance(object);
 }
 


### PR DESCRIPTION
This PR fixes #5163 

We were requiring the class of the dataset to be an InMemoryDataset or FileSystemDataset, which are not even part of the public API.
Now we loosened that requirement to just Dataset (which they both inherit from)