### PR TITLE
Increase SQLite scanner version

### DIFF
--- a/.github/config/extensions.csv
+++ b/.github/config/extensions.csv
@@ -8,7 +8,7 @@ parquet,,,
 tpcds,,,
 tpch,,,
 visualizer,,,
-sqlite_scanner,https://github.com/duckdblabs/sqlite_scanner,a560eeb15990e6e0c9dd6dffd3d892d9726c0123,
+sqlite_scanner,https://github.com/duckdblabs/sqlite_scanner,948c839fcb18565215d2924523dfd535980160a9,
 postgres_scanner,https://github.com/duckdblabs/postgres_scanner,8c972b7766c2b309618bcc7e7e8249d44f4f010c,
 substrait,https://github.com/duckdblabs/substrait,ec78d24b4e2c42f024e0c2c2af88afde30fd1108,no-windows
 arrow,https://github.com/duckdblabs/arrow,a8d7641a46fcad1976f3568125f9c652e0dcc04e,no-windows


### PR DESCRIPTION
Includes several fixes for type detection (https://github.com/duckdblabs/sqlite_scanner/pull/17 and https://github.com/duckdblabs/sqlite_scanner/pull/18) and a new `sqlite_all_varchar` setting that loads all SQLite columns as a varchar type.