### PR TITLE
[Dev] `unique_ptr` helper renames

### DIFF
--- a/benchmark/interpreted_benchmark.cpp
+++ b/benchmark/interpreted_benchmark.cpp
@@ -161,7 +161,7 @@ void InterpretedBenchmark::LoadBenchmark() {
 					throw std::runtime_error("Failed to read " + splits[0] + " from file " + splits[1]);
 				}
 
-				auto buffer = make_unsafe_array<char>(size);
+				auto buffer = make_unsafe_uniq_array<char>(size);
 				if (!file.read(buffer.get(), size)) {
 					throw std::runtime_error("Failed to read " + splits[0] + " from file " + splits[1]);
 				}

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -131,7 +131,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		break;
 	case LogicalTypeId::TIMESTAMP_TZ: {
 		string format = "tsu:" + config_timezone;
-		auto format_ptr = make_unsafe_array<char>(format.size() + 1);
+		auto format_ptr = make_unsafe_uniq_array<char>(format.size() + 1);
 		for (size_t i = 0; i < format.size(); i++) {
 			format_ptr[i] = format[i];
 		}
@@ -156,7 +156,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		uint8_t width, scale;
 		type.GetDecimalProperties(width, scale);
 		string format = "d:" + to_string(width) + "," + to_string(scale);
-		auto format_ptr = make_unsafe_array<char>(format.size() + 1);
+		auto format_ptr = make_unsafe_uniq_array<char>(format.size() + 1);
 		for (size_t i = 0; i < format.size(); i++) {
 			format_ptr[i] = format[i];
 		}
@@ -204,7 +204,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 			InitializeChild(*child.children[type_idx]);
 
 			auto &struct_col_name = child_types[type_idx].first;
-			auto name_ptr = make_unsafe_array<char>(struct_col_name.size() + 1);
+			auto name_ptr = make_unsafe_uniq_array<char>(struct_col_name.size() + 1);
 			for (size_t i = 0; i < struct_col_name.size(); i++) {
 				name_ptr[i] = struct_col_name[i];
 			}

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -33,7 +33,7 @@ struct DuckDBArrowSchemaHolder {
 	std::list<vector<ArrowSchema>> nested_children;
 	std::list<vector<ArrowSchema *>> nested_children_ptr;
 	//! This holds strings created to represent decimal types
-	vector<unsafe_array_ptr<char>> owned_type_names;
+	vector<unsafe_unique_array<char>> owned_type_names;
 };
 
 static void ReleaseDuckDBArrowSchema(ArrowSchema *schema) {

--- a/src/common/compressed_file_system.cpp
+++ b/src/common/compressed_file_system.cpp
@@ -19,10 +19,10 @@ void CompressedFile::Initialize(bool write) {
 	this->write = write;
 	stream_data.in_buf_size = compressed_fs.InBufferSize();
 	stream_data.out_buf_size = compressed_fs.OutBufferSize();
-	stream_data.in_buff = make_unsafe_array<data_t>(stream_data.in_buf_size);
+	stream_data.in_buff = make_unsafe_uniq_array<data_t>(stream_data.in_buf_size);
 	stream_data.in_buff_start = stream_data.in_buff.get();
 	stream_data.in_buff_end = stream_data.in_buff.get();
-	stream_data.out_buff = make_unsafe_array<data_t>(stream_data.out_buf_size);
+	stream_data.out_buff = make_unsafe_uniq_array<data_t>(stream_data.out_buf_size);
 	stream_data.out_buff_start = stream_data.out_buff.get();
 	stream_data.out_buff_end = stream_data.out_buff.get();
 

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -87,7 +87,7 @@ idx_t FileSystem::GetAvailableMemory() {
 }
 
 string FileSystem::GetWorkingDirectory() {
-	auto buffer = make_unsafe_array<char>(PATH_MAX);
+	auto buffer = make_unsafe_uniq_array<char>(PATH_MAX);
 	char *ret = getcwd(buffer.get(), PATH_MAX);
 	if (!ret) {
 		throw IOException("Could not get working directory!");
@@ -170,7 +170,7 @@ string FileSystem::GetWorkingDirectory() {
 	if (count == 0) {
 		throw IOException("Could not get working directory!");
 	}
-	auto buffer = make_unsafe_array<wchar_t>(count);
+	auto buffer = make_unsafe_uniq_array<wchar_t>(count);
 	idx_t ret = GetCurrentDirectoryW(count, buffer.get());
 	if (count != ret + 1) {
 		throw IOException("Could not get working directory!");

--- a/src/common/row_operations/row_gather.cpp
+++ b/src/common/row_operations/row_gather.cpp
@@ -95,8 +95,8 @@ static void GatherNestedVector(Vector &rows, const SelectionVector &row_sel, Vec
 	auto ptrs = FlatVector::GetData<data_ptr_t>(rows);
 
 	// Build the gather locations
-	auto data_locations = make_unsafe_array<data_ptr_t>(count);
-	auto mask_locations = make_unsafe_array<data_ptr_t>(count);
+	auto data_locations = make_unsafe_uniq_array<data_ptr_t>(count);
+	auto mask_locations = make_unsafe_uniq_array<data_ptr_t>(count);
 	for (idx_t i = 0; i < count; i++) {
 		auto row_idx = row_sel.get_index(i);
 		auto row = ptrs[row_idx];

--- a/src/common/serializer.cpp
+++ b/src/common/serializer.cpp
@@ -8,7 +8,7 @@ string Deserializer::Read() {
 	if (size == 0) {
 		return string();
 	}
-	auto buffer = make_unsafe_array<data_t>(size);
+	auto buffer = make_unsafe_uniq_array<data_t>(size);
 	ReadData(buffer.get(), size);
 	return string((char *)buffer.get(), size);
 }

--- a/src/common/serializer/binary_deserializer.cpp
+++ b/src/common/serializer/binary_deserializer.cpp
@@ -123,7 +123,7 @@ string BinaryDeserializer::ReadString() {
 	if (size == 0) {
 		return string();
 	}
-	auto buffer = make_unsafe_array<data_t>(size);
+	auto buffer = make_unsafe_uniq_array<data_t>(size);
 	ReadData(buffer.get(), size);
 	return string((char *)buffer.get(), size);
 }

--- a/src/common/serializer/buffered_file_reader.cpp
+++ b/src/common/serializer/buffered_file_reader.cpp
@@ -9,7 +9,7 @@ namespace duckdb {
 
 BufferedFileReader::BufferedFileReader(FileSystem &fs, const char *path, optional_ptr<ClientContext> context,
                                        FileLockType lock_type, optional_ptr<FileOpener> opener)
-    : fs(fs), data(make_unsafe_array<data_t>(FILE_BUFFER_SIZE)), offset(0), read_data(0), total_read(0),
+    : fs(fs), data(make_unsafe_uniq_array<data_t>(FILE_BUFFER_SIZE)), offset(0), read_data(0), total_read(0),
       context(context) {
 	handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ, lock_type, FileSystem::DEFAULT_COMPRESSION, opener.get());
 	file_size = fs.GetFileSize(*handle);

--- a/src/common/serializer/buffered_file_writer.cpp
+++ b/src/common/serializer/buffered_file_writer.cpp
@@ -9,7 +9,7 @@ namespace duckdb {
 constexpr uint8_t BufferedFileWriter::DEFAULT_OPEN_FLAGS;
 
 BufferedFileWriter::BufferedFileWriter(FileSystem &fs, const string &path_p, uint8_t open_flags)
-    : fs(fs), path(path_p), data(make_unsafe_array<data_t>(FILE_BUFFER_SIZE)), offset(0), total_written(0) {
+    : fs(fs), path(path_p), data(make_unsafe_uniq_array<data_t>(FILE_BUFFER_SIZE)), offset(0), total_written(0) {
 	handle = fs.OpenFile(path, open_flags, FileLockType::WRITE_LOCK);
 }
 

--- a/src/common/serializer/buffered_serializer.cpp
+++ b/src/common/serializer/buffered_serializer.cpp
@@ -8,7 +8,7 @@ BufferedSerializer::BufferedSerializer(idx_t maximum_size)
     : BufferedSerializer(make_unsafe_array<data_t>(maximum_size), maximum_size) {
 }
 
-BufferedSerializer::BufferedSerializer(unsafe_array_ptr<data_t> data, idx_t size)
+BufferedSerializer::BufferedSerializer(unsafe_unique_array<data_t> data, idx_t size)
     : maximum_size(size), data(data.get()) {
 	blob.size = 0;
 	blob.data = std::move(data);
@@ -26,7 +26,7 @@ void BufferedSerializer::WriteData(const_data_ptr_t buffer, idx_t write_size) {
 		auto new_data = new data_t[maximum_size];
 		memcpy(new_data, data, blob.size);
 		data = new_data;
-		blob.data = unsafe_array_ptr<data_t>(new_data);
+		blob.data = unsafe_unique_array<data_t>(new_data);
 	}
 
 	memcpy(data + blob.size, buffer, write_size);

--- a/src/common/serializer/buffered_serializer.cpp
+++ b/src/common/serializer/buffered_serializer.cpp
@@ -5,7 +5,7 @@
 namespace duckdb {
 
 BufferedSerializer::BufferedSerializer(idx_t maximum_size)
-    : BufferedSerializer(make_unsafe_array<data_t>(maximum_size), maximum_size) {
+    : BufferedSerializer(make_unsafe_uniq_array<data_t>(maximum_size), maximum_size) {
 }
 
 BufferedSerializer::BufferedSerializer(unsafe_unique_array<data_t> data, idx_t size)

--- a/src/common/sort/radix_sort.cpp
+++ b/src/common/sort/radix_sort.cpp
@@ -291,7 +291,7 @@ void LocalSortState::SortInMemory() {
 	// Radix sort and break ties until no more ties, or until all columns are sorted
 	idx_t sorting_size = 0;
 	idx_t col_offset = 0;
-	unsafe_array_ptr<bool> ties_ptr;
+	unsafe_unique_array<bool> ties_ptr;
 	bool *ties = nullptr;
 	bool contains_string = false;
 	for (idx_t i = 0; i < sort_layout->column_count; i++) {

--- a/src/common/sort/radix_sort.cpp
+++ b/src/common/sort/radix_sort.cpp
@@ -17,7 +17,7 @@ static void SortTiedBlobs(BufferManager &buffer_manager, const data_ptr_t datapt
 		return;
 	}
 	// Fill pointer array for sorting
-	auto ptr_block = make_unsafe_array<data_ptr_t>(end - start);
+	auto ptr_block = make_unsafe_uniq_array<data_ptr_t>(end - start);
 	auto entry_ptrs = (data_ptr_t *)ptr_block.get();
 	for (idx_t i = start; i < end; i++) {
 		entry_ptrs[i - start] = row_ptr;
@@ -158,7 +158,7 @@ inline void InsertionSort(const data_ptr_t orig_ptr, const data_ptr_t temp_ptr, 
 	const data_ptr_t target_ptr = swap ? orig_ptr : temp_ptr;
 	if (count > 1) {
 		const idx_t total_offset = col_offset + offset;
-		auto temp_val = make_unsafe_array<data_t>(row_width);
+		auto temp_val = make_unsafe_uniq_array<data_t>(row_width);
 		const data_ptr_t val = temp_val.get();
 		const auto comp_width = total_comp_width - offset;
 		for (idx_t i = 1; i < count; i++) {
@@ -249,7 +249,7 @@ void RadixSort(BufferManager &buffer_manager, const data_ptr_t &dataptr, const i
 		RadixSortLSD(buffer_manager, dataptr, count, col_offset, sort_layout.entry_size, sorting_size);
 	} else {
 		auto temp_block = buffer_manager.Allocate(MaxValue(count * sort_layout.entry_size, (idx_t)Storage::BLOCK_SIZE));
-		auto preallocated_array = make_unsafe_array<idx_t>(sorting_size * SortConstants::MSD_RADIX_LOCATIONS);
+		auto preallocated_array = make_unsafe_uniq_array<idx_t>(sorting_size * SortConstants::MSD_RADIX_LOCATIONS);
 		RadixSortMSD(dataptr, temp_block.Ptr(), count, col_offset, sort_layout.entry_size, sorting_size, 0,
 		             preallocated_array.get(), false);
 	}
@@ -305,7 +305,7 @@ void LocalSortState::SortInMemory() {
 		if (!ties) {
 			// This is the first sort
 			RadixSort(*buffer_manager, dataptr, count, col_offset, sorting_size, *sort_layout, contains_string);
-			ties_ptr = make_unsafe_array<bool>(count);
+			ties_ptr = make_unsafe_uniq_array<bool>(count);
 			ties = ties_ptr.get();
 			std::fill_n(ties, count - 1, true);
 			ties[count - 1] = false;

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -277,7 +277,7 @@ vector<string> StringUtil::TopNStrings(vector<pair<string, idx_t>> scores, idx_t
 
 struct LevenshteinArray {
 	LevenshteinArray(idx_t len1, idx_t len2) : len1(len1) {
-		dist = make_unsafe_array<idx_t>(len1 * len2);
+		dist = make_unsafe_uniq_array<idx_t>(len1 * len2);
 	}
 
 	idx_t &Score(idx_t i, idx_t j) {

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -286,7 +286,7 @@ struct LevenshteinArray {
 
 private:
 	idx_t len1;
-	unsafe_array_ptr<idx_t> dist;
+	unsafe_unique_array<idx_t> dist;
 
 	idx_t GetIndex(idx_t i, idx_t j) {
 		return j * len1 + i;

--- a/src/common/types/bit.cpp
+++ b/src/common/types/bit.cpp
@@ -78,7 +78,7 @@ void Bit::ToString(string_t bits, char *output) {
 
 string Bit::ToString(string_t str) {
 	auto len = BitLength(str);
-	auto buffer = make_unsafe_array<char>(len);
+	auto buffer = make_unsafe_uniq_array<char>(len);
 	ToString(str, buffer.get());
 	return string(buffer.get(), len);
 }
@@ -140,7 +140,7 @@ void Bit::ToBit(string_t str, string_t &output_str) {
 
 string Bit::ToBit(string_t str) {
 	auto bit_len = GetBitSize(str);
-	auto buffer = make_unsafe_array<char>(bit_len);
+	auto buffer = make_unsafe_uniq_array<char>(bit_len);
 	string_t output_str(buffer.get(), bit_len);
 	Bit::ToBit(str, output_str);
 	return output_str.GetString();

--- a/src/common/types/blob.cpp
+++ b/src/common/types/blob.cpp
@@ -64,7 +64,7 @@ void Blob::ToString(string_t blob, char *output) {
 
 string Blob::ToString(string_t blob) {
 	auto str_len = GetStringSize(blob);
-	auto buffer = make_unsafe_array<char>(str_len);
+	auto buffer = make_unsafe_uniq_array<char>(str_len);
 	Blob::ToString(blob, buffer.get());
 	return string(buffer.get(), str_len);
 }
@@ -136,7 +136,7 @@ void Blob::ToBlob(string_t str, data_ptr_t output) {
 
 string Blob::ToBlob(string_t str) {
 	auto blob_len = GetBlobSize(str);
-	auto buffer = make_unsafe_array<char>(blob_len);
+	auto buffer = make_unsafe_uniq_array<char>(blob_len);
 	Blob::ToBlob(str, (data_ptr_t)buffer.get());
 	return string(buffer.get(), blob_len);
 }

--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -292,7 +292,7 @@ void DataChunk::Slice(DataChunk &other, const SelectionVector &sel, idx_t count_
 }
 
 unsafe_unique_array<UnifiedVectorFormat> DataChunk::ToUnifiedFormat() {
-	auto orrified_data = make_unsafe_array<UnifiedVectorFormat>(ColumnCount());
+	auto orrified_data = make_unsafe_uniq_array<UnifiedVectorFormat>(ColumnCount());
 	for (idx_t col_idx = 0; col_idx < ColumnCount(); col_idx++) {
 		data[col_idx].ToUnifiedFormat(size(), orrified_data[col_idx]);
 	}

--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -291,7 +291,7 @@ void DataChunk::Slice(DataChunk &other, const SelectionVector &sel, idx_t count_
 	}
 }
 
-unsafe_array_ptr<UnifiedVectorFormat> DataChunk::ToUnifiedFormat() {
+unsafe_unique_array<UnifiedVectorFormat> DataChunk::ToUnifiedFormat() {
 	auto orrified_data = make_unsafe_array<UnifiedVectorFormat>(ColumnCount());
 	for (idx_t col_idx = 0; col_idx < ColumnCount(); col_idx++) {
 		data[col_idx].ToUnifiedFormat(size(), orrified_data[col_idx]);

--- a/src/common/types/date.cpp
+++ b/src/common/types/date.cpp
@@ -362,7 +362,7 @@ string Date::ToString(date_t date) {
 	Date::Convert(date, date_units[0], date_units[1], date_units[2]);
 
 	auto length = DateToStringCast::Length(date_units, year_length, add_bc);
-	auto buffer = make_unsafe_array<char>(length);
+	auto buffer = make_unsafe_uniq_array<char>(length);
 	DateToStringCast::Format(buffer.get(), date_units, year_length, add_bc);
 	return string(buffer.get(), length);
 }

--- a/src/common/types/decimal.cpp
+++ b/src/common/types/decimal.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 template <class SIGNED, class UNSIGNED>
 string TemplatedDecimalToString(SIGNED value, uint8_t width, uint8_t scale) {
 	auto len = DecimalToString::DecimalLength<SIGNED, UNSIGNED>(value, width, scale);
-	auto data = make_unsafe_array<char>(len + 1);
+	auto data = make_unsafe_uniq_array<char>(len + 1);
 	DecimalToString::FormatDecimal<SIGNED, UNSIGNED>(value, width, scale, data.get(), len);
 	return string(data.get(), len);
 }
@@ -25,7 +25,7 @@ string Decimal::ToString(int64_t value, uint8_t width, uint8_t scale) {
 
 string Decimal::ToString(hugeint_t value, uint8_t width, uint8_t scale) {
 	auto len = HugeintToStringCast::DecimalLength(value, width, scale);
-	auto data = make_unsafe_array<char>(len + 1);
+	auto data = make_unsafe_uniq_array<char>(len + 1);
 	HugeintToStringCast::FormatDecimal(value, width, scale, data.get(), len);
 	return string(data.get(), len);
 }

--- a/src/common/types/selection_vector.cpp
+++ b/src/common/types/selection_vector.cpp
@@ -5,7 +5,7 @@
 namespace duckdb {
 
 SelectionData::SelectionData(idx_t count) {
-	owned_data = make_unsafe_array<sel_t>(count);
+	owned_data = make_unsafe_uniq_array<sel_t>(count);
 #ifdef DEBUG
 	for (idx_t i = 0; i < count; i++) {
 		owned_data[i] = std::numeric_limits<sel_t>::max();

--- a/src/common/types/time.cpp
+++ b/src/common/types/time.cpp
@@ -158,7 +158,7 @@ string Time::ToString(dtime_t time) {
 
 	char micro_buffer[6];
 	auto length = TimeToStringCast::Length(time_units, micro_buffer);
-	auto buffer = make_unsafe_array<char>(length);
+	auto buffer = make_unsafe_uniq_array<char>(length);
 	TimeToStringCast::Format(buffer.get(), length, time_units, micro_buffer);
 	return string(buffer.get(), length);
 }

--- a/src/common/windows_util.cpp
+++ b/src/common/windows_util.cpp
@@ -11,7 +11,7 @@ std::wstring WindowsUtil::UTF8ToUnicode(const char *input) {
 	if (result_size == 0) {
 		throw IOException("Failure in MultiByteToWideChar");
 	}
-	auto buffer = make_unsafe_array<wchar_t>(result_size);
+	auto buffer = make_unsafe_uniq_array<wchar_t>(result_size);
 	result_size = MultiByteToWideChar(CP_UTF8, 0, input, -1, buffer.get(), result_size);
 	if (result_size == 0) {
 		throw IOException("Failure in MultiByteToWideChar");
@@ -26,7 +26,7 @@ static string WideCharToMultiByteWrapper(LPCWSTR input, uint32_t code_page) {
 	if (result_size == 0) {
 		throw IOException("Failure in WideCharToMultiByte");
 	}
-	auto buffer = make_unsafe_array<char>(result_size);
+	auto buffer = make_unsafe_uniq_array<char>(result_size);
 	result_size = WideCharToMultiByte(code_page, 0, input, -1, buffer.get(), result_size, 0, 0);
 	if (result_size == 0) {
 		throw IOException("Failure in WideCharToMultiByte");

--- a/src/core_functions/scalar/list/list_aggregates.cpp
+++ b/src/core_functions/scalar/list/list_aggregates.cpp
@@ -179,7 +179,7 @@ static void ListAggregatesFunction(DataChunk &args, ExpressionState &state, Vect
 
 	// state_buffer holds the state for each list of this chunk
 	idx_t size = aggr.function.state_size();
-	auto state_buffer = make_unsafe_array<data_t>(size * count);
+	auto state_buffer = make_unsafe_uniq_array<data_t>(size * count);
 
 	// state vector for initialize and finalize
 	StateVector state_vector(count, info.aggr_expr->Copy());

--- a/src/core_functions/scalar/string/printf.cpp
+++ b/src/core_functions/scalar/string/printf.cpp
@@ -94,7 +94,7 @@ static void PrintfFunction(DataChunk &args, ExpressionState &state, Vector &resu
 
 		// now gather all the format arguments
 		vector<duckdb_fmt::basic_format_arg<CTX>> format_args;
-		vector<unsafe_array_ptr<data_t>> string_args;
+		vector<unsafe_unique_array<data_t>> string_args;
 
 		for (idx_t col_idx = 1; col_idx < args.ColumnCount(); col_idx++) {
 			auto &col = args.data[col_idx];

--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -390,7 +390,7 @@ idx_t GroupedAggregateHashTable::FindOrCreateGroupsInternal(AggregateHTAppendSta
 	}
 	TupleDataCollection::ToUnifiedFormat(state.chunk_state, state.group_chunk);
 	if (!state.group_data) {
-		state.group_data = make_unsafe_array<UnifiedVectorFormat>(state.group_chunk.ColumnCount());
+		state.group_data = make_unsafe_uniq_array<UnifiedVectorFormat>(state.group_chunk.ColumnCount());
 	}
 	TupleDataCollection::GetVectorData(state.chunk_state, state.group_data.get());
 

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -332,7 +332,7 @@ unique_ptr<ScanStructure> JoinHashTable::InitializeScanStructure(DataChunk &keys
 	auto ss = make_uniq<ScanStructure>(*this);
 
 	if (join_type != JoinType::INNER) {
-		ss->found_match = make_unsafe_array<bool>(STANDARD_VECTOR_SIZE);
+		ss->found_match = make_unsafe_uniq_array<bool>(STANDARD_VECTOR_SIZE);
 		memset(ss->found_match.get(), 0, sizeof(bool) * STANDARD_VECTOR_SIZE);
 	}
 

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -142,7 +142,7 @@ static idx_t FilterNullValues(UnifiedVectorFormat &vdata, const SelectionVector 
 	return result_count;
 }
 
-idx_t JoinHashTable::PrepareKeys(DataChunk &keys, unsafe_array_ptr<UnifiedVectorFormat> &key_data,
+idx_t JoinHashTable::PrepareKeys(DataChunk &keys, unsafe_unique_array<UnifiedVectorFormat> &key_data,
                                  const SelectionVector *&current_sel, SelectionVector &sel, bool build_side) {
 	key_data = keys.ToUnifiedFormat();
 
@@ -197,7 +197,7 @@ void JoinHashTable::Build(PartitionedTupleDataAppendState &append_state, DataChu
 	}
 
 	// prepare the keys for processing
-	unsafe_array_ptr<UnifiedVectorFormat> key_data;
+	unsafe_unique_array<UnifiedVectorFormat> key_data;
 	const SelectionVector *current_sel;
 	SelectionVector sel(STANDARD_VECTOR_SIZE);
 	idx_t added_count = PrepareKeys(keys, key_data, current_sel, sel, true);

--- a/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -39,7 +39,7 @@ struct AggregateState {
 		for (auto &aggregate : aggregate_expressions) {
 			D_ASSERT(aggregate->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
 			auto &aggr = aggregate->Cast<BoundAggregateExpression>();
-			auto state = make_unsafe_array<data_t>(aggr.function.state_size());
+			auto state = make_unsafe_uniq_array<data_t>(aggr.function.state_size());
 			aggr.function.initialize(state.get());
 			aggregates.push_back(std::move(state));
 			bind_data.push_back(aggr.bind_info.get());

--- a/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -69,7 +69,7 @@ struct AggregateState {
 	}
 
 	//! The aggregate values
-	vector<unsafe_array_ptr<data_t>> aggregates;
+	vector<unsafe_unique_array<data_t>> aggregates;
 	//! The bind data
 	vector<FunctionData *> bind_data;
 	//! The destructors

--- a/src/execution/operator/join/outer_join_marker.cpp
+++ b/src/execution/operator/join/outer_join_marker.cpp
@@ -10,7 +10,7 @@ void OuterJoinMarker::Initialize(idx_t count_p) {
 		return;
 	}
 	this->count = count_p;
-	found_match = make_unsafe_array<bool>(count);
+	found_match = make_unsafe_uniq_array<bool>(count);
 	Reset();
 }
 

--- a/src/execution/operator/join/perfect_hash_join_executor.cpp
+++ b/src/execution/operator/join/perfect_hash_join_executor.cpp
@@ -25,7 +25,7 @@ bool PerfectHashJoinExecutor::BuildPerfectHashTable(LogicalType &key_type) {
 	}
 
 	// and for duplicate_checking
-	bitmap_build_idx = make_unsafe_array<bool>(build_size);
+	bitmap_build_idx = make_unsafe_uniq_array<bool>(build_size);
 	memset(bitmap_build_idx.get(), 0, sizeof(bool) * build_size); // set false
 
 	// Now fill columns with build data

--- a/src/execution/operator/join/physical_range_join.cpp
+++ b/src/execution/operator/join/physical_range_join.cpp
@@ -72,7 +72,7 @@ void PhysicalRangeJoin::GlobalSortedTable::Combine(LocalSortedTable &ltable) {
 }
 
 void PhysicalRangeJoin::GlobalSortedTable::IntializeMatches() {
-	found_match = make_unsafe_array<bool>(Count());
+	found_match = make_unsafe_uniq_array<bool>(Count());
 	memset(found_match.get(), 0, sizeof(bool) * Count());
 }
 

--- a/src/execution/operator/persistent/buffered_csv_reader.cpp
+++ b/src/execution/operator/persistent/buffered_csv_reader.cpp
@@ -1425,7 +1425,7 @@ bool BufferedCSVReader::ReadBuffer(idx_t &start, idx_t &line_start) {
 		                            GetLineNumberStr(linenr, linenr_estimated));
 	}
 
-	buffer = make_unsafe_array<char>(buffer_read_size + remaining + 1);
+	buffer = make_unsafe_uniq_array<char>(buffer_read_size + remaining + 1);
 	buffer_size = remaining + buffer_read_size;
 	if (remaining > 0) {
 		// remaining from last buffer: copy it here

--- a/src/execution/operator/projection/physical_pivot.cpp
+++ b/src/execution/operator/projection/physical_pivot.cpp
@@ -19,7 +19,7 @@ PhysicalPivot::PhysicalPivot(vector<LogicalType> types_p, unique_ptr<PhysicalOpe
 	for (auto &aggr_expr : bound_pivot.aggregates) {
 		auto &aggr = (BoundAggregateExpression &)*aggr_expr;
 		// for each aggregate, initialize an empty aggregate state and finalize it immediately
-		auto state = make_unsafe_array<data_t>(aggr.function.state_size());
+		auto state = make_unsafe_uniq_array<data_t>(aggr.function.state_size());
 		aggr.function.initialize(state.get());
 		Vector state_vector(Value::POINTER((uintptr_t)state.get()));
 		Vector result_vector(aggr_expr->return_type);

--- a/src/execution/perfect_aggregate_hashtable.cpp
+++ b/src/execution/perfect_aggregate_hashtable.cpp
@@ -23,11 +23,11 @@ PerfectAggregateHashTable::PerfectAggregateHashTable(ClientContext &context, All
 	tuple_size = layout.GetRowWidth();
 
 	// allocate and null initialize the data
-	owned_data = make_unsafe_array<data_t>(tuple_size * total_groups);
+	owned_data = make_unsafe_uniq_array<data_t>(tuple_size * total_groups);
 	data = owned_data.get();
 
 	// set up the empty payloads for every tuple, and initialize the "occupied" flag to false
-	group_is_set = make_unsafe_array<bool>(total_groups);
+	group_is_set = make_unsafe_uniq_array<bool>(total_groups);
 	memset(group_is_set.get(), 0, total_groups * sizeof(bool));
 
 	// initialize the hash table for each entry

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -334,7 +334,7 @@ public:
 	//! The current position to scan the HT for output tuples
 	idx_t ht_index;
 	//! The set of aggregate scan states
-	unsafe_array_ptr<TupleDataParallelScanState> ht_scan_states;
+	unsafe_unique_array<TupleDataParallelScanState> ht_scan_states;
 	atomic<bool> initialized;
 	atomic<bool> finished;
 };

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -404,7 +404,7 @@ SourceResultType RadixPartitionedHashTable::GetData(ExecutionContext &context, D
 		for (idx_t i = 0; i < op.aggregates.size(); i++) {
 			D_ASSERT(op.aggregates[i]->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
 			auto &aggr = op.aggregates[i]->Cast<BoundAggregateExpression>();
-			auto aggr_state = make_unsafe_array<data_t>(aggr.function.state_size());
+			auto aggr_state = make_unsafe_uniq_array<data_t>(aggr.function.state_size());
 			aggr.function.initialize(aggr_state.get());
 
 			AggregateInputData aggr_input_data(aggr.bind_info.get(), Allocator::DefaultAllocator());
@@ -433,7 +433,7 @@ SourceResultType RadixPartitionedHashTable::GetData(ExecutionContext &context, D
 		lock_guard<mutex> l(state.lock);
 		if (!state.initialized) {
 			auto &finalized_hts = gstate.finalized_hts;
-			state.ht_scan_states = make_unsafe_array<TupleDataParallelScanState>(finalized_hts.size());
+			state.ht_scan_states = make_unsafe_uniq_array<TupleDataParallelScanState>(finalized_hts.size());
 
 			const auto &layout = gstate.finalized_hts[0]->GetDataCollection().GetLayout();
 			vector<column_t> column_ids;

--- a/src/execution/window_segment_tree.cpp
+++ b/src/execution/window_segment_tree.cpp
@@ -309,7 +309,7 @@ void WindowSegmentTree::ConstructTree() {
 		level_nodes = (level_nodes + (TREE_FANOUT - 1)) / TREE_FANOUT;
 		internal_nodes += level_nodes;
 	} while (level_nodes > 1);
-	levels_flat_native = make_unsafe_array<data_t>(internal_nodes * state.size());
+	levels_flat_native = make_unsafe_uniq_array<data_t>(internal_nodes * state.size());
 	levels_flat_start.push_back(0);
 
 	idx_t levels_flat_offset = 0;

--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -141,7 +141,7 @@ string PragmaImportDatabase(ClientContext &context, const FunctionParameters &pa
 		auto handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ, FileSystem::DEFAULT_LOCK,
 		                          FileSystem::DEFAULT_COMPRESSION);
 		auto fsize = fs.GetFileSize(*handle);
-		auto buffer = make_unsafe_array<char>(fsize);
+		auto buffer = make_unsafe_uniq_array<char>(fsize);
 		fs.Read(*handle, buffer.get(), fsize);
 		auto query = string(buffer.get(), fsize);
 		// Replace the placeholder with the path provided to IMPORT

--- a/src/function/scalar/strftime_format.cpp
+++ b/src/function/scalar/strftime_format.cpp
@@ -408,7 +408,7 @@ string StrfTimeFormat::Format(timestamp_t timestamp, const string &format_str) {
 	auto time = Timestamp::GetTime(timestamp);
 
 	auto len = format.GetLength(date, time, 0, nullptr);
-	auto result = make_unsafe_array<char>(len);
+	auto result = make_unsafe_uniq_array<char>(len);
 	format.FormatString(date, time, result.get());
 	return string(result.get(), len);
 }

--- a/src/function/scalar/string/concat.cpp
+++ b/src/function/scalar/string/concat.cpp
@@ -118,7 +118,7 @@ static void TemplatedConcatWS(DataChunk &args, string_t *sep_data, const Selecti
                               const SelectionVector &rsel, idx_t count, Vector &result) {
 	vector<idx_t> result_lengths(args.size(), 0);
 	vector<bool> has_results(args.size(), false);
-	auto orrified_data = make_unsafe_array<UnifiedVectorFormat>(args.ColumnCount() - 1);
+	auto orrified_data = make_unsafe_uniq_array<UnifiedVectorFormat>(args.ColumnCount() - 1);
 	for (idx_t col_idx = 1; col_idx < args.ColumnCount(); col_idx++) {
 		args.data[col_idx].ToUnifiedFormat(args.size(), orrified_data[col_idx - 1]);
 	}

--- a/src/function/scalar/string/like.cpp
+++ b/src/function/scalar/string/like.cpp
@@ -395,11 +395,11 @@ bool ILikeOperatorFunction(string_t &str, string_t &pattern, char escape = '\0')
 
 	// lowercase both the str and the pattern
 	idx_t str_llength = LowerFun::LowerLength(str_data, str_size);
-	auto str_ldata = make_unsafe_array<char>(str_llength);
+	auto str_ldata = make_unsafe_uniq_array<char>(str_llength);
 	LowerFun::LowerCase(str_data, str_size, str_ldata.get());
 
 	idx_t pat_llength = LowerFun::LowerLength(pat_data, pat_size);
-	auto pat_ldata = make_unsafe_array<char>(pat_llength);
+	auto pat_ldata = make_unsafe_uniq_array<char>(pat_llength);
 	LowerFun::LowerCase(pat_data, pat_size, pat_ldata.get());
 	string_t str_lcase(str_ldata.get(), str_llength);
 	string_t pat_lcase(pat_ldata.get(), pat_llength);

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -36,7 +36,7 @@ struct ExportAggregateBindData : public FunctionData {
 struct CombineState : public FunctionLocalState {
 	idx_t state_size;
 
-	unsafe_array_ptr<data_t> state_buffer0, state_buffer1;
+	unsafe_unique_array<data_t> state_buffer0, state_buffer1;
 	Vector state_vector0, state_vector1;
 
 	explicit CombineState(idx_t state_size_p)
@@ -55,7 +55,7 @@ static unique_ptr<FunctionLocalState> InitCombineState(ExpressionState &state, c
 
 struct FinalizeState : public FunctionLocalState {
 	idx_t state_size;
-	unsafe_array_ptr<data_t> state_buffer;
+	unsafe_unique_array<data_t> state_buffer;
 	Vector addresses;
 
 	explicit FinalizeState(idx_t state_size_p)

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -40,8 +40,8 @@ struct CombineState : public FunctionLocalState {
 	Vector state_vector0, state_vector1;
 
 	explicit CombineState(idx_t state_size_p)
-	    : state_size(state_size_p), state_buffer0(make_unsafe_array<data_t>(state_size_p)),
-	      state_buffer1(make_unsafe_array<data_t>(state_size_p)),
+	    : state_size(state_size_p), state_buffer0(make_unsafe_uniq_array<data_t>(state_size_p)),
+	      state_buffer1(make_unsafe_uniq_array<data_t>(state_size_p)),
 	      state_vector0(Value::POINTER((uintptr_t)state_buffer0.get())),
 	      state_vector1(Value::POINTER((uintptr_t)state_buffer1.get())) {
 	}
@@ -60,7 +60,7 @@ struct FinalizeState : public FunctionLocalState {
 
 	explicit FinalizeState(idx_t state_size_p)
 	    : state_size(state_size_p),
-	      state_buffer(make_unsafe_array<data_t>(STANDARD_VECTOR_SIZE * AlignValue(state_size_p))),
+	      state_buffer(make_unsafe_uniq_array<data_t>(STANDARD_VECTOR_SIZE * AlignValue(state_size_p))),
 	      addresses(LogicalType::POINTER) {
 	}
 };

--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -88,7 +88,7 @@ static unique_ptr<FunctionData> WriteCSVBind(ClientContext &context, CopyInfo &i
 	bind_data->is_simple = bind_data->options.delimiter.size() == 1 && bind_data->options.escape.size() == 1 &&
 	                       bind_data->options.quote.size() == 1;
 	if (bind_data->is_simple) {
-		bind_data->requires_quotes = make_unsafe_array<bool>(256);
+		bind_data->requires_quotes = make_unsafe_uniq_array<bool>(256);
 		memset(bind_data->requires_quotes.get(), 0, sizeof(bool) * 256);
 		bind_data->requires_quotes['\n'] = true;
 		bind_data->requires_quotes['\r'] = true;

--- a/src/include/duckdb/common/compressed_file_system.hpp
+++ b/src/include/duckdb/common/compressed_file_system.hpp
@@ -18,8 +18,8 @@ struct StreamData {
 	// various buffers & pointers
 	bool write = false;
 	bool refresh = false;
-	unsafe_array_ptr<data_t> in_buff;
-	unsafe_array_ptr<data_t> out_buff;
+	unsafe_unique_array<data_t> in_buff;
+	unsafe_unique_array<data_t> out_buff;
 	data_ptr_t out_buff_start = nullptr;
 	data_ptr_t out_buff_end = nullptr;
 	data_ptr_t in_buff_start = nullptr;

--- a/src/include/duckdb/common/helper.hpp
+++ b/src/include/duckdb/common/helper.hpp
@@ -73,14 +73,14 @@ make_unsafe_uniq(_Args&&... __args)
 
 template<class _Tp>
 inline unique_ptr<_Tp[], std::default_delete<_Tp>, true>
-make_array(size_t __n)
+make_uniq_array(size_t __n)
 {
     return unique_ptr<_Tp[], std::default_delete<_Tp>, true>(new _Tp[__n]());
 }
 
 template<class _Tp>
 inline unique_ptr<_Tp[], std::default_delete<_Tp>, false>
-make_unsafe_array(size_t __n)
+make_unsafe_uniq_array(size_t __n)
 {
     return unique_ptr<_Tp[], std::default_delete<_Tp>, false>(new _Tp[__n]());
 }

--- a/src/include/duckdb/common/helper.hpp
+++ b/src/include/duckdb/common/helper.hpp
@@ -40,7 +40,7 @@ namespace duckdb {
 template<class _Tp, bool SAFE = true>
 struct __unique_if
 {
-    typedef unique_ptr<_Tp, SAFE> __unique_single;
+    typedef unique_ptr<_Tp, std::default_delete<_Tp>, SAFE> __unique_single;
 };
 
 template<class _Tp>
@@ -60,7 +60,7 @@ inline
 typename __unique_if<_Tp, true>::__unique_single
 make_uniq(_Args&&... __args)
 {
-    return unique_ptr<_Tp, true>(new _Tp(std::forward<_Args>(__args)...));
+    return unique_ptr<_Tp, std::default_delete<_Tp>, true>(new _Tp(std::forward<_Args>(__args)...));
 }
 
 template<class _Tp, class... _Args>
@@ -68,21 +68,21 @@ inline
 typename __unique_if<_Tp, false>::__unique_single
 make_unsafe_uniq(_Args&&... __args)
 {
-    return unique_ptr<_Tp, false>(new _Tp(std::forward<_Args>(__args)...));
+    return unique_ptr<_Tp, std::default_delete<_Tp>, false>(new _Tp(std::forward<_Args>(__args)...));
 }
 
 template<class _Tp>
-inline unique_ptr<_Tp[], true>
+inline unique_ptr<_Tp[], std::default_delete<_Tp>, true>
 make_array(size_t __n)
 {
-    return unique_ptr<_Tp[], true>(new _Tp[__n]());
+    return unique_ptr<_Tp[], std::default_delete<_Tp>, true>(new _Tp[__n]());
 }
 
 template<class _Tp>
-inline unique_ptr<_Tp[], false>
+inline unique_ptr<_Tp[], std::default_delete<_Tp>, false>
 make_unsafe_array(size_t __n)
 {
-    return unique_ptr<_Tp[], false>(new _Tp[__n]());
+    return unique_ptr<_Tp[], std::default_delete<_Tp>, false>(new _Tp[__n]());
 }
 
 template<class _Tp, class... _Args>

--- a/src/include/duckdb/common/serializer/buffered_file_reader.hpp
+++ b/src/include/duckdb/common/serializer/buffered_file_reader.hpp
@@ -18,7 +18,7 @@ public:
 	                   FileLockType lock_type = FileLockType::READ_LOCK, optional_ptr<FileOpener> opener = nullptr);
 
 	FileSystem &fs;
-	unsafe_array_ptr<data_t> data;
+	unsafe_unique_array<data_t> data;
 	idx_t offset;
 	idx_t read_data;
 	unique_ptr<FileHandle> handle;

--- a/src/include/duckdb/common/serializer/buffered_file_writer.hpp
+++ b/src/include/duckdb/common/serializer/buffered_file_writer.hpp
@@ -25,7 +25,7 @@ public:
 
 	FileSystem &fs;
 	string path;
-	unsafe_array_ptr<data_t> data;
+	unsafe_unique_array<data_t> data;
 	idx_t offset;
 	idx_t total_written;
 	unique_ptr<FileHandle> handle;

--- a/src/include/duckdb/common/serializer/buffered_serializer.hpp
+++ b/src/include/duckdb/common/serializer/buffered_serializer.hpp
@@ -16,7 +16,7 @@ namespace duckdb {
 #define SERIALIZER_DEFAULT_SIZE 1024
 
 struct BinaryData {
-	unsafe_array_ptr<data_t> data;
+	unsafe_unique_array<data_t> data;
 	idx_t size;
 };
 
@@ -26,7 +26,7 @@ public:
 	//! writing past the initial threshold
 	DUCKDB_API explicit BufferedSerializer(idx_t maximum_size = SERIALIZER_DEFAULT_SIZE);
 	//! Serializes to a provided (owned) data pointer
-	BufferedSerializer(unsafe_array_ptr<data_t> data, idx_t size);
+	BufferedSerializer(unsafe_unique_array<data_t> data, idx_t size);
 	BufferedSerializer(data_ptr_t data, idx_t size);
 
 	idx_t maximum_size;

--- a/src/include/duckdb/common/sort/duckdb_pdqsort.hpp
+++ b/src/include/duckdb/common/sort/duckdb_pdqsort.hpp
@@ -39,8 +39,8 @@ using duckdb::idx_t;
 using duckdb::data_t;
 using duckdb::data_ptr_t;
 using duckdb::unique_ptr;
-using duckdb::array_ptr;
-using duckdb::unsafe_array_ptr;
+using duckdb::unique_array;
+using duckdb::unsafe_unique_array;
 using duckdb::make_array;
 using duckdb::make_unsafe_array;
 using duckdb::FastMemcpy;
@@ -88,13 +88,13 @@ struct PDQConstants {
 	const idx_t comp_offset;
 	const idx_t comp_size;
 
-	unsafe_array_ptr<data_t> tmp_buf_ptr;
+	unsafe_unique_array<data_t> tmp_buf_ptr;
 	const data_ptr_t tmp_buf;
 
-	unsafe_array_ptr<data_t> iter_swap_buf_ptr;
+	unsafe_unique_array<data_t> iter_swap_buf_ptr;
 	const data_ptr_t iter_swap_buf;
 
-	unsafe_array_ptr<data_t> swap_offsets_buf_ptr;
+	unsafe_unique_array<data_t> swap_offsets_buf_ptr;
 	const data_ptr_t swap_offsets_buf;
 
 	const data_ptr_t end;

--- a/src/include/duckdb/common/sort/duckdb_pdqsort.hpp
+++ b/src/include/duckdb/common/sort/duckdb_pdqsort.hpp
@@ -41,8 +41,8 @@ using duckdb::data_ptr_t;
 using duckdb::unique_ptr;
 using duckdb::unique_array;
 using duckdb::unsafe_unique_array;
-using duckdb::make_array;
-using duckdb::make_unsafe_array;
+using duckdb::make_uniq_array;
+using duckdb::make_unsafe_uniq_array;
 using duckdb::FastMemcpy;
 using duckdb::FastMemcmp;
 
@@ -78,9 +78,9 @@ inline int log2(T n) {
 struct PDQConstants {
 	PDQConstants(idx_t entry_size, idx_t comp_offset, idx_t comp_size, data_ptr_t end)
 	    : entry_size(entry_size), comp_offset(comp_offset), comp_size(comp_size),
-	      tmp_buf_ptr(make_unsafe_array<data_t>(entry_size)), tmp_buf(tmp_buf_ptr.get()),
-	      iter_swap_buf_ptr(make_unsafe_array<data_t>(entry_size)), iter_swap_buf(iter_swap_buf_ptr.get()),
-	      swap_offsets_buf_ptr(make_unsafe_array<data_t>(entry_size)),
+	      tmp_buf_ptr(make_unsafe_uniq_array<data_t>(entry_size)), tmp_buf(tmp_buf_ptr.get()),
+	      iter_swap_buf_ptr(make_unsafe_uniq_array<data_t>(entry_size)), iter_swap_buf(iter_swap_buf_ptr.get()),
+	      swap_offsets_buf_ptr(make_unsafe_uniq_array<data_t>(entry_size)),
 	      swap_offsets_buf(swap_offsets_buf_ptr.get()), end(end) {
 	}
 

--- a/src/include/duckdb/common/types/data_chunk.hpp
+++ b/src/include/duckdb/common/types/data_chunk.hpp
@@ -125,7 +125,7 @@ public:
 	DUCKDB_API void Flatten();
 
 	// FIXME: this is DUCKDB_API, might need conversion back to regular unique ptr?
-	DUCKDB_API unsafe_array_ptr<UnifiedVectorFormat> ToUnifiedFormat();
+	DUCKDB_API unsafe_unique_array<UnifiedVectorFormat> ToUnifiedFormat();
 
 	DUCKDB_API void Slice(const SelectionVector &sel_vector, idx_t count);
 

--- a/src/include/duckdb/common/types/selection_vector.hpp
+++ b/src/include/duckdb/common/types/selection_vector.hpp
@@ -18,7 +18,7 @@ class VectorBuffer;
 struct SelectionData {
 	DUCKDB_API explicit SelectionData(idx_t count);
 
-	unsafe_array_ptr<sel_t> owned_data;
+	unsafe_unique_array<sel_t> owned_data;
 };
 
 struct SelectionVector {

--- a/src/include/duckdb/common/types/validity_mask.hpp
+++ b/src/include/duckdb/common/types/validity_mask.hpp
@@ -24,7 +24,7 @@ struct TemplatedValidityData {
 public:
 	inline explicit TemplatedValidityData(idx_t count) {
 		auto entry_count = EntryCount(count);
-		owned_data = make_unsafe_array<V>(entry_count);
+		owned_data = make_unsafe_uniq_array<V>(entry_count);
 		for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx++) {
 			owned_data[entry_idx] = MAX_ENTRY;
 		}
@@ -32,7 +32,7 @@ public:
 	inline TemplatedValidityData(const V *validity_mask, idx_t count) {
 		D_ASSERT(validity_mask);
 		auto entry_count = EntryCount(count);
-		owned_data = make_unsafe_array<V>(entry_count);
+		owned_data = make_unsafe_uniq_array<V>(entry_count);
 		for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx++) {
 			owned_data[entry_idx] = validity_mask[entry_idx];
 		}

--- a/src/include/duckdb/common/types/validity_mask.hpp
+++ b/src/include/duckdb/common/types/validity_mask.hpp
@@ -38,7 +38,7 @@ public:
 		}
 	}
 
-	unsafe_array_ptr<V> owned_data;
+	unsafe_unique_array<V> owned_data;
 
 public:
 	static inline idx_t EntryCount(idx_t count) {

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -71,7 +71,7 @@ public:
 	}
 	explicit VectorBuffer(idx_t data_size) : buffer_type(VectorBufferType::STANDARD_BUFFER) {
 		if (data_size > 0) {
-			data = make_unsafe_array<data_t>(data_size);
+			data = make_unsafe_uniq_array<data_t>(data_size);
 		}
 	}
 	explicit VectorBuffer(unsafe_unique_array<data_t> data_p)

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -74,7 +74,7 @@ public:
 			data = make_unsafe_array<data_t>(data_size);
 		}
 	}
-	explicit VectorBuffer(unsafe_array_ptr<data_t> data_p)
+	explicit VectorBuffer(unsafe_unique_array<data_t> data_p)
 	    : buffer_type(VectorBufferType::STANDARD_BUFFER), data(std::move(data_p)) {
 	}
 	virtual ~VectorBuffer() {
@@ -87,7 +87,7 @@ public:
 		return data.get();
 	}
 
-	void SetData(unsafe_array_ptr<data_t> new_data) {
+	void SetData(unsafe_unique_array<data_t> new_data) {
 		data = std::move(new_data);
 	}
 
@@ -120,7 +120,7 @@ public:
 protected:
 	VectorBufferType buffer_type;
 	unique_ptr<VectorAuxiliaryData> aux_data;
-	unsafe_array_ptr<data_t> data;
+	unsafe_unique_array<data_t> data;
 };
 
 //! The DictionaryBuffer holds a selection vector

--- a/src/include/duckdb/common/unique_ptr.hpp
+++ b/src/include/duckdb/common/unique_ptr.hpp
@@ -9,10 +9,10 @@
 
 namespace duckdb {
 
-template <class _Tp, bool SAFE = true>
-class unique_ptr : public std::unique_ptr<_Tp, std::default_delete<_Tp>> {
+template <class _Tp, class _Dp = std::default_delete<_Tp>, bool SAFE = true>
+class unique_ptr : public std::unique_ptr<_Tp, _Dp> {
 public:
-	using original = std::unique_ptr<_Tp, std::default_delete<_Tp>>;
+	using original = std::unique_ptr<_Tp, _Dp>;
 	using original::original;
 
 private:
@@ -53,8 +53,8 @@ public:
 	}
 };
 
-template <class _Tp, bool SAFE>
-class unique_ptr<_Tp[], SAFE> : public std::unique_ptr<_Tp[], std::default_delete<_Tp[]>> {
+template <class _Tp, class _Dp, bool SAFE>
+class unique_ptr<_Tp[], _Dp, SAFE> : public std::unique_ptr<_Tp[], std::default_delete<_Tp[]>> {
 public:
 	using original = std::unique_ptr<_Tp[], std::default_delete<_Tp[]>>;
 	using original::original;
@@ -81,12 +81,12 @@ public:
 };
 
 template <typename T>
-using array_ptr = unique_ptr<T[], true>;
+using array_ptr = unique_ptr<T[], std::default_delete<T>, true>;
 
 template <typename T>
-using unsafe_array_ptr = unique_ptr<T[], false>;
+using unsafe_array_ptr = unique_ptr<T[], std::default_delete<T>, false>;
 
 template <typename T>
-using unsafe_unique_ptr = unique_ptr<T, false>;
+using unsafe_unique_ptr = unique_ptr<T, std::default_delete<T>, false>;
 
 } // namespace duckdb

--- a/src/include/duckdb/common/unique_ptr.hpp
+++ b/src/include/duckdb/common/unique_ptr.hpp
@@ -81,10 +81,10 @@ public:
 };
 
 template <typename T>
-using array_ptr = unique_ptr<T[], std::default_delete<T>, true>;
+using unique_array = unique_ptr<T[], std::default_delete<T>, true>;
 
 template <typename T>
-using unsafe_array_ptr = unique_ptr<T[], std::default_delete<T>, false>;
+using unsafe_unique_array = unique_ptr<T[], std::default_delete<T>, false>;
 
 template <typename T>
 using unsafe_unique_ptr = unique_ptr<T, std::default_delete<T>, false>;

--- a/src/include/duckdb/execution/aggregate_hashtable.hpp
+++ b/src/include/duckdb/execution/aggregate_hashtable.hpp
@@ -73,7 +73,7 @@ struct AggregateHTAppendState {
 	SelectionVector empty_vector;
 	SelectionVector new_groups;
 	Vector addresses;
-	unsafe_array_ptr<UnifiedVectorFormat> group_data;
+	unsafe_unique_array<UnifiedVectorFormat> group_data;
 	DataChunk group_chunk;
 
 	TupleDataChunkState chunk_state;

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -65,12 +65,12 @@ public:
 	//! returned by the JoinHashTable::Scan function and can be used to resume a
 	//! probe.
 	struct ScanStructure {
-		unsafe_array_ptr<UnifiedVectorFormat> key_data;
+		unsafe_unique_array<UnifiedVectorFormat> key_data;
 		Vector pointers;
 		idx_t count;
 		SelectionVector sel_vector;
 		// whether or not the given tuple has found a match
-		unsafe_array_ptr<bool> found_match;
+		unsafe_unique_array<bool> found_match;
 		JoinHashTable &ht;
 		bool finished;
 
@@ -212,7 +212,7 @@ private:
 	//! Insert the given set of locations into the HT with the given set of hashes
 	void InsertHashes(Vector &hashes, idx_t count, data_ptr_t key_locations[], bool parallel);
 
-	idx_t PrepareKeys(DataChunk &keys, unsafe_array_ptr<UnifiedVectorFormat> &key_data,
+	idx_t PrepareKeys(DataChunk &keys, unsafe_unique_array<UnifiedVectorFormat> &key_data,
 	                  const SelectionVector *&current_sel, SelectionVector &sel, bool build_side);
 
 	//! Lock for combining data_collection when merging HTs

--- a/src/include/duckdb/execution/operator/join/outer_join_marker.hpp
+++ b/src/include/duckdb/execution/operator/join/outer_join_marker.hpp
@@ -67,7 +67,7 @@ public:
 
 private:
 	bool enabled;
-	unsafe_array_ptr<bool> found_match;
+	unsafe_unique_array<bool> found_match;
 	idx_t count;
 };
 

--- a/src/include/duckdb/execution/operator/join/perfect_hash_join_executor.hpp
+++ b/src/include/duckdb/execution/operator/join/perfect_hash_join_executor.hpp
@@ -68,7 +68,7 @@ private:
 	//! Build and probe statistics
 	PerfectHashJoinStats perfect_join_statistics;
 	//! Stores the occurences of each value in the build side
-	unsafe_array_ptr<bool> bitmap_build_idx;
+	unsafe_unique_array<bool> bitmap_build_idx;
 	//! Stores the number of unique keys in the build side
 	idx_t unique_keys = 0;
 };

--- a/src/include/duckdb/execution/operator/join/physical_range_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_range_join.hpp
@@ -83,7 +83,7 @@ public:
 		//! The total number of rows in the RHS
 		atomic<idx_t> count;
 		//! A bool indicating for each tuple in the RHS if they found a match (only used in FULL OUTER JOIN)
-		unsafe_array_ptr<bool> found_match;
+		unsafe_unique_array<bool> found_match;
 		//! Memory usage per thread
 		idx_t memory_per_thread;
 	};

--- a/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/buffered_csv_reader.hpp
@@ -60,12 +60,12 @@ public:
 	virtual ~BufferedCSVReader() {
 	}
 
-	unsafe_array_ptr<char> buffer;
+	unsafe_unique_array<char> buffer;
 	idx_t buffer_size;
 	idx_t position;
 	idx_t start = 0;
 
-	vector<unsafe_array_ptr<char>> cached_buffers;
+	vector<unsafe_unique_array<char>> cached_buffers;
 
 	unique_ptr<CSVFileHandle> file_handle;
 

--- a/src/include/duckdb/execution/operator/persistent/parallel_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/parallel_csv_reader.hpp
@@ -67,7 +67,7 @@ struct CSVBufferRead {
 		} else {
 			// 3) It starts in the current buffer and ends in the next buffer
 			D_ASSERT(next_buffer);
-			auto intersection = make_unsafe_array<char>(length);
+			auto intersection = make_unsafe_uniq_array<char>(length);
 			idx_t cur_pos = 0;
 			auto buffer_ptr = buffer->Ptr();
 			for (idx_t i = start_buffer; i < buffer->GetBufferSize(); i++) {

--- a/src/include/duckdb/execution/operator/persistent/parallel_csv_reader.hpp
+++ b/src/include/duckdb/execution/operator/persistent/parallel_csv_reader.hpp
@@ -85,7 +85,7 @@ struct CSVBufferRead {
 
 	shared_ptr<CSVBuffer> buffer;
 	shared_ptr<CSVBuffer> next_buffer;
-	vector<unsafe_array_ptr<char>> intersections;
+	vector<unsafe_unique_array<char>> intersections;
 	optional_ptr<LineInfo> line_info;
 
 	idx_t buffer_start;

--- a/src/include/duckdb/execution/perfect_aggregate_hashtable.hpp
+++ b/src/include/duckdb/execution/perfect_aggregate_hashtable.hpp
@@ -46,9 +46,9 @@ protected:
 	// The actual pointer to the data
 	data_ptr_t data;
 	//! The owned data of the HT
-	unsafe_array_ptr<data_t> owned_data;
+	unsafe_unique_array<data_t> owned_data;
 	//! Information on whether or not a specific group has any entries
-	unsafe_array_ptr<bool> group_is_set;
+	unsafe_unique_array<bool> group_is_set;
 
 	//! The minimum values for each of the group columns
 	vector<Value> group_minima;

--- a/src/include/duckdb/execution/window_segment_tree.hpp
+++ b/src/include/duckdb/execution/window_segment_tree.hpp
@@ -113,7 +113,7 @@ private:
 	Vector statev;
 
 	//! The actual window segment tree: an array of aggregate states that represent all the intermediate nodes
-	unsafe_array_ptr<data_t> levels_flat_native;
+	unsafe_unique_array<data_t> levels_flat_native;
 	//! For each level, the starting location in the levels_flat_native array
 	vector<idx_t> levels_flat_start;
 

--- a/src/include/duckdb/function/table/read_csv.hpp
+++ b/src/include/duckdb/function/table/read_csv.hpp
@@ -55,7 +55,7 @@ struct WriteCSVData : public BaseCSVData {
 	//! The size of the CSV file (in bytes) that we buffer before we flush it to disk
 	idx_t flush_size = 4096 * 8;
 	//! For each byte whether or not the CSV file requires quotes when containing the byte
-	unsafe_array_ptr<bool> requires_quotes;
+	unsafe_unique_array<bool> requires_quotes;
 };
 
 struct ColumnInfo {

--- a/src/include/duckdb/optimizer/join_order/join_relation.hpp
+++ b/src/include/duckdb/optimizer/join_order/join_relation.hpp
@@ -27,12 +27,12 @@ struct SingleJoinRelation {
 
 //! Set of relations, used in the join graph.
 struct JoinRelationSet {
-	JoinRelationSet(unsafe_array_ptr<idx_t> relations, idx_t count) : relations(std::move(relations)), count(count) {
+	JoinRelationSet(unsafe_unique_array<idx_t> relations, idx_t count) : relations(std::move(relations)), count(count) {
 	}
 
 	string ToString() const;
 
-	unsafe_array_ptr<idx_t> relations;
+	unsafe_unique_array<idx_t> relations;
 	idx_t count;
 
 	static bool IsSubset(JoinRelationSet &super, JoinRelationSet &sub);
@@ -55,7 +55,7 @@ public:
 	//! Create or get a JoinRelationSet from a set of relation bindings
 	JoinRelationSet &GetJoinRelation(unordered_set<idx_t> &bindings);
 	//! Create or get a JoinRelationSet from a (sorted, duplicate-free!) list of relations
-	JoinRelationSet &GetJoinRelation(unsafe_array_ptr<idx_t> relations, idx_t count);
+	JoinRelationSet &GetJoinRelation(unsafe_unique_array<idx_t> relations, idx_t count);
 	//! Union two sets of relations together and create a new relation set
 	JoinRelationSet &Union(JoinRelationSet &left, JoinRelationSet &right);
 	// //! Create the set difference of left \ right (i.e. all elements in left that are not in right)

--- a/src/include/duckdb/storage/statistics/base_statistics.hpp
+++ b/src/include/duckdb/storage/statistics/base_statistics.hpp
@@ -138,7 +138,7 @@ private:
 		StringStatsData string_data;
 	} stats_union;
 	//! Child stats (for LIST and STRUCT)
-	unsafe_array_ptr<BaseStatistics> child_stats;
+	unsafe_unique_array<BaseStatistics> child_stats;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/append_state.hpp
+++ b/src/include/duckdb/storage/table/append_state.hpp
@@ -44,7 +44,7 @@ struct RowGroupAppendState {
 	//! The current row_group we are appending to
 	RowGroup *row_group;
 	//! The column append states
-	unsafe_array_ptr<ColumnAppendState> states;
+	unsafe_unique_array<ColumnAppendState> states;
 	//! Offset within the row_group
 	idx_t offset_in_row_group;
 };

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -99,7 +99,7 @@ public:
 	//! The maximum row within the row group
 	idx_t max_row_group_row;
 	//! Child column scans
-	unsafe_array_ptr<ColumnScanState> column_scans;
+	unsafe_unique_array<ColumnScanState> column_scans;
 	//! Row group segment tree
 	RowGroupSegmentTree *row_groups;
 	//! The total maximum row index

--- a/src/include/duckdb/storage/table/update_segment.hpp
+++ b/src/include/duckdb/storage/table/update_segment.hpp
@@ -96,8 +96,8 @@ private:
 
 struct UpdateNodeData {
 	unique_ptr<UpdateInfo> info;
-	unsafe_array_ptr<sel_t> tuples;
-	unsafe_array_ptr<data_t> tuple_data;
+	unsafe_unique_array<sel_t> tuples;
+	unsafe_unique_array<data_t> tuple_data;
 };
 
 struct UpdateNode {

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -133,10 +133,10 @@ void ExtensionHelper::InstallExtension(ClientContext &context, const string &ext
 	InstallExtensionInternal(config, &client_config, fs, local_path, extension, force_install);
 }
 
-unsafe_array_ptr<data_t> ReadExtensionFileFromDisk(FileSystem &fs, const string &path, idx_t &file_size) {
+unsafe_unique_array<data_t> ReadExtensionFileFromDisk(FileSystem &fs, const string &path, idx_t &file_size) {
 	auto source_file = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ);
 	file_size = source_file->GetFileSize();
-	auto in_buffer = make_unsafe_array<data_t>(file_size);
+	auto in_buffer = make_unsafe_uniq_array<data_t>(file_size);
 	source_file->Read(in_buffer.get(), file_size);
 	source_file->Close();
 	return in_buffer;

--- a/src/optimizer/join_order/join_relation_set.cpp
+++ b/src/optimizer/join_order/join_relation_set.cpp
@@ -35,7 +35,7 @@ bool JoinRelationSet::IsSubset(JoinRelationSet &super, JoinRelationSet &sub) {
 	return false;
 }
 
-JoinRelationSet &JoinRelationSetManager::GetJoinRelation(unsafe_array_ptr<idx_t> relations, idx_t count) {
+JoinRelationSet &JoinRelationSetManager::GetJoinRelation(unsafe_unique_array<idx_t> relations, idx_t count) {
 	// now look it up in the tree
 	reference<JoinRelationTreeNode> info(root);
 	for (idx_t i = 0; i < count; i++) {
@@ -67,7 +67,7 @@ JoinRelationSet &JoinRelationSetManager::GetJoinRelation(idx_t index) {
 
 JoinRelationSet &JoinRelationSetManager::GetJoinRelation(unordered_set<idx_t> &bindings) {
 	// create a sorted vector of the relations
-	unsafe_array_ptr<idx_t> relations = bindings.empty() ? nullptr : make_unsafe_array<idx_t>(bindings.size());
+	unsafe_unique_array<idx_t> relations = bindings.empty() ? nullptr : make_unsafe_array<idx_t>(bindings.size());
 	idx_t count = 0;
 	for (auto &entry : bindings) {
 		relations[count++] = entry;
@@ -113,7 +113,7 @@ JoinRelationSet &JoinRelationSetManager::Union(JoinRelationSet &left, JoinRelati
 }
 
 // JoinRelationSet *JoinRelationSetManager::Difference(JoinRelationSet *left, JoinRelationSet *right) {
-// 	auto relations = unsafe_array_ptr<idx_t>(new idx_t[left->count]);
+// 	auto relations = unsafe_unique_array<idx_t>(new idx_t[left->count]);
 // 	idx_t count = 0;
 // 	// move through the left and right relations
 // 	idx_t i = 0, j = 0;

--- a/src/optimizer/join_order/join_relation_set.cpp
+++ b/src/optimizer/join_order/join_relation_set.cpp
@@ -59,7 +59,7 @@ JoinRelationSet &JoinRelationSetManager::GetJoinRelation(unsafe_unique_array<idx
 //! Create or get a JoinRelationSet from a single node with the given index
 JoinRelationSet &JoinRelationSetManager::GetJoinRelation(idx_t index) {
 	// create a sorted vector of the relations
-	auto relations = make_unsafe_array<idx_t>(1);
+	auto relations = make_unsafe_uniq_array<idx_t>(1);
 	relations[0] = index;
 	idx_t count = 1;
 	return GetJoinRelation(std::move(relations), count);
@@ -67,7 +67,7 @@ JoinRelationSet &JoinRelationSetManager::GetJoinRelation(idx_t index) {
 
 JoinRelationSet &JoinRelationSetManager::GetJoinRelation(unordered_set<idx_t> &bindings) {
 	// create a sorted vector of the relations
-	unsafe_unique_array<idx_t> relations = bindings.empty() ? nullptr : make_unsafe_array<idx_t>(bindings.size());
+	unsafe_unique_array<idx_t> relations = bindings.empty() ? nullptr : make_unsafe_uniq_array<idx_t>(bindings.size());
 	idx_t count = 0;
 	for (auto &entry : bindings) {
 		relations[count++] = entry;
@@ -77,7 +77,7 @@ JoinRelationSet &JoinRelationSetManager::GetJoinRelation(unordered_set<idx_t> &b
 }
 
 JoinRelationSet &JoinRelationSetManager::Union(JoinRelationSet &left, JoinRelationSet &right) {
-	auto relations = make_unsafe_array<idx_t>(left.count + right.count);
+	auto relations = make_unsafe_uniq_array<idx_t>(left.count + right.count);
 	idx_t count = 0;
 	// move through the left and right relations, eliminating duplicates
 	idx_t i = 0, j = 0;

--- a/src/storage/checkpoint/write_overflow_strings_to_disk.cpp
+++ b/src/storage/checkpoint/write_overflow_strings_to_disk.cpp
@@ -32,7 +32,7 @@ void WriteOverflowStringsToDisk::WriteString(string_t string, block_id_t &result
 	MiniZStream s;
 	size_t compressed_size = 0;
 	compressed_size = s.MaxCompressedLength(uncompressed_size);
-	auto compressed_buf = make_unsafe_array<data_t>(compressed_size);
+	auto compressed_buf = make_unsafe_uniq_array<data_t>(compressed_size);
 	s.Compress((const char *)string.GetData(), uncompressed_size, (char *)compressed_buf.get(), &compressed_size);
 	string_t compressed_string((const char *)compressed_buf.get(), compressed_size);
 

--- a/src/storage/compression/string_uncompressed.cpp
+++ b/src/storage/compression/string_uncompressed.cpp
@@ -292,7 +292,7 @@ string_t UncompressedStringStorage::ReadOverflowString(ColumnSegment &segment, V
 		offset += 2 * sizeof(uint32_t);
 
 		data_ptr_t decompression_ptr;
-		unsafe_array_ptr<data_t> decompression_buffer;
+		unsafe_unique_array<data_t> decompression_buffer;
 
 		// If string is in single block we decompress straight from it, else we copy first
 		if (remaining <= Storage::BLOCK_SIZE - sizeof(block_id_t) - offset) {

--- a/src/storage/compression/string_uncompressed.cpp
+++ b/src/storage/compression/string_uncompressed.cpp
@@ -298,7 +298,7 @@ string_t UncompressedStringStorage::ReadOverflowString(ColumnSegment &segment, V
 		if (remaining <= Storage::BLOCK_SIZE - sizeof(block_id_t) - offset) {
 			decompression_ptr = handle.Ptr() + offset;
 		} else {
-			decompression_buffer = make_unsafe_array<data_t>(compressed_size);
+			decompression_buffer = make_unsafe_uniq_array<data_t>(compressed_size);
 			auto target_ptr = decompression_buffer.get();
 
 			// now append the string to the single buffer

--- a/src/storage/statistics/list_stats.cpp
+++ b/src/storage/statistics/list_stats.cpp
@@ -7,7 +7,7 @@
 namespace duckdb {
 
 void ListStats::Construct(BaseStatistics &stats) {
-	stats.child_stats = unsafe_array_ptr<BaseStatistics>(new BaseStatistics[1]);
+	stats.child_stats = unsafe_unique_array<BaseStatistics>(new BaseStatistics[1]);
 	BaseStatistics::Construct(stats.child_stats[0], ListType::GetChildType(stats.GetType()));
 }
 

--- a/src/storage/statistics/struct_stats.cpp
+++ b/src/storage/statistics/struct_stats.cpp
@@ -7,7 +7,7 @@ namespace duckdb {
 
 void StructStats::Construct(BaseStatistics &stats) {
 	auto &child_types = StructType::GetChildTypes(stats.GetType());
-	stats.child_stats = unsafe_array_ptr<BaseStatistics>(new BaseStatistics[child_types.size()]);
+	stats.child_stats = unsafe_unique_array<BaseStatistics>(new BaseStatistics[child_types.size()]);
 	for (idx_t i = 0; i < child_types.size(); i++) {
 		BaseStatistics::Construct(stats.child_stats[i], child_types[i].second);
 	}

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -155,7 +155,7 @@ void ColumnScanState::Initialize(const LogicalType &type) {
 
 void CollectionScanState::Initialize(const vector<LogicalType> &types) {
 	auto &column_ids = GetColumnIds();
-	column_scans = make_unsafe_array<ColumnScanState>(column_ids.size());
+	column_scans = make_unsafe_uniq_array<ColumnScanState>(column_ids.size());
 	for (idx_t i = 0; i < column_ids.size(); i++) {
 		if (column_ids[i] == COLUMN_IDENTIFIER_ROW_ID) {
 			continue;
@@ -695,7 +695,7 @@ void RowGroup::InitializeAppend(RowGroupAppendState &append_state) {
 	append_state.row_group = this;
 	append_state.offset_in_row_group = this->count;
 	// for each column, initialize the append state
-	append_state.states = make_unsafe_array<ColumnAppendState>(GetColumnCount());
+	append_state.states = make_unsafe_uniq_array<ColumnAppendState>(GetColumnCount());
 	for (idx_t i = 0; i < GetColumnCount(); i++) {
 		auto &col_data = GetColumn(i);
 		col_data.InitializeAppend(append_state.states[i]);

--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -1044,7 +1044,7 @@ static idx_t SortSelectionVector(SelectionVector &sel, idx_t count, row_t *ids) 
 
 UpdateInfo *CreateEmptyUpdateInfo(TransactionData transaction, idx_t type_size, idx_t count,
                                   unsafe_unique_array<char> &data) {
-	data = make_unsafe_array<char>(sizeof(UpdateInfo) + (sizeof(sel_t) + type_size) * STANDARD_VECTOR_SIZE);
+	data = make_unsafe_uniq_array<char>(sizeof(UpdateInfo) + (sizeof(sel_t) + type_size) * STANDARD_VECTOR_SIZE);
 	auto update_info = (UpdateInfo *)data.get();
 	update_info->max = STANDARD_VECTOR_SIZE;
 	update_info->tuples = (sel_t *)(((data_ptr_t)update_info) + sizeof(UpdateInfo));
@@ -1145,8 +1145,8 @@ void UpdateSegment::Update(TransactionData transaction, idx_t column_index, Vect
 		auto result = make_uniq<UpdateNodeData>();
 
 		result->info = make_uniq<UpdateInfo>();
-		result->tuples = make_unsafe_array<sel_t>(STANDARD_VECTOR_SIZE);
-		result->tuple_data = make_unsafe_array<data_t>(STANDARD_VECTOR_SIZE * type_size);
+		result->tuples = make_unsafe_uniq_array<sel_t>(STANDARD_VECTOR_SIZE);
+		result->tuple_data = make_unsafe_uniq_array<data_t>(STANDARD_VECTOR_SIZE * type_size);
 		result->info->tuples = result->tuples.get();
 		result->info->tuple_data = result->tuple_data.get();
 		result->info->version_number = TRANSACTION_ID_START - 1;

--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -1043,7 +1043,7 @@ static idx_t SortSelectionVector(SelectionVector &sel, idx_t count, row_t *ids) 
 }
 
 UpdateInfo *CreateEmptyUpdateInfo(TransactionData transaction, idx_t type_size, idx_t count,
-                                  unsafe_array_ptr<char> &data) {
+                                  unsafe_unique_array<char> &data) {
 	data = make_unsafe_array<char>(sizeof(UpdateInfo) + (sizeof(sel_t) + type_size) * STANDARD_VECTOR_SIZE);
 	auto update_info = (UpdateInfo *)data.get();
 	update_info->max = STANDARD_VECTOR_SIZE;
@@ -1110,7 +1110,7 @@ void UpdateSegment::Update(TransactionData transaction, idx_t column_index, Vect
 			}
 			node = node->next;
 		}
-		unsafe_array_ptr<char> update_info_data;
+		unsafe_unique_array<char> update_info_data;
 		if (!node) {
 			// no updates made yet by this transaction: initially the update info to empty
 			if (transaction.transaction) {
@@ -1154,7 +1154,7 @@ void UpdateSegment::Update(TransactionData transaction, idx_t column_index, Vect
 		InitializeUpdateInfo(*result->info, ids, sel, count, vector_index, vector_offset);
 
 		// now create the transaction level update info in the undo log
-		unsafe_array_ptr<char> update_info_data;
+		unsafe_unique_array<char> update_info_data;
 		UpdateInfo *transaction_node;
 		if (transaction.transaction) {
 			transaction_node = transaction.transaction->CreateUpdateInfo(type_size, count);

--- a/test/api/test_prepared_api.cpp
+++ b/test/api/test_prepared_api.cpp
@@ -320,7 +320,7 @@ TEST_CASE("Test BLOB with PreparedStatement", "[api]") {
 
 	// Creating a blob buffer with almost ALL ASCII chars
 	uint8_t num_chars = 256 - 5; // skipping: '\0', '\n', '\15', ',', '\32'
-	auto blob_chars = make_unsafe_array<char>(num_chars);
+	auto blob_chars = make_unsafe_uniq_array<char>(num_chars);
 	char ch = '\0';
 	idx_t buf_idx = 0;
 	for (idx_t i = 0; i < 255; ++i, ++ch) {

--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -737,11 +737,11 @@ jobject ProcessVector(JNIEnv *env, Connection *conn_ref, Vector &vec, idx_t row_
 	auto type_str = env->NewStringUTF(type_to_jduckdb_type(vec.GetType()).c_str());
 	// construct nullmask
 	auto null_array = env->NewBooleanArray(row_count);
-	jboolean *null_array_ptr = env->GetBooleanArrayElements(null_array, nullptr);
+	jboolean *null_unique_array = env->GetBooleanArrayElements(null_array, nullptr);
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-		null_array_ptr[row_idx] = FlatVector::IsNull(vec, row_idx);
+		null_unique_array[row_idx] = FlatVector::IsNull(vec, row_idx);
 	}
-	env->ReleaseBooleanArrayElements(null_array, null_array_ptr, 0);
+	env->ReleaseBooleanArrayElements(null_array, null_unique_array, 0);
 
 	auto jvec = env->NewObject(J_DuckVector, J_DuckVector_init, type_str, (int)row_count, null_array);
 

--- a/tools/odbc/include/parameter_descriptor.hpp
+++ b/tools/odbc/include/parameter_descriptor.hpp
@@ -63,7 +63,7 @@ private:
 	OdbcHandleDesc *cur_apd;
 
 	//! a pool of allocated parameters during SQLPutData for character data
-	vector<duckdb::unsafe_array_ptr<char>> pool_allocated_ptr;
+	vector<duckdb::unsafe_unique_array<char>> pool_allocated_ptr;
 	//! Index of the
 	idx_t paramset_idx;
 	idx_t cur_paramset_idx;

--- a/tools/odbc/parameter_descriptor.cpp
+++ b/tools/odbc/parameter_descriptor.cpp
@@ -171,7 +171,7 @@ SQLRETURN ParameterDescriptor::FillParamCharDataBuffer(DescRecord &apd_record, D
 	size_t offset = 0;
 	auto sql_ind_ptr = GetSQLDescIndicatorPtr(apd_record);
 	if (*sql_ind_ptr == SQL_DATA_AT_EXEC) {
-		pool_allocated_ptr.emplace_back(duckdb::make_unsafe_array<char>(ipd_record.sql_desc_length));
+		pool_allocated_ptr.emplace_back(duckdb::make_unsafe_uniq_array<char>(ipd_record.sql_desc_length));
 		SetSQLDescDataPtr(apd_record, pool_allocated_ptr.back().get());
 		*sql_ind_ptr = 0;
 	} else {
@@ -203,7 +203,7 @@ SQLRETURN ParameterDescriptor::FillCurParamCharSet(DescRecord &apd_record, DescR
 
 	if (*len_ptr == SQL_DATA_AT_EXEC && pool_allocated_ptr.empty()) {
 		auto alloc_size = col_size * cur_apd->header.sql_desc_array_size;
-		pool_allocated_ptr.emplace_back(duckdb::make_unsafe_array<char>(alloc_size));
+		pool_allocated_ptr.emplace_back(duckdb::make_unsafe_uniq_array<char>(alloc_size));
 		SetSQLDescDataPtr(apd_record, pool_allocated_ptr.back().get());
 	}
 

--- a/tools/rpkg/src/include/typesr.hpp
+++ b/tools/rpkg/src/include/typesr.hpp
@@ -3,8 +3,8 @@
 namespace duckdb {
 
 struct DuckDBAltrepStringWrapper {
-	duckdb::unsafe_array_ptr<string_t> string_data;
-	duckdb::unsafe_array_ptr<bool> mask_data;
+	duckdb::unsafe_unique_array<string_t> string_data;
+	duckdb::unsafe_unique_array<bool> mask_data;
 	StringHeap heap;
 	idx_t length;
 };
@@ -13,7 +13,7 @@ struct DuckDBAltrepListEntryWrapper {
 	DuckDBAltrepListEntryWrapper(idx_t max_length);
 	void Reset(idx_t offset_p, idx_t length_p);
 	idx_t length;
-	duckdb::unsafe_array_ptr<data_t> data;
+	duckdb::unsafe_unique_array<data_t> data;
 };
 
 enum class RType {

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -559,7 +559,7 @@ const unsigned char *sqlite3_column_text(sqlite3_stmt *pStmt, int iCol) {
 		if (!entry.data) {
 			// not initialized yet, convert the value and initialize it
 			auto &str_val = StringValue::Get(val);
-			entry.data = duckdb::make_unsafe_array<char>(str_val.size() + 1);
+			entry.data = duckdb::make_unsafe_uniq_array<char>(str_val.size() + 1);
 			memcpy(entry.data.get(), str_val.c_str(), str_val.size() + 1);
 			entry.data_len = str_val.length();
 		}
@@ -584,7 +584,7 @@ const void *sqlite3_column_blob(sqlite3_stmt *pStmt, int iCol) {
 		if (!entry.data) {
 			// not initialized yet, convert the value and initialize it
 			auto &str_val = StringValue::Get(val);
-			entry.data = duckdb::make_unsafe_array<char>(str_val.size() + 1);
+			entry.data = duckdb::make_unsafe_uniq_array<char>(str_val.size() + 1);
 			memcpy(entry.data.get(), str_val.c_str(), str_val.size() + 1);
 			entry.data_len = str_val.length();
 		}

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -38,7 +38,7 @@ static char *sqlite3_strdup(const char *str);
 
 struct sqlite3_string_buffer {
 	//! String data
-	duckdb::unsafe_array_ptr<char> data;
+	duckdb::unsafe_unique_array<char> data;
 	//! String length
 	int data_len;
 };

--- a/tools/sqlite3_api_wrapper/sqlite3_udf_api/cast_sqlite.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_udf_api/cast_sqlite.cpp
@@ -48,7 +48,7 @@ void CastSQLite::InputVectorsToVarchar(DataChunk &data_chunk, DataChunk &new_chu
 
 VectorType CastSQLite::ToVectorsSQLiteValue(DataChunk &data_chunk, Vector &result,
                                             vector<unique_ptr<vector<sqlite3_value>>> &vec_sqlite_values,
-                                            duckdb::unsafe_array_ptr<UnifiedVectorFormat> vec_data) {
+                                            duckdb::unsafe_unique_array<UnifiedVectorFormat> vec_data) {
 	VectorType result_vec_type = VectorType::CONSTANT_VECTOR;
 
 	// Casting input data to sqlite_value

--- a/tools/sqlite3_api_wrapper/sqlite3_udf_api/include/cast_sqlite.hpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_udf_api/include/cast_sqlite.hpp
@@ -27,7 +27,7 @@ struct CastSQLite {
 
 	static VectorType ToVectorsSQLiteValue(DataChunk &data_chunk, Vector &result,
 	                                       vector<unique_ptr<vector<sqlite3_value>>> &vec_sqlites,
-	                                       duckdb::unsafe_array_ptr<UnifiedVectorFormat> vec_data);
+	                                       duckdb::unsafe_unique_array<UnifiedVectorFormat> vec_data);
 
 	static unique_ptr<vector<sqlite3_value>> ToVector(LogicalType type, UnifiedVectorFormat &vec_data, idx_t size,
 	                                                  Vector &result);


### PR DESCRIPTION
This PR is the follow up PR requested here: https://github.com/duckdb/duckdb/pull/7449#issuecomment-1545227046

Changes:
- add `deleter` back to `unique_ptr`, since this is used in the Spatial extension.
- rename `array_ptr` to `unique_array`
- rename `unsafe_array_ptr` to `unsafe_unique_array`
- rename (helper) `make_array` to `make_uniq_array`
- rename (helper) `make_unsafe_array` to `make_unsafe_uniq_array`