### PR TITLE
Fix UPSERT binding issue related to the source table_index

### DIFF
--- a/src/execution/column_binding_resolver.cpp
+++ b/src/execution/column_binding_resolver.cpp
@@ -65,9 +65,12 @@ void ColumnBindingResolver::VisitOperator(LogicalOperator &op) {
 		// ON CONFLICT DO UPDATE clause
 		auto &insert_op = (LogicalInsert &)op;
 		if (insert_op.action_type != OnConflictAction::THROW) {
+			// Get the bindings from the children
 			VisitOperatorChildren(op);
-			auto dummy_bindings = LogicalOperator::GenerateColumnBindings(
-			    insert_op.excluded_table_index, insert_op.table->GetColumns().PhysicalColumnCount());
+			auto column_count = insert_op.table->GetColumns().PhysicalColumnCount();
+			auto dummy_bindings = LogicalOperator::GenerateColumnBindings(insert_op.excluded_table_index, column_count);
+			// Now insert our dummy bindings at the start of the bindings,
+			// so the first 'column_count' indices of the chunk are reserved for our 'excluded' columns
 			bindings.insert(bindings.begin(), dummy_bindings.begin(), dummy_bindings.end());
 			if (insert_op.on_conflict_condition) {
 				VisitExpression(&insert_op.on_conflict_condition);

--- a/src/include/duckdb/planner/operator/logical_execute.hpp
+++ b/src/include/duckdb/planner/operator/logical_execute.hpp
@@ -32,11 +32,7 @@ protected:
 		// already resolved
 	}
 	vector<ColumnBinding> GetColumnBindings() override {
-		vector<ColumnBinding> bindings;
-		for (idx_t i = 0; i < types.size(); i++) {
-			bindings.push_back(ColumnBinding(0, i));
-		}
-		return bindings;
+		return GenerateColumnBindings(0, types.size());
 	}
 };
 } // namespace duckdb

--- a/src/include/duckdb/planner/operator/logical_show.hpp
+++ b/src/include/duckdb/planner/operator/logical_show.hpp
@@ -33,8 +33,7 @@ protected:
 		         LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
 	}
 	vector<ColumnBinding> GetColumnBindings() override {
-		return {ColumnBinding(0, 0), ColumnBinding(0, 1), ColumnBinding(0, 2),
-		        ColumnBinding(0, 3), ColumnBinding(0, 4), ColumnBinding(0, 5)};
+		return GenerateColumnBindings(0, types.size());
 	}
 };
 } // namespace duckdb

