### PR TITLE
Remove some function calls that can throw potential false positives in CI

### DIFF
--- a/tools/rpkg/R/register.R
+++ b/tools/rpkg/R/register.R
@@ -40,7 +40,6 @@ encode_values <- function(value) {
 #' dbReadTable(con, "data")
 #'
 #' duckdb_unregister(con, "data")
-#' try(dbReadTable(con, "data"))
 #'
 #' dbDisconnect(con)
 duckdb_register <- function(conn, name, df, overwrite = FALSE, experimental = FALSE) {

--- a/tools/rpkg/man/duckdb_register.Rd
+++ b/tools/rpkg/man/duckdb_register.Rd
@@ -40,7 +40,6 @@ duckdb_register(con, "data", data)
 dbReadTable(con, "data")
 
 duckdb_unregister(con, "data")
-try(dbReadTable(con, "data"))
 
 dbDisconnect(con)
 }


### PR DESCRIPTION
Currently the R check can throw some errors that aren't really errors. This PR removes some noise. From this
![image](https://user-images.githubusercontent.com/6248601/223716965-175db465-5a7a-4335-8e00-9aea62e99bcf.png)

to this
![image](https://user-images.githubusercontent.com/6248601/223717111-b151ca75-c19d-41bc-ad76-b7645f4ff1de.png)
