### PR TITLE
Truncate Database File on Checkpoint

### DIFF
--- a/src/include/duckdb/storage/block_manager.hpp
+++ b/src/include/duckdb/storage/block_manager.hpp
@@ -65,6 +65,9 @@ public:
 	//! Returns the number of free blocks
 	virtual idx_t FreeBlocks() = 0;
 
+	//! Truncate the underlying database file after a checkpoint
+	virtual void Truncate();
+
 	//! Register a block with the given block id in the base file
 	shared_ptr<BlockHandle> RegisterBlock(block_id_t block_id, bool is_meta_block = false);
 	//! Clear cached handles for meta blocks
@@ -73,9 +76,6 @@ public:
 	shared_ptr<BlockHandle> ConvertToPersistent(block_id_t block_id, shared_ptr<BlockHandle> old_block);
 
 	void UnregisterBlock(block_id_t block_id, bool can_destroy);
-
-	static BlockManager &GetBlockManager(ClientContext &context);
-	static BlockManager &GetBlockManager(DatabaseInstance &db);
 
 private:
 	//! The lock for the set of blocks

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -60,6 +60,8 @@ public:
 	void Write(FileBuffer &block, block_id_t block_id) override;
 	//! Write the header to disk, this is the final step of the checkpointing process
 	void WriteHeader(DatabaseHeader header) override;
+	//! Truncate the underlying database file after a checkpoint
+	void Truncate() override;
 
 	//! Returns the number of total blocks
 	idx_t TotalBlocks() override;

--- a/src/storage/buffer/block_manager.cpp
+++ b/src/storage/buffer/block_manager.cpp
@@ -79,4 +79,7 @@ void BlockManager::UnregisterBlock(block_id_t block_id, bool can_destroy) {
 	}
 }
 
