### PR TITLE
Add the three-argument variant of the pg_catalog.pg_get_expr function

### DIFF
--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -55,6 +55,7 @@ static DefaultMacro internal_macros[] = {
 	{"pg_catalog", "pg_get_viewdef", {"oid", nullptr}, "(select sql from duckdb_views() v where v.view_oid=oid)"},
 	{"pg_catalog", "pg_get_constraintdef", {"constraint_oid", "pretty_bool", nullptr}, "(select constraint_text from duckdb_constraints() d_constraint where d_constraint.table_oid=constraint_oid/1000000 and d_constraint.constraint_index=constraint_oid%1000000)"},
 	{"pg_catalog", "pg_get_expr", {"pg_node_tree", "relation_oid", nullptr}, "pg_node_tree"},
+	{"pg_catalog", "pg_get_expr", {"pg_node_tree", "relation_oid", "pretty_bool", nullptr}, "pg_node_tree"},
 	{"pg_catalog", "format_pg_type", {"type_name", nullptr}, "case when logical_type='FLOAT' then 'real' when logical_type='DOUBLE' then 'double precision' when logical_type='DECIMAL' then 'numeric' when logical_type='VARCHAR' then 'character varying' when logical_type='BLOB' then 'bytea' when logical_type='TIMESTAMP' then 'timestamp without time zone' when logical_type='TIME' then 'time without time zone' else lower(logical_type) end"},
 	{"pg_catalog", "format_type", {"type_oid", "typemod", nullptr}, "(select format_pg_type(type_name) from duckdb_types() t where t.type_oid=type_oid) || case when typemod>0 then concat('(', typemod/1000, ',', typemod%1000, ')') else '' end"},
 

--- a/test/sql/pg_catalog/system_functions.test
+++ b/test/sql/pg_catalog/system_functions.test
@@ -80,3 +80,15 @@ query I
 select pg_typeof(1);
 ----
 integer
+
+statement ok
+SELECT pg_get_expr(relpartbound, oid) FROM pg_class
+
+statement ok
+SELECT pg_get_expr(relpartbound, oid, true) FROM pg_class
+
+statement ok
+SELECT pg_has_role('duckdb', 'MEMBER')
+
+statement ok
+SELECT pg_has_role('duckdb', 'duckdb', 'MEMBER')


### PR DESCRIPTION
I bumped into this issue during my DBeaver work for my Postgres proxy server; SQLAlchemy uses the two-argument variant of `pg_get_expr`, but DBeaver uses the three-arg variant. Adding it here for completeness with no additional testing (the two-arg variant is identical in implementation and is already tested in `test/sql/pg_catalog/sqlalchemy.test`)