### PR TITLE
Parser: add support for unicode space characters

### DIFF
--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -107,6 +107,15 @@ void Parser::ParseQuery(const string &query) {
 	Transformer transformer(options.max_expression_depth);
 	string parser_error;
 	{
+		// check if there are any unicode spaces in the string
+		string new_query;
+		if (StripUnicodeSpaces(query, new_query)) {
+			// there are - strip the unicode spaces and re-run the query
+			ParseQuery(new_query);
+			return;
+		}
+	}
+	{
 		PostgresParser::SetPreserveIdentifierCase(options.preserve_identifier_case);
 		PostgresParser parser;
 		parser.Parse(query);
@@ -124,12 +133,6 @@ void Parser::ParseQuery(const string &query) {
 		}
 	}
 	if (!parser_error.empty()) {
-		// parser error - check if there are any unicode spaces in the string
-		string new_query;
-		if (StripUnicodeSpaces(query, new_query)) {
-			ParseQuery(new_query);
-			return;
-		}
 		if (options.extensions) {
 			for (auto &ext : *options.extensions) {
 				D_ASSERT(ext.parse_function);

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -19,41 +19,134 @@ namespace duckdb {
 Parser::Parser(ParserOptions options_p) : options(options_p) {
 }
 
+static bool ReplaceUnicodeSpaces(const string &query, string &new_query, vector<idx_t> &unicode_spaces) {
+	const idx_t UNICODE_SPACE_BYTES = 3;
+	if (unicode_spaces.empty()) {
+		// no unicode spaces found
+		return false;
+	}
+	idx_t prev = 0;
+	for (idx_t pos : unicode_spaces) {
+		new_query += query.substr(prev, pos - prev);
+		new_query += " ";
+		prev = pos + UNICODE_SPACE_BYTES;
+	}
+	new_query += query.substr(prev, query.size() - prev);
+	return true;
+}
+
+// This function strips unicode space characters from the query and replaces them with regular spaces
+// It returns true if any unicode space characters were found and stripped
+// See here for a list of unicode space characters - https://www.compart.com/en/unicode/category/Zs
+static bool StripUnicodeSpaces(const string &query, string &new_query) {
+	idx_t pos = 0;
+	char quote;
+	vector<idx_t> unicode_spaces;
+
+regular:
+	for (; pos + 2 < query.size(); pos++) {
+		if (query[pos] == '\xe2') {
+			if (query[pos + 1] == '\x80') {
+				if (query[pos + 2] >= '\x80' && query[pos + 2] <= '\x8b') {
+					// e28080 - e2808b
+					unicode_spaces.push_back(pos);
+				} else if (query[pos + 2] == '\xaf') {
+					// e280af
+					unicode_spaces.push_back(pos);
+				}
+			} else if (query[pos + 1] == '\x81') {
+				if (query[pos + 2] == '\x9f') {
+					// e2819f
+					unicode_spaces.push_back(pos);
+				}
+			}
+		} else if (query[pos] == '\xef') {
+			if (query[pos + 1] == '\xbb' && query[pos + 2] == '\xbf') {
+				// efbbbf
+				unicode_spaces.push_back(pos);
+			}
+		} else if (query[pos] == '\xe3') {
+			if (query[pos + 1] == '\x80' && query[pos + 2] == '\x80') {
+				// e38080
+				unicode_spaces.push_back(pos);
+			}
+		} else if (query[pos] == '"' || query[pos] == '\'') {
+			quote = query[pos];
+			pos++;
+			goto in_quotes;
+		} else if (query[pos] == '-' && query[pos + 1] == '-') {
+			goto in_comment;
+		}
+	}
+	goto end;
+in_quotes:
+	for (; pos + 1 < query.size(); pos++) {
+		if (query[pos] == quote) {
+			if (query[pos + 1] == quote) {
+				// escaped quote
+				pos++;
+				continue;
+			}
+			pos++;
+			goto regular;
+		}
+	}
+	goto end;
+in_comment:
+	for (; pos < query.size(); pos++) {
+		if (query[pos] == '\n' || query[pos] == '\r') {
+			goto regular;
+		}
+	}
+	goto end;
+end:
+	return ReplaceUnicodeSpaces(query, new_query, unicode_spaces);
+}
+
 void Parser::ParseQuery(const string &query) {
 	Transformer transformer(options.max_expression_depth);
+	string parser_error;
 	{
 		PostgresParser::SetPreserveIdentifierCase(options.preserve_identifier_case);
 		PostgresParser parser;
 		parser.Parse(query);
-
-		if (!parser.success) {
-			if (options.extensions) {
-				for (auto &ext : *options.extensions) {
-					D_ASSERT(ext.parse_function);
-					auto result = ext.parse_function(ext.parser_info.get(), query);
-					if (result.type == ParserExtensionResultType::PARSE_SUCCESSFUL) {
-						auto statement = make_unique<ExtensionStatement>(ext, move(result.parse_data));
-						statement->stmt_length = query.size();
-						statement->stmt_location = 0;
-						statements.push_back(move(statement));
-						return;
-					}
-					if (result.type == ParserExtensionResultType::DISPLAY_EXTENSION_ERROR) {
-						throw ParserException(result.error);
-					}
-				}
+		if (parser.success) {
+			if (!parser.parse_tree) {
+				// empty statement
+				return;
 			}
-			throw ParserException(QueryErrorContext::Format(query, parser.error_message, parser.error_location - 1));
-		}
 
-		if (!parser.parse_tree) {
-			// empty statement
+			// if it succeeded, we transform the Postgres parse tree into a list of
+			// SQLStatements
+			transformer.TransformParseTree(parser.parse_tree, statements);
+		} else {
+			parser_error = QueryErrorContext::Format(query, parser.error_message, parser.error_location - 1);
+		}
+	}
+	if (!parser_error.empty()) {
+		// parser error - check if there are any unicode spaces in the string
+		string new_query;
+		if (StripUnicodeSpaces(query, new_query)) {
+			ParseQuery(new_query);
 			return;
 		}
-
-		// if it succeeded, we transform the Postgres parse tree into a list of
-		// SQLStatements
-		transformer.TransformParseTree(parser.parse_tree, statements);
+		if (options.extensions) {
+			for (auto &ext : *options.extensions) {
+				D_ASSERT(ext.parse_function);
+				auto result = ext.parse_function(ext.parser_info.get(), query);
+				if (result.type == ParserExtensionResultType::PARSE_SUCCESSFUL) {
+					auto statement = make_unique<ExtensionStatement>(ext, move(result.parse_data));
+					statement->stmt_length = query.size();
+					statement->stmt_location = 0;
+					statements.push_back(move(statement));
+					return;
+				}
+				if (result.type == ParserExtensionResultType::DISPLAY_EXTENSION_ERROR) {
+					throw ParserException(result.error);
+				}
+			}
+		}
+		throw ParserException(parser_error);
 	}
 	if (!statements.empty()) {
 		auto &last_statement = statements.back();

--- a/test/sql/parser/invisible_spaces.test
+++ b/test/sql/parser/invisible_spaces.test
@@ -45,6 +45,12 @@ SELECT${unicode_space}42${unicode_space}${unicode_space}${unicode_space}${unicod
 ----
 42
 
+# invisible space in identifiers
+query I
+SELECT a${unicode_space} FROM (SELECT 42) t(a);
+----
+42
+
 endloop
 
 # the query can still fail even after replacing unicode spaces

--- a/test/sql/parser/invisible_spaces.test
+++ b/test/sql/parser/invisible_spaces.test
@@ -1,0 +1,59 @@
+# name: test/sql/parser/invisible_spaces.test
+# description: Test invisible spaces
+# group: [parser]
+
+statement ok
+PRAGMA enable_verification
+
+# non-breaking space
+query I
+SELECT 42;
+----
+42
+
+# test all special unicode spaces
+# see https://www.compart.com/en/unicode/category/Zs for a list
+foreach unicode_space                       ​   　   ﻿
+
+query I
+SELECT${unicode_space}42;
+----
+42
+
+# unicode space in strings are not modified
+query I
+SELECT${unicode_space}strlen('${unicode_space}');
+----
+3
+
+# unicode spaces in strings with escaped quotes
+query I
+SELECT${unicode_space}strlen(' ''${unicode_space}');
+----
+5
+
+# unicode space in comment
+query I
+SELECT${unicode_space} -- ${unicode_space};
+42
+----
+42
+
+# multiple unicode spaces
+query I
+SELECT${unicode_space}42${unicode_space}${unicode_space}${unicode_space}${unicode_space}${unicode_space}
+----
+42
+
+endloop
+
+# the query can still fail even after replacing unicode spaces
+statement error
+SELEC 
+
+# only a unicode space
+statement ok
+ 
+
+statement error
+S

--- a/test/sql/parser/invisible_spaces.test
+++ b/test/sql/parser/invisible_spaces.test
@@ -12,8 +12,8 @@ SELECT 42;
 42
 
 # test all special unicode spaces
-# see https://www.compart.com/en/unicode/category/Zs for a list
-foreach unicode_space                       ​   　   ﻿
+# see https://jkorpela.fi/chars/spaces.html for a list
+foreach unicode_space                       ​   　   ﻿  
 
 query I
 SELECT${unicode_space}42;
@@ -22,15 +22,15 @@ SELECT${unicode_space}42;
 
 # unicode space in strings are not modified
 query I
-SELECT${unicode_space}strlen('${unicode_space}');
+SELECT${unicode_space}strlen('${unicode_space}')>=2;
 ----
-3
+true
 
 # unicode spaces in strings with escaped quotes
 query I
-SELECT${unicode_space}strlen(' ''${unicode_space}');
+SELECT${unicode_space}strlen(' ''${unicode_space}')>=4;
 ----
-5
+true
 
 # unicode space in comment
 query I


### PR DESCRIPTION
This PR adds support for [unicode space characters](https://en.wikipedia.org/wiki/Whitespace_character#Unicode) in the parser. These characters otherwise cause confusing errors - as seemingly correct SQL statements will end up resulting in syntax errors, e.g.:

```sql
D SELECT 42;
Error: Parser Error: syntax error at or near "SELECT 42"
LINE 1: SELECT 42;
```

Unfortunately the current flex lexer does not have good support for unicode - and does not work nicely when we need multiple byte look-ahead (which we need for the various 3-byte unicode space characters). Instead, we add this support by performing a separate pass prior to parsing that converts unicode spaces into regular spaces. 