### PR TITLE
Fix spurious CI failure

### DIFF
--- a/test/sql/copy/csv/tpch_csv_sf01.test_slow
+++ b/test/sql/copy/csv/tpch_csv_sf01.test_slow
@@ -17,6 +17,9 @@ CREATE VIEW ${tpch_tbl} AS FROM read_csv_auto('__TEST_DIR__/${tpch_tbl}.csv', se
 
 endloop
 
+statement ok
+SET threads=1
+
 loop i 1 9
 
 query I


### PR DESCRIPTION
TPC-H Q15 with doubles is not deterministic in the multi-threaded scenario because of floating point inaccuracies - so run it single-threaded