### PR TITLE
Pipeline scheduling issue

### DIFF
--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -107,7 +107,7 @@ void Executor::SchedulePipeline(const shared_ptr<MetaPipeline> &meta_pipeline, S
 			                                  group_stack.pipeline_finish_event, base_stack.pipeline_complete_event);
 
 			// dependencies: base_finish -> pipeline_event -> group_finish
-			pipeline_stack.pipeline_event.AddDependency(base_stack.pipeline_event);
+			pipeline_stack.pipeline_event.AddDependency(base_stack.pipeline_finish_event);
 			group_stack.pipeline_finish_event.AddDependency(pipeline_stack.pipeline_event);
 
 			// add pipeline stack to event map


### PR DESCRIPTION
This fix solves an issue that currently triggers on master nightlies in the force-blocking-sink-source job where the test/sql/join/iejoin/iejoin_issue_7278.test would fail. Turned out to be a dependency issue in scheduling pipelines that was previously not found due to the timing difference in the force-blocking-sink-source job. 

Found the issue super fast thanks to @lnkuiper!