### PR TITLE
Shell: add individual SQL queries to the history, instead of individual lines

### DIFF
--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -1561,6 +1561,12 @@ int linenoiseHistoryAdd(const char *line) {
 	linecopy = strdup(line);
 	if (!linecopy)
 		return 0;
+	// replace all newlines with spaces
+	for (auto ptr = linecopy; *ptr; ptr++) {
+		if (*ptr == '\n' || *ptr == '\r') {
+			*ptr = ' ';
+		}
+	}
 	if (history_len == history_max_len) {
 		free(history[0]);
 		memmove(history, history + 1, sizeof(char *) * (history_max_len - 1));

--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -20050,7 +20050,9 @@ static int runOneSqlLine(ShellState *p, char *zSql, FILE *in, int startline){
   open_db(p, 0);
   if( ShellHasFlag(p,SHFLG_Backslash) ) resolve_backslashes(zSql);
   if( p->flgProgress & SHELL_PROGRESS_RESET ) p->nProgress = 0;
+#ifndef SHELL_USE_LOCAL_GETLINE
   if( zSql && *zSql && *zSql != '\3' ) shell_add_history(zSql);
+#endif
   BEGIN_TIMER;
   rc = shell_exec(p, zSql, &zErrMsg);
   END_TIMER;
@@ -20134,7 +20136,9 @@ static int process_input(ShellState *p){
     if( zLine && (zLine[0]=='.' || zLine[0]=='#') && nSql==0 ){
       if( ShellHasFlag(p, SHFLG_Echo) ) printf("%s\n", zLine);
       if( zLine[0]=='.' ){
+#ifndef SHELL_USE_LOCAL_GETLINE
         if( zLine && *zLine && *zLine != '\3' ) shell_add_history(zLine);
+#endif
         rc = do_meta_command(zLine, p);
         if( rc==2 ){ /* exit requested */
           break;

--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -746,7 +746,6 @@ static char *one_input_line(FILE *in, char *zPrior, int isContinuation){
 #else
     free(zPrior);
     zResult = shell_readline(zPrompt);
-    if( zResult && *zResult && *zResult != '\3' ) shell_add_history(zResult);
 #endif
   }
   return zResult;
@@ -20051,6 +20050,7 @@ static int runOneSqlLine(ShellState *p, char *zSql, FILE *in, int startline){
   open_db(p, 0);
   if( ShellHasFlag(p,SHFLG_Backslash) ) resolve_backslashes(zSql);
   if( p->flgProgress & SHELL_PROGRESS_RESET ) p->nProgress = 0;
+  if( zSql && *zSql && *zSql != '\3' ) shell_add_history(zSql);
   BEGIN_TIMER;
   rc = shell_exec(p, zSql, &zErrMsg);
   END_TIMER;
@@ -20134,6 +20134,7 @@ static int process_input(ShellState *p){
     if( zLine && (zLine[0]=='.' || zLine[0]=='#') && nSql==0 ){
       if( ShellHasFlag(p, SHFLG_Echo) ) printf("%s\n", zLine);
       if( zLine[0]=='.' ){
+        if( zLine && *zLine && *zLine != '\3' ) shell_add_history(zLine);
         rc = do_meta_command(zLine, p);
         if( rc==2 ){ /* exit requested */
           break;


### PR DESCRIPTION
Reopening #5406 but without all the git noise

This PR modifies what gets added to the history of the shell - instead of adding individual lines, we now add entire SQL queries to the history. If those queries contain newlines, they are converted into spaces when moving up. This should allow for easier skipping back/forth when executing multi-line queries.

This is now the history behavior:

```sql
D SELECT
> 42;
-- (press up)
D SELECT 42;
```

All newlines are removed and converted to spaces.
