### PR TITLE
Fix #5390: in filter pull-up optimizer avoid adding columns to one side of a set operation

### DIFF
--- a/src/optimizer/filter_pullup.cpp
+++ b/src/optimizer/filter_pullup.cpp
@@ -40,7 +40,6 @@ unique_ptr<LogicalOperator> FilterPullup::PullupJoin(unique_ptr<LogicalOperator>
 	case JoinType::LEFT:
 	case JoinType::ANTI:
 	case JoinType::SEMI: {
-		can_add_column = true;
 		return PullupFromLeft(move(op));
 	}
 	default:

--- a/src/optimizer/pullup/pullup_both_side.cpp
+++ b/src/optimizer/pullup/pullup_both_side.cpp
@@ -7,6 +7,8 @@ unique_ptr<LogicalOperator> FilterPullup::PullupBothSide(unique_ptr<LogicalOpera
 	FilterPullup right_pullup(true, can_add_column);
 	op->children[0] = left_pullup.Rewrite(move(op->children[0]));
 	op->children[1] = right_pullup.Rewrite(move(op->children[1]));
+	D_ASSERT(left_pullup.can_add_column == can_add_column);
+	D_ASSERT(right_pullup.can_add_column == can_add_column);
 
 	// merging filter expressions
 	for (idx_t i = 0; i < right_pullup.filters_expr_pullup.size(); ++i) {

--- a/src/optimizer/pushdown/pushdown_set_operation.cpp
+++ b/src/optimizer/pushdown/pushdown_set_operation.cpp
@@ -35,6 +35,9 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownSetOperation(unique_ptr<Logi
 	D_ASSERT(op->children.size() == 2);
 	auto left_bindings = op->children[0]->GetColumnBindings();
 	auto right_bindings = op->children[1]->GetColumnBindings();
+	if (left_bindings.size() != right_bindings.size()) {
+		throw InternalException("Filter pushdown - set operation LHS and RHS have incompatible counts");
+	}
 
 	// pushdown into set operation, we can duplicate the condition and pushdown the expressions into both sides
 	FilterPushdown left_pushdown(optimizer), right_pushdown(optimizer);

--- a/test/issues/general/test_5390.test
+++ b/test/issues/general/test_5390.test
@@ -1,0 +1,88 @@
+# name: test/issues/general/test_5390.test
+# description: Issue 5390: Segmentation fault with ROWID and LEFT/RIGHT JOIN
+# group: [general]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t0(c0 INT);
+
+statement ok
+CREATE TABLE t1(c0 INT);
+
+statement ok
+INSERT INTO t0 values (5);
+
+statement ok
+INSERT INTO t1 values (4);
+
+query II
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+INTERSECT
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+    WHERE
+        1 BETWEEN -1 AND t1.rowid;
+----
+
+query II
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+INTERSECT
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+    WHERE
+        1 BETWEEN -1 AND t1.c0;
+----
+4	5
+
+query II
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+INTERSECT
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+    WHERE 1 BETWEEN +1 AND t1.rowid;
+----
+
+query II
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+INTERSECT
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+    WHERE 1 BETWEEN 2 AND t1.rowid;
+----
+
+
+query II
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+INTERSECT
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+    WHERE 1 = t1.rowid;
+----
+
+query II
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+INTERSECT
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+    WHERE -1 = t1.rowid;
+----


### PR DESCRIPTION
Fix #5390

Fix a bug in the filter pull-up optimizer that causes it to create a corrupt query plan (where one side of a set-operation has more columns than the other side). This then causes problems later on in other optimizers.