### PR TITLE
Add starts_with function and operator

### DIFF
--- a/src/function/scalar/string/CMakeLists.txt
+++ b/src/function/scalar/string/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library_unity(
   trim.cpp
   left_right.cpp
   contains.cpp
+  starts_with.cpp
   string_split.cpp
   mismatches.cpp
   levenshtein.cpp

--- a/src/function/scalar/string/starts_with.cpp
+++ b/src/function/scalar/string/starts_with.cpp
@@ -6,84 +6,14 @@
 
 namespace duckdb {
 
-template <class UNSIGNED, int NEEDLE_SIZE>
-static bool StartsWithUnaligned(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle) {
-	if (NEEDLE_SIZE > haystack_size) {
-		// needle is bigger than haystack: haystack cannot start with needle
-		return false;
-	}
-	// starts_with for a small unaligned needle (3/5/6/7 bytes)
-	// we perform unsigned integer comparisons to check for equality of the entire needle in a single comparison
-	// this implementation is inspired by the memmem implementation of freebsd
-
-	// first we set up the needle and the first NEEDLE_SIZE characters of the haystack as UNSIGNED integers
-	UNSIGNED needle_entry = 0;
-	UNSIGNED haystack_entry = 0;
-	const UNSIGNED start = (sizeof(UNSIGNED) * 8) - 8;
-	for (int i = 0; i < NEEDLE_SIZE; i++) {
-		needle_entry |= UNSIGNED(needle[i]) << UNSIGNED(start - i * 8);
-		haystack_entry |= UNSIGNED(haystack[i]) << UNSIGNED(start - i * 8);
-	}
-	return haystack_entry == needle_entry;
-}
-
-template <class UNSIGNED>
-static bool StartsWithAligned(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle) {
-	if (sizeof(UNSIGNED) > haystack_size) {
-		// needle is bigger than haystack: haystack cannot contain needle
-		return false;
-	}
-	// starts_with for a small needle aligned with unsigned integer (1/2/4/8)
-	// similar to StartsWithUnaligned, but simpler because we only need to do a reinterpret cast
-	auto needle_entry = Load<UNSIGNED>(needle);
-	auto haystack_entry = Load<UNSIGNED>(haystack);
-	return needle_entry == haystack_entry;
-}
-
-static bool StartsWithGeneric(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle,
-                              idx_t needle_size) {
-	if (needle_size > haystack_size) {
-		// needle is bigger than haystack: haystack cannot contain needle
-		return false;
-	}
-	// this implementation is inspired by Raphael Javaux's faststrstr (https://github.com/RaphaelJ/fast_strstr)
-	// generic contains; note that we can't use strstr because we don't have null-terminated strings anymore
-	// we keep track of a shifting window sum of all characters with window size equal to needle_size
-	// this shifting sum is used to avoid calling into memcmp;
-	// we only need to call into memcmp when the window sum is equal to the needle sum
-	// when that happens, the characters are potentially the same and we call into memcmp to check if they are
-	uint32_t sums_diff = 0;
-	for (idx_t i = 0; i < needle_size; i++) {
-		sums_diff += haystack[i];
-		sums_diff -= needle[i];
-	}
-	return sums_diff == 0 && haystack[0] == needle[0] && memcmp(haystack, needle, needle_size) == 0;
-}
-
 static bool StartsWith(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle,
                        idx_t needle_size) {
 	D_ASSERT(needle_size > 0);
-	// switch algorithm depending on needle size
-	switch (needle_size) {
-	case 1:
-		return StartsWithAligned<uint8_t>(haystack, haystack_size, needle);
-	case 2:
-		return StartsWithAligned<uint16_t>(haystack, haystack_size, needle);
-	case 3:
-		return StartsWithUnaligned<uint32_t, 3>(haystack, haystack_size, needle);
-	case 4:
-		return StartsWithAligned<uint32_t>(haystack, haystack_size, needle);
-	case 5:
-		return StartsWithUnaligned<uint64_t, 5>(haystack, haystack_size, needle);
-	case 6:
-		return StartsWithUnaligned<uint64_t, 6>(haystack, haystack_size, needle);
-	case 7:
-		return StartsWithUnaligned<uint64_t, 7>(haystack, haystack_size, needle);
-	case 8:
-		return StartsWithAligned<uint64_t>(haystack, haystack_size, needle);
-	default:
-		return StartsWithGeneric(haystack, haystack_size, needle, needle_size);
+	if (needle_size > haystack_size) {
+		// needle is bigger than haystack: haystack cannot start with needle
+		return false;
 	}
+	return memcmp(haystack, needle, needle_size) == 0;
 }
 
 static bool StartsWith(const string_t &haystack_s, const string_t &needle_s) {

--- a/src/function/scalar/string/starts_with.cpp
+++ b/src/function/scalar/string/starts_with.cpp
@@ -1,0 +1,117 @@
+#include "duckdb/function/scalar/string_functions.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+
+namespace duckdb {
+
+template <class UNSIGNED, int NEEDLE_SIZE>
+static bool StartsWithUnaligned(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle) {
+	if (NEEDLE_SIZE > haystack_size) {
+		// needle is bigger than haystack: haystack cannot start with needle
+		return false;
+	}
+	// starts_with for a small unaligned needle (3/5/6/7 bytes)
+	// we perform unsigned integer comparisons to check for equality of the entire needle in a single comparison
+	// this implementation is inspired by the memmem implementation of freebsd
+
+	// first we set up the needle and the first NEEDLE_SIZE characters of the haystack as UNSIGNED integers
+	UNSIGNED needle_entry = 0;
+	UNSIGNED haystack_entry = 0;
+	const UNSIGNED start = (sizeof(UNSIGNED) * 8) - 8;
+	for (int i = 0; i < NEEDLE_SIZE; i++) {
+		needle_entry |= UNSIGNED(needle[i]) << UNSIGNED(start - i * 8);
+		haystack_entry |= UNSIGNED(haystack[i]) << UNSIGNED(start - i * 8);
+	}
+	return haystack_entry == needle_entry;
+}
+
+template <class UNSIGNED>
+static bool StartsWithAligned(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle) {
+	if (sizeof(UNSIGNED) > haystack_size) {
+		// needle is bigger than haystack: haystack cannot contain needle
+		return false;
+	}
+	// starts_with for a small needle aligned with unsigned integer (1/2/4/8)
+	// similar to StartsWithUnaligned, but simpler because we only need to do a reinterpret cast
+	auto needle_entry = Load<UNSIGNED>(needle);
+	auto haystack_entry = Load<UNSIGNED>(haystack);
+	return needle_entry == haystack_entry;
+}
+
+static bool StartsWithGeneric(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle,
+                              idx_t needle_size) {
+	if (needle_size > haystack_size) {
+		// needle is bigger than haystack: haystack cannot contain needle
+		return false;
+	}
+	// this implementation is inspired by Raphael Javaux's faststrstr (https://github.com/RaphaelJ/fast_strstr)
+	// generic contains; note that we can't use strstr because we don't have null-terminated strings anymore
+	// we keep track of a shifting window sum of all characters with window size equal to needle_size
+	// this shifting sum is used to avoid calling into memcmp;
+	// we only need to call into memcmp when the window sum is equal to the needle sum
+	// when that happens, the characters are potentially the same and we call into memcmp to check if they are
+	uint32_t sums_diff = 0;
+	for (idx_t i = 0; i < needle_size; i++) {
+		sums_diff += haystack[i];
+		sums_diff -= needle[i];
+	}
+	return sums_diff == 0 && haystack[0] == needle[0] && memcmp(haystack, needle, needle_size) == 0;
+}
+
+static bool StartsWith(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle,
+                       idx_t needle_size) {
+	D_ASSERT(needle_size > 0);
+	// switch algorithm depending on needle size
+	switch (needle_size) {
+	case 1:
+		return StartsWithAligned<uint8_t>(haystack, haystack_size, needle);
+	case 2:
+		return StartsWithAligned<uint16_t>(haystack, haystack_size, needle);
+	case 3:
+		return StartsWithUnaligned<uint32_t, 3>(haystack, haystack_size, needle);
+	case 4:
+		return StartsWithAligned<uint32_t>(haystack, haystack_size, needle);
+	case 5:
+		return StartsWithUnaligned<uint64_t, 5>(haystack, haystack_size, needle);
+	case 6:
+		return StartsWithUnaligned<uint64_t, 6>(haystack, haystack_size, needle);
+	case 7:
+		return StartsWithUnaligned<uint64_t, 7>(haystack, haystack_size, needle);
+	case 8:
+		return StartsWithAligned<uint64_t>(haystack, haystack_size, needle);
+	default:
+		return StartsWithGeneric(haystack, haystack_size, needle, needle_size);
+	}
+}
+
+static bool StartsWith(const string_t &haystack_s, const string_t &needle_s) {
+	auto haystack = (const unsigned char *)haystack_s.GetDataUnsafe();
+	auto haystack_size = haystack_s.GetSize();
+	auto needle = (const unsigned char *)needle_s.GetDataUnsafe();
+	auto needle_size = needle_s.GetSize();
+	if (needle_size == 0) {
+		// empty needle: always true
+		return true;
+	}
+	return StartsWith(haystack, haystack_size, needle, needle_size);
+}
+
+struct StartsWithOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA left, TB right) {
+		return StartsWith(left, right);
+	}
+};
+
+void StartsWithFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunction starts_with =
+	    ScalarFunction("starts_with", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	                   ScalarFunction::BinaryFunction<string_t, string_t, bool, StartsWithOperator>);
+	set.AddFunction(starts_with);
+	starts_with.name = "^@";
+	set.AddFunction(starts_with);
+}
+
+} // namespace duckdb

--- a/src/function/scalar/string_functions.cpp
+++ b/src/function/scalar/string_functions.cpp
@@ -10,6 +10,7 @@ void BuiltinFunctions::RegisterStringFunctions() {
 	Register<UpperFun>();
 	Register<StripAccentsFun>();
 	Register<ConcatFun>();
+	Register<StartsWithFun>();
 	Register<ContainsFun>();
 	Register<LengthFun>();
 	Register<LikeFun>();

--- a/src/include/duckdb/function/scalar/string_functions.hpp
+++ b/src/include/duckdb/function/scalar/string_functions.hpp
@@ -167,6 +167,10 @@ struct ContainsFun {
 	                  idx_t needle_size);
 };
 
+struct StartsWithFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct UnicodeFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/test/sql/function/string/test_starts_with_function.test
+++ b/test/sql/function/string/test_starts_with_function.test
@@ -1,0 +1,109 @@
+# name: test/sql/function/string/test_starts_with_function.test
+# description: starts_with function test
+# group: [string]
+
+statement ok
+PRAGMA enable_verification
+
+# starts_with of various lengths
+query IIIIIIIIII
+SELECT STARTS_WITH('hello world', 'h'),
+       STARTS_WITH('hello world', 'he'),
+       STARTS_WITH('hello world', 'hel'),
+       STARTS_WITH('hello world', 'hell'),
+       STARTS_WITH('hello world', 'hello'),
+       STARTS_WITH('hello world', 'hello '),
+       STARTS_WITH('hello world', 'hello w'),
+       STARTS_WITH('hello world', 'hello wo'),
+       STARTS_WITH('hello world', 'hello wor'),
+       STARTS_WITH('hello world', 'hello worl')
+----
+1	1	1	1	1	1	1	1	1	1
+
+query IIIIIIIIII
+SELECT STARTS_WITH('hello world', 'a'),
+       STARTS_WITH('hello world', 'ha'),
+       STARTS_WITH('hello world', 'hea'),
+       STARTS_WITH('hello world', 'hela'),
+       STARTS_WITH('hello world', 'hella'),
+       STARTS_WITH('hello world', 'helloa'),
+       STARTS_WITH('hello world', 'hello a'),
+       STARTS_WITH('hello world', 'hello wa'),
+       STARTS_WITH('hello world', 'hello woa'),
+       STARTS_WITH('hello world', 'hello wora')
+----
+0	0	0	0	0	0	0	0	0	0
+
+# empty starts_with
+query III
+select starts_with('hello', ''), starts_with('', ''), starts_with(NULL, '')
+----
+1	1	NULL
+
+statement ok
+CREATE TABLE strings(s VARCHAR, off INTEGER, length INTEGER);
+
+statement ok
+INSERT INTO strings VALUES ('hello', 1, 2), ('world', 2, 3), ('h', 1, 1), (NULL, 2, 2)
+
+# Test first letter
+query T
+SELECT starts_with(s,'h') FROM strings
+----
+1
+0
+1
+NULL
+
+# Test multiple letters
+query T
+SELECT starts_with(s,'he') FROM strings
+----
+1
+0
+0
+NULL
+
+# Test no match
+query T
+SELECT starts_with(s,'he-man') FROM strings
+----
+0
+0
+0
+NULL
+
+# Test NULL constant in different places
+query T
+SELECT starts_with(NULL,'h') FROM strings
+----
+NULL
+NULL
+NULL
+NULL
+
+query T
+SELECT starts_with(s,NULL) FROM strings
+----
+NULL
+NULL
+NULL
+NULL
+
+query T
+SELECT starts_with(NULL,NULL) FROM strings
+----
+NULL
+NULL
+NULL
+NULL
+
+# Test empty pattern
+query T
+SELECT starts_with(s,'') FROM strings
+----
+1
+1
+1
+NULL
+

--- a/test/sql/function/string/test_starts_with_function_utf8.test
+++ b/test/sql/function/string/test_starts_with_function_utf8.test
@@ -1,0 +1,76 @@
+# name: test/sql/function/string/test_starts_with_function_utf8.test
+# description: starts_with function test with UTF8
+# group: [string]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE strings(s VARCHAR);
+
+statement ok
+INSERT INTO strings VALUES ('átomo')
+
+statement ok
+INSERT INTO strings VALUES ('olá mundo')
+
+statement ok
+INSERT INTO strings VALUES ('你好世界')
+
+statement ok
+INSERT INTO strings VALUES ('two ñ three ₡ four 🦆 end')
+
+# Test one matching UTF8 letter
+query T
+SELECT starts_with(s,'á') FROM strings
+----
+1
+0
+0
+0
+
+# Test a sentence with an UTF-8
+query T
+SELECT starts_with(s,'olá mundo') FROM strings
+----
+0
+1
+0
+0
+
+# Test an entire UTF-8 word
+query T
+SELECT starts_with(s,'你好世界') FROM strings
+----
+0
+0
+1
+0
+
+# Test a substring of the haystack from the beginning
+query T
+SELECT starts_with(s,'two ñ thr') FROM strings
+----
+0
+0
+0
+1
+
+# Test a single UTF8 substring of the haystack in the middle
+query T
+SELECT starts_with(s,'ñ') FROM strings
+----
+0
+0
+0
+0
+
+# Test a multiple UTF8 substring of the haystack in the middle
+query T
+SELECT starts_with(s,'₡ four 🦆 e') FROM strings
+----
+0
+0
+0
+0
+

--- a/test/sql/function/string/test_starts_with_operator.test
+++ b/test/sql/function/string/test_starts_with_operator.test
@@ -1,0 +1,109 @@
+# name: test/sql/function/string/test_starts_with_operator.test
+# description: ^@ starts_with operator test
+# group: [string]
+
+statement ok
+PRAGMA enable_verification
+
+# starts_with of various lengths
+query IIIIIIIIII
+SELECT 'hello world' ^@ 'h',
+       'hello world' ^@ 'he',
+       'hello world' ^@ 'hel',
+       'hello world' ^@ 'hell',
+       'hello world' ^@ 'hello',
+       'hello world' ^@ 'hello ',
+       'hello world' ^@ 'hello w',
+       'hello world' ^@ 'hello wo',
+       'hello world' ^@ 'hello wor',
+       'hello world' ^@ 'hello worl'
+----
+1	1	1	1	1	1	1	1	1	1
+
+query IIIIIIIIII
+SELECT 'hello world' ^@ 'a',
+       'hello world' ^@ 'ha',
+       'hello world' ^@ 'hea',
+       'hello world' ^@ 'hela',
+       'hello world' ^@ 'hella',
+       'hello world' ^@ 'helloa',
+       'hello world' ^@ 'hello a',
+       'hello world' ^@ 'hello wa',
+       'hello world' ^@ 'hello woa',
+       'hello world' ^@ 'hello wora'
+----
+0	0	0	0	0	0	0	0	0	0
+
+# empty starts_with
+query III
+select 'hello' ^@ '', '' ^@ '', NULL ^@ ''
+----
+1	1	NULL
+
+statement ok
+CREATE TABLE strings(s VARCHAR, off INTEGER, length INTEGER);
+
+statement ok
+INSERT INTO strings VALUES ('hello', 1, 2), ('world', 2, 3), ('h', 1, 1), (NULL, 2, 2)
+
+# Test first letter
+query T
+SELECT s ^@ 'h' FROM strings
+----
+1
+0
+1
+NULL
+
+# Test multiple letters
+query T
+SELECT s ^@ 'he' FROM strings
+----
+1
+0
+0
+NULL
+
+# Test no match
+query T
+SELECT s ^@ 'he-man' FROM strings
+----
+0
+0
+0
+NULL
+
+# Test NULL constant in different places
+query T
+SELECT NULL ^@ 'h' FROM strings
+----
+NULL
+NULL
+NULL
+NULL
+
+query T
+SELECT s ^@ NULL FROM strings
+----
+NULL
+NULL
+NULL
+NULL
+
+query T
+SELECT NULL ^@ NULL FROM strings
+----
+NULL
+NULL
+NULL
+NULL
+
+# Test empty pattern
+query T
+SELECT s ^@ '' FROM strings
+----
+1
+1
+1
+NULL
+

--- a/test/sql/function/string/test_starts_with_operator_utf8.test
+++ b/test/sql/function/string/test_starts_with_operator_utf8.test
@@ -1,0 +1,76 @@
+# name: test/sql/function/string/test_starts_with_operator_utf8.test
+# description: ^@ starts_with operator test with UTF8
+# group: [string]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE strings(s VARCHAR);
+
+statement ok
+INSERT INTO strings VALUES ('átomo')
+
+statement ok
+INSERT INTO strings VALUES ('olá mundo')
+
+statement ok
+INSERT INTO strings VALUES ('你好世界')
+
+statement ok
+INSERT INTO strings VALUES ('two ñ three ₡ four 🦆 end')
+
+# Test one matching UTF8 letter
+query T
+SELECT s ^@ 'á' FROM strings
+----
+1
+0
+0
+0
+
+# Test a sentence with an UTF-8
+query T
+SELECT s ^@ 'olá mundo' FROM strings
+----
+0
+1
+0
+0
+
+# Test an entire UTF-8 word
+query T
+SELECT s ^@ '你好世界' FROM strings
+----
+0
+0
+1
+0
+
+# Test a substring of the haystack from the beginning
+query T
+SELECT s ^@ 'two ñ thr' FROM strings
+----
+0
+0
+0
+1
+
+# Test a single UTF8 substring of the haystack in the middle
+query T
+SELECT s ^@ 'ñ' FROM strings
+----
+0
+0
+0
+0
+
+# Test a multiple UTF8 substring of the haystack in the middle
+query T
+SELECT s ^@ '₡ four 🦆 e' FROM strings
+----
+0
+0
+0
+0
+


### PR DESCRIPTION
[#5311](https://github.com/duckdb/duckdb/issues/5311#issue-1446440132)
I removed iterations over the haystack's offsets from the existing `contains` function which performs integer comparison instead of using the slower `memcmp` function.
