### PR TITLE
Update OpenSSL to 1.1.1s

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -90,25 +90,25 @@ jobs:
         aws --version
 
       # the weird openssl findreplace fix with version numbers is from: https://github.com/h2o/h2o/issues/213
-    - name: Download OpenSSL 1.1.1k
+    - name: Download OpenSSL 1.1.1s
       shell: bash
       run: |
-        wget https://github.com/openssl/openssl/archive/refs/tags/OpenSSL_1_1_1k.tar.gz
-        tar -xzvf OpenSSL_1_1_1k.tar.gz
-        mv openssl-OpenSSL_1_1_1k openssl-1.1.1k
-        cd openssl-1.1.1k
+        wget https://github.com/openssl/openssl/archive/refs/tags/OpenSSL_1_1_1s.tar.gz
+        tar -xzvf OpenSSL_1_1_1s.tar.gz
+        mv openssl-OpenSSL_1_1_1s openssl-1.1.1s
+        cd openssl-1.1.1s
         find ./ -type f -exec sed -i -e 's/\#\ define\ OPENSSL\_VERSION\_NUMBER/\#define\ OPENSSL\_VERSION\_NUMBER/g' {} \;
 
     - name: Configure OpenSSL
       shell: bash
       run: |
-        cd openssl-1.1.1k
+        cd openssl-1.1.1s
         ./config --prefix=/usr --openssldir=/etc/ssl --libdir=lib no-shared zlib-dynamic
 
     - name: Build OpenSSL
       shell: bash
       run: |
-        cd openssl-1.1.1k
+        cd openssl-1.1.1s
         make
         make install
 


### PR DESCRIPTION
Update OpenSSL to 1.1.1s release for GitHub Python workflow.

(Unable to test this locally, please verify)