### PR TITLE
fixes #6227

### DIFF
--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -1821,6 +1821,18 @@ public class TestDuckDBJDBC {
 
 		conn.close();
 	}
+	
+	public static void test_get_tables_with_catalog() throws Exception {
+		Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+		String catalog = conn.getCatalog();
+		DatabaseMetaData databaseMetaData = conn.getMetaData();
+		try {
+			databaseMetaData.getTables(catalog, null, "%", null);
+		}
+		catch (SQLException ex) {
+			assertFalse(ex.getMessage().startsWith("Actual catalog argument is not supported"));
+		}
+	}
 
 	public static void test_get_tables_param_binding_for_table_types() throws Exception {
 		Connection conn = DriverManager.getConnection("jdbc:duckdb:");

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -1822,16 +1822,94 @@ public class TestDuckDBJDBC {
 		conn.close();
 	}
 	
-	public static void test_get_tables_with_catalog() throws Exception {
+	public static void test_get_tables_with_current_catalog() throws Exception {
+		ResultSet resultSet = null;
 		Connection conn = DriverManager.getConnection("jdbc:duckdb:");
-		String catalog = conn.getCatalog();
+		final String currentCatalog = conn.getCatalog();
 		DatabaseMetaData databaseMetaData = conn.getMetaData();
+		
+		Statement statement = conn.createStatement();
+		statement.execute("CREATE TABLE T1(ID INT)");
+		// verify that the catalog argument is supported and does not throw
 		try {
-			databaseMetaData.getTables(catalog, null, "%", null);
+			resultSet = databaseMetaData.getTables(currentCatalog, null, "%", null);
 		}
 		catch (SQLException ex) {
 			assertFalse(ex.getMessage().startsWith("Actual catalog argument is not supported"));
 		}
+		assertTrue(resultSet.next(), "getTables should return exactly 1 table");
+		final String returnedCatalog = resultSet.getString("TABLE_CAT");
+		assertTrue(
+			currentCatalog.equals(returnedCatalog), 
+			String.format("Returned catalog %s should equal current catalog %s", returnedCatalog, currentCatalog)
+		);
+		assertTrue(resultSet.next() == false, "getTables should return exactly 1 table");
+		
+		resultSet.close();
+	}
+	
+	public static void test_get_tables_with_attached_catalog() throws Exception {
+		Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+		final String currentCatalog = conn.getCatalog();
+		DatabaseMetaData databaseMetaData = conn.getMetaData();
+		Statement statement = conn.createStatement();
+		
+		// create one table in the current catalog
+		final String TABLE_NAME1 = "T1";
+		statement.execute(String.format("CREATE TABLE %s(ID INT)", TABLE_NAME1));
+
+		// create one table in an attached catalog
+		String returnedCatalog, returnedTableName;
+		ResultSet resultSet = null;
+		final String ATTACHED_CATALOG = "ATTACHED_CATALOG";
+		final String TABLE_NAME2 = "T2";
+		statement.execute(String.format("ATTACH '' AS \"%s\"", ATTACHED_CATALOG));
+		statement.execute(String.format("CREATE TABLE %s.%s(ID INT)", ATTACHED_CATALOG, TABLE_NAME2));
+
+		// test if getTables can get tables from the remote catalog.
+		resultSet = databaseMetaData.getTables(ATTACHED_CATALOG, null, "%", null);
+		assertTrue(resultSet.next(), "getTables should return exactly 1 table");
+		returnedCatalog = resultSet.getString("TABLE_CAT");
+		assertTrue(
+			ATTACHED_CATALOG.equals(returnedCatalog), 
+			String.format("Returned catalog %s should equal attached catalog %s", returnedCatalog, ATTACHED_CATALOG)
+		);
+		assertTrue(resultSet.next() == false, "getTables should return exactly 1 table");
+		resultSet.close();
+		
+		// test if getTables with null catalog returns all tables.
+		resultSet = databaseMetaData.getTables(null, null, "%", null);
+		
+		assertTrue(resultSet.next(), "getTables should return 2 tables, got 0");
+		// first table should be ATTACHED_CATALOG.T2
+		returnedCatalog = resultSet.getString("TABLE_CAT");
+		assertTrue(
+			ATTACHED_CATALOG.equals(returnedCatalog), 
+			String.format("Returned catalog %s should equal attached catalog %s", returnedCatalog, ATTACHED_CATALOG)
+		);
+		returnedTableName = resultSet.getString("TABLE_NAME");
+		assertTrue(
+			TABLE_NAME2.equals(returnedTableName), 
+			String.format("Returned table %s should equal %s", returnedTableName, TABLE_NAME2)
+		);
+		
+		assertTrue(resultSet.next(), "getTables should return 2 tables, got 1");
+		// second table should be <current catalog>.T1
+		returnedCatalog = resultSet.getString("TABLE_CAT");
+		assertTrue(
+			currentCatalog.equals(returnedCatalog), 
+			String.format("Returned catalog %s should equal current catalog %s", returnedCatalog, currentCatalog)
+		);
+		returnedTableName = resultSet.getString("TABLE_NAME");
+		assertTrue(
+			TABLE_NAME1.equals(returnedTableName), 
+			String.format("Returned table %s should equal %s", returnedTableName, TABLE_NAME1)
+		);
+		
+		assertTrue(resultSet.next() == false, "getTables should return 2 tables, got > 2");
+		resultSet.close();
+		statement.close();
+		conn.close();
 	}
 
 	public static void test_get_tables_param_binding_for_table_types() throws Exception {


### PR DESCRIPTION
- adds a test that demonstrates old implementation of getTables always throws an SQLException
- rewrites getTables to provide handling for the catalog parameter.