### PR TITLE
[CI] Skip many more CI jobs for pull requests, and add make coverage-check to run coverage locally

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -116,40 +116,10 @@ jobs:
         with:
           python-version: '3.9'
 
-      - name: Coverage Reset
-        shell: bash
-        run: |
-          lcov --config-file .github/workflows/lcovrc --zerocounters --directory .
-          lcov --config-file .github/workflows/lcovrc --capture --initial --directory . --base-directory . --no-external --output-file coverage.info
-
-      - name: Build
-        shell: bash
-        run: |
-          mkdir -p build/coverage
-          (cd build/coverage && cmake -E env CXXFLAGS="--coverage" cmake -DBUILD_PARQUET_EXTENSION=1 -DBUILD_ICU_EXTENSION=1 -DBUILD_JSON_EXTENSION=1 -DBUILD_JEMALLOC_EXTENSION=1 -DBUILD_AUTOCOMPLETE_EXTENSION=1 -DENABLE_SANITIZER=0 -DCMAKE_BUILD_TYPE=Debug ../.. && make)
-
-      - name: Run Tests
-        shell: bash
-        run: |
-          build/coverage/test/unittest
-          build/coverage/test/unittest "[intraquery]"
-          build/coverage/test/unittest "[interquery]"
-          build/coverage/test/unittest "[detailed_profiler]"
-          build/coverage/test/unittest test/sql/tpch/tpch_sf01.test_slow
-          build/coverage/tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper
-          python tools/shell/shell-test.py build/coverage/duckdb
-
-      - name: Generate Coverage
-        shell: bash
-        run: |
-          lcov --config-file .github/workflows/lcovrc --directory . --base-directory . --no-external --capture --output-file coverage.info
-          lcov --config-file .github/workflows/lcovrc --remove coverage.info $(< .github/workflows/lcov_exclude) -o lcov.info
-          genhtml -o coverage_html lcov.info
-
       - name: Check Coverage
         shell: bash
         run: |
-          python3 scripts/check_coverage.py
+          make coverage-check
 
       - name: Create Archive
         if: always()

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -33,7 +33,7 @@ env:
 jobs:
   format-check:
     name: Format Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     env:
       CC: gcc-10
@@ -59,7 +59,7 @@ jobs:
 
   tidy-check:
     name: Tidy Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: format-check
 
     env:
@@ -96,7 +96,7 @@ jobs:
 
   codecov:
     name: Code Coverage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: format-check
     strategy:
       fail-fast: false

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -33,7 +33,7 @@ env:
 jobs:
   format-check:
     name: Format Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       CC: gcc-10
@@ -59,7 +59,7 @@ jobs:
 
   tidy-check:
     name: Tidy Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: format-check
 
     env:
@@ -96,7 +96,7 @@ jobs:
 
   codecov:
     name: Code Coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: format-check
     strategy:
       fail-fast: false

--- a/.github/workflows/Julia.yml
+++ b/.github/workflows/Julia.yml
@@ -71,6 +71,11 @@ jobs:
           - ubuntu-latest
         arch:
           - x64
+        isRelease:
+          - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}
+        exclude:
+          - isRelease: false
+            version: '1.6'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -108,6 +108,7 @@ jobs:
 
  linux-release-aarch64:
    name: Linux (AARCH64)
+   if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
    runs-on: ubuntu-latest
    needs: linux-release-64
    container: ubuntu:18.04 # cross compiler not available in 16
@@ -298,6 +299,7 @@ jobs:
 
  linux-release-32:
     name: Linux (32 Bit)
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     container: ubuntu:16.04
     needs: linux-release-64
@@ -393,6 +395,7 @@ jobs:
  linux-clang:
     name: Clang 14
     runs-on: ubuntu-20.04
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
     needs: linux-release-64
 
     env:
