### PR TITLE
[Python] Fix issue related to objects that derive from `builtin.str`

### DIFF
--- a/tools/pythonpkg/src/vector_conversion.cpp
+++ b/tools/pythonpkg/src/vector_conversion.cpp
@@ -311,7 +311,7 @@ void VectorConversion::NumpyToDuckDB(PandasColumnBindData &bind_data, py::array 
 
 			// Get the pointer to the object
 			PyObject *val = src_ptr[source_idx];
-			if (bind_data.pandas_type == PandasType::OBJECT && !PyUnicode_CheckExact(val)) {
+			if (bind_data.pandas_type == PandasType::OBJECT && !py::isinstance<py::str>(val)) {
 				if (val == Py_None) {
 					out_mask.SetInvalid(row);
 					continue;
@@ -344,7 +344,7 @@ void VectorConversion::NumpyToDuckDB(PandasColumnBindData &bind_data, py::array 
 			}
 			// Python 3 string representation:
 			// https://github.com/python/cpython/blob/3a8fdb28794b2f19f6c8464378fb8b46bce1f5f4/Include/cpython/unicodeobject.h#L79
-			if (!PyUnicode_CheckExact(val)) {
+			if (!py::isinstance<py::str>(val)) {
 				out_mask.SetInvalid(row);
 				continue;
 			}

--- a/tools/pythonpkg/tests/fast/pandas/test_df_object_resolution.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_df_object_resolution.py
@@ -371,6 +371,13 @@ class TestResolveObjectColumns(object):
         double_dtype = np.dtype('float64')
         assert isinstance(converted_col['0'].dtype, double_dtype.__class__) == True
 
+    def test_numpy_stringliterals(self):
+        con = duckdb.connect()
+        df = pd.DataFrame({"x": list(map(np.str_, range(3)))})
+
+        res = con.execute("select * from df").fetchall()
+        assert res == [('0',), ('1',), ('2',)]
+
     def test_integer_conversion_fail(self):
         data = [2**10000, 0]
         x = pd.DataFrame({'0': pd.Series(data=data, dtype='object')})


### PR DESCRIPTION
This PR fixes #6932 

Anything that inherits from `builtin.str` should behave like a string, check for `instanceof` instead of an exact match with `PyUnicode_CheckExact`