### PR TITLE
CI: Change clang-format version to 11

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install
         shell: bash
-        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang-format && sudo pip3 install cmake-format black
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang-format-11 && sudo pip3 install cmake-format black
 
       - name: Format Check
         shell: bash

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -20,6 +20,9 @@ except ImportError as e:
     exit(-1)
 
 ver = subprocess.check_output(('clang-format', '--version'), text=True)
+if '11.' not in ver:
+    print('you need to run `pip install clang_format==11.0.0 - `', ver)
+    exit(-1)
 
 cpp_format_command = 'clang-format --sort-includes=0 -style=file'
 cmake_format_command = 'cmake-format'

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -20,9 +20,6 @@ except ImportError as e:
     exit(-1)
 
 ver = subprocess.check_output(('clang-format', '--version'), text=True)
-if '10.' not in ver:
-    print('you need to run `pip install clang_format==10.0.1.1 - `', ver)
-    exit(-1)
 
 cpp_format_command = 'clang-format --sort-includes=0 -style=file'
 cmake_format_command = 'cmake-format'

--- a/src/include/duckdb/storage/object_cache.hpp
+++ b/src/include/duckdb/storage/object_cache.hpp
@@ -48,7 +48,7 @@ public:
 	}
 
 	template <class T, class... Args>
-	shared_ptr<T> GetOrCreate(const string &key, Args &&... args) {
+	shared_ptr<T> GetOrCreate(const string &key, Args &&...args) {
 		lock_guard<mutex> glock(lock);
 
 		auto entry = cache.find(key);

--- a/tools/jdbc/src/test/java/org/duckdb/test/Thrower.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/Thrower.java
@@ -1,3 +1,5 @@
 package org.duckdb.test;
 
-public interface Thrower { void run() throws Exception; }
+public interface Thrower {
+    void run() throws Exception;
+}


### PR DESCRIPTION
Brew only provides clang-format11 (which works).
The version that Python provides when I install it through pip (python3 -m pip install clang_format==10.0.1.1) can not be executed by my CPU:
```
OSError: [Errno 86] Bad CPU type in executable: '/opt/homebrew/lib/python3.11/site-packages/clang_format/data/bin/clang-format'
```

So we can't have this version requirement on 10, it might be a saner solution to move everything to clang-format 11 instead, as it is more readily available.

@Mause