### PR TITLE
build: don't install python from chocolatey

### DIFF
--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -238,7 +238,7 @@ jobs:
       - name: Windows Build Tools
         shell: bash
         run: |
-          choco install python visualstudio2019-workload-vctools -y
+          choco install visualstudio2019-workload-vctools -y
 
       - name: Node Version
         shell: bash


### PR DESCRIPTION
Instead use the default runner python
This should fix the windows NodeJS builds