### PR TITLE
add swift package build tool

### DIFF
--- a/tools/swiftpm/.gitignore
+++ b/tools/swiftpm/.gitignore
@@ -1,0 +1,2 @@
+duckdb-swift-core/Sources/Cduckdb/
+duckdb-swift-core/Package.swift

--- a/tools/swiftpm/Package.swift.template
+++ b/tools/swiftpm/Package.swift.template
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.7
+
+import PackageDescription
+
+let package = Package(
+  name: "Cduckdb",
+  products: [
+    .library(name: "Cduckdb", targets: ["Cduckdb"]),
+  ],
+  targets: [
+    .target(
+      name: "Cduckdb",
+      sources: [
+        $source_list
+      ],
+      cxxSettings: [
+        $search_path_list
+        $define_list
+        .define("DUCKDB_BUILD_LIBRARY")
+      ]
+    ),
+    .testTarget(name: "CduckdbTests", dependencies: ["Cduckdb"])
+  ],
+  cxxLanguageStandard: .cxx11
+)

--- a/tools/swiftpm/create_package.py
+++ b/tools/swiftpm/create_package.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import shutil
+from pathlib import Path
+from string import Template
+
+# list of extensions to bundle
+extensions = ['parquet', 'icu', 'json']
+
+# name of the repository
+repo_name = 'duckdb-swift-core'
+
+# name of the Swift packaged C target
+swift_target_name = 'Cduckdb'
+
+# name of the target's source dir
+src_dir_name = 'duckdb'
+
+# path to target
+base_dir = os.getcwd()
+package_dir = os.path.join(base_dir, repo_name) 
+target_dir = os.path.join(package_dir, 'Sources', swift_target_name)
+includes_dir = os.path.join(target_dir, 'include')
+src_dir = os.path.join(target_dir, src_dir_name)
+
+# Prepare target directory
+Path(target_dir).mkdir(parents=True,exist_ok=True)
+Path(includes_dir).mkdir(parents=True,exist_ok=True)
+
+# build package source files
+os.chdir(os.path.join('..', '..'))
+sys.path.append('scripts')
+import package_build
+# fresh build - copy over all of the files
+(source_list, include_list, _) = package_build.build_package(
+    src_dir, extensions, 32, src_dir_name)
+# standardise paths
+source_list = [os.path.relpath(x, target_dir) if os.path.isabs(x) else x for x in source_list]
+include_list = [os.path.join(src_dir_name, x) for x in include_list]
+define_list = ['BUILD_{}_EXTENSION'.format(ext.upper()) for ext in extensions]
+# write Package.swift
+os.chdir(base_dir)
+
+# copy umbrella header to path SPM expects (auto .modulemap)
+header_file_src = os.path.join(src_dir, 'src', 'include', 'duckdb.h')
+header_file_dest= os.path.join(includes_dir, 'duckdb.h')
+shutil.copyfile(header_file_src, header_file_dest)
+
+source_list_strs = ['"' + x + '",' for x in source_list]
+include_list_strs = ['.headerSearchPath("' + x + '"),' for x in include_list]
+define_list_strs = ['.define("' + x + '"),' for x in define_list]
+src_line_prefix = '\n        ' # indents eight spaces
+
+content = {
+    'source_list': src_line_prefix.join(source_list_strs),
+    'search_path_list': src_line_prefix.join(include_list_strs),
+    'define_list': src_line_prefix.join(define_list_strs),
+}
+
+package_manifest_path = os.path.join(package_dir, 'Package.swift')
+with open('Package.swift.template', 'r') as f:
+    src = Template(f.read())
+    result = src.substitute(content)
+    with open(package_manifest_path, 'w') as f:
+        f.write(result)

--- a/tools/swiftpm/duckdb-swift-core/.gitignore
+++ b/tools/swiftpm/duckdb-swift-core/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/tools/swiftpm/duckdb-swift-core/README.md
+++ b/tools/swiftpm/duckdb-swift-core/README.md
@@ -1,0 +1,3 @@
+# Duck DB
+
+A description of this package.

--- a/tools/swiftpm/duckdb-swift-core/Tests/CduckdbTests/CduckdbTests.swift
+++ b/tools/swiftpm/duckdb-swift-core/Tests/CduckdbTests/CduckdbTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import Cduckdb
+
+final class CduckdbTests: XCTestCase {
+  
+    func test_db_connect() throws {
+      var db: duckdb_database?
+      var conn: duckdb_connection?
+      var status = duckdb_state(0)
+      status = duckdb_open(nil, &db)
+      XCTAssertEqual(status.rawValue, 0)
+      status = duckdb_connect(db, &conn)
+      XCTAssertEqual(status.rawValue, 0)
+      duckdb_disconnect(&conn)
+      duckdb_close(&db)
+    }
+}


### PR DESCRIPTION
Adds a new tool for automating the creation of a Swift wrapper package for duckdb.

### How to create a new Swift Package

To create a new package, clone the repo and run:

```
cd tools/swiftpm
python3 create_package.py
swift test --package-path duckdb-swift-core
```

Swift package manager should build the project and run the current single test - opening an in-memory db and connecting.

### Naming

The package uses the Swift convention of prefixing C wrapping libraries with the letter `C`, therefore to use the package in Swift you need to `import Cduckdb`. This reserves the `DuckDB` target name for a future Swift idiomatic package that depends on `Cduckdb`.

### Future direction

Swift developers typically expect to be able to add a repository by specifying a git repository in the `Package.swift` manifest of their own projects. However, this isn't currently possible as the tool currently requires the main duckdb to be cloned, and then a package generated locally. This is doable but not ideal.

For the best DX, I would recommend creating a workflow that commits the contents of `tools/swiftpm/duckdb-swift-core` into the root of a new duckdb controlled GitHub repo at `duckdb/duckdb-swift-core`. This could happen when a new release is tagged in the main repository. This would facilitate a typical Swift development workflow.