### PR TITLE
Map bug combo of const & non-const lists

### DIFF
--- a/src/function/scalar/map/map.cpp
+++ b/src/function/scalar/map/map.cpp
@@ -66,6 +66,9 @@ void MapConversionVerify(Vector &vector, idx_t count) {
 	}
 }
 
+// Example ExpandVector:
+// source: [1,2,3], expansion_factor: 4
+// target (result): [1,2,3,1,2,3,1,2,3,1,2,3]
 static void ExpandVector(const Vector &source, Vector &target, idx_t expansion_factor) {
 	idx_t count = ListVector::GetListSize(source);
 	auto &entry = ListVector::GetEntry(source);
@@ -144,6 +147,8 @@ static void MapFunction(DataChunk &args, ExpressionState &state, Vector &result)
 		result_data[i] = src_data[i];
 	}
 
+	// check whether one of the vectors has already been referenced to an expanded vector in the case of const/non-const
+	// combination. If not, then referencing is still necessary
 	if (!(keys_are_const && !values_are_const)) {
 		key_vector.Reference(ListVector::GetEntry(args.data[0]));
 	}

--- a/src/function/scalar/map/map.cpp
+++ b/src/function/scalar/map/map.cpp
@@ -70,11 +70,11 @@ static void ExpandVector(const Vector &source, Vector &target, idx_t expansion_f
 	idx_t count = ListVector::GetListSize(source);
 	auto &entry = ListVector::GetEntry(source);
 
-    idx_t target_idx = 0;
+	idx_t target_idx = 0;
 	for (idx_t copy = 0; copy < expansion_factor; copy++) {
 		for (idx_t key_idx = 0; key_idx < count; key_idx++) {
-            target.SetValue(target_idx, entry.GetValue(key_idx));
-            target_idx++;
+			target.SetValue(target_idx, entry.GetValue(key_idx));
+			target_idx++;
 		}
 	}
 	D_ASSERT(target_idx == count * expansion_factor);
@@ -116,19 +116,19 @@ static void MapFunction(DataChunk &args, ExpressionState &state, Vector &result)
 			throw InvalidInputException("Error in MAP creation: key list and value list do not align. i.e. different "
 			                            "size or incompatible structure");
 		}
-        ExpandVector(args.data[0], expanded_const, expansion_factor);
-        key_vector.Reference(expanded_const);
+		ExpandVector(args.data[0], expanded_const, expansion_factor);
+		key_vector.Reference(expanded_const);
 
