### PR TITLE
Fix #7274 - correctly do a case insensitive comparison in UndoBuffer::Undo

### DIFF
--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -621,7 +621,7 @@ void CatalogSet::Undo(CatalogEntry &entry) {
 		auto &dependency_manager = catalog.GetDependencyManager();
 		dependency_manager.EraseObject(to_be_removed_node);
 	}
-	if (entry.name != to_be_removed_node.name) {
+	if (!StringUtil::CIEquals(entry.name, to_be_removed_node.name)) {
 		// rename: clean up the new name when the rename is rolled back
 		auto removed_entry = mapping.find(to_be_removed_node.name);
 		if (removed_entry->second->child) {

--- a/test/sql/catalog/drop_create_rollback.test
+++ b/test/sql/catalog/drop_create_rollback.test
@@ -1,0 +1,29 @@
+# name: test/sql/catalog/drop_create_rollback.test
+# description: Issue #7274 - crash when recreating table with different case sensitivity but the same name
+# group: [catalog]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t1 (c1 CHAR(5));
+
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
+DROP TABLE IF EXISTS t1;
+
+statement ok
+CREATE TABLE T1 (C2 CHAR(5));
+
+statement ok
+SELECT C2 FROM T1;
+
+statement ok
+ROLLBACK;
+
+statement error
+SELECT C2 FROM T1;
+----
+c1


### PR DESCRIPTION
Fixes #7274

