### PR TITLE
Current fix for Issue #5266 Returning error with rowid

### DIFF
--- a/src/include/duckdb/planner/expression_binder/returning_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/returning_binder.hpp
@@ -20,6 +20,10 @@ public:
 protected:
 	BindResult BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth,
 	                          bool root_expression = false) override;
+
+	// check certain column ref Names to make sure they are supported in the returning statement
+	// (i.e rowid)
+	BindResult BindColumnRef(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth);
 };
 
 } // namespace duckdb

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -420,7 +420,7 @@ BoundStatement Binder::BindReturning(vector<unique_ptr<ParsedExpression>> return
 		column_count++;
 	}
 
-	binder->bind_context.AddGenericBinding(update_table_index, table->name, names, types);
+	binder->bind_context.AddBaseTable(update_table_index, table->name, names, types, bound_columns, table);
 	ReturningBinder returning_binder(*binder, context);
 
 	vector<unique_ptr<Expression>> projection_expressions;

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -420,7 +420,7 @@ BoundStatement Binder::BindReturning(vector<unique_ptr<ParsedExpression>> return
 		column_count++;
 	}
 
-	binder->bind_context.AddBaseTable(update_table_index, table->name, names, types, bound_columns, table);
+	binder->bind_context.AddGenericBinding(update_table_index, table->name, names, types);
 	ReturningBinder returning_binder(*binder, context);
 
 	vector<unique_ptr<Expression>> projection_expressions;

--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -82,13 +82,13 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 		unique_ptr<LogicalOperator> del_as_logicaloperator = move(del);
 		return BindReturning(move(stmt.returning_list), table, update_table_index, move(del_as_logicaloperator),
 		                     move(result));
-	} else {
-		result.plan = move(del);
-		result.names = {"Count"};
-		result.types = {LogicalType::BIGINT};
-		properties.allow_stream_result = false;
-		properties.return_type = StatementReturnType::CHANGED_ROWS;
 	}
+	result.plan = move(del);
+	result.names = {"Count"};
+	result.types = {LogicalType::BIGINT};
+	properties.allow_stream_result = false;
+	properties.return_type = StatementReturnType::CHANGED_ROWS;
+
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -166,7 +166,6 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 	properties.allow_stream_result = false;
 	properties.return_type = StatementReturnType::CHANGED_ROWS;
 	return result;
-
 }
 
 } // namespace duckdb

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -159,13 +159,14 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 
 		return BindReturning(move(stmt.returning_list), table, insert_table_index, move(index_as_logicaloperator),
 		                     move(result));
-	} else {
-		D_ASSERT(result.types.size() == result.names.size());
-		result.plan = move(insert);
-		properties.allow_stream_result = false;
-		properties.return_type = StatementReturnType::CHANGED_ROWS;
-		return result;
 	}
+
+	D_ASSERT(result.types.size() == result.names.size());
+	result.plan = move(insert);
+	properties.allow_stream_result = false;
+	properties.return_type = StatementReturnType::CHANGED_ROWS;
+	return result;
+
 }
 
 } // namespace duckdb

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -227,7 +227,6 @@ BoundStatement Binder::Bind(UpdateStatement &stmt) {
 
 		return BindReturning(move(stmt.returning_list), table, update_table_index, move(update_as_logicaloperator),
 		                     move(result));
-
 	}
 
 	update->table_index = 0;

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -228,14 +228,14 @@ BoundStatement Binder::Bind(UpdateStatement &stmt) {
 		return BindReturning(move(stmt.returning_list), table, update_table_index, move(update_as_logicaloperator),
 		                     move(result));
 
-	} else {
-		update->table_index = 0;
-		result.names = {"Count"};
-		result.types = {LogicalType::BIGINT};
-		result.plan = move(update);
-		properties.allow_stream_result = false;
-		properties.return_type = StatementReturnType::CHANGED_ROWS;
 	}
+
+	update->table_index = 0;
+	result.names = {"Count"};
+	result.types = {LogicalType::BIGINT};
+	result.plan = move(update);
+	properties.allow_stream_result = false;
+	properties.return_type = StatementReturnType::CHANGED_ROWS;
 	return result;
 }
 

--- a/src/planner/expression_binder/returning_binder.cpp
+++ b/src/planner/expression_binder/returning_binder.cpp
@@ -9,6 +9,11 @@ ReturningBinder::ReturningBinder(Binder &binder, ClientContext &context) : Expre
 
 BindResult ReturningBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
 	auto &expr = **expr_ptr;
