### PR TITLE
move ExtraTypeInfo to allow it to be derived from in out-of-tree extension

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/catalog/catalog_search_path.hpp"
 #include "duckdb/catalog/default/default_types.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/field_writer.hpp"
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/common/serializer.hpp"

--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/constants.hpp"
+#include "duckdb/common/field_writer.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/vector.hpp"
 
@@ -68,7 +69,7 @@ struct list_entry_t {
 	uint64_t length;
 };
 
-using union_tag_t = uint8_t; 
+using union_tag_t = uint8_t;
 
 //===--------------------------------------------------------------------===//
 // Internal Types
@@ -486,6 +487,75 @@ struct aggregate_state_t {
 	string function_name;
 	LogicalType return_type;
 	vector<LogicalType> bound_argument_types;
+};
+
+//===--------------------------------------------------------------------===//
+// Extra Type Info
+//===--------------------------------------------------------------------===//
+
+struct ExtraTypeInfo {
+	explicit ExtraTypeInfo(ExtraTypeInfoType type) : type(type) {
+	}
+	explicit ExtraTypeInfo(ExtraTypeInfoType type, string alias) : type(type), alias(std::move(alias)) {
+	}
+	virtual ~ExtraTypeInfo() {
+	}
+
+	ExtraTypeInfoType type;
+	string alias;
+	optional_ptr<TypeCatalogEntry> catalog_entry;
+
+public:
+	bool Equals(ExtraTypeInfo *other_p) const {
+		if (type == ExtraTypeInfoType::INVALID_TYPE_INFO || type == ExtraTypeInfoType::STRING_TYPE_INFO ||
+		    type == ExtraTypeInfoType::GENERIC_TYPE_INFO) {
+			if (!other_p) {
+				if (!alias.empty()) {
+					return false;
+				}
+				//! We only need to compare aliases when both types have them in this case
+				return true;
+			}
+			if (alias != other_p->alias) {
+				return false;
+			}
+			return true;
+		}
+		if (!other_p) {
+			return false;
+		}
+		if (type != other_p->type) {
+			return false;
+		}
+		return alias == other_p->alias && EqualsInternal(other_p);
+	}
+	//! Serializes a ExtraTypeInfo to a stand-alone binary blob
+	virtual void Serialize(FieldWriter &writer) const {
+	}
+	//! Serializes a ExtraTypeInfo to a stand-alone binary blob
+	static void Serialize(ExtraTypeInfo *info, FieldWriter &writer);
+	//! Deserializes a blob back into an ExtraTypeInfo
+	static shared_ptr<ExtraTypeInfo> Deserialize(FieldReader &reader);
+
+	virtual void FormatSerialize(FormatSerializer &serializer) const;
+	static shared_ptr<ExtraTypeInfo> FormatDeserialize(FormatDeserializer &source);
+
+	template <class TARGET>
+	TARGET &Cast() {
+		D_ASSERT(dynamic_cast<TARGET *>(this));
+		return reinterpret_cast<TARGET &>(*this);
+	}
+	template <class TARGET>
+	const TARGET &Cast() const {
+		D_ASSERT(dynamic_cast<const TARGET *>(this));
+		return reinterpret_cast<const TARGET &>(*this);
+	}
+
+protected:
+	virtual bool EqualsInternal(ExtraTypeInfo *other_p) const {
+		// Do nothing
+		return true;
+	}
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -10,7 +10,6 @@
 
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/constants.hpp"
-#include "duckdb/common/field_writer.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/vector.hpp"
 
@@ -27,6 +26,7 @@ class TypeCatalogEntry;
 class Vector;
 class ClientContext;
 class FieldWriter;
+class FieldReader;
 
 //! Extra Type Info Type
 enum class ExtraTypeInfoType : uint8_t {


### PR DESCRIPTION
Hi!

I am trying to write an out-of-tree extension to duckdb with a new type.  I would like to derive the class `ExtraTypeInfo` for my new type.  To do so, I need to include the file `src/include/duckdb/common/types.hpp`.  However, I cannot derive from `ExtraTypeInfo` because it is an incomplete type (it is currently forward declared in the header file and defined in the cpp file).  This PR moves the class definition of `ExtraTypeInfo` into the header file.

This allows me to write my own `ExtraTypeInfo` implementation in out-of-tree extensions.

Thank you for taking a look!