### PR TITLE
JSON fixes

### DIFF
--- a/extension/json/buffered_json_reader.cpp
+++ b/extension/json/buffered_json_reader.cpp
@@ -30,6 +30,10 @@ JSONFileHandle::JSONFileHandle(unique_ptr<FileHandle> file_handle_p, Allocator &
       requested_reads(0), actual_reads(0), cached_size(0) {
 }
 
+bool JSONFileHandle::IsOpen() const {
+	return file_handle != nullptr;
+}
+
 void JSONFileHandle::Close() {
 	if (file_handle) {
 		file_handle->Close();
@@ -62,19 +66,20 @@ idx_t JSONFileHandle::GetPositionAndSize(idx_t &position, idx_t requested_size) 
 	if (actual_size != 0) {
 		requested_reads++;
 	}
+
 	return actual_size;
 }
 
-void JSONFileHandle::ReadAtPosition(const char *pointer, idx_t size, idx_t position, bool sample_run) {
+void JSONFileHandle::ReadAtPosition(char *pointer, idx_t size, idx_t position, bool sample_run) {
 	D_ASSERT(size != 0);
 	if (plain_file_source) {
-		file_handle->Read((void *)pointer, size, position);
+		file_handle->Read(pointer, size, position);
 		actual_reads++;
 		return;
 	}
 
 	if (sample_run) { // Cache the buffer
-		file_handle->Read((void *)pointer, size, position);
+		file_handle->Read(pointer, size, position);
 		actual_reads++;
 		cached_buffers.emplace_back(allocator.Allocate(size));
 		memcpy(cached_buffers.back().get(), pointer, size);
@@ -87,12 +92,12 @@ void JSONFileHandle::ReadAtPosition(const char *pointer, idx_t size, idx_t posit
 		actual_reads++;
 	}
 	if (size != 0) {
-		file_handle->Read((void *)pointer, size, position);
+		file_handle->Read(pointer, size, position);
 		actual_reads++;
 	}
 }
 
-idx_t JSONFileHandle::Read(const char *pointer, idx_t requested_size, bool sample_run) {
+idx_t JSONFileHandle::Read(char *pointer, idx_t requested_size, bool sample_run) {
 	D_ASSERT(requested_size != 0);
 	if (plain_file_source) {
 		auto actual_size = ReadInternal(pointer, requested_size);
@@ -121,7 +126,7 @@ idx_t JSONFileHandle::Read(const char *pointer, idx_t requested_size, bool sampl
 	return actual_size;
 }
 
-idx_t JSONFileHandle::ReadFromCache(const char *&pointer, idx_t &size, idx_t &position) {
+idx_t JSONFileHandle::ReadFromCache(char *&pointer, idx_t &size, idx_t &position) {
 	idx_t read_size = 0;
 	idx_t total_offset = 0;
 
@@ -134,7 +139,7 @@ idx_t JSONFileHandle::ReadFromCache(const char *&pointer, idx_t &size, idx_t &po
 		if (position < total_offset + cached_buffer.GetSize()) {
 			idx_t within_buffer_offset = position - total_offset;
 			idx_t copy_size = MinValue<idx_t>(size, cached_buffer.GetSize() - within_buffer_offset);
-			memcpy((void *)pointer, cached_buffer.get() + within_buffer_offset, copy_size);
+			memcpy(pointer, cached_buffer.get() + within_buffer_offset, copy_size);
 
 			read_size += copy_size;
 			pointer += copy_size;
@@ -147,11 +152,11 @@ idx_t JSONFileHandle::ReadFromCache(const char *&pointer, idx_t &size, idx_t &po
 	return read_size;
 }
 
-idx_t JSONFileHandle::ReadInternal(const char *pointer, const idx_t requested_size) {
+idx_t JSONFileHandle::ReadInternal(char *pointer, const idx_t requested_size) {
 	// Deal with reading from pipes
 	idx_t total_read_size = 0;
 	while (total_read_size < requested_size) {
-		auto read_size = file_handle->Read((void *)(pointer + total_read_size), requested_size - total_read_size);
+		auto read_size = file_handle->Read(pointer + total_read_size, requested_size - total_read_size);
 		if (read_size == 0) {
 			break;
 		}
@@ -165,6 +170,7 @@ BufferedJSONReader::BufferedJSONReader(ClientContext &context, BufferedJSONReade
 }
 
 void BufferedJSONReader::OpenJSONFile() {
+	D_ASSERT(!IsDone());
 	lock_guard<mutex> guard(lock);
 	auto &file_system = FileSystem::GetFileSystem(context);
 	auto regular_file_handle =
@@ -184,6 +190,13 @@ void BufferedJSONReader::CloseJSONFile() {
 
 bool BufferedJSONReader::IsOpen() const {
 	return file_handle != nullptr;
+}
+
+bool BufferedJSONReader::IsDone() const {
+	if (file_handle) {
+		return !file_handle->IsOpen();
+	}
+	return false;
 }
 
 BufferedJSONReaderOptions &BufferedJSONReader::GetOptions() {
@@ -210,10 +223,6 @@ JSONRecordType BufferedJSONReader::GetRecordType() const {
 void BufferedJSONReader::SetRecordType(duckdb::JSONRecordType type) {
 	D_ASSERT(options.record_type == JSONRecordType::AUTO_DETECT);
 	options.record_type = type;
-}
-
-bool BufferedJSONReader::IsParallel() const {
-	return options.format == JSONFormat::NEWLINE_DELIMITED && file_handle->CanSeek();
 }
 
 const string &BufferedJSONReader::GetFileName() const {

--- a/extension/json/buffered_json_reader.cpp
+++ b/extension/json/buffered_json_reader.cpp
@@ -297,7 +297,7 @@ void BufferedJSONReader::ThrowTransformError(idx_t buf_index, idx_t line_or_obje
                                              const string &error_message) {
 	string unit = options.format == JSONFormat::NEWLINE_DELIMITED ? "line" : "record/value";
 	auto line = GetLineNumber(buf_index, line_or_object_in_buf);
-	throw InvalidInputException("JSON transform error in file \"%s\", in %s %llu: %s.", file_name, unit, line,
+	throw InvalidInputException("JSON transform error in file \"%s\", in %s %llu: %s", file_name, unit, line,
 	                            error_message);
 }
 

--- a/extension/json/include/buffered_json_reader.hpp
+++ b/extension/json/include/buffered_json_reader.hpp
@@ -71,6 +71,7 @@ public:
 struct JSONFileHandle {
 public:
 	JSONFileHandle(unique_ptr<FileHandle> file_handle, Allocator &allocator);
+	bool IsOpen() const;
 	void Close();
 
 	idx_t FileSize() const;
@@ -80,15 +81,15 @@ public:
 	void Seek(idx_t position);
 
 	idx_t GetPositionAndSize(idx_t &position, idx_t requested_size);
-	void ReadAtPosition(const char *pointer, idx_t size, idx_t position, bool sample_run);
-	idx_t Read(const char *pointer, idx_t requested_size, bool sample_run);
+	void ReadAtPosition(char *pointer, idx_t size, idx_t position, bool sample_run);
+	idx_t Read(char *pointer, idx_t requested_size, bool sample_run);
 
 	void Reset();
 	bool RequestedReadsComplete();
 
 private:
-	idx_t ReadFromCache(const char *&pointer, idx_t &size, idx_t &position);
-	idx_t ReadInternal(const char *pointer, const idx_t requested_size);
+	idx_t ReadFromCache(char *&pointer, idx_t &size, idx_t &position);
+	idx_t ReadInternal(char *pointer, const idx_t requested_size);
 
 private:
 	//! The JSON file handle
@@ -139,6 +140,7 @@ public:
 	void OpenJSONFile();
 	void CloseJSONFile();
 	bool IsOpen() const;
+	bool IsDone() const;
 
 	BufferedJSONReaderOptions &GetOptions();
 	const BufferedJSONReaderOptions &GetOptions() const;
@@ -147,8 +149,6 @@ public:
 	void SetFormat(JSONFormat format);
 	JSONRecordType GetRecordType() const;
 	void SetRecordType(JSONRecordType type);
-
-	bool IsParallel() const;
 
 	const string &GetFileName() const;
 	JSONFileHandle &GetFileHandle() const;

--- a/extension/json/include/json_common.hpp
+++ b/extension/json/include/json_common.hpp
@@ -170,6 +170,16 @@ public:
 	}
 
 public:
+	template <class T>
+	static T *AllocateArray(yyjson_alc *alc, idx_t count) {
+		return reinterpret_cast<T *>(alc->malloc(alc->ctx, sizeof(T) * count));
+	}
+
+	template <class T>
+	static T *AllocateArray(yyjson_mut_doc *doc, idx_t count) {
+		return AllocateArray<T>(&doc->alc, count);
+	}
+
 	static inline yyjson_mut_doc *CreateDocument(yyjson_alc *alc) {
 		D_ASSERT(alc);
 		return yyjson_mut_doc_new(alc);
@@ -419,11 +429,11 @@ private:
 
 template <>
 inline char *JSONCommon::WriteVal(yyjson_val *val, yyjson_alc *alc, idx_t &len) {
-	return yyjson_val_write_opts(val, JSONCommon::WRITE_FLAG, alc, (size_t *)&len, nullptr);
+	return yyjson_val_write_opts(val, JSONCommon::WRITE_FLAG, alc, reinterpret_cast<size_t *>(&len), nullptr);
 }
 template <>
 inline char *JSONCommon::WriteVal(yyjson_mut_val *val, yyjson_alc *alc, idx_t &len) {
-	return yyjson_mut_val_write_opts(val, JSONCommon::WRITE_FLAG, alc, (size_t *)&len, nullptr);
+	return yyjson_mut_val_write_opts(val, JSONCommon::WRITE_FLAG, alc, reinterpret_cast<size_t *>(&len), nullptr);
 }
 
 template <>

--- a/extension/json/include/json_scan.hpp
+++ b/extension/json/include/json_scan.hpp
@@ -232,6 +232,8 @@ private:
 	void ThrowObjectSizeError(const idx_t object_size);
 	void ThrowInvalidAtEndError();
 
+	bool IsParallel(JSONScanGlobalState &gstate) const;
+
 private:
 	//! Bind data
 	const JSONScanData &bind_data;
@@ -245,7 +247,7 @@ private:
 	bool is_last;
 
 	//! Current buffer read info
-	const char *buffer_ptr;
+	char *buffer_ptr;
 	idx_t buffer_size;
 	idx_t buffer_offset;
 	idx_t prev_buffer_remainder;

--- a/extension/json/json_functions.cpp
+++ b/extension/json/json_functions.cpp
@@ -220,8 +220,8 @@ static bool CastVarcharToJSON(Vector &source, Vector &result, idx_t count, CastP
 	bool success = true;
 	UnaryExecutor::ExecuteWithNulls<string_t, string_t>(
 	    source, result, count, [&](string_t input, ValidityMask &mask, idx_t idx) {
-		    auto data = (char *)(input.GetData());
-		    auto length = input.GetSize();
+		    auto data = input.GetDataWriteable();
+		    const auto length = input.GetSize();
 
 		    yyjson_read_err error;
 		    auto doc = JSONCommon::ReadDocumentUnsafe(data, length, JSONCommon::READ_FLAG, alc, &error);
@@ -236,7 +236,7 @@ static bool CastVarcharToJSON(Vector &source, Vector &result, idx_t count, CastP
 		    }
 		    return input;
 	    });
-	result.Reinterpret(source);
+	StringVector::AddHeapReference(result, source);
 	return success;
 }
 

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -276,7 +276,7 @@ static void CreateValuesStruct(const StructNames &names, yyjson_mut_doc *doc, yy
 		vals[i] = yyjson_mut_obj(doc);
 	}
 	// Initialize re-usable array for the nested values
-	auto nested_vals = (yyjson_mut_val **)doc->alc.malloc(doc->alc.ctx, sizeof(yyjson_mut_val *) * count);
+	auto nested_vals = JSONCommon::AllocateArray<yyjson_mut_val *>(doc, count);
 
 	// Add the key/value pairs to the values
 	auto &entries = StructVector::GetEntries(value_v);
@@ -301,12 +301,12 @@ static void CreateValuesMap(const StructNames &names, yyjson_mut_doc *doc, yyjso
 	// Create nested keys
 	auto &map_key_v = MapVector::GetKeys(value_v);
 	auto map_key_count = ListVector::GetListSize(value_v);
-	auto nested_keys = (yyjson_mut_val **)doc->alc.malloc(doc->alc.ctx, sizeof(yyjson_mut_val *) * map_key_count);
+	auto nested_keys = JSONCommon::AllocateArray<yyjson_mut_val *>(doc, map_key_count);
 	TemplatedCreateValues<string_t, string_t>(doc, nested_keys, map_key_v, map_key_count);
 	// Create nested values
 	auto &map_val_v = MapVector::GetValues(value_v);
 	auto map_val_count = ListVector::GetListSize(value_v);
-	auto nested_vals = (yyjson_mut_val **)doc->alc.malloc(doc->alc.ctx, sizeof(yyjson_mut_val *) * map_val_count);
+	auto nested_vals = JSONCommon::AllocateArray<yyjson_mut_val *>(doc, map_val_count);
 	CreateValues(names, doc, nested_vals, map_val_v, map_val_count);
 	// Add the key/value pairs to the values
 	UnifiedVectorFormat map_data;
@@ -338,7 +338,7 @@ static void CreateValuesUnion(const StructNames &names, yyjson_mut_doc *doc, yyj
 	}
 
 	// Initialize re-usable array for the nested values
-	auto nested_vals = (yyjson_mut_val **)doc->alc.malloc(doc->alc.ctx, sizeof(yyjson_mut_val *) * count);
+	auto nested_vals = JSONCommon::AllocateArray<yyjson_mut_val *>(doc, count);
 
 	auto &tag_v = UnionVector::GetTags(value_v);
 	UnifiedVectorFormat tag_data;
@@ -384,7 +384,7 @@ static void CreateValuesList(const StructNames &names, yyjson_mut_doc *doc, yyjs
 	// Initialize array for the nested values
 	auto &child_v = ListVector::GetEntry(value_v);
 	auto child_count = ListVector::GetListSize(value_v);
-	auto nested_vals = (yyjson_mut_val **)doc->alc.malloc(doc->alc.ctx, sizeof(yyjson_mut_val *) * child_count);
+	auto nested_vals = JSONCommon::AllocateArray<yyjson_mut_val *>(doc, child_count);
 	// Fill nested_vals with list values
 	CreateValues(names, doc, nested_vals, child_v, child_count);
 	// Now we add the values to the appropriate JSON arrays
@@ -501,12 +501,12 @@ static void ObjectFunction(DataChunk &args, ExpressionState &state, Vector &resu
 	// Initialize values
 	const idx_t count = args.size();
 	auto doc = JSONCommon::CreateDocument(alc);
-	auto objs = (yyjson_mut_val **)alc->malloc(alc->ctx, sizeof(yyjson_mut_val *) * count);
+	auto objs = JSONCommon::AllocateArray<yyjson_mut_val *>(doc, count);
 	for (idx_t i = 0; i < count; i++) {
 		objs[i] = yyjson_mut_obj(doc);
 	}
 	// Initialize a re-usable value array
-	auto vals = (yyjson_mut_val **)alc->malloc(alc->ctx, sizeof(yyjson_mut_val *) * count);
+	auto vals = JSONCommon::AllocateArray<yyjson_mut_val *>(doc, count);
 	// Loop through key/value pairs
 	for (idx_t pair_idx = 0; pair_idx < args.data.size() / 2; pair_idx++) {
 		Vector &key_v = args.data[pair_idx * 2];
@@ -533,12 +533,12 @@ static void ArrayFunction(DataChunk &args, ExpressionState &state, Vector &resul
 	// Initialize arrays
 	const idx_t count = args.size();
 	auto doc = JSONCommon::CreateDocument(alc);
-	auto arrs = (yyjson_mut_val **)alc->malloc(alc->ctx, sizeof(yyjson_mut_val *) * count);
+	auto arrs = JSONCommon::AllocateArray<yyjson_mut_val *>(doc, count);
 	for (idx_t i = 0; i < count; i++) {
 		arrs[i] = yyjson_mut_arr(doc);
 	}
 	// Initialize a re-usable value array
-	auto vals = (yyjson_mut_val **)alc->malloc(alc->ctx, sizeof(yyjson_mut_val *) * count);
+	auto vals = JSONCommon::AllocateArray<yyjson_mut_val *>(doc, count);
 	// Loop through args
 	for (auto &v : args.data) {
 		CreateValues(info.const_struct_names, doc, vals, v, count);
@@ -561,7 +561,7 @@ static void ToJSONFunctionInternal(const StructNames &names, Vector &input, cons
                                    yyjson_alc *alc) {
 	// Initialize array for values
 	auto doc = JSONCommon::CreateDocument(alc);
-	auto vals = (yyjson_mut_val **)alc->malloc(alc->ctx, sizeof(yyjson_mut_val *) * count);
+	auto vals = JSONCommon::AllocateArray<yyjson_mut_val *>(doc, count);
 	CreateValues(names, doc, vals, input, count);
 
 	// Write JSON values to string

--- a/extension/json/json_functions/json_merge_patch.cpp
+++ b/extension/json/json_functions/json_merge_patch.cpp
@@ -59,11 +59,11 @@ static void MergePatchFunction(DataChunk &args, ExpressionState &state, Vector &
 	const auto count = args.size();
 
 	// Read the first json arg
-	auto origs = (yyjson_mut_val **)alc->malloc(alc->ctx, sizeof(yyjson_mut_val *) * count);
+	auto origs = JSONCommon::AllocateArray<yyjson_mut_val *>(alc, count);
 	ReadObjects(doc, args.data[0], origs, count);
 
 	// Read the next json args one by one and merge them into the first json arg
-	auto patches = (yyjson_mut_val **)alc->malloc(alc->ctx, sizeof(yyjson_mut_val *) * count);
+	auto patches = JSONCommon::AllocateArray<yyjson_mut_val *>(alc, count);
 	for (idx_t arg_idx = 1; arg_idx < args.data.size(); arg_idx++) {
 		ReadObjects(doc, args.data[arg_idx], patches, count);
 		for (idx_t i = 0; i < count; i++) {

--- a/extension/json/json_functions/json_serialize_sql.cpp
+++ b/extension/json/json_functions/json_serialize_sql.cpp
@@ -108,7 +108,7 @@ static void JsonSerializeFunction(DataChunk &args, ExpressionState &state, Vecto
 			idx_t len;
 			auto data = yyjson_mut_val_write_opts(result_obj,
 			                                      info.format ? JSONCommon::WRITE_PRETTY_FLAG : JSONCommon::WRITE_FLAG,
-			                                      alc, (size_t *)&len, nullptr);
+			                                      alc, reinterpret_cast<size_t *>(&len), nullptr);
 			if (data == nullptr) {
 				throw SerializationException(
 				    "Failed to serialize json, perhaps the query contains invalid utf8 characters?");
@@ -124,7 +124,7 @@ static void JsonSerializeFunction(DataChunk &args, ExpressionState &state, Vecto
 			idx_t len;
 			auto data = yyjson_mut_val_write_opts(result_obj,
 			                                      info.format ? JSONCommon::WRITE_PRETTY_FLAG : JSONCommon::WRITE_FLAG,
-			                                      alc, (size_t *)&len, nullptr);
+			                                      alc, reinterpret_cast<size_t *>(&len), nullptr);
 			return StringVector::AddString(result, data, len);
 		}
 	});

--- a/extension/json/json_functions/json_structure.cpp
+++ b/extension/json/json_functions/json_structure.cpp
@@ -150,7 +150,8 @@ void JSONStructureNode::RefineCandidateTypesArray(yyjson_val *vals[], idx_t coun
 	}
 
 	idx_t offset = 0;
-	auto child_vals = (yyjson_val **)allocator.AllocateAligned(total_list_size * sizeof(yyjson_val *));
+	auto child_vals =
+	    reinterpret_cast<yyjson_val **>(allocator.AllocateAligned(total_list_size * sizeof(yyjson_val *)));
 
 	size_t idx, max;
 	yyjson_val *child_val;
@@ -173,11 +174,12 @@ void JSONStructureNode::RefineCandidateTypesObject(yyjson_val *vals[], idx_t cou
 	vector<yyjson_val **> child_vals;
 	child_vals.reserve(child_count);
 	for (idx_t child_idx = 0; child_idx < child_count; child_idx++) {
-		child_vals.emplace_back((yyjson_val **)allocator.AllocateAligned(count * sizeof(yyjson_val *)));
+		child_vals.emplace_back(
+		    reinterpret_cast<yyjson_val **>(allocator.AllocateAligned(count * sizeof(yyjson_val *))));
 	}
 
 	idx_t found_key_count;
-	auto found_keys = (bool *)allocator.AllocateAligned(sizeof(bool) * child_count);
+	auto found_keys = reinterpret_cast<bool *>(allocator.AllocateAligned(sizeof(bool) * child_count));
 
 	const auto &key_map = desc.key_map;
 	size_t idx, max;

--- a/extension/json/json_functions/read_json.cpp
+++ b/extension/json/json_functions/read_json.cpp
@@ -258,7 +258,8 @@ static void ReadJSONFunction(ClientContext &context, TableFunctionInput &data_p,
 			string hint =
 			    gstate.bind_data.auto_detect
 			        ? "\nTry increasing 'sample_size', reducing 'maximum_depth', specifying 'columns', 'format' or "
-			          "'records' manually, or setting 'ignore_errors' to true."
+			          "'records' manually, setting 'ignore_errors' to true, or setting 'union_by_name' to true when "
+			          "reading multiple files with a different structure."
 			        : "\nTry setting 'auto_detect' to true, specifying 'format' or 'records' manually, or setting "
 			          "'ignore_errors' to true.";
 			lstate.ThrowTransformError(lstate.transform_options.object_index,

--- a/extension/json/json_scan.cpp
+++ b/extension/json/json_scan.cpp
@@ -244,14 +244,13 @@ unique_ptr<GlobalTableFunctionState> JSONGlobalTableFunctionState::Init(ClientCo
 
 idx_t JSONGlobalTableFunctionState::MaxThreads() const {
 	auto &bind_data = state.bind_data;
-	if (bind_data.options.format == JSONFormat::NEWLINE_DELIMITED &&
-	    bind_data.options.compression == FileCompressionType::UNCOMPRESSED) {
+	if (bind_data.options.format == JSONFormat::NEWLINE_DELIMITED) {
 		return state.system_threads;
 	}
 
 	if (!state.json_readers.empty() && state.json_readers[0]->IsOpen()) {
 		auto &reader = *state.json_readers[0];
-		if (reader.IsParallel()) { // Auto-detected parallel scan
+		if (reader.GetFormat() == JSONFormat::NEWLINE_DELIMITED) { // Auto-detected NDJSON
 			return state.system_threads;
 		}
 	}
@@ -298,6 +297,7 @@ idx_t JSONScanLocalState::ReadNext(JSONScanGlobalState &gstate) {
 		if (!ReadNextBuffer(gstate)) {
 			return scan_count;
 		}
+		D_ASSERT(buffer_size != 0);
 		if (current_buffer_handle->buffer_index != 0 && current_reader->GetFormat() == JSONFormat::NEWLINE_DELIMITED) {
 			ReconstructFirstObject(gstate);
 			scan_count++;
@@ -308,8 +308,8 @@ idx_t JSONScanLocalState::ReadNext(JSONScanGlobalState &gstate) {
 	return scan_count;
 }
 
-static inline const char *NextNewline(const char *ptr, idx_t size) {
-	return (const char *)memchr(ptr, '\n', size);
+static inline const char *NextNewline(char *ptr, idx_t size) {
+	return char_ptr_cast(memchr(ptr, '\n', size));
 }
 
 static inline const char *PreviousNewline(const char *ptr) {
@@ -455,7 +455,21 @@ void JSONScanLocalState::ThrowInvalidAtEndError() {
 	throw InvalidInputException("Invalid JSON detected at the end of file \"%s\".", current_reader->GetFileName());
 }
 
-static pair<JSONFormat, JSONRecordType> DetectFormatAndRecordType(const char *const buffer_ptr, const idx_t buffer_size,
+bool JSONScanLocalState::IsParallel(JSONScanGlobalState &gstate) const {
+	if (bind_data.files.size() >= gstate.system_threads) {
+		// More files than threads, just parallelize over the files
+		return false;
+	}
+
+	if (current_reader->GetFormat() == JSONFormat::NEWLINE_DELIMITED) {
+		// NDJSON can be read in parallel
+		return true;
+	}
+
+	return false;
+}
+
+static pair<JSONFormat, JSONRecordType> DetectFormatAndRecordType(char *const buffer_ptr, const idx_t buffer_size,
                                                                   yyjson_alc *alc) {
 	// First we do the easy check whether it's NEWLINE_DELIMITED
 	auto line_end = NextNewline(buffer_ptr, buffer_size);
@@ -464,7 +478,7 @@ static pair<JSONFormat, JSONRecordType> DetectFormatAndRecordType(const char *co
 		SkipWhitespace(buffer_ptr, line_size, buffer_size);
 
 		yyjson_read_err error;
-		auto doc = JSONCommon::ReadDocumentUnsafe((char *)buffer_ptr, line_size, JSONCommon::READ_FLAG, alc, &error);
+		auto doc = JSONCommon::ReadDocumentUnsafe(buffer_ptr, line_size, JSONCommon::READ_FLAG, alc, &error);
 		if (error.code == YYJSON_READ_SUCCESS) { // We successfully read the line
 			if (yyjson_is_arr(doc->root) && line_size == buffer_size) {
 				// It's just one array, let's actually assume ARRAY, not NEWLINE_DELIMITED
@@ -500,8 +514,8 @@ static pair<JSONFormat, JSONRecordType> DetectFormatAndRecordType(const char *co
 
 	// It's definitely an ARRAY, but now we have to figure out if there's more than one top-level array
 	yyjson_read_err error;
-	auto doc = JSONCommon::ReadDocumentUnsafe((char *)buffer_ptr + buffer_offset, remaining, JSONCommon::READ_STOP_FLAG,
-	                                          alc, &error);
+	auto doc =
+	    JSONCommon::ReadDocumentUnsafe(buffer_ptr + buffer_offset, remaining, JSONCommon::READ_STOP_FLAG, alc, &error);
 	if (error.code == YYJSON_READ_SUCCESS) {
 		D_ASSERT(yyjson_is_arr(doc->root));
 
@@ -563,7 +577,7 @@ bool JSONScanLocalState::ReadNextBuffer(JSONScanGlobalState &gstate) {
 	} else {
 		buffer = gstate.allocator.Allocate(gstate.buffer_capacity);
 	}
-	buffer_ptr = (const char *)buffer.get();
+	buffer_ptr = char_ptr_cast(buffer.get());
 
 	idx_t buffer_index;
 	while (true) {
@@ -573,7 +587,7 @@ bool JSONScanLocalState::ReadNextBuffer(JSONScanGlobalState &gstate) {
 				if (is_last && gstate.bind_data.type != JSONScanType::SAMPLE) {
 					current_reader->CloseJSONFile();
 				}
-				if (current_reader->IsParallel()) {
+				if (IsParallel(gstate)) {
 					// If this threads' current reader is still the one at gstate.file_index,
 					// this thread can end the parallel scan
 					lock_guard<mutex> guard(gstate.lock);
@@ -599,7 +613,7 @@ bool JSONScanLocalState::ReadNextBuffer(JSONScanGlobalState &gstate) {
 			current_reader = gstate.json_readers[gstate.file_index].get();
 			if (current_reader->IsOpen()) {
 				// Can only be open from auto detection, so these should be known
-				if (!current_reader->IsParallel()) {
+				if (!IsParallel(gstate)) {
 					batch_index = gstate.batch_index++;
 					gstate.file_index++;
 				}
@@ -609,15 +623,15 @@ bool JSONScanLocalState::ReadNextBuffer(JSONScanGlobalState &gstate) {
 			current_reader->OpenJSONFile();
 			batch_index = gstate.batch_index++;
 			if (current_reader->GetFormat() != JSONFormat::AUTO_DETECT) {
-				if (!current_reader->IsParallel()) {
+				if (!IsParallel(gstate)) {
 					gstate.file_index++;
 				}
 				continue;
 			}
 
-			// If we have a low amount of files, we auto-detect within the lock,
+			// If we have less files than threads, we auto-detect within the lock,
 			// so other threads may join a parallel NDJSON scan
-			if (gstate.json_readers.size() < 100) {
+			if (gstate.json_readers.size() < gstate.system_threads) {
 				if (ReadAndAutoDetect(gstate, buffer_index, false)) {
 					continue;
 				}
@@ -637,7 +651,7 @@ bool JSONScanLocalState::ReadNextBuffer(JSONScanGlobalState &gstate) {
 	D_ASSERT(buffer_size != 0); // We should have read something if we got here
 
 	idx_t readers = 1;
-	if (current_reader->IsParallel()) {
+	if (current_reader->GetFormat() == JSONFormat::NEWLINE_DELIMITED) {
 		readers = is_last ? 1 : 2;
 	}
 
@@ -650,7 +664,7 @@ bool JSONScanLocalState::ReadNextBuffer(JSONScanGlobalState &gstate) {
 	lines_or_objects_in_buffer = 0;
 
 	// YYJSON needs this
-	memset((void *)(buffer_ptr + buffer_size), 0, YYJSON_PADDING_SIZE);
+	memset(buffer_ptr + buffer_size, 0, YYJSON_PADDING_SIZE);
 
 	return true;
 }
@@ -680,7 +694,7 @@ bool JSONScanLocalState::ReadAndAutoDetect(JSONScanGlobalState &gstate, idx_t &b
 		throw InvalidInputException("Expected file \"%s\" to contain records, detected non-record JSON instead.",
 		                            current_reader->GetFileName());
 	}
-	if (!already_incremented_file_idx && !current_reader->IsParallel()) {
+	if (!already_incremented_file_idx && !IsParallel(gstate)) {
 		gstate.file_index++;
 	}
 	return false;
@@ -739,13 +753,14 @@ void JSONScanLocalState::ReadNextBufferNoSeek(JSONScanGlobalState &gstate, idx_t
 		lock_guard<mutex> reader_guard(current_reader->lock);
 		buffer_index = current_reader->GetBufferIndex();
 
-		if (current_reader->IsOpen()) {
+		if (current_reader->IsOpen() && !current_reader->IsDone()) {
 			read_size = current_reader->GetFileHandle().Read(buffer_ptr + prev_buffer_remainder, request_size,
 			                                                 gstate.bind_data.type == JSONScanType::SAMPLE);
+			is_last = read_size < request_size;
 		} else {
 			read_size = 0;
+			is_last = false;
 		}
-		is_last = read_size < request_size;
 
 		if (!gstate.bind_data.ignore_errors && read_size == 0 && prev_buffer_remainder != 0) {
 			ThrowInvalidAtEndError();
@@ -796,13 +811,13 @@ void JSONScanLocalState::ReconstructFirstObject(JSONScanGlobalState &gstate) {
 	D_ASSERT(current_reader->GetFormat() == JSONFormat::NEWLINE_DELIMITED);
 
 	// Spinlock until the previous batch index has also read its buffer
-	JSONBufferHandle *previous_buffer_handle = nullptr;
+	optional_ptr<JSONBufferHandle> previous_buffer_handle;
 	while (!previous_buffer_handle) {
 		previous_buffer_handle = current_reader->GetBuffer(current_buffer_handle->buffer_index - 1);
 	}
 
 	// First we find the newline in the previous block
-	auto prev_buffer_ptr = (const char *)previous_buffer_handle->buffer.get() + previous_buffer_handle->buffer_size;
+	auto prev_buffer_ptr = char_ptr_cast(previous_buffer_handle->buffer.get()) + previous_buffer_handle->buffer_size;
 	auto part1_ptr = PreviousNewline(prev_buffer_ptr);
 	auto part1_size = prev_buffer_ptr - part1_ptr;
 
@@ -825,7 +840,7 @@ void JSONScanLocalState::ReconstructFirstObject(JSONScanGlobalState &gstate) {
 
 	// And copy the remainder of the line to the reconstruct buffer
 	memcpy(reconstruct_ptr + part1_size, buffer_ptr, part2_size);
-	memset((void *)(reconstruct_ptr + line_size), 0, YYJSON_PADDING_SIZE);
+	memset(reconstruct_ptr + line_size, 0, YYJSON_PADDING_SIZE);
 	buffer_offset += part2_size;
 
 	// We copied the object, so we are no longer reading the previous buffer
@@ -833,7 +848,7 @@ void JSONScanLocalState::ReconstructFirstObject(JSONScanGlobalState &gstate) {
 		current_reader->RemoveBuffer(current_buffer_handle->buffer_index - 1);
 	}
 
-	ParseJSON((char *)reconstruct_ptr, line_size, line_size);
+	ParseJSON(char_ptr_cast(reconstruct_ptr), line_size, line_size);
 }
 
 void JSONScanLocalState::ParseNextChunk() {
@@ -867,7 +882,7 @@ void JSONScanLocalState::ParseNextChunk() {
 		}
 
 		idx_t json_size = json_end - json_start;
-		ParseJSON((char *)json_start, json_size, remaining);
+		ParseJSON(json_start, json_size, remaining);
 		buffer_offset += json_size;
 
 		if (format == JSONFormat::ARRAY) {

--- a/test/sql/json/test_json_copy.test_slow
+++ b/test/sql/json/test_json_copy.test_slow
@@ -248,8 +248,9 @@ set memory_limit='1gb'
 statement ok
 COPY lineitem from '__TEST_DIR__/lineitem.json' (ARRAY)
 
+# 4gb should be enough for the rest
 statement ok
-reset memory_limit
+set memory_limit='4gb'
 
 query I
 PRAGMA tpch(1)

--- a/test/sql/json/test_json_create.test
+++ b/test/sql/json/test_json_create.test
@@ -7,6 +7,12 @@ require json
 statement ok
 pragma enable_verification
 
+# issue #7727
+query T
+SELECT TRY_CAST('{{P{P{{{{ASD{AS{D{' AS JSON);
+----
+NULL
+
 query T
 select json_quote({n: 42})
 ----


### PR DESCRIPTION
Fixes #7727 (was already fixed in the feature branch in #7624, now fixed in master as well).

This PR also fixes #7729. We weren't properly checking when the file was closed/done. The regression was caused by no longer reading compressed files in parallel, which we now do again.

As a bonus, I've removed all C-style casts from the JSON extension and replaced them with safe casts.

I noticed something strange in `test/sql/json/test_json_copy.test_slow`. This test suddenly ran out of memory because `reset memory_limit` in the test didn't do anything for some reason. I couldn't reproduce this in the CLI, but I've fixed the test by setting the memory limit to 4GB instead.