### PR TITLE
[Python] Make `pyarrow.dataset` optional

### DIFF
--- a/tools/pythonpkg/src/arrow_array_stream.cpp
+++ b/tools/pythonpkg/src/arrow_array_stream.cpp
@@ -16,7 +16,7 @@ namespace duckdb {
 
 void VerifyArrowDatasetLoaded() {
 	auto &import_cache = *DuckDBPyConnection::ImportCache();
-	if (!import_cache.pyarrow.dataset.IsLoaded()) {
+	if (!import_cache.arrow.dataset.IsLoaded()) {
 		throw InvalidInputException("Optional module 'pyarrow.dataset' is required to perform this action");
 	}
 }
@@ -112,6 +112,8 @@ unique_ptr<ArrowArrayStreamWrapper> PythonTableArrowArrayStreamFactory::Produce(
 }
 
 void PythonTableArrowArrayStreamFactory::GetSchema(uintptr_t factory_ptr, ArrowSchemaWrapper &schema) {
+	VerifyArrowDatasetLoaded();
+
 	py::gil_scoped_acquire acquire;
 	PythonTableArrowArrayStreamFactory *factory = (PythonTableArrowArrayStreamFactory *)factory_ptr;
 	D_ASSERT(factory->arrow_object);

--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/arrow_module.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/arrow_module.hpp
@@ -38,6 +38,11 @@ public:
 public:
 	PythonImportCacheItem Dataset;
 	PythonImportCacheItem Scanner;
+
+protected:
+	bool IsRequired() const override final {
+		return false;
+	}
 };
 
 struct ArrowCacheItem : public PythonImportCacheItem {

--- a/tools/pythonpkg/tests/fast/test_import_without_pyarrow_dataset.py
+++ b/tools/pythonpkg/tests/fast/test_import_without_pyarrow_dataset.py
@@ -1,0 +1,16 @@
+import pytest
+import sys
+
+pyarrow = pytest.importorskip("pyarrow")
+
+class TestImportWithoutPyArrowDataset:
+	def test_import(self, monkeypatch: pytest.MonkeyPatch):
+		monkeypatch.setitem(sys.modules, "pyarrow.dataset", None)
+		import duckdb
+		# We should be able to import duckdb even when pyarrow.dataset is missing
+
+		rel = duckdb.query('select 1')
+		arrow_table = rel.arrow()
+		with pytest.raises(ModuleNotFoundError):
+			# The replacement scan functionality relies on pyarrow.dataset
+			duckdb.query('select * from arrow_table')


### PR DESCRIPTION
This PR fixes #6093 

The `pyarrow` module was already optional, but once that import succeeds, we would try to import `pyarrow.dataset`, not marking it as optional - causing the `import duckdb` to fail

Now it's only checked when the functionality of that module is needed