### PR TITLE
Bump ubuntu to 18 for linux extensions build

### DIFF
--- a/.github/actions/ubuntu_18_setup/action.yml
+++ b/.github/actions/ubuntu_18_setup/action.yml
@@ -1,5 +1,5 @@
-name: "Setup Ubuntu 16"
-description: "Setup an Ubuntu 16 docker container with the required libraries"
+name: "Setup Ubuntu 18"
+description: "Setup an Ubuntu 18 docker container with the required libraries"
 inputs:
   openssl:
     description: 'OpenSSL'

--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/ubuntu_16_setup
+      - uses: ./.github/actions/ubuntu_18_setup
         with:
           ccache: 1
           aarch64_cross_compile: 1

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -109,7 +109,7 @@ jobs:
    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
    runs-on: ubuntu-latest
    needs: linux-release-64
-   container: ubuntu:18.04 # cross compiler not available in 16
+   container: ubuntu:18.04
    env:
      GEN: ninja
      BUILD_BENCHMARK: 1
@@ -130,7 +130,7 @@ jobs:
        with:
          fetch-depth: 0
 
-     - uses: ./.github/actions/ubuntu_16_setup
+     - uses: ./.github/actions/ubuntu_18_setup
        with:
         cccache: 1
         aarch64_cross_compile: 1
@@ -165,12 +165,12 @@ jobs:
            duckdb_odbc-linux-aarch64.zip
            duckdb_cli-linux-aarch64.zip
 
- # Linux extensions for builds that use C++11 ABI, currently these are all linux builds based on ubuntu >= 16 (e.g. NodeJS)
+ # Linux extensions for builds that use C++11 ABI, currently these are all linux builds based on ubuntu >= 18 (e.g. NodeJS)
  # note that the linux-release-64 is based on the manylinux-based extensions, which are built in .github/workflows/Python.yml
  linux-extensions-64:
     name: Linux Extensions (x64)
     runs-on: ubuntu-latest
-    container: ubuntu:16.04
+    container: ubuntu:18.04
     needs: linux-release-64
 
     steps:
@@ -178,7 +178,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: ./.github/actions/ubuntu_16_setup
+    - uses: ./.github/actions/ubuntu_18_setup
       with:
         vcpkg: 1
         openssl: 1
@@ -204,7 +204,7 @@ jobs:
     name: Linux Extensions (aarch64)
     if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
-    container: ubuntu:18.04 # cross compiler not available in 16
+    container: ubuntu:18.04
     needs: linux-release-64
 
     steps:
@@ -212,7 +212,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/ubuntu_16_setup
+      - uses: ./.github/actions/ubuntu_18_setup
         with:
           vcpkg: 1
           openssl: 1

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -255,7 +255,7 @@ jobs:
        with:
          fetch-depth: 0
 
-     - uses: ./.github/actions/ubuntu_16_setup
+     - uses: ./.github/actions/ubuntu_18_setup
        with:
          openssl: 0
          python: 0


### PR DESCRIPTION
The direct cause for this PR is the current CI failure on ubuntu 16 linux extensions: it fails because of the aws-cli not finding the proper openssl after some refactors. Switching to ubuntu 18 is an easy fix, as the aarch64 job does work.

The argument that switching to 18 is okay in general, is because of the recent switch to manylinux for the main linux distribution: this means that we don't need this job to be at 16 anymore and 18 is sufficient, since our other builds require more recent OS's anyway