### PR TITLE
2023a Time Zones

### DIFF
--- a/extension/icu/scripts/makedata.sh
+++ b/extension/icu/scripts/makedata.sh
@@ -26,7 +26,7 @@ find ${data_path/version/$data_version} -type f ! -iname "*.txt" -delete
 cp -r ${data_path/version/$data_version} ${source_path/version/$code_version}
 
 # download IANA and copy the latest Time Zone Data
-tz_version=2022g
+tz_version=2023a
 rm -rf icu-data
 git clone git@github.com:unicode-org/icu-data.git
 cp icu-data/tzdata/icunew/${tz_version}/44/*.txt ${data_path/version/$code_version}/misc

--- a/test/sql/timezone/test_icu_timezone.test
+++ b/test/sql/timezone/test_icu_timezone.test
@@ -842,3 +842,13 @@ query I
 SELECT '2023-05-01 12:00:00+00'::TIMESTAMPTZ;
 ----
 2023-05-01 06:00:00-06
+
+# 2023a
+# Egypt now uses DST again, from April through October
+statement ok
+SET TimeZone = 'Egypt';
+
+query I
+SELECT '2023-05-15 12:00:00+00'::TIMESTAMPTZ;
+----
+2023-05-15 15:00:00+03


### PR DESCRIPTION
 Briefly:
   Egypt now uses DST again, from April through October.
   This year Morocco springs forward April 23, not April 30.
   Palestine delays the start of DST this year.
   Much of Greenland still uses DST from 2024 on.
   America/Yellowknife now links to America/Edmonton.