### PR TITLE
[Julia] Fix issue related to table function callbacks and IO

### DIFF
--- a/tools/juliapkg/src/result.jl
+++ b/tools/juliapkg/src/result.jl
@@ -704,6 +704,7 @@ function execute(stmt::Stmt, params::DBInterface.StatementParams = ())
     if Threads.nthreads() != 1
         # When we have additional worker threads, don't execute using the main thread
         while duckdb_execution_is_finished(stmt.con.handle) == false
+            Base.yield()
             GC.safepoint()
         end
     else

--- a/tools/juliapkg/src/result.jl
+++ b/tools/juliapkg/src/result.jl
@@ -652,8 +652,8 @@ function execute_tasks(state::duckdb_task_state, con::Connection)
         duckdb_execute_n_tasks_state(state, 1)
         if duckdb_execution_is_finished(con.handle)
             break
-        Base.yield()
-        GC.safepoint()
+            Base.yield()
+            GC.safepoint()
         end
     end
     return

--- a/tools/juliapkg/src/result.jl
+++ b/tools/juliapkg/src/result.jl
@@ -649,10 +649,11 @@ end
 # execute background tasks in a loop, until task execution is finished
 function execute_tasks(state::duckdb_task_state, con::Connection)
     while !duckdb_task_state_is_finished(state)
-        GC.safepoint()
         duckdb_execute_n_tasks_state(state, 1)
         if duckdb_execution_is_finished(con.handle)
             break
+        Base.yield()
+        GC.safepoint()
         end
     end
     return

--- a/tools/juliapkg/test/test_table_function.jl
+++ b/tools/juliapkg/test/test_table_function.jl
@@ -28,6 +28,27 @@ function my_init_function(info::DuckDB.InitInfo)
     return MyInitStruct()
 end
 
+function my_main_function_print(info::DuckDB.FunctionInfo, output::DuckDB.DataChunk)
+    bind_info = DuckDB.get_bind_info(info, MyBindStruct)
+    init_info = DuckDB.get_init_info(info, MyInitStruct)
+
+    result_array = DuckDB.get_array(output, 1, Int64)
+    count = 0
+    for i in 1:(DuckDB.VECTOR_SIZE)
+        if init_info.pos >= bind_info.count
+            break
+        end
+        result_array[count + 1] = init_info.pos % 2 == 0 ? 42 : 84
+        # We print within the table function to test behavior with synchronous API calls in Julia table functions
+        println(result_array[count + 1])
+        count += 1
+        init_info.pos += 1
+    end
+
+    DuckDB.set_size(output, count)
+    return
+end
+
 function my_main_function(info::DuckDB.FunctionInfo, output::DuckDB.DataChunk)
     bind_info = DuckDB.get_bind_info(info, MyBindStruct)
     init_info = DuckDB.get_init_info(info, MyInitStruct)
@@ -69,6 +90,42 @@ function my_main_function_nulls(info::DuckDB.FunctionInfo, output::DuckDB.DataCh
 
     DuckDB.set_size(output, count)
     return
+end
+
+@testset "Test custom table functions that produce IO" begin
+    con = DBInterface.connect(DuckDB.DB)
+
+    DuckDB.create_table_function(
+        con,
+        "forty_two_print",
+        [Int64],
+        my_bind_function,
+        my_init_function,
+        my_main_function_print
+    )
+    GC.gc()
+
+    # 3 elements
+    results = DBInterface.execute(con, "SELECT * FROM forty_two_print(3)")
+    GC.gc()
+
+    df = DataFrame(results)
+    @test names(df) == ["forty_two"]
+    @test size(df, 1) == 3
+    @test df.forty_two == [42, 84, 42]
+
+    # > vsize elements
+    results = DBInterface.execute(con, "SELECT COUNT(*) cnt FROM forty_two_print(10000)")
+    GC.gc()
+
+    df = DataFrame(results)
+    @test df.cnt == [10000]
+
+    # 	@time begin
+    # 		results = DBInterface.execute(con, "SELECT SUM(forty_two) cnt FROM forty_two(10000000)")
+    # 	end
+    # 	df = DataFrame(results)
+    # 	println(df)
 end
 
 @testset "Test custom table functions" begin


### PR DESCRIPTION
This PR fixes an infinite loop in Julia related to IO within callbacks made to Julia from DuckDB functions (such as table functions)

What happened was that a call to a synchronous function like `println` would cause a "stop the world" type event, descheduling the current tasks, prioritizing the synchronous method.

That, together with our main thread not getting involved in execution of the query and only checking if the query is finished. Because that thread is always busy it would never get descheduled, not allowing other tasks to get picked up, causing it to endlessly wait for tasks that would never get scheduled.

Adding `Base.yield()` in the main thread tells the scheduler to deschedule this task and pick up another task, fixing the infinite loop issue.