### PR TITLE
Add initialization of HTTPState to `TryBindRelation`

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1013,6 +1013,7 @@ void ClientContext::TryBindRelation(Relation &relation, vector<ColumnDefinition>
 	D_ASSERT(!relation.GetAlias().empty());
 	D_ASSERT(!relation.ToString().empty());
 #endif
+	client_data->http_state = make_uniq<HTTPState>();
 	RunFunctionInTransaction([&]() {
 		// bind the expressions
 		auto binder = Binder::CreateBinder(*this);

--- a/tools/pythonpkg/tests/extensions/test_httpfs.py
+++ b/tools/pythonpkg/tests/extensions/test_httpfs.py
@@ -10,36 +10,42 @@ pytestmark = mark.skipif(
     reason='httpfs extension not available'
 )
 
-@pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-def test_httpfs(require, pandas):
-    connection = require('httpfs')
-    try:
-        connection.execute("SELECT id, first_name, last_name FROM PARQUET_SCAN('https://raw.githubusercontent.com/cwida/duckdb/master/data/parquet-testing/userdata1.parquet') LIMIT 3;")
-    except RuntimeError as e:
-        # Test will ignore result if it fails due to networking issues while running the test.
-        if (str(e).startswith("HTTP HEAD error")):
-            return
-        elif (str(e).startswith("Unable to connect")):
-            return
-        else:
-            raise e
+class TestHTTPFS(object):
+	def test_read_json_httpfs(self, require):
+		connection = require('httpfs')
+		res = connection.read_json('https://jsonplaceholder.typicode.com/todos')
+		assert len(res.types) == 4
 
-    result_df = connection.fetchdf()
-    exp_result = pandas.DataFrame({
-        'id': pandas.Series([1, 2, 3], dtype="int32"),
-        'first_name': ['Amanda', 'Albert', 'Evelyn'],
-        'last_name': ['Jordan', 'Freeman', 'Morgan']
-    })
-    pandas.testing.assert_frame_equal(result_df, exp_result)
+	@pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
+	def test_httpfs(self, require, pandas):
+		connection = require('httpfs')
+		try:
+			connection.execute("SELECT id, first_name, last_name FROM PARQUET_SCAN('https://raw.githubusercontent.com/cwida/duckdb/master/data/parquet-testing/userdata1.parquet') LIMIT 3;")
+		except RuntimeError as e:
+			# Test will ignore result if it fails due to networking issues while running the test.
+			if (str(e).startswith("HTTP HEAD error")):
+				return
+			elif (str(e).startswith("Unable to connect")):
+				return
+			else:
+				raise e
 
-def test_http_exception(require):
-    connection = require('httpfs')
+		result_df = connection.fetchdf()
+		exp_result = pandas.DataFrame({
+			'id': pandas.Series([1, 2, 3], dtype="int32"),
+			'first_name': ['Amanda', 'Albert', 'Evelyn'],
+			'last_name': ['Jordan', 'Freeman', 'Morgan']
+		})
+		pandas.testing.assert_frame_equal(result_df, exp_result)
 
-    with raises(duckdb.HTTPException) as exc:
-        connection.execute("SELECT * FROM PARQUET_SCAN('https://example.com/userdata1.parquet')")
+	def test_http_exception(self, require):
+		connection = require('httpfs')
 
-    value = exc.value
-    assert value.status_code == 404
-    assert value.reason == 'Not Found'
-    assert value.body == ''
-    assert 'Content-Length' in value.headers
+		with raises(duckdb.HTTPException) as exc:
+			connection.execute("SELECT * FROM PARQUET_SCAN('https://example.com/userdata1.parquet')")
+
+		value = exc.value
+		assert value.status_code == 404
+		assert value.reason == 'Not Found'
+		assert value.body == ''
+		assert 'Content-Length' in value.headers

--- a/tools/pythonpkg/tests/fast/test_httpfs.py
+++ b/tools/pythonpkg/tests/fast/test_httpfs.py
@@ -1,7 +1,0 @@
-import pytest
-import duckdb
-
-class TestHTTPFS:
-	def test_httpfs(self):
-		res = duckdb.read_json('https://jsonplaceholder.typicode.com/todos')
-		assert len(res.types) == 4

--- a/tools/pythonpkg/tests/fast/test_httpfs.py
+++ b/tools/pythonpkg/tests/fast/test_httpfs.py
@@ -1,0 +1,7 @@
+import pytest
+import duckdb
+
+class TestHTTPFS:
+	def test_httpfs(self):
+		res = duckdb.read_json('https://jsonplaceholder.typicode.com/todos')
+		assert len(res.types) == 4


### PR DESCRIPTION
This PR fixes #6827

We weren't initializing the state, causing the bind of the `read_json` function in the Python client to fail, because it uses `read_json_auto` by default - which needs to open the file during bind time.

