### PR TITLE
Add .col option to duckbox rendering in the shell

### DIFF
--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -197,6 +197,58 @@ list<ColumnDataCollection> BoxRenderer::FetchRenderCollections(ClientContext &co
 	return collections;
 }
 
+list<ColumnDataCollection> BoxRenderer::PivotCollections(ClientContext &context, list<ColumnDataCollection> input, vector<string> &column_names, vector<LogicalType> &result_types, idx_t row_count) {
+	auto &top = input.front();
+	auto &bottom = input.back();
+
+	vector<LogicalType> varchar_types;
+	vector<string> new_names;
+	new_names.emplace_back("Column");
+	new_names.emplace_back("Type");
+	varchar_types.emplace_back(LogicalType::VARCHAR);
+	varchar_types.emplace_back(LogicalType::VARCHAR);
+	for (idx_t r = 0; r < top.Count(); r++) {
+		new_names.emplace_back("Row " + to_string(r + 1));
+		varchar_types.emplace_back(LogicalType::VARCHAR);
+	}
+	for (idx_t r = 0; r < bottom.Count(); r++) {
+		auto row_index = row_count - bottom.Count() + r + 1;
+		new_names.emplace_back("Row " + to_string(row_index));
+		varchar_types.emplace_back(LogicalType::VARCHAR);
+	}
+	//
+	DataChunk row_chunk;
+	row_chunk.Initialize(Allocator::DefaultAllocator(), varchar_types);
+	std::list<ColumnDataCollection> result;
+	result.emplace_back(context, varchar_types);
+	result.emplace_back(context, varchar_types);
+	auto &res_coll = result.front();
+	ColumnDataAppendState append_state;
+	res_coll.InitializeAppend(append_state);
+	for(idx_t c = 0; c < top.ColumnCount(); c++) {
+		vector<column_t> column_ids { c };
+		auto row_index = row_chunk.size();
+		idx_t current_index = 0;
+		row_chunk.SetValue(current_index++, row_index, column_names[c]);
+		row_chunk.SetValue(current_index++, row_index, RenderType(result_types[c]));
+		for(auto &collection : input) {
+			for(auto &chunk : collection.Chunks(column_ids)) {
+				for(idx_t r = 0; r < chunk.size(); r++) {
+					row_chunk.SetValue(current_index++, row_index, chunk.GetValue(0, r));
+				}
+			}
+		}
+		row_chunk.SetCardinality(row_chunk.size() + 1);
+		if (row_chunk.size() == STANDARD_VECTOR_SIZE || c + 1 == top.ColumnCount()) {
+			res_coll.Append(append_state, row_chunk);
+			row_chunk.Reset();
+		}
+	}
+	column_names = std::move(new_names);
+	result_types = std::move(varchar_types);
+	return result;
+}
+
 string ConvertRenderValue(const string &input) {
 	return StringUtil::Replace(StringUtil::Replace(input, "\n", "\\n"), string("\0", 1), "\\0");
 }
@@ -213,11 +265,10 @@ string BoxRenderer::GetRenderValue(ColumnDataRowCollection &rows, idx_t c, idx_t
 	}
 }
 
