### PR TITLE
Issue #3207: LogicalAsOfJoin Deserialize

### DIFF
--- a/src/include/duckdb/planner/operator/logical_asof_join.hpp
+++ b/src/include/duckdb/planner/operator/logical_asof_join.hpp
@@ -20,6 +20,8 @@ public:
 
 public:
 	explicit LogicalAsOfJoin(JoinType type);
+
+	static unique_ptr<LogicalOperator> Deserialize(LogicalDeserializationState &state, FieldReader &reader);
 };
 
 } // namespace duckdb

--- a/src/planner/operator/logical_asof_join.cpp
+++ b/src/planner/operator/logical_asof_join.cpp
@@ -5,4 +5,10 @@ namespace duckdb {
 LogicalAsOfJoin::LogicalAsOfJoin(JoinType type) : LogicalComparisonJoin(type, LogicalOperatorType::LOGICAL_ASOF_JOIN) {
 }
 
+unique_ptr<LogicalOperator> LogicalAsOfJoin::Deserialize(LogicalDeserializationState &state, FieldReader &reader) {
+	auto result = make_uniq<LogicalAsOfJoin>(JoinType::INVALID);
+	LogicalComparisonJoin::Deserialize(*result, state, reader);
+	return std::move(result);
+}
+
 } // namespace duckdb


### PR DESCRIPTION
This needs to be a separate method or the object type will not be preserved.