### PR TITLE
Feature: skip broken tests for now

### DIFF
--- a/test/fuzzer/pedro/another_binder_error.test
+++ b/test/fuzzer/pedro/another_binder_error.test
@@ -2,6 +2,8 @@
 # description: Issue #4978 (issue 48): Another Binder Issue
 # group: [pedro]
 
+mode skip
+
 statement error
 SELECT avg(0) c0, (SELECT 0 OFFSET c0);
 ----

--- a/test/sql/join/inner/join_cross_product.test
+++ b/test/sql/join/inner/join_cross_product.test
@@ -35,6 +35,8 @@ select * from t1 join t2 on (i=j), t3 join t4 on (k=l) order by 1, 2, 3, 4;
 1	1	2	2
 1	1	3	3
 
+mode skip
+
 # lateral join
 query IIII rowsort
 select * from t1 join t2 on (i=j), t3 join t4 on (i+k=j+l)


### PR DESCRIPTION
These tests are fixed by #5485, but until that is merged disable them for now