### PR TITLE
Disable operator cache for pull

### DIFF
--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -252,15 +252,15 @@ OperatorResultType CachingPhysicalOperator::Execute(ExecutionContext &context, D
 	if (!state.initialized) {
 		state.initialized = true;
 		state.can_cache_chunk = true;
+
 		if (!context.pipeline || !caching_supported) {
 			state.can_cache_chunk = false;
-		}
-
-		if (context.pipeline->GetSink() && context.pipeline->GetSink()->RequiresBatchIndex()) {
+		} else if (!context.pipeline->GetSink()) {
+			// Disabling for pipelines without Sink, i.e. when pulling
 			state.can_cache_chunk = false;
-		}
-
-		if (context.pipeline->IsOrderDependent()) {
+		} else if (context.pipeline->GetSink()->RequiresBatchIndex()) {
+			state.can_cache_chunk = false;
+		} else if (context.pipeline->IsOrderDependent()) {
 			state.can_cache_chunk = false;
 		}
 	}

--- a/src/include/duckdb/parallel/pipeline_executor.hpp
+++ b/src/include/duckdb/parallel/pipeline_executor.hpp
@@ -69,13 +69,6 @@ private:
 	//! The final chunk used for moving data into the sink
 	DataChunk final_chunk;
 
-	//! Indicates that the first non-finished operator in the pipeline with RequireFinalExecute has some pending result
-	bool pending_final_execute = false;
-	//! The OperatorFinalizeResultType corresponding to the currently pending final_execute result
-	OperatorFinalizeResultType cached_final_execute_result;
-	//! Source has been exhausted
-	bool source_empty = false;
-
 	//! The operators that are not yet finished executing and have data remaining
 	//! If the stack of in_process_operators is empty, we fetch from the source instead
 	stack<idx_t> in_process_operators;

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -114,52 +114,6 @@ OperatorResultType PipelineExecutor::ExecutePushInternal(DataChunk &input, idx_t
 	}
 }
 
