### PR TITLE
Force parallelism in R dataframe scans.

### DIFF
--- a/tools/rpkg/src/scan.cpp
+++ b/tools/rpkg/src/scan.cpp
@@ -171,9 +171,9 @@ static duckdb::unique_ptr<FunctionData> DataFrameScanBind(ClientContext &context
 static idx_t DataFrameScanMaxThreads(ClientContext &context, const FunctionData *bind_data_p) {
 	D_ASSERT(bind_data_p);
 	auto bind_data = (const DataFrameScanBindData *)bind_data_p;
-	if (!bind_data->experimental) {
-		return 1;
-	}
+	//if (!bind_data->experimental) {
+	//	return 1;
+	//}
 	return ceil((double)bind_data->row_count / bind_data->rows_per_task);
 }
 

--- a/tools/rpkg/src/scan.cpp
+++ b/tools/rpkg/src/scan.cpp
@@ -171,9 +171,6 @@ static duckdb::unique_ptr<FunctionData> DataFrameScanBind(ClientContext &context
 static idx_t DataFrameScanMaxThreads(ClientContext &context, const FunctionData *bind_data_p) {
 	D_ASSERT(bind_data_p);
 	auto bind_data = (const DataFrameScanBindData *)bind_data_p;
-	//if (!bind_data->experimental) {
-	//	return 1;
-	//}
 	return ceil((double)bind_data->row_count / bind_data->rows_per_task);
 }
 


### PR DESCRIPTION
Since https://github.com/duckdb/duckdb/pull/6974 was merged we are now appending column segments of type string_t during dataframe scans. This means we are no longer copying the actual strings, but the RStringSexpType. Therefore, we can scan the data frames in parallel without R warning us that we are creating strings outside of the main thread.
