### PR TITLE
ODBC: Reformat Diagnosics Function

### DIFF
--- a/tools/odbc/connection.cpp
+++ b/tools/odbc/connection.cpp
@@ -33,9 +33,9 @@ SQLRETURN SQL_API SQLGetConnectAttr(SQLHDBC connection_handle, SQLINTEGER attrib
 	case SQL_ATTR_CURRENT_CATALOG: {
 		if (value_ptr == nullptr) {
 			*string_length_ptr = dbc->sql_attr_current_catalog.size();
-			duckdb::DiagRecord diag_rec("Catalog attribute with null value pointer.", SQLStateType::INVALID_ATTR_VALUE,
-			                            dbc->GetDataSourceName());
-			return duckdb::SetDiagnosticRecord(dbc, SQL_ERROR, "SQLGetConnectAttr", diag_rec, dbc->GetDataSourceName());
+			return duckdb::SetDiagnosticRecord(dbc, SQL_ERROR, "SQLGetConnectAttr",
+			                                   "Catalog attribute with null value pointer.",
+			                                   SQLStateType::INVALID_ATTR_VALUE, dbc->GetDataSourceName());
 		}
 
 		auto ret = SQL_SUCCESS;
@@ -45,9 +45,8 @@ SQLRETURN SQL_API SQLGetConnectAttr(SQLHDBC connection_handle, SQLINTEGER attrib
 		if (out_len == (size_t)buffer_length) {
 			ret = SQL_SUCCESS_WITH_INFO;
 			out_len = buffer_length - 1;
-			duckdb::DiagRecord diag_rec("Catalog attribute length mismatch.", SQLStateType::STR_LEN_MISMATCH,
-			                            dbc->GetDataSourceName());
-			return duckdb::SetDiagnosticRecord(dbc, SQL_SUCCESS_WITH_INFO, "SQLGetConnectAttr", diag_rec,
+			return duckdb::SetDiagnosticRecord(dbc, SQL_SUCCESS_WITH_INFO, "SQLGetConnectAttr",
+			                                   "Catalog attribute length mismatch.", SQLStateType::STR_LEN_MISMATCH,
 			                                   dbc->GetDataSourceName());
 		}
 
@@ -97,9 +96,8 @@ SQLRETURN SQL_API SQLGetConnectAttr(SQLHDBC connection_handle, SQLINTEGER attrib
 		return SQL_SUCCESS;
 	}
 	default:
-		duckdb::DiagRecord diag_rec("Attribute not supported.", SQLStateType::INVALID_ATTR_OPTION_ID,
-		                            dbc->GetDataSourceName());
-		return duckdb::SetDiagnosticRecord(dbc, SQL_ERROR, "SQLGetConnectAttr", diag_rec, dbc->GetDataSourceName());
+		return duckdb::SetDiagnosticRecord(dbc, SQL_ERROR, "SQLGetConnectAttr", "Attribute not supported.",
+		                                   SQLStateType::INVALID_ATTR_OPTION_ID, dbc->GetDataSourceName());
 	}
 }
 
@@ -150,8 +148,8 @@ SQLRETURN SQL_API SQLSetConnectAttr(SQLHDBC connection_handle, SQLINTEGER attrib
 			dbc->sql_attr_access_mode = SQL_MODE_READ_ONLY;
 			return SQL_SUCCESS;
 		}
-		duckdb::DiagRecord diag_rec("Invalid access mode.", SQLStateType::INVALID_ATTR_VALUE, dbc->GetDataSourceName());
-		return duckdb::SetDiagnosticRecord(dbc, SQL_ERROR, "SQLSetConnectAttr", diag_rec, dbc->GetDataSourceName());
+		return duckdb::SetDiagnosticRecord(dbc, SQL_ERROR, "SQLSetConnectAttr", "Invalid access mode.",
+		                                   SQLStateType::INVALID_ATTR_VALUE, dbc->GetDataSourceName());
 	}
 #ifdef SQL_ATTR_ASYNC_DBC_EVENT
 	case SQL_ATTR_ASYNC_DBC_EVENT:
@@ -164,23 +162,22 @@ SQLRETURN SQL_API SQLSetConnectAttr(SQLHDBC connection_handle, SQLINTEGER attrib
 	case SQL_ATTR_ASYNC_DBC_PCONTEXT:
 #endif
 	case SQL_ATTR_ASYNC_ENABLE: {
-		duckdb::DiagRecord diag_rec("DuckDB does not support asynchronous events.", SQLStateType::INVALID_ATTR_VALUE,
-		                            dbc->GetDataSourceName());
-		return duckdb::SetDiagnosticRecord(dbc, SQL_ERROR, "SQLSetConnectAttr", diag_rec, dbc->GetDataSourceName());
+		return duckdb::SetDiagnosticRecord(dbc, SQL_ERROR, "SQLSetConnectAttr",
+		                                   "DuckDB does not support asynchronous events.",
+		                                   SQLStateType::INVALID_ATTR_VALUE, dbc->GetDataSourceName());
 	}
 	case SQL_ATTR_AUTO_IPD:
 	case SQL_ATTR_CONNECTION_DEAD: {
-		duckdb::DiagRecord diag_rec("Read-only attribute.", SQLStateType::INVALID_ATTR_OPTION_ID,
-		                            dbc->GetDataSourceName());
-		return duckdb::SetDiagnosticRecord(dbc, SQL_ERROR, "SQLSetConnectAttr", diag_rec, dbc->GetDataSourceName());
+		return duckdb::SetDiagnosticRecord(dbc, SQL_ERROR, "SQLSetConnectAttr", "Read-only attribute.",
+		                                   SQLStateType::INVALID_ATTR_OPTION_ID, dbc->GetDataSourceName());
 	}
 	case SQL_ATTR_CONNECTION_TIMEOUT:
 		return SQL_SUCCESS;
 	case SQL_ATTR_CURRENT_CATALOG: {
 		if (dbc->conn) {
-			duckdb::DiagRecord diag_rec("Connection already established, the database name could not be set.",
-			                            SQLStateType::INVALID_CONNECTION_STR_ATTR, dbc->GetDataSourceName());
-			return duckdb::SetDiagnosticRecord(dbc, SQL_ERROR, "SQLSetConnectAttr", diag_rec, dbc->GetDataSourceName());
+			return duckdb::SetDiagnosticRecord(dbc, SQL_ERROR, "SQLSetConnectAttr",
+			                                   "Connection already established, the database name could not be set.",
+			                                   SQLStateType::INVALID_CONNECTION_STR_ATTR, dbc->GetDataSourceName());
 		}
 		if (string_length == SQL_NTS) {
 			dbc->sql_attr_current_catalog = std::string((char *)value_ptr);
@@ -203,10 +200,9 @@ SQLRETURN SQL_API SQLSetConnectAttr(SQLHDBC connection_handle, SQLINTEGER attrib
 		return SQL_SUCCESS;
 	}
 	default:
-		duckdb::DiagRecord diag_rec("Option value changed:" + std::to_string(attribute),
-		                            SQLStateType::OPTION_VALUE_CHANGED, dbc->GetDataSourceName());
-		return duckdb::SetDiagnosticRecord(dbc, SQL_SUCCESS_WITH_INFO, "SQLSetConnectAttr", diag_rec,
-		                                   dbc->GetDataSourceName());
+		return duckdb::SetDiagnosticRecord(dbc, SQL_SUCCESS_WITH_INFO, "SQLSetConnectAttr",
+		                                   "Option value changed:" + std::to_string(attribute),
+		                                   SQLStateType::OPTION_VALUE_CHANGED, dbc->GetDataSourceName());
 	}
 }
 
@@ -222,9 +218,9 @@ SQLRETURN SQL_API SQLGetInfo(SQLHDBC connection_handle, SQLUSMALLINT info_type, 
 			return SQL_ERROR;
 		}
 
-		duckdb::DiagRecord diag_rec("Invalid null value pointer for numeric info type.",
-		                            SQLStateType::INVALID_ATTR_VALUE, dbc->GetDataSourceName());
-		return duckdb::SetDiagnosticRecord(dbc, SQL_ERROR, "SQLGetInfo", diag_rec, dbc->GetDataSourceName());
+		return duckdb::SetDiagnosticRecord(dbc, SQL_ERROR, "SQLGetInfo",
+		                                   "Invalid null value pointer for numeric info type.",
+		                                   SQLStateType::INVALID_ATTR_VALUE, dbc->GetDataSourceName());
 	}
 
 	// Default strings: YES or NO
@@ -1002,10 +998,9 @@ SQLRETURN SQL_API SQLGetInfo(SQLHDBC connection_handle, SQLUSMALLINT info_type, 
 			return SQL_ERROR;
 		}
 
-		duckdb::DiagRecord diag_rec("Unrecognized attribute.", SQLStateType::INVALID_ATTR_OPTION_ID,
-		                            dbc->GetDataSourceName());
-		// returning SQL_SUCCESS, but with a record message
-		return duckdb::SetDiagnosticRecord(dbc, SQL_SUCCESS, "SQLGetInfo", diag_rec, dbc->GetDataSourceName());
+		// return SQL_SUCCESS, but with a record message
+		return duckdb::SetDiagnosticRecord(dbc, SQL_SUCCESS, "SQLGetInfo", "Unrecognized attribute.",
+		                                   SQLStateType::INVALID_ATTR_OPTION_ID, dbc->GetDataSourceName());
 	}
 } // end SQLGetInfo
 
