### PR TITLE
Correctly zero-initialize all unused memory in storage blocks, plus add CI run to ensure all memory is correctly initialized

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -204,6 +204,38 @@ jobs:
       shell: bash
       run: build/debug/test/unittest
 
+
+ storage-initialization:
+    name: Storage Initialization Verification
+    runs-on: ubuntu-20.04
+    env:
+      CC: gcc-10
+      CXX: g++-10
+      GEN: ninja
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Install
+      shell: bash
+      run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
+
+    - name: Setup Ccache
+      uses: hendrikmuhs/ccache-action@main
+      with:
+        key: ${{ github.job }}
+        save: ${{ github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb' }}
+
+    - name: Build
+      shell: bash
+      run: make debug
+
+    - name: Test
+      shell: bash
+      run: python3 scripts/test_zero_initialize.py
+
  threadsan:
     name: Thread Sanitizer
     runs-on: ubuntu-20.04

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -207,6 +207,7 @@ jobs:
 
  storage-initialization:
     name: Storage Initialization Verification
+    needs: linux-debug
     runs-on: ubuntu-20.04
     env:
       CC: gcc-10

--- a/scripts/test_zero_initialize.py
+++ b/scripts/test_zero_initialize.py
@@ -1,0 +1,75 @@
+import os
+import argparse
+import subprocess
+import shutil
+
+parser = argparse.ArgumentParser(description='''Runs storage tests both with and without explicit zero-initialization, and verifies that the final storage files are the same.
+The purpose of this is to verify all memory is correctly initialized before writing to disk - which prevents leaking of in-memory data in storage files by writing uninitialized memory to disk.''')
+parser.add_argument('--unittest', default='build/debug/test/unittest', help='path to unittest', dest='unittest')
+parser.add_argument('--zero_init_dir', default='test_zero_init_db', help='directory to write zero-initialized databases to', dest='zero_init_dir')
+parser.add_argument('--standard_dir', default='test_standard_db', help='directory to write regular databases to', dest='standard_dir')
+
+args = parser.parse_args()
+
+test_list = [
+    'test/sql/storage/test_store_integers.test'
+]
+
+def run_test(args):
+    res = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout = res.stdout.decode('utf8').strip()
+    stderr = res.stderr.decode('utf8').strip()
+    if res.returncode != 0:
+        print("Failed to run test!")
+        print("----------STDOUT-----------")
+        print(stdout)
+        print("----------STDERR-----------")
+        print(stderr)
+        print("---------------------")
+        exit(1)
+
+header_size = 4096 * 3
+block_size = 262144
+
+def compare_database(standard_db, zero_init_db):
+    with open(standard_db, 'rb') as f:
+        standard_data = f.read()
+    with open(zero_init_db, 'rb') as f:
+        zero_data = f.read()
+    if len(standard_data) != len(zero_data):
+        print(f"Length mismatch between database {standard_db} ({str(len(standard_data))}) and {zero_init_db} ({str(len(zero_data))})")
+        exit(1)
+    for i in range(len(standard_data)):
+        if standard_data[i] != zero_data[i]:
+            print(f"Mismatch between standard database ({standard_data[i]}) and zero-initialized database ({zero_data[i]}) at byte position {i}")
+            if i < header_size:
+                print("This byte is in the initial headers of the file")
+            else:
+                print(f"This byte is in block id {(i - header_size) // block_size}")
+            print("This likely means that memory was not correctly zero-initialized in a block before being written out to disk")
+            exit(1)
+    print("Success!")
+
+def compare_files(standard_dir, zero_init_dir):
+    standard_list = os.listdir(standard_dir)
+    zero_init_list = os.listdir(zero_init_dir)
+    standard_list.sort()
+    zero_init_list.sort()
+    if standard_list != zero_init_list:
+        print(f"Directories contain mismatching files (standard - {str(standard_list)}, zero init - {str(zero_init_list)})")
+        exit(1)
+    for entry in standard_list:
+        compare_database(os.path.join(standard_dir, entry), os.path.join(zero_init_dir, entry))
+
+
+for test in test_list:
+    print(f"Running test {test}")
+    shutil.rmtree(args.standard_dir)
+    shutil.rmtree(args.zero_init_dir)
+    standard_args = [args.unittest, '--test-temp-dir', args.standard_dir, test]
+    zero_init_args = [args.unittest, '--test-temp-dir', args.zero_init_dir, '--zero-initialize', test]
+    print(f"Running test in standard mode")
+    run_test(standard_args)
+    print(f"Running test in zero-initialize mode")
+    run_test(zero_init_args)
+    compare_files(args.standard_dir, args.zero_init_dir)

--- a/scripts/test_zero_initialize.py
+++ b/scripts/test_zero_initialize.py
@@ -12,7 +12,13 @@ parser.add_argument('--standard_dir', default='test_standard_db', help='director
 args = parser.parse_args()
 
 test_list = [
-    'test/sql/storage/test_store_integers.test'
+    'test/sql/storage/compression/compression_selection.test',
+    'test/sql/storage/compression/simple_compression.test',
+    'test/sql/storage/test_store_deletes.test',
+    'test/sql/storage/test_store_nulls_strings.test',
+    'test/sql/storage/test_store_null_updates.test',
+    'test/sql/storage/test_store_integers.test',
+    'test/sql/storage/test_update_delete_string.test'
 ]
 
 def run_test(args):
@@ -37,11 +43,11 @@ def compare_database(standard_db, zero_init_db):
     with open(zero_init_db, 'rb') as f:
         zero_data = f.read()
     if len(standard_data) != len(zero_data):
-        print(f"Length mismatch between database {standard_db} ({str(len(standard_data))}) and {zero_init_db} ({str(len(zero_data))})")
+        print(f"FAIL - Length mismatch between database {standard_db} ({str(len(standard_data))}) and {zero_init_db} ({str(len(zero_data))})")
         exit(1)
     for i in range(len(standard_data)):
         if standard_data[i] != zero_data[i]:
-            print(f"Mismatch between standard database ({standard_data[i]}) and zero-initialized database ({zero_data[i]}) at byte position {i}")
+            print(f"FAIL - Mismatch between standard database ({standard_data[i]}) and zero-initialized database ({zero_data[i]}) at byte position {i}")
             if i < header_size:
                 print("This byte is in the initial headers of the file")
             else:
@@ -56,7 +62,10 @@ def compare_files(standard_dir, zero_init_dir):
     standard_list.sort()
     zero_init_list.sort()
     if standard_list != zero_init_list:
-        print(f"Directories contain mismatching files (standard - {str(standard_list)}, zero init - {str(zero_init_list)})")
+        print(f"FAIL - Directories contain mismatching files (standard - {str(standard_list)}, zero init - {str(zero_init_list)})")
+        exit(1)
+    if len(standard_list) == 0:
+        print("FAIL - Directory is empty!")
         exit(1)
     for entry in standard_list:
         compare_database(os.path.join(standard_dir, entry), os.path.join(zero_init_dir, entry))

--- a/scripts/test_zero_initialize.py
+++ b/scripts/test_zero_initialize.py
@@ -3,7 +3,7 @@ import argparse
 import subprocess
 import shutil
 
-parser = argparse.ArgumentParser(description='''Runs storage tests both with and without explicit zero-initialization, and verifies that the final storage files are the same.
+parser = argparse.ArgumentParser(description='''Runs storage tests both with explicit one-initialization and with explicit zero-initialization, and verifies that the final storage files are the same.
 The purpose of this is to verify all memory is correctly initialized before writing to disk - which prevents leaking of in-memory data in storage files by writing uninitialized memory to disk.''')
 parser.add_argument('--unittest', default='build/debug/test/unittest', help='path to unittest', dest='unittest')
 parser.add_argument('--zero_init_dir', default='test_zero_init_db', help='directory to write zero-initialized databases to', dest='zero_init_dir')
@@ -66,9 +66,9 @@ for test in test_list:
     print(f"Running test {test}")
     shutil.rmtree(args.standard_dir)
     shutil.rmtree(args.zero_init_dir)
-    standard_args = [args.unittest, '--test-temp-dir', args.standard_dir, test]
+    standard_args = [args.unittest, '--test-temp-dir', args.standard_dir, test, '--one-initialize']
     zero_init_args = [args.unittest, '--test-temp-dir', args.zero_init_dir, '--zero-initialize', test]
-    print(f"Running test in standard mode")
+    print(f"Running test in one-initialize mode")
     run_test(standard_args)
     print(f"Running test in zero-initialize mode")
     run_test(zero_init_args)

--- a/scripts/test_zero_initialize.py
+++ b/scripts/test_zero_initialize.py
@@ -71,10 +71,18 @@ def compare_files(standard_dir, zero_init_dir):
         compare_database(os.path.join(standard_dir, entry), os.path.join(zero_init_dir, entry))
 
 
+def clear_directories(directories):
+    for dir in directories:
+        try:
+            shutil.rmtree(dir)
+        except FileNotFoundError as e:
+            pass
+
+test_dirs = [args.standard_dir, args.zero_init_dir]
+
 for test in test_list:
     print(f"Running test {test}")
-    shutil.rmtree(args.standard_dir)
-    shutil.rmtree(args.zero_init_dir)
+    clear_directories(test_dirs)
     standard_args = [args.unittest, '--test-temp-dir', args.standard_dir, test, '--one-initialize']
     zero_init_args = [args.unittest, '--test-temp-dir', args.zero_init_dir, '--zero-initialize', test]
     print(f"Running test in one-initialize mode")
@@ -82,3 +90,5 @@ for test in test_list:
     print(f"Running test in zero-initialize mode")
     run_test(zero_init_args)
     compare_files(args.standard_dir, args.zero_init_dir)
+
+clear_directories(test_dirs)

--- a/scripts/test_zero_initialize.py
+++ b/scripts/test_zero_initialize.py
@@ -27,6 +27,8 @@ def run_test(args):
     stderr = res.stderr.decode('utf8').strip()
     if res.returncode != 0:
         print("Failed to run test!")
+        print("----------COMMAND-----------")
+        print(' '.join(args))
         print("----------STDOUT-----------")
         print(stdout)
         print("----------STDERR-----------")

--- a/scripts/test_zero_initialize.py
+++ b/scripts/test_zero_initialize.py
@@ -111,8 +111,8 @@ test_dirs = [args.standard_dir, args.zero_init_dir]
 for test in test_list:
     print(f"Running test {test}")
     clear_directories(test_dirs)
-    standard_args = [args.unittest, '--test-temp-dir', args.standard_dir, test, '--one-initialize']
-    zero_init_args = [args.unittest, '--test-temp-dir', args.zero_init_dir, '--zero-initialize', test]
+    standard_args = [args.unittest, '--test-temp-dir', args.standard_dir, '--one-initialize', '--single-threaded', test]
+    zero_init_args = [args.unittest, '--test-temp-dir', args.zero_init_dir, '--zero-initialize', '--single-threaded', test]
     print(f"Running test in one-initialize mode")
     run_test(standard_args)
     print(f"Running test in zero-initialize mode")

--- a/src/common/file_buffer.cpp
+++ b/src/common/file_buffer.cpp
@@ -105,5 +105,4 @@ void FileBuffer::Initialize(DebugInitialize initialize) {
 	memset(internal_buffer, value, internal_size);
 }
 
-
 } // namespace duckdb

--- a/src/common/file_buffer.cpp
+++ b/src/common/file_buffer.cpp
@@ -97,4 +97,13 @@ void FileBuffer::Clear() {
 	memset(internal_buffer, 0, internal_size);
 }
 
+void FileBuffer::Initialize(DebugInitialize initialize) {
+	if (initialize == DebugInitialize::NO_INITIALIZE) {
+		return;
+	}
+	uint8_t value = initialize == DebugInitialize::DEBUG_ZERO_INITIALIZE ? 0 : 0xFF;
+	memset(internal_buffer, value, internal_size);
+}
+
+
 } // namespace duckdb

--- a/src/include/duckdb/common/enums/debug_initialize.hpp
+++ b/src/include/duckdb/common/enums/debug_initialize.hpp
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/debug_initialize.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+
+enum class DebugInitialize : uint8_t { NO_INITIALIZE = 0, DEBUG_ZERO_INITIALIZE = 1, DEBUG_ONE_INITIALIZE = 2 };
+
+} // namespace duckdb

--- a/src/include/duckdb/common/file_buffer.hpp
+++ b/src/include/duckdb/common/file_buffer.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/constants.hpp"
+#include "duckdb/common/enums/debug_initialize.hpp"
 
 namespace duckdb {
 class Allocator;
@@ -61,6 +62,8 @@ public:
 	};
 
 	MemoryRequirement CalculateMemory(uint64_t user_size);
+
+	void Initialize(DebugInitialize info);
 
 protected:
 	//! The pointer to the internal buffer that will be read or written, including the buffer header

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -145,6 +145,8 @@ struct DBConfigOptions {
 	bool enable_fsst_vectors = false;
 	//! Start transactions immediately in all attached databases - instead of lazily when a database is referenced
 	bool immediate_transaction_mode = false;
+	//! Debug setting - whether or not to zero-initialize  blocks in the storage layer when allocating
+	bool zero_initialize = false;
 	//! The set of unrecognized (other) options
 	unordered_map<string, Value> unrecognized_options;
 

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -49,6 +49,12 @@ enum class CheckpointAbort : uint8_t {
 	DEBUG_ABORT_AFTER_FREE_LIST_WRITE = 3
 };
 
+enum class DebugInitialize : uint8_t {
+	NO_INITIALIZE = 0,
+	DEBUG_ZERO_INITIALIZE = 1,
+	DEBUG_ONE_INITIALIZE = 2
+};
+
 typedef void (*set_global_function_t)(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 typedef void (*set_local_function_t)(ClientContext &context, const Value &parameter);
 typedef void (*reset_global_function_t)(DatabaseInstance *db, DBConfig &config);
@@ -145,8 +151,8 @@ struct DBConfigOptions {
 	bool enable_fsst_vectors = false;
 	//! Start transactions immediately in all attached databases - instead of lazily when a database is referenced
 	bool immediate_transaction_mode = false;
-	//! Debug setting - whether or not to zero-initialize  blocks in the storage layer when allocating
-	bool zero_initialize = false;
+	//! Debug setting - how to initialize  blocks in the storage layer when allocating
+	DebugInitialize debug_initialize = DebugInitialize::NO_INITIALIZE;
 	//! The set of unrecognized (other) options
 	unordered_map<string, Value> unrecognized_options;
 

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -49,8 +49,6 @@ enum class CheckpointAbort : uint8_t {
 	DEBUG_ABORT_AFTER_FREE_LIST_WRITE = 3
 };
 
-enum class DebugInitialize : uint8_t { NO_INITIALIZE = 0, DEBUG_ZERO_INITIALIZE = 1, DEBUG_ONE_INITIALIZE = 2 };
-
 typedef void (*set_global_function_t)(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 typedef void (*set_local_function_t)(ClientContext &context, const Value &parameter);
 typedef void (*reset_global_function_t)(DatabaseInstance *db, DBConfig &config);

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -49,11 +49,7 @@ enum class CheckpointAbort : uint8_t {
 	DEBUG_ABORT_AFTER_FREE_LIST_WRITE = 3
 };
 
-enum class DebugInitialize : uint8_t {
-	NO_INITIALIZE = 0,
-	DEBUG_ZERO_INITIALIZE = 1,
-	DEBUG_ONE_INITIALIZE = 2
-};
+enum class DebugInitialize : uint8_t { NO_INITIALIZE = 0, DEBUG_ZERO_INITIALIZE = 1, DEBUG_ONE_INITIALIZE = 2 };
 
 typedef void (*set_global_function_t)(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 typedef void (*set_local_function_t)(ClientContext &context, const Value &parameter);

--- a/src/include/duckdb/storage/block_manager.hpp
+++ b/src/include/duckdb/storage/block_manager.hpp
@@ -33,6 +33,7 @@ public:
 
 public:
 	//! Creates a new block inside the block manager
+	virtual unique_ptr<Block> ConvertBlock(block_id_t block_id, FileBuffer &source_buffer) = 0;
 	virtual unique_ptr<Block> CreateBlock(block_id_t block_id, FileBuffer *source_buffer) = 0;
 	//! Return the next free block id
 	virtual block_id_t GetFreeBlockId() = 0;

--- a/src/include/duckdb/storage/in_memory_block_manager.hpp
+++ b/src/include/duckdb/storage/in_memory_block_manager.hpp
@@ -20,6 +20,9 @@ public:
 	using BlockManager::BlockManager;
 
 	// LCOV_EXCL_START
+	unique_ptr<Block> ConvertBlock(block_id_t block_id, FileBuffer &source_buffer) override {
+		throw InternalException("Cannot perform IO in in-memory database!");
+	}
 	unique_ptr<Block> CreateBlock(block_id_t block_id, FileBuffer *source_buffer) override {
 		throw InternalException("Cannot perform IO in in-memory database!");
 	}

--- a/src/include/duckdb/storage/partial_block_manager.hpp
+++ b/src/include/duckdb/storage/partial_block_manager.hpp
@@ -44,6 +44,7 @@ struct PartialBlock {
 	PartialBlockState state;
 
 public:
+	virtual void AddUninitializedRegion(idx_t start, idx_t end) = 0;
 	virtual void Flush(idx_t free_space_left) = 0;
 	virtual void Clear() {
 	}

--- a/src/include/duckdb/storage/partial_block_manager.hpp
+++ b/src/include/duckdb/storage/partial_block_manager.hpp
@@ -44,7 +44,7 @@ struct PartialBlock {
 	PartialBlockState state;
 
 public:
-	virtual void Flush() = 0;
+	virtual void Flush(idx_t free_space_left) = 0;
 	virtual void Clear() {
 	}
 };

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/unordered_set.hpp"
 #include "duckdb/common/set.hpp"
 #include "duckdb/common/vector.hpp"
+#include "duckdb/main/config.hpp"
 
 namespace duckdb {
 
@@ -23,7 +24,7 @@ class DatabaseInstance;
 struct StorageManagerOptions {
 	bool read_only = false;
 	bool use_direct_io = false;
-	bool zero_initialize = false;
+	DebugInitialize debug_initialize = DebugInitialize::NO_INITIALIZE;
 };
 
 //! SingleFileBlockManager is an implementation for a BlockManager which manages blocks in a single file

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -40,6 +40,7 @@ public:
 	void LoadExistingDatabase();
 
 	//! Creates a new Block using the specified block_id and returns a pointer
+	unique_ptr<Block> ConvertBlock(block_id_t block_id, FileBuffer &source_buffer) override;
 	unique_ptr<Block> CreateBlock(block_id_t block_id, FileBuffer *source_buffer) override;
 	//! Return the next free block id
 	block_id_t GetFreeBlockId() override;

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -20,13 +20,19 @@ namespace duckdb {
 
 class DatabaseInstance;
 
+struct StorageManagerOptions {
+	bool read_only = false;
+	bool use_direct_io = false;
+	bool zero_initialize = false;
+};
+
 //! SingleFileBlockManager is an implementation for a BlockManager which manages blocks in a single file
 class SingleFileBlockManager : public BlockManager {
 	//! The location in the file where the block writing starts
 	static constexpr uint64_t BLOCK_START = Storage::FILE_HEADER_SIZE * 3;
 
 public:
-	SingleFileBlockManager(AttachedDatabase &db, string path, bool read_only, bool use_direct_io);
+	SingleFileBlockManager(AttachedDatabase &db, string path, StorageManagerOptions options);
 
 	void GetFileFlags(uint8_t &flags, FileLockType &lock, bool create_new);
 	void CreateNewDatabase();
@@ -96,10 +102,8 @@ private:
 	block_id_t free_list_id;
 	//! The current header iteration count
 	uint64_t iteration_count;
-	//! Whether or not the db is opened in read-only mode
-	bool read_only;
-	//! Whether or not to use Direct IO to read the blocks
-	bool use_direct_io;
+	//! The storage manager options
+	StorageManagerOptions options;
 	//! Lock for performing various operations in the single file block manager
 	mutex block_lock;
 };

--- a/src/storage/buffer/block_manager.cpp
+++ b/src/storage/buffer/block_manager.cpp
@@ -33,7 +33,6 @@ void BlockManager::ClearMetaBlockHandles() {
 }
 
 shared_ptr<BlockHandle> BlockManager::ConvertToPersistent(block_id_t block_id, shared_ptr<BlockHandle> old_block) {
-
 	// pin the old block to ensure we have it loaded in memory
 	auto old_handle = buffer_manager.Pin(old_block);
 	D_ASSERT(old_block->state == BlockState::BLOCK_LOADED);

--- a/src/storage/buffer/block_manager.cpp
+++ b/src/storage/buffer/block_manager.cpp
@@ -49,7 +49,7 @@ shared_ptr<BlockHandle> BlockManager::ConvertToPersistent(block_id_t block_id, s
 
 	// move the data from the old block into data for the new block
 	new_block->state = BlockState::BLOCK_LOADED;
-	new_block->buffer = CreateBlock(block_id, old_block->buffer.get());
+	new_block->buffer = ConvertBlock(block_id, *old_block->buffer);
 	new_block->memory_usage = old_block->memory_usage;
 	new_block->memory_charge = std::move(old_block->memory_charge);
 

--- a/src/storage/meta_block_writer.cpp
+++ b/src/storage/meta_block_writer.cpp
@@ -35,6 +35,10 @@ BlockPointer MetaBlockWriter::GetBlockPointer() {
 }
 
 void MetaBlockWriter::Flush() {
+	if (offset < block->size) {
+		// clear remaining bytes of block (if any)
+		memset(block->buffer + offset, 0, block->size - offset);
+	}
 	AdvanceBlock();
 	block = nullptr;
 }

--- a/src/storage/partial_block_manager.cpp
+++ b/src/storage/partial_block_manager.cpp
@@ -56,7 +56,12 @@ bool PartialBlockManager::GetPartialBlock(idx_t segment_size, unique_ptr<Partial
 void PartialBlockManager::RegisterPartialBlock(PartialBlockAllocation &&allocation) {
 	auto &state = allocation.partial_block->state;
 	if (state.block_use_count < max_use_count) {
-		auto new_size = AlignValue(allocation.allocation_size + state.offset_in_block);
+		auto unaligned_size = allocation.allocation_size + state.offset_in_block;
+		auto new_size = AlignValue(unaligned_size);
+		if (new_size != unaligned_size) {
+			// register the uninitialized region so we can correctly initialize it before writing to disk
+			allocation.partial_block->AddUninitializedRegion(unaligned_size, new_size);
+		}
 		state.offset_in_block = new_size;
 		auto new_space_left = state.block_size - new_size;
 		// check if the block is STILL partially filled after adding the segment_size

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -107,15 +107,15 @@ T DeserializeHeaderStructure(data_ptr_t ptr) {
 	return T::Deserialize(source);
 }
 
-SingleFileBlockManager::SingleFileBlockManager(AttachedDatabase &db, string path_p, bool read_only, bool use_direct_io)
+SingleFileBlockManager::SingleFileBlockManager(AttachedDatabase &db, string path_p, StorageManagerOptions options)
     : BlockManager(BufferManager::GetBufferManager(db)), db(db), path(std::move(path_p)),
       header_buffer(Allocator::Get(db), FileBufferType::MANAGED_BUFFER,
                     Storage::FILE_HEADER_SIZE - Storage::BLOCK_HEADER_SIZE),
-      iteration_count(0), read_only(read_only), use_direct_io(use_direct_io) {
+      iteration_count(0), options(options) {
 }
 
 void SingleFileBlockManager::GetFileFlags(uint8_t &flags, FileLockType &lock, bool create_new) {
-	if (read_only) {
+	if (options.read_only) {
 		D_ASSERT(!create_new);
 		flags = FileFlags::FILE_FLAGS_READ;
 		lock = FileLockType::READ_LOCK;
@@ -126,7 +126,7 @@ void SingleFileBlockManager::GetFileFlags(uint8_t &flags, FileLockType &lock, bo
 			flags |= FileFlags::FILE_FLAGS_FILE_CREATE;
 		}
 	}
-	if (use_direct_io) {
+	if (options.use_direct_io) {
 		flags |= FileFlags::FILE_FLAGS_DIRECT_IO;
 	}
 }
@@ -241,7 +241,7 @@ void SingleFileBlockManager::Initialize(DatabaseHeader &header) {
 }
 
 void SingleFileBlockManager::LoadFreeList() {
-	if (read_only) {
+	if (options.read_only) {
 		// no need to load free list for read only db
 		return;
 	}
@@ -344,12 +344,17 @@ idx_t SingleFileBlockManager::FreeBlocks() {
 }
 
 unique_ptr<Block> SingleFileBlockManager::CreateBlock(block_id_t block_id, FileBuffer *source_buffer) {
+	unique_ptr<Block> result;
 	if (source_buffer) {
 		D_ASSERT(source_buffer->AllocSize() == Storage::BLOCK_ALLOC_SIZE);
-		return make_uniq<Block>(*source_buffer, block_id);
+		result = make_uniq<Block>(*source_buffer, block_id);
 	} else {
-		return make_uniq<Block>(Allocator::Get(db), block_id);
+		result = make_uniq<Block>(Allocator::Get(db), block_id);
+		if (options.zero_initialize) {
+			memset(result->InternalBuffer(), 0, Storage::BLOCK_ALLOC_SIZE);
+		}
 	}
+	return result;
 }
 
 void SingleFileBlockManager::Read(Block &block) {
@@ -459,7 +464,7 @@ void SingleFileBlockManager::WriteHeader(DatabaseHeader header) {
 		throw FatalException("Checkpoint aborted after free list write because of PRAGMA checkpoint_abort flag");
 	}
 
-	if (!use_direct_io) {
+	if (!options.use_direct_io) {
 		// if we are not using Direct IO we need to fsync BEFORE we write the header to ensure that all the previous
 		// blocks are written as well
 		handle->Sync();

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -350,8 +350,9 @@ unique_ptr<Block> SingleFileBlockManager::CreateBlock(block_id_t block_id, FileB
 		result = make_uniq<Block>(*source_buffer, block_id);
 	} else {
 		result = make_uniq<Block>(Allocator::Get(db), block_id);
-		if (options.zero_initialize) {
-			memset(result->InternalBuffer(), 0, Storage::BLOCK_ALLOC_SIZE);
+		if (options.debug_initialize != DebugInitialize::NO_INITIALIZE) {
+			uint8_t value = options.debug_initialize == DebugInitialize::DEBUG_ZERO_INITIALIZE ? 0 : 0xFF;
+			memset(result->InternalBuffer(), value, Storage::BLOCK_ALLOC_SIZE);
 		}
 	}
 	return result;

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -20,14 +20,17 @@ struct BufferAllocatorData : PrivateAllocatorData {
 
 unique_ptr<FileBuffer> StandardBufferManager::ConstructManagedBuffer(idx_t size, unique_ptr<FileBuffer> &&source,
                                                                      FileBufferType type) {
+	unique_ptr<FileBuffer> result;
 	if (source) {
 		auto tmp = std::move(source);
 		D_ASSERT(tmp->AllocSize() == BufferManager::GetAllocSize(size));
-		return make_uniq<FileBuffer>(*tmp, type);
+		result = make_uniq<FileBuffer>(*tmp, type);
 	} else {
 		// no re-usable buffer: allocate a new buffer
-		return make_uniq<FileBuffer>(Allocator::Get(db), type, size);
+		result = make_uniq<FileBuffer>(Allocator::Get(db), type, size);
 	}
+	result->Initialize(DBConfig::GetConfig(db).options.debug_initialize);
+	return result;
 }
 
 class TemporaryFileManager;

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -95,6 +95,11 @@ void SingleFileStorageManager::LoadDatabase() {
 	auto &fs = FileSystem::Get(db);
 	auto &config = DBConfig::Get(db);
 	bool truncate_wal = false;
+
+	StorageManagerOptions options;
+	options.read_only = read_only;
+	options.use_direct_io = config.options.use_direct_io;
+	options.zero_initialize = config.options.zero_initialize;
 	// first check if the database exists
 	if (!fs.FileExists(path)) {
 		if (read_only) {
@@ -107,13 +112,13 @@ void SingleFileStorageManager::LoadDatabase() {
 			fs.RemoveFile(wal_path);
 		}
 		// initialize the block manager while creating a new db file
-		auto sf_block_manager = make_uniq<SingleFileBlockManager>(db, path, read_only, config.options.use_direct_io);
+		auto sf_block_manager = make_uniq<SingleFileBlockManager>(db, path, options);
 		sf_block_manager->CreateNewDatabase();
 		block_manager = std::move(sf_block_manager);
 		table_io_manager = make_uniq<SingleFileTableIOManager>(*block_manager);
 	} else {
 		// initialize the block manager while loading the current db file
-		auto sf_block_manager = make_uniq<SingleFileBlockManager>(db, path, read_only, config.options.use_direct_io);
+		auto sf_block_manager = make_uniq<SingleFileBlockManager>(db, path, options);
 		sf_block_manager->LoadExistingDatabase();
 		block_manager = std::move(sf_block_manager);
 		table_io_manager = make_uniq<SingleFileTableIOManager>(*block_manager);

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -99,7 +99,7 @@ void SingleFileStorageManager::LoadDatabase() {
 	StorageManagerOptions options;
 	options.read_only = read_only;
 	options.use_direct_io = config.options.use_direct_io;
-	options.zero_initialize = config.options.zero_initialize;
+	options.debug_initialize = config.options.debug_initialize;
 	// first check if the database exists
 	if (!fs.FileExists(path)) {
 		if (read_only) {

--- a/src/storage/table/column_checkpoint_state.cpp
+++ b/src/storage/table/column_checkpoint_state.cpp
@@ -61,6 +61,7 @@ public:
 		// into the page owned by first_segment. We flush all segment data to
 		// disk with the following call.
 		if (free_space_left > 0) {
+			// memset any free space to 0 prior to writing to disk
 			auto handle = block_manager.buffer_manager.Pin(first_segment->block);
 			memset(handle.Ptr() + Storage::BLOCK_SIZE - free_space_left, 0, free_space_left);
 		}

--- a/src/storage/table/column_checkpoint_state.cpp
+++ b/src/storage/table/column_checkpoint_state.cpp
@@ -71,7 +71,7 @@ public:
 		// At this point, we've already copied all data from tail_segments
 		// into the page owned by first_segment. We flush all segment data to
 		// disk with the following call.
-		if (free_space_left > 0) {
+		if (free_space_left > 0 || !uninitialized_regions.empty()) {
 			auto handle = block_manager.buffer_manager.Pin(first_segment->block);
 			// memset any uninitialized regions
 			for (auto &uninitialized : uninitialized_regions) {

--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -124,7 +124,7 @@ unique_ptr<DBConfig> GetTestConfig() {
 	auto result = make_uniq<DBConfig>();
 	result->options.checkpoint_wal_size = 0;
 	result->options.allow_unsigned_extensions = true;
-	switch(debug_initialize_value) {
+	switch (debug_initialize_value) {
 	case -1:
 		break;
 	case 0:

--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -22,6 +22,7 @@ using namespace std;
 namespace duckdb {
 static string custom_test_directory;
 static int debug_initialize_value = -1;
+static bool single_threaded = false;
 
 bool NO_FAIL(QueryResult &result) {
 	if (result.HasError()) {
@@ -80,6 +81,10 @@ void SetDebugInitialize(int value) {
 	debug_initialize_value = value;
 }
 
+void SetSingleThreaded() {
+	single_threaded = true;
+}
+
 string GetTestDirectory() {
 	if (custom_test_directory.empty()) {
 		return TESTING_DIRECTORY_NAME;
@@ -124,6 +129,9 @@ unique_ptr<DBConfig> GetTestConfig() {
 	auto result = make_uniq<DBConfig>();
 	result->options.checkpoint_wal_size = 0;
 	result->options.allow_unsigned_extensions = true;
+	if (single_threaded) {
+		result->options.maximum_threads = 1;
+	}
 	switch (debug_initialize_value) {
 	case -1:
 		break;

--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -21,7 +21,7 @@ using namespace std;
 
 namespace duckdb {
 static string custom_test_directory;
-static bool zero_initialize = false;
+static int debug_initialize_value = -1;
 
 bool NO_FAIL(QueryResult &result) {
 	if (result.HasError()) {
@@ -76,8 +76,8 @@ void SetTestDirectory(string path) {
 	custom_test_directory = path;
 }
 
-void SetZeroInitialize(bool new_zero_init) {
-	zero_initialize = new_zero_init;
+void SetDebugInitialize(int value) {
+	debug_initialize_value = value;
 }
 
 string GetTestDirectory() {
@@ -124,7 +124,19 @@ unique_ptr<DBConfig> GetTestConfig() {
 	auto result = make_uniq<DBConfig>();
 	result->options.checkpoint_wal_size = 0;
 	result->options.allow_unsigned_extensions = true;
-	result->options.zero_initialize = zero_initialize;
+	switch(debug_initialize_value) {
+	case -1:
+		break;
+	case 0:
+		result->options.debug_initialize = DebugInitialize::DEBUG_ZERO_INITIALIZE;
+		break;
+	case 0xFF:
+		result->options.debug_initialize = DebugInitialize::DEBUG_ONE_INITIALIZE;
+		break;
+	default:
+		fprintf(stderr, "Invalid value for debug_initialize_value\n");
+		exit(1);
+	}
 	return result;
 }
 

--- a/test/include/test_helpers.hpp
+++ b/test/include/test_helpers.hpp
@@ -41,7 +41,9 @@ string TestDirectoryPath();
 string TestCreatePath(string suffix);
 unique_ptr<DBConfig> GetTestConfig();
 bool TestIsInternalError(unordered_set<string> &internal_error_messages, const string &error);
-
+void SetTestDirectory(string path);
+void SetZeroInitialize(bool new_zero_init);
+string GetTestDirectory();
 string GetCSVPath();
 void WriteCSV(string path, const char *csv);
 void WriteBinary(string path, const uint8_t *data, uint64_t length);

--- a/test/include/test_helpers.hpp
+++ b/test/include/test_helpers.hpp
@@ -42,7 +42,7 @@ string TestCreatePath(string suffix);
 unique_ptr<DBConfig> GetTestConfig();
 bool TestIsInternalError(unordered_set<string> &internal_error_messages, const string &error);
 void SetTestDirectory(string path);
-void SetZeroInitialize(bool new_zero_init);
+void SetDebugInitialize(int value);
 string GetTestDirectory();
 string GetCSVPath();
 void WriteCSV(string path, const char *csv);

--- a/test/include/test_helpers.hpp
+++ b/test/include/test_helpers.hpp
@@ -43,6 +43,7 @@ unique_ptr<DBConfig> GetTestConfig();
 bool TestIsInternalError(unordered_set<string> &internal_error_messages, const string &error);
 void SetTestDirectory(string path);
 void SetDebugInitialize(int value);
+void SetSingleThreaded();
 string GetTestDirectory();
 string GetCSVPath();
 void WriteCSV(string path, const char *csv);

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -56,6 +56,8 @@ int main(int argc, char *argv[]) {
 			SetDebugInitialize(0);
 		} else if (string(argv[i]) == "--one-initialize") {
 			SetDebugInitialize(0xFF);
+		} else if (string(argv[i]) == "--single-threaded") {
+			SetSingleThreaded();
 		} else {
 			new_argv[new_argc] = argv[i];
 			new_argc++;

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -52,7 +52,9 @@ int main(int argc, char *argv[]) {
 			SetTestDirectory(test_dir);
 			delete_test_path = false;
 		} else if (string(argv[i]) == "--zero-initialize") {
-			SetZeroInitialize(true);
+			SetDebugInitialize(0);
+		} else if (string(argv[i]) == "--one-initialize") {
+			SetDebugInitialize(0xFF);
 		} else {
 			new_argv[new_argc] = argv[i];
 			new_argc++;

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -27,7 +27,9 @@ bool TestMemoryLeaks() {
 } // namespace duckdb
 
 int main(int argc, char *argv[]) {
+	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
 	string test_directory = DUCKDB_ROOT_DIRECTORY;
+	bool delete_test_path = true;
 
 	int new_argc = 0;
 	auto new_argv = duckdb::unique_ptr<char *[]>(new char *[argc]);
@@ -41,6 +43,16 @@ int main(int argc, char *argv[]) {
 			test_memory_leaks = true;
 		} else if (string(argv[i]) == "--test-dir") {
 			test_directory = string(argv[++i]);
+		} else if (string(argv[i]) == "--test-temp-dir") {
+			auto test_dir = string(argv[++i]);
+			if (fs->DirectoryExists(test_dir)) {
+				fprintf(stderr, "--test-temp-dir cannot point to a directory that already exists (%s)\n", test_dir.c_str());
+				return 1;
+			}
+			SetTestDirectory(test_dir);
+			delete_test_path = false;
+		} else if (string(argv[i]) == "--zero-initialize") {
+			SetZeroInitialize(true);
 		} else {
 			new_argv[new_argc] = argv[i];
 			new_argc++;
@@ -55,7 +67,7 @@ int main(int argc, char *argv[]) {
 		// create the empty testing directory
 		TestCreateDirectory(dir);
 	} catch (std::exception &ex) {
-		fprintf(stderr, "Failed to create testing directory \"%s\": %s", dir.c_str(), ex.what());
+		fprintf(stderr, "Failed to create testing directory \"%s\": %s\n", dir.c_str(), ex.what());
 		return 1;
 	}
 
@@ -63,7 +75,9 @@ int main(int argc, char *argv[]) {
 
 	int result = Catch::Session().run(new_argc, new_argv.get());
 
-	TestDeleteDirectory(dir);
+	if (delete_test_path) {
+		TestDeleteDirectory(dir);
+	}
 
 	return result;
 }

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -46,7 +46,8 @@ int main(int argc, char *argv[]) {
 		} else if (string(argv[i]) == "--test-temp-dir") {
 			auto test_dir = string(argv[++i]);
 			if (fs->DirectoryExists(test_dir)) {
-				fprintf(stderr, "--test-temp-dir cannot point to a directory that already exists (%s)\n", test_dir.c_str());
+				fprintf(stderr, "--test-temp-dir cannot point to a directory that already exists (%s)\n",
+				        test_dir.c_str());
 				return 1;
 			}
 			SetTestDirectory(test_dir);


### PR DESCRIPTION
In the storage layer there are certain situations where we currently write uninitialized memory to disk, e.g. when we have blocks that are not entirely filled. The blocks are written as-is and may contain uninitialized memory. While this does not affect the functioning of the system - writing uninitialized memory to disk can result in memory being leaked into the database file that was not intended to be written there. This PR fixes the issue by making sure all data that does not need to be written is fully zero-initialized.

#### Storage Initialization Verification
To ensure we catch this in the future, we add a debug setting to the memory manager that either (1) initializes all bits to 0 (`DEBUG_ZERO_INITIALIZE`), or (2) initializes all bits to 1 (`DEBUG_ONE_INITIALIZE`). We add a CI run that runs several of our storage tests with both of these flags enabled, and does a byte-wise comparison of the two generated databases.

If any bytes differ, the following error message is then printed that can be used to track down the uninitialized bytes:

```sql
------------------------------------------------------------------
FAIL - Mismatch between one-initialized and zero-initialized databases at byte position 1585172
------------------------------------------------------------------
One-initialized database test_standard_db/test_store_integers.db - byte value 255
Zero-initialized database test_zero_init_db/test_store_integers.db - byte value 0
This byte is in block id 6 at byte position 12 (position 20 including the block checksum)
------------------------------------------------------------------
This error likely means that memory was not correctly zero-initialized in a block before being written out to disk.
```

Note that this verification strategy only works for tests that are single-threaded, because multi-threading might affect the database file that is generated.

CC @jkub 