### PR TITLE
Add date part specifier synonyms

### DIFF
--- a/src/function/scalar/date/date_part.cpp
+++ b/src/function/scalar/date/date_part.cpp
@@ -16,28 +16,33 @@ namespace duckdb {
 
 bool TryGetDatePartSpecifier(const string &specifier_p, DatePartSpecifier &result) {
 	auto specifier = StringUtil::Lower(specifier_p);
-	if (specifier == "year" || specifier == "y" || specifier == "years") {
+	if (specifier == "year" || specifier == "yr" || specifier == "y" || specifier == "years" || specifier == "yrs") {
 		result = DatePartSpecifier::YEAR;
 	} else if (specifier == "month" || specifier == "mon" || specifier == "months" || specifier == "mons") {
 		result = DatePartSpecifier::MONTH;
 	} else if (specifier == "day" || specifier == "days" || specifier == "d" || specifier == "dayofmonth") {
 		result = DatePartSpecifier::DAY;
-	} else if (specifier == "decade" || specifier == "decades") {
+	} else if (specifier == "decade" || specifier == "dec" || specifier == "decades" || specifier == "decs") {
 		result = DatePartSpecifier::DECADE;
-	} else if (specifier == "century" || specifier == "centuries") {
+	} else if (specifier == "century" || specifier == "cent" || specifier == "centuries" || specifier == "c") {
 		result = DatePartSpecifier::CENTURY;
-	} else if (specifier == "millennium" || specifier == "millennia" || specifier == "millenium") {
+	} else if (specifier == "millennium" || specifier == "mil" || specifier == "millenniums" ||
+	           specifier == "millennia" || specifier == "mils" || specifier == "millenium") {
 		result = DatePartSpecifier::MILLENNIUM;
-	} else if (specifier == "microseconds" || specifier == "microsecond") {
+	} else if (specifier == "microseconds" || specifier == "microsecond" || specifier == "us" || specifier == "usec" ||
+	           specifier == "usecs" || specifier == "usecond" || specifier == "useconds") {
 		result = DatePartSpecifier::MICROSECONDS;
 	} else if (specifier == "milliseconds" || specifier == "millisecond" || specifier == "ms" || specifier == "msec" ||
-	           specifier == "msecs") {
+	           specifier == "msecs" || specifier == "msecond" || specifier == "mseconds") {
 		result = DatePartSpecifier::MILLISECONDS;
-	} else if (specifier == "second" || specifier == "seconds" || specifier == "s") {
+	} else if (specifier == "second" || specifier == "sec" || specifier == "seconds" || specifier == "secs" ||
+	           specifier == "s") {
 		result = DatePartSpecifier::SECOND;
-	} else if (specifier == "minute" || specifier == "minutes" || specifier == "m") {
+	} else if (specifier == "minute" || specifier == "min" || specifier == "minutes" || specifier == "mins" ||
+	           specifier == "m") {
 		result = DatePartSpecifier::MINUTE;
-	} else if (specifier == "hour" || specifier == "hours" || specifier == "h") {
+	} else if (specifier == "hour" || specifier == "hr" || specifier == "hours" || specifier == "hrs" ||
+	           specifier == "h") {
 		result = DatePartSpecifier::HOUR;
 	} else if (specifier == "epoch") {
 		// seconds since 1970-01-01

--- a/test/sql/types/interval/test_interval.test
+++ b/test/sql/types/interval/test_interval.test
@@ -22,43 +22,63 @@ SELECT INTERVAL '2Y 1 M';
 ----
 2 years 00:01:00
 
-# 2 years 4 days one minute 3 seconds 20 milliseconds
+# 2 years 4 days one minute 3 seconds 20 milliseconds 16 microseconds
 query T
-SELECT INTERVAL '2Y 1 month 1 M 3S 20mS';
+SELECT INTERVAL '2Y 1 month 1 M 3S 20mS 16uS';
 ----
-2 years 1 month 00:01:03.02
+2 years 1 month 00:01:03.020016
 
 query T
-SELECT INTERVAL '2Y 1 month 02:01:03';
+SELECT INTERVAL '2Y 1 month 02:01:03.020016';
 ----
-2 years 1 month 02:01:03
+2 years 1 month 02:01:03.020016
 
 query T
-SELECT INTERVAL '2Y 1 month 1M 3S 20mS'::VARCHAR;
+SELECT INTERVAL '2Y 1 month 1M 3S 20mS 16uS'::VARCHAR;
 ----
-2 years 1 month 00:01:03.02
-
-# -2 years +4 days +one minute 3 seconds 20 milliseconds
-query T
-SELECT INTERVAL '-2Y 4 days 1 MinUteS 3S 20mS';
-----
--2 years 4 days 00:01:03.02
+2 years 1 month 00:01:03.020016
 
 query T
-SELECT INTERVAL '-2Y 4 days 1 MinUteS 3S 20mS'::VARCHAR;
+SELECT INTERVAL '2 yr 1 mon 1 min 3 sec 20 msec 16 usec';
 ----
--2 years 4 days 00:01:03.02
+2 years 1 month 00:01:03.020016
+
+query T
+SELECT INTERVAL '2 yrs 1 mons 1 mins 3 secs 20 msecs 16 usecs';
+----
+2 years 1 month 00:01:03.020016
+
+# -2 years +4 days 5 hours 1 minute 3 seconds 20 milliseconds 16 microseconds
+query T
+SELECT INTERVAL '-2Y 4 days 5 Hours 1 MinUteS 3S 20mS 16uS';
+----
+-2 years 4 days 05:01:03.020016
+
+query T
+SELECT INTERVAL '-2Y 4 days 5 Hours 1 MinUteS 3S 20mS 16uS'::VARCHAR;
+----
+-2 years 4 days 05:01:03.020016
+
+query T
+SELECT INTERVAL '-2yr 4 d 5 hr 1 min 3 second 20 msecond 16 usecond';
+----
+-2 years 4 days 05:01:03.020016
+
+query T
+SELECT INTERVAL '-2yrs 4 d 5 hrs 1 mins 3 seconds 20 mseconds 16 useconds'::VARCHAR;
+----
+-2 years 4 days 05:01:03.020016
 
 # test ago usage
 query T
-SELECT INTERVAL '2Y 4 days 1 MinUteS 3S 20mS ago'::VARCHAR;
+SELECT INTERVAL '2Y 4 days 1 MinUteS 3S 20mS 16uS ago'::VARCHAR;
 ----
--2 years -4 days -00:01:03.02
+-2 years -4 days -00:01:03.020016
 
 query T
-SELECT INTERVAL '2Y 4 days 1 MinUteS 3S 20mS ago  '::VARCHAR;
+SELECT INTERVAL '2Y 4 days 1 MinUteS 3S 20mS 16uS ago  '::VARCHAR;
 ----
--2 years -4 days -00:01:03.02
+-2 years -4 days -00:01:03.020016
 
 # months and hours, with optional @
 query T
@@ -235,6 +255,20 @@ SELECT INTERVAL '1 millennium 2 centuries 1 decade 3 quarter';
 ----
 1210 years 9 months
 
+query T
+SELECT INTERVAL '1 millenniums 2 century 1 dec 3 quarter';
+----
+1210 years 9 months
+
+query T
+SELECT INTERVAL '1 mil 2 cent 1 decs 3 quarter';
+----
+1210 years 9 months
+
+query T
+SELECT INTERVAL '1 mils 2 c 1 decades 3 quarter';
+----
+1210 years 9 months
 
 query T
 SELECT INTERVAL '-2147483647 months -2147483647 days -9223372036854775msecs';


### PR DESCRIPTION
This PR adds the following date part specifier synonyms.

| Added synonyms | Synonyms of |
|-|-|
| `yr` and `yrs` | `year` |
| `dec` and `decs` | `decade` |
| `cent` and `c` | `century` |
| `mil`, `millenniums`, and `mils` | `millennium` |
| `us`, `usec`, `usecs`, `usecond`, and `useconds` | `microseconds` |
| `msecond` and `mseconds` | `milliseconds` |
| `sec` and `secs` | `second` |
| `min` and `mins` | `minute` |
| `hr` and `hrs` | `hour` |

All of them are available in PostgreSQL.