@@ -1036,9 +1031,9 @@ SQLRETURN SQL_API SQLEndTran(SQLSMALLINT handle_type, SQLHANDLE handle, SQLSMALL
 			dbc->conn->Rollback();
 			return SQL_SUCCESS;
 		} catch (duckdb::Exception &ex) {
-			duckdb::DiagRecord diag_rec(std::string(ex.what()), SQLStateType::SQLENDTRAN_ASYNC_FUNCT_EXECUTION,
-			                            dbc->GetDataSourceName());
-			return duckdb::SetDiagnosticRecord(dbc, SQL_ERROR, "SQLEndTran", diag_rec, dbc->GetDataSourceName());
+			return duckdb::SetDiagnosticRecord(dbc, SQL_ERROR, "SQLEndTran", std::string(ex.what()),
+			                                   SQLStateType::SQLENDTRAN_ASYNC_FUNCT_EXECUTION,
+			                                   dbc->GetDataSourceName());
 		}
 	default:
 		return SQL_ERROR;

--- a/tools/odbc/driver.cpp
+++ b/tools/odbc/driver.cpp
@@ -114,9 +114,9 @@ SQLRETURN SQL_API SQLSetEnvAttr(SQLHENV environment_handle, SQLINTEGER attribute
 		case SQL_CP_ONE_PER_HENV:
 			return SQL_SUCCESS;
 		default:
-			duckdb::DiagRecord diag_rec("Connection pooling not supported: " + std::to_string(attribute),
-			                            SQLStateType::INVALID_ATTR_OPTION_ID, "Unknown DSN");
-			return duckdb::SetDiagnosticRecord(env, SQL_SUCCESS_WITH_INFO, "SQLSetConnectAttr", diag_rec, "");
+			return duckdb::SetDiagnosticRecord(env, SQL_SUCCESS_WITH_INFO, "SQLSetConnectAttr",
+			                                   "Connection pooling not supported: " + std::to_string(attribute),
+			                                   SQLStateType::INVALID_ATTR_OPTION_ID, "");
 		}
 	case SQL_ATTR_CP_MATCH:
 		env->error_messages.emplace_back("Optional feature not supported.");

