### PR TITLE
Fix #6255: Shell should be installed in INSTALL_BIN_DIR

### DIFF
--- a/tools/shell/CMakeLists.txt
+++ b/tools/shell/CMakeLists.txt
@@ -28,4 +28,4 @@ set_target_properties(shell PROPERTIES OUTPUT_NAME duckdb)
 set_target_properties(shell PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                        ${PROJECT_BINARY_DIR})
 
-install(TARGETS shell RUNTIME DESTINATION "${PROJECT_BINARY_DIR}")
+install(TARGETS shell RUNTIME DESTINATION "${INSTALL_BIN_DIR}")


### PR DESCRIPTION
Fixes #6255

This also fixes the broken homebrew build.