### PR TITLE
Add ORDER BY clause to query in test_bool.test

### DIFF
--- a/test/sql/aggregate/aggregates/test_bool.test
+++ b/test/sql/aggregate/aggregates/test_bool.test
@@ -71,7 +71,8 @@ query III
 select d,bool_or(d > '2021-02-09') AS or_result,
        bool_and(d > '2021-02-09') AS and_result
 from t
-group by d;
+group by d
+order by d;
 ----
 NULL	NULL	NULL
 2021-02-08	0	0


### PR DESCRIPTION
In the test query which starts at line 70 in _aggregate/aggregates/test\_bool.test_, the results are grouped by d. However, there is no `ORDER BY` clause present, hence the result order can change, which would cause the test to fail.

https://github.com/duckdb/duckdb/blob/6fc7ec0231fb0466f600a7f0153aaf84b567eff5/test/sql/aggregate/aggregates/test_bool.test#L70-L78

This PR adds the `ORDER BY` clause.