### PR TITLE
[Dev] Fix #6020: Fix failure of CI with pyarrow

### DIFF
--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_recordbatchreader.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_recordbatchreader.py
@@ -28,7 +28,7 @@ class TestArrowRecordBatchReader(object):
         , format="parquet")
 
         batches= [r for r in userdata_parquet_dataset.to_batches()]
-        reader=pyarrow.dataset.Scanner.from_batches(batches,userdata_parquet_dataset.schema).to_reader()
+        reader=pyarrow.dataset.Scanner.from_batches(batches,schema=userdata_parquet_dataset.schema).to_reader()
 
         rel = duckdb_conn.from_arrow(reader)
 
@@ -53,7 +53,7 @@ class TestArrowRecordBatchReader(object):
         , format="parquet")
 
         batches= [r for r in userdata_parquet_dataset.to_batches()]
-        reader=pyarrow.dataset.Scanner.from_batches(batches,userdata_parquet_dataset.schema).to_reader()
+        reader=pyarrow.dataset.Scanner.from_batches(batches,schema=userdata_parquet_dataset.schema).to_reader()
 
         assert duckdb_conn.execute("select count(*) from reader where first_name=\'Jose\' and salary > 134708.82").fetchone()[0] == 12
         assert duckdb_conn.execute("select count(*) from reader where first_name=\'Jose\' and salary > 134708.82").fetchone()[0] == 0
@@ -75,7 +75,7 @@ class TestArrowRecordBatchReader(object):
         , format="parquet")
 
         batches= [r for r in userdata_parquet_dataset.to_batches()]
-        reader=pyarrow.dataset.Scanner.from_batches(batches,userdata_parquet_dataset.schema).to_reader()
+        reader=pyarrow.dataset.Scanner.from_batches(batches,schema=userdata_parquet_dataset.schema).to_reader()
 
         duckdb_conn.register("bla", reader)
 
@@ -96,7 +96,7 @@ class TestArrowRecordBatchReader(object):
         , format="parquet")
 
         batches= [r for r in userdata_parquet_dataset.to_batches()]
-        reader=pyarrow.dataset.Scanner.from_batches(batches,userdata_parquet_dataset.schema).to_reader()
+        reader=pyarrow.dataset.Scanner.from_batches(batches,schema=userdata_parquet_dataset.schema).to_reader()
 
         rel = duckdb.from_arrow(reader)
 
@@ -104,4 +104,3 @@ class TestArrowRecordBatchReader(object):
         # The reader is already consumed so this should be 0
         assert rel.filter("first_name=\'Jose\' and salary > 134708.82").aggregate('count(*)').execute().fetchone()[0] == 0
 
-    


### PR DESCRIPTION
Fixes #6020 

pyarrow 11.0.0 got released on January 27, 2023.
In pyarrow 10.0.1, `from_batches` function took `schama` argument as positional or keyword argument, but in 11.0.0, it takes `schama` only as keyword argument.

https://github.com/apache/arrow/compare/apache-arrow-10.0.1...apache-arrow-11.0.0#diff-704d642afd62c0e9577833149c45e3c9df38a31fc0f478eee5b68b359a9075baL2529-R2690

https://github.com/apache/arrow/blob/f10f5cfd1376fb0e602334588b3f3624d41dee7d/python/pyarrow/_dataset.pyx#L2686-L2690

This PR makes calling `from_batches` to use keyword argument `schama`.