### PR TITLE
Improve http retry

### DIFF
--- a/extension/httpfs/httpfs-extension.cpp
+++ b/extension/httpfs/httpfs-extension.cpp
@@ -18,12 +18,14 @@ static void LoadInternal(DatabaseInstance &instance) {
 
 	// Global HTTP config
 	// Single timeout value is used for all 4 types of timeouts, we could split it into 4 if users need that
-	config.AddExtensionOption("http_timeout", "HTTP connection timeout (default 30000ms)",
-	                          LogicalType::UBIGINT);
+	config.AddExtensionOption("http_timeout", "HTTP connection timeout (default 30000ms)", LogicalType::UBIGINT);
 	config.AddExtensionOption("http_retries", "HTTP retries on I/O error (default 3)", LogicalType::UBIGINT);
 	config.AddExtensionOption("http_retry_wait_ms", "Time between retries (default 100ms)", LogicalType::UBIGINT);
-	// Reduces the number of requests made while waiting, for example retry_wait_ms of 50 and backoff factor of 2 will result in wait times of  0 50 100 200 400...etc.
-	config.AddExtensionOption("http_retry_backoff", "Backoff factor for exponentially increasing retry wait time (default 4)", LogicalType::FLOAT);
+	// Reduces the number of requests made while waiting, for example retry_wait_ms of 50 and backoff factor of 2 will
+	// result in wait times of  0 50 100 200 400...etc.
+	config.AddExtensionOption("http_retry_backoff",
+	                          "Backoff factor for exponentially increasing retry wait time (default 4)",
+	                          LogicalType::FLOAT);
 
 	// Global S3 config
 	config.AddExtensionOption("s3_region", "S3 Region", LogicalType::VARCHAR);

--- a/extension/httpfs/httpfs-extension.cpp
+++ b/extension/httpfs/httpfs-extension.cpp
@@ -18,8 +18,9 @@ static void LoadInternal(DatabaseInstance &instance) {
 
 	// Global HTTP config
 	// Single timeout value is used for all 4 types of timeouts, we could split it into 4 if users need that
-	config.AddExtensionOption("httpfs_timeout", "HTTP timeout read/write/connection/retry (default 30000ms)",
+	config.AddExtensionOption("http_timeout", "HTTP timeout read/write/connection/retry (default 30000ms)",
 	                          LogicalType::UBIGINT);
+	config.AddExtensionOption("http_retries", "HTTP retries on I/O error (default 1)", LogicalType::UBIGINT);
 
 	// Global S3 config
 	config.AddExtensionOption("s3_region", "S3 Region", LogicalType::VARCHAR);

--- a/extension/httpfs/httpfs-extension.cpp
+++ b/extension/httpfs/httpfs-extension.cpp
@@ -21,6 +21,8 @@ static void LoadInternal(DatabaseInstance &instance) {
 	config.AddExtensionOption("http_timeout", "HTTP timeout read/write/connection/retry (default 30000ms)",
 	                          LogicalType::UBIGINT);
 	config.AddExtensionOption("http_retries", "HTTP retries on I/O error (default 1)", LogicalType::UBIGINT);
+	config.AddExtensionOption("http_retry_wait_ms", "Time between retries (default 100ms)", LogicalType::UBIGINT);
+	config.AddExtensionOption("http_retry_backoff", "Exponential backoff factor for retry wait time (default 1)", LogicalType::FLOAT);
 
 	// Global S3 config
 	config.AddExtensionOption("s3_region", "S3 Region", LogicalType::VARCHAR);

--- a/extension/httpfs/httpfs-extension.cpp
+++ b/extension/httpfs/httpfs-extension.cpp
@@ -18,11 +18,12 @@ static void LoadInternal(DatabaseInstance &instance) {
 
 	// Global HTTP config
 	// Single timeout value is used for all 4 types of timeouts, we could split it into 4 if users need that
-	config.AddExtensionOption("http_timeout", "HTTP timeout read/write/connection/retry (default 30000ms)",
+	config.AddExtensionOption("http_timeout", "HTTP connection timeout (default 30000ms)",
 	                          LogicalType::UBIGINT);
-	config.AddExtensionOption("http_retries", "HTTP retries on I/O error (default 1)", LogicalType::UBIGINT);
+	config.AddExtensionOption("http_retries", "HTTP retries on I/O error (default 3)", LogicalType::UBIGINT);
 	config.AddExtensionOption("http_retry_wait_ms", "Time between retries (default 100ms)", LogicalType::UBIGINT);
-	config.AddExtensionOption("http_retry_backoff", "Exponential backoff factor for retry wait time (default 1)", LogicalType::FLOAT);
+	// Reduces the number of requests made while waiting, for example retry_wait_ms of 50 and backoff factor of 2 will result in wait times of  0 50 100 200 400...etc.
+	config.AddExtensionOption("http_retry_backoff", "Backoff factor for exponentially increasing retry wait time (default 4)", LogicalType::FLOAT);
 
 	// Global S3 config
 	config.AddExtensionOption("s3_region", "S3 Region", LogicalType::VARCHAR);

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -407,7 +407,7 @@ unique_ptr<ResponseWrapper> HTTPFileHandle::Initialize() {
 		if ((flags & FileFlags::FILE_FLAGS_WRITE) && res->code == 404) {
 			if (!(flags & FileFlags::FILE_FLAGS_FILE_CREATE) && !(flags & FileFlags::FILE_FLAGS_FILE_CREATE_NEW)) {
 				throw IOException("Unable to open URL \"" + path +
-				                  "\" for writing: file does not exists and CREATE flag is not set");
+				                  "\" for writing: file does not exist and CREATE flag is not set");
 			}
 			length = 0;
 			return res;

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -128,7 +128,6 @@ unique_ptr<ResponseWrapper> HTTPFileSystem::HeadRequest(FileHandle &handle, stri
 	ParseUrl(url, path, proto_host_port);
 	auto headers = initialize_http_headers(header_map);
 
-	idx_t out_offset = 0;
 	idx_t tries = 0;
 	idx_t max_retries = hfs.http_params.retries;
 

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -143,7 +143,8 @@ unique_ptr<ResponseWrapper> HTTPFileSystem::HeadRequest(FileHandle &handle, stri
 			tries += 1;
 			hfs.http_client = GetClient(hfs.http_params, proto_host_port.c_str());
 		} else {
-			throw std::runtime_error("HTTP HEAD error on '" + url + "' (Error code " + to_string((int)res.error()) + ")");
+			throw std::runtime_error("HTTP HEAD error on '" + url + "' (Error code " + to_string((int)res.error()) +
+			                         ")");
 		}
 	}
 }
@@ -195,7 +196,8 @@ unique_ptr<ResponseWrapper> HTTPFileSystem::GetRangeRequest(FileHandle &handle, 
 			tries += 1;
 			hfs.http_client = GetClient(hfs.http_params, proto_host_port.c_str());
 		} else {
-			throw std::runtime_error("HTTP GET error on '" + url + "' (Error code " + to_string((int)res.error()) + ")");
+			throw std::runtime_error("HTTP GET error on '" + url + "' (Error code " + to_string((int)res.error()) +
+			                         ")");
 		}
 	}
 }

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -102,8 +102,9 @@ RunRequestWithRetry(const std::function<duckdb_httplib_openssl::Result(void)> &r
 			}
 		}
 
+		tries += 1;
+
 		if (should_retry && tries <= params.retries) {
-			tries += 1;
 			if (tries > 1) {
 				uint64_t sleep_amount = (uint64_t)((float)params.retry_wait_ms * pow(params.retry_backoff, tries - 2));
 				std::this_thread::sleep_for(std::chrono::milliseconds(sleep_amount));

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -113,8 +113,7 @@ RunRequestWithRetry(const std::function<duckdb_httplib_openssl::Result(void)> &r
 				retry_cb();
 			}
 		} else {
-			throw IOException("HTTP " + method + " error on '" + url + "' (Error code " + to_string((int)res.error()) +
-			                  ")");
+			throw IOException(to_string(res.error()) + " error for " + "HTTP " + method + " to '" + url + "'");
 		}
 	}
 }

--- a/extension/httpfs/include/httpfs.hpp
+++ b/extension/httpfs/include/httpfs.hpp
@@ -26,9 +26,13 @@ public:
 struct HTTPParams {
 	static constexpr uint64_t DEFAULT_TIMEOUT = 30000; // 30 sec
 	static constexpr uint64_t DEFAULT_RETRIES = 1;
+	static constexpr uint64_t DEFAULT_RETRY_WAIT_MS = 25;
+	static constexpr float DEFAULT_RETRY_BACKOFF = 1;
 
 	uint64_t timeout;
 	uint64_t retries;
+	uint64_t retry_wait_ms;
+	float retry_backoff;
 
 	static HTTPParams ReadFrom(FileOpener *opener);
 };

--- a/extension/httpfs/include/httpfs.hpp
+++ b/extension/httpfs/include/httpfs.hpp
@@ -25,8 +25,10 @@ public:
 
 struct HTTPParams {
 	static constexpr uint64_t DEFAULT_TIMEOUT = 30000; // 30 sec
+	static constexpr uint64_t DEFAULT_RETRIES = 1;
 
 	uint64_t timeout;
+	uint64_t retries;
 
 	static HTTPParams ReadFrom(FileOpener *opener);
 };

--- a/extension/httpfs/include/httpfs.hpp
+++ b/extension/httpfs/include/httpfs.hpp
@@ -25,9 +25,9 @@ public:
 
 struct HTTPParams {
 	static constexpr uint64_t DEFAULT_TIMEOUT = 30000; // 30 sec
-	static constexpr uint64_t DEFAULT_RETRIES = 1;
-	static constexpr uint64_t DEFAULT_RETRY_WAIT_MS = 25;
-	static constexpr float DEFAULT_RETRY_BACKOFF = 1;
+	static constexpr uint64_t DEFAULT_RETRIES = 3;
+	static constexpr uint64_t DEFAULT_RETRY_WAIT_MS = 100;
+	static constexpr float DEFAULT_RETRY_BACKOFF = 4;
 
 	uint64_t timeout;
 	uint64_t retries;

--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -123,8 +123,6 @@ public:
 	explicit S3FileSystem(BufferManager &buffer_manager) : buffer_manager(buffer_manager) {
 	}
 
-	constexpr static int MULTIPART_UPLOAD_WAIT_BETWEEN_RETRIES_MS = 1000;
-
 	// Global limits to write buffers
 	mutex buffers_available_lock;
 	std::condition_variable buffers_available_cv;

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -265,11 +265,12 @@ void S3FileSystem::UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuf
 	                     S3FileSystem::UrlEncode(file_handle.multipart_upload_id, true);
 	unique_ptr<ResponseWrapper> res;
 
-	res = s3fs.PutRequest(file_handle, file_handle.stripped_path + "?" + query_param, {},
-	                      (char *)write_buffer->Ptr(), write_buffer->idx);
+	res = s3fs.PutRequest(file_handle, file_handle.stripped_path + "?" + query_param, {}, (char *)write_buffer->Ptr(),
+	                      write_buffer->idx);
 
 	if (res->code != 200) {
-		throw IOException("Unable to connect to URL " + file_handle.path + " " + res->error + " (HTTP code " + to_string(res->code) + ")");
+		throw IOException("Unable to connect to URL " + file_handle.path + " " + res->error + " (HTTP code " +
+		                  to_string(res->code) + ")");
 	}
 
 	auto etag_lookup = res->headers.find("ETag");
@@ -479,9 +480,8 @@ void S3FileSystem::ReadQueryParams(const string &url_query_param, S3AuthParams &
 		query_params.erase(found_param);
 	}
 	if (!query_params.empty()) {
-		throw IOException(
-		    "Invalid query parameters found. Supported parameters are:\n's3_region', 's3_access_key_id', "
-		    "'s3_secret_access_key', 's3_session_token',\n's3_endpoint', 's3_url_style', 's3_use_ssl'");
+		throw IOException("Invalid query parameters found. Supported parameters are:\n's3_region', 's3_access_key_id', "
+		                  "'s3_secret_access_key', 's3_session_token',\n's3_endpoint', 's3_url_style', 's3_use_ssl'");
 	}
 }
 
@@ -904,7 +904,7 @@ string AWSListObjectV2::Request(string &path, HTTPParams &http_params, S3AuthPar
 		    if (response.status >= 400) {
 			    std::cerr << response.reason << std::endl;
 			    throw IOException("HTTP GET error on '" + listobjectv2_url + "' (HTTP " +
-			                             std::to_string(response.status) + ")");
+			                      std::to_string(response.status) + ")");
 		    }
 		    return true;
 	    },
@@ -913,8 +913,8 @@ string AWSListObjectV2::Request(string &path, HTTPParams &http_params, S3AuthPar
 		    return true;
 	    });
 	if (res.error() != duckdb_httplib_openssl::Error::Success) {
-		throw IOException("HTTP GET error on '" + listobjectv2_url + "' (Error code " +
-		                         to_string((int)res.error()) + ")");
+		throw IOException("HTTP GET error on '" + listobjectv2_url + "' (Error code " + to_string((int)res.error()) +
+		                  ")");
 	}
 
 	return response.str();

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -913,8 +913,7 @@ string AWSListObjectV2::Request(string &path, HTTPParams &http_params, S3AuthPar
 		    return true;
 	    });
 	if (res.error() != duckdb_httplib_openssl::Error::Success) {
-		throw IOException("HTTP GET error on '" + listobjectv2_url + "' (Error code " + to_string((int)res.error()) +
-		                  ")");
+		throw IOException(to_string(res.error()) + " error for HTTP GET to '" + listobjectv2_url + "'");
 	}
 
 	return response.str();

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -265,49 +265,16 @@ void S3FileSystem::UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuf
 	                     S3FileSystem::UrlEncode(file_handle.multipart_upload_id, true);
 	unique_ptr<ResponseWrapper> res;
 
