### PR TITLE
Support array_reverse list_reverse function 

### DIFF
--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -91,6 +91,8 @@ static DefaultMacro internal_macros[] = {
 	{DEFAULT_SCHEMA, "array_push_back", {"arr", "e", nullptr}, "list_concat(arr, list_value(e))"},
 	{DEFAULT_SCHEMA, "array_push_front", {"arr", "e", nullptr}, "list_concat(list_value(e), arr)"},
 	{DEFAULT_SCHEMA, "generate_subscripts", {"arr", "dim", nullptr}, "unnest(generate_series(1, array_length(arr, dim)))"},
+	{DEFAULT_SCHEMA, "array_reverse", {"arr", nullptr},"( SELECT coalesce(list(elm), arr) FROM ( SELECT generate_subscripts(arr, 1) as g, arr[g] as elm ORDER BY g DESC) )"},
+	{DEFAULT_SCHEMA, "list_reverse", {"arr", nullptr},"array_reverse(arr)"},
 	{DEFAULT_SCHEMA, "fdiv", {"x", "y", nullptr}, "floor(x/y)"},
 	{DEFAULT_SCHEMA, "fmod", {"x", "y", nullptr}, "(x-y*floor(x/y))"},
 	{DEFAULT_SCHEMA, "count_if", {"l", nullptr}, "sum(if(l, 1, 0))"},

--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -91,7 +91,7 @@ static DefaultMacro internal_macros[] = {
 	{DEFAULT_SCHEMA, "array_push_back", {"arr", "e", nullptr}, "list_concat(arr, list_value(e))"},
 	{DEFAULT_SCHEMA, "array_push_front", {"arr", "e", nullptr}, "list_concat(list_value(e), arr)"},
 	{DEFAULT_SCHEMA, "generate_subscripts", {"arr", "dim", nullptr}, "unnest(generate_series(1, array_length(arr, dim)))"},
-	{DEFAULT_SCHEMA, "array_reverse", {"arr", nullptr},"(SELECT CASE WHEN arr = [] THEN [] ELSE l END FROM ( SELECT array_agg(elm) as l FROM (SELECT generate_subscripts(arr, 1) AS g, arr[g] AS elm ORDER BY g DESC)))"},
+	{DEFAULT_SCHEMA, "array_reverse", {"arr", nullptr},"(SELECT CASE WHEN l IS NOT NULL THEN l ELSE arr END FROM ( SELECT array_agg(elm) as l FROM (SELECT generate_subscripts(arr, 1) AS g, arr[g] AS elm ORDER BY g DESC)))"},
 	{DEFAULT_SCHEMA, "list_reverse", {"arr", nullptr},"array_reverse(arr)"},
 	{DEFAULT_SCHEMA, "fdiv", {"x", "y", nullptr}, "floor(x/y)"},
 	{DEFAULT_SCHEMA, "fmod", {"x", "y", nullptr}, "(x-y*floor(x/y))"},

--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -91,7 +91,7 @@ static DefaultMacro internal_macros[] = {
 	{DEFAULT_SCHEMA, "array_push_back", {"arr", "e", nullptr}, "list_concat(arr, list_value(e))"},
 	{DEFAULT_SCHEMA, "array_push_front", {"arr", "e", nullptr}, "list_concat(list_value(e), arr)"},
 	{DEFAULT_SCHEMA, "generate_subscripts", {"arr", "dim", nullptr}, "unnest(generate_series(1, array_length(arr, dim)))"},
-	{DEFAULT_SCHEMA, "array_reverse", {"arr", nullptr},"( SELECT coalesce(list(elm), arr) FROM ( SELECT generate_subscripts(arr, 1) as g, arr[g] as elm ORDER BY g DESC) )"},
+	{DEFAULT_SCHEMA, "array_reverse", {"arr", nullptr},"(SELECT CASE WHEN arr = [] THEN [] ELSE l END FROM ( SELECT array_agg(elm) as l FROM (SELECT generate_subscripts(arr, 1) AS g, arr[g] AS elm ORDER BY g DESC)))"},
 	{DEFAULT_SCHEMA, "list_reverse", {"arr", nullptr},"array_reverse(arr)"},
 	{DEFAULT_SCHEMA, "fdiv", {"x", "y", nullptr}, "floor(x/y)"},
 	{DEFAULT_SCHEMA, "fmod", {"x", "y", nullptr}, "(x-y*floor(x/y))"},

--- a/test/sql/function/list/list_reverse.test
+++ b/test/sql/function/list/list_reverse.test
@@ -21,6 +21,21 @@ SELECT ${func_name}([])
 ----
 []
 
+query I
+WITH example AS (
+  SELECT [1, 2, 3] AS arr UNION ALL
+  SELECT [4, 5] AS arr UNION ALL
+  SELECT [] AS arr
+)
+SELECT
+  ${func_name}(arr) AS reverse_arr
+FROM example;
+----
+[3, 2, 1]
+[5, 4]
+[]
+
+
 endloop
 
 # test incorrect syntax
@@ -96,7 +111,7 @@ SELECT ${func_name}(i) FROM integers
 [9, 8, 7, 6, 5, 4, 3, 2, 1]
 [NULL]
 NULL
-NULL
+[]
 
 query I
 SELECT (i).${func_name}() FROM integers
@@ -104,7 +119,7 @@ SELECT (i).${func_name}() FROM integers
 [9, 8, 7, 6, 5, 4, 3, 2, 1]
 [NULL]
 NULL
-NULL
+[]
 
 endloop
 

--- a/test/sql/function/list/list_reverse.test
+++ b/test/sql/function/list/list_reverse.test
@@ -1,0 +1,145 @@
+# name: test/sql/function/list/list_reverse.test
+# description: Test list_reverse and array_reverse function
+# group: [list]
+
+# test NULL or empty
+
+foreach func_name list_reverse array_reverse
+
+query I
+SELECT ${func_name}(NULL)
+----
+NULL
+
+query I
+SELECT ${func_name}([NULL])
+----
+[NULL]
+
+query I
+SELECT ${func_name}([])
+----
+[]
+
+endloop
+
+# test incorrect syntax
+
+foreach func_name list_reverse array_reverse
+
+statement error
+SELECT ${func_name}()
+
+statement error
+SELECT ${func_name}(*)
+
+statement error
+SELECT ${func_name}([1, 2], 2)
+
+endloop
+
+# test incorrect parameter type
+
+foreach func_name list_reverse array_reverse
+
+foreach type boolean varchar tinyint smallint integer bigint hugeint utinyint usmallint uinteger ubigint float double decimal(4,1) decimal(9,4) decimal(18,6) decimal(38,10) date time timestamp timestamp_s timestamp_ms timestamp_ns timetz timestamptz interval blob
+
+statement error
+SELECT ${func_name}(NULL::${type})
+
+endloop
+
+endloop
+
+
+# list constant tests
+
+foreach func_name list_reverse array_reverse
+
+query I
+SELECT ${func_name}([1, 42, 39, 58])
+----
+[58, 39, 42, 1]
+
+query I
+SELECT ${func_name}([1, NULL, 42, 39, NULL, 58])
+----
+[58, NULL, 39, 42, NULL, 1]
+
+
+query I
+SELECT ${func_name}([1, 42, -39, 58, -1, 18])
+----
+[18, -1, 58, -39, 42, 1]
+
+query I
+SELECT ${func_name}(${func_name}([11, -100, 678]))
+----
+[11, -100, 678]
+
+endloop
+
+
+# list column tests
+
+foreach func_name list_reverse array_reverse
+
+statement ok
+CREATE OR REPLACE TABLE integers AS SELECT LIST(i) AS i FROM range(1, 10, 1) t1(i)
+
+statement ok
+INSERT INTO integers VALUES ([NULL]), (NULL), ([])
+
+query I
+SELECT ${func_name}(i) FROM integers
+----
+[9, 8, 7, 6, 5, 4, 3, 2, 1]
+[NULL]
+NULL
+NULL
+
+query I
+SELECT (i).${func_name}() FROM integers
+----
+[9, 8, 7, 6, 5, 4, 3, 2, 1]
+[NULL]
+NULL
+NULL
+
+endloop
+
+# Nested list and very Large list
+
+foreach func_name list_reverse array_reverse
+
+query I
+SELECT ${func_name}([[1], [1, 2], NULL, [NULL], [], [1, 2, 3]])
+----
+[[1, 2, 3], [], [NULL], NULL, [1, 2], [1]]
+
+query I
+SELECT ([[1], [1, 2], NULL, [NULL], [], [1, 2, 3]]).${func_name}()
+----
+[[1, 2, 3], [], [NULL], NULL, [1, 2], [1]]
+
+
+statement ok
+CREATE OR REPLACE TABLE lists AS SELECT range % 4 g, list(range) l FROM range(10000) GROUP BY range % 4;
+
+query T
+with cte0 as (
+  select g, ${func_name}(l) l from lists
+), cte1 as (
+  select g, unnest(l) i from cte0
+), cte2 as (
+  select g, i, lead(g, 1) over () lg, lead(i, 1) over () li from cte1
+)
+select count(*)
+from cte2
+where g = lg
+  and lg not null
+  and li > i
+----
+0
+
+endloop


### PR DESCRIPTION
   Ceated a new macro called `array_reverse` that takes an input array and returns the same array with its elements in reverse order, without involving any sorting(we already have `array_reverse_sort`).

Postgres doesn't have a built-in function for array_reverse, but there is a wiki page that suggests how to implement array_reverse using pl/sql.  
https://wiki.postgresql.org/wiki/Array_reverse 

Bigquery support this function.
https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#array_reverse




