### PR TITLE
Extend `format` and `printf` to support printing thousand separators similar to SQLite

### DIFF
--- a/test/sql/function/string/test_format.test
+++ b/test/sql/function/string/test_format.test
@@ -72,6 +72,18 @@ SELECT format('{1} {1} {0} {0}', 1, 2)
 ----
 2 2 1 1
 
+# hexadecimal
+query I
+select format('{:x}', 123456789)
+----
+75bcd15
+
+# binary
+query I
+select format('{:b}', 123456789)
+----
+111010110111100110100010101
+
 # incorrect number of parameters
 # too few parameters
 statement error

--- a/test/sql/function/string/test_format_extensions.test
+++ b/test/sql/function/string/test_format_extensions.test
@@ -1,4 +1,4 @@
-# name: test/sql/function/string/test_format_improvements.test
+# name: test/sql/function/string/test_format_extensions.test
 # description: Test format extensions
 # group: [string]
 

--- a/test/sql/function/string/test_format_extensions.test
+++ b/test/sql/function/string/test_format_extensions.test
@@ -1,0 +1,54 @@
+# name: test/sql/function/string/test_format_improvements.test
+# description: Test format extensions
+# group: [string]
+
+statement ok
+PRAGMA enable_verification
+
+# thousands separator
+query I
+select printf('%,d', 123456789)
+----
+123,456,789
+
+query I
+select format('{:d}', 123456789)
+----
+123456789
+
+# L prints a thousands separator as well
+query I
+select format('{:L}', 123456789)
+----
+123,456,789
+
+query I
+select format('{0:d} {0:L}', 123456789)
+----
+123456789 123,456,789
+
+statement error
+select format('{1}', 123456789)
+----
+Argument index "1" out of range
+
+statement error
+select format('{L}', 123456789)
+----
+Argument with name
+
+# better error messages
+statement error
+select printf('%:', 123456789)
+----
+Invalid type specifier ":"
+
+statement error
+select printf('%:', 123456789.123)
+----
+Invalid type specifier ":"
+
+statement error
+select printf('%:', 'str')
+----
+Invalid type specifier ":"

--- a/test/sql/function/string/test_format_extensions.test
+++ b/test/sql/function/string/test_format_extensions.test
@@ -16,16 +16,72 @@ select format('{:d}', 123456789)
 ----
 123456789
 
-# L prints a thousands separator as well
+# other supported thousand separators
 query I
-select format('{:L}', 123456789)
+select printf('%.d', 123456789)
+----
+123.456.789
+
+query I
+select printf('%_d', 123456789)
+----
+123_456_789
+
+query I
+select printf('%''d', 123456789)
+----
+123'456'789
+
+query I
+select printf('%.0d', 123456789)
+----
+123456789
+
+# prints a thousands separator as well
+query I
+select format('{:,}', 123456789)
 ----
 123,456,789
 
 query I
+select format('{:_}', 123456789)
+----
+123_456_789
+
+query I
+select format('{:''}', 123456789)
+----
+123'456'789
+
+# custom thousand separator
+query I
+select format('{:t }', 123456789)
+----
+123 456 789
+
+query I
+select format('{:t|}', 123456789)
+----
+123|456|789
+
+query I
+select format('{:tss}', 123456789)
+----
+123s456s789
+
+# and for floats?
+statement error
+select format('{:,}', 123456789.123)
+----
+Thousand separators are not supported for floating point numbers
+
+statement error
+select format('{:t}', 123456789)
+
+query I
 select format('{0:d} {0:L}', 123456789)
 ----
-123456789 123,456,789
+123456789 123456789
 
 statement error
 select format('{1}', 123456789)

--- a/third_party/fmt/format.cc
+++ b/third_party/fmt/format.cc
@@ -128,11 +128,6 @@ int (*instantiate_format_float)(double, int, internal::float_specs,
                                 internal::buffer<char>&) =
     internal::format_float;
 
-#ifndef FMT_STATIC_THOUSANDS_SEPARATOR
-template FMT_API internal::locale_ref::locale_ref(const std::locale& loc);
-template FMT_API std::locale internal::locale_ref::get<std::locale>() const;
-#endif
-
 // Explicit instantiations for char.
 
 template FMT_API std::string internal::grouping_impl<char>(locale_ref);

--- a/third_party/fmt/include/fmt/core.h
+++ b/third_party/fmt/include/fmt/core.h
@@ -323,6 +323,10 @@ template <typename Char> class basic_string_view {
     size_ -= n;
   }
 
+  std::string to_string() {
+	  return std::string((char *) data(), size());
+  }
+
   // Lexicographically compare this string reference to other.
   int compare(basic_string_view other) const {
     size_t str_size = size_ < other.size_ ? size_ : other.size_;
@@ -442,7 +446,7 @@ struct error_handler {
   FMT_CONSTEXPR error_handler(const error_handler&) = default;
 
   // This function is intentionally not constexpr to give a compile-time error.
-  FMT_NORETURN FMT_API void on_error(const char* message);
+  FMT_NORETURN FMT_API void on_error(std::string message);
 };
 }  // namespace internal
 
