### PR TITLE
Alias replacement scans to table name if no explicit alias is provided by the replacement scan

### DIFF
--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -94,7 +94,13 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 			for (auto &scan : config.replacement_scans) {
 				auto replacement_function = scan.function(context, table_name, scan.data.get());
 				if (replacement_function) {
-					replacement_function->alias = ref.alias.empty() ? replacement_function->alias : ref.alias;
+					if (!ref.alias.empty()) {
+						// user-provided alias overrides the default alias
+						replacement_function->alias = ref.alias;
+					} else if (replacement_function->alias.empty()) {
+						// if the replacement scan itself did not provide an alias we use the table name
+						replacement_function->alias = ref.table_name;
+					}
 					if (replacement_function->type == TableReferenceType::TABLE_FUNCTION) {
 						auto &table_function = replacement_function->Cast<TableFunctionRef>();
 						table_function.column_name_alias = ref.column_name_alias;

--- a/tools/nodejs/src/database.cpp
+++ b/tools/nodejs/src/database.cpp
@@ -328,7 +328,6 @@ ScanReplacement(duckdb::ClientContext &context, const std::string &table_name, d
 			children.push_back(duckdb::make_uniq<duckdb::ConstantExpression>(std::move(param)));
 		}
 		table_function->function = duckdb::make_uniq<duckdb::FunctionExpression>(jsargs.function, std::move(children));
-		table_function->alias = table_name;
 		return std::move(table_function);
 	}
 	return nullptr;

--- a/tools/pythonpkg/tests/fast/test_replacement_scan.py
+++ b/tools/pythonpkg/tests/fast/test_replacement_scan.py
@@ -26,6 +26,19 @@ class TestReplacementScan(object):
 		assert (type(pyrel3) == duckdb.DuckDBPyRelation)
 		assert (pyrel3.fetchall() == [(142,), (184,)])
 
+	def test_replacement_scan_alias(self):
+		pyrel1 = duckdb.query('from (values (1, 2)) t(i, j)')
+		pyrel2 = duckdb.query('from (values (1, 10)) t(i, k)')
+		pyrel3 = duckdb.query('from pyrel1 join pyrel2 using(i)')
+		assert (type(pyrel3) == duckdb.DuckDBPyRelation)
+		assert (pyrel3.fetchall() == [(1, 2, 10)])
+
+	def test_replacement_scan_pandas_alias(self):
+		df1 = duckdb.query('from (values (1, 2)) t(i, j)').df()
+		df2 = duckdb.query('from (values (1, 10)) t(i, k)').df()
+		df3 = duckdb.query('from df1 join df2 using(i)')
+		assert (df3.fetchall() == [(1, 2, 10)])
+
 	def test_replacement_scan_fail(self, duckdb_cursor):
 		random_object = "I love salmiak rondos"
 		con = duckdb.connect()

--- a/tools/rpkg/src/register.cpp
+++ b/tools/rpkg/src/register.cpp
@@ -215,7 +215,6 @@ unique_ptr<TableRef> duckdb::ArrowScanReplacement(ClientContext &context, const 
 			children.push_back(
 			    make_uniq<ConstantExpression>(Value::POINTER((uintptr_t)RArrowTabularStreamFactory::GetSchema)));
 			table_function->function = make_uniq<FunctionExpression>("arrow_scan", std::move(children));
-			table_function->alias = table_name;
 			return std::move(table_function);
 		}
 	}


### PR DESCRIPTION
Fixes an issue introduced by #7478 where Pandas replacement scans were aliased to `pandas_scan` instead of to the DataFrame name supplied by the user.