-vector<idx_t> BoxRenderer::ComputeRenderWidths(const vector<string> &names, const ColumnDataCollection &result,
+vector<idx_t> BoxRenderer::ComputeRenderWidths(const vector<string> &names, const vector<LogicalType> &result_types,
                                                list<ColumnDataCollection> &collections, idx_t min_width,
                                                idx_t max_width, vector<idx_t> &column_map, idx_t &total_length) {
-	auto column_count = result.ColumnCount();
-	auto &result_types = result.Types();
+	auto column_count = result_types.size();
 
 	vector<idx_t> widths;
 	widths.reserve(column_count);
@@ -357,13 +408,15 @@ void BoxRenderer::RenderHeader(const vector<string> &names, const vector<Logical
 	ss << std::endl;
 
 	// render the types
-	for (idx_t c = 0; c < column_count; c++) {
-		auto column_idx = column_map[c];
-		auto type = column_idx == SPLIT_COLUMN ? "" : RenderType(result_types[column_idx]);
-		RenderValue(ss, type, widths[c]);
+	if (config.render_mode == RenderMode::ROWS) {
+		for (idx_t c = 0; c < column_count; c++) {
+			auto column_idx = column_map[c];
+			auto type = column_idx == SPLIT_COLUMN ? "" : RenderType(result_types[column_idx]);
+			RenderValue(ss, type, widths[c]);
+		}
+		ss << config.VERTICAL;
+		ss << std::endl;
 	}
-	ss << config.VERTICAL;
-	ss << std::endl;
 
 	// render the line under the header
 	ss << config.LMIDDLE;
@@ -607,15 +660,18 @@ void BoxRenderer::Render(ClientContext &context, const vector<string> &names, co
 
 	// fetch the top and bottom render collections from the result
 	auto collections = FetchRenderCollections(context, result, top_rows, bottom_rows);
-
-	auto &result_types = result.Types();
+	auto column_names = names;
+	auto result_types = result.Types();
+	if (config.render_mode == RenderMode::COLUMNS) {
+		collections = PivotCollections(context, std::move(collections), column_names, result_types, row_count);
+	}
 
 	// for each column, figure out the width
 	// start off by figuring out the name of the header by looking at the column name and column type
 	idx_t min_width = has_hidden_rows || row_count == 0 ? minimum_row_length : 0;
 	vector<idx_t> column_map;
 	idx_t total_length;
-	auto widths = ComputeRenderWidths(names, result, collections, min_width, max_width, column_map, total_length);
+	auto widths = ComputeRenderWidths(column_names, result_types, collections, min_width, max_width, column_map, total_length);
 
 	// render boundaries for the individual columns
 	vector<idx_t> boundaries;
@@ -631,7 +687,7 @@ void BoxRenderer::Render(ClientContext &context, const vector<string> &names, co
 
 	// now begin rendering
 	// first render the header
-	RenderHeader(names, result_types, column_map, widths, boundaries, total_length, row_count > 0, ss);
+	RenderHeader(column_names, result_types, column_map, widths, boundaries, total_length, row_count > 0, ss);
 
 	// render the values, if there are any
 	RenderValues(collections, column_map, widths, result_types, ss);
@@ -651,7 +707,9 @@ void BoxRenderer::Render(ClientContext &context, const vector<string> &names, co
 	idx_t column_count = column_map.size();
 	if (has_hidden_columns) {
 		column_count--;
-		column_count_str += " (" + to_string(column_count) + " shown)";
+		if (config.render_mode == RenderMode::ROWS) {
+			column_count_str += " (" + to_string(column_count) + " shown)";
+		}
 	}
 	RenderRowCount(std::move(row_count_str), std::move(shown_str), column_count_str, boundaries, has_hidden_rows,
 	               has_hidden_columns, total_length, row_count, column_count, minimum_row_length, ss);

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -197,7 +197,9 @@ list<ColumnDataCollection> BoxRenderer::FetchRenderCollections(ClientContext &co
 	return collections;
 }
 
-list<ColumnDataCollection> BoxRenderer::PivotCollections(ClientContext &context, list<ColumnDataCollection> input, vector<string> &column_names, vector<LogicalType> &result_types, idx_t row_count) {
+list<ColumnDataCollection> BoxRenderer::PivotCollections(ClientContext &context, list<ColumnDataCollection> input,
+                                                         vector<string> &column_names,
+                                                         vector<LogicalType> &result_types, idx_t row_count) {
 	auto &top = input.front();
 	auto &bottom = input.back();
 
@@ -225,15 +227,15 @@ list<ColumnDataCollection> BoxRenderer::PivotCollections(ClientContext &context,
 	auto &res_coll = result.front();
 	ColumnDataAppendState append_state;
 	res_coll.InitializeAppend(append_state);
-	for(idx_t c = 0; c < top.ColumnCount(); c++) {
-		vector<column_t> column_ids { c };
+	for (idx_t c = 0; c < top.ColumnCount(); c++) {
+		vector<column_t> column_ids {c};
 		auto row_index = row_chunk.size();
 		idx_t current_index = 0;
 		row_chunk.SetValue(current_index++, row_index, column_names[c]);
 		row_chunk.SetValue(current_index++, row_index, RenderType(result_types[c]));
-		for(auto &collection : input) {
-			for(auto &chunk : collection.Chunks(column_ids)) {
-				for(idx_t r = 0; r < chunk.size(); r++) {
+		for (auto &collection : input) {
+			for (auto &chunk : collection.Chunks(column_ids)) {
+				for (idx_t r = 0; r < chunk.size(); r++) {
 					row_chunk.SetValue(current_index++, row_index, chunk.GetValue(0, r));
 				}
 			}
@@ -671,7 +673,8 @@ void BoxRenderer::Render(ClientContext &context, const vector<string> &names, co
 	idx_t min_width = has_hidden_rows || row_count == 0 ? minimum_row_length : 0;
 	vector<idx_t> column_map;
 	idx_t total_length;
-	auto widths = ComputeRenderWidths(column_names, result_types, collections, min_width, max_width, column_map, total_length);
+	auto widths =
+	    ComputeRenderWidths(column_names, result_types, collections, min_width, max_width, column_map, total_length);
 
 	// render boundaries for the individual columns
 	vector<idx_t> boundaries;
@@ -705,12 +708,20 @@ void BoxRenderer::Render(ClientContext &context, const vector<string> &names, co
 		}
 	}
 	idx_t column_count = column_map.size();
-	if (has_hidden_columns) {
-		column_count--;
-		if (config.render_mode == RenderMode::ROWS) {
+	if (config.render_mode == RenderMode::COLUMNS) {
+		if (has_hidden_columns) {
+			has_hidden_rows = true;
+			shown_str = " (" + to_string(column_count - 3) + " shown)";
+		} else {
+			shown_str = string();
+		}
+	} else {
+		if (has_hidden_columns) {
+			column_count--;
 			column_count_str += " (" + to_string(column_count) + " shown)";
 		}
 	}
+
 	RenderRowCount(std::move(row_count_str), std::move(shown_str), column_count_str, boundaries, has_hidden_rows,
 	               has_hidden_columns, total_length, row_count, column_count, minimum_row_length, ss);
 }

--- a/src/include/duckdb/common/box_renderer.hpp
+++ b/src/include/duckdb/common/box_renderer.hpp
@@ -18,6 +18,7 @@ class ColumnDataCollection;
 class ColumnDataRowCollection;
 
 enum class ValueRenderAlignment { LEFT, MIDDLE, RIGHT };
+enum class RenderMode { ROWS, COLUMNS };
 
 struct BoxRendererConfig {
 	// a max_width of 0 means we default to the terminal width
@@ -30,7 +31,10 @@ struct BoxRendererConfig {
 	// the max col width determines the maximum size of a single column
 	// note that the max col width is only used if the result does not fit on the screen
 	idx_t max_col_width = 20;
+	//! how to render NULL values
 	string null_value = "NULL";
+	//! Whether or not to render row-wise or column-wise
+	RenderMode render_mode = RenderMode::ROWS;
 
 #ifndef DUCKDB_ASCII_TREE_RENDERER
 	const char *LTCORNER = "\342\224\214"; // "┌";
@@ -94,10 +98,10 @@ private:
 	string RenderType(const LogicalType &type);
 	ValueRenderAlignment TypeAlignment(const LogicalType &type);
 	string GetRenderValue(ColumnDataRowCollection &rows, idx_t c, idx_t r);
-
 	list<ColumnDataCollection> FetchRenderCollections(ClientContext &context, const ColumnDataCollection &result,
 	                                                  idx_t top_rows, idx_t bottom_rows);
-	vector<idx_t> ComputeRenderWidths(const vector<string> &names, const ColumnDataCollection &result,
+	list<ColumnDataCollection> PivotCollections(ClientContext &context, list<ColumnDataCollection> input, vector<string> &column_names, vector<LogicalType> &result_types, idx_t row_count);
+	vector<idx_t> ComputeRenderWidths(const vector<string> &names, const vector<LogicalType> &result_types,
 	                                  list<ColumnDataCollection> &collections, idx_t min_width, idx_t max_width,
 	                                  vector<idx_t> &column_map, idx_t &total_length);
 	void RenderHeader(const vector<string> &names, const vector<LogicalType> &result_types,

--- a/src/include/duckdb/common/box_renderer.hpp
+++ b/src/include/duckdb/common/box_renderer.hpp
@@ -100,7 +100,9 @@ private:
 	string GetRenderValue(ColumnDataRowCollection &rows, idx_t c, idx_t r);
 	list<ColumnDataCollection> FetchRenderCollections(ClientContext &context, const ColumnDataCollection &result,
 	                                                  idx_t top_rows, idx_t bottom_rows);
-	list<ColumnDataCollection> PivotCollections(ClientContext &context, list<ColumnDataCollection> input, vector<string> &column_names, vector<LogicalType> &result_types, idx_t row_count);
+	list<ColumnDataCollection> PivotCollections(ClientContext &context, list<ColumnDataCollection> input,
+	                                            vector<string> &column_names, vector<LogicalType> &result_types,
+	                                            idx_t row_count);
 	vector<idx_t> ComputeRenderWidths(const vector<string> &names, const vector<LogicalType> &result_types,
 	                                  list<ColumnDataCollection> &collections, idx_t min_width, idx_t max_width,
 	                                  vector<idx_t> &column_map, idx_t &total_length);

--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -890,6 +890,24 @@ outstr = open(outfile,'rb').read().decode('utf8')
 if '99' not in outstr:
      raise Exception('.output test failed')
 
+# columnar mode
+test('''
+.col
+select * from range(4);
+''', out='Row 1')
+
+columns = ','.join(["'MyValue" + str(x) + "'" for x in range(100)])
+test(f'''
+.col
+select {columns};
+''', out='MyValue50')
+
+test(f'''
+.col
+select {columns}
+from range(1000)
+''', out='100 columns')
+
 # test null-byte rendering
 test('select varchar from test_all_types();', out='goo\\0se')
 

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -32,7 +32,7 @@ using namespace duckdb;
 using namespace std;
 
 extern "C" {
-char *sqlite3_print_duckbox(sqlite3_stmt *pStmt, size_t max_rows, size_t max_width, char *null_value);
+char *sqlite3_print_duckbox(sqlite3_stmt *pStmt, size_t max_rows, size_t max_width, char *null_value, int columnar);
 }
 
 static char *sqlite3_strdup(const char *str);
@@ -222,7 +222,7 @@ int sqlite3_prepare_v2(sqlite3 *db,           /* Database handle */
 	}
 }
 
-char *sqlite3_print_duckbox(sqlite3_stmt *pStmt, size_t max_rows, size_t max_width, char *null_value) {
+char *sqlite3_print_duckbox(sqlite3_stmt *pStmt, size_t max_rows, size_t max_width, char *null_value, int columnar) {
 	if (!pStmt) {
 		return nullptr;
 	}
@@ -261,6 +261,9 @@ char *sqlite3_print_duckbox(sqlite3_stmt *pStmt, size_t max_rows, size_t max_wid
 	}
 	if (null_value) {
 		config.null_value = null_value;
+	}
+	if (columnar) {
+		config.render_mode = RenderMode::COLUMNS;
 	}
 	config.max_width = max_width;
 	BoxRenderer renderer(config);


### PR DESCRIPTION
This PR adds the `.col` option to the duckbox rendering in the shell, which pivots the rows that are rendered so the columns are displayed on the row-axis instead. This is useful when looking at results with many columns. For example:

```sql
D .maxrows 10
D FROM '~/Data/ontime.parquet/*.parquet';
┌───────┬─────────┬───────┬────────────┬───┬───────────────────┬─────────┬──────────┬───────────────┐
│ year  │ quarter │ month │ dayofmonth │ … │ actualelapsedtime │ flights │ distance │ distancegroup │
│ int64 │  int64  │ int64 │   int64    │   │      double       │ double  │  double  │     int64     │
├───────┼─────────┼───────┼────────────┼───┼───────────────────┼─────────┼──────────┼───────────────┤
│  2017 │       1 │     2 │         26 │ … │             120.0 │     1.0 │    731.0 │             3 │
│  2017 │       1 │     2 │         26 │ … │             155.0 │     1.0 │    731.0 │             3 │
│  2017 │       1 │     2 │         26 │ … │              76.0 │     1.0 │    425.0 │             2 │
│  2017 │       1 │     2 │         26 │ … │              82.0 │     1.0 │    404.0 │             2 │
│  2017 │       1 │     2 │         26 │ … │             184.0 │     1.0 │   1448.0 │             6 │
│    ·  │       · │     · │          · │ · │               ·   │      ·  │      ·   │             · │
│    ·  │       · │     · │          · │ · │               ·   │      ·  │      ·   │             · │
│    ·  │       · │     · │          · │ · │               ·   │      ·  │      ·   │             · │
│  2017 │       3 │     7 │         30 │ … │             230.0 │     1.0 │   1744.0 │             7 │
│  2017 │       3 │     7 │         31 │ … │             227.0 │     1.0 │   1744.0 │             7 │
│  2017 │       3 │     7 │          1 │ … │             246.0 │     1.0 │   1744.0 │             7 │
│  2017 │       3 │     7 │          2 │ … │              NULL │     1.0 │   1744.0 │             7 │
│  2017 │       3 │     7 │          3 │ … │              NULL │     1.0 │   1744.0 │             7 │
├───────┴─────────┴───────┴────────────┴───┴───────────────────┴─────────┴──────────┴───────────────┤
│ 4276457 rows (10 shown)                                                      49 columns (8 shown) │
└───────────────────────────────────────────────────────────────────────────────────────────────────┘
D .col
D FROM '~/Data/ontime.parquet/*.parquet';
┌──────────────────────┬─────────┬──────────────────────┬───┬─────────────────┬─────────────────┐
│        Column        │  Type   │        Row 1         │ … │   Row 4276456   │   Row 4276457   │
├──────────────────────┼─────────┼──────────────────────┼───┼─────────────────┼─────────────────┤
│ year                 │ int64   │                 2017 │ … │            2017 │            2017 │
│ quarter              │ int64   │                    1 │ … │               3 │               3 │
│ month                │ int64   │                    2 │ … │               7 │               7 │
│ dayofmonth           │ int64   │                   26 │ … │              16 │              15 │
│ dayofweek            │ int64   │                    7 │ … │               7 │               6 │
│ flightdate           │ varchar │           2017-02-26 │ … │      2017-07-16 │      2017-07-15 │
│ uniquecarrier        │ varchar │                   DL │ … │              NK │              NK │
│ airlineid            │ double  │              19790.0 │ … │         20416.0 │         20416.0 │
│ carrier              │ varchar │                   DL │ … │              NK │              NK │
│ flightnum            │ varchar │                   30 │ … │             730 │             730 │
│ originairportid      │ int64   │                11298 │ … │           12892 │           12892 │
│ originairportseqid   │ int64   │              1129804 │ … │         1289205 │         1289205 │
│ origincitymarketid   │ int64   │                30194 │ … │           32575 │           32575 │
│ origin               │ varchar │                  DFW │ … │             LAX │             LAX │
│ origincityname       │ varchar │  Dallas/Fort Worth,… │ … │ Los Angeles, CA │ Los Angeles, CA │
│ originstate          │ varchar │                   TX │ … │              CA │              CA │
│ originstatefips      │ varchar │                   48 │ … │              06 │              06 │
│ originstatename      │ varchar │                Texas │ … │      California │      California │
│ originwac            │ double  │                 74.0 │ … │            91.0 │            91.0 │
│ destairportid        │ int64   │                10397 │ … │           13930 │           13930 │
│ destairportseqid     │ int64   │              1039705 │ … │         1393004 │         1393004 │
│ destcitymarketid     │ int64   │                30397 │ … │           30977 │           30977 │
│ dest                 │ varchar │                  ATL │ … │             ORD │             ORD │
│ destcityname         │ varchar │          Atlanta, GA │ … │     Chicago, IL │     Chicago, IL │
│ deststate            │ varchar │                   GA │ … │              IL │              IL │
│ deststatefips        │ varchar │                   13 │ … │              17 │              17 │
│ deststatename        │ varchar │              Georgia │ … │        Illinois │        Illinois │
│ destwac              │ double  │                 34.0 │ … │            41.0 │            41.0 │
│ crsdeptime           │ double  │               1715.0 │ … │           939.0 │           939.0 │
│ deptime              │ double  │               1711.0 │ … │           934.0 │          1056.0 │
│ depdelay             │ double  │                 -4.0 │ … │            -5.0 │            77.0 │
│ depdelayminutes      │ double  │                  0.0 │ … │             0.0 │            77.0 │
│ depdel15             │ double  │                  0.0 │ … │             0.0 │             1.0 │
│ departuredelaygroups │ double  │                 -1.0 │ … │            -1.0 │             5.0 │
│ deptimeblk           │ varchar │            1700-1759 │ … │       0900-0959 │       0900-0959 │
│ crsarrtime           │ double  │               2024.0 │ … │          1544.0 │          1544.0 │
│ arrtime              │ double  │               2011.0 │ … │          1546.0 │          1656.0 │
│ arrdelay             │ double  │                -13.0 │ … │             2.0 │            72.0 │
│ arrdelayminutes      │ double  │                  0.0 │ … │             2.0 │            72.0 │
│ arrdel15             │ double  │                  0.0 │ … │             0.0 │             1.0 │
│ arrivaldelaygroups   │ double  │                 -1.0 │ … │             0.0 │             4.0 │
│ arrtimeblk           │ varchar │            2000-2059 │ … │       1500-1559 │       1500-1559 │
│ cancelled            │ int64   │                    0 │ … │               0 │               0 │
│ diverted             │ int64   │                    0 │ … │               0 │               0 │
│ crselapsedtime       │ double  │                129.0 │ … │           245.0 │           245.0 │
│ actualelapsedtime    │ double  │                120.0 │ … │           252.0 │           240.0 │
│ flights              │ double  │                  1.0 │ … │             1.0 │             1.0 │
│ distance             │ double  │                731.0 │ … │          1744.0 │          1744.0 │
│ distancegroup        │ int64   │                    3 │ … │               7 │               7 │
├──────────────────────┴─────────┴──────────────────────┴───┴─────────────────┴─────────────────┤
│ 4276457 rows  (3 shown)                                                            49 columns │
└───────────────────────────────────────────────────────────────────────────────────────────────┘
```