### PR TITLE
[Python] Fix issue related to objects that convert to VARCHAR

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/builtins_module.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/builtins_module.hpp
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb_python/import_cache/modules/numpy_module.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb_python/import_cache/python_import_cache_item.hpp"
+
+namespace duckdb {
+
+struct BuiltinsCacheItem : public PythonImportCacheItem {
+public:
+	static constexpr const char *Name = "builtins";
+
+public:
+	~BuiltinsCacheItem() override {
+	}
+	virtual void LoadSubtypes(PythonImportCache &cache) override {
+		str.LoadAttribute("str", cache, *this);
+	}
+
+public:
+	PythonImportCacheItem str;
+};
+
+} // namespace duckdb

--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/python_import_cache.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/python_import_cache.hpp
@@ -64,9 +64,13 @@ public:
 	IpywidgetsCacheItem &ipywidgets() {
 		return LazyLoadModule(ipywidgets_module);
 	}
+	BuiltinsCacheItem &builtins() {
+		return LazyLoadModule(builtins_module);
+	}
 
 private:
 	NumpyCacheItem numpy_module;
+	BuiltinsCacheItem builtins_module;
 	PathLibCacheItem pathlib_module;
 	PyDuckDBCacheItem pyduckdb_module;
 	DatetimeCacheItem datetime_module;

--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/python_import_cache_modules.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/python_import_cache_modules.hpp
@@ -9,3 +9,4 @@
 #include "duckdb_python/import_cache/modules/pandas_module.hpp"
 #include "duckdb_python/import_cache/modules/polars_module.hpp"
 #include "duckdb_python/import_cache/modules/uuid_module.hpp"
+#include "duckdb_python/import_cache/modules/builtins_module.hpp"

--- a/tools/pythonpkg/src/include/duckdb_python/pandas_analyzer.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pandas_analyzer.hpp
@@ -28,6 +28,9 @@ public:
 	}
 
 public:
+	bool ContainsOnlyStrings() const {
+		return all_strings;
+	}
 	LogicalType GetListType(py::handle &ele, bool &can_convert);
 	LogicalType DictToMap(const PyDictionary &dict, bool &can_convert);
 	LogicalType DictToStruct(const PyDictionary &dict, bool &can_convert);
@@ -47,6 +50,8 @@ private:
 	PythonGILWrapper gil;
 	//! The resulting analyzed type
 	LogicalType analyzed_type;
+	//! Whether all objects are builtin.str
+	bool all_strings = true;
 };
 
 } // namespace duckdb

