### PR TITLE
feat(jdbc): native array reading support

### DIFF
--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -62,7 +62,6 @@ static jclass J_DuckVector;
 static jmethodID J_DuckVector_init;
 static jfieldID J_DuckVector_constlen;
 static jfieldID J_DuckVector_varlen;
-static jmethodID J_DuckVector_getObject;
 
 static jclass J_ByteBuffer;
 
@@ -185,8 +184,6 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
 	J_DuckVector_init = env->GetMethodID(J_DuckVector, "<init>", "(Ljava/lang/String;I[Z)V");
 	J_DuckVector_constlen = env->GetFieldID(J_DuckVector, "constlen_data", "Ljava/nio/ByteBuffer;");
 	J_DuckVector_varlen = env->GetFieldID(J_DuckVector, "varlen_data", "[Ljava/lang/Object;");
-	J_DuckVector_getObject = env->GetMethodID(J_DuckVector, "getObject", "(I)Ljava/lang/Object;");
-	D_ASSERT(J_DuckVector_getObject);
 
 	tmpLocalRef = env->FindClass("java/nio/ByteBuffer");
 	J_ByteBuffer = (jclass)env->NewGlobalRef(tmpLocalRef);

--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -854,7 +854,6 @@ jobject ProcessVector(JNIEnv *env, Connection* conn_ref, Vector &vec, idx_t row_
 					continue;
 				}
 
-				// TODO: apply offset
 				auto offset = list_entries[row_idx].offset;
 				auto limit = list_entries[row_idx].length;
 

--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -726,15 +726,6 @@ JNIEXPORT jobjectArray JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1fetch(
 
 	return vec_array;
 }
-
-jobject ProcessValue(JNIEnv *env, Connection *conn_ref, const Value &child_value) {
-	auto vector = new Vector(child_value); // TODO: DuckVector should own this
-	int n_elements = 1;
-	vector->Flatten(n_elements);
-	auto jobj = ProcessVector(env, conn_ref, *vector, n_elements);
-	return env->CallObjectMethod(jobj, J_DuckVector_getObject, 0);
-}
-
 jobject ProcessVector(JNIEnv *env, Connection* conn_ref, Vector &vec, idx_t row_count) {
 		auto type_str = env->NewStringUTF(vec.GetType().ToString().c_str());
 		// construct nullmask

--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -658,7 +658,7 @@ static std::string type_to_jduckdb_type(LogicalType logical_type) {
 		}
 	} break;
 	default:
-		return std::string("");
+		return logical_type.ToString();
 	}
 }
 
@@ -734,7 +734,7 @@ JNIEXPORT jobjectArray JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1fetch(
 	return vec_array;
 }
 jobject ProcessVector(JNIEnv *env, Connection *conn_ref, Vector &vec, idx_t row_count) {
-	auto type_str = env->NewStringUTF(vec.GetType().ToString().c_str());
+	auto type_str = env->NewStringUTF(type_to_jduckdb_type(vec.GetType()).c_str());
 	// construct nullmask
 	auto null_array = env->NewBooleanArray(row_count);
 	jboolean *null_array_ptr = env->GetBooleanArrayElements(null_array, nullptr);

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBArray.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBArray.java
@@ -7,9 +7,12 @@ import java.util.Map;
 
 public class DuckDBArray implements Array {
     private DuckDBVector vector;
+    int offset, length;
 
-    public DuckDBArray(DuckDBVector vector) {
+    public DuckDBArray(DuckDBVector vector, int offset, int length) {
         this.vector = vector;
+        this.length = length;
+        this.offset = offset;
     }
 
     @Override
@@ -20,9 +23,9 @@ public class DuckDBArray implements Array {
 
     @Override
     public Object getArray() throws SQLException {
-        Object[] out = new Object[vector.length];
-        for (int i=0; i<vector.length; i++) {
-            out[i] = vector.getObject(i);
+        Object[] out = new Object[length];
+        for (int i=0; i<length; i++) {
+            out[i] = vector.getObject(offset + i);
         }
         return out;
     }

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBArray.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBArray.java
@@ -5,6 +5,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Map;
 
+import static org.duckdb.DuckDBResultSetMetaData.type_to_int;
+
 public class DuckDBArray implements Array {
     private DuckDBVector vector;
     int offset, length;
@@ -17,10 +19,8 @@ public class DuckDBArray implements Array {
 
     @Override
     public void free() throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'free'");
+        // we don't own the vector, so cannot free it
     }
-
     @Override
     public Object getArray() throws SQLException {
         Object[] out = new Object[length];
@@ -31,33 +31,30 @@ public class DuckDBArray implements Array {
     }
 
     @Override
-    public Object getArray(Map<String, Class<?>> arg0) throws SQLException {
+    public Object getArray(Map<String, Class<?>> map) throws SQLException {
+        return getArray();
+    }
+
+    @Override
+    public Object getArray(long index, int count) throws SQLException {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'getArray'");
     }
 
     @Override
-    public Object getArray(long arg0, int arg1) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getArray'");
-    }
-
-    @Override
-    public Object getArray(long arg0, int arg1, Map<String, Class<?>> arg2) throws SQLException {
+    public Object getArray(long index, int count, Map<String, Class<?>> map) throws SQLException {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'getArray'");
     }
 
     @Override
     public int getBaseType() throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getBaseType'");
+        return type_to_int(vector.duckdb_type);
     }
 
     @Override
     public String getBaseTypeName() throws SQLException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getBaseTypeName'");
+        return vector.duckdb_type.name();
     }
 
     @Override
@@ -67,19 +64,19 @@ public class DuckDBArray implements Array {
     }
 
     @Override
-    public ResultSet getResultSet(Map<String, Class<?>> arg0) throws SQLException {
+    public ResultSet getResultSet(Map<String, Class<?>> map) throws SQLException {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'getResultSet'");
     }
 
     @Override
-    public ResultSet getResultSet(long arg0, int arg1) throws SQLException {
+    public ResultSet getResultSet(long index, int count) throws SQLException {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'getResultSet'");
     }
 
     @Override
-    public ResultSet getResultSet(long arg0, int arg1, Map<String, Class<?>> arg2) throws SQLException {
+    public ResultSet getResultSet(long index, int count, Map<String, Class<?>> map) throws SQLException {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'getResultSet'");
     }

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBArray.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBArray.java
@@ -1,0 +1,83 @@
+package org.duckdb;
+
+import java.sql.Array;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Map;
+
+public class DuckDBArray implements Array {
+    private DuckDBVector vector;
+
+    public DuckDBArray(DuckDBVector vector) {
+        this.vector = vector;
+    }
+
+    @Override
+    public void free() throws SQLException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'free'");
+    }
+
+    @Override
+    public Object getArray() throws SQLException {
+        Object[] out = new Object[vector.length];
+        for (int i=0; i<vector.length; i++) {
+            out[i] = vector.getObject(i);
+        }
+        return out;
+    }
+
+    @Override
+    public Object getArray(Map<String, Class<?>> arg0) throws SQLException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getArray'");
+    }
+
+    @Override
+    public Object getArray(long arg0, int arg1) throws SQLException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getArray'");
+    }
+
+    @Override
+    public Object getArray(long arg0, int arg1, Map<String, Class<?>> arg2) throws SQLException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getArray'");
+    }
+
+    @Override
+    public int getBaseType() throws SQLException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getBaseType'");
+    }
+
+    @Override
+    public String getBaseTypeName() throws SQLException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getBaseTypeName'");
+    }
+
+    @Override
+    public ResultSet getResultSet() throws SQLException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getResultSet'");
+    }
+
+    @Override
+    public ResultSet getResultSet(Map<String, Class<?>> arg0) throws SQLException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getResultSet'");
+    }
+
+    @Override
+    public ResultSet getResultSet(long arg0, int arg1) throws SQLException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getResultSet'");
+    }
+
+    @Override
+    public ResultSet getResultSet(long arg0, int arg1, Map<String, Class<?>> arg2) throws SQLException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getResultSet'");
+    }
+}

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBColumnTypeMetaData.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBColumnTypeMetaData.java
@@ -11,5 +11,11 @@ public class DuckDBColumnTypeMetaData {
 		this.width = width;
 		this.scale = scale;
 	}
