### PR TITLE
Issue #7426: DuckDBVector getTimestamp

### DIFF
--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
@@ -469,7 +469,7 @@ class DuckDBVector {
 		// Our raw data is already a proper count of units since the epoch
 		// So just construct the SQL Timestamp.
 		if (isType(DuckDBColumnType.TIMESTAMP)) {
-			return DuckDBTimestamp.fromMicroInstant(getbuf(idx, 8).getLong(idx));
+			return DuckDBTimestamp.fromMicroInstant(getbuf(idx, 8).getLong());
 		}
 		if (isType(DuckDBColumnType.TIMESTAMP_MS)) {
 			return DuckDBTimestamp.fromMilliInstant(getbuf(idx, 8).getLong());

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -505,6 +505,19 @@ public class TestDuckDBJDBC {
 		conn.close();
 	}
 
+    public static void test_consecutive_timestamps() throws Exception {
+    	long expected = 986860800000L;
+        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:"); Statement stmt = conn.createStatement()) {
+            try (ResultSet rs = stmt.executeQuery("select range from range(TIMESTAMP '2001-04-10', TIMESTAMP '2001-04-11', INTERVAL 30 MINUTE)")) {
+                while (rs.next()) {
+                    Timestamp actual = rs.getTimestamp(1, Calendar.getInstance());
+                    assertEquals(expected, actual.getTime());
+                    expected += 30 * 60 * 1_000;
+                }
+            }
+        }
+    }
+
 	public static void test_throw_wrong_datatype() throws Exception {
 		Connection conn = DriverManager.getConnection("jdbc:duckdb:");
 		Statement stmt = conn.createStatement();


### PR DESCRIPTION
Remove a spurious idx parameter in the call to getLong.

fixes #7426 