@@ -460,17 +463,9 @@ jobs:
         key: ${{ github.job }}
         save: ${{ github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb' }}
 
-    - name: Build
-      shell: bash
-      run: make release
-      env:
-        CC: gcc-4.8
-        CXX: g++-4.8
-
-
     - name: Test
       shell: bash
-      run: make allunit
+      run: make unit
       env:
         CC: gcc-4.8
         CXX: g++-4.8

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -211,6 +211,7 @@ jobs:
 
  linux-extensions-64-aarch64:
     name: Linux Extensions (AARCH64)
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     container: ubuntu:18.04 # cross compiler not available in 16
     needs: linux-release-64

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -255,6 +255,7 @@ jobs:
 
  storage-initialization:
     name: Storage Initialization Verification
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
     needs: linux-debug
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -211,6 +211,7 @@ jobs:
 
  force-blocking-sink-source:
     name: Forcing async Sinks/Sources
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
     runs-on: ubuntu-20.04
     needs: linux-debug
     env:
@@ -393,6 +394,7 @@ jobs:
 
  sqllogic:
     name: Sqllogic tests
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
     runs-on: ubuntu-20.04
     needs: linux-debug
     env:

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -76,6 +76,9 @@ jobs:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}
         exclude:
           - isRelease: false
+            node: 10
+            target_arch: x64
+          - isRelease: false
             node: 12
             target_arch: x64
           - isRelease: false
@@ -96,6 +99,9 @@ jobs:
           - isRelease: false
             node: 19
             target_arch: x64
+          - isRelease: false
+            node: 10
+            target_arch: arm64
           - isRelease: false
             node: 12
             target_arch: arm64
@@ -180,6 +186,8 @@ jobs:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}
         exclude:
           - isRelease: false
+            node: 10
+          - isRelease: false
             node: 12
           - isRelease: false
             node: 14
@@ -254,6 +262,8 @@ jobs:
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}
         exclude:
+          - isRelease: false
+            node: 10
           - isRelease: false
             node: 12
           - isRelease: false

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -133,11 +133,17 @@ jobs:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}
         exclude:
           - isRelease: false
+            python_build: 'cp37-*'
+          - isRelease: false
             python_build: 'cp38-*'
           - isRelease: false
             python_build: 'cp39-*'
           - isRelease: false
             python_build: 'cp311-*'
+          - isRelease: false
+            arch: i686
+          - isRelease: false
+            arch: aarch64
     needs: manylinux-extensions
     env:
       CIBW_BUILD: ${{ matrix.python_build}}
@@ -268,6 +274,8 @@ jobs:
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}
         exclude:
+          - isRelease: false
+            python_build: 'cp36-*'
           - isRelease: false
             python_build: 'cp37-*'
           - isRelease: false

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -374,6 +374,7 @@ jobs:
 
    python-address-sanitizer:
       name: Python Address Sanitizer (Linux)
+      if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
       runs-on: ubuntu-latest
       container: ubuntu:16.04
       needs: linux-python3-9

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -256,6 +256,7 @@ jobs:
 
   rstats-windows-extensions:
     name: R Package Windows (Extensions)
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
     needs: rstats-linux
     runs-on: windows-latest
     steps:

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -114,6 +114,7 @@ jobs:
 
  regression-test-memory-safety:
   name: Regression Tests between safe and unsafe builds
+  if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
   runs-on: ubuntu-20.04
   env:
     CC: gcc-10

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -49,6 +49,15 @@ jobs:
           - 'iOS Simulator,name=iPhone 14'
           - 'watchOS Simulator,name=Apple Watch Ultra (49mm)'
           - 'tvOS Simulator,name=Apple TV 4K (at 1080p) (2nd generation)'
+        isRelease:
+          - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}
+        exclude:
+          - isRelease: false
+            destination: 'iOS Simulator,name=iPhone 14'
+          - isRelease: false
+            destination: 'watchOS Simulator,name=Apple Watch Ultra (49mm)'
+          - isRelease: false
+            destination: 'tvOS Simulator,name=Apple TV 4K (at 1080p) (2nd generation)'
     runs-on: macos-12
     steps:
 

--- a/Makefile
+++ b/Makefile
@@ -323,18 +323,4 @@ clangd:
 	cmake -DCMAKE_BUILD_TYPE=Debug ${EXTENSIONS} -B build/clangd .
 
 coverage-check:
-	lcov --config-file .github/workflows/lcovrc --zerocounters --directory .
-	lcov --config-file .github/workflows/lcovrc --capture --initial --directory . --base-directory . --no-external --output-file coverage.info
-	mkdir -p build/coverage
-	cd build/coverage && cmake -E env CXXFLAGS="--coverage" cmake -DBUILD_PARQUET_EXTENSION=1 -DBUILD_ICU_EXTENSION=1 -DBUILD_JSON_EXTENSION=1 -DBUILD_JEMALLOC_EXTENSION=1 -DBUILD_AUTOCOMPLETE_EXTENSION=1 -DENABLE_SANITIZER=0 -DCMAKE_BUILD_TYPE=Debug ../.. && cmake --build .
-	build/coverage/test/unittest
-	build/coverage/test/unittest "[intraquery]"
-	build/coverage/test/unittest "[interquery]"
-	build/coverage/test/unittest "[detailed_profiler]"
-	build/coverage/test/unittest test/sql/tpch/tpch_sf01.test_slow
-	build/coverage/tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper
-	python3 tools/shell/shell-test.py build/coverage/duckdb
-	lcov --config-file .github/workflows/lcovrc --directory . --base-directory . --no-external --capture --output-file coverage.info
-	lcov --config-file .github/workflows/lcovrc --remove coverage.info $(< .github/workflows/lcov_exclude) -o lcov.info
-	genhtml -o coverage_html lcov.info
-	python3 scripts/check_coverage.py
+	./scripts/coverage_check.sh

--- a/Makefile
+++ b/Makefile
@@ -328,8 +328,12 @@ coverage-check:
 	mkdir -p build/coverage
 	cd build/coverage && cmake -E env CXXFLAGS="--coverage" cmake -DBUILD_PARQUET_EXTENSION=1 -DBUILD_ICU_EXTENSION=1 -DBUILD_JSON_EXTENSION=1 -DBUILD_JEMALLOC_EXTENSION=1 -DBUILD_AUTOCOMPLETE_EXTENSION=1 -DENABLE_SANITIZER=0 -DCMAKE_BUILD_TYPE=Debug ../.. && cmake --build .
 	build/coverage/test/unittest
+	build/coverage/test/unittest "[intraquery]"
+	build/coverage/test/unittest "[interquery]"
+	build/coverage/test/unittest "[detailed_profiler]"
+	build/coverage/test/unittest test/sql/tpch/tpch_sf01.test_slow
 	build/coverage/tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper
-	python tools/shell/shell-test.py build/coverage/duckdb
+	python3 tools/shell/shell-test.py build/coverage/duckdb
 	lcov --config-file .github/workflows/lcovrc --directory . --base-directory . --no-external --capture --output-file coverage.info
 	lcov --config-file .github/workflows/lcovrc --remove coverage.info $(< .github/workflows/lcov_exclude) -o lcov.info
 	genhtml -o coverage_html lcov.info

--- a/Makefile
+++ b/Makefile
@@ -321,3 +321,16 @@ bloaty: reldebug bloaty/bloaty
 
 clangd:
 	cmake -DCMAKE_BUILD_TYPE=Debug ${EXTENSIONS} -B build/clangd .
+
+coverage-check:
+	lcov --config-file .github/workflows/lcovrc --zerocounters --directory .
+	lcov --config-file .github/workflows/lcovrc --capture --initial --directory . --base-directory . --no-external --output-file coverage.info
+	mkdir -p build/coverage
+	cd build/coverage && cmake -E env CXXFLAGS="--coverage" cmake -DBUILD_PARQUET_EXTENSION=1 -DBUILD_ICU_EXTENSION=1 -DBUILD_JSON_EXTENSION=1 -DBUILD_JEMALLOC_EXTENSION=1 -DBUILD_AUTOCOMPLETE_EXTENSION=1 -DENABLE_SANITIZER=0 -DCMAKE_BUILD_TYPE=Debug ../.. && cmake --build .
+	build/coverage/test/unittest
+	build/coverage/tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper
+	python tools/shell/shell-test.py build/coverage/duckdb
+	lcov --config-file .github/workflows/lcovrc --directory . --base-directory . --no-external --capture --output-file coverage.info
+	lcov --config-file .github/workflows/lcovrc --remove coverage.info $(< .github/workflows/lcov_exclude) -o lcov.info
+	genhtml -o coverage_html lcov.info
+	python3 scripts/check_coverage.py

