### PR TITLE
Add internal option to export small buffers to arrow strings

### DIFF
--- a/src/common/arrow/arrow_appender.cpp
+++ b/src/common/arrow/arrow_appender.cpp
@@ -16,6 +16,8 @@ typedef void (*append_vector_t)(ArrowAppendData &append_data, Vector &input, idx
 typedef void (*finalize_t)(ArrowAppendData &append_data, const LogicalType &type, ArrowArray *result);
 
 struct ArrowAppendData {
+	ArrowAppendData(bool export_large_p) : export_large(export_large_p) {
+	}
 	// the buffers of the arrow vector
 	ArrowBuffer validity;
 	ArrowBuffer main_buffer;
@@ -32,21 +34,25 @@ struct ArrowAppendData {
 	// child data (if any)
 	vector<unique_ptr<ArrowAppendData>> child_data;
 
-	//! the arrow array C API data, only set after Finalize
+	// the arrow array C API data, only set after Finalize
 	unique_ptr<ArrowArray> array;
 	duckdb::array<const void *, 3> buffers = {{nullptr, nullptr, nullptr}};
 	vector<ArrowArray *> child_pointers;
+
+	// If the data is exported using large buffers
+	bool export_large = true;
 };
 
 //===--------------------------------------------------------------------===//
 // ArrowAppender
 //===--------------------------------------------------------------------===//
-static unique_ptr<ArrowAppendData> InitializeArrowChild(const LogicalType &type, idx_t capacity);
+static unique_ptr<ArrowAppendData> InitializeArrowChild(const LogicalType &type, idx_t capacity, bool export_as_large);
 static ArrowArray *FinalizeArrowChild(const LogicalType &type, ArrowAppendData &append_data);
 
-ArrowAppender::ArrowAppender(vector<LogicalType> types_p, idx_t initial_capacity) : types(std::move(types_p)) {
+ArrowAppender::ArrowAppender(vector<LogicalType> types_p, idx_t initial_capacity, bool export_as_large_p)
+    : types(std::move(types_p)), export_as_large(export_as_large_p) {
 	for (auto &type : types) {
-		auto entry = InitializeArrowChild(type, initial_capacity);
+		auto entry = InitializeArrowChild(type, initial_capacity, export_as_large_p);
 		root_data.push_back(std::move(entry));
 	}
 }
@@ -234,7 +240,7 @@ struct ArrowEnumData : public ArrowScalarBaseData<TGT> {
 	static void Initialize(ArrowAppendData &result, const LogicalType &type, idx_t capacity) {
 		result.main_buffer.reserve(capacity * sizeof(TGT));
 		// construct the enum child data
-		auto enum_data = InitializeArrowChild(LogicalType::VARCHAR, EnumType::GetSize(type));
+		auto enum_data = InitializeArrowChild(LogicalType::VARCHAR, EnumType::GetSize(type), result.export_large);
 		EnumAppendVector(*enum_data, EnumType::GetValuesInsertOrder(type), EnumType::GetSize(type));
 		result.child_data.push_back(std::move(enum_data));
 	}
@@ -317,10 +323,11 @@ struct ArrowUUIDConverter {
 	}
 };
 
-template <class SRC = string_t, class OP = ArrowVarcharConverter>
+template <class SRC = string_t, class OP = ArrowVarcharConverter, class BUFTYPE = uint64_t>
 struct ArrowVarcharData {
 	static void Initialize(ArrowAppendData &result, const LogicalType &type, idx_t capacity) {
-		result.main_buffer.reserve((capacity + 1) * sizeof(uint64_t));
+		result.main_buffer.reserve((capacity + 1) * sizeof(BUFTYPE));
+
 		result.aux_buffer.reserve(capacity);
 	}
 
@@ -334,9 +341,9 @@ struct ArrowVarcharData {
 		auto validity_data = (uint8_t *)append_data.validity.data();
 
 		// resize the offset buffer - the offset buffer holds the offsets into the child array
-		append_data.main_buffer.resize(append_data.main_buffer.size() + sizeof(uint64_t) * (size + 1));
+		append_data.main_buffer.resize(append_data.main_buffer.size() + sizeof(BUFTYPE) * (size + 1));
 		auto data = (SRC *)format.data;
-		auto offset_data = (uint64_t *)append_data.main_buffer.data();
+		auto offset_data = (BUFTYPE *)append_data.main_buffer.data();
 		if (append_data.row_count == 0) {
 			// first entry
 			offset_data[0] = 0;
@@ -344,6 +351,10 @@ struct ArrowVarcharData {
 		// now append the string data to the auxiliary buffer
 		// the auxiliary buffer's length depends on the string lengths, so we resize as required
 		auto last_offset = offset_data[append_data.row_count];
+		idx_t max_offset = append_data.row_count + to - from;
+		if (max_offset > NumericLimits<uint32_t>::Maximum() && !append_data.export_large) {
+			throw InvalidInputException("Arrow Appender: Buffer type is not sufficiently big");
+		}
 		for (idx_t i = from; i < to; i++) {
 			auto source_idx = format.sel->get_index(i);
 			auto offset_idx = append_data.row_count + i + 1 - from;
@@ -386,7 +397,7 @@ struct ArrowStructData {
 	static void Initialize(ArrowAppendData &result, const LogicalType &type, idx_t capacity) {
 		auto &children = StructType::GetChildTypes(type);
 		for (auto &child : children) {
-			auto child_buffer = InitializeArrowChild(child.second, capacity);
+			auto child_buffer = InitializeArrowChild(child.second, capacity, result.export_large);
 			result.child_data.push_back(std::move(child_buffer));
 		}
 	}
@@ -460,7 +471,7 @@ struct ArrowListData {
 	static void Initialize(ArrowAppendData &result, const LogicalType &type, idx_t capacity) {
 		auto &child_type = ListType::GetChildType(type);
 		result.main_buffer.reserve((capacity + 1) * sizeof(uint32_t));
-		auto child_buffer = InitializeArrowChild(child_type, capacity);
+		auto child_buffer = InitializeArrowChild(child_type, capacity, result.export_large);
 		result.child_data.push_back(std::move(child_buffer));
 	}
 
@@ -513,9 +524,9 @@ struct ArrowMapData {
 
 		auto &key_type = MapType::KeyType(type);
 		auto &value_type = MapType::ValueType(type);
-		auto internal_struct = make_uniq<ArrowAppendData>();
-		internal_struct->child_data.push_back(InitializeArrowChild(key_type, capacity));
-		internal_struct->child_data.push_back(InitializeArrowChild(value_type, capacity));
+		auto internal_struct = make_uniq<ArrowAppendData>(result.export_large);
+		internal_struct->child_data.push_back(InitializeArrowChild(key_type, capacity, result.export_large));
+		internal_struct->child_data.push_back(InitializeArrowChild(value_type, capacity, result.export_large));
 
 		result.child_data.push_back(std::move(internal_struct));
 	}
@@ -677,10 +688,18 @@ static void InitializeFunctionPointers(ArrowAppendData &append_data, const Logic
 	case LogicalTypeId::VARCHAR:
 	case LogicalTypeId::BLOB:
 	case LogicalTypeId::BIT:
-		InitializeFunctionPointers<ArrowVarcharData<string_t>>(append_data);
+		if (append_data.export_large) {
+			InitializeFunctionPointers<ArrowVarcharData<string_t>>(append_data);
+		} else {
+			InitializeFunctionPointers<ArrowVarcharData<string_t, ArrowVarcharConverter, uint32_t>>(append_data);
+		}
 		break;
 	case LogicalTypeId::UUID:
-		InitializeFunctionPointers<ArrowVarcharData<hugeint_t, ArrowUUIDConverter>>(append_data);
+		if (append_data.export_large) {
+			InitializeFunctionPointers<ArrowVarcharData<hugeint_t, ArrowUUIDConverter>>(append_data);
+		} else {
+			InitializeFunctionPointers<ArrowVarcharData<hugeint_t, ArrowUUIDConverter, uint32_t>>(append_data);
+		}
 		break;
 	case LogicalTypeId::ENUM:
 		switch (type.InternalType()) {
@@ -714,8 +733,8 @@ static void InitializeFunctionPointers(ArrowAppendData &append_data, const Logic
 	}
 }
 
-unique_ptr<ArrowAppendData> InitializeArrowChild(const LogicalType &type, idx_t capacity) {
-	auto result = make_uniq<ArrowAppendData>();
+unique_ptr<ArrowAppendData> InitializeArrowChild(const LogicalType &type, idx_t capacity, bool export_large) {
+	auto result = make_uniq<ArrowAppendData>(export_large);
 	InitializeFunctionPointers(*result, type);
 
 	auto byte_count = (capacity + 7) / 8;
@@ -761,7 +780,7 @@ ArrowArray *FinalizeArrowChild(const LogicalType &type, ArrowAppendData &append_
 //! Returns the underlying arrow array
 ArrowArray ArrowAppender::Finalize() {
 	D_ASSERT(root_data.size() == types.size());
-	auto root_holder = make_uniq<ArrowAppendData>();
+	auto root_holder = make_uniq<ArrowAppendData>(export_as_large);
 
 	ArrowArray result;
 	root_holder->child_pointers.resize(types.size());

--- a/src/common/arrow/arrow_appender.cpp
+++ b/src/common/arrow/arrow_appender.cpp
@@ -39,7 +39,7 @@ struct ArrowAppendData {
 	duckdb::array<const void *, 3> buffers = {{nullptr, nullptr, nullptr}};
 	vector<ArrowArray *> child_pointers;
 
-	ArrowOptions &options;
+	ArrowOptions options;
 };
 
 //===--------------------------------------------------------------------===//
@@ -48,13 +48,8 @@ struct ArrowAppendData {
 static unique_ptr<ArrowAppendData> InitializeArrowChild(const LogicalType &type, idx_t capacity, ArrowOptions &options);
 static ArrowArray *FinalizeArrowChild(const LogicalType &type, ArrowAppendData &append_data);
 
-ArrowAppender::ArrowAppender(vector<LogicalType> types_p, idx_t initial_capacity, bool export_as_large)
+ArrowAppender::ArrowAppender(vector<LogicalType> types_p, idx_t initial_capacity, ArrowOptions options)
     : types(std::move(types_p)) {
-	if (!export_as_large) {
-		options.offset_size = ArrowOffsetSize::REGULAR;
-	} else {
-		options.offset_size = ArrowOffsetSize::LARGE;
-	}
 	for (auto &type : types) {
 		auto entry = InitializeArrowChild(type, initial_capacity, options);
 		root_data.push_back(std::move(entry));

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -15,8 +15,8 @@
 
 namespace duckdb {
 
-void ArrowConverter::ToArrowArray(DataChunk &input, ArrowArray *out_array) {
-	ArrowAppender appender(input.GetTypes(), input.size());
+void ArrowConverter::ToArrowArray(DataChunk &input, ArrowArray *out_array, bool export_as_large) {
+	ArrowAppender appender(input.GetTypes(), input.size(), export_as_large);
 	appender.Append(input, 0, input.size(), input.size());
 	*out_array = appender.Finalize();
 }
@@ -59,10 +59,10 @@ void InitializeChild(ArrowSchema &child, const string &name = "") {
 	child.dictionary = nullptr;
 }
 void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
-                    const string &config_timezone);
+                    const string &config_timezone, bool export_as_large);
 
 void SetArrowMapFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
-                       const string &config_timezone) {
+                       const string &config_timezone, bool export_as_large) {
 	child.format = "+m";
 	//! Map has one child which is a struct
 	child.n_children = 1;
@@ -73,11 +73,11 @@ void SetArrowMapFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child,
 	InitializeChild(root_holder.nested_children.back()[0]);
 	child.children = &root_holder.nested_children_ptr.back()[0];
 	child.children[0]->name = "entries";
-	SetArrowFormat(root_holder, **child.children, ListType::GetChildType(type), config_timezone);
+	SetArrowFormat(root_holder, **child.children, ListType::GetChildType(type), config_timezone, export_as_large);
 }
 
 void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
-                    const string &config_timezone) {
+                    const string &config_timezone, bool export_as_large) {
 	switch (type.id()) {
 	case LogicalTypeId::BOOLEAN:
 		child.format = "b";
@@ -117,7 +117,11 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		break;
 	case LogicalTypeId::UUID:
 	case LogicalTypeId::VARCHAR:
-		child.format = "U";
+		if (export_as_large) {
+			child.format = "U";
+		} else {
+			child.format = "u";
+		}
 		break;
 	case LogicalTypeId::DATE:
 		child.format = "tdD";
@@ -171,7 +175,11 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 	}
 	case LogicalTypeId::BLOB:
 	case LogicalTypeId::BIT: {
-		child.format = "Z";
+		if (export_as_large) {
+			child.format = "Z";
+		} else {
+			child.format = "z";
+		}
 		break;
 	}
 	case LogicalTypeId::LIST: {
@@ -184,7 +192,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		InitializeChild(root_holder.nested_children.back()[0]);
 		child.children = &root_holder.nested_children_ptr.back()[0];
 		child.children[0]->name = "l";
-		SetArrowFormat(root_holder, **child.children, ListType::GetChildType(type), config_timezone);
+		SetArrowFormat(root_holder, **child.children, ListType::GetChildType(type), config_timezone, export_as_large);
 		break;
 	}
 	case LogicalTypeId::STRUCT: {
@@ -212,12 +220,13 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 			root_holder.owned_type_names.push_back(std::move(name_ptr));
 
 			child.children[type_idx]->name = root_holder.owned_type_names.back().get();
-			SetArrowFormat(root_holder, *child.children[type_idx], child_types[type_idx].second, config_timezone);
+			SetArrowFormat(root_holder, *child.children[type_idx], child_types[type_idx].second, config_timezone,
+			               export_as_large);
 		}
 		break;
 	}
 	case LogicalTypeId::MAP: {
-		SetArrowMapFormat(root_holder, child, type, config_timezone);
+		SetArrowMapFormat(root_holder, child, type, config_timezone, export_as_large);
 		break;
 	}
 	case LogicalTypeId::ENUM: {
@@ -250,7 +259,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 }
 
 void ArrowConverter::ToArrowSchema(ArrowSchema *out_schema, const vector<LogicalType> &types,
-                                   const vector<string> &names, const string &config_timezone) {
+                                   const vector<string> &names, const string &config_timezone, bool export_as_large) {
 	D_ASSERT(out_schema);
 	D_ASSERT(types.size() == names.size());
 	idx_t column_count = types.size();
@@ -278,7 +287,7 @@ void ArrowConverter::ToArrowSchema(ArrowSchema *out_schema, const vector<Logical
 
 		auto &child = root_holder->children[col_idx];
 		InitializeChild(child, names[col_idx]);
-		SetArrowFormat(*root_holder, child, types[col_idx], config_timezone);
+		SetArrowFormat(*root_holder, child, types[col_idx], config_timezone, export_as_large);
 	}
 
 	// Release ownership to caller

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -15,8 +15,8 @@
 
 namespace duckdb {
 
-void ArrowConverter::ToArrowArray(DataChunk &input, ArrowArray *out_array, bool export_as_large) {
-	ArrowAppender appender(input.GetTypes(), input.size(), export_as_large);
+void ArrowConverter::ToArrowArray(DataChunk &input, ArrowArray *out_array, ArrowOptions options) {
+	ArrowAppender appender(input.GetTypes(), input.size(), options);
 	appender.Append(input, 0, input.size(), input.size());
 	*out_array = appender.Finalize();
 }
@@ -59,10 +59,10 @@ void InitializeChild(ArrowSchema &child, const string &name = "") {
 	child.dictionary = nullptr;
 }
 void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
-                    const string &config_timezone, bool export_as_large);
+                    const string &config_timezone, ArrowOptions options);
 
 void SetArrowMapFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
-                       const string &config_timezone, bool export_as_large) {
+                       const string &config_timezone, ArrowOptions options) {
 	child.format = "+m";
 	//! Map has one child which is a struct
 	child.n_children = 1;
@@ -73,11 +73,11 @@ void SetArrowMapFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child,
 	InitializeChild(root_holder.nested_children.back()[0]);
 	child.children = &root_holder.nested_children_ptr.back()[0];
 	child.children[0]->name = "entries";
-	SetArrowFormat(root_holder, **child.children, ListType::GetChildType(type), config_timezone, export_as_large);
+	SetArrowFormat(root_holder, **child.children, ListType::GetChildType(type), config_timezone, options);
 }
 
 void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
-                    const string &config_timezone, bool export_as_large) {
+                    const string &config_timezone, ArrowOptions options) {
 	switch (type.id()) {
 	case LogicalTypeId::BOOLEAN:
 		child.format = "b";
@@ -117,7 +117,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		break;
 	case LogicalTypeId::UUID:
 	case LogicalTypeId::VARCHAR:
-		if (export_as_large) {
+		if (options.offset_size == ArrowOffsetSize::LARGE) {
 			child.format = "U";
 		} else {
 			child.format = "u";
@@ -175,7 +175,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 	}
 	case LogicalTypeId::BLOB:
 	case LogicalTypeId::BIT: {
-		if (export_as_large) {
+		if (options.offset_size == ArrowOffsetSize::LARGE) {
 			child.format = "Z";
 		} else {
 			child.format = "z";
@@ -192,7 +192,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		InitializeChild(root_holder.nested_children.back()[0]);
 		child.children = &root_holder.nested_children_ptr.back()[0];
 		child.children[0]->name = "l";
-		SetArrowFormat(root_holder, **child.children, ListType::GetChildType(type), config_timezone, export_as_large);
+		SetArrowFormat(root_holder, **child.children, ListType::GetChildType(type), config_timezone, options);
 		break;
 	}
 	case LogicalTypeId::STRUCT: {
@@ -221,12 +221,12 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 
 			child.children[type_idx]->name = root_holder.owned_type_names.back().get();
 			SetArrowFormat(root_holder, *child.children[type_idx], child_types[type_idx].second, config_timezone,
-			               export_as_large);
+			               options);
 		}
 		break;
 	}
 	case LogicalTypeId::MAP: {
-		SetArrowMapFormat(root_holder, child, type, config_timezone, export_as_large);
+		SetArrowMapFormat(root_holder, child, type, config_timezone, options);
 		break;
 	}
 	case LogicalTypeId::ENUM: {
@@ -259,7 +259,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 }
 
 void ArrowConverter::ToArrowSchema(ArrowSchema *out_schema, const vector<LogicalType> &types,
-                                   const vector<string> &names, const string &config_timezone, bool export_as_large) {
+                                   const vector<string> &names, const string &config_timezone, ArrowOptions options) {
 	D_ASSERT(out_schema);
 	D_ASSERT(types.size() == names.size());
 	idx_t column_count = types.size();
@@ -287,7 +287,7 @@ void ArrowConverter::ToArrowSchema(ArrowSchema *out_schema, const vector<Logical
 
 		auto &child = root_holder->children[col_idx];
 		InitializeChild(child, names[col_idx]);
-		SetArrowFormat(*root_holder, child, types[col_idx], config_timezone, export_as_large);
+		SetArrowFormat(*root_holder, child, types[col_idx], config_timezone, options);
 	}
 
 	// Release ownership to caller

--- a/src/include/duckdb/common/arrow/arrow_appender.hpp
+++ b/src/include/duckdb/common/arrow/arrow_appender.hpp
@@ -16,6 +16,12 @@ namespace duckdb {
 
 struct ArrowAppendData;
 
+enum ArrowOffsetSize { REGULAR, LARGE };
+
+struct ArrowOptions {
+	ArrowOffsetSize offset_size = ArrowOffsetSize::LARGE;
+};
+
 //! The ArrowAppender class can be used to incrementally construct an arrow array by appending data chunks into it
 class ArrowAppender {
 public:
@@ -35,7 +41,7 @@ private:
 	//! The total row count that has been appended
 	idx_t row_count = 0;
 
-	bool export_as_large = true;
+	ArrowOptions options;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/arrow/arrow_appender.hpp
+++ b/src/include/duckdb/common/arrow/arrow_appender.hpp
@@ -16,16 +16,10 @@ namespace duckdb {
 
 struct ArrowAppendData;
 
-enum ArrowOffsetSize { REGULAR, LARGE };
-
-struct ArrowOptions {
-	ArrowOffsetSize offset_size = ArrowOffsetSize::LARGE;
-};
-
 //! The ArrowAppender class can be used to incrementally construct an arrow array by appending data chunks into it
 class ArrowAppender {
 public:
-	DUCKDB_API ArrowAppender(vector<LogicalType> types, idx_t initial_capacity, bool export_as_large = true);
+	DUCKDB_API ArrowAppender(vector<LogicalType> types, idx_t initial_capacity, ArrowOptions options = ArrowOptions());
 	DUCKDB_API ~ArrowAppender();
 
 	//! Append a data chunk to the underlying arrow array

--- a/src/include/duckdb/common/arrow/arrow_appender.hpp
+++ b/src/include/duckdb/common/arrow/arrow_appender.hpp
@@ -19,7 +19,7 @@ struct ArrowAppendData;
 //! The ArrowAppender class can be used to incrementally construct an arrow array by appending data chunks into it
 class ArrowAppender {
 public:
-	DUCKDB_API ArrowAppender(vector<LogicalType> types, idx_t initial_capacity);
+	DUCKDB_API ArrowAppender(vector<LogicalType> types, idx_t initial_capacity, bool export_as_large = true);
 	DUCKDB_API ~ArrowAppender();
 
 	//! Append a data chunk to the underlying arrow array
@@ -34,6 +34,8 @@ private:
 	vector<unique_ptr<ArrowAppendData>> root_data;
 	//! The total row count that has been appended
 	idx_t row_count = 0;
+
+	bool export_as_large = true;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/arrow/arrow_converter.hpp
+++ b/src/include/duckdb/common/arrow/arrow_converter.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/arrow/arrow.hpp"
+#include "duckdb/common/arrow/arrow_options.hpp"
 
 struct ArrowSchema;
 
@@ -18,8 +19,8 @@ namespace duckdb {
 struct ArrowConverter {
 	DUCKDB_API static void ToArrowSchema(ArrowSchema *out_schema, const vector<LogicalType> &types,
 	                                     const vector<string> &names, const string &config_timezone,
-	                                     bool export_as_large = true);
-	DUCKDB_API static void ToArrowArray(DataChunk &input, ArrowArray *out_array, bool export_as_large = true);
+	                                     ArrowOptions options = ArrowOptions());
+	DUCKDB_API static void ToArrowArray(DataChunk &input, ArrowArray *out_array, ArrowOptions options = ArrowOptions());
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/arrow/arrow_converter.hpp
+++ b/src/include/duckdb/common/arrow/arrow_converter.hpp
@@ -17,8 +17,9 @@ namespace duckdb {
 
 struct ArrowConverter {
 	DUCKDB_API static void ToArrowSchema(ArrowSchema *out_schema, const vector<LogicalType> &types,
-	                                     const vector<string> &names, const string &config_timezone);
-	DUCKDB_API static void ToArrowArray(DataChunk &input, ArrowArray *out_array);
+	                                     const vector<string> &names, const string &config_timezone,
+	                                     bool export_as_large = true);
+	DUCKDB_API static void ToArrowArray(DataChunk &input, ArrowArray *out_array, bool export_as_large = true);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/arrow/arrow_options.hpp
+++ b/src/include/duckdb/common/arrow/arrow_options.hpp
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/arrow/arrow_options.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+namespace duckdb {
+
+enum ArrowOffsetSize { REGULAR, LARGE };
+
+struct ArrowOptions {
+	ArrowOffsetSize offset_size = ArrowOffsetSize::LARGE;
+};
+} // namespace duckdb

--- a/test/arrow/arrow_roundtrip.cpp
+++ b/test/arrow/arrow_roundtrip.cpp
@@ -4,12 +4,12 @@
 
 using namespace duckdb;
 
-static void TestArrowRoundtrip(const string &query) {
+static void TestArrowRoundtrip(const string &query, bool export_large = true) {
 	DuckDB db;
 	Connection con(db);
 
-	REQUIRE(ArrowTestHelper::RunArrowComparison(con, query, true));
-	REQUIRE(ArrowTestHelper::RunArrowComparison(con, query));
+	REQUIRE(ArrowTestHelper::RunArrowComparison(con, query, true, export_large));
+	REQUIRE(ArrowTestHelper::RunArrowComparison(con, query, false, export_large));
 }
 
 static void TestParquetRoundtrip(const string &path) {
@@ -25,6 +25,20 @@ static void TestParquetRoundtrip(const string &path) {
 	auto query = "SELECT * FROM parquet_scan('" + path + "')";
 	REQUIRE(ArrowTestHelper::RunArrowComparison(con, query, true));
 	REQUIRE(ArrowTestHelper::RunArrowComparison(con, query));
+}
+
+TEST_CASE("Test Export Large", "[arrow]") {
+	TestArrowRoundtrip("SELECT 'bla' FROM range(10000)", true);
+
+	TestArrowRoundtrip("SELECT 'bla' FROM range(10000)", false);
+
+	TestArrowRoundtrip("SELECT 'bla'::BLOB FROM range(10000)", true);
+
+	TestArrowRoundtrip("SELECT 'bla'::BLOB FROM range(10000)", false);
+
+	TestArrowRoundtrip("SELECT '3d038406-6275-4aae-bec1-1235ccdeaade'::UUID FROM range(10000) tbl(i)", true);
+
+	TestArrowRoundtrip("SELECT '3d038406-6275-4aae-bec1-1235ccdeaade'::UUID FROM range(10000) tbl(i)", false);
 }
 
 TEST_CASE("Test arrow roundtrip", "[arrow]") {

--- a/test/arrow/arrow_roundtrip.cpp
+++ b/test/arrow/arrow_roundtrip.cpp
@@ -4,12 +4,12 @@
 
 using namespace duckdb;
 
-static void TestArrowRoundtrip(const string &query, bool export_large = true) {
+static void TestArrowRoundtrip(const string &query, ArrowOptions options = ArrowOptions()) {
 	DuckDB db;
 	Connection con(db);
 
-	REQUIRE(ArrowTestHelper::RunArrowComparison(con, query, true, export_large));
-	REQUIRE(ArrowTestHelper::RunArrowComparison(con, query, false, export_large));
+	REQUIRE(ArrowTestHelper::RunArrowComparison(con, query, true, options));
+	REQUIRE(ArrowTestHelper::RunArrowComparison(con, query, false, options));
 }
 
 static void TestParquetRoundtrip(const string &path) {
@@ -28,17 +28,19 @@ static void TestParquetRoundtrip(const string &path) {
 }
 
 TEST_CASE("Test Export Large", "[arrow]") {
-	TestArrowRoundtrip("SELECT 'bla' FROM range(10000)", true);
+	ArrowOptions options;
+	options.offset_size = ArrowOffsetSize::REGULAR;
+	TestArrowRoundtrip("SELECT 'bla' FROM range(10000)");
 
-	TestArrowRoundtrip("SELECT 'bla' FROM range(10000)", false);
+	TestArrowRoundtrip("SELECT 'bla' FROM range(10000)", options);
 
-	TestArrowRoundtrip("SELECT 'bla'::BLOB FROM range(10000)", true);
+	TestArrowRoundtrip("SELECT 'bla'::BLOB FROM range(10000)");
 
-	TestArrowRoundtrip("SELECT 'bla'::BLOB FROM range(10000)", false);
+	TestArrowRoundtrip("SELECT 'bla'::BLOB FROM range(10000)", options);
 
-	TestArrowRoundtrip("SELECT '3d038406-6275-4aae-bec1-1235ccdeaade'::UUID FROM range(10000) tbl(i)", true);
+	TestArrowRoundtrip("SELECT '3d038406-6275-4aae-bec1-1235ccdeaade'::UUID FROM range(10000) tbl(i)");
 
-	TestArrowRoundtrip("SELECT '3d038406-6275-4aae-bec1-1235ccdeaade'::UUID FROM range(10000) tbl(i)", false);
+	TestArrowRoundtrip("SELECT '3d038406-6275-4aae-bec1-1235ccdeaade'::UUID FROM range(10000) tbl(i)", options);
 }
 
 TEST_CASE("Test arrow roundtrip", "[arrow]") {

--- a/test/arrow/arrow_test_helper.cpp
+++ b/test/arrow/arrow_test_helper.cpp
@@ -21,9 +21,9 @@ int ArrowTestFactory::ArrowArrayStreamGetNext(struct ArrowArrayStream *stream, s
 		if (!chunk || chunk->size() == 0) {
 			return 0;
 		}
-		ArrowConverter::ToArrowArray(*chunk, out, data.export_large);
+		ArrowConverter::ToArrowArray(*chunk, out, data.options);
 	} else {
-		ArrowAppender appender(data.factory.result->types, STANDARD_VECTOR_SIZE, data.export_large);
+		ArrowAppender appender(data.factory.result->types, STANDARD_VECTOR_SIZE, data.options);
 		idx_t count = 0;
 		while (true) {
 			auto chunk = data.factory.result->Fetch();
@@ -63,7 +63,7 @@ duckdb::unique_ptr<duckdb::ArrowArrayStreamWrapper> ArrowTestFactory::CreateStre
 
 	auto stream_wrapper = make_uniq<ArrowArrayStreamWrapper>();
 	stream_wrapper->number_of_rows = -1;
-	auto private_data = make_uniq<ArrowArrayStreamData>(factory, factory.export_large);
+	auto private_data = make_uniq<ArrowArrayStreamData>(factory, factory.options);
 	stream_wrapper->arrow_array_stream.get_schema = ArrowArrayStreamGetSchema;
 	stream_wrapper->arrow_array_stream.get_next = ArrowArrayStreamGetNext;
 	stream_wrapper->arrow_array_stream.get_last_error = ArrowArrayStreamGetLastError;
@@ -80,7 +80,7 @@ void ArrowTestFactory::GetSchema(uintptr_t factory_ptr, duckdb::ArrowSchemaWrapp
 }
 
 void ArrowTestFactory::ToArrowSchema(struct ArrowSchema *out) {
-	ArrowConverter::ToArrowSchema(out, types, names, tz, export_large);
+	ArrowConverter::ToArrowSchema(out, types, names, tz, options);
 }
 
 duckdb::unique_ptr<duckdb::ArrowArrayStreamWrapper>
@@ -147,7 +147,7 @@ vector<Value> ArrowTestHelper::ConstructArrowScan(uintptr_t arrow_object, bool f
 	return params;
 }
 
-bool ArrowTestHelper::RunArrowComparison(Connection &con, const string &query, bool big_result, bool export_large) {
+bool ArrowTestHelper::RunArrowComparison(Connection &con, const string &query, bool big_result, ArrowOptions options) {
 	// run the query
 	auto initial_result = con.Query(query);
 	if (initial_result->HasError()) {
@@ -159,8 +159,7 @@ bool ArrowTestHelper::RunArrowComparison(Connection &con, const string &query, b
 	auto tz = ClientConfig::GetConfig(*con.context).ExtractTimezone();
 	auto types = initial_result->types;
 	auto names = initial_result->names;
-	ArrowTestFactory factory(std::move(types), std::move(names), tz, std::move(initial_result), big_result,
-	                         export_large);
+	ArrowTestFactory factory(std::move(types), std::move(names), tz, std::move(initial_result), big_result, options);
 
 	// construct the arrow scan
 	auto params = ConstructArrowScan((uintptr_t)&factory, true);

--- a/test/include/arrow/arrow_test_helper.hpp
+++ b/test/include/arrow/arrow_test_helper.hpp
@@ -26,9 +26,9 @@ namespace duckdb {
 class ArrowTestFactory {
 public:
 	ArrowTestFactory(vector<LogicalType> types_p, vector<string> names_p, string tz_p,
-	                 duckdb::unique_ptr<QueryResult> result_p, bool big_result)
+	                 duckdb::unique_ptr<QueryResult> result_p, bool big_result, bool export_large = true)
 	    : types(std::move(types_p)), names(std::move(names_p)), tz(std::move(tz_p)), result(std::move(result_p)),
-	      big_result(big_result) {
+	      big_result(big_result), export_large(export_large) {
 	}
 
 	vector<LogicalType> types;
@@ -36,12 +36,15 @@ public:
 	string tz;
 	duckdb::unique_ptr<QueryResult> result;
 	bool big_result;
+	bool export_large;
 
 	struct ArrowArrayStreamData {
-		explicit ArrowArrayStreamData(ArrowTestFactory &factory) : factory(factory) {
+		explicit ArrowArrayStreamData(ArrowTestFactory &factory, bool export_large = true)
+		    : factory(factory), export_large(export_large) {
 		}
 
 		ArrowTestFactory &factory;
+		bool export_large;
 	};
 
 	static int ArrowArrayStreamGetSchema(struct ArrowArrayStream *stream, struct ArrowSchema *out);
@@ -71,7 +74,8 @@ public:
 class ArrowTestHelper {
 public:
 	//! Used in the Arrow Roundtrip Tests
-	static bool RunArrowComparison(Connection &con, const string &query, bool big_result = false);
+	static bool RunArrowComparison(Connection &con, const string &query, bool big_result = false,
+	                               bool export_large = true);
 	//! Used in the ADBC Testing
 	static bool RunArrowComparison(Connection &con, const string &query, ArrowArrayStream &arrow_stream);
 

--- a/test/include/arrow/arrow_test_helper.hpp
+++ b/test/include/arrow/arrow_test_helper.hpp
@@ -26,9 +26,9 @@ namespace duckdb {
 class ArrowTestFactory {
 public:
 	ArrowTestFactory(vector<LogicalType> types_p, vector<string> names_p, string tz_p,
-	                 duckdb::unique_ptr<QueryResult> result_p, bool big_result, bool export_large = true)
+	                 duckdb::unique_ptr<QueryResult> result_p, bool big_result, ArrowOptions options)
 	    : types(std::move(types_p)), names(std::move(names_p)), tz(std::move(tz_p)), result(std::move(result_p)),
-	      big_result(big_result), export_large(export_large) {
+	      big_result(big_result), options(options) {
 	}
 
 	vector<LogicalType> types;
@@ -36,15 +36,15 @@ public:
 	string tz;
 	duckdb::unique_ptr<QueryResult> result;
 	bool big_result;
-	bool export_large;
+	ArrowOptions options;
 
 	struct ArrowArrayStreamData {
-		explicit ArrowArrayStreamData(ArrowTestFactory &factory, bool export_large = true)
-		    : factory(factory), export_large(export_large) {
+		explicit ArrowArrayStreamData(ArrowTestFactory &factory, ArrowOptions options)
+		    : factory(factory), options(options) {
 		}
 
 		ArrowTestFactory &factory;
-		bool export_large;
+		ArrowOptions options;
 	};
 
 	static int ArrowArrayStreamGetSchema(struct ArrowArrayStream *stream, struct ArrowSchema *out);
@@ -75,7 +75,7 @@ class ArrowTestHelper {
 public:
 	//! Used in the Arrow Roundtrip Tests
 	static bool RunArrowComparison(Connection &con, const string &query, bool big_result = false,
-	                               bool export_large = true);
+	                               ArrowOptions options = ArrowOptions());
 	//! Used in the ADBC Testing
 	static bool RunArrowComparison(Connection &con, const string &query, ArrowArrayStream &arrow_stream);
 


### PR DESCRIPTION
Internal workaround for ArrowJS:
https://github.com/apache/arrow/issues/15060