### PR TITLE
feat: JDBC URL resolves `~`, `$TMPDIR`

### DIFF
--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -1,5 +1,6 @@
 package org.duckdb.test;
 
+import java.io.File;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -3230,6 +3231,36 @@ public class TestDuckDBJDBC {
 				assertEquals(rs.getObject(1), "{'hello': foo, 'world': bar}");
 			}
 		}
+	}
+	
+	public static void test_home_dir_resolution() throws Exception {
+		try (
+				Connection conn = DriverManager.getConnection("jdbc:duckdb:~/myduckdb");
+				Statement stmt = conn.createStatement();
+		) {
+			stmt.execute("CREATE TABLE test (id VARCHAR(40));");
+			stmt.execute("INSERT INTO test VALUES ('test');");
+		}
+		
+		File file = new File(DuckDBConnection.getHomeFolder(),"myduckdb");
+		file.deleteOnExit();
+		
+		assertTrue(file.exists() && file.canRead());
+	}
+	
+	public static void test_tmpdir_resolution() throws Exception {
+		try (
+				Connection conn = DriverManager.getConnection("jdbc:duckdb:${java.io.tmpdir}/myduckdb");
+				Statement stmt = conn.createStatement();
+		) {
+			stmt.execute("CREATE TABLE test (id VARCHAR(40));");
+			stmt.execute("INSERT INTO test VALUES ('test');");
+		}
+		
+		File file = new File(DuckDBConnection.getTempFolder(),"myduckdb");
+		file.deleteOnExit();
+		
+		assertTrue(file.exists() && file.canRead());
 	}
 
 	public static void main(String[] args) throws Exception {


### PR DESCRIPTION
example: `jdbc:duckdb:~/myduckdb` 
resolves to `jdbc:duckdb:/home/are/myduckdb` on Linux
resolves to  `jdbc:duckdb:/C:/Users/are/myduckdb` (or something like this, ask Redmond) on Windows
 
- resolves `~` and `${user.home}` to the OS' Home Folder of the user
- resolves `$TMPDIR` and `${java.io.tmp}` to the OS' Temp Folder

This is useful for Multi-User and or Multi-OS Deployment: 