### PR TITLE
Fix #4016: Test amalgamation with --split param

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -726,3 +726,10 @@ jobs:
       run:  |
           python scripts/amalgamation.py --extended
           clang++ -std=c++17 -Isrc/amalgamation src/amalgamation/duckdb.cpp -emit-llvm -S -O0
+
+    - name: Generate Amalgamation x8
+      shell: bash
+      run:  |
+          python scripts/amalgamation.py --extended --splits=8
+          clang++ -std=c++17 -Isrc/amalgamation src/amalgamation/duckdb*.cpp -emit-llvm -S -O0
+          clang++ *.ll -O0 -v  -Wl,-bundle

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -721,15 +721,15 @@ jobs:
       with:
         version: "10.0"
 
-    - name: Generate Amalgamation
-      shell: bash
-      run:  |
-          python scripts/amalgamation.py --extended
-          clang++ -std=c++17 -Isrc/amalgamation src/amalgamation/duckdb.cpp -emit-llvm -S -O0
-
     - name: Generate Amalgamation x8
       shell: bash
       run:  |
           python scripts/amalgamation.py --extended --splits=8
           clang++ -std=c++17 -Isrc/amalgamation src/amalgamation/duckdb*.cpp -emit-llvm -S -O0
           clang++ *.ll -O0 -v  -Wl,-bundle
+
+    - name: Generate Amalgamation
+      shell: bash
+      run:  |
+          python scripts/amalgamation.py --extended
+          clang++ -std=c++17 -Isrc/amalgamation src/amalgamation/duckdb.cpp -emit-llvm -S -O0

--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -518,8 +518,9 @@ if __name__ == "__main__":
             include_dirs = list_include_dirs()
             print('\n'.join(include_dirs))
             exit(1)
-    if not os.path.exists(amal_dir):
-        os.makedirs(amal_dir)
+    if os.path.exists(amal_dir):
+        shutil.rmtree(amal_dir)
+    os.makedirs(amal_dir)
 
     if nsplits > 1:
         generate_amalgamation_splits(source_file, header_file, nsplits)


### PR DESCRIPTION
Plus also clean up src/amalgamation before rebuilding, since older files, like duckdb.cpp may pollute it