### PR TITLE
[Dev] Add missing header guard for `concurrentqueue.hpp`

### DIFF
--- a/src/include/duckdb/parallel/concurrentqueue.hpp
+++ b/src/include/duckdb/parallel/concurrentqueue.hpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#pragma once
+
 #ifndef DUCKDB_NO_THREADS
 #include "concurrentqueue.h"
 #else


### PR DESCRIPTION
This was causing my local compilation of duckdb-wasm to fail.