### PR TITLE
Check for duplicate member tag names in serialization generation

### DIFF
--- a/src/include/duckdb/storage/object_cache.hpp
+++ b/src/include/duckdb/storage/object_cache.hpp
@@ -48,7 +48,7 @@ public:
 	}
 
 	template <class T, class... Args>
-	shared_ptr<T> GetOrCreate(const string &key, Args &&...args) {
+	shared_ptr<T> GetOrCreate(const string &key, Args &&... args) {
 		lock_guard<mutex> glock(lock);
 
 		auto entry = cache.find(key);

--- a/src/include/duckdb/storage/serialization/constraint.json
+++ b/src/include/duckdb/storage/serialization/constraint.json
@@ -50,7 +50,7 @@
         "type": "vector<string>"
       },
       {
-        "name": "type",
+        "name": "fk_type",
         "type": "ForeignKeyType",
         "property": "info.type"
       },

--- a/src/include/duckdb/storage/serialization/create_info.json
+++ b/src/include/duckdb/storage/serialization/create_info.json
@@ -152,7 +152,8 @@
         "type": "string"
       },
       {
-        "name": "type",
+        "name": "logical_type",
+        "property": "type",
         "type": "LogicalType"
       }
     ]

--- a/src/include/duckdb/storage/serialization/parse_info.json
+++ b/src/include/duckdb/storage/serialization/parse_info.json
@@ -184,7 +184,8 @@
         "type": "vector<PhysicalIndex>"
       },
       {
-        "name": "type",
+        "name": "alter_fk_type",
+        "property": "type",
         "type": "AlterForeignKeyType"
       }
     ]

