### PR TITLE
Fuzzer fixes 2, 3 and 5 of #5984

### DIFF
--- a/src/function/aggregate/holistic/quantile.cpp
+++ b/src/function/aggregate/holistic/quantile.cpp
@@ -1216,6 +1216,9 @@ static const Value &CheckQuantile(const Value &quantile_val) {
 	if (quantile < -1 || quantile > 1) {
 		throw BinderException("QUANTILE can only take parameters in the range [-1, 1]");
 	}
+	if (Value::IsNan(quantile)) {
+		throw BinderException("QUANTILE parameter cannot be NaN");
+	}
 
 	return quantile_val;
 }

--- a/src/function/scalar/date/strftime.cpp
+++ b/src/function/scalar/date/strftime.cpp
@@ -258,7 +258,7 @@ char *StrfTimeFormat::WriteDateSpecifier(StrTimeSpecifier specifier, date_t date
 	return target;
 }
 
-char *StrfTimeFormat::WriteStandardSpecifier(StrTimeSpecifier specifier, int32_t data[], const char *tz_name,
+char *StrfTimeFormat::WriteStandardSpecifier(StrTimeSpecifier specifier, int32_t data[], const char *tz_name, size_t tz_len,
                                              char *target) {
 	// data contains [0] year, [1] month, [2] day, [3] hour, [4] minute, [5] second, [6] msec, [7] utc
 	switch (specifier) {
@@ -338,7 +338,7 @@ char *StrfTimeFormat::WriteStandardSpecifier(StrTimeSpecifier specifier, int32_t
 	}
 	case StrTimeSpecifier::TZ_NAME:
 		if (tz_name) {
-			strncpy(target, tz_name, strlen(tz_name));
+			memcpy(target, tz_name, tz_len);
 			target += strlen(tz_name);
 		}
 		break;
@@ -391,7 +391,8 @@ void StrfTimeFormat::FormatString(date_t date, int32_t data[8], const char *tz_n
 		if (is_date_specifier[i]) {
 			target = WriteDateSpecifier(specifiers[i], date, target);
 		} else {
-			target = WriteStandardSpecifier(specifiers[i], data, tz_name, target);
+			auto tz_len = tz_name ? strlen(tz_name) : 0;
+			target = WriteStandardSpecifier(specifiers[i], data, tz_name, tz_len, target);
 		}
 	}
 	// copy the final literal into the target

--- a/src/function/scalar/date/strftime.cpp
+++ b/src/function/scalar/date/strftime.cpp
@@ -258,8 +258,8 @@ char *StrfTimeFormat::WriteDateSpecifier(StrTimeSpecifier specifier, date_t date
 	return target;
 }
 
-char *StrfTimeFormat::WriteStandardSpecifier(StrTimeSpecifier specifier, int32_t data[], const char *tz_name, size_t tz_len,
-                                             char *target) {
+char *StrfTimeFormat::WriteStandardSpecifier(StrTimeSpecifier specifier, int32_t data[], const char *tz_name,
+                                             size_t tz_len, char *target) {
 	// data contains [0] year, [1] month, [2] day, [3] hour, [4] minute, [5] second, [6] msec, [7] utc
 	switch (specifier) {
 	case StrTimeSpecifier::DAY_OF_MONTH_PADDED:

--- a/src/function/scalar/date/strftime.cpp
+++ b/src/function/scalar/date/strftime.cpp
@@ -338,7 +338,7 @@ char *StrfTimeFormat::WriteStandardSpecifier(StrTimeSpecifier specifier, int32_t
 	}
 	case StrTimeSpecifier::TZ_NAME:
 		if (tz_name) {
-			memcpy(target, tz_name, strlen(tz_name));
+			strncpy(target, tz_name, strlen(tz_name));
 			target += strlen(tz_name);
 		}
 		break;

--- a/src/function/scalar/date/strftime.cpp
+++ b/src/function/scalar/date/strftime.cpp
@@ -338,7 +338,7 @@ char *StrfTimeFormat::WriteStandardSpecifier(StrTimeSpecifier specifier, int32_t
 	}
 	case StrTimeSpecifier::TZ_NAME:
 		if (tz_name) {
-			strcpy(target, tz_name);
+			memcpy(target, tz_name, strlen(tz_name));
 			target += strlen(tz_name);
 		}
 		break;

--- a/src/include/duckdb/function/scalar/strftime.hpp
+++ b/src/include/duckdb/function/scalar/strftime.hpp
@@ -112,7 +112,7 @@ protected:
 	char *WritePadded(char *target, uint32_t value, size_t padding);
 	bool IsDateSpecifier(StrTimeSpecifier specifier);
 	char *WriteDateSpecifier(StrTimeSpecifier specifier, date_t date, char *target);
-	char *WriteStandardSpecifier(StrTimeSpecifier specifier, int32_t data[], const char *tz_name, char *target);
+	char *WriteStandardSpecifier(StrTimeSpecifier specifier, int32_t data[], const char *tz_name, size_t tz_len, char *target);
 };
 
 struct StrpTimeFormat : public StrTimeFormat {

--- a/src/include/duckdb/function/scalar/strftime.hpp
+++ b/src/include/duckdb/function/scalar/strftime.hpp
@@ -112,7 +112,8 @@ protected:
 	char *WritePadded(char *target, uint32_t value, size_t padding);
 	bool IsDateSpecifier(StrTimeSpecifier specifier);
 	char *WriteDateSpecifier(StrTimeSpecifier specifier, date_t date, char *target);
-	char *WriteStandardSpecifier(StrTimeSpecifier specifier, int32_t data[], const char *tz_name, size_t tz_len, char *target);
+	char *WriteStandardSpecifier(StrTimeSpecifier specifier, int32_t data[], const char *tz_name, size_t tz_len,
+	                             char *target);
 };
 
 struct StrpTimeFormat : public StrTimeFormat {

--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -83,7 +83,7 @@ public:
 
 	//! Adds a base table with the given alias to the BindContext.
 	void AddBaseTable(idx_t index, const string &alias, const vector<string> &names, const vector<LogicalType> &types,
-	                  vector<column_t> &bound_column_ids, StandardEntry *entry);
+	                  vector<column_t> &bound_column_ids, StandardEntry *entry, bool add_row_id = true);
 	//! Adds a call to a table function with the given alias to the BindContext.
 	void AddTableFunction(idx_t index, const string &alias, const vector<string> &names,
 	                      const vector<LogicalType> &types, vector<column_t> &bound_column_ids, StandardEntry *entry);

--- a/src/include/duckdb/planner/expression_binder/returning_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/returning_binder.hpp
@@ -20,10 +20,6 @@ public:
 protected:
 	BindResult BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth,
 	                          bool root_expression = false) override;
-
-	// check certain column ref Names to make sure they are supported in the returning statement
-	// (i.e rowid)
-	BindResult BindColumnRef(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth);
 };
 
 } // namespace duckdb

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -454,8 +454,8 @@ void BindContext::AddBinding(const string &alias, unique_ptr<Binding> binding) {
 
 void BindContext::AddBaseTable(idx_t index, const string &alias, const vector<string> &names,
                                const vector<LogicalType> &types, vector<column_t> &bound_column_ids,
-                               StandardEntry *entry) {
-	AddBinding(alias, make_unique<TableBinding>(alias, types, names, bound_column_ids, entry, index, true));
+                               StandardEntry *entry, bool add_row_id) {
+	AddBinding(alias, make_unique<TableBinding>(alias, types, names, bound_column_ids, entry, index, add_row_id));
 }
 
 void BindContext::AddTableFunction(idx_t index, const string &alias, const vector<string> &names,

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -449,7 +449,7 @@ BoundStatement Binder::BindReturning(vector<unique_ptr<ParsedExpression>> return
 		column_count++;
 	}
 
-	binder->bind_context.AddBaseTable(update_table_index, table->name, names, types, bound_columns, table);
+	binder->bind_context.AddBaseTable(update_table_index, table->name, names, types, bound_columns, table, false);
 	ReturningBinder returning_binder(*binder, context);
 
 	vector<unique_ptr<Expression>> projection_expressions;

--- a/src/planner/expression_binder/returning_binder.cpp
+++ b/src/planner/expression_binder/returning_binder.cpp
@@ -7,14 +7,6 @@ namespace duckdb {
 ReturningBinder::ReturningBinder(Binder &binder, ClientContext &context) : ExpressionBinder(binder, context) {
 }
 
-BindResult ReturningBinder::BindColumnRef(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth) {
-	auto &expr = **expr_ptr;
-	if (expr.GetName() == "rowid") {
-		return BindResult("rowid is not supported in returning statements");
-	}
-	return ExpressionBinder::BindExpression(expr_ptr, depth);
-}
-
 BindResult ReturningBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
 	auto &expr = **expr_ptr;
 	switch (expr.GetExpressionClass()) {
@@ -23,7 +15,7 @@ BindResult ReturningBinder::BindExpression(unique_ptr<ParsedExpression> *expr_pt
 	case ExpressionClass::BOUND_SUBQUERY:
 		return BindResult("BOUND SUBQUERY is not supported in returning statements");
 	case ExpressionClass::COLUMN_REF:
-		return BindColumnRef(expr_ptr, depth);
+		return ExpressionBinder::BindExpression(expr_ptr, depth);
 	default:
 		return ExpressionBinder::BindExpression(expr_ptr, depth);
 	}

--- a/test/fuzzer/pedro/returning_clause_with_rowid.test
+++ b/test/fuzzer/pedro/returning_clause_with_rowid.test
@@ -3,40 +3,37 @@
 # group: [pedro]
 
 statement ok
-PRAGMA enable_verification
-
-statement ok
 CREATE TABLE t0 (c0 INT);
 
 statement error
 INSERT INTO t0 VALUES (1) RETURNING c0, rowid;
 ----
-Binder Error: rowid is not supported in returning statements
+Binder Error: Referenced column "rowid" not found in FROM clause!
 
 statement error
 INSERT INTO t0 VALUES (1), (2), (3) RETURNING *, rowid;
 ----
-Binder Error: rowid is not supported in returning statements
+Binder Error: Referenced column "rowid" not found in FROM clause!
 
 statement error
 INSERT INTO t0 VALUES (4) RETURNING c0 + rowid;
 ----
-Binder Error: rowid is not supported in returning statements
+Binder Error: Referenced column "rowid" not found in FROM clause!
 
 statement error
 INSERT INTO t0 VALUES (1) RETURNING rowid c2;
 ----
-Binder Error: rowid is not supported in returning statements
+Binder Error: Referenced column "rowid" not found in FROM clause!
 
 statement error
 UPDATE t0 SET c0 = 5 WHERE c0 = 0 RETURNING rowid;
 ----
-Binder Error: rowid is not supported in returning statements
+Binder Error: Referenced column "rowid" not found in FROM clause!
 
 statement error
 DELETE FROM t0 WHERE c0 = 0 RETURNING rowid;
 ----
-Binder Error: rowid is not supported in returning statements
+Binder Error: Referenced column "rowid" not found in FROM clause!
 
 # make sure you can still return the alias rowid
 # More tests could be written, but the returning binder doesn't allow
@@ -52,3 +49,12 @@ Binder Error: Aggregate functions are not supported here
 
 statement ok
 select struct_pack(row_id := 42);
+
+# Additional test case from bug nr 5 of https://github.com/duckdb/duckdb/issues/5984
+statement ok
+CREATE TABLE t1 (c1 AS ('abc'), c2 INT);
+
+statement error
+INSERT INTO t1 SELECT 1 RETURNING rowid c1;
+----
+Binder Error: Referenced column "rowid" not found in FROM clause!

--- a/test/sql/aggregate/aggregates/test_ordered_aggregates.test
+++ b/test/sql/aggregate/aggregates/test_ordered_aggregates.test
@@ -117,6 +117,10 @@ select percentile_cont() within group(order by i) from generate_series(0,100) tb
 statement error
 select percentile_cont(0.25, 0.5) within group(order by i) from generate_series(0,100) tbl(i);
 
+# NaN is not allowed
+statement error
+SELECT percentile_disc(CAST('NaN' AS REAL)) WITHIN GROUP (ORDER BY 1);
+
 # Wrong number of arguments for MODE
 statement error
 select mode(0.25) within group(order by i) from generate_series(0,100) tbl(i);

--- a/test/sql/function/timestamp/test_icu_strftime.test
+++ b/test/sql/function/timestamp/test_icu_strftime.test
@@ -266,3 +266,24 @@ endloop
 #
 statement error
 SELECT ts, strftime(ts, '%C') FROM timestamps;
+
+#
+# Tests for fix of nr3 in list of https://github.com/duckdb/duckdb/issues/5984
+#
+statement ok
+PRAGMA TIMEZONE='Asia/Baghdad';
+SELECT strftime(TIMESTAMPTZ '-268535-1-1 0:0:0 America/Pangnirtung','%Z');
+
+statement ok
+PRAGMA TIMEZONE='Asia/Baghdad';
+SELECT strftime(TIMESTAMPTZ '-268535-1-1 0:0:0 America/Pangnirtung','%Z');
+
+statement ok
+PRAGMA TIMEZONE='Pacific/Truk';
+SELECT strftime(TIMESTAMPTZ '-217208-11-5 1:47:22 America/Merida','%Z');
+
+statement ok
+SELECT strftime(TIMESTAMPTZ '-204873-8-9 6:35:55 America/North_Dakota/Beulah','x%Z');
+
+statement ok
+SELECT strftime(TIMESTAMPTZ '292555-4-29 18:38:18 Asia/Damascus','e%Z');


### PR DESCRIPTION
This PR resolves issues 2, 3 and 5 of #5984

2: Percentile value should be between 0 and 1, NaN was not handled and would make stuff crash
3: strcpy of a non-null terminated string would cause problems, needed some minor gymnastics to avoid clang-tidy complaining as it doesn't like when you don't null terminate what looks like a c string.

5: Continuation of https://github.com/duckdb/duckdb/pull/5267. In that PR the issue appeared to be fixed, but it was hidden due to the fact the query_verification pragma in the test messes with the aliasing. I resolved this by removing the custom error message (as it was actually both having false positives as not working when aliased) and passing row_id = false to AddBaseTable.
