### PR TITLE
Issue #5342: DATE_PART Struct Indexing

### DIFF
--- a/extension/icu/icu-datepart.cpp
+++ b/extension/icu/icu-datepart.cpp
@@ -329,24 +329,24 @@ struct ICUDatePart : public ICUDateFunc {
 			for (idx_t i = 0; i < count; ++i) {
 				const auto idx = rdata.sel->get_index(i);
 				if (arg_valid.RowIsValid(idx)) {
-					res_valid.SetValid(idx);
+					res_valid.SetValid(i);
 					auto micros = SetTime(calendar, tdata[idx]);
 					const auto is_finite = Timestamp::IsFinite(tdata[idx]);
 					for (size_t col = 0; col < child_entries.size(); ++col) {
 						auto &child_entry = child_entries[col];
 						if (is_finite) {
-							FlatVector::Validity(*child_entry).SetValid(idx);
+							FlatVector::Validity(*child_entry).SetValid(i);
 							auto pdata = FlatVector::GetData<int64_t>(*child_entry);
 							auto adapter = info.adapters[col];
-							pdata[idx] = adapter(calendar, micros);
+							pdata[i] = adapter(calendar, micros);
 						} else {
-							FlatVector::Validity(*child_entry).SetInvalid(idx);
+							FlatVector::Validity(*child_entry).SetInvalid(i);
 						}
 					}
 				} else {
-					res_valid.SetInvalid(idx);
+					res_valid.SetInvalid(i);
 					for (auto &child_entry : child_entries) {
-						FlatVector::Validity(*child_entry).SetInvalid(idx);
+						FlatVector::Validity(*child_entry).SetInvalid(i);
 					}
 				}
 			}

--- a/src/function/scalar/date/date_part.cpp
+++ b/src/function/scalar/date/date_part.cpp
@@ -1420,16 +1420,16 @@ struct StructDatePart {
 				const auto idx = rdata.sel->get_index(i);
 				if (arg_valid.RowIsValid(idx)) {
 					if (Value::IsFinite(tdata[idx])) {
-						DatePart::StructOperator::Operation(part_values.data(), tdata[idx], idx, part_mask);
+						DatePart::StructOperator::Operation(part_values.data(), tdata[idx], i, part_mask);
 					} else {
 						for (auto &child_entry : child_entries) {
-							FlatVector::Validity(*child_entry).SetInvalid(idx);
+							FlatVector::Validity(*child_entry).SetInvalid(i);
 						}
 					}
 				} else {
-					res_valid.SetInvalid(idx);
+					res_valid.SetInvalid(i);
 					for (auto &child_entry : child_entries) {
-						FlatVector::Validity(*child_entry).SetInvalid(idx);
+						FlatVector::Validity(*child_entry).SetInvalid(i);
 					}
 				}
 			}

--- a/test/sql/copy/csv/auto/test_csv_auto.test
+++ b/test/sql/copy/csv/auto/test_csv_auto.test
@@ -6,7 +6,7 @@ require vector_size 512
 
 
 statement ok
-SET experimental_parallel_csv=true;
+SET experimental_parallel_csv=false;
 
 
 # CSV file with RFC-conform dialect

--- a/test/sql/function/date/test_date_part.test
+++ b/test/sql/function/date/test_date_part.test
@@ -455,6 +455,15 @@ NULL	NULL
 2022-01-01	{'isoyear': 2021, 'week': 52, 'yearweek': 202152}
 infinity	{'isoyear': NULL, 'week': NULL, 'yearweek': NULL}
 
+# Selective filtering (Issue #5342)
+query II
+SELECT d, DATE_PART(['year', 'month', 'day'], d) AS parts
+FROM dates
+WHERE s = 'day'
+ORDER BY 1;
+----
+1992-05-05	{'year': 1992, 'month': 5, 'day': 5}
+
 # Invalid parts
 
 foreach hour minute second millisecond microsecond timezone timezone_hour timezone_minute

--- a/test/sql/function/timestamp/test_icu_datepart.test
+++ b/test/sql/function/timestamp/test_icu_datepart.test
@@ -628,6 +628,15 @@ WHERE p IS DISTINCT FROM s['${partcode}'];
 
 endloop
 
+# Selective filtering (Issue #5342)
+query II
+SELECT ts, DATE_PART(['year', 'month', 'day'], ts) AS parts
+FROM timestamps
+WHERE part = 'day'
+ORDER BY 1;
+----
+2021-12-24 14:00:00-08	{'year': 2021, 'month': 12, 'day': 24}
+
 # Invalid parts
 statement error
 SELECT DATE_PART(['duck', 'minute', 'microsecond', 'timezone'], ts), ts


### PR DESCRIPTION
Fix the result indexing for the Struct variants of DATE_PART. The existing code wrote to the same output row as the input selection, which was not correct.

fixes #5342