### PR TITLE
[Python] Fix accidental dependency on `pandas`

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/python_import_cache.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/python_import_cache.hpp
@@ -74,12 +74,14 @@ public:
 	virtual void LoadSubtypes(PythonImportCache &cache) override {
 		DataFrame.LoadAttribute("DataFrame", cache, *this);
 		libs.LoadModule("pandas._libs.missing", cache);
+		isnull.LoadAttribute("isnull", cache, *this);
 	}
 
 public:
 	//! pandas.DataFrame
 	PythonImportCacheItem DataFrame;
 	PandasLibsCacheItem libs;
+	PythonImportCacheItem isnull;
 
 protected:
 	bool IsRequired() const override final {

--- a/tools/pythonpkg/src/python_conversion.cpp
+++ b/tools/pythonpkg/src/python_conversion.cpp
@@ -274,8 +274,12 @@ Value TransformPythonValue(py::handle ele, const LogicalType &target_type, bool 
 		return Value::UUID(string_val);
 	}
 	case PythonObjectType::Datetime: {
-		auto isnull_result = py::module::import("pandas").attr("isnull")(ele);
-		bool is_nat = string(py::str(isnull_result)) == "True";
+		auto &import_cache = *DuckDBPyConnection::ImportCache();
+		bool is_nat = false;
+		if (import_cache.pandas.isnull.IsLoaded()) {
+			auto isnull_result = import_cache.pandas.isnull()(ele);
+			is_nat = string(py::str(isnull_result)) == "True";
+		}
 		if (is_nat) {
 			return Value();
 		}


### PR DESCRIPTION
This PR fixes #5577

I don't believe we run tests on a environment without `pandas` installed, as it is part of the `requirements-dev.txt`
So I'm not sure if I can add a test for this, but "it works on my machine" (created a clean venv, verified pandas was not installed, ran the example provided in the issue, and it no longer crashed)

Whereas on `master` it produced:
```
(venv) ➜  duckdb git:(master) ✗ python3 tmp/implicit_pandas_dep.py     
Traceback (most recent call last):
  File "/Users/thijs/DuckDBLabs/duckdb/tmp/implicit_pandas_dep.py", line 5, in <module>
    conn.execute("INSERT INTO foo VALUES (?)", (datetime.datetime.now(),))
ModuleNotFoundError: No module named 'pandas'
```