### PR TITLE
Fuzzer #206: Fix Cast Overflow

### DIFF
--- a/extension/icu/icu-makedate.cpp
+++ b/extension/icu/icu-makedate.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/types/date.hpp"
 #include "duckdb/common/types/time.hpp"
 #include "duckdb/common/types/timestamp.hpp"
@@ -36,8 +37,8 @@ struct ICUMakeDate : public ICUDateFunc {
 
 	static bool CastToDate(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 		auto &cast_data = parameters.cast_data->Cast<CastData>();
-		auto info = (BindData *)cast_data.info.get();
-		CalendarPtr calendar(info->calendar->clone());
+		auto &info = cast_data.info->Cast<BindData>();
+		CalendarPtr calendar(info.calendar->clone());
 
 		UnaryExecutor::Execute<timestamp_t, date_t>(
 		    source, result, count, [&](timestamp_t input) { return Operation(calendar.get(), input); });
@@ -67,7 +68,7 @@ struct ICUMakeTimestampTZFunc : public ICUDateFunc {
 	static inline timestamp_t Operation(icu::Calendar *calendar, T yyyy, T mm, T dd, T hr, T mn, double ss) {
 		const auto year = yyyy + (yyyy < 0);
 
-		const auto secs = int32_t(ss);
+		const auto secs = Cast::Operation<double, int32_t>(ss);
 		ss -= secs;
 		ss *= Interval::MSECS_PER_SEC;
 		const auto millis = int32_t(ss);
@@ -87,7 +88,7 @@ struct ICUMakeTimestampTZFunc : public ICUDateFunc {
 	template <typename T>
 	static void Execute(DataChunk &input, ExpressionState &state, Vector &result) {
 		auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
-		auto &info = (BindData &)*func_expr.bind_info;
+		auto &info = func_expr.bind_info->Cast<BindData>();
 		CalendarPtr calendar_ptr(info.calendar->clone());
 		auto calendar = calendar_ptr.get();
 

--- a/test/fuzzer/sqlsmith/timestamptz_double_cast.test
+++ b/test/fuzzer/sqlsmith/timestamptz_double_cast.test
@@ -1,0 +1,25 @@
+# name: test/fuzzer/sqlsmith/timestamptz_double_cast.test
+# description: Test cast from large double to seconds
+# group: [sqlsmith]
+
+require icu
+
+statement ok
+create table all_types as 
+	select * exclude(small_enum, medium_enum, large_enum) 
+	from test_all_types();
+
+statement error
+SELECT 
+	arg_min(CAST(ref_0.timestamp_tz AS TIMESTAMP WITH TIME ZONE), 
+	CAST(make_timestamptz(
+		CAST(ref_0."bigint" AS BIGINT), 
+		CAST(ref_0."bigint" AS BIGINT), 
+		CAST(ref_0."bigint" AS BIGINT), 
+		CAST(ref_0."bigint" AS BIGINT), 
+		CAST(txid_current() AS BIGINT), 
+		CAST(ref_0."bigint" AS BIGINT)) AS TIMESTAMP WITH TIME ZONE)) 
+		OVER (PARTITION BY ref_0."smallint" ORDER BY ref_0.int_array) AS c2 
+FROM main.all_types AS ref_0
+----
+Invalid Input Error: Type DOUBLE with value


### PR DESCRIPTION
Use the cast code to extract 32 bit seconds from a double.