### PR TITLE
Fix #6276: avoid transforming the root arg of a case expression multiple times

### DIFF
--- a/src/include/duckdb/main/client_data.hpp
+++ b/src/include/duckdb/main/client_data.hpp
@@ -11,7 +11,7 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/output_type.hpp"
 #include "duckdb/common/types/value.hpp"
-#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/atomic.hpp"
 
 namespace duckdb {
@@ -39,7 +39,7 @@ struct ClientData {
 	//! The set of temporary objects that belong to this client
 	shared_ptr<AttachedDatabase> temporary_objects;
 	//! The set of bound prepared statements that belong to this client
-	unordered_map<string, shared_ptr<PreparedStatementData>> prepared_statements;
+	case_insensitive_map_t<shared_ptr<PreparedStatementData>> prepared_statements;
 
 	//! The writer used to log queries (if logging is enabled)
 	unique_ptr<BufferedFileWriter> log_query_writer;

--- a/src/parser/transform/expression/transform_case.cpp
+++ b/src/parser/transform/expression/transform_case.cpp
@@ -9,16 +9,16 @@ unique_ptr<ParsedExpression> Transformer::TransformCase(duckdb_libpgquery::PGCas
 	D_ASSERT(root);
 
 	auto case_node = make_unique<CaseExpression>();
+	auto root_arg = TransformExpression(reinterpret_cast<duckdb_libpgquery::PGNode *>(root->arg));
 	for (auto cell = root->args->head; cell != nullptr; cell = cell->next) {
 		CaseCheck case_check;
 
 		auto w = reinterpret_cast<duckdb_libpgquery::PGCaseWhen *>(cell->data.ptr_value);
 		auto test_raw = TransformExpression(reinterpret_cast<duckdb_libpgquery::PGNode *>(w->expr));
 		unique_ptr<ParsedExpression> test;
-		auto arg = TransformExpression(reinterpret_cast<duckdb_libpgquery::PGNode *>(root->arg));
-		if (arg) {
+		if (root_arg) {
 			case_check.when_expr =
-			    make_unique<ComparisonExpression>(ExpressionType::COMPARE_EQUAL, std::move(arg), std::move(test_raw));
+			    make_unique<ComparisonExpression>(ExpressionType::COMPARE_EQUAL, root_arg->Copy(), std::move(test_raw));
 		} else {
 			case_check.when_expr = std::move(test_raw);
 		}

--- a/test/sql/prepared/test_issue_6276.test
+++ b/test/sql/prepared/test_issue_6276.test
@@ -1,0 +1,14 @@
+# name: test/sql/prepared/test_issue_6276.test
+# description: Issue 6276: Spurious additional parameter required in prepared statement
+# group: [prepared]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+PREPARE v1 AS SELECT CASE ? WHEN ? THEN ? WHEN ? THEN ? ELSE ? END AS x
+
+query I
+EXECUTE V1(1, 2, 3, 4, 5, 6);
+----
+6


### PR DESCRIPTION
Fixes #6276