### PR TITLE
[Python] Fix crash in Jupyter environment related to progress bars

### DIFF
--- a/src/common/progress_bar/progress_bar.cpp
+++ b/src/common/progress_bar/progress_bar.cpp
@@ -4,6 +4,13 @@
 
 namespace duckdb {
 
+void ProgressBar::SystemOverrideCheck(ClientConfig &config) {
+	if (config.system_progress_bar_disable_reason != nullptr) {
+		throw InvalidInputException("Could not change the progress bar setting because: '%s'",
+		                            config.system_progress_bar_disable_reason);
+	}
+}
+
 unique_ptr<ProgressBarDisplay> ProgressBar::DefaultProgressBarDisplay() {
 	return make_unique<TerminalProgressBarDisplay>();
 }

--- a/src/include/duckdb/common/progress_bar/progress_bar.hpp
+++ b/src/include/duckdb/common/progress_bar/progress_bar.hpp
@@ -16,11 +16,13 @@
 
 namespace duckdb {
 
+struct ClientConfig;
 typedef unique_ptr<ProgressBarDisplay> (*progress_bar_display_create_func_t)();
 
 class ProgressBar {
 public:
 	static unique_ptr<ProgressBarDisplay> DefaultProgressBarDisplay();
+	static void SystemOverrideCheck(ClientConfig &config);
 
 	explicit ProgressBar(
 	    Executor &executor, idx_t show_progress_after,

--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -40,6 +40,8 @@ struct ClientConfig {
 	//! to output anything
 	bool emit_profiler_output = true;
 
+	//! system-wide progress bar disable.
+	char *system_progress_bar_disable_reason = nullptr;
 	//! If the progress bar is enabled or not.
 	bool enable_progress_bar = false;
 	//! If the print of the progress bar is enabled

--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -41,7 +41,7 @@ struct ClientConfig {
 	bool emit_profiler_output = true;
 
 	//! system-wide progress bar disable.
-	char *system_progress_bar_disable_reason = nullptr;
+	const char *system_progress_bar_disable_reason = nullptr;
 	//! If the progress bar is enabled or not.
 	bool enable_progress_bar = false;
 	//! If the print of the progress bar is enabled

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -454,11 +454,15 @@ Value CustomExtensionRepository::GetSetting(ClientContext &context) {
 //===--------------------------------------------------------------------===//
 
 void EnableProgressBarSetting::ResetLocal(ClientContext &context) {
-	ClientConfig::GetConfig(context).enable_progress_bar = ClientConfig().enable_progress_bar;
+	auto &config = ClientConfig::GetConfig(context);
+	ProgressBar::SystemOverrideCheck(config);
+	config.enable_progress_bar = ClientConfig().enable_progress_bar;
 }
 
 void EnableProgressBarSetting::SetLocal(ClientContext &context, const Value &input) {
-	ClientConfig::GetConfig(context).enable_progress_bar = input.GetValue<bool>();
+	auto &config = ClientConfig::GetConfig(context);
+	ProgressBar::SystemOverrideCheck(config);
+	config.enable_progress_bar = input.GetValue<bool>();
 }
 
 Value EnableProgressBarSetting::GetSetting(ClientContext &context) {
@@ -469,11 +473,15 @@ Value EnableProgressBarSetting::GetSetting(ClientContext &context) {
 // Enable Progress Bar Print
 //===--------------------------------------------------------------------===//
 void EnableProgressBarPrintSetting::SetLocal(ClientContext &context, const Value &input) {
-	ClientConfig::GetConfig(context).print_progress_bar = input.GetValue<bool>();
+	auto &config = ClientConfig::GetConfig(context);
+	ProgressBar::SystemOverrideCheck(config);
+	config.print_progress_bar = input.GetValue<bool>();
 }
 
 void EnableProgressBarPrintSetting::ResetLocal(ClientContext &context) {
-	ClientConfig::GetConfig(context).print_progress_bar = ClientConfig().print_progress_bar;
+	auto &config = ClientConfig::GetConfig(context);
+	ProgressBar::SystemOverrideCheck(config);
+	config.print_progress_bar = ClientConfig().print_progress_bar;
 }
 
 Value EnableProgressBarPrintSetting::GetSetting(ClientContext &context) {
@@ -878,13 +886,17 @@ Value ProfilingModeSetting::GetSetting(ClientContext &context) {
 //===--------------------------------------------------------------------===//
 
 void ProgressBarTimeSetting::ResetLocal(ClientContext &context) {
-	ClientConfig::GetConfig(context).wait_time = ClientConfig().wait_time;
-	ClientConfig::GetConfig(context).enable_progress_bar = ClientConfig().enable_progress_bar;
+	auto &config = ClientConfig::GetConfig(context);
+	ProgressBar::SystemOverrideCheck(config);
+	config.wait_time = ClientConfig().wait_time;
+	config.enable_progress_bar = ClientConfig().enable_progress_bar;
 }
 
 void ProgressBarTimeSetting::SetLocal(ClientContext &context, const Value &input) {
-	ClientConfig::GetConfig(context).wait_time = input.GetValue<int32_t>();
-	ClientConfig::GetConfig(context).enable_progress_bar = true;
+	auto &config = ClientConfig::GetConfig(context);
+	ProgressBar::SystemOverrideCheck(config);
+	config.wait_time = input.GetValue<int32_t>();
+	config.enable_progress_bar = true;
 }
 
 Value ProgressBarTimeSetting::GetSetting(ClientContext &context) {

--- a/tools/pythonpkg/src/jupyter/jupyter_progress_bar_display.cpp
+++ b/tools/pythonpkg/src/jupyter/jupyter_progress_bar_display.cpp
@@ -17,7 +17,7 @@ void JupyterProgressBarDisplay::Initialize() {
 	style["bar_color"] = "black";
 	progress_bar = float_progress_attr((py::arg("min") = 0, py::arg("max") = 100, py::arg("style") = style));
 
-	progress_bar.attr("layout").attr("width") = "100%";
+	progress_bar.attr("layout").attr("width") = "auto";
 
 	// Display the progress bar
 	auto display_attr = import_cache.IPython().display.display();

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -1274,9 +1274,6 @@ static bool HasJupyterProgressBarDependencies() {
 		// ipywidgets not installed, needed to support the progress bar
 		return false;
 	}
-	if (!import_cache.IPython().IsLoaded()) {
-		return false;
-	}
 	return true;
 }
 
@@ -1295,8 +1292,7 @@ static void SetDefaultConfigArguments(ClientContext &context) {
 	if (!HasJupyterProgressBarDependencies()) {
 		// Disable progress bar altogether
 		config.system_progress_bar_disable_reason =
-		    "to render a progress bar in a Jupyter environment, we require both 'ipywidgets' and 'IPython' to be "
-		    "installed, one or both of those are missing";
+		    "required package 'ipywidgets' is missing, which is needed to render progress bars in Jupyter";
 		config.enable_progress_bar = false;
 		return;
 	}

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -1294,8 +1294,9 @@ static void SetDefaultConfigArguments(ClientContext &context) {
 	}
 	if (!HasJupyterProgressBarDependencies()) {
 		// Disable progress bar altogether
-		config.system_progress_bar_disable_reason = "either 'ipywidgets' or 'IPython' modules are not installed, so we "
-		                                            "can not render a progress bar in a Jupyter environment";
+		config.system_progress_bar_disable_reason =
+		    "to render a progress bar in a Jupyter environment, we require both 'ipywidgets' and 'IPython' to be "
+		    "installed, one or both of those are missing";
 		config.enable_progress_bar = false;
 		return;
 	}


### PR DESCRIPTION
This PR fixes #6815 

Thanks to all the investigating does by the lovely people in the mentioned issue, the issue became clear and the fix is relatively straight forward.

The issue is that there are some packages we depend on to render a progress bar in Jupyter, so I added a check for those dependencies before enabling the progress bar.
Furthermore, without the `ipywidgets` package installed, we can't render any sort of progress bar in Jupyter or we're faced with a freeze/crash.
So I've also disabled altering the progress bar settings entirely when these dependencies are not present.
When attempting to alter any of the progress bar settings explicitly through PRAGMA or SET statements, you are met with the following error:
```
InvalidInputException: Invalid Input Error: Could not change the progress bar setting because: 'either 'ipywidgets' or 'IPython' modules are not installed, so we can not render a progress bar in a Jupyter environment'
```