### PR TITLE
For range joins use NL join when the LHS or RHS side is tiny

### DIFF
--- a/benchmark/micro/join/iejoin_employees.benchmark
+++ b/benchmark/micro/join/iejoin_employees.benchmark
@@ -65,6 +65,3 @@ SELECT COUNT(*) FROM (
 	FROM employees r, employees s
 	WHERE r.salary < s.salary AND r.tax > s.tax
 ) q1;
-
-result I
-99296

--- a/benchmark/micro/join/iejoin_events.benchmark
+++ b/benchmark/micro/join/iejoin_events.benchmark
@@ -41,5 +41,3 @@ SELECT COUNT(*) FROM (
 	  AND r.id <> s.id
 ) q2;
 
-result I
-3772

--- a/benchmark/micro/join/range_join_small_rhs.benchmark
+++ b/benchmark/micro/join/range_join_small_rhs.benchmark
@@ -1,0 +1,26 @@
+# name: benchmark/micro/join/range_join_small_rhs.benchmark
+# description: Range Join with a small RHS
+# group: [join]
+
+name Range Join with a small RHS
+group join
+
+load
+CREATE TABLE trip_data(fare_amount DOUBLE, trip_distance DOUBLE);
+INSERT INTO trip_data SELECT ((i * 458736436.734) % 100.0::DOUBLE), ((i * 745986489.963) % 1000.0::DOUBLE) FROM range(100000000) t(i);
+
+run
+SELECT COUNT(*)
+FROM
+    trip_data,
+    (
+        SELECT
+            AVG(fare_amount) + 3 * STDDEV_SAMP(fare_amount) as max_fare,
+            AVG(trip_distance) + 3 * STDDEV_SAMP(trip_distance) as max_distance
+        FROM trip_data
+    ) AS sub
+WHERE
+    fare_amount > 0 AND
+    fare_amount < sub.max_fare AND
+    trip_distance > 0 AND
+    trip_distance < sub.max_distance

--- a/src/execution/physical_plan/plan_comparison_join.cpp
+++ b/src/execution/physical_plan/plan_comparison_join.cpp
@@ -254,6 +254,10 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalComparison
 		default:
 			break;
 		}
+		if (left->estimated_cardinality <= 5 || right->estimated_cardinality <= 5) {
+			can_iejoin = false;
+			can_merge = false;
+		}
 		if (can_iejoin) {
 			plan = make_unique<PhysicalIEJoin>(op, move(left), move(right), move(op.conditions), op.join_type,
 			                                   op.estimated_cardinality);

--- a/src/execution/physical_plan/plan_comparison_join.cpp
+++ b/src/execution/physical_plan/plan_comparison_join.cpp
@@ -242,6 +242,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalComparison
 		                                     op.estimated_cardinality, perfect_join_stats);
 
 	} else {
+		static constexpr const idx_t NESTED_LOOP_JOIN_THRESHOLD = 5;
 		bool can_merge = has_range > 0;
 		bool can_iejoin = has_range >= 2 && recursive_cte_tables.empty();
 		switch (op.join_type) {
@@ -254,7 +255,8 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalComparison
 		default:
 			break;
 		}
-		if (left->estimated_cardinality <= 5 || right->estimated_cardinality <= 5) {
+		if (left->estimated_cardinality <= NESTED_LOOP_JOIN_THRESHOLD ||
+		    right->estimated_cardinality <= NESTED_LOOP_JOIN_THRESHOLD) {
 			can_iejoin = false;
 			can_merge = false;
 		}


### PR DESCRIPTION
For range joins - when the cardinality estimator figures out that one of the two sides of the join is very small (less than 5 rows) - we now switch to using the nested loop join instead of the IE Join or the Merge join.

The reason for that is that the IE join and merge join both introduce significant costs that depend on the size of both sides of the table:

* The merge join sorts chunks on both sides
* The IE join materializes both sides

As such, when one of the sides is tiny and the other side is gigantic, the NL join performs significantly better.

The following query (found by @pdet) triggered this optimization:

```sql
SELECT
    (SUM(trip_distance * fare_amount) - SUM(trip_distance) * SUM(fare_amount) / COUNT(*)) /
    (SUM(trip_distance * trip_distance) - SUM(trip_distance) * SUM(trip_distance) / COUNT(*)) AS beta,
    AVG(fare_amount) AS avg_fare_amount,
    AVG(trip_distance) AS avg_trip_distance
FROM 
    yellow_tripdata_2016_01,
    (
        SELECT 
            AVG(fare_amount) + 3 * STDDEV_SAMP(fare_amount) as max_fare,
            AVG(trip_distance) + 3 * STDDEV_SAMP(trip_distance) as max_distance
        FROM yellow_tripdata_2016_01
    ) AS sub
WHERE 
    fare_amount > 0 AND
    fare_amount < sub.max_fare AND 
    trip_distance > 0 AND
    trip_distance < sub.max_distance
```

In this query we do a range join between a big table and an ungrouped aggregate. The ungrouped aggregate always has a cardinality of 1. This query experienced a large regression because of the IE join (and previously because of the merge join). 

We have added a similar query on synthetic data to the benchmark runner, and this optimization speeds up the query from `14` seconds to `0.35` seconds (around 40X faster).
