### PR TITLE
Adding definition for missing extension exception

### DIFF
--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -323,6 +323,9 @@ BinderException::BinderException(const string &msg) : StandardException(Exceptio
 IOException::IOException(const string &msg) : Exception(ExceptionType::IO, msg) {
 }
 
+MissingExtensionException::MissingExtensionException(const string &msg) : Exception(ExceptionType::MISSING_EXTENSION, msg){
+}
+
 SerializationException::SerializationException(const string &msg) : Exception(ExceptionType::SERIALIZATION, msg) {
 }
 

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -323,7 +323,8 @@ BinderException::BinderException(const string &msg) : StandardException(Exceptio
 IOException::IOException(const string &msg) : Exception(ExceptionType::IO, msg) {
 }
 
-MissingExtensionException::MissingExtensionException(const string &msg) : Exception(ExceptionType::MISSING_EXTENSION, msg){
+MissingExtensionException::MissingExtensionException(const string &msg)
+    : Exception(ExceptionType::MISSING_EXTENSION, msg) {
 }
 
 SerializationException::SerializationException(const string &msg) : Exception(ExceptionType::SERIALIZATION, msg) {

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -78,7 +78,8 @@ enum class ExceptionType {
 	PARAMETER_NOT_RESOLVED = 35, // parameter types could not be resolved
 	PARAMETER_NOT_ALLOWED = 36,  // parameter types not allowed
 	DEPENDENCY = 37,             // dependency
-	HTTP = 38
+	HTTP = 38,
+	MISSING_EXTENSION = 39 // Thrown when an extension is used but not loaded
 };
 class HTTPException;
 
@@ -272,13 +273,13 @@ public:
 	}
 };
 
-class MissingExtensionException : public IOException {
+class MissingExtensionException : public Exception {
 public:
 	DUCKDB_API explicit MissingExtensionException(const string &msg);
 
 	template <typename... Args>
 	explicit MissingExtensionException(const string &msg, Args... params)
-	    : IOException(ConstructMessage(msg, params...)) {
+	    : MissingExtensionException(ConstructMessage(msg, params...)) {
 	}
 };
 


### PR DESCRIPTION
This fixes the issue you got when trying to use the `MissingExtensionException`
```cpp
Undefined symbols for architecture arm64: "duckdb::MissingExtensionException::MissingExtensionException(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)", referenced from:
```

Also I changed that the MissingExtensionException now inherits from Exception instead of IOException, but I wasn't sure on this. 