### PR TITLE
Run old CSV reader when reading many files

### DIFF
--- a/benchmark/tpch/csv/lineitem_csv_many_files.benchmark
+++ b/benchmark/tpch/csv/lineitem_csv_many_files.benchmark
@@ -1,0 +1,49 @@
+# name: benchmark/tpch/csv/lineitem_csv_many_files.benchmark
+# description: Read the lineitem CSV with many files
+# group: [csv]
+
+name Read Lineitem CSV Many Files
+group csv
+
+require tpch
+
+# create the CSV file
+load
+call dbgen(sf=1);
+COPY (FROM lineitem LIMIT 200000 OFFSET 0)       TO '${BENCHMARK_DIR}/lineitem-split-0.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 200000)  TO '${BENCHMARK_DIR}/lineitem-split-1.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 400000)  TO '${BENCHMARK_DIR}/lineitem-split-2.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 600000)  TO '${BENCHMARK_DIR}/lineitem-split-3.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 800000)  TO '${BENCHMARK_DIR}/lineitem-split-4.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 1000000) TO '${BENCHMARK_DIR}/lineitem-split-5.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 1200000) TO '${BENCHMARK_DIR}/lineitem-split-6.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 1400000) TO '${BENCHMARK_DIR}/lineitem-split-7.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 1600000) TO '${BENCHMARK_DIR}/lineitem-split-8.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 1800000) TO '${BENCHMARK_DIR}/lineitem-split-9.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 2000000) TO '${BENCHMARK_DIR}/lineitem-split-10.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 2200000) TO '${BENCHMARK_DIR}/lineitem-split-11.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 2400000) TO '${BENCHMARK_DIR}/lineitem-split-12.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 2600000) TO '${BENCHMARK_DIR}/lineitem-split-13.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 2800000) TO '${BENCHMARK_DIR}/lineitem-split-14.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 3000000) TO '${BENCHMARK_DIR}/lineitem-split-15.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 3200000) TO '${BENCHMARK_DIR}/lineitem-split-16.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 3400000) TO '${BENCHMARK_DIR}/lineitem-split-17.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 3600000) TO '${BENCHMARK_DIR}/lineitem-split-18.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 3800000) TO '${BENCHMARK_DIR}/lineitem-split-19.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 4000000) TO '${BENCHMARK_DIR}/lineitem-split-20.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 4200000) TO '${BENCHMARK_DIR}/lineitem-split-21.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 4400000) TO '${BENCHMARK_DIR}/lineitem-split-22.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 4600000) TO '${BENCHMARK_DIR}/lineitem-split-23.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 4800000) TO '${BENCHMARK_DIR}/lineitem-split-24.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 5000000) TO '${BENCHMARK_DIR}/lineitem-split-25.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 5200000) TO '${BENCHMARK_DIR}/lineitem-split-26.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 5400000) TO '${BENCHMARK_DIR}/lineitem-split-27.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 5600000) TO '${BENCHMARK_DIR}/lineitem-split-28.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 5800000) TO '${BENCHMARK_DIR}/lineitem-split-29.csv' (HEADER, DELIMITER '|');
+COPY (FROM lineitem LIMIT 200000 OFFSET 6000000) TO '${BENCHMARK_DIR}/lineitem-split-30.csv' (HEADER, DELIMITER '|');
+
+run
+SELECT COUNT(*) FROM read_csv_auto('${BENCHMARK_DIR}/lineitem-split-*.csv');
+
+result I
+6001215

