### PR TITLE
Issue #8399: ICU Epoch Offset

### DIFF
--- a/extension/icu/icu-datepart.cpp
+++ b/extension/icu/icu-datepart.cpp
@@ -109,11 +109,8 @@ struct ICUDatePart : public ICUDateFunc {
 
 	static int64_t ExtractEpoch(icu::Calendar *calendar, const uint64_t micros) {
 		UErrorCode status = U_ZERO_ERROR;
-		auto millis = calendar->getTime(status);
-		millis += ExtractField(calendar, UCAL_ZONE_OFFSET);
-		millis += ExtractField(calendar, UCAL_DST_OFFSET);
 		//	Truncate
-		return millis / Interval::MSECS_PER_SEC;
+		return calendar->getTime(status) / Interval::MSECS_PER_SEC;
 	}
 
 	static int64_t ExtractTimezone(icu::Calendar *calendar, const uint64_t micros) {
@@ -200,7 +197,12 @@ struct ICUDatePart : public ICUDateFunc {
 
 		calendar->set(UCAL_DATE, dd);
 
-		return Date::EpochToDate(ExtractEpoch(calendar, 0));
+		//	Offset to UTC
+		auto millis = calendar->getTime(status);
+		millis += ExtractField(calendar, UCAL_ZONE_OFFSET);
+		millis += ExtractField(calendar, UCAL_DST_OFFSET);
+
+		return Date::EpochToDate(millis / Interval::MSECS_PER_SEC);
 	}
 
 	static string_t MonthName(icu::Calendar *calendar, const uint64_t micros) {

--- a/test/sql/function/timestamp/test_icu_datepart.test
+++ b/test/sql/function/timestamp/test_icu_datepart.test
@@ -304,14 +304,14 @@ NULL	NULL
 query II
 SELECT epoch(ts), epoch(ts::TIMESTAMP) FROM timestamps;
 ----
--63517990756	-63517817956
--234211151	-234211151
-1609430400	1609430400
-1612195200	1612195200
-1637892913	1637892913
-1636943400	1636943400
-1636939800	1636939800
-1640354400	1640354400
+-63517962378	-63517817956
+-234185951	-234211151
+1609459200	1609430400
+1612224000	1612195200
+1637921713	1637892913
+1636972200	1636943400
+1636968600	1636939800
+1640383200	1640354400
 NULL	NULL
 NULL	NULL
 NULL	NULL
@@ -320,7 +320,7 @@ query III
 SELECT date_part(part, ts), date_part(part, ts::TIMESTAMP), part FROM timestamps;
 ----
 0	0	era
--234211151	-234211151	epoch
+-234185951	-234211151	epoch
 2020	2020	year
 2	2	month
 13123456	13123456	microsecond
@@ -611,14 +611,14 @@ ORDER BY 2
 ----
 NULL	NULL
 {'epoch': NULL, 'second': NULL, 'timezone': NULL, 'timezone_hour': NULL, 'timezone_minute': NULL}	-infinity
-{'epoch': -63517990756, 'second': 43, 'timezone': -28378, 'timezone_hour': -7, 'timezone_minute': -52}	0044-03-15 (BC) 01:40:43.987654-07:52
-{'epoch': -234211151, 'second': 48, 'timezone': -25200, 'timezone_hour': -7, 'timezone_minute': 0}	1962-07-31 05:20:48.123456-07
-{'epoch': 1609430400, 'second': 0, 'timezone': -28800, 'timezone_hour': -8, 'timezone_minute': 0}	2020-12-31 16:00:00-08
-{'epoch': 1612195200, 'second': 0, 'timezone': -28800, 'timezone_hour': -8, 'timezone_minute': 0}	2021-02-01 16:00:00-08
-{'epoch': 1636939800, 'second': 0, 'timezone': -28800, 'timezone_hour': -8, 'timezone_minute': 0}	2021-11-15 01:30:00-08
-{'epoch': 1636943400, 'second': 0, 'timezone': -28800, 'timezone_hour': -8, 'timezone_minute': 0}	2021-11-15 02:30:00-08
-{'epoch': 1637892913, 'second': 13, 'timezone': -28800, 'timezone_hour': -8, 'timezone_minute': 0}	2021-11-26 02:15:13.123456-08
-{'epoch': 1640354400, 'second': 0, 'timezone': -28800, 'timezone_hour': -8, 'timezone_minute': 0}	2021-12-24 14:00:00-08
+{'epoch': -63517962378, 'second': 43, 'timezone': -28378, 'timezone_hour': -7, 'timezone_minute': -52}	0044-03-15 (BC) 01:40:43.987654-07:52
+{'epoch': -234185951, 'second': 48, 'timezone': -25200, 'timezone_hour': -7, 'timezone_minute': 0}	1962-07-31 05:20:48.123456-07
+{'epoch': 1609459200, 'second': 0, 'timezone': -28800, 'timezone_hour': -8, 'timezone_minute': 0}	2020-12-31 16:00:00-08
+{'epoch': 1612224000, 'second': 0, 'timezone': -28800, 'timezone_hour': -8, 'timezone_minute': 0}	2021-02-01 16:00:00-08
+{'epoch': 1636968600, 'second': 0, 'timezone': -28800, 'timezone_hour': -8, 'timezone_minute': 0}	2021-11-15 01:30:00-08
+{'epoch': 1636972200, 'second': 0, 'timezone': -28800, 'timezone_hour': -8, 'timezone_minute': 0}	2021-11-15 02:30:00-08
+{'epoch': 1637921713, 'second': 13, 'timezone': -28800, 'timezone_hour': -8, 'timezone_minute': 0}	2021-11-26 02:15:13.123456-08
+{'epoch': 1640383200, 'second': 0, 'timezone': -28800, 'timezone_hour': -8, 'timezone_minute': 0}	2021-12-24 14:00:00-08
 {'epoch': NULL, 'second': NULL, 'timezone': NULL, 'timezone_hour': NULL, 'timezone_minute': NULL}	infinity
 
 # Correctness: Compare struct values with scalar values


### PR DESCRIPTION
The epoch extractor was offsetting from UTC, which was not correct. The last_day function was relying on this behaviour, so it has been moved there.