### PR TITLE
Fix #5371: correctly use instance cache in JDBC and ODBC connector

### DIFF
--- a/src/include/duckdb/main/db_instance_cache.hpp
+++ b/src/include/duckdb/main/db_instance_cache.hpp
@@ -23,11 +23,18 @@ public:
 	//! Creates and caches a new DB Instance (Fails if a cached instance already exists)
 	shared_ptr<DuckDB> CreateInstance(const string &database, DBConfig &config_dict, bool cache_instance = true);
 
+	//! Creates and caches a new DB Instance (Fails if a cached instance already exists)
+	shared_ptr<DuckDB> GetOrCreateInstance(const string &database, DBConfig &config_dict, bool cache_instance);
+
 private:
 	//! A map with the cached instances <absolute_path/instance>
 	unordered_map<string, weak_ptr<DuckDB>> db_instances;
 
 	//! Lock to alter cache
 	mutex cache_lock;
+
+private:
+	shared_ptr<DuckDB> GetInstanceInternal(const string &database, const DBConfig &config_dict);
+	shared_ptr<DuckDB> CreateInstanceInternal(const string &database, DBConfig &config_dict, bool cache_instance);
 };
 } // namespace duckdb

--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -284,7 +284,7 @@ JNIEXPORT jobject JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1startup(JNI
 			}
 		}
 		bool cache_instance = database != ":memory:" && !database.empty();
-		auto shared_db = instance_cache.CreateInstance(database, config, cache_instance);
+		auto shared_db = instance_cache.GetOrCreateInstance(database, config, cache_instance);
 		auto db = shared_db.get();
 		std::lock_guard<std::mutex> lock(db_map_lock);
 		db_map[db] = move(shared_db);

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -2446,6 +2446,19 @@ public class TestDuckDBJDBC {
 		}
 	}
 
+	public static void test_instance_cache() throws Exception {
+		Path database_file = Files.createTempFile("duckdb-instance-cache-test-", ".duckdb");
+		database_file.toFile().delete();
+
+		String jdbc_url = "jdbc:duckdb:" + database_file.toString();
+
+		Connection conn = DriverManager.getConnection(jdbc_url);
+		Connection conn2 = DriverManager.getConnection(jdbc_url);
+
+		conn.close();
+		conn2.close();
+	}
+
 	public static void main(String[] args) throws Exception {
 		// Woo I can do reflection too, take this, JUnit!
 		Method[] methods = TestDuckDBJDBC.class.getMethods();

--- a/tools/odbc/driver.cpp
+++ b/tools/odbc/driver.cpp
@@ -211,7 +211,7 @@ static SQLRETURN SetConnection(SQLHDBC connection_handle, SQLCHAR *conn_str) {
 			config.options.access_mode = duckdb::AccessMode::READ_ONLY;
 		}
 		bool cache_instance = db_name != ":memory:" && !db_name.empty();
-		dbc->env->db = instance_cache.CreateInstance(db_name, config, cache_instance);
+		dbc->env->db = instance_cache.GetOrCreateInstance(db_name, config, cache_instance);
 	}
 
 	if (!dbc->conn) {


### PR DESCRIPTION
Fixes #5371

