### PR TITLE
Use unordered_set insert range overload.

### DIFF
--- a/src/storage/index.cpp
+++ b/src/storage/index.cpp
@@ -27,9 +27,7 @@ Index::Index(AttachedDatabase &db, IndexType type, TableIOManager &table_io_mana
 	}
 
 	// create the column id set
-	for (auto column_id : column_ids) {
-		column_id_set.insert(column_id);
-	}
+	column_id_set.insert(column_ids.begin(), column_ids.end());
 }
 
 void Index::InitializeLock(IndexLock &state) {


### PR DESCRIPTION
It's more concise and in theory may be performed more efficiently.