-        src_data = value_data;
+		src_data = value_data;
 	} else if (values_are_const && !keys_are_const) {
-        Vector expanded_const(ListType::GetChildType(args.data[1].GetType()), key_count);
+		Vector expanded_const(ListType::GetChildType(args.data[1].GetType()), key_count);
 
 		auto expansion_factor = key_count / value_count;
 		if (expansion_factor != args.size()) {
 			throw InvalidInputException("Error in MAP creation: key list and value list do not align. i.e. different "
 			                            "size or incompatible structure");
 		}
-        ExpandVector(args.data[1], expanded_const, expansion_factor);
+		ExpandVector(args.data[1], expanded_const, expansion_factor);
 		value_vector.Reference(expanded_const);
 	} else {
 		if (key_count != value_count || memcmp(key_data, value_data, args.size() * sizeof(list_entry_t)) != 0) {
@@ -139,7 +139,7 @@ static void MapFunction(DataChunk &args, ExpressionState &state, Vector &result)
 
 	ListVector::SetListSize(result, MaxValue(key_count, value_count));
 
-    result_data = ListVector::GetData(result);
+	result_data = ListVector::GetData(result);
 	for (idx_t i = 0; i < args.size(); i++) {
 		result_data[i] = src_data[i];
 	}

--- a/src/function/scalar/map/map.cpp
+++ b/src/function/scalar/map/map.cpp
@@ -131,7 +131,7 @@ static void MapFunction(DataChunk &args, ExpressionState &state, Vector &result)
 		ExpandListVector(args.data[1], expanded_const, expansion_factor);
 		value_vector.Reference(ListVector::GetEntry(expanded_const));
 	} else {
-		if (key_count != value_count || memcmp(key_data, value_data, args.size() * sizeof(list_entry_t))) {
+		if (key_count != value_count || memcmp(key_data, value_data, args.size() * sizeof(list_entry_t)) != 0) {
 			throw InvalidInputException("Error in MAP creation: key list and value list do not align. i.e. different "
 			                            "size or incompatible structure");
 		}

--- a/test/sql/types/map/map_const_and_col_combination.test
+++ b/test/sql/types/map/map_const_and_col_combination.test
@@ -1,0 +1,84 @@
+# name: test/sql/types/map/map_const_and_col_combination.test
+# description: Test creating map when one list is const and the other list columnar data
+# group: [map]
+
+statement ok
+create table ints (i INT);
+
+statement ok
+INSERT INTO ints VALUES (1),(2),(3);
+
+query I
+select map(['name'], [i] ) FROM ints;
+----
+{name=1}
+{name=2}
+{name=3}
+
+query I
+select map([i], ['name'] ) FROM ints;
+----
+{1=name}
+{2=name}
+{3=name}
+
+query I
+select map([i, i+1], ['x', 'y']) FROM ints;
+----
+{1=x, 2=y}
+{2=x, 3=y}
+{3=x, 4=y}
+
+
+# test dictionary vector
+query I
+select map([i, i+1], ['x', 'y']) FROM ints WHERE i > 1;
+----
+{2=x, 3=y}
+{3=x, 4=y}
+
+query I
+select map(['key'], [range]) from range(5) WHERE range > 2;
+----
+{key=3}
+{key=4}
+
+query I
+select map(['🦆', '🦤', '🐓'], [i, i+1, i+2] ) FROM ints;
+----
+{🦆=1, 🦤=2, 🐓=3}
+{🦆=2, 🦤=3, 🐓=4}
+{🦆=3, 🦤=4, 🐓=5}
+
+query I
+SELECT map([10, i, i+1, 9], [i, 3.14, 0.12, 8.0]) FROM ints;
+----
+{10=1.00, 1=3.14, 2=0.12, 9=8.00}
+{10=2.00, 2=3.14, 3=0.12, 9=8.00}
+{10=3.00, 3=3.14, 4=0.12, 9=8.00}
+
+statement ok
+CREATE TABLE tbl (v VARCHAR[]);
+
+statement ok
+INSERT INTO tbl VALUES (ARRAY['test','string']), (ARRAY['foo','bar'])
+
+query I
+select map(['x', 'y'], v ) FROM tbl;
+----
+{x=test, y=string}
+{x=foo, y=bar}
+
+# test mismatched lists of same total length
+statement ok
+CREATE TABLE map_input (keys INT[], values INT[])
+
+statement ok
+INSERT INTO map_input VALUES ([1,0],[2]), ([3],[4, 9])
+
+statement error
+SELECT map(keys, values) FROM map_input;
+----
+Invalid Input Error: Error in MAP creation: key list has a different size from value list (3 keys, 3 values)
+
+

--- a/test/sql/types/map/map_const_and_col_combination.test
+++ b/test/sql/types/map/map_const_and_col_combination.test
@@ -15,6 +15,11 @@ select map(['name'], [i] ) FROM ints;
 {name=2}
 {name=3}
 
+statement error
+select map(['x', 'y'], [i] ) FROM ints;
+----
+Error in MAP creation: key list and value list do not align. i.e. different size or incompatible structure
+
 query I
 select map([i], ['name'] ) FROM ints;
 ----
@@ -30,12 +35,17 @@ select map([i, i+1], ['x', 'y']) FROM ints;
 {3=x, 4=y}
 
 
-# test dictionary vector
 query I
 select map([i, i+1], ['x', 'y']) FROM ints WHERE i > 1;
 ----
 {2=x, 3=y}
 {3=x, 4=y}
+
+query I
+select map(['x'], [m]) FROM (SELECT map([i], ['y']) m FROM ints WHERE i <> 1);
+----
+{x={2=y}}
+{x={3=y}}
 
 query I
 select map(['key'], [range]) from range(5) WHERE range > 2;
@@ -79,6 +89,24 @@ INSERT INTO map_input VALUES ([1,0],[2]), ([3],[4, 9])
 statement error
 SELECT map(keys, values) FROM map_input;
 ----
-Invalid Input Error: Error in MAP creation: key list has a different size from value list (3 keys, 3 values)
+Error in MAP creation: key list and value list do not align. i.e. different size or incompatible structure
 
 
+statement ok
+CREATE TABLE groups (category INT, score INT);
+
+statement ok
+INSERT INTO groups VALUES (1,2), (1,8), (1,3), (2,3), (2,4), (2,5), (3,6), (3,1), (3,9)
+
+query I
+select map(['category', 'min', 'max'], [category, MIN(score), MAX(score)]) FROM groups GROUP BY category;
+----
+{category=1, min=2, max=8}
+{category=2, min=3, max=5}
+{category=3, min=1, max=9}
+
+#Map with larger-than-vector-size cardinalities
+query I
+select MAP([range], ['a']) FROM range(10000) WHERE range = 9999;
+----
+{9999=a}


### PR DESCRIPTION
Addresses issue #6259

This issue exposed an error when map is created with both a constant and a columnar list and required some refactoring of the map function to accommodate this. 

Plus a fix when both lists contain an equal total amount of keys and values, but are actually not aligned on each row.