### PR TITLE
Fix TPC-DS date insertion

### DIFF
--- a/extension/tpcds/dsdgen/append_info-c.cpp
+++ b/extension/tpcds/dsdgen/append_info-c.cpp
@@ -62,11 +62,15 @@ void append_boolean(append_info info, int32_t value) {
 // value is a Julian date
 // FIXME: direct int conversion, offsets should be constant
 void append_date(append_info info, int64_t value) {
-	date_t dTemp;
-	jtodt(&dTemp, (int)value);
-	auto ddate = duckdb::Date::FromDate(dTemp.year, dTemp.month, dTemp.day);
 	auto append_info = (tpcds_append_information *)info;
-	append_info->appender.Append<duckdb::date_t>(ddate);
+	if (value < 0) {
+		append_info->appender.Append(nullptr);
+	} else {
+		date_t dTemp;
+		jtodt(&dTemp, (int)value);
+		auto ddate = duckdb::Date::FromDate(dTemp.year, dTemp.month, dTemp.day);
+		append_info->appender.Append<duckdb::date_t>(ddate);
+	}
 }
 
 void append_decimal(append_info info, decimal_t *val) {


### PR DESCRIPTION
In case where a date field is optional (e.g. `cc_rec_end_date_id` in `dsdgen-c`), the wrong date is being inserted when calling `append_date`. The `jtodt` method called within `append_date` does not write to its `date_t` output parameter when the input value is negative (i.e. optional), leaving `dTemp` uninitialized.

Funnily enough the `append_date` method did not fail because it always first got called with a valid date (e.g. a non-optional `start_date`), and the subsequent call with `-1` for `end_date` would then have `dTemp` use the value from the previous call, inserting `start_date` as value for `end_date` instead.