### PR TITLE
[Python/Dev] Add implicit conversion from None -> duckdb.default_connection

### DIFF
--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -114,6 +114,54 @@ static void InitializeConnectionMethods(py::module_ &m) {
 	         py::arg("name"), py::arg("connection") = py::none(), py::arg("columns") = py::none(),
 	         py::arg("sample_size") = py::none(), py::arg("maximum_depth") = py::none());
 
+	m.def("values", &PyConnectionWrapper::Values, "Create a relation object from the passed values", py::arg("values"),
+	      py::arg("connection") = py::none());
+	m.def("from_query", &PyConnectionWrapper::FromQuery, "Create a relation object from the given SQL query",
+	      py::arg("query"), py::arg("alias") = "query_relation", py::arg("connection") = py::none());
+	m.def("query", &PyConnectionWrapper::RunQuery,
+	      "Run a SQL query. If it is a SELECT statement, create a relation object from the given SQL query, otherwise "
+	      "run the query as-is.",
+	      py::arg("query"), py::arg("alias") = "query_relation", py::arg("connection") = py::none());
+	m.def("from_substrait", &PyConnectionWrapper::FromSubstrait, "Creates a query object from the substrait plan",
+	      py::arg("proto"), py::arg("connection") = py::none());
+	m.def("get_substrait", &PyConnectionWrapper::GetSubstrait, "Serialize a query object to protobuf", py::arg("query"),
+	      py::arg("connection") = py::none(), py::kw_only(), py::arg("enable_optimizer") = true);
+	m.def("get_substrait_json", &PyConnectionWrapper::GetSubstraitJSON, "Serialize a query object to protobuf",
+	      py::arg("query"), py::arg("connection") = py::none(), py::kw_only(), py::arg("enable_optimizer") = true);
+	m.def("from_substrait_json", &PyConnectionWrapper::FromSubstraitJSON, "Serialize a query object to protobuf",
+	      py::arg("json"), py::arg("connection") = py::none());
+	m.def("df", &PyConnectionWrapper::FromDF, "Create a relation object from the DataFrame df", py::arg("df"),
+	      py::arg("connection") = py::none());
+	m.def("from_df", &PyConnectionWrapper::FromDF, "Create a relation object from the DataFrame df", py::arg("df"),
+	      py::arg("connection") = py::none());
+	m.def("from_arrow", &PyConnectionWrapper::FromArrow, "Create a relation object from an Arrow object",
+	      py::arg("arrow_object"), py::arg("connection") = py::none());
+	m.def("arrow", &PyConnectionWrapper::FromArrow, "Create a relation object from an Arrow object",
+	      py::arg("arrow_object"), py::arg("connection") = py::none());
+	m.def("filter", &PyConnectionWrapper::FilterDf, "Filter the DataFrame df by the filter in filter_expr",
+	      py::arg("df"), py::arg("filter_expr"), py::arg("connection") = py::none());
+	m.def("project", &PyConnectionWrapper::ProjectDf, "Project the DataFrame df by the projection in project_expr",
+	      py::arg("df"), py::arg("project_expr"), py::arg("connection") = py::none());
+	m.def("alias", &PyConnectionWrapper::AliasDF, "Create a relation from DataFrame df with the passed alias",
+	      py::arg("df"), py::arg("alias"), py::arg("connection") = py::none());
+	m.def("order", &PyConnectionWrapper::OrderDf, "Reorder the DataFrame df by order_expr", py::arg("df"),
+	      py::arg("order_expr"), py::arg("connection") = py::none());
+	m.def("aggregate", &PyConnectionWrapper::AggregateDF,
+	      "Compute the aggregate aggr_expr by the optional groups group_expr on DataFrame df", py::arg("df"),
+	      py::arg("aggr_expr"), py::arg("group_expr") = "", py::arg("connection") = py::none());
+	m.def("distinct", &PyConnectionWrapper::DistinctDF, "Compute the distinct rows from DataFrame df ", py::arg("df"),
+	      py::arg("connection") = py::none());
+	m.def("limit", &PyConnectionWrapper::LimitDF, "Retrieve the first n rows from the DataFrame df", py::arg("df"),
+	      py::arg("n"), py::arg("connection") = py::none());
+
+	m.def("query_df", &PyConnectionWrapper::QueryDF,
+	      "Run the given SQL query in sql_query on the view named virtual_table_name that contains the content of "
+	      "DataFrame df",
+	      py::arg("df"), py::arg("virtual_table_name"), py::arg("sql_query"), py::arg("connection") = py::none());
+
+	m.def("write_csv", &PyConnectionWrapper::WriteCsvDF, "Write the DataFrame df to a CSV file in file_name",
+	      py::arg("df"), py::arg("file_name"), py::arg("connection") = py::none());
+
 	DefineMethod(
 	    {"read_csv", "from_csv_auto"}, m, &PyConnectionWrapper::ReadCSV,
 	    "Create a relation object from the CSV file in 'name'", py::arg("name"), py::arg("connection") = py::none(),
@@ -141,11 +189,7 @@ static void InitializeConnectionMethods(py::module_ &m) {
 	         "Create a relation object from the name'd table function with given parameters", py::arg("name"),
 	         py::arg("parameters") = py::none(), py::arg("connection") = py::none())
 	    .def("from_query", &PyConnectionWrapper::FromQuery, "Create a relation object from the given SQL query",
-	         py::arg("query"), py::arg("alias") = "query_relation", py::arg("connection") = py::none())
-	    .def("from_df", &PyConnectionWrapper::FromDF, "Create a relation object from the DataFrame in df",
-	         py::arg("df") = py::none(), py::arg("connection") = py::none())
-	    .def("from_arrow", &PyConnectionWrapper::FromArrow, "Create a relation object from an Arrow object",
-	         py::arg("arrow_object"), py::arg("connection") = py::none());
+	         py::arg("query"), py::arg("alias") = "query_relation", py::arg("connection") = py::none());
 
 	DefineMethod({"query", "sql"}, m, &PyConnectionWrapper::RunQuery,
 	             "Run a SQL query. If it is a SELECT statement, create a relation object from the given SQL query, "
@@ -234,64 +278,6 @@ PYBIND11_MODULE(DUCKDB_PYTHON_LIB_NAME, m) {
 	    .value("keyword", PySQLTokenType::PY_SQL_TOKEN_KEYWORD)
 	    .value("comment", PySQLTokenType::PY_SQL_TOKEN_COMMENT)
 	    .export_values();
-
-	m.def("values", &DuckDBPyRelation::Values, "Create a relation object from the passed values", py::arg("values"),
-	      py::arg("connection") = py::none());
-	m.def("from_query", &DuckDBPyRelation::FromQuery, "Create a relation object from the given SQL query",
-	      py::arg("query"), py::arg("alias") = "query_relation", py::arg("connection") = py::none());
-	m.def("query", &DuckDBPyRelation::RunQuery,
-	      "Run a SQL query. If it is a SELECT statement, create a relation object from the given SQL query, otherwise "
-	      "run the query as-is.",
-	      py::arg("query"), py::arg("alias") = "query_relation", py::arg("connection") = py::none());
-	m.def("from_substrait", &DuckDBPyRelation::FromSubstrait, "Creates a query object from the substrait plan",
-	      py::arg("proto"), py::arg("connection") = py::none());
-	m.def("get_substrait", &DuckDBPyRelation::GetSubstrait, "Serialize a query object to protobuf", py::arg("query"),
-	      py::arg("connection") = py::none(), py::kw_only(), py::arg("enable_optimizer") = true);
-	m.def("get_substrait_json", &DuckDBPyRelation::GetSubstraitJSON, "Serialize a query object to protobuf",
-	      py::arg("query"), py::arg("connection") = py::none(), py::kw_only(), py::arg("enable_optimizer") = true);
-	m.def("from_substrait_json", &DuckDBPyRelation::FromSubstraitJSON, "Serialize a query object to protobuf",
-	      py::arg("json"), py::arg("connection") = py::none());
-	m.def("from_parquet", &DuckDBPyRelation::FromParquet,
-	      "Creates a relation object from the Parquet files in file_glob", py::arg("file_glob"),
-	      py::arg("binary_as_string") = false, py::kw_only(), py::arg("file_row_number") = false,
-	      py::arg("filename") = false, py::arg("hive_partitioning") = false, py::arg("union_by_name") = false,
-	      py::arg("connection") = py::none());
-	m.def("from_parquet", &DuckDBPyRelation::FromParquets,
-	      "Creates a relation object from the Parquet files in file_globs", py::arg("file_globs"),
-	      py::arg("binary_as_string") = false, py::kw_only(), py::arg("file_row_number") = false,
-	      py::arg("filename") = false, py::arg("hive_partitioning") = false, py::arg("union_by_name") = false,
-	      py::arg("connection") = py::none());
-	m.def("df", &DuckDBPyRelation::FromDf, "Create a relation object from the DataFrame df", py::arg("df"),
-	      py::arg("connection") = py::none());
-	m.def("from_df", &DuckDBPyRelation::FromDf, "Create a relation object from the DataFrame df", py::arg("df"),
-	      py::arg("connection") = py::none());
-	m.def("from_arrow", &DuckDBPyRelation::FromArrow, "Create a relation object from an Arrow object",
-	      py::arg("arrow_object"), py::arg("connection") = py::none());
-	m.def("arrow", &DuckDBPyRelation::FromArrow, "Create a relation object from an Arrow object",
-	      py::arg("arrow_object"), py::arg("connection") = py::none());
-	m.def("filter", &DuckDBPyRelation::FilterDf, "Filter the DataFrame df by the filter in filter_expr", py::arg("df"),
-	      py::arg("filter_expr"), py::arg("connection") = py::none());
-	m.def("project", &DuckDBPyRelation::ProjectDf, "Project the DataFrame df by the projection in project_expr",
-	      py::arg("df"), py::arg("project_expr"), py::arg("connection") = py::none());
-	m.def("alias", &DuckDBPyRelation::AliasDF, "Create a relation from DataFrame df with the passed alias",
-	      py::arg("df"), py::arg("alias"), py::arg("connection") = py::none());
-	m.def("order", &DuckDBPyRelation::OrderDf, "Reorder the DataFrame df by order_expr", py::arg("df"),
-	      py::arg("order_expr"), py::arg("connection") = py::none());
-	m.def("aggregate", &DuckDBPyRelation::AggregateDF,
-	      "Compute the aggregate aggr_expr by the optional groups group_expr on DataFrame df", py::arg("df"),
-	      py::arg("aggr_expr"), py::arg("group_expr") = "", py::arg("connection") = py::none());
-	m.def("distinct", &DuckDBPyRelation::DistinctDF, "Compute the distinct rows from DataFrame df ", py::arg("df"),
-	      py::arg("connection") = py::none());
-	m.def("limit", &DuckDBPyRelation::LimitDF, "Retrieve the first n rows from the DataFrame df", py::arg("df"),
-	      py::arg("n"), py::arg("connection") = py::none());
-
-	m.def("query_df", &DuckDBPyRelation::QueryDF,
-	      "Run the given SQL query in sql_query on the view named virtual_table_name that contains the content of "
-	      "DataFrame df",
-	      py::arg("df"), py::arg("virtual_table_name"), py::arg("sql_query"), py::arg("connection") = py::none());
-
-	m.def("write_csv", &DuckDBPyRelation::WriteCsvDF, "Write the DataFrame df to a CSV file in file_name",
-	      py::arg("df"), py::arg("file_name"), py::arg("connection") = py::none());
 
 	// we need this because otherwise we try to remove registered_dfs on shutdown when python is already dead
 	auto clean_default_connection = []() {

--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -10,6 +10,7 @@
 #include "duckdb_python/pyresult.hpp"
 #include "duckdb_python/exceptions.hpp"
 #include "duckdb_python/connection_wrapper.hpp"
+#include "duckdb_python/conversions/pyconnection_default.hpp"
 
 #include "duckdb.hpp"
 

--- a/tools/pythonpkg/src/include/duckdb_python/connection_wrapper.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/connection_wrapper.hpp
@@ -14,6 +14,16 @@ public:
 	static shared_ptr<DuckDBPyConnection> ExecuteMany(const string &query, py::object params = py::list(),
 	                                                  shared_ptr<DuckDBPyConnection> conn = nullptr);
 
+	static unique_ptr<DuckDBPyRelation> DistinctDF(const DataFrame &df, shared_ptr<DuckDBPyConnection> conn = nullptr);
+
+	static unique_ptr<DuckDBPyRelation> QueryDF(const DataFrame &df, const string &view_name, const string &sql_query,
+	                                            shared_ptr<DuckDBPyConnection> conn = nullptr);
+
+	static void WriteCsvDF(const DataFrame &df, const string &file, shared_ptr<DuckDBPyConnection> conn = nullptr);
+
+	static unique_ptr<DuckDBPyRelation> AggregateDF(const DataFrame &df, const string &expr, const string &groups = "",
+	                                                shared_ptr<DuckDBPyConnection> conn = nullptr);
+
 	static shared_ptr<DuckDBPyConnection> Execute(const string &query, py::object params = py::list(),
 	                                              bool many = false, shared_ptr<DuckDBPyConnection> conn = nullptr);
 
@@ -44,8 +54,6 @@ public:
 	static unique_ptr<DuckDBPyRelation> TableFunction(const string &fname, py::object params = py::list(),
 	                                                  shared_ptr<DuckDBPyConnection> conn = nullptr);
 
-	static unique_ptr<DuckDBPyRelation> FromDF(const DataFrame &value, shared_ptr<DuckDBPyConnection> conn = nullptr);
-
 	static unique_ptr<DuckDBPyRelation> FromParquet(const string &file_glob, bool binary_as_string,
 	                                                bool file_row_number, bool filename, bool hive_partitioning,
 	                                                bool union_by_name, const py::object &compression = py::none(),
@@ -58,8 +66,6 @@ public:
 
 	static unique_ptr<DuckDBPyRelation> FromArrow(py::object &arrow_object,
 	                                              shared_ptr<DuckDBPyConnection> conn = nullptr);
-
-	static unique_ptr<DuckDBPyRelation> FromSubstrait(py::bytes &proto, shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	static unique_ptr<DuckDBPyRelation> GetSubstrait(const string &query, shared_ptr<DuckDBPyConnection> conn = nullptr,
 	                                                 bool enable_optimizer = true);
@@ -127,5 +133,30 @@ public:
 	static void UnregisterFilesystem(const py::str &name, shared_ptr<DuckDBPyConnection> conn);
 	static py::list ListFilesystems(shared_ptr<DuckDBPyConnection> conn);
 	static bool FileSystemIsRegistered(const string &name, shared_ptr<DuckDBPyConnection> conn);
+
+	static unique_ptr<DuckDBPyRelation> FromDF(const DataFrame &df, shared_ptr<DuckDBPyConnection> conn = nullptr);
+
+	static unique_ptr<DuckDBPyRelation> FromSubstrait(py::bytes &proto, shared_ptr<DuckDBPyConnection> conn = nullptr);
+
+	static unique_ptr<DuckDBPyRelation> FromSubstraitJSON(const string &json,
+	                                                      shared_ptr<DuckDBPyConnection> conn = nullptr);
+
+	static unique_ptr<DuckDBPyRelation> FromParquetDefault(const string &filename,
+	                                                       shared_ptr<DuckDBPyConnection> conn = nullptr);
+
+	static unique_ptr<DuckDBPyRelation> ProjectDf(const DataFrame &df, const string &expr,
+	                                              shared_ptr<DuckDBPyConnection> conn = nullptr);
+
+	static unique_ptr<DuckDBPyRelation> AliasDF(const DataFrame &df, const string &expr,
+	                                            shared_ptr<DuckDBPyConnection> conn = nullptr);
+
+	static unique_ptr<DuckDBPyRelation> FilterDf(const DataFrame &df, const string &expr,
+	                                             shared_ptr<DuckDBPyConnection> conn = nullptr);
+
+	static unique_ptr<DuckDBPyRelation> LimitDF(const DataFrame &df, int64_t n,
+	                                            shared_ptr<DuckDBPyConnection> conn = nullptr);
+
+	static unique_ptr<DuckDBPyRelation> OrderDf(const DataFrame &df, const string &expr,
+	                                            shared_ptr<DuckDBPyConnection> conn = nullptr);
 };
 } // namespace duckdb

--- a/tools/pythonpkg/src/include/duckdb_python/conversions/pyconnection_default.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/conversions/pyconnection_default.hpp
@@ -41,38 +41,3 @@ struct is_holder_type<DuckDBPyConnection, std::shared_ptr<DuckDBPyConnection>> :
 
 } // namespace detail
 } // namespace PYBIND11_NAMESPACE
-
-// namespace pybind11 {
-// namespace detail {
-
-// template<>
-// struct type_caster<shared_ptr<DuckDBPyConnection>>
-//{
-//	using type = DuckDBPyConnection;
-//	PYBIND11_TYPE_CASTER(shared_ptr<type>, const_name("default_connection_holder"));
-
-//	using BaseCaster = copyable_holder_caster<type, shared_ptr<type>>;
-
-//	bool load(pybind11::handle src, bool b)
-//	{
-//		if (py::none().is(src)) {
-//			value = DuckDBPyConnection::DefaultConnection();
-//			return true;
-//		}
-//		BaseCaster bc;
-
-//		return bc.load(src, b);
-//	}
-
-//	static handle cast(shared_ptr<type> base,
-//					   return_value_policy rvp,
-//					   handle h)
-//	{
-//		return BaseCaster::cast(base, rvp, h);
-//	}
-//};
-
-// template <>
-// struct is_holder_type<DuckDBPyConnection, std::shared_ptr<DuckDBPyConnection>> : std::true_type
-//{
-//};

--- a/tools/pythonpkg/src/include/duckdb_python/conversions/pyconnection_default.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/conversions/pyconnection_default.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "duckdb_python/pyconnection.hpp"
+#include "duckdb/common/helper.hpp"
+
+namespace py = pybind11;
+
+namespace pybind11 {
+namespace detail {
+
+using duckdb::DuckDBPyConnection;
+using duckdb::shared_ptr;
+
+template <>
+struct type_caster<shared_ptr<DuckDBPyConnection>> {
+	using type = DuckDBPyConnection;
+	PYBIND11_TYPE_CASTER(shared_ptr<type>, const_name("default_connection_holder"));
+
+	using BaseCaster = copyable_holder_caster<type, shared_ptr<type>>;
+
+	bool load(pybind11::handle src, bool b) {
+		if (py::none().is(src)) {
+			value = DuckDBPyConnection::DefaultConnection();
+			return true;
+		}
+		BaseCaster bc;
+
+		return bc.load(src, b);
+	}
+
+	static handle cast(shared_ptr<type> base, return_value_policy rvp, handle h) {
+		return BaseCaster::cast(base, rvp, h);
+	}
+};
+
+template <>
+struct is_holder_type<DuckDBPyConnection, std::shared_ptr<DuckDBPyConnection>> : std::true_type {};
+
+} // namespace detail
+} // namespace pybind11

--- a/tools/pythonpkg/src/include/duckdb_python/conversions/pyconnection_default.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/conversions/pyconnection_default.hpp
@@ -16,7 +16,6 @@ class type_caster<shared_ptr<DuckDBPyConnection>>
     : public copyable_holder_caster<DuckDBPyConnection, shared_ptr<DuckDBPyConnection>> {
 	using type = DuckDBPyConnection;
 	using holder_caster = copyable_holder_caster<DuckDBPyConnection, shared_ptr<DuckDBPyConnection>>;
-	using base = type_caster_base<type>;
 	PYBIND11_TYPE_CASTER(shared_ptr<type>, const_name("default_connection_holder"));
 
 	bool load(handle src, bool convert) {

--- a/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
@@ -54,67 +54,15 @@ public:
 
 	unique_ptr<DuckDBPyRelation> GetAttribute(const string &name);
 
-	static unique_ptr<DuckDBPyRelation> FromDf(const DataFrame &df, shared_ptr<DuckDBPyConnection> conn = nullptr);
-
-	static unique_ptr<DuckDBPyRelation> Values(py::object values = py::list(),
-	                                           shared_ptr<DuckDBPyConnection> conn = nullptr);
-
-	static unique_ptr<DuckDBPyRelation> FromQuery(const string &query, const string &alias,
-	                                              shared_ptr<DuckDBPyConnection> conn = nullptr);
-
-	static unique_ptr<DuckDBPyRelation> RunQuery(const string &query, const string &alias,
-	                                             shared_ptr<DuckDBPyConnection> conn = nullptr);
-
-	static unique_ptr<DuckDBPyRelation> FromParquet(const string &file_glob, bool binary_as_string,
-	                                                bool file_row_number, bool filename, bool hive_partitioning,
-	                                                bool union_by_name, shared_ptr<DuckDBPyConnection> conn = nullptr);
-
-	static unique_ptr<DuckDBPyRelation> FromParquets(const vector<string> &file_globs, bool binary_as_string,
-	                                                 bool file_row_number, bool filename, bool hive_partitioning,
-	                                                 bool union_by_name, shared_ptr<DuckDBPyConnection> conn = nullptr);
-
-	static unique_ptr<DuckDBPyRelation> FromSubstrait(py::bytes &proto, shared_ptr<DuckDBPyConnection> conn = nullptr);
-
-	static unique_ptr<DuckDBPyRelation> GetSubstrait(const string &query, shared_ptr<DuckDBPyConnection> conn = nullptr,
-	                                                 bool enable_optimizer = true);
-
-	static unique_ptr<DuckDBPyRelation>
-	GetSubstraitJSON(const string &query, shared_ptr<DuckDBPyConnection> conn = nullptr, bool enable_optimizer = true);
-	static unique_ptr<DuckDBPyRelation> FromSubstraitJSON(const string &json,
-	                                                      shared_ptr<DuckDBPyConnection> conn = nullptr);
-
-	static unique_ptr<DuckDBPyRelation> FromParquetDefault(const string &filename,
-	                                                       shared_ptr<DuckDBPyConnection> conn = nullptr);
-
-	static unique_ptr<DuckDBPyRelation> FromArrow(py::object &arrow_object,
-	                                              shared_ptr<DuckDBPyConnection> conn = nullptr);
-
-	unique_ptr<DuckDBPyRelation> Project(const string &expr);
-
-	static unique_ptr<DuckDBPyRelation> ProjectDf(const DataFrame &df, const string &expr,
-	                                              shared_ptr<DuckDBPyConnection> conn = nullptr);
-
 	py::str GetAlias();
 
 	unique_ptr<DuckDBPyRelation> SetAlias(const string &expr);
 
-	static unique_ptr<DuckDBPyRelation> AliasDF(const DataFrame &df, const string &expr,
-	                                            shared_ptr<DuckDBPyConnection> conn = nullptr);
+	unique_ptr<DuckDBPyRelation> Project(const string &expr);
 
 	unique_ptr<DuckDBPyRelation> Filter(const string &expr);
-
-	static unique_ptr<DuckDBPyRelation> FilterDf(const DataFrame &df, const string &expr,
-	                                             shared_ptr<DuckDBPyConnection> conn = nullptr);
-
 	unique_ptr<DuckDBPyRelation> Limit(int64_t n, int64_t offset = 0);
-
-	static unique_ptr<DuckDBPyRelation> LimitDF(const DataFrame &df, int64_t n,
-	                                            shared_ptr<DuckDBPyConnection> conn = nullptr);
-
 	unique_ptr<DuckDBPyRelation> Order(const string &expr);
-
-	static unique_ptr<DuckDBPyRelation> OrderDf(const DataFrame &df, const string &expr,
-	                                            shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	unique_ptr<DuckDBPyRelation> Aggregate(const string &expr, const string &groups = "");
 
@@ -173,12 +121,7 @@ public:
 	unique_ptr<DuckDBPyRelation> CumMax(const string &aggr_columns);
 	unique_ptr<DuckDBPyRelation> CumMin(const string &aggr_columns);
 
-	static unique_ptr<DuckDBPyRelation> AggregateDF(const DataFrame &df, const string &expr, const string &groups = "",
-	                                                shared_ptr<DuckDBPyConnection> conn = nullptr);
-
 	unique_ptr<DuckDBPyRelation> Distinct();
-
-	static unique_ptr<DuckDBPyRelation> DistinctDF(const DataFrame &df, shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	DataFrame FetchDF(bool date_as_object);
 
@@ -222,8 +165,6 @@ public:
 	           const py::object &timestamp_format = py::none(), const py::object &quoting = py::none(),
 	           const py::object &encoding = py::none(), const py::object &compression = py::none());
 
-	static void WriteCsvDF(const DataFrame &df, const string &file, shared_ptr<DuckDBPyConnection> conn = nullptr);
-
 	// should this return a rel with the new view?
 	unique_ptr<DuckDBPyRelation> CreateView(const string &view_name, bool replace = true);
 
@@ -231,9 +172,6 @@ public:
 
 	// Update the internal result of the relation
 	DuckDBPyRelation &Execute();
-
-	static unique_ptr<DuckDBPyRelation> QueryDF(const DataFrame &df, const string &view_name, const string &sql_query,
-	                                            shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	void InsertInto(const string &table);
 

--- a/tools/pythonpkg/src/pyduckdb/connection_wrapper.cpp
+++ b/tools/pythonpkg/src/pyduckdb/connection_wrapper.cpp
@@ -8,6 +8,26 @@ shared_ptr<DuckDBPyConnection> PyConnectionWrapper::ExecuteMany(const string &qu
 	return conn->ExecuteMany(query, params);
 }
 
+unique_ptr<DuckDBPyRelation> PyConnectionWrapper::DistinctDF(const DataFrame &df, shared_ptr<DuckDBPyConnection> conn) {
+	return conn->FromDF(df)->Distinct();
+}
+
+void PyConnectionWrapper::WriteCsvDF(const DataFrame &df, const string &file, shared_ptr<DuckDBPyConnection> conn) {
+	return conn->FromDF(df)->ToCSV(file);
+}
+
+unique_ptr<DuckDBPyRelation> PyConnectionWrapper::QueryDF(const DataFrame &df, const string &view_name,
+                                                          const string &sql_query,
+                                                          shared_ptr<DuckDBPyConnection> conn) {
+	return conn->FromDF(df)->Query(view_name, sql_query);
+}
+
+unique_ptr<DuckDBPyRelation> PyConnectionWrapper::AggregateDF(const DataFrame &df, const string &expr,
+                                                              const string &groups,
+                                                              shared_ptr<DuckDBPyConnection> conn) {
+	return conn->FromDF(df)->Aggregate(expr, groups);
+}
+
 shared_ptr<DuckDBPyConnection> PyConnectionWrapper::Execute(const string &query, py::object params, bool many,
                                                             shared_ptr<DuckDBPyConnection> conn) {
 	return conn->Execute(query, params, many);
@@ -32,22 +52,8 @@ void PyConnectionWrapper::LoadExtension(const string &extension, shared_ptr<Duck
 	conn->LoadExtension(extension);
 }
 
-unique_ptr<DuckDBPyRelation> PyConnectionWrapper::FromQuery(const string &query, const string &alias,
-                                                            shared_ptr<DuckDBPyConnection> conn) {
-	return conn->FromQuery(query, alias);
-}
-
-unique_ptr<DuckDBPyRelation> PyConnectionWrapper::RunQuery(const string &query, const string &alias,
-                                                           shared_ptr<DuckDBPyConnection> conn) {
-	return conn->RunQuery(query, alias);
-}
-
 unique_ptr<DuckDBPyRelation> PyConnectionWrapper::Table(const string &tname, shared_ptr<DuckDBPyConnection> conn) {
 	return conn->Table(tname);
-}
-
-unique_ptr<DuckDBPyRelation> PyConnectionWrapper::Values(py::object params, shared_ptr<DuckDBPyConnection> conn) {
-	return conn->Values(params);
 }
 
 unique_ptr<DuckDBPyRelation> PyConnectionWrapper::View(const string &vname, shared_ptr<DuckDBPyConnection> conn) {
@@ -88,6 +94,11 @@ unique_ptr<DuckDBPyRelation> PyConnectionWrapper::FromArrow(py::object &arrow_ob
 
 unique_ptr<DuckDBPyRelation> PyConnectionWrapper::FromSubstrait(py::bytes &proto, shared_ptr<DuckDBPyConnection> conn) {
 	return conn->FromSubstrait(proto);
+}
+
+unique_ptr<DuckDBPyRelation> PyConnectionWrapper::FromSubstraitJSON(const string &json,
+                                                                    shared_ptr<DuckDBPyConnection> conn) {
+	return conn->FromSubstraitJSON(json);
 }
 
 unique_ptr<DuckDBPyRelation> PyConnectionWrapper::GetSubstrait(const string &query, shared_ptr<DuckDBPyConnection> conn,
@@ -209,6 +220,45 @@ py::list PyConnectionWrapper::ListFilesystems(shared_ptr<DuckDBPyConnection> con
 }
 bool PyConnectionWrapper::FileSystemIsRegistered(const string &name, shared_ptr<DuckDBPyConnection> conn) {
 	return conn->FileSystemIsRegistered(name);
+}
+
+unique_ptr<DuckDBPyRelation> PyConnectionWrapper::Values(py::object values, shared_ptr<DuckDBPyConnection> conn) {
+	return conn->Values(std::move(values));
+}
+
+unique_ptr<DuckDBPyRelation> PyConnectionWrapper::FromQuery(const string &query, const string &alias,
+                                                            shared_ptr<DuckDBPyConnection> conn) {
+	return conn->FromQuery(query, alias);
+}
+
+unique_ptr<DuckDBPyRelation> PyConnectionWrapper::RunQuery(const string &query, const string &alias,
+                                                           shared_ptr<DuckDBPyConnection> conn) {
+	return conn->RunQuery(query, alias);
+}
+
+unique_ptr<DuckDBPyRelation> PyConnectionWrapper::ProjectDf(const DataFrame &df, const string &expr,
+                                                            shared_ptr<DuckDBPyConnection> conn) {
+	return conn->FromDF(df)->Project(expr);
+}
+
+unique_ptr<DuckDBPyRelation> PyConnectionWrapper::AliasDF(const DataFrame &df, const string &expr,
+                                                          shared_ptr<DuckDBPyConnection> conn) {
+	return conn->FromDF(df)->SetAlias(expr);
+}
+
+unique_ptr<DuckDBPyRelation> PyConnectionWrapper::FilterDf(const DataFrame &df, const string &expr,
+                                                           shared_ptr<DuckDBPyConnection> conn) {
+	return conn->FromDF(df)->Filter(expr);
+}
+
+unique_ptr<DuckDBPyRelation> PyConnectionWrapper::LimitDF(const DataFrame &df, int64_t n,
+                                                          shared_ptr<DuckDBPyConnection> conn) {
+	return conn->FromDF(df)->Limit(n);
+}
+
+unique_ptr<DuckDBPyRelation> PyConnectionWrapper::OrderDf(const DataFrame &df, const string &expr,
+                                                          shared_ptr<DuckDBPyConnection> conn) {
+	return conn->FromDF(df)->Order(expr);
 }
 
 } // namespace duckdb

--- a/tools/pythonpkg/src/pyduckdb/connection_wrapper.cpp
+++ b/tools/pythonpkg/src/pyduckdb/connection_wrapper.cpp
@@ -5,100 +5,61 @@ namespace duckdb {
 
 shared_ptr<DuckDBPyConnection> PyConnectionWrapper::ExecuteMany(const string &query, py::object params,
                                                                 shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->ExecuteMany(query, params);
 }
 
 shared_ptr<DuckDBPyConnection> PyConnectionWrapper::Execute(const string &query, py::object params, bool many,
                                                             shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->Execute(query, params, many);
 }
 
 shared_ptr<DuckDBPyConnection> PyConnectionWrapper::Append(const string &name, DataFrame value,
                                                            shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->Append(name, value);
 }
 
 shared_ptr<DuckDBPyConnection> PyConnectionWrapper::RegisterPythonObject(const string &name, py::object python_object,
                                                                          shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->RegisterPythonObject(name, python_object);
 }
 
 void PyConnectionWrapper::InstallExtension(const string &extension, bool force_install,
                                            shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	conn->InstallExtension(extension, force_install);
 }
 
 void PyConnectionWrapper::LoadExtension(const string &extension, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	conn->LoadExtension(extension);
 }
 
 unique_ptr<DuckDBPyRelation> PyConnectionWrapper::FromQuery(const string &query, const string &alias,
                                                             shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->FromQuery(query, alias);
 }
 
 unique_ptr<DuckDBPyRelation> PyConnectionWrapper::RunQuery(const string &query, const string &alias,
                                                            shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->RunQuery(query, alias);
 }
 
 unique_ptr<DuckDBPyRelation> PyConnectionWrapper::Table(const string &tname, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->Table(tname);
 }
 
 unique_ptr<DuckDBPyRelation> PyConnectionWrapper::Values(py::object params, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->Values(params);
 }
 
 unique_ptr<DuckDBPyRelation> PyConnectionWrapper::View(const string &vname, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->View(vname);
 }
 
 unique_ptr<DuckDBPyRelation> PyConnectionWrapper::TableFunction(const string &fname, py::object params,
                                                                 shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->TableFunction(fname, params);
 }
 
 unique_ptr<DuckDBPyRelation> PyConnectionWrapper::FromDF(const DataFrame &value, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->FromDF(value);
 }
 
@@ -107,9 +68,6 @@ unique_ptr<DuckDBPyRelation> PyConnectionWrapper::FromParquet(const string &file
                                                               bool hive_partitioning, bool union_by_name,
                                                               const py::object &compression,
                                                               shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->FromParquet(file_glob, binary_as_string, file_row_number, filename, hive_partitioning, union_by_name,
 	                         compression);
 }
@@ -119,105 +77,63 @@ unique_ptr<DuckDBPyRelation> PyConnectionWrapper::FromParquets(const vector<stri
                                                                bool hive_partitioning, bool union_by_name,
                                                                const py::object &compression,
                                                                shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->FromParquets(file_globs, binary_as_string, file_row_number, filename, hive_partitioning, union_by_name,
 	                          compression);
 }
 
 unique_ptr<DuckDBPyRelation> PyConnectionWrapper::FromArrow(py::object &arrow_object,
                                                             shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->FromArrow(arrow_object);
 }
 
 unique_ptr<DuckDBPyRelation> PyConnectionWrapper::FromSubstrait(py::bytes &proto, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->FromSubstrait(proto);
 }
 
 unique_ptr<DuckDBPyRelation> PyConnectionWrapper::GetSubstrait(const string &query, shared_ptr<DuckDBPyConnection> conn,
                                                                bool enable_optimizer) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->GetSubstrait(query, enable_optimizer);
 }
 
 unique_ptr<DuckDBPyRelation>
 PyConnectionWrapper::GetSubstraitJSON(const string &query, shared_ptr<DuckDBPyConnection> conn, bool enable_optimizer) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->GetSubstraitJSON(query, enable_optimizer);
 }
 
 unordered_set<string> PyConnectionWrapper::GetTableNames(const string &query, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->GetTableNames(query);
 }
 
 shared_ptr<DuckDBPyConnection> PyConnectionWrapper::UnregisterPythonObject(const string &name,
                                                                            shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->UnregisterPythonObject(name);
 }
 
 shared_ptr<DuckDBPyConnection> PyConnectionWrapper::Begin(shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->Begin();
 }
 
 shared_ptr<DuckDBPyConnection> PyConnectionWrapper::Commit(shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->Commit();
 }
 
 shared_ptr<DuckDBPyConnection> PyConnectionWrapper::Rollback(shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->Rollback();
 }
 
 void PyConnectionWrapper::Close(shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	conn->Close();
 }
 
 shared_ptr<DuckDBPyConnection> PyConnectionWrapper::Cursor(shared_ptr<DuckDBPyConnection> conn) {
-	// if (!conn) {
-	//	conn = DuckDBPyConnection::DefaultConnection();
-	//}
 	return conn->Cursor();
 }
 
 Optional<py::list> PyConnectionWrapper::GetDescription(shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->GetDescription();
 }
 
 Optional<py::tuple> PyConnectionWrapper::FetchOne(shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->FetchOne();
 }
 
@@ -225,9 +141,6 @@ unique_ptr<DuckDBPyRelation> PyConnectionWrapper::ReadJSON(const string &filenam
                                                            const py::object &columns, const py::object &sample_size,
                                                            const py::object &maximum_depth) {
 
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->ReadJSON(filename, columns, sample_size, maximum_depth);
 }
 
@@ -238,108 +151,63 @@ unique_ptr<DuckDBPyRelation> PyConnectionWrapper::ReadCSV(
     const py::object &encoding, const py::object &parallel, const py::object &date_format,
     const py::object &timestamp_format, const py::object &sample_size, const py::object &all_varchar,
     const py::object &normalize_names, const py::object &filename) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->ReadCSV(name, header, compression, sep, delimiter, dtype, na_values, skiprows, quotechar, escapechar,
 	                     encoding, parallel, date_format, timestamp_format, sample_size, all_varchar, normalize_names,
 	                     filename);
 }
 
 py::list PyConnectionWrapper::FetchMany(idx_t size, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->FetchMany(size);
 }
 
 py::list PyConnectionWrapper::FetchAll(shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->FetchAll();
 }
 
 py::dict PyConnectionWrapper::FetchNumpy(shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->FetchNumpy();
 }
 
 DataFrame PyConnectionWrapper::FetchDF(bool date_as_object, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->FetchDF(date_as_object);
 }
 
 DataFrame PyConnectionWrapper::FetchDFChunk(const idx_t vectors_per_chunk, bool date_as_object,
                                             shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->FetchDFChunk(vectors_per_chunk, date_as_object);
 }
 
 duckdb::pyarrow::Table PyConnectionWrapper::FetchArrow(idx_t chunk_size, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->FetchArrow(chunk_size);
 }
 
 py::dict PyConnectionWrapper::FetchPyTorch(shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->FetchPyTorch();
 }
 
 py::dict PyConnectionWrapper::FetchTF(shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->FetchTF();
 }
 
 PolarsDataFrame PyConnectionWrapper::FetchPolars(idx_t chunk_size, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->FetchPolars(chunk_size);
 }
 
 duckdb::pyarrow::RecordBatchReader PyConnectionWrapper::FetchRecordBatchReader(const idx_t chunk_size,
                                                                                shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->FetchRecordBatchReader(chunk_size);
 }
 
 void PyConnectionWrapper::RegisterFilesystem(AbstractFileSystem file_system, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->RegisterFilesystem(std::move(file_system));
 }
 void PyConnectionWrapper::UnregisterFilesystem(const py::str &name, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->UnregisterFilesystem(name);
 }
 py::list PyConnectionWrapper::ListFilesystems(shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->ListFilesystems();
 }
 bool PyConnectionWrapper::FileSystemIsRegistered(const string &name, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
 	return conn->FileSystemIsRegistered(name);
 }
 

--- a/tools/pythonpkg/src/pyduckdb/connection_wrapper.cpp
+++ b/tools/pythonpkg/src/pyduckdb/connection_wrapper.cpp
@@ -201,9 +201,9 @@ void PyConnectionWrapper::Close(shared_ptr<DuckDBPyConnection> conn) {
 }
 
 shared_ptr<DuckDBPyConnection> PyConnectionWrapper::Cursor(shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
+	// if (!conn) {
+	//	conn = DuckDBPyConnection::DefaultConnection();
+	//}
 	return conn->Cursor();
 }
 

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -36,94 +36,6 @@ DuckDBPyRelation::DuckDBPyRelation(unique_ptr<DuckDBPyResult> result_p) : rel(nu
 	this->names = result->GetNames();
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromDf(const DataFrame &df, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
-	return conn->FromDF(df);
-}
-
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Values(py::object values, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
-	return conn->Values(std::move(values));
-}
-
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromQuery(const string &query, const string &alias,
-                                                         shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
-	return conn->FromQuery(query, alias);
-}
-
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::RunQuery(const string &query, const string &alias,
-                                                        shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
-	return conn->RunQuery(query, alias);
-}
-
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromParquet(const string &file_glob, bool binary_as_string,
-                                                           bool file_row_number, bool filename, bool hive_partitioning,
-                                                           bool union_by_name, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
-	return conn->FromParquet(file_glob, binary_as_string, file_row_number, filename, hive_partitioning, union_by_name);
-}
-
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromParquets(const vector<string> &file_globs, bool binary_as_string,
-                                                            bool file_row_number, bool filename, bool hive_partitioning,
-                                                            bool union_by_name, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
-	return conn->FromParquets(file_globs, binary_as_string, file_row_number, filename, hive_partitioning,
-	                          union_by_name);
-}
-
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::GetSubstrait(const string &query, shared_ptr<DuckDBPyConnection> conn,
-                                                            bool enable_optimizer) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
-	return conn->GetSubstrait(query, enable_optimizer);
-}
-
-unique_ptr<DuckDBPyRelation>
-DuckDBPyRelation::GetSubstraitJSON(const string &query, shared_ptr<DuckDBPyConnection> conn, bool enable_optimizer) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
-	return conn->GetSubstraitJSON(query, enable_optimizer);
-}
-
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromSubstraitJSON(const string &json,
-                                                                 shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
-	return conn->FromSubstraitJSON(json);
-}
-
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromSubstrait(py::bytes &proto, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
-	return conn->FromSubstrait(proto);
-}
-
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FromArrow(py::object &arrow_object,
-                                                         shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
-	return conn->FromArrow(arrow_object);
-}
-
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Project(const string &expr) {
 	if (!rel) {
 		return nullptr;
@@ -131,14 +43,6 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Project(const string &expr) {
 	auto projected_relation = make_unique<DuckDBPyRelation>(rel->Project(expr));
 	projected_relation->rel->extra_dependencies = this->rel->extra_dependencies;
 	return projected_relation;
-}
-
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::ProjectDf(const DataFrame &df, const string &expr,
-                                                         shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
-	return conn->FromDF(df)->Project(expr);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::SetAlias(const string &expr) {
@@ -149,48 +53,16 @@ py::str DuckDBPyRelation::GetAlias() {
 	return py::str(string(rel->GetAlias()));
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::AliasDF(const DataFrame &df, const string &expr,
-                                                       shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
-	return conn->FromDF(df)->SetAlias(expr);
-}
-
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Filter(const string &expr) {
 	return make_unique<DuckDBPyRelation>(rel->Filter(expr));
-}
-
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FilterDf(const DataFrame &df, const string &expr,
-                                                        shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
-	return conn->FromDF(df)->Filter(expr);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Limit(int64_t n, int64_t offset) {
 	return make_unique<DuckDBPyRelation>(rel->Limit(n, offset));
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::LimitDF(const DataFrame &df, int64_t n,
-                                                       shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
-	return conn->FromDF(df)->Limit(n);
-}
-
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Order(const string &expr) {
 	return make_unique<DuckDBPyRelation>(rel->Order(expr));
-}
-
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::OrderDf(const DataFrame &df, const string &expr,
-                                                       shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
-	return conn->FromDF(df)->Order(expr);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Aggregate(const string &expr, const string &groups) {
@@ -456,24 +328,10 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::CumMin(const string &aggr_columns
 	return GenericWindowFunction("min", aggr_columns);
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::AggregateDF(const DataFrame &df, const string &expr,
-                                                           const string &groups, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
-	return conn->FromDF(df)->Aggregate(expr, groups);
-}
-
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Distinct() {
 	return make_unique<DuckDBPyRelation>(rel->Distinct());
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::DistinctDF(const DataFrame &df, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
-	return conn->FromDF(df)->Distinct();
-}
 duckdb::pyarrow::RecordBatchReader DuckDBPyRelation::FetchRecordBatchReader(idx_t chunk_size) {
 	AssertResult();
 	return result->FetchRecordBatchReader(chunk_size);
@@ -822,13 +680,6 @@ void DuckDBPyRelation::ToCSV(const string &filename, const py::object &sep, cons
 	PyExecuteRelation(write_csv);
 }
 
-void DuckDBPyRelation::WriteCsvDF(const DataFrame &df, const string &file, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
-	return conn->FromDF(df)->ToCSV(file);
-}
-
 // should this return a rel with the new view?
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::CreateView(const string &view_name, bool replace) {
 	rel->CreateView(view_name, replace);
@@ -890,14 +741,6 @@ DuckDBPyRelation &DuckDBPyRelation::Execute() {
 	return *this;
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyRelation::QueryDF(const DataFrame &df, const string &view_name,
-                                                       const string &sql_query, shared_ptr<DuckDBPyConnection> conn) {
-	if (!conn) {
-		conn = DuckDBPyConnection::DefaultConnection();
-	}
-	return conn->FromDF(df)->Query(view_name, sql_query);
-}
-
 void DuckDBPyRelation::InsertInto(const string &table) {
 	AssertRelation();
 	auto parsed_info = QualifiedName::Parse(table);
@@ -957,14 +800,12 @@ void DuckDBPyRelation::Print() {
 }
 
 string DuckDBPyRelation::Explain(ExplainType type) {
-
 	AssertRelation();
 	auto res = rel->Explain(type);
 	D_ASSERT(res->type == duckdb::QueryResultType::MATERIALIZED_RESULT);
 	auto &materialized = (duckdb::MaterializedQueryResult &)*res;
 	auto &coll = materialized.Collection();
 	string result;
-	bool skipped_first = false;
 	for (auto &row : coll.Rows()) {
 		// Skip the first column because it just contains 'physical plan'
 		for (idx_t col_idx = 1; col_idx < coll.ColumnCount(); col_idx++) {


### PR DESCRIPTION
Previously our `connection_wrapper.cpp` code looked like:
```c++
Optional<py::tuple> PyConnectionWrapper::FetchOne(shared_ptr<DuckDBPyConnection> conn) {
	if (!conn) {
		conn = DuckDBPyConnection::DefaultConnection();
	}
	return conn->FetchOne();
}
```
After this PR:
```c++
Optional<py::tuple> PyConnectionWrapper::FetchOne(shared_ptr<DuckDBPyConnection> conn) {
	return conn->FetchOne();
}
```

This reduces the amount of boilerplate in the python client drastically :D