### PR TITLE
Use bot token for issue workflows and increase stale issue budget

### DIFF
--- a/.github/workflows/InternalIssuesCreateMirror.yml
+++ b/.github/workflows/InternalIssuesCreateMirror.yml
@@ -5,7 +5,7 @@ on:
       - labeled
 
 env:
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  GH_TOKEN: ${{ secrets.DUCKDBLABS_BOT_TOKEN }}
   TITLE_PREFIX: "[duckdb/#${{ github.event.issue.number }}]"
 
 jobs:

--- a/.github/workflows/InternalIssuesCreateMirror.yml
+++ b/.github/workflows/InternalIssuesCreateMirror.yml
@@ -45,11 +45,17 @@ jobs:
             echo "LABEL=needs triage" >> $GITHUB_ENV
             echo "UNLABEL=needs label" >> $GITHUB_ENV
           fi
+          
+      - name: Get public issue title safely
+        run: |
+          cat << "Eebaefae2quoManoh2yi" >> $GITHUB_ENV
+          PUBLIC_ISSUE_TITLE=${{ github.event.issue.title }}
+          Eebaefae2quoManoh2yi
 
       - name: Create or label issue
         run: |
           if [ "$MIRROR_ISSUE_NUMBER" == "" ]; then
-            gh issue create --repo duckdblabs/duckdb-internal --label "$LABEL" --title "$TITLE_PREFIX - ${{ github.event.issue.title }}" --body "See https://github.com/duckdb/duckdb/issues/${{ github.event.issue.number }}"
+            gh issue create --repo duckdblabs/duckdb-internal --label "$LABEL" --title "$TITLE_PREFIX - $PUBLIC_ISSUE_TITLE" --body "See https://github.com/duckdb/duckdb/issues/${{ github.event.issue.number }}"
           else
             gh issue edit --repo duckdblabs/duckdb-internal $MIRROR_ISSUE_NUMBER --remove-label "$UNLABEL" --add-label "$LABEL"
           fi

--- a/.github/workflows/InternalIssuesUpdateMirror.yml
+++ b/.github/workflows/InternalIssuesUpdateMirror.yml
@@ -6,7 +6,7 @@ on:
       - reopened
 
 env:
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  GH_TOKEN: ${{ secrets.DUCKDBLABS_BOT_TOKEN }}
   TITLE_PREFIX: "[duckdb/#${{ github.event.issue.number }}]"
 
 jobs:

--- a/.github/workflows/IssuesCloseStale.yml
+++ b/.github/workflows/IssuesCloseStale.yml
@@ -2,8 +2,6 @@ name: Close Stale Issues
 on:
   repository_dispatch:
   workflow_dispatch:
-  schedule:
-    - cron: '00 0 * * *'
 
 jobs:
   close_stale_issues:

--- a/.github/workflows/IssuesCloseStale.yml
+++ b/.github/workflows/IssuesCloseStale.yml
@@ -14,3 +14,4 @@ jobs:
           close-issue-message: 'This issue was closed because it has been stale for 30 days with no activity.'
           days-before-stale: 90
           days-before-close: 30
+          operations-per-run: 500

--- a/.github/workflows/IssuesCloseStale.yml
+++ b/.github/workflows/IssuesCloseStale.yml
@@ -1,5 +1,7 @@
 name: Close Stale Issues
 on:
+  repository_dispatch:
+  workflow_dispatch:
   schedule:
     - cron: '00 0 * * *'
 


### PR DESCRIPTION
The stale issue bot timed out after replying to 30 issues, so I've increased its budget (for now). Maybe we can decrease it later when the bot has gone through all of the stale issues.