### PR TITLE
Shell: add individual SQL queries to the history, instead of individual lines

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -520,6 +520,8 @@ DUCKDB_API const char *duckdb_result_error(duckdb_result *result);
 /*!
 Fetches a data chunk from the duckdb_result. This function should be called repeatedly until the result is exhausted.
 
+The result must be destroyed with `duckdb_destroy_data_chunk`.
+
 This function supersedes all `duckdb_value` functions, as well as the `duckdb_column_data` and `duckdb_nullmask_data`
 functions. It results in significantly better performance, and should be preferred in newer code-bases.
 

--- a/src/include/duckdb/main/db_instance_cache.hpp
+++ b/src/include/duckdb/main/db_instance_cache.hpp
@@ -23,11 +23,18 @@ public:
 	//! Creates and caches a new DB Instance (Fails if a cached instance already exists)
 	shared_ptr<DuckDB> CreateInstance(const string &database, DBConfig &config_dict, bool cache_instance = true);
 
+	//! Creates and caches a new DB Instance (Fails if a cached instance already exists)
+	shared_ptr<DuckDB> GetOrCreateInstance(const string &database, DBConfig &config_dict, bool cache_instance);
+
 private:
 	//! A map with the cached instances <absolute_path/instance>
 	unordered_map<string, weak_ptr<DuckDB>> db_instances;
 
 	//! Lock to alter cache
 	mutex cache_lock;
+
+private:
+	shared_ptr<DuckDB> GetInstanceInternal(const string &database, const DBConfig &config_dict);
+	shared_ptr<DuckDB> CreateInstanceInternal(const string &database, DBConfig &config_dict, bool cache_instance);
 };
 } // namespace duckdb

--- a/src/optimizer/filter_pullup.cpp
+++ b/src/optimizer/filter_pullup.cpp
@@ -40,7 +40,6 @@ unique_ptr<LogicalOperator> FilterPullup::PullupJoin(unique_ptr<LogicalOperator>
 	case JoinType::LEFT:
 	case JoinType::ANTI:
 	case JoinType::SEMI: {
-		can_add_column = true;
 		return PullupFromLeft(move(op));
 	}
 	default:

--- a/src/optimizer/pullup/pullup_both_side.cpp
+++ b/src/optimizer/pullup/pullup_both_side.cpp
@@ -7,6 +7,8 @@ unique_ptr<LogicalOperator> FilterPullup::PullupBothSide(unique_ptr<LogicalOpera
 	FilterPullup right_pullup(true, can_add_column);
 	op->children[0] = left_pullup.Rewrite(move(op->children[0]));
 	op->children[1] = right_pullup.Rewrite(move(op->children[1]));
+	D_ASSERT(left_pullup.can_add_column == can_add_column);
+	D_ASSERT(right_pullup.can_add_column == can_add_column);
 
 	// merging filter expressions
 	for (idx_t i = 0; i < right_pullup.filters_expr_pullup.size(); ++i) {

--- a/src/optimizer/pushdown/pushdown_set_operation.cpp
+++ b/src/optimizer/pushdown/pushdown_set_operation.cpp
@@ -35,6 +35,9 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownSetOperation(unique_ptr<Logi
 	D_ASSERT(op->children.size() == 2);
 	auto left_bindings = op->children[0]->GetColumnBindings();
 	auto right_bindings = op->children[1]->GetColumnBindings();
+	if (left_bindings.size() != right_bindings.size()) {
+		throw InternalException("Filter pushdown - set operation LHS and RHS have incompatible counts");
+	}
 
 	// pushdown into set operation, we can duplicate the condition and pushdown the expressions into both sides
 	FilterPushdown left_pushdown(optimizer), right_pushdown(optimizer);

--- a/test/issues/general/test_5390.test
+++ b/test/issues/general/test_5390.test
@@ -1,0 +1,88 @@
+# name: test/issues/general/test_5390.test
+# description: Issue 5390: Segmentation fault with ROWID and LEFT/RIGHT JOIN
+# group: [general]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t0(c0 INT);
+
+statement ok
+CREATE TABLE t1(c0 INT);
+
+statement ok
+INSERT INTO t0 values (5);
+
+statement ok
+INSERT INTO t1 values (4);
+
+query II
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+INTERSECT
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+    WHERE
+        1 BETWEEN -1 AND t1.rowid;
+----
+
+query II
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+INTERSECT
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+    WHERE
+        1 BETWEEN -1 AND t1.c0;
+----
+4	5
+
+query II
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+INTERSECT
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+    WHERE 1 BETWEEN +1 AND t1.rowid;
+----
+
+query II
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+INTERSECT
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+    WHERE 1 BETWEEN 2 AND t1.rowid;
+----
+
+
+query II
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+INTERSECT
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+    WHERE 1 = t1.rowid;
+----
+
+query II
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+INTERSECT
+SELECT *
+    FROM t1
+    LEFT JOIN t0 ON t1.rowid = t0.rowid
+    WHERE -1 = t1.rowid;
+----

--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -284,7 +284,7 @@ JNIEXPORT jobject JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1startup(JNI
 			}
 		}
 		bool cache_instance = database != ":memory:" && !database.empty();
-		auto shared_db = instance_cache.CreateInstance(database, config, cache_instance);
+		auto shared_db = instance_cache.GetOrCreateInstance(database, config, cache_instance);
 		auto db = shared_db.get();
 		std::lock_guard<std::mutex> lock(db_map_lock);
 		db_map[db] = move(shared_db);

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -2446,6 +2446,19 @@ public class TestDuckDBJDBC {
 		}
 	}
 
+	public static void test_instance_cache() throws Exception {
+		Path database_file = Files.createTempFile("duckdb-instance-cache-test-", ".duckdb");
+		database_file.toFile().delete();
+
+		String jdbc_url = "jdbc:duckdb:" + database_file.toString();
+
+		Connection conn = DriverManager.getConnection(jdbc_url);
+		Connection conn2 = DriverManager.getConnection(jdbc_url);
+
+		conn.close();
+		conn2.close();
+	}
+
 	public static void main(String[] args) throws Exception {
 		// Woo I can do reflection too, take this, JUnit!
 		Method[] methods = TestDuckDBJDBC.class.getMethods();

--- a/tools/odbc/driver.cpp
+++ b/tools/odbc/driver.cpp
@@ -211,7 +211,7 @@ static SQLRETURN SetConnection(SQLHDBC connection_handle, SQLCHAR *conn_str) {
 			config.options.access_mode = duckdb::AccessMode::READ_ONLY;
 		}
 		bool cache_instance = db_name != ":memory:" && !db_name.empty();
-		dbc->env->db = instance_cache.CreateInstance(db_name, config, cache_instance);
+		dbc->env->db = instance_cache.GetOrCreateInstance(db_name, config, cache_instance);
 	}
 
 	if (!dbc->conn) {

--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -1561,6 +1561,12 @@ int linenoiseHistoryAdd(const char *line) {
 	linecopy = strdup(line);
 	if (!linecopy)
 		return 0;
+	// replace all newlines with spaces
+	for(auto ptr = linecopy; *ptr; ptr++) {
+		if (*ptr == '\n' || *ptr == '\r') {
+			*ptr = ' ';
+		}
+	}
 	if (history_len == history_max_len) {
 		free(history[0]);
 		memmove(history, history + 1, sizeof(char *) * (history_max_len - 1));

--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -1562,7 +1562,7 @@ int linenoiseHistoryAdd(const char *line) {
 	if (!linecopy)
 		return 0;
 	// replace all newlines with spaces
-	for(auto ptr = linecopy; *ptr; ptr++) {
+	for (auto ptr = linecopy; *ptr; ptr++) {
 		if (*ptr == '\n' || *ptr == '\r') {
 			*ptr = ' ';
 		}

--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -117,6 +117,7 @@
 #include <unistd.h>
 #include "linenoise.h"
 #include "utf8proc_wrapper.hpp"
+#include <vector>
 
 #if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
 // disable highlighting on windows (for now?)
@@ -155,27 +156,38 @@ static Color terminal_colors[] = {{"red", "\033[31m"},           {"green", "\033
                                   {"brightmagenta", "\033[95m"}, {"brightcyan", "\033[96m"},
                                   {"brightwhite", "\033[97m"},   {nullptr, nullptr}};
 static std::string bold = "\033[1m";
+static std::string underline = "\033[4m";
 static std::string keyword = "\033[32m\033[1m";
 static std::string constant = "\033[33m";
 static std::string reset = "\033[00m";
 #endif
 
+struct searchMatch {
+	size_t history_index;
+	size_t match_start;
+	size_t match_end;
+};
+
 /* The linenoiseState structure represents the state during line editing.
  * We pass this state to functions implementing specific editing
  * functionalities. */
 struct linenoiseState {
-	int ifd;            /* Terminal stdin file descriptor. */
-	int ofd;            /* Terminal stdout file descriptor. */
-	char *buf;          /* Edited line buffer. */
-	size_t buflen;      /* Edited line buffer size. */
-	const char *prompt; /* Prompt to display. */
-	size_t plen;        /* Prompt length. */
-	size_t pos;         /* Current cursor position. */
-	size_t oldpos;      /* Previous refresh cursor position. */
-	size_t len;         /* Current edited line length. */
-	size_t cols;        /* Number of columns in terminal. */
-	size_t maxrows;     /* Maximum num of rows used so far (multiline mode) */
-	int history_index;  /* The history index we are currently editing. */
+	int ifd;                                 /* Terminal stdin file descriptor. */
+	int ofd;                                 /* Terminal stdout file descriptor. */
+	char *buf;                               /* Edited line buffer. */
+	size_t buflen;                           /* Edited line buffer size. */
+	const char *prompt;                      /* Prompt to display. */
+	size_t plen;                             /* Prompt length. */
+	size_t pos;                              /* Current cursor position. */
+	size_t oldpos;                           /* Previous refresh cursor position. */
+	size_t len;                              /* Current edited line length. */
+	size_t cols;                             /* Number of columns in terminal. */
+	size_t maxrows;                          /* Maximum num of rows used so far (multiline mode) */
+	int history_index;                       /* The history index we are currently editing. */
+	bool search;                             /* Whether or not we are searching our history */
+	std::string search_buf;                  //! The search buffer
+	std::vector<searchMatch> search_matches; //! The set of search matches in our history
+	size_t search_index;                     //! The current match index
 };
 
 enum KEY_ACTION {
@@ -193,6 +205,7 @@ enum KEY_ACTION {
 	ENTER = 13,     /* Enter */
 	CTRL_N = 14,    /* Ctrl-n */
 	CTRL_P = 16,    /* Ctrl-p */
+	CTRL_R = 18,    /* Ctrl-r */
 	CTRL_T = 20,    /* Ctrl-t */
 	CTRL_U = 21,    /* Ctrl+u */
 	CTRL_W = 23,    /* Ctrl+w */
@@ -666,7 +679,7 @@ int linenoiseParseOption(const char **azArg, int nArg, const char **out_error) {
 #include <sstream>
 #include "duckdb/parser/parser.hpp"
 
-std::string highlightText(char *buf, size_t len, size_t start_pos, size_t end_pos) {
+std::string highlightText(char *buf, size_t len, size_t start_pos, size_t end_pos, searchMatch *match = nullptr) {
 	std::string sql(buf, len);
 	auto tokens = duckdb::Parser::Tokenize(sql);
 	std::stringstream ss;
@@ -681,6 +694,50 @@ std::string highlightText(char *buf, size_t len, size_t start_pos, size_t end_po
 		new_token.type = duckdb::SimplifiedTokenType::SIMPLIFIED_TOKEN_IDENTIFIER;
 		new_token.start = 0;
 		tokens.push_back(new_token);
+	}
+	if (match) {
+		// we have a search match - insert it into the token list
+		// we want to insert a search token with start = match_start, end = match_end
+		// first figure out which token type we would have at match_end (if any)
+		duckdb::SimplifiedTokenType end_type = duckdb::SimplifiedTokenType::SIMPLIFIED_TOKEN_IDENTIFIER;
+		for (size_t i = 0; i < tokens.size(); i++) {
+			if (tokens[i].start >= match->match_end) {
+				break;
+			}
+			end_type = tokens[i].type;
+		}
+
+		for (size_t i = 0; i + 1 < tokens.size(); i++) {
+			if (tokens[i].start <= match->match_start && tokens[i + 1].start >= match->match_start) {
+				// this token begins after the search position, insert the token here
+				size_t token_position = i + 1;
+				if (tokens[i].start == match->match_start) {
+					// exact start: overwrite the token
+					tokens[i].type = duckdb::SimplifiedTokenType::SIMPLIFIED_TOKEN_COMMENT;
+				} else {
+					// non-exact start: add a new token
+					duckdb::SimplifiedToken search_token;
+					search_token.type = duckdb::SimplifiedTokenType::SIMPLIFIED_TOKEN_COMMENT;
+					search_token.start = match->match_start;
+					tokens.insert(tokens.begin() + token_position, search_token);
+					token_position++;
+				}
+
+				// insert the token that marks the end of the search
+				duckdb::SimplifiedToken end_token;
+				end_token.type = end_type;
+				end_token.start = match->match_end;
+				tokens.insert(tokens.begin() + token_position, end_token);
+				token_position++;
+
+				// erase any tokens that are fully "consumed" by the search match
+				while (token_position < tokens.size() && tokens[token_position].start <= match->match_end) {
+					tokens.erase(tokens.begin() + token_position);
+				}
+
+				break;
+			}
+		}
 	}
 	for (size_t i = 0; i < tokens.size(); i++) {
 		size_t next = i + 1 < tokens.size() ? tokens[i + 1].start : len;
@@ -704,6 +761,9 @@ std::string highlightText(char *buf, size_t len, size_t start_pos, size_t end_po
 		case duckdb::SimplifiedTokenType::SIMPLIFIED_TOKEN_STRING_CONSTANT:
 			ss << constant << text << reset;
 			break;
+		case duckdb::SimplifiedTokenType::SIMPLIFIED_TOKEN_COMMENT:
+			ss << bold << underline << text << reset;
+			break;
 		default:
 			ss << text;
 		}
@@ -712,26 +772,11 @@ std::string highlightText(char *buf, size_t len, size_t start_pos, size_t end_po
 }
 #endif
 
-/* Single line low level line refresh.
- *
- * Rewrite the currently edited line accordingly to the buffer content,
- * cursor position, and number of columns of the terminal. */
-static void refreshSingleLine(struct linenoiseState *l) {
-	char seq[64];
-	size_t plen = linenoiseComputeRenderWidth(l->prompt, strlen(l->prompt));
-	int fd = l->ofd;
-	char *buf = l->buf;
-	size_t len = l->len;
-	size_t pos = l->pos;
-	struct abuf ab;
-	size_t render_pos = 0;
-#ifndef DISABLE_HIGHLIGHT
-	std::string highlight_buffer;
-#endif
-
-	if (duckdb::Utf8Proc::IsValid(l->buf, l->len)) {
+static void renderText(size_t &render_pos, char *&buf, size_t &len, size_t pos, size_t cols, size_t plen,
+                       std::string &highlight_buffer, bool enableHighlight, searchMatch *match = nullptr) {
+	if (duckdb::Utf8Proc::IsValid(buf, len)) {
 		// utf8 in prompt, handle rendering
-		size_t remaining_render_width = l->cols - plen - 1;
+		size_t remaining_render_width = cols - plen - 1;
 		size_t start_pos = 0;
 		size_t cpos = 0;
 		size_t prev_pos = 0;
@@ -743,7 +788,7 @@ static void refreshSingleLine(struct linenoiseState *l) {
 			total_render_width += cpos - prev_pos;
 			if (total_render_width >= remaining_render_width) {
 				// character does not fit anymore! we need to figure something out
-				if (prev_pos >= l->pos) {
+				if (prev_pos >= pos) {
 					// we passed the cursor: break
 					cpos = prev_pos;
 					break;
@@ -758,13 +803,13 @@ static void refreshSingleLine(struct linenoiseState *l) {
 					}
 				}
 			}
-			if (prev_pos < l->pos) {
+			if (prev_pos < pos) {
 				render_pos += char_render_width;
 			}
 		}
 #ifndef DISABLE_HIGHLIGHT
 		if (enableHighlighting) {
-			highlight_buffer = highlightText(l->buf, l->len, start_pos, cpos);
+			highlight_buffer = highlightText(buf, len, start_pos, cpos, match);
 			buf = (char *)highlight_buffer.c_str();
 			len = highlight_buffer.size();
 		} else
@@ -775,16 +820,33 @@ static void refreshSingleLine(struct linenoiseState *l) {
 		}
 	} else {
 		// invalid UTF8: fallback
-		while ((plen + pos) >= l->cols) {
+		while ((plen + pos) >= cols) {
 			buf++;
 			len--;
 			pos--;
 		}
-		while (plen + len > l->cols) {
+		while (plen + len > cols) {
 			len--;
 		}
 		render_pos = pos;
 	}
+}
+
+/* Single line low level line refresh.
+ *
+ * Rewrite the currently edited line accordingly to the buffer content,
+ * cursor position, and number of columns of the terminal. */
+static void refreshSingleLine(struct linenoiseState *l) {
+	char seq[64];
+	size_t plen = linenoiseComputeRenderWidth(l->prompt, strlen(l->prompt));
+	int fd = l->ofd;
+	char *buf = l->buf;
+	size_t len = l->len;
+	struct abuf ab;
+	size_t render_pos = 0;
+	std::string highlight_buffer;
+
+	renderText(render_pos, buf, len, l->pos, l->cols, plen, highlight_buffer, enableHighlighting);
 
 	abInit(&ab);
 	/* Cursor to left edge */
@@ -793,6 +855,99 @@ static void refreshSingleLine(struct linenoiseState *l) {
 	/* Write the prompt and the current buffer content */
 	abAppend(&ab, l->prompt, strlen(l->prompt));
 	abAppend(&ab, buf, len);
+	/* Show hits if any. */
+	refreshShowHints(&ab, l, plen);
+	/* Erase to right */
+	snprintf(seq, 64, "\x1b[0K");
+	abAppend(&ab, seq, strlen(seq));
+	/* Move cursor to original position. */
+	snprintf(seq, 64, "\r\x1b[%dC", (int)(render_pos + plen));
+	abAppend(&ab, seq, strlen(seq));
+	if (write(fd, ab.b, ab.len) == -1) {
+	} /* Can't recover from write error. */
+	abFree(&ab);
+}
+
+static void refreshSearch(struct linenoiseState *l) {
+	std::string search_prompt;
+	static const size_t SEARCH_PROMPT_RENDER_SIZE = 28;
+	static const char *NO_MATCHES = "(no matches)";
+	static const size_t NO_MATCHES_LEN = 12;
+	bool no_matches = l->search_index >= l->search_matches.size();
+	if (l->search_buf.empty()) {
+		search_prompt = "search" + std::string(SEARCH_PROMPT_RENDER_SIZE - 8, ' ') + "> ";
+	} else {
+		std::string search_text;
+		search_text += " (" + l->search_buf;
+		if (!no_matches) {
+			search_text += ", " + std::to_string(l->search_index + 1);
+			search_text += "/" + std::to_string(l->search_matches.size());
+		}
+		search_text += ")";
+		size_t search_text_length = linenoiseComputeRenderWidth(search_text.c_str(), search_text.size());
+		if (search_text_length < SEARCH_PROMPT_RENDER_SIZE - 8) {
+			// search text is short: keep search prefix
+			search_prompt = "search";
+			search_prompt += std::string(SEARCH_PROMPT_RENDER_SIZE - 8 - search_text_length, ' ');
+			search_prompt += search_text;
+			search_prompt += "> ";
+		} else if (search_text_length < SEARCH_PROMPT_RENDER_SIZE - 2) {
+			// search text is on the long side - remove search prefix
+			search_prompt = search_text;
+			if (search_text_length < SEARCH_PROMPT_RENDER_SIZE - 2) {
+				size_t extra_spaces = SEARCH_PROMPT_RENDER_SIZE - search_text_length - 2;
+				search_prompt += std::string(extra_spaces, ' ');
+			}
+			search_prompt += "> ";
+		} else {
+			// search text length is too long to fit: truncate
+			char *search_buf = (char *)search_text.c_str();
+			size_t search_len = search_text.size();
+			size_t search_render_pos = 0;
+			auto max_render_size = SEARCH_PROMPT_RENDER_SIZE - 2;
+			std::string highlight_buffer;
+			renderText(search_render_pos, search_buf, search_len, search_len, max_render_size, 0, highlight_buffer,
+			           false);
+			search_prompt = std::string(search_buf, search_len);
+			for (size_t i = search_render_pos; i < max_render_size; i++) {
+				search_prompt += " ";
+			}
+			search_prompt += "> ";
+		}
+	}
+
+	char seq[64];
+	size_t plen = linenoiseComputeRenderWidth(search_prompt.c_str(), search_prompt.size());
+	int fd = l->ofd;
+	char *buf;
+	size_t len;
+	size_t cols = l->cols;
+	struct abuf ab;
+	size_t render_pos = 0;
+	std::string highlight_buffer;
+
+	if (!no_matches) {
+		// if there are matches render the current history item
+		auto search_match = l->search_matches[l->search_index];
+		auto history_index = search_match.history_index;
+		auto cursor_position = search_match.match_end;
+		buf = history[history_index];
+		len = strlen(history[history_index]);
+		renderText(render_pos, buf, len, cursor_position, cols, plen, highlight_buffer, enableHighlighting,
+		           &search_match);
+	}
+
+	abInit(&ab);
+	/* Cursor to left edge */
+	snprintf(seq, 64, "\r");
+	abAppend(&ab, seq, strlen(seq));
+	/* Write the prompt and the current buffer content */
+	abAppend(&ab, search_prompt.c_str(), search_prompt.size());
+	if (no_matches) {
+		abAppend(&ab, NO_MATCHES, NO_MATCHES_LEN);
+	} else {
+		abAppend(&ab, buf, len);
+	}
 	/* Show hits if any. */
 	refreshShowHints(&ab, l, plen);
 	/* Erase to right */
@@ -1106,6 +1261,95 @@ static int hasMoreData(int fd) {
 	return select(1, &rfds, NULL, NULL, &tv);
 }
 
+static void cancelSearch(linenoiseState *l) {
+	l->search = false;
+	l->search_buf = std::string();
+	l->search_matches.clear();
+	l->search_index = 0;
+	refreshLine(l);
+}
+
+static void performSearch(linenoiseState *l) {
+	// we try to maintain the current match while searching
+	size_t current_match = history_len;
+	if (l->search_index < l->search_matches.size()) {
+		current_match = l->search_matches[l->search_index].history_index;
+	}
+	l->search_matches.clear();
+	l->search_index = 0;
+	if (l->search_buf.empty()) {
+		return;
+	}
+	auto lsearch = duckdb::StringUtil::Lower(l->search_buf);
+	for (size_t i = 0; i < history_len; i++) {
+		auto lhistory = duckdb::StringUtil::Lower(history[i]);
+		auto entry = lhistory.find(lsearch);
+		if (entry != duckdb::string::npos) {
+			if (i == current_match) {
+				l->search_index = l->search_matches.size();
+			}
+			searchMatch match;
+			match.history_index = i;
+			match.match_start = entry;
+			match.match_end = entry + lsearch.size();
+			l->search_matches.push_back(match);
+		}
+	}
+}
+
+static void linenoiseSearch(linenoiseState *l, char c) {
+	switch (c) {
+	case 10:
+	case ENTER: /* enter */
+		// accept search
+		cancelSearch(l);
+		return;
+	case CTRL_R:
+		// move to the next match index
+		l->search_index += 1;
+		if (l->search_index >= l->search_matches.size()) {
+			l->search_index = 0;
+		}
+		break;
+	case ESC:
+	case CTRL_C:
+	case CTRL_D:
+	case CTRL_T:
+	case CTRL_B:
+	case CTRL_F:
+	case CTRL_P:
+	case CTRL_N:
+	case CTRL_U:
+	case CTRL_K:
+	case CTRL_A:
+	case CTRL_E:
+	case CTRL_L:
+	case CTRL_W:
+		// abort search
+		cancelSearch(l);
+		return;
+	case BACKSPACE: /* backspace */
+	case 8:         /* ctrl-h */
+		// remove trailing UTF-8 bytes (if any)
+		while (!l->search_buf.empty() && ((l->search_buf.back() & 0xc0) == 0x80)) {
+			l->search_buf.pop_back();
+		}
+		// finally remove the first UTF-8 byte
+		if (!l->search_buf.empty()) {
+			l->search_buf.pop_back();
+		}
+		performSearch(l);
+		break;
+	default:
+		// add input
+		l->search_buf += c;
+		// perform the search
+		performSearch(l);
+		break;
+	}
+	refreshSearch(l);
+}
+
 /* This function is the core of the line editing capability of linenoise.
  * It expects 'fd' to be already in "raw mode" so that every key pressed
  * will be returned ASAP to read().
@@ -1130,6 +1374,7 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
 	l.cols = getColumns(stdin_fd, stdout_fd);
 	l.maxrows = 0;
 	l.history_index = 0;
+	l.search = false;
 
 	/* Buffer starts empty. */
 	l.buf[0] = '\0';
@@ -1149,6 +1394,11 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
 		nread = read(l.ifd, &c, 1);
 		if (nread <= 0)
 			return l.len;
+
+		if (l.search) {
+			linenoiseSearch(&l, c);
+			continue;
+		}
 
 		/* Only autocomplete when the callback is set. It returns < 0 when
 		 * there was an error reading from fd. Otherwise it will return the
@@ -1242,6 +1492,15 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
 		case CTRL_N: /* ctrl-n */
 			linenoiseEditHistoryNext(&l, LINENOISE_HISTORY_NEXT);
 			break;
+		case CTRL_R: /* ctrl-r */ {
+			// initiate reverse search
+			l.search = true;
+			l.search_buf = std::string();
+			l.search_matches.clear();
+			l.search_index = 0;
+			refreshSearch(&l);
+			break;
+		}
 		case ESC: /* escape sequence */
 			/* Read the next two bytes representing the escape sequence.
 			 * Use two calls to handle slow terminals returning the two

--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -1296,15 +1296,16 @@ static void performSearch(linenoiseState *l) {
 		return;
 	}
 	auto lsearch = duckdb::StringUtil::Lower(l->search_buf);
-	for (size_t i = 0; i < history_len; i++) {
-		auto lhistory = duckdb::StringUtil::Lower(history[i]);
+	for (size_t i = history_len; i > 0; i--) {
+		size_t history_index = i - 1;
+		auto lhistory = duckdb::StringUtil::Lower(history[history_index]);
 		auto entry = lhistory.find(lsearch);
 		if (entry != duckdb::string::npos) {
-			if (i == current_match) {
+			if (history_index == current_match) {
 				l->search_index = l->search_matches.size();
 			}
 			searchMatch match;
-			match.history_index = i;
+			match.history_index = history_index;
 			match.match_start = entry;
 			match.match_end = entry + lsearch.size();
 			l->search_matches.push_back(match);

--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -746,7 +746,6 @@ static char *one_input_line(FILE *in, char *zPrior, int isContinuation){
 #else
     free(zPrior);
     zResult = shell_readline(zPrompt);
-    if( zResult && *zResult && *zResult != '\3' ) shell_add_history(zResult);
 #endif
   }
   return zResult;
@@ -20051,6 +20050,7 @@ static int runOneSqlLine(ShellState *p, char *zSql, FILE *in, int startline){
   open_db(p, 0);
   if( ShellHasFlag(p,SHFLG_Backslash) ) resolve_backslashes(zSql);
   if( p->flgProgress & SHELL_PROGRESS_RESET ) p->nProgress = 0;
+  if( zSql && *zSql && *zSql != '\3' ) shell_add_history(zSql);
   BEGIN_TIMER;
   rc = shell_exec(p, zSql, &zErrMsg);
   END_TIMER;

--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -20134,6 +20134,7 @@ static int process_input(ShellState *p){
     if( zLine && (zLine[0]=='.' || zLine[0]=='#') && nSql==0 ){
       if( ShellHasFlag(p, SHFLG_Echo) ) printf("%s\n", zLine);
       if( zLine[0]=='.' ){
+        if( zLine && *zLine && *zLine != '\3' ) shell_add_history(zLine);
         rc = do_meta_command(zLine, p);
         if( rc==2 ){ /* exit requested */
           break;


### PR DESCRIPTION
This PR modifies what gets added to the history of the shell - instead of adding individual lines, we now add entire SQL queries to the history. If those queries contain newlines, they are converted into spaces when moving up. This should allow for easier skipping back/forth when executing multi-line queries.

This is now the history behavior:

```sql
D SELECT
> 42;
-- (press up)
D SELECT 42;
```

All newlines are removed and converted to spaces.

