### PR TITLE
[Fuzzer] Fix issue related to dropping a generated column

### DIFF
--- a/src/include/duckdb/catalog/catalog_entry/duck_table_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/duck_table_entry.hpp
@@ -57,6 +57,9 @@ private:
 	unique_ptr<CatalogEntry> AddForeignKeyConstraint(ClientContext &context, AlterForeignKeyInfo &info);
 	unique_ptr<CatalogEntry> DropForeignKeyConstraint(ClientContext &context, AlterForeignKeyInfo &info);
 
+	void UpdateConstraintsOnColumnDrop(const LogicalIndex &removed_index, const vector<LogicalIndex> &adjusted_indices,
+	                                   const RemoveColumnInfo &info, CreateTableInfo &create_info, bool is_generated);
+
 private:
 	//! A reference to the underlying storage unit used for this table
 	std::shared_ptr<DataTable> storage;

--- a/test/fuzzer/pedro/drop_gcol.test
+++ b/test/fuzzer/pedro/drop_gcol.test
@@ -1,0 +1,12 @@
+# name: test/fuzzer/pedro/drop_gcol.test
+# description: Issue #4571: Duplicate table name at CTE in INSERT statement
+# group: [pedro]
+
+statement ok
+pragma enable_verification
+
+statement ok
+CREATE TABLE t0 (c0 INT AS (0), c1 INT, CHECK(c1 > 0));
+
+statement ok
+ALTER TABLE t0 DROP c0;


### PR DESCRIPTION
This PR fixes 'Drop generated Column' issue from #5984 

What happened was that when dropping a column, for existing CHECK constraints, we check if the column is referenced by the check constraint.
This involves calling `LogicalToPhysical` - which throws an internal exception if the column type is Generated.
So I added a check for this.

Generated columns can not be part of check constraints, so we can just re-add the constraint.