### PR TITLE
Change join ref type to cross if join type is cross and join ref type is regular

### DIFF
--- a/tools/rpkg/R/relational.R
+++ b/tools/rpkg/R/relational.R
@@ -228,7 +228,7 @@ rel_join_ <- function(left, right, conds,
   join_ref_type <- match.arg(join_ref_type)
   # the ref type is naturally regular. Users won't write rel_join(left, right, conds, "cross", "cross")
   # so we update it here.
-  if (join == "cross") {
+  if (join == "cross" && join_ref_type == "regular") {
     join_ref_type = "cross"
   }
   rapi_rel_join(left, right, conds, join, join_ref_type)

--- a/tools/rpkg/R/relational.R
+++ b/tools/rpkg/R/relational.R
@@ -226,6 +226,11 @@ rel_join_ <- function(left, right, conds,
                       join_ref_type = c("regular", "natural", "cross", "positional", "asof")) {
   join <- match.arg(join)
   join_ref_type <- match.arg(join_ref_type)
+  # the ref type is naturally regular. Users won't write rel_join(left, right, conds, "cross", "cross")
+  # so we update it here.
+  if (join == "cross") {
+    join_ref_type = "cross"
+  }
   rapi_rel_join(left, right, conds, join, join_ref_type)
 }
 


### PR DESCRIPTION
In the R relational api, you can pass the join type "inner", "left", "right", "cross" etc. The default join_ref_type is "regular", however, if a user chooses "cross", then the join reft type needs to be cross as well. No user will write `rel_join(left, right, conds, "cross", join_ref_type="cross")`, so this PR updates the join ref type if the join type is cross. This will also get rid of a  warning in the CI output that looks like an error. As seen below

https://github.com/duckdb/duckdb/actions/runs/5532375890/jobs/10094372128 (or any of the current R GitHub actions.)

The warning can still be triggered if a user tries to execute a cross join using some other join_ref_type that doesn't allow for a cross join. Something like `rel_join(left, right, cons, "cross", "asof")`. In this case we will convert the join to a cross product and warn the user. 

![image](https://github.com/duckdb/duckdb/assets/6248601/dda816fc-85fb-4d7c-9ebe-62e01b2739c0)

