### PR TITLE
[Dev] Fix some Minio boot problems + extend Makefile for use with extensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,7 @@ reldebug:
 		${DISABLE_SANITIZER_FLAG} \
 		${STATIC_LIBCPP} \
 		${EXTENSIONS} \
+		${EXTRA_CMAKE_VARIABLES} \
 		-DCMAKE_BUILD_TYPE=RelWithDebInfo ../.. && \
 	cmake --build . --config RelWithDebInfo
 
@@ -309,6 +310,7 @@ relassert:
 		${STATIC_LIBCPP} \
 		${EXTENSIONS} \
 		-DFORCE_ASSERT=1 \
+		${EXTRA_CMAKE_VARIABLES} \
 		-DCMAKE_BUILD_TYPE=RelWithDebInfo ../.. && \
 	cmake --build . --config RelWithDebInfo
 
@@ -327,6 +329,7 @@ benchmark:
 		${STATIC_LIBCPP} \
 		${EXTENSIONS} \
 		-DBUILD_BENCHMARKS=1 \
+		${EXTRA_CMAKE_VARIABLES} \
 		-DCMAKE_BUILD_TYPE=Release ../.. && \
 	cmake --build . --config Release
 
@@ -341,6 +344,7 @@ amaldebug:
 		${EXTENSIONS} \
 		${FORCE_32_BIT_FLAG} \
 		-DAMALGAMATION_BUILD=1 \
+		${EXTRA_CMAKE_VARIABLES} \
 		-DCMAKE_BUILD_TYPE=Debug ../.. && \
 	cmake --build . --config Debug
 
@@ -352,6 +356,7 @@ tidy-check:
 		-DDISABLE_UNITY=1 \
 		-DBUILD_PARQUET_EXTENSION=TRUE \
 		-DBUILD_PYTHON_PKG=TRUE \
+		${EXTRA_CMAKE_VARIABLES} \
 		-DBUILD_SHELL=0 ../.. && \
 	python3 ../../scripts/run-clang-tidy.py -quiet ${TIDY_THREAD_PARAMETER} ${TIDY_BINARY_PARAMETER}
 
@@ -362,6 +367,7 @@ tidy-fix:
 		-DCLANG_TIDY=1 \
 		-DDISABLE_UNITY=1 \
 		-DBUILD_PARQUET_EXTENSION=TRUE \
+		${EXTRA_CMAKE_VARIABLES} \
 		-DBUILD_SHELL=0 ../.. && \
 	python3 ../../scripts/run-clang-tidy.py -fix
 

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,14 @@ all: release
 opt: release
 unit: unittest
 
-GENERATOR=
-FORCE_COLOR=
-WARNINGS_AS_ERRORS=
-FORCE_WARN_UNUSED_FLAG=
-DISABLE_UNITY_FLAG=
-DISABLE_SANITIZER_FLAG=
-OSX_BUILD_UNIVERSAL_FLAG=
-FORCE_32_BIT_FLAG=
+GENERATOR ?=
+FORCE_COLOR ?=
+WARNINGS_AS_ERRORS ?=
+FORCE_WARN_UNUSED_FLAG ?=
+DISABLE_UNITY_FLAG ?=
+DISABLE_SANITIZER_FLAG ?=
+OSX_BUILD_UNIVERSAL_FLAG ?=
+FORCE_32_BIT_FLAG ?=
 
 ifeq ($(GEN),ninja)
 	GENERATOR=-G "Ninja"
@@ -50,7 +50,8 @@ endif
 ifeq (${STATIC_LIBCPP}, 1)
 	STATIC_LIBCPP=-DSTATIC_LIBCPP=TRUE
 endif
-EXTENSIONS=-DBUILD_PARQUET_EXTENSION=TRUE
+EXTENSIONS ?=
+EXTENSIONS += -DBUILD_PARQUET_EXTENSION=TRUE
 ifeq (${DISABLE_PARQUET}, 1)
 	EXTENSIONS:=
 endif
@@ -152,6 +153,7 @@ endif
 ifneq ($(BUILD_OUT_OF_TREE_EXTENSIONS),)
 	EXTENSIONS:=${EXTENSIONS} -DDUCKDB_OOT_EXTENSION_NAMES="$(BUILD_OUT_OF_TREE_EXTENSIONS)"
 endif
+
 ifeq (${CRASH_ON_ASSERT}, 1)
 	EXTENSIONS:=${EXTENSIONS} -DASSERT_EXCEPTION=0
 endif
