### PR TITLE
ART (bug) fixes

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/catalog/catalog_search_path.hpp"
 #include "duckdb/catalog/catalog_entry/list.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_set.hpp"
 #include "duckdb/catalog/default/default_schemas.hpp"
 #include "duckdb/catalog/catalog_entry/type_catalog_entry.hpp"
@@ -249,6 +250,20 @@ CatalogEntry *Catalog::CreateCollation(ClientContext &context, CreateCollationIn
 CatalogEntry *Catalog::CreateCollation(CatalogTransaction transaction, SchemaCatalogEntry *schema,
                                        CreateCollationInfo *info) {
 	return schema->CreateCollation(transaction, info);
+}
+
+//===--------------------------------------------------------------------===//
+// Index
+//===--------------------------------------------------------------------===//
+CatalogEntry *Catalog::CreateIndex(CatalogTransaction transaction, CreateIndexInfo *info) {
+	auto &context = transaction.GetContext();
+	return CreateIndex(context, info);
+}
+
+CatalogEntry *Catalog::CreateIndex(ClientContext &context, CreateIndexInfo *info) {
+	auto schema = GetSchema(context, info->schema);
+	auto table = GetEntry<TableCatalogEntry>(context, schema->name, info->table->table_name);
+	return schema->CreateIndex(context, info, table);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/catalog/catalog_entry/index_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/index_catalog_entry.cpp
@@ -19,10 +19,11 @@ string IndexCatalogEntry::ToSQL() {
 	return sql;
 }
 
-void IndexCatalogEntry::Serialize(duckdb::MetaBlockWriter &serializer) {
-	// Here we serialize the index metadata in the following order:
-	// schema name, table name, index name, sql, index type, index constraint type, expression list.
-	// column_ids, unbound_expression
+void IndexCatalogEntry::Serialize(Serializer &serializer) {
+	// here we serialize the index metadata in the following order:
+	// schema name, table name, index name, sql, index type, index constraint type, expression list, parsed expressions,
+	// column IDs
+
 	FieldWriter writer(serializer);
 	writer.WriteString(GetSchemaName());
 	writer.WriteString(GetTableName());
@@ -37,9 +38,9 @@ void IndexCatalogEntry::Serialize(duckdb::MetaBlockWriter &serializer) {
 }
 
 unique_ptr<CreateIndexInfo> IndexCatalogEntry::Deserialize(Deserializer &source, ClientContext &context) {
-	// Here we deserialize the index metadata in the following order:
-	// root block, root offset, schema name, table name, index name, sql, index type, index constraint type, expression
-	// list.
+	// here we deserialize the index metadata in the following order:
+	// schema name, table schema name, table name, index name, sql, index type, index constraint type, expression list,
+	// parsed expression list, column IDs
 
 	auto create_index_info = make_unique<CreateIndexInfo>();
 

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -108,7 +108,7 @@ static void TemplatedGenerateKeys(ArenaAllocator &allocator, Vector &input, idx_
 	for (idx_t i = 0; i < count; i++) {
 		auto idx = idata.sel->get_index(i);
 		if (idata.validity.RowIsValid(idx)) {
-			Key::CreateKey<T>(allocator, keys[i], input_data[idx]);
+			Key::CreateKey<T>(allocator, input.GetType(), keys[i], input_data[idx]);
 		}
 	}
 }
@@ -128,7 +128,7 @@ static void ConcatenateKeys(ArenaAllocator &allocator, Vector &input, idx_t coun
 				// this column entry is NULL, set whole key to NULL
 				keys[i] = Key();
 			} else {
-				auto other_key = Key::CreateKey<T>(allocator, input_data[idx]);
+				auto other_key = Key::CreateKey<T>(allocator, input.GetType(), input_data[idx]);
 				keys[i].ConcatenateKey(allocator, other_key);
 			}
 		}
@@ -604,31 +604,31 @@ static Key CreateKey(ArenaAllocator &allocator, PhysicalType type, Value &value)
 	D_ASSERT(type == value.type().InternalType());
 	switch (type) {
 	case PhysicalType::BOOL:
-		return Key::CreateKey<bool>(allocator, value);
+		return Key::CreateKey<bool>(allocator, value.type(), value);
 	case PhysicalType::INT8:
-		return Key::CreateKey<int8_t>(allocator, value);
+		return Key::CreateKey<int8_t>(allocator, value.type(), value);
 	case PhysicalType::INT16:
-		return Key::CreateKey<int16_t>(allocator, value);
+		return Key::CreateKey<int16_t>(allocator, value.type(), value);
 	case PhysicalType::INT32:
-		return Key::CreateKey<int32_t>(allocator, value);
+		return Key::CreateKey<int32_t>(allocator, value.type(), value);
 	case PhysicalType::INT64:
-		return Key::CreateKey<int64_t>(allocator, value);
+		return Key::CreateKey<int64_t>(allocator, value.type(), value);
 	case PhysicalType::UINT8:
-		return Key::CreateKey<uint8_t>(allocator, value);
+		return Key::CreateKey<uint8_t>(allocator, value.type(), value);
 	case PhysicalType::UINT16:
-		return Key::CreateKey<uint16_t>(allocator, value);
+		return Key::CreateKey<uint16_t>(allocator, value.type(), value);
 	case PhysicalType::UINT32:
-		return Key::CreateKey<uint32_t>(allocator, value);
+		return Key::CreateKey<uint32_t>(allocator, value.type(), value);
 	case PhysicalType::UINT64:
-		return Key::CreateKey<uint64_t>(allocator, value);
+		return Key::CreateKey<uint64_t>(allocator, value.type(), value);
 	case PhysicalType::INT128:
-		return Key::CreateKey<hugeint_t>(allocator, value);
+		return Key::CreateKey<hugeint_t>(allocator, value.type(), value);
 	case PhysicalType::FLOAT:
-		return Key::CreateKey<float>(allocator, value);
+		return Key::CreateKey<float>(allocator, value.type(), value);
 	case PhysicalType::DOUBLE:
-		return Key::CreateKey<double>(allocator, value);
+		return Key::CreateKey<double>(allocator, value.type(), value);
 	case PhysicalType::VARCHAR:
-		return Key::CreateKey<string_t>(allocator, value);
+		return Key::CreateKey<string_t>(allocator, value.type(), value);
 	default:
 		throw InternalException("Invalid type for index");
 	}

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -27,7 +27,10 @@ ART::ART(const vector<column_t> &column_ids, TableIOManager &table_io_manager,
 	tree = nullptr;
 	if (block_id != DConstants::INVALID_INDEX) {
 		tree = Node::Deserialize(*this, block_id, block_offset);
-		ART::Verify();
+		Verify();
+		if (track_memory) {
+			buffer_manager.IncreaseUsedMemory(memory_size);
+		}
 	}
 	serialized_data_pointer = BlockPointer(block_id, block_offset);
 
@@ -58,7 +61,7 @@ ART::~ART() {
 	if (!tree) {
 		return;
 	}
-	ART::Verify();
+	Verify();
 	if (track_memory) {
 		buffer_manager.DecreaseUsedMemory(memory_size);
 	}
@@ -72,6 +75,7 @@ ART::~ART() {
 
 unique_ptr<IndexScanState> ART::InitializeScanSinglePredicate(const Transaction &transaction, const Value &value,
                                                               ExpressionType expression_type) {
+	// initialize point lookup
 	auto result = make_unique<ARTIndexScanState>();
 	result->values[0] = value;
 	result->expressions[0] = expression_type;
@@ -81,6 +85,7 @@ unique_ptr<IndexScanState> ART::InitializeScanSinglePredicate(const Transaction 
 unique_ptr<IndexScanState> ART::InitializeScanTwoPredicates(Transaction &transaction, const Value &low_value,
                                                             ExpressionType low_expression_type, const Value &high_value,
                                                             ExpressionType high_expression_type) {
+	// initialize range lookup
 	auto result = make_unique<ARTIndexScanState>();
 	result->values[0] = low_value;
 	result->expressions[0] = low_expression_type;
@@ -225,7 +230,7 @@ void ART::GenerateKeys(ArenaAllocator &allocator, DataChunk &input, vector<Key> 
 }
 
 //===--------------------------------------------------------------------===//
-// Construct from sorted data
+// Construct from sorted data (only during CREATE (UNIQUE) INDEX statements)
 //===--------------------------------------------------------------------===//
 
 struct KeySection {
@@ -283,7 +288,7 @@ bool Construct(ART &art, vector<Key> &keys, row_t *row_ids, Node *&node, KeySect
 		} else {
 			node = Leaf::New(start_key, prefix_start, row_ids + key_section.start, num_row_ids);
 		}
-		art.memory_size += node->MemorySize(art, false);
+		art.IncreaseMemorySize(node->MemorySize(art, false));
 		return true;
 	}
 	// create a new node and recurse
@@ -297,7 +302,7 @@ bool Construct(ART &art, vector<Key> &keys, row_t *row_ids, Node *&node, KeySect
 
 	auto prefix_length = key_section.depth - prefix_start;
 	node->prefix = Prefix(start_key, prefix_start, prefix_length);
-	art.memory_size += node->MemorySize(art, false);
+	art.IncreaseMemorySize(node->MemorySize(art, false));
 
 	// recurse on each child section
 	for (auto &child_section : child_sections) {
@@ -323,7 +328,7 @@ bool ART::ConstructFromSorted(idx_t count, vector<Key> &keys, Vector &row_identi
 }
 
 //===--------------------------------------------------------------------===//
-// Insert
+// Insert / Verification / Constraint Checking
 //===--------------------------------------------------------------------===//
 
 bool ART::Insert(IndexLock &lock, DataChunk &input, Vector &row_ids) {
@@ -331,12 +336,12 @@ bool ART::Insert(IndexLock &lock, DataChunk &input, Vector &row_ids) {
 	D_ASSERT(row_ids.GetType().InternalType() == ROW_TYPE);
 	D_ASSERT(logical_types[0] == input.data[0].GetType());
 
+	auto old_memory_size = memory_size;
+
 	// generate the keys for the given input
 	ArenaAllocator arena_allocator(BufferAllocator::Get(db));
 	vector<Key> keys(input.size());
 	GenerateKeys(arena_allocator, input, keys);
-
-	auto old_memory_size = this->memory_size;
 
 	// get the corresponding row IDs
 	row_ids.Flatten(input.size());
@@ -356,9 +361,9 @@ bool ART::Insert(IndexLock &lock, DataChunk &input, Vector &row_ids) {
 			break;
 		}
 	}
-	if (failed_index != DConstants::INVALID_INDEX) {
 
-		// failed to insert because of constraint violation: remove previously inserted entries
+	// failed to insert because of constraint violation: remove previously inserted entries
+	if (failed_index != DConstants::INVALID_INDEX) {
 		for (idx_t i = 0; i < failed_index; i++) {
 			if (keys[i].Empty()) {
 				continue;
@@ -366,14 +371,11 @@ bool ART::Insert(IndexLock &lock, DataChunk &input, Vector &row_ids) {
 			row_t row_id = row_identifiers[i];
 			Erase(tree, keys[i], 0, row_id);
 		}
-		// nothing changed, no need to update the buffer memory size
-		return false;
 	}
 
-	D_ASSERT(old_memory_size <= memory_size);
-	Verify();
-	if (track_memory) {
-		buffer_manager.IncreaseUsedMemory(memory_size - old_memory_size);
+	IncreaseAndVerifyMemorySize(old_memory_size);
+	if (failed_index != DConstants::INVALID_INDEX) {
+		return false;
 	}
 	return true;
 }
@@ -391,25 +393,12 @@ bool ART::Append(IndexLock &lock, DataChunk &appended_data, Vector &row_identifi
 
 void ART::VerifyAppend(DataChunk &chunk) {
 	ConflictManager conflict_manager(VerifyExistenceType::APPEND, chunk.size());
-	LookupValues(chunk, conflict_manager);
+	CheckConstraintsForChunk(chunk, conflict_manager);
 }
 
 void ART::VerifyAppend(DataChunk &chunk, ConflictManager &conflict_manager) {
 	D_ASSERT(conflict_manager.LookupType() == VerifyExistenceType::APPEND);
-	LookupValues(chunk, conflict_manager);
-}
-
-void ART::VerifyAppendForeignKey(DataChunk &chunk) {
-	ConflictManager conflict_manager(VerifyExistenceType::APPEND_FK, chunk.size());
-	LookupValues(chunk, conflict_manager);
-}
-
-void ART::VerifyDeleteForeignKey(DataChunk &chunk) {
-	if (!IsUnique()) {
-		return;
-	}
-	ConflictManager conflict_manager(VerifyExistenceType::DELETE_FK, chunk.size());
-	LookupValues(chunk, conflict_manager);
+	CheckConstraintsForChunk(chunk, conflict_manager);
 }
 
 bool ART::InsertToLeaf(Leaf &leaf, row_t row_id) {
@@ -430,7 +419,7 @@ bool ART::Insert(Node *&node, Key &key, idx_t depth, row_t row_id) {
 	if (!node) {
 		// node is currently empty, create a leaf here with the key
 		node = Leaf::New(key, depth, row_id);
-		this->memory_size += node->MemorySize(*this, false);
+		IncreaseMemorySize(node->MemorySize(*this, false));
 		return true;
 	}
 
@@ -455,14 +444,14 @@ bool ART::Insert(Node *&node, Key &key, idx_t depth, row_t row_id) {
 
 		Node *new_node = Node4::New();
 		new_node->prefix = Prefix(key, depth, new_prefix_length);
-		this->memory_size += new_node->MemorySize(*this, false);
+		IncreaseMemorySize(new_node->MemorySize(*this, false));
 
 		auto key_byte = node->prefix.Reduce(*this, new_prefix_length);
 		Node4::InsertChild(*this, new_node, key_byte, node);
 
 		Node *leaf_node = Leaf::New(key, depth + new_prefix_length + 1, row_id);
 		Node4::InsertChild(*this, new_node, key[depth + new_prefix_length], leaf_node);
-		this->memory_size += leaf_node->MemorySize(*this, false);
+		IncreaseMemorySize(leaf_node->MemorySize(*this, false));
 
 		node = new_node;
 		return true;
@@ -476,7 +465,7 @@ bool ART::Insert(Node *&node, Key &key, idx_t depth, row_t row_id) {
 			// prefix differs, create new node
 			Node *new_node = Node4::New();
 			new_node->prefix = Prefix(key, depth, mismatch_pos);
-			this->memory_size += new_node->MemorySize(*this, false);
+			IncreaseMemorySize(new_node->MemorySize(*this, false));
 
 			// break up prefix
 			auto key_byte = node->prefix.Reduce(*this, mismatch_pos);
@@ -484,7 +473,7 @@ bool ART::Insert(Node *&node, Key &key, idx_t depth, row_t row_id) {
 
 			Node *leaf_node = Leaf::New(key, depth + mismatch_pos + 1, row_id);
 			Node4::InsertChild(*this, new_node, key[depth + mismatch_pos], leaf_node);
-			this->memory_size += leaf_node->MemorySize(*this, false);
+			IncreaseMemorySize(leaf_node->MemorySize(*this, false));
 
 			node = new_node;
 			return true;
@@ -504,7 +493,7 @@ bool ART::Insert(Node *&node, Key &key, idx_t depth, row_t row_id) {
 
 	Node *leaf_node = Leaf::New(key, depth + 1, row_id);
 	Node::InsertChild(*this, node, key[depth], leaf_node);
-	this->memory_size += leaf_node->MemorySize(*this, false);
+	IncreaseMemorySize(leaf_node->MemorySize(*this, false));
 	return true;
 }
 
@@ -525,7 +514,7 @@ void ART::Delete(IndexLock &state, DataChunk &input, Vector &row_ids) {
 	vector<Key> keys(expression.size());
 	GenerateKeys(arena_allocator, expression, keys);
 
-	auto old_memory_size = this->memory_size;
+	auto old_memory_size = memory_size;
 
 	// now erase the elements from the database
 	row_ids.Flatten(input.size());
@@ -547,10 +536,13 @@ void ART::Delete(IndexLock &state, DataChunk &input, Vector &row_ids) {
 #endif
 	}
 
-	D_ASSERT(old_memory_size >= memory_size);
+	// if we deserialize nodes while erasing, then we might end up with more
+	// memory afterwards, so we have to either increase or decrease the used memory
 	Verify();
-	if (track_memory) {
+	if (track_memory && old_memory_size >= memory_size) {
 		buffer_manager.DecreaseUsedMemory(old_memory_size - memory_size);
+	} else if (track_memory) {
+		buffer_manager.IncreaseUsedMemory(memory_size - old_memory_size);
 	}
 }
 
@@ -566,8 +558,7 @@ void ART::Erase(Node *&node, Key &key, idx_t depth, row_t row_id) {
 		leaf->Remove(*this, row_id);
 
 		if (leaf->count == 0) {
-			D_ASSERT(this->memory_size >= leaf->MemorySize(*this, false));
-			this->memory_size -= leaf->MemorySize(*this, false);
+			DecreaseMemorySize(leaf->MemorySize(*this, false));
 			Node::Delete(node);
 			node = nullptr;
 		}
@@ -606,7 +597,7 @@ void ART::Erase(Node *&node, Key &key, idx_t depth, row_t row_id) {
 }
 
 //===--------------------------------------------------------------------===//
-// Point Query
+// Point Query (Equal)
 //===--------------------------------------------------------------------===//
 
 static Key CreateKey(ArenaAllocator &allocator, PhysicalType type, Value &value) {
@@ -645,7 +636,10 @@ static Key CreateKey(ArenaAllocator &allocator, PhysicalType type, Value &value)
 
 bool ART::SearchEqual(Key &key, idx_t max_count, vector<row_t> &result_ids) {
 
+	auto old_memory_size = memory_size;
 	auto leaf = (Leaf *)(Lookup(tree, key, 0));
+	IncreaseAndVerifyMemorySize(old_memory_size);
+
 	if (!leaf) {
 		return true;
 	}
@@ -662,19 +656,28 @@ bool ART::SearchEqual(Key &key, idx_t max_count, vector<row_t> &result_ids) {
 void ART::SearchEqualJoinNoFetch(Key &key, idx_t &result_size) {
 
 	// we need to look for a leaf
+	auto old_memory_size = memory_size;
 	auto leaf = Lookup(tree, key, 0);
+	IncreaseAndVerifyMemorySize(old_memory_size);
+
 	if (!leaf) {
 		return;
 	}
 	result_size = leaf->count;
 }
 
+//===--------------------------------------------------------------------===//
+// Lookup
+//===--------------------------------------------------------------------===//
+
 Leaf *ART::Lookup(Node *node, Key &key, idx_t depth) {
+
 	while (node) {
 		if (node->type == NodeType::NLeaf) {
 			auto leaf = (Leaf *)node;
 			auto &leaf_prefix = leaf->prefix;
-			//! Check leaf
+
+			// check if leaf contains key
 			for (idx_t i = 0; i < leaf->prefix.Size(); i++) {
 				if (leaf_prefix[i] != key[i + depth]) {
 					return nullptr;
@@ -682,22 +685,29 @@ Leaf *ART::Lookup(Node *node, Key &key, idx_t depth) {
 			}
 			return (Leaf *)node;
 		}
+
 		if (node->prefix.Size()) {
 			for (idx_t pos = 0; pos < node->prefix.Size(); pos++) {
 				if (key[depth + pos] != node->prefix[pos]) {
+					// prefix mismatch, does not contain key
 					return nullptr;
 				}
 			}
 			depth += node->prefix.Size();
 		}
+
+		// prefix matches key, but no child at byte, does not contain key
 		idx_t pos = node->GetChildPos(key[depth]);
 		if (pos == DConstants::INVALID_INDEX) {
 			return nullptr;
 		}
+
+		// recurse into child
 		node = node->GetChild(*this, pos);
 		D_ASSERT(node);
 		depth++;
 	}
+
 	return nullptr;
 }
 
@@ -710,6 +720,7 @@ Leaf *ART::Lookup(Node *node, Key &key, idx_t depth) {
 bool ART::SearchGreater(ARTIndexScanState *state, Key &key, bool inclusive, idx_t max_count,
                         vector<row_t> &result_ids) {
 
+	auto old_memory_size = memory_size;
 	Iterator *it = &state->iterator;
 
 	// greater than scan: first set the iterator to the node at which we will start our scan by finding the lowest node
@@ -718,13 +729,16 @@ bool ART::SearchGreater(ARTIndexScanState *state, Key &key, bool inclusive, idx_
 		it->art = this;
 		bool found = it->LowerBound(tree, key, inclusive);
 		if (!found) {
+			IncreaseAndVerifyMemorySize(old_memory_size);
 			return true;
 		}
 	}
 	// after that we continue the scan; we don't need to check the bounds as any value following this value is
 	// automatically bigger and hence satisfies our predicate
 	Key empty_key = Key();
-	return it->Scan(empty_key, max_count, result_ids, false);
+	auto success = it->Scan(empty_key, max_count, result_ids, false);
+	IncreaseAndVerifyMemorySize(old_memory_size);
+	return success;
 }
 
 //===--------------------------------------------------------------------===//
@@ -738,6 +752,7 @@ bool ART::SearchLess(ARTIndexScanState *state, Key &upper_bound, bool inclusive,
 		return true;
 	}
 
+	auto old_memory_size = memory_size;
 	Iterator *it = &state->iterator;
 
 	if (!it->art) {
@@ -746,11 +761,14 @@ bool ART::SearchLess(ARTIndexScanState *state, Key &upper_bound, bool inclusive,
 		it->FindMinimum(*tree);
 		// early out min value higher than upper bound query
 		if (it->cur_key > upper_bound) {
+			IncreaseAndVerifyMemorySize(old_memory_size);
 			return true;
 		}
 	}
 	// now continue the scan until we reach the upper bound
-	return it->Scan(upper_bound, max_count, result_ids, inclusive);
+	auto success = it->Scan(upper_bound, max_count, result_ids, inclusive);
+	IncreaseAndVerifyMemorySize(old_memory_size);
+	return success;
 }
 
 //===--------------------------------------------------------------------===//
@@ -760,6 +778,7 @@ bool ART::SearchLess(ARTIndexScanState *state, Key &upper_bound, bool inclusive,
 bool ART::SearchCloseRange(ARTIndexScanState *state, Key &lower_bound, Key &upper_bound, bool left_inclusive,
                            bool right_inclusive, idx_t max_count, vector<row_t> &result_ids) {
 
+	auto old_memory_size = memory_size;
 	Iterator *it = &state->iterator;
 
 	// first find the first node that satisfies the left predicate
@@ -767,11 +786,14 @@ bool ART::SearchCloseRange(ARTIndexScanState *state, Key &lower_bound, Key &uppe
 		it->art = this;
 		bool found = it->LowerBound(tree, lower_bound, left_inclusive);
 		if (!found) {
+			IncreaseAndVerifyMemorySize(old_memory_size);
 			return true;
 		}
 	}
 	// now continue the scan until we reach the upper bound
-	return it->Scan(upper_bound, max_count, result_ids, right_inclusive);
+	auto success = it->Scan(upper_bound, max_count, result_ids, right_inclusive);
+	IncreaseAndVerifyMemorySize(old_memory_size);
+	return success;
 }
 
 bool ART::Scan(Transaction &transaction, DataTable &table, IndexScanState &table_state, idx_t max_count,
@@ -844,8 +866,15 @@ bool ART::Scan(Transaction &transaction, DataTable &table, IndexScanState &table
 	return true;
 }
 
+//===--------------------------------------------------------------------===//
+// More Verification / Constraint Checking
+//===--------------------------------------------------------------------===//
+
 string ART::GenerateErrorKeyName(DataChunk &input, idx_t row) {
-	// re-executing the expressions is not very fast, but we're going to throw anyways, so we don't care
+
+	// FIXME: why exactly can we not pass the expression_chunk as an argument to this
+	// FIXME: function instead of re-executing?
+	// re-executing the expressions is not very fast, but we're going to throw, so we don't care
 	DataChunk expression_chunk;
 	expression_chunk.Initialize(Allocator::DefaultAllocator(), logical_types);
 	ExecuteExpressions(input, expression_chunk);
@@ -883,10 +912,12 @@ string ART::GenerateConstraintErrorMessage(VerifyExistenceType verify_type, cons
 	}
 }
 
-void ART::LookupValues(DataChunk &input, ConflictManager &conflict_manager) {
+void ART::CheckConstraintsForChunk(DataChunk &input, ConflictManager &conflict_manager) {
 
 	// don't alter the index during constraint checking
 	lock_guard<mutex> l(lock);
+
+	auto old_memory_size = memory_size;
 
 	// first resolve the expressions for the index
 	DataChunk expression_chunk;
@@ -900,12 +931,14 @@ void ART::LookupValues(DataChunk &input, ConflictManager &conflict_manager) {
 
 	idx_t found_conflict = DConstants::INVALID_INDEX;
 	for (idx_t i = 0; found_conflict == DConstants::INVALID_INDEX && i < input.size(); i++) {
+
 		if (keys[i].Empty()) {
 			if (conflict_manager.AddNull(i)) {
 				found_conflict = i;
 			}
 			continue;
 		}
+
 		Leaf *leaf_ptr = Lookup(tree, keys[i], 0);
 		if (leaf_ptr == nullptr) {
 			if (conflict_manager.AddMiss(i)) {
@@ -913,6 +946,7 @@ void ART::LookupValues(DataChunk &input, ConflictManager &conflict_manager) {
 			}
 			continue;
 		}
+
 		// When we find a node, we need to update the 'matches' and 'row_ids'
 		// NOTE: Leafs can have more than one row_id, but for UNIQUE/PRIMARY KEY they will only have one
 		D_ASSERT(leaf_ptr->count == 1);
@@ -921,11 +955,15 @@ void ART::LookupValues(DataChunk &input, ConflictManager &conflict_manager) {
 			found_conflict = i;
 		}
 	}
+
 	conflict_manager.FinishLookup();
+	IncreaseAndVerifyMemorySize(old_memory_size);
+
 	if (found_conflict == DConstants::INVALID_INDEX) {
 		// No conflicts detected
 		return;
 	}
+
 	auto key_name = GenerateErrorKeyName(input, found_conflict);
 	auto exception_msg = GenerateConstraintErrorMessage(conflict_manager.LookupType(), key_name);
 	throw ConstraintException(exception_msg);
@@ -935,13 +973,15 @@ void ART::LookupValues(DataChunk &input, ConflictManager &conflict_manager) {
 // Serialization
 //===--------------------------------------------------------------------===//
 
-BlockPointer ART::Serialize(duckdb::MetaBlockWriter &writer) {
+BlockPointer ART::Serialize(MetaBlockWriter &writer) {
 	lock_guard<mutex> l(lock);
+	auto old_memory_size = memory_size;
 	if (tree) {
 		serialized_data_pointer = tree->Serialize(*this, writer);
 	} else {
 		serialized_data_pointer = {(block_id_t)DConstants::INVALID_INDEX, (uint32_t)DConstants::INVALID_INDEX};
 	}
+	IncreaseAndVerifyMemorySize(old_memory_size);
 	return serialized_data_pointer;
 }
 
@@ -954,8 +994,8 @@ bool ART::MergeIndexes(IndexLock &state, Index *other_index) {
 	auto other_art = (ART *)other_index;
 
 	if (!this->tree) {
-		this->memory_size += other_art->memory_size;
-		this->tree = other_art->tree;
+		IncreaseMemorySize(other_art->memory_size);
+		tree = other_art->tree;
 		other_art->tree = nullptr;
 		return true;
 	}
@@ -985,6 +1025,16 @@ void ART::Verify() {
 		                        current_mem_size);
 	}
 #endif
+}
+
+void ART::IncreaseAndVerifyMemorySize(idx_t old_memory_size) {
+	// since we lazily deserialize ART nodes, it is possible that its in-memory size
+	// increased during lookups
+	Verify();
+	D_ASSERT(memory_size >= old_memory_size);
+	if (track_memory) {
+		buffer_manager.IncreaseUsedMemory(memory_size - old_memory_size);
+	}
 }
 
 } // namespace duckdb

--- a/src/execution/index/art/node16.cpp
+++ b/src/execution/index/art/node16.cpp
@@ -104,7 +104,7 @@ void Node16::InsertChild(ART &art, Node *&node, uint8_t key_byte, Node *new_chil
 	} else {
 		// node is full, grow to Node48
 		auto new_node = Node48::New();
-		art.memory_size += new_node->MemorySize(art, false);
+		art.IncreaseMemorySize(new_node->MemorySize(art, false));
 		new_node->count = node->count;
 		new_node->prefix = std::move(n->prefix);
 
@@ -114,8 +114,7 @@ void Node16::InsertChild(ART &art, Node *&node, uint8_t key_byte, Node *new_chil
 			n->children[i] = nullptr;
 		}
 
-		D_ASSERT(art.memory_size >= node->MemorySize(art, false));
-		art.memory_size -= node->MemorySize(art, false);
+		art.DecreaseMemorySize(node->MemorySize(art, false));
 		Node::Delete(node);
 		node = new_node;
 		Node48::InsertChild(art, node, key_byte, new_child);
@@ -130,8 +129,7 @@ void Node16::EraseChild(ART &art, Node *&node, idx_t pos) {
 	// adjust the ART size
 	if (n->ChildIsInMemory(pos)) {
 		auto child = n->GetChild(art, pos);
-		D_ASSERT(art.memory_size >= child->MemorySize(art, true));
-		art.memory_size -= child->MemorySize(art, true);
+		art.DecreaseMemorySize(child->MemorySize(art, true));
 	}
 
 	// erase the child and decrease the count
@@ -155,7 +153,7 @@ void Node16::EraseChild(ART &art, Node *&node, idx_t pos) {
 	if (node->count < Node4::GetSize()) {
 
 		auto new_node = Node4::New();
-		art.memory_size += new_node->MemorySize(art, false);
+		art.IncreaseMemorySize(new_node->MemorySize(art, false));
 		new_node->prefix = std::move(n->prefix);
 
 		for (idx_t i = 0; i < n->count; i++) {
@@ -164,8 +162,7 @@ void Node16::EraseChild(ART &art, Node *&node, idx_t pos) {
 			n->children[i] = nullptr;
 		}
 
-		D_ASSERT(art.memory_size >= node->MemorySize(art, false));
-		art.memory_size -= node->MemorySize(art, false);
+		art.DecreaseMemorySize(node->MemorySize(art, false));
 		Node::Delete(node);
 		node = new_node;
 	}

--- a/src/execution/index/art/node256.cpp
+++ b/src/execution/index/art/node256.cpp
@@ -92,8 +92,7 @@ void Node256::EraseChild(ART &art, Node *&node, idx_t pos) {
 	// adjust the ART size
 	if (n->ChildIsInMemory(pos)) {
 		auto child = n->GetChild(art, pos);
-		D_ASSERT(art.memory_size >= child->MemorySize(art, true));
-		art.memory_size -= child->MemorySize(art, true);
+		art.DecreaseMemorySize(child->MemorySize(art, true));
 	}
 
 	// erase the child and decrease the count
@@ -104,7 +103,7 @@ void Node256::EraseChild(ART &art, Node *&node, idx_t pos) {
 	if (node->count <= NODE_256_SHRINK_THRESHOLD) {
 
 		auto new_node = Node48::New();
-		art.memory_size += new_node->MemorySize(art, false);
+		art.IncreaseMemorySize(new_node->MemorySize(art, false));
 		new_node->prefix = std::move(n->prefix);
 
 		for (idx_t i = 0; i < Node256::GetSize(); i++) {
@@ -115,8 +114,7 @@ void Node256::EraseChild(ART &art, Node *&node, idx_t pos) {
 			}
 		}
 
-		D_ASSERT(art.memory_size >= node->MemorySize(art, false));
-		art.memory_size -= node->MemorySize(art, false);
+		art.DecreaseMemorySize(node->MemorySize(art, false));
 		Node::Delete(node);
 		node = new_node;
 	}

--- a/src/execution/index/art/node4.cpp
+++ b/src/execution/index/art/node4.cpp
@@ -101,7 +101,7 @@ void Node4::InsertChild(ART &art, Node *&node, uint8_t key_byte, Node *new_child
 	} else {
 		// node is full, grow to Node16
 		auto new_node = Node16::New();
-		art.memory_size += new_node->MemorySize(art, false);
+		art.IncreaseMemorySize(new_node->MemorySize(art, false));
 		new_node->count = n->count;
 		new_node->prefix = std::move(node->prefix);
 
@@ -112,8 +112,7 @@ void Node4::InsertChild(ART &art, Node *&node, uint8_t key_byte, Node *new_child
 		}
 		n->count = 0;
 
-		D_ASSERT(art.memory_size >= node->MemorySize(art, false));
-		art.memory_size -= node->MemorySize(art, false);
+		art.DecreaseMemorySize(node->MemorySize(art, false));
 		Node::Delete(node);
 		node = new_node;
 		Node16::InsertChild(art, node, key_byte, new_child);
@@ -129,8 +128,7 @@ void Node4::EraseChild(ART &art, Node *&node, idx_t pos) {
 	// adjust the ART size
 	if (n->ChildIsInMemory(pos)) {
 		auto child = n->GetChild(art, pos);
-		D_ASSERT(art.memory_size >= child->MemorySize(art, true));
-		art.memory_size -= child->MemorySize(art, true);
+		art.DecreaseMemorySize(child->MemorySize(art, true));
 	}
 
 	// erase the child and decrease the count
@@ -158,8 +156,7 @@ void Node4::EraseChild(ART &art, Node *&node, idx_t pos) {
 		// ensure that when deleting the node, we do not delete the child (because we move it)
 		n->children[0] = nullptr;
 
-		D_ASSERT(art.memory_size >= n->MemorySize(art, false));
-		art.memory_size -= n->MemorySize(art, false);
+		art.DecreaseMemorySize(n->MemorySize(art, false));
 		Node::Delete(node);
 		node = child_ref;
 	}

--- a/src/execution/index/art/node48.cpp
+++ b/src/execution/index/art/node48.cpp
@@ -105,7 +105,7 @@ void Node48::InsertChild(ART &art, Node *&node, uint8_t key_byte, Node *new_chil
 	} else {
 		// node is full, grow to Node256
 		auto new_node = Node256::New();
-		art.memory_size += new_node->MemorySize(art, false);
+		art.IncreaseMemorySize(new_node->MemorySize(art, false));
 		new_node->count = n->count;
 		new_node->prefix = std::move(n->prefix);
 
@@ -116,8 +116,7 @@ void Node48::InsertChild(ART &art, Node *&node, uint8_t key_byte, Node *new_chil
 			}
 		}
 
-		D_ASSERT(art.memory_size >= node->MemorySize(art, false));
-		art.memory_size -= node->MemorySize(art, false);
+		art.DecreaseMemorySize(node->MemorySize(art, false));
 		Node::Delete(node);
 		node = new_node;
 		Node256::InsertChild(art, node, key_byte, new_child);
@@ -130,8 +129,7 @@ void Node48::EraseChild(ART &art, Node *&node, idx_t pos) {
 	// adjust the ART size
 	if (n->ChildIsInMemory(pos)) {
 		auto child = n->GetChild(art, pos);
-		D_ASSERT(art.memory_size >= child->MemorySize(art, true));
-		art.memory_size -= child->MemorySize(art, true);
+		art.DecreaseMemorySize(child->MemorySize(art, true));
 	}
 
 	// erase the child and decrease the count
@@ -143,7 +141,7 @@ void Node48::EraseChild(ART &art, Node *&node, idx_t pos) {
 	if (node->count < NODE_48_SHRINK_THRESHOLD) {
 
 		auto new_node = Node16::New();
-		art.memory_size += new_node->MemorySize(art, false);
+		art.IncreaseMemorySize(new_node->MemorySize(art, false));
 		new_node->prefix = std::move(n->prefix);
 
 		for (idx_t i = 0; i < Node256::GetSize(); i++) {
@@ -154,8 +152,7 @@ void Node48::EraseChild(ART &art, Node *&node, idx_t pos) {
 			}
 		}
 
-		D_ASSERT(art.memory_size >= node->MemorySize(art, false));
-		art.memory_size -= node->MemorySize(art, false);
+		art.DecreaseMemorySize(node->MemorySize(art, false));
 		Node::Delete(node);
 		node = new_node;
 	}

--- a/src/execution/index/art/prefix.cpp
+++ b/src/execution/index/art/prefix.cpp
@@ -113,7 +113,7 @@ void Prefix::Overwrite(uint32_t new_size, uint8_t *data) {
 
 void Prefix::Concatenate(ART &art, uint8_t key, Prefix &other) {
 	auto new_size = size + 1 + other.size;
-	art.memory_size += (new_size - size) * sizeof(uint8_t);
+	art.IncreaseMemorySize((new_size - size) * sizeof(uint8_t));
 	// have to allocate space in our prefix array
 	auto new_prefix = AllocateArray<uint8_t>(new_size);
 	idx_t new_prefix_idx = 0;
@@ -136,8 +136,7 @@ void Prefix::Concatenate(ART &art, uint8_t key, Prefix &other) {
 
 uint8_t Prefix::Reduce(ART &art, uint32_t n) {
 	auto new_size = size - n - 1;
-	D_ASSERT(art.memory_size >= (size - new_size) * sizeof(uint8_t));
-	art.memory_size -= (size - new_size) * sizeof(uint8_t);
+	art.DecreaseMemorySize((size - new_size) * sizeof(uint8_t));
 	auto prefix = GetPrefixData();
 	auto partial_key = prefix[n];
 

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -287,9 +287,12 @@ void TableScanPushdownComplexFilter(ClientContext &context, LogicalGet &get, Fun
 	// behold
 	storage.info->indexes.Scan([&](Index &index) {
 		// first rewrite the index expression so the ColumnBindings align with the column bindings of the current table
+
 		if (index.unbound_expressions.size() > 1) {
+			// NOTE: index scans are not (yet) supported for compound index keys
 			return false;
 		}
+
 		auto index_expression = index.unbound_expressions[0]->Copy();
 		bool rewrite_possible = true;
 		RewriteIndexExpression(index, get, *index_expression, rewrite_possible);

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -29,6 +29,7 @@ struct CreateFunctionInfo;
 struct CreateViewInfo;
 struct CreateSequenceInfo;
 struct CreateCollationInfo;
+struct CreateIndexInfo;
 struct CreateTypeInfo;
 struct CreateTableInfo;
 struct DatabaseSize;
@@ -137,6 +138,9 @@ public:
 	//! Creates a collation in the catalog
 	DUCKDB_API CatalogEntry *CreateCollation(CatalogTransaction transaction, CreateCollationInfo *info);
 	DUCKDB_API CatalogEntry *CreateCollation(ClientContext &context, CreateCollationInfo *info);
+	//! Creates an index in the catalog
+	DUCKDB_API CatalogEntry *CreateIndex(CatalogTransaction transaction, CreateIndexInfo *info);
+	DUCKDB_API CatalogEntry *CreateIndex(ClientContext &context, CreateIndexInfo *info);
 
 	//! Creates a table in the catalog.
 	DUCKDB_API CatalogEntry *CreateTable(CatalogTransaction transaction, SchemaCatalogEntry *schema,
@@ -153,7 +157,7 @@ public:
 	//! Create a scalar or aggregate function in the catalog
 	DUCKDB_API CatalogEntry *CreateFunction(CatalogTransaction transaction, SchemaCatalogEntry *schema,
 	                                        CreateFunctionInfo *info);
-	//! Creates a table in the catalog.
+	//! Creates a view in the catalog
 	DUCKDB_API CatalogEntry *CreateView(CatalogTransaction transaction, SchemaCatalogEntry *schema,
 	                                    CreateViewInfo *info);
 	//! Creates a table in the catalog.

--- a/src/include/duckdb/catalog/catalog_entry/duck_index_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/duck_index_entry.hpp
@@ -1,7 +1,7 @@
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// duckdb/catalog/catalog_entry/dindex_catalog_entry.hpp
+// duckdb/catalog/catalog_entry/duck_index_entry.hpp
 //
 //
 //===----------------------------------------------------------------------===//

--- a/src/include/duckdb/catalog/catalog_entry/index_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/index_catalog_entry.hpp
@@ -34,7 +34,7 @@ public:
 
 public:
 	string ToSQL() override;
-	void Serialize(duckdb::MetaBlockWriter &serializer);
+	void Serialize(Serializer &serializer);
 	static unique_ptr<CreateIndexInfo> Deserialize(Deserializer &source, ClientContext &context);
 
 	virtual string GetSchemaName() = 0;

--- a/src/include/duckdb/common/enums/wal_type.hpp
+++ b/src/include/duckdb/common/enums/wal_type.hpp
@@ -41,6 +41,9 @@ enum class WALType : uint8_t {
 	CREATE_TABLE_MACRO = 21,
 	DROP_TABLE_MACRO = 22,
 
+	CREATE_INDEX = 23,
+	DROP_INDEX = 24,
+
 	// -----------------------------
 	// Data
 	// -----------------------------

--- a/src/include/duckdb/execution/index/art/art.hpp
+++ b/src/include/duckdb/execution/index/art/art.hpp
@@ -29,24 +29,21 @@ namespace duckdb {
 class ConflictManager;
 
 struct ARTIndexScanState : public IndexScanState {
-	ARTIndexScanState() : checked(false), result_index(0) {
-	}
 
+	//! Scan predicates (single predicate scan or range scan)
 	Value values[2];
+	//! Expressions of the scan predicates
 	ExpressionType expressions[2];
-	bool checked;
+	bool checked = false;
+	//! All scanned row IDs
 	vector<row_t> result_ids;
 	Iterator iterator;
-	//! Stores the current leaf
-	Leaf *cur_leaf = nullptr;
-	//! Offset to leaf
-	idx_t result_index = 0;
 };
 
 enum class VerifyExistenceType : uint8_t {
-	APPEND = 0,    // for purpose to append into table
-	APPEND_FK = 1, // for purpose to append into table has foreign key
-	DELETE_FK = 2  // for purpose to delete from table related to foreign key
+	APPEND = 0,    // appends to a table
+	APPEND_FK = 1, // appends to a table that has a foreign key
+	DELETE_FK = 2  // delete from a table that has a foreign key
 };
 
 class ART : public Index {
@@ -62,47 +59,44 @@ public:
 	Node *tree;
 
 public:
-	//! Initialize a scan on the index with the given expression and column ids
-	//! to fetch from the base table for a single predicate
+	//! Initialize a single predicate scan on the index with the given expression and column IDs
 	unique_ptr<IndexScanState> InitializeScanSinglePredicate(const Transaction &transaction, const Value &value,
 	                                                         ExpressionType expression_type) override;
-
-	//! Initialize a scan on the index with the given expression and column ids
-	//! to fetch from the base table for two predicates
+	//! Initialize a two predicate scan on the index with the given expression and column IDs
 	unique_ptr<IndexScanState> InitializeScanTwoPredicates(Transaction &transaction, const Value &low_value,
 	                                                       ExpressionType low_expression_type, const Value &high_value,
 	                                                       ExpressionType high_expression_type) override;
-
-	//! Perform a lookup on the index
+	//! Performs a lookup on the index, fetching up to max_count result IDs. Returns true if all row IDs were fetched,
+	//! and false otherwise
 	bool Scan(Transaction &transaction, DataTable &table, IndexScanState &state, idx_t max_count,
 	          vector<row_t> &result_ids) override;
-	//! Append entries to the index
+
+	//! Called when data is appended to the index. The lock obtained from InitializeLock must be held
 	bool Append(IndexLock &lock, DataChunk &entries, Vector &row_identifiers) override;
-	//! Verify that data can be appended to the index
+	//! Verify that data can be appended to the index without a constraint violation
 	void VerifyAppend(DataChunk &chunk) override;
-	//! Verify that data can be appended to the index
+	//! Verify that data can be appended to the index without a constraint violation using the conflict manager
 	void VerifyAppend(DataChunk &chunk, ConflictManager &conflict_manager) override;
-	//! Verify that data can be appended to the index for foreign key constraint
-	void VerifyAppendForeignKey(DataChunk &chunk) override;
-	//! Verify that data can be delete from the index for foreign key constraint
-	void VerifyDeleteForeignKey(DataChunk &chunk) override;
-	//! Delete entries in the index
+	//! Delete a chunk of entries from the index. The lock obtained from InitializeLock must be held
 	void Delete(IndexLock &lock, DataChunk &entries, Vector &row_identifiers) override;
-	//! Insert data into the index
+	//! Insert a chunk of entries into the index
 	bool Insert(IndexLock &lock, DataChunk &data, Vector &row_ids) override;
 
 	//! Construct an ART from a vector of sorted keys
 	bool ConstructFromSorted(idx_t count, vector<Key> &keys, Vector &row_identifiers);
 
-	//! Search Equal and fetches the row IDs
+	//! Search equal values and fetches the row IDs
 	bool SearchEqual(Key &key, idx_t max_count, vector<row_t> &result_ids);
-	//! Search Equal used for Joins that do not need to fetch data
+	//! Search equal values used for joins that do not need to fetch data
 	void SearchEqualJoinNoFetch(Key &key, idx_t &result_size);
-	//! Serialized the ART
+
+	//! Serializes the index and returns the pair of block_id offset positions
 	BlockPointer Serialize(duckdb::MetaBlockWriter &writer) override;
 
-	//! Merge two ARTs
+	//! Merge another index into this index. The lock obtained from InitializeLock must be held, and the other
+	//! index must also be locked during the merge
 	bool MergeIndexes(IndexLock &state, Index *other_index) override;
+
 	//! Generate ART keys for an input chunk
 	static void GenerateKeys(ArenaAllocator &allocator, DataChunk &input, vector<Key> &keys);
 
@@ -110,30 +104,32 @@ public:
 	string GenerateErrorKeyName(DataChunk &input, idx_t row);
 	//! Generate the matching error message for a constraint violation
 	string GenerateConstraintErrorMessage(VerifyExistenceType verify_type, const string &key_name);
+	//! Performs constraint checking for a chunk of input data
+	void CheckConstraintsForChunk(DataChunk &input, ConflictManager &conflict_manager) override;
 
 	//! Returns the string representation of an ART
 	string ToString() override;
-	//! Verifies that the memory_size value of the ART matches its actual size
+	//! Verifies that the in-memory size value of the index matches its actual size
 	void Verify() override;
+	//! Increases the memory size by the difference between the old size and the current size
+	//! and performs verifications
+	void IncreaseAndVerifyMemorySize(idx_t old_memory_size) override;
 
 private:
-	//! Insert a row id into a leaf node
+	//! Insert a row ID into a leaf
 	bool InsertToLeaf(Leaf &leaf, row_t row_id);
-	//! Insert the leaf value into the tree
+	//! Insert a key into the tree
 	bool Insert(Node *&node, Key &key, idx_t depth, row_t row_id);
-
-	//! Erase element from leaf (if leaf has more than one value) or eliminate the leaf itself
+	//! Erase a key from the tree (if a leaf has more than one value) or erase the leaf itself
 	void Erase(Node *&node, Key &key, idx_t depth, row_t row_id);
-
-	//! Perform 'Lookup' for an entire chunk, marking which succeeded
-	void LookupValues(DataChunk &input, ConflictManager &conflict_manager) final override;
-
-	//! Find the node with a matching key, optimistic version
+	//! Find the node with a matching key, or return nullptr if not found
 	Leaf *Lookup(Node *node, Key &key, idx_t depth);
-
+	//! Returns all row IDs belonging to a key greater (or equal) than the search key
 	bool SearchGreater(ARTIndexScanState *state, Key &key, bool inclusive, idx_t max_count, vector<row_t> &result_ids);
+	//! Returns all row IDs belonging to a key less (or equal) than the upper_bound
 	bool SearchLess(ARTIndexScanState *state, Key &upper_bound, bool inclusive, idx_t max_count,
 	                vector<row_t> &result_ids);
+	//! Returns all row IDs belonging to a key within the range of lower_bound and upper_bound
 	bool SearchCloseRange(ARTIndexScanState *state, Key &lower_bound, Key &upper_bound, bool left_inclusive,
 	                      bool right_inclusive, idx_t max_count, vector<row_t> &result_ids);
 };

--- a/src/include/duckdb/execution/index/art/art_key.hpp
+++ b/src/include/duckdb/execution/index/art/art_key.hpp
@@ -28,24 +28,24 @@ public:
 
 public:
 	template <class T>
-	static inline Key CreateKey(ArenaAllocator &allocator, T element) {
+	static inline Key CreateKey(ArenaAllocator &allocator, const LogicalType &type, T element) {
 		auto data = Key::CreateData<T>(allocator, element);
 		return Key(data, sizeof(element));
 	}
 
 	template <class T>
-	static inline Key CreateKey(ArenaAllocator &allocator, const Value &element) {
-		return CreateKey(allocator, element.GetValueUnsafe<T>());
+	static inline Key CreateKey(ArenaAllocator &allocator, const LogicalType &type, const Value &element) {
+		return CreateKey(allocator, type, element.GetValueUnsafe<T>());
 	}
 
 	template <class T>
-	static inline void CreateKey(ArenaAllocator &allocator, Key &key, T element) {
+	static inline void CreateKey(ArenaAllocator &allocator, const LogicalType &type, Key &key, T element) {
 		key.data = Key::CreateData<T>(allocator, element);
 		key.len = sizeof(element);
 	}
 
 	template <class T>
-	static inline void CreateKey(ArenaAllocator &allocator, Key &key, const Value element) {
+	static inline void CreateKey(ArenaAllocator &allocator, const LogicalType &type, Key &key, const Value element) {
 		key.data = Key::CreateData<T>(allocator, element.GetValueUnsafe<T>());
 		key.len = sizeof(element);
 	}
@@ -76,12 +76,9 @@ private:
 };
 
 template <>
-Key Key::CreateKey(ArenaAllocator &allocator, string_t value);
+Key Key::CreateKey(ArenaAllocator &allocator, const LogicalType &type, string_t value);
 template <>
-Key Key::CreateKey(ArenaAllocator &allocator, const char *value);
+Key Key::CreateKey(ArenaAllocator &allocator, const LogicalType &type, const char *value);
 template <>
-void Key::CreateKey(ArenaAllocator &allocator, Key &key, string_t value);
-template <>
-void Key::CreateKey(ArenaAllocator &allocator, Key &key, const char *value);
-
+void Key::CreateKey(ArenaAllocator &allocator, const LogicalType &type, Key &key, string_t value);
 } // namespace duckdb

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -108,6 +108,9 @@ public:
 
 	unique_ptr<BoundCreateTableInfo> BindCreateTableInfo(unique_ptr<CreateInfo> info);
 	unique_ptr<BoundCreateTableInfo> BindCreateTableInfo(unique_ptr<CreateInfo> info, SchemaCatalogEntry *schema);
+
+	vector<unique_ptr<Expression>> BindCreateIndexExpressions(TableCatalogEntry *table, CreateIndexInfo *info);
+
 	void BindCreateViewInfo(CreateViewInfo &base);
 	SchemaCatalogEntry *BindSchema(CreateInfo &info);
 	SchemaCatalogEntry *BindCreateFunctionInfo(CreateInfo &info);

--- a/src/include/duckdb/planner/expression_binder/index_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/index_binder.hpp
@@ -10,20 +10,27 @@
 
 #include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/common/unordered_map.hpp"
+#include "duckdb/parser/parsed_data/create_index_info.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 
 namespace duckdb {
 class BoundColumnRefExpression;
 
-//! The INDEX binder is responsible for binding an expression within an Index statement
+//! The IndexBinder is responsible for binding an expression within an index statement
 class IndexBinder : public ExpressionBinder {
 public:
-	IndexBinder(Binder &binder, ClientContext &context);
+	IndexBinder(Binder &binder, ClientContext &context, TableCatalogEntry *table = nullptr,
+	            CreateIndexInfo *info = nullptr);
 
 protected:
 	BindResult BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth,
 	                          bool root_expression = false) override;
-
 	string UnsupportedAggregateMessage() override;
+
+private:
+	// only for WAL replay
+	TableCatalogEntry *table;
+	CreateIndexInfo *info;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -122,6 +122,12 @@ public:
 	void UpdateColumn(TableCatalogEntry &table, ClientContext &context, Vector &row_ids,
 	                  const vector<column_t> &column_path, DataChunk &updates);
 
+	//! Add an index to the DataTable. NOTE: for CREATE (UNIQUE) INDEX statements, we use the PhysicalCreateIndex
+	//! operator. This function is only used during the WAL replay, and is a much less performant index creation
+	//! approach.
+	void WALAddIndex(ClientContext &context, unique_ptr<Index> index,
+	                 const vector<unique_ptr<Expression>> &expressions);
+
 	//! Fetches an append lock
 	void AppendLock(TableAppendState &state);
 	//! Begin appending structs to this table, obtaining necessary locks, etc
@@ -176,7 +182,7 @@ public:
 	static bool IsForeignKeyIndex(const vector<PhysicalIndex> &fk_keys, Index &index, ForeignKeyType fk_type);
 
 	//! Initializes a special scan that is used to create an index on the table, it keeps locks on the table
-	void InitializeCreateIndexScan(CreateIndexScanState &state, const vector<column_t> &column_ids);
+	void InitializeWALCreateIndexScan(CreateIndexScanState &state, const vector<column_t> &column_ids);
 	//! Scans the next chunk for the CREATE INDEX operator
 	bool CreateIndexScan(TableScanState &state, DataChunk &result, TableScanType type);
 

--- a/src/include/duckdb/storage/index.hpp
+++ b/src/include/duckdb/storage/index.hpp
@@ -44,7 +44,7 @@ public:
 	vector<column_t> column_ids;
 	//! Unordered_set of column_ids used by the index
 	unordered_set<column_t> column_id_set;
-	//! Unbound expressions used by the index
+	//! Unbound expressions used by the index during optimizations
 	vector<unique_ptr<Expression>> unbound_expressions;
 	//! The physical types stored in the index
 	vector<PhysicalType> types;
@@ -137,9 +137,10 @@ public:
 		return serialized_data_pointer;
 	}
 
-protected:
+	//! Execute the index expressions on an input chunk
 	void ExecuteExpressions(DataChunk &input, DataChunk &result);
 
+protected:
 	//! Lock used for updating the index
 	mutex lock;
 
@@ -147,11 +148,11 @@ protected:
 	BlockPointer serialized_data_pointer;
 
 private:
-	//! Bound expressions used by the index
+	//! Bound expressions used by the index during expression execution
 	vector<unique_ptr<Expression>> bound_expressions;
 	//! Expression executor for the index expressions
 	ExpressionExecutor executor;
-
+	//! Bind the unbound expressions of the index
 	unique_ptr<Expression> BindExpression(unique_ptr<Expression> expr);
 };
 

--- a/src/include/duckdb/storage/index.hpp
+++ b/src/include/duckdb/storage/index.hpp
@@ -40,9 +40,9 @@ public:
 	IndexType type;
 	//! Associated table io manager
 	TableIOManager &table_io_manager;
-	//! Column identifiers to extract from the base table
+	//! Column identifiers to extract key columns from the base table
 	vector<column_t> column_ids;
-	//! Unordered_set of column_ids used by the index
+	//! Unordered set of column_ids used by the index
 	unordered_set<column_t> column_id_set;
 	//! Unbound expressions used by the index during optimizations
 	vector<unique_ptr<Expression>> unbound_expressions;
@@ -64,75 +64,83 @@ public:
 	bool track_memory;
 
 public:
-	//! Initialize a scan on the index with the given expression and column ids
-	//! to fetch from the base table when we only have one query predicate
+	//! Initialize a single predicate scan on the index with the given expression and column IDs
 	virtual unique_ptr<IndexScanState> InitializeScanSinglePredicate(const Transaction &transaction, const Value &value,
 	                                                                 ExpressionType expressionType) = 0;
-	//! Initialize a scan on the index with the given expression and column ids
-	//! to fetch from the base table for two query predicates
+	//! Initialize a two predicate scan on the index with the given expression and column IDs
 	virtual unique_ptr<IndexScanState> InitializeScanTwoPredicates(Transaction &transaction, const Value &low_value,
 	                                                               ExpressionType low_expression_type,
 	                                                               const Value &high_value,
 	                                                               ExpressionType high_expression_type) = 0;
-	//! Perform a lookup on the index, fetching up to max_count result ids. Returns true if all row ids were fetched,
-	//! and false otherwise.
+	//! Performs a lookup on the index, fetching up to max_count result IDs. Returns true if all row IDs were fetched,
+	//! and false otherwise
 	virtual bool Scan(Transaction &transaction, DataTable &table, IndexScanState &state, idx_t max_count,
 	                  vector<row_t> &result_ids) = 0;
 
 	//! Obtain a lock on the index
 	virtual void InitializeLock(IndexLock &state);
-	//! Called when data is appended to the index. The lock obtained from InitializeAppend must be held
+	//! Called when data is appended to the index. The lock obtained from InitializeLock must be held
 	virtual bool Append(IndexLock &state, DataChunk &entries, Vector &row_identifiers) = 0;
+	//! Obtains a lock and calls Append while holding that lock
 	bool Append(DataChunk &entries, Vector &row_identifiers);
-	//! Verify that data can be appended to the index
+	//! Verify that data can be appended to the index without a constraint violation
 	virtual void VerifyAppend(DataChunk &chunk) = 0;
-	//! Verify that data can be appended to the index
+	//! Verify that data can be appended to the index without a constraint violation using the conflict manager
 	virtual void VerifyAppend(DataChunk &chunk, ConflictManager &conflict_manager) = 0;
-	//! Verify that data can be appended to the index for foreign key constraint
-	virtual void VerifyAppendForeignKey(DataChunk &chunk) = 0;
-	//! Verify that data can be delete from the index for foreign key constraint
-	virtual void VerifyDeleteForeignKey(DataChunk &chunk) = 0;
+	//! Performs constraint checking for a chunk of input data
+	virtual void CheckConstraintsForChunk(DataChunk &input, ConflictManager &conflict_manager) = 0;
 
-	//! Called when data inside the index is Deleted
+	//! Delete a chunk of entries from the index. The lock obtained from InitializeLock must be held
 	virtual void Delete(IndexLock &state, DataChunk &entries, Vector &row_identifiers) = 0;
+	//! Obtains a lock and calls Delete while holding that lock
 	void Delete(DataChunk &entries, Vector &row_identifiers);
 
-	//! Insert data into the index. Does not lock the index.
+	//! Insert a chunk of entries into the index
 	virtual bool Insert(IndexLock &lock, DataChunk &input, Vector &row_identifiers) = 0;
 
-	//! Merge other_index into this index.
+	//! Merge another index into this index. The lock obtained from InitializeLock must be held, and the other
+	//! index must also be locked during the merge
 	virtual bool MergeIndexes(IndexLock &state, Index *other_index) = 0;
+	//! Obtains a lock and calls MergeIndexes while holding that lock
 	bool MergeIndexes(Index *other_index);
 
 	//! Returns the string representation of an index
 	virtual string ToString() = 0;
-	//! Verifies that the memory_size value of the index matches its actual size
+	//! Verifies that the in-memory size value of the index matches its actual size
 	virtual void Verify() = 0;
+	//! Increases the memory size by the difference between the old size and the current size
+	//! and performs verifications
+	virtual void IncreaseAndVerifyMemorySize(idx_t old_memory_size) = 0;
 
-	//! Returns true if the index is affected by updates on the specified column ids, and false otherwise
+	//! Increases the in-memory size value
+	inline void IncreaseMemorySize(idx_t size) {
+		memory_size += size;
+	};
+	//! Decreases the in-memory size value
+	inline void DecreaseMemorySize(idx_t size) {
+		D_ASSERT(memory_size >= size);
+		memory_size -= size;
+	};
+
+	//! Returns true if the index is affected by updates on the specified column IDs, and false otherwise
 	bool IndexIsUpdated(const vector<PhysicalIndex> &column_ids) const;
-
-	//! Returns how many of the input values were found in the 'input' chunk, with the option to also record what those
-	//! matches were. For this purpose, nulls count as a match, and are returned in 'null_count'
-	virtual void LookupValues(DataChunk &input, ConflictManager &conflict_manager) = 0;
 
 	//! Returns unique flag
 	bool IsUnique() {
 		return (constraint_type == IndexConstraintType::UNIQUE || constraint_type == IndexConstraintType::PRIMARY);
 	}
-	//! Returns primary flag
+	//! Returns primary key flag
 	bool IsPrimary() {
 		return (constraint_type == IndexConstraintType::PRIMARY);
 	}
-	//! Returns foreign flag
+	//! Returns foreign key flag
 	bool IsForeign() {
 		return (constraint_type == IndexConstraintType::FOREIGN);
 	}
-	//! Serializes the index and returns the pair of block_id offset positions
-	virtual BlockPointer Serialize(duckdb::MetaBlockWriter &writer);
-	BlockPointer GetBlockPointer();
 
-	//! Returns block/offset of where index was most recently serialized.
+	//! Serializes the index and returns the pair of block_id offset positions
+	virtual BlockPointer Serialize(MetaBlockWriter &writer);
+	//! Returns the serialized data pointer to the block and offset of the serialized index
 	BlockPointer GetSerializedDataPointer() const {
 		return serialized_data_pointer;
 	}
@@ -141,17 +149,17 @@ public:
 	void ExecuteExpressions(DataChunk &input, DataChunk &result);
 
 protected:
-	//! Lock used for updating the index
+	//! Lock used for any changes to the index
 	mutex lock;
-
-	//! Pointer to most recently checkpointed index data.
+	//! Pointer to serialized index data
 	BlockPointer serialized_data_pointer;
 
 private:
-	//! Bound expressions used by the index during expression execution
+	//! Bound expressions used during expression execution
 	vector<unique_ptr<Expression>> bound_expressions;
-	//! Expression executor for the index expressions
+	//! Expression executor to execute the index expressions
 	ExpressionExecutor executor;
+
 	//! Bind the unbound expressions of the index
 	unique_ptr<Expression> BindExpression(unique_ptr<Expression> expr);
 };

--- a/src/include/duckdb/storage/write_ahead_log.hpp
+++ b/src/include/duckdb/storage/write_ahead_log.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/catalog/catalog_entry/scalar_macro_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/sequence_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_macro_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/index_catalog_entry.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/storage/storage_info.hpp"
 
@@ -77,6 +78,9 @@ protected:
 	void ReplayCreateTableMacro();
 	void ReplayDropTableMacro();
 
+	void ReplayCreateIndex();
+	void ReplayDropIndex();
+
 	void ReplayUseTable();
 	void ReplayInsert();
 	void ReplayDelete();
@@ -124,6 +128,9 @@ public:
 
 	void WriteCreateTableMacro(TableMacroCatalogEntry *entry);
 	void WriteDropTableMacro(TableMacroCatalogEntry *entry);
+
+	void WriteCreateIndex(IndexCatalogEntry *entry);
+	void WriteDropIndex(IndexCatalogEntry *entry);
 
 	void WriteCreateType(TypeCatalogEntry *entry);
 	void WriteDropType(TypeCatalogEntry *entry);

--- a/src/parser/parsed_data/create_index_info.cpp
+++ b/src/parser/parsed_data/create_index_info.cpp
@@ -16,6 +16,9 @@ unique_ptr<CreateInfo> CreateIndexInfo::Copy() const {
 	for (auto &expr : expressions) {
 		result->expressions.push_back(expr->Copy());
 	}
+	for (auto &expr : parsed_expressions) {
+		result->parsed_expressions.push_back(expr->Copy());
+	}
 
 	result->scan_types = scan_types;
 	result->names = names;

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -16,6 +16,8 @@
 #include "duckdb/parser/expression/list.hpp"
 #include "duckdb/common/index_map.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/planner/expression_binder/index_binder.hpp"
+#include "duckdb/parser/parsed_data/create_index_info.hpp"
 
 #include <algorithm>
 
@@ -298,6 +300,17 @@ unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableInfo(unique_ptr<CreateIn
 	auto &base = (CreateTableInfo &)*info;
 	auto schema = BindCreateSchema(base);
 	return BindCreateTableInfo(std::move(info), schema);
+}
+
+vector<unique_ptr<Expression>> Binder::BindCreateIndexExpressions(TableCatalogEntry *table, CreateIndexInfo *info) {
+	vector<unique_ptr<Expression>> expressions;
+
+	auto index_binder = IndexBinder(*this, this->context, table, info);
+	for (auto &expr : info->expressions) {
+		expressions.push_back(index_binder.Bind(expr));
+	}
+
+	return expressions;
 }
 
 } // namespace duckdb

--- a/src/planner/expression_binder/index_binder.cpp
+++ b/src/planner/expression_binder/index_binder.cpp
@@ -1,8 +1,14 @@
 #include "duckdb/planner/expression_binder/index_binder.hpp"
 
+#include "duckdb/parser/parsed_data/create_index_info.hpp"
+#include "duckdb/parser/expression/columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/column_binding.hpp"
+
 namespace duckdb {
 
-IndexBinder::IndexBinder(Binder &binder, ClientContext &context) : ExpressionBinder(binder, context) {
+IndexBinder::IndexBinder(Binder &binder, ClientContext &context, TableCatalogEntry *table, CreateIndexInfo *info)
+    : ExpressionBinder(binder, context), table(table), info(info) {
 }
 
 BindResult IndexBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
@@ -12,6 +18,31 @@ BindResult IndexBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, i
 		return BindResult("window functions are not allowed in index expressions");
 	case ExpressionClass::SUBQUERY:
 		return BindResult("cannot use subquery in index expressions");
+	case ExpressionClass::COLUMN_REF: {
+		if (table) {
+			// WAL replay
+			// we assume that the parsed expressions have qualified column names
+			// and that the columns exist in the table
+			auto &col_ref = (ColumnRefExpression &)expr;
+			auto col_idx = table->GetColumnIndex(col_ref.column_names.back());
+			auto col_type = table->GetColumn(col_idx).GetType();
+
+			// find the col_idx in the index.column_ids
+			auto col_id_idx = DConstants::INVALID_INDEX;
+			for (idx_t i = 0; i < info->column_ids.size(); i++) {
+				if (col_idx.index == info->column_ids[i]) {
+					col_id_idx = i;
+				}
+			}
+
+			if (col_id_idx == DConstants::INVALID_INDEX) {
+				throw InternalException("failed to replay CREATE INDEX statement - column id not found");
+			}
+			return BindResult(
+			    make_unique<BoundColumnRefExpression>(col_ref.alias, col_type, ColumnBinding(0, col_id_idx)));
+		}
+		return ExpressionBinder::BindExpression(expr_ptr, depth);
+	}
 	default:
 		return ExpressionBinder::BindExpression(expr_ptr, depth);
 	}

--- a/src/storage/index.cpp
+++ b/src/storage/index.cpp
@@ -86,7 +86,7 @@ bool Index::IndexIsUpdated(const vector<PhysicalIndex> &column_ids) const {
 	return false;
 }
 
-BlockPointer Index::Serialize(duckdb::MetaBlockWriter &writer) {
+BlockPointer Index::Serialize(MetaBlockWriter &writer) {
 	throw NotImplementedException("The implementation of this index serialization does not exist.");
 }
 

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -127,7 +127,7 @@ LocalTableStorage::LocalTableStorage(DataTable &table)
 				unbound_expressions.push_back(expr->Copy());
 			}
 			indexes.AddIndex(make_unique<ART>(art.column_ids, art.table_io_manager, std::move(unbound_expressions),
-			                                  art.constraint_type, art.db, false));
+			                                  art.constraint_type, art.db, true));
 		}
 		return false;
 	});

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -60,8 +60,7 @@ void TableIndexList::VerifyForeignKey(const vector<PhysicalIndex> &fk_keys, Data
 		throw InternalException("Internal Foreign Key error: could not find index to verify...");
 	}
 	conflict_manager.SetIndexCount(1);
-
-	index->LookupValues(chunk, conflict_manager);
+	index->CheckConstraintsForChunk(chunk, conflict_manager);
 }
 
 vector<column_t> TableIndexList::GetRequiredColumns() {

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -119,7 +119,7 @@ void WriteAheadLog::WriteSequenceValue(SequenceCatalogEntry *entry, SequenceValu
 }
 
 //===--------------------------------------------------------------------===//
-// MACRO'S
+// MACROS
 //===--------------------------------------------------------------------===//
 void WriteAheadLog::WriteCreateMacro(ScalarMacroCatalogEntry *entry) {
 	if (skip_writing) {
@@ -151,6 +151,26 @@ void WriteAheadLog::WriteDropTableMacro(TableMacroCatalogEntry *entry) {
 		return;
 	}
 	writer->Write<WALType>(WALType::DROP_TABLE_MACRO);
+	writer->WriteString(entry->schema->name);
+	writer->WriteString(entry->name);
+}
+
+//===--------------------------------------------------------------------===//
+// Indexes
+//===--------------------------------------------------------------------===//
+void WriteAheadLog::WriteCreateIndex(IndexCatalogEntry *entry) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::CREATE_INDEX);
+	entry->Serialize(*writer);
+}
+
+void WriteAheadLog::WriteDropIndex(IndexCatalogEntry *entry) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::DROP_INDEX);
 	writer->WriteString(entry->schema->name);
 	writer->WriteString(entry->name);
 }

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -87,7 +87,9 @@ void CommitState::WriteCatalogEntry(CatalogEntry *entry, data_ptr_t dataptr) {
 	case CatalogType::TABLE_MACRO_ENTRY:
 		log->WriteCreateTableMacro((TableMacroCatalogEntry *)parent);
 		break;
-
+	case CatalogType::INDEX_ENTRY:
+		log->WriteCreateIndex((IndexCatalogEntry *)parent);
+		break;
 	case CatalogType::TYPE_ENTRY:
 		log->WriteCreateType((TypeCatalogEntry *)parent);
 		break;
@@ -119,6 +121,8 @@ void CommitState::WriteCatalogEntry(CatalogEntry *entry, data_ptr_t dataptr) {
 			log->WriteDropType((TypeCatalogEntry *)entry);
 			break;
 		case CatalogType::INDEX_ENTRY:
+			log->WriteDropIndex((IndexCatalogEntry *)entry);
+			break;
 		case CatalogType::PREPARED_STATEMENT:
 		case CatalogType::SCALAR_FUNCTION_ENTRY:
 			// do nothing, indexes/prepared statements/functions aren't persisted to disk
@@ -127,7 +131,6 @@ void CommitState::WriteCatalogEntry(CatalogEntry *entry, data_ptr_t dataptr) {
 			throw InternalException("Don't know how to drop this type!");
 		}
 		break;
-	case CatalogType::INDEX_ENTRY:
 	case CatalogType::PREPARED_STATEMENT:
 	case CatalogType::AGGREGATE_FUNCTION_ENTRY:
 	case CatalogType::SCALAR_FUNCTION_ENTRY:

--- a/test/fuzzer/pedro/art_prefix_error.test
+++ b/test/fuzzer/pedro/art_prefix_error.test
@@ -1,0 +1,11 @@
+# name: test/fuzzer/pedro/art_prefix_error.test
+# description: Issue #5984, number 59
+# group: [pedro]
+
+statement ok
+CREATE TABLE t0 (c0 BLOB PRIMARY KEY);
+
+statement error
+INSERT INTO t0(c0) VALUES (BLOB '\x00a'), (BLOB '');
+----
+Not implemented Error: Indexes cannot contain BLOBs that contain null-terminated bytes.

--- a/test/fuzzer/pedro/buffer_manager_resize_issue.test
+++ b/test/fuzzer/pedro/buffer_manager_resize_issue.test
@@ -1,0 +1,35 @@
+# name: test/fuzzer/pedro/buffer_manager_resize_issue.test
+# description: Issue #5984, number 49
+# group: [pedro]
+
+statement ok
+CREATE TABLE t1 (c1 INT, c0 INT);
+
+statement ok
+CREATE TABLE t2 (c1 INT, c0 INT);
+
+statement ok
+START TRANSACTION;
+
+statement ok
+CREATE INDEX i1 ON t2 (c1);
+
+statement error
+CREATE INDEX i1 ON t1 (c0);
+----
+Catalog Error: Index with name "i1" already exists!
+
+# actually a ROLLBACK, because we threw an exception in the transaction
+statement ok
+COMMIT;
+
+statement ok
+CREATE UNIQUE INDEX i1 ON t2 (c1);
+
+statement ok
+INSERT INTO t2(c1,c0) VALUES (235,36),(43,81),(246,187),(28,149),(206,20),(135,11),(170,205),(202,63),(69,78),(160,50),(6,34),(207,28);
+
+statement error
+INSERT INTO t2(c1,c0) VALUES (86,98),(96,107),(237,190),(253,242),(229,9),(6,147);
+----
+TransactionContext Error: Failed to commit: Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicated key

--- a/test/fuzzer/pedro/pushdown_error.test
+++ b/test/fuzzer/pedro/pushdown_error.test
@@ -1,0 +1,36 @@
+# name: test/fuzzer/pedro/pushdown_error.test
+# description: WAL cannot alter table
+# group: [pedro]
+
+# fuzzer
+
+statement ok
+PRAGMA enable_verification
+
+load __TEST_DIR__/wal_crash.db
+
+statement ok
+CREATE TABLE t2(c1 INT);
+
+statement ok
+CREATE INDEX i0 ON t2(c1);
+
+statement ok
+CHECKPOINT;
+
+statement ok
+SET wal_autocheckpoint='1TB';
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+DROP INDEX i0;
+
+statement ok
+ALTER TABLE t2 ALTER c1 SET DEFAULT 0;
+
+restart
+
+query I
+SELECT * FROM t2;

--- a/test/sql/index/art/test_art_fuzzer_issues.test
+++ b/test/sql/index/art/test_art_fuzzer_issues.test
@@ -30,7 +30,10 @@ CREATE INDEX i2 ON t2 (c1);
 statement error
 INSERT INTO t2 VALUES (decode('g\x00'::BLOB)::VARCHAR),('g');
 ----
-TransactionContext Error: Failed to commit: Not implemented Error: Indexes cannot have contain null-terminated decoded BLOBs.
+TransactionContext Error: Failed to commit: Not implemented Error: Indexes cannot contain BLOBs that contain null-terminated bytes.
+
+statement ok
+INSERT INTO t2 VALUES ('\0');
 
 statement ok
 CREATE INDEX i22 ON t2 (c1);
@@ -89,7 +92,7 @@ CREATE INDEX i21 ON t21 (c1, "decode"('\x00'::BLOB));
 statement error
 INSERT INTO t21 VALUES (1);
 ----
-TransactionContext Error: Failed to commit: Not implemented Error: Indexes cannot have contain null-terminated decoded BLOBs.
+TransactionContext Error: Failed to commit: Not implemented Error: Indexes cannot contain BLOBs that contain null-terminated bytes.
 
 statement error
 CREATE INDEX i21 ON t21 (c1);

--- a/test/sql/index/art/test_art_import_export.test
+++ b/test/sql/index/art/test_art_import_export.test
@@ -1,0 +1,36 @@
+# name: test/sql/index/art/test_art_import_export.test
+# description: Test that the index is correctly exported and imported
+# group: [art]
+
+# issue 4126
+
+load __TEST_DIR__/test_art_export.db
+
+statement ok
+CREATE TABLE raw(
+    "year" SMALLINT,
+    "month" TINYINT,
+    "day" TINYINT,
+    "customer_ID" BIGINT
+);
+
+statement ok
+INSERT INTO raw VALUES (1, 1, 1, 1);
+
+statement ok
+CREATE UNIQUE INDEX customer_year_month_idx ON raw (customer_ID, year, month);
+
+restart
+
+statement ok
+EXPORT DATABASE '__TEST_DIR__/export_index_db' (FORMAT CSV)
+
+load __TEST_DIR__/test_art_import.db
+
+statement ok
+IMPORT DATABASE '__TEST_DIR__/export_index_db'
+
+statement error
+INSERT INTO raw VALUES (1, 1, 1, 1);
+----
+TransactionContext Error: Failed to commit: Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicated key

--- a/test/sql/index/test_art_keys.cpp
+++ b/test/sql/index/test_art_keys.cpp
@@ -47,8 +47,9 @@ static void TestKeys(vector<Key> &keys) {
 
 static Key CreateCompoundKey(ArenaAllocator &arena_allocator, string str_val, int32_t int_val) {
 
-	auto key_left = Key::CreateKey<string_t>(arena_allocator, string_t(str_val.c_str(), str_val.size()));
-	auto key_right = Key::CreateKey<int32_t>(arena_allocator, int_val);
+	auto key_left =
+	    Key::CreateKey<string_t>(arena_allocator, LogicalType::VARCHAR, string_t(str_val.c_str(), str_val.size()));
+	auto key_right = Key::CreateKey<int32_t>(arena_allocator, LogicalType::VARCHAR, int_val);
 
 	auto data = arena_allocator.Allocate(key_left.len + key_right.len);
 	memcpy(data, key_left.data, key_left.len);
@@ -62,124 +63,124 @@ TEST_CASE("Test correct functioning of art keys", "[art]") {
 
 	// Test tiny int
 	vector<Key> keys;
-	keys.push_back(Key::CreateKey<int8_t>(arena_allocator, -127));
-	keys.push_back(Key::CreateKey<int8_t>(arena_allocator, -55));
-	keys.push_back(Key::CreateKey<int8_t>(arena_allocator, -1));
-	keys.push_back(Key::CreateKey<int8_t>(arena_allocator, 0));
-	keys.push_back(Key::CreateKey<int8_t>(arena_allocator, 1));
-	keys.push_back(Key::CreateKey<int8_t>(arena_allocator, 55));
-	keys.push_back(Key::CreateKey<int8_t>(arena_allocator, 127));
+	keys.push_back(Key::CreateKey<int8_t>(arena_allocator, LogicalType::TINYINT, -127));
+	keys.push_back(Key::CreateKey<int8_t>(arena_allocator, LogicalType::TINYINT, -55));
+	keys.push_back(Key::CreateKey<int8_t>(arena_allocator, LogicalType::TINYINT, -1));
+	keys.push_back(Key::CreateKey<int8_t>(arena_allocator, LogicalType::TINYINT, 0));
+	keys.push_back(Key::CreateKey<int8_t>(arena_allocator, LogicalType::TINYINT, 1));
+	keys.push_back(Key::CreateKey<int8_t>(arena_allocator, LogicalType::TINYINT, 55));
+	keys.push_back(Key::CreateKey<int8_t>(arena_allocator, LogicalType::TINYINT, 127));
 	TestKeys(keys);
 
 	keys.clear();
 
 	// Test small int
-	keys.push_back(Key::CreateKey<int16_t>(arena_allocator, -32767));
-	keys.push_back(Key::CreateKey<int16_t>(arena_allocator, -127));
-	keys.push_back(Key::CreateKey<int16_t>(arena_allocator, -55));
-	keys.push_back(Key::CreateKey<int16_t>(arena_allocator, -1));
-	keys.push_back(Key::CreateKey<int16_t>(arena_allocator, 0));
-	keys.push_back(Key::CreateKey<int16_t>(arena_allocator, 1));
-	keys.push_back(Key::CreateKey<int16_t>(arena_allocator, 55));
-	keys.push_back(Key::CreateKey<int16_t>(arena_allocator, 127));
-	keys.push_back(Key::CreateKey<int16_t>(arena_allocator, 32767));
+	keys.push_back(Key::CreateKey<int16_t>(arena_allocator, LogicalType::SMALLINT, -32767));
+	keys.push_back(Key::CreateKey<int16_t>(arena_allocator, LogicalType::SMALLINT, -127));
+	keys.push_back(Key::CreateKey<int16_t>(arena_allocator, LogicalType::SMALLINT, -55));
+	keys.push_back(Key::CreateKey<int16_t>(arena_allocator, LogicalType::SMALLINT, -1));
+	keys.push_back(Key::CreateKey<int16_t>(arena_allocator, LogicalType::SMALLINT, 0));
+	keys.push_back(Key::CreateKey<int16_t>(arena_allocator, LogicalType::SMALLINT, 1));
+	keys.push_back(Key::CreateKey<int16_t>(arena_allocator, LogicalType::SMALLINT, 55));
+	keys.push_back(Key::CreateKey<int16_t>(arena_allocator, LogicalType::SMALLINT, 127));
+	keys.push_back(Key::CreateKey<int16_t>(arena_allocator, LogicalType::SMALLINT, 32767));
 	TestKeys(keys);
 
 	keys.clear();
 
 	// Test int
-	keys.push_back(Key::CreateKey<int32_t>(arena_allocator, -2147483647));
-	keys.push_back(Key::CreateKey<int32_t>(arena_allocator, -8388608));
-	keys.push_back(Key::CreateKey<int32_t>(arena_allocator, -32767));
-	keys.push_back(Key::CreateKey<int32_t>(arena_allocator, -1));
-	keys.push_back(Key::CreateKey<int32_t>(arena_allocator, 0));
-	keys.push_back(Key::CreateKey<int32_t>(arena_allocator, 1));
-	keys.push_back(Key::CreateKey<int32_t>(arena_allocator, 32767));
-	keys.push_back(Key::CreateKey<int32_t>(arena_allocator, 8388608));
-	keys.push_back(Key::CreateKey<int32_t>(arena_allocator, 2147483647));
+	keys.push_back(Key::CreateKey<int32_t>(arena_allocator, LogicalType::INTEGER, -2147483647));
+	keys.push_back(Key::CreateKey<int32_t>(arena_allocator, LogicalType::INTEGER, -8388608));
+	keys.push_back(Key::CreateKey<int32_t>(arena_allocator, LogicalType::INTEGER, -32767));
+	keys.push_back(Key::CreateKey<int32_t>(arena_allocator, LogicalType::INTEGER, -1));
+	keys.push_back(Key::CreateKey<int32_t>(arena_allocator, LogicalType::INTEGER, 0));
+	keys.push_back(Key::CreateKey<int32_t>(arena_allocator, LogicalType::INTEGER, 1));
+	keys.push_back(Key::CreateKey<int32_t>(arena_allocator, LogicalType::INTEGER, 32767));
+	keys.push_back(Key::CreateKey<int32_t>(arena_allocator, LogicalType::INTEGER, 8388608));
+	keys.push_back(Key::CreateKey<int32_t>(arena_allocator, LogicalType::INTEGER, 2147483647));
 	TestKeys(keys);
 
 	keys.clear();
 
 	// Test big int
-	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, -9223372036854775807));
-	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, -72057594037927936));
-	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, -281474976710656));
-	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, -1099511627776));
-	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, -2147483647));
-	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, -8388608));
-	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, -32767));
-	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, -1));
-	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, 0));
-	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, 1));
-	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, 32767));
-	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, 8388608));
-	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, 2147483647));
-	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, 1099511627776));
-	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, 281474976710656));
-	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, 72057594037927936));
-	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, 9223372036854775807));
+	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, LogicalType::BIGINT, -9223372036854775807));
+	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, LogicalType::BIGINT, -72057594037927936));
+	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, LogicalType::BIGINT, -281474976710656));
+	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, LogicalType::BIGINT, -1099511627776));
+	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, LogicalType::BIGINT, -2147483647));
+	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, LogicalType::BIGINT, -8388608));
+	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, LogicalType::BIGINT, -32767));
+	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, LogicalType::BIGINT, -1));
+	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, LogicalType::BIGINT, 0));
+	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, LogicalType::BIGINT, 1));
+	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, LogicalType::BIGINT, 32767));
+	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, LogicalType::BIGINT, 8388608));
+	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, LogicalType::BIGINT, 2147483647));
+	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, LogicalType::BIGINT, 1099511627776));
+	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, LogicalType::BIGINT, 281474976710656));
+	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, LogicalType::BIGINT, 72057594037927936));
+	keys.push_back(Key::CreateKey<int64_t>(arena_allocator, LogicalType::BIGINT, 9223372036854775807));
 	TestKeys(keys);
 
 	keys.clear();
 
 	// Test utiny int
