### PR TITLE
fix(adbc): crash when setting database option due to malloc

### DIFF
--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -72,7 +72,10 @@ AdbcStatusCode DatabaseNew(struct AdbcDatabase *database, struct AdbcError *erro
 	CHECK_TRUE(database, error, "Missing database object");
 
 	database->private_data = nullptr;
-	auto wrapper = (DuckDBAdbcDatabaseWrapper *)malloc(sizeof(DuckDBAdbcDatabaseWrapper));
+	// you can't malloc a struct with a non-trivial C++ constructor
+	// and std::string has a non-trivial constructor. so we need
+	// to use new and delete rather than malloc and free.
+	auto wrapper = new DuckDBAdbcDatabaseWrapper;
 	CHECK_TRUE(wrapper, error, "Allocation error");
 
 	database->private_data = wrapper;
@@ -112,7 +115,7 @@ AdbcStatusCode DatabaseRelease(struct AdbcDatabase *database, struct AdbcError *
 
 		duckdb_close(&wrapper->database);
 		duckdb_destroy_config(&wrapper->config);
-		free(database->private_data);
+		delete wrapper;
 		database->private_data = nullptr;
 	}
 	return ADBC_STATUS_OK;


### PR DESCRIPTION
Currently the `DuckDBAdbcDatabaseWrapper` gets `malloc`-ed during `DatabaseNew`. Unfortunately this is a problem because it's invalid to use malloc to initialize a struct with a non-trivial C++ constructor and `std::string` is a non-trivial C++ constructor. The result is undefined behavior which I discovered when attempting to load `libduckdb.so` via the Arrow ADBC driver manager (which loads using `dlsym`).

This is fixed by internally using `new` and `delete` when managing the wrapper.

CC @pdet @Mytherin @lidavidm