### PR TITLE
Remove Node 15 from supported versions

### DIFF
--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -70,7 +70,8 @@ jobs:
       DUCKDB_NODE_BUILD_CACHE: 0
     strategy:
       matrix:
-        node: [ '10', '12', '14', '15', '16', '17', '18', '19', '20' ]
+        # node.js current support policy to be found at https://github.com/duckdb/duckdb/tree/master/tools/nodejs#Supported-Node-versions
+        node: [ '10', '12', '14', '16', '17', '18', '19', '20' ]
         target_arch: [ x64, arm64 ]
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}
@@ -83,9 +84,6 @@ jobs:
             target_arch: x64
           - isRelease: false
             node: 14
-            target_arch: x64
-          - isRelease: false
-            node: 15
             target_arch: x64
           - isRelease: false
             node: 16
@@ -107,9 +105,6 @@ jobs:
             target_arch: arm64
           - isRelease: false
             node: 14
-            target_arch: arm64
-          - isRelease: false
-            node: 15
             target_arch: arm64
           - isRelease: false
             node: 16
@@ -188,7 +183,7 @@ jobs:
     strategy:
       matrix:
         target_arch: [ x64, arm64 ]
-        node: [ '10', '12', '14', '15', '16', '17', '18', '19', '20' ]
+        node: [ '10', '12', '14', '16', '17', '18', '19', '20' ]
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}
         exclude:
@@ -198,8 +193,6 @@ jobs:
             node: 12
           - isRelease: false
             node: 14
-          - isRelease: false
-            node: 15
           - isRelease: false
             node: 16
           - isRelease: false
@@ -212,8 +205,6 @@ jobs:
             node: 12
           - target_arch: arm64
             node: 14
-          - target_arch: arm64
-            node: 15
         # these older versions of NodeJS don't have M1 support
 
     env:
@@ -269,7 +260,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [ '10', '12', '14', '15', '16', '17', '18', '19', '20' ]
+        node: [ '10', '12', '14', '16', '17', '18', '19', '20' ]
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}
         exclude:
@@ -279,8 +270,6 @@ jobs:
             node: 12
           - isRelease: false
             node: 14
-          - isRelease: false
-            node: 15
           - isRelease: false
             node: 16
           - isRelease: false

--- a/scripts/node_build.sh
+++ b/scripts/node_build.sh
@@ -9,11 +9,6 @@ cd tools/nodejs
 make clean
 ./configure
 
-if [[ "$1" == "15" ]] ; then
-  # force upgrade npm's internal copy of node-gyp
-  npm explore npm/node_modules/@npmcli/run-script -g -- npm_config_global=false npm install node-gyp@latest
-fi
-
 npm install --build-from-source --target_arch="$TARGET_ARCH"
 
 ./node_modules/.bin/node-pre-gyp reveal --target_arch="$TARGET_ARCH"

--- a/tools/nodejs/README.md
+++ b/tools/nodejs/README.md
@@ -100,6 +100,13 @@ var stmt = con.prepare('select ?::INTEGER as fortytwo', function(err, stmt) {
 });
 ```
 
+## Supported Node versions
+We actively support only LTS and In-Support Node versions, as per July 2023, they are: Node 16, Node 18 and Node 20.
+Release schedule for Node.js can be checked here: https://github.com/nodejs/release#release-schedule.
+
+We currently bundle and test DuckDB also for Node 10, 12, 14, 17 and 19. We plan of going so going forward as long as the tooling supports it.
+As per July 2023, Node 15 has been removed from the supported versions.
+
 ## Development
 
 ### First install:


### PR DESCRIPTION
Added note to tools/nodejs/README's about node support policy

Also revert 4aa0b161dc6a154afa2943e50b928f05c33b8d9f, that had some Node 15-only fix that's not applicable anymore