### PR TITLE
Improve progress bar & box rendering

### DIFF
--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -500,8 +500,8 @@ void BoxRenderer::RenderRowCount(string row_count_str, string shown_str, const s
 	}
 	auto minimum_length = row_count_str.size() + column_count_str.size() + 6;
 	bool render_rows_and_columns = total_length >= minimum_length &&
-	                               ((has_hidden_columns && row_count > 0) || (row_count > 1 && column_count > 1));
-	bool render_rows = total_length >= minimum_row_length && row_count != 1;
+	                               ((has_hidden_columns && row_count > 0) || (row_count >= 10 && column_count > 1));
+	bool render_rows = total_length >= minimum_row_length && (row_count == 0 || row_count >= 10);
 	bool render_anything = true;
 	if (!render_rows && !render_rows_and_columns) {
 		render_anything = false;

--- a/src/include/duckdb/planner/operator/logical_aggregate.hpp
+++ b/src/include/duckdb/planner/operator/logical_aggregate.hpp
@@ -42,6 +42,7 @@ public:
 	vector<ColumnBinding> GetColumnBindings() override;
 	void Serialize(FieldWriter &writer) const override;
 	static unique_ptr<LogicalOperator> Deserialize(LogicalDeserializationState &state, FieldReader &reader);
+	idx_t EstimateCardinality(ClientContext &context) override;
 
 protected:
 	void ResolveTypes() override;

--- a/src/include/duckdb/planner/operator/logical_copy_to_file.hpp
+++ b/src/include/duckdb/planner/operator/logical_copy_to_file.hpp
@@ -28,6 +28,7 @@ public:
 public:
 	void Serialize(FieldWriter &writer) const override;
 	static unique_ptr<LogicalOperator> Deserialize(LogicalDeserializationState &state, FieldReader &reader);
+	idx_t EstimateCardinality(ClientContext &context) override;
 
 protected:
 	void ResolveTypes() override {

--- a/src/include/duckdb/planner/operator/logical_create.hpp
+++ b/src/include/duckdb/planner/operator/logical_create.hpp
@@ -26,6 +26,7 @@ public:
 public:
 	void Serialize(FieldWriter &writer) const override;
 	static unique_ptr<LogicalOperator> Deserialize(LogicalDeserializationState &state, FieldReader &reader);
+	idx_t EstimateCardinality(ClientContext &context) override;
 
 protected:
 	void ResolveTypes() override {

--- a/src/include/duckdb/planner/operator/logical_create_table.hpp
+++ b/src/include/duckdb/planner/operator/logical_create_table.hpp
@@ -27,6 +27,7 @@ public:
 public:
 	void Serialize(FieldWriter &writer) const override;
 	static unique_ptr<LogicalOperator> Deserialize(LogicalDeserializationState &state, FieldReader &reader);
+	idx_t EstimateCardinality(ClientContext &context) override;
 
 protected:
 	void ResolveTypes() override {

--- a/src/include/duckdb/planner/operator/logical_delete.hpp
+++ b/src/include/duckdb/planner/operator/logical_delete.hpp
@@ -27,6 +27,7 @@ public:
 public:
 	void Serialize(FieldWriter &writer) const override;
 	static unique_ptr<LogicalOperator> Deserialize(LogicalDeserializationState &state, FieldReader &reader);
+	idx_t EstimateCardinality(ClientContext &context) override;
 
 protected:
 	vector<ColumnBinding> GetColumnBindings() override {

--- a/src/include/duckdb/planner/operator/logical_empty_result.hpp
+++ b/src/include/duckdb/planner/operator/logical_empty_result.hpp
@@ -31,6 +31,9 @@ public:
 	}
 	void Serialize(FieldWriter &writer) const override;
 	static unique_ptr<LogicalOperator> Deserialize(LogicalDeserializationState &state, FieldReader &reader);
+	idx_t EstimateCardinality(ClientContext &context) override {
+		return 0;
+	}
 
 protected:
 	void ResolveTypes() override {

--- a/src/include/duckdb/planner/operator/logical_explain.hpp
+++ b/src/include/duckdb/planner/operator/logical_explain.hpp
@@ -31,6 +31,9 @@ public:
 public:
 	void Serialize(FieldWriter &writer) const override;
 	static unique_ptr<LogicalOperator> Deserialize(LogicalDeserializationState &state, FieldReader &reader);
+	idx_t EstimateCardinality(ClientContext &context) override {
+		return 3;
+	}
 
 protected:
 	void ResolveTypes() override {

--- a/src/include/duckdb/planner/operator/logical_expression_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_expression_get.hpp
@@ -34,6 +34,9 @@ public:
 	}
 	void Serialize(FieldWriter &writer) const override;
 	static unique_ptr<LogicalOperator> Deserialize(LogicalDeserializationState &state, FieldReader &reader);
+	idx_t EstimateCardinality(ClientContext &context) override {
+		return expressions.size();
+	}
 
 protected:
 	void ResolveTypes() override {

--- a/src/include/duckdb/planner/operator/logical_filter.hpp
+++ b/src/include/duckdb/planner/operator/logical_filter.hpp
@@ -24,7 +24,6 @@ public:
 	vector<ColumnBinding> GetColumnBindings() override;
 	void Serialize(FieldWriter &writer) const override;
 	static unique_ptr<LogicalOperator> Deserialize(LogicalDeserializationState &state, FieldReader &reader);
-	idx_t EstimateCardinality(ClientContext &context) override;
 
 	bool SplitPredicates() {
 		return SplitPredicates(expressions);

--- a/src/include/duckdb/planner/operator/logical_filter.hpp
+++ b/src/include/duckdb/planner/operator/logical_filter.hpp
@@ -24,6 +24,7 @@ public:
 	vector<ColumnBinding> GetColumnBindings() override;
 	void Serialize(FieldWriter &writer) const override;
 	static unique_ptr<LogicalOperator> Deserialize(LogicalDeserializationState &state, FieldReader &reader);
+	idx_t EstimateCardinality(ClientContext &context) override;
 
 	bool SplitPredicates() {
 		return SplitPredicates(expressions);

--- a/src/include/duckdb/planner/operator/logical_insert.hpp
+++ b/src/include/duckdb/planner/operator/logical_insert.hpp
@@ -52,5 +52,7 @@ protected:
 			types.emplace_back(LogicalType::BIGINT);
 		}
 	}
+
+	idx_t EstimateCardinality(ClientContext &context) override;
 };
 } // namespace duckdb

--- a/src/include/duckdb/planner/operator/logical_limit_percent.hpp
+++ b/src/include/duckdb/planner/operator/logical_limit_percent.hpp
@@ -36,6 +36,7 @@ public:
 
 	void Serialize(FieldWriter &writer) const override;
 	static unique_ptr<LogicalOperator> Deserialize(LogicalDeserializationState &state, FieldReader &reader);
+	idx_t EstimateCardinality(ClientContext &context) override;
 
 protected:
 	void ResolveTypes() override {

--- a/src/include/duckdb/planner/operator/logical_pragma.hpp
+++ b/src/include/duckdb/planner/operator/logical_pragma.hpp
@@ -29,6 +29,7 @@ public:
 public:
 	void Serialize(FieldWriter &writer) const override;
 	static unique_ptr<LogicalOperator> Deserialize(LogicalDeserializationState &state, FieldReader &reader);
+	idx_t EstimateCardinality(ClientContext &context) override;
 
 protected:
 	void ResolveTypes() override {

--- a/src/include/duckdb/planner/operator/logical_prepare.hpp
+++ b/src/include/duckdb/planner/operator/logical_prepare.hpp
@@ -32,6 +32,7 @@ public:
 public:
 	void Serialize(FieldWriter &writer) const override;
 	static unique_ptr<LogicalOperator> Deserialize(LogicalDeserializationState &state, FieldReader &reader);
+	idx_t EstimateCardinality(ClientContext &context) override;
 
 protected:
 	void ResolveTypes() override {

--- a/src/include/duckdb/planner/operator/logical_set.hpp
+++ b/src/include/duckdb/planner/operator/logical_set.hpp
@@ -28,6 +28,7 @@ public:
 public:
 	void Serialize(FieldWriter &writer) const override;
 	static unique_ptr<LogicalOperator> Deserialize(LogicalDeserializationState &state, FieldReader &reader);
+	idx_t EstimateCardinality(ClientContext &context) override;
 
 protected:
 	void ResolveTypes() override {

--- a/src/include/duckdb/planner/operator/logical_simple.hpp
+++ b/src/include/duckdb/planner/operator/logical_simple.hpp
@@ -25,6 +25,7 @@ public:
 public:
 	void Serialize(FieldWriter &writer) const override;
 	static unique_ptr<LogicalOperator> Deserialize(LogicalDeserializationState &state, FieldReader &reader);
+	idx_t EstimateCardinality(ClientContext &context) override;
 
 protected:
 	void ResolveTypes() override {

--- a/src/include/duckdb/planner/operator/logical_top_n.hpp
+++ b/src/include/duckdb/planner/operator/logical_top_n.hpp
@@ -32,6 +32,7 @@ public:
 	}
 	void Serialize(FieldWriter &writer) const override;
 	static unique_ptr<LogicalOperator> Deserialize(LogicalDeserializationState &state, FieldReader &reader);
+	idx_t EstimateCardinality(ClientContext &context) override;
 
 protected:
 	void ResolveTypes() override {

--- a/src/include/duckdb/planner/operator/logical_update.hpp
+++ b/src/include/duckdb/planner/operator/logical_update.hpp
@@ -32,6 +32,7 @@ public:
 public:
 	void Serialize(FieldWriter &writer) const override;
 	static unique_ptr<LogicalOperator> Deserialize(LogicalDeserializationState &state, FieldReader &reader);
+	idx_t EstimateCardinality(ClientContext &context) override;
 
 protected:
 	vector<ColumnBinding> GetColumnBindings() override {

--- a/src/planner/operator/logical_aggregate.cpp
+++ b/src/planner/operator/logical_aggregate.cpp
@@ -105,9 +105,7 @@ idx_t LogicalAggregate::EstimateCardinality(ClientContext &context) {
 		// ungrouped aggregate
 		return 1;
 	}
-	auto child_cardinality = LogicalOperator::EstimateCardinality(context);
-	// probably
-	return child_cardinality / 10;
+	return LogicalOperator::EstimateCardinality(context);
 }
 
 } // namespace duckdb

--- a/src/planner/operator/logical_aggregate.cpp
+++ b/src/planner/operator/logical_aggregate.cpp
@@ -100,4 +100,14 @@ unique_ptr<LogicalOperator> LogicalAggregate::Deserialize(LogicalDeserialization
 	return move(result);
 }
 
+idx_t LogicalAggregate::EstimateCardinality(ClientContext &context) {
+	if (groups.empty()) {
+		// ungrouped aggregate
+		return 1;
+	}
+	auto child_cardinality = LogicalOperator::EstimateCardinality(context);
+	// probably
+	return child_cardinality / 10;
+}
+
 } // namespace duckdb

--- a/src/planner/operator/logical_copy_to_file.cpp
+++ b/src/planner/operator/logical_copy_to_file.cpp
@@ -55,4 +55,8 @@ unique_ptr<LogicalOperator> LogicalCopyToFile::Deserialize(LogicalDeserializatio
 	return move(result);
 }
 
+idx_t LogicalCopyToFile::EstimateCardinality(ClientContext &context) {
+	return 1;
+}
+
 } // namespace duckdb

--- a/src/planner/operator/logical_create.cpp
+++ b/src/planner/operator/logical_create.cpp
@@ -17,4 +17,8 @@ unique_ptr<LogicalOperator> LogicalCreate::Deserialize(LogicalDeserializationSta
 	return make_unique<LogicalCreate>(state.type, move(info), schema_catalog_entry);
 }
 
+idx_t LogicalCreate::EstimateCardinality(ClientContext &context) {
+	return 1;
+}
+
 } // namespace duckdb

--- a/src/planner/operator/logical_create_table.cpp
+++ b/src/planner/operator/logical_create_table.cpp
@@ -12,4 +12,8 @@ unique_ptr<LogicalOperator> LogicalCreateTable::Deserialize(LogicalDeserializati
 	return make_unique<LogicalCreateTable>(schema, move(info));
 }
 
+idx_t LogicalCreateTable::EstimateCardinality(ClientContext &context) {
+	return 1;
+}
+
 } // namespace duckdb

--- a/src/planner/operator/logical_delete.cpp
+++ b/src/planner/operator/logical_delete.cpp
@@ -23,4 +23,8 @@ unique_ptr<LogicalOperator> LogicalDelete::Deserialize(LogicalDeserializationSta
 	return move(result);
 }
 
+idx_t LogicalDelete::EstimateCardinality(ClientContext &context) {
+	return return_chunk ? LogicalOperator::EstimateCardinality(context) : 1;
+}
+
 } // namespace duckdb

--- a/src/planner/operator/logical_filter.cpp
+++ b/src/planner/operator/logical_filter.cpp
@@ -57,4 +57,10 @@ unique_ptr<LogicalOperator> LogicalFilter::Deserialize(LogicalDeserializationSta
 	return move(result);
 }
 
+idx_t LogicalFilter::EstimateCardinality(ClientContext &context) {
+	auto child_cardinality = LogicalOperator::EstimateCardinality(context);
+	// probably
+	return child_cardinality / 5;
+}
+
 } // namespace duckdb

--- a/src/planner/operator/logical_filter.cpp
+++ b/src/planner/operator/logical_filter.cpp
@@ -57,10 +57,4 @@ unique_ptr<LogicalOperator> LogicalFilter::Deserialize(LogicalDeserializationSta
 	return move(result);
 }
 
-idx_t LogicalFilter::EstimateCardinality(ClientContext &context) {
-	auto child_cardinality = LogicalOperator::EstimateCardinality(context);
-	// probably
-	return child_cardinality / 5;
-}
-
 } // namespace duckdb

--- a/src/planner/operator/logical_insert.cpp
+++ b/src/planner/operator/logical_insert.cpp
@@ -54,4 +54,8 @@ unique_ptr<LogicalOperator> LogicalInsert::Deserialize(LogicalDeserializationSta
 	return move(result);
 }
 
+idx_t LogicalInsert::EstimateCardinality(ClientContext &context) {
+	return return_chunk ? LogicalOperator::EstimateCardinality(context) : 1;
+}
+
 } // namespace duckdb