-	keys.push_back(Key::CreateKey<uint8_t>(arena_allocator, 0));
-	keys.push_back(Key::CreateKey<uint8_t>(arena_allocator, 1));
-	keys.push_back(Key::CreateKey<uint8_t>(arena_allocator, 55));
-	keys.push_back(Key::CreateKey<uint8_t>(arena_allocator, 127));
-	keys.push_back(Key::CreateKey<uint8_t>(arena_allocator, 200));
-	keys.push_back(Key::CreateKey<uint8_t>(arena_allocator, 250));
+	keys.push_back(Key::CreateKey<uint8_t>(arena_allocator, LogicalType::UTINYINT, 0));
+	keys.push_back(Key::CreateKey<uint8_t>(arena_allocator, LogicalType::UTINYINT, 1));
+	keys.push_back(Key::CreateKey<uint8_t>(arena_allocator, LogicalType::UTINYINT, 55));
+	keys.push_back(Key::CreateKey<uint8_t>(arena_allocator, LogicalType::UTINYINT, 127));
+	keys.push_back(Key::CreateKey<uint8_t>(arena_allocator, LogicalType::UTINYINT, 200));
+	keys.push_back(Key::CreateKey<uint8_t>(arena_allocator, LogicalType::UTINYINT, 250));
 	TestKeys(keys);
 
 	keys.clear();
 
