### PR TITLE
Fix issue with setup.py builds without dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -924,7 +924,9 @@ if(BUILD_PYTHON
     string(TOUPPER ${OOTE_NAME} OOTE_NAME_UPPERCASE)
     if (${DUCKDB_OOT_EXTENSION_${OOTE_NAME_UPPERCASE}_SHOULD_LINK})
       get_target_property(OOTE_LINKED_LIBS ${OOTE_NAME}_extension LINK_LIBRARIES)
-      set(duckdb_libs ${OOTE_LINKED_LIBS} ${duckdb_libs})
+      if (NOT "${OOTE_LINKED_LIBS}" STREQUAL "OOTE_LINKED_LIBS-NOTFOUND")
+        set(duckdb_libs ${OOTE_LINKED_LIBS} ${duckdb_libs})
+      endif()
     endif()
   endforeach()
 


### PR DESCRIPTION
this thing broke when extension have no dependencies, now it does not. This breaks some statically linked extension builds with package-build.py for out-of-tree extensions. This means that currently for v0.8.0 you can not create python binaries with the out-of-tree extension built in. Of course you can still just load the loadable extension binary from python. 