### PR TITLE
[Python Dev] Use `pytest.mark.parametrize` to make test logs easier to read in `test_all_types.py`

### DIFF
--- a/tools/pythonpkg/tests/fast/api/test_native_tz.py
+++ b/tools/pythonpkg/tests/fast/api/test_native_tz.py
@@ -8,67 +8,65 @@ import pytest
 filename = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data', 'tz.parquet')
 
 
-def test_native_python_timestamp_timezone():
-    con = duckdb.connect('')
-    con.execute("SET timezone='America/Los_Angeles';")
-    res = con.execute(f"select TimeRecStart as tz  from '{filename}'").fetchone()
-    assert res[0].hour == 14 and res[0].minute == 52
-    assert res[0].tzinfo.zone == 'America/Los_Angeles'
+class TestNativeTimeZone(object):
+    def test_native_python_timestamp_timezone(self):
+        con = duckdb.connect('')
+        con.execute("SET timezone='America/Los_Angeles';")
+        res = con.execute(f"select TimeRecStart as tz  from '{filename}'").fetchone()
+        assert res[0].hour == 14 and res[0].minute == 52
+        assert res[0].tzinfo.zone == 'America/Los_Angeles'
 
-    res = con.execute(f"select TimeRecStart as tz  from '{filename}'").fetchall()[0]
-    assert res[0].hour == 14 and res[0].minute == 52
-    assert res[0].tzinfo.zone == 'America/Los_Angeles'
+        res = con.execute(f"select TimeRecStart as tz  from '{filename}'").fetchall()[0]
+        assert res[0].hour == 14 and res[0].minute == 52
+        assert res[0].tzinfo.zone == 'America/Los_Angeles'
 
-    res = con.execute(f"select TimeRecStart as tz  from '{filename}'").fetchmany(1)[0]
-    assert res[0].hour == 14 and res[0].minute == 52
-    assert res[0].tzinfo.zone == 'America/Los_Angeles'
+        res = con.execute(f"select TimeRecStart as tz  from '{filename}'").fetchmany(1)[0]
+        assert res[0].hour == 14 and res[0].minute == 52
+        assert res[0].tzinfo.zone == 'America/Los_Angeles'
 
-    con.execute("SET timezone='UTC';")
-    res = con.execute(f"select TimeRecStart as tz  from '{filename}'").fetchone()
-    assert res[0].hour == 21 and res[0].minute == 52
-    assert res[0].tzinfo.zone == 'UTC'
+        con.execute("SET timezone='UTC';")
+        res = con.execute(f"select TimeRecStart as tz  from '{filename}'").fetchone()
+        assert res[0].hour == 21 and res[0].minute == 52
+        assert res[0].tzinfo.zone == 'UTC'
 
+    def test_native_python_time_timezone(self):
+        con = duckdb.connect('')
+        with pytest.raises(duckdb.NotImplementedException, match="Not implemented Error: Unsupported type"):
+            con.execute(f"select TimeRecStart::TIMETZ  as tz  from '{filename}'").fetchone()
 
-def test_native_python_time_timezone():
-    con = duckdb.connect('')
-    with pytest.raises(duckdb.NotImplementedException, match="Not implemented Error: Unsupported type"):
-        con.execute(f"select TimeRecStart::TIMETZ  as tz  from '{filename}'").fetchone()
+    def test_pandas_timestamp_timezone(self):
+        con = duckdb.connect('')
+        res = con.execute("SET timezone='America/Los_Angeles';")
+        res = con.execute(f"select TimeRecStart as tz  from '{filename}'").df()
+        assert res.dtypes["tz"].tz.zone == 'America/Los_Angeles'
+        assert res['tz'][0].hour == 14 and res['tz'][0].minute == 52
 
+        con.execute("SET timezone='UTC';")
+        res = con.execute(f"select TimeRecStart as tz  from '{filename}'").df()
+        assert res['tz'][0].hour == 21 and res['tz'][0].minute == 52
 
