### PR TITLE
Add msan and ubsan to cifuzz (+ fix zstd + msan)

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -24,24 +24,29 @@ jobs:
   Fuzzing:
     name: OSSFuzz
     if: github.repository == 'duckdb/duckdb'
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address, undefined, memory]
     runs-on: ubuntu-latest
     steps:
-    - name: Build Fuzzers
+    - name: Build Fuzzers ${{ matrix.sanitizer }}
       id: build
       uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
       with:
         oss-fuzz-project-name: 'duckdb'
         dry-run: false
-    - name: Run Fuzzers
+        sanitizer: ${{ matrix.sanitizer }}
+    - name: Run Fuzzers ${{ matrix.sanitizer }}
       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
       with:
         oss-fuzz-project-name: 'duckdb'
-        fuzz-seconds: 600
+        fuzz-seconds: 3600
         dry-run: false
+        sanitizer: ${{ matrix.sanitizer }}
     - name: Upload Crash
       uses: actions/upload-artifact@v1
       if: failure() && steps.build.outcome == 'success'
       with:
-        name: artifacts
+        name: artifacts-${{ matrix.sanitizer }}
         path: ./out/artifacts
-

--- a/third_party/zstd/compress/zstd_compress.cpp
+++ b/third_party/zstd/compress/zstd_compress.cpp
@@ -29,6 +29,9 @@
 #include "zstd/compress/zstd_ldm.h"
 #include "zstd/compress/zstd_compress_superblock.h"
 
+#if defined (MEMORY_SANITIZER)
+#include <sanitizer/msan_interface.h>
+#endif
 
 namespace duckdb_zstd {
 /*-*************************************

--- a/third_party/zstd/include/zstd/compress/zstd_cwksp.h
+++ b/third_party/zstd/include/zstd/compress/zstd_cwksp.h
@@ -31,6 +31,10 @@
 #define ZSTD_CWKSP_ASAN_REDZONE_SIZE 128
 #endif
 
+#if defined (MEMORY_SANITIZER)
+#include <sanitizer/msan_interface.h>
+#endif
+
 namespace duckdb_zstd {
 
 /*-*************************************


### PR DESCRIPTION
Full disclosure, haven't tried (yet?) to run the fuzzers locally, but changes should be minor.

Also I did noticed that cifuzz is non functional (see last nightly run: https://github.com/duckdb/duckdb/actions/runs/5160861865/jobs/9297332564#step:5:51), it fails on a throw in fmt code:
```
    throw std::runtime_error("fuzz mode - won't grow that much");
```
that then will be re-throw as InternalError in src/common/exception_format_value.cpp. This codepath I had not though about while refactoring errors messages, unsure what was previous behaviour, high chance I had broken this since I assumed any exception in fmt had to be a failure.