### PR TITLE
Fix lambda warning on building

### DIFF
--- a/src/function/scalar/list/list_lambdas.cpp
+++ b/src/function/scalar/list/list_lambdas.cpp
@@ -368,8 +368,9 @@ static unique_ptr<FunctionData> ListFilterBind(ClientContext &context, ScalarFun
 	// try to cast to boolean, if the return type of the lambda filter expression is not already boolean
 	auto &bound_lambda_expr = (BoundLambdaExpression &)*arguments[1];
 	if (bound_lambda_expr.lambda_expr->return_type != LogicalType::BOOLEAN) {
-		bound_lambda_expr.lambda_expr = std::move(BoundCastExpression::AddCastToType(
-		    context, std::move(bound_lambda_expr.lambda_expr), LogicalType::BOOLEAN));
+		auto cast_lambda_expr =
+		    BoundCastExpression::AddCastToType(context, std::move(bound_lambda_expr.lambda_expr), LogicalType::BOOLEAN);
+		bound_lambda_expr.lambda_expr = std::move(cast_lambda_expr);
 	}
 
 	bound_function.return_type = arguments[0]->return_type;


### PR DESCRIPTION
Fixes this warning.
```
tania@laptop duckdb % make debug
mkdir -p build/debug && \
	cd build/debug && \
	cmake       -DDISABLE_VPTR_SANITIZER=1  -DBUILD_PARQUET_EXTENSION=TRUE -DDEBUG_MOVE=1 -DCMAKE_BUILD_TYPE=Debug ../.. && \
	cmake --build . --config Debug
-- git hash c0907528a3, version v0.6.1-dev2608
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/tania/DuckDB/duckdb/build/debug
[2/10] Building CXX object src/function/scalar/list/CMakeFiles/duckdb_func_list.dir/ub_duckdb_func_list.cpp.o
In file included from /Users/tania/DuckDB/duckdb/build/debug/src/function/scalar/list/ub_duckdb_func_list.cpp:2:
/Users/tania/DuckDB/duckdb/src/function/scalar/list/list_lambdas.cpp:371:35: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
                bound_lambda_expr.lambda_expr = std::move(BoundCastExpression::AddCastToType(
                                                ^
/Users/tania/DuckDB/duckdb/src/function/scalar/list/list_lambdas.cpp:371:35: note: remove std::move call here
                bound_lambda_expr.lambda_expr = std::move(BoundCastExpression::AddCastToType(
                                                ^~~~~~~~~~
1 warning generated.
```