### PR TITLE
add verbose option to generate_grammar.py

### DIFF
--- a/scripts/generate_grammar.py
+++ b/scripts/generate_grammar.py
@@ -14,6 +14,7 @@ namespace          = 'duckdb_libpgquery'
 
 counterexamples = False
 run_update = False
+verbose = False
 for arg in sys.argv[1:]:
     if arg.startswith("--bison="):
         bison_location = arg.replace("--bison=", "")
@@ -27,8 +28,10 @@ for arg in sys.argv[1:]:
         pg_dir = arg.split("=")[1] + pg_dir
     elif arg.startswith("--namespace"):
         namespace = arg.split("=")[1]
+    elif arg.startswith("--verbose"):
+        verbose = True
     else:
-        raise Exception("Unrecognized argument: " + arg + ", expected --counterexamples, --bison=/loc/to/bison, --custom_dir_prefix, --namespace")
+        raise Exception("Unrecognized argument: " + arg + ", expected --counterexamples, --bison=/loc/to/bison, --custom_dir_prefix, --namespace, --verbose")
 
 template_file      = os.path.join(base_dir, 'grammar.y')
 target_file        = os.path.join(base_dir, 'grammar.y.tmp')
@@ -246,6 +249,8 @@ if counterexamples:
     cmd += ["-Wcounterexamples"]
 if run_update:
     cmd += ["--update"]
+if verbose:
+    cmd += ["--verbose"]
 cmd += ["-o", result_source, "-d", target_file]
 print(' '.join(cmd))
 proc = subprocess.Popen(cmd, stderr=subprocess.PIPE)


### PR DESCRIPTION
The **Bison** verbose option offers additional information to facilitate the debugging of shift/reduce and reduce/reduce conflicts.

In the "grammar_out.output" file, we can identify the specific states that are causing conflicts in the grammar.

[Bison doc](https://www.gnu.org/software/bison/manual/html_node/Output-Files.html)

cc @Tishj @Mytherin 