### PR TITLE
Pass unrecognized configuration options to storage

### DIFF
--- a/src/include/duckdb/execution/operator/helper/physical_set.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_set.hpp
@@ -30,13 +30,13 @@ public:
 	void GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
 	             LocalSourceState &lstate) const override;
 
+	static void SetExtensionVariable(ClientContext &context, ExtensionOption &extension_option, const string &name,
+	                                 SetScope scope, const Value &value);
+
 public:
 	const std::string name;
 	const Value value;
 	const SetScope scope;
-
-private:
-	void SetExtensionVariable(ExecutionContext &context, DBConfig &config, ExtensionOption &extension_option) const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -145,6 +145,8 @@ struct DBConfigOptions {
 	bool experimental_parallel_csv_reader = false;
 	//! Start transactions immediately in all attached databases - instead of lazily when a database is referenced
 	bool immediate_transaction_mode = false;
+	//! The set of unrecognized (other) options
+	unordered_map<string, Value> unrecognized_options;
 
 	bool operator==(const DBConfigOptions &other) const;
 };
@@ -205,6 +207,7 @@ public:
 
 	DUCKDB_API void SetOption(const ConfigurationOption &option, const Value &value);
 	DUCKDB_API void SetOption(DatabaseInstance *db, const ConfigurationOption &option, const Value &value);
+	DUCKDB_API void SetOptionByName(const string &name, const Value &value);
 	DUCKDB_API void ResetOption(DatabaseInstance *db, const ConfigurationOption &option);
 	DUCKDB_API void SetOption(const string &name, Value value);
 	DUCKDB_API void ResetOption(const string &name);

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -145,6 +145,15 @@ void DBConfig::SetOption(const ConfigurationOption &option, const Value &value) 
 	SetOption(nullptr, option, value);
 }
 
+void DBConfig::SetOptionByName(const string &name, const Value &value) {
+	auto option = DBConfig::GetOptionByName(name);
+	if (option) {
+		SetOption(*option, value);
+	} else {
+		options.unrecognized_options[name] = value;
+	}
+}
+
 void DBConfig::SetOption(DatabaseInstance *db, const ConfigurationOption &option, const Value &value) {
 	lock_guard<mutex> l(config_lock);
 	if (!option.set_global) {

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -17,6 +17,7 @@
 #include "duckdb/parser/parsed_data/attach_info.hpp"
 #include "duckdb/storage/magic_bytes.hpp"
 #include "duckdb/storage/storage_extension.hpp"
+#include "duckdb/execution/operator/helper/physical_set.hpp"
 
 #ifndef DUCKDB_NO_THREADS
 #include "duckdb/common/thread.hpp"
@@ -37,12 +38,8 @@ DBConfig::DBConfig(std::unordered_map<string, string> &config_dict, bool read_on
 	for (auto &kv : config_dict) {
 		string key = kv.first;
 		string val = kv.second;
-		auto config_property = DBConfig::GetOptionByName(key);
-		if (!config_property) {
-			throw InvalidInputException("Unrecognized configuration property \"%s\"", key);
-		}
 		auto opt_val = Value(val);
-		DBConfig::SetOption(*config_property, opt_val);
+		DBConfig::SetOptionByName(key, opt_val);
 	}
 }
 
@@ -220,6 +217,27 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 	if (!database_type.empty()) {
 		// if we are opening an extension database - load the extension
 		ExtensionHelper::LoadExternalExtension(*this, nullptr, database_type);
+	}
+
+	if (!config.options.unrecognized_options.empty()) {
+		// check if all unrecognized options can be handled by the loaded extension(s)
+		for (auto &unrecognized_option : config.options.unrecognized_options) {
+			auto entry = config.extension_parameters.find(unrecognized_option.first);
+			if (entry == config.extension_parameters.end()) {
+				throw InvalidInputException("Unrecognized configuration property \"%s\"", unrecognized_option.first);
+			}
+		}
+
+		// if so - set the options
+		Connection con(*this);
+		con.BeginTransaction();
+		for (auto &unrecognized_option : config.options.unrecognized_options) {
+			auto entry = config.extension_parameters.find(unrecognized_option.first);
+			D_ASSERT(entry != config.extension_parameters.end());
+			PhysicalSet::SetExtensionVariable(*con.context, entry->second, unrecognized_option.first, SetScope::GLOBAL,
+			                                  unrecognized_option.second);
+		}
+		con.Commit();
 	}
 
 	// only increase thread count after storage init because we get races on catalog otherwise

--- a/tools/nodejs/src/database.cpp
+++ b/tools/nodejs/src/database.cpp
@@ -44,13 +44,8 @@ struct OpenTask : public Task {
 			for (duckdb::idx_t config_idx = 0; config_idx < config_names.Length(); config_idx++) {
 				std::string key = config_names.Get(config_idx).As<Napi::String>();
 				std::string val = config_.Get(key).As<Napi::String>();
-				auto config_property = duckdb::DBConfig::GetOptionByName(key);
-				if (!config_property) {
-					Napi::TypeError::New(env, "Unrecognized configuration property" + key).ThrowAsJavaScriptException();
-					return;
-				}
 				try {
-					duckdb_config.SetOption(*config_property, duckdb::Value(val));
+					duckdb_config.SetOptionByName(key, duckdb::Value(val));
 				} catch (std::exception &e) {
 					Napi::TypeError::New(env, "Failed to set configuration option " + key + ": " + e.what())
 					    .ThrowAsJavaScriptException();

--- a/tools/rpkg/src/database.cpp
+++ b/tools/rpkg/src/database.cpp
@@ -40,12 +40,8 @@ static bool CastRstringToVarchar(Vector &source, Vector &result, idx_t count, Ca
 	for (auto it = confignames.begin(); it != confignames.end(); ++it) {
 		std::string key = *it;
 		std::string val = cpp11::as_cpp<std::string>(configsexp[key]);
-		auto config_property = DBConfig::GetOptionByName(key);
-		if (!config_property) {
-			cpp11::stop("rapi_startup: Unrecognized configuration property '%s'", key.c_str());
-		}
 		try {
-			config.SetOption(*config_property, Value(val));
+			config.SetOptionByName(key, Value(val));
 		} catch (std::exception &e) {
 			cpp11::stop("rapi_startup: Failed to set configuration option: %s", e.what());
 		}


### PR DESCRIPTION
This PR extends the configuration so that it can initially take unknown parameters. These are saved as `key, value` pairs. After the database is instantiated we check if they match the parameters of any extensions that have been registered. This will allow extension parameters to be passed into the database configuration as well. 