### PR TITLE
Issue #5239: DATE_DIFF Microseconds Overflow

### DIFF
--- a/src/function/scalar/date/date_diff.cpp
+++ b/src/function/scalar/date/date_diff.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/function/scalar/date_functions.hpp"
 #include "duckdb/common/enums/date_part_specifier.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/operator/subtract.hpp"
 #include "duckdb/common/types/date.hpp"
 #include "duckdb/common/types/interval.hpp"
 #include "duckdb/common/types/time.hpp"
@@ -195,7 +196,9 @@ int64_t DateDiff::ISOYearOperator::Operation(timestamp_t startdate, timestamp_t 
 
 template <>
 int64_t DateDiff::MicrosecondsOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
-	return Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate);
+	const auto start = Timestamp::GetEpochMicroSeconds(startdate);
+	const auto end = Timestamp::GetEpochMicroSeconds(enddate);
+	return SubtractOperatorOverflowCheck::Operation<int64_t, int64_t, int64_t>(end, start);
 }
 
 template <>

--- a/test/sql/function/timestamp/date_diff.test_coverage
+++ b/test/sql/function/timestamp/date_diff.test_coverage
@@ -333,6 +333,14 @@ endloop
 endloop
 
 #
+# Errors
+#
+
+# Issue #5239: Overflow
+statement error
+SELECT datediff('microseconds',TIMESTAMP '276858-10-21 9:36:33',TIMESTAMP '-222154-6-30 5:19:49');----
+
+#
 # VARCHAR
 #
 statement ok


### PR DESCRIPTION
Use overflow-detecting subtraction for microseconds as the precision is high enough that it could overflow.

fixes: 5239