### PR TITLE
Add support for non-order preserving parallel writing to the CSV and Parquet writers

### DIFF
--- a/benchmark/tpch/csv/write_lineitem_csv_no_order.benchmark
+++ b/benchmark/tpch/csv/write_lineitem_csv_no_order.benchmark
@@ -1,0 +1,18 @@
+# name: benchmark/tpch/csv/write_lineitem_csv_no_order.benchmark
+# description: Write the lineitem of TPC-H SF0.1 to a CSV file (without preserving insertion order)
+# group: [csv]
+
+name Write Lineitem CSV (Non-Order Preserving)
+group csv
+
+require tpch
+
+load
+CALL dbgen(sf=0.1);
+SET preserve_insertion_order=false;
+
+run
+COPY lineitem TO '${BENCHMARK_DIR}/lineitem.csv' (FORMAT CSV, DELIMITER '|', HEADER);
+
+result I
+600572

--- a/benchmark/tpch/parquet/write_lineitem_parquet.benchmark
+++ b/benchmark/tpch/parquet/write_lineitem_parquet.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/tpch/parquet/write_lineitem_parquet.benchmark
+# description: Write the lineitem of TPC-H SF1 to a Parquet file
+# group: [parquet]
+
+name Write Lineitem Parquet
+group parquet
+
+require parquet
+
+require tpch
+
+load
+CALL dbgen(sf=1);
+
+run
+COPY lineitem TO '${BENCHMARK_DIR}/lineitem.parquet';
+
+result I
+6001215

--- a/benchmark/tpch/parquet/write_lineitem_parquet_no_order.benchmark
+++ b/benchmark/tpch/parquet/write_lineitem_parquet_no_order.benchmark
@@ -1,0 +1,20 @@
+# name: benchmark/tpch/parquet/write_lineitem_parquet_no_order.benchmark
+# description: Write the lineitem of TPC-H SF1 to a Parquet file
+# group: [parquet]
+
+name Write Lineitem Parquet (Non-Order Preserving)
+group parquet
+
+require parquet
+
+require tpch
+
+load
+CALL dbgen(sf=1);
+SET preserve_insertion_order=false;
+
+run
+COPY lineitem TO '${BENCHMARK_DIR}/lineitem.parquet';
+
+result I
+6001215

