### PR TITLE
Implement DatabaseManager::SetDefaultDatabase

### DIFF
--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -44,6 +44,7 @@ public:
 	//! Returns a reference to the system catalog
 	Catalog &GetSystemCatalog();
 	static const string &GetDefaultDatabase(ClientContext &context);
+	void SetDefaultDatabase(ClientContext &context, const string &new_value);
 
 	optional_ptr<AttachedDatabase> GetDatabaseFromPath(ClientContext &context, const string &path);
 	vector<reference<AttachedDatabase>> GetDatabases(ClientContext &context);

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -88,9 +88,7 @@ const string &DatabaseManager::GetDefaultDatabase(ClientContext &context) {
 }
 
 void DatabaseManager::SetDefaultDatabase(ClientContext &context, const string &new_value) {
-	optional_ptr<AttachedDatabase> db_entry;
-
-	context.RunFunctionInTransaction([&]() { db_entry = GetDatabase(context, new_value); });
+	auto db_entry = GetDatabase(context, new_value);
 
 	if (!db_entry) {
 		throw InternalException("Database \"%s\" not found", new_value);

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -87,6 +87,7 @@ const string &DatabaseManager::GetDefaultDatabase(ClientContext &context) {
 	return default_entry.catalog;
 }
 
+// LCOV_EXCL_START
 void DatabaseManager::SetDefaultDatabase(ClientContext &context, const string &new_value) {
 	auto db_entry = GetDatabase(context, new_value);
 
@@ -100,6 +101,7 @@ void DatabaseManager::SetDefaultDatabase(ClientContext &context, const string &n
 
 	default_database = new_value;
 }
+// LCOV_EXCL_STOP
 
 vector<reference<AttachedDatabase>> DatabaseManager::GetDatabases(ClientContext &context) {
 	vector<reference<AttachedDatabase>> result;

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -88,16 +88,9 @@ const string &DatabaseManager::GetDefaultDatabase(ClientContext &context) {
 }
 
 void DatabaseManager::SetDefaultDatabase(ClientContext &context, const string &new_value) {
-	auto has_active_transaction = context.transaction.HasActiveTransaction();
-	if (!has_active_transaction) {
-		context.transaction.BeginTransaction();
-	}
+	optional_ptr<AttachedDatabase> db_entry;
 
-	auto db_entry = GetDatabase(context, new_value);
-
-	if (!has_active_transaction) {
-		context.transaction.ClearTransaction();
-	}
+	context.RunFunctionInTransaction([&]() { db_entry = GetDatabase(context, new_value); });
 
 	if (!db_entry) {
 		throw InternalException("Database \"%s\" not found", new_value);


### PR DESCRIPTION
The `DatabaseManager::default_database` is returned by `DatabaseManager::GetDefaultDatabase` when the default catalog in the search path is invalid. In this PR, a method `SetDefaultDatabase` is added which can be used to change `default_database`.

With this change, new `Connection`s can use a database as default other than the one that was added first to the `DatabaseManager`.

The value for `default_database` can only be changed internally by calling `SetDefaultDatabase`. There is no `SET GLOBAL` option for this implemented in this PR.

I have written a unit test for this, but did not know where to put it. If you could tell me a good location for it, I can add it to the PR, too.