### PR TITLE
CI fixes: Don't persist ccache for nightlies

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -15,6 +15,7 @@ concurrency:
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   DUCKDB_WASM_VERSION: 7bf2a73
+  CCACHE_SAVE: ${{ github.repository != 'duckdb/duckdb' }}
 
 jobs:
   linux-memory-leaks:
@@ -40,7 +41,7 @@ jobs:
        uses: hendrikmuhs/ccache-action@main
        with:
          key: ${{ github.job }}
-         save: ${{ github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb' }}
+         save: ${{ env.CCACHE_SAVE }}
 
      - name: Build
        shell: bash
@@ -84,7 +85,7 @@ jobs:
       uses: hendrikmuhs/ccache-action@main
       with:
         key: ${{ github.job }}
-        save: ${{ github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb' }}
+        save: ${{ env.CCACHE_SAVE }}
 
     - name: Build
       shell: bash
@@ -128,7 +129,7 @@ jobs:
       uses: hendrikmuhs/ccache-action@main
       with:
         key: ${{ github.job }}
-        save: ${{ github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb' }}
+        save: ${{ env.CCACHE_SAVE }}
 
     - name: Build
       shell: bash
@@ -162,7 +163,7 @@ jobs:
       uses: hendrikmuhs/ccache-action@main
       with:
         key: ${{ github.job }}
-        save: ${{ github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb' }}
+        save: ${{ env.CCACHE_SAVE }}
 
     - name: Test
       shell: bash
@@ -193,7 +194,7 @@ jobs:
        uses: hendrikmuhs/ccache-action@main
        with:
          key: ${{ github.job }}
-         save: ${{ github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb' }}
+         save: ${{ env.CCACHE_SAVE }}
 
      - name: Build
        shell: bash
@@ -292,7 +293,7 @@ jobs:
        uses: hendrikmuhs/ccache-action@main
        with:
          key: ${{ github.job }}
-         save: ${{ github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb' }}
+         save: ${{ env.CCACHE_SAVE }}
 
      # Build is implied by 'make sqlite' that will invoke implicitly 'make release' (we make it explicit)
      - name: Build
@@ -325,7 +326,7 @@ jobs:
        uses: hendrikmuhs/ccache-action@main
        with:
          key: ${{ github.job }}
-         save: ${{ github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb' }}
+         save: ${{ env.CCACHE_SAVE }}
 
      - name: Build
        shell: bash
@@ -370,7 +371,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@main
         with:
           key: ${{ github.job }}
-          save: ${{ github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb' }}
+          save: ${{ env.CCACHE_SAVE }}
 
       - name: Build
         shell: bash
@@ -412,7 +413,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@main
         with:
           key: ${{ github.job }}
-          save: ${{ github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb' }}
+          save: ${{ env.CCACHE_SAVE }}
 
       - name: Build
         shell: bash
@@ -460,7 +461,7 @@ jobs:
        uses: hendrikmuhs/ccache-action@main
        with:
          key: ${{ github.job }}
-         save: ${{ github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb' }}
+         save: ${{ env.CCACHE_SAVE }}
 
      - name: Build
        shell: bash
@@ -532,7 +533,7 @@ jobs:
       uses: hendrikmuhs/ccache-action@main
       with:
         key: ${{ github.job }}
-        save: ${{ github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb' }}
+        save: ${{ env.CCACHE_SAVE }}
 
     - name: Install
       shell: bash
@@ -560,7 +561,7 @@ jobs:
       uses: hendrikmuhs/ccache-action@main
       with:
         key: ${{ github.job }}
-        save: ${{ github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb' }}
+        save: ${{ env.CCACHE_SAVE }}
 
     - name: Run
       shell: bash
@@ -601,7 +602,7 @@ jobs:
       uses: hendrikmuhs/ccache-action@main
       with:
         key: ${{ github.job }}
-        save: ${{ github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb' }}
+        save: ${{ env.CCACHE_SAVE }}
 
     - name: Build
       shell: bash
@@ -637,7 +638,7 @@ jobs:
       uses: hendrikmuhs/ccache-action@main
       with:
         key: ${{ github.job }}
-        save: ${{ github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb' }}
+        save: ${{ env.CCACHE_SAVE }}
 
     - name: Test
       shell: bash
@@ -670,7 +671,7 @@ jobs:
       uses: hendrikmuhs/ccache-action@main
       with:
         key: ${{ github.job }}
-        save: ${{ github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb' }}
+        save: ${{ env.CCACHE_SAVE }}
 
     - name: Print version
       shell: bash


### PR DESCRIPTION
Idea is that ccache is a scarce resource, capped at 10GB, so persist them on rarely execute jobs is wasteful (since other jobs will get evicted).