### PR TITLE
Remove dangerous overload of cpp11::warning()

### DIFF
--- a/tools/rpkg/inst/include/cpp11/protect.hpp
+++ b/tools/rpkg/inst/include/cpp11/protect.hpp
@@ -265,14 +265,10 @@ void stop [[noreturn]] (const std::string& fmt_arg, Args&&... args) {
   safe.noreturn(Rf_errorcall)(R_NilValue, "%s", msg.c_str());
 }
 
-template <typename... Args>
-void warning(const char* fmt_arg, Args&&... args) {
-  std::string msg = fmt::format(fmt_arg, std::forward<Args>(args)...);
-  safe[Rf_warningcall](R_NilValue, "%s", msg.c_str());
-}
+// Always making copy of string to avoid weird unwind behavior.
 
 template <typename... Args>
-void warning(const std::string& fmt_arg, Args&&... args) {
+void warning(const std::string fmt_arg, Args&&... args) {
   std::string msg = fmt::format(fmt_arg, std::forward<Args>(args)...);
   safe[Rf_warningcall](R_NilValue, "%s", msg.c_str());
 }
@@ -287,13 +283,10 @@ void stop [[noreturn]] (const std::string& fmt, Args... args) {
   safe.noreturn(Rf_errorcall)(R_NilValue, fmt.c_str(), args...);
 }
 
-template <typename... Args>
-void warning(const char* fmt, Args... args) {
-  safe[Rf_warningcall](R_NilValue, fmt, args...);
-}
+// Always making copy of string to avoid weird unwind behavior.
 
 template <typename... Args>
-void warning(const std::string& fmt, Args... args) {
+void warning(const std::string fmt, Args... args) {
   safe[Rf_warningcall](R_NilValue, fmt.c_str(), args...);
 }
 #endif

--- a/tools/rpkg/src/connection.cpp
+++ b/tools/rpkg/src/connection.cpp
@@ -3,7 +3,7 @@
 using namespace duckdb;
 
 void duckdb::ConnDeleter(ConnWrapper *conn) {
-	cpp11::warning(std::string("Connection is garbage-collected, use dbDisconnect() to avoid this."));
+	cpp11::warning("Connection is garbage-collected, use dbDisconnect() to avoid this.");
 	delete conn;
 }
 

--- a/tools/rpkg/src/database.cpp
+++ b/tools/rpkg/src/database.cpp
@@ -9,8 +9,8 @@
 using namespace duckdb;
 
 void duckdb::DBDeleter(DBWrapper *db) {
-	cpp11::warning(std::string("Database is garbage-collected, use dbDisconnect(con, shutdown=TRUE) or "
-	                           "duckdb::duckdb_shutdown(drv) to avoid this."));
+	cpp11::warning("Database is garbage-collected, use dbDisconnect(con, shutdown=TRUE) or "
+	               "duckdb::duckdb_shutdown(drv) to avoid this.");
 	delete db;
 }
 


### PR DESCRIPTION
This causes weird failuresi when unwinding, with clang. Follow-up to #8207.