### PR TITLE
Fix #6136: fix issue with SINGLE JOIN where NULL values of a struct were not correctly set 

### DIFF
--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -822,29 +822,9 @@ void ScanStructure::NextSingleJoin(DataChunk &keys, DataChunk &input, DataChunk 
 	for (idx_t i = 0; i < ht.build_types.size(); i++) {
 		auto &v = result.data[input.ColumnCount() + i];
 		// set NULL entries for every entry that was not found
-		if (v.GetType().InternalType() != PhysicalType::STRUCT) {
-			// fast path for non-structs
-			// batch set all entries to invalid
-			// then, based on which entries found a match, set those entries back to valid
-			auto &mask = FlatVector::Validity(v);
-			mask.SetAllInvalid(input.size());
-			for (idx_t j = 0; j < result_count; j++) {
-				mask.SetValid(result_sel.get_index(j));
-			}
-		} else {
-			// for structs we do this the other way around
-			// first we figure out which entries found a match
-			// then we call FlatVector::SetNull for all entries that did not find a match
-			// we need to use FlatVector::SetNull so all child entries are also correctly set to invalid
-			vector<bool> found_match;
-			found_match.resize(input.size(), false);
-			for (idx_t j = 0; j < result_count; j++) {
-				found_match[result_sel.get_index(j)] = true;
-			}
-			for (idx_t i = 0; i < input.size(); i++) {
-				if (!found_match[i]) {
-					FlatVector::SetNull(v, i, true);
-				}
+		for (idx_t j = 0; j < input.size(); j++) {
+			if (!found_match[j]) {
+				FlatVector::SetNull(v, j, true);
 			}
 		}
 		// for the remaining values we fetch the values

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -820,15 +820,15 @@ void ScanStructure::NextSingleJoin(DataChunk &keys, DataChunk &input, DataChunk 
 	}
 	// now fetch the data from the RHS
 	for (idx_t i = 0; i < ht.build_types.size(); i++) {
-		auto &v = result.data[input.ColumnCount() + i];
+		auto &vector = result.data[input.ColumnCount() + i];
 		// set NULL entries for every entry that was not found
 		for (idx_t j = 0; j < input.size(); j++) {
 			if (!found_match[j]) {
-				FlatVector::SetNull(v, j, true);
+				FlatVector::SetNull(vector, j, true);
 			}
 		}
 		// for the remaining values we fetch the values
-		GatherResult(v, result_sel, result_sel, result_count, i + ht.condition_types.size());
+		GatherResult(vector, result_sel, result_sel, result_count, i + ht.condition_types.size());
 	}
 	result.SetCardinality(input.size());
 

--- a/test/sql/subquery/scalar/test_issue_6136.test
+++ b/test/sql/subquery/scalar/test_issue_6136.test
@@ -1,0 +1,48 @@
+# name: test/sql/subquery/scalar/test_issue_6136.test
+# description: Issue 6136: Segfault when running query with correlated subqueries
+# group: [scalar]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table r as select * from values (1, 1, 'a', 'A'), (1, null, 'b', 'B'), (1, 2, 'c', 'C'), (2, null, 'd', 'D') t(ra, rb, x, y);
+
+statement ok
+create table b as select * from values (1, 1, 1), (2, 1, 2), (3, 1, 3), (4, 1, null), (5, 2, 1), (6, 2, null), (7, 99, 99) t(id, ba, bb);
+
+
+statement ok
+select
+  (select {'__matches': count(*)} from r where ba = ra and bb = rb group by ra, rb) as ref1,
+from b;
+
+statement ok
+select
+  id,
+  ba,
+  bb,
+  coalesce((select {'x': first(x), 'y': first(y), '__matches': count(*)} from r where ba = ra and bb = rb group by ra, rb), {'x': null, 'y': null, '__matches': 0}) as ref1,
+  coalesce((select {'x': first(x), 'y': first(y), '__matches': count(*)} from r where ba = ra and (bb = rb or rb is null) group by ra, rb order by bb = rb), {'x': null, 'y': null, '__matches': 0}) as ref2,
+  coalesce((select {'x': first(x), 'y': first(y), '__matches': count(*)} from r where (ba = ra or ra is null) and (bb = rb or rb is null) group by ra, rb order by ba = ra, bb = rb), {'x': null, 'y': null, '__matches': 0}) as ref3,
+  coalesce((select {'x': first(x), 'y': first(y), '__matches': count(*)} from r where (ba = ra or ra is null) group by ra order by ba = ra), {'x': null, 'y': null, '__matches': 0}) as ref4,
+from b;
+
+# postgres compatible variant
+query IIIII
+select
+  id,
+  ba,
+  bb,
+  coalesce((select ROW(min(x), min(y), count(*)) from r where ba = ra and bb = rb group by ra, rb), ROW(null, null, 0)) as ref1,
+  coalesce((select ROW(min(x), min(y), count(*)) from r where (ba = ra or ra is null) group by ra order by ba = ra), ROW(null, null, 0)) as ref4
+from b
+ORDER BY 1, 2, 3;
+----
+1	1	1	{'min(x)': a, 'min(y)': A, 'count_star()': 1}	{'min(x)': a, 'min(y)': A, 'count_star()': 3}
+2	1	2	{'min(x)': c, 'min(y)': C, 'count_star()': 1}	{'min(x)': a, 'min(y)': A, 'count_star()': 3}
+3	1	3	{'min(x)': NULL, 'min(y)': NULL, 'count_star()': 0}	{'min(x)': a, 'min(y)': A, 'count_star()': 3}
+4	1	NULL	{'min(x)': NULL, 'min(y)': NULL, 'count_star()': 0}	{'min(x)': a, 'min(y)': A, 'count_star()': 3}
+5	2	1	{'min(x)': NULL, 'min(y)': NULL, 'count_star()': 0}	{'min(x)': d, 'min(y)': D, 'count_star()': 1}
+6	2	NULL	{'min(x)': NULL, 'min(y)': NULL, 'count_star()': 0}	{'min(x)': d, 'min(y)': D, 'count_star()': 1}
+7	99	99	{'min(x)': NULL, 'min(y)': NULL, 'count_star()': 0}	{'min(x)': NULL, 'min(y)': NULL, 'count_star()': 0}


### PR DESCRIPTION
Fixes #6136 

This problem would cause undefined value access when using structs in correlated subqueries - which could then cause potential crashes in case of VARCHAR columns.