### PR TITLE
Increase vector size to 2048

### DIFF
--- a/src/include/duckdb/common/vector_size.hpp
+++ b/src/include/duckdb/common/vector_size.hpp
@@ -14,7 +14,7 @@ namespace duckdb {
 
 //! The vector size used in the execution engine
 #ifndef STANDARD_VECTOR_SIZE
-#define STANDARD_VECTOR_SIZE 1024
+#define STANDARD_VECTOR_SIZE 2048
 #endif
 
 #if ((STANDARD_VECTOR_SIZE & (STANDARD_VECTOR_SIZE - 1)) != 0)

--- a/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
@@ -79,7 +79,7 @@ struct BufferedCSVReaderOptions {
 	//! Expected number of columns
 	idx_t num_cols = 0;
 	//! Number of samples to buffer
-	idx_t buffer_size = STANDARD_VECTOR_SIZE * 100;
+	idx_t buffer_size = STANDARD_VECTOR_SIZE * 50;
 	//! Specifies the string that represents a null value
 	string null_str;
 	//! Whether file is compressed or not, and if so which compression type

--- a/src/storage/storage_info.cpp
+++ b/src/storage/storage_info.cpp
@@ -2,6 +2,6 @@
 
 namespace duckdb {
 
-const uint64_t VERSION_NUMBER = 38;
+const uint64_t VERSION_NUMBER = 39;
 
 } // namespace duckdb

--- a/test/fuzzer/pedro/vacuum_table_with_generated_column.test
+++ b/test/fuzzer/pedro/vacuum_table_with_generated_column.test
@@ -23,7 +23,7 @@ INSERT INTO test SELECT range % 5000 FROM range(10000);
 query T
 SELECT stats(x) FROM test LIMIT 1;
 ----
-[Min: 0, Max: 4999][Has Null: false, Has No Null: true][Approx Unique: 9809]
+[Min: 0, Max: 4999][Has Null: false, Has No Null: true][Approx Unique: 9435]
 
 query T
 SELECT stats(y) FROM test LIMIT 1;

--- a/test/sql/vacuum/test_analyze.test
+++ b/test/sql/vacuum/test_analyze.test
@@ -38,12 +38,12 @@ insert into test select range % 5000, range % 5000 from range(10000)
 query T
 select stats(i) from test limit 1
 ----
-[Min: 0, Max: 4999][Has Null: false, Has No Null: true][Approx Unique: 9809]
+[Min: 0, Max: 4999][Has Null: false, Has No Null: true][Approx Unique: 9435]
 
 query T
 select stats(j) from test limit 1
 ----
-[Min: 0, Max: 4999][Has Null: false, Has No Null: true][Approx Unique: 9809]
+[Min: 0, Max: 4999][Has Null: false, Has No Null: true][Approx Unique: 9435]
 
 # we enable verify_parallelism only for ANALYZE
 statement ok
@@ -65,7 +65,7 @@ select stats(i) from test limit 1
 query T
 select stats(j) from test limit 1
 ----
-[Min: 0, Max: 4999][Has Null: false, Has No Null: true][Approx Unique: 9809]
+[Min: 0, Max: 4999][Has Null: false, Has No Null: true][Approx Unique: 9435]
 
 # now we analyze the whole table
 statement ok

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_fetch.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_fetch.py
@@ -94,5 +94,5 @@ class TestArrowFetch(object):
         relation = duckdb_cursor.table('t')
         arrow_tbl = relation.arrow()
         assert arrow_tbl['a'].num_chunks == 1
-        arrow_tbl = relation.arrow(1024)
-        assert arrow_tbl['a'].num_chunks == 3
+        arrow_tbl = relation.arrow(2048)
+        assert arrow_tbl['a'].num_chunks == 2

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_fetch_recordbatch.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_fetch_recordbatch.py
@@ -17,9 +17,7 @@ class TestArrowFetchRecordBatch(object):
         record_batch_reader = query.fetch_record_batch(1024)
         assert record_batch_reader.schema.names == ['a']
         chunk = record_batch_reader.read_next_batch()
-        assert(len(chunk) == 1024)
-        chunk = record_batch_reader.read_next_batch()
-        assert(len(chunk) == 1024)
+        assert(len(chunk) == 2048)
         chunk = record_batch_reader.read_next_batch()
         assert(len(chunk) == 952)
         with pytest.raises(StopIteration):
@@ -64,7 +62,7 @@ class TestArrowFetchRecordBatch(object):
         query = duckdb_cursor.execute("SELECT a FROM t")
         record_batch_reader = query.fetch_record_batch(1)
         chunk = record_batch_reader.read_next_batch()
-        assert(len(chunk) == 1024)
+        assert(len(chunk) == 2048)
 
         query = duckdb_cursor.execute("SELECT a FROM t")
         record_batch_reader = query.fetch_record_batch(2000)

--- a/tools/pythonpkg/tests/fast/pandas/test_fetch_df_chunk.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_fetch_df_chunk.py
@@ -8,10 +8,7 @@ class TestType(object):
         query = duckdb_cursor.execute("SELECT a FROM t")
         cur_chunk = query.fetch_df_chunk()
         assert(cur_chunk['a'][0] == 0)
-        assert(len(cur_chunk) == 1024)
-        cur_chunk = query.fetch_df_chunk()
-        assert(cur_chunk['a'][0] == 1024)
-        assert(len(cur_chunk) == 1024)
+        assert(len(cur_chunk) == 2048)
         cur_chunk = query.fetch_df_chunk()
         assert(cur_chunk['a'][0] == 2048)
         assert(len(cur_chunk) == 952)
@@ -48,32 +45,21 @@ class TestType(object):
         # Return 2 vectors
         cur_chunk = query.fetch_df_chunk(2)
         assert(cur_chunk['a'][0] == 0)
-        assert(len(cur_chunk) == 2048)
+        assert(len(cur_chunk) == 4096)
         
         # Return Default 1 vector
         cur_chunk = query.fetch_df_chunk()
-        assert(cur_chunk['a'][0] == 2048)
-        assert(len(cur_chunk) == 1024)
-        
-        # Return 3 vectors
-        cur_chunk = query.fetch_df_chunk(3)
-        assert(cur_chunk['a'][0] == 3072)
-        assert(len(cur_chunk) == 3072)
-        
+        assert(cur_chunk['a'][0] == 4096)
+        assert(len(cur_chunk) == 2048)
+
         # Return 0 vectors
         cur_chunk = query.fetch_df_chunk(0)
         assert(len(cur_chunk) == 0)
 
-
-        # Return 1 vector
-        cur_chunk = query.fetch_df_chunk(1)
+        # Return more vectors than we have remaining
+        cur_chunk = query.fetch_df_chunk(3)
         assert(cur_chunk['a'][0] == 6144)
-        assert(len(cur_chunk) == 1024)
-
-         # Return more vectors than we have remaining
-        cur_chunk = query.fetch_df_chunk(100)
-        assert(cur_chunk['a'][0] == 7168)
-        assert(len(cur_chunk) == 2832)
+        assert(len(cur_chunk) == 3856)
 
         # These shouldn't throw errors (Just emmit empty chunks)
         cur_chunk = query.fetch_df_chunk(100)

--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_category.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_category.py
@@ -100,7 +100,7 @@ class TestCategory(object):
     def test_category_fetch_df_chunk(self, duckdb_cursor):
         con = duckdb.connect()
         categories = ['foo','bla',None,'zoo', 'foo', 'foo',None, 'bla']
-        result = categories*128
+        result = categories*256
         categories = result * 2
         df_result = pd.DataFrame({
             'x': pd.Categorical(result, ordered=True),

--- a/tools/pythonpkg/tests/fast/test_map.py
+++ b/tools/pythonpkg/tests/fast/test_map.py
@@ -79,7 +79,7 @@ class TestMap(object):
 
         testrel.map(return_dataframe).df().equals(pd.DataFrame({'A' : [1]}))
         
-        with pytest.raises(duckdb.InvalidInputException, match='UDF returned more than 1024 rows, which is not allowed.'):
+        with pytest.raises(duckdb.InvalidInputException, match='UDF returned more than 2048 rows, which is not allowed.'):
             testrel.map(return_big_dataframe).df()
 
         empty_rel.map(return_dataframe).df().equals(pd.DataFrame({'A' : []}))

--- a/tools/rpkg/tests/testthat/test_fetch_arrow.R
+++ b/tools/rpkg/tests/testthat/test_fetch_arrow.R
@@ -74,10 +74,7 @@ test_that("duckdb_fetch_arrow() record_batch_reader ", {
   res <- dbSendQuery(con, "SELECT * FROM t", arrow = TRUE)
   record_batch_reader <- duckdb_fetch_record_batch(res,1024)
   cur_batch <- record_batch_reader$read_next_batch()
-  expect_equal(1024, cur_batch$num_rows)
-
-  cur_batch <- record_batch_reader$read_next_batch()
-  expect_equal(1024, cur_batch$num_rows)
+  expect_equal(2048, cur_batch$num_rows)
 
   cur_batch <- record_batch_reader$read_next_batch()
   expect_equal(952, cur_batch$num_rows)


### PR DESCRIPTION
This PR increases the vector size of the system to 2048 entries (up from 1024 entries). The old vector size was inherited and tuned for the Vectorwise system. After running several experiments - it turns out that DuckDB generally performs better with a slightly higher vector size. In this PR we increase it to the next power of two. This generally improves performance across the board by around 15%~. See below for the experiments.


### Average speedup (summary)

| string_split("name", '/')[2] |    avg(speedup)    |
|------------------------------|--------------------|
| clickbench                   | 1.1586046511627908 |
| h2oai                        | 1.1426666666666667 |
| tpcds                        | 1.1628282828282837 |
| tpch                         | 1.1381818181818184 |

### All queries

The timings reported here are all a median of 5 runs. Note that even though we perform multiple runs, several of these queries complete extremely quickly, and as such the results are somewhat noisy. The trend is clear, however: increasing the vector size improves performance.

|                name                 | v1024_timing | v2048_timing | speedup |
|-------------------------------------|--------------|--------------|---------|
| benchmark/clickbench/q01.benchmark  | 0.001163     | 0.000702     | 1.66    |
| benchmark/clickbench/q02.benchmark  | 0.002145     | 0.001611     | 1.33    |
| benchmark/clickbench/q03.benchmark  | 0.001836     | 0.001627     | 1.13    |
| benchmark/clickbench/q04.benchmark  | 0.002363     | 0.002102     | 1.12    |
| benchmark/clickbench/q05.benchmark  | 0.043188     | 0.036473     | 1.18    |
| benchmark/clickbench/q06.benchmark  | 0.055241     | 0.045175     | 1.22    |
| benchmark/clickbench/q07.benchmark  | 0.00208      | 0.00199      | 1.05    |
| benchmark/clickbench/q08.benchmark  | 0.002302     | 0.001769     | 1.3     |
| benchmark/clickbench/q09.benchmark  | 0.070611     | 0.054765     | 1.29    |
| benchmark/clickbench/q10.benchmark  | 0.080739     | 0.070407     | 1.15    |
| benchmark/clickbench/q11.benchmark  | 0.013102     | 0.011443     | 1.14    |
| benchmark/clickbench/q12.benchmark  | 0.015611     | 0.011933     | 1.31    |
| benchmark/clickbench/q13.benchmark  | 0.048788     | 0.040047     | 1.22    |
| benchmark/clickbench/q14.benchmark  | 0.124795     | 0.102709     | 1.22    |
| benchmark/clickbench/q15.benchmark  | 0.04807      | 0.043341     | 1.11    |
| benchmark/clickbench/q16.benchmark  | 0.050121     | 0.041593     | 1.21    |
| benchmark/clickbench/q17.benchmark  | 0.095215     | 0.083615     | 1.14    |
| benchmark/clickbench/q18.benchmark  | 0.109215     | 0.076971     | 1.42    |
| benchmark/clickbench/q19.benchmark  | 0.163965     | 0.141077     | 1.16    |
| benchmark/clickbench/q20.benchmark  | 0.000714     | 0.000562     | 1.27    |
| benchmark/clickbench/q21.benchmark  | 0.05477      | 0.05083      | 1.08    |
| benchmark/clickbench/q22.benchmark  | 0.020267     | 0.019871     | 1.02    |
| benchmark/clickbench/q23.benchmark  | 0.027569     | 0.026354     | 1.05    |
| benchmark/clickbench/q24.benchmark  | 0.193154     | 0.177775     | 1.09    |
| benchmark/clickbench/q25.benchmark  | 0.009589     | 0.009385     | 1.02    |
| benchmark/clickbench/q26.benchmark  | 0.011109     | 0.012951     | 0.86    |
| benchmark/clickbench/q27.benchmark  | 0.014216     | 0.016951     | 0.84    |
| benchmark/clickbench/q28.benchmark  | 0.019809     | 0.017675     | 1.12    |
| benchmark/clickbench/q29.benchmark  | 1.348451     | 1.274556     | 1.06    |
| benchmark/clickbench/q30.benchmark  | 0.060388     | 0.046526     | 1.3     |
| benchmark/clickbench/q31.benchmark  | 0.041377     | 0.031629     | 1.31    |
| benchmark/clickbench/q32.benchmark  | 0.052599     | 0.043216     | 1.22    |
| benchmark/clickbench/q33.benchmark  | 0.225605     | 0.217713     | 1.04    |
| benchmark/clickbench/q34.benchmark  | 0.163504     | 0.148036     | 1.1     |
| benchmark/clickbench/q35.benchmark  | 0.15874      | 0.14863      | 1.07    |
| benchmark/clickbench/q36.benchmark  | 0.058799     | 0.046997     | 1.25    |
| benchmark/clickbench/q37.benchmark  | 0.012853     | 0.011684     | 1.1     |
| benchmark/clickbench/q38.benchmark  | 0.007855     | 0.007011     | 1.12    |
| benchmark/clickbench/q39.benchmark  | 0.003837     | 0.00365      | 1.05    |
| benchmark/clickbench/q40.benchmark  | 0.026873     | 0.024746     | 1.09    |
| benchmark/clickbench/q41.benchmark  | 0.003523     | 0.003128     | 1.13    |
| benchmark/clickbench/q42.benchmark  | 0.003371     | 0.003165     | 1.07    |
| benchmark/clickbench/q43.benchmark  | 0.004346     | 0.003633     | 1.2     |
| benchmark/h2oai/group/q01.benchmark | 0.019762     | 0.018498     | 1.07    |
| benchmark/h2oai/group/q02.benchmark | 0.064452     | 0.049451     | 1.3     |
| benchmark/h2oai/group/q03.benchmark | 0.085533     | 0.072252     | 1.18    |
| benchmark/h2oai/group/q04.benchmark | 0.009296     | 0.008286     | 1.12    |
| benchmark/h2oai/group/q05.benchmark | 0.068734     | 0.056217     | 1.22    |
| benchmark/h2oai/group/q06.benchmark | 0.227849     | 0.19175      | 1.19    |
| benchmark/h2oai/group/q07.benchmark | 0.082862     | 0.069789     | 1.19    |
| benchmark/h2oai/group/q08.benchmark | 0.426915     | 0.392793     | 1.09    |
| benchmark/h2oai/group/q09.benchmark | 0.064395     | 0.047603     | 1.35    |
| benchmark/h2oai/group/q10.benchmark | 0.474856     | 0.454602     | 1.04    |
| benchmark/h2oai/join/q01.benchmark  | 0.168966     | 0.16006      | 1.06    |
| benchmark/h2oai/join/q02.benchmark  | 0.213046     | 0.195675     | 1.09    |
| benchmark/h2oai/join/q03.benchmark  | 0.266665     | 0.238333     | 1.12    |
| benchmark/h2oai/join/q04.benchmark  | 0.217446     | 0.202063     | 1.08    |
| benchmark/h2oai/join/q05.benchmark  | 0.462971     | 0.446445     | 1.04    |
| benchmark/tpcds/sf1/q01.benchmark   | 0.016147     | 0.013907     | 1.16    |
| benchmark/tpcds/sf1/q02.benchmark   | 0.032705     | 0.030359     | 1.08    |
| benchmark/tpcds/sf1/q03.benchmark   | 0.004898     | 0.003831     | 1.28    |
| benchmark/tpcds/sf1/q04.benchmark   | 0.203007     | 0.17254      | 1.18    |
| benchmark/tpcds/sf1/q05.benchmark   | 0.01583      | 0.013165     | 1.2     |
| benchmark/tpcds/sf1/q06.benchmark   | 0.15276      | 0.125395     | 1.22    |
| benchmark/tpcds/sf1/q07.benchmark   | 0.021372     | 0.021226     | 1.01    |
| benchmark/tpcds/sf1/q08.benchmark   | 0.033861     | 0.011143     | 3.04    |
| benchmark/tpcds/sf1/q09.benchmark   | 0.033103     | 0.029707     | 1.11    |
| benchmark/tpcds/sf1/q10.benchmark   | 0.01066      | 0.010921     | 0.98    |
| benchmark/tpcds/sf1/q11.benchmark   | 0.174116     | 0.146426     | 1.19    |
| benchmark/tpcds/sf1/q12.benchmark   | 0.007906     | 0.006301     | 1.25    |
| benchmark/tpcds/sf1/q13.benchmark   | 0.023642     | 0.018098     | 1.31    |
| benchmark/tpcds/sf1/q14.benchmark   | 0.145915     | 0.118087     | 1.24    |
| benchmark/tpcds/sf1/q15.benchmark   | 0.013922     | 0.010922     | 1.27    |
| benchmark/tpcds/sf1/q16.benchmark   | 0.016414     | 0.013004     | 1.26    |
| benchmark/tpcds/sf1/q17.benchmark   | 0.044803     | 0.043485     | 1.03    |
| benchmark/tpcds/sf1/q18.benchmark   | 0.038771     | 0.029428     | 1.32    |
| benchmark/tpcds/sf1/q19.benchmark   | 0.064983     | 0.05922      | 1.1     |
| benchmark/tpcds/sf1/q20.benchmark   | 0.007453     | 0.006466     | 1.15    |
| benchmark/tpcds/sf1/q21.benchmark   | 0.01439      | 0.012422     | 1.16    |
| benchmark/tpcds/sf1/q22.benchmark   | 0.157153     | 0.14152      | 1.11    |
| benchmark/tpcds/sf1/q23.benchmark   | 0.176235     | 0.147533     | 1.19    |
| benchmark/tpcds/sf1/q24.benchmark   | 0.020198     | 0.019874     | 1.02    |
| benchmark/tpcds/sf1/q25.benchmark   | 0.041502     | 0.039936     | 1.04    |
| benchmark/tpcds/sf1/q26.benchmark   | 0.016464     | 0.011583     | 1.42    |
| benchmark/tpcds/sf1/q27.benchmark   | 0.05215      | 0.041791     | 1.25    |
| benchmark/tpcds/sf1/q28.benchmark   | 0.040518     | 0.03531      | 1.15    |
| benchmark/tpcds/sf1/q29.benchmark   | 0.040881     | 0.041036     | 1.0     |
| benchmark/tpcds/sf1/q30.benchmark   | 0.019146     | 0.018062     | 1.06    |
| benchmark/tpcds/sf1/q31.benchmark   | 0.03571      | 0.025806     | 1.38    |
| benchmark/tpcds/sf1/q32.benchmark   | 0.005128     | 0.005216     | 0.98    |
| benchmark/tpcds/sf1/q33.benchmark   | 0.003959     | 0.003255     | 1.22    |
| benchmark/tpcds/sf1/q34.benchmark   | 0.009162     | 0.006769     | 1.35    |
| benchmark/tpcds/sf1/q35.benchmark   | 0.022391     | 0.019893     | 1.13    |
| benchmark/tpcds/sf1/q36.benchmark   | 0.051988     | 0.050476     | 1.03    |
| benchmark/tpcds/sf1/q37.benchmark   | 0.02029      | 0.017253     | 1.18    |
| benchmark/tpcds/sf1/q38.benchmark   | 0.037363     | 0.030465     | 1.23    |
| benchmark/tpcds/sf1/q39.benchmark   | 0.029595     | 0.028656     | 1.03    |
| benchmark/tpcds/sf1/q40.benchmark   | 0.010209     | 0.008255     | 1.24    |
| benchmark/tpcds/sf1/q41.benchmark   | 0.003212     | 0.002958     | 1.09    |
| benchmark/tpcds/sf1/q42.benchmark   | 0.00445      | 0.003737     | 1.19    |
| benchmark/tpcds/sf1/q43.benchmark   | 0.001503     | 0.00159      | 0.95    |
| benchmark/tpcds/sf1/q44.benchmark   | 0.022451     | 0.017115     | 1.31    |
| benchmark/tpcds/sf1/q45.benchmark   | 0.011042     | 0.008722     | 1.27    |
| benchmark/tpcds/sf1/q46.benchmark   | 0.026088     | 0.025541     | 1.02    |
| benchmark/tpcds/sf1/q47.benchmark   | 0.205012     | 0.167645     | 1.22    |
| benchmark/tpcds/sf1/q48.benchmark   | 0.021266     | 0.015839     | 1.34    |
| benchmark/tpcds/sf1/q49.benchmark   | 0.013683     | 0.013473     | 1.02    |
| benchmark/tpcds/sf1/q50.benchmark   | 0.009064     | 0.008113     | 1.12    |
| benchmark/tpcds/sf1/q51.benchmark   | 0.177875     | 0.163451     | 1.09    |
| benchmark/tpcds/sf1/q52.benchmark   | 0.005824     | 0.004035     | 1.44    |
| benchmark/tpcds/sf1/q53.benchmark   | 0.00783      | 0.006307     | 1.24    |
| benchmark/tpcds/sf1/q54.benchmark   | 0.035156     | 0.032135     | 1.09    |
| benchmark/tpcds/sf1/q55.benchmark   | 0.004853     | 0.00405      | 1.2     |
| benchmark/tpcds/sf1/q56.benchmark   | 0.003595     | 0.003817     | 0.94    |
| benchmark/tpcds/sf1/q57.benchmark   | 0.089657     | 0.082367     | 1.09    |
| benchmark/tpcds/sf1/q58.benchmark   | 0.023484     | 0.017556     | 1.34    |
| benchmark/tpcds/sf1/q59.benchmark   | 0.078815     | 0.057953     | 1.36    |
| benchmark/tpcds/sf1/q60.benchmark   | 0.004109     | 0.003672     | 1.12    |
| benchmark/tpcds/sf1/q61.benchmark   | 0.014366     | 0.014585     | 0.98    |
| benchmark/tpcds/sf1/q62.benchmark   | 0.007869     | 0.006674     | 1.18    |
| benchmark/tpcds/sf1/q63.benchmark   | 0.007197     | 0.005237     | 1.37    |
| benchmark/tpcds/sf1/q64.benchmark   | 13.714494    | 7.614648     | 1.8     |
| benchmark/tpcds/sf1/q65.benchmark   | 0.026783     | 0.023911     | 1.12    |
| benchmark/tpcds/sf1/q66.benchmark   | 0.015821     | 0.020134     | 0.79    |
| benchmark/tpcds/sf1/q67.benchmark   | 0.275673     | 0.214192     | 1.29    |
| benchmark/tpcds/sf1/q68.benchmark   | 0.01418      | 0.012303     | 1.15    |
| benchmark/tpcds/sf1/q69.benchmark   | 0.012455     | 0.012012     | 1.04    |
| benchmark/tpcds/sf1/q70.benchmark   | 0.016462     | 0.017262     | 0.95    |
| benchmark/tpcds/sf1/q71.benchmark   | 0.00986      | 0.01039      | 0.95    |
| benchmark/tpcds/sf1/q72.benchmark   | 0.340834     | 0.307028     | 1.11    |
| benchmark/tpcds/sf1/q73.benchmark   | 0.006211     | 0.006532     | 0.95    |
| benchmark/tpcds/sf1/q74.benchmark   | 0.101399     | 0.090019     | 1.13    |
| benchmark/tpcds/sf1/q75.benchmark   | 0.046474     | 0.040122     | 1.16    |
| benchmark/tpcds/sf1/q76.benchmark   | 0.003984     | 0.005082     | 0.78    |
| benchmark/tpcds/sf1/q77.benchmark   | 0.007483     | 0.007425     | 1.01    |
| benchmark/tpcds/sf1/q78.benchmark   | 0.160532     | 0.154567     | 1.04    |
| benchmark/tpcds/sf1/q79.benchmark   | 0.013173     | 0.012653     | 1.04    |
| benchmark/tpcds/sf1/q80.benchmark   | 0.033364     | 0.027492     | 1.21    |
| benchmark/tpcds/sf1/q81.benchmark   | 0.023061     | 0.012597     | 1.83    |
| benchmark/tpcds/sf1/q82.benchmark   | 0.021583     | 0.016182     | 1.33    |
| benchmark/tpcds/sf1/q83.benchmark   | 0.012243     | 0.012691     | 0.96    |
| benchmark/tpcds/sf1/q84.benchmark   | 0.008603     | 0.008665     | 0.99    |
| benchmark/tpcds/sf1/q85.benchmark   | 0.043074     | 0.040369     | 1.07    |
| benchmark/tpcds/sf1/q86.benchmark   | 0.007028     | 0.006767     | 1.04    |
| benchmark/tpcds/sf1/q87.benchmark   | 0.056169     | 0.048174     | 1.17    |
| benchmark/tpcds/sf1/q88.benchmark   | 0.065571     | 0.059809     | 1.1     |
| benchmark/tpcds/sf1/q89.benchmark   | 0.015981     | 0.016204     | 0.99    |
| benchmark/tpcds/sf1/q90.benchmark   | 0.003307     | 0.002894     | 1.14    |
| benchmark/tpcds/sf1/q91.benchmark   | 0.005009     | 0.004541     | 1.1     |
| benchmark/tpcds/sf1/q92.benchmark   | 0.006326     | 0.006879     | 0.92    |
| benchmark/tpcds/sf1/q93.benchmark   | 0.018963     | 0.017156     | 1.11    |
| benchmark/tpcds/sf1/q94.benchmark   | 0.007195     | 0.007728     | 0.93    |
| benchmark/tpcds/sf1/q95.benchmark   | 0.14802      | 0.133197     | 1.11    |
| benchmark/tpcds/sf1/q96.benchmark   | 0.003338     | 0.003719     | 0.9     |
| benchmark/tpcds/sf1/q97.benchmark   | 0.030531     | 0.026163     | 1.17    |
| benchmark/tpcds/sf1/q98.benchmark   | 0.011434     | 0.009373     | 1.22    |
| benchmark/tpcds/sf1/q99.benchmark   | 0.009708     | 0.009699     | 1.0     |
| benchmark/tpch/sf1/q01.benchmark    | 0.032751     | 0.03111      | 1.05    |
| benchmark/tpch/sf1/q02.benchmark    | 0.011537     | 0.009441     | 1.22    |
| benchmark/tpch/sf1/q03.benchmark    | 0.014289     | 0.013477     | 1.06    |
| benchmark/tpch/sf1/q04.benchmark    | 0.02707      | 0.029772     | 0.91    |
| benchmark/tpch/sf1/q05.benchmark    | 0.014454     | 0.01254      | 1.15    |
| benchmark/tpch/sf1/q06.benchmark    | 0.006841     | 0.005507     | 1.24    |
| benchmark/tpch/sf1/q07.benchmark    | 0.039869     | 0.034865     | 1.14    |
| benchmark/tpch/sf1/q08.benchmark    | 0.013084     | 0.010725     | 1.22    |
| benchmark/tpch/sf1/q09.benchmark    | 0.04854      | 0.041421     | 1.17    |
| benchmark/tpch/sf1/q10.benchmark    | 0.036538     | 0.033968     | 1.08    |
| benchmark/tpch/sf1/q11.benchmark    | 0.005786     | 0.005717     | 1.01    |
| benchmark/tpch/sf1/q12.benchmark    | 0.019733     | 0.01751      | 1.13    |
| benchmark/tpch/sf1/q13.benchmark    | 0.033368     | 0.029493     | 1.13    |
| benchmark/tpch/sf1/q14.benchmark    | 0.009455     | 0.008028     | 1.18    |
| benchmark/tpch/sf1/q15.benchmark    | 0.029265     | 0.019057     | 1.54    |
| benchmark/tpch/sf1/q16.benchmark    | 0.029177     | 0.023221     | 1.26    |
| benchmark/tpch/sf1/q17.benchmark    | 0.048231     | 0.040884     | 1.18    |
| benchmark/tpch/sf1/q18.benchmark    | 0.075422     | 0.06719      | 1.12    |
| benchmark/tpch/sf1/q19.benchmark    | 0.028512     | 0.030831     | 0.92    |
| benchmark/tpch/sf1/q20.benchmark    | 0.036819     | 0.02916      | 1.26    |
| benchmark/tpch/sf1/q21.benchmark    | 0.052937     | 0.050807     | 1.04    |
| benchmark/tpch/sf1/q22.benchmark    | 0.022273     | 0.021644     | 1.03    |