### PR TITLE
Helpful error when opening URL without httpfs loaded

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -866,6 +866,9 @@ vector<string> LocalFileSystem::FetchFileWithoutGlob(const string &path, FileOpe
 			}
 		}
 	}
+	if (result.empty() && StringUtil::Lower(path).compare(0, 4, "http") == 0) {
+		throw IOException("Path starts with 'http', perhaps you forgot to install and load the httpfs extension.");
+	}
 	return result;
 }
 


### PR DESCRIPTION
I thought it would be helpful for any of the file reading extensions if they pointed out that httpfs is not loaded, if people are new and not aware that it's another extension that you have to install and load.

If this is ok, I'd adjust the other extensions too with a similar error.
I'm not a cpp coder though so this might be completely non-idiomatic

Updated to handle it in: `FS.FetchFileWithoutGlob`


```shell
./build/release/duckdb

D select count(*) FROM read_csv_auto('https://gist.githubusercontent.com/zhonglism/f146a9423e2c975de8d03c26451f841e/raw/vgsales.csv');
Error: IO Error: Path starts with 'http', perhaps you forgot to install and load the httpfs extension.
D select count(*) FROM read_csv_auto('httpsales.csv');
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│        16598 │
└──────────────┘
D select count(*) FROM read_csv_auto('vgsales.csv');
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│        16598 │
└──────────────┘
D select count(*) FROM read_csv_auto('vgsales1.csv');
Error: IO Error: No files found that match the pattern "vgsales1.csv"
```