-	bool success = false;
-	string last_error = "";
-	auto time_at_start = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+	res = s3fs.PutRequest(file_handle, file_handle.stripped_path + "?" + query_param, {},
+	                      (char *)write_buffer->Ptr(), write_buffer->idx);
 
-	// Retry loop to make large uploads resilient to brief connection issues
-	while (true) {
-		try {
-			res = s3fs.PutRequest(file_handle, file_handle.stripped_path + "?" + query_param, {},
-			                      (char *)write_buffer->Ptr(), write_buffer->idx);
-			if (res->code == 200) {
-				success = true;
-				break;
-			} else {
-				last_error = res->error + " (HTTP code " + to_string(res->code) + ")";
-			}
-		} catch (std::runtime_error &e) {
-			if (strncmp(e.what(), "HTTP PUT error", 14) != 0) {
-				throw e;
-			}
-			last_error = e.what();
-		}
-
-		// If there are no parts uploaded yet, failing immediately makes more sense than waiting for the time-out
-		if (file_handle.parts_uploaded.load() == 0) {
-			break;
-		}
-
-		auto current_time = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-		if ((uint64_t)(current_time - time_at_start) > file_handle.http_params.timeout) {
-			break;
-		}
-
-		std::this_thread::sleep_for(milliseconds(MULTIPART_UPLOAD_WAIT_BETWEEN_RETRIES_MS + 1));
-	}
-
-	if (!success) {
-		throw std::runtime_error("Unable to connect to URL \"" + file_handle.path + "\"(last attempt failed with: \"" +
-		                         last_error + "\")");
+	if (res->code != 200) {
+		throw IOException("Unable to connect to URL " + file_handle.path + " " + res->error + " (HTTP code " + to_string(res->code) + ")");
 	}
 
 	auto etag_lookup = res->headers.find("ETag");
 	if (etag_lookup == res->headers.end()) {
-		throw std::runtime_error("Unexpected reponse when uploading part to S3");
+		throw IOException("Unexpected reponse when uploading part to S3");
 	}
 
 	// Insert etag
@@ -383,7 +350,7 @@ void S3FileSystem::FinalizeMultipartUpload(S3FileHandle &file_handle) {
 	for (auto i = 0; i < parts; i++) {
 		auto etag_lookup = file_handle.part_etags.find(i);
 		if (etag_lookup == file_handle.part_etags.end()) {
-			throw std::runtime_error("Unknown part number");
+			throw IOException("Unknown part number");
 		}
 		ss << "<Part><ETag>" << etag_lookup->second << "</ETag><PartNumber>" << i + 1 << "</PartNumber></Part>";
 	}
@@ -401,7 +368,7 @@ void S3FileSystem::FinalizeMultipartUpload(S3FileHandle &file_handle) {
 
 	auto open_tag_pos = result.find("<CompleteMultipartUploadResult", 0);
 	if (open_tag_pos == string::npos) {
-		throw std::runtime_error("Unexpected response during S3 multipart upload finalization");
+		throw IOException("Unexpected response during S3 multipart upload finalization");
 	}
 	file_handle.upload_finalized = true;
 }
@@ -507,12 +474,12 @@ void S3FileSystem::ReadQueryParams(const string &url_query_param, S3AuthParams &
 		} else if (found_param->second == "false") {
 			params.use_ssl = false;
 		} else {
-			throw std::runtime_error("Incorrect setting found for s3_use_ssl, allowed values are: 'true' or 'false'");
+			throw IOException("Incorrect setting found for s3_use_ssl, allowed values are: 'true' or 'false'");
 		}
 		query_params.erase(found_param);
 	}
 	if (!query_params.empty()) {
-		throw std::runtime_error(
+		throw IOException(
 		    "Invalid query parameters found. Supported parameters are:\n's3_region', 's3_access_key_id', "
 		    "'s3_secret_access_key', 's3_session_token',\n's3_endpoint', 's3_url_style', 's3_use_ssl'");
 	}
@@ -522,15 +489,15 @@ ParsedS3Url S3FileSystem::S3UrlParse(string url, S3AuthParams &params) {
 	string http_proto, host, bucket, path, query_param;
 
 	if (url.rfind("s3://", 0) != 0) {
-		throw std::runtime_error("URL needs to start with s3://");
+		throw IOException("URL needs to start with s3://");
 	}
 	auto slash_pos = url.find('/', 5);
 	if (slash_pos == string::npos) {
-		throw std::runtime_error("URL needs to contain a '/' after the host");
+		throw IOException("URL needs to contain a '/' after the host");
 	}
 	bucket = url.substr(5, slash_pos - 5);
 	if (bucket.empty()) {
-		throw std::runtime_error("URL needs to contain a bucket name");
+		throw IOException("URL needs to contain a bucket name");
 	}
 
 	auto question_pos = url.find_last_of('?');
@@ -550,7 +517,7 @@ ParsedS3Url S3FileSystem::S3UrlParse(string url, S3AuthParams &params) {
 		query_param = url.substr(question_pos + 1);
 	}
 	if (path.empty()) {
-		throw std::runtime_error("URL needs to contain key");
+		throw IOException("URL needs to contain key");
 	}
 
 	if (params.url_style == "vhost" || params.url_style == "") {
@@ -639,7 +606,7 @@ unique_ptr<HTTPFileHandle> S3FileSystem::CreateHandle(const string &path, const 
                                                       FileLockType lock, FileCompressionType compression,
                                                       FileOpener *opener) {
 	if (!opener) {
-		throw std::runtime_error("CreateHandle called on S3FileSystem without FileOpener");
+		throw IOException("CreateHandle called on S3FileSystem without FileOpener");
 	}
 	auto s3authparams = S3AuthParams::ReadFrom(opener);
 	ReadQueryParams(query_param, s3authparams);
@@ -936,7 +903,7 @@ string AWSListObjectV2::Request(string &path, HTTPParams &http_params, S3AuthPar
 	    [&](const duckdb_httplib_openssl::Response &response) {
 		    if (response.status >= 400) {
 			    std::cerr << response.reason << std::endl;
-			    throw std::runtime_error("HTTP GET error on '" + listobjectv2_url + "' (HTTP " +
+			    throw IOException("HTTP GET error on '" + listobjectv2_url + "' (HTTP " +
 			                             std::to_string(response.status) + ")");
 		    }
 		    return true;
@@ -946,7 +913,7 @@ string AWSListObjectV2::Request(string &path, HTTPParams &http_params, S3AuthPar
 		    return true;
 	    });
 	if (res.error() != duckdb_httplib_openssl::Error::Success) {
-		throw std::runtime_error("HTTP GET error on '" + listobjectv2_url + "' (Error code " +
+		throw IOException("HTTP GET error on '" + listobjectv2_url + "' (Error code " +
 		                         to_string((int)res.error()) + ")");
 	}
 

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -275,7 +275,7 @@ void S3FileSystem::UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuf
 
 	auto etag_lookup = res->headers.find("ETag");
 	if (etag_lookup == res->headers.end()) {
-		throw IOException("Unexpected reponse when uploading part to S3");
+		throw IOException("Unexpected response when uploading part to S3");
 	}
 
 	// Insert etag

--- a/test/sql/copy/s3/download_config.test
+++ b/test/sql/copy/s3/download_config.test
@@ -19,6 +19,12 @@ foreach url_style path vhost
 statement ok
 SET s3_secret_access_key='minio_duckdb_user_password';SET s3_access_key_id='minio_duckdb_user';SET s3_region='eu-west-1'; SET s3_endpoint='duckdb-minio.com:9000'; SET s3_use_ssl=false;
 
+statement ok
+SET http_retries=5;
+
+statement ok
+SET http_timeout=50000;
+
 # Test the vhost style urls (this is the default)
 statement ok
 SET s3_url_style='${url_style}';

--- a/test/sql/copy/s3/download_config.test
+++ b/test/sql/copy/s3/download_config.test
@@ -87,3 +87,11 @@ SET s3_url_style='handwritten';
 
 statement error
 COPY test TO 's3://test-bucket-public/root-dir/test2.parquet';
+
+# 404
+statement error
+SELECT i FROM "http://test-bucket-public.duckdb-minio.com:9000/root-dir/non-existent-file-ljaslkjdas.parquet" LIMIT 3
+
+# Connection error
+statement error
+SELECT i FROM "http://test-bucket-public.duckdb-minio-non-existent-host.com:9000/root-dir/non-existent-file-ljaslkjdas.parquet" LIMIT 3

--- a/test/sql/copy/s3/download_config.test
+++ b/test/sql/copy/s3/download_config.test
@@ -20,7 +20,13 @@ statement ok
 SET s3_secret_access_key='minio_duckdb_user_password';SET s3_access_key_id='minio_duckdb_user';SET s3_region='eu-west-1'; SET s3_endpoint='duckdb-minio.com:9000'; SET s3_use_ssl=false;
 
 statement ok
-SET http_retries=5;
+SET http_retries=2;
+
+statement ok
+SET http_retry_wait_ms=10;
+
+statement ok
+SET http_retry_backoff=1;
 
 statement ok
 SET http_timeout=50000;


### PR DESCRIPTION
this PR aims makes the https retry mechanism consistent between request types and configurable:

Each HEAD, GET, PUT, and POST request will now be reattempted on:
- socket read/write error
- socket connection error
- various HTTP errors such as 429 (rate limit hit) and 503/504 (server error/timeout)

Retry mechanism uses retry wait times with configurable exponential backoff from the second retry, configurable through:
- http_retries: total number of retries
- http_retry_wait_ms: base wait time before retrying
- http_retry_backoff: backoff factor for exponential backoff

defaults are (http_retries: 3, http_retry_wait_ms: 100, http_retry_backoff:4) which results in this behaviour:
initial try -> wait 0ms -> retry1 -> wait 100ms -> retry2 -> wait 400ms -> (retry 3) -> report IOException

note that the first retry is always done without waiting.

This means that a request to a non-existing file will wait a total amount of 500ms which seems like a reasonable balance between responsiveness and robustness. 

For large uploads/downloads it may be useful to use more requests and/or longer waits.