### PR TITLE
Maintain BlockHandle of meta blocks by BlockManager

### DIFF
--- a/src/include/duckdb/storage/block_manager.hpp
+++ b/src/include/duckdb/storage/block_manager.hpp
@@ -65,9 +65,9 @@ public:
 	virtual idx_t FreeBlocks() = 0;
 
 	//! Register a block with the given block id in the base file
-	shared_ptr<BlockHandle> RegisterBlock(block_id_t block_id);
-	//! Register a meta block with the given block id and save the handle to meta_blocks
-	shared_ptr<BlockHandle> RegisterMetaBlock(block_id_t block_id);
+	shared_ptr<BlockHandle> RegisterBlock(block_id_t block_id, bool is_meta_block = false);
+	//! Clear cached handles for meta blocks
+	void ClearMetaBlockHandles();
 	//! Convert an existing in-memory buffer into a persistent disk-backed block
 	shared_ptr<BlockHandle> ConvertToPersistent(block_id_t block_id, shared_ptr<BlockHandle> old_block);
 
@@ -81,7 +81,7 @@ private:
 	mutex blocks_lock;
 	//! A mapping of block id -> BlockHandle
 	unordered_map<block_id_t, weak_ptr<BlockHandle>> blocks;
-	//! A mapping of meta block id -> BlockHandle
+	//! A map to cache the BlockHandles of meta blocks
 	unordered_map<block_id_t, shared_ptr<BlockHandle>> meta_blocks;
 };
 } // namespace duckdb

--- a/src/include/duckdb/storage/block_manager.hpp
+++ b/src/include/duckdb/storage/block_manager.hpp
@@ -66,6 +66,8 @@ public:
 
 	//! Register a block with the given block id in the base file
 	shared_ptr<BlockHandle> RegisterBlock(block_id_t block_id);
+	//! Register a meta block with the given block id and save the handle to meta_blocks
+	shared_ptr<BlockHandle> RegisterMetaBlock(block_id_t block_id);
 	//! Convert an existing in-memory buffer into a persistent disk-backed block
 	shared_ptr<BlockHandle> ConvertToPersistent(block_id_t block_id, shared_ptr<BlockHandle> old_block);
 
@@ -79,5 +81,7 @@ private:
 	mutex blocks_lock;
 	//! A mapping of block id -> BlockHandle
 	unordered_map<block_id_t, weak_ptr<BlockHandle>> blocks;
+	//! A mapping of meta block id -> BlockHandle
+	unordered_map<block_id_t, shared_ptr<BlockHandle>> meta_blocks;
 };
 } // namespace duckdb

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -249,7 +249,7 @@ BufferManager::BufferManager(DatabaseInstance &db, string tmp, idx_t maximum_mem
 BufferManager::~BufferManager() {
 }
 
-shared_ptr<BlockHandle> BlockManager::RegisterBlock(block_id_t block_id) {
+shared_ptr<BlockHandle> BlockManager::RegisterBlock(block_id_t block_id, bool is_meta_block) {
 	lock_guard<mutex> lock(blocks_lock);
 	// check if the block already exists
 	auto entry = blocks.find(block_id);
@@ -263,15 +263,15 @@ shared_ptr<BlockHandle> BlockManager::RegisterBlock(block_id_t block_id) {
 	}
 	// create a new block pointer for this block
 	auto result = make_shared<BlockHandle>(*this, block_id);
+	// for meta block, cache the handle in meta_blocks
+	if (is_meta_block) meta_blocks[block_id] = result;
 	// register the block pointer in the set of blocks as a weak pointer
 	blocks[block_id] = weak_ptr<BlockHandle>(result);
 	return result;
 }
 
-shared_ptr<BlockHandle> BlockManager::RegisterMetaBlock(block_id_t block_id) {
-	auto handle = RegisterBlock(block_id);
-	meta_blocks[block_id] = handle;
-	return handle;
+void BlockManager::ClearMetaBlockHandles() {
+	meta_blocks.clear();
 }
 
 shared_ptr<BlockHandle> BlockManager::ConvertToPersistent(block_id_t block_id, shared_ptr<BlockHandle> old_block) {

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -268,6 +268,12 @@ shared_ptr<BlockHandle> BlockManager::RegisterBlock(block_id_t block_id) {
 	return result;
 }
 
+shared_ptr<BlockHandle> BlockManager::RegisterMetaBlock(block_id_t block_id) {
+	auto handle = RegisterBlock(block_id);
+	meta_blocks[block_id] = handle;
+	return handle;
+}
+
 shared_ptr<BlockHandle> BlockManager::ConvertToPersistent(block_id_t block_id, shared_ptr<BlockHandle> old_block) {
 
 	// pin the old block to ensure we have it loaded in memory

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -264,7 +264,9 @@ shared_ptr<BlockHandle> BlockManager::RegisterBlock(block_id_t block_id, bool is
 	// create a new block pointer for this block
 	auto result = make_shared<BlockHandle>(*this, block_id);
 	// for meta block, cache the handle in meta_blocks
-	if (is_meta_block) meta_blocks[block_id] = result;
+	if (is_meta_block) {
+		meta_blocks[block_id] = result;
+	}
 	// register the block pointer in the set of blocks as a weak pointer
 	blocks[block_id] = weak_ptr<BlockHandle>(result);
 	return result;

--- a/src/storage/meta_block_reader.cpp
+++ b/src/storage/meta_block_reader.cpp
@@ -44,7 +44,7 @@ void MetaBlockReader::ReadNewBlock(block_id_t id) {
 	if (free_blocks_on_read) {
 		block_manager.MarkBlockAsModified(id);
 	}
-	block = block_manager.RegisterMetaBlock(id);
+	block = block_manager.RegisterBlock(id, true);
 	handle = buffer_manager.Pin(block);
 
 	next_block = Load<block_id_t>(handle.Ptr());

--- a/src/storage/meta_block_reader.cpp
+++ b/src/storage/meta_block_reader.cpp
@@ -44,7 +44,7 @@ void MetaBlockReader::ReadNewBlock(block_id_t id) {
 	if (free_blocks_on_read) {
 		block_manager.MarkBlockAsModified(id);
 	}
-	block = block_manager.RegisterBlock(id);
+	block = block_manager.RegisterMetaBlock(id);
 	handle = buffer_manager.Pin(block);
 
 	next_block = Load<block_id_t>(handle.Ptr());

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -136,6 +136,8 @@ void SingleFileStorageManager::LoadDatabase() {
 		//! Load from storage
 		auto checkpointer = SingleFileCheckpointReader(*this);
 		checkpointer.LoadFromStorage();
+		// finish load checkpoint, clear the cached handles of meta blocks
+		block_manager->ClearMetaBlockHandles();
 		// check if the WAL file exists
 		if (fs.FileExists(wal_path)) {
 			// replay the WAL


### PR DESCRIPTION
This PR fix #5698 

A map from `block_id` to `shared_ptr<BlockHandle>` can be maintained by `BlockManager`, making the `BlockHandle` of meta blocks not freed even when `MetaBlockReader` is freed.

To recover a TPC-H(SF=100) checkpoint (27GB), the running time of function `SingleFileStorageManager::LoadDatabase`:
| latest master | this PR  |
|  ----  | ----  |
|  5.4s  | **0.47s** |

There is a speedup of more than 10x. (Note that this experiment is performed when direct_io=false. For direct_io=true, there will be a much greater improvement.)