--- a/src/planner/operator/logical_limit.cpp
+++ b/src/planner/operator/logical_limit.cpp
@@ -39,4 +39,5 @@ unique_ptr<LogicalOperator> LogicalLimit::Deserialize(LogicalDeserializationStat
 	auto offset = reader.ReadOptional<Expression>(nullptr, state.gstate);
 	return make_unique<LogicalLimit>(limit_val, offset_val, move(limit), move(offset));
 }
+
 } // namespace duckdb

--- a/src/planner/operator/logical_limit_percent.cpp
+++ b/src/planner/operator/logical_limit_percent.cpp
@@ -17,4 +17,13 @@ unique_ptr<LogicalOperator> LogicalLimitPercent::Deserialize(LogicalDeserializat
 	auto offset = reader.ReadOptional<Expression>(nullptr, state.gstate);
 	return make_unique<LogicalLimitPercent>(limit_percent, offset_val, move(limit), move(offset));
 }
+
+idx_t LogicalLimitPercent::EstimateCardinality(ClientContext &context) {
+	auto child_cardinality = LogicalOperator::EstimateCardinality(context);
+	if (limit_percent < 0 || limit_percent > 100) {
+		return child_cardinality;
+	}
+	return idx_t(child_cardinality * (limit_percent / 100.0));
+}
+
 } // namespace duckdb

