### PR TITLE
Decode DuckDB blobs as buffers in Node UDF args

### DIFF
--- a/tools/nodejs/src/data_chunk.cpp
+++ b/tools/nodejs/src/data_chunk.cpp
@@ -145,7 +145,20 @@ Napi::Array EncodeDataChunk(Napi::Env env, duckdb::DataChunk &chunk, bool with_t
 				}
 				break;
 			}
-			case duckdb::LogicalTypeId::BLOB:
+			case duckdb::LogicalTypeId::BLOB: {
+				if (with_data) {
+					auto array = Napi::Array::New(env, chunk.size());
+					auto data = duckdb::FlatVector::GetData<duckdb::string_t>(*vec);
+
+					for (size_t i = 0; i < chunk.size(); ++i) {
+						auto value = data[i].GetString();
+						auto buf = Napi::Buffer<char>::Copy(env, value.c_str(), value.length());
+						array.Set(i, buf);
+					}
+					desc.Set("data", array);
+				}
+				break;
+			}
 			case duckdb::LogicalTypeId::VARCHAR: {
 				if (with_data) {
 					auto array = Napi::Array::New(env, chunk.size());

--- a/tools/nodejs/src/data_chunk.cpp
+++ b/tools/nodejs/src/data_chunk.cpp
@@ -151,8 +151,7 @@ Napi::Array EncodeDataChunk(Napi::Env env, duckdb::DataChunk &chunk, bool with_t
 					auto data = duckdb::FlatVector::GetData<duckdb::string_t>(*vec);
 
 					for (size_t i = 0; i < chunk.size(); ++i) {
-						auto value = data[i].GetString();
-						auto buf = Napi::Buffer<char>::Copy(env, value.c_str(), value.length());
+						auto buf = Napi::Buffer<char>::Copy(env, data[i].GetDataUnsafe(), data[i].GetSize());
 						array.Set(i, buf);
 					}
 					desc.Set("data", array);

--- a/tools/nodejs/test/udf.test.ts
+++ b/tools/nodejs/test/udf.test.ts
@@ -220,5 +220,14 @@ describe('UDFs', function() {
             });
             db.unregister_udf("udf", done);
         });
+
+        it('blob', function(done) {
+            db.register_udf("udf", "varchar", (buf: Buffer) => buf.toString("hex"));
+            db.all("select udf('\\xAA\\xAB\\xAC'::BLOB) v", function(err: null | Error, rows: TableData) {
+                if (err) throw err;
+                assert.equal(rows[0].v, "aaabac");
+            });
+            db.unregister_udf("udf", done);
+        });
     });
 });


### PR DESCRIPTION
When the UDF arguments include a blob, pass the argument to Node as a buffer instead of a string to ensure the bytes are preserved.

I ran into this while trying to write a few user defined functions to decode binary data. I couldn't work around the issue because of the conversion to UTF-16 that appears to happen when the string is passed to Node.