### PR TITLE
Support parallel (batch) insertion into tables that have indexes

### DIFF
--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -248,7 +248,7 @@ public:
 	idx_t current_index;
 	TableAppendState current_append_state;
 	unique_ptr<RowGroupCollection> current_collection;
-	unique_ptr<OptimisticDataWriter> writer;
+	OptimisticDataWriter *writer;
 	bool written_to_disk;
 
 	void FlushToDisk() {
@@ -298,16 +298,17 @@ SinkResultType PhysicalBatchInsert::Sink(ExecutionContext &context, GlobalSinkSt
 	PhysicalInsert::ResolveDefaults(table, chunk, column_index_map, lstate.default_executor, lstate.insert_chunk);
 
 	if (!lstate.current_collection) {
+		lock_guard<mutex> l(gstate.lock);
 		// no collection yet: create a new one
 		lstate.CreateNewCollection(table, insert_types);
-		lstate.writer = make_unique<OptimisticDataWriter>(gstate.table->storage.get());
+		lstate.writer = gstate.table->storage->CreateOptimisticWriter(context.client);
 	} else if (lstate.current_index != lstate.batch_index) {
 		// batch index has changed: move the old collection to the global state and create a new collection
 		TransactionData tdata(0, 0);
 		lstate.current_collection->FinalizeAppend(tdata, lstate.current_append_state);
 		lstate.FlushToDisk();
 
-		gstate.AddCollection(context.client, lstate.current_index, move(lstate.current_collection), lstate.writer.get(),
+		gstate.AddCollection(context.client, lstate.current_index, move(lstate.current_collection), lstate.writer,
 		                     &lstate.written_to_disk);
 		lstate.CreateNewCollection(table, insert_types);
 	}
@@ -377,7 +378,7 @@ SinkFinalizeType PhysicalBatchInsert::Finalize(Pipeline &pipeline, Event &event,
 	// now that we have created all of the mergers, perform the actual merging
 	vector<unique_ptr<RowGroupCollection>> final_collections;
 	final_collections.reserve(mergers.size());
-	auto writer = make_unique<OptimisticDataWriter>(&storage);
+	auto writer = storage.CreateOptimisticWriter(context);
 	for (auto &merger : mergers) {
 		final_collections.push_back(merger->Flush(*writer));
 	}

--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -69,7 +69,7 @@ public:
 	ExpressionExecutor default_executor;
 	TableAppendState local_append_state;
 	unique_ptr<RowGroupCollection> local_collection;
-	unique_ptr<OptimisticDataWriter> writer;
+	OptimisticDataWriter *writer;
 };
 
 unique_ptr<GlobalSinkState> PhysicalInsert::GetGlobalSinkState(ClientContext &context) const {
@@ -148,13 +148,14 @@ SinkResultType PhysicalInsert::Sink(ExecutionContext &context, GlobalSinkState &
 		D_ASSERT(!return_chunk);
 		// parallel append
 		if (!lstate.local_collection) {
+			lock_guard<mutex> l(gstate.lock);
 			auto &table_info = table->storage->info;
 			auto &block_manager = TableIOManager::Get(*table->storage).GetBlockManagerForRowData();
 			lstate.local_collection =
 			    make_unique<RowGroupCollection>(table_info, block_manager, insert_types, MAX_ROW_ID);
 			lstate.local_collection->InitializeEmpty();
 			lstate.local_collection->InitializeAppend(lstate.local_append_state);
-			lstate.writer = make_unique<OptimisticDataWriter>(gstate.table->storage.get());
+			lstate.writer = gstate.table->storage->CreateOptimisticWriter(context.client);
 		}
 		table->storage->VerifyAppendConstraints(*table, context.client, lstate.insert_chunk);
 		auto new_row_group = lstate.local_collection->Append(lstate.insert_chunk, lstate.local_append_state);

--- a/src/execution/physical_plan/plan_insert.cpp
+++ b/src/execution/physical_plan/plan_insert.cpp
@@ -53,11 +53,6 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalInsert &op
 
 	bool parallel_streaming_insert = !PreserveInsertionOrder(*plan);
 	bool use_batch_index = UseBatchIndex(*plan);
-	if (!op.table->storage->info->indexes.Empty()) {
-		// not for tables with indexes currently
-		parallel_streaming_insert = false;
-		use_batch_index = false;
-	}
 	if (op.return_chunk) {
 		// not supported for RETURNING (yet?)
 		parallel_streaming_insert = false;

--- a/src/include/duckdb/storage/block_manager.hpp
+++ b/src/include/duckdb/storage/block_manager.hpp
@@ -38,6 +38,8 @@ public:
 	virtual block_id_t GetFreeBlockId() = 0;
 	//! Returns whether or not a specified block is the root block
 	virtual bool IsRootBlock(block_id_t root) = 0;
+	//! Mark a block as "free"; free blocks are immediately added to the free list and can be immediately overwritten
+	virtual void MarkBlockAsFree(block_id_t block_id) = 0;
 	//! Mark a block as "modified"; modified blocks are added to the free list after a checkpoint (i.e. their data is
 	//! assumed to be rewritten)
 	virtual void MarkBlockAsModified(block_id_t block_id) = 0;

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -28,6 +28,7 @@ class ClientContext;
 class ColumnDataCollection;
 class ColumnDefinition;
 class DataTable;
+class OptimisticDataWriter;
 class RowGroup;
 class StorageManager;
 class TableCatalogEntry;
@@ -96,6 +97,8 @@ public:
 	void LocalAppend(TableCatalogEntry &table, ClientContext &context, ColumnDataCollection &collection);
 	//! Merge a row group collection into the transaction-local storage
 	void LocalMerge(ClientContext &context, RowGroupCollection &collection);
+	//! Creates an optimistic writer for this table - used for optimistically writing parallel appends
+	OptimisticDataWriter *CreateOptimisticWriter(ClientContext &context);
 
 	//! Delete the entries with the specified row identifier from the table
 	idx_t Delete(TableCatalogEntry &table, ClientContext &context, Vector &row_ids, idx_t count);

--- a/src/include/duckdb/storage/in_memory_block_manager.hpp
+++ b/src/include/duckdb/storage/in_memory_block_manager.hpp
@@ -29,6 +29,9 @@ public:
 	bool IsRootBlock(block_id_t root) override {
 		throw InternalException("Cannot perform IO in in-memory database!");
 	}
+	void MarkBlockAsFree(block_id_t block_id) override {
+		throw InternalException("Cannot perform IO in in-memory database!");
+	}
 	void MarkBlockAsModified(block_id_t block_id) override {
 		throw InternalException("Cannot perform IO in in-memory database!");
 	}

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -33,7 +33,9 @@ public:
 	block_id_t GetFreeBlockId() override;
 	//! Returns whether or not a specified block is the root block
 	bool IsRootBlock(block_id_t root) override;
-	//! Mark a block as modified
+	//! Mark a block as free (immediately re-writeable)
+	void MarkBlockAsFree(block_id_t block_id) override;
+	//! Mark a block as modified (re-writeable after a checkpoint)
 	void MarkBlockAsModified(block_id_t block_id) override;
 	//! Increase the reference count of a block. The block should hold at least one reference
 	void IncreaseBlockReferenceCount(block_id_t block_id) override;

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -80,6 +80,8 @@ public:
 
 	void AppendToIndexes(Transaction &transaction, TableAppendState &append_state, idx_t append_count,
 	                     bool append_to_table);
+	bool AppendToIndexes(Transaction &transaction, RowGroupCollection &source, TableIndexList &index_list,
+	                     const vector<LogicalType> &table_types, row_t &start_row);
 };
 
 class LocalTableManager {

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -66,8 +66,10 @@ public:
 	TableIndexList indexes;
 	//! The number of deleted rows
 	idx_t deleted_rows;
-	//! The optimistic data writer
+	//! The main optimistic data writer
 	OptimisticDataWriter optimistic_writer;
+	//! The set of all optimistic data writers associated with this table
+	vector<unique_ptr<OptimisticDataWriter>> optimistic_writers;
 
 public:
 	void InitializeScan(CollectionScanState &state, TableFilterSet *table_filters = nullptr);
@@ -82,6 +84,9 @@ public:
 	                     bool append_to_table);
 	bool AppendToIndexes(Transaction &transaction, RowGroupCollection &source, TableIndexList &index_list,
 	                     const vector<LogicalType> &table_types, row_t &start_row);
+
+	//! Creates an optimistic writer for this table
+	OptimisticDataWriter *CreateOptimisticWriter();
 };
 
 class LocalTableManager {
@@ -133,6 +138,8 @@ public:
 	static void FinalizeAppend(LocalAppendState &state);
 	//! Merge a row group collection into the transaction-local storage
 	void LocalMerge(DataTable *table, RowGroupCollection &collection);
+	//! Create an optimistic writer for the specified table
+	OptimisticDataWriter *CreateOptimisticWriter(DataTable *table);
 
 	//! Delete a set of rows from the local storage
 	idx_t Delete(DataTable *table, Vector &row_ids, idx_t count);

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -499,6 +499,11 @@ void DataTable::FinalizeLocalAppend(LocalAppendState &state) {
 	LocalStorage::FinalizeAppend(state);
 }
 
+OptimisticDataWriter *DataTable::CreateOptimisticWriter(ClientContext &context) {
+	auto &local_storage = LocalStorage::Get(context);
+	return local_storage.CreateOptimisticWriter(this);
+}
+
 void DataTable::LocalMerge(ClientContext &context, RowGroupCollection &collection) {
 	auto &local_storage = LocalStorage::Get(context);
 	local_storage.LocalMerge(this, collection);

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -235,6 +235,14 @@ block_id_t SingleFileBlockManager::GetFreeBlockId() {
 	return block;
 }
 
+void SingleFileBlockManager::MarkBlockAsFree(block_id_t block_id) {
+	lock_guard<mutex> lock(block_lock);
+	D_ASSERT(block_id >= 0);
+	D_ASSERT(free_list.find(block_id) == free_list.end());
+	multi_use_blocks.erase(block_id);
+	free_list.insert(block_id);
+}
+
 void SingleFileBlockManager::MarkBlockAsModified(block_id_t block_id) {
 	lock_guard<mutex> lock(block_lock);
 	D_ASSERT(block_id >= 0);

--- a/test/sql/insert/parallel_insert_index.test_slow
+++ b/test/sql/insert/parallel_insert_index.test_slow
@@ -1,0 +1,125 @@
+# name: test/sql/insert/parallel_insert_index.test
+# description: Test that parallel data insertion correctly verifies primary/unique key constraints
+# group: [insert]
+
+statement ok
+CREATE TABLE integers AS SELECT i FROM generate_series(0,999999,1) tbl(i);
+
+loop i 0 2
+
+#######################################################
+# case 1: batch insert followed by constraint violation
+#######################################################
+statement ok
+CREATE TABLE integers2(i INTEGER PRIMARY KEY);
+
+statement ok
+INSERT INTO integers2 SELECT i FROM integers;
+
+statement error
+INSERT INTO integers2 VALUES (42);
+----
+violates primary key constraint
+
+query I
+SELECT * FROM integers2 WHERE i=999
+----
+999
+
+query III
+SELECT SUM(i), COUNT(*), COUNT(i) FROM integers;
+----
+499999500000	1000000	1000000
+
+query III
+SELECT SUM(i), COUNT(*), COUNT(i) FROM integers2;
+----
+499999500000	1000000	1000000
+
+statement ok
+DROP TABLE integers2;
+
+#######################################################
+# case 2: constraint violation during batch insertion
+#######################################################
+
+statement ok
+CREATE TABLE integers2(i INTEGER PRIMARY KEY);
+
+statement ok
+INSERT INTO integers2 VALUES (999999)
+
+statement error
+INSERT INTO integers2 SELECT i FROM integers;
+----
+violates primary key constraint
+
+query I
+SELECT COUNT(*) FROM integers2
+----
+1
+
+statement ok
+DROP TABLE integers2;
+
+#######################################################
+# case 3: batch insert followed by constraint violation in transaction local data
+#######################################################
+statement ok
+CREATE TABLE integers2(i INTEGER PRIMARY KEY);
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+INSERT INTO integers2 SELECT i FROM integers;
+
+statement error
+INSERT INTO integers2 VALUES (42);
+----
+PRIMARY KEY or UNIQUE constraint violated
+
+statement ok
+ROLLBACK
+
+query I
+SELECT COUNT(*) FROM integers2
+----
+0
+
+statement ok
+DROP TABLE integers2;
+
+#######################################################
+# case 4: constraint violation during batch insertion in transaction local data
+#######################################################
+statement ok
+CREATE TABLE integers2(i INTEGER PRIMARY KEY);
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+INSERT INTO integers2 VALUES (999999)
+
+statement error
+INSERT INTO integers2 SELECT i FROM integers;
+----
+PRIMARY KEY or UNIQUE constraint violated
+
+statement ok
+ROLLBACK
+
+query I
+SELECT COUNT(*) FROM integers2
+----
+0
+
+statement ok
+DROP TABLE integers2;
+
+# repeat for non-insertion order preserving data
+statement ok
+SET preserve_insertion_order=false
+
+endloop

--- a/test/sql/insert/parallel_insert_index.test_slow
+++ b/test/sql/insert/parallel_insert_index.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/insert/parallel_insert_index.test
+# name: test/sql/insert/parallel_insert_index.test_slow
 # description: Test that parallel data insertion correctly verifies primary/unique key constraints
 # group: [insert]
 

--- a/test/sql/storage/parallel/reclaim_space_batch_insert.test_slow
+++ b/test/sql/storage/parallel/reclaim_space_batch_insert.test_slow
@@ -7,7 +7,10 @@ require parquet
 load __TEST_DIR__/reclaim_space_batch_insert.db
 
 statement ok
-CREATE TABLE integers AS SELECT * FROM range(10000000) t(i)
+COPY (FROM range(10000000) t(i)) TO '__TEST_DIR__/integers.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 200000)
+
+statement ok
+CREATE VIEW integers AS FROM '__TEST_DIR__/integers.parquet'
 
 statement ok
 CREATE TABLE integers2(i INTEGER PRIMARY KEY)
@@ -22,9 +25,6 @@ violates primary key constraint
 
 statement ok
 CREATE TABLE block_count(count int)
-
-statement ok
-insert into block_count select total_blocks from pragma_database_size();
 
 loop i 0 10
 
@@ -68,10 +68,10 @@ SELECT COUNT(*)-${i} FROM integers2
 ----
 2
 
-endloop
-
 # ensure there is a small diff between min and max block counts
 query I
 select (max(count)-min(count))<20 from block_count
 ----
 true
+
+endloop

--- a/test/sql/storage/parallel/reclaim_space_batch_insert.test_slow
+++ b/test/sql/storage/parallel/reclaim_space_batch_insert.test_slow
@@ -1,0 +1,80 @@
+# name: test/sql/storage/parallel/reclaim_space_batch_insert.test_slow
+# description: Test space reclamation of
+# group: [parallel]
+
+require parquet
+
+statement ok
+SET preserve_insertion_order=false
+
+load __TEST_DIR__/reclaim_space_batch_insert.db
+
+statement ok
+CREATE TABLE integers AS SELECT * FROM range(10000000) t(i)
+
+statement ok
+CREATE TABLE integers2(i INTEGER PRIMARY KEY)
+
+statement ok
+INSERT INTO integers2 VALUES (9999999)
+
+statement error
+INSERT INTO integers2 SELECT * FROM integers
+----
+violates primary key constraint
+
+statement ok
+CREATE TABLE block_count(count int)
+
+statement ok
+insert into block_count select total_blocks from pragma_database_size();
+
+loop i 0 10
+
+# conflict with base table data
+statement error
+INSERT INTO integers2 SELECT * FROM integers
+----
+violates primary key constraint
+
+# conflict with transaction local data
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+INSERT INTO integers2 VALUES (9999998);
+
+statement error
+INSERT INTO integers2 SELECT * FROM integers WHERE i<=9999998
+----
+PRIMARY KEY or UNIQUE constraint violated
+
+statement ok
+ROLLBACK
+
+query I
+SELECT COUNT(*)-${i} FROM integers2
+----
+1
+
+statement ok
+INSERT INTO integers2 VALUES (10000000 + ${i})
+
+statement ok
+CHECKPOINT;
+
+statement ok
+insert into block_count select total_blocks from pragma_database_size();
+
+query I
+SELECT COUNT(*)-${i} FROM integers2
+----
+2
+
+endloop
+
+# ensure there is a small diff between min and max block counts
+query I
+select (max(count)-min(count))<20 from block_count
+----
+true

--- a/test/sql/storage/parallel/reclaim_space_parallel_insert.test_slow
+++ b/test/sql/storage/parallel/reclaim_space_parallel_insert.test_slow
@@ -1,10 +1,13 @@
-# name: test/sql/storage/parallel/reclaim_space_batch_insert.test_slow
+# name: test/sql/storage/parallel/reclaim_space_parallel_insert.test_slow
 # description: Test space reclamation of optimistic writing with failures
 # group: [parallel]
 
 require parquet
 
-load __TEST_DIR__/reclaim_space_batch_insert.db
+load __TEST_DIR__/reclaim_space_parallel_insert.db
+
+statement ok
+SET preserve_insertion_order=false
 
 statement ok
 CREATE TABLE integers AS SELECT * FROM range(10000000) t(i)

--- a/test/sql/storage/parallel/reclaim_space_parallel_insert.test_slow
+++ b/test/sql/storage/parallel/reclaim_space_parallel_insert.test_slow
@@ -2,8 +2,6 @@
 # description: Test space reclamation of optimistic writing with failures
 # group: [parallel]
 
-require parquet
-
 load __TEST_DIR__/reclaim_space_parallel_insert.db
 
 statement ok
@@ -25,9 +23,6 @@ violates primary key constraint
 
 statement ok
 CREATE TABLE block_count(count int)
-
-statement ok
-insert into block_count select total_blocks from pragma_database_size();
 
 loop i 0 10
 
@@ -71,10 +66,10 @@ SELECT COUNT(*)-${i} FROM integers2
 ----
 2
 
-endloop
-
 # ensure there is a small diff between min and max block counts
 query I
 select (max(count)-min(count))<20 from block_count
 ----
 true
+
+endloop


### PR DESCRIPTION
When inserting into tables that have indexes, we perform a scan over the (batch) inserted data after the insertion and construct the index (in a single-threaded manner currently). In the future we should improve this by constructing the index in parallel and merging it into the main index. 

This PR also fixes two issues with the optimistic writing:
* For the parallel batch insert, we now correctly mark blocks as free to be overwritten if the insertion is rolled back
* We mark the blocks that are optimistically written as **free** instead of as **modified**. This distinction is made because the optimistically written data can be re-used immediately - we do not need to wait until a checkpoint to re-use the blocks.

CC @jkub for the last feature we add a new method to the block manager - `MarkBlockAsFree`. 