--- a/tools/odbc/handle_functions.cpp
+++ b/tools/odbc/handle_functions.cpp
@@ -5,10 +5,13 @@
 
 #include <codecvt>
 
-SQLRETURN duckdb::SetDiagnosticRecord(OdbcHandle *handle, SQLRETURN ret, std::string component,
-                                      duckdb::DiagRecord diag_record, std::string data_source) {
-	handle->odbc_diagnostic->FormatDiagnosticMessage(diag_record, data_source, component);
-	handle->odbc_diagnostic->AddDiagRecord(diag_record);
+SQLRETURN duckdb::SetDiagnosticRecord(OdbcHandle *handle, const SQLRETURN &ret, const std::string &component,
+                                      const std::string &msg, const SQLStateType &sqlstate_type,
+                                      const std::string &server_name) {
+	DiagRecord diag_rec(msg, sqlstate_type, server_name);
+
+	handle->odbc_diagnostic->FormatDiagnosticMessage(diag_rec, server_name, component);
+	handle->odbc_diagnostic->AddDiagRecord(diag_rec);
 	return ret;
 }
 

--- a/tools/odbc/include/handle_functions.hpp
+++ b/tools/odbc/include/handle_functions.hpp
@@ -7,8 +7,9 @@
 
 namespace duckdb {
 
-SQLRETURN SetDiagnosticRecord(OdbcHandle *handle, SQLRETURN ret, std::string component, duckdb::DiagRecord diag_record,
-                              std::string data_source);
+SQLRETURN SetDiagnosticRecord(OdbcHandle *handle, const SQLRETURN &ret, const std::string &component,
+                              const std::string &msg, const SQLStateType &sqlstate_type,
+                              const std::string &server_name);
 SQLRETURN ConvertHandle(SQLHANDLE &handle, OdbcHandle *&hdl);
 SQLRETURN ConvertEnvironment(SQLHANDLE &environment_handle, OdbcHandleEnv *&env);
 SQLRETURN ConvertConnection(SQLHANDLE &connection_handle, OdbcHandleDbc *&dbc);

--- a/tools/odbc/odbc_fetch.cpp
+++ b/tools/odbc/odbc_fetch.cpp
@@ -307,7 +307,7 @@ SQLRETURN OdbcFetch::Fetch(OdbcHandleStmt *hstmt, SQLULEN fetch_orientation, SQL
 	} else {
 		// sql_desc_bind_type should be greater than 0 because it contains the length of the row to be fetched
 		D_ASSERT(hstmt->row_desc->ard->header.sql_desc_bind_type > 0);
-		if (!SQL_SUCCEEDED(duckdb::OdbcFetch::RowWise(nullptr))) {
+		if (!SQL_SUCCEEDED(duckdb::OdbcFetch::RowWise(hstmt))) {
 			hstmt->error_messages.emplace_back("Row-wise fetching failed.");
 			return SQL_ERROR;
 		}

--- a/tools/odbc/statement.cpp
+++ b/tools/odbc/statement.cpp
@@ -87,10 +87,9 @@ SQLRETURN SQL_API SQLSetStmtAttr(SQLHSTMT statement_handle, SQLINTEGER attribute
 	}
 	case SQL_ATTR_IMP_PARAM_DESC:
 	case SQL_ATTR_IMP_ROW_DESC: {
-		duckdb::DiagRecord diag_rec("Option value changed:" + std::to_string(attribute),
-		                            SQLStateType::INVALID_USE_AUTO_ALLOC_DESCRIPTOR, hstmt->dbc->GetDataSourceName());
-		return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "SQLSetStmtAttr", diag_rec,
-		                                   hstmt->dbc->GetDataSourceName());
+		return duckdb::SetDiagnosticRecord(
+		    hstmt, SQL_ERROR, "SQLSetStmtAttr", "Option value changed:" + std::to_string(attribute),
+		    SQLStateType::INVALID_USE_AUTO_ALLOC_DESCRIPTOR, hstmt->dbc->GetDataSourceName());
 	}
 	case SQL_ATTR_PARAM_BIND_OFFSET_PTR: {
 		hstmt->param_desc->SetBindOffesetPtr((SQLLEN *)value_ptr);
@@ -99,10 +98,9 @@ SQLRETURN SQL_API SQLSetStmtAttr(SQLHSTMT statement_handle, SQLINTEGER attribute
 	case SQL_ATTR_CONCURRENCY: {
 		SQLULEN value = (SQLULEN)(uintptr_t)value_ptr;
 		if (value != SQL_CONCUR_LOCK) {
-			duckdb::DiagRecord diag_rec("Option value changed:" + std::to_string(attribute),
-			                            SQLStateType::OPTION_VALUE_CHANGED, hstmt->dbc->GetDataSourceName());
-			return duckdb::SetDiagnosticRecord(hstmt, SQL_SUCCESS_WITH_INFO, "SQLSetStmtAttr", diag_rec,
-			                                   hstmt->dbc->GetDataSourceName());
+			return duckdb::SetDiagnosticRecord(hstmt, SQL_SUCCESS_WITH_INFO, "SQLSetStmtAttr",
+			                                   "Option value changed:" + std::to_string(attribute),
+			                                   SQLStateType::OPTION_VALUE_CHANGED, hstmt->dbc->GetDataSourceName());
 		}
 		return SQL_SUCCESS;
 	}
@@ -116,10 +114,9 @@ SQLRETURN SQL_API SQLSetStmtAttr(SQLHSTMT statement_handle, SQLINTEGER attribute
 			break;
 		default:
 			/* Invalid attribute value */
-			duckdb::DiagRecord diag_rec("Invalid attribute value: " + std::to_string(attribute),
-			                            SQLStateType::INVALID_ATTR_VALUE, hstmt->dbc->GetDataSourceName());
-			return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "SQLSetStmtAttr", diag_rec,
-			                                   hstmt->dbc->GetDataSourceName());
+			return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "SQLSetStmtAttr",
+			                                   "Invalid attribute value: " + std::to_string(attribute),
+			                                   SQLStateType::INVALID_ATTR_VALUE, hstmt->dbc->GetDataSourceName());
 		}
 		hstmt->retrieve_data = value;
 		return SQL_SUCCESS;
@@ -134,19 +131,17 @@ SQLRETURN SQL_API SQLSetStmtAttr(SQLHSTMT statement_handle, SQLINTEGER attribute
 			hstmt->odbc_fetcher->cursor_type = SQL_CURSOR_STATIC;
 			break;
 		default:
-			duckdb::DiagRecord diag_rec("Invalid attribute value:" + std::to_string(attribute),
-			                            SQLStateType::INVALID_ATTR_VALUE, hstmt->dbc->GetDataSourceName());
-			return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "SQLSetStmtAttr", diag_rec,
-			                                   hstmt->dbc->GetDataSourceName());
+			return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "SQLSetStmtAttr",
+			                                   "Invalid attribute value:" + std::to_string(attribute),
+			                                   SQLStateType::INVALID_ATTR_VALUE, hstmt->dbc->GetDataSourceName());
 		}
 		hstmt->odbc_fetcher->cursor_scrollable = value;
 		return SQL_SUCCESS;
 	}
 	default:
