### PR TITLE
Treat MinGW as a different platform for extension loading purposes

### DIFF
--- a/src/function/table/version/pragma_version.cpp
+++ b/src/function/table/version/pragma_version.cpp
@@ -81,7 +81,9 @@ string DuckDB::Platform() {
 		postfix = "_gcc4";
 	}
 #endif
-
+#ifdef __MINGW32__
+	postfix = "_mingw";
+#endif
 	return os + "_" + arch + postfix;
 }
 


### PR DESCRIPTION
Fixes #6231

This PR makes it so that MinGW is treated as a different platform for extension installation/loading purposes. This should make it so MinGW users no longer load extensions compiled with Visual Studio which causes crashes. This is primarily a problem for R on Windows because the R toolchain uses MinGW internally.

This PR does not yet set up the infrastructure to compile & upload extensions for MinGW, however, so the extensions will not yet be available to install for MinGW users. Instead trying to install a MinGW extension should now result in an "extension not found" error.