### PR TITLE
Issue #5750: clangd std::move

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,2 +1,3 @@
 CompileFlags:
   CompilationDatabase: build/clangd
+  Add: -Wno-unqualified-std-cast-call


### PR DESCRIPTION
Disable the clang-tidy warning as we do this all over the place and it is useless noise.