-	// Test small int
-	keys.push_back(Key::CreateKey<uint16_t>(arena_allocator, 0));
-	keys.push_back(Key::CreateKey<uint16_t>(arena_allocator, 1));
-	keys.push_back(Key::CreateKey<uint16_t>(arena_allocator, 55));
-	keys.push_back(Key::CreateKey<uint16_t>(arena_allocator, 127));
-	keys.push_back(Key::CreateKey<uint16_t>(arena_allocator, 32767));
-	keys.push_back(Key::CreateKey<uint16_t>(arena_allocator, 40000));
-	keys.push_back(Key::CreateKey<uint16_t>(arena_allocator, 60000));
+	// Test usmall int
+	keys.push_back(Key::CreateKey<uint16_t>(arena_allocator, LogicalType::USMALLINT, 0));
+	keys.push_back(Key::CreateKey<uint16_t>(arena_allocator, LogicalType::USMALLINT, 1));
+	keys.push_back(Key::CreateKey<uint16_t>(arena_allocator, LogicalType::USMALLINT, 55));
+	keys.push_back(Key::CreateKey<uint16_t>(arena_allocator, LogicalType::USMALLINT, 127));
+	keys.push_back(Key::CreateKey<uint16_t>(arena_allocator, LogicalType::USMALLINT, 32767));
+	keys.push_back(Key::CreateKey<uint16_t>(arena_allocator, LogicalType::USMALLINT, 40000));
+	keys.push_back(Key::CreateKey<uint16_t>(arena_allocator, LogicalType::USMALLINT, 60000));
 
 	TestKeys(keys);
 
 	keys.clear();
 
