### PR TITLE
Fix issue 7988

### DIFF
--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -124,6 +124,22 @@ idx_t PhysicalOperator::GetMaxThreadMemory(ClientContext &context) {
 	return (max_memory / num_threads) / 4;
 }
 
+bool PhysicalOperator::OperatorCachingAllowed(ExecutionContext &context) {
+	if (!context.client.config.enable_caching_operators) {
+		return false;
+	} else if (!context.pipeline) {
+		return false;
+	} else if (!context.pipeline->GetSink()) {
+		return false;
+	} else if (context.pipeline->GetSink()->RequiresBatchIndex()) {
+		return false;
+	} else if (context.pipeline->IsOrderDependent()) {
+		return false;
+	}
+
+	return true;
+}
+
 //===--------------------------------------------------------------------===//
 // Pipeline Construction
 //===--------------------------------------------------------------------===//
@@ -239,20 +255,7 @@ OperatorResultType CachingPhysicalOperator::Execute(ExecutionContext &context, D
 #if STANDARD_VECTOR_SIZE >= 128
 	if (!state.initialized) {
 		state.initialized = true;
-		state.can_cache_chunk = true;
-
-		if (!context.client.config.enable_caching_operators) {
-			state.can_cache_chunk = false;
-		} else if (!context.pipeline || !caching_supported) {
-			state.can_cache_chunk = false;
-		} else if (!context.pipeline->GetSink()) {
-			// Disabling for pipelines without Sink, i.e. when pulling
-			state.can_cache_chunk = false;
-		} else if (context.pipeline->GetSink()->RequiresBatchIndex()) {
-			state.can_cache_chunk = false;
-		} else if (context.pipeline->IsOrderDependent()) {
-			state.can_cache_chunk = false;
-		}
+		state.can_cache_chunk = PhysicalOperator::OperatorCachingAllowed(context);
 	}
 	if (!state.can_cache_chunk) {
 		return child_result;

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -255,7 +255,7 @@ OperatorResultType CachingPhysicalOperator::Execute(ExecutionContext &context, D
 #if STANDARD_VECTOR_SIZE >= 128
 	if (!state.initialized) {
 		state.initialized = true;
-		state.can_cache_chunk = PhysicalOperator::OperatorCachingAllowed(context);
+		state.can_cache_chunk = caching_supported && PhysicalOperator::OperatorCachingAllowed(context);
 	}
 	if (!state.can_cache_chunk) {
 		return child_result;

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -156,6 +156,9 @@ public:
 	//! The maximum amount of memory the operator should use per thread.
 	static idx_t GetMaxThreadMemory(ClientContext &context);
 
+	//! Whether operator caching is allowed in the current execution context
+	static bool OperatorCachingAllowed(ExecutionContext &context);
+
 	virtual bool IsSink() const {
 		return false;
 	}

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -79,6 +79,7 @@ bool PipelineExecutor::TryFlushCachingOperators() {
 		OperatorResultType push_result;
 
 		if (in_process_operators.empty()) {
+			curr_chunk.Reset();
 			StartOperator(current_operator);
 			finalize_result = current_operator.FinalExecute(context, curr_chunk, *current_operator.op_state,
 			                                                *intermediate_states[flushing_idx]);


### PR DESCRIPTION
fixes #7988

problem was a combination of not resetting the chunk passed to the `FinalExecute` and the to_arrow_ipc function not setting the cardinality to zero (which it shouldn't need to).

Now the chunk is properly reset, and the test case in `test/sql/function/table/table_in_out.cpp` is properly testing for this bug. Additionally, the check to determine whether caching is allowed has been generalized and moved to `PhysicalOperator::OperatorCachingAllowed`