### PR TITLE
Fold some DistinctFrom + add bloaty (?)

### DIFF
--- a/src/common/vector_operations/is_distinct_from.cpp
+++ b/src/common/vector_operations/is_distinct_from.cpp
@@ -907,8 +907,9 @@ idx_t VectorOperations::DistinctLessThanNullsFirst(Vector &left, Vector &right, 
 // true := A <= B with nulls being maximal
 idx_t VectorOperations::DistinctLessThanEquals(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
                                                SelectionVector *true_sel, SelectionVector *false_sel) {
-	return TemplatedDistinctSelectOperation<duckdb::DistinctGreaterThanEquals>(right, left, sel, count, true_sel,
-	                                                                           false_sel);
+	return count -
+	       TemplatedDistinctSelectOperation<duckdb::DistinctGreaterThan>(left, right, sel, count, false_sel,
+                                                                             true_sel);
 }
 
 // true := A != B with nulls being equal, inputs selected

--- a/src/common/vector_operations/is_distinct_from.cpp
+++ b/src/common/vector_operations/is_distinct_from.cpp
@@ -900,16 +900,15 @@ idx_t VectorOperations::DistinctLessThan(Vector &left, Vector &right, const Sele
 // true := A < B with nulls being minimal
 idx_t VectorOperations::DistinctLessThanNullsFirst(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
                                                    SelectionVector *true_sel, SelectionVector *false_sel) {
-	return TemplatedDistinctSelectOperation<duckdb::DistinctLessThanNullsFirst, duckdb::DistinctLessThan>(
-	    left, right, sel, count, true_sel, false_sel);
+	return TemplatedDistinctSelectOperation<duckdb::DistinctGreaterThanNullsFirst, duckdb::DistinctGreaterThan>(
+	    right, left, sel, count, true_sel, false_sel);
 }
 
 // true := A <= B with nulls being maximal
 idx_t VectorOperations::DistinctLessThanEquals(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
                                                SelectionVector *true_sel, SelectionVector *false_sel) {
 	return count -
-	       TemplatedDistinctSelectOperation<duckdb::DistinctGreaterThan>(left, right, sel, count, false_sel,
-                                                                             true_sel);
+	       TemplatedDistinctSelectOperation<duckdb::DistinctGreaterThan>(left, right, sel, count, false_sel, true_sel);
 }
 
 // true := A != B with nulls being equal, inputs selected


### PR DESCRIPTION
Very minor PR.

Two commits folding to same code-path disequalities. Should have no impact on runtime, while minimal but positive impact on binary size. I had this hanging around for a while, it could as well be merged probably.

Last commit is optional, it adds a tool to track binaries code-size. Unsure if it makes sense as part of Makefile, or should be in a README somewhere (one nice thing, it works across the board, also on WebAssembly builds).