-	// Test int
-	keys.push_back(Key::CreateKey<uint32_t>(arena_allocator, 0));
-	keys.push_back(Key::CreateKey<uint32_t>(arena_allocator, 1));
-	keys.push_back(Key::CreateKey<uint32_t>(arena_allocator, 32767));
-	keys.push_back(Key::CreateKey<uint32_t>(arena_allocator, 8388608));
-	keys.push_back(Key::CreateKey<uint32_t>(arena_allocator, 2147483647));
-	keys.push_back(Key::CreateKey<uint32_t>(arena_allocator, 3047483647));
-	keys.push_back(Key::CreateKey<uint32_t>(arena_allocator, 4047483647));
+	// Test uint
+	keys.push_back(Key::CreateKey<uint32_t>(arena_allocator, LogicalType::UINTEGER, 0));
+	keys.push_back(Key::CreateKey<uint32_t>(arena_allocator, LogicalType::UINTEGER, 1));
+	keys.push_back(Key::CreateKey<uint32_t>(arena_allocator, LogicalType::UINTEGER, 32767));
+	keys.push_back(Key::CreateKey<uint32_t>(arena_allocator, LogicalType::UINTEGER, 8388608));
+	keys.push_back(Key::CreateKey<uint32_t>(arena_allocator, LogicalType::UINTEGER, 2147483647));
+	keys.push_back(Key::CreateKey<uint32_t>(arena_allocator, LogicalType::UINTEGER, 3047483647));
+	keys.push_back(Key::CreateKey<uint32_t>(arena_allocator, LogicalType::UINTEGER, 4047483647));
 	TestKeys(keys);
 
 	keys.clear();
 
