### PR TITLE
fix(jdbc): allow retrieving data from a prepared statement even on bind failure

### DIFF
--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
@@ -116,10 +116,10 @@ public class DuckDBResultSet implements ResultSet {
 		if (isClosed()) {
 			throw new SQLException("ResultSet was closed");
 		}
-		if (columnIndex < 1 || columnIndex > meta.column_count) {
+		int column_count = this.current_chunk.length;
+		if (column_count != 0 && (columnIndex < 1 || columnIndex > column_count)) {
 			throw new SQLException("Column index out of bounds");
 		}
-
 	}
 
 	/**


### PR DESCRIPTION
This is only a partial fix for #8115 

I don't really know enough about the binder to fix the various issues there, but this should allow people to read result sets at least