### PR TITLE
Simplify COLUMNS with lambda -> operate only on column names, instead of qualified names

### DIFF
--- a/test/sql/parser/test_columns_lists.test
+++ b/test/sql/parser/test_columns_lists.test
@@ -15,35 +15,35 @@ SELECT COLUMNS([x for x in *]) FROM integers
 13	14
 
 query I
-SELECT COLUMNS([x for x in (*) if x <> 'integers.i']) FROM integers
+SELECT COLUMNS([x for x in (*) if x <> 'i']) FROM integers
 ----
 84
 14
 
 # short-hand, allow directly specifying the lambda
 query I
-SELECT COLUMNS(x -> x <> 'integers.i') FROM integers
+SELECT COLUMNS(x -> x <> 'i') FROM integers
 ----
 84
 14
 
 query I
-SELECT COLUMNS([x for x in (*) if x SIMILAR TO '.*i']) FROM integers
+SELECT COLUMNS([x for x in (*) if x SIMILAR TO 'i']) FROM integers
 ----
 42
 13
 
-query II
+query I
 SELECT COLUMNS(['i', 'i']) FROM integers
 ----
-42	42
-13	13
+42
+13
 
-query II
+query I
 SELECT COLUMNS(list_concat(['i'], ['i'])) FROM integers
 ----
-42	42
-13	13
+42
+13
 
 # star with exclude
 query I
@@ -79,7 +79,7 @@ STAR expression is only allowed as the root element of an expression
 
 # empty lambda
 statement error
-SELECT COLUMNS([x for x in (*) if x = 'integers.k']) FROM integers
+SELECT COLUMNS([x for x in (*) if x = 'k']) FROM integers
 ----
 resulted in an empty set of columns
 
@@ -87,22 +87,17 @@ resulted in an empty set of columns
 statement error
 SELECT COLUMNS(['k']) FROM integers
 ----
-not found in FROM clause
-
-statement error
-SELECT COLUMNS(['integers2.i']) FROM integers
-----
-"integers2" not found
+not found in the FROM clause
 
 # COLUMNS and joins
 query I
-SELECT COLUMNS([x for x in (*) if x LIKE '%i']) FROM integers i1 JOIN integers i2 USING (i)
+SELECT COLUMNS([x for x in (*) if x LIKE 'i']) FROM integers i1 JOIN integers i2 USING (i)
 ----
 42
 13
 
 query II
-SELECT COLUMNS([x for x in (*) if x LIKE '%i']) FROM integers i1 JOIN integers i2 ON (i1.i=i2.i)
+SELECT COLUMNS([x for x in (*) if x LIKE 'i']) FROM integers i1 JOIN integers i2 ON (i1.i=i2.i)
 ----
 42	42
 13	13


### PR DESCRIPTION
This PR simplifies the usage of `COLUMNS` with a lambda function by operating only on column names, instead of on qualified column names.

Previously, qualified names were used in the `COLUMNS` expression, e.g. for the following table:

```sql
CREATE TABLE integers AS SELECT 42 AS col1, 84 AS col2, 100 AS col3;
```

The list of names was `['integers.col1', 'integers.col2', 'integers.col3']`.

This complicates processing because we need to take the qualified name into account - e.g. this simple regex would lead to an error:

```sql
SELECT COLUMNS(x -> x SIMILAR TO 'col[13]') FROM integers;
-- Error: Binder Error: Star expression "COLUMNS(list_filter(['integers.col1', 'integers.col2', 'integers.col3'], x -> regexp_full_match(x, 'col[13]')))" resulted in an empty set of columns
-- LINE 1: SELECT COLUMNS(x -> x SIMILAR TO 'col[13]') FR...
```

Adding `.*` to match the qualifier fixes the issue:

```sql
D SELECT COLUMNS(x -> x SIMILAR TO '.*col[13]') FROM integers;
┌───────┬───────┐
│ col1  │ col3  │
│ int32 │ int32 │
├───────┼───────┤
│    42 │   100 │
└───────┴───────┘
```

This complicates usage, and being able to distinguish between qualified names is generally not what you want. This PR modifies it so the unqualified names are matched instead, e.g. the above example works:

```sql
SELECT COLUMNS(x -> x SIMILAR TO 'col[13]') FROM integers;
┌───────┬───────┐
│ col1  │ col3  │
│ int32 │ int32 │
├───────┼───────┤
│    42 │   100 │
└───────┴───────┘
```

When duplicate column names exist, e.g. because of a join, all matching column names are returned. For example:

```sql
D SELECT COLUMNS(x -> x SIMILAR TO 'col[13]') FROM integers i1, integers i2;
┌───────┬───────┬───────┬───────┐
│ col1  │ col3  │ col1  │ col3  │
│ int32 │ int32 │ int32 │ int32 │
├───────┼───────┼───────┼───────┤
│    42 │   100 │    42 │   100 │
└───────┴───────┴───────┴───────┘
```


