### PR TITLE
Extend sqllogictest for unpritable and control charater

### DIFF
--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -359,13 +359,12 @@ string TestResultHelper::SQLLogicTestConvertValue(Value value, LogicalType sql_t
 			if (str.empty()) {
 				return "(empty)";
 			} else {
-				idx_t start_pos = 0;
-				string to("\\0");
 				for (size_t i = 0; i < str.size(); ++i) {
 					if (str[i] < ' ' || str[i] > '`') {
-						to[2] = str[i];
-						str.replace(start_pos, 1, to);
-                        start_pos += to.size();
+                        string to("\\");
+                        to += std::to_string((int)str[i]);
+						str.replace(i, 1, to);
+						i += to.size() - 1;
 					}
 				}
 				return str;

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -361,8 +361,8 @@ string TestResultHelper::SQLLogicTestConvertValue(Value value, LogicalType sql_t
 			} else {
 				for (size_t i = 0; i < str.size(); ++i) {
 					if (str[i] < ' ' || str[i] > '`') {
-                        string to("\\");
-                        to += std::to_string((int)str[i]);
+						string to("\\");
+						to += std::to_string((int)str[i]);
 						str.replace(i, 1, to);
 						i += to.size() - 1;
 					}

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -365,6 +365,7 @@ string TestResultHelper::SQLLogicTestConvertValue(Value value, LogicalType sql_t
 					if (str[i] < ' ' || str[i] > '`') {
 						to[2] = str[i];
 						str.replace(start_pos, 1, to);
+                        start_pos += to.size();
 					}
 				}
 				return str;

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -359,7 +359,15 @@ string TestResultHelper::SQLLogicTestConvertValue(Value value, LogicalType sql_t
 			if (str.empty()) {
 				return "(empty)";
 			} else {
-				return StringUtil::Replace(str, string("\0", 1), "\\0");
+				idx_t start_pos = 0;
+				string to("\\0");
+				for (size_t i = 0; i < str.size(); ++i) {
+					if (str[i] < ' ' || str[i] > '`') {
+						to[2] = str[i];
+						str.replace(start_pos, 1, to);
+					}
+				}
+				return str;
 			}
 		}
 		}


### PR DESCRIPTION
#6579  I need this to test
`query I`
 `SELECT '\x7F'::BLOB`
`----`
`\127`