--- a/src/planner/operator/logical_pragma.cpp
+++ b/src/planner/operator/logical_pragma.cpp
@@ -10,4 +10,8 @@ unique_ptr<LogicalOperator> LogicalPragma::Deserialize(LogicalDeserializationSta
 	throw NotImplementedException(LogicalOperatorToString(state.type));
 }
 
+idx_t LogicalPragma::EstimateCardinality(ClientContext &context) {
+	return 1;
+}
+
 } // namespace duckdb

--- a/src/planner/operator/logical_prepare.cpp
+++ b/src/planner/operator/logical_prepare.cpp
@@ -10,4 +10,8 @@ unique_ptr<LogicalOperator> LogicalPrepare::Deserialize(LogicalDeserializationSt
 	throw NotImplementedException(LogicalOperatorToString(state.type));
 }
 
+idx_t LogicalPrepare::EstimateCardinality(ClientContext &context) {
+	return 1;
+}
+
 } // namespace duckdb

--- a/src/planner/operator/logical_set.cpp
+++ b/src/planner/operator/logical_set.cpp
@@ -16,4 +16,8 @@ unique_ptr<LogicalOperator> LogicalSet::Deserialize(LogicalDeserializationState 
 	return make_unique<LogicalSet>(name, value, scope);
 }
 
