### PR TITLE
Add httpfs config to support packaging it as an extension

### DIFF
--- a/extension/httpfs/httpfs_config.py
+++ b/extension/httpfs/httpfs_config.py
@@ -1,0 +1,5 @@
+import os
+# list all include directories
+include_directories = [os.path.sep.join(x.split('/')) for x in ['extension/httpfs/include', 'third_party/httplib', 'extension/parquet/include']]
+# source files
+source_files = [os.path.sep.join(x.split('/')) for x in ['extension/httpfs/' + s for s in ['httpfs-extension.cpp', 'httpfs.cpp', 's3fs.cpp', 'crypto.cpp']]]


### PR DESCRIPTION
This change follows the convention used by other extensions, like parquet, to list out the relevant files for compilation. It is used by the Rust library (https://github.com/wangfenjin/duckdb-rs/pull/127) to bundle in the HTTPFS extension.