### PR TITLE
[Dev] Python test random deadlock fix

### DIFF
--- a/tools/pythonpkg/tests/fast/api/test_to_csv.py
+++ b/tools/pythonpkg/tests/fast/api/test_to_csv.py
@@ -10,56 +10,62 @@ import pytest
 
 class TestToCSV(object):
     def test_basic_to_csv(self):
+        con = duckdb.connect()
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame({'a': [5,3,23,2], 'b': [45,234,234,2]})
-        rel = duckdb.from_df(df)
+        rel = con.from_df(df)
 
         rel.to_csv(temp_file_name)
 
-        csv_rel = duckdb.read_csv(temp_file_name)
+        csv_rel = con.read_csv(temp_file_name)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     def test_to_csv_sep(self):
+        con = duckdb.connect()
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame({'a': [5,3,23,2], 'b': [45,234,234,2]})
-        rel = duckdb.from_df(df)
+        rel = con.from_df(df)
 
         rel.to_csv(temp_file_name, sep=',')
 
-        csv_rel = duckdb.read_csv(temp_file_name, sep=',')
+        csv_rel = con.read_csv(temp_file_name, sep=',')
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     def test_to_csv_na_rep(self):
+        con = duckdb.connect()
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame({'a': [5,None,23,2], 'b': [45,234,234,2]})
-        rel = duckdb.from_df(df)
+        rel = con.from_df(df)
 
         rel.to_csv(temp_file_name, na_rep="test")
 
-        csv_rel = duckdb.read_csv(temp_file_name, na_values="test")
+        csv_rel = con.read_csv(temp_file_name, na_values="test")
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     def test_to_csv_header(self):
+        con = duckdb.connect()
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame({'a': [5,None,23,2], 'b': [45,234,234,2]})
-        rel = duckdb.from_df(df)
+        rel = con.from_df(df)
 
         rel.to_csv(temp_file_name, header=True)
 
-        csv_rel = duckdb.read_csv(temp_file_name, header=True)
+        csv_rel = con.read_csv(temp_file_name, header=True)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     def test_to_csv_quotechar(self):
+        con = duckdb.connect()
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame({'a': ["\'a,b,c\'",None,"hello","bye"], 'b': [45,234,234,2]})
-        rel = duckdb.from_df(df)
+        rel = con.from_df(df)
 
         rel.to_csv(temp_file_name, quotechar='\'', sep=',')
 
-        csv_rel = duckdb.read_csv(temp_file_name, sep=',', quotechar='\'')
+        csv_rel = con.read_csv(temp_file_name, sep=',', quotechar='\'')
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     def test_to_csv_escapechar(self):
+        con = duckdb.connect()
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame(
             {
@@ -69,96 +75,104 @@ class TestToCSV(object):
                 "c_string": ["a", "b,c"],
             }
         )
-        rel = duckdb.from_df(df)
+        rel = con.from_df(df)
         rel.to_csv(temp_file_name, header=True, quotechar='"', escapechar='!')
-        csv_rel = duckdb.read_csv(temp_file_name, quotechar='"', escapechar='!')
+        csv_rel = con.read_csv(temp_file_name, quotechar='"', escapechar='!')
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     def test_to_csv_date_format(self):
+        con = duckdb.connect()
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame(tm.getTimeSeriesData())
         dt_index = df.index
         df = pd.DataFrame(
             {"A": dt_index, "B": dt_index.shift(1)}, index=dt_index
         )
-        rel = duckdb.from_df(df)
+        rel = con.from_df(df)
         rel.to_csv(temp_file_name, date_format="%Y%m%d")
 
-        csv_rel = duckdb.read_csv(temp_file_name, date_format="%Y%m%d")
+        csv_rel = con.read_csv(temp_file_name, date_format="%Y%m%d")
 
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     def test_to_csv_timestamp_format(self):
+        con = duckdb.connect()
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         data = [datetime.time(hour=23, minute=1, second=34, microsecond=234345)]
         df = pd.DataFrame(
             {'0': pd.Series(data=data, dtype='object')}
         )
-        rel = duckdb.from_df(df)
+        rel = con.from_df(df)
         rel.to_csv(temp_file_name, timestamp_format='%m/%d/%Y')
 
-        csv_rel = duckdb.read_csv(temp_file_name, timestamp_format='%m/%d/%Y')
+        csv_rel = con.read_csv(temp_file_name, timestamp_format='%m/%d/%Y')
 
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     def test_to_csv_quoting_off(self):
+        con = duckdb.connect()
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame(
             {'a': ['string1', 'string2', 'string3']}
         )