@@ -186,25 +188,75 @@ clean-python:
 debug:
 	mkdir -p ./build/debug && \
 	cd build/debug && \
-	cmake $(GENERATOR) $(FORCE_COLOR) ${WARNINGS_AS_ERRORS} ${FORCE_32_BIT_FLAG} ${DISABLE_UNITY_FLAG} ${DISABLE_SANITIZER_FLAG} ${STATIC_LIBCPP} ${EXTENSIONS} -DDEBUG_MOVE=1 -DCMAKE_BUILD_TYPE=Debug ../.. && \
+	echo ${DUCKDB_OOT_EXTENSION_SUBSTRAIT_PATH} && \
+	cmake \
+		$(GENERATOR) \
+		$(FORCE_COLOR) \
+		${WARNINGS_AS_ERRORS} \
+		${FORCE_32_BIT_FLAG} \
+		${DISABLE_UNITY_FLAG} \
+		${DISABLE_SANITIZER_FLAG} \
+		${STATIC_LIBCPP} \
+		${EXTENSIONS} \
+		${EXTRA_CMAKE_VARIABLES} \
+		-DDEBUG_MOVE=1 \
+		-DCMAKE_BUILD_TYPE=Debug ../.. && \
 	cmake --build . --config Debug
 
 release:
 	mkdir -p ./build/release && \
 	cd build/release && \
-	cmake $(GENERATOR) $(FORCE_COLOR) ${WARNINGS_AS_ERRORS} ${FORCE_WARN_UNUSED_FLAG} ${FORCE_32_BIT_FLAG} ${DISABLE_UNITY_FLAG} ${DISABLE_SANITIZER_FLAG} ${OSX_BUILD_UNIVERSAL_FLAG} ${STATIC_LIBCPP} ${EXTENSIONS} -DCMAKE_BUILD_TYPE=Release ../.. && \
+	cmake \
+		$(GENERATOR) \
+		$(FORCE_COLOR) \
+		${WARNINGS_AS_ERRORS} \
+		${FORCE_WARN_UNUSED_FLAG} \
+		${FORCE_32_BIT_FLAG} \
+		${DISABLE_UNITY_FLAG} \
+		${DISABLE_SANITIZER_FLAG} \
+		${OSX_BUILD_UNIVERSAL_FLAG} \
+		${STATIC_LIBCPP} \
+		${EXTENSIONS} \
+		${EXTRA_CMAKE_VARIABLES} \
+		-DCMAKE_BUILD_TYPE=Release ../.. && \
 	cmake --build . --config Release
 
 cldebug:
 	mkdir -p ./build/cldebug && \
 	cd build/cldebug && \
-	cmake $(GENERATOR) $(FORCE_COLOR) ${WARNINGS_AS_ERRORS} ${FORCE_32_BIT_FLAG} ${DISABLE_UNITY_FLAG} ${EXTENSIONS} -DBUILD_PYTHON=1 -DBUILD_R=1 -DENABLE_SANITIZER=0 -DENABLE_UBSAN=0 -DCMAKE_BUILD_TYPE=Debug ../.. && \
+	cmake \
+		$(GENERATOR) \
+		$(FORCE_COLOR) \
+		${WARNINGS_AS_ERRORS} \
+		${FORCE_32_BIT_FLAG} \
+		${DISABLE_UNITY_FLAG} \
+		${EXTENSIONS} \
+		-DBUILD_PYTHON=1 \
+		-DBUILD_R=1 \
+		-DENABLE_SANITIZER=0 \
+		-DENABLE_UBSAN=0 \
+		${EXTRA_CMAKE_VARIABLES} \
+		-DCMAKE_BUILD_TYPE=Debug ../.. && \
 	cmake --build . --config Debug
 
 clreldebug:
 	mkdir -p ./build/clreldebug && \
 	cd build/clreldebug && \
