### PR TITLE
[Python] Fix bug that caused a crash on conversion to arrow

### DIFF
--- a/tools/pythonpkg/src/CMakeLists.txt
+++ b/tools/pythonpkg/src/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
   vector_conversion.cpp
   python_conversion.cpp
   python_objects.cpp
+  pybind_wrapper.cpp
   arrow_array_stream.cpp)
 
 set(ALL_OBJECT_FILES

--- a/tools/pythonpkg/src/arrow_array_stream.cpp
+++ b/tools/pythonpkg/src/arrow_array_stream.cpp
@@ -112,9 +112,9 @@ unique_ptr<ArrowArrayStreamWrapper> PythonTableArrowArrayStreamFactory::Produce(
 }
 
 void PythonTableArrowArrayStreamFactory::GetSchema(uintptr_t factory_ptr, ArrowSchemaWrapper &schema) {
-	VerifyArrowDatasetLoaded();
-
 	py::gil_scoped_acquire acquire;
+
+	VerifyArrowDatasetLoaded();
 	PythonTableArrowArrayStreamFactory *factory = (PythonTableArrowArrayStreamFactory *)factory_ptr;
 	D_ASSERT(factory->arrow_object);
 	auto scanner_class = py::module::import("pyarrow.dataset").attr("Scanner");

--- a/tools/pythonpkg/src/include/duckdb_python/pybind_wrapper.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pybind_wrapper.hpp
@@ -12,6 +12,14 @@
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
 #include <vector>
+#include "duckdb/common/assert.hpp"
+
+namespace pybind11 {
+
+bool gil_check();
+void gil_assert();
+
+} // namespace pybind11
 
 namespace duckdb {
 #ifdef __GNUG__

--- a/tools/pythonpkg/src/pybind_wrapper.cpp
+++ b/tools/pythonpkg/src/pybind_wrapper.cpp
@@ -1,0 +1,13 @@
+#include "duckdb_python/pybind_wrapper.hpp"
+
+namespace pybind11 {
+
+bool gil_check() {
+	return (bool)PyGILState_Check();
+}
+
+void gil_assert() {
+	D_ASSERT(gil_check());
+}
+
+} // namespace pybind11

--- a/tools/pythonpkg/src/pybind_wrapper.cpp
+++ b/tools/pythonpkg/src/pybind_wrapper.cpp
@@ -1,4 +1,5 @@
 #include "duckdb_python/pybind_wrapper.hpp"
+#include "duckdb/common/exception.hpp"
 
 namespace pybind11 {
 
@@ -9,7 +10,9 @@ bool gil_check() {
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 void gil_assert() {
-	D_ASSERT(gil_check());
+	if (!gil_check()) {
+		throw duckdb::InternalException("The GIL should be held for this operation, but it's not!");
+	}
 }
 
 } // namespace pybind11

--- a/tools/pythonpkg/src/pybind_wrapper.cpp
+++ b/tools/pythonpkg/src/pybind_wrapper.cpp
@@ -2,10 +2,12 @@
 
 namespace pybind11 {
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 bool gil_check() {
 	return (bool)PyGILState_Check();
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 void gil_assert() {
 	D_ASSERT(gil_check());
 }

--- a/tools/pythonpkg/src/python_import_cache.cpp
+++ b/tools/pythonpkg/src/python_import_cache.cpp
@@ -36,6 +36,7 @@ PyObject *PythonImportCacheItem::AddCache(PythonImportCache &cache, py::object o
 void PythonImportCacheItem::LoadModule(const string &name, PythonImportCache &cache) {
 	load_attempted = true;
 	try {
+		py::gil_assert();
 		object = AddCache(cache, std::move(py::module::import(name.c_str())));
 	} catch (py::error_already_set &e) {
 		if (IsRequired()) {
@@ -45,6 +46,7 @@ void PythonImportCacheItem::LoadModule(const string &name, PythonImportCache &ca
 	}
 	LoadSubtypes(cache);
 }
+
 void PythonImportCacheItem::LoadAttribute(const string &name, PythonImportCache &cache, PythonImportCacheItem &source) {
 	auto source_object = source();
 	object = AddCache(cache, std::move(source_object.attr(name.c_str())));


### PR DESCRIPTION
This PR fixes #6438 

Until not too long ago, we loaded all imports at the start, while holding the GIL.
We recently moved to lazy-loading modules, and this was one of the places where the GIL was not held as the import took place - which caused the crash.

This PR adds some internal functions to verify proper management of the GIL:

`gil_check()`
\- returns a boolean indicating if the GIL is held
`gil_assert()`
\- asserts that gil_check returns True