### PR TITLE
Fix fuzzer issue 14: correctly switch between deleting from transaction local storage and main table based on ids

### DIFF
--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -171,7 +171,8 @@ public:
 	                const vector<column_t> &bound_columns, Expression &cast_expr);
 
 	void MoveStorage(DataTable *old_dt, DataTable *new_dt);
-	void FetchChunk(DataTable *table, Vector &row_ids, idx_t count, DataChunk &chunk);
+	void FetchChunk(DataTable *table, Vector &row_ids, idx_t count, const vector<column_t> &col_ids, DataChunk &chunk,
+	                ColumnFetchState &fetch_state);
 	TableIndexList &GetIndexes(DataTable *table);
 
 	void VerifyNewConstraint(DataTable &parent, const BoundConstraint &constraint);

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -596,20 +596,14 @@ void LocalStorage::ChangeType(DataTable *old_dt, DataTable *new_dt, idx_t change
 	table_manager.InsertEntry(new_dt, std::move(new_storage));
 }
 
-void LocalStorage::FetchChunk(DataTable *table, Vector &row_ids, idx_t count, DataChunk &verify_chunk) {
+void LocalStorage::FetchChunk(DataTable *table, Vector &row_ids, idx_t count, const vector<column_t> &col_ids,
+                              DataChunk &chunk, ColumnFetchState &fetch_state) {
 	auto storage = table_manager.GetStorage(table);
 	if (!storage) {
 		throw InternalException("LocalStorage::FetchChunk - local storage not found");
 	}
 
-	ColumnFetchState fetch_state;
-	vector<column_t> col_ids;
-	vector<LogicalType> types = storage->table->GetTypes();
-	for (idx_t i = 0; i < types.size(); i++) {
-		col_ids.push_back(i);
-	}
-	verify_chunk.Initialize(storage->allocator, types);
-	storage->row_groups->Fetch(transaction, verify_chunk, col_ids, row_ids, count, fetch_state);
+	storage->row_groups->Fetch(transaction, chunk, col_ids, row_ids, count, fetch_state);
 }
 
 TableIndexList &LocalStorage::GetIndexes(DataTable *table) {

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -409,7 +409,7 @@ idx_t RowGroupCollection::Delete(TransactionData transaction, DataTable *table, 
 	idx_t pos = 0;
 	do {
 		idx_t start = pos;
-		auto row_group = (RowGroup *)row_groups->GetSegment(ids[pos]);
+		auto row_group = (RowGroup *)row_groups->GetSegment(ids[start]);
 		for (pos++; pos < count; pos++) {
 			D_ASSERT(ids[pos] >= 0);
 			// check if this id still belongs to this row group

--- a/test/fuzzer/pedro/segment_tree_index_issue.test
+++ b/test/fuzzer/pedro/segment_tree_index_issue.test
@@ -1,0 +1,57 @@
+# name: test/fuzzer/pedro/segment_tree_index_issue.test
+# description: Segment tree index issue
+# group: [pedro]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t0 (c1 INT);
+
+statement ok
+INSERT INTO t0 VALUES (0);
+
+statement ok
+START TRANSACTION;
+
+statement ok
+INSERT INTO t0 VALUES (1);
+
+statement ok
+DELETE FROM t0 USING (SELECT 1) t1;
+
+query I
+SELECT * FROM t0
+----
+
+statement ok
+COMMIT
+
+# now do the same but with a table with foreign key constraints
+statement ok
+DROP TABLE t0
+
+statement ok
+CREATE TABLE t0 (c1 INT PRIMARY KEY);
+
+statement ok
+CREATE TABLE fk_integers(id INTEGER REFERENCES t0(c1))
+
+statement ok
+INSERT INTO t0 VALUES (0);
+
+statement ok
+START TRANSACTION;
+
+statement ok
+INSERT INTO t0 VALUES (1);
+
+statement ok
+DELETE FROM t0 USING (SELECT 1) t1;
+
+query I
+SELECT * FROM t0
+----
+
+statement ok
+COMMIT


### PR DESCRIPTION
When the `USING` clause is used it can happen that a single vector contains row ids that point to both the transaction-local storage and the main table storage - hence we need to have a loop to ensure we always delete from the correct `RowGroupCollection`.