--- a/src/include/duckdb/execution/operator/persistent/csv_reader_options.hpp
+++ b/src/include/duckdb/execution/operator/persistent/csv_reader_options.hpp
@@ -19,12 +19,14 @@
 
 namespace duckdb {
 
-enum NewLineIdentifier {
+enum class NewLineIdentifier : uint8_t {
 	SINGLE = 1,   // Either \r or \n
 	CARRY_ON = 2, // \r\n
 	MIX = 3,      // Hippie-Land, can't run it multithreaded
 	NOT_SET = 4
 };
+
+enum class ParallelMode { AUTOMATIC = 0, PARALLEL = 1, SINGLE_THREADED = 2 };
 
 struct BufferedCSVReaderOptions {
 	//===--------------------------------------------------------------------===//
@@ -116,7 +118,7 @@ struct BufferedCSVReaderOptions {
 	//! If we are running the parallel version of the CSV Reader. In general, the system should always auto-detect
 	//! When it can't execute a parallel run before execution. However, there are (rather specific) situations where
 	//! setting up this manually might be important
-	bool run_parallel = true;
+	ParallelMode parallel_mode;
 	//===--------------------------------------------------------------------===//
 	// WriteCSVOptions
 	//===--------------------------------------------------------------------===//

--- a/src/include/duckdb/main/client_data.hpp
+++ b/src/include/duckdb/main/client_data.hpp
@@ -63,7 +63,9 @@ struct ClientData {
 	string file_search_path;
 
 	//! The Max Line Length Size of Last Query Executed on a CSV File. (Only used for testing)
-	idx_t max_line_length = 0;
+	//! FIXME: this should not be done like this
+	bool debug_set_max_line_length = false;
+	idx_t debug_max_line_length = 0;
 
 public:
 	DUCKDB_API static ClientData &Get(ClientContext &context);

--- a/test/parallel_csv/test_parallel_csv.cpp
+++ b/test/parallel_csv/test_parallel_csv.cpp
@@ -79,7 +79,8 @@ bool RunSingleConfiguration(std::string csv_file, idx_t threads, idx_t buffer_si
 	DuckDB db(nullptr);
 	Connection con(db);
 	// Set max line length to 0 when starting a ST CSV Read
-	con.context->client_data->max_line_length = 0;
+	con.context->client_data->debug_set_max_line_length = true;
+	con.context->client_data->debug_max_line_length = 0;
 	duckdb::unique_ptr<MaterializedQueryResult> single_threaded_res;
 	ColumnDataCollection *ground_truth = nullptr;
 	bool single_threaded_passed;
@@ -109,7 +110,8 @@ bool RunFull(std::string &path, duckdb::Connection &conn, std::set<std::string> 
 	}
 
 	// Set max line length to 0 when starting a ST CSV Read
-	conn.context->client_data->max_line_length = 0;
+	conn.context->client_data->debug_set_max_line_length = true;
+	conn.context->client_data->debug_max_line_length = 0;
 	duckdb::unique_ptr<MaterializedQueryResult> single_threaded_res;
 	ColumnDataCollection *ground_truth = nullptr;
 	single_threaded_res =
@@ -121,7 +123,7 @@ bool RunFull(std::string &path, duckdb::Connection &conn, std::set<std::string> 
 		ground_truth = &single_threaded_res->Collection();
 	}
 	// For parallel CSV Reading the buffer must be at least the size of the biggest line in the File.
-	idx_t min_buffer_size = conn.context->client_data->max_line_length + 2;
+	idx_t min_buffer_size = conn.context->client_data->debug_max_line_length + 2;
 	// So our tests don't take infinite time, we will go till a max buffer size of 5 positions higher than the minimum.
 	idx_t max_buffer_size = min_buffer_size + 5;
 	// Let's go from 1 to 8 threads.

--- a/test/sql/copy/csv/batched_write/csv_write_memory_limit.test_slow
+++ b/test/sql/copy/csv/batched_write/csv_write_memory_limit.test_slow
@@ -4,6 +4,8 @@
 
 require parquet
 
+require 64bit
+
 # 100M rows, 2 BIGINT columns = 1.6GB uncompressed
 statement ok
 COPY (SELECT i, i // 5 AS j FROM range(100000000) t(i)) TO '__TEST_DIR__/large_integers.parquet'

--- a/test/sql/copy/csv/parallel/csv_parallel_buffer_size.test
+++ b/test/sql/copy/csv/parallel/csv_parallel_buffer_size.test
@@ -12,27 +12,27 @@ statement ok
 pragma threads=${thr}
 
 statement error
-SELECT sum(a) FROM read_csv('test/sql/copy/csv/data/test/multi_column_integer.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER'), auto_detect='true', delim = '|', buffer_size=5)
+SELECT sum(a) FROM read_csv('test/sql/copy/csv/data/test/multi_column_integer.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER'), auto_detect='true', delim = '|', buffer_size=5, parallel=True)
 ----
 Line does not fit in one buffer
 
 query III
-SELECT sum(a), sum(b), sum(c) FROM read_csv('test/sql/copy/csv/data/test/multi_column_integer.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER'), auto_detect='true', delim = '|', buffer_size=30)
+SELECT sum(a), sum(b), sum(c) FROM read_csv('test/sql/copy/csv/data/test/multi_column_integer.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER'), auto_detect='true', delim = '|', buffer_size=30, parallel=True)
 ----
 111111111	51866	3195
 
 query I
-SELECT sum(a) FROM read_csv('test/sql/copy/csv/data/test/multi_column_integer.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER'), auto_detect='true', delim = '|', buffer_size=30)
+SELECT sum(a) FROM read_csv('test/sql/copy/csv/data/test/multi_column_integer.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER'), auto_detect='true', delim = '|', buffer_size=30, parallel=True)
 ----
 111111111
 
 query I
-SELECT sum(a) FROM read_csv('test/sql/copy/csv/data/test/multi_column_integer_rn.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER'), auto_detect='true', delim = '|', buffer_size=30)
+SELECT sum(a) FROM read_csv('test/sql/copy/csv/data/test/multi_column_integer_rn.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER'), auto_detect='true', delim = '|', buffer_size=30, parallel=True)
 ----
 111111111
 
 query IIII
