### PR TITLE
Fix #5971: addition and subtraction on infinity of TIMESTAMPTZ

### DIFF
--- a/extension/icu/icu-dateadd.cpp
+++ b/extension/icu/icu-dateadd.cpp
@@ -53,6 +53,10 @@ static inline void CalendarAddHour(icu::Calendar *calendar, int64_t interval_hou
 
 template <>
 timestamp_t ICUCalendarAdd::Operation(timestamp_t timestamp, interval_t interval, icu::Calendar *calendar) {
+	if (!Timestamp::IsFinite(timestamp)) {
+		return timestamp;
+	}
+
 	int64_t millis = timestamp.value / Interval::MICROS_PER_MSEC;
 	int64_t micros = timestamp.value % Interval::MICROS_PER_MSEC;
 

--- a/test/sql/function/timestamp/test_icu_dateadd.test
+++ b/test/sql/function/timestamp/test_icu_dateadd.test
@@ -109,7 +109,7 @@ select 'epoch'::timestamptz + '-9223372022400001000 microseconds'::interval
 ----
 290303-12-10 (BC) 16:07:02-07:52
 
-#  interval + timestamp
+# interval + timestamp
 query II
 SELECT iv, iv + '2021-12-01 13:54:48.123456Z'::TIMESTAMPTZ FROM intervals;
 ----
@@ -166,6 +166,27 @@ select  '-9223372022400001000 microseconds'::interval + 'epoch'::timestamptz
 ----
 290303-12-10 (BC) 16:07:02-07:52
 
+# infinity
+query I
+select 'infinity'::timestamptz + '1 microsecond'::interval
+----
+infinity
+
+query I
+select '1 microsecond'::interval + 'infinity'::timestamptz
+----
+infinity
+
+query I
+select '-infinity'::timestamptz + '1 microsecond'::interval
+----
+-infinity
+
+query I
+select '1 microsecond'::interval + '-infinity'::timestamptz
+----
+-infinity
+
 # timestamp - interval
 query II
 SELECT iv, '2021-12-01 13:54:48.123456Z'::TIMESTAMPTZ - iv FROM intervals;
@@ -214,6 +235,17 @@ query I
 select 'epoch'::timestamptz - '9223372022400001000 microseconds'::interval
 ----
 290303-12-10 (BC) 16:07:02-07:52
+
+# infinity
+query I
+select 'infinity'::timestamptz - '1 day'::interval
+----
+infinity
+
+query I
+select '-infinity'::timestamptz - '1 day'::interval
+----
+-infinity
 
 # Before the epoch
 query II


### PR DESCRIPTION
Fixes #5971 

This PR adds infinity check before addition/subtraction of `TIMESTAMPTZ` and `INTERVAL`.