### PR TITLE
Fix #6304: correctly handle NULL partitions and constant vectors, plus handle default parameters in COPY

### DIFF
--- a/src/common/hive_partitioning.cpp
+++ b/src/common/hive_partitioning.cpp
@@ -150,6 +150,7 @@ HivePartitionedColumnData::HivePartitionedColumnData(const HivePartitionedColumn
 void HivePartitionedColumnData::ComputePartitionIndices(PartitionedColumnDataAppendState &state, DataChunk &input) {
 	Vector hashes(LogicalType::HASH, input.size());
 	input.Hash(group_by_columns, hashes);
+	hashes.Flatten(input.size());
 
 	for (idx_t i = 0; i < input.size(); i++) {
 		HivePartitionKey key;

--- a/src/include/duckdb/common/hive_partitioning.hpp
+++ b/src/include/duckdb/common/hive_partitioning.hpp
@@ -52,7 +52,15 @@ struct HivePartitionKey {
 
 	struct Equality {
 		bool operator()(const HivePartitionKey &a, const HivePartitionKey &b) const {
-			return a.values == b.values;
+			if (a.values.size() != b.values.size()) {
+				return false;
+			}
+			for (idx_t i = 0; i < a.values.size(); i++) {
+				if (!Value::NotDistinctFrom(a.values[i], b.values[i])) {
+					return false;
+				}
+			}
+			return true;
 		}
 	};
 };

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -97,17 +97,20 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 	for (auto &option : original_options) {
 		auto loption = StringUtil::Lower(option.first);
 		if (loption == "use_tmp_file") {
-			use_tmp_file = option.second[0].CastAs(context, LogicalType::BOOLEAN).GetValue<bool>();
+			use_tmp_file =
+			    option.second.empty() || option.second[0].CastAs(context, LogicalType::BOOLEAN).GetValue<bool>();
 			user_set_use_tmp_file = true;
 			continue;
 		}
 		if (loption == "allow_overwrite") {
-			allow_overwrite = option.second[0].CastAs(context, LogicalType::BOOLEAN).GetValue<bool>();
+			allow_overwrite =
+			    option.second.empty() || option.second[0].CastAs(context, LogicalType::BOOLEAN).GetValue<bool>();
 			continue;
 		}
 
 		if (loption == "per_thread_output") {
-			per_thread_output = option.second[0].CastAs(context, LogicalType::BOOLEAN).GetValue<bool>();
+			per_thread_output =
+			    option.second.empty() || option.second[0].CastAs(context, LogicalType::BOOLEAN).GetValue<bool>();
 			continue;
 		}
 		if (loption == "partition_by") {

--- a/test/sql/copy/partitioned/hive_filter_pushdown_bug.test
+++ b/test/sql/copy/partitioned/hive_filter_pushdown_bug.test
@@ -1,6 +1,6 @@
-# name: test/sql/copy/hive_filter_pushdown_bug.test
+# name: test/sql/copy/partitioned/hive_filter_pushdown_bug.test
 # description: confirm that hive-specific filter pushdown does not mess up the filters
-# group: [copy]
+# group: [partitioned]
 
 require parquet
 

--- a/test/sql/copy/partitioned/hive_partitioned_write.test
+++ b/test/sql/copy/partitioned/hive_partitioned_write.test
@@ -1,6 +1,6 @@
-# name: test/sql/copy/hive_partitioned_write.test
+# name: test/sql/copy/partitioned/hive_partitioned_write.test
 # description: basic tests for the hive partitioned write
-# group: [copy]
+# group: [partitioned]
 
 require parquet
 

--- a/test/sql/copy/partitioned/hive_partitioned_write.test_slow
+++ b/test/sql/copy/partitioned/hive_partitioned_write.test_slow
@@ -1,6 +1,6 @@
-# name: test/sql/copy/hive_partitioned_write.test_slow
+# name: test/sql/copy/partitioned/hive_partitioned_write.test_slow
 # description: slow test for the hive partitioned write
-# group: [copy]
+# group: [partitioned]
 
 require parquet
 

--- a/test/sql/copy/partitioned/partition_issue_6304.test
+++ b/test/sql/copy/partitioned/partition_issue_6304.test
@@ -1,0 +1,11 @@
+# name: test/sql/copy/partitioned/partition_issue_6304.test
+# description: Issue #6304: INTERNAL Error: Comparison on NULL values
+# group: [partitioned]
+
+require parquet
+
+statement ok
+copy (select NULL as i from range(100000)) to '__TEST_DIR__/issue6304_null' (format parquet, partition_by(i), allow_overwrite);
+
+statement ok
+copy (select 1 as i from range(100000)) to '__TEST_DIR__/issue6304_constant' (format parquet, partition_by(i), allow_overwrite);


### PR DESCRIPTION
Fixes #6304