### PR TITLE
Fix Issue 7278

### DIFF
--- a/src/execution/operator/join/physical_iejoin.cpp
+++ b/src/execution/operator/join/physical_iejoin.cpp
@@ -1016,19 +1016,16 @@ void PhysicalIEJoin::BuildPipelines(Pipeline &current, MetaPipeline &meta_pipeli
 
 	// Create one child meta pipeline that will hold the LHS and RHS pipelines
 	auto &child_meta_pipeline = meta_pipeline.CreateChildMetaPipeline(current, *this);
-	auto lhs_pipeline = child_meta_pipeline.GetBasePipeline();
-	auto rhs_pipeline = child_meta_pipeline.CreatePipeline();
 
 	// Build out LHS
+	auto lhs_pipeline = child_meta_pipeline.GetBasePipeline();
 	children[0]->BuildPipelines(*lhs_pipeline, child_meta_pipeline);
 
-	// RHS depends on everything in LHS
-	child_meta_pipeline.AddDependenciesFrom(rhs_pipeline, lhs_pipeline.get(), true);
-
 	// Build out RHS
+	auto rhs_pipeline = child_meta_pipeline.CreatePipeline();
 	children[1]->BuildPipelines(*rhs_pipeline, child_meta_pipeline);
 
-	// Despite having the same sink, RHS needs its own PipelineFinishEvent
+	// Despite having the same sink, RHS and everything created after it need their own (same) PipelineFinishEvent
 	child_meta_pipeline.AddFinishEvent(rhs_pipeline);
 }
 

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -99,7 +99,7 @@ void Executor::SchedulePipeline(const shared_ptr<MetaPipeline> &meta_pipeline, S
 		auto finish_group = meta_pipeline->GetFinishGroup(pipeline.get());
 		if (finish_group) {
 			// this pipeline is part of a finish group
-			const auto group_entry = event_map.find(*finish_group.get());
+			const auto group_entry = event_map.findc(*finish_group.get());
 			D_ASSERT(group_entry != event_map.end());
 			auto &group_stack = group_entry->second;
 			PipelineEventStack pipeline_stack(base_stack.pipeline_initialize_event, *pipeline_event,

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -99,7 +99,7 @@ void Executor::SchedulePipeline(const shared_ptr<MetaPipeline> &meta_pipeline, S
 		auto finish_group = meta_pipeline->GetFinishGroup(pipeline.get());
 		if (finish_group) {
 			// this pipeline is part of a finish group
-			const auto group_entry = event_map.findc(*finish_group.get());
+			const auto group_entry = event_map.find(*finish_group.get());
 			D_ASSERT(group_entry != event_map.end());
 			auto &group_stack = group_entry->second;
 			PipelineEventStack pipeline_stack(base_stack.pipeline_initialize_event, *pipeline_event,

--- a/test/sql/join/iejoin/iejoin_issue_7278.test
+++ b/test/sql/join/iejoin/iejoin_issue_7278.test
@@ -3,15 +3,12 @@
 # group: [iejoin]
 
 statement ok
-SELECT SETSEED(0.8675309);
-
-statement ok
 create temp table calendar as
 	SELECT
 		start_ts,
 		start_ts + interval '12 hours' as end_ts,
-		date_part('yearweek',start_ts)::bigint as yyyyww
-	FROM range(TIMESTAMP '2023-01-01 06:00:00', TIMESTAMP '2023-06-01 00:00:00', INTERVAL '12 hours') tbl(start_ts)
+		date_part('year',start_ts)::bigint * 100 + date_part('week',start_ts)::bigint  as yyyyww
+	FROM generate_series(TIMESTAMP '2023-01-01 06:00:00', TIMESTAMP '2023-06-01 00:00:00', INTERVAL '12 hours') tbl(start_ts)
 ;
 
 statement ok
@@ -19,10 +16,8 @@ create temp table snapshot_data as
 	select
 		TIMESTAMP '2023-03-01 08:00:00' as snapshot_ts,
 		1 as snapshot_value
-	from generate_series(100) t(i)
+	from generate_series(1,1000) t(i)
 ;
-
-loop i 0 10
 
 query I
 with cal_last_13 as (
@@ -30,12 +25,48 @@ with cal_last_13 as (
 	FROM calendar)
 )
 select
-	count(*),
+	count(*)
 from snapshot_data data
 join cal_last_13 cal
 	on data.snapshot_ts >= cal.start_ts
 	and data.snapshot_ts <= cal.end_ts
 ----
-101
+1000
 
-endloop
+query I
+with cal_last_13 as (
+	select * from calendar where yyyyww in (SELECT yyyyww
+	FROM calendar)
+	union all
+	select * from calendar where yyyyww in (SELECT yyyyww
+	FROM calendar)
+)
+select
+	count(*)
+from snapshot_data data
+join cal_last_13 cal
+	on data.snapshot_ts >= cal.start_ts
+	and data.snapshot_ts <= cal.end_ts
+----
+2000
+
+query I
+with cal_last_13 as (
+	select * from calendar where yyyyww in (SELECT yyyyww
+	FROM calendar)
+	union all
+	select * from calendar where yyyyww in (SELECT yyyyww
+	FROM calendar)
+	union all
+	select * from calendar where yyyyww in (SELECT yyyyww
+	FROM calendar)
+)
+select
+	count(*)
+from snapshot_data data
+join cal_last_13 cal
+	on data.snapshot_ts >= cal.start_ts
+	and data.snapshot_ts <= cal.end_ts
+----
+3000
+

--- a/test/sql/join/iejoin/iejoin_issue_7278.test
+++ b/test/sql/join/iejoin/iejoin_issue_7278.test
@@ -1,0 +1,41 @@
+# name: test/sql/join/iejoin/iejoin_issue_7278.test
+# description: Issue #7278: Incorrect results (child pipeline / finish event scheduling
+# group: [iejoin]
+
+statement ok
+SELECT SETSEED(0.8675309);
+
+statement ok
+create temp table calendar as
+	SELECT
+		start_ts,
+		start_ts + interval '12 hours' as end_ts,
+		date_part('yearweek',start_ts)::bigint as yyyyww
+	FROM range(TIMESTAMP '2023-01-01 06:00:00', TIMESTAMP '2023-06-01 00:00:00', INTERVAL '12 hours') tbl(start_ts)
+;
+
+statement ok
+create temp table snapshot_data as
+	select
+		TIMESTAMP '2023-03-01 08:00:00' as snapshot_ts,
+		1 as snapshot_value
+	from generate_series(100) t(i)
+;
+
+loop i 0 10
+
+query I
+with cal_last_13 as (
+	select * from calendar where yyyyww in (SELECT yyyyww
+	FROM calendar)
+)
+select
+	count(*),
+from snapshot_data data
+join cal_last_13 cal
+	on data.snapshot_ts >= cal.start_ts
+	and data.snapshot_ts <= cal.end_ts
+----
+101
+
+endloop

--- a/test/sql/join/iejoin/iejoin_issue_7278.test
+++ b/test/sql/join/iejoin/iejoin_issue_7278.test
@@ -70,3 +70,25 @@ join cal_last_13 cal
 ----
 3000
 
+query I
+with cal_last_13 as (
+	select * from calendar where yyyyww in (SELECT yyyyww
+	FROM calendar)
+	union all
+	select * from calendar where yyyyww in (SELECT yyyyww
+	FROM calendar)
+	union all
+	select * from calendar where yyyyww in (SELECT yyyyww
+	FROM calendar)
+)
+select
+	count(*)
+from snapshot_data data
+join cal_last_13 cal
+	on data.snapshot_ts >= cal.start_ts
+	and data.snapshot_ts <= cal.end_ts
+join cal_last_13 cal2
+	on data.snapshot_ts >= cal2.start_ts
+	and data.snapshot_ts <= cal2.end_ts
+----
+9000

--- a/test/sql/join/iejoin/iejoin_issue_7278.test
+++ b/test/sql/join/iejoin/iejoin_issue_7278.test
@@ -6,7 +6,7 @@ statement ok
 pragma enable_verification
 
 statement ok
-create temp table calendar as
+create table calendar as
 	SELECT
 		start_ts,
 		start_ts + interval '12 hours' as end_ts,
@@ -15,7 +15,7 @@ create temp table calendar as
 ;
 
 statement ok
-create temp table snapshot_data as
+create table snapshot_data as
 	select
 		TIMESTAMP '2023-03-01 08:00:00' as snapshot_ts,
 		1 as snapshot_value

--- a/test/sql/join/iejoin/iejoin_issue_7278.test
+++ b/test/sql/join/iejoin/iejoin_issue_7278.test
@@ -3,6 +3,9 @@
 # group: [iejoin]
 
 statement ok
+pragma enable_verification
+
+statement ok
 create temp table calendar as
 	SELECT
 		start_ts,


### PR DESCRIPTION
The issue was that union/child pipelines could be scheduled after the initial RHS pipeline was scheduled, which then all had to be finished before we finalized the LHS. This caused all data to be sunk into the LHS, causing the RHS of the join to be empty, and therefore there was no result. This PR fixes this by keeping track of "finish groups" that need to be finished together.