### PR TITLE
enable callback with checkpoint lock

### DIFF
--- a/src/include/duckdb/main/query_result.hpp
+++ b/src/include/duckdb/main/query_result.hpp
@@ -49,7 +49,7 @@ public:
 	vector<string> names;
 
 public:
-	DUCKDB_API void ThrowError(const string &prepended_message = "") const;
+	[[noreturn]] DUCKDB_API void ThrowError(const string &prepended_message = "") const;
 	DUCKDB_API void SetError(PreservedError error);
 	DUCKDB_API bool HasError() const;
 	DUCKDB_API const ExceptionType &GetErrorType() const;

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -32,7 +32,10 @@ public:
 	//! Rollback the given transaction
 	void RollbackTransaction(Transaction *transaction) override;
 
-	void Checkpoint(ClientContext &context, bool force = false) override;
+	//! Checkpoint the DB. If the checkpoint is successful, invoke the callback while still holding the checkpoint lock.
+	//! No other transactions will start or commit between checkpoint begin and callback completion. The callback,
+	//! obviously, should not try to start or commit transactions.
+	void Checkpoint(ClientContext &context, bool force = false, std::function<void()> on_checkpoint = nullptr) override;
 
 	transaction_t LowestActiveId() {
 		return lowest_active_id;

--- a/src/include/duckdb/transaction/transaction_manager.hpp
+++ b/src/include/duckdb/transaction/transaction_manager.hpp
@@ -39,7 +39,7 @@ public:
 	virtual void RollbackTransaction(Transaction *transaction) = 0;
 
 	virtual void Checkpoint(ClientContext &context, bool force = false,
-		std::function<void()> on_checkpoint = nullptr) = 0;
+	                        std::function<void()> on_checkpoint = nullptr) = 0;
 
 	static TransactionManager &Get(AttachedDatabase &db);
 

--- a/src/include/duckdb/transaction/transaction_manager.hpp
+++ b/src/include/duckdb/transaction/transaction_manager.hpp
@@ -38,7 +38,8 @@ public:
 	//! Rollback the given transaction
 	virtual void RollbackTransaction(Transaction *transaction) = 0;
 
-	virtual void Checkpoint(ClientContext &context, bool force = false) = 0;
+	virtual void Checkpoint(ClientContext &context, bool force = false,
+		std::function<void()> on_checkpoint = nullptr) = 0;
 
 	static TransactionManager &Get(AttachedDatabase &db);
 


### PR DESCRIPTION
It would be nice to execute code after checkpoint completes, but before the checkpoint lock is dropped.

There are two ways to achieve this.
1) Have Checkpoint() return the CheckpointLock, and let the caller destroy it after running the relevant code.
2) Run code as a callback, passed in parameter to checkpoint().

The latter seemed simpler, so that's what this PR does.