### PR TITLE
Fix: Don't free arrow children explicitly

### DIFF
--- a/src/common/arrow/arrow_wrapper.cpp
+++ b/src/common/arrow/arrow_wrapper.cpp
@@ -14,12 +14,6 @@ namespace duckdb {
 
 ArrowSchemaWrapper::~ArrowSchemaWrapper() {
 	if (arrow_schema.release) {
-		for (int64_t child_idx = 0; child_idx < arrow_schema.n_children; child_idx++) {
-			auto &child = *arrow_schema.children[child_idx];
-			if (child.release) {
-				child.release(&child);
-			}
-		}
 		arrow_schema.release(&arrow_schema);
 		arrow_schema.release = nullptr;
 	}
@@ -27,12 +21,6 @@ ArrowSchemaWrapper::~ArrowSchemaWrapper() {
 
 ArrowArrayWrapper::~ArrowArrayWrapper() {
 	if (arrow_array.release) {
-		for (int64_t child_idx = 0; child_idx < arrow_array.n_children; child_idx++) {
-			auto &child = *arrow_array.children[child_idx];
-			if (child.release) {
-				child.release(&child);
-			}
-		}
 		arrow_array.release(&arrow_array);
 		arrow_array.release = nullptr;
 	}


### PR DESCRIPTION
When investigating a memory leak in the spatial extensions GDAL integration we found that the way we free arrow array children may interfere with the stream providers release function, in particular the default provided [by GDAL here](https://github.com/OSGeo/gdal/blob/db31b50acf7f3539fe851211402d1fabab33eb72/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp#L403-L426), causing a memory leak.

I'm not entirely sure who's in the wrong here, but AFAIK a compliant arrow array provider should ensure that the release function also releases any eventual child arrays on its own, so we shouldn't have to do that as well.