### PR TITLE
Fix #6234 - throw invalid input exception when attempting to create non-temp entry in temp database, and disallow SET SCHEMA to temp/system schemas

### DIFF
--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -145,6 +145,11 @@ void CatalogSearchPath::Set(vector<CatalogSearchEntry> new_paths, bool is_set_sc
 			                       is_set_schema ? "schema" : "search_path", path.ToString());
 		}
 	}
+	if (is_set_schema) {
+		if (new_paths[0].catalog == TEMP_CATALOG || new_paths[0].catalog == SYSTEM_CATALOG) {
+			throw CatalogException("SET schema cannot be set to internal schema \"%s\"", new_paths[0].catalog);
+		}
+	}
 	this->set_paths = std::move(new_paths);
 	SetPaths(set_paths);
 }

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -84,7 +84,7 @@ bool CatalogSet::CreateEntry(CatalogTransaction transaction, const string &name,
 			throw InternalException("Attempting to create temporary entry \"%s\" in non-temporary catalog", name);
 		}
 		if (!value->temporary && catalog.IsTemporaryCatalog() && name != DEFAULT_SCHEMA) {
-			throw InternalException("Attempting to create non-temporary entry \"%s\" in temporary catalog", name);
+			throw InvalidInputException("Cannot create non-temporary entry \"%s\" in temporary catalog", name);
 		}
 	}
 	// lock the catalog for writing

--- a/test/sql/settings/set_schema_temp_main.test
+++ b/test/sql/settings/set_schema_temp_main.test
@@ -1,0 +1,25 @@
+# name: test/sql/settings/set_schema_temp_main.test
+# group: [settings]
+
+statement ok
+pragma enable_verification;
+
+statement error
+CREATE SCHEMA temp.s1;
+----
+Cannot create non-temporary entry "s1" in temporary catalog
+
+statement error
+CREATE SCHEMA system.s1;
+----
+Cannot create schema in system catalog
+
+statement error
+set schema = 'temp';
+----
+SET schema cannot be set to internal schema "temp"
+
+statement error
+set schema = 'system';
+----
+SET schema cannot be set to internal schema "system"


### PR DESCRIPTION
Fixes #6234