### PR TITLE
[Dev] Lock Pandas version in CI

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Before Install
         shell: bash
         run: |
-          pip install --prefer-binary "pandas==1.5.3" "requests>=2.26" "pyarrow==8.0" "psutil>=5.9.0" pytest
+          pip install --prefer-binary "pandas<=1.5.3" "requests>=2.26" "pyarrow==8.0" "psutil>=5.9.0" pytest
           sudo apt-get install g++
 
       - name: Coverage Reset

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Before Install
         shell: bash
         run: |
-          pip install --prefer-binary "pandas>=1.2.4" "requests>=2.26" "pyarrow==8.0" "psutil>=5.9.0" pytest
+          pip install --prefer-binary "pandas==1.5.3" "requests>=2.26" "pyarrow==8.0" "psutil>=5.9.0" pytest
           sudo apt-get install g++
 
       - name: Coverage Reset

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -171,7 +171,7 @@ jobs:
       shell: bash
       run: |
         sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
-        pip install numpy pytest pandas mypy psutil pyarrow
+        pip install numpy pytest "pandas==1.5.3" mypy psutil pyarrow
 
     - name: Setup Ccache
       uses: hendrikmuhs/ccache-action@main

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -171,7 +171,7 @@ jobs:
       shell: bash
       run: |
         sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
-        pip install numpy pytest "pandas==1.5.3" mypy psutil pyarrow
+        pip install numpy pytest "pandas<=1.5.3" mypy psutil pyarrow
 
     - name: Setup Ccache
       uses: hendrikmuhs/ccache-action@main

--- a/tools/pythonpkg/cibw.toml
+++ b/tools/pythonpkg/cibw.toml
@@ -4,7 +4,7 @@
 [tool.cibuildwheel]
 environment = "PIP_CONSTRAINT='build-constraints.txt'"
 before-build = 'pip install oldest-supported-numpy'
-before-test = 'pip install --prefer-binary "pandas==1.5.3" pytest-timeout mypy "psutil>=5.9.0" "requests>=2.26" fsspec   && (pip install --prefer-binary "pyarrow>=8.0" || true) && (pip install --prefer-binary "torch" || true) && (pip install --prefer-binary "polars" || true)&& (pip install --prefer-binary "tensorflow" || true)'
+before-test = 'pip install --prefer-binary "pandas<=1.5.3" pytest-timeout mypy "psutil>=5.9.0" "requests>=2.26" fsspec   && (pip install --prefer-binary "pyarrow>=8.0" || true) && (pip install --prefer-binary "torch" || true) && (pip install --prefer-binary "polars" || true)&& (pip install --prefer-binary "tensorflow" || true)'
 test-requires = 'pytest'
 test-command = 'DUCKDB_PYTHON_TEST_EXTENSION_PATH={project} DUCKDB_PYTHON_TEST_EXTENSION_REQUIRED=1 python -m pytest {project}/tests'
 

--- a/tools/pythonpkg/cibw.toml
+++ b/tools/pythonpkg/cibw.toml
@@ -4,7 +4,7 @@
 [tool.cibuildwheel]
 environment = "PIP_CONSTRAINT='build-constraints.txt'"
 before-build = 'pip install oldest-supported-numpy'
-before-test = 'pip install --prefer-binary "pandas>=0.24" pytest-timeout mypy "psutil>=5.9.0" "requests>=2.26" fsspec   && (pip install --prefer-binary "pyarrow>=8.0" || true) && (pip install --prefer-binary "torch" || true) && (pip install --prefer-binary "polars" || true)&& (pip install --prefer-binary "tensorflow" || true)'
+before-test = 'pip install --prefer-binary "pandas==1.5.3" pytest-timeout mypy "psutil>=5.9.0" "requests>=2.26" fsspec   && (pip install --prefer-binary "pyarrow>=8.0" || true) && (pip install --prefer-binary "torch" || true) && (pip install --prefer-binary "polars" || true)&& (pip install --prefer-binary "tensorflow" || true)'
 test-requires = 'pytest'
 test-command = 'DUCKDB_PYTHON_TEST_EXTENSION_PATH={project} DUCKDB_PYTHON_TEST_EXTENSION_REQUIRED=1 python -m pytest {project}/tests'
 

--- a/tools/pythonpkg/requirements-dev.txt
+++ b/tools/pythonpkg/requirements-dev.txt
@@ -3,7 +3,7 @@ pybind11>=2.6.0
 setuptools_scm>=6.3
 setuptools>=58
 pytest
-pandas
+pandas==1.5.3
 pyarrow
 mypy
 psutil>=5.9.0

--- a/tools/pythonpkg/requirements-dev.txt
+++ b/tools/pythonpkg/requirements-dev.txt
@@ -3,7 +3,7 @@ pybind11>=2.6.0
 setuptools_scm>=6.3
 setuptools>=58
 pytest
-pandas==1.5.3
+pandas<=1.5.3
 pyarrow
 mypy
 psutil>=5.9.0


### PR DESCRIPTION
This locks the version of Pandas to the last release before 2.0.0, so we can deal with the breaking changes made in 2.0.0 at a later date (but soon)