### PR TITLE
[R] Remove duplicate occurrence of dependency

### DIFF
--- a/tools/rpkg/dependencies.R
+++ b/tools/rpkg/dependencies.R
@@ -1,5 +1,5 @@
 local({
-  pkg <- c("DBI", "callr", "DBItest", "dbplyr", "testthat", "bit64", "cpp11", "arrow", "covr", "pkgbuild", "remotes", "bit64")
+  pkg <- c("DBI", "callr", "DBItest", "dbplyr", "testthat", "bit64", "cpp11", "arrow", "covr", "pkgbuild", "remotes")
 
   if (.Platform$OS.type == "unix") {
     options(HTTPUserAgent = sprintf("R/4.1.0 R (4.1.0 %s)", paste(R.version$platform, R.version$arch, R.version$os)))


### PR DESCRIPTION
This change was needed by the substrait extension.

In the CI of that extension we build on R on Mac, and this seems to have caused our CI to fail
(previously we did not use duckdb core `dependencies.R`, but it's better that we do, since we don't add any dependencies anyways)