### PR TITLE
Fix #6044: in Value::DECIMAL, switch on the width instead of assuming the width is correctly set with the corresponding integer type

### DIFF
--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -369,19 +369,11 @@ bool Value::StringIsValid(const char *str, idx_t length) {
 }
 
 Value Value::DECIMAL(int16_t value, uint8_t width, uint8_t scale) {
-	D_ASSERT(width <= Decimal::MAX_WIDTH_INT16);
-	Value result(LogicalType::DECIMAL(width, scale));
-	result.value_.smallint = value;
-	result.is_null = false;
-	return result;
+	return Value::DECIMAL(int64_t(value), width, scale);
 }
 
 Value Value::DECIMAL(int32_t value, uint8_t width, uint8_t scale) {
-	D_ASSERT(width >= Decimal::MAX_WIDTH_INT16 && width <= Decimal::MAX_WIDTH_INT32);
-	Value result(LogicalType::DECIMAL(width, scale));
-	result.value_.integer = value;
-	result.is_null = false;
-	return result;
+	return Value::DECIMAL(int64_t(value), width, scale);
 }
 
 Value Value::DECIMAL(int64_t value, uint8_t width, uint8_t scale) {

--- a/test/sql/copy/parquet/parquet_6044.test
+++ b/test/sql/copy/parquet/parquet_6044.test
@@ -1,0 +1,13 @@
+# name: test/sql/copy/parquet/parquet_6044.test
+# description: Issue #6044: node: assertion failure when calling parquet_metadata
+# group: [parquet]
+
+require parquet
+
+statement ok
+copy (select 0.9 AS a) to '__TEST_DIR__/tiny_decimal.parquet' (format 'parquet', codec 'zstd');
+
+query I
+SELECT * FROM '__TEST_DIR__/tiny_decimal.parquet'
+----
+0.9


### PR DESCRIPTION
Fixes #6044