### PR TITLE
Fix #6676 and #6677: correctly instantiate local states for nested casts

### DIFF
--- a/extension/json/include/json_functions.hpp
+++ b/extension/json/include/json_functions.hpp
@@ -54,6 +54,7 @@ public:
 
 struct JSONFunctionLocalState : public FunctionLocalState {
 public:
+	explicit JSONFunctionLocalState(Allocator &allocator);
 	explicit JSONFunctionLocalState(ClientContext &context);
 	static unique_ptr<FunctionLocalState> Init(ExpressionState &state, const BoundFunctionExpression &expr,
 	                                           FunctionData *bind_data);

--- a/extension/json/json_functions.cpp
+++ b/extension/json/json_functions.cpp
@@ -103,7 +103,10 @@ unique_ptr<FunctionData> JSONReadManyFunctionData::Bind(ClientContext &context, 
 	return make_unique<JSONReadManyFunctionData>(std::move(paths), std::move(lens));
 }
 
-JSONFunctionLocalState::JSONFunctionLocalState(ClientContext &context) : json_allocator(BufferAllocator::Get(context)) {
+JSONFunctionLocalState::JSONFunctionLocalState(Allocator &allocator) : json_allocator(allocator) {
+}
+JSONFunctionLocalState::JSONFunctionLocalState(ClientContext &context)
+    : JSONFunctionLocalState(BufferAllocator::Get(context)) {
 }
 
 unique_ptr<FunctionLocalState> JSONFunctionLocalState::Init(ExpressionState &state, const BoundFunctionExpression &expr,
@@ -184,8 +187,12 @@ unique_ptr<TableRef> JSONFunctions::ReadJSONReplacement(ClientContext &context, 
 	return std::move(table_function);
 }
 
-static unique_ptr<FunctionLocalState> InitJSONCastLocalState(ClientContext &context) {
-	return make_unique<JSONFunctionLocalState>(context);
+static unique_ptr<FunctionLocalState> InitJSONCastLocalState(CastLocalStateParameters &parameters) {
+	if (parameters.context) {
+		return make_unique<JSONFunctionLocalState>(*parameters.context);
+	} else {
+		return make_unique<JSONFunctionLocalState>(Allocator::DefaultAllocator());
+	}
 }
 
 static bool CastVarcharToJSON(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {

--- a/extension/json/json_functions.cpp
+++ b/extension/json/json_functions.cpp
@@ -215,9 +215,9 @@ static bool CastVarcharToJSON(Vector &source, Vector &result, idx_t count, CastP
 			    mask.SetInvalid(idx);
 			    success = false;
 		    }
-
 		    return input;
 	    });
+	result.Reinterpret(source);
 	return success;
 }
 

--- a/src/common/vector_operations/vector_cast.cpp
+++ b/src/common/vector_operations/vector_cast.cpp
@@ -11,7 +11,8 @@ bool VectorOperations::TryCast(CastFunctionSet &set, GetCastFunctionInput &input
 	auto cast_function = set.GetCastFunction(source.GetType(), result.GetType(), input);
 	unique_ptr<FunctionLocalState> local_state;
 	if (cast_function.init_local_state) {
-		local_state = cast_function.init_local_state(*input.context);
+		CastLocalStateParameters lparameters(input.context, cast_function.cast_data);
+		local_state = cast_function.init_local_state(lparameters);
 	}
 	CastParameters parameters(cast_function.cast_data.get(), strict, error_message, local_state.get());
 	return cast_function.function(source, result, count, parameters);

--- a/src/execution/expression_executor/execute_cast.cpp
+++ b/src/execution/expression_executor/execute_cast.cpp
@@ -11,7 +11,8 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundCastE
 	result->AddChild(expr.child.get());
 	result->Finalize();
 	if (expr.bound_cast.init_local_state) {
-		result->local_state = expr.bound_cast.init_local_state(root.executor->GetContext());
+		CastLocalStateParameters parameters(root.executor->GetContext(), expr.bound_cast.cast_data);
+		result->local_state = expr.bound_cast.init_local_state(parameters);
 	}
 	return std::move(result);
 }

--- a/src/function/cast/cast_function_set.cpp
+++ b/src/function/cast/cast_function_set.cpp
@@ -6,7 +6,7 @@
 
 namespace duckdb {
 
-BindCastInput::BindCastInput(CastFunctionSet &function_set, BindCastInfo *info, ClientContext *context)
+BindCastInput::BindCastInput(CastFunctionSet &function_set, BindCastInfo *info, optional_ptr<ClientContext> context)
     : function_set(function_set), info(info), context(context) {
 }
 

--- a/src/function/cast/list_casts.cpp
+++ b/src/function/cast/list_casts.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/function/cast/default_casts.hpp"
 #include "duckdb/function/cast/cast_function_set.hpp"
+#include "duckdb/function/cast/bound_cast_data.hpp"
 
 namespace duckdb {
 
@@ -10,6 +11,15 @@ unique_ptr<BoundCastData> ListBoundCastData::BindListToListCast(BindCastInput &i
 	auto &result_child_type = ListType::GetChildType(target);
 	auto child_cast = input.GetCastFunction(source_child_type, result_child_type);
 	return make_unique<ListBoundCastData>(std::move(child_cast));
+}
+
+unique_ptr<FunctionLocalState> ListBoundCastData::InitListLocalState(CastLocalStateParameters &parameters) {
+	auto &cast_data = (ListBoundCastData &)*parameters.cast_data;
+	if (!cast_data.child_cast_info.init_local_state) {
+		return nullptr;
+	}
+	CastLocalStateParameters child_parameters(parameters, cast_data.child_cast_info.cast_data);
+	return cast_data.child_cast_info.init_local_state(child_parameters);
 }
 
 bool ListCast::ListToListCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
@@ -40,7 +50,7 @@ bool ListCast::ListToListCast(Vector &source, Vector &result, idx_t count, CastP
 	ListVector::Reserve(result, source_size);
 	auto &append_vector = ListVector::GetEntry(result);
 
-	CastParameters child_parameters(parameters, cast_data.child_cast_info.cast_data.get());
+	CastParameters child_parameters(parameters, cast_data.child_cast_info.cast_data, parameters.local_state);
 	if (!cast_data.child_cast_info.function(source_cc, append_vector, source_size, child_parameters)) {
 		return false;
 	}
@@ -116,10 +126,13 @@ static bool ListToVarcharCast(Vector &source, Vector &result, idx_t count, CastP
 BoundCastInfo DefaultCasts::ListCastSwitch(BindCastInput &input, const LogicalType &source, const LogicalType &target) {
 	switch (target.id()) {
 	case LogicalTypeId::LIST:
-		return BoundCastInfo(ListCast::ListToListCast, ListBoundCastData::BindListToListCast(input, source, target));
+		return BoundCastInfo(ListCast::ListToListCast, ListBoundCastData::BindListToListCast(input, source, target),
+		                     ListBoundCastData::InitListLocalState);
 	case LogicalTypeId::VARCHAR:
-		return BoundCastInfo(ListToVarcharCast, ListBoundCastData::BindListToListCast(
-		                                            input, source, LogicalType::LIST(LogicalType::VARCHAR)));
+		return BoundCastInfo(
+		    ListToVarcharCast,
+		    ListBoundCastData::BindListToListCast(input, source, LogicalType::LIST(LogicalType::VARCHAR)),
+		    ListBoundCastData::InitListLocalState);
 	default:
 		return DefaultCasts::TryVectorNullCast;
 	}

--- a/src/function/cast/map_cast.cpp
+++ b/src/function/cast/map_cast.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/function/cast/default_casts.hpp"
 #include "duckdb/function/cast/cast_function_set.hpp"
+#include "duckdb/function/cast/bound_cast_data.hpp"
 
 namespace duckdb {
 
@@ -78,10 +79,12 @@ static bool MapToVarcharCast(Vector &source, Vector &result, idx_t count, CastPa
 BoundCastInfo DefaultCasts::MapCastSwitch(BindCastInput &input, const LogicalType &source, const LogicalType &target) {
 	switch (target.id()) {
 	case LogicalTypeId::MAP:
-		return BoundCastInfo(ListCast::ListToListCast, ListBoundCastData::BindListToListCast(input, source, target));
+		return BoundCastInfo(ListCast::ListToListCast, ListBoundCastData::BindListToListCast(input, source, target),
+		                     ListBoundCastData::InitListLocalState);
 	case LogicalTypeId::VARCHAR: {
 		auto varchar_type = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR);
-		return BoundCastInfo(MapToVarcharCast, ListBoundCastData::BindListToListCast(input, source, varchar_type));
+		return BoundCastInfo(MapToVarcharCast, ListBoundCastData::BindListToListCast(input, source, varchar_type),
+		                     ListBoundCastData::InitListLocalState);
 	}
 	default:
 		return TryVectorNullCast;

--- a/src/include/duckdb/common/optional_ptr.hpp
+++ b/src/include/duckdb/common/optional_ptr.hpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+ //                         DuckDB
+ //
+ // duckdb/common/optional_ptr.hpp
+ //
+ //
+ //===----------------------------------------------------------------------===//
+
+ #pragma once
+
+ #include "duckdb/common/exception.hpp"
+
+ namespace duckdb {
+
+ template<class T>
+ class optional_ptr {
+ public:
+ 	optional_ptr() : ptr(nullptr) {}
+ 	optional_ptr(T *ptr_p) : ptr(ptr_p) {} // NOLINT: allow implicit creation from pointer
+
+
+     operator bool() const {
+         return ptr;
+     }
+ 	T& operator*() {
+ 		if (!ptr) {
+ 			throw InternalException("Attempting to dereference an optional pointer of type \"%s\" that is not set", typeid(T).name());
+ 		}
+        return *ptr;
+ 	}
+     T* operator->() {
+ 		if (!ptr) {
+ 			throw InternalException("Attempting to call a method on an optional pointer of type \"%s\" that is not set", typeid(T).name());
+ 		}
+        return ptr;
+     }
+ private:
+ 	T *ptr;
+ };
+
+ }

--- a/src/include/duckdb/common/optional_ptr.hpp
+++ b/src/include/duckdb/common/optional_ptr.hpp
@@ -1,41 +1,45 @@
 //===----------------------------------------------------------------------===//
- //                         DuckDB
- //
- // duckdb/common/optional_ptr.hpp
- //
- //
- //===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/optional_ptr.hpp
+//
+//
+//===----------------------------------------------------------------------===//
 
- #pragma once
+#pragma once
 
- #include "duckdb/common/exception.hpp"
+#include "duckdb/common/exception.hpp"
 
- namespace duckdb {
+namespace duckdb {
 
- template<class T>
- class optional_ptr {
- public:
- 	optional_ptr() : ptr(nullptr) {}
- 	optional_ptr(T *ptr_p) : ptr(ptr_p) {} // NOLINT: allow implicit creation from pointer
+template <class T>
+class optional_ptr {
+public:
+	optional_ptr() : ptr(nullptr) {
+	}
+	optional_ptr(T *ptr_p) : ptr(ptr_p) { // NOLINT: allow implicit creation from pointer
+	}
+	optional_ptr(const unique_ptr<T> &ptr_p) : ptr(ptr_p.get()) { // NOLINT: allow implicit creation from unique pointer
+	}
 
+	operator bool() const {
+		return ptr;
+	}
+	T &operator*() {
+		if (!ptr) {
+			throw InternalException("Attempting to dereference an optional pointer that is not set");
+		}
+		return *ptr;
+	}
+	T *operator->() {
+		if (!ptr) {
+			throw InternalException("Attempting to call a method on an optional pointer that is not set");
+		}
+		return ptr;
+	}
 
-     operator bool() const {
-         return ptr;
-     }
- 	T& operator*() {
- 		if (!ptr) {
- 			throw InternalException("Attempting to dereference an optional pointer of type \"%s\" that is not set", typeid(T).name());
- 		}
-        return *ptr;
- 	}
-     T* operator->() {
- 		if (!ptr) {
- 			throw InternalException("Attempting to call a method on an optional pointer of type \"%s\" that is not set", typeid(T).name());
- 		}
-        return ptr;
-     }
- private:
- 	T *ptr;
- };
+private:
+	T *ptr;
+};
 
- }
+} // namespace duckdb

--- a/src/include/duckdb/function/cast/bound_cast_data.hpp
+++ b/src/include/duckdb/function/cast/bound_cast_data.hpp
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/function/cast/bound_cast_data.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/function/cast/default_casts.hpp"
+
+namespace duckdb {
+
+struct ListBoundCastData : public BoundCastData {
+	explicit ListBoundCastData(BoundCastInfo child_cast) : child_cast_info(std::move(child_cast)) {
+	}
+
+	BoundCastInfo child_cast_info;
+	static unique_ptr<BoundCastData> BindListToListCast(BindCastInput &input, const LogicalType &source,
+	                                                    const LogicalType &target);
+	static unique_ptr<FunctionLocalState> InitListLocalState(CastLocalStateParameters &parameters);
+
+public:
+	unique_ptr<BoundCastData> Copy() const override {
+		return make_unique<ListBoundCastData>(child_cast_info.Copy());
+	}
+};
+
+struct ListCast {
+	static bool ListToListCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters);
+};
+
+struct StructBoundCastData : public BoundCastData {
+	StructBoundCastData(vector<BoundCastInfo> child_casts, LogicalType target_p)
+	    : child_cast_info(std::move(child_casts)), target(std::move(target_p)) {
+	}
+
+	vector<BoundCastInfo> child_cast_info;
+	LogicalType target;
+
+	static unique_ptr<BoundCastData> BindStructToStructCast(BindCastInput &input, const LogicalType &source,
+	                                                        const LogicalType &target);
+	static unique_ptr<FunctionLocalState> InitStructCastLocalState(CastLocalStateParameters &parameters);
+
+public:
+	unique_ptr<BoundCastData> Copy() const override {
+		vector<BoundCastInfo> copy_info;
+		for (auto &info : child_cast_info) {
+			copy_info.push_back(info.Copy());
+		}
+		return make_unique<StructBoundCastData>(std::move(copy_info), target);
+	}
+};
+
+struct StructCastLocalState : public FunctionLocalState {
+public:
+	vector<unique_ptr<FunctionLocalState>> local_states;
+};
+
+struct MapBoundCastData : public BoundCastData {
+	MapBoundCastData(BoundCastInfo key_cast, BoundCastInfo value_cast)
+	    : key_cast(std::move(key_cast)), value_cast(std::move(value_cast)) {
+	}
+
+	BoundCastInfo key_cast;
+	BoundCastInfo value_cast;
+
+	static unique_ptr<BoundCastData> BindMapToMapCast(BindCastInput &input, const LogicalType &source,
+	                                                  const LogicalType &target);
+
+public:
+	unique_ptr<BoundCastData> Copy() const override {
+		return make_unique<MapBoundCastData>(key_cast.Copy(), value_cast.Copy());
+	}
+};
+
+struct MapCastLocalState : public FunctionLocalState {
+public:
+	unique_ptr<FunctionLocalState> key_state;
+	unique_ptr<FunctionLocalState> value_state;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/function/cast/cast_function_set.hpp
+++ b/src/include/duckdb/function/cast/cast_function_set.hpp
@@ -19,12 +19,12 @@ typedef BoundCastInfo (*bind_cast_function_t)(BindCastInput &input, const Logica
 typedef int64_t (*implicit_cast_cost_t)(const LogicalType &from, const LogicalType &to);
 
 struct GetCastFunctionInput {
-	GetCastFunctionInput(ClientContext *context = nullptr) : context(context) {
+	GetCastFunctionInput(optional_ptr<ClientContext> context = nullptr) : context(context) {
 	}
 	GetCastFunctionInput(ClientContext &context) : context(&context) {
 	}
 
-	ClientContext *context;
+	optional_ptr<ClientContext> context;
 };
 
 struct BindCastFunction {

--- a/src/include/duckdb/function/cast/default_casts.hpp
+++ b/src/include/duckdb/function/cast/default_casts.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/function/scalar_function.hpp"
 
 namespace duckdb {
 
@@ -32,11 +33,13 @@ struct BoundCastData {
 struct CastParameters {
 	CastParameters() {
 	}
-	CastParameters(BoundCastData *cast_data, bool strict, string *error_message, FunctionLocalState *local_state)
+	CastParameters(BoundCastData *cast_data, bool strict, string *error_message,
+	               optional_ptr<FunctionLocalState> local_state)
 	    : cast_data(cast_data), strict(strict), error_message(error_message), local_state(local_state) {
 	}
-	CastParameters(CastParameters &parent, BoundCastData *cast_data = nullptr)
-	    : cast_data(cast_data), strict(parent.strict), error_message(parent.error_message) {
+	CastParameters(CastParameters &parent, optional_ptr<BoundCastData> cast_data,
+	               optional_ptr<FunctionLocalState> local_state)
+	    : cast_data(cast_data), strict(parent.strict), error_message(parent.error_message), local_state(local_state) {
 	}
 
 	//! The bound cast data (if any)
@@ -49,8 +52,24 @@ struct CastParameters {
 	optional_ptr<FunctionLocalState> local_state;
 };
 
+struct CastLocalStateParameters {
+	CastLocalStateParameters(optional_ptr<ClientContext> context_p, optional_ptr<BoundCastData> cast_data_p)
+	    : context(context_p), cast_data(cast_data_p) {
+	}
+	CastLocalStateParameters(ClientContext &context_p, optional_ptr<BoundCastData> cast_data_p)
+	    : context(&context_p), cast_data(cast_data_p) {
+	}
+	CastLocalStateParameters(CastLocalStateParameters &parent, optional_ptr<BoundCastData> cast_data_p)
+	    : context(parent.context), cast_data(cast_data_p) {
+	}
+
+	optional_ptr<ClientContext> context;
+	//! The bound cast data (if any)
+	optional_ptr<BoundCastData> cast_data;
+};
+
 typedef bool (*cast_function_t)(Vector &source, Vector &result, idx_t count, CastParameters &parameters);
-typedef unique_ptr<FunctionLocalState> (*init_cast_local_state_t)(ClientContext &context);
+typedef unique_ptr<FunctionLocalState> (*init_cast_local_state_t)(CastLocalStateParameters &parameters);
 
 struct BoundCastInfo {
 	DUCKDB_API
@@ -66,70 +85,14 @@ public:
 };
 
 struct BindCastInput {
-	DUCKDB_API BindCastInput(CastFunctionSet &function_set, BindCastInfo *info, ClientContext *context);
+	DUCKDB_API BindCastInput(CastFunctionSet &function_set, BindCastInfo *info, optional_ptr<ClientContext> context);
 
 	CastFunctionSet &function_set;
 	BindCastInfo *info;
-	ClientContext *context;
+	optional_ptr<ClientContext> context;
 
 public:
 	DUCKDB_API BoundCastInfo GetCastFunction(const LogicalType &source, const LogicalType &target);
-};
-
-struct ListBoundCastData : public BoundCastData {
-	explicit ListBoundCastData(BoundCastInfo child_cast) : child_cast_info(std::move(child_cast)) {
-	}
-
-	BoundCastInfo child_cast_info;
-	static unique_ptr<BoundCastData> BindListToListCast(BindCastInput &input, const LogicalType &source,
-	                                                    const LogicalType &target);
-
-public:
-	unique_ptr<BoundCastData> Copy() const override {
-		return make_unique<ListBoundCastData>(child_cast_info.Copy());
-	}
-};
-
-struct ListCast {
-	static bool ListToListCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters);
-};
-
-struct StructBoundCastData : public BoundCastData {
-	StructBoundCastData(vector<BoundCastInfo> child_casts, LogicalType target_p)
-	    : child_cast_info(std::move(child_casts)), target(std::move(target_p)) {
-	}
-
-	vector<BoundCastInfo> child_cast_info;
-	LogicalType target;
-
-	static unique_ptr<BoundCastData> BindStructToStructCast(BindCastInput &input, const LogicalType &source,
-	                                                        const LogicalType &target);
-
-public:
-	unique_ptr<BoundCastData> Copy() const override {
-		vector<BoundCastInfo> copy_info;
-		for (auto &info : child_cast_info) {
-			copy_info.push_back(info.Copy());
-		}
-		return make_unique<StructBoundCastData>(std::move(copy_info), target);
-	}
-};
-
-struct MapBoundCastData : public BoundCastData {
-	MapBoundCastData(BoundCastInfo key_cast, BoundCastInfo value_cast)
-	    : key_cast(std::move(key_cast)), value_cast(std::move(value_cast)) {
-	}
-
-	BoundCastInfo key_cast;
-	BoundCastInfo value_cast;
-
-	static unique_ptr<BoundCastData> BindMapToMapCast(BindCastInput &input, const LogicalType &source,
-	                                                  const LogicalType &target);
-
-public:
-	unique_ptr<BoundCastData> Copy() const override {
-		return make_unique<MapBoundCastData>(key_cast.Copy(), value_cast.Copy());
-	}
 };
 
 struct DefaultCasts {

--- a/src/include/duckdb/function/cast/default_casts.hpp
+++ b/src/include/duckdb/function/cast/default_casts.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/optional_ptr.hpp"
 
 namespace duckdb {
 
@@ -39,13 +40,13 @@ struct CastParameters {
 	}
 
 	//! The bound cast data (if any)
-	BoundCastData *cast_data = nullptr;
+	optional_ptr<BoundCastData> cast_data;
 	//! whether or not to enable strict casting
 	bool strict = false;
 	// out: error message in case cast has failed
 	string *error_message = nullptr;
 	//! Local state
-	FunctionLocalState *local_state = nullptr;
+	optional_ptr<FunctionLocalState> local_state;
 };
 
 typedef bool (*cast_function_t)(Vector &source, Vector &result, idx_t count, CastParameters &parameters);

--- a/test/sql/json/json_nested_casts.test
+++ b/test/sql/json/json_nested_casts.test
@@ -1,0 +1,97 @@
+# name: test/sql/json/json_nested_casts.test
+# description: Casts to and from nested types with JSON
+# group: [json]
+
+require json
+
+statement ok
+PRAGMA enable_verification
+
+# list with varchar to json
+statement ok
+create table t2(blobs json[])
+
+statement ok
+insert into t2 values(json('[1,2]'));
+
+query I
+SELECT * FROM t2
+----
+[1, 2]
+
+# varchar to list of json
+query I
+select cast(json('[1,2]') as json[]);
+----
+[1, 2]
+
+statement error
+select cast(['boom'] as json[]);
+----
+Malformed JSON
+
+query I
+select cast(['[1, 2]', '[3, 4]'] as json[]);
+----
+[[1, 2], [3, 4]]
+
+# struct with varchar to json
+query I
+SELECT {'a': '[1, 2]'}::ROW(a JSON)
+----
+{'a': [1, 2]}
+
+query I
+SELECT {'a': 42, 'b': '[1, 2]'}::ROW(a JSON, b JSON)
+----
+{'a': 42, 'b': [1, 2]}
+
+query I
+SELECT {'a': 42, 'b': '[1, 2]'}::ROW(a JSON, b INT[])
+----
+{'a': 42, 'b': [1, 2]}
+
+statement error
+SELECT {'a': 'boom', 'b': '[1, 2]'}::ROW(a JSON, b INT[])
+----
+Malformed JSON
+
+# varchar to struct of json
+query I
+SELECT '{a: [1, 2]}'::ROW(a JSON)
+----
+{'a': [1, 2]}
+
+# map with varchar to json
+query I
+SELECT MAP(['42'], ['88'])::MAP(JSON, JSON)
+----
+{42=88}
+
+# varchar to map of json
+query I
+SELECT '{42=88}'::MAP(JSON, JSON)
+----
+{42=88}
+
+# varchar to union with json
+query I
+SELECT '42'::UNION(u JSON)
+----
+42
+
+# union with varchar to union with json
+query I
+SELECT '42'::UNION(u VARCHAR)::UNION(u JSON)
+----
+42
+
+query I
+SELECT ['42']::UNION(u JSON)[]
+----
+[42]
+
+query I
+SELECT '42'::UNION(u VARCHAR)::JSON
+----
+42


### PR DESCRIPTION
Fixes #6676
Fixes #6677

The issue was that the Varchar -> JSON cast requires a `local_state` which holds the allocation for the JSON object. This was added specifically for the JSON cast - other casts do not make use of this (yet). While the local state was always correctly instantiated for regular casts, nested casts (such as list, struct and union) did not instantiate the local cast state of their child types. This PR fixes that.

In addition, this PR introduces the `optional_ptr` type, which is a safe wrapper for a regular pointer that throws an `InternalException` when a `nullptr` is dereferenced. The `optional_ptr` turns such issues into exceptions instead of crashes and should be used whereever regular pointers are currently used as optional non-owning members. 