### PR TITLE
Add the default scheme to the CREATE TYPE's type search path.

### DIFF
--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -243,7 +243,7 @@ void Binder::BindLogicalType(ClientContext &context, LogicalType &type, optional
 		type = LogicalType::UNION(member_types);
 		type.SetAlias(alias);
 	} else if (type.id() == LogicalTypeId::USER) {
-		auto &user_type_name = UserType::GetTypeName(type);
+		auto user_type_name = UserType::GetTypeName(type);
 		if (catalog) {
 			type = catalog->GetType(context, schema, user_type_name, OnEntryNotFound::RETURN_NULL);
 			if (type.id() == LogicalTypeId::INVALID) {
@@ -254,7 +254,7 @@ void Binder::BindLogicalType(ClientContext &context, LogicalType &type, optional
 			type = Catalog::GetType(context, INVALID_CATALOG, schema, user_type_name);
 		}
 	} else if (type.id() == LogicalTypeId::ENUM) {
-		auto &enum_type_name = EnumType::GetTypeName(type);
+		auto enum_type_name = EnumType::GetTypeName(type);
 		optional_ptr<TypeCatalogEntry> enum_type_catalog;
 		if (catalog) {
 			enum_type_catalog =

--- a/test/sql/alter/add_col/test_add_col_user_type.test
+++ b/test/sql/alter/add_col/test_add_col_user_type.test
@@ -1,0 +1,42 @@
+# name: test/sql/alter/add_col/test_add_col_user_type.test
+# description: Test ALTER TABLE ADD COLUMN with "CREATE TYPE"-based types
+# group: [add_col]
+
+statement ok
+CREATE SCHEMA test_schema;
+
+statement ok
+CREATE TYPE main_int AS int32;
+
+statement ok
+CREATE TYPE test_schema.test_int AS int32;
+
+statement ok
+CREATE TABLE test_schema.test_t1 (i INT);
+
+statement ok
+CREATE TABLE main_t1 (i INT);
+
+#
+# main.<type> in test_schema.<table>
+#
+statement error
+ALTER TABLE main_t1 ADD COLUMN j test_int;
+
+#
+# main.<type> in test_schema.<table>
+#
+statement ok
+ALTER TABLE test_schema.test_t1 ADD COLUMN not_found main_int;
+
+#
+# test.<type> in test_schema.<table>, with qualifier
+# TODO(morrita): Currently the type name cannot be qualified. Fix this.
+# statement ok
+# ALTER TABLE test_schema.test_t1 ADD COLUMN k test_schema.test_int;
+
+#
+# test.<type> in test_schema.<table>, without qualifier
+#
+statement ok
+ALTER TABLE test_schema.test_t1 ADD COLUMN l test_int;


### PR DESCRIPTION
This fixes https://github.com/duckdb/duckdb/issues/3076.
Note: Currently the type name cannot be qualified like "test_schema.test_int",
which will be addressed by a separate PR.