### PR TITLE
[Dev] Added a ConfigOption class, that wraps a configuration option, to save the default value and allow unsetting

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -214,7 +214,7 @@ jobs:
       - uses: ./.github/actions/build_extensions
         with:
           openssl_path: ${{ env.OPENSSL_ROOT_DIR }}
-          deploy_as: linux_aarch64
+          deploy_as: linux_arm64
           treat_warn_as_error: 0
           s3_id: ${{ secrets.S3_ID }}
           s3_key: ${{ secrets.S3_KEY }}

--- a/src/function/scalar/list/list_sort.cpp
+++ b/src/function/scalar/list/list_sort.cpp
@@ -269,8 +269,8 @@ static unique_ptr<FunctionData> ListNormalSortBind(ClientContext &context, Scala
 
 	// set default values
 	auto &config = DBConfig::GetConfig(context);
-	auto order = config.options.default_order_type;
-	auto null_order = config.options.default_null_order;
+	auto order = config.options.default_order_type.Get();
+	auto null_order = config.options.default_null_order.Get();
 
 	// get the sorting order
 	if (arguments.size() >= 2) {
@@ -308,7 +308,7 @@ static unique_ptr<FunctionData> ListReverseSortBind(ClientContext &context, Scal
 	auto &config = DBConfig::GetConfig(context);
 	auto order =
 	    (config.options.default_order_type == OrderType::ASCENDING) ? OrderType::DESCENDING : OrderType::ASCENDING;
-	auto null_order = config.options.default_null_order;
+	auto null_order = config.options.default_null_order.Get();
 
 	// get the null sorting order
 	if (arguments.size() == 2) {

--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/enums/output_type.hpp"
 #include "duckdb/common/enums/profiler_format.hpp"
 #include "duckdb/common/types/value.hpp"
+#include "duckdb/main/config_option.hpp"
 
 namespace duckdb {
 class ClientContext;
@@ -24,63 +25,64 @@ typedef std::function<unique_ptr<PhysicalResultCollector>(ClientContext &context
 
 struct ClientConfig {
 	//! The home directory used by the system (if any)
-	string home_directory;
+	ConfigOption<string> home_directory;
 	//! If the query profiler is enabled or not.
-	bool enable_profiler = false;
+	ConfigOption<bool> enable_profiler = false;
 	//! If detailed query profiling is enabled
-	bool enable_detailed_profiling = false;
+	ConfigOption<bool> enable_detailed_profiling = false;
 	//! The format to print query profiling information in (default: query_tree), if enabled.
-	ProfilerPrintFormat profiler_print_format = ProfilerPrintFormat::QUERY_TREE;
+	ConfigOption<ProfilerPrintFormat> profiler_print_format = ProfilerPrintFormat::QUERY_TREE;
 	//! The file to save query profiling information to, instead of printing it to the console
 	//! (empty = print to console)
-	string profiler_save_location;
+	ConfigOption<string> profiler_save_location;
 
 	//! Allows suppressing profiler output, even if enabled. We turn on the profiler on all test runs but don't want
 	//! to output anything
-	bool emit_profiler_output = true;
+	ConfigOption<bool> emit_profiler_output = true;
 
 	//! If the progress bar is enabled or not.
-	bool enable_progress_bar = false;
+	ConfigOption<bool> enable_progress_bar = false;
 	//! If the print of the progress bar is enabled
-	bool print_progress_bar = true;
+	ConfigOption<bool> print_progress_bar = true;
 	//! The wait time before showing the progress bar
-	int wait_time = 2000;
+	ConfigOption<int> wait_time = 2000;
 
 	//! Preserve identifier case while parsing.
 	//! If false, all unquoted identifiers are lower-cased (e.g. "MyTable" -> "mytable").
-	bool preserve_identifier_case = true;
+	ConfigOption<bool> preserve_identifier_case = true;
 	//! The maximum expression depth limit in the parser
-	idx_t max_expression_depth = 1000;
+	ConfigOption<idx_t> max_expression_depth = 1000;
 
 	//! Whether or not aggressive query verification is enabled
-	bool query_verification_enabled = false;
+	ConfigOption<bool> query_verification_enabled = false;
 	//! Whether or not verification of external operators is enabled, used for testing
-	bool verify_external = false;
+	ConfigOption<bool> verify_external = false;
 	//! Whether or not we should verify the serializer
-	bool verify_serializer = false;
+	ConfigOption<bool> verify_serializer = false;
 	//! Enable the running of optimizers
-	bool enable_optimizer = true;
+	ConfigOption<bool> enable_optimizer = true;
 	//! Force parallelism of small tables, used for testing
-	bool verify_parallelism = false;
+	ConfigOption<bool> verify_parallelism = false;
 	//! Force index join independent of table cardinality, used for testing
-	bool force_index_join = false;
+	ConfigOption<bool> force_index_join = false;
 	//! Force out-of-core computation for operators that support it, used for testing
-	bool force_external = false;
+	ConfigOption<bool> force_external = false;
 	//! Force disable cross product generation when hyper graph isn't connected, used for testing
-	bool force_no_cross_product = false;
+	ConfigOption<bool> force_no_cross_product = false;
 	//! Maximum bits allowed for using a perfect hash table (i.e. the perfect HT can hold up to 2^perfect_ht_threshold
 	//! elements)
-	idx_t perfect_ht_threshold = 12;
+	ConfigOption<idx_t> perfect_ht_threshold = 12;
 
 	//! The explain output type used when none is specified (default: PHYSICAL_ONLY)
-	ExplainOutputType explain_output_type = ExplainOutputType::PHYSICAL_ONLY;
-
-	//! Generic options
-	case_insensitive_map_t<Value> set_variables;
+	ConfigOption<ExplainOutputType> explain_output_type = ExplainOutputType::PHYSICAL_ONLY;
 
 	//! Function that is used to create the result collector for a materialized result
 	//! Defaults to PhysicalMaterializedCollector
-	get_result_collector_t result_collector = nullptr;
+	ConfigOption<get_result_collector_t> result_collector = (get_result_collector_t) nullptr;
+
+public:
+	//! Generic options
+	case_insensitive_map_t<Value> set_variables;
 
 public:
 	static ClientConfig &GetConfig(ClientContext &context);
@@ -91,7 +93,7 @@ public:
 	string ExtractTimezone() const;
 
 	bool AnyVerification() {
-		return query_verification_enabled || verify_external || verify_serializer;
+		return query_verification_enabled.Get() || verify_external.Get() || verify_serializer.Get();
 	}
 };
 

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -73,7 +73,7 @@ struct ExtensionOption {
 };
 
 template <class T>
-struct DBConfigOption {
+struct ConfigOption {
 	//! Overloaded cast to T, for easy conversion
 	operator T() const {
 		return Get();
@@ -84,9 +84,9 @@ struct DBConfigOption {
 		Set(setting);
 	}
 
-	DBConfigOption() : default_value(), current_value(default_value) {
+	ConfigOption() : default_value(), current_value(default_value) {
 	}
-	DBConfigOption(T setting) : default_value(setting), current_value(default_value) {
+	ConfigOption(T setting) : default_value(setting), current_value(default_value) {
 	}
 
 	void Set(T setting) {
@@ -117,58 +117,58 @@ private:
 
 struct DBConfigOptions {
 	//! Database file path. May be empty for in-memory mode
-	DBConfigOption<string> database_path;
+	ConfigOption<string> database_path;
 	//! Access mode of the database (AUTOMATIC, READ_ONLY or READ_WRITE)
-	DBConfigOption<AccessMode> access_mode = AccessMode::AUTOMATIC;
+	ConfigOption<AccessMode> access_mode = AccessMode::AUTOMATIC;
 	//! Checkpoint when WAL reaches this size (default: 16MB)
-	DBConfigOption<idx_t> checkpoint_wal_size = 1 << 24;
+	ConfigOption<idx_t> checkpoint_wal_size = 1 << 24;
 	//! Whether or not to use Direct IO, bypassing operating system buffers
-	DBConfigOption<bool> use_direct_io = false;
+	ConfigOption<bool> use_direct_io = false;
 	//! Whether extensions should be loaded on start-up
-	DBConfigOption<bool> load_extensions = true;
+	ConfigOption<bool> load_extensions = true;
 	//! The maximum memory used by the database system (in bytes). Default: 80% of System available memory
-	DBConfigOption<idx_t> maximum_memory = (idx_t)-1;
+	ConfigOption<idx_t> maximum_memory = (idx_t)-1;
 	//! The maximum amount of CPU threads used by the database system. Default: all available.
-	DBConfigOption<idx_t> maximum_threads = (idx_t)-1;
+	ConfigOption<idx_t> maximum_threads = (idx_t)-1;
 	//! The number of external threads that work on DuckDB tasks. Default: none.
-	DBConfigOption<idx_t> external_threads = 0;
+	ConfigOption<idx_t> external_threads = 0;
 	//! Whether or not to create and use a temporary directory to store intermediates that do not fit in memory
-	DBConfigOption<bool> use_temporary_directory = true;
+	ConfigOption<bool> use_temporary_directory = true;
 	//! Directory to store temporary structures that do not fit in memory
-	DBConfigOption<string> temporary_directory = string();
+	ConfigOption<string> temporary_directory = string();
 	//! The collation type of the database
-	DBConfigOption<string> collation = string();
+	ConfigOption<string> collation = string();
 	//! The order type used when none is specified (default: ASC)
-	DBConfigOption<OrderType> default_order_type = OrderType::ASCENDING;
+	ConfigOption<OrderType> default_order_type = OrderType::ASCENDING;
 	//! Null ordering used when none is specified (default: NULLS FIRST)
-	DBConfigOption<OrderByNullType> default_null_order = OrderByNullType::NULLS_FIRST;
+	ConfigOption<OrderByNullType> default_null_order = OrderByNullType::NULLS_FIRST;
 	//! enable COPY and related commands
-	DBConfigOption<bool> enable_external_access = true;
+	ConfigOption<bool> enable_external_access = true;
 	//! Whether or not object cache is used
-	DBConfigOption<bool> object_cache_enable = false;
+	ConfigOption<bool> object_cache_enable = false;
 	//! Force checkpoint when CHECKPOINT is called or on shutdown, even if no changes have been made
-	DBConfigOption<bool> force_checkpoint = false;
+	ConfigOption<bool> force_checkpoint = false;
 	//! Run a checkpoint on successful shutdown and delete the WAL, to leave only a single database file behind
-	DBConfigOption<bool> checkpoint_on_shutdown = true;
+	ConfigOption<bool> checkpoint_on_shutdown = true;
 	//! Debug flag that decides when a checkpoing should be aborted. Only used for testing purposes.
-	DBConfigOption<CheckpointAbort> checkpoint_abort = CheckpointAbort::NO_ABORT;
+	ConfigOption<CheckpointAbort> checkpoint_abort = CheckpointAbort::NO_ABORT;
 	//! Initialize the database with the standard set of DuckDB functions
 	//! You should probably not touch this unless you know what you are doing
-	DBConfigOption<bool> initialize_default_database = true;
+	ConfigOption<bool> initialize_default_database = true;
 	//! The set of disabled optimizers (default empty)
-	DBConfigOption<set<OptimizerType>> disabled_optimizers;
+	ConfigOption<set<OptimizerType>> disabled_optimizers;
 	//! Force a specific compression method to be used when checkpointing (if available)
-	DBConfigOption<CompressionType> force_compression = CompressionType::COMPRESSION_AUTO;
+	ConfigOption<CompressionType> force_compression = CompressionType::COMPRESSION_AUTO;
 	//! Debug setting for window aggregation mode: (window, combine, separate)
-	DBConfigOption<WindowAggregationMode> window_mode = WindowAggregationMode::WINDOW;
+	ConfigOption<WindowAggregationMode> window_mode = WindowAggregationMode::WINDOW;
 	//! Whether or not preserving insertion order should be preserved
-	DBConfigOption<bool> preserve_insertion_order = true;
+	ConfigOption<bool> preserve_insertion_order = true;
 	//! Whether unsigned extensions should be loaded
-	DBConfigOption<bool> allow_unsigned_extensions = false;
+	ConfigOption<bool> allow_unsigned_extensions = false;
 	//! Enable emitting FSST Vectors
-	DBConfigOption<bool> enable_fsst_vectors = false;
+	ConfigOption<bool> enable_fsst_vectors = false;
 	//! Experimental parallel CSV reader
-	DBConfigOption<bool> experimental_parallel_csv_reader = false;
+	ConfigOption<bool> experimental_parallel_csv_reader = false;
 
 public:
 	//! Database configuration variables as controlled by SET

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -27,6 +27,7 @@
 #include "duckdb/optimizer/optimizer_extension.hpp"
 #include "duckdb/parser/parser_extension.hpp"
 #include "duckdb/planner/operator_extension.hpp"
+#include "duckdb/main/config_option.hpp"
 
 namespace duckdb {
 class CastFunctionSet;
@@ -70,49 +71,6 @@ struct ExtensionOption {
 	string description;
 	LogicalType type;
 	set_option_callback_t set_function;
-};
-
-template <class T>
-struct ConfigOption {
-	//! Overloaded cast to T, for easy conversion
-	operator T() const {
-		return Get();
-	}
-
-	//! Overloaded assignation operator, for easy assignment
-	void operator=(T setting) {
-		Set(setting);
-	}
-
-	ConfigOption() : default_value(), current_value(default_value) {
-	}
-	ConfigOption(T setting) : default_value(setting), current_value(default_value) {
-	}
-
-	void Set(T setting) {
-		current_value = setting;
-	}
-	const T &Get() const {
-		return current_value;
-	}
-
-	void Unset() {
-		current_value = default_value;
-	}
-
-	void OverrideDefault(T new_default) {
-		if (current_value == default_value) {
-			// Also update the current value if it was set to the default
-			current_value = new_default;
-		}
-		default_value = new_default;
-	}
-
-private:
-	// TODO: keep track of 'unset' to differentiate between a default value
-	// and a user-set value that is EQUAL to the default value
-	T default_value;
-	T current_value;
 };
 
 struct DBConfigOptions {

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -72,62 +72,94 @@ struct ExtensionOption {
 	set_option_callback_t set_function;
 };
 
+template <class T>
+struct DBConfigOption {
+	//! Overloaded cast to T, for easy conversion
+	operator T() const {
+		return Get();
+	}
+
+	//! Overloaded assignation operator, for easy assignment
+	void operator=(T setting) {
+		Set(setting);
+	}
+
+	DBConfigOption(T setting) : set(true), value(setting) {
+	}
+
+	bool IsSet() const {
+		return set;
+	}
+	void Set(T setting) {
+		set = true;
+		this->value = value;
+	}
+	T Get() const {
+		D_ASSERT(set);
+		return value;
+	}
+
+private:
+	bool set = false;
+	T value;
+};
+
 struct DBConfigOptions {
 	//! Database file path. May be empty for in-memory mode
-	string database_path;
+	DBConfigOption<string> database_path;
 	//! Access mode of the database (AUTOMATIC, READ_ONLY or READ_WRITE)
-	AccessMode access_mode = AccessMode::AUTOMATIC;
+	DBConfigOption<AccessMode> access_mode = AccessMode::AUTOMATIC;
 	//! Checkpoint when WAL reaches this size (default: 16MB)
-	idx_t checkpoint_wal_size = 1 << 24;
+	DBConfigOption<idx_t> checkpoint_wal_size = 1 << 24;
 	//! Whether or not to use Direct IO, bypassing operating system buffers
-	bool use_direct_io = false;
+	DBConfigOption<bool> use_direct_io = false;
 	//! Whether extensions should be loaded on start-up
-	bool load_extensions = true;
+	DBConfigOption<bool> load_extensions = true;
 	//! The maximum memory used by the database system (in bytes). Default: 80% of System available memory
-	idx_t maximum_memory = (idx_t)-1;
+	DBConfigOption<idx_t> maximum_memory = (idx_t)-1;
 	//! The maximum amount of CPU threads used by the database system. Default: all available.
-	idx_t maximum_threads = (idx_t)-1;
+	DBConfigOption<idx_t> maximum_threads = (idx_t)-1;
 	//! The number of external threads that work on DuckDB tasks. Default: none.
-	idx_t external_threads = 0;
+	DBConfigOption<idx_t> external_threads = 0;
 	//! Whether or not to create and use a temporary directory to store intermediates that do not fit in memory
-	bool use_temporary_directory = true;
+	DBConfigOption<bool> use_temporary_directory = true;
 	//! Directory to store temporary structures that do not fit in memory
-	string temporary_directory;
+	DBConfigOption<string> temporary_directory;
 	//! The collation type of the database
-	string collation = string();
+	DBConfigOption<string> collation = string();
 	//! The order type used when none is specified (default: ASC)
-	OrderType default_order_type = OrderType::ASCENDING;
+	DBConfigOption<OrderType> default_order_type = OrderType::ASCENDING;
 	//! Null ordering used when none is specified (default: NULLS FIRST)
-	OrderByNullType default_null_order = OrderByNullType::NULLS_FIRST;
+	DBConfigOption<OrderByNullType> default_null_order = OrderByNullType::NULLS_FIRST;
 	//! enable COPY and related commands
-	bool enable_external_access = true;
+	DBConfigOption<bool> enable_external_access = true;
 	//! Whether or not object cache is used
-	bool object_cache_enable = false;
+	DBConfigOption<bool> object_cache_enable = false;
 	//! Force checkpoint when CHECKPOINT is called or on shutdown, even if no changes have been made
-	bool force_checkpoint = false;
+	DBConfigOption<bool> force_checkpoint = false;
 	//! Run a checkpoint on successful shutdown and delete the WAL, to leave only a single database file behind
-	bool checkpoint_on_shutdown = true;
+	DBConfigOption<bool> checkpoint_on_shutdown = true;
 	//! Debug flag that decides when a checkpoing should be aborted. Only used for testing purposes.
-	CheckpointAbort checkpoint_abort = CheckpointAbort::NO_ABORT;
+	DBConfigOption<CheckpointAbort> checkpoint_abort = CheckpointAbort::NO_ABORT;
 	//! Initialize the database with the standard set of DuckDB functions
 	//! You should probably not touch this unless you know what you are doing
-	bool initialize_default_database = true;
+	DBConfigOption<bool> initialize_default_database = true;
 	//! The set of disabled optimizers (default empty)
-	set<OptimizerType> disabled_optimizers;
+	DBConfigOption<set<OptimizerType>> disabled_optimizers;
 	//! Force a specific compression method to be used when checkpointing (if available)
-	CompressionType force_compression = CompressionType::COMPRESSION_AUTO;
+	DBConfigOption<CompressionType> force_compression = CompressionType::COMPRESSION_AUTO;
 	//! Debug setting for window aggregation mode: (window, combine, separate)
-	WindowAggregationMode window_mode = WindowAggregationMode::WINDOW;
+	DBConfigOption<WindowAggregationMode> window_mode = WindowAggregationMode::WINDOW;
 	//! Whether or not preserving insertion order should be preserved
-	bool preserve_insertion_order = true;
+	DBConfigOption<bool> preserve_insertion_order = true;
 	//! Database configuration variables as controlled by SET
-	case_insensitive_map_t<Value> set_variables;
+	DBConfigOption<case_insensitive_map_t<Value>> set_variables;
 	//! Whether unsigned extensions should be loaded
-	bool allow_unsigned_extensions = false;
+	DBConfigOption<bool> allow_unsigned_extensions = false;
 	//! Enable emitting FSST Vectors
-	bool enable_fsst_vectors = false;
+	DBConfigOption<bool> enable_fsst_vectors = false;
 	//! Experimental parallel CSV reader
-	bool experimental_parallel_csv_reader = false;
+	DBConfigOption<bool> experimental_parallel_csv_reader = false;
 
 	bool operator==(const DBConfigOptions &other) const;
 };

--- a/src/include/duckdb/main/config_option.hpp
+++ b/src/include/duckdb/main/config_option.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+namespace duckdb {
+
+template <class T>
+struct ConfigOption {
+	//! Overloaded cast to T, for easy conversion
+	operator T() const {
+		return Get();
+	}
+
+	//! Overloaded assignation operator, for easy assignment
+	void operator=(T setting) {
+		Set(setting);
+	}
+
+	ConfigOption() : default_value(), current_value(default_value) {
+	}
+	ConfigOption(T setting) : default_value(setting), current_value(default_value) {
+	}
+
+	void Set(T setting) {
+		current_value = setting;
+	}
+	const T &Get() const {
+		return current_value;
+	}
+
+	void Unset() {
+		current_value = default_value;
+	}
+
+	void OverrideDefault(T new_default) {
+		if (current_value == default_value) {
+			// Also update the current value if it was set to the default
+			current_value = new_default;
+		}
+		default_value = new_default;
+	}
+
+private:
+	// TODO: keep track of 'unset' to differentiate between a default value
+	// and a user-set value that is EQUAL to the default value
+	T default_value;
+	T current_value;
+};
+
+} // namespace duckdb

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -389,7 +389,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingPreparedStatement(ClientCon
 		unique_ptr<PhysicalResultCollector> collector;
 		auto &config = ClientConfig::GetConfig(*this);
 		auto get_method =
-		    config.result_collector ? config.result_collector : PhysicalResultCollector::GetResultCollector;
+		    config.result_collector.Get() ? config.result_collector.Get() : PhysicalResultCollector::GetResultCollector;
 		collector = get_method(*this, statement);
 		D_ASSERT(collector->type == PhysicalOperatorType::RESULT_COLLECTOR);
 		executor.Initialize(move(collector));

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -129,7 +129,7 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 		config_ptr = user_config;
 	}
 
-	if (config_ptr->options.temporary_directory.empty() && database_path) {
+	if (config_ptr->options.temporary_directory.Get().empty() && database_path) {
 		// no directory specified: use default temp path
 		config_ptr->options.temporary_directory = string(database_path) + ".tmp";
 
@@ -142,7 +142,7 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 	if (database_path) {
 		config_ptr->options.database_path = database_path;
 	} else {
-		config_ptr->options.database_path.clear();
+		config_ptr->options.database_path.Set("");
 	}
 
 	for (auto &open : config_ptr->replacement_opens) {

--- a/src/main/extension_prefix_opener.cpp
+++ b/src/main/extension_prefix_opener.cpp
@@ -15,7 +15,7 @@ struct ExtensionPrefixOpenData : public ReplacementOpenData {
 };
 
 static unique_ptr<ReplacementOpenData> ExtensionPrefixPreOpen(DBConfig &config, ReplacementOpenStaticData *) {
-	auto path = config.options.database_path;
+	auto path = config.options.database_path.Get();
 	auto first_colon = path.find(':');
 	if (first_colon == string::npos || first_colon < 2) { // needs to be at least two characters because windows c: ...
 		return nullptr;

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -23,11 +23,11 @@ QueryProfiler::QueryProfiler(ClientContext &context_p)
 }
 
 bool QueryProfiler::IsEnabled() const {
-	return is_explain_analyze ? true : ClientConfig::GetConfig(context).enable_profiler;
+	return is_explain_analyze ? true : ClientConfig::GetConfig(context).enable_profiler.Get();
 }
 
 bool QueryProfiler::IsDetailedEnabled() const {
-	return is_explain_analyze ? false : ClientConfig::GetConfig(context).enable_detailed_profiling;
+	return is_explain_analyze ? false : ClientConfig::GetConfig(context).enable_detailed_profiling.Get();
 }
 
 ProfilerPrintFormat QueryProfiler::GetPrintFormat() const {
@@ -39,7 +39,7 @@ bool QueryProfiler::PrintOptimizerOutput() const {
 }
 
 string QueryProfiler::GetSaveLocation() const {
-	return is_explain_analyze ? string() : ClientConfig::GetConfig(context).profiler_save_location;
+	return is_explain_analyze ? string() : ClientConfig::GetConfig(context).profiler_save_location.Get();
 }
 
 QueryProfiler &QueryProfiler::Get(ClientContext &context) {

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -19,12 +19,13 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 void AccessModeSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
 	auto parameter = StringUtil::Lower(input.ToString());
+	auto &access_mode = config.options.access_mode;
 	if (parameter == "automatic") {
-		config.options.access_mode = AccessMode::AUTOMATIC;
+		access_mode = AccessMode::AUTOMATIC;
 	} else if (parameter == "read_only") {
-		config.options.access_mode = AccessMode::READ_ONLY;
+		access_mode = AccessMode::READ_ONLY;
 	} else if (parameter == "read_write") {
-		config.options.access_mode = AccessMode::READ_WRITE;
+		access_mode = AccessMode::READ_WRITE;
 	} else {
 		throw InvalidInputException(
 		    "Unrecognized parameter for option ACCESS_MODE \"%s\". Expected READ_ONLY or READ_WRITE.", parameter);

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -222,7 +222,7 @@ void DisabledOptimizersSetting::SetGlobal(DatabaseInstance *db, DBConfig &config
 Value DisabledOptimizersSetting::GetSetting(ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	string result;
-	for (auto &optimizer : config.options.disabled_optimizers) {
+	for (auto &optimizer : config.options.disabled_optimizers.Get()) {
 		if (!result.empty()) {
 			result += ",";
 		}
@@ -635,7 +635,7 @@ Value SearchPathSetting::GetSetting(ClientContext &context) {
 //===--------------------------------------------------------------------===//
 void TempDirectorySetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
 	config.options.temporary_directory = input.ToString();
-	config.options.use_temporary_directory = !config.options.temporary_directory.empty();
+	config.options.use_temporary_directory = !config.options.temporary_directory.Get().empty();
 	if (db) {
 		auto &buffer_manager = BufferManager::GetBufferManager(*db);
 		buffer_manager.SetTemporaryDirectory(config.options.temporary_directory);

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -52,7 +52,9 @@ Optimizer::Optimizer(Binder &binder, ClientContext &context) : context(context),
 
 void Optimizer::RunOptimizer(OptimizerType type, const std::function<void()> &callback) {
 	auto &config = DBConfig::GetConfig(context);
-	if (config.options.disabled_optimizers.find(type) != config.options.disabled_optimizers.end()) {
+	auto &disabled_optimizers = config.options.disabled_optimizers.Get();
+
+	if (disabled_optimizers.find(type) != disabled_optimizers.end()) {
 		// optimizer is marked as disabled: skip
 		return;
 	}

--- a/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -67,7 +67,7 @@ BindResult SelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFuncti
 			auto &config = DBConfig::GetConfig(context);
 			const auto &order = aggr.order_bys->orders[0];
 			const auto sense =
-			    (order.type == OrderType::ORDER_DEFAULT) ? config.options.default_order_type : order.type;
+			    (order.type == OrderType::ORDER_DEFAULT) ? config.options.default_order_type.Get() : order.type;
 			invert_fractions = (sense == OrderType::DESCENDING);
 		}
 	}
@@ -176,9 +176,9 @@ BindResult SelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFuncti
 		for (auto &order : aggr.order_bys->orders) {
 			auto &order_expr = (BoundExpression &)*order.expression;
 			const auto sense =
-			    (order.type == OrderType::ORDER_DEFAULT) ? config.options.default_order_type : order.type;
+			    (order.type == OrderType::ORDER_DEFAULT) ? config.options.default_order_type.Get() : order.type;
 			const auto null_order = (order.null_order == OrderByNullType::ORDER_DEFAULT)
-			                            ? config.options.default_null_order
+			                            ? config.options.default_null_order.Get()
 			                            : order.null_order;
 			order_bys->orders.emplace_back(BoundOrderByNode(sense, null_order, move(order_expr.expr)));
 		}

--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -65,11 +65,11 @@ static LogicalType ResolveWindowExpressionType(ExpressionType window_type, const
 }
 
 static inline OrderType ResolveOrderType(const DBConfig &config, OrderType type) {
-	return (type == OrderType::ORDER_DEFAULT) ? config.options.default_order_type : type;
+	return (type == OrderType::ORDER_DEFAULT) ? config.options.default_order_type.Get() : type;
 }
 
 static inline OrderByNullType ResolveNullOrder(const DBConfig &config, OrderByNullType null_order) {
-	return (null_order == OrderByNullType::ORDER_DEFAULT) ? config.options.default_null_order : null_order;
+	return (null_order == OrderByNullType::ORDER_DEFAULT) ? config.options.default_null_order.Get() : null_order;
 }
 
 static unique_ptr<Expression> GetExpression(unique_ptr<ParsedExpression> &expr) {

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -155,10 +155,10 @@ void Binder::BindModifiers(OrderBinder &order_binder, QueryNode &statement, Boun
 				if (!order_expression) {
 					continue;
 				}
-				auto type =
-				    order_node.type == OrderType::ORDER_DEFAULT ? config.options.default_order_type : order_node.type;
+				auto type = order_node.type == OrderType::ORDER_DEFAULT ? config.options.default_order_type.Get()
+				                                                        : order_node.type;
 				auto null_order = order_node.null_order == OrderByNullType::ORDER_DEFAULT
-				                      ? config.options.default_null_order
+				                      ? config.options.default_null_order.Get()
 				                      : order_node.null_order;
 				bound_order->orders.emplace_back(type, null_order, move(order_expression));
 			}


### PR DESCRIPTION
This PR takes a step towards fixing #4998

No functionality is added in this PR, just yak shaving for a future PR to add UNSET.
Apart from some `.Get()`'s nothing much changed about the codebase.

I thought about adding a `get_default_value_func_t` to the `ConfigurationOption` struct, but that would require a lot of changes to be made to existing code.

I also thought about just keeping track of value + set/unset state, and then letting GetSetting deal with checking if it's set/unset and return the default value if it's unset.

But that also didn't sound like a nice change, so now the default value is just saved in the `ConfigOption` instead