### PR TITLE
fixes #6159

### DIFF
--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java
@@ -662,8 +662,8 @@ public class DuckDBDatabaseMetaData implements DatabaseMetaData {
 			stringBuilder.append("'");
 			if (first) {
 				stringBuilder.append(" AS 'TABLE_TYPE'");
+				first = false;
 			}
-			first = false;
 		}
 		stringBuilder.append("\nORDER BY TABLE_TYPE");
 		return conn.createStatement().executeQuery(stringBuilder.toString());

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java
@@ -650,8 +650,23 @@ public class DuckDBDatabaseMetaData implements DatabaseMetaData {
 
 	@Override
 	public ResultSet getTableTypes() throws SQLException {
-		return conn.createStatement().executeQuery(
-				"SELECT DISTINCT table_type AS 'TABLE_TYPE' FROM information_schema.tables ORDER BY \"TABLE_TYPE\"");
+		String[] tableTypesArray = new String[]{"BASE TABLE", "LOCAL TEMPORARY", "VIEW"};
+		StringBuilder stringBuilder = new StringBuilder();
+		boolean first = true;
+		for (String tableType : tableTypesArray) {
+			if (!first) {
+				stringBuilder.append("\nUNION ALL\n");
+			}
+			stringBuilder.append("SELECT '");
+			stringBuilder.append(tableType);
+			stringBuilder.append("'");
+			if (first) {
+				stringBuilder.append(" AS 'TABLE_TYPE'");
+			}
+			first = false;
+		}
+		stringBuilder.append("\nORDER BY TABLE_TYPE");
+		return conn.createStatement().executeQuery(stringBuilder.toString());
 	}
 
 	@Override

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -21,9 +21,11 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
 import java.util.TimeZone;
 import java.time.LocalDateTime;
@@ -1810,6 +1812,24 @@ public class TestDuckDBJDBC {
 		conn.close();
 	}
 
+	public static void test_getTableTypes() throws Exception {
+		String[] tableTypesArray = new String[]{"BASE TABLE", "LOCAL TEMPORARY", "VIEW"};
+		List<String> tableTypesList = new ArrayList(Arrays.asList(tableTypesArray));
+
+		Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+		DatabaseMetaData databaseMetaData = conn.getMetaData();
+		ResultSet rs = databaseMetaData.getTableTypes();
+		while (rs.next()) {
+			String tableType = rs.getString("TABLE_TYPE");
+			assertTrue(tableTypesList.remove(tableType), "getTableTypes() result should include " + tableType);
+		}
+		rs.close();
+		assertTrue(
+			tableTypesList.size() == 0, 
+			"DatabaseMetaData.getTableTypes() should return " + String.join(",", tableTypesArray)
+		);
+	}
+	
 	public static void test_connect_wrong_url_bug848() throws Exception {
 		Driver d = new DuckDBDriver();
 		assertNull(d.connect("jdbc:h2:", null));


### PR DESCRIPTION
fixes #6159

Added test for DatabaseMetaData.getTableTypes()
Test reproduces https://github.com/duckdb/duckdb/issues/6159 
getTableTypes now returns a static list.