### PR TITLE
fix: cli parser issue

### DIFF
--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -191,6 +191,7 @@ void Parser::ParseQuery(const string &query) {
 		} else {
 			// split sql string into statements and re-parse using extension
 			auto query_statements = SplitQueryStringIntoStatements(query);
+			auto stmt_loc = 0;
 			for (auto const &query_statement : query_statements) {
 				PostgresParser another_parser;
 				another_parser.Parse(query_statement);
@@ -204,7 +205,8 @@ void Parser::ParseQuery(const string &query) {
 					transformer.TransformParseTree(another_parser.parse_tree, statements);
 					// important to set in the case of a mixture of DDB and parser ext statements
 					statements.back()->stmt_length = query_statement.size() - 1;
-					statements.back()->stmt_location = 0;
+					statements.back()->stmt_location = stmt_loc;
+					stmt_loc += query_statement.size();
 				} else {
 					// let extensions parse the statement which DuckDB failed to parse
 					bool parsed_single_statement = false;
@@ -215,7 +217,8 @@ void Parser::ParseQuery(const string &query) {
 						if (result.type == ParserExtensionResultType::PARSE_SUCCESSFUL) {
 							auto statement = make_uniq<ExtensionStatement>(ext, std::move(result.parse_data));
 							statement->stmt_length = query_statement.size() - 1;
-							statement->stmt_location = 0;
+							statement->stmt_location = stmt_loc;
+							stmt_loc += query_statement.size();
 							statements.push_back(std::move(statement));
 							parsed_single_statement = true;
 							break;

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -202,6 +202,9 @@ void Parser::ParseQuery(const string &query) {
 						continue;
 					}
 					transformer.TransformParseTree(another_parser.parse_tree, statements);
+					// important to set in the case of a mixture of DDB and parser ext statements
+					statements.back()->stmt_length = query_statement.size() - 1;
+					statements.back()->stmt_location = 0;
 				} else {
 					// let extensions parse the statement which DuckDB failed to parse
 					bool parsed_single_statement = false;

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -211,7 +211,7 @@ void Parser::ParseQuery(const string &query) {
 						auto result = ext.parse_function(ext.parser_info.get(), query_statement);
 						if (result.type == ParserExtensionResultType::PARSE_SUCCESSFUL) {
 							auto statement = make_uniq<ExtensionStatement>(ext, std::move(result.parse_data));
-							statement->stmt_length = query_statement.size();
+							statement->stmt_length = query_statement.size() - 1;
 							statement->stmt_location = 0;
 							statements.push_back(std::move(statement));
 							parsed_single_statement = true;

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -215,7 +215,7 @@ int sqlite3_prepare_v2(sqlite3 *db,           /* Database handle */
 
 		// extract the remainder of the query and assign it to the pzTail
 		if (pzTail && set_remainder) {
-			*pzTail = zSql + next_location;
+			*pzTail = zSql + next_location + 1;
 		}
 
 		*ppStmt = stmt.release();

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -215,7 +215,7 @@ int sqlite3_prepare_v2(sqlite3 *db,           /* Database handle */
 
 		// extract the remainder of the query and assign it to the pzTail
 		if (pzTail && set_remainder) {
-			*pzTail = zSql + next_location + 1;
+			*pzTail = zSql + next_location;
 		}
 
 		*ppStmt = stmt.release();


### PR DESCRIPTION
When trying to run the following two statements in one line in DuckDb shell:
```
CREATE DATABASE db1; CREATE TABLE db1.tbl (id INTEGER);
```
We see the following error message:
```
Error: Parser Error: syntax error at or near "REATE"
LINE 1: REATE TABLE db1.tbl (id INTEGER);
```
The reason after debugging through `shell.c` and `sqlite3_api_wrapper.cpp` is that there appears to be an extra `+1` when we produce `zLeftover` (used in `shell.c`) which is resulted by setting `stmt_length` incorrectly in the extension parser logic.

Statements tested:
```
create or replace database db99; select 1;
create or replace database db99; select 1;;create or replace database db98;
create or replace database db99; select 1; select 42;
create or replace database db99; select 1; select 42;create or replace database db98;
create or replace table tbl27 (i INTEGER); create or replace database db99;
```
 
This PR fixes this issue and I did some quick tests in DuckDB and haven't observed other issues. But will see about the CI.