### PR TITLE
Fix #5983: avoid serializing type as part of numeric statistics (de)serialization

### DIFF
--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -1584,6 +1584,10 @@ bool Value::DefaultTryCastAs(const LogicalType &target_type, bool strict) {
 	return TryCastAs(set, get_input, target_type, strict);
 }
 
+void Value::Reinterpret(LogicalType new_type) {
+	this->type_ = std::move(new_type);
+}
+
 void Value::Serialize(Serializer &main_serializer) const {
 	FieldWriter writer(main_serializer);
 	writer.WriteSerializable(type_);

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -588,7 +588,7 @@ Value Vector::GetValue(const Vector &v_p, idx_t index_p) {
 	auto value = GetValueInternal(v_p, index_p);
 	// set the alias of the type to the correct value, if there is a type alias
 	if (v_p.GetType().HasAlias()) {
-		value.type().CopyAuxInfo(v_p.GetType());
+		value.GetTypeMutable().CopyAuxInfo(v_p.GetType());
 	}
 	if (v_p.GetType().id() != LogicalTypeId::AGGREGATE_STATE && value.type().id() != LogicalTypeId::AGGREGATE_STATE) {
 

--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -63,7 +63,7 @@ public:
 	// move assignment
 	DUCKDB_API Value &operator=(Value &&other) noexcept;
 
-	inline LogicalType &type() {
+	inline LogicalType &GetTypeMutable() {
 		return type_;
 	}
 	inline const LogicalType &type() const {
@@ -220,6 +220,8 @@ public:
 	                          bool strict = false);
 	DUCKDB_API bool TryCastAs(ClientContext &context, const LogicalType &target_type, bool strict = false);
 	DUCKDB_API bool DefaultTryCastAs(const LogicalType &target_type, bool strict = false);
+
+	DUCKDB_API void Reinterpret(LogicalType new_type);
 
 	//! Serializes a Value to a stand-alone binary blob
 	DUCKDB_API void Serialize(Serializer &serializer) const;

--- a/src/storage/statistics/numeric_statistics.cpp
+++ b/src/storage/statistics/numeric_statistics.cpp
@@ -124,15 +124,113 @@ bool NumericStatistics::IsConstant() const {
 	return max <= min;
 }
 
+void SerializeNumericStatsValue(const Value &val, FieldWriter &writer) {
+	writer.WriteField<bool>(val.IsNull());
+	if (val.IsNull()) {
+		return;
+	}
+	switch (val.type().InternalType()) {
+	case PhysicalType::BOOL:
+		writer.WriteField<bool>(BooleanValue::Get(val));
+		break;
+	case PhysicalType::INT8:
+		writer.WriteField<int8_t>(TinyIntValue::Get(val));
+		break;
+	case PhysicalType::INT16:
+		writer.WriteField<int16_t>(SmallIntValue::Get(val));
+		break;
+	case PhysicalType::INT32:
+		writer.WriteField<int32_t>(IntegerValue::Get(val));
+		break;
+	case PhysicalType::INT64:
+		writer.WriteField<int64_t>(BigIntValue::Get(val));
+		break;
+	case PhysicalType::UINT8:
+		writer.WriteField<int8_t>(UTinyIntValue::Get(val));
+		break;
+	case PhysicalType::UINT16:
+		writer.WriteField<int16_t>(USmallIntValue::Get(val));
+		break;
+	case PhysicalType::UINT32:
+		writer.WriteField<int32_t>(UIntegerValue::Get(val));
+		break;
+	case PhysicalType::UINT64:
+		writer.WriteField<int64_t>(UBigIntValue::Get(val));
+		break;
+	case PhysicalType::INT128:
+		writer.WriteField<hugeint_t>(HugeIntValue::Get(val));
+		break;
+	case PhysicalType::FLOAT:
+		writer.WriteField<float>(FloatValue::Get(val));
+		break;
+	case PhysicalType::DOUBLE:
+		writer.WriteField<double>(DoubleValue::Get(val));
+		break;
+	default:
+		throw InternalException("Unsupported type for serializing numeric statistics");
+	}
+}
+
 void NumericStatistics::Serialize(FieldWriter &writer) const {
-	writer.WriteSerializable(min);
-	writer.WriteSerializable(max);
+	SerializeNumericStatsValue(min, writer);
+	SerializeNumericStatsValue(max, writer);
+}
+
+Value DeserializeNumericStatsValue(const LogicalType &type, FieldReader &reader) {
+	auto is_null = reader.ReadRequired<bool>();
+	if (is_null) {
+		return Value(type);
+	}
+	Value result;
+	switch (type.InternalType()) {
+	case PhysicalType::BOOL:
+		result = Value::BOOLEAN(reader.ReadRequired<bool>());
+		break;
+	case PhysicalType::INT8:
+		result = Value::TINYINT(reader.ReadRequired<int8_t>());
+		break;
+	case PhysicalType::INT16:
+		result = Value::SMALLINT(reader.ReadRequired<int16_t>());
+		break;
+	case PhysicalType::INT32:
+		result = Value::INTEGER(reader.ReadRequired<int32_t>());
+		break;
+	case PhysicalType::INT64:
+		result = Value::BIGINT(reader.ReadRequired<int64_t>());
+		break;
+	case PhysicalType::UINT8:
+		result = Value::UTINYINT(reader.ReadRequired<uint8_t>());
+		break;
+	case PhysicalType::UINT16:
+		result = Value::USMALLINT(reader.ReadRequired<uint16_t>());
+		break;
+	case PhysicalType::UINT32:
+		result = Value::UINTEGER(reader.ReadRequired<uint32_t>());
+		break;
+	case PhysicalType::UINT64:
+		result = Value::UBIGINT(reader.ReadRequired<uint64_t>());
+		break;
+	case PhysicalType::INT128:
+		result = Value::HUGEINT(reader.ReadRequired<hugeint_t>());
+		break;
+	case PhysicalType::FLOAT:
+		result = Value::FLOAT(reader.ReadRequired<float>());
+		break;
+	case PhysicalType::DOUBLE:
+		result = Value::DOUBLE(reader.ReadRequired<double>());
+		break;
+	default:
+		throw InternalException("Unsupported type for deserializing numeric statistics");
+	}
+	result.Reinterpret(type);
+	return result;
 }
 
 unique_ptr<BaseStatistics> NumericStatistics::Deserialize(FieldReader &reader, LogicalType type) {
-	auto min = reader.ReadRequiredSerializable<Value, Value>();
-	auto max = reader.ReadRequiredSerializable<Value, Value>();
-	return make_unique_base<BaseStatistics, NumericStatistics>(std::move(type), min, max, StatisticsType::LOCAL_STATS);
+	auto min = DeserializeNumericStatsValue(type, reader);
+	auto max = DeserializeNumericStatsValue(type, reader);
+	return make_unique_base<BaseStatistics, NumericStatistics>(std::move(type), std::move(min), std::move(max),
+	                                                           StatisticsType::LOCAL_STATS);
 }
 
 string NumericStatistics::ToString() const {

--- a/src/storage/storage_info.cpp
+++ b/src/storage/storage_info.cpp
@@ -2,7 +2,7 @@
 
 namespace duckdb {
 
-const uint64_t VERSION_NUMBER = 42;
+const uint64_t VERSION_NUMBER = 43;
 
 struct StorageVersionInfo {
 	const char *version_name;


### PR DESCRIPTION
Fixes #5983

This is a subset of #6040 that reduces the number of times `types` are serialized significantly by no longer serializing types as part of the numeric statistics. This should fix #5983. It does not solve the underlying issue that enums are potentially serialized multiple times, however. That is done in #6040, but that will likely have to wait for the next release.