### PR TITLE
remove static loading extensions for node/python/r dev builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1021,19 +1021,6 @@ if(BUILD_PYTHON
 
   get_target_property(duckdb_libs duckdb LINK_LIBRARIES)
 
-  # This searches all Out-of-tree (OOT) extensions that we have linked into duckdb for their direct dependencies and
-  # adds them to the duckdb_libs to ensure they also get linked. This allows linking OOT extensions with dependencies
-  # for the Python/R/Node builds
-  foreach(EXT_NAME IN LISTS DUCKDB_EXTENSION_NAMES)
-    string(TOUPPER ${EXT_NAME} EXT_NAME_UPPERCASE)
-    if (${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_SHOULD_BUILD} AND ${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_SHOULD_LINK})
-      get_target_property(EXT_LINKED_LIBS ${EXT_NAME}_extension LINK_LIBRARIES)
-      if (NOT "${EXT_LINKED_LIBS}" STREQUAL "EXT_LINKED_LIBS-NOTFOUND")
-        set(duckdb_libs ${EXT_LINKED_LIBS} ${duckdb_libs})
-      endif()
-    endif()
-  endforeach()
-
   if(BUILD_PYTHON)
     if(USER_SPACE)
       add_custom_target(


### PR DESCRIPTION
Remove feature earlier implemented in https://github.com/duckdb/duckdb/pull/7458. It doesn't really work with transitive dependencies making it finicky to use. This is used by the arrow extension, but I will switch instead to just loading the extension manually in the test fixture/before methods in pytest/mocha. A draft PR that contains the required changes for this is up to the extension template https://github.com/duckdb/extension-template/pull/29