### PR TITLE
Fix #7219 - we cannot use the ungrouped aggregate if there are multiple grouping sets (even if they are all empty)

### DIFF
--- a/src/execution/physical_plan/plan_aggregate.cpp
+++ b/src/execution/physical_plan/plan_aggregate.cpp
@@ -124,7 +124,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAggregate 
 
 	plan = ExtractAggregateExpressions(std::move(plan), op.expressions, op.groups);
 
-	if (op.groups.empty()) {
+	if (op.groups.empty() && op.grouping_sets.size() <= 1) {
 		// no groups, check if we can use a simple aggregation
 		// special case: aggregate entire columns together
 		bool use_simple_aggregation = true;

--- a/test/sql/aggregate/grouping_sets/multiple_empty_grouping_sets.test
+++ b/test/sql/aggregate/grouping_sets/multiple_empty_grouping_sets.test
@@ -1,0 +1,13 @@
+# name: test/sql/aggregate/grouping_sets/multiple_empty_grouping_sets.test
+# description: Issue #7219 - Wrong GROUPING SETS implementation when using 2 empty grouping sets
+# group: [grouping_sets]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+select count(*)
+group by grouping sets ((), ())
+----
+1
+1


### PR DESCRIPTION
Fixes #7219