### PR TITLE
Fix string with exponent to integer cast

### DIFF
--- a/test/sql/cast/test_exponent_in_cast.test
+++ b/test/sql/cast/test_exponent_in_cast.test
@@ -12,7 +12,13 @@ statement error
 SELECT CAST('  e1' AS INTEGER);
 
 statement error
+SELECT CAST('e1  ' AS INTEGER);
+
+statement error
 SELECT CAST('  E1' AS INTEGER);
+
+statement error
+SELECT CAST('E1  ' AS INTEGER);
 
 statement error
 SELECT CAST('e1' AS DOUBLE);
@@ -21,7 +27,13 @@ statement error
 SELECT CAST('  e1' AS DOUBLE);
 
 statement error
+SELECT CAST('e1  ' AS DOUBLE);
+
+statement error
 SELECT CAST('  E1' AS DOUBLE);
+
+statement error
+SELECT CAST('E1  ' AS DOUBLE);
 
 query I
 SELECT CAST('1e1' AS INTEGER);
@@ -34,6 +46,11 @@ SELECT CAST('  1e1' AS INTEGER);
 10
 
 query I
+SELECT CAST('1e1  ' AS INTEGER);
+----
+10
+
+query I
 SELECT CAST('1e1' AS DOUBLE);
 ----
 10.0
@@ -42,3 +59,38 @@ query I
 SELECT CAST('   1e1' AS DOUBLE);
 ----
 10.0
+
+query I
+SELECT CAST('1e1  ' AS DOUBLE);
+----
+10.0
+
+query I
+SELECT CAST('1.234567e4' AS INTEGER);
+----
+12346
+
+query I
+SELECT CAST('  1.234567e4' AS INTEGER);
+----
+12346
+
+query I
+SELECT CAST('1.234567e4  ' AS INTEGER);
+----
+12346
+
+query I
+SELECT CAST('1.234567e4' AS DOUBLE);
+----
+12345.67
+
+query I
+SELECT CAST('  1.234567e4' AS DOUBLE);
+----
+12345.67
+
+query I
+SELECT CAST('1.234567e4  ' AS DOUBLE);
+----
+12345.67


### PR DESCRIPTION
Related to [#5328](https://github.com/duckdb/duckdb/issues/5328).


Fixed `STRING` with exponent like `'1.234e2'` to `TINYINT` ~ `BIGINT` cast more precisely (not yet `HUGEINT`).

Before this fix, `'1.234e2'` was casted to `100`, because the fractional part got rounded even when there is an exponent.

Now `state.result` stores the fractional part temporarily and `'1.234e2'` is casted to `123`.

It contains rounding up / down.