### PR TITLE
[feature] Add Damerau-Levenshtein string comparison function

### DIFF
--- a/src/function/scalar/string/CMakeLists.txt
+++ b/src/function/scalar/string/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library_unity(
   string_split.cpp
   mismatches.cpp
   levenshtein.cpp
+  damerau_levenshtein.cpp
   jaccard.cpp
   jaro_winkler.cpp
   hex.cpp)

--- a/src/function/scalar/string/damerau_levenshtein.cpp
+++ b/src/function/scalar/string/damerau_levenshtein.cpp
@@ -40,7 +40,7 @@ static idx_t DamerauLevenshteinDistance(const string_t &txt, const string_t &tgt
 		// H[i, 0] = i * Wd
 		h[i + 1][1] = i;
 	}
-	for (idx_t j = 1; j <= txt_len; j++) {
+	for (idx_t j = 1; j <= tgt_len; j++) {
 		// H[0, j] = j * Wi
 		h[1][j + 1] = j;
 	}

--- a/src/function/scalar/string/damerau_levenshtein.cpp
+++ b/src/function/scalar/string/damerau_levenshtein.cpp
@@ -9,10 +9,10 @@ namespace duckdb {
 // as we need to potentially know about earlier in the string
 static idx_t DamerauLevenshteinDistance(const string_t &source, const string_t &target) {
 	// costs associated with each type of edit, to aid readability
-	constexpr uint8_t cost_substitution = 1;
-	constexpr uint8_t cost_insertion = 1;
-	constexpr uint8_t cost_deletion = 1;
-	constexpr uint8_t cost_transposition = 1;
+	constexpr uint8_t COST_SUBSTITUTION = 1;
+	constexpr uint8_t COST_INSERTION = 1;
+	constexpr uint8_t COST_DELETION = 1;
+	constexpr uint8_t COST_TRANSPOSITION = 1;
 	const auto source_len = source.GetSize();
 	const auto target_len = target.GetSize();
 
@@ -20,16 +20,16 @@ static idx_t DamerauLevenshteinDistance(const string_t &source, const string_t &
 	// either through target_len insertions
 	// or source_len deletions
 	if (source_len == 0) {
-		return target_len * cost_insertion;
+		return target_len * COST_INSERTION;
 	} else if (target_len == 0) {
-		return source_len * cost_deletion;
+		return source_len * COST_DELETION;
 	}
 
 	const auto source_str = source.GetDataUnsafe();
 	const auto target_str = target.GetDataUnsafe();
 
 	// larger than the largest possible value:
-	const auto inf = source_len * cost_deletion + target_len * cost_insertion + 1;
+	const auto inf = source_len * COST_DELETION + target_len * COST_INSERTION + 1;
 	// minimum edit distance from prefix of source string to prefix of target string
 	// same object as H in LW paper (with indices offset by 1)
 	vector<vector<idx_t>> distance(source_len + 2, vector<idx_t>(target_len + 2, inf));
@@ -40,11 +40,11 @@ static idx_t DamerauLevenshteinDistance(const string_t &source, const string_t &
 	// initialise row/column corresponding to zero-length strings
 	// partial string -> empty requires a deletion for each character
 	for (idx_t source_idx = 0; source_idx <= source_len; source_idx++) {
-		distance[source_idx + 1][1] = source_idx * cost_deletion;
+		distance[source_idx + 1][1] = source_idx * COST_DELETION;
 	}
 	// and empty -> partial string means simply inserting characters
 	for (idx_t target_idx = 1; target_idx <= target_len; target_idx++) {
-		distance[1][target_idx + 1] = target_idx * cost_insertion;
+		distance[1][target_idx + 1] = target_idx * COST_INSERTION;
 	}
 	// loop through string indices - these are offset by 2 from distance indices
 	for (idx_t source_idx = 0; source_idx < source_len; source_idx++) {
@@ -67,16 +67,16 @@ static idx_t DamerauLevenshteinDistance(const string_t &source, const string_t &
 				cost_diagonal_shift = 0;
 				largest_target_chr_matching = target_idx + 1;
 			} else {
-				cost_diagonal_shift = cost_substitution;
+				cost_diagonal_shift = COST_SUBSTITUTION;
 			}
 			distance[source_idx + 2][target_idx + 2] = MinValue(
 			    distance[source_idx + 1][target_idx + 1] + cost_diagonal_shift,
-			    MinValue(distance[source_idx + 2][target_idx + 1] + cost_insertion,
-			             MinValue(distance[source_idx + 1][target_idx + 2] + cost_deletion,
+			    MinValue(distance[source_idx + 2][target_idx + 1] + COST_INSERTION,
+			             MinValue(distance[source_idx + 1][target_idx + 2] + COST_DELETION,
 			                      distance[largest_source_chr_matching_target][largest_target_chr_matching_source] +
-			                          (source_idx - largest_source_chr_matching_target) * cost_deletion +
-			                          cost_transposition +
-			                          (target_idx - largest_target_chr_matching_source) * cost_insertion)));
+			                          (source_idx - largest_source_chr_matching_target) * COST_DELETION +
+			                          COST_TRANSPOSITION +
+			                          (target_idx - largest_target_chr_matching_source) * COST_INSERTION)));
 		}
 		largest_source_chr_matching[source_str[source_idx]] = source_idx + 1;
 	}

--- a/src/function/scalar/string/damerau_levenshtein.cpp
+++ b/src/function/scalar/string/damerau_levenshtein.cpp
@@ -1,9 +1,5 @@
-#include "duckdb/common/string_util.hpp"
-#include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
 
-#include <algorithm>
-#include <ctype.h>
 #include <map>
 
 namespace duckdb {
@@ -39,57 +35,65 @@ static idx_t DamerauLevenshteinDistance(const string_t &source, const string_t &
 	std::vector<std::vector<idx_t>> distance(source_len + 2, std::vector<idx_t>(target_len + 2, inf));
 	// keeps track of the largest string indices of source string matching each character
 	// same as DA in LW paper
-	std::map<char, idx_t> largest_source_index_matching;
+	std::map<char, idx_t> largest_source_chr_matching;
 
+	// initialise row/column corresponding to zero-length strings
+	// partial string -> empty requires a deletion for each character
 	for (idx_t source_idx = 0; source_idx <= source_len; source_idx++) {
 		distance[source_idx + 1][1] = source_idx * cost_deletion;
 	}
+	// and empty -> partial string means simply inserting characters
 	for (idx_t target_idx = 1; target_idx <= target_len; target_idx++) {
 		distance[1][target_idx + 1] = target_idx * cost_insertion;
 	}
+	// loop through string indices - these are offset by 2 from distance indices
 	for (idx_t source_idx = 0; source_idx < source_len; source_idx++) {
 		// keeps track of the largest string indices of target string matching current source character
 		// same as DB in LW paper
-		idx_t largest_target_index_matching;
-		largest_target_index_matching = 0;
+		idx_t largest_target_chr_matching;
+		largest_target_chr_matching = 0;
 		for (idx_t target_idx = 0; target_idx < target_len; target_idx++) {
-			idx_t ii, jj;
-			// cost associated to diagnoal shift in distance matrix
-			// d in LW paper
+			// correspond to i1 and j1 in LW paper respectively
+			idx_t largest_source_chr_matching_target;
+			idx_t largest_target_chr_matching_source;
+			// cost associated to diagnanl shift in distance matrix
+			// corresponds to d in LW paper
 			uint8_t cost_diagonal_shift;
-			ii = largest_source_index_matching[target_str[target_idx]];
-			jj = largest_target_index_matching;
+			largest_source_chr_matching_target = largest_source_chr_matching[target_str[target_idx]];
+			largest_target_chr_matching_source = largest_target_chr_matching;
 			// if characters match, diagonal move costs nothing and we update our largest target index
 			// otherwise move is substitution and costs as such
 			if (source_str[source_idx] == target_str[target_idx]) {
 				cost_diagonal_shift = 0;
-				largest_target_index_matching = target_idx + 1;
+				largest_target_chr_matching = target_idx + 1;
 			} else {
 				cost_diagonal_shift = cost_substitution;
 			}
-			distance[source_idx + 2][target_idx + 2] =
-			    MinValue(distance[source_idx + 1][target_idx + 1] + cost_diagonal_shift,
-			             MinValue(distance[source_idx + 2][target_idx + 1] + cost_insertion,
-			                      MinValue(distance[source_idx + 1][target_idx + 2] + cost_deletion,
-			                               distance[ii][jj] + (source_idx - ii) * cost_deletion + cost_transposition +
-			                                   (target_idx - jj) * cost_insertion)));
+			distance[source_idx + 2][target_idx + 2] = MinValue(
+			    distance[source_idx + 1][target_idx + 1] + cost_diagonal_shift,
+			    MinValue(distance[source_idx + 2][target_idx + 1] + cost_insertion,
+			             MinValue(distance[source_idx + 1][target_idx + 2] + cost_deletion,
+			                      distance[largest_source_chr_matching_target][largest_target_chr_matching_source] +
+			                          (source_idx - largest_source_chr_matching_target) * cost_deletion +
+			                          cost_transposition +
+			                          (target_idx - largest_target_chr_matching_source) * cost_insertion)));
 		}
-		largest_source_index_matching[source_str[source_idx]] = source_idx + 1;
+		largest_source_chr_matching[source_str[source_idx]] = source_idx + 1;
 	}
 	return distance[source_len + 1][target_len + 1];
 }
 
-static int64_t DamerauLevenshteinScalarFunction(Vector &result, const string_t str, const string_t tgt) {
-	return (int64_t)DamerauLevenshteinDistance(str, tgt);
+static int64_t DamerauLevenshteinScalarFunction(Vector &result, const string_t source, const string_t target) {
+	return (int64_t)DamerauLevenshteinDistance(source, target);
 }
 
 static void DamerauLevenshteinFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-	auto &str_vec = args.data[0];
-	auto &tgt_vec = args.data[1];
+	auto &source_vec = args.data[0];
+	auto &target_vec = args.data[1];
 
 	BinaryExecutor::Execute<string_t, string_t, int64_t>(
-	    str_vec, tgt_vec, result, args.size(),
-	    [&](string_t str, string_t tgt) { return DamerauLevenshteinScalarFunction(result, str, tgt); });
+	    source_vec, target_vec, result, args.size(),
+	    [&](string_t source, string_t target) { return DamerauLevenshteinScalarFunction(result, source, target); });
 }
 
 void DamerauLevenshteinFun::RegisterFunction(BuiltinFunctions &set) {

--- a/src/function/scalar/string/damerau_levenshtein.cpp
+++ b/src/function/scalar/string/damerau_levenshtein.cpp
@@ -1,9 +1,9 @@
-#include "duckdb/function/scalar/string_functions.hpp"
-#include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
+#include "duckdb/function/scalar/string_functions.hpp"
 
-#include <ctype.h>
 #include <algorithm>
+#include <ctype.h>
 #include <map>
 
 namespace duckdb {
@@ -46,7 +46,7 @@ static idx_t DamerauLevenshteinDistance(const string_t &txt, const string_t &tgt
 	}
 	for (idx_t i = 1; i <= txt_len; i++) {
 		db = 0;
-		for (idx_t j = 1; j <= tgt_len; j++) { 
+		for (idx_t j = 1; j <= tgt_len; j++) {
 			// offset as strings are 0-indexed
 			ii = da[tgt_str[j - 1]];
 			jj = db;
@@ -54,18 +54,12 @@ static idx_t DamerauLevenshteinDistance(const string_t &txt, const string_t &tgt
 				d = 0;
 				db = j;
 			} else {
-				d = 1;  // Wc
+				d = 1; // Wc
 			}
-			h[i + 1][j + 1] = MinValue(
-				h[i][j] + d,
-				MinValue(
-					h[i + 1][j] + 1,  // wi
-					MinValue(
-						h[i][j + 1] + 1,  // wd
-						h[ii][jj] + (i - ii - 1) + 1 + (j - jj - 1)
-					)
-				)
-			);
+			h[i + 1][j + 1] = MinValue(h[i][j] + d,
+			                           MinValue(h[i + 1][j] + 1,          // wi
+			                                    MinValue(h[i][j + 1] + 1, // wd
+			                                             h[ii][jj] + (i - ii - 1) + 1 + (j - jj - 1))));
 		}
 		da[txt_str[i - 1]] = i;
 	}
@@ -88,8 +82,7 @@ static void DamerauLevenshteinFunction(DataChunk &args, ExpressionState &state, 
 void DamerauLevenshteinFun::RegisterFunction(BuiltinFunctions &set) {
 	ScalarFunctionSet damerau_levenshtein("damerau_levenshtein");
 	damerau_levenshtein.AddFunction(ScalarFunction("damerau_levenshtein", {LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                                       LogicalType::BIGINT,
-	                                       DamerauLevenshteinFunction));
+	                                               LogicalType::BIGINT, DamerauLevenshteinFunction));
 	set.AddFunction(damerau_levenshtein);
 }
 

--- a/src/function/scalar/string/damerau_levenshtein.cpp
+++ b/src/function/scalar/string/damerau_levenshtein.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/function/scalar/string_functions.hpp"
-
-#include <map>
+#include "duckdb/common/map.hpp"
+#include "duckdb/common/vector.hpp"
 
 namespace duckdb {
 
@@ -32,10 +32,10 @@ static idx_t DamerauLevenshteinDistance(const string_t &source, const string_t &
 	const auto inf = source_len * cost_deletion + target_len * cost_insertion + 1;
 	// minimum edit distance from prefix of source string to prefix of target string
 	// same object as H in LW paper (with indices offset by 1)
-	std::vector<std::vector<idx_t>> distance(source_len + 2, std::vector<idx_t>(target_len + 2, inf));
+	vector<vector<idx_t>> distance(source_len + 2, vector<idx_t>(target_len + 2, inf));
 	// keeps track of the largest string indices of source string matching each character
 	// same as DA in LW paper
-	std::map<char, idx_t> largest_source_chr_matching;
+	map<char, idx_t> largest_source_chr_matching;
 
 	// initialise row/column corresponding to zero-length strings
 	// partial string -> empty requires a deletion for each character

--- a/src/function/scalar/string/damerau_levenshtein.cpp
+++ b/src/function/scalar/string/damerau_levenshtein.cpp
@@ -8,64 +8,74 @@
 
 namespace duckdb {
 
-// Lowrance-Wagner algorithm https://dl.acm.org/doi/pdf/10.1145/321879.321880
-// Can't calculate as trivial mod to levenshtein algorithm
+// Using Lowrance-Wagner (LW) algorithm: https://doi.org/10.1145%2F321879.321880
+// Can't calculate as trivial modification to levenshtein algorithm
 // as we need to potentially know about earlier in the string
-static idx_t DamerauLevenshteinDistance(const string_t &txt, const string_t &tgt) {
+static idx_t DamerauLevenshteinDistance(const string_t &source, const string_t &target) {
 	// costs associated with each type of edit, to aid readability
 	constexpr uint8_t cost_substitution = 1;
 	constexpr uint8_t cost_insertion = 1;
 	constexpr uint8_t cost_deletion = 1;
 	constexpr uint8_t cost_transposition = 1;
-	const auto txt_len = txt.GetSize();
-	const auto tgt_len = tgt.GetSize();
+	const auto source_len = source.GetSize();
+	const auto target_len = target.GetSize();
 
 	// If one string is empty, the distance equals the length of the other string
-	if (txt_len == 0) {
-		return tgt_len;
-	} else if (tgt_len == 0) {
-		return txt_len;
+	if (source_len == 0) {
+		return target_len;
+	} else if (target_len == 0) {
+		return source_len;
 	}
 
-	const auto txt_str = txt.GetDataUnsafe();
-	const auto tgt_str = tgt.GetDataUnsafe();
+	const auto source_str = source.GetDataUnsafe();
+	const auto target_str = target.GetDataUnsafe();
 
 	// larger than the largest possible value:
-	const auto inf = txt_len * cost_deletion + tgt_len * cost_insertion + 1;
-	std::vector<std::vector<idx_t>> h(txt_len + 2, std::vector<idx_t>(tgt_len + 2, inf));
-	std::map<char, idx_t> da;
+	const auto inf = source_len * cost_deletion + target_len * cost_insertion + 1;
+	// minimum edit distance from prefix of source string to prefix of target string
+	// same object as H in LW paper (with indices offset by 1)
+	std::vector<std::vector<idx_t>> distance(source_len + 2, std::vector<idx_t>(target_len + 2, inf));
+	// keeps track of the largest string indices of source string matching each character
+	// same as DA in LW paper
+	std::map<char, idx_t> largest_source_index_matching;
 
-	for (idx_t i = 0; i <= txt_len; i++) {
-		// H[i, 0] = i * Wd
-		h[i + 1][1] = i * cost_deletion;
+	for (idx_t i = 0; i <= source_len; i++) {
+		distance[i + 1][1] = i * cost_deletion;
 	}
-	for (idx_t j = 1; j <= tgt_len; j++) {
-		// H[0, j] = j * Wi
-		h[1][j + 1] = j * cost_insertion;
+	for (idx_t j = 1; j <= target_len; j++) {
+		distance[1][j + 1] = j * cost_insertion;
 	}
-	for (idx_t i = 1; i <= txt_len; i++) {
-		idx_t db;
-		db = 0;
-		for (idx_t j = 1; j <= tgt_len; j++) {
-			idx_t ii, jj, d;
+	for (idx_t i = 1; i <= source_len; i++) {
+		// keeps track of the largest string indices of target string matching current source character
+		// same as DB in LW paper
+		idx_t largest_target_index_matching;
+		largest_target_index_matching = 0;
+		for (idx_t j = 1; j <= target_len; j++) {
+			idx_t ii, jj;
+			// cost associated to diagnoal shift in distance matrix
+			// d in LW paper
+			uint8_t cost_diagonal_shift;
 			// offset as strings are 0-indexed
-			ii = da[tgt_str[j - 1]];
-			jj = db;
-			if (txt_str[i - 1] == tgt_str[j - 1]) {
-				d = 0;
-				db = j;
+			ii = largest_source_index_matching[target_str[j - 1]];
+			jj = largest_target_index_matching;
+			// if characters match, diagonal move costs nothing and we update our largest target index
+			// otherwise move is substitution and costs as such
+			if (source_str[i - 1] == target_str[j - 1]) {
+				cost_diagonal_shift = 0;
+				largest_target_index_matching = j;
 			} else {
-				d = cost_substitution; // Wc
+				cost_diagonal_shift = cost_substitution;
 			}
-			h[i + 1][j + 1] =
-			    MinValue(h[i][j] + d, MinValue(h[i + 1][j] + cost_insertion,
-			                                   MinValue(h[i][j + 1] + cost_deletion,
-			                                            h[ii][jj] + (i - ii - 1) * cost_deletion + cost_transposition +
-			                                                (j - jj - 1) * cost_insertion)));
+			distance[i + 1][j + 1] =
+			    MinValue(distance[i][j] + cost_diagonal_shift,
+			             MinValue(distance[i + 1][j] + cost_insertion,
+			                      MinValue(distance[i][j + 1] + cost_deletion,
+			                               distance[ii][jj] + (i - ii - 1) * cost_deletion + cost_transposition +
+			                                   (j - jj - 1) * cost_insertion)));
 		}
-		da[txt_str[i - 1]] = i;
+		largest_source_index_matching[source_str[i - 1]] = i;
 	}
-	return h[txt_len + 1][tgt_len + 1];
+	return distance[source_len + 1][target_len + 1];
 }
 
 static int64_t DamerauLevenshteinScalarFunction(Vector &result, const string_t str, const string_t tgt) {

--- a/src/function/scalar/string/damerau_levenshtein.cpp
+++ b/src/function/scalar/string/damerau_levenshtein.cpp
@@ -1,0 +1,96 @@
+#include "duckdb/function/scalar/string_functions.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
+#include "duckdb/common/string_util.hpp"
+
+#include <ctype.h>
+#include <algorithm>
+#include <map>
+
+namespace duckdb {
+
+// Lowrance-Wagner algorithm https://dl.acm.org/doi/pdf/10.1145/321879.321880
+// Can't calculate as trivial mod to levenshtein algorithm
+// as we need to potentially know about earlier in the string
+
+// TODO: formatting
+// TODO: variables
+static idx_t DamerauLevenshteinDistance(const string_t &txt, const string_t &tgt) {
+	auto txt_len = txt.GetSize();
+	auto tgt_len = tgt.GetSize();
+
+	// If one string is empty, the distance equals the length of the other string
+	if (txt_len == 0) {
+		return tgt_len;
+	} else if (tgt_len == 0) {
+		return txt_len;
+	}
+
+	auto txt_str = txt.GetDataUnsafe();
+	auto tgt_str = tgt.GetDataUnsafe();
+
+	// larger than the largest possible value:
+	auto inf = txt_len + tgt_len + 1;
+	std::vector<std::vector<idx_t>> h(txt_len + 2, std::vector<idx_t>(tgt_len + 2, inf));
+	std::map<char, idx_t> da;
+	// TODO: sort out this complete mess of variables
+	idx_t db;
+	idx_t ii, jj, d;
+
+	for (idx_t i = 0; i <= txt_len; i++) {
+		// H[i, 0] = i * Wd
+		h[i + 1][1] = i;
+	}
+	for (idx_t j = 1; j <= txt_len; j++) {
+		// H[0, j] = j * Wi
+		h[1][j + 1] = j;
+	}
+	for (idx_t i = 1; i <= txt_len; i++) {
+		db = 0;
+		for (idx_t j = 1; j <= tgt_len; j++) { 
+			// offset as strings are 0-indexed
+			ii = da[tgt_str[j - 1]];
+			jj = db;
+			if (txt_str[i - 1] == tgt_str[j - 1]) {
+				d = 0;
+				db = j;
+			} else {
+				d = 1;  // Wc
+			}
+			h[i + 1][j + 1] = MinValue(
+				h[i][j] + d,
+				MinValue(
+					h[i + 1][j] + 1,  // wi
+					MinValue(
+						h[i][j + 1] + 1,  // wd
+						h[ii][jj] + (i - ii - 1) + 1 + (j - jj - 1)
+					)
+				)
+			);
+		}
+		da[txt_str[i - 1]] = i;
+	}
+	return h[txt_len + 1][tgt_len + 1];
+}
+
+static int64_t DamerauLevenshteinScalarFunction(Vector &result, const string_t str, const string_t tgt) {
+	return (int64_t)DamerauLevenshteinDistance(str, tgt);
+}
+
+static void DamerauLevenshteinFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &str_vec = args.data[0];
+	auto &tgt_vec = args.data[1];
+
+	BinaryExecutor::Execute<string_t, string_t, int64_t>(
+	    str_vec, tgt_vec, result, args.size(),
+	    [&](string_t str, string_t tgt) { return DamerauLevenshteinScalarFunction(result, str, tgt); });
+}
+
+void DamerauLevenshteinFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet damerau_levenshtein("damerau_levenshtein");
+	damerau_levenshtein.AddFunction(ScalarFunction("damerau_levenshtein", {LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                       LogicalType::BIGINT,
+	                                       DamerauLevenshteinFunction));
+	set.AddFunction(damerau_levenshtein);
+}
+
+} // namespace duckdb

--- a/src/function/scalar/string_functions.cpp
+++ b/src/function/scalar/string_functions.cpp
@@ -39,6 +39,7 @@ void BuiltinFunctions::RegisterStringFunctions() {
 	Register<CHR>();
 	Register<MismatchesFun>();
 	Register<LevenshteinFun>();
+	Register<DamerauLevenshteinFun>();
 	Register<JaccardFun>();
 	Register<JaroWinklerFun>();
 

--- a/src/include/duckdb/function/scalar/string_functions.hpp
+++ b/src/include/duckdb/function/scalar/string_functions.hpp
@@ -205,6 +205,10 @@ struct LevenshteinFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct DamerauLevenshteinFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct JaccardFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/test/sql/function/string/test_damerau_levenshtein.test
+++ b/test/sql/function/string/test_damerau_levenshtein.test
@@ -213,3 +213,129 @@ SELECT damerau_levenshtein(s, '') FROM strings ORDER BY s
 5
 6
 
+
+statement ok
+DROP TABLE strings
+
+statement ok
+CREATE TABLE strings(s VARCHAR)
+
+statement ok
+INSERT INTO strings VALUES (NULL)
+
+query I
+SELECT damerau_levenshtein(s, NULL) from strings
+----
+NULL
+
+query I
+SELECT damerau_levenshtein(NULL, s) from strings
+----
+NULL
+
+query I
+SELECT damerau_levenshtein('test', s) from strings
+----
+NULL
+
+query I
+SELECT damerau_levenshtein(s, 'test') from strings
+----
+NULL
+
+query I
+SELECT damerau_levenshtein('null', s) from strings
+----
+NULL
+
+query I
+SELECT damerau_levenshtein('', s)  FROM strings
+----
+NULL
+
+query I
+SELECT damerau_levenshtein(s, '')  FROM strings
+----
+NULL
+
+
+statement ok
+DROP TABLE strings
+
+statement ok
+CREATE TABLE strings(s VARCHAR)
+
+statement ok
+INSERT INTO strings VALUES ('')
+
+query I
+SELECT damerau_levenshtein(NULL, s)  FROM strings
+----
+NULL
+
+query I
+SELECT damerau_levenshtein(s, NULL)  FROM strings
+----
+NULL
+
+query I
+SELECT damerau_levenshtein(s, '')  FROM strings
+----
+0
+
+query I
+SELECT damerau_levenshtein('', s)  FROM strings
+----
+0
+
+query I
+SELECT damerau_levenshtein(s, 'test')  FROM strings
+----
+4
+
+query I
+SELECT damerau_levenshtein('test', s)  FROM strings
+----
+4
+
+query I
+SELECT damerau_levenshtein('null', s)  FROM strings
+----
+4
+
+
+statement ok
+DROP TABLE strings
+
+statement ok
+CREATE TABLE strings(s_left VARCHAR, s_right VARCHAR)
+
+statement ok
+INSERT INTO strings VALUES 	('identical', 'identical'), ('dientical', 'identical'),
+							('dinetcila', 'identical'), ('abcdefghijk', 'bacdfzzeghki'),
+							('abcd', 'bcda'), ('great', 'greta'),
+							('abcdefghijklmnopqrstuvwxyz', 'abdcpoxwz'),
+							(NULL, NULL), ('', ''),
+							(NULL, 'test'), ('test', NULL),
+							('four', ''), ('', 'four'),
+							(NULL, ''), ('', NULL)
+
+
+query I
+SELECT damerau_levenshtein(s_left, s_right) FROM strings
+----
+0
+1
+4
+6
+2
+1
+20
+NULL
+0
+NULL
+NULL
+4
+4
+NULL
+NULL

--- a/test/sql/function/string/test_damerau_levenshtein.test
+++ b/test/sql/function/string/test_damerau_levenshtein.test
@@ -1,0 +1,129 @@
+# name: test/sql/function/string/test_damerau_levenshtein.test
+# description: Test damerau_levenshtein function
+# group: [string]
+
+statement ok
+PRAGMA enable_verification
+
+
+# normal queries
+query I
+SELECT damerau_levenshtein('out', 'out')
+----
+0
+
+query I
+SELECT damerau_levenshtein('three', 'there')
+----
+1
+
+query I
+SELECT damerau_levenshtein('potion', 'option')
+----
+1
+
+query I
+SELECT damerau_levenshtein('letter', 'lettre')
+----
+1
+
+query I
+SELECT damerau_levenshtein('three', 'there')
+----
+1
+
+query I
+SELECT damerau_levenshtein('out', 'to')
+----
+2
+
+query I
+SELECT damerau_levenshtein('to', 'out')
+----
+2
+
+query I
+SELECT damerau_levenshtein('laos', 'also')
+----
+2
+
+query I
+SELECT damerau_levenshtein('tomato', 'otamot')
+----
+3
+
+query I
+SELECT damerau_levenshtein('abcdefg', 'bacedgf')
+----
+3
+
+query I
+SELECT damerau_levenshtein('abcdefg', 'bacedgf')
+----
+3
+
+query I
+SELECT damerau_levenshtein('abcdefghi', 'bzacdefig')
+----
+4
+
+query I
+SELECT damerau_levenshtein('bzacdefig', 'abcdefghi')
+----
+4
+
+query I
+SELECT damerau_levenshtein('at', 'tarokk')
+----
+5
+
+query I
+SELECT damerau_levenshtein('organ', 'no')
+----
+4
+
+query I
+SELECT damerau_levenshtein('trips', 'strip')
+----
+2
+
+query I
+SELECT damerau_levenshtein('', 'great')
+----
+5
+
+query I
+SELECT damerau_levenshtein('great', '')
+----
+5
+
+query I
+SELECT damerau_levenshtein('', '')
+----
+0
+
+query I
+SELECT damerau_levenshtein(NULL, 'drive')
+----
+NULL
+
+query I
+SELECT damerau_levenshtein('drive', NULL)
+----
+NULL
+
+query I
+SELECT damerau_levenshtein(NULL, NULL)
+----
+NULL
+
+query I
+SELECT damerau_levenshtein('', NULL)
+----
+NULL
+
+query I
+SELECT damerau_levenshtein(NULL, '')
+----
+NULL
+

--- a/test/sql/function/string/test_damerau_levenshtein.test
+++ b/test/sql/function/string/test_damerau_levenshtein.test
@@ -78,6 +78,11 @@ SELECT damerau_levenshtein('at', 'tarokk')
 5
 
 query I
+SELECT damerau_levenshtein('tarokk', 'at')
+----
+5
+
+query I
 SELECT damerau_levenshtein('organ', 'no')
 ----
 4
@@ -86,6 +91,16 @@ query I
 SELECT damerau_levenshtein('trips', 'strip')
 ----
 2
+
+query I
+SELECT damerau_levenshtein('cat', 'cats')
+----
+1
+
+query I
+SELECT damerau_levenshtein('rat', 'brat')
+----
+1
 
 query I
 SELECT damerau_levenshtein('', 'great')
@@ -126,4 +141,75 @@ query I
 SELECT damerau_levenshtein(NULL, '')
 ----
 NULL
+
+
+statement error
+SELECT damerau_levenshtein('one', 'two', 'three')
+
+statement error
+SELECT damerau_levenshtein('one')
+
+statement error
+SELECT damerau_levenshtein()
+
+
+statement ok
+CREATE TABLE strings(s VARCHAR)
+
+statement ok
+INSERT INTO strings VALUES ('here'), ('heres'), ('there'), ('three'), ('threes')
+
+query I
+SELECT damerau_levenshtein(s, 'theres') FROM strings ORDER BY s
+----
+2
+1
+1
+2
+1
+
+query I
+SELECT damerau_levenshtein('herse', s) FROM strings ORDER BY s
+----
+1
+1
+2
+3
+3
+
+query I
+SELECT damerau_levenshtein(NULL, s) FROM strings
+----
+NULL
+NULL
+NULL
+NULL
+NULL
+
+query I
+SELECT damerau_levenshtein(NULL, s) FROM strings
+----
+NULL
+NULL
+NULL
+NULL
+NULL
+
+query I
+SELECT damerau_levenshtein('', s) FROM strings ORDER BY s
+----
+4
+5
+5
+5
+6
+
+query I
+SELECT damerau_levenshtein(s, '') FROM strings ORDER BY s
+----
+4
+5
+5
+5
+6
 

--- a/test/sql/function/string/test_damerau_levenshtein.test
+++ b/test/sql/function/string/test_damerau_levenshtein.test
@@ -103,6 +103,11 @@ SELECT damerau_levenshtein('rat', 'brat')
 1
 
 query I
+SELECT damerau_levenshtein('amanaplanacanalpanama', 'm23aanaplancaanaalnama')
+----
+6
+
+query I
 SELECT damerau_levenshtein('', 'great')
 ----
 5
@@ -315,6 +320,12 @@ INSERT INTO strings VALUES 	('identical', 'identical'), ('dientical', 'identical
 							('dinetcila', 'identical'), ('abcdefghijk', 'bacdfzzeghki'),
 							('abcd', 'bcda'), ('great', 'greta'),
 							('abcdefghijklmnopqrstuvwxyz', 'abdcpoxwz'),
+							('a_considerably_longer_string', 'a_ocnsiderably_longre_tsrig'),
+							('another-quite-long-string', 'naothre-quit-elongstrnig'),
+							('littlehampton', 'littlerhamptoner'),
+							('an_incredibly_long_string_to_compare', 'na_incerdibl_ylong_sr56ting_ot_ocmrpe'),
+							('smaller', 'notsmaller,longer'),
+							('againalongerstring', 'string'),
 							(NULL, NULL), ('', ''),
 							(NULL, 'test'), ('test', NULL),
 							('four', ''), ('', 'four'),
@@ -331,6 +342,12 @@ SELECT damerau_levenshtein(s_left, s_right) FROM strings
 2
 1
 20
+4
+5
+3
+10
+10
+12
 NULL
 0
 NULL


### PR DESCRIPTION
This proposed PR adds a new function `damerau_levenshtein` implementing the [Damerau-Levenshtein distance](https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance) string metric. It is a modification of the Levenshtein string distance, adding the edit operation of 'adjacent transpositions' to the allowed set of substitutions, insertions, and deletions. Allowing transpositions increases the complexity enough that the implementation is not a trivial extension of the existing Levenshtein implementation.