### PR TITLE
Restore auto-draft functionality

### DIFF
--- a/.github/workflows/DraftMe.yml
+++ b/.github/workflows/DraftMe.yml
@@ -1,0 +1,26 @@
+# Marks all changed PR as draft
+name: Draft on Synchronize
+on:
+  pull_request:
+    types: [ synchronize ]
+
+concurrency:
+  group: shouldturntodraft-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  mark-as-draft:
+    name: Mark as draft
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.node_id }}
+        run: |
+          mkdir -p ./pr
+          echo $PR_NUMBER > ./pr/pr_number
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr/

--- a/.github/workflows/DraftMeNot.yml
+++ b/.github/workflows/DraftMeNot.yml
@@ -1,0 +1,20 @@
+# Marks all changed PR as draft
+name: Placeholder to avoid cancel already running DraftMe jobs
+on:
+  pull_request:
+    types: [ ready_for_review ]
+
+concurrency:
+  group: shouldturntodraft-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  mark-as-draft:
+    name: Placeholder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print PR number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.node_id }}
+        run: |
+          echo $PR_NUMBER

--- a/.github/workflows/DraftPR.yml
+++ b/.github/workflows/DraftPR.yml
@@ -1,0 +1,56 @@
+# Marks all changed PR as draft
+name: Move PRs to Draft
+on:
+  workflow_run:
+    workflows: [Draft on Synchronize]
+    types:
+      - completed
+
+jobs:
+  actually-move-to-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr_number"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.zip`, Buffer.from(download.data));
+
+      - name: 'Unzip artifact'
+        run: unzip pr_number.zip
+
+      - name: 'Extract PR node id'
+        shell: bash
+        run: |
+          (echo -n "PR_NUMBER=" | cat - pr_number) >> $GITHUB_ENV
+
+      - name: 'Actually move to draft'
+        shell: bash
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
+          gh api graphql -F id=${{ env.PR_NUMBER }} -f query='
+            mutation($id: ID!) {
+              convertPullRequestToDraft(input: { pullRequestId: $id }) {
+                pullRequest {
+                  id
+                  number
+                  isDraft
+                }
+              }
+            }
+          '


### PR DESCRIPTION
3 components:
* DraftMe.yml: on PR's syncronize event, save PR's ID to be consumed by DraftPR.yml
* DraftPR.yml: on DraftMe.yml completion, mark PR as draft
* DraftMeNot.yml: on PR's ready_for_review event, cancel any 'DraftMe' job on the queue

It's clearly too complicated, but simpler setups don't cut it, seems that the nested workflows is the way to go according to GitHub (https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run).

This works (?!), and can be used as blue-print even for more complex interactions between workflows (I can think of stuff like adding a comment or labels depending on CI status, or flagging a PR as "this is complex enough that i want extra tests run here").