### PR TITLE
5982 (8, 12, 15) binder error when group by all & having clause both refer to column from correlated subquery

### DIFF
--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -194,7 +194,6 @@ unique_ptr<Expression> ExpressionBinder::Bind(unique_ptr<ParsedExpression> &expr
 			throw BinderException(error_msg);
 		}
 		auto bound_expr = (BoundExpression *)expr.get();
-		//
 		ExtractCorrelatedExpressions(binder, *bound_expr->expr);
 	}
 	D_ASSERT(expr->expression_class == ExpressionClass::BOUND_EXPRESSION);

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -194,6 +194,7 @@ unique_ptr<Expression> ExpressionBinder::Bind(unique_ptr<ParsedExpression> &expr
 			throw BinderException(error_msg);
 		}
 		auto bound_expr = (BoundExpression *)expr.get();
+		//
 		ExtractCorrelatedExpressions(binder, *bound_expr->expr);
 	}
 	D_ASSERT(expr->expression_class == ExpressionClass::BOUND_EXPRESSION);

--- a/src/planner/expression_binder/having_binder.cpp
+++ b/src/planner/expression_binder/having_binder.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/planner/expression_binder/having_binder.hpp"
 
 #include "duckdb/parser/expression/columnref_expression.hpp"
+#include "duckdb/parser/expression/subquery_expression.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression_binder/aggregate_binder.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -47,6 +48,10 @@ BindResult HavingBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, 
 		return BindResult("HAVING clause cannot contain window functions!");
 	case ExpressionClass::COLUMN_REF:
 		return BindColumnRef(expr_ptr, depth, root_expression);
+//	case ExpressionClass::SUBQUERY: {
+//		auto &tmp = (SubqueryExpression&)*expr_ptr;
+//		return BindExpression(tmp, depth);
+//	}
 	default:
 		return duckdb::SelectBinder::BindExpression(expr_ptr, depth);
 	}

--- a/src/planner/expression_binder/having_binder.cpp
+++ b/src/planner/expression_binder/having_binder.cpp
@@ -51,10 +51,6 @@ BindResult HavingBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, 
 		return BindResult("HAVING clause cannot contain window functions!");
 	case ExpressionClass::COLUMN_REF:
 		return BindColumnRef(expr_ptr, depth, root_expression);
-//	case ExpressionClass::SUBQUERY: {
-//		auto &tmp = (SubqueryExpression&)*expr_ptr;
-//		return BindExpression(tmp, depth);
-//	}
 	default:
 		return duckdb::SelectBinder::BindExpression(expr_ptr, depth);
 	}

--- a/src/planner/expression_binder/having_binder.cpp
+++ b/src/planner/expression_binder/having_binder.cpp
@@ -1,7 +1,6 @@
 #include "duckdb/planner/expression_binder/having_binder.hpp"
 
 #include "duckdb/parser/expression/columnref_expression.hpp"
-#include "duckdb/parser/expression/subquery_expression.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression_binder/aggregate_binder.hpp"
 #include "duckdb/common/string_util.hpp"

