### PR TITLE
CI: Fix typo in LinuxRelease.yml

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -138,7 +138,7 @@ jobs:
 
      - uses: ./.github/actions/ubuntu_18_setup
        with:
-        cccache: 1
+        ccache: 1
         aarch64_cross_compile: 1
 
      - name: Install unixODBC


### PR DESCRIPTION
Raised in https://github.com/duckdb/duckdb/discussions/8260

This was obvious to fix as it was just a typo.
Other warnings are all tied somehow to vcpkg details or rework connected to introduction of vcpkg, so eventually @samansmink can eventually have a proper look (with very low priority).