### PR TITLE
[Python] Adding back Query interrupt support (through Ctrl+C)

### DIFF
--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -126,6 +126,12 @@ static unique_ptr<QueryResult> CompletePendingQuery(PendingQueryResult &pending_
 	PendingExecutionResult execution_result;
 	do {
 		execution_result = pending_query.ExecuteTask();
+		{
+			py::gil_scoped_acquire gil;
+			if (PyErr_CheckSignals() != 0) {
+				throw std::runtime_error("Query interrupted");
+			}
+		}
 	} while (execution_result == PendingExecutionResult::RESULT_NOT_READY);
 	if (execution_result == PendingExecutionResult::EXECUTION_ERROR) {
 		pending_query.ThrowError();

--- a/tools/pythonpkg/tests/fast/api/test_query_interrupt.py
+++ b/tools/pythonpkg/tests/fast/api/test_query_interrupt.py
@@ -23,5 +23,5 @@ class TestQueryInterruption(object):
             # If this is not reached, we could not cancel the query before it completed
             # indicating that the query interruption functionality is broken
             assert True
-        else:
+        except KeyboardInterrupt:
             pytest.fail()

--- a/tools/pythonpkg/tests/fast/api/test_query_interrupt.py
+++ b/tools/pythonpkg/tests/fast/api/test_query_interrupt.py
@@ -1,0 +1,29 @@
+import duckdb
+import time
+import pytest
+
+import threading
+
+try:
+  import thread
+except ImportError:  # for Python 3 compat
+  import _thread as thread
+
+def send_keyboard_interrupt():
+    # Wait a couple seconds
+    time.sleep(2)
+    # Send an interrupt to the main thread
+    thread.interrupt_main()
+
+class TestQueryInterruption(object):
+    def test_query_interruption(self):
+        con = duckdb.connect()
+        thread = threading.Thread(target=send_keyboard_interrupt)
+        # Start the thread
+        thread.start()
+        try:
+            res = con.execute('select count(*) from range(100000000000000)').fetchall()
+        except RuntimeError:
+            assert True
+        # If this is not reached, this test will hang forever
+        # indicating that the query interruption functionality is broken

--- a/tools/pythonpkg/tests/fast/api/test_query_interrupt.py
+++ b/tools/pythonpkg/tests/fast/api/test_query_interrupt.py
@@ -6,8 +6,8 @@ import threading
 import _thread as thread
 
 def send_keyboard_interrupt():
-    # Wait a couple seconds
-    time.sleep(2)
+    # Wait a little, so we're sure the 'execute' has started
+    time.sleep(0.1)
     # Send an interrupt to the main thread
     thread.interrupt_main()
 
@@ -17,7 +17,11 @@ class TestQueryInterruption(object):
         thread = threading.Thread(target=send_keyboard_interrupt)
         # Start the thread
         thread.start()
-        with pytest.raises(RuntimeError):
-            res = con.execute('select count(*) from range(100000000000000)').fetchall()
-        # If this is not reached, this test will hang forever
-        # indicating that the query interruption functionality is broken
+        try:
+            res = con.execute('select count(*) from range(1000000000)').fetchall()
+        except RuntimeError:
+            # If this is not reached, we could not cancel the query before it completed
+            # indicating that the query interruption functionality is broken
+            assert True
+        else:
+            pytest.fail()

--- a/tools/pythonpkg/tests/fast/api/test_query_interrupt.py
+++ b/tools/pythonpkg/tests/fast/api/test_query_interrupt.py
@@ -3,11 +3,7 @@ import time
 import pytest
 
 import threading
-
-try:
-  import thread
-except ImportError:  # for Python 3 compat
-  import _thread as thread
+import _thread as thread
 
 def send_keyboard_interrupt():
     # Wait a couple seconds
@@ -21,9 +17,7 @@ class TestQueryInterruption(object):
         thread = threading.Thread(target=send_keyboard_interrupt)
         # Start the thread
         thread.start()
-        try:
+        with pytest.raises(RuntimeError):
             res = con.execute('select count(*) from range(100000000000000)').fetchall()
-        except RuntimeError:
-            assert True
         # If this is not reached, this test will hang forever
         # indicating that the query interruption functionality is broken


### PR DESCRIPTION
This PR fixes functionality we accidentally lost

It also adds a test for this functionality, which I've spent a good few hours on.
Despite that, I could not find a way for this test to fail on master, it just hangs infinitely
it seems `interrupt_main()` gives back control to the main thread, and since it never gets control until the query completes (which it won't), this just hangs..

So I've added a disclaimer to the test, to hopefully aid people that accidentally break this test


Writing this.. I think maybe we want to find a query that takes long, but not an ungodly amount of time, and assert that we can get the test to raise a RuntimeError (which is what happens when you interrupt the query) before it completes
Though I'm not a fan of anything that's held together by sleeps and variable execution times

Maybe we can set a memory limit and try to interrupt the query before it hits this limit?

This PR refixes #3749