### PR TITLE
R: dbplyr_fill0() no longer exists

### DIFF
--- a/tools/rpkg/R/zzz.R
+++ b/tools/rpkg/R/zzz.R
@@ -2,7 +2,6 @@
   s3_register("dbplyr::dbplyr_edition", "duckdb_connection")
   s3_register("dbplyr::db_connection_describe", "duckdb_connection")
   s3_register("dbplyr::sql_translation", "duckdb_connection")
-  s3_register("dbplyr::dbplyr_fill0", "duckdb_connection")
   s3_register("dbplyr::sql_expr_matches", "duckdb_connection")
   s3_register("dbplyr::sql_escape_date", "duckdb_connection")
   s3_register("dbplyr::sql_escape_datetime", "duckdb_connection")


### PR DESCRIPTION
Trivial. Follow-up to #8211.