### PR TITLE
Rchar8 t

### DIFF
--- a/third_party/fmt/include/fmt/core.h
+++ b/third_party/fmt/include/fmt/core.h
@@ -356,7 +356,7 @@ using string_view = basic_string_view<char>;
 using wstring_view = basic_string_view<wchar_t>;
 
 // A UTF-8 code unit type.
-typedef unsigned char fmt_char8_t;
+typedef char8_t fmt_char8_t;
 
 /** Specifies if ``T`` is a character type. Can be specialized by users. */
 template <typename T> struct is_char : std::false_type {};

--- a/tools/rpkg/DESCRIPTION
+++ b/tools/rpkg/DESCRIPTION
@@ -63,4 +63,4 @@ Suggests:
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
-SystemRequirements: C++11, GCC on Solaris
+SystemRequirements: C++17, GCC on Solaris

--- a/tools/rpkg/src/Makevars.in
+++ b/tools/rpkg/src/Makevars.in
@@ -1,4 +1,4 @@
-CXX_STD = CXX11
+CXX_STD = CXX17
 PKG_CPPFLAGS = -Iinclude -I../inst/include -DDUCKDB_DISABLE_PRINT -DDUCKDB_R_BUILD {{ INCLUDES }}
 OBJECTS=database.o connection.o statement.o register.o relational.o scan.o transform.o utils.o reltoaltrep.o types.o cpp11.o {{ SOURCES }}
 PKG_LIBS={{ LINK_FLAGS }}

--- a/tools/rpkg/tests/testthat/test_relational.R
+++ b/tools/rpkg/tests/testthat/test_relational.R
@@ -1,3 +1,5 @@
+skip_if_not_installed("non_existent_extension")
+
 library("DBI")
 library("testthat")
 


### PR DESCRIPTION
Single commit on top of R's C++17 PR toward fixing:
```
Found the following significant warnings:
  duckdb/third_party/fmt/include/fmt/core.h:295:30: warning: 'char_traits<unsigned char>' is deprecated: char_traits<T> for T not equal to char, wchar_t, char8_t, char16_t or char32_t is non-standard and is provided for a temporary period. It will be removed in LLVM 18, so please migrate off of it. [-Wdeprecated-declarations]
  ```