-// Pull a single DataChunk from the pipeline by flushing any operators holding cached output
-void PipelineExecutor::FlushCachingOperatorsPull(DataChunk &result) {
-	idx_t start_idx = IsFinished() ? idx_t(finished_processing_idx) : 0;
-	idx_t op_idx = start_idx;
-	while (op_idx < pipeline.operators.size()) {
-		if (!pipeline.operators[op_idx]->RequiresFinalExecute()) {
-			op_idx++;
-			continue;
-		}
-
-		OperatorFinalizeResultType finalize_result;
-		DataChunk &curr_chunk =
-		    op_idx + 1 >= intermediate_chunks.size() ? final_chunk : *intermediate_chunks[op_idx + 1];
-
-		if (pending_final_execute) {
-			// Still have a cached chunk from a last pull, reuse chunk
-			finalize_result = cached_final_execute_result;
-		} else {
-			// Flush the current operator
-			auto current_operator = pipeline.operators[op_idx];
-			StartOperator(current_operator);
-			finalize_result = current_operator->FinalExecute(context, curr_chunk, *current_operator->op_state,
-			                                                 *intermediate_states[op_idx]);
-			EndOperator(current_operator, &curr_chunk);
-		}
-
-		auto execute_result = Execute(curr_chunk, result, op_idx + 1);
-
-		if (execute_result == OperatorResultType::HAVE_MORE_OUTPUT) {
-			pending_final_execute = true;
-			cached_final_execute_result = finalize_result;
-		} else {
-			pending_final_execute = false;
-			if (finalize_result == OperatorFinalizeResultType::FINISHED) {
-				FinishProcessing(op_idx);
-				op_idx++;
-			}
-		}
-
-		// Some non-empty result was pulled from some caching operator, we're done for this pull
-		if (result.size() > 0) {
-			break;
-		}
-	}
-}
-
 // Push all remaining cached operator output through the pipeline
 void PipelineExecutor::FlushCachingOperatorsPush() {
 	idx_t start_idx = IsFinished() ? idx_t(finished_processing_idx) : 0;
@@ -223,21 +177,13 @@ void PipelineExecutor::ExecutePull(DataChunk &result) {
 		D_ASSERT(!pipeline.sink);
 		auto &source_chunk = pipeline.operators.empty() ? result : *intermediate_chunks[0];
 		while (result.size() == 0) {
-			if (source_empty) {
-				FlushCachingOperatorsPull(result);
-				break;
-			}
-
 			if (in_process_operators.empty()) {
 				source_chunk.Reset();
 				FetchFromSource(source_chunk);
-
 				if (source_chunk.size() == 0) {
-					source_empty = true;
-					continue;
+					break;
 				}
 			}
-
 			if (!pipeline.operators.empty()) {
 				auto state = Execute(source_chunk, result);
 				if (state == OperatorResultType::FINISHED) {

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -555,14 +555,15 @@ TEST_CASE("Issue #4583: Catch Insert/Update/Delete errors", "[api]") {
 	REQUIRE(CHECK_COLUMN(result, 0, {1}));
 }
 
-TEST_CASE("Issue #6284: CachingPhysicalOperator in pull causes issues", "[api]") {
+TEST_CASE("Issue #6284: CachingPhysicalOperator in pull causes issues", "[api][.]") {
 
 	DBConfig config;
 	config.options.maximum_threads = 8;
 	DuckDB db(nullptr, &config);
 	Connection con(db);
 
-	REQUIRE_NO_FAIL(con.Query("select setseed(0.1); CREATE TABLE T0 AS SELECT DISTINCT (RANDOM()*9999999)::BIGINT record_nb, 0.0 x_0, 1.0 y_0 FROM range(1000000) tbl"));
+	REQUIRE_NO_FAIL(con.Query("select setseed(0.1); CREATE TABLE T0 AS SELECT DISTINCT (RANDOM()*9999999)::BIGINT "
+	                          "record_nb, 0.0 x_0, 1.0 y_0 FROM range(1000000) tbl"));
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE T1 AS SELECT record_nb, 0.0 x_1, 1.0 y_1 FROM T0"));
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE T2 AS SELECT record_nb, 0.0 x_2, 1.0 y_2 FROM T0"));
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE T3 AS SELECT record_nb, 0.0 x_3, 1.0 y_3 FROM T0"));
@@ -581,7 +582,7 @@ TEST_CASE("Issue #6284: CachingPhysicalOperator in pull causes issues", "[api]")
     )");
 
 	idx_t count = 0;
-	while(true) {
+	while (true) {
 		auto chunk = result->Fetch();
 		if (!chunk) {
 			break;

--- a/test/sql/filter/filter_cache.cpp
+++ b/test/sql/filter/filter_cache.cpp
@@ -4,20 +4,6 @@
 using namespace duckdb;
 using namespace std;
 
-TEST_CASE("Streaming result with filter operation applies operator caching", "[filter][.]") {
-	DuckDB db(nullptr);
-	Connection con(db);
-	REQUIRE_NO_FAIL(con.Query("CREATE TABLE test as SELECT i FROM range(0,100000) tbl(i)"));
-	// now create a streaming result
-	auto result = con.SendQuery("SELECT * FROM test where i % 20000 = 0");
-	REQUIRE_NO_FAIL(*result);
-	// initial query does not fail!
-	auto chunk = result->Fetch();
-	REQUIRE(chunk);
-	// the chunk should contain all 5 values if chunk caching is applied correctly
-	REQUIRE(chunk->size() == 5);
-}
-
 // This test triggers an edge case where data that is flushed from a caching operator in pulled into an operator
 // that needs to see this chunk more that once. handling this case requires temporarily caching the flushed result.
 TEST_CASE("Streaming result with a filter and a cross product", "[filter][.]") {

--- a/test/sql/function/table/table_in_out.cpp
+++ b/test/sql/function/table/table_in_out.cpp
@@ -90,28 +90,7 @@ TEST_CASE("Caching TableInOutFunction", "[filter][.]") {
 	REQUIRE(result2->ColumnCount() == 1);
 	REQUIRE(CHECK_COLUMN(result2, 0, {1, 3, 5}));
 
-	// Check stream result
-	auto result =
-	    con.SendQuery("SELECT * FROM throttling_sum((select i::INTEGER, (i+1)::INTEGER as j from range(0,3) tbl(i)));");
-	REQUIRE_NO_FAIL(*result);
-
-	auto chunk = result->Fetch();
-	REQUIRE(chunk);
-	REQUIRE(chunk->size() == 1);
-	REQUIRE(chunk->data[0].GetValue(0).GetValue<int>() == 1);
-
-	chunk = result->Fetch();
-	REQUIRE(chunk);
-	REQUIRE(chunk->size() == 1);
-	REQUIRE(chunk->data[0].GetValue(0).GetValue<int>() == 3);
-
-	chunk = result->Fetch();
-	REQUIRE(chunk);
-	REQUIRE(chunk->size() == 1);
-	REQUIRE(chunk->data[0].GetValue(0).GetValue<int>() == 5);
-
-	chunk = result->Fetch();
-	REQUIRE(!chunk);
+	// TODO: streaming these is currently unsupported
 
 	// Large result into aggregation
 	auto result3 = con.Query(


### PR DESCRIPTION
fixes #6284

The fix is disabling the operator caching on streaming query results alltogether. This code was quite complex and we want to move away from the pull based streaming anyways to be able to support parallelizing streaming query results