--- a/tools/pythonpkg/src/include/duckdb_python/vector_conversion.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/vector_conversion.hpp
@@ -33,6 +33,8 @@ struct PandasColumnBindData {
 	string internal_categorical_type;
 	// When object types are cast we must hold their data somewhere
 	PythonObjectContainer<py::str> object_str_val;
+	//! Whether all objects are builtin.str objects
+	bool all_strings = true;
 };
 
 class VectorConversion {

--- a/tools/pythonpkg/src/pandas/analyzer.cpp
+++ b/tools/pythonpkg/src/pandas/analyzer.cpp
@@ -246,6 +246,13 @@ LogicalType PandasAnalyzer::DictToStruct(const PyDictionary &dict, bool &can_con
 LogicalType PandasAnalyzer::GetItemType(py::handle ele, bool &can_convert) {
 	auto object_type = GetPythonObjectType(ele);
 
+	if (all_strings && object_type == PythonObjectType::String) {
+		// Fast path for strings
+		return LogicalType::VARCHAR;
+	} else {
+		all_strings = false;
+	}
+
 	switch (object_type) {
 	case PythonObjectType::None:
 		return LogicalType::SQLNULL;
@@ -319,7 +326,6 @@ LogicalType PandasAnalyzer::GetItemType(py::handle ele, bool &can_convert) {
 	}
 	case PythonObjectType::Other:
 		// Fall back to string for unknown types
-		can_convert = false;
 		return LogicalType::VARCHAR;
 	}
 }

--- a/tools/pythonpkg/src/vector_conversion.cpp
+++ b/tools/pythonpkg/src/vector_conversion.cpp
@@ -294,7 +294,7 @@ void VectorConversion::NumpyToDuckDB(PandasColumnBindData &bind_data, py::array 
 		//! We have determined the underlying logical type of this object column
 		// Get the source pointer of the numpy array
 		auto src_ptr = (PyObject **)numpy_col.data();
-		if (out.GetType().id() != LogicalTypeId::VARCHAR) {
+		if (!bind_data.all_strings) {
 			return ScanPandasObjectColumn(bind_data, src_ptr, count, offset, out);
 		}
 
@@ -490,6 +490,7 @@ void VectorConversion::BindPandas(const DBConfig &config, py::handle df, vector<
 			if (analyzer.Analyze(get_fun(df_columns[col_idx]))) {
 				duckdb_col_type = analyzer.AnalyzedType();
 			}
+			bind_data.all_strings = analyzer.ContainsOnlyStrings();
 		}
 
 		D_ASSERT(py::hasattr(bind_data.numpy_col, "strides"));

--- a/tools/pythonpkg/tests/fast/pandas/test_df_object_resolution.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_df_object_resolution.py
@@ -371,13 +371,21 @@ class TestResolveObjectColumns(object):
         double_dtype = np.dtype('float64')
         assert isinstance(converted_col['0'].dtype, double_dtype.__class__) == True
 
+    def test_numpy_stringliterals(self):
+        con = duckdb.connect()
+        df = pd.DataFrame({"x": list(map(np.str_, range(3)))})
+
+        res = con.execute("select * from df").fetchall()
+        assert res == [('0',), ('1',), ('2',)]
+
     def test_integer_conversion_fail(self):
         data = [2**10000, 0]
         x = pd.DataFrame({'0': pd.Series(data=data, dtype='object')})
         converted_col = duckdb.query_df(x, "x", "select * from x").df()
         print(converted_col['0'])
-        double_dtype = np.dtype('object')
-        assert isinstance(converted_col['0'].dtype, double_dtype.__class__) == True
+        object_dtype = np.dtype('object')
+        # The int is too big to convert to float
+        assert isinstance(converted_col['0'].dtype, object_dtype.__class__) == True
 
     # Most of the time numpy.datetime64 is just a wrapper around a datetime.datetime object
     # But to support arbitrary precision, it can fall back to using an `int` internally

--- a/tools/pythonpkg/tests/fast/test_parameter_list.py
+++ b/tools/pythonpkg/tests/fast/test_parameter_list.py
@@ -10,13 +10,13 @@ class TestParameterList(object):
         res = conn.execute("select count(*) from bool_table where a =?",[True])
         assert res.fetchone()[0] == 1
 
-    def test_exception(self, duckdb_cursor):
+    def test_conversion_to_string(self, duckdb_cursor):
         conn = duckdb.connect()
         df_in = pd.DataFrame({'numbers': [1,2,3,4,5],})
         conn.execute("create table bool_table (a bool)")
         conn.execute("insert into bool_table values (TRUE)")
-        with pytest.raises(duckdb.NotImplementedException, match='Unable to transform'):
-            res = conn.execute("select count(*) from bool_table where a =?",[df_in])
+        res = conn.execute("select count(*) from bool_table where a =?",[df_in]).fetchall()
+        assert res == [(0,)]
 
     def test_explicit_nan_param(self):
         con = duckdb.default_connection


### PR DESCRIPTION
This PR fixes #6932 

When converting an object column to DuckDB, there is a fast path for builtin string objects.
The issue was that the decision to take this path was made too naively, based on analyzed DuckDB type.

This caused an issue for objects like `numpy.str_` literals because while they should convert to VARCHAR, we cant treat them like regular builtin strings when converting.

I have verified that builtin strings are still taking the fast path, so this shouldn't create any regressions