--- a/src/planner/expression_binder/having_binder.cpp
+++ b/src/planner/expression_binder/having_binder.cpp
@@ -23,6 +23,9 @@ BindResult HavingBinder::BindColumnRef(unique_ptr<ParsedExpression> *expr_ptr, i
 		return alias_result;
 	}
 	if (aggregate_handling == AggregateHandling::FORCE_AGGREGATES) {
+		if (depth > 0) {
+			throw BinderException("Having clause cannot reference column in correlated subquery and group by all");
+		}
 		auto expr = duckdb::SelectBinder::BindExpression(expr_ptr, depth);
 		if (expr.HasError()) {
 			return expr;

--- a/test/fuzzer/pedro/binder_error_with_having_statement.test
+++ b/test/fuzzer/pedro/binder_error_with_having_statement.test
@@ -24,3 +24,17 @@ query I
 SELECT 1 alias1 FROM (SELECT 1) t2(c1) GROUP BY c1 HAVING (SELECT c1);
 ----
 1
+
+statement ok
+CREATE TABLE t1 (c0 INT);
+
+statement error
+SELECT 0 c0 FROM t1 GROUP BY ALL HAVING c0 < ALL(SELECT 0 FROM ((SELECT 2) UNION (SELECT 2)) t2 WHERE substr('b', 1, c0) GROUP BY ALL);
+----
+Binder Error
+
+
+statement error
+SELECT 1 FROM (SELECT 1) t1(c0) GROUP BY ALL HAVING EXISTS (SELECT 1 FROM (SELECT 1) t0(c2) HAVING c0);
+----
+Binder Error

--- a/test/fuzzer/pedro/binder_error_with_having_statement.test
+++ b/test/fuzzer/pedro/binder_error_with_having_statement.test
@@ -1,5 +1,5 @@
 # name: test/fuzzer/pedro/binder_error_with_having_statement.test
-# description: Issue #5984 (8): Another Binder Error
+# description: Issue #5984 (8, 12, 15): Another Binder Error
 # group: [pedro]
 
 statement ok

--- a/test/fuzzer/pedro/binder_error_with_having_statement.test
+++ b/test/fuzzer/pedro/binder_error_with_having_statement.test
@@ -1,0 +1,13 @@
+# name: test/fuzzer/pedro/binder_error_with_having_statement.test
+# description: Issue #5984 (8): Another Binder Error 
+# group: [pedro]
+
+statement ok
+PRAGMA enable_verification
+
+mode output_result
+
+# SELECT 1 FROM (SELECT 1) t2(c1) GROUP BY ALL HAVING (SELECT c1);
+
+statement ok
+SELECT 1 alias1 FROM (SELECT 1) t2(c1) GROUP BY ALL HAVING (SELECT c1);

--- a/test/fuzzer/pedro/binder_error_with_having_statement.test
+++ b/test/fuzzer/pedro/binder_error_with_having_statement.test
@@ -9,9 +9,12 @@ PRAGMA enable_verification
 statement ok
 CREATE TABLE t2(c1 INT, c2 INT);
 
-mode output_result
-
-# SELECT 1 FROM (SELECT 1) t2(c1) GROUP BY ALL HAVING (SELECT c1);
-
-statement ok
+statement error 
 SELECT 1 alias1 FROM (SELECT 1) t2(c1) GROUP BY ALL HAVING (SELECT c1);
+----
+Binder Error
+
+query I 
+SELECT 1 alias1 FROM (SELECT 1) t2(c1) GROUP BY ALL HAVING (SELECT alias1);
+----
+1

--- a/test/fuzzer/pedro/binder_error_with_having_statement.test
+++ b/test/fuzzer/pedro/binder_error_with_having_statement.test
@@ -18,3 +18,9 @@ query I
 SELECT 1 alias1 FROM (SELECT 1) t2(c1) GROUP BY ALL HAVING (SELECT alias1);
 ----
 1
+
+# works without a group by all
+query I 
+SELECT 1 alias1 FROM (SELECT 1) t2(c1) GROUP BY c1 HAVING (SELECT c1);
+----
+1

--- a/test/fuzzer/pedro/binder_error_with_having_statement.test
+++ b/test/fuzzer/pedro/binder_error_with_having_statement.test
@@ -1,5 +1,5 @@
 # name: test/fuzzer/pedro/binder_error_with_having_statement.test
-# description: Issue #5984 (8): Another Binder Error 
+# description: Issue #5984 (8): Another Binder Error
 # group: [pedro]
 
 statement ok

--- a/test/fuzzer/pedro/binder_error_with_having_statement.test
+++ b/test/fuzzer/pedro/binder_error_with_having_statement.test
@@ -5,6 +5,10 @@
 statement ok
 PRAGMA enable_verification
 
+
+statement ok
+CREATE TABLE t2(c1 INT, c2 INT);
+
 mode output_result
 
 # SELECT 1 FROM (SELECT 1) t2(c1) GROUP BY ALL HAVING (SELECT c1);


### PR DESCRIPTION
A Group by all with a Having clause has special behavior during binding, which makes it difficult to handle correlated subqueries. This error should fix fuzzer issues 8, 12, and 15.
In fuzzer issue 8, the column c1 in the select clause references a column from a subquery in the from clause. c1 is also grouped on using the group by all, and is then in the having clause. The `group by all` forces aggregates, which requires special handling during binding. Since the column is also in a correlated subquery, the handling should be extended to also extract the column binding from the correlated subquery, but that will be a lot of work that hopefully someone can pay us for in the future. The current solution is just to throw a binder error.

Issue 8
`SELECT 1 alias1 FROM (SELECT 1) t2(c1) GROUP BY ALL HAVING (SELECT c1);`

Issue 12
`SELECT 1 FROM (SELECT 1) t1(c0) GROUP BY ALL HAVING EXISTS (SELECT 1 FROM (SELECT 1) t0(c2) HAVING c0);` issue 12

Issue 15
`SELECT 0 c0 FROM t1 GROUP BY ALL HAVING c0 < ALL(SELECT 0 FROM ((SELECT 2) UNION (SELECT 2)) t2 WHERE substr('b', 1, c0) GROUP BY ALL);`


