### PR TITLE
Fix #6420 - correctly delete temporary files that are not explicitly read back but just dropped

### DIFF
--- a/src/function/table/system/CMakeLists.txt
+++ b/src/function/table/system/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library_unity(
   duckdb_sequences.cpp
   duckdb_settings.cpp
   duckdb_tables.cpp
+  duckdb_temporary_files.cpp
   duckdb_types.cpp
   duckdb_views.cpp
   pragma_collations.cpp

--- a/src/function/table/system/duckdb_temporary_files.cpp
+++ b/src/function/table/system/duckdb_temporary_files.cpp
@@ -1,0 +1,59 @@
+#include "duckdb/function/table/system_functions.hpp"
+#include "duckdb/storage/buffer_manager.hpp"
+
+namespace duckdb {
+
+struct DuckDBTemporaryFilesData : public GlobalTableFunctionState {
+	DuckDBTemporaryFilesData() : offset(0) {
+	}
+
+	vector<TemporaryFileInformation> entries;
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> DuckDBTemporaryFilesBind(ClientContext &context, TableFunctionBindInput &input,
+                                                         vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("path");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("size");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> DuckDBTemporaryFilesInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_unique<DuckDBTemporaryFilesData>();
+
+	result->entries = BufferManager::GetBufferManager(context).GetTemporaryFiles();
+	return std::move(result);
+}
+
+void DuckDBTemporaryFilesFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (DuckDBTemporaryFilesData &)*data_p.global_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.entries[data.offset++];
+		// return values:
+		idx_t col = 0;
+		// database_name, VARCHAR
+		output.SetValue(col++, count, entry.path);
+		// database_oid, BIGINT
+		output.SetValue(col++, count, Value::BIGINT(entry.size));
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void DuckDBTemporaryFilesFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("duckdb_temporary_files", {}, DuckDBTemporaryFilesFunction, DuckDBTemporaryFilesBind,
+	                              DuckDBTemporaryFilesInit));
+}
+
+} // namespace duckdb

--- a/src/function/table/system_functions.cpp
+++ b/src/function/table/system_functions.cpp
@@ -29,6 +29,7 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 	DuckDBSequencesFun::RegisterFunction(*this);
 	DuckDBSettingsFun::RegisterFunction(*this);
 	DuckDBTablesFun::RegisterFunction(*this);
+	DuckDBTemporaryFilesFun::RegisterFunction(*this);
 	DuckDBTypesFun::RegisterFunction(*this);
 	DuckDBViewsFun::RegisterFunction(*this);
 	TestAllTypesFun::RegisterFunction(*this);

--- a/src/include/duckdb/function/table/system_functions.hpp
+++ b/src/include/duckdb/function/table/system_functions.hpp
@@ -89,6 +89,10 @@ struct DuckDBTablesFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct DuckDBTemporaryFilesFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct DuckDBTypesFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/src/include/duckdb/storage/buffer_manager.hpp
+++ b/src/include/duckdb/storage/buffer_manager.hpp
@@ -23,6 +23,11 @@ class DatabaseInstance;
 class TemporaryDirectoryHandle;
 struct EvictionQueue;
 
+struct TemporaryFileInformation {
+	string path;
+	idx_t size;
+};
+
 //! The buffer manager is in charge of handling memory management for the database. It hands out memory buffers that can
 //! be used by the database internally.
 //
@@ -97,6 +102,9 @@ public:
 
 	DUCKDB_API void ReserveMemory(idx_t size);
 	DUCKDB_API void FreeReservedMemory(idx_t size);
