### PR TITLE
Add logical plan serialization for LOAD, DROP and ALTER

### DIFF
--- a/src/include/duckdb/parser/parsed_data/drop_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/drop_info.hpp
@@ -45,6 +45,32 @@ public:
 		result->allow_drop_internal = allow_drop_internal;
 		return result;
 	}
+
+	void Serialize(Serializer &serializer) const {
+		FieldWriter writer(serializer);
+		writer.WriteField<CatalogType>(type);
+		writer.WriteString(catalog);
+		writer.WriteString(schema);
+		writer.WriteString(name);
+		writer.WriteField(if_exists);
+		writer.WriteField(cascade);
+		writer.WriteField(allow_drop_internal);
+		writer.Finalize();
+	}
+
+	static unique_ptr<ParseInfo> Deserialize(Deserializer &deserializer) {
+		FieldReader reader(deserializer);
+		auto drop_info = make_unique<DropInfo>();
+		drop_info->type = reader.ReadRequired<CatalogType>();
+		drop_info->catalog = reader.ReadRequired<string>();
+		drop_info->schema = reader.ReadRequired<string>();
+		drop_info->name = reader.ReadRequired<string>();
+		drop_info->if_exists = reader.ReadRequired<bool>();
+		drop_info->cascade = reader.ReadRequired<bool>();
+		drop_info->allow_drop_internal = reader.ReadRequired<bool>();
+		reader.Finalize();
+		return drop_info;
+	}
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/parsed_data/drop_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/drop_info.hpp
@@ -70,7 +70,7 @@ public:
 		drop_info->cascade = reader.ReadRequired<bool>();
 		drop_info->allow_drop_internal = reader.ReadRequired<bool>();
 		reader.Finalize();
-		return drop_info;
+		return std::move(drop_info);
 	}
 };
 

--- a/src/include/duckdb/parser/parsed_data/drop_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/drop_info.hpp
@@ -8,8 +8,9 @@
 
 #pragma once
 
-#include "duckdb/parser/parsed_data/parse_info.hpp"
 #include "duckdb/common/enums/catalog_type.hpp"
+#include "duckdb/common/field_writer.hpp"
+#include "duckdb/parser/parsed_data/parse_info.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/parser/parsed_data/load_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/load_info.hpp
@@ -40,7 +40,7 @@ public:
 		load_info->filename = reader.ReadRequired<string>();
 		load_info->load_type = reader.ReadRequired<LoadType>();
 		reader.Finalize();
-		return load_info;
+		return std::move(load_info);
 	}
 };
 

--- a/src/include/duckdb/parser/parsed_data/load_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/load_info.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/field_writer.hpp"
 #include "duckdb/parser/parsed_data/parse_info.hpp"
 
 namespace duckdb {

--- a/src/include/duckdb/parser/parsed_data/load_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/load_info.hpp
@@ -25,6 +25,22 @@ public:
 		result->load_type = load_type;
 		return result;
 	}
+
+	void Serialize(Serializer &serializer) const {
+		FieldWriter writer(serializer);
+		writer.WriteString(filename);
+		writer.WriteField<LoadType>(load_type);
+		writer.Finalize();
+	}
+
+	static unique_ptr<ParseInfo> Deserialize(Deserializer &deserializer) {
+		FieldReader reader(deserializer);
+		auto load_info = make_unique<LoadInfo>();
+		load_info->filename = reader.ReadRequired<string>();
+		load_info->load_type = reader.ReadRequired<LoadType>();
+		reader.Finalize();
+		return load_info;
+	}
 };
 
 } // namespace duckdb

--- a/src/planner/operator/logical_simple.cpp
+++ b/src/planner/operator/logical_simple.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/planner/operator/logical_simple.hpp"
+#include "duckdb/parser/parsed_data/alter_info.hpp"
 #include "duckdb/parser/parsed_data/drop_info.hpp"
 #include "duckdb/parser/parsed_data/load_info.hpp"
 
