### PR TITLE
Parquet reader - millisecond times are stored as int32

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -1401,7 +1401,7 @@ unique_ptr<ColumnReader> ColumnReader::CreateReader(ParquetReader &reader, const
 	case LogicalTypeId::TIME_TZ:
 		if (schema_p.__isset.logicalType && schema_p.logicalType.__isset.TIME) {
 			if (schema_p.logicalType.TIME.unit.__isset.MILLIS) {
-				return make_unique<CallbackColumnReader<int64_t, dtime_t, ParquetIntToTimeMs>>(
+				return make_unique<CallbackColumnReader<int32_t, dtime_t, ParquetIntToTimeMs>>(
 				    reader, type_p, schema_p, file_idx_p, max_define, max_repeat);
 			} else if (schema_p.logicalType.TIME.unit.__isset.MICROS) {
 				return make_unique<CallbackColumnReader<int64_t, dtime_t, ParquetIntToTime>>(
@@ -1416,7 +1416,7 @@ unique_ptr<ColumnReader> ColumnReader::CreateReader(ParquetReader &reader, const
 				return make_unique<CallbackColumnReader<int64_t, dtime_t, ParquetIntToTime>>(
 				    reader, type_p, schema_p, file_idx_p, max_define, max_repeat);
 			case ConvertedType::TIME_MILLIS:
-				return make_unique<CallbackColumnReader<int64_t, dtime_t, ParquetIntToTimeMs>>(
+				return make_unique<CallbackColumnReader<int32_t, dtime_t, ParquetIntToTimeMs>>(
 				    reader, type_p, schema_p, file_idx_p, max_define, max_repeat);
 			default:
 				break;

--- a/extension/parquet/include/parquet_timestamp.hpp
+++ b/extension/parquet/include/parquet_timestamp.hpp
@@ -22,7 +22,7 @@ timestamp_t ParquetTimestampMicrosToTimestamp(const int64_t &raw_ts);
 timestamp_t ParquetTimestampMsToTimestamp(const int64_t &raw_ts);
 timestamp_t ParquetTimestampNsToTimestamp(const int64_t &raw_ts);
 date_t ParquetIntToDate(const int32_t &raw_date);
-dtime_t ParquetIntToTimeMs(const int64_t &raw_time);
+dtime_t ParquetIntToTimeMs(const int32_t &raw_time);
 dtime_t ParquetIntToTime(const int64_t &raw_time);
 dtime_t ParquetIntToTimeNs(const int64_t &raw_time);
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -200,6 +200,11 @@ LogicalType ParquetReader::DeriveLogicalType(const SchemaElement &s_ele, bool bi
 				throw IOException("UTF8 converted type can only be set for Type::(FIXED_LEN_)BYTE_ARRAY");
 			}
 		case ConvertedType::TIME_MILLIS:
+			if (s_ele.type == Type::INT32) {
+				return LogicalType::TIME;
+			} else {
+				throw IOException("TIME_MILLIS converted type can only be set for value of Type::INT32");
+			}
 		case ConvertedType::TIME_MICROS:
 			if (s_ele.type == Type::INT64) {
 				return LogicalType::TIME;

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -1,12 +1,11 @@
 #include "parquet_statistics.hpp"
 #include "parquet_decimal_utils.hpp"
 #include "parquet_timestamp.hpp"
-
 #include "duckdb.hpp"
 #ifndef DUCKDB_AMALGAMATION
 #include "duckdb/common/types/blob.hpp"
 #include "duckdb/common/types/value.hpp"
-
+#include "duckdb/common/types/time.hpp"
 #endif
 
 namespace duckdb {
@@ -155,11 +154,31 @@ Value ParquetStatisticsUtils::ConvertValue(const LogicalType &type,
 		return Value::DATE(date_t(Load<int32_t>((data_ptr_t)stats.c_str())));
 	case LogicalTypeId::TIME:
 	case LogicalTypeId::TIME_TZ: {
-		if (stats.size() != sizeof(int64_t)) {
+		int64_t val;
+		if (stats.size() == sizeof(int32_t)) {
+			val = Load<int32_t>((data_ptr_t)stats.c_str());
+		} else if (stats.size() == sizeof(int64_t)) {
+			val = Load<int64_t>((data_ptr_t)stats.c_str());
+		} else {
 			throw InternalException("Incorrect stats size for type TIME");
 		}
-		auto time = dtime_t(Load<int64_t>((data_ptr_t)stats.c_str()));
-		return Value::TIME(time);
+		if (schema_ele.__isset.logicalType && schema_ele.logicalType.__isset.TIME) {
+			// logical type
+			if (schema_ele.logicalType.TIME.unit.__isset.MILLIS) {
+				return Value::TIME(Time::FromTimeMs(val));
+			} else if (schema_ele.logicalType.TIME.unit.__isset.NANOS) {
+				return Value::TIME(Time::FromTimeNs(val));
+			} else if (schema_ele.logicalType.TIME.unit.__isset.MICROS) {
+				return Value::TIME(dtime_t(val));
+			} else {
+				throw InternalException("Timestamp logicalType is set but unit is not defined");
+			}
+		}
+		if (schema_ele.converted_type == duckdb_parquet::format::ConvertedType::TIME_MILLIS) {
+			return Value::TIME(Time::FromTimeMs(val));
+		} else {
+			return Value::TIME(dtime_t(val));
+		}
 	}
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_TZ: {

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -171,7 +171,7 @@ Value ParquetStatisticsUtils::ConvertValue(const LogicalType &type,
 			} else if (schema_ele.logicalType.TIME.unit.__isset.MICROS) {
 				return Value::TIME(dtime_t(val));
 			} else {
-				throw InternalException("Timestamp logicalType is set but unit is not defined");
+				throw InternalException("Time logicalType is set but unit is not defined");
 			}
 		}
 		if (schema_ele.converted_type == duckdb_parquet::format::ConvertedType::TIME_MILLIS) {

--- a/extension/parquet/parquet_timestamp.cpp
+++ b/extension/parquet/parquet_timestamp.cpp
@@ -54,7 +54,7 @@ date_t ParquetIntToDate(const int32_t &raw_date) {
 	return date_t(raw_date);
 }
 
-dtime_t ParquetIntToTimeMs(const int64_t &raw_time) {
+dtime_t ParquetIntToTimeMs(const int32_t &raw_time) {
 	return Time::FromTimeMs(raw_time);
 }
 


### PR DESCRIPTION
As per the [Parquet spec](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md)

> TIME with unit MILLIS is used for millisecond precision. It must annotate an int32 that stores the number of milliseconds after midnight.

CC @samansmink 