### PR TITLE
R: Remove RProtector class

### DIFF
--- a/tools/rpkg/src/include/rapi.hpp
+++ b/tools/rpkg/src/include/rapi.hpp
@@ -168,5 +168,5 @@ SEXP rapi_record_batch(duckdb::rqry_eptr_t, int);
 cpp11::r_string rapi_ptr_to_str(SEXP extptr);
 
 void duckdb_r_transform(duckdb::Vector &src_vec, SEXP dest, duckdb::idx_t dest_offset, duckdb::idx_t n, bool integer64);
-SEXP duckdb_r_allocate(const duckdb::LogicalType &type, duckdb::RProtector &r_varvalue, duckdb::idx_t nrows);
+SEXP duckdb_r_allocate(const duckdb::LogicalType &type, duckdb::idx_t nrows);
 void duckdb_r_decorate(const duckdb::LogicalType &type, SEXP dest, bool integer64);

--- a/tools/rpkg/src/include/rapi.hpp
+++ b/tools/rpkg/src/include/rapi.hpp
@@ -72,24 +72,6 @@ struct RStringsType {
 	static LogicalType Get();
 };
 
-struct RProtector {
-	RProtector() : protect_count(0) {
-	}
-	~RProtector() {
-		if (protect_count > 0) {
-			UNPROTECT(protect_count);
-		}
-	}
-
-	SEXP Protect(SEXP sexp) {
-		protect_count++;
-		return PROTECT(sexp);
-	}
-
-private:
-	int protect_count;
-};
-
 struct DataFrameScanFunction : public TableFunction {
 	DataFrameScanFunction();
 };

--- a/tools/rpkg/src/register.cpp
+++ b/tools/rpkg/src/register.cpp
@@ -154,12 +154,11 @@ private:
 	static SEXP TransformChildFilters(SEXP functions, const string &column_name, const string op,
 	                                  vector<unique_ptr<TableFilter>> &filters, string &timezone_config) {
 		auto fit = filters.begin();
-		RProtector r;
-		auto conjunction_sexp = r.Protect(TransformFilterExpression(**fit, column_name, functions, timezone_config));
+		cpp11::sexp conjunction_sexp = TransformFilterExpression(**fit, column_name, functions, timezone_config);
 		fit++;
 		for (; fit != filters.end(); ++fit) {
-			SEXP rhs = r.Protect(TransformFilterExpression(**fit, column_name, functions, timezone_config));
-			conjunction_sexp = r.Protect(CreateExpression(functions, op, conjunction_sexp, rhs));
+			cpp11::sexp rhs = TransformFilterExpression(**fit, column_name, functions, timezone_config);
+			conjunction_sexp = CreateExpression(functions, op, conjunction_sexp, rhs);
 		}
 		return conjunction_sexp;
 	}