-	// Test big int
-	keys.push_back(Key::CreateKey<uint64_t>(arena_allocator, 0));
-	keys.push_back(Key::CreateKey<uint64_t>(arena_allocator, 1));
-	keys.push_back(Key::CreateKey<uint64_t>(arena_allocator, 32767));
-	keys.push_back(Key::CreateKey<uint64_t>(arena_allocator, 8388608));
-	keys.push_back(Key::CreateKey<uint64_t>(arena_allocator, 2147483647));
-	keys.push_back(Key::CreateKey<uint64_t>(arena_allocator, 1099511627776));
-	keys.push_back(Key::CreateKey<uint64_t>(arena_allocator, 281474976710656));
-	keys.push_back(Key::CreateKey<uint64_t>(arena_allocator, 72057594037927936));
+	// Test ubig int
+	keys.push_back(Key::CreateKey<uint64_t>(arena_allocator, LogicalType::UBIGINT, 0));
+	keys.push_back(Key::CreateKey<uint64_t>(arena_allocator, LogicalType::UBIGINT, 1));
+	keys.push_back(Key::CreateKey<uint64_t>(arena_allocator, LogicalType::UBIGINT, 32767));
+	keys.push_back(Key::CreateKey<uint64_t>(arena_allocator, LogicalType::UBIGINT, 8388608));
+	keys.push_back(Key::CreateKey<uint64_t>(arena_allocator, LogicalType::UBIGINT, 2147483647));
+	keys.push_back(Key::CreateKey<uint64_t>(arena_allocator, LogicalType::UBIGINT, 1099511627776));
+	keys.push_back(Key::CreateKey<uint64_t>(arena_allocator, LogicalType::UBIGINT, 281474976710656));
+	keys.push_back(Key::CreateKey<uint64_t>(arena_allocator, LogicalType::UBIGINT, 72057594037927936));
 	TestKeys(keys);
 
 	keys.clear();
 
 	// Test strings
