### PR TITLE
[C-API] Add `duckdb_string_t` for use with the data chunk API

### DIFF
--- a/src/common/radix_partitioning.cpp
+++ b/src/common/radix_partitioning.cpp
@@ -9,7 +9,7 @@
 namespace duckdb {
 
 template <class OP, class RETURN_TYPE, typename... ARGS>
-RETURN_TYPE RadixBitsSwitch(idx_t radix_bits, ARGS &&...args) {
+RETURN_TYPE RadixBitsSwitch(idx_t radix_bits, ARGS &&... args) {
 	D_ASSERT(radix_bits <= sizeof(hash_t) * 8);
 	switch (radix_bits) {
 	case 1:

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -775,7 +775,7 @@ Whether or not the duckdb_string_t value is inlined.
 This means that the data of the string does not have a separate allocation.
 
 */
-DUCKDB_API bool duckdb_string_is_inlined(duckdb_string_t *string);
+DUCKDB_API bool duckdb_string_is_inlined(duckdb_string_t string);
 
 //===--------------------------------------------------------------------===//
 // Date/Time/Timestamp Helpers

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -315,6 +315,7 @@ typedef enum {
 /*!
 Creates a new database or opens an existing database file stored at the the given path.
 If no path is given a new in-memory database is created instead.
+The instantiated database should be closed with 'duckdb_close'
 
 * path: Path to the database file on disk, or `nullptr` or `:memory:` to open an in-memory database.
 * out_database: The result database object.
@@ -348,6 +349,7 @@ DUCKDB_API void duckdb_close(duckdb_database *database);
 /*!
 Opens a connection to a database. Connections are required to query the database, and store transactional state
 associated with the connection.
+The instantiated connection should be closed using 'duckdb_disconnect'
 
 * database: The database file to connect to.
 * out_connection: The result connection object.

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -190,6 +190,23 @@ typedef struct {
 	idx_t size;
 } duckdb_string;
 
+/*
+    The internal data representation of a VARCHAR/BLOB column
+*/
+typedef struct {
+	union {
+		struct {
+			uint32_t length;
+			char prefix[4];
+			char *ptr;
+		} pointer;
+		struct {
+			uint32_t length;
+			char inlined[12];
+		} inlined;
+	} value;
+} duckdb_string_t;
+
 typedef struct {
 	void *data;
 	idx_t size;
@@ -750,6 +767,13 @@ This is the amount of tuples that will fit into a data chunk created by `duckdb_
 * returns: The vector size.
 */
 DUCKDB_API idx_t duckdb_vector_size();
+
+/*!
+Whether or not the duckdb_string_t value is inlined.
+This means that the data of the string does not have a separate allocation.
+
+*/
+DUCKDB_API bool duckdb_string_is_inlined(duckdb_string_t *string);
 
 //===--------------------------------------------------------------------===//
 // Date/Time/Timestamp Helpers

--- a/src/main/capi/helper-c.cpp
+++ b/src/main/capi/helper-c.cpp
@@ -186,3 +186,11 @@ void duckdb_free(void *ptr) {
 idx_t duckdb_vector_size() {
 	return STANDARD_VECTOR_SIZE;
 }
+
+bool duckdb_string_is_inlined(duckdb_string_t *string_p) {
+	if (!string_p) {
+		return false;
+	}
+	auto &string = *(duckdb::string_t *)(string_p);
+	return string.IsInlined();
+}

--- a/src/main/capi/helper-c.cpp
+++ b/src/main/capi/helper-c.cpp
@@ -187,10 +187,9 @@ idx_t duckdb_vector_size() {
 	return STANDARD_VECTOR_SIZE;
 }
 
-bool duckdb_string_is_inlined(duckdb_string_t *string_p) {
-	if (!string_p) {
-		return false;
-	}
-	auto &string = *(duckdb::string_t *)(string_p);
+bool duckdb_string_is_inlined(duckdb_string_t string_p) {
+	static_assert(sizeof(duckdb_string_t) == sizeof(duckdb::string_t),
+	              "duckdb_string_t should have the same memory layout as duckdb::string_t");
+	auto &string = *(duckdb::string_t *)(&string_p);
 	return string.IsInlined();
 }

--- a/test/api/capi/test_capi_data_chunk.cpp
+++ b/test/api/capi/test_capi_data_chunk.cpp
@@ -219,7 +219,7 @@ TEST_CASE("Test DataChunk varchar result fetch in C API", "[capi]") {
 	REQUIRE(duckdb_row_count(&result) == 5000);
 	REQUIRE(duckdb_result_error(&result) == nullptr);
 
-	auto expected_chunk_count = (5000 / STANDARD_VECTOR_SIZE) + (5000 % STANDARD_VECTOR_SIZE != 0);
+	idx_t expected_chunk_count = (5000 / STANDARD_VECTOR_SIZE) + (5000 % STANDARD_VECTOR_SIZE != 0);
 
 	REQUIRE(duckdb_result_chunk_count(result) == expected_chunk_count);
 
@@ -247,7 +247,7 @@ TEST_CASE("Test DataChunk varchar result fetch in C API", "[capi]") {
 				continue;
 			}
 			idx_t expected_length = (tuple_index % 12) + 4;
-			auto expected_character = (tuple_index % 26) + 'A';
+			char expected_character = (tuple_index % 26) + 'A';
 
 			// TODO: how does the c-api handle non-flat vectors?
 			auto tuple = string_data[i];

--- a/test/api/capi/test_capi_data_chunk.cpp
+++ b/test/api/capi/test_capi_data_chunk.cpp
@@ -193,6 +193,82 @@ TEST_CASE("Test DataChunk C API", "[capi]") {
 	duckdb_destroy_logical_type(&types[1]);
 }
 
+TEST_CASE("Test DataChunk varchar result fetch in C API", "[capi]") {
+	if (duckdb_vector_size() < 64) {
+		return;
+	}
+
+	duckdb_database database;
+	duckdb_connection connection;
+	duckdb_state state;
+
+	state = duckdb_open(nullptr, &database);
+	REQUIRE(state == DuckDBSuccess);
+	state = duckdb_connect(database, &connection);
+	REQUIRE(state == DuckDBSuccess);
+
+	constexpr const char *VARCHAR_TEST_QUERY = "select case when i != 0 and i % 42 = 0 then NULL else repeat(chr((65 + "
+	                                           "(i % 26))::INTEGER), (4 + (i % 12))) end from range(5000) tbl(i);";
+
+	// fetch a small result set
+	duckdb_result result;
+	state = duckdb_query(connection, VARCHAR_TEST_QUERY, &result);
+	REQUIRE(state == DuckDBSuccess);
+
+	REQUIRE(duckdb_column_count(&result) == 1);
+	REQUIRE(duckdb_row_count(&result) == 5000);
+	REQUIRE(duckdb_result_error(&result) == nullptr);
+
+	auto expected_chunk_count = (5000 / STANDARD_VECTOR_SIZE) + (5000 % STANDARD_VECTOR_SIZE != 0);
+
+	REQUIRE(duckdb_result_chunk_count(result) == expected_chunk_count);
+
+	auto chunk = duckdb_result_get_chunk(result, 0);
+
+	REQUIRE(duckdb_data_chunk_get_column_count(chunk) == 1);
+	REQUIRE(STANDARD_VECTOR_SIZE < 5000);
+	REQUIRE(duckdb_data_chunk_get_size(chunk) == STANDARD_VECTOR_SIZE);
+	duckdb_destroy_data_chunk(&chunk);
+
+	idx_t tuple_index = 0;
+	auto chunk_amount = duckdb_result_chunk_count(result);
+	for (idx_t chunk_index = 0; chunk_index < chunk_amount; chunk_index++) {
+		chunk = duckdb_result_get_chunk(result, chunk_index);
+		// Our result only has one column
+		auto vector = duckdb_data_chunk_get_vector(chunk, 0);
+		auto validity = duckdb_vector_get_validity(vector);
+		auto string_data = (duckdb_string_t *)duckdb_vector_get_data(vector);
+
+		auto tuples_in_chunk = duckdb_data_chunk_get_size(chunk);
+		for (idx_t i = 0; i < tuples_in_chunk; i++, tuple_index++) {
+			if (!duckdb_validity_row_is_valid(validity, i)) {
+				// This entry is NULL
+				REQUIRE((tuple_index != 0 && tuple_index % 42 == 0));
+				continue;
+			}
+			idx_t expected_length = (tuple_index % 12) + 4;
+			auto expected_character = (tuple_index % 26) + 'A';
+
+			// TODO: how does the c-api handle non-flat vectors?
+			auto tuple = string_data[i];
+			auto length = tuple.value.inlined.length;
+			REQUIRE(length == expected_length);
+			if (duckdb_string_is_inlined(&tuple)) {
+				// The data is small enough to fit in the string_t, it does not have a separate allocation
+				for (idx_t string_index = 0; string_index < length; string_index++) {
+					REQUIRE(tuple.value.inlined.inlined[string_index] == expected_character);
+				}
+			} else {
+				for (idx_t string_index = 0; string_index < length; string_index++) {
+					REQUIRE(tuple.value.pointer.ptr[string_index] == expected_character);
+				}
+			}
+		}
+		duckdb_destroy_data_chunk(&chunk);
+	}
+	duckdb_destroy_result(&result);
+}
+
 TEST_CASE("Test DataChunk result fetch in C API", "[capi]") {
 	CAPITester tester;
 	duckdb::unique_ptr<CAPIResult> result;

--- a/test/api/capi/test_capi_data_chunk.cpp
+++ b/test/api/capi/test_capi_data_chunk.cpp
@@ -253,7 +253,7 @@ TEST_CASE("Test DataChunk varchar result fetch in C API", "[capi]") {
 			auto tuple = string_data[i];
 			auto length = tuple.value.inlined.length;
 			REQUIRE(length == expected_length);
-			if (duckdb_string_is_inlined(&tuple)) {
+			if (duckdb_string_is_inlined(tuple)) {
 				// The data is small enough to fit in the string_t, it does not have a separate allocation
 				for (idx_t string_index = 0; string_index < length; string_index++) {
 					REQUIRE(tuple.value.inlined.inlined[string_index] == expected_character);

--- a/test/api/capi/test_capi_data_chunk.cpp
+++ b/test/api/capi/test_capi_data_chunk.cpp
@@ -267,6 +267,8 @@ TEST_CASE("Test DataChunk varchar result fetch in C API", "[capi]") {
 		duckdb_destroy_data_chunk(&chunk);
 	}
 	duckdb_destroy_result(&result);
+	duckdb_disconnect(&connection);
+	duckdb_close(&database);
 }
 
 TEST_CASE("Test DataChunk result fetch in C API", "[capi]") {


### PR DESCRIPTION
This PR fixes #7154 

I've added the struct as part of `duckdb.h`, and accompanied it with a test showcasing how it can be used to retrieve data from a string column.