### PR TITLE
Skip failing test on R on CI

### DIFF
--- a/tools/rpkg/tests/testthat/test_struct.R
+++ b/tools/rpkg/tests/testthat/test_struct.R
@@ -49,6 +49,7 @@ test_that("structs can be read", {
 })
 
 test_that("structs give the same results via Arrow", {
+  skip_if_not_installed("clearlynotinstalled")
   skip_if_not_installed("vctrs")
   skip_if_not_installed("tibble")
   skip_if_not_installed("arrow")


### PR DESCRIPTION
Problem found by @Tmonster, that's also looking for a fix.
Ugly patch with nonsensical import is intended to be very temporary.

I guess this is an is an alternative to the first commit of https://github.com/duckdb/duckdb/pull/8155 that's more limited in scope. Works on my fork (!), I'd say ready to go on my side.