-	cmake $(GENERATOR) $(FORCE_COLOR) ${WARNINGS_AS_ERRORS} ${FORCE_32_BIT_FLAG} ${DISABLE_UNITY_FLAG} ${STATIC_LIBCPP} ${EXTENSIONS} -DBUILD_PYTHON=1 -DBUILD_R=1 -DBUILD_FTS_EXTENSION=1 -DENABLE_SANITIZER=0 -DENABLE_UBSAN=0 -DCMAKE_BUILD_TYPE=RelWithDebInfo ../.. && \
+	cmake \
+		$(GENERATOR) \
+		$(FORCE_COLOR) \
+		${WARNINGS_AS_ERRORS} \
+		${FORCE_32_BIT_FLAG} \
+		${DISABLE_UNITY_FLAG} \
+		${STATIC_LIBCPP} \
+		${EXTENSIONS} \
+		-DBUILD_PYTHON=1 \
+		-DBUILD_R=1 \
+		-DBUILD_FTS_EXTENSION=1 \
+		-DENABLE_SANITIZER=0 \
+		-DENABLE_UBSAN=0 \
+		${EXTRA_CMAKE_VARIABLES} \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo ../.. && \
 	cmake --build . --config RelWithDebInfo
 
 unittest: debug
@@ -232,38 +284,85 @@ doxygen: docs
 reldebug:
 	mkdir -p ./build/reldebug && \
 	cd build/reldebug && \
-	cmake $(GENERATOR) $(FORCE_COLOR) ${WARNINGS_AS_ERRORS} ${FORCE_32_BIT_FLAG} ${DISABLE_UNITY_FLAG} ${DISABLE_SANITIZER_FLAG}  ${STATIC_LIBCPP} ${EXTENSIONS} -DCMAKE_BUILD_TYPE=RelWithDebInfo ../.. && \
+	cmake \
+		$(GENERATOR) \
+		$(FORCE_COLOR) \
+		${WARNINGS_AS_ERRORS} \
+		${FORCE_32_BIT_FLAG} \
+		${DISABLE_UNITY_FLAG} \
+		${DISABLE_SANITIZER_FLAG} \
+		${STATIC_LIBCPP} \
+		${EXTENSIONS} \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo ../.. && \
 	cmake --build . --config RelWithDebInfo
 
 relassert:
 	mkdir -p ./build/relassert && \
 	cd build/relassert && \
-	cmake $(GENERATOR) $(FORCE_COLOR) ${WARNINGS_AS_ERRORS} ${FORCE_32_BIT_FLAG} ${DISABLE_UNITY_FLAG} ${DISABLE_SANITIZER_FLAG} ${STATIC_LIBCPP} ${EXTENSIONS} -DFORCE_ASSERT=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo ../.. && \
+	cmake \
+		$(GENERATOR) \
+		$(FORCE_COLOR) \
+		${WARNINGS_AS_ERRORS} \
+		${FORCE_32_BIT_FLAG} \
+		${DISABLE_UNITY_FLAG} \
+		${DISABLE_SANITIZER_FLAG} \
+		${STATIC_LIBCPP} \
+		${EXTENSIONS} \
+		-DFORCE_ASSERT=1 \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo ../.. && \
 	cmake --build . --config RelWithDebInfo
 
 benchmark:
 	mkdir -p ./build/release && \
 	cd build/release && \
-	cmake $(GENERATOR) $(FORCE_COLOR) ${WARNINGS_AS_ERRORS} ${FORCE_WARN_UNUSED_FLAG} ${FORCE_32_BIT_FLAG} ${DISABLE_UNITY_FLAG} ${DISABLE_SANITIZER_FLAG} ${OSX_BUILD_UNIVERSAL_FLAG} ${STATIC_LIBCPP} ${EXTENSIONS} -DBUILD_BENCHMARKS=1 -DCMAKE_BUILD_TYPE=Release ../.. && \
+	cmake \
+		$(GENERATOR) \
+		$(FORCE_COLOR) \
+		${WARNINGS_AS_ERRORS} \
+		${FORCE_WARN_UNUSED_FLAG} \
+		${FORCE_32_BIT_FLAG} \
+		${DISABLE_UNITY_FLAG} \
+		${DISABLE_SANITIZER_FLAG} \
+		${OSX_BUILD_UNIVERSAL_FLAG} \
+		${STATIC_LIBCPP} \
+		${EXTENSIONS} \
+		-DBUILD_BENCHMARKS=1 \
+		-DCMAKE_BUILD_TYPE=Release ../.. && \
 	cmake --build . --config Release
 
 amaldebug:
 	mkdir -p ./build/amaldebug && \
 	python3 scripts/amalgamation.py && \
 	cd build/amaldebug && \
