### PR TITLE
Improve nodejs README

### DIFF
--- a/tools/nodejs/README.md
+++ b/tools/nodejs/README.md
@@ -102,10 +102,15 @@ var stmt = con.prepare('select ?::INTEGER as fortytwo', function(err, stmt) {
 
 ## Development
 
-Tests are located in `tools/nodejs/test`, these tests require Mocha to run.
-Along with all the other dev dependencies, this can be installed using `npm install` ran from `tools/nodejs` (this uses package.json)
-Tests can then be run with `npm test`
+### First install:
 
+To install all the dev dependencies of the project, navigate over to `tools/nodejs` and run `npm install` (this uses package.json)
+You might want to add the `--ignore-scripts` option if you don't care about building the package for now and just want to install the dependencies.
+
+### Tests:
+Tests are located in `tools/nodejs/test` and can be run with `npm test`
+
+### Additional notes:
 To build the NodeJS package from source, when on Windows, requires the following extra steps:
 - Set `OPENSSL_ROOT_DIR` to the root directory of an OpenSSL installation
 - Supply the `STATIC_OPENSSL=1` option when executing `make`, or set `-DOPENSSL_USE_STATIC_LIBS=1` manually when calling `cmake`

--- a/tools/nodejs/README.md
+++ b/tools/nodejs/README.md
@@ -103,7 +103,7 @@ var stmt = con.prepare('select ?::INTEGER as fortytwo', function(err, stmt) {
 ## Development
 
 Tests are located in `tools/nodejs/test`, these tests require Mocha to run.
-Mocha can be installed with `npm install mocha chai --save-dev`
+Along with all the other dev dependencies, this can be installed using `npm install` ran from `tools/nodejs` (this uses package.json)
 Tests can then be run with `npm test`
 
 To build the NodeJS package from source, when on Windows, requires the following extra steps:

--- a/tools/nodejs/README.md
+++ b/tools/nodejs/README.md
@@ -99,3 +99,14 @@ var stmt = con.prepare('select ?::INTEGER as fortytwo', function(err, stmt) {
   });
 });
 ```
+
+## Development
+
+Tests are located in `tools/nodejs/test`, these tests require Mocha to run.
+Mocha can be installed with `npm install mocha chai --save-dev`
+Tests can then be run with `npm test`
+
+To build the NodeJS package from source, when on Windows, requires the following extra steps:
+- Set `OPENSSL_ROOT_DIR` to the root directory of an OpenSSL installation
+- Supply the `STATIC_OPENSSL=1` option when executing `make`, or set `-DOPENSSL_USE_STATIC_LIBS=1` manually when calling `cmake`
+

--- a/tools/nodejs/README.md
+++ b/tools/nodejs/README.md
@@ -109,6 +109,7 @@ You might want to add the `--ignore-scripts` option if you don't care about buil
 
 ### Tests:
 Tests are located in `tools/nodejs/test` and can be run with `npm test`
+To run a single test, you can use `npm test -- --grep "name of test as given in describe"`
 
 ### Additional notes:
 To build the NodeJS package from source, when on Windows, requires the following extra steps:


### PR DESCRIPTION
I wanted to get my feet wet in the NodeJS client, but found it hard to get started.

I would also like to document the steps required to build from source.
From the `NodeJS.yml` file I have seen we do a regular build (using `make`)
followed by `./scripts/node_build.sh <npm version number>`

But there also these other scripts:
- `./scripts/install_node.sh`
- `tools/nodejs/configure`

With an additional Makefile in `tools/nodejs`, of which the rules are not documented either