@@ -23,21 +24,21 @@ void LogicalSimple::Serialize(FieldWriter &writer) const {
 
 unique_ptr<LogicalOperator> LogicalSimple::Deserialize(LogicalDeserializationState &state, FieldReader &reader) {
 	auto type = reader.ReadRequired<LogicalOperatorType>();
-	unique_ptr<ParseInfo> parseInfo;
+	unique_ptr<ParseInfo> parse_info;
 	switch (type) {
 	case LogicalOperatorType::LOGICAL_ALTER:
-		parseInfo = AlterInfo::Deserialize(reader.GetSource());
+		parse_info = AlterInfo::Deserialize(reader.GetSource());
 		break;
 	case LogicalOperatorType::LOGICAL_DROP:
-		parseInfo = DropInfo::Deserialize(reader.GetSource());
+		parse_info = DropInfo::Deserialize(reader.GetSource());
 		break;
 	case LogicalOperatorType::LOGICAL_LOAD:
-		parseInfo = LoadInfo::Deserialize(reader.GetSource());
+		parse_info = LoadInfo::Deserialize(reader.GetSource());
 		break;
 	default:
 		throw NotImplementedException(LogicalOperatorToString(state.type));
 	}
-	return make_unique<LogicalSimple>(type, std::move(parseInfo));
+	return make_unique<LogicalSimple>(type, std::move(parse_info));
 }
 
 idx_t LogicalSimple::EstimateCardinality(ClientContext &context) {

--- a/src/planner/operator/logical_simple.cpp
+++ b/src/planner/operator/logical_simple.cpp
@@ -1,13 +1,43 @@
 #include "duckdb/planner/operator/logical_simple.hpp"
+#include "duckdb/parser/parsed_data/drop_info.hpp"
+#include "duckdb/parser/parsed_data/load_info.hpp"
 
 namespace duckdb {
 
 void LogicalSimple::Serialize(FieldWriter &writer) const {
-	throw NotImplementedException(LogicalOperatorToString(type));
+	writer.WriteField<LogicalOperatorType>(type);
+	switch (type) {
+	case LogicalOperatorType::LOGICAL_ALTER:
+		static_cast<const AlterInfo &>(*info).Serialize(writer.GetSerializer());
+		break;
+	case LogicalOperatorType::LOGICAL_DROP:
+		static_cast<const DropInfo &>(*info).Serialize(writer.GetSerializer());
+		break;
+	case LogicalOperatorType::LOGICAL_LOAD:
+		static_cast<const LoadInfo &>(*info).Serialize(writer.GetSerializer());
+		break;
+	default:
+		throw NotImplementedException(LogicalOperatorToString(type));
+	}
 }
 
 unique_ptr<LogicalOperator> LogicalSimple::Deserialize(LogicalDeserializationState &state, FieldReader &reader) {
-	throw NotImplementedException(LogicalOperatorToString(state.type));
+	auto type = reader.ReadRequired<LogicalOperatorType>();
+	unique_ptr<ParseInfo> parseInfo;
+	switch (type) {
+	case LogicalOperatorType::LOGICAL_ALTER:
+		parseInfo = AlterInfo::Deserialize(reader.GetSource());
+		break;
+	case LogicalOperatorType::LOGICAL_DROP:
+		parseInfo = DropInfo::Deserialize(reader.GetSource());
+		break;
+	case LogicalOperatorType::LOGICAL_LOAD:
+		parseInfo = LoadInfo::Deserialize(reader.GetSource());
+		break;
+	default:
+		throw NotImplementedException(LogicalOperatorToString(state.type));
+	}
+	return make_unique<LogicalSimple>(type, std::move(parseInfo));
 }
 
 idx_t LogicalSimple::EstimateCardinality(ClientContext &context) {

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -154,13 +154,11 @@ static bool OperatorSupportsSerialization(LogicalOperator &op) {
 	case LogicalOperatorType::LOGICAL_CREATE_VIEW:
 	case LogicalOperatorType::LOGICAL_CREATE_SCHEMA:
 	case LogicalOperatorType::LOGICAL_CREATE_MACRO:
-	case LogicalOperatorType::LOGICAL_DROP:
 	case LogicalOperatorType::LOGICAL_PRAGMA:
 	case LogicalOperatorType::LOGICAL_TRANSACTION:
 	case LogicalOperatorType::LOGICAL_CREATE_TYPE:
 	case LogicalOperatorType::LOGICAL_EXPLAIN:
 	case LogicalOperatorType::LOGICAL_COPY_TO_FILE:
-	case LogicalOperatorType::LOGICAL_LOAD:
 	case LogicalOperatorType::LOGICAL_VACUUM:
 		// unsupported (for now)
 		return false;

--- a/test/api/test_plan_serialization.cpp
+++ b/test/api/test_plan_serialization.cpp
@@ -100,3 +100,15 @@ TEST_CASE("Test logical_update", "[serialization]") {
 // TEST_CASE("Test logical_prepare", "[serialization]") {
 //	test_helper("PREPARE v1 AS SELECT 42");
 //}
+
+TEST_CASE("Test logical_simple with DROP", "[serialization]") {
+	test_helper("DROP TABLE tbl", {"CREATE TABLE tbl (foo INTEGER)"});
+}
+
+TEST_CASE("Test logical_simple with ALTER", "[serialization]") {
+	test_helper("ALTER TABLE tbl ADD COLUMN bar INTEGER", {"CREATE TABLE tbl (foo INTEGER)"});
+}
+
+TEST_CASE("Test logical_simple with LOAD", "[serialization]") {
+	test_helper("LOAD foo");
+}


### PR DESCRIPTION
Follow-up to #4420 that adds serialization support for `LogicalSimple` operators, in particular the `LOGICAL_ALTER`, `LOGICAL_DROP`, and `LOGICAL_LOAD` types.