### PR TITLE
WebAssembly testing against duckdb-wasm latest stable version

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -596,7 +596,9 @@ jobs:
     - name: Setup
       shell: bash
       run: |
-        git clone --recurse-submodules --branch latest_stable --depth 1 https://github.com/duckdb/duckdb-wasm
+        git clone --recurse-submodules https://github.com/duckdb/duckdb-wasm
+        cd duckdb-wasm
+        git checkout 2cee83b1
 
     - name: Setup Ccache
       uses: hendrikmuhs/ccache-action@main

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -582,6 +582,36 @@ jobs:
         path: |
           duckdb-wasm32-nothreads.zip
 
+ linux-wasm-experimental:
+    name: WebAssembly duckdb-wasm builds
+    runs-on: ubuntu-22.04
+    needs: linux-release-64
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - uses: mymindstorm/setup-emsdk@v11
+
+    - name: Setup
+      shell: bash
+      run: |
+        git clone --recurse-submodules --branch latest_stable --depth 1 https://github.com/duckdb/duckdb-wasm
+
+    - name: Setup Ccache
+      uses: hendrikmuhs/ccache-action@main
+      with:
+        key: ${{ github.job }}
+        save: ${{ github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb' }}
+
+    - name: Build WebAssembly
+      shell: bash
+      run: |
+        cd duckdb-wasm
+        bash scripts/wasm_build_lib.sh relsize mvp $(pwd)/..
+        bash scripts/wasm_build_lib.sh relsize eh $(pwd)/..
+        bash scripts/wasm_build_lib.sh relsize coi $(pwd)/..
+
  symbol-leakage:
     name: Symbol Leakage
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This allows testing of arbitrary duckdb branches against the latest stable version of duckdb-wasm.

This requires a duckdb-wasm branch with the name latest_stable to be created (and pointing to current master), and will trigger a yet uncaught error that's fixed by PR #6663.