### PR TITLE
Fix amalgamation build: returning (std::)move will otherwise be flagg…

### DIFF
--- a/src/include/duckdb/parser/parsed_data/create_database_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_database_info.hpp
@@ -32,7 +32,7 @@ public:
 		result->extension_name = extension_name;
 		result->name = name;
 		result->path = path;
-		return move(result);
+		return unique_ptr<CreateInfo>(result.release());
 	}
 
 	static unique_ptr<CreateDatabaseInfo> Deserialize(Deserializer &deserializer) {

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -165,7 +165,7 @@ unique_ptr<LogicalOperator> Binder::BindUpdateSet(LogicalOperator *op, unique_pt
 		}
 	}
 	if (op->type != LogicalOperatorType::LOGICAL_UPDATE && projection_expressions.empty()) {
-		return move(root);
+		return root;
 	}
 	// now create the projection
 	auto proj = make_unique<LogicalProjection>(proj_index, std::move(projection_expressions));


### PR DESCRIPTION
…ed as not required

Probably there is a better / more general solution to this, since I expect it will pop-up also in other places