### PR TITLE
[Python] Fix GIL issue in `sql` with multiple statements

### DIFF
--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -910,21 +910,28 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::RunQuery(const string &query, c
 	// FIXME: we should add support for a relation object over a column data collection to make this more efficient
 	vector<vector<Value>> values;
 	vector<string> names = res->names;
-	while (true) {
-		auto chunk = res->Fetch();
-		if (!chunk || chunk->size() == 0) {
-			break;
-		}
-		for (idx_t r = 0; r < chunk->size(); r++) {
-			vector<Value> row;
-			for (idx_t c = 0; c < chunk->ColumnCount(); c++) {
-				row.push_back(chunk->data[c].GetValue(r));
+	{
+		py::gil_scoped_release release;
+
+		while (true) {
+			auto chunk = res->Fetch();
+			if (res->HasError()) {
+				res->ThrowError();
 			}
-			values.push_back(std::move(row));
+			if (!chunk || chunk->size() == 0) {
+				break;
+			}
+			for (idx_t r = 0; r < chunk->size(); r++) {
+				vector<Value> row;
+				for (idx_t c = 0; c < chunk->ColumnCount(); c++) {
+					row.push_back(chunk->data[c].GetValue(r));
+				}
+				values.push_back(std::move(row));
+			}
 		}
-	}
-	if (values.empty()) {
-		return nullptr;
+		if (values.empty()) {
+			return nullptr;
+		}
 	}
 	return make_uniq<DuckDBPyRelation>(make_uniq<ValueRelation>(connection->context, values, names));
 }


### PR DESCRIPTION
This PR fixes #7513 

In the python API we expect the GIL to be released when starting execution.
When `sql` is given multiple statements, we resort back to the same path as `execute` which produces a stream query result.
This is then immediately consumed, but when fetching from a stream query result, this triggers execution.
When we fetch from the result in `sql` we didn't release the GIL which ran into an issue, which we silently ignored and the result got cut short instead.