### PR TITLE
Lipo macos extensions to reduce their size

### DIFF
--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -199,23 +199,11 @@ jobs:
           run_tests: 0
           osx_universal: 1
 
-      - name: Create separate binaries again
+      - name: Create separate binaries
         shell: bash
         run: |
           ./scripts/extension-lipo-strip.sh x86_64 build/release/extension build/release/extension_arm64
           ./scripts/extension-lipo-strip.sh arm64 build/release/extension build/release/extension_x64
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: test-extensions-upload-arm64
-          path: |
-            build/release/extension_arm64/*.duckdb_extension
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: test-extensions-upload-x64
-          path: |
-            build/release/extension_x64/*.duckdb_extension
 
       - name: Deploy
         shell: bash

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -199,6 +199,24 @@ jobs:
           run_tests: 0
           osx_universal: 1
 
+      - name: Create separate binaries again
+        shell: bash
+        run: |
+          ./scripts/extension-lipo-strip.sh x86_64 build/release/extension build/release/extension_arm64
+          ./scripts/extension-lipo-strip.sh arm64 build/release/extension build/release/extension_x64
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: test-extensions-upload-arm64
+          path: |
+            build/release/extension_arm64/*.duckdb_extension
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: test-extensions-upload-x64
+          path: |
+            build/release/extension_x64/*.duckdb_extension
+
       - name: Deploy
         shell: bash
         env:
@@ -207,13 +225,13 @@ jobs:
         run: |
           if [[ "$GITHUB_REF" =~ ^(refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
             pip install awscli
-            ./scripts/extension-upload.sh osx_amd64 ${{ github.ref_name }}
-            ./scripts/extension-upload.sh osx_arm64 ${{ github.ref_name }}
+            ./scripts/extension-upload.sh osx_amd64 ${{ github.ref_name }} build/release/extension_x64
+            ./scripts/extension-upload.sh osx_arm64 ${{ github.ref_name }} build/release/extension_arm64
             ./scripts/extension-upload-test.sh
           elif [[ "$GITHUB_REF" =~ ^(refs/heads/master)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
             pip install awscli
-            ./scripts/extension-upload.sh osx_amd64 `git log -1 --format=%h`
-            ./scripts/extension-upload.sh osx_arm64 `git log -1 --format=%h`
+            ./scripts/extension-upload.sh osx_amd64 `git log -1 --format=%h` build/release/extension_x64
+            ./scripts/extension-upload.sh osx_arm64 `git log -1 --format=%h` build/release/extension_arm64
             ./scripts/extension-upload-test.sh
           else
             ./scripts/extension-upload-test.sh local

--- a/scripts/extension-lipo-strip.sh
+++ b/scripts/extension-lipo-strip.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+if [ "$#" -ne 3 ]; then
+    echo "Usage: ./extension-lipo-strip.sh <arch_to_strip> <base_dir> <output_dir>"
+fi
+
+set -e
+
+# Ensure we do nothing on failed globs
+shopt -s nullglob
+
+FILES="$2/*/*.duckdb_extension"
+
+# Ensure the output dir exists
+mkdir -p $3
+
+# Give dem fat extensions some lipo
+for f in $FILES
+do
+	ext=`basename $f .duckdb_extension`
+	lipo $f -remove $1 -output $3/$ext.duckdb_extension
+done

--- a/scripts/extension-upload.sh
+++ b/scripts/extension-upload.sh
@@ -1,16 +1,24 @@
 #!/bin/bash
 
-# Usage: ./extension-upload.sh <architecture> <commithash or version_tag>
+# Usage: ./extension-upload.sh <architecture> <commithash or version_tag> <(optionally) base_dir>
+
+if [ -z "$3" ]; then
+    BASE_DIR="build/release/extension/*"
+else
+    BASE_DIR="$3"
+fi
 
 set -e
 
+# Ensure we do nothing on failed globs
+shopt -s nullglob
+
 echo "$DUCKDB_EXTENSION_SIGNING_PK" > private.pem
 
-FILES="build/release/extension/*/*.duckdb_extension"
+FILES="$BASE_DIR/*.duckdb_extension"
 for f in $FILES
 do
 	ext=`basename $f .duckdb_extension`
-	echo $ext
 	# calculate SHA256 hash of extension binary
 	scripts/compute-extension-hash.sh $f > $f.hash
 	# encrypt hash with extension signing private key to create signature


### PR DESCRIPTION
This PR splits the universal binaries for macos extension into an arm and x86 part, reducing their size by half. Since we already deploy them for each arch separately, this is an easy win in the binary size department. Thanks @hannes for pointing out the lipo tool which makes this very simple.

I tested this by manually uploading on of the extension from gh actions to s3 then loading this from duckdb, which seems to work no problem. However, it will only be actually tested from CI on the next nightly / release and only for the x86 binary since the GH actions runners are x86.

