### PR TITLE
[julia] fix docstring of `load!` and relax type restriction

### DIFF
--- a/tools/juliapkg/src/old_interface.jl
+++ b/tools/juliapkg/src/old_interface.jl
@@ -21,11 +21,11 @@ appendDataFrame(input_df::DataFrame, db::DB, table::AbstractString, schema::Stri
     appendDataFrame(input_df, db.main_connection, table, schema)
 
 """
-    DuckDB.load!(input_df::DataFrame, con, table)
+    DuckDB.load!(con, input_df, table)
 
-Load an input DataFrame `input_df` into a DuckDB table that will be named `table`.
+Load an input DataFrame `input_df` into a new DuckDB table that will be named `table`.
 """
-function load!(con::Connection, input_df::DataFrame, table::AbstractString, schema::String = "main")
+function load!(con, input_df::DataFrame, table::AbstractString, schema::String = "main")
     register_data_frame(con, input_df, "__append_df")
     DBInterface.execute(con, "CREATE TABLE \"$schema\".\"$table\" AS SELECT * FROM __append_df")
     unregister_data_frame(con, "__append_df")


### PR DESCRIPTION
Calling `load!` fails due to the type restriction on `con`, probably due to confusion about `DBInterface.Connection` vs `DuckDB.Connection`. The easiest fix is to just omit the type restriction.