### PR TITLE
Skip row group size test on vsize=2

### DIFF
--- a/test/sql/copy/parquet/writer/row_group_size_bytes.test
+++ b/test/sql/copy/parquet/writer/row_group_size_bytes.test
@@ -4,6 +4,8 @@
 
 require parquet
 
+require vector_size 1024
+
 statement error
 copy (select 42) to '__TEST_DIR__/tbl.parquet' (ROW_GROUP_SIZE_BYTES)
 


### PR DESCRIPTION
The row group sizes are rounded to the nearest vector, so they change when the vector size changes