### PR TITLE
[swift] Make Foundation extensions public

### DIFF
--- a/tools/swift/duckdb-swift/Sources/DuckDB/Extensions/Date+Foundation.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Extensions/Date+Foundation.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-extension Foundation.Date {
+public extension Foundation.Date {
   
   /// Creates a date value initialized from a DuckDB Date value
   init(_ date: Date) {

--- a/tools/swift/duckdb-swift/Sources/DuckDB/Extensions/Time+Foundation.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Extensions/Time+Foundation.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-extension Foundation.Date {
+public extension Foundation.Date {
   
   /// Creates a date value initialized from a DuckDB Time value
   init(_ date: Time) {
@@ -32,7 +32,7 @@ extension Foundation.Date {
   }
 }
 
-extension Time {
+public extension Time {
   
   /// Creates a time value initialized from a Foundation Date
   init(_ date: Foundation.Date) {

--- a/tools/swift/duckdb-swift/Sources/DuckDB/Extensions/Timestamp+Foundation.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Extensions/Timestamp+Foundation.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-extension Foundation.Date {
+public extension Foundation.Date {
   
   /// Creates a date value initialized from a DuckDB Timestamp value
   init(_ timestamp: Timestamp) {
@@ -32,7 +32,7 @@ extension Foundation.Date {
   }
 }
 
-extension Timestamp {
+public extension Timestamp {
   
   /// Creates a timestamp value initialized from a Foundation Date
   init(_ date: Foundation.Date) {


### PR DESCRIPTION
Some were marked as internal and some were marked as public, make them all public - they are necessary to convert DuckDB types to native Swift types.