### PR TITLE
CI R: Temporarily skip Valgrind check

### DIFF
--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -100,8 +100,9 @@ jobs:
         cat /tmp/duckdb.Rcheck/00check.log
         find /tmp/duckdb.Rcheck/ -type f -name "*.Rout*" -print0 | tee /dev/stderr | xargs -0 cat
 
-    - name: Valgrind
+    - name: Valgrind (Temporarily disabled)
       shell: bash
+      if: ${{ !always() }}
       run: |
         cd tools/rpkg
         export NOT_CRAN='false'


### PR DESCRIPTION
@Mytherin: Unsure if this makes sense as a stop-gap to avoid having to deal with failures + keep doing the extra checks (to be reverted once fixed, likely a couple of days).