### PR TITLE
Compare scalar functions by name/args/return instead of function object target

### DIFF
--- a/src/function/scalar_function.cpp
+++ b/src/function/scalar_function.cpp
@@ -26,9 +26,10 @@ ScalarFunction::ScalarFunction(vector<LogicalType> arguments, LogicalType return
 }
 
 bool ScalarFunction::operator==(const ScalarFunction &rhs) const {
-	return CompareScalarFunctionT(rhs.function) && bind == rhs.bind && dependency == rhs.dependency &&
-	       statistics == rhs.statistics;
+	return name == rhs.name && arguments == rhs.arguments && return_type == rhs.return_type && varargs == rhs.varargs &&
+	       bind == rhs.bind && dependency == rhs.dependency && statistics == rhs.statistics;
 }
+
 bool ScalarFunction::operator!=(const ScalarFunction &rhs) const {
 	return !(*this == rhs);
 }
@@ -54,23 +55,6 @@ bool ScalarFunction::Equal(const ScalarFunction &rhs) const {
 	}
 
 	return true; // they are equal
-}
-
-bool ScalarFunction::CompareScalarFunctionT(const scalar_function_t &other) const {
-	typedef void(scalar_function_ptr_t)(DataChunk &, ExpressionState &, Vector &);
-
-	auto func_ptr = (scalar_function_ptr_t **)function.template target<scalar_function_ptr_t *>(); // NOLINT
-	auto other_ptr = (scalar_function_ptr_t **)other.template target<scalar_function_ptr_t *>();   // NOLINT
-
-	// Case the functions were created from lambdas the target will return a nullptr
-	if (!func_ptr && !other_ptr) {
-		return true;
-	}
-	if (func_ptr == nullptr || other_ptr == nullptr) {
-		// scalar_function_t (std::functions) from lambdas cannot be compared
-		return false;
-	}
-	return CastPointerToValue(*func_ptr) == CastPointerToValue(*other_ptr);
 }
 
 void ScalarFunction::NopFunction(DataChunk &input, ExpressionState &state, Vector &result) {

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -105,9 +105,6 @@ public:
 
 	DUCKDB_API bool Equal(const ScalarFunction &rhs) const;
 
-private:
-	bool CompareScalarFunctionT(const scalar_function_t &other) const;
-
 public:
 	DUCKDB_API static void NopFunction(DataChunk &input, ExpressionState &state, Vector &result);
 


### PR DESCRIPTION
Previously the `==` operator for ScalarFunctions would compare the `std::function::target` pointers which would internally perform a dynamic cast. Since `typeid` is not preserved through dynamically loaded extensions, this would cause the casts to fail and turn the target pointers into nullptrs which would cause different scalars to be considered equal which in turn caused too aggressive common subexpression elimination in the optimiser, leading to very strange results.

I've tested it locally, this should fix:
https://github.com/duckdblabs/duckdb_spatial/issues/103
https://github.com/duckdblabs/duckdb_spatial/issues/88