### PR TITLE
[Python] `tuple` now gets properly converted to LIST, instead of a VARCHAR

### DIFF
--- a/tools/pythonpkg/src/python_conversion.cpp
+++ b/tools/pythonpkg/src/python_conversion.cpp
@@ -280,7 +280,7 @@ PythonObjectType GetPythonObjectType(py::handle &ele) {
 		return PythonObjectType::MemoryView;
 	} else if (py::isinstance<py::bytes>(ele)) {
 		return PythonObjectType::Bytes;
-	} else if (py::isinstance<py::list>(ele)) {
+	} else if (py::isinstance<py::list>(ele) || py::isinstance<py::tuple>(ele)) {
 		return PythonObjectType::List;
 	} else if (py::isinstance<py::dict>(ele)) {
 		return PythonObjectType::Dict;

--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_object.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_object.py
@@ -9,18 +9,24 @@ class TestPandasObject(object):
     def test_object_to_string(self, duckdb_cursor):          
         con = duckdb.connect(database=':memory:', read_only=False)
         x = pd.DataFrame(
-			[
-				[1, 'a', 2],
-				[1, None, 2],
-				[1, 1.1, 2],
-				[1, 1.1, 2],
-				[1, 1.1, 2]
-			]
-		)
+            [
+                [1, 'a', 2],
+                [1, None, 2],
+                [1, 1.1, 2],
+                [1, 1.1, 2],
+                [1, 1.1, 2]
+            ]
+        )
         x = x.iloc[1:].copy()       # middle col now entirely native float items
         con.register('view2', x)
         df = con.execute('select * from view2').fetchall()
         assert df == [(1, None, 2),(1, 1.1, 2), (1, 1.1, 2), (1, 1.1, 2)]
+
+    def test_tuple_to_list(self, duckdb_cursor):
+        tuple_df = pd.DataFrame.from_dict(dict(nums=[(1,2,3,),(4,5,6,)]))
+        duckdb_cursor.execute("CREATE TABLE test as SELECT * FROM tuple_df");
+        res = duckdb_cursor.table('test').fetchall()
+        assert res == [([1, 2, 3],), ([4, 5, 6],)]
 
     def test_2273(self, duckdb_cursor):                  
         df_in = pd.DataFrame([[datetime.date(1992, 7, 30)]])


### PR DESCRIPTION
This PR fixes #5741 

We did not check for the `tuple` type, so it got treated as "other" which resulted in just being cast to VARCHAR