### PR TITLE
[Dev] Fix failing assertion in python debug

### DIFF
--- a/src/include/duckdb/function/function_serialization.hpp
+++ b/src/include/duckdb/function/function_serialization.hpp
@@ -25,8 +25,10 @@ public:
 		bool serialize = function.serialize;
 		writer.WriteField(serialize);
 		if (serialize) {
-			D_ASSERT(function.deserialize);
 			function.serialize(writer, bind_info, function);
+			// First check if serialize throws a NotImplementedException, in which case it doesn't require a deserialize
+			// function
+			D_ASSERT(function.deserialize);
 		}
 	}
 


### PR DESCRIPTION
```
tools/pythonpkg/tests/fast/pandas/test_pandas_category.py:98: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

category = ['0', '1', '2', '3', '4', '5', ...]

    def check_create_table(category):
        conn = duckdb.connect()
    
        conn.execute ("PRAGMA enable_verification")
        df_in = pd.DataFrame({
        'x': pd.Categorical(category, ordered=True),
        'y': pd.Categorical(category, ordered=True)
        })
    
        df_out = duckdb.query_df(df_in, "data", "SELECT * FROM data").df()
        assert df_in.equals(df_out)
    
>       conn.execute("CREATE TABLE t1 AS SELECT * FROM df_in")
E       duckdb.InternalException: INTERNAL Error: Assertion triggered in file "/Users/thijs/DuckDBLabs/duckdb/src/include/duckdb/function/function_serialization.hpp" on line 28: function.deserialize

tools/pythonpkg/tests/fast/pandas/test_pandas_category.py:29: InternalException
===================================== short test summary info ======================================
FAILED tools/pythonpkg/tests/fast/pandas/test_pandas_category.py::TestCategory::test_category_string_uint8
```

Because some `serialize` functions are created, but throw a NotImplementedException, they won't have a deserialize function

Which would cause the assertion to fail.
By delaying it until after the serialization function has run, we avoid the assertion triggering in this case.