### PR TITLE
Issue #5240: DATE_TRUNC Statistics Orientation

### DIFF
--- a/src/function/scalar/date/date_trunc.cpp
+++ b/src/function/scalar/date/date_trunc.cpp
@@ -710,7 +710,7 @@ static unique_ptr<FunctionData> DateTruncBind(ClientContext &context, ScalarFunc
 			bound_function.statistics = DateTruncStats<timestamp_t, timestamp_t>(part_code);
 			break;
 		case LogicalType::DATE:
-			bound_function.statistics = DateTruncStats<timestamp_t, date_t>(part_code);
+			bound_function.statistics = DateTruncStats<date_t, timestamp_t>(part_code);
 			break;
 		default:
 			throw NotImplementedException("Temporal argument type for DATETRUNC");

--- a/test/sql/function/date/date_trunc_stats.test
+++ b/test/sql/function/date/date_trunc_stats.test
@@ -10,3 +10,7 @@ CREATE table T1(A0 TIMESTAMP)
 
 statement ok
 SELECT date_trunc('DAY', A0) FROM T1
+
+# Statistics typing for DATE => TIMESTAMP
+statement error
+SELECT datetrunc('milliseconds', DATE '-2005205-7-28');


### PR DESCRIPTION
Fix the statistics template arguments for DATE => TIMESTAMP truncation.

fixes:5240