### PR TITLE
Fix crash in `ArrowTableFunction::GetArrowLogicalType` on Linux

### DIFF
--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -206,8 +206,8 @@ unique_ptr<FunctionData> ArrowTableFunction::ArrowScanBind(ClientContext &contex
 			throw InvalidInputException("arrow_scan: released schema passed");
 		}
 		if (schema.dictionary) {
-			res->arrow_convert_data[col_idx] =
-			    make_uniq<ArrowConvertData>(GetArrowLogicalType(schema, res->arrow_convert_data, col_idx));
+			auto logical_type = GetArrowLogicalType(schema, res->arrow_convert_data, col_idx);
+			res->arrow_convert_data[col_idx] = make_uniq<ArrowConvertData>(std::move(logical_type));
 			return_types.emplace_back(GetArrowLogicalType(*schema.dictionary, res->arrow_convert_data, col_idx));
 		} else {
 			return_types.emplace_back(GetArrowLogicalType(schema, res->arrow_convert_data, col_idx));

--- a/tools/pythonpkg/tests/fast/arrow/test_7699.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_7699.py
@@ -1,0 +1,22 @@
+import duckdb
+import pytest
+import string
+
+pa = pytest.importorskip("pyarrow")
+pq = pytest.importorskip("pyarrow.parquet")
+pl = pytest.importorskip("polars")
+
+class Test7699(object):
+    def test_7699(self):
+        pl_tbl = pl.DataFrame({
+            "col1" : pl.Series([
+                string.ascii_uppercase[ix+10] for ix in list(range(2)) + list(range(3))
+            ]).cast(pl.Categorical),
+        })
+
+        nickname = "df1234"
+        duckdb.register(nickname, pl_tbl)
+
+        rel = duckdb.sql("select * from df1234")
+        res = rel.fetchall()
+        assert res == [('K',), ('L',), ('K',), ('L',), ('M',)]


### PR DESCRIPTION
This PR fixes #7699 

We were relying on undefined behavior in order of operations, this behavior was different in linux, which caused a crash.
I explain the issue in more detail in a reaction to the issue.

I'm not entirely sold on this solution, because this creates an instance of ArrowConvertData within `GetArrowLogicalType` and populates it with type-specific data.
But then once we get out of this method, we override it with a new instance of ArrowConvertData.

I believe this is the current behavior on Mac.

The instances are created with different constructors so I couldn't quickly figure out if this behavior is expected or not, maybe Pedro can have a look to let me know if this is in fact the right behavior or not.