### PR TITLE
httpfs: check environment vars for AWS Credentials

### DIFF
--- a/extension/httpfs/httpfs-extension.cpp
+++ b/extension/httpfs/httpfs-extension.cpp
@@ -44,6 +44,9 @@ static void LoadInternal(DatabaseInstance &instance) {
 	                          LogicalType::UBIGINT);
 	config.AddExtensionOption("s3_uploader_thread_limit", "S3 Uploader global thread limit (default 50)",
 	                          LogicalType::UBIGINT);
+
+	auto provider = make_unique<AWSEnvironmentCredentialsProvider>(config);
+	provider->SetAll();
 }
 
 void HTTPFsExtension::Load(DuckDB &db) {

--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/chrono.hpp"
+#include "duckdb/main/config.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 #include "httpfs.hpp"
 
@@ -14,6 +15,20 @@
 #include <iostream>
 
 namespace duckdb {
+
+struct AWSEnvironmentCredentialsProvider {
+	static constexpr const char *REGION_ENV_VAR = "AWS_DEFAULT_REGION";
+	static constexpr const char *ACCESS_KEY_ENV_VAR = "AWS_ACCESS_KEY_ID";
+	static constexpr const char *SECRET_KEY_ENV_VAR = "AWS_SECRET_ACCESS_KEY";
+	static constexpr const char *SESSION_TOKEN_ENV_VAR = "AWS_SESSION_TOKEN";
+
+	explicit AWSEnvironmentCredentialsProvider(DBConfig &config) : config(config) {};
+
+	DBConfig &config;
+
+	void SetExtensionOptionValue(string key, const char *env_var);
+	void SetAll();
+};
 
 struct S3AuthParams {
 	string region;

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -142,7 +142,7 @@ void AWSEnvironmentCredentialsProvider::SetExtensionOptionValue(string key, cons
 	static char *evar;
 
 	if ((evar = std::getenv(env_var_name)) != NULL)
-		this->config.options.set_variables[key] = Value(evar);
+		this->config.SetOption(key, Value(evar));
 }
 
 void AWSEnvironmentCredentialsProvider::SetAll() {

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -138,6 +138,20 @@ string S3FileSystem::UrlEncode(const string &input, bool encode_slash) {
 	return result;
 }
 
+void AWSEnvironmentCredentialsProvider::SetExtensionOptionValue(string key, const char *env_var_name) {
+	static char *evar;
+
+	if ((evar = std::getenv(env_var_name)) != NULL)
+		this->config.options.set_variables[key] = Value(evar);
+}
+
+void AWSEnvironmentCredentialsProvider::SetAll() {
+	this->SetExtensionOptionValue("s3_region", this->REGION_ENV_VAR);
+	this->SetExtensionOptionValue("s3_access_key_id", this->ACCESS_KEY_ENV_VAR);
+	this->SetExtensionOptionValue("s3_secret_access_key", this->SECRET_KEY_ENV_VAR);
+	this->SetExtensionOptionValue("s3_session_token", this->SESSION_TOKEN_ENV_VAR);
+}
+
 S3AuthParams S3AuthParams::ReadFrom(FileOpener *opener) {
 	string region;
 	string access_key_id;


### PR DESCRIPTION
- Read and set AWS environment variables when `httpfs` extension is loaded
    - AWS_DEFAULT_REGION 
    - AWS_ACCESS_KEY_ID 
    - AWS_SECRET_ACCESS_KEY 
    - AWS_SESSION_TOKEN
- issue #4021 (partially)