### PR TITLE
Fix CMake syntax on non defined variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -925,7 +925,7 @@ foreach(EXT_NAME IN LISTS DUCKDB_EXTENSION_NAMES)
   endif()
 
   # Warning for trying to load vcpkg extensions without having VCPKG_BUILD SET
-  if (EXISTS "${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_PATH}/vcpkg.json" AND NOT "${VCPKG_BUILD}")
+  if (EXISTS "${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_PATH}/vcpkg.json" AND NOT DEFINED VCPKG_BUILD)
     message(WARNING "Extension '${EXT_NAME}' has a vcpkg.json, but build was not run with VCPKG. If build fails, check out VCPKG build instructions in 'duckdb/extension/README.md' or try manually installing the dependencies in ${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_PATH}vcpkg.json")
   endif()
 


### PR DESCRIPTION
Fix syntax, as evidenced by these breakages on WebAssembly CI: https://github.com/duckdb/duckdb/actions/runs/5686773889/job/15414149342.

Unsure if we want to have some way to test this codepath anyhow, and probably a second pass to fix WebAssembly invocation is then probably needed, but this should be a trivial fix.