### PR TITLE
CI job to move synchronized PRs to draft

### DIFF
--- a/.github/workflows/DraftMe.yml
+++ b/.github/workflows/DraftMe.yml
@@ -1,0 +1,16 @@
+# Marks all changed PR as draft
+name: Draft on Synchronize
+on:
+  pull_request:
+    types: [ synchronize ]
+
+jobs:
+  mark-as-draft:
+    name: Mark as draft
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark as draft
+        uses: voiceflow/draft-pr@latest
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Should complement PR #8007 in that PRs will move to being draft, and a subsequent click (when actually ready!) to mark them as ready will have the CI run.
Current setup requires open -> draft -> open, step 1 is now done automatically.