### PR TITLE
PhysicalPiecewiseMergeJoin improvement

### DIFF
--- a/benchmark/micro/join/range_join_big_result.benchmark
+++ b/benchmark/micro/join/range_join_big_result.benchmark
@@ -1,0 +1,15 @@
+# name: benchmark/micro/join/range_join_big_result.benchmark
+# description: Range join between integers that has many result
+# group: [join]
+
+name Range Join with big result
+group join
+
+load
+CREATE TABLE integers AS SELECT ((i * 9582398353) % 1000)::INTEGER AS i, ((i * 847892347987) % 100)::INTEGER AS j FROM range(0, 50000) tbl(i);
+
+run
+SELECT COUNT(*) FROM integers a, integers b WHERE (a.i // 1000) < b.j ORDER BY 1;
+
+result I
+2475000000

--- a/src/common/sort/merge_sorter.cpp
+++ b/src/common/sort/merge_sorter.cpp
@@ -273,16 +273,13 @@ void MergeSorter::ComputeMerge(const idx_t &count, bool left_smaller[]) {
 			break;
 		}
 		// Pin the radix sorting data
-		if (!l_done) {
-			left->PinRadix(l.block_idx);
-			l_radix_ptr = left->RadixPtr();
-		}
-		if (!r_done) {
-			right->PinRadix(r.block_idx);
-			r_radix_ptr = right->RadixPtr();
-		}
-		const idx_t &l_count = !l_done ? l_sorted_block.radix_sorting_data[l.block_idx]->count : 0;
-		const idx_t &r_count = !r_done ? r_sorted_block.radix_sorting_data[r.block_idx]->count : 0;
+		left->PinRadix(l.block_idx);
+		l_radix_ptr = left->RadixPtr();
+		right->PinRadix(r.block_idx);
+		r_radix_ptr = right->RadixPtr();
+
+		const idx_t l_count = l_sorted_block.radix_sorting_data[l.block_idx]->count;
+		const idx_t r_count = r_sorted_block.radix_sorting_data[r.block_idx]->count;
 		// Compute the merge
 		if (sort_layout.all_constant) {
 			// All sorting columns are constant size
@@ -298,12 +295,8 @@ void MergeSorter::ComputeMerge(const idx_t &count, bool left_smaller[]) {
 			}
 		} else {
 			// Pin the blob data
-			if (!l_done) {
-				left->PinData(*l_sorted_block.blob_sorting_data);
-			}
-			if (!r_done) {
-				right->PinData(*r_sorted_block.blob_sorting_data);
-			}
+			left->PinData(*l_sorted_block.blob_sorting_data);
+			right->PinData(*r_sorted_block.blob_sorting_data);
 			// Merge with variable size sorting columns
 			for (; compared < count && l.entry_idx < l_count && r.entry_idx < r_count; compared++) {
 				left_smaller[compared] =


### PR DESCRIPTION
In merge sort, for two sorted array with length _n_ and _m_ respectively, we can merge them using _n + m_ times comparison. But in `MergeJoinComplexBlocks` function, it calls compare function for _n * m_ times. This is inefficient.

This PR removes redundant comparisons by using the same idea in merge sort, and a small refactor that removes unnecessary check in `MergeSorter::ComputeMerge`.

In my computer, this optimization can reduce about 50% time when join condition has high selectivity.

```
benchmark/micro/join/range_join_big_result.benchmark       1       14.491618
benchmark/micro/join/range_join_big_result.benchmark       2       15.580933
benchmark/micro/join/range_join_big_result.benchmark       3       15.625284
benchmark/micro/join/range_join_big_result.benchmark       4       15.702231
benchmark/micro/join/range_join_big_result.benchmark       5       15.571635
```

```
benchmark/micro/join/range_join_big_result.benchmark       1       7.537545
benchmark/micro/join/range_join_big_result.benchmark       2       7.540828
benchmark/micro/join/range_join_big_result.benchmark       3       7.678278
benchmark/micro/join/range_join_big_result.benchmark       4       8.034369
benchmark/micro/join/range_join_big_result.benchmark       5       8.167570
```