### PR TITLE
Add duckdb::make_uniq

### DIFF
--- a/src/include/duckdb/common/helper.hpp
+++ b/src/include/duckdb/common/helper.hpp
@@ -43,6 +43,10 @@ unique_ptr<T> make_unique(Args &&... args) {
 #else // Visual Studio has make_unique
 using std::make_unique;
 #endif
+template <typename T, typename... Args>
+duckdb::unique_ptr<T> make_uniq(Args &&... args) {
+	return unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
 template <typename S, typename T, typename... Args>
 unique_ptr<S> make_unique_base(Args &&... args) {
 	return unique_ptr<S>(new T(std::forward<Args>(args)...));


### PR DESCRIPTION
This should allow to migrate secondary repos (extensions and duckdb-wasm) independently of the actual safe_unique_ptr implementation, and this should untangle a bit the current state.

For a secondary repo to adapt, they should:
* NOT use std::unique_ptr in any function signature / class member that is required at the interaction with main duckdb repo
* use duckdb::make_uniq to create duckdb-compatible unique_ptr