### PR TITLE
[ParquetWriter] Prevent creating broken parquet files

### DIFF
--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -220,13 +220,13 @@ vector<string> GetUniqueNames(const vector<string> &original_names) {
 		auto insert_result = name_set.insert(name);
 		if (insert_result.second == false) {
 			// Could not be inserted, name already exists
-			idx_t postfix = 1;
+			idx_t index = 1;
 			string postfixed_name;
 			while (true) {
-				postfixed_name = StringUtil::Format("%s_%d", name, postfix);
+				postfixed_name = StringUtil::Format("%s:%d", name, index);
 				auto res = name_set.insert(postfixed_name);
 				if (!res.second) {
-					postfix++;
+					index++;
 					continue;
 				}
 				break;

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -33,6 +33,34 @@ static vector<idx_t> ColumnListToIndices(const vector<bool> &vec) {
 	return ret;
 }
 
+vector<string> GetUniqueNames(const vector<string> &original_names) {
+	unordered_set<string> name_set;
+	vector<string> unique_names;
+	unique_names.reserve(original_names.size());
+
+	for (auto &name : original_names) {
+		auto insert_result = name_set.insert(name);
+		if (insert_result.second == false) {
+			// Could not be inserted, name already exists
+			idx_t index = 1;
+			string postfixed_name;
+			while (true) {
+				postfixed_name = StringUtil::Format("%s:%d", name, index);
+				auto res = name_set.insert(postfixed_name);
+				if (!res.second) {
+					index++;
+					continue;
+				}
+				break;
+			}
+			unique_names.push_back(postfixed_name);
+		} else {
+			unique_names.push_back(name);
+		}
+	}
+	return unique_names;
+}
+
 BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 	// COPY TO a file
 	auto &config = DBConfig::GetConfig(context);
@@ -99,8 +127,10 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 		use_tmp_file = is_file_and_exists && !per_thread_output && partition_cols.empty() && !is_stdout;
 	}
 
+	auto unique_column_names = GetUniqueNames(select_node.names);
+
 	auto function_data =
-	    copy_function->function.copy_to_bind(context, *stmt.info, select_node.names, select_node.types);
+	    copy_function->function.copy_to_bind(context, *stmt.info, unique_column_names, select_node.types);
 	// now create the copy information
 	auto copy = make_unique<LogicalCopyToFile>(copy_function->function, std::move(function_data));
 	copy->file_path = stmt.info->file_path;
@@ -110,7 +140,8 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 	copy->per_thread_output = per_thread_output;
 	copy->partition_output = !partition_cols.empty();
 	copy->partition_columns = std::move(partition_cols);
-	copy->names = select_node.names;
+
+	copy->names = unique_column_names;
 	copy->expected_types = select_node.types;
 
 	copy->AddChild(std::move(select_node.plan));

--- a/test/sql/copy/csv/test_csv_duplicate_columns.test
+++ b/test/sql/copy/csv/test_csv_duplicate_columns.test
@@ -1,0 +1,32 @@
+# name: test/sql/copy/csv/test_csv_duplicate_columns.test
+# group: [csv]
+
+require parquet
+
+statement ok
+COPY (SELECT 1 as a, 2 as a, 3 as a) TO '__TEST_DIR__/dupe_cols.csv' (FORMAT CSV, HEADER);
+
+# The duplicate column(s) get `:{index}` appended to it
+query III
+SELECT a, "a:1", "a:2" FROM '__TEST_DIR__/dupe_cols.csv';
+----
+1	2	3
+
+# Original names are not preserved if a dupe appears first
+statement ok
+COPY (SELECT 1 as a, 2 as a, 3 as "a:1") TO '__TEST_DIR__/dupe_cols.csv' (FORMAT CSV, HEADER);
+
+# original 'a:1' is renamed to 'a:2'
+query III
+SELECT a, "a:1", "a:1:1" FROM '__TEST_DIR__/dupe_cols.csv';
+----
+1	2	3
+
+statement ok
+COPY (SELECT 1 as a, 3 as "a:1", 2 as a) TO '__TEST_DIR__/dupe_cols.csv' (FORMAT CSV, HEADER);
+
+# Here the name is preserved, because it appears before the dupe
+query III
+SELECT a, "a:1", "a:2" FROM '__TEST_DIR__/dupe_cols.csv';
+----
+1	3	2

--- a/test/sql/copy/parquet/test_parquet_duplicate_columns.test
+++ b/test/sql/copy/parquet/test_parquet_duplicate_columns.test
@@ -1,0 +1,12 @@
+# name: test/sql/copy/parquet/test_parquet_duplicate_columns.test
+# group: [parquet]
+
+require parquet
+
+statement ok
+COPY (SELECT 1 as a, 2 as a) TO '__TEST_DIR__/dupe_cols.parquet';
+
+query II
+SELECT a, a_1 FROM '__TEST_DIR__/dupe_cols.parquet';
+----
+1	2

--- a/test/sql/copy/parquet/test_parquet_duplicate_columns.test
+++ b/test/sql/copy/parquet/test_parquet_duplicate_columns.test
@@ -4,9 +4,29 @@
 require parquet
 
 statement ok
-COPY (SELECT 1 as a, 2 as a) TO '__TEST_DIR__/dupe_cols.parquet';
+COPY (SELECT 1 as a, 2 as a, 3 as a) TO '__TEST_DIR__/dupe_cols.parquet';
 
-query II
-SELECT a, a_1 FROM '__TEST_DIR__/dupe_cols.parquet';
+# The duplicate column(s) get `:{index}` appended to it
+query III
+SELECT a, "a:1", "a:2" FROM '__TEST_DIR__/dupe_cols.parquet';
 ----
-1	2
+1	2	3
+
+# Original names are not preserved if a dupe appears first
+statement ok
+COPY (SELECT 1 as a, 2 as a, 3 as "a:1") TO '__TEST_DIR__/dupe_cols.parquet';
+
+# original 'a:1' is renamed to 'a:2'
+query III
+SELECT a, "a:1", "a:1:1" FROM '__TEST_DIR__/dupe_cols.parquet';
+----
+1	2	3
+
+statement ok
+COPY (SELECT 1 as a, 3 as "a:1", 2 as a) TO '__TEST_DIR__/dupe_cols.parquet';
+
+# Here the name is preserved, because it appears before the dupe
+query III
+SELECT a, "a:1", "a:2" FROM '__TEST_DIR__/dupe_cols.parquet';
+----
+1	3	2


### PR DESCRIPTION
This PR fixes #6067

As the issue pointed out, previously we did not check for duplicates in column names, writing them to the parquet file created a broken parquet file.

Now we rename the duplicate column names in a way that's consistent with the way it is done in other parts of the code before writing the parquet file