### PR TITLE
Misc union-type improvements

### DIFF
--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -347,7 +347,7 @@ static void CreateValuesUnion(const JSONCreateFunctionData &info, yyjson_mut_doc
 			if (!tag_data.validity.RowIsValid(tag_idx)) {
 				continue;
 			}
-			auto tag = ((int8_t *)tag_data.data)[tag_idx];
+			auto tag = ((uint8_t *)tag_data.data)[tag_idx];
 			if (tag != member_idx) {
 				continue;
 			}

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -67,7 +67,7 @@ static LogicalType GetJSONType(unordered_map<string, unique_ptr<Vector>> &const_
 	}
 	case LogicalTypeId::UNION: {
 		child_list_t<LogicalType> member_types;
-		for(idx_t member_idx = 0; member_idx < UnionType::GetMemberCount(type); member_idx++) {
+		for (idx_t member_idx = 0; member_idx < UnionType::GetMemberCount(type); member_idx++) {
 			auto &member_name = UnionType::GetMemberName(type, member_idx);
 			auto &member_type = UnionType::GetMemberType(type, member_idx);
 
@@ -312,7 +312,7 @@ static void CreateValuesMap(const JSONCreateFunctionData &info, yyjson_mut_doc *
 }
 
 static void CreateValuesUnion(const JSONCreateFunctionData &info, yyjson_mut_doc *doc, yyjson_mut_val *vals[],
-                               Vector &value_v, idx_t count) {
+                              Vector &value_v, idx_t count) {
 	// Structs become objects, therefore we initialize vals to JSON objects
 	for (idx_t i = 0; i < count; i++) {
 		vals[i] = yyjson_mut_obj(doc);
@@ -327,11 +327,11 @@ static void CreateValuesUnion(const JSONCreateFunctionData &info, yyjson_mut_doc
 	tag_v.ToUnifiedFormat(count, tag_data);
 
 	// Add the key/value pairs to the objects
-	for(idx_t member_idx = 0; member_idx < UnionType::GetMemberCount(value_v.GetType()); member_idx++) {
+	for (idx_t member_idx = 0; member_idx < UnionType::GetMemberCount(value_v.GetType()); member_idx++) {
 		auto &member_val_v = UnionVector::GetMember(value_v, member_idx);
 		auto &member_key_v = *info.const_struct_names.at(UnionType::GetMemberName(value_v.GetType(), member_idx));
 
-		// This implementation is not optimal since we convert the entire member vector, 
+		// This implementation is not optimal since we convert the entire member vector,
 		// and then skip the rows not matching the tag afterwards.
 
 		CreateValues(info, doc, nested_vals, member_val_v, count);

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -65,6 +65,17 @@ static LogicalType GetJSONType(unordered_map<string, unique_ptr<Vector>> &const_
 	case LogicalTypeId::MAP: {
 		return LogicalType::MAP(LogicalType::VARCHAR, GetJSONType(const_struct_names, MapType::ValueType(type)));
 	}
+	case LogicalTypeId::UNION: {
+		child_list_t<LogicalType> member_types;
+		for(idx_t member_idx = 0; member_idx < UnionType::GetMemberCount(type); member_idx++) {
+			auto &member_name = UnionType::GetMemberName(type, member_idx);
+			auto &member_type = UnionType::GetMemberType(type, member_idx);
+
+			const_struct_names[member_name] = make_unique<Vector>(Value(member_name));
+			member_types.emplace_back(member_name, GetJSONType(const_struct_names, member_type));
+		}
+		return LogicalType::UNION(member_types);
+	}
 	// All other types (e.g. date) are cast to VARCHAR
 	default:
 		return LogicalTypeId::VARCHAR;
@@ -300,6 +311,56 @@ static void CreateValuesMap(const JSONCreateFunctionData &info, yyjson_mut_doc *
 	}
 }
 
+static void CreateValuesUnion(const JSONCreateFunctionData &info, yyjson_mut_doc *doc, yyjson_mut_val *vals[],
+                               Vector &value_v, idx_t count) {
+	// Structs become objects, therefore we initialize vals to JSON objects
+	for (idx_t i = 0; i < count; i++) {
+		vals[i] = yyjson_mut_obj(doc);
+	}
+
+	// Initialize re-usable array for the nested values
+	auto nested_vals_ptr = unique_ptr<yyjson_mut_val *[]>(new yyjson_mut_val *[count]);
+	auto nested_vals = nested_vals_ptr.get();
+
+	auto &tag_v = UnionVector::GetTags(value_v);
+	UnifiedVectorFormat tag_data;
+	tag_v.ToUnifiedFormat(count, tag_data);
+
+	// Add the key/value pairs to the objects
+	for(idx_t member_idx = 0; member_idx < UnionType::GetMemberCount(value_v.GetType()); member_idx++) {
+		auto &member_val_v = UnionVector::GetMember(value_v, member_idx);
+		auto &member_key_v = *info.const_struct_names.at(UnionType::GetMemberName(value_v.GetType(), member_idx));
+
+		// This implementation is not optimal since we convert the entire member vector, 
+		// and then skip the rows not matching the tag afterwards.
+
+		CreateValues(info, doc, nested_vals, member_val_v, count);
+
+		// This is a inlined copy of AddKeyValuePairs but we also skip null tags
+		// and the rows where the member is not matching the tag
+		UnifiedVectorFormat key_data;
+		member_key_v.ToUnifiedFormat(count, key_data);
+		auto keys = (string_t *)key_data.data;
+
+		for (idx_t i = 0; i < count; i++) {
+			auto tag_idx = tag_data.sel->get_index(i);
+			if (!tag_data.validity.RowIsValid(tag_idx)) {
+				continue;
+			}
+			auto tag = ((int8_t *)tag_data.data)[tag_idx];
+			if (tag != member_idx) {
+				continue;
+			}
+			auto key_idx = key_data.sel->get_index(i);
+			if (!key_data.validity.RowIsValid(key_idx)) {
+				continue;
+			}
+			auto key = CreateJSONValue<string_t>(doc, keys[key_idx]);
+			yyjson_mut_obj_add(vals[i], key, nested_vals[i]);
+		}
+	}
+}
+
 static void CreateValuesList(const JSONCreateFunctionData &info, yyjson_mut_doc *doc, yyjson_mut_val *vals[],
                              Vector &value_v, idx_t count) {
 	// Initialize array for the nested values
@@ -357,6 +418,9 @@ static void CreateValues(const JSONCreateFunctionData &info, yyjson_mut_doc *doc
 		break;
 	case LogicalTypeId::LIST:
 		CreateValuesList(info, doc, vals, value_v, count);
+		break;
+	case LogicalTypeId::UNION:
+		CreateValuesUnion(info, doc, vals, value_v, count);
 		break;
 	default:
 		throw InternalException("Unsupported type arrived at JSON create function");

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -458,7 +458,7 @@ string LogicalType::ToString() const {
 		string ret = "UNION(";
 		size_t count = UnionType::GetMemberCount(*this);
 		for (size_t i = 0; i < count; i++) {
-			ret += UnionType::GetMemberType(*this, i).ToString();
+			ret += UnionType::GetMemberName(*this, i) + " " + UnionType::GetMemberType(*this, i).ToString();
 			if (i < count - 1) {
 				ret += ", ";
 			}

--- a/src/function/cast/union_casts.cpp
+++ b/src/function/cast/union_casts.cpp
@@ -173,18 +173,9 @@ unique_ptr<BoundCastData> BindUnionToUnionCast(BindCastInput &input, const Logic
 		for (idx_t target_idx = 0; target_idx < UnionType::GetMemberCount(target); target_idx++) {
 			auto &target_member_name = UnionType::GetMemberName(target, target_idx);
 
-			// found a matching member, check if the types are castable
+			// found a matching member
 			if (source_member_name == target_member_name) {
 				auto &target_member_type = UnionType::GetMemberType(target, target_idx);
-
-				if (input.function_set.ImplicitCastCost(source_member_type, target_member_type) < 0) {
-					auto message = StringUtil::Format(
-					    "Type %s can't be cast as %s. The member '%s' can't be implicitly cast from %s to %s",
-					    source.ToString(), target.ToString(), source_member_name, source_member_type.ToString(),
-					    target_member_type.ToString());
-					throw CastException(message);
-				}
-
 				tag_map[source_idx] = target_idx;
 				member_casts.push_back(input.GetCastFunction(source_member_type, target_member_type));
 				found = true;
@@ -258,6 +249,14 @@ static bool UnionToUnionCast(Vector &source, Vector &result, idx_t count, CastPa
 		}
 	} else {
 		// Otherwise, use the unified vector format to access the source vector.
+
+		// Ensure that all the result members are flat vectors
+		// This is not always the case, e.g. when a member is cast using the default TryNullCast function
+		// the resulting member vector will be a constant null vector.
+		for (idx_t target_member_idx = 0; target_member_idx < target_member_count; target_member_idx++) {
+			UnionVector::GetMember(result, target_member_idx).Flatten(count);
+		}
+
 		// We assume that a union tag vector validity matches the union vector validity.
 		UnifiedVectorFormat source_tag_format;
 		source_tag_vector.ToUnifiedFormat(count, source_tag_format);
@@ -270,6 +269,9 @@ static bool UnionToUnionCast(Vector &source, Vector &result, idx_t count, CastPa
 				auto target_tag = cast_data.tag_map[source_tag];
 				FlatVector::GetData<union_tag_t>(result_tag_vector)[row_idx] = target_tag;
 			} else {
+
+				// Issue: The members of the result is not always flatvectors
+				// In the case of TryNullCast, the result member is constant.
 				FlatVector::SetNull(result, row_idx, true);
 			}
 		}

--- a/test/sql/json/test_json_create.test
+++ b/test/sql/json/test_json_create.test
@@ -19,6 +19,21 @@ select to_json({n: 42})
 {"n":42}
 
 query T
+select to_json(union_value(n := 42))
+----
+{"n":42}
+
+query T
+SELECT to_json(union_value(a := NULL)::UNION(a INTEGER, b VARCHAR))
+----
+{"a":null}
+
+query T
+SELECT to_json(union_value(b := 'abc')::UNION(a INTEGER, b VARCHAR, c FLOAT))
+----
+{"b":"abc"}
+
+query T
 select json_object('duck', 42)
 ----
 {"duck":42}

--- a/test/sql/types/union/union_cast.test
+++ b/test/sql/types/union/union_cast.test
@@ -124,3 +124,57 @@ f32		NULL	NULL	6.0
 i32		1		NULL	NULL
 str		NULL	two		NULL
 str		NULL	three	NULL
+
+# Allow explict casts
+statement ok
+CREATE TABLE tbl3 (u UNION(i INT));
+
+statement ok
+INSERT INTO tbl3 VALUES (1), (2), (3);
+
+query I
+SELECT u::UNION(i SMALLINT) FROM tbl3 ORDER BY ALL;;
+----
+1
+2
+3
+
+statement ok
+CREATE TABLE tbl4 (u UNION(i INT, b BLOB));
+
+statement ok
+INSERT INTO tbl4 VALUES (1), ('010203'::BLOB), (3), ('070809'::BLOB);
+
+# fails since b is missing
+statement error
+SELECT u::UNION(i SMALLINT, v VARCHAR) FROM tbl4;
+
+# succeeds since b is present
+query I
+SELECT u::UNION(i SMALLINT, b VARCHAR) FROM tbl4 ORDER BY ALL;;
+----
+1
+3
+010203
+070809
+
+# fails since b is not compatible
+statement error
+SELECT u::UNION(i SMALLINT, b INT) FROM tbl4;
+
+statement ok
+DELETE FROM tbl4 WHERE union_tag(u) == 'b';
+
+statement ok
+INSERT INTO tbl4 VALUES (union_value(b := NULL::BLOB)), (union_value(b := NULL)), (NULL), (NULL::BLOB);
+
+# succeeds since all members of b is null, therefore TryNullCast allows to cast blob -> int.
+query III
+SELECT union_tag(u), union_tag(u::UNION(i SMALLINT, b INT)), u::UNION(i SMALLINT, b INT) FROM tbl4 ORDER BY ALL;;
+----
+NULL	NULL	NULL
+NULL	NULL	NULL
+i		i		1
+i		i		3
+b		b		NULL
+b		b		NULL


### PR DESCRIPTION
## Relax Union-To-Union casts

As discovered in #5467 it turns out union-to-union casts were unnecessarily strict and only allowed casts to succeed if all the members were implicitly-castable, regardless of how the union cast itself was invoked. This caused issues when printing unions containing certain types in the shell (like blobs) who can't be implicitly cast to string but always have a `VARCHAR` cast present nonetheless. 

A side effect of this is that since the `TryNullCast` cast is _always_ available for every type, it is now _always_ possible to cast union members where the types mismatch, as long as all the values in the source member are `NULL`.

You can now do things like:

```sql
CREATE TABLE tbl (u UNION(i INT));
INSERT INTO tbl VALUES (42);
-- This works since int is explicitly castable to smallint
SELECT u::UNION(i SMALLINT) FROM tbl;
```

```sql
CREATE TABLE tbl (u UNION(I INT, b BLOB));
INSERT INTO tbl VALUES (42), (union_value(b := NULL));
-- This works, since the always present TryNullCast succeeds in 
-- converting a blob to a double if the blob is null.
SELECT union_tag(u), u::UNION(I SMALLINT, b DOUBLE) FROM tbl;
----
┌──────────────┬────────────────────────────────────────┐
│ union_tag(u) │ CAST(u AS UNION(I SMALLINT, b DOUBLE)) │
│              │      union(i smallint, b double)       │
├──────────────┼────────────────────────────────────────┤
│ I            │ 42                                     │
│ b            │ NULL                                   │
└──────────────┴────────────────────────────────────────┘
```
I've added some more test to test these cases too.

## Support union types in `to_json` in the json extension

This issue was originally raised in discord, but It is now possible to convert unions to json. This basically does the same conversion as when converting structs, but then checks that the member is selected by the tag before emitting the key-value pair for each member. In theory you could avoid converting the non-selected members but since they will always be null I don't think the performance hit is significant (I suppose yyjson has the NULL value interned?). The worst part is probably having to iterate over each member column when you could just iterate over the tags, but I'll leave that as a future optimisation.

I also opted to not emit the union tag as a property in the resulting json object since I don't want to have to "reserve" a property name for the tag. If the user wants to emit a some sort of envelope or discriminator property for use in a external tool they can format it as they like using a combination of `union_tag` and `json_object` and `COALESCE`. For example:

```sql
CREATE TABLE tbl (u UNION(a INT, b VARCHAR));
INSERT INTO tbl VALUES ('hello'), (42);
SELECT to_json({
	'$type': union_tag(u),
 	'value': COALESCE(to_json(u.a), to_json(u.b))
 }) FROM tbl;
┌─────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ to_json(main.struct_pack("$type" := union_tag(u), "value" := COALESCE(to_json(u.a), to_json(u.b)))) │
│                                                json                                                 │
├─────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ {"$type":"b","value":"hello"}                                                                       │
│ {"$type":"a","value":42}                                                                            │
└─────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

## Fix union LogicalType ToString()
The `ToString` function of the union `LogicalType` did not print the member names which cause tests with query verification to fail. This is now fixed. 