### PR TITLE
[Dev] Add SQLString and SQLIndentifier helpers for `ExceptionFormatValue`

### DIFF
--- a/extension/json/json_functions/json_transform.cpp
+++ b/extension/json/json_functions/json_transform.cpp
@@ -658,7 +658,7 @@ static bool TransformObjectToMap(yyjson_val *objects[], yyjson_alc *alc, Vector 
 	// Transform keys
 	if (!JSONTransform::Transform(keys, alc, MapVector::GetKeys(result), list_size, options)) {
 		throw ConversionException(
-		    StringUtil::Format(options.error_message, ". Cannot default to NULL, because map keys cannot be NULL"));
+		    StringUtil::Format(options.error_message + ". Cannot default to NULL, because map keys cannot be NULL"));
 	}
 
 	// Transform values

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -59,6 +59,23 @@ string Exception::GetStackTrace(int max_depth) {
 }
 
 string Exception::ConstructMessageRecursive(const string &msg, std::vector<ExceptionFormatValue> &values) {
+#ifdef DEBUG
+	// Verify that we have the required amount of values for the message
+	idx_t parameter_count = 0;
+	for (idx_t i = 0; i < msg.size(); i++) {
+		if (msg[i] != '%') {
+			continue;
+		}
+		if (i < msg.size() && msg[i + 1] == '%') {
+			i++;
+			continue;
+		}
+		parameter_count++;
+	}
+	if (parameter_count != values.size()) {
+		throw InternalException("Expected %d parameters, received %d", parameter_count, values.size());
+	}
+#endif
 	return ExceptionFormatValue::Format(msg, values);
 }
 

--- a/src/common/exception_format_value.cpp
+++ b/src/common/exception_format_value.cpp
@@ -3,6 +3,7 @@
 #include "fmt/format.h"
 #include "fmt/printf.h"
 #include "duckdb/common/types/hugeint.hpp"
