### PR TITLE
R: Avoid crash when finalizing

### DIFF
--- a/tools/rpkg/src/connection.cpp
+++ b/tools/rpkg/src/connection.cpp
@@ -3,7 +3,7 @@
 using namespace duckdb;
 
 void duckdb::ConnDeleter(ConnWrapper *conn) {
-	cpp11::warning("Connection is garbage-collected, use dbDisconnect() to avoid this.");
+	cpp11::warning(std::string("Connection is garbage-collected, use dbDisconnect() to avoid this."));
 	delete conn;
 }
 

--- a/tools/rpkg/src/database.cpp
+++ b/tools/rpkg/src/database.cpp
@@ -9,8 +9,8 @@
 using namespace duckdb;
 
 void duckdb::DBDeleter(DBWrapper *db) {
-	cpp11::warning("Database is garbage-collected, use dbDisconnect(con, shutdown=TRUE) or "
-	               "duckdb::duckdb_shutdown(drv) to avoid this.");
+	cpp11::warning(std::string("Database is garbage-collected, use dbDisconnect(con, shutdown=TRUE) or "
+	                           "duckdb::duckdb_shutdown(drv) to avoid this."));
 	delete db;
 }
 


### PR DESCRIPTION
Closes https://github.com/r-dbi/RSQLite/pull/465.

This problem occurs during shutdown of R when another package that also uses the cpp11 package is loaded. The linked PR contains a reprex.

I can spend more time on that as needed.