### PR TITLE
Fuzzer 16: Between type mismatch 

### DIFF
--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -582,7 +582,7 @@ FilterResult FilterCombiner::AddBoundComparisonFilter(Expression *expr) {
 	    comparison.type != ExpressionType::COMPARE_GREATERTHAN &&
 	    comparison.type != ExpressionType::COMPARE_GREATERTHANOREQUALTO &&
 	    comparison.type != ExpressionType::COMPARE_EQUAL && comparison.type != ExpressionType::COMPARE_NOTEQUAL) {
-		// only support [>, >=, <, <=, ==] expressions
+		// only support [>, >=, <, <=, ==, !=] expressions
 		return FilterResult::UNSUPPORTED;
 	}
 	// check if one of the sides is a scalar value
@@ -610,6 +610,7 @@ FilterResult FilterCombiner::AddBoundComparisonFilter(Expression *expr) {
 		// get the current bucket of constant values
 		D_ASSERT(constant_values.find(equivalence_set) != constant_values.end());
 		auto &info_list = constant_values.find(equivalence_set)->second;
+		D_ASSERT(node->return_type == info.constant.type());
 		// check the existing constant comparisons to see if we can do any pruning
 		auto ret = AddConstantComparison(info_list, info);
 
@@ -795,7 +796,8 @@ FilterResult FilterCombiner::AddTransitiveFilters(BoundComparisonExpression &com
 			for (auto &stored_exp : stored_expressions) {
 				if (stored_exp.first->type == ExpressionType::BOUND_COLUMN_REF) {
 					auto &st_col_ref = (BoundColumnRefExpression &)*stored_exp.second;
-					if (st_col_ref.binding == col_ref.binding) {
+					if (st_col_ref.binding == col_ref.binding &&
+					    bound_cast_expr.return_type == stored_exp.second->return_type) {
 						bound_cast_expr.child = stored_exp.second->Copy();
 						right_node = GetNode(bound_cast_expr.child.get());
 						break;

--- a/test/fuzzer/pedro/between_type_mismatch.test
+++ b/test/fuzzer/pedro/between_type_mismatch.test
@@ -1,0 +1,12 @@
+# name: test/fuzzer/pedro/between_type_mismatch.test
+# description: Between type mismatch
+# group: [pedro]
+
+statement ok
+PRAGMA enable_verification;
+
+statement ok
+CREATE TABLE t0 (c1 USMALLINT);
+
+statement ok
+SELECT 1 FROM (SELECT 1) t1(c0) JOIN t0 ON c1 BETWEEN c0 AND 1;


### PR DESCRIPTION
Fuzzer issue #5984 no. 16

Problem query:
```
CREATE TABLE t0 (c1 USMALLINT);
SELECT 1 FROM (SELECT 1) t1(c0) JOIN t0 ON c1 BETWEEN c0 AND 1;
——
Assertion : left.GetType() == right.GetType() && result.GetType() == LogicalType::BOOLEAN
```

My findings:
The JOIN condition is split into filter expressions ( c0 <= c1 ) and (c1 <= 1) and after that, 
an additional transitive filter is created to compare c0 with 1.
However the expression (c1 <= 1) seems to have cast the constant’s logical type to USMALLINT in a previous optimizer step, probably because it’s more efficient than casting the entire c1 column.
But this in turn causes a problem when comparing c0 with 1 (INT <= USMALLINT)

My current solution is to only create transitive filters when the logical types match.

This does not solve the second problem query from the fuzzer issue though, so that part still needs fixing :(
```
CREATE TABLE t0 (c0 INT);
SELECT 0 FROM t0 WHERE c0 IN (0) SIMILAR TO decode('a'::BLOB);
```

