### PR TITLE
Include necessary C++ header

### DIFF
--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -10,7 +10,7 @@
 #endif
 
 #include <cstdio>
-#include <inttypes.h>
+#include <cinttypes>
 
 namespace duckdb {
 


### PR DESCRIPTION
Somehow, trying to compile DuckDB with GCC and G++ installed from conda-forge leads to an error with undefined symbols, and suggests including this C++ header instead of its C variant. Then it compiles successfully.