### PR TITLE
Add Initial DuckDB Swift API

### DIFF
--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -1,0 +1,53 @@
+name: Swift
+on:
+  workflow_dispatch:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'examples/**'
+      - 'test/**'
+      - 'tools/juliapkg/**'
+      - 'tools/nodejs/**'
+      - 'tools/pythonpkg/**'
+      - 'tools/rpkg/**'
+      - '.github/workflows/**'
+      - '!.github/workflows/Swift.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+
+  test-apple-platforms:
+    strategy:
+      matrix:
+        # destinations need to match selected version of Xcode
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#installed-simulators
+        destination:
+          - 'macOS'
+          - 'iOS Simulator,name=iPhone 14'
+          - 'watchOS Simulator,name=Apple Watch Ultra (49mm)'
+          - 'tvOS Simulator,name=Apple TV 4K (at 1080p) (2nd generation)'
+    runs-on: macos-12
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Prepare Package
+        run: python3 tools/swiftpm/create_package.py tools/swiftpm
+
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_14.2.app && /usr/bin/xcodebuild -version
+
+      - name: Run Tests
+        run: |
+          xcrun xcodebuild test \
+            -workspace tools/swiftpm/duckdb-swift/DuckDB.xcworkspace \
+            -scheme DuckDB \
+            -destination platform='${{ matrix.destination }}'
+          

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -15,7 +15,7 @@ on:
       - 'examples/**'
       - 'test/**'
       - 'tools/**'
-      - '!tools/swiftpkg/**'
+      - '!tools/swiftpm/**'
       - '.github/workflows/**'
       - '!.github/workflows/Swift.yml'
 

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -1,7 +1,12 @@
 name: Swift
 on:
-  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *"
   push:
+    branches:
+      - '**'
+      - '!master'
+      - '!feature'
     paths-ignore:
       - '**.md'
   pull_request:
@@ -9,10 +14,8 @@ on:
       - '**.md'
       - 'examples/**'
       - 'test/**'
-      - 'tools/juliapkg/**'
-      - 'tools/nodejs/**'
-      - 'tools/pythonpkg/**'
-      - 'tools/rpkg/**'
+      - 'tools/**'
+      - '!tools/swiftpkg/**'
       - '.github/workflows/**'
       - '!.github/workflows/Swift.yml'
 

