### PR TITLE
Improve memory management of ART indexes

### DIFF
--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -148,9 +148,13 @@ data_ptr_t Allocator::ReallocateData(data_ptr_t pointer, idx_t old_size, idx_t s
 	return new_pointer;
 }
 
-Allocator &Allocator::DefaultAllocator() {
-	static Allocator DEFAULT_ALLOCATOR;
+shared_ptr<Allocator> &Allocator::DefaultAllocatorReference() {
+	static shared_ptr<Allocator> DEFAULT_ALLOCATOR = make_shared<Allocator>();
 	return DEFAULT_ALLOCATOR;
+}
+
+Allocator &Allocator::DefaultAllocator() {
+	return *DefaultAllocatorReference();
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -115,6 +115,7 @@ Allocator::~Allocator() {
 }
 
 data_ptr_t Allocator::AllocateData(idx_t size) {
+	D_ASSERT(size > 0);
 	auto result = allocate_function(private_data.get(), size);
 #ifdef DEBUG
 	D_ASSERT(private_data);
@@ -127,6 +128,7 @@ void Allocator::FreeData(data_ptr_t pointer, idx_t size) {
 	if (!pointer) {
 		return;
 	}
+	D_ASSERT(size > 0);
 #ifdef DEBUG
 	D_ASSERT(private_data);
 	private_data->debug_info->FreeData(pointer, size);

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -249,7 +249,6 @@ void Construct(vector<Key> &keys, row_t *row_ids, Node *&node, KeySection &key_s
 
 	// we reached a leaf, i.e. all the bytes of start_key and end_key match
 	if (start_key.len == key_section.depth) {
-
 		// end_idx is inclusive
 		auto num_row_ids = key_section.end - key_section.start + 1;
 
@@ -258,14 +257,7 @@ void Construct(vector<Key> &keys, row_t *row_ids, Node *&node, KeySection &key_s
 			throw ConstraintException("New data contains duplicates on indexed column(s)");
 		}
 
-		// new row ids of this leaf
-		auto new_row_ids = unique_ptr<row_t[]>(new row_t[num_row_ids]);
-		for (idx_t i = 0; i < num_row_ids; i++) {
-			new_row_ids[i] = row_ids[key_section.start + i];
-		}
-
-		node = new Leaf(start_key, prefix_start, move(new_row_ids), num_row_ids);
-
+		node = new Leaf(start_key, prefix_start, row_ids + key_section.start, num_row_ids);
 	} else { // create a new node and recurse
 
 		// we will find at least two child entries of this node, otherwise we'd have reached a leaf

--- a/src/execution/index/art/leaf.cpp
+++ b/src/execution/index/art/leaf.cpp
@@ -32,7 +32,6 @@ Leaf::Leaf(unique_ptr<row_t[]> row_ids_p, idx_t num_elements_p, Prefix &prefix_p
 }
 
 void Leaf::Insert(row_t row_id) {
-
 	// Grow array
 	if (count == capacity) {
 		auto new_row_id = unique_ptr<row_t[]>(new row_t[capacity * 2]);

--- a/src/execution/index/art/leaf.cpp
+++ b/src/execution/index/art/leaf.cpp
@@ -102,11 +102,6 @@ void Leaf::Insert(row_t row_id) {
 }
 
 void Leaf::Remove(row_t row_id) {
-	if (IsInlined()) {
-		D_ASSERT(count == 1);
-		count--;
-		return;
-	}
 	idx_t entry_offset = DConstants::INVALID_INDEX;
 	row_t *row_ids = GetRowIds();
 	for (idx_t i = 0; i < count; i++) {
@@ -116,6 +111,11 @@ void Leaf::Remove(row_t row_id) {
 		}
 	}
 	if (entry_offset == DConstants::INVALID_INDEX) {
+		return;
+	}
+	if (IsInlined()) {
+		D_ASSERT(count == 1);
+		count--;
 		return;
 	}
 	count--;

--- a/src/execution/index/art/leaf.cpp
+++ b/src/execution/index/art/leaf.cpp
@@ -136,6 +136,7 @@ void Leaf::Remove(row_t row_id) {
 		auto new_row_ids = new_allocation.get() + 1;
 		memcpy(new_row_ids, row_ids, entry_offset * sizeof(row_t));
 		memcpy(new_row_ids + entry_offset, row_ids + entry_offset + 1, (count - entry_offset) * sizeof(row_t));
+		delete [] rowids.ptr;
 		rowids.ptr = new_allocation.release();
 	} else {
 		// Copy the rest

--- a/src/execution/index/art/leaf.cpp
+++ b/src/execution/index/art/leaf.cpp
@@ -6,44 +6,109 @@
 #include <cstring>
 
 namespace duckdb {
+idx_t Leaf::GetCapacity() const {
+	return IsInlined() ? 1 : rowids.ptr[0];
+}
+
+bool Leaf::IsInlined() const {
+	return count <= 1;
+}
+
+row_t Leaf::GetRowId(idx_t index) {
+	D_ASSERT(index < count);
+	if (IsInlined()) {
+		return rowids.inlined;
+	} else {
+		D_ASSERT(rowids.ptr[0] >= count);
+		return rowids.ptr[index + 1];
+	}
+}
+
+row_t *Leaf::GetRowIds() {
+	if (IsInlined()) {
+		return &rowids.inlined;
+	} else {
+		return rowids.ptr + 1;
+	}
+}
 
 Leaf::Leaf(Key &value, uint32_t depth, row_t row_id) : Node(NodeType::NLeaf) {
-	capacity = 1;
-	row_ids = unique_ptr<row_t[]>(new row_t[capacity]);
-	row_ids[0] = row_id;
 	count = 1;
+	rowids.inlined = row_id;
 	D_ASSERT(value.len >= depth);
 	prefix = Prefix(value, depth, value.len - depth);
 }
 
-Leaf::Leaf(Key &value, uint32_t depth, unique_ptr<row_t[]> row_ids_p, idx_t num_elements_p) : Node(NodeType::NLeaf) {
-	capacity = num_elements_p;
-	row_ids = move(row_ids_p);
+Leaf::Leaf(Key &value, uint32_t depth, row_t *row_ids_p, idx_t num_elements_p) : Node(NodeType::NLeaf) {
+	D_ASSERT(num_elements_p >= 1);
+	if (num_elements_p == 1) {
+		// we can inline the row ids
+		rowids.inlined = row_ids_p[0];
+	} else {
+		// new row ids of this leaf
+		count = 0;
+		Resize(row_ids_p, num_elements_p, num_elements_p);
+	}
 	count = num_elements_p;
 	D_ASSERT(value.len >= depth);
 	prefix = Prefix(value, depth, value.len - depth);
 }
 
 Leaf::Leaf(unique_ptr<row_t[]> row_ids_p, idx_t num_elements_p, Prefix &prefix_p) : Node(NodeType::NLeaf) {
-	capacity = num_elements_p;
-	row_ids = move(row_ids_p);
+	D_ASSERT(num_elements_p > 1);
+	D_ASSERT(row_ids_p[0] == row_t(num_elements_p)); // first element should contain capacity
+	rowids.ptr = row_ids_p.release();
 	count = num_elements_p;
 	prefix = prefix_p;
 }
 
+Leaf::Leaf(row_t row_id, Prefix &prefix_p) : Node(NodeType::NLeaf) {
+	rowids.inlined = row_id;
+	count = 1;
+	prefix = prefix_p;
+}
+
+Leaf::~Leaf() {
+	if (!IsInlined()) {
+		delete[] rowids.ptr;
+		count = 0;
+	}
+}
+
+row_t *Leaf::Resize(row_t *current_row_ids, uint32_t current_count, idx_t new_capacity) {
+	D_ASSERT(new_capacity >= current_count);
+	auto new_allocation = unique_ptr<row_t[]>(new row_t[new_capacity + 1]);
+	new_allocation[0] = new_capacity;
+	auto new_row_ids = new_allocation.get() + 1;
+	memcpy(new_row_ids, current_row_ids, current_count * sizeof(row_t));
+	if (!IsInlined()) {
+		// delete the old data
+		delete[] rowids.ptr;
+	}
+	// set up the new pointers
+	rowids.ptr = new_allocation.release();
+	return new_row_ids;
+}
+
 void Leaf::Insert(row_t row_id) {
-	// Grow array
+	auto capacity = GetCapacity();
+	row_t *row_ids = GetRowIds();
+	D_ASSERT(count <= capacity);
 	if (count == capacity) {
-		auto new_row_id = unique_ptr<row_t[]>(new row_t[capacity * 2]);
-		memcpy(new_row_id.get(), row_ids.get(), capacity * sizeof(row_t));
-		capacity *= 2;
-		row_ids = move(new_row_id);
+		// Grow array
+		row_ids = Resize(row_ids, count, capacity * 2);
 	}
 	row_ids[count++] = row_id;
 }
 
 void Leaf::Remove(row_t row_id) {
+	if (IsInlined()) {
+		D_ASSERT(count == 1);
+		count--;
+		return;
+	}
 	idx_t entry_offset = DConstants::INVALID_INDEX;
+	row_t *row_ids = GetRowIds();
 	for (idx_t i = 0; i < count; i++) {
 		if (row_ids[i] == row_id) {
 			entry_offset = i;
@@ -54,32 +119,41 @@ void Leaf::Remove(row_t row_id) {
 		return;
 	}
 	count--;
+	if (count == 1) {
+		// after erasing we can now inline the leaf
+		// delete the pointer and inline the remaining rowid
+		auto remaining_row_id = row_ids[0] == row_id ? row_ids[1] : row_ids[0];
+		delete[] rowids.ptr;
+		rowids.inlined = remaining_row_id;
+		return;
+	}
+	auto capacity = GetCapacity();
 	if (capacity > 2 && count < capacity / 2) {
 		// Shrink array, if less than half full
-		auto new_row_id = unique_ptr<row_t[]>(new row_t[capacity / 2]);
-		memcpy(new_row_id.get(), row_ids.get(), entry_offset * sizeof(row_t));
-		memcpy(new_row_id.get() + entry_offset, row_ids.get() + entry_offset + 1,
-		       (count - entry_offset) * sizeof(row_t));
-		capacity /= 2;
-		row_ids = move(new_row_id);
+		auto new_capacity = capacity / 2;
+		auto new_allocation = unique_ptr<row_t[]>(new row_t[new_capacity + 1]);
+		new_allocation[0] = new_capacity;
+		auto new_row_ids = new_allocation.get() + 1;
+		memcpy(new_row_ids, row_ids, entry_offset * sizeof(row_t));
+		memcpy(new_row_ids + entry_offset, row_ids + entry_offset + 1, (count - entry_offset) * sizeof(row_t));
+		rowids.ptr = new_allocation.release();
 	} else {
 		// Copy the rest
-		memmove(row_ids.get() + entry_offset, row_ids.get() + entry_offset + 1, (count - entry_offset) * sizeof(row_t));
+		memmove(row_ids + entry_offset, row_ids + entry_offset + 1, (count - entry_offset) * sizeof(row_t));
 	}
 }
 
 string Leaf::ToString(Node *node) {
-
 	Leaf *leaf = (Leaf *)node;
 	string str = "Leaf: [";
+	auto row_ids = leaf->GetRowIds();
 	for (idx_t i = 0; i < leaf->count; i++) {
-		str += i == 0 ? to_string(leaf->row_ids[i]) : ", " + to_string(leaf->row_ids[i]);
+		str += i == 0 ? to_string(row_ids[i]) : ", " + to_string(row_ids[i]);
 	}
 	return str + "]";
 }
 
 void Leaf::Merge(Node *&l_node, Node *&r_node) {
-
 	Leaf *l_n = (Leaf *)l_node;
 	Leaf *r_n = (Leaf *)r_node;
 
@@ -97,8 +171,9 @@ BlockPointer Leaf::Serialize(duckdb::MetaBlockWriter &writer) {
 	prefix.Serialize(writer);
 	// Write Row Ids
 	// Length
-	writer.Write(count);
+	writer.Write<uint16_t>(count);
 	// Actual Row Ids
+	auto row_ids = GetRowIds();
 	for (idx_t i = 0; i < count; i++) {
 		writer.Write(row_ids[i]);
 	}
@@ -109,11 +184,19 @@ Leaf *Leaf::Deserialize(MetaBlockReader &reader) {
 	Prefix prefix;
 	prefix.Deserialize(reader);
 	auto num_elements = reader.Read<uint16_t>();
-	auto elements = unique_ptr<row_t[]>(new row_t[num_elements]);
-	for (idx_t i = 0; i < num_elements; i++) {
-		elements[i] = reader.Read<row_t>();
+	if (num_elements == 1) {
+		// inlined
+		auto element = reader.Read<row_t>();
+		return new Leaf(element, prefix);
+	} else {
+		// non-inlined
+		auto elements = unique_ptr<row_t[]>(new row_t[num_elements + 1]);
+		elements[0] = num_elements;
+		for (idx_t i = 0; i < num_elements; i++) {
+			elements[i + 1] = reader.Read<row_t>();
+		}
+		return new Leaf(move(elements), num_elements, prefix);
 	}
-	return new Leaf(move(elements), num_elements, prefix);
 }
 
 } // namespace duckdb

--- a/src/execution/index/art/leaf.cpp
+++ b/src/execution/index/art/leaf.cpp
@@ -187,7 +187,7 @@ Leaf *Leaf::Deserialize(MetaBlockReader &reader) {
 	if (num_elements == 1) {
 		// inlined
 		auto element = reader.Read<row_t>();
-		return new Leaf(element, prefix);
+		return Leaf::New(element, prefix);
 	} else {
 		// non-inlined
 		auto elements = unique_ptr<row_t[]>(new row_t[num_elements + 1]);
@@ -195,7 +195,7 @@ Leaf *Leaf::Deserialize(MetaBlockReader &reader) {
 		for (idx_t i = 0; i < num_elements; i++) {
 			elements[i + 1] = reader.Read<row_t>();
 		}
-		return new Leaf(move(elements), num_elements, prefix);
+		return Leaf::New(move(elements), num_elements, prefix);
 	}
 }
 

--- a/src/execution/index/art/leaf.cpp
+++ b/src/execution/index/art/leaf.cpp
@@ -136,7 +136,7 @@ void Leaf::Remove(row_t row_id) {
 		auto new_row_ids = new_allocation.get() + 1;
 		memcpy(new_row_ids, row_ids, entry_offset * sizeof(row_t));
 		memcpy(new_row_ids + entry_offset, row_ids + entry_offset + 1, (count - entry_offset) * sizeof(row_t));
-		delete [] rowids.ptr;
+		delete[] rowids.ptr;
 		rowids.ptr = new_allocation.release();
 	} else {
 		// Copy the rest

--- a/src/execution/index/art/node.cpp
+++ b/src/execution/index/art/node.cpp
@@ -132,10 +132,10 @@ void Node::New(NodeType &type, Node *&node) {
 	}
 }
 
-template <typename T, typename... Args>
-T *AllocateObject(Args &&...args) {
+template <typename T, typename... ARGS>
+T *AllocateObject(ARGS &&...args) {
 	auto data = Allocator::DefaultAllocator().AllocateData(sizeof(T));
-	return new (data) T(std::forward<Args>(args)...);
+	return new (data) T(std::forward<ARGS>(args)...);
 }
 
 template <typename T>

--- a/src/execution/index/art/node.cpp
+++ b/src/execution/index/art/node.cpp
@@ -132,18 +132,6 @@ void Node::New(NodeType &type, Node *&node) {
 	}
 }
 
-template <typename T, typename... ARGS>
-T *AllocateObject(ARGS &&...args) {
-	auto data = Allocator::DefaultAllocator().AllocateData(sizeof(T));
-	return new (data) T(std::forward<ARGS>(args)...);
-}
-
-template <typename T>
-void DestroyObject(T *ptr) {
-	ptr->~T();
-	Allocator::DefaultAllocator().FreeData((data_ptr_t)ptr, sizeof(T));
-}
-
 Node4 *Node4::New() {
 	return AllocateObject<Node4>();
 }
@@ -168,8 +156,8 @@ Leaf *Leaf::New(Key &value, uint32_t depth, row_t *row_ids, idx_t num_elements) 
 	return AllocateObject<Leaf>(value, depth, row_ids, num_elements);
 }
 
-Leaf *Leaf::New(unique_ptr<row_t[]> row_ids, idx_t num_elements, Prefix &prefix) {
-	return AllocateObject<Leaf>(move(row_ids), num_elements, prefix);
+Leaf *Leaf::New(row_t *row_ids, idx_t num_elements, Prefix &prefix) {
+	return AllocateObject<Leaf>(row_ids, num_elements, prefix);
 }
 
 Leaf *Leaf::New(row_t row_id, Prefix &prefix) {

--- a/src/execution/index/art/node.cpp
+++ b/src/execution/index/art/node.cpp
@@ -173,7 +173,7 @@ BlockPointer Node::SerializeInternal(ART &art, duckdb::MetaBlockWriter &writer, 
 	// Write Node Type
 	writer.Write(type);
 	// Write count
-	writer.Write(count);
+	writer.Write<uint16_t>(count);
 	// Write Prefix
 	prefix.Serialize(writer);
 	// Write Key values

--- a/src/execution/index/art/node16.cpp
+++ b/src/execution/index/art/node16.cpp
@@ -77,7 +77,7 @@ void Node16::InsertChild(Node *&node, uint8_t key_byte, Node *new_child) {
 		n->count++;
 	} else {
 		// Grow to Node48
-		auto new_node = new Node48();
+		auto new_node = Node48::New();
 		for (idx_t i = 0; i < node->count; i++) {
 			new_node->child_index[n->key[i]] = i;
 			new_node->children[i] = n->children[i];
@@ -85,7 +85,7 @@ void Node16::InsertChild(Node *&node, uint8_t key_byte, Node *new_child) {
 		}
 		new_node->prefix = move(n->prefix);
 		new_node->count = node->count;
-		delete node;
+		Node::Delete(node);
 		node = new_node;
 
 		Node48::InsertChild(node, key_byte, new_child);
@@ -112,14 +112,14 @@ void Node16::EraseChild(Node *&node, int pos, ART &art) {
 
 	if (node->count <= 3) {
 		// Shrink node
-		auto new_node = new Node4();
+		auto new_node = Node4::New();
 		for (unsigned i = 0; i < n->count; i++) {
 			new_node->key[new_node->count] = n->key[i];
 			new_node->children[new_node->count++] = n->children[i];
 			n->children[i] = nullptr;
 		}
 		new_node->prefix = move(n->prefix);
-		delete node;
+		Node::Delete(node);
 		node = new_node;
 	}
 }

--- a/src/execution/index/art/node256.cpp
+++ b/src/execution/index/art/node256.cpp
@@ -67,7 +67,7 @@ void Node256::EraseChild(Node *&node, int pos, ART &art) {
 	n->children[pos].Reset();
 	n->count--;
 	if (node->count <= 36) {
-		auto new_node = new Node48();
+		auto new_node = Node48::New();
 		new_node->prefix = move(n->prefix);
 		for (idx_t i = 0; i < 256; i++) {
 			if (n->children[i]) {
@@ -77,7 +77,7 @@ void Node256::EraseChild(Node *&node, int pos, ART &art) {
 				new_node->count++;
 			}
 		}
-		delete node;
+		Node::Delete(node);
 		node = new_node;
 	}
 }

--- a/src/execution/index/art/node4.cpp
+++ b/src/execution/index/art/node4.cpp
@@ -75,7 +75,7 @@ void Node4::InsertChild(Node *&node, uint8_t key_byte, Node *new_child) {
 		n->count++;
 	} else {
 		// Grow to Node16
-		auto new_node = new Node16();
+		auto new_node = Node16::New();
 		new_node->count = 4;
 		new_node->prefix = move(node->prefix);
 		for (idx_t i = 0; i < 4; i++) {
@@ -84,7 +84,7 @@ void Node4::InsertChild(Node *&node, uint8_t key_byte, Node *new_child) {
 			n->children[i] = nullptr;
 		}
 		// Delete old node and replace it with new Node16
-		delete node;
+		Node::Delete(node);
 		node = new_node;
 		Node16::InsertChild(node, key_byte, new_child);
 	}
@@ -112,7 +112,7 @@ void Node4::EraseChild(Node *&node, int pos, ART &art) {
 		// concatenate prefixes
 		child_ref->prefix.Concatenate(n->key[0], node->prefix);
 		n->children[0] = nullptr;
-		delete node;
+		Node::Delete(node);
 		node = child_ref;
 	}
 }

--- a/src/execution/index/art/node48.cpp
+++ b/src/execution/index/art/node48.cpp
@@ -79,7 +79,7 @@ void Node48::InsertChild(Node *&node, uint8_t key_byte, Node *new_child) {
 		n->count++;
 	} else {
 		// Grow to Node256
-		auto new_node = new Node256();
+		auto new_node = Node256::New();
 		for (idx_t i = 0; i < 256; i++) {
 			if (n->child_index[i] != Node::EMPTY_MARKER) {
 				new_node->children[i] = n->children[n->child_index[i]];
@@ -88,7 +88,7 @@ void Node48::InsertChild(Node *&node, uint8_t key_byte, Node *new_child) {
 		}
 		new_node->count = n->count;
 		new_node->prefix = move(n->prefix);
-		delete node;
+		Node::Delete(node);
 		node = new_node;
 		Node256::InsertChild(node, key_byte, new_child);
 	}
@@ -100,7 +100,7 @@ void Node48::EraseChild(Node *&node, int pos, ART &art) {
 	n->child_index[pos] = Node::EMPTY_MARKER;
 	n->count--;
 	if (node->count <= 12) {
-		auto new_node = new Node16();
+		auto new_node = Node16::New();
 		new_node->prefix = move(n->prefix);
 		for (idx_t i = 0; i < 256; i++) {
 			if (n->child_index[i] != Node::EMPTY_MARKER) {
@@ -109,7 +109,7 @@ void Node48::EraseChild(Node *&node, int pos, ART &art) {
 				n->children[n->child_index[i]] = nullptr;
 			}
 		}
-		delete node;
+		Node::Delete(node);
 		node = new_node;
 	}
 }

--- a/src/execution/index/art/prefix.cpp
+++ b/src/execution/index/art/prefix.cpp
@@ -139,14 +139,14 @@ void Prefix::Concatenate(uint8_t key, Prefix &other) {
 
 uint8_t Prefix::Reduce(uint32_t n) {
 	auto new_size = size - n - 1;
+	auto prefix = GetPrefixData();
+	auto key = prefix[n];
 	if (new_size == 0) {
 		Destroy();
 		size = 0;
-		return 0;
+		return key;
 	}
 	auto new_prefix = AllocateArray(new_size);
-	auto prefix = GetPrefixData();
-	auto key = prefix[n];
 	for (idx_t i = 0; i < new_size; i++) {
 		new_prefix[i] = prefix[i + n + 1];
 	}

--- a/src/execution/index/art/prefix.cpp
+++ b/src/execution/index/art/prefix.cpp
@@ -6,12 +6,39 @@ uint32_t Prefix::Size() const {
 	return size;
 }
 
+bool Prefix::IsInlined() const {
+	return size <= PREFIX_INLINE_BYTES;
+}
+
+uint8_t *Prefix::GetPrefixData() {
+	return IsInlined() ? &value.inlined[0] : value.ptr;
+}
+
+const uint8_t *Prefix::GetPrefixData() const {
+	return IsInlined() ? &value.inlined[0] : value.ptr;
+}
+
+uint8_t *Prefix::AllocatePrefix(uint32_t size) {
+	Destroy();
+
+	this->size = size;
+	uint8_t *prefix;
+	if (IsInlined()) {
+		prefix = &value.inlined[0];
+	} else {
+		// allocate new prefix
+		value.ptr = new uint8_t[size];
+		prefix = value.ptr;
+	}
+	return prefix;
+}
+
 Prefix::Prefix() : size(0) {
 }
 
-Prefix::Prefix(Key &key, uint32_t depth, uint32_t size) : size(size) {
-	// allocate new prefix
-	prefix = unique_ptr<uint8_t[]>(new uint8_t[size]);
+
+Prefix::Prefix(Key &key, uint32_t depth, uint32_t size) : size(0) {
+	auto prefix = AllocatePrefix(size);
 
 	// copy key to prefix
 	idx_t prefix_idx = 0;
@@ -20,37 +47,64 @@ Prefix::Prefix(Key &key, uint32_t depth, uint32_t size) : size(size) {
 	}
 }
 
-Prefix::Prefix(Prefix &other_prefix, uint32_t size) : size(size) {
-	// allocate new prefix
-	prefix = unique_ptr<uint8_t[]>(new uint8_t[size]);
+Prefix::Prefix(Prefix &other_prefix, uint32_t size) : size(0) {
+	auto prefix = AllocatePrefix(size);
 
 	// copy key to Prefix
+	auto other_data = other_prefix.GetPrefixData();
 	for (idx_t i = 0; i < size; i++) {
-		prefix[i] = other_prefix[i];
+		prefix[i] = other_data[i];
+	}
+}
+
+Prefix::~Prefix() {
+	Destroy();
+}
+
+void Prefix::Destroy() {
+	if (!IsInlined()) {
+		delete [] value.ptr;
+		size = 0;
 	}
 }
 
 uint8_t &Prefix::operator[](idx_t idx) {
 	D_ASSERT(idx < Size());
-	return prefix[idx];
+	return GetPrefixData()[idx];
 }
 
 Prefix &Prefix::operator=(const Prefix &src) {
-	// allocate new prefix
-	prefix = unique_ptr<uint8_t[]>(new uint8_t[src.size]);
+	auto prefix = AllocatePrefix(src.size);
 
 	// copy prefix
+	auto src_prefix = src.GetPrefixData();
 	for (idx_t i = 0; i < src.size; i++) {
-		prefix[i] = src.prefix[i];
+		prefix[i] = src_prefix[i];
 	}
 	size = src.size;
 	return *this;
 }
 
 Prefix &Prefix::operator=(Prefix &&other) noexcept {
-	prefix = move(other.prefix);
-	size = other.size;
+	std::swap(size, other.size);
+	std::swap(value, other.value);
 	return *this;
+}
+
+void Prefix::Overwrite(uint32_t new_size, unique_ptr<uint8_t[]> data) {
+	if (new_size <= PREFIX_INLINE_BYTES) {
+		// new entry would be inlined
+		// inline the data and destroy the pointer
+		auto prefix = AllocatePrefix(new_size);
+		for(idx_t i = 0; i < new_size; i++) {
+			prefix[i] = data[i];
+		}
+	} else {
+		// new entry would not be inlined
+		// take over the data directly
+		size = new_size;
+		value.ptr = data.release();
+	}
 }
 
 void Prefix::Concatenate(uint8_t key, Prefix &other) {
@@ -65,27 +119,28 @@ void Prefix::Concatenate(uint8_t key, Prefix &other) {
 	// 2) now move the current key as part of the prefix
 	new_prefix[new_prefix_idx++] = key;
 	// 3) move the existing prefix (if any)
+	auto prefix = GetPrefixData();
 	for (uint32_t i = 0; i < size; i++) {
 		new_prefix[new_prefix_idx++] = prefix[i];
 	}
-	prefix = move(new_prefix);
-	size = new_length;
+	Overwrite(new_length, move(new_prefix));
 }
 
 uint8_t Prefix::Reduce(uint32_t n) {
 	auto new_size = size - n - 1;
 	auto new_prefix = unique_ptr<uint8_t[]>(new uint8_t[new_size]);
+	auto prefix = GetPrefixData();
 	auto key = prefix[n];
 	for (idx_t i = 0; i < new_size; i++) {
 		new_prefix[i] = prefix[i + n + 1];
 	}
-	prefix = move(new_prefix);
-	size = new_size;
+	Overwrite(new_size, move(new_prefix));
 	return key;
 }
 
 void Prefix::Serialize(duckdb::MetaBlockWriter &writer) {
 	writer.Write(size);
+	auto prefix = GetPrefixData();
 	for (idx_t i = 0; i < size; i++) {
 		writer.Write(prefix[i]);
 	}
@@ -93,7 +148,7 @@ void Prefix::Serialize(duckdb::MetaBlockWriter &writer) {
 
 void Prefix::Deserialize(duckdb::MetaBlockReader &reader) {
 	size = reader.Read<uint32_t>();
-	prefix = unique_ptr<uint8_t[]>(new uint8_t[size]);
+	auto prefix = AllocatePrefix(size);
 	for (idx_t i = 0; i < size; i++) {
 		prefix[i] = reader.Read<uint8_t>();
 	}
@@ -101,6 +156,7 @@ void Prefix::Deserialize(duckdb::MetaBlockReader &reader) {
 
 uint32_t Prefix::KeyMismatchPosition(Key &key, uint64_t depth) {
 	uint64_t pos;
+	auto prefix = GetPrefixData();
 	for (pos = 0; pos < size; pos++) {
 		if (key[depth + pos] != prefix[pos]) {
 			return pos;
@@ -110,9 +166,10 @@ uint32_t Prefix::KeyMismatchPosition(Key &key, uint64_t depth) {
 }
 
 uint32_t Prefix::MismatchPosition(Prefix &other) {
-
+	auto prefix = GetPrefixData();
+	auto other_data = other.GetPrefixData();
 	for (idx_t i = 0; i < size; i++) {
-		if (prefix[i] != other[i]) {
+		if (prefix[i] != other_data[i]) {
 			return i;
 		}
 	}

--- a/src/execution/index/art/prefix.cpp
+++ b/src/execution/index/art/prefix.cpp
@@ -36,7 +36,6 @@ uint8_t *Prefix::AllocatePrefix(uint32_t size) {
 Prefix::Prefix() : size(0) {
 }
 
-
 Prefix::Prefix(Key &key, uint32_t depth, uint32_t size) : size(0) {
 	auto prefix = AllocatePrefix(size);
 
@@ -63,7 +62,7 @@ Prefix::~Prefix() {
 
 void Prefix::Destroy() {
 	if (!IsInlined()) {
-		delete [] value.ptr;
+		delete[] value.ptr;
 		size = 0;
 	}
 }
@@ -96,7 +95,7 @@ void Prefix::Overwrite(uint32_t new_size, unique_ptr<uint8_t[]> data) {
 		// new entry would be inlined
 		// inline the data and destroy the pointer
 		auto prefix = AllocatePrefix(new_size);
-		for(idx_t i = 0; i < new_size; i++) {
+		for (idx_t i = 0; i < new_size; i++) {
 			prefix[i] = data[i];
 		}
 	} else {
@@ -141,17 +140,13 @@ uint8_t Prefix::Reduce(uint32_t n) {
 void Prefix::Serialize(duckdb::MetaBlockWriter &writer) {
 	writer.Write(size);
 	auto prefix = GetPrefixData();
-	for (idx_t i = 0; i < size; i++) {
-		writer.Write(prefix[i]);
-	}
+	writer.WriteData(prefix, size);
 }
 
 void Prefix::Deserialize(duckdb::MetaBlockReader &reader) {
 	size = reader.Read<uint32_t>();
 	auto prefix = AllocatePrefix(size);
-	for (idx_t i = 0; i < size; i++) {
-		prefix[i] = reader.Read<uint8_t>();
-	}
+	reader.ReadData(prefix, size);
 }
 
 uint32_t Prefix::KeyMismatchPosition(Key &key, uint64_t depth) {

--- a/src/execution/index/art/prefix.cpp
+++ b/src/execution/index/art/prefix.cpp
@@ -144,8 +144,9 @@ void Prefix::Serialize(duckdb::MetaBlockWriter &writer) {
 }
 
 void Prefix::Deserialize(duckdb::MetaBlockReader &reader) {
-	size = reader.Read<uint32_t>();
-	auto prefix = AllocatePrefix(size);
+	auto prefix_size = reader.Read<uint32_t>();
+	auto prefix = AllocatePrefix(prefix_size);
+	this->size = prefix_size;
 	reader.ReadData(prefix, size);
 }
 

--- a/src/execution/index/art/swizzleable_pointer.cpp
+++ b/src/execution/index/art/swizzleable_pointer.cpp
@@ -4,7 +4,7 @@ namespace duckdb {
 SwizzleablePointer::~SwizzleablePointer() {
 	if (pointer) {
 		if (!IsSwizzled()) {
-			delete (Node *)pointer;
+			Node::Delete((Node *)pointer);
 		}
 	}
 }
@@ -66,7 +66,7 @@ bool SwizzleablePointer::IsSwizzled() {
 void SwizzleablePointer::Reset() {
 	if (pointer) {
 		if (!IsSwizzled()) {
-			delete (Node *)pointer;
+			Node::Delete((Node *)pointer);
 		}
 	}
 	*this = nullptr;

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -94,6 +94,7 @@ public:
 	}
 
 	static Allocator &DefaultAllocator();
+	static shared_ptr<Allocator> &DefaultAllocatorReference();
 
 private:
 	allocate_function_ptr_t allocate_function;

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -103,6 +103,28 @@ private:
 	unique_ptr<PrivateAllocatorData> private_data;
 };
 
+template <class T>
+T *AllocateArray(idx_t size) {
+	return (T *)Allocator::DefaultAllocator().AllocateData(size * sizeof(T));
+}
+
+template <class T>
+void DeleteArray(T *ptr, idx_t size) {
+	Allocator::DefaultAllocator().FreeData((data_ptr_t)ptr, size * sizeof(T));
+}
+
+template <typename T, typename... ARGS>
+T *AllocateObject(ARGS &&...args) {
+	auto data = Allocator::DefaultAllocator().AllocateData(sizeof(T));
+	return new (data) T(std::forward<ARGS>(args)...);
+}
+
+template <typename T>
+void DestroyObject(T *ptr) {
+	ptr->~T();
+	Allocator::DefaultAllocator().FreeData((data_ptr_t)ptr, sizeof(T));
+}
+
 //! The BufferAllocator is a wrapper around the global allocator class that sends any allocations made through the
 //! buffer manager. This makes the buffer manager aware of the memory usage, allowing it to potentially free
 //! other blocks to make space in memory.

--- a/src/include/duckdb/execution/index/art/art.hpp
+++ b/src/include/duckdb/execution/index/art/art.hpp
@@ -124,6 +124,12 @@ private:
 	                      bool right_inclusive, idx_t max_count, vector<row_t> &result_ids);
 
 	void VerifyExistence(DataChunk &chunk, VerifyExistenceType verify_type, string *err_msg_ptr = nullptr);
+
+private:
+	//! The estimated ART memory consumption
+	idx_t estimated_art_size;
+	//! The estimated memory consumption of a single key
+	idx_t estimated_key_size;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/index/art/leaf.hpp
+++ b/src/include/duckdb/execution/index/art/leaf.hpp
@@ -17,7 +17,7 @@ class Leaf : public Node {
 public:
 	Leaf(Key &value, uint32_t depth, row_t row_id);
 	Leaf(Key &value, uint32_t depth, row_t *row_ids, idx_t num_elements);
-	Leaf(unique_ptr<row_t[]> row_ids, idx_t num_elements, Prefix &prefix);
+	Leaf(row_t *row_ids, idx_t num_elements, Prefix &prefix);
 	Leaf(row_t row_id, Prefix &prefix);
 	~Leaf();
 
@@ -29,7 +29,7 @@ public:
 public:
 	static Leaf *New(Key &value, uint32_t depth, row_t row_id);
 	static Leaf *New(Key &value, uint32_t depth, row_t *row_ids, idx_t num_elements);
-	static Leaf *New(unique_ptr<row_t[]> row_ids, idx_t num_elements, Prefix &prefix);
+	static Leaf *New(row_t *row_ids, idx_t num_elements, Prefix &prefix);
 	static Leaf *New(row_t row_id, Prefix &prefix);
 	//! Insert a row_id into a leaf
 	void Insert(row_t row_id);

--- a/src/include/duckdb/execution/index/art/leaf.hpp
+++ b/src/include/duckdb/execution/index/art/leaf.hpp
@@ -16,14 +16,15 @@ namespace duckdb {
 class Leaf : public Node {
 public:
 	Leaf(Key &value, uint32_t depth, row_t row_id);
-	Leaf(Key &value, uint32_t depth, unique_ptr<row_t[]> row_ids, idx_t num_elements);
+	Leaf(Key &value, uint32_t depth, row_t *row_ids, idx_t num_elements);
 	Leaf(unique_ptr<row_t[]> row_ids, idx_t num_elements, Prefix &prefix);
+	Leaf(row_t row_id, Prefix &prefix);
+	~Leaf();
 
-	idx_t capacity;
-
-	row_t GetRowId(idx_t index) {
-		return row_ids[index];
-	}
+	row_t GetRowId(idx_t index);
+	idx_t GetCapacity() const;
+	bool IsInlined() const;
+	row_t *GetRowIds();
 
 public:
 	//! Insert a row_id into a leaf
@@ -42,7 +43,13 @@ public:
 	static Leaf *Deserialize(duckdb::MetaBlockReader &reader);
 
 private:
-	unique_ptr<row_t[]> row_ids;
+	union {
+		row_t inlined;
+		row_t *ptr;
+	} rowids;
+
+private:
+	row_t *Resize(row_t *current_row_ids, uint32_t current_count, idx_t new_capacity);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/index/art/leaf.hpp
+++ b/src/include/duckdb/execution/index/art/leaf.hpp
@@ -27,6 +27,10 @@ public:
 	row_t *GetRowIds();
 
 public:
+	static Leaf *New(Key &value, uint32_t depth, row_t row_id);
+	static Leaf *New(Key &value, uint32_t depth, row_t *row_ids, idx_t num_elements);
+	static Leaf *New(unique_ptr<row_t[]> row_ids, idx_t num_elements, Prefix &prefix);
+	static Leaf *New(row_t row_id, Prefix &prefix);
 	//! Insert a row_id into a leaf
 	void Insert(row_t row_id);
 	//! Remove a row_id from a leaf

--- a/src/include/duckdb/execution/index/art/node.hpp
+++ b/src/include/duckdb/execution/index/art/node.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/storage/index.hpp"
 #include "duckdb/storage/meta_block_reader.hpp"
 #include "duckdb/storage/meta_block_writer.hpp"
+#include "duckdb/common/allocator.hpp"
 
 namespace duckdb {
 enum class NodeType : uint8_t { NLeaf = 0, N4 = 1, N16 = 2, N48 = 3, N256 = 4 };
@@ -69,6 +70,7 @@ public:
 	//! Compressed path (prefix)
 	Prefix prefix;
 
+	static void Delete(Node *node);
 	//! Get the position of a child corresponding exactly to the specific byte, returns DConstants::INVALID_INDEX if not
 	//! exists
 	virtual idx_t GetChildPos(uint8_t k) {

--- a/src/include/duckdb/execution/index/art/node16.hpp
+++ b/src/include/duckdb/execution/index/art/node16.hpp
@@ -19,6 +19,7 @@ public:
 	ARTPointer children[16];
 
 public:
+	static Node16 *New();
 	//! Get position of a specific byte, returns DConstants::INVALID_INDEX if not exists
 	idx_t GetChildPos(uint8_t k) override;
 	//! Get the position of the first child that is greater or equal to the specific byte, or DConstants::INVALID_INDEX

--- a/src/include/duckdb/execution/index/art/node256.hpp
+++ b/src/include/duckdb/execution/index/art/node256.hpp
@@ -18,6 +18,7 @@ public:
 	ARTPointer children[256];
 
 public:
+	static Node256 *New();
 	//! Get position of a specific byte, returns DConstants::INVALID_INDEX if not exists
 	idx_t GetChildPos(uint8_t k) override;
 	//! Get the position of the first child that is greater or equal to the specific byte, or DConstants::INVALID_INDEX

--- a/src/include/duckdb/execution/index/art/node4.hpp
+++ b/src/include/duckdb/execution/index/art/node4.hpp
@@ -15,11 +15,13 @@ namespace duckdb {
 class Node4 : public Node {
 public:
 	Node4();
+
 	uint8_t key[4];
 	// Pointers to the child nodes
 	ARTPointer children[4];
 
 public:
+	static Node4 *New();
 	//! Get position of a byte, returns DConstants::INVALID_INDEX if not exists
 	idx_t GetChildPos(uint8_t k) override;
 	//! Get the position of the first child that is greater or equal to the specific byte, or DConstants::INVALID_INDEX

--- a/src/include/duckdb/execution/index/art/node48.hpp
+++ b/src/include/duckdb/execution/index/art/node48.hpp
@@ -19,6 +19,7 @@ public:
 	ARTPointer children[48];
 
 public:
+	static Node48 *New();
 	//! Get position of a specific byte, returns DConstants::INVALID_INDEX if not exists
 	idx_t GetChildPos(uint8_t k) override;
 	//! Get the position of the first child that is greater or equal to the specific byte, or DConstants::INVALID_INDEX

--- a/src/include/duckdb/execution/index/art/prefix.hpp
+++ b/src/include/duckdb/execution/index/art/prefix.hpp
@@ -64,7 +64,7 @@ private:
 private:
 	bool IsInlined() const;
 	uint8_t *AllocatePrefix(uint32_t size);
-	void Overwrite(uint32_t new_size, unique_ptr<uint8_t[]> data);
+	void Overwrite(uint32_t new_size, uint8_t *data);
 	void Destroy();
 };
 

--- a/src/include/duckdb/execution/index/art/prefix.hpp
+++ b/src/include/duckdb/execution/index/art/prefix.hpp
@@ -14,6 +14,7 @@
 namespace duckdb {
 class Prefix {
 	static constexpr idx_t PREFIX_INLINE_BYTES = 8;
+
 public:
 	Prefix();
 	// Prefix created from key starting on `depth`

--- a/src/include/duckdb/execution/index/art/swizzleable_pointer.hpp
+++ b/src/include/duckdb/execution/index/art/swizzleable_pointer.hpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 #pragma once
+
 #include "duckdb/execution/index/art/node.hpp"
 
 namespace duckdb {

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -159,6 +159,8 @@ public:
 	vector<OptimizerExtension> optimizer_extensions;
 	//! Error manager
 	unique_ptr<ErrorManager> error_manager;
+	//! A reference to the (shared) default allocator (Allocator::DefaultAllocator)
+	shared_ptr<Allocator> default_allocator;
 
 	DUCKDB_API void AddExtensionOption(string name, string description, LogicalType parameter,
 	                                   set_option_callback_t function = nullptr);

--- a/src/include/duckdb/storage/buffer_manager.hpp
+++ b/src/include/duckdb/storage/buffer_manager.hpp
@@ -88,6 +88,9 @@ public:
 	virtual unique_ptr<FileBuffer> ConstructManagedBuffer(idx_t size, unique_ptr<FileBuffer> &&source,
 	                                                      FileBufferType type = FileBufferType::MANAGED_BUFFER);
 
+	DUCKDB_API void ReserveMemory(idx_t size);
+	DUCKDB_API void FreeReservedMemory(idx_t size);
+
 private:
 	//! Evict blocks until the currently used memory + extra_memory fit, returns false if this was not possible
 	//! (i.e. not enough blocks could be evicted)

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -275,6 +275,9 @@ void DatabaseInstance::Configure(DBConfig &new_config) {
 	if (!config.error_manager) {
 		config.error_manager = make_unique<ErrorManager>();
 	}
+	if (!config.default_allocator) {
+		config.default_allocator = Allocator::DefaultAllocatorReference();
+	}
 }
 
 DBConfig &DBConfig::GetConfig(ClientContext &context) {

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -928,6 +928,22 @@ string BufferManager::InMemoryWarning() {
 	       "\nOr set PRAGMA temp_directory='/path/to/tmp.tmp'";
 }
 
+void BufferManager::ReserveMemory(idx_t size) {
+	if (size == 0) {
+		return;
+	}
+	auto reservation =
+	    EvictBlocksOrThrow(size, maximum_memory, nullptr, "failed to reserve memory data of size %lld%s", size);
+	reservation.size = 0;
+}
+
+void BufferManager::FreeReservedMemory(idx_t size) {
+	if (size == 0) {
+		return;
+	}
+	current_memory -= size;
+}
+
 //===--------------------------------------------------------------------===//
 // Buffer Allocator
 //===--------------------------------------------------------------------===//

--- a/test/sql/index/art/test_art_memory_usage.test
+++ b/test/sql/index/art/test_art_memory_usage.test
@@ -14,6 +14,7 @@ CREATE FUNCTION memory_usage_to_bytes(x) AS CASE
     WHEN CONTAINS(x, 'TB') THEN REPLACE(x, 'TB', '')::INT * 1000 * 1000 * 1000 * 1000
     ELSE x::INT END
 
+# regular table
 statement ok
 create table integers(i integer);
 
@@ -32,6 +33,7 @@ SELECT memory_usage_to_bytes(current_usage.memory_usage) * 10 < base_memory.usag
 ----
 true
 
+# table with primary key
 statement ok
 create table integers(i integer primary key);
 
@@ -51,6 +53,6 @@ DROP TABLE integers
 
 # verify that the memory dropped again
 query I
-SELECT memory_usage_to_bytes(current_usage.memory_usage) * 10 < base_memory.usage FROM pragma_database_size() current_usage, base_memory;
+SELECT memory_usage_to_bytes(current_usage.memory_usage) * 10 < index_memory.usage FROM pragma_database_size() current_usage, index_memory;
 ----
 true

--- a/test/sql/index/art/test_art_memory_usage.test
+++ b/test/sql/index/art/test_art_memory_usage.test
@@ -1,0 +1,32 @@
+# name: test/sql/index/art/test_art_memory_usage.test
+# description: Test ART index with many matches
+# group: [art]
+
+require skip_reload
+
+statement ok
+create table integers(i integer);
+
+statement ok
+insert into integers select * from range(1000000);
+
+statement ok
+create temporary table base_memory as select replace(memory_usage, 'MB', '')::INT AS usage from pragma_database_size();
+
+statement ok
+drop table integers
+
+statement ok
+create table integers(i integer primary key);
+
+statement ok
+insert into integers select * from range(1000000);
+
+statement ok
+create temporary table index_memory as select replace(memory_usage, 'MB', '')::INT AS usage from pragma_database_size();
+
+query I
+SELECT index_memory.usage > 2 * base_memory.usage FROM base_memory, index_memory
+----
+1
+

--- a/test/sql/index/art/test_art_memory_usage.test
+++ b/test/sql/index/art/test_art_memory_usage.test
@@ -2,7 +2,17 @@
 # description: Test ART index with many matches
 # group: [art]
 
+require noforcestorage
+
 require skip_reload
+
+statement ok
+CREATE FUNCTION memory_usage_to_bytes(x) AS CASE
+    WHEN CONTAINS(x, 'KB') THEN REPLACE(x, 'KB', '')::INT * 1000
+    WHEN CONTAINS(x, 'MB') THEN REPLACE(x, 'MB', '')::INT * 1000 * 1000
+    WHEN CONTAINS(x, 'GB') THEN REPLACE(x, 'GB', '')::INT * 1000 * 1000 * 1000
+    WHEN CONTAINS(x, 'TB') THEN REPLACE(x, 'TB', '')::INT * 1000 * 1000 * 1000 * 1000
+    ELSE x::INT END
 
 statement ok
 create table integers(i integer);
@@ -11,10 +21,16 @@ statement ok
 insert into integers select * from range(1000000);
 
 statement ok
-create temporary table base_memory as select replace(memory_usage, 'MB', '')::INT AS usage from pragma_database_size();
+create temporary table base_memory as select memory_usage_to_bytes(memory_usage) AS usage from pragma_database_size();
 
 statement ok
 drop table integers
+
+# verify that the memory dropped again
+query I
+SELECT memory_usage_to_bytes(current_usage.memory_usage) * 10 < base_memory.usage FROM pragma_database_size() current_usage, base_memory;
+----
+true
 
 statement ok
 create table integers(i integer primary key);
@@ -23,10 +39,18 @@ statement ok
 insert into integers select * from range(1000000);
 
 statement ok
-create temporary table index_memory as select replace(memory_usage, 'MB', '')::INT AS usage from pragma_database_size();
+create temporary table index_memory as select memory_usage_to_bytes(memory_usage) AS usage from pragma_database_size();
 
 query I
 SELECT index_memory.usage > 2 * base_memory.usage FROM base_memory, index_memory
 ----
 1
 
+statement ok
+DROP TABLE integers
+
+# verify that the memory dropped again
+query I
+SELECT memory_usage_to_bytes(current_usage.memory_usage) * 10 < base_memory.usage FROM pragma_database_size() current_usage, base_memory;
+----
+true


### PR DESCRIPTION
This PR improves several aspects of the memory management around ART indexes.

* For leafs, inline the `rowid` value if there is only a single rowid, and store the `capacity` with the non-inlined data only if there is more than one rowid. This reduces the size of single-rowid leafs considerably, which is what is used for `PRIMARY`/`UNIQUE` indexes.
* For prefixes, inline the prefix if it is 8 bytes or less. This greatly reduces the number of allocations required for small prefixes (which every node, including leafs, contains).
* Add rough memory management estimation to the ART and register this in the buffer manager. Rather than counting exactly how much memory the ART consumes we make an educated guess based on types stored in the ART and amount of nodes in the ART. This at least ensures ART memory management is somewhat registered in the buffer manager and if an ART is taking up too much memory other buffers can be freed.
* Route all allocations through the `Allocator::DefaultAllocator`, allowing the ART nodes to take advantage of jemalloc if installed
