### PR TITLE
Add date_add alias to interval arithmetic

### DIFF
--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -131,6 +131,10 @@ static DefaultMacro internal_macros[] = {
 	// nested list aggregates
 	{DEFAULT_SCHEMA, "list_histogram", {"l", nullptr}, "list_aggr(l, 'histogram')"},
 
+	// date functions
+	{DEFAULT_SCHEMA, "date_add", {"date", "interval", nullptr}, "date + interval"},
+	{DEFAULT_SCHEMA, "date_sub", {"date", "interval", nullptr}, "date - interval"},
+
 	{nullptr, nullptr, {nullptr}, nullptr}
 	};
 

--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -133,7 +133,6 @@ static DefaultMacro internal_macros[] = {
 
 	// date functions
 	{DEFAULT_SCHEMA, "date_add", {"date", "interval", nullptr}, "date + interval"},
-	{DEFAULT_SCHEMA, "date_sub", {"date", "interval", nullptr}, "date - interval"},
 
 	{nullptr, nullptr, {nullptr}, nullptr}
 	};

--- a/test/sql/function/date/date_add.test
+++ b/test/sql/function/date/date_add.test
@@ -1,0 +1,34 @@
+# name: test/sql/function/date/date_add.test
+# description: Test date_add/date_sub
+# group: [date]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE dates(d DATE);
+
+statement ok
+INSERT INTO dates VALUES (DATE '1992-01-01')
+
+# date_add, bigquery
+query I
+SELECT DATE_ADD(DATE '2008-12-25', INTERVAL 5 DAY) AS five_days_later;
+----
+2008-12-30
+
+query I
+SELECT DATE_ADD(TIMESTAMP '2008-12-25 00:00:00', INTERVAL 5 DAY) AS five_days_later;
+----
+2008-12-30 00:00:00
+
+# date_sub, bigquery
+query I
+SELECT DATE_SUB(DATE '2008-12-25', INTERVAL 5 DAY) AS five_days_ago;
+----
+2008-12-20
+
+query I
+SELECT DATE_SUB(TIMESTAMP '2008-12-25 00:00:00', INTERVAL 5 DAY) AS five_days_later;
+----
+2008-12-20 00:00:00

--- a/test/sql/function/date/date_add.test
+++ b/test/sql/function/date/date_add.test
@@ -21,14 +21,3 @@ query I
 SELECT DATE_ADD(TIMESTAMP '2008-12-25 00:00:00', INTERVAL 5 DAY) AS five_days_later;
 ----
 2008-12-30 00:00:00
-
-# date_sub, bigquery
-query I
-SELECT DATE_SUB(DATE '2008-12-25', INTERVAL 5 DAY) AS five_days_ago;
-----
-2008-12-20
-
-query I
-SELECT DATE_SUB(TIMESTAMP '2008-12-25 00:00:00', INTERVAL 5 DAY) AS five_days_later;
-----
-2008-12-20 00:00:00


### PR DESCRIPTION
This matches the syntax of [BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/date_functions):

```sql
SELECT DATE_ADD(DATE '2008-12-25', INTERVAL 5 DAY) AS five_days_later;
┌─────────────────┐
│ five_days_later │
│      date       │
├─────────────────┤
│ 2008-12-30      │
└─────────────────┘

```