### PR TITLE
Pragma platform

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -106,7 +106,7 @@ jobs:
 
  linux-release-aarch64:
    name: Linux (aarch64)
-   if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
+   if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' || github.repository != 'duckdb/duckdb'
    runs-on: ubuntu-latest
    needs: linux-release-64
    container: ubuntu:18.04

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -70,6 +70,10 @@ jobs:
       shell: bash
       run: make
 
+    - name: Print platform
+      shell: bash
+      run: ./build/release/duckdb -c "PRAGMA platform;"
+
     - name: Test
       shell: bash
       run: make allunit

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -160,6 +160,10 @@ jobs:
         run: |
           GEN=ninja EXTENSION_STATIC_BUILD=1 BUILD_TPCH=1 BUILD_HTTPFS=1 STATIC_OPENSSL=1 BUILD_NODE=1 make
 
+      - name: Print platform
+        shell: bash
+        run: ./build/release/duckdb -c "PRAGMA platform;"
+
       - name: Setup
         shell: bash
         run: ./scripts/node_version.sh
@@ -241,6 +245,10 @@ jobs:
         run: |
           brew install ninja
           GEN=ninja BUILD_TPCH=1 BUILD_NODE=1 make
+
+      - name: Print platform
+        shell: bash
+        run: ./build/release/duckdb -c "PRAGMA platform;"
 
       - name: Setup
         shell: bash

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -115,6 +115,10 @@ jobs:
         shell: bash
         run: make
 
+      - name: Print platform
+        shell: bash
+        run: ./build/release/duckdb -c "PRAGMA platform;"
+
       - name: Unit Test
         shell: bash
         run: make allunit

--- a/extension/ExtensionDistribution.md
+++ b/extension/ExtensionDistribution.md
@@ -33,7 +33,8 @@ Configuration folder defaults to be placed in home directory, but can be overwri
 ## WebAssembly loadable extensions (in flux)
 
 ```
-https://extensions.duckdb.org/wasm/         The extension registry URL (can have subfolders)
+https://extensions.duckdb.org/ 	            The extension registry URL (can have subfolders)
+wasm/                                       wasm-subfolder, required
 v1.27.0/                                    The DuckDB-Wasm version identifier
 webassembly_eh/                             The platform/feature-set this extension is compatible with
 name                                        The default name of a given extension

--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -136,6 +136,10 @@ string PragmaVersion(ClientContext &context, const FunctionParameters &parameter
 	return "SELECT * FROM pragma_version();";
 }
 
+string PragmaPlatform(ClientContext &context, const FunctionParameters &parameters) {
+	return "SELECT * FROM pragma_platform();";
+}
+
 string PragmaImportDatabase(ClientContext &context, const FunctionParameters &parameters) {
 	auto &config = DBConfig::GetConfig(context);
 	if (!config.options.enable_external_access) {
@@ -192,6 +196,7 @@ void PragmaQueries::RegisterFunction(BuiltinFunctions &set) {
 	set.AddFunction(PragmaFunction::PragmaStatement("collations", PragmaCollations));
 	set.AddFunction(PragmaFunction::PragmaCall("show", PragmaShow, {LogicalType::VARCHAR}));
 	set.AddFunction(PragmaFunction::PragmaStatement("version", PragmaVersion));
+	set.AddFunction(PragmaFunction::PragmaStatement("platform", PragmaPlatform));
 	set.AddFunction(PragmaFunction::PragmaStatement("database_size", PragmaDatabaseSize));
 	set.AddFunction(PragmaFunction::PragmaStatement("functions", PragmaFunctionsQuery));
 	set.AddFunction(PragmaFunction::PragmaCall("import_database", PragmaImportDatabase, {LogicalType::VARCHAR}));

--- a/src/function/table/system_functions.cpp
+++ b/src/function/table/system_functions.cpp
@@ -10,6 +10,7 @@ namespace duckdb {
 
 void BuiltinFunctions::RegisterSQLiteFunctions() {
 	PragmaVersion::RegisterFunction(*this);
+	PragmaPlatform::RegisterFunction(*this);
 	PragmaCollations::RegisterFunction(*this);
 	PragmaTableInfo::RegisterFunction(*this);
 	PragmaStorageInfo::RegisterFunction(*this);

--- a/src/function/table/version/pragma_version.cpp
+++ b/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/common/string_util.hpp"
 
 #include <cstdint>
 
@@ -57,6 +58,13 @@ const char *DuckDB::LibraryVersion() {
 }
 
 string DuckDB::Platform() {
+#if defined(DUCKDB_CUSTOM_PLATFORM)
+	return DUCKDB_QUOTE_DEFINE(DUCKDB_CUSTOM_PLATFORM);
+#endif
+#if defined(DUCKDB_WASM_VERSION)
+	// DuckDB-Wasm requires CUSTOM_PLATFORM to be defined
+	static_assert(0, "DUCKDB_WASM_VERSION should rely on CUSTOM_PLATFORM being provided");
+#endif
 	string os = "linux";
 #if INTPTR_MAX == INT64_MAX
 	string arch = "amd64";

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -16,6 +16,17 @@
 
 namespace duckdb {
 
+#ifndef DUCKDB_QUOTE_DEFINE
+// Preprocessor trick to allow text to be converted to C-string / string
+// Expecte use is:
+//	#ifdef SOME_DEFINE
+//	string str = DUCKDB_QUOTE_DEFINE(SOME_DEFINE)
+//	...do something with str
+//	#endif SOME_DEFINE
+#define DUCKDB_QUOTE_DEFINE_IMPL(x) #x
+#define DUCKDB_QUOTE_DEFINE(x)      DUCKDB_QUOTE_DEFINE_IMPL(x)
+#endif
+
 /**
  * String Utility Functions
  * Note that these are not the most efficient implementations (i.e., they copy

--- a/src/include/duckdb/function/table/system_functions.hpp
+++ b/src/include/duckdb/function/table/system_functions.hpp
@@ -37,6 +37,10 @@ struct PragmaVersion {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct PragmaPlatform {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct PragmaDatabaseSize {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -29,6 +29,9 @@ bool ExtensionHelper::IsRelease(const string &version_tag) {
 }
 
 const string ExtensionHelper::GetVersionDirectoryName() {
+#ifdef DUCKDB_WASM_VERSION
+	return DUCKDB_QUOTE_DEFINE(DUCKDB_WASM_VERSION);
+#endif
 	if (IsRelease(DuckDB::LibraryVersion())) {
 		return NormalizeVersionTag(DuckDB::LibraryVersion());
 	} else {

--- a/test/sql/pragma/test_pragma_version.test
+++ b/test/sql/pragma/test_pragma_version.test
@@ -10,3 +10,12 @@ select * from pragma_version();
 
 statement ok
 select library_version from pragma_version();
+
+statement ok
+PRAGMA platform;
+
+statement ok
+select * from pragma_platform();
+
+statement ok
+select platform from pragma_platform();


### PR DESCRIPTION
Refactor / rework out of https://github.com/duckdb/duckdb/pull/8129 (closed).

Brings in 1 new functionality, available to end-users, `PRAGMA platform`, that returns the platform string, one of:
```
linux_amd64_gcc4
linux_amd64
linux_arm64
osx_amd64
osx_arm64
windows_amd64
windows_amd64_rtools
---
webassembly_mvp
webassembly_eh
webassembly_coi (? = we might want to change this to webassembly_threads)
```
Top part were the currently existing platforms, bottom one the 3 new one that will be explicitly added duckdb-wasm side and passed via define to duckdb.