### PR TITLE
Benchmarks

### DIFF
--- a/benchmark/micro/cast/strptime.benchmark
+++ b/benchmark/micro/cast/strptime.benchmark
@@ -6,7 +6,7 @@ name StrpTime for STRING -> DATE
 group cast
 
 load
-CREATE TABLE dates AS SELECT strftime(DATE '1992-01-01' + i::INTEGER, '%Y/%m/%d') AS d FROM range(0, 10000000) tbl(i);
+CREATE TABLE dates AS SELECT strftime(DATE '1992-01-01' + i::INTEGER, '%Y/%m/%d') AS d FROM range(0, 1000000) tbl(i);
 
 run
 SELECT MIN(strptime(d, '%Y/%m/%d')) FROM dates

--- a/benchmark/micro/join/left_outer_join_right_big.benchmark
+++ b/benchmark/micro/join/left_outer_join_right_big.benchmark
@@ -6,6 +6,7 @@ name Left Outer Join (big RHS, small LHS)
 group join
 
 load
+select setseed(0.4);
 CREATE TABLE small_table ( pkey integer, c0 char(2), c_1k integer, c_10k integer, c_100k integer, c_1m integer, c_10m integer, c_100m integer );
 insert into small_table
 select i, concat('A',mod(i,2)), (random()* 1000)::int, (random()* 10000)::int, (random()* 100000)::int,
@@ -19,4 +20,4 @@ run
 select count(*) from small_table d left outer join big_table f on ( d.pkey=f.c_10k);
 
 result I
-100000000
+99995031

--- a/benchmark/micro/join/right_outer_join_left_big.benchmark
+++ b/benchmark/micro/join/right_outer_join_left_big.benchmark
@@ -6,6 +6,7 @@ name Right Outer Join (big LHS, small RHS)
 group join
 
 load
+select setseed(0.4);
 CREATE TABLE small_table ( pkey integer, c0 char(2), c_1k integer, c_10k integer, c_100k integer, c_1m integer, c_10m integer, c_100m integer );
 insert into small_table
 select i, concat('A',mod(i,2)), (random()* 1000)::int, (random()* 10000)::int, (random()* 100000)::int,
@@ -19,4 +20,4 @@ run
 select count(*) from big_table f right outer join small_table d on ( d.pkey=f.c_10k);
 
 result I
-100000000
+99995031

--- a/benchmark/micro/limit/parquet_parallel_limit_glob.benchmark
+++ b/benchmark/micro/limit/parquet_parallel_limit_glob.benchmark
@@ -15,7 +15,7 @@ COPY (SELECT * FROM range(50000000, 100000000) t(i)) TO '${BENCHMARK_DIR}/intege
 CREATE VIEW integers AS SELECT * FROM parquet_scan(['${BENCHMARK_DIR}/integers1.parquet', '${BENCHMARK_DIR}/integers2.parquet']);
 
 run
-SELECT * FROM integers WHERE i IN (SELECT * FROM other_table) LIMIT 4
+SELECT * FROM integers WHERE i IN (SELECT * FROM other_table) ORDER BY i  LIMIT 4
 
 result I
 337

--- a/benchmark/micro/string/contains_integers.benchmark
+++ b/benchmark/micro/string/contains_integers.benchmark
@@ -8,12 +8,12 @@ group string
 require tpch
 
 load
-CREATE TABLE strs AS SELECT (i * 9876983769044 % 10000000)::VARCHAR AS s FROM range(0, 10000000) t(i);
+CREATE TABLE strs AS SELECT (i * 9 % 10000000)::VARCHAR AS s FROM range(0, 10000000) t(i);
 
 run
 SELECT COUNT(*) FROM strs WHERE contains(s, '1234')
 
 result I
-3209
+4000
 
 


### PR DESCRIPTION
While running benchmark tool (without providing specific input) a bunch of INCORRECT RESULTS or runtime assertion popped up.
I fixed/simplified the benchmarks to at least work, unsure whether it's worth deeper investigation / proper fixes on the duckdb code.

The problems are basically:

```
./duckdb
D select (123123123 * 3132123123123);
Error: Out of Range Error: Overflow in multiplication of INT64 (123123123 * 3132123123123)!

sqlite3
sqlite> select (123123123 * 3132123123123);
3.85636780539417e+20
```

`./build/benchmark/benchmark_runner benchmark/micro/limit/parquet_parallel_limit_glob.benchmark` was non deterministic (unsure whether ordering should be somehow restored, or non-determinism with parquet reader is to be expected).

strptime (duckdb code) has hardcoded that a date should have a 4 cipher year (less will work, 5+ cipher will be runtime error). Here probably either proper handling or different failure mode is required.

Last thing was about random numbers (left/right_outer_join_...), adding a seed seems right, but a double check might be nice.


Unsure whether this makes sense to merge then potentially revert once fixes land, or cherry-pick only the changes that makes sense.

Also it would be probably nice to ensure the benchmark_runner's test correctness is checked in the CI (without regression testing, just to keep those maintained) + the 'require icu' or 'require httpfs' doesn't seem to currently work as expected for benchmarks, but those are independent problems.