### PR TITLE
Fix regression & fix draft mechanism

### DIFF
--- a/.github/workflows/DraftMeNot.yml
+++ b/.github/workflows/DraftMeNot.yml
@@ -1,5 +1,5 @@
 # Marks all changed PR as draft
-name: Placeholder to avoid cancel already running DraftMe jobs
+name: Placeholder to cancel auto draft
 on:
   pull_request:
     types: [ ready_for_review ]
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   mark-as-draft:
     name: Placeholder
+    if: github.event.pull_request.draft == true
     runs-on: ubuntu-latest
     steps:
       - name: Print PR number

--- a/.github/workflows/DraftPR.yml
+++ b/.github/workflows/DraftPR.yml
@@ -1,5 +1,5 @@
 # Marks all changed PR as draft
-name: Move PRs to Draft
+name: Move PR to Draft
 on:
   workflow_run:
     workflows: [Draft on Synchronize]
@@ -8,6 +8,7 @@ on:
 
 jobs:
   actually-move-to-draft:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: 'Download artifact'

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -34,6 +34,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  BASE_BRANCH: ${{ github.base_ref || (endsWith(github.ref, '_feature') && 'feature' || 'master') }}
 
 jobs:
  regression-test-benchmark-runner:
@@ -72,7 +73,7 @@ jobs:
       shell: bash
       run: |
         make
-        git clone --branch ${GITHUB_BASE_REF:-master} https://github.com/duckdb/duckdb.git --depth=1
+        git clone --branch ${{ env.BASE_BRANCH }} https://github.com/duckdb/duckdb.git --depth=1
         cd duckdb
         make
         cd ..
@@ -145,7 +146,7 @@ jobs:
       shell: bash
       run: |
         make
-        git clone --branch ${GITHUB_BASE_REF:-master} https://github.com/duckdb/duckdb.git --depth=1
+        git clone --branch ${{ env.BASE_BRANCH }} https://github.com/duckdb/duckdb.git --depth=1
         cd duckdb
         make
         cd ..
@@ -244,7 +245,7 @@ jobs:
     - name: Build Current
       shell: bash
       run: |
-        git clone --branch ${GITHUB_BASE_REF:-master} https://github.com/duckdb/duckdb.git --depth=1
+        git clone --branch ${{ env.BASE_BRANCH }} https://github.com/duckdb/duckdb.git --depth=1
         cd duckdb/tools/pythonpkg
         python setup.py install --user
         cd ../../..
@@ -293,7 +294,7 @@ jobs:
       shell: bash
       run: |
         make
-        git clone --branch ${GITHUB_BASE_REF:-master} https://github.com/duckdb/duckdb.git --depth=1
+        git clone --branch ${{ env.BASE_BRANCH }} https://github.com/duckdb/duckdb.git --depth=1
         cd duckdb
         make
         cd ..


### PR DESCRIPTION
Regression: change so that IFF a branch name ends in _feature Regression.yml will be evaluated against (main repo) feature branch while executing workflows on forks.
Problem has been raised by @hawkfish, should reduce noise.

Naming of the branch has no effect on what happens for PRs once filed to main repo, since there base branch will still be used.

Auto-draft: minor cosmetic changes.