### PR TITLE
Fully Qualified s3url request with globs

### DIFF
--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -814,6 +814,8 @@ vector<string> S3FileSystem::Glob(const string &glob_pattern, FileOpener *opener
 	// Parse pattern
 	auto parsed_url = S3UrlParse(glob_pattern, s3_auth_params);
 
+	ReadQueryParams(parsed_url.query_param, s3_auth_params);
+
 	// Do main listobjectsv2 request
 	vector<string> s3_keys;
 	string main_continuation_token = "";
@@ -854,10 +856,9 @@ vector<string> S3FileSystem::Glob(const string &glob_pattern, FileOpener *opener
 		pattern_trimmed = pattern_trimmed.substr(parsed_url.bucket.length() + 1);
 	}
 
-	// if a ? char was present, we re-add it here as the url parsing will have trimmed it.
-	if (parsed_url.query_param != "") {
-		pattern_trimmed += '?' + parsed_url.query_param;
-	}
+	//	if (parsed_url.query_param != "") {
+	//		pattern_trimmed += '?' + parsed_url.query_param;
+	//	}
 
 	vector<string> result;
 	for (const auto &s3_key : s3_keys) {
@@ -866,6 +867,10 @@ vector<string> S3FileSystem::Glob(const string &glob_pattern, FileOpener *opener
 
 		if (is_match) {
 			auto result_full_url = "s3://" + parsed_url.bucket + "/" + s3_key;
+			// if a ? char was present, we re-add it here as the url parsing will have trimmed it.
+			if (parsed_url.query_param != "") {
+				result_full_url += '?' + parsed_url.query_param;
+			}
 			result.push_back(result_full_url);
 		}
 	}

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -856,10 +856,6 @@ vector<string> S3FileSystem::Glob(const string &glob_pattern, FileOpener *opener
 		pattern_trimmed = pattern_trimmed.substr(parsed_url.bucket.length() + 1);
 	}
 
-	//	if (parsed_url.query_param != "") {
-	//		pattern_trimmed += '?' + parsed_url.query_param;
-	//	}
-
 	vector<string> result;
 	for (const auto &s3_key : s3_keys) {
 

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -515,8 +515,6 @@ ParsedS3Url S3FileSystem::S3UrlParse(string url, S3AuthParams &params) {
 		throw IOException("URL needs to contain a bucket name");
 	}
 
-	auto question_pos = url.find_last_of('?');
-
 	// See https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
 	if (params.url_style == "path") {
 		path = "/" + bucket;
@@ -524,13 +522,18 @@ ParsedS3Url S3FileSystem::S3UrlParse(string url, S3AuthParams &params) {
 		path = "";
 	}
 
-	if (question_pos == string::npos) {
-		path += url.substr(slash_pos);
-		query_param = "";
-	} else {
-		path += url.substr(slash_pos, question_pos - slash_pos);
+	auto question_pos = url.find_last_of('?');
+	if (question_pos != string::npos) {
 		query_param = url.substr(question_pos + 1);
 	}
+
+	if (!query_param.empty() && query_param.find('.') == string::npos) {
+		path += url.substr(slash_pos, question_pos - slash_pos);
+	} else {
+		path += url.substr(slash_pos);
+		query_param = "";
+	}
+
 	if (path.empty()) {
 		throw IOException("URL needs to contain key");
 	}

--- a/test/sql/copy/s3/fully_qualified_s3_url.test
+++ b/test/sql/copy/s3/fully_qualified_s3_url.test
@@ -22,7 +22,7 @@ statement ok
 SET s3_region='eu-west-1'; SET s3_endpoint='duckdb-minio.com:9000'; SET s3_use_ssl=false;SET s3_url_style='path';
 
 statement error
-COPY test TO 's3://test-bucket/s3_query_params/test.csv;
+COPY test TO 's3://test-bucket/s3_query_params/test.csv';
 
 #test with .csv file
 statement ok
@@ -41,6 +41,22 @@ COPY test TO 's3://test-bucket/s3_query_params/test.parquet?s3_access_key_id=min
 
 query I
 SELECT i FROM "s3://test-bucket/s3_query_params/test.parquet?s3_access_key_id=minio_duckdb_user&s3_secret_access_key=minio_duckdb_user_password" LIMIT 3
+----
+0
+1
+2
+
+#test GLOB with .parquet file
+query I
+SELECT i FROM "s3://test-bucket/s3_query_params/*.parquet?s3_access_key_id=minio_duckdb_user&s3_secret_access_key=minio_duckdb_user_password" LIMIT 3
+----
+0
+1
+2
+
+#test GLOB with .parquet file
+query I
+SELECT i FROM "s3://test-bucket/s3_query_params/????.parquet?s3_access_key_id=minio_duckdb_user&s3_secret_access_key=minio_duckdb_user_password" LIMIT 3
 ----
 0
 1

--- a/test/sql/copy/s3/fully_qualified_s3_url.test
+++ b/test/sql/copy/s3/fully_qualified_s3_url.test
@@ -23,6 +23,8 @@ SET s3_region='eu-west-1'; SET s3_endpoint='duckdb-minio.com:9000'; SET s3_use_s
 
 statement error
 COPY test TO 's3://test-bucket/s3_query_params/test.csv';
+----
+IO Error: Unable to connect to URL "s3://test-bucket/s3_query_params/test.csv": 403 (Forbidden)
 
 #test with .csv file
 statement ok


### PR DESCRIPTION
Addresses issue #5766 

S3 access credentials can be passed as query paramaters(see #4786 ), however this did not work properly with globs.  This pr fixes that