### PR TITLE
No lambdas in CHECK constraint and generated columns

### DIFF
--- a/src/parser/column_definition.cpp
+++ b/src/parser/column_definition.cpp
@@ -162,6 +162,9 @@ static void InnerGetListOfDependencies(ParsedExpression &expr, vector<string> &d
 		dependencies.push_back(name);
 	}
 	ParsedExpressionIterator::EnumerateChildren(expr, [&](const ParsedExpression &child) {
+		if (expr.type == ExpressionType::LAMBDA) {
+			throw NotImplementedException("Lambda functions are currently not supported in generated columns.");
+		}
 		InnerGetListOfDependencies((ParsedExpression &)child, dependencies);
 	});
 }

--- a/src/planner/expression_binder/check_binder.cpp
+++ b/src/planner/expression_binder/check_binder.cpp
@@ -42,6 +42,19 @@ BindResult ExpressionBinder::BindQualifiedColumnName(ColumnRefExpression &colref
 }
 
 BindResult CheckBinder::BindCheckColumn(ColumnRefExpression &colref) {
+
+	// if this is a lambda parameters, then we temporarily add a BoundLambdaRef,
+	// which we capture and remove later
+	if (lambda_bindings) {
+		for (idx_t i = 0; i < lambda_bindings->size(); i++) {
+			if (colref.GetColumnName() == (*lambda_bindings)[i].dummy_name) {
+				// FIXME: support lambdas in CHECK constraints
+				// FIXME: like so: return (*lambda_bindings)[i].Bind(colref, i, depth);
+				throw NotImplementedException("Lambda functions are currently not supported in CHECK constraints.");
+			}
+		}
+	}
+
 	if (colref.column_names.size() > 1) {
 		return BindQualifiedColumnName(colref, table);
 	}

--- a/src/planner/expression_binder/check_binder.cpp
+++ b/src/planner/expression_binder/check_binder.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/planner/expression_binder/check_binder.hpp"
 
+#include "duckdb/planner/table_binding.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 

--- a/test/sql/function/list/lambdas/incorrect.test
+++ b/test/sql/function/list/lambdas/incorrect.test
@@ -107,3 +107,43 @@ SELECT cos(x -> x + 1)
 
 statement error
 SELECT cos([1], x -> x + 1)
+
+# don't allow lambdas in check constraints
+# FIXME: support lambdas in CHECK constraints
+
+statement error
+create table lambda_check (i BIGINT[],
+    CHECK (list_filter(i, x -> x % 2 = 0) == []));
+----
+Not implemented Error: Lambda functions are currently not supported in CHECK constraints.
+
+statement error
+create table lambda_check (i BIGINT[],
+    CHECK (list_transform(i, x -> x % 2) == []));
+----
+Not implemented Error: Lambda functions are currently not supported in CHECK constraints.
+
+statement error
+create table lambda_check (i BIGINT[],
+    CHECK ([x + 1 for x in i if i > 0] == []));
+----
+Not implemented Error: Lambda functions are currently not supported in CHECK constraints.
+
+statement error
+create table lambda_check (
+	i BIGINT[],
+	j BIGINT[],
+	CHECK ((list_apply(i, x -> list_count(list_filter(j, y -> y%2=0)) + x)) == []));
+----
+Not implemented Error: Lambda functions are currently not supported in CHECK constraints.
+
+# don't allow lambdas in check constraints
+# FIXME: allow lambdas in generated columns
+
+statement error
+CREATE TABLE unit2(
+	price INTEGER[],
+	total_price INTEGER GENERATED ALWAYS AS (list_transform(price, x -> x + 1)) VIRTUAL
+);
+----
+Not implemented Error: Lambda functions are currently not supported in generated columns.

--- a/test/sql/function/list/lambdas/transform.test
+++ b/test/sql/function/list/lambdas/transform.test
@@ -287,3 +287,23 @@ from (select list(b) over wind as bb, first(b) over wind as b
 [[4, 4], [2, 4], [3, 4], [4, 4], [2, 4]]	[4, 2, 3, 4, 2]	4
 [[2, 2], [3, 2], [4, 2], [2, 2], [3, 2]]	[2, 3, 4, 2, 3]	2
 [[3, 3], [4, 3], [2, 3], [3, 3], [4, 3]]	[3, 4, 2, 3, 4]	3
+
+query I
+SELECT list_transform([[2, 3], [4]], x -> list_transform([42], y -> y + 1))
+----
+[[43], [43]]
+
+query I
+SELECT list_transform([[2, 3], [4]], x -> list_transform(x, y -> y + 1))
+----
+[[3, 4], [5]]
+
+query I
+SELECT list_transform([[2, 3], [4]], x -> list_transform([1], y -> x || [y]))
+----
+[[[2, 3, 1]], [[4, 1]]]
+
+query I
+SELECT list_transform([[2, 3], [4]], x -> list_transform(x, y -> x || [y]))
+----
+[[[2, 3, 2], [2, 3, 3]], [[4, 4]]]


### PR DESCRIPTION
Throw a binder exception when people try to use lambda functions in CHECK constraints or generated columns.