### PR TITLE
[Python] only execute in `DuckDBPyRelation::Close` if it was never executed before

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
@@ -213,6 +213,8 @@ private:
 	unique_ptr<QueryResult> ExecuteInternal(bool stream_result = false);
 
 private:
+	//! Whether the relation has been executed at least once
+	bool executed;
 	shared_ptr<Relation> rel;
 	vector<LogicalType> types;
 	vector<string> names;


### PR DESCRIPTION
This PR fixes #7566

Now we remember that the relation was already executed so we don't have to execute it in Close() to make sure it was executed at least once (for insert/ other side-effect purposes)