### PR TITLE
CI NodeJS: build and publish nightly for M1

### DIFF
--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -233,7 +233,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}
 
       - name: Node ${{ matrix.node }}
-        if: matrix.target_arch != 'arm64'
         shell: bash
         run: ./scripts/node_build.sh ${{ matrix.node }}
 


### PR DESCRIPTION
Currently nightly is not published on NPM for Mac M1, and this means installs falls back to local build.