### PR TITLE
Simplifying initialization logic

### DIFF
--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -59,6 +59,7 @@ public:
 
 private:
 	void Initialize(const char *path, DBConfig *config);
+	void CreateDatabase(const string &database_type);
 
 	void Configure(DBConfig &config);
 

--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -55,6 +55,9 @@ public:
 	idx_t ModifyCatalog() {
 		return catalog_version++;
 	}
+	bool HasDefaultDatabase() {
+		return !default_database.empty();
+	}
 
 private:
 	//! The system database is a special database that holds system entries (e.g. functions)

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -56,7 +56,7 @@ public:
 
 	static const vector<string> GetPublicKeys();
 
-	static void StorageInit(string &extension, DBConfig &config);
+	static bool IsStorageExtension(string &extension, DBConfig &config);
 
 	// Returns extension name, or empty string if not a replacement open path
 	static string ExtractExtensionPrefixFromPath(const string &path);

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -56,8 +56,6 @@ public:
 
 	static const vector<string> GetPublicKeys();
 
-	static bool IsStorageExtension(string &extension, DBConfig &config);
-
 	// Returns extension name, or empty string if not a replacement open path
 	static string ExtractExtensionPrefixFromPath(const string &path);
 

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -43,11 +43,6 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Sto
 	if (!catalog) {
 		throw InternalException("AttachedDatabase - attach function did not return a catalog");
 	}
