### PR TITLE
Get issue title safely in workflow

### DIFF
--- a/.github/workflows/InternalIssuesCreateMirror.yml
+++ b/.github/workflows/InternalIssuesCreateMirror.yml
@@ -7,6 +7,7 @@ on:
 env:
   GH_TOKEN: ${{ secrets.DUCKDBLABS_BOT_TOKEN }}
   TITLE_PREFIX: "[duckdb/#${{ github.event.issue.number }}]"
+  PUBLIC_ISSUE_TITLE: ${{ github.event.issue.title }}
 
 jobs:
   create_or_label_issue:
@@ -45,12 +46,6 @@ jobs:
             echo "LABEL=needs triage" >> $GITHUB_ENV
             echo "UNLABEL=needs label" >> $GITHUB_ENV
           fi
-          
-      - name: Get public issue title safely
-        run: |
-          cat << "Eebaefae2quoManoh2yi" >> $GITHUB_ENV
-          PUBLIC_ISSUE_TITLE=${{ github.event.issue.title }}
-          Eebaefae2quoManoh2yi
 
       - name: Create or label issue
         run: |


### PR DESCRIPTION
The previous implementation was not safe although we could have easily identified malicious titles ourselves. This should be always safe