### PR TITLE
fix: support case-insensitive lookup in SHOW TABLES

### DIFF
--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -1,10 +1,10 @@
 #include "duckdb/catalog/catalog_search_path.hpp"
 
+#include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/client_context.hpp"
-#include "duckdb/catalog/catalog.hpp"
 #include "duckdb/main/database_manager.hpp"
 
 namespace duckdb {
@@ -255,7 +255,8 @@ bool CatalogSearchPath::SchemaInSearchPath(ClientContext &context, const string 
 		if (StringUtil::CIEquals(path.catalog, catalog_name)) {
 			return true;
 		}
-		if (IsInvalidCatalog(path.catalog) && StringUtil::CIEquals(catalog_name, DatabaseManager::GetDefaultDatabase(context))) {
+		if (IsInvalidCatalog(path.catalog) &&
+		    StringUtil::CIEquals(catalog_name, DatabaseManager::GetDefaultDatabase(context))) {
 			return true;
 		}
 	}

--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -249,13 +249,13 @@ void CatalogSearchPath::SetPaths(vector<CatalogSearchEntry> new_paths) {
 bool CatalogSearchPath::SchemaInSearchPath(ClientContext &context, const string &catalog_name,
                                            const string &schema_name) {
 	for (auto &path : paths) {
-		if (path.schema != schema_name) {
+		if (!StringUtil::CIEquals(path.schema, schema_name)) {
 			continue;
 		}
-		if (path.catalog == catalog_name) {
+		if (StringUtil::CIEquals(path.catalog, catalog_name)) {
 			return true;
 		}
-		if (IsInvalidCatalog(path.catalog) && catalog_name == DatabaseManager::GetDefaultDatabase(context)) {
+		if (IsInvalidCatalog(path.catalog) && StringUtil::CIEquals(catalog_name, DatabaseManager::GetDefaultDatabase(context))) {
 			return true;
 		}
 	}

--- a/test/sql/attach/attach_show_table.test
+++ b/test/sql/attach/attach_show_table.test
@@ -30,6 +30,14 @@ SHOW TABLES
 ----
 
 statement ok
+USE DB1
+
+query I
+SHOW TABLES
+----
+table_in_db1
+
+statement ok
 USE db1
 
 query I
@@ -47,6 +55,15 @@ table_in_db2
 
 statement ok
 USE db2.test_schema;
+
+query I
+SHOW TABLES
+----
+table_in_db2
+table_in_db2_test_schema
+
+statement ok
+USE DB2.TEST_sChEmA;
 
 query I
 SHOW TABLES


### PR DESCRIPTION
`SHOW TABLES` is converted into a SQL statement that calls a `in_search_path` function which was doing a case-sensitive lookup in `InSearchPathFunction` (`search_path->SchemaInSearchPath`) so when `db1` is attached and `DB1` is used, `SHOW TABLES` returned no results: (repro steps in shell.duckdb.org)
```
duckdb> attach ':memory' as db1;
┌┐
└┘
Elapsed: 37 ms

duckdb> use DB1;
┌┐
└┘
Elapsed: 5 ms

duckdb> CREATE TABLE tbl1 AS SELECT 1;
┌───────┐
│ Count │
╞═══════╡
│     1 │
└───────┘
Elapsed: 29 ms

duckdb>  SHOW TABLES;
┌┐
└┘
Elapsed: 56 ms

duckdb> USE db1;
┌┐
└┘
Elapsed: 2 ms

duckdb>  SHOW TABLES;
┌──────┐
│ name │
╞══════╡
│ tbl1 │
└──────┘
```
This fixes the issue.