### PR TITLE
[C-API] Add support for StreamQueryResult

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -1172,18 +1172,6 @@ Otherwise, all remaining tasks must be executed first.
 */
 DUCKDB_API duckdb_state duckdb_execute_pending(duckdb_pending_result pending_result, duckdb_result *out_result);
 
-/*!
-Execute the pending query result, returning a stream query result.
-
-If duckdb_pending_execute_task has been called until DUCKDB_PENDING_RESULT_READY was returned, this will return fast.
-Otherwise, all remaining tasks must be executed first.
-
-* pending_result: The pending result to execute.
-* out_result: The returned streaming result object.
-* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
-*/
-DUCKDB_API duckdb_state duckdb_create_streaming_result(duckdb_pending_result pending_result, duckdb_result *out_result);
-
 //===--------------------------------------------------------------------===//
 // Value Interface
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -1175,6 +1175,9 @@ DUCKDB_API duckdb_state duckdb_execute_pending(duckdb_pending_result pending_res
 /*!
 Execute the pending query result, returning a stream query result.
 
+If duckdb_pending_execute_task has been called until DUCKDB_PENDING_RESULT_READY was returned, this will return fast.
+Otherwise, all remaining tasks must be executed first.
+
 * pending_result: The pending result to execute.
 * out_result: The returned streaming result object.
 * returns: `DuckDBSuccess` on success or `DuckDBError` on failure.

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -571,6 +571,14 @@ Use `duckdb_result_chunk_count` to figure out how many chunks there are in the r
 DUCKDB_API duckdb_data_chunk duckdb_result_get_chunk(duckdb_result result, idx_t chunk_index);
 
 /*!
+Checks if the type of the internal result is StreamQueryResult.
+
+* result: The result object to check.
+* returns: Whether or not the result object is of the type StreamQueryResult
+*/
+DUCKDB_API bool duckdb_result_is_streaming(duckdb_result result);
+
+/*!
 Returns the number of data chunks present in the result.
 
 * result: The result object
@@ -1107,6 +1115,21 @@ DUCKDB_API duckdb_state duckdb_pending_prepared(duckdb_prepared_statement prepar
                                                 duckdb_pending_result *out_result);
 
 /*!
+Executes the prepared statement with the given bound parameters, and returns a pending result.
+This pending result will create a streaming duckdb_result when executed.
+The pending result represents an intermediate structure for a query that is not yet fully executed.
+
+Note that after calling `duckdb_pending_prepared_streaming`, the pending result should always be destroyed using
+`duckdb_destroy_pending`, even if this function returns DuckDBError.
+
+* prepared_statement: The prepared statement to execute.
+* out_result: The pending query result.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
+DUCKDB_API duckdb_state duckdb_pending_prepared_streaming(duckdb_prepared_statement prepared_statement,
+                                                          duckdb_pending_result *out_result);
+
+/*!
 Closes the pending result and de-allocates all memory allocated for the result.
 
 * pending_result: The pending result to destroy.
@@ -1148,6 +1171,15 @@ Otherwise, all remaining tasks must be executed first.
 * returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
 */
 DUCKDB_API duckdb_state duckdb_execute_pending(duckdb_pending_result pending_result, duckdb_result *out_result);
+
+/*!
+Execute the pending query result, returning a stream query result.
+
+* pending_result: The pending result to execute.
+* out_result: The returned streaming result object.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
+DUCKDB_API duckdb_state duckdb_create_streaming_result(duckdb_pending_result pending_result, duckdb_result *out_result);
 
 //===--------------------------------------------------------------------===//
 // Value Interface
@@ -2318,6 +2350,28 @@ Returns true if execution of the current query is finished.
 * con: The connection on which to check
 */
 DUCKDB_API bool duckdb_execution_is_finished(duckdb_connection con);
+
+//===--------------------------------------------------------------------===//
+// Streaming Result Interface
+//===--------------------------------------------------------------------===//
+
+/*!
+Fetches a data chunk from the (streaming) duckdb_result. This function should be called repeatedly until the result is
+exhausted.
+
+The result must be destroyed with `duckdb_destroy_data_chunk`.
+
+This function can only be used on duckdb_results created with 'duckdb_pending_prepared_streaming'
+
+If this function is used, none of the other result functions can be used and vice versa (i.e. this function cannot be
+mixed with the legacy result functions or the materialized result functions).
+
+It is not known beforehand how many chunks will be returned by this result.
+
+* result: The result object to fetch the data chunk from.
+* returns: The resulting data chunk. Returns `NULL` if the result has an error.
+*/
+DUCKDB_API duckdb_data_chunk duckdb_stream_fetch_chunk(duckdb_result result);
 
 #ifdef __cplusplus
 }