-	keys.push_back(Key::CreateKey<const char *>(arena_allocator, "abc"));
-	keys.push_back(Key::CreateKey<const char *>(arena_allocator, "babababa"));
-	keys.push_back(Key::CreateKey<const char *>(arena_allocator, "hello"));
-	keys.push_back(Key::CreateKey<const char *>(arena_allocator, "hellow"));
-	keys.push_back(Key::CreateKey<const char *>(arena_allocator, "torororororo"));
-	keys.push_back(Key::CreateKey<const char *>(arena_allocator, "torororororp"));
-	keys.push_back(Key::CreateKey<const char *>(arena_allocator, "z"));
+	keys.push_back(Key::CreateKey<const char *>(arena_allocator, LogicalType::VARCHAR, "abc"));
+	keys.push_back(Key::CreateKey<const char *>(arena_allocator, LogicalType::VARCHAR, "babababa"));
+	keys.push_back(Key::CreateKey<const char *>(arena_allocator, LogicalType::VARCHAR, "hello"));
+	keys.push_back(Key::CreateKey<const char *>(arena_allocator, LogicalType::VARCHAR, "hellow"));
+	keys.push_back(Key::CreateKey<const char *>(arena_allocator, LogicalType::VARCHAR, "torororororo"));
+	keys.push_back(Key::CreateKey<const char *>(arena_allocator, LogicalType::VARCHAR, "torororororp"));
+	keys.push_back(Key::CreateKey<const char *>(arena_allocator, LogicalType::VARCHAR, "z"));
 
 	TestKeys(keys);
 
