### PR TITLE
two changes facilitating  sending table/column stats over the wire (M…

### DIFF
--- a/src/include/duckdb/storage/statistics/base_statistics.hpp
+++ b/src/include/duckdb/storage/statistics/base_statistics.hpp
@@ -39,7 +39,7 @@ public:
 	unique_ptr<BaseStatistics> validity_stats;
 	//! The approximate count distinct stats of the column (if any)
 	unique_ptr<BaseStatistics> distinct_stats;
-	idx_t distinct_count; // estimate that one may have even if distinct_stats==nullptr 
+	idx_t distinct_count; // estimate that one may have even if distinct_stats==nullptr
 
 	//! Whether these are 'global' stats, i.e., over a whole table, or just over a segment
 	//! Some statistics are more expensive to keep, therefore we only keep them globally

--- a/src/include/duckdb/storage/statistics/base_statistics.hpp
+++ b/src/include/duckdb/storage/statistics/base_statistics.hpp
@@ -39,6 +39,8 @@ public:
 	unique_ptr<BaseStatistics> validity_stats;
 	//! The approximate count distinct stats of the column (if any)
 	unique_ptr<BaseStatistics> distinct_stats;
+	idx_t distinct_count; // estimate that one may have even if distinct_stats==nullptr 
+
 	//! Whether these are 'global' stats, i.e., over a whole table, or just over a segment
 	//! Some statistics are more expensive to keep, therefore we only keep them globally
 	StatisticsType stats_type;

--- a/src/include/duckdb/storage/statistics/node_statistics.hpp
+++ b/src/include/duckdb/storage/statistics/node_statistics.hpp
@@ -24,7 +24,7 @@ public:
 	    : has_estimated_cardinality(true), estimated_cardinality(estimated_cardinality), has_max_cardinality(true),
 	      max_cardinality(max_cardinality) {
 	}
-	void Serialize(Serializer &serializer) const { 
+	void Serialize(Serializer &serializer) const {
 		serializer.Write(has_estimated_cardinality);
 		if (has_estimated_cardinality) {
 			serializer.Write(estimated_cardinality);
@@ -33,18 +33,21 @@ public:
 				serializer.Write(max_cardinality);
 			}
 		} else {
-			assert(!has_max_cardinality);
+			D_ASSERT(!has_max_cardinality);
 		}
 	}
 	static unique_ptr<NodeStatistics> Deserialize(Deserializer &source) {
-		if (!source.Read<bool>()) {
+		bool has_estimated_cardinality = source.Read<bool>();
+		if (!has_estimated_cardinality) {
 			return make_unique<NodeStatistics>();
 		}
 		idx_t estimated_cardinality = source.Read<idx_t>();
-		if (!source.Read<bool>()) {
+		bool has_max_cardinality = source.Read<bool>();
+		if (!has_max_cardinality) {
 			return make_unique<NodeStatistics>(estimated_cardinality);
 		}
-		return make_unique<NodeStatistics>(estimated_cardinality, source.Read<idx_t>());
+		idx_t max_cardinality = source.Read<idx_t>();
+		return make_unique<NodeStatistics>(estimated_cardinality, max_cardinality);
 	}
 
 	//! Whether or not the node has an estimated cardinality specified

--- a/src/storage/statistics/base_statistics.cpp
+++ b/src/storage/statistics/base_statistics.cpp
@@ -12,7 +12,7 @@
 namespace duckdb {
 
 BaseStatistics::BaseStatistics(LogicalType type, StatisticsType stats_type)
-    : type(std::move(type)), stats_type(stats_type), distinct_count(0) {
+    : type(std::move(type)), distinct_count(0), stats_type(stats_type) {
 }
 
 BaseStatistics::~BaseStatistics() {

--- a/src/storage/statistics/base_statistics.cpp
+++ b/src/storage/statistics/base_statistics.cpp
@@ -12,7 +12,7 @@
 namespace duckdb {
 
 BaseStatistics::BaseStatistics(LogicalType type, StatisticsType stats_type)
-    : type(std::move(type)), stats_type(stats_type) {
+    : type(std::move(type)), stats_type(stats_type), distinct_count(0) {
 }
 
 BaseStatistics::~BaseStatistics() {
@@ -72,9 +72,9 @@ void BaseStatistics::Merge(const BaseStatistics &other) {
 idx_t BaseStatistics::GetDistinctCount() {
 	if (distinct_stats) {
 		auto &d_stats = (DistinctStatistics &)*distinct_stats;
-		return d_stats.GetCount();
+		distinct_count = d_stats.GetCount();
 	}
-	return 0;
+	return distinct_count;
 }
 
 unique_ptr<BaseStatistics> BaseStatistics::CreateEmpty(LogicalType type, StatisticsType stats_type) {


### PR DESCRIPTION
…otherDuck suggested):

- added a de/serialization methods for NodeStatistics
- BaseStatistics may shed the HLL (3KB per col) yet still remember distinct_count