### PR TITLE
Python: Make duckdb.sql return results for non-select queries in the form of a ValueRelation

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection.hpp
@@ -76,6 +76,8 @@ public:
 
 	shared_ptr<DuckDBPyConnection> ExecuteMany(const string &query, py::object params = py::list());
 
+	unique_ptr<QueryResult> ExecuteInternal(const string &query, py::object params = py::list(), bool many = false);
+
 	shared_ptr<DuckDBPyConnection> Execute(const string &query, py::object params = py::list(), bool many = false);
 
 	shared_ptr<DuckDBPyConnection> Append(const string &name, DataFrame value);

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -380,7 +380,7 @@ unique_ptr<QueryResult> DuckDBPyConnection::ExecuteInternal(const string &query,
 }
 
 shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Execute(const string &query, py::object params, bool many) {
-	auto res = ExecuteInternal(query, params, many);
+	auto res = ExecuteInternal(query, std::move(params), many);
 	if (res) {
 		auto py_result = make_unique<DuckDBPyResult>();
 		py_result->result = std::move(res);

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -372,7 +372,9 @@ unique_ptr<QueryResult> DuckDBPyConnection::ExecuteInternal(const string &query,
 			}
 		}
 
-		return res;
+		if (!many) {
+			return res;
+		}
 	}
 	return nullptr;
 }

--- a/tools/pythonpkg/tests/fast/api/test_duckdb_query.py
+++ b/tools/pythonpkg/tests/fast/api/test_duckdb_query.py
@@ -14,9 +14,9 @@ class TestDuckDBQuery(object):
         rel = duckdb.query('select * from v3')
         assert rel.fetchall()[0][0] == 168;
 
-        # we can run multiple select statements, but we get no result
-        res = duckdb.query('select 42; select 84;');
-        assert res is None
+        # we can run multiple select statements - we get only the last result
+        res = duckdb.query('select 42; select 84;').fetchall()
+        assert res == [(84,)]
 
     def test_duckdb_from_query(self, duckdb_cursor):
         # duckdb.from_query cannot be used to run arbitrary queries

--- a/tools/pythonpkg/tests/fast/relational_api/test_rapi_query.py
+++ b/tools/pythonpkg/tests/fast/relational_api/test_rapi_query.py
@@ -88,28 +88,31 @@ class TestRAPIQuery(object):
 
     def test_query_non_select_result(self):
         with pytest.raises(duckdb.ParserException, match="syntax error"):
-            duckdb.sql('selec 42')
+            duckdb.query('selec 42')
 
-        res = duckdb.sql('explain select 42').fetchall()
+        res = duckdb.query('explain select 42').fetchall()
         assert len(res) > 0
 
-        res = duckdb.sql('describe select 42::INT AS column_name').fetchall()
+        res = duckdb.query('describe select 42::INT AS column_name').fetchall()
         assert res[0][0] == 'column_name'
 
-        res = duckdb.sql('create or replace table integers(i integer)')
+        res = duckdb.query('create or replace table integers(i integer)')
         assert res is None
 
-        res = duckdb.sql('insert into integers values (42)')
+        res = duckdb.query('insert into integers values (42)')
         assert res is None
 
-        res = duckdb.sql('insert into integers values (84) returning *').fetchall()
+        res = duckdb.query('insert into integers values (84) returning *').fetchall()
         assert res == [(84,)]
 
-        res = duckdb.sql('select * from integers').fetchall()
+        res = duckdb.query('select * from integers').fetchall()
         assert res == [(42,), (84,)]
 
-        res = duckdb.sql('show tables').fetchall()
+        res = duckdb.query('insert into integers select * from range(10000) returning *').fetchall()
+        assert len(res) == 10000
+
+        res = duckdb.query('show tables').fetchall()
         assert len(res) > 0
 
-        res = duckdb.sql('drop table integers')
+        res = duckdb.query('drop table integers')
         assert res is None

--- a/tools/pythonpkg/tests/fast/relational_api/test_rapi_query.py
+++ b/tools/pythonpkg/tests/fast/relational_api/test_rapi_query.py
@@ -86,3 +86,30 @@ class TestRAPIQuery(object):
         result = rel.execute()
         assert(result.fetchall() == [(5,)])
 
+    def test_query_non_select_result(self):
+        with pytest.raises(duckdb.ParserException, match="syntax error"):
+            duckdb.sql('selec 42')
+
+        res = duckdb.sql('explain select 42').fetchall()
+        assert len(res) > 0
+
+        res = duckdb.sql('describe select 42::INT AS column_name').fetchall()
+        assert res[0][0] == 'column_name'
+
+        res = duckdb.sql('create or replace table integers(i integer)')
+        assert res is None
+
+        res = duckdb.sql('insert into integers values (42)')
+        assert res is None
+
+        res = duckdb.sql('insert into integers values (84) returning *').fetchall()
+        assert res == [(84,)]
+
+        res = duckdb.sql('select * from integers').fetchall()
+        assert res == [(42,), (84,)]
+
+        res = duckdb.sql('show tables').fetchall()
+        assert len(res) > 0
+
+        res = duckdb.sql('drop table integers')
+        assert res is None

--- a/tools/pythonpkg/tests/fast/relational_api/test_rapi_query.py
+++ b/tools/pythonpkg/tests/fast/relational_api/test_rapi_query.py
@@ -96,23 +96,23 @@ class TestRAPIQuery(object):
         res = duckdb.query('describe select 42::INT AS column_name').fetchall()
         assert res[0][0] == 'column_name'
 
-        res = duckdb.query('create or replace table integers(i integer)')
+        res = duckdb.query('create or replace table tbl_non_select_result(i integer)')
         assert res is None
 
-        res = duckdb.query('insert into integers values (42)')
+        res = duckdb.query('insert into tbl_non_select_result values (42)')
         assert res is None
 
-        res = duckdb.query('insert into integers values (84) returning *').fetchall()
+        res = duckdb.query('insert into tbl_non_select_result values (84) returning *').fetchall()
         assert res == [(84,)]
 
-        res = duckdb.query('select * from integers').fetchall()
+        res = duckdb.query('select * from tbl_non_select_result').fetchall()
         assert res == [(42,), (84,)]
 
-        res = duckdb.query('insert into integers select * from range(10000) returning *').fetchall()
+        res = duckdb.query('insert into tbl_non_select_result select * from range(10000) returning *').fetchall()
         assert len(res) == 10000
 
         res = duckdb.query('show tables').fetchall()
         assert len(res) > 0
 
-        res = duckdb.query('drop table integers')
+        res = duckdb.query('drop table tbl_non_select_result')
         assert res is None


### PR DESCRIPTION
This makes queries like `duckdb.sql('explain ...')` actually return their results instead of swallowing them.