### PR TITLE
Attempt to fix random NodeJS CI failure

### DIFF
--- a/scripts/node_build.sh
+++ b/scripts/node_build.sh
@@ -23,8 +23,8 @@ if [[ "$TARGET_ARCH" != "arm64" ]] ; then
 fi
 
 export PATH=$(npm bin):$PATH
-node-pre-gyp package testpackage testbinary --target_arch="$TARGET_ARCH"
+./node_modules/.bin/node-pre-gyp package testpackage testbinary --target_arch="$TARGET_ARCH"
 if [[ "$GITHUB_REF" =~ ^(refs/heads/master|refs/tags/v.+)$ ]] ; then
-  node-pre-gyp publish --target_arch=$TARGET_ARCH
-  node-pre-gyp info --target_arch=$TARGET_ARCH
+  ./node_modules/.bin/node-pre-gyp publish --target_arch=$TARGET_ARCH
+  ./node_modules/.bin/node-pre-gyp info --target_arch=$TARGET_ARCH
 fi


### PR DESCRIPTION
I have been experiencing random CI failures in `node.js Linux` on the Node 19 test.

The reported issue in the logs is `node-pre-gyp` could not be found on line 26 of `node_build.sh`, but line 19 works perfectly fine, which also calls `node-pre-gyp`, but does so through a relative path, instead of relying on the PATH env var.

So this changes line 26 and all later calls to `node-pre-gyp` to use the same method as line 19.

(probably should have just tested this on local CI first..)