### PR TITLE
[Dev] Fix broken `test_filesystem.py` test

### DIFF
--- a/tools/pythonpkg/tests/fast/test_filesystem.py
+++ b/tools/pythonpkg/tests/fast/test_filesystem.py
@@ -142,10 +142,6 @@ class TestPythonFilesystem:
     def test_arrow_fs_wrapper(self, tmp_path: Path, duckdb_cursor: DuckDBPyConnection):
         fs = importorskip('pyarrow.fs')
         from fsspec.implementations.arrow import ArrowFSWrapper
-        class ExtendedArrowFSWrapper(ArrowFSWrapper):
-            protocol = ('local')
-            # defer to the original implementation that doesn't hardcode the protocol
-            _strip_protocol = classmethod(AbstractFileSystem._strip_protocol.__func__)
 
         local = fs.LocalFileSystem()
         local_fsspec = ArrowFSWrapper(local, skip_instance_cache=True)

--- a/tools/pythonpkg/tests/fast/test_filesystem.py
+++ b/tools/pythonpkg/tests/fast/test_filesystem.py
@@ -148,7 +148,7 @@ class TestPythonFilesystem:
             _strip_protocol = classmethod(AbstractFileSystem._strip_protocol.__func__)
 
         local = fs.LocalFileSystem()
-        local_fsspec = ExtendedArrowFSWrapper(local, skip_instance_cache=True)
+        local_fsspec = ArrowFSWrapper(local, skip_instance_cache=True)
         # posix calls here required as ArrowFSWrapper only supports url-like paths (not Windows paths)
         filename = str(PurePosixPath(tmp_path.as_posix()) / "test.csv")
         with local_fsspec.open(filename, mode='w') as f:


### PR DESCRIPTION
In the latest version of `fsspec` it's no longer allowed to set the `protocol` property of the ArrowFSWrapper class.
So we need to derive from it, similar to what we do for the MemoryFileSystem