### PR TITLE
fix: use non-string-splitting variable interpolation in binding.gyp.in

### DIFF
--- a/tools/nodejs/binding.gyp.in
+++ b/tools/nodejs/binding.gyp.in
@@ -12,7 +12,7 @@
                 "${SOURCE_FILES}"
             ],
             "include_dirs": [
-                "<!@(node -p \"require('node-addon-api').include\")",
+                "<!(node -p \"require('node-addon-api').include_dir\")",
                 "${INCLUDE_FILES}"
             ],
             "defines": [


### PR DESCRIPTION
This can cause issues if built in a path containing spaces

See https://gyp.gsrc.io/docs/InputFormatReference.md#Command-Expansions

Additionally, `include` is deprecated, so updating to `include_dir`

Fixes #5643