### PR TITLE
Correctly shift row IDs during ART deletions

### DIFF
--- a/src/execution/index/art/leaf.cpp
+++ b/src/execution/index/art/leaf.cpp
@@ -192,15 +192,12 @@ void Leaf::Remove(ART &art, const row_t row_id) {
 	reference<LeafSegment> prev_segment(LeafSegment::Get(art, ptr));
 	while (copy_idx < count) {
 
-		// calculate the copy count
-		auto copy_count = count - copy_idx;
-		if (Node::LEAF_SEGMENT_SIZE - 1 < copy_count) {
-			copy_count = Node::LEAF_SEGMENT_SIZE - 1;
-		}
+		auto copy_start = copy_idx % Node::LEAF_SEGMENT_SIZE;
+		D_ASSERT(copy_start != 0);
+		auto copy_end = MinValue(copy_start + count - copy_idx, Node::LEAF_SEGMENT_SIZE);
 
 		// copy row IDs
-		D_ASSERT((copy_idx % Node::LEAF_SEGMENT_SIZE) != 0);
-		for (idx_t i = copy_idx % Node::LEAF_SEGMENT_SIZE; i <= copy_count; i++) {
+		for (idx_t i = copy_start; i < copy_end; i++) {
 			segment.get().row_ids[i - 1] = segment.get().row_ids[i];
 			copy_idx++;
 		}

--- a/test/sql/index/art/art_issue_7530.test
+++ b/test/sql/index/art/art_issue_7530.test
@@ -1,0 +1,15 @@
+# name: test/sql/index/art/art_issue_7530.test
+# description: Test to ensure correct multi-value leaf deletions
+# group: [art]
+
+statement ok
+CREATE TABLE t14(c0 BIGINT);
+
+statement ok
+INSERT INTO t14(c0) VALUES ((1)), ((1)), ((1));
+
+statement ok
+CREATE INDEX i1 ON t14(c0 );
+
+statement ok
+DELETE FROM t14 WHERE t14.rowid;


### PR DESCRIPTION
This PR fixes #7530. We incorrectly set the loop variables during row ID deletions in leaves, which leads to an always `true` loop.

