### PR TITLE
print profiling output for deserialized logical query plans

### DIFF
--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -369,7 +369,10 @@ void QueryProfiler::QueryTreeToStream(std::ostream &ss) const {
 	ss << "│└───────────────────────────────────┘│\n";
 	ss << "└─────────────────────────────────────┘\n";
 	ss << StringUtil::Replace(query, "\n", " ") + "\n";
-	if (query.empty()) {
+	
+	// checking the tree to ensure the query is really empty
+	// the query string is empty when a logical plan is deserialized
+	if (query.empty() && !root) {
 		return;
 	}
 
@@ -532,7 +535,7 @@ string QueryProfiler::ToJSON() const {
 	if (!IsEnabled()) {
 		return "{ \"result\": \"disabled\" }\n";
 	}
-	if (query.empty()) {
+	if (query.empty() && !root) {
 		return "{ \"result\": \"empty\" }\n";
 	}
 	if (!root) {

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -369,7 +369,7 @@ void QueryProfiler::QueryTreeToStream(std::ostream &ss) const {
 	ss << "│└───────────────────────────────────┘│\n";
 	ss << "└─────────────────────────────────────┘\n";
 	ss << StringUtil::Replace(query, "\n", " ") + "\n";
-	
+
 	// checking the tree to ensure the query is really empty
 	// the query string is empty when a logical plan is deserialized
 	if (query.empty() && !root) {


### PR DESCRIPTION
fixes #5357 

what happened: when I deserialize a logical query plan and try to obtain profiling information, everything works fine but there is a check in `query_profiler.cpp` which disables the print stream if the query string is empty. this unfortunately is the case when only the logical plan is given, therefore we need also some additional check to make sure the query is actually empty. I implemented this by checking if the root of the tree exists as well. 

note: I tried testing it, but could not come up with an empty query string situation that also triggers the profiler - if I try passing an empty string through the API, simply nothing happens (duh). however as always it Works On My Laptop^TM and if I try profiling a deserialized logical plan, it behaves as expected  