### PR TITLE
Make `SQLLogicTestRunner::LoadDatabase` virtual

### DIFF
--- a/test/sqlite/sqllogic_test_runner.hpp
+++ b/test/sqlite/sqllogic_test_runner.hpp
@@ -54,7 +54,7 @@ public:
 
 public:
 	void ExecuteFile(string script);
-	void LoadDatabase(string dbpath);
+	virtual void LoadDatabase(string dbpath);
 
 	string ReplaceKeywords(string input);
 


### PR DESCRIPTION
DuckDB has an extensive set of SQLLogicTests. It would be very useful for extension authors if we could make use of these tests to check that all statements and queries still work as expected with the extension enabled. As an example, for the MotherDuck extension, running these tests would be a nice way to verify the correctness of the results when using hybrid execution.

Right now, there are two ways to use an extension from the tests, to my knowledge.
First, some selected extensions can be loaded with `require [extension]`, but this does not work for custom extensions.
Second, an extension can be installed with `INSTALL 'path/to/my.duckdb_extension'`. However, only an extension _binary_ can be loaded. It would be more convenient to load a `duckdb::Extension` instance directly before running the tests rather than having to go through the install mechanisms.

This step would have to happen after the `DuckDB` instance was created in [`LoadDatabase`](https://github.com/duckdb/duckdb/blob/98e919135b3a2904f9cf714e0d2d0f4e454766d7/test/sqlite/sqllogic_test_runner.cpp#L74).

My proposal is to make the `LoadDatabase` method virtual. This would allow derived test runners to execute their setup logic after calling the base class:

```c++
void DerivedTestRunner::LoadDatabase(std::string dbpath) {
	SQLLogicTestRunner::LoadDatabase(dbpath); // Initializes db

	auto my_extension = MyExtension::make_unique();
	my_extension->Load(*db);
}
```