### PR TITLE
PER_THREAD_OUTPUT flag for COPY 

### DIFF
--- a/extension/parquet/parquet-extension.cpp
+++ b/extension/parquet/parquet-extension.cpp
@@ -92,7 +92,6 @@ struct ParquetReadGlobalState : public GlobalTableFunctionState {
 
 struct ParquetWriteBindData : public TableFunctionData {
 	vector<LogicalType> sql_types;
-	string file_name;
 	vector<string> column_names;
 	duckdb_parquet::format::CompressionCodec::type codec = duckdb_parquet::format::CompressionCodec::SNAPPY;
 	idx_t row_group_size = RowGroup::ROW_GROUP_SIZE;
@@ -581,7 +580,6 @@ unique_ptr<FunctionData> ParquetWriteBind(ClientContext &context, CopyInfo &info
 	}
 	bind_data->sql_types = sql_types;
 	bind_data->column_names = names;
-	bind_data->file_name = info.file_path;
 	return move(bind_data);
 }
 

--- a/src/execution/physical_plan/plan_copy_to_file.cpp
+++ b/src/execution/physical_plan/plan_copy_to_file.cpp
@@ -9,7 +9,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile
 	auto &fs = FileSystem::GetFileSystem(context);
 	op.file_path = fs.ExpandPath(op.file_path, FileSystem::GetFileOpener(context));
 
-	bool use_tmp_file = op.is_file_and_exists && op.use_tmp_file;
+	bool use_tmp_file = op.is_file_and_exists && op.use_tmp_file && !op.per_thread_output;
 	if (use_tmp_file) {
 		op.file_path += ".tmp";
 	}
@@ -17,6 +17,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile
 	auto copy = make_unique<PhysicalCopyToFile>(op.types, op.function, move(op.bind_data), op.estimated_cardinality);
 	copy->file_path = op.file_path;
 	copy->use_tmp_file = use_tmp_file;
+	copy->per_thread_output = op.per_thread_output;
 
 	copy->children.push_back(move(plan));
 	return move(copy);

--- a/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
@@ -24,6 +24,7 @@ public:
 	unique_ptr<FunctionData> bind_data;
 	string file_path;
 	bool use_tmp_file;
+	bool per_thread_output;
 
 public:
 	// Source interface
@@ -47,6 +48,10 @@ public:
 
 	bool IsOrderDependent() const override {
 		return true;
+	}
+
+	bool ParallelOperator() const override {
+		return per_thread_output;
 	}
 };
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
@@ -50,7 +50,7 @@ public:
 		return true;
 	}
 
-	bool ParallelOperator() const override {
+	bool ParallelSink() const override {
 		return per_thread_output;
 	}
 };

--- a/src/include/duckdb/planner/operator/logical_copy_to_file.hpp
+++ b/src/include/duckdb/planner/operator/logical_copy_to_file.hpp
@@ -24,6 +24,7 @@ public:
 	std::string file_path;
 	bool use_tmp_file;
 	bool is_file_and_exists;
+	bool per_thread_output;
 
 public:
 	void Serialize(FieldWriter &writer) const override;

