### PR TITLE
Arrow C API test - initialize result to nullptr

### DIFF
--- a/test/api/capi/test_capi_arrow.cpp
+++ b/test/api/capi/test_capi_arrow.cpp
@@ -9,7 +9,7 @@ TEST_CASE("Test arrow in C API", "[capi][arrow]") {
 	CAPITester tester;
 	duckdb::unique_ptr<CAPIResult> result;
 	duckdb_prepared_statement stmt = nullptr;
-	duckdb_arrow arrow_result;
+	duckdb_arrow arrow_result = nullptr;
 
 	// open the database in in-memory mode
 	REQUIRE(tester.OpenDatabase(nullptr));


### PR DESCRIPTION
In one of the test sections the result is destroyed without ever being allocated, which can sporadically cause the test to crash if the result is not initialized to `NULL` explicitly