### PR TITLE
Move several tests to slow tests

### DIFF
--- a/test/issues/general/test_2554.test_slow
+++ b/test/issues/general/test_2554.test_slow
@@ -1,4 +1,4 @@
-# name: test/issues/general/test_2554.test
+# name: test/issues/general/test_2554.test_slow
 # description: Issue 2554: a recursive CTE SQL works in Sqlite reports a within error in duckdb
 # group: [general]
 

--- a/test/sql/aggregate/distinct/grouped/simple.test_slow
+++ b/test/sql/aggregate/distinct/grouped/simple.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/aggregate/distinct/grouped/simple.test
+# name: test/sql/aggregate/distinct/grouped/simple.test_slow
 # description: Test aggregation/group by statements
 # group: [grouped]
 

--- a/test/sql/create/big_create_table_as.test_slow
+++ b/test/sql/create/big_create_table_as.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/create/big_create_table_as.test
+# name: test/sql/create/big_create_table_as.test_slow
 # description: Test large CREATE TABLE AS statements
 # group: [create]
 

--- a/test/sql/create/big_create_table_as_varchar.test_slow
+++ b/test/sql/create/big_create_table_as_varchar.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/create/big_create_table_as_varchar.test
+# name: test/sql/create/big_create_table_as_varchar.test_slow
 # description: Test large CREATE TABLE AS with varchar columns
 # group: [create]
 

--- a/test/sql/insert/insert_from_many_groups.test_slow
+++ b/test/sql/insert/insert_from_many_groups.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/insert/insert_from_many_groups.test
+# name: test/sql/insert/insert_from_many_groups.test_slow
 # description: Test parallel insert from many groups
 # group: [insert]
 

--- a/test/sql/join/asof/test_asof_join_missing.test_slow
+++ b/test/sql/join/asof/test_asof_join_missing.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/join/asof/test_asof_join_missing.test
+# name: test/sql/join/asof/test_asof_join_missing.test_slow
 # description: Test As-Of join with missing matches
 # group: [asof]
 

--- a/test/sql/sample/test_sample.test_slow
+++ b/test/sql/sample/test_sample.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/sample/test_sample.test
+# name: test/sql/sample/test_sample.test_slow
 # description: Test SAMPLE keyword
 # group: [sample]
 

--- a/test/sql/storage/compression/bitpacking/bitpacking_delta.test_slow
+++ b/test/sql/storage/compression/bitpacking/bitpacking_delta.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/storage/compression/bitpacking/bitpacking_delta.test
+# name: test/sql/storage/compression/bitpacking/bitpacking_delta.test_slow
 # description: Test some large incompressible data
 # group: [bitpacking]
 

--- a/test/sql/storage/multiple_clients_checkpoing_dependents.test_slow
+++ b/test/sql/storage/multiple_clients_checkpoing_dependents.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/storage/multiple_clients_checkpoing_dependents.test
+# name: test/sql/storage/multiple_clients_checkpoing_dependents.test_slow
 # description: Try to checkpoint within a transaction that depends on another transactions' changes
 # group: [storage]
 

--- a/test/sql/update/test_unaligned_update.test_slow
+++ b/test/sql/update/test_unaligned_update.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/update/test_unaligned_update.test
+# name: test/sql/update/test_unaligned_update.test_slow
 # description: Unaligned updates
 # group: [update]
 


### PR DESCRIPTION
The vsize=2 test is now frequently timing out - this should hopefully alleviate this