### PR TITLE
read_csv_auto column_types improvements

### DIFF
--- a/src/execution/operator/persistent/buffered_csv_reader.cpp
+++ b/src/execution/operator/persistent/buffered_csv_reader.cpp
@@ -922,9 +922,11 @@ vector<LogicalType> BufferedCSVReader::SniffCSV(const vector<LogicalType> &reque
 					continue;
 				}
 			}
-			if (!options.union_by_name && found < names.size()) {
+			if (!options.union_by_name && found < options.sql_types_per_column.size()) {
 				string exception = ColumnTypesError(options.sql_types_per_column, names);
-				throw BinderException(exception);
+				if (!exception.empty()) {
+					throw BinderException(exception);
+				}
 			}
 		} else {
 			// types supplied as list

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -194,6 +194,13 @@ static unique_ptr<FunctionData> ReadCSVBind(ClientContext &context, TableFunctio
 		const idx_t first_file_index = 0;
 		result->initial_reader = std::move(result->union_readers[first_file_index]);
 		D_ASSERT(names.size() == return_types.size());
+
+		if (!options.sql_types_per_column.empty()) {
+			auto exception = BufferedCSVReader::ColumnTypesError(options.sql_types_per_column, names);
+			if (!exception.empty()) {
+				throw BinderException(exception);
+			}
+		}
 	}
 
 	if (result->options.include_file_name) {

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -89,24 +89,45 @@ static unique_ptr<FunctionData> ReadCSVBind(ClientContext &context, TableFunctio
 			if (names.empty()) {
 				throw BinderException("read_csv requires at least a single column as input!");
 			}
-		} else if (loption == "column_types") {
+		} else if (loption == "column_types" || loption == "types" || loption == "dtypes") {
 			auto &child_type = kv.second.type();
-			if (child_type.id() != LogicalTypeId::STRUCT) {
-				throw BinderException("read_csv_auto column_types requires a struct as input");
+			if (child_type.id() != LogicalTypeId::STRUCT && child_type.id() != LogicalTypeId::LIST) {
+				throw BinderException("read_csv_auto %s requires a struct or list as input", kv.first);
 			}
-			auto &struct_children = StructValue::GetChildren(kv.second);
-			D_ASSERT(StructType::GetChildCount(child_type) == struct_children.size());
-			for (idx_t i = 0; i < struct_children.size(); i++) {
-				auto &name = StructType::GetChildName(child_type, i);
-				auto &val = struct_children[i];
-				if (val.type().id() != LogicalTypeId::VARCHAR) {
-					throw BinderException("read_csv_auto requires a type specification as string");
+			if (!options.sql_type_list.empty()) {
+				throw BinderException("read_csv_auto column_types/types/dtypes can only be supplied once");
+			}
+			vector<string> sql_type_names;
+			if (child_type.id() == LogicalTypeId::STRUCT) {
+				auto &struct_children = StructValue::GetChildren(kv.second);
+				D_ASSERT(StructType::GetChildCount(child_type) == struct_children.size());
+				for (idx_t i = 0; i < struct_children.size(); i++) {
+					auto &name = StructType::GetChildName(child_type, i);
+					auto &val = struct_children[i];
+					if (val.type().id() != LogicalTypeId::VARCHAR) {
+						throw BinderException("read_csv_auto %s requires a type specification as string", kv.first);
+					}
+					sql_type_names.push_back(StringValue::Get(val));
+					options.sql_types_per_column[name] = i;
 				}
-				auto def_type = TransformStringToLogicalType(StringValue::Get(val));
+			} else {
+				auto &list_child = ListType::GetChildType(child_type);
+				if (list_child.id() != LogicalTypeId::VARCHAR) {
+					throw BinderException("read_csv_auto %s requires a list of types (varchar) as input", kv.first);
+				}
+				auto &children = ListValue::GetChildren(kv.second);
+				for (auto &child : children) {
+					sql_type_names.push_back(StringValue::Get(child));
+				}
+			}
+			options.sql_type_list.reserve(sql_type_names.size());
+			for (auto &sql_type : sql_type_names) {
+				auto def_type = TransformStringToLogicalType(sql_type);
 				if (def_type.id() == LogicalTypeId::USER) {
-					throw BinderException("Unrecognized type for read_csv_auto column_types definition");
+					throw BinderException("Unrecognized type \"%s\" for read_csv_auto %s definition", sql_type,
+					                      kv.first);
 				}
-				options.sql_types_per_column[name] = def_type;
+				options.sql_type_list.push_back(move(def_type));
 			}
 		} else if (loption == "all_varchar") {
 			options.all_varchar = BooleanValue::Get(kv.second);
@@ -830,6 +851,8 @@ TableFunction ReadCSVTableFunction::GetAutoFunction(bool list_parameter) {
 	read_csv_auto.cardinality = CSVReaderCardinality;
 	ReadCSVAddNamedParameters(read_csv_auto);
 	read_csv_auto.named_parameters["column_types"] = LogicalType::ANY;
+	read_csv_auto.named_parameters["dtypes"] = LogicalType::ANY;
+	read_csv_auto.named_parameters["types"] = LogicalType::ANY;
 	return read_csv_auto;
 }
 

--- a/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
@@ -76,6 +76,8 @@ public:
 	//! Extract a single DataChunk from the CSV file and stores it in insert_chunk
 	void ParseCSV(DataChunk &insert_chunk);
 
+	static string ColumnTypesError(case_insensitive_map_t<idx_t> sql_types_per_column, const vector<string> &names);
+
 private:
 	//! Initialize Parser
 	void Initialize(const vector<LogicalType> &requested_types);

--- a/src/include/duckdb/execution/operator/persistent/csv_reader_options.hpp
+++ b/src/include/duckdb/execution/operator/persistent/csv_reader_options.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/function/scalar/strftime.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/field_writer.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
 
 namespace duckdb {
 
@@ -54,8 +55,10 @@ struct BufferedCSVReaderOptions {
 	//===--------------------------------------------------------------------===//
 	// CSVAutoOptions
 	//===--------------------------------------------------------------------===//
-	//! SQL Types defined per specific column
-	unordered_map<string, LogicalType> sql_types_per_column;
+	//! SQL Type list mapping of name to SQL type index in sql_type_list
+	case_insensitive_map_t<idx_t> sql_types_per_column;
+	//! User-defined SQL type list
+	vector<LogicalType> sql_type_list;
 	//===--------------------------------------------------------------------===//
 	// ReadCSVOptions
 	//===--------------------------------------------------------------------===//

--- a/test/sql/copy/csv/csv_dtypes.test
+++ b/test/sql/copy/csv/csv_dtypes.test
@@ -1,0 +1,57 @@
+# name: test/sql/copy/csv/csv_dtypes.test
+# description: Read a CSV with dtypes flags
+# group: [csv]
+
+#statement ok
+#PRAGMA enable_verification
+
+query II
+select typeof(Year), typeof(Quarter) from 'test/sql/copy/csv/data/real/ontime_sample.csv' LIMIT 1;
+----
+BIGINT	BIGINT
+
+query II
+select typeof(Year), typeof(Quarter) from read_csv_auto('test/sql/copy/csv/data/real/ontime_sample.csv', dtypes={'Quarter': 'TINYINT'}) LIMIT 1
+----
+BIGINT	TINYINT
+
+# case insensitivity for struct
+query II
+select typeof(Year), typeof(Quarter) from read_csv_auto('test/sql/copy/csv/data/real/ontime_sample.csv', dtypes={'quArTeR': 'TINYINT'}) LIMIT 1
+----
+BIGINT	TINYINT
+
+query II
+select typeof(Year), typeof(Quarter) from read_csv_auto('test/sql/copy/csv/data/real/ontime_sample.csv', dtypes=['INT', 'TINYINT']) LIMIT 1
+----
+INTEGER	TINYINT
+
+# mix of struct and list parameters
+statement error
+select * from read_csv_auto('test/sql/copy/csv/data/real/ontime_sample.csv', dtypes=['INT'], column_types={'Quarter': 'TINYINT'}) LIMIT 1
+----
+can only be supplied once
+
+# invalid list type
+statement error
+select * from read_csv_auto('test/sql/copy/csv/data/real/ontime_sample.csv', dtypes=[42]) LIMIT 1
+----
+requires a list of types
+
+# invalid type
+statement error
+select * from read_csv_auto('test/sql/copy/csv/data/real/ontime_sample.csv', dtypes=['unknown_type']) LIMIT 1
+----
+unknown_type
+
+# invalid struct type
+statement error
+select * from read_csv_auto('test/sql/copy/csv/data/real/ontime_sample.csv', dtypes={'Quarter': 42}) LIMIT 1
+----
+requires a type specification as string
+
+# too many sql types provided in list
+statement error
+select * from read_csv_auto('test/sql/copy/csv/data/auto/int_bol.csv', dtypes=['varchar', 'varchar', 'varchar']) LIMIT 1
+----
+3 types were provided, but CSV file only has 2 columns

--- a/test/sql/copy/csv/csv_dtypes.test
+++ b/test/sql/copy/csv/csv_dtypes.test
@@ -2,8 +2,8 @@
 # description: Read a CSV with dtypes flags
 # group: [csv]
 
-#statement ok
-#PRAGMA enable_verification
+statement ok
+PRAGMA enable_verification
 
 query II
 select typeof(Year), typeof(Quarter) from 'test/sql/copy/csv/data/real/ontime_sample.csv' LIMIT 1;

--- a/test/sql/copy/csv/csv_dtypes_union_by_name.test
+++ b/test/sql/copy/csv/csv_dtypes_union_by_name.test
@@ -1,0 +1,69 @@
+# name: test/sql/copy/csv/csv_dtypes_union_by_name.test
+# description: Read a CSV with dtypes and UNION BY NAME
+# group: [csv]
+
+#statement ok
+#PRAGMA enable_verification
+
+statement ok
+CREATE TABLE ubn1(a BIGINT);
+
+statement ok
+CREATE TABLE ubn2(a INTEGER, b INTEGER);
+
+statement ok
+CREATE TABLE ubn3(a INTEGER, c INTEGER);
+
+statement ok
+INSERT INTO ubn1 VALUES (1), (2), (9223372036854775807);
+
+statement ok
+INSERT INTO ubn2 VALUES (3,4), (5, 6);
+
+statement ok
+INSERT INTO ubn3 VALUES (100,101), (102, 103);
+
+statement ok
+COPY ubn1 TO '__TEST_DIR__/ubn1.csv' WITH (HEADER 1, DELIMITER ',');
+
+statement ok
+COPY ubn2 TO '__TEST_DIR__/ubn2.csv' WITH (HEADER 1, DELIMITER ',');
+
+statement ok
+COPY ubn3 TO '__TEST_DIR__/ubn3.csv' WITH (HEADER 1, DELIMITER ',');
+
+query III
+SELECT typeof(a), typeof(b), typeof(c)
+FROM  read_csv_auto('__TEST_DIR__/ubn*.csv', UNION_BY_NAME=TRUE, dtypes={'c': TINYINT})
+LIMIT 1;
+----
+BIGINT	BIGINT	TINYINT
+
+query III
+SELECT typeof(a), typeof(b), typeof(c)
+FROM  read_csv_auto('__TEST_DIR__/ubn*.csv', UNION_BY_NAME=TRUE, dtypes={'c': TINYINT, 'A': DOUBLE})
+LIMIT 1;
+----
+DOUBLE	BIGINT	TINYINT
+
+# unrecognized in any file
+statement error
+SELECT typeof(a), typeof(b), typeof(c)
+FROM  read_csv_auto('__TEST_DIR__/ubn*.csv', UNION_BY_NAME=TRUE, dtypes={'xxx': TINYINT})
+LIMIT 1;
+----
+xxx
+
+statement error
+SELECT typeof(a), typeof(b), typeof(c)
+FROM  read_csv_auto('__TEST_DIR__/ubn*.csv', UNION_BY_NAME=TRUE, dtypes={'c': TINYINT, 'A': DOUBLE, 'C': FLOAT})
+LIMIT 1;
+----
+Duplicate struct entry name
+
+statement error
+SELECT typeof(a), typeof(b), typeof(c)
+FROM  read_csv_auto('__TEST_DIR__/ubn*.csv', UNION_BY_NAME=TRUE, dtypes={'c': TINYINT, 'A': DOUBLE, 'xZX': FLOAT})
+LIMIT 1;
+----
+xZX


### PR DESCRIPTION
This PR extends the `column_types` parameter of `read_csv_auto`:

* The `dtypes` alias is provided to more closely match pandas and other libraries
* A list of types can be provided instead of only a struct. If a list of types is provided, the types are applied positionally (i.e. the first type is applied to the first column, etc).

```sql
D select Year, Quarter from 'test/sql/copy/csv/data/real/ontime_sample.csv' LIMIT 1;
┌───────┬─────────┐
│ Year  │ Quarter │
│ int64 │  int64  │
├───────┼─────────┤
│  1988 │       1 │
└───────┴─────────┘
D select Year, Quarter from read_csv_auto('test/sql/copy/csv/data/real/ontime_sample.csv', dtypes=[INT]) LIMIT 1;
┌───────┬─────────┐
│ Year  │ Quarter │
│ int32 │  int64  │
├───────┼─────────┤
│  1988 │       1 │
└───────┴─────────┘
D select Year, Quarter from read_csv_auto('test/sql/copy/csv/data/real/ontime_sample.csv', dtypes={'quarter': INT}) LIMIT 1;
┌───────┬─────────┐
│ Year  │ Quarter │
│ int64 │  int32  │
├───────┼─────────┤
│  1988 │       1 │
└───────┴─────────┘
```
* When a mapping of `column -> type` is provided and `union_by_name` is enabled, we no longer require every column in the mapping to be present in every file. Instead, the column must be present in *at least one file*.