### PR TITLE
Write struct fields as optionally quoted in EXPORT DATABASE

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -424,7 +424,8 @@ string LogicalType::ToString() const {
 		auto &child_types = StructType::GetChildTypes(*this);
 		string ret = "STRUCT(";
 		for (size_t i = 0; i < child_types.size(); i++) {
-			ret += child_types[i].first + " " + child_types[i].second.ToString();
+			ret += KeywordHelper::WriteOptionallyQuoted(child_types[i].first) + " " +
+			       KeywordHelper::WriteOptionallyQuoted(child_types[i].second.ToString());
 			if (i < child_types.size() - 1) {
 				ret += ", ";
 			}

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -424,8 +424,7 @@ string LogicalType::ToString() const {
 		auto &child_types = StructType::GetChildTypes(*this);
 		string ret = "STRUCT(";
 		for (size_t i = 0; i < child_types.size(); i++) {
-			ret += KeywordHelper::WriteOptionallyQuoted(child_types[i].first) + " " +
-			       KeywordHelper::WriteOptionallyQuoted(child_types[i].second.ToString());
+			ret += KeywordHelper::WriteOptionallyQuoted(child_types[i].first) + " " + child_types[i].second.ToString();
 			if (i < child_types.size() - 1) {
 				ret += ", ";
 			}

--- a/test/sql/export/export_quoted_structs.test
+++ b/test/sql/export/export_quoted_structs.test
@@ -1,0 +1,57 @@
+# name: test/sql/export/export_quoted_structs.test
+# description: Test export database
+# group: [export]
+
+# create a bunch of tables with data and views
+
+statement ok
+BEGIN TRANSACTION
+
+# 'end' is a keyword, this has to be quoted
+statement ok
+create table a (s STRUCT("end" VARCHAR));
+
+statement ok
+insert into a values ({'a':'hello'});
+
+query I
+select * from a
+----
+{'end': hello}
+
+## -- We don't support exporting user defined types yet -- ##
+#statement ok
+#create type "table" as varchar;
+
+## The type of the struct field can also be a user-defined type, which might need quotes
+#statement ok
+#create table b (s STRUCT(f1 "table"));
+
+#statement ok
+#insert into b values ({'a':'hello'});
+
+#query I
+#select * from b;
+#----
+#{'f1': hello}
+
+# now export the db
+statement ok
+EXPORT DATABASE '__TEST_DIR__/export_test' (FORMAT CSV)
+
+statement ok
+ROLLBACK
+
+statement ok
+IMPORT DATABASE '__TEST_DIR__/export_test'
+
+# Verify that the import was succesful
+query I
+select * from a
+----
+{'end': hello}
+
+#query I
+#select * from b;
+#----
+#{'f1': hello}


### PR DESCRIPTION
This PR fixes #6410 

I have also added optionally quoting for the type part of the struct field, because I figured we could potentially have a user-defined type there.
But when testing I discovered we don't support exporting user-defined types yet, so I had to comment this test out.
Figured it was worth it to keep the quoting in there though, in case we do add exporting of user-defined types in the future.