### PR TITLE
Use back-up to download unixODBC

### DIFF
--- a/scripts/install_unixodbc.sh
+++ b/scripts/install_unixodbc.sh
@@ -4,7 +4,8 @@ rm -rf build/unixodbc
 mkdir -p build/unixodbc
 cd build/unixodbc
 mkdir sources build
-curl http://www.unixodbc.org/unixODBC-2.3.11.tar.gz | tar xvz -C sources --strip-components 1
+wget http://www.unixodbc.org/unixODBC-2.3.11.tar.gz || wget http://github.com/lurcher/unixODBC/releases/download/2.3.11/unixODBC-2.3.11.tar.gz
+tar -xf unixODBC-2.3.11.tar.gz -C sources --strip-components 1
 cd sources
 ./configure --prefix `cd ../build; pwd` --disable-debug --disable-dependency-tracking --enable-static --enable-gui=no $@
 make -j install


### PR DESCRIPTION
http://www.unixodbc.org/unixODBC-2.3.11.tar.gz seems to be often down, causing CI failures https://github.com/lurcher/unixODBC/releases/download/2.3.11/unixODBC-2.3.11.tar.gz (github releases from official repo seems a good second option to go to