### PR TITLE
PRAGMA extension_version

### DIFF
--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -63,6 +63,9 @@ inputs:
   override_cxx:
     description: 'Override CXX Compiler'
     default: ''
+  duckdb_executable:
+    description: 'Location of duckdb executable'
+    default: 'build/release/duckdb'
 
 runs:
   using: "composite"
@@ -90,17 +93,17 @@ runs:
         export EXTENSION_CONFIGS=""
         export EXTENSION_CONFIGS="$EXTENSION_CONFIGS;${{ inputs.build_in_tree_extensions == 1 && '.github/config/in_tree_extensions.cmake' || ''}}"
         export EXTENSION_CONFIGS="$EXTENSION_CONFIGS;${{ inputs.build_out_of_tree_extensions == 1 && '.github/config/out_of_tree_extensions.cmake' || '' }}"
-        echo "EXTENSION_CONFIGS"
+        echo "$EXTENSION_CONFIGS"
         make
 
     - name: Check (on deploy) platform and extension_folder agree with DuckDB
       if: ${{ inputs.deploy_as != '' }}
       shell: bash
       run: |
-        ./build/release/duckdb -csv -c "SELECT platform FROM pragma_extension_version()" | tail -n 1 > PLATFORM
+        ${{ inputs.duckdb_executable }} -csv -c "SELECT platform FROM pragma_extension_version()" | tail -n 1 > PLATFORM
         echo ${{ inputs.deploy_as }} > DEPLOY_AS
         cmp PLATFORM DEPLOY_AS || exit 1
-        ./build/release/duckdb -csv -c "SELECT extension_folder FROM pragma_extension_version()" | tail -n 1 > EXTENSION_FOLDER
+        ${{ inputs.duckdb_executable }} -csv -c "SELECT extension_folder FROM pragma_extension_version()" | tail -n 1 > EXTENSION_FOLDER
         if [[ ! -z "${{ inputs.deploy_version }}" ]] ; then
           echo ${{ inputs.deploy_version }} > DEPLOY_VERSION
           cmp EXTENSION_FOLDER DEPLOY_VERSION || exit 1

--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -93,6 +93,19 @@ runs:
         echo "EXTENSION_CONFIGS"
         make
 
+    - name: Check (on deploy) platform and extension_folder agree with DuckDB
+      if: ${{ inputs.deploy_as != '' }}
+      shell: bash
+      run: |
+        ./build/release/duckdb -csv -c "SELECT platform FROM pragma_extension_version()" | tail -n 1 > PLATFORM
+        echo ${{ inputs.deploy_as }} > DEPLOY_AS
+        cmp PLATFORM DEPLOY_AS || exit 1
+        ./build/release/duckdb -csv -c "SELECT extension_folder FROM pragma_extension_version()" | tail -n 1 > EXTENSION_FOLDER
+        if [[ ! -z "${{ inputs.deploy_version }}" ]] ; then
+          echo ${{ inputs.deploy_version }} > DEPLOY_VERSION
+          cmp EXTENSION_FOLDER DEPLOY_VERSION || exit 1
+        fi
+
     - name: Run post-install scripts
       if: ${{ inputs.post_install != '' }}
       shell: bash

--- a/.github/config/uncovered_files.csv
+++ b/.github/config/uncovered_files.csv
@@ -272,7 +272,7 @@ function/table/system/duckdb_temporary_files.cpp	25
 function/table/system/pragma_table_info.cpp	2
 function/table/table_scan.cpp	12
 function/table/unnest.cpp	8
-function/table/version/pragma_version.cpp	3
+function/table/version/pragma_version.cpp	7
 function/table_function.cpp	4
 function/udf_function.cpp	6
 extension/json/buffered_json_reader.cpp	35

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -258,3 +258,4 @@ jobs:
          s3_key: ${{ secrets.S3_KEY }}
          signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
          python_name: python
+         duckdb_executable: build/release/Release/duckdb.exe

--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -136,6 +136,10 @@ string PragmaVersion(ClientContext &context, const FunctionParameters &parameter
 	return "SELECT * FROM pragma_version();";
 }
 