+	if (expr.GetName() == "rowid") {
+		// We don't support rowid on inserts/updates or deletes. It's possible
+		// the data still lives the transactional log and getting the true rowid is difficult.
+		return BindResult("rowid is not supported in returning statements");
+	}
 	switch (expr.GetExpressionClass()) {
 	case ExpressionClass::SUBQUERY:
 		return BindResult("SUBQUERY is not supported in returning statements");

--- a/test/fuzzer/pedro/returning_clause_with_rowid.test
+++ b/test/fuzzer/pedro/returning_clause_with_rowid.test
@@ -14,6 +14,11 @@ INSERT INTO t0 VALUES (1) RETURNING c0, rowid;
 Binder Error: rowid is not supported in returning statements
 
 statement error
+INSERT INTO t0 VALUES (1) RETURNING rowid c2;
+----
+Binder Error: rowid is not supported in returning statements
+
+statement error
 UPDATE t0 SET c0 = 5 WHERE c0 = 0 RETURNING rowid;
 ----
 Binder Error: rowid is not supported in returning statements

--- a/test/fuzzer/pedro/returning_clause_with_rowid.test
+++ b/test/fuzzer/pedro/returning_clause_with_rowid.test
@@ -1,0 +1,24 @@
+# name: test/fuzzer/pedro/returning_clause_with_rowid.test
+# description: Issue #4978 (8): Returning clause with rowid internal error
+# group: [pedro]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t0 (c0 INT);
+
+statement error
+INSERT INTO t0 VALUES (1) RETURNING c0, rowid;
+----
+Binder Error: rowid is not supported in returning statements
+
+statement error
+UPDATE t0 SET c0 = 5 WHERE c0 = 0 RETURNING rowid;
+----
+Binder Error: rowid is not supported in returning statements
+
+statement error
+DELETE FROM t0 WHERE c0 = 0 RETURNING rowid;
+----
+Binder Error: rowid is not supported in returning statements

--- a/test/fuzzer/pedro/returning_clause_with_rowid.test
+++ b/test/fuzzer/pedro/returning_clause_with_rowid.test
@@ -49,3 +49,6 @@ statement error
 INSERT INTO t0 VALUES (1) RETURNING sum(c0) as rowid;
 ----
 Binder Error: Aggregate functions are not supported here
+
+statement ok
+select struct_pack(row_id := 42);

--- a/test/fuzzer/pedro/returning_clause_with_rowid.test
+++ b/test/fuzzer/pedro/returning_clause_with_rowid.test
@@ -14,6 +14,16 @@ INSERT INTO t0 VALUES (1) RETURNING c0, rowid;
 Binder Error: rowid is not supported in returning statements
 
 statement error
+INSERT INTO t0 VALUES (1), (2), (3) RETURNING *, rowid;
+----
+Binder Error: rowid is not supported in returning statements
+
+statement error
+INSERT INTO t0 VALUES (4) RETURNING c0 + rowid;
+----
+Binder Error: rowid is not supported in returning statements
+
+statement error
 INSERT INTO t0 VALUES (1) RETURNING rowid c2;
 ----
 Binder Error: rowid is not supported in returning statements
@@ -27,3 +37,15 @@ statement error
 DELETE FROM t0 WHERE c0 = 0 RETURNING rowid;
 ----
 Binder Error: rowid is not supported in returning statements
+
+# make sure you can still return the alias rowid
+# More tests could be written, but the returning binder doesn't allow
+# any type of subqueries
+
+statement ok
+INSERT INTO t0 VALUES (1) RETURNING c0 as rowid;
+
+statement error
+INSERT INTO t0 VALUES (1) RETURNING sum(c0) as rowid;
+----
+Binder Error: Aggregate functions are not supported here

--- a/test/sql/returning/returning_insert.test
+++ b/test/sql/returning/returning_insert.test
@@ -52,6 +52,8 @@ INSERT INTO table1 VALUES (1, 2, 3) RETURNING a AS alias1, b AS alias2;
 # returning expression with aggregate function at top level is not allowed
 statement error
 INSERT INTO table1 VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3) RETURNING SUM(a);
+----
+Binder Error: Aggregate functions are not supported here
 
 # returning * while inserting only a subset of columns
 query III


### PR DESCRIPTION
PR to fix https://github.com/duckdb/duckdb/issues/5266. 

Fully supporting rowid in the returning clause is a bit too difficult since inserted data may still be in the transactional log and not yet in storage, so instead we will just throw a binder error.

Also some styling cleanup in this PR.