### PR TITLE
Wasm loadable extensions wip

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -625,6 +625,38 @@ jobs:
         path: |
           duckdb-wasm32.zip
 
+ linux-wasm-experimental-loadable:
+    name: WebAssembly duckdb-wasm loadable builds
+    runs-on: ubuntu-22.04
+    needs: linux-release-64
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - uses: mymindstorm/setup-emsdk@v12
+
+    - name: Setup
+      shell: bash
+      run: |
+        git clone --recurse-submodules https://github.com/duckdb/duckdb-wasm
+        cd duckdb-wasm
+        git checkout 53e4aad8ac21808a19e834df9ef559a9889f2671
+
+    - name: Setup Ccache
+      uses: hendrikmuhs/ccache-action@main
+      with:
+        key: ${{ github.job }}
+        save: ${{ github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb' }}
+
+    - name: Build WebAssembly
+      shell: bash
+      run: |
+        cd duckdb-wasm
+        WASM_LOADABLE_EXTENSIONS=1 bash scripts/wasm_build_lib.sh relsize mvp $(pwd)/..
+        WASM_LOADABLE_EXTENSIONS=1 bash scripts/wasm_build_lib.sh relsize eh $(pwd)/..
+        WASM_LOADABLE_EXTENSIONS=1 bash scripts/wasm_build_lib.sh relsize coi $(pwd)/..
+
  symbol-leakage:
     name: Symbol Leakage
     runs-on: ubuntu-20.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ endif()
 
 option(FORCE_WARN_UNUSED "Unused code objects lead to compiler warnings." FALSE)
 
+option(WASM_LOADABLE_EXTENSIONS "WebAssembly build with loadable extensions." FALSE)
 option(ENABLE_SANITIZER "Enable address sanitizer." TRUE)
 option(ENABLE_THREAD_SANITIZER "Enable thread sanitizer." FALSE)
 option(ENABLE_UBSAN "Enable undefined behavior sanitizer." TRUE)
@@ -778,7 +779,6 @@ function(build_loadable_extension_directory NAME OUTPUT_DIRECTORY PARAMETERS)
   # parse parameters
   string(FIND "${PARAMETERS}" "-no-warnings" IGNORE_WARNINGS)
 
-
   add_library(${TARGET_NAME} SHARED ${FILES})
   # this disables the -Dsome_target_EXPORTS define being added by cmake which otherwise trips clang-tidy (yay)
   set_target_properties(${TARGET_NAME} PROPERTIES DEFINE_SYMBOL "")
@@ -796,7 +796,9 @@ function(build_loadable_extension_directory NAME OUTPUT_DIRECTORY PARAMETERS)
   #    The DuckDB symbols required by the loadable extensions are left unresolved. This will reduce the size of the binaries
   #    and works well when running the DuckDB cli directly. For windows this uses delay loading. For MacOS and linux the
   #    dynamic loader will look up the missing symbols when the extension is dlopen-ed.
-  if (EXTENSION_STATIC_BUILD)
+  if(WASM_LOADABLE_EXTENSIONS)
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -sSIDE_MODULE=1 -DWASM_LOADABLE_EXTENSIONS")
+  elseif (EXTENSION_STATIC_BUILD)
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
       if (APPLE)
         set_target_properties(${TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)

--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -1,3 +1,18 @@
+if(${WASM_LOADABLE_EXTENSIONS})
+  file(
+    GLOB sources_list
+    LIST_DIRECTORIES true
+    "*")
+  foreach(dir ${sources_list})
+    if(IS_DIRECTORY ${dir})
+      add_subdirectory(${dir})
+    else()
+      continue()
+    endif()
+  endforeach()
+  return()
+endif()
+
 if(${BUILD_ICU_EXTENSION})
   add_subdirectory(icu)
 endif()

--- a/extension/httpfs/CMakeLists.txt
+++ b/extension/httpfs/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(${WASM_LOADABLE_EXTENSIONS})
+  return()
+endif()
+
 cmake_minimum_required(VERSION 2.8.12)
 
 project(HTTPFsExtension)

--- a/extension/jemalloc/CMakeLists.txt
+++ b/extension/jemalloc/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(${WASM_LOADABLE_EXTENSIONS})
+  return()
+endif()
+
 cmake_minimum_required(VERSION 2.8.12)
 
 project(JEMallocExtension)

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -59,7 +59,7 @@ bool ExtensionHelper::TryInitialLoad(DBConfig &config, FileOpener *opener, const
 	if (!config.options.allow_unsigned_extensions) {
 		auto handle = fs.OpenFile(filename, FileFlags::FILE_FLAGS_READ);
 
-		// signature is the last 265 bytes of the file
+		// signature is the last 256 bytes of the file
 
 		string signature;
 		signature.resize(256);


### PR DESCRIPTION
This enable testing the WebAssembly compilation pipeline for duckdb extension (httpfs and jemalloc excluded)