### PR TITLE
Reserve enough storage for unbound_expressions.

### DIFF
--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -29,7 +29,7 @@ LocalTableStorage::LocalTableStorage(DataTable &table)
 		if (art.constraint_type != IndexConstraintType::NONE) {
 			// unique index: create a local ART index that maintains the same unique constraint
 			vector<unique_ptr<Expression>> unbound_expressions;
-			unbound_expressions.reserve(art.unbound_expressions);
+			unbound_expressions.reserve(art.unbound_expressions.size());
 			for (auto &expr : art.unbound_expressions) {
 				unbound_expressions.push_back(expr->Copy());
 			}

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -29,6 +29,7 @@ LocalTableStorage::LocalTableStorage(DataTable &table)
 		if (art.constraint_type != IndexConstraintType::NONE) {
 			// unique index: create a local ART index that maintains the same unique constraint
 			vector<unique_ptr<Expression>> unbound_expressions;
+			unbound_expressions.reserve(art.unbound_expressions);
 			for (auto &expr : art.unbound_expressions) {
 				unbound_expressions.push_back(expr->Copy());
 			}


### PR DESCRIPTION
This avoids unnecessary dynamic vector resizes.