### PR TITLE
fix: use oldest supported numpy to build for a given python version

### DIFF
--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -279,7 +279,6 @@ setup(
         'duckdb_query_graph',
         'duckdb-stubs'
     ],
-    test_requires=['pytest-runner'],
     include_package_data=True,
     setup_requires=[
         "setuptools_scm",

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -239,12 +239,6 @@ else:
         library_dirs=library_dirs,
         language='c++')
 
-# Only include pytest-runner in setup_requires if we're invoking tests
-if {'pytest', 'test', 'ptr'}.intersection(sys.argv):
-    setup_requires = ['pytest-runner']
-else:
-    setup_requires = []
-
 setuptools_scm_conf = {"root": "../..", "relative_to": __file__}
 if os.getenv('SETUPTOOLS_SCM_NO_LOCAL', 'no') != 'no':
     setuptools_scm_conf['local_scheme'] = 'no-local-version'
@@ -280,16 +274,19 @@ setup(
     url="https://www.duckdb.org",
     long_description = 'See here for an introduction: https://duckdb.org/docs/api/python/overview',
     license='MIT',
-    install_requires=[ # these version is still available for Python 2, newer ones aren't
-         'numpy>=1.14'
-    ],
     data_files = data_files,
     packages=[
         'duckdb_query_graph',
         'duckdb-stubs'
     ],
+    test_requires=['pytest-runner'],
     include_package_data=True,
-    setup_requires=setup_requires + ["setuptools_scm<7.0.0", 'numpy>=1.14', 'pybind11>=2.6.0'],
+    setup_requires=[
+        "setuptools_scm",
+        "oldest-supported-numpy",  # compile against oldest supported numpy version, so we can support any version of numpy (numpy is always backward-compatible)
+        'pybind11>=2.6.0'
+    ],
+    requires=['numpy'],
     use_scm_version = setuptools_scm_conf,
     tests_require=['google-cloud-storage', 'mypy', 'pytest'],
     classifiers = [


### PR DESCRIPTION
This partially fixes https://github.com/duckdb/duckdb/issues/4986