### PR TITLE
Column function chaining alias

### DIFF
--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -101,6 +101,8 @@ public:
 	static bool ContainsType(const LogicalType &type, LogicalTypeId target);
 	static LogicalType ExchangeType(const LogicalType &type, LogicalTypeId target, LogicalType new_type);
 
+	virtual bool QualifyColumnAlias(const ColumnRefExpression &colref);
+
 	//! Bind the given expresion. Unlike Bind(), this does *not* mute the given ParsedExpression.
 	//! Exposed to be used from sub-binders that aren't subclasses of ExpressionBinder.
 	virtual BindResult BindExpression(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth,

--- a/src/include/duckdb/planner/expression_binder/base_select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/base_select_binder.hpp
@@ -59,6 +59,8 @@ protected:
 
 	idx_t TryBindGroup(ParsedExpression &expr, idx_t depth);
 	BindResult BindGroup(ParsedExpression &expr, idx_t depth, idx_t group_index);
+
+	bool QualifyColumnAlias(const ColumnRefExpression &colref) override;
 };
 
 } // namespace duckdb

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -388,7 +388,9 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref_p, idx_t
 	return result;
 }
 
-bool ExpressionBinder::QualifyColumnAlias(const ColumnRefExpression &colref){
+bool ExpressionBinder::QualifyColumnAlias(const ColumnRefExpression &colref) {
+	// Only BaseSelectBinder will have a valid col alias map,
+	// otherwise just return false
 	return false;
 }
 

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -388,4 +388,8 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref_p, idx_t
 	return result;
 }
 
+bool ExpressionBinder::QualifyColumnAlias(const ColumnRefExpression &colref){
+	return false;
+}
+
 } // namespace duckdb

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -45,7 +45,10 @@ BindResult ExpressionBinder::BindExpression(FunctionExpression &function, idx_t 
 				colref = make_uniq<ColumnRefExpression>(function.schema, function.catalog);
 			}
 			auto new_colref = QualifyColumnName(*colref, error);
-			if (error.empty()) {
+			bool is_col = error.empty() ? true : false;
+			bool is_col_alias = QualifyColumnAlias(*colref);
+			
+			if (is_col || is_col_alias) {
 				// we can! transform this into a function call on the column
 				// i.e. "x.lower()" becomes "lower(x)"
 				function.children.insert(function.children.begin(), std::move(colref));

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -47,7 +47,7 @@ BindResult ExpressionBinder::BindExpression(FunctionExpression &function, idx_t 
 			auto new_colref = QualifyColumnName(*colref, error);
 			bool is_col = error.empty() ? true : false;
 			bool is_col_alias = QualifyColumnAlias(*colref);
-			
+
 			if (is_col || is_col_alias) {
 				// we can! transform this into a function call on the column
 				// i.e. "x.lower()" becomes "lower(x)"

--- a/src/planner/expression_binder/base_select_binder.cpp
+++ b/src/planner/expression_binder/base_select_binder.cpp
@@ -143,4 +143,11 @@ BindResult BaseSelectBinder::BindGroup(ParsedExpression &expr, idx_t depth, idx_
 	                                                      ColumnBinding(node.group_index, group_index), depth));
 }
 
+bool BaseSelectBinder::QualifyColumnAlias(const ColumnRefExpression &colref){
+	if (!colref.IsQualified()) {
+		return alias_map.find(colref.column_names[0]) != alias_map.end() ? true : false;
+	}
+	return false;
+}
+
 } // namespace duckdb

--- a/src/planner/expression_binder/base_select_binder.cpp
+++ b/src/planner/expression_binder/base_select_binder.cpp
@@ -143,7 +143,7 @@ BindResult BaseSelectBinder::BindGroup(ParsedExpression &expr, idx_t depth, idx_
 	                                                      ColumnBinding(node.group_index, group_index), depth));
 }
 