+idx_t LogicalSet::EstimateCardinality(ClientContext &context) {
+	return 1;
+}
+
 } // namespace duckdb

--- a/src/planner/operator/logical_simple.cpp
+++ b/src/planner/operator/logical_simple.cpp
@@ -10,4 +10,8 @@ unique_ptr<LogicalOperator> LogicalSimple::Deserialize(LogicalDeserializationSta
 	throw NotImplementedException(LogicalOperatorToString(state.type));
 }
 
+idx_t LogicalSimple::EstimateCardinality(ClientContext &context) {
+	return 1;
+}
+
 } // namespace duckdb

--- a/src/planner/operator/logical_top_n.cpp
+++ b/src/planner/operator/logical_top_n.cpp
@@ -15,4 +15,13 @@ unique_ptr<LogicalOperator> LogicalTopN::Deserialize(LogicalDeserializationState
 	auto limit = reader.ReadRequired<idx_t>();
 	return make_unique<LogicalTopN>(move(orders), limit, offset);
 }
+
+idx_t LogicalTopN::EstimateCardinality(ClientContext &context) {
+	auto child_cardinality = LogicalOperator::EstimateCardinality(context);
+	if (child_cardinality < limit) {
+		return limit;
+	}
+	return child_cardinality;
+}
+
 } // namespace duckdb

