### PR TITLE
[NodeJS] Support multi-statement prepare

### DIFF
--- a/tools/nodejs/test/prepare.test.ts
+++ b/tools/nodejs/test/prepare.test.ts
@@ -360,6 +360,24 @@ describe('prepare', function() {
                 .finalize(done);
         });
 
+        it('should fail in prepare, when executing the first statement', function(done) {
+            let prepared = db.prepare("SELECT * FROM non_existent_table; SELECT 42", function(err: null | Error) {
+				if (err) {
+					done();
+					return;
+				}
+			});
+        });
+
+        it('should fail in prepare, when preparing the first statement', function(done) {
+            let prepared = db.prepare("SELCET * FROM foo; SELECT 42", function(err: null | Error) {
+				if (err) {
+					done();
+					return;
+				}
+			});
+        });
+
         after(function(done) { db.close(done); });
     });
 

--- a/tools/nodejs/test/prepare.test.ts
+++ b/tools/nodejs/test/prepare.test.ts
@@ -66,7 +66,6 @@ describe('prepare', function() {
             }
         });
 
-
         it('should prepare a statement and return values again', function(done) {
             var stmt = db.prepare("SELECT txt, num, flt, blb FROM foo ORDER BY num", function(err: null | Error) {
                 if (err) throw err;
@@ -338,6 +337,27 @@ describe('prepare', function() {
 
         it('should have retrieved all rows', function() {
             assert.equal(count, retrieved, "Didn't retrieve all rows");
+        });
+
+        after(function(done) { db.close(done); });
+    });
+
+    describe('prepare multiple statements', function() {
+        var db: sqlite3.Database;
+        before(function(done) { db = new sqlite3.Database(':memory:',
+            function(err) {
+                db.run("CREATE TABLE foo (a integer)", done)
+            }
+            ); });
+
+        it('should directly execute first statements', function(done) {
+            db.prepare("insert into foo values (3); insert into foo values (4); select * from foo")
+                .all(function(err: null | Error, rows: TableData) {
+                    if (err) throw err;
+                    assert.equal(rows[0].a, 3);
+                    assert.equal(rows[1].a, 4);
+                })
+                .finalize(done);
         });
 
         after(function(done) { db.close(done); });

--- a/tools/nodejs/test/typescript_decls.test.ts
+++ b/tools/nodejs/test/typescript_decls.test.ts
@@ -2,7 +2,7 @@ import * as duckdb from "..";
 import assert from "assert";
 import fs from "fs";
 
-describe("TypeScript declarataions", function () {
+describe("TypeScript declarations", function () {
   var db: duckdb.Database;
   before(function (done) {
     db = new duckdb.Database(":memory:", duckdb.OPEN_READWRITE, done);


### PR DESCRIPTION
This PR fixes #6198 

Things like `IMPORT` are pragmas that resolve to a query with multiple statements.
When this is passed to `Prepare` directly this throws an error.

Instead of providing this directly to Prepare we now first use ExtractStatements to get the statements, if there are more than one we directly execute everything but the last one.