### PR TITLE
DuckBox renderer fixes

### DIFF
--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -573,6 +573,13 @@ void BoxRenderer::Render(ClientContext &context, const vector<string> &names, co
 	// figure out how many/which rows to render
 	idx_t row_count = result.Count();
 	idx_t rows_to_render = MinValue<idx_t>(row_count, config.max_rows);
+	if (row_count <= config.max_rows + 3) {
+		// hiding rows adds 3 extra rows
+		// so hiding rows makes no sense if we are only slightly over the limit
+		// if we are 1 row over the limit hiding rows will actually increase the number of lines we display!
+		// in this case render all the rows
+		rows_to_render = row_count;
+	}
 	idx_t top_rows;
 	idx_t bottom_rows;
 	if (rows_to_render == row_count) {

--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -849,6 +849,22 @@ test('''
 select 42 limit 0;
 ''', out='0 rows')
 
+# #5411 - with maxrows=2, we still display all 4 rows (hiding them would take up more space)
+test('''
+.maxrows 2
+select * from range(4);
+''', out='1')
+
+outfile = tf()
+test('''
+.maxrows 2
+.output %s
+SELECT * FROM range(100);
+''' % outfile)
+outstr = open(outfile,'rb').read().decode('utf8')
+if '50' not in outstr:
+     raise Exception('.output test failed')
+
 # test null-byte rendering
 test('select varchar from test_all_types();', out='goo\\0se')
 

--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -12892,7 +12892,8 @@ static void exec_prepared_stmt(
 ){
   int rc;
   if (pArg->cMode == MODE_DuckBox) {
-	  char *str = sqlite3_print_duckbox(pStmt, pArg->max_rows, pArg->nullValue);
+	  size_t max_rows = pArg->outfile[0] == '\0' || pArg->outfile[0] == '|' ? pArg->max_rows : (size_t) -1;
+	  char *str = sqlite3_print_duckbox(pStmt, max_rows, pArg->nullValue);
 	  if (str) {
 		  utf8_printf(pArg->out, "%s", str);
 		  sqlite3_free(str);
@@ -20391,7 +20392,7 @@ static void verify_uninitialized(void){
 static void main_init(ShellState *data) {
   memset(data, 0, sizeof(*data));
   data->normalMode = data->cMode = data->mode = MODE_DuckBox;
-  data->max_rows = 20;
+  data->max_rows = 40;
   data->autoExplain = 1;
   memcpy(data->colSeparator,SEP_Column, 2);
   memcpy(data->rowSeparator,SEP_Row, 2);


### PR DESCRIPTION
* Fix #5410: in duckbox renderer no longer limit output rows if output file is set
* Fix #5411: when rows are slightly more than the max rows limit - show all rows instead

Also set the default number of maxrows to 40 instead of to 20, as generally 20 is a bit too low in my recent experience.