### PR TITLE
[Python] Add `by_name` option to `connection.append` method

### DIFF
--- a/extension/tpcds/dsdgen/dsdgen_helpers.cpp
+++ b/extension/tpcds/dsdgen/dsdgen_helpers.cpp
@@ -18,8 +18,8 @@ void InitializeDSDgen(double scale) {
 	InitConstants::Reset();
 	ResetCountCount();
 	std::string t = std::to_string(scale);
-	set_str("SCALE", (char*) t.c_str()); // set SF, which also does a default init (e.g. random seed)
-	init_rand();                 // no random numbers without this
+	set_str("SCALE", (char *)t.c_str()); // set SF, which also does a default init (e.g. random seed)
+	init_rand();                         // no random numbers without this
 }
 
 ds_key_t GetRowCount(int table_id) {

--- a/src/common/radix_partitioning.cpp
+++ b/src/common/radix_partitioning.cpp
@@ -9,7 +9,7 @@
 namespace duckdb {
 
 template <class OP, class RETURN_TYPE, typename... ARGS>
-RETURN_TYPE RadixBitsSwitch(idx_t radix_bits, ARGS &&...args) {
+RETURN_TYPE RadixBitsSwitch(idx_t radix_bits, ARGS &&... args) {
 	D_ASSERT(radix_bits <= sizeof(hash_t) * 8);
 	switch (radix_bits) {
 	case 1:

--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -192,7 +192,7 @@ static void InitializeConnectionMethods(py::module_ &m) {
 	    py::arg("all_varchar") = py::none(), py::arg("normalize_names") = py::none(), py::arg("filename") = py::none());
 
 	m.def("append", &PyConnectionWrapper::Append, "Append the passed DataFrame to the named table",
-	      py::arg("table_name"), py::arg("df"), py::arg("connection") = py::none())
+	      py::arg("table_name"), py::arg("df"), py::kw_only(), py::arg("by_name") = false, py::arg("connection") = py::none())
 	    .def("register", &PyConnectionWrapper::RegisterPythonObject,
 	         "Register the passed Python Object value for querying with a view", py::arg("view_name"),
 	         py::arg("python_object"), py::arg("connection") = py::none())

--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -192,7 +192,8 @@ static void InitializeConnectionMethods(py::module_ &m) {
 	    py::arg("all_varchar") = py::none(), py::arg("normalize_names") = py::none(), py::arg("filename") = py::none());
 
 	m.def("append", &PyConnectionWrapper::Append, "Append the passed DataFrame to the named table",
-	      py::arg("table_name"), py::arg("df"), py::kw_only(), py::arg("by_name") = false, py::arg("connection") = py::none())
+	      py::arg("table_name"), py::arg("df"), py::kw_only(), py::arg("by_name") = false,
+	      py::arg("connection") = py::none())
 	    .def("register", &PyConnectionWrapper::RegisterPythonObject,
 	         "Register the passed Python Object value for querying with a view", py::arg("view_name"),
 	         py::arg("python_object"), py::arg("connection") = py::none())

--- a/tools/pythonpkg/src/include/duckdb_python/connection_wrapper.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/connection_wrapper.hpp
@@ -44,7 +44,7 @@ public:
 	                                           shared_ptr<DuckDBPyConnection> conn = nullptr);
 	static shared_ptr<DuckDBPyType> Type(const string &type_str, shared_ptr<DuckDBPyConnection> conn = nullptr);
 
-	static shared_ptr<DuckDBPyConnection> Append(const string &name, PandasDataFrame value,
+	static shared_ptr<DuckDBPyConnection> Append(const string &name, PandasDataFrame value, bool by_name,
 	                                             shared_ptr<DuckDBPyConnection> conn = nullptr);
 
 	static shared_ptr<DuckDBPyConnection> RegisterPythonObject(const string &name, py::object python_object,

--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
@@ -96,7 +96,7 @@ public:
 
 	shared_ptr<DuckDBPyConnection> Execute(const string &query, py::object params = py::list(), bool many = false);
 
-	shared_ptr<DuckDBPyConnection> Append(const string &name, const PandasDataFrame &value);
+	shared_ptr<DuckDBPyConnection> Append(const string &name, const PandasDataFrame &value, bool by_name);
 
 	shared_ptr<DuckDBPyConnection> RegisterPythonObject(const string &name, const py::object &python_object);
 

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -163,8 +163,8 @@ static void InitializeConnectionMethods(py::class_<DuckDBPyConnection, shared_pt
 	    .def("begin", &DuckDBPyConnection::Begin, "Start a new transaction")
 	    .def("commit", &DuckDBPyConnection::Commit, "Commit changes performed within a transaction")
 	    .def("rollback", &DuckDBPyConnection::Rollback, "Roll back changes performed within a transaction")
-	    .def("append", &DuckDBPyConnection::Append, "Append the passed Data.Frame to the named table",
-	         py::arg("table_name"), py::arg("df"))
+	    .def("append", &DuckDBPyConnection::Append, "Append the passed DataFrame to the named table",
+	         py::arg("table_name"), py::arg("df"), py::kw_only(), py::arg("by_name") = false)
 	    .def("register", &DuckDBPyConnection::RegisterPythonObject,
 	         "Register the passed Python Object value for querying with a view", py::arg("view_name"),
 	         py::arg("python_object"))
@@ -439,9 +439,18 @@ shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Execute(const string &query, 
 	return shared_from_this();
 }
 
-shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Append(const string &name, const PandasDataFrame &value) {
+shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Append(const string &name, const PandasDataFrame &value, bool by_name) {
 	RegisterPythonObject("__append_df", value);
-	return Execute("INSERT INTO \"" + name + "\" SELECT * FROM __append_df");
+	string columns = "";
+	if (by_name) {
+		auto df_columns = value.attr("columns");
+		vector<string> column_names;
+		for (auto& column : df_columns) {
+			column_names.push_back(std::string(py::str(column)));
+		}
+		columns = StringUtil::Format("(%s)", StringUtil::Join(column_names, ","));
+	}
+	return Execute(StringUtil::Format("INSERT INTO \"%s\"%s SELECT * FROM __append_df", name, columns));
 }
 
 void DuckDBPyConnection::RegisterArrowObject(const py::object &arrow_object, const string &name) {

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -439,13 +439,14 @@ shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Execute(const string &query, 
 	return shared_from_this();
 }
 
-shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Append(const string &name, const PandasDataFrame &value, bool by_name) {
+shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Append(const string &name, const PandasDataFrame &value,
+                                                          bool by_name) {
 	RegisterPythonObject("__append_df", value);
 	string columns = "";
 	if (by_name) {
 		auto df_columns = value.attr("columns");
 		vector<string> column_names;
-		for (auto& column : df_columns) {
+		for (auto &column : df_columns) {
 			column_names.push_back(std::string(py::str(column)));
 		}
 		columns = StringUtil::Format("(%s)", StringUtil::Join(column_names, ","));

--- a/tools/pythonpkg/src/pyduckdb/connection_wrapper.cpp
+++ b/tools/pythonpkg/src/pyduckdb/connection_wrapper.cpp
@@ -97,9 +97,9 @@ shared_ptr<DuckDBPyConnection> PyConnectionWrapper::Execute(const string &query,
 	return conn->Execute(query, params, many);
 }
 
-shared_ptr<DuckDBPyConnection> PyConnectionWrapper::Append(const string &name, PandasDataFrame value,
+shared_ptr<DuckDBPyConnection> PyConnectionWrapper::Append(const string &name, PandasDataFrame value, bool by_name,
                                                            shared_ptr<DuckDBPyConnection> conn) {
-	return conn->Append(name, value);
+	return conn->Append(name, value, by_name);
 }
 
 shared_ptr<DuckDBPyConnection> PyConnectionWrapper::RegisterPythonObject(const string &name, py::object python_object,

--- a/tools/pythonpkg/tests/fast/pandas/test_append_df.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_append_df.py
@@ -29,3 +29,4 @@ class TestAppendDF(object):
         con.append('tbl', df_in, by_name=True)
         res = con.table('tbl').fetchall()
         assert res == [(4, False, 'duck'), (2, True, 'db')]
+    

--- a/tools/pythonpkg/tests/fast/pandas/test_append_df.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_append_df.py
@@ -11,3 +11,21 @@ class TestAppendDF(object):
         df_in = pandas.DataFrame({'numbers': [1,2,3,4,5],})
         conn.append('integers',df_in)
         assert conn.execute('select count(*) from integers').fetchone()[0] == 5
+
+    @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
+    def test_append_by_name(self, pandas):
+        con = duckdb.connect()
+        con.execute("create table tbl (a integer, b bool, c varchar)")
+        df_in = pandas.DataFrame({
+            'c': ['duck', 'db'],
+            'b': [False, True],
+            'a': [4,2]
+        })
+        # By default we append by position, causing the following exception:
+        with pytest.raises(duckdb.ConversionException, match="Conversion Error: Could not convert string 'duck' to INT32"):
+            con.append('tbl', df_in)
+
+        # When we use 'by_name' we instead append by name
+        con.append('tbl', df_in, by_name=True)
+        res = con.table('tbl').fetchall()
+        assert res == [(4, False, 'duck'), (2, True, 'db')]


### PR DESCRIPTION
This PR fixes #7176

When the (optional) `by_name` option is provided, we will use the column names of the dataframe to determine which table columns they should map to.
This means that this can only be used when the tables columns are a direct match or a subset of the columns of the dataframe.