### PR TITLE
Make ATTACH work over HTTP(S), and fix ATTACH for databases with custom types

### DIFF
--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -28,36 +28,23 @@ static unique_ptr<duckdb_httplib_openssl::Headers> initialize_http_headers(Heade
 }
 
 HTTPParams HTTPParams::ReadFrom(FileOpener *opener) {
-	uint64_t timeout;
-	uint64_t retries;
-	uint64_t retry_wait_ms;
-	float retry_backoff;
+	uint64_t timeout = DEFAULT_TIMEOUT;
+	uint64_t retries = DEFAULT_RETRIES;
+	uint64_t retry_wait_ms = DEFAULT_RETRY_WAIT_MS;
+	float retry_backoff = DEFAULT_RETRY_BACKOFF;
 	Value value;
-
-	if (opener->TryGetCurrentSetting("http_timeout", value)) {
+	if (FileOpener::TryGetCurrentSetting(opener, "http_timeout", value)) {
 		timeout = value.GetValue<uint64_t>();
-	} else {
-		timeout = DEFAULT_TIMEOUT;
 	}
-
-	if (opener->TryGetCurrentSetting("http_retries", value)) {
+	if (FileOpener::TryGetCurrentSetting(opener, "http_retries", value)) {
 		retries = value.GetValue<uint64_t>();
-	} else {
-		retries = DEFAULT_RETRIES;
 	}
-
-	if (opener->TryGetCurrentSetting("http_retry_wait_ms", value)) {
+	if (FileOpener::TryGetCurrentSetting(opener, "http_retry_wait_ms", value)) {
 		retry_wait_ms = value.GetValue<uint64_t>();
-	} else {
-		retry_wait_ms = DEFAULT_RETRY_WAIT_MS;
 	}
-
-	if (opener->TryGetCurrentSetting("http_retry_backoff", value)) {
+	if (FileOpener::TryGetCurrentSetting(opener, "http_retry_backoff", value)) {
 		retry_backoff = value.GetValue<float>();
-	} else {
-		retry_backoff = DEFAULT_RETRY_BACKOFF;
 	}
-
 	return {timeout, retries, retry_wait_ms, retry_backoff};
 }
 
@@ -299,15 +286,12 @@ unique_ptr<HTTPFileHandle> HTTPFileSystem::CreateHandle(const string &path, cons
                                                         FileOpener *opener) {
 	D_ASSERT(compression == FileCompressionType::UNCOMPRESSED);
 	return duckdb::make_unique<HTTPFileHandle>(*this, query_param.empty() ? path : path + "?" + query_param, flags,
-	                                           opener ? HTTPParams::ReadFrom(opener) : HTTPParams());
+	                                           HTTPParams::ReadFrom(opener));
 }
 
 unique_ptr<FileHandle> HTTPFileSystem::OpenFile(const string &path, uint8_t flags, FileLockType lock,
                                                 FileCompressionType compression, FileOpener *opener) {
 	D_ASSERT(compression == FileCompressionType::UNCOMPRESSED);
-	if (!opener) {
-		throw IOException("Cannot open a HTTPFS file without a file opener");
-	}
 
 	// splitting query params from base path
 	string stripped_path, query_param;
@@ -427,7 +411,7 @@ time_t HTTPFileSystem::GetLastModifiedTime(FileHandle &handle) {
 bool HTTPFileSystem::FileExists(const string &filename) {
 	try {
 		auto handle = OpenFile(filename.c_str(), FileFlags::FILE_FLAGS_READ);
-		auto &sfh = (HTTPFileHandle &)handle;
+		auto &sfh = (HTTPFileHandle &)*handle;
 		if (sfh.length == 0) {
 			return false;
 		}
@@ -448,28 +432,28 @@ void HTTPFileSystem::Seek(FileHandle &handle, idx_t location) {
 
 // Get either the local, global, or no cache depending on settings
 static HTTPMetadataCache *TryGetMetadataCache(FileOpener *opener, HTTPFileSystem &httpfs) {
-	auto client_context = opener->TryGetClientContext();
+	auto client_context = FileOpener::TryGetClientContext(opener);
+	if (!client_context) {
+		return nullptr;
+	}
 
-	if (client_context) {
-		bool use_shared_cache = client_context->db->config.options.http_metadata_cache_enable;
+	bool use_shared_cache = client_context->db->config.options.http_metadata_cache_enable;
 
-		if (use_shared_cache) {
-			if (!httpfs.global_metadata_cache) {
-				httpfs.global_metadata_cache = make_unique<HTTPMetadataCache>(false, true);
-			}
-			return httpfs.global_metadata_cache.get();
+	if (use_shared_cache) {
+		if (!httpfs.global_metadata_cache) {
+			httpfs.global_metadata_cache = make_unique<HTTPMetadataCache>(false, true);
+		}
+		return httpfs.global_metadata_cache.get();
+	} else {
+		auto lookup = client_context->registered_state.find("http_cache");
+		if (lookup == client_context->registered_state.end()) {
+			auto cache = make_shared<HTTPMetadataCache>(true, false);
+			client_context->registered_state["http_cache"] = cache;
+			return cache.get();
 		} else {
-			auto lookup = client_context->registered_state.find("http_cache");
-			if (lookup == client_context->registered_state.end()) {
-				auto cache = make_shared<HTTPMetadataCache>(true, false);
-				client_context->registered_state["http_cache"] = cache;
-				return cache.get();
-			} else {
-				return (HTTPMetadataCache *)lookup->second.get();
-			}
+			return (HTTPMetadataCache *)lookup->second.get();
 		}
 	}
-	return nullptr;
 }
 
 void HTTPFileHandle::Initialize(FileOpener *opener) {

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -172,29 +172,29 @@ S3AuthParams S3AuthParams::ReadFrom(FileOpener *opener) {
 	bool use_ssl;
 	Value value;
 
-	if (opener->TryGetCurrentSetting("s3_region", value)) {
+	if (FileOpener::TryGetCurrentSetting(opener, "s3_region", value)) {
 		region = value.ToString();
 	}
 
-	if (opener->TryGetCurrentSetting("s3_access_key_id", value)) {
+	if (FileOpener::TryGetCurrentSetting(opener, "s3_access_key_id", value)) {
 		access_key_id = value.ToString();
 	}
 
-	if (opener->TryGetCurrentSetting("s3_secret_access_key", value)) {
+	if (FileOpener::TryGetCurrentSetting(opener, "s3_secret_access_key", value)) {
 		secret_access_key = value.ToString();
 	}
 
-	if (opener->TryGetCurrentSetting("s3_session_token", value)) {
+	if (FileOpener::TryGetCurrentSetting(opener, "s3_session_token", value)) {
 		session_token = value.ToString();
 	}
 
-	if (opener->TryGetCurrentSetting("s3_endpoint", value)) {
+	if (FileOpener::TryGetCurrentSetting(opener, "s3_endpoint", value)) {
 		endpoint = value.ToString();
 	} else {
 		endpoint = "s3.amazonaws.com";
 	}
 
-	if (opener->TryGetCurrentSetting("s3_url_style", value)) {
+	if (FileOpener::TryGetCurrentSetting(opener, "s3_url_style", value)) {
 		auto val_str = value.ToString();
 		if (!(val_str == "vhost" || val_str != "path" || val_str != "")) {
 			throw std::runtime_error(
@@ -205,7 +205,7 @@ S3AuthParams S3AuthParams::ReadFrom(FileOpener *opener) {
 		url_style = "vhost";
 	}
 
-	if (opener->TryGetCurrentSetting("s3_use_ssl", value)) {
+	if (FileOpener::TryGetCurrentSetting(opener, "s3_use_ssl", value)) {
 		use_ssl = value.GetValue<bool>();
 	} else {
 		use_ssl = true;
@@ -670,15 +670,11 @@ unique_ptr<ResponseWrapper> S3FileSystem::GetRangeRequest(FileHandle &handle, st
 unique_ptr<HTTPFileHandle> S3FileSystem::CreateHandle(const string &path, const string &query_param, uint8_t flags,
                                                       FileLockType lock, FileCompressionType compression,
                                                       FileOpener *opener) {
-	if (!opener) {
-		throw IOException("CreateHandle called on S3FileSystem without FileOpener");
-	}
 	auto s3authparams = S3AuthParams::ReadFrom(opener);
 	ReadQueryParams(query_param, s3authparams);
 	string full_path = query_param.empty() ? path : path + "?" + query_param;
 
-	return duckdb::make_unique<S3FileHandle>(*this, full_path, path, flags,
-	                                         opener ? HTTPParams::ReadFrom(opener) : HTTPParams(), s3authparams,
+	return duckdb::make_unique<S3FileHandle>(*this, full_path, path, flags, HTTPParams::ReadFrom(opener), s3authparams,
 	                                         S3ConfigParams::ReadFrom(opener));
 }
 

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -220,19 +220,19 @@ S3ConfigParams S3ConfigParams::ReadFrom(FileOpener *opener) {
 	uint64_t max_upload_threads;
 	Value value;
 
-	if (opener->TryGetCurrentSetting("s3_uploader_max_filesize", value)) {
+	if (FileOpener::TryGetCurrentSetting(opener, "s3_uploader_max_filesize", value)) {
 		uploader_max_filesize = DBConfig::ParseMemoryLimit(value.GetValue<string>());
 	} else {
 		uploader_max_filesize = S3ConfigParams::DEFAULT_MAX_FILESIZE;
 	}
 
-	if (opener->TryGetCurrentSetting("s3_uploader_max_parts_per_file", value)) {
+	if (FileOpener::TryGetCurrentSetting(opener, "s3_uploader_max_parts_per_file", value)) {
 		max_parts_per_file = value.GetValue<uint64_t>();
 	} else {
 		max_parts_per_file = S3ConfigParams::DEFAULT_MAX_PARTS_PER_FILE; // AWS Default
 	}
 
-	if (opener->TryGetCurrentSetting("s3_uploader_thread_limit", value)) {
+	if (FileOpener::TryGetCurrentSetting(opener, "s3_uploader_thread_limit", value)) {
 		max_upload_threads = value.GetValue<uint64_t>();
 	} else {
 		max_upload_threads = S3ConfigParams::DEFAULT_MAX_UPLOAD_THREADS;

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -552,20 +552,16 @@ SchemaCatalogEntry *Catalog::GetSchema(ClientContext &context, const string &cat
 	return result;
 }
 
+LogicalType Catalog::GetType(ClientContext &context, const string &schema, const string &name) {
+	auto type_entry = GetEntry<TypeCatalogEntry>(context, schema, name);
+	auto result_type = type_entry->user_type;
+	LogicalType::SetCatalog(result_type, type_entry);
+	return result_type;
+}
+
 LogicalType Catalog::GetType(ClientContext &context, const string &catalog_name, const string &schema,
                              const string &name) {
-	CatalogEntry *entry;
-	entry = GetEntry(context, CatalogType::TYPE_ENTRY, catalog_name, schema, name, true);
-	if (!entry) {
-		// look in the system catalog
-		entry = GetEntry(context, CatalogType::TYPE_ENTRY, SYSTEM_CATALOG, schema, name, true);
-		if (!entry) {
-			// repeat the search to get the error
-			GetEntry(context, CatalogType::TYPE_ENTRY, catalog_name, schema, name);
-			throw InternalException("Catalog::GetType - second type lookup somehow succeeded!?");
-		}
-	}
-	auto type_entry = (TypeCatalogEntry *)entry;
+	auto type_entry = Catalog::GetEntry<TypeCatalogEntry>(context, catalog_name, schema, name);
 	auto result_type = type_entry->user_type;
 	LogicalType::SetCatalog(result_type, type_entry);
 	return result_type;

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -552,8 +552,11 @@ SchemaCatalogEntry *Catalog::GetSchema(ClientContext &context, const string &cat
 	return result;
 }
 
-LogicalType Catalog::GetType(ClientContext &context, const string &schema, const string &name) {
-	auto type_entry = GetEntry<TypeCatalogEntry>(context, schema, name);
+LogicalType Catalog::GetType(ClientContext &context, const string &schema, const string &name, bool if_exists) {
+	auto type_entry = GetEntry<TypeCatalogEntry>(context, schema, name, if_exists);
+	if (!type_entry) {
+		return LogicalType::INVALID;
+	}
 	auto result_type = type_entry->user_type;
 	LogicalType::SetCatalog(result_type, type_entry);
 	return result_type;

--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -286,7 +286,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::AddColumn(ClientContext &context, AddCo
 	for (auto &constraint : constraints) {
 		create_info->constraints.push_back(constraint->Copy());
 	}
-	Binder::BindLogicalType(context, info.new_column.TypeMutable(), catalog->GetName(), schema->name);
+	Binder::BindLogicalType(context, info.new_column.TypeMutable(), catalog, schema->name);
 	info.new_column.SetOid(columns.LogicalColumnCount());
 	info.new_column.SetStorageOid(columns.PhysicalColumnCount());
 	auto col = info.new_column.Copy();

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -196,7 +196,7 @@ public:
 	DUCKDB_API CatalogEntry *GetEntry(ClientContext &context, const string &schema, const string &name);
 
 	//! Fetches a logical type from the catalog
-	DUCKDB_API LogicalType GetType(ClientContext &context, const string &schema, const string &names);
+	DUCKDB_API LogicalType GetType(ClientContext &context, const string &schema, const string &names, bool if_exists);
 
 	DUCKDB_API static LogicalType GetType(ClientContext &context, const string &catalog_name, const string &schema,
 	                                      const string &name);

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -196,6 +196,8 @@ public:
 	DUCKDB_API CatalogEntry *GetEntry(ClientContext &context, const string &schema, const string &name);
 
 	//! Fetches a logical type from the catalog
+	DUCKDB_API LogicalType GetType(ClientContext &context, const string &schema, const string &names);
+
 	DUCKDB_API static LogicalType GetType(ClientContext &context, const string &catalog_name, const string &schema,
 	                                      const string &name);
 

--- a/src/include/duckdb/common/file_opener.hpp
+++ b/src/include/duckdb/common/file_opener.hpp
@@ -25,6 +25,8 @@ public:
 	virtual ClientContext *TryGetClientContext() = 0;
 
 	DUCKDB_API static FileOpener *Get(ClientContext &context);
+	DUCKDB_API static ClientContext *TryGetClientContext(FileOpener *opener);
+	DUCKDB_API static bool TryGetCurrentSetting(FileOpener *opener, const string &key, Value &result);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/http_stats.hpp
+++ b/src/include/duckdb/common/http_stats.hpp
@@ -35,7 +35,7 @@ public:
 
 	//! helper function to get the HTTP
 	static HTTPStats *TryGetStats(FileOpener *opener) {
-		auto client_context = opener->TryGetClientContext();
+		auto client_context = FileOpener::TryGetClientContext(opener);
 		if (client_context) {
 			return client_context->client_data->http_stats.get();
 		}

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -168,7 +168,7 @@ public:
 	void BindOnConflictClause(LogicalInsert &insert, TableCatalogEntry &table, InsertStatement &stmt);
 
 	static void BindSchemaOrCatalog(ClientContext &context, string &catalog, string &schema);
-	static void BindLogicalType(ClientContext &context, LogicalType &type, const string &catalog = INVALID_CATALOG,
+	static void BindLogicalType(ClientContext &context, LogicalType &type, Catalog *catalog = nullptr,
 	                            const string &schema = INVALID_SCHEMA);
 
 	bool HasMatchingBinding(const string &table_name, const string &column_name, string &error_message);

--- a/src/main/client_context_file_opener.cpp
+++ b/src/main/client_context_file_opener.cpp
@@ -8,4 +8,18 @@ bool ClientContextFileOpener::TryGetCurrentSetting(const string &key, Value &res
 	return context.TryGetCurrentSetting(key, result);
 }
 
+ClientContext *FileOpener::TryGetClientContext(FileOpener *opener) {
+	if (!opener) {
+		return nullptr;
+	}
+	return opener->TryGetClientContext();
+}
+
+bool FileOpener::TryGetCurrentSetting(FileOpener *opener, const string &key, Value &result) {
+	if (!opener) {
+		return false;
+	}
+	return opener->TryGetCurrentSetting(key, result);
+}
+
 } // namespace duckdb

--- a/src/planner/binder/expression/bind_cast_expression.cpp
+++ b/src/planner/binder/expression/bind_cast_expression.cpp
@@ -14,7 +14,7 @@ BindResult ExpressionBinder::BindExpression(CastExpression &expr, idx_t depth) {
 	}
 	// FIXME: We can also implement 'hello'::schema.custom_type; and pass by the schema down here.
 	// Right now just considering its DEFAULT_SCHEMA always
-	Binder::BindLogicalType(context, expr.cast_type, INVALID_CATALOG, INVALID_SCHEMA);
+	Binder::BindLogicalType(context, expr.cast_type);
 	// the children have been successfully resolved
 	auto &child = (BoundExpression &)*expr.child;
 	if (expr.try_cast) {

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -209,7 +209,7 @@ SchemaCatalogEntry *Binder::BindCreateFunctionInfo(CreateInfo &info) {
 	return BindCreateSchema(info);
 }
 
-void Binder::BindLogicalType(ClientContext &context, LogicalType &type, const string &catalog, const string &schema) {
+void Binder::BindLogicalType(ClientContext &context, LogicalType &type, Catalog *catalog, const string &schema) {
 	if (type.id() == LogicalTypeId::LIST || type.id() == LogicalTypeId::MAP) {
 		auto child_type = ListType::GetChildType(type);
 		BindLogicalType(context, child_type, catalog, schema);
@@ -241,10 +241,22 @@ void Binder::BindLogicalType(ClientContext &context, LogicalType &type, const st
 		type = LogicalType::UNION(member_types);
 		type.SetAlias(alias);
 	} else if (type.id() == LogicalTypeId::USER) {
-		type = Catalog::GetType(context, catalog, schema, UserType::GetTypeName(type));
+		auto &user_type_name = UserType::GetTypeName(type);
+		if (catalog) {
+			type = catalog->GetType(context, schema, user_type_name);
+		} else {
+			type = Catalog::GetType(context, INVALID_CATALOG, schema, user_type_name);
+		}
 	} else if (type.id() == LogicalTypeId::ENUM) {
 		auto &enum_type_name = EnumType::GetTypeName(type);
-		auto enum_type_catalog = Catalog::GetEntry<TypeCatalogEntry>(context, catalog, schema, enum_type_name, true);
+		TypeCatalogEntry *enum_type_catalog;
+		if (catalog) {
+			enum_type_catalog = catalog->GetEntry<TypeCatalogEntry>(context, schema, enum_type_name, true);
+		} else {
+			enum_type_catalog =
+			    Catalog::GetEntry<TypeCatalogEntry>(context, INVALID_CATALOG, schema, enum_type_name, true);
+		}
+
 		LogicalType::SetCatalog(type, enum_type_catalog);
 	}
 }

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -282,7 +282,7 @@ unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableInfo(unique_ptr<CreateIn
 		if (column.Type().id() == LogicalTypeId::VARCHAR) {
 			ExpressionBinder::TestCollation(context, StringType::GetCollation(column.Type()));
 		}
-		BindLogicalType(context, column.TypeMutable(), result->schema->catalog->GetName());
+		BindLogicalType(context, column.TypeMutable(), result->schema->catalog);
 		// We add a catalog dependency
 		auto type_dependency = LogicalType::GetCatalog(column.Type());
 		if (type_dependency) {

--- a/test/sql/attach/attach_all_types.test
+++ b/test/sql/attach/attach_all_types.test
@@ -1,0 +1,26 @@
+# name: test/sql/attach/attach_all_types.test
+# description: Test ATTACH of a database with all types
+# group: [attach]
+
+require noforcestorage
+
+statement ok
+ATTACH '__TEST_DIR__/attach_all_types.db' AS db1
+
+statement ok
+CREATE TABLE db1.all_types AS SELECT * FROM test_all_types();
+
+query II nosort all_types
+SELECT * FROM test_all_types()
+
+query II nosort all_types
+SELECT * FROM db1.all_types
+
+statement ok
+DETACH db1
+
+statement ok
+ATTACH '__TEST_DIR__/attach_all_types.db' AS db1
+
+query II nosort all_types
+SELECT * FROM db1.all_types

--- a/test/sql/attach/attach_enums.test
+++ b/test/sql/attach/attach_enums.test
@@ -1,0 +1,39 @@
+# name: test/sql/attach/attach_enums.test
+# description: Test ATTACH of a database with custom enums
+# group: [attach]
+
+require noforcestorage
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH '__TEST_DIR__/attach_enums.db' AS db1
+
+statement ok
+CREATE TYPE db1.mood AS ENUM ('sad', 'ok', 'happy');
+
+statement ok
+CREATE TABLE db1.person (
+    name text,
+    current_mood mood
+);
+
+statement ok
+INSERT INTO db1.person VALUES ('Moe', 'happy');
+
+query TT
+select * from db1.person
+----
+Moe	happy
+
+statement ok
+DETACH db1
+
+statement ok
+ATTACH '__TEST_DIR__/attach_enums.db' AS db1 (READ_ONLY)
+
+query TT
+select * from db1.person
+----
+Moe	happy

--- a/test/sql/attach/attach_httpfs.test
+++ b/test/sql/attach/attach_httpfs.test
@@ -6,6 +6,28 @@ require skip_reload
 
 require httpfs
 
-# ATTACH over HTTPFS is not supported yet
-statement error
+# ATTACH a DuckDB database over HTTPFS
+statement ok
 ATTACH 'https://github.com/duckdb/duckdb/raw/master/test/sql/storage_version/storage_version.db' AS db;
+
+query IIIII
+SELECT * FROM db.integral_values
+----
+1	2	3	4	5
+NULL	NULL	NULL	NULL	NULL
+
+statement error
+CREATE TABLE db.integers(i INTEGER);
+----
+Writing to HTTP files not implemented
+
+statement ok
+SELECT * FROM db.all_types
+
+statement error
+SELECT * FROM db.all_typez
+----
+all_types
+
+statement ok
+DETACH db

--- a/test/sql/copy/s3/README.md
+++ b/test/sql/copy/s3/README.md
@@ -1,0 +1,45 @@
+
+In order to test these locally, `minio` is used. This requires Docker to be installed.
+
+### Installing Docker on MacOS
+
+Install `docker` using `homebrew`.
+
+
+```bash
+brew install docker --cask
+```
+
+Then open `/Applications/Docker`. Note that the first time you open the application you need to go to the `Applications` folder, right-click `Docker` and select `open`.
+
+### Running Minio
+
+Run the `install_s3_test_server` script. This requires root. This makes a few changes to your system, specifically to `/etc/hosts` to set up a few redirect interfaces to localhost. This only needs to be run once.
+
+```bash
+sudo ./scripts/install_s3_test_server.sh
+```
+
+Then run the test server in the back-ground using Docker. Note that Docker must be opened for this to work. On MacOS you can open the docker gui (`/Applications/Docker`) and leave it open to accomplish this.
+
+
+```bash
+ ./scripts/run_s3_test_server.sh
+```
+
+Now set up the following environment variables to enable running of the tests.
+
+```bash
+export S3_TEST_SERVER_AVAILABLE=1
+export AWS_DEFAULT_REGION=eu-west-1
+export AWS_ACCESS_KEY_ID=minio_duckdb_user
+export AWS_SECRET_ACCESS_KEY=minio_duckdb_user_password
+export DUCKDB_S3_ENDPOINT=duckdb-minio.com:9000  
+export DUCKDB_S3_USE_SSL=false
+```
+
+Now you should be able to run the S3 tests using minio, e.g.:
+
+```bash
+build/debug/test/unittest test/sql/copy/s3/s3_hive_partition.test
+```


### PR DESCRIPTION
This PR makes ATTACH work over HTTP(S) connections (not S3 yet) - and fixes an issue where ATTACH would not work on databases that had enum types or custom types stored within them.