### PR TITLE
Improve suggestions when LOAD of an extension fails

### DIFF
--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -67,6 +67,7 @@ private:
 	static bool IsRelease(const string &version_tag);
 	//! Apply any known extension aliases
 	static string ApplyExtensionAlias(string extension_name);
+	static bool CreateSuggestions(const string &extension_name, string &message);
 
 private:
 	static ExtensionLoadResult LoadExtensionInternal(DuckDB &db, const std::string &extension, bool initial_load);

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -42,15 +42,12 @@ ExtensionInitResult ExtensionHelper::InitialLoad(DBConfig &config, FileOpener *o
 	}
 
 	if (!fs.FileExists(filename)) {
-		string extra_error;
-		for (idx_t i = 0, ext_count = ExtensionHelper::DefaultExtensionCount(); i < ext_count; i++) {
-			if (ExtensionHelper::GetDefaultExtension(i).name == extension) {
-				extra_error = "\nExtension \"" + extension +
-				              "\" is a known extension. Install it first using \"INSTALL " + extension + "\".";
-				break;
-			}
+		string message;
+		bool exact_match = ExtensionHelper::CreateSuggestions(extension, message);
+		if (exact_match) {
+			message += "\nInstall it first using \"INSTALL " + extension + "\".";
 		}
-		throw IOException("Extension \"%s\" not found%s", filename, extra_error);
+		throw IOException("Extension \"%s\" not found.\n%s", filename, message);
 	}
 	{
 		auto handle = fs.OpenFile(filename, FileFlags::FILE_FLAGS_READ);

--- a/test/extension/install_extension.test_slow
+++ b/test/extension/install_extension.test_slow
@@ -24,5 +24,5 @@ FORCE INSTALL '__BUILD_DIRECTORY__/test/extension/loadable_extension_demo.duckdb
 statement ok
 LOAD 'loadable_extension_demo';
 
-statement error
+statement ok
 LOAD 'loadable_extension_demo';


### PR DESCRIPTION
Similar to INSTALL, we provide more helpful feedback:

##### Typo suggestions

```sql
D LOAD tpcdsx;
Error: IO Error: Extension "/Users/myth/.duckdb/extensions/2b08e3d017/osx_arm64/tpcdsx.duckdb_extension" not found.

Candidate extensions: "tpcds", "tpch", "s3", "icu", "fts"
```

##### Install suggestion
```sql
D LOAD tpcds;
Error: IO Error: Extension "/Users/myth/.duckdb/extensions/2b08e3d017/osx_arm64/tpcds.duckdb_extension" not found.
Extension "tpcds" is an existing extension.

Install it first using "INSTALL tpcds".
```