-		duckdb::DiagRecord diag_rec("Option value changed:" + std::to_string(attribute),
-		                            SQLStateType::OPTION_VALUE_CHANGED, hstmt->dbc->GetDataSourceName());
-		return duckdb::SetDiagnosticRecord(hstmt, SQL_SUCCESS_WITH_INFO, "SQLSetStmtAttr", diag_rec,
-		                                   hstmt->dbc->GetDataSourceName());
+		return duckdb::SetDiagnosticRecord(hstmt, SQL_SUCCESS_WITH_INFO, "SQLSetStmtAttr",
+		                                   "Option value changed:" + std::to_string(attribute),
+		                                   SQLStateType::OPTION_VALUE_CHANGED, hstmt->dbc->GetDataSourceName());
 	}
 
 	return SQL_SUCCESS;
@@ -286,10 +281,9 @@ SQLRETURN SQL_API SQLGetStmtAttr(SQLHSTMT statement_handle, SQLINTEGER attribute
 	case SQL_ATTR_SIMULATE_CURSOR:
 	case SQL_ATTR_USE_BOOKMARKS:
 	default:
-		duckdb::DiagRecord diag_rec("Unsupported attribute type:" + std::to_string(attribute),
-		                            SQLStateType::INVALID_ATTR_OPTION_ID, hstmt->dbc->GetDataSourceName());
-		return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "SQLSetStmtAttr", diag_rec,
-		                                   hstmt->dbc->GetDataSourceName());
+		return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "SQLSetStmtAttr",
+		                                   "Unsupported attribute type:" + std::to_string(attribute),
+		                                   SQLStateType::INVALID_ATTR_OPTION_ID, hstmt->dbc->GetDataSourceName());
 	}
 }
 
@@ -446,10 +440,8 @@ static SQLRETURN GetColAttribute(SQLHSTMT statement_handle, SQLUSMALLINT column_
 	}
 
 	if (column_number < 1 || column_number > hstmt->stmt->GetTypes().size()) {
-		duckdb::DiagRecord diag_rec("Column number out of range", SQLStateType::INVALID_DESC_INDEX,
-		                            hstmt->dbc->GetDataSourceName());
-		return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "GetColAttribute", diag_rec,
-		                                   hstmt->dbc->GetDataSourceName());
+		return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "GetColAttribute", "Column number out of range",
+		                                   SQLStateType::INVALID_DESC_INDEX, hstmt->dbc->GetDataSourceName());
 	}
 
 	duckdb::idx_t col_idx = column_number - 1;
