### PR TITLE
string_t - rename GetDataUnsafe to GetData

### DIFF
--- a/extension/fts/fts-extension.cpp
+++ b/extension/fts/fts-extension.cpp
@@ -21,7 +21,7 @@ static void stem_function(DataChunk &args, ExpressionState &state, Vector &resul
 
 	BinaryExecutor::Execute<string_t, string_t, string_t>(
 	    input_vector, stemmer_vector, result, args.size(), [&](string_t input, string_t stemmer) {
-		    auto input_data = input.GetDataUnsafe();
+		    auto input_data = input.GetData();
 		    auto input_size = input.GetSize();
 
 		    if (stemmer.GetString() == "none") {

--- a/extension/icu/icu-extension.cpp
+++ b/extension/icu/icu-extension.cpp
@@ -69,7 +69,7 @@ struct IcuBindData : public FunctionData {
 static int32_t ICUGetSortKey(icu::Collator &collator, string_t input, duckdb::unique_ptr<char[]> &buffer,
                              int32_t &buffer_size) {
 	int32_t string_size =
-	    collator.getSortKey(icu::UnicodeString::fromUTF8(icu::StringPiece(input.GetDataUnsafe(), input.GetSize())),
+	    collator.getSortKey(icu::UnicodeString::fromUTF8(icu::StringPiece(input.GetData(), input.GetSize())),
 	                        (uint8_t *)buffer.get(), buffer_size);
 	if (string_size > buffer_size) {
 		// have to resize the buffer
@@ -77,7 +77,7 @@ static int32_t ICUGetSortKey(icu::Collator &collator, string_t input, duckdb::un
 		buffer = duckdb::unique_ptr<char[]>(new char[buffer_size]);
 
 		string_size =
-		    collator.getSortKey(icu::UnicodeString::fromUTF8(icu::StringPiece(input.GetDataUnsafe(), input.GetSize())),
+		    collator.getSortKey(icu::UnicodeString::fromUTF8(icu::StringPiece(input.GetData(), input.GetSize())),
 		                        (uint8_t *)buffer.get(), buffer_size);
 	}
 	return string_size;

--- a/extension/icu/icu-strptime.cpp
+++ b/extension/icu/icu-strptime.cpp
@@ -255,7 +255,7 @@ struct ICUStrptime : public ICUDateFunc {
 		UnaryExecutor::ExecuteWithNulls<string_t, timestamp_t>(
 		    source, result, count, [&](string_t input, ValidityMask &mask, idx_t idx) {
 			    timestamp_t result;
-			    const auto str = input.GetDataUnsafe();
+			    const auto str = input.GetData();
 			    const auto len = input.GetSize();
 			    string_t tz(nullptr, 0);
 			    bool has_offset = false;

--- a/extension/inet/ipaddress.cpp
+++ b/extension/inet/ipaddress.cpp
@@ -24,7 +24,7 @@ static bool IPAddressError(string_t input, string *error_message, string error) 
 }
 
 bool IPAddress::TryParse(string_t input, IPAddress &result, string *error_message) {
-	auto data = input.GetDataUnsafe();
+	auto data = input.GetData();
 	auto size = input.GetSize();
 	idx_t c = 0;
 	idx_t number_count = 0;

--- a/extension/json/include/json_common.hpp
+++ b/extension/json/include/json_common.hpp
@@ -228,7 +228,7 @@ public:
 	//! Get JSON value using JSON path query (safe, checks the path query)
 	template <class YYJSON_VAL_T>
 	static inline YYJSON_VAL_T *GetPointer(YYJSON_VAL_T *root, const string_t &path_str) {
-		auto ptr = path_str.GetDataUnsafe();
+		auto ptr = path_str.GetData();
 		auto len = path_str.GetSize();
 		if (len == 0) {
 			return GetPointerUnsafe<YYJSON_VAL_T>(root, ptr, len);

--- a/extension/json/json_functions.cpp
+++ b/extension/json/json_functions.cpp
@@ -19,7 +19,7 @@ static void CheckPath(const Value &path_val, string &path, size_t &len) {
 	}
 	auto path_str = path_str_val.GetValueUnsafe<string_t>();
 	len = path_str.GetSize();
-	auto ptr = path_str.GetDataUnsafe();
+	auto ptr = path_str.GetData();
 	// Empty strings and invalid $ paths yield an error
 	if (len == 0) {
 		throw InvalidInputException("Empty JSON path");
@@ -213,7 +213,7 @@ static bool CastVarcharToJSON(Vector &source, Vector &result, idx_t count, CastP
 	bool success = true;
 	UnaryExecutor::ExecuteWithNulls<string_t, string_t>(
 	    source, result, count, [&](string_t input, ValidityMask &mask, idx_t idx) {
-		    auto data = (char *)(input.GetDataUnsafe());
+		    auto data = (char *)(input.GetData());
 		    auto length = input.GetSize();
 		    yyjson_read_err error;
 

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -185,7 +185,7 @@ inline yyjson_mut_val *CreateJSONValue(yyjson_mut_doc *doc, const double &value)
 
 template <>
 inline yyjson_mut_val *CreateJSONValue(yyjson_mut_doc *doc, const string_t &value) {
-	return yyjson_mut_strn(doc, value.GetDataUnsafe(), value.GetSize());
+	return yyjson_mut_strn(doc, value.GetData(), value.GetSize());
 }
 
 inline yyjson_mut_val *CreateJSONValueFromJSON(yyjson_mut_doc *doc, const string_t &value) {

--- a/extension/json/json_functions/json_transform.cpp
+++ b/extension/json/json_functions/json_transform.cpp
@@ -98,7 +98,7 @@ static duckdb::unique_ptr<FunctionData> JSONTransformBind(ClientContext &context
 		auto doc = JSONCommon::ReadDocumentUnsafe(structure_string, JSONCommon::READ_FLAG,
 		                                          json_allocator.GetYYJSONAllocator(), &err);
 		if (err.code != YYJSON_READ_SUCCESS) {
-			JSONCommon::ThrowParseError(structure_string.GetDataUnsafe(), structure_string.GetSize(), err);
+			JSONCommon::ThrowParseError(structure_string.GetData(), structure_string.GetSize(), err);
 		}
 		bound_function.return_type = StructureStringToType(doc->root, context);
 	}

--- a/extension/json/json_serializer.cpp
+++ b/extension/json/json_serializer.cpp
@@ -227,7 +227,7 @@ void JsonSerializer::WriteValue(const string_t value) {
 	if (skip_if_empty && value.GetSize() == 0) {
 		return;
 	}
-	auto val = yyjson_mut_strncpy(doc, value.GetDataUnsafe(), value.GetSize());
+	auto val = yyjson_mut_strncpy(doc, value.GetData(), value.GetSize());
 	PushValue(val);
 }
 

--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -685,7 +685,7 @@ void StringColumnReader::PrepareDeltaByteArray(ResizeableBuffer &buffer) {
 			if (i == 0 || prefix_data[i] > string_data[i - 1].GetSize()) {
 				throw std::runtime_error("DELTA_BYTE_ARRAY - prefix is out of range - corrupt file?");
 			}
-			memcpy(result_data, string_data[i - 1].GetDataUnsafe(), prefix_data[i]);
+			memcpy(result_data, string_data[i - 1].GetData(), prefix_data[i]);
 		}
 		memcpy(result_data + prefix_data[i], buffer.ptr, suffix_data[i]);
 		buffer.inc(suffix_data[i]);

--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -1342,7 +1342,7 @@ public:
 				}
 				stats.Update(ptr[r]);
 				temp_writer.Write<uint32_t>(ptr[r].GetSize());
-				temp_writer.WriteData((const_data_ptr_t)ptr[r].GetDataUnsafe(), ptr[r].GetSize());
+				temp_writer.WriteData((const_data_ptr_t)ptr[r].GetData(), ptr[r].GetSize());
 			}
 		}
 	}
@@ -1401,7 +1401,7 @@ public:
 			stats.Update(value);
 			// write this string value to the dictionary
 			temp_writer->Write<uint32_t>(value.GetSize());
-			temp_writer->WriteData((const_data_ptr_t)(value.GetDataUnsafe()), value.GetSize());
+			temp_writer->WriteData((const_data_ptr_t)(value.GetData()), value.GetSize());
 		}
 		// flush the dictionary page and add it to the to-be-written pages
 		WriteDictionary(state, std::move(temp_writer), values.size());
@@ -1528,7 +1528,7 @@ public:
 			stats.Update(string_values[r]);
 			// write this string value to the dictionary
 			temp_writer->Write<uint32_t>(string_values[r].GetSize());
-			temp_writer->WriteData((const_data_ptr_t)string_values[r].GetDataUnsafe(), string_values[r].GetSize());
+			temp_writer->WriteData((const_data_ptr_t)string_values[r].GetData(), string_values[r].GetSize());
 		}
 		// flush the dictionary page and add it to the to-be-written pages
 		WriteDictionary(state, std::move(temp_writer), enum_count);

--- a/src/common/arrow/arrow_appender.cpp
+++ b/src/common/arrow/arrow_appender.cpp
@@ -195,7 +195,7 @@ struct ArrowEnumData : public ArrowScalarBaseData<TGT> {
 		return input.GetSize();
 	}
 	static void WriteData(data_ptr_t target, string_t input) {
-		memcpy(target, input.GetDataUnsafe(), input.GetSize());
+		memcpy(target, input.GetData(), input.GetSize());
 	}
 	static void EnumAppendVector(ArrowAppendData &append_data, const Vector &input, idx_t size) {
 		D_ASSERT(input.GetVectorType() == VectorType::FLAT_VECTOR);
@@ -301,7 +301,7 @@ struct ArrowVarcharConverter {
 
 	template <class SRC>
 	static void WriteData(data_ptr_t target, SRC input) {
-		memcpy(target, input.GetDataUnsafe(), input.GetSize());
+		memcpy(target, input.GetData(), input.GetSize());
 	}
 };
 

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -1097,7 +1097,7 @@ static inline bool TrySimpleIntegerCast(const char *buf, idx_t len, T &result, b
 
 template <>
 bool TryCast::Operation(string_t input, bool &result, bool strict) {
-	auto input_data = input.GetDataUnsafe();
+	auto input_data = input.GetData();
 	auto input_size = input.GetSize();
 
 	switch (input_size) {
@@ -1141,36 +1141,36 @@ bool TryCast::Operation(string_t input, bool &result, bool strict) {
 }
 template <>
 bool TryCast::Operation(string_t input, int8_t &result, bool strict) {
-	return TrySimpleIntegerCast<int8_t>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+	return TrySimpleIntegerCast<int8_t>(input.GetData(), input.GetSize(), result, strict);
 }
 template <>
 bool TryCast::Operation(string_t input, int16_t &result, bool strict) {
-	return TrySimpleIntegerCast<int16_t>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+	return TrySimpleIntegerCast<int16_t>(input.GetData(), input.GetSize(), result, strict);
 }
 template <>
 bool TryCast::Operation(string_t input, int32_t &result, bool strict) {
-	return TrySimpleIntegerCast<int32_t>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+	return TrySimpleIntegerCast<int32_t>(input.GetData(), input.GetSize(), result, strict);
 }
 template <>
 bool TryCast::Operation(string_t input, int64_t &result, bool strict) {
-	return TrySimpleIntegerCast<int64_t>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+	return TrySimpleIntegerCast<int64_t>(input.GetData(), input.GetSize(), result, strict);
 }
 
 template <>
 bool TryCast::Operation(string_t input, uint8_t &result, bool strict) {
-	return TrySimpleIntegerCast<uint8_t, false>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+	return TrySimpleIntegerCast<uint8_t, false>(input.GetData(), input.GetSize(), result, strict);
 }
 template <>
 bool TryCast::Operation(string_t input, uint16_t &result, bool strict) {
-	return TrySimpleIntegerCast<uint16_t, false>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+	return TrySimpleIntegerCast<uint16_t, false>(input.GetData(), input.GetSize(), result, strict);
 }
 template <>
 bool TryCast::Operation(string_t input, uint32_t &result, bool strict) {
-	return TrySimpleIntegerCast<uint32_t, false>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+	return TrySimpleIntegerCast<uint32_t, false>(input.GetData(), input.GetSize(), result, strict);
 }
 template <>
 bool TryCast::Operation(string_t input, uint64_t &result, bool strict) {
-	return TrySimpleIntegerCast<uint64_t, false>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+	return TrySimpleIntegerCast<uint64_t, false>(input.GetData(), input.GetSize(), result, strict);
 }
 
 template <class T, char decimal_separator = '.'>
@@ -1213,17 +1213,17 @@ static bool TryDoubleCast(const char *buf, idx_t len, T &result, bool strict) {
 
 template <>
 bool TryCast::Operation(string_t input, float &result, bool strict) {
-	return TryDoubleCast<float>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+	return TryDoubleCast<float>(input.GetData(), input.GetSize(), result, strict);
 }
 
 template <>
 bool TryCast::Operation(string_t input, double &result, bool strict) {
-	return TryDoubleCast<double>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+	return TryDoubleCast<double>(input.GetData(), input.GetSize(), result, strict);
 }
 
 template <>
 bool TryCastErrorMessageCommaSeparated::Operation(string_t input, float &result, string *error_message, bool strict) {
-	if (!TryDoubleCast<float, ','>(input.GetDataUnsafe(), input.GetSize(), result, strict)) {
+	if (!TryDoubleCast<float, ','>(input.GetData(), input.GetSize(), result, strict)) {
 		HandleCastError::AssignError(StringUtil::Format("Could not cast string to float: \"%s\"", input.GetString()),
 		                             error_message);
 		return false;
@@ -1233,7 +1233,7 @@ bool TryCastErrorMessageCommaSeparated::Operation(string_t input, float &result,
 
 template <>
 bool TryCastErrorMessageCommaSeparated::Operation(string_t input, double &result, string *error_message, bool strict) {
-	if (!TryDoubleCast<double, ','>(input.GetDataUnsafe(), input.GetSize(), result, strict)) {
+	if (!TryDoubleCast<double, ','>(input.GetData(), input.GetSize(), result, strict)) {
 		HandleCastError::AssignError(StringUtil::Format("Could not cast string to double: \"%s\"", input.GetString()),
 		                             error_message);
 		return false;
@@ -1518,12 +1518,12 @@ template <>
 bool TryCast::Operation(string_t input, date_t &result, bool strict) {
 	idx_t pos;
 	bool special = false;
-	return Date::TryConvertDate(input.GetDataUnsafe(), input.GetSize(), pos, result, special, strict);
+	return Date::TryConvertDate(input.GetData(), input.GetSize(), pos, result, special, strict);
 }
 
 template <>
 date_t Cast::Operation(string_t input) {
-	return Date::FromCString(input.GetDataUnsafe(), input.GetSize());
+	return Date::FromCString(input.GetData(), input.GetSize());
 }
 
 //===--------------------------------------------------------------------===//
@@ -1541,12 +1541,12 @@ bool TryCastErrorMessage::Operation(string_t input, dtime_t &result, string *err
 template <>
 bool TryCast::Operation(string_t input, dtime_t &result, bool strict) {
 	idx_t pos;
-	return Time::TryConvertTime(input.GetDataUnsafe(), input.GetSize(), pos, result, strict);
+	return Time::TryConvertTime(input.GetData(), input.GetSize(), pos, result, strict);
 }
 
 template <>
 dtime_t Cast::Operation(string_t input) {
-	return Time::FromCString(input.GetDataUnsafe(), input.GetSize());
+	return Time::FromCString(input.GetData(), input.GetSize());
 }
 
 //===--------------------------------------------------------------------===//
@@ -1554,7 +1554,7 @@ dtime_t Cast::Operation(string_t input) {
 //===--------------------------------------------------------------------===//
 template <>
 bool TryCastErrorMessage::Operation(string_t input, timestamp_t &result, string *error_message, bool strict) {
-	auto cast_result = Timestamp::TryConvertTimestamp(input.GetDataUnsafe(), input.GetSize(), result);
+	auto cast_result = Timestamp::TryConvertTimestamp(input.GetData(), input.GetSize(), result);
 	if (cast_result == TimestampCastResult::SUCCESS) {
 		return true;
 	}
@@ -1568,13 +1568,12 @@ bool TryCastErrorMessage::Operation(string_t input, timestamp_t &result, string 
 
 template <>
 bool TryCast::Operation(string_t input, timestamp_t &result, bool strict) {
-	return Timestamp::TryConvertTimestamp(input.GetDataUnsafe(), input.GetSize(), result) ==
-	       TimestampCastResult::SUCCESS;
+	return Timestamp::TryConvertTimestamp(input.GetData(), input.GetSize(), result) == TimestampCastResult::SUCCESS;
 }
 
 template <>
 timestamp_t Cast::Operation(string_t input) {
-	return Timestamp::FromCString(input.GetDataUnsafe(), input.GetSize());
+	return Timestamp::FromCString(input.GetData(), input.GetSize());
 }
 
 //===--------------------------------------------------------------------===//
@@ -1582,7 +1581,7 @@ timestamp_t Cast::Operation(string_t input) {
 //===--------------------------------------------------------------------===//
 template <>
 bool TryCastErrorMessage::Operation(string_t input, interval_t &result, string *error_message, bool strict) {
-	return Interval::FromCString(input.GetDataUnsafe(), input.GetSize(), result, error_message, strict);
+	return Interval::FromCString(input.GetData(), input.GetSize(), result, error_message, strict);
 }
 
 //===--------------------------------------------------------------------===//
@@ -1715,8 +1714,8 @@ struct HugeIntegerCastOperation {
 template <>
 bool TryCast::Operation(string_t input, hugeint_t &result, bool strict) {
 	HugeIntCastData data;
-	if (!TryIntegerCast<HugeIntCastData, true, true, HugeIntegerCastOperation>(input.GetDataUnsafe(), input.GetSize(),
-	                                                                           data, strict)) {
+	if (!TryIntegerCast<HugeIntCastData, true, true, HugeIntegerCastOperation>(input.GetData(), input.GetSize(), data,
+	                                                                           strict)) {
 		return false;
 	}
 	result = data.hugeint;
@@ -1916,7 +1915,7 @@ bool TryDecimalStringCast(string_t input, T &result, string *error_message, uint
 	state.round_set = false;
 	state.should_round = false;
 	if (!TryIntegerCast<DecimalCastData<T>, true, true, DecimalCastOperation, false, decimal_separator>(
-	        input.GetDataUnsafe(), input.GetSize(), state, false)) {
+	        input.GetData(), input.GetSize(), state, false)) {
 		string error = StringUtil::Format("Could not convert string \"%s\" to DECIMAL(%d,%d)", input.GetString(),
 		                                  (int)width, (int)scale);
 		HandleCastError::AssignError(error, error_message);

--- a/src/common/row_operations/row_heap_scatter.cpp
+++ b/src/common/row_operations/row_heap_scatter.cpp
@@ -163,7 +163,7 @@ static void HeapScatterStringVector(Vector &v, idx_t vcount, const SelectionVect
 				Store<uint32_t>(string_entry.GetSize(), key_locations[i]);
 				key_locations[i] += sizeof(uint32_t);
 				// store the string
-				memcpy(key_locations[i], string_entry.GetDataUnsafe(), string_entry.GetSize());
+				memcpy(key_locations[i], string_entry.GetData(), string_entry.GetSize());
 				key_locations[i] += string_entry.GetSize();
 			}
 		}
@@ -181,7 +181,7 @@ static void HeapScatterStringVector(Vector &v, idx_t vcount, const SelectionVect
 				Store<uint32_t>(string_entry.GetSize(), key_locations[i]);
 				key_locations[i] += sizeof(uint32_t);
 				// store the string
-				memcpy(key_locations[i], string_entry.GetDataUnsafe(), string_entry.GetSize());
+				memcpy(key_locations[i], string_entry.GetData(), string_entry.GetSize());
 				key_locations[i] += string_entry.GetSize();
 			} else {
 				// set the validitymask

--- a/src/common/row_operations/row_scatter.cpp
+++ b/src/common/row_operations/row_scatter.cpp
@@ -82,7 +82,7 @@ static void ScatterStringVector(UnifiedVectorFormat &col, Vector &rows, data_ptr
 		} else {
 			const auto &str = string_data[col_idx];
 			string_t inserted((const char *)str_locations[i], str.GetSize());
-			memcpy(inserted.GetDataWriteable(), str.GetDataUnsafe(), str.GetSize());
+			memcpy(inserted.GetDataWriteable(), str.GetData(), str.GetSize());
 			str_locations[i] += str.GetSize();
 			inserted.Finalize();
 			Store<string_t>(inserted, row + col_offset);

--- a/src/common/types/bit.cpp
+++ b/src/common/types/bit.cpp
@@ -20,7 +20,7 @@ idx_t Bit::ComputeBitstringLen(idx_t len) {
 }
 
 static inline idx_t GetBitPadding(const string_t &bit_string) {
-	auto data = (const_data_ptr_t)bit_string.GetDataUnsafe();
+	auto data = (const_data_ptr_t)bit_string.GetData();
 	D_ASSERT(idx_t(data[0]) <= 8);
 	return data[0];
 }
@@ -46,7 +46,7 @@ void Bit::Finalize(string_t &str) {
 
 void Bit::SetEmptyBitString(string_t &target, string_t &input) {
 	char *res_buf = target.GetDataWriteable();
-	const char *buf = input.GetDataUnsafe();
+	const char *buf = input.GetData();
 	memset(res_buf, 0, input.GetSize());
 	res_buf[0] = buf[0];
 	Bit::Finalize(target);
@@ -61,7 +61,7 @@ void Bit::SetEmptyBitString(string_t &target, idx_t len) {
 
 // **** casting functions ****
 void Bit::ToString(string_t bits, char *output) {
-	auto data = (const_data_ptr_t)bits.GetDataUnsafe();
+	auto data = (const_data_ptr_t)bits.GetData();
 	auto len = bits.GetSize();
 
 	idx_t padding = GetBitPadding(bits);
@@ -84,7 +84,7 @@ string Bit::ToString(string_t str) {
 }
 
 bool Bit::TryGetBitStringSize(string_t str, idx_t &str_len, string *error_message) {
-	auto data = (const_data_ptr_t)str.GetDataUnsafe();
+	auto data = (const_data_ptr_t)str.GetData();
 	auto len = str.GetSize();
 	str_len = 0;
 	for (idx_t i = 0; i < len; i++) {
@@ -107,7 +107,7 @@ bool Bit::TryGetBitStringSize(string_t str, idx_t &str_len, string *error_messag
 }
 
 void Bit::ToBit(string_t str, string_t &output_str) {
-	auto data = (const_data_ptr_t)str.GetDataUnsafe();
+	auto data = (const_data_ptr_t)str.GetData();
 	auto len = str.GetSize();
 	auto output = output_str.GetDataWriteable();
 
@@ -149,7 +149,7 @@ string Bit::ToBit(string_t str) {
 // **** scalar functions ****
 void Bit::BitString(const string_t &input, const idx_t &bit_length, string_t &result) {
 	char *res_buf = result.GetDataWriteable();
-	const char *buf = input.GetDataUnsafe();
+	const char *buf = input.GetData();
 
 	auto padding = ComputePadding(bit_length);
 	res_buf[0] = padding;
@@ -174,7 +174,7 @@ idx_t Bit::OctetLength(string_t bits) {
 
 idx_t Bit::BitCount(string_t bits) {
 	idx_t count = 0;
-	const char *buf = bits.GetDataUnsafe();
+	const char *buf = bits.GetData();
 	for (idx_t byte_idx = 1; byte_idx < OctetLength(bits) + 1; byte_idx++) {
 		for (idx_t bit_idx = 0; bit_idx < 8; bit_idx++) {
 			count += (buf[byte_idx] & (1 << bit_idx)) ? 1 : 0;
@@ -184,7 +184,7 @@ idx_t Bit::BitCount(string_t bits) {
 }
 
 idx_t Bit::BitPosition(string_t substring, string_t bits) {
-	const char *buf = bits.GetDataUnsafe();
+	const char *buf = bits.GetData();
 	auto len = bits.GetSize();
 	auto substr_len = BitLength(substring);
 	idx_t substr_idx = 0;
@@ -226,7 +226,7 @@ idx_t Bit::GetBitIndex(idx_t n) {
 }
 
 idx_t Bit::GetBitInternal(string_t bit_string, idx_t n) {
-	const char *buf = bit_string.GetDataUnsafe();
+	const char *buf = bit_string.GetData();
 	auto idx = Bit::GetBitIndex(n);
 	D_ASSERT(idx < bit_string.GetSize());
 	char byte = buf[idx] >> (7 - (n % 8));
@@ -254,7 +254,7 @@ void Bit::SetBitInternal(string_t &bit_string, idx_t n, idx_t new_value) {
 // **** BITWISE operators ****
 void Bit::RightShift(const string_t &bit_string, const idx_t &shift, string_t &result) {
 	char *res_buf = result.GetDataWriteable();
-	const char *buf = bit_string.GetDataUnsafe();
+	const char *buf = bit_string.GetData();
 	res_buf[0] = buf[0];
 	for (idx_t i = 0; i < Bit::BitLength(result); i++) {
 		if (i < shift) {
@@ -269,7 +269,7 @@ void Bit::RightShift(const string_t &bit_string, const idx_t &shift, string_t &r
 
 void Bit::LeftShift(const string_t &bit_string, const idx_t &shift, string_t &result) {
 	char *res_buf = result.GetDataWriteable();
-	const char *buf = bit_string.GetDataUnsafe();
+	const char *buf = bit_string.GetData();
 	res_buf[0] = buf[0];
 	for (idx_t i = 0; i < Bit::BitLength(bit_string); i++) {
 		if (i < (Bit::BitLength(bit_string) - shift)) {
@@ -289,8 +289,8 @@ void Bit::BitwiseAnd(const string_t &rhs, const string_t &lhs, string_t &result)
 	}
 
 	char *buf = result.GetDataWriteable();
-	const char *r_buf = rhs.GetDataUnsafe();
-	const char *l_buf = lhs.GetDataUnsafe();
+	const char *r_buf = rhs.GetData();
+	const char *l_buf = lhs.GetData();
 
 	buf[0] = l_buf[0];
 	for (idx_t i = 1; i < lhs.GetSize(); i++) {
@@ -306,8 +306,8 @@ void Bit::BitwiseOr(const string_t &rhs, const string_t &lhs, string_t &result) 
 	}
 
 	char *buf = result.GetDataWriteable();
-	const char *r_buf = rhs.GetDataUnsafe();
-	const char *l_buf = lhs.GetDataUnsafe();
+	const char *r_buf = rhs.GetData();
+	const char *l_buf = lhs.GetData();
 
 	buf[0] = l_buf[0];
 	for (idx_t i = 1; i < lhs.GetSize(); i++) {
@@ -323,8 +323,8 @@ void Bit::BitwiseXor(const string_t &rhs, const string_t &lhs, string_t &result)
 	}
 
 	char *buf = result.GetDataWriteable();
-	const char *r_buf = rhs.GetDataUnsafe();
-	const char *l_buf = lhs.GetDataUnsafe();
+	const char *r_buf = rhs.GetData();
+	const char *l_buf = lhs.GetData();
 
 	buf[0] = l_buf[0];
 	for (idx_t i = 1; i < lhs.GetSize(); i++) {
@@ -335,7 +335,7 @@ void Bit::BitwiseXor(const string_t &rhs, const string_t &lhs, string_t &result)
 
 void Bit::BitwiseNot(const string_t &input, string_t &result) {
 	char *result_buf = result.GetDataWriteable();
-	const char *buf = input.GetDataUnsafe();
+	const char *buf = input.GetData();
 
 	result_buf[0] = buf[0];
 	for (idx_t i = 1; i < input.GetSize(); i++) {

--- a/src/common/types/blob.cpp
+++ b/src/common/types/blob.cpp
@@ -24,7 +24,7 @@ bool IsRegularCharacter(data_t c) {
 }
 
 idx_t Blob::GetStringSize(string_t blob) {
-	auto data = (const_data_ptr_t)blob.GetDataUnsafe();
+	auto data = (const_data_ptr_t)blob.GetData();
 	auto len = blob.GetSize();
 	idx_t str_len = 0;
 	for (idx_t i = 0; i < len; i++) {
@@ -40,7 +40,7 @@ idx_t Blob::GetStringSize(string_t blob) {
 }
 
 void Blob::ToString(string_t blob, char *output) {
-	auto data = (const_data_ptr_t)blob.GetDataUnsafe();
+	auto data = (const_data_ptr_t)blob.GetData();
 	auto len = blob.GetSize();
 	idx_t str_idx = 0;
 	for (idx_t i = 0; i < len; i++) {
@@ -70,7 +70,7 @@ string Blob::ToString(string_t blob) {
 }
 
 bool Blob::TryGetBlobSize(string_t str, idx_t &str_len, string *error_message) {
-	auto data = (const_data_ptr_t)str.GetDataUnsafe();
+	auto data = (const_data_ptr_t)str.GetData();
 	auto len = str.GetSize();
 	str_len = 0;
 	for (idx_t i = 0; i < len; i++) {
@@ -112,7 +112,7 @@ idx_t Blob::GetBlobSize(string_t str) {
 }
 
 void Blob::ToBlob(string_t str, data_ptr_t output) {
-	auto data = (const_data_ptr_t)str.GetDataUnsafe();
+	auto data = (const_data_ptr_t)str.GetData();
 	auto len = str.GetSize();
 	idx_t blob_idx = 0;
 	for (idx_t i = 0; i < len; i++) {
@@ -149,7 +149,7 @@ idx_t Blob::ToBase64Size(string_t blob) {
 }
 
 void Blob::ToBase64(string_t blob, char *output) {
-	auto input_data = (const_data_ptr_t)blob.GetDataUnsafe();
+	auto input_data = (const_data_ptr_t)blob.GetData();
 	auto input_size = blob.GetSize();
 	idx_t out_idx = 0;
 	idx_t i;
@@ -192,7 +192,7 @@ static constexpr int BASE64_DECODING_TABLE[256] = {
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
 
 idx_t Blob::FromBase64Size(string_t str) {
-	auto input_data = str.GetDataUnsafe();
+	auto input_data = str.GetData();
 	auto input_size = str.GetSize();
 	if (input_size % 4 != 0) {
 		// valid base64 needs to always be cleanly divisible by 4
@@ -239,7 +239,7 @@ uint32_t DecodeBase64Bytes(const string_t &str, const_data_ptr_t input_data, idx
 
 void Blob::FromBase64(string_t str, data_ptr_t output, idx_t output_size) {
 	D_ASSERT(output_size == FromBase64Size(str));
-	auto input_data = (const_data_ptr_t)str.GetDataUnsafe();
+	auto input_data = (const_data_ptr_t)str.GetData();
 	auto input_size = str.GetSize();
 	if (input_size == 0) {
 		return;

--- a/src/common/types/column/column_data_allocator.cpp
+++ b/src/common/types/column/column_data_allocator.cpp
@@ -197,7 +197,7 @@ void ColumnDataAllocator::UnswizzlePointers(ChunkManagementState &state, Vector 
 	D_ASSERT(i < end);
 
 	auto base_ptr = (char *)GetDataPointer(state, block_id, offset);
-	if (strings[i].GetDataUnsafe() == base_ptr) {
+	if (strings[i].GetData() == base_ptr) {
 		// pointers are still valid
 		return;
 	}

--- a/src/common/types/column/column_data_collection.cpp
+++ b/src/common/types/column/column_data_collection.cpp
@@ -519,7 +519,7 @@ void ColumnDataCopy<string_t>(ColumnDataMetaData &meta_data, const UnifiedVector
 				target_entry = source_entry;
 			} else {
 				D_ASSERT(heap_ptr != nullptr);
-				memcpy(heap_ptr, source_entry.GetDataUnsafe(), source_entry.GetSize());
+				memcpy(heap_ptr, source_entry.GetData(), source_entry.GetSize());
 				target_entry = string_t((const char *)heap_ptr, source_entry.GetSize());
 				heap_ptr += source_entry.GetSize();
 			}

--- a/src/common/types/hash.cpp
+++ b/src/common/types/hash.cpp
@@ -64,7 +64,7 @@ hash_t Hash(const char *str) {
 
 template <>
 hash_t Hash(string_t val) {
-	return Hash(val.GetDataUnsafe(), val.GetSize());
+	return Hash(val.GetData(), val.GetSize());
 }
 
 template <>

--- a/src/common/types/hyperloglog.cpp
+++ b/src/common/types/hyperloglog.cpp
@@ -169,7 +169,7 @@ inline uint64_t HashOtherSize(const data_ptr_t &data, const idx_t &len) {
 
 template <>
 inline uint64_t TemplatedHash(const string_t &elem) {
-	data_ptr_t data = (data_ptr_t)elem.GetDataUnsafe();
+	data_ptr_t data = (data_ptr_t)elem.GetData();
 	const auto &len = elem.GetSize();
 	uint64_t h = 0;
 	for (idx_t i = 0; i + sizeof(uint64_t) <= len; i += sizeof(uint64_t)) {

--- a/src/common/types/row/tuple_data_scatter_gather.cpp
+++ b/src/common/types/row/tuple_data_scatter_gather.cpp
@@ -28,7 +28,7 @@ inline void TupleDataValueStore(const string_t &source, const data_ptr_t &row_lo
 	if (source.IsInlined()) {
 		Store<string_t>(source, row_location + offset_in_row);
 	} else {
-		memcpy(heap_location, source.GetDataUnsafe(), source.GetSize());
+		memcpy(heap_location, source.GetData(), source.GetSize());
 		Store<string_t>(string_t((const char *)heap_location, source.GetSize()), row_location + offset_in_row);
 		heap_location += source.GetSize();
 	}
@@ -44,7 +44,7 @@ template <>
 inline void TupleDataWithinListValueStore(const string_t &source, const data_ptr_t &location,
                                           data_ptr_t &heap_location) {
 	Store<uint32_t>(source.GetSize(), location);
-	memcpy(heap_location, source.GetDataUnsafe(), source.GetSize());
+	memcpy(heap_location, source.GetData(), source.GetSize());
 	heap_location += source.GetSize();
 }
 

--- a/src/common/types/string_heap.cpp
+++ b/src/common/types/string_heap.cpp
@@ -34,7 +34,7 @@ string_t StringHeap::AddString(const string &data) {
 }
 
 string_t StringHeap::AddString(const string_t &data) {
-	return AddString(data.GetDataUnsafe(), data.GetSize());
+	return AddString(data.GetData(), data.GetSize());
 }
 
 string_t StringHeap::AddBlob(const char *data, idx_t len) {
@@ -46,7 +46,7 @@ string_t StringHeap::AddBlob(const char *data, idx_t len) {
 }
 
 string_t StringHeap::AddBlob(const string_t &data) {
-	return AddBlob(data.GetDataUnsafe(), data.GetSize());
+	return AddBlob(data.GetData(), data.GetSize());
 }
 
 string_t StringHeap::EmptyString(idx_t len) {

--- a/src/common/types/string_type.cpp
+++ b/src/common/types/string_type.cpp
@@ -7,7 +7,7 @@
 namespace duckdb {
 
 void string_t::Verify() const {
-	auto dataptr = GetDataUnsafe();
+	auto dataptr = GetData();
 	(void)dataptr;
 	D_ASSERT(dataptr);
 
@@ -22,7 +22,7 @@ void string_t::Verify() const {
 	}
 	// verify that for strings with length <= INLINE_LENGTH, the rest of the string is zero
 	for (idx_t i = GetSize(); i < INLINE_LENGTH; i++) {
-		D_ASSERT(GetDataUnsafe()[i] == '\0');
+		D_ASSERT(GetData()[i] == '\0');
 	}
 }
 

--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -102,7 +102,7 @@ TimestampCastResult Timestamp::TryConvertTimestamp(const char *str, idx_t len, t
 	}
 	if (tz.GetSize() == 3) {
 		// we can ONLY handle UTC without ICU being loaded
-		auto tz_ptr = tz.GetDataUnsafe();
+		auto tz_ptr = tz.GetData();
 		if ((tz_ptr[0] == 'u' || tz_ptr[0] == 'U') && (tz_ptr[1] == 't' || tz_ptr[1] == 'T') &&
 		    (tz_ptr[2] == 'c' || tz_ptr[2] == 'C')) {
 			return TimestampCastResult::SUCCESS;

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -456,7 +456,7 @@ Value Vector::GetValueInternal(const Vector &v_p, idx_t index_p) {
 		auto str_compressed = ((string_t *)data)[index];
 		Value result =
 		    FSSTPrimitives::DecompressValue(FSSTVector::GetDecoder(const_cast<Vector &>(*vector)),
-		                                    (unsigned char *)str_compressed.GetDataUnsafe(), str_compressed.GetSize());
+		                                    (unsigned char *)str_compressed.GetData(), str_compressed.GetSize());
 		return result;
 	}
 
@@ -543,11 +543,11 @@ Value Vector::GetValueInternal(const Vector &v_p, idx_t index_p) {
 	case LogicalTypeId::AGGREGATE_STATE:
 	case LogicalTypeId::BLOB: {
 		auto str = ((string_t *)data)[index];
-		return Value::BLOB((const_data_ptr_t)str.GetDataUnsafe(), str.GetSize());
+		return Value::BLOB((const_data_ptr_t)str.GetData(), str.GetSize());
 	}
 	case LogicalTypeId::BIT: {
 		auto str = ((string_t *)data)[index];
-		return Value::BIT((const_data_ptr_t)str.GetDataUnsafe(), str.GetSize());
+		return Value::BIT((const_data_ptr_t)str.GetData(), str.GetSize());
 	}
 	case LogicalTypeId::MAP: {
 		auto offlen = ((list_entry_t *)data)[index];
@@ -637,7 +637,7 @@ string Vector::ToString(idx_t count) const {
 		for (idx_t i = 0; i < count; i++) {
 			string_t compressed_string = ((string_t *)data)[i];
 			Value val = FSSTPrimitives::DecompressValue(FSSTVector::GetDecoder(const_cast<Vector &>(*this)),
-			                                            (unsigned char *)compressed_string.GetDataUnsafe(),
+			                                            (unsigned char *)compressed_string.GetData(),
 			                                            compressed_string.GetSize());
 			retval += GetValue(i).ToString() + (i == count - 1 ? "" : ", ");
 		}
@@ -924,7 +924,7 @@ void Vector::Serialize(idx_t count, Serializer &serializer) {
 			for (idx_t i = 0; i < count; i++) {
 				auto idx = vdata.sel->get_index(i);
 				auto source = !vdata.validity.RowIsValid(idx) ? NullValue<string_t>() : strings[idx];
-				serializer.WriteStringLen((const_data_ptr_t)source.GetDataUnsafe(), source.GetSize());
+				serializer.WriteStringLen((const_data_ptr_t)source.GetData(), source.GetSize());
 			}
 			break;
 		}
@@ -1321,7 +1321,7 @@ void Vector::Verify(Vector &vector_p, const SelectionVector &sel_p, idx_t count)
 			for (idx_t i = 0; i < count; i++) {
 				auto oidx = sel->get_index(i);
 				if (validity.RowIsValid(oidx)) {
-					auto buf = strings[oidx].GetDataUnsafe();
+					auto buf = strings[oidx].GetData();
 					D_ASSERT(*buf >= 0 && *buf < 8);
 					Bit::Verify(strings[oidx]);
 				}
@@ -1706,7 +1706,7 @@ void FSSTVector::DecompressVector(const Vector &src, Vector &dst, idx_t src_offs
 		string_t compressed_string = ldata[source_idx];
 		if (dst_mask.RowIsValid(target_idx) && compressed_string.GetSize() > 0) {
 			tdata[target_idx] = FSSTPrimitives::DecompressValue(FSSTVector::GetDecoder(src), dst,
-			                                                    (unsigned char *)compressed_string.GetDataUnsafe(),
+			                                                    (unsigned char *)compressed_string.GetData(),
 			                                                    compressed_string.GetSize());
 		} else {
 			tdata[target_idx] = string_t(nullptr, 0);

--- a/src/execution/index/art/art_key.cpp
+++ b/src/execution/index/art/art_key.cpp
@@ -18,7 +18,7 @@ template <>
 Key Key::CreateKey(ArenaAllocator &allocator, const LogicalType &type, string_t value) {
 	idx_t len = value.GetSize() + 1;
 	auto data = allocator.Allocate(len);
-	memcpy(data, value.GetDataUnsafe(), len - 1);
+	memcpy(data, value.GetData(), len - 1);
 
 	// FIXME: rethink this
 	if (type == LogicalType::BLOB || type == LogicalType::VARCHAR) {
@@ -43,7 +43,7 @@ template <>
 void Key::CreateKey(ArenaAllocator &allocator, const LogicalType &type, Key &key, string_t value) {
 	key.len = value.GetSize() + 1;
 	key.data = allocator.Allocate(key.len);
-	memcpy(key.data, value.GetDataUnsafe(), key.len - 1);
+	memcpy(key.data, value.GetData(), key.len - 1);
 
 	// FIXME: rethink this
 	if (type == LogicalType::BLOB || type == LogicalType::VARCHAR) {

--- a/src/execution/operator/persistent/base_csv_reader.cpp
+++ b/src/execution/operator/persistent/base_csv_reader.cpp
@@ -381,7 +381,7 @@ void BaseCSVReader::VerifyUTF8(idx_t col_idx, idx_t row_idx, DataChunk &chunk, i
 
 	auto parse_data = FlatVector::GetData<string_t>(chunk.data[col_idx]);
 	auto s = parse_data[row_idx];
-	auto utf_type = Utf8Proc::Analyze(s.GetDataUnsafe(), s.GetSize());
+	auto utf_type = Utf8Proc::Analyze(s.GetData(), s.GetSize());
 	if (utf_type == UnicodeType::INVALID) {
 		string col_name = to_string(col_idx);
 		if (col_idx < names.size()) {

--- a/src/execution/operator/schema/physical_create_type.cpp
+++ b/src/execution/operator/schema/physical_create_type.cpp
@@ -52,7 +52,7 @@ SinkResultType PhysicalCreateType::Sink(ExecutionContext &context, GlobalSinkSta
 			throw InvalidInputException("Attempted to create ENUM type with NULL value!");
 		}
 		result_ptr[gstate.size++] =
-		    StringVector::AddStringOrBlob(gstate.result, src_ptr[idx].GetDataUnsafe(), src_ptr[idx].GetSize());
+		    StringVector::AddStringOrBlob(gstate.result, src_ptr[idx].GetData(), src_ptr[idx].GetSize());
 	}
 	return SinkResultType::NEED_MORE_INPUT;
 }

--- a/src/function/aggregate/distributive/arg_min_max.cpp
+++ b/src/function/aggregate/distributive/arg_min_max.cpp
@@ -41,7 +41,7 @@ void ArgMinMaxStateBase::CreateValue(Vector *&value) {
 template <>
 void ArgMinMaxStateBase::DestroyValue(string_t &value) {
 	if (!value.IsInlined()) {
-		delete[] value.GetDataUnsafe();
+		delete[] value.GetData();
 	}
 }
 
@@ -62,7 +62,7 @@ void ArgMinMaxStateBase::AssignValue(string_t &target, string_t new_value, bool 
 		// non-inlined string, need to allocate space for it
 		auto len = new_value.GetSize();
 		auto ptr = new char[len];
-		memcpy(ptr, new_value.GetDataUnsafe(), len);
+		memcpy(ptr, new_value.GetData(), len);
 
 		target = string_t(ptr, len);
 	}

--- a/src/function/aggregate/distributive/bitagg.cpp
+++ b/src/function/aggregate/distributive/bitagg.cpp
@@ -130,7 +130,7 @@ struct BitStringBitwiseOperation : public BitwiseOperation {
 	template <class STATE>
 	static void Destroy(AggregateInputData &aggr_input_data, STATE *state) {
 		if (state->is_set && !state->value.IsInlined()) {
-			delete[] state->value.GetDataUnsafe();
+			delete[] state->value.GetData();
 		}
 	}
 
@@ -142,7 +142,7 @@ struct BitStringBitwiseOperation : public BitwiseOperation {
 		} else { // non-inlined string, need to allocate space for it
 			auto len = input.GetSize();
 			auto ptr = new char[len];
-			memcpy(ptr, input.GetDataUnsafe(), len);
+			memcpy(ptr, input.GetData(), len);
 
 			state->value = string_t(ptr, len);
 		}

--- a/src/function/aggregate/distributive/bitstring_agg.cpp
+++ b/src/function/aggregate/distributive/bitstring_agg.cpp
@@ -134,7 +134,7 @@ struct BitStringAggOperation {
 		} else { // non-inlined string, need to allocate space for it
 			auto len = input.GetSize();
 			auto ptr = new char[len];
-			memcpy(ptr, input.GetDataUnsafe(), len);
+			memcpy(ptr, input.GetData(), len);
 			state->value = string_t(ptr, len);
 		}
 	}
@@ -151,7 +151,7 @@ struct BitStringAggOperation {
 	template <class STATE>
 	static void Destroy(AggregateInputData &aggr_input_data, STATE *state) {
 		if (state->is_set && !state->value.IsInlined()) {
-			delete[] state->value.GetDataUnsafe();
+			delete[] state->value.GetData();
 		}
 	}
 

--- a/src/function/aggregate/distributive/first.cpp
+++ b/src/function/aggregate/distributive/first.cpp
@@ -86,7 +86,7 @@ struct FirstFunctionString : public FirstFunctionBase {
 				// non-inlined string, need to allocate space for it
 				auto len = value.GetSize();
 				auto ptr = new char[len];
-				memcpy(ptr, value.GetDataUnsafe(), len);
+				memcpy(ptr, value.GetData(), len);
 
 				state->value = string_t(ptr, len);
 			}
@@ -126,7 +126,7 @@ struct FirstFunctionString : public FirstFunctionBase {
 	template <class STATE>
 	static void Destroy(AggregateInputData &aggr_input_data, STATE *state) {
 		if (state->is_set && !state->is_null && !state->value.IsInlined()) {
-			delete[] state->value.GetDataUnsafe();
+			delete[] state->value.GetData();
 		}
 	}
 };

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -144,7 +144,7 @@ struct StringMinMaxBase : public MinMaxBase {
 	template <class STATE>
 	static void Destroy(AggregateInputData &aggr_input_data, STATE *state) {
 		if (state->isset && !state->value.IsInlined()) {
-			delete[] state->value.GetDataUnsafe();
+			delete[] state->value.GetData();
 		}
 	}
 
@@ -157,7 +157,7 @@ struct StringMinMaxBase : public MinMaxBase {
 			// non-inlined string, need to allocate space for it
 			auto len = input.GetSize();
 			auto ptr = new char[len];
-			memcpy(ptr, input.GetDataUnsafe(), len);
+			memcpy(ptr, input.GetData(), len);
 
 			state->value = string_t(ptr, len);
 		}

--- a/src/function/aggregate/distributive/string_agg.cpp
+++ b/src/function/aggregate/distributive/string_agg.cpp
@@ -90,7 +90,7 @@ struct StringAggFunction {
 
 	static inline void PerformOperation(StringAggState *state, string_t str, FunctionData *data_p) {
 		auto &data = data_p->Cast<StringAggBindData>();
-		PerformOperation(state, str.GetDataUnsafe(), data.sep.c_str(), str.GetSize(), data.sep.size());
+		PerformOperation(state, str.GetData(), data.sep.c_str(), str.GetSize(), data.sep.size());
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>

--- a/src/function/cast/list_casts.cpp
+++ b/src/function/cast/list_casts.cpp
@@ -106,7 +106,7 @@ static bool ListToVarcharCast(Vector &source, Vector &result, idx_t count, CastP
 			}
 			if (child_validity.RowIsValid(idx)) {
 				auto len = child_data[idx].GetSize();
-				memcpy(dataptr + offset, child_data[idx].GetDataUnsafe(), len);
+				memcpy(dataptr + offset, child_data[idx].GetData(), len);
 				offset += len;
 			} else {
 				memcpy(dataptr + offset, "NULL", NULL_LENGTH);

--- a/src/function/cast/struct_cast.cpp
+++ b/src/function/cast/struct_cast.cpp
@@ -118,7 +118,7 @@ static bool StructToVarcharCast(Vector &source, Vector &result, idx_t count, Cas
 			// value
 			if (child_validity.RowIsValid(i)) {
 				auto len = data[i].GetSize();
-				memcpy(dataptr + offset, data[i].GetDataUnsafe(), len);
+				memcpy(dataptr + offset, data[i].GetData(), len);
 				offset += len;
 			} else {
 				memcpy(dataptr + offset, "NULL", NULL_LENGTH);

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -105,7 +105,7 @@ struct SplitStringListOperation {
 
 template <class OP>
 static bool SplitStringListInternal(const string_t &input, OP &state) {
-	const char *buf = input.GetDataUnsafe();
+	const char *buf = input.GetData();
 	idx_t len = input.GetSize();
 	idx_t lvl = 1;
 	idx_t pos = 0;
@@ -221,7 +221,7 @@ static bool FindKeyOrValueMap(const char *buf, idx_t len, idx_t &pos, OP &state,
 
 template <class OP>
 static bool SplitStringMapInternal(const string_t &input, OP &state) {
-	const char *buf = input.GetDataUnsafe();
+	const char *buf = input.GetData();
 	idx_t len = input.GetSize();
 	idx_t pos = 0;
 
@@ -301,7 +301,7 @@ static bool FindValueStruct(const char *buf, idx_t len, idx_t &pos, Vector &varc
 
 bool VectorStringToStruct::SplitStruct(string_t &input, vector<unique_ptr<Vector>> &varchar_vectors, idx_t &row_idx,
                                        string_map_t<idx_t> &child_names, vector<ValidityMask *> &child_masks) {
-	const char *buf = input.GetDataUnsafe();
+	const char *buf = input.GetData();
 	idx_t len = input.GetSize();
 	idx_t pos = 0;
 	idx_t child_idx;

--- a/src/function/scalar/bit/bitstring.cpp
+++ b/src/function/scalar/bit/bitstring.cpp
@@ -68,7 +68,7 @@ static void SetBitOperation(DataChunk &args, ExpressionState &state, Vector &res
 			                              NumericHelper::ToString(Bit::BitLength(input) - 1));
 		    }
 		    string_t target = StringVector::EmptyString(result, input.GetSize());
-		    memcpy(target.GetDataWriteable(), input.GetDataUnsafe(), input.GetSize());
+		    memcpy(target.GetDataWriteable(), input.GetData(), input.GetSize());
 		    Bit::SetBit(target, n, new_value);
 		    return target;
 	    });

--- a/src/function/scalar/blob/encode.cpp
+++ b/src/function/scalar/blob/encode.cpp
@@ -12,7 +12,7 @@ static void EncodeFunction(DataChunk &args, ExpressionState &state, Vector &resu
 struct BlobDecodeOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input) {
-		auto input_data = input.GetDataUnsafe();
+		auto input_data = input.GetData();
 		auto input_length = input.GetSize();
 		if (Utf8Proc::Analyze(input_data, input_length) == UnicodeType::INVALID) {
 			throw ConversionException(

--- a/src/function/scalar/date/strftime.cpp
+++ b/src/function/scalar/date/strftime.cpp
@@ -154,7 +154,7 @@ idx_t StrfTimeFormat::GetLength(date_t date, dtime_t time, int32_t utc_offset, c
 
 char *StrfTimeFormat::WriteString(char *target, const string_t &str) {
 	idx_t size = str.GetSize();
-	memcpy(target, str.GetDataUnsafe(), size);
+	memcpy(target, str.GetData(), size);
 	return target + size;
 }
 
@@ -766,7 +766,7 @@ int32_t StrpTimeFormat::TryParseCollection(const char *data, idx_t &pos, idx_t s
                                            idx_t collection_count) {
 	for (idx_t c = 0; c < collection_count; c++) {
 		auto &entry = collection[c];
-		auto entry_data = entry.GetDataUnsafe();
+		auto entry_data = entry.GetData();
 		auto entry_size = entry.GetSize();
 		// check if this entry matches
 		if (pos + entry_size > size) {
@@ -805,7 +805,7 @@ bool StrpTimeFormat::Parse(string_t str, ParseResult &result) {
 	result_data[6] = 0;
 	result_data[7] = 0;
 
-	auto data = str.GetDataUnsafe();
+	auto data = str.GetData();
 	idx_t size = str.GetSize();
 	// skip leading spaces
 	while (StringUtil::CharacterIsSpace(*data)) {

--- a/src/function/scalar/string/ascii.cpp
+++ b/src/function/scalar/string/ascii.cpp
@@ -7,7 +7,7 @@ namespace duckdb {
 struct AsciiOperator {
 	template <class TA, class TR>
 	static inline TR Operation(const TA &input) {
-		auto str = input.GetDataUnsafe();
+		auto str = input.GetData();
 		if (Utf8Proc::Analyze(str, input.GetSize()) == UnicodeType::ASCII) {
 			return str[0];
 		}

--- a/src/function/scalar/string/caseconvert.cpp
+++ b/src/function/scalar/string/caseconvert.cpp
@@ -120,7 +120,7 @@ template <bool IS_UPPER>
 struct CaseConvertOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
-		auto input_data = input.GetDataUnsafe();
+		auto input_data = input.GetData();
 		auto input_length = input.GetSize();
 		return UnicodeCaseConvert<IS_UPPER>(result, input_data, input_length);
 	}
@@ -135,7 +135,7 @@ template <bool IS_UPPER>
 struct CaseConvertOperatorASCII {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
-		auto input_data = input.GetDataUnsafe();
+		auto input_data = input.GetData();
 		auto input_length = input.GetSize();
 		return ASCIICaseConvert<IS_UPPER>(result, input_data, input_length);
 	}

--- a/src/function/scalar/string/concat.cpp
+++ b/src/function/scalar/string/concat.cpp
@@ -66,7 +66,7 @@ static void ConcatFunction(DataChunk &args, ExpressionState &state, Vector &resu
 			}
 			// append the constant vector to each of the strings
 			auto input_data = ConstantVector::GetData<string_t>(input);
-			auto input_ptr = input_data->GetDataUnsafe();
+			auto input_ptr = input_data->GetData();
 			auto input_len = input_data->GetSize();
 			for (idx_t i = 0; i < args.size(); i++) {
 				memcpy(result_data[i].GetDataWriteable() + result_lengths[i], input_ptr, input_len);
@@ -83,7 +83,7 @@ static void ConcatFunction(DataChunk &args, ExpressionState &state, Vector &resu
 				if (!idata.validity.RowIsValid(idx)) {
 					continue;
 				}
-				auto input_ptr = input_data[idx].GetDataUnsafe();
+				auto input_ptr = input_data[idx].GetData();
 				auto input_len = input_data[idx].GetSize();
 				memcpy(result_data[i].GetDataWriteable() + result_lengths[i], input_ptr, input_len);
 				result_lengths[i] += input_len;
@@ -98,8 +98,8 @@ static void ConcatFunction(DataChunk &args, ExpressionState &state, Vector &resu
 static void ConcatOperator(DataChunk &args, ExpressionState &state, Vector &result) {
 	BinaryExecutor::Execute<string_t, string_t, string_t>(
 	    args.data[0], args.data[1], result, args.size(), [&](string_t a, string_t b) {
-		    auto a_data = a.GetDataUnsafe();
-		    auto b_data = b.GetDataUnsafe();
+		    auto a_data = a.GetData();
+		    auto b_data = b.GetData();
 		    auto a_length = a.GetSize();
 		    auto b_length = b.GetSize();
 
@@ -167,11 +167,11 @@ static void TemplatedConcatWS(DataChunk &args, string_t *sep_data, const Selecti
 			}
 			if (has_results[ridx]) {
 				auto sep_size = sep_data[sep_idx].GetSize();
-				auto sep_ptr = sep_data[sep_idx].GetDataUnsafe();
+				auto sep_ptr = sep_data[sep_idx].GetData();
 				memcpy(result_data[ridx].GetDataWriteable() + result_lengths[ridx], sep_ptr, sep_size);
 				result_lengths[ridx] += sep_size;
 			}
-			auto input_ptr = input_data[idx].GetDataUnsafe();
+			auto input_ptr = input_data[idx].GetData();
 			auto input_len = input_data[idx].GetSize();
 			memcpy(result_data[ridx].GetDataWriteable() + result_lengths[ridx], input_ptr, input_len);
 			result_lengths[ridx] += input_len;

--- a/src/function/scalar/string/contains.cpp
+++ b/src/function/scalar/string/contains.cpp
@@ -133,9 +133,9 @@ idx_t ContainsFun::Find(const unsigned char *haystack, idx_t haystack_size, cons
 }
 
 idx_t ContainsFun::Find(const string_t &haystack_s, const string_t &needle_s) {
-	auto haystack = (const unsigned char *)haystack_s.GetDataUnsafe();
+	auto haystack = (const unsigned char *)haystack_s.GetData();
 	auto haystack_size = haystack_s.GetSize();
-	auto needle = (const unsigned char *)needle_s.GetDataUnsafe();
+	auto needle = (const unsigned char *)needle_s.GetData();
 	auto needle_size = needle_s.GetSize();
 	if (needle_size == 0) {
 		// empty needle: always true

--- a/src/function/scalar/string/damerau_levenshtein.cpp
+++ b/src/function/scalar/string/damerau_levenshtein.cpp
@@ -25,8 +25,8 @@ static idx_t DamerauLevenshteinDistance(const string_t &source, const string_t &
 		return source_len * COST_DELETION;
 	}
 
-	const auto source_str = source.GetDataUnsafe();
-	const auto target_str = target.GetDataUnsafe();
+	const auto source_str = source.GetData();
+	const auto target_str = target.GetData();
 
 	// larger than the largest possible value:
 	const auto inf = source_len * COST_DELETION + target_len * COST_INSERTION + 1;

--- a/src/function/scalar/string/hex.cpp
+++ b/src/function/scalar/string/hex.cpp
@@ -63,7 +63,7 @@ static void WriteHugeIntBinBytes(hugeint_t x, char *&output, idx_t buffer_size) 
 struct HexStrOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
-		auto data = input.GetDataUnsafe();
+		auto data = input.GetData();
 		auto size = input.GetSize();
 
 		// Allocate empty space
@@ -150,7 +150,7 @@ static void ToHexFunction(DataChunk &args, ExpressionState &state, Vector &resul
 struct BinaryStrOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
-		auto data = input.GetDataUnsafe();
+		auto data = input.GetData();
 		auto size = input.GetSize();
 
 		// Allocate empty space
@@ -228,7 +228,7 @@ struct BinaryHugeIntOperator {
 struct FromHexOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
-		auto data = input.GetDataUnsafe();
+		auto data = input.GetData();
 		auto size = input.GetSize();
 
 		if (size > NumericLimits<uint32_t>::Maximum()) {
@@ -265,7 +265,7 @@ struct FromHexOperator {
 struct FromBinaryOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
-		auto data = input.GetDataUnsafe();
+		auto data = input.GetData();
 		auto size = input.GetSize();
 
 		if (size > NumericLimits<uint32_t>::Maximum()) {

--- a/src/function/scalar/string/instr.cpp
+++ b/src/function/scalar/string/instr.cpp
@@ -16,7 +16,7 @@ struct InstrOperator {
 		auto location = ContainsFun::Find(haystack, needle);
 		if (location != DConstants::INVALID_INDEX) {
 			auto len = (utf8proc_ssize_t)location;
-			auto str = reinterpret_cast<const utf8proc_uint8_t *>(haystack.GetDataUnsafe());
+			auto str = reinterpret_cast<const utf8proc_uint8_t *>(haystack.GetData());
 			D_ASSERT(len <= (utf8proc_ssize_t)haystack.GetSize());
 			for (++string_position; len > 0; ++string_position) {
 				utf8proc_int32_t codepoint;

--- a/src/function/scalar/string/jaccard.cpp
+++ b/src/function/scalar/string/jaccard.cpp
@@ -9,7 +9,7 @@ namespace duckdb {
 static inline map<char, idx_t> GetSet(const string_t &str) {
 	auto map_of_chars = map<char, idx_t> {};
 	idx_t str_len = str.GetSize();
-	auto s = str.GetDataUnsafe();
+	auto s = str.GetData();
 
 	for (idx_t pos = 0; pos < str_len; pos++) {
 		map_of_chars.insert(std::make_pair(s[pos], 1));

--- a/src/function/scalar/string/jaro_winkler.cpp
+++ b/src/function/scalar/string/jaro_winkler.cpp
@@ -5,14 +5,14 @@
 namespace duckdb {
 
 static inline double JaroScalarFunction(const string_t &s1, const string_t &s2) {
-	auto s1_begin = s1.GetDataUnsafe();
-	auto s2_begin = s2.GetDataUnsafe();
+	auto s1_begin = s1.GetData();
+	auto s2_begin = s2.GetData();
 	return duckdb_jaro_winkler::jaro_similarity(s1_begin, s1_begin + s1.GetSize(), s2_begin, s2_begin + s2.GetSize());
 }
 
 static inline double JaroWinklerScalarFunction(const string_t &s1, const string_t &s2) {
-	auto s1_begin = s1.GetDataUnsafe();
-	auto s2_begin = s2.GetDataUnsafe();
+	auto s1_begin = s1.GetData();
+	auto s2_begin = s2.GetData();
 	return duckdb_jaro_winkler::jaro_winkler_similarity(s1_begin, s1_begin + s1.GetSize(), s2_begin,
 	                                                    s2_begin + s2.GetSize());
 }
@@ -29,7 +29,7 @@ static void CachedFunction(Vector &constant, Vector &other, Vector &result, idx_
 	auto str_val = StringValue::Get(val);
 	auto cached = CACHED_SIMILARITY(str_val);
 	UnaryExecutor::Execute<string_t, double>(other, result, count, [&](const string_t &other_str) {
-		auto other_str_begin = other_str.GetDataUnsafe();
+		auto other_str_begin = other_str.GetData();
 		return cached.similarity(other_str_begin, other_str_begin + other_str.GetSize());
 	});
 }

--- a/src/function/scalar/string/length.cpp
+++ b/src/function/scalar/string/length.cpp
@@ -141,7 +141,7 @@ void LengthFun::RegisterFunction(BuiltinFunctions &set) {
 struct UnicodeOperator {
 	template <class TA, class TR>
 	static inline TR Operation(const TA &input) {
-		auto str = reinterpret_cast<const utf8proc_uint8_t *>(input.GetDataUnsafe());
+		auto str = reinterpret_cast<const utf8proc_uint8_t *>(input.GetData());
 		auto len = input.GetSize();
 		utf8proc_int32_t codepoint;
 		(void)utf8proc_iterate(str, len, &codepoint);

--- a/src/function/scalar/string/levenshtein.cpp
+++ b/src/function/scalar/string/levenshtein.cpp
@@ -23,8 +23,8 @@ static idx_t LevenshteinDistance(const string_t &txt, const string_t &tgt) {
 		return txt_len;
 	}
 
-	auto txt_str = txt.GetDataUnsafe();
-	auto tgt_str = tgt.GetDataUnsafe();
+	auto txt_str = txt.GetData();
+	auto tgt_str = tgt.GetData();
 
 	// Create two working vectors
 	vector<idx_t> distances0(tgt_len + 1, 0);

--- a/src/function/scalar/string/like.cpp
+++ b/src/function/scalar/string/like.cpp
@@ -78,7 +78,7 @@ struct LikeMatcher : public FunctionData {
 	}
 
 	bool Match(string_t &str) {
-		auto str_data = (const unsigned char *)str.GetDataUnsafe();
+		auto str_data = (const unsigned char *)str.GetData();
 		auto str_len = str.GetSize();
 		idx_t segment_idx = 0;
 		idx_t end_idx = segments.size() - 1;
@@ -213,11 +213,11 @@ bool LikeOperatorFunction(const char *s, idx_t slen, const char *pattern, idx_t 
 }
 
 bool LikeOperatorFunction(string_t &s, string_t &pat) {
-	return LikeOperatorFunction(s.GetDataUnsafe(), s.GetSize(), pat.GetDataUnsafe(), pat.GetSize());
+	return LikeOperatorFunction(s.GetData(), s.GetSize(), pat.GetData(), pat.GetSize());
 }
 
 bool LikeOperatorFunction(string_t &s, string_t &pat, char escape) {
-	return LikeOperatorFunction(s.GetDataUnsafe(), s.GetSize(), pat.GetDataUnsafe(), pat.GetSize(), escape);
+	return LikeOperatorFunction(s.GetData(), s.GetSize(), pat.GetData(), pat.GetSize(), escape);
 }
 
 bool LikeFun::Glob(const char *string, idx_t slen, const char *pattern, idx_t plen, bool allow_question_mark) {
@@ -362,15 +362,14 @@ static char GetEscapeChar(string_t escape) {
 	if (escape.GetSize() > 1) {
 		throw SyntaxException("Invalid escape string. Escape string must be empty or one character.");
 	}
-	return escape.GetSize() == 0 ? '\0' : *escape.GetDataUnsafe();
+	return escape.GetSize() == 0 ? '\0' : *escape.GetData();
 }
 
 struct LikeEscapeOperator {
 	template <class TA, class TB, class TC>
 	static inline bool Operation(TA str, TB pattern, TC escape) {
 		char escape_char = GetEscapeChar(escape);
-		return LikeOperatorFunction(str.GetDataUnsafe(), str.GetSize(), pattern.GetDataUnsafe(), pattern.GetSize(),
-		                            escape_char);
+		return LikeOperatorFunction(str.GetData(), str.GetSize(), pattern.GetData(), pattern.GetSize(), escape_char);
 	}
 };
 
@@ -389,9 +388,9 @@ struct LikeOperator {
 };
 
 bool ILikeOperatorFunction(string_t &str, string_t &pattern, char escape = '\0') {
-	auto str_data = str.GetDataUnsafe();
+	auto str_data = str.GetData();
 	auto str_size = str.GetSize();
-	auto pat_data = pattern.GetDataUnsafe();
+	auto pat_data = pattern.GetData();
 	auto pat_size = pattern.GetSize();
 
 	// lowercase both the str and the pattern
@@ -446,8 +445,8 @@ struct NotILikeOperator {
 struct ILikeOperatorASCII {
 	template <class TA, class TB, class TR>
 	static inline TR Operation(TA str, TB pattern) {
-		return TemplatedLikeOperator<'%', '_', false, ASCIILCaseReader>(
-		    str.GetDataUnsafe(), str.GetSize(), pattern.GetDataUnsafe(), pattern.GetSize(), '\0');
+		return TemplatedLikeOperator<'%', '_', false, ASCIILCaseReader>(str.GetData(), str.GetSize(), pattern.GetData(),
+		                                                                pattern.GetSize(), '\0');
 	}
 };
 
@@ -461,7 +460,7 @@ struct NotILikeOperatorASCII {
 struct GlobOperator {
 	template <class TA, class TB, class TR>
 	static inline TR Operation(TA str, TB pattern) {
-		return LikeFun::Glob(str.GetDataUnsafe(), str.GetSize(), pattern.GetDataUnsafe(), pattern.GetSize());
+		return LikeFun::Glob(str.GetData(), str.GetSize(), pattern.GetData(), pattern.GetSize());
 	}
 };
 

--- a/src/function/scalar/string/mismatches.cpp
+++ b/src/function/scalar/string/mismatches.cpp
@@ -18,8 +18,8 @@ static int64_t MismatchesScalarFunction(Vector &result, const string_t str, stri
 	}
 
 	idx_t mismatches = 0;
-	auto str_str = str.GetDataUnsafe();
-	auto tgt_str = tgt.GetDataUnsafe();
+	auto str_str = str.GetData();
+	auto tgt_str = tgt.GetData();
 
 	for (idx_t idx = 0; idx < str_len; ++idx) {
 		if (str_str[idx] != tgt_str[idx]) {

--- a/src/function/scalar/string/nfc_normalize.cpp
+++ b/src/function/scalar/string/nfc_normalize.cpp
@@ -7,7 +7,7 @@ namespace duckdb {
 struct NFCNormalizeOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
-		auto input_data = input.GetDataUnsafe();
+		auto input_data = input.GetData();
 		auto input_length = input.GetSize();
 		if (StripAccentsFun::IsAscii(input_data, input_length)) {
 			return input;

--- a/src/function/scalar/string/pad.cpp
+++ b/src/function/scalar/string/pad.cpp
@@ -27,7 +27,7 @@ static pair<idx_t, idx_t> PadCountChars(const idx_t len, const char *data, const
 
 static bool InsertPadding(const idx_t len, const string_t &pad, vector<char> &result) {
 	//  Copy the padding until the output is long enough
-	auto data = pad.GetDataUnsafe();
+	auto data = pad.GetData();
 	auto size = pad.GetSize();
 
 	//  Check whether we need data that we don't have
@@ -63,7 +63,7 @@ static string_t LeftPadFunction(const string_t &str, const int32_t len, const st
 	result.clear();
 
 	// Get information about the base string
-	auto data_str = str.GetDataUnsafe();
+	auto data_str = str.GetData();
 	auto size_str = str.GetSize();
 
 	//  Count how much of str will fit in the output
@@ -92,7 +92,7 @@ static string_t RightPadFunction(const string_t &str, const int32_t len, const s
 	result.clear();
 
 	// Get information about the base string
-	auto data_str = str.GetDataUnsafe();
+	auto data_str = str.GetData();
 	auto size_str = str.GetSize();
 
 	// Count how much of str will fit in the output

--- a/src/function/scalar/string/prefix.cpp
+++ b/src/function/scalar/string/prefix.cpp
@@ -46,8 +46,8 @@ static bool PrefixFunction(const string_t &str, const string_t &pattern) {
 			}
 		}
 		// compare the rest of the prefix
-		const char *str_data = str.GetDataUnsafe();
-		const char *patt_data = pattern.GetDataUnsafe();
+		const char *str_data = str.GetData();
+		const char *patt_data = pattern.GetData();
 		D_ASSERT(patt_length <= str_length);
 		for (idx_t i = string_t::PREFIX_LENGTH; i < patt_length; ++i) {
 			if (str_data[i] != patt_data[i]) {

--- a/src/function/scalar/string/printf.cpp
+++ b/src/function/scalar/string/printf.cpp
@@ -138,7 +138,7 @@ static void PrintfFunction(DataChunk &args, ExpressionState &state, Vector &resu
 			case LogicalTypeId::VARCHAR: {
 				auto arg_data = FlatVector::GetData<string_t>(col);
 				auto string_view =
-				    duckdb_fmt::basic_string_view<char>(arg_data[arg_idx].GetDataUnsafe(), arg_data[arg_idx].GetSize());
+				    duckdb_fmt::basic_string_view<char>(arg_data[arg_idx].GetData(), arg_data[arg_idx].GetSize());
 				format_args.emplace_back(duckdb_fmt::internal::make_arg<CTX>(string_view));
 				break;
 			}

--- a/src/function/scalar/string/regexp/regexp_extract_all.cpp
+++ b/src/function/scalar/string/regexp/regexp_extract_all.cpp
@@ -86,7 +86,7 @@ void ExtractSingleTuple(const string_t &string, duckdb_re2::RE2 &pattern, int32_
 		idx_t child_idx = current_list_size;
 		if (match_group.empty()) {
 			// This group was not matched
-			list_content[child_idx] = string_t(string.GetDataUnsafe(), 0);
+			list_content[child_idx] = string_t(string.GetData(), 0);
 			if (match_group.begin() == nullptr) {
 				// This group is optional
 				child_validity.SetInvalid(child_idx);
@@ -94,9 +94,9 @@ void ExtractSingleTuple(const string_t &string, duckdb_re2::RE2 &pattern, int32_
 		} else {
 			// Every group is a substring of the original, we can find out the offset using the pointer
 			// the 'match_group' address is guaranteed to be bigger than that of the source
-			D_ASSERT((const char *)match_group.begin() >= string.GetDataUnsafe());
-			idx_t offset = match_group.begin() - string.GetDataUnsafe();
-			list_content[child_idx] = string_t(string.GetDataUnsafe() + offset, match_group.size());
+			D_ASSERT((const char *)match_group.begin() >= string.GetData());
+			idx_t offset = match_group.begin() - string.GetData();
+			list_content[child_idx] = string_t(string.GetData() + offset, match_group.size());
 		}
 		current_list_size++;
 		if (startpos > input.size()) {

--- a/src/function/scalar/string/repeat.cpp
+++ b/src/function/scalar/string/repeat.cpp
@@ -10,7 +10,7 @@ namespace duckdb {
 
 static string_t RepeatScalarFunction(const string_t &str, const int64_t cnt, vector<char> &result) {
 	// Get information about the repeated string
-	auto input_str = str.GetDataUnsafe();
+	auto input_str = str.GetData();
 	auto size_str = str.GetSize();
 
 	//  Reuse the buffer

--- a/src/function/scalar/string/replace.cpp
+++ b/src/function/scalar/string/replace.cpp
@@ -29,13 +29,13 @@ static idx_t NextNeedle(const char *input_haystack, idx_t size_haystack, const c
 static string_t ReplaceScalarFunction(const string_t &haystack, const string_t &needle, const string_t &thread,
                                       vector<char> &result) {
 	// Get information about the needle, the haystack and the "thread"
-	auto input_haystack = haystack.GetDataUnsafe();
+	auto input_haystack = haystack.GetData();
 	auto size_haystack = haystack.GetSize();
 
-	auto input_needle = needle.GetDataUnsafe();
+	auto input_needle = needle.GetData();
 	auto size_needle = needle.GetSize();
 
-	auto input_thread = thread.GetDataUnsafe();
+	auto input_thread = thread.GetData();
 	auto size_thread = thread.GetSize();
 
 	//  Reuse the buffer

--- a/src/function/scalar/string/reverse.cpp
+++ b/src/function/scalar/string/reverse.cpp
@@ -32,7 +32,7 @@ static void StrReverseUnicode(const char *input, idx_t n, char *output) {
 struct ReverseOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
-		auto input_data = input.GetDataUnsafe();
+		auto input_data = input.GetData();
 		auto input_length = input.GetSize();
 
 		auto target = StringVector::EmptyString(result, input_length);

--- a/src/function/scalar/string/starts_with.cpp
+++ b/src/function/scalar/string/starts_with.cpp
@@ -17,9 +17,9 @@ static bool StartsWith(const unsigned char *haystack, idx_t haystack_size, const
 }
 
 static bool StartsWith(const string_t &haystack_s, const string_t &needle_s) {
-	auto haystack = (const unsigned char *)haystack_s.GetDataUnsafe();
+	auto haystack = (const unsigned char *)haystack_s.GetData();
 	auto haystack_size = haystack_s.GetSize();
-	auto needle = (const unsigned char *)needle_s.GetDataUnsafe();
+	auto needle = (const unsigned char *)needle_s.GetData();
 	auto needle_size = needle_s.GetSize();
 	if (needle_size == 0) {
 		// empty needle: always true

--- a/src/function/scalar/string/string_split.cpp
+++ b/src/function/scalar/string/string_split.cpp
@@ -68,9 +68,9 @@ struct RegexpStringSplit {
 struct StringSplitter {
 	template <class OP>
 	static idx_t Split(string_t input, string_t delim, StringSplitInput &state, void *data) {
-		auto input_data = input.GetDataUnsafe();
+		auto input_data = input.GetData();
 		auto input_size = input.GetSize();
-		auto delim_data = delim.GetDataUnsafe();
+		auto delim_data = delim.GetData();
 		auto delim_size = delim.GetSize();
 		idx_t list_idx = 0;
 		while (input_size > 0) {
@@ -135,7 +135,7 @@ static void StringSplitExecutor(DataChunk &args, ExpressionState &state, Vector 
 		StringSplitInput split_input(result, child_entry, total_splits);
 		if (!delim_data.validity.RowIsValid(delim_idx)) {
 			// delim is NULL: copy the complete entry
-			split_input.AddSplit(inputs[input_idx].GetDataUnsafe(), inputs[input_idx].GetSize(), 0);
+			split_input.AddSplit(inputs[input_idx].GetData(), inputs[input_idx].GetSize(), 0);
 			list_struct_data[i].length = 1;
 			list_struct_data[i].offset = total_splits;
 			total_splits++;

--- a/src/function/scalar/string/strip_accents.cpp
+++ b/src/function/scalar/string/strip_accents.cpp
@@ -17,12 +17,12 @@ bool StripAccentsFun::IsAscii(const char *input, idx_t n) {
 struct StripAccentsOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
-		if (StripAccentsFun::IsAscii(input.GetDataUnsafe(), input.GetSize())) {
+		if (StripAccentsFun::IsAscii(input.GetData(), input.GetSize())) {
 			return input;
 		}
 
 		// non-ascii, perform collation
-		auto stripped = utf8proc_remove_accents((const utf8proc_uint8_t *)input.GetDataUnsafe(), input.GetSize());
+		auto stripped = utf8proc_remove_accents((const utf8proc_uint8_t *)input.GetData(), input.GetSize());
 		auto result_str = StringVector::AddString(result, (const char *)stripped);
 		free(stripped);
 		return result_str;

--- a/src/function/scalar/string/substring.cpp
+++ b/src/function/scalar/string/substring.cpp
@@ -82,7 +82,7 @@ bool SubstringStartEnd(int64_t input_size, int64_t offset, int64_t length, int64
 }
 
 string_t SubstringASCII(Vector &result, string_t input, int64_t offset, int64_t length) {
-	auto input_data = input.GetDataUnsafe();
+	auto input_data = input.GetData();
 	auto input_size = input.GetSize();
 
 	AssertInSupportedRange(input_size, offset, length);
@@ -95,7 +95,7 @@ string_t SubstringASCII(Vector &result, string_t input, int64_t offset, int64_t 
 }
 
 string_t SubstringFun::SubstringUnicode(Vector &result, string_t input, int64_t offset, int64_t length) {
-	auto input_data = input.GetDataUnsafe();
+	auto input_data = input.GetData();
 	auto input_size = input.GetSize();
 
 	AssertInSupportedRange(input_size, offset, length);
@@ -190,7 +190,7 @@ string_t SubstringFun::SubstringUnicode(Vector &result, string_t input, int64_t 
 }
 
 string_t SubstringFun::SubstringGrapheme(Vector &result, string_t input, int64_t offset, int64_t length) {
-	auto input_data = input.GetDataUnsafe();
+	auto input_data = input.GetData();
 	auto input_size = input.GetSize();
 
 	AssertInSupportedRange(input_size, offset, length);

--- a/src/function/scalar/string/suffix.cpp
+++ b/src/function/scalar/string/suffix.cpp
@@ -21,8 +21,8 @@ static bool SuffixFunction(const string_t &str, const string_t &suffix) {
 		return false;
 	}
 
-	auto suffix_data = suffix.GetDataUnsafe();
-	auto str_data = str.GetDataUnsafe();
+	auto suffix_data = suffix.GetData();
+	auto str_data = str.GetData();
 	int32_t suf_idx = suffix_size - 1;
 	idx_t str_idx = str_size - 1;
 	for (; suf_idx >= 0; --suf_idx, --str_idx) {

--- a/src/function/scalar/string/translate.cpp
+++ b/src/function/scalar/string/translate.cpp
@@ -16,13 +16,13 @@ namespace duckdb {
 static string_t TranslateScalarFunction(const string_t &haystack, const string_t &needle, const string_t &thread,
                                         vector<char> &result) {
 	// Get information about the haystack, the needle and the "thread"
-	auto input_haystack = haystack.GetDataUnsafe();
+	auto input_haystack = haystack.GetData();
 	auto size_haystack = haystack.GetSize();
 
-	auto input_needle = needle.GetDataUnsafe();
+	auto input_needle = needle.GetData();
 	auto size_needle = needle.GetSize();
 
-	auto input_thread = thread.GetDataUnsafe();
+	auto input_thread = thread.GetData();
 	auto size_thread = thread.GetSize();
 
 	// Reuse the buffer

--- a/src/function/scalar/string/trim.cpp
+++ b/src/function/scalar/string/trim.cpp
@@ -13,7 +13,7 @@ template <bool LTRIM, bool RTRIM>
 struct TrimOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
-		auto data = input.GetDataUnsafe();
+		auto data = input.GetData();
 		auto size = input.GetSize();
 
 		utf8proc_int32_t codepoint;
@@ -64,7 +64,7 @@ static void UnaryTrimFunction(DataChunk &args, ExpressionState &state, Vector &r
 }
 
 static void GetIgnoredCodepoints(string_t ignored, unordered_set<utf8proc_int32_t> &ignored_codepoints) {
-	auto dataptr = (utf8proc_uint8_t *)ignored.GetDataUnsafe();
+	auto dataptr = (utf8proc_uint8_t *)ignored.GetData();
 	auto size = ignored.GetSize();
 	idx_t pos = 0;
 	while (pos < size) {
@@ -78,7 +78,7 @@ template <bool LTRIM, bool RTRIM>
 static void BinaryTrimFunction(DataChunk &input, ExpressionState &state, Vector &result) {
 	BinaryExecutor::Execute<string_t, string_t, string_t>(
 	    input.data[0], input.data[1], result, input.size(), [&](string_t input, string_t ignored) {
-		    auto data = input.GetDataUnsafe();
+		    auto data = input.GetData();
 		    auto size = input.GetSize();
 
 		    unordered_set<utf8proc_int32_t> ignored_codepoints;

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -91,7 +91,7 @@ static void AggregateStateFinalize(DataChunk &input, ExpressionState &state_p, V
 
 		if (state_data.validity.RowIsValid(state_idx)) {
 			D_ASSERT(state_entry->GetSize() == bind_data.state_size);
-			memcpy((void *)target_ptr, state_entry->GetDataUnsafe(), bind_data.state_size);
+			memcpy((void *)target_ptr, state_entry->GetData(), bind_data.state_size);
 		} else {
 			// create a dummy state because finalize does not understand NULLs in its input
 			// we put the NULL back in explicitly below
@@ -145,13 +145,11 @@ static void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Ve
 			continue;
 		}
 		if (state0_data.validity.RowIsValid(state0_idx) && !state1_data.validity.RowIsValid(state1_idx)) {
-			result_ptr[i] =
-			    StringVector::AddStringOrBlob(result, (const char *)state0.GetDataUnsafe(), bind_data.state_size);
+			result_ptr[i] = StringVector::AddStringOrBlob(result, (const char *)state0.GetData(), bind_data.state_size);
 			continue;
 		}
 		if (!state0_data.validity.RowIsValid(state0_idx) && state1_data.validity.RowIsValid(state1_idx)) {
-			result_ptr[i] =
-			    StringVector::AddStringOrBlob(result, (const char *)state1.GetDataUnsafe(), bind_data.state_size);
+			result_ptr[i] = StringVector::AddStringOrBlob(result, (const char *)state1.GetData(), bind_data.state_size);
 			continue;
 		}
 
@@ -161,8 +159,8 @@ static void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Ve
 			                  state0.GetSize(), state1.GetSize());
 		}
 
-		memcpy(local_state.state_buffer0.get(), state0.GetDataUnsafe(), bind_data.state_size);
-		memcpy(local_state.state_buffer1.get(), state1.GetDataUnsafe(), bind_data.state_size);
+		memcpy(local_state.state_buffer0.get(), state0.GetData(), bind_data.state_size);
+		memcpy(local_state.state_buffer1.get(), state1.GetData(), bind_data.state_size);
 
 		AggregateInputData aggr_input_data(nullptr, Allocator::DefaultAllocator());
 		bind_data.aggr.combine(local_state.state_vector0, local_state.state_vector1, aggr_input_data, 1);

--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -357,7 +357,7 @@ static void WriteCSVSink(ExecutionContext &context, FunctionData &bind_data, Glo
 			// FIXME: we could gain some performance here by checking for certain types if they ever require quotes
 			// (e.g. integers only require quotes if the delimiter is a number, decimals only require quotes if the
 			// delimiter is a number or "." character)
-			WriteQuotedString(writer, csv_data, str_value.GetDataUnsafe(), str_value.GetSize(),
+			WriteQuotedString(writer, csv_data, str_value.GetData(), str_value.GetSize(),
 			                  csv_data.options.force_quote[col_idx]);
 		}
 		writer.WriteBufferData(csv_data.newline);

--- a/src/include/duckdb/common/crypto/md5.hpp
+++ b/src/include/duckdb/common/crypto/md5.hpp
@@ -26,7 +26,7 @@ public:
 	}
 	void Add(const char *data);
 	void Add(string_t string) {
-		MD5Update((const_data_ptr_t)string.GetDataUnsafe(), string.GetSize());
+		MD5Update((const_data_ptr_t)string.GetData(), string.GetSize());
 	}
 	void Add(const string &data) {
 		MD5Update((const_data_ptr_t)data.c_str(), data.size());

--- a/src/include/duckdb/common/radix.hpp
+++ b/src/include/duckdb/common/radix.hpp
@@ -50,7 +50,7 @@ public:
 
 	static inline void EncodeStringDataPrefix(data_ptr_t dataptr, string_t value, idx_t prefix_len) {
 		auto len = value.GetSize();
-		memcpy(dataptr, value.GetDataUnsafe(), MinValue(len, prefix_len));
+		memcpy(dataptr, value.GetData(), MinValue(len, prefix_len));
 		if (len < prefix_len) {
 			memset(dataptr + len, '\0', prefix_len - len);
 		}

--- a/src/include/duckdb/common/types/string_type.hpp
+++ b/src/include/duckdb/common/types/string_type.hpp
@@ -68,9 +68,11 @@ public:
 		return GetSize() <= INLINE_LENGTH;
 	}
 
-	//! this is unsafe since the string will not be terminated at the end
-	const char *GetDataUnsafe() const {
+	const char *GetData() const {
 		return IsInlined() ? (const char *)value.inlined.inlined : value.pointer.ptr;
+	}
+	const char *GetDataUnsafe() const {
+		return GetData();
 	}
 
 	char *GetDataWriteable() const {
@@ -86,7 +88,7 @@ public:
 	}
 
 	string GetString() const {
-		return string(GetDataUnsafe(), GetSize());
+		return string(GetData(), GetSize());
 	}
 
 	explicit operator string() const {
@@ -108,7 +110,7 @@ public:
 		} else {
 			// copy the data into the prefix
 #ifndef DUCKDB_DEBUG_NO_INLINE
-			auto dataptr = (char *)GetDataUnsafe();
+			auto dataptr = (char *)GetData();
 			memcpy(value.pointer.prefix, dataptr, PREFIX_LENGTH);
 #else
 			memset(value.pointer.prefix, 0, PREFIX_BYTES);
@@ -124,7 +126,7 @@ public:
 #ifdef DUCKDB_DEBUG_NO_INLINE
 			if (a.GetSize() != b.GetSize())
 				return false;
-			return (memcmp(a.GetDataUnsafe(), b.GetDataUnsafe(), a.GetSize()) == 0);
+			return (memcmp(a.GetData(), b.GetData(), a.GetSize()) == 0);
 #endif
 			uint64_t A = Load<uint64_t>((const_data_ptr_t)&a);
 			uint64_t B = Load<uint64_t>((const_data_ptr_t)&b);
@@ -177,7 +179,7 @@ public:
 			if (A != B)
 				return bswap(A) > bswap(B);
 #endif
-			auto memcmp_res = memcmp(left.GetDataUnsafe(), right.GetDataUnsafe(), min_length);
+			auto memcmp_res = memcmp(left.GetData(), right.GetData(), min_length);
 			return memcmp_res > 0 || (memcmp_res == 0 && left_length > right_length);
 		}
 	};

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -143,7 +143,7 @@ public:
 		return heap.AddString(data);
 	}
 	string_t AddBlob(string_t data) {
-		return heap.AddBlob(data.GetDataUnsafe(), data.GetSize());
+		return heap.AddBlob(data.GetData(), data.GetSize());
 	}
 	string_t EmptyString(idx_t len) {
 		return heap.EmptyString(len);

--- a/src/include/duckdb/function/scalar/regexp.hpp
+++ b/src/include/duckdb/function/scalar/regexp.hpp
@@ -22,7 +22,7 @@ void ParseRegexOptions(const string &options, duckdb_re2::RE2::Options &result, 
 void ParseRegexOptions(ClientContext &context, Expression &expr, RE2::Options &target, bool *global_replace = nullptr);
 
 inline duckdb_re2::StringPiece CreateStringPiece(const string_t &input) {
-	return duckdb_re2::StringPiece(input.GetDataUnsafe(), input.GetSize());
+	return duckdb_re2::StringPiece(input.GetData(), input.GetSize());
 }
 
 inline string_t Extract(const string_t &input, Vector &result, const RE2 &re, const duckdb_re2::StringPiece &rewrite) {

--- a/src/include/duckdb/function/scalar/string_functions.hpp
+++ b/src/include/duckdb/function/scalar/string_functions.hpp
@@ -58,7 +58,7 @@ struct LengthFun {
 
 	template <class TA, class TR>
 	static inline TR Length(TA input) {
-		auto input_data = input.GetDataUnsafe();
+		auto input_data = input.GetData();
 		auto input_length = input.GetSize();
 		TR length = 0;
 		for (idx_t i = 0; i < input_length; i++) {
@@ -69,7 +69,7 @@ struct LengthFun {
 
 	template <class TA, class TR>
 	static inline TR GraphemeCount(TA input) {
-		auto input_data = input.GetDataUnsafe();
+		auto input_data = input.GetData();
 		auto input_length = input.GetSize();
 		for (idx_t i = 0; i < input_length; i++) {
 			if (input_data[i] & 0x80) {

--- a/src/include/duckdb/main/capi/cast/utils.hpp
+++ b/src/include/duckdb/main/capi/cast/utils.hpp
@@ -80,7 +80,7 @@ struct ToCStringCastWrapper {
 		Vector result_vector(LogicalType::VARCHAR, nullptr);
 		auto result_string = OP::template Operation<SOURCE_TYPE>(input, result_vector);
 		auto result_size = result_string.GetSize();
-		auto result_data = result_string.GetDataUnsafe();
+		auto result_data = result_string.GetData();
 
 		char *allocated_data = (char *)duckdb_malloc(result_size + 1);
 		memcpy(allocated_data, result_data, result_size);

--- a/src/include/duckdb/storage/string_uncompressed.hpp
+++ b/src/include/duckdb/storage/string_uncompressed.hpp
@@ -155,7 +155,7 @@ public:
 				remaining_space -= required_space;
 				auto dict_pos = end - *dictionary_size;
 				// now write the actual string data into the dictionary
-				memcpy(dict_pos, source_data[source_idx].GetDataUnsafe(), string_length);
+				memcpy(dict_pos, source_data[source_idx].GetData(), string_length);
 
 				// place the dictionary offset into the set of vectors
 				result_data[target_idx] = *dictionary_size;

--- a/src/main/capi/cast/from_decimal-c.cpp
+++ b/src/main/capi/cast/from_decimal-c.cpp
@@ -35,7 +35,7 @@ bool CastDecimalCInternal(duckdb_result *source, duckdb_string &result, idx_t co
 		throw duckdb::InternalException("Unimplemented internal type for decimal");
 	}
 	result.data = (char *)duckdb_malloc(sizeof(char) * (result_string.GetSize() + 1));
-	memcpy(result.data, result_string.GetDataUnsafe(), result_string.GetSize());
+	memcpy(result.data, result_string.GetData(), result_string.GetSize());
 	result.data[result_string.GetSize()] = '\0';
 	result.size = result_string.GetSize();
 	return true;

--- a/src/main/capi/result-c.cpp
+++ b/src/main/capi/result-c.cpp
@@ -21,7 +21,7 @@ struct CStringConverter {
 	static DST Convert(SRC input) {
 		auto result = (char *)duckdb_malloc(input.GetSize() + 1);
 		assert(result);
-		memcpy((void *)result, input.GetDataUnsafe(), input.GetSize());
+		memcpy((void *)result, input.GetData(), input.GetSize());
 		auto write_arr = (char *)result;
 		write_arr[input.GetSize()] = '\0';
 		return result;
@@ -40,7 +40,7 @@ struct CBlobConverter {
 		result.data = (char *)duckdb_malloc(input.GetSize());
 		result.size = input.GetSize();
 		assert(result.data);
-		memcpy((void *)result.data, input.GetDataUnsafe(), input.GetSize());
+		memcpy((void *)result.data, input.GetData(), input.GetSize());
 		return result;
 	}
 

--- a/src/storage/checkpoint/write_overflow_strings_to_disk.cpp
+++ b/src/storage/checkpoint/write_overflow_strings_to_disk.cpp
@@ -33,7 +33,7 @@ void WriteOverflowStringsToDisk::WriteString(string_t string, block_id_t &result
 	size_t compressed_size = 0;
 	compressed_size = s.MaxCompressedLength(uncompressed_size);
 	auto compressed_buf = unique_ptr<data_t[]>(new data_t[compressed_size]);
-	s.Compress((const char *)string.GetDataUnsafe(), uncompressed_size, (char *)compressed_buf.get(), &compressed_size);
+	s.Compress((const char *)string.GetData(), uncompressed_size, (char *)compressed_buf.get(), &compressed_size);
 	string_t compressed_string((const char *)compressed_buf.get(), compressed_size);
 
 	// store sizes
@@ -43,7 +43,7 @@ void WriteOverflowStringsToDisk::WriteString(string_t string, block_id_t &result
 
 	// now write the remainder of the string
 	offset += 2 * sizeof(uint32_t);
-	auto strptr = compressed_string.GetDataUnsafe();
+	auto strptr = compressed_string.GetData();
 	uint32_t remaining = compressed_size;
 	while (remaining > 0) {
 		uint32_t to_write = MinValue<uint32_t>(remaining, STRING_SPACE - offset);

--- a/src/storage/compression/dictionary_compression.cpp
+++ b/src/storage/compression/dictionary_compression.cpp
@@ -208,7 +208,7 @@ public:
 		// Copy string to dict
 		current_dictionary.size += str.GetSize();
 		auto dict_pos = current_end_ptr - current_dictionary.size;
-		memcpy(dict_pos, str.GetDataUnsafe(), str.GetSize());
+		memcpy(dict_pos, str.GetData(), str.GetSize());
 		current_dictionary.Verify();
 		D_ASSERT(current_dictionary.end == Storage::BLOCK_SIZE);
 

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -155,7 +155,7 @@ idx_t FSSTStorage::StringFinalAnalyze(AnalyzeState &state_p) {
 	vector<unsigned char *> fsst_string_ptrs;
 	for (auto &str : state.fsst_strings) {
 		fsst_string_sizes.push_back(str.GetSize());
-		fsst_string_ptrs.push_back((unsigned char *)str.GetDataUnsafe());
+		fsst_string_ptrs.push_back((unsigned char *)str.GetData());
 	}
 
 	state.fsst_encoder = duckdb_fsst_create(string_count, &fsst_string_sizes[0], &fsst_string_ptrs[0], 0);
@@ -431,7 +431,7 @@ void FSSTStorage::Compress(CompressionState &state_p, Vector &scan_vector, idx_t
 		total_count++;
 		total_size += data[idx].GetSize();
 		sizes_in.push_back(data[idx].GetSize());
-		strings_in.push_back((unsigned char *)data[idx].GetDataUnsafe());
+		strings_in.push_back((unsigned char *)data[idx].GetData());
 	}
 
 	// Only Nulls or empty strings in this vector, nothing to compress
@@ -669,7 +669,7 @@ void FSSTStorage::StringFetchRow(ColumnSegment &segment, ColumnFetchState &state
 		    segment, dict, result, base_ptr, delta_decode_buffer[offsets.unused_delta_decoded_values], string_length);
 
 		result_data[result_idx] = FSSTPrimitives::DecompressValue(
-		    (void *)&decoder, result, (unsigned char *)compressed_string.GetDataUnsafe(), compressed_string.GetSize());
+		    (void *)&decoder, result, (unsigned char *)compressed_string.GetData(), compressed_string.GetSize());
 	} else {
 		// There's no fsst symtable, this only happens for empty strings or nulls, we can just emit an empty string
 		result_data[result_idx] = string_t(nullptr, 0);

--- a/src/storage/compression/string_uncompressed.cpp
+++ b/src/storage/compression/string_uncompressed.cpp
@@ -267,7 +267,7 @@ void UncompressedStringStorage::WriteStringMemory(ColumnSegment &segment, string
 	auto ptr = handle.Ptr() + state.head->offset;
 	Store<uint32_t>(string.GetSize(), ptr);
 	ptr += sizeof(uint32_t);
-	memcpy(ptr, string.GetDataUnsafe(), string.GetSize());
+	memcpy(ptr, string.GetData(), string.GetSize());
 	state.head->offset += total_length;
 }
 

--- a/src/storage/statistics/string_stats.cpp
+++ b/src/storage/statistics/string_stats.cpp
@@ -116,7 +116,7 @@ static void ConstructValue(const_data_ptr_t data, idx_t size, data_t target[]) {
 }
 
 void StringStats::Update(BaseStatistics &stats, const string_t &value) {
-	auto data = (const_data_ptr_t)value.GetDataUnsafe();
+	auto data = (const_data_ptr_t)value.GetData();
 	auto size = value.GetSize();
 
 	//! we can only fit 8 bytes, so we might need to trim our string
@@ -238,7 +238,7 @@ void StringStats::Verify(const BaseStatistics &stats, Vector &vector, const Sele
 			continue;
 		}
 		auto value = data[index];
-		auto data = value.GetDataUnsafe();
+		auto data = value.GetData();
 		auto len = value.GetSize();
 		// LCOV_EXCL_START
 		if (string_data.has_max_string_length && len > string_data.max_string_length) {

--- a/test/api/udf_function/udf_functions_to_test.hpp
+++ b/test/api/udf_function/udf_functions_to_test.hpp
@@ -143,7 +143,7 @@ static void udf_unary_function(DataChunk &input, ExpressionState &state, Vector 
 			auto input_length = ldata[i].GetSize();
 			string_t target = StringVector::EmptyString(result, input_length);
 			auto target_data = target.GetDataWriteable();
-			memcpy(target_data, ldata[i].GetDataUnsafe(), input_length);
+			memcpy(target_data, ldata[i].GetData(), input_length);
 			target.Finalize();
 			result_data[i] = target;
 		}
@@ -183,7 +183,7 @@ static void udf_binary_function(DataChunk &input, ExpressionState &state, Vector
 			auto input_length = ldata[i].GetSize();
 			string_t target = StringVector::EmptyString(result, input_length);
 			auto target_data = target.GetDataWriteable();
-			memcpy(target_data, ldata[i].GetDataUnsafe(), input_length);
+			memcpy(target_data, ldata[i].GetData(), input_length);
 			target.Finalize();
 			result_data[i] = target;
 		}
@@ -223,7 +223,7 @@ static void udf_ternary_function(DataChunk &input, ExpressionState &state, Vecto
 			auto input_length = ldata[i].GetSize();
 			string_t target = StringVector::EmptyString(result, input_length);
 			auto target_data = target.GetDataWriteable();
-			memcpy(target_data, ldata[i].GetDataUnsafe(), input_length);
+			memcpy(target_data, ldata[i].GetData(), input_length);
 			target.Finalize();
 			result_data[i] = target;
 		}

--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -784,7 +784,7 @@ JNIEXPORT jobjectArray JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1fetch(
 					continue;
 				}
 				auto &d_str = ((string_t *)FlatVector::GetData(vec))[row_idx];
-				auto j_obj = env->NewDirectByteBuffer((void *)d_str.GetDataUnsafe(), d_str.GetSize());
+				auto j_obj = env->NewDirectByteBuffer((void *)d_str.GetData(), d_str.GetSize());
 				env->SetObjectArrayElement(varlen_data, row_idx, j_obj);
 			}
 			break;
@@ -804,7 +804,7 @@ JNIEXPORT jobjectArray JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1fetch(
 					continue;
 				}
 				auto d_str = ((string_t *)FlatVector::GetData(vec))[row_idx];
-				auto j_str = decode_charbuffer_to_jstring(env, d_str.GetDataUnsafe(), d_str.GetSize());
+				auto j_str = decode_charbuffer_to_jstring(env, d_str.GetData(), d_str.GetSize());
 				env->SetObjectArrayElement(varlen_data, row_idx, j_str);
 			}
 			break;

--- a/tools/nodejs/src/data_chunk.cpp
+++ b/tools/nodejs/src/data_chunk.cpp
@@ -151,7 +151,7 @@ Napi::Array EncodeDataChunk(Napi::Env env, duckdb::DataChunk &chunk, bool with_t
 					auto data = duckdb::FlatVector::GetData<duckdb::string_t>(*vec);
 
 					for (size_t i = 0; i < chunk.size(); ++i) {
-						auto buf = Napi::Buffer<char>::Copy(env, data[i].GetDataUnsafe(), data[i].GetSize());
+						auto buf = Napi::Buffer<char>::Copy(env, data[i].GetData(), data[i].GetSize());
 						array.Set(i, buf);
 					}
 					desc.Set("data", array);

--- a/tools/nodejs/src/statement.cpp
+++ b/tools/nodejs/src/statement.cpp
@@ -377,8 +377,8 @@ struct RunPreparedTask : public Task {
 					// query results, the string data is owned by the QueryResult
 					auto result_ref_ptr = new std::shared_ptr<duckdb::QueryResult>(result_ptr);
 
-					auto array_buffer = Napi::ArrayBuffer::New(env, (void *)blob.GetDataUnsafe(), blob.GetSize(),
-					                                           deleter, result_ref_ptr);
+					auto array_buffer =
+					    Napi::ArrayBuffer::New(env, (void *)blob.GetData(), blob.GetSize(), deleter, result_ref_ptr);
 
 					auto typed_array = Napi::Uint8Array::New(env, blob.GetSize(), array_buffer, 0);
 
@@ -615,7 +615,7 @@ struct GetNextArrowIpcTask : public Task {
 			delete static_cast<unique_ptr<duckdb::DataChunk> *>(hint);
 		};
 		auto array_buffer =
-		    Napi::ArrayBuffer::New(env, (void *)blob.GetDataUnsafe(), blob.GetSize(), deleter, data_chunk_ptr);
+		    Napi::ArrayBuffer::New(env, (void *)blob.GetData(), blob.GetSize(), deleter, data_chunk_ptr);
 
 		deferred.Resolve(array_buffer);
 	}

--- a/tools/pythonpkg/src/array_wrapper.cpp
+++ b/tools/pythonpkg/src/array_wrapper.cpp
@@ -186,7 +186,7 @@ struct StringConvert {
 	static PyObject *ConvertValue(string_t val) {
 		// we could use PyUnicode_FromStringAndSize here, but it does a lot of verification that we don't need
 		// because of that it is a lot slower than it needs to be
-		auto data = (uint8_t *)val.GetDataUnsafe();
+		auto data = (uint8_t *)val.GetData();
 		auto len = val.GetSize();
 		// check if there are any non-ascii characters in there
 		for (idx_t i = 0; i < len; i++) {
@@ -211,7 +211,7 @@ struct StringConvert {
 struct BlobConvert {
 	template <class DUCKDB_T, class NUMPY_T>
 	static PyObject *ConvertValue(string_t val) {
-		return PyByteArray_FromStringAndSize(val.GetDataUnsafe(), val.GetSize());
+		return PyByteArray_FromStringAndSize(val.GetData(), val.GetSize());
 	}
 
 	template <class NUMPY_T>
@@ -223,7 +223,7 @@ struct BlobConvert {
 struct BitConvert {
 	template <class DUCKDB_T, class NUMPY_T>
 	static PyObject *ConvertValue(string_t val) {
-		return PyBytes_FromStringAndSize(val.GetDataUnsafe(), val.GetSize());
+		return PyBytes_FromStringAndSize(val.GetData(), val.GetSize());
 	}
 
 	template <class NUMPY_T>

--- a/tools/rpkg/src/transform.cpp
+++ b/tools/rpkg/src/transform.cpp
@@ -193,7 +193,7 @@ void duckdb_r_decorate(const LogicalType &type, const SEXP dest, bool integer64)
 }
 
 SEXP ToRString(const string_t &input) {
-	auto data = input.GetDataUnsafe();
+	auto data = input.GetData();
 	auto len = input.GetSize();
 	idx_t has_null_byte = 0;
 	for (idx_t c = 0; c < len; c++) {
@@ -423,7 +423,7 @@ void duckdb_r_transform(Vector &src_vec, const SEXP dest, idx_t dest_offset, idx
 				if (!rawval) {
 					throw std::bad_alloc();
 				}
-				memcpy(RAW_POINTER(rawval), src_ptr[row_idx].GetDataUnsafe(), src_ptr[row_idx].GetSize());
+				memcpy(RAW_POINTER(rawval), src_ptr[row_idx].GetData(), src_ptr[row_idx].GetSize());
 				SET_VECTOR_ELT(dest, dest_offset + row_idx, rawval);
 			}
 		}


### PR DESCRIPTION
This was initially named `GetDataUnsafe` after we removed the null-termination requirement for `string_t`. Now that it is clear `string_t` are not null-terminated it is time to rename this - there is nothing inherently unsafe about non-null terminated strings, except that certain C methods do not work with them. I would argue the unsafety is with those C methods instead of with the non-null terminated string.