### PR TITLE
Shutdown database on disconnect by default

### DIFF
--- a/tools/rpkg/R/Connection.R
+++ b/tools/rpkg/R/Connection.R
@@ -5,7 +5,12 @@
 #' @aliases duckdb_driver
 #' @keywords internal
 #' @export
-setClass("duckdb_driver", contains = "DBIDriver", slots = list(database_ref = "externalptr", dbdir = "character", read_only = "logical", bigint = "character"))
+setClass("duckdb_driver", contains = "DBIDriver", slots = list(
+  database_ref = "externalptr",
+  dbdir = "character",
+  read_only = "logical",
+  bigint = "character"
+))
 
 #' DuckDB connection class
 #'
@@ -14,17 +19,14 @@ setClass("duckdb_driver", contains = "DBIDriver", slots = list(database_ref = "e
 #' @aliases duckdb_connection
 #' @keywords internal
 #' @export
-setClass("duckdb_connection",
-  contains = "DBIConnection",
-  slots = list(
-    conn_ref = "externalptr",
-    driver = "duckdb_driver",
-    debug = "logical",
-    timezone_out = "character",
-    tz_out_convert = "character",
-    reserved_words = "character"
-  )
-)
+setClass("duckdb_connection", contains = "DBIConnection", slots = list(
+  conn_ref = "externalptr",
+  driver = "duckdb_driver",
+  debug = "logical",
+  timezone_out = "character",
+  tz_out_convert = "character",
+  reserved_words = "character"
+))
 
 duckdb_connection <- function(duckdb_driver, debug) {
   out <- new(

--- a/tools/rpkg/R/Connection.R
+++ b/tools/rpkg/R/Connection.R
@@ -22,6 +22,7 @@ setClass("duckdb_driver", contains = "DBIDriver", slots = list(
 setClass("duckdb_connection", contains = "DBIConnection", slots = list(
   conn_ref = "externalptr",
   driver = "duckdb_driver",
+  auto_shutdown = "logical",
   debug = "logical",
   timezone_out = "character",
   tz_out_convert = "character",

--- a/tools/rpkg/R/dbConnect__duckdb_driver.R
+++ b/tools/rpkg/R/dbConnect__duckdb_driver.R
@@ -53,7 +53,6 @@ dbConnect__duckdb_driver <- function(drv, dbdir = DBDIR_MEMORY, ...,
 
   # aha, a late comer. let's make a new instance.
   if (!missing_dbdir && dbdir != drv@dbdir) {
-    duckdb_shutdown(drv)
     drv <- duckdb(dbdir, read_only, bigint, config)
   }
 

--- a/tools/rpkg/R/dbConnect__duckdb_driver.R
+++ b/tools/rpkg/R/dbConnect__duckdb_driver.R
@@ -9,6 +9,8 @@
 #' @param ... Ignored
 #' @param auto_shutdown
 #'   Shutdown thes driver object from the database file when closing the connection?
+#'   By default, unneeded database connections are closed automatically.
+#'   This is required to actually disconnect from the database file.
 #' @param debug Print additional debug information such as queries
 #' @param read_only Set to `TRUE` for read-only operation
 #' @param timezone_out The time zone returned to R, defaults to `"UTC"`, which
@@ -42,7 +44,7 @@
 #' dbDisconnect(con, shutdown = TRUE)
 #' @usage NULL
 dbConnect__duckdb_driver <- function(drv, dbdir = DBDIR_MEMORY, ...,
-                                     auto_shutdown = FALSE,
+                                     auto_shutdown = TRUE,
                                      debug = getOption("duckdb.debug", FALSE),
                                      read_only = FALSE,
                                      timezone_out = "UTC",

--- a/tools/rpkg/R/dbConnect__duckdb_driver.R
+++ b/tools/rpkg/R/dbConnect__duckdb_driver.R
@@ -7,6 +7,8 @@
 #'   directory in the file system. With the default, all
 #'   data is kept in RAM
 #' @param ... Ignored
+#' @param auto_shutdown
+#'   Shutdown thes driver object from the database file when closing the connection?
 #' @param debug Print additional debug information such as queries
 #' @param read_only Set to `TRUE` for read-only operation
 #' @param timezone_out The time zone returned to R, defaults to `"UTC"`, which
@@ -40,10 +42,13 @@
 #' dbDisconnect(con, shutdown = TRUE)
 #' @usage NULL
 dbConnect__duckdb_driver <- function(drv, dbdir = DBDIR_MEMORY, ...,
+                                     auto_shutdown = FALSE,
                                      debug = getOption("duckdb.debug", FALSE),
                                      read_only = FALSE,
                                      timezone_out = "UTC",
-                                     tz_out_convert = c("with", "force"), config = list(), bigint = "numeric") {
+                                     tz_out_convert = c("with", "force"),
+                                     config = list(),
+                                     bigint = "numeric") {
   check_flag(debug)
   timezone_out <- check_tz(timezone_out)
   tz_out_convert <- match.arg(tz_out_convert)
@@ -57,12 +62,10 @@ dbConnect__duckdb_driver <- function(drv, dbdir = DBDIR_MEMORY, ...,
   }
 
   conn <- duckdb_connection(drv, debug = debug)
-  on.exit(dbDisconnect(conn))
 
+  conn@auto_shutdown <- auto_shutdown
   conn@timezone_out <- timezone_out
   conn@tz_out_convert <- tz_out_convert
-
-  on.exit(NULL)
 
   rs_on_connection_opened(conn)
 

--- a/tools/rpkg/R/dbDisconnect__duckdb_connection.R
+++ b/tools/rpkg/R/dbDisconnect__duckdb_connection.R
@@ -20,7 +20,7 @@ dbDisconnect__duckdb_connection <- function(conn, ..., shutdown = NULL) {
     shutdown <- conn@auto_shutdown
   }
   if (isTRUE(shutdown)) {
-    duckdb_shutdown(conn@driver)
+    rapi_shutdown(conn@driver@database_ref)
   }
   rs_on_connection_closed(conn)
   invisible(TRUE)

--- a/tools/rpkg/R/dbDisconnect__duckdb_connection.R
+++ b/tools/rpkg/R/dbDisconnect__duckdb_connection.R
@@ -3,16 +3,23 @@
 #' the associated instance.
 #'
 #' @param conn A `duckdb_connection` object
-#' @param shutdown Set to `TRUE` to shut down the DuckDB database instance that this connection refers to.
+#' @param shutdown
+#'   Set to `TRUE` to shut down the DuckDB database instance that this connection refers to,
+#'   if no other connections are using it.
+#'   The default is to use the `auto_shutdown` argument
+#'   that has been passed with `dbConnect()`.
 #' @rdname duckdb
 #' @usage NULL
-dbDisconnect__duckdb_connection <- function(conn, ..., shutdown = FALSE) {
+dbDisconnect__duckdb_connection <- function(conn, ..., shutdown = NULL) {
   if (!dbIsValid(conn)) {
     warning("Connection already closed.", call. = FALSE)
     invisible(FALSE)
   }
   rapi_disconnect(conn@conn_ref)
-  if (shutdown) {
+  if (is.null(shutdown)) {
+    shutdown <- conn@auto_shutdown
+  }
+  if (isTRUE(shutdown)) {
     duckdb_shutdown(conn@driver)
   }
   rs_on_connection_closed(conn)

--- a/tools/rpkg/R/dbGetInfo__duckdb_driver.R
+++ b/tools/rpkg/R/dbGetInfo__duckdb_driver.R
@@ -2,7 +2,7 @@
 #' @inheritParams DBI::dbGetInfo
 #' @usage NULL
 dbGetInfo__duckdb_driver <- function(dbObj, ...) {
-  con <- dbConnect(dbObj)
+  con <- dbConnect(dbObj, auto_shutdown = FALSE)
   version <- dbGetQuery(con, "select library_version from pragma_version()")[[1]][[1]]
   dbDisconnect(con)
   list(driver.version = version, client.version = version, dbname = dbObj@dbdir)

--- a/tools/rpkg/R/zzz.R
+++ b/tools/rpkg/R/zzz.R
@@ -2,7 +2,6 @@
   s3_register("dbplyr::dbplyr_edition", "duckdb_connection")
   s3_register("dbplyr::db_connection_describe", "duckdb_connection")
   s3_register("dbplyr::sql_translation", "duckdb_connection")
-  s3_register("dbplyr::dbplyr_fill0", "duckdb_connection")
   s3_register("dbplyr::sql_expr_matches", "duckdb_connection")
   s3_register("dbplyr::sql_escape_date", "duckdb_connection")
   s3_register("dbplyr::sql_escape_datetime", "duckdb_connection")

--- a/tools/rpkg/man/duckdb.Rd
+++ b/tools/rpkg/man/duckdb.Rd
@@ -23,7 +23,7 @@ duckdb_shutdown(drv)
   drv,
   dbdir = DBDIR_MEMORY,
   ...,
-  auto_shutdown = FALSE,
+  auto_shutdown = TRUE,
   debug = getOption("duckdb.debug", FALSE),
   read_only = FALSE,
   timezone_out = "UTC",
@@ -49,7 +49,9 @@ data is kept in RAM}
 
 \item{...}{Ignored}
 
-\item{auto_shutdown}{Shutdown thes driver object from the database file when closing the connection?}
+\item{auto_shutdown}{Shutdown thes driver object from the database file when closing the connection?
+By default, unneeded database connections are closed automatically.
+This is required to actually disconnect from the database file.}
 
 \item{debug}{Print additional debug information such as queries}
 

--- a/tools/rpkg/man/duckdb.Rd
+++ b/tools/rpkg/man/duckdb.Rd
@@ -23,6 +23,7 @@ duckdb_shutdown(drv)
   drv,
   dbdir = DBDIR_MEMORY,
   ...,
+  auto_shutdown = FALSE,
   debug = getOption("duckdb.debug", FALSE),
   read_only = FALSE,
   timezone_out = "UTC",
@@ -31,7 +32,7 @@ duckdb_shutdown(drv)
   bigint = "numeric"
 )
 
-\S4method{dbDisconnect}{duckdb_connection}(conn, ..., shutdown = FALSE)
+\S4method{dbDisconnect}{duckdb_connection}(conn, ..., shutdown = NULL)
 }
 \arguments{
 \item{dbdir}{Location for database files. Should be a path to an existing
@@ -48,6 +49,8 @@ data is kept in RAM}
 
 \item{...}{Ignored}
 
+\item{auto_shutdown}{Shutdown thes driver object from the database file when closing the connection?}
+
 \item{debug}{Print additional debug information such as queries}
 
 \item{timezone_out}{The time zone returned to R, defaults to \code{"UTC"}, which
@@ -63,7 +66,10 @@ time as the timestamp in the database, but with the new time zone.}
 
 \item{conn}{A \code{duckdb_connection} object}
 
-\item{shutdown}{Set to \code{TRUE} to shut down the DuckDB database instance that this connection refers to.}
+\item{shutdown}{Set to \code{TRUE} to shut down the DuckDB database instance that this connection refers to,
+if no other connections are using it.
+The default is to use the \code{auto_shutdown} argument
+that has been passed with \code{dbConnect()}.}
 }
 \value{
 \code{duckdb()} returns an object of class \linkS4class{duckdb_driver}.

--- a/tools/rpkg/tests/testthat/helper-DBItest.R
+++ b/tools/rpkg/tests/testthat/helper-DBItest.R
@@ -8,7 +8,7 @@ reg.finalizer(drv@database_ref, function(x) rapi_shutdown(x))
 DBItest::make_context(
   drv,
   # dblog::dblog(drv),
-  list(debug = FALSE),
+  list(auto_shutdown = FALSE, debug = FALSE),
   tweaks = DBItest::tweaks(
     omit_blob_tests = FALSE,
     temporary_tables = FALSE,

--- a/tools/rpkg/tests/testthat/test-shutdown.R
+++ b/tools/rpkg/tests/testthat/test-shutdown.R
@@ -1,0 +1,35 @@
+test_that("disconnect releases database file", {
+  db_path <- withr::local_tempfile(fileext = ".duckdb")
+
+  session_1 <- callr::r_session$new()
+  withr::defer(session_1$kill())
+  session_2 <- callr::r_session$new()
+  withr::defer(session_2$kill())
+
+  session_1$run(
+    function(db_path) {
+      .GlobalEnv$con <- DBI::dbConnect(duckdb::duckdb(), db_path)
+      DBI::dbWriteTable(con, "test", data.frame(a = 1))
+    },
+    list(db_path = db_path)
+  )
+
+  expect_error(session_2$run(
+    function(db_path) {
+      .GlobalEnv$con <- DBI::dbConnect(duckdb::duckdb(), db_path)
+    },
+    list(db_path = db_path)
+  ))
+
+  session_1$run(function() {
+    DBI::dbDisconnect(con, shutdown = TRUE)
+  })
+
+  session_2$run(
+    function(db_path) {
+      .GlobalEnv$con <- DBI::dbConnect(duckdb::duckdb(), db_path)
+      DBI::dbDisconnect(con, shutdown = TRUE)
+    },
+    list(db_path = db_path)
+  )
+})

--- a/tools/rpkg/tests/testthat/test-shutdown.R
+++ b/tools/rpkg/tests/testthat/test-shutdown.R
@@ -8,7 +8,7 @@ test_that("disconnect releases database file", {
 
   session_1$run(
     function(db_path) {
-      .GlobalEnv$con <- DBI::dbConnect(duckdb::duckdb(), db_path)
+      .GlobalEnv$con <- DBI::dbConnect(duckdb::duckdb(), db_path, auto_shutdown = TRUE)
       DBI::dbWriteTable(con, "test", data.frame(a = 1))
     },
     list(db_path = db_path)
@@ -16,19 +16,19 @@ test_that("disconnect releases database file", {
 
   expect_error(session_2$run(
     function(db_path) {
-      .GlobalEnv$con <- DBI::dbConnect(duckdb::duckdb(), db_path)
+      .GlobalEnv$con <- DBI::dbConnect(duckdb::duckdb(), db_path, auto_shutdown = TRUE)
     },
     list(db_path = db_path)
   ))
 
   session_1$run(function() {
-    DBI::dbDisconnect(con, shutdown = TRUE)
+    DBI::dbDisconnect(con)
   })
 
   session_2$run(
     function(db_path) {
-      .GlobalEnv$con <- DBI::dbConnect(duckdb::duckdb(), db_path)
-      DBI::dbDisconnect(con, shutdown = TRUE)
+      .GlobalEnv$con <- DBI::dbConnect(duckdb::duckdb(), db_path, auto_shutdown = TRUE)
+      DBI::dbDisconnect(con)
     },
     list(db_path = db_path)
   )

--- a/tools/rpkg/tests/testthat/test-shutdown.R
+++ b/tools/rpkg/tests/testthat/test-shutdown.R
@@ -8,7 +8,7 @@ test_that("disconnect releases database file", {
 
   session_1$run(
     function(db_path) {
-      .GlobalEnv$con <- DBI::dbConnect(duckdb::duckdb(), db_path, auto_shutdown = TRUE)
+      .GlobalEnv$con <- DBI::dbConnect(duckdb::duckdb(), db_path)
       DBI::dbWriteTable(con, "test", data.frame(a = 1))
     },
     list(db_path = db_path)
@@ -16,7 +16,7 @@ test_that("disconnect releases database file", {
 
   expect_error(session_2$run(
     function(db_path) {
-      .GlobalEnv$con <- DBI::dbConnect(duckdb::duckdb(), db_path, auto_shutdown = TRUE)
+      .GlobalEnv$con <- DBI::dbConnect(duckdb::duckdb(), db_path)
     },
     list(db_path = db_path)
   ))
@@ -27,7 +27,7 @@ test_that("disconnect releases database file", {
 
   session_2$run(
     function(db_path) {
-      .GlobalEnv$con <- DBI::dbConnect(duckdb::duckdb(), db_path, auto_shutdown = TRUE)
+      .GlobalEnv$con <- DBI::dbConnect(duckdb::duckdb(), db_path)
       DBI::dbDisconnect(con)
     },
     list(db_path = db_path)

--- a/tools/rpkg/tests/testthat/test_config_keyvalue.R
+++ b/tools/rpkg/tests/testthat/test_config_keyvalue.R
@@ -13,7 +13,7 @@ test_that("configuration key value pairs work as expected", {
   drv <- duckdb(config = list("default_order" = "DESC"))
 
   # the option actually does something
-  con <- dbConnect(drv)
+  con <- dbConnect(drv, auto_shutdown = FALSE)
   dbExecute(con, "create table a (i integer)")
   dbExecute(con, "insert into a values (44), (42)")
   res <- dbGetQuery(con, "select i from a order by i")


### PR DESCRIPTION
Achieved with a new argument `auto_shutdown = TRUE` to `dbConnect()`. The commits can be reviewed individually.

I also tried adding refcounting to disconnect only if no other connection uses this database. This would be the cleanest solution, but needs a little more work.

Closes #3451.