### PR TITLE
Fix #7564 - if the auto-complete extension is not enabled, inline it into the shell

### DIFF
--- a/tools/sqlite3_api_wrapper/CMakeLists.txt
+++ b/tools/sqlite3_api_wrapper/CMakeLists.txt
@@ -10,6 +10,13 @@ add_definitions(-DUSE_DUCKDB_SHELL_WRAPPER)
 
 include_directories(../../third_party/utf8proc/include)
 
+if(NOT BUILD_AUTOCOMPLETE_EXTENSION)
+  include_directories(../../extension/autocomplete/include)
+  set(ALL_OBJECT_FILES
+      ${ALL_OBJECT_FILES}
+      ../../extension/autocomplete/sql_auto_complete-extension.cpp)
+  add_definitions(-DSHELL_INLINE_AUTOCOMPLETE)
+endif()
 set(SQLITE_API_WRAPPER_FILES sqlite3_api_wrapper.cpp ${ALL_OBJECT_FILES})
 
 add_library(sqlite3_api_wrapper_static STATIC ${SQLITE_API_WRAPPER_FILES})

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -15,6 +15,9 @@
 #include "duckdb/main/error_manager.hpp"
 #include "utf8proc_wrapper.hpp"
 #include "duckdb/common/box_renderer.hpp"
+#ifdef SHELL_INLINE_AUTOCOMPLETE
+#include "sql_auto_complete-extension.hpp"
+#endif
 
 #include <ctype.h>
 #include <stdio.h>
@@ -113,6 +116,9 @@ int sqlite3_open_v2(const char *filename, /* Database filename (UTF-8) */
 		    "extensions are disabled by configuration.\nStart the shell with the -unsigned parameter to allow this "
 		    "(e.g. duckdb -unsigned).");
 		pDb->db = make_uniq<DuckDB>(filename, &config);
+#ifdef SHELL_INLINE_AUTOCOMPLETE
+		pDb->db->LoadExtension<SQLAutoCompleteExtension>();
+#endif
 		pDb->con = make_uniq<Connection>(*pDb->db);
 	} catch (const Exception &ex) {
 		if (pDb) {


### PR DESCRIPTION
Fixes #7564 