### PR TITLE
Test and fix preservation of class attribute in external pointers

### DIFF
--- a/tools/rpkg/inst/include/cpp11/external_pointer.hpp
+++ b/tools/rpkg/inst/include/cpp11/external_pointer.hpp
@@ -68,9 +68,15 @@ class external_pointer {
     data_ = safe[Rf_shallow_duplicate](rhs.data_);
   }
 
-  external_pointer(external_pointer&& rhs) { reset(rhs.release()); }
+  external_pointer(external_pointer&& rhs) {
+    data_ = rhs.data_;
+    rhs.data_ = R_NilValue;
+  }
 
-  external_pointer& operator=(external_pointer&& rhs) noexcept { reset(rhs.release()); }
+  external_pointer& operator=(external_pointer&& rhs) noexcept {
+    data_ = rhs.data_;
+    rhs.data_ = R_NilValue;
+  }
 
   external_pointer& operator=(std::nullptr_t) noexcept { reset(); };
 

--- a/tools/rpkg/src/relational.cpp
+++ b/tools/rpkg/src/relational.cpp
@@ -30,14 +30,14 @@ template <typename T, typename... ARGS>
 external_pointer<T> make_external(const string &rclass, ARGS &&... args) {
 	auto extptr = external_pointer<T>(new T(std::forward<ARGS>(args)...));
 	((sexp)extptr).attr("class") = rclass;
-	return std::move(extptr);
+	return extptr;
 }
 
 template <typename T, typename... ARGS>
 external_pointer<T> make_external_prot(const string &rclass, SEXP prot, ARGS &&... args) {
 	auto extptr = external_pointer<T>(new T(std::forward<ARGS>(args)...), true, true, prot);
 	((sexp)extptr).attr("class") = rclass;
-	return std::move(extptr);
+	return extptr;
 }
 
 // DuckDB Expressions

--- a/tools/rpkg/src/relational.cpp
+++ b/tools/rpkg/src/relational.cpp
@@ -30,14 +30,14 @@ template <typename T, typename... ARGS>
 external_pointer<T> make_external(const string &rclass, ARGS &&... args) {
 	auto extptr = external_pointer<T>(new T(std::forward<ARGS>(args)...));
 	((sexp)extptr).attr("class") = rclass;
-	return (extptr);
+	return std::move(extptr);
 }
 
 template <typename T, typename... ARGS>
 external_pointer<T> make_external_prot(const string &rclass, SEXP prot, ARGS &&... args) {
 	auto extptr = external_pointer<T>(new T(std::forward<ARGS>(args)...), true, true, prot);
 	((sexp)extptr).attr("class") = rclass;
-	return (extptr);
+	return std::move(extptr);
 }
 
 // DuckDB Expressions

--- a/tools/rpkg/tests/testthat/test_relational.R
+++ b/tools/rpkg/tests/testthat/test_relational.R
@@ -1,12 +1,12 @@
-library("DBI")
-library("testthat")
+# Run this file with testthat::test_local(filter = "^relational$")
 
 con <- dbConnect(duckdb())
 on.exit(dbDisconnect(con, shutdown = TRUE))
 
 test_that("we can create a relation from a df", {
-  rel_from_df(con, mtcars)
-  expect_true(TRUE)
+  rel <- rel_from_df(con, mtcars)
+  expect_type(rel, "externalptr")
+  expect_s3_class(rel, "duckdb_relation")
 })
 
 test_that("we won't crash when creating a relation from odd things", {


### PR DESCRIPTION
I wonder why this error seems to occur only on Linux (GCC), not on macOS (clang). Is this a compiler buglet -- should the problem have occurred in clang earlier, but for some reason clang chose to not use the `&&` versions? I tried to trim down the problem and reproduce it, to no avail.

This is the second time we update the vendored cpp11 code, we should upstream eventually.

Closes #6509.