-select * from read_csv('test/sql/copy/csv/data/test/multi_column_string.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER', d := 'VARCHAR'), auto_detect='true', delim = '|', buffer_size=25)
+select * from read_csv('test/sql/copy/csv/data/test/multi_column_string.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER', d := 'VARCHAR'), auto_detect='true', delim = '|', buffer_size=25, parallel=True)
 ----
 1	6370	371	p1
 10	214	465	p2
@@ -45,7 +45,7 @@ select * from read_csv('test/sql/copy/csv/data/test/multi_column_string.csv',  C
 100000000	15519	785	p9
 
 query IIII
-select * from read_csv('test/sql/copy/csv/data/test/multi_column_string_rn.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER', d := 'VARCHAR'), auto_detect='true', delim = '|', buffer_size=25)
+select * from read_csv('test/sql/copy/csv/data/test/multi_column_string_rn.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER', d := 'VARCHAR'), auto_detect='true', delim = '|', buffer_size=25, parallel=True)
 ----
 1	6370	371	p1
 10	214	465	p2
@@ -58,34 +58,34 @@ select * from read_csv('test/sql/copy/csv/data/test/multi_column_string_rn.csv',
 100000000	15519	785	p9
 
 query I
-SELECT sum(a) FROM read_csv('test/sql/copy/csv/data/test/new_line_string_rn.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER', d := 'VARCHAR'), auto_detect='true', delim = '|')
+SELECT sum(a) FROM read_csv('test/sql/copy/csv/data/test/new_line_string_rn.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER', d := 'VARCHAR'), auto_detect='true', delim = '|', parallel=True)
 ----
 111
 
 query I
-SELECT sum(a) FROM read_csv('test/sql/copy/csv/data/test/new_line_string_rn.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER', d := 'VARCHAR'), auto_detect='true', delim = '|', buffer_size=60)
-----
-111
-
-
-query I
-SELECT sum(a) FROM read_csv('test/sql/copy/csv/data/test/new_line_string_rn_exc.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER', d := 'VARCHAR'), auto_detect='true', delim = '|')
-----
-111
-
-query I
-SELECT sum(a) FROM read_csv('test/sql/copy/csv/data/test/new_line_string_rn_exc.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER', d := 'VARCHAR'), auto_detect='true', delim = '|', buffer_size=60)
+SELECT sum(a) FROM read_csv('test/sql/copy/csv/data/test/new_line_string_rn.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER', d := 'VARCHAR'), auto_detect='true', delim = '|', buffer_size=60, parallel=True)
 ----
 111
 
 
 query I
-SELECT sum(a) FROM read_csv('test/sql/copy/csv/data/test/new_line_string.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER', d := 'VARCHAR'), auto_detect='true', delim = '|')
+SELECT sum(a) FROM read_csv('test/sql/copy/csv/data/test/new_line_string_rn_exc.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER', d := 'VARCHAR'), auto_detect='true', delim = '|', parallel=True)
 ----
 111
 
 query I