-	cmake $(GENERATOR) $(FORCE_COLOR) ${STATIC_LIBCPP} ${EXTENSIONS} ${FORCE_32_BIT_FLAG} -DAMALGAMATION_BUILD=1 -DCMAKE_BUILD_TYPE=Debug ../.. && \
+	cmake \
+		$(GENERATOR) \
+		$(FORCE_COLOR) \
+		${STATIC_LIBCPP} \
+		${EXTENSIONS} \
+		${FORCE_32_BIT_FLAG} \
+		-DAMALGAMATION_BUILD=1 \
+		-DCMAKE_BUILD_TYPE=Debug ../.. && \
 	cmake --build . --config Debug
 
 tidy-check:
 	mkdir -p ./build/tidy && \
 	cd build/tidy && \
-	cmake -DCLANG_TIDY=1 -DDISABLE_UNITY=1 -DBUILD_PARQUET_EXTENSION=TRUE -DBUILD_PYTHON_PKG=TRUE -DBUILD_SHELL=0 ../.. && \
+	cmake \
+		-DCLANG_TIDY=1 \
+		-DDISABLE_UNITY=1 \
+		-DBUILD_PARQUET_EXTENSION=TRUE \
+		-DBUILD_PYTHON_PKG=TRUE \
+		-DBUILD_SHELL=0 ../.. && \
 	python3 ../../scripts/run-clang-tidy.py -quiet ${TIDY_THREAD_PARAMETER} ${TIDY_BINARY_PARAMETER}
 
 tidy-fix:
 	mkdir -p ./build/tidy && \
 	cd build/tidy && \
-	cmake -DCLANG_TIDY=1 -DDISABLE_UNITY=1 -DBUILD_PARQUET_EXTENSION=TRUE -DBUILD_SHELL=0 ../.. && \
+	cmake \
+		-DCLANG_TIDY=1 \
+		-DDISABLE_UNITY=1 \
+		-DBUILD_PARQUET_EXTENSION=TRUE \
+		-DBUILD_SHELL=0 ../.. && \
 	python3 ../../scripts/run-clang-tidy.py -fix
 
 test_compile: # test compilation of individual cpp files

--- a/scripts/install_s3_test_server.sh
+++ b/scripts/install_s3_test_server.sh
@@ -9,4 +9,5 @@ fi
 docker --version
 echo '127.0.0.1 duckdb-minio.com' >> /etc/hosts
 echo '127.0.0.1 test-bucket.duckdb-minio.com' >> /etc/hosts
+echo '127.0.0.1 test-bucket-2.duckdb-minio.com' >> /etc/hosts
 echo '127.0.0.1 test-bucket-public.duckdb-minio.com' >> /etc/hosts

--- a/scripts/minio_s3.yml
+++ b/scripts/minio_s3.yml
@@ -14,6 +14,8 @@ services:
       - MINIO_ROOT_PASSWORD=duckdb_minio_admin_password
       - MINIO_REGION_NAME=eu-west-1
       - MINIO_DOMAIN=duckdb-minio.com
+      - MINIO_ACCESS_KEY=duckdb_minio_admin
+      - MINIO_SECRET_KEY=duckdb_minio_admin_password
     command: server /data --console-address ":9001"
 
   minio_setup:
@@ -24,16 +26,15 @@ services:
       - minio
     volumes:
       - ${PWD}/data:/duckdb/data
+
     entrypoint: >
       /bin/sh -c "
-        while true; do
+        until (
           /usr/bin/mc config host add myminio http://duckdb-minio.com:9000 duckdb_minio_admin duckdb_minio_admin_password
-          if [ $$? -eq 0 ]; then
-            break
-          fi
-          echo 'Failed to add host alias, trying again in a second'
-          sleep 1
-        done
+        ) do
+          echo '...waiting...' && sleep 1;
+        done;
+
         /usr/bin/mc admin user add myminio minio_duckdb_user minio_duckdb_user_password
         /usr/bin/mc admin user list myminio
         /usr/bin/mc admin user info myminio minio_duckdb_user
@@ -48,9 +49,9 @@ services:
         /usr/bin/mc mb myminio/test-bucket
         /usr/bin/mc policy get myminio/test-bucket
 
-        /usr/bin/mc rb --force myminio/test-bucket_2
-        /usr/bin/mc mb myminio/test-bucket_2
-        /usr/bin/mc policy get myminio/test-bucket_2
+        /usr/bin/mc rb --force myminio/test-bucket-2
+        /usr/bin/mc mb myminio/test-bucket-2
+        /usr/bin/mc policy get myminio/test-bucket-2
 
         /usr/bin/mc rb --force myminio/test-bucket-public
         /usr/bin/mc mb myminio/test-bucket-public
