### PR TITLE
Fix #7083 - correctly reset delta offset when reading a new delta byte array page

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -647,6 +647,7 @@ void StringColumnReader::PrepareDeltaLengthByteArray(ResizeableBuffer &buffer) {
 	auto length_data = (uint32_t *)length_buffer->ptr;
 	byte_array_data = make_uniq<Vector>(LogicalType::VARCHAR, value_count);
 	byte_array_count = value_count;
+	delta_offset = 0;
 	auto string_data = FlatVector::GetData<string_t>(*byte_array_data);
 	for (idx_t i = 0; i < value_count; i++) {
 		auto str_len = length_data[i];
@@ -674,6 +675,7 @@ void StringColumnReader::PrepareDeltaByteArray(ResizeableBuffer &buffer) {
 	auto suffix_data = (uint32_t *)suffix_buffer->ptr;
 	byte_array_data = make_uniq<Vector>(LogicalType::VARCHAR, prefix_count);
 	byte_array_count = prefix_count;
+	delta_offset = 0;
 	auto string_data = FlatVector::GetData<string_t>(*byte_array_data);
 	for (idx_t i = 0; i < prefix_count; i++) {
 		auto str_len = prefix_data[i] + suffix_data[i];
@@ -715,6 +717,7 @@ void StringColumnReader::DeltaByteArray(uint8_t *defines, idx_t num_values, parq
 			delta_offset++;
 		}
 	}
+	StringVector::AddHeapReference(result, *byte_array_data);
 }
 
 class ParquetStringVectorBuffer : public VectorBuffer {

--- a/test/sql/copy/parquet/delta_byte_array_length_mismatch.test
+++ b/test/sql/copy/parquet/delta_byte_array_length_mismatch.test
@@ -6,7 +6,5 @@ require parquet
 
 require httpfs
 
-statement error
+statement ok
 SELECT * FROM parquet_scan('https://github.com/duckdb/duckdb-data/releases/download/v1.0/delta_byte_array_length_mismatch.parquet')
-----
-length mismatch

--- a/test/sql/copy/parquet/delta_byte_array_multiple_pages.test
+++ b/test/sql/copy/parquet/delta_byte_array_multiple_pages.test
@@ -1,0 +1,23 @@
+# name: test/sql/copy/parquet/delta_byte_array_multiple_pages.test
+# description: Test delta byte array parquet file with multiple pages
+# group: [parquet]
+
+require parquet
+
+require httpfs
+
+statement ok
+CREATE TABLE delta_byte_array AS SELECT * FROM parquet_scan('https://github.com/duckdb/duckdb-data/releases/download/v1.0/delta_byte_array_multiple_pages.parquet')
+
+query I
+SELECT COUNT(*) FROM delta_byte_array
+----
+100000
+
+query II
+SELECT min(strlen(json_column)), max(strlen(json_column)) FROM delta_byte_array
+----
+54	54
+
+
+


### PR DESCRIPTION
Fixes #7083 