### PR TITLE
Rework the AggregateExecutor interface to no longer have unnecessary pointers and arrays

### DIFF
--- a/src/core_functions/aggregate/algebraic/covar.cpp
+++ b/src/core_functions/aggregate/algebraic/covar.cpp
@@ -1,10 +1,6 @@
 #include "duckdb/core_functions/aggregate/algebraic_functions.hpp"
-#include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/null_value.hpp"
-#include "duckdb/common/vector_operations/vector_operations.hpp"
-#include "duckdb/function/function_set.hpp"
 #include "duckdb/core_functions/aggregate/algebraic/covar.hpp"
-#include <cmath>
 
 namespace duckdb {
 

--- a/src/core_functions/aggregate/distributive/approx_count.cpp
+++ b/src/core_functions/aggregate/distributive/approx_count.cpp
@@ -2,7 +2,6 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/types/hyperloglog.hpp"
-#include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/function/function_set.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 

--- a/src/core_functions/aggregate/distributive/approx_count.cpp
+++ b/src/core_functions/aggregate/distributive/approx_count.cpp
@@ -16,52 +16,50 @@ struct ApproxDistinctCountState {
 			delete log;
 		}
 	}
-	void Resize(idx_t count) {
-		indices.resize(count);
-		counts.resize(count);
-	}
 
 	HyperLogLog *log;
