### PR TITLE
[Upsert] Support doing updates on conflict of an explicitly created index

### DIFF
--- a/src/execution/operator/schema/physical_create_index.cpp
+++ b/src/execution/operator/schema/physical_create_index.cpp
@@ -16,7 +16,6 @@ PhysicalCreateIndex::PhysicalCreateIndex(LogicalOperator &op, TableCatalogEntry 
     : PhysicalOperator(PhysicalOperatorType::CREATE_INDEX, op.types, estimated_cardinality),
       table(table_p.Cast<DuckTableEntry>()), info(std::move(info)),
       unbound_expressions(std::move(unbound_expressions)) {
-	D_ASSERT(table_p.IsDuckTable());
 	// convert virtual column ids to storage column ids
 	for (auto &column_id : column_ids) {
 		storage_ids.push_back(table.GetColumns().LogicalToPhysical(LogicalIndex(column_id)).index);
@@ -142,6 +141,7 @@ SinkFinalizeType PhysicalCreateIndex::Finalize(Pipeline &pipeline, Event &event,
 	auto &schema = *table.schema;
 	auto index_entry = (DuckIndexEntry *)schema.CreateIndex(context, info.get(), &table);
 	if (!index_entry) {
+		D_ASSERT(info->on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT);
 		// index already exists, but error ignored because of IF NOT EXISTS
 		return SinkFinalizeType::READY;
 	}

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -534,6 +534,66 @@ void DataTable::VerifyNewConstraint(ClientContext &context, DataTable &parent, c
 	local_storage.VerifyNewConstraint(parent, *constraint);
 }
 
+bool HasUniqueIndexes(TableIndexList &list) {
+	bool has_unique_index = false;
+	list.Scan([&](Index &index) {
+		if (index.IsUnique()) {
+			return has_unique_index = true;
+			return true;
+		}
+		return false;
+	});
+	return has_unique_index;
+}
+
+static void VerifyUniqueIndexes(TableIndexList &indexes, ClientContext &context, DataChunk &chunk,
+                                ConflictManager *conflict_manager) {
+	//! check whether or not the chunk can be inserted into the indexes
+	if (conflict_manager) {
+		// This is only provided when a ON CONFLICT clause was provided
+		idx_t matching_indexes = 0;
+		auto &conflict_info = conflict_manager->GetConflictInfo();
+		// First we figure out how many indexes match our conflict target
+		// So we can optimize accordingly
+		indexes.Scan([&](Index &index) {
+			matching_indexes += conflict_info.ConflictTargetMatches(index);
+			return false;
+		});
+		conflict_manager->SetMode(ConflictManagerMode::SCAN);
+		conflict_manager->SetIndexCount(matching_indexes);
+		// First we verify only the indexes that match our conflict target
+		indexes.Scan([&](Index &index) {
+			if (!index.IsUnique()) {
+				return false;
+			}
+			if (conflict_info.ConflictTargetMatches(index)) {
+				index.VerifyAppend(chunk, *conflict_manager);
+			}
+			return false;
+		});
+
+		conflict_manager->SetMode(ConflictManagerMode::THROW);
+		// Then we scan the other indexes, throwing if they cause conflicts on tuples that were not found during
+		// the scan
+		indexes.Scan([&](Index &index) {
+			if (!index.IsUnique()) {
+				return false;
+			}
+			index.VerifyAppend(chunk, *conflict_manager);
+			return false;
+		});
+	} else {
+		// Only need to verify that no unique constraints are violated
+		indexes.Scan([&](Index &index) {
+			if (!index.IsUnique()) {
+				return false;
+			}
+			index.VerifyAppend(chunk);
+			return false;
+		});
+	}
+}
+
 void DataTable::VerifyAppendConstraints(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk,
                                         ConflictManager *conflict_manager) {
 	if (table.HasGeneratedColumns()) {
@@ -552,6 +612,11 @@ void DataTable::VerifyAppendConstraints(TableCatalogEntry &table, ClientContext 
 			VerifyGeneratedExpressionSuccess(context, table, chunk, *bound_expression, col.Oid());
 		}
 	}
+
+	if (HasUniqueIndexes(info->indexes)) {
+		VerifyUniqueIndexes(info->indexes, context, chunk, conflict_manager);
+	}
+
 	auto &constraints = table.GetConstraints();
 	auto &bound_constraints = table.GetBoundConstraints();
 	for (idx_t i = 0; i < bound_constraints.size(); i++) {
@@ -571,50 +636,7 @@ void DataTable::VerifyAppendConstraints(TableCatalogEntry &table, ClientContext 
 			break;
 		}
 		case ConstraintType::UNIQUE: {
-			//! check whether or not the chunk can be inserted into the indexes
-			if (conflict_manager) {
-				// This is only provided when a ON CONFLICT clause was provided
-				idx_t matching_indexes = 0;
-				auto &conflict_info = conflict_manager->GetConflictInfo();
-				// First we figure out how many indexes match our conflict target
-				// So we can optimize accordingly
-				info->indexes.Scan([&](Index &index) {
-					matching_indexes += conflict_info.ConflictTargetMatches(index);
-					return false;
-				});
-				conflict_manager->SetMode(ConflictManagerMode::SCAN);
-				conflict_manager->SetIndexCount(matching_indexes);
-				// First we verify only the indexes that match our conflict target
-				info->indexes.Scan([&](Index &index) {
-					if (!index.IsUnique()) {
-						return false;
-					}
-					if (conflict_info.ConflictTargetMatches(index)) {
-						index.VerifyAppend(chunk, *conflict_manager);
-					}
-					return false;
-				});
-
-				conflict_manager->SetMode(ConflictManagerMode::THROW);
-				// Then we scan the other indexes, throwing if they cause conflicts on tuples that were not found during
-				// the scan
-				info->indexes.Scan([&](Index &index) {
-					if (!index.IsUnique()) {
-						return false;
-					}
-					index.VerifyAppend(chunk, *conflict_manager);
-					return false;
-				});
-			} else {
-				// Only need to verify that no unique constraints are violated
-				info->indexes.Scan([&](Index &index) {
-					if (!index.IsUnique()) {
-						return false;
-					}
-					index.VerifyAppend(chunk);
-					return false;
-				});
-			}
+			// These were handled earlier on
 			break;
 		}
 		case ConstraintType::FOREIGN_KEY: {

--- a/test/fuzzer/pedro/buffer_manager_resize_issue.test
+++ b/test/fuzzer/pedro/buffer_manager_resize_issue.test
@@ -32,4 +32,4 @@ INSERT INTO t2(c1,c0) VALUES (235,36),(43,81),(246,187),(28,149),(206,20),(135,1
 statement error
 INSERT INTO t2(c1,c0) VALUES (86,98),(96,107),(237,190),(253,242),(229,9),(6,147);
 ----
-Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicate key
+Constraint Error: Duplicate key "c1: 6" violates unique constraint

--- a/test/sql/index/art/test_art_import_export.test
+++ b/test/sql/index/art/test_art_import_export.test
@@ -33,4 +33,4 @@ IMPORT DATABASE '__TEST_DIR__/export_index_db'
 statement error
 INSERT INTO raw VALUES (1, 1, 1, 1);
 ----
-Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicate key
+Constraint Error: Duplicate key "customer_ID: 1, year: 1, month: 1" violates unique constraint

--- a/test/sql/storage/test_unique_index_checkpoint.test
+++ b/test/sql/storage/test_unique_index_checkpoint.test
@@ -20,7 +20,7 @@ restart
 statement error
 INSERT INTO test VALUES (1,101),(2,201);
 ----
-Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicate key
+Constraint Error: Duplicate key "i: 1" violates unique constraint
 
 restart
 
@@ -38,4 +38,4 @@ restart
 statement error
 INSERT INTO unique_index_test VALUES (1,101),(2,201);
 ----
-Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicate key
+Constraint Error: Duplicate key "ordernumber: 1" violates unique constraint

--- a/test/sql/storage/wal/wal_create_index.test
+++ b/test/sql/storage/wal/wal_create_index.test
@@ -45,7 +45,7 @@ logical_opt	<REGEX>:.*INDEX_SCAN.*
 statement error
 INSERT INTO integers VALUES (1, 1);
 ----
-Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicate key
+Constraint Error: Duplicate key "#[0.0]: 1" violates unique constraint
 
 restart
 
@@ -97,7 +97,7 @@ SELECT i FROM integers WHERE i + j = 2
 statement error
 INSERT INTO integers VALUES (1, 1);
 ----
-Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicate key
+Constraint Error: Duplicate key "(#[0.0] + #[0.1]): 2" violates unique constraint
 
 statement ok
 DROP INDEX i_index;
@@ -141,7 +141,7 @@ SELECT i FROM integers WHERE j + i = 2
 statement error
 INSERT INTO integers VALUES (1, 1);
 ----
-Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicate key
+Constraint Error: Duplicate key "(#[0.0] + #[0.1]): 2" violates unique constraint
 
 statement ok
 DROP INDEX i_index;
@@ -164,7 +164,7 @@ restart
 statement error
 INSERT INTO integers VALUES (1, 1);
 ----
-Constraint Error: PRIMARY KEY or UNIQUE constraint violated: duplicate key
+Constraint Error: Duplicate key "(#[0.0] + #[0.1]): 2, #[0.0]: 1, #[0.1]: 1" violates unique constraint
 
 statement ok
 DROP INDEX i_index;

--- a/test/sql/upsert/upsert_explicit_index.test
+++ b/test/sql/upsert/upsert_explicit_index.test
@@ -1,0 +1,23 @@
+# name: test/sql/upsert/upsert_explicit_index.test
+# group: [upsert]
+
+statement ok
+pragma enable_verification;
+
+statement ok
+create table tbl (i integer, j integer);
+
+statement ok
+insert into tbl values (5,3), (3,2);
+
+statement ok
+create unique index my_index on tbl(i);
+
+statement ok
+insert into tbl values (5,2) on conflict (i) do update set j = 10;
+
+query II
+select * from tbl;
+----
+5	10
+3	2


### PR DESCRIPTION
This PR fixes a longstanding issues of #5866 

This was relatively low hanging fruit in the end.
I originally thought when I was adding support for upsert that the TableIndexList only contained the bound constraints, but that's not the case.

Making this a draft because this likely needs additional tests.
I'll port more of the postgres tests, we couldn't do that before because postgres uses `create index` a lot in their tests
<https://github.com/postgres/postgres/blob/master/src/test/regress/sql/insert_conflict.sql>

Edit:
We still cant, a lot of their tests also update columns that are indexed on.
They also make heavy uses of expressions as conflict target, which I worked on supporting, but I'm running into some binding-related issues there