### PR TITLE
Further clarify database invalidation error, unify db/transaction invalidation, and move errors to error manager

### DIFF
--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include "duckdb/common/mutex.hpp"
-#include "duckdb/common/winapi.hpp"
 #include "duckdb/main/config.hpp"
+#include "duckdb/main/valid_checker.hpp"
+#include "duckdb/common/winapi.hpp"
 #include "duckdb/main/extension.hpp"
 
 namespace duckdb {
@@ -39,8 +39,7 @@ public:
 	DUCKDB_API TaskScheduler &GetScheduler();
 	DUCKDB_API ObjectCache &GetObjectCache();
 	DUCKDB_API ConnectionManager &GetConnectionManager();
-	DUCKDB_API void Invalidate();
-	DUCKDB_API bool IsInvalidated();
+	DUCKDB_API ValidChecker &GetValidChecker();
 	DUCKDB_API void SetExtensionLoaded(const std::string &extension_name);
 
 	idx_t NumberOfThreads();
@@ -64,8 +63,7 @@ private:
 	unique_ptr<ObjectCache> object_cache;
 	unique_ptr<ConnectionManager> connection_manager;
 	unordered_set<std::string> loaded_extensions;
-	//! Set to true if a fatal exception has occurred
-	atomic<bool> is_invalidated;
+	ValidChecker db_validity;
 };
 
 //! The database object. This object holds the catalog and all the

--- a/src/include/duckdb/main/error_manager.hpp
+++ b/src/include/duckdb/main/error_manager.hpp
@@ -19,6 +19,8 @@ class DatabaseInstance;
 enum class ErrorType : uint16_t {
 	// error message types
 	UNSIGNED_EXTENSION = 0,
+	INVALIDATED_TRANSACTION = 1,
+	INVALIDATED_DATABASE = 2,
 
 	// this should always be the last value
 	ERROR_COUNT,
@@ -44,13 +46,18 @@ public:
 		return FormatExceptionRecursive(error_type, values, params...);
 	}
 
+	template <typename... Args>
+	static string FormatException(ClientContext &context, ErrorType error_type, Args... params) {
+		return Get(context).FormatException(error_type, params...);
+	}
+
 	DUCKDB_API static string InvalidUnicodeError(const string &input, const string &context);
 
 	//! Adds a custom error for a specific error type
 	void AddCustomError(ErrorType type, string new_error);
 
-	DUCKDB_API ErrorManager &Get(ClientContext &context);
-	DUCKDB_API ErrorManager &Get(DatabaseInstance &context);
+	DUCKDB_API static ErrorManager &Get(ClientContext &context);
+	DUCKDB_API static ErrorManager &Get(DatabaseInstance &context);
 
 private:
 	map<ErrorType, string> custom_errors;

--- a/src/include/duckdb/main/valid_checker.hpp
+++ b/src/include/duckdb/main/valid_checker.hpp
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/main/valid_checker.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+#include "duckdb/common/atomic.hpp"
+#include "duckdb/common/mutex.hpp"
+
+namespace duckdb {
+class DatabaseInstance;
+class Transaction;
+
+class ValidChecker {
+public:
+	ValidChecker();
+
+	DUCKDB_API static ValidChecker &Get(DatabaseInstance &db);
+	DUCKDB_API static ValidChecker &Get(Transaction &transaction);
+
+	DUCKDB_API void Invalidate(string error);
+	DUCKDB_API bool IsInvalidated();
+	DUCKDB_API string InvalidatedMessage();
+
+	template<class T>
+	static bool IsInvalidated(T &o) {
+		return Get(o).IsInvalidated();
+	}
+	template<class T>
+	static void Invalidate(T &o, string error) {
+		Get(o).Invalidate(move(error));
+	}
+
+	template<class T>
+	static string InvalidatedMessage(T &o) {
+		return Get(o).InvalidatedMessage();
+	}
+
+private:
+	//! Set to true if a fatal exception has occurred
+	mutex invalidate_lock;
+	atomic<bool> is_invalidated;
+	string invalidated_msg;
+};
+
+} // namespace duckdb
+