@@ -200,10 +201,10 @@ TEST_CASE("Test correct functioning of art keys", "[art]") {
 
 	keys.clear();
 
-	keys.push_back(Key::CreateKey<double>(arena_allocator, 0));
-	keys.push_back(Key::CreateKey<double>(arena_allocator, 0.1));
-	keys.push_back(Key::CreateKey<double>(arena_allocator, 488566));
-	keys.push_back(Key::CreateKey<double>(arena_allocator, 1163404482));
+	keys.push_back(Key::CreateKey<double>(arena_allocator, LogicalType::DOUBLE, 0));
+	keys.push_back(Key::CreateKey<double>(arena_allocator, LogicalType::DOUBLE, 0.1));
+	keys.push_back(Key::CreateKey<double>(arena_allocator, LogicalType::DOUBLE, 488566));
+	keys.push_back(Key::CreateKey<double>(arena_allocator, LogicalType::DOUBLE, 1163404482));
 
 	TestKeys(keys);
 

--- a/test/sql/storage/null_byte_storage.test
+++ b/test/sql/storage/null_byte_storage.test
@@ -27,8 +27,10 @@ SELECT * FROM null_byte WHERE v=concat('goo', chr(0), 42)
 goo\042
 
 # null byte in index
-statement ok
+statement error
 CREATE INDEX i_index ON null_byte(v)
+----
+Not implemented Error: Indexes cannot contain BLOBs that contain null-terminated bytes.
 
 query I
 SELECT * FROM null_byte WHERE v=concat('goo', chr(0), 42)

--- a/test/sql/storage/test_unique_index_checkpoint.test
+++ b/test/sql/storage/test_unique_index_checkpoint.test
@@ -1,0 +1,41 @@
+# name: test/sql/storage/test_unique_index_checkpoint.test
+# description: Verify that unique indexes are correctly checkpointed
+# group: [storage]
+
+# issue #6214
+
+load __TEST_DIR__/test_unique_index.db
+
+statement ok
+CREATE TABLE test(i INTEGER, j INTEGER);
+
+statement ok
+INSERT INTO test VALUES (1,100),(2,200);
+
+statement ok
+CREATE UNIQUE INDEX idx ON test (i);
+
+restart
+
+statement error
+INSERT INTO test VALUES (1,101),(2,201);
+----
+TransactionContext Error: Failed to commit: Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicated key
+
+restart
+
+statement ok
+CREATE TABLE IF NOT EXISTS unique_index_test AS
+SELECT i AS ordernumber, j AS quantity FROM test;
+
+restart
+
+statement ok
+CREATE UNIQUE INDEX unique_index_test_ordernumber_idx_unique ON unique_index_test (ordernumber);
+
+restart
+
+statement error
+INSERT INTO unique_index_test VALUES (1,101),(2,201);
+----
+TransactionContext Error: Failed to commit: Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicated key

--- a/test/sql/storage/wal/wal_create_index.test
+++ b/test/sql/storage/wal/wal_create_index.test
@@ -1,0 +1,170 @@
+# name: test/sql/storage/wal/wal_create_index.test
+# description: Test serialization of index to WAL
+# group: [wal]
+
+# load the DB from disk
+load __TEST_DIR__/test_wal_create_index.db
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
+statement ok
+CREATE TABLE integers(i INTEGER, j INTEGER);
+
+statement ok
+INSERT INTO integers VALUES (1,1), (2,2), (3,3);
+
+# Test single column
+statement ok
+CREATE UNIQUE INDEX i_index ON integers(i);
+
+query II
+EXPLAIN SELECT i FROM integers WHERE i = 1
+----
+logical_opt	<REGEX>:.*INDEX_SCAN.*
+
+restart
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+query II
+EXPLAIN SELECT i FROM integers WHERE i = 1
+----
+logical_opt	<REGEX>:.*INDEX_SCAN.*
+
+statement error
+INSERT INTO integers VALUES (1, 1);
+----
+TransactionContext Error: Failed to commit: Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicated key
+
+restart
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+statement ok
+DROP INDEX i_index;
+
+restart
+
+# test more complex expressions
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+statement ok
+CREATE UNIQUE INDEX i_index ON integers USING art((i + j));
+
+query II
+EXPLAIN SELECT i FROM integers WHERE i + j = 2;
+----
+logical_opt	<REGEX>:.*INDEX_SCAN.*
+
+restart
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+query II
+EXPLAIN SELECT i FROM integers WHERE i + j = 2;
+----
+logical_opt	<REGEX>:.*INDEX_SCAN.*
+
+query I
+SELECT i FROM integers WHERE i + j = 2
+----
+1
+
+statement error
+INSERT INTO integers VALUES (1, 1);
+----
+TransactionContext Error: Failed to commit: Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicated key
+
+statement ok
+DROP INDEX i_index;
+
+restart
+
+# change the order of the columns in the index expressions
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+statement ok
+CREATE UNIQUE INDEX i_index ON integers USING art((j + i));
+
+query II
+EXPLAIN SELECT i FROM integers WHERE j + i = 2;
+----
+logical_opt	<REGEX>:.*INDEX_SCAN.*
+
+restart
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+query II
+EXPLAIN SELECT i FROM integers WHERE j + i = 2;
+----
+logical_opt	<REGEX>:.*INDEX_SCAN.*
+
+query I
+SELECT i FROM integers WHERE j + i = 2
+----
+1
+
+statement error
+INSERT INTO integers VALUES (1, 1);
+----
+TransactionContext Error: Failed to commit: Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicated key
+
+statement ok
+DROP INDEX i_index;
+
+restart
+
+# compound keys
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+statement ok
+CREATE UNIQUE INDEX i_index ON integers USING art((j + i), j, i);
+
+restart
+
+statement error
+INSERT INTO integers VALUES (1, 1);
+----
+TransactionContext Error: Failed to commit: Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicated key
+
+statement ok
+DROP INDEX i_index;


### PR DESCRIPTION
This PR adds serializing the CREATE [UNIQUE] INDEX and DROP INDEXstatements to the WAL. When replaying the WAL and creating the index, it does not use the parallel physical create index operator. Thus, performance might be significantly slower.

It also fixes some memory-tracking bugs causing the ART to no longer persist, even when explicitly using `CHECKPOINT`.

Additionally, it addresses two fuzzer issues, one dealing with null-bytes. I added code to throw an exception when encountering null-bytes, so for now, indexes don't work for these cases.