### PR TITLE
fix typos in dictionary_store_worst_case.benchmark

### DIFF
--- a/benchmark/micro/compression/dictionary/dictionary_store_worst_case.benchmark
+++ b/benchmark/micro/compression/dictionary/dictionary_store_worst_case.benchmark
@@ -2,7 +2,7 @@
 # description: Storing a column containing only unique strings.
 # group: [dictionary]
 
-name name Dictionary Compression Write
+name Dictionary Compression Write
 group dictionary
 storage persistent
 require_reinit


### PR DESCRIPTION
I found duplicate "name" in dictionary_store_worst_case.benchmark so I create this pr to fix it.