### PR TITLE
Minor CIFixes: flatten.test, rowsort, ctz UBs

### DIFF
--- a/src/include/duckdb/common/bit_utils.hpp
+++ b/src/include/duckdb/common/bit_utils.hpp
@@ -112,35 +112,29 @@ struct CountZeros<uint64_t> {
 template <>
 struct CountZeros<hugeint_t> {
 	inline static int Leading(hugeint_t value) {
-		if (value == 0) {
+		const uint64_t upper = (uint64_t)value.upper;
+		const uint64_t lower = value.lower;
+
+		if (upper) {
+			return __builtin_clzll(upper);
+		} else if (lower) {
+			return 64 + __builtin_clzll(lower);
+		} else {
 			return 128;
 		}
-
-		uint64_t upper = (uint64_t)value.upper;
-		uint64_t lower = value.lower;
-
-		int res = __builtin_clzll(upper);
-		if (res == 64) {
-			res += __builtin_clzll(lower);
-		}
-
-		return res;
 	}
 
 	inline static int Trailing(hugeint_t value) {
-		if (value == 0) {
+		const uint64_t upper = (uint64_t)value.upper;
+		const uint64_t lower = value.lower;
+
+		if (lower) {
+			return __builtin_ctzll(lower);
+		} else if (upper) {
+			return 64 + __builtin_ctzll(upper);
+		} else {
 			return 128;
 		}
-
-		uint64_t upper = (uint64_t)value.upper;
-		uint64_t lower = value.lower;
-
-		int res = __builtin_ctzll(lower);
-		if (res == 64) {
-			res += __builtin_ctzll(upper);
-		}
-
-		return res;
 	}
 };
 

--- a/test/sql/function/list/flatten.test
+++ b/test/sql/function/list/flatten.test
@@ -101,7 +101,7 @@ statement ok
 CREATE TABLE lists AS SELECT i % 4 i, list(j ORDER BY rowid) j FROM nums GROUP BY i
 
 statement ok
-CREATE TABLE nested_lists AS SELECT i, list(j ORDER BY rowid) j FROM lists GROUP BY i
+CREATE TABLE nested_lists AS SELECT i, list_sort(list(j ORDER BY rowid)) j FROM lists GROUP BY i ORDER BY i
 
 query II
 FROM nested_lists

--- a/test/sql/pivot/top_level_pivot_syntax.test
+++ b/test/sql/pivot/top_level_pivot_syntax.test
@@ -29,37 +29,37 @@ INSERT INTO monthly_sales VALUES
     (2, 4500, '4-APR');
 
 # top level PIVOT syntax
-query IIIII
+query IIIII rowsort
 PIVOT monthly_sales ON MONTH USING SUM(AMOUNT)
 ----
 1	10400	8000	11000	18000
 2	39500	90700	12000	5300
 
-query IIIII
+query IIIII rowsort
 FROM (PIVOT monthly_sales ON MONTH USING SUM(AMOUNT));
 ----
 1	10400	8000	11000	18000
 2	39500	90700	12000	5300
 
-query IIIII
+query IIIII rowsort
 PIVOT monthly_sales ON MONTH USING SUM(AMOUNT) GROUP BY empid
 ----
 1	10400	8000	11000	18000
 2	39500	90700	12000	5300
 
-query IIIII
+query IIIII rowsort
 PIVOT monthly_sales ON MONTH IN ('1-JAN', '2-FEB', '3-MAR', '4-APR') USING SUM(AMOUNT) GROUP BY empid
 ----
 1	10400	8000	11000	18000
 2	39500	90700	12000	5300
 
-query IIII
+query IIII rowsort
 PIVOT monthly_sales ON MONTH IN ('1-JAN', '2-FEB', '3-MAR') USING SUM(AMOUNT) GROUP BY empid
 ----
 1	10400	8000	11000
 2	39500	90700	12000
 
-query IIIII
+query IIIII rowsort
 PIVOT monthly_sales ON MONTH USING SUM(AMOUNT) GROUP BY empid
 ----
 1	10400	8000	11000	18000


### PR DESCRIPTION
There have been a few failure on nightly and on PRs (eg https://github.com/duckdb/duckdb/pull/7784) tied to VECTOR_SIZE = 2 and the inherently non-deterministic GROUP BY behaviour.

This should fix this problem (previous attempt https://github.com/duckdb/duckdb/pull/7893 was solving only one direction)