### PR TITLE
Enum Types are now described as enums, not name

### DIFF
--- a/src/function/table/system/pragma_table_info.cpp
+++ b/src/function/table/system/pragma_table_info.cpp
@@ -111,7 +111,11 @@ static void PragmaTableInfoTable(PragmaTableOperatorData &data, TableCatalogEntr
 		// "name", PhysicalType::VARCHAR
 		output.SetValue(1, index, Value(column.Name()));
 		// "type", PhysicalType::VARCHAR
-		output.SetValue(2, index, Value(column.Type().ToString()));
+		if (column.Type().id() == LogicalTypeId::ENUM) {
+			output.SetValue(2, index, Value("ENUM")); // overwrites typename for compatibility with SQLAlchemy.See #5174
+		} else {
+			output.SetValue(2, index, Value(column.Type().ToString()));
+		}
 		// "notnull", PhysicalType::BOOL
 		output.SetValue(3, index, Value::BOOLEAN(not_null));
 		// "dflt_value", PhysicalType::VARCHAR

--- a/test/sql/show_select/test_describe_all.test
+++ b/test/sql/show_select/test_describe_all.test
@@ -5,6 +5,7 @@
 statement ok
 PRAGMA enable_verification
 
+# Describe all
 statement ok
 CREATE TABLE integers(i INTEGER, j INTEGER, a INTEGER);
 
@@ -15,3 +16,15 @@ query IIII
 DESCRIBE
 ----
 integers	[a, i, j]	[INTEGER, INTEGER, INTEGER]	False
+
+# Describe an Enum table
+statement ok
+CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy', 'grumpy');
+
+statement ok
+CREATE TABLE enums(current_mood mood)
+
+query IIIIII
+DESCRIBE enums
+----
+current_mood	ENUM	YES	NULL	NULL	NULL


### PR DESCRIPTION
Addresses issue #5174
DESCRIBE now returns an Enum as type ENUM instead of the enum name for easier SQLAlchemy compatibility.

I’ve attempted to set the type as “ENUM” in LogicalType::toString, similar to how the other types are set.  However this alteration also impacts EXPORT/IMPORT DATABASE functionality, where the type name of the ENUM gets lost. 

So therefore I catch the ENUM type beforehand in PragmaTableInfoTable