--- a/tools/rpkg/src/register.cpp
+++ b/tools/rpkg/src/register.cpp
@@ -95,15 +95,14 @@ public:
 private:
 	static SEXP TransformFilterExpression(TableFilter &filter, const string &column_name, SEXP functions,
 	                                      string &timezone_config) {
-		RProtector r;
-		auto column_name_sexp = r.Protect(Rf_mkString(column_name.c_str()));
-		auto column_name_expr = r.Protect(CreateFieldRef(functions, column_name_sexp));
+		cpp11::sexp column_name_sexp = Rf_mkString(column_name.c_str());
+		cpp11::sexp column_name_expr = CreateFieldRef(functions, column_name_sexp);
 
 		switch (filter.filter_type) {
 		case TableFilterType::CONSTANT_COMPARISON: {
 			auto constant_filter = (ConstantFilter &)filter;
-			auto constant_sexp = r.Protect(RApiTypes::ValueToSexp(constant_filter.constant, timezone_config));
-			auto constant_expr = r.Protect(CreateScalar(functions, constant_sexp));
+			cpp11::sexp constant_sexp = RApiTypes::ValueToSexp(constant_filter.constant, timezone_config);
+			cpp11::sexp constant_expr = CreateScalar(functions, constant_sexp);
 			switch (constant_filter.comparison_type) {
 			case ExpressionType::COMPARE_EQUAL: {
 				return CreateExpression(functions, "equal", column_name_expr, constant_expr);
@@ -132,7 +131,7 @@ private:
 			return CreateExpression(functions, "is_null", column_name_expr);
 		}
 		case TableFilterType::IS_NOT_NULL: {
-			auto is_null_expr = r.Protect(CreateExpression(functions, "is_null", column_name_expr));
+			cpp11::sexp is_null_expr = CreateExpression(functions, "is_null", column_name_expr);
 			return CreateExpression(functions, "invert", is_null_expr);
 		}
 		case TableFilterType::CONJUNCTION_AND: {

--- a/tools/rpkg/src/register.cpp
+++ b/tools/rpkg/src/register.cpp
@@ -78,11 +78,10 @@ public:
 
 	static void GetSchema(uintptr_t factory_p, ArrowSchemaWrapper &schema) {
 
-		RProtector r;
 		auto res = make_unique<ArrowArrayStreamWrapper>();
 		auto factory = (RArrowTabularStreamFactory *)factory_p;
-		auto schema_ptr_sexp =
-		    r.Protect(Rf_ScalarReal(static_cast<double>(reinterpret_cast<uintptr_t>(&schema.arrow_schema))));
+		cpp11::sexp schema_ptr_sexp =
+		    Rf_ScalarReal(static_cast<double>(reinterpret_cast<uintptr_t>(&schema.arrow_schema)));
 
 		cpp11::function export_fun = VECTOR_ELT(factory->export_fun, 4);
 

--- a/tools/rpkg/src/register.cpp
+++ b/tools/rpkg/src/register.cpp
@@ -165,15 +165,12 @@ private:
 
 	static SEXP TransformFilter(TableFilterSet &filter_collection, std::unordered_map<idx_t, string> &columns,
 	                            SEXP functions, string &timezone_config) {
-		RProtector r;
-
 		auto fit = filter_collection.filters.begin();
-		SEXP res = r.Protect(TransformFilterExpression(*fit->second, columns[fit->first], functions, timezone_config));
+		cpp11::sexp res = TransformFilterExpression(*fit->second, columns[fit->first], functions, timezone_config);
 		fit++;
 		for (; fit != filter_collection.filters.end(); ++fit) {
-			SEXP rhs =
-			    r.Protect(TransformFilterExpression(*fit->second, columns[fit->first], functions, timezone_config));
-			res = r.Protect(CreateExpression(functions, "and_kleene", res, rhs));
+			cpp11::sexp rhs = TransformFilterExpression(*fit->second, columns[fit->first], functions, timezone_config);
+			res = CreateExpression(functions, "and_kleene", res, rhs);
 		}
 		return res;
 	}

--- a/tools/rpkg/src/register.cpp
+++ b/tools/rpkg/src/register.cpp
@@ -187,8 +187,7 @@ private:
 	}
 
 	static SEXP CreateExpression(SEXP functions, const string name, SEXP op1, SEXP op2 = R_NilValue) {
-		RProtector r;
-		auto name_sexp = r.Protect(Rf_mkString(name.c_str()));
+		cpp11::sexp name_sexp = Rf_mkString(name.c_str());
 		return CallArrowFactory(functions, 1, name_sexp, op1, op2);
 	}
 

--- a/tools/rpkg/src/reltoaltrep.cpp
+++ b/tools/rpkg/src/reltoaltrep.cpp
@@ -106,8 +106,7 @@ struct AltrepVectorWrapper {
 	void *Dataptr() {
 		if (transformed_vector.data() == R_NilValue) {
 			auto res = rel->GetQueryResult();
-			RProtector r_varvalue;
-			transformed_vector = duckdb_r_allocate(res->types[column_index], r_varvalue, res->RowCount());
+			transformed_vector = duckdb_r_allocate(res->types[column_index], res->RowCount());
 			idx_t dest_offset = 0;
 			for (auto &chunk : res->Collection().Chunks()) {
 				SEXP dest = transformed_vector.data();

--- a/tools/rpkg/src/reltoaltrep.cpp
+++ b/tools/rpkg/src/reltoaltrep.cpp
@@ -221,7 +221,6 @@ static R_altrep_class_t LogicalTypeToAltrepType(const LogicalType &type) {
 	cpp11::writable::list data_frame(NEW_LIST(ncols));
 	data_frame.attr(R_ClassSymbol) = RStrings::get().dataframe_str;
 	auto relation_wrapper = make_shared<AltrepRelationWrapper>(drel);
-	RProtector r_protector;
 
 	cpp11::external_pointer<AltrepRownamesWrapper> ptr(new AltrepRownamesWrapper(relation_wrapper));
 
@@ -236,7 +235,7 @@ static R_altrep_class_t LogicalTypeToAltrepType(const LogicalType &type) {
 	for (size_t col_idx = 0; col_idx < ncols; col_idx++) {
 		auto &column_type = drel->Columns()[col_idx].Type();
 		cpp11::external_pointer<AltrepVectorWrapper> ptr(new AltrepVectorWrapper(relation_wrapper, col_idx));
-		auto vector_sexp = r_protector.Protect(R_new_altrep(LogicalTypeToAltrepType(column_type), ptr, R_NilValue));
+		cpp11::sexp vector_sexp = R_new_altrep(LogicalTypeToAltrepType(column_type), ptr, R_NilValue);
 		duckdb_r_decorate(column_type, vector_sexp, false);
 		SET_VECTOR_ELT(data_frame, col_idx, vector_sexp);
 	}

--- a/tools/rpkg/src/statement.cpp
+++ b/tools/rpkg/src/statement.cpp
@@ -218,8 +218,7 @@ SEXP duckdb::duckdb_execute_R_impl(MaterializedQueryResult *result, bool integer
 	SET_NAMES(data_frame, StringsToSexp(result->names));
 
 	for (size_t col_idx = 0; col_idx < ncols; col_idx++) {
-		RProtector r_varvalue;
-		cpp11::sexp varvalue = duckdb_r_allocate(result->types[col_idx], r_varvalue, nrows);
+		cpp11::sexp varvalue = duckdb_r_allocate(result->types[col_idx], nrows);
 		duckdb_r_decorate(result->types[col_idx], varvalue, integer64);
 		SET_VECTOR_ELT(data_frame, col_idx, varvalue);
 	}

--- a/tools/rpkg/src/statement.cpp
+++ b/tools/rpkg/src/statement.cpp
@@ -244,12 +244,12 @@ SEXP duckdb::duckdb_execute_R_impl(MaterializedQueryResult *result, bool integer
 
 struct AppendableRList {
 	AppendableRList() {
-		the_list = r.Protect(NEW_LIST(capacity));
+		the_list = NEW_LIST(capacity);
 	}
 	void PrepAppend() {
 		if (size >= capacity) {
 			capacity = capacity * 2;
-			SEXP new_list = r.Protect(NEW_LIST(capacity));
+			cpp11::sexp new_list = NEW_LIST(capacity);
 			D_ASSERT(new_list);
 			for (idx_t i = 0; i < size; i++) {
 				SET_VECTOR_ELT(new_list, i, VECTOR_ELT(the_list, i));
@@ -263,10 +263,9 @@ struct AppendableRList {
 		D_ASSERT(the_list != R_NilValue);
 		SET_VECTOR_ELT(the_list, size++, val);
 	}
-	SEXP the_list;
+	cpp11::sexp the_list;
 	idx_t capacity = 1000;
 	idx_t size = 0;
-	RProtector r;
 };
 
 bool FetchArrowChunk(QueryResult *result, AppendableRList &batches_list, ArrowArray &arrow_data,

--- a/tools/rpkg/src/statement.cpp
+++ b/tools/rpkg/src/statement.cpp
@@ -219,7 +219,7 @@ SEXP duckdb::duckdb_execute_R_impl(MaterializedQueryResult *result, bool integer
 
 	for (size_t col_idx = 0; col_idx < ncols; col_idx++) {
 		RProtector r_varvalue;
-		auto varvalue = r_varvalue.Protect(duckdb_r_allocate(result->types[col_idx], r_varvalue, nrows));
+		cpp11::sexp varvalue = duckdb_r_allocate(result->types[col_idx], r_varvalue, nrows);
 		duckdb_r_decorate(result->types[col_idx], varvalue, integer64);
 		SET_VECTOR_ELT(data_frame, col_idx, varvalue);
 	}

--- a/tools/rpkg/src/transform.cpp
+++ b/tools/rpkg/src/transform.cpp
@@ -48,8 +48,7 @@ SEXP duckdb_r_allocate(const LogicalType &type, RProtector &r_varvalue, idx_t nr
 	case LogicalTypeId::INTERVAL:
 		return NEW_NUMERIC(nrows);
 	case LogicalTypeId::LIST:
-		varvalue = r_varvalue.Protect(NEW_LIST(nrows));
-		break;
+		return NEW_LIST(nrows);
 	case LogicalTypeId::STRUCT: {
 		cpp11::writable::list dest_list;
 

--- a/tools/rpkg/src/transform.cpp
+++ b/tools/rpkg/src/transform.cpp
@@ -24,8 +24,7 @@ SEXP duckdb_r_allocate(const LogicalType &type, RProtector &r_varvalue, idx_t nr
 
 	switch (type.id()) {
 	case LogicalTypeId::BOOLEAN:
-		varvalue = r_varvalue.Protect(NEW_LOGICAL(nrows));
-		break;
+		return NEW_LOGICAL(nrows);
 	case LogicalTypeId::UTINYINT:
 	case LogicalTypeId::TINYINT:
 	case LogicalTypeId::SMALLINT:

--- a/tools/rpkg/src/transform.cpp
+++ b/tools/rpkg/src/transform.cpp
@@ -72,8 +72,7 @@ SEXP duckdb_r_allocate(const LogicalType &type, RProtector &r_varvalue, idx_t nr
 	case LogicalTypeId::UUID:
 		return NEW_STRING(nrows);
 	case LogicalTypeId::BLOB:
-		varvalue = r_varvalue.Protect(NEW_LIST(nrows));
-		break;
+		return NEW_LIST(nrows);
 	case LogicalTypeId::ENUM: {
 		varvalue = r_varvalue.Protect(NEW_INTEGER(nrows));
 

--- a/tools/rpkg/src/transform.cpp
+++ b/tools/rpkg/src/transform.cpp
@@ -16,8 +16,6 @@ static void VectorToR(Vector &src_vec, size_t count, void *dest, uint64_t dest_o
 }
 
 SEXP duckdb_r_allocate(const LogicalType &type, RProtector &r_varvalue, idx_t nrows) {
-	SEXP varvalue = NULL;
-
 	if (type.GetAlias() == R_STRING_TYPE_NAME) {
 		return NEW_STRING(nrows);
 	}
@@ -78,10 +76,6 @@ SEXP duckdb_r_allocate(const LogicalType &type, RProtector &r_varvalue, idx_t nr
 	default:
 		cpp11::stop("rapi_execute: Unknown column type for execute: %s", type.ToString().c_str());
 	}
-	if (!varvalue) {
-		throw std::bad_alloc();
-	}
-	return varvalue;
 }
 
 // Convert DuckDB's timestamp to R's timestamp (POSIXct). This is a represented as the number of seconds since the

--- a/tools/rpkg/src/transform.cpp
+++ b/tools/rpkg/src/transform.cpp
@@ -409,7 +409,7 @@ void duckdb_r_transform(Vector &src_vec, const SEXP dest, idx_t dest_offset, idx
 
 				RProtector ele_prot;
 				// transform the list child vector to a single R SEXP
-				auto list_element = ele_prot.Protect(duckdb_r_allocate(child_type, ele_prot, src_data[row_idx].length));
+				cpp11::sexp list_element = duckdb_r_allocate(child_type, ele_prot, src_data[row_idx].length);
 				duckdb_r_decorate(child_type, list_element, integer64);
 				duckdb_r_transform(child_vector, list_element, 0, src_data[row_idx].length, integer64);
 

--- a/tools/rpkg/src/transform.cpp
+++ b/tools/rpkg/src/transform.cpp
@@ -46,8 +46,7 @@ SEXP duckdb_r_allocate(const LogicalType &type, RProtector &r_varvalue, idx_t nr
 	case LogicalTypeId::DATE:
 	case LogicalTypeId::TIME:
 	case LogicalTypeId::INTERVAL:
-		varvalue = r_varvalue.Protect(NEW_NUMERIC(nrows));
-		break;
+		return NEW_NUMERIC(nrows);
 	case LogicalTypeId::LIST:
 		varvalue = r_varvalue.Protect(NEW_LIST(nrows));
 		break;

--- a/tools/rpkg/src/transform.cpp
+++ b/tools/rpkg/src/transform.cpp
@@ -73,11 +73,8 @@ SEXP duckdb_r_allocate(const LogicalType &type, RProtector &r_varvalue, idx_t nr
 		return NEW_STRING(nrows);
 	case LogicalTypeId::BLOB:
 		return NEW_LIST(nrows);
-	case LogicalTypeId::ENUM: {
-		varvalue = r_varvalue.Protect(NEW_INTEGER(nrows));
-
-		break;
-	}
+	case LogicalTypeId::ENUM:
+		return NEW_INTEGER(nrows);
 	default:
 		cpp11::stop("rapi_execute: Unknown column type for execute: %s", type.ToString().c_str());
 	}

--- a/tools/rpkg/src/transform.cpp
+++ b/tools/rpkg/src/transform.cpp
@@ -66,8 +66,7 @@ SEXP duckdb_r_allocate(const LogicalType &type, RProtector &r_varvalue, idx_t nr
 		dest_list.attr(R_ClassSymbol) = RStrings::get().dataframe_str;
 		dest_list.attr(R_RowNamesSymbol) = {NA_INTEGER, -static_cast<int>(nrows)};
 
-		varvalue = r_varvalue.Protect(cpp11::as_sexp(dest_list));
-		break;
+		return dest_list;
 	}
 	case LogicalTypeId::VARCHAR:
 	case LogicalTypeId::UUID:

--- a/tools/rpkg/src/transform.cpp
+++ b/tools/rpkg/src/transform.cpp
@@ -61,7 +61,7 @@ SEXP duckdb_r_allocate(const LogicalType &type, RProtector &r_varvalue, idx_t nr
 			const auto &child_type = child.second;
 
 			RProtector child_protector;
-			auto dest_child = duckdb_r_allocate(child_type, child_protector, nrows);
+			cpp11::sexp dest_child = duckdb_r_allocate(child_type, child_protector, nrows);
 			dest_list.push_back(cpp11::named_arg(name.c_str()) = std::move(dest_child));
 		}
 

--- a/tools/rpkg/src/transform.cpp
+++ b/tools/rpkg/src/transform.cpp
@@ -15,7 +15,7 @@ static void VectorToR(Vector &src_vec, size_t count, void *dest, uint64_t dest_o
 	}
 }
 
-SEXP duckdb_r_allocate(const LogicalType &type, RProtector &r_varvalue, idx_t nrows) {
+SEXP duckdb_r_allocate(const LogicalType &type, idx_t nrows) {
 	if (type.GetAlias() == R_STRING_TYPE_NAME) {
 		return NEW_STRING(nrows);
 	}
@@ -54,8 +54,7 @@ SEXP duckdb_r_allocate(const LogicalType &type, RProtector &r_varvalue, idx_t nr
 			const auto &name = child.first;
 			const auto &child_type = child.second;
 
-			RProtector child_protector;
-			cpp11::sexp dest_child = duckdb_r_allocate(child_type, child_protector, nrows);
+			cpp11::sexp dest_child = duckdb_r_allocate(child_type, nrows);
 			dest_list.push_back(cpp11::named_arg(name.c_str()) = std::move(dest_child));
 		}
 
@@ -391,9 +390,8 @@ void duckdb_r_transform(Vector &src_vec, const SEXP dest, idx_t dest_offset, idx
 				const auto end = src_data[row_idx].offset + src_data[row_idx].length;
 				child_vector.Slice(ListVector::GetEntry(src_vec), src_data[row_idx].offset, end);
 
-				RProtector ele_prot;
 				// transform the list child vector to a single R SEXP
-				cpp11::sexp list_element = duckdb_r_allocate(child_type, ele_prot, src_data[row_idx].length);
+				cpp11::sexp list_element = duckdb_r_allocate(child_type, src_data[row_idx].length);
 				duckdb_r_decorate(child_type, list_element, integer64);
 				duckdb_r_transform(child_vector, list_element, 0, src_data[row_idx].length, integer64);
 

--- a/tools/rpkg/src/transform.cpp
+++ b/tools/rpkg/src/transform.cpp
@@ -70,8 +70,7 @@ SEXP duckdb_r_allocate(const LogicalType &type, RProtector &r_varvalue, idx_t nr
 	}
 	case LogicalTypeId::VARCHAR:
 	case LogicalTypeId::UUID:
-		varvalue = r_varvalue.Protect(NEW_STRING(nrows));
-		break;
+		return NEW_STRING(nrows);
 	case LogicalTypeId::BLOB:
 		varvalue = r_varvalue.Protect(NEW_LIST(nrows));
 		break;

--- a/tools/rpkg/src/transform.cpp
+++ b/tools/rpkg/src/transform.cpp
@@ -30,8 +30,7 @@ SEXP duckdb_r_allocate(const LogicalType &type, RProtector &r_varvalue, idx_t nr
 	case LogicalTypeId::SMALLINT:
 	case LogicalTypeId::USMALLINT:
 	case LogicalTypeId::INTEGER:
-		varvalue = r_varvalue.Protect(NEW_INTEGER(nrows));
-		break;
+		return NEW_INTEGER(nrows);
 	case LogicalTypeId::UINTEGER:
 	case LogicalTypeId::UBIGINT:
 	case LogicalTypeId::BIGINT:

--- a/tools/rpkg/src/utils.cpp
+++ b/tools/rpkg/src/utils.cpp
@@ -42,9 +42,7 @@ cpp11::strings duckdb::StringsToSexp(vector<string> s) {
 
 RStrings::RStrings() {
 	// allocate strings once
-	RProtector r;
-
-	SEXP strings = r.Protect(Rf_allocVector(STRSXP, 5));
+	cpp11::sexp strings = Rf_allocVector(STRSXP, 5);
 	SET_STRING_ELT(strings, 0, secs = Rf_mkChar("secs"));
 	SET_STRING_ELT(strings, 1, mins = Rf_mkChar("mins"));
 	SET_STRING_ELT(strings, 2, hours = Rf_mkChar("hours"));
@@ -53,7 +51,7 @@ RStrings::RStrings() {
 	R_PreserveObject(strings);
 	MARK_NOT_MUTABLE(strings);
 
-	SEXP chars = r.Protect(Rf_allocVector(VECSXP, 9));
+	cpp11::sexp chars = Rf_allocVector(VECSXP, 9);
 	SET_VECTOR_ELT(chars, 0, UTC_str = Rf_mkString("UTC"));
 	SET_VECTOR_ELT(chars, 1, Date_str = Rf_mkString("Date"));
 	SET_VECTOR_ELT(chars, 2, difftime_str = Rf_mkString("difftime"));


### PR DESCRIPTION
`PROTECT()` and `UNPROTECT()` are macros that must be balanced within the same local function. I suspect `RProtector` works due to inlining, but we shouldn't rely on it.

This PR replaces the RProtector class with idioms from the cpp11 package.