### PR TITLE
Fix #6656: correctly add casts to NULL values in list_concat, and add more safety around stats mismatches

### DIFF
--- a/src/function/scalar/list/list_concat.cpp
+++ b/src/function/scalar/list/list_concat.cpp
@@ -82,9 +82,10 @@ static unique_ptr<FunctionData> ListConcatBind(ClientContext &context, ScalarFun
 		throw ParameterNotResolvedException();
 	} else if (lhs.id() == LogicalTypeId::SQLNULL || rhs.id() == LogicalTypeId::SQLNULL) {
 		// we mimic postgres behaviour: list_concat(NULL, my_list) = my_list
-		bound_function.arguments[0] = lhs;
-		bound_function.arguments[1] = rhs;
-		bound_function.return_type = rhs.id() == LogicalTypeId::SQLNULL ? lhs : rhs;
+		auto return_type = rhs.id() == LogicalTypeId::SQLNULL ? lhs : rhs;
+		bound_function.arguments[0] = return_type;
+		bound_function.arguments[1] = return_type;
+		bound_function.return_type = return_type;
 	} else {
 		D_ASSERT(lhs.id() == LogicalTypeId::LIST);
 		D_ASSERT(rhs.id() == LogicalTypeId::LIST);

--- a/src/storage/statistics/list_stats.cpp
+++ b/src/storage/statistics/list_stats.cpp
@@ -34,12 +34,16 @@ void ListStats::Copy(BaseStatistics &stats, const BaseStatistics &other) {
 }
 
 const BaseStatistics &ListStats::GetChildStats(const BaseStatistics &stats) {
-	D_ASSERT(stats.GetStatsType() == StatisticsType::LIST_STATS);
+	if (stats.GetStatsType() != StatisticsType::LIST_STATS) {
+		throw InternalException("ListStats::GetChildStats called on stats that is not a list");
+	}
 	D_ASSERT(stats.child_stats);
 	return stats.child_stats[0];
 }
 BaseStatistics &ListStats::GetChildStats(BaseStatistics &stats) {
-	D_ASSERT(stats.GetStatsType() == StatisticsType::LIST_STATS);
+	if (stats.GetStatsType() != StatisticsType::LIST_STATS) {
+		throw InternalException("ListStats::GetChildStats called on stats that is not a list");
+	}
 	D_ASSERT(stats.child_stats);
 	return stats.child_stats[0];
 }

--- a/src/storage/statistics/struct_stats.cpp
+++ b/src/storage/statistics/struct_stats.cpp
@@ -34,7 +34,9 @@ BaseStatistics StructStats::CreateEmpty(LogicalType type) {
 }
 
 const BaseStatistics *StructStats::GetChildStats(const BaseStatistics &stats) {
-	D_ASSERT(stats.GetStatsType() == StatisticsType::STRUCT_STATS);
+	if (stats.GetStatsType() != StatisticsType::STRUCT_STATS) {
+		throw InternalException("Calling StructStats::GetChildStats on stats that is not a struct");
+	}
 	return stats.child_stats.get();
 }
 

--- a/test/sql/types/list/list_concat_null.test
+++ b/test/sql/types/list/list_concat_null.test
@@ -1,0 +1,15 @@
+# name: test/sql/types/list/list_concat_null.test
+# description: Issue #6656 - Segmentation Fault on Select query on table with column of array type
+# group: [list]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE table x1 (b INT[]);
+
+statement ok
+SELECT b || NULL from x1;
+
+statement ok
+SELECT NULL || NULL from x1;


### PR DESCRIPTION
Fixes #6656 