### PR TITLE
Fuzzer issue 9 and 40 from #5984

### DIFF
--- a/src/execution/operator/persistent/physical_update.cpp
+++ b/src/execution/operator/persistent/physical_update.cpp
@@ -71,6 +71,8 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, GlobalSinkState &
 	// the row ids are given to us as the last column of the child chunk
 	auto &row_ids = chunk.data[chunk.ColumnCount() - 1];
 	update_chunk.SetCardinality(chunk);
+	update_chunk.Reset();
+
 	for (idx_t i = 0; i < expressions.size(); i++) {
 		if (expressions[i]->type == ExpressionType::VALUE_DEFAULT) {
 			// default expression, set to the default value of the column

--- a/src/execution/operator/persistent/physical_update.cpp
+++ b/src/execution/operator/persistent/physical_update.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/main/client_context.hpp"
+#include <iostream>
 
 namespace duckdb {
 
@@ -70,8 +71,8 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, GlobalSinkState &
 	// update data in the base table
 	// the row ids are given to us as the last column of the child chunk
 	auto &row_ids = chunk.data[chunk.ColumnCount() - 1];
-	update_chunk.SetCardinality(chunk);
 	update_chunk.Reset();
+	update_chunk.SetCardinality(chunk);
 
 	for (idx_t i = 0; i < expressions.size(); i++) {
 		if (expressions[i]->type == ExpressionType::VALUE_DEFAULT) {

--- a/src/execution/operator/persistent/physical_update.cpp
+++ b/src/execution/operator/persistent/physical_update.cpp
@@ -7,7 +7,6 @@
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/main/client_context.hpp"
-#include <iostream>
 
 namespace duckdb {
 

--- a/src/include/duckdb/common/types/validity_mask.hpp
+++ b/src/include/duckdb/common/types/validity_mask.hpp
@@ -83,15 +83,7 @@ public:
 		return !validity_mask;
 	}
 	inline bool CheckAllValid(idx_t count) const {
-		if (AllValid()) {
-			return true;
-		}
-		idx_t entry_count = ValidityBuffer::EntryCount(count);
-		idx_t valid_count = 0;
-		for (idx_t i = 0; i < entry_count; i++) {
-			valid_count += validity_mask[i] == ValidityBuffer::MAX_ENTRY;
-		}
-		return valid_count == entry_count;
+		return CountValid(count) == count;
 	}
 
 	inline bool CheckAllValid(idx_t to, idx_t from) const {

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -528,6 +528,8 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 	case LogicalOperatorType::LOGICAL_DELIM_JOIN: {
 		throw BinderException("Nested lateral joins or lateral joins in correlated subqueries are not (yet) supported");
 	}
+	case LogicalOperatorType::LOGICAL_SAMPLE:
+		throw BinderException("Sampling in correlated subqueries is not (yet) supported");
 	default:
 		throw InternalException("Logical operator type \"%s\" for dependent join", LogicalOperatorToString(plan->type));
 	}

--- a/test/sql/update/update_default.test
+++ b/test/sql/update/update_default.test
@@ -1,0 +1,12 @@
+# name: test/sql/update/update_default.test
+# description: Test for 40th item of fuzzer issues from https://github.com/duckdb/duckdb/issues/5984
+# group: [test]
+
+statement ok
+CREATE TABLE t1 (c0 INT);
+
+statement ok
+INSERT INTO t1(c0) VALUES (1),(2),(3);
+
+statement ok
+UPDATE t1 SET c0 = DEFAULT;

--- a/test/sql/update/update_default.test
+++ b/test/sql/update/update_default.test
@@ -1,6 +1,6 @@
 # name: test/sql/update/update_default.test
 # description: Test for 40th item of fuzzer issues from https://github.com/duckdb/duckdb/issues/5984
-# group: [test]
+# group: [update]
 
 statement ok
 CREATE TABLE t1 (c0 INT);


### PR DESCRIPTION
Fixes for nr 9 and 40 from https://github.com/duckdb/duckdb/issues/5984

9: throw BinderException to indicate SAMPLE in correlated subquery is not yet implemented
40: update chunk was not properly reset, also fixed/simplified the CheckAllValid() function which was incorrect