### PR TITLE
Handle SQL-tagged strings correctly with dplyr::tbl, fixes #6506

### DIFF
--- a/tools/rpkg/R/backend-dbplyr__duckdb_connection.R
+++ b/tools/rpkg/R/backend-dbplyr__duckdb_connection.R
@@ -391,7 +391,7 @@ dbplyr_fill0.duckdb_connection <- function(.con, .data, cols_to_fill, order_by_c
 # @param cache Enable object cache for parquet files
 tbl.duckdb_connection <- function(src, from, cache = FALSE, ...) {
   ident_q <- pkg_method("ident_q", "dbplyr")
-  if (!DBI::dbExistsTable(src, from)) from <- ident_q(from)
+  if (!inherits(from, "sql") & !DBI::dbExistsTable(src, from)) from <- ident_q(from)
   if (cache) DBI::dbExecute(src, "PRAGMA enable_object_cache")
   NextMethod("tbl")
 }

--- a/tools/rpkg/tests/testthat/test_tbl__duckdb_connection.R
+++ b/tools/rpkg/tests/testthat/test_tbl__duckdb_connection.R
@@ -63,4 +63,13 @@ test_that("Other replacement scans or functions can be registered with dplyr::tb
   expect_true(obj %>% dplyr::filter(keyword_name == "all") %>% dplyr::count() %>% dplyr::collect() == 1)
 })
 
+test_that("Strings tagged as SQL will be handled correctly with dplyr::tbl()", {
+  con <- DBI::dbConnect(duckdb())
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
+  
+  rs <- dplyr::tbl(con, dplyr::sql("SELECT 1"))
+  expect_true(inherits(rs, "tbl_duckdb_connection"))
+  expect_true(rs %>% dplyr::collect() == 1)
+})
+
 rm(`%>%`)


### PR DESCRIPTION
As demonstrated in #6506, the customised `tbl`-method did not handle strings tagged as SQL correctly. This is fixed by adding a check that skips the custom manipulation for SQL-tagged strings. Also a test was added.