### PR TITLE
Disable the extended code coverage tests for now

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -100,8 +100,6 @@ jobs:
       matrix:
         testset:
           - 'standard'
-          - 'python'
-          - 'coverage'
     needs: tidy-check
     env:
       GEN: ninja


### PR DESCRIPTION
Running multiple codecov tests seems to trip up the codecov upload frequently leading to failed CI runs - for now just disable these CI runs