### PR TITLE
CI: NighlyTests to be run also on pull requests with specific label

### DIFF
--- a/.github/workflows/ExtraTestTrigger.yml
+++ b/.github/workflows/ExtraTestTrigger.yml
@@ -1,0 +1,26 @@
+name: NightlyTests
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, labeled]
+    paths-ignore:
+      - '**.md'
+      - '.github/workflows/**'
+      - '!.github/workflows/NightlyTests.yml'
+      - '!.github/patches/duckdb-wasm/**'
+
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+jobs:
+   trigger-nightly:
+      - name: Trigger Workflow
+        if: contains(github.event.pull_request.labels.*.name, 'stress test')
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'NightlyTests.yml',
+              ref: ${{ github.event.pull_request.head.ref }},
+            })

--- a/.github/workflows/ExtraTestTrigger.yml
+++ b/.github/workflows/ExtraTestTrigger.yml
@@ -14,6 +14,7 @@ env:
 jobs:
    trigger-nightly:
      name: Trigger Workflow
+     runs-on: ubuntu-latest
      if: contains(github.event.pull_request.labels.*.name, 'stress test')
      steps:
      - uses: actions/github-script@v6

--- a/.github/workflows/ExtraTestTrigger.yml
+++ b/.github/workflows/ExtraTestTrigger.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
    trigger-nightly:
-      - name: Trigger Workflow
+        name: Trigger Workflow
         if: contains(github.event.pull_request.labels.*.name, 'stress test')
         uses: actions/github-script@v6
         with:

--- a/.github/workflows/ExtraTestTrigger.yml
+++ b/.github/workflows/ExtraTestTrigger.yml
@@ -24,5 +24,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'NightlyTests.yml',
-              ref: ${{ github.event.pull_request.head.ref }},
+              ref: '${{ github.event.pull_request.head.ref }}',
             })

--- a/.github/workflows/ExtraTestTrigger.yml
+++ b/.github/workflows/ExtraTestTrigger.yml
@@ -13,10 +13,11 @@ env:
 
 jobs:
    trigger-nightly:
-        name: Trigger Workflow
-        if: contains(github.event.pull_request.labels.*.name, 'stress test')
-        uses: actions/github-script@v6
-        with:
+     name: Trigger Workflow
+     if: contains(github.event.pull_request.labels.*.name, 'stress test')
+     steps:
+     - uses: actions/github-script@v6
+       with:
           script: |
             github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -8,6 +8,8 @@
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
+
+
 namespace duckdb {
 
 FunctionData::~FunctionData() {


### PR DESCRIPTION
I would propose that PR with label 'stress test'* have NightlyTests.yml executed together (and in the same cases) than when regular CI are triggered.

Proposal is that as long as something is NOT tagged 'stress test', behaviour is the same as today.
If a PR is tagged 'stress test', then whenever CI is triggered also NightlyTests.yml will be executed.

This would solve the problem that if one is committing wide changes, having a run on full test set might be beneficial, and currently we miss a mechanism to do that in a nice way (having stuff run on forks is brittle / not easy to track down).
Also if a PR aims to solve a problem with testing itself, it would be good to have a more visible proof that a given problem has been actually solved.

Responsibility to add (and also potentially remove) the 'stress test' label is on whoever opened a PR and/or reviewers that might feel more extensive checks are needed.

I am not sold on the name 'stress test', if anyone has a better one, very welcome! (@taniabogatsch?)