### PR TITLE
Fix #6341: LEFT/RIGHT/OUTER join on condition that is always true is only equal to a cross product if the other side is not empty

### DIFF
--- a/src/optimizer/statistics/operator/propagate_join.cpp
+++ b/src/optimizer/statistics/operator/propagate_join.cpp
@@ -83,12 +83,8 @@ void StatisticsPropagator::PropagateStatistics(LogicalComparisonJoin &join, uniq
 						*node_ptr = std::move(cross_product);
 						return;
 					}
-					case JoinType::INNER:
-					case JoinType::LEFT:
-					case JoinType::RIGHT:
-					case JoinType::OUTER: {
-						// inner/left/right/full outer join, replace with cross product
-						// since the condition is always true, left/right/outer join are equivalent to inner join here
+					case JoinType::INNER: {
+						// inner, replace with cross product
 						auto cross_product =
 						    LogicalCrossProduct::Create(std::move(join.children[0]), std::move(join.children[1]));
 						*node_ptr = std::move(cross_product);

--- a/test/optimizer/statistics/statistics_join.test
+++ b/test/optimizer/statistics/statistics_join.test
@@ -67,12 +67,6 @@ EXPLAIN SELECT i1.i FROM integers i1 LEFT JOIN integers2 i2 ON i1.i=i2.i ORDER B
 ----
 logical_opt	<REGEX>:.*EMPTY_RESULT.*
 
-# left join with guaranteed match: same as inner join
-query II
-EXPLAIN SELECT i1.i FROM integers i1 LEFT JOIN integers2 i2 ON i1.i<i2.i ORDER BY 1;
-----
-logical_opt	<REGEX>:.*CROSS_PRODUCT.*
-
 # semi join
 # join cannot match: replaced with empty result
 query II

--- a/test/sql/join/left_outer/left_join_issue_6341.test
+++ b/test/sql/join/left_outer/left_join_issue_6341.test
@@ -1,0 +1,37 @@
+# name: test/sql/join/left_outer/left_join_issue_6341.test
+# description: Issue #6341: No rows returned in LEFT JOIN with < or > against table having no rows
+# group: [left_outer]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE foo (ts TIMESTAMP);
+
+statement ok
+CREATE TABLE bar (ts TIMESTAMP);
+
+
+statement ok
+INSERT INTO foo VALUES ('2023-01-01 00:00:00');
+
+statement ok
+INSERT INTO foo VALUES ('2023-01-01 00:00:01');
+
+query II
+SELECT foo.ts foo, bar.ts bar FROM foo LEFT JOIN bar ON foo.ts = bar.ts;
+----
+2023-01-01 00:00:00	NULL
+2023-01-01 00:00:01	NULL
+
+query II
+SELECT foo.ts foo, bar.ts bar FROM foo LEFT JOIN bar ON foo.ts < bar.ts;
+----
+2023-01-01 00:00:00	NULL
+2023-01-01 00:00:01	NULL
+
+query II
+SELECT foo.ts foo, bar.ts bar FROM foo LEFT JOIN bar ON foo.ts > bar.ts;
+----
+2023-01-01 00:00:00	NULL
+2023-01-01 00:00:01	NULL


### PR DESCRIPTION
Fixes #6341