### PR TITLE
Remove FileOpener almost everywhere - instead wrap FileSystem in the ClientContext with an "OpenerFileSystem"

### DIFF
--- a/extension/autocomplete/sql_auto_complete-extension.cpp
+++ b/extension/autocomplete/sql_auto_complete-extension.cpp
@@ -179,7 +179,7 @@ static vector<AutoCompleteCandidate> SuggestFileName(ClientContext &context, str
 	auto &fs = FileSystem::GetFileSystem(context);
 	string search_dir;
 	D_ASSERT(last_pos >= prefix.size());
-	auto is_path_absolute = FileSystem::IsPathAbsolute(prefix);
+	auto is_path_absolute = fs.IsPathAbsolute(prefix);
 	for (idx_t i = prefix.size(); i > 0; i--, last_pos--) {
 		if (prefix[i - 1] == '/' || prefix[i - 1] == '\\') {
 			search_dir = prefix.substr(0, i - 1);
@@ -190,7 +190,7 @@ static vector<AutoCompleteCandidate> SuggestFileName(ClientContext &context, str
 	if (search_dir.empty()) {
 		search_dir = is_path_absolute ? "/" : ".";
 	} else {
-		search_dir = fs.ExpandPath(search_dir, FileOpener::Get(context));
+		search_dir = fs.ExpandPath(search_dir);
 	}
 	vector<AutoCompleteCandidate> result;
 	fs.ListFiles(search_dir, [&](const string &fname, bool is_dir) {

--- a/extension/json/buffered_json_reader.cpp
+++ b/extension/json/buffered_json_reader.cpp
@@ -162,9 +162,8 @@ BufferedJSONReader::BufferedJSONReader(ClientContext &context, BufferedJSONReade
 void BufferedJSONReader::OpenJSONFile() {
 	lock_guard<mutex> guard(lock);
 	auto &file_system = FileSystem::GetFileSystem(context);
-	auto file_opener = FileOpener::Get(context);
-	auto regular_file_handle = file_system.OpenFile(file_path.c_str(), FileFlags::FILE_FLAGS_READ,
-	                                                FileLockType::NO_LOCK, options.compression, file_opener);
+	auto regular_file_handle =
+	    file_system.OpenFile(file_path.c_str(), FileFlags::FILE_FLAGS_READ, FileLockType::NO_LOCK, options.compression);
 	file_handle = make_uniq<JSONFileHandle>(std::move(regular_file_handle), BufferAllocator::Get(context));
 }
 

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -80,12 +80,12 @@ public:
 
 class ParquetReader {
 public:
-	ParquetReader(Allocator &allocator, unique_ptr<FileHandle> file_handle_p);
 	ParquetReader(ClientContext &context, string file_name, ParquetOptions parquet_options);
 	ParquetReader(ClientContext &context, ParquetOptions parquet_options,
 	              shared_ptr<ParquetFileMetadataCache> metadata);
 	~ParquetReader();
 
+	FileSystem &fs;
 	Allocator &allocator;
 	string file_name;
 	vector<LogicalType> return_types;

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -88,7 +88,6 @@ public:
 
 	Allocator &allocator;
 	string file_name;
-	FileOpener *file_opener;
 	vector<LogicalType> return_types;
 	vector<string> names;
 	shared_ptr<ParquetFileMetadataCache> metadata;

--- a/extension/parquet/include/parquet_writer.hpp
+++ b/extension/parquet/include/parquet_writer.hpp
@@ -32,8 +32,8 @@ struct PreparedRowGroup {
 
 class ParquetWriter {
 public:
-	ParquetWriter(FileSystem &fs, string file_name, FileOpener *file_opener, vector<LogicalType> types,
-	              vector<string> names, duckdb_parquet::format::CompressionCodec::type codec);
+	ParquetWriter(FileSystem &fs, string file_name, vector<LogicalType> types, vector<string> names,
+	              duckdb_parquet::format::CompressionCodec::type codec);
 
 public:
 	void PrepareRowGroup(ColumnDataCollection &buffer, PreparedRowGroup &result);

--- a/extension/parquet/include/thrift_tools.hpp
+++ b/extension/parquet/include/thrift_tools.hpp
@@ -51,8 +51,7 @@ struct ReadHeadComparator {
 // 1: register all ranges that will be read, merging ranges that are consecutive
 // 2: prefetch all registered ranges
 struct ReadAheadBuffer {
-	ReadAheadBuffer(Allocator &allocator, FileHandle &handle, FileOpener &opener)
-	    : allocator(allocator), handle(handle), file_opener(opener) {
+	ReadAheadBuffer(Allocator &allocator, FileHandle &handle) : allocator(allocator), handle(handle) {
 	}
 
 	// The list of read heads
@@ -62,7 +61,6 @@ struct ReadAheadBuffer {
 
 	Allocator &allocator;
 	FileHandle &handle;
-	FileOpener &file_opener;
 
 	idx_t total_size = 0;
 
@@ -124,8 +122,8 @@ class ThriftFileTransport : public duckdb_apache::thrift::transport::TVirtualTra
 public:
 	static constexpr uint64_t PREFETCH_FALLBACK_BUFFERSIZE = 1000000;
 
-	ThriftFileTransport(Allocator &allocator, FileHandle &handle_p, FileOpener &opener, bool prefetch_mode_p)
-	    : handle(handle_p), location(0), allocator(allocator), ra_buffer(ReadAheadBuffer(allocator, handle_p, opener)),
+	ThriftFileTransport(Allocator &allocator, FileHandle &handle_p, bool prefetch_mode_p)
+	    : handle(handle_p), location(0), allocator(allocator), ra_buffer(ReadAheadBuffer(allocator, handle_p)),
 	      prefetch_mode(prefetch_mode_p) {
 	}
 

--- a/extension/parquet/parquet-extension.cpp
+++ b/extension/parquet/parquet-extension.cpp
@@ -240,7 +240,7 @@ public:
 					return nullptr;
 				}
 				auto handle = fs.OpenFile(file_name, FileFlags::FILE_FLAGS_READ, FileSystem::DEFAULT_LOCK,
-				                          FileSystem::DEFAULT_COMPRESSION, FileSystem::GetFileOpener(context));
+				                          FileSystem::DEFAULT_COMPRESSION);
 				// we need to check if the metadata cache entries are current
 				if (fs.GetLastModifiedTime(*handle) >= metadata->read_time) {
 					// missing or invalid metadata entry in cache, no usable stats overall
@@ -627,8 +627,7 @@ unique_ptr<GlobalFunctionData> ParquetWriteInitializeGlobal(ClientContext &conte
 
 	auto &fs = FileSystem::GetFileSystem(context);
 	global_state->writer =
-	    make_uniq<ParquetWriter>(fs, file_path, FileSystem::GetFileOpener(context), parquet_bind.sql_types,
-	                             parquet_bind.column_names, parquet_bind.codec);
+	    make_uniq<ParquetWriter>(fs, file_path, parquet_bind.sql_types, parquet_bind.column_names, parquet_bind.codec);
 	return std::move(global_state);
 }
 

--- a/extension/parquet/parquet-extension.cpp
+++ b/extension/parquet/parquet-extension.cpp
@@ -239,8 +239,7 @@ public:
 					// missing metadata entry in cache, no usable stats
 					return nullptr;
 				}
-				auto handle = fs.OpenFile(file_name, FileFlags::FILE_FLAGS_READ, FileSystem::DEFAULT_LOCK,
-				                          FileSystem::DEFAULT_COMPRESSION);
+				auto handle = fs.OpenFile(file_name, FileFlags::FILE_FLAGS_READ);
 				// we need to check if the metadata cache entries are current
 				if (fs.GetLastModifiedTime(*handle) >= metadata->read_time) {
 					// missing or invalid metadata entry in cache, no usable stats overall

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -49,16 +49,15 @@ using duckdb_parquet::format::Statistics;
 using duckdb_parquet::format::Type;
 
 static duckdb::unique_ptr<duckdb_apache::thrift::protocol::TProtocol>
-CreateThriftProtocol(Allocator &allocator, FileHandle &file_handle, FileOpener &opener, bool prefetch_mode) {
-	auto transport = make_shared<ThriftFileTransport>(allocator, file_handle, opener, prefetch_mode);
+CreateThriftProtocol(Allocator &allocator, FileHandle &file_handle, bool prefetch_mode) {
+	auto transport = make_shared<ThriftFileTransport>(allocator, file_handle, prefetch_mode);
 	return make_uniq<duckdb_apache::thrift::protocol::TCompactProtocolT<ThriftFileTransport>>(std::move(transport));
 }
 
-static shared_ptr<ParquetFileMetadataCache> LoadMetadata(Allocator &allocator, FileHandle &file_handle,
-                                                         FileOpener &opener) {
+static shared_ptr<ParquetFileMetadataCache> LoadMetadata(Allocator &allocator, FileHandle &file_handle) {
 	auto current_time = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 
-	auto proto = CreateThriftProtocol(allocator, file_handle, opener, false);
+	auto proto = CreateThriftProtocol(allocator, file_handle, false);
 	auto &transport = ((ThriftFileTransport &)*proto->getTransport());
 	auto file_size = transport.GetSize();
 	if (file_size < 12) {
@@ -431,17 +430,16 @@ ParquetOptions::ParquetOptions(ClientContext &context) {
 ParquetReader::ParquetReader(Allocator &allocator_p, unique_ptr<FileHandle> file_handle_p) : allocator(allocator_p) {
 	file_name = file_handle_p->path;
 	file_handle = std::move(file_handle_p);
-	metadata = LoadMetadata(allocator, *file_handle, *file_opener);
+	metadata = LoadMetadata(allocator, *file_handle);
 	InitializeSchema();
 }
 
 ParquetReader::ParquetReader(ClientContext &context_p, string file_name_p, ParquetOptions parquet_options_p)
-    : allocator(BufferAllocator::Get(context_p)), file_opener(FileSystem::GetFileOpener(context_p)),
-      parquet_options(parquet_options_p) {
+    : allocator(BufferAllocator::Get(context_p)), parquet_options(parquet_options_p) {
 	auto &fs = FileSystem::GetFileSystem(context_p);
 	file_name = std::move(file_name_p);
-	file_handle = fs.OpenFile(file_name, FileFlags::FILE_FLAGS_READ, FileSystem::DEFAULT_LOCK,
-	                          FileSystem::DEFAULT_COMPRESSION, file_opener);
+	file_handle =
+	    fs.OpenFile(file_name, FileFlags::FILE_FLAGS_READ, FileSystem::DEFAULT_LOCK, FileSystem::DEFAULT_COMPRESSION);
 	if (!file_handle->CanSeek()) {
 		throw NotImplementedException(
 		    "Reading parquet files from a FIFO stream is not supported and cannot be efficiently supported since "
@@ -451,12 +449,12 @@ ParquetReader::ParquetReader(ClientContext &context_p, string file_name_p, Parqu
 	// or if this file has cached metadata
 	// or if the cached version already expired
 	if (!ObjectCache::ObjectCacheEnabled(context_p)) {
-		metadata = LoadMetadata(allocator, *file_handle, *file_opener);
+		metadata = LoadMetadata(allocator, *file_handle);
 	} else {
 		auto last_modify_time = fs.GetLastModifiedTime(*file_handle);
 		metadata = ObjectCache::GetObjectCache(context_p).Get<ParquetFileMetadataCache>(file_name);
 		if (!metadata || (last_modify_time + 10 >= metadata->read_time)) {
-			metadata = LoadMetadata(allocator, *file_handle, *file_opener);
+			metadata = LoadMetadata(allocator, *file_handle);
 			ObjectCache::GetObjectCache(context_p).Put(file_name, metadata);
 		}
 	}
@@ -466,8 +464,7 @@ ParquetReader::ParquetReader(ClientContext &context_p, string file_name_p, Parqu
 
 ParquetReader::ParquetReader(ClientContext &context_p, ParquetOptions parquet_options_p,
                              shared_ptr<ParquetFileMetadataCache> metadata_p)
-    : allocator(BufferAllocator::Get(context_p)), file_opener(FileSystem::GetFileOpener(context_p)),
-      metadata(std::move(metadata_p)), parquet_options(parquet_options_p) {
+    : allocator(BufferAllocator::Get(context_p)), metadata(std::move(metadata_p)), parquet_options(parquet_options_p) {
 	InitializeSchema();
 }
 
@@ -635,10 +632,10 @@ void ParquetReader::InitializeScan(ParquetReaderScanState &state, vector<idx_t> 
 		}
 
 		state.file_handle = file_handle->file_system.OpenFile(file_handle->path, flags, FileSystem::DEFAULT_LOCK,
-		                                                      FileSystem::DEFAULT_COMPRESSION, file_opener);
+		                                                      FileSystem::DEFAULT_COMPRESSION);
 	}
 
-	state.thrift_file_proto = CreateThriftProtocol(allocator, *state.file_handle, *file_opener, state.prefetch_mode);
+	state.thrift_file_proto = CreateThriftProtocol(allocator, *state.file_handle, state.prefetch_mode);
 	state.root_reader = CreateReader();
 	state.define_buf.resize(allocator, STANDARD_VECTOR_SIZE);
 	state.repeat_buf.resize(allocator, STANDARD_VECTOR_SIZE);

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -431,8 +431,7 @@ ParquetReader::ParquetReader(ClientContext &context_p, string file_name_p, Parqu
     : fs(FileSystem::GetFileSystem(context_p)), allocator(BufferAllocator::Get(context_p)),
       parquet_options(parquet_options_p) {
 	file_name = std::move(file_name_p);
-	file_handle =
-	    fs.OpenFile(file_name, FileFlags::FILE_FLAGS_READ, FileSystem::DEFAULT_LOCK, FileSystem::DEFAULT_COMPRESSION);
+	file_handle = fs.OpenFile(file_name, FileFlags::FILE_FLAGS_READ);
 	if (!file_handle->CanSeek()) {
 		throw NotImplementedException(
 		    "Reading parquet files from a FIFO stream is not supported and cannot be efficiently supported since "

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -225,12 +225,12 @@ void VerifyUniqueNames(const vector<string> &names) {
 #endif
 }
 
-ParquetWriter::ParquetWriter(FileSystem &fs, string file_name_p, FileOpener *file_opener_p, vector<LogicalType> types_p,
-                             vector<string> names_p, CompressionCodec::type codec)
+ParquetWriter::ParquetWriter(FileSystem &fs, string file_name_p, vector<LogicalType> types_p, vector<string> names_p,
+                             CompressionCodec::type codec)
     : file_name(std::move(file_name_p)), sql_types(std::move(types_p)), column_names(std::move(names_p)), codec(codec) {
 	// initialize the file writer
-	writer = make_uniq<BufferedFileWriter>(
-	    fs, file_name.c_str(), FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW, file_opener_p);
+	writer = make_uniq<BufferedFileWriter>(fs, file_name.c_str(),
+	                                       FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
 	// parquet files start with the string "PAR1"
 	writer->WriteData((const_data_ptr_t) "PAR1", 4);
 	TCompactProtocolFactoryT<MyTransport> tproto_factory;

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -40,7 +40,8 @@ FileSystem::~FileSystem() {
 }
 
 FileSystem &FileSystem::GetFileSystem(ClientContext &context) {
-	return FileSystem::GetFileSystem(*context.db);
+	auto &client_data = ClientData::Get(context);
+	return *client_data.client_file_system;
 }
 
 FileOpener *FileSystem::GetFileOpener(ClientContext &context) {
@@ -193,7 +194,7 @@ string FileSystem::ExtractBaseName(const string &path) {
 	return vec[0];
 }
 
-string FileSystem::GetHomeDirectory(FileOpener *opener) {
+string FileSystem::GetHomeDirectory(optional_ptr<FileOpener> opener) {
 	// read the home_directory setting first, if it is set
 	if (opener) {
 		Value result;
@@ -215,7 +216,11 @@ string FileSystem::GetHomeDirectory(FileOpener *opener) {
 	return string();
 }
 
-string FileSystem::ExpandPath(const string &path, FileOpener *opener) {
+string FileSystem::GetHomeDirectory() {
+	return GetHomeDirectory(nullptr);
+}
+
+string FileSystem::ExpandPath(const string &path, optional_ptr<FileOpener> opener) {
 	if (path.empty()) {
 		return path;
 	}
@@ -223,6 +228,10 @@ string FileSystem::ExpandPath(const string &path, FileOpener *opener) {
 		return GetHomeDirectory(opener) + path.substr(1);
 	}
 	return path;
+}
+
+string FileSystem::ExpandPath(const string &path) {
+	return FileSystem::ExpandPath(path, nullptr);
 }
 
 // LCOV_EXCL_START
@@ -245,14 +254,6 @@ int64_t FileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
 
 int64_t FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
 	throw NotImplementedException("%s: Write is not implemented!", GetName());
-}
-
-string FileSystem::GetFileExtension(FileHandle &handle) {
-	auto dot_location = handle.path.rfind('.');
-	if (dot_location != std::string::npos) {
-		return handle.path.substr(dot_location + 1, std::string::npos);
-	}
-	return string();
 }
 
 int64_t FileSystem::GetFileSize(FileHandle &handle) {
@@ -312,10 +313,6 @@ vector<string> FileSystem::Glob(const string &path, FileOpener *opener) {
 	throw NotImplementedException("%s: Glob is not implemented!", GetName());
 }
 
-vector<string> FileSystem::Glob(const string &path, ClientContext &context) {
-	return Glob(path, GetFileOpener(context));
-}
-
 void FileSystem::RegisterSubSystem(unique_ptr<FileSystem> sub_fs) {
 	throw NotImplementedException("%s: Can't register a sub system on a non-virtual file system", GetName());
 }
@@ -337,7 +334,7 @@ bool FileSystem::CanHandleFile(const string &fpath) {
 }
 
 vector<string> FileSystem::GlobFiles(const string &pattern, ClientContext &context, FileGlobOptions options) {
-	auto result = Glob(pattern, context);
+	auto result = Glob(pattern);
 	if (result.empty()) {
 		string required_extension;
 		const string prefixes[] = {"http://", "https://", "s3://"};

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -44,10 +44,6 @@ FileSystem &FileSystem::GetFileSystem(ClientContext &context) {
 	return *client_data.client_file_system;
 }
 
-FileOpener *FileSystem::GetFileOpener(ClientContext &context) {
-	return ClientData::Get(context).file_opener.get();
-}
-
 bool PathMatched(const string &path, const string &sub_path) {
 	if (path.rfind(sub_path, 0) == 0) {
 		return true;

--- a/src/common/serializer/buffered_file_writer.cpp
+++ b/src/common/serializer/buffered_file_writer.cpp
@@ -10,7 +10,7 @@ constexpr uint8_t BufferedFileWriter::DEFAULT_OPEN_FLAGS;
 
 BufferedFileWriter::BufferedFileWriter(FileSystem &fs, const string &path_p, uint8_t open_flags)
     : fs(fs), path(path_p), data(unique_ptr<data_t[]>(new data_t[FILE_BUFFER_SIZE])), offset(0), total_written(0) {
-	handle = fs.OpenFile(path, open_flags, FileLockType::WRITE_LOCK, FileSystem::DEFAULT_COMPRESSION);
+	handle = fs.OpenFile(path, open_flags, FileLockType::WRITE_LOCK);
 }
 
 int64_t BufferedFileWriter::GetFileSize() {

--- a/src/common/serializer/buffered_file_writer.cpp
+++ b/src/common/serializer/buffered_file_writer.cpp
@@ -8,9 +8,9 @@ namespace duckdb {
 // Remove this when we switch C++17: https://stackoverflow.com/a/53350948
 constexpr uint8_t BufferedFileWriter::DEFAULT_OPEN_FLAGS;
 
-BufferedFileWriter::BufferedFileWriter(FileSystem &fs, const string &path_p, uint8_t open_flags, FileOpener *opener)
+BufferedFileWriter::BufferedFileWriter(FileSystem &fs, const string &path_p, uint8_t open_flags)
     : fs(fs), path(path_p), data(unique_ptr<data_t[]>(new data_t[FILE_BUFFER_SIZE])), offset(0), total_written(0) {
-	handle = fs.OpenFile(path, open_flags, FileLockType::WRITE_LOCK, FileSystem::DEFAULT_COMPRESSION, opener);
+	handle = fs.OpenFile(path, open_flags, FileLockType::WRITE_LOCK, FileSystem::DEFAULT_COMPRESSION);
 }
 
 int64_t BufferedFileWriter::GetFileSize() {

--- a/src/execution/operator/persistent/base_csv_reader.cpp
+++ b/src/execution/operator/persistent/base_csv_reader.cpp
@@ -32,7 +32,8 @@ string BaseCSVReader::GetLineNumberStr(idx_t linenr, bool linenr_estimated) {
 
 BaseCSVReader::BaseCSVReader(ClientContext &context_p, BufferedCSVReaderOptions options_p,
                              const vector<LogicalType> &requested_types)
-    : context(context_p), fs(FileSystem::GetFileSystem(context)), allocator(Allocator::Get(context)) {
+    : context(context_p), fs(FileSystem::GetFileSystem(context)), allocator(Allocator::Get(context)),
+      options(std::move(options_p)) {
 }
 
 BaseCSVReader::~BaseCSVReader() {

--- a/src/execution/operator/persistent/base_csv_reader.cpp
+++ b/src/execution/operator/persistent/base_csv_reader.cpp
@@ -32,8 +32,7 @@ string BaseCSVReader::GetLineNumberStr(idx_t linenr, bool linenr_estimated) {
 
 BaseCSVReader::BaseCSVReader(ClientContext &context_p, BufferedCSVReaderOptions options_p,
                              const vector<LogicalType> &requested_types)
-    : context(context_p), fs(FileSystem::GetFileSystem(context)), allocator(Allocator::Get(context)),
-      opener(FileSystem::GetFileOpener(context)), options(std::move(options_p)) {
+    : context(context_p), fs(FileSystem::GetFileSystem(context)), allocator(Allocator::Get(context)) {
 }
 
 BaseCSVReader::~BaseCSVReader() {
@@ -41,7 +40,7 @@ BaseCSVReader::~BaseCSVReader() {
 
 unique_ptr<CSVFileHandle> BaseCSVReader::OpenCSV(const BufferedCSVReaderOptions &options_p) {
 	auto file_handle = fs.OpenFile(options_p.file_path.c_str(), FileFlags::FILE_FLAGS_READ, FileLockType::NO_LOCK,
-	                               options_p.compression, this->opener);
+	                               options_p.compression);
 	if (file_handle->CanSeek()) {
 		file_handle->Reset();
 	}

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -207,8 +207,7 @@ unique_ptr<GlobalSinkState> PhysicalCopyToFile::GetGlobalSinkState(ClientContext
 			fs.CreateDirectory(file_path);
 		} else if (!overwrite_or_ignore) {
 			idx_t n_files = 0;
-			fs.ListFiles(
-			    file_path, [&n_files](const string &path, bool) { n_files++; }, FileOpener::Get(context));
+			fs.ListFiles(file_path, [&n_files](const string &path, bool) { n_files++; });
 			if (n_files > 0) {
 				throw IOException("Directory %s is not empty! Enable OVERWRITE_OR_IGNORE option to force writing",
 				                  file_path);

--- a/src/execution/operator/persistent/physical_export.cpp
+++ b/src/execution/operator/persistent/physical_export.cpp
@@ -30,7 +30,7 @@ static void WriteCatalogEntries(stringstream &ss, vector<reference<CatalogEntry>
 static void WriteStringStreamToFile(FileSystem &fs, stringstream &ss, const string &path) {
 	auto ss_string = ss.str();
 	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW,
-	                          FileLockType::WRITE_LOCK, FileSystem::DEFAULT_COMPRESSION);
+	                          FileLockType::WRITE_LOCK);
 	fs.Write(*handle, (void *)ss_string.c_str(), ss_string.size());
 	handle.reset();
 }

--- a/src/execution/operator/persistent/physical_export.cpp
+++ b/src/execution/operator/persistent/physical_export.cpp
@@ -27,10 +27,10 @@ static void WriteCatalogEntries(stringstream &ss, vector<reference<CatalogEntry>
 	ss << std::endl;
 }
 
-static void WriteStringStreamToFile(FileSystem &fs, FileOpener *opener, stringstream &ss, const string &path) {
+static void WriteStringStreamToFile(FileSystem &fs, stringstream &ss, const string &path) {
 	auto ss_string = ss.str();
 	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW,
-	                          FileLockType::WRITE_LOCK, FileSystem::DEFAULT_COMPRESSION, opener);
+	                          FileLockType::WRITE_LOCK, FileSystem::DEFAULT_COMPRESSION);
 	fs.Write(*handle, (void *)ss_string.c_str(), ss_string.size());
 	handle.reset();
 }
@@ -108,7 +108,6 @@ SourceResultType PhysicalExport::GetData(ExecutionContext &context, DataChunk &c
 
 	auto &ccontext = context.client;
 	auto &fs = FileSystem::GetFileSystem(ccontext);
-	auto *opener = FileSystem::GetFileOpener(ccontext);
 
 	// gather all catalog types to export
 	vector<reference<CatalogEntry>> schemas;
@@ -172,7 +171,7 @@ SourceResultType PhysicalExport::GetData(ExecutionContext &context, DataChunk &c
 	WriteCatalogEntries(ss, indexes);
 	WriteCatalogEntries(ss, macros);
 
-	WriteStringStreamToFile(fs, opener, ss, fs.JoinPath(info->file_path, "schema.sql"));
+	WriteStringStreamToFile(fs, ss, fs.JoinPath(info->file_path, "schema.sql"));
 
 	// write the load.sql file
 	// for every table, we write COPY INTO statement with the specified options
@@ -181,7 +180,7 @@ SourceResultType PhysicalExport::GetData(ExecutionContext &context, DataChunk &c
 		auto exported_table_info = exported_tables.data[i].table_data;
 		WriteCopyStatement(fs, load_ss, *info, exported_table_info, function);
 	}
-	WriteStringStreamToFile(fs, opener, load_ss, fs.JoinPath(info->file_path, "load.sql"));
+	WriteStringStreamToFile(fs, load_ss, fs.JoinPath(info->file_path, "load.sql"));
 	state.finished = true;
 
 	return SourceResultType::FINISHED;

--- a/src/execution/physical_plan/plan_copy_to_file.cpp
+++ b/src/execution/physical_plan/plan_copy_to_file.cpp
@@ -11,7 +11,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile
 	bool preserve_insertion_order = PhysicalPlanGenerator::PreserveInsertionOrder(context, *plan);
 	bool supports_batch_index = PhysicalPlanGenerator::UseBatchIndex(context, *plan);
 	auto &fs = FileSystem::GetFileSystem(context);
-	op.file_path = fs.ExpandPath(op.file_path, FileSystem::GetFileOpener(context));
+	op.file_path = fs.ExpandPath(op.file_path);
 	if (op.use_tmp_file) {
 		op.file_path += ".tmp";
 	}

--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -124,7 +124,6 @@ string PragmaImportDatabase(ClientContext &context, const FunctionParameters &pa
 		throw PermissionException("Import is disabled through configuration");
 	}
 	auto &fs = FileSystem::GetFileSystem(context);
-	auto *opener = FileSystem::GetFileOpener(context);
 
 	string final_query;
 	// read the "shema.sql" and "load.sql" files
@@ -132,7 +131,7 @@ string PragmaImportDatabase(ClientContext &context, const FunctionParameters &pa
 	for (auto &file : files) {
 		auto file_path = fs.JoinPath(parameters.values[0].ToString(), file);
 		auto handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ, FileSystem::DEFAULT_LOCK,
-		                          FileSystem::DEFAULT_COMPRESSION, opener);
+		                          FileSystem::DEFAULT_COMPRESSION);
 		auto fsize = fs.GetFileSize(*handle);
 		auto buffer = unique_ptr<char[]>(new char[fsize]);
 		fs.Read(*handle, buffer.get(), fsize);

--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -254,10 +254,9 @@ struct LocalWriteCSVData : public LocalFunctionData {
 };
 
 struct GlobalWriteCSVData : public GlobalFunctionData {
-	GlobalWriteCSVData(FileSystem &fs, const string &file_path, FileOpener *opener, FileCompressionType compression)
-	    : fs(fs) {
+	GlobalWriteCSVData(FileSystem &fs, const string &file_path, FileCompressionType compression) : fs(fs) {
 		handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW,
-		                     FileLockType::WRITE_LOCK, compression, opener);
+		                     FileLockType::WRITE_LOCK, compression);
 	}
 
 	void WriteData(const_data_ptr_t data, idx_t size) {
@@ -288,8 +287,8 @@ static unique_ptr<GlobalFunctionData> WriteCSVInitializeGlobal(ClientContext &co
                                                                const string &file_path) {
 	auto &csv_data = bind_data.Cast<WriteCSVData>();
 	auto &options = csv_data.options;
-	auto global_data = make_uniq<GlobalWriteCSVData>(FileSystem::GetFileSystem(context), file_path,
-	                                                 FileSystem::GetFileOpener(context), options.compression);
+	auto global_data =
+	    make_uniq<GlobalWriteCSVData>(FileSystem::GetFileSystem(context), file_path, options.compression);
 
 	if (options.header) {
 		BufferedSerializer serializer;

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -22,9 +22,7 @@ namespace duckdb {
 unique_ptr<CSVFileHandle> ReadCSV::OpenCSV(const string &file_path, FileCompressionType compression,
                                            ClientContext &context) {
 	auto &fs = FileSystem::GetFileSystem(context);
-	auto opener = FileSystem::GetFileOpener(context);
-	auto file_handle =
-	    fs.OpenFile(file_path.c_str(), FileFlags::FILE_FLAGS_READ, FileLockType::NO_LOCK, compression, opener);
+	auto file_handle = fs.OpenFile(file_path.c_str(), FileFlags::FILE_FLAGS_READ, FileLockType::NO_LOCK, compression);
 	if (file_handle->CanSeek()) {
 		file_handle->Reset();
 	}

--- a/src/include/duckdb/common/file_opener.hpp
+++ b/src/include/duckdb/common/file_opener.hpp
@@ -24,7 +24,6 @@ public:
 	virtual bool TryGetCurrentSetting(const string &key, Value &result) = 0;
 	virtual ClientContext *TryGetClientContext() = 0;
 
-	DUCKDB_API static FileOpener *Get(ClientContext &context);
 	DUCKDB_API static ClientContext *TryGetClientContext(FileOpener *opener);
 	DUCKDB_API static bool TryGetCurrentSetting(FileOpener *opener, const string &key, Value &result);
 };

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/enums/file_glob_options.hpp"
+#include "duckdb/common/optional_ptr.hpp"
 #include <functional>
 
 #undef CreateDirectory
@@ -128,8 +129,6 @@ public:
 	//! Write nr_bytes from the buffer into the file, moving the file pointer forward by nr_bytes.
 	DUCKDB_API virtual int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes);
 
-	//! Returns the extension of the file, or empty string if no extension was found.
-	DUCKDB_API string GetFileExtension(FileHandle &handle);
 	//! Returns the file size of a file handle, returns -1 on error
 	DUCKDB_API virtual int64_t GetFileSize(FileHandle &handle);
 	//! Returns the file last modified time of a file handle, returns timespec with zero on all attributes on error
@@ -167,9 +166,13 @@ public:
 	//! Gets the working directory
 	DUCKDB_API static string GetWorkingDirectory();
 	//! Gets the users home directory
-	DUCKDB_API static string GetHomeDirectory(FileOpener *opener);
+	DUCKDB_API static string GetHomeDirectory(optional_ptr<FileOpener> opener);
+	//! Gets the users home directory
+	DUCKDB_API virtual string GetHomeDirectory();
 	//! Expands a given path, including e.g. expanding the home directory of the user
-	DUCKDB_API static string ExpandPath(const string &path, FileOpener *opener);
+	DUCKDB_API static string ExpandPath(const string &path, optional_ptr<FileOpener> opener);
+	//! Expands a given path, including e.g. expanding the home directory of the user
+	DUCKDB_API virtual string ExpandPath(const string &path);
 	//! Returns the system-available memory in bytes. Returns DConstants::INVALID_INDEX if the system function fails.
 	DUCKDB_API static idx_t GetAvailableMemory();
 	//! Path separator for the current file system
@@ -187,7 +190,6 @@ public:
 
 	//! Runs a glob on the file system, returning a list of matching files
 	DUCKDB_API virtual vector<string> Glob(const string &path, FileOpener *opener = nullptr);
-	DUCKDB_API virtual vector<string> Glob(const string &path, ClientContext &context);
 	DUCKDB_API vector<string> GlobFiles(const string &path, ClientContext &context,
 	                                    FileGlobOptions options = FileGlobOptions::DISALLOW_EMPTY);
 

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -110,7 +110,6 @@ public:
 	DUCKDB_API static FileSystem &GetFileSystem(ClientContext &context);
 	DUCKDB_API static FileSystem &GetFileSystem(DatabaseInstance &db);
 	DUCKDB_API static FileSystem &Get(AttachedDatabase &db);
-	DUCKDB_API static FileOpener *GetFileOpener(ClientContext &context);
 
 	DUCKDB_API virtual unique_ptr<FileHandle> OpenFile(const string &path, uint8_t flags,
 	                                                   FileLockType lock = DEFAULT_LOCK,

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -16,7 +16,7 @@ namespace duckdb {
 class OpenerFileSystem : public FileSystem {
 public:
 	virtual FileSystem &GetFileSystem() const = 0;
-	virtual FileOpener *GetOpener() const = 0;
+	virtual optional_ptr<FileOpener> GetOpener() const = 0;
 
 	unique_ptr<FileHandle> OpenFile(const string &path, uint8_t flags, FileLockType lock = FileLockType::NO_LOCK,
 	                                FileCompressionType compression = FileCompressionType::UNCOMPRESSED,
@@ -24,7 +24,7 @@ public:
 		if (opener) {
 			throw InternalException("OpenerFileSystem cannot take an opener - the opener is pushed automatically");
 		}
-		return GetFileSystem().OpenFile(path, flags, lock, compression, GetOpener());
+		return GetFileSystem().OpenFile(path, flags, lock, compression, GetOpener().get());
 	}
 
 
@@ -78,7 +78,7 @@ public:
 		if (opener) {
 			throw InternalException("OpenerFileSystem cannot take an opener - the opener is pushed automatically");
 		}
-		return GetFileSystem().ListFiles(directory, callback, GetOpener());
+		return GetFileSystem().ListFiles(directory, callback, GetOpener().get());
 	}
 
 	void MoveFile(const string &source, const string &target) override {
@@ -108,11 +108,11 @@ public:
 		if (opener) {
 			throw InternalException("OpenerFileSystem cannot take an opener - the opener is pushed automatically");
 		}
-		return GetFileSystem().Glob(path, GetOpener());
+		return GetFileSystem().Glob(path, GetOpener().get());
 	}
 
 	std::string GetName() const override {
-		return GetFileSystem().GetName();
+		return "OpenerFileSystem - " + GetFileSystem().GetName();
 	}
 };
 

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -27,7 +27,6 @@ public:
 		return GetFileSystem().OpenFile(path, flags, lock, compression, GetOpener().get());
 	}
 
-
 	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {
 		GetFileSystem().Read(handle, buffer, nr_bytes, location);
 	};

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -1,0 +1,119 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/opener_file_system.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/file_system.hpp"
+
+namespace duckdb {
+
+// The OpenerFileSystem is wrapper for a file system that pushes an appropriate FileOpener into the various API calls
+class OpenerFileSystem : public FileSystem {
+public:
+	virtual FileSystem &GetFileSystem() const = 0;
+	virtual FileOpener *GetOpener() const = 0;
+
+	unique_ptr<FileHandle> OpenFile(const string &path, uint8_t flags, FileLockType lock = FileLockType::NO_LOCK,
+	                                FileCompressionType compression = FileCompressionType::UNCOMPRESSED,
+	                                FileOpener *opener = nullptr) override {
+		if (opener) {
+			throw InternalException("OpenerFileSystem cannot take an opener - the opener is pushed automatically");
+		}
+		return GetFileSystem().OpenFile(path, flags, lock, compression, GetOpener());
+	}
+
+
+	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {
+		GetFileSystem().Read(handle, buffer, nr_bytes, location);
+	};
+
+	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {
+		GetFileSystem().Write(handle, buffer, nr_bytes, location);
+	}
+
+	int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override {
+		return GetFileSystem().Read(handle, buffer, nr_bytes);
+	}
+
+	int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override {
+		return GetFileSystem().Write(handle, buffer, nr_bytes);
+	}
+
+	int64_t GetFileSize(FileHandle &handle) override {
+		return GetFileSystem().GetFileSize(handle);
+	}
+	time_t GetLastModifiedTime(FileHandle &handle) override {
+		return GetFileSystem().GetLastModifiedTime(handle);
+	}
+	FileType GetFileType(FileHandle &handle) override {
+		return GetFileSystem().GetFileType(handle);
+	}
+
+	void Truncate(FileHandle &handle, int64_t new_size) override {
+		GetFileSystem().Truncate(handle, new_size);
+	}
+
+	void FileSync(FileHandle &handle) override {
+		GetFileSystem().FileSync(handle);
+	}
+
+	bool DirectoryExists(const string &directory) override {
+		return GetFileSystem().DirectoryExists(directory);
+	}
+	void CreateDirectory(const string &directory) override {
+		return GetFileSystem().CreateDirectory(directory);
+	}
+
+	void RemoveDirectory(const string &directory) override {
+		return GetFileSystem().RemoveDirectory(directory);
+	}
+
+	bool ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
+	               FileOpener *opener = nullptr) override {
+		if (opener) {
+			throw InternalException("OpenerFileSystem cannot take an opener - the opener is pushed automatically");
+		}
+		return GetFileSystem().ListFiles(directory, callback, GetOpener());
+	}
+
+	void MoveFile(const string &source, const string &target) override {
+		GetFileSystem().MoveFile(source, target);
+	}
+
+	string GetHomeDirectory() override {
+		return FileSystem::GetHomeDirectory(GetOpener());
+	}
+
+	string ExpandPath(const string &path) override {
+		return FileSystem::ExpandPath(path, GetOpener());
+	}
+
+	bool FileExists(const string &filename) override {
+		return GetFileSystem().FileExists(filename);
+	}
+
+	bool IsPipe(const string &filename) override {
+		return GetFileSystem().IsPipe(filename);
+	}
+	virtual void RemoveFile(const string &filename) override {
+		GetFileSystem().RemoveFile(filename);
+	}
+
+	virtual vector<string> Glob(const string &path, FileOpener *opener = nullptr) override {
+		if (opener) {
+			throw InternalException("OpenerFileSystem cannot take an opener - the opener is pushed automatically");
+		}
+		return GetFileSystem().Glob(path, GetOpener());
+	}
+
+	std::string GetName() const override {
+		return GetFileSystem().GetName();
+	}
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/common/serializer/buffered_file_writer.hpp
+++ b/src/include/duckdb/common/serializer/buffered_file_writer.hpp
@@ -21,8 +21,7 @@ public:
 
 	//! Serializes to a buffer allocated by the serializer, will expand when
 	//! writing past the initial threshold
-	DUCKDB_API BufferedFileWriter(FileSystem &fs, const string &path, uint8_t open_flags = DEFAULT_OPEN_FLAGS,
-	                              FileOpener *opener = nullptr);
+	DUCKDB_API BufferedFileWriter(FileSystem &fs, const string &path, uint8_t open_flags = DEFAULT_OPEN_FLAGS);
 
 	FileSystem &fs;
 	string path;

--- a/src/include/duckdb/execution/operator/persistent/base_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/base_csv_reader.hpp
@@ -40,7 +40,6 @@ public:
 	ClientContext &context;
 	FileSystem &fs;
 	Allocator &allocator;
-	FileOpener *opener;
 	BufferedCSVReaderOptions options;
 	vector<LogicalType> return_types;
 	vector<string> names;

--- a/src/include/duckdb/main/client_data.hpp
+++ b/src/include/duckdb/main/client_data.hpp
@@ -20,6 +20,7 @@ class BufferedFileWriter;
 class ClientContext;
 class CatalogSearchPath;
 class FileOpener;
+class FileSystem;
 class HTTPState;
 class QueryProfiler;
 class QueryProfilerHistory;
@@ -54,6 +55,9 @@ struct ClientData {
 
 	//! HTTP State in this query
 	unique_ptr<HTTPState> http_state;
+
+	//! The clients' file system wrapper
+	unique_ptr<FileSystem> client_file_system;
 
 	//! The file search path
 	string file_search_path;

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -43,7 +43,7 @@ public:
 	static void InstallExtension(ClientContext &context, const string &extension, bool force_install);
 	static void InstallExtension(DBConfig &config, FileSystem &fs, const string &extension, bool force_install);
 	static void LoadExternalExtension(ClientContext &context, const string &extension);
-	static void LoadExternalExtension(DatabaseInstance &db, const string &extension);
+	static void LoadExternalExtension(DatabaseInstance &db, FileSystem &fs, const string &extension);
 
 	static string ExtensionDirectory(ClientContext &context);
 	static string ExtensionDirectory(DBConfig &config, FileSystem &fs);
@@ -70,8 +70,9 @@ private:
 	                                     const string &local_path, const string &extension, bool force_install);
 	static const vector<string> PathComponents();
 	static bool AllowAutoInstall(const string &extension);
-	static ExtensionInitResult InitialLoad(DBConfig &config, const string &extension);
-	static bool TryInitialLoad(DBConfig &config, const string &extension, ExtensionInitResult &result, string &error);
+	static ExtensionInitResult InitialLoad(DBConfig &config, FileSystem &fs, const string &extension);
+	static bool TryInitialLoad(DBConfig &config, FileSystem &fs, const string &extension, ExtensionInitResult &result,
+	                           string &error);
 	//! For tagged releases we use the tag, else we use the git commit hash
 	static const string GetVersionDirectoryName();
 	//! Version tags occur with and without 'v', tag in extension path is always with 'v'

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -43,10 +43,10 @@ public:
 	static void InstallExtension(ClientContext &context, const string &extension, bool force_install);
 	static void InstallExtension(DBConfig &config, FileSystem &fs, const string &extension, bool force_install);
 	static void LoadExternalExtension(ClientContext &context, const string &extension);
-	static void LoadExternalExtension(DatabaseInstance &db, FileOpener *opener, const string &extension);
+	static void LoadExternalExtension(DatabaseInstance &db, const string &extension);
 
 	static string ExtensionDirectory(ClientContext &context);
-	static string ExtensionDirectory(DBConfig &config, FileSystem &fs, FileOpener *opener);
+	static string ExtensionDirectory(DBConfig &config, FileSystem &fs);
 
 	static idx_t DefaultExtensionCount();
 	static DefaultExtension GetDefaultExtension(idx_t index);
@@ -70,9 +70,8 @@ private:
 	                                     const string &local_path, const string &extension, bool force_install);
 	static const vector<string> PathComponents();
 	static bool AllowAutoInstall(const string &extension);
-	static ExtensionInitResult InitialLoad(DBConfig &config, FileOpener *opener, const string &extension);
-	static bool TryInitialLoad(DBConfig &config, FileOpener *opener, const string &extension,
-	                           ExtensionInitResult &result, string &error);
+	static ExtensionInitResult InitialLoad(DBConfig &config, const string &extension);
+	static bool TryInitialLoad(DBConfig &config, const string &extension, ExtensionInitResult &result, string &error);
 	//! For tagged releases we use the tag, else we use the git commit hash
 	static const string GetVersionDirectoryName();
 	//! Version tags occur with and without 'v', tag in extension path is always with 'v'

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -233,10 +233,6 @@ Executor &ClientContext::GetExecutor() {
 	return *active_query->executor;
 }
 
-FileOpener *FileOpener::Get(ClientContext &context) {
-	return ClientData::Get(context).file_opener.get();
-}
-
 const string &ClientContext::GetCurrentQuery() {
 	D_ASSERT(active_query);
 	return active_query->query;

--- a/src/main/client_data.cpp
+++ b/src/main/client_data.cpp
@@ -24,8 +24,8 @@ public:
 		auto &config = DBConfig::GetConfig(context);
 		return *config.file_system;
 	}
-	FileOpener *GetOpener() const override {
-		return FileSystem::GetFileOpener(context);
+	optional_ptr<FileOpener> GetOpener() const override {
+		return ClientData::Get(context).file_opener.get();
 	}
 
 private:

--- a/src/main/client_data.cpp
+++ b/src/main/client_data.cpp
@@ -11,8 +11,26 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/database_manager.hpp"
 #include "duckdb/main/query_profiler.hpp"
+#include "duckdb/common/opener_file_system.hpp"
 
 namespace duckdb {
+
+class ClientFileSystem : public OpenerFileSystem {
+public:
+	ClientFileSystem(ClientContext &context_p) : context(context_p) {
+	}
+
+	FileSystem &GetFileSystem() const override {
+		auto &config = DBConfig::GetConfig(context);
+		return *config.file_system;
+	}
+	FileOpener *GetOpener() const override {
+		return FileSystem::GetFileOpener(context);
+	}
+
+private:
+	ClientContext &context;
+};
 
 ClientData::ClientData(ClientContext &context) : catalog_search_path(make_uniq<CatalogSearchPath>(context)) {
 	auto &db = DatabaseInstance::GetDatabase(context);
@@ -22,6 +40,7 @@ ClientData::ClientData(ClientContext &context) : catalog_search_path(make_uniq<C
 	temporary_objects->oid = DatabaseManager::Get(db).ModifyCatalog();
 	random_engine = make_uniq<RandomEngine>();
 	file_opener = make_uniq<ClientContextFileOpener>(context);
+	client_file_system = make_uniq<ClientFileSystem>(context);
 	temporary_objects->Initialize();
 }
 ClientData::~ClientData() {

--- a/src/main/client_data.cpp
+++ b/src/main/client_data.cpp
@@ -17,7 +17,7 @@ namespace duckdb {
 
 class ClientFileSystem : public OpenerFileSystem {
 public:
-	ClientFileSystem(ClientContext &context_p) : context(context_p) {
+	explicit ClientFileSystem(ClientContext &context_p) : context(context_p) {
 	}
 
 	FileSystem &GetFileSystem() const override {

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -230,7 +230,7 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 
 	if (!config.options.database_type.empty()) {
 		// if we are opening an extension database - load the extension
-		ExtensionHelper::LoadExternalExtension(*this, nullptr, config.options.database_type);
+		ExtensionHelper::LoadExternalExtension(*this, config.options.database_type);
 	}
 
 	if (!config.options.unrecognized_options.empty()) {

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -230,7 +230,10 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 
 	if (!config.options.database_type.empty()) {
 		// if we are opening an extension database - load the extension
-		ExtensionHelper::LoadExternalExtension(*this, config.options.database_type);
+		if (!config.file_system) {
+			throw InternalException("No file system!?");
+		}
+		ExtensionHelper::LoadExternalExtension(*this, *config.file_system, config.options.database_type);
 	}
 
 	if (!config.options.unrecognized_options.empty()) {

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -735,9 +735,8 @@ void LogQueryPathSetting::SetLocal(ClientContext &context, const Value &input) {
 		// empty path: clean up query writer
 		client_data.log_query_writer = nullptr;
 	} else {
-		client_data.log_query_writer =
-		    make_uniq<BufferedFileWriter>(FileSystem::GetFileSystem(context), path,
-		                                  BufferedFileWriter::DEFAULT_OPEN_FLAGS, client_data.file_opener.get());
+		client_data.log_query_writer = make_uniq<BufferedFileWriter>(FileSystem::GetFileSystem(context), path,
+		                                                             BufferedFileWriter::DEFAULT_OPEN_FLAGS);
 	}
 }
 

--- a/test/sqlite/sqllogic_command.cpp
+++ b/test/sqlite/sqllogic_command.cpp
@@ -272,9 +272,8 @@ void RestartCommand::ExecuteInternal(ExecuteContext &context) const {
 	runner.con->context->client_data->catalog_search_path->Set(catalog_search_paths);
 	runner.con->Commit();
 	if (!low_query_writer_path.empty()) {
-		runner.con->context->client_data->log_query_writer =
-		    make_uniq<BufferedFileWriter>(FileSystem::GetFileSystem(*runner.con->context), low_query_writer_path,
-		                                  1 << 1 | 1 << 5, runner.con->context->client_data->file_opener.get());
+		runner.con->context->client_data->log_query_writer = make_uniq<BufferedFileWriter>(
+		    FileSystem::GetFileSystem(*runner.con->context), low_query_writer_path, 1 << 1 | 1 << 5);
 	}
 }
 


### PR DESCRIPTION
This PR removes the need to pass in a `FileOpener` to many file system calls (such as `OpenFile`, `Glob`, etc). Instead - we create a new file system - the `OpenerFileSystem`. This file system wraps the core file system and will automatically push a `FileOpener` into calls made on that file system. The `ClientContext` has such a file system in the `ClientData` - and calling `FileSystem::GetFileSystem(context)` will return the `OpenerFileSystem`. As a result, code that used to look like this:

```cpp
auto &fs = FileSystem::GetFileSystem(context);
auto opener = FileSystem::GetFileOpener(context);
auto file_handle = fs.OpenFile(file_path.c_str(), FileFlags::FILE_FLAGS_READ, FileLockType::NO_LOCK, compression, opener);
```

Can now be simplified to look like this:

```cpp
auto &fs = FileSystem::GetFileSystem(context);
auto file_handle = fs.OpenFile(file_path.c_str(), FileFlags::FILE_FLAGS_READ, FileLockType::NO_LOCK, compression);
```

This cleans up/simplifies a lot of code around file system handling - and is much less error-prone. Previously when an opener was not passed in, the `HTTPFS` or `S3` clients would not function correctly, but the regular local file system would work. Forgetting to pass in an opener has been a common cause of code not working with non-local file systems.