### PR TITLE
Issue #7879: Missing JDBC TIMESTAMP_TZ

### DIFF
--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -1080,6 +1080,8 @@ JNIEXPORT jlong JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1arrow_1stream
 	} catch (const exception &e) {
 		env->ThrowNew(J_SQLException, e.what());
 	}
+	//	Unreachable
+	return 0;
 }
 
 class JavaArrowTabularStreamFactory {

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
@@ -1194,7 +1194,8 @@ public class DuckDBResultSet implements ResultSet {
 			}
 		} else if (type == Long.class) {
 			if (sqlType == DuckDBColumnType.BIGINT
-					|| sqlType == DuckDBColumnType.TIMESTAMP) {
+					|| sqlType == DuckDBColumnType.TIMESTAMP
+					|| sqlType == DuckDBColumnType.TIMESTAMP_WITH_TIME_ZONE) {
 				return type.cast(getLong(columnIndex));
 			} else if (sqlType == DuckDBColumnType.UINTEGER) {
 				throw new SQLException("Can't convert value to long " + type.toString());
@@ -1227,13 +1228,13 @@ public class DuckDBResultSet implements ResultSet {
 				throw new SQLException("Can't convert value to Time " + type.toString());
 			}
 		} else if (type == Timestamp.class) {
-			if (sqlType == DuckDBColumnType.TIMESTAMP) {
+			if (sqlType == DuckDBColumnType.TIMESTAMP || sqlType == DuckDBColumnType.TIMESTAMP_WITH_TIME_ZONE) {
 				return type.cast(getTimestamp(columnIndex));
 			} else {
 				throw new SQLException("Can't convert value to Timestamp " + type.toString());
 			}
 		} else if (type == LocalDateTime.class) {
-			if (sqlType == DuckDBColumnType.TIMESTAMP) {
+			if (sqlType == DuckDBColumnType.TIMESTAMP || sqlType == DuckDBColumnType.TIMESTAMP_WITH_TIME_ZONE) {
 				return type.cast(getLocalDateTime(columnIndex));
 			} else {
 				throw new SQLException("Can't convert value to LocalDateTime " + type.toString());

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
@@ -1141,7 +1141,11 @@ public class DuckDBResultSet implements ResultSet {
 	public void updateNClob(String columnLabel, Reader reader) throws SQLException {
 		throw new SQLFeatureNotSupportedException("updateNClob");
 	}
-
+	
+	private boolean isTimestamp(DuckDBColumnType sqlType) {
+		return (sqlType == DuckDBColumnType.TIMESTAMP || sqlType == DuckDBColumnType.TIMESTAMP_WITH_TIME_ZONE);
+	}
+	
 	public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
 		if (type == null) {
 			throw new SQLException("type is null");
@@ -1193,9 +1197,7 @@ public class DuckDBResultSet implements ResultSet {
 				throw new SQLException("Can't convert value to integer " + type.toString());
 			}
 		} else if (type == Long.class) {
-			if (sqlType == DuckDBColumnType.BIGINT
-					|| sqlType == DuckDBColumnType.TIMESTAMP
-					|| sqlType == DuckDBColumnType.TIMESTAMP_WITH_TIME_ZONE) {
+			if (sqlType == DuckDBColumnType.BIGINT || isTimestamp(sqlType)) {
 				return type.cast(getLong(columnIndex));
 			} else if (sqlType == DuckDBColumnType.UINTEGER) {
 				throw new SQLException("Can't convert value to long " + type.toString());
@@ -1228,13 +1230,13 @@ public class DuckDBResultSet implements ResultSet {
 				throw new SQLException("Can't convert value to Time " + type.toString());
 			}
 		} else if (type == Timestamp.class) {
-			if (sqlType == DuckDBColumnType.TIMESTAMP || sqlType == DuckDBColumnType.TIMESTAMP_WITH_TIME_ZONE) {
+			if (isTimestamp(sqlType)) {
 				return type.cast(getTimestamp(columnIndex));
 			} else {
 				throw new SQLException("Can't convert value to Timestamp " + type.toString());
 			}
 		} else if (type == LocalDateTime.class) {
-			if (sqlType == DuckDBColumnType.TIMESTAMP || sqlType == DuckDBColumnType.TIMESTAMP_WITH_TIME_ZONE) {
+			if (isTimestamp(sqlType)) {
 				return type.cast(getLocalDateTime(columnIndex));
 			} else {
 				throw new SQLException("Can't convert value to LocalDateTime " + type.toString());

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
@@ -171,7 +171,7 @@ class DuckDBVector {
 			return null;
 		}
 
-		if (isType(DuckDBColumnType.TIMESTAMP)) {
+		if (isType(DuckDBColumnType.TIMESTAMP) || isType(DuckDBColumnType.TIMESTAMP_WITH_TIME_ZONE)) {
 			return DuckDBTimestamp.toSqlTimestamp(getbuf(idx, 8).getLong());
 		}
 		if (isType(DuckDBColumnType.TIMESTAMP_MS)) {
@@ -306,7 +306,7 @@ class DuckDBVector {
 		if (check_and_null(idx)) {
 			return 0;
 		}
-		if (isType(DuckDBColumnType.BIGINT) || isType(DuckDBColumnType.TIMESTAMP)) {
+		if (isType(DuckDBColumnType.BIGINT) || isType(DuckDBColumnType.TIMESTAMP) || isType(DuckDBColumnType.TIMESTAMP_WITH_TIME_ZONE)) {
 			return getbuf(idx, 8).getLong();
 		}
 		Object o = getObject(idx);
@@ -468,7 +468,7 @@ class DuckDBVector {
 		}
 		// Our raw data is already a proper count of units since the epoch
 		// So just construct the SQL Timestamp.
-		if (isType(DuckDBColumnType.TIMESTAMP)) {
+		if (isType(DuckDBColumnType.TIMESTAMP) || isType(DuckDBColumnType.TIMESTAMP_WITH_TIME_ZONE)) {
 			return DuckDBTimestamp.fromMicroInstant(getbuf(idx, 8).getLong());
 		}
 		if (isType(DuckDBColumnType.TIMESTAMP_MS)) {
@@ -488,7 +488,7 @@ class DuckDBVector {
 		if (check_and_null(idx)) {
 			return null;
 		}
-		if (isType(DuckDBColumnType.TIMESTAMP)) {
+		if (isType(DuckDBColumnType.TIMESTAMP) || isType(DuckDBColumnType.TIMESTAMP_WITH_TIME_ZONE)) {
 			return DuckDBTimestamp.toLocalDateTime(getbuf(idx, 8).getLong());
 		}
 		Object o = getObject(idx);

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -523,7 +523,7 @@ public class TestDuckDBJDBC {
         }
     }
 
-	public static void test_throw_wrong_datatype() throws Exception {
+	public static void test_read_timestamp_tz() throws Exception {
 		Connection conn = DriverManager.getConnection("jdbc:duckdb:");
 		Statement stmt = conn.createStatement();
 		ResultSet rs;
@@ -533,12 +533,9 @@ public class TestDuckDBJDBC {
 
 		rs = stmt.executeQuery("SELECT * FROM t");
 		rs.next();
-
-		try {
-			rs.getTimestamp(2);
-			fail();
-		} catch (IllegalArgumentException e) {
-		}
+		
+		//	This succeeds now,
+		rs.getTimestamp(2);
 
 		rs.close();
 		stmt.close();

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -509,6 +509,29 @@ public class TestDuckDBJDBC {
 		stmt.close();
 		conn.close();
 	}
+	
+	public static void test_timestamptz_as_long() throws Exception {
+		Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+		Statement stmt = conn.createStatement();
+
+		ResultSet rs;
+
+		stmt.execute("SET CALENDAR='gregorian'");
+		stmt.execute("SET TIMEZONE='America/Los_Angeles'");
+		stmt.execute("CREATE TABLE t (id INT, t1 TIMESTAMPTZ)");
+		stmt.execute("INSERT INTO t (id, t1) VALUES (1, '2022-01-01T12:11:10Z')");
+		stmt.execute("INSERT INTO t (id, t1) VALUES (2, '2022-01-01T12:11:11Z')");
+
+		rs = stmt.executeQuery("SELECT * FROM t ORDER BY id");
+		rs.next();
+		assertEquals(rs.getLong(2), 1641039070000000L);
+		rs.next();
+		assertEquals(rs.getLong(2), 1641039071000000L);
+
+		rs.close();
+		stmt.close();
+		conn.close();
+	}
 
     public static void test_consecutive_timestamps() throws Exception {
     	long expected = 986860800000L;
@@ -523,7 +546,7 @@ public class TestDuckDBJDBC {
         }
     }
 
-	public static void test_read_timestamp_tz() throws Exception {
+	public static void test_throw_wrong_datatype() throws Exception {
 		Connection conn = DriverManager.getConnection("jdbc:duckdb:");
 		Statement stmt = conn.createStatement();
 		ResultSet rs;
@@ -533,9 +556,12 @@ public class TestDuckDBJDBC {
 
 		rs = stmt.executeQuery("SELECT * FROM t");
 		rs.next();
-		
-		//	This succeeds now,
-		rs.getTimestamp(2);
+
+		try {
+			rs.getShort(2);
+			fail();
+		} catch (IllegalArgumentException e) {
+		}
 
 		rs.close();
 		stmt.close();


### PR DESCRIPTION
Add some cases where converting TIMESTAMP_TZ is generating unparseable strings instead of just doing what TIMESTAMP does.

Unsure on how to test this, so suggestions from Java nerds welcome! It did fix a problem I found in Tableau.