### PR TITLE
Paths-ignore on push

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -9,6 +9,8 @@ on:
       - '!feature'
     paths-ignore:
       - '**.md'
+      - '.github/workflows/**'
+      - '!.github/workflows/CodeQuality.yml'
 
   pull_request:
     paths-ignore:

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -1,5 +1,6 @@
 name: CodeQuality
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 2 * * *"
   push:

--- a/.github/workflows/ExtensionTrigger.yml
+++ b/.github/workflows/ExtensionTrigger.yml
@@ -1,5 +1,6 @@
 name: Extension Trigger
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 2 * * *"
 

--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -8,16 +8,22 @@ on:
       - '!master'
       - '!feature'
     paths-ignore:
-      - "**"
-      - "!src/include/**"
-      - "!tools/jdbc/**"
-      - "!.github/workflows/Java.yml"
+      - '**.md'
+      - 'examples/**'
+      - 'test/**'
+      - 'tools/**'
+      - '!tools/jdbc/**'
+      - '.github/workflows/**'
+      - '!.github/workflows/Java.yml'
   pull_request:
     paths-ignore:
-      - "**"
-      - "!src/include/**"
-      - "!tools/jdbc/**"
-      - "!.github/workflows/Java.yml"
+      - '**.md'
+      - 'examples/**'
+      - 'test/**'
+      - 'tools/**'
+      - '!tools/jdbc/**'
+      - '.github/workflows/**'
+      - '!.github/workflows/Java.yml'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{
     github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha

--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -1,5 +1,6 @@
 name: Java JDBC
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 2 * * *"
   push:

--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -8,7 +8,10 @@ on:
       - '!master'
       - '!feature'
     paths-ignore:
-      - '**.md'
+      - "**"
+      - "!src/include/**"
+      - "!tools/jdbc/**"
+      - "!.github/workflows/Java.yml"
   pull_request:
     paths-ignore:
       - "**"

--- a/.github/workflows/Julia.yml
+++ b/.github/workflows/Julia.yml
@@ -1,5 +1,6 @@
 name: Julia
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 2 * * *"
   push:

--- a/.github/workflows/Julia.yml
+++ b/.github/workflows/Julia.yml
@@ -9,6 +9,12 @@ on:
       - '!feature'
     paths-ignore:
       - '**.md'
+      - 'examples/**'
+      - 'test/**'
+      - 'tools/**'
+      - '!tools/juliapkg/**'
+      - '.github/workflows/**'
+      - '!.github/workflows/Julia.yml'
   pull_request:
     paths-ignore:
       - '**.md'

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -1,5 +1,6 @@
 name: LinuxRelease
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 2 * * *"
   push:

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -9,6 +9,9 @@ on:
       - '!feature'
     paths-ignore:
       - '**.md'
+      - 'tools/**'
+      - '.github/workflows/**'
+      - '!.github/workflows/LinuxRelease.yml'
   pull_request:
     paths-ignore:
       - '**.md'

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -3,12 +3,15 @@ on:
   schedule:
     - cron: "0 2 * * *"
   push:
-    paths-ignore:
-      - '**.md'
     branches:
       - '**'
       - '!master'
       - '!feature'
+    paths-ignore:
+      - '**.md'
+      - 'tools/**'
+      - '.github/workflows/**'
+      - '!.github/workflows/Main.yml'
   pull_request:
     paths-ignore:
       - '**.md'

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1,5 +1,6 @@
 name: Main
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 2 * * *"
   push:

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -1,5 +1,6 @@
 name: NodeJS
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 2 * * *"
   push:

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -9,6 +9,13 @@ on:
       - '!feature'
     paths-ignore:
       - '**.md'
+      - 'data/**'
+      - 'examples/**'
+      - 'test/**'
+      - 'tools/**'
+      - '!tools/nodejs/**'
+      - '.github/workflows/**'
+      - '!.github/workflows/NodeJS.yml'
   pull_request:
     paths-ignore:
       - '**.md'

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -1,5 +1,6 @@
 name: OSX
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 2 * * *"
   push:

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -1,5 +1,6 @@
 name: Python
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 2 * * *"
   push:

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -9,6 +9,12 @@ on:
       - '!feature'
     paths-ignore:
       - '**.md'
+      - 'examples/**'
+      - 'test/**'
+      - 'tools/**'
+      - '!tools/pythonpkg/**'
+      - '.github/workflows/**'
+      - '!.github/workflows/Python.yml'
   pull_request:
     paths-ignore:
       - '**.md'

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -9,6 +9,12 @@ on:
       - '!feature'
     paths-ignore:
       - '**.md'
+      - 'examples/**'
+      - 'test/**'
+      - 'tools/**'
+      - '!tools/rpkg/**'
+      - '.github/workflows/**'
+      - '!.github/workflows/R.yml'
   pull_request:
     paths-ignore:
       - '**.md'

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -1,5 +1,6 @@
 name: R
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 2 * * *"
   push:

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -1,5 +1,6 @@
 name: Regression
 on:
+  workflow_dispatch:
   push:
     branches:
       - '**'

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -7,6 +7,10 @@ on:
       - '!feature'
     paths-ignore:
       - '**.md'
+      - 'tools/**'
+      - '!tools/pythonpkg/**'
+      - '.github/workflows/**'
+      - '!.github/workflows/Regression.yml'
   pull_request:
     paths-ignore:
       - '**.md'

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -1,5 +1,6 @@
 name: Windows
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 2 * * *"
   push:

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -9,6 +9,10 @@ on:
       - '!feature'
     paths-ignore:
       - '**.md'
+      - 'tools/**'
+      - '!tools/odbc/**'
+      - '.github/workflows/**'
+      - '!.github/workflows/Windows.yml'
   pull_request:
     paths-ignore:
       - '**.md'

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,6 @@
 name: CIFuzz
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 2 * * *"
   push:


### PR DESCRIPTION
As suggested by @Mytherin, adding also to pushes the paths-ignore property so that changes to separate areas of the codebase trigger less work for the CI, mirroring the behaviour of `pull_request`'s trigger.

Two additional changes, somehow related, looking for feedback mostly on those:
* modifying the Java.yml to be aligned to other workflows (even though the semantic differs: before changes to src/** different than src/include/** would not trigger a Java workflow, while now they do).

* adding `workflow_dispatch` trigger, that will allow users with write permission to schedule selected workflows either via browser interface or CLI. Given it's enable only with write access, should have basically no downsides but for allowing an escape hatches to restart workflows / bisect