### PR TITLE
Add table filter set C bindings for Table function filter pushdown

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -303,17 +303,9 @@ typedef struct _duckdb_vector {
 typedef struct _duckdb_value {
 	void *__val;
 } * duckdb_value;
-typedef struct {
-    duckdb_filter_type filter_type;
-} duckdb_table_filter;
-typedef struct {
-    duckdb_table_filter* filters;
-    size_t count;
-} duckdb_table_filter_set;
-typedef struct {
-    duckdb_table_filter_set* value;
-    bool has_value;
-} duckdb_optional_table_filter_set;
+typedef struct _table_filter_set {
+    void *__tfs;
+} * duckdb_table_filter_set;
 
 typedef enum { DuckDBSuccess = 0, DuckDBError = 1 } duckdb_state;
 typedef enum {
@@ -322,13 +314,6 @@ typedef enum {
 	DUCKDB_PENDING_ERROR = 2
 } duckdb_pending_state;
 
-typedef enum {
-    CONSTANT_COMPARISON = 0,
-    IS_NULL = 1,
-    IS_NOT_NULL = 2,
-    CONJUNCTION_OR = 3,
-    CONJUNCTION_AND = 4
-} duckdb_filter_type;
 
 //===--------------------------------------------------------------------===//
 // Open/Connect
@@ -2011,14 +1996,7 @@ This function must be used if filter pushdown is enabled to figure out which fil
 * filters: the pointer to the optional table filter set
 * returns: an optional table filter set
 */
-DUCKDB_API duckdb_optional_table_filter_set duckdb_init_get_table_filter_set(duckdb_init_info info);
-
-/*!
-De-allocates all memory allocated for the table filter set.
-
-* filters: The set of table filters to destroy.
-*/
-DUCKDB_API void duckdb_destroy_optional_table_filter_set(duckdb_optional_table_filter_set *filters);
+duckdb_table_filter_set duckdb_init_get_table_filter_set(duckdb_init_info info);
 
 /*!
 Sets how many threads can process this table function in parallel (default: 1)

--- a/src/main/capi/table_function-c.cpp
+++ b/src/main/capi/table_function-c.cpp
@@ -437,35 +437,12 @@ idx_t duckdb_init_get_column_index(duckdb_init_info info, idx_t column_index) {
 	return function_info->column_ids[column_index];
 }
 
-duckdb_optional_table_filter_set duckdb_init_get_table_filter_set(duckdb_init_info info) {
-	duckdb_optional_table_filter_set result;
-	result.has_value = false;
+duckdb_table_filter_set duckdb_init_get_table_filter_set(duckdb_init_info info) {
 	if (!info) {
-		return result;
+		return nullptr;
 	}
 	auto function_info = (duckdb::CTableInternalInitInfo *)info;
-	optional_ptr<TableFilterSet> filters = function_info->filter_sets;
-
-	if (filters.has_value()) {
-		result.has_value = true;
-		result.value = (CTableFilterSet*)malloc(sizeof(CTableFilterSet));
-		result.value->count = filters->filters.size();
-		result.value->filters = (CTableFilter*)malloc(result.value->count * sizeof(CTableFilter));
-
-		size_t i = 0;
-		for (const auto& filter : filters->filters) {
-			result.value->filters[i].filter_type = static_cast<duckdb_filter_type>(filter.second->filter_type);
-			i++;
-		}
-	}
-	return result;
-}
-
-void duckdb_destroy_optional_table_filter_set(duckdb_optional_table_filter_set *filters) {
-	if (filters->has_value) {
-		free(filters->value->filters);
-		free(filters->value);
-	}
+	return reinterpret_cast<duckdb_table_filter_set>(&(function_info->filters));
 }
 
 void duckdb_init_set_max_threads(duckdb_init_info info, idx_t max_threads) {

--- a/tools/juliapkg/src/api.jl
+++ b/tools/juliapkg/src/api.jl
@@ -2283,15 +2283,6 @@ function duckdb_init_get_table_filter_set(info)
 end
 
 """
-	duckdb_destroy_optional_table_filter_set(filters)
-De-allocates all memory allocated for the table filter set.
-* filters: The set of table filters to destroy.
-"""
-function duckdb_destroy_optional_table_filter_set(filters)
-    return ccall((:duckdb_destroy_optional_table_filter_set, libduckdb), Cvoid, (Ref{duckdb_optional_table_filter_set},), filters)
-end
-
-"""
 Sets how many threads can process this table function in parallel (default: 1)
 
 * info: The info object


### PR DESCRIPTION
This PR is inspired from https://github.com/duckdb/duckdb/pull/3287
**It's a WIP at this point.**

It aims at enhancing the C bindings API so that it enables the filter pushdown for DuckDB extensions that are not written in C++ and that use C bindings.

I'm not really knowledgeable on in C nor C++ so I tried to mimick existing implementation for projection pushdown.

I might be able to test it locally on my WIP extension but it might take some time till I get there.
I could use some help here (or if anyone feel like taking over, feel free to do so 🙌 ).