### PR TITLE
Fix affected row count returned from `INSERT .. ON CONFLICT (..)` statement

### DIFF
--- a/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
@@ -116,9 +116,10 @@ public:
 protected:
 	void CombineExistingAndInsertTuples(DataChunk &result, DataChunk &scan_chunk, DataChunk &input_chunk,
 	                                    ClientContext &client) const;
-	void OnConflictHandling(TableCatalogEntry &table, ExecutionContext &context, InsertLocalState &lstate) const;
-	void PerformOnConflictAction(ExecutionContext &context, DataChunk &chunk, TableCatalogEntry &table,
-	                             Vector &row_ids) const;
+	//! Returns the amount of updated tuples
+	idx_t OnConflictHandling(TableCatalogEntry &table, ExecutionContext &context, InsertLocalState &lstate) const;
+	idx_t PerformOnConflictAction(ExecutionContext &context, DataChunk &chunk, TableCatalogEntry &table,
+	                              Vector &row_ids) const;
 	void RegisterUpdatedRows(InsertLocalState &lstate, const Vector &row_ids, idx_t count) const;
 };
 

--- a/test/sql/upsert/upsert_default.test
+++ b/test/sql/upsert/upsert_default.test
@@ -25,3 +25,23 @@ select * from tbl;
 5	6	10
 5	7	10
 5	4	10
+
+statement ok
+create table t (i int primary key, j int);
+
+query I
+insert into t values (1, 1) on conflict do nothing;
+----
+1
+
+# 0 updates/insertions were performed
+query I
+insert into t values (1, 1) on conflict do nothing
+----
+0
+
+# 0 insertions, but one tuple is updated
+query I
+insert into t values (1, 1) on conflict (i) do update set j = excluded.i;
+----
+1


### PR DESCRIPTION
This PR fixes #7209 

DO NOTHING will not affect any rows, but DO UPDATE will, the returned value from the operator properly reflects that now