### PR TITLE
Add support for regexp matches in relational API

### DIFF
--- a/tools/rpkg/src/database.cpp
+++ b/tools/rpkg/src/database.cpp
@@ -73,7 +73,7 @@ static bool CastRstringToVarchar(Vector &source, Vector &result, idx_t count, Ca
 	auto &runtime_config = DBConfig::GetConfig(context);
 
 	auto &casts = runtime_config.GetCastFunctions();
-	casts.RegisterCastFunction(RStringsType::Get(), LogicalType::VARCHAR, CastRstringToVarchar);
+	casts.RegisterCastFunction(RStringsType::Get(), LogicalType::VARCHAR, CastRstringToVarchar, 100);
 
 	context.transaction.Commit();
 

--- a/tools/rpkg/src/reltoaltrep.cpp
+++ b/tools/rpkg/src/reltoaltrep.cpp
@@ -210,7 +210,7 @@ static R_altrep_class_t LogicalTypeToAltrepType(const LogicalType &type) {
 		return RelToAltrep::string_class;
 	default:
 		// custom string cast for R strings.
-		if (type.HasAlias() && type.GetAlias() == "r_string") {
+		if (type.HasAlias() && type.GetAlias() == R_STRING_TYPE_NAME) {
 			return RelToAltrep::string_class;
 		}
 

--- a/tools/rpkg/src/reltoaltrep.cpp
+++ b/tools/rpkg/src/reltoaltrep.cpp
@@ -209,6 +209,11 @@ static R_altrep_class_t LogicalTypeToAltrepType(const LogicalType &type) {
 	case LogicalTypeId::UUID:
 		return RelToAltrep::string_class;
 	default:
+		// custom string cast for R strings.
+		if (type.HasAlias() && type.GetAlias() == "r_string") {
+			return RelToAltrep::string_class;
+		}
+
 		cpp11::stop("rel_to_altrep: Unknown column type for altrep: %s", type.ToString().c_str());
 	}
 }

--- a/tools/rpkg/tests/testthat/test_register.R
+++ b/tools/rpkg/tests/testthat/test_register.R
@@ -74,8 +74,17 @@ test_that("experimental string handling works", {
   on.exit(dbDisconnect(con, shutdown = TRUE))
   df <- data.frame(a=c(NA, as.character(1:10000)))
 
- duckdb_register(con, "df", df, experimental=TRUE)
+  duckdb_register(con, "df", df, experimental=TRUE)
 
   expect_equal(df, dbGetQuery(con, "SELECT a::STRING a FROM df"))
   expect_equal(df, dbGetQuery(con, "SELECT a FROM df"))
+})
+
+
+test_that("We can perform regex functions on R strings ", {
+  con <- dbConnect(duckdb())
+  df <- data.frame(a=c("Hello", "World"), stringsAsFactors=FALSE)
+  duckdb_register(con,"df3", df, experimental=TRUE)
+  expected_df <- data.frame(a=c("Hello"))
+  expect_equal(expected_df, dbGetQuery(con, "SELECT * FROM df3 WHERE regexp_matches(a, 'He.*')"))
 })

--- a/tools/rpkg/tests/testthat/test_register.R
+++ b/tools/rpkg/tests/testthat/test_register.R
@@ -67,8 +67,6 @@ test_that("uppercase data frames are queryable", {
   duckdb_unregister(con, "My_Mtcars")
 })
 
-
-
 test_that("experimental string handling works", {
   con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
@@ -79,7 +77,6 @@ test_that("experimental string handling works", {
   expect_equal(df, dbGetQuery(con, "SELECT a::STRING a FROM df"))
   expect_equal(df, dbGetQuery(con, "SELECT a FROM df"))
 })
-
 
 test_that("We can perform regex functions on R strings ", {
   con <- dbConnect(duckdb())


### PR DESCRIPTION
If users wish to perform regex matches on R strings, we need to be able to implicitly cast r_string types to VARCHARS. To do this we add a cost to the `RegisterCastFunction`. We add a high cost since it is an expensive cast, however, it is the only cast available. 

A test has also been added.