### PR TITLE
Skip attach over HTTPFS test

### DIFF
--- a/test/sql/attach/attach_httpfs.test
+++ b/test/sql/attach/attach_httpfs.test
@@ -6,6 +6,8 @@ require skip_reload
 
 require httpfs
 
+mode skip
+
 # ATTACH a DuckDB database over HTTPFS
 statement ok
 ATTACH 'https://github.com/duckdb/duckdb/raw/master/test/sql/storage_version/storage_version.db' AS db;


### PR DESCRIPTION
This test works fine but breaks PRs if we make changes to the storage version - we should come up with a better way of testing this (using something like minio but for http perhaps?)