### PR TITLE
Parquet: Check for valid UTF8 also in statistics

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -589,8 +589,8 @@ StringColumnReader::StringColumnReader(ParquetReader &reader, LogicalType type_p
 	}
 }
 
-uint32_t StringColumnReader::VerifyString(const char *str_data, uint32_t str_len, const bool isVarchar) {
-	if (!isVarchar) {
+uint32_t StringColumnReader::VerifyString(const char *str_data, uint32_t str_len, const bool is_varchar) {
+	if (!is_varchar) {
 		return str_len;
 	}
 	// verify if a string is actually UTF8, and if there are no null bytes in the middle of the string

--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -589,8 +589,8 @@ StringColumnReader::StringColumnReader(ParquetReader &reader, LogicalType type_p
 	}
 }
 
-uint32_t StringColumnReader::VerifyString(const char *str_data, uint32_t str_len) {
-	if (Type() != LogicalTypeId::VARCHAR) {
+uint32_t StringColumnReader::VerifyString(const char *str_data, uint32_t str_len, const bool isVarchar) {
+	if (!isVarchar) {
 		return str_len;
 	}
 	// verify if a string is actually UTF8, and if there are no null bytes in the middle of the string
@@ -603,6 +603,10 @@ uint32_t StringColumnReader::VerifyString(const char *str_data, uint32_t str_len
 		                            Blob::ToString(string_t(str_data, str_len)) + "\" is not valid UTF8!");
 	}
 	return str_len;
+}
+
+uint32_t StringColumnReader::VerifyString(const char *str_data, uint32_t str_len) {
+	return VerifyString(str_data, str_len, Type() == LogicalTypeId::VARCHAR);
 }
 
 void StringColumnReader::Dictionary(shared_ptr<ResizeableBuffer> data, idx_t num_entries) {

--- a/extension/parquet/include/string_column_reader.hpp
+++ b/extension/parquet/include/string_column_reader.hpp
@@ -39,6 +39,7 @@ public:
 	void PrepareDeltaByteArray(ResizeableBuffer &buffer) override;
 	void DeltaByteArray(uint8_t *defines, idx_t num_values, parquet_filter_t &filter, idx_t result_offset,
 	                    Vector &result) override;
+	static uint32_t VerifyString(const char *str_data, uint32_t str_len, const bool isVarchar);
 	uint32_t VerifyString(const char *str_data, uint32_t str_len);
 
 protected:

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -1,6 +1,7 @@
 #include "parquet_statistics.hpp"
 #include "parquet_decimal_utils.hpp"
 #include "parquet_timestamp.hpp"
+#include "string_column_reader.hpp"
 #include "duckdb.hpp"
 #ifndef DUCKDB_AMALGAMATION
 #include "duckdb/common/types/blob.hpp"
@@ -253,15 +254,19 @@ unique_ptr<BaseStatistics> ParquetStatisticsUtils::TransformColumnStatistics(con
 	case LogicalTypeId::VARCHAR: {
 		auto string_stats = StringStats::CreateEmpty(type);
 		if (parquet_stats.__isset.min) {
+			StringColumnReader::VerifyString(parquet_stats.min.c_str(), parquet_stats.min.size(), true);
 			StringStats::Update(string_stats, parquet_stats.min);
 		} else if (parquet_stats.__isset.min_value) {
+			StringColumnReader::VerifyString(parquet_stats.min_value.c_str(), parquet_stats.min_value.size(), true);
 			StringStats::Update(string_stats, parquet_stats.min_value);
 		} else {
 			return nullptr;
 		}
 		if (parquet_stats.__isset.max) {
+			StringColumnReader::VerifyString(parquet_stats.max.c_str(), parquet_stats.max.size(), true);
 			StringStats::Update(string_stats, parquet_stats.max);
 		} else if (parquet_stats.__isset.max_value) {
+			StringColumnReader::VerifyString(parquet_stats.max_value.c_str(), parquet_stats.max_value.size(), true);
 			StringStats::Update(string_stats, parquet_stats.max_value);
 		} else {
 			return nullptr;

--- a/test/parquet/invalid_parquet.test
+++ b/test/parquet/invalid_parquet.test
@@ -10,7 +10,7 @@ PRAGMA enable_verification
 statement error
 SELECT * FROM parquet_scan('data/parquet-testing/invalid.parquet') limit 50;
 ----
-Invalid Input Error: Invalid unicode (byte sequence mismatch) detected in segment statistics update
+Invalid Input Error: Invalid string encoding found in Parquet file: value "TREL\xC3" is not valid UTF8!
 
 statement ok
 pragma disable_optimizer


### PR DESCRIPTION
Connected to test case from issue #5882 / PR #7402.

Adds a static VerifyString overload that takes as parameter whether underlying string is logically a VARCHAR or not.