### PR TITLE
token url encoding bug in S3 glob

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -552,6 +552,8 @@ jobs:
     env:
       BUILD_VISUALIZER: 1
       BUILD_HTTPFS: 1
+      BUILD_TPCH: 1
+      BUILD_TPCDS: 1
       S3_TEST_SERVER_AVAILABLE: 1
       GEN: ninja
 

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -912,7 +912,7 @@ string AWSListObjectV2::Request(string &path, HTTPParams &http_params, S3AuthPar
 
 	string req_params = "";
 	if (!continuation_token.empty()) {
-		req_params += "continuation-token=" + S3FileSystem::UrlEncode(continuation_token);
+		req_params += "continuation-token=" + S3FileSystem::UrlEncode(continuation_token, true);
 		req_params += "&";
 	}
 	req_params += "encoding-type=url&list-type=2";

--- a/test/sql/copy/s3/parquet_s3_tpcds.test_slow
+++ b/test/sql/copy/s3/parquet_s3_tpcds.test_slow
@@ -14,7 +14,7 @@ require-env S3_TEST_SERVER_AVAILABLE 1
 set ignore_error_messages
 
 statement ok
-SET s3_secret_access_key='S3RVER';SET s3_access_key_id='S3RVER';SET s3_region='eu-west-1'; SET s3_endpoint='s3.s3rver-endpoint.com:4923';SET s3_use_ssl=false;
+SET s3_secret_access_key='minio_duckdb_user_password';SET s3_access_key_id='minio_duckdb_user';SET s3_region='eu-west-1'; SET s3_endpoint='duckdb-minio.com:9000';SET s3_use_ssl=false;
 
 # answers are generated from postgres
 # hence check with NULLS LAST flag

--- a/test/sql/copy/s3/parquet_s3_tpch.test_slow
+++ b/test/sql/copy/s3/parquet_s3_tpch.test_slow
@@ -14,7 +14,7 @@ require-env S3_TEST_SERVER_AVAILABLE 1
 set ignore_error_messages
 
 statement ok
-SET s3_secret_access_key='S3RVER';SET s3_access_key_id='S3RVER';SET s3_region='eu-west-1'; SET s3_endpoint='s3.s3rver-endpoint.com:4923';SET s3_use_ssl=false;
+SET s3_secret_access_key='minio_duckdb_user_password';SET s3_access_key_id='minio_duckdb_user';SET s3_region='eu-west-1'; SET s3_endpoint='duckdb-minio.com:9000';SET s3_use_ssl=false;
 
 # Copy files to S3 before beginning tests
 statement ok


### PR DESCRIPTION
fixes #4975 and #5190

Continuation token for AWS ListObject calls with >1000 entries should be url encoding slashes too. Minio either doesn't use slashes in their tokens or doesn't care apparently

Also found 2 tests that were not run in CI due to their required extension not being built