### PR TITLE
Added UUID case to GetTypeToPython

### DIFF
--- a/tools/pythonpkg/src/pyresult.cpp
+++ b/tools/pythonpkg/src/pyresult.cpp
@@ -326,6 +326,7 @@ py::str GetTypeToPython(const LogicalType &type) {
 	}
 	case LogicalTypeId::JSON:
 	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::UUID:
 		return py::str("STRING");
 	case LogicalTypeId::BLOB:
 		return py::str("BINARY");

--- a/tools/pythonpkg/src/pyresult.cpp
+++ b/tools/pythonpkg/src/pyresult.cpp
@@ -326,7 +326,6 @@ py::str GetTypeToPython(const LogicalType &type) {
 	}
 	case LogicalTypeId::JSON:
 	case LogicalTypeId::VARCHAR:
-	case LogicalTypeId::UUID:
 		return py::str("STRING");
 	case LogicalTypeId::BLOB:
 		return py::str("BINARY");
@@ -352,6 +351,9 @@ py::str GetTypeToPython(const LogicalType &type) {
 	}
 	case LogicalTypeId::INTERVAL: {
 		return py::str("TIMEDELTA");
+	}
+	case LogicalTypeId::UUID: {
+		return py::str("UUID");
 	}
 	case LogicalTypeId::USER:
 	case LogicalTypeId::ENUM: {

--- a/tools/pythonpkg/tests/fast/test_result.py
+++ b/tools/pythonpkg/tests/fast/test_result.py
@@ -50,3 +50,8 @@ class TestPythonResult(object):
         res = rel.execute()
         assert res.description == [('ivals', 'TIMEDELTA', None, None, None, None, None)]
         assert res.fetchall() == [(datetime.timedelta(days=1.0),), (datetime.timedelta(seconds=2.0),), (datetime.timedelta(microseconds=1.0),)]
+
+    def test_description_uuid(self):
+        connection = duckdb.connect()
+        connection.execute("select uuid();")
+        connection.description


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/5884

I have not done any testing myself that this fixes the issue, would not be surprised if there are other places that the UUID type needs to be handled