### PR TITLE
Issue #8013: fix print pipeline with progress bar.

### DIFF
--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -247,6 +247,7 @@ string Pipeline::ToString() const {
 }
 
 void Pipeline::Print() const {
+	Printer::Print("\n");
 	Printer::Print(ToString());
 }
 


### PR DESCRIPTION
The printed plan may be on the same line as the progress bar, so the printing format will be messed up.


before:
<img width="1010" alt="print" src="https://github.com/duckdb/duckdb/assets/25699850/16f05441-db8f-4f76-8e03-1f440579a0e9">


after:

<img width="744" alt="change" src="https://github.com/duckdb/duckdb/assets/25699850/1f190947-9cb0-417a-9f1a-7f48a7c09c42">
