### PR TITLE
Allow column references in constant table functions

### DIFF
--- a/src/include/duckdb/planner/expression_binder/table_function_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/table_function_binder.hpp
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/planner/expression_binder/table_function_binder.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/planner/expression_binder.hpp"
+
+namespace duckdb {
+
+//! The Table function binder can bind standard table function parameters (i.e. non-table-in-out functions)
+class TableFunctionBinder : public ExpressionBinder {
+public:
+	TableFunctionBinder(Binder &binder, ClientContext &context);
+
+protected:
+	BindResult BindColumnReference(ColumnRefExpression &expr);
+	BindResult BindExpression(unique_ptr<ParsedExpression> *expr, idx_t depth, bool root_expression = false) override;
+
+	string UnsupportedAggregateMessage() override;
+};
+
+} // namespace duckdb

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -10,7 +10,7 @@
 #include "duckdb/parser/tableref/emptytableref.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
 #include "duckdb/planner/binder.hpp"
-#include "duckdb/planner/expression_binder/constant_binder.hpp"
+#include "duckdb/planner/expression_binder/table_function_binder.hpp"
 #include "duckdb/planner/expression_binder/select_binder.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
@@ -86,7 +86,7 @@ bool Binder::BindTableFunctionParameters(TableFunctionCatalogEntry &table_functi
 			continue;
 		}
 
-		ConstantBinder binder(*this, context, "TABLE FUNCTION parameter");
+		TableFunctionBinder binder(*this, context);
 		LogicalType sql_type;
 		auto expr = binder.Bind(child, &sql_type);
 		if (expr->HasParameter()) {

--- a/src/planner/expression_binder/CMakeLists.txt
+++ b/src/planner/expression_binder/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library_unity(
   relation_binder.cpp
   returning_binder.cpp
   select_binder.cpp
+  table_function_binder.cpp
   update_binder.cpp
   where_binder.cpp)
 set(ALL_OBJECT_FILES

--- a/src/planner/expression_binder/table_function_binder.cpp
+++ b/src/planner/expression_binder/table_function_binder.cpp
@@ -1,0 +1,36 @@
+#include "duckdb/planner/expression_binder/table_function_binder.hpp"
+#include "duckdb/parser/expression/columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+
+namespace duckdb {
+
+TableFunctionBinder::TableFunctionBinder(Binder &binder, ClientContext &context) : ExpressionBinder(binder, context) {
+}
+
+BindResult TableFunctionBinder::BindColumnReference(ColumnRefExpression &expr) {
+	auto result_name = StringUtil::Join(expr.column_names, ".");
+	return BindResult(make_unique<BoundConstantExpression>(Value(result_name)));
+}
+
+BindResult TableFunctionBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth,
+                                               bool root_expression) {
+	auto &expr = **expr_ptr;
+	switch (expr.GetExpressionClass()) {
+	case ExpressionClass::COLUMN_REF:
+		return BindColumnReference((ColumnRefExpression &)expr);
+	case ExpressionClass::SUBQUERY:
+		throw BinderException("Table function cannot contain subqueries");
+	case ExpressionClass::DEFAULT:
+		return BindResult("Table function cannot contain DEFAULT clause");
+	case ExpressionClass::WINDOW:
+		return BindResult("Table function cannot contain window functions!");
+	default:
+		return ExpressionBinder::BindExpression(expr_ptr, depth);
+	}
+}
+
+string TableFunctionBinder::UnsupportedAggregateMessage() {
+	return "Table function cannot contain aggregates!";
+}
+
+} // namespace duckdb

--- a/test/sql/copy/csv/empty_first_line.test
+++ b/test/sql/copy/csv/empty_first_line.test
@@ -18,3 +18,17 @@ SELECT * FROM read_csv_auto('data/csv/empty_first_line.csv', delim='|');
 a 1
 b 2
 c 3
+
+query I
+SELECT * FROM read_csv_auto("data/csv/empty_first_line.csv", delim="|");
+----
+a 1
+b 2
+c 3
+
+query I
+SELECT * FROM read_csv_auto("data/csv/empty_first_line"."csv", delim="|");
+----
+a 1
+b 2
+c 3


### PR DESCRIPTION
Fixes confusions like #5473

Column references are converted to strings, so e.g. `read_csv(test.csv)` is converted into `read_csv('test.csv')`. Note that we only allow this for standard table functions, not for table in-out functions, as table in-out functions can actually contain column references (as is the case when used for e.g. lateral joins). 