### PR TITLE
Remove unswizzle flag from SortedData::Unswizzle

### DIFF
--- a/src/common/sort/sorted_block.cpp
+++ b/src/common/sort/sorted_block.cpp
@@ -70,7 +70,6 @@ void SortedData::Unswizzle() {
 		auto data_handle_p = buffer_manager.Pin(data_block->block);
 		auto heap_handle_p = buffer_manager.Pin(heap_block->block);
 		RowOperations::UnswizzlePointers(layout, data_handle_p.Ptr(), heap_handle_p.Ptr(), data_block->count);
-		data_block->block->SetSwizzling("SortedData::Unswizzle");
 		state.heap_blocks.push_back(std::move(heap_block));
 		state.pinned_blocks.push_back(std::move(heap_handle_p));
 	}


### PR DESCRIPTION
Fixes #6492

The issue was that the flag was set even though all heap blocks were guaranteed to be in memory. This wrongfully triggered an assertion.