-        rel = duckdb.from_df(df)
+        rel = con.from_df(df)
         rel.to_csv(temp_file_name, quoting=None)
 
-        csv_rel = duckdb.read_csv(temp_file_name)
+        csv_rel = con.read_csv(temp_file_name)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     def test_to_csv_quoting_on(self):
+        con = duckdb.connect()
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame(
             {'a': ['string1', 'string2', 'string3']}
         )
-        rel = duckdb.from_df(df)
+        rel = con.from_df(df)
         rel.to_csv(temp_file_name, quoting="force")
 
-        csv_rel = duckdb.read_csv(temp_file_name)
+        csv_rel = con.read_csv(temp_file_name)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     def test_to_csv_quoting_quote_all(self):
+        con = duckdb.connect()
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame(
             {'a': ['string1', 'string2', 'string3']}
         )
-        rel = duckdb.from_df(df)
+        rel = con.from_df(df)
         rel.to_csv(temp_file_name, quoting=csv.QUOTE_ALL)
 
-        csv_rel = duckdb.read_csv(temp_file_name)
+        csv_rel = con.read_csv(temp_file_name)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     def test_to_csv_encoding_incorrect(self):
+        con = duckdb.connect()
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame(
             {'a': ['string1', 'string2', 'string3']}
         )
-        rel = duckdb.from_df(df)
+        rel = con.from_df(df)
         with pytest.raises(duckdb.InvalidInputException, match="Invalid Input Error: The only supported encoding option is 'UTF8"):
             rel.to_csv(temp_file_name, encoding="nope")
 
     def test_to_csv_encoding_correct(self):
+        con = duckdb.connect()
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame(
             {'a': ['string1', 'string2', 'string3']}
         )
-        rel = duckdb.from_df(df)
+        rel = con.from_df(df)
         rel.to_csv(temp_file_name, encoding="UTF-8")
-        csv_rel = duckdb.read_csv(temp_file_name)
+        csv_rel = con.read_csv(temp_file_name)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     def test_compression_gzip(self):
+        con = duckdb.connect()
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame(
             {'a': ['string1', 'string2', 'string3']}
         )
-        rel = duckdb.from_df(df)
+        rel = con.from_df(df)
         rel.to_csv(temp_file_name, compression="gzip")
-        csv_rel = duckdb.read_csv(temp_file_name, compression="gzip")
+        csv_rel = con.read_csv(temp_file_name, compression="gzip")
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()

--- a/tools/pythonpkg/tests/fast/api/test_to_csv.py
+++ b/tools/pythonpkg/tests/fast/api/test_to_csv.py
@@ -2,71 +2,76 @@ import duckdb
 import tempfile
 import os
 import pandas as pd
-import tempfile
 import pandas._testing as tm
 import datetime
 import csv
 import pytest
 
 class TestToCSV(object):
-    def test_basic_to_csv(self):
+    def test_basic_to_csv(self, tmp_path):
+        # Convert to string because we don't accept anything other than 'str' for now
+        file_name = str(tmp_path / 'file.csv')
         con = duckdb.connect()
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame({'a': [5,3,23,2], 'b': [45,234,234,2]})
         rel = con.from_df(df)
 
-        rel.to_csv(temp_file_name)
+        rel.to_csv(file_name)
 
-        csv_rel = con.read_csv(temp_file_name)
+        csv_rel = con.read_csv(file_name)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
-    def test_to_csv_sep(self):
+    def test_to_csv_sep(self, tmp_path):
+        # Convert to string because we don't accept anything other than 'str' for now
+        file_name = str(tmp_path / 'file.csv')
         con = duckdb.connect()
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame({'a': [5,3,23,2], 'b': [45,234,234,2]})
         rel = con.from_df(df)
 
-        rel.to_csv(temp_file_name, sep=',')
+        rel.to_csv(file_name, sep=',')
 
-        csv_rel = con.read_csv(temp_file_name, sep=',')
+        csv_rel = con.read_csv(file_name, sep=',')
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
-    def test_to_csv_na_rep(self):
+    def test_to_csv_na_rep(self, tmp_path):
+        # Convert to string because we don't accept anything other than 'str' for now
+        file_name = str(tmp_path / 'file.csv')
         con = duckdb.connect()
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame({'a': [5,None,23,2], 'b': [45,234,234,2]})
         rel = con.from_df(df)
 
-        rel.to_csv(temp_file_name, na_rep="test")
+        rel.to_csv(file_name, na_rep="test")
 
