### PR TITLE
Fix Parquet writer regression + add Parquet writing to regression test suite

### DIFF
--- a/.github/regression/micro.csv
+++ b/.github/regression/micro.csv
@@ -13,3 +13,4 @@ benchmark/micro/filter/parallel_complex_filter.benchmark
 benchmark/micro/catalog/add_column_empty.benchmark
 benchmark/micro/groupby-parallel/many_groups_large_values_small.benchmark
 benchmark/tpch/csv/lineitem_csv_auto_detect.benchmark
+benchmark/tpch/parquet/write_lineitem_parquet.benchmark

--- a/extension/parquet/parquet-extension.cpp
+++ b/extension/parquet/parquet-extension.cpp
@@ -122,7 +122,8 @@ struct ParquetWriteGlobalState : public GlobalFunctionData {
 };
 
 struct ParquetWriteLocalState : public LocalFunctionData {
-	explicit ParquetWriteLocalState(ClientContext &context, const vector<LogicalType> &types) : buffer(context, types) {
+	explicit ParquetWriteLocalState(ClientContext &context, const vector<LogicalType> &types)
+	    : buffer(Allocator::Get(context), types) {
 	}
 
 	ColumnDataCollection buffer;

--- a/src/common/types/column_data_collection_segment.cpp
+++ b/src/common/types/column_data_collection_segment.cpp
@@ -169,11 +169,8 @@ idx_t ColumnDataCollectionSegment::ReadVectorInternal(ChunkManagementState &stat
 		if (type_size > 0) {
 			memcpy(target_data + current_offset * type_size, base_ptr, current_vdata.count * type_size);
 		}
-		// FIXME: use bitwise operations here
 		ValidityMask current_validity(validity_data);
-		for (idx_t k = 0; k < current_vdata.count; k++) {
-			target_validity.Set(current_offset + k, current_validity.RowIsValid(k));
-		}
+		target_validity.SliceInPlace(current_validity, current_offset, 0, current_vdata.count);
 		current_offset += current_vdata.count;
 		next_index = current_vdata.next_data;
 	}

--- a/src/common/types/validity_mask.cpp
+++ b/src/common/types/validity_mask.cpp
@@ -68,31 +68,40 @@ void ValidityMask::Resize(idx_t old_size, idx_t new_size) {
 	}
 }
 
-void ValidityMask::Slice(const ValidityMask &other, idx_t source_offset, idx_t target_offset, idx_t count) {
+void ValidityMask::Slice(const ValidityMask &other, idx_t source_offset, idx_t count) {
 	if (other.AllValid()) {
 		validity_mask = nullptr;
 		validity_data.reset();
 		return;
 	}
-	if (source_offset == 0 && target_offset == 0) {
+	if (source_offset == 0) {
 		Initialize(other);
 		return;
 	}
 	ValidityMask new_mask(count);
-	new_mask.SliceInPlace(other, source_offset, target_offset, count);
+	new_mask.SliceInPlace(other, 0, source_offset, count);
 	Initialize(new_mask);
 }
 
-void ValidityMask::SliceInPlace(const ValidityMask &other, idx_t source_offset, idx_t target_offset, idx_t count) {
-	if (source_offset == 0 && target_offset == 0) {
-		Copy(other, count);
+bool ValidityMask::IsAligned(idx_t count) {
+	return count % BITS_PER_VALUE == 0;
+}
+
+void ValidityMask::SliceInPlace(const ValidityMask &other, idx_t target_offset, idx_t source_offset, idx_t count) {
+	if (IsAligned(source_offset) && IsAligned(target_offset)) {
+		auto target_validity = GetData();
+		auto source_validity = other.GetData();
+		auto source_offset_entries = EntryCount(source_offset);
+		auto target_offset_entries = EntryCount(target_offset);
+		memcpy(target_validity + target_offset_entries, source_validity + source_offset_entries,
+		       sizeof(validity_t) * EntryCount(count));
 		return;
 	}
 
 	// FIXME: use bitwise operations here
 #if 1
 	for (idx_t i = 0; i < count; i++) {
-		Set(source_offset + i, other.RowIsValid(target_offset + i));
+		Set(target_offset + i, other.RowIsValid(source_offset + i));
 	}
 #else
 	// first shift the "whole" units

--- a/src/common/types/validity_mask.cpp
+++ b/src/common/types/validity_mask.cpp
@@ -68,24 +68,32 @@ void ValidityMask::Resize(idx_t old_size, idx_t new_size) {
 	}
 }
 
-void ValidityMask::Slice(const ValidityMask &other, idx_t offset, idx_t end) {
+void ValidityMask::Slice(const ValidityMask &other, idx_t source_offset, idx_t target_offset, idx_t count) {
 	if (other.AllValid()) {
 		validity_mask = nullptr;
 		validity_data.reset();
 		return;
 	}
-	if (offset == 0) {
+	if (source_offset == 0 && target_offset == 0) {
 		Initialize(other);
 		return;
 	}
-	ValidityMask new_mask(end - offset);
-
-// FIXME THIS NEEDS FIXING!
-#if 1
-	for (idx_t i = offset; i < end; i++) {
-		new_mask.Set(i - offset, other.RowIsValid(i));
-	}
+	ValidityMask new_mask(count);
+	new_mask.SliceInPlace(other, source_offset, target_offset, count);
 	Initialize(new_mask);
+}
+
+void ValidityMask::SliceInPlace(const ValidityMask &other, idx_t source_offset, idx_t target_offset, idx_t count) {
+	if (source_offset == 0 && target_offset == 0) {
+		Copy(other, count);
+		return;
+	}
+
+	// FIXME: use bitwise operations here
+#if 1
+	for (idx_t i = 0; i < count; i++) {
+		Set(source_offset + i, other.RowIsValid(target_offset + i));
+	}
 #else
 	// first shift the "whole" units
 	idx_t entire_units = offset / BITS_PER_VALUE;

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -137,7 +137,7 @@ void Vector::Slice(Vector &other, idx_t offset, idx_t end) {
 			entries[i]->Slice(*other_entries[i], offset, end);
 		}
 		if (offset > 0) {
-			new_vector.validity.Slice(other.validity, offset, end);
+			new_vector.validity.Slice(other.validity, 0, offset, end);
 		} else {
 			new_vector.validity = other.validity;
 		}
@@ -146,7 +146,7 @@ void Vector::Slice(Vector &other, idx_t offset, idx_t end) {
 		Reference(other);
 		if (offset > 0) {
 			data = data + GetTypeIdSize(internal_type) * offset;
-			validity.Slice(other.validity, offset, end);
+			validity.Slice(other.validity, 0, offset, end);
 		}
 	}
 }

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -136,17 +136,13 @@ void Vector::Slice(Vector &other, idx_t offset, idx_t end) {
 		for (idx_t i = 0; i < entries.size(); i++) {
 			entries[i]->Slice(*other_entries[i], offset, end);
 		}
-		if (offset > 0) {
-			new_vector.validity.Slice(other.validity, 0, offset, end);
-		} else {
-			new_vector.validity = other.validity;
-		}
+		new_vector.validity.Slice(other.validity, offset, end - offset);
 		Reference(new_vector);
 	} else {
 		Reference(other);
 		if (offset > 0) {
 			data = data + GetTypeIdSize(internal_type) * offset;
-			validity.Slice(other.validity, 0, offset, end);
+			validity.Slice(other.validity, offset, end - offset);
 		}
 	}
 }

--- a/src/include/duckdb/common/types/validity_mask.hpp
+++ b/src/include/duckdb/common/types/validity_mask.hpp
@@ -323,10 +323,12 @@ public:
 public:
 	DUCKDB_API void Resize(idx_t old_size, idx_t new_size);
 
-	DUCKDB_API void SliceInPlace(const ValidityMask &other, idx_t source_offset, idx_t target_offset, idx_t count);
-	DUCKDB_API void Slice(const ValidityMask &other, idx_t source_offset, idx_t target_offset, idx_t count);
+	DUCKDB_API void SliceInPlace(const ValidityMask &other, idx_t target_offset, idx_t source_offset, idx_t count);
+	DUCKDB_API void Slice(const ValidityMask &other, idx_t source_offset, idx_t count);
 	DUCKDB_API void Combine(const ValidityMask &other, idx_t count);
 	DUCKDB_API string ToString(idx_t count) const;
+
+	DUCKDB_API static bool IsAligned(idx_t count);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/types/validity_mask.hpp
+++ b/src/include/duckdb/common/types/validity_mask.hpp
@@ -323,7 +323,8 @@ public:
 public:
 	DUCKDB_API void Resize(idx_t old_size, idx_t new_size);
 
-	DUCKDB_API void Slice(const ValidityMask &other, idx_t offset, idx_t end);
+	DUCKDB_API void SliceInPlace(const ValidityMask &other, idx_t source_offset, idx_t target_offset, idx_t count);
+	DUCKDB_API void Slice(const ValidityMask &other, idx_t source_offset, idx_t target_offset, idx_t count);
 	DUCKDB_API void Combine(const ValidityMask &other, idx_t count);
 	DUCKDB_API string ToString(idx_t count) const;
 };


### PR DESCRIPTION
Fixes #6753

The issue here was that the Parquet writer relies heavily on scanning a `ColumnDataCollection` multiple times. As part of a previous PR this was reworked to perform a copy of the data for buffer-managed `ColumnDataCollections`, which triggered an inefficient part of the copy code. This PR reverts back to the allocation-backed column data collection (avoiding the copy) and speeds up the validity mask copy.