### PR TITLE
read_csv_auto tests: Change 'delimiter' to 'delim'

### DIFF
--- a/test/sql/copy/csv/read_csv_subquery.test
+++ b/test/sql/copy/csv/read_csv_subquery.test
@@ -10,7 +10,7 @@ WITH urls AS (
 	SELECT 'a.csv' AS url UNION ALL SELECT 'b.csv'
 )
 SELECT *
-FROM read_csv_auto((SELECT url FROM urls LIMIT 3), delimiter=',')
+FROM read_csv_auto((SELECT url FROM urls LIMIT 3), delim=',')
 WHERE properties.height > -1.0
 LIMIT 10
 ----
@@ -30,6 +30,6 @@ Table function cannot contain aggregates
 
 statement error
 SELECT *
-FROM read_csv_auto('a.csv', delimiter=',', 42)
+FROM read_csv_auto('a.csv', delim=',', 42)
 ----
 Unnamed parameters cannot come after named parameters


### PR DESCRIPTION
I found this minor issue in the test suite: the parameter of `read_csv_auto` to specify the delimiter is now called `delim` and not `delimiter`. This does not cause any issue because the tests are supposed to fail anyways (with a `statement error`) but they should do so because of a different reason, not the name of the `delim` parameter.