### PR TITLE
[Python] Check overflow in DATE -> datetime conversion

### DIFF
--- a/src/common/types/date.cpp
+++ b/src/common/types/date.cpp
@@ -428,7 +428,7 @@ int64_t Date::EpochNanoseconds(date_t date) {
 	int64_t result;
 	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(date.days, Interval::MICROS_PER_DAY * 1000,
 	                                                               result)) {
-		throw ConversionException("Could not convert DATE to nanoseconds");
+		throw ConversionException("Could not convert DATE (%s) to nanoseconds", Date::ToString(date));
 	}
 	return result;
 }
@@ -436,7 +436,7 @@ int64_t Date::EpochNanoseconds(date_t date) {
 int64_t Date::EpochMicroseconds(date_t date) {
 	int64_t result;
 	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(date.days, Interval::MICROS_PER_DAY, result)) {
-		throw ConversionException("Could not convert DATE to microseconds");
+		throw ConversionException("Could not convert DATE (%s) to microseconds", Date::ToString(date));
 	}
 	return result;
 }

--- a/src/common/types/date.cpp
+++ b/src/common/types/date.cpp
@@ -425,7 +425,12 @@ int64_t Date::Epoch(date_t date) {
 }
 
 int64_t Date::EpochNanoseconds(date_t date) {
-	return ((int64_t)date.days) * (Interval::MICROS_PER_DAY * 1000);
+	int64_t result;
+	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(date.days, Interval::MICROS_PER_DAY * 1000,
+	                                                               result)) {
+		throw ConversionException("Could not convert DATE to nanoseconds");
+	}
+	return result;
 }
 
 int64_t Date::EpochMicroseconds(date_t date) {

--- a/src/include/duckdb/common/limits.hpp
+++ b/src/include/duckdb/common/limits.hpp
@@ -74,6 +74,7 @@ struct NumericLimits<int32_t> {
 		return 10;
 	}
 };
+
 template <>
 struct NumericLimits<int64_t> {
 	DUCKDB_API static constexpr int64_t Minimum() {
@@ -104,6 +105,7 @@ struct NumericLimits<hugeint_t> {
 		return 39;
 	}
 };
+
 template <>
 struct NumericLimits<uint8_t> {
 	DUCKDB_API static constexpr uint8_t Minimum() {
@@ -119,6 +121,7 @@ struct NumericLimits<uint8_t> {
 		return 3;
 	}
 };
+
 template <>
 struct NumericLimits<uint16_t> {
 	DUCKDB_API static constexpr uint16_t Minimum() {

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -509,8 +509,8 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::ReadCSV(
 			for (auto &kv : dtype_dict) {
 				struct_fields.push_back(make_pair(py::str(kv.first), Value(py::str(kv.second))));
 			}
-			auto dtype_struct = Value::STRUCT(move(struct_fields));
-			read_csv.AddNamedParameter("dtypes", move(dtype_struct));
+			auto dtype_struct = Value::STRUCT(std::move(struct_fields));
+			read_csv.AddNamedParameter("dtypes", std::move(dtype_struct));
 		} else if (py::isinstance<py::list>(dtype)) {
 			auto dtype_list = TransformPythonValue(py::list(dtype));
 			D_ASSERT(dtype_list.type().id() == LogicalTypeId::LIST);
@@ -520,7 +520,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::ReadCSV(
 					throw InvalidInputException("The types provided to 'dtype' have to be strings");
 				}
 			}
-			read_csv.AddNamedParameter("dtypes", move(dtype_list));
+			read_csv.AddNamedParameter("dtypes", std::move(dtype_list));
 		} else {
 			throw InvalidInputException("read_csv only accepts 'dtype' as a dictionary or a list of strings");
 		}

--- a/tools/pythonpkg/tests/fast/pandas/test_date_as_datetime.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_date_as_datetime.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import duckdb
 import datetime
+import pytest
 
 def run_checks(df):
     assert type(df['d'][0]) is datetime.date

--- a/tools/pythonpkg/tests/fast/pandas/test_datetime_time.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_datetime_time.py
@@ -60,3 +60,12 @@ class TestDateTimeTime(object):
         )
         df_out = duckdb.query_df(df_in, "df", "select * from df").df()
         pd.testing.assert_frame_equal(df_out, duckdb_time)
+
+    def test_pandas_datetime_overflow(self):
+        duckdb_con = duckdb.connect()
+
+        duckdb_con.execute("create table test (date DATE)")
+        duckdb_con.execute("INSERT INTO TEST VALUES ('2263-02-28')")
+
+        with pytest.raises(duckdb.ConversionException):
+            res = duckdb_con.execute("select * from test").df()

--- a/tools/pythonpkg/tests/fast/test_all_types.py
+++ b/tools/pythonpkg/tests/fast/test_all_types.py
@@ -188,14 +188,6 @@ class TestAllTypes(object):
                 ],
                 mask=[0, 0, 1],
             ),
-            'date': np.ma.array(
-                [
-                    np.datetime64(-5235121029329846272, "ns"),
-                    np.datetime64(5235121029329846272, "ns"),
-                    np.datetime64("1990-01-01T00:42"),
-                ],
-                mask=[0, 0, 1],
-            ),
             # For timestamp_ns, the lowest value is out-of-range for numpy,
             # such that the conversion yields "Not a Time"
             'timestamp_ns': np.ma.array(
@@ -314,6 +306,8 @@ class TestAllTypes(object):
         # - 'dec38_10'
 
         # The following types lead to errors:
+        # Conversion Error: Could not convert DATE to nanoseconds
+        # - 'date'
         # Conversion Error: Date out of range in timestamp conversion
         # - 'timestamp_array'
         # - 'timestamptz_array'
@@ -329,11 +323,9 @@ class TestAllTypes(object):
         for cur_type in all_types:
             if cur_type not in correct_answer_map:
                 continue
-
             result = rel.project(cur_type).fetchnumpy()
             result = result[cur_type]
             correct_answer = correct_answer_map[cur_type]
-
             if isinstance(result, pd.Categorical) or result.dtype == object:
                 assert recursive_equality(list(result), list(correct_answer))
             else:

--- a/tools/pythonpkg/tests/fast/types/test_numpy.py
+++ b/tools/pythonpkg/tests/fast/types/test_numpy.py
@@ -1,6 +1,7 @@
 import duckdb
 import numpy as np
 import datetime
+import pytest
 
 class TestNumpyDatetime64(object):
     def test_numpy_datetime64(self, duckdb_cursor):
@@ -10,4 +11,11 @@ class TestNumpyDatetime64(object):
         duckdb_con.execute("insert into tbl VALUES (CAST(? AS TIMESTAMP WITHOUT TIME ZONE))", parameters=[np.datetime64('2022-02-08T06:01:38.761310')])
         assert [(datetime.datetime(2022, 2, 8, 6, 1, 38, 761310),)] == duckdb_con.execute("select * from tbl").fetchall()
 
+    def test_numpy_datetime_overflow(self):
+        duckdb_con = duckdb.connect()
 
+        duckdb_con.execute("create table test (date DATE)")
+        duckdb_con.execute("INSERT INTO TEST VALUES ('2263-02-28')")
+
+        with pytest.raises(duckdb.ConversionException):
+            res1 = duckdb_con.execute("select * from test").fetchnumpy()


### PR DESCRIPTION
This PR fixes #4026 

The conversion from DATE -> nanoseconds was not checked for overflow.