### PR TITLE
Extend GenericExecutor

### DIFF
--- a/src/include/duckdb/common/vector_operations/generic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/generic_executor.hpp
@@ -329,6 +329,7 @@ private:
 			auto a_idx = a_state.main_data.sel->get_index(i);
 			auto b_idx = a_state.main_data.sel->get_index(i);
 			auto c_idx = a_state.main_data.sel->get_index(i);
+			auto d_idx = a_state.main_data.sel->get_index(i);
 			if (!a_state.main_data.validity.RowIsValid(a_idx) || !b_state.main_data.validity.RowIsValid(b_idx) ||
 			    !c_state.main_data.validity.RowIsValid(c_idx) || !d_state.main_data.validity.RowIsValid(d_idx)) {
 				FlatVector::SetNull(result, i, true);

--- a/src/include/duckdb/common/vector_operations/generic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/generic_executor.hpp
@@ -164,6 +164,56 @@ struct StructTypeTernary {
 	}
 };
 
+template <class A_TYPE, class B_TYPE, class C_TYPE, class D_TYPE>
+struct StructTypeQuaternary {
+	A_TYPE a_val;
+	B_TYPE b_val;
+	C_TYPE c_val;
+	D_TYPE d_val;
+
+	using STRUCT_STATE = StructTypeState<4>;
+
+	static bool ConstructType(STRUCT_STATE &state, idx_t i,
+	                          StructTypeQuaternary<A_TYPE, B_TYPE, C_TYPE, D_TYPE> &result) {
+		auto &a_data = state.child_data[0];
+		auto &b_data = state.child_data[1];
+		auto &c_data = state.child_data[2];
+		auto &d_data = state.child_data[3];
+
+		auto a_idx = a_data.sel->get_index(i);
+		auto b_idx = b_data.sel->get_index(i);
+		auto c_idx = c_data.sel->get_index(i);
+		auto d_idx = d_data.sel->get_index(i);
+		if (!a_data.validity.RowIsValid(a_idx) || !b_data.validity.RowIsValid(b_idx) ||
+		    !c_data.validity.RowIsValid(c_idx) || !d_data.validity.RowIsValid(d_idx)) {
+			return false;
+		}
+		auto a_ptr = (A_TYPE *)a_data.data;
+		auto b_ptr = (B_TYPE *)b_data.data;
+		auto c_ptr = (C_TYPE *)c_data.data;
+		auto d_ptr = (D_TYPE *)d_data.data;
+		result.a_val = a_ptr[a_idx];
+		result.b_val = b_ptr[b_idx];
+		result.c_val = c_ptr[c_idx];
+		result.d_val = d_ptr[d_idx];
+		return true;
+	}
+
+	static void AssignResult(Vector &result, idx_t i, StructTypeQuaternary<A_TYPE, B_TYPE, C_TYPE, D_TYPE> value) {
+		auto &entries = StructVector::GetEntries(result);
+
+		auto a_data = FlatVector::GetData<A_TYPE>(*entries[0]);
+		auto b_data = FlatVector::GetData<B_TYPE>(*entries[1]);
+		auto c_data = FlatVector::GetData<C_TYPE>(*entries[2]);
+		auto d_data = FlatVector::GetData<D_TYPE>(*entries[3]);
+
+		a_data[i] = value.a_val;
+		b_data[i] = value.b_val;
+		c_data[i] = value.c_val;
+		d_data[i] = value.d_val;
+	}
+};
+
 //! The GenericExecutor can handle struct types in addition to primitive types
 struct GenericExecutor {
 private:
@@ -222,6 +272,84 @@ private:
 		}
 	}
 