--- a/src/planner/operator/logical_top_n.cpp
+++ b/src/planner/operator/logical_top_n.cpp
@@ -18,7 +18,7 @@ unique_ptr<LogicalOperator> LogicalTopN::Deserialize(LogicalDeserializationState
 
 idx_t LogicalTopN::EstimateCardinality(ClientContext &context) {
 	auto child_cardinality = LogicalOperator::EstimateCardinality(context);
-	if (child_cardinality < limit) {
+	if (limit >= 0 && child_cardinality < idx_t(limit)) {
 		return limit;
 	}
 	return child_cardinality;

--- a/src/planner/operator/logical_update.cpp
+++ b/src/planner/operator/logical_update.cpp
@@ -34,4 +34,8 @@ unique_ptr<LogicalOperator> LogicalUpdate::Deserialize(LogicalDeserializationSta
 	return move(result);
 }
 
+idx_t LogicalUpdate::EstimateCardinality(ClientContext &context) {
+	return return_chunk ? LogicalOperator::EstimateCardinality(context) : 1;
+}
+
 } // namespace duckdb

--- a/test/sql/returning/returning_update.test
+++ b/test/sql/returning/returning_update.test
@@ -168,19 +168,19 @@ statement ok
 INSERT INTO table5 VALUES (1, 0, 0), (2, 0, 0), (3, 0, 1), (4, 0, 1), (5, 0, 2), (6, 0, 2);
 
 # another join with GROUP by
-query III
+query III rowsort
 UPDATE table4
 SET b4 = temp_table.sum_a
 FROM (SELECT sum(a5) as sum_a, c5 FROM table5 GROUP BY c5 ORDER BY sum_a) as temp_table
 WHERE table4.c4 = temp_table.c5
 RETURNING *;
 ----
-3	3	0
-2	7	1
 1	11	2
+2	7	1
+3	3	0
 
 # update using a window function
-query III
+query III rowsort
 UPDATE table4
 SET b4 = temp_table.row_num
 FROM (SELECT row_number() OVER (ORDER BY a4) as row_num, c4 from table4) as temp_table


### PR DESCRIPTION
* Add CSV file cardinality estimation & improve cardinality estimation of many operators. This is relevant to the progress bar as the progress bar does weighting by cardinality to determine the progress of queries with various pipelines.
* In the box renderer, only render the "X rows" for data sets with more >= 10 rows, as it looks out-of-place for otherwise small boxes.

