### PR TITLE
Avoid writing .tmp file when redirecting stdout to a file

### DIFF
--- a/src/execution/physical_plan/plan_copy_to_file.cpp
+++ b/src/execution/physical_plan/plan_copy_to_file.cpp
@@ -9,15 +9,14 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile
 	auto &fs = FileSystem::GetFileSystem(context);
 	op.file_path = fs.ExpandPath(op.file_path, FileSystem::GetFileOpener(context));
 
-	bool use_tmp_file = op.is_file_and_exists && op.use_tmp_file && !op.per_thread_output;
-	if (use_tmp_file) {
+	if (op.use_tmp_file) {
 		op.file_path += ".tmp";
 	}
 	// COPY from select statement to file
 	auto copy =
 	    make_unique<PhysicalCopyToFile>(op.types, op.function, std::move(op.bind_data), op.estimated_cardinality);
 	copy->file_path = op.file_path;
-	copy->use_tmp_file = use_tmp_file;
+	copy->use_tmp_file = op.use_tmp_file;
 	copy->per_thread_output = op.per_thread_output;
 	if (op.function.parallel) {
 		copy->parallel = op.function.parallel(context, *copy->bind_data);

--- a/src/include/duckdb/planner/operator/logical_copy_to_file.hpp
+++ b/src/include/duckdb/planner/operator/logical_copy_to_file.hpp
@@ -24,7 +24,6 @@ public:
 	unique_ptr<FunctionData> bind_data;
 	std::string file_path;
 	bool use_tmp_file;
-	bool is_file_and_exists;
 	bool per_thread_output;
 
 public:

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -62,6 +62,11 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 	if (user_set_use_tmp_file && per_thread_output) {
 		throw NotImplementedException("Can't combine USE_TMP_FILE and PER_THREAD_OUTPUT for COPY");
 	}
+	bool is_file_and_exists = config.file_system->FileExists(stmt.info->file_path);
+	bool is_pipe = config.file_system->IsPipe(stmt.info->file_path) || stmt.info->file_path == "/dev/stdout";
+	if (!user_set_use_tmp_file) {
+		use_tmp_file = is_file_and_exists && !per_thread_output && !is_pipe;
+	}
 
 	auto function_data =
 	    copy_function->function.copy_to_bind(context, *stmt.info, select_node.names, select_node.types);
@@ -70,7 +75,6 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 	copy->file_path = stmt.info->file_path;
 	copy->use_tmp_file = use_tmp_file;
 	copy->per_thread_output = per_thread_output;
-	copy->is_file_and_exists = config.file_system->FileExists(copy->file_path);
 
 	copy->AddChild(std::move(select_node.plan));
 

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -63,9 +63,9 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 		throw NotImplementedException("Can't combine USE_TMP_FILE and PER_THREAD_OUTPUT for COPY");
 	}
 	bool is_file_and_exists = config.file_system->FileExists(stmt.info->file_path);
-	bool is_pipe = config.file_system->IsPipe(stmt.info->file_path) || stmt.info->file_path == "/dev/stdout";
+	bool is_stdout = stmt.info->file_path == "/dev/stdout";
 	if (!user_set_use_tmp_file) {
-		use_tmp_file = is_file_and_exists && !per_thread_output && !is_pipe;
+		use_tmp_file = is_file_and_exists && !per_thread_output && !is_stdout;
 	}
 
 	auto function_data =

--- a/src/planner/operator/logical_copy_to_file.cpp
+++ b/src/planner/operator/logical_copy_to_file.cpp
@@ -9,7 +9,6 @@ namespace duckdb {
 void LogicalCopyToFile::Serialize(FieldWriter &writer) const {
 	writer.WriteString(file_path);
 	writer.WriteField(use_tmp_file);
-	writer.WriteField(is_file_and_exists);
 	writer.WriteField(per_thread_output);
 
 	D_ASSERT(!function.name.empty());
@@ -26,7 +25,6 @@ void LogicalCopyToFile::Serialize(FieldWriter &writer) const {
 unique_ptr<LogicalOperator> LogicalCopyToFile::Deserialize(LogicalDeserializationState &state, FieldReader &reader) {
 	auto file_path = reader.ReadRequired<string>();
 	auto use_tmp_file = reader.ReadRequired<bool>();
-	auto is_file_and_exists = reader.ReadRequired<bool>();
 	auto per_thread_output = reader.ReadRequired<bool>();
 
 	auto copy_func_name = reader.ReadRequired<string>();
@@ -52,7 +50,6 @@ unique_ptr<LogicalOperator> LogicalCopyToFile::Deserialize(LogicalDeserializatio
 	auto result = make_unique<LogicalCopyToFile>(copy_func, std::move(bind_data));
 	result->file_path = file_path;
 	result->use_tmp_file = use_tmp_file;
-	result->is_file_and_exists = is_file_and_exists;
 	result->per_thread_output = per_thread_output;
 	return std::move(result);
 }

--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -18,16 +18,25 @@ def test_exception(command, input, stdout, stderr, errmsg):
      print(stderr)
      raise Exception(errmsg)
 
-def test(cmd, out=None, err=None, extra_commands=None, input_file=None):
+def test(cmd, out=None, err=None, extra_commands=None, input_file=None, output_file=None):
      command = [sys.argv[1], '--batch', '-init', '/dev/null']
      if extra_commands:
           command += extra_commands
+
      if input_file:
           command += [cmd]
-          res = subprocess.run(command, input=open(input_file, 'rb').read(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+          input_data = open(input_file, 'rb').read()
      else:
-          res = subprocess.run(command, input=bytearray(cmd, 'utf8'), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-     stdout = res.stdout.decode('utf8').strip()
+          input_data = bytearray(cmd, 'utf8')
+     output_pipe = subprocess.PIPE
+     if output_file:
+          output_pipe = open(output_file, 'w+')
+
+     res = subprocess.run(command, input=input_data, stdout=output_pipe, stderr=subprocess.PIPE)
+     if output_file:
+          stdout = open(output_file, 'r').read()
+     else:
+          stdout = res.stdout.decode('utf8').strip()
      stderr = res.stderr.decode('utf8').strip()
 
      if out and out not in stdout:
@@ -973,3 +982,5 @@ select channel,i_brand_id,sum_sales,number_sales from mytable;
      select list(concat('thisisalongstring', range::VARCHAR)) i from range(10000)
      ''',
      out='''thisisalongstring''')
+
+     test("copy (select * from range(10000) tbl(i)) to '/dev/stdout' (format csv)", out='9999', output_file=tf())


### PR DESCRIPTION
This PR fixes a regression of #2296 found by @mskyttner where writing to `stdout` would fail if the result was redirected to a file, because the `/dev/stdout` pretends to be a file when it is redirected to a file (i.e. it sets `st_mode` in `stat` as if it is a file). For now we resolve this by checking directly if the output target is `/dev/stdout` as there does not seem to be a good way to resolve this using file system operations itself. 

We also do some clean-up of the copy to file - as the `is_file_and_exists` property is not necessary anymore after binding it should not be propagated further into the plan.