### PR TITLE
More UNNEST fixes

### DIFF
--- a/src/execution/operator/projection/physical_tableinout_function.cpp
+++ b/src/execution/operator/projection/physical_tableinout_function.cpp
@@ -70,6 +70,7 @@ OperatorResultType PhysicalTableInOutFunction::Execute(ExecutionContext &context
 			return OperatorResultType::NEED_MORE_INPUT;
 		}
 		// we are processing a new row: fetch the data for the current row
+		state.input_chunk.Reset();
 		D_ASSERT(input.ColumnCount() == state.input_chunk.ColumnCount());
 		// set up the input data to the table in-out function
 		for (idx_t col_idx = 0; col_idx < input.ColumnCount(); col_idx++) {

--- a/test/sql/types/list/unnest_null_empty.test
+++ b/test/sql/types/list/unnest_null_empty.test
@@ -53,3 +53,77 @@ Elvis	NULL	1
 Elvis	NULL	NULL
 Elvis	NULL	NULL
 Mark	NULL	1
+
+# related to issue 7391
+
+query III
+WITH t AS (
+	SELECT 1 AS r, ARRAY[1, 2, 3] AS a
+	UNION SELECT 2 AS r, ARRAY[4] AS a
+	UNION SELECT 3 AS r, NULL AS a)
+SELECT r, a, UNNEST(a) AS n
+FROM t
+ORDER BY r, n;
+----
+1	[1, 2, 3]	1
+1	[1, 2, 3]	2
+1	[1, 2, 3]	3
+2	[4]	4
+
+query II
+WITH t AS (
+	SELECT 1 AS r, ARRAY[1, 2, 3] AS a
+	UNION SELECT 2 AS r, ARRAY[4] AS a
+	UNION SELECT 3 AS r, NULL AS a)
+SELECT r, a.value
+FROM t, (SELECT UNNEST(a)) AS a(value)
+ORDER BY r, a.value
+----
+1	1
+1	2
+1	3
+2	4
+
+query II
+WITH t AS (
+	SELECT 1 AS r, ARRAY[1, 2, 3] AS a
+	UNION SELECT 2 AS r, ARRAY[4] AS a
+	UNION SELECT 3 AS r, NULL AS a)
+SELECT r, a.value
+FROM t, UNNEST(a) AS a(value)
+ORDER BY r, a.value
+----
+1	1
+1	2
+1	3
+2	4
+
+statement ok
+CREATE TABLE t AS SELECT 5 AS r, ARRAY[1, 2, 3] AS a;
+
+statement ok
+INSERT INTO t VALUES (6, [4]), (7, NULL);
+
+query II
+SELECT r, a.value
+FROM t, UNNEST(a) AS a(value)
+ORDER BY r, a.value
+----
+5	1
+5	2
+5	3
+6	4
+
+query II
+WITH t AS (
+	SELECT 5 AS r, ARRAY[1, 2, 3] AS a
+	UNION SELECT 6 AS r, ARRAY[4] AS a
+	UNION SELECT 7 AS r, NULL AS a)
+SELECT r, a.value
+FROM t, UNNEST(a) AS a(value)
+ORDER BY r, a.value
+----
+5	1
+5	2
+5	3
+6	4


### PR DESCRIPTION
This PR correctly resets the output chunk of the `UNNEST` operation in two places. If we encounter an `UNNEST(NULL)`, then we adjust the validity of that chunk, thus, we have to reset it later.