### PR TITLE
In the parallel CSV reader, prevent buffering of data unnecessarily when reading from compressed files

### DIFF
--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -259,6 +259,7 @@ public:
 	                       idx_t rows_to_skip, bool force_parallelism_p, vector<column_t> column_ids_p)
 	    : file_handle(std::move(file_handle_p)), system_threads(system_threads_p), buffer_size(buffer_size_p),
 	      force_parallelism(force_parallelism_p), column_ids(std::move(column_ids_p)) {
+		file_handle->DisableReset();
 		current_file_path = files_path_p[0];
 		estimated_linenr = rows_to_skip;
 		file_size = file_handle->FileSize();

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -27,7 +27,7 @@ unique_ptr<CSVFileHandle> ReadCSV::OpenCSV(const string &file_path, FileCompress
 	if (file_handle->CanSeek()) {
 		file_handle->Reset();
 	}
-	return make_uniq<CSVFileHandle>(std::move(file_handle));
+	return make_uniq<CSVFileHandle>(std::move(file_handle), false);
 }
 
 void ReadCSVData::FinalizeRead(ClientContext &context) {

--- a/src/include/duckdb/execution/operator/persistent/csv_file_handle.hpp
+++ b/src/include/duckdb/execution/operator/persistent/csv_file_handle.hpp
@@ -16,7 +16,8 @@ namespace duckdb {
 
 struct CSVFileHandle {
 public:
-	explicit CSVFileHandle(unique_ptr<FileHandle> file_handle_p) : file_handle(std::move(file_handle_p)) {
+	explicit CSVFileHandle(unique_ptr<FileHandle> file_handle_p, bool enable_reset = true)
+	    : file_handle(std::move(file_handle_p)), reset_enabled(enable_reset) {
 		can_seek = file_handle->CanSeek();
 		plain_file_source = file_handle->OnDiskFile() && can_seek;
 		file_size = file_handle->GetFileSize();


### PR DESCRIPTION
In the CSV reader we make multiple passes over the first few lines of the file - first for auto-detection, and then for actually reading the file. In order to facilitate this for files that we cannot seek into/re-read from easily (e.g. compressed files or streams) we buffer all data.

However, this buffering is only required for the auto-detection - after the auto-detection is completed we can disable this buffering. This already happened in the single-threaded CSV reader but did not happen in the multi-threaded CSV reader. This resulted in us keeping around all data read from compressed CSV files unnecessarily, causing high memory usage.

