### PR TITLE
Do not enable jemalloc unconditionally

### DIFF
--- a/tools/rpkg/rconfigure.py
+++ b/tools/rpkg/rconfigure.py
@@ -6,9 +6,6 @@ import platform
 
 extensions = ['parquet']
 
-if platform.system() == 'Linux' and platform.architecture()[0] == '64bit':
-    extensions.append('jemalloc')
-
 # check if there are any additional extensions being requested
 if 'DUCKDB_R_EXTENSIONS' in os.environ:
     extensions = extensions + os.environ['DUCKDB_R_EXTENSIONS'].split(",")


### PR DESCRIPTION
Fixes #6863 

With this change, the R __source package__ will [match what you publish on CRAN](https://github.com/cran/duckdb/tree/master/src), and can be installed on Windows too.

To auto-enable extensions you would need to detect the platform __at install time__ either in `src/Makevars` or `configure` that is included with the R source package. 
