### PR TITLE
7415 cross-product joins on parquet files

### DIFF
--- a/benchmark/micro/join/join_from_parquet.benchmark
+++ b/benchmark/micro/join/join_from_parquet.benchmark
@@ -1,0 +1,18 @@
+# name: benchmark/micro/join/join_from_parquet.benchmark
+# description: Join between two parquet files. We want to put the smaller parquet file on the build side  
+# group: [join]
+
+name Right Outer Join (big LHS, small RHS)
+group join
+
+require tpch
+
+cache tpch_sf1.duckdb
+
+load
+COPY lineitem TO 'lineitem.parquet';
+COPY (SELECT 42) TO 'singlerow.parquet';
+
+run
+select * from 'singlerow.parquet', 'lineitem.parquet';
+

--- a/benchmark/micro/join/join_from_parquet.benchmark
+++ b/benchmark/micro/join/join_from_parquet.benchmark
@@ -1,5 +1,5 @@
 # name: benchmark/micro/join/join_from_parquet.benchmark
-# description: Join between two parquet files. We want to put the smaller parquet file on the build side  
+# description: Join between two parquet files. We want to put the smaller parquet file on the build side
 # group: [join]
 
 name Right Outer Join (big LHS, small RHS)

--- a/src/optimizer/join_order/cardinality_estimator.cpp
+++ b/src/optimizer/join_order/cardinality_estimator.cpp
@@ -574,9 +574,9 @@ void CardinalityEstimator::EstimateBaseTableCardinality(JoinNode &node, LogicalO
 	D_ASSERT(node.set.count == 1);
 	auto relation_id = node.set.relations[0];
 
-	double lowest_card_found = NumericLimits<double>::Maximum();
+	double lowest_card_found = node.GetBaseTableCardinality();
 	for (auto &column : relation_attributes[relation_id].columns) {
-		auto card_after_filters = node.GetBaseTableCardinality();
+		auto card_after_filters = lowest_card_found;
 		ColumnBinding key = ColumnBinding(relation_id, column);
 		optional_ptr<TableFilterSet> table_filters;
 		auto actual_binding = relation_column_to_original_column.find(key);

--- a/src/optimizer/join_order/cardinality_estimator.cpp
+++ b/src/optimizer/join_order/cardinality_estimator.cpp
@@ -576,7 +576,7 @@ void CardinalityEstimator::EstimateBaseTableCardinality(JoinNode &node, LogicalO
 
 	double lowest_card_found = node.GetBaseTableCardinality();
 	for (auto &column : relation_attributes[relation_id].columns) {
-		auto card_after_filters = lowest_card_found;
+		auto card_after_filters = node.GetBaseTableCardinality();
 		ColumnBinding key = ColumnBinding(relation_id, column);
 		optional_ptr<TableFilterSet> table_filters;
 		auto actual_binding = relation_column_to_original_column.find(key);


### PR DESCRIPTION
fixes https://github.com/duckdb/duckdb/issues/7415.

Currently, we are incorrectly initializing base table cardinalities for relations when we have no column information to join them on. In this case, with a cross-product, there are no filter relations, and when we call `EstimateBaseTableCardinality` in the cardinality estimator, our initial first guess is `NumericLimits<double>::Maximum()`. This logic is not ideal since cross products don't join any columns and if a large table is originally planned on the build side, it stays on the build side. 

Here we initialize the node node cardinality with the base table cardinality in case there are no columns