### PR TITLE
Reserve expression_costs storage.

### DIFF
--- a/src/optimizer/expression_heuristics.cpp
+++ b/src/optimizer/expression_heuristics.cpp
@@ -42,6 +42,7 @@ void ExpressionHeuristics::ReorderExpressions(vector<unique_ptr<Expression>> &ex
 	};
 
 	vector<ExpressionCosts> expression_costs;
+	expression_costs.reserve(expressions.size());
 	// iterate expressions, get cost for each one
 	for (idx_t i = 0; i < expressions.size(); i++) {
 		idx_t cost = Cost(*expressions[i]);


### PR DESCRIPTION
This avoids the need to dynamically grow vector size.