--- a/src/include/duckdb/main/capi/capi_internal.hpp
+++ b/src/include/duckdb/main/capi/capi_internal.hpp
@@ -40,6 +40,7 @@ struct ExtractStatementsWrapper {
 
 struct PendingStatementWrapper {
 	unique_ptr<PendingQueryResult> statement;
+	bool allow_streaming;
 };
 
 struct ArrowResultWrapper {
@@ -56,6 +57,7 @@ struct AppenderWrapper {
 enum class CAPIResultSetType : uint8_t {
 	CAPI_RESULT_TYPE_NONE = 0,
 	CAPI_RESULT_TYPE_MATERIALIZED,
+	CAPI_RESULT_TYPE_STREAMING,
 	CAPI_RESULT_TYPE_DEPRECATED
 };
 

--- a/src/main/capi/CMakeLists.txt
+++ b/src/main/capi/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library_unity(
   prepared-c.cpp
   replacement_scan-c.cpp
   result-c.cpp
+  stream-c.cpp
   table_function-c.cpp
   threading-c.cpp
   value-c.cpp)

--- a/src/main/capi/stream-c.cpp
+++ b/src/main/capi/stream-c.cpp
@@ -1,0 +1,25 @@
+#include "duckdb/main/capi/capi_internal.hpp"
+#include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/common/allocator.hpp"
+
+duckdb_data_chunk duckdb_stream_fetch_chunk(duckdb_result result) {
+	if (!result.internal_data) {
+		return nullptr;
+	}
+	auto &result_data = *((duckdb::DuckDBResultData *)result.internal_data);
+	if (result_data.result_set_type == duckdb::CAPIResultSetType::CAPI_RESULT_TYPE_DEPRECATED) {
+		return nullptr;
+	}
+	if (result_data.result->type != duckdb::QueryResultType::STREAM_RESULT) {
+		// We can only fetch from a StreamQueryResult
+		return nullptr;
+	}
+	result_data.result_set_type = duckdb::CAPIResultSetType::CAPI_RESULT_TYPE_STREAMING;
+	auto &streaming = (duckdb::StreamQueryResult &)*result_data.result;
+	if (!streaming.IsOpen()) {
+		return nullptr;
+	}
+	// FetchRaw ? Do we care about flattening them?
+	auto chunk = streaming.Fetch();
+	return reinterpret_cast<duckdb_data_chunk>(chunk.release());
+}

--- a/test/api/capi/CMakeLists.txt
+++ b/test/api/capi/CMakeLists.txt
@@ -13,7 +13,8 @@ add_library_unity(
   test_capi_website.cpp
   test_capi_complex_types.cpp
   test_capi_to_decimal.cpp
-  test_capi_replacement_scan.cpp)
+  test_capi_replacement_scan.cpp
+  test_capi_streaming.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:test_sql_capi>
     PARENT_SCOPE)

--- a/test/api/capi/test_capi_pending.cpp
+++ b/test/api/capi/test_capi_pending.cpp
@@ -4,53 +4,6 @@
 using namespace duckdb;
 using namespace std;
 
-struct CAPIPrepared {
-	CAPIPrepared() {
-	}
-	~CAPIPrepared() {
-		if (!prepared) {
-			return;
-		}
-		duckdb_destroy_prepare(&prepared);
-	}
-
-	bool Prepare(CAPITester &tester, const string &query) {
-		auto state = duckdb_prepare(tester.connection, query.c_str(), &prepared);
-		return state == DuckDBSuccess;
-	}
-
-	duckdb_prepared_statement prepared = nullptr;
-};
-
-struct CAPIPending {
-	CAPIPending() {
-	}
-	~CAPIPending() {
-		if (!pending) {
-			return;
-		}
-		duckdb_destroy_pending(&pending);
-	}
-
-	bool Pending(CAPIPrepared &prepared) {
-		auto state = duckdb_pending_prepared(prepared.prepared, &pending);
-		return state == DuckDBSuccess;
-	}
-
-	duckdb_pending_state ExecuteTask() {
-		REQUIRE(pending);
-		return duckdb_pending_execute_task(pending);
-	}
-
-	unique_ptr<CAPIResult> Execute() {
-		duckdb_result result;
-		auto success = duckdb_execute_pending(pending, &result) == DuckDBSuccess;
-		return make_unique<CAPIResult>(result, success);
-	}
-
-	duckdb_pending_result pending = nullptr;
-};
-
 TEST_CASE("Test pending statements in C API", "[capi]") {
 	CAPITester tester;
 	CAPIPrepared prepared;

--- a/test/api/capi/test_capi_streaming.cpp
+++ b/test/api/capi/test_capi_streaming.cpp
@@ -26,7 +26,7 @@ TEST_CASE("Test streaming results in C API", "[capi]") {
 	result = pending.CreateStream();
 	REQUIRE(result);
 	REQUIRE(!result->HasError());
-	auto chunk = result->FetchChunk();
+	auto chunk = result->StreamChunk();
 
 	idx_t value = duckdb::DConstants::INVALID_INDEX;
 	idx_t chunk_count = 0;
@@ -42,6 +42,49 @@ TEST_CASE("Test streaming results in C API", "[capi]") {
 			REQUIRE(value > old_value);
 		}
 		chunk_count++;
-		chunk = result->FetchChunk();
+		chunk = result->StreamChunk();
 	}
+}
+
+TEST_CASE("Test other methods on streaming results in C API", "[capi]") {
+	CAPITester tester;
+	CAPIPrepared prepared;
+	CAPIPending pending;
+	unique_ptr<CAPIResult> result;
+
+	// open the database in in-memory mode
+	REQUIRE(tester.OpenDatabase(nullptr));
+	REQUIRE(prepared.Prepare(tester, "SELECT i::UINT32 FROM range(1000000) tbl(i)"));
+	REQUIRE(pending.PendingStreaming(prepared));
+
+	while (true) {
+		auto state = pending.ExecuteTask();
+		REQUIRE(state != DUCKDB_PENDING_ERROR);
+		if (state == DUCKDB_PENDING_RESULT_READY) {
+			break;
+		}
+	}
+
+	// Once we've done this, the StreamQueryResult is made
+	result = pending.CreateStream();
+	REQUIRE(result);
+	REQUIRE(!result->HasError());
+
+	// interrogate the result with various methods
+	auto chunk_count = result->ChunkCount();
+	REQUIRE(chunk_count == 0);
+	auto column_count = result->ColumnCount();
+	auto column_name = result->ColumnName(0);
+	auto column_type = result->ColumnType(0);
+	auto error_message = result->ErrorMessage();
+	auto fetched_chunk = result->FetchChunk(0);
+	REQUIRE(fetched_chunk == nullptr);
+	auto has_error = result->HasError();
+	auto is_null = result->IsNull(0, 0);
+	auto row_count = result->row_count();
+	auto rows_changes = result->rows_changed();
+
+	// this succeeds because the result is materialized if a stream-result method hasn't being used yet
+	auto column_data = result->ColumnData<uint32_t>(0);
+	REQUIRE(column_data != nullptr);
 }

--- a/test/api/capi/test_capi_streaming.cpp
+++ b/test/api/capi/test_capi_streaming.cpp
@@ -1,0 +1,47 @@
+#include "capi_tester.hpp"
+#include "duckdb.h"
+
+using namespace duckdb;
+using namespace std;
+
+TEST_CASE("Test streaming results in C API", "[capi]") {
+	CAPITester tester;
+	CAPIPrepared prepared;
+	CAPIPending pending;
+	unique_ptr<CAPIResult> result;
+
+	// open the database in in-memory mode
+	REQUIRE(tester.OpenDatabase(nullptr));
+	REQUIRE(prepared.Prepare(tester, "SELECT i::UINT32 FROM range(1000000) tbl(i)"));
+	REQUIRE(pending.PendingStreaming(prepared));
+
+	while (true) {
+		auto state = pending.ExecuteTask();
+		REQUIRE(state != DUCKDB_PENDING_ERROR);
+		if (state == DUCKDB_PENDING_RESULT_READY) {
+			break;
+		}
+	}
+
+	result = pending.CreateStream();
+	REQUIRE(result);
+	REQUIRE(!result->HasError());
+	auto chunk = result->FetchChunk();
+
+	idx_t value = duckdb::DConstants::INVALID_INDEX;
+	idx_t chunk_count = 0;
+	while (chunk) {
+		auto old_value = value;
+
+		auto vector = chunk->GetVector(0);
+		uint32_t *data = (uint32_t *)duckdb_vector_get_data(vector);
+		value = data[0];
+		if (old_value != duckdb::DConstants::INVALID_INDEX) {
+			// We select from a range, so we can expect every starting value of a new chunk to be higher than the last
+			// one.
+			REQUIRE(value > old_value);
+		}
+		chunk_count++;
+		chunk = result->FetchChunk();
+	}
+}

--- a/test/api/capi/test_capi_streaming.cpp
+++ b/test/api/capi/test_capi_streaming.cpp
@@ -75,19 +75,29 @@ TEST_CASE("Test other methods on streaming results in C API", "[capi]") {
 	auto chunk_count = result->ChunkCount();
 	REQUIRE(chunk_count == 0);
 	auto column_count = result->ColumnCount();
+	(void)column_count;
 	auto column_name = result->ColumnName(0);
+	(void)column_name;
 	auto column_type = result->ColumnType(0);
+	(void)column_type;
 	auto error_message = result->ErrorMessage();
+	REQUIRE(error_message == nullptr);
 	auto fetched_chunk = result->FetchChunk(0);
 	REQUIRE(fetched_chunk == nullptr);
 	auto has_error = result->HasError();
-	auto is_null = result->IsNull(0, 0);
+	REQUIRE(has_error == false);
 	auto row_count = result->row_count();
-	auto rows_changes = result->rows_changed();
+	REQUIRE(row_count == 0);
+	auto rows_changed = result->rows_changed();
+	REQUIRE(rows_changed == 0);
 
 	// this succeeds because the result is materialized if a stream-result method hasn't being used yet
 	auto column_data = result->ColumnData<uint32_t>(0);
 	REQUIRE(column_data != nullptr);
+
+	// this materializes the result
+	auto is_null = result->IsNull(0, 0);
+	REQUIRE(is_null == false);
 }
 
 TEST_CASE("Test materializing a streaming result in C API", "[capi]") {

--- a/test/include/capi_tester.hpp
+++ b/test/include/capi_tester.hpp
@@ -76,6 +76,10 @@ public:
 		return make_unique<CAPIDataChunk>(chunk);
 	}
 
+	bool IsStreaming() {
+		return duckdb_result_is_streaming(result);
+	}
+
 	unique_ptr<CAPIDataChunk> FetchChunk(idx_t chunk_idx) {
 		auto chunk = duckdb_result_get_chunk(result, chunk_idx);
 		if (!chunk) {

--- a/test/include/capi_tester.hpp
+++ b/test/include/capi_tester.hpp
@@ -265,12 +265,6 @@ struct CAPIPending {
 		return duckdb_pending_execute_task(pending);
 	}
 
-	unique_ptr<CAPIResult> CreateStream() {
-		duckdb_result result;
-		auto success = duckdb_create_streaming_result(pending, &result) == DuckDBSuccess;
-		return make_unique<CAPIResult>(result, success);
-	}
-
 	unique_ptr<CAPIResult> Execute() {
 		duckdb_result result;
 		auto success = duckdb_execute_pending(pending, &result) == DuckDBSuccess;


### PR DESCRIPTION
This PR adds a couple methods to the C-API to create and consume a stream query result.

The `pending` family of functions has a new addition:
```c
duckdb_state duckdb_pending_prepared_streaming(duckdb_prepared_statement prepared_statement,
                                               duckdb_pending_result *out_result);
```
This creates a `duckdb_pending_result`, like before, the pending query result can be partially executed with
`duckdb_pending_execute_task`.
The only difference is that to execute the pending query and turn it into a streaming query result, the following function needs to be called.
```c
duckdb_state duckdb_create_streaming_result(duckdb_pending_result pending_result, duckdb_result *out_result);
```
Similar to `duckdb_execute_pending` this creates a result object out of the pending query result.
~~(also note that this pending query result can not be turned into a regular result)~~

To interact with the result, most of the materialized-result family of functions can be used, with the exception of the chunk/row related functions.
To get a chunk out of the stream query result, instead you have to use:
```c
duckdb_data_chunk duckdb_stream_fetch_chunk(duckdb_result result);
```
