### PR TITLE
[python] Use duck typing for arrow dataset

### DIFF
--- a/tools/pythonpkg/src/arrow_array_stream.cpp
+++ b/tools/pythonpkg/src/arrow_array_stream.cpp
@@ -62,15 +62,14 @@ unique_ptr<ArrowArrayStreamWrapper> PythonTableArrowArrayStreamFactory::Produce(
 	D_ASSERT(factory->arrow_object);
 	py::handle arrow_obj_handle(factory->arrow_object);
 	auto arrow_object_type = GetArrowType(arrow_obj_handle);
-	auto scanner_class = py::module::import("pyarrow.dataset").attr("Scanner");
 
 	py::object scanner;
-	py::object arrow_scanner = scanner_class.attr("from_dataset");
 	py::object arrow_batch_scanner = py::module_::import("pyarrow.dataset").attr("Scanner").attr("from_batches");
 	switch (arrow_object_type) {
 	case PyArrowObjectType::Table: {
 		auto arrow_dataset = py::module_::import("pyarrow.dataset").attr("dataset");
 		auto dataset = arrow_dataset(arrow_obj_handle);
+		py::object arrow_scanner = dataset.attr("__class__").attr("scanner");
 		scanner = ProduceScanner(arrow_scanner, dataset, parameters, factory->config);
 		break;
 	}
@@ -86,6 +85,7 @@ unique_ptr<ArrowArrayStreamWrapper> PythonTableArrowArrayStreamFactory::Produce(
 		break;
 	}
 	case PyArrowObjectType::Dataset: {
+		py::object arrow_scanner = arrow_obj_handle.attr("__class__").attr("scanner");
 		scanner = ProduceScanner(arrow_scanner, arrow_obj_handle, parameters, factory->config);
 		break;
 	}


### PR DESCRIPTION
Currently the pyarrow.dataset.Scanner.from_dataset static method is being called to create a scanner which depends on the Arrow C++ Dataset API. This makes it harder to integrate Rust packages using arrow-rs because these use the Arrow C data interface which is very very limited (for stability purposes).

Instead, this is a small PR that uses the Dataset.scanner method to create the Scanner. For regular pyarrow Datasets, that just calls the same Scanner.from_dataset under the hood so there is no difference in behavior. But for Rust-based packages integrated via pyo3, it provides a way to override the behavior and create its own scanner, as long as the final data still meets the RecordBatchReader C data interface.