### PR TITLE
Correctly throw an error when attaching over HTTPFS

### DIFF
--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -284,6 +284,9 @@ unique_ptr<HTTPFileHandle> HTTPFileSystem::CreateHandle(const string &path, cons
 unique_ptr<FileHandle> HTTPFileSystem::OpenFile(const string &path, uint8_t flags, FileLockType lock,
                                                 FileCompressionType compression, FileOpener *opener) {
 	D_ASSERT(compression == FileCompressionType::UNCOMPRESSED);
+	if (!opener) {
+		throw IOException("Cannot open a HTTPFS file without a file opener");
+	}
 
 	// splitting query params from base path
 	string stripped_path, query_param;

--- a/test/sql/attach/attach_httpfs.test
+++ b/test/sql/attach/attach_httpfs.test
@@ -1,0 +1,11 @@
+# name: test/sql/attach/attach_httpfs.test
+# description: Test attach using httpfs
+# group: [attach]
+
+require skip_reload
+
+require httpfs
+
+# ATTACH over HTTPFS is not supported yet
+statement error
+ATTACH 'https://github.com/duckdb/duckdb/raw/master/test/sql/storage_version/storage_version.db' AS db;


### PR DESCRIPTION
We don't support attaching DuckDB databases over HTTPFS yet - with this PR we correctly throw an error instead of crashing.