### PR TITLE
Fix issue 8230

### DIFF
--- a/.github/config/uncovered_files.csv
+++ b/.github/config/uncovered_files.csv
@@ -35,6 +35,7 @@ common/file_system.cpp	19
 common/fsst.cpp	7
 common/gzip_file_system.cpp	40
 common/hive_partitioning.cpp	54
+common/http_state.cpp	36
 common/local_file_system.cpp	16
 common/multi_file_reader.cpp	15
 common/operator/cast_operators.cpp	72
@@ -475,7 +476,7 @@ main/connection.cpp	38
 main/database.cpp	39
 main/database_manager.cpp	3
 main/database_path_and_type.cpp	5
-main/db_instance_cache.cpp	26
+main/db_instance_cache.cpp	27
 main/error_manager.cpp	9
 main/extension/extension_alias.cpp	2
 main/extension/extension_helper.cpp	8

--- a/extension/httpfs/CMakeLists.txt
+++ b/extension/httpfs/CMakeLists.txt
@@ -6,6 +6,9 @@ add_extension_definitions()
 
 include_directories(include ../../third_party/httplib ../parquet/include)
 
+# Hide annoying openssl warnings
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated")
+
 build_static_extension(httpfs s3fs.cpp httpfs.cpp crypto.cpp
                        httpfs_extension.cpp)
 set(PARAMETERS "-warnings")

--- a/extension/httpfs/CMakeLists.txt
+++ b/extension/httpfs/CMakeLists.txt
@@ -6,9 +6,6 @@ add_extension_definitions()
 
 include_directories(include ../../third_party/httplib ../parquet/include)
 
