### PR TITLE
Issue #7543: Ordered MODE() Descending

### DIFF
--- a/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -99,7 +99,8 @@ BindResult BaseSelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFu
 	bool negate_fractions = false;
 	if (aggr.order_bys && aggr.order_bys->orders.size() == 1) {
 		const auto &func_name = aggr.function_name;
-		ordered_set_agg = (func_name == "quantile_cont" || func_name == "quantile_disc" || func_name == "mode");
+		ordered_set_agg = (func_name == "quantile_cont" || func_name == "quantile_disc" ||
+		                   (func_name == "mode" && aggr.children.empty()));
 
 		if (ordered_set_agg) {
 			auto &config = DBConfig::GetConfig(context);

--- a/test/sql/aggregate/aggregates/test_mode.test
+++ b/test/sql/aggregate/aggregates/test_mode.test
@@ -281,3 +281,20 @@ select k, v, mode(v) over (partition by k)
 2	2	2
 2	5	2
 3	1	1
+
+# MODE is order-sensitive, so this should bind and return the larger value
+query I
+SELECT MODE(order_occurrences ORDER BY order_occurrences DESC) FROM (
+VALUES
+	(500, 1),
+	(1000, 2),
+	(800, 3),
+	(1000, 4),
+	(500, 5),
+	(550, 6),
+	(400, 7),
+	(200, 8),
+	(10, 9)
+)items_per_order(order_occurrences, item_count);
+----
+1000

--- a/test/sql/aggregate/aggregates/test_ordered_aggregates.test
+++ b/test/sql/aggregate/aggregates/test_ordered_aggregates.test
@@ -87,6 +87,23 @@ FROM VALUES (11000), (3100), (2900), (2800), (2600), (2500) AS tab(col);
 ----
 [3100, 2900, 2600]
 
+# MODE is order-sensitive
+query I
+SELECT MODE() WITHIN GROUP (ORDER BY order_occurrences DESC) FROM (
+VALUES
+	(500, 1),
+	(1000, 2),
+	(800, 3),
+	(1000, 4),
+	(500, 5),
+	(550, 6),
+	(400, 7),
+	(200, 8),
+	(10, 9)
+) items_per_order(order_occurrences, item_count);
+----
+1000
+
 #
 # Error checking
 #

--- a/test/sql/types/timestamp/test_infinite_time.test
+++ b/test/sql/types/timestamp/test_infinite_time.test
@@ -135,13 +135,7 @@ query III
 SELECT MODE(ts), MODE(tstz), MODE(dt)
 FROM specials;
 ----
--infinity	-infinity	-infinity
-
-query III
-SELECT MODE(ts), MODE(tstz), MODE(dt)
-FROM specials;
-----
--infinity	-infinity	-infinity
+infinity	infinity	infinity
 
 query III
 SELECT APPROX_COUNT_DISTINCT(ts), APPROX_COUNT_DISTINCT(tstz), APPROX_COUNT_DISTINCT(dt)


### PR DESCRIPTION
Mode is order-dependent for tie-breaking, but the rewrite was dropping the sort order. Tie-breaking is now determined by insertion order, which may cause some query results to change.

fixes #7543