### PR TITLE
[Arrow] Record Batch Reader Invalidation

### DIFF
--- a/src/common/arrow/arrow_wrapper.cpp
+++ b/src/common/arrow/arrow_wrapper.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/common/arrow/result_arrow_wrapper.hpp"
 #include "duckdb/common/arrow/arrow_appender.hpp"
 #include "duckdb/main/query_result.hpp"
+#include "duckdb/main/client_context.hpp"
 
 namespace duckdb {
 
@@ -145,6 +146,12 @@ void ResultArrowArrayStreamWrapper::MyStreamRelease(struct ArrowArrayStream *str
 		return;
 	}
 	stream->release = nullptr;
+	auto stream_wrapper = (ResultArrowArrayStreamWrapper *)stream->private_data;
+	if (stream_wrapper->result->type == QueryResultType::STREAM_RESULT) {
+		auto &stream_result = (StreamQueryResult &)*stream_wrapper->result;
+		// nuke the dependency
+		stream_result.context->external_dependencies.erase("stream_result");
+	}
 	delete (ResultArrowArrayStreamWrapper *)stream->private_data;
 }
 

--- a/src/common/arrow/arrow_wrapper.cpp
+++ b/src/common/arrow/arrow_wrapper.cpp
@@ -157,7 +157,7 @@ const char *ResultArrowArrayStreamWrapper::MyStreamGetLastError(struct ArrowArra
 	return my_stream->last_error.Message().c_str();
 }
 
