### PR TITLE
Fix ordering in GLOB test

### DIFF
--- a/test/sql/copy/parquet/parquet_glob.test
+++ b/test/sql/copy/parquet/parquet_glob.test
@@ -61,7 +61,7 @@ select * from parquet_scan('data\parquet-testing\g*\t1.parquet') order by i
 
 # Double partial matches
 query II rowsort
-FROM parquet_scan('data/parquet-testing/glob3/*/dir/*.parquet');
+FROM parquet_scan('data/parquet-testing/glob3/*/dir/*.parquet') order by i;
 ----
 1	a
 3	c


### PR DESCRIPTION
We've encountered a test failure because the test was assuming the results to be in a certain order, while this can't be guaranteed. I've added a `order by i` to this test, similar to most of the other tests in this file.