### PR TITLE
[Julia] Fix #7420 - Don't use `unsafe_string` in `appender.jl`

### DIFF
--- a/tools/juliapkg/src/appender.jl
+++ b/tools/juliapkg/src/appender.jl
@@ -12,7 +12,7 @@ mutable struct Appender
             if error_ptr == C_NULL
                 error_message = string("Opening of Appender for table \"", table, "\" failed: unknown error")
             else
-                error_message = unsafe_string(error_ptr)
+                error_message = string(error_ptr)
             end
             duckdb_appender_destroy(handle)
             throw(QueryException(error_message))


### PR DESCRIPTION
This PR fixes #7420

Apparently this is a problem somehow, I've verified that the c-api code is correct here, returning either `NULL` or the c_str() of the `string` stored in the `AppenderWrapper` (`handle` in `appender.jl`)
This memory does not get freed before `unsafe_string` has returned. After which it should be (according to the documentation of unsafe_string) safe to free the memory used to create the unsafe string.

If the pointer was somehow invalid (but not NULL) then `string` should also crash.
So in short: can't explain why this fixes it, but the test no longer crashes in the PR 👍 