### PR TITLE
Physical batch insert: correctly optimistically flush batches to disk that are close to our row group size

### DIFF
--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -255,10 +255,10 @@ public:
 		if (!current_collection) {
 			return;
 		}
-		if (!written_to_disk || current_collection->GetTotalRows() < LocalStorage::MERGE_THRESHOLD) {
+		if (!written_to_disk && current_collection->GetTotalRows() < LocalStorage::MERGE_THRESHOLD) {
 			return;
 		}
-		writer->FlushToDisk(*current_collection);
+		writer->FlushToDisk(*current_collection, true);
 	}
 
 	void CreateNewCollection(TableCatalogEntry *table, const vector<LogicalType> &insert_types) {
@@ -307,7 +307,6 @@ SinkResultType PhysicalBatchInsert::Sink(ExecutionContext &context, GlobalSinkSt
 		TransactionData tdata(0, 0);
 		lstate.current_collection->FinalizeAppend(tdata, lstate.current_append_state);
 		lstate.FlushToDisk();
-
 		gstate.AddCollection(context.client, lstate.current_index, move(lstate.current_collection), lstate.writer,
 		                     &lstate.written_to_disk);
 		lstate.CreateNewCollection(table, insert_types);

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -28,7 +28,7 @@ public:
 	//! Flushes a specific row group to disk
 	void FlushToDisk(RowGroup *row_group);
 	//! Flushes the final row group to disk (if any)
-	void FlushToDisk(RowGroupCollection &row_groups);
+	void FlushToDisk(RowGroupCollection &row_groups, bool force = false);
 	//! Final flush: flush the partial block manager to disk
 	void FinalFlush();
 

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -35,6 +35,10 @@ public:
 	void Rollback();
 
 private:
+	//! Prepare a write to disk
+	bool PrepareWrite();
+
+private:
 	//! The table
 	DataTable *table;
 	//! The partial block manager (if we created one yet)

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -64,10 +64,14 @@ void OptimisticDataWriter::FlushToDisk(RowGroup *row_group) {
 	}
 }
 
-void OptimisticDataWriter::FlushToDisk(RowGroupCollection &row_groups) {
+void OptimisticDataWriter::FlushToDisk(RowGroupCollection &row_groups, bool force) {
 	if (!partial_manager) {
-		// no partial manager - nothing to flush
-		return;
+		if (!force) {
+			// no partial manager - nothing to flush
+			return;
+		}
+		auto &block_manager = table->info->table_io_manager->GetBlockManagerForRowData();
+		partial_manager = make_unique<PartialBlockManager>(block_manager);
 	}
 	// flush the last row group
 	FlushToDisk(row_groups.GetRowGroup(-1));

--- a/test/sql/storage/parallel/batch_insert_small_batches.test_slow
+++ b/test/sql/storage/parallel/batch_insert_small_batches.test_slow
@@ -6,11 +6,10 @@ require parquet
 
 load __TEST_DIR__/insert_small_batches.db
 
-#statement ok
-#SET threads=1;
+foreach row_group_size 5000 100000
 
 statement ok
-COPY (FROM range(1000000) tbl(i)) TO '__TEST_DIR__/small_batches.parquet' (ROW_GROUP_SIZE 5000)
+COPY (FROM range(1000000) tbl(i)) TO '__TEST_DIR__/small_batches.parquet' (ROW_GROUP_SIZE ${row_group_size})
 
 statement ok
 CREATE VIEW v1 AS SELECT * FROM '__TEST_DIR__/small_batches.parquet'
@@ -158,3 +157,23 @@ SELECT * FROM integers3 LIMIT 5 OFFSET 9999
 20001
 20002
 20003
+
+statement ok
+DROP VIEW v1
+
+statement ok
+DROP VIEW v2
+
+statement ok
+DROP VIEW v3
+
+statement ok
+DROP TABLE integers
+
+statement ok
+DROP TABLE integers2
+
+statement ok
+DROP TABLE integers3
+
+endloop


### PR DESCRIPTION
Optimistic disk flushing was (accidentally) not being triggered correctly when writing batches close to our row group size (between 60K rows and 120K rows), because of an incorrect condition (`||` instead of `&&`) and the optimistic write incorrectly bailing out when nothing has been written yet.