### PR TITLE
Correctly call Reset on cast_chunk in CSV writer to prevent string heap from continuously accumulating data

### DIFF
--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -309,6 +309,7 @@ static void WriteCSVSink(ExecutionContext &context, FunctionData &bind_data, Glo
 
 	// first cast the columns of the chunk to varchar
 	auto &cast_chunk = local_data.cast_chunk;
+	cast_chunk.Reset();
 	cast_chunk.SetCardinality(input);
 	for (idx_t col_idx = 0; col_idx < input.ColumnCount(); col_idx++) {
 		if (csv_data.sql_types[col_idx].id() == LogicalTypeId::VARCHAR) {


### PR DESCRIPTION
This fixes a memory leak in the CSV writer that would result in memory usage growing as strings would continuously be added to this cast chunk, only being destroyed after CSV writing was finished.