### PR TITLE
[Binder] Throw exception for aggregate function modifiers applied to non-aggregate functions

### DIFF
--- a/test/issues/general/test_5896.test
+++ b/test/issues/general/test_5896.test
@@ -1,0 +1,35 @@
+# name: test/issues/general/test_5896.test
+# description: Issue 5896: json_group_array() does not respect filter clauses
+# group: [general]
+
+statement ok
+PRAGMA enable_verification
+
+# the problem was actually that all aggregate modifiers were ignored for non-aggregate functions
+
+# distinct modifier
+statement error
+select sqrt(distinct range) from range(5);
+----
+Invalid Input Error: Function "sqrt" is a Scalar Function. "DISTINCT", "FILTER", and "ORDER BY" are only applicable to aggregate functions.
+
+# filter modifier
+statement error
+select sqrt(range) filter (where (range > 3)) from range(5);
+----
+Invalid Input Error: Function "sqrt" is a Scalar Function. "DISTINCT", "FILTER", and "ORDER BY" are only applicable to aggregate functions.
+
+# ordered aggregate (error is taken care of somewhere else)
+statement error
+select sqrt(range order by range) from range(5);
+----
+Invalid Input Error: Function "sqrt" is a Scalar Function. "DISTINCT", "FILTER", and "ORDER BY" are only applicable to aggregate functions.
+
+# let's test with a macro
+statement ok
+create macro my_sqrt(x) as sqrt(x)
+
+statement error
+select my_sqrt(distinct range) from range(5);
+----
+Invalid Input Error: Function "my_sqrt" is a Macro Function. "DISTINCT", "FILTER", and "ORDER BY" are only applicable to aggregate functions.


### PR DESCRIPTION
Rather than silently ignoring them. Fixes #5896.