### PR TITLE
Correct license code in nodejs project

### DIFF
--- a/tools/nodejs/package.json
+++ b/tools/nodejs/package.json
@@ -54,7 +54,7 @@
     "duckdb"
   ],
   "author": "Hannes Mühleisen",
-  "license": "MPL-2.0",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/duckdb/duckdb/issues"
   },


### PR DESCRIPTION
The repository has an MIT license, but the package.json for the nodejs project reports MPL-2.0, which confused our license compliance tooling.