### PR TITLE
C Data Interface: `duckdb_arrow_scan` and `duckdb_arrow_array_scan`

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -279,6 +279,9 @@ typedef struct _duckdb_appender {
 typedef struct _duckdb_arrow {
 	void *__arrw;
 } * duckdb_arrow;
+typedef struct _duckdb_arrow_stream {
+	void *__arrwstr;
+} * duckdb_arrow_stream;
 typedef struct _duckdb_config {
 	void *__cnfg;
 } * duckdb_config;
@@ -1077,6 +1080,31 @@ Executes the prepared statement with the given bound parameters, and returns an 
 */
 DUCKDB_API duckdb_state duckdb_execute_prepared_arrow(duckdb_prepared_statement prepared_statement,
                                                       duckdb_arrow *out_result);
+
+/*!
+Scans the Arrow stream and creates a view with the given name.
+
+* connection: The connection on which to execute the scan.
+* table_name: Name of the temporary view to create.
+* arrow: Arrow stream wrapper.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
+DUCKDB_API duckdb_state duckdb_arrow_scan(duckdb_connection connection, const char *table_name,
+                                          duckdb_arrow_stream arrow);
+
+/*!
+Scans the Arrow array and creates a view with the given name.
+
+* connection: The connection on which to execute the scan.
+* table_name: Name of the temporary view to create.
+* arrow_schema: Arrow schema wrapper.
+* arrow_array: Arrow array wrapper.
+* out_stream: Output array stream that wraps around the passed schema, for releasing/deleting once done.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
+DUCKDB_API duckdb_state duckdb_arrow_array_scan(duckdb_connection connection, const char *table_name,
+                                                duckdb_arrow_schema arrow_schema, duckdb_arrow_array arrow_array,
+                                                duckdb_arrow_stream *out_stream);
 
 //===--------------------------------------------------------------------===//
 // Extract Statements

--- a/src/main/capi/arrow-c.cpp
+++ b/src/main/capi/arrow-c.cpp
@@ -1,5 +1,6 @@
-#include "duckdb/main/capi/capi_internal.hpp"
 #include "duckdb/common/arrow/arrow_converter.hpp"
+#include "duckdb/function/table/arrow.hpp"
+#include "duckdb/main/capi/capi_internal.hpp"
 
 using duckdb::ArrowConverter;
 using duckdb::ArrowResultWrapper;
@@ -107,4 +108,156 @@ duckdb_state duckdb_execute_prepared_arrow(duckdb_prepared_statement prepared_st
 	arrow_wrapper->result = duckdb::unique_ptr_cast<QueryResult, MaterializedQueryResult>(std::move(result));
 	*out_result = reinterpret_cast<duckdb_arrow>(arrow_wrapper);
 	return !arrow_wrapper->result->HasError() ? DuckDBSuccess : DuckDBError;
+}
+
+namespace arrow_array_stream_wrapper {
+namespace {
+struct PrivateData {
+	ArrowSchema *schema;
+	ArrowArray *array;
+	bool done = false;
+};
+
+// LCOV_EXCL_START
+// This function is never called, but used to set ArrowSchema's release functions to a non-null NOOP.
+void EmptySchemaRelease(ArrowSchema *) {
+}
+// LCOV_EXCL_STOP
+
+void EmptyArrayRelease(ArrowArray *) {
+}
+
+void EmptyStreamRelease(ArrowArrayStream *) {
+}
+
+void FactoryGetSchema(uintptr_t stream_factory_ptr, duckdb::ArrowSchemaWrapper &schema) {
+	auto private_data =
+	    reinterpret_cast<PrivateData *>(reinterpret_cast<ArrowArrayStream *>(stream_factory_ptr)->private_data);
+	schema.arrow_schema = *private_data->schema;
+
+	// Need to nullify the root schema's release function here, because streams don't allow us to set the release
+	// function. For the schema's children, we nullify the release functions in `duckdb_arrow_scan`, so we don't need to
+	// handle them again here. We set this to nullptr and not EmptySchemaRelease to prevent ArrowSchemaWrapper's
+	// destructor from destroying the schema (it's the caller's responsibility).
+	schema.arrow_schema.release = nullptr;
+}
+
+int GetSchema(struct ArrowArrayStream *stream, struct ArrowSchema *out) {
+	auto private_data = static_cast<arrow_array_stream_wrapper::PrivateData *>((stream->private_data));
+	if (private_data->schema == nullptr) {
+		return DuckDBError;
+	}
+
+	*out = *private_data->schema;
+	out->release = EmptySchemaRelease;
+	return DuckDBSuccess;
+}
+
+int GetNext(struct ArrowArrayStream *stream, struct ArrowArray *out) {
+	auto private_data = static_cast<arrow_array_stream_wrapper::PrivateData *>((stream->private_data));
+	*out = *private_data->array;
+	if (private_data->done) {
+		out->release = nullptr;
+	} else {
+		out->release = EmptyArrayRelease;
+	}
+
+	private_data->done = true;
+	return DuckDBSuccess;
+}
+
+duckdb::unique_ptr<duckdb::ArrowArrayStreamWrapper> FactoryGetNext(uintptr_t stream_factory_ptr,
+                                                                   duckdb::ArrowStreamParameters &parameters) {
+	auto stream = reinterpret_cast<ArrowArrayStream *>(stream_factory_ptr);
+	auto ret = duckdb::make_uniq<duckdb::ArrowArrayStreamWrapper>();
+	ret->arrow_array_stream = *stream;
+	ret->arrow_array_stream.release = EmptyStreamRelease;
+	return ret;
+}
+
+// LCOV_EXCL_START
+// This function is never be called, because it's used to construct a stream wrapping around a caller-supplied
+// ArrowArray. Thus, the stream itself cannot produce an error.
+const char *GetLastError(struct ArrowArrayStream *stream) {
+	return nullptr;
+}
+// LCOV_EXCL_STOP
+
+void Release(struct ArrowArrayStream *stream) {
+	if (stream->private_data != nullptr) {
+		delete reinterpret_cast<PrivateData *>(stream->private_data);
+	}
+
+	stream->private_data = nullptr;
+}
+
+duckdb_state Ingest(duckdb_connection connection, const char *table_name, struct ArrowArrayStream *input) {
+	try {
+		auto cconn = reinterpret_cast<duckdb::Connection *>(connection);
+		cconn
+		    ->TableFunction("arrow_scan", {duckdb::Value::POINTER((uintptr_t)input),
+		                                   duckdb::Value::POINTER((uintptr_t)FactoryGetNext),
+		                                   duckdb::Value::POINTER((uintptr_t)FactoryGetSchema)})
+		    ->CreateView(table_name, true, false);
+	} catch (...) { // LCOV_EXCL_START
+		// Tried covering this in tests, but it proved harder than expected. At the time of writing:
+		// - Passing any name to `CreateView` worked without throwing an exception
+		// - Passing a null Arrow array worked without throwing an exception
+		// - Passing an invalid schema (without any columns) led to an InternalException with SIGABRT, which is meant to
+		//   be un-catchable. This case likely needs to be handled gracefully within `arrow_scan`.
+		// Ref: https://discord.com/channels/909674491309850675/921100573732909107/1115230468699336785
+		return DuckDBError;
+	} // LCOV_EXCL_STOP
+
+	return DuckDBSuccess;
+}
+} // namespace
+} // namespace arrow_array_stream_wrapper
+
+duckdb_state duckdb_arrow_scan(duckdb_connection connection, const char *table_name, duckdb_arrow_stream arrow) {
+	auto stream = reinterpret_cast<ArrowArrayStream *>(arrow);
+
+	// Backup release functions - we nullify children schema release functions because we don't want to release on
+	// behalf of the caller, downstream in our code. Note that Arrow releases target immediate children, but aren't
+	// recursive. So we only back up immediate children here and restore their functions.
+	ArrowSchema schema;
+	if (stream->get_schema(stream, &schema) == DuckDBError) {
+		return DuckDBError;
+	}
+
+	typedef void (*release_fn_t)(ArrowSchema *);
+	std::vector<release_fn_t> release_fns(schema.n_children);
+	for (int64_t i = 0; i < schema.n_children; i++) {
+		auto child = schema.children[i];
+		release_fns[i] = child->release;
+		child->release = arrow_array_stream_wrapper::EmptySchemaRelease;
+	}
+
+	auto ret = arrow_array_stream_wrapper::Ingest(connection, table_name, stream);
+
+	// Restore release functions.
+	for (int64_t i = 0; i < schema.n_children; i++) {
+		schema.children[i]->release = release_fns[i];
+	}
+
+	return ret;
+}
+
+duckdb_state duckdb_arrow_array_scan(duckdb_connection connection, const char *table_name,
+                                     duckdb_arrow_schema arrow_schema, duckdb_arrow_array arrow_array,
+                                     duckdb_arrow_stream *out_stream) {
+	auto private_data = new arrow_array_stream_wrapper::PrivateData;
+	private_data->schema = reinterpret_cast<ArrowSchema *>(arrow_schema);
+	private_data->array = reinterpret_cast<ArrowArray *>(arrow_array);
+	private_data->done = false;
+
+	ArrowArrayStream *stream = new ArrowArrayStream;
+	*out_stream = reinterpret_cast<duckdb_arrow_stream>(stream);
+	stream->get_schema = arrow_array_stream_wrapper::GetSchema;
+	stream->get_next = arrow_array_stream_wrapper::GetNext;
+	stream->get_last_error = arrow_array_stream_wrapper::GetLastError;
+	stream->release = arrow_array_stream_wrapper::Release;
+	stream->private_data = private_data;
+
+	return duckdb_arrow_scan(connection, table_name, reinterpret_cast<duckdb_arrow_stream>(stream));
 }

--- a/test/api/capi/test_capi_arrow.cpp
+++ b/test/api/capi/test_capi_arrow.cpp
@@ -1,9 +1,11 @@
 #include "capi_tester.hpp"
+#include "duckdb/common/arrow/arrow_appender.hpp"
+#include "duckdb/common/arrow/arrow_converter.hpp"
 
 using namespace duckdb;
 using namespace std;
 
-TEST_CASE("Test arrow in C API", "[capi]") {
+TEST_CASE("Test arrow in C API", "[capi][arrow]") {
 	CAPITester tester;
 	duckdb::unique_ptr<CAPIResult> result;
 	duckdb_prepared_statement stmt = nullptr;
@@ -12,8 +14,7 @@ TEST_CASE("Test arrow in C API", "[capi]") {
 	// open the database in in-memory mode
 	REQUIRE(tester.OpenDatabase(nullptr));
 
-	// test rows changed
-	{
+	SECTION("test rows changed") {
 		REQUIRE_NO_FAIL(tester.Query("CREATE TABLE test(a INTEGER)"));
 		REQUIRE(duckdb_query_arrow(tester.connection, "INSERT INTO test VALUES (1), (2);", &arrow_result) ==
 		        DuckDBSuccess);
@@ -22,8 +23,7 @@ TEST_CASE("Test arrow in C API", "[capi]") {
 		REQUIRE_NO_FAIL(tester.Query("drop table test"));
 	}
 
-	// test query arrow
-	{
+	SECTION("test query arrow") {
 		REQUIRE(duckdb_query_arrow(tester.connection, "SELECT 42 AS VALUE", &arrow_result) == DuckDBSuccess);
 		REQUIRE(duckdb_arrow_row_count(arrow_result) == 1);
 		REQUIRE(duckdb_arrow_column_count(arrow_result) == 1);
@@ -52,8 +52,7 @@ TEST_CASE("Test arrow in C API", "[capi]") {
 		duckdb_destroy_arrow(&arrow_result);
 	}
 
-	// test multiple chunks
-	{
+	SECTION("test multiple chunks") {
 		// create table that consists of multiple chunks
 		REQUIRE_NO_FAIL(tester.Query("BEGIN TRANSACTION"));
 		REQUIRE_NO_FAIL(tester.Query("CREATE TABLE test(a INTEGER)"));
@@ -91,8 +90,7 @@ TEST_CASE("Test arrow in C API", "[capi]") {
 		REQUIRE_NO_FAIL(tester.Query("drop table test"));
 	}
 
-	// test prepare query arrow
-	{
+	SECTION("test prepare query arrow") {
 		REQUIRE(duckdb_prepare(tester.connection, "SELECT CAST($1 AS BIGINT)", &stmt) == DuckDBSuccess);
 		REQUIRE(stmt != nullptr);
 		REQUIRE(duckdb_bind_int64(stmt, 1, 42) == DuckDBSuccess);
@@ -109,6 +107,131 @@ TEST_CASE("Test arrow in C API", "[capi]") {
 		REQUIRE(duckdb_query_arrow_array(arrow_result, (duckdb_arrow_array *)&arrow_array) == DuckDBSuccess);
 		REQUIRE(arrow_array->length == 1);
 		arrow_array->release(arrow_array);
+		delete arrow_array;
+
+		duckdb_destroy_arrow(&arrow_result);
+		duckdb_destroy_prepare(&stmt);
+	}
+
+	SECTION("test scan") {
+		const auto logical_types = duckdb::vector<LogicalType> {LogicalType(LogicalTypeId::INTEGER)};
+		const auto column_names = duckdb::vector<string> {"value"};
+
+		ArrowSchema *arrow_schema = new ArrowSchema();
+		duckdb::ArrowConverter::ToArrowSchema(arrow_schema, logical_types, column_names, "");
+
+		ArrowArray *arrow_array = new ArrowArray();
+
+		SECTION("empty array") {
+			// Create an empty view with a `value` column.
+			string view_name = "foo_empty_table";
+			ArrowArrayStream *out_stream;
+			REQUIRE(duckdb_arrow_array_scan(tester.connection, view_name.c_str(),
+			                                reinterpret_cast<duckdb_arrow_schema>(arrow_schema),
+			                                reinterpret_cast<duckdb_arrow_array>(arrow_array),
+			                                reinterpret_cast<duckdb_arrow_stream *>(&out_stream)) == DuckDBSuccess);
+
+			// Get created view from DB.
+			auto get_query = "SELECT * FROM " + view_name + ";";
+			REQUIRE(duckdb_prepare(tester.connection, get_query.c_str(), &stmt) == DuckDBSuccess);
+			REQUIRE(stmt != nullptr);
+			REQUIRE(duckdb_execute_prepared_arrow(stmt, &arrow_result) == DuckDBSuccess);
+
+			// Recover array from results.
+			ArrowArray *out_array = new ArrowArray();
+			REQUIRE(duckdb_query_arrow_array(arrow_result, reinterpret_cast<duckdb_arrow_array *>(&out_array)) ==
+			        DuckDBSuccess);
+			REQUIRE(out_array->length == 0);
+			REQUIRE(out_array->release == nullptr);
+			delete out_array;
+
+			out_stream->release(out_stream);
+			delete out_stream;
+
+			REQUIRE(arrow_array->release == nullptr);
+		}
+
+		SECTION("big array") {
+			// Create a view with a `value` column containing 4096 values.
+			int num_buffers = 2, size = STANDARD_VECTOR_SIZE * num_buffers;
+			ArrowAppender appender(logical_types, size);
+			Allocator allocator;
+
+			auto data_chunks = std::vector<DataChunk>(num_buffers);
+			for (int i = 0; i < num_buffers; i++) {
+				auto data_chunk = &data_chunks[i];
+				data_chunk->Initialize(allocator, logical_types, STANDARD_VECTOR_SIZE);
+				data_chunk->SetCardinality(STANDARD_VECTOR_SIZE);
+				for (int row = 0; row < STANDARD_VECTOR_SIZE; row++) {
+					data_chunk->SetValue(0, row, duckdb::Value(i));
+				}
+
+				appender.Append(*data_chunk, 0, data_chunk->size(), data_chunk->size());
+			}
+
+			*arrow_array = appender.Finalize();
+
+			// Create view.
+			string view_name = "foo_table";
+			ArrowArrayStream *out_stream;
+			REQUIRE(duckdb_arrow_array_scan(tester.connection, view_name.c_str(),
+			                                reinterpret_cast<duckdb_arrow_schema>(arrow_schema),
+			                                reinterpret_cast<duckdb_arrow_array>(arrow_array),
+			                                reinterpret_cast<duckdb_arrow_stream *>(&out_stream)) == DuckDBSuccess);
+
+			// Get created view from DB.
+			auto get_query = "SELECT * FROM " + view_name + ";";
+			REQUIRE(duckdb_prepare(tester.connection, get_query.c_str(), &stmt) == DuckDBSuccess);
+			REQUIRE(stmt != nullptr);
+			REQUIRE(duckdb_execute_prepared_arrow(stmt, &arrow_result) == DuckDBSuccess);
+
+			// Recover array from results.
+			ArrowArray *out_array = new ArrowArray();
+			REQUIRE(duckdb_query_arrow_array(arrow_result, reinterpret_cast<duckdb_arrow_array *>(&out_array)) ==
+			        DuckDBSuccess);
+			REQUIRE(out_array->length == STANDARD_VECTOR_SIZE);
+			out_array->release(out_array);
+			delete out_array;
+
+			out_array = new ArrowArray();
+			REQUIRE(duckdb_query_arrow_array(arrow_result, reinterpret_cast<duckdb_arrow_array *>(&out_array)) ==
+			        DuckDBSuccess);
+			REQUIRE(out_array->length == STANDARD_VECTOR_SIZE);
+			out_array->release(out_array);
+			delete out_array;
+
+			out_array = new ArrowArray();
+			REQUIRE(duckdb_query_arrow_array(arrow_result, reinterpret_cast<duckdb_arrow_array *>(&out_array)) ==
+			        DuckDBSuccess);
+			REQUIRE(out_array->length == 0);
+			REQUIRE(out_array->release == nullptr);
+			delete out_array;
+
+			out_stream->release(out_stream);
+			delete out_stream;
+
+			REQUIRE(arrow_array->release != nullptr);
+		}
+
+		SECTION("null schema") {
+			// Creating a view with a null schema should fail gracefully.
+			string view_name = "foo_empty_table_null_schema";
+			ArrowArrayStream *out_stream;
+			REQUIRE(duckdb_arrow_array_scan(tester.connection, view_name.c_str(), nullptr,
+			                                reinterpret_cast<duckdb_arrow_array>(arrow_array),
+			                                reinterpret_cast<duckdb_arrow_stream *>(&out_stream)) == DuckDBError);
+
+			out_stream->release(out_stream);
+			delete out_stream;
+		}
+
+		arrow_schema->release(arrow_schema);
+		delete arrow_schema;
+
+		if (arrow_array->release != nullptr) {
+			arrow_array->release(arrow_array);
+		}
+
 		delete arrow_array;
 
 		duckdb_destroy_arrow(&arrow_result);


### PR DESCRIPTION
Introduces two C APIs to allow scanning Arrow data into a temporary view. Unlike the Python, NodeJS, R implementations, this API works directly with the [Apache Arrow C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html). This eliminates the need to serialise to the IPC format, making the operation zero-copy.

**Why two APIs**

- `duckdb_arrow_scan` works with the an Arrow Stream
- `duckdb_arrow_array_scan` works with an Arrow Array and its corresponding Arrow Schema

In other APIs where the IPC format is mandated, there is no motivation to work directly with array/schema and a single API to work with Arrow Stream suffices. For the C API, there's a bit of boilerplate needed to wrap an array as a stream. Thus, I've added that as a separate API for consumer convenience, but please let me know if you disagree with this and would prefer just a single `duckdb_arrow_scan` API

**Comments**

Please let me know which parts of this PR require more comments; I'll be happy to add them

**Unit test**

- Current test aims to ensure that we're integrating with `TableFunction("arrow_scan" ...)` correctly, and presumes that `"arrow_scan"` is separately tested to be working as expected. Please let me know if we'd like to test more here.
- Not sure how best to test for failure, so any help would be appreciated!