### PR TITLE
Fix ODBC CI

### DIFF
--- a/.github/workflows/Julia.yml
+++ b/.github/workflows/Julia.yml
@@ -8,6 +8,8 @@ on:
        - '**.md'
        - 'examples/**'
        - 'test/**'
+       - 'tools/odbc/**'
+       - 'tools/jdbc/**'
        - 'tools/nodejs/**'
        - 'tools/pythonpkg/**'
        - 'tools/rpkg/**'

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+      - 'tools/jdbc/**'
       - 'tools/nodejs/**'
       - 'tools/juliapkg/**'
       - 'tools/pythonpkg/**'

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -348,7 +348,7 @@ jobs:
 
     - name: Install
       shell: bash
-      run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
+      run: sudo apt-get upate -y -qq && sudo apt-get install -y -qq ninja-build
 
     - name: Setup Ccache
       uses: hendrikmuhs/ccache-action@main
@@ -381,7 +381,7 @@ jobs:
     - name: Dependencies
       shell: bash
       run: |
-        sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc unixodbc-dev python3 python3-pip julia
+        sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc unixodbc-dev python3 python3-pip
         pip3 install pyodbc
 
     - name: Install psqlodbc
@@ -423,9 +423,3 @@ jobs:
     - name: Test Python ODBC
       shell: bash
       run: ./tools/odbc/test/run_pyodbc_tests.sh
-
-    - name: Test Julia ODBC
-      shell: bash
-      run: |
-        export ASAN_OPTIONS=verify_asan_link_order=0
-        julia tools/odbc/test/julia-test.jl

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -364,7 +364,7 @@ jobs:
 
  odbc:
     name: ODBC
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     env:
       BUILD_ODBC: 1
       GEN: ninja
@@ -381,14 +381,8 @@ jobs:
     - name: Dependencies
       shell: bash
       run: |
-        sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc unixodbc-dev python3 python3-pip
+        sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc unixodbc-dev python3 python3-pip julia
         pip3 install pyodbc
-
-    - name: Install nanodbc
-      shell: bash
-      run: |
-        wget https://github.com/nanodbc/nanodbc/archive/refs/tags/v2.13.0.tar.gz -O nanodbc.tgz
-        (mkdir nanodbc && tar xvf nanodbc.tgz -C nanodbc --strip-components=1 && cd nanodbc && sed -i -e "s/set(test_list/set(test_list odbc/" test/CMakeLists.txt && mkdir build && cd build && cmake -DNANODBC_DISABLE_TESTS=OFF .. && cmake --build .)
 
     - name: Install psqlodbc
       shell: bash
@@ -429,3 +423,9 @@ jobs:
     - name: Test Python ODBC
       shell: bash
       run: ./tools/odbc/test/run_pyodbc_tests.sh
+
+    - name: Test Julia ODBC
+      shell: bash
+      run: |
+        export ASAN_OPTIONS=verify_asan_link_order=0
+        julia tools/odbc/test/julia-test.jl

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -365,6 +365,7 @@ jobs:
  odbc:
     name: ODBC
     runs-on: ubuntu-22.04
+    needs: linux-debug
     env:
       BUILD_ODBC: 1
       GEN: ninja

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -384,6 +384,12 @@ jobs:
         sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc unixodbc-dev python3 python3-pip 
         pip3 install pyodbc
 
+    - name: Install nanodbc
+      shell: bash
+      run: |
+        wget https://github.com/nanodbc/nanodbc/archive/refs/tags/v2.14.0.tar.gz -O nanodbc.tgz
+        (mkdir nanodbc && tar xvf nanodbc.tgz -C nanodbc --strip-components=1 && cd nanodbc && sed -i -e "s/set(test_list/set(test_list odbc/" test/CMakeLists.txt && mkdir build && cd build && cmake -DNANODBC_DISABLE_TESTS=OFF .. && cmake --build .)
+
     - name: Install psqlodbc
       shell: bash
       run: |

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -364,7 +364,7 @@ jobs:
 
  odbc:
     name: ODBC
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       BUILD_ODBC: 1
       GEN: ninja

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+      - 'tools/jdbc/**'
       - 'tools/nodejs/**'
       - 'tools/juliapkg/**'
       - 'tools/pythonpkg/**'

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -392,7 +392,7 @@ jobs:
         tar xvf nanodbc.tgz -C nanodbc --strip-components=1
         cd nanodbc
         wget https://github.com/catchorg/Catch2/releases/download/v2.13.9/catch.hpp
-        cp catch.hpp nanodbc/test/catch/catch.hpp
+        cp catch.hpp test/catch/catch.hpp
         sed -i -e "s/set(test_list/set(test_list odbc/" test/CMakeLists.txt
         mkdir build
         cd build

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -348,7 +348,7 @@ jobs:
 
     - name: Install
       shell: bash
-      run: sudo apt-get upate -y -qq && sudo apt-get install -y -qq ninja-build
+      run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
 
     - name: Setup Ccache
       uses: hendrikmuhs/ccache-action@main
@@ -381,14 +381,14 @@ jobs:
     - name: Dependencies
       shell: bash
       run: |