-# Hide annoying openssl warnings
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated")
-
 build_static_extension(httpfs s3fs.cpp httpfs.cpp crypto.cpp
                        httpfs_extension.cpp)
 set(PARAMETERS "-warnings")

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -626,7 +626,7 @@ void HTTPFileHandle::Initialize(FileOpener *opener) {
 		// Lock cache and get or create cache entry
 		{
 			lock_guard<mutex> lock(state->cached_files_mutex);
-			auto& cache_entry_ref = state->cached_files[path];
+			auto &cache_entry_ref = state->cached_files[path];
 			if (cache_entry_ref) {
 				cached_file = cache_entry_ref;
 			} else {

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -626,7 +626,13 @@ void HTTPFileHandle::Initialize(FileOpener *opener) {
 		// Lock cache and get or create cache entry
 		{
 			lock_guard<mutex> lock(state->cached_files_mutex);
-			cached_file = state->cached_files[path];
+			auto& cache_entry_ref = state->cached_files[path];
+			if (cache_entry_ref) {
+				cached_file = cache_entry_ref;
+			} else {
+				cache_entry_ref = make_shared<CachedFile>();
+				cached_file = cache_entry_ref;
+			}
 		}
 
 		// Lock the file, and see if we need to download it

--- a/extension/httpfs/include/httpfs.hpp
+++ b/extension/httpfs/include/httpfs.hpp
@@ -62,8 +62,8 @@ public:
 	idx_t length;
 	time_t last_modified;
 
-	// If using full file download, this holds the cached file
-	shared_ptr<CachedFile> cached_file;
+	// When using full file download, the full file will be written to a cached file handle
+	unique_ptr<CachedFileHandle> cached_file_handle;
 
 	// Read info
 	idx_t buffer_available;

--- a/extension/httpfs/include/httpfs.hpp
+++ b/extension/httpfs/include/httpfs.hpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/common/http_state.hpp"
 #include "duckdb/main/client_data.hpp"
 #include "http_metadata_cache.hpp"
 
@@ -60,7 +61,9 @@ public:
 	uint8_t flags;
 	idx_t length;
 	time_t last_modified;
-	bool range_read = true;
+
+	// If using full file download, this holds the cached file
+	shared_ptr<CachedFile> cached_file;
 
 	// Read info
 	idx_t buffer_available;

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library_unity(
   fsst.cpp
   gzip_file_system.cpp
   hive_partitioning.cpp
+  http_state.cpp
   pipe_file_system.cpp
   local_file_system.cpp
   multi_file_reader.cpp

--- a/src/common/http_state.cpp
+++ b/src/common/http_state.cpp
@@ -2,7 +2,7 @@
 
 namespace duckdb {
 
-CachedFileHandle::CachedFileHandle(shared_ptr<CachedFile>& file_p) {
+CachedFileHandle::CachedFileHandle(shared_ptr<CachedFile> &file_p) {
 	// If the file was not yet initialized, we need to grab a lock.
 	if (!file_p->initialized) {
 		lock = make_uniq<lock_guard<mutex>>(file_p->lock);

--- a/src/common/http_state.cpp
+++ b/src/common/http_state.cpp
@@ -2,7 +2,7 @@
 
 namespace duckdb {
 
-CachedFileHandle::CachedFileHandle(shared_ptr<CachedFile> file_p) {
+CachedFileHandle::CachedFileHandle(shared_ptr<CachedFile>& file_p) {
 	// If the file was not yet initialized, we need to grab a lock.
 	if (!file_p->initialized) {
 		lock = make_uniq<lock_guard<mutex>>(file_p->lock);

--- a/src/common/http_state.cpp
+++ b/src/common/http_state.cpp
@@ -1,0 +1,78 @@
+#include "duckdb/common/http_state.hpp"
+
+namespace duckdb {
+
+CachedFileHandle::CachedFileHandle(shared_ptr<CachedFile> file_p) {
+	// If the file was not yet initialized, we need to grab a lock.
+	if (!file_p->initialized) {
+		lock = make_uniq<lock_guard<mutex>>(file_p->lock);
+	}
+	file = file_p;
+}
+
+void CachedFileHandle::SetInitialized() {
+	if (file->initialized) {
+		throw InternalException("Cannot set initialized on cached file that was already initialized");
+	}
+	if (!lock) {
+		throw InternalException("Cannot set initialized on cached file without lock");
+	}
+	file->initialized = true;
+	lock = nullptr;
+}
+
+void CachedFileHandle::AllocateBuffer(idx_t size) {
+	if (file->initialized) {
+		throw InternalException("Cannot allocate a buffer for a cached file that was already initialized");
+	}
+	file->data = std::shared_ptr<char>(new char[size], std::default_delete<char[]>());
+	file->capacity = size;
+}
+
+void CachedFileHandle::GrowBuffer(idx_t new_capacity, idx_t bytes_to_copy) {
+	// copy shared ptr to old data
+	auto old_data = file->data;
+	// allocate new buffer that can hold the new capacity
+	AllocateBuffer(new_capacity);
+	// copy the old data
+	Write(old_data.get(), bytes_to_copy);
+}
+
+void CachedFileHandle::Write(const char *buffer, idx_t length, idx_t offset) {
+	//! Only write to non-initialized files with a lock;
+	D_ASSERT(!file->initialized && lock);
+	memcpy(file->data.get() + offset, buffer, length);
+}
+
+void HTTPState::Reset() {
+	// Reset Counters
+	head_count = 0;
+	get_count = 0;
+	put_count = 0;
+	post_count = 0;
+	total_bytes_received = 0;
+	total_bytes_sent = 0;
+
+	// Reset cached files
+	cached_files.clear();
+}
+
+shared_ptr<HTTPState> HTTPState::TryGetState(FileOpener *opener) {
+	auto client_context = FileOpener::TryGetClientContext(opener);
+	if (client_context) {
+		return client_context->client_data->http_state;
+	}
+	return nullptr;
+}
+
+//! Get cache entry, create if not exists
+shared_ptr<CachedFile> &HTTPState::GetCachedFile(const string &path) {
+	lock_guard<mutex> lock(cached_files_mutex);
+	auto &cache_entry_ref = cached_files[path];
+	if (!cache_entry_ref) {
+		cache_entry_ref = make_shared<CachedFile>();
+	}
+	return cache_entry_ref;
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/common/http_state.hpp
+++ b/src/include/duckdb/common/http_state.hpp
@@ -24,7 +24,8 @@ class CachedFile : public std::enable_shared_from_this<CachedFile> {
 
 public:
 	unique_ptr<CachedFileHandle> GetHandle() {
-		return make_uniq<CachedFileHandle>(shared_from_this());
+		auto this_ptr = shared_from_this();
+		return make_uniq<CachedFileHandle>(this_ptr);
 	}
 
 private:
@@ -41,7 +42,7 @@ private:
 //! Handle to a CachedFile
 class CachedFileHandle {
 public:
-	explicit CachedFileHandle(shared_ptr<CachedFile> file_p);
+	explicit CachedFileHandle(shared_ptr<CachedFile>& file_p);
 
 	//! allocate a buffer for the file
 	void AllocateBuffer(idx_t size);

--- a/src/include/duckdb/common/http_state.hpp
+++ b/src/include/duckdb/common/http_state.hpp
@@ -16,53 +16,83 @@
 
 namespace duckdb {
 
-struct CachedFile {
+class CachedFileHandle;
+
+//! Represents a file that is intended to be fully downloaded, then used in parallel by multiple threads
+class CachedFile : public std::enable_shared_from_this<CachedFile> {
+	friend class CachedFileHandle;
+
+public:
+	unique_ptr<CachedFileHandle> GetHandle() {
+		return make_uniq<CachedFileHandle>(shared_from_this());
+	}
+
+private:
 	//! Cached Data
 	shared_ptr<char> data;
 	//! Data capacity
 	uint64_t capacity = 0;
-	//! If we finished downloading the file
-	bool finished = false;
-	//! Lock that allows waiting for other threads to download file
-	mutex lock = {};
+	//! Lock for initializing the file
+	mutex lock;
+	//! When initialized is set to true, the file is safe for parallel reading without holding the lock
+	atomic<bool> initialized = {false};
+};
+
+//! Handle to a CachedFile
+class CachedFileHandle {
+public:
+	explicit CachedFileHandle(shared_ptr<CachedFile> file_p);
+
+	//! allocate a buffer for the file
+	void AllocateBuffer(idx_t size);
+	//! Indicate the file is fully downloaded and safe for parallel reading without lock
+	void SetInitialized();
+	//! Grow buffer to new size, copying over `bytes_to_copy` to the new buffer
+	void GrowBuffer(idx_t new_capacity, idx_t bytes_to_copy);
+	//! Write to the buffer
+	void Write(const char *buffer, idx_t length, idx_t offset = 0);
+
+	bool Initialized() {
+		return file->initialized;
+	}
+	const char *GetData() {
+		return file->data.get();
+	}
+	uint64_t GetCapacity() {
+		return file->capacity;
+	}
+
+private:
+	unique_ptr<lock_guard<mutex>> lock;
+	shared_ptr<CachedFile> file;
 };
 
 class HTTPState {
 public:
+	//! Reset all counters and cached files
+	void Reset();
+	//! Get cache entry, create if not exists
+	shared_ptr<CachedFile> &GetCachedFile(const string &path);
+	//! Helper function to get the HTTP state
+	static shared_ptr<HTTPState> TryGetState(FileOpener *opener);
+
+	bool IsEmpty() {
+		return head_count == 0 && get_count == 0 && put_count == 0 && post_count == 0 && total_bytes_received == 0 &&
+		       total_bytes_sent == 0;
+	}
+
 	atomic<idx_t> head_count {0};
 	atomic<idx_t> get_count {0};
 	atomic<idx_t> put_count {0};
 	atomic<idx_t> post_count {0};
 	atomic<idx_t> total_bytes_received {0};
 	atomic<idx_t> total_bytes_sent {0};
+
+private:
 	//! Mutex to lock when getting the cached file(Parallel Only)
 	mutex cached_files_mutex;
 	//! In case of fully downloading the file, the cached files of this query
 	unordered_map<string, shared_ptr<CachedFile>> cached_files;
-
-	void Reset() {
-		head_count = 0;
-		get_count = 0;
-		put_count = 0;
-		post_count = 0;
-		total_bytes_received = 0;
-		total_bytes_sent = 0;
-		cached_files.clear();
-	}
-
-	//! helper function to get the HTTP
-	static shared_ptr<HTTPState> TryGetState(FileOpener *opener) {
-		auto client_context = FileOpener::TryGetClientContext(opener);
-		if (client_context) {
-			return client_context->client_data->http_state;
-		}
-		return nullptr;
-	}
-
-	bool IsEmpty() {
-		return head_count == 0 && get_count == 0 && put_count == 0 && post_count == 0 && total_bytes_received == 0 &&
-		       total_bytes_sent == 0;
-	}
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/http_state.hpp
+++ b/src/include/duckdb/common/http_state.hpp
@@ -23,6 +23,8 @@ struct CachedFile {
 	uint64_t capacity = 0;
 	//! If we finished downloading the file
 	bool finished = false;
+	//! Lock that allows waiting for other threads to download file
+	mutex lock = {};
 };
 
 class HTTPState {
@@ -36,7 +38,7 @@ public:
 	//! Mutex to lock when getting the cached file(Parallel Only)
 	mutex cached_files_mutex;
 	//! In case of fully downloading the file, the cached files of this query
-	unordered_map<string, CachedFile> cached_files;
+	unordered_map<string, shared_ptr<CachedFile>> cached_files;
 
 	void Reset() {
 		head_count = 0;

--- a/src/include/duckdb/common/http_state.hpp
+++ b/src/include/duckdb/common/http_state.hpp
@@ -42,7 +42,7 @@ private:
 //! Handle to a CachedFile
 class CachedFileHandle {
 public:
-	explicit CachedFileHandle(shared_ptr<CachedFile>& file_p);
+	explicit CachedFileHandle(shared_ptr<CachedFile> &file_p);
 
 	//! allocate a buffer for the file
 	void AllocateBuffer(idx_t size);


### PR DESCRIPTION
fixes https://github.com/duckdb/duckdb/issues/8230. 

The problem was that the unordered map was accessed in a non-thread safe way without holding a lock.
Resolved the issue by refactoring the way the cached_files map is accessed. Confirmed that this fixed the issue by using the bug reproduction from https://github.com/duckdb/duckdb/issues/8230.

