### PR TITLE
test: patch test_7652 to skip on pyarrow<11

### DIFF
--- a/tools/pythonpkg/tests/fast/arrow/test_7652.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_7652.py
@@ -3,8 +3,8 @@ import os
 import pytest
 import tempfile
 
-pa = pytest.importorskip("pyarrow")
-pq = pytest.importorskip("pyarrow.parquet")
+pa = pytest.importorskip("pyarrow", minversion="11")
+pq = pytest.importorskip("pyarrow.parquet", minversion="11")
 
 class Test7652(object):
     def test_7652(self):


### PR DESCRIPTION
This test fails with on `pyarrow<11` because the encoding isn't available.  I'd like to add this skip in for older versions of `pyarrow` since it's preventing conda-forge builds downstream (although I've patched it for now).

xref: https://github.com/conda-forge/python-duckdb-feedstock/pull/80

```
=================================== FAILURES ===================================
______________________________ Test7652.test_7652 ______________________________

self = <test_7652.Test7652 object at 0x7fce718ca990>

    def test_7652(self):
        temp_file_name = tempfile.NamedTemporaryFile(suffix='.parquet').name
        # Generate a list of values that aren't uniform in changes.
        generated_list = [1, 0, 2]
    
        print("Generated values:", generated_list)
        print(f"Min value: {min(generated_list)} max value: {max(generated_list)}")
    
        # Convert list of values to a PyArrow table with a single column.
        fake_table = pa.Table.from_arrays([pa.array(generated_list, pa.int64())], names=['n0'])
    
        # Write that column with DELTA_BINARY_PACKED encoding
        with pq.ParquetWriter(temp_file_name,
            fake_table.schema,
            column_encoding={"n0": "DELTA_BINARY_PACKED"},
            use_dictionary=False) as writer:
>           writer.write_table(fake_table)

tools/pythonpkg/tests/fast/arrow/test_7652.py:26: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/lib/python3.11/site-packages/pyarrow/parquet/core.py:1054: in write_table
    self.writer.write_table(table, row_group_size=row_group_size)
pyarrow/_parquet.pyx:1772: in pyarrow._parquet.ParquetWriter.write_table
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   OSError: Not yet implemented: Selected encoding is not supported.

pyarrow/error.pxi:115: OSError
----------------------------- Captured stdout call -----------------------------
Generated values: [1, 0, 2]
Min value: 0 max value: 2
=========================== short test summary info ============================
FAILED tools/pythonpkg/tests/fast/arrow/test_7652.py::Test7652::test_7652 - OSError: Not yet implemented: Selected encoding is not supported.
============ 1 failed, 1022 passed, 18 skipped in 95.26s (0:01:35) =============
Tests failed for python-duckdb-0.8.1-py311h1922059_0.conda - moving package to /home/conda/feedstock_root/build_artifacts/broken
```