### PR TITLE
fix(httpfs): correct listobjectv2_url for strict s3/http servers

### DIFF
--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -1020,7 +1020,7 @@ string AWSListObjectV2::Request(string &path, HTTPParams &http_params, S3AuthPar
 		req_params += "&delimiter=%2F";
 	}
 
-	string listobjectv2_url = parsed_url.http_proto + parsed_url.host + req_path + "?" + req_params;
+	string listobjectv2_url = req_path + "?" + req_params;
 
 	auto header_map =
 	    create_s3_header(req_path, req_params, parsed_url.host, "s3", "GET", s3_auth_params, "", "", "", "");


### PR DESCRIPTION
Fixes #7698 

I've tested this manually with S3, R2, and Scaleway, and it seems to now work on all three.
Previously we were sending the full URL in place of the path + query params, which is invalid according to the HTTP protocol spec, but apparently happens enough that most HTTP servers accept it okay. Given this is a protocol-level issue, I'm not sure if I can write a test for it