### PR TITLE
Issue #6595: N-Ary Positional Joins

### DIFF
--- a/benchmark/micro/join/nary_positional_join.benchmark
+++ b/benchmark/micro/join/nary_positional_join.benchmark
@@ -1,0 +1,35 @@
+# name: benchmark/micro/join/nary_positional_join.benchmark
+# description: Range self-join between random numbers
+# group: [join]
+
+name N-Ary Positional Join
+group join
+
+require tpch
+
+cache tpch_sf1_positional.duckdb
+
+load
+CALL dbgen(sf=1, suffix='_positional');
+CREATE VIEW lineitem AS (SELECT * FROM
+	(SELECT l_returnflag FROM lineitem_positional)
+	POSITIONAL JOIN
+	(SELECT l_linestatus FROM lineitem_positional)
+	POSITIONAL JOIN
+	(SELECT l_quantity FROM lineitem_positional)
+	POSITIONAL JOIN
+	(SELECT l_extendedprice FROM lineitem_positional)
+	POSITIONAL JOIN
+	(SELECT l_discount FROM lineitem_positional)
+	POSITIONAL JOIN
+	(SELECT l_tax FROM lineitem_positional)
+	POSITIONAL JOIN
+	(SELECT l_shipdate FROM lineitem_positional)
+)
+
+run
+PRAGMA tpch(1)
+
+result extension/tpch/dbgen/answers/sf1/q01.csv
+
+#<FILE>:extension/tpch/dbgen/answers/sf1/q01.csv


### PR DESCRIPTION
PhysicalPositionalScan is an n-ary operator but the planner was only using it as a binary operator. Fixing this results in a 10% performance improvement on the DSM version of TPC-H Q01 (0.27s vs 0.31s).