### PR TITLE
Http_state: Move to shared_ptr<char[]>

### DIFF
--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -262,7 +262,7 @@ unique_ptr<ResponseWrapper> HTTPFileSystem::GetRequest(FileHandle &handle, strin
 				    hfs.state->total_bytes_received += data_length;
 			    }
 			    if (!cached_file.data) {
-				    cached_file.data = std::shared_ptr<char>(new char[data_length], std::default_delete<char[]>());
+				    cached_file.data = std::shared_ptr<char[]>(new char[data_length], std::default_delete<char[]>());
 				    hfs.length = data_length;
 				    cached_file.capacity = data_length;
 				    memcpy(cached_file.data.get(), data, data_length);
@@ -274,7 +274,7 @@ unique_ptr<ResponseWrapper> HTTPFileSystem::GetRequest(FileHandle &handle, strin
 				    // Gotta eat your beans
 				    if (new_capacity != cached_file.capacity) {
 					    auto new_hfs_data =
-					        std::shared_ptr<char>(new char[new_capacity], std::default_delete<char[]>());
+					        std::shared_ptr<char[]>(new char[new_capacity], std::default_delete<char[]>());
 					    // copy the old data
 					    memcpy(new_hfs_data.get(), cached_file.data.get(), hfs.length);
 					    cached_file.capacity = new_capacity;

--- a/src/include/duckdb/common/http_state.hpp
+++ b/src/include/duckdb/common/http_state.hpp
@@ -18,7 +18,7 @@ namespace duckdb {
 
 struct CachedFile {
 	//! Cached Data
-	shared_ptr<char> data;
+	shared_ptr<char[]> data;
 	//! Data capacity
 	uint64_t capacity = 0;
 	//! If we finished downloading the file


### PR DESCRIPTION
Spin off of https://github.com/duckdb/duckdb/pull/8266, as suggested by @Mytherin cherry-picking what should be a simple fix in properly keep the types of the held memory.