### PR TITLE
Call pwrite/pread in a loop and reduce disk space usage of window_partition_paging.test_slow

### DIFF
--- a/test/sql/window/window_partition_paging.test_slow
+++ b/test/sql/window/window_partition_paging.test_slow
@@ -10,14 +10,14 @@ CREATE or replace TABLE big_table AS
     (i % 500)::int16 AS "Pid",
     (i % 5000)::int16 AS "Planid",
     left(uuid()::VARCHAR, 10) AS "Claimid",
-    FROM range(1e8::int) tbl(i);
+    FROM range(2e7::int) tbl(i);
 
 statement ok
-PRAGMA temp_directory='__TEST_DIR__/window_paging'
+PRAGMA temp_directory='window_paging'
 
-# This query would take ~12GB of memory
+# This query would take ~2.5GB of memory
 statement ok
-PRAGMA memory_limit='4GB'
+PRAGMA memory_limit='1GB'
 
 statement ok
 PRAGMA verify_external
@@ -33,4 +33,4 @@ WITH new_table as (SELECT
 SELECT MAX(Fake_Claimid), COUNT(*)
 FROM new_table
 ----
-CLAIM9999	100000000
+CLAIM999	20000000

--- a/test/sql/window/window_partition_paging.test_slow
+++ b/test/sql/window/window_partition_paging.test_slow
@@ -13,7 +13,7 @@ CREATE or replace TABLE big_table AS
     FROM range(2e7::int) tbl(i);
 
 statement ok
-PRAGMA temp_directory='window_paging'
+PRAGMA temp_directory='__TEST_DIR__/window_paging'
 
 # This query would take ~2.5GB of memory
 statement ok


### PR DESCRIPTION
`pwrite/pread` are not guaranteed to write/read the number of bytes that are passed in, but can write or read less (see the [pwrite man page](https://linux.die.net/man/2/pwrite), and [stack overflow](https://stackoverflow.com/a/9400723)). This generally doesn't happen, however. Previously we handled this by throwing an exception when this occurred. 

This error seems to have now triggered in [this CI run](https://github.com/duckdb/duckdb/actions/runs/5658490011/job/15329913981?pr=8365):

```
##[warning]You are running out of disk space. The runner will stop working when the machine runs out of disk space. Free space left: 31 MB
================================================================================
Query unexpectedly failed (test/sql/window/window_partition_paging.test_slow:25)
================================================================================
WITH new_table as (SELECT
        Pid,
        Planid,
        Claimid,
        'CLAIM' || dense_rank() OVER(PARTITION BY Pid, Planid ORDER BY Claimid) AS Fake_Claimid
    FROM big_table
)
SELECT MAX(Fake_Claimid), COUNT(*)
FROM new_table;
================================================================================
Actual result:
IO Error: Could not write all bytes to file "duckdb_unittest_tempdir/3042/window_paging/27507274.block": wanted=14721024 wrote=10674168

[2895/3033] (95%): test/sql/window/window_partition_paging.test_slow            
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
unittest is a Catch v2.13.7 host application.
Run with -? for options

-------------------------------------------------------------------------------
test/sql/window/window_partition_paging.test_slow
-------------------------------------------------------------------------------
/__w/duckdb/duckdb/test/sqlite/test_sqllogictest.cpp:204
...............................................................................

test/sql/window/window_partition_paging.test_slow:25: FAILED:
explicitly with message:
  0

```

Apparently `pwrite` can return less than the amount of bytes written in case of a full disk (instead of `ENOSPC`).

This PR makes it so that we instead call `pwrite` or `pread` again, which is a better practice to begin with. This should result in the second call to `pwrite` returning the correct `disk full` error message.

In addition this PR fixes the problem by reducing the file system space required for running the problematic test.
