### PR TITLE
Do not link statically libgcc and libstdc++

### DIFF
--- a/tools/jdbc/CMakeLists.txt
+++ b/tools/jdbc/CMakeLists.txt
@@ -23,10 +23,6 @@ include_directories(../../extension/parquet/include)
 add_library(duckdb_java SHARED src/jni/duckdb_java.cpp)
 target_compile_options(duckdb_java PRIVATE -fexceptions)
 target_link_libraries(duckdb_java duckdb-native duckdb_static parquet_extension)
-if(OS_NAME STREQUAL "linux")
-  target_link_libraries(duckdb_java -static-libgcc -static-libstdc++
-  )# static link to libstdc++ to target more linux distro
-endif()
 if(APPLE)
   set(OS_ARCH universal)
 endif()


### PR DESCRIPTION
Linking standard library with the JNI library causes multiple issues:

Since DuckDB loads extensions with `RTLD_LOCAL`, symbols will not be shared between the parent and extension. Because all extensions are linked statically against DuckDB, we could have duplicate type definitions.

For example:

<details><summary>Creating std::regex causes `std::bad_cast` to be thrown because the locale is not correctly loaded</summary>
<p>

```bash
    #0 0x7f700636f988 in AsanCheckFailed ../../../../src/libsanitizer/asan/asan_rtl.cpp:74
    #1 0x7f700639030e in __sanitizer::CheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) ../../../../src/libsanitizer/sanitizer_common/sanitizer_termination.cpp:78
    #2 0x7f70062eb5a4 in __interceptor___cxa_throw ../../../../src/libsanitizer/asan/asan_interceptors.cpp:335
    #3 0x7f6d9ba29636 in __cxa_bad_cast (/lib/x86_64-linux-gnu/libstdc++.so.6+0xa2636)
    #4 0x7f6d9ba89faf in std::__cxx11::collate<char> const& std::use_facet<std::__cxx11::collate<char> >(std::locale const&) (/lib/x86_64-linux-gnu/libstdc++.so.6+0x102faf)
    #5 0x7f6d9bf5d2d9 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > std::__cxx11::regex_traits<char>::transform<char*>(char*, char*) const (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x3ac2d9)
    #6 0x7f6d9bf56c7d in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > std::__cxx11::regex_traits<char>::transform_primary<char const*>(char const*, char const*) const (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x3a5c7d)
    #7 0x7f6d9bf492a3 in std::__detail::_BracketMatcher<std::__cxx11::regex_traits<char>, false, false>::_M_apply(char, std::integral_constant<bool, false>) const::{lambda()#1}::operator()() const (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x3982a3)
    #8 0x7f6d9bf49787 in std::__detail::_BracketMatcher<std::__cxx11::regex_traits<char>, false, false>::_M_apply(char, std::integral_constant<bool, false>) const (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x398787)
    #9 0x7f6d9bf3b62a in std::__detail::_BracketMatcher<std::__cxx11::regex_traits<char>, false, false>::_M_make_cache(std::integral_constant<bool, true>) (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x38a62a)
    #10 0x7f6d9bf2fcbb in std::__detail::_BracketMatcher<std::__cxx11::regex_traits<char>, false, false>::_M_ready() (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x37ecbb)
    #11 0x7f6d9bf31a05 in void std::__detail::_Compiler<std::__cxx11::regex_traits<char> >::_M_insert_bracket_matcher<false, false>(bool) (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x380a05)
    #12 0x7f6d9bf28cae in std::__detail::_Compiler<std::__cxx11::regex_traits<char> >::_M_bracket_expression() (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x377cae)
    #13 0x7f6d9bf1ff97 in std::__detail::_Compiler<std::__cxx11::regex_traits<char> >::_M_atom() (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x36ef97)
    #14 0x7f6d9bf1972a in std::__detail::_Compiler<std::__cxx11::regex_traits<char> >::_M_term() (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x36872a)
    #15 0x7f6d9bf0e36b in std::__detail::_Compiler<std::__cxx11::regex_traits<char> >::_M_alternative() (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x35d36b)
    #16 0x7f6d9bf0e402 in std::__detail::_Compiler<std::__cxx11::regex_traits<char> >::_M_alternative() (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x35d402)
    #17 0x7f6d9bf0e402 in std::__detail::_Compiler<std::__cxx11::regex_traits<char> >::_M_alternative() (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x35d402)
    #18 0x7f6d9bf0e402 in std::__detail::_Compiler<std::__cxx11::regex_traits<char> >::_M_alternative() (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x35d402)
    #19 0x7f6d9bf0e402 in std::__detail::_Compiler<std::__cxx11::regex_traits<char> >::_M_alternative() (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x35d402)
    #20 0x7f6d9bf0e402 in std::__detail::_Compiler<std::__cxx11::regex_traits<char> >::_M_alternative() (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x35d402)
    #21 0x7f6d9bf0e402 in std::__detail::_Compiler<std::__cxx11::regex_traits<char> >::_M_alternative() (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x35d402)
    #22 0x7f6d9bf0e402 in std::__detail::_Compiler<std::__cxx11::regex_traits<char> >::_M_alternative() (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x35d402)
    #23 0x7f6d9bf0e402 in std::__detail::_Compiler<std::__cxx11::regex_traits<char> >::_M_alternative() (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x35d402)
    #24 0x7f6d9bf0e402 in std::__detail::_Compiler<std::__cxx11::regex_traits<char> >::_M_alternative() (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x35d402)
    #25 0x7f6d9bf0e402 in std::__detail::_Compiler<std::__cxx11::regex_traits<char> >::_M_alternative() (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x35d402)
    #26 0x7f6d9bf0e402 in std::__detail::_Compiler<std::__cxx11::regex_traits<char> >::_M_alternative() (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x35d402)
    #27 0x7f6d9bf0334e in std::__detail::_Compiler<std::__cxx11::regex_traits<char> >::_M_disjunction() (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x35234e)
    #28 0x7f6d9bef7445 in std::__detail::_Compiler<std::__cxx11::regex_traits<char> >::_Compiler(char const*, char const*, std::locale const&, std::regex_constants::syntax_option_type) (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x346445)
    #29 0x7f6d9bee6fe5 in std::__cxx11::basic_regex<char, std::__cxx11::regex_traits<char> >::_M_compile(char const*, char const*, std::regex_constants::syntax_option_type) (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x335fe5)
    #30 0x7f6d9bed57cb in std::__cxx11::basic_regex<char, std::__cxx11::regex_traits<char> >::basic_regex(char const*, std::regex_constants::syntax_option_type) (/root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension+0x3247cb)
    #31 0x7f6d9bea070c in motherduck::cleanup_old_versions_and_temp_files(duckdb::DBConfig&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/ec2-user/workspace/mono/native-extension/src/wrapper_init.cpp:175
    #32 0x7f6d9bea0f96 in motherduck::verify_latest_available[abi:cxx11](duckdb::DBConfig&) /home/ec2-user/workspace/mono/native-extension/src/wrapper_init.cpp:206
    #33 0x7f6d9bea114b in motherduck_init /home/ec2-user/workspace/mono/native-extension/src/wrapper_init.cpp:215
    #34 0x7f6da121b628 in duckdb::ExtensionHelper::LoadExternalExtension(duckdb::DatabaseInstance&, duckdb::FileSystem&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (/tmp/libduckdb_java15673577176745137979.so+0xa1b628)
    #35 0x7f6da1269659 in duckdb::DatabaseInstance::Initialize(char const*, duckdb::DBConfig*) (/tmp/libduckdb_java15673577176745137979.so+0xa69659)
    #36 0x7f6da1269910 in duckdb::DuckDB::DuckDB(char const*, duckdb::DBConfig*) (/tmp/libduckdb_java15673577176745137979.so+0xa69910)
    #37 0x7f6da1269b1d in duckdb::DBInstanceCache::CreateInstanceInternal(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, duckdb::DBConfig&, bool) (/tmp/libduckdb_java15673577176745137979.so+0xa69b1d)
    #38 0x7f6da1269da4 in duckdb::DBInstanceCache::GetOrCreateInstance(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, duckdb::DBConfig&, bool) (/tmp/libduckdb_java15673577176745137979.so+0xa69da4)
    #39 0x7f6da0ea262f in Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1startup (/tmp/libduckdb_java15673577176745137979.so+0x6a262f)
    #40 0x7f6ff2093539  (<unknown module>)
```
</p>
</details> 

