### PR TITLE
[Python] Add support for named parameters

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
@@ -56,9 +56,9 @@ public:
 	static DuckDBPyConnection *DefaultConnection();
 	static PythonImportCache *ImportCache();
 
-	DuckDBPyConnection *ExecuteMany(const string &query, py::object params = py::list());
+	DuckDBPyConnection *ExecuteMany(string query, py::object params = py::list());
 
-	DuckDBPyConnection *Execute(const string &query, py::object params = py::list(), bool many = false);
+	DuckDBPyConnection *Execute(string query, py::object params = py::list(), bool many = false);
 
 	DuckDBPyConnection *Append(const string &name, DataFrame value);
 

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -143,7 +143,7 @@ static unique_ptr<QueryResult> CompletePendingQuery(PendingQueryResult &pending_
 	return pending_query.Execute();
 }
 
-py::list TransformNamedParameters(string &query, py::dict params) {
+py::list TransformNamedParameters(string &query, const py::dict &params) {
 	py::list new_params(params.size());
 
 	idx_t param_idx = 1;
@@ -173,7 +173,7 @@ DuckDBPyConnection *DuckDBPyConnection::Execute(string query, py::object params,
 	}
 	if (py::isinstance<py::dict>(params)) {
 		// Transform named parameters to regular positional parameters
-		params = TransformNamedParameters(query, (py::dict)params);
+		params = TransformNamedParameters(query, params);
 	}
 	result = nullptr;
 	unique_ptr<PreparedStatement> prep;


### PR DESCRIPTION
This PR implements named parameters (mentioned in #5388)

Basically what happens is we now detect if the passed object to `params` is a `dict`, and if it is we assume these contain named parameters, so we replace `$param_name` with `$1` in the query string and populate the param list with the corresponding values of the dict.

Test todos:
ExecuteMany tests
queries containing the named parameter in strings

Also need to check if there is no existing functionality for dictionary as `param` that gets broken by this change
