### PR TITLE
Fix #5779: Parquet writer - when writing lists write only the required subsection of a child entry to the Parquet file

### DIFF
--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -1723,6 +1723,38 @@ void ListColumnWriter::FinalizeAnalyze(ColumnWriterState &state_p) {
 	child_writer->FinalizeAnalyze(*state.child_state);
 }
 
+idx_t GetConsecutiveChildList(Vector &list, idx_t count, Vector &result) {
+	auto list_data = FlatVector::GetData<list_entry_t>(list);
+	auto &validity = FlatVector::Validity(list);
+	bool consecutive_flat_list = true;
+	idx_t child_count = 0;
+	for (idx_t i = 0; i < count; i++) {
+		if (!validity.RowIsValid(i)) {
+			continue;
+		}
+		if (list_data[i].offset != child_count) {
+			consecutive_flat_list = false;
+		}
+		child_count += list_data[i].length;
+	}
+	if (!consecutive_flat_list) {
+		SelectionVector child_sel(child_count);
+		idx_t entry = 0;
+		for (idx_t i = 0; i < count; i++) {
+			if (!validity.RowIsValid(i)) {
+				continue;
+			}
+			for (idx_t k = 0; k < list_data[i].length; k++) {
+				child_sel.set_index(entry++, list_data[i].offset + k);
+			}
+		}
+
+		result.Slice(child_sel, child_count);
+		result.Flatten(child_count);
+	}
+	return child_count;
+}
+
 void ListColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterState *parent, Vector &vector, idx_t count) {
 	auto &state = (ListColumnWriterState &)state_p;
 
@@ -1775,8 +1807,9 @@ void ListColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterState *pa
 	state.parent_index += vcount;
 
 	auto &list_child = ListVector::GetEntry(vector);
-	auto list_count = ListVector::GetListSize(vector);
-	child_writer->Prepare(*state.child_state, &state_p, list_child, list_count);
+	Vector child_list(list_child);
+	idx_t child_count = GetConsecutiveChildList(vector, count, child_list);
+	child_writer->Prepare(*state.child_state, &state_p, child_list, child_count);
 }
 
 void ListColumnWriter::BeginWrite(ColumnWriterState &state_p) {
@@ -1788,8 +1821,9 @@ void ListColumnWriter::Write(ColumnWriterState &state_p, Vector &vector, idx_t c
 	auto &state = (ListColumnWriterState &)state_p;
 
 	auto &list_child = ListVector::GetEntry(vector);
-	auto list_count = ListVector::GetListSize(vector);
-	child_writer->Write(*state.child_state, list_child, list_count);
+	Vector child_list(list_child);
+	idx_t child_count = GetConsecutiveChildList(vector, count, child_list);
+	child_writer->Write(*state.child_state, child_list, child_count);
 }
 
 void ListColumnWriter::FinalizeWrite(ColumnWriterState &state_p) {

--- a/test/sql/copy/parquet/writer/parquet_write_issue_5779.test
+++ b/test/sql/copy/parquet/writer/parquet_write_issue_5779.test
@@ -1,0 +1,74 @@
+# name: test/sql/copy/parquet/writer/parquet_write_issue_5779.test
+# description: Fix #5779: write subsection of list vector to Parquet
+# group: [writer]
+
+require parquet
+
+statement ok
+CREATE TABLE empty_lists(i INTEGER[]);
+
+statement ok
+INSERT INTO empty_lists SELECT [] FROM range(10) UNION ALL SELECT [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+statement ok
+COPY (SELECT * FROM empty_lists LIMIT 10) TO '__TEST_DIR__/emptylist_int.parquet';
+
+query I
+SELECT * FROM '__TEST_DIR__/emptylist_int.parquet'
+----
+[]
+[]
+[]
+[]
+[]
+[]
+[]
+[]
+[]
+[]
+
+statement ok
+CREATE TABLE empty_lists_varchar(i VARCHAR[]);
+
+statement ok
+INSERT INTO empty_lists_varchar SELECT [] FROM range(10) UNION ALL SELECT ['hello', 'world', 'this', 'is', 'a', 'varchar', 'list']
+
+statement ok
+COPY (SELECT * FROM empty_lists_varchar LIMIT 10) TO '__TEST_DIR__/emptylist_varchar.parquet';
+
+query I
+SELECT * FROM '__TEST_DIR__/emptylist_varchar.parquet'
+----
+[]
+[]
+[]
+[]
+[]
+[]
+[]
+[]
+[]
+[]
+
+statement ok
+CREATE TABLE empty_list_nested(i INT[][]);
+
+statement ok
+INSERT INTO empty_list_nested SELECT [] FROM range(10) UNION ALL SELECT [[1, 2, 3], [4, 5], [6, 7, 8]]
+
+statement ok
+COPY (SELECT * FROM empty_list_nested LIMIT 10) TO '__TEST_DIR__/empty_list_nested.parquet';
+
+query I
+SELECT * FROM '__TEST_DIR__/empty_list_nested.parquet'
+----
+[]
+[]
+[]
+[]
+[]
+[]
+[]
+[]
+[]
+[]


### PR DESCRIPTION
Fixes #5779