-        sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc unixodbc-dev python3 python3-pip
+        sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc unixodbc-dev python3 python3-pip 
         pip3 install pyodbc
 
     - name: Install psqlodbc
       shell: bash
       run: |
         git clone https://github.com/Mytherin/psqlodbc.git
-        (cd psqlodbc && git checkout 178899d431e1d635d59b8e82a070ff6db0e8a092 && make debug)
+        (cd psqlodbc && git checkout edd9890a5046a2006f210849abb97c6a6589a45c && make debug)
 
     - name: Setup Ccache
       uses: hendrikmuhs/ccache-action@main

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -388,7 +388,16 @@ jobs:
       shell: bash
       run: |
         wget https://github.com/nanodbc/nanodbc/archive/refs/tags/v2.14.0.tar.gz -O nanodbc.tgz
-        (mkdir nanodbc && tar xvf nanodbc.tgz -C nanodbc --strip-components=1 && cd nanodbc && sed -i -e "s/set(test_list/set(test_list odbc/" test/CMakeLists.txt && mkdir build && cd build && cmake -DNANODBC_DISABLE_TESTS=OFF .. && cmake --build .)
+        mkdir nanodbc
+        tar xvf nanodbc.tgz -C nanodbc --strip-components=1
+        cd nanodbc
+        wget https://github.com/catchorg/Catch2/releases/download/v2.13.9/catch.hpp
+        cp catch.hpp nanodbc/test/catch/catch.hpp
+        sed -i -e "s/set(test_list/set(test_list odbc/" test/CMakeLists.txt
+        mkdir build
+        cd build
+        cmake -DNANODBC_DISABLE_TESTS=OFF ..
+        cmake --build .
 
     - name: Install psqlodbc
       shell: bash

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -382,7 +382,7 @@ jobs:
     - name: Dependencies
       shell: bash
       run: |
-        sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc-dev python3 python3-pip julia
+        sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc unixodbc-common unixodbc-dev python3 python3-pip julia
         pip3 install pyodbc
 
     - name: Install nanodbc

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -365,7 +365,6 @@ jobs:
  odbc:
     name: ODBC
     runs-on: ubuntu-20.04
-    needs: linux-debug
     env:
       BUILD_ODBC: 1
       GEN: ninja
@@ -382,7 +381,7 @@ jobs:
     - name: Dependencies
       shell: bash
       run: |
-        sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc unixodbc-common unixodbc-dev python3 python3-pip julia
+        sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc unixodbc-dev python3 python3-pip julia
         pip3 install pyodbc
 
     - name: Install nanodbc

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -381,7 +381,7 @@ jobs:
     - name: Dependencies
       shell: bash
       run: |
-        sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc unixodbc-dev python3 python3-pip julia
+        sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc unixodbc-dev python3 python3-pip
         pip3 install pyodbc
 
     - name: Install nanodbc
@@ -429,9 +429,3 @@ jobs:
     - name: Test Python ODBC
       shell: bash
       run: ./tools/odbc/test/run_pyodbc_tests.sh
-
-    - name: Test Julia ODBC
-      shell: bash
-      run: |
-        export ASAN_OPTIONS=verify_asan_link_order=0
-        julia tools/odbc/test/julia-test.jl

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -9,6 +9,8 @@ on:
       - 'data/**'
       - 'examples/**'
       - 'test/**'
+      - 'tools/odbc/**'
+      - 'tools/jdbc/**'
       - 'tools/juliapkg/**'
       - 'tools/pythonpkg/**'
       - 'tools/rpkg/**'

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -8,6 +8,8 @@ on:
       - '**.md'
       - 'examples/**'
       - 'test/**'
+      - 'tools/odbc/**'
+      - 'tools/jdbc/**'
       - 'tools/juliapkg/**'
       - 'tools/nodejs/**'
       - 'tools/rpkg/**'

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -8,6 +8,8 @@ on:
       - '**.md'
       - 'examples/**'
       - 'test/**'
+      - 'tools/odbc/**'
+      - 'tools/jdbc/**'
       - 'tools/juliapkg/**'
       - 'tools/nodejs/**'
       - 'tools/pythonpkg/**'

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+      - 'tools/odbc/**'
+      - 'tools/jdbc/**'
       - 'tools/juliapkg/**'
       - 'tools/nodejs/**'
       - 'tools/rpkg/**'

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+      - 'tools/jdbc/**'
       - 'tools/juliapkg/**'
       - 'tools/nodejs/**'
       - 'tools/pythonpkg/**'

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -211,7 +211,7 @@ jobs:
       shell: bash
       run: |
         git clone https://github.com/Mytherin/psqlodbc.git
-        (cd psqlodbc && git checkout 178899d431e1d635d59b8e82a070ff6db0e8a092 && make release)
+        (cd psqlodbc && git checkout edd9890a5046a2006f210849abb97c6a6589a45c && make release)
 
     - name: Test psqlodbc
       shell: bash


### PR DESCRIPTION
Somehow the "unixodbc.h" header has disappeared from the unixodbc-dev release for ubuntu-20.4. We switch to ubuntu-22.4, which then introduces several other problems. The version of `catch` used by psqlodbc and nanodbc no longer compile there, and `julia` is not available there. We switch to the later version of `catch` and disable the julia ODBC tests for now.