### PR TITLE
Fix #7263

### DIFF
--- a/benchmark/micro/append_mix.cpp
+++ b/benchmark/micro/append_mix.cpp
@@ -29,11 +29,7 @@ using namespace duckdb;
 	void get_random_area_code(char *area_code) {                                                                       \
 		uint32_t code = uint32_t(random.NextRandom(0, 999999));                                                        \
 		auto endptr = area_code + 6;                                                                                   \
-		endptr = NumericHelper::FormatUnsigned(code, endptr);                                                          \
-		while (endptr > area_code) {                                                                                   \
-			*endptr = '0';                                                                                             \
-			endptr--;                                                                                                  \
-		}                                                                                                              \
+		NumericHelper::FormatUnsigned(code, endptr);                                                                   \
 	}                                                                                                                  \
 	void RunBenchmark(DuckDBBenchmarkState *state) override {                                                          \
 		state->conn.Query("BEGIN TRANSACTION");                                                                        \
@@ -42,7 +38,7 @@ using namespace duckdb;
 			appender.BeginRow();                                                                                       \
 			appender.Append<int32_t>(i);                                                                               \
 			if (get_random_bool()) {                                                                                   \
-				char area_code[6];                                                                                     \
+				char area_code[6] = {'0','0','0','0','0','0'};                                                         \
 				get_random_area_code(area_code);                                                                       \
 				appender.Append<string_t>(string_t(area_code, 6));                                                     \
 			} else {                                                                                                   \

--- a/benchmark/micro/append_mix.cpp
+++ b/benchmark/micro/append_mix.cpp
@@ -38,7 +38,7 @@ using namespace duckdb;
 			appender.BeginRow();                                                                                       \
 			appender.Append<int32_t>(i);                                                                               \
 			if (get_random_bool()) {                                                                                   \
-				char area_code[6] = {'0','0','0','0','0','0'};                                                         \
+				char area_code[6] = {'0', '0', '0', '0', '0', '0'};                                                    \
 				get_random_area_code(area_code);                                                                       \
 				appender.Append<string_t>(string_t(area_code, 6));                                                     \
 			} else {                                                                                                   \


### PR DESCRIPTION
Two minor non-connected fixes, one related to using potentially uninitialised field in benchmark runner (depends on compiler flags AND not deterministic), one related to string_t ending up being inlined when 0 length (here unsure what the problem could be, or if it makes sense to merge, being it's only can happen in degenerated cases during debug).

I believe this fixes #7263.