### PR TITLE
Fuzzer issue: Grapheme function overflow

### DIFF
--- a/src/function/scalar/string/left_right.cpp
+++ b/src/function/scalar/string/left_right.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/function/scalar/string_functions.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
+#include "duckdb/common/limits.hpp"
 
 #include <ctype.h>
 #include <algorithm>
@@ -65,7 +66,10 @@ static string_t RightScalarFunction(Vector &result, const string_t str, int64_t 
 		return OP::Substring(result, str, start, len);
 	}
 
-	int64_t len = num_characters - MinValue<int64_t>(num_characters, -pos);
+	int64_t len = 0;
+	if (pos != std::numeric_limits<int64_t>::min()) {
+		len = num_characters - MinValue<int64_t>(num_characters, -pos);
+	}
 	int64_t start = num_characters - len + 1;
 	return OP::Substring(result, str, start, len);
 }

--- a/test/sql/function/string/test_right.test
+++ b/test/sql/function/string/test_right.test
@@ -105,3 +105,13 @@ query TTTT
 SELECT RIGHT_GRAPHEME('🦆🤦S̈', 0), RIGHT_GRAPHEME('🦆🤦S̈', -1), RIGHT_GRAPHEME('🦆🤦S̈', -2), RIGHT_GRAPHEME('🦆🤦S̈', -3)
 ----
 (empty)	🤦S̈	S̈	(empty)
+
+# grapheme overflow
+statement ok
+SELECT right_grapheme('a', -9223372036854775808);
+
+statement ok
+SELECT "right"('a', -9223372036854775808);
+
+statement error
+SELECT right_grapheme('a', 9223372036854775808);


### PR DESCRIPTION
Addresses fuzzer issue #5984 no. 36

Overflow occurs with negation of -9223372036854775808