Cf. [std::use_facet](https://en.cppreference.com/w/cpp/locale/use_facet)

<details><summary>Duplicate type definitions of an exception prevents try/catch from working properly</summary>
<p>

```bash
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=274928113216) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=274928113216) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=274928113216, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00000040018c4476 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00000040018aa7f3 in __GI_abort () at ./stdlib/abort.c:79
#5  0x00000040bd2e33a8 in _Unwind_SetGR () from /tmp/libduckdb_java2096923608753543128.so
#6  0x00000040bd24020a in __gxx_personality_v0 () from /tmp/libduckdb_java2096923608753543128.so
#7  0x000000413b132c64 in ?? () from /lib/x86_64-linux-gnu/libgcc_s.so.1
#8  0x000000413b1336bd in _Unwind_Resume () from /lib/x86_64-linux-gnu/libgcc_s.so.1
#9  0x00000041397e3878 in motherduck::...[abi:cxx11](duckdb::DBConfig&) [clone .cold] () from /root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension
#10 0x00000041399be319 in motherduck_init () from /root/.duckdb/extensions/v0.8.0/linux_amd64/motherduck.duckdb_extension
#11 0x00000040bc21b629 in duckdb::ExtensionHelper::LoadExternalExtension(duckdb::DatabaseInstance&, duckdb::FileSystem&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) () from /tmp/libduckdb_java2096923608753543128.so
#12 0x00000040bc26965a in duckdb::DatabaseInstance::Initialize(char const*, duckdb::DBConfig*) () from /tmp/libduckdb_java2096923608753543128.so
#13 0x00000040bc269911 in duckdb::DuckDB::DuckDB(char const*, duckdb::DBConfig*) () from /tmp/libduckdb_java2096923608753543128.so
#14 0x00000040bc269b1e in duckdb::DBInstanceCache::CreateInstanceInternal(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, duckdb::DBConfig&, bool) () from /tmp/libduckdb_java2096923608753543128.so
#15 0x00000040bc269da5 in duckdb::DBInstanceCache::GetOrCreateInstance(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, duckdb::DBConfig&, bool) () from /tmp/libduckdb_java2096923608753543128.so
#16 0x00000040bbea2630 in Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1startup () from /tmp/libduckdb_java2096923608753543128.so
#17 0x000000401a10d7c5 in ?? ()
#18 0x0000004002fe07c8 in ?? ()
#19 0x000000401a10d54d in ?? ()
#20 0x0000000000000000 in ?? ()
```

</p>
</details> 