### PR TITLE
Remove unnecessary dbplyr fill method

### DIFF
--- a/tools/rpkg/R/backend-dbplyr__duckdb_connection.R
+++ b/tools/rpkg/R/backend-dbplyr__duckdb_connection.R
@@ -367,24 +367,6 @@ sql_escape_datetime.duckdb_connection <- function(con, x) {
   dbQLit(con, x)
 }
 
-# Customized translation for fill function
-# @param .con A \code{\link{dbConnect}} object, as returned by \code{dbConnect()}
-# @param .data Data frame
-# @param cols_to_fill Which colums to be altered
-# @param order_by_cols Defined order of variables
-# @param .direction Direction in which to fill missing values.
-# @name dbplyr_fill0
-dbplyr_fill0.duckdb_connection <- function(.con, .data, cols_to_fill, order_by_cols, .direction) {
-  dbplyr_fill0 <- pkg_method("dbplyr_fill0.SQLiteConnection", "dbplyr")
-
-  # Required because of the bug in dbplyr (con is not passed to "translate_sql(cumsum..." call)
-  # See https://github.com/tidyverse/dbplyr/pull/753
-  setcon <- pkg_method("set_current_con", "dbplyr")
-  setcon(.con)
-
-  dbplyr_fill0(.con, .data, cols_to_fill, order_by_cols, .direction)
-}
-
 # Customized handling for tbl() to allow the use of replacement scans
 # @param src .con A \code{\link{dbConnect}} object, as returned by \code{dbConnect()}
 # @param from Table or parquet/csv -files to be registered


### PR DESCRIPTION
This removes a workaround that has been fixed quite some time ago in dbplyr.