### PR TITLE
[Python] Fix tests for Pandas 2.0.2

### DIFF
--- a/tools/pythonpkg/src/pandas/analyzer.cpp
+++ b/tools/pythonpkg/src/pandas/analyzer.cpp
@@ -272,10 +272,20 @@ LogicalType PandasAnalyzer::GetItemType(py::handle ele, bool &can_convert) {
 		}
 		return type;
 	}
-	case PythonObjectType::Datetime:
+	case PythonObjectType::Datetime: {
+		auto tzinfo = ele.attr("tzinfo");
+		if (!py::none().is(tzinfo)) {
+			return LogicalType::TIMESTAMP_TZ;
+		}
 		return LogicalType::TIMESTAMP;
-	case PythonObjectType::Time:
+	}
+	case PythonObjectType::Time: {
+		auto tzinfo = ele.attr("tzinfo");
+		if (!py::none().is(tzinfo)) {
+			return LogicalType::TIME_TZ;
+		}
 		return LogicalType::TIME;
+	}
 	case PythonObjectType::Date:
 		return LogicalType::DATE;
 	case PythonObjectType::Timedelta:

--- a/tools/pythonpkg/tests/fast/pandas/test_datetime_timestamp.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_datetime_timestamp.py
@@ -3,6 +3,8 @@ import datetime
 import numpy as np
 import pytest
 from conftest import NumpyPandas, ArrowPandas
+from packaging.version import Version
+pd = pytest.importorskip("pandas")
 
 class TestDateTimeTimeStamp(object):
 
@@ -24,6 +26,7 @@ class TestDateTimeTimeStamp(object):
         df_out = duckdb.query_df(df_in, "df", "select * from df").df()
         pandas.testing.assert_frame_equal(df_out, duckdb_time)
 
