### PR TITLE
Fix binder error and produce more informative error message.

### DIFF
--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -231,10 +231,6 @@ string ExpressionBinder::Bind(unique_ptr<ParsedExpression> *expr, idx_t depth, b
 	}
 	// bind the expression
 	BindResult result = BindExpression(expr, depth, root_expression);
-	if (result.expression && result.expression->expression_class == ExpressionClass::BOUND_COLUMN_REF) {
-		auto &expr = (BoundColumnRefExpression&)*result.expression;
-		expr.depth = depth;
-	}
 	if (result.HasError()) {
 		return result.error;
 	}

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -231,6 +231,10 @@ string ExpressionBinder::Bind(unique_ptr<ParsedExpression> *expr, idx_t depth, b
 	}
 	// bind the expression
 	BindResult result = BindExpression(expr, depth, root_expression);
+	if (result.expression && result.expression->expression_class == ExpressionClass::BOUND_COLUMN_REF) {
+		auto &expr = (BoundColumnRefExpression&)*result.expression;
+		expr.depth = depth;
+	}
 	if (result.HasError()) {
 		return result.error;
 	}

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -93,8 +93,10 @@ BindResult SelectBinder::BindColumnRef(unique_ptr<ParsedExpression> *expr_ptr, i
 				                      colref.column_names[0]);
 			}
 			auto result = BindResult(node.select_list[index]->Copy());
-			auto &result_expr = (BoundColumnRefExpression &)*result.expression;
-			result_expr.depth = depth;
+			if (result.expression->type == ExpressionType::BOUND_COLUMN_REF) {
+				auto &result_expr = (BoundColumnRefExpression &)*result.expression;
+				result_expr.depth = depth;
+			}
 			return result;
 		}
 	}

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -92,7 +92,10 @@ BindResult SelectBinder::BindColumnRef(unique_ptr<ParsedExpression> *expr_ptr, i
 				                      "effects. This is not yet supported.",
 				                      colref.column_names[0]);
 			}
-			return BindResult(node.select_list[index]->Copy());
+			auto result = BindResult(node.select_list[index]->Copy());
+			auto &result_expr = (BoundColumnRefExpression &)*result.expression;
+			result_expr.depth = depth;
+			return result;
 		}
 	}
 	// entry was not found in the alias map: return the original error

--- a/test/fuzzer/pedro/another_binder_error.test
+++ b/test/fuzzer/pedro/another_binder_error.test
@@ -12,4 +12,14 @@ SELECT avg(0) c0, (SELECT 0 OFFSET c0 + 1);
 ----
 Parser Error: Non-constant limit or offset not supported in correlated subquery
 
+query II
+SELECT 1 c0, (SELECT 0 OFFSET c0 - 1);
+----
+1	0
+
+
+statement error
+SELECT (SELECT avg(0)) c0, (SELECT 0 OFFSET c0 + 1);
+----
+Serialization Error: Cannot copy BoundSubqueryExpression
 

--- a/test/fuzzer/pedro/another_binder_error.test
+++ b/test/fuzzer/pedro/another_binder_error.test
@@ -7,4 +7,9 @@ SELECT avg(0) c0, (SELECT 0 OFFSET c0);
 ----
 Parser Error: Non-constant limit or offset not supported in correlated subquery
 
+statement error
+SELECT avg(0) c0, (SELECT 0 OFFSET c0 + 1);
+----
+Parser Error: Non-constant limit or offset not supported in correlated subquery
+
 

--- a/test/fuzzer/pedro/another_binder_error.test
+++ b/test/fuzzer/pedro/another_binder_error.test
@@ -23,3 +23,7 @@ SELECT (SELECT avg(0)) c0, (SELECT 0 OFFSET c0 + 1);
 ----
 Serialization Error: Cannot copy BoundSubqueryExpression
 
+query II
+select avg(0) AS c0, (SELECT c0);
+----
+0.0	0.0

