### PR TITLE
[Dev] Make `copy/csv/test_union_by_name.test` result deterministic

### DIFF
--- a/test/sql/copy/csv/test_union_by_name.test
+++ b/test/sql/copy/csv/test_union_by_name.test
@@ -2,6 +2,8 @@
 # description: UNION_BY_NAME test
 # group: [csv]
 
+# Setup
+
 statement ok
 CREATE TABLE ubn1(a BIGINT);
 
@@ -10,6 +12,8 @@ CREATE TABLE ubn2(a INTEGER, b INTEGER);
 
 statement ok
 CREATE TABLE ubn3(a INTEGER, c INTEGER);
+
+# Populate the tables
 
 statement ok
 INSERT INTO ubn1 VALUES (1), (2), (9223372036854775807);
@@ -20,6 +24,8 @@ INSERT INTO ubn2 VALUES (3,4), (5, 6);
 statement ok
 INSERT INTO ubn3 VALUES (100,101), (102, 103);
 
+# Write them to temporary files
+
 statement ok
 COPY ubn1 TO '__TEST_DIR__/ubn1.csv' WITH (HEADER 1, DELIMITER ',');
 
@@ -29,12 +35,14 @@ COPY ubn2 TO '__TEST_DIR__/ubn2.csv' WITH (HEADER 1, DELIMITER ',');
 statement ok
 COPY ubn3 TO '__TEST_DIR__/ubn3.csv' WITH (HEADER 1, DELIMITER ',');
 
+# Read from them (the order matters)
+
 statement error
-SELECT * FROM read_csv_auto('__TEST_DIR__/ubn*.csv');
+SELECT * FROM read_csv_auto(['__TEST_DIR__/ubn1.csv', '__TEST_DIR__/ubn2.csv', '__TEST_DIR__/ubn3.csv']);
 
 query III
 SELECT a, b, c
-FROM  read_csv_auto('__TEST_DIR__/ubn*.csv', UNION_BY_NAME=TRUE)
+FROM  read_csv_auto(['__TEST_DIR__/ubn1.csv', '__TEST_DIR__/ubn2.csv', '__TEST_DIR__/ubn3.csv'], UNION_BY_NAME=TRUE)
 ORDER BY a;
 ----
 1	NULL	NULL
@@ -47,7 +55,7 @@ ORDER BY a;
 
 query TTT
 SELECT typeof(a), typeof(b), typeof(c)
-FROM read_csv_auto('__TEST_DIR__/ubn*.csv', UNION_BY_NAME=TRUE)
+FROM read_csv_auto(['__TEST_DIR__/ubn1.csv', '__TEST_DIR__/ubn2.csv', '__TEST_DIR__/ubn3.csv'], UNION_BY_NAME=TRUE)
 LIMIT 1;
 ----
 BIGINT	BIGINT	BIGINT


### PR DESCRIPTION
This PR fixes a random failure on Linux related to glob not being deterministic.

Example of such a failure:
<https://github.com/duckdb/duckdb/actions/runs/4619124123/jobs/8170314488?pr=6927>