### PR TITLE
[Python] Fix datetime with tzinfo converting to naive TIMESTAMP

### DIFF
--- a/tools/pythonpkg/src/python_objects.cpp
+++ b/tools/pythonpkg/src/python_objects.cpp
@@ -251,6 +251,7 @@ Value PyDateTime::ToDuckValue() {
 		// Need to subtract the UTC offset, so we invert the interval
 		utc_offset = Interval::Invert(utc_offset);
 		timestamp = Interval::Add(timestamp, utc_offset);
+		return Value::TIMESTAMPTZ(timestamp);
 	}
 	return Value::TIMESTAMP(timestamp);
 }

--- a/tools/pythonpkg/tests/fast/pandas/test_datetime_time.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_datetime_time.py
@@ -69,3 +69,19 @@ class TestDateTimeTime(object):
 
         with pytest.raises(duckdb.ConversionException):
             res = duckdb_con.execute("select * from test").df()
+
+    def test_timezone_datetime(self):
+        module = pytest.importorskip("datetime")
+        timezone = module.timezone
+        datetime = module.datetime
+
+        con = duckdb.connect()
+
+        dt = datetime.now(timezone.utc).replace(microsecond=0)
+
+        original = dt
+        stringified = str(dt)
+
+        original_res = con.execute('select ?::TIMESTAMPTZ', [original]).fetchone()
+        stringified_res = con.execute('select ?::TIMESTAMPTZ', [stringified]).fetchone()
+        assert original_res == stringified_res

--- a/tools/pythonpkg/tests/fast/pandas/test_datetime_time.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_datetime_time.py
@@ -1,15 +1,14 @@
 import pandas as pd
 import duckdb
-import datetime
 import numpy as np
 import pytest
-
+from datetime import datetime, timezone, time, timedelta
 
 class TestDateTimeTime(object):
 
     def test_time_high(self, duckdb_cursor):
         duckdb_time = duckdb.query("SELECT make_time(23, 1, 34.234345) AS '0'").df()
-        data = [datetime.time(hour=23, minute=1, second=34, microsecond=234345)]
+        data = [time(hour=23, minute=1, second=34, microsecond=234345)]
         df_in = pd.DataFrame(
             {'0': pd.Series(data=data, dtype='object')}
         )
@@ -18,7 +17,7 @@ class TestDateTimeTime(object):
 
     def test_time_low(self, duckdb_cursor):
         duckdb_time = duckdb.query("SELECT make_time(00, 01, 1.000) AS '0'").df()
-        data = [datetime.time(hour=0, minute=1, second=1)]
+        data = [time(hour=0, minute=1, second=1)]
         df_in = pd.DataFrame(
             {'0': pd.Series(data=data, dtype='object')}
         )
@@ -28,9 +27,9 @@ class TestDateTimeTime(object):
     def test_time_timezone_regular(self, duckdb_cursor):
         duckdb_time = duckdb.query("SELECT make_time(00, 01, 1.000) AS '0'").df()
         # time is 3 hours ahead of UTC
-        offset = datetime.timedelta(hours=3)
-        timezone = datetime.timezone(offset)
-        data = [datetime.time(hour=3, minute=1, second=1, tzinfo=timezone)]
+        offset = timedelta(hours=3)
+        tz = timezone(offset)
+        data = [time(hour=3, minute=1, second=1, tzinfo=tz)]
         df_in = pd.DataFrame(
             {'0': pd.Series(data=data, dtype='object')}
         )
@@ -40,9 +39,9 @@ class TestDateTimeTime(object):
     def test_time_timezone_negative_extreme(self, duckdb_cursor):
         duckdb_time = duckdb.query("SELECT make_time(12, 01, 1.000) AS '0'").df()
         # time is 14 hours behind UTC
-        offset = datetime.timedelta(hours=-14)
-        timezone = datetime.timezone(offset)
-        data = [datetime.time(hour=22, minute=1, second=1, tzinfo=timezone)]
+        offset = timedelta(hours=-14)
+        tz = timezone(offset)
+        data = [time(hour=22, minute=1, second=1, tzinfo=tz)]
         df_in = pd.DataFrame(
             {'0': pd.Series(data=data, dtype='object')}
         )
@@ -52,9 +51,9 @@ class TestDateTimeTime(object):
     def test_time_timezone_positive_extreme(self, duckdb_cursor):
         duckdb_time = duckdb.query("SELECT make_time(12, 01, 1.000) AS '0'").df()
         # time is 20 hours ahead of UTC
-        offset = datetime.timedelta(hours=20)
-        timezone = datetime.timezone(offset)
-        data = [datetime.time(hour=8, minute=1, second=1, tzinfo=timezone)]
+        offset = timedelta(hours=20)
+        tz = timezone(offset)
+        data = [time(hour=8, minute=1, second=1, tzinfo=tz)]
         df_in = pd.DataFrame(
             {'0': pd.Series(data=data, dtype='object')}
         )
@@ -71,10 +70,6 @@ class TestDateTimeTime(object):
             res = duckdb_con.execute("select * from test").df()
 
     def test_timezone_datetime(self):
-        module = pytest.importorskip("datetime")
-        timezone = module.timezone
-        datetime = module.datetime
-
         con = duckdb.connect()
 
         dt = datetime.now(timezone.utc).replace(microsecond=0)


### PR DESCRIPTION
This PR fixes #6466 

When converting the `datetime.datetime` object, we already stripped the timezone, but didn't save the value as being of the type TIMESTAMPTZ