### PR TITLE
Improve error message similarity score by using a weighted levenshtein that penalizes non-equal characters more than additions/deletions

### DIFF
--- a/src/catalog/catalog_entry/schema_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/schema_catalog_entry.cpp
@@ -24,7 +24,7 @@ SimilarCatalogEntry SchemaCatalogEntry::GetSimilarEntry(CatalogTransaction trans
                                                         const string &name) {
 	SimilarCatalogEntry result;
 	Scan(transaction.GetContext(), type, [&](CatalogEntry *entry) {
-		auto ldist = StringUtil::LevenshteinDistance(entry->name, name);
+		auto ldist = StringUtil::SimilarityScore(entry->name, name);
 		if (ldist < result.distance) {
 			result.distance = ldist;
 			result.name = entry->name;

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -460,7 +460,7 @@ SimilarCatalogEntry CatalogSet::SimilarEntry(CatalogTransaction transaction, con
 	for (auto &kv : mapping) {
 		auto mapping_value = GetMapping(transaction, kv.first);
 		if (mapping_value && !mapping_value->deleted) {
-			auto ldist = StringUtil::LevenshteinDistance(kv.first, name);
+			auto ldist = StringUtil::SimilarityScore(kv.first, name);
 			if (ldist < result.distance) {
 				result.distance = ldist;
 				result.name = kv.first;

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -249,7 +249,7 @@ private:
 };
 
 // adapted from https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Levenshtein_distance#C++
-idx_t StringUtil::LevenshteinDistance(const string &s1_p, const string &s2_p) {
+idx_t StringUtil::LevenshteinDistance(const string &s1_p, const string &s2_p, idx_t not_equal_penalty) {
 	auto s1 = StringUtil::Lower(s1_p);
 	auto s2 = StringUtil::Lower(s2_p);
 	idx_t len1 = s1.size();
@@ -273,7 +273,7 @@ idx_t StringUtil::LevenshteinDistance(const string &s1_p, const string &s2_p) {
 			// d[i][j] = std::min({ d[i - 1][j] + 1,
 			//                      d[i][j - 1] + 1,
 			//                      d[i - 1][j - 1] + (s1[i - 1] == s2[j - 1] ? 0 : 1) });
-			int equal = s1[i - 1] == s2[j - 1] ? 0 : 1;
+			int equal = s1[i - 1] == s2[j - 1] ? 0 : not_equal_penalty;
 			idx_t adjacent_score1 = array.Score(i - 1, j) + 1;
 			idx_t adjacent_score2 = array.Score(i, j - 1) + 1;
 			idx_t adjacent_score3 = array.Score(i - 1, j - 1) + equal;
@@ -285,15 +285,19 @@ idx_t StringUtil::LevenshteinDistance(const string &s1_p, const string &s2_p) {
 	return array.Score(len1, len2);
 }
 
+idx_t StringUtil::SimilarityScore(const string &s1, const string &s2) {
+	return LevenshteinDistance(s1, s2, 3);
+}
+
 vector<string> StringUtil::TopNLevenshtein(const vector<string> &strings, const string &target, idx_t n,
                                            idx_t threshold) {
 	vector<pair<string, idx_t>> scores;
 	scores.reserve(strings.size());
 	for (auto &str : strings) {
 		if (target.size() < str.size()) {
-			scores.emplace_back(str, LevenshteinDistance(str.substr(0, target.size()), target));
+			scores.emplace_back(str, SimilarityScore(str.substr(0, target.size()), target));
 		} else {
-			scores.emplace_back(str, LevenshteinDistance(str, target));
+			scores.emplace_back(str, SimilarityScore(str, target));
 		}
 	}
 	return TopNStrings(scores, n, threshold);

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -145,8 +145,15 @@ public:
 	DUCKDB_API static string Replace(string source, const string &from, const string &to);
 
 	//! Get the levenshtein distance from two strings
-	DUCKDB_API static idx_t LevenshteinDistance(const string &s1, const string &s2);
+	//! The not_equal_penalty is the penalty given when two characters in a string are not equal
+	//! The regular levenshtein distance has a not equal penalty of 1, which means changing a character is as expensive
+	//! as adding or removing one For similarity searches we often want to give extra weight to changing a character For
+	//! example: with an equal penalty of 1, "pg_am" is closer to "depdelay" than "depdelay_minutes"
+	//! with an equal penalty of 3, "depdelay_minutes" is closer to "depdelay" than to "pg_am"
+	DUCKDB_API static idx_t LevenshteinDistance(const string &s1, const string &s2, idx_t not_equal_penalty = 1);
 
+	//! Returns the similarity score between two strings
+	DUCKDB_API static idx_t SimilarityScore(const string &s1, const string &s2);
 	//! Get the top-n strings (sorted by the given score distance) from a set of scores.
 	//! At least one entry is returned (if there is one).
 	//! Strings are only returned if they have a score less than the threshold.

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -44,7 +44,7 @@ vector<string> BindContext::GetSimilarBindings(const string &column_name) {
 	for (auto &kv : bindings) {
 		auto binding = kv.second.get();
 		for (auto &name : binding->names) {
-			idx_t distance = StringUtil::LevenshteinDistance(name, column_name);
+			idx_t distance = StringUtil::SimilarityScore(name, column_name);
 			scores.emplace_back(binding->alias + "." + name, distance);
 		}
 	}

--- a/test/sql/binder/similar_to.test
+++ b/test/sql/binder/similar_to.test
@@ -1,0 +1,32 @@
+# name: test/sql/binder/similar_to.test
+# description: Test table alias with single quotes
+# group: [binder]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE depdelay_minutes(depdelay_minutes INTEGER);
+
+statement error
+SELECT * FROM depdelay
+----
+depdelay_minutes
+
+statement error
+SELECT depdelay FROM depdelay_minutes
+----
+depdelay_minutes
+
+statement ok
+CREATE TABLE lineitem(i INTEGER);
+
+statement error
+SELECT * FROM li
+----
+lineitem
+
+statement error
+SELECT * FROM lineitem_long
+----
+lineitem

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -2679,7 +2679,7 @@ public class TestDuckDBJDBC {
 				SQLException.class
 		);
 
-		assertEquals(message.contains("unrecognized configuration parameter \"invalid config name\""));
+		assertTrue(message.contains("unrecognized configuration parameter \"invalid config name\""));
 	}
 
 	private static String getSetting(Connection conn, String settingName) throws Exception {

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -2679,7 +2679,7 @@ public class TestDuckDBJDBC {
 				SQLException.class
 		);
 
-		assertEquals(message, "Catalog Error: unrecognized configuration parameter \"invalid config name\"\n\nDid you mean: \"enable_profiling\"");
+		assertEquals(message.contains("unrecognized configuration parameter \"invalid config name\""));
 	}
 
 	private static String getSetting(Connection conn, String settingName) throws Exception {

--- a/tools/sqlite3_api_wrapper/sql_auto_complete_extension.cpp
+++ b/tools/sqlite3_api_wrapper/sql_auto_complete_extension.cpp
@@ -57,9 +57,9 @@ static vector<string> ComputeSuggestions(vector<AutoCompleteCandidate> available
 		auto score = idx_t(BASE_SCORE - bonus);
 		if (prefix.size() == 0) {
 		} else if (prefix.size() < str.size()) {
-			score += StringUtil::LevenshteinDistance(str.substr(0, prefix.size()), prefix);
+			score += StringUtil::SimilarityScore(str.substr(0, prefix.size()), prefix);
 		} else {
-			score += StringUtil::LevenshteinDistance(str, prefix);
+			score += StringUtil::SimilarityScore(str, prefix);
 		}
 		D_ASSERT(score >= 0);
 		scores.emplace_back(str, score);


### PR DESCRIPTION
In this PR we switch to using a weighted-levenshtein distance for computing "similar to" suggestions, instead of a regular levenshtein distance.

The reason for this is that the regular levenshtein distance has an equal penalty for performing an addition, deletion or character substitution. That means that for strings of unequal length, there is a large base cost for adding the extra characters required. This would lead to what seem like much less similar strings to be preferred/recommended.

For example, consider the following query + error message from the current version of DuckDB:

```sql
CREATE TABLE depdelay_minutes(i INTEGER);
SELECT * FROM depdelay;
-- Error: Catalog Error: Table with name depdelay does not exist!
-- Did you mean "pg_am"?
-- LINE 1: SELECT * FROM depdelay
```

Despite `depdelay_minutes` seemingly being much more similar to `depdelay` than `pg_am`, the string `pg_am` is preferred as the edit distance is lower - primarily due to the different lengths of the strings. Namely `levenshtein(depdelay, depdelay_minutes)` is 8, whereas `levenshtein(depdelay, pg_am)` is 6. 

By providing an extra penalty for when characters are inequal (currently `3` instead of `1`) we end up with a `weighted_levenshtein(depdelay, depdelay_minutes)` of 8, and `weighted_levenshtein(depdelay, pg_am)` of 18, which results in the much more reasonable error message/suggestion:

```sql
CREATE TABLE depdelay_minutes(i INTEGER);
SELECT * FROM depdelay;
-- Error: Catalog Error: Table with name depdelay does not exist!
-- Did you mean "depdelay_minutes"?
-- LINE 1: SELECT * FROM depdelay
```