### PR TITLE
[Python] No longer truncate ByteArray values by nullbytes

### DIFF
--- a/tools/pythonpkg/src/python_conversion.cpp
+++ b/tools/pythonpkg/src/python_conversion.cpp
@@ -298,8 +298,9 @@ Value TransformPythonValue(py::handle ele, const LogicalType &target_type, bool 
 		return ele.cast<string>();
 	case PythonObjectType::ByteArray: {
 		auto byte_array = ele.ptr();
-		auto bytes = PyByteArray_AsString(byte_array);
-		return Value::BLOB_RAW(bytes);
+		const_data_ptr_t bytes = (const_data_ptr_t)PyByteArray_AsString(byte_array);
+		idx_t byte_length = PyByteArray_GET_SIZE(byte_array);
+		return Value::BLOB(bytes, byte_length);
 	}
 	case PythonObjectType::MemoryView: {
 		py::memoryview py_view = ele.cast<py::memoryview>();

--- a/tools/pythonpkg/tests/fast/test_all_types.py
+++ b/tools/pythonpkg/tests/fast/test_all_types.py
@@ -86,6 +86,18 @@ class TestAllTypes(object):
             correct_result = correct_answer_map[cur_type]
             assert recursive_equality(result, correct_result)
 
+    def test_bytearray_with_nulls(self):
+        con = duckdb.connect(database=':memory:')
+        con.execute("CREATE TABLE test (content BLOB)")
+        want = bytearray([1, 2, 0, 3, 4])
+        con.execute("INSERT INTO test VALUES (?)", [want])
+
+        con.execute("SELECT * from test")
+        got = bytearray(con.fetchall()[0][0])
+        # Don't truncate the array on the nullbyte
+        assert want == bytearray(got)
+
+
     def test_fetchnumpy(self, duckdb_cursor):
         conn = duckdb.connect()
 


### PR DESCRIPTION
This PR fixes #5443 

By treating the returned `char*` from PyByteArray_AS_STRING as a string (null-terminated)
We truncated the bytearray by a nullbyte, which we shouldn't

(re-opened #5515 as a PR to `master` instead)