### PR TITLE
Optimize String Split

### DIFF
--- a/benchmark/micro/list/string_split.benchmark
+++ b/benchmark/micro/list/string_split.benchmark
@@ -1,0 +1,20 @@
+# name: benchmark/micro/list/string_split.benchmark
+# description: String split benchmark
+# group: [list]
+
+name String Split
+group micro
+subgroup list
+
+require tpch
+
+cache tpch_sf1
+
+load
+CALL dbgen(sf=1);
+
+run
+SELECT SUM(LENGTH(str_split(l_comment, ' '))) FROM lineitem
+
+result I
+27124176

--- a/benchmark/micro/list/string_split_regexp.benchmark
+++ b/benchmark/micro/list/string_split_regexp.benchmark
@@ -1,0 +1,20 @@
+# name: benchmark/micro/list/string_split_regexp.benchmark
+# description: String split regexp benchmark
+# group: [list]
+
+name String Split Regexp
+group micro
+subgroup list
+
+require tpch
+
+cache tpch_sf1
+
+load
+CALL dbgen(sf=1);
+
+run
+SELECT SUM(LENGTH(str_split_regex(l_comment, '[z ]'))) FROM lineitem
+
+result I
+27186473

--- a/benchmark/micro/list/string_split_unicode.benchmark
+++ b/benchmark/micro/list/string_split_unicode.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/list/string_split_unicode.benchmark
+# description: String split unicode benchmark
+# group: [list]
+
+name String Split Unicode
+group micro
+subgroup list
+
+require tpch
+
+load
+CALL dbgen(sf=1);
+CREATE TABLE duck_comments AS SELECT concat(l_comment, '🦆') l_comment FROM lineitem
+
+run
+SELECT SUM(LENGTH(str_split(l_comment, ' '))) FROM duck_comments
+
+result I
+27124176

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1704,6 +1704,15 @@ idx_t ListVector::GetListSize(const Vector &vec) {
 	return ((VectorListBuffer &)*vec.auxiliary).size;
 }
 
