### PR TITLE
[RLE] Fix problem created by #8250

### DIFF
--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -92,8 +92,7 @@ idx_t ListColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t co
 	UnifiedVectorFormat offsets;
 	offset_vector.ToUnifiedFormat(scan_count, offsets);
 	auto data = UnifiedVectorFormat::GetData<uint64_t>(offsets);
-	auto constant_offsets = offset_vector.GetVectorType() == VectorType::CONSTANT_VECTOR;
-	auto last_entry = data[constant_offsets ? 0 : scan_count - 1];
+	auto last_entry = data[offsets.sel->get_index(scan_count - 1)];
 
 	// shift all offsets so they are 0 at the first entry
 	auto result_data = FlatVector::GetData<list_entry_t>(result);

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -89,16 +89,20 @@ idx_t ListColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t co
 	D_ASSERT(scan_count > 0);
 	validity.ScanCount(state.child_states[0], result, count);
 
-	auto data = FlatVector::GetData<uint64_t>(offset_vector);
-	auto last_entry = data[scan_count - 1];
+	UnifiedVectorFormat offsets;
+	offset_vector.ToUnifiedFormat(scan_count, offsets);
+	auto data = UnifiedVectorFormat::GetData<uint64_t>(offsets);
+	auto constant_offsets = offset_vector.GetVectorType() == VectorType::CONSTANT_VECTOR;
+	auto last_entry = data[constant_offsets ? 0 : scan_count - 1];
 
 	// shift all offsets so they are 0 at the first entry
 	auto result_data = FlatVector::GetData<list_entry_t>(result);
 	auto base_offset = state.last_offset;
 	idx_t current_offset = 0;
 	for (idx_t i = 0; i < scan_count; i++) {
+		auto offset_index = offsets.sel->get_index(i);
 		result_data[i].offset = current_offset;
-		result_data[i].length = data[i] - current_offset - base_offset;
+		result_data[i].length = data[offset_index] - current_offset - base_offset;
 		current_offset += result_data[i].length;
 	}
 

--- a/test/sql/storage/compression/rle/rle_constant.test
+++ b/test/sql/storage/compression/rle/rle_constant.test
@@ -5,6 +5,8 @@
 # load the DB from disk
 load __TEST_DIR__/test_rle.db
 
+require vector_size 2048
+
 statement ok
 PRAGMA force_compression = 'rle'
 


### PR DESCRIPTION
List offsets can be compressed with RLE, previously the code in `list_column_data.cpp` assumed the produced vector to be FLAT, this is no longer always the case so we need to deal with it in a generic way.

Or we should just Flatten the vector here, whichever is the cleanest.