### PR TITLE
Try to auto-cast list_filter input and throw exception when failing

### DIFF
--- a/src/function/scalar/list/list_lambdas.cpp
+++ b/src/function/scalar/list/list_lambdas.cpp
@@ -368,13 +368,8 @@ static unique_ptr<FunctionData> ListFilterBind(ClientContext &context, ScalarFun
 	// try to cast to boolean, if the return type of the lambda filter expression is not already boolean
 	auto &bound_lambda_expr = (BoundLambdaExpression &)*arguments[1];
 	if (bound_lambda_expr.lambda_expr->return_type != LogicalType::BOOLEAN) {
-		auto source_type = bound_lambda_expr.lambda_expr->return_type;
-		auto cast_function_info = GetCastFunctionInput(context);
-		CastFunctionSet cast_function_set;
-		auto bound_cast_info = cast_function_set.GetCastFunction(source_type, LogicalType::BOOLEAN, cast_function_info);
-		auto bound_cast_expr = make_unique<BoundCastExpression>(std::move(bound_lambda_expr.lambda_expr),
-		                                                        LogicalType::BOOLEAN, bound_cast_info.Copy());
-		bound_lambda_expr.lambda_expr = std::move(bound_cast_expr);
+		bound_lambda_expr.lambda_expr = std::move(BoundCastExpression::AddCastToType(
+		    context, std::move(bound_lambda_expr.lambda_expr), LogicalType::BOOLEAN));
 	}
 
 	bound_function.return_type = arguments[0]->return_type;

--- a/src/function/scalar/list/list_lambdas.cpp
+++ b/src/function/scalar/list/list_lambdas.cpp
@@ -268,9 +268,18 @@ static void ListLambdaFunction(DataChunk &args, ExpressionState &state, Vector &
 				if (IS_TRANSFORM) {
 					AppendTransformedToResult(lambda_vector, elem_cnt, result);
 				} else {
-					AppendFilteredToResult(lambda_vector, result_entries, elem_cnt, result, curr_list_len,
-					                       curr_list_offset, appended_lists_cnt, lists_len, curr_original_list_len,
-					                       input_chunk);
+					if (lambda_vector.GetType() != LogicalType::BOOLEAN) {
+						// try casting, otherwise fail
+						Vector cast_vector(LogicalType::BOOLEAN);
+						VectorOperations::Cast(state.GetContext(), lambda_vector, cast_vector, elem_cnt, true);
+						AppendFilteredToResult(cast_vector, result_entries, elem_cnt, result, curr_list_len,
+						                       curr_list_offset, appended_lists_cnt, lists_len, curr_original_list_len,
+						                       input_chunk);
+					} else {
+						AppendFilteredToResult(lambda_vector, result_entries, elem_cnt, result, curr_list_len,
+						                       curr_list_offset, appended_lists_cnt, lists_len, curr_original_list_len,
+						                       input_chunk);
+					}
 				}
 				elem_cnt = 0;
 			}
@@ -295,8 +304,16 @@ static void ListLambdaFunction(DataChunk &args, ExpressionState &state, Vector &
 	if (IS_TRANSFORM) {
 		AppendTransformedToResult(lambda_vector, elem_cnt, result);
 	} else {
-		AppendFilteredToResult(lambda_vector, result_entries, elem_cnt, result, curr_list_len, curr_list_offset,
-		                       appended_lists_cnt, lists_len, curr_original_list_len, input_chunk);
+		if (lambda_vector.GetType() != LogicalType::BOOLEAN) {
+			// try casting, otherwise fail
+			Vector cast_vector(LogicalType::BOOLEAN);
+			VectorOperations::Cast(state.GetContext(), lambda_vector, cast_vector, elem_cnt, true);
+			AppendFilteredToResult(cast_vector, result_entries, elem_cnt, result, curr_list_len, curr_list_offset,
+			                       appended_lists_cnt, lists_len, curr_original_list_len, input_chunk);
+		} else {
+			AppendFilteredToResult(lambda_vector, result_entries, elem_cnt, result, curr_list_len, curr_list_offset,
+			                       appended_lists_cnt, lists_len, curr_original_list_len, input_chunk);
+		}
 	}
 
 	if (args.AllConstant()) {

--- a/src/planner/binder/expression/bind_lambda.cpp
+++ b/src/planner/binder/expression/bind_lambda.cpp
@@ -170,6 +170,8 @@ void ExpressionBinder::CaptureLambdaColumns(vector<unique_ptr<Expression>> &capt
 		ExpressionIterator::EnumerateChildren(
 		    *expr, [&](unique_ptr<Expression> &child) { CaptureLambdaColumns(captures, list_child_type, child); });
 	}
+
+	expr->Verify();
 }
 
 } // namespace duckdb

--- a/test/sql/function/list/lambdas/filter.test
+++ b/test/sql/function/list/lambdas/filter.test
@@ -208,3 +208,29 @@ SELECT list_filter([1, 2, 3, 4, 5, 6, 7, 8, 9], x -> x > #1) FROM range(10)
 [8, 9]
 [9]
 []
+
+# fixes 5816
+# auto casting in list_filter, or exception if not possible (casting is strict)
+
+statement ok
+create table lambdas AS SELECT [5,6] AS col1, [4,8] AS col2;
+
+query I
+SELECT list_apply(col1, x -> list_filter(col2, y -> y)) from lambdas;
+----
+[[4, 8], [4, 8]]
+
+query I
+SELECT list_apply([5,6], x -> list_filter([4,8], y -> y));
+----
+[[4, 8], [4, 8]]
+
+query I
+SELECT list_apply([[5,6]], x -> list_filter(x, y -> y));
+----
+[[5, 6]]
+
+statement error
+SELECT list_transform([['abc']], x -> list_filter(x, y -> y));
+----
+Conversion Error: Could not convert string 'abc' to BOOL


### PR DESCRIPTION
This PR addresses one of the two bugs mentioned in #5816. `list_filter` would throw a runtime error when provided with non-boolean lambda expression results in nested lambdas. Now, we try to auto-cast the expression result to `bool`, and throw an exception if that fails.