### PR TITLE
CI: Node.js, remove hardcoded 'upload' step

### DIFF
--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Setup
         shell: bash
-        run: ./scripts/node_version.sh upload
+        run: ./scripts/node_version.sh
         env:
           DUCKDB_NODE_BUILD_CACHE: 0  # create a standalone package
           NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}


### PR DESCRIPTION
Currently nighly Node.js builds are broken, I am unsure of this fix, since haven't found a proper way to test.