### PR TITLE
httpfs: Encode url path on request

### DIFF
--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -714,6 +714,16 @@ void S3FileSystem::Verify() {
 		throw std::runtime_error("test fail");
 	}
 
+	// bug #5502
+	S3AuthParams auth_params5 = {"us-east-1", "AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+	                             "",          "s3.amazonaws.com",     "vhost",
+	                             true};
+	auto parsed_url = S3UrlParse("s3://example-bucket/:RDMS+OLAP+embed+feature=duckdb:", auth_params5);
+	string full_url = get_full_s3_url(auth_params, parsed_url);
+	if (full_url != "https://example-bucket.s3.amazonaws.com/%3ARDMS%2BOLAP%2Bembed%2Bfeature%3Dduckdb%3A") {
+		throw std::runtime_error("test fail");
+	}
+
 	// TODO add a test that checks the signing for path-style
 }
 

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -714,16 +714,6 @@ void S3FileSystem::Verify() {
 		throw std::runtime_error("test fail");
 	}
 
-	// bug #5502
-	S3AuthParams auth_params5 = {"us-east-1", "AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-	                             "",          "s3.amazonaws.com",     "vhost",
-	                             true};
-	auto parsed_url = S3UrlParse("s3://example-bucket/:RDMS+OLAP+embed+feature=duckdb:", auth_params5);
-	string full_url = get_full_s3_url(auth_params, parsed_url);
-	if (full_url != "https://example-bucket.s3.amazonaws.com/%3ARDMS%2BOLAP%2Bembed%2Bfeature%3Dduckdb%3A") {
-		throw std::runtime_error("test fail");
-	}
-
 	// TODO add a test that checks the signing for path-style
 }
 

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -558,7 +558,7 @@ string S3FileSystem::GetPayloadHash(char *buffer, idx_t buffer_len) {
 }
 
 static string get_full_s3_url(S3AuthParams &auth_params, ParsedS3Url parsed_url) {
-	string full_url = parsed_url.http_proto + parsed_url.host + parsed_url.path;
+	string full_url = parsed_url.http_proto + parsed_url.host + S3FileSystem::UrlEncode(parsed_url.path);
 
 	if (!parsed_url.query_param.empty()) {
 		full_url += "?" + parsed_url.query_param;

--- a/test/sql/copy/s3/url_encode.test
+++ b/test/sql/copy/s3/url_encode.test
@@ -25,6 +25,9 @@ COPY test_1 TO 's3://test-bucket-public/url_encode/just because you can doesnt m
 statement ok
 COPY test_2 TO 's3://test-bucket-public/url_encode/just+dont+use+plus+or+spaces+please.parquet' (FORMAT 'parquet');
 
+statement ok
+COPY test_3 TO 's3://test-bucket-public/url_encode/should:avoid:using:colon:in:paths.parquet' (FORMAT 'parquet');
+
 # For S3 urls spaces are fine
 query I
 SELECT * FROM "s3://test-bucket-public/url_encode/just because you can doesnt mean you should.parquet" LIMIT 1;
@@ -36,6 +39,12 @@ query I
 SELECT * FROM "s3://test-bucket-public/url_encode/just+dont+use+plus+or+spaces+please.parquet" LIMIT 1;
 ----
 2
+
+# Colons in S3 urls are encoded by duckdb internaly like boto3 (issue #5502)
+query I
+SELECT * FROM "s3://test-bucket-public/url_encode/should:avoid:using:colon:in:paths.parquet" LIMIT 1;
+----
+3
 
 # NOTE! For HTTP(s) urls, the + symbol is not encoded by duckdb, leaving it up to the server to decide if it should be interpreted
 # as a space or a plus. In the case of AWS S3, they are interpreted as encoded spaces, however Minio does not


### PR DESCRIPTION
Fix #5502

For S3, Some characters request params as well as path need to be encoded.
There is another option that cli users do it by themselves.
But, since python's `boto3` encodes url path before requesting, it will be good that duckdb cli does on behalf of the user.
(This means that `boto3` users cannot percent-encoding style path.)