### PR TITLE
Nicer looking progress bar

### DIFF
--- a/src/common/printer.cpp
+++ b/src/common/printer.cpp
@@ -16,40 +16,34 @@
 
 namespace duckdb {
 
-// LCOV_EXCL_START
-void Printer::Print(OutputStream stream, const string &str) {
+
+void Printer::RawPrint(OutputStream stream, const string &str) {
 #ifndef DUCKDB_DISABLE_PRINT
 #ifdef DUCKDB_WINDOWS
 	if (IsTerminal(stream)) {
 		// print utf8 to terminal
 		auto unicode = WindowsUtil::UTF8ToMBCS(str.c_str());
-		fprintf(stream == OutputStream::STREAM_STDERR ? stderr : stdout, "%s\n", unicode.c_str());
+		fprintf(stream == OutputStream::STREAM_STDERR ? stderr : stdout, "%s", unicode.c_str());
 		return;
 	}
 #endif
-	fprintf(stream == OutputStream::STREAM_STDERR ? stderr : stdout, "%s\n", str.c_str());
+	fprintf(stream == OutputStream::STREAM_STDERR ? stderr : stdout, "%s", str.c_str());
+#endif
+}
+
+// LCOV_EXCL_START
+void Printer::Print(OutputStream stream, const string &str) {
+	Printer::RawPrint(stream, str);
+	Printer::RawPrint(stream, "\n");
+}
+void Printer::Flush(OutputStream stream) {
+#ifndef DUCKDB_DISABLE_PRINT
+	fflush(stream == OutputStream::STREAM_STDERR ? stderr : stdout);
 #endif
 }
 
 void Printer::Print(const string &str) {
 	Printer::Print(OutputStream::STREAM_STDERR, str);
-}
-
-void Printer::PrintProgress(int percentage, const char *pbstr, int pbwidth) {
-#ifndef DUCKDB_DISABLE_PRINT
-	int lpad = (int)(percentage / 100.0 * pbwidth);
-	int rpad = pbwidth - lpad;
-	fprintf(stdout, "\r%3d%% [%.*s%*s]", percentage, lpad, pbstr, rpad, "");
-	fflush(stdout);
-#endif
-}
-
-void Printer::FinishProgressBarPrint(const char *pbstr, int pbwidth) {
-#ifndef DUCKDB_DISABLE_PRINT
-	PrintProgress(100, pbstr, pbwidth);
-	fprintf(stdout, " \n");
-	fflush(stdout);
-#endif
 }
 
 bool Printer::IsTerminal(OutputStream stream) {

--- a/src/common/printer.cpp
+++ b/src/common/printer.cpp
@@ -16,7 +16,6 @@
 
 namespace duckdb {
 
-
 void Printer::RawPrint(OutputStream stream, const string &str) {
 #ifndef DUCKDB_DISABLE_PRINT
 #ifdef DUCKDB_WINDOWS

--- a/src/common/progress_bar.cpp
+++ b/src/common/progress_bar.cpp
@@ -86,6 +86,7 @@ void ProgressBar::PrintProgressInternal(int percentage) {
 		result += PROGRESS_EMPTY;
 	}
 	result += PROGRESS_END;
+	result += " ";
 
 	Printer::RawPrint(OutputStream::STREAM_STDOUT, result);
 }
@@ -96,7 +97,7 @@ void ProgressBar::PrintProgress(int percentage) {
 
 void ProgressBar::FinishProgressBarPrint() {
 	PrintProgressInternal(100);
-	Printer::RawPrint(OutputStream::STREAM_STDOUT, " \n");
+	Printer::RawPrint(OutputStream::STREAM_STDOUT, "\n");
 	Printer::Flush(OutputStream::STREAM_STDOUT);
 }
 

--- a/src/common/progress_bar.cpp
+++ b/src/common/progress_bar.cpp
@@ -33,12 +33,71 @@ void ProgressBar::Update(bool final) {
 		current_percentage = new_percentage;
 	}
 	if (supported && print_progress && sufficient_time_elapsed && current_percentage > -1 && print_progress) {
+#ifndef DUCKDB_DISABLE_PRINT
 		if (final) {
-			Printer::FinishProgressBarPrint(PROGRESS_BAR_STRING.c_str(), PROGRESS_BAR_WIDTH);
+			FinishProgressBarPrint();
 		} else {
-			Printer::PrintProgress(current_percentage, PROGRESS_BAR_STRING.c_str(), PROGRESS_BAR_WIDTH);
+			PrintProgress(current_percentage);
 		}
+#endif
 	}
+}
+
+void ProgressBar::PrintProgressInternal(int percentage) {
+	if (percentage > 100) {
+		percentage = 100;
+	}
+	if (percentage < 0) {
+		percentage = 0;
+	}
+	string result;
+	// we divide the number of blocks by the percentage
+	// 0%   = 0
+	// 100% = PROGRESS_BAR_WIDTH
+	// the percentage determines how many blocks we need to draw
+	double blocks_to_draw = PROGRESS_BAR_WIDTH * (percentage / 100.0);
+	// because of the power of unicode, we can also draw partial blocks
+
+	// render the percentage with some padding to ensure everything stays nicely aligned
+	result = "\r";
+	if (percentage < 100) {
+		result += " ";
+	}
+	if (percentage < 10) {
+		result += " ";
+	}
+	result += to_string(percentage) + "%";
+	result += " ";
+	result += PROGRESS_START;
+	idx_t i;
+	for(i = 0; i < idx_t(blocks_to_draw); i++) {
+		result += PROGRESS_BLOCK;
+	}
+	if (i < PROGRESS_BAR_WIDTH) {
+		// print a partial block based on the percentage of the progress bar remaining
+		idx_t index = idx_t((blocks_to_draw - idx_t(blocks_to_draw)) * PARTIAL_BLOCK_COUNT);
+		if (index >= PARTIAL_BLOCK_COUNT) {
+			index = PARTIAL_BLOCK_COUNT - 1;
+		}
+		result += PROGRESS_PARTIAL[index];
+		i++;
+	}
+	for(; i < PROGRESS_BAR_WIDTH; i++) {
+		result += PROGRESS_EMPTY;
+	}
+	result += PROGRESS_END;
+
+	Printer::RawPrint(OutputStream::STREAM_STDOUT, result);
+}
+void ProgressBar::PrintProgress(int percentage) {
+	PrintProgressInternal(percentage);
+	Printer::Flush(OutputStream::STREAM_STDOUT);
+}
+
+void ProgressBar::FinishProgressBarPrint() {
+	PrintProgressInternal(100);
+	Printer::RawPrint(OutputStream::STREAM_STDOUT, " \n");
+	Printer::Flush(OutputStream::STREAM_STDOUT);
 }
 
 } // namespace duckdb

--- a/src/common/progress_bar.cpp
+++ b/src/common/progress_bar.cpp
@@ -70,7 +70,7 @@ void ProgressBar::PrintProgressInternal(int percentage) {
 	result += " ";
 	result += PROGRESS_START;
 	idx_t i;
-	for(i = 0; i < idx_t(blocks_to_draw); i++) {
+	for (i = 0; i < idx_t(blocks_to_draw); i++) {
 		result += PROGRESS_BLOCK;
 	}
 	if (i < PROGRESS_BAR_WIDTH) {
@@ -82,7 +82,7 @@ void ProgressBar::PrintProgressInternal(int percentage) {
 		result += PROGRESS_PARTIAL[index];
 		i++;
 	}
-	for(; i < PROGRESS_BAR_WIDTH; i++) {
+	for (; i < PROGRESS_BAR_WIDTH; i++) {
 		result += PROGRESS_EMPTY;
 	}
 	result += PROGRESS_END;

--- a/src/include/duckdb/common/printer.hpp
+++ b/src/include/duckdb/common/printer.hpp
@@ -17,14 +17,14 @@ enum class OutputStream : uint8_t { STREAM_STDOUT = 1, STREAM_STDERR = 2 };
 //! Printer is a static class that allows printing to logs or stdout/stderr
 class Printer {
 public:
-	//! Print the object to stderr
+	//! Print the object to the stream
 	DUCKDB_API static void Print(OutputStream stream, const string &str);
 	//! Print the object to stderr
 	DUCKDB_API static void Print(const string &str);
-	//! Prints Progress
-	DUCKDB_API static void PrintProgress(int percentage, const char *pbstr, int pbwidth);
-	//! Prints an empty line when progress bar is done
-	DUCKDB_API static void FinishProgressBarPrint(const char *pbstr, int pbwidth);
+	//! Directly prints the string to stdout without a newline
+	DUCKDB_API static void RawPrint(OutputStream stream, const string &str);
+	//! Flush an output stream
+	DUCKDB_API static void Flush(OutputStream stream);
 	//! Whether or not we are printing to a terminal
 	DUCKDB_API static bool IsTerminal(OutputStream stream);
 	//! The terminal width

--- a/src/include/duckdb/common/progress_bar.hpp
+++ b/src/include/duckdb/common/progress_bar.hpp
@@ -28,11 +28,21 @@ public:
 
 private:
 	static constexpr const idx_t PARTIAL_BLOCK_COUNT = 8;
+#ifndef DUCKDB_ASCII_TREE_RENDERER
 	const char *PROGRESS_EMPTY = " ";
-	const char *PROGRESS_PARTIAL[PARTIAL_BLOCK_COUNT] {" ", "▏", "▎", "▍", "▌", "▋", "▊", "▉"};
-	const char *PROGRESS_BLOCK = "█";
-	const char *PROGRESS_START = "▏";
-	const char *PROGRESS_END = "▕";
+	const char *PROGRESS_PARTIAL[PARTIAL_BLOCK_COUNT] {
+	    " ",           "\xE2\x96\x8F", "\xE2\x96\x8E", "\xE2\x96\x8D", "\xE2\x96\x8C", "\xE2\x96\x8B", "\xE2\x96\x8A",
+	    "\xE2\x96\x89"};
+	const char *PROGRESS_BLOCK = "\xE2\x96\x88";
+	const char *PROGRESS_START = "\xE2\x96\x95";
+	const char *PROGRESS_END = "\xE2\x96\x8F";
+#else
+	const char *PROGRESS_EMPTY = " ";
+	const char *PROGRESS_PARTIAL[PARTIAL_BLOCK_COUNT] {" ", " ", " ", " ", " ", " ", " ", " "};
+	const char *PROGRESS_BLOCK = "=";
+	const char *PROGRESS_START = "[";
+	const char *PROGRESS_END = "]";
+#endif
 	static constexpr const idx_t PROGRESS_BAR_WIDTH = 60;
 
 	void PrintProgressInternal(int percentage);

--- a/src/include/duckdb/common/progress_bar.hpp
+++ b/src/include/duckdb/common/progress_bar.hpp
@@ -25,10 +25,18 @@ public:
 	void Update(bool final);
 	//! Gets current percentage
 	double GetCurrentPercentage();
-
 private:
-	const string PROGRESS_BAR_STRING = "============================================================";
+	static constexpr const idx_t PARTIAL_BLOCK_COUNT = 8;
+	const char *PROGRESS_EMPTY = " ";
+	const char *PROGRESS_PARTIAL[PARTIAL_BLOCK_COUNT] {" ", "▏", "▎", "▍", "▌", "▋", "▊", "▉"};
+	const char *PROGRESS_BLOCK = "█";
+	const char *PROGRESS_START = "[";
+	const char *PROGRESS_END = "]";
 	static constexpr const idx_t PROGRESS_BAR_WIDTH = 60;
+
+	void PrintProgressInternal(int percentage);
+	void PrintProgress(int percentage);
+	void FinishProgressBarPrint();
 
 private:
 	//! The executor

--- a/src/include/duckdb/common/progress_bar.hpp
+++ b/src/include/duckdb/common/progress_bar.hpp
@@ -25,13 +25,14 @@ public:
 	void Update(bool final);
 	//! Gets current percentage
 	double GetCurrentPercentage();
+
 private:
 	static constexpr const idx_t PARTIAL_BLOCK_COUNT = 8;
 	const char *PROGRESS_EMPTY = " ";
 	const char *PROGRESS_PARTIAL[PARTIAL_BLOCK_COUNT] {" ", "▏", "▎", "▍", "▌", "▋", "▊", "▉"};
 	const char *PROGRESS_BLOCK = "█";
-	const char *PROGRESS_START = "[";
-	const char *PROGRESS_END = "]";
+	const char *PROGRESS_START = "▏";
+	const char *PROGRESS_END = "▕";
 	static constexpr const idx_t PROGRESS_BAR_WIDTH = 60;
 
 	void PrintProgressInternal(int percentage);

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -13,7 +13,6 @@
 #include "duckdb/common/enums/pending_execution_result.hpp"
 #include "duckdb/common/deque.hpp"
 #include "duckdb/common/pair.hpp"
-#include "duckdb/common/progress_bar.hpp"
 #include "duckdb/common/unordered_set.hpp"
 #include "duckdb/common/winapi.hpp"
 #include "duckdb/main/prepared_statement.hpp"

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -41,6 +41,7 @@
 #include "duckdb/parser/statement/execute_statement.hpp"
 #include "duckdb/common/types/column_data_collection.hpp"
 #include "duckdb/common/preserved_error.hpp"
+#include "duckdb/common/progress_bar.hpp"
 
 namespace duckdb {
 


### PR DESCRIPTION
This PR adds a nicer looking progress bar based on [this blog](https://mike42.me/blog/2018-06-make-better-cli-progress-bars-with-unicode-block-characters).

#### Old

```sql
D copy lineitem to 'lineitem-big.parquet';
 35% [=====================                                       ]
```

#### New

```sql
D copy lineitem to 'lineitem-big.parquet';
 32% ▕███████████████████▏                                        ▏ 
```

It looks better in the terminal and better in motion because of the partial block rendering, but I am too lazy to make a video, so you will just have to try it yourself to see :)

![Screenshot 2022-11-03 at 14 43 23](https://user-images.githubusercontent.com/3978469/199736707-83ee2ab8-70e9-45c0-aa3d-bb6be850b1e5.png)
