### PR TITLE
Fuzzer fixes - 4978 (16) Binder assertion error

### DIFF
--- a/src/planner/expression_binder/column_alias_binder.cpp
+++ b/src/planner/expression_binder/column_alias_binder.cpp
@@ -28,7 +28,10 @@ BindResult ColumnAliasBinder::BindAlias(ExpressionBinder &enclosing_binder, Colu
 	// found an alias: bind the alias expression
 	auto expression = node.original_expressions[alias_entry->second]->Copy();
 	in_alias = true;
-	auto result = enclosing_binder.BindExpression(&expression, depth, root_expression);
+
+	// since the alias has been found, pass a depth of 0. See Issue 4978 (#16)
+	// ColumnAliasBinders are only in Having, Qualify and Where Binders
+	auto result = enclosing_binder.BindExpression(&expression, 0, root_expression);
 	in_alias = false;
 	return result;
 }

--- a/test/fuzzer/pedro/binder_assertion_error.test
+++ b/test/fuzzer/pedro/binder_assertion_error.test
@@ -1,0 +1,27 @@
+# name: test/fuzzer/pedro/binder_assertion_error.test
+# description: Issue #4978 (16): Binder assertion error
+# group: [pedro]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t0 (c0 INT);
+
+query I
+SELECT (SELECT 2) c0 WHERE (SELECT (SELECT (SELECT c0)));
+----
+2
+
+query I
+SELECT (SELECT 0) c0 WHERE (SELECT c0);
+----
+
+statement error
+select (select 42) as a, (select a);
+----
+Serialization Error: Cannot copy BoundSubqueryExpression
+
+
+
+

--- a/test/fuzzer/pedro/binder_assertion_error.test
+++ b/test/fuzzer/pedro/binder_assertion_error.test
@@ -22,6 +22,21 @@ select (select 42) as a, (select a);
 ----
 Serialization Error: Cannot copy BoundSubqueryExpression
 
+# The last a should resolve to 1 from the (select 1) a
+# The b should resolve to 3
+query I
+select (select 1) a where (select (select 3) b where (select b) > (select a));
+----
+1
 
+# the b alias resolves to the where alias binder in the subquery
+# the a alias resolves to the where alias binder from the select clause.
+query I
+select (select 5) a where (select (select 3) b where (select b) > (select a));
+----
 
-
+# Similar to the above test case but its a positive case
+query II
+select (select 5) a, (select 7) c where (select (select 3) b where (select a) > (select b) and (select c) > (select a));
+----
+5	7

--- a/test/fuzzer/pedro/binder_assertion_error.test
+++ b/test/fuzzer/pedro/binder_assertion_error.test
@@ -40,3 +40,26 @@ query II
 select (select 5) a, (select 7) c where (select (select 3) b where (select a) > (select b) and (select c) > (select a));
 ----
 5	7
+
+statement ok
+INSERT INTO t0 VALUES (1), (2), (3), (4);
+
+# a3 is in the where clause is qualified to the a3 in the select
+# there are two instances of an a1 alias, which are both correctly qualified using the
+# alias binder in the first wherebinder encountered when attempting to bind correlated subqueries
+#
+# the where clause subquery resolves to a1 + c0 in (2)
+# so a1 and c0 both need to be 1
+query III
+select (select 1) a1, (select 3) as a3, c0
+        from t0 where a1 + c0 in (select c0 as a1 from t0 where a1 + 1 = a3);
+----
+1	3	1
+
+# same test as above except a negative case where nothing is returned.
+# The subquery in the where clause is not satisfied
+query III
+select (select 1) a1, (select 3) as a3, c0
+        from t0 where a1 + c0 in (select c0 as a1 from t0 where a1 + 5 = a3);
+----
+


### PR DESCRIPTION
Fix for fuzzer issue https://github.com/duckdb/duckdb/issues/4978 (16)

For this specific query we start binding using correlated queries and employ a "backing off" strategy until we find a binding context that can resolve the alias. In this case, only the `WhereBinder`, `QualifyBinder` and `HavingBinder` have `ColumnAliasBinders`. When `BindCorrelatedColumns` is called, we grab the active binders in order of when they were created, and starting from the end of the list, we see if the binder can resolve the Expression.

Each binder is converted into a `WhereBinder` with no column_alias_binder, and then `QualifyColumnNames` is called. Since the expression is an alias, and the where binder has a column_alias_binder of `NULL` every attempt to qualify a column name fails. 

There are two potential fixes
1. When the select binder is initially created, pass the `column_alias_map` from the `WhereBinder`. This might be a lot of work, as it will require function signature changes and more. In addition, it might make it impossible to declare the same alias name twice for two different columns/expressions
2. Pass a depth of 0 when binding an alias using the column_alias_binder. This basically means that the outermost `WhereBinder` alias map has a reference to the alias, and now the alias can be qualified.

This fix implements fix 2, as it is easier and achieves the same result. There is a test suite along with it to make sure nothing breaks.

One test includes the same alias name twice, but we still qualify it using the alias definition that occurred closest to the usage. 
