### PR TITLE
[Python] Fix #7269

### DIFF
--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -875,6 +875,7 @@ void DuckDBPyRelation::Print() {
 
 string DuckDBPyRelation::Explain(ExplainType type) {
 	AssertRelation();
+	py::gil_scoped_release release;
 	auto res = rel->Explain(type);
 	D_ASSERT(res->type == duckdb::QueryResultType::MATERIALIZED_RESULT);
 	auto &materialized = (duckdb::MaterializedQueryResult &)*res;

--- a/tools/pythonpkg/tests/fast/api/test_explain.py
+++ b/tools/pythonpkg/tests/fast/api/test_explain.py
@@ -40,6 +40,6 @@ class TestExplain(object):
 
 	def test_explain_df(self):
 		pd = pytest.importorskip("pandas")
-		df = pd.DataFrame({'a': 42})
+		df = pd.DataFrame({'a': [42]})
 		res = duckdb.sql('select * from df').explain('ANALYZE')
 		assert isinstance(res, str)

--- a/tools/pythonpkg/tests/fast/api/test_explain.py
+++ b/tools/pythonpkg/tests/fast/api/test_explain.py
@@ -37,3 +37,9 @@ class TestExplain(object):
 
 		res = duckdb.sql('select 42').explain(1)
 		assert isinstance(res, str)
+
+	def test_explain_df(self):
+		pd = pytest.importorskip("pandas")
+		df = pd.DataFrame({'a': 42})
+		res = duckdb.sql('select * from df').explain('ANALYZE')
+		assert isinstance(res, str)


### PR DESCRIPTION
This PR fixes #7269 

We were not releasing the GIL before executing, this is required by our execution code.