### PR TITLE
Fix 7947

### DIFF
--- a/src/common/vector_operations/is_distinct_from.cpp
+++ b/src/common/vector_operations/is_distinct_from.cpp
@@ -564,10 +564,12 @@ static idx_t DistinctSelectList(Vector &left, Vector &right, idx_t count, const 
 	SelectionVector lcursor(count);
 	SelectionVector rcursor(count);
 
-	ListVector::GetEntry(left).Flatten(ListVector::GetListSize(left));
-	ListVector::GetEntry(right).Flatten(ListVector::GetListSize(right));
-	Vector lchild(ListVector::GetEntry(left), lcursor, count);
-	Vector rchild(ListVector::GetEntry(right), rcursor, count);
+	Vector lentry_flattened(ListVector::GetEntry(left));
+	Vector rentry_flattened(ListVector::GetEntry(right));
+	lentry_flattened.Flatten(ListVector::GetListSize(left));
+	rentry_flattened.Flatten(ListVector::GetListSize(right));
+	Vector lchild(lentry_flattened, lcursor, count);
+	Vector rchild(rentry_flattened, rcursor, count);
 
 	// To perform the positional comparison, we use a vectorisation of the following algorithm:
 	// bool CompareLists(T *left, idx_t nleft, T *right, nright) {


### PR DESCRIPTION
Fixes #7947

The issue was that a Vector was flattened after we called `ToUnifiedFormat` on it, which destroyed the selection vector stored in the `UnifiedVectorFormat`. I've now changed it so that the `UnifiedVectorFormat` now takes ownership of the selection vector, so this specifically should no longer happen.

However, not only the selection vector can be destroyed by flattening, but also the data and the validity mask. So the real issue here is that we can't use `Flatten` after calling `ToUnifiedFormat`. I tried to add verification for this, but it seems to be happening in quite a few places, so that should be fixed in the future. Maybe `Flatten` should never modify the input `Vector`, but instead always create a new one?

I've fixed it for this specific case, though, by fixing `DistinctSelectList` to first reference, then flatten, instead of flattening immediately.