### PR TITLE
Fix Python deadlock - execute all PyRelations through the shared execute loop, and throw exception if Pandas Scan is called while GIL is held

### DIFF
--- a/src/include/duckdb/main/relation.hpp
+++ b/src/include/duckdb/main/relation.hpp
@@ -117,18 +117,26 @@ public:
 	DUCKDB_API shared_ptr<Relation> Alias(const string &alias);
 
 	//! Insert the data from this relation into a table
+	DUCKDB_API shared_ptr<Relation> InsertRel(const string &schema_name, const string &table_name);
 	DUCKDB_API void Insert(const string &table_name);
 	DUCKDB_API void Insert(const string &schema_name, const string &table_name);
 	//! Insert a row (i.e.,list of values) into a table
 	DUCKDB_API void Insert(const vector<vector<Value>> &values);
 	//! Create a table and insert the data from this relation into that table
+	DUCKDB_API shared_ptr<Relation> CreateRel(const string &schema_name, const string &table_name);
 	DUCKDB_API void Create(const string &table_name);
 	DUCKDB_API void Create(const string &schema_name, const string &table_name);
 
 	//! Write a relation to a CSV file
+	DUCKDB_API shared_ptr<Relation>
+	WriteCSVRel(const string &csv_file,
+	            case_insensitive_map_t<vector<Value>> options = case_insensitive_map_t<vector<Value>>());
 	DUCKDB_API void WriteCSV(const string &csv_file,
 	                         case_insensitive_map_t<vector<Value>> options = case_insensitive_map_t<vector<Value>>());
 	//! Write a relation to a Parquet file
+	DUCKDB_API shared_ptr<Relation>
+	WriteParquetRel(const string &parquet_file,
+	                case_insensitive_map_t<vector<Value>> options = case_insensitive_map_t<vector<Value>>());
 	DUCKDB_API void
 	WriteParquet(const string &parquet_file,
 	             case_insensitive_map_t<vector<Value>> options = case_insensitive_map_t<vector<Value>>());

--- a/tools/pythonpkg/src/pandas/scan.cpp
+++ b/tools/pythonpkg/src/pandas/scan.cpp
@@ -84,6 +84,9 @@ unique_ptr<FunctionData> PandasScanFunction::PandasScanBind(ClientContext &conte
 
 unique_ptr<GlobalTableFunctionState> PandasScanFunction::PandasScanInitGlobal(ClientContext &context,
                                                                               TableFunctionInitInput &input) {
+	if (PyGILState_Check()) {
+		throw InvalidInputException("PandasScan called but GIL was already held!");
+	}
 	return make_unique<PandasScanGlobalState>(PandasScanMaxThreads(context, input.bind_data));
 }
 


### PR DESCRIPTION
Executing all relations through a common interface will also allow cancellation of write_csv, etc using Ctrl+C. 

We also add an exception to `pandas_scan` so if it is called while the GIL is held an exception is thrown.