### PR TITLE
Change AddString to AddBlob in update_segment.cpp

### DIFF
--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -616,7 +616,7 @@ struct UpdateSelectElement {
 
 template <>
 string_t UpdateSelectElement::Operation(UpdateSegment *segment, string_t element) {
-	return element.IsInlined() ? element : segment->GetStringHeap().AddString(element);
+	return element.IsInlined() ? element : segment->GetStringHeap().AddBlob(element);
 }
 
 template <class T>
@@ -942,7 +942,7 @@ idx_t UpdateStringStatistics(UpdateSegment *segment, SegmentStatistics &stats, V
 		for (idx_t i = 0; i < count; i++) {
 			((StringStatistics &)*stats.statistics).Update(update_data[i]);
 			if (!update_data[i].IsInlined()) {
-				update_data[i] = segment->GetStringHeap().AddString(update_data[i]);
+				update_data[i] = segment->GetStringHeap().AddBlob(update_data[i]);
 			}
 		}
 		sel.Initialize(nullptr);
@@ -955,7 +955,7 @@ idx_t UpdateStringStatistics(UpdateSegment *segment, SegmentStatistics &stats, V
 				sel.set_index(not_null_count++, i);
 				((StringStatistics &)*stats.statistics).Update(update_data[i]);
 				if (!update_data[i].IsInlined()) {
-					update_data[i] = segment->GetStringHeap().AddString(update_data[i]);
+					update_data[i] = segment->GetStringHeap().AddBlob(update_data[i]);
 				}
 			}
 		}

--- a/test/sql/types/blob/test_blob_invalid_utf8.test
+++ b/test/sql/types/blob/test_blob_invalid_utf8.test
@@ -1,0 +1,12 @@
+# name: test/sql/types/blob/test_blob_invalid_utf8.test
+# description: BLOB with invalid UTF-8
+# group: [blob]
+
+statement ok
+CREATE TABLE b(b blob);
+
+statement ok
+INSERT INTO b VALUES (NULL);
+
+statement ok
+UPDATE b SET b=blob'\x80abcdefghjijklmnopqrstuvwxyz';


### PR DESCRIPTION
I've run into an issue when working on my geo extension (that makes heavy use of blobs) where I can't update a blob column when the result is invalid UTF-8. Specifically I hit the assertion in: https://github.com/duckdb/duckdb/blob/84b9e770f3663e8f179d34c09ecf86d0133b4afd/src/common/types/string_heap.cpp#L24 when called from [update_segment.cpp](https://github.com/duckdb/duckdb/blob/84b9e770f3663e8f179d34c09ecf86d0133b4afd/src/storage/table/update_segment.cpp)

I wish I could provide a reproducible example on master, but I can't find any existing BLOB-returning function in core that is able to produce invalid UTF-8.

As far as I can tell this is a harmless and reasonable fix? Surely we don't want to perform UTF-8 validation this far down in the storage when it could be a blob?