### PR TITLE
Reset parsed_chunk when figuring out new line in Parallel CSV Reader

### DIFF
--- a/src/execution/operator/persistent/parallel_csv_reader.cpp
+++ b/src/execution/operator/persistent/parallel_csv_reader.cpp
@@ -124,6 +124,8 @@ bool ParallelCSVReader::SetPosition(DataChunk &insert_chunk) {
 	while (!successfully_read_first_line) {
 		DataChunk first_line_chunk;
 		first_line_chunk.Initialize(allocator, return_types);
+		// Ensure that parse_chunk has no gunk when trying to figure new line
+		parse_chunk.Reset();
 		for (; position_buffer < end_buffer; position_buffer++) {
 			if (StringUtil::CharacterIsNewline((*buffer)[position_buffer])) {
 				bool carriage_return = (*buffer)[position_buffer] == '\r';
@@ -183,6 +185,8 @@ bool ParallelCSVReader::SetPosition(DataChunk &insert_chunk) {
 	if (verification_positions.beginning_of_first_line == 0) {
 		verification_positions.beginning_of_first_line = position_buffer;
 	}
+	// Ensure that parse_chunk has no gunk when trying to figure new line
+	parse_chunk.Reset();
 
 	verification_positions.end_of_last_line = position_buffer;
 	finished = false;


### PR DESCRIPTION
Fix: #7221 

I did not add a proper test case for this, because the file is a few MBs, and the fix was pretty straight-forward. I've tried minimizing the file size and computing it with different `buffer_size`, but I didn't manage to trigger the issue. Only with the full file.

@Mytherin, if you want, I can add the test case with the full file.