### PR TITLE
[Python] Remove `PyObject *` where possible

### DIFF
--- a/tools/pythonpkg/README.md
+++ b/tools/pythonpkg/README.md
@@ -125,3 +125,14 @@ For example:
 export PATH="$PATH:/opt/homebrew/Cellar/llvm/15.0.2/bin"
 ```
 
+# What are py::objects and a py::handles??
+
+These are classes provided by pybind11, the library we use to manage our interaction with the python environment.
+py::handle is a direct wrapper around a raw PyObject* and does not manage any references.
+py::object is similar to py::handle but it can handle refcounts.
+
+I say *can* because it doesn't have to, using `py::reinterpret_borrow<py::object>(...)` we can create a non-owning py::object, this is essentially just a py::handle but py::handle can't be used if the prototype requires a py::object.
+
+`py::reinterpret_steal<py::object>(...)` creates an owning py::object, this will increase the refcount of the python object and will decrease the refcount when the py::object goes out of scope.
+
+When directly interacting with python functions that return a `PyObject*`, such as `PyDateTime_DATE_GET_TZINFO`, you should generally wrap the call in `py::reinterpret_steal` to take ownership of the returned object.

--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/python_import_cache.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/python_import_cache.hpp
@@ -91,7 +91,7 @@ private:
 	IpywidgetsCacheItem ipywidgets_module;
 
 public:
-	PyObject *AddCache(py::object item);
+	py::handle AddCache(py::object item);
 
 private:
 	vector<py::object> owned_objects;

--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/python_import_cache_item.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/python_import_cache_item.hpp
@@ -38,13 +38,13 @@ protected:
 	}
 
 private:
-	PyObject *AddCache(PythonImportCache &cache, py::object object);
+	py::handle AddCache(PythonImportCache &cache, py::object object);
 
 private:
 	//! Whether or not we attempted to load the module
 	bool load_succeeded;
 	//! The stored item
-	PyObject *object;
+	py::handle object;
 };
 
 } // namespace duckdb

--- a/tools/pythonpkg/src/include/duckdb_python/pandas/pandas_bind.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pandas/pandas_bind.hpp
@@ -17,7 +17,7 @@ struct PandasColumnBindData {
 	unique_ptr<RegisteredArray> mask;
 	//! Only for categorical types
 	string internal_categorical_type;
-	//! When object types are cast we must hold their data somewhere
+	//! Hold ownership of objects created during scanning
 	PythonObjectContainer<py::str> object_str_val;
 };
 

--- a/tools/pythonpkg/src/include/duckdb_python/pandas/pandas_bind.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pandas/pandas_bind.hpp
@@ -18,7 +18,7 @@ struct PandasColumnBindData {
 	//! Only for categorical types
 	string internal_categorical_type;
 	//! Hold ownership of objects created during scanning
-	PythonObjectContainer<py::str> object_str_val;
+	PythonObjectContainer object_str_val;
 };
 
 struct Pandas {

--- a/tools/pythonpkg/src/include/duckdb_python/pybind11/python_object_container.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pybind11/python_object_container.hpp
@@ -17,7 +17,7 @@ namespace duckdb {
 
 template <typename TGT_PY_TYPE, typename SRC_PY_TYPE>
 struct PythonAssignmentFunction {
-	typedef void (*assign_t)(TGT_PY_TYPE &, SRC_PY_TYPE &);
+	typedef void (*assign_t)(TGT_PY_TYPE &, SRC_PY_TYPE);
 };
 
 //! Every Python Object Must be created through our container
@@ -33,25 +33,18 @@ public:
 		py_obj.clear();
 	}
 
-	unique_ptr<PythonGILWrapper> GetLock() {
-		return make_uniq<PythonGILWrapper>();
-	}
-
 	template <class NEW_PY_TYPE>
 	void AssignInternal(typename PythonAssignmentFunction<PY_TYPE, NEW_PY_TYPE>::assign_t lambda,
-	                    NEW_PY_TYPE &new_value, PythonGILWrapper &lock) {
+	                    py::handle new_value) {
+		D_ASSERT(py::gil_check());
 		PY_TYPE obj;
 		lambda(obj, new_value);
-		PushInternal(lock, obj);
-	}
-
-	void PushInternal(PythonGILWrapper &lock, PY_TYPE obj) {
-		py_obj.push_back(obj);
+		PushInternal(obj);
 	}
 
 	void Push(PY_TYPE obj) {
-		auto lock = GetLock();
-		PushInternal(*lock, std::move(obj));
+		py::gil_scoped_acquire gil;
+		PushInternal(std::move(obj));
 	}
 
 	const PY_TYPE *GetPointerTop() {
@@ -59,6 +52,10 @@ public:
 	}
 
 private:
+	void PushInternal(PY_TYPE obj) {
+		py_obj.push_back(obj);
+	}
+
 	vector<PY_TYPE> py_obj;
 };
 } // namespace duckdb

--- a/tools/pythonpkg/src/include/duckdb_python/pybind11/python_object_container.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pybind11/python_object_container.hpp
@@ -15,14 +15,8 @@
 
 namespace duckdb {
 
-template <typename TGT_PY_TYPE, typename SRC_PY_TYPE>
-struct PythonAssignmentFunction {
-	typedef void (*assign_t)(TGT_PY_TYPE &, SRC_PY_TYPE);
-};
-
 //! Every Python Object Must be created through our container
 //! The Container ensures that the GIL is HOLD on Python Object Construction/Destruction/Modification
-template <class PY_TYPE>
 class PythonObjectContainer {
 public:
 	PythonObjectContainer() {
@@ -33,29 +27,21 @@ public:
 		py_obj.clear();
 	}
 
-	template <class NEW_PY_TYPE>
-	void AssignInternal(typename PythonAssignmentFunction<PY_TYPE, NEW_PY_TYPE>::assign_t lambda,
-	                    py::handle new_value) {
-		D_ASSERT(py::gil_check());
-		PY_TYPE obj;
-		lambda(obj, new_value);
-		PushInternal(obj);
-	}
-
-	void Push(PY_TYPE obj) {
+	void Push(py::object &&obj) {
 		py::gil_scoped_acquire gil;
 		PushInternal(std::move(obj));
 	}
 
-	const PY_TYPE *GetPointerTop() {
-		return &py_obj.back();
+	const py::object &LastAddedObject() {
+		D_ASSERT(!py_obj.empty());
+		return py_obj.back();
 	}
 
 private:
-	void PushInternal(PY_TYPE obj) {
-		py_obj.push_back(obj);
+	void PushInternal(py::object &&obj) {
+		py_obj.emplace_back(obj);
 	}
 
-	vector<PY_TYPE> py_obj;
+	vector<py::object> py_obj;
 };
 } // namespace duckdb

--- a/tools/pythonpkg/src/include/duckdb_python/python_objects.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/python_objects.hpp
@@ -37,7 +37,7 @@ public:
 	idx_t len;
 
 public:
-	PyObject *operator[](const py::object &obj) const {
+	py::handle operator[](const py::object &obj) const {
 		return PyDict_GetItem(dict.ptr(), obj.ptr());
 	}
 
@@ -117,9 +117,9 @@ public:
 	interval_t ToInterval();
 
 private:
-	static int64_t GetDays(PyObject *obj);
-	static int64_t GetSeconds(PyObject *obj);
-	static int64_t GetMicros(PyObject *obj);
+	static int64_t GetDays(py::handle &obj);
+	static int64_t GetSeconds(py::handle &obj);
+	static int64_t GetMicros(py::handle &obj);
 };
 
 struct PyTime {
@@ -130,18 +130,18 @@ public:
 	int32_t minute;
 	int32_t second;
 	int32_t microsecond;
-	PyObject *timezone_obj;
+	py::object timezone_obj;
 
 public:
 	dtime_t ToDuckTime();
 	Value ToDuckValue();
 
 private:
-	static int32_t GetHours(PyObject *obj);
-	static int32_t GetMinutes(PyObject *obj);
-	static int32_t GetSeconds(PyObject *obj);
-	static int32_t GetMicros(PyObject *obj);
-	static PyObject *GetTZInfo(PyObject *obj);
+	static int32_t GetHours(py::handle &obj);
+	static int32_t GetMinutes(py::handle &obj);
+	static int32_t GetSeconds(py::handle &obj);
+	static int32_t GetMicros(py::handle &obj);
+	static py::object GetTZInfo(py::handle &obj);
 };
 
 struct PyDateTime {
@@ -155,7 +155,7 @@ public:
 	int32_t minute;
 	int32_t second;
 	int32_t micros;
-	PyObject *tzone_obj;
+	py::object tzone_obj;
 
 public:
 	timestamp_t ToTimestamp();
@@ -166,14 +166,14 @@ public:
 	bool IsNegativeInfinity() const;
 
 public:
-	static int32_t GetYears(PyObject *obj);
-	static int32_t GetMonths(PyObject *obj);
-	static int32_t GetDays(PyObject *obj);
-	static int32_t GetHours(PyObject *obj);
-	static int32_t GetMinutes(PyObject *obj);
-	static int32_t GetSeconds(PyObject *obj);
-	static int32_t GetMicros(PyObject *obj);
-	static PyObject *GetTZInfo(PyObject *obj);
+	static int32_t GetYears(py::handle &obj);
+	static int32_t GetMonths(py::handle &obj);
+	static int32_t GetDays(py::handle &obj);
+	static int32_t GetHours(py::handle &obj);
+	static int32_t GetMinutes(py::handle &obj);
+	static int32_t GetSeconds(py::handle &obj);
+	static int32_t GetMicros(py::handle &obj);
+	static py::object GetTZInfo(py::handle &obj);
 };
 
 struct PyDate {
@@ -194,7 +194,7 @@ public:
 	PyTimezone() = delete;
 
 public:
-	DUCKDB_API static interval_t GetUTCOffset(PyObject *tzone_obj);
+	DUCKDB_API static interval_t GetUTCOffset(py::handle &tzone_obj);
 };
 
 struct PythonObject {

--- a/tools/pythonpkg/src/include/duckdb_python/pyutil.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyutil.hpp
@@ -6,28 +6,28 @@
 namespace duckdb {
 
 struct PyUtil {
-	static idx_t PyByteArrayGetSize(PyObject *obj) {
-		return PyByteArray_GET_SIZE(obj); // NOLINT
+	static idx_t PyByteArrayGetSize(py::handle &obj) {
+		return PyByteArray_GET_SIZE(obj.ptr()); // NOLINT
 	}
 
-	static Py_buffer *PyMemoryViewGetBuffer(PyObject *obj) {
-		return PyMemoryView_GET_BUFFER(obj);
+	static Py_buffer *PyMemoryViewGetBuffer(py::handle &obj) {
+		return PyMemoryView_GET_BUFFER(obj.ptr());
 	}
 
-	static bool PyUnicodeIsCompactASCII(PyObject *obj) {
-		return PyUnicode_IS_COMPACT_ASCII(obj);
+	static bool PyUnicodeIsCompactASCII(py::handle &obj) {
+		return PyUnicode_IS_COMPACT_ASCII(obj.ptr());
 	}
 
-	static const char *PyUnicodeData(PyObject *obj) {
-		return const_char_ptr_cast(PyUnicode_DATA(obj));
+	static const char *PyUnicodeData(py::handle &obj) {
+		return const_char_ptr_cast(PyUnicode_DATA(obj.ptr()));
 	}
 
-	static char *PyUnicodeDataMutable(PyObject *obj) {
-		return char_ptr_cast(PyUnicode_DATA(obj));
+	static char *PyUnicodeDataMutable(py::handle &obj) {
+		return char_ptr_cast(PyUnicode_DATA(obj.ptr()));
 	}
 
-	static idx_t PyUnicodeGetLength(PyObject *obj) {
-		return PyUnicode_GET_LENGTH(obj);
+	static idx_t PyUnicodeGetLength(py::handle &obj) {
+		return PyUnicode_GET_LENGTH(obj.ptr());
 	}
 
 	static bool PyUnicodeIsCompact(PyCompactUnicodeObject *obj) {
@@ -38,20 +38,20 @@ struct PyUtil {
 		return PyUnicode_IS_ASCII(obj);
 	}
 
-	static int PyUnicodeKind(PyObject *obj) {
-		return PyUnicode_KIND(obj);
+	static int PyUnicodeKind(py::handle &obj) {
+		return PyUnicode_KIND(obj.ptr());
 	}
 
-	static Py_UCS1 *PyUnicode1ByteData(PyObject *obj) {
-		return PyUnicode_1BYTE_DATA(obj);
+	static Py_UCS1 *PyUnicode1ByteData(py::handle &obj) {
+		return PyUnicode_1BYTE_DATA(obj.ptr());
 	}
 
-	static Py_UCS2 *PyUnicode2ByteData(PyObject *obj) {
-		return PyUnicode_2BYTE_DATA(obj);
+	static Py_UCS2 *PyUnicode2ByteData(py::handle &obj) {
+		return PyUnicode_2BYTE_DATA(obj.ptr());
 	}
 
-	static Py_UCS4 *PyUnicode4ByteData(PyObject *obj) {
-		return PyUnicode_4BYTE_DATA(obj);
+	static Py_UCS4 *PyUnicode4ByteData(py::handle &obj) {
+		return PyUnicode_4BYTE_DATA(obj.ptr());
 	}
 };
 

--- a/tools/pythonpkg/src/map.cpp
+++ b/tools/pythonpkg/src/map.cpp
@@ -25,7 +25,7 @@ struct MapFunctionData : public TableFunctionData {
 	vector<string> in_names, out_names;
 };
 
-static py::handle FunctionCall(NumpyResultConversion &conversion, const vector<string> &names, PyObject *function) {
+static py::object FunctionCall(NumpyResultConversion &conversion, const vector<string> &names, PyObject *function) {
 	py::dict in_numpy_dict;
 	for (idx_t col_idx = 0; col_idx < names.size(); col_idx++) {
 		in_numpy_dict[names[col_idx].c_str()] = conversion.ToArray(col_idx);
@@ -40,7 +40,7 @@ static py::handle FunctionCall(NumpyResultConversion &conversion, const vector<s
 		throw InvalidInputException("Python error. See above for a stack trace.");
 	}
 
-	py::handle df(df_obj);
+	auto df = py::reinterpret_steal<py::object>(df_obj);
 	if (df.is_none()) { // no return, probably modified in place
 		throw InvalidInputException("No return value from Python function");
 	}

--- a/tools/pythonpkg/src/native/python_conversion.cpp
+++ b/tools/pythonpkg/src/native/python_conversion.cpp
@@ -482,15 +482,14 @@ Value TransformPythonValue(py::handle ele, const LogicalType &target_type, bool 
 	case PythonObjectType::String:
 		return ele.cast<string>();
 	case PythonObjectType::ByteArray: {
-		auto byte_array = ele.ptr();
-		const_data_ptr_t bytes = const_data_ptr_cast(PyByteArray_AsString(byte_array)); // NOLINT
-		idx_t byte_length = PyUtil::PyByteArrayGetSize(byte_array);                     // NOLINT
+		auto byte_array = ele;
+		const_data_ptr_t bytes = const_data_ptr_cast(PyByteArray_AsString(byte_array.ptr())); // NOLINT
+		idx_t byte_length = PyUtil::PyByteArrayGetSize(byte_array);                           // NOLINT
 		return Value::BLOB(bytes, byte_length);
 	}
 	case PythonObjectType::MemoryView: {
 		py::memoryview py_view = ele.cast<py::memoryview>();
-		PyObject *py_view_ptr = py_view.ptr();
-		Py_buffer *py_buf = PyUtil::PyMemoryViewGetBuffer(py_view_ptr); // NOLINT
+		Py_buffer *py_buf = PyUtil::PyMemoryViewGetBuffer(py_view); // NOLINT
 		return Value::BLOB(const_data_ptr_t(py_buf->buf), idx_t(py_buf->len));
 	}
 	case PythonObjectType::Bytes: {

--- a/tools/pythonpkg/src/native/python_objects.cpp
+++ b/tools/pythonpkg/src/native/python_objects.cpp
@@ -220,7 +220,7 @@ dtime_t PyTime::ToDuckTime() {
 
 Value PyTime::ToDuckValue() {
 	auto duckdb_time = this->ToDuckTime();
-	if (this->timezone_obj != Py_None) {
+	if (!py::none().is(this->timezone_obj)) {
 		auto utc_offset = PyTimezone::GetUTCOffset(this->timezone_obj);
 		// 'Add' requires a date_t for overflows
 		date_t ignored_date;

--- a/tools/pythonpkg/src/native/python_objects.cpp
+++ b/tools/pythonpkg/src/native/python_objects.cpp
@@ -20,10 +20,9 @@ PyDictionary::PyDictionary(py::object dict) {
 }
 
 PyTimeDelta::PyTimeDelta(py::handle &obj) {
-	auto ptr = obj.ptr();
-	days = PyTimeDelta::GetDays(ptr);
-	seconds = PyTimeDelta::GetSeconds(ptr);
-	microseconds = PyTimeDelta::GetMicros(ptr);
+	days = PyTimeDelta::GetDays(obj);
+	seconds = PyTimeDelta::GetSeconds(obj);
+	microseconds = PyTimeDelta::GetMicros(obj);
 }
 
 interval_t PyTimeDelta::ToInterval() {
@@ -42,16 +41,16 @@ interval_t PyTimeDelta::ToInterval() {
 	return interval;
 }
 
-int64_t PyTimeDelta::GetDays(PyObject *obj) {
-	return PyDateTime_TIMEDELTA_GET_DAYS(obj); // NOLINT
+int64_t PyTimeDelta::GetDays(py::handle &obj) {
+	return PyDateTime_TIMEDELTA_GET_DAYS(obj.ptr()); // NOLINT
 }
 
-int64_t PyTimeDelta::GetSeconds(PyObject *obj) {
-	return PyDateTime_TIMEDELTA_GET_SECONDS(obj); // NOLINT
+int64_t PyTimeDelta::GetSeconds(py::handle &obj) {
+	return PyDateTime_TIMEDELTA_GET_SECONDS(obj.ptr()); // NOLINT
 }
 
-int64_t PyTimeDelta::GetMicros(PyObject *obj) {
-	return PyDateTime_TIMEDELTA_GET_MICROSECONDS(obj); // NOLINT
+int64_t PyTimeDelta::GetMicros(py::handle &obj) {
+	return PyDateTime_TIMEDELTA_GET_MICROSECONDS(obj.ptr()); // NOLINT
 }
 
 PyDecimal::PyDecimal(py::handle &obj) : obj(obj) {
@@ -209,12 +208,11 @@ Value PyDecimal::ToDuckValue() {
 }
 
 PyTime::PyTime(py::handle &obj) : obj(obj) {
-	auto ptr = obj.ptr();
-	hour = PyTime::GetHours(ptr);          // NOLINT
-	minute = PyTime::GetMinutes(ptr);      // NOLINT
-	second = PyTime::GetSeconds(ptr);      // NOLINT
-	microsecond = PyTime::GetMicros(ptr);  // NOLINT
-	timezone_obj = PyTime::GetTZInfo(ptr); // NOLINT
+	hour = PyTime::GetHours(obj);          // NOLINT
+	minute = PyTime::GetMinutes(obj);      // NOLINT
+	second = PyTime::GetSeconds(obj);      // NOLINT
+	microsecond = PyTime::GetMicros(obj);  // NOLINT
+	timezone_obj = PyTime::GetTZInfo(obj); // NOLINT
 }
 dtime_t PyTime::ToDuckTime() {
 	return Time::FromTime(hour, minute, second, microsecond);
@@ -232,43 +230,42 @@ Value PyTime::ToDuckValue() {
 	return Value::TIME(duckdb_time);
 }
 
-int32_t PyTime::GetHours(PyObject *obj) {
-	return PyDateTime_TIME_GET_HOUR(obj); // NOLINT
+int32_t PyTime::GetHours(py::handle &obj) {
+	return PyDateTime_TIME_GET_HOUR(obj.ptr()); // NOLINT
 }
 
-int32_t PyTime::GetMinutes(PyObject *obj) {
-	return PyDateTime_TIME_GET_MINUTE(obj); // NOLINT
+int32_t PyTime::GetMinutes(py::handle &obj) {
+	return PyDateTime_TIME_GET_MINUTE(obj.ptr()); // NOLINT
 }
 
-int32_t PyTime::GetSeconds(PyObject *obj) {
-	return PyDateTime_TIME_GET_SECOND(obj); // NOLINT
+int32_t PyTime::GetSeconds(py::handle &obj) {
+	return PyDateTime_TIME_GET_SECOND(obj.ptr()); // NOLINT
 }
 
-int32_t PyTime::GetMicros(PyObject *obj) {
-	return PyDateTime_TIME_GET_MICROSECOND(obj); // NOLINT
+int32_t PyTime::GetMicros(py::handle &obj) {
+	return PyDateTime_TIME_GET_MICROSECOND(obj.ptr()); // NOLINT
 }
 
-PyObject *PyTime::GetTZInfo(PyObject *obj) {
-	return PyDateTime_TIME_GET_TZINFO(obj); // NOLINT
+py::object PyTime::GetTZInfo(py::handle &obj) {
+	// The object returned is borrowed, there is no reference to steal
+	return py::reinterpret_borrow<py::object>(PyDateTime_TIME_GET_TZINFO(obj.ptr())); // NOLINT
 }
 
-interval_t PyTimezone::GetUTCOffset(PyObject *tzone_obj) {
-	auto tzinfo = py::reinterpret_borrow<py::object>(tzone_obj);
-	auto res = tzinfo.attr("utcoffset")(py::none());
+interval_t PyTimezone::GetUTCOffset(py::handle &tzone_obj) {
+	auto res = tzone_obj.attr("utcoffset")(py::none());
 	auto timedelta = PyTimeDelta(res);
 	return timedelta.ToInterval();
 }
 
 PyDateTime::PyDateTime(py::handle &obj) : obj(obj) {
-	auto ptr = obj.ptr();
-	year = PyDateTime::GetYears(ptr);
-	month = PyDateTime::GetMonths(ptr);
-	day = PyDateTime::GetDays(ptr);
-	hour = PyDateTime::GetHours(ptr);
-	minute = PyDateTime::GetMinutes(ptr);
-	second = PyDateTime::GetSeconds(ptr);
-	micros = PyDateTime::GetMicros(ptr);
-	tzone_obj = PyDateTime::GetTZInfo(ptr);
+	year = PyDateTime::GetYears(obj);
+	month = PyDateTime::GetMonths(obj);
+	day = PyDateTime::GetDays(obj);
+	hour = PyDateTime::GetHours(obj);
+	minute = PyDateTime::GetMinutes(obj);
+	second = PyDateTime::GetSeconds(obj);
+	micros = PyDateTime::GetMicros(obj);
+	tzone_obj = PyDateTime::GetTZInfo(obj);
 }
 
 timestamp_t PyDateTime::ToTimestamp() {
@@ -295,7 +292,7 @@ Value PyDateTime::ToDuckValue(const LogicalType &target_type) {
 		return Value::TIMESTAMP(timestamp_t::ninfinity());
 	}
 	auto timestamp = ToTimestamp();
-	if (tzone_obj != Py_None) {
+	if (!py::none().is(tzone_obj)) {
 		auto utc_offset = PyTimezone::GetUTCOffset(tzone_obj);
 		// Need to subtract the UTC offset, so we invert the interval
 		utc_offset = Interval::Invert(utc_offset);
@@ -326,43 +323,43 @@ dtime_t PyDateTime::ToDuckTime() {
 	return Time::FromTime(hour, minute, second, micros);
 }
 
-int32_t PyDateTime::GetYears(PyObject *obj) {
-	return PyDateTime_GET_YEAR(obj); // NOLINT
+int32_t PyDateTime::GetYears(py::handle &obj) {
+	return PyDateTime_GET_YEAR(obj.ptr()); // NOLINT
 }
 
-int32_t PyDateTime::GetMonths(PyObject *obj) {
-	return PyDateTime_GET_MONTH(obj); // NOLINT
+int32_t PyDateTime::GetMonths(py::handle &obj) {
+	return PyDateTime_GET_MONTH(obj.ptr()); // NOLINT
 }
 
-int32_t PyDateTime::GetDays(PyObject *obj) {
-	return PyDateTime_GET_DAY(obj); // NOLINT
+int32_t PyDateTime::GetDays(py::handle &obj) {
+	return PyDateTime_GET_DAY(obj.ptr()); // NOLINT
 }
 
-int32_t PyDateTime::GetHours(PyObject *obj) {
-	return PyDateTime_DATE_GET_HOUR(obj); // NOLINT
+int32_t PyDateTime::GetHours(py::handle &obj) {
+	return PyDateTime_DATE_GET_HOUR(obj.ptr()); // NOLINT
 }
 
-int32_t PyDateTime::GetMinutes(PyObject *obj) {
-	return PyDateTime_DATE_GET_MINUTE(obj); // NOLINT
+int32_t PyDateTime::GetMinutes(py::handle &obj) {
+	return PyDateTime_DATE_GET_MINUTE(obj.ptr()); // NOLINT
 }
 
-int32_t PyDateTime::GetSeconds(PyObject *obj) {
-	return PyDateTime_DATE_GET_SECOND(obj); // NOLINT
+int32_t PyDateTime::GetSeconds(py::handle &obj) {
+	return PyDateTime_DATE_GET_SECOND(obj.ptr()); // NOLINT
 }
 
-int32_t PyDateTime::GetMicros(PyObject *obj) {
-	return PyDateTime_DATE_GET_MICROSECOND(obj); // NOLINT
+int32_t PyDateTime::GetMicros(py::handle &obj) {
+	return PyDateTime_DATE_GET_MICROSECOND(obj.ptr()); // NOLINT
 }
 
-PyObject *PyDateTime::GetTZInfo(PyObject *obj) {
-	return PyDateTime_DATE_GET_TZINFO(obj); // NOLINT
+py::object PyDateTime::GetTZInfo(py::handle &obj) {
+	// The object returned is borrowed, there is no reference to steal
+	return py::reinterpret_borrow<py::object>(PyDateTime_DATE_GET_TZINFO(obj.ptr())); // NOLINT
 }
 
 PyDate::PyDate(py::handle &ele) {
-	auto ptr = ele.ptr();
-	year = PyDateTime::GetYears(ptr);
-	month = PyDateTime::GetMonths(ptr);
-	day = PyDateTime::GetDays(ptr);
+	year = PyDateTime::GetYears(ele);
+	month = PyDateTime::GetMonths(ele);
+	day = PyDateTime::GetDays(ele);
 }
 
 Value PyDate::ToDuckValue() {

--- a/tools/pythonpkg/src/numpy/array_wrapper.cpp
+++ b/tools/pythonpkg/src/numpy/array_wrapper.cpp
@@ -162,19 +162,20 @@ struct StringConvert {
 		// based on the max codepoint, we construct the result string
 		auto result = PyUnicode_New(start_pos + codepoint_count, max_codepoint);
 		// based on the resulting unicode kind, we fill in the code points
-		auto kind = PyUtil::PyUnicodeKind(result);
+		auto result_handle = py::handle(result);
+		auto kind = PyUtil::PyUnicodeKind(result_handle);
 		switch (kind) {
 		case PyUnicode_1BYTE_KIND:
-			ConvertUnicodeValueTemplated<Py_UCS1>(PyUtil::PyUnicode1ByteData(result), codepoints, codepoint_count, data,
-			                                      start_pos);
+			ConvertUnicodeValueTemplated<Py_UCS1>(PyUtil::PyUnicode1ByteData(result_handle), codepoints,
+			                                      codepoint_count, data, start_pos);
 			break;
 		case PyUnicode_2BYTE_KIND:
-			ConvertUnicodeValueTemplated<Py_UCS2>(PyUtil::PyUnicode2ByteData(result), codepoints, codepoint_count, data,
-			                                      start_pos);
+			ConvertUnicodeValueTemplated<Py_UCS2>(PyUtil::PyUnicode2ByteData(result_handle), codepoints,
+			                                      codepoint_count, data, start_pos);
 			break;
 		case PyUnicode_4BYTE_KIND:
-			ConvertUnicodeValueTemplated<Py_UCS4>(PyUtil::PyUnicode4ByteData(result), codepoints, codepoint_count, data,
-			                                      start_pos);
+			ConvertUnicodeValueTemplated<Py_UCS4>(PyUtil::PyUnicode4ByteData(result_handle), codepoints,
+			                                      codepoint_count, data, start_pos);
 			break;
 		default:
 			throw NotImplementedException("Unsupported typekind constant '%d' for Python Unicode Compact decode", kind);
@@ -198,7 +199,8 @@ struct StringConvert {
 		// no unicode: fast path
 		// directly construct the string and memcpy it
 		auto result = PyUnicode_New(len, 127);
-		auto target_data = PyUtil::PyUnicodeDataMutable(result);
+		auto result_handle = py::handle(result);
+		auto target_data = PyUtil::PyUnicodeDataMutable(result_handle);
 		memcpy(target_data, data, len);
 		return result;
 	}

--- a/tools/pythonpkg/src/numpy/numpy_scan.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_scan.cpp
@@ -319,9 +319,8 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 					if (!gil) {
 						gil = make_uniq<PythonGILWrapper>();
 					}
-					bind_data.object_str_val.AssignInternal<py::handle>(
-					    [](py::str &obj, py::handle new_val) { obj = py::str(new_val); }, val);
-					val = reinterpret_cast<PyObject *>(bind_data.object_str_val.GetPointerTop()->ptr());
+					bind_data.object_str_val.Push(std::move(py::str(val)));
+					val = reinterpret_cast<PyObject *>(bind_data.object_str_val.LastAddedObject().ptr());
 				}
 			}
 			// Python 3 string representation:

--- a/tools/pythonpkg/src/numpy/numpy_scan.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_scan.cpp
@@ -317,14 +317,10 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 				}
 				if (!py::isinstance<py::str>(val)) {
 					if (!gil) {
-						gil = bind_data.object_str_val.GetLock();
+						gil = make_uniq<PythonGILWrapper>();
 					}
-					bind_data.object_str_val.AssignInternal<PyObject>(
-					    [](py::str &obj, PyObject &new_val) {
-						    py::handle object_handle = &new_val;
-						    obj = py::str(object_handle);
-					    },
-					    *val, *gil);
+					bind_data.object_str_val.AssignInternal<py::handle>(
+					    [](py::str &obj, py::handle new_val) { obj = py::str(new_val); }, val);
 					val = reinterpret_cast<PyObject *>(bind_data.object_str_val.GetPointerTop()->ptr());
 				}
 			}

--- a/tools/pythonpkg/src/numpy/numpy_scan.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_scan.cpp
@@ -325,13 +325,14 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 			}
 			// Python 3 string representation:
 			// https://github.com/python/cpython/blob/3a8fdb28794b2f19f6c8464378fb8b46bce1f5f4/Include/cpython/unicodeobject.h#L79
-			if (!py::isinstance<py::str>(val)) {
+			py::handle val_handle(val);
+			if (!py::isinstance<py::str>(val_handle)) {
 				out_mask.SetInvalid(row);
 				continue;
 			}
-			if (PyUtil::PyUnicodeIsCompactASCII(val)) {
+			if (PyUtil::PyUnicodeIsCompactASCII(val_handle)) {
 				// ascii string: we can zero copy
-				tgt_ptr[row] = string_t(PyUtil::PyUnicodeData(val), PyUtil::PyUnicodeGetLength(val));
+				tgt_ptr[row] = string_t(PyUtil::PyUnicodeData(val_handle), PyUtil::PyUnicodeGetLength(val_handle));
 			} else {
 				// unicode gunk
 				auto ascii_obj = reinterpret_cast<PyASCIIObject *>(val);
@@ -342,19 +343,19 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 					tgt_ptr[row] = string_t(const_char_ptr_cast(unicode_obj->utf8), unicode_obj->utf8_length);
 				} else if (PyUtil::PyUnicodeIsCompact(unicode_obj) &&
 				           !PyUtil::PyUnicodeIsASCII(unicode_obj)) { // NOLINT
-					auto kind = PyUtil::PyUnicodeKind(val);
+					auto kind = PyUtil::PyUnicodeKind(val_handle);
 					switch (kind) {
 					case PyUnicode_1BYTE_KIND:
-						tgt_ptr[row] = DecodePythonUnicode<Py_UCS1>(PyUtil::PyUnicode1ByteData(val),
-						                                            PyUtil::PyUnicodeGetLength(val), out);
+						tgt_ptr[row] = DecodePythonUnicode<Py_UCS1>(PyUtil::PyUnicode1ByteData(val_handle),
+						                                            PyUtil::PyUnicodeGetLength(val_handle), out);
 						break;
 					case PyUnicode_2BYTE_KIND:
-						tgt_ptr[row] = DecodePythonUnicode<Py_UCS2>(PyUtil::PyUnicode2ByteData(val),
-						                                            PyUtil::PyUnicodeGetLength(val), out);
+						tgt_ptr[row] = DecodePythonUnicode<Py_UCS2>(PyUtil::PyUnicode2ByteData(val_handle),
+						                                            PyUtil::PyUnicodeGetLength(val_handle), out);
 						break;
 					case PyUnicode_4BYTE_KIND:
-						tgt_ptr[row] = DecodePythonUnicode<Py_UCS4>(PyUtil::PyUnicode4ByteData(val),
-						                                            PyUtil::PyUnicodeGetLength(val), out);
+						tgt_ptr[row] = DecodePythonUnicode<Py_UCS4>(PyUtil::PyUnicode4ByteData(val_handle),
+						                                            PyUtil::PyUnicodeGetLength(val_handle), out);
 						break;
 					default:
 						throw NotImplementedException(

--- a/tools/pythonpkg/src/python_import_cache.cpp
+++ b/tools/pythonpkg/src/python_import_cache.cpp
@@ -20,7 +20,7 @@ bool PythonImportCacheItem::IsLoaded() const {
 	return type.ptr() != nullptr;
 }
 
-PyObject *PythonImportCacheItem::AddCache(PythonImportCache &cache, py::object object) {
+py::handle PythonImportCacheItem::AddCache(PythonImportCache &cache, py::object object) {
 	return cache.AddCache(std::move(object));
 }
 
@@ -59,7 +59,7 @@ PythonImportCache::~PythonImportCache() {
 	owned_objects.clear();
 }
 
-PyObject *PythonImportCache::AddCache(py::object item) {
+py::handle PythonImportCache::AddCache(py::object item) {
 	auto object_ptr = item.ptr();
 	owned_objects.push_back(std::move(item));
 	return object_ptr;

--- a/tools/pythonpkg/src/python_udf.cpp
+++ b/tools/pythonpkg/src/python_udf.cpp
@@ -163,9 +163,9 @@ static scalar_function_t CreateNativeFunction(PyObject *function, PythonExceptio
 		py::gil_scoped_acquire gil;
 
 		// owning references
-		vector<py::handle> python_objects;
+		vector<py::object> python_objects;
 		vector<PyObject *> python_results;
-		python_results.reserve(input.size());
+		python_results.resize(input.size());
 		for (idx_t row = 0; row < input.size(); row++) {
 
 			auto bundled_parameters = py::tuple((int)input.ColumnCount());
@@ -190,8 +190,8 @@ static scalar_function_t CreateNativeFunction(PyObject *function, PythonExceptio
 					throw NotImplementedException("Exception handling type not implemented");
 				}
 			}
-			python_objects.push_back(py::handle(ret));
-			python_results.push_back(ret);
+			python_objects.push_back(py::reinterpret_steal<py::object>(ret));
+			python_results[row] = ret;
 		}
 
 		NumpyScan::ScanObjectColumn(python_results.data(), sizeof(PyObject *), input.size(), 0, result);


### PR DESCRIPTION
This PR tries to remove all usage of raw `PyObject *` in favor of `py::object` and `py::handle` where possible.

For the longest time these concepts were not really clear to me and I've almost used them interchangeably.
This has caused memory leaks in the past.
And while working on this I've identified a couple places that looked problematic (python udfs and the `map` method for example)

I've added some documentation on py::object and py::handle, when they should be used and replaced almost all usage of raw PyObject*'s with the handle/object equivalent.

Especially when interacting with the CPython functions directly this could easily cause a memory leak if we save this pointer in a handle and don't deal with the owned reference we've been given.

## PythonObjectContainer

This code was a little terse and overcomplicated, I've reduced it to a much more general version that should serve the exact same purpose.