### PR TITLE
Shell: add support for history search

### DIFF
--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -198,6 +198,7 @@ enum KEY_ACTION {
 	CTRL_D = 4,     /* Ctrl-d */
 	CTRL_E = 5,     /* Ctrl-e */
 	CTRL_F = 6,     /* Ctrl-f */
+	CTRL_G = 7,     /* Ctrl-g */
 	CTRL_H = 8,     /* Ctrl-h */
 	TAB = 9,        /* Tab */
 	CTRL_K = 11,    /* Ctrl+k */
@@ -1413,6 +1414,7 @@ static char linenoiseSearch(linenoiseState *l, char c) {
 		break;
 	case CTRL_A: // accept search, move to start of line
 		return acceptSearch(l, CTRL_A);
+	case '\t':
 	case CTRL_E: // accept search - move to end of line
 		return acceptSearch(l, CTRL_E);
 	case CTRL_B: // accept search - move cursor left
@@ -1437,6 +1439,7 @@ static char linenoiseSearch(linenoiseState *l, char c) {
 		searchNext(l);
 		break;
 	case CTRL_C:
+	case CTRL_G:
 		// abort search
 		cancelSearch(l);
 		return 0;
@@ -1554,6 +1557,7 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
 				hintsCallback = hc;
 			}
 			return (int)l.len;
+		case CTRL_G:
 		case CTRL_C: /* ctrl-c */ {
 			l.buf[0] = '\3';
 			// we keep track of whether or not the line was empty by writing \3 to the second position of the line

--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -117,6 +117,7 @@
 #include <unistd.h>
 #include "linenoise.h"
 #include "utf8proc_wrapper.hpp"
+#include <unordered_set>
 #include <vector>
 
 #if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
@@ -1296,10 +1297,15 @@ static void performSearch(linenoiseState *l) {
 	if (l->search_buf.empty()) {
 		return;
 	}
+	std::unordered_set<std::string> matches;
 	auto lsearch = duckdb::StringUtil::Lower(l->search_buf);
 	for (size_t i = history_len; i > 0; i--) {
 		size_t history_index = i - 1;
 		auto lhistory = duckdb::StringUtil::Lower(history[history_index]);
+		if (matches.find(lhistory) != matches.end()) {
+			continue;
+		}
+		matches.insert(lhistory);
 		auto entry = lhistory.find(lsearch);
 		if (entry != duckdb::string::npos) {
 			if (history_index == current_match) {


### PR DESCRIPTION
This PR adds support for history search to the shell by pressing Ctrl+R. The search behaves similar to the history search that ships with `readline`, but with some minor improvements for usability - namely we show the number of matches from the history, and we can cycle through the list of matches using the up/down arrows.

![Screenshot 2022-11-19 at 16 41 54](https://user-images.githubusercontent.com/3978469/202859008-01eb498c-b82f-49b5-9393-03418f35c757.png)

