### PR TITLE
CI - No longer run on PR synchronize, instead run on ready_for_review 

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -16,7 +16,7 @@ on:
       - '!.github/workflows/CodeQuality.yml'
 
   pull_request:
-    types: [labeled]
+    types: [opened, reopened, ready_for_review]
     paths-ignore:
       - '**.md'
       - '.github/patches/duckdb-wasm/**'

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -16,7 +16,7 @@ on:
       - '!.github/workflows/CodeQuality.yml'
 
   pull_request:
-    types: [review_requested]
+    types: [labeled]
     paths-ignore:
       - '**.md'
       - '.github/patches/duckdb-wasm/**'

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -16,6 +16,7 @@ on:
       - '!.github/workflows/CodeQuality.yml'
 
   pull_request:
+    types: [review_requested]
     paths-ignore:
       - '**.md'
       - '.github/patches/duckdb-wasm/**'

--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -20,7 +20,7 @@ on:
       - '!.github/workflows/Java.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [labeled]
+    types: [opened, reopened, ready_for_review]
     paths-ignore:
       - '**.md'
       - 'examples/**'

--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -20,7 +20,7 @@ on:
       - '!.github/workflows/Java.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [review_requested]
+    types: [labeled]
     paths-ignore:
       - '**.md'
       - 'examples/**'

--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -20,6 +20,7 @@ on:
       - '!.github/workflows/Java.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
+    types: [review_requested]
     paths-ignore:
       - '**.md'
       - 'examples/**'

--- a/.github/workflows/Julia.yml
+++ b/.github/workflows/Julia.yml
@@ -20,6 +20,7 @@ on:
       - '!.github/workflows/Julia.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
+    types: [review_requested]
     paths-ignore:
       - '**.md'
       - 'examples/**'

--- a/.github/workflows/Julia.yml
+++ b/.github/workflows/Julia.yml
@@ -20,7 +20,7 @@ on:
       - '!.github/workflows/Julia.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [review_requested]
+    types: [labeled]
     paths-ignore:
       - '**.md'
       - 'examples/**'

--- a/.github/workflows/Julia.yml
+++ b/.github/workflows/Julia.yml
@@ -20,7 +20,7 @@ on:
       - '!.github/workflows/Julia.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [labeled]
+    types: [opened, reopened, ready_for_review]
     paths-ignore:
       - '**.md'
       - 'examples/**'

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -17,7 +17,7 @@ on:
       - '!.github/workflows/LinuxRelease.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [labeled]
+    types: [opened, reopened, ready_for_review]
     paths-ignore:
       - '**.md'
       - 'tools/**'

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -17,7 +17,7 @@ on:
       - '!.github/workflows/LinuxRelease.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [review_requested]
+    types: [labeled]
     paths-ignore:
       - '**.md'
       - 'tools/**'

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -17,6 +17,7 @@ on:
       - '!.github/workflows/LinuxRelease.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
+    types: [review_requested]
     paths-ignore:
       - '**.md'
       - 'tools/**'

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -17,6 +17,7 @@ on:
       - '!.github/workflows/Main.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
+    types: [review_requested]
     paths-ignore:
       - '**.md'
       - 'tools/**'

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -17,7 +17,7 @@ on:
       - '!.github/workflows/Main.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [labeled]
+    types: [opened, reopened, ready_for_review]
     paths-ignore:
       - '**.md'
       - 'tools/**'

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -17,7 +17,7 @@ on:
       - '!.github/workflows/Main.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [review_requested]
+    types: [labeled]
     paths-ignore:
       - '**.md'
       - 'tools/**'

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -21,7 +21,7 @@ on:
       - '!.github/workflows/NodeJS.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [labeled]
+    types: [opened, reopened, ready_for_review]
     paths-ignore:
       - '**.md'
       - 'data/**'

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -21,7 +21,7 @@ on:
       - '!.github/workflows/NodeJS.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [review_requested]
+    types: [labeled]
     paths-ignore:
       - '**.md'
       - 'data/**'

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -21,6 +21,7 @@ on:
       - '!.github/workflows/NodeJS.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
+    types: [review_requested]
     paths-ignore:
       - '**.md'
       - 'data/**'

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -16,9 +16,6 @@ on:
       - '.github/workflows/**'
       - '!.github/workflows/OSX.yml'
       - '.github/config/uncovered_files.csv'
