### PR TITLE
Fixes managed ptrs

### DIFF
--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -262,7 +262,7 @@ unique_ptr<ResponseWrapper> HTTPFileSystem::GetRequest(FileHandle &handle, strin
 				    hfs.state->total_bytes_received += data_length;
 			    }
 			    if (!cached_file.data) {
-				    cached_file.data = std::shared_ptr<char>(new char[data_length], std::default_delete<char[]>());
+				    cached_file.data = std::shared_ptr<char[]>(new char[data_length], std::default_delete<char[]>());
 				    hfs.length = data_length;
 				    cached_file.capacity = data_length;
 				    memcpy(cached_file.data.get(), data, data_length);
@@ -274,7 +274,7 @@ unique_ptr<ResponseWrapper> HTTPFileSystem::GetRequest(FileHandle &handle, strin
 				    // Gotta eat your beans
 				    if (new_capacity != cached_file.capacity) {
 					    auto new_hfs_data =
-					        std::shared_ptr<char>(new char[new_capacity], std::default_delete<char[]>());
+					        std::shared_ptr<char[]>(new char[new_capacity], std::default_delete<char[]>());
 					    // copy the old data
 					    memcpy(new_hfs_data.get(), cached_file.data.get(), hfs.length);
 					    cached_file.capacity = new_capacity;

--- a/src/include/duckdb/common/helper.hpp
+++ b/src/include/duckdb/common/helper.hpp
@@ -72,17 +72,17 @@ make_unsafe_uniq(_Args&&... __args)
 }
 
 template<class _Tp>
-inline unique_ptr<_Tp[], std::default_delete<_Tp>, true>
+inline unique_ptr<_Tp[], std::default_delete<_Tp[]>, true>
 make_uniq_array(size_t __n)
 {
-    return unique_ptr<_Tp[], std::default_delete<_Tp>, true>(new _Tp[__n]());
+    return unique_ptr<_Tp[], std::default_delete<_Tp[]>, true>(new _Tp[__n]());
 }
 
 template<class _Tp>
-inline unique_ptr<_Tp[], std::default_delete<_Tp>, false>
+inline unique_ptr<_Tp[], std::default_delete<_Tp[]>, false>
 make_unsafe_uniq_array(size_t __n)
 {
-    return unique_ptr<_Tp[], std::default_delete<_Tp>, false>(new _Tp[__n]());
+    return unique_ptr<_Tp[], std::default_delete<_Tp[]>, false>(new _Tp[__n]());
 }
 
 template<class _Tp, class... _Args>

--- a/src/include/duckdb/common/http_state.hpp
+++ b/src/include/duckdb/common/http_state.hpp
@@ -18,7 +18,7 @@ namespace duckdb {
 
 struct CachedFile {
 	//! Cached Data
-	shared_ptr<char> data;
+	shared_ptr<char[]> data;
 	//! Data capacity
 	uint64_t capacity = 0;
 	//! If we finished downloading the file

--- a/src/include/duckdb/common/unique_ptr.hpp
+++ b/src/include/duckdb/common/unique_ptr.hpp
@@ -74,10 +74,10 @@ public:
 };
 
 template <typename T>
-using unique_array = unique_ptr<T[], std::default_delete<T>, true>;
+using unique_array = unique_ptr<T[]>;
 
 template <typename T>
-using unsafe_unique_array = unique_ptr<T[], std::default_delete<T>, false>;
+using unsafe_unique_array = unique_ptr<T[], std::default_delete<T[]>, false>;
 
 template <typename T>
 using unsafe_unique_ptr = unique_ptr<T, std::default_delete<T>, false>;


### PR DESCRIPTION
While looking around in the httpfs extension I have found some code that was not obvious to read, exploration ended with finding a couple of independent small problems somehow related to type safety of unique_ptr / shared_ptr and their deleters.
I don't think either of them has any real effect in current code, given that they sort of cancelled out between each other, but given that I stumbled upon them it can as well fix them.

Problems were:
- shared_ptr<char> holding a pointer to char[]
- unsafe_unique_array and unique_array having explicit deleter with the wrong type (T instead of T[])
- always using default_deleter for unique_ptr<T[]>, independently of what was actually passed in

Commits 2+3 seems trivial to justify, commit 1 is potentially more complex, might require a proper second look.