### PR TITLE
Print join_ref_type when explaining joins

### DIFF
--- a/src/main/relation/join_relation.cpp
+++ b/src/main/relation/join_relation.cpp
@@ -52,7 +52,7 @@ const vector<ColumnDefinition> &JoinRelation::Columns() {
 
 string JoinRelation::ToString(idx_t depth) {
 	string str = RenderWhitespace(depth);
-	str += "Join " + EnumUtil::ToString(join_type);
+	str += "Join " + EnumUtil::ToString(join_ref_type) + " " + EnumUtil::ToString(join_type);
 	if (condition) {
 		str += " " + condition->GetName();
 	}


### PR DESCRIPTION
See `Join ASOF LEFT` in the output.

``` r
df1 <- data.frame(x = 1:5)
df2 <- data.frame(y = c(1, 2, 4))

duckplyr:::duckplyr_left_join(df1, df2, by = dplyr::join_by(closest(x <= y)))
#> materializing:
#> ---------------------
#> --- Relation Tree ---
#> ---------------------
#> Projection [x as x, y as y]
#>   Join ASOF LEFT <=(lhs.x, rhs.y)
#>     r_dataframe_scan(0x12b0ddc80)
#>     r_dataframe_scan(0x12b4a22e8)
#> 
#> ---------------------
#> -- Result Columns  --
#> ---------------------
#> - x (INTEGER)
#> - y (DOUBLE)
#> 
#>   x  y
#> 1 4  4
#> 2 3  4
#> 3 2  2
#> 4 1  1
#> 5 5 NA
```

<sup>Created on 2023-07-17 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>