### PR TITLE
Fix to #5461

### DIFF
--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -946,13 +946,13 @@ static bool IntegerCastLoop(const char *buf, idx_t len, T &result, bool strict) 
 					ExponentData exponent {0, false};
 					int negative = buf[pos] == '-';
 					if (negative) {
-						if (!IntegerCastLoop<ExponentData, true, false, IntegerCastOperation>(buf + pos, len - pos,
-						                                                                      exponent, strict)) {
+						if (!IntegerCastLoop<ExponentData, true, false, IntegerCastOperation, decimal_separator>(
+						        buf + pos, len - pos, exponent, strict)) {
 							return false;
 						}
 					} else {
-						if (!IntegerCastLoop<ExponentData, false, false, IntegerCastOperation>(buf + pos, len - pos,
-						                                                                       exponent, strict)) {
+						if (!IntegerCastLoop<ExponentData, false, false, IntegerCastOperation, decimal_separator>(
+						        buf + pos, len - pos, exponent, strict)) {
 							return false;
 						}
 					}


### PR DESCRIPTION
When using amalgamation builds, MSVC compiler 17.4 and later complains without this change.

libduckdb-src\duckdb.cpp(39236): error C2672: 'IntegerCastLoop': no matching overloaded function found
  libduckdb-src\duckdb.cpp(39167): note: could be 'bool duckdb::IntegerCastLoop(const char *,duckdb::idx_t,T &,bool)'
  libduckdb-src\duckdb.cpp(39260): note: 'bool duckdb::IntegerCastLoop(const char *,duckdb::idx_t,T &,bool)': could not deduce template argument for 'decimal_separator'