@@ -62,12 +63,12 @@ services:
         /usr/bin/mc cp /duckdb/data/csv/phonenumbers.csv myminio/test-bucket/presigned/phonenumbers.csv
         /usr/bin/mc cp /duckdb/data/parquet-testing/glob/t1.parquet myminio/test-bucket/presigned/t1.parquet
 
-        # large file upload
-        /usr/bin/mc cp /duckdb/data/parquet-testing/presigned/presigned-url-lineitem.parquet myminio/test-bucket/presigned/lineitem_large.parquet
+        ## large file upload
+        #/usr/bin/mc cp /duckdb/data/parquet-testing/presigned/presigned-url-lineitem.parquet myminio/test-bucket/presigned/lineitem_large.parquet
 
-        /usr/bin/mc share download myminio/test-bucket/presigned/phonenumbers.csv
-        /usr/bin/mc share download myminio/test-bucket/presigned/t1.parquet
-        /usr/bin/mc share download myminio/test-bucket/presigned/lineitem_large.parquet
+        #/usr/bin/mc share download myminio/test-bucket/presigned/phonenumbers.csv
+        #/usr/bin/mc share download myminio/test-bucket/presigned/t1.parquet
+        #/usr/bin/mc share download myminio/test-bucket/presigned/lineitem_large.parquet
 
         exit 0;
       "

--- a/scripts/minio_s3.yml
+++ b/scripts/minio_s3.yml
@@ -59,16 +59,18 @@ services:
         /usr/bin/mc policy get myminio/test-bucket-public
 
         # This is for the test of presigned URLs
+        # !!! When missing, be sure that you have ran 'scripts/generate_presigned_url.sh' !!!
+
         # small file upload
         /usr/bin/mc cp /duckdb/data/csv/phonenumbers.csv myminio/test-bucket/presigned/phonenumbers.csv
         /usr/bin/mc cp /duckdb/data/parquet-testing/glob/t1.parquet myminio/test-bucket/presigned/t1.parquet
 
-        ## large file upload
-        #/usr/bin/mc cp /duckdb/data/parquet-testing/presigned/presigned-url-lineitem.parquet myminio/test-bucket/presigned/lineitem_large.parquet
+        # large file upload
+        /usr/bin/mc cp /duckdb/data/parquet-testing/presigned/presigned-url-lineitem.parquet myminio/test-bucket/presigned/lineitem_large.parquet
 
-        #/usr/bin/mc share download myminio/test-bucket/presigned/phonenumbers.csv
-        #/usr/bin/mc share download myminio/test-bucket/presigned/t1.parquet
-        #/usr/bin/mc share download myminio/test-bucket/presigned/lineitem_large.parquet
+        /usr/bin/mc share download myminio/test-bucket/presigned/phonenumbers.csv
+        /usr/bin/mc share download myminio/test-bucket/presigned/t1.parquet
+        /usr/bin/mc share download myminio/test-bucket/presigned/lineitem_large.parquet
 
         exit 0;
       "


### PR DESCRIPTION
- `test-bucket_2` was not a valid bucket name, because of the `_`, renamed it to `test-bucket-2`
- added test-bucket-2 to the install script, the entire bucket seems unused however
- adding the host alias was not working immediately, causing the script to stop. Using an approach taken from <https://github.com/minio/mc/issues/3421#issuecomment-1433323342> instead fixed it.

I've added expanding the `EXTRA_CMAKE_VARIABLES` to the cmake build command.
This can be used by extensions to pass in the variables required for linking OOT extensions, for example:
```Makefile
EXTRA_CMAKE_VARIABLES :=
EXTRA_CMAKE_VARIABLES += -DDUCKDB_OOT_EXTENSION_SUBSTRAIT_PATH=$(PROJ_DIR)
EXTRA_CMAKE_VARIABLES += -DDUCKDB_OOT_EXTENSION_SUBSTRAIT_SHOULD_LINK=TRUE
EXTRA_CMAKE_VARIABLES += -DDUCKDB_OOT_EXTENSION_SUBSTRAIT_INCLUDE_PATH=$(PROJ_DIR)src/include
export EXTRA_CMAKE_VARIABLES
```

With this we can now leverage the duckdb Makefile from the makefile of an extension, as evidenced here:
https://github.com/duckdblabs/substrait/pull/54