### PR TITLE
Rework test_plan_serialization_bwc to do roundtrip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ autoconf/aclocal.m4
 autoconf/autom4te.cache
 /compile_commands.json
 /.wasm
-/test/api/serialized_plans/serialized_plans.temp.binary
 
 #==============================================================================#
 # Directories to ignore (do not add trailing '/'s, they skip symlinks).

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ autoconf/aclocal.m4
 autoconf/autom4te.cache
 /compile_commands.json
 /.wasm
+/test/api/serialized_plans/serialized_plans.temp.binary
 
 #==============================================================================#
 # Directories to ignore (do not add trailing '/'s, they skip symlinks).


### PR DESCRIPTION
Before this PR:
- "Generate serialized plans file" with GEN_PLAN_STORAGE set generated test/api/serialized_plans/serialized_plans.binary
- "Generate serialized plans file" without GEN_PLAN_STORAGE did nothing
- "Test deserialized plans from file" tested against test/api/serialized_plans/serialized_plans.binary

Afterwards
- "Generate serialized plans file" with GEN_PLAN_STORAGE set generates test/api/serialized_plans/serialized_plans.binary AND test it's deserialization
- "Generate serialized plans file" without GEN_PLAN_STORAGE generates test/api/serialized_plans/serialized_plans.temp.binary AND test it's deserialization
- "Test deserialized plans from file" tests against test/api/serialized_plans/serialized_plans.binary

Basically always rountrip test in "Generate serialized plans file" (either on real or temp file) and the same as before in "Test deserialized plans from file".
Also test on generation is run as part of serialization suite.
Main logic should be the same that @bleskes originally committed with minor refactoring.