--- a/src/include/duckdb/main/valid_checker.hpp
+++ b/src/include/duckdb/main/valid_checker.hpp
@@ -27,16 +27,16 @@ public:
 	DUCKDB_API bool IsInvalidated();
 	DUCKDB_API string InvalidatedMessage();
 
-	template<class T>
+	template <class T>
 	static bool IsInvalidated(T &o) {
 		return Get(o).IsInvalidated();
 	}
-	template<class T>
+	template <class T>
 	static void Invalidate(T &o, string error) {
 		Get(o).Invalidate(move(error));
 	}
 
-	template<class T>
+	template <class T>
 	static string InvalidatedMessage(T &o) {
 		return Get(o).InvalidatedMessage();
 	}
@@ -49,4 +49,3 @@ private:
 };
 
 } // namespace duckdb
-

--- a/src/include/duckdb/transaction/transaction.hpp
+++ b/src/include/duckdb/transaction/transaction.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/transaction/undo_buffer.hpp"
 #include "duckdb/common/atomic.hpp"
 #include "duckdb/transaction/transaction_data.hpp"
+#include "duckdb/main/valid_checker.hpp"
 
 namespace duckdb {
 class SequenceCatalogEntry;
@@ -33,7 +34,6 @@ struct UpdateInfo;
 
 //! The transaction object holds information about a currently running or past
 //! transaction
-
 class Transaction {
 public:
 	Transaction(weak_ptr<ClientContext> context, transaction_t start_time, transaction_t transaction_id,
@@ -58,8 +58,8 @@ public:
 	idx_t catalog_version;
 	//! Map of all sequences that were used during the transaction and the value they had in this transaction
 	unordered_map<SequenceCatalogEntry *, SequenceValue> sequence_usage;
-	//! Whether or not the transaction has been invalidated
-	bool is_invalidated;
+	//! The validity checker of the transaction
+	ValidChecker transaction_validity;
 
 public:
 	static Transaction &GetTransaction(ClientContext &context);
@@ -78,8 +78,6 @@ public:
 	//! Cleanup the undo buffer
 	void Cleanup();
 
-	void Invalidate();
-	bool IsInvalidated();
 	bool ChangesMade();
 
 	timestamp_t GetCurrentTransactionStartTimestamp() {

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -31,7 +31,8 @@ add_library_unity(
   extension_prefix_opener.cpp
   query_profiler.cpp
   query_result.cpp
-  stream_query_result.cpp)
+  stream_query_result.cpp
+  valid_checker.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_main>
     PARENT_SCOPE)

--- a/src/main/client_verify.cpp
+++ b/src/main/client_verify.cpp
@@ -75,7 +75,7 @@ PreservedError ClientContext::VerifyQuery(ClientContextLock &lock, const string 
 			statement_verifiers.push_back(move(prepared_statement_verifier));
 		}
 	} else {
-		if (db->IsInvalidated()) {
+		if (ValidChecker::IsInvalidated(*db)) {
 			return original->materialized_result->GetErrorObject();
 		}
 	}

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -47,7 +47,7 @@ DBConfig::DBConfig(std::unordered_map<string, string> &config_dict, bool read_on
 DBConfig::~DBConfig() {
 }
 
-DatabaseInstance::DatabaseInstance() : is_invalidated(false) {
+DatabaseInstance::DatabaseInstance() {
 }
 
 DatabaseInstance::~DatabaseInstance() {
@@ -272,6 +272,9 @@ void DatabaseInstance::Configure(DBConfig &new_config) {
 	config.replacement_opens = move(new_config.replacement_opens);
 	config.parser_extensions = move(new_config.parser_extensions);
 	config.error_manager = move(new_config.error_manager);
+	if (!config.error_manager) {
+		config.error_manager = make_unique<ErrorManager>();
+	}
 }
 
 DBConfig &DBConfig::GetConfig(ClientContext &context) {
@@ -324,11 +327,12 @@ string ClientConfig::ExtractTimezone() const {
 	}
 }
 
-void DatabaseInstance::Invalidate() {
-	this->is_invalidated = true;
+ValidChecker &DatabaseInstance::GetValidChecker() {
+	return db_validity;
 }
-bool DatabaseInstance::IsInvalidated() {
-	return this->is_invalidated;
+
+ValidChecker &ValidChecker::Get(DatabaseInstance &db) {
+	return db.GetValidChecker();
 }
 
 } // namespace duckdb

--- a/src/main/error_manager.cpp
+++ b/src/main/error_manager.cpp
@@ -13,6 +13,9 @@ static DefaultError internal_errors[] = {
     {ErrorType::UNSIGNED_EXTENSION,
      "Extension \"%s\" could not be loaded because its signature is either missing or invalid and unsigned extensions "
      "are disabled by configuration (allow_unsigned_extensions)"},
+    {ErrorType::INVALIDATED_TRANSACTION, "Current transaction is aborted (please ROLLBACK)"},
+    {ErrorType::INVALIDATED_DATABASE, "Failed: database has been invalidated because of a previous fatal error. The "
+                                      "database must be restarted prior to being used again.\nOriginal error: \"%s\""},
     {ErrorType::INVALID, nullptr}};
 
 string ErrorManager::FormatExceptionRecursive(ErrorType error_type, vector<ExceptionFormatValue> &values) {

--- a/src/main/valid_checker.cpp
+++ b/src/main/valid_checker.cpp
@@ -2,7 +2,8 @@
 
 namespace duckdb {
 
-ValidChecker::ValidChecker() : is_invalidated(false) {}
+ValidChecker::ValidChecker() : is_invalidated(false) {
+}
 
 void ValidChecker::Invalidate(string error) {
 	lock_guard<mutex> l(invalidate_lock);
@@ -18,4 +19,4 @@ string ValidChecker::InvalidatedMessage() {
 	lock_guard<mutex> l(invalidate_lock);
 	return invalidated_msg;
 }
-}
+} // namespace duckdb

--- a/src/main/valid_checker.cpp
+++ b/src/main/valid_checker.cpp
@@ -1,0 +1,21 @@
+#include "duckdb/main/valid_checker.hpp"
+
+namespace duckdb {
+
+ValidChecker::ValidChecker() : is_invalidated(false) {}
+
+void ValidChecker::Invalidate(string error) {
+	lock_guard<mutex> l(invalidate_lock);
+	this->is_invalidated = true;
+	this->invalidated_msg = move(error);
+}
+
+bool ValidChecker::IsInvalidated() {
+	return this->is_invalidated;
+}
+
+string ValidChecker::InvalidatedMessage() {
+	lock_guard<mutex> l(invalidate_lock);
+	return invalidated_msg;
+}
+}

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -30,8 +30,7 @@ Transaction::Transaction(weak_ptr<ClientContext> context_p, transaction_t start_
                          timestamp_t start_timestamp, idx_t catalog_version)
     : context(move(context_p)), start_time(start_time), transaction_id(transaction_id), commit_id(0),
       highest_active_query(0), active_query(MAXIMUM_QUERY_ID), start_timestamp(start_timestamp),
-      catalog_version(catalog_version), is_invalidated(false), undo_buffer(context.lock()),
-      storage(make_unique<LocalStorage>(*this)) {
+      catalog_version(catalog_version), undo_buffer(context.lock()), storage(make_unique<LocalStorage>(*this)) {
 }
 
 Transaction::~Transaction() {
@@ -138,11 +137,8 @@ void Transaction::Cleanup() {
 	undo_buffer.Cleanup();
 }
 
-void Transaction::Invalidate() {
-	is_invalidated = true;
-}
-bool Transaction::IsInvalidated() {
-	return is_invalidated;
+ValidChecker &ValidChecker::Get(Transaction &transaction) {
+	return transaction.transaction_validity;
 }
 
 } // namespace duckdb


### PR DESCRIPTION
* General clean-up of the invalidation of a database/transaction to also include the original error that lead to the invalidation
* Unify invalidation of database/transaction in `ValidChecker` class
* Move the error messages to the error manager