### PR TITLE
[UB sanitizer] Prevent doing arithmetic on NaN in 'logical_limit_percent.cpp'

### DIFF
--- a/src/planner/operator/logical_limit_percent.cpp
+++ b/src/planner/operator/logical_limit_percent.cpp
@@ -20,7 +20,7 @@ unique_ptr<LogicalOperator> LogicalLimitPercent::Deserialize(LogicalDeserializat
 
 idx_t LogicalLimitPercent::EstimateCardinality(ClientContext &context) {
 	auto child_cardinality = LogicalOperator::EstimateCardinality(context);
-	if (limit_percent < 0 || limit_percent > 100) {
+	if ((limit_percent < 0 || limit_percent > 100) || isnan(limit_percent)) {
 		return child_cardinality;
 	}
 	return idx_t(child_cardinality * (limit_percent / 100.0));

--- a/src/planner/operator/logical_limit_percent.cpp
+++ b/src/planner/operator/logical_limit_percent.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/field_writer.hpp"
 #include "duckdb/planner/operator/logical_limit_percent.hpp"
+#include <cmath>
 
 namespace duckdb {
 
@@ -20,7 +21,7 @@ unique_ptr<LogicalOperator> LogicalLimitPercent::Deserialize(LogicalDeserializat
 
 idx_t LogicalLimitPercent::EstimateCardinality(ClientContext &context) {
 	auto child_cardinality = LogicalOperator::EstimateCardinality(context);
-	if ((limit_percent < 0 || limit_percent > 100) || isnan(limit_percent)) {
+	if ((limit_percent < 0 || limit_percent > 100) || std::isnan(limit_percent)) {
 		return child_cardinality;
 	}
 	return idx_t(child_cardinality * (limit_percent / 100.0));


### PR DESCRIPTION
This PR fixes a UB sanitizer issue triggering - which is causing the CI on master to fail

The issue:
> /Users/runner/work/duckdb/duckdb/src/planner/operator/logical_limit_percent.cpp:26:15: runtime error: nan is outside the range of representable values of type 'unsigned long long'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/runner/work/duckdb/duckdb/src/planner/operator/logical_limit_percent.cpp:26:15 in 