### PR TITLE
Make NumPy dependency optional

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -182,13 +182,11 @@ jobs:
         fi
 
    osx-python3:
-      if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
       name: Python 3 OSX
       runs-on: macos-latest
       strategy:
        matrix:
         python_build: [cp36-*, cp37-*, cp38-*, cp39-*, cp310-*, cp311-*]
-      needs: linux-python3-9
       env:
         CIBW_BUILD: ${{ matrix.python_build}}
         CIBW_ARCHS: 'x86_64 universal2 arm64'
@@ -253,7 +251,6 @@ jobs:
             python_build: 'cp39-*'
           - isRelease: false
             python_build: 'cp311-*'
-      needs: linux-python3-9
 
       env:
         CIBW_BUILD: ${{ matrix.python_build}}

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -182,11 +182,13 @@ jobs:
         fi
 
    osx-python3:
+      if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
       name: Python 3 OSX
       runs-on: macos-latest
       strategy:
        matrix:
         python_build: [cp36-*, cp37-*, cp38-*, cp39-*, cp310-*, cp311-*]
+      needs: linux-python3-9
       env:
         CIBW_BUILD: ${{ matrix.python_build}}
         CIBW_ARCHS: 'x86_64 universal2 arm64'
@@ -251,6 +253,7 @@ jobs:
             python_build: 'cp39-*'
           - isRelease: false
             python_build: 'cp311-*'
+      needs: linux-python3-9
 
       env:
         CIBW_BUILD: ${{ matrix.python_build}}

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -153,11 +153,6 @@ class get_pybind_include(object):
         import pybind11
         return pybind11.get_include(self.user)
 
-class get_numpy_include(object):
-    def __str__(self):
-        import numpy
-        return numpy.get_include()
-
 extra_files = []
 header_files = []
 
@@ -169,7 +164,7 @@ script_path = os.path.dirname(os.path.abspath(__file__))
 main_include_path = os.path.join(script_path, 'src', 'include')
 main_source_path = os.path.join(script_path, 'src')
 main_source_files = ['duckdb_python.cpp'] + list_source_files(main_source_path)
-include_directories = [main_include_path, get_numpy_include(), get_pybind_include(), get_pybind_include(user=True)]
+include_directories = [main_include_path, get_pybind_include(), get_pybind_include(user=True)]
 
 if len(existing_duckdb_dir) == 0:
     # no existing library supplied: compile everything from source
@@ -285,16 +280,13 @@ setup(
     url="https://www.duckdb.org",
     long_description = 'See here for an introduction: https://duckdb.org/docs/api/python/overview',
     license='MIT',
-    install_requires=[ # these version is still available for Python 2, newer ones aren't
-         'numpy>=1.14'
-    ],
     data_files = data_files,
     packages=[
         'duckdb_query_graph',
         'duckdb-stubs'
     ],
     include_package_data=True,
-    setup_requires=setup_requires + ["setuptools_scm<7.0.0", 'numpy>=1.14', 'pybind11>=2.6.0'],
+    setup_requires=setup_requires + ["setuptools_scm<7.0.0", 'pybind11>=2.6.0'],
     use_scm_version = setuptools_scm_conf,
     tests_require=['google-cloud-storage', 'mypy', 'pytest'],
     classifiers = [

--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/python_import_cache.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/python_import_cache.hpp
@@ -44,8 +44,6 @@ public:
 		return LazyLoadModule(uuid_module);
 	}
 	PandasCacheItem &pandas() {
-		// make sure NumPy is loaded before pandas
-		numpy();
 		return LazyLoadModule(pandas_module);
 	}
 	PolarsCacheItem &polars() {

--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/python_import_cache.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/python_import_cache.hpp
@@ -19,17 +19,6 @@ namespace duckdb {
 struct PythonImportCache {
 public:
 	explicit PythonImportCache() {
-#ifdef WIN32
-		py::gil_scoped_acquire acquire;
-		numpy();
-		datetime();
-		decimal();
-		uuid();
-		pandas();
-		arrow();
-		IPython();
-		ipywidgets();
-#endif
 	}
 	~PythonImportCache();
 
@@ -55,6 +44,8 @@ public:
 		return LazyLoadModule(uuid_module);
 	}
 	PandasCacheItem &pandas() {
+		// make sure NumPy is loaded before pandas
+		numpy();
 		return LazyLoadModule(pandas_module);
 	}
 	PolarsCacheItem &polars() {

--- a/tools/pythonpkg/tests/conftest.py
+++ b/tools/pythonpkg/tests/conftest.py
@@ -1,4 +1,3 @@
-import numpy
 import os
 import pytest
 import shutil


### PR DESCRIPTION
Fixes #657

As actually mentioned in that issue - as we use pybind11 now we no longer need to explicitly depend on NumPy.

While it is just nice to get rid of the dependency - it also fixes [this odd issue we are running into in the CI](https://github.com/duckdb/duckdb/actions/runs/4151437138/jobs/7181905441).

> Expected 192 from C header, got 216 from PyObject

By not explicitly adding NumPy includes and depending on NumPy this issue seems to go away.