### PR TITLE
[CI] Fix test failure introduced by #8348

### DIFF
--- a/tools/pythonpkg/tests/fast/pandas/test_copy_on_write.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_copy_on_write.py
@@ -1,6 +1,8 @@
 import duckdb
 import pytest
-import pandas
+
+# https://pandas.pydata.org/docs/dev/user_guide/copy_on_write.html
+pandas = pytest.importorskip('pandas', '1.5', reason='copy_on_write does not exist in earlier versions')
 import datetime
 
 


### PR DESCRIPTION
Copy on write is introduced in pandas 1.5, in earlier versions the setting doesn't exist and causes a crash

As evidenced by: https://github.com/duckdb/duckdb/actions/runs/5654900512/job/15319393220?pr=8357#step:6:11735