### PR TITLE
[Python] Fix `relation.query()` not accepting non-select statements

### DIFF
--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -665,6 +665,9 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Query(const string &view_name, co
 		// Execute it anyways, for creation/altering statements
 		// We only care that it succeeds, we can't store the result
 		D_ASSERT(query_result);
+		if (query_result->HasError()) {
+			query_result->ThrowError();
+		}
 	}
 	return nullptr;
 }

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -659,8 +659,14 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Query(const string &view_name, co
 		auto query = PragmaShow(*rel->context.GetContext(), parameters);
 		return Query(view_name, query);
 	}
-	throw InvalidInputException("'DuckDBPyRelation.query' does not accept statements of type %s",
-	                            StatementTypeToString(statement.type));
+	{
+		py::gil_scoped_release release;
+		auto query_result = rel->context.GetContext()->Query(move(parser.statements[0]), false);
+		// Execute it anyways, for creation/altering statements
+		// We only care that it succeeds, we can't store the result
+		D_ASSERT(query_result);
+	}
+	return nullptr;
 }
 
 unique_ptr<DuckDBPyResult> DuckDBPyRelation::Execute() {

--- a/tools/pythonpkg/tests/fast/relational_api/test_rapi_query.py
+++ b/tools/pythonpkg/tests/fast/relational_api/test_rapi_query.py
@@ -57,6 +57,14 @@ class TestRAPIQuery(object):
         with pytest.raises(duckdb.InvalidInputException):
             rel.insert([5])
 
+    def test_query_non_select(self):
+        con = duckdb.connect()
+        rel = con.query("select [1,2,3,4]");
+        rel.query("relation", "create table tbl as select * from relation")
+
+        result = con.execute("select * from tbl").fetchall()
+        assert result == [([1,2,3,4],)]
+
     def test_query_table_unrelated(self, tbl_table):
         con = duckdb.default_connection
         rel = con.table("tbl")
@@ -65,12 +73,3 @@ class TestRAPIQuery(object):
         result = rel.execute()
         assert(result.fetchall() == [(5,)])
 
-    def test_query_broken(self, tbl_table):
-        con = duckdb.default_connection
-        rel = con.query("select i from range(10000) tbl(i)")
-
-        with pytest.raises(duckdb.InvalidInputException):
-            rel = rel.query("x", "insert into tbl VALUES(5)")
-        result = rel.execute()
-        # The query has no result, so the original relation wasn't executed in the last `rel.query` call
-        assert(len(result.fetchall()) == 10000)

--- a/tools/pythonpkg/tests/fast/relational_api/test_rapi_query.py
+++ b/tools/pythonpkg/tests/fast/relational_api/test_rapi_query.py
@@ -65,6 +65,19 @@ class TestRAPIQuery(object):
         result = con.execute("select * from tbl").fetchall()
         assert result == [([1,2,3,4],)]
 
+    def test_query_non_select_fail(self):
+        con = duckdb.connect()
+        rel = con.query("select [1,2,3,4]")
+        con.execute("create table tbl as select range(10)")
+        # Table already exists
+        with pytest.raises(duckdb.CatalogException):
+            rel.query("relation", "create table tbl as select * from relation")
+
+        # View referenced does not exist
+        with pytest.raises(duckdb.CatalogException):
+            rel.query("relation", "create table tbl as select * from not_a_valid_view")
+
+
     def test_query_table_unrelated(self, tbl_table):
         con = duckdb.default_connection
         rel = con.table("tbl")


### PR DESCRIPTION
This PR fixes #5380 

Instead of throwing an error, we now still execute the query (because of the side-effects it could have), and return None as the DuckDBPyRelation result of the function