### PR TITLE
R: Fix protection errors for relational API

### DIFF
--- a/tools/rpkg/inst/include/cpp11/external_pointer.hpp
+++ b/tools/rpkg/inst/include/cpp11/external_pointer.hpp
@@ -57,8 +57,8 @@ class external_pointer {
 
   external_pointer(SEXP data) : data_(valid_type(data)) {}
 
-  external_pointer(pointer p, bool use_deleter = true, bool finalize_on_exit = true)
-      : data_(safe[R_MakeExternalPtr]((void*)p, R_NilValue, R_NilValue)) {
+  external_pointer(pointer p, bool use_deleter = true, bool finalize_on_exit = true, SEXP prot = R_NilValue)
+      : data_(safe[R_MakeExternalPtr]((void*)p, R_NilValue, prot)) {
     if (use_deleter) {
       R_RegisterCFinalizerEx(data_, r_deleter, static_cast<r_bool>(finalize_on_exit));
     }

--- a/tools/rpkg/src/include/rapi.hpp
+++ b/tools/rpkg/src/include/rapi.hpp
@@ -62,7 +62,7 @@ struct ArrowScanReplacementData : public ReplacementScanData {
 	DBWrapper *wrapper;
 };
 
-SEXP StringsToSexp(vector<std::string> s);
+cpp11::strings StringsToSexp(vector<std::string> s);
 
 SEXP ToUtf8(SEXP string_sexp);
 

--- a/tools/rpkg/src/relational.cpp
+++ b/tools/rpkg/src/relational.cpp
@@ -103,7 +103,10 @@ external_pointer<T> make_external_prot(const string &rclass, SEXP prot, ARGS &&.
 	                                (int32_t)(NumericLimits<int32_t>::Maximum() * unif_rand()));
 	auto rel =
 	    con->conn->TableFunction("r_dataframe_scan", {Value::POINTER((uintptr_t)(SEXP)df)}, other_params)->Alias(alias);
-	auto res = sexp(make_external<RelationWrapper>("duckdb_relation", std::move(rel)));
+
+	cpp11::writable::list prot = { df };
+
+	auto res = sexp(make_external_prot<RelationWrapper>("duckdb_relation", prot, std::move(rel)));
 	res.attr("df") = df;
 	return res;
 }
@@ -123,7 +126,10 @@ external_pointer<T> make_external_prot(const string &rclass, SEXP prot, ARGS &&.
 		filter_expr = make_unique<ConjunctionExpression>(ExpressionType::CONJUNCTION_AND, std::move(filters));
 	}
 	auto res = std::make_shared<FilterRelation>(rel->rel, std::move(filter_expr));
-	return make_external<RelationWrapper>("duckdb_relation", res);
+
+	cpp11::writable::list prot = { rel };
+
+	return make_external_prot<RelationWrapper>("duckdb_relation", prot, res);
 }
 
 [[cpp11::register]] SEXP rapi_rel_project(duckdb::rel_extptr_t rel, list exprs) {
@@ -141,7 +147,10 @@ external_pointer<T> make_external_prot(const string &rclass, SEXP prot, ARGS &&.
 	}
 
 	auto res = std::make_shared<ProjectionRelation>(rel->rel, std::move(projections), std::move(aliases));
-	return make_external_prot<RelationWrapper>("duckdb_relation", (sexp)rel, res);
+
+	cpp11::writable::list prot = { rel };
+
+	return make_external_prot<RelationWrapper>("duckdb_relation", prot, res);
 }
 
 [[cpp11::register]] SEXP rapi_rel_aggregate(duckdb::rel_extptr_t rel, list groups, list aggregates) {
@@ -168,7 +177,10 @@ external_pointer<T> make_external_prot(const string &rclass, SEXP prot, ARGS &&.
 	}
 
 	auto res = std::make_shared<AggregateRelation>(rel->rel, std::move(res_aggregates), std::move(res_groups));
-	return make_external<RelationWrapper>("duckdb_relation", res);
+
+	cpp11::writable::list prot = { rel };
+
+	return make_external_prot<RelationWrapper>("duckdb_relation", prot, res);
 }
 
 [[cpp11::register]] SEXP rapi_rel_order(duckdb::rel_extptr_t rel, list orders) {
@@ -179,7 +191,10 @@ external_pointer<T> make_external_prot(const string &rclass, SEXP prot, ARGS &&.
 	}
 
 	auto res = std::make_shared<OrderRelation>(rel->rel, std::move(res_orders));
-	return make_external<RelationWrapper>("duckdb_relation", res);
+
+	cpp11::writable::list prot = { rel };
+
+	return make_external_prot<RelationWrapper>("duckdb_relation", prot, res);
 }
 
 [[cpp11::register]] SEXP rapi_rel_join(duckdb::rel_extptr_t left, duckdb::rel_extptr_t right, list conds,
@@ -207,7 +222,10 @@ external_pointer<T> make_external_prot(const string &rclass, SEXP prot, ARGS &&.
 		join_type = JoinType::OUTER;
 	}
 	auto res = std::make_shared<JoinRelation>(left->rel, right->rel, std::move(cond), join_type);
-	return make_external<RelationWrapper>("duckdb_relation", res);
+
+	cpp11::writable::list prot = { left, right };
+
+	return make_external_prot<RelationWrapper>("duckdb_relation", prot, res);
 }
 
 static SEXP result_to_df(unique_ptr<QueryResult> res) {
@@ -238,15 +256,24 @@ static SEXP result_to_df(unique_ptr<QueryResult> res) {
 
 [[cpp11::register]] SEXP rapi_rel_union_all(duckdb::rel_extptr_t rel_a, duckdb::rel_extptr_t rel_b) {
 	auto res = std::make_shared<SetOpRelation>(rel_a->rel, rel_b->rel, SetOperationType::UNION);
-	return make_external<RelationWrapper>("duckdb_relation", res);
+
+	cpp11::writable::list prot = { rel_a, rel_b };
+
+	return make_external_prot<RelationWrapper>("duckdb_relation", prot, res);
 }
 
 [[cpp11::register]] SEXP rapi_rel_limit(duckdb::rel_extptr_t rel, int64_t n) {
-	return make_external<RelationWrapper>("duckdb_relation", std::make_shared<LimitRelation>(rel->rel, n, 0));
+
+	cpp11::writable::list prot = { rel };
+
+	return make_external_prot<RelationWrapper>("duckdb_relation", prot, std::make_shared<LimitRelation>(rel->rel, n, 0));
 }
 
 [[cpp11::register]] SEXP rapi_rel_distinct(duckdb::rel_extptr_t rel) {
-	return make_external<RelationWrapper>("duckdb_relation", std::make_shared<DistinctRelation>(rel->rel));
+
+	cpp11::writable::list prot = { rel };
+
+	return make_external_prot<RelationWrapper>("duckdb_relation", prot, std::make_shared<DistinctRelation>(rel->rel));
 }
 
 [[cpp11::register]] SEXP rapi_rel_to_df(duckdb::rel_extptr_t rel) {
@@ -266,7 +293,9 @@ static SEXP result_to_df(unique_ptr<QueryResult> res) {
 }
 
 [[cpp11::register]] SEXP rapi_rel_set_alias(duckdb::rel_extptr_t rel, std::string alias) {
-	return make_external<RelationWrapper>("duckdb_relation", rel->rel->Alias(alias));
+	cpp11::writable::list prot = { rel };
+
+	return make_external_prot<RelationWrapper>("duckdb_relation", prot, rel->rel->Alias(alias));
 }
 
 [[cpp11::register]] SEXP rapi_rel_sql(duckdb::rel_extptr_t rel, std::string sql) {
@@ -287,12 +316,18 @@ static SEXP result_to_df(unique_ptr<QueryResult> res) {
 
 [[cpp11::register]] SEXP rapi_rel_set_intersect(duckdb::rel_extptr_t rel_a, duckdb::rel_extptr_t rel_b) {
 	auto res = std::make_shared<SetOpRelation>(rel_a->rel, rel_b->rel, SetOperationType::INTERSECT);
-	return make_external<RelationWrapper>("duckdb_relation", res);
+
+	cpp11::writable::list prot = { rel_a, rel_b };
+
+	return make_external_prot<RelationWrapper>("duckdb_relation", prot, res);
 }
 
 [[cpp11::register]] SEXP rapi_rel_set_diff(duckdb::rel_extptr_t rel_a, duckdb::rel_extptr_t rel_b) {
 	auto res = std::make_shared<SetOpRelation>(rel_a->rel, rel_b->rel, SetOperationType::EXCEPT);
-	return make_external<RelationWrapper>("duckdb_relation", res);
+
+	cpp11::writable::list prot = { rel_a, rel_b };
+
+	return make_external_prot<RelationWrapper>("duckdb_relation", prot, res);
 }
 
 [[cpp11::register]] SEXP rapi_rel_set_symdiff(duckdb::rel_extptr_t rel_a, duckdb::rel_extptr_t rel_b) {
@@ -301,5 +336,8 @@ static SEXP result_to_df(unique_ptr<QueryResult> res) {
 	auto a_except_b = std::make_shared<SetOpRelation>(rel_a->rel, rel_b->rel, SetOperationType::EXCEPT);
 	auto b_except_a = std::make_shared<SetOpRelation>(rel_b->rel, rel_a->rel, SetOperationType::EXCEPT);
 	auto symdiff = std::make_shared<SetOpRelation>(a_except_b, b_except_a, SetOperationType::UNION);
-	return make_external<RelationWrapper>("duckdb_relation", symdiff);
+
+	cpp11::writable::list prot = { rel_a, rel_b };
+
+	return make_external_prot<RelationWrapper>("duckdb_relation", prot, symdiff);
 }

--- a/tools/rpkg/src/relational.cpp
+++ b/tools/rpkg/src/relational.cpp
@@ -104,7 +104,7 @@ external_pointer<T> make_external_prot(const string &rclass, SEXP prot, ARGS &&.
 	auto rel =
 	    con->conn->TableFunction("r_dataframe_scan", {Value::POINTER((uintptr_t)(SEXP)df)}, other_params)->Alias(alias);
 
-	cpp11::writable::list prot = { df };
+	cpp11::writable::list prot = {df};
 
 	auto res = sexp(make_external_prot<RelationWrapper>("duckdb_relation", prot, std::move(rel)));
 	res.attr("df") = df;
@@ -127,7 +127,7 @@ external_pointer<T> make_external_prot(const string &rclass, SEXP prot, ARGS &&.
 	}
 	auto res = std::make_shared<FilterRelation>(rel->rel, std::move(filter_expr));
 
-	cpp11::writable::list prot = { rel };
+	cpp11::writable::list prot = {rel};
 
 	return make_external_prot<RelationWrapper>("duckdb_relation", prot, res);
 }
@@ -148,7 +148,7 @@ external_pointer<T> make_external_prot(const string &rclass, SEXP prot, ARGS &&.
 
 	auto res = std::make_shared<ProjectionRelation>(rel->rel, std::move(projections), std::move(aliases));
 
-	cpp11::writable::list prot = { rel };
+	cpp11::writable::list prot = {rel};
 
 	return make_external_prot<RelationWrapper>("duckdb_relation", prot, res);
 }
@@ -178,7 +178,7 @@ external_pointer<T> make_external_prot(const string &rclass, SEXP prot, ARGS &&.
 
 	auto res = std::make_shared<AggregateRelation>(rel->rel, std::move(res_aggregates), std::move(res_groups));
 
-	cpp11::writable::list prot = { rel };
+	cpp11::writable::list prot = {rel};
 
 	return make_external_prot<RelationWrapper>("duckdb_relation", prot, res);
 }
@@ -192,7 +192,7 @@ external_pointer<T> make_external_prot(const string &rclass, SEXP prot, ARGS &&.
 
 	auto res = std::make_shared<OrderRelation>(rel->rel, std::move(res_orders));
 
-	cpp11::writable::list prot = { rel };
+	cpp11::writable::list prot = {rel};
 
 	return make_external_prot<RelationWrapper>("duckdb_relation", prot, res);
 }
@@ -223,7 +223,7 @@ external_pointer<T> make_external_prot(const string &rclass, SEXP prot, ARGS &&.
 	}
 	auto res = std::make_shared<JoinRelation>(left->rel, right->rel, std::move(cond), join_type);
 
-	cpp11::writable::list prot = { left, right };
+	cpp11::writable::list prot = {left, right};
 
 	return make_external_prot<RelationWrapper>("duckdb_relation", prot, res);
 }
@@ -257,21 +257,22 @@ static SEXP result_to_df(unique_ptr<QueryResult> res) {
 [[cpp11::register]] SEXP rapi_rel_union_all(duckdb::rel_extptr_t rel_a, duckdb::rel_extptr_t rel_b) {
 	auto res = std::make_shared<SetOpRelation>(rel_a->rel, rel_b->rel, SetOperationType::UNION);
 
-	cpp11::writable::list prot = { rel_a, rel_b };
+	cpp11::writable::list prot = {rel_a, rel_b};
 
 	return make_external_prot<RelationWrapper>("duckdb_relation", prot, res);
 }
 
 [[cpp11::register]] SEXP rapi_rel_limit(duckdb::rel_extptr_t rel, int64_t n) {
 
-	cpp11::writable::list prot = { rel };
+	cpp11::writable::list prot = {rel};
 
-	return make_external_prot<RelationWrapper>("duckdb_relation", prot, std::make_shared<LimitRelation>(rel->rel, n, 0));
+	return make_external_prot<RelationWrapper>("duckdb_relation", prot,
+	                                           std::make_shared<LimitRelation>(rel->rel, n, 0));
 }
 
 [[cpp11::register]] SEXP rapi_rel_distinct(duckdb::rel_extptr_t rel) {
 
-	cpp11::writable::list prot = { rel };
+	cpp11::writable::list prot = {rel};
 
 	return make_external_prot<RelationWrapper>("duckdb_relation", prot, std::make_shared<DistinctRelation>(rel->rel));
 }
@@ -293,7 +294,7 @@ static SEXP result_to_df(unique_ptr<QueryResult> res) {
 }
 
 [[cpp11::register]] SEXP rapi_rel_set_alias(duckdb::rel_extptr_t rel, std::string alias) {
-	cpp11::writable::list prot = { rel };
+	cpp11::writable::list prot = {rel};
 
 	return make_external_prot<RelationWrapper>("duckdb_relation", prot, rel->rel->Alias(alias));
 }
@@ -317,7 +318,7 @@ static SEXP result_to_df(unique_ptr<QueryResult> res) {
 [[cpp11::register]] SEXP rapi_rel_set_intersect(duckdb::rel_extptr_t rel_a, duckdb::rel_extptr_t rel_b) {
 	auto res = std::make_shared<SetOpRelation>(rel_a->rel, rel_b->rel, SetOperationType::INTERSECT);
 
-	cpp11::writable::list prot = { rel_a, rel_b };
+	cpp11::writable::list prot = {rel_a, rel_b};
 
 	return make_external_prot<RelationWrapper>("duckdb_relation", prot, res);
 }
@@ -325,7 +326,7 @@ static SEXP result_to_df(unique_ptr<QueryResult> res) {
 [[cpp11::register]] SEXP rapi_rel_set_diff(duckdb::rel_extptr_t rel_a, duckdb::rel_extptr_t rel_b) {
 	auto res = std::make_shared<SetOpRelation>(rel_a->rel, rel_b->rel, SetOperationType::EXCEPT);
 
-	cpp11::writable::list prot = { rel_a, rel_b };
+	cpp11::writable::list prot = {rel_a, rel_b};
 
 	return make_external_prot<RelationWrapper>("duckdb_relation", prot, res);
 }
@@ -337,7 +338,7 @@ static SEXP result_to_df(unique_ptr<QueryResult> res) {
 	auto b_except_a = std::make_shared<SetOpRelation>(rel_b->rel, rel_a->rel, SetOperationType::EXCEPT);
 	auto symdiff = std::make_shared<SetOpRelation>(a_except_b, b_except_a, SetOperationType::UNION);
 
-	cpp11::writable::list prot = { rel_a, rel_b };
+	cpp11::writable::list prot = {rel_a, rel_b};
 
 	return make_external_prot<RelationWrapper>("duckdb_relation", prot, symdiff);
 }

--- a/tools/rpkg/src/relational.cpp
+++ b/tools/rpkg/src/relational.cpp
@@ -33,6 +33,13 @@ external_pointer<T> make_external(const string &rclass, ARGS &&... args) {
 	return (extptr);
 }
 
+template <typename T, typename... ARGS>
+external_pointer<T> make_external_prot(const string &rclass, SEXP prot, ARGS &&... args) {
+	auto extptr = external_pointer<T>(new T(std::forward<ARGS>(args)...), true, true, prot);
+	((sexp)extptr).attr("class") = rclass;
+	return (extptr);
+}
+
 // DuckDB Expressions
 
 [[cpp11::register]] SEXP rapi_expr_reference(std::string name, std::string table) {
@@ -134,7 +141,7 @@ external_pointer<T> make_external(const string &rclass, ARGS &&... args) {
 	}
 
 	auto res = std::make_shared<ProjectionRelation>(rel->rel, std::move(projections), std::move(aliases));
-	return make_external<RelationWrapper>("duckdb_relation", res);
+	return make_external_prot<RelationWrapper>("duckdb_relation", (sexp)rel, res);
 }
 
 [[cpp11::register]] SEXP rapi_rel_aggregate(duckdb::rel_extptr_t rel, list groups, list aggregates) {

--- a/tools/rpkg/src/reltoaltrep.cpp
+++ b/tools/rpkg/src/reltoaltrep.cpp
@@ -224,7 +224,8 @@ static R_altrep_class_t LogicalTypeToAltrepType(const LogicalType &type) {
 	RProtector r_protector;
 
 	cpp11::external_pointer<AltrepRownamesWrapper> ptr(new AltrepRownamesWrapper(relation_wrapper));
-	auto row_names_sexp = R_new_altrep(RelToAltrep::rownames_class, ptr, rel);
+
+	cpp11::sexp row_names_sexp = R_new_altrep(RelToAltrep::rownames_class, ptr, rel);
 	install_new_attrib(data_frame, R_RowNamesSymbol, row_names_sexp);
 	vector<string> names;
 	for (auto &col : drel->Columns()) {

--- a/tools/rpkg/src/utils.cpp
+++ b/tools/rpkg/src/utils.cpp
@@ -32,9 +32,8 @@ static SEXP cpp_str_to_charsexp(string s) {
 	return cstr_to_charsexp(s.c_str());
 }
 
-SEXP duckdb::StringsToSexp(vector<string> s) {
-	RProtector r;
-	SEXP retsexp = r.Protect(NEW_STRING(s.size()));
+cpp11::strings duckdb::StringsToSexp(vector<string> s) {
+	cpp11::writable::strings retsexp(s.size());
 	for (idx_t i = 0; i < s.size(); i++) {
 		SET_STRING_ELT(retsexp, i, cpp_str_to_charsexp(s[i]));
 	}


### PR DESCRIPTION
Closes #6465.

This adds a tiny change to the vendored cpp11 code, we should eventually upstream it to take advantage of future updates.