### PR TITLE
expose the `StripUnicodeSpaces` parser utility method

### DIFF
--- a/src/include/duckdb/parser/parser.hpp
+++ b/src/include/duckdb/parser/parser.hpp
@@ -62,6 +62,8 @@ public:
 	//! Parses a column list (i.e. as found in a CREATE TABLE statement)
 	static ColumnList ParseColumnList(const string &column_list, ParserOptions options = ParserOptions());
 
+	static bool StripUnicodeSpaces(const string &query_str, string &new_query);
+
 private:
 	ParserOptions options;
 };

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -45,7 +45,7 @@ static bool ReplaceUnicodeSpaces(const string &query, string &new_query, vector<
 // This function strips unicode space characters from the query and replaces them with regular spaces
 // It returns true if any unicode space characters were found and stripped
 // See here for a list of unicode space characters - https://jkorpela.fi/chars/spaces.html
-static bool StripUnicodeSpaces(const string &query_str, string &new_query) {
+bool Parser::StripUnicodeSpaces(const string &query_str, string &new_query) {
 	const idx_t NBSP_LEN = 2;
 	const idx_t USP_LEN = 3;
 	idx_t pos = 0;


### PR DESCRIPTION
This will allow us to now have to copy over the method when implementing our custom parser.