### PR TITLE
Fix #7582 - correctly set "last_offset" in InitializeScanWithOffset and turn assertion into run-time check

### DIFF
--- a/test/sql/storage/issue7582_list_storage.test
+++ b/test/sql/storage/issue7582_list_storage.test
@@ -1,0 +1,27 @@
+# name: test/sql/storage/issue7582_list_storage.test
+# description: Issue #7582: EXC_BAD_ACCESS during insert
+# group: [storage]
+
+require parquet
+
+load __TEST_DIR__/issue7582.db
+
+statement ok
+SET wal_autocheckpoint='1GB'
+
+statement ok
+CREATE TABLE tbl (n TEXT[]);
+
+statement ok
+INSERT INTO tbl (n) SELECT CASE WHEN i<100 THEN ['a', 'b'] ELSE [] END l FROM range(1026) t(i);
+
+statement ok
+INSERT INTO tbl (n) SELECT CASE WHEN i<100 THEN ['a', 'b'] ELSE [] END l FROM range(1026) t(i);
+
+statement ok
+INSERT INTO tbl (n) SELECT CASE WHEN i<100 THEN ['a', 'b'] ELSE [] END l FROM range(1026) t(i);
+
+restart
+
+statement ok
+FROM tbl


### PR DESCRIPTION
Fixes #7582 

This issue pops up when inserting several small lists into a table (small enough to not trigger the WAL auto-checkpoint). The system tries to commit a subset of the lists using `InitializeScanWithOffset` - but the scan was not correctly initializing `last_offset` leading to reading out of bounds on the child list.

This triggers an assertion which this PR has also turned into an `InternalException`.