### PR TITLE
Wasm signing script

### DIFF
--- a/tools/wasm/scripts/extension-upload-wasm.sh
+++ b/tools/wasm/scripts/extension-upload-wasm.sh
@@ -43,7 +43,7 @@ do
 	# compress extension binary
 	gzip < $f.append > "$f.gz"
 	# upload compressed extension binary to S3
-	aws s3 cp $f.gz s3://duckdb-extensions/$2/wasm-$1/$ext.duckdb_extension.gz --acl public-read
+	aws s3 cp $f.gz s3://duckdb-extensions/$2/wasm-$1/$ext.duckdb_extension.wasm --acl public-read --content-encoding gzip
 done
 
 rm private.pem

--- a/tools/wasm/scripts/extension-upload-wasm.sh
+++ b/tools/wasm/scripts/extension-upload-wasm.sh
@@ -9,6 +9,9 @@ echo "$DUCKDB_EXTENSION_SIGNING_PK" > private.pem
 FILES="build/$1/extensions/*/*.duckdb_extension.wasm"
 for f in $FILES
 do
+	# validate input file
+	wasm-validate --enable-all $f
+
 	ext=`basename $f .duckdb_extension.wasm`
 	echo $ext
 	# calculate SHA256 hash of extension binary
@@ -33,6 +36,10 @@ do
 	openssl pkeyutl -sign -in $f.hash -inkey private.pem -pkeyopt digest:sha256 -out $f.sign
 	# append signature to extension binary
 	cat $f.sign >> $f.append
+
+	# validate generated file
+	wasm-validate --enable-all $f.append
+
 	# compress extension binary
 	gzip < $f.append > "$f.gz"
 	# upload compressed extension binary to S3

--- a/tools/wasm/scripts/extension-upload-wasm.sh
+++ b/tools/wasm/scripts/extension-upload-wasm.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Usage: ./extension-upload.sh <architecture> <commithash or version_tag>
+
+set -e
+
+echo "$DUCKDB_EXTENSION_SIGNING_PK" > private.pem
+
+FILES="build/$1/extensions/*/*.duckdb_extension.wasm"
+for f in $FILES
+do
+	ext=`basename $f .duckdb_extension.wasm`
+	echo $ext
+	# calculate SHA256 hash of extension binary
+	cat $f > $f.append
+	# 0 for custom section
+	echo -n -e '\x00' >> $.append
+	# 113 in hex = 275 in decimal, total lenght of what follows (1 + 16 + 2 + 256)
+	# [1(continuation) + 0010011(payload) = \x93, 0(continuation) + 10(payload) = \x02]
+	echo -n -e '\x93\x02' >> $.append
+	# 10 in hex = 16 in decimal, lenght of name, 1 byte
+	echo -n -e '\x10' >> $.append
+	# the name of the WebAssembly custom section, 16 bytes
+	echo -n 'duckdb_signature' >> $.append
+	# 100 in hex, 256 in decimal
+	# [1(continuation) + 0000000(payload) = \x80, 0(continuation) + 10(payload) = \x02],
+	# for a grand total of 2 bytes
+	echo -n '\x80\x02' >> $.append
+	# the actual payload, 256 bytes, to be added later
+
+	openssl dgst -binary -sha256 $f.append > $f.hash
+	# encrypt hash with extension signing private key to create signature
+	openssl pkeyutl -sign -in $f.hash -inkey private.pem -pkeyopt digest:sha256 -out $f.sign
+	# append signature to extension binary
+	cat $f.sign >> $f.append
+	# compress extension binary
+	gzip < $f.append > "$f.gz"
+	# upload compressed extension binary to S3
+	aws s3 cp $f.gz s3://duckdb-extensions/$2/wasm-$1/$ext.duckdb_extension.gz --acl public-read
+done
+
+rm private.pem


### PR DESCRIPTION
Modelled after script/extension-upload.sh, with this changes:

* extension names are expected to be "quack.duckdb_extension.wasm"
* content will have content-encoding gzip, so browsers will automatically perform decompression
* hash encoded as a WebAssembly custom section (so the resulting file it's still valid)

WebAssembly custom section format is like:
1- single byte 0
2- how many bytes in total will follow (len(3) + len(4) + len(5) + len(6) = 275, ULEB encoded)
3- how many bytes in part 4 (len(name) -> 16, ULEB encoded)
4- name of the custom section, encoded as a char array (name = "duckdb_extension")
5 - how many bytes in part 6 (len(hash) -> 256, ULEB encoded)
6 - actual hash

Note that format is completly agnostic, could be used to encode also other sort of information (say versioning), but for that making this a sub-tool would be handy, for now keeping it simpler with hardcoded values.

I tested locally, Wasm part should work. Note also that the testing with `--enable-all` do not means skipping errors, only that all feature are considered enabled.

Potentially relevant:
https://en.wikipedia.org/wiki/LEB128#Unsigned_LEB128
https://webassembly.github.io/spec/core/binary/modules.html#binary-customsec