### PR TITLE
[Swift] add Int/UInt decoding to VectorElementDecoder

### DIFF
--- a/tools/swift/duckdb-swift/Sources/DuckDB/Column.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Column.swift
@@ -130,6 +130,9 @@ public extension Column {
   /// the given type and the column's underlying database type, returned
   /// elements will always be equal to `nil`.
   ///
+  /// - Warning: Implicit conversion of a DuckDB integer column value greater
+  ///   than `Int.max` or less than `Int.min` is a programmer error and will
+  ///   result in a runtime precondition failure
   /// - Parameter type: the native Swift type to cast to
   /// - Returns: a typed DuckDB result set ``Column``
   func cast(to type: Int.Type) -> Column<Int> {
@@ -208,6 +211,9 @@ public extension Column {
   /// the given type and the column's underlying database type, returned
   /// elements will always be equal to `nil`.
   ///
+  /// - Warning: Implicit conversion of a DuckDB integer column value greater
+  ///   than `UInt.max` is a programmer error and will result in a runtime
+  ///   precondition failure
   /// - Parameter type: the native Swift type to cast to
   /// - Returns: a typed DuckDB result set ``Column``
   func cast(to type: UInt.Type) -> Column<UInt> {

--- a/tools/swift/duckdb-swift/Sources/DuckDB/Internal/VectorElementDecoder.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Internal/VectorElementDecoder.swift
@@ -126,6 +126,10 @@ extension VectorElementDataDecoder {
       element.unwrapNull()
     }
     
+    func decode(_ type: Int.Type) throws -> Int {
+      try attemptDecode { try element.unwrap(type) }
+    }
+    
     func decode(_ type: Int8.Type) throws -> Int8 {
       try attemptDecode { try element.unwrap(type) }
     }
@@ -139,6 +143,10 @@ extension VectorElementDataDecoder {
     }
     
     func decode(_ type: Int64.Type) throws -> Int64 {
+      try attemptDecode { try element.unwrap(type) }
+    }
+    
+    func decode(_ type: UInt.Type) throws -> UInt {
       try attemptDecode { try element.unwrap(type) }
     }
     

--- a/tools/swift/duckdb-swift/Tests/DuckDBTests/TypeConversionTests.swift
+++ b/tools/swift/duckdb-swift/Tests/DuckDBTests/TypeConversionTests.swift
@@ -270,6 +270,11 @@ final class TypeConversionTests: XCTestCase {
     try extractTest(testColumnName: "int_array", expected: expected) { $0.cast(to: [Int32?].self) }
   }
   
+  func test_extract_from_int_array_casting_to_swift_int() throws {
+    let expected = [[], [Int(42), 999, nil, nil, -42], nil]
+    try extractTest(testColumnName: "int_array", expected: expected) { $0.cast(to: [Int?].self) }
+  }
+  
   func test_extract_from_double_array() throws {
     // We need this contraption to work around .nan != .nan
     enum DoubleBox: Equatable {


### PR DESCRIPTION
Adds implicit conversion to Int/UInt in VectorElementDecoder allowing usage of Int/UInt in composite types.

See #7318 for more info. Thank you, @indragiek, for the heads-up.