--- a/test/fuzzer/pedro/another_binder_error.test
+++ b/test/fuzzer/pedro/another_binder_error.test
@@ -1,0 +1,22 @@
+# name: test/fuzzer/pedro/another_binder_error.test
+# group: [pedro]
+
+# Originally an INTERNAL ERROR was thrown, which is not what we want to show users, so now we do this.
+# Having trouble figuring out where to change this error to just a simple Binder Error.
+# Within the (SELECT 0 OFFSET 0) a basic BinderError is produced, but then BindCorrelatedColumns gets called.
+# Eventually a binding is found for c0 to the alias defined in the first select term.
+# ExtractCorrelatedExpressions, should then extract the correlated column/alias but this doesn't happen.
+# The check `bound_colref.depth > 0` is false while the depth of the binders when binding the second c0 is very much 1.
+# This is because we are binding a delimiter in a subquery, and a depth of 0 is assumed
+#       See BindDelimiter in `bind_select_node.cpp` and then the line `auto expr = expr_binder.Bind(delimiter);`
+# and `return BindResult(node.select_list[index]->Copy());` is used to return a bind result.
+# However, since we are in correlated subqueries, we need to update it to 1 the proper depth.
+# by resetting it, we get a much nicer error which is that you can't set non-constant limit or offset in correlated subqueries
+
+
+statement error
+SELECT avg(0) c0, (SELECT 0 OFFSET c0);
+----
+Parser Error: Non-constant limit or offset not supported in correlated subquery
+
+

--- a/test/fuzzer/pedro/another_binder_error.test
+++ b/test/fuzzer/pedro/another_binder_error.test
@@ -1,18 +1,6 @@
 # name: test/fuzzer/pedro/another_binder_error.test
+# description: Issue #4978 (issue 48): Another Binder Issue
 # group: [pedro]
-
-# Originally an INTERNAL ERROR was thrown, which is not what we want to show users, so now we do this.
-# Having trouble figuring out where to change this error to just a simple Binder Error.
-# Within the (SELECT 0 OFFSET 0) a basic BinderError is produced, but then BindCorrelatedColumns gets called.
-# Eventually a binding is found for c0 to the alias defined in the first select term.
-# ExtractCorrelatedExpressions, should then extract the correlated column/alias but this doesn't happen.
-# The check `bound_colref.depth > 0` is false while the depth of the binders when binding the second c0 is very much 1.
-# This is because we are binding a delimiter in a subquery, and a depth of 0 is assumed
-#       See BindDelimiter in `bind_select_node.cpp` and then the line `auto expr = expr_binder.Bind(delimiter);`
-# and `return BindResult(node.select_list[index]->Copy());` is used to return a bind result.
-# However, since we are in correlated subqueries, we need to update it to 1 the proper depth.
-# by resetting it, we get a much nicer error which is that you can't set non-constant limit or offset in correlated subqueries
-
 
 statement error
 SELECT avg(0) c0, (SELECT 0 OFFSET c0);


### PR DESCRIPTION
This address fuzzer issue 48 in https://github.com/duckdb/duckdb/issues/4978

Originally an `INTERNAL ERROR: BINDER ERROR` message was thrown, which I don't think is the most informative message to show users. Especially the `INTERNAL ERROR`

- Within the (SELECT 0 OFFSET c0) an informative BinderError is produced, but then `BindCorrelatedColumns` gets called.
- Eventually a binding is found for c0 to the alias defined in the first select term and the error is ignored.
- `ExtractCorrelatedExpressions`, should then extract the correlated column/alias into the binder context but this doesn't happen.
- The check `bound_colref.depth > 0` in `ExtractCorrelatedExpressions` is false while the depth of the column c0 is very much 1.
- This is because we are binding a delimiter in a subquery, and a depth of 0 is assumed. See `BindDelimiter()` in `bind_select_node.cpp`, which calls`expr_binder.Bind(delimiter);` which calls `auto error_msg = Bind(&expr, 0, root_expression);` in `expression_binder.cpp`. The 0 is the depth.
-  So since we are in correlated subqueries, we need to make sure the ColumnRef has the proper depth. Now it is set to the depth determined by logic in the correlatedsubquery code.

I'm not sure if this is the best fix though, as it feels like it could mess up other logic that uses the same code path. Maybe a nicer fix would be passing the depth to the `BindDelimiter `and keep passing it along?  Open to other ideas though.
