### PR TITLE
Julia: support Pkg.test()

### DIFF
--- a/tools/juliapkg/test/Project.toml
+++ b/tools/juliapkg/test/Project.toml
@@ -1,6 +1,10 @@
 [deps]
 DBInterface = "a10d1c49-ce27-4219-8d33-6db1a4562965"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+FixedPointDecimals = "fb4d412d-6eee-574d-9565-ede6634db7b0"
 SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"

--- a/tools/juliapkg/test/test_sqlite.jl
+++ b/tools/juliapkg/test/test_sqlite.jl
@@ -18,8 +18,9 @@ function setup_clean_test_db(f::Function, args...)
         "track"
     ]
     con = DBInterface.connect(DuckDB.DB)
+    datadir = joinpath(@__DIR__, "../data")
     for table in tables
-        DBInterface.execute(con, "CREATE TABLE $table AS SELECT * FROM 'data/$table.parquet'")
+        DBInterface.execute(con, "CREATE TABLE $table AS SELECT * FROM '$datadir/$table.parquet'")
     end
 
     try

--- a/tools/juliapkg/test/test_tpch.jl
+++ b/tools/juliapkg/test/test_tpch.jl
@@ -7,7 +7,12 @@
 
     # load TPC-H into DuckDB
     native_con = DBInterface.connect(DuckDB.DB)
-    DBInterface.execute(native_con, "CALL dbgen(sf=$sf)")
+    try
+        DBInterface.execute(native_con, "CALL dbgen(sf=$sf)")
+    catch
+        @info "TPC-H extension not available; skipping"
+        return
+    end
 
     # convert all tables to Julia DataFrames
     customer = DataFrame(DBInterface.execute(native_con, "SELECT * FROM customer"))

--- a/tools/juliapkg/test/test_tpch_multithread.jl
+++ b/tools/juliapkg/test/test_tpch_multithread.jl
@@ -7,7 +7,12 @@ function test_tpch_multithread()
 
     # load TPC-H into DuckDB
     native_con = DBInterface.connect(DuckDB.DB)
-    DBInterface.execute(native_con, "CALL dbgen(sf=$sf)")
+    try
+        DBInterface.execute(native_con, "CALL dbgen(sf=$sf)")
+    catch
+        @info "TPC-H extension not available; skipping"
+        return
+    end
 
     # convert all tables to Julia DataFrames
     customer = DataFrame(DBInterface.execute(native_con, "SELECT * FROM customer"))


### PR DESCRIPTION
This change allows the built-in `Pkg.test()` to also run tests successfully, adding deps to the test Project.toml and cleaning up one path assumption.

I've also added some logic to skip the TPC-H tests if not available, which seems to be necessary if developing against the prebuilt `DuckDB_jll` binary.