@@ -520,7 +524,7 @@ class basic_format_parse_context : private ErrorHandler {
 
   FMT_CONSTEXPR void check_arg_id(basic_string_view<Char>) {}
 
-  FMT_CONSTEXPR void on_error(const char* message) {
+  FMT_CONSTEXPR void on_error(std::string message) {
     ErrorHandler::on_error(message);
   }
 
@@ -1158,7 +1162,7 @@ template <typename OutputIt, typename Char> class basic_format_context {
   format_arg arg(basic_string_view<char_type> name);
 
   internal::error_handler error_handler() { return {}; }
-  void on_error(const char* message) { error_handler().on_error(message); }
+  void on_error(std::string message) { error_handler().on_error(message); }
 
   // Returns an iterator to the beginning of the output range.
   iterator out() { return out_; }

--- a/third_party/fmt/include/fmt/core.h
+++ b/third_party/fmt/include/fmt/core.h
@@ -62,15 +62,9 @@
 
 // Check if relaxed C++14 constexpr is supported.
 // GCC doesn't allow throw in constexpr until version 6 (bug 67371).
-#ifndef FMT_USE_CONSTEXPR
-#  define FMT_USE_CONSTEXPR                                           \
-    (FMT_HAS_FEATURE(cxx_relaxed_constexpr) || FMT_MSC_VER >= 1910 || \
-     (FMT_GCC_VERSION >= 600 && __cplusplus >= 201402L)) &&           \
-        !FMT_NVCC
-#endif
 #if FMT_USE_CONSTEXPR
-#  define FMT_CONSTEXPR constexpr
-#  define FMT_CONSTEXPR_DECL constexpr
+#  define FMT_CONSTEXPR inline
+#  define FMT_CONSTEXPR_DECL
 #else
 #  define FMT_CONSTEXPR inline
 #  define FMT_CONSTEXPR_DECL
@@ -420,7 +414,7 @@ template <typename S>
 struct is_compile_string : std::is_base_of<compile_string, S> {};
 
 template <typename S, FMT_ENABLE_IF(is_compile_string<S>::value)>
-constexpr basic_string_view<typename S::char_type> to_string_view(const S& s) {
+FMT_CONSTEXPR basic_string_view<typename S::char_type> to_string_view(const S& s) {
   return s;
 }
 

--- a/third_party/fmt/include/fmt/format.h
+++ b/third_party/fmt/include/fmt/format.h
@@ -1529,7 +1529,7 @@ template <typename Range> class basic_writer {
       if (group == groups.cend())
         size += sep_size * ((num_digits - 1) / groups.back());
       writer.write_int(size, get_prefix(), specs,
-                       num_writer{abs_value, size, groups, sep});
+                       num_writer{abs_value, size, groups, static_cast<char_type>(sep)});
     }
 
     FMT_NORETURN void on_error(std::string error) {

--- a/third_party/fmt/include/fmt/printf.h
+++ b/third_party/fmt/include/fmt/printf.h
@@ -396,6 +396,12 @@ void basic_printf_context<OutputIt, Char>::parse_flags(format_specs& specs,
     case ',':
       specs.thousands = ',';
       break;
+    case '\'':
+      specs.thousands = '\'';
+      break;
+    case '_':
+      specs.thousands = '_';
+      break;
     default:
       return;
     }
@@ -475,6 +481,7 @@ OutputIt basic_printf_context<OutputIt, Char>::format() {
     if (arg_index == 0) on_error("argument index out of range");
 
     // Parse precision.
+	bool empty_precision = false;
     if (it != end && *it == '.') {
       ++it;
       c = it != end ? *it : 0;
@@ -487,6 +494,7 @@ OutputIt basic_printf_context<OutputIt, Char>::format() {
             static_cast<int>(visit_format_arg(internal::printf_precision_handler(), get_arg()));
       } else {
         specs.precision = 0;
+		empty_precision = true;
       }
     }
 
@@ -557,6 +565,9 @@ OutputIt basic_printf_context<OutputIt, Char>::format() {
         break;
       }
     }
+	if (specs.type == 'd' && empty_precision) {
+		specs.thousands = '.';
+	}
 
     start = it;
 

--- a/third_party/fmt/include/fmt/printf.h
+++ b/third_party/fmt/include/fmt/printf.h
@@ -363,7 +363,7 @@ template <typename OutputIt, typename Char> class basic_printf_context {
 
   basic_format_parse_context<Char>& parse_context() { return parse_ctx_; }
 
-  FMT_CONSTEXPR void on_error(const char* message) {
+  FMT_CONSTEXPR void on_error(std::string message) {
     parse_ctx_.on_error(message);
   }
 
@@ -392,6 +392,9 @@ void basic_printf_context<OutputIt, Char>::parse_flags(format_specs& specs,
       break;
     case '#':
       specs.alt = true;
+      break;
+    case ',':
+      specs.thousands = ',';
       break;
     default:
       return;


### PR DESCRIPTION
```sql
select printf('%,d', 12345678) as n;
┌────────────┐
│     n      │
│  varchar   │
├────────────┤
│ 12,345,678 │
└────────────┘
select format('{:L}', 12345678) as n;
┌────────────┐
│     n      │
│  varchar   │
├────────────┤
│ 12,345,678 │
└────────────┘
```

Also improve error messages generated from format

```sql
D select printf('%s', 123);
Error: Invalid Error: Invalid type specifier "s" for formatting a value of type int
```