### PR TITLE
Restore node-pre-gyp credentials

### DIFF
--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -21,6 +21,8 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.NODE_PRE_GYP_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.NODE_PRE_GYP_SECRETACCESSKEY }}
 
 jobs:
   linux-nodejs:


### PR DESCRIPTION
Fixing problem introduced earlier in e3d4105f575e46a131ccb81aa0ec86275dbafb35, reintroducing NODE_PRE_GYP credentials where needed.

This will cause all NodeJS action to fail until patched.