### PR TITLE
Feature: Allow binary-formatted strings to be cast to integers

### DIFF
--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -822,6 +822,16 @@ struct IntegerCastOperation {
 	}
 
 	template <class T, bool NEGATIVE>
+	static bool HandleBinaryDigit(T &state, uint8_t digit) {
+		using result_t = typename T::Result;
+		if (state.result > (NumericLimits<result_t>::Maximum() - digit) / 2) {
+			return false;
+		}
+		state.result = state.result * 2 + digit;
+		return true;
+	}
+
+	template <class T, bool NEGATIVE>
 	static bool HandleExponent(T &state, int32_t exponent) {
 		using result_t = typename T::Result;
 		double dbl_res = state.result * std::pow(10.0L, exponent);
@@ -975,6 +985,43 @@ static bool IntegerHexCastLoop(const char *buf, idx_t len, T &result, bool stric
 	return pos > start_pos;
 }
 
+template <class T, bool NEGATIVE, bool ALLOW_EXPONENT, class OP = IntegerCastOperation>
+static bool IntegerBinaryCastLoop(const char *buf, idx_t len, T &result, bool strict) {
+	if (ALLOW_EXPONENT || NEGATIVE) {
+		return false;
+	}
+	idx_t start_pos = 1;
+	idx_t pos = start_pos;
+	uint8_t digit;
+	char current_char;
+	while (pos < len) {
+		current_char = buf[pos];
+		if (current_char == '_' && pos > start_pos) {
+			// skip underscore, if it is not the first character
+			pos++;
+			if (pos == len) {
+				// we cant end on an underscore either
+				return false;
+			}
+			continue;
+		} else if (current_char == '0') {
+			digit = 0;
+		} else if (current_char == '1') {
+			digit = 1;
+		} else {
+			return false;
+		}
+		pos++;
+		if (!OP::template HandleBinaryDigit<T, NEGATIVE>(result, digit)) {
+			return false;
+		}
+	}
+	if (!OP::template Finalize<T, NEGATIVE>(result)) {
+		return false;
+	}
+	return pos > start_pos;
+}
+
 template <class T, bool IS_SIGNED = true, bool ALLOW_EXPONENT = true, class OP = IntegerCastOperation,
           bool ZERO_INITIALIZE = true>
 static bool TryIntegerCast(const char *buf, idx_t len, T &result, bool strict) {
@@ -989,17 +1036,24 @@ static bool TryIntegerCast(const char *buf, idx_t len, T &result, bool strict) {
 	int negative = *buf == '-';
 
 	// If it starts with 0x or 0X, we parse it as a hex value
-	int hex = len > 1 && *buf == '0' && (buf[1] == 'x' || buf[1] == 'X');
+	auto is_hex = len > 1 && *buf == '0' && (buf[1] == 'x' || buf[1] == 'X');
+	bool is_binary = len > 1 && *buf == '0' && (buf[1] == 'b' || buf[1] == 'B');
 
 	if (ZERO_INITIALIZE) {
 		memset(&result, 0, sizeof(T));
 	}
 	if (!negative) {
-		if (hex) {
+		if (is_hex) {
 			// Skip the 0x
 			buf++;
 			len--;
 			return IntegerHexCastLoop<T, false, false, OP>(buf, len, result, strict);
+		}
+		if (is_binary) {
+			// Skip the 0b
+			buf++;
+			len--;
+			return IntegerBinaryCastLoop<T, false, false, OP>(buf, len, result, strict);
 		} else {
 			return IntegerCastLoop<T, false, ALLOW_EXPONENT, OP>(buf, len, result, strict);
 		}
@@ -1515,6 +1569,19 @@ struct HugeIntegerCastOperation {
 	}
 
 	template <class T, bool NEGATIVE>
+	static bool HandleBinaryDigit(T &result, uint8_t digit) {
+		if (result.intermediate > (NumericLimits<int64_t>::Maximum() - digit) / 2) {
+			// intermediate is full: need to flush it
+			if (!result.Flush()) {
+				return false;
+			}
+		}
+		result.intermediate = result.intermediate * 2 + digit;
+		result.digits++;
+		return true;
+	}
+
+	template <class T, bool NEGATIVE>
 	static bool HandleExponent(T &result, int32_t exponent) {
 		if (!result.Flush()) {
 			return false;
@@ -1618,6 +1685,11 @@ struct DecimalCastOperation {
 
 	template <class T, bool NEGATIVE>
 	static bool HandleHexDigit(T &state, uint8_t digit) {
+		return false;
+	}
+
+	template <class T, bool NEGATIVE>
+	static bool HandleBinaryDigit(T &state, uint8_t digit) {
 		return false;
 	}
 

--- a/test/sql/cast/test_string_binary_cast.test
+++ b/test/sql/cast/test_string_binary_cast.test
@@ -1,0 +1,142 @@
+# name: test/sql/cast/test_string_binary_cast.test
+# group: [cast]
+
+foreach prefix 0b 0B
+
+# Empty binary should fail
+statement error
+SELECT '${prefix}'::INT
+
+# Binary with invalid characters should fail
+statement error
+SELECT '${prefix}2'::INT
+
+statement error
+SELECT '${prefix}10105'::INT
+
+# Negative binary should fail
+statement error
+SELECT '${prefix}-1'::INT
+
+statement error
+SELECT '-${prefix}1'::INT
+
+# Basic asserts
+query I
+SELECT '${prefix}1'::INT
+----
+1
+
+query I
+SELECT '${prefix}10'::INT
+----
+2
+
+query I
+SELECT '${prefix}11'::INT
+----
+3
+
+query I
+SELECT '${prefix}0000000'::INT
+----
+0
+
+# Allow underscores as digit separators
+query I
+SELECT '${prefix}1_0'::INT
+----
+2
+
+query I
+SELECT '${prefix}1_0_0'::INT
+----
+4
+
+query I
+SELECT '${prefix}11110000_11110000'::INT
+----
+61680
+
+# But dont allow them at the start or end
+statement error
+SELECT '${prefix}_1'::INT
+
+statement error
+SELECT '${prefix}1_'::INT
+
+statement error
+SELECT '${prefix}1_0_'::INT
+
+statement error
+SELECT '${prefix}_1_0'::INT
+
+
+# Property check! 
+foreach binary 1 01 00 0_0 10 10101 1001 0001 1111 1111_1111 01111111111111111111111111111111 01111111_11111111_11111111_11111111
+
+query I
+WITH binary_string as (select replace('${binary}', '_', '') as str)
+SELECT 
+	list_sum([ (CASE WHEN str[i+1] = '0' THEN 0 ELSE 1 END) * (2 ** (len(str)-(i+1))) for i in range(len(str))])::INT
+	==
+	'${prefix}${binary}'::INT
+FROM binary_string
+----
+true
+
+endloop
+
+
+# Test limits
+query I
+SELECT '${prefix}0000000000000000000000000000000001111111'::TINYINT
+----
+127
+
+query I
+SELECT '${prefix}0000000000000000000000000000000011111111'::UINT8
+----
+255
+
+statement error
+SELECT '${prefix}00000000000000000000000000000000111111111'::TINYINT
+
+query I
+SELECT '${prefix}1111111111111111111111111111111'::INT
+----
+2147483647
+
+statement error
+SELECT '${prefix}11111111111111111111111111111111'::INT
+
+query I
+SELECT '${prefix}01111111111111111111111111111111'::UINT32
+----
+2147483647
+
+query I
+SELECT '${prefix}11111111111111111111111111111111'::UINT32
+----
+4294967295
+
+query I
+SELECT '${prefix}11111111111111111111111111111111'::BIGINT
+----
+4294967295
+
+query I
+SELECT '${prefix}111111111111111111111111111111111111111111111111111111111111111'::BIGINT
+----
+9223372036854775807
+
+statement error
+SELECT '${prefix}1111111111111111111111111111111111111111111111111111111111111111'::BIGINT
+
+query I
+SELECT '${prefix}1111111111111111111111111111111111111111111111111111111111111111'::UINT64
+----
+18446744073709551615
+
+
+endloop


### PR DESCRIPTION
Partially closes #5196. 

Ideally a proper literal syntax should be reserved to create bit-strings, like in Postgres, but since we don't have a proper bit-string type yet that will have to wait.

This implementation also allows underscores to be used as digit separators, which greatly help when working with larger binary numbers.  