### PR TITLE
Disable attaching on-disk DuckDB databases if external access is disabled

### DIFF
--- a/src/execution/operator/schema/physical_attach.cpp
+++ b/src/execution/operator/schema/physical_attach.cpp
@@ -14,7 +14,6 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // Source
 //===--------------------------------------------------------------------===//
-
 SourceResultType PhysicalAttach::GetData(ExecutionContext &context, DataChunk &chunk,
                                          OperatorSourceInput &input) const {
 	// parse the options

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -40,7 +40,7 @@ public:
 	//! Create an attached database instance with the specified storage extension
 	AttachedDatabase(DatabaseInstance &db, Catalog &catalog, StorageExtension &ext, string name, AttachInfo &info,
 	                 AccessMode access_mode);
-	~AttachedDatabase();
+	~AttachedDatabase() override;
 
 	void Initialize();
 
@@ -57,6 +57,8 @@ public:
 	bool IsSystem() const;
 	bool IsTemporary() const;
 	bool IsReadOnly() const;
+	bool IsInitialDatabase() const;
+	void SetInitialDatabase();
 
 	static string ExtractDatabaseName(const string &dbpath);
 
@@ -67,6 +69,7 @@ private:
 	unique_ptr<TransactionManager> transaction_manager;
 	AttachedDatabaseType type;
 	optional_ptr<Catalog> parent_catalog;
+	bool is_initial_database = false;
 };
 
 } // namespace duckdb

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -124,4 +124,12 @@ Catalog &AttachedDatabase::ParentCatalog() {
 	return *parent_catalog;
 }
 
+bool AttachedDatabase::IsInitialDatabase() const {
+	return is_initial_database;
+}
+
+void AttachedDatabase::SetInitialDatabase() {
+	is_initial_database = true;
+}
+
 } // namespace duckdb

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -171,6 +171,7 @@ void DatabaseInstance::CreateMainDatabase() {
 	}
 
 	// initialize the database
+	initial_database->SetInitialDatabase();
 	initial_database->Initialize();
 }
 

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/transaction/transaction_manager.hpp"
 #include "duckdb/common/serializer/buffered_file_reader.hpp"
 #include "duckdb/main/attached_database.hpp"
+#include "duckdb/main/database_manager.hpp"
 
 namespace duckdb {
 
@@ -98,6 +99,11 @@ void SingleFileStorageManager::LoadDatabase() {
 	auto &fs = FileSystem::Get(db);
 	auto &config = DBConfig::Get(db);
 	bool truncate_wal = false;
+	if (!config.options.enable_external_access) {
+		if (!db.IsInitialDatabase()) {
+			throw PermissionException("Attaching on-disk databases is disabled through configuration");
+		}
+	}
 
 	StorageManagerOptions options;
 	options.read_only = read_only;

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -605,3 +605,13 @@ TEST_CASE("Fuzzer 50 - Alter table heap-use-after-free", "[api]") {
 	con.SendQuery("CREATE TABLE t0(c0 INT);");
 	con.SendQuery("ALTER TABLE t0 ADD c1 TIMESTAMP_SEC;");
 }
+
+TEST_CASE("Test loading database with enable_external_access set to false", "[api]") {
+	DBConfig config;
+	config.options.enable_external_access = false;
+	auto path = TestCreatePath("external_access_test");
+	DuckDB db(path, &config);
+	Connection con(db);
+
+	REQUIRE_FAIL(con.Query("ATTACH 'mydb.db' AS external_access_test"));
+}

--- a/test/sql/attach/attach_external_access.test
+++ b/test/sql/attach/attach_external_access.test
@@ -1,0 +1,17 @@
+# name: test/sql/attach/attach_external_access.test
+# description: Test ATTACH with enable external access set to false
+# group: [attach]
+
+require skip_reload
+
+statement ok
+SET enable_external_access=false
+
+# we can attach in-memory databases
+statement ok
+ATTACH ':memory:' AS db1
+
+statement error
+ATTACH 'mydb.db' AS db2
+----
+Attaching on-disk databases is disabled through configuration


### PR DESCRIPTION
This makes commands like `ATTACH 'mydb.db' AS db2` fail with a `PermissionException` if `enable_external_access` is set to false.

Note that this does not apply to the initial database that is loaded on start-up, so it is possible to set `enable_external_access` to false in the initial configuration while still loading an on-disk database, i.e. this keeps on working:

```cpp
DBConfig config;
config.options.enable_external_access = false;
DuckDB db("mydb.db", &config);
```

CC @bleskes 