### PR TITLE
Use cmake's find_package to trace git executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,24 +196,29 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "SunOS")
   set(SUN TRUE)
 endif()
 
-if (NOT DEFINED GIT_COMMIT_HASH)
+find_package(Git)
+if(Git_FOUND)
+  if (NOT DEFINED GIT_COMMIT_HASH)
+    execute_process(
+            COMMAND ${GIT_EXECUTABLE} log -1 --format=%h
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            RESULT_VARIABLE GIT_RESULT
+            OUTPUT_VARIABLE GIT_COMMIT_HASH
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+  endif()
   execute_process(
-          COMMAND git log -1 --format=%h
+          COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-          RESULT_VARIABLE GIT_RESULT
-          OUTPUT_VARIABLE GIT_COMMIT_HASH
+          OUTPUT_VARIABLE GIT_LAST_TAG
           OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(
+          COMMAND ${GIT_EXECUTABLE} describe --tags --long
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+          OUTPUT_VARIABLE GIT_ITERATION
+          OUTPUT_STRIP_TRAILING_WHITESPACE)
+else()
+  message("Git NOT FOUND")
 endif()
-execute_process(
-        COMMAND git describe --tags --abbrev=0
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        OUTPUT_VARIABLE GIT_LAST_TAG
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process(
-        COMMAND git describe --tags --long
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        OUTPUT_VARIABLE GIT_ITERATION
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 if(GIT_RESULT EQUAL "0")
   string(REGEX REPLACE "v([0-9]+).[0-9]+.[0-9]+" "\\1" DUCKDB_MAJOR_VERSION "${GIT_LAST_TAG}")
@@ -237,6 +242,8 @@ else()
   set(DUCKDB_DEV_ITERATION 0)
   set(DUCKDB_VERSION "v${DUCKDB_MAJOR_VERSION}.${DUCKDB_MINOR_VERSION}.${DUCKDB_PATCH_VERSION}-dev${DUCKDB_DEV_ITERATION}")
 endif()
+
+message(STATUS "git hash ${GIT_COMMIT_HASH}, version ${DUCKDB_VERSION}")
 
 option(AMALGAMATION_BUILD
        "Build from the amalgamation files, rather than from the normal sources."


### PR DESCRIPTION
Our ARM Docker build (powered by GitHub actions) failed to find the git executable, resulting in `pragma_version()` returning a mysterious `Error while loading /usr/local/sbin/git: No such file or directory` string. 

Debugging the source of trouble, it seems that `execute_process` (and it's underlying [execpv](https://linux.die.net/man/3/execvp)) fail to find `git`, even though the `git` is available at `/usr/bin` and the path is `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`. Specifying a full path as a command, or copying over `git` into `/usr/local/sbin` fixes the problem, which was curious. Obviously, local docker builds on M1 work fine. AMD builds on GitHub work fine.

Rather than going down the rabbit hole of this rather esoteric issue with `execute_process`, this commit uses CMake's find_package to find the full path of `git` and using it for `execute_process`. This is considered a best practice, and a side effect solves our issue.