### PR TITLE
CI: Test for cron based workflows

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -1,6 +1,11 @@
 name: LinuxRelease
 on:
+  schedule:
+    - cron: "0 2 * * *"
   push:
+    branches:
+      - '**'
+      - '!master'
     paths-ignore:
       - '**.md'
   pull_request:


### PR DESCRIPTION
Idea is running LinuxRelease workflow (plus a few others) on a fixed schedule instead on every push to master