-def test_pandas_timestamp_timezone():
-    con = duckdb.connect('')
-    res = con.execute("SET timezone='America/Los_Angeles';")
-    res = con.execute(f"select TimeRecStart as tz  from '{filename}'").df()
-    assert res.dtypes["tz"].tz.zone == 'America/Los_Angeles'
-    assert res['tz'][0].hour == 14 and res['tz'][0].minute == 52
+    def test_pandas_timestamp_time(self):
+        con = duckdb.connect('')
+        with pytest.raises(
+            duckdb.NotImplementedException, match="Not implemented Error: Unsupported type \"TIME WITH TIME ZONE\""
+        ):
+            con.execute(f"select TimeRecStart::TIMETZ  as tz  from '{filename}'").df()
 
-    con.execute("SET timezone='UTC';")
-    res = con.execute(f"select TimeRecStart as tz  from '{filename}'").df()
-    assert res['tz'][0].hour == 21 and res['tz'][0].minute == 52
+    def test_arrow_timestamp_timezone(self):
+        pa = pytest.importorskip('pyarrow')
+        con = duckdb.connect('')
+        res = con.execute("SET timezone='America/Los_Angeles';")
+        res = con.execute(f"select TimeRecStart as tz  from '{filename}'").arrow().to_pandas()
+        assert res.dtypes["tz"].tz.zone == 'America/Los_Angeles'
+        assert res['tz'][0].hour == 14 and res['tz'][0].minute == 52
 
+        con.execute("SET timezone='UTC';")
+        res = con.execute(f"select TimeRecStart as tz  from '{filename}'").arrow().to_pandas()
+        assert res.dtypes["tz"].tz.zone == 'UTC'
+        assert res['tz'][0].hour == 21 and res['tz'][0].minute == 52
 
-def test_pandas_timestamp_time():
-    con = duckdb.connect('')
-    with pytest.raises(duckdb.NotImplementedException, match="Not implemented Error: Unsupported type"):
-        con.execute(f"select TimeRecStart::TIMETZ  as tz  from '{filename}'").df()
-
-
-def test_arrow_timestamp_timezone():
-    pa = pytest.importorskip('pyarrow')
-    con = duckdb.connect('')
-    res = con.execute("SET timezone='America/Los_Angeles';")
-    res = con.execute(f"select TimeRecStart as tz  from '{filename}'").arrow().to_pandas()
-    assert res.dtypes["tz"].tz.zone == 'America/Los_Angeles'
-    assert res['tz'][0].hour == 14 and res['tz'][0].minute == 52
-
-    con.execute("SET timezone='UTC';")
-    res = con.execute(f"select TimeRecStart as tz  from '{filename}'").arrow().to_pandas()
-    assert res.dtypes["tz"].tz.zone == 'UTC'
-    assert res['tz'][0].hour == 21 and res['tz'][0].minute == 52
-
-
-def test_arrow_timestamp_time():
-    pa = pytest.importorskip('pyarrow')
-    con = duckdb.connect('')
-    with pytest.raises(duckdb.NotImplementedException, match="Unsupported Arrow type"):
-        con.execute(f"select TimeRecStart::TIMETZ  as tz  from '{filename}'").arrow()
+    def test_arrow_timestamp_time(self):
+        pa = pytest.importorskip('pyarrow')
+        con = duckdb.connect('')
+        with pytest.raises(duckdb.NotImplementedException, match="Unsupported Arrow type"):
+            con.execute(f"select TimeRecStart::TIMETZ  as tz  from '{filename}'").arrow()

--- a/tools/pythonpkg/tests/fast/test_all_types.py
+++ b/tools/pythonpkg/tests/fast/test_all_types.py
@@ -6,19 +6,7 @@ import math
 from decimal import Decimal
 from uuid import UUID
 import pytz
-
-
-def get_all_types():
-    conn = duckdb.connect()
-    all_types = conn.execute("describe select * from test_all_types()").fetchall()
-    types = []
-    for cur_type in all_types:
-        types.append(cur_type[0])
-    return types
-
-
-all_types = get_all_types()
-all_types.remove("time_tz")
+import pytest
 
 
 # we need to write our own equality function that considers nan==nan for testing purposes
@@ -42,8 +30,71 @@ def recursive_equality(o1, o2):
         return False
 
 
