### PR TITLE
Issue #7230: Named Window Overrides

### DIFF
--- a/src/include/duckdb/parser/transformer.hpp
+++ b/src/include/duckdb/parser/transformer.hpp
@@ -312,7 +312,8 @@ private:
 	void TransformExpressionList(duckdb_libpgquery::PGList &list, vector<unique_ptr<ParsedExpression>> &result);
 
 	//! Transform a Postgres PARTITION BY/ORDER BY specification into lists of expressions
-	void TransformWindowDef(duckdb_libpgquery::PGWindowDef *window_spec, WindowExpression *expr);
+	void TransformWindowDef(duckdb_libpgquery::PGWindowDef *window_spec, WindowExpression *expr,
+	                        const char *window_name = nullptr);
 	//! Transform a Postgres window frame specification into frame expressions
 	void TransformWindowFrame(duckdb_libpgquery::PGWindowDef *window_spec, WindowExpression *expr);
 

--- a/test/sql/window/test_window_clause.test
+++ b/test/sql/window/test_window_clause.test
@@ -21,3 +21,42 @@ select max(base), max(referenced), sum(refined), sum(unrefined) from (
 ) q;
 ----
 4	4	60	69
+
+#
+# Clause overrides
+#
+query IIII
+select 
+  x, y, 
+  count(*) over (partition by y order by x), 
+  count(*) over (w order by x)
+from (values (1, 1), (2, 1), (3, 2), (4, 2)) as t (x, y)
+window w as (partition by y)
+order by x
+----
+1	1	1	1
+2	1	2	2
+3	2	1	1
+4	2	2	2
+
+statement error
+select 
+  x, y, 
+  count(*) over (partition by y order by x), 
+  count(*) over (w order by x)
+from (values (1, 1), (2, 1), (3, 2), (4, 2)) as t (x, y)
+window w as (partition by y order by x desc)
+order by x
+----
+Cannot override ORDER BY clause of window "w"
+
+statement error
+select 
+  x, y, 
+  count(*) over (partition by y order by x), 
+  count(*) over (w partition by y)
+from (values (1, 1), (2, 1), (3, 2), (4, 2)) as t (x, y)
+window w as (partition by x)
+order by x
+----
+Cannot override PARTITION BY clause of window "w"


### PR DESCRIPTION
Check for illegal overrides of named windows.
Previously we were only taking one or the other and not merging.