-ResultArrowArrayStreamWrapper::ResultArrowArrayStreamWrapper(unique_ptr<QueryResult> result_p, idx_t batch_size_p)
+ResultArrowArrayStreamWrapper::ResultArrowArrayStreamWrapper(shared_ptr<QueryResult> result_p, idx_t batch_size_p)
     : result(move(result_p)) {
 	//! We first initialize the private data of the stream
 	stream.private_data = this;

--- a/src/include/duckdb/common/arrow/result_arrow_wrapper.hpp
+++ b/src/include/duckdb/common/arrow/result_arrow_wrapper.hpp
@@ -14,9 +14,9 @@
 namespace duckdb {
 class ResultArrowArrayStreamWrapper {
 public:
-	explicit ResultArrowArrayStreamWrapper(unique_ptr<QueryResult> result, idx_t batch_size);
+	explicit ResultArrowArrayStreamWrapper(shared_ptr<QueryResult> result, idx_t batch_size);
 	ArrowArrayStream stream;
-	unique_ptr<QueryResult> result;
+	shared_ptr<QueryResult> result;
 	PreservedError last_error;
 	idx_t batch_size;
 	vector<LogicalType> column_types;

--- a/src/include/duckdb/common/arrow/result_arrow_wrapper.hpp
+++ b/src/include/duckdb/common/arrow/result_arrow_wrapper.hpp
@@ -14,9 +14,11 @@
 namespace duckdb {
 class ResultArrowArrayStreamWrapper {
 public:
-	explicit ResultArrowArrayStreamWrapper(shared_ptr<QueryResult> result, idx_t batch_size);
+	explicit ResultArrowArrayStreamWrapper(unique_ptr<QueryResult> result, idx_t batch_size);
+
+	~ResultArrowArrayStreamWrapper();
 	ArrowArrayStream stream;
-	shared_ptr<QueryResult> result;
+	unique_ptr<QueryResult> result;
 	PreservedError last_error;
 	idx_t batch_size;
 	vector<LogicalType> column_types;

--- a/src/include/duckdb/main/external_dependencies.hpp
+++ b/src/include/duckdb/main/external_dependencies.hpp
@@ -10,7 +10,7 @@
 
 namespace duckdb {
 
-enum ExternalDependenciesType { PYTHON_DEPENDENCY };
+enum ExternalDependenciesType { PYTHON_DEPENDENCY, STREAM_DEPENDENCY };
 class ExternalDependency {
 public:
 	explicit ExternalDependency(ExternalDependenciesType type_p) : type(type_p) {};

--- a/src/main/stream_query_result.cpp
+++ b/src/main/stream_query_result.cpp
@@ -103,6 +103,7 @@ bool StreamQueryResult::IsOpen() {
 }
 
 void StreamQueryResult::Close() {
+	context->external_dependencies.erase("stream_result");
 	context.reset();
 }
 

--- a/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
@@ -37,6 +37,14 @@ public:
 	vector<unique_ptr<RegisteredObject>> py_object_list;
 };
 
+class StreamDependencies : public ExternalDependency {
+public:
+	explicit StreamDependencies(StreamQueryResult *result_p)
+	    : ExternalDependency(ExternalDependenciesType::STREAM_DEPENDENCY), result(result_p) {};
+
+	StreamQueryResult *result;
+};
+
 struct DuckDBPyRelation {
 public:
 	explicit DuckDBPyRelation(shared_ptr<Relation> rel);

--- a/tools/pythonpkg/src/include/duckdb_python/pyresult.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyresult.hpp
@@ -18,7 +18,7 @@ struct DuckDBPyResult {
 public:
 	idx_t chunk_offset = 0;
 
-	shared_ptr<QueryResult> result;
+	unique_ptr<QueryResult> result;
 	unique_ptr<DataChunk> current_chunk;
 	// Holds the categories of Categorical/ENUM types
 	unordered_map<idx_t, py::list> categories;

--- a/tools/pythonpkg/src/include/duckdb_python/pyresult.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyresult.hpp
@@ -18,7 +18,7 @@ struct DuckDBPyResult {
 public:
 	idx_t chunk_offset = 0;
 
-	unique_ptr<QueryResult> result;
+	shared_ptr<QueryResult> result;
 	unique_ptr<DataChunk> current_chunk;
 	// Holds the categories of Categorical/ENUM types
 	unordered_map<idx_t, py::list> categories;

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -622,6 +622,9 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::CreateView(const string &view_nam
 	rel->CreateView(view_name, replace);
 	// We need to pass ownership of any Python Object Dependencies to the connection
 	auto all_dependencies = rel->GetAllDependencies();
+	if (view_name == "stream_dependency") {
+		throw InvalidInputException("This view name is reserved, please utilize a different one");
+	}
 	rel->context.GetContext()->external_dependencies[view_name] = move(all_dependencies);
 	return make_unique<DuckDBPyRelation>(rel);
 }
@@ -640,6 +643,9 @@ static bool IsDescribeStatement(SQLStatement &statement) {
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Query(const string &view_name, const string &sql_query) {
 	auto view_relation = CreateView(view_name);
 	auto all_dependencies = rel->GetAllDependencies();
+	if (view_name == "stream_dependency") {
+		throw InvalidInputException("This view name is reserved, please utilize a different one");
+	}
 	rel->context.GetContext()->external_dependencies[view_name] = move(all_dependencies);
 
 	Parser parser(rel->context.GetContext()->GetParserOptions());

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_invalid_reader.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_invalid_reader.py
@@ -1,0 +1,41 @@
+import duckdb
+import pytest
+
+pa = pytest.importorskip('pyarrow')
+
+def test_reader_produce_consume_same_connection():
+	con = duckdb.connect(database=':memory:')
+	arrow_table = pa.Table.from_pydict({'i':[1, 2, 3, 4], 'j':["one", "two", "three", "four"]})
+	con.execute('SELECT * FROM arrow_table WHERE i < 3')
+	duckdb_rbr = con.fetch_record_batch()
+	with pytest.raises(IOError, match='Query Stream is closed'):
+		con.execute('SELECT * FROM duckdb_rbr WHERE i > 1').fetchall()
+
+
+def test_reader_produce_consume_dif_connection():
+	con = duckdb.connect(database=':memory:')
+	con_2 = duckdb.connect(database=':memory:')
+	arrow_table = pa.Table.from_pydict({'i':[1, 2, 3, 4], 'j':["one", "two", "three", "four"]})
+	con.execute('SELECT * FROM arrow_table WHERE i < 3')
+	duckdb_rbr = con.fetch_record_batch()
+	# con invalidates the duckdb_rbr by executing something else
+	con.execute('SELECT 1') 
+	with pytest.raises(IOError, match='Query Stream is closed'):
+		con_2.execute('SELECT * FROM duckdb_rbr WHERE i > 1').fetchall()
+
+	con.execute('SELECT * FROM arrow_table WHERE i < 3')
+	duckdb_rbr = con.fetch_record_batch()
+	# this should work
+	res = con_2.execute('SELECT * FROM duckdb_rbr WHERE i > 1').fetchall()
+	assert res == [(2, 'two')]
+
+def test_reader_produce_consume_same_connection_delete_reader():
+	con = duckdb.connect(database=':memory:')
+	arrow_table = pa.Table.from_pydict({'i':[1, 2, 3, 4], 'j':["one", "two", "three", "four"]})
+	con.execute('SELECT * FROM arrow_table WHERE i < 3')
+	duckdb_rbr = con.fetch_record_batch()
+	# con invalidates the duckdb_rbr by executing something else
+	del duckdb_rbr
+	with pytest.raises(duckdb.CatalogException, match='Table with name duckdb_rbr does not exist!'):
+		con.execute('SELECT * FROM duckdb_rbr WHERE i > 1').fetchall()
+	


### PR DESCRIPTION
Related to #5397 

I basically added record batch readers created over a stream query result as dependent of the current connection. The stream is then invalidated(i.e., closed) if another query is executed by the same connection.

The main problem I have with this (hence first opening it as a draft) is that I cannot test it since invalidating a stream does not throw an error but rather crashes the application.

```
/Users/voltrondata/github-actions-runner/_work/crossbow/crossbow/arrow/cpp/src/arrow/c/bridge.cc:1782:  Check failed: _s.ok() Operation failed: StatusFromCError(stream_.get_schema(&stream_, &c_schema))
Bad status: IOError: Invalid Error: Query Stream is closed
0   libarrow.900.dylib                  0x00000001436149e8 _ZN5arrow4util7CerrLogD2Ev + 236
1   libarrow.900.dylib                  0x00000001436148f4 _ZN5arrow4util7CerrLogD0Ev + 12
2   libarrow.900.dylib                  0x000000014360bb6c _ZN5arrow4util8ArrowLogD1Ev + 48
3   libarrow.900.dylib                  0x0000000143699fd0 _ZNK5arrow12_GLOBAL__N_122ArrayStreamBatchReader11CacheSchemaEv + 848
4   lib.cpython-310-darwin.so           0x000000010ecc2844 _ZL54__pyx_getprop_7pyarrow_3lib_17RecordBatchReader_schemaP7_objectPv + 68
5   Python                              0x00000001008d46f4 _PyObject_GenericGetAttrWithDict + 144
6   Python                              0x00000001008d4f10 PyObject_GetAttrString + 116
7   duckdb.cpython-310-darwin.so        0x0000000128009b24 _ZN8pybind117getattrENS_6handleEPKc + 56
8   duckdb.cpython-310-darwin.so        0x0000000128009a64 _ZN8pybind116detail17accessor_policies8str_attr3getENS_6handleEPKc + 48
9   duckdb.cpython-310-darwin.so        0x00000001280099d8 _ZNK8pybind116detail8accessorINS0_17accessor_policies8str_attrEE9get_cacheEv + 72
10  duckdb.cpython-310-darwin.so        0x000000012801d27c _ZNK8pybind116detail8accessorINS0_17accessor_policies8str_attrEEcvNS_6objectEEv + 32
11  duckdb.cpython-310-darwin.so        0x0000000128044ae0 _ZNK8pybind116detail10object_apiINS0_8accessorINS0_17accessor_policies8str_attrEEEE4attrEPKc + 44
12  duckdb.cpython-310-darwin.so        0x00000001280805e4 _ZN6duckdb34PythonTableArrowArrayStreamFactory9GetSchemaEmRNS_18ArrowSchemaWrapperE + 528
13  duckdb.cpython-310-darwin.so        0x0000000128e6bdbc _ZN6duckdb18ArrowTableFunction13ArrowScanBindERNS_13ClientContextERNS_22TableFunctionBindInputERNSt3__16vectorINS_11LogicalTypeENS5_9allocatorIS7_EEEERNS6_INS5_12basic_stringIcNS5_11char_traitsIcEENS8_IcEEEENS8_ISG_EEEE + 196
14  duckdb.cpython-310-darwin.so        0x00000001283b02bc _ZN6duckdb6Binder25BindTableFunctionInternalERNS_13TableFunctionERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEENS3_6vectorINS_5ValueENS7_ISD_EEEENS3_13unordered_mapIS9_SD_NS_33CaseInsensitiveStringHashFunctionENS_29CaseInsensitiveStringEqualityENS7_INS3_4pairISA_SD_EEEEEENSC_INS_11LogicalTypeENS7_ISN_EEEENSC_IS9_NS7_IS9_EEEERKSR_NS3_10unique_ptrINS_18ExternalDependencyENS3_14default_deleteISV_EEEE + 200
15  duckdb.cpython-310-darwin.so        0x00000001283aae38 _ZN6duckdb6Binder4BindERNS_16TableFunctionRefE + 2840
16  duckdb.cpython-310-darwin.so        0x00000001283a8954 _ZN6duckdb6Binder4BindERNS_12BaseTableRefE + 2224
17  duckdb.cpython-310-darwin.so        0x000000012846ee20 _ZN6duckdb6Binder4BindERNS_8TableRefE + 148
18  duckdb.cpython-310-darwin.so        0x0000000128303dd4 _ZN6duckdb6Binder8BindNodeERNS_10SelectNodeE + 380
19  duckdb.cpython-310-darwin.so        0x000000012846e830 _ZN6duckdb6Binder8BindNodeERNS_9QueryNodeE + 132
20  duckdb.cpython-310-darwin.so        0x000000012846ea18 _ZN6duckdb6Binder4BindERNS_9QueryNodeE + 52
21  duckdb.cpython-310-darwin.so        0x00000001283435a4 _ZN6duckdb6Binder4BindERNS_15SelectStatementE + 76
22  duckdb.cpython-310-darwin.so        0x000000012846e11c _ZN6duckdb6Binder4BindERNS_12SQLStatementE + 120
23  duckdb.cpython-310-darwin.so        0x0000000128478c98 _ZN6duckdb7Planner10CreatePlanERNS_12SQLStatementE + 192
24  duckdb.cpython-310-darwin.so        0x0000000128479e68 _ZN6duckdb7Planner10CreatePlanENSt3__110unique_ptrINS_12SQLStatementENS1_14default_deleteIS3_EEEE + 148
25  duckdb.cpython-310-darwin.so        0x000000012988ff08 _ZN6duckdb13ClientContext23CreatePreparedStatementERNS_17ClientContextLockERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEENS3_10unique_ptrINS_12SQLStatementENS3_14default_deleteISD_EEEEPNS3_6vectorINS_5ValueENS7_ISI_EEEE + 520
26  duckdb.cpython-310-darwin.so        0x00000001299434b0 _ZZN6duckdb13ClientContext15PrepareInternalERNS_17ClientContextLockENSt3__110unique_ptrINS_12SQLStatementENS3_14default_deleteIS5_EEEEENK3$_1clEv + 100
27  duckdb.cpython-310-darwin.so        0x000000012994342c _ZNSt3__1L8__invokeIRZN6duckdb13ClientContext15PrepareInternalERNS1_17ClientContextLockENS_10unique_ptrINS1_12SQLStatementENS_14default_deleteIS6_EEEEE3$_1JEEEDTclscT_fp_spscT0_fp0_EEOSC_DpOSD_ + 24
28  duckdb.cpython-310-darwin.so        0x00000001299433e4 _ZNSt3__128__invoke_void_return_wrapperIvLb1EE6__callIJRZN6duckdb13ClientContext15PrepareInternalERNS3_17ClientContextLockENS_10unique_ptrINS3_12SQLStatementENS_14default_deleteIS8_EEEEE3$_1EEEvDpOT_ + 28
29  duckdb.cpython-310-darwin.so        0x00000001299433bc _ZNSt3__110__function12__alloc_funcIZN6duckdb13ClientContext15PrepareInternalERNS2_17ClientContextLockENS_10unique_ptrINS2_12SQLStatementENS_14default_deleteIS7_EEEEE3$_1NS_9allocatorISB_EEFvvEEclEv + 28
30  duckdb.cpython-310-darwin.so        0x0000000129942180 _ZNSt3__110__function6__funcIZN6duckdb13ClientContext15PrepareInternalERNS2_17ClientContextLockENS_10unique_ptrINS2_12SQLStatementENS_14default_deleteIS7_EEEEE3$_1NS_9allocatorISB_EEFvvEEclEv + 28
31  duckdb.cpython-310-darwin.so        0x0000000129947d98 _ZNKSt3__110__function12__value_funcIFvvEEclEv + 60
32  duckdb.cpython-310-darwin.so        0x0000000129897c98 _ZNKSt3__18functionIFvvEEclEv + 24
33  duckdb.cpython-310-darwin.so        0x0000000129892ee8 _ZN6duckdb13ClientContext32RunFunctionInTransactionInternalERNS_17ClientContextLockERKNSt3__18functionIFvvEEEb + 420
34  duckdb.cpython-310-darwin.so        0x0000000129893280 _ZN6duckdb13ClientContext15PrepareInternalERNS_17ClientContextLockENSt3__110unique_ptrINS_12SQLStatementENS3_14default_deleteIS5_EEEE + 236
35  duckdb.cpython-310-darwin.so        0x000000012989363c _ZN6duckdb13ClientContext7PrepareENSt3__110unique_ptrINS_12SQLStatementENS1_14default_deleteIS3_EEEE + 144
36  duckdb.cpython-310-darwin.so        0x000000012989d484 _ZN6duckdb10Connection7PrepareENSt3__110unique_ptrINS_12SQLStatementENS1_14default_deleteIS3_EEEE + 84
37  duckdb.cpython-310-darwin.so        0x00000001280b79b8 _ZN6duckdb18DuckDBPyConnection7ExecuteERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEN8pybind116objectEb + 1316
38  duckdb.cpython-310-darwin.so        0x00000001280d8304 _ZZN8pybind1112cpp_functionC1IPN6duckdb18DuckDBPyConnectionES3_JRKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEENS_6objectEbEJNS_4nameENS_9is_methodENS_7siblingEA86_cNS_3argENS_5arg_vESK_EEEMT0_FT_DpT1_EDpRKT2_ENKUlS4_SD_SE_bE_clES4_SD_SE_b + 196
39  duckdb.cpython-310-darwin.so        0x00000001280d81ec _ZNO8pybind116detail15argument_loaderIJPN6duckdb18DuckDBPyConnectionERKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEENS_6objectEbEE9call_implIS4_RZNS_12cpp_functionC1IS4_S3_JSD_SE_bEJNS_4nameENS_9is_methodENS_7siblingEA86_cNS_3argENS_5arg_vESO_EEEMT0_FT_DpT1_EDpRKT2_EUlS4_SD_SE_bE_JLm0ELm1ELm2ELm3EENS0_9void_typeEEESQ_OSP_NS0_14index_sequenceIJXspT1_EEEEOT2_ + 180
40  duckdb.cpython-310-darwin.so        0x00000001280d7b6c _ZNO8pybind116detail15argument_loaderIJPN6duckdb18DuckDBPyConnectionERKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEENS_6objectEbEE4callIS4_NS0_9void_typeERZNS_12cpp_functionC1IS4_S3_JSD_SE_bEJNS_4nameENS_9is_methodENS_7siblingEA86_cNS_3argENS_5arg_vESP_EEEMT0_FT_DpT1_EDpRKT2_EUlS4_SD_SE_bE_EENS5_9enable_ifIXntsr3std7is_voidISR_EE5valueESR_E4typeEOT1_ + 56
41  duckdb.cpython-310-darwin.so        0x00000001280d798c _ZZN8pybind1112cpp_function10initializeIZNS0_C1IPN6duckdb18DuckDBPyConnectionES4_JRKNSt3__112basic_stringIcNS6_11char_traitsIcEENS6_9allocatorIcEEEENS_6objectEbEJNS_4nameENS_9is_methodENS_7siblingEA86_cNS_3argENS_5arg_vESL_EEEMT0_FT_DpT1_EDpRKT2_EUlS5_SE_SF_bE_S5_JS5_SE_SF_bEJSG_SH_SI_SJ_SK_SL_SL_EEEvOSN_PFSM_SP_ESV_ENKUlRNS_6detail13function_callEE_clES12_ + 200
42  duckdb.cpython-310-darwin.so        0x00000001280d78a8 _ZZN8pybind1112cpp_function10initializeIZNS0_C1IPN6duckdb18DuckDBPyConnectionES4_JRKNSt3__112basic_stringIcNS6_11char_traitsIcEENS6_9allocatorIcEEEENS_6objectEbEJNS_4nameENS_9is_methodENS_7siblingEA86_cNS_3argENS_5arg_vESL_EEEMT0_FT_DpT1_EDpRKT2_EUlS5_SE_SF_bE_S5_JS5_SE_SF_bEJSG_SH_SI_SJ_SK_SL_SL_EEEvOSN_PFSM_SP_ESV_ENUlRNS_6detail13function_callEE_8__invokeES12_ + 28
43  duckdb.cpython-310-darwin.so        0x000000012801c144 _ZN8pybind1112cpp_function10dispatcherEP7_objectS2_S2_ + 3476
44  Python                              0x00000001008ce164 cfunction_call + 60
45  Python                              0x000000010087bd9c _PyObject_MakeTpCall + 136
46  Python                              0x000000010087f1dc method_vectorcall + 604
47  Python                              0x0000000100976b98 call_function + 128
48  Python                              0x00000001009743c4 _PyEval_EvalFrameDefault + 42944
49  Python                              0x00000001009689ac _PyEval_Vector + 376
50  Python                              0x0000000100968820 PyEval_EvalCode + 104
51  Python                              0x00000001009c16f4 run_eval_code_obj + 84
52  Python                              0x00000001009c1658 run_mod + 112
53  Python                              0x00000001009c12ec pyrun_file + 148
54  Python                              0x00000001009c0c20 _PyRun_SimpleFileObject + 268
55  Python                              0x00000001009c0264 _PyRun_AnyFileObject + 232
56  Python                              0x00000001009e3078 pymain_run_file_obj + 220
57  Python                              0x00000001009e27c8 pymain_run_file + 72
58  Python                              0x00000001009e2058 Py_RunMain + 872
59  Python                              0x00000001009e3458 Py_BytesMain + 40
60  dyld                                0x00000001a8a73e50 start + 2544
[1]    6571 abort      python3 t.py
```

Our guess is that If you throw an exception past a C interface then that's always a bug because the C interface cannot deal with exceptions.

@cpcloud and @gforsyth maybe we are missing a try/catch somewhere? or any other viable solution?
