### PR TITLE
Fix progress bar of regular table scan

### DIFF
--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -37,7 +37,7 @@ static storage_t GetStorageIndex(TableCatalogEntry &table, column_t column_id) {
 }
 
 struct TableScanGlobalState : public GlobalTableFunctionState {
-	TableScanGlobalState(ClientContext &context, const FunctionData *bind_data_p) {
+	TableScanGlobalState(ClientContext &context, const FunctionData *bind_data_p) : row_count(0) {
 		D_ASSERT(bind_data_p);
 		auto &bind_data = (const TableScanBindData &)*bind_data_p;
 		max_threads = bind_data.table->storage->MaxThreads(context);
@@ -46,6 +46,8 @@ struct TableScanGlobalState : public GlobalTableFunctionState {
 	ParallelTableScanState state;
 	mutex lock;
 	idx_t max_threads;
+	//! How many rows we already scanned
+	atomic<idx_t> row_count;
 
 	vector<idx_t> projection_ids;
 	vector<LogicalType> scanned_types;
@@ -125,6 +127,7 @@ static void TableScanFunc(ClientContext &context, TableFunctionInput &data_p, Da
 			bind_data.table->storage->Scan(transaction, output, state.scan_state);
 		}
 		if (output.size() > 0) {
+			gstate.row_count += output.size();
 			return;
 		}
 		if (!TableScanParallelStateNext(context, data_p.bind_data, data_p.local_state, data_p.global_state)) {
@@ -144,14 +147,15 @@ bool TableScanParallelStateNext(ClientContext &context, const FunctionData *bind
 }
 
 double TableScanProgress(ClientContext &context, const FunctionData *bind_data_p,
-                         const GlobalTableFunctionState *gstate) {
+                         const GlobalTableFunctionState *gstate_p) {
 	auto &bind_data = (TableScanBindData &)*bind_data_p;
+	auto &gstate = (TableScanGlobalState &)*gstate_p;
 	idx_t total_rows = bind_data.table->storage->GetTotalRows();
-	if (total_rows == 0 || total_rows < STANDARD_VECTOR_SIZE) {
+	if (total_rows == 0) {
 		//! Table is either empty or smaller than a vector size, so it is finished
 		return 100;
 	}
-	auto percentage = double(bind_data.chunk_count * STANDARD_VECTOR_SIZE * 100.0) / total_rows;
+	auto percentage = 100 * (double(gstate.row_count) / total_rows);
 	if (percentage > 100) {
 		//! In case the last chunk has less elements than STANDARD_VECTOR_SIZE, if our percentage is over 100
 		//! It means we finished this table.
@@ -394,7 +398,6 @@ string TableScanToString(const FunctionData *bind_data_p) {
 static void TableScanSerialize(FieldWriter &writer, const FunctionData *bind_data_p, const TableFunction &function) {
 	auto &bind_data = (TableScanBindData &)*bind_data_p;
 
-	D_ASSERT(bind_data.chunk_count == 0);
 	writer.WriteString(bind_data.table->schema->name);
 	writer.WriteString(bind_data.table->name);
 	writer.WriteField<bool>(bind_data.is_index_scan);

--- a/src/include/duckdb/function/table/table_scan.hpp
+++ b/src/include/duckdb/function/table/table_scan.hpp
@@ -15,8 +15,7 @@ namespace duckdb {
 class TableCatalogEntry;
 
 struct TableScanBindData : public TableFunctionData {
-	explicit TableScanBindData(TableCatalogEntry *table)
-	    : table(table), is_index_scan(false), is_create_index(false) {
+	explicit TableScanBindData(TableCatalogEntry *table) : table(table), is_index_scan(false), is_create_index(false) {
 	}
 
 	//! The table to scan

--- a/src/include/duckdb/function/table/table_scan.hpp
+++ b/src/include/duckdb/function/table/table_scan.hpp
@@ -16,7 +16,7 @@ class TableCatalogEntry;
 
 struct TableScanBindData : public TableFunctionData {
 	explicit TableScanBindData(TableCatalogEntry *table)
-	    : table(table), is_index_scan(false), is_create_index(false), chunk_count(0) {
+	    : table(table), is_index_scan(false), is_create_index(false) {
 	}
 
 	//! The table to scan
@@ -28,9 +28,6 @@ struct TableScanBindData : public TableFunctionData {
 	bool is_create_index;
 	//! The row ids to fetch (in case of an index scan)
 	vector<row_t> result_ids;
-
-	//! How many chunks we already scanned
-	atomic<idx_t> chunk_count;
 
 public:
 	bool Equals(const FunctionData &other_p) const override {


### PR DESCRIPTION
Correctly increment the progress bar again - and use row count instead of chunk count.