@@ -458,10 +450,8 @@ static SQLRETURN GetColAttribute(SQLHSTMT statement_handle, SQLUSMALLINT column_
 	switch (field_identifier) {
 	case SQL_DESC_LABEL: {
 		if (buffer_length <= 0) {
-			duckdb::DiagRecord diag_rec("Inadequate buffer length", SQLStateType::INVALID_STR_BUFF_LENGTH,
-			                            hstmt->dbc->GetDataSourceName());
-			return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "GetColAttribute", diag_rec,
-			                                   hstmt->dbc->GetDataSourceName());
+			return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "GetColAttribute", "Inadequate buffer length",
+			                                   SQLStateType::INVALID_STR_BUFF_LENGTH, hstmt->dbc->GetDataSourceName());
 		}
 
 		auto col_name = hstmt->stmt->GetNames()[col_idx];
@@ -497,10 +487,8 @@ static SQLRETURN GetColAttribute(SQLHSTMT statement_handle, SQLUSMALLINT column_
 		return SQL_SUCCESS;
 	case SQL_DESC_TYPE_NAME: {
 		if (buffer_length <= 0) {
-			duckdb::DiagRecord diag_rec("Inadequate buffer length", SQLStateType::INVALID_STR_BUFF_LENGTH,
-			                            hstmt->dbc->GetDataSourceName());
-			return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "GetColAttribute", diag_rec,
-			                                   hstmt->dbc->GetDataSourceName());
+			return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "GetColAttribute", "Inadequate buffer length",
+			                                   SQLStateType::INVALID_STR_BUFF_LENGTH, hstmt->dbc->GetDataSourceName());
 		}
 
 		auto internal_type = hstmt->stmt->GetTypes()[col_idx].InternalType();
@@ -518,10 +506,8 @@ static SQLRETURN GetColAttribute(SQLHSTMT statement_handle, SQLUSMALLINT column_
 	case SQL_DESC_DISPLAY_SIZE: {
 		auto ret = duckdb::ApiInfo::GetColumnSize(hstmt->stmt->GetTypes()[col_idx], numeric_attribute_ptr);
 		if (ret == SQL_ERROR) {
-			duckdb::DiagRecord diag_rec("Unsupported type for display size", SQLStateType::INVALID_PARAMETER_TYPE,
-			                            hstmt->dbc->GetDataSourceName());
-			return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "GetColAttribute", diag_rec,
-			                                   hstmt->dbc->GetDataSourceName());
+			return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "GetColAttribute", "Unsupported type for display size",
+			                                   SQLStateType::INVALID_PARAMETER_TYPE, hstmt->dbc->GetDataSourceName());
 		}
 		return SQL_SUCCESS;
 	}
@@ -619,10 +605,8 @@ static SQLRETURN GetColAttribute(SQLHSTMT statement_handle, SQLUSMALLINT column_
 		return SQL_SUCCESS;
 	}
 	default:
-		duckdb::DiagRecord diag_rec("Unsupported attribute type", SQLStateType::INVALID_ATTR_OPTION_ID,
-		                            hstmt->dbc->GetDataSourceName());
-		return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "GetColAttribute", diag_rec,
-		                                   hstmt->dbc->GetDataSourceName());
+		return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "GetColAttribute", "Unsupported attribute type",
+		                                   SQLStateType::INVALID_ATTR_OPTION_ID, hstmt->dbc->GetDataSourceName());
 	}
 }
 

