### PR TITLE
Skip concurrent index/grouping sets tests for now

### DIFF
--- a/test/sql/insert/insert_from_many_grouping_sets.test
+++ b/test/sql/insert/insert_from_many_grouping_sets.test
@@ -2,7 +2,6 @@
 # description: Test parallel insert from many groups
 # group: [insert]
 
-
 # FIXME: occasionally this test fails on the CI with a thread sanitizer failure
 mode skip
 

--- a/test/sql/insert/insert_from_many_grouping_sets.test
+++ b/test/sql/insert/insert_from_many_grouping_sets.test
@@ -2,6 +2,10 @@
 # description: Test parallel insert from many groups
 # group: [insert]
 
+
+# FIXME: occasionally this test fails on the CI with a thread sanitizer failure
+mode skip
+
 statement ok
 CREATE TABLE integers AS SELECT i, i%2 as j FROM generate_series(0,999999,1) tbl(i);
 

--- a/test/sql/parallelism/interquery/test_concurrent_index.cpp
+++ b/test/sql/parallelism/interquery/test_concurrent_index.cpp
@@ -351,6 +351,8 @@ static void join_integers(Connection *con, bool *index_join_success, idx_t threa
 }
 
 TEST_CASE("Concurrent appends during index join", "[interquery][.]") {
+	// FIXME: this test occassionally fails in the CI, likely due to a race condition in the index code
+	return;
 	unique_ptr<QueryResult> result;
 	DuckDB db(nullptr);
 	Connection con(db);


### PR DESCRIPTION
These occasionally fail the CI - we need to have a better look at these later.