-SELECT sum(a) FROM read_csv('test/sql/copy/csv/data/test/new_line_string.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER', d := 'VARCHAR'), auto_detect='true', delim = '|', buffer_size=60)
+SELECT sum(a) FROM read_csv('test/sql/copy/csv/data/test/new_line_string_rn_exc.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER', d := 'VARCHAR'), auto_detect='true', delim = '|', buffer_size=60, parallel=True)
+----
+111
+
+
+query I
+SELECT sum(a) FROM read_csv('test/sql/copy/csv/data/test/new_line_string.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER', d := 'VARCHAR'), auto_detect='true', delim = '|', parallel=True)
+----
+111
+
+query I
+SELECT sum(a) FROM read_csv('test/sql/copy/csv/data/test/new_line_string.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER', d := 'VARCHAR'), auto_detect='true', delim = '|', buffer_size=60, parallel=True)
 ----
 111
 

--- a/test/sql/copy/csv/parallel/csv_parallel_new_line.test
+++ b/test/sql/copy/csv/parallel/csv_parallel_new_line.test
@@ -17,7 +17,7 @@ pragma threads=${thr}
 
 # Test read_csv auto with \n
 query IIII
-select * from read_csv_auto('test/sql/copy/csv/data/test/multi_column_string.csv', buffer_size=${i})
+select * from read_csv_auto('test/sql/copy/csv/data/test/multi_column_string.csv', buffer_size=${i}, parallel=True)
 ----
 1	6370	371	p1
 10	214	465	p2
@@ -31,7 +31,7 @@ select * from read_csv_auto('test/sql/copy/csv/data/test/multi_column_string.csv
 
 # Test read_csv auto with \r
 query IIII
-select * from read_csv_auto('test/sql/copy/csv/data/auto/multi_column_string_r.csv', buffer_size=${i})
+select * from read_csv_auto('test/sql/copy/csv/data/auto/multi_column_string_r.csv', buffer_size=${i}, parallel=True)
 ----
 1	6370	371	p1
 10	214	465	p2
@@ -45,7 +45,7 @@ select * from read_csv_auto('test/sql/copy/csv/data/auto/multi_column_string_r.c
 
 # Test read_csv auto with mix \r and \n
 query IIII
-select * from read_csv_auto('test/sql/copy/csv/data/auto/multi_column_string_mix_r_n.csv', buffer_size=${i})
+select * from read_csv_auto('test/sql/copy/csv/data/auto/multi_column_string_mix_r_n.csv', buffer_size=${i}, parallel=True)
 ----
 1	6370	371	p1
 10	214	465	p2
@@ -60,7 +60,7 @@ select * from read_csv_auto('test/sql/copy/csv/data/auto/multi_column_string_mix
 
 # Test read_csv auto with \r\n
 query IIII
-select * from read_csv_auto('test/sql/copy/csv/data/test/multi_column_string_rn.csv', buffer_size=${i}, header=False)
+select * from read_csv_auto('test/sql/copy/csv/data/test/multi_column_string_rn.csv', buffer_size=${i}, header=False, parallel=True)
 ----
 1	6370	371	p1
 10	214	465	p2
@@ -78,7 +78,7 @@ endloop
 
 # Test read_csv auto with mix \r, \n and \r\n (This must always run single threaded)
 query IIII
-select * from read_csv_auto('test/sql/copy/csv/data/auto/multi_column_string_mix.csv')
+select * from read_csv_auto('test/sql/copy/csv/data/auto/multi_column_string_mix.csv', parallel=True)
 ----
 1	6370	371	p1
 10	214	465	p2
@@ -100,12 +100,12 @@ statement ok
 pragma threads=${thr}
 
 statement error
-select * from read_csv('test/sql/copy/csv/data/test/multi_column_string.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER', d := 'VARCHAR'), auto_detect='false', delim = '|', new_line = '\r\n')
+select * from read_csv('test/sql/copy/csv/data/test/multi_column_string.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER', d := 'VARCHAR'), auto_detect='false', delim = '|', new_line = '\r\n', parallel=True)
 
 
 # Test read_csv with user defined variable
 query IIII
-select * from read_csv('test/sql/copy/csv/data/test/multi_column_string.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER', d := 'VARCHAR'), auto_detect='false', delim = '|', new_line = '\n')
+select * from read_csv('test/sql/copy/csv/data/test/multi_column_string.csv',  COLUMNS=STRUCT_PACK(a := 'INTEGER', b := 'INTEGER', c := 'INTEGER', d := 'VARCHAR'), auto_detect='false', delim = '|', new_line = '\n', parallel=True)
 ----
 1	6370	371	p1
 10	214	465	p2
