### PR TITLE
SQLLogicTest - instead of moving prepared statements over avoid restarting database when there are prepared statements

### DIFF
--- a/test/sql/prepared/prepared_select.test
+++ b/test/sql/prepared/prepared_select.test
@@ -2,9 +2,6 @@
 # description: Test order of unmarked prepared statements in select
 # group: [prepared]
 
-require skip_reload
-
-
 # select - from - where with subquery
 statement ok
 PREPARE s1 AS SELECT ?::VARCHAR FROM (SELECT ?::INTEGER) tbl(i) WHERE i > ?::INTEGER

--- a/test/sql/prepared/prepared_update.test
+++ b/test/sql/prepared/prepared_update.test
@@ -2,9 +2,6 @@
 # description: Test order of unmarked prepared statements
 # group: [prepared]
 
-require skip_reload
-
-
 statement ok
 CREATE TABLE integers(i INTEGER, j VARCHAR)
 

--- a/test/sql/prepared/test_prepare_delete.test
+++ b/test/sql/prepared/test_prepare_delete.test
@@ -2,9 +2,6 @@
 # description: PREPARE for DELETE
 # group: [prepared]
 
-require skip_reload
-
-
 statement ok
 CREATE TABLE b (i TINYINT)
 

--- a/test/sql/prepared/test_prepare_delete_update.test
+++ b/test/sql/prepared/test_prepare_delete_update.test
@@ -2,9 +2,6 @@
 # description: PREPARE for DELETE/UPDATE
 # group: [prepared]
 
-require skip_reload
-
-
 # DELETE
 statement ok
 CREATE TABLE b (i TINYINT)

--- a/test/sql/prepared/test_prepare_drop.test
+++ b/test/sql/prepared/test_prepare_drop.test
@@ -2,9 +2,6 @@
 # description: PREPARE and DROPping tables
 # group: [prepared]
 
-require skip_reload
-
-
 statement ok con1
 CREATE TABLE a (i TINYINT)
 

--- a/test/sql/prepared/test_prepare_insert.test_slow
+++ b/test/sql/prepared/test_prepare_insert.test_slow
@@ -2,9 +2,6 @@
 # description: PREPARE for INSERT
 # group: [prepared]
 
-require skip_reload
-
-
 statement ok
 CREATE TABLE b (i TINYINT)
 

--- a/test/sql/prepared/test_prepare_null.test
+++ b/test/sql/prepared/test_prepare_null.test
@@ -2,8 +2,6 @@
 # description: PREPARE with NULL
 # group: [prepared]
 
-require skip_reload
-
 statement ok
 CREATE TABLE b (i TINYINT)
 

--- a/test/sql/prepared/test_prepare_select.test
+++ b/test/sql/prepared/test_prepare_select.test
@@ -2,9 +2,6 @@
 # description: PREPARE for SELECT clause
 # group: [prepared]
 
-require skip_reload
-
-
 statement ok
 CREATE TABLE a (i TINYINT)
 

--- a/test/sql/prepared/test_prepare_subquery.test
+++ b/test/sql/prepared/test_prepare_subquery.test
@@ -2,9 +2,6 @@
 # description: Prepared statements and subqueries
 # group: [prepared]
 
-require skip_reload
-
-
 # simple subquery
 statement ok
 PREPARE v1 AS SELECT * FROM (SELECT $1::INTEGER) sq1;

--- a/test/sql/prepared/test_prepare_types.test
+++ b/test/sql/prepared/test_prepare_types.test
@@ -2,9 +2,6 @@
 # description: PREPARE many types for INSERT
 # group: [prepared]
 
-require skip_reload
-
-
 # prepare different types in insert
 statement ok
 CREATE TABLE test(a TINYINT, b SMALLINT, c INTEGER, d BIGINT, e REAL, f DOUBLE, g DATE, h VARCHAR)

--- a/test/sql/prepared/test_prepare_unused_cte.test
+++ b/test/sql/prepared/test_prepare_unused_cte.test
@@ -2,9 +2,6 @@
 # description: Test binding unreferenced CTE parameters
 # group: [prepared]
 
-require skip_reload
-
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sqlite/sqllogic_command.cpp
+++ b/test/sqlite/sqllogic_command.cpp
@@ -64,13 +64,16 @@ void Command::RestartDatabase(ExecuteContext &context, Connection *&connection, 
 	} catch (...) {
 		query_fail = true;
 	}
-	bool is_any_transaction_active = false;
+	bool can_restart = true;
 	for (auto &conn : connection->context->db->GetConnectionManager().connections) {
+		if (!conn.first->client_data->prepared_statements.empty()) {
+			can_restart = false;
+		}
 		if (conn.first->transaction.HasActiveTransaction()) {
-			is_any_transaction_active = true;
+			can_restart = false;
 		}
 	}
-	if (!query_fail && !is_any_transaction_active && !runner.skip_reload) {
+	if (!query_fail && can_restart && !runner.skip_reload) {
 		// We basically restart the database if no transaction is active and if the query is valid
 		auto command = make_unique<RestartCommand>(runner);
 		runner.ExecuteCommand(std::move(command));
@@ -257,8 +260,6 @@ void RestartCommand::ExecuteInternal(ExecuteContext &context) const {
 		low_query_writer_path = runner.con->context->client_data->log_query_writer->path;
 	}
 
-	auto prepared_statements = std::move(runner.con->context->client_data->prepared_statements);
-
 	runner.LoadDatabase(runner.dbpath);
 
 	runner.con->context->config = client_config;
@@ -271,7 +272,6 @@ void RestartCommand::ExecuteInternal(ExecuteContext &context) const {
 		    make_unique<BufferedFileWriter>(FileSystem::GetFileSystem(*runner.con->context), low_query_writer_path,
 		                                    1 << 1 | 1 << 5, runner.con->context->client_data->file_opener.get());
 	}
-	runner.con->context->client_data->prepared_statements = std::move(prepared_statements);
 }
 
 void Statement::ExecuteInternal(ExecuteContext &context) const {


### PR DESCRIPTION
This fixes spurious crashes when running `--force-restart --force-storage` on tests with prepared statements (e.g. `test_enum_code.test`).

We cannot just move over prepared statements because the prepared statements hold state that might point to the current database. Upon restarting that state is invalid and points to random memory. Instead we should just not restart when `PREPARE` is called in a test.