### PR TITLE
node / TypesScript bindings: add missing accessMode argument to Database constructor.

### DIFF
--- a/tools/nodejs/lib/duckdb.d.ts
+++ b/tools/nodejs/lib/duckdb.d.ts
@@ -49,7 +49,7 @@ export class QueryResult {
 }
 
 export class Database {
-  constructor(path: string, callback?: Callback<any>);
+  constructor(path: string, accessMode?: number, callback?: Callback<any>);
 
   close(callback: Callback<void>): void;
 

--- a/tools/nodejs/test/typescript_decls.test.ts
+++ b/tools/nodejs/test/typescript_decls.test.ts
@@ -5,7 +5,7 @@ import fs from "fs";
 describe("TypeScript declarataions", function () {
   var db: duckdb.Database;
   before(function (done) {
-    db = new duckdb.Database(":memory:", done);
+    db = new duckdb.Database(":memory:", duckdb.OPEN_READWRITE, done);
   });
 
   it("typescript: Database constructor no callback", (done) => {
@@ -13,17 +13,37 @@ describe("TypeScript declarataions", function () {
     done();
   });
 
+  it("Database.create -- read only flag", (done) => {
+    const roDb = new duckdb.Database(
+      ":memory:",
+      duckdb.OPEN_READONLY,
+      (err: duckdb.DuckDbError | null, res: any) => {
+        assert.equal(err?.code, "DUCKDB_NODEJS_ERROR");
+        assert.equal(err?.errno, -1);
+        assert.match(
+          err?.message ?? "",
+          /Cannot launch in-memory database in read-only mode/
+        );
+        done();
+      }
+    );
+  });
+
   it("typescript: Database constructor path error", (done) => {
-    const tdb0 = new duckdb.Database("./bogusPath.db", (err, res) => {
-      // Issue: I'm a little surprised that specifying an invalid file path
-      // doesn't seem to immediately signal an error here, but it doesn't.
-      tdb0.all(
-        "PRAGMA show_tables",
-        (err: duckdb.DuckDbError | null, res: any) => {
-          done();
-        }
-      );
-    });
+    const tdb0 = new duckdb.Database(
+      "./bogusPath.db",
+      duckdb.OPEN_READWRITE,
+      (err, res) => {
+        // Issue: I'm a little surprised that specifying an invalid file path
+        // doesn't seem to immediately signal an error here, but it doesn't.
+        tdb0.all(
+          "PRAGMA show_tables",
+          (err: duckdb.DuckDbError | null, res: any) => {
+            done();
+          }
+        );
+      }
+    );
   });
 
   it("typescript: query with error", (done) => {
@@ -136,7 +156,7 @@ describe("TypeScript declarataions", function () {
 describe("typescript: simple prepared statement", function () {
   var db: duckdb.Database;
   before(function (done) {
-    db = new duckdb.Database(":memory:", done);
+    db = new duckdb.Database(":memory:", duckdb.OPEN_READWRITE, done);
   });
 
   it("should prepare, run and finalize the statement", function (done) {
@@ -151,7 +171,7 @@ describe("typescript: simple prepared statement", function () {
 describe("typescript: prepared statements", function () {
   var db: duckdb.Database;
   before(function (done) {
-    db = new duckdb.Database(":memory:", done);
+    db = new duckdb.Database(":memory:", duckdb.OPEN_READWRITE, done);
   });
 
   var inserted = 0;
@@ -193,7 +213,7 @@ describe("typescript: stream and QueryResult", function () {
   let db: duckdb.Database;
   let conn: duckdb.Connection;
   before((done) => {
-    db = new duckdb.Database(":memory:", () => {
+    db = new duckdb.Database(":memory:", duckdb.OPEN_READWRITE, () => {
       conn = new duckdb.Connection(db, done);
     });
   });

--- a/tools/nodejs/test/typescript_decls.test.ts
+++ b/tools/nodejs/test/typescript_decls.test.ts
@@ -20,9 +20,11 @@ describe("TypeScript declarataions", function () {
       (err: duckdb.DuckDbError | null, res: any) => {
         assert.equal(err?.code, "DUCKDB_NODEJS_ERROR");
         assert.equal(err?.errno, -1);
-        assert.match(
-          err?.message ?? "",
-          /Cannot launch in-memory database in read-only mode/
+        const errMessage: string = err?.message ?? "";
+        assert(
+          errMessage.includes(
+            "Cannot launch in-memory database in read-only mode"
+          )
         );
         done();
       }


### PR DESCRIPTION
In the original TypeScript bindings I submitted in an earlier PR, I omitted the optional `accessMode` argument from the `Database` constructor. This prevents being able to open Database objects with a different access mode than the default read/write mode.  This PR adds back this argument to the TS bindings, and includes updated tests.

These base TS bindings unfortunately become a bit less ergonomic, since the only way to omit the accessMode argument is if we also omit the result callback.  A more ergonomic interface, that provides TypeScript bindings and promise wrappers, is available in the [duckdb-async package](https://github.com/motherduckdb/duckdb-async).