### PR TITLE
respect column order for partitioned write

### DIFF
--- a/src/common/bind_helpers.cpp
+++ b/src/common/bind_helpers.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
+#include <numeric>
 
 namespace duckdb {
 
@@ -62,6 +63,60 @@ vector<bool> ParseColumnList(const Value &value, vector<string> &names, const st
 		return result;
 	}
 	return ParseColumnList(children, names, loption);
+}
+
+vector<idx_t> ParseColumnsOrdered(const vector<Value> &set, vector<string> &names, const string &loption) {
+	vector<idx_t> result;
+
+	if (set.empty()) {
+		throw BinderException("\"%s\" expects a column list or * as parameter", loption);
+	}
+
+	// Maps option to bool indicating if its found and the index in the original set
+	case_insensitive_map_t<std::pair<bool, idx_t>> option_map;
+	for (idx_t i = 0; i < set.size(); i++) {
+		option_map[set[i].ToString()] = {false, i};
+	}
+	result.resize(option_map.size());
+
+	for (idx_t i = 0; i < names.size(); i++) {
+		auto entry = option_map.find(names[i]);
+		if (entry != option_map.end()) {
+			result[entry->second.second] = i;
+			entry->second.first = true;
+		}
+	}
+	for (auto &entry : option_map) {
+		if (!entry.second.first) {
+			throw BinderException("\"%s\" expected to find %s, but it was not found in the table", loption,
+			                      entry.first.c_str());
+		}
+	}
+	return result;
+}
+
+vector<idx_t> ParseColumnsOrdered(const Value &value, vector<string> &names, const string &loption) {
+	vector<idx_t> result;
+
+	// Only accept a list of arguments
+	if (value.type().id() != LogicalTypeId::LIST) {
+		// Support a single argument if it's '*'
+		if (value.type().id() == LogicalTypeId::VARCHAR && value.GetValue<string>() == "*") {
+			result.resize(names.size(), 0);
+			std::iota(std::begin(result), std::end(result), 0);
+			return result;
+		}
+		throw BinderException("\"%s\" expects a column list or * as parameter", loption);
+	}
+	auto &children = ListValue::GetChildren(value);
+	// accept '*' as single argument
+	if (children.size() == 1 && children[0].type().id() == LogicalTypeId::VARCHAR &&
+	    children[0].GetValue<string>() == "*") {
+		result.resize(names.size(), 0);
+		std::iota(std::begin(result), std::end(result), 0);
+		return result;
+	}
+	return ParseColumnsOrdered(children, names, loption);
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/common/bind_helpers.hpp
+++ b/src/include/duckdb/common/bind_helpers.hpp
@@ -17,5 +17,7 @@ class Value;
 Value ConvertVectorToValue(vector<Value> set);
 vector<bool> ParseColumnList(const vector<Value> &set, vector<string> &names, const string &option_name);
 vector<bool> ParseColumnList(const Value &value, vector<string> &names, const string &option_name);
+vector<idx_t> ParseColumnsOrdered(const vector<Value> &set, vector<string> &names, const string &loption);
+vector<idx_t> ParseColumnsOrdered(const Value &value, vector<string> &names, const string &loption);
 
 } // namespace duckdb

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -23,16 +23,6 @@
 
 namespace duckdb {
 
-static vector<idx_t> ColumnListToIndices(const vector<bool> &vec) {
-	vector<idx_t> ret;
-	for (idx_t i = 0; i < vec.size(); i++) {
-		if (vec[i]) {
-			ret.push_back(i);
-		}
-	}
-	return ret;
-}
-
 vector<string> GetUniqueNames(const vector<string> &original_names) {
 	unordered_set<string> name_set;
 	vector<string> unique_names;
@@ -115,7 +105,7 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 		}
 		if (loption == "partition_by") {
 			auto converted = ConvertVectorToValue(std::move(option.second));
-			partition_cols = ColumnListToIndices(ParseColumnList(converted, select_node.names, loption));
+			partition_cols = ParseColumnsOrdered(converted, select_node.names, loption);
 			continue;
 		}
 		stmt.info->options[option.first] = option.second;

--- a/test/sql/copy/partitioned/hive_partitioned_write.test
+++ b/test/sql/copy/partitioned/hive_partitioned_write.test
@@ -77,7 +77,7 @@ statement ok
 COPY test TO '__TEST_DIR__/partitioned4' (FORMAT PARQUET, PARTITION_BY part_col);
 
 query III
-SELECT part_col, value_col, value2_col FROM parquet_scan('__TEST_DIR__/partitioned4/*/*.parquet', HIVE_PARTITIONING=1) WHERE part_col=0 ORDER BY value2_col;
+SELECT part_col, value_col, value2_col FROM parquet_scan('__TEST_DIR__/partitioned4/part_col=*/*.parquet', HIVE_PARTITIONING=1) WHERE part_col=0 ORDER BY value2_col;
 ----
 0	1	0
 0	3	2
@@ -152,3 +152,44 @@ SELECT part_col, value_col, value2_col FROM '__TEST_DIR__/partitioned8/part_col=
 0	0	4
 0	2	6
 0	4	8
+
+# Order matters!
+statement ok
+COPY test TO '__TEST_DIR__/partitioned9' (FORMAT PARQUET, PARTITION_BY (part_col, value_col));
+
+query I
+SELECT min(value2_col) as min_val
+FROM parquet_scan('__TEST_DIR__/partitioned9/part_col=*/value_col=*/*.parquet', FILENAME=1)
+GROUP BY filename
+ORDER BY min_val
+----
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+
+statement ok
+COPY test TO '__TEST_DIR__/partitioned10' (FORMAT PARQUET, PARTITION_BY (value_col, part_col));
+
+query I
+SELECT min(value2_col) as min_val
+FROM parquet_scan('__TEST_DIR__/partitioned10/value_col=*/part_col=*/*.parquet', FILENAME=1)
+GROUP BY filename
+ORDER BY min_val
+----
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9

--- a/test/sql/copy/partitioned/hive_partitioned_write.test_slow
+++ b/test/sql/copy/partitioned/hive_partitioned_write.test_slow
@@ -21,13 +21,13 @@ call dbgen(sf=1);
 
 # Partition by 2 columns
 statement ok
-COPY lineitem TO '__TEST_DIR__/lineitem_sf1_partitioned' (FORMAT PARQUET, PARTITION_BY (l_returnflag, l_linestatus));
+COPY lineitem TO '__TEST_DIR__/lineitem_sf1_partitioned' (FORMAT PARQUET, PARTITION_BY (l_linestatus, l_returnflag));
 
 statement ok
 DROP TABLE lineitem;
 
 statement ok
-CREATE VIEW lineitem as SELECT * FROM parquet_scan('__TEST_DIR__/lineitem_sf1_partitioned/*/*/*.parquet', HIVE_PARTITIONING=1);
+CREATE VIEW lineitem as SELECT * FROM parquet_scan('__TEST_DIR__/lineitem_sf1_partitioned/l_linestatus=*/l_returnflag=*/*.parquet', HIVE_PARTITIONING=1);
 
 loop i 1 9
 


### PR DESCRIPTION
Fixes #6343
Now the order at which columns are given is used as the order of nesting of the directories produced