--- a/src/parser/statement/insert_statement.cpp
+++ b/src/parser/statement/insert_statement.cpp
@@ -28,6 +28,9 @@ InsertStatement::InsertStatement(const InsertStatement &other)
       select_statement(unique_ptr_cast<SQLStatement, SelectStatement>(other.select_statement->Copy())),
       columns(other.columns), table(other.table), schema(other.schema), catalog(other.catalog) {
 	cte_map = other.cte_map.Copy();
+	if (other.table_ref) {
+		table_ref = other.table_ref->Copy();
+	}
 	if (other.on_conflict_info) {
 		on_conflict_info = other.on_conflict_info->Copy();
 	}

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -301,6 +301,7 @@ void Binder::BindOnConflictClause(LogicalInsert &insert, TableCatalogEntry &tabl
 		insert.on_conflict_condition = std::move(condition);
 	}
 
+	auto bindings = insert.children[0]->GetColumnBindings();
 	idx_t projection_index = DConstants::INVALID_INDEX;
 	std::vector<unique_ptr<LogicalOperator>> *insert_child_operators;
 	insert_child_operators = &insert.children;

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -301,7 +301,27 @@ void Binder::BindOnConflictClause(LogicalInsert &insert, TableCatalogEntry &tabl
 		insert.on_conflict_condition = std::move(condition);
 	}
 
-	auto projection_index = insert.children[0]->GetTableIndex()[0];
+	idx_t projection_index = DConstants::INVALID_INDEX;
+	std::vector<unique_ptr<LogicalOperator>> *insert_child_operators;
+	insert_child_operators = &insert.children;
+	while (projection_index == DConstants::INVALID_INDEX) {
+		if (insert_child_operators->empty()) {
+			// No further children to visit
+			break;
+		}
+		D_ASSERT(insert_child_operators->size() >= 1);
+		auto &current_child = (*insert_child_operators)[0];
+		auto table_indices = current_child->GetTableIndex();
+		if (table_indices.empty()) {
+			// This operator does not have a table index to refer to, we have to visit its children
+			insert_child_operators = &current_child->children;
+			continue;
+		}
+		projection_index = table_indices[0];
+	}
+	if (projection_index == DConstants::INVALID_INDEX) {
+		throw InternalException("Could not locate a table_index from the children of the insert");
+	}
 
 	string unused;
 	auto original_binding = bind_context.GetBinding(table_alias, unused);

--- a/src/planner/logical_operator.cpp
+++ b/src/planner/logical_operator.cpp
@@ -57,6 +57,7 @@ void LogicalOperator::ResolveOperatorTypes() {
 
 vector<ColumnBinding> LogicalOperator::GenerateColumnBindings(idx_t table_idx, idx_t column_count) {
 	vector<ColumnBinding> result;
+	result.reserve(column_count);
 	for (idx_t i = 0; i < column_count; i++) {
 		result.emplace_back(table_idx, i);
 	}
@@ -84,6 +85,7 @@ vector<ColumnBinding> LogicalOperator::MapBindings(const vector<ColumnBinding> &
 		vector<ColumnBinding> result_bindings;
 		result_bindings.reserve(projection_map.size());
 		for (auto index : projection_map) {
+			D_ASSERT(index < bindings.size());
 			result_bindings.push_back(bindings[index]);
 		}
 		return result_bindings;

--- a/test/sql/upsert/upsert_distinct_bug.test
+++ b/test/sql/upsert/upsert_distinct_bug.test
@@ -1,0 +1,47 @@
+# name: test/sql/upsert/upsert_distinct_bug.test
+# group: [upsert]
+
+# Create raw data table
+statement ok
+CREATE TABLE test_table_raw(id VARCHAR, name VARCHAR);
+
+# Insert raw data
+statement ok
+INSERT INTO test_table_raw VALUES
+	('abc001','foo'),
+	('abc002','bar'),
+	('abc001','foo2'),
+	('abc002','bar2');
+
+# Create aggregated data table
+statement ok
+CREATE TABLE test_table(id VARCHAR PRIMARY KEY, name VARCHAR);
+
+
+# Insert aggregated data
+statement error
+INSERT INTO test_table
+SELECT
+  DISTINCT(id) as id,
+  name
+FROM test_table_raw;
+
+# Insert aggregated data
+statement error
+INSERT INTO test_table
+SELECT
+  DISTINCT(id) as id,
+  name
+FROM test_table_raw;
+
+# Insert aggregated data second time with "INSERT OR IGNORE" => Segmentation fault
+# This contains conflicts between the to-be-inserted rows, still won't succeed
+statement error
+INSERT OR IGNORE INTO test_table
+SELECT
+  DISTINCT(id) as id,
+  name
+FROM test_table_raw;
+
+statement ok
+SELECT * FROM test_table_raw;


### PR DESCRIPTION
This PR fixes #6271 

When binding the UPSERT clause, we have to replace the `table_index` of the BoundColumnReferences, because originally they refer to the table we're inserting into, and not to the "table" we're inserting from.

Previously we assumed to find this table_index in the `insert->children[0]->GetTableIndex()[0]`
But in the case of LogicalDistinct (and probably others), this LogicalOperator doesn't have a table index.

So now we recursively check child[0] until we find a GetTableIndex() that doesn't return an empty vector.