### PR TITLE
CI: Update Swift.yml

### DIFF
--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -1,14 +1,22 @@
 name: Swift
 on:
-  schedule:
-    - cron: "0 2 * * *"
+  workflow_dispatch:
+  repository_dispatch:
   push:
     branches:
       - '**'
       - '!master'
       - '!feature'
+    tags:
+      - '**'
     paths-ignore:
       - '**.md'
+      - 'examples/**'
+      - 'test/**'
+      - 'tools/**'
+      - '!tools/swiftpm/**'
+      - '.github/workflows/**'
+      - '!.github/workflows/Swift.yml'
   pull_request:
     paths-ignore:
       - '**.md'


### PR DESCRIPTION
@tcldr, could you possibly double check on this?

Idea is that now we have repository_dispatch to trigger highly builds (so scheduled / cron is not needed) + it might still be worth checking on releases (even just because) + adding a more extensive path-ignore (this time for pushes inside PRs).