### PR TITLE
Python box rendering: limit rendering to 10K rows

### DIFF
--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -600,7 +600,7 @@ void BoxRenderer::Render(ClientContext &context, const vector<string> &names, co
 	if (has_hidden_rows) {
 		shown_str = "(";
 		if (has_limited_rows) {
-			shown_str += ">" + to_string(config.limit - 1) + ", ";
+			shown_str += ">" + to_string(config.limit - 1) + " rows, ";
 		}
 		shown_str += to_string(top_rows + bottom_rows) + " shown)";
 	}

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -589,7 +589,6 @@ void BoxRenderer::Render(ClientContext &context, const vector<string> &names, co
 		top_rows = rows_to_render / 2 + (rows_to_render % 2 != 0 ? 1 : 0);
 		bottom_rows = rows_to_render - top_rows;
 	}
-	// (≥ " + to_string(config.limit) ")"
 	auto row_count_str = to_string(row_count) + " rows";
 	bool has_limited_rows = config.limit > 0 && row_count == config.limit;
 	if (has_limited_rows) {

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -589,11 +589,20 @@ void BoxRenderer::Render(ClientContext &context, const vector<string> &names, co
 		top_rows = rows_to_render / 2 + (rows_to_render % 2 != 0 ? 1 : 0);
 		bottom_rows = rows_to_render - top_rows;
 	}
+	// (≥ " + to_string(config.limit) ")"
 	auto row_count_str = to_string(row_count) + " rows";
+	bool has_limited_rows = config.limit > 0 && row_count == config.limit;
+	if (has_limited_rows) {
+		row_count_str = "? rows";
+	}
 	string shown_str;
 	bool has_hidden_rows = top_rows < row_count;
 	if (has_hidden_rows) {
-		shown_str = "(" + to_string(top_rows + bottom_rows) + " shown)";
+		shown_str = "(";
+		if (has_limited_rows) {
+			shown_str += ">" + to_string(config.limit - 1) + ", ";
+		}
+		shown_str += to_string(top_rows + bottom_rows) + " shown)";
 	}
 	auto minimum_row_length = MaxValue<idx_t>(row_count_str.size(), shown_str.size()) + 4;
 

--- a/src/include/duckdb/common/box_renderer.hpp
+++ b/src/include/duckdb/common/box_renderer.hpp
@@ -22,7 +22,11 @@ enum class ValueRenderAlignment { LEFT, MIDDLE, RIGHT };
 struct BoxRendererConfig {
 	// a max_width of 0 means we default to the terminal width
 	idx_t max_width = 0;
+	// the maximum amount of rows to render
 	idx_t max_rows = 20;
+	// the limit that is applied prior to rendering
+	// if we are rendering exactly "limit" rows then a question mark is rendered instead
+	idx_t limit = 0;
 	// the max col width determines the maximum size of a single column
 	// note that the max col width is only used if the result does not fit on the screen
 	idx_t max_col_width = 20;

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -642,11 +642,14 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Map(py::function fun) {
 
 string DuckDBPyRelation::Print() {
 	if (rendered_result.empty()) {
+		idx_t limit_rows = 10000;
 		BoxRenderer renderer;
-		auto res = ExecuteInternal();
+		auto limit = Limit(limit_rows, 0);
+		auto res = limit->ExecuteInternal();
 
 		auto context = rel->context.GetContext();
 		BoxRendererConfig config;
+		config.limit = limit_rows;
 		rendered_result = res->ToBox(*context, config);
 	}
 	return rendered_result;

--- a/tools/pythonpkg/tests/fast/test_relation.py
+++ b/tools/pythonpkg/tests/fast/test_relation.py
@@ -230,3 +230,11 @@ class TestRelation(object):
             # invalid conversion of negative integer to UINTEGER
             rel.project("CAST(a as UINTEGER)").fetchnumpy()
 
+
+    def test_relation_print(self, duckdb_cursor):
+        con = duckdb.connect()
+        con.execute("Create table t1 as select * from range(1000000)")
+        rel1 = con.table('t1')
+        text1 = str(rel1)
+        assert '? rows' in text1
+        assert '>9999 rows' in text1


### PR DESCRIPTION
This is a more user-friendly - since we avoid loading loads of data for display purposes by default. When the limit is reached we show only the first 10K rows and display that there are an unknown number (but more than 9999 rows) in the data set. 

```
>>> import duckdb
>>> duckdb.read_csv('lineitem.csv')
┌──────────┬──────────┬──────────┬──────────┬──────────┬──────────┬──────────┬──────────┬──────────┬──────────┬────────────┬────────────┬────────────┬───────────────────┬──────────┬────────────────────────────────────────────┐
│ column00 │ column01 │ column02 │ column03 │ column04 │ column05 │ column06 │ column07 │ column08 │ column09 │  column10  │  column11  │  column12  │     column13      │ column14 │                  column15                  │
│  int64   │  int64   │  int64   │  int64   │  int64   │  double  │  double  │  double  │ varchar  │ varchar  │    date    │    date    │    date    │      varchar      │ varchar  │                  varchar                   │
├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼────────────┼────────────┼────────────┼───────────────────┼──────────┼────────────────────────────────────────────┤
│        1 │   155190 │     7706 │        1 │       17 │ 21168.23 │     0.04 │     0.02 │ N        │ O        │ 1996-03-13 │ 1996-02-12 │ 1996-03-22 │ DELIVER IN PERSON │ TRUCK    │ egular courts above the                    │
│        1 │    67310 │     7311 │        2 │       36 │ 45983.16 │     0.09 │     0.06 │ N        │ O        │ 1996-04-12 │ 1996-02-28 │ 1996-04-20 │ TAKE BACK RETURN  │ MAIL     │ ly final dependencies: slyly bold          │
│        1 │    63700 │     3701 │        3 │        8 │  13309.6 │      0.1 │     0.02 │ N        │ O        │ 1996-01-29 │ 1996-03-05 │ 1996-01-31 │ TAKE BACK RETURN  │ REG AIR  │ riously. regular, express dep              │
│        1 │     2132 │     4633 │        4 │       28 │ 28955.64 │     0.09 │     0.06 │ N        │ O        │ 1996-04-21 │ 1996-03-30 │ 1996-05-16 │ NONE              │ AIR      │ lites. fluffily even de                    │
│        1 │    24027 │     1534 │        5 │       24 │ 22824.48 │      0.1 │     0.04 │ N        │ O        │ 1996-03-30 │ 1996-03-14 │ 1996-04-01 │ NONE              │ FOB      │  pending foxes. slyly re                   │
│        1 │    15635 │      638 │        6 │       32 │ 49620.16 │     0.07 │     0.02 │ N        │ O        │ 1996-01-30 │ 1996-02-07 │ 1996-02-03 │ DELIVER IN PERSON │ MAIL     │ arefully slyly ex                          │
│        2 │   106170 │     1191 │        1 │       38 │ 44694.46 │      0.0 │     0.05 │ N        │ O        │ 1997-01-28 │ 1997-01-14 │ 1997-02-02 │ TAKE BACK RETURN  │ RAIL     │ ven requests. deposits breach a            │
│        3 │     4297 │     1798 │        1 │       45 │ 54058.05 │     0.06 │      0.0 │ R        │ F        │ 1994-02-02 │ 1994-01-04 │ 1994-02-23 │ NONE              │ AIR      │ ongside of the furiously brave acco        │
│        3 │    19036 │     6540 │        2 │       49 │ 46796.47 │      0.1 │      0.0 │ R        │ F        │ 1993-11-09 │ 1993-12-20 │ 1993-11-24 │ TAKE BACK RETURN  │ RAIL     │  unusual accounts. eve                     │
│        3 │   128449 │     3474 │        3 │       27 │ 39890.88 │     0.06 │     0.07 │ A        │ F        │ 1994-01-16 │ 1993-11-22 │ 1994-01-23 │ DELIVER IN PERSON │ SHIP     │ nal foxes wake.                            │
│        · │      ·   │       ·  │        · │        · │     ·    │       ·  │       ·  │ ·        │ ·        │     ·      │     ·      │     ·      │         ·         │  ·       │        ·                                   │
│        · │      ·   │       ·  │        · │        · │     ·    │       ·  │       ·  │ ·        │ ·        │     ·      │     ·      │     ·      │         ·         │  ·       │        ·                                   │
│        · │      ·   │       ·  │        · │        · │     ·    │       ·  │       ·  │ ·        │ ·        │     ·      │     ·      │     ·      │         ·         │  ·       │        ·                                   │
│    10049 │   164042 │     6559 │        4 │       30 │  33181.2 │     0.09 │     0.04 │ N        │ O        │ 1997-08-26 │ 1997-09-18 │ 1997-09-07 │ DELIVER IN PERSON │ MAIL     │ ses sleep along the furiously unusual shea │
│    10050 │   199821 │     7379 │        1 │       33 │ 63387.06 │     0.08 │     0.05 │ N        │ O        │ 1996-11-12 │ 1996-11-09 │ 1996-11-25 │ NONE              │ TRUCK    │ ests haggl                                 │
│    10050 │   175779 │      814 │        2 │       35 │ 64916.95 │     0.06 │      0.0 │ N        │ O        │ 1997-01-02 │ 1996-11-14 │ 1997-01-19 │ COLLECT COD       │ FOB      │  bold, regular foxe                        │
│    10050 │   104518 │     7029 │        3 │        5 │  7612.55 │     0.08 │     0.08 │ N        │ O        │ 1996-09-15 │ 1996-10-24 │ 1996-09-28 │ COLLECT COD       │ RAIL     │ he ideas detect slyly dur                  │
│    10050 │    22788 │      295 │        4 │       29 │ 49612.62 │     0.06 │     0.04 │ N        │ O        │ 1996-11-15 │ 1996-11-14 │ 1996-11-27 │ COLLECT COD       │ MAIL     │ st furiously final requ                    │
│    10051 │    82853 │      378 │        1 │       31 │ 56911.35 │     0.08 │     0.04 │ N        │ O        │ 1996-06-20 │ 1996-07-17 │ 1996-07-18 │ DELIVER IN PERSON │ SHIP     │ nal packages sleep along the r             │
│    10051 │    97751 │     2770 │        2 │       28 │  48965.0 │     0.06 │     0.08 │ N        │ O        │ 1996-06-04 │ 1996-06-24 │ 1996-06-08 │ TAKE BACK RETURN  │ TRUCK    │  final ideas sle                           │
│    10051 │    86917 │     6918 │        3 │       14 │ 26654.74 │     0.08 │      0.0 │ N        │ O        │ 1996-08-23 │ 1996-08-18 │ 1996-09-10 │ TAKE BACK RETURN  │ REG AIR  │ ully even requests are fi                  │
│    10051 │     5431 │     5432 │        4 │       46 │ 61475.78 │     0.08 │     0.02 │ N        │ O        │ 1996-07-11 │ 1996-08-21 │ 1996-07-29 │ COLLECT COD       │ TRUCK    │ eaves are after the blithely ev            │
│    10052 │    38654 │     8655 │        1 │       30 │  47779.5 │     0.07 │     0.06 │ A        │ F        │ 1994-12-18 │ 1994-12-02 │ 1994-12-29 │ NONE              │ SHIP     │ ove the blithely final a                   │
├──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴────────────┴────────────┴────────────┴───────────────────┴──────────┴────────────────────────────────────────────┤
│ ? rows (>9999 rows, 20 shown)                                                                                                                                                                                       16 columns │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘


```