### PR TITLE
[Optimizer] Fix `regexp_matches` (again)

### DIFF
--- a/test/optimizer/regex_optimizer_coverage.test
+++ b/test/optimizer/regex_optimizer_coverage.test
@@ -47,6 +47,17 @@ query I nosort correct_result
 select regexp_matches(word, '[A-A]') from test;
 ----
 
+# case-insensitive
 query I nosort correct_result
 select regexp_matches(word, '(?i)[A-A]') from test;
+----
+
+# single-line mode
+query I nosort correct_result
+select regexp_matches(word, '(?s)[A-A]') from test;
+----
+
+# multi-line mode
+query I nosort correct_result
+select regexp_matches(word, '(?m)[A-A]') from test;
 ----

--- a/test/optimizer/regex_optimizer_coverage.test
+++ b/test/optimizer/regex_optimizer_coverage.test
@@ -46,3 +46,7 @@ select regexp_matches(word, '[AAAA]') from test;
 query I nosort correct_result
 select regexp_matches(word, '[A-A]') from test;
 ----
+
+query I nosort correct_result
+select regexp_matches(word, '(?i)[A-A]') from test;
+----


### PR DESCRIPTION
This PR fixes #7068 

Previously when fixing this, I experienced weird behavior from `PossibleMatchRange`, where the pattern `A` would return `A` as min and max as `B` , which I "fixed" by just returning the original pattern string in that case.

That doesn't work, because the problematic case in the issue should not be optimized to a simple `count`.
Increasing the `N` value passed to `PossibleMatchRange` removes this inaccuracy, allowing us to properly judge whether this can be optimized or not.