### PR TITLE
docs: add nodejs connection args to docs

### DIFF
--- a/tools/nodejs/lib/duckdb.js
+++ b/tools/nodejs/lib/duckdb.js
@@ -47,6 +47,7 @@ var OPEN_PRIVATECACHE = duckdb.OPEN_PRIVATECACHE;
 /**
  * Main database interface
  * @arg path - path to database file or :memory: for in-memory database
+ * @arg access_mode - access mode
  * @arg config - the configuration object
  * @arg callback - callback function
  */

--- a/tools/nodejs/lib/duckdb.js
+++ b/tools/nodejs/lib/duckdb.js
@@ -46,6 +46,9 @@ var OPEN_PRIVATECACHE = duckdb.OPEN_PRIVATECACHE;
 // some wrappers for compatibilities sake
 /**
  * Main database interface
+ * @arg path - path to database file or :memory: for in-memory database
+ * @arg config - the configuration object
+ * @arg callback - callback function
  */
 var Database = duckdb.Database;
 /**


### PR DESCRIPTION
Asked the question [here](https://discord.com/channels/909674491309850675/921125471905787944/1055962760153923614) wondering how to pass a config to the nodejs database constructor since I couldn't find it in the docs. This PR is an attempt to add that info to the docs.