### PR TITLE
Add support for array_to_string as an alias to list_aggr with 'string_agg'

### DIFF
--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -92,6 +92,7 @@ static DefaultMacro internal_macros[] = {
 	{DEFAULT_SCHEMA, "array_pop_front", {"arr", nullptr}, "arr[2:]"},
 	{DEFAULT_SCHEMA, "array_push_back", {"arr", "e", nullptr}, "list_concat(arr, list_value(e))"},
 	{DEFAULT_SCHEMA, "array_push_front", {"arr", "e", nullptr}, "list_concat(list_value(e), arr)"},
+	{DEFAULT_SCHEMA, "array_to_string", {"arr", "sep", nullptr}, "list_aggr(arr, 'string_agg', sep)"},
 	{DEFAULT_SCHEMA, "generate_subscripts", {"arr", "dim", nullptr}, "unnest(generate_series(1, array_length(arr, dim)))"},
 	{DEFAULT_SCHEMA, "fdiv", {"x", "y", nullptr}, "floor(x/y)"},
 	{DEFAULT_SCHEMA, "fmod", {"x", "y", nullptr}, "(x-y*floor(x/y))"},

--- a/src/core_functions/scalar/list/list_aggregates.cpp
+++ b/src/core_functions/scalar/list/list_aggregates.cpp
@@ -344,19 +344,16 @@ static void ListAggregatesFunction(DataChunk &args, ExpressionState &state, Vect
 }
 
 static void ListAggregateFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-
-	D_ASSERT(args.ColumnCount() == 2);
+	D_ASSERT(args.ColumnCount() >= 2);
 	ListAggregatesFunction<AggregateFunctor, true>(args, state, result);
 }
 
 static void ListDistinctFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-
 	D_ASSERT(args.ColumnCount() == 1);
 	ListAggregatesFunction<DistinctFunctor>(args, state, result);
 }
 
 static void ListUniqueFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-
 	D_ASSERT(args.ColumnCount() == 1);
 	ListAggregatesFunction<UniqueFunctor>(args, state, result);
 }

--- a/test/sql/function/list/array_to_string.test
+++ b/test/sql/function/list/array_to_string.test
@@ -1,0 +1,45 @@
+# name: test/sql/function/list/array_to_string.test
+# description: Test array_to_string function
+# group: [list]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT array_to_string([1,2,3], '')
+----
+123
+
+query I
+SELECT array_to_string([1,2,3], '-')
+----
+1-2-3
+
+query I
+SELECT array_to_string(NULL, '-')
+----
+NULL
+
+query I
+SELECT array_to_string([1, 2, 3], NULL)
+----
+1,2,3
+
+
+query I
+SELECT array_to_string([], '-')
+----
+NULL
+
+query I
+SELECT array_to_string([i, i + 1], '-') FROM range(6) t(i) WHERE i<=2 OR i>4
+----
+0-1
+1-2
+2-3
+5-6
+
+statement error
+SELECT array_to_string([1, 2, 3], k) FROM repeat(',', 5) t(k)
+----
+Separator argument to StringAgg must be a constant


### PR DESCRIPTION
```sql
select array_to_string([1, 2, 3], '-') as a;
┌─────────┐
│    a    │
│ varchar │
├─────────┤
│ 1-2-3   │
└─────────┘
-- equivalent to
select list_aggr([1, 2, 3], 'string_agg', '-') as a;
┌─────────┐
│    a    │
│ varchar │
├─────────┤
│ 1-2-3   │
└─────────┘

```