+idx_t ListVector::GetListCapacity(const Vector &vec) {
+	if (vec.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		auto &child = DictionaryVector::Child(vec);
+		return ListVector::GetListSize(child);
+	}
+	D_ASSERT(vec.auxiliary);
+	return ((VectorListBuffer &)*vec.auxiliary).capacity;
+}
+
 void ListVector::ReferenceEntry(Vector &vector, Vector &other) {
 	D_ASSERT(vector.GetType().id() == LogicalTypeId::LIST);
 	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR ||

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -36,18 +36,7 @@ static inline duckdb_re2::StringPiece CreateStringPiece(string_t &input) {
 	return duckdb_re2::StringPiece(input.GetDataUnsafe(), input.GetSize());
 }
 
-struct RegexLocalState : public FunctionLocalState {
-	explicit RegexLocalState(RegexpBaseBindData &info)
-	    : constant_pattern(duckdb_re2::StringPiece(info.constant_string.c_str(), info.constant_string.size()),
-	                       info.options) {
-		D_ASSERT(info.constant_pattern);
-	}
-
-	RE2 constant_pattern;
-};
-
-static unique_ptr<FunctionLocalState> RegexInitLocalState(const BoundFunctionExpression &expr,
-                                                          FunctionData *bind_data) {
+unique_ptr<FunctionLocalState> RegexInitLocalState(const BoundFunctionExpression &expr, FunctionData *bind_data) {
 	auto &info = (RegexpBaseBindData &)*bind_data;
 	if (info.constant_pattern) {
 		return make_unique<RegexLocalState>(info);
@@ -154,8 +143,8 @@ unique_ptr<FunctionData> RegexpMatchesBindData::Copy() const {
 	                                          range_success);
 }
 
-static unique_ptr<FunctionData> RegexpMatchesBind(ClientContext &context, ScalarFunction &bound_function,
-                                                  vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> RegexpMatchesBind(ClientContext &context, ScalarFunction &bound_function,
+                                           vector<unique_ptr<Expression>> &arguments) {
 	// pattern is the second argument. If its constant, we can already prepare the pattern and store it for later.
 	D_ASSERT(arguments.size() == 2 || arguments.size() == 3);
 	RE2::Options options;

--- a/src/function/scalar/string/string_split.cpp
+++ b/src/function/scalar/string/string_split.cpp
@@ -81,7 +81,7 @@ struct StringSplitter {
 			if (match_size == 0 && pos == 0) {
 				// special case: 0 length match and pos is 0
 				// move to the next character
-				for(pos++; pos < input_size; pos++) {
+				for (pos++; pos < input_size; pos++) {
 					if (LengthFun::IsCharacter(input_data[pos])) {
 						break;
 					}

--- a/src/function/scalar/string/string_split.cpp
+++ b/src/function/scalar/string/string_split.cpp
@@ -1,13 +1,8 @@
 #include "duckdb/common/exception.hpp"
-#include "duckdb/common/pair.hpp"
-#include "duckdb/common/types/chunk_collection.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/vector_size.hpp"
 #include "duckdb/function/scalar/regexp.hpp"
-#include "duckdb/function/scalar/string_functions.hpp"
-#include "utf8proc.hpp"
-#include "utf8proc_wrapper.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
 
 namespace duckdb {
@@ -86,7 +81,11 @@ struct StringSplitter {
 			if (match_size == 0 && pos == 0) {
 				// special case: 0 length match and pos is 0
 				// move to the next character
-				pos = utf8proc_next_grapheme(input_data, input_size, 0);
+				for(pos++; pos < input_size; pos++) {
+					if (LengthFun::IsCharacter(input_data[pos])) {
+						break;
+					}
+				}
 				if (pos == input_size) {
 					break;
 				}

--- a/src/function/scalar/string/string_split.cpp
+++ b/src/function/scalar/string/string_split.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/vector_size.hpp"
 #include "duckdb/function/scalar/regexp.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 
 namespace duckdb {
 
@@ -184,7 +185,7 @@ void StringSplitFun::RegisterFunction(BuiltinFunctions &set) {
 	                         FunctionSideEffects::NO_SIDE_EFFECTS, FunctionNullHandling::SPECIAL_HANDLING);
 	regexp_split.AddFunction(regex_fun);
 	// regexp options
-	regex_fun.arguments.push_back(LogicalType::VARCHAR);
+	regex_fun.arguments.emplace_back(LogicalType::VARCHAR);
 	regexp_split.AddFunction(regex_fun);
 	for (auto &name : {"string_split_regex", "str_split_regex", "regexp_split_to_array"}) {
 		regexp_split.name = name;

--- a/src/function/scalar/string/string_split.cpp
+++ b/src/function/scalar/string/string_split.cpp
@@ -8,186 +8,103 @@
 #include "duckdb/function/scalar/string_functions.hpp"
 #include "utf8proc.hpp"
 #include "utf8proc_wrapper.hpp"
+#include "duckdb/function/scalar/string_functions.hpp"
 
 namespace duckdb {
 
-struct StringSplitIterator {
-public:
-	explicit StringSplitIterator(idx_t size) : size(size) {
-	}
-	virtual ~StringSplitIterator() {
+struct StringSplitInput {
+	StringSplitInput(Vector &result_list, Vector &result_child, idx_t offset)
+	    : result_list(result_list), result_child(result_child), offset(offset) {
 	}
 
-	idx_t size;
+	Vector &result_list;
+	Vector &result_child;
+	idx_t offset;
 
-public:
-	virtual idx_t Next(const char *input) = 0;
-	bool HasNext() {
-		return offset < size;
+	void AddSplit(const char *split_data, idx_t split_size, idx_t list_idx) {
+		auto list_entry = offset + list_idx;
+		if (list_entry >= ListVector::GetListCapacity(result_list)) {
+			ListVector::SetListSize(result_list, offset + list_idx);
+			ListVector::Reserve(result_list, ListVector::GetListCapacity(result_list) * 2);
+		}
+		FlatVector::GetData<string_t>(result_child)[list_entry] =
+		    StringVector::AddString(result_child, split_data, split_size);
 	}
-	idx_t Start() {
-		return start;
-	}
-
-protected:
-	idx_t start = 0;  // end of last place a delim match was found
-	idx_t offset = 0; // current position
 };
 
-struct AsciiStringSplitIterator : virtual public StringSplitIterator {
-public:
-	AsciiStringSplitIterator(size_t size, const char *delim, const size_t delim_size)
-	    : StringSplitIterator(size), delim(delim), delim_size(delim_size) {
+struct RegularStringSplit {
+	static idx_t Find(const char *input_data, idx_t input_size, const char *delim_data, idx_t delim_size,
+	                  idx_t &match_size, void *data) {
+		match_size = delim_size;
+		return ContainsFun::Find((const unsigned char *)input_data, input_size, (const unsigned char *)delim_data,
+		                         delim_size);
 	}
-	idx_t Next(const char *input) override {
-		// special case: separate by empty delimiter
-		if (delim_size == 0) {
-			offset++;
-			start = offset;
-			return offset;
-		}
-		for (offset = start; HasNext(); offset++) {
-			// potential delimiter match
-			if (input[offset] == delim[0] && offset + delim_size <= size) {
-				idx_t i;
-				for (i = 1; i < delim_size; i++) {
-					if (input[offset + i] != delim[i]) {
-						break;
-					}
-				}
-				// delimiter found: skip start over delimiter
-				if (i == delim_size) {
-					start = offset + delim_size;
-					return offset;
-				}
-			}
-		}
-		return offset;
-	}
-
-protected:
-	const char *delim;
-	size_t delim_size;
 };
 
-struct UnicodeStringSplitIterator : virtual public StringSplitIterator {
-public:
-	UnicodeStringSplitIterator(size_t input_size, const char *delim, const size_t delim_size)
-	    : StringSplitIterator(input_size), delim_size(delim_size) {
-		int cp_sz;
-		for (idx_t i = 0; i < delim_size; i += cp_sz) {
-			delim_cps.push_back(utf8proc_codepoint(delim, cp_sz));
-		}
-	}
-	idx_t Next(const char *input) override {
-		// special case: separate by empty delimiter
-		if (delim_size == 0) {
-			offset = utf8proc_next_grapheme(input, size, offset);
-			start = offset;
-			return offset;
-		}
-		int cp_sz;
-		for (offset = start; HasNext(); offset = utf8proc_next_grapheme(input, size, offset)) {
-			// potential delimiter match
-			if (utf8proc_codepoint(&input[offset], cp_sz) == delim_cps[0] && offset + delim_size <= size) {
-				idx_t delim_offset = cp_sz;
-				for (idx_t i = 1; i < delim_cps.size(); i++) {
-					if (utf8proc_codepoint(&input[offset + delim_offset], cp_sz) != delim_cps[i]) {
-						break;
-					}
-					delim_offset += cp_sz;
-				}
-				// delimiter found: skip start over delimiter
-				if (delim_offset == delim_size) {
-					start = offset + delim_size;
-					return offset;
-				}
-			}
-		}
-		return offset;
-	}
-
-protected:
-	vector<utf8proc_int32_t> delim_cps;
-	size_t delim_size;
-};
-
-struct RegexStringSplitIterator : virtual public StringSplitIterator {
-public:
-	RegexStringSplitIterator(size_t input_size, unique_ptr<RE2> re, const bool ascii_only)
-	    : StringSplitIterator(input_size), re(move(re)), ascii_only(ascii_only) {
-	}
-	idx_t Next(const char *input) override {
-		duckdb_re2::StringPiece input_sp(input, size);
+struct ConstantRegexpStringSplit {
+	static idx_t Find(const char *input_data, idx_t input_size, const char *delim_data, idx_t delim_size,
+	                  idx_t &match_size, void *data) {
+		D_ASSERT(data);
+		auto regex = (duckdb_re2::RE2 *)data;
 		duckdb_re2::StringPiece match;
-		if (re->Match(input_sp, start, size, RE2::UNANCHORED, &match, 1)) {
-			offset = match.data() - input;
-			// special case: 0 length match
-			if (match.empty() && start < size) {
-				if (ascii_only) {
-					offset++;
-				} else {
-					offset = utf8proc_next_grapheme(input, size, offset);
-				}
-				start = offset;
-			} else {
-				start = offset + match.size();
-			}
-		} else {
-			offset = size;
+		if (!regex->Match(duckdb_re2::StringPiece(input_data, input_size), 0, input_size, RE2::UNANCHORED, &match, 1)) {
+			return DConstants::INVALID_INDEX;
 		}
-		return offset;
+		match_size = match.size();
+		return match.data() - input_data;
 	}
-
-protected:
-	unique_ptr<RE2> re;
-	bool ascii_only;
 };
 
-void BaseStringSplitFunction(const char *input, StringSplitIterator &iter, Vector &result) {
-	// special case: empty string
-	if (iter.size == 0) {
-		Value val = StringVector::AddString(ListVector::GetEntry(result), &input[0], 0);
-		ListVector::PushBack(result, val);
-		return;
-	}
-	while (iter.HasNext()) {
-		idx_t start = iter.Start();
-		idx_t end = iter.Next(input);
-		size_t length = end - start;
-		Value to_insert(StringVector::AddString(ListVector::GetEntry(result), &input[start], length));
-		ListVector::PushBack(result, to_insert);
-	}
-}
-
-unique_ptr<Vector> BaseStringSplitFunction(string_t input, string_t delim, const bool regex) {
-	const char *input_data = input.GetDataUnsafe();
-	size_t input_size = input.GetSize();
-	const char *delim_data = delim.GetDataUnsafe();
-	size_t delim_size = delim.GetSize();
-
-	bool ascii_only = Utf8Proc::Analyze(input_data, input_size) == UnicodeType::ASCII;
-
-	auto list_type = LogicalType::LIST(LogicalType::VARCHAR);
-	auto output = make_unique<Vector>(list_type);
-	unique_ptr<StringSplitIterator> iter;
-	if (regex) {
-		auto re = make_unique<RE2>(duckdb_re2::StringPiece(delim_data, delim_size));
-		if (!re->ok()) {
-			throw Exception(re->error());
+struct RegexpStringSplit {
+	static idx_t Find(const char *input_data, idx_t input_size, const char *delim_data, idx_t delim_size,
+	                  idx_t &match_size, void *data) {
+		duckdb_re2::RE2 regex(duckdb_re2::StringPiece(delim_data, delim_size));
+		if (!regex.ok()) {
+			throw InvalidInputException(regex.error());
 		}
-		iter = make_unique_base<StringSplitIterator, RegexStringSplitIterator>(input_size, move(re), ascii_only);
-	} else if (ascii_only) {
-		iter = make_unique_base<StringSplitIterator, AsciiStringSplitIterator>(input_size, delim_data, delim_size);
-	} else {
-		iter = make_unique_base<StringSplitIterator, UnicodeStringSplitIterator>(input_size, delim_data, delim_size);
+		return ConstantRegexpStringSplit::Find(input_data, input_size, delim_data, delim_size, match_size, &regex);
 	}
-	BaseStringSplitFunction(input_data, *iter, *output);
+};
 
-	return output;
-}
+struct StringSplitter {
+	template <class OP>
+	static idx_t Split(string_t input, string_t delim, StringSplitInput &state, void *data) {
+		auto input_data = input.GetDataUnsafe();
+		auto input_size = input.GetSize();
+		auto delim_data = delim.GetDataUnsafe();
+		auto delim_size = delim.GetSize();
+		if (delim_size == 0) {
+			throw InvalidInputException("Invalid input to string-split: empty separator");
+		}
+		bool found_first_match = false;
+		idx_t list_idx = 0;
+		while (input_size > 0) {
+			idx_t match_size;
+			auto pos = OP::Find(input_data, input_size, delim_data, delim_size, match_size, data);
+			if (pos > input_size) {
+				break;
+			}
+			// special case: 0 length match and pos is 0
+			// move to the next character
+			if (match_size == 0 && pos == 0 && found_first_match) {
+				pos = utf8proc_next_grapheme(input_data, input_size, 0);
+			}
+			D_ASSERT(input_size >= pos + match_size);
+			state.AddSplit(input_data, pos, list_idx);
 
-static void StringSplitExecutor(DataChunk &args, ExpressionState &state, Vector &result, const bool regex) {
+			list_idx++;
+			input_data += (pos + match_size);
+			input_size -= (pos + match_size);
+			found_first_match = true;
+		}
+		state.AddSplit(input_data, input_size, list_idx);
+		list_idx++;
+		return list_idx;
+	}
+};
+
+template <class OP>
+static void StringSplitExecutor(DataChunk &args, ExpressionState &state, Vector &result, void *data = nullptr) {
 	UnifiedVectorFormat input_data;
 	args.data[0].ToUnifiedFormat(args.size(), input_data);
 	auto inputs = (string_t *)input_data.data;
@@ -202,10 +119,11 @@ static void StringSplitExecutor(DataChunk &args, ExpressionState &state, Vector 
 	ListVector::SetListSize(result, 0);
 
 	auto list_struct_data = FlatVector::GetData<list_entry_t>(result);
-	auto list_vector_type = LogicalType::LIST(LogicalType::VARCHAR);
 
-	idx_t total_len = 0;
+	// count all the splits and set up the list entries
+	auto &child_entry = ListVector::GetEntry(result);
 	auto &result_mask = FlatVector::Validity(result);
+	idx_t total_splits = 0;
 	for (idx_t i = 0; i < args.size(); i++) {
 		auto input_idx = input_data.sel->get_index(i);
 		auto delim_idx = delim_data.sel->get_index(i);
@@ -213,36 +131,43 @@ static void StringSplitExecutor(DataChunk &args, ExpressionState &state, Vector 
 			result_mask.SetInvalid(i);
 			continue;
 		}
-		string_t input = inputs[input_idx];
-
-		unique_ptr<Vector> split_input;
+		StringSplitInput split_input(result, child_entry, total_splits);
 		if (!delim_data.validity.RowIsValid(delim_idx)) {
-			// special case: delimiter is NULL
-			split_input = make_unique<Vector>(list_vector_type);
-			Value val(input);
-			ListVector::PushBack(*split_input, val);
-		} else {
-			string_t delim = delims[delim_idx];
-			split_input = BaseStringSplitFunction(input, delim, regex);
+			// delim is NULL: copy the complete entry
+			split_input.AddSplit(inputs[input_idx].GetDataUnsafe(), inputs[input_idx].GetSize(), 0);
+			list_struct_data[i].length = 1;
+			list_struct_data[i].offset = total_splits;
+			total_splits++;
+			continue;
 		}
-		list_struct_data[i].length = ListVector::GetListSize(*split_input);
-		list_struct_data[i].offset = total_len;
-		total_len += ListVector::GetListSize(*split_input);
-		ListVector::Append(result, ListVector::GetEntry(*split_input), ListVector::GetListSize(*split_input));
+		auto list_length = StringSplitter::Split<OP>(inputs[input_idx], delims[delim_idx], split_input, data);
+		list_struct_data[i].length = list_length;
+		list_struct_data[i].offset = total_splits;
+		total_splits += list_length;
 	}
+	ListVector::SetListSize(result, total_splits);
+	D_ASSERT(ListVector::GetListSize(result) == total_splits);
 
-	D_ASSERT(ListVector::GetListSize(result) == total_len);
 	if (args.AllConstant()) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
 	}
 }
 
 static void StringSplitFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-	StringSplitExecutor(args, state, result, false);
+	StringSplitExecutor<RegularStringSplit>(args, state, result, nullptr);
 }
 
 static void StringSplitRegexFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-	StringSplitExecutor(args, state, result, true);
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (RegexpMatchesBindData &)*func_expr.bind_info;
+	if (info.constant_pattern) {
+		// fast path: pre-compiled regex
+		auto &lstate = (RegexLocalState &)*ExecuteFunctionState::GetFunctionState(state);
+		StringSplitExecutor<ConstantRegexpStringSplit>(args, state, result, &lstate.constant_pattern);
+	} else {
+		// slow path: have to re-compile regex for every row
+		StringSplitExecutor<RegexpStringSplit>(args, state, result);
+	}
 }
 
 void StringSplitFun::RegisterFunction(BuiltinFunctions &set) {
@@ -253,10 +178,18 @@ void StringSplitFun::RegisterFunction(BuiltinFunctions &set) {
 	regular_fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
 	set.AddFunction({"string_split", "str_split", "string_to_array", "split"}, regular_fun);
 
-	auto regex_fun =
-	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, varchar_list_type, StringSplitRegexFunction);
-	regex_fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
-	set.AddFunction({"string_split_regex", "str_split_regex", "regexp_split_to_array"}, regex_fun);
+	ScalarFunctionSet regexp_split("string_split_regex");
+	ScalarFunction regex_fun({LogicalType::VARCHAR, LogicalType::VARCHAR}, varchar_list_type, StringSplitRegexFunction,
+	                         RegexpMatchesBind, nullptr, nullptr, RegexInitLocalState, LogicalType::INVALID,
+	                         FunctionSideEffects::NO_SIDE_EFFECTS, FunctionNullHandling::SPECIAL_HANDLING);
+	regexp_split.AddFunction(regex_fun);
+	// regexp options
+	regex_fun.arguments.push_back(LogicalType::VARCHAR);
+	regexp_split.AddFunction(regex_fun);
+	for (auto &name : {"string_split_regex", "str_split_regex", "regexp_split_to_array"}) {
+		regexp_split.name = name;
+		set.AddFunction(regexp_split);
+	}
 }
 
 } // namespace duckdb

--- a/src/function/scalar/string/string_split.cpp
+++ b/src/function/scalar/string/string_split.cpp
@@ -84,9 +84,9 @@ struct StringSplitter {
 			if (pos > input_size) {
 				break;
 			}
-			// special case: 0 length match and pos is 0
-			// move to the next character
 			if (match_size == 0 && pos == 0 && found_first_match) {
+				// special case: 0 length match and pos is 0
+				// move to the next character
 				pos = utf8proc_next_grapheme(input_data, input_size, 0);
 			}
 			D_ASSERT(input_size >= pos + match_size);

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -322,6 +322,9 @@ struct ListVector {
 	DUCKDB_API static idx_t GetListSize(const Vector &vector);
 	//! Sets the total size of the underlying child-vector of a list
 	DUCKDB_API static void SetListSize(Vector &vec, idx_t size);
+	//! Gets the total capacity of the underlying child-vector of a list
+	DUCKDB_API static idx_t GetListCapacity(const Vector &vector);
+	//! Sets the total capacity of the underlying child-vector of a list
 	DUCKDB_API static void Reserve(Vector &vec, idx_t required_capacity);
 	DUCKDB_API static void Append(Vector &target, const Vector &source, idx_t source_size, idx_t source_offset = 0);
 	DUCKDB_API static void Append(Vector &target, const Vector &source, const SelectionVector &sel, idx_t source_size,

--- a/src/include/duckdb/function/scalar/regexp.hpp
+++ b/src/include/duckdb/function/scalar/regexp.hpp
@@ -60,4 +60,18 @@ struct RegexpExtractBindData : public RegexpBaseBindData {
 	bool Equals(const FunctionData &other_p) const override;
 };
 
+struct RegexLocalState : public FunctionLocalState {
+	explicit RegexLocalState(RegexpBaseBindData &info)
+	    : constant_pattern(duckdb_re2::StringPiece(info.constant_string.c_str(), info.constant_string.size()),
+	                       info.options) {
+		D_ASSERT(info.constant_pattern);
+	}
+
+	RE2 constant_pattern;
+};
+
+unique_ptr<FunctionLocalState> RegexInitLocalState(const BoundFunctionExpression &expr, FunctionData *bind_data);
+unique_ptr<FunctionData> RegexpMatchesBind(ClientContext &context, ScalarFunction &bound_function,
+                                           vector<unique_ptr<Expression>> &arguments);
+
 } // namespace duckdb

--- a/test/sql/function/string/test_string_split.test
+++ b/test/sql/function/string/test_string_split.test
@@ -96,15 +96,23 @@ SELECT UNNEST(string_split('', 'delim'))
 ----
 (empty)
 
-statement error
+query T
 SELECT UNNEST(string_split('aaaaa', ''))
 ----
-empty separator
+a
+a
+a
+a
+a
 
-statement error
+query T
 SELECT UNNEST(string_split('🦆🦆🦆🦆🦆', ''))
 ----
-empty separator
+🦆
+🦆
+🦆
+🦆
+🦆
 
 query T
 SELECT UNNEST(string_split('abab', 'b'))
@@ -166,10 +174,14 @@ a
 a
 a
 
-statement error
+query T
 SELECT UNNEST(string_split_regex('aaaaa', ''))
 ----
-empty separator
+a
+a
+a
+a
+a
 
 
 query T
@@ -208,10 +220,14 @@ select UNNEST(string_split('1||2|3||', '||'))
 2|3
 (empty)
 
-statement error
+query T
 select UNNEST(string_split('1|2|3', ''))
 ----
-empty separator
+1
+|
+2
+|
+3
 
 query T
 select UNNEST(string_split('', '|'))
@@ -228,19 +244,19 @@ select string_split(NULL, '|') IS NULL
 ----
 1
 
-statement error
+query T
 select UNNEST(string_split('abc', ''))
 ----
-empty separator
+a
+b
+c
 
 query T
 select UNNEST(string_split_regex('abc', '(|abc)'))
 ----
-(empty)
 a
 b
 c
-(empty)
 
 query T
 select UNNEST(string_split_regex('abc', '(abc|)'))
@@ -266,41 +282,6 @@ select UNNEST(string_split_regex('abc', '(abc|,)'))
 (empty)
 
 query T
-select UNNEST(string_split_regex('axxxc', 'z*'))
-----
-(empty)
-a
-x
-x
-x
-c
-(empty)
-
-query T
-select UNNEST(string_split(' aa', ' '))
-----
-(empty)
-aa
-
-query T
-select UNNEST(string_split(' aa ', ' '))
-----
-(empty)
-aa
-(empty)
-
-query T
-select UNNEST(string_split('aa ', ' '))
-----
-aa
-(empty)
-
-query T
-select UNNEST(string_split_regex('axxxc', 'z+'))
-----
-axxxc
-
-query T
 select UNNEST(string_split('1,2,3,4,,6', ','))
 ----
 1
@@ -313,7 +294,6 @@ select UNNEST(string_split('1,2,3,4,,6', ','))
 query T
 select UNNEST(string_split_regex('1,2,3,4,,6', '(,|)'))
 ----
-(empty)
 1
 (empty)
 2
@@ -324,13 +304,11 @@ select UNNEST(string_split_regex('1,2,3,4,,6', '(,|)'))
 (empty)
 (empty)
 6
-(empty)
 
 
 query T
 select UNNEST(string_split_regex('1,2,3,4,,6', '(|,)'))
 ----
-(empty)
 1
 ,
 2
@@ -341,7 +319,6 @@ select UNNEST(string_split_regex('1,2,3,4,,6', '(|,)'))
 ,
 ,
 6
-(empty)
 
 query T
 select UNNEST(string_split_regex('1,2,3,4,*,6', '(,|\*)'))
@@ -364,14 +341,6 @@ select UNNEST(string_split_regex('1,2,3,4,*,6', '(\*|,)'))
 (empty)
 (empty)
 6
-
-query T
-SELECT UNNEST(string_split_regex('-AA=AA+aA*', 'a+', 'i'))
-----
--
-=
-+
-*
 
 # test incorrect usage
 statement error

--- a/test/sql/function/string/test_string_split.test
+++ b/test/sql/function/string/test_string_split.test
@@ -96,23 +96,15 @@ SELECT UNNEST(string_split('', 'delim'))
 ----
 (empty)
 
-query T
+statement error
 SELECT UNNEST(string_split('aaaaa', ''))
 ----
-a
-a
-a
-a
-a
+empty separator
 
-query T
+statement error
 SELECT UNNEST(string_split('🦆🦆🦆🦆🦆', ''))
 ----
-🦆
-🦆
-🦆
-🦆
-🦆
+empty separator
 
 query T
 SELECT UNNEST(string_split('abab', 'b'))
@@ -174,14 +166,10 @@ a
 a
 a
 
-query T
+statement error
 SELECT UNNEST(string_split_regex('aaaaa', ''))
 ----
-a
-a
-a
-a
-a
+empty separator
 
 
 query T
@@ -220,14 +208,10 @@ select UNNEST(string_split('1||2|3||', '||'))
 2|3
 (empty)
 
-query T
+statement error
 select UNNEST(string_split('1|2|3', ''))
 ----
-1
-|
-2
-|
-3
+empty separator
 
 query T
 select UNNEST(string_split('', '|'))
@@ -244,19 +228,19 @@ select string_split(NULL, '|') IS NULL
 ----
 1
 
-query T
+statement error
 select UNNEST(string_split('abc', ''))
 ----
-a
-b
-c
+empty separator
 
 query T
 select UNNEST(string_split_regex('abc', '(|abc)'))
 ----
+(empty)
 a
 b
 c
+(empty)
 
 query T
 select UNNEST(string_split_regex('abc', '(abc|)'))
@@ -282,6 +266,41 @@ select UNNEST(string_split_regex('abc', '(abc|,)'))
 (empty)
 
 query T
+select UNNEST(string_split_regex('axxxc', 'z*'))
+----
+(empty)
+a
+x
+x
+x
+c
+(empty)
+
+query T
+select UNNEST(string_split(' aa', ' '))
+----
+(empty)
+aa
+
+query T
+select UNNEST(string_split(' aa ', ' '))
+----
+(empty)
+aa
+(empty)
+
+query T
+select UNNEST(string_split('aa ', ' '))
+----
+aa
+(empty)
+
+query T
+select UNNEST(string_split_regex('axxxc', 'z+'))
+----
+axxxc
+
+query T
 select UNNEST(string_split('1,2,3,4,,6', ','))
 ----
 1
@@ -294,6 +313,7 @@ select UNNEST(string_split('1,2,3,4,,6', ','))
 query T
 select UNNEST(string_split_regex('1,2,3,4,,6', '(,|)'))
 ----
+(empty)
 1
 (empty)
 2
@@ -304,11 +324,13 @@ select UNNEST(string_split_regex('1,2,3,4,,6', '(,|)'))
 (empty)
 (empty)
 6
+(empty)
 
 
 query T
 select UNNEST(string_split_regex('1,2,3,4,,6', '(|,)'))
 ----
+(empty)
 1
 ,
 2
@@ -319,6 +341,7 @@ select UNNEST(string_split_regex('1,2,3,4,,6', '(|,)'))
 ,
 ,
 6
+(empty)
 
 query T
 select UNNEST(string_split_regex('1,2,3,4,*,6', '(,|\*)'))

--- a/test/sql/function/string/test_string_split.test
+++ b/test/sql/function/string/test_string_split.test
@@ -365,6 +365,14 @@ select UNNEST(string_split_regex('1,2,3,4,*,6', '(\*|,)'))
 (empty)
 6
 
+query T
+SELECT UNNEST(string_split_regex('-AA=AA+aA*', 'a+', 'i'))
+----
+-
+=
++
+*
+
 # test incorrect usage
 statement error
 select string_split()


### PR DESCRIPTION
This PR reworks the string split operator and optimizes it significantly, particularly the `regexp_string_split` operator sees large performance improvements. In summary:

* Avoid using the Value API as much as possible, and directly construct results as `string_t` objects
* Simplify implementation of string_split to use existing optimized search used in `Contains`, rather than re-implementing the string search in a slower manner
* For regexp_string_split, cache the regexp if it is a constant to avoid having to re-compile it for every value (which is the most common case)

Some benchmarks:

###### ASCII string split

```sql
CALL dbgen(sf=1);
CREATE TABLE duck_comments AS SELECT concat(l_comment, '🦆') l_comment FROM lineitem;
SELECT SUM(LENGTH(str_split(l_comment, ' '))) FROM lineitem;
```

###### Unicode string split
```sql
CALL dbgen(sf=1);
SELECT SUM(LENGTH(str_split(l_comment, ' '))) FROM duck_comments;
```

###### Regex string split
```sql
CALL dbgen(sf=1);
SELECT SUM(LENGTH(str_split_regex(l_comment, '[z ]'))) FROM lineitem
```

| Benchmark |  Old  |  New  |
|-----------|-------|-------|
| ASCII     | 0.72s | 0.08s |
| Unicode   | 0.91s | 0.08s |
| Regex     | 17.5s | 0.29s |
