### PR TITLE
issue 5984  #42 disable nan as random seed

### DIFF
--- a/src/function/scalar/math/setseed.cpp
+++ b/src/function/scalar/math/setseed.cpp
@@ -36,7 +36,7 @@ static void SetSeedFunction(DataChunk &args, ExpressionState &state, Vector &res
 
 	auto &random_engine = RandomEngine::Get(info.context);
 	for (idx_t i = 0; i < args.size(); i++) {
-		if (input_seeds[i] < -1.0 || input_seeds[i] > 1.0) {
+		if (input_seeds[i] < -1.0 || input_seeds[i] > 1.0 || Value::IsNan(input_seeds[i])) {
 			throw Exception("SETSEED accepts seed values between -1.0 and 1.0, inclusive");
 		}
 		uint32_t norm_seed = (input_seeds[i] + 1.0) * half_max;

--- a/test/fuzzer/pedro/nan_as_seed.test
+++ b/test/fuzzer/pedro/nan_as_seed.test
@@ -3,4 +3,30 @@
 # group: [pedro]
 
 statement ok
-SELECT setseed(CAST('nan' AS REAL));
+pragma enable_verification
+
+statement ok
+create table test as select range i from range(10000)
+
+foreach type FLOAT DOUBLE REAL
+
+foreach val nan
+
+statement error
+SELECT setseed('${val}'::${type});
+----
+SETSEED accepts seed values
+
+statement ok
+SELECT setseed(0.5);
+
+statement ok
+SELECT 1, random();
+
+statement ok
+select * from test using sample 100;
+
+endloop
+
+endloop
+

--- a/test/fuzzer/pedro/nan_as_seed.test
+++ b/test/fuzzer/pedro/nan_as_seed.test
@@ -1,4 +1,4 @@
-# name: test/fuzzer/pedro/nan-as-seed.test
+# name: test/fuzzer/pedro/nan_as_seed.test
 # description: Issue #4984 (42): Nan as seed
 # group: [pedro]
 

--- a/test/fuzzer/pedro/nan_as_seed.test
+++ b/test/fuzzer/pedro/nan_as_seed.test
@@ -1,0 +1,6 @@
+# name: test/fuzzer/pedro/nan-as-seed.test
+# description: Issue #4984 (42): Nan as seed
+# group: [pedro]
+
+statement ok
+SELECT setseed(CAST('nan' AS REAL));


### PR DESCRIPTION
Throw an error if `NaN` is used as a seed.

Comes from https://github.com/duckdb/duckdb/issues/5984 number 42