### PR TITLE
(julia) fix show for query result

### DIFF
--- a/tools/juliapkg/src/result.jl
+++ b/tools/juliapkg/src/result.jl
@@ -833,4 +833,4 @@ DBInterface.execute(con::Connection, sql::AbstractString) = DBInterface.execute(
 DBInterface.execute(db::DB, sql::AbstractString, result_type::Type) =
     DBInterface.execute(db.main_connection, sql, result_type)
 
-Base.show(io::IO, result::DuckDB.QueryResult) = print(io, Tables.rows(result))
+Base.show(io::IO, result::DuckDB.QueryResult) = print(io, Tables.columntable(result))


### PR DESCRIPTION
recent improvements in DuckDB.jl by @aplavin introduced a bug during interactive REPL usage wherein trying to display a `QueryResult` resulted in an error

```julia
Error showing value of type DuckDB.QueryResult:
ERROR: StackOverflowError:
Stacktrace:
     [1] print(io::IOContext{Base.TTY}, x::DuckDB.QueryResult)
       @ Base .\strings\io.jl:32
     [2] show(io::IOContext{Base.TTY}, result::DuckDB.QueryResult)
       @ DuckDB C:\Users\beasont\.julia\packages\DuckDB\Mp79X\src\result.jl:836
     [3] print(io::IOContext{Base.TTY}, x::DuckDB.QueryResult)
       @ Base .\strings\io.jl:35
--- the last 2 lines are repeated 7676 more times ---
 [15356] show
       @ C:\Users\beasont\.julia\packages\DuckDB\Mp79X\src\result.jl:836 [inlined]
 ...
```

Here I simply fix it so that it does not error.

Note that the changes introduced previously also change the printing behavior (it is no longer displayed as a table). If this change is desired, we could use PrettyTables.jl (which is what DataFrames.jl uses under the hood) to pretty-print tables here as well.