### PR TITLE
CI Job names to explicit platform they build for

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -37,6 +37,7 @@ env:
 
 jobs:
  linux-release-64:
+    # Builds binaries for linux_amd64_gcc4
     name: Linux (x64)
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2014_x86_64
@@ -105,6 +106,7 @@ jobs:
           duckdb_cli-linux-amd64.zip
 
  linux-release-aarch64:
+   # Builds binaries for linux_arm64
    name: Linux (aarch64)
    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
    runs-on: ubuntu-latest
@@ -168,6 +170,7 @@ jobs:
  # Linux extensions for builds that use C++11 ABI, currently these are all linux builds based on ubuntu >= 18 (e.g. NodeJS)
  # note that the linux-release-64 is based on the manylinux-based extensions, which are built in .github/workflows/Python.yml
  linux-extensions-64:
+    # Builds extensions for linux_amd64
     name: Linux Extensions (x64)
     runs-on: ubuntu-latest
     container: ubuntu:18.04
@@ -201,6 +204,7 @@ jobs:
           build/release/extension/*/*.duckdb_extension
 
  linux-extensions-64-aarch64:
+    # Builds extensions for linux_arm64
     name: Linux Extensions (aarch64)
     if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -72,6 +72,7 @@ jobs:
         clang++ -DDEBUG -O0 -std=c++11 -Wall -Werror -emit-llvm -S duckdb.cpp
 
   xcode-release:
+    # Builds binaries for osx_arm64 and osx_amd64
     name: OSX Release
     runs-on: macos-latest
     needs: xcode-debug
@@ -164,6 +165,7 @@ jobs:
             duckdb_odbc-osx-universal.zip
 
   xcode-extensions:
+    # Builds extensions for osx_arm64 and osx_amd64
     name: OSX Extensions Release
     runs-on: macos-latest
     needs: xcode-debug

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -85,6 +85,7 @@ jobs:
         cibuildwheel --output-dir wheelhouse --config-file cibw.toml duckdb_tarball
 
    manylinux-extensions-x64:
+    # Builds extensions for linux_md64_gcc4
     name: Linux Extensions (ggc4)
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2014_x86_64

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -179,6 +179,7 @@ jobs:
         R CMD INSTALL .
 
   rstats-windows:
+    # Builds binaries for windows_amd64_rtools
     name: R Package Windows
     needs: rstats-linux
     runs-on: windows-latest
@@ -221,6 +222,7 @@ jobs:
         if egrep 'NOTE|WARNING|ERROR' /tmp/duckdb.Rcheck/00check.log ; then exit 1; fi
 
   rstats-windows-extensions:
+    # Builds extensions for windows_amd64_rtools
     name: R Package Windows (Extensions)
     if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
     needs: rstats-linux

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -37,6 +37,7 @@ env:
 
 jobs:
  win-release-64:
+    # Builds binaries for windows_amd64
     name: Windows (64 Bit)
     runs-on: windows-latest
     steps:
@@ -226,6 +227,7 @@ jobs:
            tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper.exe
 
  win-extensions-64:
+   # Builds extensions for windows_amd64
    name: Windows Extensions (64-bit)
    runs-on: windows-latest
    needs: win-release-64


### PR DESCRIPTION
Note that this has no external impact since it changes only the pretty name of the CI jobs (identifier and so links are the same).
Reason is making some choices more explicit.

Independent but inspired from https://github.com/duckdb/duckdb/pull/8195.