### PR TITLE
Fix #5936 - in the Pragma parser, avoid calling ToString() on column references because it might add quotes to keywords

### DIFF
--- a/src/parser/transform/statement/transform_pragma.cpp
+++ b/src/parser/transform/statement/transform_pragma.cpp
@@ -36,6 +36,13 @@ unique_ptr<SQLStatement> Transformer::TransformPragma(duckdb_libpgquery::PGNode 
 			} else if (node->type == duckdb_libpgquery::T_PGAConst) {
 				auto constant = TransformConstant((duckdb_libpgquery::PGAConst *)node);
 				info.parameters.push_back(((ConstantExpression &)*constant).value);
+			} else if (expr->type == ExpressionType::COLUMN_REF) {
+				auto &colref = (ColumnRefExpression &)*expr;
+				if (!colref.IsQualified()) {
+					info.parameters.emplace_back(colref.GetColumnName());
+				} else {
+					info.parameters.emplace_back(expr->ToString());
+				}
 			} else {
 				info.parameters.emplace_back(expr->ToString());
 			}

--- a/test/sql/fts/test_issue_5936.test
+++ b/test/sql/fts/test_issue_5936.test
@@ -1,0 +1,16 @@
+# name: test/sql/fts/test_issue_5936.test
+# description: Issue #5936 - Confusing "column does not exist" error when using column named "document" with full text search
+# group: [fts]
+
+require skip_reload
+
+require fts
+
+statement ok
+CREATE TABLE documents(document VARCHAR, url VARCHAR);
+
+statement ok
+INSERT INTO documents VALUES ('hello world', 'https://example.com'), ('foobar', 'https://google.com');
+
+statement ok
+PRAGMA create_fts_index(documents, url, document);


### PR DESCRIPTION
Fixes #5936 