### PR TITLE
Correctly compute Windows terminal width, and add a `.maxwidth` option to the shell for duckbox mode

### DIFF
--- a/src/common/printer.cpp
+++ b/src/common/printer.cpp
@@ -65,7 +65,7 @@ idx_t Printer::TerminalWidth() {
 	int columns, rows;
 
 	GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
-	rows = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
+	rows = csbi.srWindow.Right - csbi.srWindow.Left + 1;
 	return rows;
 #else
 	struct winsize w;

--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -874,6 +874,17 @@ outstr = open(outfile,'rb').read().decode('utf8')
 if '50' not in outstr:
      raise Exception('.output test failed')
 
+# we always display all columns when outputting to a file
+columns = ', '.join([str(x) for x in range(100)])
+outfile = tf()
+test('''
+.output %s
+SELECT %s
+''' % (outfile, columns))
+outstr = open(outfile,'rb').read().decode('utf8')
+if '99' not in outstr:
+     raise Exception('.output test failed')
+
 # test null-byte rendering
 test('select varchar from test_all_types();', out='goo\\0se')
 

--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -10729,7 +10729,8 @@ struct ShellState {
   int nIndent;           /* Size of array aiIndent[] */
   int iIndent;           /* Index of current op in aiIndent[] */
   EQPGraph sGraph;       /* Information for the graphical EXPLAIN QUERY PLAN */
-  size_t max_rows;       /* The maximum number of rows to render */
+  size_t max_rows;       /* The maximum number of rows to render in DuckBox mode */
+  size_t max_width;      /* The maximum number of characters to render horizontally in DuckBox mode */
 #if defined(SQLITE_ENABLE_SESSION)
   int nSession;             /* Number of active sessions */
   OpenSession aSession[4];  /* Array of sessions.  [0] is in focus. */
@@ -12880,7 +12881,7 @@ columnar_end:
   sqlite3_free(azData);
 }
 
-extern char *sqlite3_print_duckbox(sqlite3_stmt *pStmt, size_t max_rows, char *null_value);
+extern char *sqlite3_print_duckbox(sqlite3_stmt *pStmt, size_t max_rows, size_t max_width, char *null_value);
 
 /*
 ** Run a prepared statement
@@ -12892,7 +12893,8 @@ static void exec_prepared_stmt(
   int rc;
   if (pArg->cMode == MODE_DuckBox) {
 	  size_t max_rows = pArg->outfile[0] == '\0' || pArg->outfile[0] == '|' ? pArg->max_rows : (size_t) -1;
-	  char *str = sqlite3_print_duckbox(pStmt, max_rows, pArg->nullValue);
+	  size_t max_width = pArg->outfile[0] == '\0' || pArg->outfile[0] == '|' ? pArg->max_width : (size_t) -1;
+	  char *str = sqlite3_print_duckbox(pStmt, max_rows, max_width, pArg->nullValue);
 	  if (str) {
 		  utf8_printf(pArg->out, "%s", str);
 		  sqlite3_free(str);
@@ -13658,6 +13660,7 @@ static const char *(azHelp[]) = {
 #endif
   ".log FILE|off            Turn logging on or off.  FILE can be stderr/stdout",
   ".maxrows COUNT           Sets the maximum number of rows for display. Only for duckbox mode.",
+  ".maxwidth COUNT          Sets the maximum width in characters. 0 defaults to terminal width. Only for duckbox mode.",
   ".mode MODE ?TABLE?       Set output mode",
   "   MODE is one of:",
   "     ascii     Columns/rows delimited by 0x1F and 0x1E",
@@ -18254,6 +18257,17 @@ static int do_meta_command(char *zLine, ShellState *p){
 		rc = 1;
 	}else{
 	  p->max_rows = (size_t)integerValue(azArg[1]);
+	}
+  }else
+  if( c=='m' && strncmp(azArg[0], "maxwidth", n)==0 ){
+	if( nArg==1 ){
+      raw_printf(p->out, "current max maxwidth: %zu\n", p->max_width);
+	}else
+    if( nArg!=2 ){
+		raw_printf(stderr, "Usage: .maxwidth COUNT\n");
+		rc = 1;
+	}else{
+	  p->max_width = (size_t)integerValue(azArg[1]);
 	}
   }else
   if( c=='m' && strncmp(azArg[0], "mode", n)==0 ){

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -32,7 +32,7 @@ using namespace duckdb;
 using namespace std;
 
 extern "C" {
-char *sqlite3_print_duckbox(sqlite3_stmt *pStmt, size_t max_rows, char *null_value);
+char *sqlite3_print_duckbox(sqlite3_stmt *pStmt, size_t max_rows, size_t max_width, char *null_value);
 }
 
 static char *sqlite3_strdup(const char *str);
@@ -222,7 +222,7 @@ int sqlite3_prepare_v2(sqlite3 *db,           /* Database handle */
 	}
 }
 
-char *sqlite3_print_duckbox(sqlite3_stmt *pStmt, size_t max_rows, char *null_value) {
+char *sqlite3_print_duckbox(sqlite3_stmt *pStmt, size_t max_rows, size_t max_width, char *null_value) {
 	if (!pStmt) {
 		return nullptr;
 	}
@@ -262,6 +262,7 @@ char *sqlite3_print_duckbox(sqlite3_stmt *pStmt, size_t max_rows, char *null_val
 	if (null_value) {
 		config.null_value = null_value;
 	}
+	config.max_width = max_width;
 	BoxRenderer renderer(config);
 	auto result_rendering =
 	    renderer.ToString(*pStmt->db->con->context, pStmt->result->names, materialized.Collection());


### PR DESCRIPTION
Fixes #5921