### PR TITLE
Arrow stream ingestion for JDBC client

### DIFF
--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -354,6 +354,15 @@ void ArrowTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	arrow.filter_pushdown = true;
 	arrow.filter_prune = true;
 	set.AddFunction(arrow);
+
+	TableFunction arrow_dumb("arrow_scan_dumb", {LogicalType::POINTER, LogicalType::POINTER, LogicalType::POINTER},
+	                    ArrowScanFunction, ArrowScanBind, ArrowScanInitGlobal, ArrowScanInitLocal);
+	arrow_dumb.cardinality = ArrowScanCardinality;
+	arrow_dumb.get_batch_index = ArrowGetBatchIndex;
+	arrow_dumb.projection_pushdown = false;
+	arrow_dumb.filter_pushdown = false;
+	arrow_dumb.filter_prune = false;
+	set.AddFunction(arrow_dumb);
 }
 
 void BuiltinFunctions::RegisterArrowFunctions() {

--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -356,7 +356,7 @@ void ArrowTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	set.AddFunction(arrow);
 
 	TableFunction arrow_dumb("arrow_scan_dumb", {LogicalType::POINTER, LogicalType::POINTER, LogicalType::POINTER},
-	                    ArrowScanFunction, ArrowScanBind, ArrowScanInitGlobal, ArrowScanInitLocal);
+	                         ArrowScanFunction, ArrowScanBind, ArrowScanInitGlobal, ArrowScanInitLocal);
 	arrow_dumb.cardinality = ArrowScanCardinality;
 	arrow_dumb.get_batch_index = ArrowGetBatchIndex;
 	arrow_dumb.projection_pushdown = false;

--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/main/db_instance_cache.hpp"
 #include "duckdb/common/arrow/result_arrow_wrapper.hpp"
+#include "duckdb/function/table/arrow.hpp"
 
 using namespace duckdb;
 using namespace std;
@@ -949,4 +950,51 @@ JNIEXPORT jlong JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1arrow_1stream
 
 	auto wrapper = new ResultArrowArrayStreamWrapper(move(res_ref->res), batch_size);
 	return (jlong)&wrapper->stream;
+}
+
+
+class JavaArrowTabularStreamFactory {
+public:
+	JavaArrowTabularStreamFactory(ArrowArrayStream* stream_ptr_p)
+	    : stream_ptr(stream_ptr_p) {};
+
+	~JavaArrowTabularStreamFactory() {
+		printf("close()\n");
+		stream_ptr->release(stream_ptr);
+	}
+
+	static unique_ptr<ArrowArrayStreamWrapper> Produce(uintptr_t factory_p, ArrowStreamParameters &parameters) {
+		// TODO what do we do with parameters?
+		auto factory = (JavaArrowTabularStreamFactory*)factory_p;
+		auto res = make_unique<ArrowArrayStreamWrapper>();
+		res->arrow_array_stream = *factory->stream_ptr;
+		return res;
+	}
+
+	static void GetSchema(uintptr_t factory_p, ArrowSchemaWrapper &schema) {
+	    auto factory = (JavaArrowTabularStreamFactory*)factory_p;
+		factory->stream_ptr->get_schema(factory->stream_ptr, &schema.arrow_schema);
+		return;
+	}
+
+	ArrowArrayStream* stream_ptr;
+};
+
+
+
+
+JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1arrow_1register
+    (JNIEnv *env , jclass, jobject conn_ref_buf, jlong arrow_array_stream_pointer, jbyteArray name_j) {
+
+	auto conn = get_connection(env, conn_ref_buf);
+	auto name = byte_array_to_string(env, name_j);
+
+	auto arrow_array_stream = (ArrowArrayStream*) (uintptr_t) arrow_array_stream_pointer;
+
+	auto factory = new JavaArrowTabularStreamFactory(arrow_array_stream);
+	vector<Value> parameters;
+	parameters.push_back(Value::POINTER((uintptr_t)factory));
+	parameters.push_back(Value::POINTER((uintptr_t)JavaArrowTabularStreamFactory::Produce));
+	parameters.push_back(Value::POINTER((uintptr_t)JavaArrowTabularStreamFactory::GetSchema));
+	conn->TableFunction("arrow_scan_dumb", parameters)->CreateView(name, true, true);
 }

