### PR TITLE
Issue #5258: Inverse Percentile NULLs

### DIFF
--- a/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -29,9 +29,15 @@ static void InvertPercentileFractions(unique_ptr<ParsedExpression> &fractions) {
 	if (value.type().id() == LogicalTypeId::LIST) {
 		vector<Value> values;
 		for (const auto &element_val : ListValue::GetChildren(value)) {
-			values.push_back(Value::DOUBLE(1 - element_val.GetValue<double>()));
+			if (element_val.IsNull()) {
+				values.push_back(element_val);
+			} else {
+				values.push_back(Value::DOUBLE(1 - element_val.GetValue<double>()));
+			}
 		}
 		bound.expr = make_unique<BoundConstantExpression>(Value::LIST(values));
+	} else if (value.IsNull()) {
+		bound.expr = make_unique<BoundConstantExpression>(value);
 	} else {
 		bound.expr = make_unique<BoundConstantExpression>(Value::DOUBLE(1 - value.GetValue<double>()));
 	}

--- a/test/sql/aggregate/aggregates/test_ordered_aggregates.test
+++ b/test/sql/aggregate/aggregates/test_ordered_aggregates.test
@@ -119,3 +119,10 @@ select percentile_cont('duck') within group(order by i) from generate_series(0,1
 # aggregate function calls cannot be nested
 statement error
 SELECT percentile_disc(sum(1)) WITHIN GROUP (ORDER BY 1 DESC);
+
+# NULL fractions with DESC should not be inverted
+statement error
+SELECT percentile_disc(strftime(DATE '1-11-25',NULL)) WITHIN GROUP (ORDER BY 1 DESC);
+
+statement error
+SELECT percentile_cont(CASE 1 WHEN 2 THEN 3 END) WITHIN GROUP (ORDER BY 1 DESC);


### PR DESCRIPTION
Make the percentile inversion code NULL-aware.

fixes:5258