### PR TITLE
Avoid unnecessary table lookup.

### DIFF
--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -252,7 +252,7 @@ shared_ptr<LocalTableStorage> LocalTableManager::MoveEntry(DataTable &table) {
 		return nullptr;
 	}
 	auto storage_entry = std::move(entry->second);
-	table_storage.erase(table);
+	table_storage.erase(entry);
 	return storage_entry;
 }
 


### PR DESCRIPTION
`erase` overload that accepts a key type performs an unnecessary lookup of the `entry` that is already available. Passing `entry` directly avoids this unnecessary lookup.