### PR TITLE
Add format_bytes function that formats bytes to a human readable size

### DIFF
--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -79,6 +79,8 @@ static DefaultMacro internal_macros[] = {
 	{"pg_catalog", "pg_ts_template_is_visible", {"template_oid", nullptr}, "true"},
 	{"pg_catalog", "pg_type_is_visible", {"type_oid", nullptr}, "true"},
 
+	{"pg_catalog", "pg_size_pretty", {"bytes", nullptr}, "format_bytes(bytes)"},
+
 	{DEFAULT_SCHEMA, "round_even", {"x", "n", nullptr}, "CASE ((abs(x) * power(10, n+1)) % 10) WHEN 5 THEN round(x/2, n) * 2 ELSE round(x, n) END"},
 	{DEFAULT_SCHEMA, "roundbankers", {"x", "n", nullptr}, "round_even(x, n)"},
 	{DEFAULT_SCHEMA, "nullif", {"a", "b", nullptr}, "CASE WHEN a=b THEN NULL ELSE a END"},

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -163,6 +163,11 @@ string StringUtil::BytesToHumanReadableString(idx_t bytes) {
 	megabytes -= gigabytes * 1000;
 	auto terabytes = gigabytes / 1000;
 	gigabytes -= terabytes * 1000;
+	auto petabytes = terabytes / 1000;
+	terabytes -= petabytes * 1000;
+	if (petabytes > 0) {
+		return to_string(petabytes) + "." + to_string(terabytes / 100) + "PB";
+	}
 	if (terabytes > 0) {
 		return to_string(terabytes) + "." + to_string(gigabytes / 100) + "TB";
 	} else if (gigabytes > 0) {
@@ -172,7 +177,7 @@ string StringUtil::BytesToHumanReadableString(idx_t bytes) {
 	} else if (kilobytes > 0) {
 		return to_string(kilobytes) + "KB";
 	} else {
-		return to_string(bytes) + " bytes";
+		return to_string(bytes) + (bytes == 1 ? " byte" : " bytes");
 	}
 }
 

--- a/src/core_functions/function_list.cpp
+++ b/src/core_functions/function_list.cpp
@@ -148,6 +148,8 @@ static StaticFunctionDefinition internal_functions[] = {
 	DUCKDB_SCALAR_FUNCTION(ListFlattenFun),
 	DUCKDB_SCALAR_FUNCTION_SET(FloorFun),
 	DUCKDB_SCALAR_FUNCTION(FormatFun),
+	DUCKDB_SCALAR_FUNCTION_ALIAS(FormatreadabledecimalsizeFun),
+	DUCKDB_SCALAR_FUNCTION(FormatBytesFun),
 	DUCKDB_SCALAR_FUNCTION(FromBase64Fun),
 	DUCKDB_SCALAR_FUNCTION_ALIAS(FromBinaryFun),
 	DUCKDB_SCALAR_FUNCTION_ALIAS(FromHexFun),

--- a/src/core_functions/scalar/string/CMakeLists.txt
+++ b/src/core_functions/scalar/string/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library_unity(
   bar.cpp
   chr.cpp
   damerau_levenshtein.cpp
+  format_bytes.cpp
   hamming.cpp
   hex.cpp
   instr.cpp

--- a/src/core_functions/scalar/string/format_bytes.cpp
+++ b/src/core_functions/scalar/string/format_bytes.cpp
@@ -1,0 +1,29 @@
+#include "duckdb/core_functions/scalar/string_functions.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/string_util.hpp"
+
+namespace duckdb {
+
+static void FormatBytesFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	UnaryExecutor::Execute<int64_t, string_t>(args.data[0], result, args.size(), [&](int64_t bytes) {
+		bool is_negative = bytes < 0;
+		idx_t unsigned_bytes;
+		if (bytes < 0) {
+			if (bytes == NumericLimits<int64_t>::Minimum()) {
+				unsigned_bytes = idx_t(NumericLimits<int64_t>::Maximum()) + 1;
+			} else {
+				unsigned_bytes = idx_t(-bytes);
+			}
+		} else {
+			unsigned_bytes = idx_t(bytes);
+		}
+		return StringVector::AddString(result, (is_negative ? "-" : "") +
+		                                           StringUtil::BytesToHumanReadableString(unsigned_bytes));
+	});
+}
+
+ScalarFunction FormatBytesFun::GetFunction() {
+	return ScalarFunction({LogicalType::BIGINT}, LogicalType::VARCHAR, FormatBytesFunction);
+}
+
+} // namespace duckdb

--- a/src/core_functions/scalar/string/functions.json
+++ b/src/core_functions/scalar/string/functions.json
@@ -53,6 +53,14 @@
         "type": "scalar_function"
     },
     {
+        "name": "format_bytes",
+        "parameters": "bytes",
+        "description": "Converts bytes to a human-readable presentation (e.g. 16000 -> 16KB)",
+        "example": "format_bytes(1000 * 16)",
+        "type": "scalar_function",
+        "aliases": ["formatReadableDecimalSize"]
+    },
+    {
         "name": "hamming",
         "parameters": "str1,str2",
         "description": "The number of positions with different characters for 2 strings of equal length. Different case is considered different.",

--- a/src/include/duckdb/core_functions/scalar/string_functions.hpp
+++ b/src/include/duckdb/core_functions/scalar/string_functions.hpp
@@ -88,6 +88,21 @@ struct FormatFun {
 	static ScalarFunction GetFunction();
 };
 
+struct FormatBytesFun {
+	static constexpr const char *Name = "format_bytes";
+	static constexpr const char *Parameters = "bytes";
+	static constexpr const char *Description = "Converts bytes to a human-readable presentation (e.g. 16000 -> 16KB)";
+	static constexpr const char *Example = "format_bytes(1000 * 16)";
+
+	static ScalarFunction GetFunction();
+};
+
+struct FormatreadabledecimalsizeFun {
+	using ALIAS = FormatBytesFun;
+
+	static constexpr const char *Name = "formatReadableDecimalSize";
+};
+
 struct HammingFun {
 	static constexpr const char *Name = "hamming";
 	static constexpr const char *Parameters = "str1,str2";

--- a/test/sql/function/string/format_bytes.test
+++ b/test/sql/function/string/format_bytes.test
@@ -1,0 +1,101 @@
+# name: test/sql/function/string/format_bytes.test
+# description: Test the to_hex/from_hex function
+# group: [string]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT format_bytes(0);
+----
+0 bytes
+
+query I
+SELECT format_bytes(999);
+----
+999 bytes
+
+query I
+SELECT format_bytes(1000);
+----
+1KB
+
+query I
+SELECT pg_size_pretty(1000);
+----
+1KB
+
+query I
+SELECT formatReadableDecimalSize(1000);
+----
+1KB
+
+query I
+SELECT format_bytes(1000*1000-1);
+----
+999KB
+
+query I
+SELECT format_bytes(1000*1000);
+----
+1.0MB
+
+query I
+SELECT format_bytes(1000*1000 + 555555);
+----
+1.5MB
+
+query I
+SELECT format_bytes(1000*1000*1000-1);
+----
+999.9MB
+
+query I
+SELECT format_bytes(1000*1000*1000);
+----
+1.0GB
+
+query I
+SELECT format_bytes(1000::BIGINT*1000*1000*1000-1);
+----
+999.9GB
+
+query I
+SELECT format_bytes(1000::BIGINT*1000*1000*1000);
+----
+1.0TB
+
+query I
+SELECT format_bytes(1000::BIGINT*1000*1000*1000*1000-1);
+----
+999.9TB
+
+query I
+SELECT format_bytes(1000::BIGINT*1000*1000*1000*1000);
+----
+1.0PB
+
+query I
+SELECT format_bytes(9223372036854775807);
+----
+9223.3PB
+
+query I
+SELECT format_bytes(NULL);
+----
+NULL
+
+query I
+SELECT format_bytes(1);
+----
+1 byte
+
+query I
+SELECT format_bytes(-1);
+----
+-1 byte
+
+query I
+SELECT format_bytes(-9223372036854775808);
+----
+-9223.3PB


### PR DESCRIPTION
```sql
D select format_bytes(16500000) as f;
┌─────────┐
│    f    │
│ varchar │
├─────────┤
│ 16.5MB  │
└─────────┘
```