### PR TITLE
Bump duckdb-wasm to support duckdb::make_uniq

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -598,7 +598,7 @@ jobs:
       run: |
         git clone --recurse-submodules https://github.com/duckdb/duckdb-wasm
         cd duckdb-wasm
-        git checkout 53e4aad8ac21808a19e834df9ef559a9889f2671
+        git checkout e401029fb3020c7a7be2c03896717c615418277e
 
     - name: Setup Ccache
       uses: hendrikmuhs/ccache-action@main
@@ -641,7 +641,7 @@ jobs:
       run: |
         git clone --recurse-submodules https://github.com/duckdb/duckdb-wasm
         cd duckdb-wasm
-        git checkout 53e4aad8ac21808a19e834df9ef559a9889f2671
+        git checkout e401029fb3020c7a7be2c03896717c615418277e
 
     - name: Setup Ccache
       uses: hendrikmuhs/ccache-action@main


### PR DESCRIPTION
Dependency dance to bring in safe_unique_ptr.
Current status is everything works with duckdb::make_uniq or std::make_unique, PR adapts to the changes to duckdb-wasm now merged in master.

Alternative to https://github.com/duckdb/duckdb/pull/6926 (that I will temporary put on hold)