### PR TITLE
Increase memory limit in test to prevent non-deterministic CI failures

### DIFF
--- a/test/sql/copy/parquet/batched_write/parquet_write_memory_limit.test_slow
+++ b/test/sql/copy/parquet/batched_write/parquet_write_memory_limit.test_slow
@@ -16,7 +16,7 @@ statement ok
 SET threads=4
 
 statement ok
-SET memory_limit='900MB'
+SET memory_limit='1GB'
 
 # stream from one parquet file to another
 query I


### PR DESCRIPTION
The memory limit was much lower in this test because we weren't accounting for our allocated buffers. In a recent PR I fixed this and also had to increase the memory limit. I didn't increase it enough; there have been a few non-deterministic CI failures. I hope this is enough, I can't reproduce it on my local machine.