### PR TITLE
Fix #6668: correctly report errors that occur during index appends

### DIFF
--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -330,8 +330,7 @@ bool ART::ConstructFromSorted(idx_t count, vector<Key> &keys, Vector &row_identi
 //===--------------------------------------------------------------------===//
 // Insert / Verification / Constraint Checking
 //===--------------------------------------------------------------------===//
-
-bool ART::Insert(IndexLock &lock, DataChunk &input, Vector &row_ids) {
+PreservedError ART::Insert(IndexLock &lock, DataChunk &input, Vector &row_ids) {
 
 	D_ASSERT(row_ids.GetType().InternalType() == ROW_TYPE);
 	D_ASSERT(logical_types[0] == input.data[0].GetType());
@@ -375,12 +374,13 @@ bool ART::Insert(IndexLock &lock, DataChunk &input, Vector &row_ids) {
 
 	IncreaseAndVerifyMemorySize(old_memory_size);
 	if (failed_index != DConstants::INVALID_INDEX) {
-		return false;
+		return PreservedError(ConstraintException("PRIMARY KEY or UNIQUE constraint violated: duplicate key \"%s\"",
+		                                          AppendRowError(input, failed_index)));
 	}
-	return true;
+	return PreservedError();
 }
 
-bool ART::Append(IndexLock &lock, DataChunk &appended_data, Vector &row_identifiers) {
+PreservedError ART::Append(IndexLock &lock, DataChunk &appended_data, Vector &row_identifiers) {
 	DataChunk expression_result;
 	expression_result.Initialize(Allocator::DefaultAllocator(), logical_types);
 

--- a/src/include/duckdb/execution/index/art/art.hpp
+++ b/src/include/duckdb/execution/index/art/art.hpp
@@ -72,7 +72,7 @@ public:
 	          vector<row_t> &result_ids) override;
 
 	//! Called when data is appended to the index. The lock obtained from InitializeLock must be held
-	bool Append(IndexLock &lock, DataChunk &entries, Vector &row_identifiers) override;
+	PreservedError Append(IndexLock &lock, DataChunk &entries, Vector &row_identifiers) override;
 	//! Verify that data can be appended to the index without a constraint violation
 	void VerifyAppend(DataChunk &chunk) override;
 	//! Verify that data can be appended to the index without a constraint violation using the conflict manager
@@ -80,7 +80,7 @@ public:
 	//! Delete a chunk of entries from the index. The lock obtained from InitializeLock must be held
 	void Delete(IndexLock &lock, DataChunk &entries, Vector &row_identifiers) override;
 	//! Insert a chunk of entries into the index
-	bool Insert(IndexLock &lock, DataChunk &data, Vector &row_ids) override;
+	PreservedError Insert(IndexLock &lock, DataChunk &data, Vector &row_ids) override;
 
 	//! Construct an ART from a vector of sorted keys
 	bool ConstructFromSorted(idx_t count, vector<Key> &keys, Vector &row_identifiers);

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -150,8 +150,8 @@ public:
 
 	//! Append a chunk with the row ids [row_start, ..., row_start + chunk.size()] to all indexes of the table, returns
 	//! whether or not the append succeeded
-	bool AppendToIndexes(DataChunk &chunk, row_t row_start);
-	static bool AppendToIndexes(TableIndexList &indexes, DataChunk &chunk, row_t row_start);
+	PreservedError AppendToIndexes(DataChunk &chunk, row_t row_start);
+	static PreservedError AppendToIndexes(TableIndexList &indexes, DataChunk &chunk, row_t row_start);
 	//! Remove a chunk with the row ids [row_start, ..., row_start + chunk.size()] from all indexes of the table
 	void RemoveFromIndexes(TableAppendState &state, DataChunk &chunk, row_t row_start);
 	//! Remove the chunk with the specified set of row identifiers from all indexes of the table

--- a/src/include/duckdb/storage/index.hpp
+++ b/src/include/duckdb/storage/index.hpp
@@ -80,9 +80,9 @@ public:
 	//! Obtain a lock on the index
 	virtual void InitializeLock(IndexLock &state);
 	//! Called when data is appended to the index. The lock obtained from InitializeLock must be held
-	virtual bool Append(IndexLock &state, DataChunk &entries, Vector &row_identifiers) = 0;
+	virtual PreservedError Append(IndexLock &state, DataChunk &entries, Vector &row_identifiers) = 0;
 	//! Obtains a lock and calls Append while holding that lock
-	bool Append(DataChunk &entries, Vector &row_identifiers);
+	PreservedError Append(DataChunk &entries, Vector &row_identifiers);
 	//! Verify that data can be appended to the index without a constraint violation
 	virtual void VerifyAppend(DataChunk &chunk) = 0;
 	//! Verify that data can be appended to the index without a constraint violation using the conflict manager
@@ -96,7 +96,7 @@ public:
 	void Delete(DataChunk &entries, Vector &row_identifiers);
 
 	//! Insert a chunk of entries into the index
-	virtual bool Insert(IndexLock &lock, DataChunk &input, Vector &row_identifiers) = 0;
+	virtual PreservedError Insert(IndexLock &lock, DataChunk &input, Vector &row_identifiers) = 0;
 
 	//! Merge another index into this index. The lock obtained from InitializeLock must be held, and the other
 	//! index must also be locked during the merge
@@ -147,6 +147,7 @@ public:
 
 	//! Execute the index expressions on an input chunk
 	void ExecuteExpressions(DataChunk &input, DataChunk &result);
+	static string AppendRowError(DataChunk &input, idx_t index);
 
 protected:
 	//! Lock used for any changes to the index

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -88,8 +88,8 @@ public:
 
 	void AppendToIndexes(DuckTransaction &transaction, TableAppendState &append_state, idx_t append_count,
 	                     bool append_to_table);
-	bool AppendToIndexes(DuckTransaction &transaction, RowGroupCollection &source, TableIndexList &index_list,
-	                     const vector<LogicalType> &table_types, row_t &start_row);
+	PreservedError AppendToIndexes(DuckTransaction &transaction, RowGroupCollection &source, TableIndexList &index_list,
+	                               const vector<LogicalType> &table_types, row_t &start_row);
 
 	//! Creates an optimistic writer for this table
 	OptimisticDataWriter *CreateOptimisticWriter();

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1206,9 +1206,9 @@ void DataTable::WALAddIndex(ClientContext &context, unique_ptr<Index> index,
 			index->ExecuteExpressions(intermediate, result);
 
 			// insert into the index
-			if (!index->Insert(lock, result, intermediate.data[intermediate.ColumnCount() - 1])) {
-				throw InternalException("Error during WAL replay. Can't create unique index, table contains "
-				                        "duplicate data on indexed column(s).");
+			auto error = index->Insert(lock, result, intermediate.data[intermediate.ColumnCount() - 1]);
+			if (error) {
+				throw InternalException("Error during WAL replay: %s", error.Message());
 			}
 		}
 	}

--- a/src/storage/index.cpp
+++ b/src/storage/index.cpp
@@ -36,7 +36,7 @@ void Index::InitializeLock(IndexLock &state) {
 	state.index_lock = unique_lock<mutex>(lock);
 }
 
-bool Index::Append(DataChunk &entries, Vector &row_identifiers) {
+PreservedError Index::Append(DataChunk &entries, Vector &row_identifiers) {
 	IndexLock state;
 	InitializeLock(state);
 	return Append(state, entries, row_identifiers);
@@ -88,6 +88,17 @@ bool Index::IndexIsUpdated(const vector<PhysicalIndex> &column_ids) const {
 
 BlockPointer Index::Serialize(MetaBlockWriter &writer) {
 	throw NotImplementedException("The implementation of this index serialization does not exist.");
+}
+
+string Index::AppendRowError(DataChunk &input, idx_t index) {
+	string error;
+	for (idx_t c = 0; c < input.ColumnCount(); c++) {
+		if (c > 0) {
+			error += ", ";
+		}
+		error += input.GetValue(c, index).ToString();
+	}
+	return error;
 }
 
 } // namespace duckdb

--- a/test/fuzzer/pedro/buffer_manager_resize_issue.test
+++ b/test/fuzzer/pedro/buffer_manager_resize_issue.test
@@ -32,4 +32,4 @@ INSERT INTO t2(c1,c0) VALUES (235,36),(43,81),(246,187),(28,149),(206,20),(135,1
 statement error
 INSERT INTO t2(c1,c0) VALUES (86,98),(96,107),(237,190),(253,242),(229,9),(6,147);
 ----
-TransactionContext Error: Failed to commit: Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicated key
+Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicate key

--- a/test/fuzzer/pedro/create_index_error.test
+++ b/test/fuzzer/pedro/create_index_error.test
@@ -57,7 +57,7 @@ CREATE INDEX i0 ON t1 (c1, (decode('\x81\x5C\xE5'::BLOB)::VARCHAR));
 statement error
 INSERT INTO t1 VALUES (1);
 ----
-TransactionContext Error: Failed to commit: Conversion Error: Failure in decode: could not convert blob to UTF8 string, the blob contained invalid UTF8 characters
+Conversion Error: Failure in decode: could not convert blob to UTF8 string, the blob contained invalid UTF8 characters
 
 statement ok
 CREATE INDEX i1 ON t1 USING ART (c1);

--- a/test/sql/index/art/test_art_fuzzer_issues.test
+++ b/test/sql/index/art/test_art_fuzzer_issues.test
@@ -30,7 +30,7 @@ CREATE INDEX i2 ON t2 (c1);
 statement error
 INSERT INTO t2 VALUES (decode('g\x00'::BLOB)::VARCHAR),('g');
 ----
-TransactionContext Error: Failed to commit: Not implemented Error: Indexes cannot contain BLOBs that contain null-terminated bytes.
+Not implemented Error: Indexes cannot contain BLOBs that contain null-terminated bytes.
 
 statement ok
 INSERT INTO t2 VALUES ('\0');
@@ -92,7 +92,7 @@ CREATE INDEX i21 ON t21 (c1, "decode"('\x00'::BLOB));
 statement error
 INSERT INTO t21 VALUES (1);
 ----
-TransactionContext Error: Failed to commit: Not implemented Error: Indexes cannot contain BLOBs that contain null-terminated bytes.
+Not implemented Error: Indexes cannot contain BLOBs that contain null-terminated bytes.
 
 statement error
 CREATE INDEX i21 ON t21 (c1);

--- a/test/sql/index/art/test_art_import_export.test
+++ b/test/sql/index/art/test_art_import_export.test
@@ -33,4 +33,4 @@ IMPORT DATABASE '__TEST_DIR__/export_index_db'
 statement error
 INSERT INTO raw VALUES (1, 1, 1, 1);
 ----
-TransactionContext Error: Failed to commit: Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicated key
+Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicate key

--- a/test/sql/storage/test_unique_index_checkpoint.test
+++ b/test/sql/storage/test_unique_index_checkpoint.test
@@ -20,7 +20,7 @@ restart
 statement error
 INSERT INTO test VALUES (1,101),(2,201);
 ----
-TransactionContext Error: Failed to commit: Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicated key
+Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicate key
 
 restart
 
@@ -38,4 +38,4 @@ restart
 statement error
 INSERT INTO unique_index_test VALUES (1,101),(2,201);
 ----
-TransactionContext Error: Failed to commit: Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicated key
+Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicate key

--- a/test/sql/storage/wal/wal_create_index.test
+++ b/test/sql/storage/wal/wal_create_index.test
@@ -45,7 +45,7 @@ logical_opt	<REGEX>:.*INDEX_SCAN.*
 statement error
 INSERT INTO integers VALUES (1, 1);
 ----
-TransactionContext Error: Failed to commit: Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicated key
+Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicate key
 
 restart
 
@@ -97,7 +97,7 @@ SELECT i FROM integers WHERE i + j = 2
 statement error
 INSERT INTO integers VALUES (1, 1);
 ----
-TransactionContext Error: Failed to commit: Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicated key
+Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicate key
 
 statement ok
 DROP INDEX i_index;
@@ -141,7 +141,7 @@ SELECT i FROM integers WHERE j + i = 2
 statement error
 INSERT INTO integers VALUES (1, 1);
 ----
-TransactionContext Error: Failed to commit: Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicated key
+Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicate key
 
 statement ok
 DROP INDEX i_index;
@@ -164,7 +164,7 @@ restart
 statement error
 INSERT INTO integers VALUES (1, 1);
 ----
-TransactionContext Error: Failed to commit: Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicated key
+Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicate key
 
 statement ok
 DROP INDEX i_index;

--- a/test/sql/upsert/upsert_conflict_target.test
+++ b/test/sql/upsert/upsert_conflict_target.test
@@ -17,7 +17,7 @@ create or replace table tbl (
 statement error
 insert into tbl VALUES (1,2,3), (1,2,3);
 ----
-Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicated key
+Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicate key
 
 statement ok
 insert into tbl VALUES (1,2,3), (1,4,5);


### PR DESCRIPTION
Fixes #6668

This PR fixes the behavior of index appends so that when an error occurs while appending to an index, the actual error is displayed. Previously the system would assume that any error that occurred while appending must be a unique constraint violation, but that is no longer the case now that our index correctly tracks memory as OOM errors can also be thrown.
