### PR TITLE
Enables sqlite3_wrapper tests for windows

### DIFF
--- a/tools/sqlite3_api_wrapper/CMakeLists.txt
+++ b/tools/sqlite3_api_wrapper/CMakeLists.txt
@@ -21,12 +21,17 @@ if(NOT WIN32)
   add_library(sqlite3_api_wrapper SHARED ${SQLITE_API_WRAPPER_FILES})
   target_link_libraries(sqlite3_api_wrapper duckdb ${DUCKDB_EXTRA_LINK_FLAGS})
   link_threads(sqlite3_api_wrapper)
+endif()
 
-  include_directories(../../third_party/catch)
+include_directories(../../third_party/catch)
 
-  include_directories(test/include)
-  add_subdirectory(test)
+include_directories(test/include)
+add_subdirectory(test)
 
-  add_executable(test_sqlite3_api_wrapper ${SQLITE_TEST_FILES})
+add_executable(test_sqlite3_api_wrapper ${SQLITE_TEST_FILES})
+if(WIN32)
+  target_link_libraries(test_sqlite3_api_wrapper sqlite3_api_wrapper_static)
+else()
   target_link_libraries(test_sqlite3_api_wrapper sqlite3_api_wrapper)
 endif()
+

--- a/tools/sqlite3_api_wrapper/CMakeLists.txt
+++ b/tools/sqlite3_api_wrapper/CMakeLists.txt
@@ -34,4 +34,3 @@ if(WIN32)
 else()
   target_link_libraries(test_sqlite3_api_wrapper sqlite3_api_wrapper)
 endif()
-


### PR DESCRIPTION
This PR enables the sqlite3_wrapper tests for windows.

I think the build pipeline does not execute this test under windows, but it is useful for local development under windows.