--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -956,11 +956,6 @@ class JavaArrowTabularStreamFactory {
 public:
 	JavaArrowTabularStreamFactory(ArrowArrayStream *stream_ptr_p) : stream_ptr(stream_ptr_p) {};
 
-	~JavaArrowTabularStreamFactory() {
-		printf("close()\n");
-		stream_ptr->release(stream_ptr);
-	}
-
 	static unique_ptr<ArrowArrayStreamWrapper> Produce(uintptr_t factory_p, ArrowStreamParameters &parameters) {
 
 		auto factory = (JavaArrowTabularStreamFactory *)factory_p;

--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -952,11 +952,9 @@ JNIEXPORT jlong JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1arrow_1stream
 	return (jlong)&wrapper->stream;
 }
 
-
 class JavaArrowTabularStreamFactory {
 public:
-	JavaArrowTabularStreamFactory(ArrowArrayStream* stream_ptr_p)
-	    : stream_ptr(stream_ptr_p) {};
+	JavaArrowTabularStreamFactory(ArrowArrayStream *stream_ptr_p) : stream_ptr(stream_ptr_p) {};
 
 	~JavaArrowTabularStreamFactory() {
 		printf("close()\n");
@@ -964,32 +962,38 @@ public:
 	}
 
 	static unique_ptr<ArrowArrayStreamWrapper> Produce(uintptr_t factory_p, ArrowStreamParameters &parameters) {
-		// TODO what do we do with parameters?
-		auto factory = (JavaArrowTabularStreamFactory*)factory_p;
+
+		auto factory = (JavaArrowTabularStreamFactory *)factory_p;
+		if (!factory->stream_ptr->release) {
+			throw InvalidInputException("This stream has been released");
+		}
 		auto res = make_unique<ArrowArrayStreamWrapper>();
 		res->arrow_array_stream = *factory->stream_ptr;
+		factory->stream_ptr->release = nullptr;
 		return res;
 	}
 
 	static void GetSchema(uintptr_t factory_p, ArrowSchemaWrapper &schema) {
-	    auto factory = (JavaArrowTabularStreamFactory*)factory_p;
+		auto factory = (JavaArrowTabularStreamFactory *)factory_p;
+		if (!factory->stream_ptr->release) {
+			throw InvalidInputException("This stream has been released");
+		}
 		factory->stream_ptr->get_schema(factory->stream_ptr, &schema.arrow_schema);
 		return;
 	}
 
-	ArrowArrayStream* stream_ptr;
+	ArrowArrayStream *stream_ptr;
 };
 
-
-
-
-JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1arrow_1register
-    (JNIEnv *env , jclass, jobject conn_ref_buf, jlong arrow_array_stream_pointer, jbyteArray name_j) {
+JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1arrow_1register(JNIEnv *env, jclass,
+                                                                                  jobject conn_ref_buf,
+                                                                                  jlong arrow_array_stream_pointer,
+                                                                                  jbyteArray name_j) {
 
 	auto conn = get_connection(env, conn_ref_buf);
 	auto name = byte_array_to_string(env, name_j);
 
-	auto arrow_array_stream = (ArrowArrayStream*) (uintptr_t) arrow_array_stream_pointer;
+	auto arrow_array_stream = (ArrowArrayStream *)(uintptr_t)arrow_array_stream_pointer;
 
 	auto factory = new JavaArrowTabularStreamFactory(arrow_array_stream);
 	vector<Value> parameters;

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBNative.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBNative.java
@@ -95,7 +95,9 @@ public class DuckDBNative {
 	
 	protected static native int duckdb_jdbc_fetch_size();
 
-	protected static native long duckdb_jdbc_arrow_stream(ByteBuffer appender_ref, long batch_size);
+	protected static native long duckdb_jdbc_arrow_stream(ByteBuffer res_ref, long batch_size);
+	
+	protected static native void duckdb_jdbc_arrow_register(ByteBuffer conn_ref, long arrow_array_stream_pointer, byte[] name);
 
 	protected static native ByteBuffer duckdb_jdbc_create_appender(ByteBuffer conn_ref, byte[] schema_name, byte[] table_name) throws SQLException;
 


### PR DESCRIPTION
This adds a new method to the DuckDB JDBC client to read Arrow streams like views. Here is an example:

```Java
// arrow stuff
BufferAllocator allocator = new RootAllocator();
ArrowStreamReader reader = null; /* should not be null of course */
ArrowArrayStream arrow_array_stream = ArrowArrayStream.allocateNew(allocator);
Data.exportArrayStream(allocator, reader, arrow_array_stream);

// duckdb stuff
Class.forName("org.duckdb.DuckDBDriver");
DuckDBConnection conn = (DuckDBConnection) DriverManager.getConnection("jdbc:duckdb:");
conn.registerArrowStream("adsf", arrow_array_stream);

// run a query
Statement stmt = conn.createStatement();
ResultSet rs = (DuckDBResultSet) stmt.executeQuery("SELECT count(*) FROM adsf");
rs.next();
System.out.println(rs.getInt(1));
rs.close();

// clean up
stmt.close();
conn.close();
arrow_array_stream.close();
reader.close();
allocator.close();
```

CC @jonathanswenson 