### PR TITLE
fixed bug in generating grammar script

### DIFF
--- a/scripts/generate_grammar.py
+++ b/scripts/generate_grammar.py
@@ -262,3 +262,11 @@ if res != 0:
 
 os.rename(result_source, target_source_loc)
 os.rename(result_header, target_header_loc)
+
+with open_utf8(target_source_loc, 'r') as f:
+    text = f.read()
+
+text = text.replace('#include "grammar_out.hpp"', '#include "include/parser/gram.hpp"')
+
+with open_utf8(target_source_loc, 'w+') as f:
+    f.write(text)


### PR DESCRIPTION
obligatory premise: I have absolutely no idea what I am doing

I am no bison expert, but I am tasked to extend the parser for my phd stuff, and after I made my changes and tried to regenerate the grammar, I encountered a bug that also happens if I don't touch anything and just try to regenerate the existing grammar.

here's what happens:
```
[15:39:36] ila :: ila-XPS-9320  ➜  ~/Code/duckdb ‹master*› » python3 scripts/generate_grammar.py
bison -o third_party/libpg_query/grammar/grammar_out.cpp -d third_party/libpg_query/grammar/grammar.y.tmp
[15:50:49] ila :: ila-XPS-9320  ➜  ~/Code/duckdb ‹master*› » python3 scripts/generate_flex.py      
```
these are the instructions in the README. now, if I try to recompile duckdb with the new grammar cpp files, I get this error:
```
[176/205] Building CXX object third_party/libpg_query/CMakeFiles/duckdb_pg_query.dir/src_backend_parser_gram.cpp.o
FAILED: third_party/libpg_query/CMakeFiles/duckdb_pg_query.dir/src_backend_parser_gram.cpp.o 
/usr/bin/c++ -DDUCKDB_BUILD_LIBRARY -I/home/ila/Code/duckdb/src/include -I/home/ila/Code/duckdb/third_party/fsst -I/home/ila/Code/duckdb/third_party/fmt/include -I/home/ila/Code/duckdb/third_party/hyperloglog -I/home/ila/Code/duckdb/third_party/fastpforlib -I/home/ila/Code/duckdb/third_party/fast_float -I/home/ila/Code/duckdb/third_party/re2 -I/home/ila/Code/duckdb/third_party/miniz -I/home/ila/Code/duckdb/third_party/utf8proc/include -I/home/ila/Code/duckdb/third_party/miniparquet -I/home/ila/Code/duckdb/third_party/concurrentqueue -I/home/ila/Code/duckdb/third_party/pcg -I/home/ila/Code/duckdb/third_party/tdigest -I/home/ila/Code/duckdb/third_party/mbedtls/include -I/home/ila/Code/duckdb/third_party/jaro_winkler -I/home/ila/Code/duckdb/third_party/libpg_query/include -O3 -DNDEBUG -O3 -DNDEBUG   -fPIC -fvisibility=hidden -fdiagnostics-color=always -w -std=c++11 -MD -MT third_party/libpg_query/CMakeFiles/duckdb_pg_query.dir/src_backend_parser_gram.cpp.o -MF third_party/libpg_query/CMakeFiles/duckdb_pg_query.dir/src_backend_parser_gram.cpp.o.d -o third_party/libpg_query/CMakeFiles/duckdb_pg_query.dir/src_backend_parser_gram.cpp.o -c /home/ila/Code/duckdb/third_party/libpg_query/src_backend_parser_gram.cpp
third_party/libpg_query/grammar/grammar_out.cpp:265:10: fatal error: grammar_out.hpp: No such file or directory
compilation terminated.
[187/205] Building CXX object src/execution/expression_executor/CMakeFiles/duckdb_expression_executor.dir/ub_duckdb_expression_executor.cpp.o
ninja: build stopped: subcommand failed.
```
after investigating for a bit, I found that the python script to regenerate the grammar ultimately renames the header file generated with the `-d` flag in the filesystem, but does not rename the inclusion of this very same header in the `src_backend_parser_gram.cpp` file. therefore I opted for the quick and dirty fix in python.

as I said, I have no idea whether this is a me problem or whether this is the most efficient fix, but as always it works on my computer^tm

let me know if you have any thoughts and have a good day :)
