### PR TITLE
do not link libgcc/libc++ statically.

### DIFF
--- a/tools/jdbc/CMakeLists.txt
+++ b/tools/jdbc/CMakeLists.txt
@@ -23,10 +23,6 @@ include_directories(../../extension/parquet/include)
 add_library(duckdb_java SHARED src/jni/duckdb_java.cpp)
 target_compile_options(duckdb_java PRIVATE -fexceptions)
 target_link_libraries(duckdb_java duckdb-native duckdb_static parquet_extension)
-if(OS_NAME STREQUAL "linux")
-  target_link_libraries(duckdb_java -static-libgcc -static-libstdc++
-  )# static link to libstdc++ to target more linux distro
-endif()
 if(APPLE)
   set(OS_ARCH universal)
 endif()


### PR DESCRIPTION
Currently the java library links statically to libc++. It seems it was a conscious decision to link c++ statically into the JNI library, for reasons of portability. Without knowing what problems this solves, it's hard to evaluate what we lose with this change.

Static linking to libc++ means duckdb has different type definitions for things like std::extension, std::locale, and others, compared to its extensions. We've seen two concrete issues resulting:
- duckdb can't catch an std::exception thrown by an extension, which means any exception will be fatal to the process.
- std::locale not being properly initialized.

I suspect these are just a few of the issues that can be caused by having multiple copies of the C++ runtime linked in. 

~~I'm still verifying this fix, which is why this is a draft PR.~~ Curious to start discussion in parallel.
[edit] Fix is confirmed.  