-        csv_rel = con.read_csv(temp_file_name, na_values="test")
+        csv_rel = con.read_csv(file_name, na_values="test")
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
-    def test_to_csv_header(self):
+    def test_to_csv_header(self, tmp_path):
+        # Convert to string because we don't accept anything other than 'str' for now
+        file_name = str(tmp_path / 'file.csv')
         con = duckdb.connect()
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame({'a': [5,None,23,2], 'b': [45,234,234,2]})
         rel = con.from_df(df)
 
-        rel.to_csv(temp_file_name, header=True)
+        rel.to_csv(file_name, header=True)
 
-        csv_rel = con.read_csv(temp_file_name, header=True)
+        csv_rel = con.read_csv(file_name, header=True)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
-    def test_to_csv_quotechar(self):
+    def test_to_csv_quotechar(self, tmp_path):
+        # Convert to string because we don't accept anything other than 'str' for now
+        file_name = str(tmp_path / 'file.csv')
         con = duckdb.connect()
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame({'a': ["\'a,b,c\'",None,"hello","bye"], 'b': [45,234,234,2]})
         rel = con.from_df(df)
 
-        rel.to_csv(temp_file_name, quotechar='\'', sep=',')
+        rel.to_csv(file_name, quotechar='\'', sep=',')
 
-        csv_rel = con.read_csv(temp_file_name, sep=',', quotechar='\'')
+        csv_rel = con.read_csv(file_name, sep=',', quotechar='\'')
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
-    def test_to_csv_escapechar(self):
+    def test_to_csv_escapechar(self, tmp_path):
+        # Convert to string because we don't accept anything other than 'str' for now
+        file_name = str(tmp_path / 'file.csv')
         con = duckdb.connect()
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame(
             {
                 "c_bool": [True, False],
@@ -76,103 +81,111 @@ class TestToCSV(object):
             }
         )
         rel = con.from_df(df)
-        rel.to_csv(temp_file_name, header=True, quotechar='"', escapechar='!')
-        csv_rel = con.read_csv(temp_file_name, quotechar='"', escapechar='!')
+        rel.to_csv(file_name, header=True, quotechar='"', escapechar='!')
+        csv_rel = con.read_csv(file_name, quotechar='"', escapechar='!')
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
-    def test_to_csv_date_format(self):
+    def test_to_csv_date_format(self, tmp_path):
+        # Convert to string because we don't accept anything other than 'str' for now
+        file_name = str(tmp_path / 'file.csv')
         con = duckdb.connect()
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame(tm.getTimeSeriesData())
         dt_index = df.index
         df = pd.DataFrame(
             {"A": dt_index, "B": dt_index.shift(1)}, index=dt_index
         )
         rel = con.from_df(df)
-        rel.to_csv(temp_file_name, date_format="%Y%m%d")
+        rel.to_csv(file_name, date_format="%Y%m%d")
 
-        csv_rel = con.read_csv(temp_file_name, date_format="%Y%m%d")
+        csv_rel = con.read_csv(file_name, date_format="%Y%m%d")
 
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
-    def test_to_csv_timestamp_format(self):
+    def test_to_csv_timestamp_format(self, tmp_path):
+        # Convert to string because we don't accept anything other than 'str' for now
+        file_name = str(tmp_path / 'file.csv')
         con = duckdb.connect()
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         data = [datetime.time(hour=23, minute=1, second=34, microsecond=234345)]
         df = pd.DataFrame(
             {'0': pd.Series(data=data, dtype='object')}
         )
         rel = con.from_df(df)
-        rel.to_csv(temp_file_name, timestamp_format='%m/%d/%Y')
+        rel.to_csv(file_name, timestamp_format='%m/%d/%Y')
 
-        csv_rel = con.read_csv(temp_file_name, timestamp_format='%m/%d/%Y')
+        csv_rel = con.read_csv(file_name, timestamp_format='%m/%d/%Y')
 
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
-    def test_to_csv_quoting_off(self):
+    def test_to_csv_quoting_off(self, tmp_path):
+        # Convert to string because we don't accept anything other than 'str' for now
+        file_name = str(tmp_path / 'file.csv')
         con = duckdb.connect()
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame(
             {'a': ['string1', 'string2', 'string3']}
         )
         rel = con.from_df(df)
-        rel.to_csv(temp_file_name, quoting=None)
+        rel.to_csv(file_name, quoting=None)
 
