### PR TITLE
Issue #5366: QUANTILE_DISC Intervals

### DIFF
--- a/src/function/aggregate/holistic/quantile.cpp
+++ b/src/function/aggregate/holistic/quantile.cpp
@@ -320,7 +320,8 @@ struct Interpolator {
 template <>
 struct Interpolator<true> {
 	Interpolator(const double q, const idx_t n_p)
-	    : n(n_p), RN((double)(n_p - 1) * q), FRN(floor(RN)), CRN(FRN), begin(0), end(n_p) {
+	    : n(n_p), RN((double)(n_p * q)), FRN(MaxValue<idx_t>(1, n_p - floor(n_p - RN)) - 1), CRN(FRN), begin(0),
+	      end(n_p) {
 	}
 
 	template <class INPUT_TYPE, class TARGET_TYPE, typename ACCESSOR = QuantileDirect<INPUT_TYPE>>

--- a/test/sql/aggregate/aggregates/test_quantile_disc.test
+++ b/test/sql/aggregate/aggregates/test_quantile_disc.test
@@ -2,6 +2,8 @@
 # description: Test QUANTILE_DISC aggregate
 # group: [aggregates]
 
+require 64bit
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/aggregate/aggregates/test_quantile_disc_list.test
+++ b/test/sql/aggregate/aggregates/test_quantile_disc_list.test
@@ -2,6 +2,8 @@
 # description: Test QUANTILE_DISC operator with LIST quantiles
 # group: [aggregates]
 
+require 64bit
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/aggregate/aggregates/test_quantile_disc_list.test
+++ b/test/sql/aggregate/aggregates/test_quantile_disc_list.test
@@ -139,6 +139,15 @@ SELECT quantile_disc(r, []) FROM quantiles
 ----
 []
 
+# Oracle boundaries
+query I
+SELECT quantile_disc(col, [0.1, 0.32, 0.33, 0.34, 0.49, .5, .51, 0.75, 0.9, 0.999, 1])
+FROM VALUES (0), (1), (2), (10) AS tab(col);
+----
+[0, 1, 1, 1, 1, 1, 2, 2, 10, 10, 10]
+
+
+# Invalid use
 statement error
 SELECT quantile_disc(r, [-0.1, 0.5, 0.9]) FROM quantiles
 

--- a/test/sql/types/nested/list/list_aggr_parameter.test
+++ b/test/sql/types/nested/list/list_aggr_parameter.test
@@ -11,9 +11,9 @@ SELECT list_aggr(list(i), 'quantile', 0.5) FROM range(1, 11) tbl(i);
 5
 
 query I
-SELECT list_aggr(list(i), 'quantile', [0.2, 0.5, 0.8]) FROM range(1, 11) tbl(i);
+SELECT list_aggr(list(i), 'quantile', [0.25, 0.5, 0.75]) FROM range(1, 11) tbl(i);
 ----
-[2, 5, 8]
+[3, 5, 8]
 
 query I
 SELECT list_aggr(list(i), 'string_agg', '|') FROM range(1, 4) tbl(i);

--- a/test/sql/types/timestamp/test_infinite_time.test
+++ b/test/sql/types/timestamp/test_infinite_time.test
@@ -187,7 +187,7 @@ FROM specials;
 {-infinity=1, 1970-01-01 00:00:00=1, infinity=1}	{-infinity=1, 1970-01-01 00:00:00+00=1, infinity=1}	{-infinity=1, 1970-01-01=1, infinity=1}
 
 query III
-SELECT QUANTILE_DISC(ts, 0.34), QUANTILE_DISC(tstz, 0.34), QUANTILE_DISC(dt, 0.34)
+SELECT QUANTILE_DISC(ts, 0.32), QUANTILE_DISC(tstz, 0.32), QUANTILE_DISC(dt, 0.32)
 FROM specials;
 ----
 -infinity	-infinity	-infinity

--- a/test/sql/window/test_quantile_window.test
+++ b/test/sql/window/test_quantile_window.test
@@ -286,12 +286,12 @@ SELECT r, QUANTILE_DISC(i, [0.25, 0.5, 0.75]) OVER (ORDER BY r ROWS BETWEEN p PR
 FROM t
 ORDER BY 1
 ----
-0	[0, 1, 1]
+0	[0, 1, 2]
 1	[0, 1, 2]
 2	[1, 2, 3]
 3	[2, 3, 4]
-4	[3, 4, 4]
-5	[4, 4, 4]
+4	[3, 4, 5]
+5	[4, 4, 5]
 
 # Moving discrete list with NULLs
 query II
@@ -307,12 +307,12 @@ SELECT r, QUANTILE_DISC(i, [0.25, 0.5, 0.75]) OVER (ORDER BY r ROWS BETWEEN p PR
 FROM t
 ORDER BY 1
 ----
-0	[1, 1, 1]
-1	[1, 2, 2]
+0	[1, 1, 2]
+1	[1, 2, 3]
 2	[1, 2, 3]
 3	[2, 3, 4]
-4	[3, 4, 4]
-5	[4, 4, 4]
+4	[3, 4, 5]
+5	[4, 4, 5]
 
 # Moving discrete list with all NULLs
 query II
@@ -501,12 +501,12 @@ SELECT r, QUANTILE_DISC(i, [0.25, 0.5, 0.75]) OVER (ORDER BY r ROWS BETWEEN p PR
 FROM t
 ORDER BY 1
 ----
-0	[1, 1, 1]
-1	[1, 2, 2]
+0	[1, 1, 2]
+1	[1, 2, 3]
 2	[1, 2, 3]
 3	[2, 3, 4]
-4	[3, 4, 4]
-5	[4, 4, 4]
+4	[3, 4, 5]
+5	[4, 4, 5]
 
 query II
 WITH t(r, i, p, f) AS (VALUES


### PR DESCRIPTION
Change the discrete interval boundaries to match Oracle.
Modify or disable the tests on 32 bit thanks to DECIMAL => DOUBLE conversion differences.
