### PR TITLE
Fix #5903: ICU addition overflow

### DIFF
--- a/extension/icu/icu-dateadd.cpp
+++ b/extension/icu/icu-dateadd.cpp
@@ -31,6 +31,26 @@ struct ICUCalendarAge : public ICUDateFunc {
 	}
 };
 
+static inline void CalendarAddHour(icu::Calendar *calendar, int64_t interval_hour, UErrorCode &status) {
+	if (interval_hour >= 0) {
+		while (interval_hour > 0) {
+			calendar->add(UCAL_HOUR,
+			              interval_hour > NumericLimits<int32_t>::Maximum() ? NumericLimits<int32_t>::Maximum()
+			                                                                : interval_hour,
+			              status);
+			interval_hour -= NumericLimits<int32_t>::Maximum();
+		}
+	} else {
+		while (interval_hour < 0) {
+			calendar->add(UCAL_HOUR,
+			              interval_hour < NumericLimits<int32_t>::Minimum() ? NumericLimits<int32_t>::Minimum()
+			                                                                : interval_hour,
+			              status);
+			interval_hour -= NumericLimits<int32_t>::Minimum();
+		}
+	}
+}
+
 template <>
 timestamp_t ICUCalendarAdd::Operation(timestamp_t timestamp, interval_t interval, icu::Calendar *calendar) {
 	int64_t millis = timestamp.value / Interval::MICROS_PER_MSEC;
@@ -74,7 +94,7 @@ timestamp_t ICUCalendarAdd::Operation(timestamp_t timestamp, interval_t interval
 		calendar->add(UCAL_MILLISECOND, interval_ms, status);
 		calendar->add(UCAL_SECOND, interval_s, status);
 		calendar->add(UCAL_MINUTE, interval_m, status);
-		calendar->add(UCAL_HOUR, interval_h, status);
+		CalendarAddHour(calendar, interval_h, status);
 
 		calendar->add(UCAL_DATE, interval.days, status);
 		calendar->add(UCAL_MONTH, interval.months, status);
@@ -83,7 +103,7 @@ timestamp_t ICUCalendarAdd::Operation(timestamp_t timestamp, interval_t interval
 		calendar->add(UCAL_MONTH, interval.months, status);
 		calendar->add(UCAL_DATE, interval.days, status);
 
-		calendar->add(UCAL_HOUR, interval_h, status);
+		CalendarAddHour(calendar, interval_h, status);
 		calendar->add(UCAL_MINUTE, interval_m, status);
 		calendar->add(UCAL_SECOND, interval_s, status);
 		calendar->add(UCAL_MILLISECOND, interval_ms, status);

--- a/test/sql/function/timestamp/test_icu_dateadd.test
+++ b/test/sql/function/timestamp/test_icu_dateadd.test
@@ -93,6 +93,22 @@ select '1999-12-31 16:00:00-08'::timestamptz + interval 2400 hours
 ----
 2000-04-09 17:00:00-07
 
+statement error
+select 'epoch'::timestamptz + '9223372036854775000 microseconds'::interval
+
+query I
+select 'epoch'::timestamptz + '9223372036854774999 microseconds'::interval
+----
+294247-01-09 20:00:54.774999-08
+
+statement error
+select 'epoch'::timestamptz + '-9223372022400001001 microseconds'::interval
+
+query I
+select 'epoch'::timestamptz + '-9223372022400001000 microseconds'::interval
+----
+290303-12-10 (BC) 16:07:02-07:52
+
 #  interval + timestamp
 query II
 SELECT iv, iv + '2021-12-01 13:54:48.123456Z'::TIMESTAMPTZ FROM intervals;
@@ -134,6 +150,22 @@ select interval 2400 hours + '1999-12-31 16:00:00-08'::timestamptz
 ----
 2000-04-09 17:00:00-07
 
+statement error
+select '9223372036854775000 microseconds'::interval + 'epoch'::timestamptz
+
+query I
+select '9223372036854774999 microseconds'::interval + 'epoch'::timestamptz
+----
+294247-01-09 20:00:54.774999-08
+
+statement error
+select '-9223372022400001001 microseconds'::interval + 'epoch'::timestamptz
+
+query I
+select  '-9223372022400001000 microseconds'::interval + 'epoch'::timestamptz
+----
+290303-12-10 (BC) 16:07:02-07:52
+
 # timestamp - interval
 query II
 SELECT iv, '2021-12-01 13:54:48.123456Z'::TIMESTAMPTZ - iv FROM intervals;
@@ -174,6 +206,14 @@ query I
 select '2000-04-09 17:00:00-07'::timestamptz - interval 2400 hours
 ----
 1999-12-31 16:00:00-08
+
+statement error
+select 'epoch'::timestamptz - '9223372022400001001 microseconds'::interval
+
+query I
+select 'epoch'::timestamptz - '9223372022400001000 microseconds'::interval
+----
+290303-12-10 (BC) 16:07:02-07:52
 
 # Before the epoch
 query II
@@ -378,8 +418,8 @@ set timezone = 'Europe/London';
 
 statement ok
 CREATE TABLE london AS (
-	SELECT * 
-	FROM (VALUES 
+	SELECT *
+	FROM (VALUES
 		('2000-10-29 03:00:00+00'::TIMESTAMPTZ, '2000-03-26 03:00:00+01'::TIMESTAMPTZ, '2000-01-03 00:00:00+00'::TIMESTAMPTZ)
 		) tbl(dst2, dst1, origin)
 	);


### PR DESCRIPTION
Fixes #5903 
Split calling `Calendar::add(EDateFields field, int32_t amount, UErrorCode& status)` into multiple times to prevent it from overflowing when `amount` is casted from `int64_t`.