### PR TITLE
Fix rel to sql

### DIFF
--- a/src/include/duckdb/parser/expression/window_expression.hpp
+++ b/src/include/duckdb/parser/expression/window_expression.hpp
@@ -87,8 +87,10 @@ public:
 		// Start with function call
 		string result = schema.empty() ? function_name : schema + "." + function_name;
 		result += "(";
-		result += StringUtil::Join(entry.children, entry.children.size(), ", ",
-		                           [](const unique_ptr<BASE> &child) { return child->ToString(); });
+		if (entry.children.size()) {
+			result += StringUtil::Join(entry.children, entry.children.size(), ", ",
+			                           [](const unique_ptr<BASE> &child) { return child->ToString(); });
+		}
 		// Lead/Lag extra arguments
 		if (entry.offset_expr.get()) {
 			result += ", ";

--- a/tools/rpkg/src/relational.cpp
+++ b/tools/rpkg/src/relational.cpp
@@ -245,6 +245,14 @@ static WindowBoundary StringToWindowBoundary(string &window_boundary) {
 	}
 }
 
+bool constant_expression_is_not_null(duckdb::expr_extptr_t expr) {
+	if (expr->type == ExpressionType::VALUE_CONSTANT) {
+		auto const_expr = expr->Cast<ConstantExpression>();
+		return !const_expr.value.IsNull();
+	}
+	return true;
+}
+
 [[cpp11::register]] SEXP rapi_expr_window(duckdb::expr_extptr_t window_function, list partitions, list order_bys,
                                           std::string window_boundary_start, std::string window_boundary_end,
                                           duckdb::expr_extptr_t start_expr, duckdb::expr_extptr_t end_expr,
@@ -274,16 +282,17 @@ static WindowBoundary StringToWindowBoundary(string &window_boundary) {
 	for (expr_extptr_t partition : partitions) {
 		window_expr->partitions.push_back(partition->Copy());
 	}
-	if (start_expr) {
+
+	if (constant_expression_is_not_null(start_expr)) {
 		window_expr->start_expr = start_expr->Copy();
 	}
-	if (end_expr) {
+	if (constant_expression_is_not_null(end_expr)) {
 		window_expr->end_expr = end_expr->Copy();
 	}
-	if (offset_expr) {
+	if (constant_expression_is_not_null(offset_expr)) {
 		window_expr->offset_expr = offset_expr->Copy();
 	}
-	if (default_expr) {
+	if (constant_expression_is_not_null(default_expr)) {
 		window_expr->default_expr = default_expr->Copy();
 	}
 


### PR DESCRIPTION
Check the window parameter constant expressions to see if they are null. This way, ToString() won't print them.
https://github.com/duckdb/duckdb-r/issues/7