### PR TITLE
Fix exception fmt

### DIFF
--- a/.github/config/uncovered_files.csv
+++ b/.github/config/uncovered_files.csv
@@ -26,7 +26,7 @@ common/enum_util.cpp	3512
 common/enums/expression_type.cpp	183
 common/enums/join_type.cpp	3
 common/exception.cpp	95
-common/exception_format_value.cpp	8
+common/exception_format_value.cpp	9
 common/field_writer.cpp	3
 common/file_buffer.cpp	5
 common/file_system.cpp	19

--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -17,6 +17,7 @@ on:
       - '!tools/jdbc/**'
       - '.github/workflows/**'
       - '!.github/workflows/Java.yml'
+      - '.github/config/uncovered_files.csv'
   pull_request:
     paths-ignore:
       - '**.md'
@@ -26,6 +27,7 @@ on:
       - '!tools/jdbc/**'
       - '.github/workflows/**'
       - '!.github/workflows/Java.yml'
+      - '.github/config/uncovered_files.csv'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{
     github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha

--- a/.github/workflows/Julia.yml
+++ b/.github/workflows/Julia.yml
@@ -17,6 +17,7 @@ on:
       - '!tools/juliapkg/**'
       - '.github/workflows/**'
       - '!.github/workflows/Julia.yml'
+      - '.github/config/uncovered_files.csv'
   pull_request:
     paths-ignore:
       - '**.md'
@@ -26,6 +27,7 @@ on:
       - '!tools/juliapkg/**'
       - '.github/workflows/**'
       - '!.github/workflows/Julia.yml'
+      - '.github/config/uncovered_files.csv'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -14,12 +14,14 @@ on:
       - 'tools/**'
       - '.github/workflows/**'
       - '!.github/workflows/LinuxRelease.yml'
+      - '.github/config/uncovered_files.csv'
   pull_request:
     paths-ignore:
       - '**.md'
       - 'tools/**'
       - '.github/workflows/**'
       - '!.github/workflows/LinuxRelease.yml'
+      - '.github/config/uncovered_files.csv'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -14,12 +14,14 @@ on:
       - 'tools/**'
       - '.github/workflows/**'
       - '!.github/workflows/Main.yml'
+      - '.github/config/uncovered_files.csv'
   pull_request:
     paths-ignore:
       - '**.md'
       - 'tools/**'
       - '.github/workflows/**'
       - '!.github/workflows/Main.yml'
+      - '.github/config/uncovered_files.csv'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -18,6 +18,7 @@ on:
       - '!tools/nodejs/**'
       - '.github/workflows/**'
       - '!.github/workflows/NodeJS.yml'
+      - '.github/config/uncovered_files.csv'
   pull_request:
     paths-ignore:
       - '**.md'
@@ -28,6 +29,7 @@ on:
       - '!tools/nodejs/**'
       - '.github/workflows/**'
       - '!.github/workflows/NodeJS.yml'
+      - '.github/config/uncovered_files.csv'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -14,6 +14,7 @@ on:
       - 'tools/**'
       - '.github/workflows/**'
       - '!.github/workflows/OSX.yml'
+      - '.github/config/uncovered_files.csv'
   pull_request:
     branches-ignore:
       - '**'

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -17,6 +17,7 @@ on:
       - '!tools/pythonpkg/**'
       - '.github/workflows/**'
       - '!.github/workflows/Python.yml'
+      - '.github/config/uncovered_files.csv'
   pull_request:
     paths-ignore:
       - '**.md'
@@ -26,6 +27,7 @@ on:
       - '!tools/pythonpkg/**'
       - '.github/workflows/**'
       - '!.github/workflows/Python.yml'
+      - '.github/config/uncovered_files.csv'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -17,6 +17,7 @@ on:
       - '!tools/rpkg/**'
       - '.github/workflows/**'
       - '!.github/workflows/R.yml'
+      - '.github/config/uncovered_files.csv'
   pull_request:
     paths-ignore:
       - '**.md'
@@ -26,6 +27,7 @@ on:
       - '!tools/rpkg/**'
       - '.github/workflows/**'
       - '!.github/workflows/R.yml'
+      - '.github/config/uncovered_files.csv'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -15,6 +15,7 @@ on:
       - '!tools/pythonpkg/**'
       - '.github/workflows/**'
       - '!.github/workflows/Regression.yml'
+      - '.github/config/uncovered_files.csv'
   pull_request:
     paths-ignore:
       - '**.md'
@@ -22,6 +23,7 @@ on:
       - '!tools/pythonpkg/**'
       - '.github/workflows/**'
       - '!.github/workflows/Regression.yml'
+      - '.github/config/uncovered_files.csv'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -17,6 +17,7 @@ on:
       - '!tools/swift/**'
       - '.github/workflows/**'
       - '!.github/workflows/Swift.yml'
+      - '.github/config/uncovered_files.csv'
   pull_request:
     paths-ignore:
       - '**.md'
@@ -26,6 +27,7 @@ on:
       - '!tools/swift/**'
       - '.github/workflows/**'
       - '!.github/workflows/Swift.yml'
+      - '.github/config/uncovered_files.csv'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}

