### PR TITLE
We should not treat replacement open paths as disk paths

### DIFF
--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -57,6 +57,8 @@ public:
 	static void ReplacementOpenPost(ClientContext &context, const string &extension, DatabaseInstance &instance,
 	                                ReplacementOpenData *open_data);
 
+	static string ExtractExtensionPrefixFromPath(const string &path);
+
 private:
 	static const vector<string> PathComponents();
 	static ExtensionInitResult InitialLoad(DBConfig &context, FileOpener *opener, const string &extension);

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -57,6 +57,7 @@ public:
 	static void ReplacementOpenPost(ClientContext &context, const string &extension, DatabaseInstance &instance,
 	                                ReplacementOpenData *open_data);
 
+	// Returns extension name, or empty string if not a replacement open path
 	static string ExtractExtensionPrefixFromPath(const string &path);
 
 private:

--- a/src/main/db_instance_cache.cpp
+++ b/src/main/db_instance_cache.cpp
@@ -1,5 +1,5 @@
 #include "duckdb/main/db_instance_cache.hpp"
-
+#include "duckdb/main/extension_helper.hpp"
 namespace duckdb {
 
 string GetDBAbsolutePath(const string &database) {
@@ -8,6 +8,10 @@ string GetDBAbsolutePath(const string &database) {
 	}
 	if (database.rfind(":memory:", 0) == 0) {
 		// this is a memory db, just return it.
+		return database;
+	}
+	if (!ExtensionHelper::ExtractExtensionPrefixFromPath(database).empty()){
+		// this database path is handled by a replacement open and is not a file path
 		return database;
 	}
 	if (FileSystem::IsPathAbsolute(database)) {

--- a/src/main/db_instance_cache.cpp
+++ b/src/main/db_instance_cache.cpp
@@ -10,7 +10,7 @@ string GetDBAbsolutePath(const string &database) {
 		// this is a memory db, just return it.
 		return database;
 	}
-	if (!ExtensionHelper::ExtractExtensionPrefixFromPath(database).empty()){
+	if (!ExtensionHelper::ExtractExtensionPrefixFromPath(database).empty()) {
 		// this database path is handled by a replacement open and is not a file path
 		return database;
 	}

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -176,4 +176,20 @@ void ExtensionHelper::ReplacementOpenPost(ClientContext &context, const string &
 	}
 }
 
+string ExtensionHelper::ExtractExtensionPrefixFromPath(const string &path){
+	auto first_colon = path.find(':');
+	if (first_colon == string::npos || first_colon < 2) { // needs to be at least two characters because windows c: ...
+		return "";
+	}
+	auto extension = path.substr(0, first_colon);
+	D_ASSERT(extension.size() > 1);
+	// needs to be alphanumeric
+	for (auto &ch : extension) {
+		if (!isalnum(ch) && ch != '_') {
+			return "";
+		}
+	}
+	return extension;
+}
+
 } // namespace duckdb

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -176,7 +176,7 @@ void ExtensionHelper::ReplacementOpenPost(ClientContext &context, const string &
 	}
 }
 
-string ExtensionHelper::ExtractExtensionPrefixFromPath(const string &path){
+string ExtensionHelper::ExtractExtensionPrefixFromPath(const string &path) {
 	auto first_colon = path.find(':');
 	if (first_colon == string::npos || first_colon < 2) { // needs to be at least two characters because windows c: ...
 		return "";

--- a/src/main/extension_prefix_opener.cpp
+++ b/src/main/extension_prefix_opener.cpp
@@ -17,7 +17,7 @@ struct ExtensionPrefixOpenData : public ReplacementOpenData {
 static unique_ptr<ReplacementOpenData> ExtensionPrefixPreOpen(DBConfig &config, ReplacementOpenStaticData *) {
 	auto path = config.options.database_path;
 	string extension = ExtensionHelper::ExtractExtensionPrefixFromPath(path);
-	if(extension.empty()){
+	if (extension.empty()) {
 		return nullptr;
 	}
 	auto extension_data = ExtensionHelper::ReplacementOpenPre(extension, config);

--- a/src/main/extension_prefix_opener.cpp
+++ b/src/main/extension_prefix_opener.cpp
@@ -16,17 +16,9 @@ struct ExtensionPrefixOpenData : public ReplacementOpenData {
 
 static unique_ptr<ReplacementOpenData> ExtensionPrefixPreOpen(DBConfig &config, ReplacementOpenStaticData *) {
 	auto path = config.options.database_path;
-	auto first_colon = path.find(':');
-	if (first_colon == string::npos || first_colon < 2) { // needs to be at least two characters because windows c: ...
+	string extension = ExtensionHelper::ExtractExtensionPrefixFromPath(path);
+	if(extension.empty()){
 		return nullptr;
-	}
-	auto extension = path.substr(0, first_colon);
-	D_ASSERT(extension.size() > 1);
-	// needs to be alphanumeric
-	for (auto &ch : extension) {
-		if (!isalnum(ch) && ch != '_') {
-			return nullptr;
-		}
 	}
 	auto extension_data = ExtensionHelper::ReplacementOpenPre(extension, config);
 	if (extension_data) {


### PR DESCRIPTION
When testing out the replacement open from python, it tried to get the absolute path before checking if it was a replacement open style path `extension_name://other_stuff`. GetAbsolutePath prepended the pwd, and then it wasn't recognized as a replaement-open path. In addition, we should probably not cache replacement open databases in the dbcache, but limit that to local file paths. Since sensing what to do was required in two places, I factored out the logic to extract the extension name.

Not sure if returning an empty string is a great way to indicate "not an extension", so left a comment in the header.