+	template <class A_TYPE, class B_TYPE, class C_TYPE, class RESULT_TYPE, class FUNC>
+	static void ExecuteTernaryInternal(Vector &a, Vector &b, Vector &c, Vector &result, idx_t count, FUNC &fun) {
+		auto constant =
+		    a.GetVectorType() == VectorType::CONSTANT_VECTOR && b.GetVectorType() == VectorType::CONSTANT_VECTOR;
+
+		typename A_TYPE::STRUCT_STATE a_state;
+		typename B_TYPE::STRUCT_STATE b_state;
+		typename C_TYPE::STRUCT_STATE c_state;
+
+		a_state.PrepareVector(a, count);
+		b_state.PrepareVector(b, count);
+		c_state.PrepareVector(c, count);
+
+		for (idx_t i = 0; i < (constant ? 1 : count); i++) {
+			auto a_idx = a_state.main_data.sel->get_index(i);
+			auto b_idx = a_state.main_data.sel->get_index(i);
+			auto c_idx = a_state.main_data.sel->get_index(i);
+			if (!a_state.main_data.validity.RowIsValid(a_idx) || !b_state.main_data.validity.RowIsValid(b_idx) ||
+			    !c_state.main_data.validity.RowIsValid(c_idx)) {
+				FlatVector::SetNull(result, i, true);
+				continue;
+			}
+			A_TYPE a_val;
+			B_TYPE b_val;
+			C_TYPE c_val;
+			if (!A_TYPE::ConstructType(a_state, i, a_val) || !B_TYPE::ConstructType(b_state, i, b_val) ||
+			    !C_TYPE::ConstructType(c_state, i, c_val)) {
+				FlatVector::SetNull(result, i, true);
+				continue;
+			}
+			RESULT_TYPE::AssignResult(result, i, fun(a_val, b_val, c_val));
+		}
+		if (constant) {
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		}
+	}
+
+	template <class A_TYPE, class B_TYPE, class C_TYPE, class D_TYPE, class RESULT_TYPE, class FUNC>
+	static void ExecuteQuaternaryInternal(Vector &a, Vector &b, Vector &c, Vector &d, Vector &result, idx_t count,
+	                                      FUNC &fun) {
+		auto constant =
+		    a.GetVectorType() == VectorType::CONSTANT_VECTOR && b.GetVectorType() == VectorType::CONSTANT_VECTOR;
+
+		typename A_TYPE::STRUCT_STATE a_state;
+		typename B_TYPE::STRUCT_STATE b_state;
+		typename C_TYPE::STRUCT_STATE c_state;
+		typename D_TYPE::STRUCT_STATE d_state;
+
+		a_state.PrepareVector(a, count);
+		b_state.PrepareVector(b, count);
+		c_state.PrepareVector(c, count);
+		d_state.PrepareVector(d, count);
+
+		for (idx_t i = 0; i < (constant ? 1 : count); i++) {
+			auto a_idx = a_state.main_data.sel->get_index(i);
+			auto b_idx = a_state.main_data.sel->get_index(i);
+			auto c_idx = a_state.main_data.sel->get_index(i);
+			if (!a_state.main_data.validity.RowIsValid(a_idx) || !b_state.main_data.validity.RowIsValid(b_idx) ||
+			    !c_state.main_data.validity.RowIsValid(c_idx) || !d_state.main_data.validity.RowIsValid(d_idx)) {
+				FlatVector::SetNull(result, i, true);
+				continue;
+			}
+			A_TYPE a_val;
+			B_TYPE b_val;
+			C_TYPE c_val;
+			D_TYPE d_val;
+			if (!A_TYPE::ConstructType(a_state, i, a_val) || !B_TYPE::ConstructType(b_state, i, b_val) ||
+			    !C_TYPE::ConstructType(c_state, i, c_val) || !D_TYPE::ConstructType(d_state, i, d_val)) {
+				FlatVector::SetNull(result, i, true);
+				continue;
+			}
+			RESULT_TYPE::AssignResult(result, i, fun(a_val, b_val, c_val, d_val));
+		}
+		if (constant) {
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		}
+	}
+
 public:
 	template <class A_TYPE, class RESULT_TYPE, class FUNC = std::function<RESULT_TYPE(A_TYPE)>>
 	static void ExecuteUnary(Vector &input, Vector &result, idx_t count, FUNC fun) {
@@ -230,6 +358,16 @@ public:
 	template <class A_TYPE, class B_TYPE, class RESULT_TYPE, class FUNC = std::function<RESULT_TYPE(A_TYPE)>>
 	static void ExecuteBinary(Vector &a, Vector &b, Vector &result, idx_t count, FUNC fun) {
 		ExecuteBinaryInternal<A_TYPE, B_TYPE, RESULT_TYPE, FUNC>(a, b, result, count, fun);
+	}
+	template <class A_TYPE, class B_TYPE, class C_TYPE, class RESULT_TYPE,
+	          class FUNC = std::function<RESULT_TYPE(A_TYPE)>>
+	static void ExecuteTernary(Vector &a, Vector &b, Vector &c, Vector &result, idx_t count, FUNC fun) {
+		ExecuteTernaryInternal<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC>(a, b, c, result, count, fun);
+	}
+	template <class A_TYPE, class B_TYPE, class C_TYPE, class D_TYPE, class RESULT_TYPE,
+	          class FUNC = std::function<RESULT_TYPE(A_TYPE)>>
+	static void ExecuteQuaternary(Vector &a, Vector &b, Vector &c, Vector &d, Vector &result, idx_t count, FUNC fun) {
+		ExecuteQuaternaryInternal<A_TYPE, B_TYPE, C_TYPE, D_TYPE, RESULT_TYPE, FUNC>(a, b, c, d, result, count, fun);
 	}
 };
 


### PR DESCRIPTION
Extend GenericExecutor with additonal arities, as well as a StructType wrapper for 4-member structs. Adds:
- `ExecuteTernary`
- `ExecuteQuaternary`
- `StructTypeQuaternary`