### PR TITLE
Enable BuildPipelines for nested recursive CTEs

### DIFF
--- a/src/execution/operator/join/physical_join.cpp
+++ b/src/execution/operator/join/physical_join.cpp
@@ -61,9 +61,6 @@ void PhysicalJoin::BuildJoinPipelines(Pipeline &current, MetaPipeline &meta_pipe
 	bool add_child_pipeline = false;
 	auto &join_op = (PhysicalJoin &)op;
 	if (IsRightOuterJoin(join_op.join_type)) {
-		if (meta_pipeline.HasRecursiveCTE()) {
-			throw NotImplementedException("FULL and RIGHT outer joins are not supported in recursive CTEs yet");
-		}
 		add_child_pipeline = true;
 	}
 

--- a/src/execution/operator/set/physical_recursive_cte.cpp
+++ b/src/execution/operator/set/physical_recursive_cte.cpp
@@ -180,10 +180,6 @@ void PhysicalRecursiveCTE::BuildPipelines(Pipeline &current, MetaPipeline &meta_
 	auto &executor = meta_pipeline.GetExecutor();
 	executor.AddRecursiveCTE(this);
 
-	if (meta_pipeline.HasRecursiveCTE()) {
-		throw InternalException("Recursive CTE detected WITHIN a recursive CTE node");
-	}
-
 	// the LHS of the recursive CTE is our initial state
 	auto initial_state_pipeline = meta_pipeline.CreateChildMetaPipeline(current, this);
 	initial_state_pipeline->Build(children[0].get());

--- a/src/parallel/meta_pipeline.cpp
+++ b/src/parallel/meta_pipeline.cpp
@@ -156,9 +156,6 @@ Pipeline *MetaPipeline::CreateUnionPipeline(Pipeline &current, bool order_matter
 void MetaPipeline::CreateChildPipeline(Pipeline &current, PhysicalOperator *op, Pipeline *last_pipeline) {
 	// rule 2: 'current' must be fully built (down to the source) before creating the child pipeline
 	D_ASSERT(current.source);
-	if (HasRecursiveCTE()) {
-		throw NotImplementedException("Child pipelines are not supported in recursive CTEs yet");
-	}
 
 	// create the child pipeline (same batch index)
 	pipelines.emplace_back(state.CreateChildPipeline(executor, current, op));

--- a/test/issues/general/test_2554.test
+++ b/test/issues/general/test_2554.test
@@ -1,0 +1,38 @@
+# name: test/issues/general/test_2554.test
+# description: Issue 2554: a recursive CTE SQL works in Sqlite reports a within error in duckdb
+# group: [general]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+WITH RECURSIVE
+input(sud) AS (
+VALUES('53..7....6..195....98....6.8...6...34..8.3..17...2...6.6....28....419..5....8..79')
+),
+digits(z, lp) AS (
+VALUES('1', 1)
+UNION ALL SELECT
+CAST(lp+1 AS TEXT), lp+1 FROM digits WHERE lp<9
+),
+x(s, ind) AS (
+SELECT sud, instr(sud, '.') FROM input
+UNION ALL
+SELECT
+substr(s, 1, ind::int-1) || z || substr(s, ind::int+1),
+instr( substr(s, 1, ind::int-1) || z || substr(s, ind::int+1), '.' )
+FROM x, digits AS z
+WHERE ind::int>0
+AND NOT EXISTS (
+SELECT 1
+FROM digits AS lp
+WHERE z.z = substr(s, ((ind::int-1)/9)*9 + lp, 1)
+OR z.z = substr(s, ((ind::int-1)%9) + (lp-1)*9 + 1, 1)
+OR z.z = substr(s, (((ind::int-1)/3) % 3) * 3
++ ((ind::int-1)/27) * 27 + lp
++ ((lp-1) / 3) * 6, 1)
+)
+)
+SELECT s FROM x WHERE ind::int=0;
+----
+534678912672195348198342567859761423426853791713924856961537284287419635345286179

--- a/test/issues/general/test_5200.test
+++ b/test/issues/general/test_5200.test
@@ -1,0 +1,22 @@
+# name: test/issues/general/test_5200.test
+# description: Issue 5200: a CTE SQL cause INTERNAL Error: Recursive CTE detected WITHIN a recursive CTE node then FATAL Error: Failed: database has been invalidated!
+# group: [general]
+
+statement ok
+PRAGMA enable_verification
+
+statement error
+with recursive f(n,f) as (  ------- 构造阶乘表
+select 0,1::bigint
+union all
+select n+1,f*(n+1)::bigint from f where n<45
+)
+,t(n,s,f) as (
+select 1,lv-1,1::bigint from (values(1),(2))s(lv)
+union all
+select t.n+1,t.s+f.n,t.f*f.f::bigint
+  from t
+       ,f
+where t.n<9 and f.n<=t.n+1
+)
+select sum(f.f/t.f) from t,f where t.n=4 and t.s>0 and t.s=f.n;

--- a/test/sql/cte/test_nested_recursive_cte.test
+++ b/test/sql/cte/test_nested_recursive_cte.test
@@ -1,0 +1,59 @@
+# name: test/sql/cte/test_nested_recursive_cte.test
+# description: Test Nested Recursive Common Table Expressions (CTE)
+# group: [cte]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+WITH RECURSIVE t(x) AS
+(
+  SELECT 1
+    UNION ALL
+  SELECT x+1
+  FROM   t
+  WHERE  x < 4
+),
+u(x) AS
+(
+  SELECT *
+  FROM   t
+    UNION ALL
+  SELECT u.x * 2 + t.x
+  FROM   u, t
+  WHERE  u.x < 32
+)
+SELECT *
+FROM   u
+ORDER BY x
+LIMIT 5;
+----
+1
+2
+3
+3
+4
+
+query III
+WITH RECURSIVE collatz(x, t, steps) AS
+(
+  SELECT x, x, 0
+  FROM   (WITH RECURSIVE n(t) AS (SELECT 1 UNION ALL SELECT t+1 FROM n WHERE t < 10) SELECT * FROM n) AS _(x)
+    UNION ALL
+  (SELECT x, CASE WHEN t%2 = 1 THEN t * 3 + p ELSE t / 2 END, steps + p
+   FROM   collatz, (WITH RECURSIVE n(t) AS (SELECT 1 UNION ALL SELECT t+1 FROM n WHERE t < 1) SELECT * FROM n) AS _(p)
+   WHERE  t <> 1)
+)
+SELECT * FROM collatz WHERE t = 1
+ORDER BY x;
+----
+1	1	0
+2	1	1
+3	1	7
+4	1	 2
+5	1	 5
+6	1	 8
+7	1	16
+8	1	 3
+9	1	19
+10	1	6

--- a/test/sql/cte/test_outer_joins_recursive_cte.test
+++ b/test/sql/cte/test_outer_joins_recursive_cte.test
@@ -1,0 +1,30 @@
+# name: test/sql/cte/test_outer_joins_recursive_cte.test
+# description: Test Recursive Common Table Expressions (CTE) with outer joins
+# group: [cte]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE v(x INT);
+
+statement ok
+INSERT INTO v
+VALUES
+(1),(2),(3);
+
+query II
+WITH RECURSIVE t(x) AS
+(
+  SELECT 1
+    UNION ALL
+  SELECT x + 1
+  FROM   (SELECT t.x+1 FROM v AS _(p) FULL OUTER JOIN t ON t.x = p) AS _(x)
+  WHERE  x < 10
+) SELECT * FROM v AS _(p) RIGHT OUTER JOIN t ON t.x = p;
+----
+1	1
+3	3
+NULL	5
+NULL	7
+NULL	9

--- a/test/sql/cte/test_outer_joins_recursive_cte.test
+++ b/test/sql/cte/test_outer_joins_recursive_cte.test
@@ -21,7 +21,7 @@ WITH RECURSIVE t(x) AS
   SELECT x + 1
   FROM   (SELECT t.x+1 FROM v AS _(p) FULL OUTER JOIN t ON t.x = p) AS _(x)
   WHERE  x < 10
-) SELECT * FROM v AS _(p) RIGHT OUTER JOIN t ON t.x = p;
+) SELECT * FROM v AS _(p) RIGHT OUTER JOIN t ON t.x = p ORDER BY p NULLS LAST;
 ----
 1	1
 3	3


### PR DESCRIPTION
This pr allows the construction of pipelines with nested recursive CTEs. I think #4970 fixed this.

As a result of this pr, issues #2554, and #5200 are fixed.