### PR TITLE
[Python] Changed use of DuckDBPyConnection to shared_ptr

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
@@ -31,7 +31,7 @@ public:
 	unique_ptr<PythonTableArrowArrayStreamFactory> arrow_factory;
 };
 
-struct DuckDBPyConnection {
+struct DuckDBPyConnection : public std::enable_shared_from_this<DuckDBPyConnection> {
 public:
 	shared_ptr<DuckDB> database;
 	unique_ptr<Connection> connection;
@@ -48,21 +48,21 @@ public:
 	static void Initialize(py::handle &m);
 	static void Cleanup();
 
-	DuckDBPyConnection *Enter();
+	shared_ptr<DuckDBPyConnection> Enter();
 
 	static bool Exit(DuckDBPyConnection &self, const py::object &exc_type, const py::object &exc,
 	                 const py::object &traceback);
 
-	static DuckDBPyConnection *DefaultConnection();
+	static shared_ptr<DuckDBPyConnection> DefaultConnection();
 	static PythonImportCache *ImportCache();
 
-	DuckDBPyConnection *ExecuteMany(const string &query, py::object params = py::list());
+	shared_ptr<DuckDBPyConnection> ExecuteMany(const string &query, py::object params = py::list());
 
-	DuckDBPyConnection *Execute(const string &query, py::object params = py::list(), bool many = false);
+	shared_ptr<DuckDBPyConnection> Execute(const string &query, py::object params = py::list(), bool many = false);
 
-	DuckDBPyConnection *Append(const string &name, DataFrame value);
+	shared_ptr<DuckDBPyConnection> Append(const string &name, DataFrame value);
 
-	DuckDBPyConnection *RegisterPythonObject(const string &name, py::object python_object);
+	shared_ptr<DuckDBPyConnection> RegisterPythonObject(const string &name, py::object python_object);
 
 	void InstallExtension(const string &extension, bool force_install = false);
 
@@ -99,13 +99,13 @@ public:
 
 	unordered_set<string> GetTableNames(const string &query);
 
-	DuckDBPyConnection *UnregisterPythonObject(const string &name);
+	shared_ptr<DuckDBPyConnection> UnregisterPythonObject(const string &name);
 
-	DuckDBPyConnection *Begin();
+	shared_ptr<DuckDBPyConnection> Begin();
 
-	DuckDBPyConnection *Commit();
+	shared_ptr<DuckDBPyConnection> Commit();
 
-	DuckDBPyConnection *Rollback();
+	shared_ptr<DuckDBPyConnection> Rollback();
 
 	void Close();
 

--- a/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
@@ -46,70 +46,68 @@ public:
 public:
 	static void Initialize(py::handle &m);
 
-	static unique_ptr<DuckDBPyRelation> FromDf(const DataFrame &df,
-	                                           DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	static unique_ptr<DuckDBPyRelation> FromDf(const DataFrame &df, shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	static unique_ptr<DuckDBPyRelation> Values(py::object values = py::list(),
-	                                           DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	                                           shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	static unique_ptr<DuckDBPyRelation> FromQuery(const string &query, const string &alias,
-	                                              DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	                                              shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	static unique_ptr<DuckDBPyRelation> RunQuery(const string &query, const string &alias,
-	                                             DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	                                             shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	static unique_ptr<DuckDBPyRelation> FromCsvAuto(const string &filename,
-	                                                DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	                                                shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	static unique_ptr<DuckDBPyRelation> FromParquet(const string &file_glob, bool binary_as_string,
 	                                                bool file_row_number, bool filename, bool hive_partitioning,
-	                                                DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	                                                shared_ptr<DuckDBPyConnection> conn = nullptr);
 
-	static unique_ptr<DuckDBPyRelation>
-	FromParquets(const vector<string> &file_globs, bool binary_as_string, bool file_row_number, bool filename,
-	             bool hive_partitioning, DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	static unique_ptr<DuckDBPyRelation> FromParquets(const vector<string> &file_globs, bool binary_as_string,
+	                                                 bool file_row_number, bool filename, bool hive_partitioning,
+	                                                 shared_ptr<DuckDBPyConnection> conn = nullptr);
 
-	static unique_ptr<DuckDBPyRelation>
-	FromSubstrait(py::bytes &proto, DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	static unique_ptr<DuckDBPyRelation> FromSubstrait(py::bytes &proto, shared_ptr<DuckDBPyConnection> conn = nullptr);
 
-	static unique_ptr<DuckDBPyRelation>
-	GetSubstrait(const string &query, DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	static unique_ptr<DuckDBPyRelation> GetSubstrait(const string &query,
+	                                                 shared_ptr<DuckDBPyConnection> conn = nullptr);
 
-	static unique_ptr<DuckDBPyRelation>
-	GetSubstraitJSON(const string &query, DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	static unique_ptr<DuckDBPyRelation> GetSubstraitJSON(const string &query,
+	                                                     shared_ptr<DuckDBPyConnection> conn = nullptr);
 
-	static unique_ptr<DuckDBPyRelation>
-	FromParquetDefault(const string &filename, DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	static unique_ptr<DuckDBPyRelation> FromParquetDefault(const string &filename,
+	                                                       shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	static unique_ptr<DuckDBPyRelation> FromArrow(py::object &arrow_object,
-	                                              DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	                                              shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	unique_ptr<DuckDBPyRelation> Project(const string &expr);
 
 	static unique_ptr<DuckDBPyRelation> ProjectDf(const DataFrame &df, const string &expr,
-	                                              DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	                                              shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	py::str GetAlias();
 
 	unique_ptr<DuckDBPyRelation> SetAlias(const string &expr);
 
 	static unique_ptr<DuckDBPyRelation> AliasDF(const DataFrame &df, const string &expr,
-	                                            DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	                                            shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	unique_ptr<DuckDBPyRelation> Filter(const string &expr);
 
 	static unique_ptr<DuckDBPyRelation> FilterDf(const DataFrame &df, const string &expr,
-	                                             DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	                                             shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	unique_ptr<DuckDBPyRelation> Limit(int64_t n, int64_t offset = 0);
 
 	static unique_ptr<DuckDBPyRelation> LimitDF(const DataFrame &df, int64_t n,
-	                                            DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	                                            shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	unique_ptr<DuckDBPyRelation> Order(const string &expr);
 
 	static unique_ptr<DuckDBPyRelation> OrderDf(const DataFrame &df, const string &expr,
-	                                            DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	                                            shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	unique_ptr<DuckDBPyRelation> Aggregate(const string &expr, const string &groups = "");
 
@@ -165,12 +163,11 @@ public:
 	unique_ptr<DuckDBPyRelation> CumMin(const string &aggr_columns);
 
 	static unique_ptr<DuckDBPyRelation> AggregateDF(const DataFrame &df, const string &expr, const string &groups = "",
-	                                                DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	                                                shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	unique_ptr<DuckDBPyRelation> Distinct();
 
-	static unique_ptr<DuckDBPyRelation> DistinctDF(const DataFrame &df,
-	                                               DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	static unique_ptr<DuckDBPyRelation> DistinctDF(const DataFrame &df, shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	DataFrame ToDF(bool date_as_object);
 
@@ -198,8 +195,7 @@ public:
 
 	void WriteCsv(const string &file);
 
-	static void WriteCsvDF(const DataFrame &df, const string &file,
-	                       DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	static void WriteCsvDF(const DataFrame &df, const string &file, shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	// should this return a rel with the new view?
 	unique_ptr<DuckDBPyRelation> CreateView(const string &view_name, bool replace = true);
@@ -209,7 +205,7 @@ public:
 	unique_ptr<DuckDBPyResult> Execute();
 
 	static unique_ptr<DuckDBPyResult> QueryDF(const DataFrame &df, const string &view_name, const string &sql_query,
-	                                          DuckDBPyConnection *conn = DuckDBPyConnection::DefaultConnection());
+	                                          shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	void InsertInto(const string &table);
 

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -16,14 +16,14 @@ namespace duckdb {
 DuckDBPyRelation::DuckDBPyRelation(shared_ptr<Relation> rel) : rel(move(rel)) {
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromDf(const DataFrame &df, DuckDBPyConnection *conn) {
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromDf(const DataFrame &df, shared_ptr<DuckDBPyConnection> conn) {
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}
 	return conn->FromDF(df);
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Values(py::object values, DuckDBPyConnection *conn) {
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Values(py::object values, shared_ptr<DuckDBPyConnection> conn) {
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}
@@ -31,7 +31,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Values(py::object values, DuckDBP
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromQuery(const string &query, const string &alias,
-                                                         DuckDBPyConnection *conn) {
+                                                         shared_ptr<DuckDBPyConnection> conn) {
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}
@@ -39,14 +39,15 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromQuery(const string &query, co
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::RunQuery(const string &query, const string &alias,
-                                                        DuckDBPyConnection *conn) {
+                                                        shared_ptr<DuckDBPyConnection> conn) {
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}
 	return conn->RunQuery(query, alias);
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromCsvAuto(const string &filename, DuckDBPyConnection *conn) {
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromCsvAuto(const string &filename,
+                                                           shared_ptr<DuckDBPyConnection> conn) {
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}
@@ -55,7 +56,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromCsvAuto(const string &filenam
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromParquet(const string &file_glob, bool binary_as_string,
                                                            bool file_row_number, bool filename, bool hive_partitioning,
-                                                           DuckDBPyConnection *conn) {
+                                                           shared_ptr<DuckDBPyConnection> conn) {
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}
@@ -64,35 +65,37 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromParquet(const string &file_gl
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromParquets(const vector<string> &file_globs, bool binary_as_string,
                                                             bool file_row_number, bool filename, bool hive_partitioning,
-                                                            DuckDBPyConnection *conn) {
+                                                            shared_ptr<DuckDBPyConnection> conn) {
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}
 	return conn->FromParquets(file_globs, binary_as_string, file_row_number, filename, hive_partitioning);
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::GetSubstrait(const string &query, DuckDBPyConnection *conn) {
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::GetSubstrait(const string &query, shared_ptr<DuckDBPyConnection> conn) {
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}
 	return conn->GetSubstrait(query);
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::GetSubstraitJSON(const string &query, DuckDBPyConnection *conn) {
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::GetSubstraitJSON(const string &query,
+                                                                shared_ptr<DuckDBPyConnection> conn) {
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}
 	return conn->GetSubstraitJSON(query);
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromSubstrait(py::bytes &proto, DuckDBPyConnection *conn) {
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromSubstrait(py::bytes &proto, shared_ptr<DuckDBPyConnection> conn) {
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}
 	return conn->FromSubstrait(proto);
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromArrow(py::object &arrow_object, DuckDBPyConnection *conn) {
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromArrow(py::object &arrow_object,
+                                                         shared_ptr<DuckDBPyConnection> conn) {
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}
@@ -106,7 +109,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Project(const string &expr) {
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::ProjectDf(const DataFrame &df, const string &expr,
-                                                         DuckDBPyConnection *conn) {
+                                                         shared_ptr<DuckDBPyConnection> conn) {
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}
@@ -122,7 +125,7 @@ py::str DuckDBPyRelation::GetAlias() {
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::AliasDF(const DataFrame &df, const string &expr,
-                                                       DuckDBPyConnection *conn) {
+                                                       shared_ptr<DuckDBPyConnection> conn) {
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}
@@ -134,7 +137,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Filter(const string &expr) {
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FilterDf(const DataFrame &df, const string &expr,
-                                                        DuckDBPyConnection *conn) {
+                                                        shared_ptr<DuckDBPyConnection> conn) {
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}
@@ -145,7 +148,8 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Limit(int64_t n, int64_t offset) 
 	return make_unique<DuckDBPyRelation>(rel->Limit(n, offset));
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::LimitDF(const DataFrame &df, int64_t n, DuckDBPyConnection *conn) {
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::LimitDF(const DataFrame &df, int64_t n,
+                                                       shared_ptr<DuckDBPyConnection> conn) {
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}
@@ -157,7 +161,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Order(const string &expr) {
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::OrderDf(const DataFrame &df, const string &expr,
-                                                       DuckDBPyConnection *conn) {
+                                                       shared_ptr<DuckDBPyConnection> conn) {
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}
@@ -331,7 +335,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::CumMin(const string &aggr_columns
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::AggregateDF(const DataFrame &df, const string &expr,
-                                                           const string &groups, DuckDBPyConnection *conn) {
+                                                           const string &groups, shared_ptr<DuckDBPyConnection> conn) {
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}
@@ -342,7 +346,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Distinct() {
 	return make_unique<DuckDBPyRelation>(rel->Distinct());
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::DistinctDF(const DataFrame &df, DuckDBPyConnection *conn) {
+unique_ptr<DuckDBPyRelation> DuckDBPyRelation::DistinctDF(const DataFrame &df, shared_ptr<DuckDBPyConnection> conn) {
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}
@@ -464,7 +468,7 @@ void DuckDBPyRelation::WriteCsv(const string &file) {
 	rel->WriteCSV(file);
 }
 
-void DuckDBPyRelation::WriteCsvDF(const DataFrame &df, const string &file, DuckDBPyConnection *conn) {
+void DuckDBPyRelation::WriteCsvDF(const DataFrame &df, const string &file, shared_ptr<DuckDBPyConnection> conn) {
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}
@@ -539,7 +543,7 @@ unique_ptr<DuckDBPyResult> DuckDBPyRelation::Execute() {
 }
 
 unique_ptr<DuckDBPyResult> DuckDBPyRelation::QueryDF(const DataFrame &df, const string &view_name,
-                                                     const string &sql_query, DuckDBPyConnection *conn) {
+                                                     const string &sql_query, shared_ptr<DuckDBPyConnection> conn) {
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}


### PR DESCRIPTION
This is necessary because of our intent to change the default connection.

As described here https://pybind11.readthedocs.io/en/stable/advanced/smart_ptrs.html#std-shared-ptr
when using shared_ptrs with pybind, you should also return them as shared pointers, or pybind will wrap it in a shared_ptr and that can cause undefined behavior

This change was previously part of another PR, which has now been closed.

After this PR is merged I can submit the PR to add all methods of DuckDBPyConnection to the 'duckdb' module