### PR TITLE
Add support for named parameters in the API

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -1711,6 +1711,16 @@ Adds a parameter to the table function.
 DUCKDB_API void duckdb_table_function_add_parameter(duckdb_table_function table_function, duckdb_logical_type type);
 
 /*!
+Adds a named parameter to the table function.
+
+* table_function: The table function
+* name: The name of the parameter
+* type: The type of the parameter to add.
+*/
+DUCKDB_API void duckdb_table_function_add_named_parameter(duckdb_table_function table_function, const char *name,
+                                                          duckdb_logical_type type);
+
+/*!
 Assigns extra information to the table function that can be fetched during binding, etc.
 
 * table_function: The table function
@@ -1817,6 +1827,17 @@ The result must be destroyed with `duckdb_destroy_value`.
 * returns: The value of the parameter. Must be destroyed with `duckdb_destroy_value`.
 */
 DUCKDB_API duckdb_value duckdb_bind_get_parameter(duckdb_bind_info info, idx_t index);
+
+/*!
+Retrieves a named parameter with the given name.
+
+The result must be destroyed with `duckdb_destroy_value`.
+
+* info: The info object
+* name: The name of the parameter
+* returns: The value of the parameter. Must be destroyed with `duckdb_destroy_value`.
+*/
+DUCKDB_API duckdb_value duckdb_bind_get_named_parameter(duckdb_bind_info info, const char *name);
 
 /*!
 Sets the user-provided bind data in the bind object. This object can be retrieved again during execution.

--- a/src/main/capi/table_function-c.cpp
+++ b/src/main/capi/table_function-c.cpp
@@ -208,6 +208,16 @@ void duckdb_table_function_add_parameter(duckdb_table_function function, duckdb_
 	tf->arguments.push_back(*logical_type);
 }
 
+void duckdb_table_function_add_named_parameter(duckdb_table_function function, const char *name,
+                                               duckdb_logical_type type) {
+	if (!function || !type) {
+		return;
+	}
+	auto tf = (duckdb::TableFunction *)function;
+	auto logical_type = (duckdb::LogicalType *)type;
+	tf->named_parameters.insert({name, *logical_type});
+}
+
 void duckdb_table_function_set_extra_info(duckdb_table_function function, void *extra_info,
                                           duckdb_delete_callback_t destroy) {
 	if (!function) {
@@ -317,6 +327,19 @@ duckdb_value duckdb_bind_get_parameter(duckdb_bind_info info, idx_t index) {
 	}
 	auto bind_info = (duckdb::CTableInternalBindInfo *)info;
 	return reinterpret_cast<duckdb_value>(new duckdb::Value(bind_info->input.inputs[index]));
+}
+
+duckdb_value duckdb_bind_get_named_parameter(duckdb_bind_info info, const char *name) {
+	if (!info || !name) {
+		return nullptr;
+	}
+	auto bind_info = (duckdb::CTableInternalBindInfo *)info;
+	auto t = bind_info->input.named_parameters.find(name);
+	if (t == bind_info->input.named_parameters.end()) {
+		return nullptr;
+	} else {
+		return reinterpret_cast<duckdb_value>(new duckdb::Value(t->second));
+	}
 }
 
 void duckdb_bind_set_bind_data(duckdb_bind_info info, void *bind_data, duckdb_delete_callback_t destroy) {

--- a/test/api/capi/capi_table_functions.cpp
+++ b/test/api/capi/capi_table_functions.cpp
@@ -67,6 +67,11 @@ static void capi_register_table_function(duckdb_connection connection, const cha
 	duckdb_table_function_add_parameter(function, type);
 	duckdb_destroy_logical_type(&type);
 
+	// add a named parameter
+	duckdb_logical_type itype = duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
+	duckdb_table_function_add_named_parameter(function, "my_parameter", itype);
+	duckdb_destroy_logical_type(&itype);
+
 	// set up the function pointers
 	duckdb_table_function_set_bind(function, bind);
 	duckdb_table_function_set_init(function, init);
@@ -90,6 +95,10 @@ TEST_CASE("Test Table Functions C API", "[capi]") {
 
 	// now call it
 	result = tester.Query("SELECT * FROM my_function(1)");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->Fetch<int64_t>(0, 0) == 42);
+
+	result = tester.Query("SELECT * FROM my_function(1, my_parameter=3)");
 	REQUIRE_NO_FAIL(*result);
 	REQUIRE(result->Fetch<int64_t>(0, 0) == 42);
 

--- a/test/api/capi/capi_table_functions.cpp
+++ b/test/api/capi/capi_table_functions.cpp
@@ -200,7 +200,7 @@ void my_named_function(duckdb_function_info info, duckdb_data_chunk output) {
 		if (init_data->pos >= bind_data->size) {
 			break;
 		}
-		ptr[i] = init_data->pos % 2 == 0 ? (42*bind_data->multiplier) : (84*bind_data->multiplier);
+		ptr[i] = init_data->pos % 2 == 0 ? (42 * bind_data->multiplier) : (84 * bind_data->multiplier);
 		init_data->pos++;
 	}
 	duckdb_data_chunk_set_size(output, i);
@@ -211,7 +211,8 @@ TEST_CASE("Test Table Function named parameters in C API", "[capi]") {
 	unique_ptr<CAPIResult> result;
 
 	REQUIRE(tester.OpenDatabase(nullptr));
-	capi_register_table_function(tester.connection, "my_multiplier_function", my_named_bind, my_named_init, my_named_function);
+	capi_register_table_function(tester.connection, "my_multiplier_function", my_named_bind, my_named_init,
+	                             my_named_function);
 
 	result = tester.Query("SELECT * FROM my_multiplier_function(3)");
 	REQUIRE_NO_FAIL(*result);

--- a/test/api/capi/capi_table_functions.cpp
+++ b/test/api/capi/capi_table_functions.cpp
@@ -68,7 +68,7 @@ static void capi_register_table_function(duckdb_connection connection, const cha
 	duckdb_destroy_logical_type(&type);
 
 	// add a named parameter
-	duckdb_logical_type itype = duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
+	duckdb_logical_type itype = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
 	duckdb_table_function_add_named_parameter(function, "my_parameter", itype);
 	duckdb_destroy_logical_type(&itype);
 
@@ -101,6 +101,11 @@ TEST_CASE("Test Table Functions C API", "[capi]") {
 	result = tester.Query("SELECT * FROM my_function(1, my_parameter=3)");
 	REQUIRE_NO_FAIL(*result);
 	REQUIRE(result->Fetch<int64_t>(0, 0) == 42);
+
+	result = tester.Query("SELECT * FROM my_function(1, my_parameter=\"val\")");
+	REQUIRE(result->HasError());
+	result = tester.Query("SELECT * FROM my_function(1, nota_parameter=\"val\")");
+	REQUIRE(result->HasError());
 
 	result = tester.Query("SELECT * FROM my_function(3)");
 	REQUIRE_NO_FAIL(*result);
@@ -146,4 +151,81 @@ TEST_CASE("Test Table Function errors in C API", "[capi]") {
 	REQUIRE(result->HasError());
 	result = tester.Query("SELECT * FROM my_error_function(1)");
 	REQUIRE(result->HasError());
+}
+
+struct my_named_bind_data_struct {
+	int64_t size;
+	int64_t multiplier;
+};
+
+void my_named_bind(duckdb_bind_info info) {
+	REQUIRE(duckdb_bind_get_parameter_count(info) == 1);
+
+	duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
+	duckdb_bind_add_result_column(info, "forty_two", type);
+	duckdb_destroy_logical_type(&type);
+
+	auto my_bind_data = (my_named_bind_data_struct *)malloc(sizeof(my_named_bind_data_struct));
+
+	auto param = duckdb_bind_get_parameter(info, 0);
+	my_bind_data->size = duckdb_get_int64(param);
+	duckdb_destroy_value(&param);
+
+	auto nparam = duckdb_bind_get_named_parameter(info, "my_parameter");
+	if (nparam) {
+		my_bind_data->multiplier = duckdb_get_int64(nparam);
+	} else {
+		my_bind_data->multiplier = 1;
+	}
+	duckdb_destroy_value(&nparam);
+
+	duckdb_bind_set_bind_data(info, my_bind_data, free);
+}
+
+void my_named_init(duckdb_init_info info) {
+	REQUIRE(duckdb_init_get_bind_data(info) != nullptr);
+	REQUIRE(duckdb_init_get_bind_data(nullptr) == nullptr);
+
+	auto my_init_data = (my_init_data_struct *)malloc(sizeof(my_init_data_struct));
+	my_init_data->pos = 0;
+	duckdb_init_set_init_data(info, my_init_data, free);
+}
+
+void my_named_function(duckdb_function_info info, duckdb_data_chunk output) {
+	auto bind_data = (my_named_bind_data_struct *)duckdb_function_get_bind_data(info);
+	auto init_data = (my_init_data_struct *)duckdb_function_get_init_data(info);
+	auto ptr = (int64_t *)duckdb_vector_get_data(duckdb_data_chunk_get_vector(output, 0));
+	idx_t i;
+	for (i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+		if (init_data->pos >= bind_data->size) {
+			break;
+		}
+		ptr[i] = init_data->pos % 2 == 0 ? (42*bind_data->multiplier) : (84*bind_data->multiplier);
+		init_data->pos++;
+	}
+	duckdb_data_chunk_set_size(output, i);
+}
+
+TEST_CASE("Test Table Function named parameters in C API", "[capi]") {
+	CAPITester tester;
+	unique_ptr<CAPIResult> result;
+
+	REQUIRE(tester.OpenDatabase(nullptr));
+	capi_register_table_function(tester.connection, "my_multiplier_function", my_named_bind, my_named_init, my_named_function);
+
+	result = tester.Query("SELECT * FROM my_multiplier_function(3)");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->Fetch<int64_t>(0, 0) == 42);
+	REQUIRE(result->Fetch<int64_t>(0, 1) == 84);
+	REQUIRE(result->Fetch<int64_t>(0, 2) == 42);
+
+	result = tester.Query("SELECT * FROM my_multiplier_function(2, my_parameter=2)");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->Fetch<int64_t>(0, 0) == 84);
+	REQUIRE(result->Fetch<int64_t>(0, 1) == 168);
+
+	result = tester.Query("SELECT * FROM my_multiplier_function(2, my_parameter=3)");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->Fetch<int64_t>(0, 0) == 126);
+	REQUIRE(result->Fetch<int64_t>(0, 1) == 252);
 }


### PR DESCRIPTION
Currently, extensions set named parameters directly on the TableFunction object. For rust-based extensions, I'm not sure this is easily doable, so this PR adds two new APIs `duckdb_table_function_add_named_parameter` and `duckdb_bind_get_named_parameter`.