### PR TITLE
Fix #5546: allow foldable scalar expressions in standard table functions

### DIFF
--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -92,11 +92,11 @@ bool Binder::BindTableFunctionParameters(TableFunctionCatalogEntry &table_functi
 		if (expr->HasParameter()) {
 			throw ParameterNotResolvedException();
 		}
-		if (!expr->IsFoldable()) {
+		if (!expr->IsScalar()) {
 			error = "Table function requires a constant parameter";
 			return false;
 		}
-		auto constant = ExpressionExecutor::EvaluateScalar(context, *expr);
+		auto constant = ExpressionExecutor::EvaluateScalar(context, *expr, true);
 		if (parameter_name.empty()) {
 			// unnamed parameter
 			if (!named_parameters.empty()) {

--- a/test/sql/table_function/range_non_foldable.test
+++ b/test/sql/table_function/range_non_foldable.test
@@ -1,0 +1,32 @@
+# name: test/sql/table_function/range_non_foldable.test
+# description: Issue #5546: non-foldable constant parameters to table function
+# group: [table_function]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT COUNT(*)
+FROM range(
+  current_date,
+  current_date + interval '7' days,
+  interval '1 day'
+)
+----
+7
+
+statement ok
+SELECT to_timestamp(range) as entry
+    FROM range(
+      epoch(date_trunc('month', current_date)),
+      epoch(date_trunc('month', current_date) + interval '1 month' - interval '1 day'),
+      epoch(interval '1 day')
+    )
+
+statement ok
+SELECT to_timestamp(range) as entry
+FROM range(
+  epoch(date_trunc('month', current_date)),
+  epoch(date_trunc('month', current_date) + interval '1 month' - interval '1 day'),
+  epoch(interval '1 day')
+)


### PR DESCRIPTION
Fixes #5546 