### PR TITLE
Fix cardinality estimation memoization bug

### DIFF
--- a/src/planner/logical_operator.cpp
+++ b/src/planner/logical_operator.cpp
@@ -167,7 +167,8 @@ idx_t LogicalOperator::EstimateCardinality(ClientContext &context) {
 		max_cardinality = MaxValue(child->EstimateCardinality(context), max_cardinality);
 	}
 	has_estimated_cardinality = true;
-	return estimated_cardinality = max_cardinality;
+	estimated_cardinality = max_cardinality;
+	return estimated_cardinality;
 }
 
 void LogicalOperator::Print() {

--- a/src/planner/logical_operator.cpp
+++ b/src/planner/logical_operator.cpp
@@ -167,7 +167,7 @@ idx_t LogicalOperator::EstimateCardinality(ClientContext &context) {
 		max_cardinality = MaxValue(child->EstimateCardinality(context), max_cardinality);
 	}
 	has_estimated_cardinality = true;
-	return max_cardinality;
+	return estimated_cardinality = max_cardinality;
 }
 
 void LogicalOperator::Print() {

--- a/test/sql/pg_catalog/sqlalchemy.test
+++ b/test/sql/pg_catalog/sqlalchemy.test
@@ -354,6 +354,7 @@ FROM pg_catalog.pg_type t
 		LEFT JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
 		LEFT JOIN pg_catalog.pg_enum e ON t.oid = e.enumtypid
 WHERE t.typtype = 'e'
+ORDER BY e.enumsortorder
 ----
 greeting	true	main	hi
 greeting	true	main	bonjour


### PR DESCRIPTION
Cardinality estimation gives wrong value (0) when called the second time. This leads to a problem in the join_order_optimizer that then wrongly converts left joins to right joins in typical star schema queries.