### PR TITLE
naming mismatch for linux arm extension upload

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -214,7 +214,7 @@ jobs:
       - uses: ./.github/actions/build_extensions
         with:
           openssl_path: ${{ env.OPENSSL_ROOT_DIR }}
-          deploy_as: linux_aarch64
+          deploy_as: linux_arm64
           treat_warn_as_error: 0
           s3_id: ${{ secrets.S3_ID }}
           s3_key: ${{ secrets.S3_KEY }}


### PR DESCRIPTION
in src/function/table/version/pragma_version.cpp we call it arm64, in CI extension binary upload we call it aarch64. That doesn't work

As a fix for 0.6.0 i copied this directly on S3 so it works already.