-        csv_rel = con.read_csv(temp_file_name)
+        csv_rel = con.read_csv(file_name)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
-    def test_to_csv_quoting_on(self):
+    def test_to_csv_quoting_on(self, tmp_path):
+        # Convert to string because we don't accept anything other than 'str' for now
+        file_name = str(tmp_path / 'file.csv')
         con = duckdb.connect()
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame(
             {'a': ['string1', 'string2', 'string3']}
         )
         rel = con.from_df(df)
-        rel.to_csv(temp_file_name, quoting="force")
+        rel.to_csv(file_name, quoting="force")
 
-        csv_rel = con.read_csv(temp_file_name)
+        csv_rel = con.read_csv(file_name)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
-    def test_to_csv_quoting_quote_all(self):
+    def test_to_csv_quoting_quote_all(self, tmp_path):
+        # Convert to string because we don't accept anything other than 'str' for now
+        file_name = str(tmp_path / 'file.csv')
         con = duckdb.connect()
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame(
             {'a': ['string1', 'string2', 'string3']}
         )
         rel = con.from_df(df)
-        rel.to_csv(temp_file_name, quoting=csv.QUOTE_ALL)
+        rel.to_csv(file_name, quoting=csv.QUOTE_ALL)
 
-        csv_rel = con.read_csv(temp_file_name)
+        csv_rel = con.read_csv(file_name)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
-    def test_to_csv_encoding_incorrect(self):
+    def test_to_csv_encoding_incorrect(self, tmp_path):
+        # Convert to string because we don't accept anything other than 'str' for now
+        file_name = str(tmp_path / 'file.csv')
         con = duckdb.connect()
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame(
             {'a': ['string1', 'string2', 'string3']}
         )
         rel = con.from_df(df)
         with pytest.raises(duckdb.InvalidInputException, match="Invalid Input Error: The only supported encoding option is 'UTF8"):
-            rel.to_csv(temp_file_name, encoding="nope")
+            rel.to_csv(file_name, encoding="nope")
 
-    def test_to_csv_encoding_correct(self):
+    def test_to_csv_encoding_correct(self, tmp_path):
+        # Convert to string because we don't accept anything other than 'str' for now
+        file_name = str(tmp_path / 'file.csv')
         con = duckdb.connect()
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame(
             {'a': ['string1', 'string2', 'string3']}
         )
         rel = con.from_df(df)
-        rel.to_csv(temp_file_name, encoding="UTF-8")
-        csv_rel = con.read_csv(temp_file_name)
+        rel.to_csv(file_name, encoding="UTF-8")
+        csv_rel = con.read_csv(file_name)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
-    def test_compression_gzip(self):
+    def test_compression_gzip(self, tmp_path):
+        # Convert to string because we don't accept anything other than 'str' for now
+        file_name = str(tmp_path / 'file.csv')
         con = duckdb.connect()
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame(
             {'a': ['string1', 'string2', 'string3']}
         )
         rel = con.from_df(df)
-        rel.to_csv(temp_file_name, compression="gzip")
-        csv_rel = con.read_csv(temp_file_name, compression="gzip")
+        rel.to_csv(file_name, compression="gzip")
+        csv_rel = con.read_csv(file_name, compression="gzip")
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()

--- a/tools/pythonpkg/tests/fast/api/test_to_parquet.py
+++ b/tools/pythonpkg/tests/fast/api/test_to_parquet.py
@@ -10,21 +10,23 @@ import pytest
 
 class TestToParquet(object):
     def test_basic_to_parquet(self):
+        con = duckdb.connect()
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame({'a': [5,3,23,2], 'b': [45,234,234,2]})
-        rel = duckdb.from_df(df)
+        rel = con.from_df(df)
 
         rel.to_parquet(temp_file_name)
 
-        csv_rel = duckdb.read_parquet(temp_file_name)
+        csv_rel = con.read_parquet(temp_file_name)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     def test_compression_gzip(self):
+        con = duckdb.connect()
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         df = pd.DataFrame(
             {'a': ['string1', 'string2', 'string3']}
         )
-        rel = duckdb.from_df(df)
+        rel = con.from_df(df)
         rel.to_parquet(temp_file_name, compression="gzip")
-        csv_rel = duckdb.read_parquet(temp_file_name, compression="gzip")
+        csv_rel = con.read_parquet(temp_file_name, compression="gzip")
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()


### PR DESCRIPTION
This PR should fix the random deadlock on `test_to_csv.py`

The problem has manifested in a couple unrelated PRs, namely:
`https://github.com/duckdb/duckdb/actions/runs/4129399926/jobs/7141659107`

Steps taken to (hopefully) address the issue:
- make all tests use their own duckdb connection
- switching from using `tempfile` directly, make use of `tmp_path` fixture provided by `pytest`