### PR TITLE
Fuzzer #156: Copy Before Swizzle

### DIFF
--- a/src/common/types/row/row_data_collection_scanner.cpp
+++ b/src/common/types/row/row_data_collection_scanner.cpp
@@ -101,15 +101,16 @@ void RowDataCollectionScanner::AlignHeapBlocks(RowDataCollection &swizzled_block
 			    make_uniq<RowDataBlock>(buffer_manager, MaxValue<idx_t>(total_size, (idx_t)Storage::BLOCK_SIZE), 1));
 			auto new_heap_handle = buffer_manager.Pin(swizzled_string_heap.blocks.back()->block);
 			auto new_heap_ptr = new_heap_handle.Ptr();
+			for (auto &ptr_and_size : ptrs_and_sizes) {
+				memcpy(new_heap_ptr, ptr_and_size.first, ptr_and_size.second);
+				new_heap_ptr += ptr_and_size.second;
+			}
+			new_heap_ptr = new_heap_handle.Ptr();
 			if (swizzled_string_heap.keep_pinned) {
 				// Since the heap blocks are pinned, we can unswizzle the data again.
 				swizzled_string_heap.pinned_blocks.emplace_back(std::move(new_heap_handle));
 				RowOperations::UnswizzlePointers(layout, base_row_ptr, new_heap_ptr, data_block->count);
 				RowOperations::UnswizzleHeapPointer(layout, base_row_ptr, new_heap_ptr, data_block->count);
-			}
-			for (auto &ptr_and_size : ptrs_and_sizes) {
-				memcpy(new_heap_ptr, ptr_and_size.first, ptr_and_size.second);
-				new_heap_ptr += ptr_and_size.second;
 			}
 		}
 	}

--- a/test/sql/window/test_split_partition_heap.test
+++ b/test/sql/window/test_split_partition_heap.test
@@ -1,0 +1,12 @@
+# name: test/sql/window/test_split_partition_heap.test
+# description: Validate AlignHeapBlocks whith 2 heap : 1 data
+# group: [window]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table partsupp as select uuid()::varchar as c5 from range(8000);
+
+statement ok
+SELECT (ntile(5002) OVER (ROWS BETWEEN CURRENT ROW AND CURRENT ROW) >= 0), c5 FROM partsupp;


### PR DESCRIPTION
The new string validation logic assumes that the string data is copied before the pointers are swizzled.