-  pull_request:
-    branches-ignore:
-      - '**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/master' || github.sha }}

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -20,7 +20,7 @@ on:
       - '!.github/workflows/Python.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [labeled]
+    types: [opened, reopened, ready_for_review]
     paths-ignore:
       - '**.md'
       - 'examples/**'

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -20,6 +20,7 @@ on:
       - '!.github/workflows/Python.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
+    types: [review_requested]
     paths-ignore:
       - '**.md'
       - 'examples/**'

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -20,7 +20,7 @@ on:
       - '!.github/workflows/Python.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [review_requested]
+    types: [labeled]
     paths-ignore:
       - '**.md'
       - 'examples/**'

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -20,6 +20,7 @@ on:
       - '!.github/workflows/R.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
+    types: [review_requested]
     paths-ignore:
       - '**.md'
       - 'examples/**'

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -20,7 +20,7 @@ on:
       - '!.github/workflows/R.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [labeled]
+    types: [opened, reopened, ready_for_review]
     paths-ignore:
       - '**.md'
       - 'examples/**'

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -20,7 +20,7 @@ on:
       - '!.github/workflows/R.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [review_requested]
+    types: [labeled]
     paths-ignore:
       - '**.md'
       - 'examples/**'

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -18,7 +18,7 @@ on:
       - '!.github/workflows/Regression.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [labeled]
+    types: [opened, reopened, ready_for_review]
     paths-ignore:
       - '**.md'
       - 'tools/**'

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -18,7 +18,7 @@ on:
       - '!.github/workflows/Regression.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [review_requested]
+    types: [labeled]
     paths-ignore:
       - '**.md'
       - 'tools/**'

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -18,6 +18,7 @@ on:
       - '!.github/workflows/Regression.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
+    types: [review_requested]
     paths-ignore:
       - '**.md'
       - 'tools/**'

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -20,7 +20,7 @@ on:
       - '!.github/workflows/Swift.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [labeled]
+    types: [opened, reopened, ready_for_review]
     paths-ignore:
       - '**.md'
       - 'examples/**'

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -20,7 +20,7 @@ on:
       - '!.github/workflows/Swift.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [review_requested]
+    types: [labeled]
     paths-ignore:
       - '**.md'
       - 'examples/**'

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -20,6 +20,7 @@ on:
       - '!.github/workflows/Swift.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
+    types: [review_requested]
     paths-ignore:
       - '**.md'
       - 'examples/**'

--- a/.github/workflows/WebAssembly.yml
+++ b/.github/workflows/WebAssembly.yml
@@ -19,7 +19,7 @@ on:
       - '!.github/workflows/WebAssembly.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [review_requested]
+    types: [labeled]
     paths-ignore:
       - '**.md'
       - 'script/**'

--- a/.github/workflows/WebAssembly.yml
+++ b/.github/workflows/WebAssembly.yml
@@ -19,6 +19,7 @@ on:
       - '!.github/workflows/WebAssembly.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
+    types: [review_requested]
     paths-ignore:
       - '**.md'
       - 'script/**'

--- a/.github/workflows/WebAssembly.yml
+++ b/.github/workflows/WebAssembly.yml
@@ -19,7 +19,7 @@ on:
       - '!.github/workflows/WebAssembly.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [labeled]
+    types: [opened, reopened, ready_for_review]
     paths-ignore:
       - '**.md'
       - 'script/**'

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -18,7 +18,7 @@ on:
       - '!.github/workflows/Windows.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [labeled]
+    types: [opened, reopened, ready_for_review]
     paths-ignore:
       - '**.md'
       - 'tools/**'

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -18,6 +18,7 @@ on:
       - '!.github/workflows/Windows.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
+    types: [review_requested]
     paths-ignore:
       - '**.md'
       - 'tools/**'

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -18,7 +18,7 @@ on:
       - '!.github/workflows/Windows.yml'
       - '.github/config/uncovered_files.csv'
   pull_request:
-    types: [review_requested]
+    types: [labeled]
     paths-ignore:
       - '**.md'
       - 'tools/**'


### PR DESCRIPTION
By default Github actions run [when a pull request is opened, re-opened and when a push is made to the head branch of a PR (`synchronize`)](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request). The latter is problematic with open PRs because CI is triggered many times, often non-deliberately, clogging the CI of the main repository.

This PR removes the `synchronize` trigger and adds the `ready_for_review` trigger (which occurs when a pull request changes from draft to one that is ready for review).

In the future we might want to replace this with explicit comments triggering PRs but let's try this for now.
