### PR TITLE
Allow core duckdb to handle unrecognized C API configuration

### DIFF
--- a/src/main/capi/config-c.cpp
+++ b/src/main/capi/config-c.cpp
@@ -42,13 +42,10 @@ duckdb_state duckdb_set_config(duckdb_config config, const char *name, const cha
 	if (!config || !name || !option) {
 		return DuckDBError;
 	}
-	auto config_option = DBConfig::GetOptionByName(name);
-	if (!config_option) {
-		return DuckDBError;
-	}
+
 	try {
 		auto db_config = (DBConfig *)config;
-		db_config->SetOption(*config_option, Value(option));
+		db_config->SetOptionByName(name, Value(option));
 	} catch (...) {
 		return DuckDBError;
 	}

--- a/test/api/capi/test_capi.cpp
+++ b/test/api/capi/test_capi.cpp
@@ -467,7 +467,6 @@ TEST_CASE("Test C API config", "[capi]") {
 	REQUIRE(duckdb_create_config(&config) == DuckDBSuccess);
 	REQUIRE(duckdb_set_config(config, "access_mode", "invalid_access_mode") == DuckDBError);
 	REQUIRE(duckdb_set_config(config, "access_mode", "read_only") == DuckDBSuccess);
-	REQUIRE(duckdb_set_config(config, "aaaa_invalidoption", "read_only") == DuckDBError);
 
 	auto dbdir = TestCreatePath("capi_read_only_db");
 
@@ -493,6 +492,13 @@ TEST_CASE("Test C API config", "[capi]") {
 
 	// now we can connect
 	REQUIRE(duckdb_open_ext(dbdir.c_str(), &db, config, &error) == DuckDBSuccess);
+
+	// test unrecognized configuration
+	REQUIRE(duckdb_set_config(config, "aaaa_invalidoption", "read_only") == DuckDBSuccess);
+	REQUIRE( ((DBConfig *)config)->options.unrecognized_options["aaaa_invalidoption"] == "read_only");
+	REQUIRE(duckdb_open_ext(dbdir.c_str(), &db, config, &error) == DuckDBError);
+	REQUIRE_THAT(error, Catch::Matchers::Contains("Unrecognized configuration property"));
+	duckdb_free(error);
 
 	// we can destroy the config right after duckdb_open
 	duckdb_destroy_config(&config);

--- a/test/api/capi/test_capi.cpp
+++ b/test/api/capi/test_capi.cpp
@@ -495,7 +495,7 @@ TEST_CASE("Test C API config", "[capi]") {
 
 	// test unrecognized configuration
 	REQUIRE(duckdb_set_config(config, "aaaa_invalidoption", "read_only") == DuckDBSuccess);
-	REQUIRE( ((DBConfig *)config)->options.unrecognized_options["aaaa_invalidoption"] == "read_only");
+	REQUIRE(((DBConfig *)config)->options.unrecognized_options["aaaa_invalidoption"] == "read_only");
 	REQUIRE(duckdb_open_ext(dbdir.c_str(), &db, config, &error) == DuckDBError);
 	REQUIRE_THAT(error, Catch::Matchers::Contains("Unrecognized configuration property"));
 	duckdb_free(error);

--- a/tools/juliapkg/test/test_config.jl
+++ b/tools/juliapkg/test/test_config.jl
@@ -15,7 +15,6 @@
     # if we add this configuration flag, nulls should come last
     config = DuckDB.Config()
     DuckDB.set_config(config, "default_null_order", "nulls_first")
-    @test_throws DuckDB.QueryException DuckDB.set_config(config, "unrecognized option", "aaa")
 
     con = DBInterface.connect(DuckDB.DB, ":memory:", config)
 
@@ -26,9 +25,13 @@
     @test size(df, 1) == 2
     @test isequal(df.a, [missing, 42])
 
-    DBInterface.close!(config)
-    DBInterface.close!(config)
     DBInterface.close!(con)
+
+    DuckDB.set_config(config, "unrecognized option", "aaa")
+    @test_throws DuckDB.ConnectionException con = DBInterface.connect(DuckDB.DB, ":memory:", config)
+
+    DBInterface.close!(config)
+    DBInterface.close!(config)
 end
 
 @testset "Test Set TimeZone" begin


### PR DESCRIPTION
Similar to #7713, this PR removes the C API logic for eagerly failing when an unrecognized option is encountered, instead allowing the core DuckDB to postpone the validation until after extension autoloading.

The eager validation turned up in [go-duckdb](https://github.com/marcboeker/go-duckdb) driver, which uses the C API.

Affiliation: MotherDuck