--- a/.github/workflows/WebAssembly.yml
+++ b/.github/workflows/WebAssembly.yml
@@ -17,6 +17,7 @@ on:
       - '!tools/wasm/**'
       - '.github/workflows/**'
       - '!.github/workflows/WebAssembly.yml'
+      - '.github/config/uncovered_files.csv'
   pull_request:
     paths-ignore:
       - '**.md'
@@ -26,6 +27,7 @@ on:
       - '!tools/wasm/**'
       - '.github/workflows/**'
       - '!.github/workflows/WebAssembly.yml'
+      - '.github/config/uncovered_files.csv'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -15,6 +15,7 @@ on:
       - '!tools/odbc/**'
       - '.github/workflows/**'
       - '!.github/workflows/Windows.yml'
+      - '.github/config/uncovered_files.csv'
   pull_request:
     paths-ignore:
       - '**.md'
@@ -22,6 +23,7 @@ on:
       - '!tools/odbc/**'
       - '.github/workflows/**'
       - '!.github/workflows/Windows.yml'
+      - '.github/config/uncovered_files.csv'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -14,6 +14,7 @@ on:
       - 'tools/**'
       - '.github/workflows/**'
       - '!.github/workflows/cifuzz.yml'
+      - '.github/config/uncovered_files.csv'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -73,8 +73,11 @@ string Exception::ConstructMessageRecursive(const string &msg, std::vector<Excep
 		parameter_count++;
 	}
 	if (parameter_count != values.size()) {
-		throw InternalException("Expected %d parameters, received %d", parameter_count, values.size());
+		throw InternalException("Primary exception: %s\nSecondary exception in ConstructMessageRecursive: Expected %d "
+		                        "parameters, received %d",
+		                        msg.c_str(), parameter_count, values.size());
 	}
+
 #endif
 	return ExceptionFormatValue::Format(msg, values);
 }

--- a/src/common/exception_format_value.cpp
+++ b/src/common/exception_format_value.cpp
@@ -68,22 +68,27 @@ ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(hugeint_t value) {
 }
 
 string ExceptionFormatValue::Format(const string &msg, std::vector<ExceptionFormatValue> &values) {
-	std::vector<duckdb_fmt::basic_format_arg<duckdb_fmt::printf_context>> format_args;
-	for (auto &val : values) {
-		switch (val.type) {
-		case ExceptionFormatValueType::FORMAT_VALUE_TYPE_DOUBLE:
-			format_args.push_back(duckdb_fmt::internal::make_arg<duckdb_fmt::printf_context>(val.dbl_val));
-			break;
-		case ExceptionFormatValueType::FORMAT_VALUE_TYPE_INTEGER:
-			format_args.push_back(duckdb_fmt::internal::make_arg<duckdb_fmt::printf_context>(val.int_val));
-			break;
-		case ExceptionFormatValueType::FORMAT_VALUE_TYPE_STRING:
-			format_args.push_back(duckdb_fmt::internal::make_arg<duckdb_fmt::printf_context>(val.str_val));
-			break;
+	try {
+		std::vector<duckdb_fmt::basic_format_arg<duckdb_fmt::printf_context>> format_args;
+		for (auto &val : values) {
+			switch (val.type) {
+			case ExceptionFormatValueType::FORMAT_VALUE_TYPE_DOUBLE:
+				format_args.push_back(duckdb_fmt::internal::make_arg<duckdb_fmt::printf_context>(val.dbl_val));
+				break;
+			case ExceptionFormatValueType::FORMAT_VALUE_TYPE_INTEGER:
+				format_args.push_back(duckdb_fmt::internal::make_arg<duckdb_fmt::printf_context>(val.int_val));
+				break;
+			case ExceptionFormatValueType::FORMAT_VALUE_TYPE_STRING:
+				format_args.push_back(duckdb_fmt::internal::make_arg<duckdb_fmt::printf_context>(val.str_val));
+				break;
+			}
 		}
+		return duckdb_fmt::vsprintf(msg, duckdb_fmt::basic_format_args<duckdb_fmt::printf_context>(
+		                                     format_args.data(), static_cast<int>(format_args.size())));
+	} catch (std::exception &ex) {
+		throw InternalException(std::string("Primary exception: ") + msg +
+		                        "\nSecondary exception in ExceptionFormatValue: " + ex.what());
 	}
-	return duckdb_fmt::vsprintf(msg, duckdb_fmt::basic_format_args<duckdb_fmt::printf_context>(
-	                                     format_args.data(), static_cast<int>(format_args.size())));
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -105,6 +105,9 @@ public:
 
 	template <typename... Args>
 	static string ConstructMessage(const string &msg, Args... params) {
+		const std::size_t num_args = sizeof...(Args);
+		if (num_args == 0)
+			return msg;
 		std::vector<ExceptionFormatValue> values;
 		return ConstructMessageRecursive(msg, values, params...);
 	}


### PR DESCRIPTION
First commit guard any exception happening during formatting of exceptions, and rely to the user both primary exception message AND the [developer-oriented] exception message relative to formatting in a single message.

Second commit avoid formatting IFF a single std::string is passed in input.
This solves the problem in the example, but potentially also others where '%' are present in the string.

Fixes #7677.