--- a/scripts/coverage_check.sh
+++ b/scripts/coverage_check.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+lcov --config-file .github/workflows/lcovrc --zerocounters --directory .
+lcov --config-file .github/workflows/lcovrc --capture --initial --directory . --base-directory . --no-external --output-file coverage.info
+mkdir -p build/coverage
+(cd build/coverage && cmake -E env CXXFLAGS="--coverage" cmake -DBUILD_PARQUET_EXTENSION=1 -DBUILD_ICU_EXTENSION=1 -DBUILD_JSON_EXTENSION=1 -DBUILD_JEMALLOC_EXTENSION=1 -DBUILD_AUTOCOMPLETE_EXTENSION=1 -DENABLE_SANITIZER=0 -DCMAKE_BUILD_TYPE=Debug ../.. && cmake --build .)
+build/coverage/test/unittest
+build/coverage/test/unittest "[intraquery]"
+build/coverage/test/unittest "[interquery]"
+build/coverage/test/unittest "[detailed_profiler]"
+build/coverage/test/unittest test/sql/tpch/tpch_sf01.test_slow
+build/coverage/tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper
+python3 tools/shell/shell-test.py build/coverage/duckdb
+lcov --config-file .github/workflows/lcovrc --directory . --base-directory . --no-external --capture --output-file coverage.info
+lcov --config-file .github/workflows/lcovrc --remove coverage.info $(< .github/workflows/lcov_exclude) -o lcov.info
+genhtml -o coverage_html lcov.info
+python3 scripts/check_coverage.py

--- a/scripts/coverage_check.sh
+++ b/scripts/coverage_check.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
+
+# prepare coverage file
 lcov --config-file .github/workflows/lcovrc --zerocounters --directory .
 lcov --config-file .github/workflows/lcovrc --capture --initial --directory . --base-directory . --no-external --output-file coverage.info
+
+# build with coverage enabled
 mkdir -p build/coverage
 (cd build/coverage && cmake -E env CXXFLAGS="--coverage" cmake -DBUILD_PARQUET_EXTENSION=1 -DBUILD_ICU_EXTENSION=1 -DBUILD_JSON_EXTENSION=1 -DBUILD_JEMALLOC_EXTENSION=1 -DBUILD_AUTOCOMPLETE_EXTENSION=1 -DENABLE_SANITIZER=0 -DCMAKE_BUILD_TYPE=Debug ../.. && cmake --build .)
+
+# run tests
 build/coverage/test/unittest
 build/coverage/test/unittest "[intraquery]"
 build/coverage/test/unittest "[interquery]"
@@ -10,7 +16,13 @@ build/coverage/test/unittest "[detailed_profiler]"
 build/coverage/test/unittest test/sql/tpch/tpch_sf01.test_slow
 build/coverage/tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper
 python3 tools/shell/shell-test.py build/coverage/duckdb
+
+# finalize coverage file
 lcov --config-file .github/workflows/lcovrc --directory . --base-directory . --no-external --capture --output-file coverage.info
 lcov --config-file .github/workflows/lcovrc --remove coverage.info $(< .github/workflows/lcov_exclude) -o lcov.info
+
+# generate coverage html
 genhtml -o coverage_html lcov.info
+
+# check that coverage passes threshold
 python3 scripts/check_coverage.py


### PR DESCRIPTION
This PR adds more skips for CI runs when run in pull requests - in particular we try to skip CI jobs that take a long time but seldomly find bugs. Note that these are still run in the nightly and for releases and hence might need to be periodically fixed when a PR breaks them accidentally - although this is generally rare. The goal is to speed up the general workflow at the expense of occasionally having to go back and fix an issue (similar to what we do for MacOS runs currently - e.g. #8038).

The full list of tests this PR adds to-be-skipped are:

* Linux aarch64 builds
* Linux 32-bit builds
* Linux Clang 14
* Forcing async Sinks/Sources
* Storage Initialization Verification
* Sqllogic tests
* NodeJS 10
* Python 3.6/3.7
* Julia 1.6
* Python Address Sanitizer
* R Package Windows
* Regression Tests between safe and unsafe builds
* Swift WatchOS, iOS, tvOS


# make coverage-check

In addition, this PR also adds a new `make coverage-check` option that runs the code coverage. This can be used to more easily run and debug the code coverage locally.