-bool BaseSelectBinder::QualifyColumnAlias(const ColumnRefExpression &colref){
+bool BaseSelectBinder::QualifyColumnAlias(const ColumnRefExpression &colref) {
 	if (!colref.IsQualified()) {
 		return alias_map.find(colref.column_names[0]) != alias_map.end() ? true : false;
 	}

--- a/test/sql/binder/test_function_chainging_alias.test
+++ b/test/sql/binder/test_function_chainging_alias.test
@@ -1,0 +1,91 @@
+# name: test/sql/binder/test_function_chainging_alias.test
+# description: referencing an alias or a function chaining alias that exists earlier on 
+#              in the SELECT clause (Issue #7190)
+# group: [binder]
+
+statement ok
+PRAGMA enable_verification
+
+query II
+SELECT 'test' || ' more testing' as added,
+        added.substr(5) as my_substr
+----
+test more testing	 more testing
+
+statement ok
+CREATE TABLE varchars(v VARCHAR);
+
+statement ok
+INSERT INTO varchars VALUES ('>>%Test<<'), ('%FUNCTION%'), ('Chaining')
+
+query I
+SELECT v.lower() FROM varchars
+----
+>>%test<<
+%function%
+chaining
+
+# only_alphabet is used before defined
+statement error
+SELECT  v.trim('><') as trim_inequality,
+        only_alphabet.lower() as lower
+        trim_inequality.replace('%', '') as only_alphabet,
+FROM varchars
+
+
+query III
+SELECT  v.trim('><') as trim_inequality,
+        trim_inequality.replace('%', '') as only_alphabet,
+        only_alphabet.lower() as lower
+FROM varchars
+----
+%Test	Test	test
+%FUNCTION%	FUNCTION	function
+Chaining	Chaining	chaining
+
+# Test col with table name 
+query III
+SELECT  varchars.v.trim('><') as trim_inequality,
+        trim_inequality.replace('%', '') as only_alphabet,
+        only_alphabet.lower() as lower
+FROM varchars
+----
+%Test	Test	test
+%FUNCTION%	FUNCTION	function
+Chaining	Chaining	chaining
+
+statement ok
+DELETE FROM varchars
+
+statement ok
+INSERT INTO varchars VALUES ('Test Function Chainging Alias');
+
+# list
+query III
+SELECT  v.split(' ') strings,
+        strings.lower() lower,
+        lower.upper() upper
+FROM varchars
+----
+[Test, Function, Chainging, Alias]	[test, function, chainging, alias]	[TEST, FUNCTION, CHAINGING, ALIAS]
+
+query IIII
+SELECT  v.split(' ') strings,
+        strings.apply(x -> x.lower()).filter(x -> x[1] == 't') lower,
+        strings.apply(x -> x.upper()).filter(x -> x[1] == 'T') upper,
+        lower + upper  as mix_case_srings
+FROM varchars
+----
+[Test, Function, Chainging, Alias]	[test]	[TEST]	[test, TEST]
+
+# prepared statements
+statement ok
+PREPARE v1 AS 
+SELECT ?.split(' ').lower() lstrings,
+       ?.split(' ').upper() ustrings,
+       list_concat(lstrings::VARCHAR[], ustrings::VARCHAR[]) as mix_case_srings
+
+query III
+EXECUTE v1('Hello World', 'test function chainging')
+----
+[hello, world]	[TEST, FUNCTION, CHAINGING]	[hello, world, TEST, FUNCTION, CHAINGING]

--- a/test/sql/binder/test_function_chainging_alias.test
+++ b/test/sql/binder/test_function_chainging_alias.test
@@ -1,7 +1,8 @@
 # name: test/sql/binder/test_function_chainging_alias.test
-# description: referencing an alias or a function chaining alias that exists earlier on 
-#              in the SELECT clause (Issue #7190)
+# description: referencing an alias or a function chaining alias that exists earlier on
 # group: [binder]
+
+#              in the SELECT clause (Issue #7190)
 
 statement ok
 PRAGMA enable_verification


### PR DESCRIPTION
Fix https://github.com/duckdb/duckdb/issues/7190

Now we can support this ! 

```sql
SELECT
        'test' || ' more testing' as added,
        added.substr(5) as my_substr,
        my_substr.upper() usubstr, 
        my_substr.lower() lsubstr,
        usubstr ||  lsubstr mix_substr
```
```
┌───────────────────┬───────────────┬───────────────┬───────────────┬────────────────────────────┐
│       added       │   my_substr   │    usubstr    │    lsubstr    │         mix_substr         │
│      varchar      │    varchar    │    varchar    │    varchar    │          varchar           │
├───────────────────┼───────────────┼───────────────┼───────────────┼────────────────────────────┤
│ test more testing │  more testing │  MORE TESTING │  more testing │  MORE TESTING more testing │
└───────────────────┴───────────────┴───────────────┴───────────────┴────────────────────────────┘
```
