### PR TITLE
Add "require noalternativeverify" to all FTS tests

### DIFF
--- a/test/sql/fts/test_fts_attach.test
+++ b/test/sql/fts/test_fts_attach.test
@@ -8,6 +8,8 @@ require fts
 
 require skip_reload
 
+require noalternativeverify
+
 statement ok
 ATTACH '__TEST_DIR__/tester.db' as search_con
 

--- a/test/sql/fts/test_indexing.test_slow
+++ b/test/sql/fts/test_indexing.test_slow
@@ -6,6 +6,8 @@ require skip_reload
 
 require fts
 
+require noalternativeverify
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/fts/test_indexing_and_schema.test
+++ b/test/sql/fts/test_indexing_and_schema.test
@@ -4,6 +4,8 @@
 
 require fts
 
+require noalternativeverify
+
 statement ok
 CREATE SCHEMA test
 

--- a/test/sql/fts/test_issue_5936.test
+++ b/test/sql/fts/test_issue_5936.test
@@ -6,6 +6,8 @@ require skip_reload
 
 require fts
 
+require noalternativeverify
+
 statement ok
 CREATE TABLE documents(document VARCHAR, url VARCHAR);
 


### PR DESCRIPTION
Should fix nightly CI run failure. The problem is that an internal verifier tries to create a materialized CTE, but we can't because it's a correlated subquery.