### PR TITLE
Update tests broken after conflicting PRs

### DIFF
--- a/test/sql/copy/hive_types.test
+++ b/test/sql/copy/hive_types.test
@@ -89,11 +89,11 @@ BIGINT	VARCHAR	DATE
 
 # Complex filter filtering first file, filter should be pruned completely if hive_partitioning=1
 query II
-explain from parquet_scan('__TEST_DIR__/partition/**/*.parquet', hive_partitioning=0) where aired < '2006-1-1'::DATE;
+explain from parquet_scan('__TEST_DIR__/partition/**/*.parquet', HIVE_PARTITIONING=0, HIVE_TYPES_AUTOCAST=0) where aired < '2006-1-1'::DATE;
 ----
 physical_plan	<REGEX>:.*(PARQUET_SCAN.*Filters:|FILTER).*
 
 query II
-explain from parquet_scan('__TEST_DIR__/partition/**/*.parquet', hive_partitioning=1) where aired < '2006-1-1'::DATE;
+explain from parquet_scan('__TEST_DIR__/partition/**/*.parquet', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=0) where aired < '2006-1-1'::DATE;
 ----
-physical_plan	<!REGEX>:.*(PARQUET_SCAN.*Filters:|FILTER).*
+physical_plan	<REGEX>:.*(PARQUET_SCAN.*File Filters: \(aired \<).*

--- a/test/sql/copy/parquet/parquet_hive.test
+++ b/test/sql/copy/parquet/parquet_hive.test
@@ -78,12 +78,12 @@ Hive partition mismatch
 
 # Verify that filters are pushed down into the parquet scan (Only file with the filter are read)
 query II
-EXPLAIN select id, date from parquet_scan('data/parquet-testing/hive-partitioning/different_order/*/*/test.parquet', HIVE_PARTITIONING=1) where date = '2013-01-01';
+EXPLAIN select id, date from parquet_scan('data/parquet-testing/hive-partitioning/different_order/*/*/test.parquet', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=0) where date = '2013-01-01';
 ----
 physical_plan	<REGEX>:.*PARQUET_SCAN.*File Filters: \(date = '2013.*-01.*-01'\).*
 
 query II
-EXPLAIN select id, date from parquet_scan('data/parquet-testing/hive-partitioning/different_order/*/*/test.parquet', HIVE_PARTITIONING=1) where date = '2018-01-01';
+EXPLAIN select id, date from parquet_scan('data/parquet-testing/hive-partitioning/different_order/*/*/test.parquet', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=0) where date = '2018-01-01';
 ----
 physical_plan	<REGEX>:.*PARQUET_SCAN.*File Filters: \(date = '2018.*-01.*-01'\).*
 
@@ -94,12 +94,12 @@ EXPLAIN select id, value, part, date from parquet_scan('data/parquet-testing/hiv
 physical_plan	<!REGEX>:.*PARQUET_SCAN.*File Filters:.*
 
 query II
-EXPLAIN select id, date from parquet_scan('data/parquet-testing/hive-partitioning/simple/*/*/test.parquet', HIVE_PARTITIONING=1) where date = '2012-01-01' and id < 10;
+EXPLAIN select id, date from parquet_scan('data/parquet-testing/hive-partitioning/simple/*/*/test.parquet', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=0) where date = '2012-01-01' and id < 10;
 ----
 physical_plan	<REGEX>:.*PARQUET_SCAN.*File Filters: \(date = '2012.*-01.*-01'\).*
 
 query II
-EXPLAIN select id, date from parquet_scan('data/parquet-testing/hive-partitioning/simple/*/*/test.parquet', HIVE_PARTITIONING=1) where date = '2013-01-01' and id < 10;
+EXPLAIN select id, date from parquet_scan('data/parquet-testing/hive-partitioning/simple/*/*/test.parquet', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=0) where date = '2013-01-01' and id < 10;
 ----
 physical_plan	<REGEX>:.*PARQUET_SCAN.*File Filters: \(date = '2013.*-01.*-01'\).*
 
@@ -111,7 +111,7 @@ select id, value, part, CAST(date AS DATE) as date_cast from parquet_scan('data/
 
 # Complex filter filtering first file, filter should be pruned completely
 query II
-explain select id, value, part, CAST(date AS DATE) as date_cast from parquet_scan('data/parquet-testing/hive-partitioning/different_order/*/*/test.parquet', HIVE_PARTITIONING=1) where concat(date_cast::VARCHAR, part) == '2013-01-01b';
+explain select id, value, part, CAST(date AS DATE) as date_cast from parquet_scan('data/parquet-testing/hive-partitioning/different_order/*/*/test.parquet', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=0) where concat(date_cast::VARCHAR, part) == '2013-01-01b';
 ----
 physical_plan	<REGEX>:.*PARQUET_SCAN.*File Filters: \(concat\(CAST.*\(CAST.*\(date AS DATE\) AS.*VARCHAR\),.*part\) = '20.*
 
@@ -123,20 +123,20 @@ select id, value, part, CAST(date AS DATE) as date_cast from parquet_scan('data/
 
 # Complex filter filtering second file, filter should be pruned completely
 query II
-explain select id, value, part, CAST(date AS DATE) as date_cast from parquet_scan('data/parquet-testing/hive-partitioning/different_order/*/*/test.parquet', HIVE_PARTITIONING=1) where concat(date_cast::VARCHAR, part) == '2012-01-01a';
+explain select id, value, part, CAST(date AS DATE) as date_cast from parquet_scan('data/parquet-testing/hive-partitioning/different_order/*/*/test.parquet', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=0) where concat(date_cast::VARCHAR, part) == '2012-01-01a';
 ----
 physical_plan	<REGEX>:.*PARQUET_SCAN.*File Filters: \(concat\(CAST.*\(CAST.*\(date AS DATE\) AS.*VARCHAR\),.*part\) = '20.*
 
 # Currently, complex fiters combining hive columns and regular columns, can prevent filter pushdown for some situations
 # TODO: we want to support filter pushdown here too
 query II
-explain select id, value, part, CAST(date AS DATE) as date_cast from parquet_scan('data/parquet-testing/hive-partitioning/different_order/*/*/test.parquet', HIVE_PARTITIONING=1) where (date_cast=CAST('2013-01-01' as DATE) AND (value='value1' OR concat(date_cast::VARCHAR, part) == '2013-01-01b'));
+explain select id, value, part, CAST(date AS DATE) as date_cast from parquet_scan('data/parquet-testing/hive-partitioning/different_order/*/*/test.parquet', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=0) where (date_cast=CAST('2013-01-01' as DATE) AND (value='value1' OR concat(date_cast::VARCHAR, part) == '2013-01-01b'));
 ----
 physical_plan	<REGEX>:.*PARQUET_SCAN.*File Filters: \(CAST\(date AS.*DATE.*\) = '2013-01-01'::DATE.*
 
 # Idem
 query II
-explain select id, value, part, CAST(date AS DATE) as date_cast from parquet_scan('data/parquet-testing/hive-partitioning/different_order/*/*/test.parquet', HIVE_PARTITIONING=1) where (date_cast=CAST('2012-01-01' as DATE) AND (value='value2' OR concat(date_cast::VARCHAR, part) == '2012-01-01a'));
+explain select id, value, part, CAST(date AS DATE) as date_cast from parquet_scan('data/parquet-testing/hive-partitioning/different_order/*/*/test.parquet', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=0) where (date_cast=CAST('2012-01-01' as DATE) AND (value='value2' OR concat(date_cast::VARCHAR, part) == '2012-01-01a'));
 ----
 physical_plan	<REGEX>:.*PARQUET_SCAN.*File Filters: \(CAST\(date AS.*DATE.*\) = '2012-01-01'::DATE.*
 
@@ -185,12 +185,12 @@ COPY (SELECT * FROM t1) TO '__TEST_DIR__/hive_filters_2' (FORMAT PARQUET, PARTIT
 
 # There should be Table Filters (id < 50) and regular filters
 query II
-EXPLAIN select a from parquet_scan('__TEST_DIR__/hive_filters/*/*.parquet', HIVE_PARTITIONING=1) where c=500 and a < 4;
+EXPLAIN select a from parquet_scan('__TEST_DIR__/hive_filters/*/*.parquet', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=0) where c=500 and a < 4;
 ----
 physical_plan	<REGEX>:.*PARQUET_SCAN.*Filters:.*a<4 AND a IS NOT.*NULL.*File Filters: \(CAST\(c AS.*INTEGER\) = 500\).*
 
 # unsatisfiable file filters also show up
 query II
-EXPLAIN select a from parquet_scan('__TEST_DIR__/hive_filters_2/*/*/*.parquet', HIVE_PARTITIONING=1) where c > 500 and c < 500;
+EXPLAIN select a from parquet_scan('__TEST_DIR__/hive_filters_2/*/*/*.parquet', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=0) where c > 500 and c < 500;
 ----
 physical_plan	<REGEX>:.*PARQUET_SCAN.*File Filters:.*\(CAST\(c AS.*INTEGER\).*BETWEEN 500.*

--- a/test/sql/copy/parquet/test_parquet_force_download.test
+++ b/test/sql/copy/parquet/test_parquet_force_download.test
@@ -66,7 +66,7 @@ UNION ALL SELECT * FROM PARQUET_SCAN('https://raw.githubusercontent.com/cwida/du
 UNION ALL SELECT * FROM PARQUET_SCAN('https://raw.githubusercontent.com/cwida/duckdb/master/data/parquet-testing/userdata1.parquet')
 
 statement ok
-COPY (from user_info) TO 'row-user-data.parquet' (FORMAT PARQUET,  ROW_GROUP_SIZE 2048);
+COPY (from user_info) TO 's3://test-bucket/row-user-data.parquet' (FORMAT PARQUET,  ROW_GROUP_SIZE 2048);
 
 statement ok
 COPY (from user_info limit 100) TO 's3://test-bucket/row-user-data_1.parquet' (FORMAT PARQUET,  ROW_GROUP_SIZE 2048);

--- a/test/sql/copy/partitioned/hive_filter_pushdown.test
+++ b/test/sql/copy/partitioned/hive_filter_pushdown.test
@@ -40,23 +40,23 @@ physical_plan	<!REGEX>:.*PARQUET_SCAN.*File Filters:.*
 
 # Check that hive specific filters are pushed down into the explain plan regardless of format type
 query II
-explain SELECT * FROM parquet_scan('__TEST_DIR__/hive_pushdown_bug/*/*.parquet', HIVE_PARTITIONING=1) where c=500;
+explain SELECT * FROM parquet_scan('__TEST_DIR__/hive_pushdown_bug/*/*.parquet', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=1) where c=500;
 ----
-physical_plan	<REGEX>:.*PARQUET_SCAN.*File Filters: \(CAST\(c AS.*INTEGER\) = 500\).*
+physical_plan	<REGEX>:.*PARQUET_SCAN.*File Filters: \(c = 500\).*
 
 query II
-explain SELECT * FROM parquet_scan('__TEST_DIR__/hive_pushdown_bug/*/*.parquet', HIVE_PARTITIONING=1) where c=500 and b=20;
+explain SELECT * FROM parquet_scan('__TEST_DIR__/hive_pushdown_bug/*/*.parquet', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=1) where c=500 and b=20;
 ----
-physical_plan	<REGEX>:.*PARQUET_SCAN.*File Filters: \(CAST\(c AS.*INTEGER\) = 500\).*
+physical_plan	<REGEX>:.*PARQUET_SCAN.*File Filters: \(c = 500\).*
 
 # File Filters show up in read csv auto for hive partitioned csv files. 
 statement ok
 COPY (SELECT i::VARCHAR as a, (i*10)::VARCHAR as b, (i*100)::VARCHAR as c from range(0,10) tbl(i)) TO '__TEST_DIR__/hive_pushdown_bug_csv' (FORMAT CSV, PARTITION_BY c);
 
 query II
-explain SELECT * FROM read_csv_auto('__TEST_DIR__/hive_pushdown_bug_csv/*/*.csv', HIVE_PARTITIONING=1, names=['a','b','c']) where c=500;
+explain SELECT * FROM read_csv_auto('__TEST_DIR__/hive_pushdown_bug_csv/*/*.csv', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=1, names=['a','b','c']) where c=500;
 ----
-physical_plan	<REGEX>:.*READ_CSV_AUTO.*File Filters: \(CAST\(c AS.*INTEGER\) = 500\).*
+physical_plan	<REGEX>:.*READ_CSV_AUTO.*File Filters: \(c = 500\).*
 
 # same for json paritioned files
 #statement ok

--- a/test/sql/copy/s3/s3_hive_partition.test
+++ b/test/sql/copy/s3/s3_hive_partition.test
@@ -88,13 +88,13 @@ COPY (SELECT * FROM t1) TO 's3://test-bucket/hive-partitioning/filter-test-csv' 
 
 # There should be Table Filters (id < 50) and file filters (c = 500)
 query II
-EXPLAIN select a from parquet_scan('s3://test-bucket/hive-partitioning/filter-test-parquet/*/*.parquet', HIVE_PARTITIONING=1) where c=500 and a < 4;
+EXPLAIN select a from parquet_scan('s3://test-bucket/hive-partitioning/filter-test-parquet/*/*.parquet', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=0) where c=500 and a < 4;
 ----
 physical_plan	<REGEX>:.*PARQUET_SCAN.*Filters:.*a<4 AND a IS NOT.*NULL.*File Filters: \(CAST\(c AS.*INTEGER\) = 500\).*
 
 # There should be Table Filters (id < 50) and file filters (c = 500)
 query II
-EXPLAIN select a from read_csv_auto('s3://test-bucket/hive-partitioning/filter-test-csv/*/*.csv', HIVE_PARTITIONING=1, columns={'a': 'INT', 'b':'INT', 'c':'INT'}) where c=500 and a < 4;
+EXPLAIN select a from read_csv_auto('s3://test-bucket/hive-partitioning/filter-test-csv/*/*.csv', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=0, columns={'a': 'INT', 'b':'INT', 'c':'INT'}) where c=500 and a < 4;
 ----
 physical_plan	<REGEX>:.*FILTER.*(a < 4).*READ_CSV_AUTO.*File Filters: \(CAST\(c AS.*INTEGER\) = 500\).*
 


### PR DESCRIPTION
https://github.com/duckdb/duckdb/pull/7674 and https://github.com/duckdb/duckdb/pull/7986 were conflicting in CI

Reason was that physical plan checks from @Tmonster were not accounting the autocast that would be default on by @lverdoes. resolved by switching off autocast and  updating checked physical plans in tests