+void BlockManager::Truncate() {
+}
+
 } // namespace duckdb

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -111,6 +111,9 @@ void SingleFileCheckpointWriter::CreateCheckpoint() {
 	// truncate the WAL
 	wal->Truncate(0);
 
+	// truncate the file
+	block_manager.Truncate();
+
 	// mark all blocks written as part of the metadata as modified
 	metadata_writer->MarkWrittenBlocks();
 	table_metadata_writer->MarkWrittenBlocks();

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -369,6 +369,7 @@ void SingleFileBlockManager::Write(FileBuffer &buffer, block_id_t block_id) {
 }
 
 void SingleFileBlockManager::Truncate() {
+	BlockManager::Truncate();
 	idx_t blocks_to_truncate = 0;
 	// reverse iterate over the free-list
 	for (auto entry = free_list.rbegin(); entry != free_list.rend(); entry++) {

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -368,6 +368,28 @@ void SingleFileBlockManager::Write(FileBuffer &buffer, block_id_t block_id) {
 	ChecksumAndWrite(buffer, BLOCK_START + block_id * Storage::BLOCK_ALLOC_SIZE);
 }
 
+void SingleFileBlockManager::Truncate() {
+	idx_t blocks_to_truncate = 0;
+	// reverse iterate over the free-list
+	for (auto entry = free_list.rbegin(); entry != free_list.rend(); entry++) {
+		auto block_id = *entry;
+		if (block_id + 1 != max_block) {
+			break;
+		}
+		blocks_to_truncate++;
+		max_block--;
+	}
+	if (blocks_to_truncate == 0) {
+		// nothing to truncate
+		return;
+	}
+	// truncate the file
+	for (idx_t i = 0; i < blocks_to_truncate; i++) {
+		free_list.erase(max_block + i);
+	}
+	handle->Truncate(BLOCK_START + max_block * Storage::BLOCK_ALLOC_SIZE);
+}
+
 vector<block_id_t> SingleFileBlockManager::GetFreeListBlocks() {
 	vector<block_id_t> free_list_blocks;
 

--- a/test/sql/storage/test_reclaim_space_update.test_slow
+++ b/test/sql/storage/test_reclaim_space_update.test_slow
@@ -48,8 +48,10 @@ SELECT MIN(i), MAX(i), COUNT(*) FROM integers
 statement ok
 CHECKPOINT;
 
-query I nosort expected_blocks
-select total_blocks from pragma_database_size();
+query I
+select total_blocks<10 from pragma_database_size();
+----
+true
 
 query III
 SELECT MIN(i), MAX(i), COUNT(*) FROM integers

--- a/test/sql/storage/vacuum/test_truncate_after_delete.test_slow
+++ b/test/sql/storage/vacuum/test_truncate_after_delete.test_slow
@@ -1,0 +1,85 @@
+# name: test/sql/storage/vacuum/test_truncate_after_delete.test_slow
+# description: Test truncating of the database file after data is deleted
+# group: [vacuum]
+
+load __TEST_DIR__/truncate_after_delete.db
+
+statement ok
+CREATE TABLE uuids(i VARCHAR);
+
+loop i 0 10
+
+statement ok
+DROP TABLE IF EXISTS integers
+
+statement ok
+INSERT INTO uuids SELECT uuid()::varchar FROM range(1000000);
+
+statement ok
+CHECKPOINT
+
+query I
+SELECT total_blocks > 50 FROM pragma_database_size();
+----
+true
+
+# note that just deleting does not free the space yet
+# that is because deleting + checkpointing causes the metadata to be written at the END of the file
+# as we cannot override the deleted data yet
+statement ok
+DELETE FROM uuids
+
+statement ok
+CHECKPOINT
+
+# doing ANOTHER action and checkpointing again causes the data to be truncated
+# since the metadata can then overwrite the previously written data
+statement ok
+CREATE TABLE integers(i INTEGER);
+
+statement ok
+INSERT INTO integers VALUES (1), (2), (3);
+
+statement ok
+CHECKPOINT
+
+query I
+SELECT total_blocks < 10 FROM pragma_database_size();
+----
+true
+
+endloop
+
+restart
+
+query I
+FROM integers
+----
+1
+2
+3
+
+query I
+FROM uuids
+----
+
+# resume operation after truncation
+restart
+
+statement ok
+DELETE FROM integers
+
+statement ok
+INSERT INTO integers FROM range(1000000);
+
+query I
+SELECT SUM(i) FROM integers
+----
+499999500000
+
+restart
+
+query I
+SELECT SUM(i) FROM integers
+----
+499999500000


### PR DESCRIPTION
This PR adds support for truncating the DuckDB database file on checkpoint if there are free blocks at the end of the file. As a result - we can now shrink the DuckDB file if tables or rows are deleted and there is space left at the end of the file.

Note that this won't always work as expected in its current form. If we drop a big table and then checkpoint, the file will likely not shrink. That is because as part of the checkpoint process we will write new metadata to the file. As we cannot overwrite the big table yet (to maintain ACID properties) - the metadata is written to the end of the file. As a result of the new metadata being at the end of the file, the file will not be able to be shrunk yet.

On a *subsequent* checkpoint, the file will be able to shrink as the new metadata can then overwrite the old data in the big table.

For example:
```sql
CREATE TABLE uuids(i VARCHAR);
INSERT INTO uuids SELECT uuid()::varchar FROM range(1000000);
PRAGMA database_size;
┌───────────────┬───────────────┬────────────┬──────────────┬─────────────┬─────────────┬──────────┬──────────────┬──────────────┐
│ database_name │ database_size │ block_size │ total_blocks │ used_blocks │ free_blocks │ wal_size │ memory_usage │ memory_limit │
│    varchar    │    varchar    │   int64    │    int64     │    int64    │    int64    │ varchar  │   varchar    │   varchar    │
├───────────────┼───────────────┼────────────┼──────────────┼─────────────┼─────────────┼──────────┼──────────────┼──────────────┤
│ test          │ 22.0MB        │     262144 │           84 │          84 │           0 │ 0 bytes  │ 21.4MB       │ 54.9GB       │
└───────────────┴───────────────┴────────────┴──────────────┴─────────────┴─────────────┴──────────┴──────────────┴──────────────┘
-- deleting and then checkpointing does not free any space
DELETE FROM uuids;
CHECKPOINT;
PRAGMA database_size;
┌───────────────┬───────────────┬────────────┬──────────────┬─────────────┬─────────────┬──────────┬──────────────┬──────────────┐
│ database_name │ database_size │ block_size │ total_blocks │ used_blocks │ free_blocks │ wal_size │ memory_usage │ memory_limit │
│    varchar    │    varchar    │   int64    │    int64     │    int64    │    int64    │ varchar  │   varchar    │   varchar    │
├───────────────┼───────────────┼────────────┼──────────────┼─────────────┼─────────────┼──────────┼──────────────┼──────────────┤
│ test          │ 22.0MB        │     262144 │           84 │          84 │           0 │ 8.0MB    │ 21.4MB       │ 54.9GB       │
└───────────────┴───────────────┴────────────┴──────────────┴─────────────┴─────────────┴──────────┴──────────────┴──────────────┘
-- performing an unrelated change and checkpointing again frees the space
CREATE TABLE new_table(i INT);
CHECKPOINT;
PRAGMA database_size;
┌───────────────┬───────────────┬────────────┬──────────────┬─────────────┬─────────────┬──────────┬──────────────┬──────────────┐
│ database_name │ database_size │ block_size │ total_blocks │ used_blocks │ free_blocks │ wal_size │ memory_usage │ memory_limit │
│    varchar    │    varchar    │   int64    │    int64     │    int64    │    int64    │ varchar  │   varchar    │   varchar    │
├───────────────┼───────────────┼────────────┼──────────────┼─────────────┼─────────────┼──────────┼──────────────┼──────────────┤
│ test          │ 786KB         │     262144 │            3 │           3 │           0 │ 0 bytes  │ 0 bytes      │ 54.9GB       │
└───────────────┴───────────────┴────────────┴──────────────┴─────────────┴─────────────┴──────────┴──────────────┴──────────────┘
```