### PR TITLE
Partially fixes #6936 - Avoid unnecessarily calling ToString in expression executor state

### DIFF
--- a/src/execution/expression_executor.cpp
+++ b/src/execution/expression_executor.cpp
@@ -56,7 +56,7 @@ Allocator &ExpressionExecutor::GetAllocator() {
 
 void ExpressionExecutor::AddExpression(const Expression &expr) {
 	expressions.push_back(&expr);
-	auto state = make_uniq<ExpressionExecutorState>(expr.ToString());
+	auto state = make_uniq<ExpressionExecutorState>();
 	Initialize(expr, *state);
 	state->Verify();
 	states.push_back(std::move(state));

--- a/src/execution/expression_executor_state.cpp
+++ b/src/execution/expression_executor_state.cpp
@@ -31,11 +31,10 @@ ClientContext &ExpressionState::GetContext() {
 	return root.executor->GetContext();
 }
 
-ExpressionState::ExpressionState(const Expression &expr, ExpressionExecutorState &root)
-    : expr(expr), root(root), name(expr.ToString()) {
+ExpressionState::ExpressionState(const Expression &expr, ExpressionExecutorState &root) : expr(expr), root(root) {
 }
 
-ExpressionExecutorState::ExpressionExecutorState(const string &name) : profiler(), name(name) {
+ExpressionExecutorState::ExpressionExecutorState() : profiler() {
 }
 
 void ExpressionState::Verify(ExpressionExecutorState &root_executor) {

--- a/src/include/duckdb/execution/expression_executor_state.hpp
+++ b/src/include/duckdb/execution/expression_executor_state.hpp
@@ -29,7 +29,6 @@ struct ExpressionState {
 	vector<unique_ptr<ExpressionState>> child_states;
 	vector<LogicalType> types;
 	DataChunk intermediate_chunk;
-	string name;
 	CycleCounter profiler;
 
 public:
@@ -55,12 +54,11 @@ public:
 };
 
 struct ExpressionExecutorState {
-	explicit ExpressionExecutorState(const string &name);
+	ExpressionExecutorState();
 
 	unique_ptr<ExpressionState> root_state;
 	ExpressionExecutor *executor = nullptr;
 	CycleCounter profiler;
-	string name;
 
 	void Verify();
 };

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -690,7 +690,7 @@ ExpressionExecutorInfo::ExpressionExecutorInfo(ExpressionExecutor &executor, con
 ExpressionRootInfo::ExpressionRootInfo(ExpressionExecutorState &state, string name)
     : current_count(state.profiler.current_count), sample_count(state.profiler.sample_count),
       sample_tuples_count(state.profiler.sample_tuples_count), tuples_count(state.profiler.tuples_count),
-      name(state.name), time(state.profiler.time) {
+      name("expression"), time(state.profiler.time) {
 	// Use the name of expression-tree as extra-info
 	extra_info = std::move(name);
 	auto expression_info_p = make_uniq<ExpressionInfo>();

--- a/test/sql/pivot/test_pivot.test
+++ b/test/sql/pivot/test_pivot.test
@@ -14,7 +14,7 @@ CREATE TABLE Product(DaysToManufacture int, StandardCost int);
 statement ok
 INSERT INTO Product VALUES (0, 5.0885), (1, 223.88), (2, 359.1082), (4, 949.4105);
 
-query II
+query II rowsort
 SELECT DaysToManufacture, AVG(StandardCost) AS AverageCost
 FROM Product
 GROUP BY DaysToManufacture;


### PR DESCRIPTION
Issue #6936 

This decreases the cost of constructing the expression state for expressions, which lowers the cost of executing many expressions on a small amount of data.