### PR TITLE
Fix Julia BoundsError with arrays > 2048

### DIFF
--- a/tools/juliapkg/src/result.jl
+++ b/tools/juliapkg/src/result.jl
@@ -148,9 +148,9 @@ function convert_vector(
     ::Type{SRC},
     ::Type{DST}
 ) where {SRC, DST}
-    array = get_array(vector, SRC)
+    array = get_array(vector, SRC, size)
     if !all_valid
-        validity = get_validity(vector)
+        validity = get_validity(vector, size)
     end
     for i in 1:size
         if all_valid || isvalid(validity, i)
@@ -175,7 +175,7 @@ function convert_vector_string(
     raw_ptr = duckdb_vector_get_data(vector.handle)
     ptr = Base.unsafe_convert(Ptr{duckdb_string_t}, raw_ptr)
     if !all_valid
-        validity = get_validity(vector)
+        validity = get_validity(vector, size)
     end
     for i in 1:size
         if all_valid || isvalid(validity, i)
@@ -218,9 +218,9 @@ function convert_vector_list(
         ldata.target_type
     )
 
-    array = get_array(vector, SRC)
+    array = get_array(vector, SRC, size)
     if !all_valid
-        validity = get_validity(vector)
+        validity = get_validity(vector, size)
     end
     for i in 1:size
         if all_valid || isvalid(validity, i)
@@ -276,7 +276,7 @@ function convert_vector_struct(
     child_arrays = convert_struct_children(column_data, vector, size)
 
     if !all_valid
-        validity = get_validity(vector)
+        validity = get_validity(vector, size)
     end
     for i in 1:size
         if all_valid || isvalid(validity, i)
@@ -305,7 +305,7 @@ function convert_vector_union(
     child_arrays = convert_struct_children(column_data, vector, size)
 
     if !all_valid
-        validity = get_validity(vector)
+        validity = get_validity(vector, size)
     end
     for row in 1:size
         # For every row/record
@@ -359,9 +359,9 @@ function convert_vector_map(
     keys = child_arrays[1]
     values = child_arrays[2]
 
-    array = get_array(vector, SRC)
+    array = get_array(vector, SRC, size)
     if !all_valid
-        validity = get_validity(vector)
+        validity = get_validity(vector, size)
     end
     for i in 1:size
         if all_valid || isvalid(validity, i)

--- a/tools/juliapkg/src/vector.jl
+++ b/tools/juliapkg/src/vector.jl
@@ -10,17 +10,18 @@ struct Vec
     end
 end
 
-function get_array(vector::Vec, ::Type{T})::Vector{T} where {T}
+function get_array(vector::Vec, ::Type{T}, size = VECTOR_SIZE)::Vector{T} where {T}
     raw_ptr = duckdb_vector_get_data(vector.handle)
     ptr = Base.unsafe_convert(Ptr{T}, raw_ptr)
-    return unsafe_wrap(Vector{T}, ptr, VECTOR_SIZE, own = false)
+    return unsafe_wrap(Vector{T}, ptr, size, own = false)
 end
 
-function get_validity(vector::Vec)::ValidityMask
+function get_validity(vector::Vec, size = VECTOR_SIZE)::ValidityMask
     duckdb_vector_ensure_validity_writable(vector.handle)
     validity_ptr = duckdb_vector_get_validity(vector.handle)
     ptr = Base.unsafe_convert(Ptr{UInt64}, validity_ptr)
-    validity_vector = unsafe_wrap(Vector{UInt64}, ptr, VECTOR_SIZE ÷ BITS_PER_VALUE, own = false)
+    size_words = div(size, BITS_PER_VALUE, RoundUp)
+    validity_vector = unsafe_wrap(Vector{UInt64}, ptr, size_words, own = false)
     return ValidityMask(validity_vector)
 end
 

--- a/tools/juliapkg/test/runtests.jl
+++ b/tools/juliapkg/test/runtests.jl
@@ -8,6 +8,7 @@ using UUIDs
 test_files = [
     "test_appender.jl",
     "test_basic_queries.jl",
+    "test_big_nested.jl",
     "test_config.jl",
     "test_connection.jl",
     "test_df_scan.jl",

--- a/tools/juliapkg/test/test_big_nested.jl
+++ b/tools/juliapkg/test/test_big_nested.jl
@@ -1,0 +1,77 @@
+
+@testset "Test big list" begin
+    con = DBInterface.connect(DuckDB.DB)
+
+    DBInterface.execute(con, "CREATE TABLE list_table (int_list INT[]);")
+    DBInterface.execute(con, "INSERT INTO list_table VALUES (range(2049));")
+    df = DataFrame(DBInterface.execute(con, "SELECT * FROM list_table;"))
+    @test length(df[1, :int_list]) == 2049
+
+    DBInterface.close!(con)
+end
+
+@testset "Test big bitstring" begin
+    con = DBInterface.connect(DuckDB.DB)
+
+    DBInterface.execute(con, "CREATE TABLE bit_table (bits BIT);")
+    # 131073 = 64 * 2048 + 1
+    DBInterface.execute(con, "INSERT INTO bit_table VALUES (bitstring('1010'::BIT, 131073));")
+    df = DataFrame(DBInterface.execute(con, "SELECT * FROM bit_table;"))
+    # Currently mapped to Julia in an odd way.
+    # Can reenable following https://github.com/duckdb/duckdb/issues/7065
+    # Can't use skip = true prior to Julia 1.7
+    @static if VERSION ≥ v"1.7"
+        @test length(df[1, :bits]) == 131073 skip = true
+    end
+
+    DBInterface.close!(con)
+end
+
+@testset "Test big string" begin
+    con = DBInterface.connect(DuckDB.DB)
+
+    DBInterface.execute(con, "CREATE TABLE str_table (str VARCHAR);")
+    DBInterface.execute(con, "INSERT INTO str_table VALUES (repeat('🦆', 1024) || '🪿');")
+    df = DataFrame(DBInterface.execute(con, "SELECT * FROM str_table;"))
+    @test length(df[1, :str]) == 1025
+
+    DBInterface.close!(con)
+end
+
+@testset "Test big map" begin
+    con = DBInterface.connect(DuckDB.DB)
+
+    DBInterface.execute(con, "CREATE TABLE map_table (map MAP(VARCHAR, INT));")
+    DBInterface.execute(
+        con,
+        "INSERT INTO map_table VALUES (map_from_entries([{'k': 'billy' || num, 'v': num} for num in range(2049)]));"
+    )
+    df = DataFrame(DBInterface.execute(con, "SELECT * FROM map_table;"))
+    @test length(df[1, :map]) == 2049
+
+    DBInterface.close!(con)
+end
+
+@testset "Test big struct" begin
+    con = DBInterface.connect(DuckDB.DB)
+
+    DBInterface.execute(con, "CREATE TABLE struct_table (stct STRUCT(a INT[], b INT[]));")
+    DBInterface.execute(con, "INSERT INTO struct_table VALUES ({'a': range(1024), 'b': range(1025)});")
+    df = DataFrame(DBInterface.execute(con, "SELECT * FROM struct_table;"))
+    s = df[1, :stct]
+    @test length(s.a) == 1024
+    @test length(s.b) == 1025
+
+    DBInterface.close!(con)
+end
+
+@testset "Test big union" begin
+    con = DBInterface.connect(DuckDB.DB)
+
+    DBInterface.execute(con, "CREATE TABLE union_table (uni UNION(a INT[], b INT));")
+    DBInterface.execute(con, "INSERT INTO union_table (uni) VALUES (union_value(a := range(2049))), (42);")
+    df = DataFrame(DBInterface.execute(con, "SELECT * FROM union_table;"))
+    @test length(df[1, :uni]) == 2049
+
+    DBInterface.close!(con)
+end


### PR DESCRIPTION
Fixes #6924 

When mapping regions of memory to Julia, typically it is modeled as an array including an extent. Currently, this was always VECTOR_SIZE = 2048, however child elements of array-like data structures can have data with larger extents. This commit uses the actual extent for these variable sized data structures.