### PR TITLE
Set total_byte_size of Parquet row groups

### DIFF
--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -297,6 +297,7 @@ void ParquetWriter::PrepareRowGroup(ColumnDataCollection &buffer, PreparedRowGro
 	// set up a new row group for this chunk collection
 	auto &row_group = result.row_group;
 	row_group.num_rows = buffer.Count();
+	row_group.total_byte_size = buffer.SizeInBytes();
 	row_group.__isset.file_offset = true;
 
 	auto &states = result.states;

--- a/test/sql/copy/parquet/writer/row_group_size_bytes.test
+++ b/test/sql/copy/parquet/writer/row_group_size_bytes.test
@@ -28,6 +28,12 @@ select max(row_group_num_rows) from parquet_metadata('__TEST_DIR__/tbl.parquet')
 ----
 16384
 
+# also test that we set this thing
+query T
+select min(row_group_bytes) != 0 from parquet_metadata('__TEST_DIR__/tbl.parquet')
+----
+1
+
 # and also just integer values
 # we set the memory limit to be half as big, and we get a max row group size of half what we had before
 statement ok


### PR DESCRIPTION
Set uncompressed size of row group in parquet metadata as per the spec:
```
/** Total byte size of all the uncompressed column data in this row group **/
required i64 total_byte_size
```