### PR TITLE
[jemalloc] Detect LG_PAGE

### DIFF
--- a/extension/jemalloc/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
+++ b/extension/jemalloc/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
@@ -205,7 +205,23 @@ namespace duckdb_jemalloc {
 /* #undef LG_QUANTUM */
 
 /* One page is 2^LG_PAGE bytes. */
-#if defined(__DARWIN__) || defined(__APPLE__)
+// FIXME (duckdb): not sure how future-proof this is. What if Intel makes a chip with a 16k page?
+//  What if someone uses a Windows ARM machine? I hope this suffices for now. If an issue pops up we can fix it.
+#if defined(__i386__)
+#define LG_PAGE 12
+#elif defined(__x86_64__) || defined(__amd64__)
+#define LG_PAGE 12
+#elif defined(__powerpc__) || defined(__ppc__)
+#define LG_PAGE 12
+#elif defined(__sparc__)
+#define LG_PAGE 12
+#elif defined(__ia64__)
+#define LG_PAGE 12
+#elif defined(COMPILER_MSVC) && defined(_M_IX86)
+#define LG_PAGE 12
+#elif defined(__aarch64__)
+#define LG_PAGE 14
+#elif defined(__ARM_ARCH)
 #define LG_PAGE 14
 #else
 #define LG_PAGE 12


### PR DESCRIPTION
This usually happens in jemalloc's `configure` script, which we don't run because we want to be portable. So, we have to detect at compile-time, which I've attempted in this PR. I'm not sure how future-proof this is, but I hope this fixes #5640.