### PR TITLE
Art bug fixes

### DIFF
--- a/.github/config/uncovered_files.csv
+++ b/.github/config/uncovered_files.csv
@@ -156,7 +156,7 @@ execution/index/art/leaf.cpp	38
 execution/index/art/node.cpp	40
 execution/index/art/node48.cpp	8
 execution/index/art/node256.cpp	4
-execution/index/art/prefix.cpp	78
+execution/index/art/prefix.cpp	4
 execution/index/art/prefix_segment.cpp	2
 execution/join_hashtable.cpp	22
 execution/nested_loop_join/nested_loop_join_inner.cpp	24

--- a/src/execution/index/art/leaf_segment.cpp
+++ b/src/execution/index/art/leaf_segment.cpp
@@ -15,6 +15,16 @@ LeafSegment &LeafSegment::New(ART &art, Node &node) {
 	return segment;
 }
 
+void LeafSegment::Free(ART &art, Node &node) {
+
+	D_ASSERT(node.IsSet());
+	D_ASSERT(!node.IsSwizzled());
+
+	// free next segment
+	auto next_segment = LeafSegment::Get(art, node).next;
+	Node::Free(art, next_segment);
+}
+
 LeafSegment &LeafSegment::Append(ART &art, uint32_t &count, const row_t row_id) {
 
 	reference<LeafSegment> segment(*this);

--- a/src/execution/index/art/node16.cpp
+++ b/src/execution/index/art/node16.cpp
@@ -60,6 +60,7 @@ Node16 &Node16::ShrinkNode48(ART &art, Node &node16, Node &node48) {
 	n16.prefix.Move(n48.prefix);
 
 	for (idx_t i = 0; i < Node::NODE_256_CAPACITY; i++) {
+		D_ASSERT(n16.count <= Node::NODE_16_CAPACITY);
 		if (n48.child_index[i] != Node::EMPTY_MARKER) {
 			n16.key[n16.count] = i;
 			n16.children[n16.count] = n48.children[n48.child_index[i]];
@@ -160,6 +161,7 @@ optional_ptr<Node> Node16::GetChild(const uint8_t byte) {
 
 	for (idx_t i = 0; i < count; i++) {
 		if (key[i] == byte) {
+			D_ASSERT(children[i].IsSet());
 			return &children[i];
 		}
 	}
@@ -171,6 +173,7 @@ optional_ptr<Node> Node16::GetNextChild(uint8_t &byte) {
 	for (idx_t i = 0; i < count; i++) {
 		if (key[i] >= byte) {
 			byte = key[i];
+			D_ASSERT(children[i].IsSet());
 			return &children[i];
 		}
 	}

--- a/src/execution/index/art/node256.cpp
+++ b/src/execution/index/art/node256.cpp
@@ -83,6 +83,7 @@ void Node256::InsertChild(ART &art, Node &node, const uint8_t byte, const Node c
 	D_ASSERT(!n256.children[byte].IsSet());
 
 	n256.count++;
+	D_ASSERT(n256.count <= Node::NODE_256_CAPACITY);
 	n256.children[byte] = child;
 }
 

--- a/src/execution/index/art/node4.cpp
+++ b/src/execution/index/art/node4.cpp
@@ -37,6 +37,7 @@ Node4 &Node4::ShrinkNode16(ART &art, Node &node4, Node &node16) {
 	auto &n4 = Node4::New(art, node4);
 	auto &n16 = Node16::Get(art, node16);
 
+	D_ASSERT(n16.count <= Node::NODE_4_CAPACITY);
 	n4.count = n16.count;
 	n4.prefix.Move(n16.prefix);
 
@@ -145,6 +146,7 @@ optional_ptr<Node> Node4::GetChild(const uint8_t byte) {
 
 	for (idx_t i = 0; i < count; i++) {
 		if (key[i] == byte) {
+			D_ASSERT(children[i].IsSet());
 			return &children[i];
 		}
 	}
@@ -156,6 +158,7 @@ optional_ptr<Node> Node4::GetNextChild(uint8_t &byte) {
 	for (idx_t i = 0; i < count; i++) {
 		if (key[i] >= byte) {
 			byte = key[i];
+			D_ASSERT(children[i].IsSet());
 			return &children[i];
 		}
 	}

--- a/src/execution/index/art/node48.cpp
+++ b/src/execution/index/art/node48.cpp
@@ -85,6 +85,7 @@ Node48 &Node48::ShrinkNode256(ART &art, Node &node48, Node &node256) {
 	n48.prefix.Move(n256.prefix);
 
 	for (idx_t i = 0; i < Node::NODE_256_CAPACITY; i++) {
+		D_ASSERT(n48.count <= Node::NODE_48_CAPACITY);
 		if (n256.children[i].IsSet()) {
 			n48.child_index[i] = n48.count;
 			n48.children[n48.count] = n256.children[i];
@@ -168,6 +169,7 @@ optional_ptr<Node> Node48::GetNextChild(uint8_t &byte) {
 	for (idx_t i = byte; i < Node::NODE_256_CAPACITY; i++) {
 		if (child_index[i] != Node::EMPTY_MARKER) {
 			byte = i;
+			D_ASSERT(children[child_index[i]].IsSet());
 			return &children[child_index[i]];
 		}
 	}

--- a/src/execution/index/art/prefix.cpp
+++ b/src/execution/index/art/prefix.cpp
@@ -427,6 +427,7 @@ void Prefix::Vacuum(ART &art) {
 	auto &allocator = Node::GetAllocator(art, NType::PREFIX_SEGMENT);
 	if (allocator.NeedsVacuum(data.ptr)) {
 		data.ptr.SetPtr(allocator.VacuumPointer(data.ptr));
+		data.ptr.type = (uint8_t)NType::PREFIX_SEGMENT;
 	}
 
 	auto ptr = data.ptr;
@@ -435,6 +436,7 @@ void Prefix::Vacuum(ART &art) {
 		ptr = segment.next;
 		if (ptr.IsSet() && allocator.NeedsVacuum(ptr)) {
 			segment.next.SetPtr(allocator.VacuumPointer(ptr));
+			segment.next.type = (uint8_t)NType::PREFIX_SEGMENT;
 			ptr = segment.next;
 		}
 	}

--- a/src/include/duckdb/execution/index/art/art.hpp
+++ b/src/include/duckdb/execution/index/art/art.hpp
@@ -97,8 +97,11 @@ public:
 	//! Performs constraint checking for a chunk of input data
 	void CheckConstraintsForChunk(DataChunk &input, ConflictManager &conflict_manager) override;
 
-	//! Returns the string representation of the ART
-	string ToString() override;
+	//! Returns the string representation of the ART, or only traverses and verifies the index
+	string VerifyAndToString(IndexLock &state, const bool only_verify) override;
+
+	//! Find the node with a matching key, or return nullptr if not found
+	Node Lookup(Node node, const ARTKey &key, idx_t depth);
 
 private:
 	//! Insert a row ID into a leaf
@@ -107,8 +110,7 @@ private:
 	bool Insert(Node &node, const ARTKey &key, idx_t depth, const row_t &row_id);
 	//! Erase a key from the tree (if a leaf has more than one value) or erase the leaf itself
 	void Erase(Node &node, const ARTKey &key, idx_t depth, const row_t &row_id);
-	//! Find the node with a matching key, or return nullptr if not found
-	Node Lookup(Node node, const ARTKey &key, idx_t depth);
+
 	//! Returns all row IDs belonging to a key greater (or equal) than the search key
 	bool SearchGreater(ARTIndexScanState &state, ARTKey &key, bool inclusive, idx_t max_count,
 	                   vector<row_t> &result_ids);
@@ -129,6 +131,10 @@ private:
 	//! Finalizes a vacuum operation by calling the finalize operation of all qualifying
 	//! fixed size allocators
 	void FinalizeVacuum(const ARTFlags &flags);
+
+	//! Internal function to return the string representation of the ART,
+	//! or only traverses and verifies the index
+	string VerifyAndToStringInternal(const bool only_verify);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/index/art/fixed_size_allocator.hpp
+++ b/src/include/duckdb/execution/index/art/fixed_size_allocator.hpp
@@ -100,6 +100,9 @@ public:
 	//! Vacuums a pointer
 	SwizzleablePointer VacuumPointer(const SwizzleablePointer ptr);
 
+	//! Verify that the allocation counts match the existing positions on the buffers
+	void Verify() const;
+
 private:
 	//! Returns the data_ptr_t of a pointer
 	inline data_ptr_t Get(const SwizzleablePointer ptr) const {

--- a/src/include/duckdb/execution/index/art/leaf.hpp
+++ b/src/include/duckdb/execution/index/art/leaf.hpp
@@ -73,7 +73,7 @@ public:
 	uint32_t FindRowId(const ART &art, Node &ptr, const row_t row_id) const;
 
 	//! Returns the string representation of a leaf
-	string ToString(const ART &art) const;
+	string VerifyAndToString(const ART &art, const bool only_verify) const;
 
 	//! Serialize this leaf
 	BlockPointer Serialize(const ART &art, MetaBlockWriter &writer) const;

--- a/src/include/duckdb/execution/index/art/leaf_segment.hpp
+++ b/src/include/duckdb/execution/index/art/leaf_segment.hpp
@@ -26,6 +26,8 @@ public:
 	static inline LeafSegment &Get(const ART &art, const Node ptr) {
 		return *Node::GetAllocator(art, NType::LEAF_SEGMENT).Get<LeafSegment>(ptr);
 	}
+	//! Free the leaf segment and any subsequent ones
+	static void Free(ART &art, Node &node);
 
 	//! Append a row ID to the current segment, or create a new segment containing that row ID
 	LeafSegment &Append(ART &art, uint32_t &count, const row_t row_id);

--- a/src/include/duckdb/execution/index/art/node48.hpp
+++ b/src/include/duckdb/execution/index/art/node48.hpp
@@ -59,6 +59,7 @@ public:
 	//! Get the child for the respective byte in the node
 	inline optional_ptr<Node> GetChild(const uint8_t byte) {
 		if (child_index[byte] != Node::EMPTY_MARKER) {
+			D_ASSERT(children[child_index[byte]].IsSet());
 			return &children[child_index[byte]];
 		}
 		return nullptr;

--- a/src/include/duckdb/storage/in_memory_block_manager.hpp
+++ b/src/include/duckdb/storage/in_memory_block_manager.hpp
@@ -21,43 +21,43 @@ public:
 
 	// LCOV_EXCL_START
 	unique_ptr<Block> ConvertBlock(block_id_t block_id, FileBuffer &source_buffer) override {
-		throw InternalException("Cannot perform IO in in-memory database!");
+		throw InternalException("Cannot perform IO in in-memory database - ConvertBlock!");
 	}
 	unique_ptr<Block> CreateBlock(block_id_t block_id, FileBuffer *source_buffer) override {
-		throw InternalException("Cannot perform IO in in-memory database!");
+		throw InternalException("Cannot perform IO in in-memory database - CreateBlock!");
 	}
 	block_id_t GetFreeBlockId() override {
-		throw InternalException("Cannot perform IO in in-memory database!");
+		throw InternalException("Cannot perform IO in in-memory database - GetFreeBlockId!");
 	}
 	bool IsRootBlock(block_id_t root) override {
-		throw InternalException("Cannot perform IO in in-memory database!");
+		throw InternalException("Cannot perform IO in in-memory database - IsRootBlock!");
 	}
 	void MarkBlockAsFree(block_id_t block_id) override {
-		throw InternalException("Cannot perform IO in in-memory database!");
+		throw InternalException("Cannot perform IO in in-memory database - MarkBlockAsFree!");
 	}
 	void MarkBlockAsModified(block_id_t block_id) override {
-		throw InternalException("Cannot perform IO in in-memory database!");
+		throw InternalException("Cannot perform IO in in-memory database - MarkBlockAsModified!");
 	}
 	void IncreaseBlockReferenceCount(block_id_t block_id) override {
-		throw InternalException("Cannot perform IO in in-memory database!");
+		throw InternalException("Cannot perform IO in in-memory database - IncreaseBlockReferenceCount!");
 	}
 	block_id_t GetMetaBlock() override {
-		throw InternalException("Cannot perform IO in in-memory database!");
+		throw InternalException("Cannot perform IO in in-memory database - GetMetaBlock!");
 	}
 	void Read(Block &block) override {
-		throw InternalException("Cannot perform IO in in-memory database!");
+		throw InternalException("Cannot perform IO in in-memory database - Read!");
 	}
 	void Write(FileBuffer &block, block_id_t block_id) override {
-		throw InternalException("Cannot perform IO in in-memory database!");
+		throw InternalException("Cannot perform IO in in-memory database - Write!");
 	}
 	void WriteHeader(DatabaseHeader header) override {
-		throw InternalException("Cannot perform IO in in-memory database!");
+		throw InternalException("Cannot perform IO in in-memory database - WriteHeader!");
 	}
 	idx_t TotalBlocks() override {
-		throw InternalException("Cannot perform IO in in-memory database!");
+		throw InternalException("Cannot perform IO in in-memory database - TotalBlocks!");
 	}
 	idx_t FreeBlocks() override {
-		throw InternalException("Cannot perform IO in in-memory database!");
+		throw InternalException("Cannot perform IO in in-memory database - FreeBlocks!");
 	}
 	// LCOV_EXCL_STOP
 };

--- a/src/include/duckdb/storage/index.hpp
+++ b/src/include/duckdb/storage/index.hpp
@@ -104,8 +104,10 @@ public:
 	//! Obtains a lock and calls Vacuum while holding that lock
 	void Vacuum();
 
-	//! Returns the string representation of an index
-	virtual string ToString() = 0;
+	//! Returns the string representation of an index, or only traverses and verifies the index
+	virtual string VerifyAndToString(IndexLock &state, const bool only_verify) = 0;
+	//! Obtains a lock and calls VerifyAndToString while holding that lock
+	string VerifyAndToString(const bool only_verify);
 
 	//! Returns true if the index is affected by updates on the specified column IDs, and false otherwise
 	bool IndexIsUpdated(const vector<PhysicalIndex> &column_ids) const;

--- a/src/storage/index.cpp
+++ b/src/storage/index.cpp
@@ -59,6 +59,19 @@ bool Index::MergeIndexes(Index &other_index) {
 	}
 }
 
+string Index::VerifyAndToString(const bool only_verify) {
+
+	IndexLock state;
+	InitializeLock(state);
+
+	switch (this->type) {
+	case IndexType::ART:
+		return Cast<ART>().VerifyAndToString(state, only_verify);
+	default:
+		throw InternalException("Unimplemented index type for VerifyAndToString");
+	}
+}
+
 void Index::Vacuum() {
 
 	IndexLock state;

--- a/test/sql/index/art/art_coverage.test
+++ b/test/sql/index/art/art_coverage.test
@@ -2,6 +2,8 @@
 # description: Test edge cases to increase ART coverage
 # group: [art]
 
+require vector_size 2048
+
 # very mixed-length prefixes
 
 statement ok
@@ -119,10 +121,3 @@ WHERE rowid IN (SELECT rowid FROM mixed_distinct_prefixes LIMIT 1000)
 
 statement ok
 DROP INDEX idx_mixed_distinct_prefixes
-
-#119                 if (other.IsInlined()) {
-#120                         for (idx_t i = 0; i < other.count; i++) {
-#121                                 segment = segment.get().Append(art, count, other.data.inlined[i]);
-#123                         return;
-
-

--- a/test/sql/index/art/art_coverage.test
+++ b/test/sql/index/art/art_coverage.test
@@ -1,0 +1,128 @@
+# name: test/sql/index/art/art_coverage.test
+# description: Test edge cases to increase ART coverage
+# group: [art]
+
+# very mixed-length prefixes
+
+statement ok
+CREATE TABLE different_prefixes(str VARCHAR)
+
+statement ok
+INSERT INTO different_prefixes SELECT 'my first very long prefix that is really very long' || range FROM range(2048)
+
+statement ok
+INSERT INTO different_prefixes SELECT (range / 100)::VARCHAR || range::VARCHAR FROM range(2048)
+
+statement ok
+INSERT INTO different_prefixes SELECT 'my first very long prefix, the other not quite as long prefix that is still very long' || range FROM range(2048)
+
+statement ok
+INSERT INTO different_prefixes SELECT 'my first very long prefix, the other not quite as long prefix that is still very long and even longer omg!' || range FROM range(2048)
+
+statement ok
+INSERT INTO different_prefixes SELECT range::VARCHAR || (range + 1)::VARCHAR FROM range(2048)
+
+statement ok
+CREATE INDEX idx_different_prefixes ON different_prefixes(str)
+
+statement ok
+DELETE FROM different_prefixes
+WHERE rowid IN (SELECT rowid FROM different_prefixes LIMIT 1000)
+
+statement ok
+DELETE FROM different_prefixes
+WHERE rowid IN (SELECT rowid FROM different_prefixes LIMIT 3000)
+
+statement ok
+DROP INDEX idx_different_prefixes;
+
+# this time all prefixes are long
+
+statement ok
+CREATE TABLE longer_prefixes(str VARCHAR)
+
+statement ok
+INSERT INTO longer_prefixes
+SELECT 'my first very long prefix that is really very long' || range FROM range(2048)
+
+statement ok
+INSERT INTO longer_prefixes
+SELECT 'my first very long prefix, the other not quite as long prefix that is still very long' || range FROM range(2048)
+
+statement ok
+CREATE INDEX idx_longer_prefixes ON longer_prefixes(str)
+
+query I
+SELECT str FROM longer_prefixes
+WHERE str = 'my first very long prefix that is really very long77'
+----
+my first very long prefix that is really very long77
+
+statement ok
+DROP INDEX idx_longer_prefixes;
+
+# more distinct prefixes
+
+statement ok
+CREATE TABLE distinct_prefixes (str VARCHAR)
+
+statement ok
+INSERT INTO distinct_prefixes SELECT
+	'2022-01-01'::DATE + range::INTEGER * 1000 ||
+	'1004-02-01'::DATE + range::INTEGER * 100 ||
+	'.' || '6004-02-01'::DATE + range::INTEGER * 2000
+	FROM range(100000);
+
+statement ok
+CREATE INDEX idx_distinct_prefixes ON distinct_prefixes(str)
+
+statement ok
+DROP INDEX idx_distinct_prefixes
+
+# more mixed-length distinct prefixes
+
+statement ok
+CREATE TABLE mixed_distinct_prefixes (str VARCHAR)
+
+statement ok
+INSERT INTO mixed_distinct_prefixes SELECT
+	'2022-01-01'::DATE + range::INTEGER * 1000
+	FROM range(100000);
+
+statement ok
+INSERT INTO mixed_distinct_prefixes SELECT
+	'2022-01-01'::DATE + range::INTEGER * 1000 ||
+	'1004-02-01'::DATE + range::INTEGER * 100
+	FROM range(100000);
+
+statement ok
+INSERT INTO mixed_distinct_prefixes SELECT
+	'2022-01-01'::DATE + range::INTEGER * 1000 ||
+	'1004-02-01'::DATE + range::INTEGER * 100 ||
+	'.' || '6004-02-01'::DATE + range::INTEGER * 2000
+	FROM range(100000);
+
+statement ok
+CREATE INDEX idx_mixed_distinct_prefixes ON mixed_distinct_prefixes(str)
+
+statement ok
+DELETE FROM mixed_distinct_prefixes
+WHERE rowid IN (SELECT rowid FROM mixed_distinct_prefixes LIMIT 1000)
+
+statement ok
+DELETE FROM mixed_distinct_prefixes
+WHERE rowid IN (SELECT rowid FROM mixed_distinct_prefixes LIMIT 1000)
+
+statement ok
+DELETE FROM mixed_distinct_prefixes
+WHERE rowid IN (SELECT rowid FROM mixed_distinct_prefixes LIMIT 1000)
+
+statement ok
+DROP INDEX idx_mixed_distinct_prefixes
+
+#119                 if (other.IsInlined()) {
+#120                         for (idx_t i = 0; i < other.count; i++) {
+#121                                 segment = segment.get().Append(art, count, other.data.inlined[i]);
+#123                         return;
+
+

--- a/test/sql/index/art/test_art_vacuum_strings.test_slow
+++ b/test/sql/index/art/test_art_vacuum_strings.test_slow
@@ -60,7 +60,7 @@ statement ok
 CREATE INDEX idx ON t(i);
 
 query I
-SELECT mem_to_bytes(current.memory_usage) > 15 * base.usage
+SELECT mem_to_bytes(current.memory_usage) > 5 * base.usage
 FROM base, pragma_database_size() current;
 ----
 1


### PR DESCRIPTION
This PR contains several bug fixes (mostly) to the vacuum code of the ART. We were only vacuuming half of the possible memory. Additionally, we were not correctly decreasing the total allocation count during vacuum operations, leading to succeeding wrong calculations. 

To decrease the memory consumption of huge index creation operations, this PR moves the vacuum code into the `Combine` calls of the `PhysicalCreateIndex` operator. Maybe further investigation is necessary here, because each `Sink` can become very large, if the small ARTs only allocate a few nodes for some node types (still always allocate and merge a whole block - in the extreme case one block only contains one node).

Also, we were not always correctly initializing the swizzle flag and the type of nodes, leading to invalid memory when unexpected bits were set in these memory sections.

This PR also adds a lot of ART verification assertions/functions. It extends the `VerifyAndToString` function to be used in assertions. It adds code to verify a chunk's keys/row IDs after each construct/insert and delete. Additionally, it verifies that the allocators are valid after each merge and vacuum.

This PR also increases the coverage of the ART by adding an additional test file specifically handling different prefix situations.

Related issues: #7406, #7760