### PR TITLE
Added JSON Text Sequence (RFC 7464) Output Mode

### DIFF
--- a/tools/shell/shell-test.py
+++ b/tools/shell/shell-test.py
@@ -309,9 +309,37 @@ CREATE INDEX a_idx ON a(i);
 test('.sha3sum')
 
 test('''
+.mode json
+SELECT *
+FROM (
+    VALUES
+    ('Jan', 'Apr'),
+    ('Feb', 'May'),
+    ('Mar', 'Jun')
+);
+''', out='[{"col0":"Jan","col1":"Apr"},\n{"col0":"Feb","col1":"May"},\n{"col0":"Mar","col1":"Jun"}]\n')
+
+test('''
 .mode jsonlines
-SELECT 42,43;
-''', out='{"42":42,"43":43}')
+SELECT *
+FROM (
+    VALUES
+    ('Jan', 'Apr'),
+    ('Feb', 'May'),
+    ('Mar', 'Jun')
+);
+''', out='{"col0":"Jan","col1":"Apr"}\n{"col0":"Feb","col1":"May"}\n{"col0":"Mar","col1":"Jun"}\n')
+
+test('''
+.mode jsonsequence
+SELECT *
+FROM (
+    VALUES
+    ('Jan', 'Apr'),
+    ('Feb', 'May'),
+    ('Mar', 'Jun')
+);
+''', out='\x1E{"col0":"Jan","col1":"Apr"}\n\x1E{"col0":"Feb","col1":"May"}\n\x1E{"col0":"Mar","col1":"Jun"}\n')
 
 test('''
 .mode csv


### PR DESCRIPTION
This PR adds support for the JSON Text Sequence ([RFC 7464](https://datatracker.ietf.org/doc/html/rfc7464)) output mode. I also added a missing description for the `jsonlines` CLI option (related to https://github.com/duckdb/duckdb/pull/4234).


**Short description from RFC 7464:**
> A JSON text sequence consists of any number of JSON texts, all encoded
   in UTF-8, each prefixed by an ASCII Record Separator (0x1E), and each
   ending with an ASCII Line Feed character (0x0A).

**Example usage:**
```shell
$ cat <<CSV > example.csv
name,location,value
Ben,US,123
Hans,DE,42
CSV
$ duckdb -jsonsequence -c "SELECT * FROM 'example.csv'" > example.jsons
```
```
$ hexdump -C example.jsons 
00000000  1e 7b 22 6e 61 6d 65 22  3a 22 42 65 6e 22 2c 22  |.{"name":"Ben","|
00000010  6c 6f 63 61 74 69 6f 6e  22 3a 22 55 53 22 2c 22  |location":"US","|
00000020  76 61 6c 75 65 22 3a 31  32 33 7d 0a 1e 7b 22 6e  |value":123}..{"n|
00000030  61 6d 65 22 3a 22 48 61  6e 73 22 2c 22 6c 6f 63  |ame":"Hans","loc|
00000040  61 74 69 6f 6e 22 3a 22  44 45 22 2c 22 76 61 6c  |ation":"DE","val|
00000050  75 65 22 3a 34 32 7d 0a                           |ue":42}.|
00000058
```

```shell
$ cat example.jsons | jq --seq                                     
{
  "name": "Ben",
  "location": "US",
  "value": 123
}
{
  "name": "Hans",
  "location": "DE",
  "value": 42
}
```

**Info from jq manpage:**
> --seq:
   Use  the application/json-seq MIME type scheme for separating JSON texts in jq´s input
   and output. This means that an ASCII RS (record separator) character is printed before
   each  value on output and an ASCII LF (line feed) is printed after every output. Input
   JSON texts that  fail  to  parse  are  ignored  (but  warned  about),  discarding  all
   subsequent input until the next RS. This more also parses the output of jq without the
   --seq option.