+string PragmaExtensionVersion(ClientContext &context, const FunctionParameters &parameters) {
+	return "SELECT * FROM pragma_extension_version();";
+}
+
 string PragmaImportDatabase(ClientContext &context, const FunctionParameters &parameters) {
 	auto &config = DBConfig::GetConfig(context);
 	if (!config.options.enable_external_access) {
@@ -192,6 +196,7 @@ void PragmaQueries::RegisterFunction(BuiltinFunctions &set) {
 	set.AddFunction(PragmaFunction::PragmaStatement("collations", PragmaCollations));
 	set.AddFunction(PragmaFunction::PragmaCall("show", PragmaShow, {LogicalType::VARCHAR}));
 	set.AddFunction(PragmaFunction::PragmaStatement("version", PragmaVersion));
+	set.AddFunction(PragmaFunction::PragmaStatement("extension_version", PragmaExtensionVersion));
 	set.AddFunction(PragmaFunction::PragmaStatement("database_size", PragmaDatabaseSize));
 	set.AddFunction(PragmaFunction::PragmaStatement("functions", PragmaFunctionsQuery));
 	set.AddFunction(PragmaFunction::PragmaCall("import_database", PragmaImportDatabase, {LogicalType::VARCHAR}));

--- a/src/function/table/system_functions.cpp
+++ b/src/function/table/system_functions.cpp
@@ -10,6 +10,7 @@ namespace duckdb {
 
 void BuiltinFunctions::RegisterSQLiteFunctions() {
 	PragmaVersion::RegisterFunction(*this);
+	PragmaExtensionVersion::RegisterFunction(*this);
 	PragmaCollations::RegisterFunction(*this);
 	PragmaTableInfo::RegisterFunction(*this);
 	PragmaStorageInfo::RegisterFunction(*this);

--- a/src/function/table/version/pragma_version.cpp
+++ b/src/function/table/version/pragma_version.cpp
@@ -56,6 +56,26 @@ const char *DuckDB::LibraryVersion() {
 	return DUCKDB_VERSION;
 }
 
+static const string NormalizeVersionTag(const string &version_tag) {
+	if (version_tag.length() > 0 && version_tag[0] != 'v') {
+		return "v" + version_tag;
+	}
+	return version_tag;
+}
+
+static bool IsRelease(const string &version_tag) {
+	return !StringUtil::Contains(version_tag, "-dev");
+}
+
+
+string DuckDB::ExtensionFolder() {
+	if (IsRelease(DuckDB::LibraryVersion())) {
+		return NormalizeVersionTag(DuckDB::LibraryVersion());
+	} else {
+		return DuckDB::SourceID();
+	}
+}
+
 string DuckDB::Platform() {
 	string os = "linux";
 #if INTPTR_MAX == INT64_MAX

--- a/src/include/duckdb/function/table/system_functions.hpp
+++ b/src/include/duckdb/function/table/system_functions.hpp
@@ -37,6 +37,10 @@ struct PragmaVersion {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct PragmaExtensionVersion {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct PragmaDatabaseSize {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -101,6 +101,7 @@ public:
 	DUCKDB_API idx_t NumberOfThreads();
 	DUCKDB_API static const char *SourceID();
 	DUCKDB_API static const char *LibraryVersion();
+	DUCKDB_API static string ExtensionFolder();
 	DUCKDB_API static idx_t StandardVectorSize();
 	DUCKDB_API static string Platform();
 	DUCKDB_API bool ExtensionIsLoaded(const std::string &name);

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -15,23 +15,8 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // Install Extension
 //===--------------------------------------------------------------------===//
-const string ExtensionHelper::NormalizeVersionTag(const string &version_tag) {
-	if (version_tag.length() > 0 && version_tag[0] != 'v') {
-		return "v" + version_tag;
-	}
-	return version_tag;
-}
-
-bool ExtensionHelper::IsRelease(const string &version_tag) {
-	return !StringUtil::Contains(version_tag, "-dev");
-}
-
 const string ExtensionHelper::GetVersionDirectoryName() {
-	if (IsRelease(DuckDB::LibraryVersion())) {
-		return NormalizeVersionTag(DuckDB::LibraryVersion());
-	} else {
-		return DuckDB::SourceID();
-	}
+	return DuckDB::ExtensionFolder();
 }
 
 const vector<string> ExtensionHelper::PathComponents() {

--- a/test/sql/pragma/test_pragma_version.test
+++ b/test/sql/pragma/test_pragma_version.test
@@ -10,3 +10,12 @@ select * from pragma_version();
 
 statement ok
 select library_version from pragma_version();
+
+statement ok
+PRAGMA extension_version;
+
+statement ok
+select * from pragma_extension_version();
+
+statement ok
+select extension_folder from pragma_extension_version();


### PR DESCRIPTION
Main idea is having the extensionFolder AND the platform to be DuckDB-wide setting, and also to be available to be queried.
Extension folder is already a function of LibraryVersion and SourceID, added explicitly that for WebAssembly it will be the previous default with appended a "-wasm" followed by DUCKDB_WASM_HASH.

Why making it explicitly?
This can simplify even more extension building, and makes for a single source of truth (the code that implements `ExtensionFolder()`) instead of duplicating code between deployment scripts and DuckDB.

Deployment will eventually only take extensionFolder AND platform from the DuckDB version built alongside the extensions, without taking an external parameter that can eventually go out of sync.

Rework is justified by DuckDB-Wasm loadable extensions, and would simplify code / reduce surface for inconsistencies.

There are a few details that might be worth some yak shaving, mostly around naming conventions the externally available data:
"PRAGMA extension_version" is ok? Alternatives?
"SELECT * FROM pragma_extension_version()" has currently 2 fields, extension_folder and platform. Are ok as names? Should they be included directly in an expanded "SELECT * FROM pragma_version()"?

---

Naming convention for duckdb-wasm extension folder, currently proposed is:
regular_extension_folder + "-wasm" + wasm_hash_or_version.
It combines both names in one, so that logically it will find place alongside the other folder, but they will be clearly different.
Idea is that for example v0.9.0 will have it's v0.9.0-wasm + wasm_hash_or_version

Why not a single folder? To be future proof, since multiple duckdb-wasm versions, potentially incompatibles, might depend on the same duckdb version.