### PR TITLE
disable node client arrow ipc replacement scans

### DIFF
--- a/tools/nodejs/src/connection.cpp
+++ b/tools/nodejs/src/connection.cpp
@@ -110,14 +110,10 @@ Connection::Connection(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Connec
 	database_ref = Napi::ObjectWrap<Database>::Unwrap(info[0].As<Napi::Object>());
 	database_ref->Ref();
 
-	if (!database_ref->database) {
-		Napi::Error::New(env, "Connection created on database that was not yet initialized")
-		    .ThrowAsJavaScriptException();
-		return;
-	}
 	// Register replacement scan
-	database_ref->database->instance->config.replacement_scans.emplace_back(
-	    ScanReplacement, duckdb::make_unique<NodeReplacementScanData>(this));
+	// TODO: disabled currently, either fix or remove.
+//	database_ref->database->instance->config.replacement_scans.emplace_back(
+//	    ScanReplacement, duckdb::make_unique<NodeReplacementScanData>(this));
 
 	Napi::Function callback;
 	if (info.Length() > 0 && info[1].IsFunction()) {
@@ -346,6 +342,10 @@ Napi::Value Connection::RegisterUdf(const Napi::CallbackInfo &info) {
 // Register Arrow IPC buffers for scanning from DuckDB
 Napi::Value Connection::RegisterBuffer(const Napi::CallbackInfo &info) {
 	auto env = info.Env();
+
+	Napi::TypeError::New(env, "Register buffer currently not implemented").ThrowAsJavaScriptException();
+	return env.Null();
+
 	if (info.Length() < 2 || !info[0].IsString() || !info[1].IsObject()) {
 		Napi::TypeError::New(env, "Incorrect params").ThrowAsJavaScriptException();
 		return env.Null();
@@ -390,6 +390,10 @@ Napi::Value Connection::RegisterBuffer(const Napi::CallbackInfo &info) {
 
 Napi::Value Connection::UnRegisterBuffer(const Napi::CallbackInfo &info) {
 	auto env = info.Env();
+
+	Napi::TypeError::New(env, "Register buffer currently not implemented").ThrowAsJavaScriptException();
+	return env.Null();
+
 	if (info.Length() != 1 || !info[0].IsString()) {
 		Napi::TypeError::New(env, "Holding it wrong").ThrowAsJavaScriptException();
 		return env.Null();

--- a/tools/nodejs/src/connection.cpp
+++ b/tools/nodejs/src/connection.cpp
@@ -112,8 +112,8 @@ Connection::Connection(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Connec
 
 	// Register replacement scan
 	// TODO: disabled currently, either fix or remove.
-//	database_ref->database->instance->config.replacement_scans.emplace_back(
-//	    ScanReplacement, duckdb::make_unique<NodeReplacementScanData>(this));
+	//	database_ref->database->instance->config.replacement_scans.emplace_back(
+	//	    ScanReplacement, duckdb::make_unique<NodeReplacementScanData>(this));
 
 	Napi::Function callback;
 	if (info.Length() > 0 && info[1].IsFunction()) {

--- a/tools/nodejs/test/arrow.test.js
+++ b/tools/nodejs/test/arrow.test.js
@@ -1,0 +1,61 @@
+var sqlite3 = require('..');
+var assert = require('assert');
+var fs = require('fs');
+
+describe('exec', function() {
+    var db;
+    before(function(done) {
+        db = new sqlite3.Database(':memory:', done);
+    });
+
+    // Note: arrow IPC api requires the arrow extension to be loaded. The tests for this functionality reside in:
+    //       https://github.com/duckdblabs/arrow
+    describe(`Arrow IPC API fails neatly when extension not loaded`, () => {
+        let db;
+        let conn;
+        before((done) => {
+            db = new sqlite3.Database(':memory:', {"allow_unsigned_extensions": "true"}, () => {
+                done();
+            });
+        });
+
+        it(`Basic examples`, async () => {
+            const range_size = 130000;
+            const query = `SELECT * FROM range(0,${range_size}) tbl(i)`;
+
+            db.arrowIPCStream(query).then(
+                () => Promise.reject(new Error('Expected method to reject.')),
+                err => {
+                    assert(err.message.includes("Catalog Error: Function with name to_arrow_ipc is not on the catalog, but it exists in the arrow extension. To Install and Load the extension, run: INSTALL arrow; LOAD arrow;"))
+                }
+            );
+
+            db.arrowIPCAll(`SELECT * FROM ipc_table`, function (err, result) {
+                if (err) {
+                    assert(err.message.includes("Catalog Error: Function with name to_arrow_ipc is not on the catalog, but it exists in the arrow extension. To Install and Load the extension, run: INSTALL arrow; LOAD arrow;"))
+                } else {
+                    assert.fail("Expected error");
+                }
+            });
+
+            assert.throws(() => db.register_buffer("ipc_table", [1,'a',1], true), TypeError, "Incorrect parameters");
+        });
+
+        it('Register buffer should be disabled currently', function(done) {
+            try {
+                db.register_buffer();
+                assert(0);
+            } catch (error) {
+                assert(error.message.includes('Register buffer currently not implemented'))
+            }
+
+            try {
+                db.unregister_buffer();
+                assert(0);
+            } catch (error) {
+                assert(error.message.includes('Register buffer currently not implemented'))
+            }
+            done()
+        });
+    });
+});


### PR DESCRIPTION
Due to breaking issue with the arrow ipc replacement scans, we disable them for this release.

Added a test to confirm arrow api fails nicely when extension not loaded.

@hannes @Mytherin 