### PR TITLE
Add more tests for fetch* functions, and add support for Pandas-style .describe()

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
@@ -250,6 +250,7 @@ private:
 	                              const string &projected_columns = "", const string &window_function = "");
 	void AssertResult() const;
 	void AssertResultOpen() const;
+	void AssertRelation() const;
 	void ExecuteOrThrow();
 	unique_ptr<QueryResult> ExecuteInternal();
 

--- a/tools/pythonpkg/src/include/duckdb_python/pyresult.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyresult.hpp
@@ -48,6 +48,7 @@ public:
 
 	duckdb::pyarrow::RecordBatchReader FetchRecordBatchReader(idx_t chunk_size);
 
+	static py::list GetDescription(const vector<string> &names, const vector<LogicalType> &types);
 	py::list Description();
 
 	void Close();

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -638,7 +638,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromQuery(const string &query, 
 	const char *duckdb_query_error = R"(duckdb.from_query cannot be used to run arbitrary SQL queries.
 It can only be used to run individual SELECT statements, and converts the result of that SELECT
 statement into a Relation object.
-Use duckdb.query to run arbitrary SQL queries.)";
+Use duckdb.sql to run arbitrary SQL queries.)";
 	return make_unique<DuckDBPyRelation>(connection->RelationFromQuery(query, alias, duckdb_query_error));
 }
 

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -214,7 +214,7 @@ py::list DuckDBPyRelation::Description() {
 }
 
 struct DescribeAggregateInfo {
-	DescribeAggregateInfo(string name_p, bool numeric_only = false)
+	explicit DescribeAggregateInfo(string name_p, bool numeric_only = false)
 	    : name(std::move(name_p)), numeric_only(numeric_only) {
 	}
 

--- a/tools/pythonpkg/src/pyresult.cpp
+++ b/tools/pythonpkg/src/pyresult.cpp
@@ -364,17 +364,19 @@ py::str GetTypeToPython(const LogicalType &type) {
 	}
 }
 