--- a/tools/odbc/statement_functions.cpp
+++ b/tools/odbc/statement_functions.cpp
@@ -59,10 +59,6 @@ SQLRETURN duckdb::PrepareStmt(SQLHSTMT statement_handle, SQLCHAR *statement_text
 
 	auto query = OdbcUtils::ReadString(statement_text, text_length);
 	hstmt->stmt = hstmt->dbc->conn->Prepare(query);
-	if (hstmt->stmt->data && !hstmt->stmt->GetStatementProperties().bound_all_parameters) {
-		return (SetDiagnosticRecord(hstmt, SQL_ERROR, "PrepareStmt", "Not all parameters are bound",
-		                            SQLStateType::SYNTAX_ERROR_OR_ACCESS_VIOLATION, hstmt->dbc->GetDataSourceName()));
-	}
 	if (hstmt->stmt->HasError()) {
 		return (SetDiagnosticRecord(hstmt, SQL_ERROR, "PrepareStmt", hstmt->stmt->error.Message(),
 		                            SQLStateType::SYNTAX_ERROR_OR_ACCESS_VIOLATION, hstmt->dbc->GetDataSourceName()));

--- a/tools/odbc/statement_functions.cpp
+++ b/tools/odbc/statement_functions.cpp
@@ -59,7 +59,7 @@ SQLRETURN duckdb::PrepareStmt(SQLHSTMT statement_handle, SQLCHAR *statement_text
 
 	auto query = OdbcUtils::ReadString(statement_text, text_length);
 	hstmt->stmt = hstmt->dbc->conn->Prepare(query);
-	if (!hstmt->stmt->GetStatementProperties().bound_all_parameters) {
+	if (hstmt->stmt->data && !hstmt->stmt->GetStatementProperties().bound_all_parameters) {
 		DiagRecord diag_rec("Not all parameters are bound", SQLStateType::SYNTAX_ERROR_OR_ACCESS_VIOLATION,
 		                    hstmt->dbc->GetDataSourceName());
 		return (SetDiagnosticRecord(hstmt, SQL_ERROR, "PrepareStmt", diag_rec, hstmt->dbc->GetDataSourceName()));

--- a/tools/odbc/statement_functions.cpp
+++ b/tools/odbc/statement_functions.cpp
@@ -60,14 +60,12 @@ SQLRETURN duckdb::PrepareStmt(SQLHSTMT statement_handle, SQLCHAR *statement_text
 	auto query = OdbcUtils::ReadString(statement_text, text_length);
 	hstmt->stmt = hstmt->dbc->conn->Prepare(query);
 	if (hstmt->stmt->data && !hstmt->stmt->GetStatementProperties().bound_all_parameters) {
-		DiagRecord diag_rec("Not all parameters are bound", SQLStateType::SYNTAX_ERROR_OR_ACCESS_VIOLATION,
-		                    hstmt->dbc->GetDataSourceName());
-		return (SetDiagnosticRecord(hstmt, SQL_ERROR, "PrepareStmt", diag_rec, hstmt->dbc->GetDataSourceName()));
+		return (SetDiagnosticRecord(hstmt, SQL_ERROR, "PrepareStmt", "Not all parameters are bound",
+		                            SQLStateType::SYNTAX_ERROR_OR_ACCESS_VIOLATION, hstmt->dbc->GetDataSourceName()));
 	}
 	if (hstmt->stmt->HasError()) {
-		DiagRecord diag_rec(hstmt->stmt->error.Message(), SQLStateType::SYNTAX_ERROR_OR_ACCESS_VIOLATION,
-		                    hstmt->dbc->GetDataSourceName());
-		return (SetDiagnosticRecord(hstmt, SQL_ERROR, "PrepareStmt", diag_rec, hstmt->dbc->GetDataSourceName()));
+		return (SetDiagnosticRecord(hstmt, SQL_ERROR, "PrepareStmt", hstmt->stmt->error.Message(),
+		                            SQLStateType::SYNTAX_ERROR_OR_ACCESS_VIOLATION, hstmt->dbc->GetDataSourceName()));
 	}
 
 	hstmt->param_desc->ResetParams(hstmt->stmt->n_param);
@@ -123,10 +121,8 @@ SQLRETURN duckdb::SingleExecuteStmt(duckdb::OdbcHandleStmt *stmt) {
 	stmt->res = stmt->stmt->Execute(values);
 
 	if (stmt->res->HasError()) {
-		duckdb::DiagRecord diag_rec(stmt->res->GetError(), duckdb::SQLStateType::GENERAL_ERROR,
-		                            stmt->dbc->GetDataSourceName());
-		return duckdb::SetDiagnosticRecord(stmt, SQL_ERROR, "SingleExecuteStmt", diag_rec,
-		                                   stmt->dbc->GetDataSourceName());
+		return duckdb::SetDiagnosticRecord(stmt, SQL_ERROR, "SingleExecuteStmt", stmt->res->GetError(),
+		                                   duckdb::SQLStateType::GENERAL_ERROR, stmt->dbc->GetDataSourceName());
 	}
 	stmt->open = true;
 	if (ret == SQL_STILL_EXECUTING) {
@@ -154,8 +150,8 @@ static SQLRETURN ValidateType(LogicalTypeId input, LogicalTypeId expected, duckd
 	if (input != expected) {
 		string msg = "Type mismatch error: received " + EnumUtil::ToString(input) + ", but expected " +
 		             EnumUtil::ToString(expected);
-		duckdb::DiagRecord diag_rec(msg, SQLStateType::RESTRICTED_DATA_TYPE, stmt->dbc->GetDataSourceName());
-		return duckdb::SetDiagnosticRecord(stmt, SQL_ERROR, "ValidateType", diag_rec, stmt->dbc->GetDataSourceName());
+		return duckdb::SetDiagnosticRecord(stmt, SQL_ERROR, "ValidateType", msg, SQLStateType::RESTRICTED_DATA_TYPE,
+		                                   stmt->dbc->GetDataSourceName());
 	}
 	return SQL_SUCCESS;
 }
@@ -165,8 +161,8 @@ static SQLRETURN ThrowInvalidCast(const string &component, const LogicalType &fr
 	string msg = "Not implemented Error: Unimplemented type for cast (" + from_type.ToString() + " -> " +
 	             to_type.ToString() + ")";
 
-	duckdb::DiagRecord diag_rec(msg, SQLStateType::INVALID_DATATIME_FORMAT, stmt->dbc->GetDataSourceName());
-	return duckdb::SetDiagnosticRecord(stmt, SQL_ERROR, component, diag_rec, stmt->dbc->GetDataSourceName());
+	return duckdb::SetDiagnosticRecord(stmt, SQL_ERROR, component, msg, SQLStateType::INVALID_DATATIME_FORMAT,
+	                                   stmt->dbc->GetDataSourceName());
 }
 
 template <class SRC, class DEST = SRC>
@@ -183,10 +179,8 @@ static SQLRETURN GetInternalValue(duckdb::OdbcHandleStmt *stmt, const duckdb::Va
 		}
 		return SQL_SUCCESS;
 	} catch (duckdb::Exception &ex) {
-		duckdb::DiagRecord diag_rec(std::string(ex.what()), SQLStateType::RESTRICTED_DATA_TYPE,
-		                            stmt->dbc->GetDataSourceName());
-		return duckdb::SetDiagnosticRecord(stmt, SQL_ERROR, "GetInternalValue", diag_rec,
-		                                   stmt->dbc->GetDataSourceName());
+		return duckdb::SetDiagnosticRecord(stmt, SQL_ERROR, "GetInternalValue", std::string(ex.what()),
+		                                   SQLStateType::RESTRICTED_DATA_TYPE, stmt->dbc->GetDataSourceName());
 	}
 }
 
@@ -198,10 +192,8 @@ static bool CastTimestampValue(duckdb::OdbcHandleStmt *stmt, const duckdb::Value
 		target = CAST_OP::template Operation<timestamp_t, TARGET_TYPE>(timestamp);
 		return true;
 	} catch (duckdb::Exception &ex) {
-		duckdb::DiagRecord diag_rec(std::string(ex.what()), SQLStateType::INVALID_DATATIME_FORMAT,
-		                            stmt->dbc->GetDataSourceName());
-		return duckdb::SetDiagnosticRecord(stmt, SQL_ERROR, "CastTimestampValue", diag_rec,
-		                                   stmt->dbc->GetDataSourceName());
+		return duckdb::SetDiagnosticRecord(stmt, SQL_ERROR, "CastTimestampValue", std::string(ex.what()),
+		                                   SQLStateType::INVALID_DATATIME_FORMAT, stmt->dbc->GetDataSourceName());
 	}
 }
 
@@ -209,9 +201,8 @@ SQLRETURN GetVariableValue(const std::string &val_str, SQLUSMALLINT col_idx, duc
                            SQLPOINTER target_value_ptr, SQLLEN buffer_length, SQLLEN *str_len_or_ind_ptr) {
 	if (!target_value_ptr) {
 		if (OdbcUtils::SetStringValueLength(val_str, str_len_or_ind_ptr) == SQL_SUCCESS) {
-			duckdb::DiagRecord diag_rec("Could not set str_len_or_ind_ptr",
-			                            duckdb::SQLStateType::INVALID_STR_BUFF_LENGTH, stmt->dbc->GetDataSourceName());
-			return duckdb::SetDiagnosticRecord(stmt, SQL_ERROR, "GetVariableValue", diag_rec,
+			return duckdb::SetDiagnosticRecord(stmt, SQL_ERROR, "GetVariableValue", "Could not set str_len_or_ind_ptr",
+			                                   duckdb::SQLStateType::INVALID_STR_BUFF_LENGTH,
 			                                   stmt->dbc->GetDataSourceName());
 		}
 		return SQL_SUCCESS;
@@ -446,9 +437,8 @@ SQLRETURN duckdb::GetDataStmtResult(OdbcHandleStmt *hstmt, SQLUSMALLINT col_or_p
 			auto str_input = string_t(val_str);
 			if (!TryCast::Operation<string_t, date_t>(str_input, date)) {
 				auto msg = CastExceptionText<string_t, date_t>(str_input);
-				duckdb::DiagRecord diag_rec(msg, SQLStateType::RESTRICTED_DATA_TYPE, hstmt->dbc->GetDataSourceName());
-				return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "GetDataStmtResult", diag_rec,
-				                                   hstmt->dbc->GetDataSourceName());
+				return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "GetDataStmtResult", msg,
+				                                   SQLStateType::RESTRICTED_DATA_TYPE, hstmt->dbc->GetDataSourceName());
 			}
 			break;
 		}
@@ -503,9 +493,8 @@ SQLRETURN duckdb::GetDataStmtResult(OdbcHandleStmt *hstmt, SQLUSMALLINT col_or_p
 			auto str_input = string_t(val_str);
 			if (!TryCast::Operation<string_t, dtime_t>(str_input, time)) {
 				auto msg = CastExceptionText<string_t, dtime_t>(str_input);
-				duckdb::DiagRecord diag_rec(msg, SQLStateType::RESTRICTED_DATA_TYPE, hstmt->dbc->GetDataSourceName());
-				return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "GetDataStmtResult", diag_rec,
-				                                   hstmt->dbc->GetDataSourceName());
+				return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "GetDataStmtResult", msg,
+				                                   SQLStateType::RESTRICTED_DATA_TYPE, hstmt->dbc->GetDataSourceName());
 			}
 			break;
 		}
@@ -544,9 +533,8 @@ SQLRETURN duckdb::GetDataStmtResult(OdbcHandleStmt *hstmt, SQLUSMALLINT col_or_p
 			auto date_input = val.GetValue<date_t>();
 			if (!TryCast::Operation<date_t, timestamp_t>(date_input, timestamp)) {
 				auto msg = CastExceptionText<date_t, timestamp_t>(date_input);
-				duckdb::DiagRecord diag_rec(msg, SQLStateType::RESTRICTED_DATA_TYPE, hstmt->dbc->GetDataSourceName());
-				return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "GetDataStmtResult", diag_rec,
-				                                   hstmt->dbc->GetDataSourceName());
+				return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "GetDataStmtResult", msg,
+				                                   SQLStateType::RESTRICTED_DATA_TYPE, hstmt->dbc->GetDataSourceName());
 			}
 			break;
 		}
@@ -555,9 +543,8 @@ SQLRETURN duckdb::GetDataStmtResult(OdbcHandleStmt *hstmt, SQLUSMALLINT col_or_p
 			auto str_input = string_t(val_str);
 			if (!TryCast::Operation<string_t, timestamp_t>(str_input, timestamp)) {
 				auto msg = CastExceptionText<string_t, timestamp_t>(str_input);
-				duckdb::DiagRecord diag_rec(msg, SQLStateType::RESTRICTED_DATA_TYPE, hstmt->dbc->GetDataSourceName());
-				return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "GetDataStmtResult", diag_rec,
-				                                   hstmt->dbc->GetDataSourceName());
+				return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "GetDataStmtResult", msg,
+				                                   SQLStateType::RESTRICTED_DATA_TYPE, hstmt->dbc->GetDataSourceName());
 			}
 			break;
 		}
