### PR TITLE
Fixing a clang16 problem that slipped through

### DIFF
--- a/third_party/fmt/include/fmt/core.h
+++ b/third_party/fmt/include/fmt/core.h
@@ -359,12 +359,11 @@ using wstring_view = basic_string_view<wchar_t>;
 #if FMT_HAS_FEATURE(__cpp_char8_t)
 typedef char8_t fmt_char8_t;
 #else
-typedef unsigned char fmt_char8_t;
+typedef char fmt_char8_t;
 #endif
 
 /** Specifies if ``T`` is a character type. Can be specialized by users. */
 template <typename T> struct is_char : std::false_type {};
-template <> struct is_char<char> : std::true_type {};
 template <> struct is_char<wchar_t> : std::true_type {};
 template <> struct is_char<fmt_char8_t> : std::true_type {};
 template <> struct is_char<char16_t> : std::true_type {};


### PR DESCRIPTION
FMT used unsigned char as an internal type to represent single-byte characters. But it does not seem to matter and clang16 does not like the unsigned version:
`
duckdb/third_party/fmt/include/fmt/core.h:295:30: warning: 'char_traits<unsigned char>' is deprecated: char_traits<T> for T not equal to char, wchar_t, char8_t, char16_t or char32_t is non-standard and is provided for a temporary period. It will be removed in LLVM 18, so please migrate off of it. [-Wdeprecated-declarations]
`

From the spec:
https://en.cppreference.com/w/cpp/language/types
> char - type for character representation which can be most efficiently processed on the target system (has the same representation and alignment as either signed char or unsigned char, but is always a distinct type). [Multibyte characters strings](https://en.cppreference.com/w/cpp/string/multibyte) use this type to represent code units. For every value of type unsigned char in range [0, 255], converting the value to char and then back to unsigned char produces the original value. (since C++11) The signedness of char depends on the compiler and the target platform: the defaults for ARM and PowerPC are typically unsigned, the defaults for x86 and x64 are typically signed.