### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -383,7 +383,8 @@ jobs:
     - name: Dependencies
       shell: bash
       run: |
-        sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build unixodbc unixodbc-dev python3 python3-pip 
+        sudo apt-get update -y -qq
+        sudo apt-get install -y -qq ninja-build unixodbc-dev
         pip3 install pyodbc
 
     - name: Install nanodbc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -791,7 +791,7 @@ function(build_loadable_extension_directory NAME OUTPUT_DIRECTORY PARAMETERS)
       if (APPLE)
         set_target_properties(${TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
         # Note that on MacOS we need to use the -exported_symbol whitelist feature due to a lack of -exclude-libs flag in mac's ld variant
-        set(WHITELIST "-Wl,-exported_symbol,_${NAME}_init -Wl,-exported_symbol,_${NAME}_version -Wl,-exported_symbol,_${NAME}_storage_init")
+        set(WHITELIST "-Wl,-exported_symbol,_${NAME}_init -Wl,-exported_symbol,_${NAME}_version -Wl,-exported_symbol,_${NAME}_storage_ini*")
         target_link_libraries(${TARGET_NAME} duckdb_static ${DUCKDB_EXTRA_LINK_FLAGS} -Wl,-dead_strip ${WHITELIST})
       else()
         # For GNU we rely on fvisibility=hidden to hide the extension symbols and use -exclude-libs to hide the duckdb symbols

--- a/test/sql/join/external/external_join_many_duplicates.test_slow
+++ b/test/sql/join/external/external_join_many_duplicates.test_slow
@@ -2,6 +2,9 @@
 # description: Test external join with many duplicates in build side
 # group: [external]
 
+# runs out of memory occassionally on 32-bit machines
+require 64bit
+
 statement ok
 pragma verify_external
 


### PR DESCRIPTION
* _storage_init is not required, so use a wildcard when defining the exported symbol for MacOS
* require 64bit on a test that uses a lot of memory as it occassionally triggers an OOM on 32 bit CI runs