### PR TITLE
Fix #5853: fully qualify function names inside macros during the binding process

### DIFF
--- a/src/include/duckdb/function/function_serialization.hpp
+++ b/src/include/duckdb/function/function_serialization.hpp
@@ -47,7 +47,7 @@ public:
 		// note: original_arguments are optional (can be list of size 0)
 		auto original_arguments = reader.ReadRequiredSerializableList<LogicalType, LogicalType>();
 
-		auto func_catalog = Catalog::GetEntry(context, type, INVALID_CATALOG, DEFAULT_SCHEMA, name);
+		auto func_catalog = Catalog::GetEntry(context, type, SYSTEM_CATALOG, DEFAULT_SCHEMA, name);
 		if (!func_catalog || func_catalog->type != type) {
 			throw InternalException("Cant find catalog entry for function %s", name);
 		}

--- a/test/sql/catalog/function/test_recursive_macro.test
+++ b/test/sql/catalog/function/test_recursive_macro.test
@@ -1,0 +1,33 @@
+# name: test/sql/catalog/function/test_recursive_macro.test
+# description: Test recursive macros
+# group: [function]
+
+statement ok
+CREATE MACRO "sum"(x) AS (CASE WHEN sum(x) IS NULL THEN 0 ELSE sum(x) END);
+
+query I
+SELECT sum(1);
+----
+1
+
+query I
+SELECT sum(1) WHERE 42=0
+----
+0
+
+statement ok
+DROP MACRO sum
+
+# recursive macro with explicit qualification
+statement ok
+CREATE MACRO "sum"(x) AS (CASE WHEN system.main.sum(x) IS NULL THEN 0 ELSE system.main.sum(x) END);
+
+query I
+SELECT sum(1);
+----
+1
+
+query I
+SELECT sum(1) WHERE 42=0
+----
+0


### PR DESCRIPTION
Fixes #5853

During binding we extend unqualified function calls with the catalog and schema information of the function we found, e.g.:

```sql
CREATE MACRO "sum"(x) AS (CASE WHEN sum(x) IS NULL THEN 0 ELSE sum(x) END);
-- becomes
CREATE MACRO "sum"(x) AS (CASE WHEN system.main.sum(x) IS NULL THEN 0 ELSE system.main.sum(x) END);
```

This prevents recursive macros from being created, where during initial binding we bind to `system.main.sum`, but during subsequent binding we bind to the same macro again (`db.main.sum`).