### PR TITLE
Coalesce expression operator should propagate null

### DIFF
--- a/src/planner/expression.cpp
+++ b/src/planner/expression.cpp
@@ -51,7 +51,8 @@ bool Expression::HasSideEffects() const {
 bool Expression::PropagatesNullValues() const {
 	if (type == ExpressionType::OPERATOR_IS_NULL || type == ExpressionType::OPERATOR_IS_NOT_NULL ||
 	    type == ExpressionType::COMPARE_NOT_DISTINCT_FROM || type == ExpressionType::COMPARE_DISTINCT_FROM ||
-	    type == ExpressionType::CONJUNCTION_OR || type == ExpressionType::CONJUNCTION_AND) {
+	    type == ExpressionType::CONJUNCTION_OR || type == ExpressionType::CONJUNCTION_AND ||
+	    type == ExpressionType::OPERATOR_COALESCE) {
 		return false;
 	}
 	bool propagate_null_values = true;

--- a/test/sql/subquery/scalar/test_issue_7079.test
+++ b/test/sql/subquery/scalar/test_issue_7079.test
@@ -1,0 +1,46 @@
+# name: test/sql/subquery/scalar/test_issue_7079.test
+# description: Issue 7079: Coalesce function not functioning properly in DuckDB macro function
+# group: [scalar]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE MACRO array_rv(arr) AS (
+    SELECT CASE WHEN l IS NOT NULL THEN l ELSE arr END 
+    FROM (
+        SELECT array_agg(elm) as l  
+        FROM (SELECT generate_subscripts(arr, 1) AS g, arr[g] AS elm ORDER BY g DESC)
+    ) 
+);
+
+statement ok
+CREATE MACRO array_rv_coal(arr) AS (
+    SELECT COALESCE(l,arr)
+    FROM (
+        SELECT array_agg(elm) as l  
+        FROM (SELECT generate_subscripts(arr, 1) AS g, arr[g] AS elm ORDER BY g DESC)
+    ) 
+);
+
+statement ok
+CREATE TABLE t AS (
+  SELECT [1, 2, 3] AS arr UNION ALL   
+  SELECT [4, 5] AS arr UNION ALL   
+  SELECT [] AS arr 
+);
+
+
+query I
+SELECT array_rv(arr) FROM t ORDER BY arr;
+----
+[]
+[3, 2, 1]
+[5, 4]
+
+query I
+SELECT array_rv_coal(arr) FROM t ORDER BY arr;
+----
+[]
+[3, 2, 1]
+[5, 4]


### PR DESCRIPTION
Fix https://github.com/duckdb/duckdb/issues/7079

```sql
CREATE MACRO array_rv(arr) AS (
    SELECT CASE WHEN l IS NOT NULL THEN l ELSE arr END 
    FROM (
        SELECT array_agg(elm) as l  
        FROM (SELECT generate_subscripts(arr, 1) AS g, arr[g] AS elm ORDER BY g DESC)
    ) 
);
```

```sql 
CREATE MACRO array_rv_coal(arr) AS (
    SELECT COALESCE(l,arr)
    FROM (
        SELECT array_agg(elm) as l  
        FROM (SELECT generate_subscripts(arr, 1) AS g, arr[g] AS elm ORDER BY g DESC)
    ) 
);
```

 array_rv and array_rv_coal should have same result.