### PR TITLE
Move Storage to inner include

### DIFF
--- a/src/common/file_buffer.cpp
+++ b/src/common/file_buffer.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/helper.hpp"
+#include "duckdb/common/storage.hpp"
 
 #include <cstring>
 

--- a/src/include/duckdb/common/constants.hpp
+++ b/src/include/duckdb/common/constants.hpp
@@ -96,21 +96,6 @@ struct DConstants {
 	static constexpr const idx_t INVALID_INDEX = idx_t(-1);
 };
 
-struct Storage {
-	//! The size of a hard disk sector, only really needed for Direct IO
-	constexpr static int SECTOR_SIZE = 4096;
-	//! Block header size for blocks written to the storage
-	constexpr static int BLOCK_HEADER_SIZE = sizeof(uint64_t);
-	// Size of a memory slot managed by the StorageManager. This is the quantum of allocation for Blocks on DuckDB. We
-	// default to 256KB. (1 << 18)
-	constexpr static int BLOCK_ALLOC_SIZE = 262144;
-	//! The actual memory space that is available within the blocks
-	constexpr static int BLOCK_SIZE = BLOCK_ALLOC_SIZE - BLOCK_HEADER_SIZE;
-	//! The size of the headers. This should be small and written more or less atomically by the hard disk. We default
-	//! to the page size, which is 4KB. (1 << 12)
-	constexpr static int FILE_HEADER_SIZE = 4096;
-};
-
 struct LogicalIndex {
 	explicit LogicalIndex(idx_t index) : index(index) {
 	}

--- a/src/include/duckdb/common/storage.hpp
+++ b/src/include/duckdb/common/storage.hpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/storage.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <memory>
+#include <cstdint>
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/winapi.hpp"
+
+namespace duckdb {
+
+struct Storage {
+	//! The size of a hard disk sector, only really needed for Direct IO
+	constexpr static int SECTOR_SIZE = 4096;
+	//! Block header size for blocks written to the storage
+	constexpr static int BLOCK_HEADER_SIZE = sizeof(uint64_t);
+	// Size of a memory slot managed by the StorageManager. This is the quantum of allocation for Blocks on DuckDB. We
+	// default to 256KB. (1 << 18)
+	constexpr static int BLOCK_ALLOC_SIZE = 262144;
+	//! The actual memory space that is available within the blocks
+	constexpr static int BLOCK_SIZE = BLOCK_ALLOC_SIZE - BLOCK_HEADER_SIZE;
+	//! The size of the headers. This should be small and written more or less atomically by the hard disk. We default
+	//! to the page size, which is 4KB. (1 << 12)
+	constexpr static int FILE_HEADER_SIZE = 4096;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include "duckdb/common/enums/profiler_format.hpp"
-#include "duckdb/common/serializer/buffered_file_writer.hpp"
 #include "duckdb/common/winapi.hpp"
 #include "duckdb/function/udf_function.hpp"
 #include "duckdb/main/materialized_query_result.hpp"

--- a/src/include/duckdb/storage/buffer/buffer_handle.hpp
+++ b/src/include/duckdb/storage/buffer/buffer_handle.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "duckdb/storage/storage_info.hpp"
+#include "duckdb/common/common.hpp"
 
 namespace duckdb {
 class BlockHandle;

--- a/src/include/duckdb/storage/storage_info.hpp
+++ b/src/include/duckdb/storage/storage_info.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/vector_size.hpp"
+#include "duckdb/common/storage.hpp"
 
 namespace duckdb {
 class Serializer;

--- a/test/sqlite/sqllogic_command.cpp
+++ b/test/sqlite/sqllogic_command.cpp
@@ -1,6 +1,7 @@
 #include "sqllogic_command.hpp"
 #include "sqllogic_test_runner.hpp"
 #include "result_helper.hpp"
+#include "duckdb/common/serializer/buffered_file_writer.hpp"
 #include "duckdb/main/connection_manager.hpp"
 #include "duckdb/parser/statement/create_statement.hpp"
 #include "duckdb/main/client_data.hpp"


### PR DESCRIPTION
This should make Storage not visible from duckdb.hpp, so that less conflicts like #6504 would happen. Broader idea would be that functions tagged DUCKDB_API should be visible from duckdb.hpp, the rest are just implementation details that can potentially hidden.