### PR TITLE
Build Python wheels for aarch64 using QEMU

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -138,6 +138,7 @@ jobs:
     needs: manylinux-extensions
     env:
       CIBW_BUILD: ${{ matrix.python_build}}
+      CIBW_SKIP: '*-musllinux_aarch64'
       CIBW_ARCHS: ${{ matrix.arch == 'i686' && 'auto32' || matrix.arch == 'aarch64' && 'aarch64' || 'auto64' }}
       SETUPTOOLS_SCM_NO_LOCAL: 'yes'
       PYTEST_TIMEOUT: '600'

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        arch: [i686, x86_64]
+        arch: [i686, x86_64, aarch64]
         python_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*]
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}
@@ -138,7 +138,7 @@ jobs:
     needs: manylinux-extensions
     env:
       CIBW_BUILD: ${{ matrix.python_build}}
-      CIBW_ARCHS: ${{ matrix.arch == 'i686' && 'auto32' || 'auto64'}}
+      CIBW_ARCHS: ${{ matrix.arch == 'i686' && 'auto32' || matrix.arch == 'aarch64' && 'aarch64' || 'auto64' }}
       SETUPTOOLS_SCM_NO_LOCAL: 'yes'
       PYTEST_TIMEOUT: '600'
       DUCKDB_BUILD_UNITY: 1
@@ -147,6 +147,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      if: ${{ matrix.arch == 'aarch64' }}
 
     - uses: actions/setup-python@v4
       with:

--- a/tools/pythonpkg/cibw.toml
+++ b/tools/pythonpkg/cibw.toml
@@ -18,5 +18,10 @@ test-command = "python -m pytest {project}/tests/fast"
 select = "*i686*"
 test-command = "python -m pytest {project}/tests/fast"
 
+# For aarch64 we don't build extensions
+[[tool.cibuildwheel.overrides]]
+select = "*aarch64*"
+test-command = "python -m pytest {project}/tests/fast"
+
 [tool.cibuildwheel.windows]
 test-command = "python -m pytest {project}/tests/fast"


### PR DESCRIPTION
Python linux wheels for aarch64 were originally introduced in #1678, then later removed in #3381.

As stated in issues #1677 and #4407, building from source is slow for developers and may not be possible on some machines.

These changes add aarch64 wheel support.
They do not introduce building extensions for aarch64, analogous to the current behavior for musllinux and i686 builds.

Resolves #1677
Resolves #4407