### PR TITLE
httpfs: remove unneded include

### DIFF
--- a/extension/httpfs/CMakeLists.txt
+++ b/extension/httpfs/CMakeLists.txt
@@ -4,7 +4,7 @@ project(HTTPFsExtension)
 
 add_extension_definitions()
 
-include_directories(include ../.. ../../third_party/httplib ../parquet/include)
+include_directories(include ../../third_party/httplib ../parquet/include)
 
 add_library(httpfs_extension STATIC s3fs.cpp httpfs.cpp crypto.cpp
                                     httpfs-extension.cpp)


### PR DESCRIPTION
This has the funny side effect that if any file in the duckdb folder matched (case insensitive) with a name of a c++ header things would stop working (eg adding a file named LIST). I believe this should not be needed, but letting the CI do the check.