### PR TITLE
Summarise for duckplyr

### DIFF
--- a/tools/rpkg/src/database.cpp
+++ b/tools/rpkg/src/database.cpp
@@ -5,7 +5,6 @@
 #include "duckdb/parser/parsed_data/create_type_info.hpp"
 #include "duckdb/function/cast/cast_function_set.hpp"
 #include "duckdb/common/vector_operations/generic_executor.hpp"
-#include "iostream"
 
 using namespace duckdb;
 

--- a/tools/rpkg/src/database.cpp
+++ b/tools/rpkg/src/database.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/parser/parsed_data/create_type_info.hpp"
 #include "duckdb/function/cast/cast_function_set.hpp"
 #include "duckdb/common/vector_operations/generic_executor.hpp"
+#include "iostream"
 
 using namespace duckdb;
 

--- a/tools/rpkg/src/relational.cpp
+++ b/tools/rpkg/src/relational.cpp
@@ -145,9 +145,6 @@ external_pointer<T> make_external(const string &rclass, Args &&...args) {
 		res_aggregates.push_back(expr->Copy());
 	}
 
-	std::cout << "aggregates = " << aggregates << std::endl;
-	std::cout << "groups.size() = " << groups.size() << std::endl;
-
 	int aggr_idx = 0; // has to be int for - reasons
 	auto aggr_names = aggregates.names();
 
@@ -166,15 +163,11 @@ external_pointer<T> make_external(const string &rclass, Args &&...args) {
 		return make_external<RelationWrapper>("duckdb_relation", lim);
 	}
 	return make_external<RelationWrapper>("duckdb_relation", res);
-
-
-	
 }
 
 [[cpp11::register]] SEXP rapi_rel_order(duckdb::rel_extptr_t rel, list orders) {
 	vector<OrderByNode> res_orders;
 
-	std::cout << "IN RAPI rel Order" << std::endl;
 	for (expr_extptr_t expr : orders) {
 		res_orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_FIRST, expr->Copy());
 	}
@@ -212,7 +205,6 @@ static SEXP result_to_df(unique_ptr<QueryResult> res) {
 	D_ASSERT(res->type == QueryResultType::MATERIALIZED_RESULT);
 	auto mat_res = (MaterializedQueryResult *)res.get();
 
-	std::cout << "IN result to df" << std::endl;
 	writable::integers row_names;
 	row_names.push_back(NA_INTEGER);
 	row_names.push_back(-mat_res->RowCount());

--- a/tools/rpkg/src/relational.cpp
+++ b/tools/rpkg/src/relational.cpp
@@ -23,8 +23,6 @@
 #include "duckdb/main/relation/limit_relation.hpp"
 #include "duckdb/main/relation/distinct_relation.hpp"
 
-#include "iostream"
-
 using namespace duckdb;
 using namespace cpp11;
 

--- a/tools/rpkg/src/relational.cpp
+++ b/tools/rpkg/src/relational.cpp
@@ -159,11 +159,16 @@ external_pointer<T> make_external(const string &rclass, Args &&...args) {
 		res_aggregates.push_back(move(expr));
 		aggr_idx++;
 	}
-	if (groups.size() == 0) {
-		auto res = std::make_shared<ProjectionRelation>(rel->rel, move())
-	}
 
 	auto res = std::make_shared<AggregateRelation>(rel->rel, move(res_aggregates), move(res_groups));
+	if (groups.size() == 0) {
+		auto lim = std::make_shared<LimitRelation>(res, 1, 0);
+		return make_external<RelationWrapper>("duckdb_relation", lim);
+	}
+	return make_external<RelationWrapper>("duckdb_relation", res);
+
+
+	
 }
 
 [[cpp11::register]] SEXP rapi_rel_order(duckdb::rel_extptr_t rel, list orders) {

--- a/tools/rpkg/tests/testthat/test_relational.R
+++ b/tools/rpkg/tests/testthat/test_relational.R
@@ -178,3 +178,16 @@ test_that("A union with different column types throws an error", {
      rel <- rel_union_all(test_df_a1, test_df_a2)
      expect_error(rapi_rel_to_df(rel), "Invalid Error: Result mismatch in query!")
 })
+
+
+test_that("rel aggregate with no groups but a sum over a column, sums the column", {
+skip("duckplyr specific")
+})
+
+test_that("rel aggregate with groups and aggregate function works", {
+skip("duckplyr specific")
+})
+
+test_that("rel aggregate with no groups and no aggregate function returns one line", {
+skip("duckplyr specific")
+})


### PR DESCRIPTION
This should address the issue found by Kirill in https://github.com/duckdblabs/duckplyr/pull/1. I don't know if it is "logically" correct however. Here I've provided an explanation of my thinking and feedback I'm looking for

To maintain parity with dplyr, we need to return only 1 row when there is no `.by` term. When `duckplyr_summarise` has no `.by` term, there are no elements in the groups list passed to the function `rapi_rel_aggregate`. This is equivalent to not having a `group by` clause in a SQL statement.

```R
> df2
# A tibble: 5 × 2
      g     x
  <dbl> <int>
1     1     1
2     1     2
3     2     3
4     2     4
5     2     5

> duckplyr:::duckplyr_summarise(df2, out=sum(x))
# A tibble: 1 × 1
    out
  <dbl>
1     15

> duckplyr:::duckplyr_summarise(df2, out=1)
# A tibble: 5 × 1
    out
  <dbl>
1     1
2     1
3     1
4     1
5     1
# The above statement compared to this one shows where the issues are.
# statement dplyr good
> summarise(df2,  out=1)
# A tibble: 1 × 1
    out
  <dbl>
1     1

> duckplyr:::duckplyr_summarize(df2, .by=g, out=sum(x))
# A tibble: 2 × 2
      g   out
  <dbl> <dbl>
1     1     3
2     2    12
```

What I am confused about is that `dckplyr:::duckplyr_summarise(df2, out=1)` translates to `Select 1 from df2` which returns 1 for every row in df2. This behavoir is also present in SQLlite.

```SQL
sqlite> create table t0 (c0 int, c1 varchar default "sfd");
sqlite> insert into t0 VALUES (1, "a"), (2, "b"), (3, "c"), (4,"d");
sqlite> select 1 from t0;
1
1
1
1
```

The fix I've proposed is that if there are no groups, we can limit the result to one row. If a user still supplies an aggregation function (e.g. `sum(), max(), avg()`) only one row will be returned and the `limit 1` term has no effect. 

Looking for feedback for

1) Why this might not be a good idea and how `limit 1` could break some output when no groups are applied
and
2) If it is indeed a bad idea, what kind of select/project operator should I be wrapping the aggregate operator with?