--- a/src/include/duckdb/storage/serialization/tableref.json
+++ b/src/include/duckdb/storage/serialization/tableref.json
@@ -63,7 +63,8 @@
         "optional": true
       },
       {
-        "name": "type",
+        "name": "join_type",
+        "property": "type",
         "type": "JoinType"
       },
       {
@@ -99,10 +100,6 @@
       {
         "name": "function",
         "type": "ParsedExpression*"
-      },
-      {
-        "name": "alias",
-        "type": "string"
       },
       {
         "name": "column_name_alias",

--- a/src/storage/serialization/serialize_constraint.cpp
+++ b/src/storage/serialization/serialize_constraint.cpp
@@ -50,7 +50,7 @@ void ForeignKeyConstraint::FormatSerialize(FormatSerializer &serializer) const {
 	Constraint::FormatSerialize(serializer);
 	serializer.WriteProperty("pk_columns", pk_columns);
 	serializer.WriteProperty("fk_columns", fk_columns);
-	serializer.WriteProperty("type", info.type);
+	serializer.WriteProperty("fk_type", info.type);
 	serializer.WriteProperty("schema", info.schema);
 	serializer.WriteProperty("table", info.table);
 	serializer.WriteProperty("pk_keys", info.pk_keys);
@@ -61,7 +61,7 @@ unique_ptr<Constraint> ForeignKeyConstraint::FormatDeserialize(FormatDeserialize
 	auto result = duckdb::unique_ptr<ForeignKeyConstraint>(new ForeignKeyConstraint());
 	deserializer.ReadProperty("pk_columns", result->pk_columns);
 	deserializer.ReadProperty("fk_columns", result->fk_columns);
-	deserializer.ReadProperty("type", result->info.type);
+	deserializer.ReadProperty("fk_type", result->info.type);
 	deserializer.ReadProperty("schema", result->info.schema);
 	deserializer.ReadProperty("table", result->info.table);
 	deserializer.ReadProperty("pk_keys", result->info.pk_keys);

--- a/src/storage/serialization/serialize_create_info.cpp
+++ b/src/storage/serialization/serialize_create_info.cpp
@@ -160,13 +160,13 @@ unique_ptr<CreateInfo> CreateTableInfo::FormatDeserialize(FormatDeserializer &de
 void CreateTypeInfo::FormatSerialize(FormatSerializer &serializer) const {
 	CreateInfo::FormatSerialize(serializer);
 	serializer.WriteProperty("name", name);
-	serializer.WriteProperty("type", type);
+	serializer.WriteProperty("logical_type", type);
 }
 
 unique_ptr<CreateInfo> CreateTypeInfo::FormatDeserialize(FormatDeserializer &deserializer) {
 	auto result = duckdb::unique_ptr<CreateTypeInfo>(new CreateTypeInfo());
 	deserializer.ReadProperty("name", result->name);
-	deserializer.ReadProperty("type", result->type);
+	deserializer.ReadProperty("logical_type", result->type);
 	return std::move(result);
 }
 

--- a/src/storage/serialization/serialize_parse_info.cpp
+++ b/src/storage/serialization/serialize_parse_info.cpp
@@ -176,7 +176,7 @@ void AlterForeignKeyInfo::FormatSerialize(FormatSerializer &serializer) const {
 	serializer.WriteProperty("fk_columns", fk_columns);
 	serializer.WriteProperty("pk_keys", pk_keys);
 	serializer.WriteProperty("fk_keys", fk_keys);
-	serializer.WriteProperty("type", type);
+	serializer.WriteProperty("alter_fk_type", type);
 }
 
 unique_ptr<AlterTableInfo> AlterForeignKeyInfo::FormatDeserialize(FormatDeserializer &deserializer) {
@@ -186,7 +186,7 @@ unique_ptr<AlterTableInfo> AlterForeignKeyInfo::FormatDeserialize(FormatDeserial
 	deserializer.ReadProperty("fk_columns", result->fk_columns);
 	deserializer.ReadProperty("pk_keys", result->pk_keys);
 	deserializer.ReadProperty("fk_keys", result->fk_keys);
-	deserializer.ReadProperty("type", result->type);
+	deserializer.ReadProperty("alter_fk_type", result->type);
 	return std::move(result);
 }
 

--- a/src/storage/serialization/serialize_tableref.cpp
+++ b/src/storage/serialization/serialize_tableref.cpp
@@ -96,7 +96,7 @@ void JoinRef::FormatSerialize(FormatSerializer &serializer) const {
 	serializer.WriteProperty("left", *left);
 	serializer.WriteProperty("right", *right);
 	serializer.WriteOptionalProperty("condition", condition);
-	serializer.WriteProperty("type", type);
+	serializer.WriteProperty("join_type", type);
 	serializer.WriteProperty("ref_type", ref_type);
 	serializer.WriteProperty("using_columns", using_columns);
 }
@@ -106,7 +106,7 @@ unique_ptr<TableRef> JoinRef::FormatDeserialize(FormatDeserializer &deserializer
 	deserializer.ReadProperty("left", result->left);
 	deserializer.ReadProperty("right", result->right);
 	deserializer.ReadOptionalProperty("condition", result->condition);
-	deserializer.ReadProperty("type", result->type);
+	deserializer.ReadProperty("join_type", result->type);
 	deserializer.ReadProperty("ref_type", result->ref_type);
 	deserializer.ReadProperty("using_columns", result->using_columns);
 	return std::move(result);
@@ -151,14 +151,14 @@ unique_ptr<TableRef> SubqueryRef::FormatDeserialize(FormatDeserializer &deserial
 void TableFunctionRef::FormatSerialize(FormatSerializer &serializer) const {
 	TableRef::FormatSerialize(serializer);
 	serializer.WriteProperty("function", *function);
-	serializer.WriteProperty("alias", alias);
+	serializer.WriteProperty("function_alias", alias);
 	serializer.WriteProperty("column_name_alias", column_name_alias);
 }
 
 unique_ptr<TableRef> TableFunctionRef::FormatDeserialize(FormatDeserializer &deserializer) {
 	auto result = duckdb::unique_ptr<TableFunctionRef>(new TableFunctionRef());
 	deserializer.ReadProperty("function", result->function);
-	deserializer.ReadProperty("alias", result->alias);
+	deserializer.ReadProperty("function_alias", result->alias);
 	deserializer.ReadProperty("column_name_alias", result->column_name_alias);
 	return std::move(result);
 }

--- a/src/storage/serialization/serialize_tableref.cpp
+++ b/src/storage/serialization/serialize_tableref.cpp
@@ -151,14 +151,12 @@ unique_ptr<TableRef> SubqueryRef::FormatDeserialize(FormatDeserializer &deserial
 void TableFunctionRef::FormatSerialize(FormatSerializer &serializer) const {
 	TableRef::FormatSerialize(serializer);
 	serializer.WriteProperty("function", *function);
-	serializer.WriteProperty("function_alias", alias);
 	serializer.WriteProperty("column_name_alias", column_name_alias);
 }
 
 unique_ptr<TableRef> TableFunctionRef::FormatDeserialize(FormatDeserializer &deserializer) {
 	auto result = duckdb::unique_ptr<TableFunctionRef>(new TableFunctionRef());
 	deserializer.ReadProperty("function", result->function);
-	deserializer.ReadProperty("function_alias", result->alias);
 	deserializer.ReadProperty("column_name_alias", result->column_name_alias);
 	return std::move(result);
 }

--- a/test/sql/json/test_serialize_sql.test
+++ b/test/sql/json/test_serialize_sql.test
@@ -89,3 +89,10 @@ statement error
 SELECT * FROM json_execute_serialized_sql(json_serialize_sql('SELECT * FROM tbl2', skip_null := true, skip_empty := true));
 ----
 Parser Error: Expected but did not find property 'modifiers' in json object: '{"type":"SELECT_NODE","select_list":[{"class":"STAR","type":"STAR","columns":false}],"from_table":{"type":"BASE_TABLE","table_name":"tbl2"},"aggregate_handling":"STANDARD_HANDLING"}'
+
+
+# Test execute json serialized sql with multiple nested type tags
+query II
+SELECT * FROM json_execute_serialized_sql(json_serialize_sql('WITH a(i) as (SELECT 1) SELECT a1.i as i1, a2.i as i2 FROM a as a1, a as a2'));
+----
+1	1


### PR DESCRIPTION
Also adjust some tag names to no longer conflict within their inheritance chain.

Closes #8381