### PR TITLE
duckdb::unique_ptr: Add conversions between duckdb::unique_ptr

### DIFF
--- a/src/include/duckdb/common/unique_ptr.hpp
+++ b/src/include/duckdb/common/unique_ptr.hpp
@@ -35,6 +35,14 @@ public:
 		__unique_ptr_utils::AssertNotNull((void *)original::get());
 		return original::get();
 	}
+	unique_ptr() : std::unique_ptr<_Tp, _Dp>() {
+	}
+	template <class X, typename std::enable_if<std::is_base_of<_Tp, X>::value, void>::type>
+	unique_ptr(unique_ptr<X, std::default_delete<X>> &&ptr) : std::unique_ptr<_Tp, _Dp>(std::move(ptr)) {
+	}
+	template <class X, class DX, typename std::enable_if<std::is_base_of<_Tp, X>::value, void>::type>
+	unique_ptr(unique_ptr<X, DX> &&ptr) : std::unique_ptr<_Tp, _Dp>(std::move(ptr)) {
+	}
 
 #ifdef DUCKDB_CLANG_TIDY
 	// This is necessary to tell clang-tidy that it reinitializes the variable after a move


### PR DESCRIPTION
This should make downcasts between duckdb::unique_ptr work out of the box, as it does for std::unique_ptr, and this in turns avoid a few std::moves or explicit conversions that might otherwise be required.