### PR TITLE
Add ExtensionUtil class and move function registration to ExtensionUtil

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -381,6 +381,7 @@ jobs:
       CXX: g++-10
       TREAT_WARNINGS_AS_ERRORS: 1
       DISABLE_UNITY: 1
+      DISABLE_PARQUET: 1
       GEN: ninja
 
     steps:

--- a/extension/autocomplete/sql_auto_complete-extension.cpp
+++ b/extension/autocomplete/sql_auto_complete-extension.cpp
@@ -10,9 +10,9 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/client_data.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
-#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "sql_auto_complete-extension.hpp"
+#include "duckdb/main/extension_util.hpp"
 
 namespace duckdb {
 
@@ -399,18 +399,9 @@ void SQLAutoCompleteFunction(ClientContext &context, TableFunctionInput &data_p,
 }
 
 static void LoadInternal(DatabaseInstance &db) {
-	Connection con(db);
-	con.BeginTransaction();
-
-	auto &context = *con.context;
-
-	Catalog &catalog = Catalog::GetSystemCatalog(context);
 	TableFunction auto_complete_fun("sql_auto_complete", {LogicalType::VARCHAR}, SQLAutoCompleteFunction,
 	                                SQLAutoCompleteBind, SQLAutoCompleteInit);
-	CreateTableFunctionInfo auto_complete_info(auto_complete_fun);
-	catalog.CreateTableFunction(context, auto_complete_info);
-
-	con.Commit();
+	ExtensionUtil::RegisterFunction(db, auto_complete_fun);
 }
 void SQLAutoCompleteExtension::Load(DuckDB &db) {
 	LoadInternal(*db.instance);

--- a/extension/inet/inet-extension.cpp
+++ b/extension/inet/inet-extension.cpp
@@ -2,23 +2,16 @@
 
 #include "duckdb.hpp"
 #include "duckdb/common/exception.hpp"
-#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/function/scalar_function.hpp"
-#include "duckdb/parser/parsed_data/create_type_info.hpp"
-#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
-#include "duckdb/catalog/catalog.hpp"
-#include "duckdb/main/config.hpp"
+#include "duckdb/main/extension_util.hpp"
 #include "inet-extension.hpp"
 #include "inet_functions.hpp"
 
 namespace duckdb {
 
 void INETExtension::Load(DuckDB &db) {
-	Connection con(db);
-	con.BeginTransaction();
-
-	auto &catalog = Catalog::GetSystemCatalog(*con.context);
+	auto &db_instance = *db.instance;
 
 	// add the "inet" type
 	child_list_t<LogicalType> children;
@@ -28,29 +21,19 @@ void INETExtension::Load(DuckDB &db) {
 	auto inet_type = LogicalType::STRUCT(std::move(children));
 	inet_type.SetAlias("inet");
 
-	CreateTypeInfo info("inet", inet_type);
-	info.temporary = true;
-	info.internal = true;
-	catalog.CreateType(*con.context, info);
+	ExtensionUtil::RegisterType(db_instance, "inet", inet_type);
 
 	// add inet functions
-	auto host_fun = ScalarFunction("host", {inet_type}, LogicalType::VARCHAR, INetFunctions::Host);
-	CreateScalarFunctionInfo host_info(host_fun);
-	catalog.CreateFunction(*con.context, host_info);
+	ScalarFunction host_fun("host", {inet_type}, LogicalType::VARCHAR, INetFunctions::Host);
+	ExtensionUtil::RegisterFunction(db_instance, host_fun);
 
-	auto substract_fun = ScalarFunction("-", {inet_type, LogicalType::BIGINT}, inet_type, INetFunctions::Subtract);
-	CreateScalarFunctionInfo subtract_info(substract_fun);
-	subtract_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
-	catalog.CreateFunction(*con.context, subtract_info);
+	ScalarFunction subtract_fun("-", {inet_type, LogicalType::BIGINT}, inet_type, INetFunctions::Subtract);
+	ExtensionUtil::ExtendFunction(db_instance, subtract_fun);
 
 	// add inet casts
-	auto &config = DBConfig::GetConfig(*con.context);
-
-	auto &casts = config.GetCastFunctions();
-	casts.RegisterCastFunction(LogicalType::VARCHAR, inet_type, INetFunctions::CastVarcharToINET, 100);
-	casts.RegisterCastFunction(inet_type, LogicalType::VARCHAR, INetFunctions::CastINETToVarchar);
-
-	con.Commit();
+	ExtensionUtil::RegisterCastFunction(db_instance, LogicalType::VARCHAR, inet_type, INetFunctions::CastVarcharToINET,
+	                                    100);
+	ExtensionUtil::RegisterCastFunction(db_instance, inet_type, LogicalType::VARCHAR, INetFunctions::CastINETToVarchar);
 }
 
 std::string INETExtension::Name() {

--- a/extension/json/include/json_functions.hpp
+++ b/extension/json/include/json_functions.hpp
@@ -8,9 +8,7 @@
 
 #pragma once
 
-#include "duckdb/parser/parsed_data/create_copy_function_info.hpp"
-#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
-#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+#include "duckdb/main/extension_util.hpp"
 #include "json_common.hpp"
 
 namespace duckdb {
@@ -66,40 +64,40 @@ public:
 
 class JSONFunctions {
 public:
-	static vector<CreateScalarFunctionInfo> GetScalarFunctions();
-	static vector<CreatePragmaFunctionInfo> GetPragmaFunctions();
-	static vector<CreateTableFunctionInfo> GetTableFunctions();
+	static vector<ScalarFunctionSet> GetScalarFunctions();
+	static vector<PragmaFunctionSet> GetPragmaFunctions();
+	static vector<TableFunctionSet> GetTableFunctions();
 	static unique_ptr<TableRef> ReadJSONReplacement(ClientContext &context, const string &table_name,
 	                                                ReplacementScanData *data);
 	static TableFunction GetReadJSONTableFunction(shared_ptr<JSONScanInfo> function_info);
-	static CreateCopyFunctionInfo GetJSONCopyFunction();
+	static CopyFunction GetJSONCopyFunction();
 	static void RegisterCastFunctions(CastFunctionSet &casts);
 
 private:
 	// Scalar functions
-	static CreateScalarFunctionInfo GetExtractFunction();
-	static CreateScalarFunctionInfo GetExtractStringFunction();
+	static ScalarFunctionSet GetExtractFunction();
+	static ScalarFunctionSet GetExtractStringFunction();
 
-	static CreateScalarFunctionInfo GetArrayFunction();
-	static CreateScalarFunctionInfo GetObjectFunction();
-	static CreateScalarFunctionInfo GetToJSONFunction();
-	static CreateScalarFunctionInfo GetArrayToJSONFunction();
-	static CreateScalarFunctionInfo GetRowToJSONFunction();
-	static CreateScalarFunctionInfo GetMergePatchFunction();
+	static ScalarFunctionSet GetArrayFunction();
+	static ScalarFunctionSet GetObjectFunction();
+	static ScalarFunctionSet GetToJSONFunction();
+	static ScalarFunctionSet GetArrayToJSONFunction();
+	static ScalarFunctionSet GetRowToJSONFunction();
+	static ScalarFunctionSet GetMergePatchFunction();
 
-	static CreateScalarFunctionInfo GetStructureFunction();
-	static CreateScalarFunctionInfo GetTransformFunction();
-	static CreateScalarFunctionInfo GetTransformStrictFunction();
+	static ScalarFunctionSet GetStructureFunction();
+	static ScalarFunctionSet GetTransformFunction();
+	static ScalarFunctionSet GetTransformStrictFunction();
 
-	static CreateScalarFunctionInfo GetArrayLengthFunction();
-	static CreateScalarFunctionInfo GetContainsFunction();
-	static CreateScalarFunctionInfo GetKeysFunction();
-	static CreateScalarFunctionInfo GetTypeFunction();
-	static CreateScalarFunctionInfo GetValidFunction();
-	static CreateScalarFunctionInfo GetSerializeSqlFunction();
-	static CreateScalarFunctionInfo GetDeserializeSqlFunction();
+	static ScalarFunctionSet GetArrayLengthFunction();
+	static ScalarFunctionSet GetContainsFunction();
+	static ScalarFunctionSet GetKeysFunction();
+	static ScalarFunctionSet GetTypeFunction();
+	static ScalarFunctionSet GetValidFunction();
+	static ScalarFunctionSet GetSerializeSqlFunction();
+	static ScalarFunctionSet GetDeserializeSqlFunction();
 
-	static CreatePragmaFunctionInfo GetExecuteJsonSerializedSqlPragmaFunction();
+	static PragmaFunctionSet GetExecuteJsonSerializedSqlPragmaFunction();
 
 	template <class FUNCTION_INFO>
 	static void AddAliases(const vector<string> &names, FUNCTION_INFO fun, vector<FUNCTION_INFO> &functions) {
@@ -111,13 +109,13 @@ private:
 
 private:
 	// Table functions
-	static CreateTableFunctionInfo GetReadJSONObjectsFunction();
-	static CreateTableFunctionInfo GetReadNDJSONObjectsFunction();
-	static CreateTableFunctionInfo GetReadJSONFunction();
-	static CreateTableFunctionInfo GetReadNDJSONFunction();
-	static CreateTableFunctionInfo GetReadJSONAutoFunction();
-	static CreateTableFunctionInfo GetReadNDJSONAutoFunction();
-	static CreateTableFunctionInfo GetExecuteJsonSerializedSqlFunction();
+	static TableFunctionSet GetReadJSONObjectsFunction();
+	static TableFunctionSet GetReadNDJSONObjectsFunction();
+	static TableFunctionSet GetReadJSONFunction();
+	static TableFunctionSet GetReadNDJSONFunction();
+	static TableFunctionSet GetReadJSONAutoFunction();
+	static TableFunctionSet GetReadNDJSONAutoFunction();
+	static TableFunctionSet GetExecuteJsonSerializedSqlFunction();
 };
 
 } // namespace duckdb

--- a/extension/json/json-extension.cpp
+++ b/extension/json/json-extension.cpp
@@ -3,13 +3,12 @@
 
 #include "duckdb/catalog/catalog_entry/macro_catalog_entry.hpp"
 #include "duckdb/catalog/default/default_functions.hpp"
+#include "duckdb/main/extension_util.hpp"
 #include "duckdb/common/string_util.hpp"
-#include "duckdb/function/cast/cast_function_set.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
-#include "duckdb/parser/parsed_data/create_type_info.hpp"
-#include "duckdb/parser/parsed_data/create_pragma_function_info.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
+#include "duckdb/function/copy_function.hpp"
 #include "json_common.hpp"
 #include "json_functions.hpp"
 
@@ -23,34 +22,27 @@ static DefaultMacro json_macros[] = {
     {nullptr, nullptr, {nullptr}, nullptr}};
 
 void JSONExtension::Load(DuckDB &db) {
-	Connection con(db);
-	con.BeginTransaction();
-	auto &context = *con.context;
-	auto &catalog = Catalog::GetSystemCatalog(context);
-
+	auto &db_instance = *db.instance;
 	// JSON type
 	auto json_type = JSONCommon::JSONType();
-	CreateTypeInfo type_info(JSONCommon::JSON_TYPE_NAME, json_type);
-	type_info.temporary = true;
-	type_info.internal = true;
-	catalog.CreateType(context, type_info);
+	ExtensionUtil::RegisterType(db_instance, JSONCommon::JSON_TYPE_NAME, std::move(json_type));
 
 	// JSON casts
-	JSONFunctions::RegisterCastFunctions(DBConfig::GetConfig(context).GetCastFunctions());
+	JSONFunctions::RegisterCastFunctions(DBConfig::GetConfig(db_instance).GetCastFunctions());
 
 	// JSON scalar functions
 	for (auto &fun : JSONFunctions::GetScalarFunctions()) {
-		catalog.CreateFunction(context, fun);
+		ExtensionUtil::RegisterFunction(db_instance, fun);
 	}
 
 	// JSON table functions
 	for (auto &fun : JSONFunctions::GetTableFunctions()) {
-		catalog.CreateTableFunction(context, fun);
+		ExtensionUtil::RegisterFunction(db_instance, fun);
 	}
 
 	// JSON pragma functions
 	for (auto &fun : JSONFunctions::GetPragmaFunctions()) {
-		catalog.CreatePragmaFunction(context, fun);
+		ExtensionUtil::RegisterFunction(db_instance, fun);
 	}
 
 	// JSON replacement scan
@@ -59,15 +51,13 @@ void JSONExtension::Load(DuckDB &db) {
 
 	// JSON copy function
 	auto copy_fun = JSONFunctions::GetJSONCopyFunction();
-	catalog.CreateCopyFunction(context, copy_fun);
+	ExtensionUtil::RegisterFunction(db_instance, std::move(copy_fun));
 
 	// JSON macro's
 	for (idx_t index = 0; json_macros[index].name != nullptr; index++) {
 		auto info = DefaultFunctionGenerator::CreateInternalMacroInfo(json_macros[index]);
-		catalog.CreateFunction(context, *info);
+		ExtensionUtil::RegisterFunction(db_instance, *info);
 	}
-
-	con.Commit();
 }
 
 std::string JSONExtension::Name() {

--- a/extension/json/json_functions.cpp
+++ b/extension/json/json_functions.cpp
@@ -121,8 +121,8 @@ JSONFunctionLocalState &JSONFunctionLocalState::ResetAndGet(ExpressionState &sta
 	return lstate;
 }
 
-vector<CreateScalarFunctionInfo> JSONFunctions::GetScalarFunctions() {
-	vector<CreateScalarFunctionInfo> functions;
+vector<ScalarFunctionSet> JSONFunctions::GetScalarFunctions() {
+	vector<ScalarFunctionSet> functions;
 
 	// Extract functions
 	AddAliases({"json_extract", "json_extract_path"}, GetExtractFunction(), functions);
@@ -153,14 +153,14 @@ vector<CreateScalarFunctionInfo> JSONFunctions::GetScalarFunctions() {
 	return functions;
 }
 
-vector<CreatePragmaFunctionInfo> JSONFunctions::GetPragmaFunctions() {
-	vector<CreatePragmaFunctionInfo> functions;
+vector<PragmaFunctionSet> JSONFunctions::GetPragmaFunctions() {
+	vector<PragmaFunctionSet> functions;
 	functions.push_back(GetExecuteJsonSerializedSqlPragmaFunction());
 	return functions;
 }
 
-vector<CreateTableFunctionInfo> JSONFunctions::GetTableFunctions() {
-	vector<CreateTableFunctionInfo> functions;
+vector<TableFunctionSet> JSONFunctions::GetTableFunctions() {
+	vector<TableFunctionSet> functions;
 
 	// Reads JSON as string
 	functions.push_back(GetReadJSONObjectsFunction());

--- a/extension/json/json_functions/copy_json.cpp
+++ b/extension/json/json_functions/copy_json.cpp
@@ -106,7 +106,7 @@ static duckdb::unique_ptr<FunctionData> CopyFromJSONBind(ClientContext &context,
 	return std::move(bind_data);
 }
 
-CreateCopyFunctionInfo JSONFunctions::GetJSONCopyFunction() {
+CopyFunction JSONFunctions::GetJSONCopyFunction() {
 	CopyFunction function("json");
 	function.extension = "json";
 
@@ -116,7 +116,7 @@ CreateCopyFunctionInfo JSONFunctions::GetJSONCopyFunction() {
 	function.copy_from_function = JSONFunctions::GetReadJSONTableFunction(
 	    make_shared<JSONScanInfo>(JSONScanType::READ_JSON, JSONFormat::AUTO_DETECT, JSONRecordType::RECORDS, false));
 
-	return CreateCopyFunctionInfo(function);
+	return function;
 }
 
 } // namespace duckdb

--- a/extension/json/json_functions/json_array_length.cpp
+++ b/extension/json/json_functions/json_array_length.cpp
@@ -28,12 +28,11 @@ static void GetArrayLengthFunctionsInternal(ScalarFunctionSet &set, const Logica
 	                               JSONReadManyFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
 }
 
-CreateScalarFunctionInfo JSONFunctions::GetArrayLengthFunction() {
+ScalarFunctionSet JSONFunctions::GetArrayLengthFunction() {
 	ScalarFunctionSet set("json_array_length");
 	GetArrayLengthFunctionsInternal(set, LogicalType::VARCHAR);
 	GetArrayLengthFunctionsInternal(set, JSONCommon::JSONType());
-
-	return CreateScalarFunctionInfo(std::move(set));
+	return set;
 }
 
 } // namespace duckdb

--- a/extension/json/json_functions/json_contains.cpp
+++ b/extension/json/json_functions/json_contains.cpp
@@ -139,7 +139,7 @@ static void GetContainsFunctionInternal(ScalarFunctionSet &set, const LogicalTyp
 	                               JSONFunctionLocalState::Init));
 }
 
-CreateScalarFunctionInfo JSONFunctions::GetContainsFunction() {
+ScalarFunctionSet JSONFunctions::GetContainsFunction() {
 	ScalarFunctionSet set("json_contains");
 	GetContainsFunctionInternal(set, LogicalType::VARCHAR, LogicalType::VARCHAR);
 	GetContainsFunctionInternal(set, LogicalType::VARCHAR, JSONCommon::JSONType());
@@ -147,7 +147,7 @@ CreateScalarFunctionInfo JSONFunctions::GetContainsFunction() {
 	GetContainsFunctionInternal(set, JSONCommon::JSONType(), JSONCommon::JSONType());
 	// TODO: implement json_contains that accepts path argument as well
 
-	return CreateScalarFunctionInfo(std::move(set));
+	return set;
 }
 
 } // namespace duckdb

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -515,41 +515,41 @@ static void ToJSONFunction(DataChunk &args, ExpressionState &state, Vector &resu
 	}
 }
 
-CreateScalarFunctionInfo JSONFunctions::GetObjectFunction() {
-	auto fun = ScalarFunction("json_object", {}, JSONCommon::JSONType(), ObjectFunction, JSONObjectBind, nullptr,
+ScalarFunctionSet JSONFunctions::GetObjectFunction() {
+	ScalarFunction fun("json_object", {}, JSONCommon::JSONType(), ObjectFunction, JSONObjectBind, nullptr,
 	                          nullptr, JSONFunctionLocalState::Init);
 	fun.varargs = LogicalType::ANY;
 	fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
-	return CreateScalarFunctionInfo(fun);
+	return ScalarFunctionSet(fun);
 }
 
-CreateScalarFunctionInfo JSONFunctions::GetArrayFunction() {
-	auto fun = ScalarFunction("json_array", {}, JSONCommon::JSONType(), ArrayFunction, JSONArrayBind, nullptr, nullptr,
+ScalarFunctionSet JSONFunctions::GetArrayFunction() {
+	ScalarFunction fun("json_array", {}, JSONCommon::JSONType(), ArrayFunction, JSONArrayBind, nullptr, nullptr,
 	                          JSONFunctionLocalState::Init);
 	fun.varargs = LogicalType::ANY;
 	fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
-	return CreateScalarFunctionInfo(fun);
+	return ScalarFunctionSet(fun);
 }
 
-CreateScalarFunctionInfo JSONFunctions::GetToJSONFunction() {
-	auto fun = ScalarFunction("to_json", {}, JSONCommon::JSONType(), ToJSONFunction, ToJSONBind, nullptr, nullptr,
+ScalarFunctionSet JSONFunctions::GetToJSONFunction() {
+	ScalarFunction fun("to_json", {}, JSONCommon::JSONType(), ToJSONFunction, ToJSONBind, nullptr, nullptr,
 	                          JSONFunctionLocalState::Init);
 	fun.varargs = LogicalType::ANY;
-	return CreateScalarFunctionInfo(fun);
+	return ScalarFunctionSet(fun);
 }
 
-CreateScalarFunctionInfo JSONFunctions::GetArrayToJSONFunction() {
-	auto fun = ScalarFunction("array_to_json", {}, JSONCommon::JSONType(), ToJSONFunction, ArrayToJSONBind, nullptr,
+ScalarFunctionSet JSONFunctions::GetArrayToJSONFunction() {
+	ScalarFunction fun("array_to_json", {}, JSONCommon::JSONType(), ToJSONFunction, ArrayToJSONBind, nullptr,
 	                          nullptr, JSONFunctionLocalState::Init);
 	fun.varargs = LogicalType::ANY;
-	return CreateScalarFunctionInfo(fun);
+	return ScalarFunctionSet(fun);
 }
 
-CreateScalarFunctionInfo JSONFunctions::GetRowToJSONFunction() {
-	auto fun = ScalarFunction("row_to_json", {}, JSONCommon::JSONType(), ToJSONFunction, RowToJSONBind, nullptr,
+ScalarFunctionSet JSONFunctions::GetRowToJSONFunction() {
+	ScalarFunction fun("row_to_json", {}, JSONCommon::JSONType(), ToJSONFunction, RowToJSONBind, nullptr,
 	                          nullptr, JSONFunctionLocalState::Init);
 	fun.varargs = LogicalType::ANY;
-	return CreateScalarFunctionInfo(fun);
+	return ScalarFunctionSet(fun);
 }
 
 } // namespace duckdb

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -516,8 +516,8 @@ static void ToJSONFunction(DataChunk &args, ExpressionState &state, Vector &resu
 }
 
 ScalarFunctionSet JSONFunctions::GetObjectFunction() {
-	ScalarFunction fun("json_object", {}, JSONCommon::JSONType(), ObjectFunction, JSONObjectBind, nullptr,
-	                          nullptr, JSONFunctionLocalState::Init);
+	ScalarFunction fun("json_object", {}, JSONCommon::JSONType(), ObjectFunction, JSONObjectBind, nullptr, nullptr,
+	                   JSONFunctionLocalState::Init);
 	fun.varargs = LogicalType::ANY;
 	fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
 	return ScalarFunctionSet(fun);
@@ -525,7 +525,7 @@ ScalarFunctionSet JSONFunctions::GetObjectFunction() {
 
 ScalarFunctionSet JSONFunctions::GetArrayFunction() {
 	ScalarFunction fun("json_array", {}, JSONCommon::JSONType(), ArrayFunction, JSONArrayBind, nullptr, nullptr,
-	                          JSONFunctionLocalState::Init);
+	                   JSONFunctionLocalState::Init);
 	fun.varargs = LogicalType::ANY;
 	fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
 	return ScalarFunctionSet(fun);
@@ -533,21 +533,21 @@ ScalarFunctionSet JSONFunctions::GetArrayFunction() {
 
 ScalarFunctionSet JSONFunctions::GetToJSONFunction() {
 	ScalarFunction fun("to_json", {}, JSONCommon::JSONType(), ToJSONFunction, ToJSONBind, nullptr, nullptr,
-	                          JSONFunctionLocalState::Init);
+	                   JSONFunctionLocalState::Init);
 	fun.varargs = LogicalType::ANY;
 	return ScalarFunctionSet(fun);
 }
 
 ScalarFunctionSet JSONFunctions::GetArrayToJSONFunction() {
-	ScalarFunction fun("array_to_json", {}, JSONCommon::JSONType(), ToJSONFunction, ArrayToJSONBind, nullptr,
-	                          nullptr, JSONFunctionLocalState::Init);
+	ScalarFunction fun("array_to_json", {}, JSONCommon::JSONType(), ToJSONFunction, ArrayToJSONBind, nullptr, nullptr,
+	                   JSONFunctionLocalState::Init);
 	fun.varargs = LogicalType::ANY;
 	return ScalarFunctionSet(fun);
 }
 
 ScalarFunctionSet JSONFunctions::GetRowToJSONFunction() {
-	ScalarFunction fun("row_to_json", {}, JSONCommon::JSONType(), ToJSONFunction, RowToJSONBind, nullptr,
-	                          nullptr, JSONFunctionLocalState::Init);
+	ScalarFunction fun("row_to_json", {}, JSONCommon::JSONType(), ToJSONFunction, RowToJSONBind, nullptr, nullptr,
+	                   JSONFunctionLocalState::Init);
 	fun.varargs = LogicalType::ANY;
 	return ScalarFunctionSet(fun);
 }

--- a/extension/json/json_functions/json_extract.cpp
+++ b/extension/json/json_functions/json_extract.cpp
@@ -35,13 +35,12 @@ static void GetExtractFunctionsInternal(ScalarFunctionSet &set, const LogicalTyp
 	                               JSONReadManyFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
 }
 
-CreateScalarFunctionInfo JSONFunctions::GetExtractFunction() {
+ScalarFunctionSet JSONFunctions::GetExtractFunction() {
 	// Generic extract function
 	ScalarFunctionSet set("json_extract");
 	GetExtractFunctionsInternal(set, LogicalType::VARCHAR);
 	GetExtractFunctionsInternal(set, JSONCommon::JSONType());
-
-	return CreateScalarFunctionInfo(set);
+	return set;
 }
 
 static void GetExtractStringFunctionsInternal(ScalarFunctionSet &set, const LogicalType &input_type) {
@@ -52,13 +51,12 @@ static void GetExtractStringFunctionsInternal(ScalarFunctionSet &set, const Logi
 	                               JSONReadManyFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
 }
 
-CreateScalarFunctionInfo JSONFunctions::GetExtractStringFunction() {
+ScalarFunctionSet JSONFunctions::GetExtractStringFunction() {
 	// String extract function
 	ScalarFunctionSet set("json_extract_string");
 	GetExtractStringFunctionsInternal(set, LogicalType::VARCHAR);
 	GetExtractStringFunctionsInternal(set, JSONCommon::JSONType());
-
-	return CreateScalarFunctionInfo(set);
+	return set;
 }
 
 } // namespace duckdb

--- a/extension/json/json_functions/json_keys.cpp
+++ b/extension/json/json_functions/json_keys.cpp
@@ -49,12 +49,11 @@ static void GetJSONKeysFunctionsInternal(ScalarFunctionSet &set, const LogicalTy
 	                               JSONReadManyFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
 }
 
-CreateScalarFunctionInfo JSONFunctions::GetKeysFunction() {
+ScalarFunctionSet JSONFunctions::GetKeysFunction() {
 	ScalarFunctionSet set("json_keys");
 	GetJSONKeysFunctionsInternal(set, LogicalType::VARCHAR);
 	GetJSONKeysFunctionsInternal(set, JSONCommon::JSONType());
-
-	return CreateScalarFunctionInfo(std::move(set));
+	return set;
 }
 
 } // namespace duckdb

--- a/extension/json/json_functions/json_merge_patch.cpp
+++ b/extension/json/json_functions/json_merge_patch.cpp
@@ -96,13 +96,13 @@ static void MergePatchFunction(DataChunk &args, ExpressionState &state, Vector &
 	}
 }
 
-CreateScalarFunctionInfo JSONFunctions::GetMergePatchFunction() {
+ScalarFunctionSet JSONFunctions::GetMergePatchFunction() {
 	ScalarFunction fun("json_merge_patch", {}, JSONCommon::JSONType(), MergePatchFunction, JSONMergePatchBind, nullptr,
 	                   nullptr, JSONFunctionLocalState::Init);
 	fun.varargs = LogicalType::ANY;
 	fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
 
-	return CreateScalarFunctionInfo(fun);
+	return ScalarFunctionSet(fun);
 }
 
 } // namespace duckdb

--- a/extension/json/json_functions/json_serialize_sql.cpp
+++ b/extension/json/json_functions/json_serialize_sql.cpp
@@ -132,7 +132,7 @@ static void JsonSerializeFunction(DataChunk &args, ExpressionState &state, Vecto
 	});
 }
 
-CreateScalarFunctionInfo JSONFunctions::GetSerializeSqlFunction() {
+ScalarFunctionSet JSONFunctions::GetSerializeSqlFunction() {
 	ScalarFunctionSet set("json_serialize_sql");
 	set.AddFunction(ScalarFunction({LogicalType::VARCHAR}, JSONCommon::JSONType(), JsonSerializeFunction,
 	                               JsonSerializeBind, nullptr, nullptr, JSONFunctionLocalState::Init));
@@ -150,7 +150,7 @@ CreateScalarFunctionInfo JSONFunctions::GetSerializeSqlFunction() {
 	                   JSONCommon::JSONType(), JsonSerializeFunction, JsonSerializeBind, nullptr, nullptr,
 	                   JSONFunctionLocalState::Init));
 
-	return CreateScalarFunctionInfo(set);
+	return set;
 }
 
 //----------------------------------------------------------------------
@@ -204,11 +204,11 @@ static void JsonDeserializeFunction(DataChunk &args, ExpressionState &state, Vec
 	});
 }
 
-CreateScalarFunctionInfo JSONFunctions::GetDeserializeSqlFunction() {
+ScalarFunctionSet JSONFunctions::GetDeserializeSqlFunction() {
 	ScalarFunctionSet set("json_deserialize_sql");
 	set.AddFunction(ScalarFunction({JSONCommon::JSONType()}, LogicalType::VARCHAR, JsonDeserializeFunction, nullptr,
 	                               nullptr, nullptr, JSONFunctionLocalState::Init));
-	return CreateScalarFunctionInfo(set);
+	return set;
 }
 
 //----------------------------------------------------------------------
@@ -223,8 +223,8 @@ static string ExecuteJsonSerializedSqlPragmaFunction(ClientContext &context, con
 	return stmt->ToString();
 }
 
-CreatePragmaFunctionInfo JSONFunctions::GetExecuteJsonSerializedSqlPragmaFunction() {
-	return CreatePragmaFunctionInfo(PragmaFunction::PragmaCall(
+PragmaFunctionSet JSONFunctions::GetExecuteJsonSerializedSqlPragmaFunction() {
+	return PragmaFunctionSet(PragmaFunction::PragmaCall(
 	    "json_execute_serialized_sql", ExecuteJsonSerializedSqlPragmaFunction, {LogicalType::VARCHAR}));
 }
 
@@ -270,10 +270,10 @@ struct ExecuteSqlTableFunction {
 	}
 };
 
-CreateTableFunctionInfo JSONFunctions::GetExecuteJsonSerializedSqlFunction() {
+TableFunctionSet JSONFunctions::GetExecuteJsonSerializedSqlFunction() {
 	TableFunction func("json_execute_serialized_sql", {LogicalType::VARCHAR}, ExecuteSqlTableFunction::Function,
 	                   ExecuteSqlTableFunction::Bind);
-	return CreateTableFunctionInfo(func);
+	return TableFunctionSet(func);
 }
 
 } // namespace duckdb

--- a/extension/json/json_functions/json_structure.cpp
+++ b/extension/json/json_functions/json_structure.cpp
@@ -476,11 +476,11 @@ static void GetStructureFunctionInternal(ScalarFunctionSet &set, const LogicalTy
 	                               JSONFunctionLocalState::Init));
 }
 
-CreateScalarFunctionInfo JSONFunctions::GetStructureFunction() {
+ScalarFunctionSet JSONFunctions::GetStructureFunction() {
 	ScalarFunctionSet set("json_structure");
 	GetStructureFunctionInternal(set, LogicalType::VARCHAR);
 	GetStructureFunctionInternal(set, JSONCommon::JSONType());
-	return CreateScalarFunctionInfo(set);
+	return set;
 }
 
 static LogicalType StructureToTypeArray(ClientContext &context, const JSONStructureNode &node, const idx_t max_depth,

--- a/extension/json/json_functions/json_transform.cpp
+++ b/extension/json/json_functions/json_transform.cpp
@@ -685,11 +685,11 @@ static void GetTransformFunctionInternal(ScalarFunctionSet &set, const LogicalTy
 	                               JSONTransformBind, nullptr, nullptr, JSONFunctionLocalState::Init));
 }
 
-CreateScalarFunctionInfo JSONFunctions::GetTransformFunction() {
+ScalarFunctionSet JSONFunctions::GetTransformFunction() {
 	ScalarFunctionSet set("json_transform");
 	GetTransformFunctionInternal(set, LogicalType::VARCHAR);
 	GetTransformFunctionInternal(set, JSONCommon::JSONType());
-	return CreateScalarFunctionInfo(set);
+	return set;
 }
 
 static void GetTransformStrictFunctionInternal(ScalarFunctionSet &set, const LogicalType &input_type) {
@@ -697,11 +697,11 @@ static void GetTransformStrictFunctionInternal(ScalarFunctionSet &set, const Log
 	                               JSONTransformBind, nullptr, nullptr, JSONFunctionLocalState::Init));
 }
 
-CreateScalarFunctionInfo JSONFunctions::GetTransformStrictFunction() {
+ScalarFunctionSet JSONFunctions::GetTransformStrictFunction() {
 	ScalarFunctionSet set("json_transform_strict");
 	GetTransformStrictFunctionInternal(set, LogicalType::VARCHAR);
 	GetTransformStrictFunctionInternal(set, JSONCommon::JSONType());
-	return CreateScalarFunctionInfo(set);
+	return set;
 }
 
 } // namespace duckdb

--- a/extension/json/json_functions/json_type.cpp
+++ b/extension/json/json_functions/json_type.cpp
@@ -28,12 +28,11 @@ static void GetTypeFunctionsInternal(ScalarFunctionSet &set, const LogicalType &
 	                               JSONReadManyFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
 }
 
-CreateScalarFunctionInfo JSONFunctions::GetTypeFunction() {
+ScalarFunctionSet JSONFunctions::GetTypeFunction() {
 	ScalarFunctionSet set("json_type");
 	GetTypeFunctionsInternal(set, LogicalType::VARCHAR);
 	GetTypeFunctionsInternal(set, JSONCommon::JSONType());
-
-	return CreateScalarFunctionInfo(std::move(set));
+	return set;
 }
 
 } // namespace duckdb

--- a/extension/json/json_functions/json_valid.cpp
+++ b/extension/json/json_functions/json_valid.cpp
@@ -16,12 +16,12 @@ static void GetValidFunctionInternal(ScalarFunctionSet &set, const LogicalType &
 	                               nullptr, JSONFunctionLocalState::Init));
 }
 
-CreateScalarFunctionInfo JSONFunctions::GetValidFunction() {
+ScalarFunctionSet JSONFunctions::GetValidFunction() {
 	ScalarFunctionSet set("json_valid");
 	GetValidFunctionInternal(set, LogicalType::VARCHAR);
 	GetValidFunctionInternal(set, JSONCommon::JSONType());
 
-	return CreateScalarFunctionInfo(set);
+	return set;
 }
 
 } // namespace duckdb

--- a/extension/json/json_functions/read_json.cpp
+++ b/extension/json/json_functions/read_json.cpp
@@ -293,33 +293,33 @@ TableFunction JSONFunctions::GetReadJSONTableFunction(shared_ptr<JSONScanInfo> f
 	return table_function;
 }
 
-CreateTableFunctionInfo CreateJSONFunctionInfo(string name, shared_ptr<JSONScanInfo> info, bool auto_function = false) {
+TableFunctionSet CreateJSONFunctionInfo(string name, shared_ptr<JSONScanInfo> info, bool auto_function = false) {
 	auto table_function = JSONFunctions::GetReadJSONTableFunction(std::move(info));
 	table_function.name = std::move(name);
 	if (auto_function) {
 		table_function.named_parameters["maximum_depth"] = LogicalType::BIGINT;
 	}
-	return CreateTableFunctionInfo(MultiFileReader::CreateFunctionSet(table_function));
+	return MultiFileReader::CreateFunctionSet(table_function);
 }
 
-CreateTableFunctionInfo JSONFunctions::GetReadJSONFunction() {
+TableFunctionSet JSONFunctions::GetReadJSONFunction() {
 	auto info =
 	    make_shared<JSONScanInfo>(JSONScanType::READ_JSON, JSONFormat::UNSTRUCTURED, JSONRecordType::RECORDS, false);
 	return CreateJSONFunctionInfo("read_json", std::move(info));
 }
 
-CreateTableFunctionInfo JSONFunctions::GetReadNDJSONFunction() {
+TableFunctionSet JSONFunctions::GetReadNDJSONFunction() {
 	auto info = make_shared<JSONScanInfo>(JSONScanType::READ_JSON, JSONFormat::NEWLINE_DELIMITED,
 	                                      JSONRecordType::RECORDS, false);
 	return CreateJSONFunctionInfo("read_ndjson", std::move(info));
 }
 
-CreateTableFunctionInfo JSONFunctions::GetReadJSONAutoFunction() {
+TableFunctionSet JSONFunctions::GetReadJSONAutoFunction() {
 	auto info = make_shared<JSONScanInfo>(JSONScanType::READ_JSON, JSONFormat::AUTO_DETECT, JSONRecordType::AUTO, true);
 	return CreateJSONFunctionInfo("read_json_auto", std::move(info), true);
 }
 
-CreateTableFunctionInfo JSONFunctions::GetReadNDJSONAutoFunction() {
+TableFunctionSet JSONFunctions::GetReadNDJSONAutoFunction() {
 	auto info =
 	    make_shared<JSONScanInfo>(JSONScanType::READ_JSON, JSONFormat::NEWLINE_DELIMITED, JSONRecordType::AUTO, true);
 	return CreateJSONFunctionInfo("read_ndjson_auto", std::move(info), true);

--- a/extension/json/json_functions/read_json_objects.cpp
+++ b/extension/json/json_functions/read_json_objects.cpp
@@ -46,22 +46,22 @@ TableFunction GetReadJSONObjectsTableFunction(bool list_parameter, shared_ptr<JS
 	return table_function;
 }
 
-CreateTableFunctionInfo JSONFunctions::GetReadJSONObjectsFunction() {
+TableFunctionSet JSONFunctions::GetReadJSONObjectsFunction() {
 	TableFunctionSet function_set("read_json_objects");
 	auto function_info =
 	    make_shared<JSONScanInfo>(JSONScanType::READ_JSON_OBJECTS, JSONFormat::UNSTRUCTURED, JSONRecordType::JSON);
 	function_set.AddFunction(GetReadJSONObjectsTableFunction(false, function_info));
 	function_set.AddFunction(GetReadJSONObjectsTableFunction(true, function_info));
-	return CreateTableFunctionInfo(function_set);
+	return function_set;
 }
 
-CreateTableFunctionInfo JSONFunctions::GetReadNDJSONObjectsFunction() {
+TableFunctionSet JSONFunctions::GetReadNDJSONObjectsFunction() {
 	TableFunctionSet function_set("read_ndjson_objects");
 	auto function_info =
 	    make_shared<JSONScanInfo>(JSONScanType::READ_JSON_OBJECTS, JSONFormat::NEWLINE_DELIMITED, JSONRecordType::JSON);
 	function_set.AddFunction(GetReadJSONObjectsTableFunction(false, function_info));
 	function_set.AddFunction(GetReadJSONObjectsTableFunction(true, function_info));
-	return CreateTableFunctionInfo(function_set);
+	return function_set;
 }
 
 } // namespace duckdb

--- a/src/catalog/catalog_transaction.cpp
+++ b/src/catalog/catalog_transaction.cpp
@@ -31,4 +31,8 @@ ClientContext &CatalogTransaction::GetContext() {
 	return *context;
 }
 
+CatalogTransaction CatalogTransaction::GetSystemTransaction(DatabaseInstance &db) {
+	return CatalogTransaction(db, 1, 1);
+}
+
 } // namespace duckdb

--- a/src/catalog/duck_catalog.cpp
+++ b/src/catalog/duck_catalog.cpp
@@ -22,7 +22,7 @@ void DuckCatalog::Initialize(bool load_builtin) {
 	// first initialize the base system catalogs
 	// these are never written to the WAL
 	// we start these at 1 because deleted entries default to 0
-	CatalogTransaction data(GetDatabase(), 1, 1);
+	auto data = CatalogTransaction::GetSystemTransaction(GetDatabase());
 
 	// create the default schema
 	CreateSchemaInfo info;

--- a/src/function/function_set.cpp
+++ b/src/function/function_set.cpp
@@ -6,6 +6,10 @@ namespace duckdb {
 ScalarFunctionSet::ScalarFunctionSet(string name) : FunctionSet(std::move(name)) {
 }
 
+ScalarFunctionSet::ScalarFunctionSet(ScalarFunction fun) : FunctionSet(std::move(fun.name)) {
+	functions.push_back(std::move(fun));
+}
+
 ScalarFunction ScalarFunctionSet::GetFunctionByArguments(ClientContext &context, const vector<LogicalType> &arguments) {
 	string error;
 	FunctionBinder binder(context);
@@ -18,6 +22,10 @@ ScalarFunction ScalarFunctionSet::GetFunctionByArguments(ClientContext &context,
 }
 
 AggregateFunctionSet::AggregateFunctionSet(string name) : FunctionSet(std::move(name)) {
+}
+
+AggregateFunctionSet::AggregateFunctionSet(AggregateFunction fun) : FunctionSet(std::move(fun.name)) {
+	functions.push_back(std::move(fun));
 }
 
 AggregateFunction AggregateFunctionSet::GetFunctionByArguments(ClientContext &context,
@@ -53,6 +61,10 @@ AggregateFunction AggregateFunctionSet::GetFunctionByArguments(ClientContext &co
 TableFunctionSet::TableFunctionSet(string name) : FunctionSet(std::move(name)) {
 }
 
+TableFunctionSet::TableFunctionSet(TableFunction fun) : FunctionSet(std::move(fun.name)) {
+	functions.push_back(std::move(fun));
+}
+
 TableFunction TableFunctionSet::GetFunctionByArguments(ClientContext &context, const vector<LogicalType> &arguments) {
 	string error;
 	FunctionBinder binder(context);
@@ -62,6 +74,13 @@ TableFunction TableFunctionSet::GetFunctionByArguments(ClientContext &context, c
 		                        error);
 	}
 	return GetFunctionByOffset(index);
+}
+
+PragmaFunctionSet::PragmaFunctionSet(string name) : FunctionSet(std::move(name)) {
+}
+
+PragmaFunctionSet::PragmaFunctionSet(PragmaFunction fun) : FunctionSet(std::move(fun.name)) {
+	functions.push_back(std::move(fun));
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/catalog/catalog_transaction.hpp
+++ b/src/include/duckdb/catalog/catalog_transaction.hpp
@@ -28,6 +28,8 @@ struct CatalogTransaction {
 	transaction_t start_time;
 
 	ClientContext &GetContext();
+
+	static CatalogTransaction GetSystemTransaction(DatabaseInstance &db);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/function/function_set.hpp
+++ b/src/include/duckdb/function/function_set.hpp
@@ -64,6 +64,7 @@ public:
 class ScalarFunctionSet : public FunctionSet<ScalarFunction> {
 public:
 	DUCKDB_API explicit ScalarFunctionSet(string name);
+	DUCKDB_API explicit ScalarFunctionSet(ScalarFunction fun);
 
 	DUCKDB_API ScalarFunction GetFunctionByArguments(ClientContext &context, const vector<LogicalType> &arguments);
 };
@@ -71,6 +72,7 @@ public:
 class AggregateFunctionSet : public FunctionSet<AggregateFunction> {
 public:
 	DUCKDB_API explicit AggregateFunctionSet(string name);
+	DUCKDB_API explicit AggregateFunctionSet(AggregateFunction fun);
 
 	DUCKDB_API AggregateFunction GetFunctionByArguments(ClientContext &context, const vector<LogicalType> &arguments);
 };
@@ -78,14 +80,15 @@ public:
 class TableFunctionSet : public FunctionSet<TableFunction> {
 public:
 	DUCKDB_API explicit TableFunctionSet(string name);
+	DUCKDB_API explicit TableFunctionSet(TableFunction fun);
 
 	TableFunction GetFunctionByArguments(ClientContext &context, const vector<LogicalType> &arguments);
 };
 
 class PragmaFunctionSet : public FunctionSet<PragmaFunction> {
 public:
-	explicit PragmaFunctionSet(string name) : FunctionSet(std::move(name)) {
-	}
+	DUCKDB_API explicit PragmaFunctionSet(string name);
+	DUCKDB_API explicit PragmaFunctionSet(PragmaFunction fun);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/extension_util.hpp
+++ b/src/include/duckdb/main/extension_util.hpp
@@ -13,7 +13,7 @@
 #include "duckdb/function/function_set.hpp"
 
 namespace duckdb {
-class CreateMacroInfo;
+struct CreateMacroInfo;
 class DatabaseInstance;
 
 //! The ExtensionUtil class contains methods that are useful for extensions
@@ -35,8 +35,6 @@ public:
 	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, CopyFunction function);
 	//! Register a new scalar function - throw an exception if the function already exists
 	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, CreateMacroInfo &info);
-	//! Extend an existing function with a new overload
-	DUCKDB_API static void ExtendFunction(DatabaseInstance &db, ScalarFunction function);
 
 	//! Registers a new type
 	DUCKDB_API static void RegisterType(DatabaseInstance &db, string type_name, LogicalType type);

--- a/src/include/duckdb/main/extension_util.hpp
+++ b/src/include/duckdb/main/extension_util.hpp
@@ -42,8 +42,9 @@ public:
 	DUCKDB_API static void RegisterType(DatabaseInstance &db, string type_name, LogicalType type);
 
 	//! Registers a cast between two types
-	DUCKDB_API static void RegisterCastFunction(DatabaseInstance &db, const LogicalType &source, const LogicalType &target, BoundCastInfo function,
-	                                     int64_t implicit_cast_cost = -1);
+	DUCKDB_API static void RegisterCastFunction(DatabaseInstance &db, const LogicalType &source,
+	                                            const LogicalType &target, BoundCastInfo function,
+	                                            int64_t implicit_cast_cost = -1);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/extension_util.hpp
+++ b/src/include/duckdb/main/extension_util.hpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/main/extension_util.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+#include "duckdb/function/cast/cast_function_set.hpp"
+#include "duckdb/function/function_set.hpp"
+
+namespace duckdb {
+class DatabaseInstance;
+
+//! The ExtensionUtil class contains methods that are useful for extensions
+class ExtensionUtil {
+public:
+	//! Register a new scalar function - throw an exception if the function already exists
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, ScalarFunction function);
+	//! Register a new scalar function - throw an exception if the function already exists
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, ScalarFunctionSet function);
+	//! Register a new table function - throw an exception if the function already exists
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, TableFunction function);
+	//! Register a new pragma function - throw an exception if the function already exists
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, PragmaFunction function);
+	//! Extend an existing function with a new overload
+	DUCKDB_API static void ExtendFunction(DatabaseInstance &db, ScalarFunction function);
+
+	//! Registers a new type
+	DUCKDB_API static void RegisterType(DatabaseInstance &db, string type_name, LogicalType type);
+
+	//! Registers a cast between two types
+	DUCKDB_API static void RegisterCastFunction(DatabaseInstance &db, const LogicalType &source, const LogicalType &target, BoundCastInfo function,
+	                                     int64_t implicit_cast_cost = -1);
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/main/extension_util.hpp
+++ b/src/include/duckdb/main/extension_util.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/function/function_set.hpp"
 
 namespace duckdb {
+class CreateMacroInfo;
 class DatabaseInstance;
 
 //! The ExtensionUtil class contains methods that are useful for extensions
@@ -24,8 +25,16 @@ public:
 	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, ScalarFunctionSet function);
 	//! Register a new table function - throw an exception if the function already exists
 	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, TableFunction function);
+	//! Register a new scalar function - throw an exception if the function already exists
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, TableFunctionSet function);
 	//! Register a new pragma function - throw an exception if the function already exists
 	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, PragmaFunction function);
+	//! Register a new scalar function - throw an exception if the function already exists
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, PragmaFunctionSet function);
+	//! Register a new scalar function - throw an exception if the function already exists
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, CopyFunction function);
+	//! Register a new scalar function - throw an exception if the function already exists
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, CreateMacroInfo &info);
 	//! Extend an existing function with a new overload
 	DUCKDB_API static void ExtendFunction(DatabaseInstance &db, ScalarFunction function);
 

--- a/src/include/duckdb/main/extension_util.hpp
+++ b/src/include/duckdb/main/extension_util.hpp
@@ -21,19 +21,19 @@ class ExtensionUtil {
 public:
 	//! Register a new scalar function - throw an exception if the function already exists
 	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, ScalarFunction function);
-	//! Register a new scalar function - throw an exception if the function already exists
+	//! Register a new scalar function set - throw an exception if the function already exists
 	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, ScalarFunctionSet function);
 	//! Register a new table function - throw an exception if the function already exists
 	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, TableFunction function);
-	//! Register a new scalar function - throw an exception if the function already exists
+	//! Register a new table function set - throw an exception if the function already exists
 	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, TableFunctionSet function);
 	//! Register a new pragma function - throw an exception if the function already exists
 	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, PragmaFunction function);
-	//! Register a new scalar function - throw an exception if the function already exists
+	//! Register a new pragma function set - throw an exception if the function already exists
 	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, PragmaFunctionSet function);
-	//! Register a new scalar function - throw an exception if the function already exists
+	//! Register a new copy function - throw an exception if the function already exists
 	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, CopyFunction function);
-	//! Register a new scalar function - throw an exception if the function already exists
+	//! Register a new macro function - throw an exception if the function already exists
 	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, CreateMacroInfo &info);
 
 	//! Registers a new type

--- a/src/main/extension/CMakeLists.txt
+++ b/src/main/extension/CMakeLists.txt
@@ -60,8 +60,14 @@ if(${EXIT_TIME_DESTRUCTORS_WARNING})
   set(CMAKE_CXX_FLAGS_DEBUG
       "${CMAKE_CXX_FLAGS_DEBUG} -Wno-exit-time-destructors")
 endif()
-add_library_unity(duckdb_main_extension OBJECT extension_alias.cpp
-                  extension_helper.cpp extension_install.cpp extension_load.cpp)
+add_library_unity(
+  duckdb_main_extension
+  OBJECT
+  extension_alias.cpp
+  extension_helper.cpp
+  extension_install.cpp
+  extension_load.cpp
+  extension_util.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_main_extension>
     PARENT_SCOPE)

--- a/src/main/extension/extension_util.cpp
+++ b/src/main/extension/extension_util.cpp
@@ -54,7 +54,7 @@ void ExtensionUtil::RegisterFunction(DatabaseInstance &db, PragmaFunctionSet fun
 	CreatePragmaFunctionInfo info(std::move(function_name), std::move(function));
 	auto &system_catalog = Catalog::GetSystemCatalog(db);
 	auto data = CatalogTransaction::GetSystemTransaction(db);
-	system_catalog.CreateFunction(data, info);
+	system_catalog.CreatePragmaFunction(data, info);
 }
 
 void ExtensionUtil::RegisterFunction(DatabaseInstance &db, CopyFunction function) {
@@ -65,15 +65,6 @@ void ExtensionUtil::RegisterFunction(DatabaseInstance &db, CopyFunction function
 }
 
 void ExtensionUtil::RegisterFunction(DatabaseInstance &db, CreateMacroInfo &info) {
-	auto &system_catalog = Catalog::GetSystemCatalog(db);
-	auto data = CatalogTransaction::GetSystemTransaction(db);
-	system_catalog.CreateFunction(data, info);
-}
-
-void ExtensionUtil::ExtendFunction(DatabaseInstance &db, ScalarFunction function) {
-	D_ASSERT(!function.name.empty());
-	CreateScalarFunctionInfo info(std::move(function));
-	info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
 	auto &system_catalog = Catalog::GetSystemCatalog(db);
 	auto data = CatalogTransaction::GetSystemTransaction(db);
 	system_catalog.CreateFunction(data, info);

--- a/src/main/extension/extension_util.cpp
+++ b/src/main/extension/extension_util.cpp
@@ -39,7 +39,6 @@ void ExtensionUtil::RegisterFunction(DatabaseInstance &db, TableFunctionSet func
 	auto &system_catalog = Catalog::GetSystemCatalog(db);
 	auto data = CatalogTransaction::GetSystemTransaction(db);
 	system_catalog.CreateFunction(data, info);
-
 }
 
 void ExtensionUtil::RegisterFunction(DatabaseInstance &db, PragmaFunction function) {
@@ -90,11 +89,11 @@ void ExtensionUtil::RegisterType(DatabaseInstance &db, string type_name, Logical
 	system_catalog.CreateType(data, info);
 }
 
-void
-ExtensionUtil::RegisterCastFunction(DatabaseInstance &db, const LogicalType &source, const LogicalType &target,
-					 BoundCastInfo function, int64_t implicit_cast_cost) {
+void ExtensionUtil::RegisterCastFunction(DatabaseInstance &db, const LogicalType &source, const LogicalType &target,
+                                         BoundCastInfo function, int64_t implicit_cast_cost) {
 	auto &config = DBConfig::GetConfig(db);
 	auto &casts = config.GetCastFunctions();
-	casts.RegisterCastFunction(source, target, std::move(function), implicit_cast_cost);}
-
+	casts.RegisterCastFunction(source, target, std::move(function), implicit_cast_cost);
 }
+
+} // namespace duckdb

--- a/src/main/extension/extension_util.cpp
+++ b/src/main/extension/extension_util.cpp
@@ -1,0 +1,69 @@
+#include "duckdb/main/extension_util.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/parser/parsed_data/create_type_info.hpp"
+#include "duckdb/parser/parsed_data/create_pragma_function_info.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/main/config.hpp"
+
+namespace duckdb {
+
+void ExtensionUtil::RegisterFunction(DatabaseInstance &db, ScalarFunctionSet set) {
+	D_ASSERT(!set.name.empty());
+	CreateScalarFunctionInfo info(std::move(set));
+	auto &system_catalog = Catalog::GetSystemCatalog(db);
+	auto data = CatalogTransaction::GetSystemTransaction(db);
+	system_catalog.CreateFunction(data, info);
+}
+
+void ExtensionUtil::RegisterFunction(DatabaseInstance &db, ScalarFunction function) {
+	D_ASSERT(!function.name.empty());
+	ScalarFunctionSet set(function.name);
+	set.AddFunction(std::move(function));
+	RegisterFunction(db, std::move(set));
+}
+
+void ExtensionUtil::RegisterFunction(DatabaseInstance &db, TableFunction function) {
+	D_ASSERT(!function.name.empty());
+	CreateTableFunctionInfo info(std::move(function));
+	auto &system_catalog = Catalog::GetSystemCatalog(db);
+	auto data = CatalogTransaction::GetSystemTransaction(db);
+	system_catalog.CreateFunction(data, info);
+}
+
+void ExtensionUtil::RegisterFunction(DatabaseInstance &db, PragmaFunction function) {
+	D_ASSERT(!function.name.empty());
+	CreatePragmaFunctionInfo info(std::move(function));
+	auto &system_catalog = Catalog::GetSystemCatalog(db);
+	auto data = CatalogTransaction::GetSystemTransaction(db);
+	system_catalog.CreateFunction(data, info);
+}
+
+void ExtensionUtil::ExtendFunction(DatabaseInstance &db, ScalarFunction function) {
+	D_ASSERT(!function.name.empty());
+	CreateScalarFunctionInfo info(std::move(function));
+	info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+	auto &system_catalog = Catalog::GetSystemCatalog(db);
+	auto data = CatalogTransaction::GetSystemTransaction(db);
+	system_catalog.CreateFunction(data, info);
+}
+
+void ExtensionUtil::RegisterType(DatabaseInstance &db, string type_name, LogicalType type) {
+	D_ASSERT(!type_name.empty());
+	CreateTypeInfo info(std::move(type_name), std::move(type));
+	info.temporary = true;
+	info.internal = true;
+	auto &system_catalog = Catalog::GetSystemCatalog(db);
+	auto data = CatalogTransaction::GetSystemTransaction(db);
+	system_catalog.CreateType(data, info);
+}
+
+void
+ExtensionUtil::RegisterCastFunction(DatabaseInstance &db, const LogicalType &source, const LogicalType &target,
+					 BoundCastInfo function, int64_t implicit_cast_cost) {
+	auto &config = DBConfig::GetConfig(db);
+	auto &casts = config.GetCastFunctions();
+	casts.RegisterCastFunction(source, target, std::move(function), implicit_cast_cost);}
+
+}


### PR DESCRIPTION
This PR adds the ExtensionUtil class which can be used by C++ extensions to register functions. This cleans up the code for function registration in extensions - but also avoids pulling in unnecessarily large parts of DuckDB into the statically linked builds. Previously `BeginTransaction` and `Commit` would call `Query` internally, which would then pull in almost all of DuckDB into all extensions. This registration mechanism avoids that which decreases the extension size of simple extensions dramatically.

Before:

```bash
22M autocomplete.duckdb_extension
22M fts.duckdb_extension
28M icu.duckdb_extension
22M inet.duckdb_extension
22M json.duckdb_extension
24M tpcds.duckdb_extension
23M tpch.duckdb_extension
```

After:

```bash
2.4M autocomplete.duckdb_extension
1.3M fts.duckdb_extension
 28M icu.duckdb_extension
458K inet.duckdb_extension
 22M json.duckdb_extension
 10M tpcds.duckdb_extension
9.2M tpch.duckdb_extension
```

* ICU has not been moved to the `ExtensionUtil` yet because it has a few complex interactions with function registration (tail patching functions).
* The JSON extension still calls into arbitrary SQL queries through `json_execute_serialized_sql` - if we can remove that the size of the JSON extension decreases to 10MB

CC @pdet this should be used by #7290 as well to avoid increasing the size of the HTTPFS extension unnecessarily