### PR TITLE
Shared ColumnDataAllocator: hold lock for just a bit longer

### DIFF
--- a/src/common/types/column_data_allocator.cpp
+++ b/src/common/types/column_data_allocator.cpp
@@ -30,15 +30,16 @@ ColumnDataAllocator::ColumnDataAllocator(ClientContext &context, ColumnDataAlloc
 
 BufferHandle ColumnDataAllocator::Pin(uint32_t block_id) {
 	D_ASSERT(type == ColumnDataAllocatorType::BUFFER_MANAGER_ALLOCATOR);
-	shared_ptr<BlockHandle> *block_handle;
 	if (shared) {
-		// need to grab handle from the vector within a lock else threadsan will complain
 		lock_guard<mutex> guard(lock);
-		block_handle = &blocks[block_id].handle;
+		return PinInternal(block_id);
 	} else {
-		block_handle = &blocks[block_id].handle;
+		return PinInternal(block_id);
 	}
-	return alloc.buffer_manager->Pin(*block_handle);
+}
+
+BufferHandle ColumnDataAllocator::PinInternal(uint32_t block_id) {
+	return alloc.buffer_manager->Pin(blocks[block_id].handle);
 }
 
 void ColumnDataAllocator::AllocateBlock() {

--- a/src/include/duckdb/common/types/column_data_allocator.hpp
+++ b/src/include/duckdb/common/types/column_data_allocator.hpp
@@ -58,6 +58,7 @@ private:
 	void AllocateEmptyBlock(idx_t size);
 	void AllocateBlock();
 	BufferHandle Pin(uint32_t block_id);
+	BufferHandle PinInternal(uint32_t block_id);
 
 	bool HasBlocks() const {
 		return !blocks.empty();


### PR DESCRIPTION
Was causing the occasional segfault when doing out-of-core hash joins