### PR TITLE
Fix bug causing loss of order preservation in insert

### DIFF
--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -1,10 +1,11 @@
 #include "duckdb/execution/operator/persistent/physical_batch_insert.hpp"
-#include "duckdb/parser/parsed_data/create_table_info.hpp"
-#include "duckdb/storage/table_io_manager.hpp"
+
 #include "duckdb/parallel/thread_context.hpp"
-#include "duckdb/storage/table/row_group_collection.hpp"
-#include "duckdb/transaction/local_storage.hpp"
+#include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/storage/data_table.hpp"
+#include "duckdb/storage/table/row_group_collection.hpp"
+#include "duckdb/storage/table_io_manager.hpp"
+#include "duckdb/transaction/local_storage.hpp"
 
 namespace duckdb {
 
@@ -48,22 +49,9 @@ public:
 		if (Empty()) {
 			return nullptr;
 		}
-		unique_ptr<RowGroupCollection> new_collection;
-		if (current_collections.size() == 1) {
-			// we have gathered only one row group collection: merge it directly
-			new_collection = move(current_collections[0]);
-		} else {
+		unique_ptr<RowGroupCollection> new_collection = move(current_collections[0]);
+		if (current_collections.size() > 1) {
 			// we have gathered multiple collections: create one big collection and merge that
-			// find the biggest collection
-			idx_t biggest_index = 0;
-			for (idx_t i = 1; i < current_collections.size(); i++) {
-				D_ASSERT(current_collections[i]);
-				if (current_collections[i]->GetTotalRows() > current_collections[biggest_index]->GetTotalRows()) {
-					biggest_index = i;
-				}
-			}
-			// now append all the other collections to this collection
-			new_collection = move(current_collections[biggest_index]);
 			auto &types = new_collection->GetTypes();
 			TableAppendState append_state;
 			new_collection->InitializeAppend(append_state);

--- a/test/sql/order/order_parallel_ctas.test_slow
+++ b/test/sql/order/order_parallel_ctas.test_slow
@@ -1,0 +1,64 @@
+# name: test/sql/order/order_parallel_ctas.test_slow
+# description: Test parallel CREATE TABLE AS with ORDER BY
+# group: [order]
+
+require skip_reload
+
+# load the DB from disk
+load __TEST_DIR__/order_parallel_ctas.db
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+statement ok
+pragma verify_parallelism
+
+statement ok
+create table integers as select range i from range(100000) order by random()
+
+loop i 0 20
+
+statement ok
+create table sorted_integers as select i from integers order by i
+
+restart
+
+# empty result if sorted
+query T
+select * FROM sorted_integers QUALIFY NOT (i>lag(i) over () OR lag(i) OVER () IS NULL)
+----
+
+
+statement ok
+drop table sorted_integers
+
+endloop
+
+# now we do the same but with a UNION ALL
+
+loop i 0 20
+
+statement ok
+create table sorted_integers as
+with p1 as (
+    select i from integers order by i
+), p2 as (
+    select i + 100000 from integers order by i
+)
+select * from p1 union all select * from p2
+
+restart
+
+# empty result if sorted
+query T
+select * FROM sorted_integers QUALIFY NOT (i>lag(i) over () OR lag(i) OVER () IS NULL)
+----
+
+
+statement ok
+drop table sorted_integers
+
+endloop


### PR DESCRIPTION
An optimization in `physical_batch_insert.cpp` caused the insertion order to be lost, which became apparent with a test that created a table from a query with `UNION ALL`. In short, the optimization finds the largest `RowGroupCollection`, and appends the rest of the data to it. However, if the largest `RowGroupCollection` came from the second `SELECT` in the `UNION ALL` query, then the second part would be appended first, causing the insertion order to be incorrect. I've removed this optimization and added a test for it.

This was uncovered when working on feature #5403