+# Regenerate the 'all_types' list using:
+
+# def get_all_types():
+#    conn = duckdb.connect()
+#    rel = conn.sql("""
+#        select * EXCLUDE
+#            time_tz
+#        from test_all_types()
+#    """)
+#    return rel.columns
+# all_types = get_all_types()
+# for type in all_types:
+# 	print(f'\t"{type}",')
+# exit()
+
+all_types = [
+    "bool",
+    "tinyint",
+    "smallint",
+    "int",
+    "bigint",
+    "hugeint",
+    "utinyint",
+    "usmallint",
+    "uint",
+    "ubigint",
+    "date",
+    "time",
+    "timestamp",
+    "timestamp_s",
+    "timestamp_ms",
+    "timestamp_ns",
+    "timestamp_tz",
+    "float",
+    "double",
+    "dec_4_1",
+    "dec_9_4",
+    "dec_18_6",
+    "dec38_10",
+    "uuid",
+    "interval",
+    "varchar",
+    "blob",
+    "bit",
+    "small_enum",
+    "medium_enum",
+    "large_enum",
+    "int_array",
+    "double_array",
+    "date_array",
+    "timestamp_array",
+    "timestamptz_array",
+    "varchar_array",
+    "nested_int_array",
+    "struct",
+    "struct_of_arrays",
+    "array_of_structs",
+    "map",
+    "union",
+]
+
+
 class TestAllTypes(object):
-    def test_fetchall(self, duckdb_cursor):
+    @pytest.mark.parametrize('cur_type', all_types)
+    def test_fetchall(self, cur_type):
         conn = duckdb.connect()
         conn.execute("SET TimeZone =UTC")
         # We replace these values since the extreme ranges are not supported in native-python.
@@ -162,14 +213,13 @@ class TestAllTypes(object):
             'timestamp_tz': [(datetime.datetime(1990, 1, 1, 0, 0, tzinfo=pytz.UTC),)],
             'union': [('Frank',), (5,), (None,)],
         }
-        for cur_type in all_types:
-            if cur_type in replacement_values:
-                result = conn.execute("select " + replacement_values[cur_type]).fetchall()
-                print(cur_type, result)
-            else:
-                result = conn.execute(f'select "{cur_type}" from test_all_types()').fetchall()
-            correct_result = correct_answer_map[cur_type]
-            assert recursive_equality(result, correct_result)
+        if cur_type in replacement_values:
+            result = conn.execute("select " + replacement_values[cur_type]).fetchall()
+            print(cur_type, result)
+        else:
+            result = conn.execute(f'select "{cur_type}" from test_all_types()').fetchall()
+        correct_result = correct_answer_map[cur_type]
+        assert recursive_equality(result, correct_result)
 
     def test_bytearray_with_nulls(self):
         con = duckdb.connect(database=':memory:')
@@ -182,7 +232,8 @@ class TestAllTypes(object):
         # Don't truncate the array on the nullbyte
         assert want == bytearray(got)
 
