### PR TITLE
Remove assertion on empty linked list

### DIFF
--- a/src/core_functions/aggregate/nested/list.cpp
+++ b/src/core_functions/aggregate/nested/list.cpp
@@ -77,7 +77,12 @@ static void ListCombineFunction(Vector &states_vector, Vector &combined, Aggrega
 	for (idx_t i = 0; i < count; i++) {
 
 		auto &state = *states_ptr[states_data.sel->get_index(i)];
-		D_ASSERT(state.linked_list.total_capacity != 0);
+		if (state.linked_list.total_capacity == 0) {
+			// NULL, no need to append
+			// this can happen when adding a FILTER to the grouping, e.g.,
+			// LIST(i) FILTER (WHERE i <> 3)
+			continue;
+		}
 
 		if (combined_ptr[i]->linked_list.total_capacity == 0) {
 			combined_ptr[i]->linked_list = state.linked_list;

--- a/test/sql/aggregate/aggregates/test_list_aggregate_function.test
+++ b/test/sql/aggregate/aggregates/test_list_aggregate_function.test
@@ -212,3 +212,18 @@ SELECT g, list_count(LIST(i)) FROM long_str GROUP BY g ORDER BY g
 # fix issue 5523
 statement ok
 SELECT LIST(i) OVER (PARTITION BY i % 10 ORDER BY i) FROM range(10000) t(i);
+
+# test linked list capacity of 0
+
+statement ok
+CREATE TABLE list_extract_test(i INTEGER, g INTEGER);
+
+statement ok
+INSERT INTO list_extract_test VALUES (1, 1), (2, 1), (3, 2), (NULL, 3), (42, 3);
+
+query II
+SELECT g, LIST(i ORDER BY i ASC) FILTER (WHERE i <> 3) FROM list_extract_test GROUP BY g;
+----
+1	[1, 2]
+2	NULL
+3	[42]


### PR DESCRIPTION
This PR removes an incorrect assertion. We found this in a nightly test run. By filtering all the values out of a group during aggregation, we can end up with an empty list.