### PR TITLE
Fix class name in error message

### DIFF
--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -193,14 +193,14 @@ const vector<unique_ptr<Constraint>> &TableCatalogEntry::GetConstraints() {
 }
 
 DataTable &TableCatalogEntry::GetStorage() {
-	throw InternalException("Calling GetStorage on a TableCatalogEntry that is not a DTableCatalogEntry");
+	throw InternalException("Calling GetStorage on a TableCatalogEntry that is not a DuckTableEntry");
 }
 
 DataTable *TableCatalogEntry::GetStoragePtr() {
-	throw InternalException("Calling GetStoragePtr on a TableCatalogEntry that is not a DTableCatalogEntry");
+	throw InternalException("Calling GetStoragePtr on a TableCatalogEntry that is not a DuckTableEntry");
 }
 
 const vector<unique_ptr<BoundConstraint>> &TableCatalogEntry::GetBoundConstraints() {
-	throw InternalException("Calling GetBoundConstraints on a TableCatalogEntry that is not a DTableCatalogEntry");
+	throw InternalException("Calling GetBoundConstraints on a TableCatalogEntry that is not a DuckTableEntry");
 }
 } // namespace duckdb


### PR DESCRIPTION
`DTableCatalogEntry` is the old name of `DuckTableEntry`?