### PR TITLE
Allocator: throw std::bad_alloc if a malloc allocation fails

### DIFF
--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -26,6 +26,9 @@ AllocatedData::AllocatedData() : allocator(nullptr), pointer(nullptr), allocated
 
 AllocatedData::AllocatedData(Allocator &allocator, data_ptr_t pointer, idx_t allocated_size)
     : allocator(&allocator), pointer(pointer), allocated_size(allocated_size) {
+	if (!pointer) {
+		throw InternalException("AllocatedData object constructed with nullptr");
+	}
 }
 AllocatedData::~AllocatedData() {
 	Reset();

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -3,7 +3,6 @@
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/atomic.hpp"
 #include "duckdb/common/exception.hpp"
-#include "duckdb/common/likely.hpp"
 
 #include <cstdint>
 
@@ -120,7 +119,7 @@ Allocator::~Allocator() {
 
 data_ptr_t Allocator::AllocateData(idx_t size) {
 	D_ASSERT(size > 0);
-	if (DUCKDB_UNLIKELY(size >= MAXIMUM_ALLOC_SIZE)) {
+	if (size >= MAXIMUM_ALLOC_SIZE) {
 		D_ASSERT(false);
 		throw InternalException("Requested allocation size of %llu is out of range - maximum allocation size is %llu",
 		                        size, MAXIMUM_ALLOC_SIZE);
@@ -130,7 +129,7 @@ data_ptr_t Allocator::AllocateData(idx_t size) {
 	D_ASSERT(private_data);
 	private_data->debug_info->AllocateData(result, size);
 #endif
-	if (DUCKDB_UNLIKELY(!result)) {
+	if (!result) {
 		throw std::bad_alloc();
 	}
 	return result;
@@ -152,7 +151,7 @@ data_ptr_t Allocator::ReallocateData(data_ptr_t pointer, idx_t old_size, idx_t s
 	if (!pointer) {
 		return nullptr;
 	}
-	if (DUCKDB_UNLIKELY(size >= MAXIMUM_ALLOC_SIZE)) {
+	if (size >= MAXIMUM_ALLOC_SIZE) {
 		D_ASSERT(false);
 		throw InternalException(
 		    "Requested re-allocation size of %llu is out of range - maximum allocation size is %llu", size,
@@ -163,7 +162,7 @@ data_ptr_t Allocator::ReallocateData(data_ptr_t pointer, idx_t old_size, idx_t s
 	D_ASSERT(private_data);
 	private_data->debug_info->ReallocateData(pointer, new_pointer, old_size, size);
 #endif
-	if (DUCKDB_UNLIKELY(!new_pointer)) {
+	if (!new_pointer) {
 		throw std::bad_alloc();
 	}
 	return new_pointer;

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -149,6 +149,9 @@ data_ptr_t Allocator::ReallocateData(data_ptr_t pointer, idx_t old_size, idx_t s
 	D_ASSERT(private_data);
 	private_data->debug_info->ReallocateData(pointer, new_pointer, old_size, size);
 #endif
+	if (DUCKDB_UNLIKELY(!new_pointer)) {
+		throw std::bad_alloc();
+	}
 	return new_pointer;
 }
 

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -117,6 +117,11 @@ Allocator::~Allocator() {
 
 data_ptr_t Allocator::AllocateData(idx_t size) {
 	D_ASSERT(size > 0);
+	if (DUCKDB_UNLIKELY(size >= MAXIMUM_ALLOC_SIZE)) {
+		D_ASSERT(false);
+		throw InternalException("Requested allocation size of %llu is out of range - maximum allocation size is %llu",
+		                        size, MAXIMUM_ALLOC_SIZE);
+	}
 	auto result = allocate_function(private_data.get(), size);
 #ifdef DEBUG
 	D_ASSERT(private_data);
@@ -143,6 +148,12 @@ void Allocator::FreeData(data_ptr_t pointer, idx_t size) {
 data_ptr_t Allocator::ReallocateData(data_ptr_t pointer, idx_t old_size, idx_t size) {
 	if (!pointer) {
 		return nullptr;
+	}
+	if (DUCKDB_UNLIKELY(size >= MAXIMUM_ALLOC_SIZE)) {
+		D_ASSERT(false);
+		throw InternalException(
+		    "Requested re-allocation size of %llu is out of range - maximum allocation size is %llu", size,
+		    MAXIMUM_ALLOC_SIZE);
 	}
 	auto new_pointer = reallocate_function(private_data.get(), pointer, old_size, size);
 #ifdef DEBUG

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/atomic.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/likely.hpp"
 
 #include <cstdint>
 
@@ -121,6 +122,9 @@ data_ptr_t Allocator::AllocateData(idx_t size) {
 	D_ASSERT(private_data);
 	private_data->debug_info->AllocateData(result, size);
 #endif
+	if (DUCKDB_UNLIKELY(!result)) {
+		throw std::bad_alloc();
+	}
 	return result;
 }
 

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -61,6 +61,9 @@ private:
 };
 
 class Allocator {
+	// 281TB ought to be enough for anybody
+	static constexpr const idx_t MAXIMUM_ALLOC_SIZE = 281474976710656ULL;
+
 public:
 	DUCKDB_API Allocator();
 	DUCKDB_API Allocator(allocate_function_ptr_t allocate_function_p, free_function_ptr_t free_function_p,


### PR DESCRIPTION
This fixes crashes when run in very high memory pressure situations by correctly throwing a `std::bad_alloc` when allocations through our allocator fail. 