### PR TITLE
fix: accept either AWS_REGION or AWS_DEFAULT_REGION

### DIFF
--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -18,7 +18,8 @@
 namespace duckdb {
 
 struct AWSEnvironmentCredentialsProvider {
-	static constexpr const char *REGION_ENV_VAR = "AWS_DEFAULT_REGION";
+	static constexpr const char *REGION_ENV_VAR = "AWS_REGION";
+	static constexpr const char *DEFAULT_REGION_ENV_VAR = "AWS_DEFAULT_REGION";
 	static constexpr const char *ACCESS_KEY_ENV_VAR = "AWS_ACCESS_KEY_ID";
 	static constexpr const char *SECRET_KEY_ENV_VAR = "AWS_SECRET_ACCESS_KEY";
 	static constexpr const char *SESSION_TOKEN_ENV_VAR = "AWS_SESSION_TOKEN";

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -161,7 +161,7 @@ void AWSEnvironmentCredentialsProvider::SetAll() {
 	this->SetExtensionOptionValue("s3_session_token", this->SESSION_TOKEN_ENV_VAR);
 	this->SetExtensionOptionValue("s3_endpoint", this->DUCKDB_ENDPOINT_ENV_VAR);
 	this->SetExtensionOptionValue("s3_use_ssl", this->DUCKDB_USE_SSL_ENV_VAR);
-	}
+}
 
 S3AuthParams S3AuthParams::ReadFrom(FileOpener *opener) {
 	string region;

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -154,8 +154,8 @@ void AWSEnvironmentCredentialsProvider::SetExtensionOptionValue(string key, cons
 }
 
 void AWSEnvironmentCredentialsProvider::SetAll() {
-	const char *region_env_var = this->REGION_ENV_VAR != NULL ? this->REGION_ENV_VAR : this->DEFAULT_REGION_ENV_VAR;
-	this->SetExtensionOptionValue("s3_region", region_env_var);
+	this->SetExtensionOptionValue("s3_region", this->DEFAULT_REGION_ENV_VAR);
+	this->SetExtensionOptionValue("s3_region", this->REGION_ENV_VAR);
 	this->SetExtensionOptionValue("s3_access_key_id", this->ACCESS_KEY_ENV_VAR);
 	this->SetExtensionOptionValue("s3_secret_access_key", this->SECRET_KEY_ENV_VAR);
 	this->SetExtensionOptionValue("s3_session_token", this->SESSION_TOKEN_ENV_VAR);

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -154,7 +154,7 @@ void AWSEnvironmentCredentialsProvider::SetExtensionOptionValue(string key, cons
 }
 
 void AWSEnvironmentCredentialsProvider::SetAll() {
-    const char *region_env_var = std::getenv(this->REGION_ENV_VAR) != NULL ? this->REGION_ENV_VAR : this->DEFAULT_REGION_ENV_VAR;
+    const char *region_env_var = this->REGION_ENV_VAR != NULL ? this->REGION_ENV_VAR : this->DEFAULT_REGION_ENV_VAR;
     this->SetExtensionOptionValue("s3_region", region_env_var);
     this->SetExtensionOptionValue("s3_access_key_id", this->ACCESS_KEY_ENV_VAR);
     this->SetExtensionOptionValue("s3_secret_access_key", this->SECRET_KEY_ENV_VAR);
@@ -162,7 +162,6 @@ void AWSEnvironmentCredentialsProvider::SetAll() {
     this->SetExtensionOptionValue("s3_endpoint", this->DUCKDB_ENDPOINT_ENV_VAR);
     this->SetExtensionOptionValue("s3_use_ssl", this->DUCKDB_USE_SSL_ENV_VAR);
 }
-
 
 S3AuthParams S3AuthParams::ReadFrom(FileOpener *opener) {
 	string region;

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -154,8 +154,8 @@ void AWSEnvironmentCredentialsProvider::SetExtensionOptionValue(string key, cons
 }
 
 void AWSEnvironmentCredentialsProvider::SetAll() {
-	const char *region_env_var = this->REGION_ENV_VAR != NULL ? this->REGION_ENV_VAR : this->DEFAULT_REGION_ENV_VAR;
-	this->SetExtensionOptionValue("s3_region", region_env_var);
+	this->SetExtensionOptionValue("s3_region", DEFAULT_REGION_ENV_VAR);
+	this->SetExtensionOptionValue("s3_region", REGION_ENV_VAR);
 	this->SetExtensionOptionValue("s3_access_key_id", this->ACCESS_KEY_ENV_VAR);
 	this->SetExtensionOptionValue("s3_secret_access_key", this->SECRET_KEY_ENV_VAR);
 	this->SetExtensionOptionValue("s3_session_token", this->SESSION_TOKEN_ENV_VAR);

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -154,14 +154,14 @@ void AWSEnvironmentCredentialsProvider::SetExtensionOptionValue(string key, cons
 }
 
 void AWSEnvironmentCredentialsProvider::SetAll() {
-    const char *region_env_var = this->REGION_ENV_VAR != NULL ? this->REGION_ENV_VAR : this->DEFAULT_REGION_ENV_VAR;
-    this->SetExtensionOptionValue("s3_region", region_env_var);
-    this->SetExtensionOptionValue("s3_access_key_id", this->ACCESS_KEY_ENV_VAR);
-    this->SetExtensionOptionValue("s3_secret_access_key", this->SECRET_KEY_ENV_VAR);
-    this->SetExtensionOptionValue("s3_session_token", this->SESSION_TOKEN_ENV_VAR);
-    this->SetExtensionOptionValue("s3_endpoint", this->DUCKDB_ENDPOINT_ENV_VAR);
-    this->SetExtensionOptionValue("s3_use_ssl", this->DUCKDB_USE_SSL_ENV_VAR);
-}
+	const char *region_env_var = this->REGION_ENV_VAR != NULL ? this->REGION_ENV_VAR : this->DEFAULT_REGION_ENV_VAR;
+	this->SetExtensionOptionValue("s3_region", region_env_var);
+	this->SetExtensionOptionValue("s3_access_key_id", this->ACCESS_KEY_ENV_VAR);
+	this->SetExtensionOptionValue("s3_secret_access_key", this->SECRET_KEY_ENV_VAR);
+	this->SetExtensionOptionValue("s3_session_token", this->SESSION_TOKEN_ENV_VAR);
+	this->SetExtensionOptionValue("s3_endpoint", this->DUCKDB_ENDPOINT_ENV_VAR);
+	this->SetExtensionOptionValue("s3_use_ssl", this->DUCKDB_USE_SSL_ENV_VAR);
+	}
 
 S3AuthParams S3AuthParams::ReadFrom(FileOpener *opener) {
 	string region;

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -154,13 +154,15 @@ void AWSEnvironmentCredentialsProvider::SetExtensionOptionValue(string key, cons
 }
 
 void AWSEnvironmentCredentialsProvider::SetAll() {
-	this->SetExtensionOptionValue("s3_region", this->REGION_ENV_VAR);
-	this->SetExtensionOptionValue("s3_access_key_id", this->ACCESS_KEY_ENV_VAR);
-	this->SetExtensionOptionValue("s3_secret_access_key", this->SECRET_KEY_ENV_VAR);
-	this->SetExtensionOptionValue("s3_session_token", this->SESSION_TOKEN_ENV_VAR);
-	this->SetExtensionOptionValue("s3_endpoint", this->DUCKDB_ENDPOINT_ENV_VAR);
-	this->SetExtensionOptionValue("s3_use_ssl", this->DUCKDB_USE_SSL_ENV_VAR);
+    const char *region_env_var = std::getenv(this->REGION_ENV_VAR) != NULL ? this->REGION_ENV_VAR : this->DEFAULT_REGION_ENV_VAR;
+    this->SetExtensionOptionValue("s3_region", region_env_var);
+    this->SetExtensionOptionValue("s3_access_key_id", this->ACCESS_KEY_ENV_VAR);
+    this->SetExtensionOptionValue("s3_secret_access_key", this->SECRET_KEY_ENV_VAR);
+    this->SetExtensionOptionValue("s3_session_token", this->SESSION_TOKEN_ENV_VAR);
+    this->SetExtensionOptionValue("s3_endpoint", this->DUCKDB_ENDPOINT_ENV_VAR);
+    this->SetExtensionOptionValue("s3_use_ssl", this->DUCKDB_USE_SSL_ENV_VAR);
 }
+
 
 S3AuthParams S3AuthParams::ReadFrom(FileOpener *opener) {
 	string region;

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -154,8 +154,8 @@ void AWSEnvironmentCredentialsProvider::SetExtensionOptionValue(string key, cons
 }
 
 void AWSEnvironmentCredentialsProvider::SetAll() {
-	this->SetExtensionOptionValue("s3_region", DEFAULT_REGION_ENV_VAR);
-	this->SetExtensionOptionValue("s3_region", REGION_ENV_VAR);
+	const char *region_env_var = this->REGION_ENV_VAR != NULL ? this->REGION_ENV_VAR : this->DEFAULT_REGION_ENV_VAR;
+	this->SetExtensionOptionValue("s3_region", region_env_var);
 	this->SetExtensionOptionValue("s3_access_key_id", this->ACCESS_KEY_ENV_VAR);
 	this->SetExtensionOptionValue("s3_secret_access_key", this->SECRET_KEY_ENV_VAR);
 	this->SetExtensionOptionValue("s3_session_token", this->SESSION_TOKEN_ENV_VAR);


### PR DESCRIPTION
This is a small fix for the `httpfs` extension to retrieve either the `AWS_REGION` or `AWS_DEFAULT_REGION` from environment variables if they exist. If both exist then `AWS_REGION` takes precedence, which seems to be the convention from reading AWS documentation.

It caught me out that only `AWS_DEFAULT_REGION` was accepted, as I am used to using `AWS_REGION` in my projects; I noticed someone else had this issue [here](https://github.com/duckdb/duckdb/issues/6134) too, so thought I'd attempt a fix.

This is my first time attempting anything in C++, so apologies if I've done something incorrectly/against convention; any feedback gratefully received, or perhaps you don't see this as an issue!