### PR TITLE
Disable url decoding of http header values

### DIFF
--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -3237,7 +3237,7 @@ inline bool parse_header(const char *beg, const char *end, T fn) {
 	}
 
 	if (p < end) {
-		fn(std::string(beg, key_end), decode_url(std::string(p, end), false));
+		fn(std::string(beg, key_end), std::string(p, end));
 		return true;
 	}
 
@@ -6077,7 +6077,7 @@ inline bool ClientImpl::redirect(Request &req, Response &res, Error &error) {
 		return false;
 	}
 
-	auto location = detail::decode_url(res.get_header_value("location"), false);
+	auto location = res.get_header_value("location");
 	if (location.empty()) { return false; }
 
 	const static Regex re(


### PR DESCRIPTION
According to [someone on stackoverflow](https://stackoverflow.com/questions/23215227/is-it-appropriate-or-necessary-to-use-percent-encoding-with-http-headers), you shouldn't url encode header values. So we should probably not decode them.

Should fix #5121, this was likely causing the AWS signature to be incorrect failing the redirect.

tested with this query derived from above issue:
```
select count(*) from 'https://huggingface.co/datasets/deepmind/code_contests/resolve/main/data/test-00000-of-00001-9c49eeff30aacaa8.parquet' LIMIT 1;
```