### PR TITLE
Several parallel CSV reader fixes

### DIFF
--- a/src/execution/operator/persistent/csv_buffer.cpp
+++ b/src/execution/operator/persistent/csv_buffer.cpp
@@ -3,17 +3,21 @@
 
 namespace duckdb {
 
-CSVBuffer::CSVBuffer(idx_t buffer_size_p, CSVFileHandle &file_handle) : first_buffer(true) {
-	buffer = unique_ptr<char[]>(new char[buffer_size_p]);
-	actual_size = file_handle.Read(buffer.get(), buffer_size_p);
+CSVBuffer::CSVBuffer(ClientContext &context, idx_t buffer_size_p, CSVFileHandle &file_handle)
+    : context(context), first_buffer(true) {
+	this->handle = AllocateBuffer(buffer_size_p);
+
+	auto buffer = Ptr();
+	actual_size = file_handle.Read(buffer, buffer_size_p);
 	if (actual_size >= 3 && buffer[0] == '\xEF' && buffer[1] == '\xBB' && buffer[2] == '\xBF') {
 		start_position += 3;
 	}
 	last_buffer = file_handle.FinishedReading();
 }
 
-CSVBuffer::CSVBuffer(unique_ptr<char[]> buffer_p, idx_t buffer_size_p, idx_t actual_size_p, bool final_buffer)
-    : buffer(move(buffer_p)), actual_size(actual_size_p), last_buffer(final_buffer) {
+CSVBuffer::CSVBuffer(ClientContext &context, BufferHandle buffer_p, idx_t buffer_size_p, idx_t actual_size_p,
+                     bool final_buffer)
+    : context(context), handle(move(buffer_p)), actual_size(actual_size_p), last_buffer(final_buffer) {
 }
 
 unique_ptr<CSVBuffer> CSVBuffer::Next(CSVFileHandle &file_handle, idx_t set_buffer_size) {
@@ -22,12 +26,16 @@ unique_ptr<CSVBuffer> CSVBuffer::Next(CSVFileHandle &file_handle, idx_t set_buff
 		return nullptr;
 	}
 
-	auto next_buffer = unique_ptr<char[]>(new char[set_buffer_size]);
+	auto next_buffer = AllocateBuffer(set_buffer_size);
+	idx_t next_buffer_actual_size = file_handle.Read(next_buffer.Ptr(), set_buffer_size);
 
-	idx_t next_buffer_actual_size = file_handle.Read(next_buffer.get(), set_buffer_size);
-
-	return make_unique<CSVBuffer>(move(next_buffer), set_buffer_size, next_buffer_actual_size,
+	return make_unique<CSVBuffer>(context, move(next_buffer), set_buffer_size, next_buffer_actual_size,
 	                              file_handle.FinishedReading());
+}
+
+BufferHandle CSVBuffer::AllocateBuffer(idx_t buffer_size) {
+	auto &buffer_manager = BufferManager::GetBufferManager(context);
+	return buffer_manager.Allocate(MaxValue<idx_t>(Storage::BLOCK_SIZE, buffer_size));
 }
 
 idx_t CSVBuffer::GetBufferSize() {

--- a/src/execution/operator/persistent/csv_reader_options.cpp
+++ b/src/execution/operator/persistent/csv_reader_options.cpp
@@ -31,6 +31,9 @@ static bool ParseBoolean(const Value &value, const string &loption) {
 }
 
 static string ParseString(const Value &value, const string &loption) {
+	if (value.IsNull()) {
+		return string();
+	}
 	if (value.type().id() == LogicalTypeId::LIST) {
 		auto &children = ListValue::GetChildren(value);
 		if (children.size() != 1) {

--- a/src/execution/operator/persistent/csv_reader_options.cpp
+++ b/src/execution/operator/persistent/csv_reader_options.cpp
@@ -185,6 +185,11 @@ void BufferedCSVReaderOptions::SetReadOption(const string &loption, const Value 
 		ignore_errors = ParseBoolean(value, loption);
 	} else if (loption == "union_by_name") {
 		union_by_name = ParseBoolean(value, loption);
+	} else if (loption == "buffer_size") {
+		buffer_size = ParseInteger(value, loption);
+		if (buffer_size == 0) {
+			throw InvalidInputException("Buffer Size option must be higher than 0");
+		}
 	} else {
 		throw BinderException("Unrecognized option for CSV reader \"%s\"", loption);
 	}

--- a/src/execution/operator/persistent/parallel_csv_reader.cpp
+++ b/src/execution/operator/persistent/parallel_csv_reader.cpp
@@ -164,10 +164,11 @@ normal : {
 	/* state: normal parsing state */
 	// this state parses the remainder of a non-quoted value until we reach a delimiter or newline
 	for (; position_buffer < end_buffer; position_buffer++) {
-		if ((*buffer)[position_buffer] == options.delimiter[0]) {
+		auto c = (*buffer)[position_buffer];
+		if (c == options.delimiter[0]) {
 			// delimiter: end the value and add it to the chunk
 			goto add_value;
-		} else if (StringUtil::CharacterIsNewline((*buffer)[position_buffer])) {
+		} else if (StringUtil::CharacterIsNewline(c)) {
 			// newline: add row
 			D_ASSERT(try_add_line || column == insert_chunk.ColumnCount() - 1);
 			goto add_row;
@@ -237,10 +238,11 @@ in_quotes:
 	has_quotes = true;
 	position_buffer++;
 	for (; position_buffer < end_buffer; position_buffer++) {
-		if ((*buffer)[position_buffer] == options.quote[0]) {
+		auto c = (*buffer)[position_buffer];
+		if (c == options.quote[0]) {
 			// quote: move to unquoted state
 			goto unquote;
-		} else if ((*buffer)[position_buffer] == options.escape[0]) {
+		} else if (c == options.escape[0]) {
 			// escape: store the escaped position and move to handle_escape state
 			escape_positions.push_back(position_buffer - start_buffer);
 			goto handle_escape;
@@ -262,7 +264,7 @@ in_quotes:
 		goto in_quotes;
 	}
 
-unquote:
+unquote : {
 	/* state: unquote: this state handles the state directly after we unquote*/
 	//
 	// in this state we expect either another quote (entering the quoted state again, and escaping the quote)
@@ -272,16 +274,16 @@ unquote:
 		offset = 1;
 		goto final_state;
 	}
-	if ((*buffer)[position_buffer] == options.quote[0] &&
-	    (options.escape.empty() || options.escape[0] == options.quote[0])) {
+	auto c = (*buffer)[position_buffer];
+	if (c == options.quote[0] && (options.escape.empty() || options.escape[0] == options.quote[0])) {
 		// escaped quote, return to quoted state and store escape position
 		escape_positions.push_back(position_buffer - start_buffer);
 		goto in_quotes;
-	} else if ((*buffer)[position_buffer] == options.delimiter[0]) {
+	} else if (c == options.delimiter[0]) {
 		// delimiter, add value
 		offset = 1;
 		goto add_value;
-	} else if (StringUtil::CharacterIsNewline((*buffer)[position_buffer])) {
+	} else if (StringUtil::CharacterIsNewline(c)) {
 		offset = 1;
 		D_ASSERT(column == insert_chunk.ColumnCount() - 1);
 		goto add_row;

--- a/src/execution/operator/persistent/parallel_csv_reader.cpp
+++ b/src/execution/operator/persistent/parallel_csv_reader.cpp
@@ -298,6 +298,7 @@ unquote : {
 		    options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
 		return false;
 	}
+}
 handle_escape : {
 	/* state: handle_escape */
 	// escape should be followed by a quote or another escape character

--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -109,6 +109,11 @@ static unique_ptr<FunctionData> ReadCSVBind(ClientContext &context, CopyInfo &in
 		options.force_not_null.resize(expected_types.size(), false);
 	}
 	bind_data->FinalizeRead(context);
+	if (!bind_data->single_threaded && options.auto_detect) {
+		options.file_path = bind_data->files[0];
+		auto initial_reader = make_unique<BufferedCSVReader>(context, options);
+		options = initial_reader->options;
+	}
 	return move(bind_data);
 }
 

--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -16,7 +16,7 @@ void SubstringDetection(string &str_1, string &str_2, const string &name_str_1, 
 	if (str_1.empty() || str_2.empty()) {
 		return;
 	}
-	if ((str_1.find(str_2) != string::npos || str_2.find(str_1) != std::string::npos) && str_1 != "NULL") {
+	if ((str_1.find(str_2) != string::npos || str_2.find(str_1) != std::string::npos)) {
 		throw BinderException("%s must not appear in the %s specification and vice versa", name_str_1, name_str_2);
 	}
 }

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -112,7 +112,7 @@ static unique_ptr<FunctionData> ReadCSVBind(ClientContext &context, TableFunctio
 		} else {
 			D_ASSERT(return_types.size() == names.size());
 		}
-		options = result->options;
+		options = initial_reader->options;
 		result->sql_types = initial_reader->sql_types;
 		result->initial_reader = move(initial_reader);
 	} else {

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -94,11 +94,6 @@ static unique_ptr<FunctionData> ReadCSVBind(ClientContext &context, TableFunctio
 			options.include_file_name = BooleanValue::Get(kv.second);
 		} else if (loption == "hive_partitioning") {
 			options.include_parsed_hive_partitions = BooleanValue::Get(kv.second);
-		} else if (loption == "buffer_size") {
-			options.buffer_size = kv.second.GetValue<uint64_t>();
-			if (options.buffer_size == 0) {
-				throw InvalidInputException("Buffer Size option must be higher than 0");
-			}
 		} else {
 			options.SetReadOption(loption, kv.second, names);
 		}

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -27,9 +27,6 @@ public:
 	DUCKDB_API static bool CharacterIsNewline(char c) {
 		return c == '\n' || c == '\r';
 	}
-	DUCKDB_API static bool CharacterIsNullTerminator(char c) {
-		return c == '\0';
-	}
 	DUCKDB_API static bool CharacterIsDigit(char c) {
 		return c >= '0' && c <= '9';
 	}

--- a/test/sql/copy/csv/auto/test_auto_cranlogs.test
+++ b/test/sql/copy/csv/auto/test_auto_cranlogs.test
@@ -19,3 +19,18 @@ SELECT * FROM cranlogs LIMIT 5;
 2013-06-15	00:58:50	501915	2.15.3	x86_64	linux-gnu	animation	2.2	IN	4
 2013-06-15	00:14:52	254933	3.0.1	x86_64	linux-gnu	foreign	0.8-54	HK	5
 
+# FIXME: this one doesn't work
+mode skip
+
+# read with parallel reader and verify that we get the same result
+statement ok
+SET experimental_parallel_csv=true;
+
+statement ok
+CREATE TABLE cranlogs2 AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/real/tmp2013-06-15.csv.gz');
+
+query IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
+(SELECT * FROM cranlogs EXCEPT SELECT * FROM cranlogs2)
+UNION ALL
+(SELECT * FROM cranlogs2 EXCEPT SELECT * FROM cranlogs)
+----

--- a/test/sql/copy/csv/auto/test_auto_greek_ncvoter.test
+++ b/test/sql/copy/csv/auto/test_auto_greek_ncvoter.test
@@ -24,3 +24,19 @@ SELECT county_id, county_desc, vtd_desc, name_prefx_cd FROM ncvoters;
 1	ALAMANCE	035	(empty)
 1	ALAMANCE	064	(empty)
 
+# read with parallel reader and verify that we get the same result
+statement ok
+SET experimental_parallel_csv=true;
+
+statement ok
+CREATE TABLE ncvoters2 AS SELECT * FROM ncvoters LIMIT 0
+
+statement ok
+COPY ncvoters2 FROM 'test/sql/copy/csv/data/real/ncvoter.csv' (FORMAT CSV, AUTO_DETECT TRUE);
+
+query IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
+(SELECT * FROM ncvoters EXCEPT SELECT * FROM ncvoters2)
+UNION ALL
+(SELECT * FROM ncvoters2 EXCEPT SELECT * FROM ncvoters)
+----
+

--- a/test/sql/copy/csv/auto/test_auto_greek_utf8.test
+++ b/test/sql/copy/csv/auto/test_auto_greek_utf8.test
@@ -3,6 +3,9 @@
 # group: [auto]
 
 statement ok
+SET experimental_parallel_csv=true;
+
+statement ok
 CREATE TABLE greek_utf8 AS SELECT i, nfc_normalize(j) j, k FROM read_csv_auto ('test/sql/copy/csv/data/real/greek_utf8.csv') t(i, j, k)
 
 query I

--- a/test/sql/copy/csv/auto/test_auto_greek_utf8.test
+++ b/test/sql/copy/csv/auto/test_auto_greek_utf8.test
@@ -2,6 +2,9 @@
 # description: Test read_csv_auto from greek-utf8 csv
 # group: [auto]
 
+# FIXME: experimental CSV reader breaks on vector size 2
+require vector_size 512
+
 statement ok
 SET experimental_parallel_csv=true;
 

--- a/test/sql/copy/csv/auto/test_auto_imdb.test
+++ b/test/sql/copy/csv/auto/test_auto_imdb.test
@@ -12,3 +12,15 @@ SELECT COUNT(*) FROM movie_info;
 ----
 201
 
+# read with parallel reader and verify that we get the same result
+statement ok
+SET experimental_parallel_csv=true;
+
+statement ok
+CREATE TABLE movie_info2 AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/real/imdb_movie_info_escaped.csv');
+
+query IIIII
+(FROM movie_info EXCEPT FROM movie_info2)
+UNION ALL
+(FROM movie_info2 EXCEPT FROM movie_info)
+----

--- a/test/sql/copy/csv/auto/test_auto_lineitem.test
+++ b/test/sql/copy/csv/auto/test_auto_lineitem.test
@@ -25,3 +25,19 @@ SELECT l_partkey, l_comment FROM lineitem WHERE l_orderkey=1 ORDER BY l_linenumb
 2403	 pending foxes. slyly re
 1564	arefully slyly ex
 
+# read with parallel reader and verify that we get the same result
+statement ok
+SET experimental_parallel_csv=true;
+
+statement ok
+CREATE TABLE lineitem2 AS SELECT * FROM lineitem LIMIT 0
+
+statement ok
+COPY lineitem2 FROM 'test/sql/copy/csv/data/real/lineitem_sample.csv' (FORMAT CSV, AUTO_DETECT TRUE);
+
+query IIIIIIIIIIIIIIII
+(SELECT * FROM lineitem EXCEPT SELECT * FROM lineitem2)
+UNION ALL
+(SELECT * FROM lineitem2 EXCEPT SELECT * FROM lineitem)
+----
+

--- a/test/sql/copy/csv/auto/test_auto_ontime.test
+++ b/test/sql/copy/csv/auto/test_auto_ontime.test
@@ -23,3 +23,22 @@ SELECT year, uniquecarrier, origin, origincityname, div5longestgtime FROM ontime
 1988	AA	JFK	New York, NY	NULL
 1988	AA	JFK	New York, NY	NULL
 
+# FIXME: this one doesn't work
+mode skip
+
+# read with parallel reader and verify that we get the same result
+statement ok
+SET experimental_parallel_csv=true;
+
+statement ok
+CREATE TABLE ontime2 AS SELECT * FROM ontime LIMIT 0
+
+statement ok
+COPY ontime2 FROM 'test/sql/copy/csv/data/real/ontime_sample.csv' (HEADER TRUE);
+
+query IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
+(SELECT * FROM ontime EXCEPT SELECT * FROM ontime2)
+UNION ALL
+(SELECT * FROM ontime2 EXCEPT SELECT * FROM ontime)
+----
+

--- a/test/sql/copy/csv/auto/test_auto_voter.test
+++ b/test/sql/copy/csv/auto/test_auto_voter.test
@@ -14,3 +14,16 @@ query I
 SELECT COUNT(*) FROM "test/sql/copy/csv/data/real/voter.tsv";
 ----
 5300
+
+# read with parallel reader and verify that we get the same result
+statement ok
+SET experimental_parallel_csv=true;
+
+statement ok
+CREATE TABLE voters2 AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/real/voter.tsv');
+
+query IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
+(SELECT * FROM voters EXCEPT SELECT * FROM voters2)
+UNION ALL
+(SELECT * FROM voters2 EXCEPT SELECT * FROM voters)
+----

--- a/test/sql/copy/csv/auto/test_auto_voter.test
+++ b/test/sql/copy/csv/auto/test_auto_voter.test
@@ -15,6 +15,9 @@ SELECT COUNT(*) FROM "test/sql/copy/csv/data/real/voter.tsv";
 ----
 5300
 
+mode skip
+# FIXME: this doesn't work yet
+
 # read with parallel reader and verify that we get the same result
 statement ok
 SET experimental_parallel_csv=true;
@@ -27,3 +30,5 @@ query IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
 UNION ALL
 (SELECT * FROM voters2 EXCEPT SELECT * FROM voters)
 ----
+
+mode unskip

--- a/test/sql/copy/csv/auto/test_auto_web_page.test
+++ b/test/sql/copy/csv/auto/test_auto_web_page.test
@@ -19,3 +19,15 @@ SELECT * FROM web_page ORDER BY column00 LIMIT 3;
 2	AAAAAAAACAAAAAAA	1997-09-03	2000-09-02	2450814	2452580	N	NULL	http://www.foo.com	protected	1564	4	3	1
 3	AAAAAAAACAAAAAAA	2000-09-03	NULL	2450814	2452611	N	NULL	http://www.foo.com	feedback	1564	4	3	4
 
+# read with parallel reader and verify that we get the same result
+statement ok
+SET experimental_parallel_csv=true;
+
+statement ok
+CREATE TABLE web_page2 AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/real/web_page.csv');
+
+query IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
+(SELECT * FROM web_page EXCEPT SELECT * FROM web_page2)
+UNION ALL
+(SELECT * FROM web_page2 EXCEPT SELECT * FROM web_page)
+----

--- a/test/sql/copy/csv/auto/test_auto_web_page.test
+++ b/test/sql/copy/csv/auto/test_auto_web_page.test
@@ -26,7 +26,7 @@ SET experimental_parallel_csv=true;
 statement ok
 CREATE TABLE web_page2 AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/real/web_page.csv');
 
-query IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
+query IIIIIIIIIIIIII
 (SELECT * FROM web_page EXCEPT SELECT * FROM web_page2)
 UNION ALL
 (SELECT * FROM web_page2 EXCEPT SELECT * FROM web_page)

--- a/test/sql/copy/csv/auto/test_csv_auto.test
+++ b/test/sql/copy/csv/auto/test_csv_auto.test
@@ -4,6 +4,14 @@
 
 require vector_size 512
 
+mode skip
+
+# FIXME: this results in errors
+statement ok
+SET experimental_parallel_csv=true;
+
+mode unskip
+
 # CSV file with RFC-conform dialect
 statement ok
 CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/rfc_conform.csv');

--- a/test/sql/copy/csv/auto/test_fallback_all_varchar.test
+++ b/test/sql/copy/csv/auto/test_fallback_all_varchar.test
@@ -2,6 +2,14 @@
 # description: Test optional parameters for read csv
 # group: [auto]
 
+mode skip
+
+# FIXME: this results in errors
+statement ok
+SET experimental_parallel_csv=true;
+
+mode unskip
+
 # CSV file with irregularity in first column and default sample size
 statement ok
 CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/test_fallback.csv');

--- a/test/sql/copy/csv/auto/test_header_completion.test
+++ b/test/sql/copy/csv/auto/test_header_completion.test
@@ -2,6 +2,14 @@
 # description: Test csv header completion
 # group: [auto]
 
+mode skip
+
+# FIXME: this results in errors
+statement ok
+SET experimental_parallel_csv=true;
+
+mode unskip
+
 # CSV file with one missing header
 statement ok
 CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/missing_header_col.csv');


### PR DESCRIPTION
* Correctly pass auto-detected parameters to the parallel CSV reader
* Allocate CSV reader buffers through the buffer manager
* Move buffer_size parameter from `read_csv` to the generic read options, allowing it to also be used for `COPY` statements
* Minor clean-up - convert NULL values in CSV reader options to empty strings instead of the literal `NULL`
* Add the parallel CSV reader to several more tests (including a few ones that don't work yet and are currently skipped, CC @pdet)