### PR TITLE
Equalizing DBConfig constructors

### DIFF
--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -27,8 +27,7 @@ DBConfig::DBConfig() {
 	error_manager = make_unique<ErrorManager>();
 }
 
-DBConfig::DBConfig(std::unordered_map<string, string> &config_dict, bool read_only) {
-	compression_functions = make_unique<CompressionFunctionSet>();
+DBConfig::DBConfig(std::unordered_map<string, string> &config_dict, bool read_only) : DBConfig::DBConfig() {
 	if (read_only) {
 		options.access_mode = AccessMode::READ_ONLY;
 	}


### PR DESCRIPTION
The constructor which allows one to specify configuration does not initialize replacement opens. This was called by python, perhaps other clients.