+
+	//! Returns a list of all temporary files
+	vector<TemporaryFileInformation> GetTemporaryFiles();
 
 private:
 	//! Register an in-memory buffer of arbitrary size, as long as it is >= BLOCK_SIZE. can_destroy signifies whether or

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -521,11 +521,8 @@ void BufferManager::PurgeQueue() {
 
 void BlockManager::UnregisterBlock(block_id_t block_id, bool can_destroy) {
 	if (block_id >= MAXIMUM_BLOCK) {
-		// in-memory buffer: destroy the buffer
-		if (!can_destroy) {
-			// buffer could have been offloaded to disk: remove the file
-			buffer_manager.DeleteTemporaryFile(block_id);
-		}
+		// in-memory buffer: buffer could have been offloaded to disk: remove the file
+		buffer_manager.DeleteTemporaryFile(block_id);
 	} else {
 		lock_guard<mutex> lock(blocks_lock);
 		// on-disk block: erase from list of blocks in manager

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -607,7 +607,11 @@ public:
 	//! Returns true if the max_index has been altered
 	bool RemoveIndex(idx_t index) {
 		// remove this block from the set of blocks
-		indexes_in_use.erase(index);
+		auto entry = indexes_in_use.find(index);
+		if (entry == indexes_in_use.end()) {
+			throw InternalException("RemoveIndex - index %llu not found in indexes_in_use", index);
+		}
+		indexes_in_use.erase(entry);
 		free_indexes.insert(index);
 		// check if we can truncate the file
 
@@ -616,7 +620,7 @@ public:
 		if (max_index_in_use < max_index) {
 			// max index in use is lower than the max_index
 			// reduce the max_index
-			max_index = max_index_in_use + 1;
+			max_index = indexes_in_use.empty() ? 0 : max_index_in_use + 1;
 			// we can remove any free_indexes that are larger than the current max_index
 			while (!free_indexes.empty()) {
 				auto max_entry = *free_indexes.rbegin();
@@ -692,16 +696,15 @@ public:
 
 	unique_ptr<FileBuffer> ReadTemporaryBuffer(block_id_t id, idx_t block_index,
 	                                           unique_ptr<FileBuffer> reusable_buffer) {
-		auto buffer =
-		    ReadTemporaryBufferInternal(BufferManager::GetBufferManager(db), *handle, GetPositionInFile(block_index),
-		                                Storage::BLOCK_SIZE, id, std::move(reusable_buffer));
-		{
-			// remove the block (and potentially truncate the temp file)
-			TemporaryFileLock lock(file_lock);
-			D_ASSERT(handle);
-			RemoveTempBlockIndex(lock, block_index);
-		}
-		return buffer;
+		return ReadTemporaryBufferInternal(BufferManager::GetBufferManager(db), *handle, GetPositionInFile(block_index),
+		                                   Storage::BLOCK_SIZE, id, std::move(reusable_buffer));
+	}
+
+	void EraseBlockIndex(block_id_t block_index) {
+		// remove the block (and potentially truncate the temp file)
+		TemporaryFileLock lock(file_lock);
+		D_ASSERT(handle);
+		RemoveTempBlockIndex(lock, block_index);
 	}
 
 	bool DeleteIfEmpty() {
@@ -715,6 +718,14 @@ public:
 		auto &fs = FileSystem::GetFileSystem(db);
 		fs.RemoveFile(path);
 		return true;
+	}
+
+	TemporaryFileInformation GetTemporaryFile() {
+		TemporaryFileLock lock(file_lock);
+		TemporaryFileInformation info;
+		info.path = path;
+		info.size = GetPositionInFile(index_manager.GetMaxIndex());
+		return info;
 	}
 
 private:
@@ -817,7 +828,7 @@ public:
 		{
 			// remove the block (and potentially erase the temp file)
 			TemporaryManagerLock lock(manager_lock);
-			EraseUsedBlock(lock, id, handle, index.file_index);
+			EraseUsedBlock(lock, id, handle, index);
 		}
 		return buffer;
 	}
@@ -826,14 +837,29 @@ public:
 		TemporaryManagerLock lock(manager_lock);
 		auto index = GetTempBlockIndex(lock, id);
 		auto handle = GetFileHandle(lock, index.file_index);
-		EraseUsedBlock(lock, id, handle, index.file_index);
+		EraseUsedBlock(lock, id, handle, index);
+	}
+
+	vector<TemporaryFileInformation> GetTemporaryFiles() {
+		lock_guard<mutex> lock(manager_lock);
+		vector<TemporaryFileInformation> result;
+		for (auto &file : files) {
+			result.push_back(file.second->GetTemporaryFile());
+		}
+		return result;
 	}
 
 private:
-	void EraseUsedBlock(TemporaryManagerLock &lock, block_id_t id, TemporaryFileHandle *handle, idx_t file_index) {
-		used_blocks.erase(id);
+	void EraseUsedBlock(TemporaryManagerLock &lock, block_id_t id, TemporaryFileHandle *handle,
+	                    TemporaryFileIndex index) {
+		auto entry = used_blocks.find(id);
+		if (entry == used_blocks.end()) {
+			throw InternalException("EraseUsedBlock - Block %llu not found in used blocks", id);
+		}
+		used_blocks.erase(entry);
+		handle->EraseBlockIndex(index.block_index);
 		if (handle->DeleteIfEmpty()) {
-			EraseFileHandle(lock, file_index);
+			EraseFileHandle(lock, index.file_index);
 		}
 	}
 
@@ -963,6 +989,35 @@ void BufferManager::DeleteTemporaryFile(block_id_t id) {
 	if (fs.FileExists(path)) {
 		fs.RemoveFile(path);
 	}
+}
+
+vector<TemporaryFileInformation> BufferManager::GetTemporaryFiles() {
+	vector<TemporaryFileInformation> result;
+	if (temp_directory.empty()) {
+		return result;
+	}
+	{
+		lock_guard<mutex> temp_handle_guard(temp_handle_lock);
+		if (temp_directory_handle) {
+			result = temp_directory_handle->GetTempFile().GetTemporaryFiles();
+		}
+	}
+	auto &fs = FileSystem::GetFileSystem(db);
+	fs.ListFiles(temp_directory, [&](const string &name, bool is_dir) {
+		if (is_dir) {
+			return;
+		}
+		if (!StringUtil::EndsWith(name, ".block")) {
+			return;
+		}
+		TemporaryFileInformation info;
+		info.path = name;
+		auto handle = fs.OpenFile(name, FileFlags::FILE_FLAGS_READ);
+		info.size = fs.GetFileSize(*handle);
+		handle.reset();
+		result.push_back(info);
+	});
+	return result;
 }
 
 string BufferManager::InMemoryWarning() {

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -62,7 +62,7 @@ BlockHandle::BlockHandle(BlockManager &block_manager, block_id_t block_id_p, uni
 	memory_charge = std::move(reservation);
 }
 
-BlockHandle::~BlockHandle() {
+BlockHandle::~BlockHandle() { // NOLINT: allow internal exceptions
 	// being destroyed, so any unswizzled pointers are just binary junk now.
 	unswizzled = nullptr;
 	auto &buffer_manager = block_manager.buffer_manager;

--- a/test/sql/outofcore/leftover_temp_files_issue_6420.test_slow
+++ b/test/sql/outofcore/leftover_temp_files_issue_6420.test_slow
@@ -64,6 +64,23 @@ SELECT COUNT(*) > 0 FROM duckdb_temporary_files()
 ----
 false
 
+# performing a large window function
+statement ok
+CREATE OR REPLACE TEMPORARY TABLE ans as select l1.*, row_number() OVER (PARTITION BY l_orderkey, l_linenumber ORDER BY l_orderkey) from lineitem1 l1
+
+query I
+SELECT COUNT(*) > 0 FROM duckdb_temporary_files()
+----
+true
+
+statement ok
+DROP TABLE ans;
+
+query I
+SELECT COUNT(*) > 0 FROM duckdb_temporary_files()
+----
+false
+
 # performing a large hash join should not leave temp files
 statement ok
 CREATE OR REPLACE TEMPORARY TABLE ans as select l1.*, l2.* from lineitem1 l1 JOIN lineitem2 l2 USING (l_orderkey, l_linenumber)

--- a/test/sql/outofcore/leftover_temp_files_issue_6420.test_slow
+++ b/test/sql/outofcore/leftover_temp_files_issue_6420.test_slow
@@ -1,0 +1,82 @@
+# name: test/sql/outofcore/leftover_temp_files_issue_6420.test_slow
+# description: Issue #6420: Large joins in persistent databases have left over temporary directory
+# group: [outofcore]
+
+load __TEST_DIR__/leftover_temp_files.db
+
+require tpch
+
+statement ok
+SET memory_limit='1GB';
+
+statement ok
+CALL dbgen(sf=1);
+
+statement ok
+ALTER TABLE lineitem RENAME TO lineitem1
+
+statement ok
+CREATE TABLE lineitem2 AS FROM lineitem1
+
+# creating and dropping a temp table should not leave temp files
+statement ok
+CREATE OR REPLACE TEMPORARY TABLE ans as select l1.* from lineitem1 l1;
+
+query I
+SELECT COUNT(*) > 0 FROM duckdb_temporary_files()
+----
+true
+
+statement ok
+DROP TABLE ans;
+
+query I
+SELECT COUNT(*) > 0 FROM duckdb_temporary_files()
+----
+false
+
+# creating and dropping a table with an ORDER BY should not leave temp files
+statement ok
+CREATE OR REPLACE TEMPORARY TABLE ans as select l1.*, l1.* from lineitem1 l1 ORDER BY l_orderkey, l_returnflag
+
+query I
+SELECT COUNT(*) > 0 FROM duckdb_temporary_files()
+----
+true
+
+statement ok
+DROP TABLE ans;
+
+query I
+SELECT COUNT(*) > 0 FROM duckdb_temporary_files()
+----
+false
+
+# performing a small hash join should not leave temp files
+statement ok
+CREATE OR REPLACE TEMPORARY TABLE ans as select l1.*, l2.* from lineitem1 l1 JOIN (FROM lineitem2 l2 WHERE l_orderkey<10000) AS l2 USING (l_orderkey, l_linenumber)
+
+statement ok
+DROP TABLE ans;
+
+query I
+SELECT COUNT(*) > 0 FROM duckdb_temporary_files()
+----
+false
+
+# performing a large hash join should not leave temp files
+statement ok
+CREATE OR REPLACE TEMPORARY TABLE ans as select l1.*, l2.* from lineitem1 l1 JOIN lineitem2 l2 USING (l_orderkey, l_linenumber)
+
+query I
+SELECT COUNT(*) > 0 FROM duckdb_temporary_files()
+----
+true
+
+statement ok
+DROP TABLE ans;
+
+query I
+SELECT COUNT(*) > 0 FROM duckdb_temporary_files()
+----
+false


### PR DESCRIPTION
Fixes #6420 

This PR also introduces the `duckdb_temporary_files` function which returns the set of temporary files currently managed by the BufferManager. This is used to test whether or not any temporary files are left behind after performing operations that can off-load to disk with a low memory limit (large joins, creating temp tables, window functions, etc).