### PR TITLE
Swap arguments for atan2 function to atan2(y, x)

### DIFF
--- a/src/core_functions/scalar/math/functions.json
+++ b/src/core_functions/scalar/math/functions.json
@@ -49,9 +49,9 @@
     },
     {
         "name": "atan2",
-        "parameters": "x,y",
-        "description": "computes the arctangent (x, y)",
-        "example": "atan2(0.5, 0.5)",
+        "parameters": "y,x",
+        "description": "computes the arctangent (y, x)",
+        "example": "atan2(1.0, 0.0)",
         "type": "scalar_function"
     },
     {

--- a/src/include/duckdb/core_functions/scalar/math_functions.hpp
+++ b/src/include/duckdb/core_functions/scalar/math_functions.hpp
@@ -101,9 +101,9 @@ struct AtanFun {
 
 struct Atan2Fun {
 	static constexpr const char *Name = "atan2";
-	static constexpr const char *Parameters = "x,y";
-	static constexpr const char *Description = "computes the arctangent (x, y)";
-	static constexpr const char *Example = "atan2(0.5, 0.5)";
+	static constexpr const char *Parameters = "y,x";
+	static constexpr const char *Description = "computes the arctangent (y, x)";
+	static constexpr const char *Example = "atan2(1.0, 0.0)";
 
 	static ScalarFunction GetFunction();
 };


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-web/issues/877

The parameter naming convention of `atan2(y, x)` is in line with the [mathematical notation (wiki)](https://en.wikipedia.org/wiki/Atan2) and the [PostgreSQL documentation](https://www.postgresql.org/docs/15/functions-math.html).