### PR TITLE
Remove 2 extra bytes from magic string pattern.

### DIFF
--- a/src/storage/magic_bytes.cpp
+++ b/src/storage/magic_bytes.cpp
@@ -16,7 +16,7 @@ DataFileType MagicBytes::CheckMagicBytes(FileSystem *fs_p, const string &path) {
 	char buffer[MAGIC_BYTES_READ_SIZE];
 
 	handle->Read(buffer, MAGIC_BYTES_READ_SIZE);
-	if (memcmp(buffer, "SQLite format 3\0\0\0", 16) == 0) {
+	if (memcmp(buffer, "SQLite format 3\0", 16) == 0) {
 		return DataFileType::SQLITE_FILE;
 	}
 	if (memcmp(buffer, "PAR1", 4) == 0) {


### PR DESCRIPTION
`"SQLite format 3\0\0\0"` is technically 19 bytes (18 bytes for the string content + 1 byte for the string terminator), which is unnecessary given that `memcmp` compares only the first 16 bytes.