### PR TITLE
More precise kurtosis

### DIFF
--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -116,6 +116,8 @@ static DefaultMacro internal_macros[] = {
 	{DEFAULT_SCHEMA, "list_first", {"l", nullptr}, "list_aggr(l, 'first')"},
 	{DEFAULT_SCHEMA, "list_any_value", {"l", nullptr}, "list_aggr(l, 'any_value')"},
 	{DEFAULT_SCHEMA, "list_kurtosis", {"l", nullptr}, "list_aggr(l, 'kurtosis')"},
+	{DEFAULT_SCHEMA, "list_kurtosis_samp", {"l", nullptr}, "list_aggr(l, 'kurtosis_samp')"},
+	{DEFAULT_SCHEMA, "list_kurtosis_pop", {"l", nullptr}, "list_aggr(l, 'kurtosis_pop')"},
 	{DEFAULT_SCHEMA, "list_min", {"l", nullptr}, "list_aggr(l, 'min')"},
 	{DEFAULT_SCHEMA, "list_max", {"l", nullptr}, "list_aggr(l, 'max')"},
 	{DEFAULT_SCHEMA, "list_product", {"l", nullptr}, "list_aggr(l, 'product')"},

--- a/src/function/aggregate/distributive/kurtosis.cpp
+++ b/src/function/aggregate/distributive/kurtosis.cpp
@@ -39,7 +39,7 @@ struct KurtosisOperation {
 
 	/*
 	Formula here is taken from wikipedia:
-		https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Higher-order_statistics
+	    https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Higher-order_statistics
 	But adds a bias correction at the end in the case of sample kurtosis.
 	A reference for the correction can be found on:
 	Joanes, Derrick N., and Christine A. Gill.
@@ -60,8 +60,7 @@ struct KurtosisOperation {
 		if (state->n <= UINT32_MAX) {
 			const uint64_t n_u64 = state->n;
 			n_poly = n_u64 * n_u64 - uint64_t(3) * n_u64 + uint64_t(3);
-		}
-		else {
+		} else {
 			const double n_dbl = state->n;
 			n_poly = n_dbl * n_dbl - 3.0 * n_dbl + 3.0;
 		}
@@ -99,8 +98,7 @@ struct KurtosisOperation {
 
 		if (std::is_same<KurtosisFlag, KurtosisFlagNoBiasCorrection>::value) {
 			target[idx] = (state->n * state->m4) / (state->m2 * state->m2) - 3.0;
-		}
-		else {
+		} else {
 			const double g2 = (state->n * state->m4) / (state->m2 * state->m2);
 			const double cdiff = 3.0 * (state->n - idx_t(1));
 			double ratio;
@@ -108,8 +106,7 @@ struct KurtosisOperation {
 				const uint64_t n_u64 = state->n;
 				const uint64_t div = (n_u64 - uint64_t(2)) * (n_u64 - uint64_t(3));
 				ratio = static_cast<double>(n_u64 - uint64_t(1)) / static_cast<double>(div);
-			}
-			else {
+			} else {
 				const double n_dbl = state->n;
 				ratio = (n_dbl - 1.0) / ((n_dbl - 2.0) * (n_dbl - 3.0));
 			}
@@ -130,26 +127,20 @@ struct KurtosisOperation {
 void KurtosisFun::RegisterFunction(BuiltinFunctions &set) {
 	AggregateFunctionSet kurtosis_fun("kurtosis");
 	kurtosis_fun.AddFunction(
-		AggregateFunction::UnaryAggregate<KurtosisState, double, double, KurtosisOperation<KurtosisFlagBiasCorrection>>(
-			LogicalType::DOUBLE, LogicalType::DOUBLE
-		)
-	);
+	    AggregateFunction::UnaryAggregate<KurtosisState, double, double, KurtosisOperation<KurtosisFlagBiasCorrection>>(
+	        LogicalType::DOUBLE, LogicalType::DOUBLE));
 	set.AddFunction(kurtosis_fun);
 
 	AggregateFunctionSet kurtosis_samp_fun("kurtosis_samp");
 	kurtosis_samp_fun.AddFunction(
-		AggregateFunction::UnaryAggregate<KurtosisState, double, double, KurtosisOperation<KurtosisFlagBiasCorrection>>(
-			LogicalType::DOUBLE, LogicalType::DOUBLE
-		)
-	);
+	    AggregateFunction::UnaryAggregate<KurtosisState, double, double, KurtosisOperation<KurtosisFlagBiasCorrection>>(
+	        LogicalType::DOUBLE, LogicalType::DOUBLE));
 	set.AddFunction(kurtosis_samp_fun);
 
 	AggregateFunctionSet kurtosis_pop_fun("kurtosis_pop");
-	kurtosis_pop_fun.AddFunction(
-		AggregateFunction::UnaryAggregate<KurtosisState, double, double, KurtosisOperation<KurtosisFlagNoBiasCorrection>>(
-			LogicalType::DOUBLE, LogicalType::DOUBLE
-		)
-	);
+	kurtosis_pop_fun.AddFunction(AggregateFunction::UnaryAggregate<KurtosisState, double, double,
+	                                                               KurtosisOperation<KurtosisFlagNoBiasCorrection>>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
 	set.AddFunction(kurtosis_pop_fun);
 }
 

--- a/src/function/aggregate/distributive/kurtosis.cpp
+++ b/src/function/aggregate/distributive/kurtosis.cpp
@@ -21,7 +21,7 @@ struct KurtosisFlagBiasCorrection {};
 
 struct KurtosisFlagNoBiasCorrection {};
 
-template <class KurtosisFlag>
+template <class KURTOSIS_FLAG>
 struct KurtosisOperation {
 	template <class STATE>
 	static void Initialize(STATE *state) {
@@ -96,7 +96,7 @@ struct KurtosisOperation {
 			mask.SetInvalid(idx);
 		} // LCOV_EXCL_STOP
 
-		if (std::is_same<KurtosisFlag, KurtosisFlagNoBiasCorrection>::value) {
+		if (std::is_same<KURTOSIS_FLAG, KurtosisFlagNoBiasCorrection>::value) {
 			target[idx] = (state->n * state->m4) / (state->m2 * state->m2) - 3.0;
 		} else {
 			const double g2 = (state->n * state->m4) / (state->m2 * state->m2);

--- a/src/function/aggregate/distributive/kurtosis.cpp
+++ b/src/function/aggregate/distributive/kurtosis.cpp
@@ -57,7 +57,7 @@ struct KurtosisOperation {
 		const double term1 = delta * delta_n * n1;
 		// Note: for n<=2^32, this can be calculated more precisely with integer types
 		double n_poly;
-		if (state->n <= UINT32_MAX) {
+		if (state->n > 3 && state->n <= UINT32_MAX) {
 			const uint64_t n_u64 = state->n;
 			n_poly = n_u64 * n_u64 - uint64_t(3) * n_u64 + uint64_t(3);
 		} else {
@@ -102,7 +102,7 @@ struct KurtosisOperation {
 			const double g2 = (state->n * state->m4) / (state->m2 * state->m2);
 			const double cdiff = 3.0 * (state->n - idx_t(1));
 			double ratio;
-			if (state->n <= UINT32_MAX) {
+			if (state->n > 3 && state->n <= UINT32_MAX) {
 				const uint64_t n_u64 = state->n;
 				const uint64_t div = (n_u64 - uint64_t(2)) * (n_u64 - uint64_t(3));
 				ratio = static_cast<double>(n_u64 - uint64_t(1)) / static_cast<double>(div);
@@ -111,7 +111,7 @@ struct KurtosisOperation {
 				ratio = (n_dbl - 1.0) / ((n_dbl - 2.0) * (n_dbl - 3.0));
 			}
 
-			target[idx] = ratio * ((state->n + 1.0) * g2 - cdiff);
+			target[idx] = ratio * ((state->n + idx_t(1)) * g2 - cdiff);
 		}
 
 		if (!Value::DoubleIsFinite(target[idx])) {

--- a/test/sql/aggregate/aggregates/test_kurtosis.test
+++ b/test/sql/aggregate/aggregates/test_kurtosis.test
@@ -62,6 +62,16 @@ select kurtosis(k), kurtosis(v), kurtosis(v2) from aggr;
 ----
 11.000000	-1.961428	-1.445120
 
+query III
+select kurtosis_samp(k), kurtosis_samp(v), kurtosis_samp(v2) from aggr;
+----
+11.000000	-1.961428	-1.445120
+
+query III
+select kurtosis_pop(k), kurtosis_pop(v), kurtosis_pop(v2) from aggr;
+----
+6.100000	-1.676857	-1.358688
+
 query I
 select  kurtosis(v2) from aggr group by v;
 ----

--- a/test/sql/function/list/aggregates/kurtosis.test
+++ b/test/sql/function/list/aggregates/kurtosis.test
@@ -35,6 +35,26 @@ NULL
 NULL
 NULL
 
+query I
+select list_kurtosis_samp(k) from aggr;
+----
+11.000000
+-1.961428
+-1.445120
+NULL
+NULL
+NULL
+
+query I
+select list_kurtosis_pop(k) from aggr;
+----
+6.100000
+-1.676857
+-1.358688
+NULL
+NULL
+NULL
+
 # incorrect usage
 statement error
 select list_kurtosis()


### PR DESCRIPTION
This PR changes the calculation of kurtosis from using sums of higher-order powers towards running sums of **centered** exponentiated terms.

This approach is typically more precise (esp. when dealing with large numbers), although it's a bit slower. I nevertheless imagine that most people would prioritize precision in a kurtosis calculation.

Along the way, it differentiates between bias-corrected and non-bias-corrected versions of the calculation (it's BTW not obvious from the docs that it applies this correction by default), with the same naming separation that is used for standard deviation and variance.