### PR TITLE
Add missing shell mode descriptions

### DIFF
--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -13668,6 +13668,7 @@ static const char *(azHelp[]) = {
   "     html      HTML <table> code",
   "     insert    SQL insert statements for TABLE",
   "     json      Results in a JSON array",
+  "     jsonlines Results in a NDJSON",
   "     latex     LaTeX tabular environment code",
   "     line      One value per line",
   "     list      Values delimited by \"|\"",
@@ -18320,8 +18321,8 @@ static int do_meta_command(char *zLine, ShellState *p){
       raw_printf(p->out, "current output mode: %s\n", modeDescr[p->mode]);
     }else{
       raw_printf(stderr, "Error: mode should be one of: "
-         "ascii box column csv duckbox html insert json latex line list "
-         "markdown quote table tabs tcl trash \n");
+         "ascii box column csv duckbox html insert json jsonlines latex line "
+         "list markdown quote table tabs tcl trash \n");
       rc = 1;
     }
     p->cMode = p->mode;

--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -13664,9 +13664,11 @@ static const char *(azHelp[]) = {
   "     box       Tables using unicode box-drawing characters",
   "     csv       Comma-separated values",
   "     column    Output in columns.  (See .width)",
+  "     duckbox   Tables with extensive features",
   "     html      HTML <table> code",
   "     insert    SQL insert statements for TABLE",
   "     json      Results in a JSON array",
+  "     latex     LaTeX tabular environment code",
   "     line      One value per line",
   "     list      Values delimited by \"|\"",
   "     markdown  Markdown table format",
@@ -13674,6 +13676,7 @@ static const char *(azHelp[]) = {
   "     table     ASCII-art table",
   "     tabs      Tab-separated values",
   "     tcl       TCL list elements",
+  "     trash     No output",
   ".nullvalue STRING        Use STRING in place of NULL values",
   ".once ?OPTIONS? ?FILE?   Output for the next SQL command only to FILE",
   "     If FILE begins with '|' then open as a pipe",
@@ -18317,8 +18320,8 @@ static int do_meta_command(char *zLine, ShellState *p){
       raw_printf(p->out, "current output mode: %s\n", modeDescr[p->mode]);
     }else{
       raw_printf(stderr, "Error: mode should be one of: "
-         "ascii duckbox box column csv html insert json line list markdown "
-         "quote table tabs tcl latex trash \n");
+         "ascii box column csv duckbox html insert json latex line list "
+         "markdown quote table tabs tcl trash \n");
       rc = 1;
     }
     p->cMode = p->mode;


### PR DESCRIPTION
Closes #6233 

This PR adds missing descriptions about duckbox (#5140), jsonlines (#4234), latex (#1227), and trash (#1821) shell modes.

Now `.help .mode` shows the following.

```shell
D .help .mode
.import FILE TABLE       Import data from FILE into TABLE
   Options:
     --ascii               Use \037 and \036 as column and row separators
     --csv                 Use , and \n as column and row separators
     --skip N              Skip the first N rows of input
     -v                    "Verbose" - increase auxiliary output
   Notes:
     *  If TABLE does not exist, it is created.  The first row of input
        determines the column names.
     *  If neither --csv or --ascii are used, the input mode is derived
        from the ".mode" output mode
     *  If FILE begins with "|" then it is a command that generates the
        input text.
.mode MODE ?TABLE?       Set output mode
   MODE is one of:
     ascii     Columns/rows delimited by 0x1F and 0x1E
     box       Tables using unicode box-drawing characters
     csv       Comma-separated values
     column    Output in columns.  (See .width)
     duckbox   Tables with extensive features
     html      HTML <table> code
     insert    SQL insert statements for TABLE
     json      Results in a JSON array
     jsonlines Results in a NDJSON
     latex     LaTeX tabular environment code
     line      One value per line
     list      Values delimited by "|"
     markdown  Markdown table format
     quote     Escape answers as for SQL
     table     ASCII-art table
     tabs      Tab-separated values
     tcl       TCL list elements
     trash     No output
```
