### PR TITLE
add `dayname`/`monthname` functions for `timestamptz` type

### DIFF
--- a/extension/icu/icu-datepart.cpp
+++ b/extension/icu/icu-datepart.cpp
@@ -203,6 +203,14 @@ struct ICUDatePart : public ICUDateFunc {
 		return Date::EpochToDate(ExtractEpoch(calendar, 0));
 	}
 
+	static string_t MonthName(icu::Calendar *calendar, const uint64_t micros) {
+		return Date::MONTH_NAMES[ExtractMonth(calendar, micros) - 1];
+	}
+
+	static string_t DayName(icu::Calendar *calendar, const uint64_t micros) {
+		return Date::DAY_NAMES[ExtractDayOfWeek(calendar, micros)];
+	}
+
 	template <typename RESULT_TYPE>
 	struct BindAdapterData : public BindData {
 		using result_t = RESULT_TYPE;
@@ -355,6 +363,29 @@ struct ICUDatePart : public ICUDateFunc {
 		result.Verify(count);
 	}
 
+	template <typename INPUT_TYPE>
+	static void NameFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+		using bind_t = BindAdapterData<string_t>;
+		D_ASSERT(args.ColumnCount() == 1);
+		auto &date_arg = args.data[0];
+
+		auto &func_expr = (BoundFunctionExpression &)state.expr;
+		auto &info = (bind_t &)*func_expr.bind_info;
+		CalendarPtr calendar_ptr(info.calendar->clone());
+		auto calendar = calendar_ptr.get();
+
+		UnaryExecutor::ExecuteWithNulls<INPUT_TYPE, string_t>(date_arg, result, args.size(),
+		                                                      [&](INPUT_TYPE input, ValidityMask &mask, idx_t idx) {
+			                                                      if (Timestamp::IsFinite(input)) {
+				                                                      const auto micros = SetTime(calendar, input);
+				                                                      return info.adapters[0](calendar, micros);
+			                                                      } else {
+				                                                      mask.SetInvalid(idx);
+				                                                      return string_t();
+			                                                      }
+		                                                      });
+	}
+
 	template <typename BIND_TYPE>
 	static duckdb::unique_ptr<FunctionData> BindAdapter(ClientContext &context, ScalarFunction &bound_function,
 	                                                    vector<duckdb::unique_ptr<Expression>> &arguments,
@@ -482,6 +513,42 @@ struct ICUDatePart : public ICUDateFunc {
 		CreateScalarFunctionInfo func_info(set);
 		catalog.AddFunction(context, func_info);
 	}
+
+	static unique_ptr<FunctionData> BindMonthName(ClientContext &context, ScalarFunction &bound_function,
+	                                              vector<unique_ptr<Expression>> &arguments) {
+		using data_t = BindAdapterData<string_t>;
+		return BindAdapter<data_t>(context, bound_function, arguments, MonthName);
+	}
+
+	template <typename INPUT_TYPE>
+	static ScalarFunction GetMonthNameFunction(const LogicalType &temporal_type) {
+		return ScalarFunction({temporal_type}, LogicalType::VARCHAR, NameFunction<INPUT_TYPE>, BindMonthName);
+	}
+	static void AddMonthNameFunctions(const string &name, ClientContext &context) {
+		auto &catalog = Catalog::GetSystemCatalog(context);
+		ScalarFunctionSet set(name);
+		set.AddFunction(GetMonthNameFunction<timestamp_t>(LogicalType::TIMESTAMP_TZ));
+		CreateScalarFunctionInfo func_info(set);
+		catalog.AddFunction(context, func_info);
+	}
+
+	static unique_ptr<FunctionData> BindDayName(ClientContext &context, ScalarFunction &bound_function,
+	                                            vector<unique_ptr<Expression>> &arguments) {
+		using data_t = BindAdapterData<string_t>;
+		return BindAdapter<data_t>(context, bound_function, arguments, DayName);
+	}
+
+	template <typename INPUT_TYPE>
+	static ScalarFunction GetDayNameFunction(const LogicalType &temporal_type) {
+		return ScalarFunction({temporal_type}, LogicalType::VARCHAR, NameFunction<INPUT_TYPE>, BindDayName);
+	}
+	static void AddDayNameFunctions(const string &name, ClientContext &context) {
+		auto &catalog = Catalog::GetSystemCatalog(context);
+		ScalarFunctionSet set(name);
+		set.AddFunction(GetDayNameFunction<timestamp_t>(LogicalType::TIMESTAMP_TZ));
+		CreateScalarFunctionInfo func_info(set);
+		catalog.AddFunction(context, func_info);
+	}
 };
 
 void RegisterICUDatePartFunctions(ClientContext &context) {
@@ -519,6 +586,10 @@ void RegisterICUDatePartFunctions(ClientContext &context) {
 
 	//  register the last_day function
 	ICUDatePart::AddLastDayFunctions("last_day", context);
+
+	// register the dayname/monthname functions
+	ICUDatePart::AddMonthNameFunctions("monthname", context);
+	ICUDatePart::AddDayNameFunctions("dayname", context);
 
 	// finally the actual date_part function
 	ICUDatePart::AddDatePartFunctions("date_part", context);

--- a/test/sql/function/timestamp/test_icu_datepart.test
+++ b/test/sql/function/timestamp/test_icu_datepart.test
@@ -698,6 +698,22 @@ infinity	NULL	NULL
 -infinity	NULL	NULL
 NULL	NULL	NULL
 
+# dayname/monthname
+query II
+SELECT dayname(ts), monthname(ts) from timestamps;
+----
+Wednesday	March
+Tuesday	July
+Thursday	December
+Monday	February
+Friday	November
+Monday	November
+Monday	November
+Friday	December
+NULL	NULL
+NULL	NULL
+NULL	NULL
+
 #
 # Fractional Time Zones
 #


### PR DESCRIPTION
This PR adds versions of the `dayname` and `monthname` functions that operate on the `timestamp with time zone` type, which should fix #3545. To be honest I'm not much of a C++ programmer but was able to pattern match on how other functions are added in here and how the (non-ICU) date_part.cpp [looks up day/month names](https://github.com/duckdb/duckdb/blob/fc797c18cf8be9262fc9a519592b64b379de84b1/src/core_functions/scalar/date/date_part.cpp#L1192-L1204).