### PR TITLE
Box renderer: Always display "0 rows" if there are no rows

### DIFF
--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -597,7 +597,7 @@ void BoxRenderer::Render(ClientContext &context, const vector<string> &names, co
 
 	// for each column, figure out the width
 	// start off by figuring out the name of the header by looking at the column name and column type
-	idx_t min_width = has_hidden_rows ? minimum_row_length : 0;
+	idx_t min_width = has_hidden_rows || row_count == 0 ? minimum_row_length : 0;
 	vector<idx_t> column_map;
 	idx_t total_length;
 	auto widths = ComputeRenderWidths(names, result, collections, min_width, max_width, column_map, total_length);

--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -843,6 +843,12 @@ SELECT * FROM sql_auto_complete('SELECT MyColumn FROM My') LIMIT 1;
 """, out="MyTable"
 )
 
+# duckbox renderer displays the number of rows if there are none
+test('''
+.mode duckbox
+select 42 limit 0;
+''', out='0 rows')
+
 if os.name != 'nt':
      shell_test_dir = 'shell_test_dir'
      try:


### PR DESCRIPTION
Minor fix to the box renderer to always display "0 rows" if there are no rows, even if we have very short column names.

```
D select 42 limit 0;
┌────────┐
│   42   │
│ int32  │
├────────┤
│ 0 rows │
└────────┘
```