### PR TITLE
[Python] `map` now defaults to original type when analyzed type at bind is NULL

### DIFF
--- a/tools/pythonpkg/src/array_wrapper.cpp
+++ b/tools/pythonpkg/src/array_wrapper.cpp
@@ -535,55 +535,41 @@ RawArrayWrapper::RawArrayWrapper(const LogicalType &type) : data(nullptr), type(
 	}
 }
 
-void RawArrayWrapper::Initialize(idx_t capacity) {
-	string dtype;
+string RawArrayWrapper::DuckDBToNumpyDtype(const LogicalType &type) {
 	switch (type.id()) {
 	case LogicalTypeId::BOOLEAN:
-		dtype = "bool";
-		break;
+		return "bool";
 	case LogicalTypeId::TINYINT:
-		dtype = "int8";
-		break;
+		return "int8";
 	case LogicalTypeId::SMALLINT:
-		dtype = "int16";
-		break;
+		return "int16";
 	case LogicalTypeId::INTEGER:
-		dtype = "int32";
-		break;
+		return "int32";
 	case LogicalTypeId::BIGINT:
-		dtype = "int64";
-		break;
+		return "int64";
 	case LogicalTypeId::UTINYINT:
-		dtype = "uint8";
-		break;
+		return "uint8";
 	case LogicalTypeId::USMALLINT:
-		dtype = "uint16";
-		break;
+		return "uint16";
 	case LogicalTypeId::UINTEGER:
-		dtype = "uint32";
-		break;
+		return "uint32";
 	case LogicalTypeId::UBIGINT:
-		dtype = "uint64";
-		break;
+		return "uint64";
 	case LogicalTypeId::FLOAT:
-		dtype = "float32";
-		break;
+		return "float32";
 	case LogicalTypeId::HUGEINT:
 	case LogicalTypeId::DOUBLE:
 	case LogicalTypeId::DECIMAL:
-		dtype = "float64";
-		break;
+		return "float64";
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_TZ:
 	case LogicalTypeId::TIMESTAMP_NS:
 	case LogicalTypeId::TIMESTAMP_MS:
 	case LogicalTypeId::TIMESTAMP_SEC:
 	case LogicalTypeId::DATE:
-		dtype = "datetime64[ns]";
-		break;
+		return "datetime64[ns]";
 	case LogicalTypeId::INTERVAL:
-		dtype = "timedelta64[ns]";
-		break;
+		return "timedelta64[ns]";
 	case LogicalTypeId::TIME:
 	case LogicalTypeId::TIME_TZ:
 	case LogicalTypeId::VARCHAR:
@@ -593,23 +579,27 @@ void RawArrayWrapper::Initialize(idx_t capacity) {
 	case LogicalTypeId::MAP:
 	case LogicalTypeId::STRUCT:
 	case LogicalTypeId::UUID:
-		dtype = "object";
-		break;
+		return "object";
 	case LogicalTypeId::ENUM: {
 		auto size = EnumType::GetSize(type);
 		if (size <= (idx_t)NumericLimits<int8_t>::Maximum()) {
-			dtype = "int8";
+			return "int8";
 		} else if (size <= (idx_t)NumericLimits<int16_t>::Maximum()) {
-			dtype = "int16";
+			return "int16";
 		} else if (size <= (idx_t)NumericLimits<int32_t>::Maximum()) {
-			dtype = "int32";
+			return "int32";
 		} else {
 			throw InternalException("Size not supported on ENUM types");
 		}
-	} break;
+	}
 	default:
 		throw NotImplementedException("Unsupported type \"%s\"", type.ToString());
 	}
+}
+
+void RawArrayWrapper::Initialize(idx_t capacity) {
+	string dtype = DuckDBToNumpyDtype(type);
+
 	array = py::array(py::dtype(dtype), capacity);
 	data = (data_ptr_t)array.mutable_data();
 }

--- a/tools/pythonpkg/src/include/duckdb_python/array_wrapper.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/array_wrapper.hpp
@@ -13,6 +13,7 @@
 
 namespace duckdb {
 struct RawArrayWrapper {
+
 	explicit RawArrayWrapper(const LogicalType &type);
 
 	py::array array;
@@ -22,6 +23,7 @@ struct RawArrayWrapper {
 	idx_t count;
 
 public:
+	static string DuckDBToNumpyDtype(const LogicalType &type);
 	void Initialize(idx_t capacity);
 	void Resize(idx_t new_capacity);
 	void Append(idx_t current_offset, Vector &input, idx_t count);

--- a/tools/pythonpkg/tests/fast/test_map.py
+++ b/tools/pythonpkg/tests/fast/test_map.py
@@ -25,7 +25,7 @@ class TestMap(object):
         # column type differs from bind
         def evil2(df):
             if len(df) == 0:
-                df['col0'] = df['col0'].astype('string')
+                df['col0'] = df['col0'].astype('int')
             return df
 
         # column name differs from bind
@@ -89,6 +89,16 @@ class TestMap(object):
 
         with pytest.raises(duckdb.InvalidInputException, match='Need a DataFrame with at least one column'):
             testrel.map(return_empty_df).df()
+
+    def test_map_with_object_column(self, duckdb_cursor):
+        def return_with_no_modification(df):
+            return df
+
+        # BLOB maps to 'object'
+        # when a dataframe with 'object' column is returned, we use the content to infer the type
+        # when the dataframe is empty, this results in NULL, which is not desirable
+        # in this case we assume the returned type should be the same as the input type
+        duckdb_cursor.values([b'1234']).map(return_with_no_modification).fetchall()
 
     def test_isse_3237(self, duckdb_cursor):
         def process(rel):


### PR DESCRIPTION
This PR fixes #6532 

There are two main causes for this issue:
- When mapping LogicalType to dtype, our options are too limited, so we have to result to `object`.
- When converting a column from a dataframe with the 'object' dtype, we have to analyze the contents to determine the LogicalType, when this is empty the result is NULL.

In the bind of `map`, we call the UDF with a zero-row dataframe.
When the user calls map on a dataset that contains types that map to 'object':
```c++
	case LogicalTypeId::TIME:
	case LogicalTypeId::TIME_TZ:
	case LogicalTypeId::VARCHAR:
	case LogicalTypeId::BIT:
	case LogicalTypeId::BLOB:
	case LogicalTypeId::LIST:
	case LogicalTypeId::MAP:
	case LogicalTypeId::STRUCT:
	case LogicalTypeId::UUID:
		return "object";
```
And this dataframe is then returned to us, with no content, the resulting type is NULL.
We now override this returned NULL type when we can infer from the original types/names what it should be.