### PR TITLE
Chore: Bump duckdb-wasm AND move to emscripten latest

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -26,7 +26,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  DUCKDB_WASM_VERSION: "0e27318"
+  DUCKDB_WASM_VERSION: "a8f2c38"
   CCACHE_SAVE: ${{ github.repository != 'duckdb/duckdb' }}
 
 jobs:
@@ -688,7 +688,7 @@ jobs:
 
     - uses: mymindstorm/setup-emsdk@v12
       with:
-        version: 3.1.41
+        version: 'latest'
 
     - name: Setup
       shell: bash


### PR DESCRIPTION
Emscripten 3.1.42 had a bug related to SIMD in clang/llvm (https://github.com/llvm/llvm-project/issues/63500), fixed and now included in 3.1.43.