### PR TITLE
Implement #6003 - add names option to CSV reader

### DIFF
--- a/src/execution/operator/persistent/buffered_csv_reader.cpp
+++ b/src/execution/operator/persistent/buffered_csv_reader.cpp
@@ -721,6 +721,9 @@ void BufferedCSVReader::DetectHeader(const vector<vector<LogicalType>> &best_sql
 			names.push_back(column_name);
 		}
 	}
+	for (idx_t i = 0; i < MinValue<idx_t>(names.size(), options.name_list.size()); i++) {
+		names[i] = options.name_list[i];
+	}
 }
 
 vector<LogicalType> BufferedCSVReader::RefineTypeDetection(const vector<LogicalType> &type_candidates,

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -100,7 +100,6 @@ static unique_ptr<FunctionData> ReadCSVBind(ClientContext &context, TableFunctio
 				throw BinderException("read_csv requires at least a single column as input!");
 			}
 		} else if (loption == "column_names" || loption == "names") {
-			auto &child_type = kv.second.type();
 			if (!options.name_list.empty()) {
 				throw BinderException("read_csv_auto column_names/names can only be supplied once");
 			}

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -101,8 +101,6 @@ static unique_ptr<FunctionData> ReadCSVBind(ClientContext &context, TableFunctio
 			}
 		} else if (loption == "column_names" || loption == "names") {
 			auto &child_type = kv.second.type();
-			D_ASSERT(child_type.id() == LogicalTypeId::LIST);
-			D_ASSERT(ListType::GetChildType(child_type).id() == LogicalTypeId::VARCHAR);
 			if (!options.name_list.empty()) {
 				throw BinderException("read_csv_auto column_names/names can only be supplied once");
 			}

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -99,6 +99,21 @@ static unique_ptr<FunctionData> ReadCSVBind(ClientContext &context, TableFunctio
 			if (names.empty()) {
 				throw BinderException("read_csv requires at least a single column as input!");
 			}
+		} else if (loption == "column_names" || loption == "names") {
+			auto &child_type = kv.second.type();
+			D_ASSERT(child_type.id() == LogicalTypeId::LIST);
+			auto &list_child = ListType::GetChildType(child_type);
+			D_ASSERT(list_child.id() == LogicalTypeId::VARCHAR);
+			if (!options.name_list.empty()) {
+				throw BinderException("read_csv_auto column_names/names can only be supplied once");
+			}
+			if (kv.second.IsNull()) {
+				throw BinderException("read_csv_auto %s cannot be NULL", kv.first);
+			}
+			auto &children = ListValue::GetChildren(kv.second);
+			for (auto &child : children) {
+				options.name_list.push_back(StringValue::Get(child));
+			}
 		} else if (loption == "column_types" || loption == "types" || loption == "dtypes") {
 			auto &child_type = kv.second.type();
 			if (child_type.id() != LogicalTypeId::STRUCT && child_type.id() != LogicalTypeId::LIST) {
@@ -961,6 +976,8 @@ TableFunction ReadCSVTableFunction::GetAutoFunction(bool list_parameter) {
 	read_csv_auto.named_parameters["column_types"] = LogicalType::ANY;
 	read_csv_auto.named_parameters["dtypes"] = LogicalType::ANY;
 	read_csv_auto.named_parameters["types"] = LogicalType::ANY;
+	read_csv_auto.named_parameters["names"] = LogicalType::LIST(LogicalType::VARCHAR);
+	read_csv_auto.named_parameters["column_names"] = LogicalType::LIST(LogicalType::VARCHAR);
 	return read_csv_auto;
 }
 

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -102,8 +102,7 @@ static unique_ptr<FunctionData> ReadCSVBind(ClientContext &context, TableFunctio
 		} else if (loption == "column_names" || loption == "names") {
 			auto &child_type = kv.second.type();
 			D_ASSERT(child_type.id() == LogicalTypeId::LIST);
-			auto &list_child = ListType::GetChildType(child_type);
-			D_ASSERT(list_child.id() == LogicalTypeId::VARCHAR);
+			D_ASSERT(ListType::GetChildType(child_type).id() == LogicalTypeId::VARCHAR);
 			if (!options.name_list.empty()) {
 				throw BinderException("read_csv_auto column_names/names can only be supplied once");
 			}

--- a/src/include/duckdb/execution/operator/persistent/csv_reader_options.hpp
+++ b/src/include/duckdb/execution/operator/persistent/csv_reader_options.hpp
@@ -75,6 +75,8 @@ struct BufferedCSVReaderOptions {
 	case_insensitive_map_t<idx_t> sql_types_per_column;
 	//! User-defined SQL type list
 	vector<LogicalType> sql_type_list;
+	//! User-defined name list
+	vector<string> name_list;
 	//===--------------------------------------------------------------------===//
 	// ReadCSVOptions
 	//===--------------------------------------------------------------------===//

--- a/test/sql/copy/csv/csv_names.test
+++ b/test/sql/copy/csv/csv_names.test
@@ -1,0 +1,57 @@
+# name: test/sql/copy/csv/csv_names.test
+# description: Read a CSV with names flags
+# group: [csv]
+
+statement ok
+PRAGMA enable_verification
+
+# no names provided
+query IIII
+select column00, column01, column02, column03 from 'test/sql/copy/csv/data/real/lineitem_sample.csv' LIMIT 1;
+----
+1	15519	785	1
+
+# override the names partially
+query IIII
+select l_orderkey, l_partkey, column02, column03 from read_csv_auto('test/sql/copy/csv/data/real/lineitem_sample.csv', names=['l_orderkey', 'l_partkey']) LIMIT 1;
+----
+1	15519	785	1
+
+# empty list
+query IIII
+select column00, column01, column02, column03 from read_csv_auto('test/sql/copy/csv/data/real/lineitem_sample.csv', names=[]) LIMIT 1;
+----
+1	15519	785	1
+
+# specify all names
+query IIII
+select l_orderkey, l_partkey, l_commitdate, l_comment from read_csv_auto('test/sql/copy/csv/data/real/lineitem_sample.csv', column_names=['l_orderkey', 'l_partkey', 'l_suppkey', 'l_linenumber', 'l_quantity', 'l_extendedprice', 'l_discount', 'l_tax', 'l_returnflag', 'l_linestatus', 'l_shipdate', 'l_commitdate', 'l_receiptdate', 'l_shipinstruct', 'l_shipmode', 'l_comment']) LIMIT 1;
+----
+1	15519	1996-02-12	egular courts above the
+
+# specify too many names
+query IIII
+select l_orderkey, l_partkey, l_commitdate, l_comment from read_csv_auto('test/sql/copy/csv/data/real/lineitem_sample.csv', names=['l_orderkey', 'l_partkey', 'l_suppkey', 'l_linenumber', 'l_quantity', 'l_extendedprice', 'l_discount', 'l_tax', 'l_returnflag', 'l_linestatus', 'l_shipdate', 'l_commitdate', 'l_receiptdate', 'l_shipinstruct', 'l_shipmode', 'l_comment', 'xx']) LIMIT 1;
+----
+1	15519	1996-02-12	egular courts above the
+
+# specify names on a file with a header
+query II
+select yr, Quarter from read_csv_auto('test/sql/copy/csv/data/real/ontime_sample.csv', names=['yr']) LIMIT 1;
+----
+1988	1
+
+# NULL
+statement error
+select column00, column01, column02, column03 from read_csv_auto('test/sql/copy/csv/data/real/lineitem_sample.csv', names=NULL) LIMIT 1;
+----
+read_csv_auto names cannot be NULL
+
+# specify the names twice
+statement error
+select l_orderkey, l_partkey, column02, column03 from read_csv_auto('test/sql/copy/csv/data/real/lineitem_sample.csv', names=['l_orderkey', 'l_partkey'], column_names=['l_orderkey']) LIMIT 1;
+----
+read_csv_auto column_names/names can only be supplied once
+
+statement error
+select l_orderkey, l_partkey, column02, column03 from read_csv_auto('test/sql/copy/csv/data/real/lineitem_sample.csv', names=42) LIMIT 1;

--- a/test/sql/copy/csv/csv_names.test
+++ b/test/sql/copy/csv/csv_names.test
@@ -55,3 +55,9 @@ read_csv_auto column_names/names can only be supplied once
 
 statement error
 select l_orderkey, l_partkey, column02, column03 from read_csv_auto('test/sql/copy/csv/data/real/lineitem_sample.csv', names=42) LIMIT 1;
+
+# duplicate names
+statement error
+select l_orderkey, l_partkey, column02, column03 from read_csv_auto('test/sql/copy/csv/data/real/lineitem_sample.csv', names=['l_orderkey', 'l_orderkey']) LIMIT 1;
+----
+duplicate column name


### PR DESCRIPTION
Implements #6003

This allows you to override only the names of a CSV file - which is useful when reading CSV files without headers but where types can be correctly inferred. Example usage:

###### dates.csv
```
1992|1|1
1993|1|1
```

```sql
SELECT * FROM read_csv_auto('dates.csv', names=['year', 'month', 'day']);
```

@Tishj perhaps you can pick this up and add it to the `read_csv` method in the Python client?