### PR TITLE
[Dev]: ICU 2023b TimeZones

### DIFF
--- a/extension/icu/scripts/makedata.sh
+++ b/extension/icu/scripts/makedata.sh
@@ -26,7 +26,7 @@ find ${data_path/version/$data_version} -type f ! -iname "*.txt" -delete
 cp -r ${data_path/version/$data_version} ${source_path/version/$code_version}
 
 # download IANA and copy the latest Time Zone Data
-tz_version=2023a
+tz_version=2023b
 rm -rf icu-data
 git clone git@github.com:unicode-org/icu-data.git
 cp icu-data/tzdata/icunew/${tz_version}/44/*.txt ${data_path/version/$code_version}/misc

--- a/test/sql/timezone/test_icu_timezone.test
+++ b/test/sql/timezone/test_icu_timezone.test
@@ -852,3 +852,13 @@ query I
 SELECT '2023-05-15 12:00:00+00'::TIMESTAMPTZ;
 ----
 2023-05-15 15:00:00+03
+
+# 2023b
+# This year Lebanon springs forward April 20/21 not March 25/26.
+statement ok
+SET TimeZone = 'Asia/Beirut';
+
+query II
+SELECT '2023-03-26 12:00:00+00'::TIMESTAMPTZ, '2023-04-21 12:00:00+00'::TIMESTAMPTZ;
+----
+2023-03-26 14:00:00+02	2023-04-21 15:00:00+03


### PR DESCRIPTION
This year Lebanon springs forward April 20/21 not March 25/26.