### PR TITLE
Fix crash/error caused by importing an empty database.

### DIFF
--- a/src/include/duckdb/planner/pragma_handler.hpp
+++ b/src/include/duckdb/planner/pragma_handler.hpp
@@ -29,8 +29,9 @@ private:
 	ClientContext &context;
 
 private:
-	//! Handles a pragma statement, (potentially) returning a new statement to replace the current one
-	string HandlePragma(SQLStatement *statement);
+	//! Handles a pragma statement, returns whether the statement was expanded, if it was expanded the 'resulting_query'
+	//! contains the statement(s) to replace the current one
+	bool HandlePragma(SQLStatement *statement, string &resulting_query);
 
 	void HandlePragmaStatementsInternal(vector<unique_ptr<SQLStatement>> &statements);
 };

--- a/tools/pythonpkg/tests/fast/test_import_export.py
+++ b/tools/pythonpkg/tests/fast/test_import_export.py
@@ -3,39 +3,26 @@ import pytest
 from os import path
 import shutil
 import os
-
-@pytest.fixture(scope="session")
-def export_path(tmp_path_factory):
-    database = tmp_path_factory.mktemp("export_dbs", numbered=True)
-    return str(database)
-
-@pytest.fixture(scope="session")
-def import_path(tmp_path_factory):
-    database = tmp_path_factory.mktemp("import_dbs", numbered=True)
-    return str(database)
+from pathlib import Path
 
 def export_database(export_location):
     # Create the db
-    duckdb.execute("create table tbl (a integer, b integer);");
-    duckdb.execute("insert into tbl values (5,1);");
+    con = duckdb.connect()
+    con.execute("create table tbl (a integer, b integer);");
+    con.execute("insert into tbl values (5,1);");
 
     # Export the db
-    duckdb.execute(f"export database '{export_location}';");
+    con.execute(f"export database '{export_location}';");
     print(f"Exported database to {export_location}")
 
-    # Destroy the db
-    duckdb.execute("drop table tbl");
-
 def import_database(import_location):
-    duckdb.execute(f"import database '{import_location}'")
+    con = duckdb.connect()
+    con.execute(f"import database '{import_location}'")
     print(f"Imported database from {import_location}");
 
-    res = duckdb.query("select * from tbl").fetchall()
+    res = con.query("select * from tbl").fetchall()
     assert res == [(5,1),]
     print("Successfully queried an imported database that was moved from its original export location!")
-
-    # Destroy the db
-    duckdb.execute("drop table tbl");
 
 def move_database(export_location, import_location):
     assert path.exists(export_location)
@@ -44,9 +31,47 @@ def move_database(export_location, import_location):
     for file in ['schema.sql', 'load.sql', 'tbl.csv']:
         shutil.move(path.join(export_location, file), import_location)
 
+def export_move_and_import(export_path, import_path):
+    export_database(export_path)
+    move_database(export_path, import_path)
+    import_database(import_path)
+
+def export_and_import_empty_db(db_path, _):
+    con = duckdb.connect()
+
+    # Export the db
+    con.execute(f"export database '{db_path}';");
+    print(f"Exported database to {db_path}")
+
+    con.close();
+    con = duckdb.connect()
+    con.execute(f"import database '{db_path}'")
+
 class TestDuckDBImportExport():
-	
-    def test_import_and_export(self, export_path, import_path):
-        export_database(export_path)
-        move_database(export_path, import_path)
-        import_database(import_path)
+
+    @pytest.mark.parametrize('routine', [
+        export_move_and_import,
+        export_and_import_empty_db
+    ])
+    def test_import_and_export(self, routine, tmp_path_factory):
+        export_path = str(tmp_path_factory.mktemp("export_dbs", numbered=True))
+        import_path = str(tmp_path_factory.mktemp("import_dbs", numbered=True))
+        routine(export_path, import_path)
+
+    def test_import_empty_db(self, tmp_path_factory):
+        import_path = str(tmp_path_factory.mktemp("empty_db", numbered=True))
+
+        # Create an empty db folder structure
+        Path(Path(import_path) / 'load.sql').touch()
+        Path(Path(import_path) / 'schema.sql').touch()
+
+        con = duckdb.connect()
+        con.execute(f"import database '{import_path}'")
+
+        # Put a single comment into the 'schema.sql' file
+        with open(Path(import_path) / 'schema.sql', 'w') as f:
+            f.write('--\n')
+
+        con.close()
+        con = duckdb.connect()
+        con.execute(f"import database '{import_path}'")

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -174,6 +174,9 @@ int sqlite3_prepare_v2(sqlite3 *db,           /* Database handle */
 		statements.push_back(std::move(parser.statements[0]));
 
 		db->con->context->HandlePragmaStatements(statements);
+		if (statements.empty()) {
+			return SQLITE_OK;
+		}
 
 		// if there are multiple statements here, we are dealing with an import database statement
 		// we directly execute all statements besides the final one


### PR DESCRIPTION
This PR fixes #7022 

When the pragma expanded to 0 statements, we did not handle this correctly and tried dereferencing an empty vector ( through `vector.back()`)

When the `schema.sql` file is empty entirely, `HandlePragma` returns an empty string, which we used to signal that the pragma did not expand to any statements.
In which case we forwarded the statement - this failed in the Bind phase, because the import pragma doesn't have a function attached.