@@ -118,10 +118,10 @@ select * from read_csv('test/sql/copy/csv/data/test/multi_column_string.csv',  C
 100000000	15519	785	p9
 
 statement error
-select * from read_csv_auto('test/sql/copy/csv/data/test/multi_column_string.csv',  new_line = '\r\n')
+select * from read_csv_auto('test/sql/copy/csv/data/test/multi_column_string.csv',  new_line = '\r\n', parallel=True)
 
 query IIII
-select * from read_csv_auto('test/sql/copy/csv/data/test/multi_column_string.csv',   new_line = '\n')
+select * from read_csv_auto('test/sql/copy/csv/data/test/multi_column_string.csv',   new_line = '\n', parallel=True)
 ----
 1	6370	371	p1
 10	214	465	p2
@@ -134,6 +134,6 @@ select * from read_csv_auto('test/sql/copy/csv/data/test/multi_column_string.csv
 100000000	15519	785	p9
 
 statement error
-select * from read_csv_auto('test/sql/copy/csv/data/test/multi_column_string.csv',  new_line = 'not_valid')
+select * from read_csv_auto('test/sql/copy/csv/data/test/multi_column_string.csv',  new_line = 'not_valid', parallel=True)
 
 endloop

--- a/test/sql/copy/csv/parallel/test_parallel_option.test
+++ b/test/sql/copy/csv/parallel/test_parallel_option.test
@@ -6,6 +6,9 @@
 statement ok
 PRAGMA verify_parallelism
 
+statement ok
+SET threads=4;
+
 # By default runs multi-threaded
 query II
 explain  select * from read_csv_auto('test/sql/copy/csv/data/test/multi_column_string_rn.csv')

--- a/test/sql/copy/csv/test_union_by_name.test
+++ b/test/sql/copy/csv/test_union_by_name.test
@@ -5,6 +5,9 @@
 statement ok
 SET default_null_order='nulls_first';
 
+statement ok
+SET threads=4
+
 # Setup
 
 statement ok

--- a/test/sql/copy/csv/test_union_by_name.test
+++ b/test/sql/copy/csv/test_union_by_name.test
@@ -5,9 +5,6 @@
 statement ok
 SET default_null_order='nulls_first';
 
-statement ok
-SET threads=4
-
 # Setup
 
 statement ok
@@ -70,7 +67,7 @@ BIGINT	BIGINT	BIGINT
 statement error
 SELECT * FROM read_csv_auto(['data/csv/union-by-name/ubn1.csv', 'data/csv/union-by-name/ubn2.csv', 'data/csv/union-by-name/ubn3.csv', 'data/csv/union-by-name/ubn4.csv'])
 ----
-Error in file "data/csv/union-by-name/ubn2.csv"
+Error in file
 
 query IIIII
 SELECT  a, b, c, ts, k  

--- a/test/sql/copy/parquet/batched_write/parquet_write_memory_limit.test_slow
+++ b/test/sql/copy/parquet/batched_write/parquet_write_memory_limit.test_slow
@@ -4,6 +4,8 @@
 
 require parquet
 
+require 64bit
+
 # 100M rows, 2 BIGINT columns = 1.6GB uncompressed
 statement ok
 COPY (SELECT i, i // 5 AS j FROM range(100000000) t(i)) TO '__TEST_DIR__/large_integers.parquet'


### PR DESCRIPTION
When reading many CSV files, the old CSV reader could already parallelize over the files. This actually works out to be around ~2X faster as reading files individually means there is no contention between threads to deal with. With this PR we check the amount of files that we are reading - if it is more than 2X the number of threads we fallback to the old CSV reader.

Included is a benchmark that partitions lineitem into 30 different CSV files. The performance for reading the CSV files is as follows:

| Single-Threaded | Parallel |
|-----------------|----------|
| 0.32s           | 0.61s    |
