### PR TITLE
Add list_reverse function

### DIFF
--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -99,6 +99,9 @@ static DefaultMacro internal_macros[] = {
 	{DEFAULT_SCHEMA, "count_if", {"l", nullptr}, "sum(if(l, 1, 0))"},
 	{DEFAULT_SCHEMA, "split_part", {"string", "delimiter", "position", nullptr}, "coalesce(string_split(string, delimiter)[position],'')"},
 
+    {DEFAULT_SCHEMA, "list_reverse", {"l", nullptr}, "CASE WHEN l is NULL THEN NULL else l[:-:-1] END"},
+    {DEFAULT_SCHEMA, "array_reverse", {"l", nullptr}, "list_reverse(l)"},
+
     // FIXME implement as actual function if we encounter a lot of performance issues. Complexity now: n * m, with hashing possibly n + m
     {DEFAULT_SCHEMA, "list_intersect", {"l1", "l2", nullptr}, "list_filter(l1, (x) -> list_contains(l2, x))"},
     {DEFAULT_SCHEMA, "array_intersect", {"l1", "l2", nullptr}, "list_intersect(l1, l2)"},

--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -99,7 +99,7 @@ static DefaultMacro internal_macros[] = {
 	{DEFAULT_SCHEMA, "count_if", {"l", nullptr}, "sum(if(l, 1, 0))"},
 	{DEFAULT_SCHEMA, "split_part", {"string", "delimiter", "position", nullptr}, "coalesce(string_split(string, delimiter)[position],'')"},
 
-    {DEFAULT_SCHEMA, "list_reverse", {"l", nullptr}, "CASE WHEN l is NULL THEN NULL else l[:-:-1] END"},
+    {DEFAULT_SCHEMA, "list_reverse", {"l", nullptr}, "l[:-:-1]"},
     {DEFAULT_SCHEMA, "array_reverse", {"l", nullptr}, "list_reverse(l)"},
 
     // FIXME implement as actual function if we encounter a lot of performance issues. Complexity now: n * m, with hashing possibly n + m

--- a/src/core_functions/scalar/list/array_slice.cpp
+++ b/src/core_functions/scalar/list/array_slice.cpp
@@ -308,6 +308,12 @@ static void ArraySliceFunction(DataChunk &args, ExpressionState &state, Vector &
 	auto count = args.size();
 
 	Vector &list_or_str_vector = args.data[0];
+	if (list_or_str_vector.GetType().id() == LogicalTypeId::SQLNULL) {
+		auto &result_validity = FlatVector::Validity(result);
+		result_validity.SetInvalid(0);
+		return;
+	}
+
 	Vector &begin_vector = args.data[1];
 	Vector &end_vector = args.data[2];
 

--- a/test/sql/function/list/list_reverse.test
+++ b/test/sql/function/list/list_reverse.test
@@ -1,3 +1,6 @@
+# name: test/sql/function/list/list_reverse.test
+# group: [list]
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/function/list/list_reverse.test
+++ b/test/sql/function/list/list_reverse.test
@@ -12,32 +12,32 @@ SELECT ${f}(NULL);
 NULL
 
 query I
-SELECT ${f}(ARRAY[]);
+SELECT ${f}([]);
 ----
 []
 
 query I
-SELECT ${f}(ARRAY[NULL]);
+SELECT ${f}([NULL]);
 ----
 [NULL]
 
 query I
-SELECT ${f}(ARRAY[1, 42, 2]);
+SELECT ${f}([1, 42, 2]);
 ----
 [2, 42, 1]
 
 query I
-SELECT ${f}(ARRAY[1, 42, NULL, 2]);
+SELECT ${f}([1, 42, NULL, 2]);
 ----
 [2, NULL, 42, 1]
 
 query I
-SELECT ${f}(${f}(ARRAY[1, 3, 3, 42, 117, 69, NULL]));
+SELECT ${f}(${f}([1, 3, 3, 42, 117, 69, NULL]));
 ----
 [1, 3, 3, 42, 117, 69, NULL]
 
 query I
-SELECT ${f} (ARRAY[[1, 2 ,42], [3, 4]]);
+SELECT ${f} ([[1, 2 ,42], [3, 4]]);
 ----
 [[3, 4], [1, 2, 42]]
 
@@ -120,7 +120,7 @@ statement error
 SELECT ${f}(42)
 
 statement error
-SELECT ${f} (ARRAY[1, 3, 2, 42, 117,, NULL])
+SELECT ${f} ([1, 3, 2, 42, 117,, NULL])
 
 statement ok
 CREATE TABLE palindromes (s VARCHAR);
@@ -144,4 +144,141 @@ tattarrattat
 statement ok
 DROP TABLE palindromes;
 
+query I
+WITH example AS (
+  SELECT [1, 2, 3] AS arr UNION ALL
+  SELECT [4, 5] AS arr UNION ALL
+  SELECT [] AS arr
+)
+SELECT
+  ${f}(arr) AS reverse_arr
+FROM example;
+----
+[3, 2, 1]
+[5, 4]
+[]
+
+
 endloop
+
+# test incorrect syntax
+
+foreach f list_reverse array_reverse
+
+statement error
+SELECT ${f}()
+
+statement error
+SELECT ${f}(*)
+
+statement error
+SELECT ${f}([1, 2], 2)
+
+endloop
+
+# test incorrect parameter type
+
+foreach f list_reverse array_reverse
+
+foreach type boolean varchar tinyint smallint integer bigint hugeint utinyint usmallint uinteger ubigint float double decimal(4,1) decimal(9,4) decimal(18,6) decimal(38,10) date time timestamp timestamp_s timestamp_ms timestamp_ns timetz timestamptz interval blob
+
+statement error
+SELECT ${f}(NULL::${type})
+
+endloop
+
+endloop
+
+
+# list constant tests
+
+foreach f list_reverse array_reverse
+
+query I
+SELECT ${f}([1, 42, 39, 58])
+----
+[58, 39, 42, 1]
+
+query I
+SELECT ${f}([1, NULL, 42, 39, NULL, 58])
+----
+[58, NULL, 39, 42, NULL, 1]
+
+
+query I
+SELECT ${f}([1, 42, -39, 58, -1, 18])
+----
+[18, -1, 58, -39, 42, 1]
+
+query I
+SELECT ${f}(${f}([11, -100, 678]))
+----
+[11, -100, 678]
+
+endloop
+
+
+# list column tests
+
+foreach f list_reverse array_reverse
+
+statement ok
+CREATE OR REPLACE TABLE integers AS SELECT LIST(i) AS i FROM range(1, 10, 1) t1(i)
+
+statement ok
+INSERT INTO integers VALUES ([NULL]), (NULL), ([])
+
+query I
+SELECT ${f}(i) FROM integers
+----
+[9, 8, 7, 6, 5, 4, 3, 2, 1]
+[NULL]
+NULL
+[]
+
+query I
+SELECT (i).${f}() FROM integers
+----
+[9, 8, 7, 6, 5, 4, 3, 2, 1]
+[NULL]
+NULL
+[]
+
+endloop
+
+# Nested list and very Large list
+
+foreach f list_reverse array_reverse
+
+query I
+SELECT ${f}([[1], [1, 2], NULL, [NULL], [], [1, 2, 3]])
+----
+[[1, 2, 3], [], [NULL], NULL, [1, 2], [1]]
+
+query I
+SELECT ([[1], [1, 2], NULL, [NULL], [], [1, 2, 3]]).${f}()
+----
+[[1, 2, 3], [], [NULL], NULL, [1, 2], [1]]
+
+
+statement ok
+CREATE OR REPLACE TABLE lists AS SELECT range % 4 g, list(range) l FROM range(10000) GROUP BY range % 4;
+
+query T
+with cte0 as (
+  select g, ${f}(l) l from lists
+), cte1 as (
+  select g, unnest(l) i from cte0
+), cte2 as (
+  select g, i, lead(g, 1) over () lg, lead(i, 1) over () li from cte1
+)
+select count(*)
+from cte2
+where g = lg
+  and lg not null
+  and li > i
+----
+0
+
+endloop
+

--- a/test/sql/function/list/list_reverse.test
+++ b/test/sql/function/list/list_reverse.test
@@ -1,0 +1,144 @@
+statement ok
+PRAGMA enable_verification
+
+foreach f list_reverse array_reverse
+
+query I
+SELECT ${f}(NULL);
+----
+NULL
+
+query I
+SELECT ${f}(ARRAY[]);
+----
+[]
+
+query I
+SELECT ${f}(ARRAY[NULL]);
+----
+[NULL]
+
+query I
+SELECT ${f}(ARRAY[1, 42, 2]);
+----
+[2, 42, 1]
+
+query I
+SELECT ${f}(ARRAY[1, 42, NULL, 2]);
+----
+[2, NULL, 42, 1]
+
+query I
+SELECT ${f}(${f}(ARRAY[1, 3, 3, 42, 117, 69, NULL]));
+----
+[1, 3, 3, 42, 117, 69, NULL]
+
+query I
+SELECT ${f} (ARRAY[[1, 2 ,42], [3, 4]]);
+----
+[[3, 4], [1, 2, 42]]
+
+query I
+prepare q1 as select ${f}(?);
+execute q1([5, 42, 3]);
+----
+[3, 42, 5]
+
+query I
+create table tbl_big as select range(5000) as list;
+select list_sort((list), 'desc') == ${f}(list) from tbl_big;
+----
+true
+
+statement ok
+CREATE TABLE tbl (id INTEGER, list INTEGER[]);
+
+statement ok
+INSERT INTO tbl VALUES (1, [NULL, 3, 117, 42, 1]), (2, NULL), (3, [1, 8, 9]), (4, NULL), (5, NULL), (6, [NULL]);
+
+query II
+SELECT id, ${f}(list) FROM tbl ORDER BY id;
+----
+1	[1, 42, 117, 3, NULL]
+2	NULL
+3	[9, 8, 1]
+4	NULL
+5	NULL
+6	[NULL]
+
+statement ok
+DROP TABLE tbl;
+
+statement ok
+CREATE TABLE tbl2 (id INTEGER, list INTEGER[]);
+
+statement ok
+INSERT INTO tbl2 VALUES (1, [1, 2, 3]), (1, [4, 5, 6]), (3, [7, 8, 9]);
+
+query II
+SELECT id, ${f}(list) FROM tbl2 ORDER BY id;
+----
+1	[3, 2, 1]
+1	[6, 5, 4]
+3	[9, 8, 7]
+
+statement ok
+DROP TABLE tbl2;
+
+query IIIIIIII
+select ${f}(${f}(columns(['int_array', 'varchar_array', 'nested_int_array', 'array_of_structs', 'timestamp_array', 'double_array', 'date_array', 'timestamptz_array']))) == columns(['int_array', 'varchar_array', 'nested_int_array', 'array_of_structs', 'timestamp_array', 'double_array', 'date_array', 'timestamptz_array']) from test_all_types();
+----
+true	true	true	true	true	true	true	true
+true	true	true	true	true	true	true	true
+NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
+
+statement ok
+select ${f}(test_vector) from test_vector_types(null::int[], false);
+
+statement ok
+select ${f}(test_vector) from test_vector_types(null::int[], true);
+
+query I nosort q1
+select true from test_vector_types(null::int[], false);
+----
+
+query I nosort q1
+select list_sort((list), 'desc') == list from (select ${f}(test_vector) as list from test_vector_types(null::int[], false));
+----
+
+query I nosort q1
+select list_sort((list), 'desc') == list from (select ${f}(test_vector) as list from test_vector_types(null::int[], true));
+----
+
+statement error
+SELECT ${f}()
+
+statement error
+SELECT ${f}(42)
+
+statement error
+SELECT ${f} (ARRAY[1, 3, 2, 42, 117,, NULL])
+
+statement ok
+CREATE TABLE palindromes (s VARCHAR);
+
+statement ok
+INSERT INTO palindromes VALUES ('racecar'), ('civic'), ('defied'), ('repaper'), ('kayak'), ('rotator'), ('tattarrattat'), ('saippuakivikauppias'), ('malayalam');
+
+query I
+SELECT list_aggr(${f}(str_split(s, '')), 'string_agg', '') FROM palindromes ORDER BY s;
+----
+civic
+deifed
+kayak
+malayalam
+racecar
+repaper
+rotator
+saippuakivikauppias
+tattarrattat
+
+statement ok
+DROP TABLE palindromes;
+
+endloop

--- a/test/sql/function/list/list_reverse.test_slow
+++ b/test/sql/function/list/list_reverse.test_slow
@@ -1,0 +1,23 @@
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE all_types AS SELECT * FROM test_all_types();
+
+foreach colname bool tinyint smallint int bigint hugeint utinyint usmallint uint ubigint date time timestamp timestamp_s timestamp_ms timestamp_ns time_tz timestamp_tz float double dec_4_1 dec_9_4 dec_18_6 dec38_10 uuid interval varchar blob small_enum medium_enum large_enum int_array double_array date_array timestamp_array timestamptz_array varchar_array nested_int_array struct struct_of_arrays array_of_structs map
+
+statement ok
+select list_reverse(["${colname}"]) FROM all_types;
+
+endloop
+
+statement ok
+create table tbl as select range(5000) as list;
+
+query I nosort reversered list
+select list_sort(range(5000), 'desc');
+----
+
+query I nosort reversered list
+select list_reverse(list) from tbl;
+----

--- a/test/sql/function/list/list_reverse.test_slow
+++ b/test/sql/function/list/list_reverse.test_slow
@@ -1,3 +1,6 @@
+# name: test/sql/function/list/list_reverse.test_slow
+# group: [list]
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/types/nested/list/test_list_slice_step.test
+++ b/test/sql/types/nested/list/test_list_slice_step.test
@@ -187,6 +187,21 @@ SELECT a[start:stop:step] from err;
 
 # NULL's
 query I
+SELECT list_slice(NULL, 1, 3, 2);
+----
+NULL
+
+query I
+SELECT list_slice(NULL, 0, 0);
+----
+NULL
+
+query I
+SELECT list_slice(NULL, 1, 3, -1);
+----
+NULL
+
+query I
 SELECT ([1,2,3,4,5])[1:3:NULL];
 ----
 NULL


### PR DESCRIPTION
Add a rewrite for `list_reverse(l)` as well the alias `array_reverse(l)`.

```SQL
select list_reverse([1,2,3,4,5]);
┌──────────────────────────────────────────────┐
│ list_reverse(main.list_value(1, 2, 3, 4, 5)) │
│                   int32[]                    │
├──────────────────────────────────────────────┤
│ [5, 4, 3, 2, 1]                              │
└──────────────────────────────────────────────┘
```

The tests are from #7132