### PR TITLE
Use std::all_of instead of raw loop in Disjoint.

### DIFF
--- a/src/optimizer/join_order/join_order_optimizer.cpp
+++ b/src/optimizer/join_order/join_order_optimizer.cpp
@@ -25,7 +25,11 @@ namespace duckdb {
 //! Returns true if A and B are disjoint, false otherwise
 template <class T>
 static bool Disjoint(const unordered_set<T> &a, const unordered_set<T> &b) {
-	return std::all_of(a.begin(), a.end(), [&b](const auto& entry) { return b.find(entry) == b.end(); });
+	return std::all_of(
+		a.begin(), a.end(),
+		[&b](typename std::unordered_set<T>::const_reference entry) {
+			return b.find(entry) == b.end();
+		});
 }
 
 //! Extract the set of relations referred to inside an expression

--- a/src/optimizer/join_order/join_order_optimizer.cpp
+++ b/src/optimizer/join_order/join_order_optimizer.cpp
@@ -25,7 +25,7 @@ namespace duckdb {
 //! Returns true if A and B are disjoint, false otherwise
 template <class T>
 static bool Disjoint(const unordered_set<T> &a, const unordered_set<T> &b) {
-	return all_of(begin(a), end(a), [&b](const auto& entry) { return b.find(entry) == end(b); });
+	return std::all_of(a.begin(), a.end(), [&b](const auto& entry) { return b.find(entry) == b.end(); });
 }
 
 //! Extract the set of relations referred to inside an expression

--- a/src/optimizer/join_order/join_order_optimizer.cpp
+++ b/src/optimizer/join_order/join_order_optimizer.cpp
@@ -25,11 +25,9 @@ namespace duckdb {
 //! Returns true if A and B are disjoint, false otherwise
 template <class T>
 static bool Disjoint(const unordered_set<T> &a, const unordered_set<T> &b) {
-	return std::all_of(
-		a.begin(), a.end(),
-		[&b](typename std::unordered_set<T>::const_reference entry) {
-			return b.find(entry) == b.end();
-		});
+	return std::all_of(a.begin(), a.end(), [&b](typename std::unordered_set<T>::const_reference entry) {
+		return b.find(entry) == b.end();
+	});
 }
 
 //! Extract the set of relations referred to inside an expression

--- a/src/optimizer/join_order/join_order_optimizer.cpp
+++ b/src/optimizer/join_order/join_order_optimizer.cpp
@@ -24,13 +24,8 @@ namespace duckdb {
 
 //! Returns true if A and B are disjoint, false otherwise
 template <class T>
-static bool Disjoint(unordered_set<T> &a, unordered_set<T> &b) {
-	for (auto &entry : a) {
-		if (b.find(entry) != b.end()) {
-			return false;
-		}
-	}
-	return true;
+static bool Disjoint(const unordered_set<T> &a, const unordered_set<T> &b) {
+	return all_of(begin(a), end(a), [&b](const auto& entry) { return b.find(entry) == end(b); });
 }
 
 //! Extract the set of relations referred to inside an expression


### PR DESCRIPTION
Following Sean Parent's "No raw loops" mantra. all_of better communicates the intent and can be easily vectorized and/or parallelized using execution policies. While at it, also `const`ed parameter references, since `Disjoint` is not supposed to mutate them.