### PR TITLE
fix: nodejs source releases should be standalone

### DIFF
--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -63,6 +63,8 @@ jobs:
       - name: Setup
         shell: bash
         run: ./scripts/node_version.sh upload
+        env:
+          DUCKDB_NODE_BUILD_CACHE: 0  # create a standalone package
 
       - name: Validate Docs
         run: npx jsdoc-to-markdown --files tools/nodejs/lib/*.js >> $GITHUB_STEP_SUMMARY

--- a/scripts/node_version.sh
+++ b/scripts/node_version.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -ex
+
 cd tools/nodejs
 ./configure
 

--- a/scripts/node_version.sh
+++ b/scripts/node_version.sh
@@ -22,6 +22,8 @@ else
 	export TAG='--tag next'
 fi
 
+npm pack --dry-run
+
 # upload to npm, maybe
 if [[ "$GITHUB_REF" =~ ^(refs/heads/master|refs/tags/v.+)$ && "$1" = "upload" ]] ; then
 	npm config set //registry.npmjs.org/:_authToken $NODE_AUTH_TOKEN

--- a/tools/nodejs/configure.py
+++ b/tools/nodejs/configure.py
@@ -22,7 +22,7 @@ import package_build
 
 defines = ['BUILD_{}_EXTENSION'.format(ext.upper()) for ext in extensions]
 
-if 'DUCKDB_NODE_BUILD_CACHE' in os.environ and os.path.isfile(cache_file):
+if os.environ.get('DUCKDB_NODE_BUILD_CACHE') == '1' and os.path.isfile(cache_file):
     with open(cache_file, 'rb') as f:
         cache = pickle.load(f)
     source_list = cache['source_list']


### PR DESCRIPTION
Fixes the issue that was introduced in https://github.com/duckdb/duckdb/pull/5691