### PR TITLE
Implements function "sqlite3_column_table_name" for the sqlite3 wrapper

### DIFF
--- a/tools/sqlite3_api_wrapper/include/duckdb_shell_wrapper.h
+++ b/tools/sqlite3_api_wrapper/include/duckdb_shell_wrapper.h
@@ -38,6 +38,7 @@
 #define sqlite3_column_int             duckdb_shell_sqlite3_column_int
 #define sqlite3_column_int64           duckdb_shell_sqlite3_column_int64
 #define sqlite3_column_name            duckdb_shell_sqlite3_column_name
+#define sqlite3_column_table_name      duckdb_shell_sqlite3_column_table_name
 #define sqlite3_column_text            duckdb_shell_sqlite3_column_text
 #define sqlite3_column_type            duckdb_shell_sqlite3_column_type
 #define sqlite3_column_value           duckdb_shell_sqlite3_column_value
@@ -168,4 +169,3 @@
 #define sqlite3_vsnprintf              duckdb_shell_sqlite3_vsnprintf
 #define sqlite3_vtab_collation         duckdb_shell_sqlite3_vtab_collation
 #define sqlite3_vtab_config            duckdb_shell_sqlite3_vtab_config
-#define sqlite3_column_table_name      duckdb_shell_sqlite3_column_table_name

--- a/tools/sqlite3_api_wrapper/include/duckdb_shell_wrapper.h
+++ b/tools/sqlite3_api_wrapper/include/duckdb_shell_wrapper.h
@@ -168,3 +168,4 @@
 #define sqlite3_vsnprintf              duckdb_shell_sqlite3_vsnprintf
 #define sqlite3_vtab_collation         duckdb_shell_sqlite3_vtab_collation
 #define sqlite3_vtab_config            duckdb_shell_sqlite3_vtab_config
+#define sqlite3_column_table_name      duckdb_shell_sqlite3_column_table_name

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -1101,7 +1101,7 @@ const char *sqlite3_column_table_name(sqlite3_stmt *pStmt, int iCol) {
 	}
 
 	auto &&names = pStmt->prepared->GetNames();
-	if (names.size() <= iCol) {
+	if (iCol < 0 || names.size() <= static_cast<size_t>(iCol)) {
 		return nullptr;
 	}
 
@@ -1114,7 +1114,7 @@ const char *sqlite3_column_decltype(sqlite3_stmt *pStmt, int iCol) {
 	}
 
 	auto &&types = pStmt->prepared->GetTypes();
-	if (types.size() <= iCol) {
+	if (iCol < 0 || types.size() <= static_cast<size_t>(iCol)) {
 		return nullptr;
 	}
 

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -1046,14 +1046,9 @@ int sqlite3_complete(const char *zSql) {
 
 // length of varchar or blob value
 int sqlite3_column_bytes(sqlite3_stmt *pStmt, int iCol) {
-	Value val;
-	if (!sqlite3_column_has_value(pStmt, iCol, LogicalType::VARCHAR, val)) {
-		if (!sqlite3_column_has_value(pStmt, iCol, LogicalType::BLOB, val)) {
-			return 0;
-		}
-	}
-	auto r = StringValue::Get(val);
-	return r.size();
+	// fprintf(stderr, "sqlite3_column_bytes: unsupported.\n");
+	return pStmt->current_text[iCol].data_len;
+	// return -1;
 }
 
 sqlite3_value *sqlite3_column_value(sqlite3_stmt *, int iCol) {


### PR DESCRIPTION
This PR implements the missing function "sqlite3_column_table_name" for the sqlit3 wrapper (see https://github.com/duckdb/duckdb/blob/master/third_party/sqlite/include/sqlite3.h#L4579 )

Without this, the linker will fail when a program uses this function.