+
+	public static DuckDBColumnTypeMetaData parseColumnTypeMetadata(String columnTypeDetail) {
+		String[] split_details = columnTypeDetail.split(";");
+		return new DuckDBColumnTypeMetaData(Short.parseShort(split_details[0].replace("DECIMAL", ""))
+				, Short.parseShort(split_details[1]), Short.parseShort(split_details[2]));
+	}
 }
 	

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
@@ -1070,7 +1070,7 @@ public class DuckDBResultSet implements ResultSet {
 	}
 
 	public Clob getClob(String columnLabel) throws SQLException {
-		return getClob(findColumn(columnLabel));
+		throw new SQLFeatureNotSupportedException("getClob");
 	}
 
 	public Array getArray(String columnLabel) throws SQLException {

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
@@ -386,15 +386,7 @@ public class DuckDBResultSet implements ResultSet {
 		if (check_and_null(columnIndex)) {
 			return 0;
 		}
-		if (isType(columnIndex, DuckDBColumnType.BIGINT)
-			   || isType(columnIndex, DuckDBColumnType.TIMESTAMP)) {
-			return getbuf(columnIndex, 8).getLong();
-		}
-		Object o = getObject(columnIndex);
-		if (o instanceof Number) {
-			return ((Number) o).longValue();
-		}
-		return Long.parseLong(o.toString());
+		return current_chunk[columnIndex - 1].getLong(chunk_idx - 1);
 	}
 
 	public BigInteger getHugeint(int columnIndex) throws SQLException {

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
@@ -407,7 +407,7 @@ public class DuckDBResultSet implements ResultSet {
 		return current_chunk[columnIndex - 1].getUuid(chunk_idx - 1);
 	}
 
-	static class DuckDBBlobResult implements Blob {
+	public static class DuckDBBlobResult implements Blob {
 
 		static class ByteBufferBackedInputStream extends InputStream {
 
@@ -488,6 +488,26 @@ public class DuckDBResultSet implements ResultSet {
 		public int setBytes(long pos, byte[] bytes, int offset, int len) throws SQLException {
 			throw new SQLFeatureNotSupportedException("setBytes");
 
+		}
+
+		@Override
+		public String toString() {
+			return "DuckDBBlobResult{" +
+					"buffer=" + buffer +
+					'}';
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			DuckDBBlobResult that = (DuckDBBlobResult) o;
+			return Objects.equals(buffer, that.buffer);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(buffer);
 		}
 
 		private ByteBuffer buffer;

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
@@ -355,28 +355,11 @@ public class DuckDBResultSet implements ResultSet {
 	}
 
 	public Date getDate(int columnIndex) throws SQLException {
-		String string_value = getLazyString(columnIndex);
-		if (string_value == null) {
-			return null;
-		}
-		try {
-			return Date.valueOf(string_value);
-		} catch (Exception e) {
-			return null;
-		}
+		return check_and_null(columnIndex) ? null : current_chunk[columnIndex - 1].getDate(chunk_idx - 1);
 	}
 
 	public Time getTime(int columnIndex) throws SQLException {
-		String string_value = getLazyString(columnIndex);
-		if (string_value == null) {
-			return null;
-		}
-		try {
-
-			return Time.valueOf(getLazyString(columnIndex));
-		} catch (Exception e) {
-			return null;
-		}
+		return check_and_null(columnIndex) ? null : current_chunk[columnIndex - 1].getTime(chunk_idx - 1);
 	}
 
 	public Timestamp getTimestamp(int columnIndex) throws SQLException {

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
@@ -1056,7 +1056,7 @@ public class DuckDBResultSet implements ResultSet {
 
 	public Array getArray(int columnIndex) throws SQLException {
 		if (isType(columnIndex, DuckDBColumnType.LIST)) {
-			return new DuckDBArray((DuckDBVector) current_chunk[columnIndex-1].varlen_data[chunk_idx - 1]);
+			return (DuckDBArray) current_chunk[columnIndex-1].varlen_data[chunk_idx - 1];
 		}
 		throw new SQLFeatureNotSupportedException("getArray");
 	}

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSetMetaData.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSetMetaData.java
@@ -3,7 +3,6 @@ package org.duckdb;
 import java.sql.Date;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
@@ -13,8 +12,6 @@ import java.time.OffsetDateTime;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.UUID;
-
-import org.duckdb.DuckDBResultSet.DuckDBBlobResult;
 
 public class DuckDBResultSetMetaData implements ResultSetMetaData {
 
@@ -36,10 +33,8 @@ public class DuckDBResultSetMetaData implements ResultSetMetaData {
 		this.column_types = column_types_al.toArray(this.column_types);
 
 		for (String column_type_detail : this.column_types_details) {
-			if (!column_type_detail.equals("")) {
-				String[] split_details = column_type_detail.split(";");
-				column_types_meta.add(new DuckDBColumnTypeMetaData(Short.parseShort(split_details[0].replace("DECIMAL", ""))
-							, Short.parseShort(split_details[1]), Short.parseShort(split_details[2])));
+			if (column_type_detail.startsWith("DECIMAL")) {
+				column_types_meta.add(DuckDBColumnTypeMetaData.parseColumnTypeMetadata(column_type_detail));
 			}
 			else { column_types_meta.add(null); }
 		}

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSetMetaData.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSetMetaData.java
@@ -47,14 +47,14 @@ public class DuckDBResultSetMetaData implements ResultSetMetaData {
 	}
 
 	public static DuckDBColumnType TypeNameToType(String type_name) {
-		if (type_name.startsWith("DECIMAL")) {
+		if (type_name.endsWith("[]")) {
+			return DuckDBColumnType.LIST;
+		} else if (type_name.startsWith("DECIMAL")) {
 			return DuckDBColumnType.DECIMAL;
 		} else if (type_name.equals("TIME WITH TIME ZONE")) {
 			return DuckDBColumnType.TIME_WITH_TIME_ZONE;
 		} else if (type_name.equals("TIMESTAMP WITH TIME ZONE")) {
 			return DuckDBColumnType.TIMESTAMP_WITH_TIME_ZONE;
-		} else if (type_name.endsWith("[]")) {
-			return DuckDBColumnType.LIST;
 		} else if (type_name.startsWith("STRUCT")) {
 			return DuckDBColumnType.STRUCT;
 		} else if (type_name.startsWith("MAP")) {

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSetMetaData.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSetMetaData.java
@@ -1,16 +1,16 @@
 package org.duckdb;
 
-import java.sql.Date;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.sql.Types;
-import java.util.ArrayList;
-import java.time.OffsetTime;
-import java.time.OffsetDateTime;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.util.ArrayList;
 import java.util.UUID;
 
 public class DuckDBResultSetMetaData implements ResultSetMetaData {
@@ -146,19 +146,15 @@ public class DuckDBResultSetMetaData implements ResultSetMetaData {
 		case TINYINT:
 			return Byte.class.getName();
 		case SMALLINT:
-			return Short.class.getName();
-		case INTEGER:
-			return Integer.class.getName();
-		case BIGINT:
-			return Long.class.getName();
-		case HUGEINT:
-			return BigInteger.class.getName();
 		case UTINYINT:
 			return Short.class.getName();
+		case INTEGER:
 		case USMALLINT:
 			return Integer.class.getName();
+		case BIGINT:
 		case UINTEGER:
 			return Long.class.getName();
+		case HUGEINT:
 		case UBIGINT:
 			return BigInteger.class.getName();
 		case FLOAT:
@@ -168,11 +164,11 @@ public class DuckDBResultSetMetaData implements ResultSetMetaData {
 		case DECIMAL:
 			return BigDecimal.class.getName();
 		case TIME:
-			return Time.class.getName();
+			return LocalTime.class.getName();
 		case TIME_WITH_TIME_ZONE:
 			return OffsetTime.class.getName();
 		case DATE:
-			return Date.class.getName();
+			return LocalDate.class.getName();
 		case TIMESTAMP:
 		case TIMESTAMP_NS:
 		case TIMESTAMP_S:

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSetMetaData.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSetMetaData.java
@@ -191,6 +191,8 @@ public class DuckDBResultSetMetaData implements ResultSetMetaData {
 			return DuckDBResultSet.DuckDBBlobResult.class.getName();
 		case UUID:
 			return UUID.class.getName();
+		case LIST:
+			return DuckDBArray.class.getName();
 		default:
 			return String.class.getName();
 		}

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBTimestamp.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBTimestamp.java
@@ -61,7 +61,7 @@ public class DuckDBTimestamp {
 	}
 
 	private static LocalTime toLocalTime(long timeMicros) {
-		return LocalTime.ofSecondOfDay(micros2seconds(timeMicros));
+		return LocalTime.ofNanoOfDay(timeMicros * 1000);
 	}
 
 	public static OffsetDateTime toOffsetDateTime(long timeMicros) {

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
@@ -37,7 +37,14 @@ public class DuckDBVector {
 		return buf;
 	}
 
+	private boolean check_and_null(int columnIndex) {
+		return nullmask[columnIndex];
+	}
+
 	public long getLong(int columnIndex) throws SQLException {
+		if (check_and_null(columnIndex)) {
+			return 0;
+		}
 		if (duckdb_type == DuckDBColumnType.BIGINT || duckdb_type == DuckDBColumnType.TIMESTAMP) {
 			return getbuf(columnIndex, 8).getLong();
 		}
@@ -49,6 +56,9 @@ public class DuckDBVector {
 	}
 
 	public int getInt(int columnIndex) throws SQLException {
+		if (check_and_null(columnIndex)) {
+			return 0;
+		}
 		if (duckdb_type == DuckDBColumnType.INTEGER) {
 			return getbuf(columnIndex, 4).getInt();
 		}

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
@@ -45,7 +45,7 @@ public class DuckDBVector {
 		if (check_and_null(columnIndex)) {
 			return 0;
 		}
-		if (duckdb_type == DuckDBColumnType.BIGINT || duckdb_type == DuckDBColumnType.TIMESTAMP) {
+		if (isType(columnIndex, DuckDBColumnType.BIGINT) || isType(columnIndex, DuckDBColumnType.TIMESTAMP)) {
 			return getbuf(columnIndex, 8).getLong();
 		}
 		Object o = getObject(columnIndex);
@@ -59,7 +59,7 @@ public class DuckDBVector {
 		if (check_and_null(columnIndex)) {
 			return 0;
 		}
-		if (duckdb_type == DuckDBColumnType.INTEGER) {
+		if (isType(columnIndex, DuckDBColumnType.INTEGER)) {
 			return getbuf(columnIndex, 4).getInt();
 		}
 		Object o = getObject(columnIndex);
@@ -67,5 +67,9 @@ public class DuckDBVector {
 			return ((Number) o).intValue();
 		}
 		return Integer.parseInt(o.toString());
+	}
+
+	private boolean isType(int columnIndex, DuckDBColumnType columnType) {
+		return duckdb_type == columnType;
 	}
 }

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
@@ -1,19 +1,48 @@
 package org.duckdb;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 
 public class DuckDBVector {
 	
 	public DuckDBVector(String duckdb_type, int length,  boolean[] nullmask) {
 		super();
-		this.duckdb_type = duckdb_type;
+		this.duckdb_type = DuckDBResultSetMetaData.TypeNameToType(duckdb_type);
 		this.length = length;
 		this.nullmask = nullmask;
 	}
-	protected String duckdb_type;
+	protected DuckDBColumnType duckdb_type;
 	protected int length;
 	protected boolean[] nullmask;
 	protected ByteBuffer constlen_data = null;
 	protected Object[] varlen_data = null;
 
+	public Object getObject(int columnIndex) throws SQLException {
+		switch (duckdb_type) {
+		case INTEGER:
+			return getInt(columnIndex);
+		default:
+			throw new SQLFeatureNotSupportedException(duckdb_type.toString());
+		}
+	}
+
+	protected ByteBuffer getbuf(int columnIndex, int typeWidth) {
+		ByteBuffer buf = constlen_data;
+		buf.order(ByteOrder.LITTLE_ENDIAN);
+		buf.position(columnIndex * typeWidth);
+		return buf;
+	}
+
+	public int getInt(int columnIndex) throws SQLException {
+		if (duckdb_type == DuckDBColumnType.INTEGER) {
+			return getbuf(columnIndex, 4).getInt();
+		}
+		Object o = getObject(columnIndex);
+		if (o instanceof Number) {
+			return ((Number) o).intValue();
+		}
+		return Integer.parseInt(o.toString());
+	}
 }

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
@@ -17,26 +17,25 @@ import java.time.OffsetTime;
 import java.util.Calendar;
 import java.util.UUID;
 
-public class DuckDBVector {
+class DuckDBVector {
 	// Constant to construct BigDecimals from hugeint_t
 	private final static BigDecimal ULONG_MULTIPLIER = new BigDecimal("18446744073709551616");
 
-	private final DuckDBColumnTypeMetaData meta;
-
-	public DuckDBVector(String duckdb_type, int length,  boolean[] nullmask) {
+	DuckDBVector(String duckdb_type, int length, boolean[] nullmask) {
 		super();
 		this.duckdb_type = DuckDBResultSetMetaData.TypeNameToType(duckdb_type);
 		this.meta = this.duckdb_type == DuckDBColumnType.DECIMAL ? DuckDBColumnTypeMetaData.parseColumnTypeMetadata(duckdb_type) : null;
 		this.length = length;
 		this.nullmask = nullmask;
 	}
+	private final DuckDBColumnTypeMetaData meta;
 	protected DuckDBColumnType duckdb_type;
 	protected int length;
 	protected boolean[] nullmask;
 	protected ByteBuffer constlen_data = null;
 	protected Object[] varlen_data = null;
 
-	public Object getObject(int columnIndex) throws SQLException {
+	Object getObject(int columnIndex) throws SQLException {
 		if (check_and_null(columnIndex)) {
 			return null;
 		}
@@ -171,14 +170,14 @@ public class DuckDBVector {
 		return UUID.fromString(o.toString());
 	}
 
-	public String getLazyString(int idx) {
+	String getLazyString(int idx) {
 		if (check_and_null(idx)) {
 			return null;
 		}
 		return (String) varlen_data[idx];
 	}
 
-	public Array getArray(int columnIndex) throws SQLException {
+	Array getArray(int columnIndex) throws SQLException {
 		if (check_and_null(columnIndex)) {
 			return null;
 		}
@@ -188,7 +187,7 @@ public class DuckDBVector {
 		throw new SQLFeatureNotSupportedException("getArray");
 	}
 
-	public Blob getBlob(int columnIndex) throws SQLException {
+	Blob getBlob(int columnIndex) throws SQLException {
 		if (check_and_null(columnIndex)) {
 			return null;
 		}
@@ -199,7 +198,7 @@ public class DuckDBVector {
 		throw new SQLFeatureNotSupportedException("getBlob");
 	}
 
-	public JsonNode getJsonObject(int idx) {
+	JsonNode getJsonObject(int idx) {
 		if (check_and_null(idx)) {
 			return null;
 		}
@@ -207,7 +206,7 @@ public class DuckDBVector {
 		return result == null ? null : new JsonNode(result);
 	}
 
-	public Date getDate(int idx) {
+	Date getDate(int idx) {
 		if (check_and_null(idx)) {
 			return null;
 		}
@@ -223,14 +222,14 @@ public class DuckDBVector {
 		}
 	}
 
-	public OffsetTime getOffsetTime(int columnIndex) {
+	OffsetTime getOffsetTime(int columnIndex) {
 		if (check_and_null(columnIndex)) {
 			return null;
 		}
 		return DuckDBTimestamp.toOffsetTime(getbuf(columnIndex, 8).getLong());
 	}
 
-	public Time getTime(int idx) {
+	Time getTime(int idx) {
 		// TODO: load from native format
 		String string_value = getLazyString(idx);
 		if (string_value == null) {
@@ -243,7 +242,7 @@ public class DuckDBVector {
 		}
 	}
 
-	public Boolean getBoolean(int idx) throws SQLException {
+	Boolean getBoolean(int idx) throws SQLException {
 		if (check_and_null(idx)) {
 			return false;
 		}
@@ -269,7 +268,7 @@ public class DuckDBVector {
 		return nullmask[columnIndex];
 	}
 
-	public long getLong(int columnIndex) throws SQLException {
+	long getLong(int columnIndex) throws SQLException {
 		if (check_and_null(columnIndex)) {
 			return 0;
 		}
@@ -283,7 +282,7 @@ public class DuckDBVector {
 		return Long.parseLong(o.toString());
 	}
 
-	public int getInt(int columnIndex) throws SQLException {
+	int getInt(int columnIndex) throws SQLException {
 		if (check_and_null(columnIndex)) {
 			return 0;
 		}
@@ -297,7 +296,7 @@ public class DuckDBVector {
 		return Integer.parseInt(o.toString());
 	}
 
-	public short getUint8(int columnIndex) throws SQLException {
+	short getUint8(int columnIndex) throws SQLException {
 		if (check_and_null(columnIndex)) {
 			return 0;
 		}
@@ -309,7 +308,7 @@ public class DuckDBVector {
 		throw new SQLFeatureNotSupportedException("getUint8");
 	}
 
-	public long getUint32(int columnIndex) throws SQLException {
+	long getUint32(int columnIndex) throws SQLException {
 		if (check_and_null(columnIndex)) {
 			return 0;
 		}
@@ -322,7 +321,7 @@ public class DuckDBVector {
 		throw new SQLFeatureNotSupportedException("getUint32");
 	}
 
-	public int getUint16(int columnIndex) throws SQLException {
+	int getUint16(int columnIndex) throws SQLException {
 		if (check_and_null(columnIndex)) {
 			return 0;
 		}
@@ -335,7 +334,7 @@ public class DuckDBVector {
 		throw new SQLFeatureNotSupportedException("getUint16");
 	}
 
-	public BigInteger getUint64(int columnIndex) throws SQLException {
+	BigInteger getUint64(int columnIndex) throws SQLException {
 		if (check_and_null(columnIndex)) {
 			return BigInteger.ZERO;
 		}
@@ -351,7 +350,7 @@ public class DuckDBVector {
 		throw new SQLFeatureNotSupportedException("getUint64");
 	}
 
-	public double getDouble(int columnIndex) throws SQLException {
+	double getDouble(int columnIndex) throws SQLException {
 		if (check_and_null(columnIndex)) {
 			return Double.NaN;
 		}
@@ -365,7 +364,7 @@ public class DuckDBVector {
 		return Double.parseDouble(o.toString());
 	}
 
-	public byte getByte(int columnIndex) throws SQLException {
+	byte getByte(int columnIndex) throws SQLException {
 		if (check_and_null(columnIndex)) {
 			return 0;
 		}
@@ -379,7 +378,7 @@ public class DuckDBVector {
 		return Byte.parseByte(o.toString());
 	}
 
-	public short getShort(int columnIndex) throws SQLException {
+	short getShort(int columnIndex) throws SQLException {
 		if (check_and_null(columnIndex)) {
 			return 0;
 		}
@@ -393,7 +392,7 @@ public class DuckDBVector {
 		return Short.parseShort(o.toString());
 	}
 
-	public BigInteger getHugeint(int columnIndex) throws SQLException {
+	BigInteger getHugeint(int columnIndex) throws SQLException {
 		if (check_and_null(columnIndex)) {
 			return BigInteger.ZERO;
 		}
@@ -429,7 +428,7 @@ public class DuckDBVector {
 		return duckdb_type == columnType;
 	}
 
-	public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
+	Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
 		if (check_and_null(columnIndex)) {
 			return null;
 		}
@@ -451,7 +450,7 @@ public class DuckDBVector {
 		return Timestamp.valueOf(o.toString());
 	}
 
-	public LocalDateTime getLocalDateTime(int columnIndex) throws SQLException {
+	LocalDateTime getLocalDateTime(int columnIndex) throws SQLException {
 		if (check_and_null(columnIndex)) {
 			return null;
 		}

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
@@ -96,7 +96,7 @@ class DuckDBVector {
 		if (check_and_null(columnIndex)) {
 			return null;
 		}
-		if (isType(columnIndex, DuckDBColumnType.DECIMAL)) {
+		if (isType(DuckDBColumnType.DECIMAL)) {
 			switch (meta.type_size) {
 				case 16:
 					return new BigDecimal((int) getbuf(columnIndex, 2).getShort())
@@ -125,7 +125,7 @@ class DuckDBVector {
 			return null;
 		}
 
-		if (isType(columnIndex, DuckDBColumnType.TIMESTAMP_WITH_TIME_ZONE)) {
+		if (isType(DuckDBColumnType.TIMESTAMP_WITH_TIME_ZONE)) {
 			return DuckDBTimestamp.toOffsetDateTime(getbuf(columnIndex, 8).getLong());
 		}
 		Object o = getObject(columnIndex);
@@ -137,16 +137,16 @@ class DuckDBVector {
 			return null;
 		}
 
-		if (isType(columnIndex, DuckDBColumnType.TIMESTAMP)) {
+		if (isType(DuckDBColumnType.TIMESTAMP)) {
 			return DuckDBTimestamp.toSqlTimestamp(getbuf(columnIndex, 8).getLong());
 		}
-		if (isType(columnIndex, DuckDBColumnType.TIMESTAMP_MS)) {
+		if (isType(DuckDBColumnType.TIMESTAMP_MS)) {
 			return DuckDBTimestamp.toSqlTimestamp(getbuf(columnIndex, 8).getLong() * 1000);
 		}
-		if (isType(columnIndex, DuckDBColumnType.TIMESTAMP_NS)) {
+		if (isType(DuckDBColumnType.TIMESTAMP_NS)) {
 			return DuckDBTimestamp.toSqlTimestampNanos(getbuf(columnIndex, 8).getLong());
 		}
-		if (isType(columnIndex, DuckDBColumnType.TIMESTAMP_S)) {
+		if (isType(DuckDBColumnType.TIMESTAMP_S)) {
 			return DuckDBTimestamp.toSqlTimestamp(getbuf(columnIndex, 8).getLong() * 1_000_000);
 		}
 		Object o = getObject(columnIndex);
@@ -158,7 +158,7 @@ class DuckDBVector {
 			return null;
 		}
 
-		if (isType(columnIndex, DuckDBColumnType.UUID)) {
+		if (isType(DuckDBColumnType.UUID)) {
 			ByteBuffer buffer = getbuf(columnIndex, 16);
 			long leastSignificantBits = buffer.getLong();
 
@@ -181,7 +181,7 @@ class DuckDBVector {
 		if (check_and_null(columnIndex)) {
 			return null;
 		}
-		if (isType(columnIndex, DuckDBColumnType.LIST)) {
+		if (isType(DuckDBColumnType.LIST)) {
 			return (Array) varlen_data[columnIndex];
 		}
 		throw new SQLFeatureNotSupportedException("getArray");
@@ -191,7 +191,7 @@ class DuckDBVector {
 		if (check_and_null(columnIndex)) {
 			return null;
 		}
-		if (isType(columnIndex, DuckDBColumnType.BLOB)) {
+		if (isType(DuckDBColumnType.BLOB)) {
 			return new DuckDBResultSet.DuckDBBlobResult((ByteBuffer) varlen_data[columnIndex]);
 		}
 
@@ -246,7 +246,7 @@ class DuckDBVector {
 		if (check_and_null(idx)) {
 			return false;
 		}
-		if (isType(idx, DuckDBColumnType.BOOLEAN)) {
+		if (isType(DuckDBColumnType.BOOLEAN)) {
 			return getbuf(idx, 1).get() == 1;
 		}
 		Object o = getObject(idx);
@@ -272,7 +272,7 @@ class DuckDBVector {
 		if (check_and_null(columnIndex)) {
 			return 0;
 		}
-		if (isType(columnIndex, DuckDBColumnType.BIGINT) || isType(columnIndex, DuckDBColumnType.TIMESTAMP)) {
+		if (isType(DuckDBColumnType.BIGINT) || isType(DuckDBColumnType.TIMESTAMP)) {
 			return getbuf(columnIndex, 8).getLong();
 		}
 		Object o = getObject(columnIndex);
@@ -286,7 +286,7 @@ class DuckDBVector {
 		if (check_and_null(columnIndex)) {
 			return 0;
 		}
-		if (isType(columnIndex, DuckDBColumnType.INTEGER)) {
+		if (isType(DuckDBColumnType.INTEGER)) {
 			return getbuf(columnIndex, 4).getInt();
 		}
 		Object o = getObject(columnIndex);
@@ -300,7 +300,7 @@ class DuckDBVector {
 		if (check_and_null(columnIndex)) {
 			return 0;
 		}
-		if (isType(columnIndex, DuckDBColumnType.UTINYINT)) {
+		if (isType(DuckDBColumnType.UTINYINT)) {
 			ByteBuffer buf = ByteBuffer.allocate(2);
 			getbuf(columnIndex, 1).get(buf.array(), 1, 1);
 			return buf.getShort();
@@ -312,7 +312,7 @@ class DuckDBVector {
 		if (check_and_null(columnIndex)) {
 			return 0;
 		}
-		if (isType(columnIndex, DuckDBColumnType.UINTEGER)) {
+		if (isType(DuckDBColumnType.UINTEGER)) {
 			ByteBuffer buf = ByteBuffer.allocate(8);
 			buf.order(ByteOrder.LITTLE_ENDIAN);
 			getbuf(columnIndex, 4).get(buf.array(), 0, 4);
@@ -325,7 +325,7 @@ class DuckDBVector {
 		if (check_and_null(columnIndex)) {
 			return 0;
 		}
-		if (isType(columnIndex, DuckDBColumnType.USMALLINT)) {
+		if (isType(DuckDBColumnType.USMALLINT)) {
 			ByteBuffer buf = ByteBuffer.allocate(4);
 			buf.order(ByteOrder.LITTLE_ENDIAN);
 			getbuf(columnIndex, 2).get(buf.array(), 0, 2);
@@ -338,7 +338,7 @@ class DuckDBVector {
 		if (check_and_null(columnIndex)) {
 			return BigInteger.ZERO;
 		}
-		if (isType(columnIndex, DuckDBColumnType.UBIGINT)) {
+		if (isType(DuckDBColumnType.UBIGINT)) {
 			byte[] buf_res = new byte[16];
 			byte[] buf = new byte[8];
 			getbuf(columnIndex, 8).get(buf);
@@ -354,7 +354,7 @@ class DuckDBVector {
 		if (check_and_null(columnIndex)) {
 			return Double.NaN;
 		}
-		if (isType(columnIndex, DuckDBColumnType.DOUBLE)) {
+		if (isType(DuckDBColumnType.DOUBLE)) {
 			return getbuf(columnIndex, 8).getDouble();
 		}
 		Object o = getObject(columnIndex);
@@ -368,7 +368,7 @@ class DuckDBVector {
 		if (check_and_null(columnIndex)) {
 			return 0;
 		}
-		if (isType(columnIndex, DuckDBColumnType.TINYINT)) {
+		if (isType(DuckDBColumnType.TINYINT)) {
 			return getbuf(columnIndex, 1).get();
 		}
 		Object o = getObject(columnIndex);
@@ -382,7 +382,7 @@ class DuckDBVector {
 		if (check_and_null(columnIndex)) {
 			return 0;
 		}
-		if (isType(columnIndex, DuckDBColumnType.SMALLINT)) {
+		if (isType(DuckDBColumnType.SMALLINT)) {
 			return getbuf(columnIndex, 2).getShort();
 		}
 		Object o = getObject(columnIndex);
@@ -396,7 +396,7 @@ class DuckDBVector {
 		if (check_and_null(columnIndex)) {
 			return BigInteger.ZERO;
 		}
-		if (isType(columnIndex, DuckDBColumnType.HUGEINT)) {
+		if (isType(DuckDBColumnType.HUGEINT)) {
 			byte[] buf = new byte[16];
 			getbuf(columnIndex, 16).get(buf);
 			for (int i = 0; i < 8; i++) {
@@ -410,11 +410,11 @@ class DuckDBVector {
 		return new BigInteger(o.toString());
 	}
 
-	public float getFloat(int columnIndex) throws SQLException {
+	float getFloat(int columnIndex) throws SQLException {
 		if (check_and_null(columnIndex)) {
 			return Float.NaN;
 		}
-		if (isType(columnIndex, DuckDBColumnType.FLOAT)) {
+		if (isType(DuckDBColumnType.FLOAT)) {
 			return getbuf(columnIndex, 4).getFloat();
 		}
 		Object o = getObject(columnIndex);
@@ -424,7 +424,7 @@ class DuckDBVector {
 		return Float.parseFloat(o.toString());
 	}
 
-	private boolean isType(int columnIndex, DuckDBColumnType columnType) {
+	private boolean isType(DuckDBColumnType columnType) {
 		return duckdb_type == columnType;
 	}
 
@@ -434,16 +434,16 @@ class DuckDBVector {
 		}
 		// Our raw data is already a proper count of units since the epoch
 		// So just construct the SQL Timestamp.
-		if (isType(columnIndex, DuckDBColumnType.TIMESTAMP)) {
+		if (isType(DuckDBColumnType.TIMESTAMP)) {
 			return DuckDBTimestamp.fromMicroInstant(getbuf(columnIndex, 8).getLong(columnIndex));
 		}
-		if (isType(columnIndex, DuckDBColumnType.TIMESTAMP_MS)) {
+		if (isType(DuckDBColumnType.TIMESTAMP_MS)) {
 			return DuckDBTimestamp.fromMilliInstant(getbuf(columnIndex, 8).getLong());
 		}
-		if (isType(columnIndex, DuckDBColumnType.TIMESTAMP_NS)) {
+		if (isType(DuckDBColumnType.TIMESTAMP_NS)) {
 			return DuckDBTimestamp.fromNanoInstant(getbuf(columnIndex, 8).getLong());
 		}
-		if (isType(columnIndex, DuckDBColumnType.TIMESTAMP_S)) {
+		if (isType(DuckDBColumnType.TIMESTAMP_S)) {
 			return DuckDBTimestamp.fromSecondInstant(getbuf(columnIndex, 8).getLong());
 		}
 		Object o = getObject(columnIndex);
@@ -454,7 +454,7 @@ class DuckDBVector {
 		if (check_and_null(columnIndex)) {
 			return null;
 		}
-		if (isType(columnIndex, DuckDBColumnType.TIMESTAMP)) {
+		if (isType(DuckDBColumnType.TIMESTAMP)) {
 			return DuckDBTimestamp.toLocalDateTime(getbuf(columnIndex, 8).getLong());
 		}
 		Object o = getObject(columnIndex);

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
@@ -3,6 +3,7 @@ package org.duckdb;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.sql.SQLException;
+import java.math.BigInteger;
 import java.sql.SQLFeatureNotSupportedException;
 
 public class DuckDBVector {
@@ -21,10 +22,28 @@ public class DuckDBVector {
 
 	public Object getObject(int columnIndex) throws SQLException {
 		switch (duckdb_type) {
+		case TINYINT:
+			return getByte(columnIndex);
+		case SMALLINT:
+			return getShort(columnIndex);
 		case INTEGER:
 			return getInt(columnIndex);
 		case BIGINT:
 			return getLong(columnIndex);
+		case HUGEINT:
+			return getHugeint(columnIndex);
+		case UTINYINT:
+			return getUint8(columnIndex);
+		case USMALLINT:
+			return getUint16(columnIndex);
+		case UINTEGER:
+			return getUint32(columnIndex);
+		case UBIGINT:
+			return getUint64(columnIndex);
+		case FLOAT:
+			return getFloat(columnIndex);
+		case DOUBLE:
+			return getDouble(columnIndex);
 		default:
 			throw new SQLFeatureNotSupportedException(duckdb_type.toString());
 		}
@@ -67,6 +86,134 @@ public class DuckDBVector {
 			return ((Number) o).intValue();
 		}
 		return Integer.parseInt(o.toString());
+	}
+
+	public short getUint8(int columnIndex) throws SQLException {
+		if (check_and_null(columnIndex)) {
+			return 0;
+		}
+		if (isType(columnIndex, DuckDBColumnType.UTINYINT)) {
+			ByteBuffer buf = ByteBuffer.allocate(2);
+			getbuf(columnIndex, 1).get(buf.array(), 1, 1);
+			return buf.getShort();
+		}
+		throw new SQLFeatureNotSupportedException("getUint8");
+	}
+
+	public long getUint32(int columnIndex) throws SQLException {
+		if (check_and_null(columnIndex)) {
+			return 0;
+		}
+		if (isType(columnIndex, DuckDBColumnType.UINTEGER)) {
+			ByteBuffer buf = ByteBuffer.allocate(8);
+			buf.order(ByteOrder.LITTLE_ENDIAN);
+			getbuf(columnIndex, 4).get(buf.array(), 0, 4);
+			return buf.getLong();
+		}
+		throw new SQLFeatureNotSupportedException("getUint32");
+	}
+
+	public int getUint16(int columnIndex) throws SQLException {
+		if (check_and_null(columnIndex)) {
+			return 0;
+		}
+		if (isType(columnIndex, DuckDBColumnType.USMALLINT)) {
+			ByteBuffer buf = ByteBuffer.allocate(4);
+			buf.order(ByteOrder.LITTLE_ENDIAN);
+			getbuf(columnIndex, 2).get(buf.array(), 0, 2);
+			return buf.getInt();
+		}
+		throw new SQLFeatureNotSupportedException("getUint16");
+	}
+
+	public BigInteger getUint64(int columnIndex) throws SQLException {
+		if (check_and_null(columnIndex)) {
+			return BigInteger.ZERO;
+		}
+		if (isType(columnIndex, DuckDBColumnType.UBIGINT)) {
+			byte[] buf_res = new byte[16];
+			byte[] buf = new byte[8];
+			getbuf(columnIndex, 8).get(buf);
+			for (int i = 0; i < 8; i++) {
+				buf_res[i + 8] = buf[7 - i];
+			}
+			return new BigInteger(buf_res);
+		}
+		throw new SQLFeatureNotSupportedException("getUint64");
+	}
+
+	public double getDouble(int columnIndex) throws SQLException {
+		if (check_and_null(columnIndex)) {
+			return Double.NaN;
+		}
+		if (isType(columnIndex, DuckDBColumnType.DOUBLE)) {
+			return getbuf(columnIndex, 8).getDouble();
+		}
+		Object o = getObject(columnIndex);
+		if (o instanceof Number) {
+			return ((Number) o).doubleValue();
+		}
+		return Double.parseDouble(o.toString());
+	}
+
+	public byte getByte(int columnIndex) throws SQLException {
+		if (check_and_null(columnIndex)) {
+			return 0;
+		}
+		if (isType(columnIndex, DuckDBColumnType.TINYINT)) {
+			return getbuf(columnIndex, 1).get();
+		}
+		Object o = getObject(columnIndex);
+		if (o instanceof Number) {
+			return ((Number) o).byteValue();
+		}
+		return Byte.parseByte(o.toString());
+	}
+
+	public short getShort(int columnIndex) throws SQLException {
+		if (check_and_null(columnIndex)) {
+			return 0;
+		}
+		if (isType(columnIndex, DuckDBColumnType.SMALLINT)) {
+			return getbuf(columnIndex, 2).getShort();
+		}
+		Object o = getObject(columnIndex);
+		if (o instanceof Number) {
+			return ((Number) o).shortValue();
+		}
+		return Short.parseShort(o.toString());
+	}
+
+	public BigInteger getHugeint(int columnIndex) throws SQLException {
+		if (check_and_null(columnIndex)) {
+			return BigInteger.ZERO;
+		}
+		if (isType(columnIndex, DuckDBColumnType.HUGEINT)) {
+			byte[] buf = new byte[16];
+			getbuf(columnIndex, 16).get(buf);
+			for (int i = 0; i < 8; i++) {
+				byte keep = buf[i];
+				buf[i] = buf[15 - i];
+				buf[15 - i] = keep;
+			}
+			return new BigInteger(buf);
+		}
+		Object o = getObject(columnIndex);
+		return new BigInteger(o.toString());
+	}
+
+	public float getFloat(int columnIndex) throws SQLException {
+		if (check_and_null(columnIndex)) {
+			return Float.NaN;
+		}
+		if (isType(columnIndex, DuckDBColumnType.FLOAT)) {
+			return getbuf(columnIndex, 4).getFloat();
+		}
+		Object o = getObject(columnIndex);
+		if (o instanceof Number) {
+			return ((Number) o).floatValue();
+		}
+		return Float.parseFloat(o.toString());
 	}
 
 	private boolean isType(int columnIndex, DuckDBColumnType columnType) {

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
@@ -35,80 +35,80 @@ class DuckDBVector {
 	protected ByteBuffer constlen_data = null;
 	protected Object[] varlen_data = null;
 
-	Object getObject(int columnIndex) throws SQLException {
-		if (check_and_null(columnIndex)) {
+	Object getObject(int idx) throws SQLException {
+		if (check_and_null(idx)) {
 			return null;
 		}
 		switch (duckdb_type) {
 			case BOOLEAN:
-				return getBoolean(columnIndex);
+				return getBoolean(idx);
 			case TINYINT:
-				return getByte(columnIndex);
+				return getByte(idx);
 			case SMALLINT:
-				return getShort(columnIndex);
+				return getShort(idx);
 			case INTEGER:
-				return getInt(columnIndex);
+				return getInt(idx);
 			case BIGINT:
-				return getLong(columnIndex);
+				return getLong(idx);
 			case HUGEINT:
-				return getHugeint(columnIndex);
+				return getHugeint(idx);
 			case UTINYINT:
-				return getUint8(columnIndex);
+				return getUint8(idx);
 			case USMALLINT:
-				return getUint16(columnIndex);
+				return getUint16(idx);
 			case UINTEGER:
-				return getUint32(columnIndex);
+				return getUint32(idx);
 			case UBIGINT:
-				return getUint64(columnIndex);
+				return getUint64(idx);
 			case FLOAT:
-				return getFloat(columnIndex);
+				return getFloat(idx);
 			case DOUBLE:
-				return getDouble(columnIndex);
+				return getDouble(idx);
 			case DECIMAL:
-				return getBigDecimal(columnIndex);
+				return getBigDecimal(idx);
 			case TIME:
-				return getTime(columnIndex);
+				return getTime(idx);
 			case TIME_WITH_TIME_ZONE:
-				return getOffsetTime(columnIndex);
+				return getOffsetTime(idx);
 			case DATE:
-				return getDate(columnIndex);
+				return getDate(idx);
 			case TIMESTAMP:
 			case TIMESTAMP_NS:
 			case TIMESTAMP_S:
 			case TIMESTAMP_MS:
-				return getTimestamp(columnIndex);
+				return getTimestamp(idx);
 			case TIMESTAMP_WITH_TIME_ZONE:
-				return getOffsetDateTime(columnIndex);
+				return getOffsetDateTime(idx);
 			case JSON:
-				return getJsonObject(columnIndex);
+				return getJsonObject(idx);
 			case BLOB:
-				return getBlob(columnIndex);
+				return getBlob(idx);
 			case UUID:
-				return getUuid(columnIndex);
+				return getUuid(idx);
 			case LIST:
-				return getArray(columnIndex);
+				return getArray(idx);
 			default:
-				return getLazyString(columnIndex);
+				return getLazyString(idx);
 		}
 	}
 
-	BigDecimal getBigDecimal(int columnIndex) throws SQLException {
-		if (check_and_null(columnIndex)) {
+	BigDecimal getBigDecimal(int idx) throws SQLException {
+		if (check_and_null(idx)) {
 			return null;
 		}
 		if (isType(DuckDBColumnType.DECIMAL)) {
 			switch (meta.type_size) {
 				case 16:
-					return new BigDecimal((int) getbuf(columnIndex, 2).getShort())
+					return new BigDecimal((int) getbuf(idx, 2).getShort())
 							.scaleByPowerOfTen(meta.scale * -1);
 				case 32:
-					return new BigDecimal(getbuf(columnIndex, 4).getInt())
+					return new BigDecimal(getbuf(idx, 4).getInt())
 							.scaleByPowerOfTen(meta.scale * -1);
 				case 64:
-					return new BigDecimal(getbuf(columnIndex, 8).getLong())
+					return new BigDecimal(getbuf(idx, 8).getLong())
 							.scaleByPowerOfTen(meta.scale * -1);
 				case 128:
-					ByteBuffer buf = getbuf(columnIndex, 16);
+					ByteBuffer buf = getbuf(idx, 16);
 					long lower = buf.getLong();
 					long upper = buf.getLong();
 					return new BigDecimal(upper).multiply(ULONG_MULTIPLIER)
@@ -116,57 +116,57 @@ class DuckDBVector {
 							.scaleByPowerOfTen(meta.scale * -1);
 			}
 		}
-		Object o = getObject(columnIndex);
+		Object o = getObject(idx);
 		return new BigDecimal(o.toString());
 	}
 
-	OffsetDateTime getOffsetDateTime(int columnIndex) throws SQLException {
-		if (check_and_null(columnIndex)) {
+	OffsetDateTime getOffsetDateTime(int idx) throws SQLException {
+		if (check_and_null(idx)) {
 			return null;
 		}
 
 		if (isType(DuckDBColumnType.TIMESTAMP_WITH_TIME_ZONE)) {
-			return DuckDBTimestamp.toOffsetDateTime(getbuf(columnIndex, 8).getLong());
+			return DuckDBTimestamp.toOffsetDateTime(getbuf(idx, 8).getLong());
 		}
-		Object o = getObject(columnIndex);
+		Object o = getObject(idx);
 		return OffsetDateTime.parse(o.toString());
 	}
 
-	Timestamp getTimestamp(int columnIndex) throws SQLException {
-		if (check_and_null(columnIndex)) {
+	Timestamp getTimestamp(int idx) throws SQLException {
+		if (check_and_null(idx)) {
 			return null;
 		}
 
 		if (isType(DuckDBColumnType.TIMESTAMP)) {
-			return DuckDBTimestamp.toSqlTimestamp(getbuf(columnIndex, 8).getLong());
+			return DuckDBTimestamp.toSqlTimestamp(getbuf(idx, 8).getLong());
 		}
 		if (isType(DuckDBColumnType.TIMESTAMP_MS)) {
-			return DuckDBTimestamp.toSqlTimestamp(getbuf(columnIndex, 8).getLong() * 1000);
+			return DuckDBTimestamp.toSqlTimestamp(getbuf(idx, 8).getLong() * 1000);
 		}
 		if (isType(DuckDBColumnType.TIMESTAMP_NS)) {
-			return DuckDBTimestamp.toSqlTimestampNanos(getbuf(columnIndex, 8).getLong());
+			return DuckDBTimestamp.toSqlTimestampNanos(getbuf(idx, 8).getLong());
 		}
 		if (isType(DuckDBColumnType.TIMESTAMP_S)) {
-			return DuckDBTimestamp.toSqlTimestamp(getbuf(columnIndex, 8).getLong() * 1_000_000);
+			return DuckDBTimestamp.toSqlTimestamp(getbuf(idx, 8).getLong() * 1_000_000);
 		}
-		Object o = getObject(columnIndex);
+		Object o = getObject(idx);
 		return Timestamp.valueOf(o.toString());
 	}
 
-	UUID getUuid(int columnIndex) throws SQLException {
-		if (check_and_null(columnIndex)) {
+	UUID getUuid(int idx) throws SQLException {
+		if (check_and_null(idx)) {
 			return null;
 		}
 
 		if (isType(DuckDBColumnType.UUID)) {
-			ByteBuffer buffer = getbuf(columnIndex, 16);
+			ByteBuffer buffer = getbuf(idx, 16);
 			long leastSignificantBits = buffer.getLong();
 
 			// Account for unsigned
 			long mostSignificantBits = buffer.getLong() - Long.MAX_VALUE - 1;
 			return new UUID(mostSignificantBits, leastSignificantBits);
 		}
-		Object o = getObject(columnIndex);
+		Object o = getObject(idx);
 		return UUID.fromString(o.toString());
 	}
 
@@ -177,22 +177,22 @@ class DuckDBVector {
 		return (String) varlen_data[idx];
 	}
 
-	Array getArray(int columnIndex) throws SQLException {
-		if (check_and_null(columnIndex)) {
+	Array getArray(int idx) throws SQLException {
+		if (check_and_null(idx)) {
 			return null;
 		}
 		if (isType(DuckDBColumnType.LIST)) {
-			return (Array) varlen_data[columnIndex];
+			return (Array) varlen_data[idx];
 		}
 		throw new SQLFeatureNotSupportedException("getArray");
 	}
 
-	Blob getBlob(int columnIndex) throws SQLException {
-		if (check_and_null(columnIndex)) {
+	Blob getBlob(int idx) throws SQLException {
+		if (check_and_null(idx)) {
 			return null;
 		}
 		if (isType(DuckDBColumnType.BLOB)) {
-			return new DuckDBResultSet.DuckDBBlobResult((ByteBuffer) varlen_data[columnIndex]);
+			return new DuckDBResultSet.DuckDBBlobResult((ByteBuffer) varlen_data[idx]);
 		}
 
 		throw new SQLFeatureNotSupportedException("getBlob");
@@ -222,11 +222,11 @@ class DuckDBVector {
 		}
 	}
 
-	OffsetTime getOffsetTime(int columnIndex) {
-		if (check_and_null(columnIndex)) {
+	OffsetTime getOffsetTime(int idx) {
+		if (check_and_null(idx)) {
 			return null;
 		}
-		return DuckDBTimestamp.toOffsetTime(getbuf(columnIndex, 8).getLong());
+		return DuckDBTimestamp.toOffsetTime(getbuf(idx, 8).getLong());
 	}
 
 	Time getTime(int idx) {
@@ -257,91 +257,91 @@ class DuckDBVector {
 		return Boolean.parseBoolean(o.toString());
 	}
 
-	protected ByteBuffer getbuf(int columnIndex, int typeWidth) {
+	protected ByteBuffer getbuf(int idx, int typeWidth) {
 		ByteBuffer buf = constlen_data;
 		buf.order(ByteOrder.LITTLE_ENDIAN);
-		buf.position(columnIndex * typeWidth);
+		buf.position(idx * typeWidth);
 		return buf;
 	}
 
-	private boolean check_and_null(int columnIndex) {
-		return nullmask[columnIndex];
+	private boolean check_and_null(int idx) {
+		return nullmask[idx];
 	}
 
-	long getLong(int columnIndex) throws SQLException {
-		if (check_and_null(columnIndex)) {
+	long getLong(int idx) throws SQLException {
+		if (check_and_null(idx)) {
 			return 0;
 		}
 		if (isType(DuckDBColumnType.BIGINT) || isType(DuckDBColumnType.TIMESTAMP)) {
-			return getbuf(columnIndex, 8).getLong();
+			return getbuf(idx, 8).getLong();
 		}
-		Object o = getObject(columnIndex);
+		Object o = getObject(idx);
 		if (o instanceof Number) {
 			return ((Number) o).longValue();
 		}
 		return Long.parseLong(o.toString());
 	}
 
-	int getInt(int columnIndex) throws SQLException {
-		if (check_and_null(columnIndex)) {
+	int getInt(int idx) throws SQLException {
+		if (check_and_null(idx)) {
 			return 0;
 		}
 		if (isType(DuckDBColumnType.INTEGER)) {
-			return getbuf(columnIndex, 4).getInt();
+			return getbuf(idx, 4).getInt();
 		}
-		Object o = getObject(columnIndex);
+		Object o = getObject(idx);
 		if (o instanceof Number) {
 			return ((Number) o).intValue();
 		}
 		return Integer.parseInt(o.toString());
 	}
 
-	short getUint8(int columnIndex) throws SQLException {
-		if (check_and_null(columnIndex)) {
+	short getUint8(int idx) throws SQLException {
+		if (check_and_null(idx)) {
 			return 0;
 		}
 		if (isType(DuckDBColumnType.UTINYINT)) {
 			ByteBuffer buf = ByteBuffer.allocate(2);
-			getbuf(columnIndex, 1).get(buf.array(), 1, 1);
+			getbuf(idx, 1).get(buf.array(), 1, 1);
 			return buf.getShort();
 		}
 		throw new SQLFeatureNotSupportedException("getUint8");
 	}
 
-	long getUint32(int columnIndex) throws SQLException {
-		if (check_and_null(columnIndex)) {
+	long getUint32(int idx) throws SQLException {
+		if (check_and_null(idx)) {
 			return 0;
 		}
 		if (isType(DuckDBColumnType.UINTEGER)) {
 			ByteBuffer buf = ByteBuffer.allocate(8);
 			buf.order(ByteOrder.LITTLE_ENDIAN);
-			getbuf(columnIndex, 4).get(buf.array(), 0, 4);
+			getbuf(idx, 4).get(buf.array(), 0, 4);
 			return buf.getLong();
 		}
 		throw new SQLFeatureNotSupportedException("getUint32");
 	}
 
-	int getUint16(int columnIndex) throws SQLException {
-		if (check_and_null(columnIndex)) {
+	int getUint16(int idx) throws SQLException {
+		if (check_and_null(idx)) {
 			return 0;
 		}
 		if (isType(DuckDBColumnType.USMALLINT)) {
 			ByteBuffer buf = ByteBuffer.allocate(4);
 			buf.order(ByteOrder.LITTLE_ENDIAN);
-			getbuf(columnIndex, 2).get(buf.array(), 0, 2);
+			getbuf(idx, 2).get(buf.array(), 0, 2);
 			return buf.getInt();
 		}
 		throw new SQLFeatureNotSupportedException("getUint16");
 	}
 
-	BigInteger getUint64(int columnIndex) throws SQLException {
-		if (check_and_null(columnIndex)) {
+	BigInteger getUint64(int idx) throws SQLException {
+		if (check_and_null(idx)) {
 			return BigInteger.ZERO;
 		}
 		if (isType(DuckDBColumnType.UBIGINT)) {
 			byte[] buf_res = new byte[16];
 			byte[] buf = new byte[8];
-			getbuf(columnIndex, 8).get(buf);
+			getbuf(idx, 8).get(buf);
 			for (int i = 0; i < 8; i++) {
 				buf_res[i + 8] = buf[7 - i];
 			}
@@ -350,55 +350,55 @@ class DuckDBVector {
 		throw new SQLFeatureNotSupportedException("getUint64");
 	}
 
-	double getDouble(int columnIndex) throws SQLException {
-		if (check_and_null(columnIndex)) {
+	double getDouble(int idx) throws SQLException {
+		if (check_and_null(idx)) {
 			return Double.NaN;
 		}
 		if (isType(DuckDBColumnType.DOUBLE)) {
-			return getbuf(columnIndex, 8).getDouble();
+			return getbuf(idx, 8).getDouble();
 		}
-		Object o = getObject(columnIndex);
+		Object o = getObject(idx);
 		if (o instanceof Number) {
 			return ((Number) o).doubleValue();
 		}
 		return Double.parseDouble(o.toString());
 	}
 
-	byte getByte(int columnIndex) throws SQLException {
-		if (check_and_null(columnIndex)) {
+	byte getByte(int idx) throws SQLException {
+		if (check_and_null(idx)) {
 			return 0;
 		}
 		if (isType(DuckDBColumnType.TINYINT)) {
-			return getbuf(columnIndex, 1).get();
+			return getbuf(idx, 1).get();
 		}
-		Object o = getObject(columnIndex);
+		Object o = getObject(idx);
 		if (o instanceof Number) {
 			return ((Number) o).byteValue();
 		}
 		return Byte.parseByte(o.toString());
 	}
 
-	short getShort(int columnIndex) throws SQLException {
-		if (check_and_null(columnIndex)) {
+	short getShort(int idx) throws SQLException {
+		if (check_and_null(idx)) {
 			return 0;
 		}
 		if (isType(DuckDBColumnType.SMALLINT)) {
-			return getbuf(columnIndex, 2).getShort();
+			return getbuf(idx, 2).getShort();
 		}
-		Object o = getObject(columnIndex);
+		Object o = getObject(idx);
 		if (o instanceof Number) {
 			return ((Number) o).shortValue();
 		}
 		return Short.parseShort(o.toString());
 	}
 
-	BigInteger getHugeint(int columnIndex) throws SQLException {
-		if (check_and_null(columnIndex)) {
+	BigInteger getHugeint(int idx) throws SQLException {
+		if (check_and_null(idx)) {
 			return BigInteger.ZERO;
 		}
 		if (isType(DuckDBColumnType.HUGEINT)) {
 			byte[] buf = new byte[16];
-			getbuf(columnIndex, 16).get(buf);
+			getbuf(idx, 16).get(buf);
 			for (int i = 0; i < 8; i++) {
 				byte keep = buf[i];
 				buf[i] = buf[15 - i];
@@ -406,18 +406,18 @@ class DuckDBVector {
 			}
 			return new BigInteger(buf);
 		}
-		Object o = getObject(columnIndex);
+		Object o = getObject(idx);
 		return new BigInteger(o.toString());
 	}
 
-	float getFloat(int columnIndex) throws SQLException {
-		if (check_and_null(columnIndex)) {
+	float getFloat(int idx) throws SQLException {
+		if (check_and_null(idx)) {
 			return Float.NaN;
 		}
 		if (isType(DuckDBColumnType.FLOAT)) {
-			return getbuf(columnIndex, 4).getFloat();
+			return getbuf(idx, 4).getFloat();
 		}
-		Object o = getObject(columnIndex);
+		Object o = getObject(idx);
 		if (o instanceof Number) {
 			return ((Number) o).floatValue();
 		}
@@ -428,36 +428,36 @@ class DuckDBVector {
 		return duckdb_type == columnType;
 	}
 
-	Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
-		if (check_and_null(columnIndex)) {
+	Timestamp getTimestamp(int idx, Calendar cal) throws SQLException {
+		if (check_and_null(idx)) {
 			return null;
 		}
 		// Our raw data is already a proper count of units since the epoch
 		// So just construct the SQL Timestamp.
 		if (isType(DuckDBColumnType.TIMESTAMP)) {
-			return DuckDBTimestamp.fromMicroInstant(getbuf(columnIndex, 8).getLong(columnIndex));
+			return DuckDBTimestamp.fromMicroInstant(getbuf(idx, 8).getLong(idx));
 		}
 		if (isType(DuckDBColumnType.TIMESTAMP_MS)) {
-			return DuckDBTimestamp.fromMilliInstant(getbuf(columnIndex, 8).getLong());
+			return DuckDBTimestamp.fromMilliInstant(getbuf(idx, 8).getLong());
 		}
 		if (isType(DuckDBColumnType.TIMESTAMP_NS)) {
-			return DuckDBTimestamp.fromNanoInstant(getbuf(columnIndex, 8).getLong());
+			return DuckDBTimestamp.fromNanoInstant(getbuf(idx, 8).getLong());
 		}
 		if (isType(DuckDBColumnType.TIMESTAMP_S)) {
-			return DuckDBTimestamp.fromSecondInstant(getbuf(columnIndex, 8).getLong());
+			return DuckDBTimestamp.fromSecondInstant(getbuf(idx, 8).getLong());
 		}
-		Object o = getObject(columnIndex);
+		Object o = getObject(idx);
 		return Timestamp.valueOf(o.toString());
 	}
 
-	LocalDateTime getLocalDateTime(int columnIndex) throws SQLException {
-		if (check_and_null(columnIndex)) {
+	LocalDateTime getLocalDateTime(int idx) throws SQLException {
+		if (check_and_null(idx)) {
 			return null;
 		}
 		if (isType(DuckDBColumnType.TIMESTAMP)) {
-			return DuckDBTimestamp.toLocalDateTime(getbuf(columnIndex, 8).getLong());
+			return DuckDBTimestamp.toLocalDateTime(getbuf(idx, 8).getLong());
 		}
-		Object o = getObject(columnIndex);
+		Object o = getObject(idx);
 		return LocalDateTime.parse(o.toString());
 	}
 }

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
@@ -23,6 +23,8 @@ public class DuckDBVector {
 		switch (duckdb_type) {
 		case INTEGER:
 			return getInt(columnIndex);
+		case BIGINT:
+			return getLong(columnIndex);
 		default:
 			throw new SQLFeatureNotSupportedException(duckdb_type.toString());
 		}
@@ -33,6 +35,17 @@ public class DuckDBVector {
 		buf.order(ByteOrder.LITTLE_ENDIAN);
 		buf.position(columnIndex * typeWidth);
 		return buf;
+	}
+
+	public long getLong(int columnIndex) throws SQLException {
+		if (duckdb_type == DuckDBColumnType.BIGINT || duckdb_type == DuckDBColumnType.TIMESTAMP) {
+			return getbuf(columnIndex, 8).getLong();
+		}
+		Object o = getObject(columnIndex);
+		if (o instanceof Number) {
+			return ((Number) o).longValue();
+		}
+		return Long.parseLong(o.toString());
 	}
 
 	public int getInt(int columnIndex) throws SQLException {

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -3214,7 +3214,7 @@ public class TestDuckDBJDBC {
 			 PreparedStatement statement = connection.prepareStatement("select [1]")) {
 			ResultSet rs = statement.executeQuery();
 			assertTrue(rs.next());
-			assertEquals(Arrays.toString((Object[])rs.getArray(1).getArray()), "[1]");
+			assertEquals(Arrays.asList((Object[])rs.getArray(1).getArray()), Arrays.asList(1));
 		}
 	}
 

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -3211,10 +3211,17 @@ public class TestDuckDBJDBC {
 
 	public static void test_list() throws Exception {
 		try (Connection connection = DriverManager.getConnection("jdbc:duckdb:");
-			 PreparedStatement statement = connection.prepareStatement("select [1]")) {
-			ResultSet rs = statement.executeQuery();
-			assertTrue(rs.next());
-			assertEquals(Arrays.asList((Object[])rs.getArray(1).getArray()), Arrays.asList(1));
+			 Statement statement = connection.createStatement()) {
+			try (ResultSet rs = statement.executeQuery("select [1]")) {
+				assertTrue(rs.next());
+				assertEquals(Arrays.asList((Object[])rs.getArray(1).getArray()), Arrays.asList(1));
+			}
+			try (ResultSet rs = statement.executeQuery("select unnest([[1], [42, 69]])")) {
+				assertTrue(rs.next());
+				assertEquals(Arrays.asList((Object[])rs.getArray(1).getArray()), Arrays.asList(1));
+				assertTrue(rs.next());
+				assertEquals(Arrays.asList((Object[])rs.getArray(1).getArray()), Arrays.asList(42, 69));
+			}
 		}
 	}
 

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -1619,12 +1619,12 @@ public class TestDuckDBJDBC {
 		assertEquals(rs.getObject("ts"), Timestamp.valueOf("2019-11-26 21:11:00"));
 		assertEquals(rs.getTimestamp("ts"), Timestamp.valueOf("2019-11-26 21:11:00"));
 
-		assertEquals(rs.getObject("dt"), Date.valueOf("2019-11-26"));
+		assertEquals(rs.getObject("dt"), LocalDate.parse("2019-11-26"));
 		assertEquals(rs.getDate("dt"), Date.valueOf("2019-11-26"));
 
 		assertEquals(rs.getObject("iv"), "5 days");
 
-		assertEquals(rs.getObject("te"), Time.valueOf("21:11:00"));
+		assertEquals(rs.getObject("te"), LocalTime.parse("21:11:00"));
 		assertEquals(rs.getTime("te"), Time.valueOf("21:11:00"));
 
 		assertFalse(rs.next());

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -3289,34 +3289,6 @@ public class TestDuckDBJDBC {
 		}
 	}
 
-	public static void test_get_int() throws Exception {
-		try (Connection connection = DriverManager.getConnection("jdbc:duckdb:"); Statement s = connection.createStatement()) {
-			try (PreparedStatement p = connection.prepareStatement("select * from generate_series(?, ?)")) {
-				p.setInt(1, 0);
-				p.setInt(2, 1);
-
-				try (ResultSet rs = p.executeQuery()) {
-					int i = 0;
-					while (rs.next()) {
-						assertEquals(rs.getInt(1), i++);
-					}
-				}
-			}
-		}
-	}
-
-	public static void test_execute_update() throws Exception {
-		try (Connection connection = DriverManager.getConnection("jdbc:duckdb:"); Statement s = connection.createStatement()) {
-			s.executeUpdate("drop table if exists t");
-			s.executeUpdate("create table t (i int)");
-		
-			try (PreparedStatement p = connection.prepareStatement("insert into t (i) select ?")) {
-				p.setInt(1, 1);
-				p.executeUpdate();
-			}
-		}
-	}
-
 	public static void main(String[] args) throws Exception {
 		// Woo I can do reflection too, take this, JUnit!
 		Method[] methods = TestDuckDBJDBC.class.getMethods();

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -3242,7 +3242,7 @@ public class TestDuckDBJDBC {
 				List<Array> actual = arrayToList(rs.getArray(1));
 
 				for (int i=0; i<actual.size(); i++) {
-					assertEquals(arrayToList(actual.get(i)), expected.get(i));
+					assertEquals(actual.get(i), expected.get(i));
 				}
 			}
 			try (ResultSet rs = statement.executeQuery("select unnest([[], [69]])")) {

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -3271,9 +3271,7 @@ public class TestDuckDBJDBC {
 		T[] array = (T[]) actual.getArray();
 		List<Object> out = new ArrayList<>();
 		for (T t : array) {
-			if (t instanceof Double && Double.isNaN((Double) t)) {
-				out.add("NaN");
-			} else if (t instanceof Array) {
+			if (t instanceof Array) {
 				out.add(arrayToList((Array) t));
 			} else {
 				out.add(t);
@@ -3402,7 +3400,7 @@ public class TestDuckDBJDBC {
 				42, 999, null, null, -42
 		));
 		correct_answer_map.put("double_array", trio(
-				42.0, "NaN", Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, null, -42.0
+				42.0, Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, null, -42.0
 		));
 		correct_answer_map.put("date_array", trio(
 				LocalDate.parse("1970-01-01"),

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -3214,7 +3214,7 @@ public class TestDuckDBJDBC {
 			 PreparedStatement statement = connection.prepareStatement("select [1]")) {
 			ResultSet rs = statement.executeQuery();
 			assertTrue(rs.next());
-			assertEquals(rs.getObject(1), "[1]");
+			assertEquals(Arrays.toString((Object[])rs.getArray(1).getArray()), "[1]");
 		}
 	}
 
@@ -3286,6 +3286,34 @@ public class TestDuckDBJDBC {
 			assertEquals(s.executeUpdate("insert into t values (1)"), 1);
 			assertFalse(s.execute("insert into t values (1)"));
 			assertEquals(s.getUpdateCount(), 1);
+		}
+	}
+
+	public static void test_get_int() throws Exception {
+		try (Connection connection = DriverManager.getConnection("jdbc:duckdb:"); Statement s = connection.createStatement()) {
+			try (PreparedStatement p = connection.prepareStatement("select * from generate_series(?, ?)")) {
+				p.setInt(1, 0);
+				p.setInt(2, 1);
+
+				try (ResultSet rs = p.executeQuery()) {
+					int i = 0;
+					while (rs.next()) {
+						assertEquals(rs.getInt(1), i++);
+					}
+				}
+			}
+		}
+	}
+
+	public static void test_execute_update() throws Exception {
+		try (Connection connection = DriverManager.getConnection("jdbc:duckdb:"); Statement s = connection.createStatement()) {
+			s.executeUpdate("drop table if exists t");
+			s.executeUpdate("create table t (i int)");
+		
+			try (PreparedStatement p = connection.prepareStatement("insert into t (i) select ?")) {
+				p.setInt(1, 1);
+				p.executeUpdate();
+			}
 		}
 	}
 

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -65,6 +65,7 @@ import java.util.logging.Logger;
 
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
 import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
 import static java.time.temporal.ChronoField.OFFSET_SECONDS;
 import static java.time.temporal.ChronoField.YEAR_OF_ERA;
@@ -3477,26 +3478,26 @@ public class TestDuckDBJDBC {
 		correct_answer_map.put("interval", asList("00:00:00", "83 years 3 months 999 days 00:16:39.999999", null));
 		correct_answer_map.put("timestamp", asList(DuckDBTimestamp.toSqlTimestamp(-9223372022400000000L), DuckDBTimestamp.toSqlTimestamp(9223372036854775807L), null));
 		correct_answer_map.put("date", asList(LocalDate.of(-5877641, 6, 25), LocalDate.of(5881580, 7, 10), null));
-//		correct_answer_map.put("timestamp_s",  of(
-//				LocalDateTime.of(-290308, 12, 22, 0, 0),
-//				LocalDateTime.of(294247,1,10,4,0, 54),
-//				null
-//		));
-//		correct_answer_map.put("timestamp_ns", of(
-//				LocalDateTime.parse("1677-09-21T00:12:43.145225"),
-//				LocalDateTime.parse("2262-04-11T23:47:16.854775"),
-//				null
-//		));
-//		correct_answer_map.put("timestamp_ms", of(
-//				LocalDateTime.of(-290308, 12, 22, 0, 0, 0),
-//				LocalDateTime.of(294247, 1, 10, 4, 0, 54, 775000),
-//				null
-//		));
-//		correct_answer_map.put("timestamp_tz", of(
-//				OffsetDateTime.of(LocalDateTime.of(-290303, 12, 11, 0, 0, 0), ZoneOffset.UTC),
-//				OffsetDateTime.of(LocalDateTime.of(294247, 1, 10, 4, 0, 54, 776806), ZoneOffset.UTC),
-//				null
-//		));
+		correct_answer_map.put("timestamp_s", asList(
+				Timestamp.valueOf(LocalDateTime.of(-290308, 12, 22, 0, 0)),
+				Timestamp.valueOf(LocalDateTime.of(294247,1,10,4,0, 54)),
+				null
+		));
+		correct_answer_map.put("timestamp_ns", asList(
+				Timestamp.valueOf(LocalDateTime.parse("1677-09-21T00:12:43.145225")),
+				Timestamp.valueOf(LocalDateTime.parse("2262-04-11T23:47:16.854775")),
+				null
+		));
+		correct_answer_map.put("timestamp_ms", asList(
+				Timestamp.valueOf(LocalDateTime.of(-290308, 12, 22, 0, 0, 0)),
+				Timestamp.valueOf(LocalDateTime.of(294247, 1, 10, 4, 0, 54, 775000000)),
+				null
+		));
+		correct_answer_map.put("timestamp_tz", asList(
+				OffsetDateTime.of(LocalDateTime.of(-290308, 12, 22, 0, 0, 0), ZoneOffset.UTC),
+				OffsetDateTime.of(LocalDateTime.of(294247, 1, 10, 4, 0, 54, 776806000), ZoneOffset.UTC),
+				null
+		));
 	}
 
 	public static void test_all_types() throws Exception {
@@ -3526,7 +3527,9 @@ public class TestDuckDBJDBC {
 						}
 
 						if (actual instanceof Timestamp && expected instanceof Timestamp) {
-							assertEquals(((Timestamp)actual).getTime(), ((Timestamp)expected).getTime(), 500);
+							assertEquals(((Timestamp) actual).getTime(), ((Timestamp) expected).getTime(), 500);
+						} else if (actual instanceof OffsetDateTime && expected instanceof OffsetDateTime) {
+							assertEquals(((OffsetDateTime) actual).getLong(MILLI_OF_SECOND), ((OffsetDateTime) expected).getLong(MILLI_OF_SECOND), 5000);
 						} else if (actual instanceof List) {
 							assertListsEqual((List) actual, (List)expected);
 						} else {

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -3331,9 +3331,6 @@ public class TestDuckDBJDBC {
 				rs.next();
 				for (int i=1; i<=rsmd.getColumnCount(); i++) {
 					Object value = rs.getObject(i);
-					if (value == null) {
-						continue; // FIXME: when we add a complete test_all_types() test
-					}
 
 					assertEquals(
 						rsmd.getColumnClassName(i),
@@ -3515,10 +3512,6 @@ public class TestDuckDBJDBC {
 					for (int i = 0; i<metaData.getColumnCount(); i++) {
 						String columnName = metaData.getColumnName(i + 1);
 						List<Object> answers = correct_answer_map.get(columnName);
-						if (answers == null) {
-							logger.warning(String.format("Skipping %s for now", columnName));
-							continue;
-						}
 						Object expected = answers.get(rowIdx);
 
 						Object actual = rs.getObject(i + 1);

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -3320,6 +3320,22 @@ public class TestDuckDBJDBC {
 		}
 	}
 
+	// https://github.com/duckdb/duckdb/issues/7218
+	public static void test_unknown_result_type() throws Exception {
+		try (Connection connection = DriverManager.getConnection("jdbc:duckdb:");
+			 PreparedStatement p = connection.prepareStatement("select generate_series.generate_series from generate_series(?, ?) order by 1")) {
+			p.setInt(1, 0);
+			p.setInt(2, 1);
+	
+			try (ResultSet rs = p.executeQuery()) {
+				rs.next();
+				assertEquals(rs.getInt(1), 0);
+				rs.next();
+				assertEquals(rs.getInt(1), 1);
+			}
+		}
+	}
+
 	public static void main(String[] args) throws Exception {
 		// Woo I can do reflection too, take this, JUnit!
 		Method[] methods = TestDuckDBJDBC.class.getMethods();


### PR DESCRIPTION
Most of the work in this PR was moving various methods from DuckDBResultSet into DuckDBVector.

From here it should be straightforward to add Struct and Map support

Fixes part of https://github.com/duckdb/duckdb/discussions/7173, and incidentally, fixes https://github.com/duckdb/duckdb/issues/7218 and fixes https://github.com/duckdb/duckdb/issues/5278