### PR TITLE
Fix distinct aggregate race: insert next event before scheduling tasks

### DIFF
--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -690,6 +690,10 @@ public:
 
 public:
 	void Schedule() override {
+		//! Now that all tables are combined, it's time to do the distinct aggregations
+		auto new_event = make_shared<HashDistinctAggregateFinalizeEvent>(op, gstate, *pipeline, client);
+		this->InsertEvent(move(new_event));
+
 		vector<unique_ptr<Task>> tasks;
 		for (idx_t i = 0; i < op.groupings.size(); i++) {
 			auto &grouping = op.groupings[i];
@@ -706,10 +710,6 @@ public:
 
 		D_ASSERT(!tasks.empty());
 		SetTasks(move(tasks));
-
-		//! Now that all tables are combined, it's time to do the distinct aggregations
-		auto new_event = make_shared<HashDistinctAggregateFinalizeEvent>(op, gstate, *pipeline, client);
-		this->InsertEvent(move(new_event));
 	}
 };
 

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -690,10 +690,6 @@ public:
 
 public:
 	void Schedule() override {
-		//! Now that all tables are combined, it's time to do the distinct aggregations
-		auto new_event = make_shared<HashDistinctAggregateFinalizeEvent>(op, gstate, *pipeline, client);
-		this->InsertEvent(move(new_event));
-
 		vector<unique_ptr<Task>> tasks;
 		for (idx_t i = 0; i < op.groupings.size(); i++) {
 			auto &grouping = op.groupings[i];
@@ -710,6 +706,12 @@ public:
 
 		D_ASSERT(!tasks.empty());
 		SetTasks(move(tasks));
+	}
+
+	void FinishEvent() override {
+		//! Now that all tables are combined, it's time to do the distinct aggregations
+		auto new_event = make_shared<HashDistinctAggregateFinalizeEvent>(op, gstate, *pipeline, client);
+		this->InsertEvent(move(new_event));
 	}
 };
 


### PR DESCRIPTION
We need to insert the next event BEFORE scheduling the tasks. Otherwise we might finish all tasks before the next event is correctly scheduled, causing the subsequent event to be incorrectly skipped. 

This is very rare but has already happened on CI. Adding a sleep and running the TPC-H SF0.1 test makes it easily reproducible on Q16:

```cpp
		SetTasks(move(tasks));
...
		std::this_thread::sleep_for(std::chrono::milliseconds(1000));

		//! Now that all tables are combined, it's time to do the distinct aggregations
		auto new_event = make_shared<HashDistinctAggregateFinalizeEvent>(op, gstate, *pipeline, client);
		this->InsertEvent(move(new_event));

```

No results are output because the finalize is never called:

```
Wrong row count in query! (test/sql/tpch/tpch_sf01.test_slow:21)!
Expected 2762 rows, but got 0 rows
================================================================================
PRAGMA tpch(16);
================================================================================
Expected result:
================================================================================
Brand#14	SMALL ANODIZED NICKEL	45	12
...
Brand#53	MEDIUM BURNISHED BRASS	49	3
================================================================================
Actual result:
================================================================================
p_brand	p_type	p_size	supplier_cnt	
VARCHAR	VARCHAR	INTEGER	BIGINT	
[ Rows: 0]


```