### PR TITLE
capi: duckdb_interrupt & duckdb_query_progress

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -361,6 +361,21 @@ The instantiated connection should be closed using 'duckdb_disconnect'
 DUCKDB_API duckdb_state duckdb_connect(duckdb_database database, duckdb_connection *out_connection);
 
 /*!
+Interrupt running query
+
+* connection: The connection to interruot
+*/
+DUCKDB_API void duckdb_interrupt(duckdb_connection connection);
+
+/*!
+Get progress of the running query
+
+* connection: The working connection
+* returns: -1 if no progress or a percentage of the progress
+*/
+DUCKDB_API double duckdb_query_progress(duckdb_connection connection);
+
+/*!
 Closes the specified connection and de-allocates all memory allocated for that connection.
 
 * connection: The connection to close.

--- a/src/main/capi/duckdb-c.cpp
+++ b/src/main/capi/duckdb-c.cpp
@@ -54,6 +54,22 @@ duckdb_state duckdb_connect(duckdb_database database, duckdb_connection *out) {
 	return DuckDBSuccess;
 }
 
+void duckdb_interrupt(duckdb_connection connection) {
+	if (!connection) {
+		return;
+	}
+	Connection *conn = reinterpret_cast<Connection *>(connection);
+	conn->Interrupt();
+}
+
+double duckdb_query_progress(duckdb_connection connection) {
+	if (!connection) {
+		return -1;
+	}
+	Connection *conn = reinterpret_cast<Connection *>(connection);
+	return conn->context->GetProgress();
+}
+
 void duckdb_disconnect(duckdb_connection *connection) {
 	if (connection && *connection) {
 		Connection *conn = reinterpret_cast<Connection *>(*connection);

--- a/test/api/capi/test_capi_streaming.cpp
+++ b/test/api/capi/test_capi_streaming.cpp
@@ -97,3 +97,44 @@ TEST_CASE("Test other methods on streaming results in C API", "[capi]") {
 	auto is_null = result->IsNull(0, 0);
 	REQUIRE(is_null == false);
 }
+
+TEST_CASE("Test query progress and interrupt in C API", "[capi]") {
+	CAPITester tester;
+	CAPIPrepared prepared;
+	CAPIPending pending;
+	duckdb::unique_ptr<CAPIResult> result;
+
+	// test null handling
+	REQUIRE(duckdb_query_progress(nullptr) == -1.0);
+	duckdb_interrupt(nullptr);
+
+	// open the database in in-memory mode
+	REQUIRE(tester.OpenDatabase(nullptr));
+	REQUIRE_NO_FAIL(tester.Query("create table tbl as select range a, mod(range,10) b from range(10000);"));
+	REQUIRE_NO_FAIL(tester.Query("create table tbl_2 as select range a from range(10000);"));
+	REQUIRE_NO_FAIL(tester.Query("set enable_progress_bar=true;"));
+	REQUIRE_NO_FAIL(tester.Query("set enable_progress_bar_print=false;"));
+	// test no progress before query
+	REQUIRE(duckdb_query_progress(tester.connection) == -1.0);
+	// test zero progress with query
+	REQUIRE(prepared.Prepare(tester, "select count(*) from tbl where a = (select min(a) from tbl_2)"));
+	REQUIRE(pending.PendingStreaming(prepared));
+	REQUIRE(duckdb_query_progress(tester.connection) == 0.0);
+
+	// test progress
+	while (duckdb_query_progress(tester.connection) == 0.0) {
+		auto state = pending.ExecuteTask();
+		REQUIRE(state == DUCKDB_PENDING_RESULT_NOT_READY);
+	}
+	REQUIRE(duckdb_query_progress(tester.connection) >= 0.0);
+
+	// test interrupt
+	duckdb_interrupt(tester.connection);
+	while (true) {
+		auto state = pending.ExecuteTask();
+		REQUIRE(state != DUCKDB_PENDING_RESULT_READY);
+		if (state == DUCKDB_PENDING_ERROR) {
+			break;
+		}
+	}
+}


### PR DESCRIPTION
Introduces two C functions to interrupt queries and get queries progress