--- a/.github/workflows/SwiftRelease.yml
+++ b/.github/workflows/SwiftRelease.yml
@@ -1,0 +1,65 @@
+name: SwiftRelease
+on:
+  release:
+    types: [published]
+  push:
+    branches: [master]
+
+env:
+  SOURCE_REF: ${{ github.event_name == 'release' && github.ref_name || 'master' }}
+  TARGET_REPO: 'duckdb/duckdb-swift'
+  TARGET_REF: 'main'
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+jobs:
+
+  update:
+
+    name: Update Swift Repo
+    runs-on: ubuntu-latest
+    steps:
+          
+      - name: Checkout Source Repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.SOURCE_REF }}
+          path: 'source-repo'
+          
+      - name: Checkout Target Repo
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.TARGET_REPO }}
+          ref: ${{ env.TARGET_REF }}
+          token: ${{ env.GH_TOKEN }}
+          path: 'target-repo'
+
+      - name: Generate Swift Package
+        run: python3 source-repo/tools/swiftpm/create_package.py source-repo/tools/swiftpm
+
+      - name: Package Update
+        run: |
+          mkdir updated-repo
+          mv -v target-repo/.git updated-repo/.git
+          mv -v source-repo/tools/swiftpm/duckdb-swift/* updated-repo/
+
+      - name: Commit Updated Repo
+        run: |
+          git -C updated-repo config user.name github-actions
+          git -C updated-repo config user.email github-actions@github.com
+          git -C updated-repo add -A
+          if [[ $(git -C updated-repo status --porcelain) ]]; then
+            git -C updated-repo commit -m "automated update"
+          fi
+
+      - name: Push Update
+        if: github.event_name == 'push'
+        run: |
+          git -C updated-repo push
+
+      - name: Tag Release
+        if: github.event_name == 'release'
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          git -C updated-repo tag -a $TAG_NAME -m "Release $TAG_NAME"
+          git -C updated-repo push origin $TAG_NAME

--- a/tools/swiftpm/.gitignore
+++ b/tools/swiftpm/.gitignore
@@ -1,0 +1,2 @@
+duckdb-swift/Sources/Cduckdb/
+duckdb-swift/Package.swift

--- a/tools/swiftpm/Package.swift.template
+++ b/tools/swiftpm/Package.swift.template
@@ -1,0 +1,36 @@
+// swift-tools-version: 5.7
+
+import PackageDescription
+
+let package = Package(
+
+  name: "DuckDB",
+  products: [
+    .library(name: "DuckDB", targets: ["DuckDB"]),
+  ],
+  targets: [
+    .target(
+      name: "DuckDB",
+      dependencies: ["Cduckdb"]
+    ),
+    .target(
+      name: "Cduckdb",
+      sources: [
+        $source_list
+      ],
+      cxxSettings: [
+        $search_path_list
+        $define_list
+        .define("DUCKDB_BUILD_LIBRARY")
+      ]
+    ),
+    .testTarget(
+      name: "DuckDBTests",
+      dependencies: ["DuckDB"],
+      resources: [
+          .process("Resources")
+      ]
+    )
+  ],
+  cxxLanguageStandard: .cxx11
+)

--- a/tools/swiftpm/create_package.py
+++ b/tools/swiftpm/create_package.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import shutil
+from pathlib import Path
+from string import Template
+
+# list of extensions to bundle
+extensions = ['parquet', 'icu', 'json']
+
+# name of the repository
+repo_name = 'duckdb-swift'
+
+# name of the Swift package C target
+swift_target_name = 'Cduckdb'
+
+# name of the target's source dir
+src_dir_name = 'duckdb'
+
+# path to target
+base_dir = os.path.abspath(sys.argv[1] if len(sys.argv) > 1 else os.getcwd())
+package_dir = os.path.join(base_dir, repo_name) 
+target_dir = os.path.join(package_dir, 'Sources', swift_target_name)
+includes_dir = os.path.join(target_dir, 'include')
+src_dir = os.path.join(target_dir, src_dir_name)
+
+# Prepare target directory
+Path(target_dir).mkdir(parents=True,exist_ok=True)
+Path(includes_dir).mkdir(parents=True,exist_ok=True)
+
+# build package source files
+os.chdir(base_dir)
+os.chdir(os.path.join('..', '..'))
+sys.path.append('scripts')
+import package_build
+# fresh build - copy over all of the files
+(source_list, include_list, _) = package_build.build_package(
+    src_dir, extensions, 32, src_dir_name)
+# standardise paths
+source_list = [os.path.relpath(x, target_dir) if os.path.isabs(x) else x for x in source_list]
+include_list = [os.path.join(src_dir_name, x) for x in include_list]
+define_list = ['BUILD_{}_EXTENSION'.format(ext.upper()) for ext in extensions]
+# write Package.swift
+os.chdir(base_dir)
+
+# copy umbrella header to path SPM expects (auto .modulemap)
+header_file_src = os.path.join(src_dir, 'src', 'include', 'duckdb.h')
+header_file_dest= os.path.join(includes_dir, 'duckdb.h')
+shutil.copyfile(header_file_src, header_file_dest)
+
+source_list_strs = ['"' + x + '",' for x in source_list]
+include_list_strs = ['.headerSearchPath("' + x + '"),' for x in include_list]
+define_list_strs = ['.define("' + x + '"),' for x in define_list]
+src_line_prefix = '\n        ' # indents eight spaces
+
+content = {
+    'source_list': src_line_prefix.join(source_list_strs),
+    'search_path_list': src_line_prefix.join(include_list_strs),
+    'define_list': src_line_prefix.join(define_list_strs),
+}
+
+package_manifest_path = os.path.join(package_dir, 'Package.swift')
+with open('Package.swift.template', 'r') as f:
+    src = Template(f.read())
+    result = src.substitute(content)
+    with open(package_manifest_path, 'w') as f:
+        f.write(result)

--- a/tools/swiftpm/duckdb-swift/.gitignore
+++ b/tools/swiftpm/duckdb-swift/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/tools/swiftpm/duckdb-swift/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/tools/swiftpm/duckdb-swift/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string>
+//  DuckDB
+//  https://github.com/duckdb/duckdb-swift
+//
+//  Copyright © 2018-___YEAR___ Stichting DuckDB Foundation
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.</string>
+</dict>
+</plist>
+

--- a/tools/swiftpm/duckdb-swift/.swiftpm/xcode/xcshareddata/xcschemes/DuckDB.xcscheme
+++ b/tools/swiftpm/duckdb-swift/.swiftpm/xcode/xcshareddata/xcschemes/DuckDB.xcscheme
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DuckDB_DuckDBTests"
+               BuildableName = "DuckDB_DuckDBTests"
+               BlueprintName = "DuckDB_DuckDBTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DuckDB"
+               BuildableName = "DuckDB"
+               BlueprintName = "DuckDB"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DuckDBTests"
+               BuildableName = "DuckDBTests"
+               BlueprintName = "DuckDBTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Cduckdb"
+               BuildableName = "Cduckdb"
+               BlueprintName = "Cduckdb"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DuckDBTests"
+               BuildableName = "DuckDBTests"
+               BlueprintName = "DuckDBTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DuckDB_DuckDBTests"
+            BuildableName = "DuckDB_DuckDBTests"
+            BlueprintName = "DuckDB_DuckDBTests"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/tools/swiftpm/duckdb-swift/DuckDB.xcworkspace/contents.xcworkspacedata
+++ b/tools/swiftpm/duckdb-swift/DuckDB.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:">
+   </FileRef>
+</Workspace>

--- a/tools/swiftpm/duckdb-swift/DuckDB.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/tools/swiftpm/duckdb-swift/DuckDB.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string>
+//  DuckDB
+//  https://github.com/duckdb/duckdb-swift
+//
+//  Copyright © 2018-___YEAR___ Stichting DuckDB Foundation
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.</string>
+</dict>
+</plist>
+

--- a/tools/swiftpm/duckdb-swift/DuckDB.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/tools/swiftpm/duckdb-swift/DuckDB.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/tools/swiftpm/duckdb-swift/README.md
+++ b/tools/swiftpm/duckdb-swift/README.md
@@ -1,0 +1,3 @@
+# DuckDB
+
+A description of this package.

--- a/tools/swiftpm/duckdb-swift/Sources/DuckDB/Internal/CTypeUtilities.swift
+++ b/tools/swiftpm/duckdb-swift/Sources/DuckDB/Internal/CTypeUtilities.swift
@@ -1,0 +1,56 @@
+//
+//  DuckDB
+//  https://github.com/duckdb/duckdb-swift
+//
+//  Copyright © 2018-2023 Stichting DuckDB Foundation
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+
+@_implementationOnly import Cduckdb
+import Foundation
+
+extension duckdb_state {
+  static let success = duckdb_state(0)
+  static let failure = duckdb_state(1)
+}
+
+extension duckdb_pending_state {
+  static let ready = duckdb_pending_state(0)
+  static let notReady = duckdb_pending_state(1)
+  static let error = duckdb_pending_state(2)
+}
+
+extension UnsafePointer where Pointee == duckdb_string {
+  
+  private static let inlineLimit = UInt32(12)
+  
+  var contents: String {
+    let contentsSize = UnsafeRawPointer(self).load(as: UInt32.self)
+    let strPtr: UnsafeRawPointer
+    if contentsSize <= Self.inlineLimit {
+      strPtr = UnsafeRawPointer(self).advanced(by: MemoryLayout<UInt32>.stride)
+    }
+    else {
+      let strPtrPtr = UnsafeRawPointer(self).advanced(by: MemoryLayout<UInt64>.stride)
+      strPtr = strPtrPtr.load(as: UnsafeRawPointer.self)
+    }
+    let stringData = Data(bytes: strPtr, count: Int(contentsSize))
+    return String(data: stringData, encoding:.utf8)!
+  }
+}

--- a/tools/swiftpm/duckdb-swift/Sources/DuckDB/Internal/DataChunk.swift
+++ b/tools/swiftpm/duckdb-swift/Sources/DuckDB/Internal/DataChunk.swift
@@ -1,0 +1,47 @@
+//
+//  DuckDB
+//  https://github.com/duckdb/duckdb-swift
+//
+//  Copyright © 2018-2023 Stichting DuckDB Foundation
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+
+@_implementationOnly import Cduckdb
+import Foundation
+
+final class DataChunk {
+  
+  var count: DBInt { duckdb_data_chunk_get_size(ptr.pointee) }
+  var columnCount: DBInt { duckdb_data_chunk_get_column_count(ptr.pointee) }
+  
+  private let ptr = UnsafeMutablePointer<duckdb_data_chunk?>.allocate(capacity: 1)
+  
+  init(result: QueryResult, index: DBInt) {
+    self.ptr.pointee = result.withCResult { duckdb_result_get_chunk($0, index)! }
+  }
+  
+  deinit {
+    duckdb_destroy_data_chunk(ptr)
+    ptr.deallocate()
+  }
+  
+  func withCVector<T>(at index: DBInt, _ body: (duckdb_vector) throws -> T) rethrows -> T {
+    try body(duckdb_data_chunk_get_vector(ptr.pointee, index))
+  }
+}

--- a/tools/swiftpm/duckdb-swift/Sources/DuckDB/Internal/DuckDBTypeID.swift
+++ b/tools/swiftpm/duckdb-swift/Sources/DuckDB/Internal/DuckDBTypeID.swift
@@ -1,0 +1,134 @@
+//
+//  DuckDB
+//  https://github.com/duckdb/duckdb-swift
+//
+//  Copyright © 2018-2023 Stichting DuckDB Foundation
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+
+@_implementationOnly import Cduckdb
+
+struct DuckDBTypeID: RawRepresentable, Equatable {
+  let rawValue: UInt32
+  init(rawValue: UInt32) {
+    self.rawValue = rawValue
+  }
+}
+
+extension DuckDBTypeID {
+  // invalid data type
+  static let invalid = DuckDBTypeID(rawValue: DUCKDB_TYPE_INVALID.rawValue)
+  // bool
+  static let boolean = DuckDBTypeID(rawValue: DUCKDB_TYPE_BOOLEAN.rawValue)
+  // int8_t
+  static let tinyint = DuckDBTypeID(rawValue: DUCKDB_TYPE_TINYINT.rawValue)
+  // int16_t
+  static let smallint = DuckDBTypeID(rawValue: DUCKDB_TYPE_SMALLINT.rawValue)
+  // int32_t
+  static let integer = DuckDBTypeID(rawValue: DUCKDB_TYPE_INTEGER.rawValue)
+  // int64_t
+  static let bigint = DuckDBTypeID(rawValue: DUCKDB_TYPE_BIGINT.rawValue)
+  // uint8_t
+  static let utinyint = DuckDBTypeID(rawValue: DUCKDB_TYPE_UTINYINT.rawValue)
+  // uint16_t
+  static let usmallint = DuckDBTypeID(rawValue: DUCKDB_TYPE_USMALLINT.rawValue)
+  // uint32_t
+  static let uinteger = DuckDBTypeID(rawValue: DUCKDB_TYPE_UINTEGER.rawValue)
+  // uint64_t
+  static let ubigint = DuckDBTypeID(rawValue: DUCKDB_TYPE_UBIGINT.rawValue)
+  // float
+  static let float = DuckDBTypeID(rawValue: DUCKDB_TYPE_FLOAT.rawValue)
+  // double
+  static let double = DuckDBTypeID(rawValue: DUCKDB_TYPE_DOUBLE.rawValue)
+  // duckdb_timestamp, in microseconds
+  static let timestamp = DuckDBTypeID(rawValue: DUCKDB_TYPE_TIMESTAMP.rawValue)
+  // duckdb_date
+  static let date = DuckDBTypeID(rawValue: DUCKDB_TYPE_DATE.rawValue)
+  // duckdb_time
+  static let time = DuckDBTypeID(rawValue: DUCKDB_TYPE_TIME.rawValue)
+  // duckdb_interval
+  static let interval = DuckDBTypeID(rawValue: DUCKDB_TYPE_INTERVAL.rawValue)
+  // duckdb_hugeint
+  static let hugeint = DuckDBTypeID(rawValue: DUCKDB_TYPE_HUGEINT.rawValue)
+  // const char*
+  static let varchar = DuckDBTypeID(rawValue: DUCKDB_TYPE_VARCHAR.rawValue)
+  // duckdb_blob
+  static let blob = DuckDBTypeID(rawValue: DUCKDB_TYPE_BLOB.rawValue)
+  // decimal
+  static let decimal = DuckDBTypeID(rawValue: DUCKDB_TYPE_DECIMAL.rawValue)
+  // duckdb_timestamp, in seconds
+  static let timestamp_s = DuckDBTypeID(rawValue: DUCKDB_TYPE_TIMESTAMP_S.rawValue)
+  // duckdb_timestamp, in milliseconds
+  static let timestamp_ms = DuckDBTypeID(rawValue: DUCKDB_TYPE_TIMESTAMP_MS.rawValue)
+  // duckdb_timestamp, in nanoseconds
+  static let timestamp_ns = DuckDBTypeID(rawValue: DUCKDB_TYPE_TIMESTAMP_NS.rawValue)
+  // enum type, only useful as logical type
+  static let `enum` = DuckDBTypeID(rawValue: DUCKDB_TYPE_ENUM.rawValue)
+  // list type, only useful as logical type
+  static let list = DuckDBTypeID(rawValue: DUCKDB_TYPE_LIST.rawValue)
+  // struct type, only useful as logical type
+  static let `struct` = DuckDBTypeID(rawValue: DUCKDB_TYPE_STRUCT.rawValue)
+  // map type, only useful as logical type
+  static let map = DuckDBTypeID(rawValue: DUCKDB_TYPE_MAP.rawValue)
+  // union type, only useful as logical type
+  static let union = DuckDBTypeID(rawValue: DUCKDB_TYPE_UNION.rawValue)
+  // duckdb_hugeint
+  static let uuid = DuckDBTypeID(rawValue: DUCKDB_TYPE_UUID.rawValue)
+  // const char*
+//  static let json = DUCKDB_TYPE(DUCKDB_TYPE_JSON.rawValue)
+}
+
+extension DuckDBTypeID: CustomStringConvertible {
+  
+  public var description: String {
+    switch self {
+    case .boolean: return "boolean"
+    case .tinyint: return "tinyint"
+    case .smallint: return "smallint"
+    case .integer: return "integer"
+    case .bigint: return "bigint"
+    case .utinyint: return "utinyint"
+    case .usmallint: return "usmallint"
+    case .uinteger: return "uinteger"
+    case .ubigint: return "ubigint"
+    case .float: return "float"
+    case .double: return "double"
+    case .timestamp: return "timestamp"
+    case .date: return "date"
+    case .time: return "time"
+    case .interval: return "interval"
+    case .hugeint: return "hugeint"
+    case .varchar: return "varchar"
+    case .blob: return "blob"
+    case .decimal: return "decimal"
+    case .timestamp_s: return "timestamp_s"
+    case .timestamp_ms: return "timestamp_ms"
+    case .timestamp_ns: return "timestamp_ns"
+    case .`enum`: return "enum"
+    case .list: return "list"
+    case .`struct`: return "struct"
+    case .map: return "map"
+    case .union: return "union"
+    case .uuid: return "uuid"
+//    case .json: return "json"
+    case .invalid: return "invalid"
+    default: return "unknown (\(self.rawValue))"
+    }
+  }
+}

--- a/tools/swiftpm/duckdb-swift/Sources/DuckDB/Internal/PrimitiveDatabaseValue.swift
+++ b/tools/swiftpm/duckdb-swift/Sources/DuckDB/Internal/PrimitiveDatabaseValue.swift
@@ -1,0 +1,71 @@
+//
+//  DuckDB
+//  https://github.com/duckdb/duckdb-swift
+//
+//  Copyright © 2018-2023 Stichting DuckDB Foundation
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+
+protocol PrimitiveDatabaseValue {
+  static var representedDatabaseTypeID: DuckDBTypeID { get }
+}
+
+extension Bool: PrimitiveDatabaseValue {
+  static var representedDatabaseTypeID: DuckDBTypeID { .boolean }
+}
+
+extension Int8: PrimitiveDatabaseValue {
+  static var representedDatabaseTypeID: DuckDBTypeID { .tinyint }
+}
+
+extension Int16: PrimitiveDatabaseValue {
+  static var representedDatabaseTypeID: DuckDBTypeID { .smallint }
+}
+
+extension Int32: PrimitiveDatabaseValue {
+  static var representedDatabaseTypeID: DuckDBTypeID { .integer }
+}
+
+extension Int64: PrimitiveDatabaseValue  {
+  static var representedDatabaseTypeID: DuckDBTypeID { .bigint }
+}
+
+extension UInt8: PrimitiveDatabaseValue {
+  static var representedDatabaseTypeID: DuckDBTypeID { .utinyint }
+}
+
+extension UInt16: PrimitiveDatabaseValue {
+  static var representedDatabaseTypeID: DuckDBTypeID { .usmallint }
+}
+
+extension UInt32: PrimitiveDatabaseValue {
+  static var representedDatabaseTypeID: DuckDBTypeID { .uinteger }
+}
+
+extension UInt64: PrimitiveDatabaseValue {
+  static var representedDatabaseTypeID: DuckDBTypeID { .ubigint }
+}
+
+extension Float: PrimitiveDatabaseValue {
+  static var representedDatabaseTypeID: DuckDBTypeID { .float }
+}
+
+extension Double: PrimitiveDatabaseValue {
+  static var representedDatabaseTypeID: DuckDBTypeID { .double }
+}

--- a/tools/swiftpm/duckdb-swift/Sources/DuckDB/Internal/Utilities.swift
+++ b/tools/swiftpm/duckdb-swift/Sources/DuckDB/Internal/Utilities.swift
@@ -1,0 +1,33 @@
+//
+//  DuckDB
+//  https://github.com/duckdb/duckdb-swift
+//
+//  Copyright © 2018-2023 Stichting DuckDB Foundation
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+
+import Foundation
+
+extension Optional where Wrapped: StringProtocol {
+  
+  func withOptionalCString<T>(_ body: (UnsafePointer<CChar>?) throws -> T) rethrows -> T {
+    guard let string = self else { return try body(nil) }
+    return try string.withCString(body)
+  }
+}

--- a/tools/swiftpm/duckdb-swift/Sources/DuckDB/Public/Column.swift
+++ b/tools/swiftpm/duckdb-swift/Sources/DuckDB/Public/Column.swift
@@ -1,0 +1,150 @@
+//
+//  DuckDB
+//  https://github.com/duckdb/duckdb-swift
+//
+//  Copyright © 2018-2023 Stichting DuckDB Foundation
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+
+@_implementationOnly import Cduckdb
+
+public struct Column<DataType> {
+  
+  private let result: QueryResult
+  private let columnIndex: DBInt
+  private let itemAt: (DBInt) -> DataType?
+  
+  init(result: QueryResult, columnIndex: DBInt) where DataType == Void {
+    let transformer = result.transformer(forColumn: columnIndex, to: Void.self)
+    self.init(result: result, columnIndex: columnIndex, itemAt: transformer)
+  }
+  
+  init(result: QueryResult, columnIndex: DBInt, itemAt: @escaping (DBInt) -> DataType?) {
+    self.result = result
+    self.columnIndex = columnIndex
+    self.itemAt = itemAt
+  }
+}
+
+// MARK: - Type Casting
+
+public extension Column {
+  
+  func cast(to type: Void.Type) -> Column<Void> {
+    .init(result: result, columnIndex: columnIndex)
+  }
+  
+  func cast(to type: Bool.Type) -> Column<Bool> {
+    let transformer = result.transformer(forColumn: columnIndex, to: Bool.self)
+    return .init(result: result, columnIndex: columnIndex, itemAt: transformer)
+  }
+  
+  func cast(to type: Int8.Type) -> Column<Int8> {
+    let transformer = result.transformer(forColumn: columnIndex, to: Int8.self)
+    return .init(result: result, columnIndex: columnIndex, itemAt: transformer)
+  }
+  
+  func cast(to type: Int16.Type) -> Column<Int16> {
+    let transformer = result.transformer(forColumn: columnIndex, to: Int16.self)
+    return .init(result: result, columnIndex: columnIndex, itemAt: transformer)
+  }
+  
+  func cast(to type: Int32.Type) -> Column<Int32> {
+    let transformer = result.transformer(forColumn: columnIndex, to: Int32.self)
+    return .init(result: result, columnIndex: columnIndex, itemAt: transformer)
+  }
+  
+  func cast(to type: Int64.Type) -> Column<Int64> {
+    let transformer = result.transformer(forColumn: columnIndex, to: Int64.self)
+    return .init(result: result, columnIndex: columnIndex, itemAt: transformer)
+  }
+  
+  func cast(to type: UInt8.Type) -> Column<UInt8> {
+    let transformer = result.transformer(forColumn: columnIndex, to: UInt8.self)
+    return .init(result: result, columnIndex: columnIndex, itemAt: transformer)
+  }
+  
+  func cast(to type: UInt16.Type) -> Column<UInt16> {
+    let transformer = result.transformer(forColumn: columnIndex, to: UInt16.self)
+    return .init(result: result, columnIndex: columnIndex, itemAt: transformer)
+  }
+  
+  func cast(to type: UInt32.Type) -> Column<UInt32> {
+    let transformer = result.transformer(forColumn: columnIndex, to: UInt32.self)
+    return .init(result: result, columnIndex: columnIndex, itemAt: transformer)
+  }
+  
+  func cast(to type: UInt64.Type) -> Column<UInt64> {
+    let transformer = result.transformer(forColumn: columnIndex, to: UInt64.self)
+    return .init(result: result, columnIndex: columnIndex, itemAt: transformer)
+  }
+  
+  func cast(to type: Float.Type) -> Column<Float> {
+    let transformer = result.transformer(forColumn: columnIndex, to: Float.self)
+    return .init(result: result, columnIndex: columnIndex, itemAt: transformer)
+  }
+  
+  func cast(to type: Double.Type) -> Column<Double> {
+    let transformer = result.transformer(forColumn: columnIndex, to: Double.self)
+    return .init(result: result, columnIndex: columnIndex, itemAt: transformer)
+  }
+  
+  func cast(to type: String.Type) -> Column<String> {
+    let transformer = result.transformer(forColumn: columnIndex, to: String.self)
+    return .init(result: result, columnIndex: columnIndex, itemAt: transformer)
+  }
+}
+
+// MARK: - Collection conformance
+
+extension Column: Collection {
+  
+  public typealias Element = DataType?
+  
+  public struct Iterator: IteratorProtocol {
+    
+    private let column: Column
+    private var position: DBInt
+    
+    init(column: Column) {
+      self.column = column
+      self.position = column.startIndex
+    }
+    
+    public mutating func next() -> Element? {
+      guard position < column.endIndex else { return nil }
+      defer { position += 1 }
+      return .some(column[position])
+    }
+  }
+  
+  public var startIndex: DBInt { 0 }
+  public var endIndex: DBInt { result.rowCount }
+  
+  public subscript(position: DBInt) -> DataType? {
+    itemAt(position)
+  }
+  
+  public func makeIterator() -> Iterator {
+    Iterator(column: self)
+  }
+  
+  public func index(after i: DBInt) -> DBInt { i + 1 }
+  public func index(before i: DBInt) -> DBInt { i - 1 }
+}

--- a/tools/swiftpm/duckdb-swift/Sources/DuckDB/Public/Connection.swift
+++ b/tools/swiftpm/duckdb-swift/Sources/DuckDB/Public/Connection.swift
@@ -1,0 +1,59 @@
+//
+//  DuckDB
+//  https://github.com/duckdb/duckdb-swift
+//
+//  Copyright © 2018-2023 Stichting DuckDB Foundation
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+
+@_implementationOnly import Cduckdb
+
+public final class Connection {
+
+  private let database: Database
+  private let ptr = UnsafeMutablePointer<duckdb_connection?>.allocate(capacity: 1)
+
+  public init(database: Database) throws {
+    self.database = database
+    let status = database.withCDatabase { duckdb_connect($0, ptr) }
+    guard status == .success else { throw DatabaseError.failedToOpenConnection }
+  }
+
+  deinit {
+    duckdb_disconnect(ptr)
+    ptr.deallocate()
+  }
+  
+  public func query(_ sql: String) throws -> QueryResult {
+    try QueryResult(connection: self, sql: sql)
+  }
+  
+  public func execute(_ sql: String) throws {
+    let status = sql.withCString { queryStrPtr in
+      duckdb_query(ptr.pointee, queryStrPtr, nil)
+    }
+    guard status == .success else {
+      throw DatabaseError.queryError(reason: nil)
+    }
+  }
+  
+  func withCConnection<T>(_ body: (duckdb_connection?) throws -> T) rethrows -> T {
+    try body(ptr.pointee)
+  }
+}

--- a/tools/swiftpm/duckdb-swift/Sources/DuckDB/Public/Database.swift
+++ b/tools/swiftpm/duckdb-swift/Sources/DuckDB/Public/Database.swift
@@ -1,0 +1,79 @@
+//
+//  DuckDB
+//  https://github.com/duckdb/duckdb-swift
+//
+//  Copyright © 2018-2023 Stichting DuckDB Foundation
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+
+@_implementationOnly import Cduckdb
+import Foundation
+
+// TODO: - Check its safe to always assume UInt64 insetad of idx_t
+public typealias DBInt = UInt64
+
+public final class Database {
+  
+  public enum Store {
+    case file(at: URL)
+    case inMemory
+  }
+  
+  private let ptr = UnsafeMutablePointer<duckdb_database?>.allocate(capacity: 1)
+  
+  public convenience init(store: Store = .inMemory) throws {
+    var fileURL: URL?
+    if case .file(let url) = store {
+      guard url.isFileURL else {
+        throw DatabaseError.failedToOpenDatabase(
+          reason: "provided URL for database store file must be local")
+      }
+      fileURL = url
+    }
+    try self.init(path: fileURL?.path, config: nil)
+  }
+  
+  private init(path: String?, config: duckdb_config?) throws {
+    let outError = UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>.allocate(capacity: 1)
+    defer { outError.deallocate() }
+    let status = path.withOptionalCString { strPtr in
+      duckdb_open_ext(strPtr, ptr, config, outError)
+    }
+    guard status == .success else {
+      let error = outError.pointee.map { ptr in
+        defer { duckdb_free(ptr) }
+        return String(cString: ptr)
+      }
+      throw DatabaseError.failedToOpenDatabase(reason: error)
+    }
+  }
+  
+  deinit {
+    duckdb_close(ptr)
+    ptr.deallocate()
+  }
+  
+  public func connect() throws -> Connection {
+    try .init(database: self)
+  }
+  
+  func withCDatabase<T>(_ body: (duckdb_database?) throws -> T) rethrows -> T {
+    try body(ptr.pointee)
+  }
+}

--- a/tools/swiftpm/duckdb-swift/Sources/DuckDB/Public/DatabaseError.swift
+++ b/tools/swiftpm/duckdb-swift/Sources/DuckDB/Public/DatabaseError.swift
@@ -1,0 +1,29 @@
+//
+//  DuckDB
+//  https://github.com/duckdb/duckdb-swift
+//
+//  Copyright © 2018-2023 Stichting DuckDB Foundation
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+
+enum DatabaseError: Error {
+  case failedToOpenDatabase(reason: String?)
+  case failedToOpenConnection
+  case queryError(reason: String?)
+}

--- a/tools/swiftpm/duckdb-swift/Sources/DuckDB/Public/QueryResult.swift
+++ b/tools/swiftpm/duckdb-swift/Sources/DuckDB/Public/QueryResult.swift
@@ -1,0 +1,202 @@
+//
+//  DuckDB
+//  https://github.com/duckdb/duckdb-swift
+//
+//  Copyright © 2018-2023 Stichting DuckDB Foundation
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+
+@_implementationOnly import Cduckdb
+import Foundation
+
+public final class QueryResult {
+  
+  public var chunkCount: DBInt { duckdb_result_chunk_count(ptr.pointee) }
+  public var columnCount: DBInt { duckdb_column_count(ptr) }
+  public var rowsChanged: DBInt { duckdb_rows_changed(ptr) }
+  
+  lazy private (set) var rowCount = {
+    guard chunkCount > 0 else { return DBInt(0) }
+    let lastChunk = dataChunk(at: chunkCount - 1)
+    return (chunkCount - 1) * Self.vectorSize + lastChunk.count
+  }()
+  
+  private let ptr = UnsafeMutablePointer<duckdb_result>.allocate(capacity: 1)
+  
+  init(connection: Connection, sql: String) throws {
+    let status = sql.withCString { queryStrPtr in
+      connection.withCConnection { duckdb_query($0, queryStrPtr, ptr) }
+    }
+    guard status == .success else {
+      let error = duckdb_result_error(ptr).map(String.init(cString:))
+      throw DatabaseError.queryError(reason: error)
+    }
+  }
+  
+  deinit {
+    duckdb_destroy_result(ptr)
+    ptr.deallocate()
+  }
+  
+  public subscript(_ columnIndex: DBInt) -> Column<Void> {
+    precondition(columnIndex < columnCount)
+    return Column(result: self, columnIndex: columnIndex)
+  }
+  
+  public func columnName(at index: DBInt) -> String {
+    String(cString: duckdb_column_name(ptr, index))
+  }
+  
+  public func index(forColumnName columnName: String) -> DBInt? {
+    for i in 0..<columnCount {
+      if self.columnName(at: i) == columnName {
+        return i
+      }
+    }
+    return nil
+  }
+  
+  func columnDataType(at index: DBInt) -> DuckDBTypeID {
+    let dataType = duckdb_column_type(ptr, index)
+    return DuckDBTypeID(rawValue: dataType.rawValue)
+  }
+  
+  func withCResult<T>(_ body: (duckdb_result) throws -> T) rethrows -> T {
+    try body(ptr.pointee)
+  }
+}
+
+// MARK: - Type Casting Transformers
+
+extension QueryResult {
+  
+  func transformer(
+    forColumn columnIndex: DBInt, to type: Void.Type
+  ) -> (DBInt) -> Void? {
+    return { [self] itemIndex in
+      let path = Self.path(forColumn: columnIndex, item: itemIndex)
+      return isValidItem(at: path) ? () : nil
+    }
+  }
+  
+  func transformer<T: PrimitiveDatabaseValue>(
+    forColumn columnIndex: DBInt, to type: T.Type
+  ) -> (DBInt) -> T? {
+    let columnDataType = columnDataType(at: columnIndex)
+    guard columnDataType == T.representedDatabaseTypeID else {
+      let columnTypeString = columnDataType.description.uppercased()
+      assertionFailure("unsupported type conversion from \(columnTypeString) to \(T.self)")
+      return { _ in nil }
+    }
+    return { [self] itemIndex in
+      let path = Self.path(forColumn: columnIndex, item: itemIndex)
+      guard isValidItem(at: path) else { return nil }
+      return withAssumedCDataPointer(of: T.self, at: path) { $0[0] }
+    }
+  }
+  
+  func transformer(
+    forColumn columnIndex: DBInt, to type: String.Type
+  ) -> (DBInt) -> String? {
+    let columnDataType = columnDataType(at: columnIndex)
+    guard columnDataType == .varchar else {
+      let columnTypeString = columnDataType.description.uppercased()
+      assertionFailure("unsupported type conversion from \(columnTypeString) to \(String.self)")
+      return { _ in nil }
+    }
+    return { [self] itemIndex -> String? in
+      let path = Self.path(forColumn: columnIndex, item: itemIndex)
+      guard isValidItem(at: path) else { return nil }
+      return withAssumedCDataPointer(of: duckdb_string.self, at: path) { $0.contents }
+    }
+  }
+}
+
+// MARK: - Data Extraction Utilities
+
+private extension QueryResult {
+  
+  static let inlineLimit = UInt32(12)
+  
+  func dataChunk(at index: DBInt) -> DataChunk {
+    precondition(index < chunkCount, "data chunk out of bounds")
+    return DataChunk(result: self, index: index)
+  }
+  
+  func isValidItem(at path: Path) -> Bool {
+    let chunk = dataChunk(at: path.chunk)
+    return chunk.withCVector(at: path.column) { vector in
+      let validityMasks = duckdb_vector_get_validity(vector)
+      guard let validityMasks else { return true }
+      let validityMasksBuffer = UnsafeBufferPointer(
+        start: validityMasks, count: Int(duckdb_vector_size() / 64))
+      let validityEntryIndex = path.row / 64
+      let validityBitIndex = path.row % 64
+      let validityMask = validityMasksBuffer[Int(validityEntryIndex)]
+      let validityBit = (DBInt(1) << validityBitIndex)
+      return validityMask & validityBit != 0
+    }
+  }
+  
+  func withAssumedCDataPointer<T, Result>(
+    of type: T.Type, at path: Path, _ body: (UnsafePointer<T>) throws -> Result
+  ) rethrows -> Result {
+    let chunk = dataChunk(at: path.chunk)
+    return try chunk.withCVector(at: path.column) { vector in
+      let dataPtr = duckdb_vector_get_data(vector)!
+      let itemDataPtr = dataPtr.assumingMemoryBound(to: T.self)
+      return try body(itemDataPtr.advanced(by: Int(path.row)))
+    }
+  }
+}
+
+// MARK: - Path Utilities
+
+private extension QueryResult {
+  
+  struct Path {
+    let column: DBInt
+    let chunk: DBInt
+    let row: DBInt
+  }
+  
+  static let vectorSize = DBInt(duckdb_vector_size())
+  
+  static func path(forColumn column: DBInt, item itemIndex: DBInt) -> Path {
+    let chunkIndex = itemIndex / Self.vectorSize
+    let rowIndex = itemIndex % Self.vectorSize
+    return Path(column: column, chunk: chunkIndex, row: rowIndex)
+  }
+}
+
+// MARK: - Debug Description
+
+extension QueryResult: CustomDebugStringConvertible {
+  
+  public var debugDescription: String {
+    var columns = [String]()
+    let summary = "chunks: \(chunkCount), rows changed: \(rowsChanged), columns: \(columnCount)"
+    for i in 0..<columnCount {
+      let name = columnName(at: i)
+      let type = columnDataType(at: i).description.uppercased()
+      columns.append("\t\(name) \(type)")
+    }
+    return "\(Self.self): \(summary) (\n\(columns.joined(separator: ",\n"))\n)"
+  }
+}

--- a/tools/swiftpm/duckdb-swift/Sources/DuckDB/Public/QueryResult.swift
+++ b/tools/swiftpm/duckdb-swift/Sources/DuckDB/Public/QueryResult.swift
@@ -132,8 +132,6 @@ extension QueryResult {
 
 private extension QueryResult {
   
-  static let inlineLimit = UInt32(12)
-  
   func dataChunk(at index: DBInt) -> DataChunk {
     precondition(index < chunkCount, "data chunk out of bounds")
     return DataChunk(result: self, index: index)

--- a/tools/swiftpm/duckdb-swift/Tests/DuckDBTests/DuckDBTests.swift
+++ b/tools/swiftpm/duckdb-swift/Tests/DuckDBTests/DuckDBTests.swift
@@ -1,0 +1,85 @@
+//
+//  DuckDB
+//  https://github.com/duckdb/duckdb-swift
+//
+//  Copyright © 2018-2023 Stichting DuckDB Foundation
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+
+import XCTest
+@testable import DuckDB
+
+final class DuckDBTests: XCTestCase {
+  
+  func test_create_in_memory_database() throws {
+    let _ = try Database(store: .inMemory)
+  }
+  
+  func test_create_local_file_datebase() throws {
+    let fileURL = try Self.generateTemporaryFileURL(forFileNamed: "test.tb")
+    defer { Self.cleanUpTemporaryFileURL(fileURL) }
+    let _ = try Database(store: .file(at: fileURL))
+  }
+  
+  func test_connect_to_in_memory_datebase() throws {
+    let _ = try Database(store: .inMemory).connect()
+  }
+  
+  func test_connect_to_local_file_datebase() throws {
+    let fileURL = try Self.generateTemporaryFileURL(forFileNamed: "test.tb")
+    defer { Self.cleanUpTemporaryFileURL(fileURL) }
+    let _ = try Database(store: .file(at: fileURL)).connect()
+  }
+  
+  func test_execute_statement() throws {
+    let connection = try Database(store: .inMemory).connect()
+    try connection.execute("SELECT version();")
+  }
+  
+  func test_query_result() throws {
+    let connection = try Database(store: .inMemory).connect()
+    let result = try connection.query("SELECT * FROM test_all_types();")
+    let element: Void? = result[0][0]
+    XCTAssertNotNil(element)
+  }
+}
+
+// MARK: - Temp Directory Helpers
+
+private extension DuckDBTests {
+  
+  static func generateTemporaryFileURL(forFileNamed fileName: String) throws -> URL {
+    let tmpDirURL = try FileManager.default.url(
+      for: .itemReplacementDirectory,
+      in: .userDomainMask,
+      appropriateFor: FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0],
+      create: true
+    )
+    return tmpDirURL.appendingPathComponent(fileName)
+  }
+  
+  static func cleanUpTemporaryFileURL(_ fileURL: URL) {
+    do {
+      try FileManager.default.removeItem(at: fileURL.deletingLastPathComponent())
+    }
+    catch {
+      print("Ignored failed attempt to remove temp dir at \(fileURL):\n\t\(error)")
+    }
+  }
+}

--- a/tools/swiftpm/duckdb-swift/Tests/DuckDBTests/TypeConversionTests.swift
+++ b/tools/swiftpm/duckdb-swift/Tests/DuckDBTests/TypeConversionTests.swift
@@ -1,0 +1,151 @@
+//
+//  DuckDB
+//  https://github.com/duckdb/duckdb-swift
+//
+//  Copyright © 2018-2023 Stichting DuckDB Foundation
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+
+
+import XCTest
+@testable import DuckDB
+
+final class TypeConversionTests: XCTestCase {
+  
+  func test_extract_from_bool() throws {
+    let expected = [false, true, nil]
+    let connection = try Database(store: .inMemory).connect()
+    let result = try connection.query("SELECT bool FROM test_all_types();")
+    let column = result[0].cast(to: Bool.self)
+    for (index, item) in expected.enumerated() {
+      XCTAssertEqual(column[DBInt(index)], item)
+    }
+  }
+  
+  func test_extract_from_utinyint() throws {
+    let expected = [UInt8.min, .max, nil]
+    let connection = try Database(store: .inMemory).connect()
+    let result = try connection.query("SELECT utinyint FROM test_all_types();")
+    let column = result[0].cast(to: UInt8.self)
+    for (index, item) in expected.enumerated() {
+      XCTAssertEqual(column[DBInt(index)], item)
+    }
+  }
+  
+  func test_extract_from_usmallint() throws {
+    let expected = [UInt16.min, .max, nil]
+    let connection = try Database(store: .inMemory).connect()
+    let result = try connection.query("SELECT usmallint FROM test_all_types();")
+    let column = result[0].cast(to: UInt16.self)
+    for (index, item) in expected.enumerated() {
+      XCTAssertEqual(column[DBInt(index)], item)
+    }
+  }
+  
+  func test_extract_from_uint() throws {
+    let expected = [UInt32.min, .max, nil]
+    let connection = try Database(store: .inMemory).connect()
+    let result = try connection.query("SELECT uint FROM test_all_types();")
+    let column = result[0].cast(to: UInt32.self)
+    for (index, item) in expected.enumerated() {
+      XCTAssertEqual(column[DBInt(index)], item)
+    }
+  }
+  
+  func test_extract_from_ubigint() throws {
+    let expected = [UInt64.min, .max, nil]
+    let connection = try Database(store: .inMemory).connect()
+    let result = try connection.query("SELECT ubigint FROM test_all_types();")
+    let column = result[0].cast(to: UInt64.self)
+    for (index, item) in expected.enumerated() {
+      XCTAssertEqual(column[DBInt(index)], item)
+    }
+  }
+  
+  func test_extract_from_tinyint() throws {
+    let expected = [Int8.min, .max, nil]
+    let connection = try Database(store: .inMemory).connect()
+    let result = try connection.query("SELECT tinyint FROM test_all_types();")
+    let column = result[0].cast(to: Int8.self)
+    for (index, item) in expected.enumerated() {
+      XCTAssertEqual(column[DBInt(index)], item)
+    }
+  }
+  
+  func test_extract_from_smallint() throws {
+    let expected = [Int16.min, .max, nil]
+    let connection = try Database(store: .inMemory).connect()
+    let result = try connection.query("SELECT smallint FROM test_all_types();")
+    let column = result[0].cast(to: Int16.self)
+    for (index, item) in expected.enumerated() {
+      XCTAssertEqual(column[DBInt(index)], item)
+    }
+  }
+  
+  func test_extract_from_int() throws {
+    let expected = [Int32.min, .max, nil]
+    let connection = try Database(store: .inMemory).connect()
+    let result = try connection.query("SELECT int FROM test_all_types();")
+    let column = result[0].cast(to: Int32.self)
+    for (index, item) in expected.enumerated() {
+      XCTAssertEqual(column[DBInt(index)], item)
+    }
+  }
+  
+  func test_extract_from_bigint() throws {
+    let expected = [Int64.min, .max, nil]
+    let connection = try Database(store: .inMemory).connect()
+    let result = try connection.query("SELECT bigint FROM test_all_types();")
+    let column = result[0].cast(to: Int64.self)
+    for (index, item) in expected.enumerated() {
+      XCTAssertEqual(column[DBInt(index)], item)
+    }
+  }
+  
+  func test_extract_from_float() throws {
+    let expected = [-Float.greatestFiniteMagnitude, .greatestFiniteMagnitude, nil]
+    let connection = try Database(store: .inMemory).connect()
+    let result = try connection.query("SELECT float FROM test_all_types();")
+    let column = result[0].cast(to: Float.self)
+    for (index, item) in expected.enumerated() {
+      XCTAssertEqual(column[DBInt(index)], item)
+    }
+  }
+  
+  func test_extract_from_double() throws {
+    let expected = [-Double.greatestFiniteMagnitude, .greatestFiniteMagnitude, nil]
+    let connection = try Database(store: .inMemory).connect()
+    let result = try connection.query("SELECT double FROM test_all_types();")
+    let column = result[0].cast(to: Double.self)
+    for (index, item) in expected.enumerated() {
+      XCTAssertEqual(column[DBInt(index)], item)
+    }
+  }
+  
+  func test_extract_from_varchar() throws {
+    let expected = ["🦆🦆🦆🦆🦆🦆", "goo\0se", nil]
+    let connection = try Database(store: .inMemory).connect()
+    let result = try connection.query("SELECT varchar FROM test_all_types();")
+    let column = result[0].cast(to: String.self)
+    for (index, item) in expected.enumerated() {
+      XCTAssertEqual(column[DBInt(index)], item)
+    }
+  }
+}
+


### PR DESCRIPTION
### Contents

An initial version of the Duck DB Swift API:

Includes:
- Native Swift versions of Database/Connection/Result types
- Basic querying via textual SQL interface.
- Extraction of results for all the primitive types (plus string).
- Basic Testing

In addition, for CI:
- Tests automatically run for Apple platforms (iOS, macOS, watchOS, tvOS)
- Auto commit/push updates on master to swift specific repository.
- Auto tag the Swift repo on the creation of a release in the main repo.

### Setup

If building from a fork, first you'll need to sync the upstream tags:

```
git remote add upstream https://github.com/duckdb/duckdb.git
git fetch upstream
git push -f --tags origin master
```

Then, generate the package by running:
```
python3 tools/swiftpm/create_package.py tools/swiftpm/
```

You should then be able to open the `tools/swiftpm/swift-duckdb/DuckDB.xcworkspace` file in Xcode to explore the Package.