### PR TITLE
Issue 5660 - do not allow unnest with alias in groupby

### DIFF
--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -445,6 +445,7 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SelectNode &statement) {
 	vector<LogicalType> internal_sql_types;
 	for (idx_t i = 0; i < statement.select_list.size(); i++) {
 		bool is_window = statement.select_list[i]->IsWindow();
+		idx_t unnest_count = result->unnests.size();
 		LogicalType result_type;
 		auto expr = select_binder.Bind(statement.select_list[i], &result_type);
 		if (statement.aggregate_handling == AggregateHandling::FORCE_AGGREGATES && select_binder.HasBoundColumns()) {
@@ -453,6 +454,9 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SelectNode &statement) {
 			}
 			if (is_window) {
 				throw BinderException("Cannot group on a window clause");
+			}
+			if (result->unnests.size() > unnest_count) {
+				throw BinderException("Cannot group on an UNNEST clause");
 			}
 			// we are forcing aggregates, and the node has columns bound
 			// this entry becomes a group

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -456,7 +456,7 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SelectNode &statement) {
 				throw BinderException("Cannot group on a window clause");
 			}
 			if (result->unnests.size() > unnest_count) {
-				throw BinderException("Cannot group on an UNNEST clause");
+				throw BinderException("Cannot group on an UNNEST or UNLIST clause");
 			}
 			// we are forcing aggregates, and the node has columns bound
 			// this entry becomes a group

--- a/test/issues/general/test_5660.test
+++ b/test/issues/general/test_5660.test
@@ -1,0 +1,23 @@
+# name: test/issues/general/test_5660.test
+# description: Issue 5660: Group by all throws binder error when a more informative error should be produced
+# group: [general]
+
+statement ok
+CREATE TABLE foo AS SELECT 'a, b, c' AS "x", '1' AS y;
+
+statement error
+SELECT y, UNLIST(string_split("x", ', ')) alias, COUNT(*) FROM foo GROUP BY y, alias;
+----
+Binder Error
+
+statement ok
+select * from foo
+
+statement error
+SELECT y, UNLIST(string_split("x", ', ')) x, COUNT(*) FROM foo GROUP BY ALL;
+----
+Binder Error
+
+# Make sure we don't invalidate the database
+statement ok
+select * from foo

--- a/test/issues/general/test_5660.test
+++ b/test/issues/general/test_5660.test
@@ -18,6 +18,10 @@ SELECT y, UNLIST(string_split("x", ', ')) x, COUNT(*) FROM foo GROUP BY ALL;
 ----
 Binder Error
 
+# essentially the same as above but with a subquery instead of a group by and unlist
+statement ok
+select f.y, k.c1, count(*) FROM foo f, (Select UNLIST(string_split("x", ', ')) c1) k group by y, k.c1;
+
 # Make sure we don't invalidate the database
 statement ok
 select * from foo


### PR DESCRIPTION
This PR is to produce a more informative error message for https://github.com/duckdb/duckdb/issues/5660. Currently we throw an internal error when failing to bind the column reference when unnest is used with an alias in a group by statement. Instead we should throw a normal binder error so we don't invalidate the database. 

The reason we don't want to have an unnest statement with an alias and a group by expression is because both a group by and an unnest/unlist with an alias are initially bound to a bound column ref. If you have both expressions in a select statement, you have one of two issues.

1) the group by is planned before the unnest, but then the unnest can no longer find the projected table values from before the group by.
2) The unnest is planned before the group by. It is possible to get this to work, but it would require changing the order of how we bind and plan operators, which could break a number of other test cases.

If users *need* this functionality, they can re-write their queries so that they use subqueries like in the test file added in this PR