### PR TITLE
6. Like empty list assertion error

### DIFF
--- a/src/function/cast/list_casts.cpp
+++ b/src/function/cast/list_casts.cpp
@@ -61,6 +61,7 @@ static bool ListToVarcharCast(Vector &source, Vector &result, idx_t count, CastP
 	auto list_data = FlatVector::GetData<list_entry_t>(varchar_list);
 	auto &validity = FlatVector::Validity(varchar_list);
 
+	child.Flatten(count);
 	auto child_data = FlatVector::GetData<string_t>(child);
 	auto &child_validity = FlatVector::Validity(child);
 

--- a/test/fuzzer/pedro/like_empty_list.test
+++ b/test/fuzzer/pedro/like_empty_list.test
@@ -11,6 +11,11 @@ SELECT '1' LIKE [];
 false
 
 query I
+SELECT [] LIKE 1;
+----
+false
+
+query I
 SELECT [] LIKE [];
 ----
 true

--- a/test/fuzzer/pedro/like_empty_list.test
+++ b/test/fuzzer/pedro/like_empty_list.test
@@ -1,0 +1,21 @@
+# name: test/fuzzer/pedro/like_empty_list.test
+# description: Issue #4978 (#6):  Like empty list assertion error
+# group: [pedro]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT '1' LIKE [];
+----
+false
+
+query I
+SELECT [] LIKE [];
+----
+true
+
+query I
+SELECT 1 FROM (SELECT 2) t1(c0) NATURAL RIGHT JOIN (SELECT 2) t0(c0) WHERE (0, t1.c0) NOT LIKE '0';
+----
+1


### PR DESCRIPTION
Addresses issue #4978 nr. 6: Like empty list assertion error:
Queries such as : 
``` SELECT '1' LIKE []; ```
triggered the assertion: Assertion `vector.GetVectorType() == VectorType::FLAT_VECTOR'
This was due to the casting of LIST->VARCHAR, whereby the child of list is not set as a flat vector, because the child casting fails since type is unknown (empty). 