### PR TITLE
[Dev] Rename `ClientProperties` property `timezone` -> `time_zone`

### DIFF
--- a/.github/config/extensions.csv
+++ b/.github/config/extensions.csv
@@ -11,4 +11,4 @@ visualizer,,,
 sqlite_scanner,https://github.com/duckdblabs/sqlite_scanner,a1244aad27de0e2cad8341ae63348565755346a7,
 postgres_scanner,https://github.com/duckdblabs/postgres_scanner,cd043b49cdc9e0d3752535b8333c9433e1007a48,
 substrait,https://github.com/duckdblabs/substrait,48d64b27c7a6985d6f6c3e65044038544608c03b,no-windows
-arrow,https://github.com/duckdblabs/arrow,a617abc0dc7360fc461264a52f471d4ea9aadf05,no-windows
+arrow,https://github.com/duckdblabs/arrow,ec206c1232fcae6d2c3d64194e3f1e43068d3deb,no-windows

--- a/src/include/duckdb/main/query_result.hpp
+++ b/src/include/duckdb/main/query_result.hpp
@@ -20,7 +20,7 @@ enum class QueryResultType : uint8_t { MATERIALIZED_RESULT, STREAM_RESULT, PENDI
 
 //! A set of properties from the client context that can be used to interpret the query result
 struct ClientProperties {
-	string timezone;
+	string time_zone;
 };
 
 class BaseQueryResult {

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1156,7 +1156,7 @@ ParserOptions ClientContext::GetParserOptions() const {
 
 ClientProperties ClientContext::GetClientProperties() const {
 	ClientProperties properties;
-	properties.timezone = ClientConfig::GetConfig(*this).ExtractTimezone();
+	properties.time_zone = ClientConfig::GetConfig(*this).ExtractTimezone();
 	return properties;
 }
 

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -165,7 +165,7 @@ string QueryResult::HeaderToString() {
 }
 
 string QueryResult::GetConfigTimezone(QueryResult &query_result) {
-	return query_result.client_properties.timezone;
+	return query_result.client_properties.time_zone;
 }
 
 } // namespace duckdb


### PR DESCRIPTION
This is done to work around a macro defined on windows, issue encountered in #7171 
This PR has a dependency on a PR in the `duckdblabs/arrow` repo:
https://github.com/duckdblabs/arrow/pull/9