### PR TITLE
[Python] Properly use NumPy array `stride` when scanning `object` arrays.

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/numpy/numpy_scan.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/numpy/numpy_scan.hpp
@@ -9,7 +9,7 @@ struct PandasColumnBindData;
 
 struct NumpyScan {
 	static void Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset, Vector &out);
-	static void ScanObjectColumn(PyObject **col, idx_t count, idx_t offset, Vector &out);
+	static void ScanObjectColumn(PyObject **col, idx_t stride, idx_t count, idx_t offset, Vector &out);
 };
 
 } // namespace duckdb

--- a/tools/pythonpkg/src/numpy/numpy_scan.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_scan.cpp
@@ -13,7 +13,6 @@
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb_python/numpy/numpy_scan.hpp"
 #include "duckdb_python/pandas/column/pandas_numpy_column.hpp"
-#include "duckdb/common/printer.hpp"
 
 namespace duckdb {
 
@@ -180,27 +179,18 @@ void NumpyScan::ScanObjectColumn(PyObject **col, idx_t stride, idx_t count, idx_
 	auto &mask = FlatVector::Validity(out);
 	PythonGILWrapper gil; // We're creating python objects here, so we need the GIL
 
-	if (stride == sizeof(PyObject*)) {
+	if (stride == sizeof(PyObject *)) {
 		auto src_ptr = col + offset;
 		for (idx_t i = 0; i < count; i++) {
 			ScanNumpyObject(src_ptr[i], i, out);
 		}
 	} else {
 		for (idx_t i = 0; i < count; i++) {
-			auto src_ptr = col[stride / sizeof(PyObject*) * (i + offset)];
+			auto src_ptr = col[stride / sizeof(PyObject *) * (i + offset)];
 			ScanNumpyObject(src_ptr, i, out);
 		}
 	}
 	VerifyTypeConstraints(out, count);
-}
-
-static void PrintNumpyArray(const py::array &array) {
-	Printer::Print(StringUtil::Format("strides: %d", array.strides(0)));
-	Printer::Print(StringUtil::Format("itemsize: %d", array.itemsize()));
-	Printer::Print(StringUtil::Format("size: %d", array.size()));
-	Printer::Print(StringUtil::Format("owndata: %d", array.owndata()));
-	Printer::Print(StringUtil::Format("flags: %d", array.flags()));
-	Printer::Print(StringUtil::Format("offset_at: %d", array.offset_at()));
 }
 
 //! 'offset' is the offset within the column
@@ -209,7 +199,6 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 	D_ASSERT(bind_data.pandas_col->Backend() == PandasColumnBackend::NUMPY);
 	auto &numpy_col = reinterpret_cast<PandasNumpyColumn &>(*bind_data.pandas_col);
 	auto &array = numpy_col.array;
-	PrintNumpyArray(array);
 
 	switch (bind_data.numpy_type) {
 	case NumpyNullableType::BOOL:

--- a/tools/pythonpkg/src/python_udf.cpp
+++ b/tools/pythonpkg/src/python_udf.cpp
@@ -196,7 +196,8 @@ static scalar_function_t CreateNativeFunction(PyObject *function, PythonExceptio
 
 		// Cast the resulting native python to DuckDB, using the return type
 		// result.Resize(input.size());
-		NumpyScan::ScanObjectColumn(python_results.data(), input.size(), 0, result);
+		// TODO: don't hardcode stride to 8
+		NumpyScan::ScanObjectColumn(python_results.data(), 8, input.size(), 0, result);
 		if (input.size() == 1) {
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
 		}

--- a/tools/pythonpkg/src/python_udf.cpp
+++ b/tools/pythonpkg/src/python_udf.cpp
@@ -194,7 +194,7 @@ static scalar_function_t CreateNativeFunction(PyObject *function, PythonExceptio
 			python_results.push_back(ret);
 		}
 
-		NumpyScan::ScanObjectColumn(python_results.data(), sizeof(PyObject*), input.size(), 0, result);
+		NumpyScan::ScanObjectColumn(python_results.data(), sizeof(PyObject *), input.size(), 0, result);
 		if (input.size() == 1) {
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
 		}

--- a/tools/pythonpkg/src/python_udf.cpp
+++ b/tools/pythonpkg/src/python_udf.cpp
@@ -194,10 +194,7 @@ static scalar_function_t CreateNativeFunction(PyObject *function, PythonExceptio
 			python_results.push_back(ret);
 		}
 
-		// Cast the resulting native python to DuckDB, using the return type
-		// result.Resize(input.size());
-		// TODO: don't hardcode stride to 8
-		NumpyScan::ScanObjectColumn(python_results.data(), 8, input.size(), 0, result);
+		NumpyScan::ScanObjectColumn(python_results.data(), sizeof(PyObject*), input.size(), 0, result);
 		if (input.size() == 1) {
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
 		}

--- a/tools/pythonpkg/tests/fast/pandas/test_df_object_resolution.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_df_object_resolution.py
@@ -403,6 +403,7 @@ class TestResolveObjectColumns(object):
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
     def test_numpy_object_with_stride(self, pandas):
+        con = duckdb.connect()
         df = pandas.DataFrame(columns=["idx", "evens", "zeros"])
 
         df["idx"] = list(range(10))
@@ -414,7 +415,7 @@ class TestResolveObjectColumns(object):
             df.loc[df["idx"] == i, "evens"] += counter
             counter += 2
 
-        res = duckdb.sql("select * from df").fetchall()
+        res = con.sql("select * from df").fetchall()
         assert res == [
             (0, 0, 0),
             (1, 2, 0),

--- a/tools/pythonpkg/tests/fast/pandas/test_df_object_resolution.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_df_object_resolution.py
@@ -402,6 +402,34 @@ class TestResolveObjectColumns(object):
         assert isinstance(converted_col['0'].dtype, double_dtype.__class__) == True
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
+    def test_numpy_object_with_stride(self, pandas):
+        df = pandas.DataFrame(columns=["idx", "evens", "zeros"])
+
+        df["idx"] = list(range(10))
+        for col in df.columns[1:]:
+            df[col].values[:] = 0
+
+        counter = 0
+        for i in range(10):
+            df.loc[df["idx"] == i, "evens"] += counter
+            counter += 2
+
+        res = duckdb.sql("select * from df").fetchall()
+        assert res == [
+            (0, 0, 0),
+            (1, 2, 0),
+            (2, 4, 0),
+            (3, 6, 0),
+            (4, 8, 0),
+            (5, 10, 0),
+            (6, 12, 0),
+            (7, 14, 0),
+            (8, 16, 0),
+            (9, 18, 0)
+        ]
+
+
+    @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
     def test_numpy_stringliterals(self, pandas):
         con = duckdb.connect()
         df = pandas.DataFrame({"x": list(map(np.str_, range(3)))})


### PR DESCRIPTION
This PR fixes #7937

Numpy arrays can have strides, which indicate the offset between each entry of the array.
When this is equal to the itemsize the iteration through this is straight forward, but if the stride differs we need to take this into account.

We already did this in other places, but this was not being done for object columns yet.