### PR TITLE
fix(JDBC): push down update count calculation into execute() method

### DIFF
--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
@@ -151,6 +151,14 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 			close();
 			throw e;
 		}
+
+		if (returnsChangedRows) {
+			if (select_result.next()) {
+				update_result = select_result.getInt(1);
+			}
+			select_result.close();
+		}
+
 		return returnsResultSet;
 	}
 
@@ -169,13 +177,7 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 			throw new SQLException("executeUpdate() can only be used with queries that return nothing (eg, a DDL statement), or update rows");
 		}
 		execute();
-		update_result = 0;
-		if (select_result.next()) {
-			update_result = select_result.getInt(1);
-		}
-		select_result.close();
-
-		return update_result;
+		return getUpdateCount();
 	}
 
 	@Override
@@ -379,7 +381,7 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 			throw new SQLException("Prepare something first");
 		}
 
-		if (!returnsChangedRows || update_result == 0) {
+		if (returnsResultSet || select_result.isFinished()) {
 			return -1;
 		}
 		return update_result;

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
@@ -1475,4 +1475,7 @@ public class DuckDBResultSet implements ResultSet {
 		return iface.isInstance(this);
 	}
 
+	boolean isFinished() {
+		return finished;
+	}
 }

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -3232,6 +3232,15 @@ public class TestDuckDBJDBC {
 		}
 	}
 
+	public static void test_update_count() throws Exception {
+		try (Connection connection = DriverManager.getConnection("jdbc:duckdb:"); Statement s = connection.createStatement()) {
+			s.executeUpdate("create table t (i int)");
+			assertEquals(s.executeUpdate("insert into t values (1)"), 1);
+			assertFalse(s.execute("insert into t values (1)"));
+			assertEquals(s.getUpdateCount(), 1);
+		}
+	}
+
 	public static void main(String[] args) throws Exception {
 		// Woo I can do reflection too, take this, JUnit!
 		Method[] methods = TestDuckDBJDBC.class.getMethods();


### PR DESCRIPTION
This is a partial fix for https://github.com/duckdb/duckdb/issues/7188, it does not yet implement getMoreResults

@lukaseder are you able to check that this fulfills the contract as you understand it?