### PR TITLE
[swift] Add a CodingUserInfoKey for accessing the LogicalType

### DIFF
--- a/tools/swift/duckdb-swift/Sources/DuckDB/CodingUserInfoKeys.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/CodingUserInfoKeys.swift
@@ -1,0 +1,52 @@
+//
+//  DuckDB
+//  https://github.com/duckdb/duckdb-swift
+//
+//  Copyright © 2018-2023 Stichting DuckDB Foundation
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+
+public struct CodingUserInfoKeys {
+  /// This key is set on the `userInfo` dictionary of the `Decoder` that is
+  /// used when transforming data into a `Decodable`. The value is the ``LogicalType``
+  /// of the element being decoded. This can be used to implement dynamic decoding
+  /// behavior based on the underlying database type.
+  ///
+  /// For example:
+  /// ```swift
+  ///  struct DynamicDecodable: Decodable {
+  ///   init(from decoder: Decoder) throws {
+  ///      guard let logicalType = decoder.userInfo[CodingUserInfoKeys.logicalType] as? LogicalType else {
+  ///       throw Error.expectedLogicalType
+  ///      }
+  ///      switch logicalType.dataType {
+  ///        case .list:
+  ///          let unkeyedContainer = try decoder.unkeyedContainer()
+  ///          ...
+  ///        case .map, .struct:
+  ///          let keyedContainer = try decoder.container(keyedBy: AnyCodingKey.self)
+  ///          ...
+  ///      }
+  ///    }
+  ///  }
+  ///
+  ///  let column = result[0].cast(to: DynamicDecodable.self)
+  ///  ```
+  public static let logicalTypeCodingUserInfoKey = CodingUserInfoKey(rawValue: "logicalType")!
+}

--- a/tools/swift/duckdb-swift/Sources/DuckDB/Internal/Vector.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Internal/Vector.swift
@@ -258,6 +258,7 @@ extension Vector: Collection {
 extension Vector.Element {
   
   var dataType: DatabaseType { vector.logicalType.dataType }
+  var logicalType: LogicalType { vector.logicalType }
   
   func unwrapNull() -> Bool { vector.unwrapNull(at: index) }
   func unwrap(_ type: Int.Type) throws -> Int { try vector.unwrap(type, at: index) }

--- a/tools/swift/duckdb-swift/Sources/DuckDB/Internal/VectorElementDecoder.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Internal/VectorElementDecoder.swift
@@ -57,12 +57,13 @@ fileprivate struct VectorElementDataDecoder: Decoder {
   }
   
   let codingPath: [CodingKey]
-  let userInfo = [CodingUserInfoKey : Any]()
   let element: Vector.Element
+  let userInfo: [CodingUserInfoKey : Any]
   
   init(element: Vector.Element, codingPath: [CodingKey] = []) {
     self.codingPath = codingPath
     self.element = element
+    self.userInfo = [CodingUserInfoKeys.logicalTypeCodingUserInfoKey: element.logicalType]
   }
   
   func container<Key: CodingKey>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {

--- a/tools/swift/duckdb-swift/Tests/DuckDBTests/CodingUserInfoKeysTests.swift
+++ b/tools/swift/duckdb-swift/Tests/DuckDBTests/CodingUserInfoKeysTests.swift
@@ -1,0 +1,47 @@
+//
+//  DuckDB
+//  https://github.com/duckdb/duckdb-swift
+//
+//  Copyright © 2018-2023 Stichting DuckDB Foundation
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+
+import XCTest
+@testable import DuckDB
+
+final class CodingUserInfoKeysTests: XCTestCase {
+  func test_logical_type() throws {
+    let connection = try Database(store: .inMemory).connect()
+    try connection.execute("""
+      CREATE TABLE t1(int_list INT[]);
+      INSERT INTO t1 VALUES ([1, 2, 3]);
+    """)
+    let result = try connection.query("SELECT * FROM t1;")
+    let column = result[0].cast(to: TestDynamicDecodable.self)
+    XCTAssertEqual(column[0]?.logicalType?.dataType, .list)
+  }
+}
+
+struct TestDynamicDecodable: Decodable {
+  let logicalType: LogicalType?
+
+  init(from decoder: Decoder) throws {
+    self.logicalType = decoder.userInfo[CodingUserInfoKeys.logicalTypeCodingUserInfoKey] as? LogicalType
+  }
+}


### PR DESCRIPTION
This exposes the `LogicalType` of the element being decoded via a `CodingUserInfoKey` on `VectorElementDecoder`. This allows a custom type that implements the `Decodable` protocol to implement dynamic decoding behavior based on the logical type or database type. See the code documentation / tests for an example.