### PR TITLE
Fix sql auto complete extension CI issue

### DIFF
--- a/extension/autocomplete/sql_auto_complete-extension.cpp
+++ b/extension/autocomplete/sql_auto_complete-extension.cpp
@@ -33,7 +33,7 @@ struct SQLAutoCompleteData : public GlobalTableFunctionState {
 };
 
 struct AutoCompleteCandidate {
-	AutoCompleteCandidate(string candidate_p, int32_t score_bonus = 0)
+	explicit AutoCompleteCandidate(string candidate_p, int32_t score_bonus = 0)
 	    : candidate(std::move(candidate_p)), score_bonus(score_bonus) {
 	}
 
@@ -408,7 +408,7 @@ void SQLAutoCompleteExtension::Load(DuckDB &db) {
 }
 
 std::string SQLAutoCompleteExtension::Name() {
-	return "sql_auto_complete";
+	return "autocomplete";
 }
 
 } // namespace duckdb

--- a/tools/sqlite3_api_wrapper/CMakeLists.txt
+++ b/tools/sqlite3_api_wrapper/CMakeLists.txt
@@ -10,7 +10,7 @@ add_definitions(-DUSE_DUCKDB_SHELL_WRAPPER)
 
 include_directories(../../third_party/utf8proc/include)
 
-if(NOT BUILD_AUTOCOMPLETE_EXTENSION)
+if(NOT BUILD_AUTOCOMPLETE_EXTENSION AND NOT DISABLE_BUILTIN_EXTENSIONS)
   include_directories(../../extension/autocomplete/include)
   set(ALL_OBJECT_FILES
       ${ALL_OBJECT_FILES}


### PR DESCRIPTION
Left-over fixes from #7621 

* Use the same name for the extension everywhere (`autocomplete`, not `sql_auto_complete`)
* Disable inlining of the extension into the shell when `DISABLE_BUILTIN_EXTENSIONS` is set