### PR TITLE
Remove unnecessary code modifying the validity mask of the child vectors of a struct

### DIFF
--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -129,19 +129,9 @@ void StructColumnData::Append(BaseStatistics &stats, ColumnAppendState &state, V
 	// append the null values
 	validity.Append(*stats.validity_stats, state.child_appends[0], vector, count);
 
-	auto &struct_validity = FlatVector::Validity(vector);
-
 	auto &struct_stats = (StructStatistics &)stats;
 	auto &child_entries = StructVector::GetEntries(vector);
 	for (idx_t i = 0; i < child_entries.size(); i++) {
-		if (!struct_validity.AllValid()) {
-			// we set the child entries of the struct to NULL
-			// for any values in which the struct itself is NULL
-			child_entries[i]->Flatten(count);
-
-			auto &child_validity = FlatVector::Validity(*child_entries[i]);
-			child_validity.Combine(struct_validity, count);
-		}
 		sub_columns[i]->Append(*struct_stats.child_stats[i], state.child_appends[i + 1], *child_entries[i], count);
 	}
 }

--- a/test/sql/storage/invalid_unicode_scrambled.test_slow
+++ b/test/sql/storage/invalid_unicode_scrambled.test_slow
@@ -1,0 +1,14 @@
+# name: test/sql/storage/invalid_unicode_scrambled.test_slow
+# description: Issue #1650 - "invalid unicode detected in segment statistics" when inserting structs with strings and NULL values
+# group: [storage]
+
+require httpfs
+
+require parquet
+
+statement ok
+create or replace table blah as (with
+us as (select distinct * from 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/invalid_unicode_scrambled.parquet') select Address from
+us);
+
+


### PR DESCRIPTION
This was old code that was added to ensure child vectors are NULL where-ever struct vectors themselves are NULL in the storage layer - but this property is now enforced by the system for all struct vectors everywhere, so this code is not necessary here anymore.

In addition, this code was not correct and introduced issues in certain edge cases when appending structs with string values (#1650, CC @AlexanderVR thanks for finding a reproducible example and sharing the data).