### PR TITLE
More descriptive error message if we are using a table function as a scalar function

### DIFF
--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -34,8 +34,8 @@ BindResult ExpressionBinder::BindExpression(FunctionExpression &function, idx_t 
 		if (table_func) {
 			throw BinderException(binder.FormatError(
 			    function,
-			    StringUtil::Format("Function \"%s\" is a table-function but it is used as a scalar function. This "
-			                       "function has to be called a FROM clause (similar to a table).",
+			    StringUtil::Format("Function \"%s\" is a table function but it was used as a scalar function. This "
+			                       "function has to be called in a FROM clause (similar to a table).",
 			                       function.function_name)));
 		}
 		// not a table function - search again without if_exists to throw the error

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -26,7 +26,23 @@ BindResult ExpressionBinder::BindExpression(FunctionExpression &function, idx_t 
 		return BindUnnest(function, depth);
 	}
 	auto func = Catalog::GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, function.catalog, function.schema,
-	                              function.function_name, false, error_context);
+	                              function.function_name, true, error_context);
+	if (!func) {
+		// function was not found - check if we this is a table function
+		auto table_func = Catalog::GetEntry(context, CatalogType::TABLE_FUNCTION_ENTRY, function.catalog,
+		                                    function.schema, function.function_name, true, error_context);
+		if (table_func) {
+			throw BinderException(binder.FormatError(
+			    function,
+			    StringUtil::Format("Function \"%s\" is a table-function but it is used as a scalar function. This "
+			                       "function has to be called a FROM clause (similar to a table).",
+			                       function.function_name)));
+		}
+		// not a table function - search again without if_exists to throw the error
+		Catalog::GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, function.catalog, function.schema,
+		                  function.function_name, false, error_context);
+		throw InternalException("Catalog::GetEntry for scalar function did not throw a second time");
+	}
 
 	if (func->type != CatalogType::AGGREGATE_FUNCTION_ENTRY &&
 	    (function.distinct || function.filter || !function.order_bys->orders.empty())) {

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -31,11 +31,11 @@ void MainHeader::Serialize(Serializer &ser) {
 void MainHeader::CheckMagicBytes(FileHandle &handle) {
 	data_t magic_bytes[MAGIC_BYTE_SIZE];
 	if (handle.GetFileSize() < MainHeader::MAGIC_BYTE_SIZE + MainHeader::MAGIC_BYTE_OFFSET) {
-		throw IOException("The file is not a valid DuckDB database file!");
+		throw IOException("The file \"%s\" exists, but it is not a valid DuckDB database file!", handle.path);
 	}
 	handle.Read(magic_bytes, MainHeader::MAGIC_BYTE_SIZE, MainHeader::MAGIC_BYTE_OFFSET);
 	if (memcmp(magic_bytes, MainHeader::MAGIC_BYTES, MainHeader::MAGIC_BYTE_SIZE) != 0) {
-		throw IOException("The file is not a valid DuckDB database file!");
+		throw IOException("The file \"%s\" exists, but it is not a valid DuckDB database file!", handle.path);
 	}
 }
 

--- a/test/sql/error/table_function_as_scalar_function.test
+++ b/test/sql/error/table_function_as_scalar_function.test
@@ -1,0 +1,8 @@
+# name: test/sql/error/table_function_as_scalar_function.test
+# description: Use a table function as a scalar function
+# group: [error]
+
+statement error
+SELECT read_csv('test.csv')
+----
+FROM

--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -425,7 +425,7 @@ SELECT * FROM t1;
 duckdb_nonsense_db = 'duckdbtest_nonsensedb.db'
 with open(duckdb_nonsense_db, 'w+') as f:
      f.write('blablabla')
-test('', err='The file is not a valid DuckDB database file', extra_commands=[duckdb_nonsense_db])
+test('', err='not a valid DuckDB database file', extra_commands=[duckdb_nonsense_db])
 os.remove(duckdb_nonsense_db)
 
 # enable_profiling doesn't result in any output


### PR DESCRIPTION
This PR improves error messages thrown when using table functions as scalar functions, e.g.:

```sql
SELECT read_csv('test.csv')
```

```sql
Binder Error: Function "read_csv" is a table-function but it is used as a scalar function. This function has to be called a FROM clause (similar to a table).
LINE 1: SELECT read_csv('test.csv')
               ^
```