### PR TITLE
allow delay load with duckdb.dll

### DIFF
--- a/src/include/duckdb/main/loadable_extension.hpp
+++ b/src/include/duckdb/main/loadable_extension.hpp
@@ -39,12 +39,17 @@ explanation of this crazy process:
 * https://docs.microsoft.com/en-us/cpp/build/reference/understanding-the-helper-function?view=msvc-160
 */
 FARPROC WINAPI duckdb_dllimport_delay_hook(unsigned dliNotify, PDelayLoadInfo pdli) {
+	HMODULE module;
 	switch (dliNotify) {
 	case dliNotePreLoadLibrary:
 		if (strcmp(pdli->szDll, "duckdb.dll") != 0) {
 			return NULL;
 		}
-		return (FARPROC)GetModuleHandle(NULL);
+		module = GetModuleHandle(pdli->szDll);
+		if (!module) {
+			module = GetModuleHandle(NULL);
+		}
+		return (FARPROC)module;
 	default:
 		return NULL;
 	}


### PR DESCRIPTION
On windows when loading a loadable extension duckdb uses delay load hook which returns exe's handle instead of duckdb.dll handle. This allows to load extensions form CLI exe (which doesn't use duckdb.dll but has the same exports) but not when duckdb is actually in a dll loaded from another exe (e.g. python). This change allows to attach loadable extensions to duckdb.dll if it has already been loaded by the main process.