### PR TITLE
[PythonDev] Fix Python regression test CI

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -171,7 +171,7 @@ jobs:
       shell: bash
       run: |
         sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
-        pip install numpy pytest pandas mypy psutil pyarrow
+        pip install numpy pytest pandas mypy psutil "pyarrow<=11.0.0"
 
     - name: Setup Ccache
       uses: hendrikmuhs/ccache-action@main


### PR DESCRIPTION
Our Python regression test has been failing, the only real difference between the last succesful run and the failing ones is a pyarrow version change.

As evidenced here:
succeeds:
<https://github.com/duckdb/duckdb/actions/runs/4859648471/jobs/8662527018>
fails:
<https://github.com/duckdb/duckdb/actions/runs/4863738205/jobs/8671850978?pr=7325>

Hopefully locking the pyarrow version at 11.0.0 will fix the failures