### PR TITLE
ODBC: Fix for Issue #8190

### DIFF
--- a/tools/odbc/statement_functions.cpp
+++ b/tools/odbc/statement_functions.cpp
@@ -59,7 +59,7 @@ SQLRETURN duckdb::PrepareStmt(SQLHSTMT statement_handle, SQLCHAR *statement_text
 
 	auto query = OdbcUtils::ReadString(statement_text, text_length);
 	hstmt->stmt = hstmt->dbc->conn->Prepare(query);
-	if (!hstmt->stmt->GetStatementProperties().bound_all_parameters) {
+	if (hstmt->stmt->data && !hstmt->stmt->GetStatementProperties().bound_all_parameters) {
 		DiagRecord diag_rec("Not all parameters are bound", SQLStateType::SYNTAX_ERROR_OR_ACCESS_VIOLATION,
 		                    hstmt->dbc->GetDataSourceName());
 		return (SetDiagnosticRecord(hstmt, SQL_ERROR, "PrepareStmt", diag_rec, hstmt->dbc->GetDataSourceName()));

--- a/tools/odbc/statement_functions.cpp
+++ b/tools/odbc/statement_functions.cpp
@@ -59,6 +59,11 @@ SQLRETURN duckdb::PrepareStmt(SQLHSTMT statement_handle, SQLCHAR *statement_text
 
 	auto query = OdbcUtils::ReadString(statement_text, text_length);
 	hstmt->stmt = hstmt->dbc->conn->Prepare(query);
+	if (!hstmt->stmt->GetStatementProperties().bound_all_parameters) {
+		DiagRecord diag_rec("Not all parameters are bound", SQLStateType::SYNTAX_ERROR_OR_ACCESS_VIOLATION,
+		                    hstmt->dbc->GetDataSourceName());
+		return (SetDiagnosticRecord(hstmt, SQL_ERROR, "PrepareStmt", diag_rec, hstmt->dbc->GetDataSourceName()));
+	}
 	if (hstmt->stmt->HasError()) {
 		DiagRecord diag_rec(hstmt->stmt->error.Message(), SQLStateType::SYNTAX_ERROR_OR_ACCESS_VIOLATION,
 		                    hstmt->dbc->GetDataSourceName());

--- a/tools/odbc/test/tests/select.cpp
+++ b/tools/odbc/test/tests/select.cpp
@@ -1,7 +1,5 @@
 #include "../common.h"
 
-#include <iostream>
-
 using namespace odbc_test;
 
 TEST_CASE("Test Select Statement", "[odbc]") {
@@ -52,16 +50,15 @@ TEST_CASE("Test Select Statement", "[odbc]") {
 		DATA_CHECK(hstmt, i, std::to_string(i).c_str());
 	}
 
-	// SELECT $x
+	// SELECT $x; should throw error
 	SQLRETURN ret = SQLExecDirect(hstmt, ConvertToSQLCHAR("SELECT $x"), SQL_NTS);
 	REQUIRE(ret == SQL_ERROR);
 	std::string state;
 	std::string message;
 	ACCESS_DIAGNOSTIC(state, message, hstmt, SQL_HANDLE_STMT);
-	std::cout << "State: " << state << std::endl;
-	std::cout << "Message: " << message << std::endl;
-
-	//	EXECUTE_AND_CHECK("SQLExecDirect (SELECT $x)", SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT $x"), SQL_NTS);
+	REQUIRE(state == "42000");
+	REQUIRE(message == "ODBC_DuckDB->PrepareStmt\n"
+	                   "Not all parameters are bound");
 
 	// Free the statement handle
 	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);

--- a/tools/odbc/test/tests/select.cpp
+++ b/tools/odbc/test/tests/select.cpp
@@ -52,6 +52,17 @@ TEST_CASE("Test Select Statement", "[odbc]") {
 		DATA_CHECK(hstmt, i, std::to_string(i).c_str());
 	}
 
+	// SELECT $x
+	SQLRETURN ret = SQLExecDirect(hstmt, ConvertToSQLCHAR("SELECT $x"), SQL_NTS);
+	REQUIRE(ret == SQL_ERROR);
+	std::string state;
+	std::string message;
+	ACCESS_DIAGNOSTIC(state, message, hstmt, SQL_HANDLE_STMT);
+	std::cout << "State: " << state << std::endl;
+	std::cout << "Message: " << message << std::endl;
+
+	//	EXECUTE_AND_CHECK("SQLExecDirect (SELECT $x)", SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT $x"), SQL_NTS);
+
 	// Free the statement handle
 	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
 	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);


### PR DESCRIPTION
This PR provides a fix for #8190.

Now the driver correctly returns `SQL_ERROR` and populates the diagnostics record, when a query with an uninitialized prepared statement is executed eg: `SELECT $x;`.