### PR TITLE
Allow core duckdb to handle unrecognized JDBC configuration

### DIFF
--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -315,13 +315,10 @@ JNIEXPORT jobject JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1startup(JNI
 			D_ASSERT(env->IsInstanceOf(value, J_String));
 			const string &value_str = jstring_to_string(env, (jstring)value);
 
-			auto const pOption = DBConfig::GetOptionByName(key_str);
-			if (pOption) {
-				config.SetOption(*pOption, Value(value_str));
-			} else {
-				throw CatalogException(
-				    "unrecognized configuration parameter \"%s\"\n%s", key_str,
-				    StringUtil::CandidatesErrorMessage(DBConfig::GetOptionNames(), key_str, "Did you mean"));
+			try {
+				config.SetOptionByName(key_str, Value(value_str));
+			} catch (Exception e) {
+				throw CatalogException("Failed to set configuration option \"%s\"", key_str, e.what());
 			}
 		}
 		bool cache_instance = database != ":memory:" && !database.empty();

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -2788,7 +2788,19 @@ public class TestDuckDBJDBC {
 				SQLException.class
 		);
 
-		assertTrue(message.contains("unrecognized configuration parameter \"invalid config name\""));
+		assertTrue(message.contains("Unrecognized configuration property \"invalid config name\""));
+	}
+
+	public static void test_valid_but_local_config_throws_exception() throws Exception {
+		Properties info = new Properties();
+		info.put("ordered_aggregate_threshold", "123");
+
+		String message = assertThrows(
+				() -> DriverManager.getConnection("jdbc:duckdb:", info),
+				SQLException.class
+		);
+
+		assertTrue(message.contains("Failed to set configuration option \"ordered_aggregate_threshold\""));
 	}
 
 	private static String getSetting(Connection conn, String settingName) throws Exception {
@@ -3619,7 +3631,7 @@ public class TestDuckDBJDBC {
 			System.out.println("No tests found that match " + specific_test);
 			System.exit(1);
 		}
-		System.out.println("OK");
+		System.out.println(anyFailed ? "FAILED" : "OK");
 
 		System.exit(anyFailed ? 1 : 0);
 	}


### PR DESCRIPTION
In https://github.com/duckdb/duckdb/commit/de7e0667f06f5ab7e50121d1d54a9cf39dde4620, DuckDB acquired ability to postpone decisions on whether an option was truly unrecognized until after the extensions could claim their options.

When passing options from JDBC, there is currently a difference between extension options passed through URL parameters (they work) and those passed through the connection property map (they fail due to not being recognized as valid core DuckDB settings).

This PR:
- removes the logic for eagerly failing on an unrecognized DuckDB setting from the JDBC driver, instead delegating to DuckDB core.
- updates `TestDuckDBJDBC.test_invalid_config` to reflect the slightly different core DuckDB error message.

Other changes:
- Adds a `test_valid_but_local_config_throws_exception` to verify failures on valid configuration options that nonetheless cannot be set when creating a connection.
- In TestDuckDBJDBC.java, updates the final test suite message to be `FAILED` rather than `OK` if any failing tests were found. This line is unrelated to the PR's substance; happy to remove it.


Affiliation: MotherDuck