### PR TITLE
Fix the use of COLUMNS(...) in ORDER BY clause

### DIFF
--- a/src/parser/transform/helpers/transform_orderby.cpp
+++ b/src/parser/transform/helpers/transform_orderby.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/transformer.hpp"
+#include "duckdb/parser/expression/star_expression.hpp"
 
 namespace duckdb {
 
@@ -35,6 +36,13 @@ bool Transformer::TransformOrderBy(duckdb_libpgquery::PGList *order, vector<Orde
 				throw NotImplementedException("Unimplemented order by type");
 			}
 			auto order_expression = TransformExpression(target);
+			if (order_expression->GetExpressionClass() == ExpressionClass::STAR) {
+				auto &star_expr = (StarExpression &)*order_expression;
+				D_ASSERT(star_expr.relation_name.empty());
+				if (star_expr.columns) {
+					throw ParserException("COLUMNS expr is not supported in ORDER BY");
+				}
+			}
 			result.emplace_back(type, null_order, move(order_expression));
 		} else {
 			throw NotImplementedException("ORDER BY list member type %d\n", temp->type);

--- a/test/sql/parser/test_columns.test
+++ b/test/sql/parser/test_columns.test
@@ -78,3 +78,10 @@ SELECT COLUMNS(*) + COLUMNS(* EXCLUDE(j)) FROM integers
 # COLUMNS in subquery without FROM clause
 statement error
 SELECT (SELECT COLUMNS(*)) FROM integers
+
+# COLUMNS in order by cluase
+statement error
+SELECT * FROM integers ORDER BY COLUMNS('index[0-9]');
+
+statement error
+SELECT * FROM integers ORDER BY COLUMNS(*);


### PR DESCRIPTION
```SQL
CREATE TABLE test (x INT, y INT);

SELECT x FROM test ORDER BY COLUMNS('y');

┌───────────────────────────┐
│          ORDER_BY         │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│          ORDERS:          │
│        test.x ASC        │
└─────────────┬─────────────┘
```

Temporarily banned. (or it should be expanded correctly).