### PR TITLE
[Python - Chore] Update name of pybind11 type caster for doc gen

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/conversions/pyconnection_default.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/conversions/pyconnection_default.hpp
@@ -16,7 +16,8 @@ class type_caster<shared_ptr<DuckDBPyConnection>>
     : public copyable_holder_caster<DuckDBPyConnection, shared_ptr<DuckDBPyConnection>> {
 	using type = DuckDBPyConnection;
 	using holder_caster = copyable_holder_caster<DuckDBPyConnection, shared_ptr<DuckDBPyConnection>>;
-	PYBIND11_TYPE_CASTER(shared_ptr<type>, const_name("default_connection_holder"));
+	// This is used to generate documentation on duckdb-web
+	PYBIND11_TYPE_CASTER(shared_ptr<type>, const_name("duckdb.DuckDBPyConnection"));
 
 	bool load(handle src, bool convert) {
 		if (py::none().is(src)) {


### PR DESCRIPTION
This PR fixes changes requested in https://github.com/duckdb/duckdb-web/pull/673

The name of the type caster is used in the generation of the docs, which I hadn't realized, from what I read it was just internally to identify the caster in pybind.