### PR TITLE
Fix #2743 by removing NotImplementedException in CreateUnionPipeline

### DIFF
--- a/src/parallel/meta_pipeline.cpp
+++ b/src/parallel/meta_pipeline.cpp
@@ -133,10 +133,6 @@ bool MetaPipeline::HasFinishEvent(Pipeline *pipeline) {
 }
 
 Pipeline *MetaPipeline::CreateUnionPipeline(Pipeline &current, bool order_matters) {
-	if (HasRecursiveCTE()) {
-		throw NotImplementedException("UNIONS are not supported in recursive CTEs yet");
-	}
-
 	// create the union pipeline (batch index 0, should be set correctly afterwards)
 	auto union_pipeline = CreatePipeline();
 	state.SetPipelineOperators(*union_pipeline, state.GetPipelineOperators(current));

--- a/test/issues/general/test_2743.test
+++ b/test/issues/general/test_2743.test
@@ -112,7 +112,7 @@ SELECT * FROM t ORDER BY x, y;
 10	1
 
 statement ok
-CREATE TEMP TABLE flights (
+CREATE TABLE flights (
   source  TEXT,
   dest    TEXT,
   carrier TEXT
@@ -128,7 +128,7 @@ INSERT INTO flights VALUES
 ;
 
 statement ok
-CREATE TEMP TABLE trains (
+CREATE TABLE trains (
   source TEXT,
   dest   TEXT
 );

--- a/test/issues/general/test_2743.test
+++ b/test/issues/general/test_2743.test
@@ -110,3 +110,137 @@ SELECT * FROM t ORDER BY x, y;
 8	1
 9	1
 10	1
+
+statement ok
+CREATE TEMP TABLE flights (
+  source  TEXT,
+  dest    TEXT,
+  carrier TEXT
+);
+
+statement ok
+INSERT INTO flights VALUES
+('A', 'B', 'C1'),
+('A', 'C', 'C2'),
+('A', 'D', 'C1'),
+('B', 'D', 'C3'),
+('C', 'E', 'C3')
+;
+
+statement ok
+CREATE TEMP TABLE trains (
+  source TEXT,
+  dest   TEXT
+);
+
+statement ok
+INSERT INTO trains VALUES
+('B', 'C'),
+('A', 'E'),
+('C', 'E')
+;
+
+query III
+WITH RECURSIVE connections(source, dest, carrier) AS (
+     (SELECT f.source, f.dest, f.carrier
+      FROM flights f
+      WHERE f.source = 'A'
+    UNION ALL
+      SELECT r.source, r.dest, 'Rail' AS carrier
+      FROM trains r
+      WHERE r.source = 'A')
+  UNION ALL -- two recursive terms below
+     (SELECT c.source, f.dest, f.carrier
+      FROM connections c, flights f
+      WHERE c.dest = f.source
+    UNION ALL
+      SELECT c.source, r.dest, 'Rail' AS carrier
+      FROM connections c, trains r
+      WHERE c.dest = r.source)
+)
+SELECT * FROM connections;
+----
+A	B	C1
+A	C	C2
+A	D	C1
+A	E	Rail
+A	D	C3
+A	E	C3
+A	C	Rail
+A	E	Rail
+A	E	C3
+A	E	Rail
+
+query I
+WITH RECURSIVE t(x) AS
+(
+  (SELECT 2
+    UNION
+  SELECT 1)
+    UNION ALL
+  (SELECT x+1
+  FROM   t
+  WHERE  x < 4
+    UNION
+  SELECT x*2
+  FROM   t
+  WHERE  x >= 4 AND x < 8
+    UNION ALL
+  SELECT x+1
+  FROM   t
+  WHERE  x >= 4 AND x < 8)
+) SELECT * FROM t ORDER BY x;
+----
+1
+2
+2
+3
+3
+4
+4
+5
+5
+6
+6
+7
+7
+8
+8
+8
+8
+10
+10
+12
+12
+14
+14
+
+query I
+WITH RECURSIVE foo(i) AS
+    (values (1)
+      UNION
+    (SELECT i+1 FROM foo WHERE i < 2
+      UNION ALL
+    SELECT i+1 FROM foo WHERE i < 2
+      UNION
+    SELECT i+1 FROM foo WHERE i < 2
+      UNION ALL
+    SELECT i+1 FROM foo WHERE i < 2
+      UNION
+    SELECT i+1 FROM foo WHERE i < 2
+      UNION ALL
+    SELECT i+1 FROM foo WHERE i < 2
+      UNION
+    SELECT i+1 FROM foo WHERE i < 2
+      UNION ALL
+    SELECT i+1 FROM foo WHERE i < 2
+      UNION
+    SELECT i+1 FROM foo WHERE i < 2
+      UNION ALL
+    SELECT i+1 FROM foo WHERE i < 2
+      UNION
+    SELECT i+1 FROM foo WHERE i < 2)
+) SELECT * FROM foo;
+----
+1
+2

--- a/test/issues/general/test_2743.test
+++ b/test/issues/general/test_2743.test
@@ -15,9 +15,7 @@ WITH RECURSIVE t(x, y) AS
   (SELECT x+1, 1
   FROM   t
   WHERE  x < 10 AND y = 1
-
     UNION ALL
-
   SELECT x+1, 2
   FROM   t
   WHERE  x < 10 AND y = 2)
@@ -94,14 +92,12 @@ WITH RECURSIVE t(x, y) AS
   (SELECT x+1, 1
   FROM   t
   WHERE  x < 10 AND y = 1
-
     UNION ALL
-
   SELECT x+1, 1
   FROM   t
   WHERE  x < 10 AND y = 2)
 )
-SELECT * FROM t;
+SELECT * FROM t ORDER BY x, y;
 ----
 1	1
 1	2

--- a/test/issues/general/test_2743.test
+++ b/test/issues/general/test_2743.test
@@ -1,0 +1,116 @@
+# name: test/issues/general/test_2743.test
+# description: Issue 2743: RuntimeError: Not implemented Error: UNIONS are not supported in recursive CTEs yet
+# group: [general]
+
+statement ok
+PRAGMA enable_verification
+
+query II
+WITH RECURSIVE t(x, y) AS
+(
+  SELECT 1, 1
+    UNION ALL
+  SELECT 1, 2
+    UNION ALL
+  (SELECT x+1, 1
+  FROM   t
+  WHERE  x < 10 AND y = 1
+
+    UNION ALL
+
+  SELECT x+1, 2
+  FROM   t
+  WHERE  x < 10 AND y = 2)
+)
+SELECT * FROM t ORDER BY x, y;
+----
+1	1
+1	2
+2	1
+2	2
+3	1
+3	2
+4	1
+4	2
+5	1
+5	2
+6	1
+6	2
+7	1
+7	2
+8	1
+8	2
+9	1
+9	2
+10	1
+10	2
+
+query II
+WITH RECURSIVE t(x, y) AS
+(
+  SELECT 1, 1
+    UNION ALL
+  SELECT 1, 2
+    UNION ALL
+  SELECT t, z
+  FROM   t, LATERAL
+    (SELECT x+1, 2
+     WHERE  t.y = 1
+      UNION ALL
+     SELECT x+1, 1
+     WHERE t.y = 2) AS _(t, z)
+  WHERE t.x < 10
+)
+SELECT * FROM t ORDER BY x, y;
+----
+1	1
+1	2
+2	1
+2	2
+3	1
+3	2
+4	1
+4	2
+5	1
+5	2
+6	1
+6	2
+7	1
+7	2
+8	1
+8	2
+9	1
+9	2
+10	1
+10	2
+
+query II
+WITH RECURSIVE t(x, y) AS
+(
+  SELECT 1, 1
+    UNION
+  SELECT 1, 2
+    UNION
+  (SELECT x+1, 1
+  FROM   t
+  WHERE  x < 10 AND y = 1
+
+    UNION ALL
+
+  SELECT x+1, 1
+  FROM   t
+  WHERE  x < 10 AND y = 2)
+)
+SELECT * FROM t;
+----
+1	1
+1	2
+2	1
+3	1
+4	1
+5	1
+6	1
+7	1
+8	1
+9	1
+10	1


### PR DESCRIPTION
This pr fixes #2743.

Some tests:

```
WITH RECURSIVE t(x, y) AS
(
  SELECT 1, 1
    UNION ALL
  SELECT 1, 2
    UNION ALL
  (SELECT x+1, 1
  FROM   t
  WHERE  x < 10 AND y = 1

    UNION ALL
  
  SELECT x+1, 2
  FROM   t
  WHERE  x < 10 AND y = 2)
)
SELECT * FROM t;
```

```
WITH RECURSIVE t(x, y) AS
(
  SELECT 1, 1
    UNION ALL
  SELECT 1, 2
    UNION ALL
  SELECT t, z
  FROM   t, LATERAL
    (SELECT x+1, 2
     WHERE  t.y = 1
      UNION ALL
     SELECT x+1, 1
     WHERE t.y = 2) AS _(t, z)
  WHERE t.x < 10
)
SELECT * FROM t;
```

```

WITH RECURSIVE t(x, y) AS
(
  SELECT 1, 1
    UNION
  SELECT 1, 2
    UNION
  (SELECT x+1, 1
  FROM   t
  WHERE  x < 10 AND y = 1

    UNION ALL
  
  SELECT x+1, 1
  FROM   t
  WHERE  x < 10 AND y = 2)
)
SELECT * FROM t;
```

These queries return the expected result.
Therefore I think, the exception is no longer required and should be removed.