-py::list DuckDBPyResult::Description() {
-	const auto names = result->names;
-
-	py::list desc(names.size());
+py::list DuckDBPyResult::GetDescription(const vector<string> &names, const vector<LogicalType> &types) {
+	py::list desc;
 
 	for (idx_t col_idx = 0; col_idx < names.size(); col_idx++) {
 		auto py_name = py::str(names[col_idx]);
-		auto py_type = GetTypeToPython(result->types[col_idx]);
-		desc[col_idx] = py::make_tuple(py_name, py_type, py::none(), py::none(), py::none(), py::none(), py::none());
+		auto py_type = GetTypeToPython(types[col_idx]);
+		desc.append(py::make_tuple(py_name, py_type, py::none(), py::none(), py::none(), py::none(), py::none()));
 	}
 	return desc;
+}
+
+py::list DuckDBPyResult::Description() {
+	return GetDescription(result->names, result->types);
 }
 
 void DuckDBPyResult::Close() {

--- a/tools/pythonpkg/tests/fast/api/test_dbapi00.py
+++ b/tools/pythonpkg/tests/fast/api/test_dbapi00.py
@@ -34,8 +34,8 @@ class TestSimpleDBAPI(object):
         assert_result_equal(list_of_results)
         res = duckdb_cursor.fetchmany(2)
         assert(len(res) == 0)
-        with pytest.raises(duckdb.InvalidInputException):
-            res = duckdb_cursor.fetchmany(3)
+        res = duckdb_cursor.fetchmany(3)
+        assert(len(res) == 0)
 
     def test_fetchmany(self, duckdb_cursor):
         # Get truth value
@@ -59,8 +59,8 @@ class TestSimpleDBAPI(object):
         assert(iteration_count == expected_iteration_count)
         assert(len(list_of_results) == truth_value)
         assert_result_equal(list_of_results)
-        with pytest.raises(duckdb.InvalidInputException):
-            res = duckdb_cursor.fetchmany(3)
+        res = duckdb_cursor.fetchmany(3)
+        assert(len(res) == 0)
 
     def test_fetchmany_too_many(self, duckdb_cursor):
         truth_value = len(duckdb_cursor.execute('select * from integers').fetchall())
@@ -70,8 +70,8 @@ class TestSimpleDBAPI(object):
         assert_result_equal(res)
         res = duckdb_cursor.fetchmany(2)
         assert(len(res) == 0)
-        with pytest.raises(duckdb.InvalidInputException):
-            res = duckdb_cursor.fetchmany(3)
+        res = duckdb_cursor.fetchmany(3)
+        assert(len(res) == 0)
 
     def test_numpy_selection(self, duckdb_cursor):
         duckdb_cursor.execute('SELECT * FROM integers')

--- a/tools/pythonpkg/tests/fast/api/test_dbapi_fetch.py
+++ b/tools/pythonpkg/tests/fast/api/test_dbapi_fetch.py
@@ -1,0 +1,81 @@
+import duckdb
+import pytest
+
+class TestDBApiFetch(object):
+    def test_multiple_fetch_one(self, duckdb_cursor):
+        con = duckdb.connect()
+        c = con.execute('SELECT 42')
+        assert c.fetchone() == (42,)
+        assert c.fetchone() is None
+        assert c.fetchone() is None
+
+    def test_multiple_fetch_all(self, duckdb_cursor):
+        con = duckdb.connect()
+        c = con.execute('SELECT 42')
+        assert c.fetchall() == [(42,)]
+        assert c.fetchall() == []
+        assert c.fetchall() == []
+
+    def test_multiple_fetch_many(self, duckdb_cursor):
+        con = duckdb.connect()
+        c = con.execute('SELECT 42')
+        assert c.fetchmany(1000) == [(42,)]
+        assert c.fetchmany(1000) == []
+        assert c.fetchmany(1000) == []
+
+    def test_multiple_fetch_df(self, duckdb_cursor):
+        pd = pytest.importorskip("pandas")
+        con = duckdb.connect()
+        c = con.execute('SELECT 42::BIGINT AS a')
+        pd.testing.assert_frame_equal(c.df(), pd.DataFrame.from_dict({'a': [42]}))
+        assert c.df() is None
+        assert c.df() is None
+
+    def test_multiple_fetch_arrow(self, duckdb_cursor):
+        pd = pytest.importorskip("pandas")
+        arrow = pytest.importorskip("pyarrow")
+        con = duckdb.connect()
+        c = con.execute('SELECT 42::BIGINT AS a')
+        df = c.arrow().to_pandas()
+        pd.testing.assert_frame_equal(df, pd.DataFrame.from_dict({'a': [42]}))
+        assert c.arrow() is None
+        assert c.arrow() is None
+
+    def test_multiple_close(self, duckdb_cursor):
+        con = duckdb.connect()
+        c = con.execute('SELECT 42')
+        c.close()
+        c.close()
+        c.close()
+        with pytest.raises(duckdb.InvalidInputException, match='No open result set'):
+            c.fetchall()
+
+    def test_multiple_fetch_all_relation(self, duckdb_cursor):
+        res = duckdb.query('SELECT 42')
+        assert res.fetchall() == [(42,)]
+        assert res.fetchall() == [(42,)]
+        assert res.fetchall() == [(42,)]
+
+    def test_multiple_fetch_many_relation(self, duckdb_cursor):
+        res = duckdb.query('SELECT 42')
+        assert res.fetchmany(10000) == [(42,)]
+        assert res.fetchmany(10000) == []
+        assert res.fetchmany(10000) == []
+
+    def test_fetch_one_relation(self, duckdb_cursor):
+        res = duckdb.query('SELECT * FROM range(3)')
+        assert res.fetchone() == (0,)
+        assert res.fetchone() == (1,)
+        assert res.fetchone() == (2,)
+        assert res.fetchone() is None
+        assert res.fetchone() is None
+        assert res.fetchone() is None
+        assert res.fetchall() == []
+        # we can execute explicitly to reset the result
+        res.execute()
+        assert res.fetchone() == (0,)
+        res.execute()
+        assert res.fetchone() == (0,)
+        assert res.fetchone() == (1,)
+        assert res.fetchone() == (2,)
+        assert res.fetchone() is None

--- a/tools/pythonpkg/tests/fast/relational_api/test_rapi_aggregations.py
+++ b/tools/pythonpkg/tests/fast/relational_api/test_rapi_aggregations.py
@@ -194,4 +194,4 @@ class TestRAPIAggregations(object):
         aggregation_generic(table.sem,[[(0.35355339059327373,)], [(0.35355339059327373, 0.38890872965260104)]])
 
     def test_describe(self, table):
-        assert table.describe().fetchall() == [('[Min: 1, Max: 2][Has Null: true, Has No Null: true][Approx Unique: 2]', '[Min: 2.10, Max: 3.20][Has Null: true, Has No Null: true][Approx Unique: 2]', '[Min: a, Max: b, Has Unicode: false, Max String Length: 1][Has Null: true, Has No Null: true][Approx Unique: 2]')]
+        assert table.describe().fetchall() is not None

--- a/tools/pythonpkg/tests/fast/relational_api/test_rapi_description.py
+++ b/tools/pythonpkg/tests/fast/relational_api/test_rapi_description.py
@@ -15,29 +15,27 @@ class TestRAPIDescription(object):
         pd = pytest.importorskip("pandas")
         res = duckdb.query('select 42::INT AS a, 84::BIGINT AS b')
         duck_describe = res.describe().df()
-        pandas_describe = res.df().describe()
-        for name in ['a', 'b']:
-            np.testing.assert_array_equal(np.array(duck_describe[name]), np.array(pandas_describe[name]))
+        np.testing.assert_array_equal(duck_describe['aggr'], ['count', 'mean', 'stddev', 'min', 'max', 'median'])
+        np.testing.assert_array_equal(duck_describe['a'], [1, 42, float('nan'), 42, 42, 42])
+        np.testing.assert_array_equal(duck_describe['b'], [1, 84, float('nan'), 84, 84, 84])
 
         # now with more values
         res = duckdb.query('select CASE WHEN i%2=0 THEN i ELSE NULL END AS i, i * 10 AS j, (i * 23 / 27)::DOUBLE AS k FROM range(10000) t(i)')
         duck_describe = res.describe().df()
-        pandas_describe = res.df().describe()
-        for name in ['i', 'j', 'k']:
-            np.testing.assert_allclose(np.array(duck_describe[name]), np.array(pandas_describe[name]))
+        np.testing.assert_allclose(duck_describe['i'], [5000.0, 4999.0, 2887.0400066504103, 0.0, 9998.0, 4999.0])
+        np.testing.assert_allclose(duck_describe['j'], [10000.0, 49995.0, 28868.956799071675, 0.0, 99990.0, 49995.0])
+        np.testing.assert_allclose(duck_describe['k'], [10000.0, 4258.3518, 2459.207430770227, 0.0, 8517.0, 4258.5])
 
         # describe data with other (non-numeric) types
         res = duckdb.query("select 'hello world' AS a, [1, 2, 3] AS b")
         duck_describe = res.describe().df()
-        np.testing.assert_array_equal(duck_describe['a'], [1, 'hello world', 1])
-        np.testing.assert_array_equal(duck_describe['b'], [1, '[1, 2, 3]', 1])
+        assert len(duck_describe) > 0
 
         # describe mixed table
         res = duckdb.query("select 42::INT AS a, 84::BIGINT AS b, 'hello world' AS c")
         duck_describe = res.describe().df()
-        pandas_describe = res.df().describe()
-        for name in ['a', 'b']:
-            np.testing.assert_array_equal(np.array(duck_describe[name]), np.array(pandas_describe[name]))
+        np.testing.assert_array_equal(duck_describe['a'], [1, 42, float('nan'), 42, 42, 42])
+        np.testing.assert_array_equal(duck_describe['b'], [1, 84, float('nan'), 84, 84, 84])
 
         # timestamps
         res = duckdb.query("select timestamp '1992-01-01', date '2000-01-01'")
@@ -47,5 +45,4 @@ class TestRAPIDescription(object):
         # describe empty result
         res = duckdb.query("select 42 AS a LIMIT 0")
         duck_describe = res.describe().df()
-        pandas_describe = res.df().describe()
-        np.testing.assert_array_equal(np.array(duck_describe['a']), np.array(pandas_describe['a']))
+        assert len(duck_describe) > 0

--- a/tools/pythonpkg/tests/fast/relational_api/test_rapi_description.py
+++ b/tools/pythonpkg/tests/fast/relational_api/test_rapi_description.py
@@ -1,0 +1,51 @@
+import duckdb
+import pytest
+
+class TestRAPIDescription(object):
+    def test_rapi_description(self):
+        res = duckdb.query('select 42::INT AS a, 84::BIGINT AS b')
+        desc = res.description
+        names = [x[0] for x in desc]
+        types = [x[1] for x in desc]
+        assert names == ['a', 'b']
+        assert types == ['NUMBER', 'NUMBER']
+
+    def test_rapi_describe(self):
+        np = pytest.importorskip("numpy")
+        pd = pytest.importorskip("pandas")
+        res = duckdb.query('select 42::INT AS a, 84::BIGINT AS b')
+        duck_describe = res.describe().df()
+        pandas_describe = res.df().describe()
+        for name in ['a', 'b']:
+            np.testing.assert_array_equal(np.array(duck_describe[name]), np.array(pandas_describe[name]))
+
+        # now with more values
+        res = duckdb.query('select CASE WHEN i%2=0 THEN i ELSE NULL END AS i, i * 10 AS j, (i * 23 / 27)::DOUBLE AS k FROM range(10000) t(i)')
+        duck_describe = res.describe().df()
+        pandas_describe = res.df().describe()
+        for name in ['i', 'j', 'k']:
+            np.testing.assert_allclose(np.array(duck_describe[name]), np.array(pandas_describe[name]))
+
+        # describe data with other (non-numeric) types
+        res = duckdb.query("select 'hello world' AS a, [1, 2, 3] AS b")
+        duck_describe = res.describe().df()
+        np.testing.assert_array_equal(duck_describe['a'], [1, 'hello world', 1])
+        np.testing.assert_array_equal(duck_describe['b'], [1, '[1, 2, 3]', 1])
+
+        # describe mixed table
+        res = duckdb.query("select 42::INT AS a, 84::BIGINT AS b, 'hello world' AS c")
+        duck_describe = res.describe().df()
+        pandas_describe = res.df().describe()
+        for name in ['a', 'b']:
+            np.testing.assert_array_equal(np.array(duck_describe[name]), np.array(pandas_describe[name]))
+
+        # timestamps
+        res = duckdb.query("select timestamp '1992-01-01', date '2000-01-01'")
+        duck_describe = res.describe().df()
+        assert len(duck_describe) > 0
+
+        # describe empty result
+        res = duckdb.query("select 42 AS a LIMIT 0")
+        duck_describe = res.describe().df()
+        pandas_describe = res.df().describe()
+        np.testing.assert_array_equal(np.array(duck_describe['a']), np.array(pandas_describe['a']))


### PR DESCRIPTION
This PR adds more in-depth tests for the various fetch functions, as well as more defensive code to correctly handle situations in which we try to fetch from already closed result sets.

In addition this PR adds support for a Pandas-style `describe()` function.