### PR TITLE
[Python] No jemalloc for successful build on android

### DIFF
--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -63,7 +63,7 @@ extensions = ['parquet', 'icu', 'fts', 'tpch', 'tpcds', 'visualizer', 'json', 'e
 if platform.system() == 'Windows':
     extensions = ['parquet', 'icu', 'fts', 'tpch', 'json', 'excel']
 
-if platform.system() == 'Linux' and platform.architecture()[0] == '64bit':
+if platform.system() == 'Linux' and platform.architecture()[0] == '64bit' and not hasattr(sys, 'getandroidapilevel'):
     extensions.append('jemalloc')
 
 unity_build = 0


### PR DESCRIPTION
Fixes #6329

On Android OS, some features in pthread are not available and building jemalloc fails.

This PR will avoid using jemalloc while `pip install` (Edit: in git repository) on Android OS.

With this PR, building duckdb on my Android phone (Termux 0.101/Python 3.11.2/Android 10/Galaxy A7) was successful.