+    @pytest.mark.skipif(Version(pd.__version__) < Version('2.0.2'), reason="pandas < 2.0.2 does not properly convert timezones")
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
     def test_timestamp_timezone_regular(self, pandas):
         duckdb_time = duckdb.query("""
@@ -40,6 +43,7 @@ class TestDateTimeTimeStamp(object):
         print(duckdb_time)
         pandas.testing.assert_frame_equal(df_out, duckdb_time)
 
+    @pytest.mark.skipif(Version(pd.__version__) < Version('2.0.2'), reason="pandas < 2.0.2 does not properly convert timezones")
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
     def test_timestamp_timezone_negative_extreme(self, pandas):
         duckdb_time = duckdb.query("""
@@ -61,6 +65,7 @@ class TestDateTimeTimeStamp(object):
         df_out = duckdb.query_df(df_in, "df", "select * from df").df()
         pandas.testing.assert_frame_equal(df_out, duckdb_time)
 
+    @pytest.mark.skipif(Version(pd.__version__) < Version('2.0.2'), reason="pandas < 2.0.2 does not properly convert timezones")
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
     def test_timestamp_timezone_positive_extreme(self, pandas):
         duckdb_time = duckdb.query("""

--- a/tools/pythonpkg/tests/fast/pandas/test_datetime_timestamp.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_datetime_timestamp.py
@@ -7,7 +7,7 @@ from conftest import NumpyPandas, ArrowPandas
 class TestDateTimeTimeStamp(object):
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_timestamp_high(self, duckdb_cursor, pandas):
+    def test_timestamp_high(self, pandas):
         duckdb_time = duckdb.query("SELECT '2260-01-01 23:59:00'::TIMESTAMP AS '0'").df()
         df_in = pandas.DataFrame(
             {0: pandas.Series(data=[datetime.datetime(year=2260, month=1, day=1, hour=23, minute=59)], dtype='object')}
@@ -16,7 +16,7 @@ class TestDateTimeTimeStamp(object):
         pandas.testing.assert_frame_equal(df_out, duckdb_time)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_timestamp_low(self, duckdb_cursor, pandas):
+    def test_timestamp_low(self, pandas):
         duckdb_time = duckdb.query("SELECT '1680-01-01 23:59:00'::TIMESTAMP AS '0'").df()
         df_in = pandas.DataFrame(
             {0: pandas.Series(data=[datetime.datetime(year=1680, month=1, day=1, hour=23, minute=59)], dtype='object')}
@@ -25,37 +25,60 @@ class TestDateTimeTimeStamp(object):
         pandas.testing.assert_frame_equal(df_out, duckdb_time)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_timestamp_timezone_regular(self, duckdb_cursor, pandas):
-        duckdb_time = duckdb.query("SELECT '2022-01-01 12:00:00'::TIMESTAMP AS '0'").df()
-        # time is 3 hours ahead of UTC
-        offset = datetime.timedelta(hours=3)
+    def test_timestamp_timezone_regular(self, pandas):
+        duckdb_time = duckdb.query("""
+            SELECT timestamp '2022-01-01 12:00:00' AT TIME ZONE 'Pacific/Easter' as "0"
+        """).df()
+
+        offset = datetime.timedelta(hours=-2)
         timezone = datetime.timezone(offset)
         df_in = pandas.DataFrame(
             {0: pandas.Series(data=[datetime.datetime(year=2022, month=1, day=1, hour=15, tzinfo=timezone)], dtype='object')}
         )
         df_out = duckdb.query_df(df_in, "df", "select * from df").df()
+        print(df_out)
+        print(duckdb_time)
         pandas.testing.assert_frame_equal(df_out, duckdb_time)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_timestamp_timezone_negative_extreme(self, duckdb_cursor, pandas):
-        duckdb_time = duckdb.query("SELECT '2022-01-01 12:00:00'::TIMESTAMP AS '0'").df()
-        # time is 14 hours behind UTC
-        offset = datetime.timedelta(hours=-14)
+    def test_timestamp_timezone_negative_extreme(self, pandas):
+        duckdb_time = duckdb.query("""
+            SELECT timestamp '2022-01-01 12:00:00' AT TIME ZONE 'Chile/EasterIsland' as "0"
+        """).df()
+
+        offset = datetime.timedelta(hours=-19)
         timezone = datetime.timezone(offset)
+
         df_in = pandas.DataFrame(
-            {0: pandas.Series(data=[datetime.datetime(year=2021, month=12, day=31, hour=22, tzinfo=timezone)], dtype='object')}
+            {0: pandas.Series(data=[datetime.datetime(
+                year=2021,
+                month=12,
+                day=31,
+                hour=22,
+                tzinfo=timezone
+            )], dtype='object')}
         )
         df_out = duckdb.query_df(df_in, "df", "select * from df").df()
         pandas.testing.assert_frame_equal(df_out, duckdb_time)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_timestamp_timezone_positive_extreme(self, duckdb_cursor, pandas):
-        duckdb_time = duckdb.query("SELECT '2021-12-31 23:00:00'::TIMESTAMP AS '0'").df()
-        # time is 20 hours ahead of UTC
+    def test_timestamp_timezone_positive_extreme(self, pandas):
+        duckdb_time = duckdb.query("""
+            SELECT timestamp '2021-12-31 23:00:00' AT TIME ZONE 'kea_CV' as "0"
+        """).df()
+
+        # 'kea_CV' is 20 hours ahead of UTC
         offset = datetime.timedelta(hours=20)
         timezone = datetime.timezone(offset)
+
         df_in = pandas.DataFrame(
-            {0: pandas.Series(data=[datetime.datetime(year=2022, month=1, day=1, hour=19, tzinfo=timezone)], dtype='object')}
+            {0: pandas.Series(data=[datetime.datetime(
+                year=2022,
+                month=1,
+                day=1,
+                hour=19,
+                tzinfo=timezone
+            )], dtype='object')}
         )
-        df_out = duckdb.query_df(df_in, "df", "select * from df").df()
+        df_out = duckdb.query_df(df_in, "df", """select * from df""").df()
         pandas.testing.assert_frame_equal(df_out, duckdb_time)


### PR DESCRIPTION
This PR should fix the recent CI failures in `tools/pythonpkg/tests/fast/pandas/test_datetime_timestamp.py`.

Notable changes:
- These tests now create a duckdb timestamp with timezone in a fixed timezone
- PandasAnalyzer now properly detects that a `datetime.datetime` / `datetime.time` object has `tzinfo` and properly detects the `_TZ` version of the LogicalType for it now.