### PR TITLE
Issue #5887: ICU DateAdd Overflow

### DIFF
--- a/extension/icu/icu-dateadd.cpp
+++ b/extension/icu/icu-dateadd.cpp
@@ -58,7 +58,20 @@ timestamp_t ICUCalendarAdd::Operation(timestamp_t timestamp, interval_t interval
 	calendar->setTime(udate, status);
 
 	// Add interval fields from lowest to highest
-	calendar->add(UCAL_MILLISECOND, interval.micros / Interval::MICROS_PER_MSEC, status);
+
+	// Break units apart to avoid overflow
+	auto remaining = interval.micros / Interval::MICROS_PER_MSEC;
+	calendar->add(UCAL_MILLISECOND, remaining % Interval::MSECS_PER_SEC, status);
+
+	remaining /= Interval::MSECS_PER_SEC;
+	calendar->add(UCAL_SECOND, remaining % Interval::SECS_PER_MINUTE, status);
+
+	remaining /= Interval::SECS_PER_MINUTE;
+	calendar->add(UCAL_MINUTE, remaining % Interval::MINS_PER_HOUR, status);
+
+	remaining /= Interval::MINS_PER_HOUR;
+	calendar->add(UCAL_HOUR, remaining, status);
+
 	calendar->add(UCAL_DATE, interval.days, status);
 	calendar->add(UCAL_MONTH, interval.months, status);
 

--- a/test/sql/function/timestamp/test_icu_dateadd.test
+++ b/test/sql/function/timestamp/test_icu_dateadd.test
@@ -87,6 +87,12 @@ SELECT iv, '2021-12-01 13:54:48.123456Z'::TIMESTAMPTZ + iv FROM intervals;
 00:00:00.000612	2021-12-01 05:54:48.124068-08
 -00:00:00.000485	2021-12-01 05:54:48.122971-08
 
+# ms overflow
+query I
+select '1999-12-31 16:00:00-08'::timestamptz + interval 2400 hours
+----
+2000-04-09 17:00:00-07
+
 #  interval + timestamp
 query II
 SELECT iv, iv + '2021-12-01 13:54:48.123456Z'::TIMESTAMPTZ FROM intervals;
@@ -122,6 +128,12 @@ SELECT iv, iv + '2021-12-01 13:54:48.123456Z'::TIMESTAMPTZ FROM intervals;
 00:00:00.000612	2021-12-01 05:54:48.124068-08
 -00:00:00.000485	2021-12-01 05:54:48.122971-08
 
+# ms overflow
+query I
+select interval 2400 hours + '1999-12-31 16:00:00-08'::timestamptz
+----
+2000-04-09 17:00:00-07
+
 # timestamp - interval
 query II
 SELECT iv, '2021-12-01 13:54:48.123456Z'::TIMESTAMPTZ - iv FROM intervals;
@@ -156,6 +168,12 @@ SELECT iv, '2021-12-01 13:54:48.123456Z'::TIMESTAMPTZ - iv FROM intervals;
 -00:00:00.000001	2021-12-01 05:54:48.123457-08
 00:00:00.000612	2021-12-01 05:54:48.122844-08
 -00:00:00.000485	2021-12-01 05:54:48.123941-08
+
+# ms overflow
+query I
+select '2000-04-09 17:00:00-07'::timestamptz - interval 2400 hours
+----
+1999-12-31 16:00:00-08
 
 # Before the epoch
 query II


### PR DESCRIPTION
Break down the micros value from the interval and add the pieces so it doesn't overflow.

fixes #5887 