### PR TITLE
Serialize: more fixes, part 2

### DIFF
--- a/extension/icu/third_party/icu/i18n/nfsubs.cpp
+++ b/extension/icu/third_party/icu/i18n/nfsubs.cpp
@@ -1310,10 +1310,8 @@ NumeratorSubstitution::doParse(const UnicodeString& text,
         // compute the 'effective' base and prescale the value down
         int64_t n = result.getLong(status); // force conversion!
         int64_t d = 1;
-        int32_t pow = 0;
         while (d <= n) {
             d *= 10;
-            ++pow;
         }
         // now add the zeros
         while (zeroCount > 0) {

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -559,6 +559,10 @@ bool LogicalType::GetDecimalProperties(uint8_t &width, uint8_t &scale) const {
 		scale = DecimalType::GetScale(*this);
 		break;
 	default:
+		// Nonsense values to ensure initialization
+		width = 255u;
+		scale = 255u;
+		// FIXME(carlo): This should be probably a throw, requires checkign the various call-sites
 		return false;
 	}
 	return true;

--- a/src/core_functions/scalar/list/list_lambdas.cpp
+++ b/src/core_functions/scalar/list/list_lambdas.cpp
@@ -328,7 +328,6 @@ static unique_ptr<FunctionData> ListLambdaBind(ClientContext &context, ScalarFun
 	}
 
 	if (arguments[0]->return_type.id() == LogicalTypeId::SQLNULL) {
-		bound_function.arguments.pop_back();
 		bound_function.arguments[0] = LogicalType::SQLNULL;
 		bound_function.return_type = LogicalType::SQLNULL;
 		return make_uniq<VariableReturnBindData>(bound_function.return_type);

--- a/src/execution/index/art/leaf.cpp
+++ b/src/execution/index/art/leaf.cpp
@@ -292,6 +292,7 @@ string Leaf::VerifyAndToString(const ART &art, const bool only_verify) const {
 	}
 
 	D_ASSERT(remaining == 0);
+	(void)this_count;
 	D_ASSERT(this_count == count);
 	return only_verify ? "" : "Leaf [count: " + to_string(count) + ", row IDs: " + str + "] \n";
 }

--- a/src/execution/index/art/node.cpp
+++ b/src/execution/index/art/node.cpp
@@ -313,6 +313,7 @@ string Node::VerifyAndToString(ART &art, const bool only_verify) {
 		child = GetNextChild(art, byte, false);
 	}
 
+	(void)child_count;
 	// ensure that the child count is at least two
 	D_ASSERT(child_count > 1);
 	return only_verify ? "" : "\n" + str + "]";

--- a/src/function/aggregate/distributive/first.cpp
+++ b/src/function/aggregate/distributive/first.cpp
@@ -297,8 +297,9 @@ template <bool LAST, bool SKIP_NULLS>
 unique_ptr<FunctionData> BindDecimalFirst(ClientContext &context, AggregateFunction &function,
                                           vector<unique_ptr<Expression>> &arguments) {
 	auto decimal_type = arguments[0]->return_type;
+	auto name = std::move(function.name);
 	function = GetFirstFunction<LAST, SKIP_NULLS>(decimal_type);
-	function.name = "first";
+	function.name = std::move(name);
 	function.return_type = decimal_type;
 	return nullptr;
 }

--- a/src/include/duckdb/planner/bound_result_modifier.hpp
+++ b/src/include/duckdb/planner/bound_result_modifier.hpp
@@ -95,6 +95,9 @@ public:
 	unique_ptr<BoundOrderModifier> Copy() const;
 	static bool Equals(const BoundOrderModifier &left, const BoundOrderModifier &right);
 	static bool Equals(const unique_ptr<BoundOrderModifier> &left, const unique_ptr<BoundOrderModifier> &right);
+
+	void Serialize(Serializer &serializer) const;
+	static unique_ptr<BoundOrderModifier> Deserialize(Deserializer &source, PlanDeserializationState &state);
 };
 
 enum class DistinctType : uint8_t { DISTINCT = 0, DISTINCT_ON = 1 };

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -218,7 +218,6 @@ BindResult ExpressionBinder::BindLambdaFunction(FunctionExpression &function, Sc
 			D_ASSERT(binding.names.size() == 1);
 			D_ASSERT(binding.types.size() == 1);
 
-			bound_function_expr.function.arguments.push_back(binding.types[0]);
 			auto bound_lambda_param =
 			    make_uniq<BoundReferenceExpression>(binding.names[0], binding.types[0], lambda_index);
 			bound_function_expr.children.push_back(std::move(bound_lambda_param));
@@ -227,7 +226,6 @@ BindResult ExpressionBinder::BindLambdaFunction(FunctionExpression &function, Sc
 
 	// push back the captures into the children vector and the correct return types into the bound_function arguments
 	for (auto &capture : bound_lambda.captures) {
-		bound_function_expr.function.arguments.push_back(capture->return_type);
 		bound_function_expr.children.push_back(std::move(capture));
 	}
 

--- a/src/planner/bound_result_modifier.cpp
+++ b/src/planner/bound_result_modifier.cpp
@@ -16,6 +16,20 @@ BoundOrderByNode::BoundOrderByNode(OrderType type, OrderByNullType null_order, u
                                    unique_ptr<BaseStatistics> stats)
     : type(type), null_order(null_order), expression(std::move(expression)), stats(std::move(stats)) {
 }
+void BoundOrderModifier::Serialize(Serializer &serializer) const {
+	FieldWriter writer(serializer);
+	writer.WriteRegularSerializableList(orders);
+	writer.Finalize();
+}
+unique_ptr<BoundOrderModifier> BoundOrderModifier::Deserialize(Deserializer &source, PlanDeserializationState &state) {
+	auto x = make_uniq<BoundOrderModifier>();
+
+	FieldReader reader(source);
+	x->orders = reader.ReadRequiredSerializableList<BoundOrderByNode, BoundOrderByNode>(state);
+	reader.Finalize();
+
+	return x;
+}
 
 BoundOrderByNode BoundOrderByNode::Copy() const {
 	if (stats) {

--- a/src/planner/expression.cpp
+++ b/src/planner/expression.cpp
@@ -130,6 +130,9 @@ unique_ptr<Expression> Expression::Deserialize(Deserializer &source, PlanDeseria
 	case ExpressionClass::BOUND_CONSTANT:
 		result = BoundConstantExpression::Deserialize(state, reader);
 		break;
+	case ExpressionClass::BOUND_DEFAULT:
+		result = BoundDefaultExpression::Deserialize(state, reader);
+		break;
 	case ExpressionClass::BOUND_FUNCTION:
 		result = BoundFunctionExpression::Deserialize(state, reader);
 		break;

--- a/src/planner/expression/bound_default_expression.cpp
+++ b/src/planner/expression/bound_default_expression.cpp
@@ -1,10 +1,16 @@
 #include "duckdb/planner/expression/bound_default_expression.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/field_writer.hpp"
 
 namespace duckdb {
 
 void BoundDefaultExpression::Serialize(FieldWriter &writer) const {
-	throw NotImplementedException(ExpressionTypeToString(type));
+	writer.WriteSerializable(return_type);
+}
+
+unique_ptr<Expression> BoundDefaultExpression::Deserialize(ExpressionDeserializationState &state, FieldReader &reader) {
+	auto return_type = reader.ReadRequiredSerializable<LogicalType, LogicalType>();
+	return make_uniq<BoundDefaultExpression>(return_type);
 }
 
 } // namespace duckdb

--- a/src/planner/operator/logical_distinct.cpp
+++ b/src/planner/operator/logical_distinct.cpp
@@ -16,15 +16,16 @@ string LogicalDistinct::ParamsToString() const {
 void LogicalDistinct::Serialize(FieldWriter &writer) const {
 	writer.WriteField<DistinctType>(distinct_type);
 	writer.WriteSerializableList(distinct_targets);
-	if (order_by) {
-		throw NotImplementedException("Serializing ORDER BY not yet supported");
-	}
+	writer.WriteOptional(order_by);
 }
 
 unique_ptr<LogicalOperator> LogicalDistinct::Deserialize(LogicalDeserializationState &state, FieldReader &reader) {
 	auto distinct_type = reader.ReadRequired<DistinctType>();
 	auto distinct_targets = reader.ReadRequiredSerializableList<Expression>(state.gstate);
-	return make_uniq<LogicalDistinct>(std::move(distinct_targets), distinct_type);
+	auto order_by = reader.ReadOptional<BoundOrderModifier>(nullptr, state.gstate);
+	auto ret = make_uniq<LogicalDistinct>(std::move(distinct_targets), distinct_type);
+	ret->order_by = std::move(order_by);
+	return std::move(ret);
 }
 
 } // namespace duckdb


### PR DESCRIPTION
More challenging commit is https://github.com/duckdb/duckdb/commit/0e5d20e6b6cc44c9bf194a3cc0ce8d18138a5bf1, authored together with @taniabogatsch. It seems to make sense both in current state AND make serialization possible.

This has been uncovered while implementing serialization on list's lambdas, but that code is for the next PR.