### PR TITLE
cppcheck on feature

### DIFF
--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -474,7 +474,7 @@ BufferHandle S3FileSystem::Allocate(idx_t part_size, uint16_t max_threads) {
 			auto currently_in_use = buffers_in_use;
 			if (currently_in_use == 0) {
 				// There exist no upload write buffers that can release more memory. We really ran out of memory here.
-				throw e;
+				throw;
 			} else {
 				// Wait for more buffers to become available before trying again
 				buffers_available_cv.wait(lck, [&] { return buffers_in_use < currently_in_use; });

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -102,7 +102,7 @@ string S3FileSystem::UrlDecode(string input) {
 	replace(input.begin(), input.end(), '+', ' ');
 	for (idx_t i = 0; i < input.length(); i++) {
 		if (int(input[i]) == 37) {
-			int ii;
+			unsigned int ii;
 			sscanf(input.substr(i + 1, 2).c_str(), "%x", &ii);
 			ch = static_cast<char>(ii);
 			result += ch;

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -76,7 +76,7 @@ static shared_ptr<ParquetFileMetadataCache> LoadMetadata(Allocator &allocator, F
 	}
 	// read four-byte footer length from just before the end magic bytes
 	auto footer_len = *reinterpret_cast<uint32_t *>(buf.ptr);
-	if (footer_len <= 0 || file_size < 12 + footer_len) {
+	if (footer_len == 0 || file_size < 12 + footer_len) {
 		throw InvalidInputException("Footer length error in file '%s'", file_handle.path);
 	}
 	auto metadata_pos = file_size - (footer_len + 8);

--- a/src/common/arrow/arrow_appender.cpp
+++ b/src/common/arrow/arrow_appender.cpp
@@ -786,7 +786,6 @@ ArrowArray ArrowAppender::Finalize() {
 
 	// Configure root array
 	result.length = row_count;
-	result.n_children = types.size();
 	result.n_buffers = 1;
 	result.buffers = root_holder->buffers.data(); // there is no actual buffer there since we don't have NULLs
 	result.offset = 0;

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -62,11 +62,11 @@ string Exception::ConstructMessageRecursive(const string &msg, std::vector<Excep
 #ifdef DEBUG
 	// Verify that we have the required amount of values for the message
 	idx_t parameter_count = 0;
-	for (idx_t i = 0; i < msg.size(); i++) {
+	for (idx_t i = 0; i + 1 < msg.size(); i++) {
 		if (msg[i] != '%') {
 			continue;
 		}
-		if (i < msg.size() && msg[i + 1] == '%') {
+		if (msg[i + 1] == '%') {
 			i++;
 			continue;
 		}

--- a/src/common/types/uuid.cpp
+++ b/src/common/types/uuid.cpp
@@ -49,7 +49,7 @@ bool UUID::FromString(string str, hugeint_t &result) {
 		count++;
 	}
 	// Flip the first bit to make `order by uuid` same as `order by uuid::varchar`
-	result.upper ^= (int64_t(1) << 63);
+	result.upper ^= (uint64_t(1) << 63);
 	return count == 32;
 }
 
@@ -61,7 +61,7 @@ void UUID::ToString(hugeint_t input, char *buf) {
 	};
 
 	// Flip back before convert to string
-	int64_t upper = input.upper ^ (int64_t(1) << 63);
+	int64_t upper = input.upper ^ (uint64_t(1) << 63);
 	idx_t pos = 0;
 	byte_to_hex(upper >> 56 & 0xFF, buf, pos);
 	byte_to_hex(upper >> 48 & 0xFF, buf, pos);

--- a/src/execution/expression_executor.cpp
+++ b/src/execution/expression_executor.cpp
@@ -126,7 +126,7 @@ bool ExpressionExecutor::TryEvaluateScalar(ClientContext &context, const Express
 		result = EvaluateScalar(context, expr);
 		return true;
 	} catch (InternalException &ex) {
-		throw ex;
+		throw;
 	} catch (...) {
 		return false;
 	}

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -395,15 +395,15 @@ struct WindowColumnIterator {
 		return coll->GetCell<T>(pos + m);
 	}
 
-	friend inline iterator &operator+(const iterator &a, difference_type n) {
+	friend inline iterator operator+(const iterator &a, difference_type n) {
 		return iterator(a.coll, a.pos + n);
 	}
 
-	friend inline iterator &operator-(const iterator &a, difference_type n) {
+	friend inline iterator operator-(const iterator &a, difference_type n) {
 		return iterator(a.coll, a.pos - n);
 	}
 
-	friend inline iterator &operator+(difference_type n, const iterator &a) {
+	friend inline iterator operator+(difference_type n, const iterator &a) {
 		return a + n;
 	}
 	friend inline difference_type operator-(const iterator &a, const iterator &b) {

--- a/src/execution/operator/join/physical_asof_join.cpp
+++ b/src/execution/operator/join/physical_asof_join.cpp
@@ -669,7 +669,7 @@ public:
 	//! The read cursor
 	unique_ptr<PayloadScanner> scanner;
 	//! Pointer to the matches
-	const bool *found_match;
+	const bool *found_match = {};
 };
 
 AsOfLocalSourceState::AsOfLocalSourceState(AsOfGlobalSourceState &gsource, const PhysicalAsOfJoin &op)

--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -169,8 +169,7 @@ public:
 	template <typename TR, typename... Args>
 	void CreateScalarFunction(const string &name, vector<LogicalType> args, LogicalType ret_type,
 	                          TR (*udf_func)(Args...)) {
-		scalar_function_t function =
-		    UDFWrapper::CreateScalarFunction<TR, Args...>(name, args, std::move(ret_type), udf_func);
+		scalar_function_t function = UDFWrapper::CreateScalarFunction<TR, Args...>(name, args, ret_type, udf_func);
 		UDFWrapper::RegisterFunction(name, args, ret_type, function, *context);
 	}
 

--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -272,7 +272,6 @@ struct RLEScanState : public SegmentScanState {
 	}
 
 	BufferHandle handle;
-	uint32_t rle_offset;
 	idx_t entry_pos;
 	idx_t position_in_entry;
 	uint32_t rle_count_offset;


### PR DESCRIPTION
I ran cppcheck on duckdb, I happened to be on feature at that point but I guess this can also be repurposed to be on top of master (only 1 commit is related to feature, can take that out and backport the rest if it makes sense).

Setup is something like:
```
brew install cppcheck
cppcheck src -I src/include --enable=all -q --std=c++11
```
Then sifting through then logs looking for scary sounding errors.

Tool has some drawbacks (eg errors on taking reference to temporary are mostly bogus, and too noisy), but potentially with some filtering on the notified errors could be considered to be added as part of (nightly) CI or whenever someone is bug-hunting a particular area of the codebase.