### PR TITLE
Add Java constant for default schema name

### DIFF
--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBDatabase.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBDatabase.java
@@ -8,6 +8,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class DuckDBDatabase {
 
+	/** Name of the DuckDB default schema. */
+	public static final String DEFAULT_SCHEMA = "main";
+
 	protected String url;
 	protected boolean read_only;
 	private AtomicInteger connections;

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -1585,9 +1585,9 @@ public class TestDuckDBJDBC {
 
 		rs = md.getSchemas(null, "ma%");
 		assertTrue(rs.next());
-		assertEquals(rs.getString("TABLE_SCHEM"), "main");
+		assertEquals(rs.getString("TABLE_SCHEM"), DuckDBDatabase.DEFAULT_SCHEMA);
 		assertNull(rs.getObject("TABLE_CATALOG"));
-		assertEquals(rs.getString(1), "main");
+		assertEquals(rs.getString(1), DuckDBDatabase.DEFAULT_SCHEMA);
 		assertNull(rs.getObject(2));
 
 		assertFalse(rs.next());
@@ -1602,8 +1602,8 @@ public class TestDuckDBJDBC {
 		assertTrue(rs.next());
 		assertNull(rs.getObject("TABLE_CAT"));
 		assertNull(rs.getObject(1));
-		assertEquals(rs.getString("TABLE_SCHEM"), "main");
-		assertEquals(rs.getString(2), "main");
+		assertEquals(rs.getString("TABLE_SCHEM"), DuckDBDatabase.DEFAULT_SCHEMA);
+		assertEquals(rs.getString(2), DuckDBDatabase.DEFAULT_SCHEMA);
 		assertEquals(rs.getString("TABLE_NAME"), "a");
 		assertEquals(rs.getString(3), "a");
 		assertEquals(rs.getString("TABLE_TYPE"), "BASE TABLE");
@@ -1624,8 +1624,8 @@ public class TestDuckDBJDBC {
 		assertTrue(rs.next());
 		assertNull(rs.getObject("TABLE_CAT"));
 		assertNull(rs.getObject(1));
-		assertEquals(rs.getString("TABLE_SCHEM"), "main");
-		assertEquals(rs.getString(2), "main");
+		assertEquals(rs.getString("TABLE_SCHEM"), DuckDBDatabase.DEFAULT_SCHEMA);
+		assertEquals(rs.getString(2), DuckDBDatabase.DEFAULT_SCHEMA);
 		assertEquals(rs.getString("TABLE_NAME"), "b");
 		assertEquals(rs.getString(3), "b");
 		assertEquals(rs.getString("TABLE_TYPE"), "VIEW");
@@ -1646,13 +1646,13 @@ public class TestDuckDBJDBC {
 		assertFalse(rs.next());
 		rs.close();
 
-		rs = md.getTables(null, "main", "a", null);
+		rs = md.getTables(null, DuckDBDatabase.DEFAULT_SCHEMA, "a", null);
 
 		assertTrue(rs.next());
 		assertNull(rs.getObject("TABLE_CAT"));
 		assertNull(rs.getObject(1));
-		assertEquals(rs.getString("TABLE_SCHEM"), "main");
-		assertEquals(rs.getString(2), "main");
+		assertEquals(rs.getString("TABLE_SCHEM"), DuckDBDatabase.DEFAULT_SCHEMA);
+		assertEquals(rs.getString(2), DuckDBDatabase.DEFAULT_SCHEMA);
 		assertEquals(rs.getString("TABLE_NAME"), "a");
 		assertEquals(rs.getString(3), "a");
 		assertEquals(rs.getString("TABLE_TYPE"), "BASE TABLE");
@@ -1673,7 +1673,7 @@ public class TestDuckDBJDBC {
 
 		rs.close();
 
-		rs = md.getTables(null, "main", "xxx", null);
+		rs = md.getTables(null, DuckDBDatabase.DEFAULT_SCHEMA, "xxx", null);
 		assertFalse(rs.next());
 		rs.close();
 
@@ -1681,8 +1681,8 @@ public class TestDuckDBJDBC {
 		assertTrue(rs.next());
 		assertNull(rs.getObject("TABLE_CAT"));
 		assertNull(rs.getObject(1));
-		assertEquals(rs.getString("TABLE_SCHEM"), "main");
-		assertEquals(rs.getString(2), "main");
+		assertEquals(rs.getString("TABLE_SCHEM"), DuckDBDatabase.DEFAULT_SCHEMA);
+		assertEquals(rs.getString(2), DuckDBDatabase.DEFAULT_SCHEMA);
 		assertEquals(rs.getString("TABLE_NAME"), "a");
 		assertEquals(rs.getString(3), "a");
 		assertEquals(rs.getString("COLUMN_NAME"), "i");
@@ -1701,12 +1701,12 @@ public class TestDuckDBJDBC {
 		assertFalse(rs.next());
 		rs.close();
 
-		rs = md.getColumns(null, "main", "a", "i");
+		rs = md.getColumns(null, DuckDBDatabase.DEFAULT_SCHEMA, "a", "i");
 		assertTrue(rs.next());
 		assertNull(rs.getObject("TABLE_CAT"));
 		assertNull(rs.getObject(1));
-		assertEquals(rs.getString("TABLE_SCHEM"), "main");
-		assertEquals(rs.getString(2), "main");
+		assertEquals(rs.getString("TABLE_SCHEM"), DuckDBDatabase.DEFAULT_SCHEMA);
+		assertEquals(rs.getString(2), DuckDBDatabase.DEFAULT_SCHEMA);
 		assertEquals(rs.getString("TABLE_NAME"), "a");
 		assertEquals(rs.getString(3), "a");
 		assertEquals(rs.getString("COLUMN_NAME"), "i");
@@ -1724,12 +1724,12 @@ public class TestDuckDBJDBC {
 		rs.close();
 
 		// try with catalog as well
-		rs = md.getColumns(conn.getCatalog(), "main", "a", "i");
+		rs = md.getColumns(conn.getCatalog(), DuckDBDatabase.DEFAULT_SCHEMA, "a", "i");
 		assertTrue(rs.next());
 		assertNull(rs.getObject("TABLE_CAT"));
 		assertNull(rs.getObject(1));
-		assertEquals(rs.getString("TABLE_SCHEM"), "main");
-		assertEquals(rs.getString(2), "main");
+		assertEquals(rs.getString("TABLE_SCHEM"), DuckDBDatabase.DEFAULT_SCHEMA);
+		assertEquals(rs.getString(2), DuckDBDatabase.DEFAULT_SCHEMA);
 		assertEquals(rs.getString("TABLE_NAME"), "a");
 		assertEquals(rs.getString(3), "a");
 		assertEquals(rs.getString("COLUMN_NAME"), "i");
@@ -1750,11 +1750,11 @@ public class TestDuckDBJDBC {
 		assertFalse(rs.next());
 		rs.close();
 
-		rs = md.getColumns(null, "main", "xxx", "i");
+		rs = md.getColumns(null, DuckDBDatabase.DEFAULT_SCHEMA, "xxx", "i");
 		assertFalse(rs.next());
 		rs.close();
 
-		rs = md.getColumns(null, "main", "a", "xxx");
+		rs = md.getColumns(null, DuckDBDatabase.DEFAULT_SCHEMA, "a", "xxx");
 		assertFalse(rs.next());
 		rs.close();
 
@@ -1805,7 +1805,7 @@ public class TestDuckDBJDBC {
 
 		// int8, int4, int2, int1, float8, float4
 		stmt.execute("CREATE TABLE numbers (a BIGINT, b INTEGER, c SMALLINT, d TINYINT, e DOUBLE, f FLOAT)");
-		DuckDBAppender appender = conn.createAppender("main", "numbers");
+		DuckDBAppender appender = conn.createAppender(DuckDBDatabase.DEFAULT_SCHEMA, "numbers");
 
 		for (int i = 0; i < 50; i++) {
 			appender.beginRow();
@@ -1851,7 +1851,7 @@ public class TestDuckDBJDBC {
 		Statement stmt = conn.createStatement();
 
 		stmt.execute("CREATE TABLE data (a INTEGER, s VARCHAR)");
-		DuckDBAppender appender = conn.createAppender("main", "data");
+		DuckDBAppender appender = conn.createAppender(DuckDBDatabase.DEFAULT_SCHEMA, "data");
 
 		for (int i = 0; i < 1000; i++) {
 			appender.beginRow();
@@ -1881,7 +1881,7 @@ public class TestDuckDBJDBC {
 
 		stmt.execute("CREATE TABLE data (str_value VARCHAR(10))");
 		String expectedValue = "䭔\uD86D\uDF7C🔥\uD83D\uDE1C";
-		try (DuckDBAppender appender = conn.createAppender("main", "data")) {
+		try (DuckDBAppender appender = conn.createAppender(DuckDBDatabase.DEFAULT_SCHEMA, "data")) {
 			appender.beginRow();
 			appender.append(expectedValue);
 			appender.endRow();
@@ -1905,7 +1905,7 @@ public class TestDuckDBJDBC {
 
 		try {
 			@SuppressWarnings("unused")
-			DuckDBAppender appender = conn.createAppender("main", "data");
+			DuckDBAppender appender = conn.createAppender(DuckDBDatabase.DEFAULT_SCHEMA, "data");
 			fail();
 		} catch (SQLException e) {
 		}
@@ -1919,7 +1919,7 @@ public class TestDuckDBJDBC {
 		Statement stmt = conn.createStatement();
 
 		stmt.execute("CREATE TABLE data (a INTEGER)");
-		DuckDBAppender appender = conn.createAppender("main", "data");
+		DuckDBAppender appender = conn.createAppender(DuckDBDatabase.DEFAULT_SCHEMA, "data");
 
 		appender.beginRow();
 		appender.append(1);
@@ -1947,7 +1947,7 @@ public class TestDuckDBJDBC {
 
 		stmt.execute("CREATE TABLE data (a INTEGER)");
 		stmt.close();
-		DuckDBAppender appender = conn.createAppender("main", "data");
+		DuckDBAppender appender = conn.createAppender(DuckDBDatabase.DEFAULT_SCHEMA, "data");
 
 		try {
 			appender.beginRow();
@@ -1966,7 +1966,7 @@ public class TestDuckDBJDBC {
 
 		stmt.execute("CREATE TABLE data (a INTEGER, b INTEGER)");
 		stmt.close();
-		DuckDBAppender appender = conn.createAppender("main", "data");
+		DuckDBAppender appender = conn.createAppender(DuckDBDatabase.DEFAULT_SCHEMA, "data");
 
 		try {
 			appender.beginRow();
@@ -1984,7 +1984,7 @@ public class TestDuckDBJDBC {
 		Statement stmt = conn.createStatement();
 
 		stmt.execute("CREATE TABLE data (a INTEGER)");
-		DuckDBAppender appender = conn.createAppender("main", "data");
+		DuckDBAppender appender = conn.createAppender(DuckDBDatabase.DEFAULT_SCHEMA, "data");
 
 		try {
 			appender.beginRow();
@@ -2003,7 +2003,7 @@ public class TestDuckDBJDBC {
 
 		stmt.execute("CREATE TABLE data (a INTEGER)");
 
-		DuckDBAppender appender = conn.createAppender("main", "data");
+		DuckDBAppender appender = conn.createAppender(DuckDBDatabase.DEFAULT_SCHEMA, "data");
 
 		appender.beginRow();
 		appender.append(null);
@@ -2028,7 +2028,7 @@ public class TestDuckDBJDBC {
 
 		stmt.execute("CREATE TABLE data (a VARCHAR)");
 
-		DuckDBAppender appender = conn.createAppender("main", "data");
+		DuckDBAppender appender = conn.createAppender(DuckDBDatabase.DEFAULT_SCHEMA, "data");
 
 		appender.beginRow();
 		appender.append(null);
@@ -2244,7 +2244,7 @@ public class TestDuckDBJDBC {
 	public static void test_get_schema() throws Exception {
 		DuckDBConnection conn = (DuckDBConnection) DriverManager.getConnection("jdbc:duckdb:");
 
-		assertEquals(conn.getSchema(), "main");
+		assertEquals(conn.getSchema(), DuckDBDatabase.DEFAULT_SCHEMA);
 
 		try (Statement stmt = conn.createStatement()) {
 			stmt.execute("CREATE SCHEMA alternate_schema;");
@@ -2415,11 +2415,11 @@ public class TestDuckDBJDBC {
 
 	public static void test_get_functions() throws Exception {
 		try (Connection conn = DriverManager.getConnection("jdbc:duckdb:")) {
-			ResultSet functions = conn.getMetaData().getFunctions(null, "main", "string_split");
+			ResultSet functions = conn.getMetaData().getFunctions(null, DuckDBDatabase.DEFAULT_SCHEMA, "string_split");
 
 			assertTrue(functions.next());
 			assertNull(functions.getObject("FUNCTION_CAT"));
-			assertEquals("main", functions.getString("FUNCTION_SCHEM"));
+			assertEquals(DuckDBDatabase.DEFAULT_SCHEMA, functions.getString("FUNCTION_SCHEM"));
 			assertEquals("string_split", functions.getString("FUNCTION_NAME"));
 			assertNull(functions.getString("REMARKS"));
 			assertEquals(DatabaseMetaData.functionNoTable, functions.getInt("FUNCTION_TYPE"));
@@ -2427,17 +2427,17 @@ public class TestDuckDBJDBC {
 			assertFalse(functions.next());
 
 			// two items for two overloads?
-			functions = conn.getMetaData().getFunctions(null, "main", "read_csv_auto");
+			functions = conn.getMetaData().getFunctions(null, DuckDBDatabase.DEFAULT_SCHEMA, "read_csv_auto");
 			assertTrue(functions.next());
 			assertNull(functions.getObject("FUNCTION_CAT"));
-			assertEquals("main", functions.getString("FUNCTION_SCHEM"));
+			assertEquals(DuckDBDatabase.DEFAULT_SCHEMA, functions.getString("FUNCTION_SCHEM"));
 			assertEquals("read_csv_auto", functions.getString("FUNCTION_NAME"));
 			assertNull(functions.getString("REMARKS"));
 			assertEquals(DatabaseMetaData.functionReturnsTable, functions.getInt("FUNCTION_TYPE"));
 
 			assertTrue(functions.next());
 			assertNull(functions.getObject("FUNCTION_CAT"));
-			assertEquals("main", functions.getString("FUNCTION_SCHEM"));
+			assertEquals(DuckDBDatabase.DEFAULT_SCHEMA, functions.getString("FUNCTION_SCHEM"));
 			assertEquals("read_csv_auto", functions.getString("FUNCTION_NAME"));
 			assertNull(functions.getString("REMARKS"));
 			assertEquals(DatabaseMetaData.functionReturnsTable, functions.getInt("FUNCTION_TYPE"));


### PR DESCRIPTION
As the title says, I added a constant in the Java code for the default schema name. So we don't have to hard-code "main" in the Java.