### PR TITLE
Add new wal_rename_and_recreate mode

### DIFF
--- a/src/function/pragma/pragma_functions.cpp
+++ b/src/function/pragma/pragma_functions.cpp
@@ -108,6 +108,14 @@ static void PragmaDisableCheckpointOnShutdown(ClientContext &context, const Func
 	DBConfig::GetConfig(context).options.checkpoint_on_shutdown = false;
 }
 
+static void PragmaEnableWALRenameAndRecreate(ClientContext &context, const FunctionParameters &parameters) {
+	DBConfig::GetConfig(context).options.wal_rename_and_recreate = true;
+}
+
+static void PragmaDisableWALRenameAndRecreate(ClientContext &context, const FunctionParameters &parameters) {
+	DBConfig::GetConfig(context).options.wal_rename_and_recreate = false;
+}
+
 static void PragmaEnableOptimizer(ClientContext &context, const FunctionParameters &parameters) {
 	ClientConfig::GetConfig(context).enable_optimizer = true;
 }
@@ -152,6 +160,9 @@ void PragmaFunctions::RegisterFunction(BuiltinFunctions &set) {
 	set.AddFunction(PragmaFunction::PragmaStatement("enable_checkpoint_on_shutdown", PragmaEnableCheckpointOnShutdown));
 	set.AddFunction(
 	    PragmaFunction::PragmaStatement("disable_checkpoint_on_shutdown", PragmaDisableCheckpointOnShutdown));
+
+	set.AddFunction(PragmaFunction::PragmaStatement("enable_wal_rename_and_recreate", PragmaEnableWALRenameAndRecreate));
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_wal_rename_and_recreate", PragmaDisableWALRenameAndRecreate));
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/common/serializer/buffered_file_writer.hpp
+++ b/src/include/duckdb/common/serializer/buffered_file_writer.hpp
@@ -25,6 +25,8 @@ public:
 
 	FileSystem &fs;
 	string path;
+	uint8_t open_flags;
+	uint32_t rotate_count;
 	unsafe_unique_array<data_t> data;
 	idx_t offset;
 	idx_t total_written;
@@ -36,6 +38,8 @@ public:
 	DUCKDB_API void Sync();
 	//! Flush the buffer to the file (without sync)
 	DUCKDB_API void Flush();
+	//! Rotates the file, renaming the current file and re-opening the file
+	DUCKDB_API void Rotate();
 	//! Returns the current size of the file
 	DUCKDB_API int64_t GetFileSize();
 	//! Truncate the size to a previous size (given that size <= GetFileSize())

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -121,6 +121,10 @@ struct DBConfigOptions {
 	bool force_checkpoint = false;
 	//! Run a checkpoint on successful shutdown and delete the WAL, to leave only a single database file behind
 	bool checkpoint_on_shutdown = true;
+	//! Rather than truncating the WAL file, renames the file to .wal.$COUNTER and creates a new .wal file.
+	//! The copies become unmanaged by the database with the expectation that an external process is managing them.
+	bool wal_rename_and_recreate = false;
+
 	//! Debug flag that decides when a checkpoing should be aborted. Only used for testing purposes.
 	CheckpointAbort checkpoint_abort = CheckpointAbort::NO_ABORT;
 	//! Initialize the database with the standard set of DuckDB functions

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -32,7 +32,11 @@ idx_t WriteAheadLog::GetTotalWritten() {
 }
 
 void WriteAheadLog::Truncate(int64_t size) {
-	writer->Truncate(size);
+	if (size == 0 && DBConfig::Get(database).options.wal_rename_and_recreate) {
+		writer->Rotate();
+	} else {
+		writer->Truncate(size);
+	}
 }
 
 void WriteAheadLog::Delete() {


### PR DESCRIPTION
This PR is to elicit conversation and is not really meant to be merged. (C++ is barely legible to me and I couldn't figure out how to properly test this new behavior).

DuckDB currently manages the WAL in a way which prevents external applications from being able to reliably read it. Namely, checkpoints truncate the contents of the file. In this PR I'm exploring the possibility of a new behavior renames the wal file and opens a new file, with the ideal that an external application would be responsible for managing the copies.

I _believe_ this could enable some exciting possibilities; for example: streaming replication.