### PR TITLE
Issue #7220 - add support for DEFAULT VALUES clause in INSERT INTO

### DIFF
--- a/src/include/duckdb/parser/statement/insert_statement.hpp
+++ b/src/include/duckdb/parser/statement/insert_statement.hpp
@@ -82,7 +82,7 @@ public:
 
 	//! If the INSERT statement is inserted DIRECTLY from a values list (i.e. INSERT INTO tbl VALUES (...)) this returns
 	//! the expression list Otherwise, this returns NULL
-	ExpressionListRef *GetValuesList() const;
+	optional_ptr<ExpressionListRef> GetValuesList() const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/statement/insert_statement.hpp
+++ b/src/include/duckdb/parser/statement/insert_statement.hpp
@@ -72,6 +72,9 @@ public:
 	//! CTEs
 	CommonTableExpressionMap cte_map;
 
+	//! Whether or not this a DEFAULT VALUES
+	bool default_values = false;
+
 protected:
 	InsertStatement(const InsertStatement &other);
 

--- a/src/parser/statement/insert_statement.cpp
+++ b/src/parser/statement/insert_statement.cpp
@@ -27,8 +27,8 @@ InsertStatement::InsertStatement()
 }
 
 InsertStatement::InsertStatement(const InsertStatement &other)
-    : SQLStatement(other),
-      select_statement(unique_ptr_cast<SQLStatement, SelectStatement>(other.select_statement->Copy())),
+    : SQLStatement(other), select_statement(unique_ptr_cast<SQLStatement, SelectStatement>(
+                               other.select_statement ? other.select_statement->Copy() : nullptr)),
       columns(other.columns), table(other.table), schema(other.schema), catalog(other.catalog) {
 	cte_map = other.cte_map.Copy();
 	for (auto &expr : other.returning_list) {
@@ -95,8 +95,10 @@ string InsertStatement::ToString() const {
 	if (values_list) {
 		values_list->alias = string();
 		result += values_list->ToString();
-	} else {
+	} else if (select_statement) {
 		result += select_statement->ToString();
+	} else {
+		result += "DEFAULT VALUES";
 	}
 	if (!or_replace_shorthand_set && on_conflict_info) {
 		auto &conflict_info = *on_conflict_info;
@@ -155,7 +157,10 @@ unique_ptr<SQLStatement> InsertStatement::Copy() const {
 	return unique_ptr<InsertStatement>(new InsertStatement(*this));
 }
 
-ExpressionListRef *InsertStatement::GetValuesList() const {
+optional_ptr<ExpressionListRef> InsertStatement::GetValuesList() const {
+	if (!select_statement) {
+		return nullptr;
+	}
 	if (select_statement->node->type != QueryNodeType::SELECT_NODE) {
 		return nullptr;
 	}
@@ -178,7 +183,7 @@ ExpressionListRef *InsertStatement::GetValuesList() const {
 	if (!node.from_table || node.from_table->type != TableReferenceType::EXPRESSION_LIST) {
 		return nullptr;
 	}
-	return (ExpressionListRef *)node.from_table.get();
+	return &node.from_table->Cast<ExpressionListRef>();
 }
 
 } // namespace duckdb

--- a/src/parser/statement/insert_statement.cpp
+++ b/src/parser/statement/insert_statement.cpp
@@ -29,7 +29,8 @@ InsertStatement::InsertStatement()
 InsertStatement::InsertStatement(const InsertStatement &other)
     : SQLStatement(other), select_statement(unique_ptr_cast<SQLStatement, SelectStatement>(
                                other.select_statement ? other.select_statement->Copy() : nullptr)),
-      columns(other.columns), table(other.table), schema(other.schema), catalog(other.catalog) {
+      columns(other.columns), table(other.table), schema(other.schema), catalog(other.catalog),
+      default_values(other.default_values) {
 	cte_map = other.cte_map.Copy();
 	for (auto &expr : other.returning_list) {
 		returning_list.emplace_back(expr->Copy());
@@ -93,11 +94,14 @@ string InsertStatement::ToString() const {
 	result += " ";
 	auto values_list = GetValuesList();
 	if (values_list) {
+		D_ASSERT(!default_values);
 		values_list->alias = string();
 		result += values_list->ToString();
 	} else if (select_statement) {
+		D_ASSERT(!default_values);
 		result += select_statement->ToString();
 	} else {
+		D_ASSERT(default_values);
 		result += "DEFAULT VALUES";
 	}
 	if (!or_replace_shorthand_set && on_conflict_info) {

--- a/src/parser/transform/statement/transform_insert.cpp
+++ b/src/parser/transform/statement/transform_insert.cpp
@@ -26,12 +26,6 @@ unique_ptr<InsertStatement> Transformer::TransformInsert(duckdb_libpgquery::PGNo
 	auto stmt = reinterpret_cast<duckdb_libpgquery::PGInsertStmt *>(node);
 	D_ASSERT(stmt);
 
-	if (!stmt->selectStmt) {
-		// TODO: This should be easy to add, we already support DEFAULT in the values list,
-		// this could probably just be transformed into VALUES (DEFAULT, DEFAULT, DEFAULT, ..) in the Binder
-		throw ParserException("DEFAULT VALUES clause is not supported!");
-	}
-
 	auto result = make_uniq<InsertStatement>();
 	if (stmt->withClause) {
 		TransformCTE(reinterpret_cast<duckdb_libpgquery::PGWithClause *>(stmt->withClause), result->cte_map);
@@ -49,7 +43,9 @@ unique_ptr<InsertStatement> Transformer::TransformInsert(duckdb_libpgquery::PGNo
 	if (stmt->returningList) {
 		Transformer::TransformExpressionList(*(stmt->returningList), result->returning_list);
 	}
-	result->select_statement = TransformSelect(stmt->selectStmt, false);
+	if (stmt->selectStmt) {
+		result->select_statement = TransformSelect(stmt->selectStmt, false);
+	}
 
 	auto qname = TransformQualifiedName(stmt->relation);
 	result->table = qname.name;

--- a/src/parser/transform/statement/transform_insert.cpp
+++ b/src/parser/transform/statement/transform_insert.cpp
@@ -45,6 +45,8 @@ unique_ptr<InsertStatement> Transformer::TransformInsert(duckdb_libpgquery::PGNo
 	}
 	if (stmt->selectStmt) {
 		result->select_statement = TransformSelect(stmt->selectStmt, false);
+	} else {
+		result->default_values = true;
 	}
 
 	auto qname = TransformQualifiedName(stmt->relation);

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/table/table_scan.hpp"
+#include "duckdb/planner/operator/logical_dummy_scan.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/expression_binder/returning_binder.hpp"
@@ -409,7 +410,7 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 	AddCTEMap(stmt.cte_map);
 
 	vector<LogicalIndex> named_column_map;
-	if (!stmt.columns.empty()) {
+	if (!stmt.columns.empty() || !stmt.select_statement) {
 		// insertion statement specifies column list
 
 		// create a mapping of (list index) -> (column index)
@@ -448,10 +449,6 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 
 	// bind the default values
 	BindDefaultValues(table.GetColumns(), insert->bound_defaults);
-	if (!stmt.select_statement) {
-		result.plan = std::move(insert);
-		return result;
-	}
 
 	// Exclude the generated columns from this amount
 	idx_t expected_columns = stmt.columns.empty() ? table.GetColumns().PhysicalColumnCount() : stmt.columns.size();
@@ -488,14 +485,19 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 	}
 
 	// parse select statement and add to logical plan
-	auto select_binder = Binder::CreateBinder(context, this);
-	auto root_select = select_binder->Bind(*stmt.select_statement);
-	MoveCorrelatedExpressions(*select_binder);
+	unique_ptr<LogicalOperator> root;
+	if (stmt.select_statement) {
+		auto select_binder = Binder::CreateBinder(context, this);
+		auto root_select = select_binder->Bind(*stmt.select_statement);
+		MoveCorrelatedExpressions(*select_binder);
 
-	CheckInsertColumnCountMismatch(expected_columns, root_select.types.size(), !stmt.columns.empty(),
-	                               table.name.c_str());
+		CheckInsertColumnCountMismatch(expected_columns, root_select.types.size(), !stmt.columns.empty(),
+		                               table.name.c_str());
 
-	auto root = CastLogicalOperatorToTypes(root_select.types, insert->expected_types, std::move(root_select.plan));
+		root = CastLogicalOperatorToTypes(root_select.types, insert->expected_types, std::move(root_select.plan));
+	} else {
+		root = make_uniq<LogicalDummyScan>(GenerateTableIndex());
+	}
 	insert->AddChild(std::move(root));
 
 	BindOnConflictClause(*insert, table, stmt);

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -410,7 +410,7 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 	AddCTEMap(stmt.cte_map);
 
 	vector<LogicalIndex> named_column_map;
-	if (!stmt.columns.empty() || !stmt.select_statement) {
+	if (!stmt.columns.empty() || stmt.default_values) {
 		// insertion statement specifies column list
 
 		// create a mapping of (list index) -> (column index)
@@ -449,7 +449,10 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 
 	// bind the default values
 	BindDefaultValues(table.GetColumns(), insert->bound_defaults);
-
+	if (!stmt.select_statement && !stmt.default_values) {
+		result.plan = std::move(insert);
+		return result;
+	}
 	// Exclude the generated columns from this amount
 	idx_t expected_columns = stmt.columns.empty() ? table.GetColumns().PhysicalColumnCount() : stmt.columns.size();
 

--- a/test/issues/general/test_3997.test
+++ b/test/issues/general/test_3997.test
@@ -55,6 +55,5 @@ select x from x;
 statement error
 with y(y) as (select 2) delete from x using (select y) z(z) where x = z;
 
-# at the moment keep this as an error
-statement error
+statement ok
 insert into x default values;

--- a/test/sql/catalog/table/test_default_values.test
+++ b/test/sql/catalog/table/test_default_values.test
@@ -1,0 +1,51 @@
+# name: test/sql/catalog/table/test_default_values.test
+# description: Test DEFAULT VALUES insert
+# group: [table]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table x (i int default 1, j int default 2)
+
+statement ok
+insert into x default values;
+
+query II
+SELECT * FROM x
+----
+1	2
+
+# returning
+query I
+insert into x default values returning (i);
+----
+1
+
+query I
+insert into x default values returning (j);
+----
+2
+
+statement error
+insert into x(i) default values;
+----
+Parser Error
+
+# on conflict
+statement ok
+drop table x;
+
+statement ok
+create table x (i int primary key default 1, j int default 2)
+
+statement ok
+insert into x default values;
+
+statement error
+insert into x default values;
+----
+violates primary key constraint
+
+statement ok
+insert into x default values on conflict do nothing;

--- a/test/sql/upsert/upsert_default_values.test
+++ b/test/sql/upsert/upsert_default_values.test
@@ -10,10 +10,11 @@ create or replace table tbl (
 	b integer
 );
 
-statement error
+statement ok
 insert into tbl DEFAULT VALUES;
-----
-Parser Error: DEFAULT VALUES clause is not supported!
 
-# We only bind the on conflict clause when there is a SelectStmt child, so when support is added for DEFAULT VALUES
-# This might also need to be changed
+query II
+FROM tbl
+----
+5	NULL
+


### PR DESCRIPTION
Implements #7220 

This is now supported:

```sql
create table x (i int default 1, j int default 2)
insert into x default values;
```