+#include "duckdb/parser/keyword_helper.hpp"
 
 namespace duckdb {
 
@@ -40,6 +41,19 @@ template <>
 ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(string value) {
 	return ExceptionFormatValue(std::move(value));
 }
+
+template <>
+ExceptionFormatValue
+ExceptionFormatValue::CreateFormatValue(SQLString value) { // NOLINT: templating requires us to copy value here
+	return KeywordHelper::WriteQuoted(value.raw_string, '\'');
+}
+
+template <>
+ExceptionFormatValue
+ExceptionFormatValue::CreateFormatValue(SQLIdentifier value) { // NOLINT: templating requires us to copy value here
+	return KeywordHelper::WriteOptionallyQuoted(value.raw_string, '"');
+}
+
 template <>
 ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const char *value) {
 	return ExceptionFormatValue(string(value));

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -349,7 +349,7 @@ string LogicalType::ToString() const {
 		auto &child_types = StructType::GetChildTypes(*this);
 		string ret = "STRUCT(";
 		for (size_t i = 0; i < child_types.size(); i++) {
-			ret += KeywordHelper::WriteOptionallyQuoted(child_types[i].first) + " " + child_types[i].second.ToString();
+			ret += StringUtil::Format("%s %s", SQLIdentifier(child_types[i].first), child_types[i].second);
 			if (i < child_types.size() - 1) {
 				ret += ", ";
 			}

--- a/src/execution/operator/persistent/physical_export.cpp
+++ b/src/execution/operator/persistent/physical_export.cpp
@@ -51,8 +51,8 @@ static void WriteCopyStatement(FileSystem &fs, stringstream &ss, CopyInfo &info,
 		ss << KeywordHelper::WriteOptionallyQuoted(exported_table.schema_name) << ".";
 	}
 
-	ss << KeywordHelper::WriteOptionallyQuoted(exported_table.table_name) << " FROM '" << exported_table.file_path
-	   << "' (";
+	ss << StringUtil::Format("%s FROM '%s' (", SQLIdentifier(exported_table.table_name),
+	                         SQLString(exported_table.file_path));
 
 	// write the copy options
 	ss << "FORMAT '" << info.format << "'";

--- a/src/execution/operator/persistent/physical_export.cpp
+++ b/src/execution/operator/persistent/physical_export.cpp
@@ -51,7 +51,7 @@ static void WriteCopyStatement(FileSystem &fs, stringstream &ss, CopyInfo &info,
 		ss << KeywordHelper::WriteOptionallyQuoted(exported_table.schema_name) << ".";
 	}
 
-	ss << StringUtil::Format("%s FROM '%s' (", SQLIdentifier(exported_table.table_name),
+	ss << StringUtil::Format("%s FROM %s (", SQLIdentifier(exported_table.table_name),
 	                         SQLString(exported_table.file_path));
 
 	// write the copy options

--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -41,7 +41,7 @@ string PragmaShowTables(ClientContext &context, const FunctionParameters &parame
 	)
 	SELECT "name"
 	FROM db_objects
-	ORDER BY "name";)EOF", where_clause, where_clause, where_clause);
+	ORDER BY "name";)EOF", where_clause, where_clause);
 	// clang-format on
 
 	return pragma_query;

--- a/src/include/duckdb/common/exception_format_value.hpp
+++ b/src/include/duckdb/common/exception_format_value.hpp
@@ -15,6 +15,28 @@
 
 namespace duckdb {
 
+// Helper class to support custom overloading
+// Escaping " and quoting the value with "
+class SQLIdentifier {
+public:
+	SQLIdentifier(const string &raw_string) : raw_string(raw_string) {
+	}
+
+public:
+	string raw_string;
+};
+
+// Helper class to support custom overloading
+// Escaping ' and quoting the value with '
+class SQLString {
+public:
+	SQLString(const string &raw_string) : raw_string(raw_string) {
+	}
+
+public:
+	string raw_string;
+};
+
 enum class PhysicalType : uint8_t;
 struct LogicalType;
 
@@ -46,6 +68,10 @@ public:
 
 template <>
 DUCKDB_API ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(PhysicalType value);
+template <>
+DUCKDB_API ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(SQLString value);
+template <>
+DUCKDB_API ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(SQLIdentifier value);
 template <>
 DUCKDB_API ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(LogicalType value);
 template <>

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -15,6 +15,7 @@
 #include <cstring>
 
 namespace duckdb {
+
 /**
  * String Utility Functions
  * Note that these are not the most efficient implementations (i.e., they copy
@@ -83,6 +84,23 @@ public:
 			return true;
 		}
 		return false;
+	}
+
+	template <class TO>
+	static vector<TO> ConvertStrings(const vector<string> &strings) {
+		vector<TO> result;
+		for (auto &string : strings) {
+			result.emplace_back(string);
+		}
+		return result;
+	}
+
+	static vector<SQLIdentifier> ConvertToSQLIdentifiers(const vector<string> &strings) {
+		return ConvertStrings<SQLIdentifier>(strings);
+	}
+
+	static vector<SQLString> ConvertToSQLStrings(const vector<string> &strings) {
+		return ConvertStrings<SQLString>(strings);
 	}
 
 	//! Returns true if the needle string exists in the haystack

--- a/src/include/duckdb/parser/expression/function_expression.hpp
+++ b/src/include/duckdb/parser/expression/function_expression.hpp
@@ -92,7 +92,7 @@ public:
 		result += StringUtil::Join(entry.children, entry.children.size(), ", ", [&](const unique_ptr<BASE> &child) {
 			return child->alias.empty() || !add_alias
 			           ? child->ToString()
-			           : KeywordHelper::WriteOptionallyQuoted(child->alias) + " := " + child->ToString();
+			           : StringUtil::Format("%s := %s", SQLIdentifier(child->alias), child->ToString());
 		});
 		// ordered aggregate
 		if (order_bys && !order_bys->orders.empty()) {

--- a/src/include/duckdb/parser/expression/operator_expression.hpp
+++ b/src/include/duckdb/parser/expression/operator_expression.hpp
@@ -96,8 +96,8 @@ public:
 			auto child_string = entry.children[1]->ToString();
 			D_ASSERT(child_string.size() >= 3);
 			D_ASSERT(child_string[0] == '\'' && child_string[child_string.size() - 1] == '\'');
-			return "(" + entry.children[0]->ToString() + ")." +
-			       KeywordHelper::WriteOptionallyQuoted(child_string.substr(1, child_string.size() - 2));
+			return StringUtil::Format("(%s).%s", entry.children[0]->ToString(),
+			                          SQLIdentifier(child_string.substr(1, child_string.size() - 2)));
 		}
 		case ExpressionType::ARRAY_CONSTRUCTOR: {
 			string result = "(ARRAY[";

--- a/src/include/duckdb/parser/keyword_helper.hpp
+++ b/src/include/duckdb/parser/keyword_helper.hpp
@@ -17,8 +17,13 @@ public:
 	//! Returns true if the given text matches a keyword of the parser
 	static bool IsKeyword(const string &text);
 
+	static string EscapeQuotes(const string &text, char quote = '"');
+
 	//! Returns true if the given string needs to be quoted when written as an identifier
 	static bool RequiresQuotes(const string &text, bool allow_caps = true);
+
+	//! Writes a string that is quoted
+	static string WriteQuoted(const string &text, char quote = '\'');
 
 	//! Writes a string that is optionally quoted + escaped so it can be used as an identifier
 	static string WriteOptionallyQuoted(const string &text, char quote = '"', bool allow_caps = true);

--- a/src/parser/expression/collate_expression.cpp
+++ b/src/parser/expression/collate_expression.cpp
@@ -15,7 +15,7 @@ CollateExpression::CollateExpression(string collation_p, unique_ptr<ParsedExpres
 }
 
 string CollateExpression::ToString() const {
-	return child->ToString() + " COLLATE " + KeywordHelper::WriteOptionallyQuoted(collation);
+	return StringUtil::Format("%s COLLATE %s", child->ToString(), SQLIdentifier(collation));
 }
 
 bool CollateExpression::Equal(const CollateExpression *a, const CollateExpression *b) {

--- a/src/parser/keyword_helper.cpp
+++ b/src/parser/keyword_helper.cpp
@@ -29,11 +29,21 @@ bool KeywordHelper::RequiresQuotes(const string &text, bool allow_caps) {
 	return IsKeyword(text);
 }
 
+string KeywordHelper::EscapeQuotes(const string &text, char quote) {
+	return StringUtil::Replace(text, string(1, quote), string(2, quote));
+}
+
+string KeywordHelper::WriteQuoted(const string &text, char quote) {
+	// 1. Escapes all occurences of 'quote' by doubling them (escape in SQL)
+	// 2. Adds quotes around the string
+	return string(1, quote) + EscapeQuotes(text) + string(1, quote);
+}
+
 string KeywordHelper::WriteOptionallyQuoted(const string &text, char quote, bool allow_caps) {
 	if (!RequiresQuotes(text, allow_caps)) {
 		return text;
 	}
-	return string(1, quote) + StringUtil::Replace(text, string(1, quote), string(2, quote)) + string(1, quote);
+	return WriteQuoted(text, quote);
 }
 
 } // namespace duckdb

--- a/src/parser/query_node/select_node.cpp
+++ b/src/parser/query_node/select_node.cpp
@@ -39,7 +39,7 @@ string SelectNode::ToString() const {
 		}
 		result += select_list[i]->ToString();
 		if (!select_list[i]->alias.empty()) {
-			result += " AS " + KeywordHelper::WriteOptionallyQuoted(select_list[i]->alias);
+			result += StringUtil::Format(" AS %s", SQLIdentifier(select_list[i]->alias));
 		}
 	}
 	if (from_table && from_table->type != TableReferenceType::EMPTY) {

--- a/src/parser/statement/copy_statement.cpp
+++ b/src/parser/statement/copy_statement.cpp
@@ -86,7 +86,7 @@ string CopyStatement::ToString() const {
 		D_ASSERT(!select_statement);
 		result += TablePart(*info);
 		result += " FROM";
-		result += StringUtil::Format(" '%s'", info->file_path);
+		result += StringUtil::Format(" %s", SQLString(info->file_path));
 		result += CopyOptionsToString(info->format, info->options);
 	} else {
 		if (select_statement) {
@@ -96,7 +96,7 @@ string CopyStatement::ToString() const {
 			result += TablePart(*info);
 		}
 		result += " TO ";
-		result += StringUtil::Format("'%s'", info->file_path);
+		result += StringUtil::Format("%s", SQLString(info->file_path));
 		result += CopyOptionsToString(info->format, info->options);
 	}
 	return result;

--- a/src/parser/tableref.cpp
+++ b/src/parser/tableref.cpp
@@ -16,7 +16,7 @@ string TableRef::BaseToString(string result) const {
 
 string TableRef::BaseToString(string result, const vector<string> &column_name_alias) const {
 	if (!alias.empty()) {
-		result += " AS " + KeywordHelper::WriteOptionallyQuoted(alias);
+		result += StringUtil::Format(" AS %s", SQLIdentifier(alias));
 	}
 	if (!column_name_alias.empty()) {
 		D_ASSERT(!alias.empty());

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -300,7 +300,7 @@ vector<string> TestResultHelper::LoadResultFromFile(string fname, vector<string>
 		if (i > 0) {
 			struct_definition += ", ";
 		}
-		struct_definition += KeywordHelper::WriteOptionallyQuoted(names[i]) + " := 'VARCHAR'";
+		struct_definition += StringUtil::Format("%s := VARCHAR", SQLIdentifier(names[i]));
 	}
 	struct_definition += ")";
 

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -521,9 +521,17 @@ shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Append(const string &name, co
 		for (auto &column : df_columns) {
 			column_names.push_back(std::string(py::str(column)));
 		}
-		columns = StringUtil::Format("(%s)", StringUtil::Join(column_names, ","));
+		columns += "(";
+		for (idx_t i = 0; i < column_names.size(); i++) {
+			auto &column = column_names[i];
+			if (i != 0) {
+				columns += ", ";
+			}
+			columns += StringUtil::Format("%s", SQLIdentifier(column));
+		}
+		columns += ")";
 	}
-	return Execute(StringUtil::Format("INSERT INTO \"%s\"%s SELECT * FROM __append_df", name, columns));
+	return Execute(StringUtil::Format("INSERT INTO %s %s SELECT * FROM __append_df", SQLIdentifier(name), columns));
 }
 
 void DuckDBPyConnection::RegisterArrowObject(const py::object &arrow_object, const string &name) {

--- a/tools/pythonpkg/tests/fast/pandas/test_append_df.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_append_df.py
@@ -29,7 +29,20 @@ class TestAppendDF(object):
         con.append('tbl', df_in, by_name=True)
         res = con.table('tbl').fetchall()
         assert res == [(4, False, 'duck'), (2, True, 'db')]
-    
+
+    @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
+    def test_append_by_name_quoted(self, pandas):
+        con = duckdb.connect()
+        con.execute("""
+            create table tbl ("needs to be quoted" integer, other varchar)
+        """)
+        df_in = pandas.DataFrame({
+            "needs to be quoted": [1,2,3]
+        })
+        con.append('tbl', df_in, by_name=True)
+        res = con.table('tbl').fetchall()
+        assert res == [(1, None), (2, None), (3, None)]
+
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
     def test_append_by_name_no_exact_match(self, pandas):
         con = duckdb.connect()


### PR DESCRIPTION
This PR fixes #7472 

It also implements the suggestion made in https://github.com/duckdb/duckdb/issues/7472#issuecomment-1545319276

Next to that I've also added some DEBUG verification code to StringUtil::Format which checks that the right amount of arguments are provided for the given argument string.