### PR TITLE
Resolve the conflict between the CTE name and the referring table name.

### DIFF
--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -32,7 +32,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 				    "Circular reference to CTE \"%s\", There are two possible solutions. \n1. use WITH RECURSIVE to "
 				    "use recursive CTEs. \n2. If "
 				    "you want to use the TABLE name \"%s\" the same as the CTE name, please explicitly add "
-				    "\"SCHEMA\" befrome table name. You can try \"main.%s\" (main is the duckdb default schema)",
+				    "\"SCHEMA\" before table name. You can try \"main.%s\" (main is the duckdb default schema)",
 				    ref.table_name, ref.table_name, ref.table_name);
 			}
 			// Move CTE to subquery and bind recursively

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -21,7 +21,13 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 	QueryErrorContext error_context(root_statement, ref.query_location);
 	// CTEs and views are also referred to using BaseTableRefs, hence need to distinguish here
 	// check if the table name refers to a CTE
-	auto found_cte = FindCTE(ref.table_name + ref.schema_name, ref.table_name == alias);
+
+	// CTE name should never be qualified (i.e. schema_name should be empty)
+	optional_ptr<CommonTableExpressionInfo> found_cte = nullptr;
+	if (ref.schema_name.empty()) {
+		found_cte = FindCTE(ref.table_name, ref.table_name == alias);
+	}
+
 	if (found_cte) {
 		// Check if there is a CTE binding in the BindContext
 		auto &cte = *found_cte;

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -21,15 +21,19 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 	QueryErrorContext error_context(root_statement, ref.query_location);
 	// CTEs and views are also referred to using BaseTableRefs, hence need to distinguish here
 	// check if the table name refers to a CTE
-	auto found_cte = FindCTE(ref.table_name, ref.table_name == alias);
+	auto found_cte = FindCTE(ref.table_name + ref.schema_name, ref.table_name == alias);
 	if (found_cte) {
 		// Check if there is a CTE binding in the BindContext
 		auto &cte = *found_cte;
 		auto ctebinding = bind_context.GetCTEBinding(ref.table_name);
 		if (!ctebinding) {
 			if (CTEIsAlreadyBound(cte)) {
-				throw BinderException("Circular reference to CTE \"%s\", use WITH RECURSIVE to use recursive CTEs",
-				                      ref.table_name);
+				throw BinderException(
+				    "Circular reference to CTE \"%s\", There are two possible solutions. \n1. use WITH RECURSIVE to "
+				    "use recursive CTEs. \n2. If "
+				    "you want to use the TABLE name \"%s\" the same as the CTE name, please explicitly add "
+				    "\"SCHEMA\" befrome table name. You can try \"main.%s\" (main is the duckdb default schema)",
+				    ref.table_name, ref.table_name, ref.table_name);
 			}
 			// Move CTE to subquery and bind recursively
 			SubqueryRef subquery(unique_ptr_cast<SQLStatement, SelectStatement>(cte.query->Copy()));

--- a/test/sql/cte/test_issue_5673.test
+++ b/test/sql/cte/test_issue_5673.test
@@ -1,5 +1,5 @@
 # name: test/sql/cte/test_issue_5673.test
-# description: Issue #5673 and #4987: CTE and Table name are name shadowing 
+# description: Issue #5673 and #4987: CTE and Table name are name shadowing
 # group: [cte]
 
 statement ok
@@ -44,3 +44,14 @@ some_more_logic as (
 select * from some_more_logic;
 ----
 1
+
+with
+orders as (
+    select * from stg_orders
+    where ordered_at >= (select max(ordered_at) from main.orders)
+),
+some_more_logic as (
+    select *
+    from orders
+)
+select * from some_more_logic;

--- a/test/sql/cte/test_issue_5673.test
+++ b/test/sql/cte/test_issue_5673.test
@@ -1,0 +1,46 @@
+# name: test/sql/cte/test_issue_5673.test
+# description: Issue #5673 and #4987: CTE and Table name are name shadowing 
+# group: [cte]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create or replace table orders(ordered_at int);
+
+statement ok
+create or replace table stg_orders(ordered_at int);
+
+statement ok
+insert into orders values (1);
+
+statement ok
+insert into stg_orders values (1);
+
+statement error
+with
+orders as (
+    select * from stg_orders
+    where ordered_at >= (select max(ordered_at) from orders)
+),
+some_more_logic as (
+    select *
+    from orders
+)
+select * from some_more_logic;
+----
+Binder Error: Circular reference to CTE "orders", There are two possible solutions.
+
+query I
+with
+orders as (
+    select * from main.stg_orders
+    where ordered_at >= (select max(ordered_at) from main.orders)
+),
+some_more_logic as (
+    select *
+    from orders
+)
+select * from some_more_logic;
+----
+1

--- a/test/sql/cte/test_issue_5673.test
+++ b/test/sql/cte/test_issue_5673.test
@@ -44,14 +44,3 @@ some_more_logic as (
 select * from some_more_logic;
 ----
 1
-
-with
-orders as (
-    select * from stg_orders
-    where ordered_at >= (select max(ordered_at) from main.orders)
-),
-some_more_logic as (
-    select *
-    from orders
-)
-select * from some_more_logic;


### PR DESCRIPTION
Fix https://github.com/duckdb/duckdb/issues/5673 and https://github.com/duckdb/duckdb/issues/4987

Provide a clear error message and guide for the case of CTE name and table name shadowing.

❌
```sql
with
orders as (
    select * from stg_orders
    where ordered_at >= (select max(ordered_at) from orders)
),
some_more_logic as (
    select *
    from orders
)
select * from some_more_logic;
```
Error: Binder Error: Circular reference to CTE "orders", There are two possible solutions.
1. use WITH RECURSIVE to use recursive CTEs.
2. If you want to use the TABLE name "orders" the same as the CTE name, please explicitly add "SCHEMA" before table name. You can try "main.orders" (main is the duckdb default schema)

✅
```sql
with
orders as (
    select * from stg_orders
    where ordered_at >= (select max(ordered_at) from main.orders) # add schema here 
),
some_more_logic as (
    select *
    from orders
)
select * from some_more_logic;
``` 
So user can explicitly add "SCHEMA"  to the CTE tableref. 

We can pass the schema_name +  table_name to FindCTE, as @aarashy says in (https://github.com/duckdb/duckdb/issues/4987 ) "CTE names are never allowed to be qualified" (Postgres also not allow qualified CTE name). 

If a tableref is qualified, we can confirm that it should not be a CTE name.