@@ -800,10 +787,8 @@ SQLRETURN duckdb::GetDataStmtResult(OdbcHandleStmt *hstmt, SQLUSMALLINT col_or_p
 	}
 	// TODO other types
 	default:
-		duckdb::DiagRecord diag_rec("Unsupported type", SQLStateType::RESTRICTED_DATA_TYPE,
-		                            hstmt->dbc->GetDataSourceName());
-		return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "GetDataStmtResult", diag_rec,
-		                                   hstmt->dbc->GetDataSourceName());
+		return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "GetDataStmtResult", "Unsupported type",
+		                                   SQLStateType::RESTRICTED_DATA_TYPE, hstmt->dbc->GetDataSourceName());
 	} // end switch "(target_type)": SQL_C_TYPE_TIMESTAMP
 }
 

--- a/tools/odbc/statement_functions.cpp
+++ b/tools/odbc/statement_functions.cpp
@@ -59,6 +59,11 @@ SQLRETURN duckdb::PrepareStmt(SQLHSTMT statement_handle, SQLCHAR *statement_text
 
 	auto query = OdbcUtils::ReadString(statement_text, text_length);
 	hstmt->stmt = hstmt->dbc->conn->Prepare(query);
+	if (!hstmt->stmt->GetStatementProperties().bound_all_parameters) {
+		DiagRecord diag_rec("Not all parameters are bound", SQLStateType::SYNTAX_ERROR_OR_ACCESS_VIOLATION,
+		                    hstmt->dbc->GetDataSourceName());
+		return (SetDiagnosticRecord(hstmt, SQL_ERROR, "PrepareStmt", diag_rec, hstmt->dbc->GetDataSourceName()));
+	}
 	if (hstmt->stmt->HasError()) {
 		DiagRecord diag_rec(hstmt->stmt->error.Message(), SQLStateType::SYNTAX_ERROR_OR_ACCESS_VIOLATION,
 		                    hstmt->dbc->GetDataSourceName());

--- a/tools/odbc/test/tests/select.cpp
+++ b/tools/odbc/test/tests/select.cpp
@@ -50,16 +50,6 @@ TEST_CASE("Test Select Statement", "[odbc]") {
 		DATA_CHECK(hstmt, i, std::to_string(i).c_str());
 	}
 
-	// SELECT $x; should throw error
-	SQLRETURN ret = SQLExecDirect(hstmt, ConvertToSQLCHAR("SELECT $x"), SQL_NTS);
-	REQUIRE(ret == SQL_ERROR);
-	std::string state;
-	std::string message;
-	ACCESS_DIAGNOSTIC(state, message, hstmt, SQL_HANDLE_STMT);
-	REQUIRE(state == "42000");
-	REQUIRE(message == "ODBC_DuckDB->PrepareStmt\n"
-	                   "Not all parameters are bound");
-
 	// Free the statement handle
 	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
 	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);

--- a/tools/odbc/test/tests/select.cpp
+++ b/tools/odbc/test/tests/select.cpp
@@ -1,7 +1,5 @@
 #include "../common.h"
 
-#include <iostream>
-
 using namespace odbc_test;
 
 TEST_CASE("Test Select Statement", "[odbc]") {
@@ -52,16 +50,15 @@ TEST_CASE("Test Select Statement", "[odbc]") {
 		DATA_CHECK(hstmt, i, std::to_string(i).c_str());
 	}
 
-	// SELECT $x
+	// SELECT $x; should throw error
 	SQLRETURN ret = SQLExecDirect(hstmt, ConvertToSQLCHAR("SELECT $x"), SQL_NTS);
 	REQUIRE(ret == SQL_ERROR);
 	std::string state;
 	std::string message;
 	ACCESS_DIAGNOSTIC(state, message, hstmt, SQL_HANDLE_STMT);
-	std::cout << "State: " << state << std::endl;
-	std::cout << "Message: " << message << std::endl;
-
-	//	EXECUTE_AND_CHECK("SQLExecDirect (SELECT $x)", SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT $x"), SQL_NTS);
+	REQUIRE(state == "42000");
+	REQUIRE(message == "ODBC_DuckDB->PrepareStmt\n"
+	                   "Not all parameters are bound");
 
 	// Free the statement handle
 	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);

--- a/tools/odbc/test/tests/select.cpp
+++ b/tools/odbc/test/tests/select.cpp
@@ -52,6 +52,17 @@ TEST_CASE("Test Select Statement", "[odbc]") {
 		DATA_CHECK(hstmt, i, std::to_string(i).c_str());
 	}
 
+	// SELECT $x
+	SQLRETURN ret = SQLExecDirect(hstmt, ConvertToSQLCHAR("SELECT $x"), SQL_NTS);
+	REQUIRE(ret == SQL_ERROR);
+	std::string state;
+	std::string message;
+	ACCESS_DIAGNOSTIC(state, message, hstmt, SQL_HANDLE_STMT);
+	std::cout << "State: " << state << std::endl;
+	std::cout << "Message: " << message << std::endl;
+
+	//	EXECUTE_AND_CHECK("SQLExecDirect (SELECT $x)", SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT $x"), SQL_NTS);
+
 	// Free the statement handle
 	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
 	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);


### PR DESCRIPTION
Small reformatting that simplifies the calling of the diagnostics function, shouldn't change any functionality.

Also in a previous PR when reformating `OdbcFetch::RowWise` I accidentally passed `nullptr` instead of `hstmt`.  This is fixed now.