--- a/extension/parquet/include/parquet_writer.hpp
+++ b/extension/parquet/include/parquet_writer.hpp
@@ -26,11 +26,6 @@ class FileSystem;
 class FileOpener;
 
 class ParquetWriter {
-	friend class ColumnWriter;
-	friend class BasicColumnWriter;
-	friend class ListColumnWriter;
-	friend class StructColumnWriter;
-
 public:
 	ParquetWriter(FileSystem &fs, string file_name, FileOpener *file_opener, vector<LogicalType> types,
 	              vector<string> names, duckdb_parquet::format::CompressionCodec::type codec);
@@ -41,6 +36,19 @@ public:
 
 	static duckdb_parquet::format::Type::type DuckDBTypeToParquetType(const LogicalType &duckdb_type);
 	static void SetSchemaProperties(const LogicalType &duckdb_type, duckdb_parquet::format::SchemaElement &schema_ele);
+
+	duckdb_apache::thrift::protocol::TProtocol *GetProtocol() {
+		return protocol.get();
+	}
+	duckdb_parquet::format::CompressionCodec::type GetCodec() {
+		return codec;
+	}
+	duckdb_parquet::format::Type::type GetType(idx_t schema_idx) {
+		return file_meta_data.schema[schema_idx].type;
+	}
+	BufferedFileWriter &GetWriter() {
+		return *writer;
+	}
 
 private:
 	string file_name;

--- a/extension/parquet/parquet-extension.cpp
+++ b/extension/parquet/parquet-extension.cpp
@@ -733,6 +733,17 @@ unique_ptr<LocalFunctionData> ParquetWriteInitializeLocal(ExecutionContext &cont
 	return make_unique<ParquetWriteLocalState>(context.client, bind_data.sql_types);
 }
 
+//===--------------------------------------------------------------------===//
+// Parallel
+//===--------------------------------------------------------------------===//
+bool ParquetWriteIsParallel(ClientContext &context, FunctionData &bind_data) {
+	auto &config = DBConfig::GetConfig(context);
+	if (config.options.preserve_insertion_order) {
+		return false;
+	}
+	return true;
+}
+
 unique_ptr<TableFunctionRef> ParquetScanReplacement(ClientContext &context, const string &table_name,
                                                     ReplacementScanData *data) {
 	auto lower_name = StringUtil::Lower(table_name);
@@ -769,6 +780,7 @@ void ParquetExtension::Load(DuckDB &db) {
 	function.copy_to_sink = ParquetWriteSink;
 	function.copy_to_combine = ParquetWriteCombine;
 	function.copy_to_finalize = ParquetWriteFinalize;
+	function.parallel = ParquetWriteIsParallel;
 	function.copy_from_bind = ParquetScanFunction::ParquetReadBind;
 	function.copy_from_function = scan_fun.functions[0];
 

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -249,18 +249,17 @@ void ParquetWriter::Flush(ColumnDataCollection &buffer) {
 	if (buffer.Count() == 0) {
 		return;
 	}
-	lock_guard<mutex> glock(lock);
 
 	// set up a new row group for this chunk collection
 	ParquetRowGroup row_group;
 	row_group.num_rows = buffer.Count();
-	row_group.file_offset = writer->GetTotalWritten();
 	row_group.__isset.file_offset = true;
 
+	vector<unique_ptr<ColumnWriterState>> states;
 	// iterate over each of the columns of the chunk collection and write them
 	D_ASSERT(buffer.ColumnCount() == column_writers.size());
 	for (idx_t col_idx = 0; col_idx < buffer.ColumnCount(); col_idx++) {
-		const unique_ptr<ColumnWriter> &col_writer = column_writers[col_idx];
+		const auto &col_writer = column_writers[col_idx];
 		auto write_state = col_writer->InitializeWriteState(row_group, buffer.GetAllocator());
 		if (col_writer->HasAnalyze()) {
 			for (auto &chunk : buffer.Chunks()) {
@@ -275,6 +274,14 @@ void ParquetWriter::Flush(ColumnDataCollection &buffer) {
 		for (auto &chunk : buffer.Chunks()) {
 			col_writer->Write(*write_state, chunk.data[col_idx], chunk.size());
 		}
+		states.push_back(move(write_state));
+	}
+
+	lock_guard<mutex> glock(lock);
+	row_group.file_offset = writer->GetTotalWritten();
+	for (idx_t col_idx = 0; col_idx < buffer.ColumnCount(); col_idx++) {
+		const auto &col_writer = column_writers[col_idx];
+		auto write_state = move(states[col_idx]);
 		col_writer->FinalizeWrite(*write_state);
 	}
 

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -40,7 +40,7 @@ void MoveTmpFile(ClientContext &context, const string &tmp_file_path) {
 PhysicalCopyToFile::PhysicalCopyToFile(vector<LogicalType> types, CopyFunction function_p,
                                        unique_ptr<FunctionData> bind_data, idx_t estimated_cardinality)
     : PhysicalOperator(PhysicalOperatorType::COPY_TO_FILE, move(types), estimated_cardinality),
-      function(move(function_p)), bind_data(move(bind_data)) {
+      function(move(function_p)), bind_data(move(bind_data)), parallel(false) {
 }
 
 SinkResultType PhysicalCopyToFile::Sink(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate,

--- a/src/execution/physical_plan/plan_copy_to_file.cpp
+++ b/src/execution/physical_plan/plan_copy_to_file.cpp
@@ -18,6 +18,9 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile
 	copy->file_path = op.file_path;
 	copy->use_tmp_file = use_tmp_file;
 	copy->per_thread_output = op.per_thread_output;
+	if (op.function.parallel) {
+		copy->parallel = op.function.parallel(context, *copy->bind_data);
+	}
 
 	copy->children.push_back(move(plan));
 	return move(copy);

--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
+#include "duckdb/main/config.hpp"
 #include <limits>
 
 namespace duckdb {
@@ -390,6 +391,17 @@ void WriteCSVFinalize(ClientContext &context, FunctionData &bind_data, GlobalFun
 	global_state.handle.reset();
 }
 
+//===--------------------------------------------------------------------===//
+// Parallel
+//===--------------------------------------------------------------------===//
+bool WriteCSVIsParallel(ClientContext &context, FunctionData &bind_data) {
+	auto &config = DBConfig::GetConfig(context);
+	if (config.options.preserve_insertion_order) {
+		return false;
+	}
+	return true;
+}
+
 void CSVCopyFunction::RegisterFunction(BuiltinFunctions &set) {
 	CopyFunction info("csv");
 	info.copy_to_bind = WriteCSVBind;
@@ -398,6 +410,7 @@ void CSVCopyFunction::RegisterFunction(BuiltinFunctions &set) {
 	info.copy_to_sink = WriteCSVSink;
 	info.copy_to_combine = WriteCSVCombine;
 	info.copy_to_finalize = WriteCSVFinalize;
+	info.parallel = WriteCSVIsParallel;
 
 	info.copy_from_bind = ReadCSVBind;
 	info.copy_from_function = ReadCSVTableFunction::GetFunction();

--- a/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
@@ -24,6 +24,7 @@ public:
 	unique_ptr<FunctionData> bind_data;
 	string file_path;
 	bool use_tmp_file;
+	bool parallel;
 	bool per_thread_output;
 
 public:
@@ -51,7 +52,7 @@ public:
 	}
 
 	bool ParallelSink() const override {
-		return per_thread_output;
+		return per_thread_output || parallel;
 	}
 };
 } // namespace duckdb

--- a/src/include/duckdb/function/copy_function.hpp
+++ b/src/include/duckdb/function/copy_function.hpp
@@ -44,13 +44,14 @@ typedef unique_ptr<FunctionData> (*copy_to_deserialize_t)(ClientContext &context
 typedef unique_ptr<FunctionData> (*copy_from_bind_t)(ClientContext &context, CopyInfo &info,
                                                      vector<string> &expected_names,
                                                      vector<LogicalType> &expected_types);
+typedef bool (*copy_to_is_parallel_t)(ClientContext &context, FunctionData &bind_data);
 
 class CopyFunction : public Function {
 public:
 	explicit CopyFunction(string name)
 	    : Function(name), copy_to_bind(nullptr), copy_to_initialize_local(nullptr), copy_to_initialize_global(nullptr),
-	      copy_to_sink(nullptr), copy_to_combine(nullptr), copy_to_finalize(nullptr), serialize(nullptr),
-	      deserialize(nullptr), copy_from_bind(nullptr) {
+	      copy_to_sink(nullptr), copy_to_combine(nullptr), copy_to_finalize(nullptr), parallel(nullptr),
+	      serialize(nullptr), deserialize(nullptr), copy_from_bind(nullptr) {
 	}
 
 	copy_to_bind_t copy_to_bind;
@@ -59,6 +60,7 @@ public:
 	copy_to_sink_t copy_to_sink;
 	copy_to_combine_t copy_to_combine;
 	copy_to_finalize_t copy_to_finalize;
+	copy_to_is_parallel_t parallel;
 
 	copy_to_serialize_t serialize;
 	copy_to_deserialize_t deserialize;

--- a/test/sql/copy/csv/tpch_parallel_copy.test_slow
+++ b/test/sql/copy/csv/tpch_parallel_copy.test_slow
@@ -1,0 +1,42 @@
+# name: test/sql/copy/csv/tpch_parallel_copy.test_slow
+# description: Test parallel TPC-H SF0.1
+# group: [csv]
+
+require tpch
+
+statement ok
+CALL dbgen(sf=0.1, suffix='_original');
+
+statement ok
+CALL dbgen(sf=0);
+
+statement ok
+SET preserve_insertion_order=false
+
+foreach tpch_tbl orders customer lineitem nation part partsupp region supplier
+
+statement ok
+COPY ${tpch_tbl}_original TO '__TEST_DIR__/${tpch_tbl}.csv' (DELIMITER '|', HEADER);
+
+statement ok
+COPY ${tpch_tbl} FROM '__TEST_DIR__/${tpch_tbl}.csv' (DELIMITER '|', HEADER);
+
+endloop
+
+loop i 1 9
+
+query I
+PRAGMA tpch(${i})
+----
+<FILE>:extension/tpch/dbgen/answers/sf0.1/q0${i}.csv
+
+endloop
+
+loop i 10 23
+
+query I
+PRAGMA tpch(${i})
+----
+<FILE>:extension/tpch/dbgen/answers/sf0.1/q${i}.csv
+
+endloop

--- a/test/sql/copy/parquet/tpch_parallel_copy.test_slow
+++ b/test/sql/copy/parquet/tpch_parallel_copy.test_slow
@@ -7,7 +7,7 @@ require parquet
 require tpch
 
 statement ok
-CALL dbgen(sf=0.1, suffix='_original');
+CALL dbgen(sf=1, suffix='_original');
 
 statement ok
 CALL dbgen(sf=0);
@@ -30,7 +30,7 @@ loop i 1 9
 query I
 PRAGMA tpch(${i})
 ----
-<FILE>:extension/tpch/dbgen/answers/sf0.1/q0${i}.csv
+<FILE>:extension/tpch/dbgen/answers/sf1/q0${i}.csv
 
 endloop
 
@@ -39,6 +39,6 @@ loop i 10 23
 query I
 PRAGMA tpch(${i})
 ----
-<FILE>:extension/tpch/dbgen/answers/sf0.1/q${i}.csv
+<FILE>:extension/tpch/dbgen/answers/sf1/q${i}.csv
 
 endloop

--- a/test/sql/copy/parquet/tpch_parallel_copy.test_slow
+++ b/test/sql/copy/parquet/tpch_parallel_copy.test_slow
@@ -1,0 +1,44 @@
+# name: test/sql/copy/parquet/tpch_parallel_copy.test_slow
+# description: Test parallel TPC-H SF0.1
+# group: [parquet]
+
+require parquet
+
+require tpch
+
+statement ok
+CALL dbgen(sf=0.1, suffix='_original');
+
+statement ok
+CALL dbgen(sf=0);
+
+statement ok
+SET preserve_insertion_order=false
+
+foreach tpch_tbl orders customer lineitem nation part partsupp region supplier
+
+statement ok
+COPY ${tpch_tbl}_original TO '__TEST_DIR__/${tpch_tbl}.parquet';
+
+statement ok
+COPY ${tpch_tbl} FROM '__TEST_DIR__/${tpch_tbl}.parquet';
+
+endloop
+
+loop i 1 9
+
+query I
+PRAGMA tpch(${i})
+----
+<FILE>:extension/tpch/dbgen/answers/sf0.1/q0${i}.csv
+
+endloop
+
+loop i 10 23
+
+query I
+PRAGMA tpch(${i})
+----
+<FILE>:extension/tpch/dbgen/answers/sf0.1/q${i}.csv
+
+endloop


### PR DESCRIPTION
This PR adds support for parallel writing to CSV/Parquet files as long as order-preservation is turned off:

```sql
SET preserve_insertion_order=false;
```

Below are some timings of writing the TPC-H SF1 lineitem table to CSV/Parquet on my laptop:

| Format  | Old  | New (8T) |
|---------|------|----------|
| CSV     | 2.6s | 0.38s    |
| Parquet | 7.5s | 1.3s     |