### PR TITLE
Regression.yml to check agaist GITHUB_BASE_REF

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -69,7 +69,7 @@ jobs:
       shell: bash
       run: |
         make
-        git clone https://github.com/duckdb/duckdb.git --depth=1
+        git clone --branch ${GITHUB_BASE_REF:-master} https://github.com/duckdb/duckdb.git --depth=1
         cd duckdb
         make
         cd ..
@@ -224,7 +224,7 @@ jobs:
       shell: bash
       run: |
         make
-        git clone https://github.com/duckdb/duckdb.git --depth=1
+        git clone --branch ${GITHUB_BASE_REF:-master} https://github.com/duckdb/duckdb.git --depth=1
         cd duckdb
         make
         cd ..
@@ -285,7 +285,7 @@ jobs:
     - name: Build Current
       shell: bash
       run: |
-        git clone https://github.com/duckdb/duckdb.git --depth=1
+        git clone --branch ${GITHUB_BASE_REF:-master} https://github.com/duckdb/duckdb.git --depth=1
         cd duckdb/tools/pythonpkg
         python setup.py install --user
         cd ../../..
@@ -334,7 +334,7 @@ jobs:
       shell: bash
       run: |
         make
-        git clone https://github.com/duckdb/duckdb.git --depth=1
+        git clone --branch ${GITHUB_BASE_REF:-master} https://github.com/duckdb/duckdb.git --depth=1
         cd duckdb
         make
         cd ..


### PR DESCRIPTION
GITHUB_BASE_REF will be equal to the target branch for pull requests, and undefined, otherwise.
(docs: https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)

Given we use the bash syntax to use variable or default (= to 'master'), this should make that pull requests against feature (or any other branch) will be tested only that given branch.

I am waiting for another round of testing on my fork, but this should address the regression on 'feature' branch.