### PR TITLE
Relational set operations coerce to richer type

### DIFF
--- a/src/include/duckdb/main/relation/setop_relation.hpp
+++ b/src/include/duckdb/main/relation/setop_relation.hpp
@@ -20,6 +20,7 @@ public:
 	shared_ptr<Relation> left;
 	shared_ptr<Relation> right;
 	SetOperationType setop_type;
+	vector<ColumnDefinition> columns;
 
 public:
 	unique_ptr<QueryNode> GetQueryNode() override;

--- a/src/main/relation/setop_relation.cpp
+++ b/src/main/relation/setop_relation.cpp
@@ -11,8 +11,7 @@ SetOpRelation::SetOpRelation(shared_ptr<Relation> left_p, shared_ptr<Relation> r
 	if (left->context.GetContext() != right->context.GetContext()) {
 		throw Exception("Cannot combine LEFT and RIGHT relations of different connections!");
 	}
-	vector<ColumnDefinition> dummy_columns;
-	context.GetContext()->TryBindRelation(*this, dummy_columns);
+	context.GetContext()->TryBindRelation(*this, this->columns);
 }
 
 unique_ptr<QueryNode> SetOpRelation::GetQueryNode() {
@@ -31,7 +30,7 @@ string SetOpRelation::GetAlias() {
 }
 
 const vector<ColumnDefinition> &SetOpRelation::Columns() {
-	return left->Columns();
+	return this->columns;
 }
 
 string SetOpRelation::ToString(idx_t depth) {

--- a/tools/rpkg/tests/testthat/test_relational.R
+++ b/tools/rpkg/tests/testthat/test_relational.R
@@ -272,11 +272,15 @@ test_that("we throw an error when attempting to union all relations that are not
     expect_error(rel_union_all(test_df_a2, test_df_b2), "Binder Error")
 })
 
-test_that("A union with different column types throws an error", {
+test_that("A union with different column types casts to the richer type", {
      test_df_a1 <- duckdb:::rel_from_df(con, data.frame(a=c(1)))
      test_df_a2 <- duckdb:::rel_from_df(con, data.frame(a=c('1')))
      rel <- duckdb:::rel_union_all(test_df_a1, test_df_a2)
-     expect_error(duckdb:::rapi_rel_to_df(rel), "Invalid Error: Result mismatch in query!")
+     res <- duckdb:::rapi_rel_to_df(rel)
+     expected <- data.frame(a=c('1.0', '1'))
+     expect_equal(class(res$a), class(expected$a))
+     expect_equal(res$a[1], expected$a[1])
+     expect_equal(res$a[2], expected$a[2])
 })
 
 test_that("Set Intersect returns set intersection", {

--- a/tools/rpkg/tests/testthat/test_relational.R
+++ b/tools/rpkg/tests/testthat/test_relational.R
@@ -273,10 +273,10 @@ test_that("we throw an error when attempting to union all relations that are not
 })
 
 test_that("A union with different column types throws an error", {
-     test_df_a1 <- rel_from_df(con, data.frame(a=c(1)))
-     test_df_a2 <- rel_from_df(con, data.frame(a=c('1')))
-     rel <- rel_union_all(test_df_a1, test_df_a2)
-     expect_error(rapi_rel_to_df(rel), "Invalid Error: Result mismatch in query!")
+     test_df_a1 <- duckdb:::rel_from_df(con, data.frame(a=c(1)))
+     test_df_a2 <- duckdb:::rel_from_df(con, data.frame(a=c('1')))
+     rel <- duckdb:::rel_union_all(test_df_a1, test_df_a2)
+     expect_error(duckdb:::rapi_rel_to_df(rel), "Invalid Error: Result mismatch in query!")
 })
 
 test_that("Set Intersect returns set intersection", {
@@ -288,6 +288,21 @@ test_that("Set Intersect returns set intersection", {
     dim(rel_df)
     expected_result <- data.frame(a=c(1), b=c(3))
     expect_equal(rel_df, expected_result)
+})
+
+test_that("Set intersect casts columns to the richer type", {
+   # df1 is Integer
+   df1 <- data.frame(x = 1:4)
+   # df2 has Double
+   df2 <- data.frame(x = 4)
+   expect_equal(class(df1$x), "integer")
+   expect_equal(class(df2$x), "numeric")
+   out <- rel_set_intersect(
+     rel_from_df(con, df1),
+     rel_from_df(con, df2)
+   )
+   out_df <- rapi_rel_to_df(out)
+   expect_equal(class(out_df$x), "numeric")
 })
 
 test_that("Set Diff returns the set difference", {


### PR DESCRIPTION
This fixes https://github.com/duckdb/duckdb/issues/6368

When I initially implemented set operations, I didn't know what the columns were for during the TryBindRelation call. Now I do!


