### PR TITLE
fix issue #5488

### DIFF
--- a/src/storage/compression/dictionary_compression.cpp
+++ b/src/storage/compression/dictionary_compression.cpp
@@ -186,7 +186,7 @@ public:
 	void Verify() override {
 		current_dictionary.Verify();
 		D_ASSERT(current_segment->count == selection_buffer.size());
-		D_ASSERT(DictionaryCompressionStorage::CalculateSpaceRequirements(
+		D_ASSERT(DictionaryCompressionStorage::HasEnoughSpace(
 		    current_segment->count.load(), index_buffer.size(), current_dictionary.size, current_width));
 		D_ASSERT(current_dictionary.end == Storage::BLOCK_SIZE);
 		D_ASSERT(index_buffer.size() == current_string_map.size() + 1); // +1 is for null value

--- a/src/storage/compression/dictionary_compression.cpp
+++ b/src/storage/compression/dictionary_compression.cpp
@@ -36,11 +36,15 @@ public:
 				new_string = !LookupString(data[idx]);
 			}
 
-			bool fits = HasEnoughSpace(new_string, string_size);
+			bool fits = CalculateSpaceRequirements(new_string, string_size);
 			if (!fits) {
 				Flush();
 				new_string = true;
-				D_ASSERT(HasEnoughSpace(new_string, string_size));
+
+				fits = CalculateSpaceRequirements(new_string, string_size);
+				if (!fits) {
+					throw InternalException("Dictionary compression could not write to new segment");
+				}
 			}
 
 			if (!row_is_valid) {
@@ -68,8 +72,8 @@ protected:
 	virtual void AddNewString(string_t str) = 0;
 	// Add a null value to the compression state
 	virtual void AddNull() = 0;
-	// Check if we have enough space to add a string
-	virtual bool HasEnoughSpace(bool new_string, size_t string_size) = 0;
+	// Needs to be called before adding a value. Will return false if a flush is required first.
+	virtual bool CalculateSpaceRequirements(bool new_string, size_t string_size) = 0;
 	// Flush the segment to disk if compressing or reset the counters if analyzing
 	virtual void Flush(bool final = false) = 0;
 };
@@ -182,8 +186,8 @@ public:
 	void Verify() override {
 		current_dictionary.Verify();
 		D_ASSERT(current_segment->count == selection_buffer.size());
-		D_ASSERT(DictionaryCompressionStorage::HasEnoughSpace(current_segment->count.load(), index_buffer.size(),
-		                                                      current_dictionary.size, current_width));
+		D_ASSERT(DictionaryCompressionStorage::CalculateSpaceRequirements(
+		    current_segment->count.load(), index_buffer.size(), current_dictionary.size, current_width));
 		D_ASSERT(current_dictionary.end == Storage::BLOCK_SIZE);
 		D_ASSERT(index_buffer.size() == current_string_map.size() + 1); // +1 is for null value
 	}
@@ -232,7 +236,7 @@ public:
 		current_segment->count++;
 	}
 
-	bool HasEnoughSpace(bool new_string, size_t string_size) override {
+	bool CalculateSpaceRequirements(bool new_string, size_t string_size) override {
 		if (new_string) {
 			next_width = BitpackingPrimitives::MinimumBitWidth(index_buffer.size() - 1 + new_string);
 			return DictionaryCompressionStorage::HasEnoughSpace(current_segment->count.load() + 1,
@@ -353,7 +357,7 @@ struct DictionaryAnalyzeState : public DictionaryCompressionState {
 		current_tuple_count++;
 	}
 
-	bool HasEnoughSpace(bool new_string, size_t string_size) override {
+	bool CalculateSpaceRequirements(bool new_string, size_t string_size) override {
 		if (new_string) {
 			next_width =
 			    BitpackingPrimitives::MinimumBitWidth(current_unique_count + 2); // 1 for null, one for new string

--- a/src/storage/compression/dictionary_compression.cpp
+++ b/src/storage/compression/dictionary_compression.cpp
@@ -186,8 +186,8 @@ public:
 	void Verify() override {
 		current_dictionary.Verify();
 		D_ASSERT(current_segment->count == selection_buffer.size());
-		D_ASSERT(DictionaryCompressionStorage::HasEnoughSpace(
-		    current_segment->count.load(), index_buffer.size(), current_dictionary.size, current_width));
+		D_ASSERT(DictionaryCompressionStorage::HasEnoughSpace(current_segment->count.load(), index_buffer.size(),
+		                                                      current_dictionary.size, current_width));
 		D_ASSERT(current_dictionary.end == Storage::BLOCK_SIZE);
 		D_ASSERT(index_buffer.size() == current_string_map.size() + 1); // +1 is for null value
 	}

--- a/test/issues/general/test_5488.test
+++ b/test/issues/general/test_5488.test
@@ -1,0 +1,24 @@
+# name: test/issues/general/test_5488.test
+# description: Issue 5488: Reproducible data corruption on simple insert
+# group: [general]
+
+# load the DB from disk
+load __TEST_DIR__/issue_5488.db
+
+statement ok
+pragma force_compression='dictionary'
+
+statement ok
+CREATE TABLE test ( col_a TEXT);
+
+# We need a dataset that will only write unique values as it flushes a segment, this will trigger the bug
+statement ok
+INSERT INTO test SELECT case when i<100 then concat(repeat('string',400), i::VARCHAR) else 'target_string_we_will_count' end from range(0,100000) tbl(i);
+
+statement ok
+checkpoint;
+
+query I
+SELECT count(*) from test where col_a = 'target_string_we_will_count';
+----
+99900


### PR DESCRIPTION
There was an issue where the bitwidth would not be calculated properly on flushing the segment. This would happen when a row group would overflow 1 block, and then write only unique strings to the other block.  The reason for this was that the width is actually calculated as a side-effect of the confusingly named `HasEnoughSpace` function that was ran only in a `D_ASSERT` right after flushing. 

I did add a test, but it doesnt trigger the bug in current CI as it would be run with assertions preventing the bug from happening.