-	vector<uint64_t> indices;
-	vector<uint8_t> counts;
 };
 
 struct ApproxCountDistinctFunction {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		new (state) STATE;
+	static void Initialize(STATE &state) {
+		state.log = nullptr;
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		if (!source.log) {
 			return;
 		}
-		if (!target->log) {
-			target->log = new HyperLogLog();
+		if (!target.log) {
+			target.log = new HyperLogLog();
 		}
-		D_ASSERT(target->log);
+		D_ASSERT(target.log);
 		D_ASSERT(source.log);
-		auto new_log = target->log->MergePointer(*source.log);
-		delete target->log;
-		target->log = new_log;
+		auto new_log = target.log->MergePointer(*source.log);
+		delete target.log;
+		target.log = new_log;
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (state->log) {
-			target[idx] = state->log->Count();
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.log) {
+			target = state.log->Count();
 		} else {
-			target[idx] = 0;
+			target = 0;
 		}
 	}
 
 	static bool IgnoreNull() {
 		return true;
 	}
+
 	template <class STATE>
-	static void Destroy(AggregateInputData &aggr_input_data, STATE *state) {
-		state->~STATE();
+	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
+		if (state.log) {
+			delete state.log;
+			state.log = nullptr;
+		}
 	}
 };
 
@@ -77,10 +75,8 @@ static void ApproxCountDistinctSimpleUpdateFunction(Vector inputs[], AggregateIn
 	UnifiedVectorFormat vdata;
 	inputs[0].ToUnifiedFormat(count, vdata);
 
-	agg_state->Resize(count);
-	auto indices = agg_state->indices.data();
-	auto counts = agg_state->counts.data();
-
+	uint64_t indices[STANDARD_VECTOR_SIZE];
+	uint8_t counts[STANDARD_VECTOR_SIZE];
 	HyperLogLog::ProcessEntries(vdata, inputs[0].GetType(), indices, counts, count);
 	agg_state->log->AddToLog(vdata, count, indices, counts);
 }
@@ -93,23 +89,18 @@ static void ApproxCountDistinctUpdateFunction(Vector inputs[], AggregateInputDat
 	state_vector.ToUnifiedFormat(count, sdata);
 	auto states = UnifiedVectorFormat::GetDataNoConst<ApproxDistinctCountState *>(sdata);
 
-	uint64_t *indices = nullptr;
-	uint8_t *counts = nullptr;
 	for (idx_t i = 0; i < count; i++) {
 		auto agg_state = states[sdata.sel->get_index(i)];
 		if (!agg_state->log) {
 			agg_state->log = new HyperLogLog();
-		}
-		if (i == 0) {
-			agg_state->Resize(count);
-			indices = agg_state->indices.data();
-			counts = agg_state->counts.data();
 		}
 	}
 
 	UnifiedVectorFormat vdata;
 	inputs[0].ToUnifiedFormat(count, vdata);
 
+	uint64_t indices[STANDARD_VECTOR_SIZE];
+	uint8_t counts[STANDARD_VECTOR_SIZE];
 	HyperLogLog::ProcessEntries(vdata, inputs[0].GetType(), indices, counts, count);
 	HyperLogLog::AddToLogs(vdata, count, indices, counts, reinterpret_cast<HyperLogLog ***>(states), sdata.sel);
 }

--- a/src/core_functions/aggregate/distributive/approx_count.cpp
+++ b/src/core_functions/aggregate/distributive/approx_count.cpp
@@ -74,6 +74,9 @@ static void ApproxCountDistinctSimpleUpdateFunction(Vector inputs[], AggregateIn
 	UnifiedVectorFormat vdata;
 	inputs[0].ToUnifiedFormat(count, vdata);
 
+	if (count > STANDARD_VECTOR_SIZE) {
+		throw InternalException("ApproxCountDistinct - count must be at most vector size");
+	}
 	uint64_t indices[STANDARD_VECTOR_SIZE];
 	uint8_t counts[STANDARD_VECTOR_SIZE];
 	HyperLogLog::ProcessEntries(vdata, inputs[0].GetType(), indices, counts, count);
@@ -98,6 +101,9 @@ static void ApproxCountDistinctUpdateFunction(Vector inputs[], AggregateInputDat
 	UnifiedVectorFormat vdata;
 	inputs[0].ToUnifiedFormat(count, vdata);
 
+	if (count > STANDARD_VECTOR_SIZE) {
+		throw InternalException("ApproxCountDistinct - count must be at most vector size");
+	}
 	uint64_t indices[STANDARD_VECTOR_SIZE];
 	uint8_t counts[STANDARD_VECTOR_SIZE];
 	HyperLogLog::ProcessEntries(vdata, inputs[0].GetType(), indices, counts, count);

--- a/src/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/src/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -25,8 +25,8 @@ struct ArgMinMaxStateBase {
 	}
 
 	template <typename T>
-	static inline void ReadValue(Vector &result, T &arg, T *target, idx_t idx) {
-		target[idx] = arg;
+	static inline void ReadValue(Vector &result, T &arg, T &target) {
+		target = arg;
 	}
 
 	bool is_initialized;
@@ -69,8 +69,8 @@ void ArgMinMaxStateBase::AssignValue(string_t &target, string_t new_value, bool 
 }
 
 template <>
-void ArgMinMaxStateBase::ReadValue(Vector &result, string_t &arg, string_t *target, idx_t idx) {
-	target[idx] = StringVector::AddStringOrBlob(result, arg);
+void ArgMinMaxStateBase::ReadValue(Vector &result, string_t &arg, string_t &target) {
+	target = StringVector::AddStringOrBlob(result, arg);
 }
 
 template <class A, class B>
@@ -97,54 +97,55 @@ struct ArgMinMaxState : public ArgMinMaxStateBase {
 
 template <class COMPARATOR>
 struct ArgMinMaxBase {
+
 	template <class STATE>
-	static void Destroy(AggregateInputData &aggr_input_data, STATE *state) {
-		state->~STATE();
+	static void Initialize(STATE &state) {
+		new (&state) STATE;
 	}
 
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		new (state) STATE;
+	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
+		state.~STATE();
 	}
 
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const A_TYPE *x_data, const B_TYPE *y_data,
+	static void Operation(STATE &state, AggregateInputData &, const A_TYPE *x_data, const B_TYPE *y_data,
 	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
-		if (!state->is_initialized) {
-			STATE::template AssignValue<A_TYPE>(state->arg, x_data[xidx], false);
-			STATE::template AssignValue<B_TYPE>(state->value, y_data[yidx], false);
-			state->is_initialized = true;
+		if (!state.is_initialized) {
+			STATE::template AssignValue<A_TYPE>(state.arg, x_data[xidx], false);
+			STATE::template AssignValue<B_TYPE>(state.value, y_data[yidx], false);
+			state.is_initialized = true;
 		} else {
 			OP::template Execute<A_TYPE, B_TYPE, STATE>(state, x_data[xidx], y_data[yidx]);
 		}
 	}
 
 	template <class A_TYPE, class B_TYPE, class STATE>
-	static void Execute(STATE *state, A_TYPE x_data, B_TYPE y_data) {
-		if (COMPARATOR::Operation(y_data, state->value)) {
-			STATE::template AssignValue<A_TYPE>(state->arg, x_data, true);
-			STATE::template AssignValue<B_TYPE>(state->value, y_data, true);
+	static void Execute(STATE &state, A_TYPE x_data, B_TYPE y_data) {
+		if (COMPARATOR::Operation(y_data, state.value)) {
+			STATE::template AssignValue<A_TYPE>(state.arg, x_data, true);
+			STATE::template AssignValue<B_TYPE>(state.value, y_data, true);
 		}
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		if (!source.is_initialized) {
 			return;
 		}
-		if (!target->is_initialized || COMPARATOR::Operation(source.value, target->value)) {
-			STATE::template AssignValue(target->arg, source.arg, target->is_initialized);
-			STATE::template AssignValue(target->value, source.value, target->is_initialized);
-			target->is_initialized = true;
+		if (!target.is_initialized || COMPARATOR::Operation(source.value, target.value)) {
+			STATE::template AssignValue(target.arg, source.arg, target.is_initialized);
+			STATE::template AssignValue(target.value, source.value, target.is_initialized);
+			target.is_initialized = true;
 		}
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (!state->is_initialized) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (!state.is_initialized) {
+			finalize_data.ReturnNull();
 		} else {
-			STATE::template ReadValue(result, state->arg, target, idx);
+			STATE::template ReadValue(finalize_data.result, state.arg, target);
 		}
 	}
 
@@ -156,14 +157,14 @@ struct ArgMinMaxBase {
 template <typename COMPARATOR>
 struct VectorArgMinMaxBase : ArgMinMaxBase<COMPARATOR> {
 	template <class STATE>
-	static void AssignVector(STATE *state, Vector &arg, const idx_t idx) {
-		if (!state->is_initialized) {
-			state->arg = new Vector(arg.GetType());
-			state->arg->SetVectorType(VectorType::CONSTANT_VECTOR);
+	static void AssignVector(STATE &state, Vector &arg, const idx_t idx) {
+		if (!state.is_initialized) {
+			state.arg = new Vector(arg.GetType());
+			state.arg->SetVectorType(VectorType::CONSTANT_VECTOR);
 		}
 		sel_t selv = idx;
 		SelectionVector sel(&selv);
-		VectorOperations::Copy(arg, *state->arg, sel, 1, 0, 0);
+		VectorOperations::Copy(arg, *state.arg, sel, 1, 0, 0);
 	}
 
 	template <class STATE>
@@ -190,49 +191,37 @@ struct VectorArgMinMaxBase : ArgMinMaxBase<COMPARATOR> {
 			const auto bval = bys[bidx];
 
 			const auto sidx = sdata.sel->get_index(i);
-			auto state = states[sidx];
-			if (!state->is_initialized) {
-				STATE::template AssignValue<BY_TYPE>(state->value, bval, false);
+			auto &state = *states[sidx];
+			if (!state.is_initialized) {
+				STATE::template AssignValue<BY_TYPE>(state.value, bval, false);
 				AssignVector(state, arg, i);
-				state->is_initialized = true;
+				state.is_initialized = true;
 
-			} else if (COMPARATOR::template Operation<BY_TYPE>(bval, state->value)) {
-				STATE::template AssignValue<BY_TYPE>(state->value, bval, true);
+			} else if (COMPARATOR::template Operation<BY_TYPE>(bval, state.value)) {
+				STATE::template AssignValue<BY_TYPE>(state.value, bval, true);
 				AssignVector(state, arg, i);
 			}
 		}
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		if (!source.is_initialized) {
 			return;
 		}
-		if (!target->is_initialized || COMPARATOR::Operation(source.value, target->value)) {
-			STATE::template AssignValue(target->value, source.value, target->is_initialized);
+		if (!target.is_initialized || COMPARATOR::Operation(source.value, target.value)) {
+			STATE::template AssignValue(target.value, source.value, target.is_initialized);
 			AssignVector(target, *source.arg, 0);
-			target->is_initialized = true;
+			target.is_initialized = true;
 		}
 	}
 
-	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (!state->is_initialized) {
-			// we need to use SetNull here
-			// since for STRUCT columns only setting the validity mask of the struct is incorrect
-			// as for a struct column, we need to also set ALL child columns to NULL
-			switch (result.GetVectorType()) {
-			case VectorType::FLAT_VECTOR:
-				FlatVector::SetNull(result, idx, true);
-				break;
-			case VectorType::CONSTANT_VECTOR:
-				ConstantVector::SetNull(result, true);
-				break;
-			default:
-				throw InternalException("Invalid result vector type for nested arg_min/max");
-			}
+	template <class STATE>
+	static void Finalize(STATE &state, AggregateFinalizeData &finalize_data) {
+		if (!state.is_initialized) {
+			finalize_data.ReturnNull();
 		} else {
-			VectorOperations::Copy(*state->arg, result, 1, 0, idx);
+			VectorOperations::Copy(*state.arg, finalize_data.result, 1, 0, finalize_data.result_idx);
 		}
 	}
 
@@ -247,11 +236,10 @@ struct VectorArgMinMaxBase : ArgMinMaxBase<COMPARATOR> {
 template <class OP, class ARG_TYPE, class BY_TYPE>
 AggregateFunction GetVectorArgMinMaxFunctionInternal(const LogicalType &by_type, const LogicalType &type) {
 	using STATE = ArgMinMaxState<ARG_TYPE, BY_TYPE>;
-	return AggregateFunction({type, by_type}, type, AggregateFunction::StateSize<STATE>,
-	                         AggregateFunction::StateInitialize<STATE, OP>, OP::template Update<STATE>,
-	                         AggregateFunction::StateCombine<STATE, OP>,
-	                         AggregateFunction::StateFinalize<STATE, void, OP>, nullptr, OP::Bind,
-	                         AggregateFunction::StateDestroy<STATE, OP>);
+	return AggregateFunction(
+	    {type, by_type}, type, AggregateFunction::StateSize<STATE>, AggregateFunction::StateInitialize<STATE, OP>,
+	    OP::template Update<STATE>, AggregateFunction::StateCombine<STATE, OP>,
+	    AggregateFunction::StateVoidFinalize<STATE, OP>, nullptr, OP::Bind, AggregateFunction::StateDestroy<STATE, OP>);
 }
 
 template <class OP, class ARG_TYPE>

--- a/src/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/src/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -109,14 +109,13 @@ struct ArgMinMaxBase {
 	}
 
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const A_TYPE *x_data, const B_TYPE *y_data,
-	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+	static void Operation(STATE &state, const A_TYPE &x, const B_TYPE &y, AggregateBinaryInput &) {
 		if (!state.is_initialized) {
-			STATE::template AssignValue<A_TYPE>(state.arg, x_data[xidx], false);
-			STATE::template AssignValue<B_TYPE>(state.value, y_data[yidx], false);
+			STATE::template AssignValue<A_TYPE>(state.arg, x, false);
+			STATE::template AssignValue<B_TYPE>(state.value, y, false);
 			state.is_initialized = true;
 		} else {
-			OP::template Execute<A_TYPE, B_TYPE, STATE>(state, x_data[xidx], y_data[yidx]);
+			OP::template Execute<A_TYPE, B_TYPE, STATE>(state, x, y);
 		}
 	}
 

--- a/src/core_functions/aggregate/distributive/bitagg.cpp
+++ b/src/core_functions/aggregate/distributive/bitagg.cpp
@@ -42,53 +42,53 @@ static AggregateFunction GetBitfieldUnaryAggregate(LogicalType type) {
 
 struct BitwiseOperation {
 	template <class STATE>
-	static void Initialize(STATE *state) {
+	static void Initialize(STATE &state) {
 		//  If there are no matching rows, returns a null value.
-		state->is_set = false;
+		state.is_set = false;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
-		if (!state->is_set) {
+	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (!state.is_set) {
 			OP::template Assign(state, input[idx]);
-			state->is_set = true;
+			state.is_set = true;
 		} else {
 			OP::template Execute(state, input[idx]);
 		}
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
+	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
 	                              ValidityMask &mask, idx_t count) {
 		OP::template Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
 	}
 
 	template <class INPUT_TYPE, class STATE>
-	static void Assign(STATE *state, INPUT_TYPE input) {
-		state->value = input;
+	static void Assign(STATE &state, INPUT_TYPE input) {
+		state.value = input;
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		if (!source.is_set) {
 			// source is NULL, nothing to do.
 			return;
 		}
-		if (!target->is_set) {
+		if (!target.is_set) {
 			// target is NULL, use source value directly.
 			OP::template Assign(target, source.value);
-			target->is_set = true;
+			target.is_set = true;
 		} else {
 			OP::template Execute(target, source.value);
 		}
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (!state->is_set) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (!state.is_set) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = state->value;
+			target = state.value;
 		}
 	}
 
@@ -99,26 +99,26 @@ struct BitwiseOperation {
 
 struct BitAndOperation : public BitwiseOperation {
 	template <class INPUT_TYPE, class STATE>
-	static void Execute(STATE *state, INPUT_TYPE input) {
-		state->value &= input;
+	static void Execute(STATE &state, INPUT_TYPE input) {
+		state.value &= input;
 	}
 };
 
 struct BitOrOperation : public BitwiseOperation {
 	template <class INPUT_TYPE, class STATE>
-	static void Execute(STATE *state, INPUT_TYPE input) {
-		state->value |= input;
+	static void Execute(STATE &state, INPUT_TYPE input) {
+		state.value |= input;
 	}
 };
 
 struct BitXorOperation : public BitwiseOperation {
 	template <class INPUT_TYPE, class STATE>
-	static void Execute(STATE *state, INPUT_TYPE input) {
-		state->value ^= input;
+	static void Execute(STATE &state, INPUT_TYPE input) {
+		state.value ^= input;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
+	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
 	                              ValidityMask &mask, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
@@ -128,32 +128,32 @@ struct BitXorOperation : public BitwiseOperation {
 
 struct BitStringBitwiseOperation : public BitwiseOperation {
 	template <class STATE>
-	static void Destroy(AggregateInputData &aggr_input_data, STATE *state) {
-		if (state->is_set && !state->value.IsInlined()) {
-			delete[] state->value.GetData();
+	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
+		if (state.is_set && !state.value.IsInlined()) {
+			delete[] state.value.GetData();
 		}
 	}
 
 	template <class INPUT_TYPE, class STATE>
-	static void Assign(STATE *state, INPUT_TYPE input) {
-		D_ASSERT(state->is_set == false);
+	static void Assign(STATE &state, INPUT_TYPE input) {
+		D_ASSERT(state.is_set == false);
 		if (input.IsInlined()) {
-			state->value = input;
+			state.value = input;
 		} else { // non-inlined string, need to allocate space for it
 			auto len = input.GetSize();
 			auto ptr = new char[len];
 			memcpy(ptr, input.GetData(), len);
 
-			state->value = string_t(ptr, len);
+			state.value = string_t(ptr, len);
 		}
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (!state->is_set) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (!state.is_set) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = StringVector::AddStringOrBlob(result, state->value);
+			target = finalize_data.ReturnString(state.value);
 		}
 	}
 };
@@ -161,27 +161,27 @@ struct BitStringBitwiseOperation : public BitwiseOperation {
 struct BitStringAndOperation : public BitStringBitwiseOperation {
 
 	template <class INPUT_TYPE, class STATE>
-	static void Execute(STATE *state, INPUT_TYPE input) {
-		Bit::BitwiseAnd(input, state->value, state->value);
+	static void Execute(STATE &state, INPUT_TYPE input) {
+		Bit::BitwiseAnd(input, state.value, state.value);
 	}
 };
 
 struct BitStringOrOperation : public BitStringBitwiseOperation {
 
 	template <class INPUT_TYPE, class STATE>
-	static void Execute(STATE *state, INPUT_TYPE input) {
-		Bit::BitwiseOr(input, state->value, state->value);
+	static void Execute(STATE &state, INPUT_TYPE input) {
+		Bit::BitwiseOr(input, state.value, state.value);
 	}
 };
 
 struct BitStringXorOperation : public BitStringBitwiseOperation {
 	template <class INPUT_TYPE, class STATE>
-	static void Execute(STATE *state, INPUT_TYPE input) {
-		Bit::BitwiseXor(input, state->value, state->value);
+	static void Execute(STATE &state, INPUT_TYPE input) {
+		Bit::BitwiseXor(input, state.value, state.value);
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
+	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
 	                              ValidityMask &mask, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);

--- a/src/core_functions/aggregate/distributive/bitagg.cpp
+++ b/src/core_functions/aggregate/distributive/bitagg.cpp
@@ -48,19 +48,18 @@ struct BitwiseOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
 		if (!state.is_set) {
-			OP::template Assign(state, input[idx]);
+			OP::template Assign(state, input);
 			state.is_set = true;
 		} else {
-			OP::template Execute(state, input[idx]);
+			OP::template Execute(state, input);
 		}
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
-	                              ValidityMask &mask, idx_t count) {
-		OP::template Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+		OP::template Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 	}
 
 	template <class INPUT_TYPE, class STATE>
@@ -118,10 +117,9 @@ struct BitXorOperation : public BitwiseOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
-	                              ValidityMask &mask, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
-			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}
 	}
 };
@@ -181,10 +179,9 @@ struct BitStringXorOperation : public BitStringBitwiseOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
-	                              ValidityMask &mask, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
-			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}
 	}
 };

--- a/src/core_functions/aggregate/distributive/bitagg.cpp
+++ b/src/core_functions/aggregate/distributive/bitagg.cpp
@@ -58,7 +58,8 @@ struct BitwiseOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		OP::template Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 	}
 
@@ -117,7 +118,8 @@ struct BitXorOperation : public BitwiseOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}
@@ -179,7 +181,8 @@ struct BitStringXorOperation : public BitStringBitwiseOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}

--- a/src/core_functions/aggregate/distributive/bitstring_agg.cpp
+++ b/src/core_functions/aggregate/distributive/bitstring_agg.cpp
@@ -48,47 +48,47 @@ struct BitStringAggOperation {
 	static constexpr const idx_t MAX_BIT_RANGE = 1000000000; // for now capped at 1 billion bits
 
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->is_set = false;
+	static void Initialize(STATE &state) {
+		state.is_set = false;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &data, const INPUT_TYPE *input, ValidityMask &mask,
+	static void Operation(STATE &state, AggregateInputData &data, const INPUT_TYPE *input, ValidityMask &mask,
 	                      idx_t idx) {
 		auto &bind_agg_data = data.bind_data->template Cast<BitstringAggBindData>();
-		if (!state->is_set) {
+		if (!state.is_set) {
 			if (bind_agg_data.min.IsNull() || bind_agg_data.max.IsNull()) {
 				throw BinderException(
 				    "Could not retrieve required statistics. Alternatively, try by providing the statistics "
 				    "explicitly: BITSTRING_AGG(col, min, max) ");
 			}
-			state->min = bind_agg_data.min.GetValue<INPUT_TYPE>();
-			state->max = bind_agg_data.max.GetValue<INPUT_TYPE>();
+			state.min = bind_agg_data.min.GetValue<INPUT_TYPE>();
+			state.max = bind_agg_data.max.GetValue<INPUT_TYPE>();
 			idx_t bit_range =
 			    GetRange(bind_agg_data.min.GetValue<INPUT_TYPE>(), bind_agg_data.max.GetValue<INPUT_TYPE>());
 			if (bit_range > MAX_BIT_RANGE) {
 				throw OutOfRangeException(
 				    "The range between min and max value (%s <-> %s) is too large for bitstring aggregation",
-				    NumericHelper::ToString(state->min), NumericHelper::ToString(state->max));
+				    NumericHelper::ToString(state.min), NumericHelper::ToString(state.max));
 			}
 			idx_t len = Bit::ComputeBitstringLen(bit_range);
 			auto target = len > string_t::INLINE_LENGTH ? string_t(new char[len], len) : string_t(len);
 			Bit::SetEmptyBitString(target, bit_range);
 
-			state->value = target;
-			state->is_set = true;
+			state.value = target;
+			state.is_set = true;
 		}
-		if (input[idx] >= state->min && input[idx] <= state->max) {
+		if (input[idx] >= state.min && input[idx] <= state.max) {
 			Execute(state, input[idx], bind_agg_data.min.GetValue<INPUT_TYPE>());
 		} else {
 			throw OutOfRangeException("Value %s is outside of provided min and max range (%s <-> %s)",
-			                          NumericHelper::ToString(input[idx]), NumericHelper::ToString(state->min),
-			                          NumericHelper::ToString(state->max));
+			                          NumericHelper::ToString(input[idx]), NumericHelper::ToString(state.min),
+			                          NumericHelper::ToString(state.max));
 		}
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
+	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
 	                              ValidityMask &mask, idx_t count) {
 		OP::template Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
 	}
@@ -108,51 +108,51 @@ struct BitStringAggOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE>
-	static void Execute(STATE *state, INPUT_TYPE input, INPUT_TYPE min) {
-		Bit::SetBit(state->value, input - min, 1);
+	static void Execute(STATE &state, INPUT_TYPE input, INPUT_TYPE min) {
+		Bit::SetBit(state.value, input - min, 1);
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		if (!source.is_set) {
 			return;
 		}
-		if (!target->is_set) {
+		if (!target.is_set) {
 			Assign(target, source.value);
-			target->is_set = true;
-			target->min = source.min;
-			target->max = source.max;
+			target.is_set = true;
+			target.min = source.min;
+			target.max = source.max;
 		} else {
-			Bit::BitwiseOr(source.value, target->value, target->value);
+			Bit::BitwiseOr(source.value, target.value, target.value);
 		}
 	}
 
 	template <class INPUT_TYPE, class STATE>
-	static void Assign(STATE *state, INPUT_TYPE input) {
-		D_ASSERT(state->is_set == false);
+	static void Assign(STATE &state, INPUT_TYPE input) {
+		D_ASSERT(state.is_set == false);
 		if (input.IsInlined()) {
-			state->value = input;
+			state.value = input;
 		} else { // non-inlined string, need to allocate space for it
 			auto len = input.GetSize();
 			auto ptr = new char[len];
 			memcpy(ptr, input.GetData(), len);
-			state->value = string_t(ptr, len);
+			state.value = string_t(ptr, len);
 		}
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (!state->is_set) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (!state.is_set) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = StringVector::AddStringOrBlob(result, state->value);
+			target = StringVector::AddStringOrBlob(finalize_data.result, state.value);
 		}
 	}
 
 	template <class STATE>
-	static void Destroy(AggregateInputData &aggr_input_data, STATE *state) {
-		if (state->is_set && !state->value.IsInlined()) {
-			delete[] state->value.GetData();
+	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
+		if (state.is_set && !state.value.IsInlined()) {
+			delete[] state.value.GetData();
 		}
 	}
 
@@ -162,10 +162,10 @@ struct BitStringAggOperation {
 };
 
 template <>
-void BitStringAggOperation::Execute(BitAggState<hugeint_t> *state, hugeint_t input, hugeint_t min) {
+void BitStringAggOperation::Execute(BitAggState<hugeint_t> &state, hugeint_t input, hugeint_t min) {
 	idx_t val;
 	if (Hugeint::TryCast(input - min, val)) {
-		Bit::SetBit(state->value, val, 1);
+		Bit::SetBit(state.value, val, 1);
 	} else {
 		throw OutOfRangeException("Range too large for bitstring aggregation");
 	}

--- a/src/core_functions/aggregate/distributive/bitstring_agg.cpp
+++ b/src/core_functions/aggregate/distributive/bitstring_agg.cpp
@@ -53,9 +53,8 @@ struct BitStringAggOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &data, const INPUT_TYPE *input, ValidityMask &mask,
-	                      idx_t idx) {
-		auto &bind_agg_data = data.bind_data->template Cast<BitstringAggBindData>();
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input) {
+		auto &bind_agg_data = unary_input.input.bind_data->template Cast<BitstringAggBindData>();
 		if (!state.is_set) {
 			if (bind_agg_data.min.IsNull() || bind_agg_data.max.IsNull()) {
 				throw BinderException(
@@ -78,19 +77,18 @@ struct BitStringAggOperation {
 			state.value = target;
 			state.is_set = true;
 		}
-		if (input[idx] >= state.min && input[idx] <= state.max) {
-			Execute(state, input[idx], bind_agg_data.min.GetValue<INPUT_TYPE>());
+		if (input >= state.min && input <= state.max) {
+			Execute(state, input, bind_agg_data.min.GetValue<INPUT_TYPE>());
 		} else {
 			throw OutOfRangeException("Value %s is outside of provided min and max range (%s <-> %s)",
-			                          NumericHelper::ToString(input[idx]), NumericHelper::ToString(state.min),
+			                          NumericHelper::ToString(input), NumericHelper::ToString(state.min),
 			                          NumericHelper::ToString(state.max));
 		}
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
-	                              ValidityMask &mask, idx_t count) {
-		OP::template Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+		OP::template Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 	}
 
 	template <class INPUT_TYPE>

--- a/src/core_functions/aggregate/distributive/bitstring_agg.cpp
+++ b/src/core_functions/aggregate/distributive/bitstring_agg.cpp
@@ -87,7 +87,8 @@ struct BitStringAggOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		OP::template Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 	}
 

--- a/src/core_functions/aggregate/distributive/bool.cpp
+++ b/src/core_functions/aggregate/distributive/bool.cpp
@@ -34,16 +34,15 @@ struct BoolAndFunFunction {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input) {
 		state.empty = false;
-		state.val = input[idx] && state.val;
+		state.val = input && state.val;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
-	                              ValidityMask &mask, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
-			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}
 	}
 	static bool IgnoreNull() {
@@ -73,16 +72,15 @@ struct BoolOrFunFunction {
 		target = state.val;
 	}
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input) {
 		state.empty = false;
-		state.val = input[idx] || state.val;
+		state.val = input || state.val;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
-	                              ValidityMask &mask, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
-			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}
 	}
 

--- a/src/core_functions/aggregate/distributive/bool.cpp
+++ b/src/core_functions/aggregate/distributive/bool.cpp
@@ -40,7 +40,8 @@ struct BoolAndFunFunction {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}
@@ -78,7 +79,8 @@ struct BoolOrFunFunction {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}

--- a/src/core_functions/aggregate/distributive/bool.cpp
+++ b/src/core_functions/aggregate/distributive/bool.cpp
@@ -13,34 +13,34 @@ struct BoolState {
 
 struct BoolAndFunFunction {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->val = true;
-		state->empty = true;
+	static void Initialize(STATE &state) {
+		state.val = true;
+		state.empty = true;
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
-		target->val = target->val && source.val;
-		target->empty = target->empty && source.empty;
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+		target.val = target.val && source.val;
+		target.empty = target.empty && source.empty;
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (state->empty) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.empty) {
+			finalize_data.ReturnNull();
 			return;
 		}
-		target[idx] = state->val;
+		target = state.val;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
-		state->empty = false;
-		state->val = input[idx] && state->val;
+	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		state.empty = false;
+		state.val = input[idx] && state.val;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
+	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
 	                              ValidityMask &mask, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
@@ -53,33 +53,33 @@ struct BoolAndFunFunction {
 
 struct BoolOrFunFunction {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->val = false;
-		state->empty = true;
+	static void Initialize(STATE &state) {
+		state.val = false;
+		state.empty = true;
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
-		target->val = target->val || source.val;
-		target->empty = target->empty && source.empty;
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+		target.val = target.val || source.val;
+		target.empty = target.empty && source.empty;
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (state->empty) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.empty) {
+			finalize_data.ReturnNull();
 			return;
 		}
-		target[idx] = state->val;
+		target = state.val;
 	}
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
-		state->empty = false;
-		state->val = input[idx] || state->val;
+	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		state.empty = false;
+		state.val = input[idx] || state.val;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
 	                              ValidityMask &mask, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);

--- a/src/core_functions/aggregate/distributive/entropy.cpp
+++ b/src/core_functions/aggregate/distributive/entropy.cpp
@@ -75,38 +75,36 @@ struct EntropyFunctionBase {
 
 struct EntropyFunction : EntropyFunctionBase {
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input) {
 		if (!state.distinct) {
 			state.distinct = new unordered_map<INPUT_TYPE, idx_t>();
 		}
-		(*state.distinct)[input[idx]]++;
+		(*state.distinct)[input]++;
 		state.count++;
 	}
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
-	                              ValidityMask &mask, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
-			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}
 	}
 };
 
 struct EntropyFunctionString : EntropyFunctionBase {
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input) {
 		if (!state.distinct) {
 			state.distinct = new unordered_map<string, idx_t>();
 		}
-		auto value = input[idx].GetString();
+		auto value = input.GetString();
 		(*state.distinct)[value]++;
 		state.count++;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
-	                              ValidityMask &mask, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
-			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}
 	}
 };

--- a/src/core_functions/aggregate/distributive/entropy.cpp
+++ b/src/core_functions/aggregate/distributive/entropy.cpp
@@ -83,7 +83,8 @@ struct EntropyFunction : EntropyFunctionBase {
 		state.count++;
 	}
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}
@@ -102,7 +103,8 @@ struct EntropyFunctionString : EntropyFunctionBase {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}

--- a/src/core_functions/aggregate/distributive/entropy.cpp
+++ b/src/core_functions/aggregate/distributive/entropy.cpp
@@ -27,38 +27,38 @@ struct EntropyState {
 
 struct EntropyFunctionBase {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->distinct = nullptr;
-		state->count = 0;
+	static void Initialize(STATE &state) {
+		state.distinct = nullptr;
+		state.count = 0;
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		if (!source.distinct) {
 			return;
 		}
-		if (!target->distinct) {
-			target->Assign(source);
+		if (!target.distinct) {
+			target.Assign(source);
 			return;
 		}
 		for (auto &val : *source.distinct) {
 			auto value = val.first;
-			(*target->distinct)[value] += val.second;
+			(*target.distinct)[value] += val.second;
 		}
-		target->count += source.count;
+		target.count += source.count;
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		double count = state->count;
-		if (state->distinct) {
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		double count = state.count;
+		if (state.distinct) {
 			double entropy = 0;
-			for (auto &val : *state->distinct) {
+			for (auto &val : *state.distinct) {
 				entropy += (val.second / count) * log2(count / val.second);
 			}
-			target[idx] = entropy;
+			target = entropy;
 		} else {
-			target[idx] = 0;
+			target = 0;
 		}
 	}
 
@@ -66,24 +66,24 @@ struct EntropyFunctionBase {
 		return true;
 	}
 	template <class STATE>
-	static void Destroy(AggregateInputData &aggr_input_data, STATE *state) {
-		if (state->distinct) {
-			delete state->distinct;
+	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
+		if (state.distinct) {
+			delete state.distinct;
 		}
 	}
 };
 
 struct EntropyFunction : EntropyFunctionBase {
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
-		if (!state->distinct) {
-			state->distinct = new unordered_map<INPUT_TYPE, idx_t>();
+	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (!state.distinct) {
+			state.distinct = new unordered_map<INPUT_TYPE, idx_t>();
 		}
-		(*state->distinct)[input[idx]]++;
-		state->count++;
+		(*state.distinct)[input[idx]]++;
+		state.count++;
 	}
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
 	                              ValidityMask &mask, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
@@ -93,17 +93,17 @@ struct EntropyFunction : EntropyFunctionBase {
 
 struct EntropyFunctionString : EntropyFunctionBase {
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
-		if (!state->distinct) {
-			state->distinct = new unordered_map<string, idx_t>();
+	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (!state.distinct) {
+			state.distinct = new unordered_map<string, idx_t>();
 		}
 		auto value = input[idx].GetString();
-		(*state->distinct)[value]++;
-		state->count++;
+		(*state.distinct)[value]++;
+		state.count++;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
+	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
 	                              ValidityMask &mask, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);

--- a/src/core_functions/aggregate/distributive/kurtosis.cpp
+++ b/src/core_functions/aggregate/distributive/kurtosis.cpp
@@ -22,20 +22,19 @@ struct KurtosisOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
-	                              ValidityMask &mask, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
-			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *data, ValidityMask &mask, idx_t idx) {
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input) {
 		state.n++;
-		state.sum += data[idx];
-		state.sum_sqr += pow(data[idx], 2);
-		state.sum_cub += pow(data[idx], 3);
-		state.sum_four += pow(data[idx], 4);
+		state.sum += input;
+		state.sum_sqr += pow(input, 2);
+		state.sum_cub += pow(input, 3);
+		state.sum_four += pow(input, 4);
 	}
 
 	template <class STATE, class OP>

--- a/src/core_functions/aggregate/distributive/kurtosis.cpp
+++ b/src/core_functions/aggregate/distributive/kurtosis.cpp
@@ -16,13 +16,13 @@ struct KurtosisState {
 
 struct KurtosisOperation {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->n = 0;
-		state->sum = state->sum_sqr = state->sum_cub = state->sum_four = 0.0;
+	static void Initialize(STATE &state) {
+		state.n = 0;
+		state.sum = state.sum_sqr = state.sum_cub = state.sum_four = 0.0;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
+	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
 	                              ValidityMask &mask, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
@@ -30,53 +30,52 @@ struct KurtosisOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const INPUT_TYPE *data, ValidityMask &mask, idx_t idx) {
-		state->n++;
-		state->sum += data[idx];
-		state->sum_sqr += pow(data[idx], 2);
-		state->sum_cub += pow(data[idx], 3);
-		state->sum_four += pow(data[idx], 4);
+	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *data, ValidityMask &mask, idx_t idx) {
+		state.n++;
+		state.sum += data[idx];
+		state.sum_sqr += pow(data[idx], 2);
+		state.sum_cub += pow(data[idx], 3);
+		state.sum_four += pow(data[idx], 4);
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		if (source.n == 0) {
 			return;
 		}
-		target->n += source.n;
-		target->sum += source.sum;
-		target->sum_sqr += source.sum_sqr;
-		target->sum_cub += source.sum_cub;
-		target->sum_four += source.sum_four;
+		target.n += source.n;
+		target.sum += source.sum;
+		target.sum_sqr += source.sum_sqr;
+		target.sum_cub += source.sum_cub;
+		target.sum_four += source.sum_four;
 	}
 
 	template <class TARGET_TYPE, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, TARGET_TYPE *target, ValidityMask &mask,
-	                     idx_t idx) {
-		auto n = (double)state->n;
+	static void Finalize(STATE &state, TARGET_TYPE &target, AggregateFinalizeData &finalize_data) {
+		auto n = (double)state.n;
 		if (n <= 3) {
-			mask.SetInvalid(idx);
+			finalize_data.ReturnNull();
 			return;
 		}
 		double temp = 1 / n;
 		//! This is necessary due to linux 32 bits
 		long double temp_aux = 1 / n;
-		if (state->sum_sqr - state->sum * state->sum * temp == 0 ||
-		    state->sum_sqr - state->sum * state->sum * temp_aux == 0) {
-			mask.SetInvalid(idx);
+		if (state.sum_sqr - state.sum * state.sum * temp == 0 ||
+		    state.sum_sqr - state.sum * state.sum * temp_aux == 0) {
+			finalize_data.ReturnNull();
 			return;
 		}
 		double m4 =
-		    temp * (state->sum_four - 4 * state->sum_cub * state->sum * temp +
-		            6 * state->sum_sqr * state->sum * state->sum * temp * temp - 3 * pow(state->sum, 4) * pow(temp, 3));
+		    temp * (state.sum_four - 4 * state.sum_cub * state.sum * temp +
+		            6 * state.sum_sqr * state.sum * state.sum * temp * temp - 3 * pow(state.sum, 4) * pow(temp, 3));
 
-		double m2 = temp * (state->sum_sqr - state->sum * state->sum * temp);
+		double m2 = temp * (state.sum_sqr - state.sum * state.sum * temp);
 		if (m2 <= 0 || ((n - 2) * (n - 3)) == 0) { // m2 shouldn't be below 0 but floating points are weird
-			mask.SetInvalid(idx);
+			finalize_data.ReturnNull();
 			return;
 		}
-		target[idx] = (n - 1) * ((n + 1) * m4 / (m2 * m2) - 3 * (n - 1)) / ((n - 2) * (n - 3));
-		if (!Value::DoubleIsFinite(target[idx])) {
+		target = (n - 1) * ((n + 1) * m4 / (m2 * m2) - 3 * (n - 1)) / ((n - 2) * (n - 3));
+		if (!Value::DoubleIsFinite(target)) {
 			throw OutOfRangeException("Kurtosis is out of range!");
 		}
 	}

--- a/src/core_functions/aggregate/distributive/kurtosis.cpp
+++ b/src/core_functions/aggregate/distributive/kurtosis.cpp
@@ -22,7 +22,8 @@ struct KurtosisOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}

--- a/src/core_functions/aggregate/distributive/minmax.cpp
+++ b/src/core_functions/aggregate/distributive/minmax.cpp
@@ -54,7 +54,8 @@ struct MinMaxBase {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		if (!state.isset) {
 			OP::template Assign<INPUT_TYPE, STATE>(state, input, unary_input.input);
 			state.isset = true;

--- a/src/core_functions/aggregate/distributive/minmax.cpp
+++ b/src/core_functions/aggregate/distributive/minmax.cpp
@@ -49,28 +49,28 @@ static AggregateFunction GetUnaryAggregate(LogicalType type) {
 
 struct MinMaxBase {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->isset = false;
+	static void Initialize(STATE &state) {
+		state.isset = false;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &input_data, const INPUT_TYPE *input,
+	static void ConstantOperation(STATE &state, AggregateInputData &input_data, const INPUT_TYPE *input,
 	                              ValidityMask &mask, idx_t count) {
 		D_ASSERT(mask.RowIsValid(0));
-		if (!state->isset) {
+		if (!state.isset) {
 			OP::template Assign<INPUT_TYPE, STATE>(state, input_data, input[0]);
-			state->isset = true;
+			state.isset = true;
 		} else {
 			OP::template Execute<INPUT_TYPE, STATE>(state, input_data, input[0]);
 		}
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &input_data, const INPUT_TYPE *input, ValidityMask &mask,
+	static void Operation(STATE &state, AggregateInputData &input_data, const INPUT_TYPE *input, ValidityMask &mask,
 	                      idx_t idx) {
-		if (!state->isset) {
+		if (!state.isset) {
 			OP::template Assign<INPUT_TYPE, STATE>(state, input_data, input[idx]);
-			state->isset = true;
+			state.isset = true;
 		} else {
 			OP::template Execute<INPUT_TYPE, STATE>(state, input_data, input[idx]);
 		}
@@ -83,105 +83,108 @@ struct MinMaxBase {
 
 struct NumericMinMaxBase : public MinMaxBase {
 	template <class INPUT_TYPE, class STATE>
-	static void Assign(STATE *state, AggregateInputData &, INPUT_TYPE input) {
-		state->value = input;
+	static void Assign(STATE &state, AggregateInputData &, INPUT_TYPE input) {
+		state.value = input;
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		mask.Set(idx, state->isset);
-		target[idx] = state->value;
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (!state.isset) {
+			finalize_data.ReturnNull();
+		} else {
+			target = state.value;
+		}
 	}
 };
 
 struct MinOperation : public NumericMinMaxBase {
 	template <class INPUT_TYPE, class STATE>
-	static void Execute(STATE *state, AggregateInputData &, INPUT_TYPE input) {
-		if (LessThan::Operation<INPUT_TYPE>(input, state->value)) {
-			state->value = input;
+	static void Execute(STATE &state, AggregateInputData &, INPUT_TYPE input) {
+		if (LessThan::Operation<INPUT_TYPE>(input, state.value)) {
+			state.value = input;
 		}
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		if (!source.isset) {
 			// source is NULL, nothing to do
 			return;
 		}
-		if (!target->isset) {
+		if (!target.isset) {
 			// target is NULL, use source value directly
-			*target = source;
-		} else if (GreaterThan::Operation(target->value, source.value)) {
-			target->value = source.value;
+			target = source;
+		} else if (GreaterThan::Operation(target.value, source.value)) {
+			target.value = source.value;
 		}
 	}
 };
 
 struct MaxOperation : public NumericMinMaxBase {
 	template <class INPUT_TYPE, class STATE>
-	static void Execute(STATE *state, AggregateInputData &, INPUT_TYPE input) {
-		if (GreaterThan::Operation<INPUT_TYPE>(input, state->value)) {
-			state->value = input;
+	static void Execute(STATE &state, AggregateInputData &, INPUT_TYPE input) {
+		if (GreaterThan::Operation<INPUT_TYPE>(input, state.value)) {
+			state.value = input;
 		}
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		if (!source.isset) {
 			// source is NULL, nothing to do
 			return;
 		}
-		if (!target->isset) {
+		if (!target.isset) {
 			// target is NULL, use source value directly
-			*target = source;
-		} else if (LessThan::Operation(target->value, source.value)) {
-			target->value = source.value;
+			target = source;
+		} else if (LessThan::Operation(target.value, source.value)) {
+			target.value = source.value;
 		}
 	}
 };
 
 struct StringMinMaxBase : public MinMaxBase {
 	template <class STATE>
-	static void Destroy(AggregateInputData &aggr_input_data, STATE *state) {
-		if (state->isset && !state->value.IsInlined()) {
-			delete[] state->value.GetData();
+	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
+		if (state.isset && !state.value.IsInlined()) {
+			delete[] state.value.GetData();
 		}
 	}
 
 	template <class INPUT_TYPE, class STATE>
-	static void Assign(STATE *state, AggregateInputData &input_data, INPUT_TYPE input) {
-		Destroy(input_data, state);
+	static void Assign(STATE &state, AggregateInputData &input_data, INPUT_TYPE input) {
+		Destroy(state, input_data);
 		if (input.IsInlined()) {
-			state->value = input;
+			state.value = input;
 		} else {
 			// non-inlined string, need to allocate space for it
 			auto len = input.GetSize();
 			auto ptr = new char[len];
 			memcpy(ptr, input.GetData(), len);
 
-			state->value = string_t(ptr, len);
+			state.value = string_t(ptr, len);
 		}
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (!state->isset) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (!state.isset) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = StringVector::AddStringOrBlob(result, state->value);
+			target = StringVector::AddStringOrBlob(finalize_data.result, state.value);
 		}
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &input_data) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &input_data) {
 		if (!source.isset) {
 			// source is NULL, nothing to do
 			return;
 		}
-		if (!target->isset) {
+		if (!target.isset) {
 			// target is NULL, use source value directly
 			Assign(target, input_data, source.value);
-			target->isset = true;
+			target.isset = true;
 		} else {
 			OP::template Execute<string_t, STATE>(target, input_data, source.value);
 		}
@@ -190,8 +193,8 @@ struct StringMinMaxBase : public MinMaxBase {
 
 struct MinOperationString : public StringMinMaxBase {
 	template <class INPUT_TYPE, class STATE>
-	static void Execute(STATE *state, AggregateInputData &input_data, INPUT_TYPE input) {
-		if (LessThan::Operation<INPUT_TYPE>(input, state->value)) {
+	static void Execute(STATE &state, AggregateInputData &input_data, INPUT_TYPE input) {
+		if (LessThan::Operation<INPUT_TYPE>(input, state.value)) {
 			Assign(state, input_data, input);
 		}
 	}
@@ -199,8 +202,8 @@ struct MinOperationString : public StringMinMaxBase {
 
 struct MaxOperationString : public StringMinMaxBase {
 	template <class INPUT_TYPE, class STATE>
-	static void Execute(STATE *state, AggregateInputData &input_data, INPUT_TYPE input) {
-		if (GreaterThan::Operation<INPUT_TYPE>(input, state->value)) {
+	static void Execute(STATE &state, AggregateInputData &input_data, INPUT_TYPE input) {
+		if (GreaterThan::Operation<INPUT_TYPE>(input, state.value)) {
 			Assign(state, input_data, input);
 		}
 	}
@@ -379,31 +382,31 @@ struct VectorMinMaxBase {
 	}
 
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->value = nullptr;
+	static void Initialize(STATE &state) {
+		state.value = nullptr;
 	}
 
 	template <class STATE>
-	static void Destroy(AggregateInputData &aggr_input_data, STATE *state) {
-		if (state->value) {
-			delete state->value;
+	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
+		if (state.value) {
+			delete state.value;
 		}
-		state->value = nullptr;
+		state.value = nullptr;
 	}
 
 	template <class STATE>
-	static void Assign(STATE *state, Vector &input, const idx_t idx) {
-		if (!state->value) {
-			state->value = new Vector(input.GetType());
-			state->value->SetVectorType(VectorType::CONSTANT_VECTOR);
+	static void Assign(STATE &state, Vector &input, const idx_t idx) {
+		if (!state.value) {
+			state.value = new Vector(input.GetType());
+			state.value->SetVectorType(VectorType::CONSTANT_VECTOR);
 		}
 		sel_t selv = idx;
 		SelectionVector sel(&selv);
-		VectorOperations::Copy(input, *state->value, sel, 1, 0, 0);
+		VectorOperations::Copy(input, *state.value, sel, 1, 0, 0);
 	}
 
 	template <class STATE>
-	static void Execute(STATE *state, Vector &input, const idx_t idx, const idx_t count) {
+	static void Execute(STATE &state, Vector &input, const idx_t idx, const idx_t count) {
 		Assign(state, input, idx);
 	}
 
@@ -423,8 +426,8 @@ struct VectorMinMaxBase {
 				continue;
 			}
 			const auto sidx = sdata.sel->get_index(i);
-			auto state = states[sidx];
-			if (!state->value) {
+			auto &state = *states[sidx];
+			if (!state.value) {
 				Assign(state, input, i);
 			} else {
 				OP::template Execute(state, input, i, count);
@@ -433,34 +436,22 @@ struct VectorMinMaxBase {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		if (!source.value) {
 			return;
-		} else if (!target->value) {
+		} else if (!target.value) {
 			Assign(target, *source.value, 0);
 		} else {
 			OP::template Execute(target, *source.value, 0, 1);
 		}
 	}
 
-	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (!state->value) {
-			// we need to use SetNull here
-			// since for STRUCT columns only setting the validity mask of the struct is incorrect
-			// as for a struct column, we need to also set ALL child columns to NULL
-			switch (result.GetVectorType()) {
-			case VectorType::FLAT_VECTOR:
-				FlatVector::SetNull(result, idx, true);
-				break;
-			case VectorType::CONSTANT_VECTOR:
-				ConstantVector::SetNull(result, true);
-				break;
-			default:
-				throw InternalException("Invalid result vector type for nested min/max");
-			}
+	template <class STATE>
+	static void Finalize(STATE &state, AggregateFinalizeData &finalize_data) {
+		if (!state.value) {
+			finalize_data.ReturnNull();
 		} else {
-			VectorOperations::Copy(*state->value, result, 1, 0, idx);
+			VectorOperations::Copy(*state.value, finalize_data.result, 1, 0, finalize_data.result_idx);
 		}
 	}
 
@@ -474,8 +465,8 @@ struct VectorMinMaxBase {
 
 struct MinOperationVector : public VectorMinMaxBase {
 	template <class STATE>
-	static void Execute(STATE *state, Vector &input, const idx_t idx, const idx_t count) {
-		if (TemplatedOptimumValue<DistinctLessThan>(input, idx, count, *state->value, 0, 1)) {
+	static void Execute(STATE &state, Vector &input, const idx_t idx, const idx_t count) {
+		if (TemplatedOptimumValue<DistinctLessThan>(input, idx, count, *state.value, 0, 1)) {
 			Assign(state, input, idx);
 		}
 	}
@@ -483,8 +474,8 @@ struct MinOperationVector : public VectorMinMaxBase {
 
 struct MaxOperationVector : public VectorMinMaxBase {
 	template <class STATE>
-	static void Execute(STATE *state, Vector &input, const idx_t idx, const idx_t count) {
-		if (TemplatedOptimumValue<DistinctGreaterThan>(input, idx, count, *state->value, 0, 1)) {
+	static void Execute(STATE &state, Vector &input, const idx_t idx, const idx_t count) {
+		if (TemplatedOptimumValue<DistinctGreaterThan>(input, idx, count, *state.value, 0, 1)) {
 			Assign(state, input, idx);
 		}
 	}
@@ -518,11 +509,10 @@ unique_ptr<FunctionData> BindDecimalMinMax(ClientContext &context, AggregateFunc
 
 template <typename OP, typename STATE>
 static AggregateFunction GetMinMaxFunction(const LogicalType &type) {
-	return AggregateFunction({type}, type, AggregateFunction::StateSize<STATE>,
-	                         AggregateFunction::StateInitialize<STATE, OP>, OP::template Update<STATE, OP>,
-	                         AggregateFunction::StateCombine<STATE, OP>,
-	                         AggregateFunction::StateFinalize<STATE, void, OP>, nullptr, OP::Bind,
-	                         AggregateFunction::StateDestroy<STATE, OP>);
+	return AggregateFunction(
+	    {type}, type, AggregateFunction::StateSize<STATE>, AggregateFunction::StateInitialize<STATE, OP>,
+	    OP::template Update<STATE, OP>, AggregateFunction::StateCombine<STATE, OP>,
+	    AggregateFunction::StateVoidFinalize<STATE, OP>, nullptr, OP::Bind, AggregateFunction::StateDestroy<STATE, OP>);
 }
 
 template <class OP, class OP_STRING, class OP_VECTOR>

--- a/src/core_functions/aggregate/distributive/product.cpp
+++ b/src/core_functions/aggregate/distributive/product.cpp
@@ -33,18 +33,17 @@ struct ProductFunction {
 		target = state.val;
 	}
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input) {
 		if (state.empty) {
 			state.empty = false;
 		}
-		state.val *= input[idx];
+		state.val *= input;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
-	                              ValidityMask &mask, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
-			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}
 	}
 

--- a/src/core_functions/aggregate/distributive/product.cpp
+++ b/src/core_functions/aggregate/distributive/product.cpp
@@ -41,7 +41,8 @@ struct ProductFunction {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}

--- a/src/core_functions/aggregate/distributive/product.cpp
+++ b/src/core_functions/aggregate/distributive/product.cpp
@@ -13,35 +13,35 @@ struct ProductState {
 
 struct ProductFunction {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->val = 1;
-		state->empty = true;
+	static void Initialize(STATE &state) {
+		state.val = 1;
+		state.empty = true;
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
-		target->val *= source.val;
-		target->empty = target->empty && source.empty;
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+		target.val *= source.val;
+		target.empty = target.empty && source.empty;
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (state->empty) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.empty) {
+			finalize_data.ReturnNull();
 			return;
 		}
-		target[idx] = state->val;
+		target = state.val;
 	}
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
-		if (state->empty) {
-			state->empty = false;
+	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (state.empty) {
+			state.empty = false;
 		}
-		state->val *= input[idx];
+		state.val *= input[idx];
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
+	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
 	                              ValidityMask &mask, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);

--- a/src/core_functions/aggregate/distributive/skew.cpp
+++ b/src/core_functions/aggregate/distributive/skew.cpp
@@ -21,19 +21,18 @@ struct SkewnessOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
-	                              ValidityMask &mask, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
-			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *data, ValidityMask &mask, idx_t idx) {
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input) {
 		state.n++;
-		state.sum += data[idx];
-		state.sum_sqr += pow(data[idx], 2);
-		state.sum_cub += pow(data[idx], 3);
+		state.sum += input;
+		state.sum_sqr += pow(input, 2);
+		state.sum_cub += pow(input, 3);
 	}
 
 	template <class STATE, class OP>

--- a/src/core_functions/aggregate/distributive/skew.cpp
+++ b/src/core_functions/aggregate/distributive/skew.cpp
@@ -21,7 +21,8 @@ struct SkewnessOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}

--- a/src/core_functions/aggregate/distributive/skew.cpp
+++ b/src/core_functions/aggregate/distributive/skew.cpp
@@ -15,13 +15,13 @@ struct SkewState {
 
 struct SkewnessOperation {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->n = 0;
-		state->sum = state->sum_sqr = state->sum_cub = 0;
+	static void Initialize(STATE &state) {
+		state.n = 0;
+		state.sum = state.sum_sqr = state.sum_cub = 0;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
+	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
 	                              ValidityMask &mask, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
@@ -29,48 +29,46 @@ struct SkewnessOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const INPUT_TYPE *data, ValidityMask &mask, idx_t idx) {
-		state->n++;
-		state->sum += data[idx];
-		state->sum_sqr += pow(data[idx], 2);
-		state->sum_cub += pow(data[idx], 3);
+	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *data, ValidityMask &mask, idx_t idx) {
+		state.n++;
+		state.sum += data[idx];
+		state.sum_sqr += pow(data[idx], 2);
+		state.sum_cub += pow(data[idx], 3);
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		if (source.n == 0) {
 			return;
 		}
 
-		target->n += source.n;
-		target->sum += source.sum;
-		target->sum_sqr += source.sum_sqr;
-		target->sum_cub += source.sum_cub;
+		target.n += source.n;
+		target.sum += source.sum;
+		target.sum_sqr += source.sum_sqr;
+		target.sum_cub += source.sum_cub;
 	}
 
 	template <class TARGET_TYPE, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, TARGET_TYPE *target, ValidityMask &mask,
-	                     idx_t idx) {
-		if (state->n <= 2) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, TARGET_TYPE &target, AggregateFinalizeData &finalize_data) {
+		if (state.n <= 2) {
+			finalize_data.ReturnNull();
 			return;
 		}
-		double n = state->n;
+		double n = state.n;
 		double temp = 1 / n;
-		auto p = std::pow(temp * (state->sum_sqr - state->sum * state->sum * temp), 3);
+		auto p = std::pow(temp * (state.sum_sqr - state.sum * state.sum * temp), 3);
 		if (p < 0) {
 			p = 0; // Shouldn't be below 0 but floating points are weird
 		}
 		double div = std::sqrt(p);
 		if (div == 0) {
-			mask.SetInvalid(idx);
+			finalize_data.ReturnNull();
 			return;
 		}
 		double temp1 = std::sqrt(n * (n - 1)) / (n - 2);
-		target[idx] = temp1 * temp *
-		              (state->sum_cub - 3 * state->sum_sqr * state->sum * temp + 2 * pow(state->sum, 3) * temp * temp) /
-		              div;
-		if (!Value::DoubleIsFinite(target[idx])) {
+		target = temp1 * temp *
+		         (state.sum_cub - 3 * state.sum_sqr * state.sum * temp + 2 * pow(state.sum, 3) * temp * temp) / div;
+		if (!Value::DoubleIsFinite(target)) {
 			throw OutOfRangeException("SKEW is out of range!");
 		}
 	}

--- a/src/core_functions/aggregate/distributive/string_agg.cpp
+++ b/src/core_functions/aggregate/distributive/string_agg.cpp
@@ -32,25 +32,25 @@ struct StringAggBindData : public FunctionData {
 
 struct StringAggFunction {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->dataptr = nullptr;
-		state->alloc_size = 0;
-		state->size = 0;
+	static void Initialize(STATE &state) {
+		state.dataptr = nullptr;
+		state.alloc_size = 0;
+		state.size = 0;
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (!state->dataptr) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (!state.dataptr) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = StringVector::AddString(result, state->dataptr, state->size);
+			target = StringVector::AddString(finalize_data.result, state.dataptr, state.size);
 		}
 	}
 
 	template <class STATE>
-	static void Destroy(AggregateInputData &aggr_input_data, STATE *state) {
-		if (state->dataptr) {
-			delete[] state->dataptr;
+	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
+		if (state.dataptr) {
+			delete[] state.dataptr;
 		}
 	}
 
@@ -58,49 +58,49 @@ struct StringAggFunction {
 		return true;
 	}
 
-	static inline void PerformOperation(StringAggState *state, const char *str, const char *sep, idx_t str_size,
+	static inline void PerformOperation(StringAggState &state, const char *str, const char *sep, idx_t str_size,
 	                                    idx_t sep_size) {
-		if (!state->dataptr) {
+		if (!state.dataptr) {
 			// first iteration: allocate space for the string and copy it into the state
-			state->alloc_size = MaxValue<idx_t>(8, NextPowerOfTwo(str_size));
-			state->dataptr = new char[state->alloc_size];
-			state->size = str_size;
-			memcpy(state->dataptr, str, str_size);
+			state.alloc_size = MaxValue<idx_t>(8, NextPowerOfTwo(str_size));
+			state.dataptr = new char[state.alloc_size];
+			state.size = str_size;
+			memcpy(state.dataptr, str, str_size);
 		} else {
 			// subsequent iteration: first check if we have space to place the string and separator
-			idx_t required_size = state->size + str_size + sep_size;
-			if (required_size > state->alloc_size) {
+			idx_t required_size = state.size + str_size + sep_size;
+			if (required_size > state.alloc_size) {
 				// no space! allocate extra space
-				while (state->alloc_size < required_size) {
-					state->alloc_size *= 2;
+				while (state.alloc_size < required_size) {
+					state.alloc_size *= 2;
 				}
-				auto new_data = new char[state->alloc_size];
-				memcpy(new_data, state->dataptr, state->size);
-				delete[] state->dataptr;
-				state->dataptr = new_data;
+				auto new_data = new char[state.alloc_size];
+				memcpy(new_data, state.dataptr, state.size);
+				delete[] state.dataptr;
+				state.dataptr = new_data;
 			}
 			// copy the separator
-			memcpy(state->dataptr + state->size, sep, sep_size);
-			state->size += sep_size;
+			memcpy(state.dataptr + state.size, sep, sep_size);
+			state.size += sep_size;
 			// copy the string
-			memcpy(state->dataptr + state->size, str, str_size);
-			state->size += str_size;
+			memcpy(state.dataptr + state.size, str, str_size);
+			state.size += str_size;
 		}
 	}
 
-	static inline void PerformOperation(StringAggState *state, string_t str, FunctionData *data_p) {
+	static inline void PerformOperation(StringAggState &state, string_t str, optional_ptr<FunctionData> data_p) {
 		auto &data = data_p->Cast<StringAggBindData>();
 		PerformOperation(state, str.GetData(), data.sep.c_str(), str.GetSize(), data.sep.size());
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &aggr_input_data, const INPUT_TYPE *str_data,
+	static void Operation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *str_data,
 	                      ValidityMask &str_mask, idx_t str_idx) {
 		PerformOperation(state, str_data[str_idx], aggr_input_data.bind_data);
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
+	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
 	                              ValidityMask &mask, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
@@ -108,7 +108,7 @@ struct StringAggFunction {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &aggr_input_data) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input_data) {
 		if (!source.dataptr) {
 			// source is not set: skip combining
 			return;

--- a/src/core_functions/aggregate/distributive/string_agg.cpp
+++ b/src/core_functions/aggregate/distributive/string_agg.cpp
@@ -99,7 +99,8 @@ struct StringAggFunction {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}

--- a/src/core_functions/aggregate/distributive/string_agg.cpp
+++ b/src/core_functions/aggregate/distributive/string_agg.cpp
@@ -94,16 +94,14 @@ struct StringAggFunction {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *str_data,
-	                      ValidityMask &str_mask, idx_t str_idx) {
-		PerformOperation(state, str_data[str_idx], aggr_input_data.bind_data);
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input) {
+		PerformOperation(state, input, unary_input.input.bind_data);
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
-	                              ValidityMask &mask, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
-			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}
 	}
 

--- a/src/core_functions/aggregate/distributive/sum.cpp
+++ b/src/core_functions/aggregate/distributive/sum.cpp
@@ -8,37 +8,37 @@ namespace duckdb {
 
 struct SumSetOperation {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->Initialize();
+	static void Initialize(STATE &state) {
+		state.Initialize();
 	}
 	template <class STATE>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
-		target->Combine(source);
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+		target.Combine(source);
 	}
 	template <class STATE>
-	static void AddValues(STATE *state, idx_t count) {
-		state->isset = true;
+	static void AddValues(STATE &state, idx_t count) {
+		state.isset = true;
 	}
 };
 
 struct IntegerSumOperation : public BaseSumOperation<SumSetOperation, RegularAdd> {
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (!state->isset) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (!state.isset) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = Hugeint::Convert(state->value);
+			target = Hugeint::Convert(state.value);
 		}
 	}
 };
 
 struct SumToHugeintOperation : public BaseSumOperation<SumSetOperation, HugeintAdd> {
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (!state->isset) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (!state.isset) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = state->value;
+			target = state.value;
 		}
 	}
 };
@@ -46,11 +46,11 @@ struct SumToHugeintOperation : public BaseSumOperation<SumSetOperation, HugeintA
 template <class ADD_OPERATOR>
 struct DoubleSumOperation : public BaseSumOperation<SumSetOperation, ADD_OPERATOR> {
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (!state->isset) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (!state.isset) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = state->value;
+			target = state.value;
 		}
 	}
 };
@@ -60,11 +60,11 @@ using KahanSumOperation = DoubleSumOperation<KahanAdd>;
 
 struct HugeintSumOperation : public BaseSumOperation<SumSetOperation, RegularAdd> {
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (!state->isset) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (!state.isset) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = state->value;
+			target = state.value;
 		}
 	}
 };

--- a/src/core_functions/aggregate/holistic/approximate_quantile.cpp
+++ b/src/core_functions/aggregate/holistic/approximate_quantile.cpp
@@ -55,13 +55,13 @@ struct ApproxQuantileOperation {
 	using SAVE_TYPE = duckdb_tdigest::Value;
 
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->pos = 0;
-		state->h = nullptr;
+	static void Initialize(STATE &state) {
+		state.pos = 0;
+		state.h = nullptr;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
+	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
 	                              ValidityMask &mask, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
@@ -69,35 +69,35 @@ struct ApproxQuantileOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const INPUT_TYPE *data, ValidityMask &mask, idx_t idx) {
+	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *data, ValidityMask &mask, idx_t idx) {
 		auto val = Cast::template Operation<INPUT_TYPE, SAVE_TYPE>(data[idx]);
 		if (!Value::DoubleIsFinite(val)) {
 			return;
 		}
-		if (!state->h) {
-			state->h = new duckdb_tdigest::TDigest(100);
+		if (!state.h) {
+			state.h = new duckdb_tdigest::TDigest(100);
 		}
-		state->h->add(val);
-		state->pos++;
+		state.h->add(val);
+		state.pos++;
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		if (source.pos == 0) {
 			return;
 		}
 		D_ASSERT(source.h);
-		if (!target->h) {
-			target->h = new duckdb_tdigest::TDigest(100);
+		if (!target.h) {
+			target.h = new duckdb_tdigest::TDigest(100);
 		}
-		target->h->merge(source.h);
-		target->pos += source.pos;
+		target.h->merge(source.h);
+		target.pos += source.pos;
 	}
 
 	template <class STATE>
-	static void Destroy(AggregateInputData &aggr_input_data, STATE *state) {
-		if (state->h) {
-			delete state->h;
+	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
+		if (state.h) {
+			delete state.h;
 		}
 	}
 
@@ -109,19 +109,17 @@ struct ApproxQuantileOperation {
 struct ApproxQuantileScalarOperation : public ApproxQuantileOperation {
 
 	template <class TARGET_TYPE, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, TARGET_TYPE *target,
-	                     ValidityMask &mask, idx_t idx) {
-
-		if (state->pos == 0) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, TARGET_TYPE &target, AggregateFinalizeData &finalize_data) {
+		if (state.pos == 0) {
+			finalize_data.ReturnNull();
 			return;
 		}
-		D_ASSERT(state->h);
-		D_ASSERT(aggr_input_data.bind_data);
-		state->h->compress();
-		auto &bind_data = aggr_input_data.bind_data->template Cast<ApproximateQuantileBindData>();
+		D_ASSERT(state.h);
+		D_ASSERT(finalize_data.input.bind_data);
+		state.h->compress();
+		auto &bind_data = finalize_data.input.bind_data->template Cast<ApproximateQuantileBindData>();
 		D_ASSERT(bind_data.quantiles.size() == 1);
-		target[idx] = Cast::template Operation<SAVE_TYPE, TARGET_TYPE>(state->h->quantile(bind_data.quantiles[0]));
+		target = Cast::template Operation<SAVE_TYPE, TARGET_TYPE>(state.h->quantile(bind_data.quantiles[0]));
 	}
 };
 
@@ -212,66 +210,64 @@ template <class CHILD_TYPE>
 struct ApproxQuantileListOperation : public ApproxQuantileOperation {
 
 	template <class RESULT_TYPE, class STATE>
-	static void Finalize(Vector &result_list, AggregateInputData &aggr_input_data, STATE *state, RESULT_TYPE *target,
-	                     ValidityMask &mask, idx_t idx) {
-		if (state->pos == 0) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, RESULT_TYPE &target, AggregateFinalizeData &finalize_data) {
+		if (state.pos == 0) {
+			finalize_data.ReturnNull();
 			return;
 		}
 
-		D_ASSERT(aggr_input_data.bind_data);
-		auto &bind_data = aggr_input_data.bind_data->template Cast<ApproximateQuantileBindData>();
+		D_ASSERT(finalize_data.input.bind_data);
+		auto &bind_data = finalize_data.input.bind_data->template Cast<ApproximateQuantileBindData>();
 
-		auto &result = ListVector::GetEntry(result_list);
-		auto ridx = ListVector::GetListSize(result_list);
-		ListVector::Reserve(result_list, ridx + bind_data.quantiles.size());
+		auto &result = ListVector::GetEntry(finalize_data.result);
+		auto ridx = ListVector::GetListSize(finalize_data.result);
+		ListVector::Reserve(finalize_data.result, ridx + bind_data.quantiles.size());
 		auto rdata = FlatVector::GetData<CHILD_TYPE>(result);
 
-		D_ASSERT(state->h);
-		state->h->compress();
+		D_ASSERT(state.h);
+		state.h->compress();
 
-		auto &entry = target[idx];
+		auto &entry = target;
 		entry.offset = ridx;
 		entry.length = bind_data.quantiles.size();
 		for (size_t q = 0; q < entry.length; ++q) {
 			const auto &quantile = bind_data.quantiles[q];
-			rdata[ridx + q] = Cast::template Operation<SAVE_TYPE, CHILD_TYPE>(state->h->quantile(quantile));
+			rdata[ridx + q] = Cast::template Operation<SAVE_TYPE, CHILD_TYPE>(state.h->quantile(quantile));
 		}
 
-		ListVector::SetListSize(result_list, entry.offset + entry.length);
+		ListVector::SetListSize(finalize_data.result, entry.offset + entry.length);
 	}
 
-	template <class STATE_TYPE, class RESULT_TYPE>
-	static void FinalizeList(Vector &states, AggregateInputData &aggr_input_data, Vector &result, idx_t count, // NOLINT
-	                         idx_t offset) {
-		D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
-
-		D_ASSERT(aggr_input_data.bind_data);
-		auto &bind_data = aggr_input_data.bind_data->template Cast<ApproximateQuantileBindData>();
-
-		if (states.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ListVector::Reserve(result, bind_data.quantiles.size());
-
-			auto sdata = ConstantVector::GetData<STATE_TYPE *>(states);
-			auto rdata = ConstantVector::GetData<RESULT_TYPE>(result);
-			auto &mask = ConstantVector::Validity(result);
-			Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[0], rdata, mask, 0);
-		} else {
-			D_ASSERT(states.GetVectorType() == VectorType::FLAT_VECTOR);
-			result.SetVectorType(VectorType::FLAT_VECTOR);
-			ListVector::Reserve(result, (offset + count) * bind_data.quantiles.size());
-
-			auto sdata = FlatVector::GetData<STATE_TYPE *>(states);
-			auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
-			auto &mask = FlatVector::Validity(result);
-			for (idx_t i = 0; i < count; i++) {
-				Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[i], rdata, mask, i + offset);
-			}
-		}
-
-		result.Verify(count);
-	}
+	//	template <class STATE_TYPE, class RESULT_TYPE>
+	//	static void FinalizeList(Vector &states, AggregateInputData &aggr_input_data, Vector &result, idx_t count, //
+	//NOLINT 	                         idx_t offset) { 		D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
+	//
+	//		D_ASSERT(aggr_input_data.bind_data);
+	//		auto &bind_data = aggr_input_data.bind_data->template Cast<ApproximateQuantileBindData>();
+	//
+	//		if (states.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+	//			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	//			ListVector::Reserve(result, bind_data.quantiles.size());
+	//
+	//			auto sdata = ConstantVector::GetData<STATE_TYPE *>(states);
+	//			auto rdata = ConstantVector::GetData<RESULT_TYPE>(result);
+	//			auto &mask = ConstantVector::Validity(result);
+	//			Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[0], rdata, mask, 0);
+	//		} else {
+	//			D_ASSERT(states.GetVectorType() == VectorType::FLAT_VECTOR);
+	//			result.SetVectorType(VectorType::FLAT_VECTOR);
+	//			ListVector::Reserve(result, (offset + count) * bind_data.quantiles.size());
+	//
+	//			auto sdata = FlatVector::GetData<STATE_TYPE *>(states);
+	//			auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
+	//			auto &mask = FlatVector::Validity(result);
+	//			for (idx_t i = 0; i < count; i++) {
+	//				Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[i], rdata, mask, i + offset);
+	//			}
+	//		}
+	//
+	//		result.Verify(count);
+	//	}
 };
 
 template <class STATE, class INPUT_TYPE, class RESULT_TYPE, class OP>
@@ -280,8 +276,8 @@ static AggregateFunction ApproxQuantileListAggregate(const LogicalType &input_ty
 	return AggregateFunction(
 	    {input_type}, result_type, AggregateFunction::StateSize<STATE>, AggregateFunction::StateInitialize<STATE, OP>,
 	    AggregateFunction::UnaryScatterUpdate<STATE, INPUT_TYPE, OP>, AggregateFunction::StateCombine<STATE, OP>,
-	    OP::template FinalizeList<STATE, RESULT_TYPE>, AggregateFunction::UnaryUpdate<STATE, INPUT_TYPE, OP>, nullptr,
-	    AggregateFunction::StateDestroy<STATE, OP>);
+	    AggregateFunction::StateFinalize<STATE, RESULT_TYPE, OP>, AggregateFunction::UnaryUpdate<STATE, INPUT_TYPE, OP>,
+	    nullptr, AggregateFunction::StateDestroy<STATE, OP>);
 }
 
 template <typename INPUT_TYPE, typename SAVE_TYPE>

--- a/src/core_functions/aggregate/holistic/approximate_quantile.cpp
+++ b/src/core_functions/aggregate/holistic/approximate_quantile.cpp
@@ -61,16 +61,15 @@ struct ApproxQuantileOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
-	                              ValidityMask &mask, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
-			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *data, ValidityMask &mask, idx_t idx) {
-		auto val = Cast::template Operation<INPUT_TYPE, SAVE_TYPE>(data[idx]);
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input) {
+		auto val = Cast::template Operation<INPUT_TYPE, SAVE_TYPE>(input);
 		if (!Value::DoubleIsFinite(val)) {
 			return;
 		}
@@ -107,7 +106,6 @@ struct ApproxQuantileOperation {
 };
 
 struct ApproxQuantileScalarOperation : public ApproxQuantileOperation {
-
 	template <class TARGET_TYPE, class STATE>
 	static void Finalize(STATE &state, TARGET_TYPE &target, AggregateFinalizeData &finalize_data) {
 		if (state.pos == 0) {
@@ -237,37 +235,6 @@ struct ApproxQuantileListOperation : public ApproxQuantileOperation {
 
 		ListVector::SetListSize(finalize_data.result, entry.offset + entry.length);
 	}
-
-	//	template <class STATE_TYPE, class RESULT_TYPE>
-	//	static void FinalizeList(Vector &states, AggregateInputData &aggr_input_data, Vector &result, idx_t count, //
-	//NOLINT 	                         idx_t offset) { 		D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
-	//
-	//		D_ASSERT(aggr_input_data.bind_data);
-	//		auto &bind_data = aggr_input_data.bind_data->template Cast<ApproximateQuantileBindData>();
-	//
-	//		if (states.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-	//			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-	//			ListVector::Reserve(result, bind_data.quantiles.size());
-	//
-	//			auto sdata = ConstantVector::GetData<STATE_TYPE *>(states);
-	//			auto rdata = ConstantVector::GetData<RESULT_TYPE>(result);
-	//			auto &mask = ConstantVector::Validity(result);
-	//			Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[0], rdata, mask, 0);
-	//		} else {
-	//			D_ASSERT(states.GetVectorType() == VectorType::FLAT_VECTOR);
-	//			result.SetVectorType(VectorType::FLAT_VECTOR);
-	//			ListVector::Reserve(result, (offset + count) * bind_data.quantiles.size());
-	//
-	//			auto sdata = FlatVector::GetData<STATE_TYPE *>(states);
-	//			auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
-	//			auto &mask = FlatVector::Validity(result);
-	//			for (idx_t i = 0; i < count; i++) {
-	//				Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[i], rdata, mask, i + offset);
-	//			}
-	//		}
-	//
-	//		result.Verify(count);
-	//	}
 };
 
 template <class STATE, class INPUT_TYPE, class RESULT_TYPE, class OP>

--- a/src/core_functions/aggregate/holistic/approximate_quantile.cpp
+++ b/src/core_functions/aggregate/holistic/approximate_quantile.cpp
@@ -61,7 +61,8 @@ struct ApproxQuantileOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}

--- a/src/core_functions/aggregate/holistic/mode.cpp
+++ b/src/core_functions/aggregate/holistic/mode.cpp
@@ -155,11 +155,11 @@ struct ModeFunction {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
 		if (!state.frequency_map) {
 			state.frequency_map = new typename STATE::Counts();
 		}
-		auto key = KEY_TYPE(input[idx]);
+		auto key = KEY_TYPE(input);
 		auto &i = (*state.frequency_map)[key];
 		i.count++;
 		i.first_row = MinValue<idx_t>(i.first_row, state.count);
@@ -198,12 +198,11 @@ struct ModeFunction {
 		}
 	}
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask,
-	                              idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &, idx_t count) {
 		if (!state.frequency_map) {
 			state.frequency_map = new typename STATE::Counts();
 		}
-		auto key = KEY_TYPE(input[0]);
+		auto key = KEY_TYPE(input);
 		auto &i = (*state.frequency_map)[key];
 		i.count += count;
 		i.first_row = MinValue<idx_t>(i.first_row, state.count);

--- a/src/core_functions/aggregate/holistic/mode.cpp
+++ b/src/core_functions/aggregate/holistic/mode.cpp
@@ -150,126 +150,125 @@ struct ModeAssignmentString {
 template <typename KEY_TYPE, typename ASSIGN_OP>
 struct ModeFunction {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->Initialize();
+	static void Initialize(STATE &state) {
+		state.Initialize();
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
-		if (!state->frequency_map) {
-			state->frequency_map = new typename STATE::Counts();
+	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (!state.frequency_map) {
+			state.frequency_map = new typename STATE::Counts();
 		}
 		auto key = KEY_TYPE(input[idx]);
-		auto &i = (*state->frequency_map)[key];
+		auto &i = (*state.frequency_map)[key];
 		i.count++;
-		i.first_row = MinValue<idx_t>(i.first_row, state->count);
-		state->count++;
+		i.first_row = MinValue<idx_t>(i.first_row, state.count);
+		state.count++;
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		if (!source.frequency_map) {
 			return;
 		}
-		if (!target->frequency_map) {
+		if (!target.frequency_map) {
 			// Copy - don't destroy! Otherwise windowing will break.
-			target->frequency_map = new typename STATE::Counts(*source.frequency_map);
+			target.frequency_map = new typename STATE::Counts(*source.frequency_map);
 			return;
 		}
 		for (auto &val : *source.frequency_map) {
-			auto &i = (*target->frequency_map)[val.first];
+			auto &i = (*target.frequency_map)[val.first];
 			i.count += val.second.count;
 			i.first_row = MinValue(i.first_row, val.second.first_row);
 		}
-		target->count += source.count;
+		target.count += source.count;
 	}
 
-	template <class INPUT_TYPE, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, INPUT_TYPE *target, ValidityMask &mask,
-	                     idx_t idx) {
-		if (!state->frequency_map) {
-			mask.SetInvalid(idx);
+	template <class T, class STATE>
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (!state.frequency_map) {
+			finalize_data.ReturnNull();
 			return;
 		}
-		auto highest_frequency = state->Scan();
-		if (highest_frequency != state->frequency_map->end()) {
-			target[idx] = ASSIGN_OP::template Assign<INPUT_TYPE, INPUT_TYPE>(result, highest_frequency->first);
+		auto highest_frequency = state.Scan();
+		if (highest_frequency != state.frequency_map->end()) {
+			target = ASSIGN_OP::template Assign<T, T>(finalize_data.result, highest_frequency->first);
 		} else {
-			mask.SetInvalid(idx);
+			finalize_data.ReturnNull();
 		}
 	}
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask,
+	static void ConstantOperation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask,
 	                              idx_t count) {
-		if (!state->frequency_map) {
-			state->frequency_map = new typename STATE::Counts();
+		if (!state.frequency_map) {
+			state.frequency_map = new typename STATE::Counts();
 		}
 		auto key = KEY_TYPE(input[0]);
-		auto &i = (*state->frequency_map)[key];
+		auto &i = (*state.frequency_map)[key];
 		i.count += count;
-		i.first_row = MinValue<idx_t>(i.first_row, state->count);
-		state->count += count;
+		i.first_row = MinValue<idx_t>(i.first_row, state.count);
+		state.count += count;
 	}
 
 	template <class STATE, class INPUT_TYPE, class RESULT_TYPE>
 	static void Window(const INPUT_TYPE *data, const ValidityMask &fmask, const ValidityMask &dmask,
-	                   AggregateInputData &, STATE *state, const FrameBounds &frame, const FrameBounds &prev,
+	                   AggregateInputData &, STATE &state, const FrameBounds &frame, const FrameBounds &prev,
 	                   Vector &result, idx_t rid, idx_t bias) {
 		auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
 		auto &rmask = FlatVector::Validity(result);
 
 		ModeIncluded included(fmask, dmask, bias);
 
-		if (!state->frequency_map) {
-			state->frequency_map = new typename STATE::Counts;
+		if (!state.frequency_map) {
+			state.frequency_map = new typename STATE::Counts;
 		}
 		const double tau = .25;
-		if (state->nonzero <= tau * state->frequency_map->size()) {
-			state->Reset();
+		if (state.nonzero <= tau * state.frequency_map->size()) {
+			state.Reset();
 			// for f ∈ F do
 			for (auto f = frame.first; f < frame.second; ++f) {
 				if (included(f)) {
-					state->ModeAdd(KEY_TYPE(data[f]), f);
+					state.ModeAdd(KEY_TYPE(data[f]), f);
 				}
 			}
 		} else {
 			// for f ∈ P \ F do
 			for (auto p = prev.first; p < frame.first; ++p) {
 				if (included(p)) {
-					state->ModeRm(KEY_TYPE(data[p]), p);
+					state.ModeRm(KEY_TYPE(data[p]), p);
 				}
 			}
 			for (auto p = frame.second; p < prev.second; ++p) {
 				if (included(p)) {
-					state->ModeRm(KEY_TYPE(data[p]), p);
+					state.ModeRm(KEY_TYPE(data[p]), p);
 				}
 			}
 
 			// for f ∈ F \ P do
 			for (auto f = frame.first; f < prev.first; ++f) {
 				if (included(f)) {
-					state->ModeAdd(KEY_TYPE(data[f]), f);
+					state.ModeAdd(KEY_TYPE(data[f]), f);
 				}
 			}
 			for (auto f = prev.second; f < frame.second; ++f) {
 				if (included(f)) {
-					state->ModeAdd(KEY_TYPE(data[f]), f);
+					state.ModeAdd(KEY_TYPE(data[f]), f);
 				}
 			}
 		}
 
-		if (!state->valid) {
+		if (!state.valid) {
 			// Rescan
-			auto highest_frequency = state->Scan();
-			if (highest_frequency != state->frequency_map->end()) {
-				*(state->mode) = highest_frequency->first;
-				state->count = highest_frequency->second.count;
-				state->valid = (state->count > 0);
+			auto highest_frequency = state.Scan();
+			if (highest_frequency != state.frequency_map->end()) {
+				*(state.mode) = highest_frequency->first;
+				state.count = highest_frequency->second.count;
+				state.valid = (state.count > 0);
 			}
 		}
 
-		if (state->valid) {
-			rdata[rid] = ASSIGN_OP::template Assign<INPUT_TYPE, RESULT_TYPE>(result, *state->mode);
+		if (state.valid) {
+			rdata[rid] = ASSIGN_OP::template Assign<INPUT_TYPE, RESULT_TYPE>(result, *state.mode);
 		} else {
 			rmask.Set(rid, false);
 		}
@@ -280,8 +279,8 @@ struct ModeFunction {
 	}
 
 	template <class STATE>
-	static void Destroy(AggregateInputData &aggr_input_data, STATE *state) {
-		state->Destroy();
+	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
+		state.Destroy();
 	}
 };
 

--- a/src/core_functions/aggregate/holistic/quantile.cpp
+++ b/src/core_functions/aggregate/holistic/quantile.cpp
@@ -456,7 +456,8 @@ struct QuantileOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}

--- a/src/core_functions/aggregate/holistic/quantile.cpp
+++ b/src/core_functions/aggregate/holistic/quantile.cpp
@@ -451,12 +451,12 @@ struct QuantileBindData : public FunctionData {
 
 struct QuantileOperation {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		new (state) STATE;
+	static void Initialize(STATE &state) {
+		new (&state) STATE();
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
 	                              ValidityMask &mask, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
@@ -464,60 +464,60 @@ struct QuantileOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const INPUT_TYPE *data, ValidityMask &mask, idx_t idx) {
-		state->v.emplace_back(data[idx]);
+	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *data, ValidityMask &mask, idx_t idx) {
+		state.v.emplace_back(data[idx]);
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		if (source.v.empty()) {
 			return;
 		}
-		target->v.insert(target->v.end(), source.v.begin(), source.v.end());
+		target.v.insert(target.v.end(), source.v.begin(), source.v.end());
 	}
 
 	template <class STATE>
-	static void Destroy(AggregateInputData &aggr_input_data, STATE *state) {
-		state->~STATE();
+	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
+		state.~STATE();
 	}
 
 	static bool IgnoreNull() {
 		return true;
 	}
 };
-
-template <class STATE_TYPE, class RESULT_TYPE, class OP>
-static void ExecuteListFinalize(Vector &states, AggregateInputData &aggr_input_data, Vector &result,
-                                idx_t count, // NOLINT
-                                idx_t offset) {
-	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
-
-	D_ASSERT(aggr_input_data.bind_data);
-	auto &bind_data = aggr_input_data.bind_data->Cast<QuantileBindData>();
-
-	if (states.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ListVector::Reserve(result, bind_data.quantiles.size());
-
-		auto sdata = ConstantVector::GetData<STATE_TYPE *>(states);
-		auto rdata = ConstantVector::GetData<RESULT_TYPE>(result);
-		auto &mask = ConstantVector::Validity(result);
-		OP::template Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[0], rdata, mask, 0);
-	} else {
-		D_ASSERT(states.GetVectorType() == VectorType::FLAT_VECTOR);
-		result.SetVectorType(VectorType::FLAT_VECTOR);
-		ListVector::Reserve(result, (offset + count) * bind_data.quantiles.size());
-
-		auto sdata = FlatVector::GetData<STATE_TYPE *>(states);
-		auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
-		auto &mask = FlatVector::Validity(result);
-		for (idx_t i = 0; i < count; i++) {
-			OP::template Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[i], rdata, mask, i + offset);
-		}
-	}
-
-	result.Verify(count);
-}
+//
+// template <class STATE_TYPE, class RESULT_TYPE, class OP>
+// static void ExecuteListFinalize(Vector &states, AggregateInputData &aggr_input_data, Vector &result,
+//                                idx_t count, // NOLINT
+//                                idx_t offset) {
+//	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
+//
+//	D_ASSERT(aggr_input_data.bind_data);
+//	auto &bind_data = aggr_input_data.bind_data->Cast<QuantileBindData>();
+//
+//	if (states.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+//		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+//		ListVector::Reserve(result, bind_data.quantiles.size());
+//
+//		auto sdata = ConstantVector::GetData<STATE_TYPE *>(states);
+//		auto rdata = ConstantVector::GetData<RESULT_TYPE>(result);
+//		auto &mask = ConstantVector::Validity(result);
+//		OP::template Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[0], rdata, mask, 0);
+//	} else {
+//		D_ASSERT(states.GetVectorType() == VectorType::FLAT_VECTOR);
+//		result.SetVectorType(VectorType::FLAT_VECTOR);
+//		ListVector::Reserve(result, (offset + count) * bind_data.quantiles.size());
+//
+//		auto sdata = FlatVector::GetData<STATE_TYPE *>(states);
+//		auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
+//		auto &mask = FlatVector::Validity(result);
+//		for (idx_t i = 0; i < count; i++) {
+//			OP::template Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[i], rdata, mask, i + offset);
+//		}
+//	}
+//
+//	result.Verify(count);
+//}
 
 template <class STATE, class INPUT_TYPE, class RESULT_TYPE, class OP>
 static AggregateFunction QuantileListAggregate(const LogicalType &input_type, const LogicalType &child_type) { // NOLINT
@@ -525,30 +525,29 @@ static AggregateFunction QuantileListAggregate(const LogicalType &input_type, co
 	return AggregateFunction(
 	    {input_type}, result_type, AggregateFunction::StateSize<STATE>, AggregateFunction::StateInitialize<STATE, OP>,
 	    AggregateFunction::UnaryScatterUpdate<STATE, INPUT_TYPE, OP>, AggregateFunction::StateCombine<STATE, OP>,
-	    ExecuteListFinalize<STATE, RESULT_TYPE, OP>, AggregateFunction::UnaryUpdate<STATE, INPUT_TYPE, OP>, nullptr,
-	    AggregateFunction::StateDestroy<STATE, OP>);
+	    AggregateFunction::StateFinalize<STATE, RESULT_TYPE, OP>, AggregateFunction::UnaryUpdate<STATE, INPUT_TYPE, OP>,
+	    nullptr, AggregateFunction::StateDestroy<STATE, OP>);
 }
 
 template <bool DISCRETE>
 struct QuantileScalarOperation : public QuantileOperation {
 
-	template <class RESULT_TYPE, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, RESULT_TYPE *target,
-	                     ValidityMask &mask, idx_t idx) {
-		if (state->v.empty()) {
-			mask.SetInvalid(idx);
+	template <class T, class STATE>
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.v.empty()) {
+			finalize_data.ReturnNull();
 			return;
 		}
-		D_ASSERT(aggr_input_data.bind_data);
-		auto &bind_data = aggr_input_data.bind_data->Cast<QuantileBindData>();
+		D_ASSERT(finalize_data.input.bind_data);
+		auto &bind_data = finalize_data.input.bind_data->Cast<QuantileBindData>();
 		D_ASSERT(bind_data.quantiles.size() == 1);
-		Interpolator<DISCRETE> interp(bind_data.quantiles[0], state->v.size(), bind_data.desc);
-		target[idx] = interp.template Operation<typename STATE::SaveType, RESULT_TYPE>(state->v.data(), result);
+		Interpolator<DISCRETE> interp(bind_data.quantiles[0], state.v.size(), bind_data.desc);
+		target = interp.template Operation<typename STATE::SaveType, T>(state.v.data(), finalize_data.result);
 	}
 
 	template <class STATE, class INPUT_TYPE, class RESULT_TYPE>
 	static void Window(const INPUT_TYPE *data, const ValidityMask &fmask, const ValidityMask &dmask,
-	                   AggregateInputData &aggr_input_data, STATE *state, const FrameBounds &frame,
+	                   AggregateInputData &aggr_input_data, STATE &state, const FrameBounds &frame,
 	                   const FrameBounds &prev, Vector &result, idx_t ridx, idx_t bias) {
 		auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
 		auto &rmask = FlatVector::Validity(result);
@@ -556,10 +555,10 @@ struct QuantileScalarOperation : public QuantileOperation {
 		QuantileIncluded included(fmask, dmask, bias);
 
 		//  Lazily initialise frame state
-		auto prev_pos = state->pos;
-		state->SetPos(frame.second - frame.first);
+		auto prev_pos = state.pos;
+		state.SetPos(frame.second - frame.first);
 
-		auto index = state->w.data();
+		auto index = state.w.data();
 		D_ASSERT(index);
 
 		D_ASSERT(aggr_input_data.bind_data);
@@ -577,7 +576,7 @@ struct QuantileScalarOperation : public QuantileOperation {
 				Interpolator<DISCRETE> interp(q, prev_pos, false);
 				replace = CanReplace(index, data, j, interp.FRN, interp.CRN, included);
 				if (replace) {
-					state->pos = prev_pos;
+					state.pos = prev_pos;
 				}
 			}
 		} else {
@@ -586,10 +585,10 @@ struct QuantileScalarOperation : public QuantileOperation {
 
 		if (!replace && !included.AllValid()) {
 			// Remove the NULLs
-			state->pos = std::partition(index, index + state->pos, included) - index;
+			state.pos = std::partition(index, index + state.pos, included) - index;
 		}
-		if (state->pos) {
-			Interpolator<DISCRETE> interp(q, state->pos, false);
+		if (state.pos) {
+			Interpolator<DISCRETE> interp(q, state.pos, false);
 
 			using ID = QuantileIndirect<INPUT_TYPE>;
 			ID indirect(data);
@@ -661,43 +660,42 @@ AggregateFunction GetDiscreteQuantileAggregateFunction(const LogicalType &type) 
 template <class CHILD_TYPE, bool DISCRETE>
 struct QuantileListOperation : public QuantileOperation {
 
-	template <class RESULT_TYPE, class STATE>
-	static void Finalize(Vector &result_list, AggregateInputData &aggr_input_data, STATE *state, RESULT_TYPE *target,
-	                     ValidityMask &mask, idx_t idx) {
-		if (state->v.empty()) {
-			mask.SetInvalid(idx);
+	template <class T, class STATE>
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.v.empty()) {
+			finalize_data.ReturnNull();
 			return;
 		}
 
-		D_ASSERT(aggr_input_data.bind_data);
-		auto &bind_data = aggr_input_data.bind_data->Cast<QuantileBindData>();
+		D_ASSERT(finalize_data.input.bind_data);
+		auto &bind_data = finalize_data.input.bind_data->Cast<QuantileBindData>();
 
-		auto &result = ListVector::GetEntry(result_list);
-		auto ridx = ListVector::GetListSize(result_list);
-		ListVector::Reserve(result_list, ridx + bind_data.quantiles.size());
+		auto &result = ListVector::GetEntry(finalize_data.result);
+		auto ridx = ListVector::GetListSize(finalize_data.result);
+		ListVector::Reserve(finalize_data.result, ridx + bind_data.quantiles.size());
 		auto rdata = FlatVector::GetData<CHILD_TYPE>(result);
 
-		auto v_t = state->v.data();
+		auto v_t = state.v.data();
 		D_ASSERT(v_t);
 
-		auto &entry = target[idx];
+		auto &entry = target;
 		entry.offset = ridx;
 		idx_t lower = 0;
 		for (const auto &q : bind_data.order) {
 			const auto &quantile = bind_data.quantiles[q];
-			Interpolator<DISCRETE> interp(quantile, state->v.size(), bind_data.desc);
+			Interpolator<DISCRETE> interp(quantile, state.v.size(), bind_data.desc);
 			interp.begin = lower;
 			rdata[ridx + q] = interp.template Operation<typename STATE::SaveType, CHILD_TYPE>(v_t, result);
 			lower = interp.FRN;
 		}
 		entry.length = bind_data.quantiles.size();
 
-		ListVector::SetListSize(result_list, entry.offset + entry.length);
+		ListVector::SetListSize(finalize_data.result, entry.offset + entry.length);
 	}
 
 	template <class STATE, class INPUT_TYPE, class RESULT_TYPE>
 	static void Window(const INPUT_TYPE *data, const ValidityMask &fmask, const ValidityMask &dmask,
-	                   AggregateInputData &aggr_input_data, STATE *state, const FrameBounds &frame,
+	                   AggregateInputData &aggr_input_data, STATE &state, const FrameBounds &frame,
 	                   const FrameBounds &prev, Vector &list, idx_t lidx, idx_t bias) {
 		D_ASSERT(aggr_input_data.bind_data);
 		auto &bind_data = aggr_input_data.bind_data->Cast<QuantileBindData>();
@@ -717,10 +715,10 @@ struct QuantileListOperation : public QuantileOperation {
 		auto rdata = FlatVector::GetData<CHILD_TYPE>(result);
 
 		//  Lazily initialise frame state
-		auto prev_pos = state->pos;
-		state->SetPos(frame.second - frame.first);
+		auto prev_pos = state.pos;
+		state.SetPos(frame.second - frame.first);
 
-		auto index = state->w.data();
+		auto index = state.w.data();
 
 		// We can generalise replacement for quantile lists by observing that when a replacement is
 		// valid for a single quantile, it is valid for all quantiles greater/less than that quantile
@@ -728,7 +726,7 @@ struct QuantileListOperation : public QuantileOperation {
 		// So if a replaced index in an IQR is located between Q25 and Q50, but has a value below Q25,
 		// then Q25 must be recomputed, but Q50 and Q75 are unaffected.
 		// For a single element list, this reduces to the scalar case.
-		std::pair<idx_t, idx_t> replaceable {state->pos, 0};
+		std::pair<idx_t, idx_t> replaceable {state.pos, 0};
 		if (frame.first == prev.first + 1 && frame.second == prev.second + 1) {
 			//  Fixed frame size
 			const auto j = ReplaceIndex(index, frame, prev);
@@ -750,7 +748,7 @@ struct QuantileListOperation : public QuantileOperation {
 					}
 				}
 				if (replaceable.first < replaceable.second) {
-					state->pos = prev_pos;
+					state.pos = prev_pos;
 				}
 			}
 		} else {
@@ -759,15 +757,15 @@ struct QuantileListOperation : public QuantileOperation {
 
 		if (replaceable.first >= replaceable.second && !included.AllValid()) {
 			// Remove the NULLs
-			state->pos = std::partition(index, index + state->pos, included) - index;
+			state.pos = std::partition(index, index + state.pos, included) - index;
 		}
 
-		if (state->pos) {
+		if (state.pos) {
 			using ID = QuantileIndirect<INPUT_TYPE>;
 			ID indirect(data);
 			for (const auto &q : bind_data.order) {
 				const auto &quantile = bind_data.quantiles[q];
-				Interpolator<DISCRETE> interp(quantile, state->pos, false);
+				Interpolator<DISCRETE> interp(quantile, state.pos, false);
 				if (replaceable.first <= interp.FRN && interp.CRN <= replaceable.second) {
 					rdata[lentry.offset + q] = interp.template Replace<idx_t, CHILD_TYPE, ID>(index, result, indirect);
 				} else {
@@ -1035,24 +1033,23 @@ struct MadAccessor<dtime_t, interval_t, dtime_t> {
 template <typename MEDIAN_TYPE>
 struct MedianAbsoluteDeviationOperation : public QuantileOperation {
 
-	template <class RESULT_TYPE, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, RESULT_TYPE *target, ValidityMask &mask,
-	                     idx_t idx) {
-		if (state->v.empty()) {
-			mask.SetInvalid(idx);
+	template <class T, class STATE>
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.v.empty()) {
+			finalize_data.ReturnNull();
 			return;
 		}
 		using SAVE_TYPE = typename STATE::SaveType;
-		Interpolator<false> interp(0.5, state->v.size(), false);
-		const auto med = interp.template Operation<SAVE_TYPE, MEDIAN_TYPE>(state->v.data(), result);
+		Interpolator<false> interp(0.5, state.v.size(), false);
+		const auto med = interp.template Operation<SAVE_TYPE, MEDIAN_TYPE>(state.v.data(), finalize_data.result);
 
-		MadAccessor<SAVE_TYPE, RESULT_TYPE, MEDIAN_TYPE> accessor(med);
-		target[idx] = interp.template Operation<SAVE_TYPE, RESULT_TYPE>(state->v.data(), result, accessor);
+		MadAccessor<SAVE_TYPE, T, MEDIAN_TYPE> accessor(med);
+		target = interp.template Operation<SAVE_TYPE, T>(state.v.data(), finalize_data.result, accessor);
 	}
 
 	template <class STATE, class INPUT_TYPE, class RESULT_TYPE>
 	static void Window(const INPUT_TYPE *data, const ValidityMask &fmask, const ValidityMask &dmask,
-	                   AggregateInputData &, STATE *state, const FrameBounds &frame, const FrameBounds &prev,
+	                   AggregateInputData &, STATE &state, const FrameBounds &frame, const FrameBounds &prev,
 	                   Vector &result, idx_t ridx, idx_t bias) {
 		auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
 		auto &rmask = FlatVector::Validity(result);
@@ -1060,25 +1057,25 @@ struct MedianAbsoluteDeviationOperation : public QuantileOperation {
 		QuantileIncluded included(fmask, dmask, bias);
 
 		//  Lazily initialise frame state
-		auto prev_pos = state->pos;
-		state->SetPos(frame.second - frame.first);
+		auto prev_pos = state.pos;
+		state.SetPos(frame.second - frame.first);
 
-		auto index = state->w.data();
+		auto index = state.w.data();
 		D_ASSERT(index);
 
 		// We need a second index for the second pass.
-		if (state->pos > state->m.size()) {
-			state->m.resize(state->pos);
+		if (state.pos > state.m.size()) {
+			state.m.resize(state.pos);
 		}
 
-		auto index2 = state->m.data();
+		auto index2 = state.m.data();
 		D_ASSERT(index2);
 
 		// The replacement trick does not work on the second index because if
 		// the median has changed, the previous order is not correct.
 		// It is probably close, however, and so reuse is helpful.
 		ReuseIndexes(index2, frame, prev);
-		std::partition(index2, index2 + state->pos, included);
+		std::partition(index2, index2 + state.pos, included);
 
 		// Find the two positions needed for the median
 		const float q = 0.5;
@@ -1092,7 +1089,7 @@ struct MedianAbsoluteDeviationOperation : public QuantileOperation {
 				Interpolator<false> interp(q, prev_pos, false);
 				replace = CanReplace(index, data, j, interp.FRN, interp.CRN, included);
 				if (replace) {
-					state->pos = prev_pos;
+					state.pos = prev_pos;
 				}
 			}
 		} else {
@@ -1101,11 +1098,11 @@ struct MedianAbsoluteDeviationOperation : public QuantileOperation {
 
 		if (!replace && !included.AllValid()) {
 			// Remove the NULLs
-			state->pos = std::partition(index, index + state->pos, included) - index;
+			state.pos = std::partition(index, index + state.pos, included) - index;
 		}
 
-		if (state->pos) {
-			Interpolator<false> interp(q, state->pos, false);
+		if (state.pos) {
+			Interpolator<false> interp(q, state.pos, false);
 
 			// Compute or replace median from the first index
 			using ID = QuantileIndirect<INPUT_TYPE>;

--- a/src/core_functions/aggregate/holistic/quantile.cpp
+++ b/src/core_functions/aggregate/holistic/quantile.cpp
@@ -456,16 +456,15 @@ struct QuantileOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
-	                              ValidityMask &mask, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
-			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *data, ValidityMask &mask, idx_t idx) {
-		state.v.emplace_back(data[idx]);
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+		state.v.emplace_back(input);
 	}
 
 	template <class STATE, class OP>
@@ -485,39 +484,6 @@ struct QuantileOperation {
 		return true;
 	}
 };
-//
-// template <class STATE_TYPE, class RESULT_TYPE, class OP>
-// static void ExecuteListFinalize(Vector &states, AggregateInputData &aggr_input_data, Vector &result,
-//                                idx_t count, // NOLINT
-//                                idx_t offset) {
-//	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
-//
-//	D_ASSERT(aggr_input_data.bind_data);
-//	auto &bind_data = aggr_input_data.bind_data->Cast<QuantileBindData>();
-//
-//	if (states.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-//		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-//		ListVector::Reserve(result, bind_data.quantiles.size());
-//
-//		auto sdata = ConstantVector::GetData<STATE_TYPE *>(states);
-//		auto rdata = ConstantVector::GetData<RESULT_TYPE>(result);
-//		auto &mask = ConstantVector::Validity(result);
-//		OP::template Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[0], rdata, mask, 0);
-//	} else {
-//		D_ASSERT(states.GetVectorType() == VectorType::FLAT_VECTOR);
-//		result.SetVectorType(VectorType::FLAT_VECTOR);
-//		ListVector::Reserve(result, (offset + count) * bind_data.quantiles.size());
-//
-//		auto sdata = FlatVector::GetData<STATE_TYPE *>(states);
-//		auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
-//		auto &mask = FlatVector::Validity(result);
-//		for (idx_t i = 0; i < count; i++) {
-//			OP::template Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[i], rdata, mask, i + offset);
-//		}
-//	}
-//
-//	result.Verify(count);
-//}
 
 template <class STATE, class INPUT_TYPE, class RESULT_TYPE, class OP>
 static AggregateFunction QuantileListAggregate(const LogicalType &input_type, const LogicalType &child_type) { // NOLINT

--- a/src/core_functions/aggregate/holistic/reservoir_quantile.cpp
+++ b/src/core_functions/aggregate/holistic/reservoir_quantile.cpp
@@ -92,7 +92,8 @@ struct ReservoirQuantileOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}

--- a/src/core_functions/aggregate/holistic/reservoir_quantile.cpp
+++ b/src/core_functions/aggregate/holistic/reservoir_quantile.cpp
@@ -84,15 +84,15 @@ struct ReservoirQuantileBindData : public FunctionData {
 
 struct ReservoirQuantileOperation {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->v = nullptr;
-		state->len = 0;
-		state->pos = 0;
-		state->r_samp = nullptr;
+	static void Initialize(STATE &state) {
+		state.v = nullptr;
+		state.len = 0;
+		state.pos = 0;
+		state.r_samp = nullptr;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
+	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
 	                              ValidityMask &mask, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
@@ -100,44 +100,44 @@ struct ReservoirQuantileOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &aggr_input_data, const INPUT_TYPE *data, ValidityMask &mask,
+	static void Operation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *data, ValidityMask &mask,
 	                      idx_t idx) {
 		auto &bind_data = aggr_input_data.bind_data->template Cast<ReservoirQuantileBindData>();
-		if (state->pos == 0) {
-			state->Resize(bind_data.sample_size);
+		if (state.pos == 0) {
+			state.Resize(bind_data.sample_size);
 		}
-		if (!state->r_samp) {
-			state->r_samp = new BaseReservoirSampling();
+		if (!state.r_samp) {
+			state.r_samp = new BaseReservoirSampling();
 		}
-		D_ASSERT(state->v);
-		state->FillReservoir(bind_data.sample_size, data[idx]);
+		D_ASSERT(state.v);
+		state.FillReservoir(bind_data.sample_size, data[idx]);
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		if (source.pos == 0) {
 			return;
 		}
-		if (target->pos == 0) {
-			target->Resize(source.len);
+		if (target.pos == 0) {
+			target.Resize(source.len);
 		}
-		if (!target->r_samp) {
-			target->r_samp = new BaseReservoirSampling();
+		if (!target.r_samp) {
+			target.r_samp = new BaseReservoirSampling();
 		}
 		for (idx_t src_idx = 0; src_idx < source.pos; src_idx++) {
-			target->FillReservoir(target->len, source.v[src_idx]);
+			target.FillReservoir(target.len, source.v[src_idx]);
 		}
 	}
 
 	template <class STATE>
-	static void Destroy(AggregateInputData &aggr_input_data, STATE *state) {
-		if (state->v) {
-			free(state->v);
-			state->v = nullptr;
+	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
+		if (state.v) {
+			free(state.v);
+			state.v = nullptr;
 		}
-		if (state->r_samp) {
-			delete state->r_samp;
-			state->r_samp = nullptr;
+		if (state.r_samp) {
+			delete state.r_samp;
+			state.r_samp = nullptr;
 		}
 	}
 
@@ -147,21 +147,20 @@ struct ReservoirQuantileOperation {
 };
 
 struct ReservoirQuantileScalarOperation : public ReservoirQuantileOperation {
-	template <class TARGET_TYPE, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, TARGET_TYPE *target,
-	                     ValidityMask &mask, idx_t idx) {
-		if (state->pos == 0) {
-			mask.SetInvalid(idx);
+	template <class T, class STATE>
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.pos == 0) {
+			finalize_data.ReturnNull();
 			return;
 		}
-		D_ASSERT(state->v);
-		D_ASSERT(aggr_input_data.bind_data);
-		auto &bind_data = aggr_input_data.bind_data->template Cast<ReservoirQuantileBindData>();
-		auto v_t = state->v;
+		D_ASSERT(state.v);
+		D_ASSERT(finalize_data.input.bind_data);
+		auto &bind_data = finalize_data.input.bind_data->template Cast<ReservoirQuantileBindData>();
+		auto v_t = state.v;
 		D_ASSERT(bind_data.quantiles.size() == 1);
-		auto offset = (idx_t)((double)(state->pos - 1) * bind_data.quantiles[0]);
-		std::nth_element(v_t, v_t + offset, v_t + state->pos);
-		target[idx] = v_t[offset];
+		auto offset = (idx_t)((double)(state.pos - 1) * bind_data.quantiles[0]);
+		std::nth_element(v_t, v_t + offset, v_t + state.pos);
+		target = v_t[offset];
 	}
 };
 
@@ -206,70 +205,67 @@ AggregateFunction GetReservoirQuantileAggregateFunction(PhysicalType type) {
 
 template <class CHILD_TYPE>
 struct ReservoirQuantileListOperation : public ReservoirQuantileOperation {
-
-	template <class RESULT_TYPE, class STATE>
-	static void Finalize(Vector &result_list, AggregateInputData &aggr_input_data, STATE *state, RESULT_TYPE *target,
-	                     ValidityMask &mask, idx_t idx) {
-		if (state->pos == 0) {
-			mask.SetInvalid(idx);
+	template <class T, class STATE>
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.pos == 0) {
+			finalize_data.ReturnNull();
 			return;
 		}
 
-		D_ASSERT(aggr_input_data.bind_data);
-		auto &bind_data = aggr_input_data.bind_data->template Cast<ReservoirQuantileBindData>();
+		D_ASSERT(finalize_data.input.bind_data);
+		auto &bind_data = finalize_data.input.bind_data->template Cast<ReservoirQuantileBindData>();
 
-		auto &result = ListVector::GetEntry(result_list);
-		auto ridx = ListVector::GetListSize(result_list);
-		ListVector::Reserve(result_list, ridx + bind_data.quantiles.size());
+		auto &result = ListVector::GetEntry(finalize_data.result);
+		auto ridx = ListVector::GetListSize(finalize_data.result);
+		ListVector::Reserve(finalize_data.result, ridx + bind_data.quantiles.size());
 		auto rdata = FlatVector::GetData<CHILD_TYPE>(result);
 
-		auto v_t = state->v;
+		auto v_t = state.v;
 		D_ASSERT(v_t);
 
-		auto &entry = target[idx];
+		auto &entry = target;
 		entry.offset = ridx;
 		entry.length = bind_data.quantiles.size();
 		for (size_t q = 0; q < entry.length; ++q) {
 			const auto &quantile = bind_data.quantiles[q];
-			auto offset = (idx_t)((double)(state->pos - 1) * quantile);
-			std::nth_element(v_t, v_t + offset, v_t + state->pos);
+			auto offset = (idx_t)((double)(state.pos - 1) * quantile);
+			std::nth_element(v_t, v_t + offset, v_t + state.pos);
 			rdata[ridx + q] = v_t[offset];
 		}
 
-		ListVector::SetListSize(result_list, entry.offset + entry.length);
+		ListVector::SetListSize(finalize_data.result, entry.offset + entry.length);
 	}
-
-	template <class STATE_TYPE, class RESULT_TYPE>
-	static void FinalizeList(Vector &states, AggregateInputData &aggr_input_data, Vector &result, idx_t count, // NOLINT
-	                         idx_t offset) {
-		D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
-
-		D_ASSERT(aggr_input_data.bind_data);
-		auto &bind_data = aggr_input_data.bind_data->Cast<ReservoirQuantileBindData>();
-
-		if (states.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ListVector::Reserve(result, bind_data.quantiles.size());
-
-			auto sdata = ConstantVector::GetData<STATE_TYPE *>(states);
-			auto rdata = ConstantVector::GetData<RESULT_TYPE>(result);
-			auto &mask = ConstantVector::Validity(result);
-			Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[0], rdata, mask, 0);
-		} else {
-			D_ASSERT(states.GetVectorType() == VectorType::FLAT_VECTOR);
-			result.SetVectorType(VectorType::FLAT_VECTOR);
-			ListVector::Reserve(result, (offset + count) * bind_data.quantiles.size());
-
-			auto sdata = FlatVector::GetData<STATE_TYPE *>(states);
-			auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
-			auto &mask = FlatVector::Validity(result);
-			for (idx_t i = 0; i < count; i++) {
-				Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[i], rdata, mask, i + offset);
-			}
-		}
-
-		result.Verify(count);
-	}
+	//
+	//	template <class STATE_TYPE, class RESULT_TYPE>
+	//	static void FinalizeList(Vector &states, AggregateInputData &aggr_input_data, Vector &result, idx_t count, //
+	//NOLINT 	                         idx_t offset) { 		D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
+	//
+	//		D_ASSERT(aggr_input_data.bind_data);
+	//		auto &bind_data = aggr_input_data.bind_data->Cast<ReservoirQuantileBindData>();
+	//
+	//		if (states.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+	//			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	//			ListVector::Reserve(result, bind_data.quantiles.size());
+	//
+	//			auto sdata = ConstantVector::GetData<STATE_TYPE *>(states);
+	//			auto rdata = ConstantVector::GetData<RESULT_TYPE>(result);
+	//			auto &mask = ConstantVector::Validity(result);
+	//			Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[0], rdata, mask, 0);
+	//		} else {
+	//			D_ASSERT(states.GetVectorType() == VectorType::FLAT_VECTOR);
+	//			result.SetVectorType(VectorType::FLAT_VECTOR);
+	//			ListVector::Reserve(result, (offset + count) * bind_data.quantiles.size());
+	//
+	//			auto sdata = FlatVector::GetData<STATE_TYPE *>(states);
+	//			auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
+	//			auto &mask = FlatVector::Validity(result);
+	//			for (idx_t i = 0; i < count; i++) {
+	//				Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[i], rdata, mask, i + offset);
+	//			}
+	//		}
+	//
+	//		result.Verify(count);
+	//	}
 };
 
 template <class STATE, class INPUT_TYPE, class RESULT_TYPE, class OP>
@@ -278,8 +274,8 @@ static AggregateFunction ReservoirQuantileListAggregate(const LogicalType &input
 	return AggregateFunction(
 	    {input_type}, result_type, AggregateFunction::StateSize<STATE>, AggregateFunction::StateInitialize<STATE, OP>,
 	    AggregateFunction::UnaryScatterUpdate<STATE, INPUT_TYPE, OP>, AggregateFunction::StateCombine<STATE, OP>,
-	    OP::template FinalizeList<STATE, RESULT_TYPE>, AggregateFunction::UnaryUpdate<STATE, INPUT_TYPE, OP>, nullptr,
-	    AggregateFunction::StateDestroy<STATE, OP>);
+	    AggregateFunction::StateFinalize<STATE, RESULT_TYPE, OP>, AggregateFunction::UnaryUpdate<STATE, INPUT_TYPE, OP>,
+	    nullptr, AggregateFunction::StateDestroy<STATE, OP>);
 }
 
 template <typename INPUT_TYPE, typename SAVE_TYPE>

--- a/src/core_functions/aggregate/regression/regr_avg.cpp
+++ b/src/core_functions/aggregate/regression/regr_avg.cpp
@@ -12,23 +12,23 @@ struct RegrState {
 
 struct RegrAvgFunction {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->sum = 0;
-		state->count = 0;
+	static void Initialize(STATE &state) {
+		state.sum = 0;
+		state.count = 0;
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
-		target->sum += source.sum;
-		target->count += source.count;
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+		target.sum += source.sum;
+		target.count += source.count;
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (state->count == 0) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.count == 0) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = state->sum / (double)state->count;
+			target = state.sum / (double)state.count;
 		}
 	}
 	static bool IgnoreNull() {
@@ -37,19 +37,19 @@ struct RegrAvgFunction {
 };
 struct RegrAvgXFunction : RegrAvgFunction {
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const A_TYPE *x_data, const B_TYPE *y_data,
+	static void Operation(STATE &state, AggregateInputData &, const A_TYPE *x_data, const B_TYPE *y_data,
 	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
-		state->sum += y_data[yidx];
-		state->count++;
+		state.sum += y_data[yidx];
+		state.count++;
 	}
 };
 
 struct RegrAvgYFunction : RegrAvgFunction {
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const A_TYPE *x_data, const B_TYPE *y_data,
+	static void Operation(STATE &state, AggregateInputData &, const A_TYPE *x_data, const B_TYPE *y_data,
 	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
-		state->sum += x_data[xidx];
-		state->count++;
+		state.sum += x_data[xidx];
+		state.count++;
 	}
 };
 

--- a/src/core_functions/aggregate/regression/regr_avg.cpp
+++ b/src/core_functions/aggregate/regression/regr_avg.cpp
@@ -37,18 +37,16 @@ struct RegrAvgFunction {
 };
 struct RegrAvgXFunction : RegrAvgFunction {
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const A_TYPE *x_data, const B_TYPE *y_data,
-	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
-		state.sum += y_data[yidx];
+	static void Operation(STATE &state, const A_TYPE &x, const B_TYPE &y, AggregateBinaryInput &idata) {
+		state.sum += y;
 		state.count++;
 	}
 };
 
 struct RegrAvgYFunction : RegrAvgFunction {
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const A_TYPE *x_data, const B_TYPE *y_data,
-	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
-		state.sum += x_data[xidx];
+	static void Operation(STATE &state, const A_TYPE &x, const B_TYPE &y, AggregateBinaryInput &idata) {
+		state.sum += x;
 		state.count++;
 	}
 };

--- a/src/core_functions/aggregate/regression/regr_intercept.cpp
+++ b/src/core_functions/aggregate/regression/regr_intercept.cpp
@@ -23,13 +23,11 @@ struct RegrInterceptOperation {
 	}
 
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
-	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+	static void Operation(STATE &state, const A_TYPE &x, const B_TYPE &y, AggregateBinaryInput &idata) {
 		state.count++;
-		state.sum_x += y_data[yidx];
-		state.sum_y += x_data[xidx];
-		RegrSlopeOperation::Operation<A_TYPE, B_TYPE, RegrSlopeState, OP>(state.slope, aggr_input_data, x_data, y_data,
-		                                                                  amask, bmask, xidx, yidx);
+		state.sum_x += y;
+		state.sum_y += x;
+		RegrSlopeOperation::Operation<A_TYPE, B_TYPE, RegrSlopeState, OP>(state.slope, x, y, idata);
 	}
 
 	template <class STATE, class OP>

--- a/src/core_functions/aggregate/regression/regr_intercept.cpp
+++ b/src/core_functions/aggregate/regression/regr_intercept.cpp
@@ -15,42 +15,41 @@ struct RegrInterceptState {
 
 struct RegrInterceptOperation {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->count = 0;
-		state->sum_x = 0;
-		state->sum_y = 0;
-		RegrSlopeOperation::Initialize<RegrSlopeState>(&state->slope);
+	static void Initialize(STATE &state) {
+		state.count = 0;
+		state.sum_x = 0;
+		state.sum_y = 0;
+		RegrSlopeOperation::Initialize<RegrSlopeState>(state.slope);
 	}
 
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
+	static void Operation(STATE &state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
 	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
-		state->count++;
-		state->sum_x += y_data[yidx];
-		state->sum_y += x_data[xidx];
-		RegrSlopeOperation::Operation<A_TYPE, B_TYPE, RegrSlopeState, OP>(&state->slope, aggr_input_data, x_data,
-		                                                                  y_data, amask, bmask, xidx, yidx);
+		state.count++;
+		state.sum_x += y_data[yidx];
+		state.sum_y += x_data[xidx];
+		RegrSlopeOperation::Operation<A_TYPE, B_TYPE, RegrSlopeState, OP>(state.slope, aggr_input_data, x_data, y_data,
+		                                                                  amask, bmask, xidx, yidx);
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &aggr_input_data) {
-		target->count += source.count;
-		target->sum_x += source.sum_x;
-		target->sum_y += source.sum_y;
-		RegrSlopeOperation::Combine<RegrSlopeState, OP>(source.slope, &target->slope, aggr_input_data);
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input_data) {
+		target.count += source.count;
+		target.sum_x += source.sum_x;
+		target.sum_y += source.sum_y;
+		RegrSlopeOperation::Combine<RegrSlopeState, OP>(source.slope, target.slope, aggr_input_data);
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, T *target,
-	                     ValidityMask &mask, idx_t idx) {
-		if (state->count == 0) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.count == 0) {
+			finalize_data.ReturnNull();
 			return;
 		}
-		RegrSlopeOperation::Finalize<T, RegrSlopeState>(result, aggr_input_data, &state->slope, target, mask, idx);
-		auto x_avg = state->sum_x / state->count;
-		auto y_avg = state->sum_y / state->count;
-		target[idx] = y_avg - target[idx] * x_avg;
+		RegrSlopeOperation::Finalize<T, RegrSlopeState>(state.slope, target, finalize_data);
+		auto x_avg = state.sum_x / state.count;
+		auto y_avg = state.sum_y / state.count;
+		target = y_avg - target * x_avg;
 	}
 
 	static bool IgnoreNull() {

--- a/src/core_functions/aggregate/regression/regr_r2.cpp
+++ b/src/core_functions/aggregate/regression/regr_r2.cpp
@@ -17,51 +17,48 @@ struct RegrR2State {
 
 struct RegrR2Operation {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		CorrOperation::Initialize<CorrState>(&state->corr);
-		STDDevBaseOperation::Initialize<StddevState>(&state->var_pop_x);
-		STDDevBaseOperation::Initialize<StddevState>(&state->var_pop_y);
+	static void Initialize(STATE &state) {
+		CorrOperation::Initialize<CorrState>(state.corr);
+		STDDevBaseOperation::Initialize<StddevState>(state.var_pop_x);
+		STDDevBaseOperation::Initialize<StddevState>(state.var_pop_y);
 	}
 
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
+	static void Operation(STATE &state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
 	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
-		CorrOperation::Operation<A_TYPE, B_TYPE, CorrState, OP>(&state->corr, aggr_input_data, y_data, x_data, bmask,
+		CorrOperation::Operation<A_TYPE, B_TYPE, CorrState, OP>(state.corr, aggr_input_data, y_data, x_data, bmask,
 		                                                        amask, yidx, xidx);
-		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(&state->var_pop_x, aggr_input_data, y_data, bmask,
-		                                                        yidx);
-		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(&state->var_pop_y, aggr_input_data, x_data, amask,
-		                                                        xidx);
+		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(state.var_pop_x, aggr_input_data, y_data, bmask, yidx);
+		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(state.var_pop_y, aggr_input_data, x_data, amask, xidx);
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &aggr_input_data) {
-		CorrOperation::Combine<CorrState, OP>(source.corr, &target->corr, aggr_input_data);
-		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop_x, &target->var_pop_x, aggr_input_data);
-		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop_y, &target->var_pop_y, aggr_input_data);
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input_data) {
+		CorrOperation::Combine<CorrState, OP>(source.corr, target.corr, aggr_input_data);
+		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop_x, target.var_pop_x, aggr_input_data);
+		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop_y, target.var_pop_y, aggr_input_data);
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, T *target,
-	                     ValidityMask &mask, idx_t idx) {
-		auto var_pop_x = state->var_pop_x.count > 1 ? (state->var_pop_x.dsquared / state->var_pop_x.count) : 0;
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		auto var_pop_x = state.var_pop_x.count > 1 ? (state.var_pop_x.dsquared / state.var_pop_x.count) : 0;
 		if (!Value::DoubleIsFinite(var_pop_x)) {
 			throw OutOfRangeException("VARPOP(X) is out of range!");
 		}
 		if (var_pop_x == 0) {
-			mask.SetInvalid(idx);
+			finalize_data.ReturnNull();
 			return;
 		}
-		auto var_pop_y = state->var_pop_y.count > 1 ? (state->var_pop_y.dsquared / state->var_pop_y.count) : 0;
+		auto var_pop_y = state.var_pop_y.count > 1 ? (state.var_pop_y.dsquared / state.var_pop_y.count) : 0;
 		if (!Value::DoubleIsFinite(var_pop_y)) {
 			throw OutOfRangeException("VARPOP(Y) is out of range!");
 		}
 		if (var_pop_y == 0) {
-			target[idx] = 1;
+			target = 1;
 			return;
 		}
-		CorrOperation::Finalize<T, CorrState>(result, aggr_input_data, &state->corr, target, mask, idx);
-		target[idx] = pow(target[idx], 2);
+		CorrOperation::Finalize<T, CorrState>(state.corr, target, finalize_data);
+		target = pow(target, 2);
 	}
 
 	static bool IgnoreNull() {

--- a/src/core_functions/aggregate/regression/regr_r2.cpp
+++ b/src/core_functions/aggregate/regression/regr_r2.cpp
@@ -28,8 +28,8 @@ struct RegrR2Operation {
 	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
 		CorrOperation::Operation<A_TYPE, B_TYPE, CorrState, OP>(state.corr, aggr_input_data, y_data, x_data, bmask,
 		                                                        amask, yidx, xidx);
-		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(state.var_pop_x, aggr_input_data, y_data, bmask, yidx);
-		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(state.var_pop_y, aggr_input_data, x_data, amask, xidx);
+		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.var_pop_x, y_data[yidx]);
+		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.var_pop_y, x_data[xidx]);
 	}
 
 	template <class STATE, class OP>

--- a/src/core_functions/aggregate/regression/regr_r2.cpp
+++ b/src/core_functions/aggregate/regression/regr_r2.cpp
@@ -24,12 +24,10 @@ struct RegrR2Operation {
 	}
 
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
-	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
-		CorrOperation::Operation<A_TYPE, B_TYPE, CorrState, OP>(state.corr, aggr_input_data, y_data, x_data, bmask,
-		                                                        amask, yidx, xidx);
-		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.var_pop_x, y_data[yidx]);
-		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.var_pop_y, x_data[xidx]);
+	static void Operation(STATE &state, const A_TYPE &x, const B_TYPE &y, AggregateBinaryInput &idata) {
+		CorrOperation::Operation<A_TYPE, B_TYPE, CorrState, OP>(state.corr, x, y, idata);
+		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.var_pop_x, y);
+		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.var_pop_y, x);
 	}
 
 	template <class STATE, class OP>

--- a/src/core_functions/aggregate/regression/regr_sxx_syy.cpp
+++ b/src/core_functions/aggregate/regression/regr_sxx_syy.cpp
@@ -52,7 +52,7 @@ struct RegrSXXOperation : RegrBaseOperation {
 	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
 		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(state.count, aggr_input_data, y_data, x_data, bmask,
 		                                                         amask, yidx, xidx);
-		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(state.var_pop, aggr_input_data, y_data, bmask, yidx);
+		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.var_pop, y_data[yidx]);
 	}
 };
 
@@ -62,7 +62,7 @@ struct RegrSYYOperation : RegrBaseOperation {
 	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
 		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(state.count, aggr_input_data, y_data, x_data, bmask,
 		                                                         amask, yidx, xidx);
-		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(state.var_pop, aggr_input_data, x_data, bmask, xidx);
+		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.var_pop, x_data[xidx]);
 	}
 };
 

--- a/src/core_functions/aggregate/regression/regr_sxx_syy.cpp
+++ b/src/core_functions/aggregate/regression/regr_sxx_syy.cpp
@@ -16,30 +16,29 @@ struct RegrSState {
 
 struct RegrBaseOperation {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		RegrCountFunction::Initialize<size_t>(&state->count);
-		STDDevBaseOperation::Initialize<StddevState>(&state->var_pop);
+	static void Initialize(STATE &state) {
+		RegrCountFunction::Initialize<size_t>(state.count);
+		STDDevBaseOperation::Initialize<StddevState>(state.var_pop);
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &aggr_input_data) {
-		RegrCountFunction::Combine<size_t, OP>(source.count, &target->count, aggr_input_data);
-		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop, &target->var_pop, aggr_input_data);
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input_data) {
+		RegrCountFunction::Combine<size_t, OP>(source.count, target.count, aggr_input_data);
+		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop, target.var_pop, aggr_input_data);
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, T *target,
-	                     ValidityMask &mask, idx_t idx) {
-		if (state->var_pop.count == 0) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.var_pop.count == 0) {
+			finalize_data.ReturnNull();
 			return;
 		}
-		auto var_pop = state->var_pop.count > 1 ? (state->var_pop.dsquared / state->var_pop.count) : 0;
+		auto var_pop = state.var_pop.count > 1 ? (state.var_pop.dsquared / state.var_pop.count) : 0;
 		if (!Value::DoubleIsFinite(var_pop)) {
 			throw OutOfRangeException("VARPOP is out of range!");
 		}
-		RegrCountFunction::Finalize<T, size_t>(result, aggr_input_data, &state->count, target, mask, idx);
-		target[idx] *= var_pop;
+		RegrCountFunction::Finalize<T, size_t>(state.count, target, finalize_data);
+		target *= var_pop;
 	}
 
 	static bool IgnoreNull() {
@@ -49,21 +48,21 @@ struct RegrBaseOperation {
 
 struct RegrSXXOperation : RegrBaseOperation {
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
+	static void Operation(STATE &state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
 	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
-		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(&state->count, aggr_input_data, y_data, x_data, bmask,
+		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(state.count, aggr_input_data, y_data, x_data, bmask,
 		                                                         amask, yidx, xidx);
-		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(&state->var_pop, aggr_input_data, y_data, bmask, yidx);
+		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(state.var_pop, aggr_input_data, y_data, bmask, yidx);
 	}
 };
 
 struct RegrSYYOperation : RegrBaseOperation {
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
+	static void Operation(STATE &state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
 	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
-		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(&state->count, aggr_input_data, y_data, x_data, bmask,
+		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(state.count, aggr_input_data, y_data, x_data, bmask,
 		                                                         amask, yidx, xidx);
-		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(&state->var_pop, aggr_input_data, x_data, bmask, xidx);
+		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(state.var_pop, aggr_input_data, x_data, bmask, xidx);
 	}
 };
 

--- a/src/core_functions/aggregate/regression/regr_sxx_syy.cpp
+++ b/src/core_functions/aggregate/regression/regr_sxx_syy.cpp
@@ -48,21 +48,17 @@ struct RegrBaseOperation {
 
 struct RegrSXXOperation : RegrBaseOperation {
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
-	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
-		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(state.count, aggr_input_data, y_data, x_data, bmask,
-		                                                         amask, yidx, xidx);
-		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.var_pop, y_data[yidx]);
+	static void Operation(STATE &state, const A_TYPE &x, const B_TYPE &y, AggregateBinaryInput &idata) {
+		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(state.count, x, y, idata);
+		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.var_pop, y);
 	}
 };
 
 struct RegrSYYOperation : RegrBaseOperation {
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
-	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
-		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(state.count, aggr_input_data, y_data, x_data, bmask,
-		                                                         amask, yidx, xidx);
-		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.var_pop, x_data[xidx]);
+	static void Operation(STATE &state, const A_TYPE &x, const B_TYPE &y, AggregateBinaryInput &idata) {
+		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(state.count, x, y, idata);
+		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.var_pop, x);
 	}
 };
 

--- a/src/core_functions/aggregate/regression/regr_sxy.cpp
+++ b/src/core_functions/aggregate/regression/regr_sxy.cpp
@@ -14,33 +14,32 @@ struct RegrSXyState {
 
 struct RegrSXYOperation {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		RegrCountFunction::Initialize<size_t>(&state->count);
-		CovarOperation::Initialize<CovarState>(&state->cov_pop);
+	static void Initialize(STATE &state) {
+		RegrCountFunction::Initialize<size_t>(state.count);
+		CovarOperation::Initialize<CovarState>(state.cov_pop);
 	}
 
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
+	static void Operation(STATE &state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
 	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
-		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(&state->count, aggr_input_data, y_data, x_data, bmask,
+		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(state.count, aggr_input_data, y_data, x_data, bmask,
 		                                                         amask, yidx, xidx);
-		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(&state->cov_pop, aggr_input_data, x_data, y_data,
-		                                                          amask, bmask, xidx, yidx);
+		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(state.cov_pop, aggr_input_data, x_data, y_data, amask,
+		                                                          bmask, xidx, yidx);
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &aggr_input_data) {
-		CovarOperation::Combine<CovarState, OP>(source.cov_pop, &target->cov_pop, aggr_input_data);
-		RegrCountFunction::Combine<size_t, OP>(source.count, &target->count, aggr_input_data);
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input_data) {
+		CovarOperation::Combine<CovarState, OP>(source.cov_pop, target.cov_pop, aggr_input_data);
+		RegrCountFunction::Combine<size_t, OP>(source.count, target.count, aggr_input_data);
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, T *target,
-	                     ValidityMask &mask, idx_t idx) {
-		CovarPopOperation::Finalize<T, CovarState>(result, aggr_input_data, &state->cov_pop, target, mask, idx);
-		auto cov_pop = target[idx];
-		RegrCountFunction::Finalize<T, size_t>(result, aggr_input_data, &state->count, target, mask, idx);
-		target[idx] *= cov_pop;
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		CovarPopOperation::Finalize<T, CovarState>(state.cov_pop, target, finalize_data);
+		auto cov_pop = target;
+		RegrCountFunction::Finalize<T, size_t>(state.count, target, finalize_data);
+		target *= cov_pop;
 	}
 
 	static bool IgnoreNull() {

--- a/src/core_functions/aggregate/regression/regr_sxy.cpp
+++ b/src/core_functions/aggregate/regression/regr_sxy.cpp
@@ -20,12 +20,9 @@ struct RegrSXYOperation {
 	}
 
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
-	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
-		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(state.count, aggr_input_data, y_data, x_data, bmask,
-		                                                         amask, yidx, xidx);
-		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(state.cov_pop, aggr_input_data, x_data, y_data, amask,
-		                                                          bmask, xidx, yidx);
+	static void Operation(STATE &state, const A_TYPE &x, const B_TYPE &y, AggregateBinaryInput &idata) {
+		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(state.count, x, y, idata);
+		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(state.cov_pop, x, y, idata);
 	}
 
 	template <class STATE, class OP>

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -125,15 +125,7 @@ struct CountFunction : public BaseCountFunction {
 	static void CountScatter(Vector inputs[], AggregateInputData &aggr_input_data, idx_t input_count, Vector &states,
 	                         idx_t count) {
 		auto &input = inputs[0];
-		if (input.GetVectorType() == VectorType::CONSTANT_VECTOR &&
-		    states.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-			if (ConstantVector::IsNull(input)) {
-				return;
-			}
-			auto sdata = ConstantVector::GetData<STATE *>(states);
-			*sdata += count;
-		} else if (input.GetVectorType() == VectorType::FLAT_VECTOR &&
-		           states.GetVectorType() == VectorType::FLAT_VECTOR) {
+		if (input.GetVectorType() == VectorType::FLAT_VECTOR && states.GetVectorType() == VectorType::FLAT_VECTOR) {
 			auto sdata = FlatVector::GetData<STATE *>(states);
 			CountFlatLoop(sdata, FlatVector::Validity(input), count);
 		} else {

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -122,16 +122,18 @@ struct CountFunction : public BaseCountFunction {
 		}
 	}
 
-	static void CountScatter(Vector inputs[], AggregateInputData &aggr_input_data, idx_t input_count,
-									   Vector &states, idx_t count) {
+	static void CountScatter(Vector inputs[], AggregateInputData &aggr_input_data, idx_t input_count, Vector &states,
+	                         idx_t count) {
 		auto &input = inputs[0];
-		if (input.GetVectorType() == VectorType::CONSTANT_VECTOR && states.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		if (input.GetVectorType() == VectorType::CONSTANT_VECTOR &&
+		    states.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			if (ConstantVector::IsNull(input)) {
 				return;
 			}
 			auto sdata = ConstantVector::GetData<STATE *>(states);
 			*sdata += count;
-		} else if (input.GetVectorType() == VectorType::FLAT_VECTOR && states.GetVectorType() == VectorType::FLAT_VECTOR) {
+		} else if (input.GetVectorType() == VectorType::FLAT_VECTOR &&
+		           states.GetVectorType() == VectorType::FLAT_VECTOR) {
 			auto sdata = FlatVector::GetData<STATE *>(states);
 			CountFlatLoop(sdata, FlatVector::Validity(input), count);
 		} else {
@@ -168,7 +170,8 @@ struct CountFunction : public BaseCountFunction {
 		}
 	}
 
-	static inline void CountUpdateLoop(STATE &result, ValidityMask &mask, idx_t count, const SelectionVector &sel_vector) {
+	static inline void CountUpdateLoop(STATE &result, ValidityMask &mask, idx_t count,
+	                                   const SelectionVector &sel_vector) {
 		if (mask.AllValid()) {
 			// no NULL values
 			result += count;
@@ -213,11 +216,11 @@ struct CountFunction : public BaseCountFunction {
 };
 
 AggregateFunction CountFun::GetFunction() {
-	AggregateFunction fun(
-		    {LogicalType(LogicalTypeId::ANY)}, LogicalType::BIGINT, AggregateFunction::StateSize<int64_t>,
-		    AggregateFunction::StateInitialize<int64_t, CountFunction>, CountFunction::CountScatter,
-		    AggregateFunction::StateCombine<int64_t, CountFunction>, AggregateFunction::StateFinalize<int64_t, int64_t, CountFunction>,
-		    FunctionNullHandling::SPECIAL_HANDLING, CountFunction::CountUpdate);
+	AggregateFunction fun({LogicalType(LogicalTypeId::ANY)}, LogicalType::BIGINT, AggregateFunction::StateSize<int64_t>,
+	                      AggregateFunction::StateInitialize<int64_t, CountFunction>, CountFunction::CountScatter,
+	                      AggregateFunction::StateCombine<int64_t, CountFunction>,
+	                      AggregateFunction::StateFinalize<int64_t, int64_t, CountFunction>,
+	                      FunctionNullHandling::SPECIAL_HANDLING, CountFunction::CountUpdate);
 	fun.name = "count";
 	fun.order_dependent = AggregateOrderDependent::NOT_ORDER_DEPENDENT;
 	return fun;

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -7,30 +7,30 @@ namespace duckdb {
 
 struct BaseCountFunction {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		*state = 0;
+	static void Initialize(STATE &state) {
+		state = 0;
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
-		*target += source;
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+		target += source;
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		target[idx] = *state;
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		target = state;
 	}
 };
 
 struct CountStarFunction : public BaseCountFunction {
 	template <class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, idx_t idx) {
-		*state += 1;
+	static void Operation(STATE &state, AggregateInputData &, idx_t idx) {
+		state += 1;
 	}
 
 	template <class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &, idx_t count) {
-		*state += count;
+	static void ConstantOperation(STATE &state, AggregateInputData &, idx_t count) {
+		state += count;
 	}
 
 	template <typename RESULT_TYPE>
@@ -56,14 +56,14 @@ struct CountStarFunction : public BaseCountFunction {
 
 struct CountFunction : public BaseCountFunction {
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
-		*state += 1;
+	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		state += 1;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask,
+	static void ConstantOperation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask,
 	                              idx_t count) {
-		*state += count;
+		state += count;
 	}
 
 	static bool IgnoreNull() {

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -55,27 +55,170 @@ struct CountStarFunction : public BaseCountFunction {
 };
 
 struct CountFunction : public BaseCountFunction {
-	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+	using STATE = int64_t;
+
+	static void Operation(STATE &state) {
 		state += 1;
 	}
 
-	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask,
-	                              idx_t count) {
+	static void ConstantOperation(STATE &state, idx_t count) {
 		state += count;
 	}
 
 	static bool IgnoreNull() {
 		return true;
 	}
+
+	static inline void CountFlatLoop(STATE **__restrict states, ValidityMask &mask, idx_t count) {
+		if (!mask.AllValid()) {
+			idx_t base_idx = 0;
+			auto entry_count = ValidityMask::EntryCount(count);
+			for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx++) {
+				auto validity_entry = mask.GetValidityEntry(entry_idx);
+				idx_t next = MinValue<idx_t>(base_idx + ValidityMask::BITS_PER_VALUE, count);
+				if (ValidityMask::AllValid(validity_entry)) {
+					// all valid: perform operation
+					for (; base_idx < next; base_idx++) {
+						CountFunction::Operation(*states[base_idx]);
+					}
+				} else if (ValidityMask::NoneValid(validity_entry)) {
+					// nothing valid: skip all
+					base_idx = next;
+					continue;
+				} else {
+					// partially valid: need to check individual elements for validity
+					idx_t start = base_idx;
+					for (; base_idx < next; base_idx++) {
+						if (ValidityMask::RowIsValid(validity_entry, base_idx - start)) {
+							CountFunction::Operation(*states[base_idx]);
+						}
+					}
+				}
+			}
+		} else {
+			for (idx_t i = 0; i < count; i++) {
+				CountFunction::Operation(*states[i]);
+			}
+		}
+	}
+
+	static inline void CountScatterLoop(STATE **__restrict states, const SelectionVector &isel,
+	                                    const SelectionVector &ssel, ValidityMask &mask, idx_t count) {
+		if (!mask.AllValid()) {
+			// potential NULL values
+			for (idx_t i = 0; i < count; i++) {
+				auto idx = isel.get_index(i);
+				auto sidx = ssel.get_index(i);
+				if (mask.RowIsValid(idx)) {
+					CountFunction::Operation(*states[sidx]);
+				}
+			}
+		} else {
+			// quick path: no NULL values
+			for (idx_t i = 0; i < count; i++) {
+				auto sidx = ssel.get_index(i);
+				CountFunction::Operation(*states[sidx]);
+			}
+		}
+	}
+
+	static void CountScatter(Vector inputs[], AggregateInputData &aggr_input_data, idx_t input_count,
+									   Vector &states, idx_t count) {
+		auto &input = inputs[0];
+		if (input.GetVectorType() == VectorType::CONSTANT_VECTOR && states.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			if (ConstantVector::IsNull(input)) {
+				return;
+			}
+			auto sdata = ConstantVector::GetData<STATE *>(states);
+			*sdata += count;
+		} else if (input.GetVectorType() == VectorType::FLAT_VECTOR && states.GetVectorType() == VectorType::FLAT_VECTOR) {
+			auto sdata = FlatVector::GetData<STATE *>(states);
+			CountFlatLoop(sdata, FlatVector::Validity(input), count);
+		} else {
+			UnifiedVectorFormat idata, sdata;
+			input.ToUnifiedFormat(count, idata);
+			states.ToUnifiedFormat(count, sdata);
+			CountScatterLoop(reinterpret_cast<STATE **>(sdata.data), *idata.sel, *sdata.sel, idata.validity, count);
+		}
+	}
+
+	static inline void CountFlatUpdateLoop(STATE &result, ValidityMask &mask, idx_t count) {
+		idx_t base_idx = 0;
+		auto entry_count = ValidityMask::EntryCount(count);
+		for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx++) {
+			auto validity_entry = mask.GetValidityEntry(entry_idx);
+			idx_t next = MinValue<idx_t>(base_idx + ValidityMask::BITS_PER_VALUE, count);
+			if (ValidityMask::AllValid(validity_entry)) {
+				// all valid
+				result += next - base_idx;
+				base_idx = next;
+			} else if (ValidityMask::NoneValid(validity_entry)) {
+				// nothing valid: skip all
+				base_idx = next;
+				continue;
+			} else {
+				// partially valid: need to check individual elements for validity
+				idx_t start = base_idx;
+				for (; base_idx < next; base_idx++) {
+					if (ValidityMask::RowIsValid(validity_entry, base_idx - start)) {
+						result++;
+					}
+				}
+			}
+		}
+	}
+
+	static inline void CountUpdateLoop(STATE &result, ValidityMask &mask, idx_t count, const SelectionVector &sel_vector) {
+		if (mask.AllValid()) {
+			// no NULL values
+			result += count;
+			return;
+		}
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = sel_vector.get_index(i);
+			if (mask.RowIsValid(idx)) {
+				result++;
+			}
+		}
+	}
+
+	static void CountUpdate(Vector inputs[], AggregateInputData &, idx_t input_count, data_ptr_t state_p, idx_t count) {
+		auto &input = inputs[0];
+		auto &result = *reinterpret_cast<STATE *>(state_p);
+		switch (input.GetVectorType()) {
+		case VectorType::CONSTANT_VECTOR: {
+			if (!ConstantVector::IsNull(input)) {
+				// if the constant is not null increment the state
+				result += count;
+			}
+			break;
+		}
+		case VectorType::FLAT_VECTOR: {
+			CountFlatUpdateLoop(result, FlatVector::Validity(input), count);
+			break;
+		}
+		case VectorType::SEQUENCE_VECTOR: {
+			// sequence vectors cannot have NULL values
+			result += count;
+			break;
+		}
+		default: {
+			UnifiedVectorFormat idata;
+			input.ToUnifiedFormat(count, idata);
+			CountUpdateLoop(result, idata.validity, count, *idata.sel);
+			break;
+		}
+		}
+	}
 };
 
 AggregateFunction CountFun::GetFunction() {
-	auto fun = AggregateFunction::UnaryAggregate<int64_t, int64_t, int64_t, CountFunction>(
-	    LogicalType(LogicalTypeId::ANY), LogicalType::BIGINT);
+	AggregateFunction fun(
+		    {LogicalType(LogicalTypeId::ANY)}, LogicalType::BIGINT, AggregateFunction::StateSize<int64_t>,
+		    AggregateFunction::StateInitialize<int64_t, CountFunction>, CountFunction::CountScatter,
+		    AggregateFunction::StateCombine<int64_t, CountFunction>, AggregateFunction::StateFinalize<int64_t, int64_t, CountFunction>,
+		    FunctionNullHandling::SPECIAL_HANDLING, CountFunction::CountUpdate);
 	fun.name = "count";
-	fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
 	fun.order_dependent = AggregateOrderDependent::NOT_ORDER_DEPENDENT;
 	return fun;
 }

--- a/src/function/aggregate/distributive/first.cpp
+++ b/src/function/aggregate/distributive/first.cpp
@@ -43,7 +43,8 @@ struct FirstFunction : public FirstFunctionBase {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 	}
 
@@ -100,7 +101,8 @@ struct FirstFunctionString : public FirstFunctionBase {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 	}
 

--- a/src/function/aggregate/distributive/first.cpp
+++ b/src/function/aggregate/distributive/first.cpp
@@ -27,9 +27,9 @@ struct FirstFunctionBase {
 template <bool LAST, bool SKIP_NULLS>
 struct FirstFunction : public FirstFunctionBase {
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input) {
 		if (LAST || !state.is_set) {
-			if (!mask.RowIsValid(idx)) {
+			if (!unary_input.RowIsValid()) {
 				if (!SKIP_NULLS) {
 					state.is_set = true;
 				}
@@ -37,15 +37,14 @@ struct FirstFunction : public FirstFunctionBase {
 			} else {
 				state.is_set = true;
 				state.is_null = false;
-				state.value = input[idx];
+				state.value = input;
 			}
 		}
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
-	                              ValidityMask &mask, idx_t count) {
-		Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+		Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 	}
 
 	template <class STATE, class OP>
@@ -94,17 +93,15 @@ struct FirstFunctionString : public FirstFunctionBase {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &input_data, const INPUT_TYPE *input, ValidityMask &mask,
-	                      idx_t idx) {
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input) {
 		if (LAST || !state.is_set) {
-			SetValue(state, input_data, input[idx], !mask.RowIsValid(idx));
+			SetValue(state, unary_input.input, input, !unary_input.RowIsValid());
 		}
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
-	                              ValidityMask &mask, idx_t count) {
-		Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+		Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 	}
 
 	template <class STATE, class OP>

--- a/src/function/aggregate/distributive/first.cpp
+++ b/src/function/aggregate/distributive/first.cpp
@@ -14,9 +14,9 @@ struct FirstState {
 
 struct FirstFunctionBase {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->is_set = false;
-		state->is_null = false;
+	static void Initialize(STATE &state) {
+		state.is_set = false;
+		state.is_null = false;
 	}
 
 	static bool IgnoreNull() {
@@ -27,40 +27,40 @@ struct FirstFunctionBase {
 template <bool LAST, bool SKIP_NULLS>
 struct FirstFunction : public FirstFunctionBase {
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
-		if (LAST || !state->is_set) {
+	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (LAST || !state.is_set) {
 			if (!mask.RowIsValid(idx)) {
 				if (!SKIP_NULLS) {
-					state->is_set = true;
+					state.is_set = true;
 				}
-				state->is_null = true;
+				state.is_null = true;
 			} else {
-				state->is_set = true;
-				state->is_null = false;
-				state->value = input[idx];
+				state.is_set = true;
+				state.is_null = false;
+				state.value = input[idx];
 			}
 		}
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
+	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
 	                              ValidityMask &mask, idx_t count) {
 		Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
-		if (!target->is_set) {
-			*target = source;
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+		if (!target.is_set) {
+			target = source;
 		}
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (!state->is_set || state->is_null) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (!state.is_set || state.is_null) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = state->value;
+			target = state.value;
 		}
 	}
 };
@@ -68,65 +68,65 @@ struct FirstFunction : public FirstFunctionBase {
 template <bool LAST, bool SKIP_NULLS>
 struct FirstFunctionString : public FirstFunctionBase {
 	template <class STATE>
-	static void SetValue(STATE *state, AggregateInputData &input_data, string_t value, bool is_null) {
-		if (LAST && state->is_set) {
-			Destroy(input_data, state);
+	static void SetValue(STATE &state, AggregateInputData &input_data, string_t value, bool is_null) {
+		if (LAST && state.is_set) {
+			Destroy(state, input_data);
 		}
 		if (is_null) {
 			if (!SKIP_NULLS) {
-				state->is_set = true;
-				state->is_null = true;
+				state.is_set = true;
+				state.is_null = true;
 			}
 		} else {
-			state->is_set = true;
-			state->is_null = false;
+			state.is_set = true;
+			state.is_null = false;
 			if (value.IsInlined()) {
-				state->value = value;
+				state.value = value;
 			} else {
 				// non-inlined string, need to allocate space for it
 				auto len = value.GetSize();
 				auto ptr = new char[len];
 				memcpy(ptr, value.GetData(), len);
 
-				state->value = string_t(ptr, len);
+				state.value = string_t(ptr, len);
 			}
 		}
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &input_data, const INPUT_TYPE *input, ValidityMask &mask,
+	static void Operation(STATE &state, AggregateInputData &input_data, const INPUT_TYPE *input, ValidityMask &mask,
 	                      idx_t idx) {
-		if (LAST || !state->is_set) {
+		if (LAST || !state.is_set) {
 			SetValue(state, input_data, input[idx], !mask.RowIsValid(idx));
 		}
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
+	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, const INPUT_TYPE *input,
 	                              ValidityMask &mask, idx_t count) {
 		Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &input_data) {
-		if (source.is_set && (LAST || !target->is_set)) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &input_data) {
+		if (source.is_set && (LAST || !target.is_set)) {
 			SetValue(target, input_data, source.value, source.is_null);
 		}
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (!state->is_set || state->is_null) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (!state.is_set || state.is_null) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = StringVector::AddStringOrBlob(result, state->value);
+			target = StringVector::AddStringOrBlob(finalize_data.result, state.value);
 		}
 	}
 
 	template <class STATE>
-	static void Destroy(AggregateInputData &aggr_input_data, STATE *state) {
-		if (state->is_set && !state->is_null && !state->value.IsInlined()) {
-			delete[] state->value.GetData();
+	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
+		if (state.is_set && !state.is_null && !state.value.IsInlined()) {
+			delete[] state.value.GetData();
 		}
 	}
 };
@@ -138,14 +138,14 @@ struct FirstStateVector {
 template <bool LAST, bool SKIP_NULLS>
 struct FirstVectorFunction {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->value = nullptr;
+	static void Initialize(STATE &state) {
+		state.value = nullptr;
 	}
 
 	template <class STATE>
-	static void Destroy(AggregateInputData &aggr_input_data, STATE *state) {
-		if (state->value) {
-			delete state->value;
+	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
+		if (state.value) {
+			delete state.value;
 		}
 	}
 	static bool IgnoreNull() {
@@ -153,14 +153,14 @@ struct FirstVectorFunction {
 	}
 
 	template <class STATE>
-	static void SetValue(STATE *state, Vector &input, const idx_t idx) {
-		if (!state->value) {
-			state->value = new Vector(input.GetType());
-			state->value->SetVectorType(VectorType::CONSTANT_VECTOR);
+	static void SetValue(STATE &state, Vector &input, const idx_t idx) {
+		if (!state.value) {
+			state.value = new Vector(input.GetType());
+			state.value->SetVectorType(VectorType::CONSTANT_VECTOR);
 		}
 		sel_t selv = idx;
 		SelectionVector sel(&selv);
-		VectorOperations::Copy(input, *state->value, sel, 1, 0, 0);
+		VectorOperations::Copy(input, *state.value, sel, 1, 0, 0);
 	}
 
 	static void Update(Vector inputs[], AggregateInputData &, idx_t input_count, Vector &state_vector, idx_t count) {
@@ -177,33 +177,26 @@ struct FirstVectorFunction {
 			if (SKIP_NULLS && !idata.validity.RowIsValid(idx)) {
 				continue;
 			}
-			auto state = states[sdata.sel->get_index(i)];
-			if (LAST || !state->value) {
+			auto &state = *states[sdata.sel->get_index(i)];
+			if (LAST || !state.value) {
 				SetValue(state, input, i);
 			}
 		}
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
-		if (source.value && (LAST || !target->value)) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+		if (source.value && (LAST || !target.value)) {
 			SetValue(target, *source.value, 0);
 		}
 	}
 
-	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (!state->value) {
-			// we need to use FlatVector::SetNull here
-			// since for STRUCT columns only setting the validity mask of the struct is incorrect
-			// as for a struct column, we need to also set ALL child columns to NULL
-			if (result.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-				ConstantVector::SetNull(result, true);
-			} else {
-				FlatVector::SetNull(result, idx, true);
-			}
+	template <class STATE>
+	static void Finalize(STATE &state, AggregateFinalizeData &finalize_data) {
+		if (!state.value) {
+			finalize_data.ReturnNull();
 		} else {
-			VectorOperations::Copy(*state->value, result, 1, 0, idx);
+			VectorOperations::Copy(*state.value, finalize_data.result, 1, 0, finalize_data.result_idx);
 		}
 	}
 
@@ -289,7 +282,7 @@ static AggregateFunction GetFirstFunction(const LogicalType &type) {
 		return AggregateFunction({type}, type, AggregateFunction::StateSize<FirstStateVector>,
 		                         AggregateFunction::StateInitialize<FirstStateVector, OP>, OP::Update,
 		                         AggregateFunction::StateCombine<FirstStateVector, OP>,
-		                         AggregateFunction::StateFinalize<FirstStateVector, void, OP>, nullptr, OP::Bind,
+		                         AggregateFunction::StateVoidFinalize<FirstStateVector, OP>, nullptr, OP::Bind,
 		                         AggregateFunction::StateDestroy<FirstStateVector, OP>, nullptr, nullptr);
 	}
 	}

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -253,13 +253,13 @@ struct SortedAggregateState {
 
 struct SortedAggregateFunction {
 	template <typename STATE>
-	static void Initialize(STATE *state) {
-		new (state) STATE();
+	static void Initialize(STATE &state) {
+		new (&state) STATE();
 	}
 
 	template <typename STATE>
-	static void Destroy(AggregateInputData &aggr_input_data, STATE *state) {
-		state->~STATE();
+	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
+		state.~STATE();
 	}
 
 	static void ProjectInputs(Vector inputs[], const SortedAggregateBindData &order_bind, idx_t input_count,
@@ -345,10 +345,10 @@ struct SortedAggregateFunction {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &aggr_input_data) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input_data) {
 		auto &order_bind = aggr_input_data.bind_data->Cast<SortedAggregateBindData>();
 		auto &other = const_cast<STATE &>(source);
-		target->Combine(order_bind, other);
+		target.Combine(order_bind, other);
 	}
 
 	static void Window(Vector inputs[], const ValidityMask &filter_mask, AggregateInputData &aggr_input_data,

--- a/src/include/duckdb/core_functions/aggregate/algebraic/corr.hpp
+++ b/src/include/duckdb/core_functions/aggregate/algebraic/corr.hpp
@@ -24,49 +24,49 @@ struct CorrState {
 // CORR(y, x) = COVAR_POP(y, x) / (STDDEV_POP(x) * STDDEV_POP(y))
 struct CorrOperation {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		CovarOperation::Initialize<CovarState>(&state->cov_pop);
-		STDDevBaseOperation::Initialize<StddevState>(&state->dev_pop_x);
-		STDDevBaseOperation::Initialize<StddevState>(&state->dev_pop_y);
+	static void Initialize(STATE &state) {
+		CovarOperation::Initialize<CovarState>(state.cov_pop);
+		STDDevBaseOperation::Initialize<StddevState>(state.dev_pop_x);
+		STDDevBaseOperation::Initialize<StddevState>(state.dev_pop_y);
 	}
 
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
+	static void Operation(STATE &state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
 	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
-		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(&state->cov_pop, aggr_input_data, x_data, y_data,
+		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(state.cov_pop, aggr_input_data, x_data, y_data,
 		                                                          amask, bmask, xidx, yidx);
-		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(&state->dev_pop_x, aggr_input_data, x_data, amask,
+		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(state.dev_pop_x, aggr_input_data, x_data, amask,
 		                                                        xidx);
-		STDDevBaseOperation::Operation<B_TYPE, StddevState, OP>(&state->dev_pop_y, aggr_input_data, y_data, bmask,
+		STDDevBaseOperation::Operation<B_TYPE, StddevState, OP>(state.dev_pop_y, aggr_input_data, y_data, bmask,
 		                                                        yidx);
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &aggr_input_data) {
-		CovarOperation::Combine<CovarState, OP>(source.cov_pop, &target->cov_pop, aggr_input_data);
-		STDDevBaseOperation::Combine<StddevState, OP>(source.dev_pop_x, &target->dev_pop_x, aggr_input_data);
-		STDDevBaseOperation::Combine<StddevState, OP>(source.dev_pop_y, &target->dev_pop_y, aggr_input_data);
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input_data) {
+		CovarOperation::Combine<CovarState, OP>(source.cov_pop, target.cov_pop, aggr_input_data);
+		STDDevBaseOperation::Combine<StddevState, OP>(source.dev_pop_x, target.dev_pop_x, aggr_input_data);
+		STDDevBaseOperation::Combine<StddevState, OP>(source.dev_pop_y, target.dev_pop_y, aggr_input_data);
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (state->cov_pop.count == 0 || state->dev_pop_x.count == 0 || state->dev_pop_y.count == 0) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.cov_pop.count == 0 || state.dev_pop_x.count == 0 || state.dev_pop_y.count == 0) {
+			finalize_data.ReturnNull();
 		} else {
-			auto cov = state->cov_pop.co_moment / state->cov_pop.count;
-			auto std_x = state->dev_pop_x.count > 1 ? sqrt(state->dev_pop_x.dsquared / state->dev_pop_x.count) : 0;
+			auto cov = state.cov_pop.co_moment / state.cov_pop.count;
+			auto std_x = state.dev_pop_x.count > 1 ? sqrt(state.dev_pop_x.dsquared / state.dev_pop_x.count) : 0;
 			if (!Value::DoubleIsFinite(std_x)) {
 				throw OutOfRangeException("STDDEV_POP for X is out of range!");
 			}
-			auto std_y = state->dev_pop_y.count > 1 ? sqrt(state->dev_pop_y.dsquared / state->dev_pop_y.count) : 0;
+			auto std_y = state.dev_pop_y.count > 1 ? sqrt(state.dev_pop_y.dsquared / state.dev_pop_y.count) : 0;
 			if (!Value::DoubleIsFinite(std_y)) {
 				throw OutOfRangeException("STDDEV_POP for Y is out of range!");
 			}
 			if (std_x * std_y == 0) {
-				mask.SetInvalid(idx);
+				finalize_data.ReturnNull();
 				return;
 			}
-			target[idx] = cov / (std_x * std_y);
+			target = cov / (std_x * std_y);
 		}
 	}
 

--- a/src/include/duckdb/core_functions/aggregate/algebraic/corr.hpp
+++ b/src/include/duckdb/core_functions/aggregate/algebraic/corr.hpp
@@ -35,10 +35,8 @@ struct CorrOperation {
 	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
 		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(state.cov_pop, aggr_input_data, x_data, y_data,
 		                                                          amask, bmask, xidx, yidx);
-		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(state.dev_pop_x, aggr_input_data, x_data, amask,
-		                                                        xidx);
-		STDDevBaseOperation::Operation<B_TYPE, StddevState, OP>(state.dev_pop_y, aggr_input_data, y_data, bmask,
-		                                                        yidx);
+		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.dev_pop_x, x_data[xidx]);
+		STDDevBaseOperation::Execute<B_TYPE, StddevState>(state.dev_pop_y, y_data[yidx]);
 	}
 
 	template <class STATE, class OP>

--- a/src/include/duckdb/core_functions/aggregate/algebraic/corr.hpp
+++ b/src/include/duckdb/core_functions/aggregate/algebraic/corr.hpp
@@ -31,12 +31,10 @@ struct CorrOperation {
 	}
 
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
-	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
-		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(state.cov_pop, aggr_input_data, x_data, y_data,
-		                                                          amask, bmask, xidx, yidx);
-		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.dev_pop_x, x_data[xidx]);
-		STDDevBaseOperation::Execute<B_TYPE, StddevState>(state.dev_pop_y, y_data[yidx]);
+	static void Operation(STATE &state, const A_TYPE &x_input, const B_TYPE &y_input, AggregateBinaryInput &idata) {
+		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(state.cov_pop, x_input, y_input, idata);
+		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.dev_pop_x, x_input);
+		STDDevBaseOperation::Execute<B_TYPE, StddevState>(state.dev_pop_y, y_input);
 	}
 
 	template <class STATE, class OP>

--- a/src/include/duckdb/core_functions/aggregate/algebraic/covar.hpp
+++ b/src/include/duckdb/core_functions/aggregate/algebraic/covar.hpp
@@ -21,51 +21,51 @@ struct CovarState {
 
 struct CovarOperation {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->count = 0;
-		state->meanx = 0;
-		state->meany = 0;
-		state->co_moment = 0;
+	static void Initialize(STATE &state) {
+		state.count = 0;
+		state.meanx = 0;
+		state.meany = 0;
+		state.co_moment = 0;
 	}
 
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const A_TYPE *x_data, const B_TYPE *y_data, ValidityMask &amask,
+	static void Operation(STATE &state, AggregateInputData &, const A_TYPE *x_data, const B_TYPE *y_data, ValidityMask &amask,
 	                      ValidityMask &bmask, idx_t xidx, idx_t yidx) {
 		// update running mean and d^2
-		const uint64_t n = ++(state->count);
+		const uint64_t n = ++(state.count);
 
 		const auto x = x_data[xidx];
-		const double dx = (x - state->meanx);
-		const double meanx = state->meanx + dx / n;
+		const double dx = (x - state.meanx);
+		const double meanx = state.meanx + dx / n;
 
 		const auto y = y_data[yidx];
-		const double dy = (y - state->meany);
-		const double meany = state->meany + dy / n;
+		const double dy = (y - state.meany);
+		const double meany = state.meany + dy / n;
 
-		const double C = state->co_moment + dx * (y - meany);
+		const double C = state.co_moment + dx * (y - meany);
 
-		state->meanx = meanx;
-		state->meany = meany;
-		state->co_moment = C;
+		state.meanx = meanx;
+		state.meany = meany;
+		state.co_moment = C;
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
-		if (target->count == 0) {
-			*target = source;
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+		if (target.count == 0) {
+			target = source;
 		} else if (source.count > 0) {
-			const auto count = target->count + source.count;
-			const auto meanx = (source.count * source.meanx + target->count * target->meanx) / count;
-			const auto meany = (source.count * source.meany + target->count * target->meany) / count;
+			const auto count = target.count + source.count;
+			const auto meanx = (source.count * source.meanx + target.count * target.meanx) / count;
+			const auto meany = (source.count * source.meany + target.count * target.meany) / count;
 
 			//  Schubert and Gertz SSDBM 2018, equation 21
-			const auto deltax = target->meanx - source.meanx;
-			const auto deltay = target->meany - source.meany;
-			target->co_moment =
-			    source.co_moment + target->co_moment + deltax * deltay * source.count * target->count / count;
-			target->meanx = meanx;
-			target->meany = meany;
-			target->count = count;
+			const auto deltax = target.meanx - source.meanx;
+			const auto deltay = target.meany - source.meany;
+			target.co_moment =
+			    source.co_moment + target.co_moment + deltax * deltay * source.count * target.count / count;
+			target.meanx = meanx;
+			target.meany = meany;
+			target.count = count;
 		}
 	}
 
@@ -76,22 +76,22 @@ struct CovarOperation {
 
 struct CovarPopOperation : public CovarOperation {
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (state->count == 0) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.count == 0) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = state->co_moment / state->count;
+			target = state.co_moment / state.count;
 		}
 	}
 };
 
 struct CovarSampOperation : public CovarOperation {
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if ((state->count) < 2) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.count < 2) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = state->co_moment / (state->count - 1);
+			target = state.co_moment / (state.count - 1);
 		}
 	}
 };

--- a/src/include/duckdb/core_functions/aggregate/algebraic/covar.hpp
+++ b/src/include/duckdb/core_functions/aggregate/algebraic/covar.hpp
@@ -29,16 +29,13 @@ struct CovarOperation {
 	}
 
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const A_TYPE *x_data, const B_TYPE *y_data, ValidityMask &amask,
-	                      ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+	static void Operation(STATE &state, const A_TYPE &x, const B_TYPE &y, AggregateBinaryInput &idata) {
 		// update running mean and d^2
 		const uint64_t n = ++(state.count);
 
-		const auto x = x_data[xidx];
 		const double dx = (x - state.meanx);
 		const double meanx = state.meanx + dx / n;
 
-		const auto y = y_data[yidx];
 		const double dy = (y - state.meany);
 		const double meany = state.meany + dy / n;
 

--- a/src/include/duckdb/core_functions/aggregate/algebraic/stddev.hpp
+++ b/src/include/duckdb/core_functions/aggregate/algebraic/stddev.hpp
@@ -23,28 +23,28 @@ struct StddevState {
 // method, DOI: 10.2307/1266577
 struct STDDevBaseOperation {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->count = 0;
-		state->mean = 0;
-		state->dsquared = 0;
+	static void Initialize(STATE &state) {
+		state.count = 0;
+		state.mean = 0;
+		state.dsquared = 0;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const INPUT_TYPE *input_data, ValidityMask &mask, idx_t idx) {
+	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input_data, ValidityMask &mask, idx_t idx) {
 		// update running mean and d^2
-		state->count++;
+		state.count++;
 		const double input = input_data[idx];
-		const double mean_differential = (input - state->mean) / state->count;
-		const double new_mean = state->mean + mean_differential;
-		const double dsquared_increment = (input - new_mean) * (input - state->mean);
-		const double new_dsquared = state->dsquared + dsquared_increment;
+		const double mean_differential = (input - state.mean) / state.count;
+		const double new_mean = state.mean + mean_differential;
+		const double dsquared_increment = (input - new_mean) * (input - state.mean);
+		const double new_dsquared = state.dsquared + dsquared_increment;
 
-		state->mean = new_mean;
-		state->dsquared = new_dsquared;
+		state.mean = new_mean;
+		state.dsquared = new_dsquared;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input_data,
+	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, INPUT_TYPE *input_data,
 	                              ValidityMask &mask, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input_data, mask, 0);
@@ -52,17 +52,17 @@ struct STDDevBaseOperation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
-		if (target->count == 0) {
-			*target = source;
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+		if (target.count == 0) {
+			target = source;
 		} else if (source.count > 0) {
-			const auto count = target->count + source.count;
-			const auto mean = (source.count * source.mean + target->count * target->mean) / count;
-			const auto delta = source.mean - target->mean;
-			target->dsquared =
-			    source.dsquared + target->dsquared + delta * delta * source.count * target->count / count;
-			target->mean = mean;
-			target->count = count;
+			const auto count = target.count + source.count;
+			const auto mean = (source.count * source.mean + target.count * target.mean) / count;
+			const auto delta = source.mean - target.mean;
+			target.dsquared =
+			    source.dsquared + target.dsquared + delta * delta * source.count * target.count / count;
+			target.mean = mean;
+			target.count = count;
 		}
 	}
 
@@ -73,12 +73,12 @@ struct STDDevBaseOperation {
 
 struct VarSampOperation : public STDDevBaseOperation {
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (state->count <= 1) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.count <= 1) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = state->dsquared / (state->count - 1);
-			if (!Value::DoubleIsFinite(target[idx])) {
+			target = state.dsquared / (state.count - 1);
+			if (!Value::DoubleIsFinite(target)) {
 				throw OutOfRangeException("VARSAMP is out of range!");
 			}
 		}
@@ -87,12 +87,12 @@ struct VarSampOperation : public STDDevBaseOperation {
 
 struct VarPopOperation : public STDDevBaseOperation {
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (state->count == 0) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.count == 0) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = state->count > 1 ? (state->dsquared / state->count) : 0;
-			if (!Value::DoubleIsFinite(target[idx])) {
+			target = state.count > 1 ? (state.dsquared / state.count) : 0;
+			if (!Value::DoubleIsFinite(target)) {
 				throw OutOfRangeException("VARPOP is out of range!");
 			}
 		}
@@ -101,12 +101,12 @@ struct VarPopOperation : public STDDevBaseOperation {
 
 struct STDDevSampOperation : public STDDevBaseOperation {
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (state->count <= 1) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.count <= 1) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = sqrt(state->dsquared / (state->count - 1));
-			if (!Value::DoubleIsFinite(target[idx])) {
+			target = sqrt(state.dsquared / (state.count - 1));
+			if (!Value::DoubleIsFinite(target)) {
 				throw OutOfRangeException("STDDEV_SAMP is out of range!");
 			}
 		}
@@ -115,12 +115,12 @@ struct STDDevSampOperation : public STDDevBaseOperation {
 
 struct STDDevPopOperation : public STDDevBaseOperation {
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (state->count == 0) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.count == 0) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = state->count > 1 ? sqrt(state->dsquared / state->count) : 0;
-			if (!Value::DoubleIsFinite(target[idx])) {
+			target = state.count > 1 ? sqrt(state.dsquared / state.count) : 0;
+			if (!Value::DoubleIsFinite(target)) {
 				throw OutOfRangeException("STDDEV_POP is out of range!");
 			}
 		}
@@ -129,12 +129,12 @@ struct STDDevPopOperation : public STDDevBaseOperation {
 
 struct StandardErrorOfTheMeanOperation : public STDDevBaseOperation {
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (state->count == 0) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.count == 0) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = sqrt(state->dsquared / state->count) / sqrt((state->count));
-			if (!Value::DoubleIsFinite(target[idx])) {
+			target = sqrt(state.dsquared / state.count) / sqrt((state.count));
+			if (!Value::DoubleIsFinite(target)) {
 				throw OutOfRangeException("SEM is out of range!");
 			}
 		}

--- a/src/include/duckdb/core_functions/aggregate/algebraic/stddev.hpp
+++ b/src/include/duckdb/core_functions/aggregate/algebraic/stddev.hpp
@@ -29,11 +29,10 @@ struct STDDevBaseOperation {
 		state.dsquared = 0;
 	}
 
-	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input_data, ValidityMask &mask, idx_t idx) {
+	template <class INPUT_TYPE, class STATE>
+	static void Execute(STATE &state, const INPUT_TYPE &input) {
 		// update running mean and d^2
 		state.count++;
-		const double input = input_data[idx];
 		const double mean_differential = (input - state.mean) / state.count;
 		const double new_mean = state.mean + mean_differential;
 		const double dsquared_increment = (input - new_mean) * (input - state.mean);
@@ -41,13 +40,18 @@ struct STDDevBaseOperation {
 
 		state.mean = new_mean;
 		state.dsquared = new_dsquared;
+
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &aggr_input_data, INPUT_TYPE *input_data,
-	                              ValidityMask &mask, idx_t count) {
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+		Execute(state, input);
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
-			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input_data, mask, 0);
+			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}
 	}
 

--- a/src/include/duckdb/core_functions/aggregate/regression/regr_count.hpp
+++ b/src/include/duckdb/core_functions/aggregate/regression/regr_count.hpp
@@ -16,26 +16,26 @@ namespace duckdb {
 
 struct RegrCountFunction {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		*state = 0;
+	static void Initialize(STATE &state) {
+		state = 0;
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
-		*target += source;
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+		target += source;
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		target[idx] = *state;
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		target = state;
 	}
 	static bool IgnoreNull() {
 		return true;
 	}
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const A_TYPE *x_data, const B_TYPE *y_data, ValidityMask &amask,
+	static void Operation(STATE &state, AggregateInputData &, const A_TYPE *x_data, const B_TYPE *y_data, ValidityMask &amask,
 	                      ValidityMask &bmask, idx_t xidx, idx_t yidx) {
-		*state += 1;
+		state += 1;
 	}
 };
 

--- a/src/include/duckdb/core_functions/aggregate/regression/regr_count.hpp
+++ b/src/include/duckdb/core_functions/aggregate/regression/regr_count.hpp
@@ -33,8 +33,7 @@ struct RegrCountFunction {
 		return true;
 	}
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const A_TYPE *x_data, const B_TYPE *y_data, ValidityMask &amask,
-	                      ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+	static void Operation(STATE &state, const A_TYPE &, const B_TYPE &, AggregateBinaryInput &) {
 		state += 1;
 	}
 };

--- a/src/include/duckdb/core_functions/aggregate/regression/regr_slope.hpp
+++ b/src/include/duckdb/core_functions/aggregate/regression/regr_slope.hpp
@@ -25,11 +25,9 @@ struct RegrSlopeOperation {
 	}
 
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
-	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
-		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(state.cov_pop, aggr_input_data, y_data, x_data,
-		                                                          bmask, amask, yidx, xidx);
-		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.var_pop, y_data[yidx]);
+	static void Operation(STATE &state, const A_TYPE &x, const B_TYPE &y, AggregateBinaryInput &idata) {
+		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(state.cov_pop, x, y, idata);
+		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.var_pop, y);
 	}
 
 	template <class STATE, class OP>

--- a/src/include/duckdb/core_functions/aggregate/regression/regr_slope.hpp
+++ b/src/include/duckdb/core_functions/aggregate/regression/regr_slope.hpp
@@ -29,7 +29,7 @@ struct RegrSlopeOperation {
 	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
 		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(state.cov_pop, aggr_input_data, y_data, x_data,
 		                                                          bmask, amask, yidx, xidx);
-		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(state.var_pop, aggr_input_data, y_data, bmask, yidx);
+		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.var_pop, y_data[yidx]);
 	}
 
 	template <class STATE, class OP>

--- a/src/include/duckdb/core_functions/aggregate/regression/regr_slope.hpp
+++ b/src/include/duckdb/core_functions/aggregate/regression/regr_slope.hpp
@@ -19,40 +19,40 @@ struct RegrSlopeState {
 
 struct RegrSlopeOperation {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		CovarOperation::Initialize<CovarState>(&state->cov_pop);
-		STDDevBaseOperation::Initialize<StddevState>(&state->var_pop);
+	static void Initialize(STATE &state) {
+		CovarOperation::Initialize<CovarState>(state.cov_pop);
+		STDDevBaseOperation::Initialize<StddevState>(state.var_pop);
 	}
 
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
+	static void Operation(STATE &state, AggregateInputData &aggr_input_data, const A_TYPE *x_data, const B_TYPE *y_data,
 	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
-		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(&state->cov_pop, aggr_input_data, y_data, x_data,
+		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(state.cov_pop, aggr_input_data, y_data, x_data,
 		                                                          bmask, amask, yidx, xidx);
-		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(&state->var_pop, aggr_input_data, y_data, bmask, yidx);
+		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(state.var_pop, aggr_input_data, y_data, bmask, yidx);
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &aggr_input_data) {
-		CovarOperation::Combine<CovarState, OP>(source.cov_pop, &target->cov_pop, aggr_input_data);
-		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop, &target->var_pop, aggr_input_data);
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input_data) {
+		CovarOperation::Combine<CovarState, OP>(source.cov_pop, target.cov_pop, aggr_input_data);
+		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop, target.var_pop, aggr_input_data);
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (state->cov_pop.count == 0 || state->var_pop.count == 0) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.cov_pop.count == 0 || state.var_pop.count == 0) {
+			finalize_data.ReturnNull();
 		} else {
-			auto cov = state->cov_pop.co_moment / state->cov_pop.count;
-			auto var_pop = state->var_pop.count > 1 ? (state->var_pop.dsquared / state->var_pop.count) : 0;
+			auto cov = state.cov_pop.co_moment / state.cov_pop.count;
+			auto var_pop = state.var_pop.count > 1 ? (state.var_pop.dsquared / state.var_pop.count) : 0;
 			if (!Value::DoubleIsFinite(var_pop)) {
 				throw OutOfRangeException("VARPOP is out of range!");
 			}
 			if (var_pop == 0) {
-				mask.SetInvalid(idx);
+				finalize_data.ReturnNull();
 				return;
 			}
-			target[idx] = cov / var_pop;
+			target = cov / var_pop;
 		}
 	}
 

--- a/src/include/duckdb/core_functions/aggregate/sum_helpers.hpp
+++ b/src/include/duckdb/core_functions/aggregate/sum_helpers.hpp
@@ -144,16 +144,15 @@ struct BaseSumOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
 		STATEOP::template AddValues<STATE>(state, 1);
-		ADDOP::template AddNumber<STATE, INPUT_TYPE>(state, input[idx]);
+		ADDOP::template AddNumber<STATE, INPUT_TYPE>(state, input);
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask,
-	                              idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &, idx_t count) {
 		STATEOP::template AddValues<STATE>(state, count);
-		ADDOP::template AddConstant<STATE, INPUT_TYPE>(state, *input, count);
+		ADDOP::template AddConstant<STATE, INPUT_TYPE>(state, input, count);
 	}
 
 	static bool IgnoreNull() {

--- a/src/include/duckdb/core_functions/aggregate/sum_helpers.hpp
+++ b/src/include/duckdb/core_functions/aggregate/sum_helpers.hpp
@@ -133,27 +133,27 @@ struct HugeintAdd {
 template <class STATEOP, class ADDOP>
 struct BaseSumOperation {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->value = 0;
+	static void Initialize(STATE &state) {
+		state.value = 0;
 		STATEOP::template Initialize<STATE>(state);
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &aggr_input_data) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input_data) {
 		STATEOP::template Combine<STATE>(source, target, aggr_input_data);
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
 		STATEOP::template AddValues<STATE>(state, 1);
-		ADDOP::template AddNumber<STATE, INPUT_TYPE>(*state, input[idx]);
+		ADDOP::template AddNumber<STATE, INPUT_TYPE>(state, input[idx]);
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask,
+	static void ConstantOperation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask,
 	                              idx_t count) {
 		STATEOP::template AddValues<STATE>(state, count);
-		ADDOP::template AddConstant<STATE, INPUT_TYPE>(*state, *input, count);
+		ADDOP::template AddConstant<STATE, INPUT_TYPE>(state, *input, count);
 	}
 
 	static bool IgnoreNull() {

--- a/src/include/duckdb/function/aggregate_state.hpp
+++ b/src/include/duckdb/function/aggregate_state.hpp
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/function/aggregate_state.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/function/function.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
+#include "duckdb/storage/statistics/node_statistics.hpp"
+
+namespace duckdb {
+
+enum class AggregateType : uint8_t { NON_DISTINCT = 1, DISTINCT = 2 };
+//! Whether or not the input order influences the result of the aggregate
+enum class AggregateOrderDependent : uint8_t { ORDER_DEPENDENT = 1, NOT_ORDER_DEPENDENT = 2 };
+
+class BoundAggregateExpression;
+
+struct AggregateInputData {
+	AggregateInputData(optional_ptr<FunctionData> bind_data_p, Allocator &allocator_p)
+	    : bind_data(bind_data_p), allocator(allocator_p) {
+	}
+	optional_ptr<FunctionData> bind_data;
+	Allocator &allocator;
+};
+
+struct AggregateUnaryInput {
+	AggregateUnaryInput(AggregateInputData &input_p, ValidityMask &input_mask_p)
+	    : input(input_p), input_mask(input_mask_p), input_idx(0) {
+	}
+
+	AggregateInputData &input;
+	ValidityMask &input_mask;
+	idx_t input_idx;
+
+	inline bool RowIsValid() {
+		return input_mask.RowIsValid(input_idx);
+	}
+};
+
+
+struct AggregateFinalizeData {
+	AggregateFinalizeData(Vector &result_p, AggregateInputData &input_p)
+	    : result(result_p), input(input_p), result_idx(0) {
+	}
+
+	Vector &result;
+	AggregateInputData &input;
+	idx_t result_idx;
+
+	inline void ReturnNull() {
+		switch (result.GetVectorType()) {
+		case VectorType::FLAT_VECTOR:
+			FlatVector::SetNull(result, result_idx, true);
+			break;
+		case VectorType::CONSTANT_VECTOR:
+			ConstantVector::SetNull(result, true);
+			break;
+		default:
+			throw InternalException("Invalid result vector type for aggregate");
+		}
+	}
+
+	inline string_t ReturnString(string_t value) {
+		return StringVector::AddStringOrBlob(result, value);
+	}
+};
+
+struct AggregateStatisticsInput {
+	AggregateStatisticsInput(optional_ptr<FunctionData> bind_data_p, vector<BaseStatistics> &child_stats_p,
+	                         optional_ptr<NodeStatistics> node_stats_p)
+	    : bind_data(bind_data_p), child_stats(child_stats_p), node_stats(node_stats_p) {
+	}
+
+	optional_ptr<FunctionData> bind_data;
+	vector<BaseStatistics> &child_stats;
+	optional_ptr<NodeStatistics> node_stats;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/function/aggregate_state.hpp
+++ b/src/include/duckdb/function/aggregate_state.hpp
@@ -42,6 +42,17 @@ struct AggregateUnaryInput {
 	}
 };
 
+struct AggregateBinaryInput {
+	AggregateBinaryInput(AggregateInputData &input_p, ValidityMask &left_mask_p, ValidityMask &right_mask_p)
+	    : input(input_p), left_mask(left_mask_p), right_mask(right_mask_p) {
+	}
+
+	AggregateInputData &input;
+	ValidityMask &left_mask;
+	ValidityMask &right_mask;
+	idx_t lidx;
+	idx_t ridx;
+};
 
 struct AggregateFinalizeData {
 	AggregateFinalizeData(Vector &result_p, AggregateInputData &input_p)

--- a/test/api/udf_function/udf_functions_to_test.hpp
+++ b/test/api/udf_function/udf_functions_to_test.hpp
@@ -375,16 +375,13 @@ struct UDFCovarOperation {
 	}
 
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const A_TYPE *x_data, const B_TYPE *y_data,
-	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+	static void Operation(STATE &state, const A_TYPE &x, const B_TYPE &y, AggregateBinaryInput &idata) {
 		// update running mean and d^2
 		const uint64_t n = ++(state.count);
 
-		const auto x = x_data[xidx];
 		const double dx = (x - state.meanx);
 		const double meanx = state.meanx + dx / n;
 
-		const auto y = y_data[yidx];
 		const double dy = (y - state.meany);
 		const double meany = state.meany + dy / n;
 

--- a/test/api/udf_function/udf_functions_to_test.hpp
+++ b/test/api/udf_function/udf_functions_to_test.hpp
@@ -318,36 +318,36 @@ struct udf_avg_state_t {
 
 struct UDFAverageFunction {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->count = 0;
-		state->sum = 0;
+	static void Initialize(STATE &state) {
+		state.count = 0;
+		state.sum = 0;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
-		state->sum += input[idx];
-		state->count++;
+	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		state.sum += input[idx];
+		state.count++;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE *state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask,
+	static void ConstantOperation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask,
 	                              idx_t count) {
-		state->count += count;
-		state->sum += input[0] * count;
+		state.count += count;
+		state.sum += input[0] * count;
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
-		target->count += source.count;
-		target->sum += source.sum;
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+		target.count += source.count;
+		target.sum += source.sum;
 	}
 
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (state->count == 0) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.count == 0) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = state->sum / state->count;
+			target = state.sum / state.count;
 		}
 	}
 
@@ -368,51 +368,51 @@ struct udf_covar_state_t {
 
 struct UDFCovarOperation {
 	template <class STATE>
-	static void Initialize(STATE *state) {
-		state->count = 0;
-		state->meanx = 0;
-		state->meany = 0;
-		state->co_moment = 0;
+	static void Initialize(STATE &state) {
+		state.count = 0;
+		state.meanx = 0;
+		state.meany = 0;
+		state.co_moment = 0;
 	}
 
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
-	static void Operation(STATE *state, AggregateInputData &, const A_TYPE *x_data, const B_TYPE *y_data,
+	static void Operation(STATE &state, AggregateInputData &, const A_TYPE *x_data, const B_TYPE *y_data,
 	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
 		// update running mean and d^2
-		const uint64_t n = ++(state->count);
+		const uint64_t n = ++(state.count);
 
 		const auto x = x_data[xidx];
-		const double dx = (x - state->meanx);
-		const double meanx = state->meanx + dx / n;
+		const double dx = (x - state.meanx);
+		const double meanx = state.meanx + dx / n;
 
 		const auto y = y_data[yidx];
-		const double dy = (y - state->meany);
-		const double meany = state->meany + dy / n;
+		const double dy = (y - state.meany);
+		const double meany = state.meany + dy / n;
 
-		const double C = state->co_moment + dx * (y - meany);
+		const double C = state.co_moment + dx * (y - meany);
 
-		state->meanx = meanx;
-		state->meany = meany;
-		state->co_moment = C;
+		state.meanx = meanx;
+		state.meany = meany;
+		state.co_moment = C;
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
-		if (target->count == 0) {
-			*target = source;
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+		if (target.count == 0) {
+			target = source;
 		} else if (source.count > 0) {
-			const auto count = target->count + source.count;
-			const auto meanx = (source.count * source.meanx + target->count * target->meanx) / count;
-			const auto meany = (source.count * source.meany + target->count * target->meany) / count;
+			const auto count = target.count + source.count;
+			const auto meanx = (source.count * source.meanx + target.count * target.meanx) / count;
+			const auto meany = (source.count * source.meany + target.count * target.meany) / count;
 
 			//  Schubert and Gertz SSDBM 2018, equation 21
-			const auto deltax = target->meanx - source.meanx;
-			const auto deltay = target->meany - source.meany;
-			target->co_moment =
-			    source.co_moment + target->co_moment + deltax * deltay * source.count * target->count / count;
-			target->meanx = meanx;
-			target->meany = meany;
-			target->count = count;
+			const auto deltax = target.meanx - source.meanx;
+			const auto deltay = target.meany - source.meany;
+			target.co_moment =
+			    source.co_moment + target.co_moment + deltax * deltay * source.count * target.count / count;
+			target.meanx = meanx;
+			target.meany = meany;
+			target.count = count;
 		}
 	}
 
@@ -423,11 +423,11 @@ struct UDFCovarOperation {
 
 struct UDFCovarPopOperation : public UDFCovarOperation {
 	template <class T, class STATE>
-	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
-		if (state->count == 0) {
-			mask.SetInvalid(idx);
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.count == 0) {
+			finalize_data.ReturnNull();
 		} else {
-			target[idx] = state->co_moment / state->count;
+			target = state.co_moment / state.count;
 		}
 	}
 };

--- a/test/api/udf_function/udf_functions_to_test.hpp
+++ b/test/api/udf_function/udf_functions_to_test.hpp
@@ -324,16 +324,15 @@ struct UDFAverageFunction {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void Operation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
-		state.sum += input[idx];
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+		state.sum += input;
 		state.count++;
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask,
-	                              idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &, idx_t count) {
 		state.count += count;
-		state.sum += input[0] * count;
+		state.sum += input * count;
 	}
 
 	template <class STATE, class OP>

--- a/test/sql/aggregate/aggregates/test_count.test
+++ b/test/sql/aggregate/aggregates/test_count.test
@@ -2,6 +2,15 @@
 # description: Test COUNT operator
 # group: [aggregates]
 
+mode skip
+
+# FIXME - prepared statements on COUNT DISTINCT run into an internal error
+
+statement ok
+PRAGMA enable_verification
+
+mode unskip
+
 # test counts on scalar values
 query IIIII
 SELECT COUNT(*), COUNT(1), COUNT(100), COUNT(NULL), COUNT(DISTINCT 1)
@@ -38,4 +47,3 @@ SELECT COUNT(1 ORDER BY 1)
 # cannot do DISTINCT *
 statement error
 SELECT COUNT(DISTINCT *) FROM integers
-

--- a/test/sql/aggregate/aggregates/test_count_all_types.test
+++ b/test/sql/aggregate/aggregates/test_count_all_types.test
@@ -1,0 +1,62 @@
+# name: test/sql/aggregate/aggregates/test_count_all_types.test
+# description: Test COUNT operator with different vector types
+# group: [aggregates]
+
+statement ok
+PRAGMA enable_verification
+
+foreach flatten false true
+
+query I nosort count_int
+SELECT COUNT(n) FROM test_vector_types(NULL::INT, ${flatten}) t(n);
+----
+
+query I nosort count_int_list
+SELECT list_aggr(n, 'count') FROM test_vector_types(NULL::INT[], ${flatten}) t(n);
+----
+
+query I nosort count_varchar
+SELECT COUNT(n) FROM test_vector_types(NULL::VARCHAR, ${flatten}) t(n);
+----
+
+query I nosort count_distinct_int
+SELECT COUNT(DISTINCT n) FROM test_vector_types(NULL::INT, ${flatten}) t(n);
+----
+
+query I nosort count_distinct_varchar
+SELECT COUNT(DISTINCT n) FROM test_vector_types(NULL::VARCHAR, ${flatten}) t(n);
+----
+
+query I nosort count_int_grouped
+SELECT n, COUNT(n) FROM test_vector_types(NULL::INT, ${flatten}) t(n) GROUP BY n;
+----
+
+endloop
+
+statement ok
+CREATE TABLE int(i INT);
+
+statement ok
+INSERT INTO int FROM range(128);
+INSERT INTO int SELECT NULL FROM range(128);
+INSERT INTO int FROM range(77);
+INSERT INTO int SELECT NULL FROM range(61);
+INSERT INTO int FROM range(88);
+INSERT INTO int SELECT NULL FROM range(33);
+INSERT INTO int FROM range(44);
+INSERT INTO int SELECT NULL FROM range(11);
+INSERT INTO int FROM range(13);
+INSERT INTO int SELECT NULL FROM range(27);
+
+query II
+SELECT COUNT(i), COUNT(rowid) FROM int
+----
+350	610
+
+query III
+SELECT rowid // 200 AS g, COUNT(i), COUNT(rowid) FROM int GROUP BY g
+----
+0	128	200
+1	83	200
+2	139	200
+3	0	10


### PR DESCRIPTION
This PR changes the `AggregateExecutor` interface to be simpler and no longer have pointers and arrays - but instead have references everywhere and use `optional_ptr` for optionals (such as the bind data). In addition we add some extra structures like `AggregateUnaryInput` that offer helper methods which further cleans up the interface.

Note that the actual `AggregateFunction` interface is unchanged - this only changes the `AggregateExecutor` helper that allows for easier implementation of aggregates (and that is used by most of our aggregate functions).

#### New Interface
```cpp
template <class STATE>
void Initialize(STATE &state) {
	state.count = 0;
	state.sum = 0;
}

template <class INPUT_TYPE, class STATE, class OP>
void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
	state.sum += input;
	state.count++;
}

template <class STATE, class OP>
void Combine(const STATE &source, STATE &target, AggregateInputData &) {
	target.count += source.count;
	target.sum += source.sum;
}

template <class T, class STATE>
void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
	if (state.count == 0) {
		finalize_data.ReturnNull();
	} else {
		target = state.sum / state.count;
	}
}
```

#### Old Interface
```cpp

template <class STATE>
void Initialize(STATE *state) {
	state->count = 0;
	state->sum = 0;
}

template <class INPUT_TYPE, class STATE, class OP>
void Operation(STATE *state, AggregateInputData &, const INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
	state->sum += input[idx];
	state->count++;
}

template <class STATE, class OP>
void Combine(const STATE &source, STATE *target, AggregateInputData &) {
	target->count += source.count;
	target->sum += source.sum;
}

template <class T, class STATE>
void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
	if (state->count == 0) {
		mask.SetInvalid(idx);
	} else {
		target[idx] = state->sum / state->count;
	}
}
```

One side-effect of this change is that the `Count` function can no longer use the `AggregateExecutor` - as that was previously reliant on ignoring the input data array to support input data of all types, which it can no longer do now that it is a reference instead of a pointer. 