### PR TITLE
Enables sqlite3 wrapper tests for win32 builds

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -58,6 +58,7 @@ jobs:
       shell: bash
       run: |
         python tools/shell/shell-test.py Release/duckdb.exe
+        tools/sqlite3_api_wrapper/Release/test_sqlite3_api_wrapper.exe
 
     - name: Deploy
       shell: bash
@@ -116,6 +117,7 @@ jobs:
       shell: bash
       run: |
         python tools/shell/shell-test.py Release/duckdb.exe
+        tools/sqlite3_api_wrapper/Release/test_sqlite3_api_wrapper.exe
 
     - name: Deploy
       shell: bash
@@ -167,6 +169,11 @@ jobs:
          run: |
            cp src/libduckdb.dll .
            test/unittest.exe
+           
+       - name: Tools Test
+         shell: msys2 {0}
+         run: |
+           tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper.exe
 
  odbc-win-64:
     name: ODBC Windows

--- a/tools/sqlite3_api_wrapper/CMakeLists.txt
+++ b/tools/sqlite3_api_wrapper/CMakeLists.txt
@@ -21,12 +21,17 @@ if(NOT WIN32)
   add_library(sqlite3_api_wrapper SHARED ${SQLITE_API_WRAPPER_FILES})
   target_link_libraries(sqlite3_api_wrapper duckdb ${DUCKDB_EXTRA_LINK_FLAGS})
   link_threads(sqlite3_api_wrapper)
+endif()
 
-  include_directories(../../third_party/catch)
+include_directories(../../third_party/catch)
 
-  include_directories(test/include)
-  add_subdirectory(test)
+include_directories(test/include)
+add_subdirectory(test)
 
-  add_executable(test_sqlite3_api_wrapper ${SQLITE_TEST_FILES})
+add_executable(test_sqlite3_api_wrapper ${SQLITE_TEST_FILES})
+if(WIN32)
+  target_link_libraries(test_sqlite3_api_wrapper sqlite3_api_wrapper_static)
+else()
   target_link_libraries(test_sqlite3_api_wrapper sqlite3_api_wrapper)
 endif()
+

--- a/tools/sqlite3_api_wrapper/CMakeLists.txt
+++ b/tools/sqlite3_api_wrapper/CMakeLists.txt
@@ -34,4 +34,3 @@ if(WIN32)
 else()
   target_link_libraries(test_sqlite3_api_wrapper sqlite3_api_wrapper)
 endif()
-


### PR DESCRIPTION
This PR enables the sqlite3 wrapper tests for win32 builds.  

They are also activated in the windows workflow for msvc64, msvc32 and mingw. All tests are executed under "Tools Test". For mingw, I added the "Tools Test" buildstep, so that mingw has the same buildsteps as the msvc builds.