### PR TITLE
Added the 'GetExpectedParameterTypes' method to the PreparedStatement…

### DIFF
--- a/src/include/duckdb/main/prepared_statement.hpp
+++ b/src/include/duckdb/main/prepared_statement.hpp
@@ -60,6 +60,8 @@ public:
 	DUCKDB_API const vector<LogicalType> &GetTypes();
 	//! Returns the result names of the prepared statement
 	DUCKDB_API const vector<string> &GetNames();
+	//! Returns the map of parameter index to the expected type of parameter
+	DUCKDB_API vector<LogicalType> GetExpectedParameterTypes() const;
 
 	//! Create a pending query result of the prepared statement with the given set of arguments
 	template <typename... Args>

--- a/src/main/prepared_statement.cpp
+++ b/src/main/prepared_statement.cpp
@@ -52,6 +52,16 @@ const vector<string> &PreparedStatement::GetNames() {
 	return data->names;
 }
 
+vector<LogicalType> PreparedStatement::GetExpectedParameterTypes() const {
+	D_ASSERT(data);
+	vector<LogicalType> expected_types(data->value_map.size());
+	for (auto &it : data->value_map) {
+		D_ASSERT(it.second);
+		expected_types[it.first - 1] = it.second->value.type();
+	}
+	return expected_types;
+}
+
 unique_ptr<QueryResult> PreparedStatement::Execute(vector<Value> &values, bool allow_stream_result) {
 	auto pending = PendingQuery(values, allow_stream_result);
 	if (pending->HasError()) {

--- a/src/main/prepared_statement.cpp
+++ b/src/main/prepared_statement.cpp
@@ -56,8 +56,11 @@ vector<LogicalType> PreparedStatement::GetExpectedParameterTypes() const {
 	D_ASSERT(data);
 	vector<LogicalType> expected_types(data->value_map.size());
 	for (auto &it : data->value_map) {
+		D_ASSERT(it.first >= 1);
+		idx_t param_index = it.first - 1;
+		D_ASSERT(param_index < expected_types.size());
 		D_ASSERT(it.second);
-		expected_types[it.first - 1] = it.second->value.type();
+		expected_types[param_index] = it.second->value.type();
 	}
 	return expected_types;
 }


### PR DESCRIPTION
This method allows to get the expected types of parameters of SQL query.

To be short.
DuckDB amalgamation can be used in the Erlang NIF. In the Erlang the parameters of SQL query are passed as terms. [Term](https://www.erlang.org/doc/reference_manual/data_types.html) - a piece of data of any data type. We can use special Erlang NIF functions like enif_is_number(term), enif_is_binary(term) to detect the type of the term we passed into query and convert this term parameter to the duckdb::Value parameter of this detected type. 

Basically, it works, but may be it would be more correct if we could get the expected types of parsed SQL query parameters from the duckdb::PreparedStatement not from the terms itself, and try convert Erlang terms to the duckdb::Value's of expected types.