### PR TITLE
Cast overflow varchar to decimal

### DIFF
--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -1578,7 +1578,7 @@ bool TryCast::Operation(string_t input, hugeint_t &result, bool strict) {
 //===--------------------------------------------------------------------===//
 template <class T>
 struct DecimalCastData {
-	typedef T type;
+	typedef T type_t;
 	T result;
 	uint8_t width;
 	uint8_t scale;
@@ -1602,12 +1602,12 @@ struct DecimalCastOperation {
 		}
 		state.digit_count++;
 		if (NEGATIVE) {
-			if (state.result < (NumericLimits<typename T::type>::Minimum() / 10)) {
+			if (state.result < (NumericLimits<typename T::type_t>::Minimum() / 10)) {
 				return false;
 			}
 			state.result = state.result * 10 - digit;
 		} else {
-			if (state.result > (NumericLimits<typename T::type>::Maximum() / 10)) {
+			if (state.result > (NumericLimits<typename T::type_t>::Maximum() / 10)) {
 				return false;
 			}
 			state.result = state.result * 10 + digit;

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -1592,28 +1592,28 @@ struct DecimalCastData {
 
 template <typename T>
 constexpr T MaxValue() {
-    return (std::numeric_limits<T>::max)();
+	return (std::numeric_limits<T>::max)();
 }
 
 template <>
 hugeint_t MaxValue<hugeint_t>() {
-    hugeint_t huge;
-    huge.upper = MaxValue<int64_t>();
-    huge.lower = MaxValue<uint64_t>();
-    return huge;
+	hugeint_t huge;
+	huge.upper = MaxValue<int64_t>();
+	huge.lower = MaxValue<uint64_t>();
+	return huge;
 }
 
 template <typename T>
 constexpr T MinValue() {
-    return (std::numeric_limits<T>::min)();
+	return (std::numeric_limits<T>::min)();
 }
 
 template <>
 hugeint_t MinValue<hugeint_t>() {
-    hugeint_t huge;
-    huge.upper = MinValue<int64_t>();
-    huge.lower = MaxValue<uint64_t>();
-    return huge;
+	hugeint_t huge;
+	huge.upper = MinValue<int64_t>();
+	huge.lower = MaxValue<uint64_t>();
+	return huge;
 }
 
 struct DecimalCastOperation {
@@ -1629,14 +1629,14 @@ struct DecimalCastOperation {
 		}
 		state.digit_count++;
 		if (NEGATIVE) {
-            if (state.result < (MinValue<typename T::type>() / 10)){
-                return false;
-            }
+			if (state.result < (MinValue<typename T::type>() / 10)) {
+				return false;
+			}
 			state.result = state.result * 10 - digit;
 		} else {
-            if (state.result > (MaxValue<typename T::type>() / 10)){
-                return false;
-            }
+			if (state.result > (MaxValue<typename T::type>() / 10)) {
+				return false;
+			}
 			state.result = state.result * 10 + digit;
 		}
 		return true;

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -23,6 +23,7 @@
 
 #include <cctype>
 #include <cmath>
+#include <limits>
 #include <cstdlib>
 
 namespace duckdb {
@@ -1578,6 +1579,7 @@ bool TryCast::Operation(string_t input, hugeint_t &result, bool strict) {
 //===--------------------------------------------------------------------===//
 template <class T>
 struct DecimalCastData {
+	typedef T type;
 	T result;
 	uint8_t width;
 	uint8_t scale;
@@ -1587,6 +1589,32 @@ struct DecimalCastData {
 	uint8_t excessive_decimals;
 	bool positive_exponent;
 };
+
+template <typename T>
+constexpr T MaxValue() {
+    return (std::numeric_limits<T>::max)();
+}
+
+template <>
+hugeint_t MaxValue<hugeint_t>() {
+    hugeint_t huge;
+    huge.upper = MaxValue<int64_t>();
+    huge.lower = MaxValue<uint64_t>();
+    return huge;
+}
+
+template <typename T>
+constexpr T MinValue() {
+    return (std::numeric_limits<T>::min)();
+}
+
+template <>
+hugeint_t MinValue<hugeint_t>() {
+    hugeint_t huge;
+    huge.upper = MinValue<int64_t>();
+    huge.lower = MaxValue<uint64_t>();
+    return huge;
+}
 
 struct DecimalCastOperation {
 	template <class T, bool NEGATIVE>
@@ -1601,8 +1629,14 @@ struct DecimalCastOperation {
 		}
 		state.digit_count++;
 		if (NEGATIVE) {
+            if (state.result < (MinValue<typename T::type>() / 10)){
+                return false;
+            }
 			state.result = state.result * 10 - digit;
 		} else {
+            if (state.result > (MaxValue<typename T::type>() / 10)){
+                return false;
+            }
 			state.result = state.result * 10 + digit;
 		}
 		return true;

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -1579,7 +1579,7 @@ bool TryCast::Operation(string_t input, hugeint_t &result, bool strict) {
 template <class TYPE>
 struct DecimalCastData {
 	typedef TYPE type_t;
-    TYPE result;
+	TYPE result;
 	uint8_t width;
 	uint8_t scale;
 	uint8_t digit_count;

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -1590,32 +1590,6 @@ struct DecimalCastData {
 	bool positive_exponent;
 };
 
-template <typename T>
-constexpr T MaxValue() {
-	return (std::numeric_limits<T>::max)();
-}
-
-template <>
-hugeint_t MaxValue<hugeint_t>() {
-	hugeint_t huge;
-	huge.upper = MaxValue<int64_t>();
-	huge.lower = MaxValue<uint64_t>();
-	return huge;
-}
-
-template <typename T>
-constexpr T MinValue() {
-	return (std::numeric_limits<T>::min)();
-}
-
-template <>
-hugeint_t MinValue<hugeint_t>() {
-	hugeint_t huge;
-	huge.upper = MinValue<int64_t>();
-	huge.lower = MaxValue<uint64_t>();
-	return huge;
-}
-
 struct DecimalCastOperation {
 	template <class T, bool NEGATIVE>
 	static bool HandleDigit(T &state, uint8_t digit) {
@@ -1629,12 +1603,12 @@ struct DecimalCastOperation {
 		}
 		state.digit_count++;
 		if (NEGATIVE) {
-			if (state.result < (MinValue<typename T::type>() / 10)) {
+			if (state.result < (NumericLimits<typename T::type>::Minimum() / 10)) {
 				return false;
 			}
 			state.result = state.result * 10 - digit;
 		} else {
-			if (state.result > (MaxValue<typename T::type>() / 10)) {
+			if (state.result > (NumericLimits<typename T::type>::Maximum() / 10)) {
 				return false;
 			}
 			state.result = state.result * 10 + digit;

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -23,7 +23,6 @@
 
 #include <cctype>
 #include <cmath>
-#include <limits>
 #include <cstdlib>
 
 namespace duckdb {

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -1576,10 +1576,10 @@ bool TryCast::Operation(string_t input, hugeint_t &result, bool strict) {
 //===--------------------------------------------------------------------===//
 // Decimal String Cast
 //===--------------------------------------------------------------------===//
-template <class T>
+template <class TYPE>
 struct DecimalCastData {
-	typedef T type_t;
-	T result;
+	typedef TYPE type_t;
+    TYPE result;
 	uint8_t width;
 	uint8_t scale;
 	uint8_t digit_count;

--- a/test/fuzzer/pedro/overflow_varchar_decimal_cast.test
+++ b/test/fuzzer/pedro/overflow_varchar_decimal_cast.test
@@ -1,0 +1,21 @@
+# name: test/fuzzer/pedro/overflow_varchar_decimal_cast.test
+# group: [pedro]
+
+statement ok
+PRAGMA enable_verification
+
+statement error
+SELECT CAST(strftime(TIMESTAMP '1-1-1 0:00:00',340282346638528859811704183484516925440.0) AS DECIMAL(10,2));
+
+query I
+SELECT '552.123242346e+11'::DECIMAL;
+----
+55212324234600.000
+
+query I
+SELECT '-3.4028234663852886e+16'::DECIMAL(30);
+----
+-34028234663852886
+
+statement error
+SELECT '-3.4028234663852886e+38'::DECIMAL;

--- a/test/sql/show_select/test_describe_all.test
+++ b/test/sql/show_select/test_describe_all.test
@@ -10,6 +10,7 @@ CREATE TABLE integers(i INTEGER, j INTEGER, a INTEGER);
 
 statement ok
 DESCRIBE;
+
 query IIII
 DESCRIBE
 ----

--- a/test/sql/show_select/test_describe_all.test
+++ b/test/sql/show_select/test_describe_all.test
@@ -5,27 +5,12 @@
 statement ok
 PRAGMA enable_verification
 
-
-# Describe all
 statement ok
 CREATE TABLE integers(i INTEGER, j INTEGER, a INTEGER);
 
 statement ok
 DESCRIBE;
-
 query IIII
 DESCRIBE
 ----
 integers	[a, i, j]	[INTEGER, INTEGER, INTEGER]	False
-
-# Describe an Enum table
-statement ok
-CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy', 'grumpy');
-
-statement ok
-CREATE TABLE enums(current_mood mood)
-
-query IIIIII
-DESCRIBE enums
-----
-current_mood	ENUM	YES	NULL	NULL	NULL

--- a/test/sql/show_select/test_describe_all.test
+++ b/test/sql/show_select/test_describe_all.test
@@ -5,6 +5,8 @@
 statement ok
 PRAGMA enable_verification
 
+
+# Describe all
 statement ok
 CREATE TABLE integers(i INTEGER, j INTEGER, a INTEGER);
 
@@ -15,3 +17,15 @@ query IIII
 DESCRIBE
 ----
 integers	[a, i, j]	[INTEGER, INTEGER, INTEGER]	False
+
+# Describe an Enum table
+statement ok
+CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy', 'grumpy');
+
+statement ok
+CREATE TABLE enums(current_mood mood)
+
+query IIIIII
+DESCRIBE enums
+----
+current_mood	ENUM	YES	NULL	NULL	NULL


### PR DESCRIPTION
Addresses issue #4978 nr. 35: Cast overflow. Example:
```SELECT '-3.4028234663852886e+38'::DECIMAL```

When casting number represented as varchar to a decimal value it would overflow when too large to fit into the underlying integer types of a decimal, now it returns a casting error instead.  
<strike>  I’ve handled this issue by adding numeric limits check which checks limits for int16, int32, int64, and huge-int required a specialisation check. </strike>
I just found out this functionality was already available in the codebase ! So used that instead