### PR TITLE
Add tests to cover issue 5132 and enable force reload

### DIFF
--- a/test/sql/json/test_json_extract.test
+++ b/test/sql/json/test_json_extract.test
@@ -273,10 +273,6 @@ SELECT x::JSON->'$.settings.layer2."tris.legomenon"."summary.report"' FROM t12;
 ----
 false
 
-
-# can't deal with force reload / force storage (#5132)
-require skip_reload
-
 # test issue #5063
 statement ok
 create table test5063 as select '{"a": 1, "b": 2}' js

--- a/test/sql/prepared/test_prepare_issue_5132.test
+++ b/test/sql/prepared/test_prepare_issue_5132.test
@@ -1,0 +1,14 @@
+# name: test/sql/prepared/test_prepare_issue_5132.test
+# description: Test reproducible example in #5132
+# group: [prepared]
+
+statement ok
+create table test as select 42 i
+
+statement ok
+prepare q1 as SELECT cast(? AS VARCHAR) FROM test
+
+query T
+execute q1('oops')
+----
+oops

--- a/test/sql/types/union/union_tag.test
+++ b/test/sql/types/union/union_tag.test
@@ -2,9 +2,6 @@
 # description: Test union_tag
 # group: [union]
 
-# See issue #5132 - this should be fixed and then skip_reload can be removed
-require skip_reload
-
 # Union type must be fully resolved
 statement error
 SELECT union_tag(1);


### PR DESCRIPTION
A prior commit fixed #5132 and this PR just adds a test for it. It also enables `--force-reload --force-storage` for two other tests that now pass.