### PR TITLE
Kitchen sink related to duckdb-wasm WIP

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -74,19 +74,11 @@ jobs:
         shell: bash
         run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang-tidy && sudo pip3 install pybind11[global]
 
-      - name: Cache clang-tidy
-        id: date
-        shell: bash
-        run: echo "name=now::$(date)" >> $GITHUB_OUTPUT
-
-      - name: Cache clang-tidy
-        uses: actions/cache@v3
+      - name: Setup Ccache
+        uses: hendrikmuhs/ccache-action@main
         with:
-          path: ~/.ctcache/cache
-          key: clang-tidy-${{ steps.date.outputs.now }}
-          restore-keys: |
-            clang-tidy
-
+          key: ${{ github.job }}
+          save: ${{ github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb' }}
       - name: Download clang-tidy-cache
         shell: bash
         run: |

--- a/src/include/duckdb/common/helper.hpp
+++ b/src/include/duckdb/common/helper.hpp
@@ -82,6 +82,13 @@ unique_ptr<S> make_uniq_base(Args &&... args) {
 	return unique_ptr<S>(new T(std::forward<Args>(args)...));
 }
 
+#ifdef DUCKDB_ENABLE_DEPRECATED_API
+template <typename S, typename T, typename... Args>
+unique_ptr<S> make_unique_base(Args &&... args) {
+	return unique_ptr<S>(new T(std::forward<Args>(args)...));
+}
+#endif // DUCKDB_ENABLE_DEPRECATED_API
+
 template <typename T, typename S>
 unique_ptr<S> unique_ptr_cast(unique_ptr<T> src) {
 	return unique_ptr<S>(static_cast<S *>(src.release()));
@@ -111,7 +118,10 @@ typename std::remove_reference<T>::type&& move(T&& t) noexcept {
 
 template <class T, class... _Args>
 static duckdb::unique_ptr<T> make_unique(_Args&&... __args) {
+#ifndef DUCKDB_ENABLE_DEPRECATED_API
 	static_assert(sizeof(T) == 0, "Use make_uniq instead of make_unique!");
+#endif // DUCKDB_ENABLE_DEPRECATED_API
+	return unique_ptr<T>(new T(std::forward<_Args>(__args)...));
 }
 
 template <typename T>

--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -175,24 +175,16 @@ public:
 	DUCKDB_API static Value BIT(const string &data);
 
 	template <class T>
-	T GetValue() const {
-		throw InternalException("Unimplemented template type for Value::GetValue");
-	}
+	T GetValue() const;
 	template <class T>
-	static Value CreateValue(T value) {
-		throw InternalException("Unimplemented template type for Value::CreateValue");
-	}
+	static Value CreateValue(T value);
 	// Returns the internal value. Unlike GetValue(), this method does not perform casting, and assumes T matches the
 	// type of the value. Only use this if you know what you are doing.
 	template <class T>
-	T GetValueUnsafe() const {
-		throw InternalException("Unimplemented template type for Value::GetValueUnsafe");
-	}
+	T GetValueUnsafe() const;
 	//! Returns a reference to the internal value. This can only be used for primitive types.
 	template <class T>
-	T &GetReferenceUnsafe() {
-		throw InternalException("Unimplemented template type for Value::GetReferenceUnsafe");
-	}
+	T &GetReferenceUnsafe();
 
 	//! Return a copy of this value
 	Value Copy() const {


### PR DESCRIPTION
UNSAFE_BACKWARD_COMPATIBILITY would allow some leeway for older code (say exceptions) to adapt to upstream duckdb-core. Unsure if we should also stick a attribute::deprecated on top, just to make it more visible / pushing for adapting.

CreateValue I miss context. Moving it to not being defined changes behaviour slightly: now classes convertible to a primitive would have conversion performed implicitly (say std::vector -> duckdb::vector).
Alternative could also be a static_assert, so that errors are found during compilations instead that at runtime.
In the meantime I found the problematic places, so it's not really that relevant, it's more that this what I followed to find the problem.