### PR TITLE
Issue #5622: Validate Timezone Characters

### DIFF
--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -20,9 +20,6 @@ static_assert(sizeof(timestamp_t) == sizeof(int64_t), "timestamp_t was padded");
 // T may be a space
 // Z is optional
 // ISO 8601
-static inline bool CharacterIsTimeZone(char c) {
-	return StringUtil::CharacterIsAlpha(c) || StringUtil::CharacterIsDigit(c) || c == '_' || c == '/';
-}
 
 bool Timestamp::TryConvertTimestampTZ(const char *str, idx_t len, timestamp_t &result, bool &has_offset, string_t &tz) {
 	idx_t pos;

--- a/src/function/scalar/date/strftime.cpp
+++ b/src/function/scalar/date/strftime.cpp
@@ -1101,8 +1101,8 @@ bool StrpTimeFormat::Parse(string_t str, ParseResult &result) {
 					pos++;
 				}
 				const auto tz_begin = data + pos;
-				// stop when we encounter a space or the end of the string
-				while (pos < size && !StringUtil::CharacterIsSpace(data[pos])) {
+				// stop when we encounter a non-tz character
+				while (pos < size && Timestamp::CharacterIsTimeZone(data[pos])) {
 					pos++;
 				}
 				const auto tz_end = data + pos;

--- a/src/include/duckdb/common/types/timestamp.hpp
+++ b/src/include/duckdb/common/types/timestamp.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/limits.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/winapi.hpp"
 
@@ -76,21 +77,21 @@ struct timestamp_t { // NOLINT
 	};
 
 	// special values
-	static timestamp_t infinity() {
+	static timestamp_t infinity() { // NOLINT
 		return timestamp_t(NumericLimits<int64_t>::Maximum());
-	} // NOLINT
-	static timestamp_t ninfinity() {
+	}                                // NOLINT
+	static timestamp_t ninfinity() { // NOLINT
 		return timestamp_t(-NumericLimits<int64_t>::Maximum());
-	} // NOLINT
-	static inline timestamp_t epoch() {
+	}                                   // NOLINT
+	static inline timestamp_t epoch() { // NOLINT
 		return timestamp_t(0);
 	} // NOLINT
 };
 
-struct timestamp_tz_t : public timestamp_t {};
-struct timestamp_ns_t : public timestamp_t {};
-struct timestamp_ms_t : public timestamp_t {};
-struct timestamp_sec_t : public timestamp_t {};
+struct timestamp_tz_t : public timestamp_t {};  // NOLINT
+struct timestamp_ns_t : public timestamp_t {};  // NOLINT
+struct timestamp_ms_t : public timestamp_t {};  // NOLINT
+struct timestamp_sec_t : public timestamp_t {}; // NOLINT
 
 //! The Timestamp class is a static class that holds helper functions for the Timestamp
 //! type.
@@ -120,6 +121,12 @@ public:
 	//! Create a Timestamp object from a specified (date, time) combination
 	DUCKDB_API static timestamp_t FromDatetime(date_t date, dtime_t time);
 	DUCKDB_API static bool TryFromDatetime(date_t date, dtime_t time, timestamp_t &result);
+
+	//! Is the character a valid part of a time zone name?
+	static inline bool CharacterIsTimeZone(char c) {
+		return StringUtil::CharacterIsAlpha(c) || StringUtil::CharacterIsDigit(c) || c == '_' || c == '/' || c == '+' ||
+		       c == '-';
+	}
 
 	//! Is the timestamp finite or infinite?
 	static inline bool IsFinite(timestamp_t timestamp) {

--- a/test/sql/function/timestamp/test_strptime.test
+++ b/test/sql/function/timestamp/test_strptime.test
@@ -249,6 +249,17 @@ select strptime('2020-12-30 23:25:58.745232-04', '%Y-%m-%d %H:%M:%S.%f%z');
 ----
 2020-12-31 03:25:58.745232+00
 
+# Don't swallow non-spaces
+query I
+SELECT strptime('Mon Oct 17 2022 22:00:00 +0000 (GMT)', '%a %b %d %Y %X %z (%Z)') as broken;
+----
+2022-10-17 22:00:00+00
+
+query I
+SELECT strptime('Mon Oct 17 2022 22:00:00 +0000 (GMT', '%a %b %d %Y %X %z (%Z') as working;
+----
+2022-10-17 22:00:00+00
+
 # incorrect usage
 statement error
 select strptime('2020-12-31 21:25:58.745232+0', '%Y-%m-%d %H:%M:%S.%f%z');

--- a/test/sql/function/timestamp/test_strptime.test
+++ b/test/sql/function/timestamp/test_strptime.test
@@ -251,14 +251,17 @@ select strptime('2020-12-30 23:25:58.745232-04', '%Y-%m-%d %H:%M:%S.%f%z');
 
 # Don't swallow non-spaces
 query I
-SELECT strptime('Mon Oct 17 2022 22:00:00 +0000 (GMT)', '%a %b %d %Y %X %z (%Z)') as broken;
+SELECT strptime('Mon Oct 17 2022 22:00:00 GMT+0000 (GMT)', '%a %b %d %Y %X GMT%z (%Z)') as fixed;
 ----
 2022-10-17 22:00:00+00
 
 query I
-SELECT strptime('Mon Oct 17 2022 22:00:00 +0000 (GMT', '%a %b %d %Y %X %z (%Z') as working;
+SELECT strptime('Mon Oct 17 2022 22:00:00 GMT+0000 (GMT', '%a %b %d %Y %X GMT%z (%Z') as working;
 ----
 2022-10-17 22:00:00+00
+
+statement error
+SELECT strptime('Mon Oct 17 2022 22:00:00 GMT+0000 (GMT)', '%a %b %d %Y %X GMT%z (%Z') as broken;
 
 # incorrect usage
 statement error


### PR DESCRIPTION
Use a single method to validate time zone characters, not just "non-space". Update the method to include all characters appearing in ICU TZ names.