### PR TITLE
Parquet Reader: Re-use (de)compression and dictionary buffers and allocate powers of two

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -53,6 +53,10 @@ ColumnReader::ColumnReader(ParquetReader &reader, LogicalType type_p, const Sche
 ColumnReader::~ColumnReader() {
 }
 
+Allocator &ColumnReader::GetAllocator() {
+	return reader.allocator;
+}
+
 ParquetReader &ColumnReader::Reader() {
 	return reader;
 }
@@ -219,14 +223,14 @@ void ColumnReader::PreparePageV2(PageHeader &page_hdr) {
 
 void ColumnReader::AllocateBlock(idx_t size) {
 	if (!block) {
-		block = make_shared<ResizeableBuffer>(this->reader.allocator, size);
+		block = make_shared<ResizeableBuffer>(GetAllocator(), size);
 	} else {
-		block->resize(this->reader.allocator, size);
+		block->resize(GetAllocator(), size);
 	}
 }
 
 void ColumnReader::AllocateCompressed(idx_t size) {
-	compressed_buffer.resize(this->reader.allocator, size);
+	compressed_buffer.resize(GetAllocator(), size);
 }
 
 void ColumnReader::PreparePage(PageHeader &page_hdr) {

--- a/extension/parquet/include/callback_column_reader.hpp
+++ b/extension/parquet/include/callback_column_reader.hpp
@@ -19,6 +19,9 @@ template <class PARQUET_PHYSICAL_TYPE, class DUCKDB_PHYSICAL_TYPE,
 class CallbackColumnReader
     : public TemplatedColumnReader<DUCKDB_PHYSICAL_TYPE,
                                    CallbackParquetValueConversion<PARQUET_PHYSICAL_TYPE, DUCKDB_PHYSICAL_TYPE, FUNC>> {
+	using BaseType =
+	    TemplatedColumnReader<DUCKDB_PHYSICAL_TYPE,
+	                          CallbackParquetValueConversion<PARQUET_PHYSICAL_TYPE, DUCKDB_PHYSICAL_TYPE, FUNC>>;
 
 public:
 	CallbackColumnReader(ParquetReader &reader, LogicalType type_p, const SchemaElement &schema_p, idx_t file_idx_p,
@@ -29,8 +32,8 @@ public:
 	}
 
 protected:
-	void Dictionary(shared_ptr<ByteBuffer> dictionary_data, idx_t num_entries) {
-		this->dict = make_shared<ResizeableBuffer>(this->reader.allocator, num_entries * sizeof(DUCKDB_PHYSICAL_TYPE));
+	void Dictionary(shared_ptr<ResizeableBuffer> dictionary_data, idx_t num_entries) {
+		BaseType::AllocateDict(num_entries * sizeof(DUCKDB_PHYSICAL_TYPE));
 		auto dict_ptr = (DUCKDB_PHYSICAL_TYPE *)this->dict->ptr;
 		for (idx_t i = 0; i < num_entries; i++) {
 			dict_ptr[i] = FUNC(dictionary_data->read<PARQUET_PHYSICAL_TYPE>());

--- a/extension/parquet/include/column_reader.hpp
+++ b/extension/parquet/include/column_reader.hpp
@@ -74,6 +74,7 @@ public:
 	virtual unique_ptr<BaseStatistics> Stats(idx_t row_group_idx_p, const std::vector<ColumnChunk> &columns);
 
 protected:
+	Allocator &GetAllocator();
 	// readers that use the default Read() need to implement those
 	virtual void Plain(shared_ptr<ByteBuffer> plain_data, uint8_t *defines, idx_t num_values, parquet_filter_t &filter,
 	                   idx_t result_offset, Vector &result);

--- a/extension/parquet/include/column_reader.hpp
+++ b/extension/parquet/include/column_reader.hpp
@@ -77,7 +77,7 @@ protected:
 	// readers that use the default Read() need to implement those
 	virtual void Plain(shared_ptr<ByteBuffer> plain_data, uint8_t *defines, idx_t num_values, parquet_filter_t &filter,
 	                   idx_t result_offset, Vector &result);
-	virtual void Dictionary(shared_ptr<ByteBuffer> dictionary_data, idx_t num_entries);
+	virtual void Dictionary(shared_ptr<ResizeableBuffer> dictionary_data, idx_t num_entries);
 	virtual void Offsets(uint32_t *offsets, uint8_t *defines, idx_t num_values, parquet_filter_t &filter,
 	                     idx_t result_offset, Vector &result);
 
@@ -109,6 +109,8 @@ protected:
 	idx_t pending_skips = 0;
 
 private:
+	void AllocateBlock(idx_t size);
+	void AllocateCompressed(idx_t size);
 	void PrepareRead(parquet_filter_t &filter);
 	void PreparePage(PageHeader &page_hdr);
 	void PrepareDataPage(PageHeader &page_hdr);
@@ -124,6 +126,7 @@ private:
 
 	shared_ptr<ResizeableBuffer> block;
 
+	ResizeableBuffer compressed_buffer;
 	ResizeableBuffer offset_buffer;
 
 	unique_ptr<RleBpDecoder> dict_decoder;

--- a/extension/parquet/include/resizable_buffer.hpp
+++ b/extension/parquet/include/resizable_buffer.hpp
@@ -74,7 +74,7 @@ public:
 			return;
 		}
 		if (new_size > alloc_len) {
-			alloc_len = new_size;
+			alloc_len = NextPowerOfTwo(new_size);
 			allocated_data = allocator.Allocate(alloc_len);
 			ptr = (char *)allocated_data.get();
 		}

--- a/extension/parquet/include/string_column_reader.hpp
+++ b/extension/parquet/include/string_column_reader.hpp
@@ -29,7 +29,7 @@ public:
 	idx_t fixed_width_string_length;
 
 public:
-	void Dictionary(shared_ptr<ByteBuffer> dictionary_data, idx_t num_entries) override;
+	void Dictionary(shared_ptr<ResizeableBuffer> dictionary_data, idx_t num_entries) override;
 
 	uint32_t VerifyString(const char *str_data, uint32_t str_len);
 

--- a/extension/parquet/include/templated_column_reader.hpp
+++ b/extension/parquet/include/templated_column_reader.hpp
@@ -35,10 +35,18 @@ public:
 	                      idx_t max_define_p, idx_t max_repeat_p)
 	    : ColumnReader(reader, move(type_p), schema_p, schema_idx_p, max_define_p, max_repeat_p) {};
 
-	shared_ptr<ByteBuffer> dict;
+	shared_ptr<ResizeableBuffer> dict;
 
 public:
-	void Dictionary(shared_ptr<ByteBuffer> data, idx_t num_entries) override {
+	void AllocateDict(idx_t size) {
+		if (!dict) {
+			dict = make_shared<ResizeableBuffer>(this->reader.allocator, size);
+		} else {
+			dict->resize(this->reader.allocator, size);
+		}
+	}
+
+	void Dictionary(shared_ptr<ResizeableBuffer> data, idx_t num_entries) override {
 		dict = move(data);
 	}
 

--- a/extension/parquet/include/templated_column_reader.hpp
+++ b/extension/parquet/include/templated_column_reader.hpp
@@ -40,9 +40,9 @@ public:
 public:
 	void AllocateDict(idx_t size) {
 		if (!dict) {
-			dict = make_shared<ResizeableBuffer>(this->reader.allocator, size);
+			dict = make_shared<ResizeableBuffer>(GetAllocator(), size);
 		} else {
-			dict->resize(this->reader.allocator, size);
+			dict->resize(GetAllocator(), size);
 		}
 	}
 

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -130,7 +130,7 @@ data_ptr_t Allocator::AllocateData(idx_t size) {
 	private_data->debug_info->AllocateData(result, size);
 #endif
 	if (!result) {
-		throw std::bad_alloc();
+		throw OutOfMemoryException("Failed to allocate block of %llu bytes", size);
 	}
 	return result;
 }
@@ -163,7 +163,7 @@ data_ptr_t Allocator::ReallocateData(data_ptr_t pointer, idx_t old_size, idx_t s
 	private_data->debug_info->ReallocateData(pointer, new_pointer, old_size, size);
 #endif
 	if (!new_pointer) {
-		throw std::bad_alloc();
+		throw OutOfMemoryException("Failed to re-allocate block of %llu bytes", size);
 	}
 	return new_pointer;
 }

--- a/src/include/duckdb/common/constants.hpp
+++ b/src/include/duckdb/common/constants.hpp
@@ -144,6 +144,6 @@ struct PhysicalIndex {
 	}
 };
 
-uint64_t NextPowerOfTwo(uint64_t v);
+DUCKDB_API uint64_t NextPowerOfTwo(uint64_t v);
 
 } // namespace duckdb


### PR DESCRIPTION
This reduces memory fragmentation caused by the Parquet reader by re-using buffers as much as possible and by allocating blocks as powers-of-two instead of the exact size as specified in the Parquet file.