### PR TITLE
Issue #6861: Index out of bound for all-NULL case.

### DIFF
--- a/src/common/sort/sorted_block.cpp
+++ b/src/common/sort/sorted_block.cpp
@@ -366,11 +366,16 @@ int SBIterator::ComparisonValue(ExpressionType comparison) {
 	}
 }
 
+static idx_t GetBlockCountWithEmptyCheck(const GlobalSortState &gss) {
+	D_ASSERT(gss.sorted_blocks.size() > 0);
+	return gss.sorted_blocks[0]->radix_sorting_data.size();
+}
+
 SBIterator::SBIterator(GlobalSortState &gss, ExpressionType comparison, idx_t entry_idx_p)
-    : sort_layout(gss.sort_layout), block_count(gss.sorted_blocks[0]->radix_sorting_data.size()),
-      block_capacity(gss.block_capacity), cmp_size(sort_layout.comparison_size), entry_size(sort_layout.entry_size),
-      all_constant(sort_layout.all_constant), external(gss.external), cmp(ComparisonValue(comparison)),
-      scan(gss.buffer_manager, gss), block_ptr(nullptr), entry_ptr(nullptr) {
+    : sort_layout(gss.sort_layout), block_count(GetBlockCountWithEmptyCheck(gss)), block_capacity(gss.block_capacity),
+      cmp_size(sort_layout.comparison_size), entry_size(sort_layout.entry_size), all_constant(sort_layout.all_constant),
+      external(gss.external), cmp(ComparisonValue(comparison)), scan(gss.buffer_manager, gss), block_ptr(nullptr),
+      entry_ptr(nullptr) {
 
 	scan.sb = gss.sorted_blocks[0].get();
 	scan.block_idx = block_count;

--- a/src/execution/operator/join/physical_iejoin.cpp
+++ b/src/execution/operator/join/physical_iejoin.cpp
@@ -402,6 +402,10 @@ IEJoinUnion::IEJoinUnion(ClientContext &context, const PhysicalIEJoin &op, Sorte
 	r_executor.AddExpression(*op.rhs_orders[1][0].expression);
 	AppendKey(t2, r_executor, *l1, -1, -1, b2);
 
+	if (l1->global_sort_state.sorted_blocks.empty()) {
+		return;
+	}
+
 	Sort(*l1);
 
 	op1 = make_uniq<SBIterator>(l1->global_sort_state, cmp1);

--- a/test/sql/join/iejoin/iejoin_issue_6861.test
+++ b/test/sql/join/iejoin/iejoin_issue_6861.test
@@ -1,0 +1,21 @@
+# name: test/sql/join/iejoin/iejoin_issue_6861.test
+# description: Issue #6861: Index out of bound for all-NULL case.
+# group: [iejoin]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE test(x INT);
+
+statement ok
+INSERT INTO test(x) VALUES (1), (2), (3), (NULL), (NULL), (NULL);
+
+statement ok
+UPDATE test SET x=(NULL);
+
+query II
+SELECT * 
+FROM test AS a, test AS b 
+WHERE (a.x BETWEEN b.x AND b.x);
+----

--- a/test/sql/join/iejoin/iejoin_issue_6861.test
+++ b/test/sql/join/iejoin/iejoin_issue_6861.test
@@ -8,14 +8,35 @@ PRAGMA enable_verification
 statement ok
 CREATE TABLE test(x INT);
 
+query II
+SELECT * 
+FROM test AS a, test AS b 
+WHERE (a.x BETWEEN b.x AND b.x);
+----
+
 statement ok
 INSERT INTO test(x) VALUES (1), (2), (3), (NULL), (NULL), (NULL);
 
 statement ok
-UPDATE test SET x=(NULL);
+CREATE TABLE all_null AS SELECT * FROM test;
+
+statement ok
+UPDATE all_null SET x=(NULL);
 
 query II
 SELECT * 
-FROM test AS a, test AS b 
+FROM all_null AS a, all_null AS b 
+WHERE (a.x BETWEEN b.x AND b.x);
+----
+
+query II
+SELECT * 
+FROM test AS a, all_null AS b 
+WHERE (a.x BETWEEN b.x AND b.x);
+----
+
+query II
+SELECT * 
+FROM all_null AS a, test AS b 
 WHERE (a.x BETWEEN b.x AND b.x);
 ----


### PR DESCRIPTION
This fixes #6861

In constructor of `SBIterator`, it directly use `gss.sorted_blocks[0]`, but in all-NULL case `gss.sorted_blocks` is empty.

BTW, should we add assert in constructor of `SBIterator`? But to do this we must make `block_count` non-const to assign it after assertion.