### PR TITLE
[Fuzzer] Fix crash caused by UPDATE on a table with a leading generated column

### DIFF
--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -108,7 +108,7 @@ void PhysicalInsert::ResolveDefaults(TableCatalogEntry *table, DataChunk &chunk,
 			auto storage_idx = col.StorageOid();
 			if (column_index_map[i] == DConstants::INVALID_INDEX) {
 				// insert default value
-				default_executor.ExecuteExpression(i, result.data[storage_idx]);
+				default_executor.ExecuteExpression(storage_idx, result.data[storage_idx]);
 			} else {
 				// get value from child chunk
 				D_ASSERT((idx_t)column_index_map[i] < chunk.ColumnCount());

--- a/test/fuzzer/pedro/gcol_update_default_assertion.test
+++ b/test/fuzzer/pedro/gcol_update_default_assertion.test
@@ -1,0 +1,17 @@
+# name: test/fuzzer/pedro/gcol_update_default_assertion.test
+# group: [pedro]
+
+statement ok
+pragma enable_verification
+
+statement ok
+CREATE TABLE t1 (
+	c0 VARCHAR(10) AS ('1') VIRTUAL,
+	c1 INT
+);
+
+statement ok
+INSERT INTO t1(c1) VALUES (0);
+
+statement ok
+UPDATE t1 SET c1 = DEFAULT;


### PR DESCRIPTION
This PR fixes 24 of #4978 

It's a classic Logical vs Physical index situation, an expression was being added to the 'bound_defaults' expression list for a generated column, which caused a mismatch in the chunk.ColumnCount() and the expression list size.