### PR TITLE
Segmented signing checks on extensions

### DIFF
--- a/scripts/compute-extension-hash.sh
+++ b/scripts/compute-extension-hash.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+rm -f hash_concats
+touch hash_concats
+
+split -b 1M $1
+
+FILES="x*"
+for f in $FILES
+do
+	# sha256 a segment
+	scripts/compute-hash.sh $f >> hash_concats
+	rm $f
+done
+
+# sha256 the concatenation
+scripts/compute-hash.sh hash_concats > hash_composite
+
+cat hash_composite

--- a/scripts/compute-hash.sh
+++ b/scripts/compute-hash.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+openssl dgst -binary -sha256 $1 > hash
+
+cat hash

--- a/scripts/extension-upload.sh
+++ b/scripts/extension-upload.sh
@@ -12,7 +12,7 @@ do
 	ext=`basename $f .duckdb_extension`
 	echo $ext
 	# calculate SHA256 hash of extension binary
-	scripts/compute-hash.sh $f > $f.hash
+	scripts/compute-extension-hash.sh $f > $f.hash
 	# encrypt hash with extension signing private key to create signature
 	openssl pkeyutl -sign -in $f.hash -inkey private.pem -pkeyopt digest:sha256 -out $f.sign
 	# append signature to extension binary

--- a/scripts/extension-upload.sh
+++ b/scripts/extension-upload.sh
@@ -12,7 +12,7 @@ do
 	ext=`basename $f .duckdb_extension`
 	echo $ext
 	# calculate SHA256 hash of extension binary
-	openssl dgst -binary -sha256 $f > $f.hash
+	scripts/compute-hash.sh $f > $f.hash
 	# encrypt hash with extension signing private key to create signature
 	openssl pkeyutl -sign -in $f.hash -inkey private.pem -pkeyopt digest:sha256 -out $f.sign
 	# append signature to extension binary


### PR DESCRIPTION
Bottleneck of sha256 computation is alleviated by computing sha256 on fixed-size segments, and then combining the hashes. This is basically a 2-level Merkle tree, with root, no internal nodes, and file_size / 1MB leafs.

Note that 2-level sha256 computation is computed both on threaded and non-threaded versions, since results will have to agree (and in any case the second step has constant negligible cost).