--- a/src/planner/operator/logical_copy_to_file.cpp
+++ b/src/planner/operator/logical_copy_to_file.cpp
@@ -10,6 +10,7 @@ void LogicalCopyToFile::Serialize(FieldWriter &writer) const {
 	writer.WriteString(file_path);
 	writer.WriteField(use_tmp_file);
 	writer.WriteField(is_file_and_exists);
+	writer.WriteField(per_thread_output);
 
 	D_ASSERT(!function.name.empty());
 	writer.WriteString(function.name);
@@ -26,6 +27,7 @@ unique_ptr<LogicalOperator> LogicalCopyToFile::Deserialize(LogicalDeserializatio
 	auto file_path = reader.ReadRequired<string>();
 	auto use_tmp_file = reader.ReadRequired<bool>();
 	auto is_file_and_exists = reader.ReadRequired<bool>();
+	auto per_thread_output = reader.ReadRequired<bool>();
 
 	auto copy_func_name = reader.ReadRequired<string>();
 
@@ -52,6 +54,7 @@ unique_ptr<LogicalOperator> LogicalCopyToFile::Deserialize(LogicalDeserializatio
 	result->file_path = file_path;
 	result->use_tmp_file = use_tmp_file;
 	result->is_file_and_exists = is_file_and_exists;
+	result->per_thread_output = per_thread_output;
 	return move(result);
 }
 

--- a/test/sql/copy/per_thread_output.test
+++ b/test/sql/copy/per_thread_output.test
@@ -4,10 +4,6 @@
 
 require parquet
 
-
-statement ok
-PRAGMA enable_verification
-
 statement ok
 PRAGMA verify_parallelism;
 
@@ -22,5 +18,23 @@ COPY (FROM bigdata) TO '__TEST_DIR__/per_thread_output.parquet' (FORMAT PARQUET,
 
 query I
 SELECT COUNT(*) FROM PARQUET_SCAN('__TEST_DIR__/per_thread_output.parquet/*')
+----
+10000
+
+query I
+SELECT STR_SPLIT(file, '/')[-1] f FROM GLOB('__TEST_DIR__/per_thread_output.parquet/*') ORDER BY f
+----
+out_0
+out_1
+out_2
+out_3
+
+
+# with a trailing slash
+statement ok
+COPY (FROM bigdata) TO '__TEST_DIR__/per_thread_output2.parquet/' (FORMAT PARQUET, PER_THREAD_OUTPUT TRUE);
+
+query I
+SELECT COUNT(*) FROM PARQUET_SCAN('__TEST_DIR__/per_thread_output2.parquet/*')
 ----
 10000

--- a/test/sql/copy/per_thread_output.test
+++ b/test/sql/copy/per_thread_output.test
@@ -11,7 +11,7 @@ statement ok
 pragma threads=4;
 
 statement ok
-create table bigdata as select * from generate_series (9999);
+CREATE TABLE bigdata AS FROM generate_series (9999);
 
 statement ok
 COPY (FROM bigdata) TO '__TEST_DIR__/per_thread_output.parquet' (FORMAT PARQUET, PER_THREAD_OUTPUT TRUE);
@@ -56,7 +56,7 @@ statement ok
 COPY (FROM bigdata) TO '__TEST_DIR__/per_thread_output.csv' (FORMAT CSV, PER_THREAD_OUTPUT TRUE);
 
 query I
-SELECT COUNT(*) FROM READ_CSV_AUTO('__TEST_DIR__/per_thread_output.csv/*')
+SELECT COUNT(*) FROM READ_CSV_AUTO('__TEST_DIR__/per_thread_output.csv/*', HEADER=FALSE, SEP=',', QUOTE=FALSE)
 ----
 10000
 

--- a/test/sql/copy/per_thread_output.test
+++ b/test/sql/copy/per_thread_output.test
@@ -1,0 +1,26 @@
+# name: test/sql/copy/per_thread_output.test
+# description: 
+# group: [copy]
+
+require parquet
+
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+PRAGMA verify_parallelism;
+
+statement ok
+pragma threads=4;
+
+statement ok
+create table bigdata as select * from generate_series (9999);
+
+statement ok
+COPY (FROM bigdata) TO '__TEST_DIR__/per_thread_output.parquet' (FORMAT PARQUET, PER_THREAD_OUTPUT TRUE);
+
+query I
+SELECT COUNT(*) FROM PARQUET_SCAN('__TEST_DIR__/per_thread_output.parquet/*')
+----
+10000

--- a/test/sql/copy/per_thread_output.test
+++ b/test/sql/copy/per_thread_output.test
@@ -51,24 +51,6 @@ SELECT COUNT(*) FROM PARQUET_SCAN('__TEST_DIR__/per_thread_output2.parquet/*')
 10000
 
 
-# this should also work with csv
-statement ok
-COPY (FROM bigdata) TO '__TEST_DIR__/per_thread_output.csv' (FORMAT CSV, PER_THREAD_OUTPUT TRUE);
-
-query I
-SELECT COUNT(*) FROM READ_CSV_AUTO('__TEST_DIR__/per_thread_output.csv/*', HEADER=FALSE, SEP=',', QUOTE=FALSE)
-----
-10000
-
-query I
-SELECT STR_SPLIT(REPLACE(file, '\','/'), '/')[-1]  f FROM GLOB('__TEST_DIR__/per_thread_output.csv/*') ORDER BY f
-----
-out_0
-out_1
-out_2
-out_3
-
-
 # this should not work
 statement error
-COPY (FROM bigdata) TO '__TEST_DIR__/per_thread_output.csv' (FORMAT CSV, PER_THREAD_OUTPUT TRUE, USE_TMP_FILE TRUE);
+COPY (FROM bigdata) TO '__TEST_DIR__/per_thread_output3.parquet' (FORMAT PARQUET, PER_THREAD_OUTPUT TRUE, USE_TMP_FILE TRUE);

--- a/test/sql/copy/per_thread_output.test
+++ b/test/sql/copy/per_thread_output.test
@@ -67,3 +67,8 @@ out_0
 out_1
 out_2
 out_3
+
+
+# this should not work
+statement error
+COPY (FROM bigdata) TO '__TEST_DIR__/per_thread_output.csv' (FORMAT CSV, PER_THREAD_OUTPUT TRUE, USE_TMP_FILE TRUE);

--- a/test/sql/copy/per_thread_output.test
+++ b/test/sql/copy/per_thread_output.test
@@ -22,7 +22,7 @@ SELECT COUNT(*) FROM PARQUET_SCAN('__TEST_DIR__/per_thread_output.parquet/*')
 10000
 
 query I
-SELECT STR_SPLIT(file, '/')[-1] f FROM GLOB('__TEST_DIR__/per_thread_output.parquet/*') ORDER BY f
+SELECT STR_SPLIT(REPLACE(file, '\','/'), '/')[-1]  f FROM GLOB('__TEST_DIR__/per_thread_output.parquet/*') ORDER BY f
 ----
 out_0
 out_1
@@ -49,3 +49,21 @@ query I
 SELECT COUNT(*) FROM PARQUET_SCAN('__TEST_DIR__/per_thread_output2.parquet/*')
 ----
 10000
+
+
+# this should also work with csv
+statement ok
+COPY (FROM bigdata) TO '__TEST_DIR__/per_thread_output.csv' (FORMAT CSV, PER_THREAD_OUTPUT TRUE);
+
+query I
+SELECT COUNT(*) FROM READ_CSV_AUTO('__TEST_DIR__/per_thread_output.csv/*')
+----
+10000
+
+query I
+SELECT STR_SPLIT(REPLACE(file, '\','/'), '/')[-1]  f FROM GLOB('__TEST_DIR__/per_thread_output.csv/*') ORDER BY f
+----
+out_0
+out_1
+out_2
+out_3

--- a/test/sql/copy/per_thread_output.test
+++ b/test/sql/copy/per_thread_output.test
@@ -1,5 +1,5 @@
 # name: test/sql/copy/per_thread_output.test
-# description: 
+# description: test PER_THREAD_OUTPUT parameter for COPY
 # group: [copy]
 
 require parquet
@@ -34,6 +34,17 @@ out_3
 statement ok
 COPY (FROM bigdata) TO '__TEST_DIR__/per_thread_output2.parquet/' (FORMAT PARQUET, PER_THREAD_OUTPUT TRUE);
 
+query I
+SELECT COUNT(*) FROM PARQUET_SCAN('__TEST_DIR__/per_thread_output2.parquet/*')
+----
+10000
+
+
+# cant write to existing folders
+statement error
+COPY (FROM bigdata) TO '__TEST_DIR__/per_thread_output2.parquet/' (FORMAT PARQUET, PER_THREAD_OUTPUT TRUE);
+
+# we have not added anything
 query I
 SELECT COUNT(*) FROM PARQUET_SCAN('__TEST_DIR__/per_thread_output2.parquet/*')
 ----


### PR DESCRIPTION
We add a `PER_THREAD_OUTPUT ` flag to the `COPY` statement. This flag causes the COPY operator to become a parallel sink where each thread writes to a separate output file in a folder. For example,

```SQL
PRAGMA verify_parallelism;
PRAGMA threads=4;
CREATE TABLE bigdata as FROM generate_series (9999);
COPY (FROM bigdata) TO 'some_output' (FORMAT CSV, PER_THREAD_OUTPUT TRUE);
```
will create a folder `some_output` with four files `out_[0-3]` in it, each containing a portion of the table. If the folder already exists, it needs to be empty.

This works across copy functions, so `FORMAT PARQUET` will work as well.

The result is a great speed-up in COPY, on my MacBook:

```
CALL dbgen(sf=1);

.timer on

COPY (FROM lineitem) TO '/tmp/lineitem.parquet' (FORMAT PARQUET, PER_THREAD_OUTPUT FALSE);
Run Time (s): real 4.344 user 3.977938 sys 0.355404

COPY (FROM lineitem) TO '/tmp/lineitem2.parquet' (FORMAT PARQUET, PER_THREAD_OUTPUT TRUE);
Run Time (s): real 0.731 user 5.026201 sys 1.310579


COPY (FROM lineitem) TO '/tmp/lineitem.csv' (FORMAT CSV, PER_THREAD_OUTPUT FALSE);
Run Time (s): real 2.570 user 2.437168 sys 0.111984

COPY (FROM lineitem) TO '/tmp/lineitem2.csv' (FORMAT CSV, PER_THREAD_OUTPUT TRUE);
Run Time (s): real 0.343 user 2.947312 sys 0.143668
```



