### PR TITLE
Fuzzer issue #5984 no.43. Substring generating an invalid string

### DIFF
--- a/src/function/scalar/string/substring.cpp
+++ b/src/function/scalar/string/substring.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/storage/statistics/string_statistics.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "utf8proc.hpp"
+#include "duckdb/common/types/blob.hpp"
 
 namespace duckdb {
 
@@ -138,6 +139,13 @@ string_t SubstringFun::SubstringUnicode(Vector &result, string_t input, int64_t 
 				}
 			}
 		}
+		while (!LengthFun::IsCharacter(input_data[start_pos])) {
+			start_pos++;
+		}
+		while (end_pos < input_size && !LengthFun::IsCharacter(input_data[end_pos])) {
+			end_pos++;
+		}
+
 		if (end_pos == DConstants::INVALID_INDEX) {
 			return SubstringEmptyString(result);
 		}

--- a/test/sql/types/string/test_unicode.test
+++ b/test/sql/types/string/test_unicode.test
@@ -16,12 +16,32 @@ SELECT * FROM emojis ORDER BY id
 1	🦆
 2	🦆🍞🦆
 
-# substring on emojis
+# substring on unicode
 query TT
 SELECT substring(s, 1, 1), substring(s, 2, 1) FROM emojis ORDER BY id
 ----
 🦆	(empty)
 🦆	🍞
+
+query I
+SELECT substring(decode('u\xD5\x8D1'::BLOB)::VARCHAR, -1);
+----
+1
+
+query I
+SELECT substring('u🦆', -2, 1);
+----
+u
+
+query I
+SELECT substring('A3🦤u🦆f', -3, 3);
+----
+u🦆f
+
+query I
+SELECT substring('🦤🦆f', -3, 2);
+----
+🦤🦆
 
 # length on emojis
 query I


### PR DESCRIPTION
Addresses fuzzer issue #5984  no.43 

Problem query:
```
SELECT substring(decode('u\xD5\x8D1'::BLOB)::VARCHAR, -1);
——
Assertion `utf_type != UnicodeType::INVALID
```

The issue seemed to be when calling substring with a string containing unicode character(s) and a negative offset. 
A negative offset will start indexing from the end of the string and could cut of a unicode character midway when iterating through the string. 