-	auto is_duckdb_derived = dynamic_cast<DuckCatalog *>(catalog.get()) != nullptr;
-	if (is_duckdb_derived) {
-		storage =
-		    make_unique<SingleFileStorageManager>(*this, std::move(info.path), access_mode == AccessMode::READ_ONLY);
-	}
 	transaction_manager =
 	    storage_extension.create_transaction_manager(storage_extension.storage_info.get(), *this, *catalog);
 	if (!transaction_manager) {

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -231,13 +231,6 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 	// initialize the system catalog
 	db_manager->InitializeSystemCatalog();
 
-	bool extension_will_create_default_db =
-	    (database_type.empty()) ? false : ExtensionHelper::IsStorageExtension(database_type, config);
-
-	if (!extension_will_create_default_db) {
-		CreateDatabase("");
-	}
-
 	if (!database_type.empty()) {
 		// if we are opening an extension database - load the extension
 		ExtensionHelper::LoadExternalExtension(*this, nullptr, database_type);

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -139,8 +139,9 @@ unique_ptr<AttachedDatabase> DatabaseInstance::CreateAttachedDatabase(AttachInfo
                                                                       AccessMode access_mode) {
 	unique_ptr<AttachedDatabase> attached_database;
 	if (!type.empty()) {
-		// find the storage extensionon database
-		auto entry = config.storage_extensions.find(type);
+		// find the storage extension
+		auto extension_name = ExtensionHelper::ApplyExtensionAlias(type);
+		auto entry = config.storage_extensions.find(extension_name);
 		if (entry == config.storage_extensions.end()) {
 			throw BinderException("Unrecognized storage type \"%s\"", type);
 		}

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -199,52 +199,31 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 
 	// check if we are opening a standard DuckDB database or an extension database
 	auto database_type = ExtractDatabaseType(config.options.database_path);
-	if (!database_type.empty()) {
-		// we are opening an extension database, run storage_init
-		ExtensionHelper::StorageInit(database_type, config);
-	}
-	AttachInfo info;
-	info.name = AttachedDatabase::ExtractDatabaseName(config.options.database_path);
-	info.path = config.options.database_path;
-
-	auto attached_database = CreateAttachedDatabase(info, database_type, config.options.access_mode);
-	auto initial_database = attached_database.get();
-	{
-		Connection con(*this);
-		con.BeginTransaction();
-		db_manager->AddDatabase(*con.context, std::move(attached_database));
-		con.Commit();
-	}
 
 	// initialize the system catalog
 	db_manager->InitializeSystemCatalog();
-	// initialize the database
-	initial_database->Initialize();
 
 	if (!database_type.empty()) {
 		// if we are opening an extension database - load the extension
 		ExtensionHelper::LoadExternalExtension(*this, nullptr, database_type);
 	}
 
-	if (!config.options.unrecognized_options.empty()) {
-		// check if all unrecognized options can be handled by the loaded extension(s)
-		for (auto &unrecognized_option : config.options.unrecognized_options) {
-			auto entry = config.extension_parameters.find(unrecognized_option.first);
-			if (entry == config.extension_parameters.end()) {
-				throw InvalidInputException("Unrecognized configuration property \"%s\"", unrecognized_option.first);
-			}
+	if (!db_manager->HasDefaultDatabase()) {
+		AttachInfo info;
+		info.name = AttachedDatabase::ExtractDatabaseName(config.options.database_path);
+		info.path = config.options.database_path;
+
+		auto attached_database = CreateAttachedDatabase(info, database_type, config.options.access_mode);
+		auto initial_database = attached_database.get();
+		{
+			Connection con(*this);
+			con.BeginTransaction();
+			db_manager->AddDatabase(*con.context, std::move(attached_database));
+			con.Commit();
 		}
 
-		// if so - set the options
-		Connection con(*this);
-		con.BeginTransaction();
-		for (auto &unrecognized_option : config.options.unrecognized_options) {
-			auto entry = config.extension_parameters.find(unrecognized_option.first);
-			D_ASSERT(entry != config.extension_parameters.end());
-			PhysicalSet::SetExtensionVariable(*con.context, entry->second, unrecognized_option.first, SetScope::GLOBAL,
-			                                  unrecognized_option.second);
-		}
-		con.Commit();
+		// initialize the database
+		initial_database->Initialize();
 	}
 
 	// only increase thread count after storage init because we get races on catalog otherwise

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -12,7 +12,6 @@ namespace duckdb {
 typedef void (*ext_init_fun_t)(DatabaseInstance &);
 typedef const char *(*ext_version_fun_t)(void);
 typedef void (*ext_storage_init_t)(DBConfig &);
-typedef bool (*extension_will_create_default_database_t)(void);
 
 template <class T>
 static T LoadFunctionFromDLL(void *dll, const string &function_name, const string &filename) {

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -11,7 +11,7 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 typedef void (*ext_init_fun_t)(DatabaseInstance &);
 typedef const char *(*ext_version_fun_t)(void);
-typedef void (*ext_storage_init_t)(DBConfig &);
+typedef bool (*ext_is_storage_t)(void);
 
 template <class T>
 static T LoadFunctionFromDLL(void *dll, const string &function_name, const string &filename) {
@@ -201,6 +201,37 @@ string ExtensionHelper::ExtractExtensionPrefixFromPath(const string &path) {
 		}
 	}
 	return extension;
+}
+
+bool ExtensionHelper::IsStorageExtension(string &extension, DBConfig &config) {
+	extension = ExtensionHelper::ApplyExtensionAlias(extension);
+	ExtensionInitResult res;
+	string error;
+	if (!TryInitialLoad(config, nullptr, extension, res, error)) {
+		if (!ExtensionHelper::AllowAutoInstall(extension)) {
+			throw IOException(error);
+		}
+		// the extension load failed - try installing the extension
+		if (!config.file_system) {
+			throw InternalException("Attempting to install an extension without a file system");
+		}
+		ExtensionHelper::InstallExtension(config, *config.file_system, extension, false);
+		// try loading again
+		if (!TryInitialLoad(config, nullptr, extension, res, error)) {
+			throw IOException(error);
+		}
+	}
+	auto storage_fun_name = res.basename + "_is_storage";
+
+	ext_is_storage_t is_storage_fun;
+	is_storage_fun = LoadFunctionFromDLL<ext_is_storage_t>(res.lib_hdl, storage_fun_name, res.filename);
+
+	try {
+		return (*is_storage_fun)();
+	} catch (std::exception &e) {
+		throw InvalidInputException("Extension Initialize function \"%s\" from file \"%s\" threw an exception: \"%s\"",
+		                            storage_fun_name, res.filename, e.what());
+	}
 }
 
 } // namespace duckdb

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -181,7 +181,6 @@ void ExtensionHelper::LoadExternalExtension(ClientContext &context, const string
 	LoadExternalExtension(DatabaseInstance::GetDatabase(context), FileSystem::GetFileOpener(context), extension);
 }
 
-
 string ExtensionHelper::ExtractExtensionPrefixFromPath(const string &path) {
 	auto first_colon = path.find(':');
 	if (first_colon == string::npos || first_colon < 2) { // needs to be at least two characters because windows c: ...

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -131,8 +131,6 @@ ExtensionInitResult ExtensionHelper::InitialLoad(DBConfig &config, FileOpener *o
 	string error;
 	ExtensionInitResult result;
 	if (!TryInitialLoad(config, opener, extension, result, error)) {
-		throw IOException(error);
-	} else {
 		if (!ExtensionHelper::AllowAutoInstall(extension)) {
 			throw IOException(error);
 		}

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -12,6 +12,7 @@ namespace duckdb {
 typedef void (*ext_init_fun_t)(DatabaseInstance &);
 typedef const char *(*ext_version_fun_t)(void);
 typedef void (*ext_storage_init_t)(DBConfig &);
+typedef bool (*extension_will_create_default_database_t)(void);
 
 template <class T>
 static T LoadFunctionFromDLL(void *dll, const string &function_name, const string &filename) {
@@ -181,37 +182,6 @@ void ExtensionHelper::LoadExternalExtension(ClientContext &context, const string
 	LoadExternalExtension(DatabaseInstance::GetDatabase(context), FileSystem::GetFileOpener(context), extension);
 }
 
-void ExtensionHelper::StorageInit(string &extension, DBConfig &config) {
-	extension = ExtensionHelper::ApplyExtensionAlias(extension);
-	ExtensionInitResult res;
-	string error;
-	if (!TryInitialLoad(config, nullptr, extension, res, error)) {
-		if (!ExtensionHelper::AllowAutoInstall(extension)) {
-			throw IOException(error);
-		}
-		// the extension load failed - try installing the extension
-		if (!config.file_system) {
-			throw InternalException("Attempting to install an extension without a file system");
-		}
-		ExtensionHelper::InstallExtension(config, *config.file_system, extension, false);
-		// try loading again
-		if (!TryInitialLoad(config, nullptr, extension, res, error)) {
-			throw IOException(error);
-		}
-	}
-	auto storage_fun_name = res.basename + "_storage_init";
-
-	ext_storage_init_t storage_init_fun;
-	storage_init_fun = LoadFunctionFromDLL<ext_storage_init_t>(res.lib_hdl, storage_fun_name, res.filename);
-
-	try {
-		(*storage_init_fun)(config);
-	} catch (std::exception &e) {
-		throw InvalidInputException(
-		    "Storage initialization function \"%s\" from file \"%s\" threw an exception: \"%s\"", storage_fun_name,
-		    res.filename, e.what());
-	}
-}
 
 string ExtensionHelper::ExtractExtensionPrefixFromPath(const string &path) {
 	auto first_colon = path.find(':');

--- a/tools/pythonpkg/tests/fast/api/test_config.py
+++ b/tools/pythonpkg/tests/fast/api/test_config.py
@@ -38,6 +38,14 @@ class TestDBConfig(object):
             query_failed = True
         assert query_failed == True
 
+    def test_unrecognized_option(self, duckdb_cursor):
+        success = True
+        try:
+            con_regular = duckdb.connect(':memory:', config={'thisoptionisprobablynotthere': '42'})
+        except:
+            success = False
+        assert success==False
+
     def test_incorrect_parameter(self, duckdb_cursor):
         success = True
         try:

--- a/tools/pythonpkg/tests/fast/api/test_config.py
+++ b/tools/pythonpkg/tests/fast/api/test_config.py
@@ -38,14 +38,6 @@ class TestDBConfig(object):
             query_failed = True
         assert query_failed == True
 
-    def test_unrecognized_option(self, duckdb_cursor):
-        success = True
-        try:
-            con_regular = duckdb.connect(':memory:', config={'thisoptionisprobablynotthere': '42'})
-        except:
-            success = False
-        assert success==False
-
     def test_incorrect_parameter(self, duckdb_cursor):
         success = True
         try:


### PR DESCRIPTION
Removed `storage_init` hook and allow the extension's `init` hook to initialize the default database. This is necessary to ensure that new connections land in the right database. 

I worry about hidden dependencies on a database being fully initialized before the extension's init is called. I have noticed that catalog lookups do query the default database when they are not fully specified, this can cause issues in existing `init` methods. Not sure whether it makes more sense to reevaluate each hidden dependency to move un-need reliance on the default database, or to add specially opt-in during initialization (to ensure only advanced users use this feature).