-    def test_fetchnumpy(self, duckdb_cursor):
+    @pytest.mark.parametrize('cur_type', all_types)
+    def test_fetchnumpy(self, cur_type):
         conn = duckdb.connect()
 
         correct_answer_map = {
@@ -405,22 +456,22 @@ class TestAllTypes(object):
         # - 'date_array'
 
         rel = conn.table_function("test_all_types")
-        for cur_type in all_types:
-            if cur_type not in correct_answer_map:
-                continue
-            result = rel.project(f'"{cur_type}"').fetchnumpy()
-            result = result[cur_type]
-            correct_answer = correct_answer_map[cur_type]
-            if isinstance(result, pd.Categorical) or result.dtype == object:
-                assert recursive_equality(list(result), list(correct_answer))
-            else:
-                # assert_equal compares NaN equal, but also compares masked
-                # elements equal to any unmasked element
-                if isinstance(result, np.ma.MaskedArray) or isinstance(correct_answer, np.ma.MaskedArray):
-                    assert np.all(result.mask == correct_answer.mask)
-                np.testing.assert_equal(result, correct_answer)
+        if cur_type not in correct_answer_map:
+            return
+        result = rel.project(f'"{cur_type}"').fetchnumpy()
+        result = result[cur_type]
+        correct_answer = correct_answer_map[cur_type]
+        if isinstance(result, pd.Categorical) or result.dtype == object:
+            assert recursive_equality(list(result), list(correct_answer))
+        else:
+            # assert_equal compares NaN equal, but also compares masked
+            # elements equal to any unmasked element
+            if isinstance(result, np.ma.MaskedArray) or isinstance(correct_answer, np.ma.MaskedArray):
+                assert np.all(result.mask == correct_answer.mask)
+            np.testing.assert_equal(result, correct_answer)
 
-    def test_arrow(self, duckdb_cursor):
+    @pytest.mark.parametrize('cur_type', all_types)
+    def test_arrow(self, cur_type):
         try:
             import pyarrow as pa
         except:
@@ -430,21 +481,21 @@ class TestAllTypes(object):
         # We do not round trip enum types
         enum_types = {'small_enum', 'medium_enum', 'large_enum', 'double_array'}
         conn = duckdb.connect()
-        for cur_type in all_types:
-            if cur_type in replacement_values:
-                arrow_table = conn.execute("select " + replacement_values[cur_type]).arrow()
-            else:
-                arrow_table = conn.execute(f'select "{cur_type}" from test_all_types()').arrow()
-            if cur_type in enum_types:
-                round_trip_arrow_table = conn.execute("select * from arrow_table").arrow()
-                result_arrow = conn.execute("select * from arrow_table").fetchall()
-                result_roundtrip = conn.execute("select * from round_trip_arrow_table").fetchall()
-                assert recursive_equality(result_arrow, result_roundtrip)
-            else:
-                round_trip_arrow_table = conn.execute("select * from arrow_table").arrow()
-                assert arrow_table.equals(round_trip_arrow_table, check_metadata=True)
+        if cur_type in replacement_values:
+            arrow_table = conn.execute("select " + replacement_values[cur_type]).arrow()
+        else:
+            arrow_table = conn.execute(f'select "{cur_type}" from test_all_types()').arrow()
+        if cur_type in enum_types:
+            round_trip_arrow_table = conn.execute("select * from arrow_table").arrow()
+            result_arrow = conn.execute("select * from arrow_table").fetchall()
+            result_roundtrip = conn.execute("select * from round_trip_arrow_table").fetchall()
+            assert recursive_equality(result_arrow, result_roundtrip)
+        else:
+            round_trip_arrow_table = conn.execute("select * from arrow_table").arrow()
+            assert arrow_table.equals(round_trip_arrow_table, check_metadata=True)
 
-    def test_pandas(self):
+    @pytest.mark.parametrize('cur_type', all_types)
+    def test_pandas(self, cur_type):
         # We skip those since the extreme ranges are not supported in python.
         replacement_values = {
             'timestamp': "'1990-01-01 00:00:00'::TIMESTAMP",
@@ -460,14 +511,13 @@ class TestAllTypes(object):
 
         conn = duckdb.connect()
         conn.execute("SET timezone = UTC")
-        for cur_type in all_types:
-            if cur_type in replacement_values:
-                dataframe = conn.execute("select " + replacement_values[cur_type]).df()
-            else:
-                dataframe = conn.execute(f'select "{cur_type}" from test_all_types()').df()
-            print(cur_type)
-            round_trip_dataframe = conn.execute("select * from dataframe").df()
-            result_dataframe = conn.execute("select * from dataframe").fetchall()
-            print(round_trip_dataframe)
-            result_roundtrip = conn.execute("select * from round_trip_dataframe").fetchall()
-            assert recursive_equality(result_dataframe, result_roundtrip)
+        if cur_type in replacement_values:
+            dataframe = conn.execute("select " + replacement_values[cur_type]).df()
+        else:
+            dataframe = conn.execute(f'select "{cur_type}" from test_all_types()').df()
+        print(cur_type)
+        round_trip_dataframe = conn.execute("select * from dataframe").df()
+        result_dataframe = conn.execute("select * from dataframe").fetchall()
+        print(round_trip_dataframe)
+        result_roundtrip = conn.execute("select * from round_trip_dataframe").fetchall()
+        assert recursive_equality(result_dataframe, result_roundtrip)


### PR DESCRIPTION
Previously we used the list of all_types directly in the test, and when something failed it was not clear which type was the cause for this failure.

With pytest.mark.parametrize the exact type that we were testing is present in the logs, making debugging easier.